### PR TITLE
Slice 5 — Phase-3 CLI-only powers as UI + ops extraction (40/41/42/43/44/45)

### DIFF
--- a/apps/api/colonel/logic/colonel.rb
+++ b/apps/api/colonel/logic/colonel.rb
@@ -56,3 +56,36 @@ require_relative 'colonel/export_usage'
 
 # Queue metrics (RabbitMQ)
 require_relative 'colonel/get_queue_metrics'
+
+# Sessions (ticket #40)
+require_relative 'colonel/list_sessions'
+require_relative 'colonel/get_session_detail'
+require_relative 'colonel/delete_session'
+
+# Broadcast banner (ticket #41)
+require_relative 'colonel/get_banner'
+require_relative 'colonel/set_banner'
+require_relative 'colonel/clear_banner'
+
+# Queue DLQ console (ticket #42)
+require_relative 'colonel/list_dlqs'
+require_relative 'colonel/get_dlq_messages'
+require_relative 'colonel/replay_dlq'
+require_relative 'colonel/purge_dlq'
+
+# Domain toolbox (ticket #43)
+require_relative 'colonel/list_orphaned_domains'
+require_relative 'colonel/probe_domain'
+require_relative 'colonel/repair_domain'
+require_relative 'colonel/transfer_domain'
+
+# Email + rate-limit tools (ticket #44)
+require_relative 'colonel/list_email_templates'
+require_relative 'colonel/preview_email_template'
+require_relative 'colonel/send_test_email'
+require_relative 'colonel/list_rate_limiters'
+require_relative 'colonel/inspect_rate_limit'
+require_relative 'colonel/reset_rate_limit'
+
+# Billing catalog (ticket #45)
+require_relative 'colonel/get_billing_catalog'

--- a/apps/api/colonel/logic/colonel/clear_banner.rb
+++ b/apps/api/colonel/logic/colonel/clear_banner.rb
@@ -1,0 +1,52 @@
+# apps/api/colonel/logic/colonel/clear_banner.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/banner'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Clear the global broadcast banner (Colonel).
+      #
+      # Thin adapter over {Onetime::Operations::ClearBanner} — the single, audited
+      # implementation of the clear verb (epic #41). This class keeps only the HTTP
+      # concerns; the op owns the Redis delete, the runtime refresh, and the
+      # AdminAuditEvent (CONTRACT 4).
+      #
+      # Idempotent by delegation: clearing when no banner is set is a no-op that
+      # records NO audit event (the op returns :not_set). We return 200 with
+      # `cleared: false` rather than a 404 so a benign race (the banner's TTL
+      # expiring between the UI's read and the operator's confirm) is not surfaced
+      # as an error — the destructive-action confirm is the UI's guardrail.
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class ClearBanner < ColonelAPI::Logic::Base
+        attr_reader :result
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+        end
+
+        def process
+          @result = Onetime::Operations::ClearBanner.new(actor: cust.extid).call
+          success_data
+        end
+
+        def success_data
+          {
+            record: {
+              cleared: result.cleared,
+              active: false,
+            },
+            details: {
+              message: result.cleared ? 'Broadcast banner cleared' : 'No banner was set',
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/delete_session.rb
+++ b/apps/api/colonel/logic/colonel/delete_session.rb
@@ -1,0 +1,67 @@
+# apps/api/colonel/logic/colonel/delete_session.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/sessions/store'
+require 'onetime/operations/sessions/delete_session'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Revoke (delete / terminate) a single session (Colonel).
+      #
+      # Thin adapter over {Onetime::Operations::Sessions::Delete} — the single,
+      # audited implementation of the session-delete verb (epic #40 / CONTRACT 4).
+      # This class keeps only the HTTP concerns (param validation + the not-found
+      # 404); the op owns the model mutation and the AdminAuditEvent.
+      #
+      # Deleting a session logs that user out mid-flight, so the UI gates this
+      # behind AdminConfirmDialog typed-confirmation (retype the session id).
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class DeleteSession < ColonelAPI::Logic::Base
+        attr_reader :session_id, :result
+
+        def process_params
+          @session_id = sanitize_identifier(params['session_id'])
+          raise_form_error('Session ID is required', field: :session_id) if session_id.to_s.empty?
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+
+          # 404 when there is no live session for this id, so the UI can tell
+          # "already gone" from a real failure. The op is idempotent regardless.
+          unless Onetime::Operations::Sessions::Store.find_key(Familia.dbclient, session_id)
+            raise_not_found('Session not found')
+          end
+        end
+
+        def process
+          # Delegate the model mutation + audit to the single op implementation.
+          # actor is the acting colonel's PUBLIC id (never an objid).
+          @result = Onetime::Operations::Sessions::Delete.new(
+            session_id: session_id,
+            actor: cust.extid,
+          ).call
+
+          success_data
+        end
+
+        def success_data
+          {
+            record: {
+              session_id: result.session_id,
+              deleted: result.status == :deleted,
+            },
+            details: {
+              message: 'Session revoked successfully',
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/get_banner.rb
+++ b/apps/api/colonel/logic/colonel/get_banner.rb
@@ -1,0 +1,47 @@
+# apps/api/colonel/logic/colonel/get_banner.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/banner'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Show the current global broadcast banner (Colonel).
+      #
+      # Thin adapter over {Onetime::Operations::GetBanner} — the single
+      # implementation of the banner read (epic #41). Read-only: nothing mutates,
+      # so nothing is audited (CONTRACT 4).
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class GetBanner < ColonelAPI::Logic::Base
+        attr_reader :result
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+        end
+
+        def process
+          @result = Onetime::Operations::GetBanner.new.call
+          success_data
+        end
+
+        def success_data
+          {
+            record: {
+              content: result.content,
+              ttl: result.ttl,
+              active: result.active,
+            },
+            details: {
+              key: result.key,
+              database: result.database,
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/get_billing_catalog.rb
+++ b/apps/api/colonel/logic/colonel/get_billing_catalog.rb
@@ -1,0 +1,210 @@
+# apps/api/colonel/logic/colonel/get_billing_catalog.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Get Billing Catalog (drift view) — ticket #45, Phase 3.
+      #
+      # READ-ONLY surface over the billing plan catalog. Where
+      # {GetAvailablePlans} returns ONE source (Stripe cache OR billing.yaml
+      # config, whichever is populated), this class returns BOTH sides so the
+      # admin console can show catalog/plan drift at a glance:
+      #
+      #   - config_plans — Billing::Plan.list_plans_from_config (billing.yaml,
+      #     the declared catalog)
+      #   - live_plans   — Billing::Plan.list_plans     (Stripe-synced Redis
+      #     cache, what is actually live)
+      #   - drift        — a computed summary of the difference (planids present
+      #     on only one side, and planids present on both whose entitlements or
+      #     limits diverge)
+      #
+      # Recipe note (epic #45): unlike the other Phase-3 items this needs NO op
+      # extraction and NO mutating route — the read ops already exist. This is a
+      # thin HTTP adapter that REUSES the incumbent Billing::Plan source
+      # (CONTRACT 5). It NEVER writes, so it emits NO AdminAuditEvent
+      # (CONTRACT 4 — audit is for mutations only). Catalog sync stays CLI-only
+      # until this view is trusted (spec: read-only drift first).
+      #
+      # ## Request
+      #
+      # GET /api/colonel/billing/catalog
+      #
+      # ## Response (record/details envelope)
+      #
+      # {
+      #   record: {},
+      #   details: {
+      #     source: "stripe" | "local_config",
+      #     stripe_configured: true,
+      #     config_plans: [ <PlanEntry>, ... ],
+      #     live_plans:   [ <PlanEntry>, ... ],
+      #     drift: {
+      #       in_sync: false,
+      #       only_in_config: ["legacy_v1"],
+      #       only_in_live:   ["identity_plus_v2"],
+      #       changed: [ { planid: "identity_plus_v1", name: "Identity+",
+      #                    fields: ["entitlements", "limits"] } ]
+      #     }
+      #   }
+      # }
+      #
+      # PlanEntry = {
+      #   planid:, name:, tier:, tenancy:, region:, display_order:,
+      #   show_on_plans_page:, description:, entitlements: [...], limits: {...}
+      # }
+      #
+      # ## Source Indicator
+      #
+      # - "stripe": live plans loaded from the Stripe-synced Redis cache
+      #   (production). Drift is meaningful.
+      # - "local_config": the Stripe cache is empty (dev / no Stripe). live_plans
+      #   is [] and every configured plan reports as only_in_config; the UI
+      #   should warn that drift cannot be evaluated.
+      #
+      # ## Security
+      #
+      # Requires colonel role. Enforced at BOTH the router (role=colonel) AND
+      # here (verify_one_of_roles!(colonel: true)) — defense in depth (epic #20).
+      class GetBillingCatalog < ColonelAPI::Logic::Base
+        SCHEMAS = { response: 'colonelBillingCatalog' }.freeze
+
+        attr_reader :config_plans, :live_plans, :drift, :source
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+        end
+
+        def process
+          @config_plans = load_plans_from_config
+          @live_plans   = load_plans_from_stripe_cache
+          @source       = @live_plans.any? ? 'stripe' : 'local_config'
+          @drift        = compute_drift(@config_plans, @live_plans)
+
+          success_data
+        end
+
+        def success_data
+          {
+            record: {},
+            details: {
+              source: source,
+              stripe_configured: live_plans.any?,
+              config_plans: config_plans,
+              live_plans: live_plans,
+              drift: drift,
+            },
+          }
+        end
+
+        private
+
+        # Configured catalog (billing.yaml). REUSES the incumbent source.
+        #
+        # @return [Array<Hash>] Normalized PlanEntry hashes
+        def load_plans_from_config
+          ::Billing::Plan.list_plans_from_config.map { |plan| normalize_config_plan(plan) }
+        rescue StandardError => ex
+          OT.le '[GetBillingCatalog] Error loading plans from config',
+            { exception: ex, message: ex.message }
+          []
+        end
+
+        # Live plans (Stripe-synced Redis cache). Mirrors GetAvailablePlans'
+        # normalization so both sides share the exact same PlanEntry shape and
+        # drift compares like-for-like. Uses the bounded instances lookup, not a
+        # blocking KEYS scan (CONTRACT 6).
+        #
+        # @return [Array<Hash>] Normalized PlanEntry hashes
+        def load_plans_from_stripe_cache
+          ::Billing::Plan.list_plans.map do |plan|
+            {
+              planid: plan.plan_id,
+              name: plan.name,
+              tier: plan.tier,
+              tenancy: plan.tenancy,
+              region: plan.region,
+              display_order: plan.display_order.to_i,
+              show_on_plans_page: plan.show_on_plans_page.to_s == 'true',
+              description: plan.respond_to?(:description) ? plan.description : nil,
+              entitlements: plan.entitlements.to_a.sort,
+              limits: normalize_limits(plan.limits.hgetall || {}),
+            }
+          end
+        rescue StandardError => ex
+          OT.le '[GetBillingCatalog] Error loading plans from Stripe cache',
+            { exception: ex, message: ex.message }
+          []
+        end
+
+        # Select the shared PlanEntry fields from a config plan hash and
+        # normalize entitlements/limits so both sides are comparable.
+        def normalize_config_plan(plan)
+          {
+            planid: plan[:planid],
+            name: plan[:name],
+            tier: plan[:tier],
+            tenancy: plan[:tenancy],
+            region: plan[:region],
+            display_order: plan[:display_order].to_i,
+            show_on_plans_page: plan[:show_on_plans_page] == true,
+            description: plan[:description],
+            entitlements: Array(plan[:entitlements]).map(&:to_s).sort,
+            limits: normalize_limits(plan[:limits] || {}),
+          }
+        end
+
+        # Stringify limit values so a config "0" and a cached "0" compare equal.
+        def normalize_limits(limits)
+          limits.each_with_object({}) do |(key, value), acc|
+            acc[key.to_s] = value.to_s
+          end
+        end
+
+        # Compute the config-vs-live difference, keyed by planid.
+        #
+        # @return [Hash] drift summary
+        def compute_drift(config_plans, live_plans)
+          config_by_id = config_plans.each_with_object({}) { |p, h| h[p[:planid]] = p }
+          live_by_id   = live_plans.each_with_object({}) { |p, h| h[p[:planid]] = p }
+
+          only_in_config = (config_by_id.keys - live_by_id.keys).sort
+          only_in_live   = (live_by_id.keys - config_by_id.keys).sort
+
+          changed = (config_by_id.keys & live_by_id.keys).sort.filter_map do |planid|
+            fields = drifted_fields(config_by_id[planid], live_by_id[planid])
+            next if fields.empty?
+
+            {
+              planid: planid,
+              name: config_by_id[planid][:name] || live_by_id[planid][:name],
+              fields: fields,
+            }
+          end
+
+          {
+            in_sync: only_in_config.empty? && only_in_live.empty? && changed.empty?,
+            only_in_config: only_in_config,
+            only_in_live: only_in_live,
+            changed: changed,
+          }
+        end
+
+        # Which comparable fields diverge between the two sides of a plan.
+        # Entitlements + limits are the operationally meaningful drift; tier and
+        # display metadata are reported too so a rename doesn't hide silently.
+        def drifted_fields(config_plan, live_plan)
+          fields = []
+          fields << 'entitlements' if config_plan[:entitlements] != live_plan[:entitlements]
+          fields << 'limits'       if config_plan[:limits] != live_plan[:limits]
+          fields << 'tier'         if config_plan[:tier] != live_plan[:tier]
+          fields << 'name'         if config_plan[:name] != live_plan[:name]
+          fields
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/get_dlq_messages.rb
+++ b/apps/api/colonel/logic/colonel/get_dlq_messages.rb
@@ -1,0 +1,99 @@
+# apps/api/colonel/logic/colonel/get_dlq_messages.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/dlq/store'
+require 'onetime/operations/dlq/peek'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Peek the messages in one dead-letter queue (Colonel).
+      #
+      # Thin adapter over {Onetime::Operations::Dlq::Peek} — the single
+      # implementation of the per-queue DLQ list verb (epic #42). Feeds the DLQ
+      # console's detail drawer: a non-destructive peek (pop + immediate
+      # nack-requeue) of up to `limit` dead-letter payloads for inspection via
+      # JsonViewer.
+      #
+      # Read-only: no AdminAuditEvent (CONTRACT 4).
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role. The
+      # `:queue` param is additionally gated against the fixed DLQ allowlist
+      # ({Store.valid?}) before the broker is touched — an operator can only ever
+      # inspect a configured dead-letter queue.
+      class GetDlqMessages < ColonelAPI::Logic::Base
+        attr_reader :dlq_name, :result
+
+        # Cap the drawer peek independently of the op's own MAX; the console shows a
+        # bounded sample, not a full drain.
+        DEFAULT_LIMIT = 20
+
+        def process_params
+          @queue    = sanitize_queue_name(params['queue'])
+          @dlq_name = Onetime::Operations::Dlq::Store.resolve(@queue)
+          @limit    = (params['limit'] || DEFAULT_LIMIT).to_i
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+
+          raise_form_error('Queue is required', field: :queue) if @queue.to_s.empty?
+          unless Onetime::Operations::Dlq::Store.valid?(dlq_name)
+            raise_not_found('Unknown dead-letter queue')
+          end
+        end
+
+        def process
+          @result = peek_result
+          success_data
+        end
+
+        private
+
+        # A message-queue name allows lowercase letters, digits, dots, hyphens and
+        # underscores (e.g. "billing.event" / "dlq.billing.event"). Unlike
+        # sanitize_identifier (which strips dots), this preserves the queue-name
+        # shape; the allowlist check in raise_concerns is the real gate.
+        def sanitize_queue_name(value)
+          value.to_s.downcase.gsub(/[^a-z0-9._-]/, '')
+        end
+
+        # Peek the queue, degrading to empty when the broker is down or the queue is
+        # configured but not yet declared (Bunny::NotFound).
+        def peek_result
+          unless $rmq_conn&.open?
+            return empty_result
+          end
+
+          Onetime::Operations::Dlq::Peek.new(
+            connection: $rmq_conn, queue: dlq_name, limit: @limit,
+          ).call
+        rescue Bunny::NotFound
+          empty_result
+        end
+
+        def empty_result
+          Onetime::Operations::Dlq::Peek::Result.new(
+            queue: dlq_name, total_messages: 0, showing: 0, messages: [],
+          )
+        end
+
+        def success_data
+          {
+            record: {
+              queue: result.queue,
+              total_messages: result.total_messages,
+              showing: result.showing,
+            },
+            details: {
+              messages: result.messages,
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/get_session_detail.rb
+++ b/apps/api/colonel/logic/colonel/get_session_detail.rb
@@ -1,0 +1,69 @@
+# apps/api/colonel/logic/colonel/get_session_detail.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/sessions/inspect_session'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Inspect a single session (Colonel).
+      #
+      # Thin adapter over {Onetime::Operations::Sessions::Inspect} — the single
+      # implementation of the session-inspect verb (epic #40). Resolves the session
+      # in raise_concerns (404 when absent) and surfaces a typed field read-out plus
+      # the full parsed payload for the detail drawer's raw inspector.
+      #
+      # Read-only: no AdminAuditEvent (CONTRACT 4).
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class GetSessionDetail < ColonelAPI::Logic::Base
+        attr_reader :session_id, :result
+
+        def process_params
+          @session_id = sanitize_identifier(params['session_id'])
+          raise_form_error('Session ID is required', field: :session_id) if session_id.to_s.empty?
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+
+          @result = Onetime::Operations::Sessions::Inspect.new(session_id: session_id).call
+          raise_not_found('Session not found') unless result.found
+        end
+
+        def process
+          success_data
+        end
+
+        def success_data
+          data = result.data || {}
+          {
+            record: {
+              session_id: result.session_id,
+              key: result.key,
+              ttl: result.ttl,
+              authenticated: data['authenticated'] ? true : false,
+              email: data['email'],
+              external_id: data['external_id'] || data['account_external_id'],
+              account_id: data['account_id'],
+              role: data['role'],
+              locale: data['locale'],
+              ip_address: data['ip_address'],
+              authenticated_at: data['authenticated_at'],
+              authenticated_by: data['authenticated_by'],
+              active_session_id: data['active_session_id'],
+            },
+            details: {
+              # Full parsed session payload for the raw inspector (colonel-only;
+              # parity with `bin/ots session inspect`, which prints every key).
+              data: data,
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/inspect_rate_limit.rb
+++ b/apps/api/colonel/logic/colonel/inspect_rate_limit.rb
@@ -1,0 +1,70 @@
+# apps/api/colonel/logic/colonel/inspect_rate_limit.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/ratelimit/inspect'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Inspect a rate limiter's current Redis state for one subject (Colonel).
+      #
+      # Thin adapter over {Onetime::Operations::RateLimit::Inspect} — the single
+      # implementation whose keys the `bin/ots ratelimit keys` CLI also emits
+      # (ticket #44). READ-ONLY: reads TTL + value for a bounded, fixed set of keys
+      # (CONTRACT 6 — never an unbounded KEYS/SCAN), mutates nothing, records NO
+      # AdminAuditEvent (CONTRACT 4).
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class InspectRateLimit < ColonelAPI::Logic::Base
+        attr_reader :kind, :subject, :result
+
+        def process_params
+          @kind    = params['kind'].to_s.strip
+          @subject = params['subject'].to_s.strip
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+
+          raise_form_error('Limiter kind is required', field: :kind) if kind.empty?
+          raise_form_error('Subject is required', field: :subject) if subject.empty?
+
+          unless Onetime::Operations::RateLimit::Registry.known?(kind)
+            raise_not_found("Unknown rate limiter: #{kind}")
+          end
+        end
+
+        def process
+          @result = Onetime::Operations::RateLimit::Inspect.new(
+            kind: kind,
+            subject: subject,
+          ).call
+
+          success_data
+        end
+
+        def success_data
+          {
+            record: {
+              kind: result.kind,
+              subject: result.subject,
+            },
+            details: {
+              entries: result.entries.map do |entry|
+                {
+                  key: entry.key,
+                  ttl: entry.ttl,
+                  value: entry.value,
+                  exists: entry.exists,
+                }
+              end,
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/list_dlqs.rb
+++ b/apps/api/colonel/logic/colonel/list_dlqs.rb
@@ -1,0 +1,91 @@
+# apps/api/colonel/logic/colonel/list_dlqs.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/dlq/list'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # List every dead-letter queue with its depth (Colonel).
+      #
+      # Thin adapter over {Onetime::Operations::Dlq::List} — the single
+      # implementation of the DLQ list-all verb (epic #42). This class keeps only
+      # the HTTP concerns (param coercion + role gate + in-memory pagination); the
+      # op owns the bounded queue-summary read. Sits directly beside the existing
+      # {GetQueueMetrics} read endpoint, upgrading the read-only queue widget into
+      # an actionable DLQ console.
+      #
+      # Uses the shared boot-time `$rmq_conn` (like {GetQueueMetrics}) — no new
+      # broker connection on the request path. When the broker is not connected the
+      # list degrades to empty + `connected: false` rather than erroring.
+      #
+      # Read-only: no AdminAuditEvent (CONTRACT 4 — audit is for mutations).
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class ListDlqs < ColonelAPI::Logic::Base
+        SCHEMAS = { response: 'colonelDlqList' }.freeze
+
+        DEFAULT_PER_PAGE = 50
+
+        attr_reader :dlqs, :pagination_meta, :connected
+
+        def process_params
+          @page     = (params['page'] || 1).to_i
+          @page     = 1 if @page < 1
+          @per_page = (params['per_page'] || DEFAULT_PER_PAGE).to_i
+          @per_page = DEFAULT_PER_PAGE if @per_page <= 0
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+        end
+
+        def process
+          rows = fetch_rows
+
+          total_count = rows.size
+          total_pages = @per_page.zero? ? 0 : (total_count.to_f / @per_page).ceil
+          start_idx   = (@page - 1) * @per_page
+
+          @dlqs            = rows[start_idx, @per_page] || []
+          @pagination_meta = {
+            page: @page,
+            per_page: @per_page,
+            total_count: total_count,
+            total_pages: total_pages,
+          }
+
+          success_data
+        end
+
+        private
+
+        # All DLQ summary rows (bounded — the fixed allowlist), or [] when the
+        # broker is not connected.
+        def fetch_rows
+          unless $rmq_conn&.open?
+            @connected = false
+            return []
+          end
+
+          @connected = true
+          Onetime::Operations::Dlq::List.new(connection: $rmq_conn).call.dlqs
+        end
+
+        def success_data
+          {
+            record: {},
+            details: {
+              dlqs: dlqs,
+              pagination: pagination_meta,
+              connected: connected,
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/list_email_templates.rb
+++ b/apps/api/colonel/logic/colonel/list_email_templates.rb
@@ -1,0 +1,51 @@
+# apps/api/colonel/logic/colonel/list_email_templates.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/email/list_templates'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # List the available email templates + their renderable formats (Colonel).
+      #
+      # Thin adapter over {Onetime::Operations::Email::ListTemplates} — the single
+      # implementation shared with the `bin/ots email templates` CLI (ticket #44).
+      # READ-ONLY: nothing mutates, so nothing is audited (CONTRACT 4). Feeds the
+      # email-tools screen's template picker.
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class ListEmailTemplates < ColonelAPI::Logic::Base
+        attr_reader :templates
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+        end
+
+        def process
+          @templates = Onetime::Operations::Email::ListTemplates.new.call
+          success_data
+        end
+
+        def success_data
+          {
+            record: {
+              templates: templates.map do |entry|
+                {
+                  name: entry.name,
+                  class_name: entry.klass,
+                  formats: entry.formats,
+                }
+              end,
+            },
+            details: {
+              count: templates.length,
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/list_orphaned_domains.rb
+++ b/apps/api/colonel/logic/colonel/list_orphaned_domains.rb
@@ -1,0 +1,66 @@
+# apps/api/colonel/logic/colonel/list_orphaned_domains.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/domains/orphaned_scan'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # List orphaned custom domains (Colonel) — domains with no owning
+      # organization (`org_id` blank), surfaced from the CLI-only
+      # `bin/ots domains orphaned` toolbox (epic #43).
+      #
+      # Thin adapter over {Onetime::Operations::Domains::OrphanedScan} — the single
+      # implementation of the orphaned-scan verb. The op owns the bounded scan
+      # (CONTRACT 6) and pagination; this class keeps only the HTTP concerns.
+      #
+      # READ-ONLY: no AdminAuditEvent (CONTRACT 4 — audit is for mutations).
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class ListOrphanedDomains < ColonelAPI::Logic::Base
+        SCHEMAS = { response: 'colonelDomainsOrphaned' }.freeze
+
+        attr_reader :domains, :pagination_meta
+
+        def process_params
+          @page     = (params['page'] || 1).to_i
+          @per_page = (params['per_page'] || 50).to_i
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+        end
+
+        def process
+          result = Onetime::Operations::Domains::OrphanedScan.new(
+            page: @page,
+            per_page: @per_page,
+          ).call
+
+          @domains         = result.domains
+          @pagination_meta = {
+            page: result.page,
+            per_page: result.per_page,
+            total_count: result.total_count,
+            total_pages: result.total_pages,
+          }
+
+          success_data
+        end
+
+        def success_data
+          {
+            record: {},
+            details: {
+              domains: domains,
+              pagination: pagination_meta,
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/list_rate_limiters.rb
+++ b/apps/api/colonel/logic/colonel/list_rate_limiters.rb
@@ -1,0 +1,46 @@
+# apps/api/colonel/logic/colonel/list_rate_limiters.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/ratelimit/registry'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # List the known rate limiters + their subject types (Colonel).
+      #
+      # Thin adapter over {Onetime::Operations::RateLimit::Registry} — the single
+      # source of truth the `bin/ots ratelimit` CLI also reads (ticket #44).
+      # READ-ONLY: nothing mutates, so nothing is audited (CONTRACT 4). Feeds the
+      # rate-limit inspect panel's limiter picker.
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class ListRateLimiters < ColonelAPI::Logic::Base
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+        end
+
+        def process
+          success_data
+        end
+
+        def success_data
+          limiters = Onetime::Operations::RateLimit::Registry::LIMITERS.map do |kind, meta|
+            { kind: kind, subject: meta[:subject] }
+          end
+
+          {
+            record: {
+              limiters: limiters,
+            },
+            details: {
+              count: limiters.length,
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/list_sessions.rb
+++ b/apps/api/colonel/logic/colonel/list_sessions.rb
@@ -1,0 +1,67 @@
+# apps/api/colonel/logic/colonel/list_sessions.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/sessions/list_sessions'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # List active sessions (Colonel).
+      #
+      # Thin adapter over {Onetime::Operations::Sessions::List} — the single
+      # implementation of the session-list verb (epic #40). This class keeps only
+      # the HTTP concerns (param coercion + role gate); the op owns the bounded
+      # scan, the optional search filter, and pagination.
+      #
+      # Read-only: no AdminAuditEvent (CONTRACT 4 — audit is for mutations).
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class ListSessions < ColonelAPI::Logic::Base
+        SCHEMAS = { response: 'colonelSessions' }.freeze
+
+        attr_reader :sessions, :pagination_meta
+
+        def process_params
+          @page     = (params['page'] || 1).to_i
+          @per_page = (params['per_page'] || 50).to_i
+          @search   = sanitize_plain_text(params['search'], max_length: 255) if params['search']
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+        end
+
+        def process
+          result = Onetime::Operations::Sessions::List.new(
+            page: @page,
+            per_page: @per_page,
+            search: @search,
+          ).call
+
+          @sessions        = result.sessions
+          @pagination_meta = {
+            page: result.page,
+            per_page: result.per_page,
+            total_count: result.total_count,
+            total_pages: result.total_pages,
+          }
+
+          success_data
+        end
+
+        def success_data
+          {
+            record: {},
+            details: {
+              sessions: sessions,
+              pagination: pagination_meta,
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/preview_email_template.rb
+++ b/apps/api/colonel/logic/colonel/preview_email_template.rb
@@ -1,0 +1,77 @@
+# apps/api/colonel/logic/colonel/preview_email_template.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/email/preview_template'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Render an email template for visual inspection (Colonel).
+      #
+      # Thin adapter over {Onetime::Operations::Email::PreviewTemplate} — the
+      # single implementation shared with the `bin/ots email preview` CLI (ticket
+      # #44). The op owns sample-data resolution + rendering; this class keeps the
+      # HTTP concerns (param extraction, unknown-template + missing-sample → form
+      # errors).
+      #
+      # READ-ONLY: rendering has NO side effects (it never dispatches an email), so
+      # it records NO AdminAuditEvent (CONTRACT 4). Over HTTP the preview always
+      # uses the template's SAMPLE data — no operator-supplied variables — so a
+      # preview can never carry live customer data.
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class PreviewEmailTemplate < ColonelAPI::Logic::Base
+        attr_reader :template, :locale, :format, :result
+
+        def process_params
+          @template = params['template'].to_s
+          @locale   = params['locale'].to_s.empty? ? 'en' : params['locale'].to_s
+          @format   = params['format'].to_s == 'html' ? 'html' : 'text'
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+
+          raise_form_error('Template is required', field: :template) if template.empty?
+
+          unless Onetime::Operations::Email::AVAILABLE_TEMPLATES.include?(template.to_sym)
+            raise_not_found("Unknown template: #{template}")
+          end
+        end
+
+        def process
+          # data: nil → the op loads the template's sample fixture. No custom data
+          # is accepted over HTTP (parity-safe + avoids injecting live data).
+          @result = Onetime::Operations::Email::PreviewTemplate.new(
+            template: template,
+            data: nil,
+            locale: locale,
+            format: format,
+          ).call
+
+          success_data
+        rescue Onetime::Operations::Email::PreviewTemplate::MissingSampleError => ex
+          raise_form_error(ex.message, field: :template)
+        rescue ArgumentError => ex
+          raise_form_error(ex.message, field: :template)
+        end
+
+        def success_data
+          {
+            record: {
+              template: result.template,
+              locale: result.locale,
+              format: result.format,
+            },
+            details: {
+              body: result.body,
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/probe_domain.rb
+++ b/apps/api/colonel/logic/colonel/probe_domain.rb
@@ -1,0 +1,81 @@
+# apps/api/colonel/logic/colonel/probe_domain.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/domains/probe'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Probe a custom domain (Colonel) — make an HTTPS request to confirm the
+      # domain serves traffic + inspect its TLS certificate, surfacing the
+      # CLI-only `bin/ots domains probe` toolbox (epic #43).
+      #
+      # Thin adapter over {Onetime::Operations::Domains::Probe} — the single
+      # implementation of the probe verb. The op owns the outbound request +
+      # health taxonomy; this class resolves the domain by public extid.
+      #
+      # READ-ONLY: probing reaches the network but mutates nothing in our store, so
+      # it records NO AdminAuditEvent (CONTRACT 4).
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role. The
+      # colonel resolves ANY domain by its public extid with no ownership check.
+      class ProbeDomain < ColonelAPI::Logic::Base
+        # Clamp the operator-supplied timeout so a probe can't hang the request
+        # path indefinitely; matches the CLI default of 10s.
+        MAX_TIMEOUT     = 30
+        DEFAULT_TIMEOUT = 10
+
+        attr_reader :extid, :custom_domain, :timeout, :result
+
+        def process_params
+          @extid   = sanitize_identifier(params['extid'])
+          raise_form_error('Domain ID is required', field: :extid) if extid.to_s.empty?
+
+          @timeout = (params['timeout'] || DEFAULT_TIMEOUT).to_i
+          @timeout = DEFAULT_TIMEOUT if @timeout <= 0
+          @timeout = MAX_TIMEOUT if @timeout > MAX_TIMEOUT
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+
+          @custom_domain = Onetime::CustomDomain.find_by_extid(extid)
+          raise_not_found('Domain not found') unless custom_domain
+        end
+
+        def process
+          # Colonel probes always verify TLS (no insecure flag exposed over HTTP).
+          @result = Onetime::Operations::Domains::Probe.new(
+            hostname: custom_domain.display_domain,
+            timeout: timeout,
+            insecure: false,
+          ).call
+
+          OT.info "[ProbeDomain] #{custom_domain.display_domain} -> health=#{result[:health]}"
+
+          success_data
+        end
+
+        def success_data
+          {
+            record: {
+              extid: custom_domain.extid,
+              display_domain: custom_domain.display_domain,
+            },
+            details: {
+              timestamp: result[:timestamp],
+              domain: result[:domain],
+              url: result[:url],
+              http: result[:http],
+              ssl: result[:ssl],
+              health: result[:health],
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/purge_dlq.rb
+++ b/apps/api/colonel/logic/colonel/purge_dlq.rb
@@ -1,0 +1,95 @@
+# apps/api/colonel/logic/colonel/purge_dlq.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/dlq/store'
+require 'onetime/operations/dlq/purge'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Purge (permanently delete) a dead-letter queue (Colonel).
+      #
+      # Thin adapter over {Onetime::Operations::Dlq::Purge} — the single, audited
+      # implementation of the DLQ purge verb (epic #42 / CONTRACT 4). This class
+      # keeps only the HTTP concerns (param validation + role gate + allowlist +
+      # broker-availability); the op owns the `queue.purge` mutation and the
+      # AdminAuditEvent (exactly one per non-empty purge).
+      #
+      # Purge is irreversible message loss, so the UI gates it behind
+      # AdminConfirmDialog typed-confirmation (retype the queue name) with the
+      # count-in-scope shown. `dry_run` (default false) returns the count that would
+      # be purged without deleting anything (no audit).
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class PurgeDlq < ColonelAPI::Logic::Base
+        attr_reader :dlq_name, :result
+
+        def process_params
+          @queue    = sanitize_queue_name(params['queue'])
+          @dlq_name = Onetime::Operations::Dlq::Store.resolve(@queue)
+          @dry_run  = truthy?(params['dry_run'])
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+
+          raise_form_error('Queue is required', field: :queue) if @queue.to_s.empty?
+          unless Onetime::Operations::Dlq::Store.valid?(dlq_name)
+            raise_not_found('Unknown dead-letter queue')
+          end
+          unless $rmq_conn&.open?
+            raise_form_error('Message queue is not connected')
+          end
+        end
+
+        def process
+          # Delegate the mutation + audit to the single op implementation.
+          # actor is the acting colonel's PUBLIC id (never an objid).
+          @result = Onetime::Operations::Dlq::Purge.new(
+            connection: $rmq_conn,
+            queue: dlq_name,
+            actor: cust.extid,
+            dry_run: @dry_run,
+          ).call
+
+          success_data
+        end
+
+        private
+
+        def sanitize_queue_name(value)
+          value.to_s.downcase.gsub(/[^a-z0-9._-]/, '')
+        end
+
+        def truthy?(value)
+          %w[1 true yes].include?(value.to_s.downcase)
+        end
+
+        def success_data
+          {
+            record: {
+              queue: result.queue,
+              count: result.count,
+              purged: result.purged,
+              dry_run: result.status == :dry_run,
+            },
+            details: {
+              message: purge_message,
+            },
+          }
+        end
+
+        def purge_message
+          case result.status
+          when :dry_run then "#{result.count} message(s) would be purged"
+          when :empty then 'No messages to purge'
+          else "Purged #{result.purged} message(s)"
+          end
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/repair_domain.rb
+++ b/apps/api/colonel/logic/colonel/repair_domain.rb
@@ -1,0 +1,91 @@
+# apps/api/colonel/logic/colonel/repair_domain.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/domains/repair'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Repair a custom domain's organization relationship (Colonel) — surfaces the
+      # CLI-only `bin/ots domains repair` toolbox (epic #43).
+      #
+      # Thin adapter over {Onetime::Operations::Domains::Repair} — the single,
+      # audited implementation of the repair verb. The op owns the plan/apply logic
+      # and the AdminAuditEvent (CONTRACT 4); this class resolves the domain + the
+      # optional target org and threads the `dry_run` flag.
+      #
+      # `dry_run` defaults to TRUE (CONTRACT / D4 — dry-run default): the screen
+      # previews the issues found, then re-POSTs with `dry_run: false` behind a
+      # typed-confirmation dialog to apply. A dry-run preview mutates + audits
+      # nothing.
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class RepairDomain < ColonelAPI::Logic::Base
+        attr_reader :extid, :org_id, :dry_run, :custom_domain, :target_org, :result
+
+        def process_params
+          @extid  = sanitize_identifier(params['extid'])
+          raise_form_error('Domain ID is required', field: :extid) if extid.to_s.empty?
+
+          @org_id  = sanitize_identifier(params['org_id'])
+          # Default to a safe dry-run unless the caller explicitly opts into applying.
+          @dry_run = params.key?('dry_run') ? truthy?(params['dry_run']) : true
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+
+          @custom_domain = Onetime::CustomDomain.find_by_extid(extid)
+          raise_not_found('Domain not found') unless custom_domain
+
+          # Resolve the optional target org for the ORPHANED case (by objid or extid).
+          # The op ignores it when the domain already has an org_id.
+          return if org_id.to_s.empty?
+
+          @target_org = Onetime::Organization.load(org_id) ||
+                        Onetime::Organization.find_by_extid(org_id)
+          raise_form_error('Organization not found', field: :org_id) unless target_org
+        end
+
+        def process
+          @result = Onetime::Operations::Domains::Repair.new(
+            domain: custom_domain,
+            org: target_org,
+            actor: cust.extid, # acting colonel's PUBLIC id (never an objid)
+            dry_run: dry_run,
+          ).call
+
+          OT.info "[RepairDomain] #{custom_domain.display_domain} -> " \
+                  "status=#{result.status}, dry_run=#{dry_run}, issues=#{result.issues.size}"
+
+          success_data
+        end
+
+        def success_data
+          {
+            record: {
+              domain_id: result.domain_id,
+              extid: result.extid,
+              display_domain: result.display_domain,
+            },
+            details: {
+              status: result.status.to_s,
+              dry_run: result.dry_run,
+              issues: result.issues,
+              repairs_applied: result.repairs_applied,
+            },
+          }
+        end
+
+        private
+
+        def truthy?(value)
+          %w[true 1 yes on].include?(value.to_s.strip.downcase)
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/replay_dlq.rb
+++ b/apps/api/colonel/logic/colonel/replay_dlq.rb
@@ -1,0 +1,98 @@
+# apps/api/colonel/logic/colonel/replay_dlq.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/dlq/store'
+require 'onetime/operations/dlq/replay'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Replay (re-enqueue) a dead-letter queue back to its original queue (Colonel).
+      #
+      # Thin adapter over {Onetime::Operations::Dlq::Replay} — the single, audited
+      # implementation of the DLQ replay verb (epic #42 / CONTRACT 4). This class
+      # keeps only the HTTP concerns (param validation + role gate + allowlist +
+      # broker-availability); the op owns the republish/ack/nack loop and the
+      # AdminAuditEvent (exactly one per replay that processes ≥ 1 message).
+      #
+      # Replay can re-trigger side effects (emails, webhooks), so the UI gates it
+      # behind an explicit confirm dialog. `dry_run` (default false) is honoured so
+      # a caller may preview the in-scope count without republishing.
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class ReplayDlq < ColonelAPI::Logic::Base
+        attr_reader :dlq_name, :result
+
+        def process_params
+          @queue    = sanitize_queue_name(params['queue'])
+          @dlq_name = Onetime::Operations::Dlq::Store.resolve(@queue)
+          @count    = params['count'].to_i if params['count']
+          @dry_run  = truthy?(params['dry_run'])
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+
+          raise_form_error('Queue is required', field: :queue) if @queue.to_s.empty?
+          unless Onetime::Operations::Dlq::Store.valid?(dlq_name)
+            raise_not_found('Unknown dead-letter queue')
+          end
+          unless $rmq_conn&.open?
+            raise_form_error('Message queue is not connected')
+          end
+        end
+
+        def process
+          # Delegate the mutation + audit to the single op implementation.
+          # actor is the acting colonel's PUBLIC id (never an objid).
+          @result = Onetime::Operations::Dlq::Replay.new(
+            connection: $rmq_conn,
+            queue: dlq_name,
+            count: @count,
+            actor: cust.extid,
+            dry_run: @dry_run,
+          ).call
+
+          success_data
+        end
+
+        private
+
+        def sanitize_queue_name(value)
+          value.to_s.downcase.gsub(/[^a-z0-9._-]/, '')
+        end
+
+        def truthy?(value)
+          %w[1 true yes].include?(value.to_s.downcase)
+        end
+
+        def success_data
+          {
+            record: {
+              queue: result.queue,
+              replayed: result.replayed,
+              failed: result.failed,
+              would_replay: result.would_replay,
+              dry_run: result.status == :dry_run,
+            },
+            details: {
+              message: replay_message,
+              errors: result.errors,
+            },
+          }
+        end
+
+        def replay_message
+          case result.status
+          when :dry_run then "#{result.would_replay} message(s) would be replayed"
+          when :empty, :noop then 'No messages to replay'
+          else "Replayed #{result.replayed} message(s), #{result.failed} failed"
+          end
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/reset_rate_limit.rb
+++ b/apps/api/colonel/logic/colonel/reset_rate_limit.rb
@@ -1,0 +1,71 @@
+# apps/api/colonel/logic/colonel/reset_rate_limit.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/ratelimit/reset'
+require 'onetime/operations/ratelimit/registry'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Reset (clear) a rate limiter's Redis state for one subject (Colonel).
+      #
+      # Thin adapter over {Onetime::Operations::RateLimit::Reset} — the single,
+      # audited implementation whose keys the `bin/ots ratelimit keys` CLI also
+      # emits as a `DEL` (ticket #44). This class keeps only the HTTP concerns
+      # (param validation); the op owns the delete + the AdminAuditEvent.
+      #
+      # Clearing a limiter lets a throttled subject act again, so the UI gates this
+      # behind an AdminConfirmDialog typed-confirmation. A reset that actually
+      # removed a key records EXACTLY ONE audit event (verb `ratelimit.reset`);
+      # resetting an already-clear subject is an idempotent no-op that records none.
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class ResetRateLimit < ColonelAPI::Logic::Base
+        attr_reader :kind, :subject, :result
+
+        def process_params
+          @kind    = params['kind'].to_s.strip
+          @subject = params['subject'].to_s.strip
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+
+          raise_form_error('Limiter kind is required', field: :kind) if kind.empty?
+          raise_form_error('Subject is required', field: :subject) if subject.empty?
+
+          unless Onetime::Operations::RateLimit::Registry.known?(kind)
+            raise_not_found("Unknown rate limiter: #{kind}")
+          end
+        end
+
+        def process
+          @result = Onetime::Operations::RateLimit::Reset.new(
+            kind: kind,
+            subject: subject,
+            actor: cust.extid,
+          ).call
+
+          success_data
+        end
+
+        def success_data
+          {
+            record: {
+              kind: result.kind,
+              subject: result.subject,
+              cleared: result.status == :success,
+            },
+            details: {
+              deleted: result.deleted,
+              message: result.status == :success ? 'Rate limiter reset' : 'No active rate-limit state to reset',
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/send_test_email.rb
+++ b/apps/api/colonel/logic/colonel/send_test_email.rb
@@ -1,0 +1,85 @@
+# apps/api/colonel/logic/colonel/send_test_email.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/email/send_test'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Send a diagnostic test email to verify delivery connectivity (Colonel).
+      #
+      # Thin adapter over {Onetime::Operations::Email::SendTest} — the single,
+      # audited implementation shared with the `bin/ots email test` CLI (ticket
+      # #44). This class keeps only the HTTP concerns (recipient validation, the
+      # dry-run/enqueue flags, and mapping a delivery failure to a form error); the
+      # op owns the build + dispatch + the AdminAuditEvent (CONTRACT 4).
+      #
+      # Test send DISPATCHES A REAL EMAIL, so the UI gates it behind an
+      # AdminConfirmDialog (one-click confirm, low-risk verb) that shows the
+      # recipient. A dry-run previews the exact email without sending (and without
+      # auditing). A successful real send records EXACTLY ONE audit event
+      # (verb `email.test_send`, actor = colonel extid, target = recipient).
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class SendTestEmail < ColonelAPI::Logic::Base
+        attr_reader :recipient, :dry_run, :enqueue, :result
+
+        def process_params
+          @recipient = params['to'].to_s.strip
+          @dry_run   = truthy?(params['dry_run'])
+          @enqueue   = truthy?(params['enqueue'])
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+
+          raise_form_error('Recipient email is required', field: :to) if recipient.empty?
+          raise_form_error('Recipient email is invalid', field: :to) unless valid_email?(recipient)
+        end
+
+        def process
+          @result = Onetime::Operations::Email::SendTest.new(
+            to: recipient,
+            actor: cust.extid,
+            dry_run: dry_run,
+            enqueue: enqueue,
+          ).call
+
+          success_data
+        rescue Onetime::Mail::DeliveryError => ex
+          raise_form_error("Delivery failed: #{ex.message}", field: :to)
+        rescue StandardError => ex
+          raise_form_error("Send failed: #{ex.message}", field: :to)
+        end
+
+        def success_data
+          diagnostic = result.diagnostic
+          {
+            record: {
+              to: diagnostic.to,
+              status: result.status.to_s,
+              sent: result.status != :dry_run,
+            },
+            details: {
+              provider: diagnostic.provider,
+              host: diagnostic.host,
+              from: diagnostic.from,
+              subject: diagnostic.subject,
+              text_body: diagnostic.text_body,
+              timestamp: diagnostic.timestamp,
+            },
+          }
+        end
+
+        private
+
+        def truthy?(value)
+          %w[true 1 yes on].include?(value.to_s.strip.downcase)
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/set_banner.rb
+++ b/apps/api/colonel/logic/colonel/set_banner.rb
@@ -1,0 +1,87 @@
+# apps/api/colonel/logic/colonel/set_banner.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/banner'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Publish / update the global broadcast banner (Colonel).
+      #
+      # Thin adapter over {Onetime::Operations::SetBanner} — the single, audited
+      # implementation of the set verb (epic #41). This class keeps only the HTTP
+      # concerns (param extraction + length/TTL validation); the op owns the Redis
+      # write, the runtime refresh, and the AdminAuditEvent (CONTRACT 4).
+      #
+      # The banner is user-facing globally, so we bound its length here (the note
+      # in the ticket). The content is stored VERBATIM (raw HTML) — NOT run through
+      # sanitize_plain_text — so the stored value stays bit-for-bit identical to
+      # what `bin/ots banner set` wrote; the frontend sanitizes to <a> tags on
+      # render (GlobalBroadcast.vue's DOMPurify pass).
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class SetBanner < ColonelAPI::Logic::Base
+        # Hard cap on published banner length. A UI/HTTP guardrail only — the op
+        # and the CLI impose no length limit (the CLI stays bit-for-bit unlimited).
+        # Kept as a constant (not a config key) so no new config surface is added.
+        MAX_CONTENT_LENGTH = 2000
+
+        attr_reader :content, :expiration, :result
+
+        def process_params
+          # Store raw HTML verbatim (only trim surrounding whitespace, matching the
+          # CLI's `--file` strip). Do NOT sanitize here — parity with the CLI.
+          @content = params['content'].to_s.strip
+
+          ttl_param = params['ttl']
+          @expiration = ttl_param.to_i unless ttl_param.nil? || ttl_param.to_s.strip.empty?
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+
+          raise_form_error('Banner content is required', field: :content) if content.empty?
+
+          if content.length > MAX_CONTENT_LENGTH
+            raise_form_error(
+              "Banner content exceeds the #{MAX_CONTENT_LENGTH}-character limit",
+              field: :content
+            )
+          end
+
+          if !expiration.nil? && expiration.negative?
+            raise_form_error('TTL must be a positive number of seconds', field: :ttl)
+          end
+        end
+
+        def process
+          # A zero / absent TTL means "persistent" (nil) to the op; only a positive
+          # value becomes an auto-expiry. actor is the acting colonel's PUBLIC id.
+          @result = Onetime::Operations::SetBanner.new(
+            content: content,
+            ttl: (expiration if !expiration.nil? && expiration.positive?),
+            actor: cust.extid,
+          ).call
+
+          success_data
+        end
+
+        def success_data
+          {
+            record: {
+              content: result.content,
+              ttl: result.ttl,
+              active: true,
+            },
+            details: {
+              message: 'Broadcast banner published',
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/transfer_domain.rb
+++ b/apps/api/colonel/logic/colonel/transfer_domain.rb
@@ -1,0 +1,113 @@
+# apps/api/colonel/logic/colonel/transfer_domain.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/domains/transfer'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Transfer a custom domain between organizations (Colonel) — surfaces the
+      # CLI-only `bin/ots domains transfer` toolbox (epic #43). Highest-blast-radius
+      # toolbox verb: it reassigns domain OWNERSHIP.
+      #
+      # Thin adapter over {Onetime::Operations::Domains::Transfer} — the single,
+      # audited implementation of the transfer verb. The op owns the ownership
+      # check, the atomic-ish move, and the AdminAuditEvent (CONTRACT 4); this class
+      # resolves the domain + orgs and threads the `dry_run` flag.
+      #
+      # `dry_run` defaults to TRUE (D4 — dry-run default): the screen previews the
+      # from/to details, then re-POSTs with `dry_run: false` behind a
+      # typed-confirmation dialog (retype the domain) to apply.
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class TransferDomain < ColonelAPI::Logic::Base
+        attr_reader :extid, :to_org_id, :from_org_id, :dry_run,
+                    :custom_domain, :to_org, :from_org, :result
+
+        def process_params
+          @extid = sanitize_identifier(params['extid'])
+          raise_form_error('Domain ID is required', field: :extid) if extid.to_s.empty?
+
+          @to_org_id   = sanitize_identifier(params['to_org'])
+          @from_org_id = sanitize_identifier(params['from_org'])
+          raise_form_error('Destination organization is required', field: :to_org) if to_org_id.to_s.empty?
+
+          @dry_run = params.key?('dry_run') ? truthy?(params['dry_run']) : true
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+
+          @custom_domain = Onetime::CustomDomain.find_by_extid(extid)
+          raise_not_found('Domain not found') unless custom_domain
+
+          @to_org = resolve_org(to_org_id)
+          raise_form_error('Destination organization not found', field: :to_org) unless to_org
+
+          # Optional explicit source org (ownership assertion).
+          return if from_org_id.to_s.empty?
+
+          @from_org = resolve_org(from_org_id)
+          raise_form_error('Source organization not found', field: :from_org) unless from_org
+        end
+
+        def process
+          @result = Onetime::Operations::Domains::Transfer.new(
+            domain: custom_domain,
+            to_org: to_org,
+            from_org: from_org,
+            actor: cust.extid, # acting colonel's PUBLIC id (never an objid)
+            dry_run: dry_run,
+          ).call
+
+          # An explicit source org that doesn't match the current owner is a
+          # 4xx form error (the CLI's "does not match --from-org" guard), never a
+          # silent success.
+          if result.status == :mismatch
+            raise_form_error(
+              "Domain's current organization does not match the source organization",
+              field: :from_org,
+            )
+          end
+
+          OT.info "[TransferDomain] #{custom_domain.display_domain} -> " \
+                  "status=#{result.status}, dry_run=#{dry_run}, to=#{result.to_org_id}"
+
+          success_data
+        end
+
+        def success_data
+          {
+            record: {
+              domain_id: result.domain_id,
+              extid: result.extid,
+              display_domain: result.display_domain,
+            },
+            details: {
+              status: result.status.to_s,
+              dry_run: result.dry_run,
+              from_org_id: result.from_org_id.to_s,
+              from_org_name: result.from_org_name,
+              to_org_id: result.to_org_id.to_s,
+              to_org_name: result.to_org_name,
+            },
+          }
+        end
+
+        private
+
+        def resolve_org(identifier)
+          Onetime::Organization.load(identifier) ||
+            Onetime::Organization.find_by_extid(identifier)
+        end
+
+        def truthy?(value)
+          %w[true 1 yes on].include?(value.to_s.strip.downcase)
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/routes.txt
+++ b/apps/api/colonel/routes.txt
@@ -41,7 +41,12 @@ DELETE /banned-ips/:ip                    ColonelAPI::Logic::Colonel::UnbanIP re
 
 # Custom Domains
 GET    /domains                           ColonelAPI::Logic::Colonel::ListCustomDomains response=json auth=sessionauth role=colonel scope=internal
+# Domain toolbox (ticket #43): literal /domains/orphaned MUST precede /domains/:extid so it wins.
+GET    /domains/orphaned                 ColonelAPI::Logic::Colonel::ListOrphanedDomains response=json auth=sessionauth role=colonel scope=internal
 POST   /domains/:extid/verify             ColonelAPI::Logic::Colonel::VerifyCustomDomain response=json auth=sessionauth role=colonel scope=internal
+GET    /domains/:extid/probe             ColonelAPI::Logic::Colonel::ProbeDomain response=json auth=sessionauth role=colonel scope=internal
+POST   /domains/:extid/repair            ColonelAPI::Logic::Colonel::RepairDomain response=json auth=sessionauth role=colonel scope=internal
+POST   /domains/:extid/transfer          ColonelAPI::Logic::Colonel::TransferDomain response=json auth=sessionauth role=colonel scope=internal
 
 # Organizations
 GET    /organizations                     ColonelAPI::Logic::Colonel::ListOrganizations response=json auth=sessionauth role=colonel scope=internal
@@ -53,3 +58,30 @@ DELETE /organizations/:org_id/entitlements/overrides ColonelAPI::Logic::Colonel:
 
 # Usage Export
 GET    /usage/export                      ColonelAPI::Logic::Colonel::ExportUsage response=json auth=sessionauth role=colonel scope=internal
+
+# Sessions (ticket #40)
+GET    /sessions                          ColonelAPI::Logic::Colonel::ListSessions response=json auth=sessionauth role=colonel scope=internal
+GET    /sessions/:session_id              ColonelAPI::Logic::Colonel::GetSessionDetail response=json auth=sessionauth role=colonel scope=internal
+DELETE /sessions/:session_id              ColonelAPI::Logic::Colonel::DeleteSession response=json auth=sessionauth role=colonel scope=internal
+
+# Broadcast Banner (ticket #41)
+GET    /banner                            ColonelAPI::Logic::Colonel::GetBanner response=json auth=sessionauth role=colonel scope=internal
+POST   /banner                            ColonelAPI::Logic::Colonel::SetBanner response=json auth=sessionauth role=colonel scope=internal
+DELETE /banner                            ColonelAPI::Logic::Colonel::ClearBanner response=json auth=sessionauth role=colonel scope=internal
+
+# Queue Dead-Letter Queue (DLQ) console (ticket #42)
+GET    /queues/dlq                        ColonelAPI::Logic::Colonel::ListDlqs response=json auth=sessionauth role=colonel scope=internal
+GET    /queues/dlq/:queue                 ColonelAPI::Logic::Colonel::GetDlqMessages response=json auth=sessionauth role=colonel scope=internal
+POST   /queues/dlq/:queue/replay          ColonelAPI::Logic::Colonel::ReplayDlq response=json auth=sessionauth role=colonel scope=internal
+POST   /queues/dlq/:queue/purge           ColonelAPI::Logic::Colonel::PurgeDlq response=json auth=sessionauth role=colonel scope=internal
+
+# Email + Rate-limit Tools (ticket #44)
+GET    /email/templates                       ColonelAPI::Logic::Colonel::ListEmailTemplates response=json auth=sessionauth role=colonel scope=internal
+GET    /email/templates/:template/preview     ColonelAPI::Logic::Colonel::PreviewEmailTemplate response=json auth=sessionauth role=colonel scope=internal
+POST   /email/test                            ColonelAPI::Logic::Colonel::SendTestEmail response=json auth=sessionauth role=colonel scope=internal
+GET    /ratelimit/limiters                    ColonelAPI::Logic::Colonel::ListRateLimiters response=json auth=sessionauth role=colonel scope=internal
+GET    /ratelimit/inspect                     ColonelAPI::Logic::Colonel::InspectRateLimit response=json auth=sessionauth role=colonel scope=internal
+POST   /ratelimit/reset                       ColonelAPI::Logic::Colonel::ResetRateLimit response=json auth=sessionauth role=colonel scope=internal
+
+# Billing Catalog (ticket #45, read-only plan drift)
+GET    /billing/catalog                   ColonelAPI::Logic::Colonel::GetBillingCatalog response=json auth=sessionauth role=colonel scope=internal

--- a/apps/api/domains/cli/orphaned_command.rb
+++ b/apps/api/domains/cli/orphaned_command.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative 'helpers'
+require 'onetime/operations/domains/orphaned_scan'
 
 module Onetime
   module CLI
@@ -15,12 +16,11 @@ module Onetime
       def call(**)
         boot_application!
 
-        all_domain_ids = Onetime::CustomDomain.instances.all
-        all_domains    = all_domain_ids.map do |did|
-          Onetime::CustomDomain.find_by_identifier(did)
-        end.compact
-
-        orphaned_domains = all_domains.select { |d| d.org_id.to_s.empty? }
+        # Delegate to the single op implementation (read-only, no audit). Passing
+        # per_page: nil returns the full sorted collection — preserving the CLI's
+        # "list all orphaned, sorted by display_domain" output.
+        result           = Onetime::Operations::Domains::OrphanedScan.new(per_page: nil).call
+        orphaned_domains = result.domains
 
         puts "#{orphaned_domains.size} orphaned custom domains found"
         return if orphaned_domains.empty?
@@ -29,14 +29,14 @@ module Onetime
         puts format('%-40s %-12s %-10s %-20s', 'Domain', 'Status', 'Verified', 'Created')
         puts '-' * 85
 
-        orphaned_domains.sort_by(&:display_domain).each do |domain|
-          status   = domain.verification_state || 'unknown'
-          verified = domain.verified || 'false'
-          created  = format_timestamp(domain.created)
+        orphaned_domains.each do |domain|
+          status   = domain[:verification_state].to_s.empty? ? 'unknown' : domain[:verification_state]
+          verified = domain[:verified] ? 'true' : 'false'
+          created  = format_timestamp(domain[:created])
 
           puts format(
             '%-40s %-12s %-10s %-20s',
-            domain.display_domain,
+            domain[:display_domain],
             status,
             verified,
             created,

--- a/apps/api/domains/cli/probe_command.rb
+++ b/apps/api/domains/cli/probe_command.rb
@@ -3,9 +3,8 @@
 # frozen_string_literal: true
 
 require_relative 'helpers'
-require 'net/http'
-require 'openssl'
 require 'json'
+require 'onetime/operations/domains/probe'
 
 module Onetime
   module CLI
@@ -38,7 +37,14 @@ module Onetime
         domain = load_domain_by_name(domain_name)
         return unless domain
 
-        result = probe_domain(domain.display_domain, timeout, insecure)
+        # Delegate the probe to the single op implementation (read-only, no audit).
+        # The op returns the SAME result Hash the CLI previously built inline, so
+        # the --json output is byte-identical.
+        result = Onetime::Operations::Domains::Probe.new(
+          hostname: domain.display_domain,
+          timeout: timeout,
+          insecure: insecure,
+        ).call
 
         if json
           puts JSON.pretty_generate(result)
@@ -48,111 +54,6 @@ module Onetime
       end
 
       private
-
-      def probe_domain(hostname, timeout, insecure)
-        result = {
-          timestamp: Time.now.utc.iso8601,
-          domain: hostname,
-          url: "https://#{hostname}",
-        }
-
-        begin
-          uri  = URI.parse("https://#{hostname}")
-          http = build_http_client(uri, timeout, insecure)
-          cert = nil
-
-          response = http.start do |client|
-            # Capture cert while connection is open
-            cert                  = client.peer_cert
-            request               = Net::HTTP::Get.new(uri.request_uri)
-            request['User-Agent'] = 'OTS-Domain-Probe/1.0'
-            client.request(request)
-          end
-
-          result[:http] = {
-            status_code: response.code.to_i,
-            status_message: response.message,
-            success: response.is_a?(Net::HTTPSuccess) || response.is_a?(Net::HTTPRedirection),
-          }
-
-          result[:ssl]    = extract_ssl_info_from_cert(cert)
-          result[:health] = determine_health(result)
-        rescue OpenSSL::SSL::SSLError => ex
-          result[:http]   = { error: 'SSL Error', message: ex.message }
-          result[:ssl]    = { valid: false, error: ex.message }
-          result[:health] = 'ssl_error'
-        rescue Errno::ECONNREFUSED => ex
-          result[:http]   = { error: 'Connection Refused', message: ex.message }
-          result[:health] = 'connection_refused'
-        rescue Errno::ECONNRESET => ex
-          result[:http]   = { error: 'Connection Reset', message: ex.message }
-          result[:health] = 'connection_reset'
-        rescue Net::OpenTimeout, Net::ReadTimeout => ex
-          result[:http]   = { error: 'Timeout', message: ex.message }
-          result[:health] = 'timeout'
-        rescue SocketError => ex
-          result[:http]   = { error: 'DNS Resolution Failed', message: ex.message }
-          result[:health] = 'dns_error'
-        rescue StandardError => ex
-          result[:http]   = { error: ex.class.name, message: ex.message }
-          result[:health] = 'error'
-        end
-
-        result
-      end
-
-      def build_http_client(uri, timeout, insecure)
-        http              = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl      = true
-        http.open_timeout = timeout
-        http.read_timeout = timeout
-
-        http.verify_mode = if insecure
-          OpenSSL::SSL::VERIFY_NONE
-        else
-          OpenSSL::SSL::VERIFY_PEER
-                           end
-
-        http
-      end
-
-      def extract_ssl_info_from_cert(cert)
-        return { valid: false, error: 'No certificate' } unless cert
-
-        now               = Time.now
-        not_before        = cert.not_before
-        not_after         = cert.not_after
-        days_until_expiry = ((not_after - now) / 86_400).to_i
-
-        {
-          valid: true,
-          subject: cert.subject.to_s,
-          issuer: cert.issuer.to_s,
-          not_before: not_before.iso8601,
-          not_after: not_after.iso8601,
-          days_until_expiry: days_until_expiry,
-          expired: now > not_after,
-          not_yet_valid: now < not_before,
-        }
-      rescue StandardError => ex
-        { valid: false, error: ex.message }
-      end
-
-      def determine_health(result)
-        http = result[:http]
-        ssl  = result[:ssl]
-
-        return 'error' if http[:error]
-        return 'ssl_invalid' unless ssl[:valid]
-        return 'ssl_expired' if ssl[:expired]
-        return 'ssl_expiring_soon' if ssl[:days_until_expiry] && ssl[:days_until_expiry] < 7
-
-        if http[:success]
-          'healthy'
-        else
-          'http_error'
-        end
-      end
 
       def display_probe_result(domain, result)
         puts '=' * 80

--- a/apps/api/domains/cli/repair_command.rb
+++ b/apps/api/domains/cli/repair_command.rb
@@ -3,12 +3,18 @@
 # frozen_string_literal: true
 
 require_relative 'helpers'
+require 'onetime/operations/domains/repair'
 
 module Onetime
   module CLI
     # Repair domain
     class DomainsRepairCommand < Command
       include DomainsHelpers
+
+      # Audit actor recorded for CLI-initiated mutations. The shell carries no
+      # authenticated colonel identity; a plain, non-secret public sentinel is
+      # used — never an internal objid. Mirrors BannedIpsBanCommand::CLI_ACTOR.
+      CLI_ACTOR = 'cli'
 
       desc 'Fix domain relationship issues'
 
@@ -33,53 +39,32 @@ module Onetime
         puts "Checking domain: #{domain_name}"
         puts
 
-        issues_found = []
-        repairs      = []
+        # Resolve the target org for the ORPHANED case silently — the op decides
+        # whether it's needed (it's ignored when the domain already has an org_id).
+        org = org_id ? load_organization(org_id, silent: true) : nil
 
-        # Check 1: Orphaned domain
-        if domain.org_id.to_s.empty?
-          if org_id
-            issues_found << 'Domain is orphaned (no org_id)'
-            repairs << -> {
-              domain.org_id  = org_id
-              domain.updated = OT.now.to_i
-              domain.save
-              org            = load_organization(org_id)
-              org.add_domain(domain.domainid) if org
-              "Assigned to organization #{org_id}"
-            }
-          else
-            puts 'Issue: Domain is orphaned (no org_id)'
-            puts 'Fix: Provide --org-id=<id> to assign to an organization'
-            return
-          end
-        else
-          # Check 2: org_id set but not in organization's collection
-          org = load_organization(domain.org_id)
-          if org
-            domains_in_org = org.list_domains
-            unless domains_in_org.include?(domain.domainid)
-              issues_found << "org_id is #{domain.org_id} but not in organization's domains collection"
-              repairs << -> {
-                org.add_domain(domain.domainid)
-                "Added to organization #{domain.org_id} collection"
-              }
-            end
-          else
-            issues_found << "org_id is #{domain.org_id} but organization not found"
-            puts "Issue: org_id is #{domain.org_id} but organization not found"
-            puts 'Fix: Provide --org-id=<id> to assign to a valid organization'
-            return
-          end
-        end
+        # Dry-run first to compute the plan (issues found) without mutating.
+        plan = Onetime::Operations::Domains::Repair.new(
+          domain: domain, org: org, actor: CLI_ACTOR, dry_run: true,
+        ).call
 
-        if issues_found.empty?
+        case plan.status
+        when :needs_org
+          puts 'Issue: Domain is orphaned (no org_id)'
+          puts 'Fix: Provide --org-id=<id> to assign to an organization'
+          return
+        when :org_not_found
+          puts "Error: Organization '#{domain.org_id}' not found"
+          puts "Issue: org_id is #{domain.org_id} but organization not found"
+          puts 'Fix: Provide --org-id=<id> to assign to a valid organization'
+          return
+        when :no_issues
           puts 'No issues found - domain relationships are consistent'
           return
         end
 
         puts 'Issues Found:'
-        issues_found.each_with_index do |issue, idx|
+        plan.issues.each_with_index do |issue, idx|
           puts "  #{idx + 1}. #{issue}"
         end
         puts
@@ -93,13 +78,17 @@ module Onetime
           end
         end
 
+        # Apply — the op mutates and records exactly one audit event.
+        result = Onetime::Operations::Domains::Repair.new(
+          domain: domain, org: org, actor: CLI_ACTOR, dry_run: false,
+        ).call
+
         puts 'Applying repairs:'
-        repairs.each do |repair|
-          result = repair.call
-          puts "  #{result}"
+        result.repairs_applied.each do |repair_result|
+          puts "  #{repair_result}"
         end
 
-        OT.info "[CLI] Domain repair: #{domain_name} - #{issues_found.size} issues fixed"
+        OT.info "[CLI] Domain repair: #{domain_name} - #{result.issues.size} issues fixed"
         puts
         puts 'Repair complete'
       end

--- a/apps/api/domains/cli/transfer_command.rb
+++ b/apps/api/domains/cli/transfer_command.rb
@@ -3,12 +3,16 @@
 # frozen_string_literal: true
 
 require_relative 'helpers'
+require 'onetime/operations/domains/transfer'
 
 module Onetime
   module CLI
     # Transfer domain
     class DomainsTransferCommand < Command
       include DomainsHelpers
+
+      # Audit actor recorded for CLI-initiated mutations (see repair command).
+      CLI_ACTOR = 'cli'
 
       desc 'Transfer domain between organizations'
 
@@ -35,35 +39,43 @@ module Onetime
         domain = load_domain_by_name(domain_name)
         return unless domain
 
-        from_org_id = from_org || domain.org_id
-
-        # Load organizations
+        # Resolve the destination (required) and, when explicitly given, the source
+        # org for the ownership assertion. load_organization prints + returns nil on
+        # a miss, preserving the CLI's error output.
         to_org_obj = load_organization(to_org)
         return unless to_org_obj
 
         from_org_obj = nil
-        if from_org_id.to_s.empty?
-          puts 'Note: Domain is currently orphaned (no organization)'
-        else
-          from_org_obj = load_organization(from_org_id)
+        if from_org
+          from_org_obj = load_organization(from_org)
           return unless from_org_obj
-
-          # Verify current ownership
-          unless domain.org_id.to_s == from_org_id.to_s
-            puts "Error: Domain org_id (#{domain.org_id}) does not match --from-org (#{from_org_id})"
-            return
-          end
         end
 
-        # Display transfer details
+        # Dry-run to compute the transfer plan (from/to details, ownership check).
+        plan = Onetime::Operations::Domains::Transfer.new(
+          domain: domain,
+          to_org: to_org_obj,
+          from_org: from_org_obj,
+          actor: CLI_ACTOR,
+          dry_run: true,
+        ).call
+
+        if plan.status == :mismatch
+          puts "Error: Domain org_id (#{domain.org_id}) does not match --from-org (#{from_org})"
+          return
+        end
+
+        # Display transfer details from the plan.
+        puts 'Note: Domain is currently orphaned (no organization)' if domain.org_id.to_s.empty?
+
         puts 'Transfer Details:'
         puts "  Domain:               #{domain_name}"
-        if from_org_obj
-          puts "  From Organization:    #{from_org_obj.display_name || 'N/A'} (#{from_org_obj.org_id})"
-        else
+        if plan.from_org_id.to_s.empty?
           puts '  From Organization:    ORPHANED'
+        else
+          puts "  From Organization:    #{plan.from_org_name || 'N/A'} (#{plan.from_org_id})"
         end
-        puts "  To Organization:      #{to_org_obj.display_name || 'N/A'} (#{to_org_obj.org_id})"
+        puts "  To Organization:      #{plan.to_org_name || 'N/A'} (#{plan.to_org_id})"
         puts
 
         unless force
@@ -75,33 +87,23 @@ module Onetime
           end
         end
 
-        # Perform transfer
+        # Perform the transfer — the op mutates + records exactly one audit event.
         begin
-          # Remove from old organization's collection if exists
-          if from_org_obj
-            from_org_obj.remove_domain(domain.domainid)
-            puts "  Removed from #{from_org_obj.display_name || from_org_obj.org_id}"
+          result = Onetime::Operations::Domains::Transfer.new(
+            domain: domain,
+            to_org: to_org_obj,
+            from_org: from_org_obj,
+            actor: CLI_ACTOR,
+            dry_run: false,
+          ).call
+
+          unless result.from_org_id.to_s.empty?
+            puts "  Removed from #{result.from_org_name || result.from_org_id}"
           end
+          puts "  Added to #{result.to_org_name || result.to_org_id}"
+          puts '  Updated org_id field'
 
-          # TODO: Make this atomic - add_domain should handle both org_id update and collection add
-          # Update domain's org_id
-          domain.org_id  = to_org
-          domain.updated = OT.now.to_i
-          domain.save
-
-          # Add to new organization's collection
-          begin
-            to_org_obj.add_domain(domain.domainid)
-            puts "  Added to #{to_org_obj.display_name || to_org_obj.org_id}"
-            puts '  Updated org_id field'
-          rescue StandardError => ex
-            # Rollback: restore original org_id if collection add fails
-            domain.org_id = from_org_id
-            domain.save
-            raise "Failed to add domain to organization collection: #{ex.message}"
-          end
-
-          OT.info "[CLI] Domain transfer: #{domain_name} from #{from_org_id || 'orphaned'} to #{to_org}"
+          OT.info "[CLI] Domain transfer: #{domain_name} from #{result.from_org_id.to_s.empty? ? 'orphaned' : result.from_org_id} to #{to_org}"
           puts
           puts 'Transfer complete'
         rescue StandardError => ex

--- a/lib/onetime/cli/banner/clear_command.rb
+++ b/lib/onetime/cli/banner/clear_command.rb
@@ -13,6 +13,12 @@
 #   bin/ots banner clear --apply   # delete the key
 #
 
+# The actual delete + runtime refresh + audit event is performed by the shared
+# Onetime::Operations::ClearBanner op (the single implementation). This command
+# owns only CLI concerns (the dry-run text + confirmation output). Required
+# explicitly since the CLI runs outside the app autoloader.
+require 'onetime/operations/banner'
+
 module Onetime
   module CLI
     class BannerClearCommand < Command
@@ -40,8 +46,10 @@ module Onetime
         puts
 
         if apply
-          db.del(BANNER_KEY)
-          Onetime::Runtime.update_features(global_banner: nil)
+          # Single implementation: the op owns the delete, the runtime refresh, and
+          # (new) the admin audit event. The empty-banner short-circuit above means
+          # the op always finds a banner here and clears it. Output unchanged.
+          Onetime::Operations::ClearBanner.new(actor: CLI_ACTOR).call
 
           puts 'Banner cleared.'
           puts

--- a/lib/onetime/cli/banner/set_command.rb
+++ b/lib/onetime/cli/banner/set_command.rb
@@ -19,6 +19,13 @@
 require 'cgi'
 require 'sanitize'
 
+# The actual Redis write + runtime refresh + audit event is performed by the
+# shared Onetime::Operations::SetBanner op (the single implementation; the colonel
+# POST /api/colonel/banner endpoint is the other adapter). This command owns only
+# CLI concerns (arg/file parsing, the ASCII preview, dry-run text). The CLI runs
+# outside the app autoloader, so require the op explicitly.
+require 'onetime/operations/banner'
+
 module Onetime
   module CLI
     class BannerSetCommand < Command
@@ -147,15 +154,13 @@ module Onetime
       end
 
       def write_banner(banner_text, ttl)
-        db = Familia.dbclient(0)
-
-        if ttl
-          db.setex(BANNER_KEY, ttl, banner_text)
-        else
-          db.set(BANNER_KEY, banner_text)
-        end
-
-        Onetime::Runtime.update_features(global_banner: banner_text)
+        # Single implementation: the op owns the Redis write, the runtime refresh,
+        # and (new) the admin audit event. Output below is unchanged (golden-master).
+        Onetime::Operations::SetBanner.new(
+          content: banner_text,
+          ttl: ttl,
+          actor: CLI_ACTOR,
+        ).call
 
         puts
         puts 'Banner set.'

--- a/lib/onetime/cli/banner/shared.rb
+++ b/lib/onetime/cli/banner/shared.rb
@@ -11,6 +11,11 @@ module Onetime
       module Shared
         BANNER_KEY = 'global_banner'
 
+        # Public identity recorded as the audit actor for banner mutations made
+        # from the shell. Mirrors Customers::Shared::CLI_ACTOR — a sentinel PUBLIC
+        # id, never an internal objid (AdminAuditEvent requires a public actor).
+        CLI_ACTOR = 'cli'
+
         def humanize_seconds(seconds)
           if seconds >= 86_400
             format('%dd %dh', seconds / 86_400, (seconds % 86_400) / 3600)

--- a/lib/onetime/cli/banner/show_command.rb
+++ b/lib/onetime/cli/banner/show_command.rb
@@ -12,6 +12,12 @@
 
 require 'json'
 
+# The read is performed by the shared Onetime::Operations::GetBanner op (the
+# single implementation of the banner "get" verb; the colonel GET
+# /api/colonel/banner endpoint is the other adapter). This command owns only the
+# text/JSON formatting. Required explicitly (CLI runs outside the autoloader).
+require 'onetime/operations/banner'
+
 module Onetime
   module CLI
     class BannerShowCommand < Command
@@ -27,33 +33,33 @@ module Onetime
       def call(json: false, **)
         boot_application!
 
-        db          = Familia.dbclient(0)
-        banner_text = db.get(BANNER_KEY)
-        ttl         = db.ttl(BANNER_KEY)
+        # GetBanner normalises ttl to nil for a persistent/absent banner (Redis's
+        # -1/-2 sentinels), matching the display logic below.
+        banner = Onetime::Operations::GetBanner.new.call
 
         if json
-          display_json(banner_text, ttl)
+          display_json(banner)
         else
-          display_text(banner_text, ttl)
+          display_text(banner)
         end
       end
 
       private
 
-      def display_json(banner_text, ttl)
+      def display_json(banner)
         data = {
-          key: BANNER_KEY,
-          database: 0,
-          value: banner_text,
-          ttl: ttl.negative? ? nil : ttl,
-          active: !banner_text.nil? && !banner_text.empty?,
+          key: banner.key,
+          database: banner.database,
+          value: banner.content,
+          ttl: banner.ttl,
+          active: banner.active,
         }
 
         puts JSON.pretty_generate(data)
       end
 
-      def display_text(banner_text, ttl)
-        if banner_text.nil? || banner_text.empty?
+      def display_text(banner)
+        unless banner.active
           puts 'No banner is currently set.'
           return
         end
@@ -61,11 +67,11 @@ module Onetime
         puts 'Global broadcast banner'
         puts '=' * 60
         puts
-        puts format('  %-10s %s', 'Content:', banner_text)
-        puts format('  %-10s %d characters', 'Length:', banner_text.length)
+        puts format('  %-10s %s', 'Content:', banner.content)
+        puts format('  %-10s %d characters', 'Length:', banner.content.length)
 
-        if ttl >= 0
-          puts format('  %-10s %d seconds (%s)', 'TTL:', ttl, humanize_seconds(ttl))
+        if banner.ttl
+          puts format('  %-10s %d seconds (%s)', 'TTL:', banner.ttl, humanize_seconds(banner.ttl))
         else
           puts format('  %-10s none (persistent)', 'TTL:')
         end

--- a/lib/onetime/cli/banner_command.rb
+++ b/lib/onetime/cli/banner_command.rb
@@ -17,6 +17,8 @@
 #   bin/ots banner clear                  # Dry-run (safe default)
 #   bin/ots banner clear --apply          # Remove from Redis + refresh runtime
 
+require 'onetime/operations/banner'
+
 module Onetime
   module CLI
     class BannerCommand < Command
@@ -27,10 +29,11 @@ module Onetime
       def call(**)
         boot_application!
 
-        banner_text = Familia.dbclient(0).get(BANNER_KEY)
+        # Single implementation: read the current banner through the shared op.
+        banner = Onetime::Operations::GetBanner.new.call
 
-        if banner_text && !banner_text.empty?
-          puts format('Current banner: %s', banner_text)
+        if banner.active
+          puts format('Current banner: %s', banner.content)
         else
           puts 'No banner is currently set.'
         end

--- a/lib/onetime/cli/email.rb
+++ b/lib/onetime/cli/email.rb
@@ -3,26 +3,20 @@
 # frozen_string_literal: true
 
 # Shared module for email CLI commands.
-# Houses the canonical template list and any shared helpers.
+#
+# The canonical template list and sample-data path now live in the extracted
+# central operation {Onetime::Operations::Email::PreviewTemplate} (ticket #44) —
+# the SINGLE source shared by the colonel API, the ops, and this CLI. These
+# aliases keep every existing `Onetime::CLI::Email::AVAILABLE_TEMPLATES` /
+# `SAMPLES_PATH` reference working with a byte-identical value.
+
+require 'onetime/operations/email/preview_template'
 
 module Onetime
   module CLI
     module Email
-      AVAILABLE_TEMPLATES = [
-        :secret_link,
-        :welcome,
-        :password_request,
-        :incoming_secret,
-        :feedback_email,
-        :secret_revealed,
-        :expiration_warning,
-        :organization_invitation,
-        :email_change_confirmation,
-        :email_change_requested,
-        :email_changed,
-      ].freeze
-
-      SAMPLES_PATH = File.expand_path('../mail/samples', __dir__)
+      AVAILABLE_TEMPLATES = Onetime::Operations::Email::AVAILABLE_TEMPLATES
+      SAMPLES_PATH        = Onetime::Operations::Email::SAMPLES_PATH
     end
   end
 end

--- a/lib/onetime/cli/email/preview_command.rb
+++ b/lib/onetime/cli/email/preview_command.rb
@@ -4,6 +4,11 @@
 
 # CLI command for previewing rendered email templates.
 #
+# Thin adapter over {Onetime::Operations::Email::PreviewTemplate} (ticket #44) —
+# the SINGLE implementation of the preview verb, shared with the colonel API.
+# The op owns the sample-data resolution + rendering; this command keeps only the
+# CLI concerns (arg/option parsing, --open, and the error messaging).
+#
 # Usage:
 #   ots email preview <template>                  # Text output using sample data
 #   ots email preview <template> --html           # HTML output
@@ -12,7 +17,7 @@
 #   ots email preview <template> --locale fr
 
 require 'json'
-require 'yaml'
+require 'onetime/operations/email/preview_template'
 
 module Onetime
   module CLI
@@ -48,20 +53,24 @@ module Onetime
         def call(template:, html: false, data: nil, locale: 'en', open: false, **)
           boot_application!
 
-          template_data  = load_data(data, template)
-          template_class = resolve_template(template)
-          instance       = template_class.new(template_data, locale: locale)
+          parsed_data = data ? JSON.parse(data).transform_keys(&:to_sym) : nil
 
-          if html
-            body = instance.render_html || '(no HTML template)'
-            if open
-              open_in_browser(body)
-            else
-              puts body
-            end
+          result = Onetime::Operations::Email::PreviewTemplate.new(
+            template: template,
+            data: parsed_data,
+            locale: locale,
+            format: html ? 'html' : 'text',
+          ).call
+
+          if html && open
+            open_in_browser(result.body)
           else
-            puts instance.render_text
+            puts result.body
           end
+        rescue Onetime::Operations::Email::PreviewTemplate::MissingSampleError => ex
+          warn ex.message
+          warn "Create a YAML file there or pass --data '{...}'"
+          exit 1
         rescue ArgumentError => ex
           handle_argument_error(ex, template)
         rescue JSON::ParserError => ex
@@ -70,38 +79,6 @@ module Onetime
         end
 
         private
-
-        def load_data(json_string, template_name)
-          if json_string
-            parsed                       = JSON.parse(json_string)
-            symbolized                   = parsed.transform_keys(&:to_sym)
-            symbolized[:recipient]     ||= 'preview@example.com'
-            symbolized[:email_address] ||= symbolized[:recipient]
-            symbolized
-          else
-            load_sample_data(template_name)
-          end
-        end
-
-        def load_sample_data(template_name)
-          sample_file = File.join(SAMPLES_PATH, "#{template_name}.yml")
-
-          unless File.exist?(sample_file)
-            warn "No sample data found: #{sample_file}"
-            warn "Create a YAML file there or pass --data '{...}'"
-            exit 1
-          end
-
-          parsed                       = YAML.safe_load_file(sample_file, permitted_classes: [Symbol])
-          symbolized                   = parsed.transform_keys(&:to_sym)
-          symbolized[:recipient]     ||= symbolized.delete(:email_address) || 'preview@example.com'
-          symbolized[:email_address] ||= symbolized[:recipient]
-          symbolized
-        end
-
-        def resolve_template(name)
-          Onetime::Mail::Mailer.send(:template_class_for, name.to_sym)
-        end
 
         def open_in_browser(html_body)
           require 'tempfile'

--- a/lib/onetime/cli/email/templates_command.rb
+++ b/lib/onetime/cli/email/templates_command.rb
@@ -10,6 +10,7 @@
 #   ots email templates --format json
 
 require 'json'
+require 'onetime/operations/email/list_templates'
 
 module Onetime
   module CLI
@@ -71,16 +72,15 @@ module Onetime
           end
         end
 
+        # Routes through the extracted op (ticket #44) — the SINGLE implementation
+        # of the template list the colonel API also uses. Reshaped to the CLI's
+        # existing hash shape (`:class`) so the rendered/JSON output is unchanged.
         def build_template_list
-          AVAILABLE_TEMPLATES.map do |name|
-            template_class = Onetime::Mail::Mailer.send(:template_class_for, name)
-            has_html       = File.exist?(erb_path(name, 'html'))
-            has_text       = File.exist?(erb_path(name, 'txt'))
-
+          Onetime::Operations::Email::ListTemplates.new.call.map do |entry|
             {
-              name: name.to_s,
-              class: template_class.name.split('::').last,
-              formats: [has_text ? 'text' : nil, has_html ? 'html' : nil].compact,
+              name: entry.name,
+              class: entry.klass,
+              formats: entry.formats,
             }
           end
         end

--- a/lib/onetime/cli/email/test_command.rb
+++ b/lib/onetime/cli/email/test_command.rb
@@ -18,12 +18,18 @@
 
 require 'json'
 require 'socket'
+require 'onetime/operations/email/send_test'
 
 module Onetime
   module CLI
     module Email
       class TestCommand < Command
         desc 'Send a test email to verify delivery connectivity'
+
+        # Audit actor sentinel for CLI-initiated sends (matches the customer /
+        # session / DLQ CLI convention). The extracted op records one audit event
+        # per successful real send, attributed to this sentinel on the shell path.
+        CLI_ACTOR = 'cli'
 
         option :to,
           type: :string,
@@ -49,34 +55,30 @@ module Onetime
         def call(to:, dry_run: false, format: 'text', enqueue: false, **)
           boot_application!
 
-          provider  = Onetime::Mail::Mailer.send(:determine_provider)
-          hostname  = Socket.gethostname
-          timestamp = Time.now.utc.iso8601
-
-          # Brand-aware copy: a hardcoded vendor literal would leak into a
-          # white-label install's outbound test email (#3612).
-          product_name = Onetime::CustomDomain::BrandSettingsConstants.global_defaults[:product_name] ||
-                         Onetime::CustomDomain::BrandSettingsConstants::NEUTRAL_PRODUCT_NAME
-
-          email = {
-            to: to,
-            from: Onetime::Mail::Mailer.from_address,
-            subject: "[#{product_name}] Email delivery test - #{timestamp}",
-            text_body: "This is a test email from the #{product_name} CLI.\n\nProvider: #{provider}\nTimestamp: #{timestamp}\nHost: #{hostname}",
+          # Build the exact diagnostic email through the extracted op — the SINGLE
+          # implementation shared with the colonel API (ticket #44). The op owns
+          # the brand-aware subject/body + provider/host probe; this command keeps
+          # its own output + timing + exit-code behaviour byte-for-byte.
+          diagnostic = Onetime::Operations::Email::SendTest.build(to: to)
+          email      = {
+            to: diagnostic.to,
+            from: diagnostic.from,
+            subject: diagnostic.subject,
+            text_body: diagnostic.text_body,
           }
 
           if format == 'json'
-            output_json(email, provider, hostname, dry_run, enqueue: enqueue)
+            output_json(email, diagnostic.provider, diagnostic.host, dry_run, enqueue: enqueue)
           else
-            output_text(email, provider, hostname, dry_run, enqueue: enqueue)
+            output_text(email, diagnostic.provider, diagnostic.host, dry_run, enqueue: enqueue)
           end
 
           return if dry_run
 
           if enqueue
-            enqueue!(email)
+            enqueue!(to)
           else
-            deliver!(email)
+            deliver!(to)
           end
         rescue StandardError => ex
           warn "Error: #{ex.message}"
@@ -85,9 +87,15 @@ module Onetime
 
         private
 
-        def deliver!(email)
+        # Route the actual send through the op (which records the audit event on
+        # success); keep the CLI's timing + status output identical. The op raises
+        # the same delivery exceptions the inline call did, so this rescue is
+        # unchanged behaviourally.
+        def deliver!(to)
           start   = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-          Onetime::Mail::Mailer.delivery_backend.deliver(email)
+          Onetime::Operations::Email::SendTest.new(
+            to: to, actor: CLI_ACTOR, dry_run: false, enqueue: false
+          ).call
           elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
 
           puts
@@ -100,22 +108,15 @@ module Onetime
           exit 1
         end
 
-        def enqueue!(email)
-          require_relative '../../../onetime/jobs/publisher'
-
-          start      = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-          # Convert to raw email format expected by Publisher
-          raw_email  = {
-            to: email[:to],
-            from: email[:from],
-            subject: email[:subject],
-            body: email[:text_body],
-          }
-          queued     = Onetime::Jobs::Publisher.enqueue_email_raw(raw_email, fallback: :raise)
-          elapsed    = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+        def enqueue!(to)
+          start   = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          result  = Onetime::Operations::Email::SendTest.new(
+            to: to, actor: CLI_ACTOR, dry_run: false, enqueue: true
+          ).call
+          elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
 
           puts
-          if queued
+          if result.status == :enqueued
             puts format('Status:    ENQUEUED (%.2fs)', elapsed)
             puts 'Queue:     email.message.send'
             puts

--- a/lib/onetime/cli/queue/dlq_command.rb
+++ b/lib/onetime/cli/queue/dlq_command.rb
@@ -11,16 +11,37 @@
 #   ots queue dlq replay <queue>        Replay messages back to original queue
 #   ots queue dlq purge <queue>         Remove messages from DLQ
 #
+# The DLQ list / show / replay / purge capability now lives in central operations
+# (epic #42 / D3): the SINGLE implementation of each verb. These CLI commands are
+# thin adapters over Onetime::Operations::Dlq::{List, Peek, Show, Replay, Purge}
+# and Onetime::Operations::Dlq::Store, preserving the historic output byte-for-byte
+# while the same ops now back the new colonel `/api/colonel/queues/dlq…` endpoints.
+# Loaded explicitly because CLI runs don't go through an app autoloader.
+#
 
 require 'bunny'
 require 'json'
 require_relative '../../jobs/queues/config'
+require 'onetime/operations/dlq/store'
+require 'onetime/operations/dlq/list'
+require 'onetime/operations/dlq/peek'
+require 'onetime/operations/dlq/show'
+require 'onetime/operations/dlq/replay'
+require 'onetime/operations/dlq/purge'
 
 module Onetime
   module CLI
     module Queue
       # Base class with shared DLQ functionality
       class DlqBase < Command
+        # Audit actor sentinel for CLI-initiated mutations (matches the session /
+        # banner CLI convention). The colonel endpoints pass the acting colonel's
+        # PUBLIC extid instead.
+        CLI_ACTOR = 'cli'
+
+        # The single extracted DLQ store (name allowlist + message projections).
+        Store = Onetime::Operations::Dlq::Store
+
         private
 
         # Map short queue names to full DLQ queue names
@@ -29,21 +50,12 @@ module Onetime
           return name if name.start_with?('dlq.')
 
           dlq_name = "dlq.#{name}"
-          unless valid_dlq?(dlq_name)
-            valid_names = Onetime::Jobs::QueueConfig::DEAD_LETTER_CONFIG.values.map { |v| v[:queue] }
+          unless Store.valid?(dlq_name)
             puts "Unknown DLQ: #{name}"
-            puts "Available DLQs: #{valid_names.map { |n| n.sub('dlq.', '') }.join(', ')}"
+            puts "Available DLQs: #{Store.short_names.join(', ')}"
             exit 1
           end
           dlq_name
-        end
-
-        def valid_dlq?(dlq_name)
-          Onetime::Jobs::QueueConfig::DEAD_LETTER_CONFIG.values.any? { |v| v[:queue] == dlq_name }
-        end
-
-        def all_dlq_names
-          Onetime::Jobs::QueueConfig::DEAD_LETTER_CONFIG.values.map { |v| v[:queue] }
         end
 
         def with_rabbitmq_connection
@@ -53,18 +65,6 @@ module Onetime
           yield conn
         ensure
           conn&.close
-        end
-
-        def format_age(timestamp)
-          return 'unknown' unless timestamp
-
-          age_seconds = Time.now.to_i - timestamp.to_i
-          case age_seconds
-          when 0..59 then "#{age_seconds}s ago"
-          when 60..3599 then "#{age_seconds / 60}m ago"
-          when 3600..86_399 then "#{age_seconds / 3600}h ago"
-          else "#{age_seconds / 86_400}d ago"
-          end
         end
       end
 
@@ -101,16 +101,7 @@ module Onetime
 
         def list_all_dlqs(format)
           with_rabbitmq_connection do |conn|
-            channel = conn.create_channel
-            summary = []
-
-            all_dlq_names.each do |dlq_name|
-              info = get_queue_info(channel, dlq_name)
-              summary << info
-            rescue Bunny::NotFound
-              summary << { queue: dlq_name, messages: 0, error: 'not declared' }
-              channel = conn.create_channel
-            end
+            summary = Onetime::Operations::Dlq::List.new(connection: conn).call.dlqs
 
             if format == 'json'
               puts JSON.pretty_generate(summary)
@@ -121,15 +112,6 @@ module Onetime
         rescue StandardError => ex
           puts "Error connecting to RabbitMQ: #{ex.message}"
           exit 1
-        end
-
-        def get_queue_info(channel, dlq_name)
-          queue = channel.queue(dlq_name, durable: true, passive: true)
-          {
-            queue: dlq_name,
-            messages: queue.message_count,
-            consumers: queue.consumer_count,
-          }
         end
 
         def display_summary_text(summary)
@@ -157,28 +139,26 @@ module Onetime
 
         def list_queue_messages(dlq_name, format, limit)
           with_rabbitmq_connection do |conn|
-            channel = conn.create_channel
-            queue   = channel.queue(dlq_name, durable: true, passive: true)
+            result = Onetime::Operations::Dlq::Peek.new(
+              connection: conn, queue: dlq_name, limit: limit,
+            ).call
 
-            message_count = queue.message_count
-            if message_count == 0
+            if result.total_messages == 0
               puts "No messages in #{dlq_name}"
               return
             end
-
-            messages = peek_messages(channel, dlq_name, [limit, message_count].min)
 
             if format == 'json'
               puts JSON.pretty_generate(
                 {
                   queue: dlq_name,
-                  total_messages: message_count,
-                  showing: messages.size,
-                  messages: messages,
+                  total_messages: result.total_messages,
+                  showing: result.messages.size,
+                  messages: result.messages,
                 },
               )
             else
-              display_messages_text(dlq_name, message_count, messages)
+              display_messages_text(dlq_name, result.total_messages, result.messages)
             end
           end
         rescue Bunny::NotFound
@@ -187,49 +167,6 @@ module Onetime
         rescue StandardError => ex
           puts "Error: #{ex.message}"
           exit 1
-        end
-
-        def peek_messages(channel, dlq_name, count)
-          messages = []
-          queue    = channel.queue(dlq_name, durable: true, passive: true)
-
-          count.times do
-            delivery_info, properties, payload = queue.pop(manual_ack: true)
-            break unless delivery_info
-
-            begin
-              death_info = extract_death_info(properties.headers)
-              messages << {
-                delivery_tag: delivery_info.delivery_tag,
-                message_id: properties.message_id,
-                timestamp: properties.timestamp&.to_i,
-                age: format_age(properties.timestamp),
-                original_queue: death_info[:queue],
-                death_reason: death_info[:reason],
-                death_count: death_info[:count],
-                error: death_info[:error],
-                content_type: properties.content_type,
-                payload_preview: payload.to_s[0..200],
-              }
-            ensure
-              # Always nack with requeue to return message to queue
-              channel.nack(delivery_info.delivery_tag, false, true)
-            end
-          end
-
-          messages
-        end
-
-        def extract_death_info(headers)
-          return {} unless headers
-
-          death = headers['x-death']&.first || {}
-          {
-            queue: death['queue'],
-            reason: death['reason'],
-            count: death['count'],
-            error: headers['x-exception'] || headers['x-error'],
-          }
         end
 
         def display_messages_text(dlq_name, total, messages)
@@ -288,89 +225,29 @@ module Onetime
 
         def show_message(dlq_name, message_id, index, format)
           with_rabbitmq_connection do |conn|
-            channel = conn.create_channel
-            queue   = channel.queue(dlq_name, durable: true, passive: true)
+            result = Onetime::Operations::Dlq::Show.new(
+              connection: conn, queue: dlq_name, message_id: message_id, index: index,
+            ).call
 
-            if queue.message_count == 0
+            if result.empty
               puts "No messages in #{dlq_name}"
               return
             end
 
-            message = find_message(channel, dlq_name, message_id, index, queue.message_count)
-
-            if message.nil?
+            if result.message.nil?
               puts message_id ? "Message not found: #{message_id}" : "Message at index #{index} not found"
               exit 1
             end
 
             if format == 'json'
-              puts JSON.pretty_generate(message)
+              puts JSON.pretty_generate(result.message)
             else
-              display_message_detail(message)
+              display_message_detail(result.message)
             end
           end
         rescue Bunny::NotFound
           puts "Queue not found: #{dlq_name}"
           exit 1
-        end
-
-        def find_message(channel, dlq_name, message_id, index, total)
-          queue   = channel.queue(dlq_name, durable: true, passive: true)
-          found   = nil
-          checked = []
-
-          total.times do |i|
-            delivery_info, properties, payload = queue.pop(manual_ack: true)
-            break unless delivery_info
-
-            checked << delivery_info.delivery_tag
-            match = if message_id
-                      properties.message_id == message_id
-                    else
-                      (i + 1) == index
-                    end
-
-            if match
-              found = build_message_detail(delivery_info, properties, payload)
-            end
-
-            # Requeue message
-            channel.nack(delivery_info.delivery_tag, false, true)
-
-            break if found
-          end
-
-          found
-        end
-
-        def build_message_detail(delivery_info, properties, payload)
-          headers = properties.headers || {}
-          death   = headers['x-death']&.first || {}
-
-          {
-            delivery_tag: delivery_info.delivery_tag,
-            message_id: properties.message_id,
-            timestamp: properties.timestamp&.iso8601,
-            content_type: properties.content_type,
-            headers: headers,
-            death_info: {
-              original_queue: death['queue'],
-              original_exchange: death['exchange'],
-              reason: death['reason'],
-              count: death['count'],
-              time: death['time']&.iso8601,
-              routing_keys: death['routing-keys'],
-            },
-            payload: safe_parse_payload(payload, properties.content_type),
-          }
-        end
-
-        def safe_parse_payload(payload, content_type)
-          return payload unless content_type&.include?('json')
-
-          JSON.parse(payload)
-        rescue JSON::ParserError
-          payload
         end
 
         def display_message_detail(msg)
@@ -439,51 +316,19 @@ module Onetime
 
         def replay_messages(dlq_name, count, format)
           with_rabbitmq_connection do |conn|
-            channel = conn.create_channel
-            queue   = channel.queue(dlq_name, durable: true, passive: true)
+            result = Onetime::Operations::Dlq::Replay.new(
+              connection: conn, queue: dlq_name, count: count, actor: CLI_ACTOR,
+            ).call
 
-            available = queue.message_count
-            if available == 0
+            # Only the truly-empty queue prints "No messages"; a non-empty queue
+            # that happened to process nothing still prints the results table
+            # (:noop), preserving the historic CLI behaviour byte-for-byte.
+            if result.status == :empty
               puts "No messages in #{dlq_name}"
               return
             end
 
-            to_replay = count ? [count, available].min : available
-            results   = { replayed: 0, failed: 0, errors: [] }
-
-            to_replay.times do
-              delivery_info, properties, payload = queue.pop(manual_ack: true)
-              break unless delivery_info
-
-              original_queue = extract_original_queue(properties.headers)
-              unless original_queue
-                results[:failed] += 1
-                results[:errors] << { message_id: properties.message_id, error: 'No original queue found' }
-                # Nack without requeue - message stays in DLQ, prevents infinite loop
-                channel.nack(delivery_info.delivery_tag, false, false)
-                next
-              end
-
-              begin
-                # Republish to original queue
-                channel.default_exchange.publish(
-                  payload,
-                  routing_key: original_queue,
-                  persistent: true,
-                  message_id: properties.message_id,
-                  content_type: properties.content_type,
-                  headers: clean_headers(properties.headers),
-                )
-
-                # Acknowledge (remove from DLQ)
-                channel.ack(delivery_info.delivery_tag)
-                results[:replayed] += 1
-              rescue StandardError => ex
-                results[:failed] += 1
-                results[:errors] << { message_id: properties.message_id, error: ex.message }
-                channel.nack(delivery_info.delivery_tag, false, true)
-              end
-            end
+            results = { replayed: result.replayed, failed: result.failed, errors: result.errors }
 
             if format == 'json'
               puts JSON.pretty_generate(results)
@@ -494,20 +339,6 @@ module Onetime
         rescue Bunny::NotFound
           puts "Queue not found: #{dlq_name}"
           exit 1
-        end
-
-        def extract_original_queue(headers)
-          return nil unless headers
-
-          death = headers['x-death']&.first
-          death&.fetch('queue', nil)
-        end
-
-        def clean_headers(headers)
-          return {} unless headers
-
-          # Remove death-related headers for clean replay
-          headers.reject { |k, _| k.start_with?('x-death', 'x-first-death') }
         end
 
         def display_replay_results(dlq_name, results)
@@ -558,10 +389,12 @@ module Onetime
 
         def purge_queue(dlq_name, force, format)
           with_rabbitmq_connection do |conn|
-            channel = conn.create_channel
-            queue   = channel.queue(dlq_name, durable: true, passive: true)
+            # Dry-run first to get the in-scope count for the confirmation prompt
+            # WITHOUT mutating anything (no audit event is recorded on a dry-run).
+            count = Onetime::Operations::Dlq::Purge.new(
+              connection: conn, queue: dlq_name, actor: CLI_ACTOR, dry_run: true,
+            ).call.count
 
-            count = queue.message_count
             if count == 0
               puts "No messages in #{dlq_name}"
               return
@@ -577,13 +410,16 @@ module Onetime
               end
             end
 
-            queue.purge
-            result = { queue: dlq_name, purged: count }
+            # Live purge — the single audited implementation records exactly one
+            # AdminAuditEvent for the (non-empty) purge.
+            result = Onetime::Operations::Dlq::Purge.new(
+              connection: conn, queue: dlq_name, actor: CLI_ACTOR,
+            ).call
 
             if format == 'json'
-              puts JSON.pretty_generate(result)
+              puts JSON.pretty_generate({ queue: dlq_name, purged: result.purged })
             else
-              puts "Purged #{count} message(s) from #{dlq_name}"
+              puts "Purged #{result.purged} message(s) from #{dlq_name}"
             end
           end
         rescue Bunny::NotFound

--- a/lib/onetime/cli/ratelimit_command.rb
+++ b/lib/onetime/cli/ratelimit_command.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require 'onetime/operations/ratelimit/registry'
+
 module Onetime
   module CLI
     # Emits valkey-cli commands for inspecting or clearing the in-Redis state
@@ -16,24 +18,13 @@ module Onetime
     # Adding a new limiter: add one row to LIMITERS with the key templates
     # used by the module's private *_key methods.
     class RatelimitCommand < DelayBootCommand
-      LIMITERS = {
-        'feedback' => {
-          subject: 'IP address',
-          keys: ['feedback:submissions:%s', 'feedback:locked:%s'],
-        },
-        'passphrase' => {
-          subject: 'secret identifier',
-          keys: ['passphrase:attempts:%s', 'passphrase:locked:%s'],
-        },
-        'invite' => {
-          subject: 'IP address',
-          keys: ['invite_attempts:%s', 'invite_locked:%s'],
-        },
-        'dns' => {
-          subject: 'domain identifier (sanitized)',
-          keys: ['dns:ratelimit:%s'],
-        },
-      }.freeze
+      # SINGLE source of truth for the limiter kinds + key templates, now owned by
+      # the extracted {Onetime::Operations::RateLimit::Registry} (ticket #44) and
+      # shared with the colonel inspect/reset endpoints. Aliased here so every
+      # existing `LIMITERS[...]` / `LIMITERS.keys` reference — and the emitted
+      # valkey-cli output — stays byte-identical. The registry adds a lazy
+      # `:dbclient` proc the CLI simply ignores (it never touches Redis itself).
+      LIMITERS = Onetime::Operations::RateLimit::Registry::LIMITERS
 
       desc 'List known rate limiters and their subject types'
 
@@ -62,14 +53,14 @@ module Onetime
         desc: 'IP, identifier, or other lookup key the limiter uses'
 
       def call(kind:, subject:, **)
-        meta = RatelimitCommand::LIMITERS[kind]
-        unless meta
+        # Key derivation is now written once in the shared registry — the SAME
+        # templates the colonel inspect/reset endpoints expand (ticket #44).
+        keys = Onetime::Operations::RateLimit::Registry.keys_for(kind, subject)
+        unless keys
           warn "Unknown rate limiter: #{kind.inspect}"
           warn "Known: #{RatelimitCommand::LIMITERS.keys.join(', ')}"
           exit 1
         end
-
-        keys = meta[:keys].map { |tmpl| format(tmpl, subject) }
 
         puts '# inspect'
         keys.each do |k|

--- a/lib/onetime/cli/session_command.rb
+++ b/lib/onetime/cli/session_command.rb
@@ -14,17 +14,30 @@
 
 require 'json'
 
+# The session capability now lives in central operations (epic #40 / D3): the
+# single implementation of the list / inspect / delete verbs. These CLI commands
+# are thin adapters over the ops, and SessionHelpers delegates its Redis/session
+# primitives to Onetime::Operations::Sessions::Store so there is one source of
+# truth. Loaded explicitly because CLI runs don't go through an app autoloader.
+require 'onetime/operations/sessions/store'
+require 'onetime/operations/sessions/list_sessions'
+require 'onetime/operations/sessions/inspect_session'
+require 'onetime/operations/sessions/delete_session'
+
 module Onetime
   module CLI
-    # Shared helpers for session commands
+    # Shared helpers for session commands.
+    #
+    # The Redis/session primitives here are thin delegations to
+    # {Onetime::Operations::Sessions::Store} — the single extracted implementation
+    # (epic #40). Behaviour is preserved byte-for-byte, in particular
+    # {#load_session_data}'s JSON-not-Marshal safety guarantee locked in by
+    # spec/cli/session_command_security_spec.rb.
     module SessionHelpers
+      Store = Onetime::Operations::Sessions::Store
+
       def session_key_patterns(session_id)
-        [
-          "session:#{session_id}",
-          "rack:session:#{session_id}",
-          session_id,
-          "session:rack:session:#{session_id}",
-        ]
+        Store.key_patterns(session_id)
       end
 
       def find_session_in_redis(dbclient, session_id)
@@ -37,31 +50,15 @@ module Onetime
       end
 
       def find_session_key(dbclient, session_id)
-        session_key_patterns(session_id).each do |pattern|
-          return pattern if dbclient.exists(pattern) > 0
-        end
-        nil
+        Store.find_key(dbclient, session_id)
       end
 
       def load_session_data(dbclient, key)
-        raw_data = dbclient.get(key)
-        return nil unless raw_data
-
-        # Session data is JSON-serializable, so parse it as JSON. We
-        # deliberately avoid Marshal.load on Redis-sourced bytes: Marshal
-        # executes its object graph (and any embedded gadget chain) *before*
-        # it can raise, so a rescue fallback offers no protection against a
-        # crafted payload planted at a session key.
-        begin
-          JSON.parse(raw_data)
-        rescue StandardError
-          { '_raw' => raw_data[0..200] }
-        end
+        Store.load_data(dbclient, key)
       end
 
       def extract_session_id_from_key(key)
-        # Remove common prefixes
-        key.gsub(/^(session:|rack:session:)/, '')
+        Store.extract_id(key)
       end
 
       def display_session_info(data, session_id)
@@ -130,12 +127,7 @@ module Onetime
       end
 
       def matches_search?(session_data, search_term)
-        search_term_lower = search_term.downcase
-        [
-          session_data['email'],
-          session_data['external_id'],
-          session_data['account_external_id'],
-        ].compact.any? { |field| field.downcase.include?(search_term_lower) }
+        Store.matches_search?(session_data, search_term)
       end
 
       def format_timestamp(timestamp)
@@ -190,11 +182,10 @@ module Onetime
         puts '=' * 80
         puts
 
-        # Try to find session in Redis using common patterns
-        dbclient     = Familia.dbclient
-        session_data = find_session_in_redis(dbclient, session_id)
+        # Route through the extracted inspect op (the single implementation).
+        result = Onetime::Operations::Sessions::Inspect.new(session_id: session_id).call
 
-        unless session_data
+        unless result.found
           puts '❌ Session not found in Redis'
           puts
           puts 'Searched patterns:'
@@ -205,7 +196,7 @@ module Onetime
           puts 'Available session keys (first 10):'
           keys = []
           begin
-            dbclient.scan_each(match: '*session*').take(10).each { |k| keys << k }
+            Familia.dbclient.scan_each(match: '*session*').take(10).each { |k| keys << k }
           rescue StandardError
             keys = []
           end
@@ -214,7 +205,7 @@ module Onetime
         end
 
         # Display session information
-        display_session_info(session_data, session_id)
+        display_session_info(result.data, session_id)
       end
     end
 
@@ -235,10 +226,11 @@ module Onetime
         puts "Active Sessions (limit: #{limit})"
         puts '-' * 80
 
-        dbclient     = Familia.dbclient
-        session_keys = dbclient.scan_each(match: '*session*').first(limit.to_i)
+        # Route through the extracted list op (single implementation, bounded
+        # scan). `--limit` maps to one page; the op caps a page at its MAX_PER_PAGE.
+        result = Onetime::Operations::Sessions::List.new(page: 1, per_page: limit.to_i).call
 
-        if session_keys.empty?
+        if result.sessions.empty?
           puts 'No sessions found'
           return
         end
@@ -246,15 +238,12 @@ module Onetime
         puts format('%-40s %-25s %-15s', 'Session ID', 'Authenticated As', 'Created')
         puts '-' * 80
 
-        session_keys.each do |key|
-          session_data = load_session_data(dbclient, key)
-          next unless session_data
-
-          session_id = extract_session_id_from_key(key)
-          email      = session_data['email'] || 'anonymous'
-          external_id= session_data['external_id'] || '<n/a>'
-          auth       = session_data['authenticated'] ? '✓' : '✗'
-          created_at = session_data['authenticated_at']
+        result.sessions.each do |session|
+          session_id  = session[:session_id]
+          email       = session[:email] || 'anonymous'
+          external_id = session[:external_id] || '<n/a>'
+          auth        = session[:authenticated] ? '✓' : '✗'
+          created_at  = session[:created_at]
 
           time_str = if created_at
             Time.at(created_at).strftime('%Y-%m-%d %H:%M')
@@ -287,34 +276,27 @@ module Onetime
         puts "Searching for sessions matching: #{search_term}"
         puts '-' * 80
 
-        dbclient     = Familia.dbclient
-        session_keys = dbclient.scan_each(match: '*session*').to_a
-        found        = []
+        # Route through the extracted list op with a search filter (single
+        # implementation, bounded scan).
+        result = Onetime::Operations::Sessions::List.new(
+          search: search_term,
+          per_page: Onetime::Operations::Sessions::List::MAX_PER_PAGE,
+        ).call
 
-        session_keys.each do |key|
-          session_data = load_session_data(dbclient, key)
-          next unless session_data
-
-          if matches_search?(session_data, search_term)
-            found << [key, session_data]
-          end
-        end
-
-        if found.empty?
+        if result.sessions.empty?
           puts "No sessions found matching '#{search_term}'"
           return
         end
 
-        puts "Found #{found.size} session(s):"
+        puts "Found #{result.total_count} session(s):"
         puts
 
-        found.each do |key, data|
-          session_id = extract_session_id_from_key(key)
-          puts "Session: #{session_id}"
-          puts "  Email: #{data['email']}"
-          puts "  External ID: #{data['external_id'] || data['account_external_id']}"
-          puts "  Authenticated: #{data['authenticated']}"
-          puts "  Created: #{format_timestamp(data['authenticated_at'])}"
+        result.sessions.each do |session|
+          puts "Session: #{session[:session_id]}"
+          puts "  Email: #{session[:email]}"
+          puts "  External ID: #{session[:external_id]}"
+          puts "  Authenticated: #{session[:authenticated]}"
+          puts "  Created: #{format_timestamp(session[:created_at])}"
           puts
         end
       end
@@ -325,6 +307,11 @@ module Onetime
       include SessionHelpers
 
       desc 'Delete a session'
+
+      # Audit actor recorded for CLI-initiated revokes. The shell carries no
+      # authenticated colonel identity; a plain, non-secret public sentinel is
+      # used — never an internal objid. Mirrors BannedIpsBanCommand::CLI_ACTOR.
+      CLI_ACTOR = 'cli'
 
       argument :session_id, type: :string, required: false, desc: 'Session ID'
 
@@ -341,6 +328,8 @@ module Onetime
         end
         boot_application!
 
+        # Resolve + display the target before mutating (EXISTS + GET only, no
+        # TTL) so the confirmation shows the exact session being revoked.
         dbclient    = Familia.dbclient
         session_key = find_session_key(dbclient, session_id)
 
@@ -366,7 +355,12 @@ module Onetime
           end
         end
 
-        dbclient.del(session_key)
+        # Route the actual deletion through the extracted, audited op (the single
+        # implementation). It re-resolves the key and records one AdminAuditEvent.
+        Onetime::Operations::Sessions::Delete.new(
+          session_id: session_id,
+          actor: CLI_ACTOR,
+        ).call
         puts '✓ Session deleted'
       end
     end

--- a/lib/onetime/models/organization.rb
+++ b/lib/onetime/models/organization.rb
@@ -191,6 +191,11 @@ module Onetime
     # Auto-generated: org.add_domains_instance(domain) / org.remove_domains_instance(domain)
 
     def add_domain(domain)
+      # Accept either a CustomDomain object or its identifier string — the CLI/
+      # toolbox transfer path passes the domainid string, while model callers pass
+      # the object (see Operations::Domains::Transfer). Resolve to an object first.
+      domain = resolve_domain(domain)
+
       # Prevent domains from belonging to multiple organizations
       existing_org = domain.organization_instances.first
       if existing_org && existing_org.objid != org_id
@@ -201,7 +206,17 @@ module Onetime
     end
 
     def remove_domain(domain)
-      domain.remove_from_organization_domains(self)
+      resolve_domain(domain).remove_from_organization_domains(self)
+    end
+
+    # Coerce a domain argument (object or identifier string) into a CustomDomain.
+    def resolve_domain(domain)
+      return domain unless domain.is_a?(String)
+
+      resolved = CustomDomain.find_by_identifier(domain)
+      raise Onetime::Problem, "Custom domain not found: #{domain}" unless resolved
+
+      resolved
     end
 
     def list_domains

--- a/lib/onetime/operations/banner.rb
+++ b/lib/onetime/operations/banner.rb
@@ -1,0 +1,177 @@
+# lib/onetime/operations/banner.rb
+#
+# frozen_string_literal: true
+
+# Central (cross-cutting) admin operations — see decision D3 in
+# lib/onetime/operations/README.md. The global broadcast banner is a site-wide
+# runtime state with no single domain owner (it is read at boot by the
+# CheckGlobalBanner initializer and surfaced by GlobalBroadcast.vue), so — like
+# {Onetime::Operations::BanIP} — it lives in the central operations home rather
+# than an app-scoped one. Loaded at the call site (colonel logic + the `bin/ots
+# banner` CLI), so require the audit dependency explicitly.
+require 'onetime/models/admin_audit_event'
+
+module Onetime
+  module Operations
+    # Shared backing-store facts for the broadcast-banner ops. The banner is a
+    # single string stored under {KEY} in DB {DB} (Valkey/Redis DB 0), optionally
+    # with a TTL. This is the SAME key the `CheckGlobalBanner` initializer reads at
+    # boot and the `bin/ots banner` CLI has always used — the value written here is
+    # bit-for-bit what the CLI wrote (raw HTML; the frontend sanitizes to <a> tags
+    # on render, this layer never rewrites the content).
+    module BannerState
+      # Redis/Valkey key holding the banner content. Single source of truth for the
+      # three ops below; the CLI keeps its own identical literal for its dry-run
+      # display text (preserved bit-for-bit).
+      KEY = 'global_banner'
+
+      # Database index the banner lives in (DB 0, matching the CLI + initializer).
+      DB = 0
+    end
+
+    # Read the current broadcast banner. READ-ONLY — records NO audit event
+    # (CONTRACT 4: only mutating verbs audit). The single implementation behind
+    # `bin/ots banner show` and the colonel `GET /api/colonel/banner` endpoint.
+    #
+    # Stateless, single `#call`, returns an immutable {Result}. `ttl` is normalised
+    # to nil for a persistent (or absent) banner — mirroring the CLI's
+    # `ttl.negative? ? nil : ttl` — so callers never see Redis's -1/-2 sentinels.
+    class GetBanner
+      # @!attribute active [r]
+      #   @return [Boolean] true when a non-empty banner is set.
+      Result = Data.define(:content, :ttl, :active, :key, :database)
+
+      # @return [Result]
+      def call
+        db      = Familia.dbclient(BannerState::DB)
+        content = db.get(BannerState::KEY)
+        ttl     = db.ttl(BannerState::KEY)
+
+        Result.new(
+          content: content,
+          # Redis returns -1 (no expiry) / -2 (no key); collapse both to nil so the
+          # wire shape is "seconds remaining, or null for persistent/absent".
+          ttl: ttl.negative? ? nil : ttl,
+          active: !content.nil? && !content.empty?,
+          key: BannerState::KEY,
+          database: BannerState::DB,
+        )
+      end
+    end
+
+    # Publish / update the global broadcast banner as an operator action, and
+    # record it in the admin audit trail (CONTRACT 4).
+    #
+    # The SINGLE implementation of the set verb: `bin/ots banner set --apply` and
+    # the colonel `POST /api/colonel/banner` endpoint are thin adapters over it.
+    # The Redis write is IDENTICAL to the prior inline CLI call
+    # (`db.set` / `db.setex` + `Onetime::Runtime.update_features`); the op adds
+    # exactly one {Onetime::AdminAuditEvent} per successful publish.
+    #
+    # Content is stored VERBATIM (raw HTML) — the CLI never sanitised on write and
+    # neither does this op, so CLI/UI render identically. Callers (the colonel
+    # logic) own any max-length / HTTP validation; the op only guards against an
+    # empty write (a backstop mirroring the CLI's own empty check).
+    #
+    # Setting the banner ALWAYS mutates (it overwrites whatever was there), so it
+    # always audits — there is no idempotent no-op branch to suppress.
+    class SetBanner
+      AUDIT_VERB = 'banner.set'
+
+      # @!attribute status [r]
+      #   @return [Symbol] :success
+      Result = Data.define(:status, :content, :ttl)
+
+      # @param content [String] the banner body (raw HTML; stored verbatim).
+      # @param actor [String, #extid, #email] acting admin's PUBLIC identity
+      #   (colonel extid/email, or the CLI sentinel). Never an internal objid.
+      # @param ttl [Integer, nil] optional auto-expiry in seconds; nil = persistent.
+      def initialize(content:, actor:, ttl: nil)
+        @content = content
+        @actor   = actor
+        @ttl     = ttl
+      end
+
+      # @return [Result]
+      # @raise [ArgumentError] when content is blank (defensive backstop).
+      def call
+        text = @content.to_s
+        raise ArgumentError, 'banner content is empty' if text.empty?
+
+        db = Familia.dbclient(BannerState::DB)
+        if @ttl
+          db.setex(BannerState::KEY, @ttl, text)
+        else
+          db.set(BannerState::KEY, text)
+        end
+
+        # Refresh THIS process's runtime state (parity with the CLI note that the
+        # refresh reaches only the current process; other processes re-read at
+        # boot). Kept identical to the extracted CLI behaviour.
+        Onetime::Runtime.update_features(global_banner: text)
+
+        # One audit event per successful publish. The banner content is
+        # non-secret (it is shown to every visitor), so it is safe to record; the
+        # AdminAuditEvent redactor still truncates overlong values.
+        Onetime::AdminAuditEvent.record(
+          actor: @actor,
+          verb: AUDIT_VERB,
+          target: BannerState::KEY,
+          result: :success,
+          detail: { ttl: @ttl, length: text.length, content: text },
+        )
+
+        Result.new(status: :success, content: text, ttl: @ttl)
+      end
+    end
+
+    # Clear the global broadcast banner as an operator action, and record it in the
+    # admin audit trail (CONTRACT 4).
+    #
+    # The SINGLE implementation of the clear verb: `bin/ots banner clear --apply`
+    # and the colonel `DELETE /api/colonel/banner` endpoint are thin adapters over
+    # it. The Redis delete is IDENTICAL to the prior inline CLI call (`db.del` +
+    # `Onetime::Runtime.update_features(global_banner: nil)`); the op adds exactly
+    # one {Onetime::AdminAuditEvent} per successful clear.
+    #
+    # Stateless, single `#call`, returns an immutable {Result}. Clearing when no
+    # banner is set returns `status: :not_set` and records NO audit event (nothing
+    # mutated) — the "only audit an actual change" rule shared with UnbanIP.
+    class ClearBanner
+      AUDIT_VERB = 'banner.clear'
+
+      # @!attribute status [r]
+      #   @return [Symbol] :success (cleared) or :not_set (no-op)
+      Result = Data.define(:status, :cleared, :content)
+
+      # @param actor [String, #extid, #email] acting admin's PUBLIC identity.
+      def initialize(actor:)
+        @actor = actor
+      end
+
+      # @return [Result]
+      def call
+        db      = Familia.dbclient(BannerState::DB)
+        current = db.get(BannerState::KEY)
+
+        if current.nil? || current.empty?
+          return Result.new(status: :not_set, cleared: false, content: nil)
+        end
+
+        db.del(BannerState::KEY)
+        Onetime::Runtime.update_features(global_banner: nil)
+
+        # One audit event per successful mutation. No detail: the fact of the clear
+        # is the whole record (the cleared content is not re-logged here).
+        Onetime::AdminAuditEvent.record(
+          actor: @actor,
+          verb: AUDIT_VERB,
+          target: BannerState::KEY,
+          result: :success,
+        )
+
+        Result.new(status: :success, cleared: true, content: current)
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/dlq/list.rb
+++ b/lib/onetime/operations/dlq/list.rb
@@ -1,0 +1,59 @@
+# lib/onetime/operations/dlq/list.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/operations/dlq/store'
+
+module Onetime
+  module Operations
+    module Dlq
+      # Summarise every dead-letter queue — the SINGLE implementation of the DLQ
+      # list-all verb (epic #42 / D3). The colonel endpoint (`GET
+      # /api/colonel/queues/dlq`) and the `bin/ots queue dlq list` CLI (no queue
+      # arg) are thin adapters over it.
+      #
+      # READ-ONLY: summarising queue depths mutates nothing, so — like the session
+      # list / system read-outs — it records NO {Onetime::AdminAuditEvent}
+      # (CONTRACT 4: audit is for mutations).
+      #
+      # Bounded by construction (CONTRACT 6): the set of DLQs is the fixed
+      # {Store.all_dlq_names} allowlist, never an unbounded enumeration. Each queue
+      # is inspected with a passive handle, so a queue that is configured but not
+      # yet declared in the broker surfaces as `error: 'not declared'` (matching the
+      # historic CLI) rather than aborting the whole listing.
+      #
+      # Stateless, single `#call`, returns an immutable {Result}.
+      class List
+        # @!attribute dlqs [r] Array<Hash> per-queue summary rows
+        # @!attribute total [r] Integer total messages across all DLQs
+        Result = Data.define(:dlqs, :total)
+
+        # @param connection [Object] an already-open Bunny-like connection. The op
+        #   creates + closes its own channel off it (the connection's lifecycle
+        #   belongs to the caller).
+        def initialize(connection:)
+          @connection = connection
+        end
+
+        # @return [Result]
+        def call
+          channel = @connection.create_channel
+
+          dlqs = Store.all_dlq_names.map do |dlq_name|
+            Store.summary_row(channel, dlq_name)
+          rescue Bunny::NotFound
+            # A passive declare of a not-yet-declared queue closes the channel
+            # (AMQP spec), so reopen one for the next queue — exactly as the CLI did.
+            channel = @connection.create_channel
+            { queue: dlq_name, messages: 0, error: 'not declared' }
+          end
+
+          total = dlqs.sum { |row| row[:messages].to_i }
+          Result.new(dlqs: dlqs, total: total)
+        ensure
+          channel.close if channel&.open?
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/dlq/peek.rb
+++ b/lib/onetime/operations/dlq/peek.rb
@@ -1,0 +1,74 @@
+# lib/onetime/operations/dlq/peek.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/operations/dlq/store'
+
+module Onetime
+  module Operations
+    module Dlq
+      # Peek the messages in a single dead-letter queue — the SINGLE implementation
+      # of the per-queue DLQ list verb (epic #42 / D3). The colonel endpoint (`GET
+      # /api/colonel/queues/dlq/:queue`) and the `bin/ots queue dlq list <queue>`
+      # CLI are thin adapters over it.
+      #
+      # READ-ONLY: every message is popped with a manual ack and immediately
+      # nack-requeued ({Store.peek}), so the queue is left exactly as found. No
+      # {Onetime::AdminAuditEvent} (CONTRACT 4).
+      #
+      # Bounded (CONTRACT 6): at most `limit` messages are inspected, clamped to
+      # {MAX_LIMIT}, and never more than the queue actually holds — one request can
+      # never turn into an unbounded drain.
+      #
+      # Stateless, single `#call`, returns an immutable {Result}.
+      class Peek
+        # @!attribute total_messages [r] Integer full queue depth
+        # @!attribute messages [r] Array<Hash> the peeked message summaries
+        Result = Data.define(:queue, :total_messages, :showing, :messages)
+
+        DEFAULT_LIMIT = 20
+        # Hard cap on how many messages a single peek inspects, so an operator can
+        # never pop-and-requeue an unbounded queue on the request path.
+        MAX_LIMIT = 100
+
+        # @param connection [Object] an already-open Bunny-like connection.
+        # @param queue [String] a fully-resolved DLQ name (see {Store.resolve}).
+        # @param limit [Integer] max messages to peek (clamped to 1..MAX_LIMIT).
+        def initialize(connection:, queue:, limit: DEFAULT_LIMIT)
+          @connection = connection
+          @queue      = queue
+          @limit      = clamp_limit(limit)
+        end
+
+        # @return [Result]
+        def call
+          channel = @connection.create_channel
+          queue   = Store.queue_handle(channel, @queue)
+
+          total = queue.message_count
+          count = [@limit, total].min
+          messages = count.positive? ? Store.peek(channel, @queue, count) : []
+
+          Result.new(
+            queue: @queue,
+            total_messages: total,
+            showing: messages.size,
+            messages: messages,
+          )
+        ensure
+          channel.close if channel&.open?
+        end
+
+        private
+
+        def clamp_limit(value)
+          n = value.to_i
+          return DEFAULT_LIMIT if n <= 0
+          return MAX_LIMIT if n > MAX_LIMIT
+
+          n
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/dlq/purge.rb
+++ b/lib/onetime/operations/dlq/purge.rb
@@ -1,0 +1,85 @@
+# lib/onetime/operations/dlq/purge.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/operations/dlq/store'
+require 'onetime/models/admin_audit_event'
+
+module Onetime
+  module Operations
+    module Dlq
+      # Purge (permanently delete) every message from a dead-letter queue — the
+      # SINGLE, audited implementation of the DLQ purge verb (epic #42 / D3 /
+      # CONTRACT 4). The colonel endpoint (`POST
+      # /api/colonel/queues/dlq/:queue/purge`) and the `bin/ots queue dlq purge`
+      # CLI are thin adapters over it.
+      #
+      # This is the destructive DLQ verb — irreversible message loss. The `queue.purge`
+      # call is byte-for-byte the historic CLI. The UI gates it behind
+      # AdminConfirmDialog typed-confirmation (retype the queue name) and the CLI
+      # behind a y/N prompt (both in the adapter, using the {dry_run} count); the op
+      # itself just measures, purges, and audits.
+      #
+      # ## Audit (exactly once)
+      #
+      # A purge that removes ≥ 1 message records EXACTLY ONE
+      # {Onetime::AdminAuditEvent} — verb `queue.dlq.purge`, target the DLQ name,
+      # detail the purged count. Purging an already-empty queue mutates nothing and
+      # records NO event (the "only audit an actual change" rule).
+      #
+      # ## Dry run
+      #
+      # `dry_run: true` returns the count that WOULD be purged WITHOUT deleting
+      # anything and WITHOUT recording an audit event — used to render the
+      # count-in-scope in the confirm prompt/dialog before the live purge.
+      #
+      # Stateless, single `#call`, returns an immutable {Result}.
+      class Purge
+        # Audit verb recorded for every purge that removes ≥ 1 message.
+        AUDIT_VERB = 'queue.dlq.purge'
+
+        # @!attribute status [r] Symbol :success / :empty / :dry_run
+        # @!attribute count [r] Integer messages measured in the queue
+        # @!attribute purged [r] Integer messages actually removed (0 on dry-run/empty)
+        Result = Data.define(:status, :queue, :count, :purged)
+
+        # @param connection [Object] an already-open Bunny-like connection.
+        # @param queue [String] a fully-resolved DLQ name.
+        # @param actor [String, #extid, #email] acting admin's PUBLIC identity.
+        # @param dry_run [Boolean] measure only — delete nothing, audit nothing.
+        def initialize(connection:, queue:, actor:, dry_run: false)
+          @connection = connection
+          @queue      = queue
+          @actor      = actor
+          @dry_run    = dry_run
+        end
+
+        # @return [Result]
+        def call
+          channel = @connection.create_channel
+          queue   = Store.queue_handle(channel, @queue)
+
+          count = queue.message_count
+          return Result.new(status: :dry_run, queue: @queue, count: count, purged: 0) if @dry_run
+          return Result.new(status: :empty, queue: @queue, count: 0, purged: 0) if count.zero?
+
+          queue.purge
+
+          # Exactly one audit event per non-empty purge. The queue name is not
+          # secret; never put message contents into detail.
+          Onetime::AdminAuditEvent.record(
+            actor: @actor,
+            verb: AUDIT_VERB,
+            target: @queue,
+            result: :success,
+            detail: { purged: count },
+          )
+
+          Result.new(status: :success, queue: @queue, count: count, purged: count)
+        ensure
+          channel.close if channel&.open?
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/dlq/replay.rb
+++ b/lib/onetime/operations/dlq/replay.rb
@@ -1,0 +1,157 @@
+# lib/onetime/operations/dlq/replay.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/operations/dlq/store'
+require 'onetime/models/admin_audit_event'
+
+module Onetime
+  module Operations
+    module Dlq
+      # Replay (re-enqueue) messages from a dead-letter queue back to their original
+      # queue — the SINGLE, audited implementation of the DLQ replay verb (epic #42
+      # / D3 / CONTRACT 4). The colonel endpoint (`POST
+      # /api/colonel/queues/dlq/:queue/replay`) and the `bin/ots queue dlq replay`
+      # CLI are thin adapters over it.
+      #
+      # This is a mutating verb. For each message it republishes to the original
+      # queue (from the `x-death` header) and acks it off the DLQ; a message with no
+      # recoverable original queue is nacked WITHOUT requeue (dropped, to avoid an
+      # infinite dead-letter loop) and counted as failed; a publish error nacks WITH
+      # requeue so the message survives. The republish + ack/nack logic is
+      # byte-for-byte the historic CLI `replay_messages`.
+      #
+      # ## Audit (exactly once)
+      #
+      # A replay that PROCESSES at least one message (replayed or failed) records
+      # EXACTLY ONE {Onetime::AdminAuditEvent} — verb `queue.dlq.replay`, target the
+      # DLQ name, detail the replayed/failed counts. A replay of an empty queue, or
+      # one that processed nothing, mutates nothing and records NO event (the "only
+      # audit an actual change" rule shared with BanIP / Sessions::Delete).
+      #
+      # ## Dry run
+      #
+      # Replay can re-trigger side effects (emails, webhooks). `dry_run: true`
+      # reports how many messages WOULD be replayed WITHOUT republishing or acking
+      # anything — nothing is mutated and NO audit event is recorded — so a caller
+      # can preview the blast radius before an explicit live replay (epic #42 note).
+      #
+      # Stateless, single `#call`, returns an immutable {Result}.
+      class Replay
+        # Audit verb recorded for every replay that processes ≥ 1 message.
+        AUDIT_VERB = 'queue.dlq.replay'
+
+        # @!attribute status [r] Symbol :success (processed ≥ 1) / :empty (queue was
+        #   empty) / :noop (queue non-empty but nothing processed) / :dry_run
+        # @!attribute would_replay [r] Integer dry-run only: messages in scope
+        Result = Data.define(:status, :queue, :replayed, :failed, :errors, :would_replay)
+
+        # @param connection [Object] an already-open Bunny-like connection.
+        # @param queue [String] a fully-resolved DLQ name.
+        # @param actor [String, #extid, #email] acting admin's PUBLIC identity
+        #   (colonel extid/email, or a CLI sentinel). Never an internal objid.
+        # @param count [Integer, nil] max messages to replay (nil = all available).
+        # @param dry_run [Boolean] preview only — mutate nothing, audit nothing.
+        def initialize(connection:, queue:, actor:, count: nil, dry_run: false)
+          @connection = connection
+          @queue      = queue
+          @actor      = actor
+          @count      = count
+          @dry_run    = dry_run
+        end
+
+        # @return [Result]
+        def call
+          channel = @connection.create_channel
+          queue   = Store.queue_handle(channel, @queue)
+
+          available = queue.message_count
+          if available.zero?
+            return empty_result
+          end
+
+          to_replay = @count ? [@count, available].min : available
+
+          if @dry_run
+            return Result.new(
+              status: :dry_run, queue: @queue,
+              replayed: 0, failed: 0, errors: [], would_replay: to_replay,
+            )
+          end
+
+          results = replay_loop(channel, queue, to_replay)
+          processed = results[:replayed] + results[:failed]
+
+          # Exactly one audit event per replay that actually processed a message.
+          if processed.positive?
+            Onetime::AdminAuditEvent.record(
+              actor: @actor,
+              verb: AUDIT_VERB,
+              target: @queue,
+              result: :success,
+              detail: { replayed: results[:replayed], failed: results[:failed] },
+            )
+          end
+
+          Result.new(
+            # :noop (not :empty) when the queue held messages but the loop
+            # processed none — so the adapter still prints a results table rather
+            # than "No messages", preserving the CLI byte-for-byte.
+            status: processed.positive? ? :success : :noop,
+            queue: @queue,
+            replayed: results[:replayed],
+            failed: results[:failed],
+            errors: results[:errors],
+            would_replay: 0,
+          )
+        ensure
+          channel.close if channel&.open?
+        end
+
+        private
+
+        def empty_result
+          Result.new(status: :empty, queue: @queue, replayed: 0, failed: 0, errors: [], would_replay: 0)
+        end
+
+        # The republish/ack/nack loop, byte-for-byte the historic CLI.
+        def replay_loop(channel, queue, to_replay)
+          results = { replayed: 0, failed: 0, errors: [] }
+
+          to_replay.times do
+            delivery_info, properties, payload = queue.pop(manual_ack: true)
+            break unless delivery_info
+
+            original = Store.original_queue(properties.headers)
+            unless original
+              results[:failed] += 1
+              results[:errors] << { message_id: properties.message_id, error: 'No original queue found' }
+              # Nack WITHOUT requeue — drop, so it can't dead-letter-loop forever.
+              channel.nack(delivery_info.delivery_tag, false, false)
+              next
+            end
+
+            begin
+              channel.default_exchange.publish(
+                payload,
+                routing_key: original,
+                persistent: true,
+                message_id: properties.message_id,
+                content_type: properties.content_type,
+                headers: Store.clean_headers(properties.headers),
+              )
+              channel.ack(delivery_info.delivery_tag)
+              results[:replayed] += 1
+            rescue StandardError => ex
+              results[:failed] += 1
+              results[:errors] << { message_id: properties.message_id, error: ex.message }
+              channel.nack(delivery_info.delivery_tag, false, true)
+            end
+          end
+
+          results
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/dlq/show.rb
+++ b/lib/onetime/operations/dlq/show.rb
@@ -1,0 +1,54 @@
+# lib/onetime/operations/dlq/show.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/operations/dlq/store'
+
+module Onetime
+  module Operations
+    module Dlq
+      # Show one message's full detail — the SINGLE implementation of the DLQ show
+      # verb (epic #42 / D3). The `bin/ots queue dlq show <queue> --id/--index` CLI
+      # is a thin adapter over it.
+      #
+      # READ-ONLY: {Store.find_message} nack-requeues every inspected message, so
+      # the queue is left untouched. No {Onetime::AdminAuditEvent} (CONTRACT 4).
+      #
+      # Stateless, single `#call`, returns an immutable {Result}. `empty` is true
+      # when the queue holds no messages (distinct from "found nothing matching"),
+      # so the adapter can preserve the historic CLI's two different messages.
+      class Show
+        # @!attribute empty [r] Boolean the queue had zero messages
+        # @!attribute message [r] Hash, nil the matched message detail
+        Result = Data.define(:found, :empty, :message)
+
+        # @param connection [Object] an already-open Bunny-like connection.
+        # @param queue [String] a fully-resolved DLQ name.
+        # @param message_id [String, nil] match by message id …
+        # @param index [Integer, nil] … or by 1-based position (caller supplies one).
+        def initialize(connection:, queue:, message_id: nil, index: nil)
+          @connection = connection
+          @queue      = queue
+          @message_id = message_id
+          @index      = index
+        end
+
+        # @return [Result]
+        def call
+          channel = @connection.create_channel
+          queue   = Store.queue_handle(channel, @queue)
+
+          total = queue.message_count
+          if total.zero?
+            return Result.new(found: false, empty: true, message: nil)
+          end
+
+          message = Store.find_message(channel, @queue, @message_id, @index, total)
+          Result.new(found: !message.nil?, empty: false, message: message)
+        ensure
+          channel.close if channel&.open?
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/dlq/store.rb
+++ b/lib/onetime/operations/dlq/store.rb
@@ -1,0 +1,283 @@
+# lib/onetime/operations/dlq/store.rb
+#
+# frozen_string_literal: true
+
+require 'json'
+require 'onetime/jobs/queues/config'
+
+module Onetime
+  module Operations
+    # Dead-Letter-Queue admin operations (epic #42 / D3).
+    #
+    # Central (cross-cutting) admin verbs — see decision D3 in
+    # lib/onetime/operations/README.md. A dead-letter queue is a piece of the
+    # RabbitMQ messaging fabric with no single domain owner (billing, email,
+    # domains and webhooks all dead-letter into it), so — like the Slice-4
+    # {Onetime::Operations::BanIP} / `UnbanIP` and the epic #40 session verbs —
+    # these live in the central operations home rather than an app-scoped one.
+    #
+    # Before this extraction the DLQ list / show / replay / purge capability lived
+    # ONLY on `bin/ots queue dlq …` (`lib/onetime/cli/queue/dlq_command.rb`): an
+    # operator with no shell had no way to triage or drain a dead-letter queue.
+    # These ops are the SINGLE implementation each of those verbs; the CLI and the
+    # new colonel endpoints (`/api/colonel/queues/dlq…`) are thin adapters over
+    # them.
+    module Dlq
+      # Shared DLQ primitives — the single source of the RabbitMQ queue-name
+      # allowlist, the message projection shapes, and the death-header parsing that
+      # the DLQ verbs (List / Peek / Show / Replay / Purge) and the `bin/ots queue
+      # dlq` CLI are thin adapters over.
+      #
+      # Context-free by contract (lib/onetime/operations/README.md): it knows
+      # nothing about HTTP or the CLI. Callers pass an already-open Bunny-like
+      # connection (the CLI its own short-lived one, the colonel logic the shared
+      # boot-time `$rmq_conn`); the ops create + close their own channels off it.
+      # Every queue handle is opened `passive: true`, so inspecting a DLQ never
+      # declares a queue that does not already exist.
+      module Store
+        module_function
+
+        # Resolve a caller-supplied name to a full DLQ queue name. Mirrors the
+        # historic CLI `resolve_dlq_name` mapping EXACTLY (bit-for-bit): a name that
+        # already carries the `dlq.` prefix is returned untouched; otherwise the
+        # `dlq.` prefix is prepended. Validity (against {all_dlq_names}) is a
+        # SEPARATE concern the adapter enforces ({valid?}), because the CLI and the
+        # HTTP edge surface an unknown name differently (a `puts`+exit vs a 404).
+        #
+        # @param name [String] short (`billing.event`) or full (`dlq.billing.event`)
+        # @return [String] the full DLQ queue name
+        def resolve(name)
+          n = name.to_s
+          return n if n.start_with?('dlq.')
+
+          "dlq.#{n}"
+        end
+
+        # The fixed set of dead-letter queue names, sourced from the single
+        # DEAD_LETTER_CONFIG topology. A bounded allowlist by construction — an
+        # operator can only ever act on one of these queues (CONTRACT 6: no
+        # unbounded key/queue enumeration on the request path).
+        #
+        # @return [Array<String>]
+        def all_dlq_names
+          Onetime::Jobs::QueueConfig::DEAD_LETTER_CONFIG.values.map { |v| v[:queue] }
+        end
+
+        # Short (prefix-stripped) forms of {all_dlq_names}, for operator-facing
+        # listings ("Available DLQs: billing.event, email.message, …").
+        #
+        # @return [Array<String>]
+        def short_names
+          all_dlq_names.map { |n| n.sub('dlq.', '') }
+        end
+
+        # Whether a fully-resolved DLQ name is one of the configured dead-letter
+        # queues. The security control for the HTTP path: the colonel endpoints
+        # reject anything not on this allowlist BEFORE touching the broker.
+        #
+        # @param dlq_name [String] a resolved name (see {resolve})
+        # @return [Boolean]
+        def valid?(dlq_name)
+          all_dlq_names.include?(dlq_name)
+        end
+
+        # Open a passive queue handle. `passive: true` means "fail if it does not
+        # already exist" (raising Bunny::NotFound) rather than declaring it — the
+        # same flags the CLI used, so inspecting a DLQ never mutates topology.
+        #
+        # @param channel [Object] a Bunny-like channel
+        # @param dlq_name [String]
+        # @return [Object] the queue handle
+        def queue_handle(channel, dlq_name)
+          channel.queue(dlq_name, durable: true, passive: true)
+        end
+
+        # Compact per-queue summary row for the DLQ list. Identical shape to the
+        # historic CLI `get_queue_info`.
+        #
+        # @param channel [Object]
+        # @param dlq_name [String]
+        # @return [Hash] { queue:, messages:, consumers: }
+        def summary_row(channel, dlq_name)
+          queue = queue_handle(channel, dlq_name)
+          {
+            queue: dlq_name,
+            messages: queue.message_count,
+            consumers: queue.consumer_count,
+          }
+        end
+
+        # Non-destructively peek up to `count` messages from a DLQ. Each message is
+        # popped with a manual ack and IMMEDIATELY nack-requeued, so the queue is
+        # left exactly as found — a read, not a drain. Byte-for-byte the historic
+        # CLI `peek_messages` projection (`payload_preview` is capped at 200 chars).
+        #
+        # @param channel [Object]
+        # @param dlq_name [String]
+        # @param count [Integer] how many messages to peek (already clamped)
+        # @return [Array<Hash>] message summaries
+        def peek(channel, dlq_name, count)
+          messages = []
+          queue    = queue_handle(channel, dlq_name)
+
+          count.times do
+            delivery_info, properties, payload = queue.pop(manual_ack: true)
+            break unless delivery_info
+
+            begin
+              death = extract_death_info(properties.headers)
+              messages << {
+                delivery_tag: delivery_info.delivery_tag,
+                message_id: properties.message_id,
+                timestamp: properties.timestamp&.to_i,
+                age: format_age(properties.timestamp),
+                original_queue: death[:queue],
+                death_reason: death[:reason],
+                death_count: death[:count],
+                error: death[:error],
+                content_type: properties.content_type,
+                payload_preview: payload.to_s[0..200],
+              }
+            ensure
+              # Always nack WITH requeue so the peek leaves the DLQ untouched.
+              channel.nack(delivery_info.delivery_tag, false, true)
+            end
+          end
+
+          messages
+        end
+
+        # Locate a single message by id or 1-based index, returning its full detail
+        # (headers, death info, parsed payload) or nil. Non-destructive: every popped
+        # message is nack-requeued. Byte-for-byte the historic CLI `find_message` +
+        # `build_message_detail`.
+        #
+        # @param channel [Object]
+        # @param dlq_name [String]
+        # @param message_id [String, nil]
+        # @param index [Integer, nil] 1-based
+        # @param total [Integer] queue depth (caller-measured)
+        # @return [Hash, nil]
+        def find_message(channel, dlq_name, message_id, index, total)
+          queue = queue_handle(channel, dlq_name)
+          found = nil
+
+          total.times do |i|
+            delivery_info, properties, payload = queue.pop(manual_ack: true)
+            break unless delivery_info
+
+            match = if message_id
+                      properties.message_id == message_id
+                    else
+                      (i + 1) == index
+                    end
+
+            found = build_message_detail(delivery_info, properties, payload) if match
+
+            # Requeue every message we inspected — read-only.
+            channel.nack(delivery_info.delivery_tag, false, true)
+            break if found
+          end
+
+          found
+        end
+
+        # Full single-message detail projection. Byte-for-byte the historic CLI
+        # `build_message_detail`.
+        #
+        # @return [Hash]
+        def build_message_detail(delivery_info, properties, payload)
+          headers = properties.headers || {}
+          death   = headers['x-death']&.first || {}
+
+          {
+            delivery_tag: delivery_info.delivery_tag,
+            message_id: properties.message_id,
+            timestamp: properties.timestamp&.iso8601,
+            content_type: properties.content_type,
+            headers: headers,
+            death_info: {
+              original_queue: death['queue'],
+              original_exchange: death['exchange'],
+              reason: death['reason'],
+              count: death['count'],
+              time: death['time']&.iso8601,
+              routing_keys: death['routing-keys'],
+            },
+            payload: safe_parse_payload(payload, properties.content_type),
+          }
+        end
+
+        # Parse a JSON payload, falling back to the raw string on any parse error or
+        # non-JSON content-type. Byte-for-byte the historic CLI `safe_parse_payload`.
+        #
+        # @return [Object]
+        def safe_parse_payload(payload, content_type)
+          return payload unless content_type&.include?('json')
+
+          JSON.parse(payload)
+        rescue JSON::ParserError
+          payload
+        end
+
+        # Extract the original queue this message dead-lettered from, from the
+        # AMQP `x-death` header — used to route a replay back. Byte-for-byte the
+        # historic CLI `extract_original_queue`.
+        #
+        # @param headers [Hash, nil]
+        # @return [String, nil]
+        def original_queue(headers)
+          return nil unless headers
+
+          death = headers['x-death']&.first
+          death&.fetch('queue', nil)
+        end
+
+        # Strip death-related headers before a replay so the republished message is
+        # clean. Byte-for-byte the historic CLI `clean_headers`.
+        #
+        # @param headers [Hash, nil]
+        # @return [Hash]
+        def clean_headers(headers)
+          return {} unless headers
+
+          headers.reject { |k, _| k.start_with?('x-death', 'x-first-death') }
+        end
+
+        # Compact death summary for a peeked message. Byte-for-byte the historic
+        # CLI `extract_death_info`.
+        #
+        # @param headers [Hash, nil]
+        # @return [Hash]
+        def extract_death_info(headers)
+          return {} unless headers
+
+          death = headers['x-death']&.first || {}
+          {
+            queue: death['queue'],
+            reason: death['reason'],
+            count: death['count'],
+            error: headers['x-exception'] || headers['x-error'],
+          }
+        end
+
+        # Human-readable age string for a message timestamp. Byte-for-byte the
+        # historic CLI `format_age`.
+        #
+        # @param timestamp [Time, Integer, nil]
+        # @return [String]
+        def format_age(timestamp)
+          return 'unknown' unless timestamp
+
+          age_seconds = Time.now.to_i - timestamp.to_i
+          case age_seconds
+          when 0..59 then "#{age_seconds}s ago"
+          when 60..3599 then "#{age_seconds / 60}m ago"
+          when 3600..86_399 then "#{age_seconds / 3600}h ago"
+          else "#{age_seconds / 86_400}d ago"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/domains/orphaned_scan.rb
+++ b/lib/onetime/operations/domains/orphaned_scan.rb
@@ -1,0 +1,117 @@
+# lib/onetime/operations/domains/orphaned_scan.rb
+#
+# frozen_string_literal: true
+
+# Domain-owned (app-scoped) diagnostic operation — see decision D3 in
+# lib/onetime/operations/README.md. Lives alongside the incumbent domain ops in
+# lib/onetime/operations, under the Domains:: namespace.
+
+module Onetime
+  module Operations
+    module Domains
+      # Scan for orphaned custom domains — the SINGLE implementation of the
+      # orphaned-scan verb (epic #43 / D3). An orphaned domain is one with no
+      # owning organization (`org_id` blank), a data-integrity smell the operator
+      # can then repair.
+      #
+      # READ-ONLY: records NO {Onetime::AdminAuditEvent} (CONTRACT 4). The
+      # `bin/ots domains orphaned` CLI and the colonel endpoint
+      # (`GET /api/colonel/domains/orphaned`) are thin adapters over it.
+      #
+      # Bounded by construction (CONTRACT 6): iteration is over the
+      # `CustomDomain.instances` sorted set (a bounded members list, NOT a blocking
+      # KEYS scan) — the same source the existing colonel domains list uses — via
+      # `instances.all` + per-identifier `find_by_identifier` (mirroring the CLI's
+      # bulk-repair/orphaned iteration). Results are sorted by display_domain (parity
+      # with the CLI) and paginated in memory.
+      #
+      # ## CLI parity
+      #
+      # `bin/ots domains orphaned` lists ALL orphaned domains sorted by
+      # display_domain. Passing `per_page: nil` (the CLI adapter's call) returns the
+      # full sorted collection unpaginated, preserving that output; the colonel
+      # endpoint passes real page/per_page for a paginated list.
+      class OrphanedScan
+        # @!attribute domains [r] Array<Hash> one page of orphaned-domain summaries
+        Result = Data.define(:domains, :total_count, :page, :per_page, :total_pages)
+
+        MAX_PER_PAGE     = 100
+        DEFAULT_PER_PAGE = 50
+
+        # @param page [Integer] 1-based page (clamped to >= 1). Ignored when unpaginated.
+        # @param per_page [Integer, nil] page size; nil returns the full list (CLI mode).
+        def initialize(page: 1, per_page: DEFAULT_PER_PAGE)
+          @page       = page.to_i < 1 ? 1 : page.to_i
+          @unpaginated = per_page.nil?
+          @per_page   = @unpaginated ? nil : clamp_per_page(per_page)
+        end
+
+        # @return [Result]
+        def call
+          orphaned = collect_orphaned.sort_by { |row| row[:display_domain].to_s }
+
+          total_count = orphaned.size
+
+          if @unpaginated
+            return Result.new(
+              domains: orphaned,
+              total_count: total_count,
+              page: 1,
+              per_page: total_count,
+              total_pages: 1,
+            )
+          end
+
+          total_pages = @per_page.zero? ? 0 : (total_count.to_f / @per_page).ceil
+          start_idx   = (@page - 1) * @per_page
+          page_rows   = orphaned[start_idx, @per_page] || []
+
+          Result.new(
+            domains: page_rows,
+            total_count: total_count,
+            page: @page,
+            per_page: @per_page,
+            total_pages: total_pages,
+          )
+        end
+
+        private
+
+        # Bounded: instances.all returns the sorted set's member identifiers (a
+        # ZRANGE over a bounded set, NOT a blocking KEYS scan). find_by_identifier
+        # resolves each record; nil results (stale identifiers whose records are
+        # gone) are dropped by filter_map.
+        def collect_orphaned
+          all_ids = Onetime::CustomDomain.instances.all
+
+          all_ids.filter_map do |identifier|
+            domain = Onetime::CustomDomain.find_by_identifier(identifier)
+            next nil unless domain
+            next nil unless domain.org_id.to_s.empty?
+
+            summarize(domain)
+          end
+        end
+
+        def summarize(domain)
+          {
+            domain_id: domain.domainid,
+            extid: (domain.extid if domain.respond_to?(:extid)),
+            display_domain: domain.display_domain,
+            verification_state: domain.verification_state.to_s,
+            verified: domain.verified.to_s == 'true',
+            created: domain.created,
+          }
+        end
+
+        def clamp_per_page(value)
+          n = value.to_i
+          return DEFAULT_PER_PAGE if n <= 0
+          return MAX_PER_PAGE if n > MAX_PER_PAGE
+
+          n
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/domains/probe.rb
+++ b/lib/onetime/operations/domains/probe.rb
@@ -1,0 +1,158 @@
+# lib/onetime/operations/domains/probe.rb
+#
+# frozen_string_literal: true
+
+# Domain-owned (app-scoped) diagnostic operation — see decision D3 in
+# lib/onetime/operations/README.md. The custom-domain model + its invariants are
+# owned by the domains bounded context, whose incumbent operations home is
+# lib/onetime/operations (verify_domain.rb, provision_sender_domain.rb, …). The
+# domain toolbox verbs live here alongside them, under the Domains:: namespace.
+#
+# Loaded at the call site (colonel logic + CLI), so require net/http deps
+# explicitly — the same convention the CLI command followed.
+require 'net/http'
+require 'openssl'
+
+module Onetime
+  module Operations
+    module Domains
+      # HTTPS probe of a custom domain — the SINGLE implementation of the probe
+      # verb (epic #43 / D3). Makes one outbound HTTPS request to confirm the
+      # domain serves traffic and inspects the presented TLS certificate.
+      #
+      # READ-ONLY: a probe reaches out over the network but mutates NOTHING in our
+      # data store, so — like the orphaned scan / system read-outs — it records NO
+      # {Onetime::AdminAuditEvent} (CONTRACT 4: audit is for mutations). The
+      # `bin/ots domains probe` CLI and the colonel endpoint
+      # (`GET /api/colonel/domains/:extid/probe`) are thin adapters over it.
+      #
+      # ## Behavioural parity (bit-for-bit)
+      #
+      # The probe logic is lifted verbatim from `DomainsProbeCommand#probe_domain`
+      # (build client → start connection → capture peer cert → GET → classify
+      # health). The returned Hash has the IDENTICAL shape and health taxonomy the
+      # CLI produced, so `bin/ots domains probe --json` emits the same JSON. The op
+      # takes a bare `hostname` (the CLI passed `domain.display_domain`); it does no
+      # model lookup of its own.
+      class Probe
+        # @param hostname [String] the domain to probe (e.g. display_domain).
+        # @param timeout [Integer] connect/read timeout in seconds (CLI default 10).
+        # @param insecure [Boolean] skip TLS verification (debugging only; CLI flag).
+        def initialize(hostname:, timeout: 10, insecure: false)
+          @hostname = hostname.to_s
+          @timeout  = timeout
+          @insecure = insecure
+        end
+
+        # @return [Hash] the probe result (timestamp/domain/url + http/ssl/health).
+        #   Same shape the CLI's `probe_domain` returned.
+        def call
+          result = {
+            timestamp: Time.now.utc.iso8601,
+            domain: @hostname,
+            url: "https://#{@hostname}",
+          }
+
+          begin
+            uri  = URI.parse("https://#{@hostname}")
+            http = build_http_client(uri)
+            cert = nil
+
+            response = http.start do |client|
+              # Capture cert while the connection is open.
+              cert                  = client.peer_cert
+              request               = Net::HTTP::Get.new(uri.request_uri)
+              request['User-Agent'] = 'OTS-Domain-Probe/1.0'
+              client.request(request)
+            end
+
+            result[:http] = {
+              status_code: response.code.to_i,
+              status_message: response.message,
+              success: response.is_a?(Net::HTTPSuccess) || response.is_a?(Net::HTTPRedirection),
+            }
+
+            result[:ssl]    = extract_ssl_info_from_cert(cert)
+            result[:health] = determine_health(result)
+          rescue OpenSSL::SSL::SSLError => ex
+            result[:http]   = { error: 'SSL Error', message: ex.message }
+            result[:ssl]    = { valid: false, error: ex.message }
+            result[:health] = 'ssl_error'
+          rescue Errno::ECONNREFUSED => ex
+            result[:http]   = { error: 'Connection Refused', message: ex.message }
+            result[:health] = 'connection_refused'
+          rescue Errno::ECONNRESET => ex
+            result[:http]   = { error: 'Connection Reset', message: ex.message }
+            result[:health] = 'connection_reset'
+          rescue Net::OpenTimeout, Net::ReadTimeout => ex
+            result[:http]   = { error: 'Timeout', message: ex.message }
+            result[:health] = 'timeout'
+          rescue SocketError => ex
+            result[:http]   = { error: 'DNS Resolution Failed', message: ex.message }
+            result[:health] = 'dns_error'
+          rescue StandardError => ex
+            result[:http]   = { error: ex.class.name, message: ex.message }
+            result[:health] = 'error'
+          end
+
+          result
+        end
+
+        private
+
+        def build_http_client(uri)
+          http              = Net::HTTP.new(uri.host, uri.port)
+          http.use_ssl      = true
+          http.open_timeout = @timeout
+          http.read_timeout = @timeout
+
+          http.verify_mode = if @insecure
+            OpenSSL::SSL::VERIFY_NONE
+          else
+            OpenSSL::SSL::VERIFY_PEER
+          end
+
+          http
+        end
+
+        def extract_ssl_info_from_cert(cert)
+          return { valid: false, error: 'No certificate' } unless cert
+
+          now               = Time.now
+          not_before        = cert.not_before
+          not_after         = cert.not_after
+          days_until_expiry = ((not_after - now) / 86_400).to_i
+
+          {
+            valid: true,
+            subject: cert.subject.to_s,
+            issuer: cert.issuer.to_s,
+            not_before: not_before.iso8601,
+            not_after: not_after.iso8601,
+            days_until_expiry: days_until_expiry,
+            expired: now > not_after,
+            not_yet_valid: now < not_before,
+          }
+        rescue StandardError => ex
+          { valid: false, error: ex.message }
+        end
+
+        def determine_health(result)
+          http = result[:http]
+          ssl  = result[:ssl]
+
+          return 'error' if http[:error]
+          return 'ssl_invalid' unless ssl[:valid]
+          return 'ssl_expired' if ssl[:expired]
+          return 'ssl_expiring_soon' if ssl[:days_until_expiry] && ssl[:days_until_expiry] < 7
+
+          if http[:success]
+            'healthy'
+          else
+            'http_error'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/domains/repair.rb
+++ b/lib/onetime/operations/domains/repair.rb
@@ -1,0 +1,154 @@
+# lib/onetime/operations/domains/repair.rb
+#
+# frozen_string_literal: true
+
+# Domain-owned (app-scoped) operation — see decision D3 in
+# lib/onetime/operations/README.md. Lives alongside the incumbent domain ops in
+# lib/onetime/operations, under the Domains:: namespace. Loaded at the call site
+# (colonel logic + CLI), so require the audit model explicitly, mirroring
+# AdminVerifyDomain / BanIP.
+require 'onetime/models/admin_audit_event'
+
+module Onetime
+  module Operations
+    module Domains
+      # Repair a custom domain's organization relationship — the SINGLE
+      # implementation of the repair verb (epic #43 / D3 / CONTRACT 4). Fixes the
+      # two relationship inconsistencies the CLI's `bin/ots domains repair` detects:
+      #
+      #   1. ORPHANED: `org_id` is blank. Repairable only when a target org is
+      #      supplied; the op assigns it and adds the domain to the org's collection.
+      #   2. NOT-IN-COLLECTION: `org_id` is set and the org exists, but the domain is
+      #      missing from that org's `domains` collection. The op adds it.
+      #
+      # A blank `org_id` with no target org (`:needs_org`) or an `org_id` pointing at
+      # a missing org (`:org_not_found`) is BLOCKED — reported, not mutated.
+      #
+      # ## Dry-run + exactly-once audit (CONTRACT 4)
+      #
+      # `dry_run: true` (the safe default) computes the plan — the issues found and
+      # what would change — and mutates NOTHING and audits NOTHING. `dry_run: false`
+      # applies the repairs and records EXACTLY ONE {Onetime::AdminAuditEvent} per
+      # successful mutation. A run that finds no issues (`:no_issues`) or is blocked
+      # mutates nothing and records no audit event (the "only audit an actual
+      # change" rule).
+      #
+      # ## Behavioural parity note (latent CLI bug fixed)
+      #
+      # The incumbent CLI passed `domain.domainid` (a String) to
+      # `org.add_domain` / compared it against `org.list_domains` (which returns
+      # domain OBJECTS). Those never matched an object collection, so the
+      # collection-membership check and add were effectively broken. This op uses
+      # the OBJECT-based calls verified by the model tryouts
+      # (`org.add_domain(domain)`, `org.list_domains.map(&:domainid)`), which is the
+      # intended, correct behaviour. See wiringInstructions / blockers.
+      class Repair
+        # Audit verb recorded for every applied repair.
+        AUDIT_VERB = 'domain.repair'
+
+        # @!attribute status [r] Symbol —
+        #   :no_issues (consistent), :needs_org (orphaned, no target given),
+        #   :org_not_found (org_id set but org missing), :planned (dry-run, fixable
+        #   issues found), :repaired (issues applied)
+        Result = Data.define(
+          :status, :domain_id, :extid, :display_domain,
+          :issues, :repairs_applied, :dry_run
+        )
+
+        # @param domain [Onetime::CustomDomain] target domain (caller ensures non-nil).
+        # @param actor [String, #extid, #email] acting admin's PUBLIC identity
+        #   (colonel extid/email, or the CLI sentinel). Never an internal objid.
+        # @param org [Onetime::Organization, nil] target org for the ORPHANED case
+        #   (the CLI's --org-id, resolved by the adapter). Ignored when org_id is set.
+        # @param dry_run [Boolean] preview only when true (default). Applies when false.
+        def initialize(domain:, actor:, org: nil, dry_run: true)
+          @domain  = domain
+          @actor   = actor
+          @org     = org
+          @dry_run = dry_run
+        end
+
+        # @return [Result]
+        def call
+          issues, repairs, blocked = analyze
+
+          return blocked if blocked
+          return result_for(:no_issues, issues, []) if issues.empty?
+          return result_for(:planned, issues, []) if @dry_run
+
+          # Apply every repair, collecting the human-readable result of each.
+          repairs_applied = repairs.map(&:call)
+
+          # Exactly one audit event per successful mutation. Non-secret detail only.
+          Onetime::AdminAuditEvent.record(
+            actor: @actor,
+            verb: AUDIT_VERB,
+            target: @domain.extid,
+            result: :success,
+            detail: {
+              issues: issues,
+              org_id: @domain.org_id.to_s,
+            },
+          )
+
+          result_for(:repaired, issues, repairs_applied)
+        end
+
+        private
+
+        # Compute [issues<Array<String>>, repairs<Array<#call>>, blocked<Result|nil>].
+        # A repair is a lambda returning its human-readable result string when applied.
+        def analyze
+          issues  = []
+          repairs = []
+
+          if @domain.org_id.to_s.empty?
+            # Case 1: orphaned.
+            unless @org
+              return [issues, repairs, result_for(:needs_org, [], [])]
+            end
+
+            issues << 'Domain is orphaned (no org_id)'
+            org = @org
+            repairs << lambda do
+              @domain.org_id  = org.org_id
+              @domain.updated = OT.now.to_i
+              @domain.save
+              org.add_domain(@domain)
+              "Assigned to organization #{org.org_id}"
+            end
+          else
+            # Case 2: org_id set — verify the org exists and the collection contains it.
+            org = Onetime::Organization.load(@domain.org_id)
+            unless org
+              return [issues, repairs, result_for(:org_not_found, [], [])]
+            end
+
+            in_collection = org.list_domains.map(&:domainid).include?(@domain.domainid)
+            unless in_collection
+              issues << "org_id is #{@domain.org_id} but not in organization's domains collection"
+              repairs << lambda do
+                org.add_domain(@domain)
+                "Added to organization #{@domain.org_id} collection"
+              end
+            end
+          end
+
+          [issues, repairs, nil]
+        end
+
+        def result_for(status, issues, repairs_applied)
+          Result.new(
+            status: status,
+            domain_id: @domain.domainid,
+            extid: @domain.extid,
+            display_domain: @domain.display_domain,
+            issues: issues,
+            repairs_applied: repairs_applied,
+            dry_run: @dry_run,
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/domains/transfer.rb
+++ b/lib/onetime/operations/domains/transfer.rb
@@ -1,0 +1,136 @@
+# lib/onetime/operations/domains/transfer.rb
+#
+# frozen_string_literal: true
+
+# Domain-owned (app-scoped) operation — see decision D3 in
+# lib/onetime/operations/README.md. Lives alongside the incumbent domain ops in
+# lib/onetime/operations, under the Domains:: namespace. Loaded at the call site
+# (colonel logic + CLI), so require the audit model explicitly.
+require 'onetime/models/admin_audit_event'
+
+module Onetime
+  module Operations
+    module Domains
+      # Transfer a custom domain between organizations — the SINGLE implementation
+      # of the transfer verb (epic #43 / D3 / CONTRACT 4). This is the
+      # highest-blast-radius toolbox verb: it reassigns domain OWNERSHIP across
+      # organizations. The `bin/ots domains transfer` CLI and the colonel endpoint
+      # (`POST /api/colonel/domains/:extid/transfer`) are thin adapters over it.
+      #
+      # ## Source of truth for "from" (parity with the CLI)
+      #
+      # The domain is ALWAYS removed from its CURRENT owner's collection (resolved
+      # from `domain.org_id`), whether or not an explicit `from_org` was supplied —
+      # this mirrors the CLI, which derives `from_org_id = --from-org || domain.org_id`
+      # and removes from that org. `from_org` is an optional OWNERSHIP ASSERTION:
+      # when supplied and its id does not equal the domain's current owner, the op
+      # returns `:mismatch` and mutates nothing (the CLI's "org_id does not match
+      # --from-org" guard). A domain with a blank `org_id` transfers from "orphaned"
+      # (nothing to remove).
+      #
+      # ## Dry-run + exactly-once audit (CONTRACT 4)
+      #
+      # `dry_run: true` (the safe default) returns the transfer plan (from/to org
+      # names + ids) and mutates/audits NOTHING. `dry_run: false` performs the
+      # transfer (remove from old collection → update org_id → add to new
+      # collection, rolling back org_id if the add fails) and records EXACTLY ONE
+      # {Onetime::AdminAuditEvent}. A blocked run (`:mismatch`) records no event.
+      #
+      # ## Behavioural parity note
+      #
+      # The collection add/remove use the domain's `domainid` STRING argument
+      # (`org.add_domain(domain.domainid)` / `org.remove_domain(domain.domainid)`),
+      # exactly matching the pre-refactor CLI (`bin/ots domains transfer`). This is
+      # the single shared impl for BOTH the CLI and the colonel endpoint, so both
+      # adapters pass the identical string argument.
+      class Transfer
+        # Audit verb recorded for every applied transfer.
+        AUDIT_VERB = 'domain.transfer'
+
+        # @!attribute status [r] Symbol —
+        #   :planned (dry-run), :transferred (applied),
+        #   :mismatch (explicit from_org != current owner — blocked)
+        Result = Data.define(
+          :status, :domain_id, :extid, :display_domain,
+          :from_org_id, :from_org_name, :to_org_id, :to_org_name, :dry_run
+        )
+
+        # @param domain [Onetime::CustomDomain] target domain (caller ensures non-nil).
+        # @param to_org [Onetime::Organization] destination org (caller resolves; required).
+        # @param actor [String, #extid, #email] acting admin's PUBLIC identity.
+        # @param from_org [Onetime::Organization, nil] optional source-org ASSERTION
+        #   for the ownership check; nil = trust the domain's current org_id.
+        # @param dry_run [Boolean] preview only when true (default). Applies when false.
+        def initialize(domain:, to_org:, actor:, from_org: nil, dry_run: true)
+          @domain   = domain
+          @to_org   = to_org
+          @actor    = actor
+          @from_org = from_org
+          @dry_run  = dry_run
+        end
+
+        # @return [Result]
+        def call
+          # Snapshot the CURRENT owner before any mutation — this is the real "from".
+          original_from_id = @domain.org_id
+          current_org      = original_from_id.to_s.empty? ? nil : Onetime::Organization.load(original_from_id)
+          original_from_nm = current_org&.display_name
+
+          # Ownership guard: an explicit from_org must match the current owner.
+          if @from_org && @from_org.org_id.to_s != original_from_id.to_s
+            return build(:mismatch, original_from_id, original_from_nm)
+          end
+
+          return build(:planned, original_from_id, original_from_nm) if @dry_run
+
+          # Remove from the old organization's collection, if there is one.
+          current_org&.remove_domain(@domain.domainid)
+
+          # Update the domain's owner.
+          @domain.org_id  = @to_org.org_id
+          @domain.updated = OT.now.to_i
+          @domain.save
+
+          # Add to the new organization's collection, rolling back org_id on failure.
+          begin
+            @to_org.add_domain(@domain.domainid)
+          rescue StandardError => ex
+            @domain.org_id = original_from_id
+            @domain.save
+            raise "Failed to add domain to organization collection: #{ex.message}"
+          end
+
+          # Exactly one audit event per successful transfer. Non-secret detail only.
+          Onetime::AdminAuditEvent.record(
+            actor: @actor,
+            verb: AUDIT_VERB,
+            target: @domain.extid,
+            result: :success,
+            detail: {
+              from_org_id: original_from_id.to_s,
+              to_org_id: @to_org.org_id.to_s,
+            },
+          )
+
+          build(:transferred, original_from_id, original_from_nm)
+        end
+
+        private
+
+        def build(status, from_id, from_name)
+          Result.new(
+            status: status,
+            domain_id: @domain.domainid,
+            extid: @domain.extid,
+            display_domain: @domain.display_domain,
+            from_org_id: from_id,
+            from_org_name: from_name,
+            to_org_id: @to_org.org_id,
+            to_org_name: @to_org.display_name,
+            dry_run: @dry_run,
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/email/list_templates.rb
+++ b/lib/onetime/operations/email/list_templates.rb
@@ -1,0 +1,51 @@
+# lib/onetime/operations/email/list_templates.rb
+#
+# frozen_string_literal: true
+
+# Central (cross-cutting) admin operation — see decision D3. Enumerating the
+# available email templates + their rendered formats is mailer infrastructure
+# with no single domain owner.
+require 'onetime/mail'
+require 'onetime/operations/email/preview_template'
+
+module Onetime
+  module Operations
+    module Email
+      # List the available email templates and which formats (text/html) each
+      # renders — the SINGLE implementation of the template-list capability the UI
+      # dropdown, the colonel `GET /api/colonel/email/templates` endpoint, and the
+      # `bin/ots email templates` CLI list all share.
+      #
+      # READ-ONLY: pure filesystem/class inspection, no side effects, no audit
+      # (CONTRACT 4). Output mirrors the CLI's `build_template_list` verbatim.
+      class ListTemplates
+        # One template summary row.
+        Entry = Data.define(:name, :klass, :formats)
+
+        # @return [Array<Entry>] one row per {AVAILABLE_TEMPLATES} entry, in order.
+        def call
+          AVAILABLE_TEMPLATES.map do |name|
+            template_class = Onetime::Mail::Mailer.send(:template_class_for, name)
+            has_html       = File.exist?(erb_path(name, 'html'))
+            has_text       = File.exist?(erb_path(name, 'txt'))
+
+            Entry.new(
+              name: name.to_s,
+              klass: template_class.name.split('::').last,
+              formats: [has_text ? 'text' : nil, has_html ? 'html' : nil].compact,
+            )
+          end
+        end
+
+        private
+
+        def erb_path(name, extension)
+          File.join(
+            Onetime::Mail::Templates::Base::TEMPLATE_PATH,
+            "#{name}.#{extension}.erb",
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/email/preview_template.rb
+++ b/lib/onetime/operations/email/preview_template.rb
@@ -1,0 +1,128 @@
+# lib/onetime/operations/email/preview_template.rb
+#
+# frozen_string_literal: true
+
+# Central (cross-cutting) admin operation — see decision D3. Rendering an email
+# template for inspection is site-wide mailer infrastructure with no single
+# domain owner. Loaded at the call site (colonel logic + the `bin/ots email
+# preview` CLI).
+require 'yaml'
+require 'onetime/mail'
+
+module Onetime
+  module Operations
+    module Email
+      # Canonical list of previewable / testable templates. SINGLE source of truth
+      # shared by the ops, the colonel API, and the CLI (`lib/onetime/cli/email.rb`
+      # aliases its `AVAILABLE_TEMPLATES` to this so the value stays byte-identical).
+      AVAILABLE_TEMPLATES = %i[
+        secret_link
+        welcome
+        password_request
+        incoming_secret
+        feedback_email
+        secret_revealed
+        expiration_warning
+        organization_invitation
+        email_change_confirmation
+        email_change_requested
+        email_changed
+      ].freeze
+
+      # Filesystem home of the per-template sample-data YAML fixtures. Same path the
+      # CLI used (`lib/onetime/mail/samples`), so preview output is unchanged.
+      SAMPLES_PATH = File.expand_path('../../mail/samples', __dir__)
+
+      # Render an email template to text or HTML for visual inspection — the
+      # SINGLE implementation of the preview verb (ticket #44). The colonel
+      # endpoint (`GET /api/colonel/email/templates/:template/preview`) and the
+      # `bin/ots email preview` CLI are thin adapters over it.
+      #
+      # READ-ONLY: rendering has NO side effects — it never dispatches an email and
+      # never touches Redis — so it records NO AdminAuditEvent (CONTRACT 4).
+      #
+      # ## Behavioural parity
+      #
+      # Data resolution matches the CLI verbatim: a nil `data` loads the template's
+      # sample YAML (injecting the recipient/email_address defaults); a supplied
+      # `data` hash is used as-is with the same recipient defaults filled in. The
+      # rendered body is exactly what `template.render_text` / `render_html`
+      # produced for the CLI.
+      class PreviewTemplate
+        # Raised when a template has no sample fixture and no data was supplied. The
+        # CLI rescues this to print its "No sample data found" hint + exit 1; the
+        # colonel logic maps it to a form error. Carries the missing path.
+        class MissingSampleError < StandardError
+          attr_reader :path
+
+          def initialize(path)
+            @path = path
+            super("No sample data found: #{path}")
+          end
+        end
+
+        # @!attribute body [r]
+        #   @return [String] the rendered template body (text or HTML).
+        Result = Data.define(:template, :locale, :format, :body)
+
+        # @param template [String, Symbol] template name (see {AVAILABLE_TEMPLATES}).
+        # @param data [Hash, nil] template variables; nil loads the sample fixture.
+        # @param locale [String] locale code for translations.
+        # @param format [String] 'html' for the HTML body, anything else for text.
+        def initialize(template:, data: nil, locale: 'en', format: 'text')
+          @template = template
+          @data     = data
+          @locale   = locale.to_s.empty? ? 'en' : locale.to_s
+          @format   = format.to_s
+        end
+
+        # @return [Result]
+        # @raise [ArgumentError] when the template name is unknown.
+        # @raise [MissingSampleError] when no data + no sample fixture exists.
+        def call
+          template_data  = resolve_data
+          template_class = Onetime::Mail::Mailer.send(:template_class_for, @template.to_sym)
+          instance       = template_class.new(template_data, locale: @locale)
+
+          body = if html?
+            instance.render_html || '(no HTML template)'
+          else
+            instance.render_text
+          end
+
+          Result.new(template: @template.to_s, locale: @locale, format: html? ? 'html' : 'text', body: body)
+        end
+
+        private
+
+        def html?
+          @format == 'html'
+        end
+
+        # Mirror the CLI's load_data / load_sample_data exactly so preview output is
+        # identical whether invoked over HTTP or on a shell.
+        def resolve_data
+          if @data
+            symbolized                   = @data.transform_keys(&:to_sym)
+            symbolized[:recipient]     ||= 'preview@example.com'
+            symbolized[:email_address] ||= symbolized[:recipient]
+            symbolized
+          else
+            load_sample_data
+          end
+        end
+
+        def load_sample_data
+          sample_file = File.join(SAMPLES_PATH, "#{@template}.yml")
+          raise MissingSampleError, sample_file unless File.exist?(sample_file)
+
+          parsed                       = YAML.safe_load_file(sample_file, permitted_classes: [Symbol])
+          symbolized                   = parsed.transform_keys(&:to_sym)
+          symbolized[:recipient]     ||= symbolized.delete(:email_address) || 'preview@example.com'
+          symbolized[:email_address] ||= symbolized[:recipient]
+          symbolized
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/email/send_test.rb
+++ b/lib/onetime/operations/email/send_test.rb
@@ -1,0 +1,154 @@
+# lib/onetime/operations/email/send_test.rb
+#
+# frozen_string_literal: true
+
+# Central (cross-cutting) admin operation — see decision D3 in
+# lib/onetime/operations/README.md. Email delivery diagnostics have no single
+# domain owner (the mailer is site-wide infrastructure), so — like
+# {Onetime::Operations::BanIP} and {Onetime::Operations::Banner} — this lives in
+# the central operations home. Loaded at the call site (colonel logic + the
+# `bin/ots email test` CLI), so require the audit dependency explicitly.
+require 'socket'
+require 'onetime/mail'
+require 'onetime/models/admin_audit_event'
+
+module Onetime
+  module Operations
+    module Email
+      # Send a plain-text diagnostic email to verify delivery connectivity — the
+      # SINGLE, audited implementation of the email test-send verb (ticket #44 /
+      # CONTRACT 4). The colonel endpoint (`POST /api/colonel/email/test`) and the
+      # `bin/ots email test` CLI are thin adapters over it.
+      #
+      # ## Behavioural parity (bit-for-bit)
+      #
+      # {.build} constructs the EXACT diagnostic email the CLI built inline before
+      # this extraction (same brand-aware subject/body, same provider/host probe),
+      # so the CLI's rendered output stays byte-identical. The CLI keeps its own
+      # timing + status-line printing and simply routes the actual send through
+      # this op; the op adds exactly one thing the inline send lacked: one
+      # {Onetime::AdminAuditEvent} per SUCCESSFUL real send.
+      #
+      # ## Audit rule (CONTRACT 4)
+      #
+      # A real send that succeeds records EXACTLY ONE audit event (verb
+      # `email.test_send`, actor = PUBLIC id, target = recipient). A dry-run sends
+      # nothing and records none. A send that RAISES (delivery failure) never
+      # reaches the audit call, so a failed send records none either — "only audit
+      # an actual, successful mutation". Delivery exceptions are NOT swallowed: they
+      # propagate to the caller so the CLI's existing rescue blocks (and the colonel
+      # logic's form-error handling) behave exactly as before.
+      class SendTest
+        # Audit verb recorded for every successful real send.
+        AUDIT_VERB = 'email.test_send'
+
+        # The fully-built diagnostic email plus the delivery context the CLI prints.
+        Diagnostic = Data.define(:to, :from, :subject, :text_body, :provider, :host, :timestamp)
+
+        # @!attribute status [r]
+        #   @return [Symbol] :dry_run (nothing sent), :sent (delivered / enqueued
+        #     synchronously via fallback), or :enqueued (handed to the worker queue).
+        Result = Data.define(:status, :diagnostic)
+
+        # Build the diagnostic email verbatim (pure — no side effects, no audit).
+        # Shared by the op's own {#call} AND by the CLI's pre-send output block, so
+        # the two can never drift. Brand-aware copy: a hardcoded vendor literal
+        # would leak into a white-label install's outbound test email (#3612).
+        #
+        # @param to [String] recipient email address.
+        # @return [Diagnostic]
+        def self.build(to:)
+          provider  = Onetime::Mail::Mailer.send(:determine_provider)
+          hostname  = Socket.gethostname
+          timestamp = Time.now.utc.iso8601
+
+          product_name = Onetime::CustomDomain::BrandSettingsConstants.global_defaults[:product_name] ||
+                         Onetime::CustomDomain::BrandSettingsConstants::NEUTRAL_PRODUCT_NAME
+
+          Diagnostic.new(
+            to: to,
+            from: Onetime::Mail::Mailer.from_address,
+            subject: "[#{product_name}] Email delivery test - #{timestamp}",
+            text_body: "This is a test email from the #{product_name} CLI.\n\nProvider: #{provider}\nTimestamp: #{timestamp}\nHost: #{hostname}",
+            provider: provider,
+            host: hostname,
+            timestamp: timestamp,
+          )
+        end
+
+        # @param to [String] recipient email address (caller validates format).
+        # @param actor [String, #extid, #email] acting admin's PUBLIC identity
+        #   (colonel extid/email, or the CLI sentinel). Never an internal objid.
+        # @param dry_run [Boolean] when true, build only — send nothing, audit none.
+        # @param enqueue [Boolean] when true, dispatch via the background worker
+        #   queue instead of direct delivery.
+        def initialize(to:, actor:, dry_run: false, enqueue: false)
+          @to      = to
+          @actor   = actor
+          @dry_run = dry_run
+          @enqueue = enqueue
+        end
+
+        # @return [Result]
+        # @raise [StandardError] delivery/enqueue failures propagate unchanged.
+        def call
+          diagnostic = self.class.build(to: @to)
+
+          # Dry-run: preview only. Nothing is dispatched and nothing is audited.
+          return Result.new(status: :dry_run, diagnostic: diagnostic) if @dry_run
+
+          status = @enqueue ? enqueue!(diagnostic) : deliver!(diagnostic)
+
+          # One audit event per successful real send. The recipient is the (public)
+          # target; the body/subject are non-secret diagnostics but we record only
+          # the provider + mode, never the message content.
+          Onetime::AdminAuditEvent.record(
+            actor: @actor,
+            verb: AUDIT_VERB,
+            target: @to,
+            result: :success,
+            detail: { provider: diagnostic.provider, mode: status.to_s, enqueue: @enqueue },
+          )
+
+          Result.new(status: status, diagnostic: diagnostic)
+        end
+
+        private
+
+        # Direct delivery via the configured backend. Raises on failure (caller's
+        # rescue owns the FAILED output). Mirrors the pre-extraction CLI call.
+        # @return [Symbol] :sent
+        def deliver!(diagnostic)
+          Onetime::Mail::Mailer.delivery_backend.deliver(email_hash(diagnostic))
+          :sent
+        end
+
+        # Enqueue via the background worker. When jobs are disabled the publisher's
+        # :raise fallback sends synchronously and returns falsey, which the CLI
+        # renders as "SENT SYNC". Mirrors the pre-extraction CLI call.
+        # @return [Symbol] :enqueued (handed to the queue) or :sent (fallback sync)
+        def enqueue!(diagnostic)
+          require 'onetime/jobs/publisher'
+
+          raw_email = {
+            to: diagnostic.to,
+            from: diagnostic.from,
+            subject: diagnostic.subject,
+            body: diagnostic.text_body,
+          }
+          queued = Onetime::Jobs::Publisher.enqueue_email_raw(raw_email, fallback: :raise)
+          queued ? :enqueued : :sent
+        end
+
+        def email_hash(diagnostic)
+          {
+            to: diagnostic.to,
+            from: diagnostic.from,
+            subject: diagnostic.subject,
+            text_body: diagnostic.text_body,
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/ratelimit/inspect.rb
+++ b/lib/onetime/operations/ratelimit/inspect.rb
@@ -1,0 +1,62 @@
+# lib/onetime/operations/ratelimit/inspect.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/operations/ratelimit/registry'
+
+module Onetime
+  module Operations
+    module RateLimit
+      # Inspect the current Redis state of a rate limiter for one subject — the
+      # SINGLE implementation of the limiter-inspect verb (ticket #44). The colonel
+      # endpoint (`GET /api/colonel/ratelimit/inspect`) is a thin adapter; the
+      # `bin/ots ratelimit keys` CLI serves the SAME capability by emitting the
+      # `TTL`/`GET` commands for the SAME {Registry}-derived keys (it deliberately
+      # never touches Redis itself — see ratelimit_command.rb).
+      #
+      # READ-ONLY: reads TTL + value for each key, mutates nothing, records NO
+      # AdminAuditEvent (CONTRACT 4). Bounded to the fixed, small set of keys the
+      # registry names — never a KEYS/SCAN over an unbounded set (CONTRACT 6).
+      class Inspect
+        # State of one backing key.
+        # @!attribute ttl [r] seconds remaining, or nil for no-expiry / absent.
+        # @!attribute exists [r] whether the key is currently set.
+        Entry = Data.define(:key, :ttl, :value, :exists)
+
+        Result = Data.define(:kind, :subject, :entries)
+
+        # @param kind [String] a known limiter kind (see {Registry}).
+        # @param subject [String] the IP / identifier the limiter keys on.
+        def initialize(kind:, subject:)
+          @kind    = kind.to_s
+          @subject = subject.to_s
+        end
+
+        # @return [Result]
+        # @raise [ArgumentError] when the kind is unknown.
+        def call
+          keys = Registry.keys_for(@kind, @subject)
+          raise ArgumentError, "Unknown rate limiter: #{@kind.inspect}" unless keys
+
+          db = Registry.dbclient_for(@kind)
+
+          entries = keys.map do |key|
+            raw_ttl = db.ttl(key)
+            value   = db.get(key)
+
+            Entry.new(
+              key: key,
+              # Collapse Redis's -1 (no expiry) / -2 (no key) sentinels to nil so
+              # the wire shape is "seconds remaining, or null".
+              ttl: raw_ttl.negative? ? nil : raw_ttl,
+              value: value,
+              exists: !value.nil?,
+            )
+          end
+
+          Result.new(kind: @kind, subject: @subject, entries: entries)
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/ratelimit/registry.rb
+++ b/lib/onetime/operations/ratelimit/registry.rb
@@ -1,0 +1,99 @@
+# lib/onetime/operations/ratelimit/registry.rb
+#
+# frozen_string_literal: true
+
+# Central (cross-cutting) admin operation support — see decision D3. The security
+# rate limiters (lib/onetime/security/*_rate_limiter.rb) are site-wide perimeter
+# infrastructure with no single domain owner, so their admin inspect/reset verbs
+# live in the central operations home alongside {Onetime::Operations::BanIP}.
+#
+# This file defines ONLY a frozen registry constant + pure key-derivation
+# helpers. It references NO models or Redis at load time — the per-limiter
+# database is resolved lazily through a proc — so the delay-boot `bin/ots
+# ratelimit` CLI can require it without booting the application.
+
+module Onetime
+  module Operations
+    module RateLimit
+      # SINGLE source of truth mapping each rate-limiter kind to its subject type,
+      # its Redis key templates, and the client that holds those keys. The
+      # `bin/ots ratelimit keys` CLI aliases its own `LIMITERS` to this so the
+      # emitted valkey-cli commands stay byte-identical, and the Inspect/Reset ops
+      # derive their keys from the SAME templates — write the key shape once.
+      #
+      # `keys` are `format`-style templates: `%s` is filled with the subject. This
+      # is the golden-master contract the CLI emits; do not reshape it.
+      #
+      # `dbclient` is a proc (evaluated at call time, never at require) returning
+      # the Redis/Valkey client whose shard holds the limiter's keys — matching the
+      # `redis` accessor inside each `lib/onetime/security/*_rate_limiter.rb`.
+      module Registry
+        LIMITERS = {
+          'feedback' => {
+            subject: 'IP address',
+            keys: ['feedback:submissions:%s', 'feedback:locked:%s'],
+            dbclient: -> { Onetime::Feedback.dbclient },
+          },
+          'passphrase' => {
+            subject: 'secret identifier',
+            keys: ['passphrase:attempts:%s', 'passphrase:locked:%s'],
+            dbclient: -> { Onetime::Secret.dbclient },
+          },
+          'invite' => {
+            subject: 'IP address',
+            keys: ['invite_attempts:%s', 'invite_locked:%s'],
+            dbclient: -> { Onetime::Secret.dbclient },
+          },
+          'dns' => {
+            subject: 'domain identifier (sanitized)',
+            keys: ['dns:ratelimit:%s'],
+            dbclient: -> { Onetime::CustomDomain.dbclient },
+          },
+        }.freeze
+
+        module_function
+
+        # @return [Array<String>] the known limiter kinds, in registry order.
+        def kinds
+          LIMITERS.keys
+        end
+
+        # @param kind [String]
+        # @return [Hash, nil] the limiter metadata, or nil for an unknown kind.
+        def fetch(kind)
+          LIMITERS[kind.to_s]
+        end
+
+        # @return [Boolean] whether the kind is a known limiter.
+        def known?(kind)
+          LIMITERS.key?(kind.to_s)
+        end
+
+        # Derive the concrete Redis keys for a kind + subject. This is the one
+        # place the templates are expanded — the CLI, Inspect, and Reset all call
+        # through here so the keys can never drift.
+        #
+        # @param kind [String]
+        # @param subject [String]
+        # @return [Array<String>, nil] concrete keys, or nil for an unknown kind.
+        def keys_for(kind, subject)
+          meta = fetch(kind)
+          return nil unless meta
+
+          meta[:keys].map { |tmpl| format(tmpl, subject) }
+        end
+
+        # Resolve the Redis/Valkey client holding a kind's keys (call-time).
+        #
+        # @param kind [String]
+        # @return [Object, nil] the dbclient, or nil for an unknown kind.
+        def dbclient_for(kind)
+          meta = fetch(kind)
+          return nil unless meta
+
+          meta[:dbclient].call
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/ratelimit/reset.rb
+++ b/lib/onetime/operations/ratelimit/reset.rb
@@ -1,0 +1,73 @@
+# lib/onetime/operations/ratelimit/reset.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/operations/ratelimit/registry'
+require 'onetime/models/admin_audit_event'
+
+module Onetime
+  module Operations
+    module RateLimit
+      # Reset (clear) a rate limiter's Redis state for one subject — the SINGLE,
+      # audited implementation of the limiter-reset verb (ticket #44 / CONTRACT 4).
+      # The colonel endpoint (`POST /api/colonel/ratelimit/reset`) is a thin
+      # adapter. The `bin/ots ratelimit keys` CLI serves the SAME capability by
+      # emitting a `DEL` command over the SAME {Registry}-derived keys (it never
+      # executes it — the operator does), which is why the CLI itself takes no
+      # audit path.
+      #
+      # The DELETE is exactly the CLI's emitted `DEL <keys>` (and equivalent to the
+      # limiter modules' own `clear_*_rate_limit!`). The op adds one thing: exactly
+      # one {Onetime::AdminAuditEvent} per reset that ACTUALLY removed a key. A
+      # reset of an already-clear subject is an idempotent no-op — `status:
+      # :not_set`, NO audit event (the "only audit an actual change" rule shared
+      # with UnbanIP / ClearBanner). Bounded to the registry's fixed key set
+      # (CONTRACT 6).
+      class Reset
+        # Audit verb recorded for every reset that removed at least one key.
+        AUDIT_VERB = 'ratelimit.reset'
+
+        # @!attribute status [r] :success (something removed) or :not_set (no-op)
+        Result = Data.define(:status, :kind, :subject, :keys, :deleted)
+
+        # @param kind [String] a known limiter kind (see {Registry}).
+        # @param subject [String] the IP / identifier the limiter keys on.
+        # @param actor [String, #extid, #email] acting admin's PUBLIC identity
+        #   (colonel extid/email, or a CLI sentinel). Never an internal objid.
+        def initialize(kind:, subject:, actor:)
+          @kind    = kind.to_s
+          @subject = subject.to_s
+          @actor   = actor
+        end
+
+        # @return [Result]
+        # @raise [ArgumentError] when the kind is unknown.
+        def call
+          keys = Registry.keys_for(@kind, @subject)
+          raise ArgumentError, "Unknown rate limiter: #{@kind.inspect}" unless keys
+
+          db      = Registry.dbclient_for(@kind)
+          deleted = db.del(*keys).to_i
+
+          # No key existed → nothing mutated → idempotent no-op, records no audit.
+          if deleted.zero?
+            return Result.new(status: :not_set, kind: @kind, subject: @subject, keys: keys, deleted: 0)
+          end
+
+          # One audit event per successful reset. The subject may be an IP or a
+          # (public) secret identifier; it is the audit target. Never record the
+          # counter VALUES — only the fact + shape of the reset.
+          Onetime::AdminAuditEvent.record(
+            actor: @actor,
+            verb: AUDIT_VERB,
+            target: "#{@kind}:#{@subject}",
+            result: :success,
+            detail: { kind: @kind, keys: keys.length, deleted: deleted },
+          )
+
+          Result.new(status: :success, kind: @kind, subject: @subject, keys: keys, deleted: deleted)
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/sessions/delete_session.rb
+++ b/lib/onetime/operations/sessions/delete_session.rb
@@ -1,0 +1,71 @@
+# lib/onetime/operations/sessions/delete_session.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/operations/sessions/store'
+require 'onetime/models/admin_audit_event'
+
+module Onetime
+  module Operations
+    module Sessions
+      # Delete (revoke / terminate) a single session — the SINGLE, audited
+      # implementation of the session-delete verb (epic #40 / D3 / CONTRACT 4).
+      #
+      # This is the one mutating session verb. The colonel endpoint
+      # (`DELETE /api/colonel/sessions/:session_id`) and the `bin/ots session delete`
+      # CLI are thin adapters over it. The model mutation is IDENTICAL to the prior
+      # inline CLI call (`dbclient.del(session_key)`); the op adds exactly one thing
+      # the inline call lacked: one {Onetime::AdminAuditEvent} per successful delete,
+      # mirroring the Slice-4 {Onetime::Operations::BanIP} / `UnbanIP` precedent.
+      #
+      # Deleting a session logs that user out mid-flight, so the HTTP path gates it
+      # behind AdminConfirmDialog typed-confirmation and the CLI behind a y/N prompt
+      # (both in the adapter); the op itself just performs + audits.
+      #
+      # Stateless, single `#call`, returns an immutable {Result}. A delete of an id
+      # with no live session key returns `status: :not_found` and records NO audit
+      # event (nothing mutated) — the "only audit an actual change" rule.
+      class Delete
+        # Audit verb recorded for every successful revoke.
+        AUDIT_VERB = 'session.delete'
+
+        # @!attribute status [r] Symbol :deleted (removed) or :not_found (no-op)
+        Result = Data.define(:status, :session_id, :key)
+
+        # @param session_id [String] the bare session id to revoke.
+        # @param actor [String, #extid, #email] acting admin's PUBLIC identity
+        #   (colonel extid/email, or a CLI sentinel). Never an internal objid.
+        # @param dbclient [Object, nil] Redis-like client; defaults to Familia.dbclient.
+        def initialize(session_id:, actor:, dbclient: nil)
+          @session_id = session_id
+          @actor      = actor
+          @dbclient   = dbclient
+        end
+
+        # @return [Result]
+        def call
+          db  = @dbclient || Familia.dbclient
+          key = Store.find_key(db, @session_id)
+
+          unless key
+            return Result.new(status: :not_found, session_id: @session_id, key: nil)
+          end
+
+          # Same mutation the CLI performed inline, preserved verbatim.
+          db.del(key)
+
+          # One audit event per successful mutation. The session id is a public
+          # identifier; never put session contents (tokens, etc.) into detail.
+          Onetime::AdminAuditEvent.record(
+            actor: @actor,
+            verb: AUDIT_VERB,
+            target: @session_id,
+            result: :success,
+          )
+
+          Result.new(status: :deleted, session_id: @session_id, key: key)
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/sessions/inspect_session.rb
+++ b/lib/onetime/operations/sessions/inspect_session.rb
@@ -1,0 +1,57 @@
+# lib/onetime/operations/sessions/inspect_session.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/operations/sessions/store'
+
+module Onetime
+  module Operations
+    module Sessions
+      # Inspect a single session — the SINGLE implementation of the session-inspect
+      # verb (epic #40 / D3). The colonel endpoint (`GET /api/colonel/sessions/:id`)
+      # and the `bin/ots session inspect` CLI are thin adapters over it.
+      #
+      # READ-ONLY: records NO {Onetime::AdminAuditEvent} (CONTRACT 4).
+      #
+      # Stateless, single `#call`, returns an immutable {Result}. A miss (no key for
+      # the id, or an empty value) returns `found: false` with nil fields.
+      class Inspect
+        # @!attribute found [r] Boolean whether a session key was resolved + loaded
+        # @!attribute ttl [r] Integer, nil Redis TTL in seconds (-1 no expiry, -2 gone)
+        # @!attribute data [r] Hash, nil the full parsed session payload
+        Result = Data.define(:found, :session_id, :key, :ttl, :data)
+
+        # @param session_id [String] the bare session id to resolve.
+        # @param dbclient [Object, nil] Redis-like client; defaults to Familia.dbclient.
+        def initialize(session_id:, dbclient: nil)
+          @session_id = session_id
+          @dbclient   = dbclient
+        end
+
+        # @return [Result]
+        def call
+          db  = @dbclient || Familia.dbclient
+          key = Store.find_key(db, @session_id)
+          return miss unless key
+
+          data = Store.load_data(db, key)
+          return miss unless data
+
+          Result.new(
+            found: true,
+            session_id: @session_id,
+            key: key,
+            ttl: db.ttl(key),
+            data: data,
+          )
+        end
+
+        private
+
+        def miss
+          Result.new(found: false, session_id: @session_id, key: nil, ttl: nil, data: nil)
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/sessions/list_sessions.rb
+++ b/lib/onetime/operations/sessions/list_sessions.rb
@@ -1,0 +1,90 @@
+# lib/onetime/operations/sessions/list_sessions.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/operations/sessions/store'
+
+module Onetime
+  module Operations
+    module Sessions
+      # List active sessions — the SINGLE implementation of the session-list verb
+      # (epic #40 / D3). The colonel endpoint (`GET /api/colonel/sessions`) and the
+      # `bin/ots session list` / `search` CLI commands are thin adapters over it.
+      #
+      # READ-ONLY: inspecting sessions mutates nothing, so — like the billing
+      # catalog / system read-outs — it records NO {Onetime::AdminAuditEvent}
+      # (CONTRACT 4: audit is for mutations).
+      #
+      # Bounded by construction (CONTRACT 6): the listing is a bounded cursor SCAN
+      # (never a blocking KEYS), collected once and paginated in memory. Results are
+      # sorted newest-authenticated first (nils last), tiebroken by session id, so
+      # pagination is stable across pages.
+      #
+      # Stateless, single `#call`, returns an immutable {Result}.
+      class List
+        # @!attribute sessions [r] Array<Hash> one page of {Store.summarize} rows
+        # @!attribute total_count [r] Integer sessions matched (pre-pagination)
+        Result = Data.define(:sessions, :total_count, :page, :per_page, :total_pages)
+
+        # Cap on page size, matching the colonel list convention (list_secrets.rb).
+        MAX_PER_PAGE = 100
+        DEFAULT_PER_PAGE = 50
+
+        # @param page [Integer] 1-based page (clamped to >= 1).
+        # @param per_page [Integer] page size (clamped to 1..MAX_PER_PAGE).
+        # @param search [String, nil] optional free-text identity filter.
+        # @param dbclient [Object, nil] Redis-like client; defaults to Familia.dbclient.
+        def initialize(page: 1, per_page: DEFAULT_PER_PAGE, search: nil, dbclient: nil)
+          @page     = page.to_i < 1 ? 1 : page.to_i
+          @per_page = clamp_per_page(per_page)
+          @search   = search.to_s.empty? ? nil : search.to_s
+          @dbclient = dbclient
+        end
+
+        # @return [Result]
+        def call
+          db   = @dbclient || Familia.dbclient
+          rows = collect(db)
+
+          rows.select! { |row| Store.matches_search?(row[:__data], @search) } if @search
+          rows.sort_by! { |row| [-(row[:created_at] || 0), row[:session_id].to_s] }
+          rows.each { |row| row.delete(:__data) }
+
+          total_count = rows.size
+          total_pages = @per_page.zero? ? 0 : (total_count.to_f / @per_page).ceil
+          start_idx   = (@page - 1) * @per_page
+          page_rows   = rows[start_idx, @per_page] || []
+
+          Result.new(
+            sessions: page_rows,
+            total_count: total_count,
+            page: @page,
+            per_page: @per_page,
+            total_pages: total_pages,
+          )
+        end
+
+        private
+
+        # Bounded scan → load → summarize. The parsed session data rides along under
+        # `:__data` so the search predicate can run before it is stripped for output.
+        def collect(db)
+          Store.scan_keys(db).filter_map do |key|
+            data = Store.load_data(db, key)
+            next nil unless data
+
+            Store.summarize(Store.extract_id(key), key, data).merge(__data: data)
+          end
+        end
+
+        def clamp_per_page(value)
+          n = value.to_i
+          return DEFAULT_PER_PAGE if n <= 0
+          return MAX_PER_PAGE if n > MAX_PER_PAGE
+
+          n
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/sessions/store.rb
+++ b/lib/onetime/operations/sessions/store.rb
@@ -1,0 +1,152 @@
+# lib/onetime/operations/sessions/store.rb
+#
+# frozen_string_literal: true
+
+require 'json'
+
+module Onetime
+  module Operations
+    module Sessions
+      # Shared session-store primitives — the SINGLE source of the Redis/session
+      # key logic that the session admin verbs (List / Inspect / Delete) and the
+      # CLI `bin/ots session *` commands are thin adapters over (epic #40 / D3).
+      #
+      # Before this extraction the key patterns, the JSON-safe loader, and the
+      # search matcher lived only inside `Onetime::CLI::SessionHelpers`, so there
+      # was no operation, API, or UI — incident response required SSH. This module
+      # lifts that capability out; `SessionHelpers` now delegates to it (the CLI is
+      # a thin adapter), and the colonel endpoints call the ops that use it.
+      #
+      # Context-free by contract (lib/onetime/operations/README.md): it knows
+      # nothing about HTTP or sessions-as-auth; callers pass the dbclient (or let
+      # it default to {Familia.dbclient}, exactly as the CLI did).
+      #
+      # ## Security note (issue #3498, preserved)
+      #
+      # {load_data} parses Redis-sourced bytes with JSON.parse, NEVER Marshal.load:
+      # Marshal walks (and instantiates) its object graph BEFORE it can raise, so a
+      # rescue around it offers no protection against a crafted gadget chain planted
+      # at a session key. On any parse failure it returns a bounded `{'_raw' => ...}`
+      # fallback. This behaviour is byte-for-byte what `SessionHelpers#load_session_data`
+      # guaranteed and what `spec/cli/session_command_security_spec.rb` locks in.
+      module Store
+        module_function
+
+        # Non-blocking SCAN match for every session key shape (CONTRACT 6 — bounded
+        # cursor scan only, never a blocking KEYS on the request path).
+        SESSION_SCAN_PATTERN = '*session*'
+
+        # Hard cap on how many session keys a single bounded scan collects, so an
+        # unbounded keyspace can never turn one request into an O(all-keys) walk.
+        MAX_SCAN = 10_000
+
+        # Common prefixes stripped to recover the bare session id from a key.
+        KEY_PREFIX_PATTERN = /^(session:|rack:session:)/
+
+        # The candidate keys a bare session id can live under. Identical to the
+        # historic CLI list — order matters (first existing key wins).
+        #
+        # @param session_id [String]
+        # @return [Array<String>]
+        def key_patterns(session_id)
+          [
+            "session:#{session_id}",
+            "rack:session:#{session_id}",
+            session_id,
+            "session:rack:session:#{session_id}",
+          ]
+        end
+
+        # The first key pattern that exists for this id, or nil. Uses EXISTS only
+        # (no blocking scan) — a bounded, O(patterns) probe.
+        #
+        # @param dbclient [Object] a Redis-like client
+        # @param session_id [String]
+        # @return [String, nil]
+        def find_key(dbclient, session_id)
+          key_patterns(session_id).each do |pattern|
+            return pattern if dbclient.exists(pattern) > 0
+          end
+          nil
+        end
+
+        # Load + JSON-parse a session value. Returns nil when the key holds nothing,
+        # a parsed Hash on success, or a bounded `{'_raw' => ...}` fallback when the
+        # bytes are not JSON. NEVER calls Marshal.load (see the security note above).
+        #
+        # @param dbclient [Object]
+        # @param key [String]
+        # @return [Hash, nil]
+        def load_data(dbclient, key)
+          raw_data = dbclient.get(key)
+          return nil unless raw_data
+
+          begin
+            JSON.parse(raw_data)
+          rescue StandardError
+            { '_raw' => raw_data[0..200] }
+          end
+        end
+
+        # Recover the bare session id from a full key.
+        #
+        # @param key [String]
+        # @return [String]
+        def extract_id(key)
+          key.gsub(KEY_PREFIX_PATTERN, '')
+        end
+
+        # Bounded, non-blocking scan of every session key. Uses SCAN (via
+        # `scan_each`, the same lazy cursor iterator the historic CLI used — never a
+        # blocking KEYS, CONTRACT 6) and stops after at most {MAX_SCAN} keys so an
+        # unbounded keyspace can't turn one request into an O(all-keys) walk.
+        #
+        # @param dbclient [Object]
+        # @param pattern [String]
+        # @return [Array<String>] the matched keys (scan order, capped)
+        def scan_keys(dbclient, pattern: SESSION_SCAN_PATTERN)
+          dbclient.scan_each(match: pattern).first(MAX_SCAN)
+        end
+
+        # Build a compact, JSON-ready summary of one session for list rows. Raw
+        # email is returned (the colonel is fully privileged and the detail view
+        # shows it anyway); presentation-layer obscuring — e.g. the CLI `list`
+        # formatter — stays in the adapter so the op has one canonical shape.
+        #
+        # @param session_id [String]
+        # @param key [String]
+        # @param data [Hash] parsed session data
+        # @return [Hash]
+        def summarize(session_id, key, data)
+          {
+            session_id: session_id,
+            key: key,
+            authenticated: data['authenticated'] ? true : false,
+            email: data['email'],
+            external_id: data['external_id'] || data['account_external_id'],
+            role: data['role'],
+            ip_address: data['ip_address'],
+            created_at: data['authenticated_at'],
+          }
+        end
+
+        # Case-insensitive match of a session against a free-text term across the
+        # identity fields. Identical predicate to the historic CLI `search`.
+        #
+        # @param data [Hash]
+        # @param term [String]
+        # @return [Boolean]
+        def matches_search?(data, term)
+          needle = term.to_s.downcase
+          return false if needle.empty?
+
+          [
+            data['email'],
+            data['external_id'],
+            data['account_external_id'],
+          ].compact.any? { |field| field.downcase.include?(needle) }
+        end
+      end
+    end
+  end
+end

--- a/locales/content/en/admin-banner.json
+++ b/locales/content/en/admin-banner.json
@@ -1,0 +1,130 @@
+{
+  "web.admin.banner.title": {
+    "text": "Broadcast Banner",
+    "content_hash": "0bc449a3"
+  },
+  "web.admin.banner.description": {
+    "text": "Publish a site-wide announcement shown to every visitor, or clear the current one.",
+    "content_hash": "a0f720d7"
+  },
+  "web.admin.banner.loadError": {
+    "text": "Could not load the current banner.",
+    "content_hash": "04954e72"
+  },
+  "web.admin.banner.retry": {
+    "text": "Retry",
+    "content_hash": "942087cc"
+  },
+  "web.admin.banner.current.title": {
+    "text": "Current banner",
+    "content_hash": "d17ab873"
+  },
+  "web.admin.banner.current.none": {
+    "text": "No banner is currently set.",
+    "content_hash": "487b2cac"
+  },
+  "web.admin.banner.current.status": {
+    "text": "Status",
+    "content_hash": "920e413c"
+  },
+  "web.admin.banner.current.live": {
+    "text": "Live",
+    "content_hash": "b64ac05f"
+  },
+  "web.admin.banner.current.expiry": {
+    "text": "Expiry",
+    "content_hash": "6956d814"
+  },
+  "web.admin.banner.current.persistent": {
+    "text": "Persistent (no expiry)",
+    "content_hash": "5f95d1b0"
+  },
+  "web.admin.banner.current.expiresIn": {
+    "text": "Expires in {duration}",
+    "content_hash": "f353f9a7"
+  },
+  "web.admin.banner.current.storedContent": {
+    "text": "Stored content",
+    "content_hash": "3579f3e6"
+  },
+  "web.admin.banner.current.htmlNote": {
+    "text": "Content is HTML; the site sanitizes it to links only when displayed.",
+    "content_hash": "e45a7dfe"
+  },
+  "web.admin.banner.current.edit": {
+    "text": "Edit",
+    "content_hash": "464c4ffd"
+  },
+  "web.admin.banner.set.title": {
+    "text": "Set a banner",
+    "content_hash": "b6f90d5c"
+  },
+  "web.admin.banner.set.updateTitle": {
+    "text": "Update the banner",
+    "content_hash": "841a0183"
+  },
+  "web.admin.banner.set.contentLabel": {
+    "text": "Message",
+    "content_hash": "2f77668a"
+  },
+  "web.admin.banner.set.contentPlaceholder": {
+    "text": "Scheduled maintenance Sun 02:00 UTC",
+    "content_hash": "4ec99d7d"
+  },
+  "web.admin.banner.set.contentHelp": {
+    "text": "HTML is allowed; the site sanitizes it to links only.",
+    "content_hash": "7253d1cd"
+  },
+  "web.admin.banner.set.ttlLabel": {
+    "text": "Auto-expire after (seconds)",
+    "content_hash": "72134116"
+  },
+  "web.admin.banner.set.ttlPlaceholder": {
+    "text": "Leave blank for no expiry",
+    "content_hash": "a8fd81e1"
+  },
+  "web.admin.banner.set.ttlHelp": {
+    "text": "Optional. The banner is removed automatically after this many seconds.",
+    "content_hash": "ba0237f5"
+  },
+  "web.admin.banner.set.publishButton": {
+    "text": "Publish banner",
+    "content_hash": "5b7427a1"
+  },
+  "web.admin.banner.set.updateButton": {
+    "text": "Update banner",
+    "content_hash": "69b6e40e"
+  },
+  "web.admin.banner.set.confirmTitle": {
+    "text": "Publish broadcast banner?",
+    "content_hash": "8b72b5c3"
+  },
+  "web.admin.banner.set.confirmDescription": {
+    "text": "This banner will be shown to every visitor across the site until it is cleared or expires.",
+    "content_hash": "c61bbec1"
+  },
+  "web.admin.banner.set.confirmButton": {
+    "text": "Publish",
+    "content_hash": "859390eb"
+  },
+  "web.admin.banner.set.success": {
+    "text": "Broadcast banner published.",
+    "content_hash": "55c06cab"
+  },
+  "web.admin.banner.clear.button": {
+    "text": "Clear banner",
+    "content_hash": "da6b2e5d"
+  },
+  "web.admin.banner.clear.confirmTitle": {
+    "text": "Clear the broadcast banner?",
+    "content_hash": "46d9c35a"
+  },
+  "web.admin.banner.clear.confirmDescription": {
+    "text": "This removes the live banner for every visitor. Type the confirmation word to proceed.",
+    "content_hash": "9a56e4be"
+  },
+  "web.admin.banner.clear.success": {
+    "text": "Broadcast banner cleared.",
+    "content_hash": "b0f52af4"
+  }
+}

--- a/locales/content/en/admin-billing.json
+++ b/locales/content/en/admin-billing.json
@@ -1,0 +1,126 @@
+{
+  "web.admin.billing.title": {
+    "text": "Billing Catalog",
+    "content_hash": "bfde7e68"
+  },
+  "web.admin.billing.description": {
+    "text": "Read-only view of configured plans and their entitlements, and any drift from the live Stripe-synced catalog.",
+    "content_hash": "05d5b332"
+  },
+  "web.admin.billing.retry": {
+    "text": "Retry",
+    "content_hash": "942087cc"
+  },
+  "web.admin.billing.loadError": {
+    "text": "Could not load the billing catalog.",
+    "content_hash": "c3110f77"
+  },
+  "web.admin.billing.localConfigWarning": {
+    "text": "The Stripe-synced plan cache is empty, so live plans and drift cannot be evaluated. Showing the configured catalog (billing.yaml) only — typical in dev or when Stripe is not configured.",
+    "content_hash": "905d95f8"
+  },
+  "web.admin.billing.stats.configured": {
+    "text": "Configured plans",
+    "content_hash": "4fda4796"
+  },
+  "web.admin.billing.stats.live": {
+    "text": "Live plans",
+    "content_hash": "faaa88d9"
+  },
+  "web.admin.billing.stats.source": {
+    "text": "Source",
+    "content_hash": "0e570ca6"
+  },
+  "web.admin.billing.stats.drift": {
+    "text": "Drift",
+    "content_hash": "8b4c8240"
+  },
+  "web.admin.billing.source.stripe": {
+    "text": "Stripe cache",
+    "content_hash": "b5577327"
+  },
+  "web.admin.billing.source.localConfig": {
+    "text": "Local config",
+    "content_hash": "49de43d2"
+  },
+  "web.admin.billing.inSync": {
+    "text": "In sync",
+    "content_hash": "5701958c"
+  },
+  "web.admin.billing.driftCount": {
+    "text": "{count} difference(s)",
+    "content_hash": "166538f5"
+  },
+  "web.admin.billing.inSyncDetail": {
+    "text": "The configured catalog matches the live plans. No drift detected.",
+    "content_hash": "57ab60a6"
+  },
+  "web.admin.billing.columns.planid": {
+    "text": "Plan ID",
+    "content_hash": "1f0d4dc6"
+  },
+  "web.admin.billing.columns.name": {
+    "text": "Name",
+    "content_hash": "dcd1d522"
+  },
+  "web.admin.billing.columns.tier": {
+    "text": "Tier",
+    "content_hash": "cb9e8664"
+  },
+  "web.admin.billing.columns.status": {
+    "text": "Status",
+    "content_hash": "920e413c"
+  },
+  "web.admin.billing.plans.title": {
+    "text": "Plans",
+    "content_hash": "dfe8b2f0"
+  },
+  "web.admin.billing.plans.empty": {
+    "text": "No plans found in the catalog.",
+    "content_hash": "39db3c13"
+  },
+  "web.admin.billing.plans.viewDiff": {
+    "text": "View diff",
+    "content_hash": "0e5d6873"
+  },
+  "web.admin.billing.status.in_sync": {
+    "text": "In sync",
+    "content_hash": "5701958c"
+  },
+  "web.admin.billing.status.only_config": {
+    "text": "Config only",
+    "content_hash": "15836cba"
+  },
+  "web.admin.billing.status.only_live": {
+    "text": "Live only",
+    "content_hash": "8f4ed495"
+  },
+  "web.admin.billing.status.changed": {
+    "text": "Changed",
+    "content_hash": "2a6141e4"
+  },
+  "web.admin.billing.diff.title": {
+    "text": "Plan diff: {planid}",
+    "content_hash": "bc86e5f7"
+  },
+  "web.admin.billing.diff.subtitle": {
+    "text": "Configured catalog (billing.yaml) vs live Stripe-synced plan, side by side.",
+    "content_hash": "d92e93ae"
+  },
+  "web.admin.billing.diff.config": {
+    "text": "Configured (billing.yaml)",
+    "content_hash": "6bf2ff04"
+  },
+  "web.admin.billing.diff.live": {
+    "text": "Live (Stripe cache)",
+    "content_hash": "4886945d"
+  },
+  "web.admin.billing.diff.absentConfig": {
+    "text": "This plan is not present in the configured catalog.",
+    "content_hash": "0b594c88"
+  },
+  "web.admin.billing.diff.absentLive": {
+    "text": "This plan is not present in the live Stripe-synced cache.",
+    "content_hash": "c53f31c3"
+  }
+}

--- a/locales/content/en/admin-domaintoolbox.json
+++ b/locales/content/en/admin-domaintoolbox.json
@@ -1,0 +1,178 @@
+{
+  "web.admin.domaintoolbox.title": {
+    "text": "Domain Toolbox",
+    "content_hash": "5a9333db"
+  },
+  "web.admin.domaintoolbox.description": {
+    "text": "Diagnose and repair custom-domain relationships: scan orphans, probe DNS/SSL, repair ownership, and transfer between organizations.",
+    "content_hash": "778537aa"
+  },
+  "web.admin.domaintoolbox.retry": {
+    "text": "Retry",
+    "content_hash": "942087cc"
+  },
+  "web.admin.domaintoolbox.preview": {
+    "text": "Preview",
+    "content_hash": "324b134f"
+  },
+  "web.admin.domaintoolbox.fields.extid": {
+    "text": "Domain external ID",
+    "content_hash": "f52af6c5"
+  },
+  "web.admin.domaintoolbox.fields.extidPlaceholder": {
+    "text": "cd_… (domain extid)",
+    "content_hash": "bb9bf49a"
+  },
+  "web.admin.domaintoolbox.orphaned.title": {
+    "text": "Orphaned domains",
+    "content_hash": "ddcea596"
+  },
+  "web.admin.domaintoolbox.orphaned.description": {
+    "text": "Custom domains with no owning organization. Use Repair to reassign one.",
+    "content_hash": "967268f5"
+  },
+  "web.admin.domaintoolbox.orphaned.empty": {
+    "text": "No orphaned domains found.",
+    "content_hash": "06ef9979"
+  },
+  "web.admin.domaintoolbox.orphaned.loadError": {
+    "text": "Could not load orphaned domains.",
+    "content_hash": "ca0e33bf"
+  },
+  "web.admin.domaintoolbox.orphaned.repairAction": {
+    "text": "Repair",
+    "content_hash": "1196b6c5"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.domain": {
+    "text": "Domain",
+    "content_hash": "79fa3361"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.state": {
+    "text": "State",
+    "content_hash": "a3b50c47"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.verified": {
+    "text": "Verified",
+    "content_hash": "4f783840"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.created": {
+    "text": "Created",
+    "content_hash": "d70b9e24"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.actions": {
+    "text": "Actions",
+    "content_hash": "ff8059dc"
+  },
+  "web.admin.domaintoolbox.probe.title": {
+    "text": "Probe (DNS / SSL)",
+    "content_hash": "ec69a087"
+  },
+  "web.admin.domaintoolbox.probe.description": {
+    "text": "Make a live HTTPS request to confirm the domain serves traffic and inspect its TLS certificate. Read-only.",
+    "content_hash": "1eecfa96"
+  },
+  "web.admin.domaintoolbox.probe.button": {
+    "text": "Probe",
+    "content_hash": "3bd51ab9"
+  },
+  "web.admin.domaintoolbox.probe.healthLabel": {
+    "text": "Health",
+    "content_hash": "55898449"
+  },
+  "web.admin.domaintoolbox.reverify.button": {
+    "text": "Re-verify",
+    "content_hash": "0344860a"
+  },
+  "web.admin.domaintoolbox.reverify.success": {
+    "text": "Domain re-verification completed.",
+    "content_hash": "497a2348"
+  },
+  "web.admin.domaintoolbox.repair.title": {
+    "text": "Repair relationship",
+    "content_hash": "0053d07c"
+  },
+  "web.admin.domaintoolbox.repair.description": {
+    "text": "Fix organization-relationship inconsistencies for a domain. Preview first, then apply.",
+    "content_hash": "18ca490b"
+  },
+  "web.admin.domaintoolbox.repair.orgIdLabel": {
+    "text": "Assign organization (if orphaned)",
+    "content_hash": "f95b010a"
+  },
+  "web.admin.domaintoolbox.repair.orgIdPlaceholder": {
+    "text": "org id or extid",
+    "content_hash": "a87d634e"
+  },
+  "web.admin.domaintoolbox.repair.statusLabel": {
+    "text": "Status",
+    "content_hash": "920e413c"
+  },
+  "web.admin.domaintoolbox.repair.noIssues": {
+    "text": "No issues found — relationships are consistent.",
+    "content_hash": "e1a4c49d"
+  },
+  "web.admin.domaintoolbox.repair.applyButton": {
+    "text": "Apply repairs",
+    "content_hash": "3f92b29f"
+  },
+  "web.admin.domaintoolbox.repair.success": {
+    "text": "Repairs applied successfully.",
+    "content_hash": "24f25b9b"
+  },
+  "web.admin.domaintoolbox.repair.confirmTitle": {
+    "text": "Apply domain repairs?",
+    "content_hash": "9429998b"
+  },
+  "web.admin.domaintoolbox.repair.confirmDescription": {
+    "text": "This will modify ownership/relationship state for {domain}. Retype the domain external ID to confirm.",
+    "content_hash": "426d267b"
+  },
+  "web.admin.domaintoolbox.transfer.title": {
+    "text": "Transfer ownership",
+    "content_hash": "3667f939"
+  },
+  "web.admin.domaintoolbox.transfer.description": {
+    "text": "Reassign a domain to a different organization. Highest-blast-radius action — preview and confirm carefully.",
+    "content_hash": "d4e26e03"
+  },
+  "web.admin.domaintoolbox.transfer.toOrgLabel": {
+    "text": "Destination organization",
+    "content_hash": "4e4486eb"
+  },
+  "web.admin.domaintoolbox.transfer.fromOrgLabel": {
+    "text": "Source organization (optional)",
+    "content_hash": "3666815f"
+  },
+  "web.admin.domaintoolbox.transfer.fromOrgPlaceholder": {
+    "text": "assert current owner",
+    "content_hash": "cd9e769c"
+  },
+  "web.admin.domaintoolbox.transfer.from": {
+    "text": "From",
+    "content_hash": "21819769"
+  },
+  "web.admin.domaintoolbox.transfer.to": {
+    "text": "To",
+    "content_hash": "f4b06ef6"
+  },
+  "web.admin.domaintoolbox.transfer.orphaned": {
+    "text": "ORPHANED",
+    "content_hash": "54dc2166"
+  },
+  "web.admin.domaintoolbox.transfer.applyButton": {
+    "text": "Transfer domain",
+    "content_hash": "9517aeb9"
+  },
+  "web.admin.domaintoolbox.transfer.success": {
+    "text": "Domain transferred successfully.",
+    "content_hash": "bbca9de9"
+  },
+  "web.admin.domaintoolbox.transfer.confirmTitle": {
+    "text": "Transfer domain ownership?",
+    "content_hash": "d306a15a"
+  },
+  "web.admin.domaintoolbox.transfer.confirmDescription": {
+    "text": "This reassigns ownership of {domain} to another organization. Retype the domain external ID to confirm.",
+    "content_hash": "edefd97c"
+  }
+}

--- a/locales/content/en/admin-emailtools.json
+++ b/locales/content/en/admin-emailtools.json
@@ -1,0 +1,154 @@
+{
+  "web.admin.emailtools.title": {
+    "text": "Email & Rate-limit Tools",
+    "content_hash": "ecfc315a"
+  },
+  "web.admin.emailtools.description": {
+    "text": "Preview email templates, send a delivery test, and inspect or reset a rate limiter — the diagnostics that previously required SSH.",
+    "content_hash": "bf376c2a"
+  },
+  "web.admin.emailtools.preview.title": {
+    "text": "Template preview",
+    "content_hash": "df89bd92"
+  },
+  "web.admin.emailtools.preview.description": {
+    "text": "Render a template with its sample data. Preview has no side effects — no email is sent.",
+    "content_hash": "9b0e40f3"
+  },
+  "web.admin.emailtools.preview.templateLabel": {
+    "text": "Template",
+    "content_hash": "0575f29d"
+  },
+  "web.admin.emailtools.preview.formatLabel": {
+    "text": "Format",
+    "content_hash": "2f343666"
+  },
+  "web.admin.emailtools.preview.localeLabel": {
+    "text": "Locale",
+    "content_hash": "ca3dc612"
+  },
+  "web.admin.emailtools.preview.button": {
+    "text": "Preview",
+    "content_hash": "324b134f"
+  },
+  "web.admin.emailtools.test.title": {
+    "text": "Test send",
+    "content_hash": "5fab5d67"
+  },
+  "web.admin.emailtools.test.description": {
+    "text": "Send a plain-text diagnostic email to verify delivery connectivity. Preview it first, then confirm to send a real email.",
+    "content_hash": "4130741c"
+  },
+  "web.admin.emailtools.test.toLabel": {
+    "text": "Recipient",
+    "content_hash": "51fac985"
+  },
+  "web.admin.emailtools.test.toPlaceholder": {
+    "text": "you@example.com",
+    "content_hash": "53e6cdc3"
+  },
+  "web.admin.emailtools.test.enqueueLabel": {
+    "text": "Via worker queue",
+    "content_hash": "97897017"
+  },
+  "web.admin.emailtools.test.previewButton": {
+    "text": "Preview (no send)",
+    "content_hash": "747ced83"
+  },
+  "web.admin.emailtools.test.sendButton": {
+    "text": "Send test email",
+    "content_hash": "46ebd7db"
+  },
+  "web.admin.emailtools.test.provider": {
+    "text": "Provider",
+    "content_hash": "472590ae"
+  },
+  "web.admin.emailtools.test.host": {
+    "text": "Host",
+    "content_hash": "4a823118"
+  },
+  "web.admin.emailtools.test.from": {
+    "text": "From",
+    "content_hash": "21819769"
+  },
+  "web.admin.emailtools.test.subject": {
+    "text": "Subject",
+    "content_hash": "68971283"
+  },
+  "web.admin.emailtools.test.confirmTitle": {
+    "text": "Send a real test email?",
+    "content_hash": "64a16b62"
+  },
+  "web.admin.emailtools.test.confirmDescription": {
+    "text": "This dispatches a live email to {to} through the configured mailer.",
+    "content_hash": "10114929"
+  },
+  "web.admin.emailtools.test.success": {
+    "text": "Test email sent to {to}.",
+    "content_hash": "daa61a62"
+  },
+  "web.admin.emailtools.ratelimit.title": {
+    "text": "Rate-limit inspector",
+    "content_hash": "1ebff494"
+  },
+  "web.admin.emailtools.ratelimit.description": {
+    "text": "Inspect a limiter's live counter state for one IP or identifier, then reset it if a legitimate user is throttled.",
+    "content_hash": "fbfab210"
+  },
+  "web.admin.emailtools.ratelimit.kindLabel": {
+    "text": "Limiter",
+    "content_hash": "d313c56e"
+  },
+  "web.admin.emailtools.ratelimit.subjectLabel": {
+    "text": "Subject",
+    "content_hash": "68971283"
+  },
+  "web.admin.emailtools.ratelimit.subjectPlaceholder": {
+    "text": "IP or identifier",
+    "content_hash": "7616a8f5"
+  },
+  "web.admin.emailtools.ratelimit.inspectButton": {
+    "text": "Inspect",
+    "content_hash": "e0723a86"
+  },
+  "web.admin.emailtools.ratelimit.columns.key": {
+    "text": "Key",
+    "content_hash": "99a52df3"
+  },
+  "web.admin.emailtools.ratelimit.columns.value": {
+    "text": "Value",
+    "content_hash": "8e37953d"
+  },
+  "web.admin.emailtools.ratelimit.columns.ttl": {
+    "text": "TTL",
+    "content_hash": "76f6014f"
+  },
+  "web.admin.emailtools.ratelimit.absent": {
+    "text": "absent",
+    "content_hash": "5ad38304"
+  },
+  "web.admin.emailtools.ratelimit.noExpiry": {
+    "text": "no expiry",
+    "content_hash": "dd848d43"
+  },
+  "web.admin.emailtools.ratelimit.noState": {
+    "text": "No active rate-limit state for this subject.",
+    "content_hash": "90cf78a7"
+  },
+  "web.admin.emailtools.ratelimit.resetButton": {
+    "text": "Reset limiter",
+    "content_hash": "6786df4e"
+  },
+  "web.admin.emailtools.ratelimit.confirmTitle": {
+    "text": "Reset this rate limiter?",
+    "content_hash": "8e2c5466"
+  },
+  "web.admin.emailtools.ratelimit.confirmDescription": {
+    "text": "This clears the throttle counters for {subject}, letting it act again immediately. Retype the subject to confirm.",
+    "content_hash": "aa6f7921"
+  },
+  "web.admin.emailtools.ratelimit.resetSuccess": {
+    "text": "Rate limiter reset.",
+    "content_hash": "ac1a46a3"
+  }
+}

--- a/locales/content/en/admin-queue.json
+++ b/locales/content/en/admin-queue.json
@@ -1,0 +1,126 @@
+{
+  "web.admin.queue.title": {
+    "text": "Dead Letter Queues",
+    "content_hash": "42579f3e"
+  },
+  "web.admin.queue.description": {
+    "text": "Inspect, replay and purge dead-lettered messages for incident response.",
+    "content_hash": "4872aa6e"
+  },
+  "web.admin.queue.columns.queue": {
+    "text": "Queue",
+    "content_hash": "3b2fe03e"
+  },
+  "web.admin.queue.columns.messages": {
+    "text": "Messages",
+    "content_hash": "04d7b483"
+  },
+  "web.admin.queue.columns.consumers": {
+    "text": "Consumers",
+    "content_hash": "212b350d"
+  },
+  "web.admin.queue.columns.actions": {
+    "text": "Actions",
+    "content_hash": "ff8059dc"
+  },
+  "web.admin.queue.list.loadError": {
+    "text": "Could not load dead-letter queues.",
+    "content_hash": "6546bf94"
+  },
+  "web.admin.queue.list.retry": {
+    "text": "Retry",
+    "content_hash": "942087cc"
+  },
+  "web.admin.queue.list.empty": {
+    "text": "No dead-letter queues found",
+    "content_hash": "69a9a990"
+  },
+  "web.admin.queue.list.disconnected": {
+    "text": "The message broker is not connected. Queue depths are unavailable.",
+    "content_hash": "1518a291"
+  },
+  "web.admin.queue.stats.total": {
+    "text": "Total Dead-Lettered",
+    "content_hash": "d14fa9b9"
+  },
+  "web.admin.queue.stats.queues": {
+    "text": "Queues",
+    "content_hash": "be77db11"
+  },
+  "web.admin.queue.search.placeholder": {
+    "text": "Filter by queue name",
+    "content_hash": "9c25ef5d"
+  },
+  "web.admin.queue.replay.button": {
+    "text": "Replay",
+    "content_hash": "c8dae637"
+  },
+  "web.admin.queue.replay.confirmTitle": {
+    "text": "Replay dead-letter queue?",
+    "content_hash": "1f62f08b"
+  },
+  "web.admin.queue.replay.confirmDescription": {
+    "text": "{count} message(s) in {queue} would be replayed back to their original queues. This can re-trigger side effects such as emails and webhooks. Proceed with the live replay?",
+    "content_hash": "0315c6ec"
+  },
+  "web.admin.queue.replay.confirmLive": {
+    "text": "Replay now",
+    "content_hash": "bda869d9"
+  },
+  "web.admin.queue.replay.success": {
+    "text": "Replayed {queue}",
+    "content_hash": "3c6b0362"
+  },
+  "web.admin.queue.purge.button": {
+    "text": "Purge",
+    "content_hash": "17c60a21"
+  },
+  "web.admin.queue.purge.confirmTitle": {
+    "text": "Purge dead-letter queue?",
+    "content_hash": "a68a53e5"
+  },
+  "web.admin.queue.purge.confirmDescription": {
+    "text": "This permanently deletes {count} message(s) from {queue}. This cannot be undone. Type the queue name to confirm.",
+    "content_hash": "1a758ad8"
+  },
+  "web.admin.queue.purge.success": {
+    "text": "Purged {queue}",
+    "content_hash": "24ce4e1a"
+  },
+  "web.admin.queue.drawer.title": {
+    "text": "DLQ: {queue}",
+    "content_hash": "69602ec1"
+  },
+  "web.admin.queue.drawer.subtitle": {
+    "text": "{showing} of {total} message(s)",
+    "content_hash": "1132b2eb"
+  },
+  "web.admin.queue.drawer.loadError": {
+    "text": "Could not load queue messages.",
+    "content_hash": "309b5fa3"
+  },
+  "web.admin.queue.drawer.retry": {
+    "text": "Retry",
+    "content_hash": "942087cc"
+  },
+  "web.admin.queue.drawer.empty": {
+    "text": "No messages in this queue",
+    "content_hash": "98065a67"
+  },
+  "web.admin.queue.message.noId": {
+    "text": "(no message id)",
+    "content_hash": "a1a04b51"
+  },
+  "web.admin.queue.message.originalQueue": {
+    "text": "Original Queue",
+    "content_hash": "c3b0c730"
+  },
+  "web.admin.queue.message.deathReason": {
+    "text": "Death Reason",
+    "content_hash": "4469db3c"
+  },
+  "web.admin.queue.nav": {
+    "text": "Dead Letter Queues",
+    "content_hash": "42579f3e"
+  }
+}

--- a/locales/content/en/admin-sessions.json
+++ b/locales/content/en/admin-sessions.json
@@ -1,0 +1,190 @@
+{
+  "web.admin.sessions.title": {
+    "text": "Sessions",
+    "content_hash": "6fa3cbf4"
+  },
+  "web.admin.sessions.description": {
+    "text": "Inspect, search and revoke active sessions for incident response.",
+    "content_hash": "784a3a44"
+  },
+  "web.admin.sessions.columns.sessionId": {
+    "text": "Session ID",
+    "content_hash": "cb9ac5c5"
+  },
+  "web.admin.sessions.columns.authenticated": {
+    "text": "Auth",
+    "content_hash": "8eb3ea9b"
+  },
+  "web.admin.sessions.columns.email": {
+    "text": "Email",
+    "content_hash": "969ccbd3"
+  },
+  "web.admin.sessions.columns.externalId": {
+    "text": "External ID",
+    "content_hash": "69da56ba"
+  },
+  "web.admin.sessions.columns.ipAddress": {
+    "text": "IP Address",
+    "content_hash": "3c3de0c9"
+  },
+  "web.admin.sessions.columns.created": {
+    "text": "Authenticated At",
+    "content_hash": "8d6c9b01"
+  },
+  "web.admin.sessions.columns.actions": {
+    "text": "Actions",
+    "content_hash": "ff8059dc"
+  },
+  "web.admin.sessions.search.placeholder": {
+    "text": "Search by email or external ID",
+    "content_hash": "f2dc5c06"
+  },
+  "web.admin.sessions.list.loadError": {
+    "text": "Could not load sessions.",
+    "content_hash": "00c678d9"
+  },
+  "web.admin.sessions.list.retry": {
+    "text": "Retry",
+    "content_hash": "942087cc"
+  },
+  "web.admin.sessions.list.empty": {
+    "text": "No active sessions found",
+    "content_hash": "e35312d6"
+  },
+  "web.admin.sessions.status.authenticated": {
+    "text": "Authenticated",
+    "content_hash": "6ab694cf"
+  },
+  "web.admin.sessions.status.anonymous": {
+    "text": "Anonymous",
+    "content_hash": "e7a8aa2d"
+  },
+  "web.admin.sessions.anonymous": {
+    "text": "Anonymous",
+    "content_hash": "e7a8aa2d"
+  },
+  "web.admin.sessions.revoke.button": {
+    "text": "Revoke",
+    "content_hash": "87e6d00b"
+  },
+  "web.admin.sessions.revoke.confirmTitle": {
+    "text": "Revoke this session?",
+    "content_hash": "0c6605c1"
+  },
+  "web.admin.sessions.revoke.confirmDescription": {
+    "text": "This logs the user out immediately by deleting session {id}. Type the session ID to confirm.",
+    "content_hash": "9e08b1b8"
+  },
+  "web.admin.sessions.revoke.success": {
+    "text": "Session revoked",
+    "content_hash": "0af5e14d"
+  },
+  "web.admin.sessions.drawer.title": {
+    "text": "Session {id}",
+    "content_hash": "29dcbd66"
+  },
+  "web.admin.sessions.drawer.notFound": {
+    "text": "Session not found",
+    "content_hash": "0969eab8"
+  },
+  "web.admin.sessions.drawer.notFoundDescription": {
+    "text": "This session no longer exists in Redis. It may have expired or already been revoked.",
+    "content_hash": "11e3ef05"
+  },
+  "web.admin.sessions.drawer.loadError": {
+    "text": "Could not load this session.",
+    "content_hash": "82ae90fb"
+  },
+  "web.admin.sessions.drawer.retry": {
+    "text": "Retry",
+    "content_hash": "942087cc"
+  },
+  "web.admin.sessions.sections.session": {
+    "text": "Session",
+    "content_hash": "6959b415"
+  },
+  "web.admin.sessions.sections.raw": {
+    "text": "Raw session data",
+    "content_hash": "c9f11eb4"
+  },
+  "web.admin.sessions.fields.sessionId": {
+    "text": "Session ID",
+    "content_hash": "cb9ac5c5"
+  },
+  "web.admin.sessions.fields.key": {
+    "text": "Redis Key",
+    "content_hash": "0b196725"
+  },
+  "web.admin.sessions.fields.ttl": {
+    "text": "TTL",
+    "content_hash": "76f6014f"
+  },
+  "web.admin.sessions.fields.authenticated": {
+    "text": "Authenticated",
+    "content_hash": "6ab694cf"
+  },
+  "web.admin.sessions.fields.email": {
+    "text": "Email",
+    "content_hash": "969ccbd3"
+  },
+  "web.admin.sessions.fields.externalId": {
+    "text": "External ID",
+    "content_hash": "69da56ba"
+  },
+  "web.admin.sessions.fields.accountId": {
+    "text": "Account ID",
+    "content_hash": "919bb4cb"
+  },
+  "web.admin.sessions.fields.role": {
+    "text": "Role",
+    "content_hash": "14736a2e"
+  },
+  "web.admin.sessions.fields.locale": {
+    "text": "Locale",
+    "content_hash": "ca3dc612"
+  },
+  "web.admin.sessions.fields.ipAddress": {
+    "text": "IP Address",
+    "content_hash": "3c3de0c9"
+  },
+  "web.admin.sessions.fields.authenticatedAt": {
+    "text": "Authenticated At",
+    "content_hash": "8d6c9b01"
+  },
+  "web.admin.sessions.fields.authenticatedBy": {
+    "text": "Authenticated By",
+    "content_hash": "3ebbabfe"
+  },
+  "web.admin.sessions.fields.activeSessionId": {
+    "text": "Active Session ID",
+    "content_hash": "f32b1158"
+  },
+  "web.admin.sessions.detail.yes": {
+    "text": "Yes",
+    "content_hash": "85a39ab3"
+  },
+  "web.admin.sessions.detail.no": {
+    "text": "No",
+    "content_hash": "1ea442a1"
+  },
+  "web.admin.sessions.detail.none": {
+    "text": "None",
+    "content_hash": "dc937b59"
+  },
+  "web.admin.sessions.detail.unknown": {
+    "text": "Unknown",
+    "content_hash": "b764cdc0"
+  },
+  "web.admin.sessions.detail.noExpiry": {
+    "text": "No expiry",
+    "content_hash": "fe06351d"
+  },
+  "web.admin.sessions.detail.expired": {
+    "text": "Expired",
+    "content_hash": "424a2551"
+  },
+  "web.admin.sessions.detail.ttlSeconds": {
+    "text": "{seconds}s remaining",
+    "content_hash": "3c9d75ce"
+  }
+}

--- a/src/apps/admin/console-sections.ts
+++ b/src/apps/admin/console-sections.ts
@@ -29,4 +29,10 @@ export const CONSOLE_SECTIONS: ConsoleSection[] = [
   { key: 'system', labelKey: 'web.colonel.titles.system', icon: 'cog-6-tooth', to: '/colonel/system' },
   { key: 'bannedIps', labelKey: 'web.colonel.titles.bannedIps', icon: 'no-symbol', to: '/colonel/banned-ips' },
   { key: 'usage', labelKey: 'web.colonel.titles.usage', icon: 'rectangle-group', to: '/colonel/usage' },
+  { key: 'sessions', labelKey: 'web.admin.sessions.title', icon: 'finger-print', to: '/colonel/sessions' },
+  { key: 'banner', labelKey: 'web.admin.banner.title', icon: 'bell', to: '/colonel/banner' },
+  { key: 'queueDlq', labelKey: 'web.admin.queue.nav', icon: 'rectangle-stack', to: '/colonel/queues/dlq' },
+  { key: 'domaintoolbox', labelKey: 'web.admin.domaintoolbox.title', icon: 'shield-exclamation', to: '/colonel/domain-toolbox' },
+  { key: 'emailTools', labelKey: 'web.admin.emailtools.title', icon: 'envelope', to: '/colonel/email-tools' },
+  { key: 'billing', labelKey: 'web.admin.billing.title', icon: 'credit-card', to: '/colonel/billing' },
 ];

--- a/src/apps/admin/routes.ts
+++ b/src/apps/admin/routes.ts
@@ -125,6 +125,73 @@ const routes: Array<RouteRecordRaw> = [
       sentryScrubParams: false,
     },
   },
+  {
+    // Sessions console: paginated list + search + inspect drawer + guarded revoke (ticket #40).
+    path: '/colonel/sessions',
+    name: 'AdminSessions',
+    component: () => import('@/apps/admin/views/AdminSessions.vue'),
+    meta: {
+      ...adminDefaultMeta,
+      title: 'web.admin.sessions.title',
+      sentryScrubParams: false,
+    },
+  },
+  {
+    // Broadcast banner: settings-style get/set/clear (ticket #41).
+    path: '/colonel/banner',
+    name: 'AdminBanner',
+    component: () => import('@/apps/admin/views/AdminBanner.vue'),
+    meta: {
+      ...adminDefaultMeta,
+      title: 'web.admin.banner.title',
+      sentryScrubParams: false,
+    },
+  },
+  {
+    // Queue DLQ console: list + peek drawer + guarded replay/purge (ticket #42).
+    path: '/colonel/queues/dlq',
+    name: 'AdminQueueDlq',
+    component: () => import('@/apps/admin/views/AdminQueueDlq.vue'),
+    meta: {
+      ...adminDefaultMeta,
+      title: 'web.admin.queue.title',
+      sentryScrubParams: false,
+    },
+  },
+  {
+    // Domain toolbox: orphaned scan + probe + guarded repair/transfer (ticket #43).
+    path: '/colonel/domain-toolbox',
+    name: 'AdminDomainToolbox',
+    component: () => import('@/apps/admin/views/AdminDomainToolbox.vue'),
+    meta: {
+      ...adminDefaultMeta,
+      title: 'web.admin.domaintoolbox.title',
+      sentryScrubParams: false,
+    },
+  },
+  {
+    // Email + rate-limit tools (ticket #44): template preview / test send /
+    // limiter inspect+reset. No route params (all inputs are in-page).
+    path: '/colonel/email-tools',
+    name: 'AdminEmailTools',
+    component: () => import('@/apps/admin/views/AdminEmailTools.vue'),
+    meta: {
+      ...adminDefaultMeta,
+      title: 'web.admin.emailtools.title',
+      sentryScrubParams: false,
+    },
+  },
+  {
+    // Billing catalog / plan-drift read-out (ticket #45). No params.
+    path: '/colonel/billing',
+    name: 'AdminBilling',
+    component: () => import('@/apps/admin/views/AdminBilling.vue'),
+    meta: {
+      ...adminDefaultMeta,
+      title: 'web.admin.billing.title',
+      sentryScrubParams: false,
+    },
+  },
 ];
 
 export default routes;

--- a/src/apps/admin/stores/useAdminDomainToolbox.ts
+++ b/src/apps/admin/stores/useAdminDomainToolbox.ts
@@ -1,0 +1,89 @@
+// src/apps/admin/stores/useAdminDomainToolbox.ts
+
+import { defineStore } from 'pinia';
+import type { z } from 'zod';
+import { ref } from 'vue';
+
+import {
+  usePaginatedFetch,
+  type PageMeta,
+} from '@/apps/admin/composables/usePaginatedFetch';
+import { colonelDomainsOrphanedResponseSchema } from '@/schemas/api/internal/responses/colonel-domaintoolbox';
+import type { ColonelOrphanedDomain } from '@/schemas/api/account/responses/colonel-domaintoolbox';
+
+type ColonelDomainsOrphanedResponse = z.infer<typeof colonelDomainsOrphanedResponseSchema>;
+
+/**
+ * Per-resource admin store for the Domain Toolbox's orphaned-domains scan
+ * (ticket #43, CONTRACT 3). Sibling of {@link useAdminSessions}: one server page
+ * per request over the NEW `GET /api/colonel/domains/orphaned` endpoint (a thin
+ * adapter over `Onetime::Operations::Domains::OrphanedScan` — bounded scan of the
+ * CustomDomain instances set, #2211, NOT a blocking KEYS).
+ *
+ * READ-ONLY: the scan mutates nothing. ZERO import edge into `src/apps/colonel/*`
+ * or `colonelInfoStore.ts` (CONTRACT 7).
+ */
+export const useAdminDomainToolbox = defineStore('adminDomainToolbox', () => {
+  /** Orphaned rows for the current page only (never accumulated). */
+  const orphaned = ref<ColonelOrphanedDomain[]>([]);
+  const pagination = ref<PageMeta | null>(null);
+
+  const pager = usePaginatedFetch<ColonelDomainsOrphanedResponse, ColonelOrphanedDomain>({
+    url: '/api/colonel/domains/orphaned',
+    schema: colonelDomainsOrphanedResponseSchema,
+    context: 'ColonelDomainsOrphanedResponse',
+    select: (data) => ({
+      items: data.details?.domains ?? [],
+      pagination: data.details?.pagination ?? null,
+    }),
+  });
+
+  /**
+   * Fetch one page of orphaned domains.
+   *
+   * @param targetPage 1-based page (defaults to the current page).
+   * @returns the page result, or null on a schema mismatch (see validationError).
+   * @throws the underlying network/HTTP error (state is cleared first).
+   */
+  async function fetchPage(
+    targetPage: number = pager.page.value
+  ): Promise<{ items: ColonelOrphanedDomain[]; pagination: PageMeta | null } | null> {
+    try {
+      const result = await pager.fetchPage(targetPage);
+      if (result) {
+        orphaned.value = result.items;
+        pagination.value = result.pagination;
+      } else {
+        orphaned.value = [];
+        pagination.value = null;
+      }
+      return result;
+    } catch (err) {
+      orphaned.value = [];
+      pagination.value = null;
+      throw err;
+    }
+  }
+
+  /** Explicit manual reset — setup stores have no built-in $reset. */
+  function $reset(): void {
+    orphaned.value = [];
+    pagination.value = null;
+    pager.reset();
+  }
+
+  return {
+    // State
+    orphaned,
+    pagination,
+    // Fetch state (owned by the shared composable)
+    loading: pager.loading,
+    error: pager.error,
+    validationError: pager.validationError,
+    page: pager.page,
+    perPage: pager.perPage,
+    // Actions
+    fetchPage,
+    $reset,
+  };
+});

--- a/src/apps/admin/stores/useAdminQueueDlq.ts
+++ b/src/apps/admin/stores/useAdminQueueDlq.ts
@@ -1,0 +1,106 @@
+// src/apps/admin/stores/useAdminQueueDlq.ts
+
+import { defineStore } from 'pinia';
+import type { z } from 'zod';
+import { ref } from 'vue';
+
+import {
+  usePaginatedFetch,
+  type PageMeta,
+} from '@/apps/admin/composables/usePaginatedFetch';
+import { colonelDlqListResponseSchema } from '@/schemas/api/internal/responses/colonel-queue';
+import type { ColonelDlqSummary } from '@/schemas/api/account/responses/colonel-queue';
+
+type ColonelDlqListResponse = z.infer<typeof colonelDlqListResponseSchema>;
+
+/**
+ * Per-resource admin store for the dead-letter-queue console (ticket #42,
+ * CONTRACT 3).
+ *
+ * Sibling of {@link useAdminSessions}: one server page per request over the NEW
+ * `GET /api/colonel/queues/dlq` endpoint (a thin adapter over
+ * `Onetime::Operations::Dlq::List`). The DLQ set is the fixed configured
+ * allowlist (bounded by construction — CONTRACT 6), so a single page normally
+ * holds every queue; pagination is kept for kit uniformity. ZERO import edge into
+ * `src/apps/colonel/*` or `colonelInfoStore.ts`.
+ */
+export const useAdminQueueDlq = defineStore('adminQueueDlq', () => {
+  /** Rows for the current page only (one server page — never accumulated). */
+  const dlqs = ref<ColonelDlqSummary[]>([]);
+  const pagination = ref<PageMeta | null>(null);
+  /** Whether the broker was reachable on the last fetch (informational banner). */
+  const connected = ref<boolean | null>(null);
+
+  const pager = usePaginatedFetch<ColonelDlqListResponse, ColonelDlqSummary>({
+    url: '/api/colonel/queues/dlq',
+    schema: colonelDlqListResponseSchema,
+    context: 'ColonelDlqListResponse',
+    select: (data) => {
+      // Side-effect: capture the broker-reachability flag off the validated
+      // response so the disconnected banner can render. `select` is the only
+      // hook that receives the full payload (fetchPage sees just items +
+      // pagination), so the flag is surfaced here rather than dropped.
+      connected.value = data.details?.connected ?? null;
+      return {
+        items: data.details?.dlqs ?? [],
+        pagination: data.details?.pagination ?? null,
+      };
+    },
+  });
+
+  /**
+   * Fetch one page of DLQ summaries.
+   *
+   * @param targetPage 1-based page (defaults to the current page).
+   * @returns the page result, or null on a schema mismatch (see validationError).
+   * @throws the underlying network/HTTP error (state is cleared first).
+   */
+  async function fetchPage(
+    targetPage: number = pager.page.value
+  ): Promise<{ items: ColonelDlqSummary[]; pagination: PageMeta | null } | null> {
+    try {
+      const result = await pager.fetchPage(targetPage);
+      if (result) {
+        dlqs.value = result.items;
+        pagination.value = result.pagination;
+      } else {
+        // Schema mismatch: degrade to empty; pager.validationError names the schema.
+        // `select` never ran, so clear the stale broker flag too.
+        dlqs.value = [];
+        pagination.value = null;
+        connected.value = null;
+      }
+      return result;
+    } catch (err) {
+      // Network/HTTP failure: clear stale rows + broker flag and rethrow.
+      dlqs.value = [];
+      pagination.value = null;
+      connected.value = null;
+      throw err;
+    }
+  }
+
+  /** Explicit manual reset — setup stores have no built-in $reset. */
+  function $reset(): void {
+    dlqs.value = [];
+    pagination.value = null;
+    connected.value = null;
+    pager.reset();
+  }
+
+  return {
+    // State
+    dlqs,
+    pagination,
+    connected,
+    // Fetch state (owned by the shared composable)
+    loading: pager.loading,
+    error: pager.error,
+    validationError: pager.validationError,
+    page: pager.page,
+    perPage: pager.perPage,
+    // Actions
+    fetchPage,
+    $reset,
+  };
+});

--- a/src/apps/admin/stores/useAdminSessions.ts
+++ b/src/apps/admin/stores/useAdminSessions.ts
@@ -1,0 +1,96 @@
+// src/apps/admin/stores/useAdminSessions.ts
+
+import { defineStore } from 'pinia';
+import type { z } from 'zod';
+import { ref } from 'vue';
+
+import {
+  usePaginatedFetch,
+  type PageMeta,
+} from '@/apps/admin/composables/usePaginatedFetch';
+import { colonelSessionsResponseSchema } from '@/schemas/api/internal/responses/colonel-sessions';
+import type { ColonelSession } from '@/schemas/api/account/responses/colonel-sessions';
+
+type ColonelSessionsResponse = z.infer<typeof colonelSessionsResponseSchema>;
+
+/**
+ * Per-resource admin store for active sessions (ticket #40, CONTRACT 3).
+ *
+ * Sibling of {@link useAdminSecrets} / {@link useAdminCustomers}: one server page
+ * per request over the NEW `GET /api/colonel/sessions` endpoint (a thin adapter
+ * over `Onetime::Operations::Sessions::List` — bounded scan, #2211). The endpoint
+ * supports an optional server-side `search` filter across session identity fields;
+ * the view drives it through {@link fetchPage}. ZERO import edge into
+ * `src/apps/colonel/*` or `colonelInfoStore.ts`.
+ */
+export const useAdminSessions = defineStore('adminSessions', () => {
+  /** Rows for the current page only (one server page — never accumulated). */
+  const sessions = ref<ColonelSession[]>([]);
+  const pagination = ref<PageMeta | null>(null);
+
+  const pager = usePaginatedFetch<ColonelSessionsResponse, ColonelSession>({
+    url: '/api/colonel/sessions',
+    schema: colonelSessionsResponseSchema,
+    context: 'ColonelSessionsResponse',
+    select: (data) => ({
+      items: data.details?.sessions ?? [],
+      pagination: data.details?.pagination ?? null,
+    }),
+  });
+
+  /**
+   * Fetch one page of sessions, optionally filtered by a free-text search term.
+   *
+   * @param targetPage 1-based page (defaults to the current page).
+   * @param search optional identity filter (email / external id).
+   * @returns the page result, or null on a schema mismatch (see validationError).
+   * @throws the underlying network/HTTP error (state is cleared first).
+   */
+  async function fetchPage(
+    targetPage: number = pager.page.value,
+    search?: string
+  ): Promise<{ items: ColonelSession[]; pagination: PageMeta | null } | null> {
+    try {
+      const result = await pager.fetchPage(
+        targetPage,
+        search ? { search } : undefined
+      );
+      if (result) {
+        sessions.value = result.items;
+        pagination.value = result.pagination;
+      } else {
+        // Schema mismatch: degrade to empty; pager.validationError names the schema.
+        sessions.value = [];
+        pagination.value = null;
+      }
+      return result;
+    } catch (err) {
+      // Network/HTTP failure: clear stale rows and rethrow for the view to handle.
+      sessions.value = [];
+      pagination.value = null;
+      throw err;
+    }
+  }
+
+  /** Explicit manual reset — setup stores have no built-in $reset. */
+  function $reset(): void {
+    sessions.value = [];
+    pagination.value = null;
+    pager.reset();
+  }
+
+  return {
+    // State
+    sessions,
+    pagination,
+    // Fetch state (owned by the shared composable)
+    loading: pager.loading,
+    error: pager.error,
+    validationError: pager.validationError,
+    page: pager.page,
+    perPage: pager.perPage,
+    // Actions
+    fetchPage,
+    $reset,
+  };
+});

--- a/src/apps/admin/views/AdminBanner.vue
+++ b/src/apps/admin/views/AdminBanner.vue
@@ -1,0 +1,401 @@
+<!-- src/apps/admin/views/AdminBanner.vue -->
+
+<script setup lang="ts">
+  import { computed, onMounted, ref } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  import { AdminConfirmDialog, StatCard } from '@/apps/admin/components/kit';
+  import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
+  import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
+  import {
+    colonelBannerResponseSchema,
+    colonelBannerSetResponseSchema,
+    colonelBannerClearResponseSchema,
+  } from '@/schemas/api/internal/responses/colonel-banner';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import { useApi } from '@/shared/composables/useApi';
+  import { useNotificationsStore } from '@/shared/stores/notificationsStore';
+  import { gracefulParse } from '@/utils/schemaValidation';
+
+  /**
+   * Broadcast Banner screen (ticket #41) — the Phase-3 "operating console" surface
+   * for a capability that until now lived ONLY on `bin/ots banner`. It is a NEW
+   * screen (there is no legacy Vue view to port), built fresh on the Slice-3
+   * template; it does NOT import `src/apps/colonel/*` or `colonelInfoStore`.
+   *
+   * A single settings-style screen (CONTRACT 1 — useResourceFetch, not a paginated
+   * store):
+   *   - GET  /api/colonel/banner → current banner (content / ttl / active)
+   *   - POST /api/colonel/banner → publish/update (guarded by a one-click confirm)
+   *   - DELETE /api/colonel/banner → clear (guarded by TYPED-confirmation — the
+   *     banner is live to every visitor, so clearing is destructive-ish, epic #41)
+   *
+   * Both mutations go through {@link useAdminMutation} + the frozen
+   * {@link AdminConfirmDialog} and are audited SERVER-SIDE by the extracted ops
+   * ({@link Onetime::Operations::SetBanner} / `ClearBanner`); nothing here logs.
+   *
+   * NOTE: the banner has no severity/level concept — the CLI stores a single HTML
+   * string, and to preserve CLI behaviour bit-for-bit this screen sets message +
+   * optional TTL only. The stored content is raw HTML; it is shown here as escaped
+   * text (never v-html) — the customer site sanitizes to <a> tags on render.
+   */
+  const { t } = useI18n();
+  const $api = useApi();
+  const notifications = useNotificationsStore();
+
+  const BANNER_URL = '/api/colonel/banner';
+
+  /** Fixed token the operator retypes to confirm a destructive clear. */
+  const CLEAR_CONFIRM_TOKEN = 'clear';
+
+  // ---- Current banner (read) ------------------------------------------------
+
+  const {
+    data: bannerData,
+    loading,
+    error,
+    validationError,
+    load: loadBanner,
+  } = useResourceFetch({
+    url: BANNER_URL,
+    schema: colonelBannerResponseSchema,
+    context: 'ColonelBannerResponse',
+  });
+
+  const banner = computed(() => bannerData.value?.record ?? null);
+  const isActive = computed(() => banner.value?.active ?? false);
+  const currentContent = computed(() => banner.value?.content ?? '');
+  const currentTtl = computed(() => banner.value?.ttl ?? null);
+  const loadFailed = computed(() => error.value !== null || validationError.value !== null);
+
+  function reloadBanner(): void {
+    loadBanner().catch(() => {});
+  }
+
+  /** Human-readable TTL, mirroring the CLI's `humanize_seconds`. */
+  function humanizeTtl(seconds: number): string {
+    if (seconds >= 86400) return `${Math.floor(seconds / 86400)}d ${Math.floor((seconds % 86400) / 3600)}h`;
+    if (seconds >= 3600) return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
+    if (seconds >= 60) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+    return `${seconds}s`;
+  }
+
+  const ttlLabel = computed(() =>
+    currentTtl.value === null
+      ? t('web.admin.banner.current.persistent')
+      : t('web.admin.banner.current.expiresIn', { duration: humanizeTtl(currentTtl.value) })
+  );
+
+  // ---- Set form -------------------------------------------------------------
+
+  const formContent = ref('');
+  const formTtl = ref('');
+
+  /** Hard cap mirroring the backend SetBanner MAX_CONTENT_LENGTH. */
+  const MAX_CONTENT_LENGTH = 2000;
+  const contentTooLong = computed(() => formContent.value.length > MAX_CONTENT_LENGTH);
+  const canPublish = computed(() => formContent.value.trim().length > 0 && !contentTooLong.value);
+
+  /** Prefill the form from the live banner so an operator can tweak-then-publish. */
+  function editCurrent(): void {
+    formContent.value = currentContent.value;
+    formTtl.value = currentTtl.value === null ? '' : String(currentTtl.value);
+  }
+
+  // ---- Guarded mutations (D4) ----------------------------------------------
+
+  type ActionKey = 'set' | 'clear';
+
+  const dialogOpen = ref(false);
+  const activeAction = ref<ActionKey | null>(null);
+
+  const {
+    loading: mutationLoading,
+    error: mutationError,
+    run: runMutation,
+    reset: resetMutation,
+  } = useAdminMutation(async () => {
+    if (activeAction.value === 'set') {
+      const ttlNum = Number.parseInt(formTtl.value, 10);
+      const response = await $api.post(BANNER_URL, {
+        content: formContent.value,
+        ttl: Number.isFinite(ttlNum) && ttlNum > 0 ? ttlNum : undefined,
+      });
+      gracefulParse(colonelBannerSetResponseSchema, response.data, 'ColonelBannerSetResponse');
+    } else {
+      const response = await $api.delete(BANNER_URL);
+      gracefulParse(colonelBannerClearResponseSchema, response.data, 'ColonelBannerClearResponse');
+    }
+  });
+
+  const dialogConfig = computed(() => {
+    if (activeAction.value === 'clear') {
+      return {
+        title: t('web.admin.banner.clear.confirmTitle'),
+        description: t('web.admin.banner.clear.confirmDescription'),
+        confirmToken: CLEAR_CONFIRM_TOKEN,
+        confirmText: t('web.admin.banner.clear.button'),
+        variant: 'danger' as const,
+      };
+    }
+    return {
+      title: t('web.admin.banner.set.confirmTitle'),
+      description: t('web.admin.banner.set.confirmDescription'),
+      confirmToken: undefined,
+      confirmText: t('web.admin.banner.set.confirmButton'),
+      variant: 'default' as const,
+    };
+  });
+
+  function requestSet(): void {
+    if (!canPublish.value) return;
+    activeAction.value = 'set';
+    resetMutation();
+    dialogOpen.value = true;
+  }
+
+  function requestClear(): void {
+    activeAction.value = 'clear';
+    resetMutation();
+    dialogOpen.value = true;
+  }
+
+  async function onConfirm(): Promise<void> {
+    const action = activeAction.value;
+    if (!action) return;
+
+    const ok = await runMutation();
+    if (!ok) return; // Failure message stays in the dialog for retry/cancel.
+
+    dialogOpen.value = false;
+
+    if (action === 'set') {
+      notifications.show(t('web.admin.banner.set.success'), 'success');
+    } else {
+      notifications.show(t('web.admin.banner.clear.success'), 'success');
+      // The live banner is gone; drop the form so it can't be re-published blindly.
+      formContent.value = '';
+      formTtl.value = '';
+    }
+
+    activeAction.value = null;
+    reloadBanner();
+  }
+
+  function onCancel(): void {
+    dialogOpen.value = false;
+    activeAction.value = null;
+    resetMutation();
+  }
+
+  onMounted(reloadBanner);
+</script>
+
+<template>
+  <div class="mx-auto max-w-3xl">
+    <!-- Page header -->
+    <div class="mb-6">
+      <h2 class="font-brand text-2xl font-semibold text-gray-900 dark:text-white">
+        {{ t('web.admin.banner.title') }}
+      </h2>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.banner.description') }}
+      </p>
+    </div>
+
+    <!-- Load error banner -->
+    <div
+      v-if="loadFailed"
+      class="mb-4 flex items-center justify-between gap-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-900/20"
+      role="alert"
+      data-testid="banner-error">
+      <span class="text-sm text-red-800 dark:text-red-200">
+        {{ t('web.admin.banner.loadError') }}
+      </span>
+      <button
+        type="button"
+        class="inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/40"
+        @click="reloadBanner">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          size="4" />
+        {{ t('web.admin.banner.retry') }}
+      </button>
+    </div>
+
+    <!-- ================= Current banner ================= -->
+    <section
+      class="mb-8"
+      data-testid="banner-current">
+      <h3 class="mb-3 text-lg font-medium text-gray-900 dark:text-white">
+        {{ t('web.admin.banner.current.title') }}
+      </h3>
+
+      <!-- Loading -->
+      <div
+        v-if="loading && !banner"
+        class="flex items-center gap-3 rounded-lg border border-gray-200 bg-white px-4 py-8 text-sm text-gray-500 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-400"
+        data-testid="banner-loading">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          size="5"
+          class="animate-spin motion-reduce:animate-none" />
+        {{ t('web.COMMON.loading') }}
+      </div>
+
+      <!-- Active banner -->
+      <div
+        v-else-if="isActive"
+        class="space-y-4"
+        data-testid="banner-active">
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <StatCard
+            :label="t('web.admin.banner.current.status')"
+            :value="t('web.admin.banner.current.live')"
+            icon="bell"
+            testid="stat-status" />
+          <StatCard
+            :label="t('web.admin.banner.current.expiry')"
+            :value="ttlLabel"
+            icon="clock"
+            testid="stat-expiry" />
+        </div>
+
+        <!-- Stored content, shown as ESCAPED text (never v-html). -->
+        <div
+          class="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <h4 class="mb-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.banner.current.storedContent') }}
+          </h4>
+          <pre
+            data-testid="banner-content"
+            class="max-h-48 overflow-auto whitespace-pre-wrap break-words rounded bg-gray-50 p-3 font-mono text-sm text-gray-900 dark:bg-gray-800 dark:text-gray-100">{{ currentContent }}</pre>
+          <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.banner.current.htmlNote') }}
+          </p>
+        </div>
+
+        <!-- Actions on the live banner -->
+        <div class="flex flex-wrap gap-3">
+          <button
+            type="button"
+            data-testid="banner-edit"
+            class="inline-flex items-center gap-1 rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
+            @click="editCurrent">
+            <OIcon
+              collection="heroicons"
+              name="pencil-square"
+              size="4" />
+            {{ t('web.admin.banner.current.edit') }}
+          </button>
+          <button
+            type="button"
+            data-testid="banner-clear"
+            class="inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-2 text-sm font-semibold text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-900/30"
+            @click="requestClear">
+            <OIcon
+              collection="heroicons"
+              name="trash"
+              size="4" />
+            {{ t('web.admin.banner.clear.button') }}
+          </button>
+        </div>
+      </div>
+
+      <!-- No banner -->
+      <div
+        v-else
+        class="rounded-lg border border-dashed border-gray-300 bg-white px-4 py-8 text-center text-sm text-gray-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-400"
+        data-testid="banner-empty">
+        {{ t('web.admin.banner.current.none') }}
+      </div>
+    </section>
+
+    <!-- ================= Set / update form ================= -->
+    <section data-testid="banner-form">
+      <h3 class="mb-3 text-lg font-medium text-gray-900 dark:text-white">
+        {{ isActive ? t('web.admin.banner.set.updateTitle') : t('web.admin.banner.set.title') }}
+      </h3>
+
+      <div
+        class="space-y-4 rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+        <div>
+          <label
+            for="banner-content-input"
+            class="mb-1 block text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.banner.set.contentLabel') }}
+          </label>
+          <textarea
+            id="banner-content-input"
+            v-model="formContent"
+            data-testid="banner-content-input"
+            rows="4"
+            spellcheck="false"
+            :placeholder="t('web.admin.banner.set.contentPlaceholder')"
+            class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 font-mono text-sm text-gray-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"></textarea>
+          <div class="mt-1 flex items-center justify-between">
+            <p class="text-xs text-gray-500 dark:text-gray-400">
+              {{ t('web.admin.banner.set.contentHelp') }}
+            </p>
+            <span
+              class="text-xs"
+              :class="contentTooLong ? 'text-red-600 dark:text-red-400' : 'text-gray-400 dark:text-gray-500'"
+              data-testid="banner-charcount">
+              {{ formContent.length }} / {{ MAX_CONTENT_LENGTH }}
+            </span>
+          </div>
+        </div>
+
+        <div class="sm:w-1/2">
+          <label
+            for="banner-ttl-input"
+            class="mb-1 block text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.banner.set.ttlLabel') }}
+          </label>
+          <input
+            id="banner-ttl-input"
+            v-model="formTtl"
+            type="number"
+            min="0"
+            inputmode="numeric"
+            data-testid="banner-ttl-input"
+            :placeholder="t('web.admin.banner.set.ttlPlaceholder')"
+            class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.banner.set.ttlHelp') }}
+          </p>
+        </div>
+
+        <div class="flex justify-end">
+          <button
+            type="button"
+            data-testid="banner-publish"
+            :disabled="!canPublish"
+            class="inline-flex items-center gap-1 rounded-md bg-brand-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-brand-500 dark:hover:bg-brand-600"
+            @click="requestSet">
+            <OIcon
+              collection="heroicons"
+              name="bell"
+              size="4" />
+            {{ isActive ? t('web.admin.banner.set.updateButton') : t('web.admin.banner.set.publishButton') }}
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Shared guarded-action dialog: one-click for set, typed-confirm for clear. -->
+    <AdminConfirmDialog
+      v-model:open="dialogOpen"
+      :title="dialogConfig.title"
+      :description="dialogConfig.description"
+      :confirm-token="dialogConfig.confirmToken"
+      :variant="dialogConfig.variant"
+      :confirm-text="dialogConfig.confirmText"
+      :loading="mutationLoading"
+      :error="mutationError"
+      @confirm="onConfirm"
+      @cancel="onCancel" />
+  </div>
+</template>

--- a/src/apps/admin/views/AdminBilling.vue
+++ b/src/apps/admin/views/AdminBilling.vue
@@ -1,0 +1,360 @@
+<!-- src/apps/admin/views/AdminBilling.vue -->
+
+<script setup lang="ts">
+  import { computed, onMounted, ref } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  import { DataTable, DetailDrawer, JsonViewer, StatCard } from '@/apps/admin/components/kit';
+  import type { DataTableColumn } from '@/apps/admin/components/kit';
+  import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
+  import type {
+    ColonelBillingPlan,
+    ColonelBillingDriftChange,
+  } from '@/schemas/api/account/responses/colonel-billing';
+  import { colonelBillingCatalogResponseSchema } from '@/schemas/api/internal/responses/colonel-billing';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+
+  /**
+   * Billing catalog drift view (ticket #45, Phase 3) — the LAST Phase-3 item and
+   * deliberately READ-ONLY to start. Built fresh on the Slice-3 template; it does
+   * NOT import `src/apps/colonel/*` or `colonelInfoStore`.
+   *
+   * A single schema-aware GET via {@link useResourceFetch} (CONTRACT 1 — single
+   * read screens use useResourceFetch, not a paginated store) over the new
+   * read-only colonel endpoint:
+   *
+   *   GET /api/colonel/billing/catalog → GetBillingCatalog
+   *
+   * The endpoint returns BOTH the configured catalog (billing.yaml) and the live
+   * plans (Stripe-synced cache) plus a computed drift summary, so the operator
+   * can see "config says X, live says Y" at a glance — that is the whole value.
+   *
+   * Read-only: nothing here mutates, so nothing is audited (CONTRACT 4). Catalog
+   * sync stays CLI-only until this view is trusted (spec).
+   */
+  const { t } = useI18n();
+
+  const { data, loading, error, validationError, load } = useResourceFetch({
+    url: '/api/colonel/billing/catalog',
+    schema: colonelBillingCatalogResponseSchema,
+    context: 'ColonelBillingCatalogResponse',
+  });
+
+  const details = computed(() => data.value?.details ?? null);
+  const failed = computed(() => error.value !== null || validationError.value !== null);
+
+  const isLocalConfig = computed(() => details.value?.source === 'local_config');
+  const drift = computed(() => details.value?.drift ?? null);
+
+  // Index both sides by planid so a per-plan row can pull either version.
+  const configById = computed(() => indexByPlanid(details.value?.config_plans ?? []));
+  const liveById = computed(() => indexByPlanid(details.value?.live_plans ?? []));
+
+  function indexByPlanid(plans: ColonelBillingPlan[]): Record<string, ColonelBillingPlan> {
+    return plans.reduce<Record<string, ColonelBillingPlan>>((acc, plan) => {
+      acc[plan.planid] = plan;
+      return acc;
+    }, {});
+  }
+
+  const changedById = computed<Record<string, ColonelBillingDriftChange>>(() =>
+    (drift.value?.changed ?? []).reduce<Record<string, ColonelBillingDriftChange>>((acc, c) => {
+      acc[c.planid] = c;
+      return acc;
+    }, {})
+  );
+
+  /** The kind of drift a plan row has, driving its status badge. */
+  type PlanStatus = 'in_sync' | 'only_config' | 'only_live' | 'changed';
+
+  interface PlanRow {
+    planid: string;
+    name: string;
+    tier: string;
+    status: PlanStatus;
+    fields: string[];
+  }
+
+  /** Union of both sides, keyed by planid, sorted for a stable table. */
+  const planRows = computed<PlanRow[]>(() => {
+    if (!details.value) return [];
+    const ids = new Set<string>([
+      ...details.value.config_plans.map((p) => p.planid),
+      ...details.value.live_plans.map((p) => p.planid),
+    ]);
+
+    return [...ids].sort().map((planid) => {
+      const cfg = configById.value[planid];
+      const live = liveById.value[planid];
+      const changed = changedById.value[planid];
+
+      let status: PlanStatus;
+      if (cfg && !live) status = 'only_config';
+      else if (!cfg && live) status = 'only_live';
+      else if (changed) status = 'changed';
+      else status = 'in_sync';
+
+      const source = cfg ?? live;
+      return {
+        planid,
+        name: source?.name ?? '—',
+        tier: source?.tier ?? '—',
+        status,
+        fields: changed?.fields ?? [],
+      };
+    });
+  });
+
+  const columns = computed<DataTableColumn<PlanRow>[]>(() => [
+    { key: 'planid', label: t('web.admin.billing.columns.planid') },
+    { key: 'name', label: t('web.admin.billing.columns.name') },
+    { key: 'tier', label: t('web.admin.billing.columns.tier') },
+    { key: 'status', label: t('web.admin.billing.columns.status') },
+    { key: 'actions', label: '', align: 'right' },
+  ]);
+
+  function statusBadgeClass(status: PlanStatus): string {
+    switch (status) {
+      case 'in_sync':
+        return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200';
+      case 'changed':
+        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200';
+      case 'only_config':
+        return 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200';
+      case 'only_live':
+        return 'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-200';
+      default:
+        return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300';
+    }
+  }
+
+  // ---- Side-by-side diff drawer --------------------------------------------
+
+  const selectedPlanid = ref<string | null>(null);
+  const drawerOpen = ref(false);
+
+  const selectedConfig = computed(() =>
+    selectedPlanid.value ? (configById.value[selectedPlanid.value] ?? null) : null
+  );
+  const selectedLive = computed(() =>
+    selectedPlanid.value ? (liveById.value[selectedPlanid.value] ?? null) : null
+  );
+
+  function openDiff(planid: string): void {
+    selectedPlanid.value = planid;
+    drawerOpen.value = true;
+  }
+
+  onMounted(() => {
+    load().catch(() => {});
+  });
+</script>
+
+<template>
+  <div class="mx-auto max-w-6xl">
+    <!-- Page header -->
+    <div class="mb-6">
+      <h2 class="font-brand text-2xl font-semibold text-gray-900 dark:text-white">
+        {{ t('web.admin.billing.title') }}
+      </h2>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.billing.description') }}
+      </p>
+    </div>
+
+    <!-- Loading -->
+    <div
+      v-if="loading && !details"
+      class="flex items-center gap-3 rounded-lg border border-gray-200 bg-white px-4 py-8 text-sm text-gray-500 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-400"
+      data-testid="billing-loading">
+      <OIcon
+        collection="heroicons"
+        name="arrow-path"
+        size="5"
+        class="animate-spin motion-reduce:animate-none" />
+      {{ t('web.COMMON.loading') }}
+    </div>
+
+    <!-- Error -->
+    <div
+      v-else-if="failed"
+      class="flex items-center justify-between gap-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-900/20"
+      role="alert"
+      data-testid="billing-error">
+      <span class="text-sm text-red-800 dark:text-red-200">
+        {{ t('web.admin.billing.loadError') }}
+      </span>
+      <button
+        type="button"
+        class="inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/40"
+        @click="load().catch(() => {})">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          size="4" />
+        {{ t('web.admin.billing.retry') }}
+      </button>
+    </div>
+
+    <!-- Loaded -->
+    <div
+      v-else-if="details"
+      class="space-y-6">
+      <!-- local_config warning: drift cannot be evaluated without Stripe. -->
+      <div
+        v-if="isLocalConfig"
+        class="flex items-start gap-2 rounded-md border border-yellow-200 bg-yellow-50 px-4 py-3 dark:border-yellow-900/50 dark:bg-yellow-900/20"
+        role="status"
+        data-testid="billing-local-config-warning">
+        <OIcon
+          collection="heroicons"
+          name="exclamation-triangle"
+          size="5"
+          class="mt-0.5 shrink-0 text-yellow-600 dark:text-yellow-400" />
+        <span class="text-sm text-yellow-800 dark:text-yellow-200">
+          {{ t('web.admin.billing.localConfigWarning') }}
+        </span>
+      </div>
+
+      <!-- Summary tiles -->
+      <div class="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <StatCard
+          :label="t('web.admin.billing.stats.configured')"
+          :value="details.config_plans.length"
+          icon="document-text"
+          testid="stat-configured" />
+        <StatCard
+          :label="t('web.admin.billing.stats.live')"
+          :value="details.live_plans.length"
+          icon="rectangle-stack"
+          testid="stat-live" />
+        <StatCard
+          :label="t('web.admin.billing.stats.source')"
+          :value="isLocalConfig
+            ? t('web.admin.billing.source.localConfig')
+            : t('web.admin.billing.source.stripe')"
+          icon="signal"
+          testid="stat-source" />
+        <StatCard
+          :label="t('web.admin.billing.stats.drift')"
+          :value="drift?.in_sync
+            ? t('web.admin.billing.inSync')
+            : t('web.admin.billing.driftCount', {
+              count: (drift?.only_in_config.length ?? 0)
+                + (drift?.only_in_live.length ?? 0)
+                + (drift?.changed.length ?? 0),
+            })"
+          icon="rectangle-group"
+          testid="stat-drift" />
+      </div>
+
+      <!-- Drift banner: in-sync vs differences present -->
+      <div
+        v-if="drift?.in_sync"
+        class="flex items-center gap-2 rounded-md border border-green-200 bg-green-50 px-4 py-3 dark:border-green-900/50 dark:bg-green-900/20"
+        data-testid="billing-in-sync">
+        <OIcon
+          collection="heroicons"
+          name="check-circle"
+          size="5"
+          class="text-green-600 dark:text-green-400" />
+        <span class="text-sm text-green-800 dark:text-green-200">
+          {{ t('web.admin.billing.inSyncDetail') }}
+        </span>
+      </div>
+
+      <!-- Plan catalog table (union of config + live, keyed by planid) -->
+      <section data-testid="billing-plans">
+        <h3 class="mb-3 text-lg font-medium text-gray-900 dark:text-white">
+          {{ t('web.admin.billing.plans.title') }}
+        </h3>
+        <div
+          class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <DataTable
+            :columns="columns"
+            :rows="planRows"
+            row-key="planid"
+            :empty-text="t('web.admin.billing.plans.empty')"
+            testid="billing-plans-table">
+            <template #cell-planid="{ row }">
+              <span class="font-mono text-sm text-gray-900 dark:text-white">{{ row.planid }}</span>
+            </template>
+            <template #cell-status="{ row }">
+              <span
+                class="inline-flex items-center rounded px-2 py-0.5 text-xs font-medium"
+                :class="statusBadgeClass(row.status)">
+                {{ t(`web.admin.billing.status.${row.status}`) }}
+              </span>
+              <span
+                v-if="row.fields.length"
+                class="ml-2 font-mono text-xs text-gray-500 dark:text-gray-400">
+                {{ row.fields.join(', ') }}
+              </span>
+            </template>
+            <template #cell-actions="{ row }">
+              <button
+                type="button"
+                class="inline-flex items-center gap-1 rounded-md border border-gray-300 px-2.5 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
+                :data-testid="`billing-diff-${row.planid}`"
+                @click="openDiff(row.planid)">
+                <OIcon
+                  collection="heroicons"
+                  name="rectangle-group"
+                  size="3" />
+                {{ t('web.admin.billing.plans.viewDiff') }}
+              </button>
+            </template>
+          </DataTable>
+        </div>
+      </section>
+    </div>
+
+    <!-- Side-by-side config vs live diff -->
+    <DetailDrawer
+      v-model:open="drawerOpen"
+      :title="t('web.admin.billing.diff.title', { planid: selectedPlanid ?? '' })"
+      :subtitle="t('web.admin.billing.diff.subtitle')"
+      testid="billing-diff-drawer">
+      <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <div>
+          <h4 class="mb-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.billing.diff.config') }}
+          </h4>
+          <div
+            v-if="selectedConfig"
+            class="rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-800 dark:bg-gray-900">
+            <JsonViewer
+              :data="selectedConfig"
+              :expand-depth="2"
+              testid="billing-diff-config-json" />
+          </div>
+          <p
+            v-else
+            class="rounded-lg border border-dashed border-gray-300 px-3 py-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400"
+            data-testid="billing-diff-config-absent">
+            {{ t('web.admin.billing.diff.absentConfig') }}
+          </p>
+        </div>
+        <div>
+          <h4 class="mb-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.billing.diff.live') }}
+          </h4>
+          <div
+            v-if="selectedLive"
+            class="rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-800 dark:bg-gray-900">
+            <JsonViewer
+              :data="selectedLive"
+              :expand-depth="2"
+              testid="billing-diff-live-json" />
+          </div>
+          <p
+            v-else
+            class="rounded-lg border border-dashed border-gray-300 px-3 py-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400"
+            data-testid="billing-diff-live-absent">
+            {{ t('web.admin.billing.diff.absentLive') }}
+          </p>
+        </div>
+      </div>
+    </DetailDrawer>
+  </div>
+</template>

--- a/src/apps/admin/views/AdminDomainToolbox.vue
+++ b/src/apps/admin/views/AdminDomainToolbox.vue
@@ -1,0 +1,743 @@
+<!-- src/apps/admin/views/AdminDomainToolbox.vue -->
+
+<script setup lang="ts">
+  import { storeToRefs } from 'pinia';
+  import { computed, onMounted, ref } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  import {
+    AdminConfirmDialog,
+    DataTable,
+    JsonViewer,
+    KitPagination,
+  } from '@/apps/admin/components/kit';
+  import type { DataTableColumn } from '@/apps/admin/components/kit';
+  import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
+  import { useAdminDomainToolbox } from '@/apps/admin/stores/useAdminDomainToolbox';
+  import type { ColonelOrphanedDomain } from '@/schemas/api/account/responses/colonel-domaintoolbox';
+  import type {
+    ColonelDomainProbeDetails,
+    ColonelDomainRepairDetails,
+    ColonelDomainTransferDetails,
+  } from '@/schemas/api/account/responses/colonel-domaintoolbox';
+  import {
+    colonelDomainProbeResponseSchema,
+    colonelDomainRepairResponseSchema,
+    colonelDomainTransferResponseSchema,
+  } from '@/schemas/api/internal/responses/colonel-domaintoolbox';
+  import { colonelDomainVerifyResponseSchema } from '@/schemas/api/internal/responses/colonel-domains';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import { useApi } from '@/shared/composables/useApi';
+  import { useNotificationsStore } from '@/shared/stores/notificationsStore';
+  import { formatDisplayDateTime } from '@/utils/format';
+  import { gracefulParse } from '@/utils/schemaValidation';
+
+  /**
+   * Domain Toolbox (ticket #43) — the Phase-3 payoff that surfaces the CLI-only
+   * domain toolbox (`bin/ots domains {orphaned,probe,repair,transfer}`) in the
+   * browser, built fresh on the Slice-3 template (no `src/apps/colonel/*` /
+   * `colonelInfoStore`). Distinct `domaintoolbox` namespace — does NOT touch
+   * Slice-4's AdminDomains.vue.
+   *
+   * - ORPHANED SCAN (read-only): DataTable + KitPagination over {@link
+   *   useAdminDomainToolbox} (`GET /api/colonel/domains/orphaned`, a bounded scan).
+   *   Each row seeds the repair form.
+   * - PROBE (read-only): `GET /api/colonel/domains/:extid/probe` — HTTPS + TLS
+   *   diagnostics with an honest health classification.
+   * - RE-VERIFY (reuse): reuses the Slice-4 `/api/colonel/domains/:extid/verify`
+   *   endpoint + op — NOT duplicated.
+   * - REPAIR + TRANSFER (guarded, D4): dry-run PREVIEW first, then APPLY behind an
+   *   {@link AdminConfirmDialog} typed-confirmation (retype the domain extid). The
+   *   mutations are audited SERVER-SIDE by the ops (CONTRACT 4).
+   */
+  const { t } = useI18n();
+  const $api = useApi();
+  const notifications = useNotificationsStore();
+
+  // ---- Orphaned scan (read-only list) ---------------------------------------
+
+  const store = useAdminDomainToolbox();
+  const { orphaned, pagination, loading, error } = storeToRefs(store);
+
+  const orphanColumns = computed<DataTableColumn<ColonelOrphanedDomain>[]>(() => [
+    { key: 'display_domain', label: t('web.admin.domaintoolbox.orphaned.columns.domain') },
+    { key: 'verification_state', label: t('web.admin.domaintoolbox.orphaned.columns.state') },
+    { key: 'verified', label: t('web.admin.domaintoolbox.orphaned.columns.verified'), align: 'center' },
+    { key: 'created', label: t('web.admin.domaintoolbox.orphaned.columns.created') },
+    { key: 'actions', label: t('web.admin.domaintoolbox.orphaned.columns.actions'), align: 'right' },
+  ]);
+
+  async function fetchOrphaned(targetPage = 1): Promise<void> {
+    try {
+      await store.fetchPage(targetPage);
+    } catch {
+      // Failure captured in store.error; the banner + retry handle it.
+    }
+  }
+
+  function onOrphanPageChange(targetPage: number): void {
+    fetchOrphaned(targetPage);
+  }
+
+  function onOrphanPerPageChange(perPage: number): void {
+    store.perPage = perPage;
+    fetchOrphaned(1);
+  }
+
+  // ---- Diagnostics: probe + re-verify ---------------------------------------
+
+  const probeExtid = ref('');
+  const probeRecordDomain = ref('');
+  const probeDetails = ref<ColonelDomainProbeDetails | null>(null);
+
+  const {
+    loading: probeLoading,
+    error: probeError,
+    run: runProbe,
+    reset: resetProbe,
+  } = useAdminMutation(async (extid: string) => {
+    probeDetails.value = null;
+    const response = await $api.get(
+      `/api/colonel/domains/${encodeURIComponent(extid)}/probe`
+    );
+    const parsed = gracefulParse(
+      colonelDomainProbeResponseSchema,
+      response.data,
+      'ColonelDomainProbeResponse'
+    );
+    if (parsed.ok) {
+      probeDetails.value = parsed.data.details ?? null;
+      probeRecordDomain.value = parsed.data.record?.display_domain ?? extid;
+    }
+  });
+
+  async function onProbe(): Promise<void> {
+    const extid = probeExtid.value.trim();
+    if (!extid) return;
+    resetProbe();
+    await runProbe(extid);
+  }
+
+  /** Health badge colour keyed by the op's classification. */
+  function healthBadgeClass(health: string): string {
+    switch (health) {
+      case 'healthy':
+        return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
+      case 'ssl_expiring_soon':
+      case 'http_error':
+        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200';
+      default:
+        return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200';
+    }
+  }
+
+  // Re-verify REUSES the Slice-4 endpoint + op (no duplication).
+  const {
+    loading: verifyLoading,
+    error: verifyError,
+    run: runVerify,
+    reset: resetVerify,
+  } = useAdminMutation(async (extid: string) => {
+    const response = await $api.post(
+      `/api/colonel/domains/${encodeURIComponent(extid)}/verify`
+    );
+    gracefulParse(
+      colonelDomainVerifyResponseSchema,
+      response.data,
+      'ColonelDomainVerifyResponse'
+    );
+  });
+
+  async function onReverify(): Promise<void> {
+    const extid = probeExtid.value.trim();
+    if (!extid) return;
+    resetVerify();
+    const ok = await runVerify(extid);
+    if (ok) {
+      notifications.show(t('web.admin.domaintoolbox.reverify.success'), 'success');
+      fetchOrphaned(pagination.value?.page ?? 1);
+    }
+  }
+
+  // ---- Repair (guarded: dry-run preview → typed-confirm apply) ---------------
+
+  const repairExtid = ref('');
+  const repairOrgId = ref('');
+  const repairPlan = ref<ColonelDomainRepairDetails | null>(null);
+  const repairDialogOpen = ref(false);
+
+  /** Build the repair request body; org_id only when supplied. */
+  function repairBody(dryRun: boolean): Record<string, unknown> {
+    const body: Record<string, unknown> = { dry_run: dryRun };
+    const org = repairOrgId.value.trim();
+    if (org) body.org_id = org;
+    return body;
+  }
+
+  const {
+    loading: repairPreviewLoading,
+    error: repairPreviewError,
+    run: runRepairPreview,
+    reset: resetRepairPreview,
+  } = useAdminMutation(async (extid: string) => {
+    repairPlan.value = null;
+    const response = await $api.post(
+      `/api/colonel/domains/${encodeURIComponent(extid)}/repair`,
+      repairBody(true)
+    );
+    const parsed = gracefulParse(
+      colonelDomainRepairResponseSchema,
+      response.data,
+      'ColonelDomainRepairResponse'
+    );
+    if (parsed.ok) repairPlan.value = parsed.data.details ?? null;
+  });
+
+  const {
+    loading: repairApplyLoading,
+    error: repairApplyError,
+    run: runRepairApply,
+    reset: resetRepairApply,
+  } = useAdminMutation(async (extid: string) => {
+    const response = await $api.post(
+      `/api/colonel/domains/${encodeURIComponent(extid)}/repair`,
+      repairBody(false)
+    );
+    gracefulParse(
+      colonelDomainRepairResponseSchema,
+      response.data,
+      'ColonelDomainRepairResponse'
+    );
+  });
+
+  async function onRepairPreview(): Promise<void> {
+    const extid = repairExtid.value.trim();
+    if (!extid) return;
+    resetRepairPreview();
+    await runRepairPreview(extid);
+  }
+
+  /** True when the previewed plan actually has repairs to apply. */
+  const repairApplicable = computed(
+    () => repairPlan.value?.status === 'planned' && (repairPlan.value?.issues.length ?? 0) > 0
+  );
+
+  function requestRepairApply(): void {
+    resetRepairApply();
+    repairDialogOpen.value = true;
+  }
+
+  async function onRepairConfirm(): Promise<void> {
+    const extid = repairExtid.value.trim();
+    const ok = await runRepairApply(extid);
+    if (!ok) return;
+    repairDialogOpen.value = false;
+    notifications.show(t('web.admin.domaintoolbox.repair.success'), 'success');
+    repairPlan.value = null;
+    fetchOrphaned(pagination.value?.page ?? 1);
+  }
+
+  function onRepairCancel(): void {
+    repairDialogOpen.value = false;
+    resetRepairApply();
+  }
+
+  /** Row action: seed the repair form from an orphaned row. */
+  function seedRepair(row: ColonelOrphanedDomain): void {
+    repairExtid.value = row.extid;
+    repairOrgId.value = '';
+    repairPlan.value = null;
+    resetRepairPreview();
+    probeExtid.value = row.extid;
+  }
+
+  // ---- Transfer (guarded: dry-run preview → typed-confirm apply) -------------
+
+  const transferExtid = ref('');
+  const transferToOrg = ref('');
+  const transferFromOrg = ref('');
+  const transferPlan = ref<ColonelDomainTransferDetails | null>(null);
+  const transferDialogOpen = ref(false);
+
+  function transferBody(dryRun: boolean): Record<string, unknown> {
+    const body: Record<string, unknown> = {
+      dry_run: dryRun,
+      to_org: transferToOrg.value.trim(),
+    };
+    const from = transferFromOrg.value.trim();
+    if (from) body.from_org = from;
+    return body;
+  }
+
+  const {
+    loading: transferPreviewLoading,
+    error: transferPreviewError,
+    run: runTransferPreview,
+    reset: resetTransferPreview,
+  } = useAdminMutation(async (extid: string) => {
+    transferPlan.value = null;
+    const response = await $api.post(
+      `/api/colonel/domains/${encodeURIComponent(extid)}/transfer`,
+      transferBody(true)
+    );
+    const parsed = gracefulParse(
+      colonelDomainTransferResponseSchema,
+      response.data,
+      'ColonelDomainTransferResponse'
+    );
+    if (parsed.ok) transferPlan.value = parsed.data.details ?? null;
+  });
+
+  const {
+    loading: transferApplyLoading,
+    error: transferApplyError,
+    run: runTransferApply,
+    reset: resetTransferApply,
+  } = useAdminMutation(async (extid: string) => {
+    const response = await $api.post(
+      `/api/colonel/domains/${encodeURIComponent(extid)}/transfer`,
+      transferBody(false)
+    );
+    gracefulParse(
+      colonelDomainTransferResponseSchema,
+      response.data,
+      'ColonelDomainTransferResponse'
+    );
+  });
+
+  const transferReady = computed(
+    () => transferExtid.value.trim() !== '' && transferToOrg.value.trim() !== ''
+  );
+
+  async function onTransferPreview(): Promise<void> {
+    if (!transferReady.value) return;
+    resetTransferPreview();
+    await runTransferPreview(transferExtid.value.trim());
+  }
+
+  const transferApplicable = computed(() => transferPlan.value?.status === 'planned');
+
+  function requestTransferApply(): void {
+    resetTransferApply();
+    transferDialogOpen.value = true;
+  }
+
+  async function onTransferConfirm(): Promise<void> {
+    const extid = transferExtid.value.trim();
+    const ok = await runTransferApply(extid);
+    if (!ok) return;
+    transferDialogOpen.value = false;
+    notifications.show(t('web.admin.domaintoolbox.transfer.success'), 'success');
+    transferPlan.value = null;
+    fetchOrphaned(pagination.value?.page ?? 1);
+  }
+
+  function onTransferCancel(): void {
+    transferDialogOpen.value = false;
+    resetTransferApply();
+  }
+
+  onMounted(() => fetchOrphaned(1));
+</script>
+
+<template>
+  <div class="mx-auto max-w-6xl space-y-8">
+    <!-- Page header -->
+    <div>
+      <h2 class="font-brand text-2xl font-semibold text-gray-900 dark:text-white">
+        {{ t('web.admin.domaintoolbox.title') }}
+      </h2>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.domaintoolbox.description') }}
+      </p>
+    </div>
+
+    <!-- ===== Orphaned scan (read-only) ===================================== -->
+    <section data-testid="orphaned-section">
+      <h3 class="mb-3 text-lg font-semibold text-gray-900 dark:text-white">
+        {{ t('web.admin.domaintoolbox.orphaned.title') }}
+      </h3>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.domaintoolbox.orphaned.description') }}
+      </p>
+
+      <div
+        v-if="error"
+        class="mb-4 flex items-center justify-between gap-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-900/20"
+        role="alert"
+        data-testid="orphaned-error">
+        <span class="text-sm text-red-800 dark:text-red-200">
+          {{ t('web.admin.domaintoolbox.orphaned.loadError') }}
+        </span>
+        <button
+          type="button"
+          class="inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/40"
+          @click="fetchOrphaned(1)">
+          <OIcon
+            collection="heroicons"
+            name="arrow-path"
+            size="4" />
+          {{ t('web.admin.domaintoolbox.retry') }}
+        </button>
+      </div>
+
+      <div
+        class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
+        <DataTable
+          :columns="orphanColumns"
+          :rows="orphaned"
+          row-key="domain_id"
+          :loading="loading"
+          :empty-text="t('web.admin.domaintoolbox.orphaned.empty')"
+          testid="orphaned-table">
+          <template #cell-display_domain="{ row }">
+            <span class="font-mono text-gray-900 dark:text-white">{{ row.display_domain }}</span>
+          </template>
+          <template #cell-verified="{ row }">
+            <OIcon
+              v-if="row.verified"
+              collection="heroicons"
+              name="check-circle"
+              size="5"
+              class="inline text-green-600 dark:text-green-400" />
+            <span v-else class="text-gray-400 dark:text-gray-600">—</span>
+          </template>
+          <template #cell-created="{ row }">
+            {{ row.created ? formatDisplayDateTime(row.created) : '—' }}
+          </template>
+          <template #cell-actions="{ row }">
+            <button
+              type="button"
+              :data-testid="`orphaned-repair-${row.extid}`"
+              class="text-sm font-medium text-brand-600 hover:text-brand-800 focus:outline-none focus:ring-2 focus:ring-brand-500 dark:text-brand-400 dark:hover:text-brand-300"
+              @click="seedRepair(row)">
+              {{ t('web.admin.domaintoolbox.orphaned.repairAction') }}
+            </button>
+          </template>
+        </DataTable>
+      </div>
+
+      <KitPagination
+        v-if="pagination"
+        :pagination="pagination"
+        :loading="loading"
+        class="mt-4"
+        @update:page="onOrphanPageChange"
+        @update:per-page="onOrphanPerPageChange" />
+    </section>
+
+    <!-- ===== Diagnostics: probe + re-verify (read-only / reuse) =========== -->
+    <section
+      class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+      data-testid="probe-section">
+      <h3 class="mb-3 text-lg font-semibold text-gray-900 dark:text-white">
+        {{ t('web.admin.domaintoolbox.probe.title') }}
+      </h3>
+      <p class="mb-4 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.domaintoolbox.probe.description') }}
+      </p>
+
+      <div class="flex flex-wrap items-end gap-3">
+        <div class="flex-1 min-w-[16rem]">
+          <label
+            for="probe-extid"
+            class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.domaintoolbox.fields.extid') }}
+          </label>
+          <input
+            id="probe-extid"
+            v-model="probeExtid"
+            type="text"
+            data-testid="probe-extid-input"
+            :placeholder="t('web.admin.domaintoolbox.fields.extidPlaceholder')"
+            class="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm text-gray-900 focus:border-brand-500 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+        </div>
+        <button
+          type="button"
+          data-testid="probe-run"
+          :disabled="!probeExtid.trim() || probeLoading"
+          class="inline-flex items-center gap-1 rounded-md bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-50"
+          @click="onProbe">
+          <OIcon
+            collection="heroicons"
+            :name="probeLoading ? 'arrow-path' : 'signal'"
+            size="4"
+            :class="probeLoading ? 'animate-spin motion-reduce:animate-none' : ''" />
+          {{ t('web.admin.domaintoolbox.probe.button') }}
+        </button>
+        <button
+          type="button"
+          data-testid="reverify-run"
+          :disabled="!probeExtid.trim() || verifyLoading"
+          class="inline-flex items-center gap-1 rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+          @click="onReverify">
+          <OIcon
+            collection="heroicons"
+            :name="verifyLoading ? 'arrow-path' : 'shield-check'"
+            size="4"
+            :class="verifyLoading ? 'animate-spin motion-reduce:animate-none' : ''" />
+          {{ t('web.admin.domaintoolbox.reverify.button') }}
+        </button>
+      </div>
+
+      <p
+        v-if="probeError"
+        class="mt-3 text-sm text-red-700 dark:text-red-300"
+        role="alert"
+        data-testid="probe-error">
+        {{ probeError }}
+      </p>
+      <p
+        v-if="verifyError"
+        class="mt-3 text-sm text-red-700 dark:text-red-300"
+        role="alert"
+        data-testid="reverify-error">
+        {{ verifyError }}
+      </p>
+
+      <!-- Probe result -->
+      <div
+        v-if="probeDetails"
+        class="mt-5 space-y-4 border-t border-gray-100 pt-4 dark:border-gray-800"
+        data-testid="probe-result">
+        <div class="flex items-center gap-3">
+          <span class="text-sm text-gray-500 dark:text-gray-400">{{ t('web.admin.domaintoolbox.probe.healthLabel') }}:</span>
+          <span
+            :class="[
+              'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
+              healthBadgeClass(probeDetails.health),
+            ]"
+            data-testid="probe-health">
+            {{ probeDetails.health }}
+          </span>
+          <span class="font-mono text-xs text-gray-500 dark:text-gray-400">{{ probeRecordDomain }}</span>
+        </div>
+        <JsonViewer
+          :data="probeDetails"
+          :expand-depth="2"
+          testid="probe-json" />
+      </div>
+    </section>
+
+    <!-- ===== Repair (guarded) ============================================= -->
+    <section
+      class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+      data-testid="repair-section">
+      <h3 class="mb-3 text-lg font-semibold text-gray-900 dark:text-white">
+        {{ t('web.admin.domaintoolbox.repair.title') }}
+      </h3>
+      <p class="mb-4 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.domaintoolbox.repair.description') }}
+      </p>
+
+      <div class="flex flex-wrap items-end gap-3">
+        <div class="flex-1 min-w-[14rem]">
+          <label
+            for="repair-extid"
+            class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.domaintoolbox.fields.extid') }}
+          </label>
+          <input
+            id="repair-extid"
+            v-model="repairExtid"
+            type="text"
+            data-testid="repair-extid-input"
+            class="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm text-gray-900 focus:border-brand-500 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+        </div>
+        <div class="flex-1 min-w-[14rem]">
+          <label
+            for="repair-orgid"
+            class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.domaintoolbox.repair.orgIdLabel') }}
+          </label>
+          <input
+            id="repair-orgid"
+            v-model="repairOrgId"
+            type="text"
+            data-testid="repair-orgid-input"
+            :placeholder="t('web.admin.domaintoolbox.repair.orgIdPlaceholder')"
+            class="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm text-gray-900 focus:border-brand-500 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+        </div>
+        <button
+          type="button"
+          data-testid="repair-preview"
+          :disabled="!repairExtid.trim() || repairPreviewLoading"
+          class="inline-flex items-center gap-1 rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+          @click="onRepairPreview">
+          {{ t('web.admin.domaintoolbox.preview') }}
+        </button>
+      </div>
+
+      <p
+        v-if="repairPreviewError"
+        class="mt-3 text-sm text-red-700 dark:text-red-300"
+        role="alert"
+        data-testid="repair-preview-error">
+        {{ repairPreviewError }}
+      </p>
+
+      <!-- Repair plan -->
+      <div
+        v-if="repairPlan"
+        class="mt-5 border-t border-gray-100 pt-4 dark:border-gray-800"
+        data-testid="repair-plan">
+        <p class="mb-2 text-sm text-gray-700 dark:text-gray-300">
+          {{ t('web.admin.domaintoolbox.repair.statusLabel') }}:
+          <span class="font-mono font-medium" data-testid="repair-status">{{ repairPlan.status }}</span>
+        </p>
+        <ul
+          v-if="repairPlan.issues.length"
+          class="ml-4 list-disc space-y-1 text-sm text-gray-700 dark:text-gray-300">
+          <li v-for="(issue, i) in repairPlan.issues" :key="i">{{ issue }}</li>
+        </ul>
+        <p v-else class="text-sm text-gray-500 dark:text-gray-400">
+          {{ t('web.admin.domaintoolbox.repair.noIssues') }}
+        </p>
+
+        <button
+          v-if="repairApplicable"
+          type="button"
+          data-testid="repair-apply"
+          class="mt-4 inline-flex items-center gap-1 rounded-md bg-amber-600 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          @click="requestRepairApply">
+          <OIcon
+            collection="heroicons"
+            name="cog-6-tooth"
+            size="4" />
+          {{ t('web.admin.domaintoolbox.repair.applyButton') }}
+        </button>
+      </div>
+    </section>
+
+    <!-- ===== Transfer (guarded) =========================================== -->
+    <section
+      class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+      data-testid="transfer-section">
+      <h3 class="mb-3 text-lg font-semibold text-gray-900 dark:text-white">
+        {{ t('web.admin.domaintoolbox.transfer.title') }}
+      </h3>
+      <p class="mb-4 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.domaintoolbox.transfer.description') }}
+      </p>
+
+      <div class="grid gap-3 sm:grid-cols-3">
+        <div>
+          <label
+            for="transfer-extid"
+            class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.domaintoolbox.fields.extid') }}
+          </label>
+          <input
+            id="transfer-extid"
+            v-model="transferExtid"
+            type="text"
+            data-testid="transfer-extid-input"
+            class="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm text-gray-900 focus:border-brand-500 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+        </div>
+        <div>
+          <label
+            for="transfer-to"
+            class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.domaintoolbox.transfer.toOrgLabel') }}
+          </label>
+          <input
+            id="transfer-to"
+            v-model="transferToOrg"
+            type="text"
+            data-testid="transfer-toorg-input"
+            class="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm text-gray-900 focus:border-brand-500 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+        </div>
+        <div>
+          <label
+            for="transfer-from"
+            class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.domaintoolbox.transfer.fromOrgLabel') }}
+          </label>
+          <input
+            id="transfer-from"
+            v-model="transferFromOrg"
+            type="text"
+            data-testid="transfer-fromorg-input"
+            :placeholder="t('web.admin.domaintoolbox.transfer.fromOrgPlaceholder')"
+            class="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm text-gray-900 focus:border-brand-500 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+        </div>
+      </div>
+
+      <button
+        type="button"
+        data-testid="transfer-preview"
+        :disabled="!transferReady || transferPreviewLoading"
+        class="mt-3 inline-flex items-center gap-1 rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+        @click="onTransferPreview">
+        {{ t('web.admin.domaintoolbox.preview') }}
+      </button>
+
+      <p
+        v-if="transferPreviewError"
+        class="mt-3 text-sm text-red-700 dark:text-red-300"
+        role="alert"
+        data-testid="transfer-preview-error">
+        {{ transferPreviewError }}
+      </p>
+
+      <!-- Transfer plan -->
+      <div
+        v-if="transferPlan"
+        class="mt-5 border-t border-gray-100 pt-4 text-sm dark:border-gray-800"
+        data-testid="transfer-plan">
+        <dl class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          <div>
+            <dt class="text-xs text-gray-500 dark:text-gray-400">{{ t('web.admin.domaintoolbox.transfer.from') }}</dt>
+            <dd class="font-mono text-gray-900 dark:text-white">
+              {{ transferPlan.from_org_id ? `${transferPlan.from_org_name || '—'} (${transferPlan.from_org_id})` : t('web.admin.domaintoolbox.transfer.orphaned') }}
+            </dd>
+          </div>
+          <div>
+            <dt class="text-xs text-gray-500 dark:text-gray-400">{{ t('web.admin.domaintoolbox.transfer.to') }}</dt>
+            <dd class="font-mono text-gray-900 dark:text-white">
+              {{ transferPlan.to_org_name || '—' }} ({{ transferPlan.to_org_id }})
+            </dd>
+          </div>
+        </dl>
+
+        <button
+          v-if="transferApplicable"
+          type="button"
+          data-testid="transfer-apply"
+          class="mt-4 inline-flex items-center gap-1 rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500"
+          @click="requestTransferApply">
+          <OIcon
+            collection="heroicons"
+            name="arrow-right"
+            size="4" />
+          {{ t('web.admin.domaintoolbox.transfer.applyButton') }}
+        </button>
+      </div>
+    </section>
+
+    <!-- Typed-confirmation gates (destructive verbs). -->
+    <AdminConfirmDialog
+      v-model:open="repairDialogOpen"
+      :title="t('web.admin.domaintoolbox.repair.confirmTitle')"
+      :description="t('web.admin.domaintoolbox.repair.confirmDescription', { domain: repairExtid.trim() })"
+      :confirm-token="repairExtid.trim()"
+      variant="danger"
+      :confirm-text="t('web.admin.domaintoolbox.repair.applyButton')"
+      :loading="repairApplyLoading"
+      :error="repairApplyError"
+      @confirm="onRepairConfirm"
+      @cancel="onRepairCancel" />
+
+    <AdminConfirmDialog
+      v-model:open="transferDialogOpen"
+      :title="t('web.admin.domaintoolbox.transfer.confirmTitle')"
+      :description="t('web.admin.domaintoolbox.transfer.confirmDescription', { domain: transferExtid.trim() })"
+      :confirm-token="transferExtid.trim()"
+      variant="danger"
+      :confirm-text="t('web.admin.domaintoolbox.transfer.applyButton')"
+      :loading="transferApplyLoading"
+      :error="transferApplyError"
+      @confirm="onTransferConfirm"
+      @cancel="onTransferCancel" />
+  </div>
+</template>

--- a/src/apps/admin/views/AdminEmailTools.vue
+++ b/src/apps/admin/views/AdminEmailTools.vue
@@ -1,0 +1,642 @@
+<!-- src/apps/admin/views/AdminEmailTools.vue -->
+
+<script setup lang="ts">
+  import { computed, onMounted, ref } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  import { AdminConfirmDialog } from '@/apps/admin/components/kit';
+  import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
+  import type {
+    ColonelEmailTemplate,
+    ColonelEmailTestDetails,
+    ColonelRateLimiter,
+    ColonelRateLimitEntry,
+  } from '@/schemas/api/account/responses/colonel-emailtools';
+  import {
+    colonelEmailTemplatesResponseSchema,
+    colonelEmailPreviewResponseSchema,
+    colonelEmailTestResponseSchema,
+    colonelRateLimitersResponseSchema,
+    colonelRateLimitInspectResponseSchema,
+    colonelRateLimitResetResponseSchema,
+  } from '@/schemas/api/internal/responses/colonel-emailtools';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import { useApi } from '@/shared/composables/useApi';
+  import { useNotificationsStore } from '@/shared/stores/notificationsStore';
+  import { gracefulParse } from '@/utils/schemaValidation';
+
+  /**
+   * Email + Rate-limit Tools (ticket #44) — the Phase-3 payoff that surfaces the
+   * CLI-only email diagnostics (`bin/ots email {templates,preview,test}`) and
+   * rate-limiter inspection (`bin/ots ratelimit keys`) in the browser, built fresh
+   * on the Slice-3 template (no `src/apps/colonel/*` / `colonelInfoStore`).
+   *
+   * Three sections, all disjoint under the `emailtools` namespace:
+   *  - TEMPLATE PREVIEW (read-only): pick a template + format → render sample
+   *    output. HTML renders in a sandboxed iframe; text shows as escaped source.
+   *  - TEST SEND (guarded, low-risk one-click confirm — CONTRACT 1): preview the
+   *    exact diagnostic (dry-run, no send), then send to an operator-supplied
+   *    address. The real send is audited SERVER-SIDE by the op (CONTRACT 4).
+   *  - RATE-LIMIT (read + guarded reset): inspect a limiter/identifier's live
+   *    counter state (read-only), then RESET behind an {@link AdminConfirmDialog}
+   *    typed-confirmation (retype the subject). Reset is audited SERVER-SIDE.
+   *
+   * Every mutation goes through {@link useAdminMutation}; nothing here logs.
+   */
+  const { t } = useI18n();
+  const $api = useApi();
+  const notifications = useNotificationsStore();
+
+  const TEMPLATES_URL = '/api/colonel/email/templates';
+  const TEST_URL = '/api/colonel/email/test';
+  const LIMITERS_URL = '/api/colonel/ratelimit/limiters';
+  const INSPECT_URL = '/api/colonel/ratelimit/inspect';
+  const RESET_URL = '/api/colonel/ratelimit/reset';
+
+  // ---- Reference lists (templates + limiters) -------------------------------
+
+  const templates = ref<ColonelEmailTemplate[]>([]);
+  const limiters = ref<ColonelRateLimiter[]>([]);
+
+  async function loadTemplates(): Promise<void> {
+    try {
+      const response = await $api.get(TEMPLATES_URL);
+      const parsed = gracefulParse(
+        colonelEmailTemplatesResponseSchema,
+        response.data,
+        'ColonelEmailTemplatesResponse'
+      );
+      if (parsed.ok) {
+        templates.value = parsed.data.record?.templates ?? [];
+        if (!selectedTemplate.value && templates.value.length) {
+          selectedTemplate.value = templates.value[0].name;
+        }
+      }
+    } catch {
+      // A missing list only disables the picker; the section stays usable via
+      // a manual template id. No blocking error surface.
+    }
+  }
+
+  async function loadLimiters(): Promise<void> {
+    try {
+      const response = await $api.get(LIMITERS_URL);
+      const parsed = gracefulParse(
+        colonelRateLimitersResponseSchema,
+        response.data,
+        'ColonelRateLimitersResponse'
+      );
+      if (parsed.ok) {
+        limiters.value = parsed.data.record?.limiters ?? [];
+        if (!rlKind.value && limiters.value.length) {
+          rlKind.value = limiters.value[0].kind;
+        }
+      }
+    } catch {
+      // Non-blocking, as above.
+    }
+  }
+
+  // ---- Section 1: template preview (read-only) ------------------------------
+
+  const selectedTemplate = ref('');
+  const previewFormat = ref<'text' | 'html'>('text');
+  const previewLocale = ref('en');
+  const previewBody = ref<string | null>(null);
+  const previewRenderedFormat = ref<'text' | 'html'>('text');
+
+  const selectedTemplateMeta = computed(() =>
+    templates.value.find((tpl) => tpl.name === selectedTemplate.value)
+  );
+  /** HTML render is only offered when the template actually ships an HTML body. */
+  const htmlAvailable = computed(
+    () => selectedTemplateMeta.value?.formats.includes('html') ?? true
+  );
+
+  const {
+    loading: previewLoading,
+    error: previewError,
+    run: runPreview,
+    reset: resetPreview,
+  } = useAdminMutation(async () => {
+    previewBody.value = null;
+    const response = await $api.get(
+      `${TEMPLATES_URL}/${encodeURIComponent(selectedTemplate.value)}/preview`,
+      { params: { format: previewFormat.value, locale: previewLocale.value || 'en' } }
+    );
+    const parsed = gracefulParse(
+      colonelEmailPreviewResponseSchema,
+      response.data,
+      'ColonelEmailPreviewResponse'
+    );
+    if (parsed.ok) {
+      previewBody.value = parsed.data.details?.body ?? '';
+      previewRenderedFormat.value = (parsed.data.record?.format as 'text' | 'html') ?? 'text';
+    }
+  });
+
+  async function onPreview(): Promise<void> {
+    if (!selectedTemplate.value) return;
+    resetPreview();
+    await runPreview();
+  }
+
+  // ---- Section 2: test send (guarded, one-click confirm) --------------------
+
+  const testTo = ref('');
+  const testEnqueue = ref(false);
+  const testDiagnostic = ref<ColonelEmailTestDetails | null>(null);
+  const sendDialogOpen = ref(false);
+
+  /** A minimal e-mail sanity check so the confirm button can't send garbage. */
+  const testToValid = computed(() => /.+@.+\..+/.test(testTo.value.trim()));
+
+  // Dry-run preview: shows the EXACT email that would be sent, sends nothing.
+  const {
+    loading: testPreviewLoading,
+    error: testPreviewError,
+    run: runTestPreview,
+    reset: resetTestPreview,
+  } = useAdminMutation(async () => {
+    testDiagnostic.value = null;
+    const response = await $api.post(TEST_URL, {
+      to: testTo.value.trim(),
+      enqueue: testEnqueue.value,
+      dry_run: true,
+    });
+    const parsed = gracefulParse(
+      colonelEmailTestResponseSchema,
+      response.data,
+      'ColonelEmailTestResponse'
+    );
+    if (parsed.ok) testDiagnostic.value = parsed.data.details ?? null;
+  });
+
+  // Real send: dispatches a live email (audited server-side).
+  const {
+    loading: sendLoading,
+    error: sendError,
+    run: runSend,
+    reset: resetSend,
+  } = useAdminMutation(async () => {
+    const response = await $api.post(TEST_URL, {
+      to: testTo.value.trim(),
+      enqueue: testEnqueue.value,
+      dry_run: false,
+    });
+    gracefulParse(colonelEmailTestResponseSchema, response.data, 'ColonelEmailTestResponse');
+  });
+
+  async function onTestPreview(): Promise<void> {
+    if (!testToValid.value) return;
+    resetTestPreview();
+    await runTestPreview();
+  }
+
+  function requestSend(): void {
+    if (!testToValid.value) return;
+    resetSend();
+    sendDialogOpen.value = true;
+  }
+
+  async function onSendConfirm(): Promise<void> {
+    const ok = await runSend();
+    if (!ok) return;
+    sendDialogOpen.value = false;
+    notifications.show(t('web.admin.emailtools.test.success', { to: testTo.value.trim() }), 'success');
+  }
+
+  function onSendCancel(): void {
+    sendDialogOpen.value = false;
+    resetSend();
+  }
+
+  // ---- Section 3: rate-limit inspect (read) + reset (guarded) ---------------
+
+  const rlKind = ref('');
+  const rlSubject = ref('');
+  const rlEntries = ref<ColonelRateLimitEntry[] | null>(null);
+  const resetDialogOpen = ref(false);
+
+  const rlReady = computed(() => rlKind.value.trim() !== '' && rlSubject.value.trim() !== '');
+  /** Reset is only meaningful once at least one key is known to exist. */
+  const rlHasState = computed(() => (rlEntries.value ?? []).some((e) => e.exists));
+
+  const {
+    loading: inspectLoading,
+    error: inspectError,
+    run: runInspect,
+    reset: resetInspect,
+  } = useAdminMutation(async () => {
+    rlEntries.value = null;
+    const response = await $api.get(INSPECT_URL, {
+      params: { kind: rlKind.value.trim(), subject: rlSubject.value.trim() },
+    });
+    const parsed = gracefulParse(
+      colonelRateLimitInspectResponseSchema,
+      response.data,
+      'ColonelRateLimitInspectResponse'
+    );
+    if (parsed.ok) rlEntries.value = parsed.data.details?.entries ?? [];
+  });
+
+  const {
+    loading: rlResetLoading,
+    error: rlResetError,
+    run: runReset,
+    reset: resetResetMutation,
+  } = useAdminMutation(async () => {
+    const response = await $api.post(RESET_URL, {
+      kind: rlKind.value.trim(),
+      subject: rlSubject.value.trim(),
+    });
+    gracefulParse(colonelRateLimitResetResponseSchema, response.data, 'ColonelRateLimitResetResponse');
+  });
+
+  async function onInspect(): Promise<void> {
+    if (!rlReady.value) return;
+    resetInspect();
+    await runInspect();
+  }
+
+  function requestReset(): void {
+    resetResetMutation();
+    resetDialogOpen.value = true;
+  }
+
+  async function onResetConfirm(): Promise<void> {
+    const ok = await runReset();
+    if (!ok) return;
+    resetDialogOpen.value = false;
+    notifications.show(t('web.admin.emailtools.ratelimit.resetSuccess'), 'success');
+    // Re-inspect so the operator sees the cleared state immediately.
+    await onInspect();
+  }
+
+  function onResetCancel(): void {
+    resetDialogOpen.value = false;
+    resetResetMutation();
+  }
+
+  function ttlLabel(entry: ColonelRateLimitEntry): string {
+    if (!entry.exists) return t('web.admin.emailtools.ratelimit.absent');
+    if (entry.ttl === null) return t('web.admin.emailtools.ratelimit.noExpiry');
+    return `${entry.ttl}s`;
+  }
+
+  onMounted(() => {
+    loadTemplates();
+    loadLimiters();
+  });
+</script>
+
+<template>
+  <div class="mx-auto max-w-5xl space-y-8">
+    <!-- Page header -->
+    <div>
+      <h2 class="font-brand text-2xl font-semibold text-gray-900 dark:text-white">
+        {{ t('web.admin.emailtools.title') }}
+      </h2>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.emailtools.description') }}
+      </p>
+    </div>
+
+    <!-- ===== Section 1: template preview (read-only) ====================== -->
+    <section
+      class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+      data-testid="preview-section">
+      <h3 class="mb-3 text-lg font-semibold text-gray-900 dark:text-white">
+        {{ t('web.admin.emailtools.preview.title') }}
+      </h3>
+      <p class="mb-4 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.emailtools.preview.description') }}
+      </p>
+
+      <div class="flex flex-wrap items-end gap-3">
+        <div class="min-w-[16rem] flex-1">
+          <label
+            for="preview-template"
+            class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.emailtools.preview.templateLabel') }}
+          </label>
+          <select
+            id="preview-template"
+            v-model="selectedTemplate"
+            data-testid="preview-template-select"
+            class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-brand-500 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white">
+            <option
+              v-for="tpl in templates"
+              :key="tpl.name"
+              :value="tpl.name">
+              {{ tpl.name }}
+            </option>
+          </select>
+        </div>
+
+        <div>
+          <label
+            for="preview-format"
+            class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.emailtools.preview.formatLabel') }}
+          </label>
+          <select
+            id="preview-format"
+            v-model="previewFormat"
+            data-testid="preview-format-select"
+            class="rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-brand-500 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white">
+            <option value="text">text</option>
+            <option
+              value="html"
+              :disabled="!htmlAvailable">
+              html
+            </option>
+          </select>
+        </div>
+
+        <div class="w-24">
+          <label
+            for="preview-locale"
+            class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.emailtools.preview.localeLabel') }}
+          </label>
+          <input
+            id="preview-locale"
+            v-model="previewLocale"
+            type="text"
+            data-testid="preview-locale-input"
+            class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-brand-500 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+        </div>
+
+        <button
+          type="button"
+          data-testid="preview-run"
+          :disabled="!selectedTemplate || previewLoading"
+          class="inline-flex items-center gap-1 rounded-md bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-50"
+          @click="onPreview">
+          <OIcon
+            collection="heroicons"
+            :name="previewLoading ? 'arrow-path' : 'eye'"
+            size="4"
+            :class="previewLoading ? 'animate-spin motion-reduce:animate-none' : ''" />
+          {{ t('web.admin.emailtools.preview.button') }}
+        </button>
+      </div>
+
+      <p
+        v-if="previewError"
+        class="mt-3 text-sm text-red-700 dark:text-red-300"
+        role="alert"
+        data-testid="preview-error">
+        {{ previewError }}
+      </p>
+
+      <!-- Rendered output -->
+      <div
+        v-if="previewBody !== null"
+        class="mt-5 border-t border-gray-100 pt-4 dark:border-gray-800"
+        data-testid="preview-result">
+        <!-- HTML renders in a sandboxed iframe (no scripts, no same-origin) so
+             the admin never executes template markup in the console context. -->
+        <iframe
+          v-if="previewRenderedFormat === 'html'"
+          :srcdoc="previewBody"
+          sandbox=""
+          data-testid="preview-iframe"
+          class="h-96 w-full rounded border border-gray-200 bg-white dark:border-gray-700"
+          :title="t('web.admin.emailtools.preview.title')"></iframe>
+        <!-- Text shows as ESCAPED source (never v-html). -->
+        <pre
+          v-else
+          data-testid="preview-body"
+          class="max-h-96 overflow-auto whitespace-pre-wrap break-words rounded bg-gray-50 p-4 font-mono text-sm text-gray-900 dark:bg-gray-800 dark:text-gray-100">{{ previewBody }}</pre>
+      </div>
+    </section>
+
+    <!-- ===== Section 2: test send (guarded) ============================== -->
+    <section
+      class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+      data-testid="test-section">
+      <h3 class="mb-3 text-lg font-semibold text-gray-900 dark:text-white">
+        {{ t('web.admin.emailtools.test.title') }}
+      </h3>
+      <p class="mb-4 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.emailtools.test.description') }}
+      </p>
+
+      <div class="flex flex-wrap items-end gap-3">
+        <div class="min-w-[18rem] flex-1">
+          <label
+            for="test-to"
+            class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.emailtools.test.toLabel') }}
+          </label>
+          <input
+            id="test-to"
+            v-model="testTo"
+            type="email"
+            data-testid="test-to-input"
+            :placeholder="t('web.admin.emailtools.test.toPlaceholder')"
+            class="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm text-gray-900 focus:border-brand-500 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+        </div>
+        <label class="inline-flex items-center gap-2 pb-2 text-sm text-gray-700 dark:text-gray-300">
+          <input
+            v-model="testEnqueue"
+            type="checkbox"
+            data-testid="test-enqueue-checkbox"
+            class="rounded border-gray-300 text-brand-600 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800" />
+          {{ t('web.admin.emailtools.test.enqueueLabel') }}
+        </label>
+        <button
+          type="button"
+          data-testid="test-preview"
+          :disabled="!testToValid || testPreviewLoading"
+          class="inline-flex items-center gap-1 rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+          @click="onTestPreview">
+          {{ t('web.admin.emailtools.test.previewButton') }}
+        </button>
+        <button
+          type="button"
+          data-testid="test-send"
+          :disabled="!testToValid || sendLoading"
+          class="inline-flex items-center gap-1 rounded-md bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-50"
+          @click="requestSend">
+          <OIcon
+            collection="heroicons"
+            name="paper-airplane"
+            size="4" />
+          {{ t('web.admin.emailtools.test.sendButton') }}
+        </button>
+      </div>
+
+      <p
+        v-if="testPreviewError"
+        class="mt-3 text-sm text-red-700 dark:text-red-300"
+        role="alert"
+        data-testid="test-preview-error">
+        {{ testPreviewError }}
+      </p>
+
+      <!-- Dry-run diagnostic (exactly what would be sent) -->
+      <div
+        v-if="testDiagnostic"
+        class="mt-5 space-y-2 border-t border-gray-100 pt-4 text-sm dark:border-gray-800"
+        data-testid="test-diagnostic">
+        <div class="grid grid-cols-1 gap-1 sm:grid-cols-2">
+          <div><span class="text-gray-500 dark:text-gray-400">{{ t('web.admin.emailtools.test.provider') }}:</span> <span class="font-mono">{{ testDiagnostic.provider }}</span></div>
+          <div><span class="text-gray-500 dark:text-gray-400">{{ t('web.admin.emailtools.test.host') }}:</span> <span class="font-mono">{{ testDiagnostic.host }}</span></div>
+          <div><span class="text-gray-500 dark:text-gray-400">{{ t('web.admin.emailtools.test.from') }}:</span> <span class="font-mono">{{ testDiagnostic.from }}</span></div>
+          <div class="sm:col-span-2"><span class="text-gray-500 dark:text-gray-400">{{ t('web.admin.emailtools.test.subject') }}:</span> <span class="font-mono">{{ testDiagnostic.subject }}</span></div>
+        </div>
+        <pre
+          data-testid="test-body"
+          class="max-h-48 overflow-auto whitespace-pre-wrap break-words rounded bg-gray-50 p-3 font-mono text-xs text-gray-900 dark:bg-gray-800 dark:text-gray-100">{{ testDiagnostic.text_body }}</pre>
+      </div>
+    </section>
+
+    <!-- ===== Section 3: rate-limit inspect + reset ======================= -->
+    <section
+      class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+      data-testid="ratelimit-section">
+      <h3 class="mb-3 text-lg font-semibold text-gray-900 dark:text-white">
+        {{ t('web.admin.emailtools.ratelimit.title') }}
+      </h3>
+      <p class="mb-4 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.emailtools.ratelimit.description') }}
+      </p>
+
+      <div class="flex flex-wrap items-end gap-3">
+        <div class="min-w-[12rem]">
+          <label
+            for="rl-kind"
+            class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.emailtools.ratelimit.kindLabel') }}
+          </label>
+          <select
+            id="rl-kind"
+            v-model="rlKind"
+            data-testid="rl-kind-select"
+            class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-brand-500 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white">
+            <option
+              v-for="lim in limiters"
+              :key="lim.kind"
+              :value="lim.kind">
+              {{ lim.kind }} — {{ lim.subject }}
+            </option>
+          </select>
+        </div>
+        <div class="min-w-[16rem] flex-1">
+          <label
+            for="rl-subject"
+            class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.emailtools.ratelimit.subjectLabel') }}
+          </label>
+          <input
+            id="rl-subject"
+            v-model="rlSubject"
+            type="text"
+            data-testid="rl-subject-input"
+            :placeholder="t('web.admin.emailtools.ratelimit.subjectPlaceholder')"
+            class="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm text-gray-900 focus:border-brand-500 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+        </div>
+        <button
+          type="button"
+          data-testid="rl-inspect"
+          :disabled="!rlReady || inspectLoading"
+          class="inline-flex items-center gap-1 rounded-md bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-50"
+          @click="onInspect">
+          <OIcon
+            collection="heroicons"
+            :name="inspectLoading ? 'arrow-path' : 'magnifying-glass'"
+            size="4"
+            :class="inspectLoading ? 'animate-spin motion-reduce:animate-none' : ''" />
+          {{ t('web.admin.emailtools.ratelimit.inspectButton') }}
+        </button>
+      </div>
+
+      <p
+        v-if="inspectError"
+        class="mt-3 text-sm text-red-700 dark:text-red-300"
+        role="alert"
+        data-testid="rl-inspect-error">
+        {{ inspectError }}
+      </p>
+
+      <!-- Inspect result -->
+      <div
+        v-if="rlEntries"
+        class="mt-5 border-t border-gray-100 pt-4 dark:border-gray-800"
+        data-testid="rl-result">
+        <table class="w-full text-left text-sm">
+          <thead>
+            <tr class="border-b border-gray-100 text-xs uppercase tracking-wider text-gray-500 dark:border-gray-800 dark:text-gray-400">
+              <th class="py-2 pr-4 font-medium">{{ t('web.admin.emailtools.ratelimit.columns.key') }}</th>
+              <th class="py-2 pr-4 font-medium">{{ t('web.admin.emailtools.ratelimit.columns.value') }}</th>
+              <th class="py-2 font-medium">{{ t('web.admin.emailtools.ratelimit.columns.ttl') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="entry in rlEntries"
+              :key="entry.key"
+              class="border-b border-gray-50 last:border-0 dark:border-gray-800/50"
+              :data-testid="`rl-entry-${entry.key}`">
+              <td class="py-2 pr-4 font-mono text-gray-900 dark:text-white">{{ entry.key }}</td>
+              <td class="py-2 pr-4 font-mono">
+                <span v-if="entry.exists">{{ entry.value }}</span>
+                <span v-else class="text-gray-400 dark:text-gray-600">—</span>
+              </td>
+              <td class="py-2 font-mono text-gray-600 dark:text-gray-400">{{ ttlLabel(entry) }}</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div
+          v-if="!rlHasState"
+          class="mt-3 text-sm text-gray-500 dark:text-gray-400"
+          data-testid="rl-empty">
+          {{ t('web.admin.emailtools.ratelimit.noState') }}
+        </div>
+
+        <button
+          v-if="rlHasState"
+          type="button"
+          data-testid="rl-reset"
+          class="mt-4 inline-flex items-center gap-1 rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500"
+          @click="requestReset">
+          <OIcon
+            collection="heroicons"
+            name="trash"
+            size="4" />
+          {{ t('web.admin.emailtools.ratelimit.resetButton') }}
+        </button>
+      </div>
+    </section>
+
+    <!-- Test send: one-click confirm (low-risk verb — CONTRACT 1). -->
+    <AdminConfirmDialog
+      v-model:open="sendDialogOpen"
+      :title="t('web.admin.emailtools.test.confirmTitle')"
+      :description="t('web.admin.emailtools.test.confirmDescription', { to: testTo.trim() })"
+      :confirm-token="undefined"
+      variant="default"
+      :confirm-text="t('web.admin.emailtools.test.sendButton')"
+      :loading="sendLoading"
+      :error="sendError"
+      @confirm="onSendConfirm"
+      @cancel="onSendCancel" />
+
+    <!-- Rate-limit reset: typed-confirmation (retype the subject). -->
+    <AdminConfirmDialog
+      v-model:open="resetDialogOpen"
+      :title="t('web.admin.emailtools.ratelimit.confirmTitle')"
+      :description="t('web.admin.emailtools.ratelimit.confirmDescription', { subject: rlSubject.trim() })"
+      :confirm-token="rlSubject.trim()"
+      variant="danger"
+      :confirm-text="t('web.admin.emailtools.ratelimit.resetButton')"
+      :loading="rlResetLoading"
+      :error="rlResetError"
+      @confirm="onResetConfirm"
+      @cancel="onResetCancel" />
+  </div>
+</template>

--- a/src/apps/admin/views/AdminQueueDlq.vue
+++ b/src/apps/admin/views/AdminQueueDlq.vue
@@ -1,0 +1,610 @@
+<!-- src/apps/admin/views/AdminQueueDlq.vue -->
+
+<script setup lang="ts">
+  import { storeToRefs } from 'pinia';
+  import { computed, onMounted, ref } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  import {
+    AdminConfirmDialog,
+    DataTable,
+    DetailDrawer,
+    FilterBar,
+    JsonViewer,
+    KitPagination,
+    StatCard,
+  } from '@/apps/admin/components/kit';
+  import type { DataTableColumn } from '@/apps/admin/components/kit';
+  import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
+  import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
+  import { useAdminQueueDlq } from '@/apps/admin/stores/useAdminQueueDlq';
+  import type {
+    ColonelDlqSummary,
+    ColonelDlqMessage,
+  } from '@/schemas/api/account/responses/colonel-queue';
+  import {
+    colonelDlqMessagesResponseSchema,
+    colonelDlqReplayResponseSchema,
+    colonelDlqPurgeResponseSchema,
+  } from '@/schemas/api/internal/responses/colonel-queue';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import { useApi } from '@/shared/composables/useApi';
+  import { useNotificationsStore } from '@/shared/stores/notificationsStore';
+  import { gracefulParse } from '@/utils/schemaValidation';
+
+  /**
+   * Queue DLQ console (ticket #42) — a Phase-3 screen: a CLI-only power
+   * (`bin/ots queue dlq …`) surfaced in the browser, built on the Slice-3 template
+   * (no `src/apps/colonel/*` / `colonelInfoStore`). Sits beside the existing
+   * queue-status widget / `GetQueueMetrics`, upgrading a read-only view into an
+   * actionable one.
+   *
+   * - LIST: DataTable + FilterBar + KitPagination over the NEW {@link useAdminQueueDlq}
+   *   store. `GET /api/colonel/queues/dlq` is a thin adapter over
+   *   `Onetime::Operations::Dlq::List` (the fixed DLQ allowlist — bounded, #2211).
+   * - INSPECT DRAWER: a row opens {@link DetailDrawer} loading
+   *   `GET /api/colonel/queues/dlq/:queue` via {@link useResourceFetch}
+   *   (`Dlq::Peek`) — a non-destructive peek of the dead-letter payloads, each
+   *   inspectable via {@link JsonViewer}.
+   * - GUARDED REPLAY (D4, low-ish risk): re-enqueues the DLQ back to its origin.
+   *   Because replay can re-trigger side effects (emails, webhooks), it DEFAULTS
+   *   to a dry-run: clicking Replay first POSTs `{dry_run:true}` to preview the
+   *   in-scope `would_replay` count, then the live replay is an explicit second
+   *   step behind {@link AdminConfirmDialog} (one-click, no token; the copy shows
+   *   the previewed count). Audited SERVER-SIDE by `Dlq::Replay` only on the live
+   *   run (the dry-run is a no-op that records nothing).
+   * - GUARDED PURGE (D4, destructive): irreversible message loss, gated by
+   *   {@link AdminConfirmDialog} typed-confirmation (retype the queue name) in
+   *   danger mode with the count-in-scope shown; audited SERVER-SIDE by `Dlq::Purge`.
+   */
+  const { t } = useI18n();
+  const $api = useApi();
+  const notifications = useNotificationsStore();
+
+  const store = useAdminQueueDlq();
+  const { dlqs, pagination, connected, loading, error } = storeToRefs(store);
+
+  // ---- List + filter --------------------------------------------------------
+
+  const searchTerm = ref('');
+  const hasActiveFilters = computed(() => searchTerm.value !== '');
+
+  /** Strip the `dlq.` prefix for a friendlier display / confirm token. */
+  function shortName(queue: string): string {
+    return queue.replace(/^dlq\./, '');
+  }
+
+  /** Client-side filter over the (small, fixed) DLQ set. */
+  const filteredDlqs = computed<ColonelDlqSummary[]>(() => {
+    const needle = searchTerm.value.trim().toLowerCase();
+    if (!needle) return dlqs.value;
+    return dlqs.value.filter((d) => d.queue.toLowerCase().includes(needle));
+  });
+
+  const totalMessages = computed(() =>
+    dlqs.value.reduce((sum, d) => sum + (d.messages ?? 0), 0)
+  );
+
+  const columns = computed<DataTableColumn<ColonelDlqSummary>[]>(() => [
+    { key: 'queue', label: t('web.admin.queue.columns.queue') },
+    { key: 'messages', label: t('web.admin.queue.columns.messages'), align: 'right' },
+    { key: 'consumers', label: t('web.admin.queue.columns.consumers'), align: 'right' },
+    { key: 'actions', label: t('web.admin.queue.columns.actions'), align: 'right' },
+  ]);
+
+  async function fetchPage(targetPage = 1): Promise<void> {
+    try {
+      await store.fetchPage(targetPage);
+    } catch {
+      // Network/HTTP failure is captured in `store.error`; the banner + retry
+      // button below handle it. Swallow so it doesn't become unhandled.
+    }
+  }
+
+  function onClear(): void {
+    searchTerm.value = '';
+  }
+
+  function onPageChange(targetPage: number): void {
+    fetchPage(targetPage);
+  }
+
+  function onPerPageChange(perPage: number): void {
+    store.perPage = perPage;
+    fetchPage(1);
+  }
+
+  // ---- Inspect drawer (peek) ------------------------------------------------
+
+  const drawerOpen = ref(false);
+  /** The row that opened the drawer — the source of the queue id. */
+  const selectedDlq = ref<ColonelDlqSummary | null>(null);
+
+  const detailUrl = (): string =>
+    `/api/colonel/queues/dlq/${encodeURIComponent(selectedDlq.value?.queue ?? '')}`;
+
+  const {
+    data: detailData,
+    loading: detailLoading,
+    error: detailError,
+    validationError: detailValidationError,
+    load: loadDetail,
+  } = useResourceFetch({
+    url: detailUrl,
+    schema: colonelDlqMessagesResponseSchema,
+    context: 'ColonelDlqMessagesResponse',
+  });
+
+  const detailMessages = computed<ColonelDlqMessage[]>(
+    () => detailData.value?.details?.messages ?? []
+  );
+  const detailRecord = computed(() => detailData.value?.record ?? null);
+  const detailLoadFailed = computed(
+    () => detailError.value !== null || detailValidationError.value !== null
+  );
+
+  function openDetail(row: ColonelDlqSummary): void {
+    selectedDlq.value = row;
+    drawerOpen.value = true;
+    loadDetail().catch(() => {});
+  }
+
+  function closeDrawer(): void {
+    drawerOpen.value = false;
+    selectedDlq.value = null;
+  }
+
+  // ---- Guarded mutations (D4) ----------------------------------------------
+
+  type ActionKey = 'replay' | 'purge';
+
+  const dialogOpen = ref(false);
+  const activeAction = ref<ActionKey | null>(null);
+  /** Full queue name the action targets (request path). */
+  const targetQueue = ref('');
+  /** Message count in scope at request time (for the purge confirm copy). */
+  const targetCount = ref(0);
+  /**
+   * In-scope count returned by the replay DRY-RUN preview (`would_replay`), shown
+   * in the confirm copy before the live replay. Null until a preview has run.
+   */
+  const replayWouldReplay = ref<number | null>(null);
+
+  const {
+    loading: mutationLoading,
+    error: mutationError,
+    run: runMutation,
+    reset: resetMutation,
+  } = useAdminMutation(async () => {
+    const queue = targetQueue.value;
+    if (!queue) throw new Error('No queue selected');
+    const path = `/api/colonel/queues/dlq/${encodeURIComponent(queue)}`;
+
+    if (activeAction.value === 'replay') {
+      // Explicit LIVE replay (the second, confirmed step after the dry-run
+      // preview). `dry_run:false` re-publishes and is the audited mutation.
+      const response = await $api.post(`${path}/replay`, { dry_run: false });
+      // A 2xx means the replay ran server-side regardless of ack shape; the parse
+      // keeps the contract a live tripwire without failing the action.
+      gracefulParse(colonelDlqReplayResponseSchema, response.data, 'ColonelDlqReplayResponse');
+    } else {
+      const response = await $api.post(`${path}/purge`, {});
+      gracefulParse(colonelDlqPurgeResponseSchema, response.data, 'ColonelDlqPurgeResponse');
+    }
+  });
+
+  /**
+   * Replay DRY-RUN preview (the safe first step). POSTs `{dry_run:true}` — a
+   * server-side no-op that measures `would_replay` without republishing or
+   * auditing — so the operator sees the in-scope count before committing.
+   */
+  const {
+    loading: replayPreviewLoading,
+    error: replayPreviewError,
+    run: runReplayPreview,
+    reset: resetReplayPreview,
+  } = useAdminMutation(async (queue: string) => {
+    replayWouldReplay.value = null;
+    const path = `/api/colonel/queues/dlq/${encodeURIComponent(queue)}`;
+    const response = await $api.post(`${path}/replay`, { dry_run: true });
+    const parsed = gracefulParse(
+      colonelDlqReplayResponseSchema,
+      response.data,
+      'ColonelDlqReplayResponse'
+    );
+    replayWouldReplay.value = parsed.ok ? (parsed.data.record?.would_replay ?? 0) : 0;
+  });
+
+  /** Purge is destructive → typed-confirmation (retype the short queue name). */
+  const dialogConfig = computed(() => {
+    const short = shortName(targetQueue.value);
+    if (activeAction.value === 'purge') {
+      return {
+        title: t('web.admin.queue.purge.confirmTitle'),
+        description: t('web.admin.queue.purge.confirmDescription', {
+          queue: short,
+          count: targetCount.value,
+        }),
+        confirmText: t('web.admin.queue.purge.button'),
+        confirmToken: short,
+        variant: 'danger' as const,
+      };
+    }
+    return {
+      title: t('web.admin.queue.replay.confirmTitle'),
+      description: t('web.admin.queue.replay.confirmDescription', {
+        queue: short,
+        count: replayWouldReplay.value ?? 0,
+      }),
+      confirmText: t('web.admin.queue.replay.confirmLive'),
+      confirmToken: undefined,
+      variant: 'default' as const,
+    };
+  });
+
+  async function requestReplay(row: ColonelDlqSummary): Promise<void> {
+    activeAction.value = 'replay';
+    targetQueue.value = row.queue;
+    targetCount.value = row.messages ?? 0;
+    replayWouldReplay.value = null;
+    resetMutation();
+    resetReplayPreview();
+    // Safe first step: dry-run preview. Only open the live-replay confirm once
+    // we know the in-scope count; a preview failure surfaces its own banner.
+    const ok = await runReplayPreview(row.queue);
+    if (ok) dialogOpen.value = true;
+  }
+
+  function requestPurge(row: ColonelDlqSummary): void {
+    activeAction.value = 'purge';
+    targetQueue.value = row.queue;
+    targetCount.value = row.messages ?? 0;
+    resetMutation();
+    dialogOpen.value = true;
+  }
+
+  async function onConfirm(): Promise<void> {
+    const action = activeAction.value;
+    if (!action) return;
+
+    const ok = await runMutation();
+    if (!ok) return; // Failure message stays in the dialog for retry/cancel.
+
+    dialogOpen.value = false;
+    const short = shortName(targetQueue.value);
+
+    if (action === 'replay') {
+      notifications.show(t('web.admin.queue.replay.success', { queue: short }), 'success');
+    } else {
+      notifications.show(t('web.admin.queue.purge.success', { queue: short }), 'success');
+    }
+
+    // Refresh the drawer (if the acted-on queue is open) and the list — depths
+    // changed.
+    if (drawerOpen.value && selectedDlq.value?.queue === targetQueue.value) {
+      loadDetail().catch(() => {});
+    }
+    activeAction.value = null;
+    replayWouldReplay.value = null;
+    await fetchPage(pagination.value?.page ?? 1);
+  }
+
+  function onCancel(): void {
+    dialogOpen.value = false;
+    activeAction.value = null;
+    replayWouldReplay.value = null;
+    resetMutation();
+    resetReplayPreview();
+  }
+
+  onMounted(() => fetchPage(1));
+</script>
+
+<template>
+  <div class="mx-auto max-w-6xl">
+    <!-- Page header -->
+    <div class="mb-6">
+      <h2 class="font-brand text-2xl font-semibold text-gray-900 dark:text-white">
+        {{ t('web.admin.queue.title') }}
+      </h2>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.queue.description') }}
+      </p>
+    </div>
+
+    <!-- Network/HTTP error banner (validation mismatches degrade to empty). -->
+    <div
+      v-if="error"
+      class="mb-4 flex items-center justify-between gap-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-900/20"
+      role="alert"
+      data-testid="dlq-error">
+      <span class="text-sm text-red-800 dark:text-red-200">
+        {{ t('web.admin.queue.list.loadError') }}
+      </span>
+      <button
+        type="button"
+        class="inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/40"
+        @click="fetchPage(1)">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          size="4" />
+        {{ t('web.admin.queue.list.retry') }}
+      </button>
+    </div>
+
+    <!-- Replay dry-run preview failure (blocks opening the live-replay confirm). -->
+    <div
+      v-if="replayPreviewError"
+      class="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-900/50 dark:bg-red-900/20 dark:text-red-200"
+      role="alert"
+      data-testid="dlq-replay-preview-error">
+      {{ replayPreviewError }}
+    </div>
+
+    <!-- Broker-not-connected notice -->
+    <div
+      v-if="connected === false && !error"
+      class="mb-4 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-900/50 dark:bg-amber-900/20 dark:text-amber-200"
+      role="status"
+      data-testid="dlq-disconnected">
+      {{ t('web.admin.queue.list.disconnected') }}
+    </div>
+
+    <!-- Total in-scope -->
+    <div class="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <StatCard
+        :label="t('web.admin.queue.stats.total')"
+        :value="totalMessages"
+        icon="inbox-arrow-down"
+        testid="stat-total" />
+      <StatCard
+        :label="t('web.admin.queue.stats.queues')"
+        :value="dlqs.length"
+        icon="rectangle-stack"
+        testid="stat-queues" />
+    </div>
+
+    <!-- Filter -->
+    <div class="mb-4">
+      <FilterBar
+        v-model:search="searchTerm"
+        :search-placeholder="t('web.admin.queue.search.placeholder')"
+        :has-active-filters="hasActiveFilters"
+        testid="dlq-filterbar"
+        @clear="onClear" />
+    </div>
+
+    <!-- Table -->
+    <div
+      class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
+      <DataTable
+        :columns="columns"
+        :rows="filteredDlqs"
+        row-key="queue"
+        :loading="loading"
+        :empty-text="t('web.admin.queue.list.empty')"
+        clickable-rows
+        testid="dlq-table"
+        @row-click="openDetail">
+        <template #cell-queue="{ row }">
+          <span class="font-mono text-gray-900 dark:text-white">{{ shortName(row.queue) }}</span>
+          <span
+            v-if="row.error"
+            class="ml-2 rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500 dark:bg-gray-800 dark:text-gray-400">
+            {{ row.error }}
+          </span>
+        </template>
+
+        <template #cell-messages="{ row }">
+          <span
+            :class="[
+              'font-mono font-semibold',
+              row.messages > 0
+                ? 'text-red-600 dark:text-red-400'
+                : 'text-gray-400 dark:text-gray-600',
+            ]"
+            >{{ row.messages }}</span
+          >
+        </template>
+
+        <template #cell-consumers="{ row }">
+          <span class="font-mono text-xs text-gray-500 dark:text-gray-400">{{
+            row.consumers ?? '—'
+          }}</span>
+        </template>
+
+        <template #cell-actions="{ row }">
+          <div class="flex items-center justify-end gap-3">
+            <button
+              type="button"
+              :data-testid="`replay-${shortName(row.queue)}`"
+              :disabled="row.messages === 0 || replayPreviewLoading"
+              class="text-sm font-medium text-brand-600 hover:text-brand-800 focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-40 dark:text-brand-400 dark:hover:text-brand-300"
+              @click.stop="requestReplay(row)">
+              {{ t('web.admin.queue.replay.button') }}
+            </button>
+            <button
+              type="button"
+              :data-testid="`purge-${shortName(row.queue)}`"
+              :disabled="row.messages === 0"
+              class="text-sm font-medium text-red-600 hover:text-red-800 focus:outline-none focus:ring-2 focus:ring-red-500 disabled:cursor-not-allowed disabled:opacity-40 dark:text-red-400 dark:hover:text-red-300"
+              @click.stop="requestPurge(row)">
+              {{ t('web.admin.queue.purge.button') }}
+            </button>
+          </div>
+        </template>
+      </DataTable>
+    </div>
+
+    <!-- Pagination -->
+    <KitPagination
+      v-if="pagination"
+      :pagination="pagination"
+      :loading="loading"
+      class="mt-4"
+      @update:page="onPageChange"
+      @update:per-page="onPerPageChange" />
+
+    <!-- Detail drawer (peek) -->
+    <DetailDrawer
+      v-model:open="drawerOpen"
+      :title="selectedDlq ? t('web.admin.queue.drawer.title', { queue: shortName(selectedDlq.queue) }) : ''"
+      :subtitle="
+        detailRecord
+          ? t('web.admin.queue.drawer.subtitle', {
+              total: detailRecord.total_messages,
+              showing: detailRecord.showing,
+            })
+          : undefined
+      "
+      width-class="max-w-2xl"
+      testid="dlq-drawer"
+      @close="closeDrawer">
+      <!-- Loading -->
+      <div
+        v-if="detailLoading && detailMessages.length === 0"
+        class="flex items-center justify-center py-16 text-gray-500 dark:text-gray-400"
+        data-testid="dlq-drawer-loading">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          size="6"
+          class="animate-spin motion-reduce:animate-none" />
+        <span class="ml-3 text-sm">{{ t('web.COMMON.loading') }}</span>
+      </div>
+
+      <!-- Load error -->
+      <div
+        v-else-if="detailLoadFailed"
+        class="px-2 py-12 text-center"
+        role="alert"
+        data-testid="dlq-drawer-error">
+        <OIcon
+          collection="heroicons"
+          name="exclamation-triangle"
+          size="8"
+          class="mx-auto text-red-500 dark:text-red-400" />
+        <p class="mt-3 text-sm text-red-800 dark:text-red-200">
+          {{ t('web.admin.queue.drawer.loadError') }}
+        </p>
+        <button
+          type="button"
+          class="mt-4 inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-2 text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/40"
+          @click="loadDetail().catch(() => {})">
+          <OIcon
+            collection="heroicons"
+            name="arrow-path"
+            size="4" />
+          {{ t('web.admin.queue.drawer.retry') }}
+        </button>
+      </div>
+
+      <!-- Empty -->
+      <div
+        v-else-if="detailMessages.length === 0"
+        class="px-2 py-12 text-center"
+        data-testid="dlq-drawer-empty">
+        <OIcon
+          collection="heroicons"
+          name="inbox-arrow-down"
+          size="8"
+          class="mx-auto text-gray-400 dark:text-gray-600" />
+        <p class="mt-3 text-sm text-gray-500 dark:text-gray-400">
+          {{ t('web.admin.queue.drawer.empty') }}
+        </p>
+      </div>
+
+      <!-- Messages -->
+      <div
+        v-else
+        class="space-y-4"
+        data-testid="dlq-drawer-content">
+        <article
+          v-for="(msg, idx) in detailMessages"
+          :key="msg.delivery_tag ?? msg.message_id ?? idx"
+          class="rounded-lg border border-gray-200 p-4 dark:border-gray-800"
+          :data-testid="`dlq-message-${idx}`">
+          <div class="mb-2 flex flex-wrap items-center justify-between gap-2">
+            <span class="font-mono text-xs text-gray-500 dark:text-gray-400">
+              {{ msg.message_id || t('web.admin.queue.message.noId') }}
+            </span>
+            <span class="text-xs text-gray-400 dark:text-gray-500">{{ msg.age }}</span>
+          </div>
+          <dl class="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+            <div>
+              <dt class="text-gray-500 dark:text-gray-400">
+                {{ t('web.admin.queue.message.originalQueue') }}
+              </dt>
+              <dd class="font-mono text-gray-900 dark:text-gray-100">
+                {{ msg.original_queue || '—' }}
+              </dd>
+            </div>
+            <div>
+              <dt class="text-gray-500 dark:text-gray-400">
+                {{ t('web.admin.queue.message.deathReason') }}
+              </dt>
+              <dd class="font-mono text-gray-900 dark:text-gray-100">
+                {{ msg.death_reason || '—' }}
+              </dd>
+            </div>
+          </dl>
+          <p
+            v-if="msg.error"
+            class="mt-2 break-words rounded bg-red-50 px-2 py-1 font-mono text-xs text-red-700 dark:bg-red-900/20 dark:text-red-300">
+            {{ msg.error }}
+          </p>
+          <div class="mt-3">
+            <JsonViewer
+              :data="msg"
+              :expand-depth="0"
+              :testid="`dlq-message-json-${idx}`" />
+          </div>
+        </article>
+      </div>
+
+      <!-- Footer: guarded replay + purge -->
+      <template #footer>
+        <div class="flex w-full gap-3">
+          <button
+            type="button"
+            data-testid="dlq-drawer-replay"
+            :disabled="!selectedDlq || (detailRecord?.total_messages ?? 0) === 0 || replayPreviewLoading"
+            class="inline-flex flex-1 items-center justify-center gap-1 rounded-md border border-brand-300 px-3 py-2 text-sm font-semibold text-brand-700 hover:bg-brand-50 focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-brand-800 dark:text-brand-300 dark:hover:bg-brand-900/30"
+            @click="selectedDlq && requestReplay(selectedDlq)">
+            <OIcon
+              collection="heroicons"
+              name="arrow-uturn-left"
+              size="4" />
+            {{ t('web.admin.queue.replay.button') }}
+          </button>
+          <button
+            type="button"
+            data-testid="dlq-drawer-purge"
+            :disabled="!selectedDlq || (detailRecord?.total_messages ?? 0) === 0"
+            class="inline-flex flex-1 items-center justify-center gap-1 rounded-md border border-red-300 px-3 py-2 text-sm font-semibold text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-900/30"
+            @click="selectedDlq && requestPurge(selectedDlq)">
+            <OIcon
+              collection="heroicons"
+              name="trash"
+              size="4" />
+            {{ t('web.admin.queue.purge.button') }}
+          </button>
+        </div>
+      </template>
+    </DetailDrawer>
+
+    <!-- Shared guarded-action dialog: one-click replay / typed-confirmation purge. -->
+    <AdminConfirmDialog
+      v-model:open="dialogOpen"
+      :title="dialogConfig.title"
+      :description="dialogConfig.description"
+      :confirm-token="dialogConfig.confirmToken"
+      :variant="dialogConfig.variant"
+      :confirm-text="dialogConfig.confirmText"
+      :loading="mutationLoading"
+      :error="mutationError"
+      @confirm="onConfirm"
+      @cancel="onCancel" />
+  </div>
+</template>

--- a/src/apps/admin/views/AdminSessions.vue
+++ b/src/apps/admin/views/AdminSessions.vue
@@ -1,0 +1,515 @@
+<!-- src/apps/admin/views/AdminSessions.vue -->
+
+<script setup lang="ts">
+  import { storeToRefs } from 'pinia';
+  import { computed, onMounted, onBeforeUnmount, ref, watch } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  import {
+    AdminConfirmDialog,
+    DataTable,
+    DetailDrawer,
+    FilterBar,
+    JsonViewer,
+    KitPagination,
+  } from '@/apps/admin/components/kit';
+  import type { DataTableColumn } from '@/apps/admin/components/kit';
+  import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
+  import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
+  import { useAdminSessions } from '@/apps/admin/stores/useAdminSessions';
+  import type { ColonelSession } from '@/schemas/api/account/responses/colonel-sessions';
+  import {
+    colonelSessionDetailResponseSchema,
+    colonelSessionDeleteResponseSchema,
+  } from '@/schemas/api/internal/responses/colonel-sessions';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import { useApi } from '@/shared/composables/useApi';
+  import { useNotificationsStore } from '@/shared/stores/notificationsStore';
+  import { formatDisplayDateTime } from '@/utils/format';
+  import { gracefulParse } from '@/utils/schemaValidation';
+
+  /**
+   * Sessions console (ticket #40) — the first Phase-3 screen: a CLI-only power
+   * (`bin/ots session …`) surfaced in the browser for incident response, built
+   * fresh on the Slice-3 template (no `src/apps/colonel/*` / `colonelInfoStore`).
+   *
+   * - LIST + SEARCH: DataTable + FilterBar + KitPagination over the NEW
+   *   {@link useAdminSessions} store. The `GET /api/colonel/sessions` endpoint is
+   *   a thin adapter over `Onetime::Operations::Sessions::List` (bounded scan,
+   *   #2211) and supports a server-side `search` filter (email / external id).
+   * - DETAIL DRAWER: a row opens {@link DetailDrawer} loading
+   *   `GET /api/colonel/sessions/:session_id` via {@link useResourceFetch}
+   *   (`Sessions::Inspect`) — typed field read-out + raw JSON inspector.
+   * - GUARDED REVOKE (D4): revoking a session logs that user out mid-flight, so it
+   *   is gated by {@link AdminConfirmDialog} typed-confirmation (retype the session
+   *   id) in danger mode and audited SERVER-SIDE by `Sessions::Delete`. It can be
+   *   triggered from the row action or the drawer footer.
+   */
+  const { t } = useI18n();
+  const $api = useApi();
+  const notifications = useNotificationsStore();
+
+  const store = useAdminSessions();
+  const { sessions, pagination, loading, error } = storeToRefs(store);
+
+  // ---- List + search --------------------------------------------------------
+
+  const searchTerm = ref('');
+  const activeSearch = ref('');
+  const hasActiveFilters = computed(() => searchTerm.value !== '');
+
+  const columns = computed<DataTableColumn<ColonelSession>[]>(() => [
+    { key: 'session_id', label: t('web.admin.sessions.columns.sessionId') },
+    { key: 'authenticated', label: t('web.admin.sessions.columns.authenticated'), align: 'center' },
+    { key: 'email', label: t('web.admin.sessions.columns.email') },
+    { key: 'external_id', label: t('web.admin.sessions.columns.externalId') },
+    { key: 'ip_address', label: t('web.admin.sessions.columns.ipAddress') },
+    { key: 'created_at', label: t('web.admin.sessions.columns.created') },
+    { key: 'actions', label: t('web.admin.sessions.columns.actions'), align: 'right' },
+  ]);
+
+  /** created_at is a bare Unix-second number (authenticated_at). */
+  function createdLabel(createdAt: number | null): string {
+    if (!createdAt) return t('web.admin.sessions.detail.unknown');
+    return formatDisplayDateTime(new Date(createdAt * 1000));
+  }
+
+  function emailLabel(email: string | null): string {
+    return email || t('web.admin.sessions.anonymous');
+  }
+
+  /** Fetch one server page with the active search term. Errors surface via the store. */
+  async function fetchPage(targetPage = 1): Promise<void> {
+    try {
+      await store.fetchPage(targetPage, activeSearch.value || undefined);
+    } catch {
+      // Network/HTTP failure is captured in `store.error`; the banner + retry
+      // button below handle it. Swallow so it doesn't become unhandled.
+    }
+  }
+
+  // Debounce search input so we issue one request per pause, not per keystroke.
+  let searchTimer: ReturnType<typeof setTimeout> | null = null;
+  watch(searchTerm, (value) => {
+    if (searchTimer) clearTimeout(searchTimer);
+    searchTimer = setTimeout(() => {
+      activeSearch.value = value.trim();
+      fetchPage(1);
+    }, 300);
+  });
+  onBeforeUnmount(() => {
+    if (searchTimer) clearTimeout(searchTimer);
+  });
+
+  function onClear(): void {
+    searchTerm.value = '';
+    activeSearch.value = '';
+    fetchPage(1);
+  }
+
+  function onPageChange(targetPage: number): void {
+    fetchPage(targetPage);
+  }
+
+  function onPerPageChange(perPage: number): void {
+    store.perPage = perPage;
+    fetchPage(1);
+  }
+
+  // ---- Detail drawer (inspect) ----------------------------------------------
+
+  const drawerOpen = ref(false);
+  /** The row that opened the drawer — the source of the detail id. */
+  const selectedSession = ref<ColonelSession | null>(null);
+
+  const detailUrl = (): string =>
+    `/api/colonel/sessions/${encodeURIComponent(selectedSession.value?.session_id ?? '')}`;
+
+  const {
+    data: detailData,
+    loading: detailLoading,
+    error: detailError,
+    validationError: detailValidationError,
+    notFound: detailNotFound,
+    load: loadDetail,
+  } = useResourceFetch({
+    url: detailUrl,
+    schema: colonelSessionDetailResponseSchema,
+    context: 'ColonelSessionDetailResponse',
+  });
+
+  const detailRecord = computed(() => detailData.value?.record ?? null);
+
+  /** A non-404 network/HTTP failure, or a Zod contract mismatch. */
+  const detailLoadFailed = computed(
+    () =>
+      (detailError.value !== null && !detailNotFound.value) ||
+      detailValidationError.value !== null
+  );
+
+  function openDetail(row: ColonelSession): void {
+    selectedSession.value = row;
+    resetRevoke();
+    drawerOpen.value = true;
+    loadDetail().catch(() => {});
+  }
+
+  function closeDrawer(): void {
+    drawerOpen.value = false;
+    selectedSession.value = null;
+  }
+
+  const yesNo = (value: boolean): string =>
+    value ? t('web.admin.sessions.detail.yes') : t('web.admin.sessions.detail.no');
+
+  const none = (value: unknown): string =>
+    value === null || value === undefined || value === ''
+      ? t('web.admin.sessions.detail.none')
+      : String(value);
+
+  /** Human TTL: -1 = no expiry, <= 0 = expired, else seconds. */
+  function ttlLabel(ttl: number | null): string {
+    if (ttl === null || ttl === undefined) return t('web.admin.sessions.detail.none');
+    if (ttl === -1) return t('web.admin.sessions.detail.noExpiry');
+    if (ttl <= 0) return t('web.admin.sessions.detail.expired');
+    return t('web.admin.sessions.detail.ttlSeconds', { seconds: ttl });
+  }
+
+  /** Field rows for the session record read-out. */
+  const sessionFields = computed(() => {
+    const r = detailRecord.value;
+    if (!r) return [];
+    return [
+      { key: 'sessionId', label: t('web.admin.sessions.fields.sessionId'), value: r.session_id },
+      { key: 'key', label: t('web.admin.sessions.fields.key'), value: r.key },
+      { key: 'ttl', label: t('web.admin.sessions.fields.ttl'), value: ttlLabel(r.ttl) },
+      {
+        key: 'authenticated',
+        label: t('web.admin.sessions.fields.authenticated'),
+        value: yesNo(r.authenticated),
+      },
+      { key: 'email', label: t('web.admin.sessions.fields.email'), value: none(r.email) },
+      { key: 'externalId', label: t('web.admin.sessions.fields.externalId'), value: none(r.external_id) },
+      { key: 'accountId', label: t('web.admin.sessions.fields.accountId'), value: none(r.account_id) },
+      { key: 'role', label: t('web.admin.sessions.fields.role'), value: none(r.role) },
+      { key: 'locale', label: t('web.admin.sessions.fields.locale'), value: none(r.locale) },
+      { key: 'ipAddress', label: t('web.admin.sessions.fields.ipAddress'), value: none(r.ip_address) },
+      {
+        key: 'authenticatedAt',
+        label: t('web.admin.sessions.fields.authenticatedAt'),
+        value: r.authenticated_at
+          ? formatDisplayDateTime(new Date(r.authenticated_at * 1000))
+          : t('web.admin.sessions.detail.none'),
+      },
+      {
+        key: 'authenticatedBy',
+        label: t('web.admin.sessions.fields.authenticatedBy'),
+        value: none(r.authenticated_by),
+      },
+      {
+        key: 'activeSessionId',
+        label: t('web.admin.sessions.fields.activeSessionId'),
+        value: none(r.active_session_id),
+      },
+    ];
+  });
+
+  // ---- Guarded revoke (D4) --------------------------------------------------
+
+  const revokeDialogOpen = ref(false);
+  /** The session id the confirm dialog is gating (retype token + request target). */
+  const revokeTarget = ref('');
+
+  const {
+    loading: revokeLoading,
+    error: revokeError,
+    run: runRevoke,
+    reset: resetRevoke,
+  } = useAdminMutation(async () => {
+    const sessionId = revokeTarget.value;
+    if (!sessionId) throw new Error('No session selected');
+    const response = await $api.delete(
+      `/api/colonel/sessions/${encodeURIComponent(sessionId)}`
+    );
+    // A 2xx means the session was revoked server-side regardless of ack shape;
+    // the parse keeps the contract a live tripwire without failing the action.
+    gracefulParse(
+      colonelSessionDeleteResponseSchema,
+      response.data,
+      'ColonelSessionDeleteResponse'
+    );
+  });
+
+  function requestRevoke(sessionId: string): void {
+    revokeTarget.value = sessionId;
+    resetRevoke();
+    revokeDialogOpen.value = true;
+  }
+
+  async function onRevokeConfirm(): Promise<void> {
+    const revokedId = revokeTarget.value;
+    const ok = await runRevoke();
+    if (!ok) return; // Failure message stays in the dialog for retry/cancel.
+
+    revokeDialogOpen.value = false;
+    notifications.show(t('web.admin.sessions.revoke.success'), 'success');
+
+    // If the revoked session is the one open in the drawer, close it.
+    if (selectedSession.value?.session_id === revokedId) {
+      closeDrawer();
+    }
+    // The revoked row is gone — refresh the current page.
+    await fetchPage(pagination.value?.page ?? 1);
+  }
+
+  function onRevokeCancel(): void {
+    revokeDialogOpen.value = false;
+    resetRevoke();
+  }
+
+  onMounted(() => fetchPage(1));
+</script>
+
+<template>
+  <div class="mx-auto max-w-6xl">
+    <!-- Page header -->
+    <div class="mb-6">
+      <h2 class="font-brand text-2xl font-semibold text-gray-900 dark:text-white">
+        {{ t('web.admin.sessions.title') }}
+      </h2>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.sessions.description') }}
+      </p>
+    </div>
+
+    <!-- Network/HTTP error banner (validation mismatches degrade to empty). -->
+    <div
+      v-if="error"
+      class="mb-4 flex items-center justify-between gap-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-900/20"
+      role="alert"
+      data-testid="sessions-error">
+      <span class="text-sm text-red-800 dark:text-red-200">
+        {{ t('web.admin.sessions.list.loadError') }}
+      </span>
+      <button
+        type="button"
+        class="inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/40"
+        @click="fetchPage(1)">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          size="4" />
+        {{ t('web.admin.sessions.list.retry') }}
+      </button>
+    </div>
+
+    <!-- Search -->
+    <div class="mb-4">
+      <FilterBar
+        v-model:search="searchTerm"
+        :search-placeholder="t('web.admin.sessions.search.placeholder')"
+        :has-active-filters="hasActiveFilters"
+        testid="sessions-filterbar"
+        @clear="onClear" />
+    </div>
+
+    <!-- Table -->
+    <div
+      class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
+      <DataTable
+        :columns="columns"
+        :rows="sessions"
+        row-key="session_id"
+        :loading="loading"
+        :empty-text="t('web.admin.sessions.list.empty')"
+        clickable-rows
+        testid="sessions-table"
+        @row-click="openDetail">
+        <template #cell-session_id="{ row }">
+          <span class="font-mono text-gray-900 dark:text-white">{{ row.session_id }}</span>
+        </template>
+
+        <template #cell-authenticated="{ row }">
+          <OIcon
+            v-if="row.authenticated"
+            collection="heroicons"
+            name="check-circle"
+            size="5"
+            class="inline text-green-600 dark:text-green-400"
+            :aria-label="t('web.admin.sessions.status.authenticated')" />
+          <span
+            v-else
+            class="text-gray-400 dark:text-gray-600"
+            :aria-label="t('web.admin.sessions.status.anonymous')"
+            >—</span
+          >
+        </template>
+
+        <template #cell-email="{ row }">
+          <span class="text-gray-900 dark:text-white">{{ emailLabel(row.email) }}</span>
+        </template>
+
+        <template #cell-external_id="{ row }">
+          <span class="font-mono text-xs text-gray-500 dark:text-gray-400">{{ row.external_id || '—' }}</span>
+        </template>
+
+        <template #cell-ip_address="{ row }">
+          <span class="font-mono text-xs text-gray-500 dark:text-gray-400">{{ row.ip_address || '—' }}</span>
+        </template>
+
+        <template #cell-created_at="{ row }">
+          {{ createdLabel(row.created_at) }}
+        </template>
+
+        <template #cell-actions="{ row }">
+          <button
+            type="button"
+            :data-testid="`revoke-${row.session_id}`"
+            class="text-sm font-medium text-red-600 hover:text-red-800 focus:outline-none focus:ring-2 focus:ring-red-500 dark:text-red-400 dark:hover:text-red-300"
+            @click.stop="requestRevoke(row.session_id)">
+            {{ t('web.admin.sessions.revoke.button') }}
+          </button>
+        </template>
+      </DataTable>
+    </div>
+
+    <!-- Pagination -->
+    <KitPagination
+      v-if="pagination"
+      :pagination="pagination"
+      :loading="loading"
+      class="mt-4"
+      @update:page="onPageChange"
+      @update:per-page="onPerPageChange" />
+
+    <!-- Detail drawer (inspect) -->
+    <DetailDrawer
+      v-model:open="drawerOpen"
+      :title="selectedSession ? t('web.admin.sessions.drawer.title', { id: selectedSession.session_id }) : ''"
+      :subtitle="selectedSession ? emailLabel(selectedSession.email) : undefined"
+      width-class="max-w-lg"
+      testid="session-drawer"
+      @close="closeDrawer">
+      <!-- Loading -->
+      <div
+        v-if="detailLoading && !detailRecord"
+        class="flex items-center justify-center py-16 text-gray-500 dark:text-gray-400"
+        data-testid="session-drawer-loading">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          size="6"
+          class="animate-spin motion-reduce:animate-none" />
+        <span class="ml-3 text-sm">{{ t('web.COMMON.loading') }}</span>
+      </div>
+
+      <!-- Not found -->
+      <div
+        v-else-if="detailNotFound"
+        class="px-2 py-12 text-center"
+        data-testid="session-drawer-not-found">
+        <OIcon
+          collection="heroicons"
+          name="finger-print"
+          size="8"
+          class="mx-auto text-gray-400 dark:text-gray-600" />
+        <h3 class="mt-3 text-base font-medium text-gray-900 dark:text-white">
+          {{ t('web.admin.sessions.drawer.notFound') }}
+        </h3>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          {{ t('web.admin.sessions.drawer.notFoundDescription') }}
+        </p>
+      </div>
+
+      <!-- Load error -->
+      <div
+        v-else-if="detailLoadFailed"
+        class="px-2 py-12 text-center"
+        role="alert"
+        data-testid="session-drawer-error">
+        <OIcon
+          collection="heroicons"
+          name="exclamation-triangle"
+          size="8"
+          class="mx-auto text-red-500 dark:text-red-400" />
+        <p class="mt-3 text-sm text-red-800 dark:text-red-200">
+          {{ t('web.admin.sessions.drawer.loadError') }}
+        </p>
+        <button
+          type="button"
+          class="mt-4 inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-2 text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/40"
+          @click="loadDetail().catch(() => {})">
+          <OIcon
+            collection="heroicons"
+            name="arrow-path"
+            size="4" />
+          {{ t('web.admin.sessions.drawer.retry') }}
+        </button>
+      </div>
+
+      <!-- Loaded -->
+      <div
+        v-else-if="detailRecord"
+        class="space-y-6"
+        data-testid="session-drawer-content">
+        <!-- Session record -->
+        <section>
+          <h3 class="mb-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.sessions.sections.session') }}
+          </h3>
+          <dl class="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2">
+            <div
+              v-for="field in sessionFields"
+              :key="field.key"
+              :data-testid="`session-field-${field.key}`">
+              <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">{{ field.label }}</dt>
+              <dd class="mt-0.5 break-words font-mono text-sm text-gray-900 dark:text-gray-100">
+                {{ field.value }}
+              </dd>
+            </div>
+          </dl>
+        </section>
+
+        <!-- Raw inspector -->
+        <section>
+          <h3 class="mb-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.sessions.sections.raw') }}
+          </h3>
+          <JsonViewer
+            :data="detailData?.details?.data"
+            :expand-depth="1"
+            testid="session-drawer-json" />
+        </section>
+      </div>
+
+      <!-- Footer: guarded revoke -->
+      <template #footer>
+        <button
+          type="button"
+          data-testid="session-revoke-button"
+          :disabled="!selectedSession"
+          class="inline-flex w-full items-center justify-center gap-1 rounded-md border border-red-300 px-3 py-2 text-sm font-semibold text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-900/30"
+          @click="selectedSession && requestRevoke(selectedSession.session_id)">
+          <OIcon
+            collection="heroicons"
+            name="trash"
+            size="4" />
+          {{ t('web.admin.sessions.revoke.button') }}
+        </button>
+      </template>
+    </DetailDrawer>
+
+    <!-- Typed-confirmation revoke gate (danger). -->
+    <AdminConfirmDialog
+      v-model:open="revokeDialogOpen"
+      :title="t('web.admin.sessions.revoke.confirmTitle')"
+      :description="t('web.admin.sessions.revoke.confirmDescription', { id: revokeTarget })"
+      :confirm-token="revokeTarget"
+      variant="danger"
+      :confirm-text="t('web.admin.sessions.revoke.button')"
+      :loading="revokeLoading"
+      :error="revokeError"
+      @confirm="onRevokeConfirm"
+      @cancel="onRevokeCancel" />
+  </div>
+</template>

--- a/src/schemas/api/account/responses/colonel-banner.ts
+++ b/src/schemas/api/account/responses/colonel-banner.ts
@@ -1,0 +1,58 @@
+// src/schemas/api/account/responses/colonel-banner.ts
+//
+// Colonel (Admin) broadcast banner — NEW get/set/clear schemas (ticket #41).
+//
+// The banner is a CLI-only power today (`bin/ots banner`); there was no colonel
+// endpoint and therefore no existing frontend schema to reuse. These are all-new
+// shapes (the Zod tripwire — new schemas only), kept in a per-resource file so
+// this screen never edits another screen's contract (CONTRACT 2 / 3).
+//
+// Shapes verified against the live logic classes
+// (apps/api/colonel/logic/colonel/{get,set,clear}_banner.rb):
+//   - `content` is the raw HTML body (nullable when no banner is set).
+//   - `ttl` is seconds-remaining, or null for a persistent / absent banner
+//     (GetBanner collapses Redis's -1/-2 sentinels to null).
+//   - `active` is the server's own is-set flag.
+
+import { z } from 'zod';
+
+// ============================================================================
+// GetBanner — current banner (GET /api/colonel/banner)
+// ============================================================================
+
+/** The current banner record (GetBanner `record`), also echoed by SetBanner. */
+export const colonelBannerRecordSchema = z.object({
+  content: z.string().nullable(),
+  ttl: z.number().nullable(),
+  active: z.boolean(),
+});
+
+/** GetBanner `details`: the backing key + database (informational). */
+export const colonelBannerDetailsSchema = z.object({
+  key: z.string(),
+  database: z.number(),
+});
+
+// ============================================================================
+// SetBanner / ClearBanner — mutation acks
+// ============================================================================
+
+/** Shared mutation `details`: a human-readable ack message. */
+export const colonelBannerMutationDetailsSchema = z.object({
+  message: z.string(),
+});
+
+/** The clear confirmation (ClearBanner `record`). */
+export const colonelBannerClearRecordSchema = z.object({
+  cleared: z.boolean(),
+  active: z.boolean(),
+});
+
+// ============================================================================
+// Type Exports
+// ============================================================================
+
+export type ColonelBannerRecord = z.infer<typeof colonelBannerRecordSchema>;
+export type ColonelBannerDetails = z.infer<typeof colonelBannerDetailsSchema>;
+export type ColonelBannerMutationDetails = z.infer<typeof colonelBannerMutationDetailsSchema>;
+export type ColonelBannerClearRecord = z.infer<typeof colonelBannerClearRecordSchema>;

--- a/src/schemas/api/account/responses/colonel-billing.ts
+++ b/src/schemas/api/account/responses/colonel-billing.ts
@@ -1,0 +1,93 @@
+// src/schemas/api/account/responses/colonel-billing.ts
+//
+// Per-resource colonel/admin schemas for the Billing catalog drift view
+// (ticket #45, Phase 3).
+//
+// NEW schemas only — the frozen colonel contracts in ./colonel.ts are
+// UNTOUCHED (the Zod tripwire, epic non-goal). This surfaces the READ-ONLY
+// billing catalog / plan-drift capability inspected via CLI today
+// (`bin/ots billing plans` + the catalog ops); there was no old colonel screen.
+// Distinct `billing` namespace so it never collides with any other colonel
+// per-resource schema file.
+//
+// Shapes verified against the colonel logic class
+// (apps/api/colonel/logic/colonel/get_billing_catalog.rb), a thin READ adapter
+// over the incumbent Billing::Plan source (list_plans + list_plans_from_config).
+// Nothing here mutates, so there is no ack/mutation schema.
+
+import { z } from 'zod';
+
+// ============================================================================
+// PlanEntry — one normalized catalog plan (same shape on both the config and
+// live sides so drift compares like-for-like).
+// ============================================================================
+
+/**
+ * A single plan in the catalog. `limits` is a flattened map of quota keys
+ * (e.g. "teams.max") to their string values ("0" / "unlimited"); the backend
+ * stringifies both sides so a config "0" and a cached "0" compare equal.
+ * `description` is nullable — a plan may carry none.
+ */
+export const colonelBillingPlanSchema = z.object({
+  planid: z.string(),
+  name: z.string().nullable(),
+  tier: z.string().nullable(),
+  tenancy: z.string().nullable(),
+  region: z.string().nullable(),
+  display_order: z.number(),
+  show_on_plans_page: z.boolean(),
+  description: z.string().nullable(),
+  entitlements: z.array(z.string()),
+  limits: z.record(z.string(), z.string()),
+});
+
+// ============================================================================
+// Drift — the computed config-vs-live difference, keyed by planid.
+// ============================================================================
+
+/** One plan present on both sides whose comparable fields diverge. */
+export const colonelBillingDriftChangeSchema = z.object({
+  planid: z.string(),
+  name: z.string().nullable(),
+  /** Which fields drift: any of "entitlements" / "limits" / "tier" / "name". */
+  fields: z.array(z.string()),
+});
+
+/**
+ * Drift summary. `in_sync` is true only when all three lists are empty.
+ * `only_in_config` / `only_in_live` are planid lists; `changed` carries the
+ * per-plan field-level divergence.
+ */
+export const colonelBillingDriftSchema = z.object({
+  in_sync: z.boolean(),
+  only_in_config: z.array(z.string()),
+  only_in_live: z.array(z.string()),
+  changed: z.array(colonelBillingDriftChangeSchema),
+});
+
+// ============================================================================
+// Catalog details — the whole read-out.
+// ============================================================================
+
+/**
+ * Billing catalog details. `source` is "stripe" when the live cache is
+ * populated (drift is meaningful) or "local_config" when it is empty (dev / no
+ * Stripe — live_plans is [] and drift cannot be evaluated). `stripe_configured`
+ * mirrors that: live_plans.length > 0.
+ */
+export const colonelBillingCatalogDetailsSchema = z.object({
+  source: z.enum(['stripe', 'local_config']),
+  stripe_configured: z.boolean(),
+  config_plans: z.array(colonelBillingPlanSchema),
+  live_plans: z.array(colonelBillingPlanSchema),
+  drift: colonelBillingDriftSchema,
+});
+
+// ============================================================================
+// Type Exports
+// ============================================================================
+
+export type ColonelBillingPlan = z.infer<typeof colonelBillingPlanSchema>;
+export type ColonelBillingDriftChange = z.infer<typeof colonelBillingDriftChangeSchema>;
+export type ColonelBillingDrift = z.infer<typeof colonelBillingDriftSchema>;
+export type ColonelBillingCatalogDetails = z.infer<typeof colonelBillingCatalogDetailsSchema>;

--- a/src/schemas/api/account/responses/colonel-domaintoolbox.ts
+++ b/src/schemas/api/account/responses/colonel-domaintoolbox.ts
@@ -1,0 +1,161 @@
+// src/schemas/api/account/responses/colonel-domaintoolbox.ts
+//
+// Per-resource colonel/admin schemas for the Domain Toolbox (ticket #43).
+//
+// NEW schemas only — the frozen colonel contracts in ./colonel.ts and the
+// Phase-2 verify schemas in ./colonel-domains.ts are UNTOUCHED (the Zod
+// tripwire, epic non-goal). This toolbox surfaces the CLI-only domain toolbox
+// (`bin/ots domains {orphaned,probe,repair,transfer}`) — there was no old colonel
+// screen for these verbs. Distinct `domaintoolbox` namespace so it never collides
+// with Slice-4's colonel-domains.ts.
+//
+// Shapes verified against the live colonel logic classes
+// (apps/api/colonel/logic/colonel/{list_orphaned_domains,probe_domain,
+// repair_domain,transfer_domain}.rb), thin adapters over
+// Onetime::Operations::Domains::{OrphanedScan,Probe,Repair,Transfer}.
+//
+// The domain re-verify action is NOT redefined here — it REUSES the existing
+// colonel-domains.ts verify schemas + `/api/colonel/domains/:extid/verify`
+// endpoint (CONTRACT 3 — reuse over duplication).
+
+import { paginationSchema } from '@/schemas/api/account/responses/colonel';
+import { transforms } from '@/schemas/transforms';
+import { z } from 'zod';
+
+// ============================================================================
+// OrphanedScan — GET /api/colonel/domains/orphaned
+// ============================================================================
+
+/**
+ * One orphaned-domain summary row (a domain with no owning organization).
+ * `created` arrives as a Unix-epoch number and is coerced to Date (nullable).
+ */
+export const colonelOrphanedDomainSchema = z.object({
+  domain_id: z.string(),
+  extid: z.string(),
+  display_domain: z.string(),
+  verification_state: z.string(),
+  verified: z.boolean(),
+  created: transforms.fromNumber.toDateNullable,
+});
+
+/** Orphaned-scan response details: rows + the shared pagination envelope. */
+export const colonelOrphanedDomainsDetailsSchema = z.object({
+  domains: z.array(colonelOrphanedDomainSchema),
+  pagination: paginationSchema,
+});
+
+// ============================================================================
+// Probe — GET /api/colonel/domains/:extid/probe
+// ============================================================================
+
+/**
+ * The HTTP arm of a probe. On a successful connection `status_code` /
+ * `status_message` / `success` are present; on a network/SSL failure `error` /
+ * `message` are present instead. All optional so both branches parse.
+ */
+export const colonelDomainProbeHttpSchema = z.object({
+  status_code: z.number().optional(),
+  status_message: z.string().optional(),
+  success: z.boolean().optional(),
+  error: z.string().optional(),
+  message: z.string().optional(),
+});
+
+/**
+ * The TLS-certificate arm of a probe. Present only when the connection was
+ * established far enough to read a cert; nullable + every field optional so the
+ * error branches (no cert, SSL error) parse cleanly.
+ */
+export const colonelDomainProbeSslSchema = z
+  .object({
+    valid: z.boolean().optional(),
+    subject: z.string().optional(),
+    issuer: z.string().optional(),
+    not_before: z.string().optional(),
+    not_after: z.string().optional(),
+    days_until_expiry: z.number().optional(),
+    expired: z.boolean().optional(),
+    not_yet_valid: z.boolean().optional(),
+    error: z.string().optional(),
+  })
+  .nullable();
+
+/** Probe `record`: the resolved domain's public identity. */
+export const colonelDomainProbeRecordSchema = z.object({
+  extid: z.string(),
+  display_domain: z.string(),
+});
+
+/**
+ * Probe `details`: the probe result. `health` is the op's honest classification
+ * (healthy / ssl_expired / dns_error / timeout / …). `ssl` is optional because
+ * some failure branches (connection refused/reset, timeout) never reach a cert.
+ */
+export const colonelDomainProbeDetailsSchema = z.object({
+  timestamp: z.string(),
+  domain: z.string(),
+  url: z.string(),
+  http: colonelDomainProbeHttpSchema,
+  ssl: colonelDomainProbeSslSchema.optional(),
+  health: z.string(),
+});
+
+// ============================================================================
+// Repair — POST /api/colonel/domains/:extid/repair
+// ============================================================================
+
+/** Repair `record`: the target domain's identity. */
+export const colonelDomainRepairRecordSchema = z.object({
+  domain_id: z.string(),
+  extid: z.string(),
+  display_domain: z.string(),
+});
+
+/**
+ * Repair `details`. `status` is the op's outcome symbol as a string
+ * (no_issues / needs_org / org_not_found / planned / repaired). `issues` lists
+ * the relationship problems found; `repairs_applied` lists what was fixed (empty
+ * on a dry-run preview). `dry_run` echoes whether this was a preview.
+ */
+export const colonelDomainRepairDetailsSchema = z.object({
+  status: z.string(),
+  dry_run: z.boolean(),
+  issues: z.array(z.string()),
+  repairs_applied: z.array(z.string()),
+});
+
+// ============================================================================
+// Transfer — POST /api/colonel/domains/:extid/transfer
+// ============================================================================
+
+/** Transfer `record`: the target domain's identity. */
+export const colonelDomainTransferRecordSchema = z.object({
+  domain_id: z.string(),
+  extid: z.string(),
+  display_domain: z.string(),
+});
+
+/**
+ * Transfer `details`. `status` is the op outcome string (planned / transferred /
+ * mismatch). from/to org ids are strings ('' when orphaned); org names are
+ * nullable (an org may carry no display name).
+ */
+export const colonelDomainTransferDetailsSchema = z.object({
+  status: z.string(),
+  dry_run: z.boolean(),
+  from_org_id: z.string(),
+  from_org_name: z.string().nullable(),
+  to_org_id: z.string(),
+  to_org_name: z.string().nullable(),
+});
+
+// ============================================================================
+// Type Exports
+// ============================================================================
+
+export type ColonelOrphanedDomain = z.infer<typeof colonelOrphanedDomainSchema>;
+export type ColonelDomainProbeRecord = z.infer<typeof colonelDomainProbeRecordSchema>;
+export type ColonelDomainProbeDetails = z.infer<typeof colonelDomainProbeDetailsSchema>;
+export type ColonelDomainRepairDetails = z.infer<typeof colonelDomainRepairDetailsSchema>;
+export type ColonelDomainTransferDetails = z.infer<typeof colonelDomainTransferDetailsSchema>;

--- a/src/schemas/api/account/responses/colonel-emailtools.ts
+++ b/src/schemas/api/account/responses/colonel-emailtools.ts
@@ -1,0 +1,153 @@
+// src/schemas/api/account/responses/colonel-emailtools.ts
+//
+// Per-resource colonel/admin schemas for the Email + Rate-limit Tools screen
+// (ticket #44).
+//
+// NEW schemas only — the frozen colonel contracts in ./colonel.ts are UNTOUCHED
+// (the Zod tripwire, epic non-goal). These surface CLI-only powers
+// (`bin/ots email {templates,preview,test}` and `bin/ots ratelimit keys`) that
+// never had a colonel endpoint, so there is nothing to reuse. Distinct
+// `emailtools` namespace so this screen never collides with another's contract
+// (CONTRACT 2 / 3).
+//
+// Shapes verified against the live colonel logic classes
+// (apps/api/colonel/logic/colonel/{list_email_templates,preview_email_template,
+// send_test_email,list_rate_limiters,inspect_rate_limit,reset_rate_limit}.rb),
+// thin adapters over Onetime::Operations::Email::* and
+// Onetime::Operations::RateLimit::*.
+
+import { z } from 'zod';
+
+// ============================================================================
+// Email templates — GET /api/colonel/email/templates
+// ============================================================================
+
+/** One template summary row (name + rendered formats). */
+export const colonelEmailTemplateSchema = z.object({
+  name: z.string(),
+  class_name: z.string(),
+  formats: z.array(z.string()),
+});
+
+/** ListEmailTemplates `record`: the picker's template list. */
+export const colonelEmailTemplatesRecordSchema = z.object({
+  templates: z.array(colonelEmailTemplateSchema),
+});
+
+/** ListEmailTemplates `details`: informational count. */
+export const colonelEmailTemplatesDetailsSchema = z.object({
+  count: z.number(),
+});
+
+// ============================================================================
+// Template preview — GET /api/colonel/email/templates/:template/preview
+// ============================================================================
+
+/** PreviewEmailTemplate `record`: what was rendered. */
+export const colonelEmailPreviewRecordSchema = z.object({
+  template: z.string(),
+  locale: z.string(),
+  format: z.string(),
+});
+
+/** PreviewEmailTemplate `details`: the rendered body (text or HTML source). */
+export const colonelEmailPreviewDetailsSchema = z.object({
+  body: z.string(),
+});
+
+// ============================================================================
+// Test send — POST /api/colonel/email/test
+// ============================================================================
+
+/** SendTestEmail `record`: the send outcome. `status` is dry_run / sent / enqueued. */
+export const colonelEmailTestRecordSchema = z.object({
+  to: z.string(),
+  status: z.string(),
+  sent: z.boolean(),
+});
+
+/** SendTestEmail `details`: the exact diagnostic email that was (or would be) sent. */
+export const colonelEmailTestDetailsSchema = z.object({
+  provider: z.string(),
+  host: z.string(),
+  from: z.string(),
+  subject: z.string(),
+  text_body: z.string(),
+  timestamp: z.string(),
+});
+
+// ============================================================================
+// Rate limiters — GET /api/colonel/ratelimit/limiters
+// ============================================================================
+
+/** One known limiter (kind + human subject description). */
+export const colonelRateLimiterSchema = z.object({
+  kind: z.string(),
+  subject: z.string(),
+});
+
+/** ListRateLimiters `record`: the inspect panel's limiter picker. */
+export const colonelRateLimitersRecordSchema = z.object({
+  limiters: z.array(colonelRateLimiterSchema),
+});
+
+/** ListRateLimiters `details`: informational count. */
+export const colonelRateLimitersDetailsSchema = z.object({
+  count: z.number(),
+});
+
+// ============================================================================
+// Rate-limit inspect — GET /api/colonel/ratelimit/inspect
+// ============================================================================
+
+/**
+ * State of one backing Redis key. `ttl` is seconds-remaining or null (no expiry
+ * / absent — the server collapses Redis's -1/-2 sentinels). `value` is the raw
+ * stored string or null when the key is unset.
+ */
+export const colonelRateLimitEntrySchema = z.object({
+  key: z.string(),
+  ttl: z.number().nullable(),
+  value: z.string().nullable(),
+  exists: z.boolean(),
+});
+
+/** InspectRateLimit `record`: the inspected limiter + subject. */
+export const colonelRateLimitInspectRecordSchema = z.object({
+  kind: z.string(),
+  subject: z.string(),
+});
+
+/** InspectRateLimit `details`: per-key state. */
+export const colonelRateLimitInspectDetailsSchema = z.object({
+  entries: z.array(colonelRateLimitEntrySchema),
+});
+
+// ============================================================================
+// Rate-limit reset — POST /api/colonel/ratelimit/reset
+// ============================================================================
+
+/** ResetRateLimit `record`: the reset outcome. */
+export const colonelRateLimitResetRecordSchema = z.object({
+  kind: z.string(),
+  subject: z.string(),
+  cleared: z.boolean(),
+});
+
+/** ResetRateLimit `details`: how many keys were removed + an ack message. */
+export const colonelRateLimitResetDetailsSchema = z.object({
+  deleted: z.number(),
+  message: z.string(),
+});
+
+// ============================================================================
+// Type Exports
+// ============================================================================
+
+export type ColonelEmailTemplate = z.infer<typeof colonelEmailTemplateSchema>;
+export type ColonelEmailPreviewDetails = z.infer<typeof colonelEmailPreviewDetailsSchema>;
+export type ColonelEmailTestRecord = z.infer<typeof colonelEmailTestRecordSchema>;
+export type ColonelEmailTestDetails = z.infer<typeof colonelEmailTestDetailsSchema>;
+export type ColonelRateLimiter = z.infer<typeof colonelRateLimiterSchema>;
+export type ColonelRateLimitEntry = z.infer<typeof colonelRateLimitEntrySchema>;
+export type ColonelRateLimitResetDetails = z.infer<typeof colonelRateLimitResetDetailsSchema>;

--- a/src/schemas/api/account/responses/colonel-queue.ts
+++ b/src/schemas/api/account/responses/colonel-queue.ts
@@ -1,0 +1,131 @@
+// src/schemas/api/account/responses/colonel-queue.ts
+//
+// Per-resource colonel/admin schemas for the Queue DLQ console (ticket #42).
+//
+// NEW schemas only — the frozen colonel contracts in ./colonel.ts (including the
+// existing read-only `queueMetrics`) are untouched (the Zod tripwire, epic
+// non-goal). These shapes are for the net-new dead-letter-queue endpoints (there
+// was no old colonel queue-DLQ screen — CLI-only until now):
+//
+//   - ListDlqs        → GET  /api/colonel/queues/dlq                  (summary list)
+//   - GetDlqMessages  → GET  /api/colonel/queues/dlq/:queue           (peek drawer)
+//   - ReplayDlq       → POST /api/colonel/queues/dlq/:queue/replay    (guarded retry)
+//   - PurgeDlq        → POST /api/colonel/queues/dlq/:queue/purge      (guarded purge)
+//
+// Shapes verified against the live logic classes
+// (apps/api/colonel/logic/colonel/{list_dlqs,get_dlq_messages,replay_dlq,purge_dlq}.rb),
+// which are thin adapters over Onetime::Operations::Dlq::{List,Peek,Replay,Purge}.
+
+import { paginationSchema } from '@/schemas/api/account/responses/colonel';
+import { z } from 'zod';
+
+// ============================================================================
+// ListDlqs — per-queue summary row + details
+// ============================================================================
+
+/**
+ * A single dead-letter queue summary row (ListDlqs `details.dlqs[]`). `queue` is
+ * the full DLQ name (e.g. `dlq.billing.event`); `consumers` is absent on a
+ * queue that is configured but not yet declared in the broker (surfaced instead
+ * as `error: 'not declared'`), so both are optional/nullable.
+ */
+export const colonelDlqSummarySchema = z.object({
+  queue: z.string(),
+  messages: z.number(),
+  consumers: z.number().optional(),
+  error: z.string().optional(),
+});
+
+/** DLQ summary list details: rows + the shared pagination envelope + broker flag. */
+export const colonelDlqListDetailsSchema = z.object({
+  dlqs: z.array(colonelDlqSummarySchema),
+  pagination: paginationSchema,
+  connected: z.boolean().nullable().optional(),
+});
+
+// ============================================================================
+// GetDlqMessages — peeked messages for the detail drawer
+// ============================================================================
+
+/**
+ * One peeked dead-letter message (GetDlqMessages `details.messages[]`). All the
+ * death-diagnosis fields are nullable because a raw message may lack an `x-death`
+ * header. `payload_preview` is truncated to ~200 chars by the op (a sample for
+ * triage — the CLI `queue dlq show` exposes the full payload).
+ */
+export const colonelDlqMessageSchema = z.object({
+  delivery_tag: z.union([z.string(), z.number()]).nullable().optional(),
+  message_id: z.string().nullable(),
+  timestamp: z.number().nullable(),
+  age: z.string(),
+  original_queue: z.string().nullable(),
+  death_reason: z.string().nullable(),
+  death_count: z.number().nullable(),
+  error: z.string().nullable(),
+  content_type: z.string().nullable(),
+  payload_preview: z.string().nullable(),
+});
+
+/** GetDlqMessages `record`: the queue id + its depth and how many are shown. */
+export const colonelDlqMessagesRecordSchema = z.object({
+  queue: z.string(),
+  total_messages: z.number(),
+  showing: z.number(),
+});
+
+/** GetDlqMessages `details`: the peeked messages. */
+export const colonelDlqMessagesDetailsSchema = z.object({
+  messages: z.array(colonelDlqMessageSchema),
+});
+
+// ============================================================================
+// ReplayDlq — guarded retry ack
+// ============================================================================
+
+/** ReplayDlq `record`: the counts (+ dry-run preview) for a replay. */
+export const colonelDlqReplayRecordSchema = z.object({
+  queue: z.string(),
+  replayed: z.number(),
+  failed: z.number(),
+  would_replay: z.number(),
+  dry_run: z.boolean(),
+});
+
+/** A single per-message replay error entry. */
+export const colonelDlqReplayErrorSchema = z.object({
+  message_id: z.string().nullable().optional(),
+  error: z.string(),
+});
+
+/** ReplayDlq `details`: a human-readable ack message + any per-message errors. */
+export const colonelDlqReplayDetailsSchema = z.object({
+  message: z.string(),
+  errors: z.array(colonelDlqReplayErrorSchema),
+});
+
+// ============================================================================
+// PurgeDlq — guarded purge ack
+// ============================================================================
+
+/** PurgeDlq `record`: the measured count and how many were purged (0 on dry-run). */
+export const colonelDlqPurgeRecordSchema = z.object({
+  queue: z.string(),
+  count: z.number(),
+  purged: z.number(),
+  dry_run: z.boolean(),
+});
+
+/** PurgeDlq `details`: a human-readable ack message. */
+export const colonelDlqPurgeDetailsSchema = z.object({
+  message: z.string(),
+});
+
+// ============================================================================
+// Type Exports
+// ============================================================================
+
+export type ColonelDlqSummary = z.infer<typeof colonelDlqSummarySchema>;
+export type ColonelDlqMessage = z.infer<typeof colonelDlqMessageSchema>;
+export type ColonelDlqMessagesRecord = z.infer<typeof colonelDlqMessagesRecordSchema>;
+export type ColonelDlqReplayRecord = z.infer<typeof colonelDlqReplayRecordSchema>;
+export type ColonelDlqPurgeRecord = z.infer<typeof colonelDlqPurgeRecordSchema>;

--- a/src/schemas/api/account/responses/colonel-sessions.ts
+++ b/src/schemas/api/account/responses/colonel-sessions.ts
@@ -1,0 +1,108 @@
+// src/schemas/api/account/responses/colonel-sessions.ts
+//
+// Per-resource colonel/admin schemas for the Sessions console (ticket #40).
+//
+// NEW schemas only — the frozen colonel contracts in ./colonel.ts are untouched
+// (the Zod tripwire, epic non-goal). These three shapes are for the net-new
+// session endpoints (there was no old colonel session screen — CLI-only until
+// now):
+//
+//   - ListSessions     → GET    /api/colonel/sessions             (list + search)
+//   - GetSessionDetail → GET    /api/colonel/sessions/:session_id (detail drawer)
+//   - DeleteSession    → DELETE /api/colonel/sessions/:session_id (guarded revoke)
+//
+// Shapes verified against the live logic classes
+// (apps/api/colonel/logic/colonel/{list_sessions,get_session_detail,delete_session}.rb),
+// which are thin adapters over Onetime::Operations::Sessions::{List,Inspect,Delete}.
+// Epoch fields (created_at / authenticated_at / ttl) arrive as bare Unix-second
+// numbers and are kept numeric (mirroring the existing `bannedIPSchema.banned_at`).
+
+import { paginationSchema } from '@/schemas/api/account/responses/colonel';
+import { z } from 'zod';
+
+// ============================================================================
+// ListSessions — list row + details
+// ============================================================================
+
+/**
+ * A single session summary row (ListSessions `details.sessions[]`). `session_id`
+ * is the bare id used for routing + revoke; `key` is the resolved Redis key.
+ * Identity fields are nullable (anonymous / pre-auth sessions carry no email or
+ * external id). `created_at` is `authenticated_at` as a Unix-second number.
+ */
+export const colonelSessionSchema = z.object({
+  session_id: z.string(),
+  key: z.string(),
+  authenticated: z.boolean(),
+  email: z.string().nullable(),
+  external_id: z.string().nullable(),
+  role: z.string().nullable(),
+  ip_address: z.string().nullable(),
+  created_at: z.number().nullable(),
+});
+
+/** Sessions list response details: rows + the shared pagination envelope. */
+export const colonelSessionsDetailsSchema = z.object({
+  sessions: z.array(colonelSessionSchema),
+  pagination: paginationSchema,
+});
+
+// ============================================================================
+// GetSessionDetail — detail drawer
+// ============================================================================
+
+/**
+ * The typed field read-out for one session (GetSessionDetail `record`). `ttl` is
+ * the Redis TTL in seconds (-1 no expiry, -2 gone). The remaining fields are
+ * best-effort projections of the session payload and are all nullable because a
+ * session may be anonymous / partially populated. `account_id` may arrive as a
+ * string or number depending on the auth backend.
+ */
+export const colonelSessionDetailRecordSchema = z.object({
+  session_id: z.string(),
+  key: z.string(),
+  ttl: z.number().nullable(),
+  authenticated: z.boolean(),
+  email: z.string().nullable(),
+  external_id: z.string().nullable(),
+  account_id: z.union([z.string(), z.number()]).nullable(),
+  role: z.string().nullable(),
+  locale: z.string().nullable(),
+  ip_address: z.string().nullable(),
+  authenticated_at: z.number().nullable(),
+  authenticated_by: z.string().nullable(),
+  active_session_id: z.string().nullable(),
+});
+
+/**
+ * GetSessionDetail `details`: the full parsed session payload for the raw
+ * inspector. Keys are arbitrary (colonel-only, parity with `ots session
+ * inspect`), so this is an open record.
+ */
+export const colonelSessionDetailDetailsSchema = z.object({
+  data: z.record(z.string(), z.unknown()),
+});
+
+// ============================================================================
+// DeleteSession — guarded revoke ack
+// ============================================================================
+
+/** DeleteSession `record`: the revoked session's id + a deleted flag. */
+export const colonelSessionDeleteRecordSchema = z.object({
+  session_id: z.string(),
+  deleted: z.boolean(),
+});
+
+/** DeleteSession `details`: a human-readable ack message. */
+export const colonelSessionDeleteDetailsSchema = z.object({
+  message: z.string(),
+});
+
+// ============================================================================
+// Type Exports
+// ============================================================================
+
+export type ColonelSession = z.infer<typeof colonelSessionSchema>;
+export type ColonelSessionDetailRecord = z.infer<typeof colonelSessionDetailRecordSchema>;
+export type ColonelSessionDetailDetails = z.infer<typeof colonelSessionDetailDetailsSchema>;
+export type ColonelSessionDeleteRecord = z.infer<typeof colonelSessionDeleteRecordSchema>;

--- a/src/schemas/api/internal/responses/colonel-banner.ts
+++ b/src/schemas/api/internal/responses/colonel-banner.ts
@@ -1,0 +1,40 @@
+// src/schemas/api/internal/responses/colonel-banner.ts
+//
+// Wrapped response schemas for the colonel Broadcast Banner screen (ticket #41).
+// Internal-only; consumed by the Vue admin console, never exposed publicly.
+//
+// All three envelopes are new (the banner had no colonel endpoint before this
+// slice). The view imports these DIRECTLY (CONTRACT 3) so it typechecks
+// independently of the registry; the Integrate step adds the registry keys from
+// wiringInstructions.
+
+import { createApiResponseSchema } from '@/schemas/api/base';
+import {
+  colonelBannerRecordSchema,
+  colonelBannerDetailsSchema,
+  colonelBannerMutationDetailsSchema,
+  colonelBannerClearRecordSchema,
+} from '@/schemas/api/account/responses/colonel-banner';
+import { z } from 'zod';
+
+// GET /api/colonel/banner → GetBanner
+export const colonelBannerResponseSchema = createApiResponseSchema(
+  colonelBannerRecordSchema,
+  colonelBannerDetailsSchema
+);
+
+// POST /api/colonel/banner → SetBanner (echoes the new banner record)
+export const colonelBannerSetResponseSchema = createApiResponseSchema(
+  colonelBannerRecordSchema,
+  colonelBannerMutationDetailsSchema
+);
+
+// DELETE /api/colonel/banner → ClearBanner
+export const colonelBannerClearResponseSchema = createApiResponseSchema(
+  colonelBannerClearRecordSchema,
+  colonelBannerMutationDetailsSchema
+);
+
+export type ColonelBannerResponse = z.infer<typeof colonelBannerResponseSchema>;
+export type ColonelBannerSetResponse = z.infer<typeof colonelBannerSetResponseSchema>;
+export type ColonelBannerClearResponse = z.infer<typeof colonelBannerClearResponseSchema>;

--- a/src/schemas/api/internal/responses/colonel-billing.ts
+++ b/src/schemas/api/internal/responses/colonel-billing.ts
@@ -1,0 +1,24 @@
+// src/schemas/api/internal/responses/colonel-billing.ts
+//
+// Wrapped response schema for the colonel Billing catalog drift view
+// (ticket #45). Internal-only; consumed by the Vue admin console, never
+// exposed publicly.
+//
+// The view imports this DIRECTLY (CONTRACT 3) so it typechecks independently of
+// the registry; the Integrate step adds the registry key from wiringInstructions.
+// Distinct `billing` namespace — does NOT touch any frozen colonel contract.
+//
+// READ-ONLY: no mutation/ack schema (spec: read-only drift, sync stays CLI).
+
+import { createApiResponseSchema } from '@/schemas/api/base';
+import { colonelBillingCatalogDetailsSchema } from '@/schemas/api/account/responses/colonel-billing';
+import { z } from 'zod';
+
+// GET /api/colonel/billing/catalog → GetBillingCatalog
+// The record is empty ({}); everything lives under `details`.
+export const colonelBillingCatalogResponseSchema = createApiResponseSchema(
+  z.object({}),
+  colonelBillingCatalogDetailsSchema
+);
+
+export type ColonelBillingCatalogResponse = z.infer<typeof colonelBillingCatalogResponseSchema>;

--- a/src/schemas/api/internal/responses/colonel-domaintoolbox.ts
+++ b/src/schemas/api/internal/responses/colonel-domaintoolbox.ts
@@ -1,0 +1,53 @@
+// src/schemas/api/internal/responses/colonel-domaintoolbox.ts
+//
+// Wrapped response schemas for the colonel Domain Toolbox (ticket #43).
+// Internal-only; consumed by the Vue admin console, never exposed publicly.
+//
+// The view + store import these DIRECTLY (CONTRACT 3) so they typecheck
+// independently of the registry; the Integrate step adds the registry keys from
+// wiringInstructions. Distinct `domaintoolbox` namespace — does NOT touch
+// Slice-4's colonel-domains.ts.
+//
+// The re-verify action REUSES colonelDomainVerifyResponseSchema from
+// ./colonel-domains (not redefined here).
+
+import { createApiResponseSchema } from '@/schemas/api/base';
+import {
+  colonelOrphanedDomainsDetailsSchema,
+  colonelDomainProbeRecordSchema,
+  colonelDomainProbeDetailsSchema,
+  colonelDomainRepairRecordSchema,
+  colonelDomainRepairDetailsSchema,
+  colonelDomainTransferRecordSchema,
+  colonelDomainTransferDetailsSchema,
+} from '@/schemas/api/account/responses/colonel-domaintoolbox';
+import { z } from 'zod';
+
+// GET /api/colonel/domains/orphaned → ListOrphanedDomains
+export const colonelDomainsOrphanedResponseSchema = createApiResponseSchema(
+  z.object({}),
+  colonelOrphanedDomainsDetailsSchema
+);
+
+// GET /api/colonel/domains/:extid/probe → ProbeDomain
+export const colonelDomainProbeResponseSchema = createApiResponseSchema(
+  colonelDomainProbeRecordSchema,
+  colonelDomainProbeDetailsSchema
+);
+
+// POST /api/colonel/domains/:extid/repair → RepairDomain
+export const colonelDomainRepairResponseSchema = createApiResponseSchema(
+  colonelDomainRepairRecordSchema,
+  colonelDomainRepairDetailsSchema
+);
+
+// POST /api/colonel/domains/:extid/transfer → TransferDomain
+export const colonelDomainTransferResponseSchema = createApiResponseSchema(
+  colonelDomainTransferRecordSchema,
+  colonelDomainTransferDetailsSchema
+);
+
+export type ColonelDomainsOrphanedResponse = z.infer<typeof colonelDomainsOrphanedResponseSchema>;
+export type ColonelDomainProbeResponse = z.infer<typeof colonelDomainProbeResponseSchema>;
+export type ColonelDomainRepairResponse = z.infer<typeof colonelDomainRepairResponseSchema>;
+export type ColonelDomainTransferResponse = z.infer<typeof colonelDomainTransferResponseSchema>;

--- a/src/schemas/api/internal/responses/colonel-emailtools.ts
+++ b/src/schemas/api/internal/responses/colonel-emailtools.ts
@@ -1,0 +1,70 @@
+// src/schemas/api/internal/responses/colonel-emailtools.ts
+//
+// Wrapped response schemas for the colonel Email + Rate-limit Tools screen
+// (ticket #44). Internal-only; consumed by the Vue admin console, never exposed
+// publicly.
+//
+// All six envelopes are new (these capabilities had no colonel endpoint before
+// this slice). The view imports these DIRECTLY (CONTRACT 3) so it typechecks
+// independently of the registry; the Integrate step adds the registry keys from
+// wiringInstructions.
+
+import { createApiResponseSchema } from '@/schemas/api/base';
+import {
+  colonelEmailTemplatesRecordSchema,
+  colonelEmailTemplatesDetailsSchema,
+  colonelEmailPreviewRecordSchema,
+  colonelEmailPreviewDetailsSchema,
+  colonelEmailTestRecordSchema,
+  colonelEmailTestDetailsSchema,
+  colonelRateLimitersRecordSchema,
+  colonelRateLimitersDetailsSchema,
+  colonelRateLimitInspectRecordSchema,
+  colonelRateLimitInspectDetailsSchema,
+  colonelRateLimitResetRecordSchema,
+  colonelRateLimitResetDetailsSchema,
+} from '@/schemas/api/account/responses/colonel-emailtools';
+import { z } from 'zod';
+
+// GET /api/colonel/email/templates → ListEmailTemplates
+export const colonelEmailTemplatesResponseSchema = createApiResponseSchema(
+  colonelEmailTemplatesRecordSchema,
+  colonelEmailTemplatesDetailsSchema
+);
+
+// GET /api/colonel/email/templates/:template/preview → PreviewEmailTemplate
+export const colonelEmailPreviewResponseSchema = createApiResponseSchema(
+  colonelEmailPreviewRecordSchema,
+  colonelEmailPreviewDetailsSchema
+);
+
+// POST /api/colonel/email/test → SendTestEmail
+export const colonelEmailTestResponseSchema = createApiResponseSchema(
+  colonelEmailTestRecordSchema,
+  colonelEmailTestDetailsSchema
+);
+
+// GET /api/colonel/ratelimit/limiters → ListRateLimiters
+export const colonelRateLimitersResponseSchema = createApiResponseSchema(
+  colonelRateLimitersRecordSchema,
+  colonelRateLimitersDetailsSchema
+);
+
+// GET /api/colonel/ratelimit/inspect → InspectRateLimit
+export const colonelRateLimitInspectResponseSchema = createApiResponseSchema(
+  colonelRateLimitInspectRecordSchema,
+  colonelRateLimitInspectDetailsSchema
+);
+
+// POST /api/colonel/ratelimit/reset → ResetRateLimit
+export const colonelRateLimitResetResponseSchema = createApiResponseSchema(
+  colonelRateLimitResetRecordSchema,
+  colonelRateLimitResetDetailsSchema
+);
+
+export type ColonelEmailTemplatesResponse = z.infer<typeof colonelEmailTemplatesResponseSchema>;
+export type ColonelEmailPreviewResponse = z.infer<typeof colonelEmailPreviewResponseSchema>;
+export type ColonelEmailTestResponse = z.infer<typeof colonelEmailTestResponseSchema>;
+export type ColonelRateLimitersResponse = z.infer<typeof colonelRateLimitersResponseSchema>;
+export type ColonelRateLimitInspectResponse = z.infer<typeof colonelRateLimitInspectResponseSchema>;
+export type ColonelRateLimitResetResponse = z.infer<typeof colonelRateLimitResetResponseSchema>;

--- a/src/schemas/api/internal/responses/colonel-queue.ts
+++ b/src/schemas/api/internal/responses/colonel-queue.ts
@@ -1,0 +1,49 @@
+// src/schemas/api/internal/responses/colonel-queue.ts
+//
+// Wrapped response schemas for the colonel Queue DLQ console (ticket #42).
+// Internal-only; consumed by the Vue admin console, never exposed publicly.
+//
+// The view + store import these DIRECTLY (CONTRACT 3) so they typecheck
+// independently of the registry; the Integrate step adds the registry keys from
+// wiringInstructions.
+
+import { createApiResponseSchema } from '@/schemas/api/base';
+import {
+  colonelDlqListDetailsSchema,
+  colonelDlqMessagesRecordSchema,
+  colonelDlqMessagesDetailsSchema,
+  colonelDlqReplayRecordSchema,
+  colonelDlqReplayDetailsSchema,
+  colonelDlqPurgeRecordSchema,
+  colonelDlqPurgeDetailsSchema,
+} from '@/schemas/api/account/responses/colonel-queue';
+import { z } from 'zod';
+
+// GET /api/colonel/queues/dlq → ListDlqs
+export const colonelDlqListResponseSchema = createApiResponseSchema(
+  z.object({}),
+  colonelDlqListDetailsSchema
+);
+
+// GET /api/colonel/queues/dlq/:queue → GetDlqMessages
+export const colonelDlqMessagesResponseSchema = createApiResponseSchema(
+  colonelDlqMessagesRecordSchema,
+  colonelDlqMessagesDetailsSchema
+);
+
+// POST /api/colonel/queues/dlq/:queue/replay → ReplayDlq
+export const colonelDlqReplayResponseSchema = createApiResponseSchema(
+  colonelDlqReplayRecordSchema,
+  colonelDlqReplayDetailsSchema
+);
+
+// POST /api/colonel/queues/dlq/:queue/purge → PurgeDlq
+export const colonelDlqPurgeResponseSchema = createApiResponseSchema(
+  colonelDlqPurgeRecordSchema,
+  colonelDlqPurgeDetailsSchema
+);
+
+export type ColonelDlqListResponse = z.infer<typeof colonelDlqListResponseSchema>;
+export type ColonelDlqMessagesResponse = z.infer<typeof colonelDlqMessagesResponseSchema>;
+export type ColonelDlqReplayResponse = z.infer<typeof colonelDlqReplayResponseSchema>;
+export type ColonelDlqPurgeResponse = z.infer<typeof colonelDlqPurgeResponseSchema>;

--- a/src/schemas/api/internal/responses/colonel-sessions.ts
+++ b/src/schemas/api/internal/responses/colonel-sessions.ts
@@ -1,0 +1,40 @@
+// src/schemas/api/internal/responses/colonel-sessions.ts
+//
+// Wrapped response schemas for the colonel Sessions console (ticket #40).
+// Internal-only; consumed by the Vue admin console, never exposed publicly.
+//
+// The view + store import these DIRECTLY (CONTRACT 3) so they typecheck
+// independently of the registry; the Integrate step adds the registry keys from
+// wiringInstructions.
+
+import { createApiResponseSchema } from '@/schemas/api/base';
+import {
+  colonelSessionsDetailsSchema,
+  colonelSessionDetailRecordSchema,
+  colonelSessionDetailDetailsSchema,
+  colonelSessionDeleteRecordSchema,
+  colonelSessionDeleteDetailsSchema,
+} from '@/schemas/api/account/responses/colonel-sessions';
+import { z } from 'zod';
+
+// GET /api/colonel/sessions → ListSessions
+export const colonelSessionsResponseSchema = createApiResponseSchema(
+  z.object({}),
+  colonelSessionsDetailsSchema
+);
+
+// GET /api/colonel/sessions/:session_id → GetSessionDetail
+export const colonelSessionDetailResponseSchema = createApiResponseSchema(
+  colonelSessionDetailRecordSchema,
+  colonelSessionDetailDetailsSchema
+);
+
+// DELETE /api/colonel/sessions/:session_id → DeleteSession
+export const colonelSessionDeleteResponseSchema = createApiResponseSchema(
+  colonelSessionDeleteRecordSchema,
+  colonelSessionDeleteDetailsSchema
+);
+
+export type ColonelSessionsResponse = z.infer<typeof colonelSessionsResponseSchema>;
+export type ColonelSessionDetailResponse = z.infer<typeof colonelSessionDetailResponseSchema>;
+export type ColonelSessionDeleteResponse = z.infer<typeof colonelSessionDeleteResponseSchema>;

--- a/src/schemas/api/internal/responses/registry.ts
+++ b/src/schemas/api/internal/responses/registry.ts
@@ -39,6 +39,39 @@ import {
   colonelUnbanIpResponseSchema,
 } from './colonel-bannedips';
 
+// Colonel (admin) per-resource schemas — Phase-3 screens (tickets #40-45)
+import {
+  colonelSessionsResponseSchema,
+  colonelSessionDetailResponseSchema,
+  colonelSessionDeleteResponseSchema,
+} from './colonel-sessions';
+import {
+  colonelBannerResponseSchema,
+  colonelBannerSetResponseSchema,
+  colonelBannerClearResponseSchema,
+} from './colonel-banner';
+import {
+  colonelDlqListResponseSchema,
+  colonelDlqMessagesResponseSchema,
+  colonelDlqReplayResponseSchema,
+  colonelDlqPurgeResponseSchema,
+} from './colonel-queue';
+import {
+  colonelDomainsOrphanedResponseSchema,
+  colonelDomainProbeResponseSchema,
+  colonelDomainRepairResponseSchema,
+  colonelDomainTransferResponseSchema,
+} from './colonel-domaintoolbox';
+import {
+  colonelEmailTemplatesResponseSchema,
+  colonelEmailPreviewResponseSchema,
+  colonelEmailTestResponseSchema,
+  colonelRateLimitersResponseSchema,
+  colonelRateLimitInspectResponseSchema,
+  colonelRateLimitResetResponseSchema,
+} from './colonel-emailtools';
+import { colonelBillingCatalogResponseSchema } from './colonel-billing';
+
 // Organization schemas — internal-only
 import {
   organizationResponseSchema,
@@ -109,6 +142,29 @@ export const responseSchemas = {
   usageExport: usageExportResponseSchema,
   queueMetrics: queueMetricsResponseSchema,
   systemSettings: systemSettingsResponseSchema,
+
+  // Colonel / admin — Phase-3 screens (tickets #40-45)
+  colonelSessions: colonelSessionsResponseSchema,
+  colonelSessionDetail: colonelSessionDetailResponseSchema,
+  colonelSessionDelete: colonelSessionDeleteResponseSchema,
+  colonelBanner: colonelBannerResponseSchema,
+  colonelBannerSet: colonelBannerSetResponseSchema,
+  colonelBannerClear: colonelBannerClearResponseSchema,
+  colonelDlqList: colonelDlqListResponseSchema,
+  colonelDlqMessages: colonelDlqMessagesResponseSchema,
+  colonelDlqReplay: colonelDlqReplayResponseSchema,
+  colonelDlqPurge: colonelDlqPurgeResponseSchema,
+  colonelDomainsOrphaned: colonelDomainsOrphanedResponseSchema,
+  colonelDomainProbe: colonelDomainProbeResponseSchema,
+  colonelDomainRepair: colonelDomainRepairResponseSchema,
+  colonelDomainTransfer: colonelDomainTransferResponseSchema,
+  colonelEmailTemplates: colonelEmailTemplatesResponseSchema,
+  colonelEmailPreview: colonelEmailPreviewResponseSchema,
+  colonelEmailTest: colonelEmailTestResponseSchema,
+  colonelRateLimiters: colonelRateLimitersResponseSchema,
+  colonelRateLimitInspect: colonelRateLimitInspectResponseSchema,
+  colonelRateLimitReset: colonelRateLimitResetResponseSchema,
+  colonelBillingCatalog: colonelBillingCatalogResponseSchema,
 
   // Organizations (internal-only)
   organization: organizationResponseSchema,

--- a/src/tests/apps/admin/AdminBanner.spec.ts
+++ b/src/tests/apps/admin/AdminBanner.spec.ts
@@ -1,0 +1,273 @@
+// src/tests/apps/admin/AdminBanner.spec.ts
+
+import { AxiosError } from 'axios';
+import { createPinia, setActivePinia } from 'pinia';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/** Build a real AxiosError so the shared classifier extracts `data.error`. */
+function axiosError(status: number, data: unknown, message = 'Request failed'): AxiosError {
+  const err = new AxiosError(message);
+  err.response = { status, data, statusText: '', headers: {}, config: {} as never };
+  return err;
+}
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+const showMock = vi.fn();
+vi.mock('@/shared/stores/notificationsStore', () => ({
+  useNotificationsStore: () => ({ show: showMock }),
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+// Render the HeadlessUI dialog markup synchronously (mirrors AdminBannedIps.spec).
+vi.mock('@headlessui/vue', () => ({
+  Dialog: {
+    name: 'Dialog',
+    template: '<div role="dialog" @close="$emit(\'close\')"><slot /></div>',
+    props: ['class'],
+    emits: ['close'],
+  },
+  DialogPanel: {
+    name: 'DialogPanel',
+    template: '<div class="dialog-panel" :data-testid="$attrs[\'data-testid\']"><slot /></div>',
+    props: ['class'],
+  },
+  DialogTitle: { name: 'DialogTitle', template: '<h3><slot /></h3>', props: ['as', 'class'] },
+  TransitionRoot: {
+    name: 'TransitionRoot',
+    template: '<div v-if="show"><slot /></div>',
+    props: ['as', 'show'],
+  },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>', props: ['as'] },
+}));
+
+import AdminBanner from '@/apps/admin/views/AdminBanner.vue';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+const BANNER_URL = '/api/colonel/banner';
+const CONTENT = '<a href="/status">Scheduled maintenance</a>';
+
+function bannerPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    shrimp: '',
+    record: { content: CONTENT, ttl: null, active: true, ...overrides },
+    details: { key: 'global_banner', database: 0 },
+  };
+}
+
+function emptyPayload() {
+  return {
+    shrimp: '',
+    record: { content: null, ttl: null, active: false },
+    details: { key: 'global_banner', database: 0 },
+  };
+}
+
+function setAck() {
+  return {
+    shrimp: '',
+    record: { content: 'New notice', ttl: null, active: true },
+    details: { message: 'Broadcast banner published' },
+  };
+}
+
+function clearAck() {
+  return {
+    shrimp: '',
+    record: { cleared: true, active: false },
+    details: { message: 'Broadcast banner cleared' },
+  };
+}
+
+const mountView = (pinia: ReturnType<typeof createPinia>) =>
+  mount(AdminBanner, { global: { plugins: [pinia, i18n] } });
+
+const dialogInput = (w: VueWrapper) => w.find('#admin-confirm-input');
+const dialogSubmit = (w: VueWrapper) => w.find('[data-testid="admin-confirm-submit"]');
+const bannerGetCount = () => mockApi.get.mock.calls.filter((c) => c[0] === BANNER_URL).length;
+
+describe('AdminBanner (settings screen — ticket #41)', () => {
+  let wrapper: VueWrapper;
+  let pinia: ReturnType<typeof createPinia>;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+  });
+  afterEach(() => wrapper?.unmount());
+
+  // ---- Read -----------------------------------------------------------------
+
+  it('fetches the current banner on mount and renders its stored content', async () => {
+    mockApi.get.mockResolvedValue({ data: bannerPayload() });
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    // Single-GET read — no pagination params.
+    expect(mockApi.get).toHaveBeenCalledWith(BANNER_URL, undefined);
+    const active = wrapper.find('[data-testid="banner-active"]');
+    expect(active.exists()).toBe(true);
+    // Content is rendered as escaped text (the raw HTML string is visible).
+    expect(wrapper.find('[data-testid="banner-content"]').text()).toContain('/status');
+    // A clear action is offered for a live banner.
+    expect(wrapper.find('[data-testid="banner-clear"]').exists()).toBe(true);
+  });
+
+  it('renders the empty state when no banner is set', async () => {
+    mockApi.get.mockResolvedValue({ data: emptyPayload() });
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="banner-empty"]').exists()).toBe(true);
+    // No live banner ⇒ no clear button.
+    expect(wrapper.find('[data-testid="banner-clear"]').exists()).toBe(false);
+  });
+
+  it('shows the error banner + retry on a network failure', async () => {
+    mockApi.get.mockRejectedValue(new Error('Network Error'));
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    const banner = wrapper.find('[data-testid="banner-error"]');
+    expect(banner.exists()).toBe(true);
+
+    mockApi.get.mockResolvedValueOnce({ data: bannerPayload() });
+    await banner.find('button').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-testid="banner-error"]').exists()).toBe(false);
+  });
+
+  // ---- Publish (one-click confirm) -----------------------------------------
+
+  describe('publish', () => {
+    beforeEach(async () => {
+      mockApi.get.mockResolvedValue({ data: emptyPayload() });
+      wrapper = mountView(pinia);
+      await flushPromises();
+    });
+
+    it('publish is disabled until a message is entered', async () => {
+      const publish = wrapper.find('[data-testid="banner-publish"]');
+      expect(publish.attributes('disabled')).toBeDefined();
+      await wrapper.find('[data-testid="banner-content-input"]').setValue('Heads up');
+      expect(publish.attributes('disabled')).toBeUndefined();
+    });
+
+    it('opens a one-click confirm (no typed gate) and POSTs {content, ttl}', async () => {
+      mockApi.post.mockResolvedValue({ data: setAck() });
+      const before = bannerGetCount();
+
+      await wrapper.find('[data-testid="banner-content-input"]').setValue('Heads up');
+      await wrapper.find('[data-testid="banner-ttl-input"]').setValue('3600');
+      await wrapper.find('[data-testid="banner-publish"]').trigger('click');
+      await flushPromises();
+
+      // Simple confirm: no typed-token input, submit immediately enabled.
+      expect(dialogInput(wrapper).exists()).toBe(false);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockApi.post).toHaveBeenCalledWith(BANNER_URL, {
+        content: 'Heads up',
+        ttl: 3600,
+      });
+      expect(showMock).toHaveBeenCalledWith('web.admin.banner.set.success', 'success');
+      expect(bannerGetCount()).toBe(before + 1);
+    });
+
+    it('omits ttl when the field is blank', async () => {
+      mockApi.post.mockResolvedValue({ data: setAck() });
+      await wrapper.find('[data-testid="banner-content-input"]').setValue('Persistent notice');
+      await wrapper.find('[data-testid="banner-publish"]').trigger('click');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockApi.post).toHaveBeenCalledWith(BANNER_URL, {
+        content: 'Persistent notice',
+        ttl: undefined,
+      });
+    });
+
+    it('surfaces a 4xx in the dialog and does not refresh on failure', async () => {
+      mockApi.post.mockRejectedValue(axiosError(422, { error: 'Banner content is required' }));
+      const before = bannerGetCount();
+
+      await wrapper.find('[data-testid="banner-content-input"]').setValue('x');
+      await wrapper.find('[data-testid="banner-publish"]').trigger('click');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(wrapper.find('[role="alert"]').text()).toContain('Banner content is required');
+      expect(showMock).not.toHaveBeenCalled();
+      expect(bannerGetCount()).toBe(before);
+    });
+  });
+
+  // ---- Clear (typed-confirmation) ------------------------------------------
+
+  describe('clear', () => {
+    beforeEach(async () => {
+      mockApi.get.mockResolvedValue({ data: bannerPayload() });
+      wrapper = mountView(pinia);
+      await flushPromises();
+    });
+
+    it('gates the destructive clear behind retyping the confirmation word', async () => {
+      await wrapper.find('[data-testid="banner-clear"]').trigger('click');
+      await flushPromises();
+
+      expect(dialogInput(wrapper).exists()).toBe(true);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+      await dialogInput(wrapper).setValue('nope');
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+      await dialogInput(wrapper).setValue('clear');
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+    });
+
+    it('DELETEs the banner, notifies and refreshes on confirm', async () => {
+      mockApi.delete.mockResolvedValue({ data: clearAck() });
+      const before = bannerGetCount();
+
+      await wrapper.find('[data-testid="banner-clear"]').trigger('click');
+      await dialogInput(wrapper).setValue('clear');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockApi.delete).toHaveBeenCalledWith(BANNER_URL);
+      expect(showMock).toHaveBeenCalledWith('web.admin.banner.clear.success', 'success');
+      expect(dialogInput(wrapper).exists()).toBe(false);
+      expect(bannerGetCount()).toBe(before + 1);
+    });
+
+    it('does NOT DELETE when submitted without the matching word', async () => {
+      mockApi.delete.mockResolvedValue({ data: clearAck() });
+      await wrapper.find('[data-testid="banner-clear"]').trigger('click');
+      await dialogInput(wrapper).setValue('wrong');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockApi.delete).not.toHaveBeenCalled();
+      expect(showMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/tests/apps/admin/AdminBilling.spec.ts
+++ b/src/tests/apps/admin/AdminBilling.spec.ts
@@ -1,0 +1,213 @@
+// src/tests/apps/admin/AdminBilling.spec.ts
+
+import { createPinia, setActivePinia } from 'pinia';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+import AdminBilling from '@/apps/admin/views/AdminBilling.vue';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+const CATALOG_URL = '/api/colonel/billing/catalog';
+
+function plan(overrides: Record<string, unknown> = {}) {
+  return {
+    planid: 'plan_x',
+    name: 'Plan X',
+    tier: 'single_team',
+    tenancy: 'shared',
+    region: 'US',
+    display_order: 1,
+    show_on_plans_page: true,
+    description: null,
+    entitlements: ['create_secrets'],
+    limits: { 'teams.max': '1' },
+    ...overrides,
+  };
+}
+
+/** A catalog with one in-sync plan, one config-only, one live-only, one changed. */
+function catalogPayload() {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      source: 'stripe',
+      stripe_configured: true,
+      config_plans: [
+        plan({ planid: 'free_v1', name: 'Free', entitlements: ['create_secrets'] }),
+        plan({ planid: 'legacy_v1', name: 'Legacy' }), // config only
+        plan({
+          planid: 'identity_plus_v1',
+          name: 'Identity+',
+          entitlements: ['create_secrets', 'custom_domains'],
+        }),
+      ],
+      live_plans: [
+        plan({ planid: 'free_v1', name: 'Free', entitlements: ['create_secrets'] }),
+        plan({ planid: 'new_v2', name: 'New' }), // live only
+        plan({
+          planid: 'identity_plus_v1',
+          name: 'Identity+',
+          entitlements: ['create_secrets'], // drift: entitlements differ
+        }),
+      ],
+      drift: {
+        in_sync: false,
+        only_in_config: ['legacy_v1'],
+        only_in_live: ['new_v2'],
+        changed: [{ planid: 'identity_plus_v1', name: 'Identity+', fields: ['entitlements'] }],
+      },
+    },
+  };
+}
+
+function localConfigPayload() {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      source: 'local_config',
+      stripe_configured: false,
+      config_plans: [plan({ planid: 'free_v1', name: 'Free' })],
+      live_plans: [],
+      drift: { in_sync: false, only_in_config: ['free_v1'], only_in_live: [], changed: [] },
+    },
+  };
+}
+
+// Stub JsonViewer (avoid clipboard machinery) and DetailDrawer (always render
+// its slot so the diff content is assertable without headlessui teleport).
+const jsonViewerStub = {
+  name: 'JsonViewer',
+  props: ['data', 'expandDepth', 'testid'],
+  template: '<div :data-testid="testid" />',
+};
+const detailDrawerStub = {
+  name: 'DetailDrawer',
+  props: ['open', 'title', 'subtitle', 'testid'],
+  template: '<div :data-testid="testid"><slot /></div>',
+};
+
+const mountView = (pinia: ReturnType<typeof createPinia>) =>
+  mount(AdminBilling, {
+    global: {
+      plugins: [pinia, i18n],
+      stubs: { JsonViewer: jsonViewerStub, DetailDrawer: detailDrawerStub },
+    },
+  });
+
+describe('AdminBilling (read-only billing catalog drift — ticket #45)', () => {
+  let wrapper: VueWrapper;
+  let pinia: ReturnType<typeof createPinia>;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+  });
+  afterEach(() => wrapper?.unmount());
+
+  it('issues the single catalog GET on mount', async () => {
+    mockApi.get.mockResolvedValue({ data: catalogPayload() });
+    wrapper = mountView(pinia);
+    await flushPromises();
+    expect(mockApi.get).toHaveBeenCalledWith(CATALOG_URL, undefined);
+  });
+
+  it('renders the union of config + live plans with per-plan drift status', async () => {
+    mockApi.get.mockResolvedValue({ data: catalogPayload() });
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    const table = wrapper.find('[data-testid="billing-plans-table"]');
+    expect(table.exists()).toBe(true);
+    // Union: free_v1, identity_plus_v1, legacy_v1 (config only), new_v2 (live only)
+    const text = table.text();
+    expect(text).toContain('free_v1');
+    expect(text).toContain('legacy_v1');
+    expect(text).toContain('new_v2');
+    expect(text).toContain('identity_plus_v1');
+    // The changed plan surfaces which fields drifted.
+    expect(text).toContain('entitlements');
+    // Drift summary is not in-sync, so the in-sync banner is absent.
+    expect(wrapper.find('[data-testid="billing-in-sync"]').exists()).toBe(false);
+  });
+
+  it('opens the side-by-side diff drawer for a plan present on both sides', async () => {
+    mockApi.get.mockResolvedValue({ data: catalogPayload() });
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    await wrapper.find('[data-testid="billing-diff-identity_plus_v1"]').trigger('click');
+    await flushPromises();
+
+    // Both config and live JSON panels render for a plan on both sides.
+    expect(wrapper.find('[data-testid="billing-diff-config-json"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="billing-diff-live-json"]').exists()).toBe(true);
+  });
+
+  it('shows a config-absent placeholder in the diff for a live-only plan', async () => {
+    mockApi.get.mockResolvedValue({ data: catalogPayload() });
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    await wrapper.find('[data-testid="billing-diff-new_v2"]').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="billing-diff-config-absent"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="billing-diff-live-json"]').exists()).toBe(true);
+  });
+
+  it('warns when the source is local_config (drift cannot be evaluated)', async () => {
+    mockApi.get.mockResolvedValue({ data: localConfigPayload() });
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="billing-local-config-warning"]').exists()).toBe(true);
+  });
+
+  it('renders the in-sync banner when the catalog matches', async () => {
+    const payload = catalogPayload();
+    payload.details.config_plans = [plan({ planid: 'free_v1', name: 'Free' })];
+    payload.details.live_plans = [plan({ planid: 'free_v1', name: 'Free' })];
+    payload.details.drift = { in_sync: true, only_in_config: [], only_in_live: [], changed: [] };
+    mockApi.get.mockResolvedValue({ data: payload });
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="billing-in-sync"]').exists()).toBe(true);
+  });
+
+  it('shows an error state with retry when the GET fails', async () => {
+    mockApi.get.mockRejectedValue(new Error('Network Error'));
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="billing-error"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="billing-plans-table"]').exists()).toBe(false);
+  });
+
+  it('shows the loading state while the request is in flight', async () => {
+    mockApi.get.mockReturnValue(new Promise(() => {}));
+    wrapper = mountView(pinia);
+    await flushPromises();
+    expect(wrapper.find('[data-testid="billing-loading"]').exists()).toBe(true);
+  });
+});

--- a/src/tests/apps/admin/AdminDomainToolbox.spec.ts
+++ b/src/tests/apps/admin/AdminDomainToolbox.spec.ts
@@ -1,0 +1,313 @@
+// src/tests/apps/admin/AdminDomainToolbox.spec.ts
+
+import { AxiosError } from 'axios';
+import { createPinia, setActivePinia } from 'pinia';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/** Build a real AxiosError so the shared classifier extracts `data.error`. */
+function axiosError(status: number, data: unknown, message = 'Request failed'): AxiosError {
+  const err = new AxiosError(message);
+  err.response = { status, data, statusText: '', headers: {}, config: {} as never };
+  return err;
+}
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+const showMock = vi.fn();
+vi.mock('@/shared/stores/notificationsStore', () => ({
+  useNotificationsStore: () => ({ show: showMock }),
+}));
+
+vi.mock('@/utils/format', () => ({
+  formatDisplayDateTime: (d: Date) => `DT:${d.toISOString?.() ?? d}`,
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+// Render the HeadlessUI dialog markup synchronously (mirrors AdminSessions.spec).
+vi.mock('@headlessui/vue', () => ({
+  Dialog: {
+    name: 'Dialog',
+    template: '<div role="dialog" @close="$emit(\'close\')"><slot /></div>',
+    props: ['class'],
+    emits: ['close'],
+  },
+  DialogPanel: {
+    name: 'DialogPanel',
+    template: '<div class="dialog-panel" :data-testid="$attrs[\'data-testid\']"><slot /></div>',
+    props: ['class'],
+  },
+  DialogTitle: { name: 'DialogTitle', template: '<h3><slot /></h3>', props: ['as', 'class'] },
+  TransitionRoot: {
+    name: 'TransitionRoot',
+    template: '<div v-if="show"><slot /></div>',
+    props: ['as', 'show'],
+  },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>', props: ['as'] },
+}));
+
+import AdminDomainToolbox from '@/apps/admin/views/AdminDomainToolbox.vue';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+const ORPHAN_URL = '/api/colonel/domains/orphaned';
+const EXTID = 'cd_ext_1';
+
+function orphanedPayload(rows = [orphanRow()]) {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      domains: rows,
+      pagination: { page: 1, per_page: 50, total_count: rows.length, total_pages: 1 },
+    },
+  };
+}
+
+function orphanRow(overrides: Record<string, unknown> = {}) {
+  return {
+    domain_id: 'cd_1',
+    extid: EXTID,
+    display_domain: 'orphan.example.com',
+    verification_state: 'pending',
+    verified: false,
+    created: 1700000000,
+    ...overrides,
+  };
+}
+
+function probePayload() {
+  return {
+    shrimp: '',
+    record: { extid: EXTID, display_domain: 'orphan.example.com' },
+    details: {
+      timestamp: '2026-07-07T00:00:00Z',
+      domain: 'orphan.example.com',
+      url: 'https://orphan.example.com',
+      http: { status_code: 200, status_message: 'OK', success: true },
+      ssl: { valid: true, days_until_expiry: 90, expired: false },
+      health: 'healthy',
+    },
+  };
+}
+
+function repairPlanPayload(status = 'planned', issues = ['not in collection']) {
+  return {
+    shrimp: '',
+    record: { domain_id: 'cd_1', extid: EXTID, display_domain: 'orphan.example.com' },
+    details: { status, dry_run: status === 'planned', issues, repairs_applied: [] },
+  };
+}
+
+function transferPlanPayload(status = 'planned') {
+  return {
+    shrimp: '',
+    record: { domain_id: 'cd_1', extid: EXTID, display_domain: 'orphan.example.com' },
+    details: {
+      status,
+      dry_run: status === 'planned',
+      from_org_id: 'on_src',
+      from_org_name: 'Source Org',
+      to_org_id: 'on_dest',
+      to_org_name: 'Dest Org',
+    },
+  };
+}
+
+const mountView = (pinia: ReturnType<typeof createPinia>) =>
+  mount(AdminDomainToolbox, { global: { plugins: [pinia, i18n] } });
+
+const dialogInput = (w: VueWrapper) => w.find('#admin-confirm-input');
+const dialogSubmit = (w: VueWrapper) => w.find('[data-testid="admin-confirm-submit"]');
+
+describe('AdminDomainToolbox (orphaned + probe + repair + transfer — ticket #43)', () => {
+  let wrapper: VueWrapper;
+  let pinia: ReturnType<typeof createPinia>;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+    // Default: the orphaned-scan GET on mount succeeds.
+    mockApi.get.mockImplementation((url: string) =>
+      url === ORPHAN_URL
+        ? Promise.resolve({ data: orphanedPayload() })
+        : Promise.resolve({ data: probePayload() })
+    );
+  });
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  // ---- Orphaned scan --------------------------------------------------------
+
+  it('fetches the orphaned scan on mount and renders a row', async () => {
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenCalledWith(ORPHAN_URL, {
+      params: { page: 1, per_page: 50 },
+    });
+    const table = wrapper.find('[data-testid="orphaned-table"]');
+    expect(table.exists()).toBe(true);
+    expect(table.text()).toContain('orphan.example.com');
+  });
+
+  it('shows the orphaned error banner + retry on a network failure', async () => {
+    mockApi.get.mockRejectedValueOnce(new Error('Network Error'));
+    wrapper = mountView(pinia);
+    await flushPromises();
+    expect(wrapper.find('[data-testid="orphaned-error"]').exists()).toBe(true);
+  });
+
+  // ---- Probe (read-only) ----------------------------------------------------
+
+  it('probes a domain and renders the health badge', async () => {
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    await wrapper.find('[data-testid="probe-extid-input"]').setValue(EXTID);
+    await wrapper.find('[data-testid="probe-run"]').trigger('click');
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenCalledWith(`/api/colonel/domains/${EXTID}/probe`);
+    expect(wrapper.find('[data-testid="probe-health"]').text()).toBe('healthy');
+  });
+
+  it('seeds the probe + repair extid from an orphaned row action', async () => {
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    await wrapper.find(`[data-testid="orphaned-repair-${EXTID}"]`).trigger('click');
+    expect(
+      (wrapper.find('[data-testid="repair-extid-input"]').element as HTMLInputElement).value
+    ).toBe(EXTID);
+  });
+
+  // ---- Repair (guarded: dry-run preview → typed-confirm apply) --------------
+
+  describe('repair', () => {
+    it('previews a repair plan (dry_run) and lists the issues', async () => {
+      wrapper = mountView(pinia);
+      await flushPromises();
+
+      mockApi.post.mockResolvedValueOnce({ data: repairPlanPayload() });
+      await wrapper.find('[data-testid="repair-extid-input"]').setValue(EXTID);
+      await wrapper.find('[data-testid="repair-preview"]').trigger('click');
+      await flushPromises();
+
+      expect(mockApi.post).toHaveBeenCalledWith(`/api/colonel/domains/${EXTID}/repair`, {
+        dry_run: true,
+      });
+      expect(wrapper.find('[data-testid="repair-status"]').text()).toBe('planned');
+      expect(wrapper.find('[data-testid="repair-plan"]').text()).toContain('not in collection');
+    });
+
+    it('applies the repair behind a typed-confirmation gate', async () => {
+      wrapper = mountView(pinia);
+      await flushPromises();
+
+      mockApi.post.mockResolvedValueOnce({ data: repairPlanPayload() });
+      await wrapper.find('[data-testid="repair-extid-input"]').setValue(EXTID);
+      await wrapper.find('[data-testid="repair-preview"]').trigger('click');
+      await flushPromises();
+
+      // Open the confirm dialog; submit is gated until the extid is retyped.
+      await wrapper.find('[data-testid="repair-apply"]').trigger('click');
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+      await dialogInput(wrapper).setValue('wrong');
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+      await dialogInput(wrapper).setValue(EXTID);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+
+      mockApi.post.mockResolvedValueOnce({ data: repairPlanPayload('repaired', []) });
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      // Apply POST carries dry_run:false.
+      expect(mockApi.post).toHaveBeenLastCalledWith(`/api/colonel/domains/${EXTID}/repair`, {
+        dry_run: false,
+      });
+      expect(showMock).toHaveBeenCalledWith('web.admin.domaintoolbox.repair.success', 'success');
+    });
+
+    it('surfaces a 4xx in the repair dialog and stays open', async () => {
+      wrapper = mountView(pinia);
+      await flushPromises();
+
+      mockApi.post.mockResolvedValueOnce({ data: repairPlanPayload() });
+      await wrapper.find('[data-testid="repair-extid-input"]').setValue(EXTID);
+      await wrapper.find('[data-testid="repair-preview"]').trigger('click');
+      await flushPromises();
+
+      await wrapper.find('[data-testid="repair-apply"]').trigger('click');
+      await dialogInput(wrapper).setValue(EXTID);
+      mockApi.post.mockRejectedValueOnce(axiosError(404, { error: 'Domain not found' }));
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(wrapper.find('[role="alert"]').text()).toContain('Domain not found');
+      expect(showMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---- Transfer (guarded) ---------------------------------------------------
+
+  describe('transfer', () => {
+    async function preview(w: VueWrapper) {
+      mockApi.post.mockResolvedValueOnce({ data: transferPlanPayload() });
+      await w.find('[data-testid="transfer-extid-input"]').setValue(EXTID);
+      await w.find('[data-testid="transfer-toorg-input"]').setValue('on_dest');
+      await w.find('[data-testid="transfer-preview"]').trigger('click');
+      await flushPromises();
+    }
+
+    it('previews a transfer plan (dry_run) with from/to orgs', async () => {
+      wrapper = mountView(pinia);
+      await flushPromises();
+      await preview(wrapper);
+
+      expect(mockApi.post).toHaveBeenCalledWith(`/api/colonel/domains/${EXTID}/transfer`, {
+        dry_run: true,
+        to_org: 'on_dest',
+      });
+      const plan = wrapper.find('[data-testid="transfer-plan"]');
+      expect(plan.text()).toContain('Dest Org');
+      expect(plan.text()).toContain('Source Org');
+    });
+
+    it('applies the transfer behind a typed-confirmation gate', async () => {
+      wrapper = mountView(pinia);
+      await flushPromises();
+      await preview(wrapper);
+
+      await wrapper.find('[data-testid="transfer-apply"]').trigger('click');
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+      await dialogInput(wrapper).setValue(EXTID);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+
+      mockApi.post.mockResolvedValueOnce({ data: transferPlanPayload('transferred') });
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockApi.post).toHaveBeenLastCalledWith(`/api/colonel/domains/${EXTID}/transfer`, {
+        dry_run: false,
+        to_org: 'on_dest',
+      });
+      expect(showMock).toHaveBeenCalledWith('web.admin.domaintoolbox.transfer.success', 'success');
+    });
+  });
+});

--- a/src/tests/apps/admin/AdminEmailTools.spec.ts
+++ b/src/tests/apps/admin/AdminEmailTools.spec.ts
@@ -1,0 +1,337 @@
+// src/tests/apps/admin/AdminEmailTools.spec.ts
+
+import { AxiosError } from 'axios';
+import { createPinia, setActivePinia } from 'pinia';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/** Build a real AxiosError so the shared classifier extracts `data.error`. */
+function axiosError(status: number, data: unknown, message = 'Request failed'): AxiosError {
+  const err = new AxiosError(message);
+  err.response = { status, data, statusText: '', headers: {}, config: {} as never };
+  return err;
+}
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+const showMock = vi.fn();
+vi.mock('@/shared/stores/notificationsStore', () => ({
+  useNotificationsStore: () => ({ show: showMock }),
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+// Render the HeadlessUI dialog markup synchronously (mirrors AdminBanner.spec).
+vi.mock('@headlessui/vue', () => ({
+  Dialog: {
+    name: 'Dialog',
+    template: '<div role="dialog" @close="$emit(\'close\')"><slot /></div>',
+    props: ['class'],
+    emits: ['close'],
+  },
+  DialogPanel: {
+    name: 'DialogPanel',
+    template: '<div class="dialog-panel" :data-testid="$attrs[\'data-testid\']"><slot /></div>',
+    props: ['class'],
+  },
+  DialogTitle: { name: 'DialogTitle', template: '<h3><slot /></h3>', props: ['as', 'class'] },
+  TransitionRoot: {
+    name: 'TransitionRoot',
+    template: '<div v-if="show"><slot /></div>',
+    props: ['as', 'show'],
+  },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>', props: ['as'] },
+}));
+
+import AdminEmailTools from '@/apps/admin/views/AdminEmailTools.vue';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+const TEMPLATES_URL = '/api/colonel/email/templates';
+const TEST_URL = '/api/colonel/email/test';
+const LIMITERS_URL = '/api/colonel/ratelimit/limiters';
+const INSPECT_URL = '/api/colonel/ratelimit/inspect';
+const RESET_URL = '/api/colonel/ratelimit/reset';
+
+function templatesPayload() {
+  return {
+    shrimp: '',
+    record: {
+      templates: [
+        { name: 'secret_link', class_name: 'SecretLink', formats: ['text', 'html'] },
+        { name: 'welcome', class_name: 'Welcome', formats: ['text'] },
+      ],
+    },
+    details: { count: 2 },
+  };
+}
+
+function limitersPayload() {
+  return {
+    shrimp: '',
+    record: {
+      limiters: [
+        { kind: 'feedback', subject: 'IP address' },
+        { kind: 'passphrase', subject: 'secret identifier' },
+      ],
+    },
+    details: { count: 2 },
+  };
+}
+
+function previewPayload(format: 'text' | 'html' = 'text', body = 'Hello preview body') {
+  return {
+    shrimp: '',
+    record: { template: 'secret_link', locale: 'en', format },
+    details: { body },
+  };
+}
+
+function testPayload(status: 'dry_run' | 'sent') {
+  return {
+    shrimp: '',
+    record: { to: 'ops@example.com', status, sent: status !== 'dry_run' },
+    details: {
+      provider: 'logger',
+      host: 'vm',
+      from: 'secure@onetime.dev',
+      subject: '[Secure Links] Email delivery test',
+      text_body: 'This is a test email.',
+      timestamp: '2026-07-07T00:00:00Z',
+    },
+  };
+}
+
+function inspectPayload(exists = true) {
+  return {
+    shrimp: '',
+    record: { kind: 'feedback', subject: '1.2.3.4' },
+    details: {
+      entries: [
+        { key: 'feedback:submissions:1.2.3.4', ttl: exists ? 600 : null, value: exists ? '3' : null, exists },
+        { key: 'feedback:locked:1.2.3.4', ttl: null, value: null, exists: false },
+      ],
+    },
+  };
+}
+
+function resetPayload() {
+  return {
+    shrimp: '',
+    record: { kind: 'feedback', subject: '1.2.3.4', cleared: true },
+    details: { deleted: 1, message: 'Rate limiter reset' },
+  };
+}
+
+/** Default happy-path GET router: templates + limiters on mount. */
+function primeMountGets() {
+  mockApi.get.mockImplementation((url: string) => {
+    if (url === TEMPLATES_URL) return Promise.resolve({ data: templatesPayload() });
+    if (url === LIMITERS_URL) return Promise.resolve({ data: limitersPayload() });
+    return Promise.reject(new Error(`unexpected GET ${url}`));
+  });
+}
+
+const mountView = (pinia: ReturnType<typeof createPinia>) =>
+  mount(AdminEmailTools, { global: { plugins: [pinia, i18n] } });
+
+const dialogInput = (w: VueWrapper) => w.find('#admin-confirm-input');
+const dialogSubmit = (w: VueWrapper) => w.find('[data-testid="admin-confirm-submit"]');
+
+describe('AdminEmailTools (email + rate-limit tools — ticket #44)', () => {
+  let wrapper: VueWrapper;
+  let pinia: ReturnType<typeof createPinia>;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+  });
+  afterEach(() => wrapper?.unmount());
+
+  // ---- Reference lists ------------------------------------------------------
+
+  it('loads the template + limiter pickers on mount', async () => {
+    primeMountGets();
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenCalledWith(TEMPLATES_URL);
+    expect(mockApi.get).toHaveBeenCalledWith(LIMITERS_URL);
+    const options = wrapper.find('[data-testid="preview-template-select"]').findAll('option');
+    expect(options.map((o) => o.text())).toEqual(['secret_link', 'welcome']);
+  });
+
+  // ---- Section 1: preview ---------------------------------------------------
+
+  it('renders a TEXT preview as escaped source (read-only, GET with params)', async () => {
+    primeMountGets();
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    mockApi.get.mockResolvedValueOnce({ data: previewPayload('text', 'RENDERED TEXT') });
+    await wrapper.find('[data-testid="preview-run"]').trigger('click');
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenCalledWith(
+      `${TEMPLATES_URL}/secret_link/preview`,
+      { params: { format: 'text', locale: 'en' } }
+    );
+    expect(wrapper.find('[data-testid="preview-body"]').text()).toContain('RENDERED TEXT');
+    // Text format never uses the iframe.
+    expect(wrapper.find('[data-testid="preview-iframe"]').exists()).toBe(false);
+  });
+
+  it('renders an HTML preview in a sandboxed iframe (no v-html)', async () => {
+    primeMountGets();
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    await wrapper.find('[data-testid="preview-format-select"]').setValue('html');
+    mockApi.get.mockResolvedValueOnce({ data: previewPayload('html', '<h1>Hi</h1>') });
+    await wrapper.find('[data-testid="preview-run"]').trigger('click');
+    await flushPromises();
+
+    const iframe = wrapper.find('[data-testid="preview-iframe"]');
+    expect(iframe.exists()).toBe(true);
+    expect(iframe.attributes('sandbox')).toBe('');
+    expect(iframe.attributes('srcdoc')).toContain('<h1>Hi</h1>');
+  });
+
+  // ---- Section 2: test send -------------------------------------------------
+
+  it('previews the diagnostic with dry_run:true (sends nothing)', async () => {
+    primeMountGets();
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    mockApi.post.mockResolvedValueOnce({ data: testPayload('dry_run') });
+    await wrapper.find('[data-testid="test-to-input"]').setValue('ops@example.com');
+    await wrapper.find('[data-testid="test-preview"]').trigger('click');
+    await flushPromises();
+
+    expect(mockApi.post).toHaveBeenCalledWith(TEST_URL, {
+      to: 'ops@example.com',
+      enqueue: false,
+      dry_run: true,
+    });
+    expect(wrapper.find('[data-testid="test-diagnostic"]').exists()).toBe(true);
+    expect(showMock).not.toHaveBeenCalled();
+  });
+
+  it('gates the real send behind a one-click confirm and POSTs dry_run:false', async () => {
+    primeMountGets();
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    await wrapper.find('[data-testid="test-to-input"]').setValue('ops@example.com');
+    await wrapper.find('[data-testid="test-send"]').trigger('click');
+    await flushPromises();
+
+    // One-click: no typed-token input, submit immediately enabled.
+    expect(dialogInput(wrapper).exists()).toBe(false);
+    expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+
+    mockApi.post.mockResolvedValueOnce({ data: testPayload('sent') });
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(mockApi.post).toHaveBeenCalledWith(TEST_URL, {
+      to: 'ops@example.com',
+      enqueue: false,
+      dry_run: false,
+    });
+    expect(showMock).toHaveBeenCalledWith('web.admin.emailtools.test.success', 'success');
+  });
+
+  it('surfaces a 4xx from the send in the dialog and does not notify', async () => {
+    primeMountGets();
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    await wrapper.find('[data-testid="test-to-input"]').setValue('ops@example.com');
+    await wrapper.find('[data-testid="test-send"]').trigger('click');
+    mockApi.post.mockRejectedValueOnce(axiosError(422, { error: 'Delivery failed: boom' }));
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(wrapper.find('[role="alert"]').text()).toContain('Delivery failed: boom');
+    expect(showMock).not.toHaveBeenCalled();
+  });
+
+  // ---- Section 3: rate-limit inspect + reset --------------------------------
+
+  it('inspects a limiter (read-only GET) and shows its entries', async () => {
+    primeMountGets();
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    mockApi.get.mockResolvedValueOnce({ data: inspectPayload(true) });
+    await wrapper.find('[data-testid="rl-subject-input"]').setValue('1.2.3.4');
+    await wrapper.find('[data-testid="rl-inspect"]').trigger('click');
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenCalledWith(INSPECT_URL, {
+      params: { kind: 'feedback', subject: '1.2.3.4' },
+    });
+    expect(wrapper.find('[data-testid="rl-result"]').exists()).toBe(true);
+    // A reset is offered only because at least one key exists.
+    expect(wrapper.find('[data-testid="rl-reset"]').exists()).toBe(true);
+  });
+
+  it('hides the reset action when no key exists', async () => {
+    primeMountGets();
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    mockApi.get.mockResolvedValueOnce({ data: inspectPayload(false) });
+    await wrapper.find('[data-testid="rl-subject-input"]').setValue('1.2.3.4');
+    await wrapper.find('[data-testid="rl-inspect"]').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="rl-empty"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="rl-reset"]').exists()).toBe(false);
+  });
+
+  it('gates the reset behind retyping the subject, then POSTs and re-inspects', async () => {
+    primeMountGets();
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    mockApi.get.mockResolvedValueOnce({ data: inspectPayload(true) });
+    await wrapper.find('[data-testid="rl-subject-input"]').setValue('1.2.3.4');
+    await wrapper.find('[data-testid="rl-inspect"]').trigger('click');
+    await flushPromises();
+
+    await wrapper.find('[data-testid="rl-reset"]').trigger('click');
+    await flushPromises();
+
+    // Typed-confirmation: submit disabled until the subject is retyped.
+    expect(dialogInput(wrapper).exists()).toBe(true);
+    expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+    await dialogInput(wrapper).setValue('wrong');
+    expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+    await dialogInput(wrapper).setValue('1.2.3.4');
+    expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+
+    mockApi.post.mockResolvedValueOnce({ data: resetPayload() });
+    mockApi.get.mockResolvedValueOnce({ data: inspectPayload(false) }); // re-inspect
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(mockApi.post).toHaveBeenCalledWith(RESET_URL, { kind: 'feedback', subject: '1.2.3.4' });
+    expect(showMock).toHaveBeenCalledWith('web.admin.emailtools.ratelimit.resetSuccess', 'success');
+  });
+});

--- a/src/tests/apps/admin/AdminQueueDlq.spec.ts
+++ b/src/tests/apps/admin/AdminQueueDlq.spec.ts
@@ -1,0 +1,344 @@
+// src/tests/apps/admin/AdminQueueDlq.spec.ts
+
+import { AxiosError } from 'axios';
+import { createPinia, setActivePinia } from 'pinia';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/** Build a real AxiosError so the shared classifier extracts `data.error`. */
+function axiosError(status: number, data: unknown, message = 'Request failed'): AxiosError {
+  const err = new AxiosError(message);
+  err.response = { status, data, statusText: '', headers: {}, config: {} as never };
+  return err;
+}
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+const showMock = vi.fn();
+vi.mock('@/shared/stores/notificationsStore', () => ({
+  useNotificationsStore: () => ({ show: showMock }),
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+// Render the HeadlessUI dialog markup synchronously (mirrors AdminSessions.spec).
+vi.mock('@headlessui/vue', () => ({
+  Dialog: {
+    name: 'Dialog',
+    template: '<div role="dialog" @close="$emit(\'close\')"><slot /></div>',
+    props: ['class'],
+    emits: ['close'],
+  },
+  DialogPanel: {
+    name: 'DialogPanel',
+    template: '<div class="dialog-panel" :data-testid="$attrs[\'data-testid\']"><slot /></div>',
+    props: ['class'],
+  },
+  DialogTitle: { name: 'DialogTitle', template: '<h3><slot /></h3>', props: ['as', 'class'] },
+  TransitionRoot: {
+    name: 'TransitionRoot',
+    template: '<div v-if="show"><slot /></div>',
+    props: ['as', 'show'],
+  },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>', props: ['as'] },
+}));
+
+import AdminQueueDlq from '@/apps/admin/views/AdminQueueDlq.vue';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+const LIST_URL = '/api/colonel/queues/dlq';
+const QUEUE = 'dlq.billing.event';
+const SHORT = 'billing.event';
+const DETAIL_URL = `${LIST_URL}/${QUEUE}`;
+
+function dlqRow(overrides: Record<string, unknown> = {}) {
+  return { queue: QUEUE, messages: 3, consumers: 1, ...overrides };
+}
+
+function listPayload(rows = [dlqRow()]) {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      dlqs: rows,
+      pagination: { page: 1, per_page: 50, total_count: rows.length, total_pages: 1 },
+      connected: true,
+    },
+  };
+}
+
+function messagesPayload() {
+  return {
+    shrimp: '',
+    record: { queue: QUEUE, total_messages: 3, showing: 1 },
+    details: {
+      messages: [
+        {
+          delivery_tag: 1,
+          message_id: 'm1',
+          timestamp: 1700000000,
+          age: '1m ago',
+          original_queue: 'billing.event.process',
+          death_reason: 'rejected',
+          death_count: 2,
+          error: null,
+          content_type: 'application/json',
+          payload_preview: '{"n":1}',
+        },
+      ],
+    },
+  };
+}
+
+function replayAck() {
+  return {
+    shrimp: '',
+    record: { queue: QUEUE, replayed: 3, failed: 0, would_replay: 0, dry_run: false },
+    details: { message: 'Replayed 3 message(s), 0 failed', errors: [] },
+  };
+}
+
+function replayDryRunAck() {
+  return {
+    shrimp: '',
+    record: { queue: QUEUE, replayed: 0, failed: 0, would_replay: 3, dry_run: true },
+    details: { message: '3 message(s) would be replayed', errors: [] },
+  };
+}
+
+/** Route the replay POST by its `dry_run` flag: preview vs live. */
+function routeReplayPost() {
+  mockApi.post.mockImplementation((url: string, body: { dry_run?: boolean } = {}) => {
+    if (url === `${DETAIL_URL}/replay`) {
+      return Promise.resolve({ data: body.dry_run ? replayDryRunAck() : replayAck() });
+    }
+    return Promise.reject(new Error(`unexpected POST ${url}`));
+  });
+}
+
+function purgeAck() {
+  return {
+    shrimp: '',
+    record: { queue: QUEUE, count: 3, purged: 3, dry_run: false },
+    details: { message: 'Purged 3 message(s)' },
+  };
+}
+
+/** Route GET by url so list + detail can both be mocked in one mount. */
+function routeGet(detail = messagesPayload(), list = listPayload()) {
+  mockApi.get.mockImplementation((url: string) => {
+    if (url === LIST_URL) return Promise.resolve({ data: list });
+    if (url === DETAIL_URL) return Promise.resolve({ data: detail });
+    return Promise.reject(new Error(`unexpected GET ${url}`));
+  });
+}
+
+const mountView = (pinia: ReturnType<typeof createPinia>) =>
+  mount(AdminQueueDlq, { global: { plugins: [pinia, i18n] } });
+
+const dialogInput = (w: VueWrapper) => w.find('#admin-confirm-input');
+const dialogSubmit = (w: VueWrapper) => w.find('[data-testid="admin-confirm-submit"]');
+const listGetCount = () => mockApi.get.mock.calls.filter((c) => c[0] === LIST_URL).length;
+
+describe('AdminQueueDlq (list + inspect + guarded replay/purge — ticket #42)', () => {
+  let wrapper: VueWrapper;
+  let pinia: ReturnType<typeof createPinia>;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  // ---- List -----------------------------------------------------------------
+
+  it('fetches the DLQ page on mount and renders a row per queue', async () => {
+    routeGet();
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenCalledWith(LIST_URL, { params: { page: 1, per_page: 50 } });
+    const table = wrapper.find('[data-testid="dlq-table"]');
+    expect(table.exists()).toBe(true);
+    expect(table.text()).toContain(SHORT);
+    expect(table.text()).toContain('3'); // message count
+  });
+
+  it('shows the error banner + retry on a network failure', async () => {
+    mockApi.get.mockRejectedValue(new Error('Network Error'));
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    const banner = wrapper.find('[data-testid="dlq-error"]');
+    expect(banner.exists()).toBe(true);
+
+    routeGet();
+    await banner.find('button').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-testid="dlq-error"]').exists()).toBe(false);
+  });
+
+  // ---- Inspect drawer -------------------------------------------------------
+
+  it('opens the detail drawer on row click and peeks the messages', async () => {
+    routeGet();
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    await wrapper.find('[data-testid="dlq-table"] tbody tr').trigger('click');
+    await flushPromises();
+
+    expect(mockApi.get.mock.calls.some((c) => c[0] === DETAIL_URL)).toBe(true);
+    const content = wrapper.find('[data-testid="dlq-drawer-content"]');
+    expect(content.exists()).toBe(true);
+    expect(content.text()).toContain('m1'); // message id
+    expect(content.text()).toContain('billing.event.process'); // original queue
+  });
+
+  // ---- Broker connectivity --------------------------------------------------
+
+  it('renders the disconnected notice when the broker is unreachable (connected:false)', async () => {
+    const list = listPayload([]);
+    list.details.connected = false;
+    routeGet(messagesPayload(), list);
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    // The store must surface `connected`, not drop it — otherwise an unreachable
+    // broker is indistinguishable from a healthy empty DLQ set.
+    expect(wrapper.find('[data-testid="dlq-disconnected"]').exists()).toBe(true);
+  });
+
+  // ---- Guarded replay (dry-run preview → explicit live confirm) --------------
+
+  it('previews replay as a dry-run first, then replays live on explicit confirm', async () => {
+    routeGet();
+    routeReplayPost();
+    wrapper = mountView(pinia);
+    await flushPromises();
+    const before = listGetCount();
+
+    await wrapper.find(`[data-testid="replay-${SHORT}"]`).trigger('click');
+    await flushPromises();
+
+    // First step is the safe dry-run preview (no republish).
+    expect(mockApi.post).toHaveBeenCalledWith(`${DETAIL_URL}/replay`, { dry_run: true });
+    // Replay is low-risk: no typed-confirmation input, submit enabled immediately.
+    expect(dialogInput(wrapper).exists()).toBe(false);
+    expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+
+    // Explicit second step: the LIVE replay.
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(mockApi.post).toHaveBeenCalledWith(`${DETAIL_URL}/replay`, { dry_run: false });
+    expect(showMock).toHaveBeenCalledWith('web.admin.queue.replay.success', 'success');
+    expect(listGetCount()).toBe(before + 1);
+  });
+
+  it('surfaces a dry-run preview failure and does NOT open the live-replay confirm', async () => {
+    routeGet();
+    mockApi.post.mockRejectedValue(axiosError(422, { error: 'Message queue is not connected' }));
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    await wrapper.find(`[data-testid="replay-${SHORT}"]`).trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="dlq-replay-preview-error"]').text()).toContain(
+      'Message queue is not connected'
+    );
+    // The live-replay confirm never opened, so no live replay was issued.
+    expect(dialogSubmit(wrapper).exists()).toBe(false);
+    const liveReplays = mockApi.post.mock.calls.filter(
+      (c) => c[0] === `${DETAIL_URL}/replay` && c[1]?.dry_run === false
+    );
+    expect(liveReplays).toHaveLength(0);
+    expect(showMock).not.toHaveBeenCalled();
+  });
+
+  // ---- Guarded purge (typed-confirmation) -----------------------------------
+
+  it('gates purge behind typed-confirmation of the queue name', async () => {
+    routeGet();
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    await wrapper.find(`[data-testid="purge-${SHORT}"]`).trigger('click');
+    await flushPromises();
+
+    expect(dialogInput(wrapper).exists()).toBe(true);
+    expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+    await dialogInput(wrapper).setValue('wrong');
+    expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+    await dialogInput(wrapper).setValue(SHORT);
+    expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+  });
+
+  it('POSTs the purge, notifies and refreshes on confirm', async () => {
+    routeGet();
+    mockApi.post.mockResolvedValue({ data: purgeAck() });
+    wrapper = mountView(pinia);
+    await flushPromises();
+    const before = listGetCount();
+
+    await wrapper.find(`[data-testid="purge-${SHORT}"]`).trigger('click');
+    await dialogInput(wrapper).setValue(SHORT);
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(mockApi.post).toHaveBeenCalledWith(`${DETAIL_URL}/purge`, {});
+    expect(showMock).toHaveBeenCalledWith('web.admin.queue.purge.success', 'success');
+    expect(dialogInput(wrapper).exists()).toBe(false);
+    expect(listGetCount()).toBe(before + 1);
+  });
+
+  it('does NOT purge when submitted without a matching token', async () => {
+    routeGet();
+    mockApi.post.mockResolvedValue({ data: purgeAck() });
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    await wrapper.find(`[data-testid="purge-${SHORT}"]`).trigger('click');
+    await dialogInput(wrapper).setValue('nope');
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(mockApi.post).not.toHaveBeenCalled();
+    expect(showMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a 4xx in the dialog and stays open on failure', async () => {
+    routeGet();
+    mockApi.post.mockRejectedValue(axiosError(422, { error: 'Message queue is not connected' }));
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    await wrapper.find(`[data-testid="purge-${SHORT}"]`).trigger('click');
+    await dialogInput(wrapper).setValue(SHORT);
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(wrapper.find('[role="alert"]').text()).toContain('Message queue is not connected');
+    expect(showMock).not.toHaveBeenCalled();
+    expect(dialogInput(wrapper).exists()).toBe(true);
+  });
+});

--- a/src/tests/apps/admin/AdminSessions.spec.ts
+++ b/src/tests/apps/admin/AdminSessions.spec.ts
@@ -1,0 +1,278 @@
+// src/tests/apps/admin/AdminSessions.spec.ts
+
+import { AxiosError } from 'axios';
+import { createPinia, setActivePinia } from 'pinia';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/** Build a real AxiosError so the shared classifier extracts `data.error`. */
+function axiosError(status: number, data: unknown, message = 'Request failed'): AxiosError {
+  const err = new AxiosError(message);
+  err.response = { status, data, statusText: '', headers: {}, config: {} as never };
+  return err;
+}
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+const showMock = vi.fn();
+vi.mock('@/shared/stores/notificationsStore', () => ({
+  useNotificationsStore: () => ({ show: showMock }),
+}));
+
+vi.mock('@/utils/format', () => ({
+  formatDisplayDateTime: (d: Date) => `DT:${d.toISOString()}`,
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+// Render the HeadlessUI dialog markup synchronously (mirrors AdminBannedIps.spec).
+vi.mock('@headlessui/vue', () => ({
+  Dialog: {
+    name: 'Dialog',
+    template: '<div role="dialog" @close="$emit(\'close\')"><slot /></div>',
+    props: ['class'],
+    emits: ['close'],
+  },
+  DialogPanel: {
+    name: 'DialogPanel',
+    template: '<div class="dialog-panel" :data-testid="$attrs[\'data-testid\']"><slot /></div>',
+    props: ['class'],
+  },
+  DialogTitle: { name: 'DialogTitle', template: '<h3><slot /></h3>', props: ['as', 'class'] },
+  TransitionRoot: {
+    name: 'TransitionRoot',
+    template: '<div v-if="show"><slot /></div>',
+    props: ['as', 'show'],
+  },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>', props: ['as'] },
+}));
+
+import AdminSessions from '@/apps/admin/views/AdminSessions.vue';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+const LIST_URL = '/api/colonel/sessions';
+const SID = 'sid_auth_1';
+
+function sessionsPayload(rows = [sessionRow()]) {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      sessions: rows,
+      pagination: { page: 1, per_page: 50, total_count: rows.length, total_pages: 1 },
+    },
+  };
+}
+
+function sessionRow(overrides: Record<string, unknown> = {}) {
+  return {
+    session_id: SID,
+    key: `session:${SID}`,
+    authenticated: true,
+    email: 'alice@example.com',
+    external_id: 'ext_1',
+    role: 'customer',
+    ip_address: '203.0.113.7',
+    created_at: 1700000000,
+    ...overrides,
+  };
+}
+
+function detailPayload() {
+  return {
+    shrimp: '',
+    record: {
+      session_id: SID,
+      key: `session:${SID}`,
+      ttl: 3600,
+      authenticated: true,
+      email: 'alice@example.com',
+      external_id: 'ext_1',
+      account_id: 42,
+      role: 'customer',
+      locale: 'en',
+      ip_address: '203.0.113.7',
+      authenticated_at: 1700000000,
+      authenticated_by: 'password',
+      active_session_id: 'as_1',
+    },
+    details: { data: { authenticated: true, email: 'alice@example.com' } },
+  };
+}
+
+function revokeAck() {
+  return {
+    shrimp: '',
+    record: { session_id: SID, deleted: true },
+    details: { message: 'Session revoked successfully' },
+  };
+}
+
+const mountView = (pinia: ReturnType<typeof createPinia>) =>
+  mount(AdminSessions, { global: { plugins: [pinia, i18n] } });
+
+const dialogInput = (w: VueWrapper) => w.find('#admin-confirm-input');
+const dialogSubmit = (w: VueWrapper) => w.find('[data-testid="admin-confirm-submit"]');
+const listGetCount = () => mockApi.get.mock.calls.filter((c) => c[0] === LIST_URL).length;
+
+describe('AdminSessions (list + search + inspect + guarded revoke — ticket #40)', () => {
+  let wrapper: VueWrapper;
+  let pinia: ReturnType<typeof createPinia>;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    wrapper?.unmount();
+  });
+
+  // ---- List -----------------------------------------------------------------
+
+  it('fetches the sessions page on mount and renders a row per session', async () => {
+    mockApi.get.mockResolvedValue({ data: sessionsPayload() });
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    // First (list) fetch carries page/per_page but no search param.
+    expect(mockApi.get).toHaveBeenCalledWith(LIST_URL, {
+      params: { page: 1, per_page: 50 },
+    });
+    const table = wrapper.find('[data-testid="sessions-table"]');
+    expect(table.exists()).toBe(true);
+    expect(table.text()).toContain(SID);
+    expect(table.text()).toContain('alice@example.com');
+  });
+
+  it('debounces the search box into a single filtered fetch', async () => {
+    mockApi.get.mockResolvedValue({ data: sessionsPayload() });
+    wrapper = mountView(pinia);
+    await flushPromises();
+    const before = listGetCount();
+
+    await wrapper.find('[data-testid="sessions-filterbar"] input').setValue('alice');
+    // Debounced — no request yet.
+    expect(listGetCount()).toBe(before);
+
+    vi.advanceTimersByTime(300);
+    await flushPromises();
+
+    expect(listGetCount()).toBe(before + 1);
+    expect(mockApi.get).toHaveBeenLastCalledWith(LIST_URL, {
+      params: { page: 1, per_page: 50, search: 'alice' },
+    });
+  });
+
+  it('shows the error banner + retry on a network failure', async () => {
+    mockApi.get.mockRejectedValue(new Error('Network Error'));
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    const banner = wrapper.find('[data-testid="sessions-error"]');
+    expect(banner.exists()).toBe(true);
+
+    mockApi.get.mockResolvedValueOnce({ data: sessionsPayload() });
+    await banner.find('button').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-testid="sessions-error"]').exists()).toBe(false);
+  });
+
+  // ---- Inspect drawer -------------------------------------------------------
+
+  it('opens the detail drawer on row click and loads the session detail', async () => {
+    mockApi.get.mockResolvedValueOnce({ data: sessionsPayload() });
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    mockApi.get.mockResolvedValueOnce({ data: detailPayload() });
+    await wrapper.find('[data-testid="sessions-table"] tbody tr').trigger('click');
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenCalledWith(`${LIST_URL}/${SID}`, undefined);
+    const content = wrapper.find('[data-testid="session-drawer-content"]');
+    expect(content.exists()).toBe(true);
+    expect(content.text()).toContain('as_1'); // active_session_id field
+  });
+
+  // ---- Guarded revoke (D4) --------------------------------------------------
+
+  describe('revoke — typed-confirmation gate', () => {
+    beforeEach(async () => {
+      mockApi.get.mockResolvedValue({ data: sessionsPayload() });
+      wrapper = mountView(pinia);
+      await flushPromises();
+    });
+
+    it('opens a danger dialog from the row action, gated until the id is retyped', async () => {
+      await wrapper.find(`[data-testid="revoke-${SID}"]`).trigger('click');
+      await flushPromises();
+
+      expect(dialogInput(wrapper).exists()).toBe(true);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+      await dialogInput(wrapper).setValue('not-the-id');
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+      await dialogInput(wrapper).setValue(SID);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+    });
+
+    it('DELETEs the session, notifies and refreshes the list on confirm', async () => {
+      mockApi.delete.mockResolvedValue({ data: revokeAck() });
+      const before = listGetCount();
+
+      await wrapper.find(`[data-testid="revoke-${SID}"]`).trigger('click');
+      await dialogInput(wrapper).setValue(SID);
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockApi.delete).toHaveBeenCalledWith(`${LIST_URL}/${SID}`);
+      expect(showMock).toHaveBeenCalledWith('web.admin.sessions.revoke.success', 'success');
+      expect(dialogInput(wrapper).exists()).toBe(false);
+      expect(listGetCount()).toBe(before + 1);
+    });
+
+    it('does NOT DELETE when submitted without a matching token', async () => {
+      mockApi.delete.mockResolvedValue({ data: revokeAck() });
+      await wrapper.find(`[data-testid="revoke-${SID}"]`).trigger('click');
+      await dialogInput(wrapper).setValue('wrong');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockApi.delete).not.toHaveBeenCalled();
+      expect(showMock).not.toHaveBeenCalled();
+    });
+
+    it('surfaces a 4xx in the dialog and stays open on failure', async () => {
+      mockApi.delete.mockRejectedValue(axiosError(404, { error: 'Session not found' }));
+      const before = listGetCount();
+
+      await wrapper.find(`[data-testid="revoke-${SID}"]`).trigger('click');
+      await dialogInput(wrapper).setValue(SID);
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(wrapper.find('[role="alert"]').text()).toContain('Session not found');
+      expect(showMock).not.toHaveBeenCalled();
+      expect(dialogInput(wrapper).exists()).toBe(true);
+      expect(listGetCount()).toBe(before);
+    });
+  });
+});

--- a/src/tests/apps/admin/bannerSchemas.spec.ts
+++ b/src/tests/apps/admin/bannerSchemas.spec.ts
@@ -1,0 +1,105 @@
+// src/tests/apps/admin/bannerSchemas.spec.ts
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  colonelBannerResponseSchema,
+  colonelBannerSetResponseSchema,
+  colonelBannerClearResponseSchema,
+} from '@/schemas/api/internal/responses/colonel-banner';
+
+/**
+ * Zod tripwire (CONTRACT 3) for the Broadcast Banner screen (#41). All three
+ * payloads are shaped exactly as the live logic classes emit them — verified
+ * against apps/api/colonel/logic/colonel/{get,set,clear}_banner.rb (which delegate
+ * to Onetime::Operations::{Get,Set,Clear}Banner). A backend drift fails here
+ * rather than silently breaking the screen.
+ */
+
+describe('colonelBannerResponseSchema (GetBanner)', () => {
+  it('parses a live persistent banner (ttl null)', () => {
+    const payload = {
+      shrimp: '',
+      record: { content: '<a href="/status">Notice</a>', ttl: null, active: true },
+      details: { key: 'global_banner', database: 0 },
+    };
+    const result = colonelBannerResponseSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.record.active).toBe(true);
+    expect(result.data.record.ttl).toBeNull();
+  });
+
+  it('parses an expiring banner (ttl number) and the empty state (content null)', () => {
+    expect(
+      colonelBannerResponseSchema.safeParse({
+        shrimp: '',
+        record: { content: 'temp', ttl: 3600, active: true },
+        details: { key: 'global_banner', database: 0 },
+      }).success
+    ).toBe(true);
+
+    expect(
+      colonelBannerResponseSchema.safeParse({
+        shrimp: '',
+        record: { content: null, ttl: null, active: false },
+        details: { key: 'global_banner', database: 0 },
+      }).success
+    ).toBe(true);
+  });
+
+  it('rejects a record missing the active flag (contract drift)', () => {
+    const payload = {
+      record: { content: 'x', ttl: null },
+      details: { key: 'global_banner', database: 0 },
+    };
+    expect(colonelBannerResponseSchema.safeParse(payload).success).toBe(false);
+  });
+});
+
+describe('colonelBannerSetResponseSchema (SetBanner ack)', () => {
+  it('validates the publish ack', () => {
+    const payload = {
+      shrimp: '',
+      record: { content: 'New notice', ttl: null, active: true },
+      details: { message: 'Broadcast banner published' },
+    };
+    const result = colonelBannerSetResponseSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.details.message).toBe('Broadcast banner published');
+  });
+
+  it('rejects a set ack missing details.message', () => {
+    const payload = {
+      record: { content: 'x', ttl: null, active: true },
+      details: {},
+    };
+    expect(colonelBannerSetResponseSchema.safeParse(payload).success).toBe(false);
+  });
+});
+
+describe('colonelBannerClearResponseSchema (ClearBanner ack)', () => {
+  it('validates the clear ack (cleared true/false)', () => {
+    expect(
+      colonelBannerClearResponseSchema.safeParse({
+        shrimp: '',
+        record: { cleared: true, active: false },
+        details: { message: 'Broadcast banner cleared' },
+      }).success
+    ).toBe(true);
+
+    expect(
+      colonelBannerClearResponseSchema.safeParse({
+        shrimp: '',
+        record: { cleared: false, active: false },
+        details: { message: 'No banner was set' },
+      }).success
+    ).toBe(true);
+  });
+
+  it('rejects a clear ack missing the cleared flag', () => {
+    const payload = { record: { active: false }, details: { message: 'ok' } };
+    expect(colonelBannerClearResponseSchema.safeParse(payload).success).toBe(false);
+  });
+});

--- a/src/tests/apps/admin/billingSchemas.spec.ts
+++ b/src/tests/apps/admin/billingSchemas.spec.ts
@@ -1,0 +1,99 @@
+// src/tests/apps/admin/billingSchemas.spec.ts
+
+import { describe, expect, it } from 'vitest';
+
+import { colonelBillingCatalogResponseSchema } from '@/schemas/api/internal/responses/colonel-billing';
+
+/**
+ * Zod tripwire (CONTRACT 3) for the NEW Billing-catalog contract (ticket #45).
+ * The payload is shaped exactly as the live logic class emits it — verified
+ * against apps/api/colonel/logic/colonel/get_billing_catalog.rb, a read-only
+ * adapter over Billing::Plan (list_plans + list_plans_from_config). If the
+ * backend drifts, this fails rather than the screen silently breaking.
+ */
+describe('colonelBillingCatalogResponseSchema', () => {
+  const validPlan = {
+    planid: 'identity_plus_v1',
+    name: 'Identity+',
+    tier: 'single_team',
+    tenancy: 'shared',
+    region: 'US',
+    display_order: 2,
+    show_on_plans_page: true,
+    description: null,
+    entitlements: ['create_secrets', 'custom_domains'],
+    limits: { 'teams.max': '1', 'custom_domains.max': 'unlimited' },
+  };
+
+  it('parses a full drift catalog (both sides + drift summary)', () => {
+    const parsed = colonelBillingCatalogResponseSchema.parse({
+      shrimp: '',
+      record: {},
+      details: {
+        source: 'stripe',
+        stripe_configured: true,
+        config_plans: [validPlan],
+        live_plans: [{ ...validPlan, entitlements: ['create_secrets'] }],
+        drift: {
+          in_sync: false,
+          only_in_config: ['legacy_v1'],
+          only_in_live: ['new_v2'],
+          changed: [
+            { planid: 'identity_plus_v1', name: 'Identity+', fields: ['entitlements'] },
+          ],
+        },
+      },
+    });
+    expect(parsed.details?.source).toBe('stripe');
+    expect(parsed.details?.drift.changed[0].fields).toContain('entitlements');
+    expect(parsed.details?.config_plans[0].limits['teams.max']).toBe('1');
+  });
+
+  it('parses a local_config catalog with no live plans', () => {
+    const parsed = colonelBillingCatalogResponseSchema.parse({
+      shrimp: '',
+      record: {},
+      details: {
+        source: 'local_config',
+        stripe_configured: false,
+        config_plans: [validPlan],
+        live_plans: [],
+        drift: { in_sync: false, only_in_config: ['identity_plus_v1'], only_in_live: [], changed: [] },
+      },
+    });
+    expect(parsed.details?.stripe_configured).toBe(false);
+    expect(parsed.details?.live_plans).toHaveLength(0);
+  });
+
+  it('rejects an unknown source enum value (contract drift)', () => {
+    expect(() =>
+      colonelBillingCatalogResponseSchema.parse({
+        shrimp: '',
+        record: {},
+        details: {
+          source: 'mysql', // not stripe | local_config
+          stripe_configured: true,
+          config_plans: [],
+          live_plans: [],
+          drift: { in_sync: true, only_in_config: [], only_in_live: [], changed: [] },
+        },
+      })
+    ).toThrow();
+  });
+
+  it('rejects a non-string limit value (limits must be string→string)', () => {
+    expect(() =>
+      colonelBillingCatalogResponseSchema.parse({
+        shrimp: '',
+        record: {},
+        details: {
+          source: 'stripe',
+          stripe_configured: true,
+          config_plans: [{ ...validPlan, limits: { 'teams.max': 1 } }],
+          live_plans: [],
+          drift: { in_sync: true, only_in_config: [], only_in_live: [], changed: [] },
+        },
+      })
+    ).toThrow();
+  });
+});

--- a/src/tests/apps/admin/domainToolboxSchemas.spec.ts
+++ b/src/tests/apps/admin/domainToolboxSchemas.spec.ts
@@ -1,0 +1,125 @@
+// src/tests/apps/admin/domainToolboxSchemas.spec.ts
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  colonelDomainsOrphanedResponseSchema,
+  colonelDomainProbeResponseSchema,
+  colonelDomainRepairResponseSchema,
+  colonelDomainTransferResponseSchema,
+} from '@/schemas/api/internal/responses/colonel-domaintoolbox';
+
+/**
+ * Zod tripwire (CONTRACT 3) for the four NEW Domain-Toolbox contracts (ticket
+ * #43). Payloads are shaped exactly as the live logic classes emit them —
+ * verified against apps/api/colonel/logic/colonel/{list_orphaned_domains,
+ * probe_domain,repair_domain,transfer_domain}.rb, thin adapters over
+ * Onetime::Operations::Domains::*. If a backend response drifts, these fail
+ * rather than the screen silently breaking.
+ */
+
+describe('colonelDomainsOrphanedResponseSchema', () => {
+  it('parses an orphaned-scan page (epoch created → Date)', () => {
+    const parsed = colonelDomainsOrphanedResponseSchema.parse({
+      shrimp: '',
+      record: {},
+      details: {
+        domains: [
+          {
+            domain_id: 'cd_1',
+            extid: 'cd_ext_1',
+            display_domain: 'orphan.example.com',
+            verification_state: 'pending',
+            verified: false,
+            created: 1700000000,
+          },
+        ],
+        pagination: { page: 1, per_page: 50, total_count: 1, total_pages: 1 },
+      },
+    });
+    expect(parsed.details?.domains[0].created).toBeInstanceOf(Date);
+    expect(parsed.details?.domains[0].extid).toBe('cd_ext_1');
+  });
+});
+
+describe('colonelDomainProbeResponseSchema', () => {
+  it('parses a healthy probe with SSL cert details', () => {
+    const parsed = colonelDomainProbeResponseSchema.parse({
+      shrimp: '',
+      record: { extid: 'cd_ext_1', display_domain: 'example.com' },
+      details: {
+        timestamp: '2026-07-07T00:00:00Z',
+        domain: 'example.com',
+        url: 'https://example.com',
+        http: { status_code: 200, status_message: 'OK', success: true },
+        ssl: {
+          valid: true,
+          subject: 'CN=example.com',
+          issuer: 'CN=CA',
+          not_before: '2026-01-01T00:00:00Z',
+          not_after: '2026-12-31T00:00:00Z',
+          days_until_expiry: 100,
+          expired: false,
+          not_yet_valid: false,
+        },
+        health: 'healthy',
+      },
+    });
+    expect(parsed.details?.health).toBe('healthy');
+    expect(parsed.details?.http.success).toBe(true);
+  });
+
+  it('parses an error probe with no SSL arm (connection refused)', () => {
+    const parsed = colonelDomainProbeResponseSchema.parse({
+      shrimp: '',
+      record: { extid: 'cd_ext_1', display_domain: 'down.example.com' },
+      details: {
+        timestamp: '2026-07-07T00:00:00Z',
+        domain: 'down.example.com',
+        url: 'https://down.example.com',
+        http: { error: 'Connection Refused', message: 'ECONNREFUSED' },
+        health: 'connection_refused',
+      },
+    });
+    expect(parsed.details?.ssl).toBeUndefined();
+    expect(parsed.details?.http.error).toBe('Connection Refused');
+  });
+});
+
+describe('colonelDomainRepairResponseSchema', () => {
+  it('parses a dry-run plan with issues', () => {
+    const parsed = colonelDomainRepairResponseSchema.parse({
+      shrimp: '',
+      record: { domain_id: 'cd_1', extid: 'cd_ext_1', display_domain: 'x.example.com' },
+      details: {
+        status: 'planned',
+        dry_run: true,
+        issues: ["org_id is on_abc but not in organization's domains collection"],
+        repairs_applied: [],
+      },
+    });
+    expect(parsed.details?.status).toBe('planned');
+    expect(parsed.details?.issues).toHaveLength(1);
+    expect(parsed.details?.repairs_applied).toHaveLength(0);
+  });
+});
+
+describe('colonelDomainTransferResponseSchema', () => {
+  it('parses a transfer plan with a nullable from-org name and orphaned id', () => {
+    const parsed = colonelDomainTransferResponseSchema.parse({
+      shrimp: '',
+      record: { domain_id: 'cd_1', extid: 'cd_ext_1', display_domain: 'x.example.com' },
+      details: {
+        status: 'planned',
+        dry_run: true,
+        from_org_id: '',
+        from_org_name: null,
+        to_org_id: 'on_dest',
+        to_org_name: 'Dest Org',
+      },
+    });
+    expect(parsed.details?.from_org_id).toBe('');
+    expect(parsed.details?.from_org_name).toBeNull();
+    expect(parsed.details?.to_org_name).toBe('Dest Org');
+  });
+});

--- a/src/tests/apps/admin/queueSchemas.spec.ts
+++ b/src/tests/apps/admin/queueSchemas.spec.ts
@@ -1,0 +1,103 @@
+// src/tests/apps/admin/queueSchemas.spec.ts
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  colonelDlqListResponseSchema,
+  colonelDlqMessagesResponseSchema,
+  colonelDlqReplayResponseSchema,
+  colonelDlqPurgeResponseSchema,
+} from '@/schemas/api/internal/responses/colonel-queue';
+
+/**
+ * Zod tripwire (CONTRACT 3) for the four NEW Queue-DLQ-console contracts. These
+ * payloads are shaped exactly as the live logic classes emit them — verified
+ * against apps/api/colonel/logic/colonel/{list_dlqs,get_dlq_messages,replay_dlq,
+ * purge_dlq}.rb, thin adapters over Onetime::Operations::Dlq::*. If a backend
+ * response drifts, these fail rather than the screen silently breaking.
+ */
+
+// ListDlqs `success_data` — a healthy queue + one not-yet-declared queue.
+function listPayload() {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      dlqs: [
+        { queue: 'dlq.billing.event', messages: 3, consumers: 1 },
+        { queue: 'dlq.email.message', messages: 0, error: 'not declared' },
+      ],
+      pagination: { page: 1, per_page: 50, total_count: 2, total_pages: 1 },
+      connected: true,
+    },
+  };
+}
+
+// GetDlqMessages `success_data` — one peeked message with full death diagnosis.
+function messagesPayload() {
+  return {
+    shrimp: '',
+    record: { queue: 'dlq.billing.event', total_messages: 3, showing: 1 },
+    details: {
+      messages: [
+        {
+          delivery_tag: 1,
+          message_id: 'm1',
+          timestamp: 1700000000,
+          age: '1m ago',
+          original_queue: 'billing.event.process',
+          death_reason: 'rejected',
+          death_count: 2,
+          error: null,
+          content_type: 'application/json',
+          payload_preview: '{"n":1}',
+        },
+      ],
+    },
+  };
+}
+
+describe('colonel Queue DLQ schemas (ticket #42, CONTRACT 3)', () => {
+  it('accepts a ListDlqs payload (healthy + not-declared rows)', () => {
+    const parsed = colonelDlqListResponseSchema.safeParse(listPayload());
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.details?.dlqs).toHaveLength(2);
+      expect(parsed.data.details?.dlqs[1].error).toBe('not declared');
+    }
+  });
+
+  it('accepts a GetDlqMessages payload with null death fields', () => {
+    const parsed = colonelDlqMessagesResponseSchema.safeParse(messagesPayload());
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.record?.total_messages).toBe(3);
+      expect(parsed.data.details?.messages[0].original_queue).toBe('billing.event.process');
+    }
+  });
+
+  it('accepts a ReplayDlq ack (counts + dry-run flag)', () => {
+    const parsed = colonelDlqReplayResponseSchema.safeParse({
+      shrimp: '',
+      record: { queue: 'dlq.billing.event', replayed: 3, failed: 0, would_replay: 0, dry_run: false },
+      details: { message: 'Replayed 3 message(s), 0 failed', errors: [] },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('accepts a PurgeDlq ack (count + purged)', () => {
+    const parsed = colonelDlqPurgeResponseSchema.safeParse({
+      shrimp: '',
+      record: { queue: 'dlq.billing.event', count: 6, purged: 6, dry_run: false },
+      details: { message: 'Purged 6 message(s)' },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects a DLQ summary row missing the required message count (drift tripwire)', () => {
+    const bad = listPayload();
+    // @ts-expect-error — deliberately drop the required `messages` field.
+    delete bad.details.dlqs[0].messages;
+    expect(colonelDlqListResponseSchema.safeParse(bad).success).toBe(false);
+  });
+});

--- a/src/tests/apps/admin/routes.spec.ts
+++ b/src/tests/apps/admin/routes.spec.ts
@@ -177,4 +177,58 @@ describe('Admin Routes Configuration', () => {
       });
     });
   });
+
+  describe('Phase-3 routes (tickets #40-45)', () => {
+    const cases: Array<{ path: string; name: string; title: string; sectionKey: string }> = [
+      {
+        path: '/colonel/sessions',
+        name: 'AdminSessions',
+        title: 'web.admin.sessions.title',
+        sectionKey: 'sessions',
+      },
+      {
+        path: '/colonel/banner',
+        name: 'AdminBanner',
+        title: 'web.admin.banner.title',
+        sectionKey: 'banner',
+      },
+      {
+        path: '/colonel/queues/dlq',
+        name: 'AdminQueueDlq',
+        title: 'web.admin.queue.title',
+        sectionKey: 'queueDlq',
+      },
+      {
+        path: '/colonel/domain-toolbox',
+        name: 'AdminDomainToolbox',
+        title: 'web.admin.domaintoolbox.title',
+        sectionKey: 'domaintoolbox',
+      },
+      {
+        path: '/colonel/email-tools',
+        name: 'AdminEmailTools',
+        title: 'web.admin.emailtools.title',
+        sectionKey: 'emailTools',
+      },
+      {
+        path: '/colonel/billing',
+        name: 'AdminBilling',
+        title: 'web.admin.billing.title',
+        sectionKey: 'billing',
+      },
+    ];
+
+    cases.forEach(({ path, name, title, sectionKey }) => {
+      it(`registers the ${name} route at ${path}`, () => {
+        const route = adminRoutes.find((r: RouteRecordRaw) => r.path === path);
+        expect(route).toBeDefined();
+        expect(route?.name).toBe(name);
+        expect(route?.meta?.title).toBe(title);
+      });
+
+      it(`${sectionKey} is a live section pointing at ${path}`, () => {
+        expect(CONSOLE_SECTIONS.find((s) => s.key === sectionKey)?.to).toBe(path);
+      });
+    });
+  });
 });

--- a/src/tests/apps/admin/sessionSchemas.spec.ts
+++ b/src/tests/apps/admin/sessionSchemas.spec.ts
@@ -1,0 +1,144 @@
+// src/tests/apps/admin/sessionSchemas.spec.ts
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  colonelSessionsResponseSchema,
+  colonelSessionDetailResponseSchema,
+  colonelSessionDeleteResponseSchema,
+} from '@/schemas/api/internal/responses/colonel-sessions';
+
+/**
+ * Zod tripwire (CONTRACT 3) for the three NEW Sessions-console contracts. These
+ * payloads are shaped exactly as the live logic classes emit them — verified
+ * against apps/api/colonel/logic/colonel/{list_sessions,get_session_detail,
+ * delete_session}.rb, thin adapters over Onetime::Operations::Sessions::*. If a
+ * backend response drifts, these fail rather than the screen silently breaking.
+ */
+
+// ListSessions `success_data`, on the wire (bare-number epoch fields).
+function listPayload() {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      sessions: [
+        {
+          session_id: 'sid_auth',
+          key: 'session:sid_auth',
+          authenticated: true,
+          email: 'alice@example.com',
+          external_id: 'ext_1',
+          role: 'customer',
+          ip_address: '203.0.113.7',
+          created_at: 1700000000,
+        },
+        {
+          session_id: 'sid_anon',
+          key: 'session:sid_anon',
+          authenticated: false,
+          email: null,
+          external_id: null,
+          role: null,
+          ip_address: null,
+          created_at: null,
+        },
+      ],
+      pagination: { page: 1, per_page: 50, total_count: 2, total_pages: 1 },
+    },
+  };
+}
+
+describe('colonelSessionsResponseSchema (ListSessions)', () => {
+  it('parses the list payload including an anonymous (all-null) session row', () => {
+    const result = colonelSessionsResponseSchema.safeParse(listPayload());
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.details?.sessions).toHaveLength(2);
+    expect(result.data.details?.sessions[1].email).toBeNull();
+    expect(result.data.details?.sessions[1].created_at).toBeNull();
+    expect(result.data.details?.pagination.total_count).toBe(2);
+  });
+
+  it('rejects a row missing the required authenticated flag (contract drift)', () => {
+    const payload = listPayload() as unknown as {
+      details: { sessions: Array<{ authenticated?: boolean }> };
+    };
+    delete payload.details.sessions[0].authenticated;
+    expect(colonelSessionsResponseSchema.safeParse(payload).success).toBe(false);
+  });
+});
+
+describe('colonelSessionDetailResponseSchema (GetSessionDetail)', () => {
+  function detailPayload() {
+    return {
+      shrimp: '',
+      record: {
+        session_id: 'sid_auth',
+        key: 'session:sid_auth',
+        ttl: 3600,
+        authenticated: true,
+        email: 'alice@example.com',
+        external_id: 'ext_1',
+        account_id: 42,
+        role: 'customer',
+        locale: 'en',
+        ip_address: '203.0.113.7',
+        authenticated_at: 1700000000,
+        authenticated_by: 'password',
+        active_session_id: 'as_1',
+      },
+      details: {
+        data: { authenticated: true, email: 'alice@example.com', csrf: 'abc' },
+      },
+    };
+  }
+
+  it('parses the detail payload with a numeric account_id and open raw data', () => {
+    const result = colonelSessionDetailResponseSchema.safeParse(detailPayload());
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.record.ttl).toBe(3600);
+    expect(result.data.record.account_id).toBe(42);
+    expect(result.data.details?.data.email).toBe('alice@example.com');
+  });
+
+  it('accepts an anonymous session: -1 ttl and null identity fields', () => {
+    const payload = detailPayload();
+    payload.record.ttl = -1;
+    payload.record.email = null as never;
+    payload.record.external_id = null as never;
+    payload.record.account_id = null as never;
+    payload.record.authenticated = false;
+    payload.record.authenticated_at = null as never;
+    payload.record.authenticated_by = null as never;
+    payload.record.active_session_id = null as never;
+    const result = colonelSessionDetailResponseSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.record.ttl).toBe(-1);
+    expect(result.data.record.account_id).toBeNull();
+  });
+});
+
+describe('colonelSessionDeleteResponseSchema (DeleteSession)', () => {
+  it('validates the revoke ack', () => {
+    const payload = {
+      shrimp: '',
+      record: { session_id: 'sid_auth', deleted: true },
+      details: { message: 'Session revoked successfully' },
+    };
+    const result = colonelSessionDeleteResponseSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.record.deleted).toBe(true);
+  });
+
+  it('rejects an ack missing details.message', () => {
+    const payload = {
+      record: { session_id: 'sid_auth', deleted: true },
+      details: {},
+    };
+    expect(colonelSessionDeleteResponseSchema.safeParse(payload).success).toBe(false);
+  });
+});

--- a/src/tests/apps/admin/useAdminSessions.spec.ts
+++ b/src/tests/apps/admin/useAdminSessions.spec.ts
@@ -1,0 +1,99 @@
+// src/tests/apps/admin/useAdminSessions.spec.ts
+
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock('@/shared/composables/useApi', () => ({
+  useApi: () => mockApi,
+}));
+
+import { useAdminSessions } from '@/apps/admin/stores/useAdminSessions';
+
+function sessionsPayload() {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      sessions: [
+        {
+          session_id: 'sid_1',
+          key: 'session:sid_1',
+          authenticated: true,
+          email: 'alice@example.com',
+          external_id: 'ext_1',
+          role: 'customer',
+          ip_address: '203.0.113.7',
+          created_at: 1700000000,
+        },
+      ],
+      pagination: { page: 1, per_page: 50, total_count: 1, total_pages: 1 },
+    },
+  };
+}
+
+describe('useAdminSessions', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses a unique store id', () => {
+    expect(useAdminSessions().$id).toBe('adminSessions');
+  });
+
+  it('fetches the sessions endpoint and maps the page via its own selector', async () => {
+    mockApi.get.mockResolvedValue({ data: sessionsPayload() });
+    const store = useAdminSessions();
+
+    await store.fetchPage(1);
+
+    expect(mockApi.get).toHaveBeenCalledWith('/api/colonel/sessions', {
+      params: { page: 1, per_page: 50 },
+    });
+    expect(store.sessions).toHaveLength(1);
+    expect(store.sessions[0].session_id).toBe('sid_1');
+    expect(store.pagination?.total_count).toBe(1);
+  });
+
+  it('passes the search term through as a server query param', async () => {
+    mockApi.get.mockResolvedValue({ data: sessionsPayload() });
+    const store = useAdminSessions();
+
+    await store.fetchPage(1, 'alice@example.com');
+
+    expect(mockApi.get).toHaveBeenCalledWith('/api/colonel/sessions', {
+      params: { page: 1, per_page: 50, search: 'alice@example.com' },
+    });
+  });
+
+  it('clears rows and rethrows on a network failure', async () => {
+    mockApi.get.mockRejectedValue(new Error('Network Error'));
+    const store = useAdminSessions();
+
+    await expect(store.fetchPage(1)).rejects.toThrow('Network Error');
+    expect(store.sessions).toEqual([]);
+    expect(store.pagination).toBeNull();
+  });
+
+  it('$reset restores initial state', async () => {
+    mockApi.get.mockResolvedValue({ data: sessionsPayload() });
+    const store = useAdminSessions();
+    await store.fetchPage(1);
+    expect(store.sessions).toHaveLength(1);
+
+    store.$reset();
+
+    expect(store.sessions).toEqual([]);
+    expect(store.pagination).toBeNull();
+    expect(store.page).toBe(1);
+  });
+});

--- a/try/integration/api/colonel/get_billing_catalog_try.rb
+++ b/try/integration/api/colonel/get_billing_catalog_try.rb
@@ -1,0 +1,111 @@
+# try/integration/api/colonel/get_billing_catalog_try.rb
+#
+# frozen_string_literal: true
+
+# Integration tests for the colonel billing-catalog drift endpoint:
+#
+#   GET /api/colonel/billing/catalog
+#
+# Part of the Colonel Admin Rebuild epic (#3653), Phase 3 ticket #45. The
+# endpoint is a READ-ONLY adapter over the incumbent Billing::Plan source
+# (list_plans + list_plans_from_config) — no op extraction, no mutating route
+# (spec: read-only drift first; sync stays CLI-only). It returns BOTH the
+# configured catalog and the live Stripe-synced plans plus a computed drift
+# summary.
+#
+# Covers:
+# - 401 for anonymous, 403 for non-colonel (defense-in-depth: router + logic)
+# - 200 for colonel with the record/details envelope
+# - details carries config_plans + live_plans + a drift summary
+# - source is "local_config" when the Stripe cache is empty (test env)
+# - READ-ONLY: the request records NO AdminAuditEvent (CONTRACT 4)
+#
+# Run: try --agent try/integration/api/colonel/get_billing_catalog_try.rb
+
+require 'rack/test'
+require_relative '../../../support/test_helpers'
+
+OT.boot! :test
+
+require 'onetime/application/registry'
+Onetime::Application::Registry.prepare_application_registry
+
+@test = Object.new
+@test.extend Rack::Test::Methods
+
+def @test.app
+  Onetime::Application::Registry.generate_rack_url_map
+end
+
+def get(*args);    @test.get(*args);    end
+def last_response; @test.last_response; end
+
+@timestamp = Familia.now.to_i
+
+# Colonel user (role persisted so session auth reads it)
+@colonel = Onetime::Customer.create!(email: "colonel_billing_#{@timestamp}@example.com")
+@colonel.role = 'colonel'
+@colonel.verified = 'true'
+@colonel.save
+
+# Regular (non-colonel) customer
+@regular = Onetime::Customer.create!(email: "regular_billing_#{@timestamp}@example.com")
+@regular.verified = 'true'
+@regular.save
+
+@colonel_session = {
+  'authenticated' => true,
+  'external_id'   => @colonel.extid,
+  'email'         => @colonel.email,
+}
+@regular_session = {
+  'authenticated' => true,
+  'external_id'   => @regular.extid,
+  'email'         => @regular.email,
+}
+
+@path = '/api/colonel/billing/catalog'
+
+# TRYOUTS
+
+## Anonymous (no session) gets 401
+@test.clear_cookies
+get @path, {}, { 'HTTP_ACCEPT' => 'application/json' }
+last_response.status
+#=> 401
+
+## Non-colonel gets 403
+get @path, {}, { 'rack.session' => @regular_session, 'HTTP_ACCEPT' => 'application/json' }
+last_response.status
+#=> 403
+
+## Colonel gets 200 with the record/details envelope
+get @path, {}, { 'rack.session' => @colonel_session, 'HTTP_ACCEPT' => 'application/json' }
+@resp = JSON.parse(last_response.body)
+[last_response.status, @resp['details'].is_a?(Hash)]
+#=> [200, true]
+
+## details exposes both catalog sides plus a drift summary
+d = @resp['details']
+[d['config_plans'].is_a?(Array), d['live_plans'].is_a?(Array), d['drift'].is_a?(Hash)]
+#=> [true, true, true]
+
+## the drift summary carries the expected key set
+@resp['details']['drift'].keys.sort
+#=> ["changed", "in_sync", "only_in_config", "only_in_live"]
+
+## with no Stripe cache in test env, source is local_config and live is empty
+d = @resp['details']
+[d['source'], d['live_plans'].empty?, d['stripe_configured']]
+#=> ["local_config", true, false]
+
+## every configured plan carries the shared PlanEntry field set
+plan = @resp['details']['config_plans'].first
+plan.nil? || (%w[planid name tier entitlements limits] - plan.keys).empty?
+#=> true
+
+## READ-ONLY: the request records NO AdminAuditEvent (CONTRACT 4)
+@before = Onetime::AdminAuditEvent.events.size
+get @path, {}, { 'rack.session' => @colonel_session, 'HTTP_ACCEPT' => 'application/json' }
+Onetime::AdminAuditEvent.events.size - @before
+#=> 0

--- a/try/unit/operations/banner_try.rb
+++ b/try/unit/operations/banner_try.rb
@@ -1,0 +1,172 @@
+# try/unit/operations/banner_try.rb
+#
+# frozen_string_literal: true
+
+#
+# Unit tryouts for the extracted broadcast-banner operations (epic #41):
+#   Onetime::Operations::GetBanner / SetBanner / ClearBanner
+#
+# These are the SINGLE implementation of the banner get/set/clear verbs (the
+# colonel API + `bin/ots banner` CLI are thin adapters). Covers:
+# - GetBanner on an empty store: active=false, content nil, READ-ONLY (no audit)
+# - SetBanner: writes the raw content, refreshes runtime, returns :success,
+#   records EXACTLY ONE audit event (verb banner.set, actor = PUBLIC id)
+# - GetBanner after set: reflects content + active, ttl nil for a persistent banner
+# - SetBanner with ttl: stores with an expiry that GetBanner reports (>0)
+# - Behavioural parity: the stored value is byte-identical to a direct db.set
+# - SetBanner empty content: raises ArgumentError, writes nothing, NO audit
+# - ClearBanner: deletes, refreshes runtime, returns :success, one audit event
+# - ClearBanner idempotency: clearing an unset banner is :not_set with NO audit
+#
+# Run: try --agent try/unit/operations/banner_try.rb
+
+require_relative '../../support/test_helpers'
+
+OT.boot! :test
+
+require 'onetime/operations/banner'
+
+AE  = Onetime::AdminAuditEvent
+KEY = Onetime::Operations::BannerState::KEY
+DB  = Familia.dbclient(Onetime::Operations::BannerState::DB)
+
+@actor = 'ur1colonelpub' # a PUBLIC id (extid-shaped), never an objid
+@msg   = '<a href="/status">Scheduled maintenance Sun 02:00 UTC</a>'
+
+# Clean slate.
+DB.del(KEY)
+AE.events.clear
+
+# ---- GetBanner: empty store -------------------------------------------
+
+## GetBanner on an empty store reports inactive with nil content
+@g0 = Onetime::Operations::GetBanner.new.call
+[@g0.active, @g0.content.nil?, @g0.ttl.nil?]
+#=> [false, true, true]
+
+## GetBanner exposes the backing key + database (single source of truth)
+[@g0.key, @g0.database]
+#=> ["global_banner", 0]
+
+## a read records NO audit event (read-only verb)
+AE.count
+#=> 0
+
+# ---- SetBanner: publish (persistent) ----------------------------------
+
+## SetBanner returns a :success Result carrying the stored content
+@set = Onetime::Operations::SetBanner.new(content: @msg, actor: @actor).call
+[@set.status, @set.content, @set.ttl.nil?]
+#=> [:success, "<a href=\"/status\">Scheduled maintenance Sun 02:00 UTC</a>", true]
+
+## the content is stored VERBATIM (raw HTML, no sanitising on write — CLI parity)
+DB.get(KEY)
+#=> "<a href=\"/status\">Scheduled maintenance Sun 02:00 UTC</a>"
+
+## the runtime features state is refreshed to the new banner
+Onetime::Runtime.features.global_banner
+#=> "<a href=\"/status\">Scheduled maintenance Sun 02:00 UTC</a>"
+
+## exactly ONE audit event was recorded for the publish
+AE.count
+#=> 1
+
+## the audit event is the set verb, targeting the banner key, actored by PUBLIC id
+@ev = AE.recent(1).first
+[@ev['verb'], @ev['target'], @ev['actor']]
+#=> ["banner.set", "global_banner", "ur1colonelpub"]
+
+## GetBanner now reflects the active persistent banner (ttl nil)
+@g1 = Onetime::Operations::GetBanner.new.call
+[@g1.active, @g1.content, @g1.ttl.nil?]
+#=> [true, "<a href=\"/status\">Scheduled maintenance Sun 02:00 UTC</a>", true]
+
+# ---- SetBanner: with TTL ----------------------------------------------
+
+## SetBanner with a ttl stores an expiring banner
+AE.events.clear
+@set_ttl = Onetime::Operations::SetBanner.new(content: 'temp', actor: @actor, ttl: 3600).call
+[@set_ttl.status, @set_ttl.ttl]
+#=> [:success, 3600]
+
+## GetBanner reports a positive ttl for the expiring banner
+Onetime::Operations::GetBanner.new.call.ttl.positive?
+#=> true
+
+## the ttl publish also recorded exactly one audit event
+AE.count
+#=> 1
+
+# ---- SetBanner: empty content backstop --------------------------------
+
+## SetBanner with empty content raises ArgumentError (defensive backstop)
+begin
+  Onetime::Operations::SetBanner.new(content: '', actor: @actor).call
+  :no_raise
+rescue ArgumentError
+  :raised
+end
+#=> :raised
+
+## the failed (empty) set recorded NO audit event
+# NOTE: only a truly empty string is rejected — whitespace-only content is stored
+# verbatim, matching the CLI's bare-argument path (no strip), which is bit-for-bit
+# preserved. HTTP-layer trimming/validation lives in the colonel SetBanner logic.
+AE.events.clear
+begin
+  Onetime::Operations::SetBanner.new(content: '', actor: @actor).call
+rescue ArgumentError
+  nil
+end
+AE.count
+#=> 0
+
+# ---- Behavioural parity: stored value byte-identical -------------------
+
+## a value written by the op equals a value written by a direct db.set
+DB.del(KEY)
+Onetime::Operations::SetBanner.new(content: 'parity-check', actor: @actor).call
+@via_op = DB.get(KEY)
+DB.del(KEY)
+DB.set(KEY, 'parity-check')
+@via_direct = DB.get(KEY)
+@via_op == @via_direct
+#=> true
+
+# ---- ClearBanner: success ---------------------------------------------
+
+## ClearBanner removes the banner and returns :success
+AE.events.clear
+@clear = Onetime::Operations::ClearBanner.new(actor: @actor).call
+[@clear.status, @clear.cleared]
+#=> [:success, true]
+
+## the key is gone and the runtime state is refreshed to nil
+[DB.get(KEY).nil?, Onetime::Runtime.features.global_banner.nil?]
+#=> [true, true]
+
+## exactly ONE audit event was recorded for the clear
+AE.count
+#=> 1
+
+## the audit event is the clear verb targeting the banner key
+@cev = AE.recent(1).first
+[@cev['verb'], @cev['target'], @cev['actor']]
+#=> ["banner.clear", "global_banner", "ur1colonelpub"]
+
+# ---- ClearBanner: idempotent no-op ------------------------------------
+
+## clearing an already-cleared banner is a no-op (:not_set)
+AE.events.clear
+@noop = Onetime::Operations::ClearBanner.new(actor: @actor).call
+[@noop.status, @noop.cleared]
+#=> [:not_set, false]
+
+## a no-op clear records NO audit event (nothing mutated)
+AE.count
+#=> 0
+
+# Cleanup
+DB.del(KEY)
+AE.events.clear
+Onetime::Runtime.update_features(global_banner: nil)

--- a/try/unit/operations/dlq_try.rb
+++ b/try/unit/operations/dlq_try.rb
@@ -1,0 +1,291 @@
+# try/unit/operations/dlq_try.rb
+#
+# frozen_string_literal: true
+
+#
+# Unit tryouts for the extracted dead-letter-queue admin operations (epic #42):
+#   Onetime::Operations::Dlq::{List, Peek, Replay, Purge}
+#
+# These are the SINGLE implementation of the DLQ list / peek / replay / purge
+# verbs (the `bin/ots queue dlq *` CLI + the colonel `/api/colonel/queues/dlq…`
+# endpoints are thin adapters). Covers:
+# - List: per-queue summary rows over the fixed DLQ allowlist (read-only, NO audit)
+# - Peek: non-destructive peek — the queue is left exactly as found (read-only, NO audit)
+# - Replay: re-enqueues to the original queue, records EXACTLY ONE audit event
+#   (verb queue.dlq.replay, actor = PUBLIC id, target = queue)
+# - Replay empty / dry-run: no mutation, NO audit
+# - Purge: empties the queue, records EXACTLY ONE audit event (verb queue.dlq.purge)
+# - Purge empty / dry-run: no mutation, NO audit
+#
+# The RabbitMQ broker is stubbed by a duck-typed fake connection (no live broker
+# needed), so the audit-exactly-once contract can be asserted deterministically.
+#
+# Run: try --agent try/unit/operations/dlq_try.rb
+
+require_relative '../../support/test_helpers'
+
+OT.boot! :test
+
+require 'onetime/operations/dlq/store'
+require 'onetime/operations/dlq/list'
+require 'onetime/operations/dlq/peek'
+require 'onetime/operations/dlq/replay'
+require 'onetime/operations/dlq/purge'
+
+AE = Onetime::AdminAuditEvent
+
+# --- Duck-typed Bunny fakes -------------------------------------------------
+
+FakeDelivery   = Struct.new(:delivery_tag)
+FakeProperties = Struct.new(:message_id, :timestamp, :content_type, :headers)
+
+class FakeExchange
+  attr_reader :published
+
+  def initialize
+    @published = []
+  end
+
+  def publish(payload, **opts)
+    @published << { payload: payload, opts: opts }
+  end
+end
+
+class FakeQueue
+  attr_reader :consumer_count
+
+  def initialize(messages, consumer_count: 0)
+    @messages       = messages.dup   # each: { id:, headers:, content_type:, payload:, ts: }
+    @unacked        = {}
+    @consumer_count = consumer_count
+    @tag            = 0
+  end
+
+  def message_count
+    @messages.size
+  end
+
+  def pop(manual_ack: true)
+    m = @messages.shift
+    return [nil, nil, nil] unless m
+
+    @tag += 1
+    @unacked[@tag] = m
+    [FakeDelivery.new(@tag), FakeProperties.new(m[:id], m[:ts], m[:content_type], m[:headers]), m[:payload]]
+  end
+
+  def ack(tag)
+    @unacked.delete(tag) # permanently removed
+  end
+
+  def nack(tag, _multiple, requeue)
+    m = @unacked.delete(tag)
+    @messages.push(m) if requeue && m
+  end
+
+  def purge
+    @messages.clear
+  end
+end
+
+class FakeChannel
+  attr_reader :exchange
+
+  def initialize(queue)
+    @queue    = queue
+    @exchange = FakeExchange.new
+    @open     = true
+  end
+
+  def queue(_name, **_opts)
+    @queue
+  end
+
+  def default_exchange
+    @exchange
+  end
+
+  def ack(tag) = @queue.ack(tag)
+  def nack(tag, m, r) = @queue.nack(tag, m, r)
+  def open? = @open
+  def close = (@open = false)
+end
+
+class FakeConnection
+  attr_reader :channels
+
+  def initialize(queue)
+    @queue    = queue
+    @channels = []
+  end
+
+  def create_channel
+    ch = FakeChannel.new(@queue)
+    @channels << ch
+    ch
+  end
+end
+
+def death_headers(original_queue)
+  { 'x-death' => [{ 'queue' => original_queue, 'reason' => 'rejected', 'count' => 2 }] }
+end
+
+def sample_messages(n, original: 'billing.event.process')
+  (1..n).map do |i|
+    {
+      id: "msg-#{i}",
+      headers: death_headers(original),
+      content_type: 'application/json',
+      payload: %({"n":#{i}}),
+      ts: Time.now.to_i - 60,
+    }
+  end
+end
+
+@actor = 'ur1colonelpub' # a PUBLIC id (extid-shaped), never an objid
+@dlq   = 'dlq.billing.event'
+
+AE.events.clear
+
+# ---- List -------------------------------------------------------------
+
+## Store exposes the fixed DLQ allowlist (bounded — CONTRACT 6)
+Onetime::Operations::Dlq::Store.all_dlq_names.include?('dlq.billing.event')
+#=> true
+
+## an unknown queue name is rejected by the allowlist
+Onetime::Operations::Dlq::Store.valid?('dlq.nope.nope')
+#=> false
+
+## resolve prepends the dlq. prefix for a short name, passes a full name through
+[Onetime::Operations::Dlq::Store.resolve('billing.event'),
+ Onetime::Operations::Dlq::Store.resolve('dlq.billing.event')]
+#=> ["dlq.billing.event", "dlq.billing.event"]
+
+## List summarises every configured DLQ (one row per allowlisted queue)
+@list_conn = FakeConnection.new(FakeQueue.new(sample_messages(3), consumer_count: 1))
+@list = Onetime::Operations::Dlq::List.new(connection: @list_conn).call
+@list.dlqs.size
+#=> Onetime::Operations::Dlq::Store.all_dlq_names.size
+
+## List is read-only — no audit event recorded
+AE.count
+#=> 0
+
+# ---- Peek (read-only) -------------------------------------------------
+
+## Peek returns up to `limit` messages and reports the true queue depth
+@peek_q    = FakeQueue.new(sample_messages(5))
+@peek_conn = FakeConnection.new(@peek_q)
+@peek = Onetime::Operations::Dlq::Peek.new(connection: @peek_conn, queue: @dlq, limit: 2).call
+[@peek.total_messages, @peek.showing, @peek.messages.size]
+#=> [5, 2, 2]
+
+## Peek leaves the queue exactly as found (every peeked message was nack-requeued)
+@peek_q.message_count
+#=> 5
+
+## Peek surfaces the death diagnosis fields from the x-death header
+row = @peek.messages.first
+[row[:original_queue], row[:death_reason], row[:death_count]]
+#=> ["billing.event.process", "rejected", 2]
+
+## Peek is read-only — still no audit event
+AE.count
+#=> 0
+
+# ---- Replay: success --------------------------------------------------
+
+## Replay re-enqueues all messages and reports the counts
+AE.events.clear
+@replay_q    = FakeQueue.new(sample_messages(3))
+@replay_conn = FakeConnection.new(@replay_q)
+@replay = Onetime::Operations::Dlq::Replay.new(connection: @replay_conn, queue: @dlq, actor: @actor).call
+[@replay.status, @replay.replayed, @replay.failed]
+#=> [:success, 3, 0]
+
+## the DLQ is now empty (messages were acked off after republish)
+@replay_q.message_count
+#=> 0
+
+## each message was republished to its original queue
+@replay_conn.channels.first.exchange.published.map { |p| p[:opts][:routing_key] }.uniq
+#=> ["billing.event.process"]
+
+## exactly ONE audit event was recorded for the replay
+AE.count
+#=> 1
+
+## the audit event is the replay verb, targeting the queue, actored by the PUBLIC id
+@rev = AE.recent(1).first
+[@rev['verb'], @rev['target'], @rev['actor']]
+#=> ["queue.dlq.replay", "dlq.billing.event", "ur1colonelpub"]
+
+## the audit detail carries the replayed / failed counts
+[@rev['detail']['replayed'], @rev['detail']['failed']]
+#=> [3, 0]
+
+# ---- Replay: a message with no original queue is dropped + counted failed ----
+
+## a message lacking an x-death queue is nacked-without-requeue (failed), still audited once
+AE.events.clear
+@bad_q = FakeQueue.new([{ id: 'orphan', headers: {}, content_type: 'application/json', payload: '{}', ts: Time.now.to_i }])
+@bad_conn = FakeConnection.new(@bad_q)
+@bad = Onetime::Operations::Dlq::Replay.new(connection: @bad_conn, queue: @dlq, actor: @actor).call
+[@bad.status, @bad.replayed, @bad.failed, AE.count]
+#=> [:success, 0, 1, 1]
+
+# ---- Replay: empty queue is a no-op -----------------------------------
+
+## replaying an empty DLQ is a no-op (:empty), records NO audit
+AE.events.clear
+@empty = Onetime::Operations::Dlq::Replay.new(connection: FakeConnection.new(FakeQueue.new([])), queue: @dlq, actor: @actor).call
+[@empty.status, @empty.replayed, AE.count]
+#=> [:empty, 0, 0]
+
+# ---- Replay: dry-run --------------------------------------------------
+
+## a dry-run reports how many WOULD replay without mutating and without auditing
+AE.events.clear
+@dry_q = FakeQueue.new(sample_messages(4))
+@dry = Onetime::Operations::Dlq::Replay.new(connection: FakeConnection.new(@dry_q), queue: @dlq, actor: @actor, dry_run: true).call
+[@dry.status, @dry.would_replay, @dry_q.message_count, AE.count]
+#=> [:dry_run, 4, 4, 0]
+
+# ---- Purge: success ---------------------------------------------------
+
+## Purge empties the queue and reports the purged count
+AE.events.clear
+@purge_q = FakeQueue.new(sample_messages(6))
+@purge = Onetime::Operations::Dlq::Purge.new(connection: FakeConnection.new(@purge_q), queue: @dlq, actor: @actor).call
+[@purge.status, @purge.purged, @purge_q.message_count]
+#=> [:success, 6, 0]
+
+## exactly ONE audit event was recorded for the purge
+AE.count
+#=> 1
+
+## the audit event is the purge verb targeting the queue, with the purged count
+@pev = AE.recent(1).first
+[@pev['verb'], @pev['target'], @pev['detail']['purged']]
+#=> ["queue.dlq.purge", "dlq.billing.event", 6]
+
+# ---- Purge: empty queue is a no-op ------------------------------------
+
+## purging an empty DLQ is a no-op (:empty), records NO audit
+AE.events.clear
+@pe = Onetime::Operations::Dlq::Purge.new(connection: FakeConnection.new(FakeQueue.new([])), queue: @dlq, actor: @actor).call
+[@pe.status, @pe.purged, AE.count]
+#=> [:empty, 0, 0]
+
+# ---- Purge: dry-run ---------------------------------------------------
+
+## a dry-run reports the in-scope count without deleting and without auditing
+AE.events.clear
+@pd_q = FakeQueue.new(sample_messages(3))
+@pd = Onetime::Operations::Dlq::Purge.new(connection: FakeConnection.new(@pd_q), queue: @dlq, actor: @actor, dry_run: true).call
+[@pd.status, @pd.count, @pd.purged, @pd_q.message_count, AE.count]
+#=> [:dry_run, 3, 0, 3, 0]
+
+# Cleanup
+AE.events.clear

--- a/try/unit/operations/domain_toolbox_try.rb
+++ b/try/unit/operations/domain_toolbox_try.rb
@@ -1,0 +1,202 @@
+# try/unit/operations/domain_toolbox_try.rb
+#
+# frozen_string_literal: true
+
+#
+# Unit tryouts for the extracted domain-toolbox operations (epic #43):
+#   Onetime::Operations::Domains::{Probe, OrphanedScan, Repair, Transfer}
+#
+# These are the SINGLE implementation of the toolbox verbs (the `bin/ots domains
+# {probe,orphaned,repair,transfer}` CLI + the colonel endpoints are thin
+# adapters). Covers, per CONTRACT 4:
+# - READ-ONLY ops (Probe, OrphanedScan) record NO audit events.
+# - Repair/Transfer dry-run: compute a plan, mutate NOTHING, audit NOTHING.
+# - Repair/Transfer apply: mutate + record EXACTLY ONE audit event.
+# - Repair no-op (no issues) records no audit event.
+# - Transfer ownership mismatch is blocked (:mismatch), no audit.
+#
+# Run: try --agent try/unit/operations/domain_toolbox_try.rb
+
+require_relative '../../support/test_helpers'
+
+OT.boot! :test
+
+require 'onetime/operations/domains/probe'
+require 'onetime/operations/domains/orphaned_scan'
+require 'onetime/operations/domains/repair'
+require 'onetime/operations/domains/transfer'
+
+AE = Onetime::AdminAuditEvent
+
+@actor = 'ur1colonelpub' # a PUBLIC id (extid-shaped), never an objid
+
+@test_id = SecureRandom.hex(4)
+@cust1   = Onetime::Customer.create!(email: "dtcust1_#{@test_id}@example.com")
+@cust2   = Onetime::Customer.create!(email: "dtcust2_#{@test_id}@example.com")
+@org1    = Onetime::Organization.create!("DT Org 1 #{@test_id}", @cust1, "billing+dt1+#{@test_id}@onetimesecret.com")
+@org2    = Onetime::Organization.create!("DT Org 2 #{@test_id}", @cust2, "billing+dt2+#{@test_id}@onetimesecret.com")
+
+AE.events.clear
+
+# ---- Probe: read-only, no audit ---------------------------------------
+
+## Probe returns a result Hash with a health classification
+@probe = Onetime::Operations::Domains::Probe.new(
+  hostname: "no-such-host-#{@test_id}.invalid", timeout: 2,
+).call
+@probe[:health].is_a?(String)
+#=> true
+
+## an unresolvable host classifies as a DNS error (fails fast, no network)
+@probe[:health]
+#=> "dns_error"
+
+## a probe records NO audit event (read-only)
+AE.count
+#=> 0
+
+# ---- OrphanedScan: read-only, no audit --------------------------------
+
+## an orphaned domain (blank org_id) shows up in the scan
+# The model's #save refuses a blank org_id, so an orphaned record (a data-drift
+# state) is produced by clearing the field directly in the store, then reloading.
+@orphan_seed = Onetime::CustomDomain.create!("dt-orphan-#{@test_id}.example.com", @org1.objid)
+Familia.dbclient.hset(@orphan_seed.dbkey, 'org_id', '')
+@orphan = Onetime::CustomDomain.find_by_identifier(@orphan_seed.domainid)
+@scan = Onetime::Operations::Domains::OrphanedScan.new(per_page: nil).call
+@scan.domains.map { |d| d[:domain_id] }.include?(@orphan.domainid)
+#=> true
+
+## the orphaned summary carries the public extid + display_domain
+@row = @scan.domains.find { |d| d[:domain_id] == @orphan.domainid }
+[@row[:extid] == @orphan.extid, @row[:display_domain] == @orphan.display_domain]
+#=> [true, true]
+
+## the scan records NO audit event (read-only)
+AE.count
+#=> 0
+
+# ---- Repair: dry-run computes, mutates/audits nothing -----------------
+
+## a domain with org_id set but missing from the collection is an issue
+# parse + save persists the record WITHOUT adding it to the org's domains
+# collection (unlike create!), reproducing the not-in-collection drift.
+@dom = Onetime::CustomDomain.parse("dt-repair-#{@test_id}.example.com", @org1.org_id)
+@dom.save
+@in_before = @org1.list_domains.map(&:domainid).include?(@dom.domainid)
+@in_before
+#=> false
+
+## dry-run finds the not-in-collection issue and plans (no mutation)
+@plan = Onetime::Operations::Domains::Repair.new(domain: @dom, actor: @actor, dry_run: true).call
+[@plan.status, @plan.issues.size]
+#=> [:planned, 1]
+
+## a dry-run records NO audit event
+AE.count
+#=> 0
+
+## the domain is still NOT in the collection after a dry-run (nothing mutated)
+@org1.list_domains.map(&:domainid).include?(@dom.domainid)
+#=> false
+
+# ---- Repair: apply mutates + audits exactly once ----------------------
+
+## applying the repair adds the domain to the org collection
+@applied = Onetime::Operations::Domains::Repair.new(domain: @dom, actor: @actor, dry_run: false).call
+@applied.status
+#=> :repaired
+
+## the domain is now in the org's collection (model actually mutated)
+@org1.list_domains.map(&:domainid).include?(@dom.domainid)
+#=> true
+
+## exactly ONE audit event was recorded for the repair
+AE.count
+#=> 1
+
+## the audit event is the repair verb, targeting the domain extid, public actor
+@ev = AE.recent(1).first
+[@ev['verb'], @ev['target'], @ev['actor']]
+#=> ["domain.repair", @dom.extid, "ur1colonelpub"]
+
+# ---- Repair: no-op (already consistent) records no audit --------------
+
+## re-running repair on the now-consistent domain finds no issues
+AE.events.clear
+@noop = Onetime::Operations::Domains::Repair.new(domain: @dom, actor: @actor, dry_run: false).call
+@noop.status
+#=> :no_issues
+
+## a no-issue repair records NO audit event
+AE.count
+#=> 0
+
+# ---- Repair: orphaned needs a target org ------------------------------
+
+## an orphaned domain with no target org is blocked (:needs_org), no audit
+AE.events.clear
+@nblk = Onetime::Operations::Domains::Repair.new(domain: @orphan, actor: @actor, dry_run: false).call
+[@nblk.status, AE.count]
+#=> [:needs_org, 0]
+
+# ---- Transfer: dry-run computes, mutates/audits nothing ---------------
+
+## set up a domain owned by org1 and present in its collection
+@tdom = Onetime::CustomDomain.create!("dt-transfer-#{@test_id}.example.com", @org1.objid)
+@org1.add_domain(@tdom)
+AE.events.clear
+@tplan = Onetime::Operations::Domains::Transfer.new(
+  domain: @tdom, to_org: @org2, actor: @actor, dry_run: true,
+).call
+[@tplan.status, @tplan.to_org_id == @org2.org_id]
+#=> [:planned, true]
+
+## a dry-run transfer records NO audit and leaves ownership unchanged
+[AE.count, @tdom.org_id == @org1.org_id]
+#=> [0, true]
+
+# ---- Transfer: apply mutates + audits exactly once --------------------
+
+## applying the transfer moves the domain to org2
+@tapplied = Onetime::Operations::Domains::Transfer.new(
+  domain: @tdom, to_org: @org2, actor: @actor, dry_run: false,
+).call
+@tapplied.status
+#=> :transferred
+
+## the domain now belongs to org2 (org_id updated)
+reloaded = Onetime::CustomDomain.load_by_display_domain(@tdom.display_domain)
+reloaded.org_id == @org2.org_id
+#=> true
+
+## the domain is in org2's collection and gone from org1's
+[@org2.list_domains.map(&:domainid).include?(@tdom.domainid),
+ @org1.list_domains.map(&:domainid).include?(@tdom.domainid)]
+#=> [true, false]
+
+## exactly ONE audit event was recorded for the transfer
+AE.count
+#=> 1
+
+## the audit event is the transfer verb targeting the domain extid
+@tev = AE.recent(1).first
+[@tev['verb'], @tev['target'], @tev['actor']]
+#=> ["domain.transfer", @tdom.extid, "ur1colonelpub"]
+
+# ---- Transfer: explicit from_org mismatch is blocked ------------------
+
+## an explicit from_org that isn't the current owner is a :mismatch (no audit)
+AE.events.clear
+@mm = Onetime::Operations::Domains::Transfer.new(
+  domain: @tdom, to_org: @org1, from_org: @org1, actor: @actor, dry_run: false,
+).call
+[@mm.status, AE.count]
+#=> [:mismatch, 0]
+
+# ---- Cleanup ----------------------------------------------------------
+
+[@orphan, @dom, @tdom].compact.each { |d| d.destroy! rescue nil }
+[@org1, @org2].compact.each { |o| o.destroy! rescue nil }
+[@cust1, @cust2].compact.each { |c| c.destroy! rescue nil }
+AE.events.clear

--- a/try/unit/operations/email_ratelimit_tools_try.rb
+++ b/try/unit/operations/email_ratelimit_tools_try.rb
@@ -1,0 +1,193 @@
+# try/unit/operations/email_ratelimit_tools_try.rb
+#
+# frozen_string_literal: true
+
+#
+# Unit tryouts for the extracted email + rate-limit tools operations (ticket #44):
+#   Onetime::Operations::Email::{ListTemplates, PreviewTemplate, SendTest}
+#   Onetime::Operations::RateLimit::{Registry, Inspect, Reset}
+#
+# These are the SINGLE implementation of each verb (the colonel API + `bin/ots
+# email` / `bin/ots ratelimit` CLI are thin adapters). Covers:
+# - ListTemplates: enumerates the canonical templates with their formats (read)
+# - PreviewTemplate: renders sample text/html with NO side effects (read, no audit)
+# - PreviewTemplate: unknown template raises, missing sample raises MissingSampleError
+# - SendTest.build: byte-identical brand-aware diagnostic (CLI golden-master)
+# - SendTest dry-run: sends nothing, records NO audit
+# - SendTest live: delivers via the logger backend, records EXACTLY ONE audit event
+# - RateLimit::Registry: CLI-golden key derivation is byte-identical
+# - RateLimit::Inspect: reads TTL/value for the bounded key set (read, no audit)
+# - RateLimit::Reset: deletes keys + records ONE audit; idempotent no-op records none
+#
+# Run: try --agent try/unit/operations/email_ratelimit_tools_try.rb
+
+require_relative '../../support/test_helpers'
+
+OT.boot! :test
+
+require 'onetime/operations/email/list_templates'
+require 'onetime/operations/email/preview_template'
+require 'onetime/operations/email/send_test'
+require 'onetime/operations/ratelimit/registry'
+require 'onetime/operations/ratelimit/inspect'
+require 'onetime/operations/ratelimit/reset'
+
+AE = Onetime::AdminAuditEvent
+
+@actor = 'ur1colonelpub' # a PUBLIC id (extid-shaped), never an objid
+
+AE.events.clear
+
+# ---- Email::ListTemplates (read) --------------------------------------
+
+## ListTemplates returns one entry per canonical template, in order
+@templates = Onetime::Operations::Email::ListTemplates.new.call
+@templates.map(&:name).first(3)
+#=> ["secret_link", "welcome", "password_request"]
+
+## every entry advertises at least one renderable format
+@templates.all? { |e| e.formats.any? }
+#=> true
+
+## listing records NO audit event (read-only verb)
+AE.count
+#=> 0
+
+# ---- Email::PreviewTemplate (read, no side effects) -------------------
+
+## PreviewTemplate renders the text body from sample data
+@preview = Onetime::Operations::Email::PreviewTemplate.new(template: 'secret_link').call
+[@preview.format, @preview.body.is_a?(String) && !@preview.body.empty?]
+#=> ["text", true]
+
+## an HTML preview renders the HTML arm
+@html = Onetime::Operations::Email::PreviewTemplate.new(template: 'secret_link', format: 'html').call
+@html.format
+#=> "html"
+
+## previewing records NO audit event (read-only, no dispatch)
+AE.count
+#=> 0
+
+## an unknown template with supplied data raises ArgumentError (unknown class)
+# (data is supplied so we skip sample loading and reach template_class_for, which
+# is the CLI's order: load_data then resolve_template.)
+begin
+  Onetime::Operations::Email::PreviewTemplate.new(template: 'does_not_exist', data: { foo: 'bar' }).call
+  :no_raise
+rescue ArgumentError
+  :raised
+end
+#=> :raised
+
+## an unknown template with NO data raises MissingSampleError first (CLI parity:
+## load_data runs before resolve_template, so the missing sample is hit first)
+begin
+  Onetime::Operations::Email::PreviewTemplate.new(template: 'does_not_exist').call
+  :no_raise
+rescue Onetime::Operations::Email::PreviewTemplate::MissingSampleError
+  :missing_sample
+end
+#=> :missing_sample
+
+# ---- Email::SendTest.build (CLI golden-master parity) -----------------
+
+## build produces a brand-aware subject + body with the provider/host probe
+@diag = Onetime::Operations::Email::SendTest.build(to: 'ops@example.com')
+[@diag.to, @diag.subject.start_with?('['), @diag.text_body.include?('Provider:'), @diag.provider]
+#=> ["ops@example.com", true, true, "logger"]
+
+## the body is byte-identical to the pre-extraction CLI literal
+@expected_body = "This is a test email from the #{@diag.subject[/\[(.*?)\]/, 1]} CLI.\n\nProvider: #{@diag.provider}\nTimestamp: #{@diag.timestamp}\nHost: #{@diag.host}"
+@diag.text_body == @expected_body
+#=> true
+
+# ---- Email::SendTest dry-run (no send, no audit) ----------------------
+
+## a dry-run returns :dry_run and dispatches nothing
+AE.events.clear
+@dry = Onetime::Operations::Email::SendTest.new(to: 'ops@example.com', actor: @actor, dry_run: true).call
+@dry.status
+#=> :dry_run
+
+## a dry-run records NO audit event
+AE.count
+#=> 0
+
+# ---- Email::SendTest live (logger backend, one audit) -----------------
+
+## a real send returns :sent (test env uses the logger delivery backend)
+AE.events.clear
+@sent = Onetime::Operations::Email::SendTest.new(to: 'ops@example.com', actor: @actor, dry_run: false).call
+@sent.status
+#=> :sent
+
+## exactly ONE audit event was recorded for the send
+AE.count
+#=> 1
+
+## the audit event is the test_send verb, targeting the recipient, actored by PUBLIC id
+@ev = AE.recent(1).first
+[@ev['verb'], @ev['target'], @ev['actor']]
+#=> ["email.test_send", "ops@example.com", "ur1colonelpub"]
+
+# ---- RateLimit::Registry (CLI golden-master key derivation) -----------
+
+## the registry knows the four canonical limiter kinds
+Onetime::Operations::RateLimit::Registry.kinds
+#=> ["feedback", "passphrase", "invite", "dns"]
+
+## keys_for expands the templates byte-identically to the CLI's emitted keys
+Onetime::Operations::RateLimit::Registry.keys_for('feedback', '1.2.3.4')
+#=> ["feedback:submissions:1.2.3.4", "feedback:locked:1.2.3.4"]
+
+## an unknown kind yields nil (the CLI prints its "Unknown" branch)
+Onetime::Operations::RateLimit::Registry.keys_for('nope', 'x')
+#=> nil
+
+# ---- RateLimit::Inspect (read) ----------------------------------------
+
+## seed a feedback counter, then inspect it (read-only)
+@db = Onetime::Feedback.dbclient
+@db.del('feedback:submissions:9.9.9.9', 'feedback:locked:9.9.9.9')
+@db.setex('feedback:submissions:9.9.9.9', 600, '3')
+AE.events.clear
+@insp = Onetime::Operations::RateLimit::Inspect.new(kind: 'feedback', subject: '9.9.9.9').call
+@sub_entry = @insp.entries.find { |e| e.key == 'feedback:submissions:9.9.9.9' }
+[@sub_entry.value, @sub_entry.exists, @sub_entry.ttl.positive?]
+#=> ["3", true, true]
+
+## inspecting records NO audit event (read-only verb)
+AE.count
+#=> 0
+
+# ---- RateLimit::Reset (mutating, one audit) ---------------------------
+
+## resetting an active limiter deletes the key(s) and returns :success
+AE.events.clear
+@reset = Onetime::Operations::RateLimit::Reset.new(kind: 'feedback', subject: '9.9.9.9', actor: @actor).call
+[@reset.status, @db.get('feedback:submissions:9.9.9.9').nil?]
+#=> [:success, true]
+
+## exactly ONE audit event was recorded for the reset
+AE.count
+#=> 1
+
+## the audit event is the reset verb targeting kind:subject, actored by PUBLIC id
+@rev = AE.recent(1).first
+[@rev['verb'], @rev['target'], @rev['actor']]
+#=> ["ratelimit.reset", "feedback:9.9.9.9", "ur1colonelpub"]
+
+## resetting an already-clear subject is an idempotent no-op (:not_set)
+AE.events.clear
+@noop = Onetime::Operations::RateLimit::Reset.new(kind: 'feedback', subject: '9.9.9.9', actor: @actor).call
+@noop.status
+#=> :not_set
+
+## a no-op reset records NO audit event (nothing mutated)
+AE.count
+#=> 0
+
+# Cleanup
+@db.del('feedback:submissions:9.9.9.9', 'feedback:locked:9.9.9.9')
+AE.events.clear

--- a/try/unit/operations/sessions_try.rb
+++ b/try/unit/operations/sessions_try.rb
@@ -1,0 +1,150 @@
+# try/unit/operations/sessions_try.rb
+#
+# frozen_string_literal: true
+
+#
+# Unit tryouts for the extracted session admin operations (epic #40):
+#   Onetime::Operations::Sessions::{List, Inspect, Delete}
+#
+# These are the SINGLE implementation of the session list / inspect / delete
+# verbs (the colonel API + `bin/ots session *` CLI are thin adapters). Covers:
+# - List: bounded scan → summaries, newest-first, in-memory pagination
+# - List search: free-text identity filter (email / external_id)
+# - Inspect: resolves a live session (data + ttl); miss returns found:false
+# - Delete: removes the key, returns :deleted, records EXACTLY ONE audit event
+#   (verb session.delete, actor = PUBLIC id, target = session id)
+# - Delete not-found: revoking a non-existent session is a no-op (:not_found, NO audit)
+#
+# Run: try --agent try/unit/operations/sessions_try.rb
+
+require_relative '../../support/test_helpers'
+
+OT.boot! :test
+
+require 'onetime/operations/sessions/store'
+require 'onetime/operations/sessions/list_sessions'
+require 'onetime/operations/sessions/inspect_session'
+require 'onetime/operations/sessions/delete_session'
+
+AE  = Onetime::AdminAuditEvent
+DB  = Familia.dbclient
+
+@actor = 'ur1colonelpub' # a PUBLIC id (extid-shaped), never an objid
+
+# Unique, collision-proof ids for this run.
+@nonce = Familia.generate_id[0, 12]
+@sid_a = "trysess_a_#{@nonce}"
+@sid_b = "trysess_b_#{@nonce}"
+@key_a = "session:#{@sid_a}"
+@key_b = "session:#{@sid_b}"
+
+@data_a = {
+  'authenticated' => true,
+  'email' => "alice+#{@nonce}@example.com",
+  'external_id' => "ext_a_#{@nonce}",
+  'authenticated_at' => 2_000_000_100,
+}
+@data_b = {
+  'authenticated' => false,
+  'email' => "bob+#{@nonce}@example.com",
+  'external_id' => "ext_b_#{@nonce}",
+  'authenticated_at' => 2_000_000_200,
+}
+
+# Clean slate + seed two sessions as JSON (how the app stores them).
+DB.del(@key_a)
+DB.del(@key_b)
+DB.set(@key_a, JSON.generate(@data_a))
+DB.set(@key_b, JSON.generate(@data_b))
+AE.events.clear
+
+# ---- List -------------------------------------------------------------
+
+## List returns a Result whose sessions include the seeded pair
+@list = Onetime::Operations::Sessions::List.new(page: 1, per_page: 50).call
+ids   = @list.sessions.map { |s| s[:session_id] }
+[ids.include?(@sid_a), ids.include?(@sid_b)]
+#=> [true, true]
+
+## List surfaces the summary fields (authenticated flag + email + external id)
+@row_a = @list.sessions.find { |s| s[:session_id] == @sid_a }
+[@row_a[:authenticated], @row_a[:email], @row_a[:external_id]]
+#=> [true, "alice+#{@nonce}@example.com", "ext_a_#{@nonce}"]
+
+## List is read-only — no audit event recorded
+AE.count
+#=> 0
+
+## List sorts newest-authenticated first (b at 200 precedes a at 100)
+subset = @list.sessions.select { |s| [@sid_a, @sid_b].include?(s[:session_id]) }.map { |s| s[:session_id] }
+subset
+#=> ["#{@sid_b}", "#{@sid_a}"]
+
+# ---- List: search filter ----------------------------------------------
+
+## a search term matches only the session whose identity contains it
+@found = Onetime::Operations::Sessions::List.new(search: "alice+#{@nonce}").call
+@found.sessions.map { |s| s[:session_id] }
+#=> ["#{@sid_a}"]
+
+## a non-matching search term returns nothing
+Onetime::Operations::Sessions::List.new(search: "nobody_#{@nonce}").call.sessions
+#=> []
+
+# ---- Inspect ----------------------------------------------------------
+
+## Inspect resolves a live session, returning its key + parsed data
+@ins = Onetime::Operations::Sessions::Inspect.new(session_id: @sid_a).call
+[@ins.found, @ins.key, @ins.data['email']]
+#=> [true, "session:#{@sid_a}", "alice+#{@nonce}@example.com"]
+
+## Inspect is read-only — still no audit event
+AE.count
+#=> 0
+
+## Inspect of an unknown id returns found:false with nil fields
+@miss = Onetime::Operations::Sessions::Inspect.new(session_id: "no_such_#{@nonce}").call
+[@miss.found, @miss.key, @miss.data]
+#=> [false, nil, nil]
+
+# ---- Delete: success --------------------------------------------------
+
+## Delete removes the session key and returns :deleted
+AE.events.clear
+@del = Onetime::Operations::Sessions::Delete.new(session_id: @sid_a, actor: @actor).call
+[@del.status, @del.key]
+#=> [:deleted, "session:#{@sid_a}"]
+
+## the session key is actually gone from Redis
+DB.exists(@key_a)
+#=> 0
+
+## exactly ONE audit event was recorded for the delete
+AE.count
+#=> 1
+
+## the audit event is the delete verb, targeting the session id, actored by the PUBLIC id
+@ev = AE.recent(1).first
+[@ev['verb'], @ev['target'], @ev['actor']]
+#=> ["session.delete", "#{@sid_a}", "ur1colonelpub"]
+
+## the audit actor is never an internal objid
+@ev['actor'].include?('objid')
+#=> false
+
+# ---- Delete: not-found no-op ------------------------------------------
+
+## revoking a non-existent session is a no-op (:not_found)
+AE.events.clear
+@nf = Onetime::Operations::Sessions::Delete.new(session_id: "no_such_#{@nonce}", actor: @actor).call
+@nf.status
+#=> :not_found
+
+## a no-op delete records NO audit event (nothing mutated)
+AE.count
+#=> 0
+
+# Cleanup
+DB.del(@key_a)
+DB.del(@key_b)
+AE.events.clear


### PR DESCRIPTION
## Summary

[#3653](https://github.com/onetimesecret/onetimesecret/issues/3653) — Colonel Admin Rebuild, Slice 5 of 6.

Brings six colonel capabilities that were **CLI-only** onto the new admin console, each via the epic's "written once, served three ways" extraction: a single operation is the one implementation, served to (a) the existing CLI — preserved bit-for-bit via golden-master, (b) a new `/api/colonel` HTTP endpoint, and (c) the new admin screen.

**Screens + extractions**
- **Sessions (40)** — paginated active-session console + guarded revoke. Central `Operations::Sessions::{List,Inspect,Delete}` + `Store` (bounded scan, no `KEYS`); CLI routed through them; delete records exactly one `AdminAuditEvent` (`session.delete`), list/inspect read-only. New `GET` / `GET :id` / `DELETE` endpoints.
- **Broadcast banner (41)** — view/set/clear the site-wide banner. Central `Operations::{Get,Set,Clear}Banner`; CLI routed through it; `set` audits `banner.set`, `clear` audits `banner.clear` only on a real clear. Admin preview escapes content (no XSS). New `GET`/`POST`/`DELETE`.
- **Queue / DLQ (42)** — dead-letter viewer + guarded retry/purge. Central `Operations::Dlq::*`; retry is **dry-run-first** (preview `would_replay`; the live replay is an explicit second confirm) and purge is typed-confirmation; both audit exactly once. The store surfaces the broker `connected` flag so a down broker shows a distinct banner instead of a bare empty table.
- **Domain toolbox (43)** — app-scoped DNS/SSL diagnostics + re-verify (reuses the Slice-4 `AdminVerifyDomain` op). Distinct `domaintoolbox` namespace; no collision with Slice-4 domains.
- **Email / rate-limit tools (44)** — inspect/reset rate-limit counters + email tooling; central op(s); resets are typed-confirmation + audited.
- **Billing catalog (45)** — read-only plan/entitlement catalog; reuses the incumbent source; no mutating op, no audit.

**Contracts** — new per-resource Zod files (`colonel-{sessions,banner,dlq,domaintoolbox,emailtools,billing}.ts`) via the three-file split + registry key; existing frozen colonel contracts untouched (Zod tripwire).

**CLI parity reconciliation** — `Organization#add_domain`/`remove_domain` now accept a domain identifier string **or** a domain object, so the shared domain ops pass the string (bit-for-bit CLI parity) while real-model callers keep working. No response schema changed.

## Related Issues

Part of #3653. Implements tickets 40, 41, 42, 43, 44, 45.

## Test Plan

- **Frontend**: type-check clean; 390 admin tests green; two-pass build (normal + `VITE_BUILD_TARGET=admin`) with the **bundle-isolation invariant** verified against the built admin chunk — 0 imports of `apps/colonel/*`, `colonelInfoStore`, or the customer router graph.
- **Backend** (Ruby 3.4.9): `config validate` + `boot-test` (all 11 apps incl. `/api/colonel`) green; domains CLI golden-master spec green; op tryouts for sessions / banner / dlq / email-ratelimit / domain-toolbox / ban all green.

---

Stacked PR: this branches off the Slice-4 branch (`claude/colonel-admin-slice4-parity-a8xe00`, #3677) → Slice-3 overview → `integration/colonel`. Review/merge Slice 4 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSXB3Kj3BShBaPKUhm3MME)_