### PR TITLE
Slice 4 — Phase-2 admin parity screens (secrets, domains, orgs, system/banned-ips/usage)

### DIFF
--- a/apps/api/colonel/cli/bannedips/ban_command.rb
+++ b/apps/api/colonel/cli/bannedips/ban_command.rb
@@ -1,0 +1,79 @@
+# apps/api/colonel/cli/bannedips/ban_command.rb
+#
+# frozen_string_literal: true
+
+# Ban an IP address / CIDR from the shell.
+#
+# Thin adapter over {Onetime::Operations::BanIP} (the single, audited ban verb).
+# The op is loaded explicitly because CLI runs don't go through the colonel app's
+# autoloader. Bans are recorded in the admin audit trail with actor `cli`.
+#
+# Usage:
+#   bin/ots bannedips ban 203.0.113.4
+#   bin/ots bannedips ban 203.0.113.0/24 --reason "credential stuffing"
+#   bin/ots bannedips ban 203.0.113.4 --expiration 3600   # auto-expire in 1h
+
+require 'ipaddr'
+require 'onetime/operations/ban_ip'
+
+module Onetime
+  module CLI
+    class BannedIpsBanCommand < Command
+      # Audit actor recorded for CLI-initiated mutations. The shell carries no
+      # authenticated colonel identity; a plain, non-secret public sentinel is
+      # used — never an internal objid. Mirrors Customers::Shared::CLI_ACTOR.
+      CLI_ACTOR = 'cli'
+
+      desc 'Ban an IP address or CIDR range'
+
+      argument :ip_address,
+        type: :string,
+        required: true,
+        desc: 'IP address or CIDR range to ban (e.g. 203.0.113.4 or 203.0.113.0/24)'
+
+      option :reason,
+        type: :string,
+        desc: 'Reason for the ban (stored on the record and in the audit trail)'
+      option :expiration,
+        type: :integer,
+        desc: 'Auto-expire the ban after this many seconds (default: permanent)'
+
+      def call(ip_address:, reason: nil, expiration: nil, **)
+        boot_application!
+
+        ip = ip_address.to_s.strip
+        if ip.empty?
+          warn 'Error: IP address is required'
+          exit 1
+        end
+
+        # Validate format up front, matching the colonel endpoint's guard.
+        begin
+          IPAddr.new(ip)
+        rescue IPAddr::InvalidAddressError
+          warn "Error: invalid IP address or CIDR: #{ip}"
+          exit 1
+        end
+
+        result = Onetime::Operations::BanIP.new(
+          ip_address: ip,
+          reason: reason,
+          banned_by: CLI_ACTOR,
+          actor: CLI_ACTOR,
+          expiration: expiration,
+        ).call
+
+        case result.status
+        when :already_banned
+          puts "Already banned: #{ip}"
+        when :success
+          puts "Banned: #{ip}"
+          puts "  Reason: #{result.reason}" if result.reason && !result.reason.to_s.empty?
+          puts "  Expires: #{expiration ? "in #{expiration}s" : 'never'}"
+        end
+      end
+    end
+
+    register 'bannedips ban', BannedIpsBanCommand
+  end
+end

--- a/apps/api/colonel/cli/bannedips/list_command.rb
+++ b/apps/api/colonel/cli/bannedips/list_command.rb
@@ -1,0 +1,66 @@
+# apps/api/colonel/cli/bannedips/list_command.rb
+#
+# frozen_string_literal: true
+
+# List banned IP addresses from the shell (read-only — no audit).
+#
+# Mirrors ColonelAPI::Logic::Colonel::ListBannedIPs: a bounded index read
+# (Onetime::BannedIP.instances → load_multi), never a blocking KEYS/SCAN
+# (#2211). Sorted most-recently-banned first.
+#
+# Usage:
+#   bin/ots bannedips list
+
+require 'colonel/models/banned_ip'
+
+module Onetime
+  module CLI
+    class BannedIpsListCommand < Command
+      desc 'List banned IP addresses (most recent first)'
+
+      def call(**)
+        boot_application!
+
+        ids    = Onetime::BannedIP.instances.to_a
+        banned = Onetime::BannedIP.load_multi(ids).compact
+        banned.select!(&:ip_address) # drop incomplete/corrupted records
+        banned.sort_by! { |ip| -(ip.banned_at || 0) }
+
+        if banned.empty?
+          puts 'No IPs are currently banned.'
+          return
+        end
+
+        puts format('%-24s %-30s %-20s %s', 'IP ADDRESS', 'REASON', 'BANNED AT', 'BANNED BY')
+        puts '-' * 96
+        banned.each do |ip|
+          puts format(
+            '%-24s %-30s %-20s %s',
+            ip.ip_address,
+            truncate(ip.reason, 30),
+            format_time(ip.banned_at),
+            ip.banned_by || '-',
+          )
+        end
+        puts
+        puts "Total: #{banned.size} banned IP(s)"
+      end
+
+      private
+
+      def truncate(value, width)
+        str = value.to_s
+        str = '-' if str.empty?
+        str.length > width ? "#{str[0, width - 1]}…" : str
+      end
+
+      def format_time(epoch)
+        return '-' unless epoch
+
+        Time.at(epoch.to_i).utc.strftime('%Y-%m-%d %H:%M UTC')
+      end
+    end
+
+    register 'bannedips list', BannedIpsListCommand
+  end
+end

--- a/apps/api/colonel/cli/bannedips/unban_command.rb
+++ b/apps/api/colonel/cli/bannedips/unban_command.rb
@@ -1,0 +1,54 @@
+# apps/api/colonel/cli/bannedips/unban_command.rb
+#
+# frozen_string_literal: true
+
+# Remove an IP ban from the shell.
+#
+# Thin adapter over {Onetime::Operations::UnbanIP} (the single, audited unban
+# verb). Unbans are recorded in the admin audit trail with actor `cli`.
+#
+# Usage:
+#   bin/ots bannedips unban 203.0.113.4
+#   bin/ots bannedips unban 203.0.113.0/24
+
+require 'onetime/operations/unban_ip'
+
+module Onetime
+  module CLI
+    class BannedIpsUnbanCommand < Command
+      # See BannedIpsBanCommand::CLI_ACTOR — the CLI's non-secret audit sentinel.
+      CLI_ACTOR = 'cli'
+
+      desc 'Remove an IP address / CIDR ban'
+
+      argument :ip_address,
+        type: :string,
+        required: true,
+        desc: 'IP address or CIDR range to unban'
+
+      def call(ip_address:, **)
+        boot_application!
+
+        ip = ip_address.to_s.strip
+        if ip.empty?
+          warn 'Error: IP address is required'
+          exit 1
+        end
+
+        result = Onetime::Operations::UnbanIP.new(
+          ip_address: ip,
+          actor: CLI_ACTOR,
+        ).call
+
+        case result.status
+        when :not_found
+          puts "Not banned: #{ip}"
+        when :success
+          puts "Unbanned: #{ip}"
+        end
+      end
+    end
+
+    register 'bannedips unban', BannedIpsUnbanCommand
+  end
+end

--- a/apps/api/colonel/cli/bannedips_command.rb
+++ b/apps/api/colonel/cli/bannedips_command.rb
@@ -1,0 +1,47 @@
+# apps/api/colonel/cli/bannedips_command.rb
+#
+# frozen_string_literal: true
+
+# CLI command group for managing banned IP addresses.
+#
+# Surfaces the ban/unban verbs — previously API-only — on the shell so an
+# incident responder can ban an abusive IP without the admin UI (epic #33). All
+# subcommands are thin adapters over the single, audited operations
+# {Onetime::Operations::BanIP} / {Onetime::Operations::UnbanIP}.
+#
+# Auto-discovered by lib/onetime/cli.rb's apps/*/*/cli glob — no central require.
+#
+# Usage:
+#   bin/ots bannedips                       # Show count + usage
+#   bin/ots bannedips list                  # List banned IPs (most recent first)
+#   bin/ots bannedips ban IP [--reason R]   # Ban an IP address / CIDR
+#   bin/ots bannedips unban IP              # Remove a ban
+
+require 'colonel/models/banned_ip'
+
+module Onetime
+  module CLI
+    class BannedIpsCommand < Command
+      desc 'Manage banned IP addresses'
+
+      def call(**)
+        boot_application!
+
+        count = Onetime::BannedIP.instances.size
+
+        puts format('%d banned IP(s)', count)
+        puts
+        puts 'Usage:'
+        puts '  bin/ots bannedips list                      # List banned IPs (recent first)'
+        puts '  bin/ots bannedips ban IP                    # Ban an IP address / CIDR'
+        puts '  bin/ots bannedips ban IP --reason "abuse"   # Ban with a reason (stored + audited)'
+        puts "  bin/ots bannedips ban IP --expiration 3600  # Auto-expire the ban after 1 hour"
+        puts '  bin/ots bannedips unban IP                  # Remove a ban'
+        puts
+        puts 'Mutations are recorded in the admin audit trail (actor: cli).'
+      end
+    end
+
+    register 'bannedips', BannedIpsCommand, aliases: ['banned-ips']
+  end
+end

--- a/apps/api/colonel/logic/colonel.rb
+++ b/apps/api/colonel/logic/colonel.rb
@@ -44,6 +44,7 @@ require_relative 'colonel/unban_ip'
 
 # Custom domains
 require_relative 'colonel/list_custom_domains'
+require_relative 'colonel/verify_custom_domain'
 
 # Organizations
 require_relative 'colonel/list_organizations'

--- a/apps/api/colonel/logic/colonel/ban_ip.rb
+++ b/apps/api/colonel/logic/colonel/ban_ip.rb
@@ -4,12 +4,22 @@
 
 require 'ipaddr'
 require_relative '../base'
+require 'onetime/operations/ban_ip'
 
 module ColonelAPI
   module Logic
     module Colonel
+      # Ban an IP address / CIDR (Colonel).
+      #
+      # Thin adapter over {Onetime::Operations::BanIP} — the single, audited
+      # implementation of the ban verb (epic #33). This class keeps only the HTTP
+      # concerns (param validation + the already-banned form error); the op owns
+      # the model mutation and the AdminAuditEvent (CONTRACT 4).
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
       class BanIP < ColonelAPI::Logic::Base
-        attr_reader :ip_address, :reason, :expiration, :banned_ip
+        attr_reader :ip_address, :reason, :expiration, :result
 
         def process_params
           @ip_address = sanitize_ip_address(params['ip_address'])
@@ -36,13 +46,17 @@ module ColonelAPI
         end
 
         def process
-          # Ban the IP
-          @banned_ip = Onetime::BannedIP.ban!(
-            ip_address,
+          # Delegate the model mutation + audit to the single op implementation.
+          # banned_by keeps the historic value (acting colonel's objid) for
+          # bit-for-bit parity with the prior inline call; actor is the colonel's
+          # PUBLIC id, used only for the audit trail (never an objid).
+          @result = Onetime::Operations::BanIP.new(
+            ip_address: ip_address,
             reason: reason,
             banned_by: cust.objid,
+            actor: cust.extid,
             expiration: expiration,
-          )
+          ).call
 
           success_data
         end
@@ -50,11 +64,11 @@ module ColonelAPI
         def success_data
           {
             record: {
-              id: banned_ip.objid,
-              ip_address: banned_ip.ip_address,
-              reason: banned_ip.reason,
-              banned_by: banned_ip.banned_by,
-              banned_at: banned_ip.banned_at,
+              id: result.id,
+              ip_address: result.ip_address,
+              reason: result.reason,
+              banned_by: result.banned_by,
+              banned_at: result.banned_at,
             },
             details: {
               message: 'IP address banned successfully',

--- a/apps/api/colonel/logic/colonel/manage_entitlement_override.rb
+++ b/apps/api/colonel/logic/colonel/manage_entitlement_override.rb
@@ -73,7 +73,7 @@ module ColonelAPI
         def raise_concerns
           verify_one_of_roles!(colonel: true)
 
-          @org = Onetime::Organization.load(@org_id)
+          @org = load_organization
           raise_not_found('Organization not found') unless @org&.exists?
 
           # Validate entitlement name is known (optional, but helps catch typos)
@@ -96,6 +96,8 @@ module ColonelAPI
             @org.clear_entitlement_overrides
           end
 
+          record_audit_event
+
           success_data
         end
 
@@ -114,6 +116,34 @@ module ColonelAPI
         end
 
         private
+
+        # Resolve the target org by PUBLIC id (extid) first — the admin
+        # organizations screen routes exclusively by extid — then fall back to
+        # objid so existing objid-based callers (CLI, older integrations) keep
+        # working. Mirrors InvestigateOrganization#load_organization.
+        def load_organization
+          org = Onetime::Organization.find_by_extid(@org_id)
+          return org if org
+
+          Onetime::Organization.load(@org_id)
+        end
+
+        # One audit event per successful entitlement-override mutation
+        # (CONTRACT 4 / epic D4). Emitted from the logic layer: this
+        # billing-domain verb has no extracted Operation yet (a dedicated
+        # billing op is deferred to a follow-up per the epic's "improvements
+        # ship as separate PRs"), so the non-negotiable audit backstop lives
+        # here. actor/target are PUBLIC ids (never objids); AdminAuditEvent.record
+        # is best-effort and swallows its own failures, so it never breaks the op.
+        def record_audit_event
+          Onetime::AdminAuditEvent.record(
+            actor: cust.extid,
+            verb: "organization.entitlement.#{@action}",
+            target: @org.extid,
+            result: :success,
+            detail: @action == 'clear' ? {} : { entitlement: @entitlement },
+          )
+        end
 
         def action_past_tense
           ACTION_PAST_TENSE[@action]

--- a/apps/api/colonel/logic/colonel/unban_ip.rb
+++ b/apps/api/colonel/logic/colonel/unban_ip.rb
@@ -3,10 +3,20 @@
 # frozen_string_literal: true
 
 require_relative '../base'
+require 'onetime/operations/unban_ip'
 
 module ColonelAPI
   module Logic
     module Colonel
+      # Unban an IP address / CIDR (Colonel).
+      #
+      # Thin adapter over {Onetime::Operations::UnbanIP} — the single, audited
+      # implementation of the unban verb (epic #33). This class keeps only the
+      # HTTP concerns (param validation + the not-banned 404); the op owns the
+      # model mutation and the AdminAuditEvent (CONTRACT 4).
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
       class UnbanIP < ColonelAPI::Logic::Base
         attr_reader :ip_address, :unbanned
 
@@ -25,8 +35,13 @@ module ColonelAPI
         end
 
         def process
-          # Unban the IP
-          @unbanned = Onetime::BannedIP.unban!(ip_address)
+          # Delegate the model mutation + audit to the single op implementation.
+          # actor is the acting colonel's PUBLIC id (never an objid).
+          result   = Onetime::Operations::UnbanIP.new(
+            ip_address: ip_address,
+            actor: cust.extid,
+          ).call
+          @unbanned = result.unbanned
 
           success_data
         end

--- a/apps/api/colonel/logic/colonel/verify_custom_domain.rb
+++ b/apps/api/colonel/logic/colonel/verify_custom_domain.rb
@@ -1,0 +1,87 @@
+# apps/api/colonel/logic/colonel/verify_custom_domain.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/admin_verify_domain'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Verify Custom Domain (Colonel)
+      #
+      # @api Runs DNS + SSL verification for a single custom domain, on demand,
+      #   from the admin console — surfacing the CLI-only `bin/ots domains verify`
+      #   capability in the UI (epic #31). Requires the colonel role.
+      #
+      # Thin adapter over {Onetime::Operations::AdminVerifyDomain}, which reuses the
+      # incumbent {Onetime::Operations::VerifyDomain} (shared DNS/SSL verifier, no
+      # duplication) and records the AdminAuditEvent (CONTRACT 4). The response
+      # reports the HONEST post-verification state (verified / resolving / pending /
+      # unverified, plus any op error) — it never fakes success.
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this logic
+      # (verify_one_of_roles!(colonel: true)) enforce the colonel role. Unlike the
+      # customer-facing DomainsAPI verify endpoint, the colonel resolves ANY domain
+      # by its public extid with no organization-ownership check.
+      class VerifyCustomDomain < ColonelAPI::Logic::Base
+        attr_reader :extid, :custom_domain, :result
+
+        def process_params
+          @extid = sanitize_identifier(params['extid'])
+          raise_form_error('Domain ID is required', field: :extid) if extid.to_s.empty?
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+
+          # Resolve globally by PUBLIC id (extid) — the colonel domains list exposes
+          # only extid. Colonel access is cross-organization, so (unlike GetDomain)
+          # there is no ownership/membership gate here.
+          @custom_domain = Onetime::CustomDomain.find_by_extid(extid)
+          raise_not_found('Domain not found') unless custom_domain
+        end
+
+        def process
+          @result = Onetime::Operations::AdminVerifyDomain.new(
+            domain: custom_domain,
+            actor: cust.extid, # acting colonel's PUBLIC id (never an objid)
+            persist: true,
+          ).call
+
+          OT.info "[VerifyCustomDomain] #{custom_domain.display_domain} -> " \
+                  "state=#{result.current_state}, dns=#{result.dns_validated}, " \
+                  "resolving=#{result.is_resolving}"
+
+          success_data
+        end
+
+        def success_data
+          {
+            record: {
+              domain_id: custom_domain.domainid,
+              extid: custom_domain.extid,
+              display_domain: custom_domain.display_domain,
+              verification_state: custom_domain.verification_state.to_s,
+              verified: custom_domain.verified.to_s == 'true',
+              resolving: custom_domain.resolving.to_s == 'true',
+              ready: custom_domain.ready?,
+              updated: custom_domain.updated,
+            },
+            details: {
+              previous_state: result.previous_state.to_s,
+              current_state: result.current_state.to_s,
+              changed: result.changed?,
+              dns_validated: result.dns_validated,
+              ssl_ready: result.ssl_ready,
+              is_resolving: result.is_resolving,
+              # nil on success; the op's captured error message on a check failure.
+              error: result.error,
+              message: 'Domain verification completed',
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/routes.txt
+++ b/apps/api/colonel/routes.txt
@@ -41,6 +41,7 @@ DELETE /banned-ips/:ip                    ColonelAPI::Logic::Colonel::UnbanIP re
 
 # Custom Domains
 GET    /domains                           ColonelAPI::Logic::Colonel::ListCustomDomains response=json auth=sessionauth role=colonel scope=internal
+POST   /domains/:extid/verify             ColonelAPI::Logic::Colonel::VerifyCustomDomain response=json auth=sessionauth role=colonel scope=internal
 
 # Organizations
 GET    /organizations                     ColonelAPI::Logic::Colonel::ListOrganizations response=json auth=sessionauth role=colonel scope=internal

--- a/lib/onetime/operations/admin_verify_domain.rb
+++ b/lib/onetime/operations/admin_verify_domain.rb
@@ -1,0 +1,84 @@
+# lib/onetime/operations/admin_verify_domain.rb
+#
+# frozen_string_literal: true
+
+# Reuses (does not rewrite) the incumbent domain-verify operation. Loaded at the
+# call site (the colonel logic class), so require the dependencies explicitly —
+# the same convention the CLI + domain API logic follow.
+require 'onetime/operations/verify_domain'
+require 'onetime/models/admin_audit_event'
+
+module Onetime
+  module Operations
+    # ADMIN domain-verify wrapper: run DNS/SSL verification for a single custom
+    # domain as a colonel / operator action, and record it in the admin audit
+    # trail (epic #31 / CONTRACT 4).
+    #
+    # This deliberately does NOT re-implement verification — it delegates to the
+    # incumbent {Onetime::Operations::VerifyDomain} (the shared DNS/SSL verifier
+    # with atomic persistence semantics, issue #3080) and adds exactly one
+    # {Onetime::AdminAuditEvent} per call.
+    #
+    # ## Why a wrapper instead of auditing inside VerifyDomain
+    #
+    # The bare `VerifyDomain` op is also driven by NON-admin callers — the
+    # `bin/ots domains verify` CLI, the `DomainsAPI::Logic::Domains::VerifyDomain`
+    # customer endpoint, and the scheduled `domain_refresh_job`. None of those are
+    # admin actions and must not land in the admin audit trail; auditing inside the
+    # bare op would mislabel every scheduled/self-service verification as operator
+    # activity AND perturb the CLI's golden-master output. So the audit lives in
+    # this admin-only wrapper (mirrors the customer-verify precedent
+    # {Auth::Operations::Customers::SetVerification}); the incumbent op is untouched.
+    #
+    # A verify always potentially mutates state (it persists the refreshed
+    # verified/resolving flags + `updated`), so — unlike the customer wrapper, which
+    # only audits an actual change — this records EXACTLY ONE event per call
+    # regardless of the DNS outcome, with `result:` reflecting success/failure. That
+    # is the mutating-op audit contract (CONTRACT 4): one event per mutating action.
+    #
+    # The underlying {Onetime::Operations::VerifyDomain::Result} is returned
+    # unchanged so the caller can surface the honest verification outcome
+    # (verified / resolving / pending / unverified, or an error) to the operator.
+    class AdminVerifyDomain
+      # Audit verb recorded for every admin domain verification.
+      AUDIT_VERB = 'domain.verify'
+
+      # @param domain [Onetime::CustomDomain] target domain (caller ensures non-nil)
+      # @param actor [String, #extid, #email] acting admin's PUBLIC identity
+      #   (colonel extid/email). Never an internal objid.
+      # @param persist [Boolean] whether to save verification changes (default true;
+      #   pass false for a read-only health check — still audited as an attempt).
+      def initialize(domain:, actor:, persist: true)
+        @domain  = domain
+        @actor   = actor
+        @persist = persist
+      end
+
+      # @return [Onetime::Operations::VerifyDomain::Result] the verification result
+      #   (passthrough from the incumbent op).
+      def call
+        result = Onetime::Operations::VerifyDomain.new(
+          domain: @domain,
+          persist: @persist,
+        ).call
+
+        Onetime::AdminAuditEvent.record(
+          actor: @actor,
+          verb: AUDIT_VERB,
+          target: @domain.extid,
+          result: result.success? ? :success : :failure,
+          detail: {
+            previous_state: result.previous_state.to_s,
+            current_state: result.current_state.to_s,
+            dns_validated: result.dns_validated,
+            is_resolving: result.is_resolving,
+            ssl_ready: result.ssl_ready,
+            persisted: result.persisted,
+          },
+        )
+
+        result
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/ban_ip.rb
+++ b/lib/onetime/operations/ban_ip.rb
@@ -1,0 +1,118 @@
+# lib/onetime/operations/ban_ip.rb
+#
+# frozen_string_literal: true
+
+# Central (cross-cutting) admin operation — see decision D3 in
+# lib/onetime/operations/README.md. IP bans have no single domain owner (the
+# perimeter is site-wide, enforced by the ip_ban middleware), so — unlike the
+# auth-owned customer verbs — this lives in the central operations home. Loaded
+# at the call site (colonel logic + CLI), so require the dependencies explicitly,
+# mirroring AdminVerifyDomain.
+require 'colonel/models/banned_ip'
+require 'onetime/models/admin_audit_event'
+
+module Onetime
+  module Operations
+    # Ban a single IP address / CIDR as an operator action, and record it in the
+    # admin audit trail (epic #33 / CONTRACT 4).
+    #
+    # This is the SINGLE implementation of the ban verb. Before this extraction
+    # `BanIP`/`UnbanIP` were API-only: the colonel logic called
+    # {Onetime::BannedIP.ban!} directly, so an incident responder on a shell had
+    # no way to ban an IP. The colonel endpoint
+    # (`POST /api/colonel/banned-ips`) and the `bin/ots bannedips ban` CLI are now
+    # thin adapters over this op.
+    #
+    # ## Behavioural parity (bit-for-bit)
+    #
+    # The model call is IDENTICAL to the prior inline call
+    # (`Onetime::BannedIP.ban!(ip, reason:, banned_by:, expiration:)`): `banned_by`
+    # is still whatever the caller supplies (the colonel logic passes the acting
+    # colonel's objid, preserving the stored field verbatim), and `expiration` is
+    # passed through unchanged. The op adds exactly one thing the inline call
+    # lacked: one {Onetime::AdminAuditEvent} per successful ban.
+    #
+    # ## Audit vs. stored identity
+    #
+    # `banned_by` (stored ON the record, surfaced in the UI's "Banned By" column)
+    # and `actor` (the audit-trail identity) are DISTINCT on purpose: the audit
+    # actor must be a PUBLIC id (colonel extid/email), never an internal objid,
+    # while the historic `banned_by` field keeps its existing objid value for
+    # bit-for-bit parity.
+    #
+    # Stateless, single `#call`, returns an immutable {Result}. A ban that is a
+    # no-op (the IP is already covered by an existing ban) returns
+    # `status: :already_banned` and records NO audit event (nothing mutated),
+    # mirroring the "only audit an actual change" rule used by the customer verbs.
+    class BanIP
+      # Audit verb recorded for every successful ban.
+      AUDIT_VERB = 'ip.ban'
+
+      # @!attribute status [r]
+      #   @return [Symbol] :success (banned) or :already_banned (no-op)
+      Result = Data.define(:status, :id, :ip_address, :reason, :banned_by, :banned_at)
+
+      # @param ip_address [String] the IP address or CIDR to ban (caller validates
+      #   format; this op does not re-parse it).
+      # @param actor [String, #extid, #email] acting admin's PUBLIC identity
+      #   (colonel extid/email, or a CLI sentinel). Never an internal objid.
+      # @param reason [String, nil] optional human-readable reason (stored + audited).
+      # @param banned_by [String, nil] value stored on the record's `banned_by`
+      #   field (the colonel logic passes the acting colonel's objid, preserving
+      #   the historic behaviour). Distinct from `actor`.
+      # @param expiration [Integer, nil] optional TTL in seconds; nil = permanent.
+      def initialize(ip_address:, actor:, reason: nil, banned_by: nil, expiration: nil)
+        @ip_address = ip_address
+        @actor      = actor
+        @reason     = reason
+        @banned_by  = banned_by
+        @expiration = expiration
+      end
+
+      # @return [Result]
+      def call
+        # Defensive idempotency guard so a CLI/reuse caller never double-bans or
+        # records a spurious audit event. In the HTTP path the colonel logic's
+        # raise_concerns already rejects an already-banned IP with a form error
+        # (bit-for-bit preserved), so this branch is reached only off the request
+        # path (e.g. the CLI).
+        if Onetime::BannedIP.banned?(@ip_address)
+          return Result.new(
+            status: :already_banned,
+            id: nil,
+            ip_address: @ip_address,
+            reason: nil,
+            banned_by: nil,
+            banned_at: nil,
+          )
+        end
+
+        banned = Onetime::BannedIP.ban!(
+          @ip_address,
+          reason: @reason,
+          banned_by: @banned_by,
+          expiration: @expiration,
+        )
+
+        # One audit event per successful mutation. `reason` is non-secret; never
+        # put secret content / tokens into detail.
+        Onetime::AdminAuditEvent.record(
+          actor: @actor,
+          verb: AUDIT_VERB,
+          target: banned.ip_address,
+          result: :success,
+          detail: { reason: @reason, expiration: @expiration },
+        )
+
+        Result.new(
+          status: :success,
+          id: banned.objid,
+          ip_address: banned.ip_address,
+          reason: banned.reason,
+          banned_by: banned.banned_by,
+          banned_at: banned.banned_at,
+        )
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/unban_ip.rb
+++ b/lib/onetime/operations/unban_ip.rb
@@ -1,0 +1,63 @@
+# lib/onetime/operations/unban_ip.rb
+#
+# frozen_string_literal: true
+
+# Central (cross-cutting) admin operation — see decision D3 in
+# lib/onetime/operations/README.md. Sibling of {Onetime::Operations::BanIP};
+# loaded at the call site, so require the dependencies explicitly.
+require 'colonel/models/banned_ip'
+require 'onetime/models/admin_audit_event'
+
+module Onetime
+  module Operations
+    # Unban a single IP address / CIDR as an operator action, and record it in the
+    # admin audit trail (epic #33 / CONTRACT 4).
+    #
+    # The SINGLE implementation of the unban verb: the colonel endpoint
+    # (`DELETE /api/colonel/banned-ips/:ip`) and the `bin/ots bannedips unban` CLI
+    # are thin adapters over it. The model call is IDENTICAL to the prior inline
+    # call (`Onetime::BannedIP.unban!(ip)`); the op adds exactly one
+    # {Onetime::AdminAuditEvent} per successful unban.
+    #
+    # Stateless, single `#call`, returns an immutable {Result}. An unban of an IP
+    # that is not banned returns `status: :not_found` and records NO audit event
+    # (nothing mutated).
+    class UnbanIP
+      # Audit verb recorded for every successful unban.
+      AUDIT_VERB = 'ip.unban'
+
+      # @!attribute status [r]
+      #   @return [Symbol] :success (removed) or :not_found (nothing to remove)
+      Result = Data.define(:status, :ip_address, :unbanned)
+
+      # @param ip_address [String] the IP address or CIDR to unban.
+      # @param actor [String, #extid, #email] acting admin's PUBLIC identity
+      #   (colonel extid/email, or a CLI sentinel). Never an internal objid.
+      def initialize(ip_address:, actor:)
+        @ip_address = ip_address
+        @actor      = actor
+      end
+
+      # @return [Result]
+      def call
+        # BannedIP.unban! returns true when a record was removed, false when the
+        # exact IP was not indexed (nothing to remove). Preserved verbatim.
+        unbanned = Onetime::BannedIP.unban!(@ip_address)
+
+        unless unbanned
+          return Result.new(status: :not_found, ip_address: @ip_address, unbanned: false)
+        end
+
+        # One audit event per successful mutation.
+        Onetime::AdminAuditEvent.record(
+          actor: @actor,
+          verb: AUDIT_VERB,
+          target: @ip_address,
+          result: :success,
+        )
+
+        Result.new(status: :success, ip_address: @ip_address, unbanned: true)
+      end
+    end
+  end
+end

--- a/locales/content/en/admin-bannedips.json
+++ b/locales/content/en/admin-bannedips.json
@@ -1,0 +1,114 @@
+{
+  "web.admin.bannedIps.title": {
+    "text": "Banned IPs",
+    "content_hash": "0ece5643"
+  },
+  "web.admin.bannedIps.description": {
+    "text": "Ban and unban IP addresses at the site perimeter.",
+    "content_hash": "69c0c992"
+  },
+  "web.admin.bannedIps.currentIp": {
+    "text": "Your current IP",
+    "content_hash": "14ff3ec5"
+  },
+  "web.admin.bannedIps.actions.cancel": {
+    "text": "Cancel",
+    "content_hash": "19766ed6"
+  },
+  "web.admin.bannedIps.actions.ban": {
+    "text": "Ban an IP",
+    "content_hash": "9937d7fd"
+  },
+  "web.admin.bannedIps.actions.quickBan": {
+    "text": "Ban this IP",
+    "content_hash": "95720658"
+  },
+  "web.admin.bannedIps.stats.total": {
+    "text": "Total Banned",
+    "content_hash": "41059c94"
+  },
+  "web.admin.bannedIps.columns.ipAddress": {
+    "text": "IP Address",
+    "content_hash": "3c3de0c9"
+  },
+  "web.admin.bannedIps.columns.reason": {
+    "text": "Reason",
+    "content_hash": "f81ab834"
+  },
+  "web.admin.bannedIps.columns.bannedAt": {
+    "text": "Banned At",
+    "content_hash": "dfbd120e"
+  },
+  "web.admin.bannedIps.columns.bannedBy": {
+    "text": "Banned By",
+    "content_hash": "9f47db0e"
+  },
+  "web.admin.bannedIps.columns.actions": {
+    "text": "Actions",
+    "content_hash": "ff8059dc"
+  },
+  "web.admin.bannedIps.list.loadError": {
+    "text": "Could not load banned IPs.",
+    "content_hash": "539f2e34"
+  },
+  "web.admin.bannedIps.list.retry": {
+    "text": "Retry",
+    "content_hash": "942087cc"
+  },
+  "web.admin.bannedIps.list.empty": {
+    "text": "No IPs are currently banned",
+    "content_hash": "b72cc9c5"
+  },
+  "web.admin.bannedIps.form.title": {
+    "text": "Ban an IP address",
+    "content_hash": "59961746"
+  },
+  "web.admin.bannedIps.form.ipLabel": {
+    "text": "IP Address or CIDR",
+    "content_hash": "133d0819"
+  },
+  "web.admin.bannedIps.form.reasonLabel": {
+    "text": "Reason (optional)",
+    "content_hash": "0f7d4664"
+  },
+  "web.admin.bannedIps.form.reasonPlaceholder": {
+    "text": "e.g. credential stuffing",
+    "content_hash": "828a15ae"
+  },
+  "web.admin.bannedIps.form.submit": {
+    "text": "Ban IP",
+    "content_hash": "f91a5285"
+  },
+  "web.admin.bannedIps.ban.confirmTitle": {
+    "text": "Ban this IP address?",
+    "content_hash": "512acd7b"
+  },
+  "web.admin.bannedIps.ban.confirmDescription": {
+    "text": "This blocks {ip} at the site perimeter. Type the IP to confirm.",
+    "content_hash": "d8f6142e"
+  },
+  "web.admin.bannedIps.ban.button": {
+    "text": "Ban IP",
+    "content_hash": "f91a5285"
+  },
+  "web.admin.bannedIps.ban.success": {
+    "text": "Banned {ip}",
+    "content_hash": "97180685"
+  },
+  "web.admin.bannedIps.unban.confirmTitle": {
+    "text": "Remove this ban?",
+    "content_hash": "88473e59"
+  },
+  "web.admin.bannedIps.unban.confirmDescription": {
+    "text": "This unblocks {ip}. Type the IP to confirm.",
+    "content_hash": "6bec3191"
+  },
+  "web.admin.bannedIps.unban.button": {
+    "text": "Unban",
+    "content_hash": "25fb5989"
+  },
+  "web.admin.bannedIps.unban.success": {
+    "text": "Unbanned {ip}",
+    "content_hash": "79192c36"
+  }
+}

--- a/locales/content/en/admin-domains.json
+++ b/locales/content/en/admin-domains.json
@@ -1,0 +1,42 @@
+{
+  "web.admin.domains.list.loadError": {
+    "text": "Could not load domains.",
+    "content_hash": "548deff8"
+  },
+  "web.admin.domains.retry": {
+    "text": "Retry",
+    "content_hash": "942087cc"
+  },
+  "web.admin.domains.verify.button": {
+    "text": "Verify",
+    "content_hash": "eea2745e"
+  },
+  "web.admin.domains.verify.confirmTitle": {
+    "text": "Verify domain?",
+    "content_hash": "07c4dc4f"
+  },
+  "web.admin.domains.verify.confirmDescription": {
+    "text": "Run DNS and SSL verification checks for {domain}.",
+    "content_hash": "06797824"
+  },
+  "web.admin.domains.verify.success.verified": {
+    "text": "{domain} is verified.",
+    "content_hash": "802b5d1e"
+  },
+  "web.admin.domains.verify.success.resolving": {
+    "text": "{domain} is resolving but not yet verified.",
+    "content_hash": "bc8aecad"
+  },
+  "web.admin.domains.verify.success.pending": {
+    "text": "{domain} is pending — DNS is not resolving yet.",
+    "content_hash": "0d9f66d5"
+  },
+  "web.admin.domains.verify.success.unverified": {
+    "text": "{domain} could not be verified.",
+    "content_hash": "630da482"
+  },
+  "web.admin.domains.verify.success.done": {
+    "text": "Verification complete for {domain}.",
+    "content_hash": "ed67e22d"
+  }
+}

--- a/locales/content/en/admin-organizations.json
+++ b/locales/content/en/admin-organizations.json
@@ -1,0 +1,146 @@
+{
+  "web.admin.organizations.list.loadError": {
+    "text": "Could not load organizations.",
+    "content_hash": "130d5e70"
+  },
+  "web.admin.organizations.retry": {
+    "text": "Retry",
+    "content_hash": "942087cc"
+  },
+  "web.admin.organizations.fields.contactEmail": {
+    "text": "Contact email",
+    "content_hash": "6d7fce11"
+  },
+  "web.admin.organizations.fields.owner": {
+    "text": "Owner",
+    "content_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.fields.plan": {
+    "text": "Plan",
+    "content_hash": "fa8ed0bd"
+  },
+  "web.admin.organizations.fields.subscription": {
+    "text": "Subscription status",
+    "content_hash": "f0723c4e"
+  },
+  "web.admin.organizations.fields.periodEnd": {
+    "text": "Period end",
+    "content_hash": "eeae9fdd"
+  },
+  "web.admin.organizations.fields.billingEmail": {
+    "text": "Billing email",
+    "content_hash": "8805b928"
+  },
+  "web.admin.organizations.fields.stripeCustomer": {
+    "text": "Stripe customer",
+    "content_hash": "8f169be1"
+  },
+  "web.admin.organizations.fields.stripeSubscription": {
+    "text": "Stripe subscription",
+    "content_hash": "53f71e08"
+  },
+  "web.admin.organizations.fields.orgId": {
+    "text": "Organization ID",
+    "content_hash": "1f466322"
+  },
+  "web.admin.organizations.fields.created": {
+    "text": "Created",
+    "content_hash": "d70b9e24"
+  },
+  "web.admin.organizations.fields.updated": {
+    "text": "Updated",
+    "content_hash": "3a5ecca1"
+  },
+  "web.admin.organizations.investigate.description": {
+    "text": "Compare local billing state against the live Stripe subscription.",
+    "content_hash": "d7bbe9ed"
+  },
+  "web.admin.organizations.investigate.rawPayload": {
+    "text": "Raw investigation payload",
+    "content_hash": "29ca7df2"
+  },
+  "web.admin.organizations.investigate.parseError": {
+    "text": "The investigation response did not match the expected format.",
+    "content_hash": "db59cab1"
+  },
+  "web.admin.organizations.entitlements.section": {
+    "text": "Entitlement overrides",
+    "content_hash": "48812068"
+  },
+  "web.admin.organizations.entitlements.description": {
+    "text": "Grant or revoke entitlements independently of the plan. Effective = plan entitlements + grants - revokes.",
+    "content_hash": "4c38425b"
+  },
+  "web.admin.organizations.entitlements.inputLabel": {
+    "text": "Entitlement",
+    "content_hash": "0d8f0b2d"
+  },
+  "web.admin.organizations.entitlements.placeholder": {
+    "text": "e.g. custom_domains",
+    "content_hash": "05346c68"
+  },
+  "web.admin.organizations.entitlements.grant": {
+    "text": "Grant",
+    "content_hash": "78b7d037"
+  },
+  "web.admin.organizations.entitlements.revoke": {
+    "text": "Revoke",
+    "content_hash": "87e6d00b"
+  },
+  "web.admin.organizations.entitlements.clear": {
+    "text": "Clear all overrides",
+    "content_hash": "f0e485c3"
+  },
+  "web.admin.organizations.entitlements.effective": {
+    "text": "Effective entitlements",
+    "content_hash": "b840f8c8"
+  },
+  "web.admin.organizations.entitlements.grants": {
+    "text": "Grants",
+    "content_hash": "b3e1c95a"
+  },
+  "web.admin.organizations.entitlements.revokes": {
+    "text": "Revokes",
+    "content_hash": "f0e69b17"
+  },
+  "web.admin.organizations.entitlements.noOverrides": {
+    "text": "Perform an action to view this organization's current override state.",
+    "content_hash": "98d2e30d"
+  },
+  "web.admin.organizations.entitlements.confirm.grantTitle": {
+    "text": "Grant entitlement?",
+    "content_hash": "a4b2c57b"
+  },
+  "web.admin.organizations.entitlements.confirm.grantDescription": {
+    "text": "Grant “{entitlement}” to {org}. This changes the organization's billing entitlements.",
+    "content_hash": "542ce26a"
+  },
+  "web.admin.organizations.entitlements.confirm.revokeTitle": {
+    "text": "Revoke entitlement?",
+    "content_hash": "c93d520a"
+  },
+  "web.admin.organizations.entitlements.confirm.revokeDescription": {
+    "text": "Revoke “{entitlement}” from {org}. This changes the organization's billing entitlements.",
+    "content_hash": "a5d2a8a6"
+  },
+  "web.admin.organizations.entitlements.confirm.clearTitle": {
+    "text": "Clear all entitlement overrides?",
+    "content_hash": "e36eb218"
+  },
+  "web.admin.organizations.entitlements.confirm.clearDescription": {
+    "text": "Remove every grant and revoke override for {org}, resetting it to its plan entitlements.",
+    "content_hash": "96bad079"
+  },
+  "web.admin.organizations.entitlements.success.granted": {
+    "text": "Entitlement “{entitlement}” granted.",
+    "content_hash": "cf52fb0e"
+  },
+  "web.admin.organizations.entitlements.success.revoked": {
+    "text": "Entitlement “{entitlement}” revoked.",
+    "content_hash": "279d425d"
+  },
+  "web.admin.organizations.entitlements.success.cleared": {
+    "text": "All entitlement overrides cleared.",
+    "content_hash": "a482743b"
+  }
+}

--- a/locales/content/en/admin-secrets.json
+++ b/locales/content/en/admin-secrets.json
@@ -1,0 +1,242 @@
+{
+  "web.admin.secrets.title": {
+    "text": "Secrets",
+    "content_hash": "d8707d41"
+  },
+  "web.admin.secrets.description": {
+    "text": "Inspect a secret's receipt and delete it without SSH.",
+    "content_hash": "c3451cbf"
+  },
+  "web.admin.secrets.columns.shortId": {
+    "text": "Short ID",
+    "content_hash": "7eaeb4a7"
+  },
+  "web.admin.secrets.columns.state": {
+    "text": "State",
+    "content_hash": "a3b50c47"
+  },
+  "web.admin.secrets.columns.owner": {
+    "text": "Owner",
+    "content_hash": "4b1b8aa3"
+  },
+  "web.admin.secrets.columns.created": {
+    "text": "Created",
+    "content_hash": "d70b9e24"
+  },
+  "web.admin.secrets.columns.expiration": {
+    "text": "Expiration",
+    "content_hash": "f38d6e0e"
+  },
+  "web.admin.secrets.columns.age": {
+    "text": "Age (days)",
+    "content_hash": "52ae64c6"
+  },
+  "web.admin.secrets.list.empty": {
+    "text": "No secrets found",
+    "content_hash": "28647b3b"
+  },
+  "web.admin.secrets.list.loadError": {
+    "text": "Could not load secrets.",
+    "content_hash": "17269345"
+  },
+  "web.admin.secrets.list.retry": {
+    "text": "Retry",
+    "content_hash": "942087cc"
+  },
+  "web.admin.secrets.never": {
+    "text": "Never",
+    "content_hash": "6300ef80"
+  },
+  "web.admin.secrets.anonymous": {
+    "text": "Anonymous",
+    "content_hash": "e7a8aa2d"
+  },
+  "web.admin.secrets.ageDays": {
+    "text": "{days} days",
+    "content_hash": "a2246fbc"
+  },
+  "web.admin.secrets.state.new": {
+    "text": "New",
+    "content_hash": "18fdd549"
+  },
+  "web.admin.secrets.state.received": {
+    "text": "Received",
+    "content_hash": "49f19bee"
+  },
+  "web.admin.secrets.state.viewed": {
+    "text": "Viewed",
+    "content_hash": "1b28d178"
+  },
+  "web.admin.secrets.drawer.title": {
+    "text": "Secret {shortid}",
+    "content_hash": "8b311d32"
+  },
+  "web.admin.secrets.drawer.loadError": {
+    "text": "Could not load this secret.",
+    "content_hash": "c96672e4"
+  },
+  "web.admin.secrets.drawer.notFound": {
+    "text": "Secret not found",
+    "content_hash": "70a9532c"
+  },
+  "web.admin.secrets.drawer.notFoundDescription": {
+    "text": "This secret no longer exists. It may have expired or been deleted.",
+    "content_hash": "bc412692"
+  },
+  "web.admin.secrets.drawer.retry": {
+    "text": "Retry",
+    "content_hash": "942087cc"
+  },
+  "web.admin.secrets.sections.secret": {
+    "text": "Secret",
+    "content_hash": "7e32a729"
+  },
+  "web.admin.secrets.sections.receipt": {
+    "text": "Receipt",
+    "content_hash": "dad5a969"
+  },
+  "web.admin.secrets.sections.owner": {
+    "text": "Owner",
+    "content_hash": "4b1b8aa3"
+  },
+  "web.admin.secrets.sections.raw": {
+    "text": "Raw",
+    "content_hash": "848123d1"
+  },
+  "web.admin.secrets.fields.secretId": {
+    "text": "Secret ID",
+    "content_hash": "79592419"
+  },
+  "web.admin.secrets.fields.shortId": {
+    "text": "Short ID",
+    "content_hash": "7eaeb4a7"
+  },
+  "web.admin.secrets.fields.state": {
+    "text": "State",
+    "content_hash": "a3b50c47"
+  },
+  "web.admin.secrets.fields.created": {
+    "text": "Created",
+    "content_hash": "d70b9e24"
+  },
+  "web.admin.secrets.fields.updated": {
+    "text": "Updated",
+    "content_hash": "3a5ecca1"
+  },
+  "web.admin.secrets.fields.expiration": {
+    "text": "Expiration",
+    "content_hash": "f38d6e0e"
+  },
+  "web.admin.secrets.fields.age": {
+    "text": "Age",
+    "content_hash": "39b7370f"
+  },
+  "web.admin.secrets.fields.lifespan": {
+    "text": "Lifespan",
+    "content_hash": "58994285"
+  },
+  "web.admin.secrets.fields.owner": {
+    "text": "Owner",
+    "content_hash": "4b1b8aa3"
+  },
+  "web.admin.secrets.fields.receiptId": {
+    "text": "Receipt ID",
+    "content_hash": "2c13d799"
+  },
+  "web.admin.secrets.fields.hasCiphertext": {
+    "text": "Has ciphertext",
+    "content_hash": "e9188bad"
+  },
+  "web.admin.secrets.fields.ciphertextLength": {
+    "text": "Ciphertext length",
+    "content_hash": "0f1744fd"
+  },
+  "web.admin.secrets.receiptFields.receiptId": {
+    "text": "Receipt ID",
+    "content_hash": "2c13d799"
+  },
+  "web.admin.secrets.receiptFields.shortId": {
+    "text": "Short ID",
+    "content_hash": "7eaeb4a7"
+  },
+  "web.admin.secrets.receiptFields.state": {
+    "text": "State",
+    "content_hash": "a3b50c47"
+  },
+  "web.admin.secrets.receiptFields.secretTtl": {
+    "text": "Secret TTL",
+    "content_hash": "b89c0b51"
+  },
+  "web.admin.secrets.receiptFields.recipients": {
+    "text": "Recipients",
+    "content_hash": "1e8568a8"
+  },
+  "web.admin.secrets.receiptFields.hasPassphrase": {
+    "text": "Has passphrase",
+    "content_hash": "af458f26"
+  },
+  "web.admin.secrets.receiptFields.shareDomain": {
+    "text": "Share domain",
+    "content_hash": "db963805"
+  },
+  "web.admin.secrets.receiptFields.created": {
+    "text": "Created",
+    "content_hash": "d70b9e24"
+  },
+  "web.admin.secrets.receiptFields.secretExpired": {
+    "text": "Secret expired",
+    "content_hash": "c127dab6"
+  },
+  "web.admin.secrets.receipt.none": {
+    "text": "No receipt is associated with this secret.",
+    "content_hash": "5ddceaed"
+  },
+  "web.admin.secrets.ownerFields.email": {
+    "text": "Email",
+    "content_hash": "969ccbd3"
+  },
+  "web.admin.secrets.ownerFields.userId": {
+    "text": "User ID",
+    "content_hash": "7967e089"
+  },
+  "web.admin.secrets.ownerFields.role": {
+    "text": "Role",
+    "content_hash": "14736a2e"
+  },
+  "web.admin.secrets.ownerFields.verified": {
+    "text": "Verified",
+    "content_hash": "4f783840"
+  },
+  "web.admin.secrets.owner.anonymous": {
+    "text": "Anonymous (no owner)",
+    "content_hash": "390f11ad"
+  },
+  "web.admin.secrets.detail.yes": {
+    "text": "Yes",
+    "content_hash": "85a39ab3"
+  },
+  "web.admin.secrets.detail.no": {
+    "text": "No",
+    "content_hash": "1ea442a1"
+  },
+  "web.admin.secrets.detail.none": {
+    "text": "None",
+    "content_hash": "dc937b59"
+  },
+  "web.admin.secrets.actions.delete.button": {
+    "text": "Delete secret",
+    "content_hash": "1a48c8c8"
+  },
+  "web.admin.secrets.actions.delete.confirmTitle": {
+    "text": "Delete secret?",
+    "content_hash": "4a779a67"
+  },
+  "web.admin.secrets.actions.delete.confirmDescription": {
+    "text": "This permanently deletes secret {shortid} and its receipt. This cannot be undone.",
+    "content_hash": "51f807ad"
+  },
+  "web.admin.secrets.actions.delete.success": {
+    "text": "Secret deleted.",
+    "content_hash": "52f1640f"
+  }
+}

--- a/locales/content/en/admin-system.json
+++ b/locales/content/en/admin-system.json
@@ -1,0 +1,158 @@
+{
+  "web.admin.system.title": {
+    "text": "System",
+    "content_hash": "6725e7bb"
+  },
+  "web.admin.system.description": {
+    "text": "Database, queue, and infrastructure status.",
+    "content_hash": "0115f495"
+  },
+  "web.admin.system.retry": {
+    "text": "Retry",
+    "content_hash": "942087cc"
+  },
+  "web.admin.system.database.title": {
+    "text": "Main Database ({engine})",
+    "content_hash": "1391230b"
+  },
+  "web.admin.system.database.loadError": {
+    "text": "Could not load database metrics.",
+    "content_hash": "905055c6"
+  },
+  "web.admin.system.database.server": {
+    "text": "Server",
+    "content_hash": "aef7de28"
+  },
+  "web.admin.system.database.memory": {
+    "text": "Memory",
+    "content_hash": "c3963aed"
+  },
+  "web.admin.system.database.databases": {
+    "text": "Databases",
+    "content_hash": "61d2afe2"
+  },
+  "web.admin.system.database.dbSummary": {
+    "text": "{keys} keys, {expires} with TTL",
+    "content_hash": "26b9e17c"
+  },
+  "web.admin.system.database.stats.customers": {
+    "text": "Customers",
+    "content_hash": "aabe76f1"
+  },
+  "web.admin.system.database.stats.secrets": {
+    "text": "Secrets",
+    "content_hash": "d8707d41"
+  },
+  "web.admin.system.database.stats.receipts": {
+    "text": "Receipts",
+    "content_hash": "60a627df"
+  },
+  "web.admin.system.database.stats.totalKeys": {
+    "text": "Total Keys",
+    "content_hash": "4e0d27f5"
+  },
+  "web.admin.system.database.fields.version": {
+    "text": "Version",
+    "content_hash": "dd167905"
+  },
+  "web.admin.system.database.fields.mode": {
+    "text": "Mode",
+    "content_hash": "5e23ec6a"
+  },
+  "web.admin.system.database.fields.uptimeDays": {
+    "text": "Uptime (days)",
+    "content_hash": "7ab314f8"
+  },
+  "web.admin.system.database.fields.connectedClients": {
+    "text": "Connected Clients",
+    "content_hash": "434adc3a"
+  },
+  "web.admin.system.database.fields.opsPerSec": {
+    "text": "Ops/sec",
+    "content_hash": "6634251d"
+  },
+  "web.admin.system.database.fields.totalCommands": {
+    "text": "Total Commands",
+    "content_hash": "c5ce5aaf"
+  },
+  "web.admin.system.database.fields.usedMemory": {
+    "text": "Used Memory",
+    "content_hash": "bac68a65"
+  },
+  "web.admin.system.database.fields.rssMemory": {
+    "text": "RSS Memory",
+    "content_hash": "7fe77d15"
+  },
+  "web.admin.system.database.fields.peakMemory": {
+    "text": "Peak Memory",
+    "content_hash": "9d44afa6"
+  },
+  "web.admin.system.database.fields.fragmentation": {
+    "text": "Fragmentation Ratio",
+    "content_hash": "721494dd"
+  },
+  "web.admin.system.queue.title": {
+    "text": "Queue",
+    "content_hash": "3b2fe03e"
+  },
+  "web.admin.system.queue.loadError": {
+    "text": "Could not load queue metrics.",
+    "content_hash": "715bdc88"
+  },
+  "web.admin.system.queue.empty": {
+    "text": "No queues found",
+    "content_hash": "3cd4eb88"
+  },
+  "web.admin.system.queue.connected": {
+    "text": "Connected",
+    "content_hash": "22965568"
+  },
+  "web.admin.system.queue.disconnected": {
+    "text": "Disconnected",
+    "content_hash": "04dfac36"
+  },
+  "web.admin.system.queue.activeWorkers": {
+    "text": "{count} active workers",
+    "content_hash": "49e6369c"
+  },
+  "web.admin.system.queue.columns.name": {
+    "text": "Queue",
+    "content_hash": "3b2fe03e"
+  },
+  "web.admin.system.queue.columns.pending": {
+    "text": "Pending",
+    "content_hash": "331551b0"
+  },
+  "web.admin.system.queue.columns.consumers": {
+    "text": "Consumers",
+    "content_hash": "212b350d"
+  },
+  "web.admin.system.queue.health.healthy": {
+    "text": "Healthy",
+    "content_hash": "7f1e323b"
+  },
+  "web.admin.system.queue.health.degraded": {
+    "text": "Degraded",
+    "content_hash": "a8494c12"
+  },
+  "web.admin.system.queue.health.unhealthy": {
+    "text": "Unhealthy",
+    "content_hash": "317b1fbc"
+  },
+  "web.admin.system.queue.health.unknown": {
+    "text": "Unknown",
+    "content_hash": "b764cdc0"
+  },
+  "web.admin.system.redis.title": {
+    "text": "Redis INFO",
+    "content_hash": "e762bd3c"
+  },
+  "web.admin.system.redis.loadError": {
+    "text": "Could not load Redis metrics.",
+    "content_hash": "ca5945d6"
+  },
+  "web.admin.system.redis.captured": {
+    "text": "Captured {at}",
+    "content_hash": "57b40c0f"
+  }
+}

--- a/locales/content/en/admin-usage.json
+++ b/locales/content/en/admin-usage.json
@@ -1,0 +1,70 @@
+{
+  "web.admin.usage.title": {
+    "text": "Usage",
+    "content_hash": "8d59829c"
+  },
+  "web.admin.usage.description": {
+    "text": "Export usage metrics for a date range.",
+    "content_hash": "97bd3325"
+  },
+  "web.admin.usage.startDate": {
+    "text": "Start Date",
+    "content_hash": "4c52faad"
+  },
+  "web.admin.usage.endDate": {
+    "text": "End Date",
+    "content_hash": "e970951c"
+  },
+  "web.admin.usage.fetch": {
+    "text": "Fetch Data",
+    "content_hash": "429532fe"
+  },
+  "web.admin.usage.loadError": {
+    "text": "Could not load usage data.",
+    "content_hash": "ffb557d7"
+  },
+  "web.admin.usage.retry": {
+    "text": "Retry",
+    "content_hash": "942087cc"
+  },
+  "web.admin.usage.empty": {
+    "text": "No data for this range",
+    "content_hash": "5fed1795"
+  },
+  "web.admin.usage.byState": {
+    "text": "Secrets by State",
+    "content_hash": "916bbcb6"
+  },
+  "web.admin.usage.secretsByDay": {
+    "text": "Secrets by Day",
+    "content_hash": "24a01e8e"
+  },
+  "web.admin.usage.usersByDay": {
+    "text": "New Users by Day",
+    "content_hash": "8c1f089f"
+  },
+  "web.admin.usage.columns.date": {
+    "text": "Date",
+    "content_hash": "99c40ab4"
+  },
+  "web.admin.usage.columns.count": {
+    "text": "Count",
+    "content_hash": "37bac495"
+  },
+  "web.admin.usage.stats.totalSecrets": {
+    "text": "Total Secrets",
+    "content_hash": "e17a5459"
+  },
+  "web.admin.usage.stats.newUsers": {
+    "text": "New Users",
+    "content_hash": "d3ee48b0"
+  },
+  "web.admin.usage.stats.avgSecrets": {
+    "text": "Avg Secrets/Day",
+    "content_hash": "948b0701"
+  },
+  "web.admin.usage.stats.avgUsers": {
+    "text": "Avg Users/Day",
+    "content_hash": "491f626d"
+  }
+}

--- a/spec/unit/onetime/operations/admin_verify_domain_spec.rb
+++ b/spec/unit/onetime/operations/admin_verify_domain_spec.rb
@@ -1,0 +1,98 @@
+# spec/unit/onetime/operations/admin_verify_domain_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for Onetime::Operations::AdminVerifyDomain.
+#
+# Covers: it reuses (delegates to) the incumbent VerifyDomain op, passes the
+# result through unchanged, and records EXACTLY ONE AdminAuditEvent per call —
+# with result: :success on a clean run and :failure when the op reports an error
+# (epic #31 / CONTRACT 4). The bare VerifyDomain op is never audited by
+# non-admin callers, so the admin trail only sees admin-initiated verifies.
+#
+# Run: pnpm run test:rspec spec/unit/onetime/operations/admin_verify_domain_spec.rb
+
+require 'spec_helper'
+require 'onetime/models/admin_audit_event'
+require 'onetime/operations/admin_verify_domain'
+
+RSpec.describe Onetime::Operations::AdminVerifyDomain do
+  let(:domain) { double('CustomDomain', extid: 'cd_abc123', display_domain: 'secrets.example.com') }
+  let(:inner)  { instance_double(Onetime::Operations::VerifyDomain) }
+
+  # A stand-in for VerifyDomain::Result with the fields the wrapper reads.
+  def result_double(success:, previous: :pending, current: :verified)
+    double(
+      'VerifyDomain::Result',
+      success?: success,
+      previous_state: previous,
+      current_state: current,
+      dns_validated: success,
+      is_resolving: success,
+      ssl_ready: success,
+      persisted: true,
+      error: success ? nil : 'DNS lookup failed',
+    )
+  end
+
+  before do
+    allow(Onetime::AdminAuditEvent).to receive(:record)
+    allow(Onetime::Operations::VerifyDomain).to receive(:new).and_return(inner)
+  end
+
+  it 'delegates to the incumbent VerifyDomain op with the domain and persist flag' do
+    allow(inner).to receive(:call).and_return(result_double(success: true))
+
+    described_class.new(domain: domain, actor: 'ur_col').call
+
+    expect(Onetime::Operations::VerifyDomain).to have_received(:new).with(
+      domain: domain, persist: true
+    )
+  end
+
+  it 'records exactly one audit event with result: :success on a clean verify' do
+    op_result = result_double(success: true, previous: :pending, current: :verified)
+    allow(inner).to receive(:call).and_return(op_result)
+
+    returned = described_class.new(domain: domain, actor: 'ur_col').call
+
+    # Returns the underlying Result unchanged.
+    expect(returned).to be(op_result)
+    expect(Onetime::AdminAuditEvent).to have_received(:record).once.with(
+      actor: 'ur_col',
+      verb: 'domain.verify',
+      target: 'cd_abc123',
+      result: :success,
+      detail: hash_including(
+        previous_state: 'pending',
+        current_state: 'verified',
+        dns_validated: true,
+        is_resolving: true,
+        ssl_ready: true,
+      ),
+    )
+  end
+
+  it 'records result: :failure (still exactly one event) when the op reports an error' do
+    allow(inner).to receive(:call).and_return(
+      result_double(success: false, previous: :pending, current: :pending)
+    )
+
+    described_class.new(domain: domain, actor: 'ur_col').call
+
+    expect(Onetime::AdminAuditEvent).to have_received(:record).once.with(
+      hash_including(verb: 'domain.verify', target: 'cd_abc123', result: :failure)
+    )
+  end
+
+  it 'forwards persist: false for a read-only health check (still audited)' do
+    allow(inner).to receive(:call).and_return(result_double(success: true))
+
+    described_class.new(domain: domain, actor: 'ur_col', persist: false).call
+
+    expect(Onetime::Operations::VerifyDomain).to have_received(:new).with(
+      domain: domain, persist: false
+    )
+    expect(Onetime::AdminAuditEvent).to have_received(:record).once
+  end
+end

--- a/src/apps/admin/console-sections.ts
+++ b/src/apps/admin/console-sections.ts
@@ -23,10 +23,10 @@ export interface ConsoleSection {
 export const CONSOLE_SECTIONS: ConsoleSection[] = [
   { key: 'overview', labelKey: 'web.colonel.titles.index', icon: 'home', to: '/colonel' },
   { key: 'customers', labelKey: 'web.colonel.titles.users', icon: 'users', to: '/colonel/customers' },
-  { key: 'secrets', labelKey: 'web.colonel.titles.secrets', icon: 'key' },
-  { key: 'organizations', labelKey: 'web.colonel.titles.organizations', icon: 'building-office' },
-  { key: 'domains', labelKey: 'web.colonel.titles.domains', icon: 'globe-alt' },
-  { key: 'system', labelKey: 'web.colonel.titles.system', icon: 'cog-6-tooth' },
-  { key: 'bannedIps', labelKey: 'web.colonel.titles.bannedIps', icon: 'no-symbol' },
-  { key: 'usage', labelKey: 'web.colonel.titles.usage', icon: 'rectangle-group' },
+  { key: 'secrets', labelKey: 'web.colonel.titles.secrets', icon: 'key', to: '/colonel/secrets' },
+  { key: 'organizations', labelKey: 'web.colonel.titles.organizations', icon: 'building-office', to: '/colonel/organizations' },
+  { key: 'domains', labelKey: 'web.colonel.titles.domains', icon: 'globe-alt', to: '/colonel/domains' },
+  { key: 'system', labelKey: 'web.colonel.titles.system', icon: 'cog-6-tooth', to: '/colonel/system' },
+  { key: 'bannedIps', labelKey: 'web.colonel.titles.bannedIps', icon: 'no-symbol', to: '/colonel/banned-ips' },
+  { key: 'usage', labelKey: 'web.colonel.titles.usage', icon: 'rectangle-group', to: '/colonel/usage' },
 ];

--- a/src/apps/admin/routes.ts
+++ b/src/apps/admin/routes.ts
@@ -58,6 +58,73 @@ const routes: Array<RouteRecordRaw> = [
     },
     props: true,
   },
+  {
+    // Secrets: paginated list + receipt drawer + guarded delete (ticket #30).
+    // No route params (the receipt opens in a DetailDrawer, not a sub-route).
+    path: '/colonel/secrets',
+    name: 'AdminSecrets',
+    component: () => import('@/apps/admin/views/AdminSecrets.vue'),
+    meta: {
+      ...adminDefaultMeta,
+      title: 'web.admin.secrets.title',
+      sentryScrubParams: false,
+    },
+  },
+  {
+    // Domains list (ticket #31): card grid + per-domain verify. No params.
+    path: '/colonel/domains',
+    name: 'AdminDomains',
+    component: () => import('@/apps/admin/views/AdminDomains.vue'),
+    meta: {
+      ...adminDefaultMeta,
+      title: 'web.colonel.titles.domains',
+      sentryScrubParams: false,
+    },
+  },
+  {
+    // Organizations list + billing-investigate + entitlement overrides (ticket #32).
+    path: '/colonel/organizations',
+    name: 'AdminOrganizations',
+    component: () => import('@/apps/admin/views/AdminOrganizations.vue'),
+    meta: {
+      ...adminDefaultMeta,
+      title: 'web.colonel.titles.organizations',
+      sentryScrubParams: false,
+    },
+  },
+  {
+    // System monitoring read-out: db / redis / queue metrics (ticket #33).
+    path: '/colonel/system',
+    name: 'AdminSystem',
+    component: () => import('@/apps/admin/views/AdminSystem.vue'),
+    meta: {
+      ...adminDefaultMeta,
+      title: 'web.admin.system.title',
+      sentryScrubParams: false,
+    },
+  },
+  {
+    // Banned IPs: bounded list + guarded ban / unban (ticket #33).
+    path: '/colonel/banned-ips',
+    name: 'AdminBannedIps',
+    component: () => import('@/apps/admin/views/AdminBannedIps.vue'),
+    meta: {
+      ...adminDefaultMeta,
+      title: 'web.admin.bannedIps.title',
+      sentryScrubParams: false,
+    },
+  },
+  {
+    // Usage export read-out (ticket #33).
+    path: '/colonel/usage',
+    name: 'AdminUsage',
+    component: () => import('@/apps/admin/views/AdminUsage.vue'),
+    meta: {
+      ...adminDefaultMeta,
+      title: 'web.admin.usage.title',
+      sentryScrubParams: false,
+    },
+  },
 ];
 
 export default routes;

--- a/src/apps/admin/stores/useAdminDomains.ts
+++ b/src/apps/admin/stores/useAdminDomains.ts
@@ -1,0 +1,92 @@
+// src/apps/admin/stores/useAdminDomains.ts
+
+import {
+  usePaginatedFetch,
+  type PageMeta,
+} from '@/apps/admin/composables/usePaginatedFetch';
+import type { ColonelCustomDomain } from '@/schemas/api/account/responses/colonel';
+import { colonelCustomDomainsResponseSchema } from '@/schemas/api/internal/responses/colonel';
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import type { z } from 'zod';
+
+
+type ColonelCustomDomainsResponse = z.infer<typeof colonelCustomDomainsResponseSchema>;
+
+/**
+ * Per-resource admin store for custom domains (CONTRACT 1 / #31).
+ *
+ * Sibling of {@link useAdminCustomers} / {@link useAdminSecrets} — the shared
+ * paginated-fetch composable makes a new resource a few lines pointing at its
+ * endpoint + schema + selector. Backed by the existing `GET /api/colonel/domains`
+ * and the existing `colonelCustomDomainsResponseSchema` (REUSED, no schema
+ * changes — CONTRACT 3). Owns ONLY this resource's page state.
+ *
+ * Isolation: ZERO import edge into `src/apps/colonel/*` or
+ * `src/shared/stores/colonelInfoStore.ts` (enforced by the architecture test),
+ * so the legacy tree never enters the isolated admin bundle.
+ */
+export const useAdminDomains = defineStore('adminDomains', () => {
+  /** Rows for the current page only (one server page — never accumulated). */
+  const domains = ref<ColonelCustomDomain[]>([]);
+  const pagination = ref<PageMeta | null>(null);
+
+  const pager = usePaginatedFetch<ColonelCustomDomainsResponse, ColonelCustomDomain>({
+    url: '/api/colonel/domains',
+    schema: colonelCustomDomainsResponseSchema,
+    context: 'CustomDomainsResponse',
+    select: (data) => ({
+      items: data.details?.domains ?? [],
+      pagination: data.details?.pagination ?? null,
+    }),
+  });
+
+  /**
+   * Fetch one page of domains.
+   *
+   * @param targetPage 1-based page (defaults to the current page).
+   * @returns the page result, or null on a schema mismatch (see validationError).
+   * @throws the underlying network/HTTP error (state is cleared first).
+   */
+  async function fetchPage(
+    targetPage: number = pager.page.value
+  ): Promise<{ items: ColonelCustomDomain[]; pagination: PageMeta | null } | null> {
+    try {
+      const result = await pager.fetchPage(targetPage);
+      if (result) {
+        domains.value = result.items;
+        pagination.value = result.pagination;
+      } else {
+        domains.value = [];
+        pagination.value = null;
+      }
+      return result;
+    } catch (err) {
+      domains.value = [];
+      pagination.value = null;
+      throw err;
+    }
+  }
+
+  /** Explicit manual reset — setup stores have no built-in $reset. */
+  function $reset(): void {
+    domains.value = [];
+    pagination.value = null;
+    pager.reset();
+  }
+
+  return {
+    // State
+    domains,
+    pagination,
+    // Fetch state (owned by the shared composable)
+    loading: pager.loading,
+    error: pager.error,
+    validationError: pager.validationError,
+    page: pager.page,
+    perPage: pager.perPage,
+    // Actions
+    fetchPage,
+    $reset,
+  };
+});

--- a/src/apps/admin/stores/useAdminOrganizations.ts
+++ b/src/apps/admin/stores/useAdminOrganizations.ts
@@ -1,0 +1,108 @@
+// src/apps/admin/stores/useAdminOrganizations.ts
+
+import {
+  usePaginatedFetch,
+  type PageMeta,
+} from '@/apps/admin/composables/usePaginatedFetch';
+import type { ColonelOrganization } from '@/schemas/api/account/responses/colonel';
+import { colonelOrganizationsResponseSchema } from '@/schemas/api/internal/responses/colonel';
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import type { z } from 'zod';
+
+type ColonelOrganizationsResponse = z.infer<typeof colonelOrganizationsResponseSchema>;
+
+/** Server-side filters the `GET /api/colonel/organizations` endpoint honours. */
+export interface OrganizationFilters {
+  /** Subscription status: active / trialing / past_due / canceled. */
+  status?: string;
+  /** Billing sync health: synced / potentially_stale / unknown. */
+  sync_status?: string;
+}
+
+/**
+ * Per-resource admin store for organizations (CONTRACT 1 / #32).
+ *
+ * Sibling of {@link useAdminCustomers} / {@link useAdminDomains} — the shared
+ * paginated-fetch composable makes a new resource a few lines pointing at its
+ * endpoint + schema + selector. Backed by the existing
+ * `GET /api/colonel/organizations` and the existing
+ * `colonelOrganizationsResponseSchema` (REUSED, no schema changes — CONTRACT 3).
+ * Owns ONLY this resource's page state; the two server-side filters
+ * (subscription `status` + billing `sync_status`) are threaded through as fetch
+ * params, mirroring the legacy `ColonelOrganizations` screen's filter bar.
+ *
+ * Isolation: ZERO import edge into `src/apps/colonel/*` or
+ * `src/shared/stores/colonelInfoStore.ts` (enforced by the architecture test),
+ * so the legacy tree never enters the isolated admin bundle.
+ */
+export const useAdminOrganizations = defineStore('adminOrganizations', () => {
+  /** Rows for the current page only (one server page — never accumulated). */
+  const organizations = ref<ColonelOrganization[]>([]);
+  const pagination = ref<PageMeta | null>(null);
+
+  const pager = usePaginatedFetch<ColonelOrganizationsResponse, ColonelOrganization>({
+    url: '/api/colonel/organizations',
+    schema: colonelOrganizationsResponseSchema,
+    context: 'ColonelOrganizationsResponse',
+    select: (data) => ({
+      items: data.details?.organizations ?? [],
+      pagination: data.details?.pagination ?? null,
+    }),
+  });
+
+  /**
+   * Fetch one page of organizations.
+   *
+   * @param targetPage 1-based page (defaults to the current page).
+   * @param filters optional subscription `status` + billing `sync_status` server
+   *   filters (empty/undefined values are dropped by the composable).
+   * @returns the page result, or null on a schema mismatch (see validationError).
+   * @throws the underlying network/HTTP error (state is cleared first).
+   */
+  async function fetchPage(
+    targetPage: number = pager.page.value,
+    filters: OrganizationFilters = {}
+  ): Promise<{ items: ColonelOrganization[]; pagination: PageMeta | null } | null> {
+    try {
+      const result = await pager.fetchPage(targetPage, {
+        status: filters.status,
+        sync_status: filters.sync_status,
+      });
+      if (result) {
+        organizations.value = result.items;
+        pagination.value = result.pagination;
+      } else {
+        organizations.value = [];
+        pagination.value = null;
+      }
+      return result;
+    } catch (err) {
+      organizations.value = [];
+      pagination.value = null;
+      throw err;
+    }
+  }
+
+  /** Explicit manual reset — setup stores have no built-in $reset. */
+  function $reset(): void {
+    organizations.value = [];
+    pagination.value = null;
+    pager.reset();
+  }
+
+  return {
+    // State
+    organizations,
+    pagination,
+    // Fetch state (owned by the shared composable)
+    loading: pager.loading,
+    error: pager.error,
+    validationError: pager.validationError,
+    page: pager.page,
+    perPage: pager.perPage,
+    // Actions
+    fetchPage,
+    $reset,
+  };
+});

--- a/src/apps/admin/views/AdminBannedIps.vue
+++ b/src/apps/admin/views/AdminBannedIps.vue
@@ -1,0 +1,373 @@
+<!-- src/apps/admin/views/AdminBannedIps.vue -->
+
+<script setup lang="ts">
+  import { computed, onMounted, ref } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  import { AdminConfirmDialog, DataTable, StatCard } from '@/apps/admin/components/kit';
+  import type { DataTableColumn } from '@/apps/admin/components/kit';
+  import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
+  import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
+  import type { BannedIP } from '@/schemas/api/account/responses/colonel';
+  import {
+    bannedIPsResponseSchema,
+    colonelBanIpResponseSchema,
+    colonelUnbanIpResponseSchema,
+  } from '@/schemas/api/internal/responses/colonel-bannedips';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import { useApi } from '@/shared/composables/useApi';
+  import { useNotificationsStore } from '@/shared/stores/notificationsStore';
+  import { formatDisplayDateTime } from '@/utils/format';
+  import { gracefulParse } from '@/utils/schemaValidation';
+
+  /**
+   * BannedIPs screen (ticket #33) — list + guarded ban/unban, the Phase-2 parity
+   * port of the hand-rolled `ColonelBannedIPs.vue` rebuilt on the Slice-3 template
+   * (no `src/apps/colonel/*` / `colonelInfoStore` imports).
+   *
+   * - LIST via {@link useResourceFetch} against `GET /api/colonel/banned-ips`
+   *   (a bounded index read — #2211, no server pagination), REUSING the frozen
+   *   `bannedIPsResponseSchema` (CONTRACT 3). Rendered with the kit DataTable.
+   * - The hand-rolled add-IP form is replaced with kit-styled inputs + the shared
+   *   {@link AdminConfirmDialog}.
+   * - GUARDED ban + unban (D4): both go through {@link useAdminMutation} +
+   *   typed-confirmation (retype the IP) — ban is `POST /banned-ips`, unban is
+   *   `DELETE /banned-ips/:ip`. Both are audited SERVER-SIDE by the extracted
+   *   ops ({@link Onetime::Operations::BanIP} / `UnbanIP`); nothing here logs.
+   */
+  const { t } = useI18n();
+  const $api = useApi();
+  const notifications = useNotificationsStore();
+
+  // ---- List -----------------------------------------------------------------
+
+  const {
+    data: listData,
+    loading,
+    error,
+    validationError,
+    load: loadList,
+  } = useResourceFetch({
+    url: '/api/colonel/banned-ips',
+    schema: bannedIPsResponseSchema,
+    context: 'BannedIPsResponse',
+  });
+
+  const bannedIPs = computed<BannedIP[]>(() => listData.value?.details?.banned_ips ?? []);
+  const currentIP = computed(() => listData.value?.details?.current_ip ?? '');
+  const totalCount = computed(() => listData.value?.details?.total_count ?? 0);
+  const loadFailed = computed(() => error.value !== null || validationError.value !== null);
+
+  function reloadList(): void {
+    loadList().catch(() => {});
+  }
+
+  const columns = computed<DataTableColumn<BannedIP>[]>(() => [
+    { key: 'ip_address', label: t('web.admin.bannedIps.columns.ipAddress') },
+    { key: 'reason', label: t('web.admin.bannedIps.columns.reason') },
+    { key: 'banned_at', label: t('web.admin.bannedIps.columns.bannedAt') },
+    { key: 'banned_by', label: t('web.admin.bannedIps.columns.bannedBy') },
+    { key: 'actions', label: t('web.admin.bannedIps.columns.actions'), align: 'right' },
+  ]);
+
+  /** banned_at is Unix seconds (bannedIPSchema keeps it a bare number). */
+  function bannedAtLabel(bannedAt: number): string {
+    return formatDisplayDateTime(new Date(bannedAt * 1000));
+  }
+
+  // ---- Add-IP form ----------------------------------------------------------
+
+  const newIP = ref('');
+  const newReason = ref('');
+  const showBanForm = ref(false);
+
+  function toggleBanForm(): void {
+    showBanForm.value = !showBanForm.value;
+  }
+
+  function quickBanCurrent(): void {
+    newIP.value = currentIP.value;
+    newReason.value = '';
+    showBanForm.value = true;
+  }
+
+  // ---- Guarded mutations (D4) ----------------------------------------------
+
+  type ActionKey = 'ban' | 'unban';
+
+  const dialogOpen = ref(false);
+  const activeAction = ref<ActionKey | null>(null);
+  /** The IP the confirm dialog is gating (retype token + request target). */
+  const targetIp = ref('');
+  /** Reason captured at ban-request time (the form may change after). */
+  const targetReason = ref('');
+
+  const {
+    loading: mutationLoading,
+    error: mutationError,
+    run: runMutation,
+    reset: resetMutation,
+  } = useAdminMutation(async () => {
+    const ip = targetIp.value;
+    if (!ip) throw new Error('No IP selected');
+
+    if (activeAction.value === 'ban') {
+      const response = await $api.post('/api/colonel/banned-ips', {
+        ip_address: ip,
+        reason: targetReason.value || undefined,
+      });
+      // A 2xx means the ban was applied server-side regardless of ack shape; the
+      // parse keeps the contract a live tripwire without failing the action.
+      gracefulParse(colonelBanIpResponseSchema, response.data, 'ColonelBanIpResponse');
+    } else {
+      const response = await $api.delete(`/api/colonel/banned-ips/${encodeURIComponent(ip)}`);
+      gracefulParse(colonelUnbanIpResponseSchema, response.data, 'ColonelUnbanIpResponse');
+    }
+  });
+
+  const dialogConfig = computed(() => {
+    if (activeAction.value === 'ban') {
+      return {
+        title: t('web.admin.bannedIps.ban.confirmTitle'),
+        description: t('web.admin.bannedIps.ban.confirmDescription', { ip: targetIp.value }),
+        confirmText: t('web.admin.bannedIps.ban.button'),
+        variant: 'danger' as const,
+      };
+    }
+    return {
+      title: t('web.admin.bannedIps.unban.confirmTitle'),
+      description: t('web.admin.bannedIps.unban.confirmDescription', { ip: targetIp.value }),
+      confirmText: t('web.admin.bannedIps.unban.button'),
+      variant: 'default' as const,
+    };
+  });
+
+  function requestBan(): void {
+    const ip = newIP.value.trim();
+    if (!ip) return; // Nothing to confirm without an IP.
+    activeAction.value = 'ban';
+    targetIp.value = ip;
+    targetReason.value = newReason.value.trim();
+    resetMutation();
+    dialogOpen.value = true;
+  }
+
+  function requestUnban(ip: string): void {
+    activeAction.value = 'unban';
+    targetIp.value = ip;
+    targetReason.value = '';
+    resetMutation();
+    dialogOpen.value = true;
+  }
+
+  async function onConfirm(): Promise<void> {
+    const action = activeAction.value;
+    if (!action) return;
+
+    const ok = await runMutation();
+    if (!ok) return; // Failure message stays in the dialog for retry/cancel.
+
+    dialogOpen.value = false;
+
+    if (action === 'ban') {
+      notifications.show(t('web.admin.bannedIps.ban.success', { ip: targetIp.value }), 'success');
+      newIP.value = '';
+      newReason.value = '';
+      showBanForm.value = false;
+    } else {
+      notifications.show(t('web.admin.bannedIps.unban.success', { ip: targetIp.value }), 'success');
+    }
+
+    activeAction.value = null;
+    reloadList();
+  }
+
+  function onCancel(): void {
+    dialogOpen.value = false;
+    activeAction.value = null;
+    resetMutation();
+  }
+
+  onMounted(reloadList);
+</script>
+
+<template>
+  <div class="mx-auto max-w-5xl">
+    <!-- Page header -->
+    <div class="mb-6 flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <h2 class="font-brand text-2xl font-semibold text-gray-900 dark:text-white">
+          {{ t('web.admin.bannedIps.title') }}
+        </h2>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          {{ t('web.admin.bannedIps.description') }}
+        </p>
+      </div>
+      <button
+        type="button"
+        data-testid="toggle-ban-form"
+        class="inline-flex shrink-0 items-center gap-1 rounded-md border border-red-300 px-3 py-2 text-sm font-semibold text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-900/30"
+        @click="toggleBanForm">
+        <OIcon
+          collection="heroicons"
+          :name="showBanForm ? 'x-mark' : 'no-symbol'"
+          size="4" />
+        {{ showBanForm ? t('web.admin.bannedIps.actions.cancel') : t('web.admin.bannedIps.actions.ban') }}
+      </button>
+    </div>
+
+    <!-- Error banner -->
+    <div
+      v-if="loadFailed"
+      class="mb-4 flex items-center justify-between gap-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-900/20"
+      role="alert"
+      data-testid="bannedips-error">
+      <span class="text-sm text-red-800 dark:text-red-200">
+        {{ t('web.admin.bannedIps.list.loadError') }}
+      </span>
+      <button
+        type="button"
+        class="inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/40"
+        @click="reloadList">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          size="4" />
+        {{ t('web.admin.bannedIps.list.retry') }}
+      </button>
+    </div>
+
+    <!-- Current IP + count -->
+    <div class="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <div
+        class="flex items-center justify-between gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 dark:border-blue-900/50 dark:bg-blue-900/20"
+        data-testid="current-ip">
+        <div class="min-w-0">
+          <p class="text-xs font-medium uppercase tracking-wider text-blue-700 dark:text-blue-300">
+            {{ t('web.admin.bannedIps.currentIp') }}
+          </p>
+          <p class="mt-0.5 truncate font-mono text-lg font-semibold text-blue-900 dark:text-blue-100">
+            {{ currentIP || '—' }}
+          </p>
+        </div>
+        <button
+          v-if="currentIP && currentIP !== 'unknown'"
+          type="button"
+          data-testid="quick-ban"
+          class="shrink-0 rounded px-3 py-1.5 text-sm font-medium text-blue-700 hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-blue-300 dark:hover:bg-blue-800/50"
+          @click="quickBanCurrent">
+          {{ t('web.admin.bannedIps.actions.quickBan') }}
+        </button>
+      </div>
+      <StatCard
+        :label="t('web.admin.bannedIps.stats.total')"
+        :value="totalCount"
+        icon="no-symbol"
+        testid="stat-total" />
+    </div>
+
+    <!-- Ban form -->
+    <div
+      v-if="showBanForm"
+      class="mb-6 rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+      data-testid="ban-form">
+      <h3 class="mb-4 text-sm font-medium text-gray-900 dark:text-white">
+        {{ t('web.admin.bannedIps.form.title') }}
+      </h3>
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div>
+          <label
+            for="ban-ip"
+            class="mb-1 block text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.bannedIps.form.ipLabel') }}
+          </label>
+          <input
+            id="ban-ip"
+            v-model="newIP"
+            type="text"
+            data-testid="ban-ip-input"
+            placeholder="203.0.113.4"
+            autocomplete="off"
+            spellcheck="false"
+            class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 font-mono text-sm text-gray-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+            @keyup.enter="requestBan" />
+        </div>
+        <div>
+          <label
+            for="ban-reason"
+            class="mb-1 block text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.bannedIps.form.reasonLabel') }}
+          </label>
+          <input
+            id="ban-reason"
+            v-model="newReason"
+            type="text"
+            data-testid="ban-reason-input"
+            :placeholder="t('web.admin.bannedIps.form.reasonPlaceholder')"
+            class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+        </div>
+      </div>
+      <div class="mt-4">
+        <button
+          type="button"
+          data-testid="ban-submit"
+          :disabled="!newIP.trim()"
+          class="inline-flex items-center gap-1 rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-red-700 dark:hover:bg-red-800"
+          @click="requestBan">
+          <OIcon
+            collection="heroicons"
+            name="no-symbol"
+            size="4" />
+          {{ t('web.admin.bannedIps.form.submit') }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Banned IPs table -->
+    <div
+      class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
+      <DataTable
+        :columns="columns"
+        :rows="bannedIPs"
+        row-key="id"
+        :loading="loading"
+        :empty-text="t('web.admin.bannedIps.list.empty')"
+        testid="bannedips-table">
+        <template #cell-ip_address="{ row }">
+          <span class="font-mono text-gray-900 dark:text-white">{{ row.ip_address }}</span>
+        </template>
+        <template #cell-reason="{ row }">
+          <span class="text-gray-600 dark:text-gray-400">{{ row.reason || '—' }}</span>
+        </template>
+        <template #cell-banned_at="{ row }">
+          {{ bannedAtLabel(row.banned_at) }}
+        </template>
+        <template #cell-banned_by="{ row }">
+          <span class="font-mono text-xs text-gray-500 dark:text-gray-400">{{ row.banned_by || '—' }}</span>
+        </template>
+        <template #cell-actions="{ row }">
+          <button
+            type="button"
+            :data-testid="`unban-${row.ip_address}`"
+            class="text-sm font-medium text-red-600 hover:text-red-800 focus:outline-none focus:ring-2 focus:ring-red-500 dark:text-red-400 dark:hover:text-red-300"
+            @click="requestUnban(row.ip_address)">
+            {{ t('web.admin.bannedIps.unban.button') }}
+          </button>
+        </template>
+      </DataTable>
+    </div>
+
+    <!-- Shared guarded-action dialog (typed-confirmation for ban + unban). -->
+    <AdminConfirmDialog
+      v-model:open="dialogOpen"
+      :title="dialogConfig.title"
+      :description="dialogConfig.description"
+      :confirm-token="targetIp"
+      :variant="dialogConfig.variant"
+      :confirm-text="dialogConfig.confirmText"
+      :loading="mutationLoading"
+      :error="mutationError"
+      @confirm="onConfirm"
+      @cancel="onCancel" />
+  </div>
+</template>

--- a/src/apps/admin/views/AdminDomains.vue
+++ b/src/apps/admin/views/AdminDomains.vue
@@ -1,0 +1,420 @@
+<!-- src/apps/admin/views/AdminDomains.vue -->
+
+<script setup lang="ts">
+
+  import { AdminConfirmDialog, KitPagination } from '@/apps/admin/components/kit';
+  import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
+  import { useAdminDomains } from '@/apps/admin/stores/useAdminDomains';
+  import type { ColonelCustomDomain } from '@/schemas/api/account/responses/colonel';
+  import { colonelDomainVerifyResponseSchema } from '@/schemas/api/internal/responses/colonel-domains';
+  import type { ColonelDomainVerifyResponse } from '@/schemas/api/internal/responses/colonel-domains';
+  import CardGridSkeleton from '@/shared/components/closet/CardGridSkeleton.vue';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import { useApi } from '@/shared/composables/useApi';
+  import { useNotificationsStore } from '@/shared/stores/notificationsStore';
+  import { formatDisplayDateTime } from '@/utils/format';
+  import { gracefulParse } from '@/utils/schemaValidation';
+  import { storeToRefs } from 'pinia';
+  import { computed, onMounted, ref } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  /**
+   * Domains screen — card grid + per-domain verify (ticket #31, Phase-2 parity
+   * port). Rebuilt fresh on the Slice-3 template; it does NOT import the retiring
+   * `src/apps/colonel/ColonelDomains.vue`, but preserves its card layout and
+   * status badges for parity.
+   *
+   * - LIST via {@link useAdminDomains} (a per-resource paginated store over the
+   *   existing `GET /api/colonel/domains`) + {@link KitPagination}. One server
+   *   page per request (CONTRACT 1). Loading uses the shared CardGridSkeleton;
+   *   icons via OIcon.
+   * - The VERIFY action is the only capability beyond a straight port: it POSTs to
+   *   the new `/api/colonel/domains/:extid/verify` endpoint (which reuses the
+   *   existing `VerifyDomain` op and audits the verify server-side — CONTRACT 4),
+   *   guarded by a one-click {@link AdminConfirmDialog} (low-risk verb — no typed
+   *   confirmation) + {@link useAdminMutation}. The result is surfaced HONESTLY
+   *   from the op's real DNS/SSL outcome (verified / resolving / pending /
+   *   unverified) — success is never faked.
+   */
+  const { t } = useI18n();
+  const $api = useApi();
+  const notifications = useNotificationsStore();
+
+  const store = useAdminDomains();
+  const { domains, pagination, loading, error } = storeToRefs(store);
+
+  // ---- Status badges (parity with the legacy screen) ------------------------
+
+  /** Verification-state badge colours, keyed by the op's state symbol. */
+  function stateBadgeClass(state: string): string {
+    switch (state) {
+      case 'verified':
+        return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
+      case 'pending':
+        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200';
+      case 'resolving':
+        return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200';
+      default:
+        return 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200';
+    }
+  }
+
+  const stateLabels = computed<Record<string, string>>(() => ({
+    verified: t('web.colonel.customDomains.status.verified'),
+    resolving: t('web.colonel.customDomains.status.resolving'),
+    pending: t('web.colonel.customDomains.status.pending'),
+  }));
+
+  function stateLabel(state: string): string {
+    return stateLabels.value[state] ?? state;
+  }
+
+  // ---- List fetching --------------------------------------------------------
+
+  async function fetchPage(targetPage = 1): Promise<void> {
+    try {
+      await store.fetchPage(targetPage);
+    } catch {
+      // Network/HTTP failure is captured in `store.error`; the banner + retry
+      // below handle it. Swallow so it doesn't become an unhandled rejection.
+    }
+  }
+
+  function onPageChange(targetPage: number): void {
+    fetchPage(targetPage);
+  }
+
+  function onPerPageChange(perPage: number): void {
+    store.perPage = perPage;
+    fetchPage(1);
+  }
+
+  // ---- Guarded verify action ------------------------------------------------
+
+  const dialogOpen = ref(false);
+  /** The domain awaiting confirmation, or currently being verified. */
+  const activeDomain = ref<ColonelCustomDomain | null>(null);
+  /** extid of the domain whose verify request is in flight (per-card spinner). */
+  const verifyingExtid = ref<string | null>(null);
+  /** The last parsed verify ack, read in onConfirm to pick an honest message. */
+  const verifyResult = ref<ColonelDomainVerifyResponse | null>(null);
+
+  const {
+    loading: verifyLoading,
+    error: verifyError,
+    run: runVerify,
+    reset: resetVerify,
+  } = useAdminMutation(async (extid: string) => {
+    verifyResult.value = null;
+    const response = await $api.post(
+      `/api/colonel/domains/${encodeURIComponent(extid)}/verify`
+    );
+    // Parse the ack so it stays a live tripwire. A 2xx means the verify ran
+    // server-side regardless of ack shape; a mismatch is reported by
+    // gracefulParse but does not fail the action (we fall back to a generic
+    // success message and refresh the list).
+    const parsed = gracefulParse(
+      colonelDomainVerifyResponseSchema,
+      response.data,
+      'ColonelDomainVerifyResponse'
+    );
+    verifyResult.value = parsed.ok ? parsed.data : null;
+  });
+
+  const dialogDescription = computed(() =>
+    activeDomain.value
+      ? t('web.admin.domains.verify.confirmDescription', {
+          domain: activeDomain.value.display_domain,
+        })
+      : undefined
+  );
+
+  function requestVerify(domain: ColonelCustomDomain): void {
+    activeDomain.value = domain;
+    resetVerify();
+    dialogOpen.value = true;
+  }
+
+  /** Per-state operator notification. Unknown states fall back to `done`. */
+  const VERIFY_MESSAGE_KEYS: Record<string, string> = {
+    verified: 'web.admin.domains.verify.success.verified',
+    resolving: 'web.admin.domains.verify.success.resolving',
+    pending: 'web.admin.domains.verify.success.pending',
+    unverified: 'web.admin.domains.verify.success.unverified',
+  };
+
+  /** Map the honest post-verify state to its operator notification. */
+  function notifyOutcome(): void {
+    const state = verifyResult.value?.details?.current_state ?? '';
+    const domainName = activeDomain.value?.display_domain ?? '';
+    const messageKey = VERIFY_MESSAGE_KEYS[state] ?? 'web.admin.domains.verify.success.done';
+
+    notifications.show(
+      t(messageKey, { domain: domainName }),
+      state === 'verified' ? 'success' : 'info'
+    );
+  }
+
+  async function onConfirm(): Promise<void> {
+    const domain = activeDomain.value;
+    if (!domain) return;
+
+    verifyingExtid.value = domain.extid;
+    const ok = await runVerify(domain.extid);
+    verifyingExtid.value = null;
+
+    if (!ok) return; // Failure message stays in the dialog for retry/cancel.
+
+    dialogOpen.value = false;
+    notifyOutcome();
+    // Re-fetch the current page so every card's badge reflects real persisted
+    // state (the verify may have flipped verified/resolving).
+    await fetchPage(pagination.value?.page ?? 1);
+    activeDomain.value = null;
+    verifyResult.value = null;
+  }
+
+  function onCancel(): void {
+    dialogOpen.value = false;
+    activeDomain.value = null;
+    resetVerify();
+  }
+
+  onMounted(() => fetchPage(1));
+</script>
+
+<template>
+  <div class="mx-auto max-w-6xl">
+    <!-- Page header -->
+    <div class="mb-6">
+      <h2 class="font-brand text-2xl font-semibold text-gray-900 dark:text-white">
+        {{ t('web.colonel.customDomains.title') }}
+      </h2>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.colonel.customDomains.description') }}
+      </p>
+    </div>
+
+    <!-- Network/HTTP error banner (validation mismatches degrade to empty). -->
+    <div
+      v-if="error"
+      class="mb-4 flex items-center justify-between gap-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-900/20"
+      role="alert"
+      data-testid="domains-error">
+      <span class="text-sm text-red-800 dark:text-red-200">
+        {{ t('web.admin.domains.list.loadError') }}
+      </span>
+      <button
+        type="button"
+        class="inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-800 hover:bg-red-100 focus:ring-2 focus:ring-red-500 focus:outline-none dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/40"
+        @click="fetchPage(1)">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          size="4" />
+        {{ t('web.admin.domains.retry') }}
+      </button>
+    </div>
+
+    <!-- Loading (first load) -->
+    <CardGridSkeleton
+      v-if="loading && domains.length === 0"
+      :count="4"
+      data-testid="domains-loading" />
+
+    <!-- Empty -->
+    <div
+      v-else-if="domains.length === 0"
+      class="rounded-lg border border-gray-200 bg-white p-12 text-center dark:border-gray-700 dark:bg-gray-800"
+      data-testid="domains-empty">
+      <p class="text-gray-500 dark:text-gray-400">
+        {{ t('web.colonel.customDomains.empty') }}
+      </p>
+    </div>
+
+    <!-- Card grid -->
+    <template v-else>
+      <div
+        data-testid="domains-grid"
+        class="grid gap-6 sm:grid-cols-1 lg:grid-cols-2">
+        <div
+          v-for="domain in domains"
+          :key="domain.domain_id"
+          :data-testid="`domain-card-${domain.extid}`"
+          class="flex flex-col rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <!-- Header: logo + domain + verification badge -->
+          <div class="mb-4 flex items-start justify-between gap-3">
+            <div class="flex min-w-0 items-center gap-4">
+              <!-- Logo thumbnail -->
+              <div
+                v-if="domain.has_logo"
+                class="size-16 flex-shrink-0 overflow-hidden rounded-lg border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900">
+                <img
+                  :src="domain.logo_url ?? undefined"
+                  :alt="`${domain.display_domain} logo`"
+                  class="size-full object-contain"
+                  loading="lazy" />
+              </div>
+              <div
+                v-else
+                class="flex size-16 flex-shrink-0 items-center justify-center rounded-lg border border-gray-200 bg-gray-100 dark:border-gray-700 dark:bg-gray-700">
+                <span class="text-xs text-gray-400">{{ t('web.colonel.customDomains.noLogo') }}</span>
+              </div>
+
+              <!-- Domain info -->
+              <div class="min-w-0">
+                <h3 class="truncate text-lg font-semibold text-gray-900 dark:text-white">
+                  {{ domain.display_domain }}
+                </h3>
+                <p
+                  v-if="domain.brand.name"
+                  class="truncate text-sm text-gray-600 dark:text-gray-400">
+                  {{ domain.brand.name }}
+                </p>
+              </div>
+            </div>
+
+            <!-- Verification badge -->
+            <span
+              :class="[
+                'inline-flex flex-shrink-0 items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
+                stateBadgeClass(domain.verification_state),
+              ]"
+              :data-testid="`domain-state-${domain.extid}`">
+              {{ stateLabel(domain.verification_state) }}
+            </span>
+          </div>
+
+          <!-- Brand details -->
+          <div
+            v-if="domain.brand.tagline || domain.brand.homepage_url"
+            class="mb-4 border-t border-gray-100 pt-4 dark:border-gray-700">
+            <p
+              v-if="domain.brand.tagline"
+              class="text-sm text-gray-600 dark:text-gray-400">
+              {{ domain.brand.tagline }}
+            </p>
+            <a
+              v-if="domain.brand.homepage_url"
+              :href="domain.brand.homepage_url"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="mt-1 inline-block text-sm text-brand-600 hover:text-brand-700 dark:text-brand-400">
+              {{ domain.brand.homepage_url }} ↗
+            </a>
+          </div>
+
+          <!-- Domain details grid -->
+          <div
+            class="grid grid-cols-2 gap-4 border-t border-gray-100 pt-4 text-sm dark:border-gray-700">
+            <div>
+              <span class="text-gray-500 dark:text-gray-400">{{ t('web.colonel.customDomains.labels.organization') }}:</span>
+              <p class="font-medium text-gray-900 dark:text-white">
+                {{ domain.org_name }}
+              </p>
+            </div>
+            <div>
+              <span class="text-gray-500 dark:text-gray-400">{{ t('web.colonel.customDomains.labels.externalId') }}:</span>
+              <p class="font-mono text-xs text-gray-900 dark:text-white">
+                {{ domain.extid }}
+              </p>
+            </div>
+            <div>
+              <span class="text-gray-500 dark:text-gray-400">{{ t('web.colonel.customDomains.labels.created') }}:</span>
+              <p class="text-gray-900 dark:text-white">
+                {{ formatDisplayDateTime(domain.created) }}
+              </p>
+            </div>
+            <div>
+              <span class="text-gray-500 dark:text-gray-400">{{ t('web.colonel.customDomains.labels.updated') }}:</span>
+              <p class="text-gray-900 dark:text-white">
+                {{ domain.updated ? formatDisplayDateTime(domain.updated) : '—' }}
+              </p>
+            </div>
+          </div>
+
+          <!-- Status flags -->
+          <div class="mt-4 flex flex-wrap gap-2 border-t border-gray-100 pt-4 dark:border-gray-700">
+            <span
+              v-if="domain.verified"
+              class="inline-flex items-center rounded-full bg-green-50 px-2 py-1 text-xs font-medium text-green-700 dark:bg-green-900 dark:text-green-200">
+              ✓ {{ t('web.colonel.customDomains.status.verified') }}
+            </span>
+            <span
+              v-if="domain.resolving"
+              class="inline-flex items-center rounded-full bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 dark:bg-blue-900 dark:text-blue-200">
+              ✓ {{ t('web.colonel.customDomains.status.resolving') }}
+            </span>
+            <span
+              v-if="domain.ready"
+              class="inline-flex items-center rounded-full bg-green-50 px-2 py-1 text-xs font-medium text-green-700 dark:bg-green-900 dark:text-green-200">
+              ✓ {{ t('web.colonel.customDomains.status.ready') }}
+            </span>
+            <span
+              v-if="domain.homepage_config?.enabled"
+              class="inline-flex items-center rounded-full bg-purple-50 px-2 py-1 text-xs font-medium text-purple-700 dark:bg-purple-900 dark:text-purple-200">
+              {{ t('web.colonel.customDomains.status.publicHomepage') }}
+            </span>
+            <span
+              v-if="domain.api_config?.enabled"
+              class="inline-flex items-center rounded-full bg-purple-50 px-2 py-1 text-xs font-medium text-purple-700 dark:bg-purple-900 dark:text-purple-200">
+              {{ t('web.colonel.customDomains.status.publicApi') }}
+            </span>
+          </div>
+
+          <!-- Icon preview (if available) -->
+          <div
+            v-if="domain.has_icon"
+            class="mt-4 border-t border-gray-100 pt-4 dark:border-gray-700">
+            <span class="text-xs text-gray-500 dark:text-gray-400">{{ t('web.colonel.customDomains.labels.favicon') }}:</span>
+            <div
+              class="mt-2 inline-block size-8 overflow-hidden rounded border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900">
+              <img
+                :src="domain.icon_url ?? undefined"
+                :alt="`${domain.display_domain} favicon`"
+                class="size-full object-contain"
+                loading="lazy" />
+            </div>
+          </div>
+
+          <!-- Verify action -->
+          <div class="mt-4 border-t border-gray-100 pt-4 dark:border-gray-700">
+            <button
+              type="button"
+              :data-testid="`domain-verify-${domain.extid}`"
+              :disabled="verifyingExtid === domain.extid"
+              class="inline-flex w-full items-center justify-center gap-1 rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-brand-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+              @click="requestVerify(domain)">
+              <OIcon
+                collection="heroicons"
+                :name="verifyingExtid === domain.extid ? 'arrow-path' : 'shield-check'"
+                size="4"
+                :class="verifyingExtid === domain.extid ? 'animate-spin motion-reduce:animate-none' : ''" />
+              {{ t('web.admin.domains.verify.button') }}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Pagination -->
+      <KitPagination
+        v-if="pagination"
+        :pagination="pagination"
+        :loading="loading"
+        class="mt-6"
+        @update:page="onPageChange"
+        @update:per-page="onPerPageChange" />
+    </template>
+
+    <!-- Shared guarded-action dialog (one-click confirm for the low-risk verb). -->
+    <AdminConfirmDialog
+      v-model:open="dialogOpen"
+      :title="t('web.admin.domains.verify.confirmTitle')"
+      :description="dialogDescription"
+      :confirm-text="t('web.admin.domains.verify.button')"
+      :loading="verifyLoading"
+      :error="verifyError"
+      @confirm="onConfirm"
+      @cancel="onCancel" />
+  </div>
+</template>

--- a/src/apps/admin/views/AdminOrganizations.vue
+++ b/src/apps/admin/views/AdminOrganizations.vue
@@ -1,0 +1,939 @@
+<!-- src/apps/admin/views/AdminOrganizations.vue -->
+
+<script setup lang="ts">
+  import { storeToRefs } from 'pinia';
+  import { computed, onMounted, ref } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  import {
+    AdminConfirmDialog,
+    DataTable,
+    DetailDrawer,
+    FilterBar,
+    JsonViewer,
+    KitPagination,
+    StatCard,
+  } from '@/apps/admin/components/kit';
+  import type { DataTableColumn, FilterConfig } from '@/apps/admin/components/kit';
+  import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
+  import { useAdminOrganizations } from '@/apps/admin/stores/useAdminOrganizations';
+  import type {
+    ColonelOrganization,
+    InvestigateOrganizationResult,
+  } from '@/schemas/api/account/responses/colonel';
+  import type { ColonelEntitlementOverrideRecord } from '@/schemas/api/account/responses/colonel-organizations';
+  import { investigateOrganizationResponseSchema } from '@/schemas/api/internal/responses/colonel';
+  import { colonelEntitlementOverrideResponseSchema } from '@/schemas/api/internal/responses/colonel-organizations';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import { useApi } from '@/shared/composables/useApi';
+  import { useNotificationsStore } from '@/shared/stores/notificationsStore';
+  import { getPlanLabel } from '@/types/billing';
+  import { formatDisplayDateTime } from '@/utils/format';
+  import { gracefulParse } from '@/utils/schemaValidation';
+
+  /**
+   * Organizations screen — billing health monitor + billing-investigate workflow
+   * + entitlement-override management (ticket #32, Phase-2 parity port; #2349).
+   *
+   * Rebuilt fresh on the Slice-3 template; it does NOT import the retiring
+   * `src/apps/colonel/views/ColonelOrganizations.vue` (806 lines) but preserves
+   * its behaviour: lead with the unique identifier (contact_email), badge only
+   * problems (potentially_stale / unknown), group billing data, and expose the
+   * on-demand billing investigation.
+   *
+   * - LIST via {@link useAdminOrganizations} (a per-resource paginated store over
+   *   the existing `GET /api/colonel/organizations`) + {@link DataTable} +
+   *   {@link FilterBar} (subscription + sync-status server filters) +
+   *   {@link KitPagination}. One server page per request (CONTRACT 1). Reuses the
+   *   existing `colonelOrganizationsResponseSchema` (CONTRACT 3 — no schema drift).
+   * - A row opens a {@link DetailDrawer} with the org's billing read-out and the
+   *   two per-org workflows:
+   *     1. INVESTIGATE — POSTs `organizations/:extid/investigate` (read-only; no
+   *        mutation, no audit) and renders the comparison verdict / issues / Stripe
+   *        summary as structured markup PLUS the raw payload via {@link JsonViewer}
+   *        (the acceptance criterion replacing the legacy ad-hoc markup).
+   *     2. ENTITLEMENT OVERRIDES — grant / revoke / clear, each a MUTATING billing
+   *        action, so each goes through {@link useAdminMutation} + a
+   *        typed-confirmation {@link AdminConfirmDialog} (retype the org's public
+   *        id) and is audited server-side (CONTRACT 3 / 4 / D4).
+   */
+  const { t } = useI18n();
+  const $api = useApi();
+  const notifications = useNotificationsStore();
+
+  const store = useAdminOrganizations();
+  const { organizations, pagination, loading, error } = storeToRefs(store);
+
+  // ---- Filters --------------------------------------------------------------
+
+  const SYNC_STATUS_OPTIONS = ['potentially_stale', 'unknown', 'synced'] as const;
+  const SUBSCRIPTION_OPTIONS = ['active', 'trialing', 'past_due', 'canceled'] as const;
+
+  const statusFilter = ref('');
+  const syncStatusFilter = ref('');
+
+  const hasActiveFilters = computed(
+    () => statusFilter.value !== '' || syncStatusFilter.value !== ''
+  );
+
+  const SYNC_FILTER_LABELS: Record<string, string> = {
+    potentially_stale: 'web.colonel.organizations.filters.potentiallyStale',
+    unknown: 'web.colonel.organizations.filters.unknown',
+    synced: 'web.colonel.organizations.filters.synced',
+  };
+  const SUBSCRIPTION_FILTER_LABELS: Record<string, string> = {
+    active: 'web.colonel.organizations.filters.active',
+    trialing: 'web.colonel.organizations.filters.trialing',
+    past_due: 'web.colonel.organizations.filters.pastDue',
+    canceled: 'web.colonel.organizations.filters.canceled',
+  };
+
+  const filters = computed<FilterConfig[]>(() => [
+    {
+      key: 'sync_status',
+      label: t('web.colonel.organizations.filters.syncStatus'),
+      value: syncStatusFilter.value,
+      options: SYNC_STATUS_OPTIONS.map((v) => ({ value: v, label: t(SYNC_FILTER_LABELS[v]) })),
+    },
+    {
+      key: 'status',
+      label: t('web.colonel.organizations.filters.subscription'),
+      value: statusFilter.value,
+      options: SUBSCRIPTION_OPTIONS.map((v) => ({
+        value: v,
+        label: t(SUBSCRIPTION_FILTER_LABELS[v]),
+      })),
+    },
+  ]);
+
+  // ---- Columns --------------------------------------------------------------
+
+  const columns = computed<DataTableColumn<ColonelOrganization>[]>(() => [
+    { key: 'account', label: t('web.colonel.organizations.columns.account') },
+    { key: 'billing', label: t('web.colonel.organizations.columns.billing') },
+    { key: 'status', label: t('web.colonel.organizations.columns.status') },
+    { key: 'usage', label: t('web.colonel.organizations.columns.usage') },
+    { key: 'created', label: t('web.colonel.organizations.columns.created') },
+  ]);
+
+  /** Lead with the unique identifier, not the generic "Default Workspace". */
+  function primaryIdentifier(org: ColonelOrganization): string {
+    return org.contact_email || org.extid;
+  }
+
+  function planLabel(planid: string | null): string {
+    return planid ? getPlanLabel(planid) : getPlanLabel('free');
+  }
+
+  /** Only non-normal subscription states get a coloured badge. */
+  function subscriptionBadgeClass(status: string | null): string {
+    switch (status) {
+      case 'trialing':
+        return 'bg-blue-100 text-blue-800 dark:bg-blue-900/50 dark:text-blue-200';
+      case 'past_due':
+        return 'bg-orange-100 text-orange-800 dark:bg-orange-900/50 dark:text-orange-200';
+      case 'canceled':
+        return 'bg-red-100 text-red-800 dark:bg-red-900/50 dark:text-red-200';
+      default:
+        return '';
+    }
+  }
+  function needsSubscriptionBadge(status: string | null): boolean {
+    return status !== null && status !== 'active';
+  }
+
+  const totalOrganizations = computed(() => pagination.value?.total_count ?? 0);
+  const staleCount = computed(
+    () => organizations.value.filter((o) => o.sync_status === 'potentially_stale').length
+  );
+  const unknownCount = computed(
+    () => organizations.value.filter((o) => o.sync_status === 'unknown').length
+  );
+
+  // ---- List fetching --------------------------------------------------------
+
+  async function fetchPage(targetPage = 1): Promise<void> {
+    try {
+      await store.fetchPage(targetPage, {
+        status: statusFilter.value || undefined,
+        sync_status: syncStatusFilter.value || undefined,
+      });
+    } catch {
+      // Network/HTTP failure is captured in `store.error`; the banner + retry
+      // below handle it. Swallow so it doesn't become an unhandled rejection.
+    }
+  }
+
+  function onFilterChange(key: string, value: string): void {
+    if (key === 'sync_status') syncStatusFilter.value = value;
+    else if (key === 'status') statusFilter.value = value;
+    fetchPage(1);
+  }
+  function onClear(): void {
+    statusFilter.value = '';
+    syncStatusFilter.value = '';
+    fetchPage(1);
+  }
+  function onPageChange(targetPage: number): void {
+    fetchPage(targetPage);
+  }
+  function onPerPageChange(perPage: number): void {
+    store.perPage = perPage;
+    fetchPage(1);
+  }
+
+  // ---- Detail drawer --------------------------------------------------------
+
+  const drawerOpen = ref(false);
+  const selectedOrg = ref<ColonelOrganization | null>(null);
+
+  function openDetail(org: ColonelOrganization): void {
+    selectedOrg.value = org;
+    // Reset per-org workflow state so a re-opened drawer never shows stale data.
+    investigateResult.value = null;
+    investigateError.value = null;
+    overrideState.value = null;
+    entitlementInput.value = '';
+    resetEntitlement();
+    drawerOpen.value = true;
+  }
+
+  const drawerFields = computed(() => {
+    const o = selectedOrg.value;
+    if (!o) return [];
+    return [
+      { key: 'contactEmail', label: t('web.admin.organizations.fields.contactEmail'), value: o.contact_email || '—' },
+      { key: 'owner', label: t('web.admin.organizations.fields.owner'), value: o.owner_email || '—' },
+      { key: 'plan', label: t('web.admin.organizations.fields.plan'), value: planLabel(o.planid) },
+      { key: 'subscription', label: t('web.admin.organizations.fields.subscription'), value: o.subscription_status || '—' },
+      { key: 'periodEnd', label: t('web.admin.organizations.fields.periodEnd'), value: o.subscription_period_end || '—' },
+      { key: 'billingEmail', label: t('web.admin.organizations.fields.billingEmail'), value: o.billing_email || '—' },
+      { key: 'stripeCustomer', label: t('web.admin.organizations.fields.stripeCustomer'), value: o.stripe_customer_id || '—', mono: true },
+      { key: 'stripeSubscription', label: t('web.admin.organizations.fields.stripeSubscription'), value: o.stripe_subscription_id || '—', mono: true },
+      { key: 'orgId', label: t('web.admin.organizations.fields.orgId'), value: o.extid, mono: true },
+      { key: 'created', label: t('web.admin.organizations.fields.created'), value: formatDisplayDateTime(o.created) },
+      { key: 'updated', label: t('web.admin.organizations.fields.updated'), value: o.updated ? formatDisplayDateTime(o.updated) : '—' },
+    ];
+  });
+
+  // ---- Investigate (read-only; POST-to-read, no mutation / no audit) --------
+
+  const investigateLoading = ref(false);
+  const investigateError = ref<string | null>(null);
+  const investigateResult = ref<InvestigateOrganizationResult | null>(null);
+
+  async function runInvestigate(): Promise<void> {
+    const org = selectedOrg.value;
+    if (!org) return;
+
+    investigateLoading.value = true;
+    investigateError.value = null;
+    try {
+      const response = await $api.post(
+        `/api/colonel/organizations/${encodeURIComponent(org.extid)}/investigate`
+      );
+      const parsed = gracefulParse(
+        investigateOrganizationResponseSchema,
+        response.data,
+        'InvestigateOrganizationResponse'
+      );
+      if (parsed.ok) {
+        investigateResult.value = parsed.data.record;
+      } else {
+        // Contract drift: report the mismatch honestly rather than a blank panel.
+        investigateError.value = t('web.admin.organizations.investigate.parseError');
+      }
+    } catch {
+      investigateError.value = t('web.colonel.organizations.investigation.failed');
+    } finally {
+      investigateLoading.value = false;
+    }
+  }
+
+  function verdictBadgeClass(verdict: string): string {
+    switch (verdict) {
+      case 'synced':
+        return 'bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-200';
+      case 'mismatch_detected':
+        return 'bg-red-100 text-red-800 dark:bg-red-900/50 dark:text-red-200';
+      default:
+        return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300';
+    }
+  }
+  function verdictLabel(verdict: string): string {
+    switch (verdict) {
+      case 'synced':
+        return t('web.colonel.organizations.investigation.verifiedSynced');
+      case 'mismatch_detected':
+        return t('web.colonel.organizations.investigation.mismatchFound');
+      default:
+        return t('web.colonel.organizations.investigation.unableToCompare');
+    }
+  }
+  function severityBadgeClass(severity: string): string {
+    switch (severity) {
+      case 'critical':
+        return 'bg-red-100 text-red-800 dark:bg-red-900/50 dark:text-red-200';
+      case 'high':
+        return 'bg-orange-100 text-orange-800 dark:bg-orange-900/50 dark:text-orange-200';
+      case 'medium':
+        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/50 dark:text-yellow-200';
+      default:
+        return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300';
+    }
+  }
+
+  // ---- Entitlement overrides (MUTATING — guarded + audited server-side) ------
+
+  type EntitlementAction = 'grant' | 'revoke' | 'clear';
+
+  const entitlementInput = ref('');
+  /** Recomputed override state, populated only after a successful action. */
+  const overrideState = ref<ColonelEntitlementOverrideRecord | null>(null);
+
+  const entitlementDialogOpen = ref(false);
+  const activeEntitlementAction = ref<EntitlementAction | null>(null);
+  /** The entitlement name captured when the dialog was requested (grant/revoke). */
+  const pendingEntitlement = ref('');
+
+  const {
+    loading: entitlementLoading,
+    error: entitlementError,
+    run: runEntitlement,
+    reset: resetEntitlement,
+  } = useAdminMutation(async () => {
+    const org = selectedOrg.value;
+    const action = activeEntitlementAction.value;
+    if (!org || !action) throw new Error('No active entitlement action');
+
+    const base = `/api/colonel/organizations/${encodeURIComponent(org.extid)}/entitlements`;
+    const response =
+      action === 'clear'
+        ? await $api.delete(`${base}/overrides`)
+        : await $api.post(`${base}/${action}`, { entitlement: pendingEntitlement.value });
+
+    const parsed = gracefulParse(
+      colonelEntitlementOverrideResponseSchema,
+      response.data,
+      'ColonelEntitlementOverrideResponse'
+    );
+    // A 2xx means the mutation succeeded server-side regardless of ack shape; a
+    // mismatch is reported by gracefulParse but does not fail the action.
+    overrideState.value = parsed.ok ? parsed.data.record : null;
+  });
+
+  function requestGrant(): void {
+    if (!entitlementInput.value.trim()) return;
+    pendingEntitlement.value = entitlementInput.value.trim();
+    activeEntitlementAction.value = 'grant';
+    resetEntitlement();
+    entitlementDialogOpen.value = true;
+  }
+  function requestRevoke(): void {
+    if (!entitlementInput.value.trim()) return;
+    pendingEntitlement.value = entitlementInput.value.trim();
+    activeEntitlementAction.value = 'revoke';
+    resetEntitlement();
+    entitlementDialogOpen.value = true;
+  }
+  function requestClear(): void {
+    pendingEntitlement.value = '';
+    activeEntitlementAction.value = 'clear';
+    resetEntitlement();
+    entitlementDialogOpen.value = true;
+  }
+
+  const entitlementDialogConfig = computed(() => {
+    const org = selectedOrg.value;
+    const name = primaryIdentifier(org ?? ({} as ColonelOrganization));
+    const token = org?.extid; // typed-confirmation: retype the org's public id.
+    switch (activeEntitlementAction.value) {
+      case 'grant':
+        return {
+          title: t('web.admin.organizations.entitlements.confirm.grantTitle'),
+          description: t('web.admin.organizations.entitlements.confirm.grantDescription', {
+            entitlement: pendingEntitlement.value,
+            org: name,
+          }),
+          confirmToken: token,
+          variant: 'default' as const,
+          confirmText: t('web.admin.organizations.entitlements.grant'),
+        };
+      case 'revoke':
+        return {
+          title: t('web.admin.organizations.entitlements.confirm.revokeTitle'),
+          description: t('web.admin.organizations.entitlements.confirm.revokeDescription', {
+            entitlement: pendingEntitlement.value,
+            org: name,
+          }),
+          confirmToken: token,
+          variant: 'danger' as const,
+          confirmText: t('web.admin.organizations.entitlements.revoke'),
+        };
+      case 'clear':
+        return {
+          title: t('web.admin.organizations.entitlements.confirm.clearTitle'),
+          description: t('web.admin.organizations.entitlements.confirm.clearDescription', {
+            org: name,
+          }),
+          confirmToken: token,
+          variant: 'danger' as const,
+          confirmText: t('web.admin.organizations.entitlements.clear'),
+        };
+      default:
+        return {
+          title: '',
+          description: undefined,
+          confirmToken: undefined,
+          variant: 'default' as const,
+          confirmText: undefined,
+        };
+    }
+  });
+
+  const ENTITLEMENT_SUCCESS_KEYS: Record<EntitlementAction, string> = {
+    grant: 'web.admin.organizations.entitlements.success.granted',
+    revoke: 'web.admin.organizations.entitlements.success.revoked',
+    clear: 'web.admin.organizations.entitlements.success.cleared',
+  };
+
+  async function onEntitlementConfirm(): Promise<void> {
+    const action = activeEntitlementAction.value;
+    if (!action) return;
+
+    const ok = await runEntitlement();
+    if (!ok) return; // Failure message stays in the dialog for retry/cancel.
+
+    entitlementDialogOpen.value = false;
+    notifications.show(
+      t(ENTITLEMENT_SUCCESS_KEYS[action], { entitlement: pendingEntitlement.value }),
+      'success'
+    );
+    if (action === 'clear') entitlementInput.value = '';
+    activeEntitlementAction.value = null;
+  }
+
+  function onEntitlementCancel(): void {
+    entitlementDialogOpen.value = false;
+    activeEntitlementAction.value = null;
+    resetEntitlement();
+  }
+
+  onMounted(() => fetchPage(1));
+</script>
+
+<template>
+  <div class="mx-auto max-w-6xl">
+    <!-- Page header -->
+    <div class="mb-6">
+      <h2 class="font-brand text-2xl font-semibold text-gray-900 dark:text-white">
+        {{ t('web.colonel.organizations.title') }}
+      </h2>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.colonel.organizations.description') }}
+      </p>
+    </div>
+
+    <!-- Network/HTTP error banner (validation mismatches degrade to empty). -->
+    <div
+      v-if="error"
+      class="mb-4 flex items-center justify-between gap-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-900/20"
+      role="alert"
+      data-testid="organizations-error">
+      <span class="text-sm text-red-800 dark:text-red-200">
+        {{ t('web.admin.organizations.list.loadError') }}
+      </span>
+      <button
+        type="button"
+        class="inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/40"
+        @click="fetchPage(1)">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          size="4" />
+        {{ t('web.admin.organizations.retry') }}
+      </button>
+    </div>
+
+    <!-- Count summary (stale / unknown highlighted) -->
+    <p class="mb-3 text-sm text-gray-600 dark:text-gray-400">
+      {{ t('web.colonel.organizations.organizationsCount', { count: totalOrganizations }) }}
+      <template v-if="staleCount > 0 || unknownCount > 0">
+        <span class="mx-1">-</span>
+        <span
+          v-if="staleCount > 0"
+          class="font-medium text-yellow-600 dark:text-yellow-400">
+          {{ t('web.colonel.organizations.needAttention', { count: staleCount }) }}
+        </span>
+        <span
+          v-if="staleCount > 0 && unknownCount > 0"
+          class="mx-1"
+          >/</span
+        >
+        <span
+          v-if="unknownCount > 0"
+          class="text-gray-500 dark:text-gray-400">
+          {{ t('web.colonel.organizations.unknownCount', { count: unknownCount }) }}
+        </span>
+      </template>
+    </p>
+
+    <!-- Filters -->
+    <div class="mb-4">
+      <FilterBar
+        :filters="filters"
+        :show-search="false"
+        :has-active-filters="hasActiveFilters"
+        testid="organizations-filterbar"
+        @filter-change="onFilterChange"
+        @clear="onClear" />
+    </div>
+
+    <!-- Table -->
+    <div
+      class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
+      <DataTable
+        :columns="columns"
+        :rows="organizations"
+        row-key="extid"
+        :loading="loading"
+        :empty-text="t('web.colonel.organizations.noOrganizations')"
+        clickable-rows
+        testid="organizations-table"
+        @row-click="openDetail">
+        <!-- Account -->
+        <template #cell-account="{ row }">
+          <div class="font-medium text-gray-900 dark:text-white">{{ primaryIdentifier(row) }}</div>
+          <div
+            v-if="row.display_name && row.display_name !== 'Default Workspace'"
+            class="text-xs text-gray-500 dark:text-gray-400">
+            {{ row.display_name }}
+          </div>
+        </template>
+
+        <!-- Billing (plan + subscription) -->
+        <template #cell-billing="{ row }">
+          <div class="text-sm text-gray-900 dark:text-white">{{ planLabel(row.planid) }}</div>
+          <div class="mt-0.5">
+            <span
+              v-if="needsSubscriptionBadge(row.subscription_status)"
+              class="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium"
+              :class="subscriptionBadgeClass(row.subscription_status)">
+              {{ row.subscription_status }}
+            </span>
+            <span
+              v-else-if="row.subscription_status === 'active'"
+              class="text-xs text-gray-500 dark:text-gray-400">
+              {{ t('web.colonel.organizations.status.active') }}
+            </span>
+            <span
+              v-else
+              class="text-xs text-gray-400 dark:text-gray-500"
+              >—</span
+            >
+          </div>
+        </template>
+
+        <!-- Status (badge problems only) -->
+        <template #cell-status="{ row }">
+          <template v-if="row.sync_status === 'potentially_stale'">
+            <span
+              class="inline-flex items-center rounded bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800 dark:bg-yellow-900/50 dark:text-yellow-200">
+              {{ t('web.colonel.organizations.status.stale') }}
+            </span>
+            <div
+              v-if="row.sync_status_reason"
+              class="mt-1 max-w-xs whitespace-normal text-xs text-yellow-700 dark:text-yellow-300">
+              {{ row.sync_status_reason }}
+            </div>
+          </template>
+          <span
+            v-else-if="row.sync_status === 'unknown'"
+            class="inline-flex items-center rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+            {{ t('web.colonel.organizations.status.unknown') }}
+          </span>
+          <span
+            v-else
+            class="text-xs text-gray-400 dark:text-gray-500"
+            >—</span
+          >
+        </template>
+
+        <!-- Usage (members / domains) -->
+        <template #cell-usage="{ row }">
+          <span :title="t('web.colonel.organizations.usage.members', { count: row.member_count })"
+            >{{ row.member_count }}m</span
+          >
+          <span class="mx-1">/</span>
+          <span :title="t('web.colonel.organizations.usage.domains', { count: row.domain_count })"
+            >{{ row.domain_count }}d</span
+          >
+        </template>
+
+        <!-- Created -->
+        <template #cell-created="{ row }">
+          {{ formatDisplayDateTime(row.created) }}
+        </template>
+      </DataTable>
+    </div>
+
+    <!-- Pagination -->
+    <KitPagination
+      v-if="pagination"
+      :pagination="pagination"
+      :loading="loading"
+      class="mt-4"
+      @update:page="onPageChange"
+      @update:per-page="onPerPageChange" />
+
+    <!-- Detail drawer: billing read-out + investigate + entitlement overrides -->
+    <DetailDrawer
+      v-model:open="drawerOpen"
+      width-class="max-w-2xl"
+      :title="selectedOrg ? primaryIdentifier(selectedOrg) : undefined"
+      :subtitle="selectedOrg?.extid"
+      testid="organizations-drawer">
+      <div
+        v-if="selectedOrg"
+        class="space-y-8">
+        <!-- Billing read-out -->
+        <section>
+          <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <StatCard
+              :label="t('web.colonel.organizations.columns.members')"
+              :value="selectedOrg.member_count"
+              icon="users"
+              testid="org-stat-members" />
+            <StatCard
+              :label="t('web.colonel.organizations.columns.domains')"
+              :value="selectedOrg.domain_count"
+              icon="globe-alt"
+              testid="org-stat-domains" />
+            <StatCard
+              :label="t('web.admin.organizations.fields.plan')"
+              :value="planLabel(selectedOrg.planid)"
+              icon="credit-card" />
+            <StatCard
+              :label="t('web.colonel.organizations.columns.status')"
+              :value="selectedOrg.sync_status"
+              icon="shield-check" />
+          </div>
+
+          <dl class="mt-5 grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2">
+            <div
+              v-for="field in drawerFields"
+              :key="field.key"
+              :data-testid="`org-field-${field.key}`">
+              <dt class="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                {{ field.label }}
+              </dt>
+              <dd
+                class="mt-0.5 break-words text-sm text-gray-900 dark:text-gray-100"
+                :class="field.mono ? 'font-mono text-xs' : ''">
+                {{ field.value }}
+              </dd>
+            </div>
+          </dl>
+        </section>
+
+        <!-- Investigate -->
+        <section
+          class="border-t border-gray-200 pt-6 dark:border-gray-800"
+          data-testid="org-investigate">
+          <div class="flex items-center justify-between gap-3">
+            <div>
+              <h3 class="text-base font-semibold text-gray-900 dark:text-white">
+                {{ t('web.colonel.organizations.investigation.result') }}
+              </h3>
+              <p class="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
+                {{ t('web.admin.organizations.investigate.description') }}
+              </p>
+            </div>
+            <button
+              type="button"
+              data-testid="org-investigate-button"
+              :disabled="investigateLoading"
+              class="inline-flex shrink-0 items-center gap-1 rounded-md bg-brand-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-brand-500 dark:hover:bg-brand-600"
+              @click="runInvestigate">
+              <OIcon
+                collection="heroicons"
+                :name="investigateLoading ? 'arrow-path' : 'magnifying-glass'"
+                size="4"
+                :class="investigateLoading ? 'animate-spin motion-reduce:animate-none' : ''" />
+              {{
+                investigateLoading
+                  ? t('web.colonel.organizations.actions.checking')
+                  : t('web.colonel.organizations.actions.investigate')
+              }}
+            </button>
+          </div>
+
+          <!-- Investigate error -->
+          <div
+            v-if="investigateError"
+            class="mt-4 rounded-md bg-red-50 p-3 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-300"
+            role="alert"
+            data-testid="org-investigate-error">
+            {{ investigateError }}
+          </div>
+
+          <!-- Investigate result -->
+          <div
+            v-else-if="investigateResult"
+            class="mt-4 space-y-4"
+            data-testid="org-investigate-result">
+            <div class="flex flex-wrap items-center gap-2">
+              <span
+                class="inline-flex items-center rounded px-2 py-0.5 text-xs font-medium"
+                :class="verdictBadgeClass(investigateResult.comparison.verdict)"
+                data-testid="org-investigate-verdict">
+                {{ verdictLabel(investigateResult.comparison.verdict) }}
+              </span>
+              <span class="text-xs text-gray-500 dark:text-gray-400">
+                {{ investigateResult.investigated_at }}
+              </span>
+            </div>
+
+            <p
+              v-if="investigateResult.comparison.details"
+              class="text-sm text-gray-600 dark:text-gray-300">
+              {{ investigateResult.comparison.details }}
+            </p>
+
+            <!-- Issues (#2349 parity: field + local vs stripe + severity) -->
+            <div
+              v-if="investigateResult.comparison.issues?.length"
+              class="space-y-2">
+              <div
+                v-for="(issue, idx) in investigateResult.comparison.issues"
+                :key="idx"
+                class="rounded border border-gray-200 bg-gray-50 p-2 text-xs dark:border-gray-700 dark:bg-gray-800/50">
+                <div class="flex items-center gap-2">
+                  <span
+                    class="inline-flex items-center rounded px-1.5 py-0.5 font-medium"
+                    :class="severityBadgeClass(issue.severity)">
+                    {{ issue.severity }}
+                  </span>
+                  <span class="font-medium text-gray-700 dark:text-gray-300">{{ issue.field }}</span>
+                </div>
+                <div class="mt-1 grid grid-cols-2 gap-4">
+                  <div>
+                    <span class="text-gray-500 dark:text-gray-400"
+                      >{{ t('web.colonel.organizations.investigation.local') }}:</span
+                    >
+                    <code class="ml-1 text-gray-900 dark:text-white">{{ issue.local }}</code>
+                  </div>
+                  <div>
+                    <span class="text-gray-500 dark:text-gray-400"
+                      >{{ t('web.colonel.organizations.investigation.stripe') }}:</span
+                    >
+                    <code class="ml-1 text-gray-900 dark:text-white">{{ issue.stripe }}</code>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Stripe subscription summary (when available) -->
+            <div
+              v-if="investigateResult.stripe.available && investigateResult.stripe.subscription"
+              class="border-t border-gray-200 pt-3 dark:border-gray-700">
+              <h4 class="mb-2 text-xs font-medium text-gray-500 dark:text-gray-400">
+                {{ t('web.colonel.organizations.investigation.stripeDetails') }}
+              </h4>
+              <div class="grid grid-cols-2 gap-2 text-xs md:grid-cols-4">
+                <div>
+                  <span class="text-gray-500 dark:text-gray-400"
+                    >{{ t('web.colonel.organizations.investigation.statusLabel') }}:</span
+                  >
+                  <span class="ml-1 font-medium text-gray-900 dark:text-white">{{
+                    investigateResult.stripe.subscription.status
+                  }}</span>
+                </div>
+                <div>
+                  <span class="text-gray-500 dark:text-gray-400"
+                    >{{ t('web.colonel.organizations.investigation.product') }}:</span
+                  >
+                  <span class="ml-1 font-medium text-gray-900 dark:text-white">{{
+                    investigateResult.stripe.subscription.product_name || 'N/A'
+                  }}</span>
+                </div>
+                <div>
+                  <span class="text-gray-500 dark:text-gray-400"
+                    >{{ t('web.colonel.organizations.investigation.resolvedPlan') }}:</span
+                  >
+                  <span class="ml-1 font-medium text-gray-900 dark:text-white">{{
+                    investigateResult.stripe.subscription.resolved_plan_id || '(none)'
+                  }}</span>
+                </div>
+                <div>
+                  <span class="text-gray-500 dark:text-gray-400"
+                    >{{ t('web.colonel.organizations.investigation.priceId') }}:</span
+                  >
+                  <code class="ml-1 font-mono text-gray-700 dark:text-gray-300">{{
+                    investigateResult.stripe.subscription.price_id || 'N/A'
+                  }}</code>
+                </div>
+              </div>
+            </div>
+            <p
+              v-else-if="investigateResult.stripe.reason"
+              class="text-xs text-gray-500 dark:text-gray-400">
+              {{ investigateResult.stripe.reason }}
+            </p>
+
+            <!-- Raw payload (AC: JsonViewer replaces the legacy ad-hoc markup) -->
+            <div>
+              <h4 class="mb-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                {{ t('web.admin.organizations.investigate.rawPayload') }}
+              </h4>
+              <JsonViewer
+                :data="investigateResult"
+                :expand-depth="1"
+                testid="org-investigate-json" />
+            </div>
+          </div>
+        </section>
+
+        <!-- Entitlement overrides -->
+        <section
+          class="border-t border-gray-200 pt-6 dark:border-gray-800"
+          data-testid="org-entitlements">
+          <h3 class="text-base font-semibold text-gray-900 dark:text-white">
+            {{ t('web.admin.organizations.entitlements.section') }}
+          </h3>
+          <p class="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.organizations.entitlements.description') }}
+          </p>
+
+          <div class="mt-4">
+            <label
+              for="org-entitlement-input"
+              class="block text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              {{ t('web.admin.organizations.entitlements.inputLabel') }}
+            </label>
+            <div class="mt-2 flex flex-wrap gap-2">
+              <input
+                id="org-entitlement-input"
+                v-model="entitlementInput"
+                type="text"
+                autocomplete="off"
+                spellcheck="false"
+                data-testid="org-entitlement-input"
+                :placeholder="t('web.admin.organizations.entitlements.placeholder')"
+                class="min-w-0 flex-1 rounded-md border border-gray-300 px-3 py-2 font-mono text-sm placeholder:text-gray-400 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+              <button
+                type="button"
+                data-testid="org-entitlement-grant"
+                :disabled="!entitlementInput.trim()"
+                class="inline-flex items-center gap-1 rounded-md bg-brand-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-brand-500 dark:hover:bg-brand-600"
+                @click="requestGrant">
+                {{ t('web.admin.organizations.entitlements.grant') }}
+              </button>
+              <button
+                type="button"
+                data-testid="org-entitlement-revoke"
+                :disabled="!entitlementInput.trim()"
+                class="inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-2 text-sm font-semibold text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-900/30"
+                @click="requestRevoke">
+                {{ t('web.admin.organizations.entitlements.revoke') }}
+              </button>
+            </div>
+            <button
+              type="button"
+              data-testid="org-entitlement-clear"
+              class="mt-3 inline-flex items-center gap-1 text-sm font-medium text-red-700 hover:text-red-800 focus:outline-none dark:text-red-400 dark:hover:text-red-300"
+              @click="requestClear">
+              <OIcon
+                collection="heroicons"
+                name="trash"
+                size="4" />
+              {{ t('web.admin.organizations.entitlements.clear') }}
+            </button>
+          </div>
+
+          <!-- Recomputed override state (populated after an action) -->
+          <div
+            v-if="overrideState"
+            class="mt-5 space-y-3"
+            data-testid="org-override-state">
+            <div>
+              <p class="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                {{ t('web.admin.organizations.entitlements.effective') }}
+              </p>
+              <div class="mt-1 flex flex-wrap gap-1">
+                <span
+                  v-for="ent in overrideState.effective_entitlements"
+                  :key="`eff-${ent}`"
+                  class="inline-flex items-center rounded bg-green-50 px-2 py-0.5 font-mono text-xs text-green-700 dark:bg-green-900/40 dark:text-green-200">
+                  {{ ent }}
+                </span>
+                <span
+                  v-if="overrideState.effective_entitlements.length === 0"
+                  class="text-xs text-gray-400 dark:text-gray-500"
+                  >—</span
+                >
+              </div>
+            </div>
+            <div class="grid grid-cols-2 gap-4">
+              <div>
+                <p class="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                  {{ t('web.admin.organizations.entitlements.grants') }}
+                </p>
+                <div class="mt-1 flex flex-wrap gap-1">
+                  <span
+                    v-for="ent in overrideState.grants"
+                    :key="`grant-${ent}`"
+                    class="inline-flex items-center rounded bg-brand-50 px-2 py-0.5 font-mono text-xs text-brand-700 dark:bg-brand-900/30 dark:text-brand-300">
+                    {{ ent }}
+                  </span>
+                  <span
+                    v-if="overrideState.grants.length === 0"
+                    class="text-xs text-gray-400 dark:text-gray-500"
+                    >—</span
+                  >
+                </div>
+              </div>
+              <div>
+                <p class="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                  {{ t('web.admin.organizations.entitlements.revokes') }}
+                </p>
+                <div class="mt-1 flex flex-wrap gap-1">
+                  <span
+                    v-for="ent in overrideState.revokes"
+                    :key="`revoke-${ent}`"
+                    class="inline-flex items-center rounded bg-red-50 px-2 py-0.5 font-mono text-xs text-red-700 dark:bg-red-900/30 dark:text-red-300">
+                    {{ ent }}
+                  </span>
+                  <span
+                    v-if="overrideState.revokes.length === 0"
+                    class="text-xs text-gray-400 dark:text-gray-500"
+                    >—</span
+                  >
+                </div>
+              </div>
+            </div>
+          </div>
+          <p
+            v-else
+            class="mt-4 text-xs text-gray-400 dark:text-gray-500"
+            data-testid="org-override-empty">
+            {{ t('web.admin.organizations.entitlements.noOverrides') }}
+          </p>
+        </section>
+      </div>
+    </DetailDrawer>
+
+    <!-- Guarded entitlement mutation (typed-confirmation — sibling of the drawer). -->
+    <AdminConfirmDialog
+      v-model:open="entitlementDialogOpen"
+      :title="entitlementDialogConfig.title"
+      :description="entitlementDialogConfig.description"
+      :confirm-token="entitlementDialogConfig.confirmToken"
+      :variant="entitlementDialogConfig.variant"
+      :confirm-text="entitlementDialogConfig.confirmText"
+      :loading="entitlementLoading"
+      :error="entitlementError"
+      @confirm="onEntitlementConfirm"
+      @cancel="onEntitlementCancel" />
+  </div>
+</template>

--- a/src/apps/admin/views/AdminSecrets.vue
+++ b/src/apps/admin/views/AdminSecrets.vue
@@ -1,0 +1,596 @@
+<!-- src/apps/admin/views/AdminSecrets.vue -->
+
+<script setup lang="ts">
+  import { storeToRefs } from 'pinia';
+  import { computed, onMounted, ref } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  import {
+    AdminConfirmDialog,
+    DataTable,
+    DetailDrawer,
+    JsonViewer,
+    KitPagination,
+  } from '@/apps/admin/components/kit';
+  import type { DataTableColumn } from '@/apps/admin/components/kit';
+  import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
+  import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
+  import { useAdminSecrets } from '@/apps/admin/stores/useAdminSecrets';
+  import type { ColonelSecret } from '@/schemas/api/account/responses/colonel';
+  import {
+    colonelSecretDeleteResponseSchema,
+    colonelSecretReceiptResponseSchema,
+  } from '@/schemas/api/internal/responses/colonel-secrets';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import { useApi } from '@/shared/composables/useApi';
+  import { useNotificationsStore } from '@/shared/stores/notificationsStore';
+  import { formatDisplayDateTime } from '@/utils/format';
+  import { gracefulParse } from '@/utils/schemaValidation';
+
+  /**
+   * Secrets screen (ticket #30) — the parity port of the hand-rolled
+   * `ColonelSecrets.vue`, rebuilt on the Slice-3 template.
+   *
+   * - LIST: DataTable + KitPagination over the existing {@link useAdminSecrets}
+   *   store (one server page per request; the list endpoint offers no server-side
+   *   filter, so — like AdminCustomers — no inert FilterBar is shown).
+   * - RECEIPT DRAWER: clicking a row opens a {@link DetailDrawer} that loads
+   *   GET /api/colonel/secrets/:secret_id via {@link useResourceFetch} (secret
+   *   record + receipt metadata + owner + raw JSON inspector).
+   * - GUARDED DELETE (D4): the drawer footer surfaces the destructive delete that
+   *   `DELETE /api/colonel/secrets/:secret_id` has always supported but no UI ever
+   *   exposed. It is gated by {@link AdminConfirmDialog} typed-confirmation
+   *   (retype the secret's short id) in danger mode. On success the list refreshes.
+   */
+  const { t } = useI18n();
+  const $api = useApi();
+  const notifications = useNotificationsStore();
+
+  const store = useAdminSecrets();
+  const { secrets, pagination, loading, error } = storeToRefs(store);
+
+  const columns = computed<DataTableColumn<ColonelSecret>[]>(() => [
+    { key: 'shortid', label: t('web.admin.secrets.columns.shortId') },
+    { key: 'state', label: t('web.admin.secrets.columns.state') },
+    { key: 'owner', label: t('web.admin.secrets.columns.owner') },
+    { key: 'created', label: t('web.admin.secrets.columns.created') },
+    { key: 'expiration', label: t('web.admin.secrets.columns.expiration') },
+    { key: 'age', label: t('web.admin.secrets.columns.age'), align: 'right' },
+  ]);
+
+  /** State badge classes, mirroring the old colonel screen's colour language. */
+  function stateBadgeClass(state: string): string {
+    switch (state) {
+      case 'new':
+        return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200';
+      case 'received':
+        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200';
+      default:
+        return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300';
+    }
+  }
+
+  function stateLabel(state: string): string {
+    return t(`web.admin.secrets.state.${state}`, state);
+  }
+
+  /** Age in whole days, matching the legacy screen (`floor(age / 86400)`). */
+  function ageInDays(age: number): number {
+    return Math.floor(age / 86400);
+  }
+
+  // ---- List paging ----------------------------------------------------------
+
+  async function fetchPage(targetPage = 1): Promise<void> {
+    try {
+      await store.fetchPage(targetPage);
+    } catch {
+      // Network/HTTP failure is captured in `store.error`; the banner + retry
+      // button below handle it. Swallow so it doesn't become unhandled.
+    }
+  }
+
+  function onPageChange(targetPage: number): void {
+    fetchPage(targetPage);
+  }
+
+  function onPerPageChange(perPage: number): void {
+    store.perPage = perPage;
+    fetchPage(1);
+  }
+
+  // ---- Receipt drawer -------------------------------------------------------
+
+  const drawerOpen = ref(false);
+  /** The row that opened the drawer — the source of the delete id + confirm token. */
+  const selectedSecret = ref<ColonelSecret | null>(null);
+
+  const receiptUrl = (): string =>
+    `/api/colonel/secrets/${encodeURIComponent(selectedSecret.value?.secret_id ?? '')}`;
+
+  const {
+    data: receiptData,
+    loading: receiptLoading,
+    error: receiptError,
+    validationError: receiptValidationError,
+    notFound: receiptNotFound,
+    load: loadReceipt,
+  } = useResourceFetch({
+    url: receiptUrl,
+    schema: colonelSecretReceiptResponseSchema,
+    context: 'ColonelSecretReceiptResponse',
+  });
+
+  const receiptRecord = computed(() => receiptData.value?.record ?? null);
+  const receiptDetails = computed(() => receiptData.value?.details ?? null);
+
+  /** A non-404 network/HTTP failure, or a Zod contract mismatch. */
+  const receiptLoadFailed = computed(
+    () =>
+      (receiptError.value !== null && !receiptNotFound.value) ||
+      receiptValidationError.value !== null
+  );
+
+  function openReceipt(row: ColonelSecret): void {
+    selectedSecret.value = row;
+    resetDelete();
+    drawerOpen.value = true;
+    loadReceipt().catch(() => {});
+  }
+
+  function closeDrawer(): void {
+    drawerOpen.value = false;
+    selectedSecret.value = null;
+  }
+
+  const drawerSubtitle = computed(() => {
+    const s = selectedSecret.value;
+    if (!s) return undefined;
+    return stateLabel(s.state);
+  });
+
+  const yesNo = (value: boolean): string =>
+    value ? t('web.admin.secrets.detail.yes') : t('web.admin.secrets.detail.no');
+
+  /** Field rows for the secret record read-out. */
+  const secretFields = computed(() => {
+    const r = receiptRecord.value;
+    if (!r) return [];
+    return [
+      { key: 'secretId', label: t('web.admin.secrets.fields.secretId'), value: r.secret_id },
+      { key: 'shortId', label: t('web.admin.secrets.fields.shortId'), value: r.shortid },
+      { key: 'state', label: t('web.admin.secrets.fields.state'), value: stateLabel(r.state) },
+      {
+        key: 'created',
+        label: t('web.admin.secrets.fields.created'),
+        value: formatDisplayDateTime(r.created),
+      },
+      {
+        key: 'updated',
+        label: t('web.admin.secrets.fields.updated'),
+        value: r.updated
+          ? formatDisplayDateTime(r.updated)
+          : t('web.admin.secrets.detail.none'),
+      },
+      {
+        key: 'expiration',
+        label: t('web.admin.secrets.fields.expiration'),
+        value: r.expiration
+          ? formatDisplayDateTime(r.expiration)
+          : t('web.admin.secrets.never'),
+      },
+      {
+        key: 'age',
+        label: t('web.admin.secrets.fields.age'),
+        value: t('web.admin.secrets.ageDays', { days: ageInDays(r.age) }),
+      },
+      {
+        key: 'lifespan',
+        label: t('web.admin.secrets.fields.lifespan'),
+        value: r.lifespan ?? t('web.admin.secrets.detail.none'),
+      },
+      {
+        key: 'owner',
+        label: t('web.admin.secrets.fields.owner'),
+        value: ownerLabel(r.owner_id),
+      },
+      {
+        key: 'receiptId',
+        label: t('web.admin.secrets.fields.receiptId'),
+        value: r.receipt_id || t('web.admin.secrets.detail.none'),
+      },
+      {
+        key: 'hasCiphertext',
+        label: t('web.admin.secrets.fields.hasCiphertext'),
+        value: yesNo(r.has_ciphertext),
+      },
+      {
+        key: 'ciphertextLength',
+        label: t('web.admin.secrets.fields.ciphertextLength'),
+        value: r.ciphertext_length,
+      },
+    ];
+  });
+
+  /** Field rows for the receipt metadata read-out (only when a receipt exists). */
+  const receiptFields = computed(() => {
+    const m = receiptDetails.value?.metadata;
+    if (!m) return [];
+    const recipients = Array.isArray(m.recipients)
+      ? m.recipients.join(', ')
+      : (m.recipients ?? t('web.admin.secrets.detail.none'));
+    return [
+      { key: 'receiptId', label: t('web.admin.secrets.receiptFields.receiptId'), value: m.receipt_id },
+      { key: 'shortId', label: t('web.admin.secrets.receiptFields.shortId'), value: m.shortid },
+      { key: 'state', label: t('web.admin.secrets.receiptFields.state'), value: m.state },
+      {
+        key: 'secretTtl',
+        label: t('web.admin.secrets.receiptFields.secretTtl'),
+        value: m.secret_ttl ?? t('web.admin.secrets.detail.none'),
+      },
+      {
+        key: 'recipients',
+        label: t('web.admin.secrets.receiptFields.recipients'),
+        value: recipients || t('web.admin.secrets.detail.none'),
+      },
+      {
+        key: 'hasPassphrase',
+        label: t('web.admin.secrets.receiptFields.hasPassphrase'),
+        value: yesNo(m.has_passphrase),
+      },
+      {
+        key: 'shareDomain',
+        label: t('web.admin.secrets.receiptFields.shareDomain'),
+        value: m.share_domain || t('web.admin.secrets.detail.none'),
+      },
+      {
+        key: 'created',
+        label: t('web.admin.secrets.receiptFields.created'),
+        value: formatDisplayDateTime(m.created),
+      },
+      {
+        key: 'secretExpired',
+        label: t('web.admin.secrets.receiptFields.secretExpired'),
+        value: yesNo(m.secret_expired),
+      },
+    ];
+  });
+
+  /** Owner read-out rows (only when the secret has a non-anonymous owner). */
+  const ownerFields = computed(() => {
+    const o = receiptDetails.value?.owner;
+    if (!o) return [];
+    return [
+      { key: 'email', label: t('web.admin.secrets.ownerFields.email'), value: o.email },
+      { key: 'userId', label: t('web.admin.secrets.ownerFields.userId'), value: o.user_id },
+      { key: 'role', label: t('web.admin.secrets.ownerFields.role'), value: o.role },
+      {
+        key: 'verified',
+        label: t('web.admin.secrets.ownerFields.verified'),
+        value: yesNo(o.verified),
+      },
+    ];
+  });
+
+  /** Human label for an owner id ('anon'/empty → Anonymous). */
+  function ownerLabel(ownerId: string | null): string {
+    if (!ownerId || ownerId === 'anon') return t('web.admin.secrets.anonymous');
+    return ownerId;
+  }
+
+  // ---- Guarded delete (D4) --------------------------------------------------
+
+  const deleteDialogOpen = ref(false);
+
+  const {
+    loading: deleteLoading,
+    error: deleteError,
+    run: runDelete,
+    reset: resetDelete,
+  } = useAdminMutation(async () => {
+    const secretId = selectedSecret.value?.secret_id;
+    if (!secretId) throw new Error('No secret selected');
+    const response = await $api.delete(
+      `/api/colonel/secrets/${encodeURIComponent(secretId)}`
+    );
+    // A 2xx means the secret was deleted server-side regardless of ack shape; the
+    // parse keeps the contract a live tripwire without failing the action.
+    gracefulParse(
+      colonelSecretDeleteResponseSchema,
+      response.data,
+      'ColonelSecretDeleteResponse'
+    );
+  });
+
+  /** The exact string the operator must retype to enable the delete. */
+  const deleteToken = computed(() => selectedSecret.value?.shortid ?? '');
+
+  function requestDelete(): void {
+    resetDelete();
+    deleteDialogOpen.value = true;
+  }
+
+  async function onDeleteConfirm(): Promise<void> {
+    const ok = await runDelete();
+    if (!ok) return; // Failure message stays in the dialog for retry/cancel.
+
+    deleteDialogOpen.value = false;
+    closeDrawer();
+    notifications.show(t('web.admin.secrets.actions.delete.success'), 'success');
+    // The deleted row is gone — refresh the current page.
+    await fetchPage(pagination.value?.page ?? 1);
+  }
+
+  function onDeleteCancel(): void {
+    deleteDialogOpen.value = false;
+    resetDelete();
+  }
+
+  onMounted(() => fetchPage(1));
+</script>
+
+<template>
+  <div class="mx-auto max-w-6xl">
+    <!-- Page header -->
+    <div class="mb-6">
+      <h2 class="font-brand text-2xl font-semibold text-gray-900 dark:text-white">
+        {{ t('web.admin.secrets.title') }}
+      </h2>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.secrets.description') }}
+      </p>
+    </div>
+
+    <!-- Network/HTTP error banner (validation mismatches degrade to empty). -->
+    <div
+      v-if="error"
+      class="mb-4 flex items-center justify-between gap-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-900/20"
+      role="alert"
+      data-testid="secrets-error">
+      <span class="text-sm text-red-800 dark:text-red-200">
+        {{ t('web.admin.secrets.list.loadError') }}
+      </span>
+      <button
+        type="button"
+        class="inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/40"
+        @click="fetchPage(1)">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          size="4" />
+        {{ t('web.admin.secrets.list.retry') }}
+      </button>
+    </div>
+
+    <!-- Table -->
+    <div
+      class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
+      <DataTable
+        :columns="columns"
+        :rows="secrets"
+        row-key="secret_id"
+        :loading="loading"
+        :empty-text="t('web.admin.secrets.list.empty')"
+        clickable-rows
+        testid="secrets-table"
+        @row-click="openReceipt">
+        <template #cell-shortid="{ row }">
+          <span class="font-mono text-gray-900 dark:text-white">{{ row.shortid }}</span>
+        </template>
+
+        <template #cell-state="{ row }">
+          <span
+            class="inline-flex rounded px-2 py-0.5 text-xs font-medium"
+            :class="stateBadgeClass(row.state)">
+            {{ stateLabel(row.state) }}
+          </span>
+        </template>
+
+        <template #cell-owner="{ row }">
+          <span class="text-gray-600 dark:text-gray-400">{{ ownerLabel(row.owner_id) }}</span>
+        </template>
+
+        <template #cell-created="{ row }">
+          {{ formatDisplayDateTime(row.created) }}
+        </template>
+
+        <template #cell-expiration="{ row }">
+          {{ row.expiration ? formatDisplayDateTime(row.expiration) : t('web.admin.secrets.never') }}
+        </template>
+
+        <template #cell-age="{ row }">
+          {{ ageInDays(row.age) }}
+        </template>
+      </DataTable>
+    </div>
+
+    <!-- Pagination -->
+    <KitPagination
+      v-if="pagination"
+      :pagination="pagination"
+      :loading="loading"
+      class="mt-4"
+      @update:page="onPageChange"
+      @update:per-page="onPerPageChange" />
+
+    <!-- Receipt drawer -->
+    <DetailDrawer
+      v-model:open="drawerOpen"
+      :title="selectedSecret ? t('web.admin.secrets.drawer.title', { shortid: selectedSecret.shortid }) : ''"
+      :subtitle="drawerSubtitle"
+      width-class="max-w-lg"
+      testid="secret-drawer"
+      @close="closeDrawer">
+      <!-- Loading -->
+      <div
+        v-if="receiptLoading && !receiptRecord"
+        class="flex items-center justify-center py-16 text-gray-500 dark:text-gray-400"
+        data-testid="secret-drawer-loading">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          size="6"
+          class="animate-spin motion-reduce:animate-none" />
+        <span class="ml-3 text-sm">{{ t('web.COMMON.loading') }}</span>
+      </div>
+
+      <!-- Not found -->
+      <div
+        v-else-if="receiptNotFound"
+        class="px-2 py-12 text-center"
+        data-testid="secret-drawer-not-found">
+        <OIcon
+          collection="heroicons"
+          name="key"
+          size="8"
+          class="mx-auto text-gray-400 dark:text-gray-600" />
+        <h3 class="mt-3 text-base font-medium text-gray-900 dark:text-white">
+          {{ t('web.admin.secrets.drawer.notFound') }}
+        </h3>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          {{ t('web.admin.secrets.drawer.notFoundDescription') }}
+        </p>
+      </div>
+
+      <!-- Load error -->
+      <div
+        v-else-if="receiptLoadFailed"
+        class="px-2 py-12 text-center"
+        role="alert"
+        data-testid="secret-drawer-error">
+        <OIcon
+          collection="heroicons"
+          name="exclamation-triangle"
+          size="8"
+          class="mx-auto text-red-500 dark:text-red-400" />
+        <p class="mt-3 text-sm text-red-800 dark:text-red-200">
+          {{ t('web.admin.secrets.drawer.loadError') }}
+        </p>
+        <button
+          type="button"
+          class="mt-4 inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-2 text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/40"
+          @click="loadReceipt().catch(() => {})">
+          <OIcon
+            collection="heroicons"
+            name="arrow-path"
+            size="4" />
+          {{ t('web.admin.secrets.drawer.retry') }}
+        </button>
+      </div>
+
+      <!-- Loaded -->
+      <div
+        v-else-if="receiptRecord"
+        class="space-y-6"
+        data-testid="secret-drawer-content">
+        <!-- Secret record -->
+        <section>
+          <h3 class="mb-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.secrets.sections.secret') }}
+          </h3>
+          <dl class="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2">
+            <div
+              v-for="field in secretFields"
+              :key="field.key"
+              :data-testid="`secret-field-${field.key}`">
+              <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">{{ field.label }}</dt>
+              <dd class="mt-0.5 break-words font-mono text-sm text-gray-900 dark:text-gray-100">
+                {{ field.value }}
+              </dd>
+            </div>
+          </dl>
+        </section>
+
+        <!-- Receipt metadata -->
+        <section data-testid="secret-drawer-receipt">
+          <h3 class="mb-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.secrets.sections.receipt') }}
+          </h3>
+          <dl
+            v-if="receiptDetails?.metadata"
+            class="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2">
+            <div
+              v-for="field in receiptFields"
+              :key="field.key"
+              :data-testid="`receipt-field-${field.key}`">
+              <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">{{ field.label }}</dt>
+              <dd class="mt-0.5 break-words font-mono text-sm text-gray-900 dark:text-gray-100">
+                {{ field.value }}
+              </dd>
+            </div>
+          </dl>
+          <p
+            v-else
+            class="text-sm text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.secrets.receipt.none') }}
+          </p>
+        </section>
+
+        <!-- Owner -->
+        <section data-testid="secret-drawer-owner">
+          <h3 class="mb-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.secrets.sections.owner') }}
+          </h3>
+          <dl
+            v-if="receiptDetails?.owner"
+            class="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2">
+            <div
+              v-for="field in ownerFields"
+              :key="field.key"
+              :data-testid="`owner-field-${field.key}`">
+              <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">{{ field.label }}</dt>
+              <dd class="mt-0.5 break-words text-sm text-gray-900 dark:text-gray-100">
+                {{ field.value }}
+              </dd>
+            </div>
+          </dl>
+          <p
+            v-else
+            class="text-sm text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.secrets.owner.anonymous') }}
+          </p>
+        </section>
+
+        <!-- Raw inspector -->
+        <section>
+          <h3 class="mb-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.secrets.sections.raw') }}
+          </h3>
+          <JsonViewer
+            :data="receiptData"
+            :expand-depth="2"
+            testid="secret-drawer-json" />
+        </section>
+      </div>
+
+      <!-- Footer: guarded delete -->
+      <template #footer>
+        <button
+          type="button"
+          data-testid="secret-delete-button"
+          :disabled="!selectedSecret"
+          class="inline-flex w-full items-center justify-center gap-1 rounded-md border border-red-300 px-3 py-2 text-sm font-semibold text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-900/30"
+          @click="requestDelete">
+          <OIcon
+            collection="heroicons"
+            name="trash"
+            size="4" />
+          {{ t('web.admin.secrets.actions.delete.button') }}
+        </button>
+      </template>
+    </DetailDrawer>
+
+    <!-- Typed-confirmation delete gate (danger). -->
+    <AdminConfirmDialog
+      v-model:open="deleteDialogOpen"
+      :title="t('web.admin.secrets.actions.delete.confirmTitle')"
+      :description="t('web.admin.secrets.actions.delete.confirmDescription', { shortid: deleteToken })"
+      :confirm-token="deleteToken"
+      variant="danger"
+      :confirm-text="t('web.admin.secrets.actions.delete.button')"
+      :loading="deleteLoading"
+      :error="deleteError"
+      @confirm="onDeleteConfirm"
+      @cancel="onDeleteCancel" />
+  </div>
+</template>

--- a/src/apps/admin/views/AdminSystem.vue
+++ b/src/apps/admin/views/AdminSystem.vue
@@ -1,0 +1,469 @@
+<!-- src/apps/admin/views/AdminSystem.vue -->
+
+<script setup lang="ts">
+  import { computed, onMounted } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  import { DataTable, JsonViewer, StatCard } from '@/apps/admin/components/kit';
+  import type { DataTableColumn } from '@/apps/admin/components/kit';
+  import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
+  import type { QueueMetric } from '@/schemas/api/account/responses/colonel';
+  import {
+    databaseMetricsResponseSchema,
+    queueMetricsResponseSchema,
+    redisMetricsResponseSchema,
+  } from '@/schemas/api/internal/responses/colonel-system';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import { formatDisplayDateTime } from '@/utils/format';
+
+  /**
+   * System screen (ticket #33) — the read-only status/info read-out, a Phase-2
+   * parity port of the legacy `ColonelSystem` / `ColonelSystemMainDB` /
+   * `ColonelSystemRedis` views rebuilt fresh on the Slice-3 template. It does NOT
+   * import `src/apps/colonel/*` or `colonelInfoStore`.
+   *
+   * Three independent single-GET read-outs via {@link useResourceFetch} (CONTRACT
+   * 1 — single screens use useResourceFetch, not a paginated store). All reads
+   * REUSE the frozen wrapped schemas (CONTRACT 3):
+   *   - GET /api/colonel/system/database → server + memory + db sizes + model counts
+   *   - GET /api/colonel/queue           → connection + worker health + per-queue
+   *   - GET /api/colonel/system/redis    → full Redis/Valkey INFO (JsonViewer)
+   *
+   * Read-only: nothing here mutates, so nothing is audited (CONTRACT 4).
+   */
+  const { t } = useI18n();
+
+  // ---- Database metrics -----------------------------------------------------
+
+  const {
+    data: dbData,
+    loading: dbLoading,
+    error: dbError,
+    validationError: dbValidationError,
+    load: loadDb,
+  } = useResourceFetch({
+    url: '/api/colonel/system/database',
+    schema: databaseMetricsResponseSchema,
+    context: 'DatabaseMetricsResponse',
+  });
+
+  const db = computed(() => dbData.value?.details ?? null);
+  const dbFailed = computed(() => dbError.value !== null || dbValidationError.value !== null);
+
+  // Valkey reports both valkey_version and a Redis-compat redis_version. Prefer
+  // Valkey when present so the page reflects the real engine (parity with the
+  // legacy MainDB view).
+  const engineName = computed(() =>
+    db.value?.redis_info.valkey_version ? 'Valkey' : 'Redis'
+  );
+  const engineVersion = computed(
+    () => db.value?.redis_info.valkey_version ?? db.value?.redis_info.redis_version ?? '—'
+  );
+
+  const num = (value: number | undefined | null): string =>
+    typeof value === 'number' ? value.toLocaleString() : '—';
+
+  /** Database-size rows, normalised from the record<string, {keys,…} | string>. */
+  const databaseSizeRows = computed(() => {
+    const sizes = db.value?.database_sizes ?? {};
+    return Object.entries(sizes).map(([name, info]) => {
+      if (info !== null && typeof info === 'object' && 'keys' in info) {
+        return {
+          name,
+          keys: info.keys as number,
+          expires: info.expires as number,
+          raw: null as string | null,
+        };
+      }
+      return { name, keys: null, expires: null, raw: String(info) };
+    });
+  });
+
+  // ---- Queue metrics --------------------------------------------------------
+
+  const {
+    data: queueData,
+    loading: queueLoading,
+    error: queueError,
+    validationError: queueValidationError,
+    load: loadQueue,
+  } = useResourceFetch({
+    url: '/api/colonel/queue',
+    schema: queueMetricsResponseSchema,
+    context: 'QueueMetricsResponse',
+  });
+
+  const queue = computed(() => queueData.value?.details ?? null);
+  const queueFailed = computed(
+    () => queueError.value !== null || queueValidationError.value !== null
+  );
+
+  const queueColumns = computed<DataTableColumn<QueueMetric>[]>(() => [
+    { key: 'name', label: t('web.admin.system.queue.columns.name') },
+    { key: 'pending_messages', label: t('web.admin.system.queue.columns.pending'), align: 'right' },
+    { key: 'consumers', label: t('web.admin.system.queue.columns.consumers'), align: 'right' },
+  ]);
+
+  /** Worker-health badge classes, keyed by the backend health enum. */
+  function healthBadgeClass(status: string): string {
+    switch (status) {
+      case 'healthy':
+        return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200';
+      case 'degraded':
+        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200';
+      case 'unhealthy':
+        return 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200';
+      default:
+        return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300';
+    }
+  }
+
+  // ---- Redis full INFO ------------------------------------------------------
+
+  const {
+    data: redisData,
+    loading: redisLoading,
+    error: redisError,
+    validationError: redisValidationError,
+    load: loadRedis,
+  } = useResourceFetch({
+    url: '/api/colonel/system/redis',
+    schema: redisMetricsResponseSchema,
+    context: 'RedisMetricsResponse',
+  });
+
+  const redis = computed(() => redisData.value?.details ?? null);
+  const redisFailed = computed(
+    () => redisError.value !== null || redisValidationError.value !== null
+  );
+
+  function loadAll(): void {
+    loadDb().catch(() => {});
+    loadQueue().catch(() => {});
+    loadRedis().catch(() => {});
+  }
+
+  onMounted(loadAll);
+</script>
+
+<template>
+  <div class="mx-auto max-w-6xl">
+    <!-- Page header -->
+    <div class="mb-6">
+      <h2 class="font-brand text-2xl font-semibold text-gray-900 dark:text-white">
+        {{ t('web.admin.system.title') }}
+      </h2>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.system.description') }}
+      </p>
+    </div>
+
+    <!-- ================= Database metrics ================= -->
+    <section
+      class="mb-8"
+      data-testid="system-database">
+      <h3 class="mb-3 text-lg font-medium text-gray-900 dark:text-white">
+        {{ t('web.admin.system.database.title', { engine: engineName }) }}
+      </h3>
+
+      <!-- Loading -->
+      <div
+        v-if="dbLoading && !db"
+        class="flex items-center gap-3 rounded-lg border border-gray-200 bg-white px-4 py-8 text-sm text-gray-500 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-400"
+        data-testid="system-database-loading">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          size="5"
+          class="animate-spin motion-reduce:animate-none" />
+        {{ t('web.COMMON.loading') }}
+      </div>
+
+      <!-- Error -->
+      <div
+        v-else-if="dbFailed"
+        class="flex items-center justify-between gap-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-900/20"
+        role="alert"
+        data-testid="system-database-error">
+        <span class="text-sm text-red-800 dark:text-red-200">
+          {{ t('web.admin.system.database.loadError') }}
+        </span>
+        <button
+          type="button"
+          class="inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/40"
+          @click="loadDb().catch(() => {})">
+          <OIcon
+            collection="heroicons"
+            name="arrow-path"
+            size="4" />
+          {{ t('web.admin.system.retry') }}
+        </button>
+      </div>
+
+      <!-- Loaded -->
+      <div
+        v-else-if="db"
+        class="space-y-4">
+        <!-- Model counts + server tiles -->
+        <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+          <StatCard
+            :label="t('web.admin.system.database.stats.customers')"
+            :value="num(db.model_counts.customers)"
+            icon="users"
+            testid="stat-customers" />
+          <StatCard
+            :label="t('web.admin.system.database.stats.secrets')"
+            :value="num(db.model_counts.secrets)"
+            icon="key"
+            testid="stat-secrets" />
+          <StatCard
+            :label="t('web.admin.system.database.stats.receipts')"
+            :value="num(db.model_counts.receipts)"
+            icon="receipt-percent"
+            testid="stat-receipts" />
+          <StatCard
+            :label="t('web.admin.system.database.stats.totalKeys')"
+            :value="num(db.total_keys)"
+            icon="circle-stack"
+            testid="stat-total-keys" />
+        </div>
+
+        <!-- Server info -->
+        <div
+          class="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <h4 class="mb-3 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.system.database.server') }}
+          </h4>
+          <dl class="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-3">
+            <div data-testid="server-version">
+              <dt class="text-xs text-gray-500 dark:text-gray-400">{{ t('web.admin.system.database.fields.version') }}</dt>
+              <dd class="mt-0.5 font-mono text-sm text-gray-900 dark:text-white">{{ engineVersion }}</dd>
+            </div>
+            <div>
+              <dt class="text-xs text-gray-500 dark:text-gray-400">{{ t('web.admin.system.database.fields.mode') }}</dt>
+              <dd class="mt-0.5 font-mono text-sm text-gray-900 dark:text-white">{{ db.redis_info.redis_mode ?? '—' }}</dd>
+            </div>
+            <div>
+              <dt class="text-xs text-gray-500 dark:text-gray-400">{{ t('web.admin.system.database.fields.uptimeDays') }}</dt>
+              <dd class="mt-0.5 font-mono text-sm text-gray-900 dark:text-white">{{ num(db.redis_info.uptime_in_days) }}</dd>
+            </div>
+            <div>
+              <dt class="text-xs text-gray-500 dark:text-gray-400">{{ t('web.admin.system.database.fields.connectedClients') }}</dt>
+              <dd class="mt-0.5 font-mono text-sm text-gray-900 dark:text-white">{{ num(db.redis_info.connected_clients) }}</dd>
+            </div>
+            <div>
+              <dt class="text-xs text-gray-500 dark:text-gray-400">{{ t('web.admin.system.database.fields.opsPerSec') }}</dt>
+              <dd class="mt-0.5 font-mono text-sm text-gray-900 dark:text-white">{{ num(db.redis_info.instantaneous_ops_per_sec) }}</dd>
+            </div>
+            <div>
+              <dt class="text-xs text-gray-500 dark:text-gray-400">{{ t('web.admin.system.database.fields.totalCommands') }}</dt>
+              <dd class="mt-0.5 font-mono text-sm text-gray-900 dark:text-white">{{ num(db.redis_info.total_commands_processed) }}</dd>
+            </div>
+          </dl>
+        </div>
+
+        <!-- Memory -->
+        <div
+          class="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <h4 class="mb-3 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.system.database.memory') }}
+          </h4>
+          <dl class="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4">
+            <div>
+              <dt class="text-xs text-gray-500 dark:text-gray-400">{{ t('web.admin.system.database.fields.usedMemory') }}</dt>
+              <dd class="mt-0.5 font-mono text-sm text-gray-900 dark:text-white">{{ db.memory_stats.used_memory_human }}</dd>
+            </div>
+            <div>
+              <dt class="text-xs text-gray-500 dark:text-gray-400">{{ t('web.admin.system.database.fields.rssMemory') }}</dt>
+              <dd class="mt-0.5 font-mono text-sm text-gray-900 dark:text-white">{{ db.memory_stats.used_memory_rss_human }}</dd>
+            </div>
+            <div>
+              <dt class="text-xs text-gray-500 dark:text-gray-400">{{ t('web.admin.system.database.fields.peakMemory') }}</dt>
+              <dd class="mt-0.5 font-mono text-sm text-gray-900 dark:text-white">{{ db.memory_stats.used_memory_peak_human }}</dd>
+            </div>
+            <div>
+              <dt class="text-xs text-gray-500 dark:text-gray-400">{{ t('web.admin.system.database.fields.fragmentation') }}</dt>
+              <dd class="mt-0.5 font-mono text-sm text-gray-900 dark:text-white">{{ db.memory_stats.mem_fragmentation_ratio.toFixed(2) }}</dd>
+            </div>
+          </dl>
+        </div>
+
+        <!-- Database sizes -->
+        <div
+          class="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+          data-testid="system-database-sizes">
+          <h4 class="mb-3 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.system.database.databases') }}
+          </h4>
+          <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            <div
+              v-for="row in databaseSizeRows"
+              :key="row.name"
+              class="rounded border border-gray-200 p-3 dark:border-gray-700">
+              <div class="font-mono text-sm font-semibold text-gray-900 dark:text-white">{{ row.name }}</div>
+              <div class="mt-1 text-xs text-gray-600 dark:text-gray-400">
+                <template v-if="row.raw === null">
+                  {{ t('web.admin.system.database.dbSummary', { keys: num(row.keys), expires: num(row.expires) }) }}
+                </template>
+                <template v-else>{{ row.raw }}</template>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ================= Queue status ================= -->
+    <section
+      class="mb-8"
+      data-testid="system-queue">
+      <h3 class="mb-3 text-lg font-medium text-gray-900 dark:text-white">
+        {{ t('web.admin.system.queue.title') }}
+      </h3>
+
+      <div
+        v-if="queueLoading && !queue"
+        class="flex items-center gap-3 rounded-lg border border-gray-200 bg-white px-4 py-8 text-sm text-gray-500 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-400"
+        data-testid="system-queue-loading">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          size="5"
+          class="animate-spin motion-reduce:animate-none" />
+        {{ t('web.COMMON.loading') }}
+      </div>
+
+      <div
+        v-else-if="queueFailed"
+        class="flex items-center justify-between gap-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-900/20"
+        role="alert"
+        data-testid="system-queue-error">
+        <span class="text-sm text-red-800 dark:text-red-200">
+          {{ t('web.admin.system.queue.loadError') }}
+        </span>
+        <button
+          type="button"
+          class="inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/40"
+          @click="loadQueue().catch(() => {})">
+          <OIcon
+            collection="heroicons"
+            name="arrow-path"
+            size="4" />
+          {{ t('web.admin.system.retry') }}
+        </button>
+      </div>
+
+      <div
+        v-else-if="queue"
+        class="space-y-4">
+        <!-- Connection + health summary -->
+        <div class="flex flex-wrap items-center gap-3">
+          <span
+            class="inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium"
+            :class="queue.connection.connected
+              ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200'
+              : 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200'"
+            data-testid="queue-connection">
+            <OIcon
+              collection="heroicons"
+              :name="queue.connection.connected ? 'check-circle' : 'x-circle'"
+              size="3" />
+            {{ queue.connection.connected
+              ? t('web.admin.system.queue.connected')
+              : t('web.admin.system.queue.disconnected') }}
+          </span>
+          <span
+            v-if="queue.connection.host"
+            class="font-mono text-xs text-gray-500 dark:text-gray-400">
+            {{ queue.connection.host }}
+          </span>
+          <span
+            class="inline-flex rounded px-2 py-0.5 text-xs font-medium"
+            :class="healthBadgeClass(queue.worker_health.status)"
+            data-testid="queue-health">
+            {{ t(`web.admin.system.queue.health.${queue.worker_health.status}`, queue.worker_health.status) }}
+          </span>
+          <span
+            v-if="queue.worker_health.active_workers !== undefined"
+            class="text-xs text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.system.queue.activeWorkers', { count: queue.worker_health.active_workers }) }}
+          </span>
+        </div>
+
+        <!-- Per-queue table -->
+        <div
+          class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <DataTable
+            :columns="queueColumns"
+            :rows="queue.queues"
+            row-key="name"
+            :empty-text="t('web.admin.system.queue.empty')"
+            testid="queue-table">
+            <template #cell-name="{ row }">
+              <span class="font-mono text-gray-900 dark:text-white">{{ row.name }}</span>
+            </template>
+            <template #cell-pending_messages="{ row }">
+              {{ num(row.pending_messages) }}
+            </template>
+            <template #cell-consumers="{ row }">
+              {{ num(row.consumers) }}
+            </template>
+          </DataTable>
+        </div>
+      </div>
+    </section>
+
+    <!-- ================= Redis / Valkey full INFO ================= -->
+    <section data-testid="system-redis">
+      <h3 class="mb-1 text-lg font-medium text-gray-900 dark:text-white">
+        {{ t('web.admin.system.redis.title') }}
+      </h3>
+      <p
+        v-if="redis"
+        class="mb-3 text-xs text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.system.redis.captured', { at: formatDisplayDateTime(redis.timestamp) }) }}
+      </p>
+
+      <div
+        v-if="redisLoading && !redis"
+        class="flex items-center gap-3 rounded-lg border border-gray-200 bg-white px-4 py-8 text-sm text-gray-500 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-400"
+        data-testid="system-redis-loading">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          size="5"
+          class="animate-spin motion-reduce:animate-none" />
+        {{ t('web.COMMON.loading') }}
+      </div>
+
+      <div
+        v-else-if="redisFailed"
+        class="flex items-center justify-between gap-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-900/20"
+        role="alert"
+        data-testid="system-redis-error">
+        <span class="text-sm text-red-800 dark:text-red-200">
+          {{ t('web.admin.system.redis.loadError') }}
+        </span>
+        <button
+          type="button"
+          class="inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/40"
+          @click="loadRedis().catch(() => {})">
+          <OIcon
+            collection="heroicons"
+            name="arrow-path"
+            size="4" />
+          {{ t('web.admin.system.retry') }}
+        </button>
+      </div>
+
+      <div
+        v-else-if="redis"
+        class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+        <JsonViewer
+          :data="redis.redis_info"
+          :expand-depth="1"
+          testid="system-redis-json" />
+      </div>
+    </section>
+  </div>
+</template>

--- a/src/apps/admin/views/AdminUsage.vue
+++ b/src/apps/admin/views/AdminUsage.vue
@@ -1,0 +1,315 @@
+<!-- src/apps/admin/views/AdminUsage.vue -->
+
+<script setup lang="ts">
+  import { computed, onMounted, ref } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  import { StatCard } from '@/apps/admin/components/kit';
+  import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
+  import { usageExportResponseSchema } from '@/schemas/api/internal/responses/colonel-usage';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+
+  /**
+   * Usage screen (ticket #33) — a read-only metrics read-out over a date range,
+   * the Phase-2 parity port of the legacy `ColonelUsageExport` view rebuilt on
+   * the Slice-3 template (no `src/apps/colonel/*` / `colonelInfoStore` imports).
+   *
+   * Single-GET read-out via {@link useResourceFetch} (CONTRACT 1 — single screens
+   * use useResourceFetch), REUSING the frozen `usageExportResponseSchema`
+   * (CONTRACT 3). The date range is passed as `start_date` / `end_date` Unix-second
+   * params; `load(params)` re-issues the request and `refresh()` repeats the last.
+   * Read-only: nothing here mutates, so nothing is audited (CONTRACT 4).
+   *
+   * Stub note (spec #33): backend usage counters that are stubbed at 0 upstream
+   * are surfaced as-is — this screen never fabricates numbers.
+   */
+  const { t } = useI18n();
+
+  const startDate = ref('');
+  const endDate = ref('');
+
+  const {
+    data: usageData,
+    loading,
+    error,
+    validationError,
+    load,
+  } = useResourceFetch({
+    url: '/api/colonel/usage/export',
+    schema: usageExportResponseSchema,
+    context: 'UsageExportResponse',
+  });
+
+  const usage = computed(() => usageData.value?.details ?? null);
+  const loadFailed = computed(() => error.value !== null || validationError.value !== null);
+
+  /** ISO yyyy-mm-dd for a Date, for the native date inputs. */
+  function toInputDate(date: Date): string {
+    return date.toISOString().split('T')[0];
+  }
+
+  function applyDefaultDates(): void {
+    const end = new Date();
+    const start = new Date();
+    start.setDate(start.getDate() - 30);
+    startDate.value = toInputDate(start);
+    endDate.value = toInputDate(end);
+  }
+
+  /** Fetch the export for the current date inputs (empty inputs → server default). */
+  function fetchUsage(): void {
+    const start = startDate.value
+      ? Math.floor(new Date(startDate.value).getTime() / 1000)
+      : undefined;
+    const end = endDate.value
+      ? Math.floor(new Date(endDate.value).getTime() / 1000)
+      : undefined;
+    load({ start_date: start, end_date: end }).catch(() => {});
+  }
+
+  // ---- Derived read-out rows ------------------------------------------------
+
+  type DayRow = { date: string; count: number };
+
+  function toSortedRows(map: Record<string, number> | undefined): DayRow[] {
+    if (!map) return [];
+    return Object.entries(map)
+      .map(([date, count]) => ({ date, count }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+  }
+
+  const secretsByDay = computed<DayRow[]>(() => toSortedRows(usage.value?.secrets_by_day));
+  const usersByDay = computed<DayRow[]>(() => toSortedRows(usage.value?.users_by_day));
+
+  const secretsByState = computed(() =>
+    Object.entries(usage.value?.usage_data.secrets_by_state ?? {})
+      .map(([state, count]) => ({ state, count }))
+      .sort((a, b) => b.count - a.count)
+  );
+
+  onMounted(() => {
+    applyDefaultDates();
+    fetchUsage();
+  });
+</script>
+
+<template>
+  <div class="mx-auto max-w-5xl">
+    <!-- Page header -->
+    <div class="mb-6">
+      <h2 class="font-brand text-2xl font-semibold text-gray-900 dark:text-white">
+        {{ t('web.admin.usage.title') }}
+      </h2>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.usage.description') }}
+      </p>
+    </div>
+
+    <!-- Date-range selector -->
+    <div
+      class="mb-6 rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+      data-testid="usage-range">
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div>
+          <label
+            for="usage-start"
+            class="mb-1 block text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.usage.startDate') }}
+          </label>
+          <input
+            id="usage-start"
+            v-model="startDate"
+            type="date"
+            data-testid="usage-start"
+            class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+        </div>
+        <div>
+          <label
+            for="usage-end"
+            class="mb-1 block text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.usage.endDate') }}
+          </label>
+          <input
+            id="usage-end"
+            v-model="endDate"
+            type="date"
+            data-testid="usage-end"
+            class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+        </div>
+        <div class="flex items-end">
+          <button
+            type="button"
+            data-testid="usage-fetch"
+            :disabled="loading"
+            class="inline-flex w-full items-center justify-center gap-1 rounded-md bg-brand-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-brand-500 dark:hover:bg-brand-600"
+            @click="fetchUsage">
+            <OIcon
+              v-if="loading"
+              collection="heroicons"
+              name="arrow-path"
+              size="4"
+              class="animate-spin motion-reduce:animate-none" />
+            {{ loading ? t('web.COMMON.loading') : t('web.admin.usage.fetch') }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Error -->
+    <div
+      v-if="loadFailed"
+      class="mb-4 flex items-center justify-between gap-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-900/20"
+      role="alert"
+      data-testid="usage-error">
+      <span class="text-sm text-red-800 dark:text-red-200">
+        {{ t('web.admin.usage.loadError') }}
+      </span>
+      <button
+        type="button"
+        class="inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/40"
+        @click="fetchUsage">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          size="4" />
+        {{ t('web.admin.usage.retry') }}
+      </button>
+    </div>
+
+    <!-- Loaded -->
+    <div
+      v-if="usage"
+      class="space-y-6"
+      data-testid="usage-content">
+      <!-- Summary tiles -->
+      <div class="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StatCard
+          :label="t('web.admin.usage.stats.totalSecrets')"
+          :value="usage.usage_data.total_secrets.toLocaleString()"
+          icon="key"
+          testid="usage-total-secrets" />
+        <StatCard
+          :label="t('web.admin.usage.stats.newUsers')"
+          :value="usage.usage_data.total_new_users.toLocaleString()"
+          icon="user-plus"
+          testid="usage-new-users" />
+        <StatCard
+          :label="t('web.admin.usage.stats.avgSecrets')"
+          :value="usage.usage_data.avg_secrets_per_day.toFixed(1)"
+          testid="usage-avg-secrets" />
+        <StatCard
+          :label="t('web.admin.usage.stats.avgUsers')"
+          :value="usage.usage_data.avg_users_per_day.toFixed(1)"
+          testid="usage-avg-users" />
+      </div>
+
+      <!-- Secrets by state -->
+      <section
+        v-if="secretsByState.length > 0"
+        class="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+        data-testid="usage-by-state">
+        <h3 class="mb-3 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+          {{ t('web.admin.usage.byState') }}
+        </h3>
+        <div class="flex flex-wrap gap-2">
+          <span
+            v-for="row in secretsByState"
+            :key="row.state"
+            class="inline-flex items-center gap-1.5 rounded bg-gray-100 px-2.5 py-1 text-sm text-gray-700 dark:bg-gray-800 dark:text-gray-300">
+            <span class="font-mono">{{ row.state }}</span>
+            <span class="font-semibold text-gray-900 dark:text-white">{{ row.count.toLocaleString() }}</span>
+          </span>
+        </div>
+      </section>
+
+      <!-- Daily breakdowns -->
+      <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <!-- Secrets by day -->
+        <section
+          class="rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <div class="border-b border-gray-200 px-5 py-3 dark:border-gray-800">
+            <h3 class="text-sm font-medium text-gray-900 dark:text-white">
+              {{ t('web.admin.usage.secretsByDay') }}
+            </h3>
+          </div>
+          <div class="max-h-96 overflow-y-auto">
+            <table class="min-w-full">
+              <thead class="sticky top-0 bg-gray-50 dark:bg-gray-800">
+                <tr>
+                  <th class="px-5 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400">
+                    {{ t('web.admin.usage.columns.date') }}
+                  </th>
+                  <th class="px-5 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400">
+                    {{ t('web.admin.usage.columns.count') }}
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="divide-y divide-gray-200 dark:divide-gray-800"
+                data-testid="usage-secrets-by-day">
+                <tr v-if="secretsByDay.length === 0">
+                  <td
+                    colspan="2"
+                    class="px-5 py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+                    {{ t('web.admin.usage.empty') }}
+                  </td>
+                </tr>
+                <tr
+                  v-for="row in secretsByDay"
+                  :key="row.date">
+                  <td class="px-5 py-1.5 text-sm text-gray-900 dark:text-white">{{ row.date }}</td>
+                  <td class="px-5 py-1.5 text-right font-mono text-sm text-gray-900 dark:text-white">
+                    {{ row.count.toLocaleString() }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <!-- New users by day -->
+        <section
+          class="rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <div class="border-b border-gray-200 px-5 py-3 dark:border-gray-800">
+            <h3 class="text-sm font-medium text-gray-900 dark:text-white">
+              {{ t('web.admin.usage.usersByDay') }}
+            </h3>
+          </div>
+          <div class="max-h-96 overflow-y-auto">
+            <table class="min-w-full">
+              <thead class="sticky top-0 bg-gray-50 dark:bg-gray-800">
+                <tr>
+                  <th class="px-5 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400">
+                    {{ t('web.admin.usage.columns.date') }}
+                  </th>
+                  <th class="px-5 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400">
+                    {{ t('web.admin.usage.columns.count') }}
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="divide-y divide-gray-200 dark:divide-gray-800"
+                data-testid="usage-users-by-day">
+                <tr v-if="usersByDay.length === 0">
+                  <td
+                    colspan="2"
+                    class="px-5 py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+                    {{ t('web.admin.usage.empty') }}
+                  </td>
+                </tr>
+                <tr
+                  v-for="row in usersByDay"
+                  :key="row.date">
+                  <td class="px-5 py-1.5 text-sm text-gray-900 dark:text-white">{{ row.date }}</td>
+                  <td class="px-5 py-1.5 text-right font-mono text-sm text-gray-900 dark:text-white">
+                    {{ row.count.toLocaleString() }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/schemas/api/account/responses/colonel-bannedips.ts
+++ b/src/schemas/api/account/responses/colonel-bannedips.ts
@@ -1,0 +1,65 @@
+// src/schemas/api/account/responses/colonel-bannedips.ts
+//
+// Colonel (Admin) banned-IPs — NEW ban/unban ACK schemas (ticket #33).
+//
+// The banned-IPs LIST read side already has frozen schemas (`bannedIPSchema` /
+// `bannedIPsDetailsSchema` in `./colonel` + `bannedIPsResponseSchema` in
+// `../../internal/responses/colonel`); the BannedIPs screen REUSES those
+// (CONTRACT 3 — reuse over duplication). This file adds ONLY the two shapes that
+// had no frontend schema: the guarded ban + unban acks. Kept in a per-resource
+// file so this screen never edits another screen's contract (CONTRACT 2 / the
+// Zod tripwire — new schemas only).
+//
+// Shapes verified against the live logic classes
+// (apps/api/colonel/logic/colonel/ban_ip.rb, unban_ip.rb): `banned_at` is a bare
+// Unix-epoch number (mirroring the frozen `bannedIPSchema`, NOT transformed to
+// Date), and the mutating endpoints echo a `record` + `details.message` envelope.
+
+import { z } from 'zod';
+
+// ============================================================================
+// BanIP — guarded ban ack (POST /api/colonel/banned-ips)
+// ============================================================================
+
+/**
+ * The created ban record (BanIP `record`). Mirrors {@link bannedIPSchema}, minus
+ * transforms: `banned_at` stays a number (seconds). `banned_by` is whatever the
+ * op stored (the acting colonel's objid from the UI path, or `cli` from the
+ * shell) and is display-only.
+ */
+export const colonelBanIpRecordSchema = z.object({
+  id: z.string(),
+  ip_address: z.string(),
+  reason: z.string().nullable(),
+  banned_by: z.string().nullable(),
+  banned_at: z.number(),
+});
+
+/** BanIP `details`: a human-readable ack message. */
+export const colonelBanIpDetailsSchema = z.object({
+  message: z.string(),
+});
+
+// ============================================================================
+// UnbanIP — guarded unban ack (DELETE /api/colonel/banned-ips/:ip)
+// ============================================================================
+
+/** The unban confirmation (UnbanIP `record`). */
+export const colonelUnbanIpRecordSchema = z.object({
+  ip_address: z.string(),
+  unbanned: z.boolean(),
+});
+
+/** UnbanIP `details`: a human-readable ack message. */
+export const colonelUnbanIpDetailsSchema = z.object({
+  message: z.string(),
+});
+
+// ============================================================================
+// Type Exports
+// ============================================================================
+
+export type ColonelBanIpRecord = z.infer<typeof colonelBanIpRecordSchema>;
+export type ColonelBanIpDetails = z.infer<typeof colonelBanIpDetailsSchema>;
+export type ColonelUnbanIpRecord = z.infer<typeof colonelUnbanIpRecordSchema>;
+export type ColonelUnbanIpDetails = z.infer<typeof colonelUnbanIpDetailsSchema>;

--- a/src/schemas/api/account/responses/colonel-domains.ts
+++ b/src/schemas/api/account/responses/colonel-domains.ts
@@ -1,0 +1,59 @@
+// src/schemas/api/account/responses/colonel-domains.ts
+
+/**
+ * Colonel (Admin) domains — NEW verify-endpoint schemas (ticket #31).
+ *
+ * The domains LIST read side already has frozen schemas
+ * (`colonelCustomDomainSchema` / `colonelCustomDomainsResponseSchema` in
+ * `./colonel` + `../../internal/responses/colonel`); the domains screen REUSES
+ * those (CONTRACT 3 — reuse over duplication). This file adds ONLY the schemas
+ * for the NEW `POST /api/colonel/domains/:extid/verify` endpoint, kept in a
+ * per-resource file so the domains screen never edits another screen's contract
+ * (CONTRACT 2 / the Zod tripwire — new schemas only).
+ *
+ * These describe the SHAPE the new colonel logic class
+ * (`ColonelAPI::Logic::Colonel::VerifyCustomDomain`) returns: the refreshed
+ * domain `record` plus the honest verification outcome in `details`. The verify
+ * op reports real DNS/SSL state, so `current_state` is authoritative and the
+ * screen surfaces it verbatim (verified / resolving / pending / unverified) —
+ * it never fakes success.
+ */
+
+import { transforms } from '@/schemas/transforms';
+import { z } from 'zod';
+
+/**
+ * Refreshed domain record after a verify. A minimal slice — just what the card
+ * needs to re-render its badge/flags without a full list re-fetch. Fields mirror
+ * their counterparts on {@link colonelCustomDomainSchema}. `updated` arrives as a
+ * Unix-epoch number and is coerced to Date (nullable).
+ */
+export const colonelDomainVerifyRecordSchema = z.object({
+  domain_id: z.string(),
+  extid: z.string(),
+  display_domain: z.string(),
+  verification_state: z.string(),
+  verified: z.boolean(),
+  resolving: z.boolean(),
+  ready: z.boolean(),
+  updated: transforms.fromNumber.toDateNullable,
+});
+
+/**
+ * The verify outcome. `current_state` is the post-verification state and drives
+ * the operator-facing notification. `error` is the op's captured DNS/SSL error
+ * message (or null on a clean run) — surfaced honestly rather than swallowed.
+ */
+export const colonelDomainVerifyDetailsSchema = z.object({
+  previous_state: z.string(),
+  current_state: z.string(),
+  changed: z.boolean(),
+  dns_validated: z.boolean(),
+  ssl_ready: z.boolean(),
+  is_resolving: z.boolean(),
+  error: z.string().nullable(),
+  message: z.string(),
+});
+
+export type ColonelDomainVerifyRecord = z.infer<typeof colonelDomainVerifyRecordSchema>;
+export type ColonelDomainVerifyDetails = z.infer<typeof colonelDomainVerifyDetailsSchema>;

--- a/src/schemas/api/account/responses/colonel-organizations.ts
+++ b/src/schemas/api/account/responses/colonel-organizations.ts
@@ -1,0 +1,50 @@
+// src/schemas/api/account/responses/colonel-organizations.ts
+
+/**
+ * Colonel (Admin) organizations — NEW entitlement-override ack schema (ticket #32).
+ *
+ * The organizations LIST and the billing-INVESTIGATE read sides already have
+ * frozen schemas in `./colonel` (`colonelOrganizationSchema` /
+ * `colonelOrganizationsDetailsSchema` and `investigateOrganizationResultSchema`),
+ * wrapped in `../../internal/responses/colonel`
+ * (`colonelOrganizationsResponseSchema` / `investigateOrganizationResponseSchema`).
+ * The organizations screen REUSES those (CONTRACT 3 — reuse over duplication) and
+ * does NOT redefine them here.
+ *
+ * This file adds ONLY the schema for the entitlement-override MUTATION endpoints,
+ * which had no frontend contract until this screen surfaced them:
+ *   POST   /api/colonel/organizations/:org_id/entitlements/grant
+ *   POST   /api/colonel/organizations/:org_id/entitlements/revoke
+ *   DELETE /api/colonel/organizations/:org_id/entitlements/overrides
+ *
+ * It describes the SHAPE `ColonelAPI::Logic::Colonel::ManageEntitlementOverride`
+ * returns: the org's PUBLIC id, the affected entitlement (null on a full clear),
+ * the past-tense action, and the recomputed override state
+ * (effective = plan_entitlements + grants - revokes). Kept in a per-resource file
+ * so the organizations screen never edits another screen's contract (CONTRACT 2 /
+ * the Zod tripwire — new schemas only).
+ */
+
+import { z } from 'zod';
+
+/**
+ * The recomputed entitlement-override state after a grant / revoke / clear.
+ *
+ * `entitlement` is the single entitlement acted on for grant/revoke and is null
+ * for a full clear (the endpoint sends `null`, and older acks may omit the key).
+ * `action` is the past-tense verb the backend emits (`ACTION_PAST_TENSE`).
+ * `effective_entitlements` is the materialised result the org now resolves to.
+ */
+export const colonelEntitlementOverrideRecordSchema = z.object({
+  org_id: z.string(),
+  extid: z.string(),
+  entitlement: z.string().nullable().optional(),
+  action: z.enum(['granted', 'revoked', 'cleared']),
+  effective_entitlements: z.array(z.string()),
+  grants: z.array(z.string()),
+  revokes: z.array(z.string()),
+});
+
+export type ColonelEntitlementOverrideRecord = z.infer<
+  typeof colonelEntitlementOverrideRecordSchema
+>;

--- a/src/schemas/api/account/responses/colonel-secrets.ts
+++ b/src/schemas/api/account/responses/colonel-secrets.ts
@@ -1,0 +1,127 @@
+// src/schemas/api/account/responses/colonel-secrets.ts
+//
+// Per-resource colonel/admin schemas for the Secrets screen (ticket #30).
+//
+// NEW schemas only — the frozen colonel contracts in ./colonel.ts are untouched
+// (the Zod tripwire, epic non-goal). The secrets LIST reuses the existing
+// `colonelSecretsResponseSchema` / `colonelSecretSchema` from ./colonel.ts; this
+// file adds only the two shapes that had no frontend schema yet:
+//
+//   - GetSecretReceipt → GET    /api/colonel/secrets/:secret_id  (receipt drawer)
+//   - DeleteSecret     → DELETE /api/colonel/secrets/:secret_id  (guarded delete ack)
+//
+// Shapes verified against the live logic classes
+// (apps/api/colonel/logic/colonel/get_secret_receipt.rb, delete_secret.rb):
+// timestamps arrive as Unix-epoch numbers and are transformed to Date, mirroring
+// the existing `colonelSecretSchema`.
+
+import { transforms } from '@/schemas/transforms';
+import { z } from 'zod';
+
+// ============================================================================
+// GetSecretReceipt — receipt/detail drawer
+// ============================================================================
+
+/**
+ * The core secret record on the receipt drawer (GetSecretReceipt `record`).
+ * `secret_id` is the secret's objid (the id used for routing + delete);
+ * `shortid` is the human-facing short id shown in the list. No ciphertext is
+ * ever transmitted — only `has_ciphertext` + `ciphertext_length`.
+ */
+export const colonelSecretReceiptRecordSchema = z.object({
+  secret_id: z.string(),
+  shortid: z.string(),
+  state: z.string(),
+  lifespan: z.number().nullable(),
+  created: transforms.fromNumber.toDate,
+  updated: transforms.fromNumber.toDateNullable,
+  expiration: transforms.fromNumber.toDateNullable,
+  age: z.number(),
+  owner_id: z.string().nullable(),
+  receipt_id: z.string().nullable(),
+  has_ciphertext: z.boolean(),
+  ciphertext_length: z.number(),
+});
+
+/**
+ * Associated receipt metadata (GetSecretReceipt `details.metadata`). Null when
+ * the secret has no receipt (`receipt_identifier` unset). `secret_ttl` is a
+ * Familia field that may arrive as a string or number; `recipients` may be a
+ * plain string or an array depending on how the receipt was created — both are
+ * accepted so a data-drift edge never crashes a read-only inspector.
+ */
+export const colonelSecretReceiptMetadataSchema = z.object({
+  receipt_id: z.string(),
+  shortid: z.string(),
+  state: z.string(),
+  secret_ttl: z.union([z.number(), z.string()]).nullable(),
+  recipients: z.union([z.array(z.string()), z.string()]).nullable(),
+  has_passphrase: z.boolean(),
+  share_domain: z.string().nullable(),
+  created: transforms.fromNumber.toDate,
+  secret_expired: z.boolean(),
+});
+
+/**
+ * Owner read-out (GetSecretReceipt `details.owner`). Null for anonymous secrets
+ * (`owner_id` == 'anon' / unset). `email` is the OBSCURED email; `user_id` is
+ * the owner's objid.
+ */
+export const colonelSecretReceiptOwnerSchema = z.object({
+  user_id: z.string(),
+  email: z.string(),
+  role: z.string(),
+  verified: z.boolean(),
+});
+
+/** The `details` payload of GetSecretReceipt: receipt metadata + owner. */
+export const colonelSecretReceiptDetailsSchema = z.object({
+  metadata: colonelSecretReceiptMetadataSchema.nullable(),
+  owner: colonelSecretReceiptOwnerSchema.nullable(),
+});
+
+// ============================================================================
+// DeleteSecret — guarded delete ack
+// ============================================================================
+
+/** The deleted secret summary (DeleteSecret `record.secret`). */
+export const colonelSecretDeleteSecretSchema = z.object({
+  secret_id: z.string(),
+  shortid: z.string(),
+  state: z.string(),
+  owner_id: z.string().nullable(),
+});
+
+/** The deleted receipt summary (DeleteSecret `record.metadata`), null if none. */
+export const colonelSecretDeleteMetadataSchema = z.object({
+  receipt_id: z.string(),
+  shortid: z.string(),
+});
+
+/**
+ * DeleteSecret `record`: a delete confirmation carrying the destroyed secret's
+ * public identity + the associated receipt (when one existed). The UI treats a
+ * 2xx as success and refreshes the list, so this schema is a live tripwire
+ * rather than a routing source.
+ */
+export const colonelSecretDeleteRecordSchema = z.object({
+  deleted: z.boolean(),
+  secret: colonelSecretDeleteSecretSchema,
+  metadata: colonelSecretDeleteMetadataSchema.nullable(),
+});
+
+/** DeleteSecret `details`: a human-readable ack message. */
+export const colonelSecretDeleteDetailsSchema = z.object({
+  message: z.string(),
+});
+
+// ============================================================================
+// Type Exports
+// ============================================================================
+
+export type ColonelSecretReceiptRecord = z.infer<typeof colonelSecretReceiptRecordSchema>;
+export type ColonelSecretReceiptMetadata = z.infer<typeof colonelSecretReceiptMetadataSchema>;
+export type ColonelSecretReceiptOwner = z.infer<typeof colonelSecretReceiptOwnerSchema>;
+export type ColonelSecretReceiptDetails = z.infer<typeof colonelSecretReceiptDetailsSchema>;
+export type ColonelSecretDeleteRecord = z.infer<typeof colonelSecretDeleteRecordSchema>;
+export type ColonelSecretDeleteDetails = z.infer<typeof colonelSecretDeleteDetailsSchema>;

--- a/src/schemas/api/internal/responses/colonel-bannedips.ts
+++ b/src/schemas/api/internal/responses/colonel-bannedips.ts
@@ -1,0 +1,42 @@
+// src/schemas/api/internal/responses/colonel-bannedips.ts
+//
+// Wrapped response schemas for the colonel BannedIPs screen (ticket #33).
+// Internal-only; consumed by the Vue admin console, never exposed publicly.
+//
+// The banned-IPs LIST reuses the existing `bannedIPsResponseSchema` from
+// ./colonel (re-exported here so the view has a single per-resource import
+// surface — CONTRACT 3, reuse not duplicate). This file WRAPS only the two new
+// single-record envelopes: the guarded ban + unban acks.
+//
+// The view imports these DIRECTLY (CONTRACT 3) so it typechecks independently of
+// the registry; the Integrate step adds the registry keys from wiringInstructions.
+
+import { createApiResponseSchema } from '@/schemas/api/base';
+import {
+  colonelBanIpRecordSchema,
+  colonelBanIpDetailsSchema,
+  colonelUnbanIpRecordSchema,
+  colonelUnbanIpDetailsSchema,
+} from '@/schemas/api/account/responses/colonel-bannedips';
+import { z } from 'zod';
+
+// Re-export the REUSED list schema so the BannedIPs view imports every banned-IP
+// contract from this one per-resource file (the schema itself lives in ./colonel
+// and is untouched — the Zod tripwire).
+export { bannedIPsResponseSchema } from './colonel';
+export type { BannedIPsResponse } from './colonel';
+
+// POST /api/colonel/banned-ips → BanIP
+export const colonelBanIpResponseSchema = createApiResponseSchema(
+  colonelBanIpRecordSchema,
+  colonelBanIpDetailsSchema
+);
+
+// DELETE /api/colonel/banned-ips/:ip → UnbanIP
+export const colonelUnbanIpResponseSchema = createApiResponseSchema(
+  colonelUnbanIpRecordSchema,
+  colonelUnbanIpDetailsSchema
+);
+
+export type ColonelBanIpResponse = z.infer<typeof colonelBanIpResponseSchema>;
+export type ColonelUnbanIpResponse = z.infer<typeof colonelUnbanIpResponseSchema>;

--- a/src/schemas/api/internal/responses/colonel-domains.ts
+++ b/src/schemas/api/internal/responses/colonel-domains.ts
@@ -1,0 +1,25 @@
+// src/schemas/api/internal/responses/colonel-domains.ts
+//
+// Wrapped response schema for the NEW colonel domain-verify endpoint (ticket
+// #31). Internal-only; consumed by the Vue admin bundle. Per-resource file so
+// the domains screen typechecks independently of the shared registry (CONTRACT
+// 3) and never touches another screen's contract. The Integrate step adds the
+// matching `colonelDomainVerify` key to `registry.ts`.
+//
+// The domains LIST read schema (`colonelCustomDomainsResponseSchema`) is REUSED
+// from `./colonel`, not redefined here.
+
+import {
+  colonelDomainVerifyRecordSchema,
+  colonelDomainVerifyDetailsSchema,
+} from '@/schemas/api/account/responses/colonel-domains';
+import { createApiResponseSchema } from '@/schemas/api/base';
+import { z } from 'zod';
+
+/** `POST /api/colonel/domains/:extid/verify` → `{ record, details }` ack. */
+export const colonelDomainVerifyResponseSchema = createApiResponseSchema(
+  colonelDomainVerifyRecordSchema,
+  colonelDomainVerifyDetailsSchema
+);
+
+export type ColonelDomainVerifyResponse = z.infer<typeof colonelDomainVerifyResponseSchema>;

--- a/src/schemas/api/internal/responses/colonel-organizations.ts
+++ b/src/schemas/api/internal/responses/colonel-organizations.ts
@@ -1,0 +1,31 @@
+// src/schemas/api/internal/responses/colonel-organizations.ts
+//
+// Wrapped response schema for the NEW colonel entitlement-override endpoints
+// (ticket #32). Internal-only; consumed by the Vue admin bundle. Per-resource
+// file so the organizations screen typechecks independently of the shared
+// registry (CONTRACT 3) and never touches another screen's contract. The
+// Integrate step adds the matching `colonelEntitlementOverride` key to
+// `registry.ts`.
+//
+// The organizations LIST (`colonelOrganizationsResponseSchema`) and the
+// billing-INVESTIGATE (`investigateOrganizationResponseSchema`) read schemas are
+// REUSED from `./colonel`, not redefined here (CONTRACT 3 — reuse over
+// duplication).
+
+import { colonelEntitlementOverrideRecordSchema } from '@/schemas/api/account/responses/colonel-organizations';
+import { createApiResponseSchema } from '@/schemas/api/base';
+import { z } from 'zod';
+
+/**
+ * `POST /api/colonel/organizations/:org_id/entitlements/:action` and
+ * `DELETE /api/colonel/organizations/:org_id/entitlements/overrides` →
+ * `{ record }` ack. `ManageEntitlementOverride` returns only `record` (no
+ * `details`), which `createApiResponseSchema` already makes optional.
+ */
+export const colonelEntitlementOverrideResponseSchema = createApiResponseSchema(
+  colonelEntitlementOverrideRecordSchema
+);
+
+export type ColonelEntitlementOverrideResponse = z.infer<
+  typeof colonelEntitlementOverrideResponseSchema
+>;

--- a/src/schemas/api/internal/responses/colonel-secrets.ts
+++ b/src/schemas/api/internal/responses/colonel-secrets.ts
@@ -1,0 +1,35 @@
+// src/schemas/api/internal/responses/colonel-secrets.ts
+//
+// Wrapped response schemas for the colonel Secrets screen (ticket #30).
+// Internal-only; consumed by the Vue admin console, never exposed publicly.
+//
+// The secrets LIST reuses the existing `colonelSecretsResponseSchema` from
+// ./colonel.ts (imported by useAdminSecrets). This file wraps ONLY the two
+// new single-record envelopes: the receipt drawer + the guarded-delete ack.
+//
+// The view imports these DIRECTLY (CONTRACT 3) so it typechecks independently of
+// the registry; the Integrate step adds the registry keys from wiringInstructions.
+
+import { createApiResponseSchema } from '@/schemas/api/base';
+import {
+  colonelSecretReceiptRecordSchema,
+  colonelSecretReceiptDetailsSchema,
+  colonelSecretDeleteRecordSchema,
+  colonelSecretDeleteDetailsSchema,
+} from '@/schemas/api/account/responses/colonel-secrets';
+import { z } from 'zod';
+
+// GET /api/colonel/secrets/:secret_id → GetSecretReceipt
+export const colonelSecretReceiptResponseSchema = createApiResponseSchema(
+  colonelSecretReceiptRecordSchema,
+  colonelSecretReceiptDetailsSchema
+);
+
+// DELETE /api/colonel/secrets/:secret_id → DeleteSecret
+export const colonelSecretDeleteResponseSchema = createApiResponseSchema(
+  colonelSecretDeleteRecordSchema,
+  colonelSecretDeleteDetailsSchema
+);
+
+export type ColonelSecretReceiptResponse = z.infer<typeof colonelSecretReceiptResponseSchema>;
+export type ColonelSecretDeleteResponse = z.infer<typeof colonelSecretDeleteResponseSchema>;

--- a/src/schemas/api/internal/responses/colonel-system.ts
+++ b/src/schemas/api/internal/responses/colonel-system.ts
@@ -1,0 +1,27 @@
+// src/schemas/api/internal/responses/colonel-system.ts
+//
+// Per-resource schema surface for the colonel System screen (ticket #33).
+// Internal-only; consumed by the Vue admin console.
+//
+// The System screen is a READ-ONLY status/info read-out over three endpoints
+// that ALREADY have frozen response schemas in ./colonel:
+//   - GET /api/colonel/system/database → databaseMetricsResponseSchema
+//   - GET /api/colonel/system/redis    → redisMetricsResponseSchema
+//   - GET /api/colonel/queue           → queueMetricsResponseSchema
+//
+// Per CONTRACT 3 (the Zod tripwire) those contracts are REUSED, never
+// duplicated. This file merely RE-EXPORTS them so the System view imports every
+// system contract from one per-resource module and typechecks independently of
+// the registry — the schemas themselves live in ./colonel and are untouched.
+
+export {
+  databaseMetricsResponseSchema,
+  redisMetricsResponseSchema,
+  queueMetricsResponseSchema,
+} from './colonel';
+
+export type {
+  DatabaseMetricsResponse,
+  RedisMetricsResponse,
+  QueueMetricsResponse,
+} from './colonel';

--- a/src/schemas/api/internal/responses/colonel-usage.ts
+++ b/src/schemas/api/internal/responses/colonel-usage.ts
@@ -1,0 +1,16 @@
+// src/schemas/api/internal/responses/colonel-usage.ts
+//
+// Per-resource schema surface for the colonel Usage screen (ticket #33).
+// Internal-only; consumed by the Vue admin console.
+//
+// The Usage screen is a READ-ONLY metrics read-out over one endpoint that
+// ALREADY has a frozen response schema in ./colonel:
+//   - GET /api/colonel/usage/export → usageExportResponseSchema
+//
+// Per CONTRACT 3 (the Zod tripwire) that contract is REUSED, never duplicated.
+// This file RE-EXPORTS it so the Usage view imports from one per-resource module
+// and typechecks independently of the registry — the schema itself lives in
+// ./colonel and is untouched.
+
+export { usageExportResponseSchema } from './colonel';
+export type { UsageExportResponse } from './colonel';

--- a/src/schemas/api/internal/responses/registry.ts
+++ b/src/schemas/api/internal/responses/registry.ts
@@ -27,6 +27,18 @@ import {
   colonelUserMutationResponseSchema,
 } from './colonel';
 
+// Colonel (admin) per-resource ack schemas — Phase-2 screens (tickets #30-33)
+import {
+  colonelSecretReceiptResponseSchema,
+  colonelSecretDeleteResponseSchema,
+} from './colonel-secrets';
+import { colonelDomainVerifyResponseSchema } from './colonel-domains';
+import { colonelEntitlementOverrideResponseSchema } from './colonel-organizations';
+import {
+  colonelBanIpResponseSchema,
+  colonelUnbanIpResponseSchema,
+} from './colonel-bannedips';
+
 // Organization schemas — internal-only
 import {
   organizationResponseSchema,
@@ -82,12 +94,18 @@ export const responseSchemas = {
   colonelUserDetail: colonelUserDetailResponseSchema,
   colonelUserMutation: colonelUserMutationResponseSchema,
   colonelSecrets: colonelSecretsResponseSchema,
+  colonelSecretReceipt: colonelSecretReceiptResponseSchema,
+  colonelSecretDelete: colonelSecretDeleteResponseSchema,
   customDomains: colonelCustomDomainsResponseSchema,
+  colonelDomainVerify: colonelDomainVerifyResponseSchema,
   colonelOrganizations: colonelOrganizationsResponseSchema,
   investigateOrganization: investigateOrganizationResponseSchema,
+  colonelEntitlementOverride: colonelEntitlementOverrideResponseSchema,
   databaseMetrics: databaseMetricsResponseSchema,
   redisMetrics: redisMetricsResponseSchema,
   bannedIPs: bannedIPsResponseSchema,
+  colonelBanIp: colonelBanIpResponseSchema,
+  colonelUnbanIp: colonelUnbanIpResponseSchema,
   usageExport: usageExportResponseSchema,
   queueMetrics: queueMetricsResponseSchema,
   systemSettings: systemSettingsResponseSchema,

--- a/src/tests/apps/admin/AdminBannedIps.spec.ts
+++ b/src/tests/apps/admin/AdminBannedIps.spec.ts
@@ -1,0 +1,286 @@
+// src/tests/apps/admin/AdminBannedIps.spec.ts
+
+import { AxiosError } from 'axios';
+import { createPinia, setActivePinia } from 'pinia';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/** Build a real AxiosError so the shared classifier extracts `data.error`. */
+function axiosError(status: number, data: unknown, message = 'Request failed'): AxiosError {
+  const err = new AxiosError(message);
+  err.response = { status, data, statusText: '', headers: {}, config: {} as never };
+  return err;
+}
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+const showMock = vi.fn();
+vi.mock('@/shared/stores/notificationsStore', () => ({
+  useNotificationsStore: () => ({ show: showMock }),
+}));
+
+vi.mock('@/utils/format', () => ({
+  formatDisplayDateTime: (d: Date) => `DT:${d.toISOString()}`,
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+// Render the HeadlessUI dialog markup synchronously (mirrors AdminSecrets.spec).
+vi.mock('@headlessui/vue', () => ({
+  Dialog: {
+    name: 'Dialog',
+    template: '<div role="dialog" @close="$emit(\'close\')"><slot /></div>',
+    props: ['class'],
+    emits: ['close'],
+  },
+  DialogPanel: {
+    name: 'DialogPanel',
+    template: '<div class="dialog-panel" :data-testid="$attrs[\'data-testid\']"><slot /></div>',
+    props: ['class'],
+  },
+  DialogTitle: { name: 'DialogTitle', template: '<h3><slot /></h3>', props: ['as', 'class'] },
+  TransitionRoot: {
+    name: 'TransitionRoot',
+    template: '<div v-if="show"><slot /></div>',
+    props: ['as', 'show'],
+  },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>', props: ['as'] },
+}));
+
+import AdminBannedIps from '@/apps/admin/views/AdminBannedIps.vue';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+const LIST_URL = '/api/colonel/banned-ips';
+const EXISTING_IP = '203.0.113.4';
+const NEW_IP = '198.51.100.7';
+
+function bannedIpsPayload(rows = [bannedIpRow()]) {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      current_ip: '203.0.113.9',
+      banned_ips: rows,
+      total_count: rows.length,
+    },
+  };
+}
+
+function bannedIpRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'bip1',
+    ip_address: EXISTING_IP,
+    reason: 'abuse',
+    banned_by: 'objid_colonel',
+    banned_at: 1700000000,
+    ...overrides,
+  };
+}
+
+function banAck() {
+  return {
+    shrimp: '',
+    record: {
+      id: 'bip2',
+      ip_address: NEW_IP,
+      reason: 'credential stuffing',
+      banned_by: 'objid_colonel',
+      banned_at: 1700000100,
+    },
+    details: { message: 'IP address banned successfully' },
+  };
+}
+
+function unbanAck() {
+  return {
+    shrimp: '',
+    record: { ip_address: EXISTING_IP, unbanned: true },
+    details: { message: 'IP address unbanned successfully' },
+  };
+}
+
+const mountView = (pinia: ReturnType<typeof createPinia>) =>
+  mount(AdminBannedIps, { global: { plugins: [pinia, i18n] } });
+
+const dialogInput = (w: VueWrapper) => w.find('#admin-confirm-input');
+const dialogSubmit = (w: VueWrapper) => w.find('[data-testid="admin-confirm-submit"]');
+const listGetCount = () => mockApi.get.mock.calls.filter((c) => c[0] === LIST_URL).length;
+
+describe('AdminBannedIps (list + guarded ban/unban — ticket #33)', () => {
+  let wrapper: VueWrapper;
+  let pinia: ReturnType<typeof createPinia>;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+  });
+  afterEach(() => wrapper?.unmount());
+
+  // ---- List -----------------------------------------------------------------
+
+  it('fetches the banned-IP index on mount and renders a row per ban', async () => {
+    mockApi.get.mockResolvedValue({ data: bannedIpsPayload() });
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    // Bounded index read — no server pagination params (#2211).
+    expect(mockApi.get).toHaveBeenCalledWith(LIST_URL, undefined);
+    const table = wrapper.find('[data-testid="bannedips-table"]');
+    expect(table.exists()).toBe(true);
+    expect(table.text()).toContain(EXISTING_IP);
+    expect(table.text()).toContain('abuse');
+    // The current-IP panel reads from the same envelope.
+    expect(wrapper.find('[data-testid="current-ip"]').text()).toContain('203.0.113.9');
+  });
+
+  it('shows the error banner + retry on a network failure', async () => {
+    mockApi.get.mockRejectedValue(new Error('Network Error'));
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    const banner = wrapper.find('[data-testid="bannedips-error"]');
+    expect(banner.exists()).toBe(true);
+
+    mockApi.get.mockResolvedValueOnce({ data: bannedIpsPayload() });
+    await banner.find('button').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-testid="bannedips-error"]').exists()).toBe(false);
+  });
+
+  // ---- Guarded ban (D4) -----------------------------------------------------
+
+  describe('ban — typed-confirmation gate', () => {
+    beforeEach(async () => {
+      mockApi.get.mockResolvedValue({ data: bannedIpsPayload() });
+      wrapper = mountView(pinia);
+      await flushPromises();
+      // Open the ban form and enter an IP + reason.
+      await wrapper.find('[data-testid="toggle-ban-form"]').trigger('click');
+      await wrapper.find('[data-testid="ban-ip-input"]').setValue(NEW_IP);
+      await wrapper.find('[data-testid="ban-reason-input"]').setValue('credential stuffing');
+    });
+
+    it('opens a danger dialog whose confirm stays disabled until the IP is retyped', async () => {
+      await wrapper.find('[data-testid="ban-submit"]').trigger('click');
+      await flushPromises();
+
+      expect(dialogInput(wrapper).exists()).toBe(true);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+      await dialogInput(wrapper).setValue('not-the-ip');
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+      await dialogInput(wrapper).setValue(NEW_IP);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+    });
+
+    it('POSTs the ban with {ip_address, reason}, notifies, closes the form and refreshes the list', async () => {
+      mockApi.post.mockResolvedValue({ data: banAck() });
+      const before = listGetCount();
+
+      await wrapper.find('[data-testid="ban-submit"]').trigger('click');
+      await dialogInput(wrapper).setValue(NEW_IP);
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockApi.post).toHaveBeenCalledWith(LIST_URL, {
+        ip_address: NEW_IP,
+        reason: 'credential stuffing',
+      });
+      expect(showMock).toHaveBeenCalledWith('web.admin.bannedIps.ban.success', 'success');
+      // Dialog closed (input gone), the ban form collapsed, and the list re-fetched.
+      expect(dialogInput(wrapper).exists()).toBe(false);
+      expect(wrapper.find('[data-testid="ban-form"]').exists()).toBe(false);
+      expect(listGetCount()).toBe(before + 1);
+    });
+
+    it('does NOT POST when submitted without a matching token', async () => {
+      mockApi.post.mockResolvedValue({ data: banAck() });
+      await wrapper.find('[data-testid="ban-submit"]').trigger('click');
+      await dialogInput(wrapper).setValue('wrong');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockApi.post).not.toHaveBeenCalled();
+      expect(showMock).not.toHaveBeenCalled();
+    });
+
+    it('surfaces a 4xx in the dialog and stays open on failure', async () => {
+      mockApi.post.mockRejectedValue(axiosError(422, { error: 'IP already banned' }));
+
+      await wrapper.find('[data-testid="ban-submit"]').trigger('click');
+      await dialogInput(wrapper).setValue(NEW_IP);
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(wrapper.find('[role="alert"]').text()).toContain('IP already banned');
+      expect(showMock).not.toHaveBeenCalled();
+      // Dialog stays put for retry/cancel.
+      expect(dialogInput(wrapper).exists()).toBe(true);
+    });
+  });
+
+  // ---- Guarded unban (D4) ---------------------------------------------------
+
+  describe('unban — typed-confirmation gate', () => {
+    beforeEach(async () => {
+      mockApi.get.mockResolvedValue({ data: bannedIpsPayload() });
+      wrapper = mountView(pinia);
+      await flushPromises();
+    });
+
+    it('opens the dialog from the row action, gated until the IP is retyped', async () => {
+      await wrapper.find(`[data-testid="unban-${EXISTING_IP}"]`).trigger('click');
+      await flushPromises();
+
+      expect(dialogInput(wrapper).exists()).toBe(true);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+      await dialogInput(wrapper).setValue(EXISTING_IP);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+    });
+
+    it('DELETEs the ban, notifies and refreshes the list on confirm', async () => {
+      mockApi.delete.mockResolvedValue({ data: unbanAck() });
+      const before = listGetCount();
+
+      await wrapper.find(`[data-testid="unban-${EXISTING_IP}"]`).trigger('click');
+      await dialogInput(wrapper).setValue(EXISTING_IP);
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockApi.delete).toHaveBeenCalledWith(`${LIST_URL}/${EXISTING_IP}`);
+      expect(showMock).toHaveBeenCalledWith('web.admin.bannedIps.unban.success', 'success');
+      expect(dialogInput(wrapper).exists()).toBe(false);
+      expect(listGetCount()).toBe(before + 1);
+    });
+
+    it('surfaces a 4xx in the dialog and does not refresh on failure', async () => {
+      mockApi.delete.mockRejectedValue(axiosError(422, { error: 'IP not currently banned' }));
+      const before = listGetCount();
+
+      await wrapper.find(`[data-testid="unban-${EXISTING_IP}"]`).trigger('click');
+      await dialogInput(wrapper).setValue(EXISTING_IP);
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(wrapper.find('[role="alert"]').text()).toContain('IP not currently banned');
+      expect(showMock).not.toHaveBeenCalled();
+      expect(listGetCount()).toBe(before);
+    });
+  });
+});

--- a/src/tests/apps/admin/AdminDomains.spec.ts
+++ b/src/tests/apps/admin/AdminDomains.spec.ts
@@ -1,0 +1,213 @@
+// src/tests/apps/admin/AdminDomains.spec.ts
+
+import { createPinia, setActivePinia } from 'pinia';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+const showMock = vi.fn();
+vi.mock('@/shared/stores/notificationsStore', () => ({
+  useNotificationsStore: () => ({ show: showMock }),
+}));
+
+// Deterministic, bootstrap-free date rendering.
+vi.mock('@/utils/format', () => ({
+  formatDisplayDateTime: (d: Date) => `DT:${d.toISOString()}`,
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+// Render the confirm dialog synchronously in jsdom (same shim the kit test uses).
+vi.mock('@headlessui/vue', () => ({
+  Dialog: {
+    name: 'Dialog',
+    template: '<div role="dialog" @close="$emit(\'close\')"><slot /></div>',
+    props: ['class'],
+    emits: ['close'],
+  },
+  DialogPanel: {
+    name: 'DialogPanel',
+    template: '<div class="dialog-panel" :data-testid="$attrs[\'data-testid\']"><slot /></div>',
+    props: ['class'],
+  },
+  DialogTitle: { name: 'DialogTitle', template: '<h3><slot /></h3>', props: ['as', 'class'] },
+  TransitionRoot: {
+    name: 'TransitionRoot',
+    template: '<div v-if="show"><slot /></div>',
+    props: ['as', 'show'],
+  },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>', props: ['as'] },
+}));
+
+import AdminDomains from '@/apps/admin/views/AdminDomains.vue';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+function domainRow(overrides: Record<string, unknown> = {}) {
+  return {
+    domain_id: 'cd1',
+    extid: 'cd_abc123',
+    display_domain: 'secrets.example.com',
+    base_domain: 'example.com',
+    subdomain: 'secrets',
+    status: null,
+    verified: false,
+    resolving: false,
+    verification_state: 'pending',
+    ready: false,
+    created: 1700000000,
+    updated: 1700003600,
+    org_id: 'org1',
+    org_name: 'Acme',
+    brand: { name: 'Acme', tagline: null, homepage_url: null },
+    homepage_config: null,
+    api_config: null,
+    has_logo: false,
+    has_icon: false,
+    logo_url: null,
+    icon_url: null,
+    ...overrides,
+  };
+}
+
+function domainsPayload(row: Record<string, unknown> = {}) {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      domains: [domainRow(row)],
+      pagination: { page: 1, per_page: 50, total_count: 1, total_pages: 1 },
+    },
+  };
+}
+
+function verifyAck(current_state = 'verified') {
+  return {
+    shrimp: '',
+    record: {
+      domain_id: 'cd1',
+      extid: 'cd_abc123',
+      display_domain: 'secrets.example.com',
+      verification_state: current_state,
+      verified: current_state === 'verified',
+      resolving: current_state === 'verified' || current_state === 'resolving',
+      ready: current_state === 'verified',
+      updated: 1700009999,
+    },
+    details: {
+      previous_state: 'pending',
+      current_state,
+      changed: true,
+      dns_validated: current_state === 'verified',
+      ssl_ready: current_state === 'verified',
+      is_resolving: current_state !== 'pending',
+      error: null,
+      message: 'Domain verification completed',
+    },
+  };
+}
+
+describe('AdminDomains (card grid + verify — ticket #31)', () => {
+  let wrapper: VueWrapper;
+  let pinia: ReturnType<typeof createPinia>;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+  });
+  afterEach(() => wrapper?.unmount());
+
+  const mountView = () => mount(AdminDomains, { global: { plugins: [pinia, i18n] } });
+
+  it('fetches the first page on mount and renders a card per domain', async () => {
+    mockApi.get.mockResolvedValue({ data: domainsPayload() });
+    wrapper = mountView();
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenCalledWith('/api/colonel/domains', {
+      params: { page: 1, per_page: 50 },
+    });
+    const grid = wrapper.find('[data-testid="domains-grid"]');
+    expect(grid.exists()).toBe(true);
+    expect(grid.text()).toContain('secrets.example.com');
+    expect(wrapper.find('[data-testid="domain-card-cd_abc123"]').exists()).toBe(true);
+  });
+
+  it('renders the empty state when there are no domains', async () => {
+    mockApi.get.mockResolvedValue({
+      data: { shrimp: '', record: {}, details: { domains: [], pagination: { page: 1, per_page: 50, total_count: 0, total_pages: 0 } } },
+    });
+    wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="domains-empty"]').exists()).toBe(true);
+  });
+
+  it('verifies a domain: POSTs the verify endpoint, notifies the honest state, and refetches', async () => {
+    mockApi.get.mockResolvedValue({ data: domainsPayload() });
+    mockApi.post.mockResolvedValue({ data: verifyAck('verified') });
+    wrapper = mountView();
+    await flushPromises();
+    expect(mockApi.get).toHaveBeenCalledTimes(1);
+
+    // Open the confirm dialog for this domain.
+    await wrapper.find('[data-testid="domain-verify-cd_abc123"]').trigger('click');
+    await flushPromises();
+
+    // One-click confirm (no typed token) — submit is enabled immediately.
+    const submit = wrapper.find('[data-testid="admin-confirm-submit"]');
+    expect(submit.exists()).toBe(true);
+    await submit.trigger('submit');
+    await flushPromises();
+
+    expect(mockApi.post).toHaveBeenCalledWith('/api/colonel/domains/cd_abc123/verify');
+    // Honest outcome surfaced as a success notification for a verified result.
+    expect(showMock).toHaveBeenCalledTimes(1);
+    expect(showMock.mock.calls[0][1]).toBe('success');
+    // Re-fetches the current page so the badge reflects persisted state.
+    expect(mockApi.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces a non-verified outcome honestly (info notification, not faked success)', async () => {
+    mockApi.get.mockResolvedValue({ data: domainsPayload() });
+    mockApi.post.mockResolvedValue({ data: verifyAck('pending') });
+    wrapper = mountView();
+    await flushPromises();
+
+    await wrapper.find('[data-testid="domain-verify-cd_abc123"]').trigger('click');
+    await flushPromises();
+    await wrapper.find('[data-testid="admin-confirm-submit"]').trigger('submit');
+    await flushPromises();
+
+    expect(showMock).toHaveBeenCalledTimes(1);
+    expect(showMock.mock.calls[0][1]).toBe('info');
+  });
+
+  it('shows the error banner + retry on a network failure', async () => {
+    mockApi.get.mockRejectedValue(new Error('Network Error'));
+    wrapper = mountView();
+    await flushPromises();
+
+    const banner = wrapper.find('[data-testid="domains-error"]');
+    expect(banner.exists()).toBe(true);
+
+    mockApi.get.mockResolvedValueOnce({ data: domainsPayload() });
+    await banner.find('button').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-testid="domains-error"]').exists()).toBe(false);
+  });
+});

--- a/src/tests/apps/admin/AdminOrganizations.spec.ts
+++ b/src/tests/apps/admin/AdminOrganizations.spec.ts
@@ -1,0 +1,278 @@
+// src/tests/apps/admin/AdminOrganizations.spec.ts
+
+import { createPinia, setActivePinia } from 'pinia';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+const showMock = vi.fn();
+vi.mock('@/shared/stores/notificationsStore', () => ({
+  useNotificationsStore: () => ({ show: showMock }),
+}));
+
+vi.mock('@/utils/format', () => ({
+  formatDisplayDateTime: (d: Date) => `DT:${d.toISOString()}`,
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+// The JsonViewer's copy affordance touches navigator.clipboard; stub it (same
+// shim the kit's JsonViewer.spec uses) so the investigate panel mounts cleanly.
+vi.mock('@/shared/components/ui/CopyButton.vue', () => ({
+  default: { name: 'CopyButton', template: '<button class="copy-button" />', props: ['text', 'tooltip', 'testid'] },
+}));
+
+// Render the headlessui dialogs synchronously in jsdom.
+vi.mock('@headlessui/vue', () => ({
+  Dialog: {
+    name: 'Dialog',
+    template: '<div role="dialog" @close="$emit(\'close\')"><slot /></div>',
+    props: ['class'],
+    emits: ['close'],
+  },
+  DialogPanel: {
+    name: 'DialogPanel',
+    template: '<div class="dialog-panel" :data-testid="$attrs[\'data-testid\']"><slot /></div>',
+    props: ['class'],
+  },
+  DialogTitle: { name: 'DialogTitle', template: '<h3><slot /></h3>', props: ['as', 'class'] },
+  TransitionRoot: {
+    name: 'TransitionRoot',
+    template: '<div v-if="show"><slot /></div>',
+    props: ['as', 'show'],
+  },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>', props: ['as'] },
+}));
+
+import AdminOrganizations from '@/apps/admin/views/AdminOrganizations.vue';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+function orgRow(overrides: Record<string, unknown> = {}) {
+  return {
+    org_id: 'org1',
+    extid: 'on_abc123',
+    display_name: 'Acme',
+    contact_email: 'owner@acme.test',
+    owner_id: 'cust1',
+    owner_email: 'ow***@a***.test',
+    member_count: 3,
+    domain_count: 1,
+    is_default: false,
+    created: 1700000000,
+    updated: 1700003600,
+    planid: 'identity_plus_v1',
+    stripe_customer_id: 'cus_123',
+    stripe_subscription_id: 'sub_123',
+    subscription_status: 'active',
+    subscription_period_end: '2026-01-01',
+    billing_email: 'billing@acme.test',
+    sync_status: 'potentially_stale',
+    sync_status_reason: 'planid differs from Stripe',
+    ...overrides,
+  };
+}
+
+function orgsPayload(rows = [orgRow()]) {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      organizations: rows,
+      pagination: { page: 1, per_page: 50, total_count: rows.length, total_pages: 1 },
+      filters: { status: null, sync_status: null },
+    },
+  };
+}
+
+function investigatePayload() {
+  return {
+    shrimp: '',
+    record: {
+      org_id: 'org1',
+      extid: 'on_abc123',
+      investigated_at: '2026-07-06 12:00:00 UTC',
+      local: {
+        planid: 'free_v1',
+        stripe_customer_id: 'cus_123',
+        stripe_subscription_id: 'sub_123',
+        subscription_status: 'active',
+        subscription_period_end: null,
+      },
+      stripe: {
+        available: true,
+        reason: null,
+        subscription: {
+          id: 'sub_123',
+          status: 'active',
+          current_period_end: 1735689600,
+          price_id: 'price_1',
+          price_nickname: null,
+          product_id: 'prod_1',
+          product_name: 'Identity Plus',
+          subscription_metadata_plan_id: null,
+          price_metadata_plan_id: 'identity_plus_v1',
+          resolved_plan_id: 'identity_plus_v1',
+        },
+      },
+      comparison: {
+        match: false,
+        verdict: 'mismatch_detected',
+        details: 'planid differs',
+        issues: [{ field: 'planid', local: 'free_v1', stripe: 'identity_plus_v1', severity: 'high' }],
+      },
+    },
+  };
+}
+
+function grantAck() {
+  return {
+    shrimp: '',
+    record: {
+      org_id: 'org1',
+      extid: 'on_abc123',
+      entitlement: 'custom_domains',
+      action: 'granted',
+      effective_entitlements: ['create_secrets', 'custom_domains'],
+      grants: ['custom_domains'],
+      revokes: [],
+    },
+  };
+}
+
+describe('AdminOrganizations (list + investigate + entitlements — ticket #32)', () => {
+  let wrapper: VueWrapper;
+  let pinia: ReturnType<typeof createPinia>;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+  });
+  afterEach(() => wrapper?.unmount());
+
+  const mountView = () => mount(AdminOrganizations, { global: { plugins: [pinia, i18n] } });
+  const dialogInput = (w: VueWrapper) => w.find('#admin-confirm-input');
+  const dialogSubmit = (w: VueWrapper) => w.find('[data-testid="admin-confirm-submit"]');
+
+  it('fetches the first page on mount and renders a row per organization', async () => {
+    mockApi.get.mockResolvedValue({ data: orgsPayload() });
+    wrapper = mountView();
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenCalledWith('/api/colonel/organizations', {
+      params: { page: 1, per_page: 50 },
+    });
+    const table = wrapper.find('[data-testid="organizations-table"]');
+    expect(table.exists()).toBe(true);
+    expect(table.text()).toContain('owner@acme.test');
+  });
+
+  it('renders the empty state when there are no organizations', async () => {
+    mockApi.get.mockResolvedValue({ data: orgsPayload([]) });
+    wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="organizations-table-empty"]').exists()).toBe(true);
+  });
+
+  it('refetches with the sync-status filter when it changes', async () => {
+    mockApi.get.mockResolvedValue({ data: orgsPayload() });
+    wrapper = mountView();
+    await flushPromises();
+
+    const select = wrapper.find('#kit-filter-sync_status');
+    await select.setValue('potentially_stale');
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenLastCalledWith('/api/colonel/organizations', {
+      params: { page: 1, per_page: 50, sync_status: 'potentially_stale' },
+    });
+  });
+
+  it('opens the detail drawer on row click and investigates on demand', async () => {
+    mockApi.get.mockResolvedValue({ data: orgsPayload() });
+    mockApi.post.mockResolvedValue({ data: investigatePayload() });
+    wrapper = mountView();
+    await flushPromises();
+
+    await wrapper.find('[data-testid="organizations-table"] tbody tr').trigger('click');
+    await flushPromises();
+
+    const drawer = wrapper.find('[data-testid="organizations-drawer"]');
+    expect(drawer.exists()).toBe(true);
+    expect(drawer.text()).toContain('on_abc123');
+
+    await wrapper.find('[data-testid="org-investigate-button"]').trigger('click');
+    await flushPromises();
+
+    expect(mockApi.post).toHaveBeenCalledWith('/api/colonel/organizations/on_abc123/investigate');
+    const result = wrapper.find('[data-testid="org-investigate-result"]');
+    expect(result.exists()).toBe(true);
+    // #2349 parity: the mismatch verdict + issue field surface in the read-out.
+    expect(wrapper.find('[data-testid="org-investigate-verdict"]').exists()).toBe(true);
+    expect(result.text()).toContain('planid');
+  });
+
+  it('grants an entitlement through a typed-confirmation dialog and shows the new override state', async () => {
+    mockApi.get.mockResolvedValue({ data: orgsPayload() });
+    mockApi.post.mockResolvedValue({ data: grantAck() });
+    wrapper = mountView();
+    await flushPromises();
+
+    await wrapper.find('[data-testid="organizations-table"] tbody tr').trigger('click');
+    await flushPromises();
+
+    // Enter an entitlement and request a grant.
+    await wrapper.find('[data-testid="org-entitlement-input"]').setValue('custom_domains');
+    await wrapper.find('[data-testid="org-entitlement-grant"]').trigger('click');
+    await flushPromises();
+
+    // Typed-confirmation gate: confirm stays disabled until the org's public id
+    // is retyped exactly.
+    expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+    await dialogInput(wrapper).setValue('on_abc123');
+    expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+
+    await dialogSubmit(wrapper).trigger('submit');
+    await flushPromises();
+
+    expect(mockApi.post).toHaveBeenCalledWith(
+      '/api/colonel/organizations/on_abc123/entitlements/grant',
+      { entitlement: 'custom_domains' }
+    );
+    expect(showMock).toHaveBeenCalledTimes(1);
+    expect(showMock.mock.calls[0][1]).toBe('success');
+    // The recomputed override state renders after the mutation.
+    const state = wrapper.find('[data-testid="org-override-state"]');
+    expect(state.exists()).toBe(true);
+    expect(state.text()).toContain('custom_domains');
+  });
+
+  it('shows the error banner + retry on a network failure', async () => {
+    mockApi.get.mockRejectedValue(new Error('Network Error'));
+    wrapper = mountView();
+    await flushPromises();
+
+    const banner = wrapper.find('[data-testid="organizations-error"]');
+    expect(banner.exists()).toBe(true);
+
+    mockApi.get.mockResolvedValueOnce({ data: orgsPayload() });
+    await banner.find('button').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-testid="organizations-error"]').exists()).toBe(false);
+  });
+});

--- a/src/tests/apps/admin/AdminSecrets.spec.ts
+++ b/src/tests/apps/admin/AdminSecrets.spec.ts
@@ -1,0 +1,302 @@
+// src/tests/apps/admin/AdminSecrets.spec.ts
+
+import { AxiosError } from 'axios';
+import { createPinia, setActivePinia } from 'pinia';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/** Build a real AxiosError so the shared classifier extracts `data.error`. */
+function axiosError(status: number, data: unknown, message = 'Request failed'): AxiosError {
+  const err = new AxiosError(message);
+  err.response = { status, data, statusText: '', headers: {}, config: {} as never };
+  return err;
+}
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+const showMock = vi.fn();
+vi.mock('@/shared/stores/notificationsStore', () => ({
+  useNotificationsStore: () => ({ show: showMock }),
+}));
+
+vi.mock('@/utils/format', () => ({
+  formatDisplayDateTime: (d: Date) => `DT:${d.toISOString()}`,
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+// Render HeadlessUI dialog markup synchronously (mirrors AdminCustomerDetail.spec).
+// DialogPanel renders its default slot, which for DetailDrawer contains the
+// header/body/footer slot outlets.
+vi.mock('@headlessui/vue', () => ({
+  Dialog: {
+    name: 'Dialog',
+    template: '<div role="dialog" @close="$emit(\'close\')"><slot /></div>',
+    props: ['class'],
+    emits: ['close'],
+  },
+  DialogPanel: {
+    name: 'DialogPanel',
+    template: '<div class="dialog-panel" :data-testid="$attrs[\'data-testid\']"><slot /></div>',
+    props: ['class'],
+  },
+  DialogTitle: { name: 'DialogTitle', template: '<h3><slot /></h3>', props: ['as', 'class'] },
+  TransitionRoot: {
+    name: 'TransitionRoot',
+    template: '<div v-if="show"><slot /></div>',
+    props: ['as', 'show'],
+  },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>', props: ['as'] },
+}));
+
+import AdminSecrets from '@/apps/admin/views/AdminSecrets.vue';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+const LIST_URL = '/api/colonel/secrets';
+const SECRET_ID = 's1';
+const SHORT_ID = 'abc123';
+const RECEIPT_URL = `/api/colonel/secrets/${SECRET_ID}`;
+
+function secretsPayload() {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      secrets: [
+        {
+          secret_id: SECRET_ID,
+          shortid: SHORT_ID,
+          owner_id: 'ext_owner',
+          state: 'received',
+          created: 1700000000,
+          expiration: 1700003600,
+          lifespan: 3600,
+          receipt_id: 'r1',
+          age: 172800,
+          has_ciphertext: true,
+        },
+      ],
+      pagination: { page: 1, per_page: 50, total_count: 1, total_pages: 1 },
+    },
+  };
+}
+
+function receiptPayload() {
+  return {
+    shrimp: '',
+    record: {
+      secret_id: SECRET_ID,
+      shortid: SHORT_ID,
+      state: 'received',
+      lifespan: 3600,
+      created: 1700000000,
+      updated: 1700000100,
+      expiration: 1700003600,
+      age: 172800,
+      owner_id: 'ext_owner',
+      receipt_id: 'r1',
+      has_ciphertext: true,
+      ciphertext_length: 256,
+    },
+    details: {
+      metadata: {
+        receipt_id: 'r1',
+        shortid: 'rh1',
+        state: 'viewed',
+        secret_ttl: 3600,
+        recipients: ['alice@example.com'],
+        has_passphrase: false,
+        share_domain: 'example.com',
+        created: 1700000000,
+        secret_expired: false,
+      },
+      owner: { user_id: 'objid_owner', email: 'o***@e***.com', role: 'customer', verified: true },
+    },
+  };
+}
+
+/** Route GETs by URL so the list + receipt fetches return distinct payloads. */
+function routeGet() {
+  mockApi.get.mockImplementation((url: string) => {
+    if (url === RECEIPT_URL) return Promise.resolve({ data: receiptPayload() });
+    return Promise.resolve({ data: secretsPayload() });
+  });
+}
+
+const mountView = (pinia: ReturnType<typeof createPinia>) =>
+  mount(AdminSecrets, {
+    global: { plugins: [pinia, i18n], stubs: { JsonViewer: true } },
+  });
+
+const dialogInput = (w: VueWrapper) => w.find('#admin-confirm-input');
+const dialogSubmit = (w: VueWrapper) => w.find('[data-testid="admin-confirm-submit"]');
+
+describe('AdminSecrets (list + receipt + guarded delete — ticket #30)', () => {
+  let wrapper: VueWrapper;
+  let pinia: ReturnType<typeof createPinia>;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+  });
+  afterEach(() => wrapper?.unmount());
+
+  // ---- List -----------------------------------------------------------------
+
+  it('fetches the first page on mount and renders a row per secret', async () => {
+    routeGet();
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenCalledWith(LIST_URL, {
+      params: { page: 1, per_page: 50 },
+    });
+    const table = wrapper.find('[data-testid="secrets-table"]');
+    expect(table.exists()).toBe(true);
+    expect(table.text()).toContain(SHORT_ID);
+    // Age rendered in whole days (172800s / 86400 = 2).
+    expect(table.text()).toContain('2');
+    // No filter bar (the list endpoint offers no server-side filter).
+    expect(wrapper.find('[data-testid="secrets-filterbar"]').exists()).toBe(false);
+  });
+
+  it('shows the error banner + retry on a network failure', async () => {
+    mockApi.get.mockRejectedValue(new Error('Network Error'));
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    const banner = wrapper.find('[data-testid="secrets-error"]');
+    expect(banner.exists()).toBe(true);
+
+    routeGet();
+    await banner.find('button').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-testid="secrets-error"]').exists()).toBe(false);
+  });
+
+  // ---- Receipt drawer -------------------------------------------------------
+
+  it('opens the receipt drawer and fetches GetSecretReceipt on row click', async () => {
+    routeGet();
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    await wrapper.find('[data-testid="secrets-table"] tbody tr').trigger('click');
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenCalledWith(RECEIPT_URL, undefined);
+    const content = wrapper.find('[data-testid="secret-drawer-content"]');
+    expect(content.exists()).toBe(true);
+    expect(wrapper.find('[data-testid="secret-field-secretId"]').text()).toContain(SECRET_ID);
+    // Receipt + owner sub-sections render from details.
+    expect(wrapper.find('[data-testid="receipt-field-receiptId"]').text()).toContain('r1');
+    expect(wrapper.find('[data-testid="owner-field-email"]').text()).toContain('o***@e***.com');
+  });
+
+  it('renders the not-found panel in the drawer on a 404', async () => {
+    mockApi.get.mockImplementation((url: string) => {
+      if (url === RECEIPT_URL) {
+        return Promise.reject(Object.assign(new Error('nf'), { response: { status: 404 } }));
+      }
+      return Promise.resolve({ data: secretsPayload() });
+    });
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    await wrapper.find('[data-testid="secrets-table"] tbody tr').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="secret-drawer-not-found"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="secret-drawer-content"]').exists()).toBe(false);
+  });
+
+  // ---- Guarded delete (D4) --------------------------------------------------
+
+  describe('delete — typed-confirmation gate', () => {
+    beforeEach(async () => {
+      routeGet();
+      wrapper = mountView(pinia);
+      await flushPromises();
+      await wrapper.find('[data-testid="secrets-table"] tbody tr').trigger('click');
+      await flushPromises();
+    });
+
+    it('opens a danger dialog whose confirm stays disabled until the short id is retyped', async () => {
+      await wrapper.find('[data-testid="secret-delete-button"]').trigger('click');
+      await flushPromises();
+
+      expect(dialogInput(wrapper).exists()).toBe(true);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+      await dialogInput(wrapper).setValue('not-the-id');
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+      await dialogInput(wrapper).setValue(SHORT_ID);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+    });
+
+    it('DELETEs the secret, notifies, closes the drawer and refreshes the list on confirm', async () => {
+      mockApi.delete.mockResolvedValue({
+        data: {
+          shrimp: '',
+          record: {
+            deleted: true,
+            secret: { secret_id: SECRET_ID, shortid: SHORT_ID, state: 'received', owner_id: 'ext_owner' },
+            metadata: { receipt_id: 'r1', shortid: 'rh1' },
+          },
+          details: { message: 'Secret and associated receipt deleted successfully' },
+        },
+      });
+      const listGetsBefore = mockApi.get.mock.calls.filter((c) => c[0] === LIST_URL).length;
+
+      await wrapper.find('[data-testid="secret-delete-button"]').trigger('click');
+      await dialogInput(wrapper).setValue(SHORT_ID);
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockApi.delete).toHaveBeenCalledWith(RECEIPT_URL);
+      expect(showMock).toHaveBeenCalledWith('web.admin.secrets.actions.delete.success', 'success');
+      // Drawer closed + list re-fetched (one more list GET than before).
+      expect(wrapper.find('[data-testid="secret-drawer-content"]').exists()).toBe(false);
+      const listGetsAfter = mockApi.get.mock.calls.filter((c) => c[0] === LIST_URL).length;
+      expect(listGetsAfter).toBe(listGetsBefore + 1);
+    });
+
+    it('does NOT delete when submitted without a matching token', async () => {
+      mockApi.delete.mockResolvedValue({ data: {} });
+      await wrapper.find('[data-testid="secret-delete-button"]').trigger('click');
+      await dialogInput(wrapper).setValue('wrong');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockApi.delete).not.toHaveBeenCalled();
+      expect(showMock).not.toHaveBeenCalled();
+    });
+
+    it('surfaces the backend error in the dialog and stays put on failure', async () => {
+      mockApi.delete.mockRejectedValue(axiosError(422, { error: 'Secret not found' }));
+
+      await wrapper.find('[data-testid="secret-delete-button"]').trigger('click');
+      await dialogInput(wrapper).setValue(SHORT_ID);
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(wrapper.find('[role="alert"]').text()).toContain('Secret not found');
+      expect(showMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/tests/apps/admin/AdminSystem.spec.ts
+++ b/src/tests/apps/admin/AdminSystem.spec.ts
@@ -1,0 +1,180 @@
+// src/tests/apps/admin/AdminSystem.spec.ts
+
+import { createPinia, setActivePinia } from 'pinia';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+vi.mock('@/utils/format', () => ({
+  formatDisplayDateTime: (d: Date) => `DT:${d.toISOString()}`,
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+import AdminSystem from '@/apps/admin/views/AdminSystem.vue';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+const DB_URL = '/api/colonel/system/database';
+const QUEUE_URL = '/api/colonel/queue';
+const REDIS_URL = '/api/colonel/system/redis';
+
+function dbPayload() {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      redis_info: {
+        redis_version: '7.2.0',
+        valkey_version: '8.0.1',
+        server_name: 'valkey',
+        redis_mode: 'standalone',
+        os: 'Linux',
+        uptime_in_seconds: 100000,
+        uptime_in_days: 1,
+        connected_clients: 5,
+        total_commands_processed: 123456,
+        instantaneous_ops_per_sec: 10,
+      },
+      database_sizes: { db0: { keys: 100, expires: 10, avg_ttl: 0 } },
+      total_keys: 100,
+      memory_stats: {
+        used_memory: 1000,
+        used_memory_human: '1.0M',
+        used_memory_rss: 2000,
+        used_memory_rss_human: '2.0M',
+        used_memory_peak: 3000,
+        used_memory_peak_human: '3.0M',
+        mem_fragmentation_ratio: 1.5,
+      },
+      model_counts: { customers: 42, secrets: 100, receipts: 50 },
+    },
+  };
+}
+
+function queuePayload() {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      connection: { connected: true, host: 'localhost:2121' },
+      worker_health: { status: 'healthy', active_workers: 2 },
+      queues: [{ name: 'mailer', pending_messages: 3, consumers: 1 }],
+    },
+  };
+}
+
+function redisPayload() {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      redis_info: { redis_version: '7.2.0', role: 'master' },
+      timestamp: 1700000000,
+    },
+  };
+}
+
+/** Route each of the three independent single-GET read-outs by URL. */
+function routeGet() {
+  mockApi.get.mockImplementation((url: string) => {
+    if (url === DB_URL) return Promise.resolve({ data: dbPayload() });
+    if (url === QUEUE_URL) return Promise.resolve({ data: queuePayload() });
+    if (url === REDIS_URL) return Promise.resolve({ data: redisPayload() });
+    return Promise.reject(new Error(`unexpected GET ${url}`));
+  });
+}
+
+// Stub the kit JsonViewer so the Redis section mounts without the CopyButton /
+// clipboard machinery; expose the testid so the loaded branch is assertable.
+const jsonViewerStub = {
+  name: 'JsonViewer',
+  template: '<div data-testid="system-redis-json" />',
+  props: ['data', 'expandDepth', 'testid'],
+};
+
+const mountView = (pinia: ReturnType<typeof createPinia>) =>
+  mount(AdminSystem, {
+    global: { plugins: [pinia, i18n], stubs: { JsonViewer: jsonViewerStub } },
+  });
+
+describe('AdminSystem (read-only status read-out — ticket #33)', () => {
+  let wrapper: VueWrapper;
+  let pinia: ReturnType<typeof createPinia>;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+  });
+  afterEach(() => wrapper?.unmount());
+
+  it('issues the three independent GETs on mount', async () => {
+    routeGet();
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenCalledWith(DB_URL, undefined);
+    expect(mockApi.get).toHaveBeenCalledWith(QUEUE_URL, undefined);
+    expect(mockApi.get).toHaveBeenCalledWith(REDIS_URL, undefined);
+  });
+
+  it('renders the loaded database, queue and redis read-outs', async () => {
+    routeGet();
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    // Database: model counts + engine version render straight from the record.
+    const db = wrapper.find('[data-testid="system-database"]');
+    expect(db.exists()).toBe(true);
+    expect(wrapper.find('[data-testid="system-database-error"]').exists()).toBe(false);
+    expect(db.text()).toContain('42'); // customers count
+    expect(wrapper.find('[data-testid="server-version"]').text()).toContain('8.0.1');
+    expect(wrapper.find('[data-testid="system-database-sizes"]').text()).toContain('db0');
+
+    // Queue: connection host + per-queue row render.
+    const queue = wrapper.find('[data-testid="system-queue"]');
+    expect(queue.text()).toContain('localhost:2121');
+    expect(wrapper.find('[data-testid="queue-table"]').text()).toContain('mailer');
+
+    // Redis: the JsonViewer read-out mounts (loaded branch, not loading/error).
+    expect(wrapper.find('[data-testid="system-redis-json"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="system-redis-error"]').exists()).toBe(false);
+  });
+
+  it('shows a per-section error state when each GET fails', async () => {
+    mockApi.get.mockRejectedValue(new Error('Network Error'));
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="system-database-error"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="system-queue-error"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="system-redis-error"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="system-redis-json"]').exists()).toBe(false);
+  });
+
+  it('shows the loading state while the requests are in flight', async () => {
+    mockApi.get.mockReturnValue(new Promise(() => {})); // never resolves
+    wrapper = mountView(pinia);
+
+    // onMounted flips loading before the first await; a tick lets the render
+    // reflect it. The GET never resolves, so loading persists.
+    await flushPromises();
+    expect(wrapper.find('[data-testid="system-database-loading"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="system-queue-loading"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="system-redis-loading"]').exists()).toBe(true);
+  });
+});

--- a/src/tests/apps/admin/AdminUsage.spec.ts
+++ b/src/tests/apps/admin/AdminUsage.spec.ts
@@ -1,0 +1,122 @@
+// src/tests/apps/admin/AdminUsage.spec.ts
+
+import { createPinia, setActivePinia } from 'pinia';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+import AdminUsage from '@/apps/admin/views/AdminUsage.vue';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+const USAGE_URL = '/api/colonel/usage/export';
+
+function usagePayload() {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      date_range: { start_date: 1700000000, end_date: 1702592000, days: 30 },
+      usage_data: {
+        total_secrets: 1234,
+        total_new_users: 56,
+        secrets_by_state: { received: 800, viewed: 400, expired: 34 },
+        avg_secrets_per_day: 41.1333,
+        avg_users_per_day: 1.86,
+      },
+      secrets_by_day: { '2026-06-01': 10, '2026-06-02': 20 },
+      users_by_day: { '2026-06-01': 1, '2026-06-02': 2 },
+    },
+  };
+}
+
+const mountView = (pinia: ReturnType<typeof createPinia>) =>
+  mount(AdminUsage, { global: { plugins: [pinia, i18n] } });
+
+describe('AdminUsage (read-only metrics read-out — ticket #33)', () => {
+  let wrapper: VueWrapper;
+  let pinia: ReturnType<typeof createPinia>;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+  });
+  afterEach(() => wrapper?.unmount());
+
+  it('fetches the export with a date range on mount', async () => {
+    mockApi.get.mockResolvedValue({ data: usagePayload() });
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenCalledTimes(1);
+    const [url, config] = mockApi.get.mock.calls[0];
+    expect(url).toBe(USAGE_URL);
+    // The default 30-day range is passed as Unix-second start/end params.
+    expect(config).toBeDefined();
+    expect(typeof config.params.start_date).toBe('number');
+    expect(typeof config.params.end_date).toBe('number');
+  });
+
+  it('renders the loaded summary tiles, state breakdown and daily rows', async () => {
+    mockApi.get.mockResolvedValue({ data: usagePayload() });
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    const content = wrapper.find('[data-testid="usage-content"]');
+    expect(content.exists()).toBe(true);
+    // Totals render straight from the record (localised number formatting).
+    expect(wrapper.find('[data-testid="usage-total-secrets"]').text()).toContain('1,234');
+    expect(wrapper.find('[data-testid="usage-new-users"]').text()).toContain('56');
+
+    // Secrets-by-state chips.
+    const byState = wrapper.find('[data-testid="usage-by-state"]');
+    expect(byState.text()).toContain('received');
+    expect(byState.text()).toContain('800');
+
+    // Per-day tables.
+    expect(wrapper.find('[data-testid="usage-secrets-by-day"]').text()).toContain('2026-06-01');
+    expect(wrapper.find('[data-testid="usage-users-by-day"]').text()).toContain('2026-06-02');
+  });
+
+  it('shows the error banner + retry on a network failure', async () => {
+    mockApi.get.mockRejectedValue(new Error('Network Error'));
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    const banner = wrapper.find('[data-testid="usage-error"]');
+    expect(banner.exists()).toBe(true);
+    expect(wrapper.find('[data-testid="usage-content"]').exists()).toBe(false);
+
+    mockApi.get.mockResolvedValueOnce({ data: usagePayload() });
+    await banner.find('button').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-testid="usage-error"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="usage-content"]').exists()).toBe(true);
+  });
+
+  it('disables the fetch button while a request is in flight', async () => {
+    mockApi.get.mockReturnValue(new Promise(() => {})); // never resolves
+    wrapper = mountView(pinia);
+
+    // onMounted flips loading before the first await; a tick lets the render
+    // reflect it. The GET never resolves, so loading persists.
+    await flushPromises();
+    expect(wrapper.find('[data-testid="usage-fetch"]').attributes('disabled')).toBeDefined();
+  });
+});

--- a/src/tests/apps/admin/bannedIpSchemas.spec.ts
+++ b/src/tests/apps/admin/bannedIpSchemas.spec.ts
@@ -1,0 +1,132 @@
+// src/tests/apps/admin/bannedIpSchemas.spec.ts
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  bannedIPsResponseSchema,
+  colonelBanIpResponseSchema,
+  colonelUnbanIpResponseSchema,
+} from '@/schemas/api/internal/responses/colonel-bannedips';
+
+/**
+ * Zod tripwire (CONTRACT 3) for the BannedIPs screen (#33). The two NEW ack
+ * payloads are shaped exactly as the live logic classes emit them — verified
+ * against apps/api/colonel/logic/colonel/ban_ip.rb and unban_ip.rb (which now
+ * delegate to Onetime::Operations::BanIP / UnbanIP). The reused LIST schema is
+ * re-exported from this per-resource module and is exercised too, so a backend
+ * drift fails here rather than silently breaking the screen.
+ */
+
+describe('bannedIPsResponseSchema (ListBannedIPs — reused)', () => {
+  it('parses the list read-out and keeps banned_at a number', () => {
+    const payload = {
+      shrimp: '',
+      record: {},
+      details: {
+        current_ip: '203.0.113.9',
+        banned_ips: [
+          {
+            id: 'banned_ip_objid',
+            ip_address: '203.0.113.4',
+            reason: 'abuse',
+            banned_by: 'objid_colonel',
+            banned_at: 1783378400,
+          },
+        ],
+        total_count: 1,
+      },
+    };
+    const result = bannedIPsResponseSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.details?.banned_ips[0].banned_at).toBe(1783378400);
+    expect(result.data.details?.current_ip).toBe('203.0.113.9');
+  });
+
+  it('defaults current_ip to "unknown" when omitted', () => {
+    const payload = {
+      shrimp: '',
+      record: {},
+      details: { banned_ips: [], total_count: 0 },
+    };
+    const result = bannedIPsResponseSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.details?.current_ip).toBe('unknown');
+  });
+
+  it('accepts a ban record with null reason + banned_by (anonymous/CLI ban)', () => {
+    const payload = {
+      shrimp: '',
+      record: {},
+      details: {
+        current_ip: '203.0.113.9',
+        banned_ips: [
+          { id: 'x', ip_address: '203.0.113.0/24', reason: null, banned_by: null, banned_at: 1 },
+        ],
+        total_count: 1,
+      },
+    };
+    expect(bannedIPsResponseSchema.safeParse(payload).success).toBe(true);
+  });
+});
+
+describe('colonelBanIpResponseSchema (BanIP ack)', () => {
+  it('validates the ban ack', () => {
+    const payload = {
+      shrimp: '',
+      record: {
+        id: 'banned_ip_objid',
+        ip_address: '203.0.113.4',
+        reason: 'credential stuffing',
+        banned_by: 'objid_colonel',
+        banned_at: 1783378400,
+      },
+      details: { message: 'IP address banned successfully' },
+    };
+    const result = colonelBanIpResponseSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.record.banned_at).toBe(1783378400);
+    expect(result.data.record.ip_address).toBe('203.0.113.4');
+  });
+
+  it('accepts a null reason + banned_by (permanent ban with no reason)', () => {
+    const payload = {
+      shrimp: '',
+      record: { id: 'x', ip_address: '203.0.113.4', reason: null, banned_by: null, banned_at: 1 },
+      details: { message: 'IP address banned successfully' },
+    };
+    expect(colonelBanIpResponseSchema.safeParse(payload).success).toBe(true);
+  });
+
+  it('rejects a ban ack missing ip_address (contract drift)', () => {
+    const payload = {
+      record: { id: 'x', reason: null, banned_by: null, banned_at: 1 },
+      details: { message: 'ok' },
+    };
+    expect(colonelBanIpResponseSchema.safeParse(payload).success).toBe(false);
+  });
+});
+
+describe('colonelUnbanIpResponseSchema (UnbanIP ack)', () => {
+  it('validates the unban ack', () => {
+    const payload = {
+      shrimp: '',
+      record: { ip_address: '203.0.113.4', unbanned: true },
+      details: { message: 'IP address unbanned successfully' },
+    };
+    const result = colonelUnbanIpResponseSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.record.unbanned).toBe(true);
+  });
+
+  it('rejects an unban ack missing details.message', () => {
+    const payload = {
+      record: { ip_address: '203.0.113.4', unbanned: true },
+      details: {},
+    };
+    expect(colonelUnbanIpResponseSchema.safeParse(payload).success).toBe(false);
+  });
+});

--- a/src/tests/apps/admin/colonelOrganizationSchemas.spec.ts
+++ b/src/tests/apps/admin/colonelOrganizationSchemas.spec.ts
@@ -1,0 +1,218 @@
+// src/tests/apps/admin/colonelOrganizationSchemas.spec.ts
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  colonelOrganizationsResponseSchema,
+  investigateOrganizationResponseSchema,
+} from '@/schemas/api/internal/responses/colonel';
+import { colonelEntitlementOverrideResponseSchema } from '@/schemas/api/internal/responses/colonel-organizations';
+
+/**
+ * Zod tripwire (CONTRACT 3, ticket #32). The organizations screen REUSES the
+ * frozen list + investigate schemas and adds ONE new schema for the
+ * entitlement-override MUTATION endpoints. These payloads are shaped exactly as
+ * the colonel logic classes emit them (verified against list_organizations.rb /
+ * investigate_organization.rb / manage_entitlement_override.rb). If the backend
+ * response drifts, these fail rather than the UI silently breaking.
+ */
+
+describe('colonelOrganizationsResponseSchema (reused list contract)', () => {
+  it('parses the real list payload and transforms created/updated to Date', () => {
+    const payload = {
+      shrimp: '',
+      record: {},
+      details: {
+        organizations: [
+          {
+            org_id: 'org1',
+            extid: 'on_abc',
+            display_name: 'Acme',
+            contact_email: 'owner@acme.test',
+            owner_id: 'cust1',
+            owner_email: 'ow***@a***.test',
+            member_count: 2,
+            domain_count: 0,
+            is_default: false,
+            created: 1700000000.5,
+            updated: null,
+            planid: null,
+            stripe_customer_id: null,
+            stripe_subscription_id: null,
+            subscription_status: null,
+            subscription_period_end: null,
+            billing_email: null,
+            sync_status: 'unknown',
+            sync_status_reason: null,
+          },
+        ],
+        pagination: { page: 1, per_page: 50, total_count: 1, total_pages: 1 },
+        filters: { status: null, sync_status: null },
+      },
+    };
+    const result = colonelOrganizationsResponseSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.details?.organizations[0].created).toBeInstanceOf(Date);
+    expect(result.data.details?.organizations[0].updated).toBeNull();
+  });
+
+  it('rejects an unknown sync_status (contract drift)', () => {
+    const payload = {
+      shrimp: '',
+      record: {},
+      details: {
+        organizations: [
+          {
+            org_id: 'o',
+            extid: 'on_x',
+            display_name: null,
+            contact_email: null,
+            owner_id: null,
+            owner_email: null,
+            member_count: 0,
+            domain_count: 0,
+            is_default: true,
+            created: 1700000000,
+            updated: null,
+            planid: null,
+            stripe_customer_id: null,
+            stripe_subscription_id: null,
+            subscription_status: null,
+            subscription_period_end: null,
+            billing_email: null,
+            sync_status: 'exploded',
+            sync_status_reason: null,
+          },
+        ],
+        pagination: { page: 1, per_page: 50, total_count: 1, total_pages: 1 },
+        filters: { status: null, sync_status: null },
+      },
+    };
+    expect(colonelOrganizationsResponseSchema.safeParse(payload).success).toBe(false);
+  });
+});
+
+describe('investigateOrganizationResponseSchema (reused investigate contract)', () => {
+  it('parses a mismatch verdict with issues + stripe subscription', () => {
+    const payload = {
+      shrimp: '',
+      record: {
+        org_id: 'org1',
+        extid: 'on_abc',
+        investigated_at: '2026-07-06 12:00:00 UTC',
+        local: {
+          planid: 'free_v1',
+          stripe_customer_id: 'cus_1',
+          stripe_subscription_id: 'sub_1',
+          subscription_status: 'active',
+          subscription_period_end: null,
+        },
+        stripe: {
+          available: true,
+          reason: null,
+          subscription: {
+            id: 'sub_1',
+            status: 'active',
+            current_period_end: 1735689600,
+            price_id: 'price_1',
+            price_nickname: null,
+            product_id: 'prod_1',
+            product_name: 'Identity Plus',
+            subscription_metadata_plan_id: null,
+            price_metadata_plan_id: 'identity_plus_v1',
+            resolved_plan_id: 'identity_plus_v1',
+          },
+        },
+        comparison: {
+          match: false,
+          verdict: 'mismatch_detected',
+          details: 'planid differs',
+          issues: [
+            { field: 'planid', local: 'free_v1', stripe: 'identity_plus_v1', severity: 'high' },
+          ],
+        },
+      },
+    };
+    const result = investigateOrganizationResponseSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.record.comparison.verdict).toBe('mismatch_detected');
+    expect(result.data.record.comparison.issues?.[0].severity).toBe('high');
+  });
+
+  it('parses a "no subscription" investigation (stripe unavailable)', () => {
+    const payload = {
+      shrimp: '',
+      record: {
+        org_id: 'org1',
+        extid: 'on_abc',
+        investigated_at: '2026-07-06 12:00:00 UTC',
+        local: {
+          planid: null,
+          stripe_customer_id: null,
+          stripe_subscription_id: null,
+          subscription_status: null,
+          subscription_period_end: null,
+        },
+        stripe: { available: false, reason: 'No subscription ID stored locally', subscription: null },
+        comparison: { match: null, verdict: 'unable_to_compare' },
+      },
+    };
+    expect(investigateOrganizationResponseSchema.safeParse(payload).success).toBe(true);
+  });
+});
+
+describe('colonelEntitlementOverrideResponseSchema (new mutation ack)', () => {
+  it('validates a grant ack', () => {
+    const payload = {
+      shrimp: '',
+      record: {
+        org_id: 'org1',
+        extid: 'on_abc',
+        entitlement: 'custom_domains',
+        action: 'granted',
+        effective_entitlements: ['create_secrets', 'custom_domains'],
+        grants: ['custom_domains'],
+        revokes: [],
+      },
+    };
+    const result = colonelEntitlementOverrideResponseSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.record.action).toBe('granted');
+    expect(result.data.record.grants).toContain('custom_domains');
+  });
+
+  it('validates a clear ack (null entitlement, empty overrides)', () => {
+    const payload = {
+      shrimp: '',
+      record: {
+        org_id: 'org1',
+        extid: 'on_abc',
+        entitlement: null,
+        action: 'cleared',
+        effective_entitlements: ['create_secrets'],
+        grants: [],
+        revokes: [],
+      },
+    };
+    expect(colonelEntitlementOverrideResponseSchema.safeParse(payload).success).toBe(true);
+  });
+
+  it('rejects an unknown action (contract drift)', () => {
+    const payload = {
+      shrimp: '',
+      record: {
+        org_id: 'org1',
+        extid: 'on_abc',
+        entitlement: 'x',
+        action: 'exploded',
+        effective_entitlements: [],
+        grants: [],
+        revokes: [],
+      },
+    };
+    expect(colonelEntitlementOverrideResponseSchema.safeParse(payload).success).toBe(false);
+  });
+});

--- a/src/tests/apps/admin/routes.spec.ts
+++ b/src/tests/apps/admin/routes.spec.ts
@@ -128,11 +128,53 @@ describe('Admin Routes Configuration', () => {
       expect(customers?.to).toBe('/colonel/customers');
     });
 
-    it('the remaining sections have no route until later phases wire them', () => {
-      const liveKeys = new Set(['overview', 'customers']);
-      const placeholders = CONSOLE_SECTIONS.filter((s) => !liveKeys.has(s.key));
-      expect(placeholders.length).toBeGreaterThan(0);
-      placeholders.forEach((s) => expect(s.to).toBeUndefined());
+    it('every console section is now wired to a route (Phase 2 complete)', () => {
+      // Phase 2 (tickets #30-33) wires the last placeholder sections: secrets,
+      // organizations, domains, system, bannedIps, usage. Every section now
+      // points at a live route, and each `to` resolves to a defined route.
+      const routePaths = new Set(adminRoutes.map((r: RouteRecordRaw) => r.path));
+      CONSOLE_SECTIONS.forEach((s) => {
+        expect(s.to).toBeDefined();
+        expect(routePaths.has(s.to as string)).toBe(true);
+      });
+    });
+
+    it('maps each Phase-2 section to its list route', () => {
+      const expected: Record<string, string> = {
+        secrets: '/colonel/secrets',
+        organizations: '/colonel/organizations',
+        domains: '/colonel/domains',
+        system: '/colonel/system',
+        bannedIps: '/colonel/banned-ips',
+        usage: '/colonel/usage',
+      };
+      Object.entries(expected).forEach(([key, path]) => {
+        expect(CONSOLE_SECTIONS.find((s) => s.key === key)?.to).toBe(path);
+      });
+    });
+  });
+
+  describe('Phase-2 routes (tickets #30-33)', () => {
+    const cases: Array<{ path: string; name: string; title: string }> = [
+      { path: '/colonel/secrets', name: 'AdminSecrets', title: 'web.admin.secrets.title' },
+      { path: '/colonel/domains', name: 'AdminDomains', title: 'web.colonel.titles.domains' },
+      {
+        path: '/colonel/organizations',
+        name: 'AdminOrganizations',
+        title: 'web.colonel.titles.organizations',
+      },
+      { path: '/colonel/system', name: 'AdminSystem', title: 'web.admin.system.title' },
+      { path: '/colonel/banned-ips', name: 'AdminBannedIps', title: 'web.admin.bannedIps.title' },
+      { path: '/colonel/usage', name: 'AdminUsage', title: 'web.admin.usage.title' },
+    ];
+
+    cases.forEach(({ path, name, title }) => {
+      it(`registers the ${name} route at ${path}`, () => {
+        const route = adminRoutes.find((r: RouteRecordRaw) => r.path === path);
+        expect(route).toBeDefined();
+        expect(route?.name).toBe(name);
+        expect(route?.meta?.title).toBe(title);
+      });
     });
   });
 });

--- a/src/tests/apps/admin/secretSchemas.spec.ts
+++ b/src/tests/apps/admin/secretSchemas.spec.ts
@@ -1,0 +1,137 @@
+// src/tests/apps/admin/secretSchemas.spec.ts
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  colonelSecretReceiptResponseSchema,
+  colonelSecretDeleteResponseSchema,
+} from '@/schemas/api/internal/responses/colonel-secrets';
+
+/**
+ * Zod tripwire (CONTRACT 3) for the two NEW Secrets-screen contracts. These
+ * payloads are shaped exactly as the live logic classes emit them — verified
+ * against apps/api/colonel/logic/colonel/get_secret_receipt.rb and delete_secret.rb
+ * (timestamps as Unix-epoch numbers, obscured owner email, receipt-optional). If
+ * a backend response drifts, these fail rather than the drawer silently breaking.
+ */
+
+// GetSecretReceipt `success_data`, on the wire (numbers for date fields).
+function receiptPayload() {
+  return {
+    shrimp: '',
+    record: {
+      secret_id: 'sec_objid',
+      shortid: 'sh1',
+      state: 'received',
+      lifespan: 3600,
+      created: 1783378400.12,
+      updated: 1783378401,
+      expiration: 1783382000,
+      age: 172800,
+      owner_id: 'ext_owner',
+      receipt_id: 'rec_objid',
+      has_ciphertext: true,
+      ciphertext_length: 512,
+    },
+    details: {
+      metadata: {
+        receipt_id: 'rec_objid',
+        shortid: 'rh1',
+        state: 'viewed',
+        secret_ttl: 3600,
+        recipients: ['alice@example.com'],
+        has_passphrase: true,
+        share_domain: 'example.com',
+        created: 1783378400,
+        secret_expired: false,
+      },
+      owner: { user_id: 'objid_owner', email: 'a***@e***.com', role: 'customer', verified: true },
+    },
+  };
+}
+
+describe('colonelSecretReceiptResponseSchema (GetSecretReceipt)', () => {
+  it('parses the real receipt payload and transforms timestamps to Date', () => {
+    const result = colonelSecretReceiptResponseSchema.safeParse(receiptPayload());
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.data.record.created).toBeInstanceOf(Date);
+    expect(result.data.record.updated).toBeInstanceOf(Date);
+    expect(result.data.record.expiration).toBeInstanceOf(Date);
+    expect(result.data.details?.metadata?.created).toBeInstanceOf(Date);
+    expect(result.data.details?.owner?.email).toBe('a***@e***.com');
+  });
+
+  it('accepts an anonymous secret: null owner, null receipt metadata, null expiration', () => {
+    const payload = receiptPayload();
+    payload.details.metadata = null as never;
+    payload.details.owner = null as never;
+    payload.record.owner_id = null as never;
+    payload.record.expiration = null as never;
+    payload.record.updated = null as never;
+
+    const result = colonelSecretReceiptResponseSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.details?.metadata).toBeNull();
+    expect(result.data.details?.owner).toBeNull();
+    expect(result.data.record.expiration).toBeNull();
+  });
+
+  it('accepts recipients as a plain string (data-drift tolerance)', () => {
+    const payload = receiptPayload();
+    payload.details.metadata!.recipients = 'alice@example.com' as never;
+    expect(colonelSecretReceiptResponseSchema.safeParse(payload).success).toBe(true);
+  });
+
+  it('rejects a payload missing has_ciphertext (contract drift)', () => {
+    const payload = receiptPayload() as unknown as { record: { has_ciphertext?: boolean } };
+    delete payload.record.has_ciphertext;
+    expect(colonelSecretReceiptResponseSchema.safeParse(payload).success).toBe(false);
+  });
+});
+
+describe('colonelSecretDeleteResponseSchema (DeleteSecret)', () => {
+  it('validates the delete ack with an associated receipt', () => {
+    const payload = {
+      shrimp: '',
+      record: {
+        deleted: true,
+        secret: { secret_id: 'sec_objid', shortid: 'sh1', state: 'received', owner_id: 'ext_owner' },
+        metadata: { receipt_id: 'rec_objid', shortid: 'rh1' },
+      },
+      details: { message: 'Secret and associated receipt deleted successfully' },
+    };
+    expect(colonelSecretDeleteResponseSchema.safeParse(payload).success).toBe(true);
+  });
+
+  it('validates the delete ack when the secret had no receipt (null metadata, anon owner)', () => {
+    const payload = {
+      shrimp: '',
+      record: {
+        deleted: true,
+        secret: { secret_id: 'sec_objid', shortid: 'sh1', state: 'new', owner_id: null },
+        metadata: null,
+      },
+      details: { message: 'Secret and associated receipt deleted successfully' },
+    };
+    const result = colonelSecretDeleteResponseSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.record.deleted).toBe(true);
+    expect(result.data.record.metadata).toBeNull();
+  });
+
+  it('rejects an ack missing details.message', () => {
+    const payload = {
+      record: {
+        deleted: true,
+        secret: { secret_id: 'x', shortid: 'y', state: 'new', owner_id: null },
+        metadata: null,
+      },
+      details: {},
+    };
+    expect(colonelSecretDeleteResponseSchema.safeParse(payload).success).toBe(false);
+  });
+});

--- a/src/tests/apps/admin/useAdminDomains.spec.ts
+++ b/src/tests/apps/admin/useAdminDomains.spec.ts
@@ -1,0 +1,106 @@
+// src/tests/apps/admin/useAdminDomains.spec.ts
+
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock('@/shared/composables/useApi', () => ({
+  useApi: () => mockApi,
+}));
+
+import { useAdminDomains } from '@/apps/admin/stores/useAdminDomains';
+
+function domainRow(overrides: Record<string, unknown> = {}) {
+  return {
+    domain_id: 'cd1',
+    extid: 'cd_abc123',
+    display_domain: 'secrets.example.com',
+    base_domain: 'example.com',
+    subdomain: 'secrets',
+    status: null,
+    verified: true,
+    resolving: true,
+    verification_state: 'verified',
+    ready: true,
+    created: 1700000000,
+    updated: 1700003600,
+    org_id: 'org1',
+    org_name: 'Acme',
+    brand: { name: 'Acme', tagline: null, homepage_url: null },
+    homepage_config: null,
+    api_config: null,
+    has_logo: false,
+    has_icon: false,
+    logo_url: null,
+    icon_url: null,
+    ...overrides,
+  };
+}
+
+function domainsPayload() {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      domains: [domainRow()],
+      pagination: { page: 1, per_page: 50, total_count: 1, total_pages: 1 },
+    },
+  };
+}
+
+describe('useAdminDomains', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses a unique store id', () => {
+    expect(useAdminDomains().$id).toBe('adminDomains');
+  });
+
+  it('fetches the domains endpoint and maps the page via its own selector', async () => {
+    mockApi.get.mockResolvedValue({ data: domainsPayload() });
+    const store = useAdminDomains();
+
+    await store.fetchPage(1);
+
+    expect(mockApi.get).toHaveBeenCalledWith('/api/colonel/domains', {
+      params: { page: 1, per_page: 50 },
+    });
+    expect(store.domains).toHaveLength(1);
+    expect(store.domains[0].display_domain).toBe('secrets.example.com');
+    expect(store.domains[0].created).toBeInstanceOf(Date);
+    expect(store.pagination?.total_count).toBe(1);
+  });
+
+  it('clears rows and rethrows on a network failure', async () => {
+    mockApi.get.mockRejectedValue(new Error('Network Error'));
+    const store = useAdminDomains();
+
+    await expect(store.fetchPage(1)).rejects.toThrow('Network Error');
+    expect(store.domains).toEqual([]);
+    expect(store.pagination).toBeNull();
+    expect(store.error).toBeInstanceOf(Error);
+  });
+
+  it('$reset restores initial state', async () => {
+    mockApi.get.mockResolvedValue({ data: domainsPayload() });
+    const store = useAdminDomains();
+    await store.fetchPage(1);
+    expect(store.domains).toHaveLength(1);
+
+    store.$reset();
+
+    expect(store.domains).toEqual([]);
+    expect(store.pagination).toBeNull();
+    expect(store.page).toBe(1);
+  });
+});

--- a/src/tests/apps/admin/useAdminOrganizations.spec.ts
+++ b/src/tests/apps/admin/useAdminOrganizations.spec.ts
@@ -1,0 +1,139 @@
+// src/tests/apps/admin/useAdminOrganizations.spec.ts
+
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock('@/shared/composables/useApi', () => ({
+  useApi: () => mockApi,
+}));
+
+import { useAdminOrganizations } from '@/apps/admin/stores/useAdminOrganizations';
+
+function orgRow(overrides: Record<string, unknown> = {}) {
+  return {
+    org_id: 'org1',
+    extid: 'on_abc123',
+    display_name: 'Acme',
+    contact_email: 'owner@acme.test',
+    owner_id: 'cust1',
+    owner_email: 'ow***@a***.test',
+    member_count: 3,
+    domain_count: 1,
+    is_default: false,
+    created: 1700000000,
+    updated: 1700003600,
+    planid: 'identity_plus_v1',
+    stripe_customer_id: 'cus_123',
+    stripe_subscription_id: 'sub_123',
+    subscription_status: 'active',
+    subscription_period_end: '2026-01-01',
+    billing_email: 'billing@acme.test',
+    sync_status: 'potentially_stale',
+    sync_status_reason: 'planid differs from Stripe',
+    ...overrides,
+  };
+}
+
+function orgsPayload(rows = [orgRow()]) {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      organizations: rows,
+      pagination: { page: 1, per_page: 50, total_count: rows.length, total_pages: 1 },
+      filters: { status: null, sync_status: null },
+    },
+  };
+}
+
+describe('useAdminOrganizations', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses a unique store id', () => {
+    expect(useAdminOrganizations().$id).toBe('adminOrganizations');
+  });
+
+  it('fetches the organizations endpoint and maps the page via its own selector', async () => {
+    mockApi.get.mockResolvedValue({ data: orgsPayload() });
+    const store = useAdminOrganizations();
+
+    await store.fetchPage(1);
+
+    expect(mockApi.get).toHaveBeenCalledWith('/api/colonel/organizations', {
+      params: { page: 1, per_page: 50 },
+    });
+    expect(store.organizations).toHaveLength(1);
+    expect(store.organizations[0].extid).toBe('on_abc123');
+    expect(store.organizations[0].created).toBeInstanceOf(Date);
+    expect(store.pagination?.total_count).toBe(1);
+  });
+
+  it('threads the subscription + sync-status filters through as query params', async () => {
+    mockApi.get.mockResolvedValue({ data: orgsPayload() });
+    const store = useAdminOrganizations();
+
+    await store.fetchPage(2, { status: 'past_due', sync_status: 'potentially_stale' });
+
+    expect(mockApi.get).toHaveBeenCalledWith('/api/colonel/organizations', {
+      params: { page: 2, per_page: 50, status: 'past_due', sync_status: 'potentially_stale' },
+    });
+  });
+
+  it('drops empty filters (no phantom query params)', async () => {
+    mockApi.get.mockResolvedValue({ data: orgsPayload() });
+    const store = useAdminOrganizations();
+
+    await store.fetchPage(1, { status: '', sync_status: undefined });
+
+    expect(mockApi.get).toHaveBeenCalledWith('/api/colonel/organizations', {
+      params: { page: 1, per_page: 50 },
+    });
+  });
+
+  it('clears rows and rethrows on a network failure', async () => {
+    mockApi.get.mockRejectedValue(new Error('Network Error'));
+    const store = useAdminOrganizations();
+
+    await expect(store.fetchPage(1)).rejects.toThrow('Network Error');
+    expect(store.organizations).toEqual([]);
+    expect(store.pagination).toBeNull();
+    expect(store.error).toBeInstanceOf(Error);
+  });
+
+  it('degrades to empty (no throw) on a schema mismatch', async () => {
+    mockApi.get.mockResolvedValue({
+      data: { shrimp: '', record: {}, details: { organizations: 'nope' } },
+    });
+    const store = useAdminOrganizations();
+
+    const result = await store.fetchPage(1);
+    expect(result).toBeNull();
+    expect(store.organizations).toEqual([]);
+    expect(store.validationError).toBe('ColonelOrganizationsResponse');
+  });
+
+  it('$reset restores initial state', async () => {
+    mockApi.get.mockResolvedValue({ data: orgsPayload() });
+    const store = useAdminOrganizations();
+    await store.fetchPage(1);
+    expect(store.organizations).toHaveLength(1);
+
+    store.$reset();
+
+    expect(store.organizations).toEqual([]);
+    expect(store.pagination).toBeNull();
+    expect(store.page).toBe(1);
+  });
+});

--- a/try/integration/api/colonel/manage_entitlement_override_try.rb
+++ b/try/integration/api/colonel/manage_entitlement_override_try.rb
@@ -257,6 +257,41 @@ last_response.status
 #=> 403
 
 # ----------------------------------------------------------------
+# Audit trail (CONTRACT 4 / D4) + extid-first org resolution (#32)
+# ----------------------------------------------------------------
+
+## Grant via the org's PUBLIC extid resolves the org and returns 200 (extid-first)
+post "/api/colonel/organizations/#{@org.extid}/entitlements/grant",
+  { entitlement: 'audit_probe_one' }.to_json,
+  { 'rack.session' => @colonel_session, 'CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json' }
+[last_response.status, JSON.parse(last_response.body)['record']['action']]
+#=> [200, 'granted']
+
+## A grant records exactly one AdminAuditEvent with the colonel actor + org target
+@before_count = Onetime::AdminAuditEvent.count
+post "/api/colonel/organizations/#{@org.extid}/entitlements/grant",
+  { entitlement: 'audit_probe_two' }.to_json,
+  { 'rack.session' => @colonel_session, 'CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json' }
+@evt = Onetime::AdminAuditEvent.recent(1).first
+[
+  Onetime::AdminAuditEvent.count - @before_count,
+  @evt['verb'],
+  @evt['actor'] == @colonel.extid,
+  @evt['target'] == @org.extid,
+  @evt['result'],
+  @evt['detail'],
+]
+#=> [1, 'organization.entitlement.grant', true, true, 'success', { 'entitlement' => 'audit_probe_two' }]
+
+## Clear records an audit event with the clear verb and an empty detail
+delete "/api/colonel/organizations/#{@org.extid}/entitlements/overrides",
+  {},
+  { 'rack.session' => @colonel_session, 'HTTP_ACCEPT' => 'application/json' }
+@evt = Onetime::AdminAuditEvent.recent(1).first
+[last_response.status, @evt['verb'], @evt['target'] == @org.extid, @evt['detail']]
+#=> [200, 'organization.entitlement.clear', true, {}]
+
+# ----------------------------------------------------------------
 # Teardown
 # ----------------------------------------------------------------
 @org.destroy!       rescue nil

--- a/try/unit/operations/ban_unban_ip_try.rb
+++ b/try/unit/operations/ban_unban_ip_try.rb
@@ -1,0 +1,135 @@
+# try/unit/operations/ban_unban_ip_try.rb
+#
+# frozen_string_literal: true
+
+#
+# Unit tryouts for the extracted IP-ban operations (epic #33):
+#   Onetime::Operations::BanIP / Onetime::Operations::UnbanIP
+#
+# These are the SINGLE implementation of the ban/unban verbs (the colonel API +
+# `bin/ots bannedips` CLI are thin adapters). Covers:
+# - BanIP: bans the IP, returns an immutable Result, records EXACTLY ONE audit
+#   event (verb ip.ban, actor = PUBLIC id, target = ip), preserves banned_by
+# - BanIP idempotency: an already-banned IP is a no-op (:already_banned, NO audit)
+# - UnbanIP: removes the ban, returns :success, records exactly one audit event
+# - UnbanIP not-found: unbanning a non-banned IP is a no-op (:not_found, NO audit)
+# - Behavioural parity: the stored record matches a direct BannedIP.ban! call
+#
+# Run: try --agent try/unit/operations/ban_unban_ip_try.rb
+
+require_relative '../../support/test_helpers'
+
+OT.boot! :test
+
+require 'onetime/operations/ban_ip'
+require 'onetime/operations/unban_ip'
+
+AE  = Onetime::AdminAuditEvent
+BIP = Onetime::BannedIP
+
+# Documentation-range IPs (RFC 5737 TEST-NET-3), unlikely to collide with fixtures.
+@ip      = '203.0.113.201'
+@ip_cidr = '198.51.100.0/24'
+@actor   = 'ur1colonelpub' # a PUBLIC id (extid-shaped), never an objid
+@stored  = 'objid_internal_colonel' # what the UI path stores in banned_by
+
+# Clean slate.
+BIP.unban!(@ip)
+BIP.unban!(@ip_cidr)
+AE.events.clear
+
+# ---- BanIP: success ----------------------------------------------------
+
+## BanIP returns a Result whose status is :success
+@ban = Onetime::Operations::BanIP.new(
+  ip_address: @ip, actor: @actor, reason: 'abuse', banned_by: @stored,
+).call
+@ban.status
+#=> :success
+
+## the ban Result carries the created record's public fields
+[@ban.ip_address, @ban.reason, @ban.banned_by, @ban.id.is_a?(String)]
+#=> ["203.0.113.201", "abuse", "objid_internal_colonel", true]
+
+## the IP is now banned (model state actually mutated)
+BIP.banned?(@ip)
+#=> true
+
+## exactly ONE audit event was recorded for the ban
+AE.count
+#=> 1
+
+## the audit event is the ban verb, targeting the IP, actored by the PUBLIC id
+@ev = AE.recent(1).first
+[@ev['verb'], @ev['target'], @ev['actor']]
+#=> ["ip.ban", "203.0.113.201", "ur1colonelpub"]
+
+## the audit actor is the public id, never the stored objid
+@ev['actor'].include?('objid_internal')
+#=> false
+
+## the audit detail carries the (non-secret) reason
+@ev['detail']['reason']
+#=> "abuse"
+
+# ---- BanIP: idempotent no-op ------------------------------------------
+
+## re-banning an already-banned IP is a no-op (:already_banned)
+AE.events.clear
+@rb = Onetime::Operations::BanIP.new(ip_address: @ip, actor: @actor).call
+@rb.status
+#=> :already_banned
+
+## a no-op ban records NO audit event (nothing mutated)
+AE.count
+#=> 0
+
+# ---- UnbanIP: success -------------------------------------------------
+
+## UnbanIP removes the ban and returns :success
+AE.events.clear
+@unban = Onetime::Operations::UnbanIP.new(ip_address: @ip, actor: @actor).call
+[@unban.status, @unban.unbanned]
+#=> [:success, true]
+
+## the IP is no longer banned
+BIP.banned?(@ip)
+#=> false
+
+## exactly ONE audit event was recorded for the unban
+AE.count
+#=> 1
+
+## the audit event is the unban verb targeting the IP
+u = AE.recent(1).first
+[u['verb'], u['target'], u['actor']]
+#=> ["ip.unban", "203.0.113.201", "ur1colonelpub"]
+
+# ---- UnbanIP: not-found no-op -----------------------------------------
+
+## unbanning a non-banned IP is a no-op (:not_found)
+AE.events.clear
+@nf = Onetime::Operations::UnbanIP.new(ip_address: @ip, actor: @actor).call
+[@nf.status, @nf.unbanned]
+#=> [:not_found, false]
+
+## a no-op unban records NO audit event
+AE.count
+#=> 0
+
+# ---- Behavioural parity: CIDR ban + banned_by default -----------------
+
+## a CIDR ban works and defaults banned_by to nil when not supplied
+AE.events.clear
+@cidr_ban = Onetime::Operations::BanIP.new(ip_address: @ip_cidr, actor: @actor).call
+[@cidr_ban.status, @cidr_ban.banned_by.nil?]
+#=> [:success, true]
+
+## a CIDR ban covers addresses inside the range (CIDR matching preserved)
+BIP.banned?('198.51.100.42')
+#=> true
+
+# Cleanup
+BIP.unban!(@ip)
+BIP.unban!(@ip_cidr)
+AE.events.clear


### PR DESCRIPTION
## Summary

Epic [#3653 — Colonel Admin Rebuild](https://github.com/onetimesecret/onetimesecret/issues/3653) · Phase 2, tickets **30 / 31 / 32 / 33**.

**Stacked PR** — base is `claude/colonel-admin-rebuild-overview-a8xe00` (PR #3673, Slices 1–3), not `develop`. Review after #3673.

Ports the remaining Phase-2 colonel screens onto the new admin app. Each screen reuses existing colonel read endpoints and routes by public **extid** to match the customer slice.

- **Secrets (30)** — list + receipt `DetailDrawer`; guarded delete gated by the secret shortid typed-confirmation token. Reuses `ListSecrets` / `GetSecretReceipt` / `DeleteSecret` unchanged (pure wiring).
- **Domains (31)** — list + per-domain verify. New `POST /api/colonel/domains/:extid/verify` delegates to a new admin wrapper op (`Operations::AdminVerifyDomain`) that reuses the incumbent `VerifyDomain` and records exactly one `AdminAuditEvent` (`domain.verify`); non-admin verify paths stay unaudited.
- **Organizations (32)** — list + billing-investigate (POST-to-read, no mutation); entitlement grant/revoke/clear now resolve by extid and emit one `AdminAuditEvent` per successful mutation from the logic layer.
- **System / Banned IPs / Usage (33)** — read-only system panel + usage export; guarded ban/unban riding new extracted `Operations::BanIP` / `UnbanIP` ops that record exactly one `AdminAuditEvent` each (`ip.ban` / `ip.unban`); idempotent no-ops record none.

**Contracts:** new per-resource Zod files (`colonel-{secrets,domains,organizations,system,bannedips,usage}.ts`) split account-detail + internal-wrapper with a registry key; existing frozen `colonel.ts` contracts untouched (Zod tripwire preserved).

**Follow-up (flagged, out of scope for this pure-wiring slice):** the reused `DeleteSecret` logic class emits no `AdminAuditEvent` — now that delete is UI-reachable, a later ticket should extract a central `Operations::Secrets::Delete` op that records the delete and wire the endpoint through it, preserving the response contract.

## Related Issues

Part of epic #3653 (Phase 2). Advances tickets 30, 31, 32, 33. No auto-close (stacked on a feature branch).

## Test Plan

- **Frontend:** `pnpm test:base run src/tests/apps/admin` → **29 files / 283 tests green**, incl. component specs for all six screens (ban/unban typed-confirmation gate, request bodies, list refresh, and 4xx failure-in-dialog paths).
- **Build:** two-pass `pnpm run build` green; **bundle-isolation invariant verified against the built admin chunk** — parsed `admin.*.js.map`: 0 imports of `apps/colonel/*`, `colonelInfoStore`, or the customer router graph.
- **Type-check / lint:** `pnpm run type-check` + `lint:base` exit 0.
- **Backend (Ruby 3.4.9):** `bin/ots config validate` OK; `bin/ots boot-test` loads all 11 apps incl. `/api/colonel` with the new verify route; new op tryouts green (`ban_unban_ip_try.rb` 17/17 — asserts exactly-one audit event per mutation, idempotent no-ops record none; entitlement + domain-verify tryouts green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSXB3Kj3BShBaPKUhm3MME)_