### PR TITLE
docs: clarify email-quality-controls epic scope and retire schedule_email

### DIFF
--- a/docs/specs/email-quality-controls/00-epic.md
+++ b/docs/specs/email-quality-controls/00-epic.md
@@ -161,6 +161,108 @@ in parallel with 30/31. 50 needs 10, 11, and 20; 51 needs 50. 60 needs 20 and
 is 10 → 11 → 20 → 30 → 31 (suppression fed by provider feedback), with 21 in
 tow for operator access; 40 and 50 follow.
 
+## Classification & prioritization (2026-07)
+
+Volume context: ~10k transactional emails/month (~330/day), each an individual
+choice by a free or paid account holder. That is **below** Gmail/Yahoo's 5k/day
+"bulk sender" hard threshold — so RFC 8058 one-click unsubscribe is best-practice
+and complaint-reducing, not a compliance gate yet. The acute risk at this volume
+is not throughput; it is **sending to dead or hostile mailboxes on a shared
+sending domain** (anyone can put an arbitrary third-party address into a secret
+link). Bounces and complaints are the reputation currency, and today we neither
+suppress nor even observe them.
+
+### Per-slice flags
+
+| Slice | Flag | Rationale |
+|---|---|---|
+| 10 headers + classification | **NOW (trim)** | The **category taxonomy** is required for suppression scope (31). The **headers channel** is only consumed by unsubscribe (50) — defer that half with 50 to shrink Phase 0. |
+| 11 keys + hashing + tokens | **NOW (trim)** | `address_hash`/`domain_hash` + key purpose are required for suppression keys. The **stateless Token codec** is only consumed by 50/51 — defer with them. |
+| 20 suppression model + gate | **NOW** | The core capability. The gate at `Delivery::Base#deliver` is the whole point. |
+| 21 suppression ops + CLI | **NOW** | Operators/support need check/add/remove/import from day one. |
+| 30 ESP webhook ingestion | **NOW\*** | "Biggest reputation win." A suppression list nobody feeds is theater. **\*API-provider-only** — inert on plain SMTP (see fitness finding B). |
+| 31 bounce/complaint handlers | **NOW\*** | Turns feedback into suppressions. Same SMTP caveat. |
+| 61 hardening + cutover | **NOW (partial)** | The bits that ship Phase 1 safely: default-on flip, provider backfill import, and the **pre-existing DLQ PII leak** fix. Schedule-queue decision can ride later. |
+| 22 suppression admin UI | **MAYBE LATER** | CLI (21) covers operations. Build when list volume makes CLI painful for non-engineer support. |
+| 40 outbound rate limits | **MAYBE LATER (ship the address limiter early)** | The per-address anti-harassment cap is the valuable core and is cheap; the domain/sender/tenant limiters are the deferrable bulk. |
+| 50 one-click unsubscribe | **MAYBE LATER (strong recommend)** | Under the bulk threshold so not compulsory, but recipient-facing mail is exactly the unsolicited profile that generates complaints — a mute button directly lowers the metric that matters most. Blocked on fitness finding A. |
+| 51 opt-back-in | **MAYBE LATER** | Depends on 50; no value before it ships. |
+| 60 observability | **MAYBE LATER** | The control-loop's measurement half. Cheap, but only useful once 20+30/31 are producing signal. |
+
+### Prioritization
+
+**1. Bare minimum to maintain reputation** (the epic's own shortest path,
+`10 → 11 → 20 → 30 → 31`, plus `21`):
+- Category taxonomy + address hashing (10/11, trimmed).
+- Suppression store + the `Delivery::Base#deliver` gate (20).
+- CLI + import ops for operators (21).
+- **Automatic bounce/complaint ingestion (30/31)** — the difference between a
+  living suppression list and a dead one. **Only viable if production runs an
+  API provider (SES/SendGrid/Lettermint), not plain SMTP.**
+- The Phase-1 slice of cutover (61): default-on + backfill + DLQ PII fix.
+
+**2. Stretch, if dev time allows** (in order):
+- One-click unsubscribe (50) + its trimmed 10/11 header/token halves — the
+  single best complaint-rate lever and a Gmail/Yahoo best practice we should
+  adopt before we're forced to.
+- The per-address anti-harassment rate limiter (the useful sliver of 40).
+- Observability counters + health job (60) for early warning.
+
+**3. Wait until X:**
+- **22 (admin UI)** — until support outgrows the CLI, or non-engineers need
+  self-serve access.
+- **Rest of 40 (domain/sender/tenant limiters)** — until slice 60 shows an
+  actual abuse or noisy-tenant signal; ceilings should be set from real data.
+- **51 (opt-back-in)** — until 50 has shipped and accidental-unsubscribe
+  support load justifies it.
+- **50/51 as a compliance item** — becomes non-optional if daily volume to any
+  single mailbox provider approaches 5k/day, or if slice-60 complaint rate
+  trends toward 0.1%.
+- **61 schedule-queue decision** — until real usage data says whether to fix or
+  retire `schedule_email` (see fitness finding C).
+
+### Fitness of current mailer (verified against code, not assumed)
+
+The architecture the design leans on is **sound and real**. `Delivery::Base#deliver`
+is a genuine 100% choke point (worker, `:sync`/`:async_thread` fallbacks,
+`deliver_raw`, CLI, DLQ replay all pass through it); `normalize_email` whitelists
+exactly the six documented keys; the KeyDerivation `PURPOSES` table, the
+`pending_federated_subscription`/`banned_ip`/`admin_audit_event` model precedents,
+and the entire Stripe webhook pipeline all exist as described and are cloneable.
+No fundamental rework is required. Three items to **resolve before the slices that
+depend on them**, however:
+
+- **A — Provider header capability (blocks 50 on some backends).** No backend
+  maps custom headers today; `List-Unsubscribe` must be added to all four. SMTP
+  (`::Mail`) and SendGrid (v3 JSON) are trivial. **SES** (`content.simple`) needs
+  aws-sdk-sesv2 1.96.0 to expose `Message#headers`; if it doesn't, fall back to
+  `content: {raw:}`, which changes DKIM signing inputs — verify the installed gem
+  first. **Lettermint** is the real risk: the vendored SDK (0.2.0) is used only
+  through its fluent builder with no header call, and the gem is not inspectable
+  in-repo. **If production runs Lettermint, confirm the SDK exposes a header API
+  before committing to slice 50** — otherwise it's a raw-API workaround or a
+  blocker, exactly as slice 10 warns.
+- **B — Which global backend does production run?** The platform runs ONE global
+  backend (`resolve_backend` ignores per-customer config). Webhook feedback
+  (30/31) is **only possible on an API provider**. On plain SMTP the bare-minimum
+  path degrades to manual + import suppression only, which elevates 50
+  (unsubscribe) from stretch toward necessary. Settle this before sequencing.
+- **C — `schedule_email` is an orphaned path (pre-existing latent bug, not this
+  epic's fault).** `schedule_email` publishes to `email.message.schedule`, which
+  has **no consumer**; messages sit until the 24h queue TTL dead-letters them,
+  and `DlqEmailConsumerJob` then **discards** everything except three auth
+  templates. Any delayed mail routed through it today (the design flags
+  `expiration_warning`) is silently dropped. This is independent of the epic but
+  worth triaging now; the epic correctly forbids building on it until 61 decides
+  fix-vs-retire.
+
+Two smaller precision notes, neither a blocker: the four existing Security rate
+limiters are **not** a uniform mold (only `invite_token` is a class with
+`force_enabled` + evalsha + Registry wiring — use it as the template for slice 40,
+not "the four"); and `EmailHash` raises for a missing `FEDERATION_SECRET` lazily
+at compute time (not at require), so the new `EmailProtection` helper must derive
+lazily and stay boot-safe — which slice 11 already specifies.
+
 ## Related prior art
 
 - #3653 — Colonel Admin Rebuild epic: the Operations/adapters architecture,

--- a/docs/specs/email-quality-controls/00-epic.md
+++ b/docs/specs/email-quality-controls/00-epic.md
@@ -45,8 +45,9 @@ So implementers don't follow stale assumptions:
 2. **`email.message.schedule` has no consumer.** Delayed messages rely on
    per-message TTL expiry dead-lettering into `dlq.email.message`, where
    `DlqEmailConsumerJob` replays only auth templates and **discards** the rest
-   (including `expiration_warning`). Do not build anything on `schedule_email`
-   until slice 61 fixes or retires it.
+   (including `expiration_warning`). **This is a live bug** — expiration warnings
+   are dropped in jobs-enabled regions. `schedule_email` and the queue are being
+   **retired** (slice 61, decision C); build nothing on the delayed path.
 3. **Receipts store recipients obscured** (`recipients! eaddrs_safe_str` in
    `lib/onetime/models/receipt/features/deprecated_fields.rb`). Per-recipient
    send history cannot be reconstructed from Receipts; it must be recorded at
@@ -218,8 +219,9 @@ suppress nor even observe them.
 - **50/51 as a compliance item** — becomes non-optional if daily volume to any
   single mailbox provider approaches 5k/day, or if slice-60 complaint rate
   trends toward 0.1%.
-- **61 schedule-queue decision** — until real usage data says whether to fix or
-  retire `schedule_email` (see fitness finding C).
+- ~~**61 schedule-queue decision**~~ — **settled: retire `schedule_email` now**
+  (fitness finding C). This is a live-outage fix, not a wait-for-data item; do it
+  ahead of the epic.
 
 ### Fitness of current mailer (verified against code, not assumed)
 
@@ -242,19 +244,27 @@ depend on them**, however:
   in-repo. **If production runs Lettermint, confirm the SDK exposes a header API
   before committing to slice 50** — otherwise it's a raw-API workaround or a
   blocker, exactly as slice 10 warns.
-- **B — Which global backend does production run?** The platform runs ONE global
-  backend (`resolve_backend` ignores per-customer config). Webhook feedback
-  (30/31) is **only possible on an API provider**. On plain SMTP the bare-minimum
-  path degrades to manual + import suppression only, which elevates 50
-  (unsubscribe) from stretch toward necessary. Settle this before sequencing.
-- **C — `schedule_email` is an orphaned path (pre-existing latent bug, not this
-  epic's fault).** `schedule_email` publishes to `email.message.schedule`, which
-  has **no consumer**; messages sit until the 24h queue TTL dead-letters them,
-  and `DlqEmailConsumerJob` then **discards** everything except three auth
-  templates. Any delayed mail routed through it today (the design flags
-  `expiration_warning`) is silently dropped. This is independent of the epic but
-  worth triaging now; the epic correctly forbids building on it until 61 decides
-  fix-vs-retire.
+- **B — Global backends: all four are production-critical (settled).** We run 10
+  regional environments spanning SMTP, SES, SendGrid, and Lettermint, so slice 10
+  (headers + category) must land in **all four delivery methods plus Logger** —
+  none is optional or trimmable. It also means webhook feedback (30/31) covers
+  only the SES/SendGrid/Lettermint regions; the SMTP region(s) get manual + import
+  suppression only, so slice 50 (unsubscribe) is closer to necessary than stretch
+  for those. And finding A's Lettermint header question is **on the critical
+  path**, not hypothetical — at least one region runs it.
+- **C — `schedule_email` is a LIVE bug; decision: RETIRE it (settled).**
+  `schedule_email` publishes to `email.message.schedule`, which has **no
+  consumer**; messages dead-letter (per-message expiry or the 24h queue TTL) and
+  `DlqEmailConsumerJob` **discards** everything except three auth templates. Its
+  only caller is `ExpirationWarningJob`, so **expiration-warning emails are
+  silently dropped in every jobs-enabled region today** (they only send on
+  jobs-disabled self-hosted, where the fallback ignores the delay and sends
+  immediately — the behavior we actually want). Decision: take slice 61 option
+  (b) — delete `schedule_email` + the `email.message.schedule` queue, and rewire
+  `ExpirationWarningJob` to send immediately via `enqueue_email` on the hourly
+  scan (matching the existing fallback behavior). This fixes a real outage and
+  removes the trap in one move; pull it forward out of 61 into its own small fix
+  ahead of the epic. Concrete steps in slice 61.
 
 Two smaller precision notes, neither a blocker: the four existing Security rate
 limiters are **not** a uniform mold (only `invite_token` is a class with

--- a/docs/specs/email-quality-controls/51-opt-back-in.md
+++ b/docs/specs/email-quality-controls/51-opt-back-in.md
@@ -97,8 +97,9 @@ invocation.
 - The `suppression_recovery` category is a tempting bypass channel — its
   membership is a frozen one-element list, asserted in spec; adding to it
   requires touching this policy deliberately.
-- Do NOT batch or delay the confirmation email through `schedule_email`
-  (grounding correction 2 — the schedule queue is a trap until slice 61).
+- Send the confirmation email immediately via `enqueue_email`; there is no
+  delayed-send path (`schedule_email` and the `email.message.schedule` queue are
+  removed in slice 61, grounding correction 2).
 - Refusal copy must be generic ("this address's status can't be changed here;
   contact support") — naming the reason would disclose complaint state to
   whoever holds the token.

--- a/docs/specs/email-quality-controls/61-hardening-cutover.md
+++ b/docs/specs/email-quality-controls/61-hardening-cutover.md
@@ -32,15 +32,32 @@ operators and pentesters.
     truncation).
   - Webhook idempotency records (slice 30) hold raw provider payloads: confirm
     the 5-day TTL and that no colonel surface renders them unredacted.
-- **Schedule-queue decision** (grounding correction 2): `email.message.
-  schedule` has no consumer, so delayed mail (today: `expiration_warning`)
-  dead-letters and is discarded. Either (a) implement the missing consumer
-  path (dead-letter routing back to `email.message.send` via
-  `x-dead-letter-routing-key` on a versioned queue — queue arguments are
-  immutable, so this is a `.v2` two-release migration), or (b) retire
-  `schedule_email` and send expiration warnings directly with the job's own
-  timing. Decide with real usage data; (b) is simpler and the epic's flows
-  never use delays.
+- **Schedule-queue removal** (grounding correction 2 — DECIDED: option (b),
+  pull ahead of the epic as a standalone live-bug fix): `email.message.schedule`
+  has no consumer, so delayed mail dead-letters and is discarded — meaning
+  `ExpirationWarningJob` (its only caller) sends **nothing** in jobs-enabled
+  regions today. Retire the delayed path entirely:
+  - Delete `Publisher.schedule_email` / `#schedule_email` (class + instance) from
+    `lib/onetime/jobs/publisher.rb`.
+  - Rewire `ExpirationWarningJob#schedule_warning_email` to call
+    `Onetime::Jobs::Publisher.enqueue_email(:expiration_warning, {...})` — send
+    immediately on the hourly scan. Drop the `WARNING_BUFFER_SECONDS`/`delay`
+    computation; the scan window (`warning_hours`) already scopes which secrets
+    warn, and the `warning_sent?`/`mark_warning_sent` dedup already prevents
+    repeats. (This is exactly what the jobs-disabled fallback already does.)
+  - Remove the `email.message.schedule` entry from `QueueConfig::QUEUES`. The
+    queue's `dlx.email.message` DLX is shared with `email.message.send`, so the
+    `DEAD_LETTER_CONFIG` mapping stays. Note the manual RabbitMQ queue teardown
+    across the 10 regional environments in the migration notes (queue args are
+    immutable; a stale unused queue is harmless but should be deleted for hygiene).
+  - Update specs: `publisher_spec` (drop `respond_to(:schedule_email)` +
+    trace-propagation cases), `queue_config_spec` (drop the
+    `email.message.schedule` expectations), and `expiration_warning_job_spec`
+    (retarget the ~8 `schedule_email` mocks to `enqueue_email`, drop delay
+    assertions).
+  - `DlqEmailConsumerJob`'s `discarded_non_auth` behavior no longer strands
+    `expiration_warning` (nothing schedules it); re-document the discard set
+    accordingly.
 - **DLQ replay hygiene**: verify (tryout) that colonel DLQ replay and
   `DlqEmailConsumerJob` re-deliveries hit the slice-20 gate — suppression state
   at REPLAY time wins, not at original-send time. (True by construction with
@@ -77,8 +94,10 @@ operators and pentesters.
       idempotency re-verified on the real dumps.
 - [ ] DLQ peek shows obscured addresses in previews (CLI + colonel),
       byte-for-byte otherwise.
-- [ ] Schedule-queue decision made, implemented, and `DlqEmailConsumerJob`'s
-      discard behavior re-documented to match.
+- [ ] `schedule_email` + `email.message.schedule` queue removed;
+      `ExpirationWarningJob` sends immediately via `enqueue_email` and a tryout
+      confirms warnings actually deliver in a jobs-enabled config;
+      `DlqEmailConsumerJob`'s discard behavior re-documented to match.
 - [ ] Replay-time suppression tryout green.
 - [ ] Pentest scope updated; operator guide + runbooks merged; scriv fragments
       present.


### PR DESCRIPTION
## Summary

Adds comprehensive prioritization and fitness analysis to the email-quality-controls epic specification, and settles the schedule-queue decision by retiring the broken `schedule_email` delayed-send path.

### Key changes:

1. **Epic 00 (overview)**: 
   - Clarifies that `schedule_email` is a live bug (expiration warnings silently dropped in jobs-enabled regions) and is being retired, not fixed
   - Adds new "Classification & prioritization (2026-07)" section with:
     - Volume context and reputation risk analysis
     - Per-slice prioritization table (NOW / MAYBE LATER / WAIT)
     - Rationale for deferring headers/tokens/UI/rate-limiters/observability
     - Fitness findings A–C documenting real architecture constraints and the schedule-queue decision

2. **Slice 61 (hardening-cutover)**:
   - Converts the open "schedule-queue decision" into a settled decision: **retire option (b)**
   - Concrete implementation steps: delete `Publisher.schedule_email`, rewire `ExpirationWarningJob` to call `enqueue_email` directly, remove the queue from config, update specs and DLQ discard documentation
   - Moves this as a standalone live-bug fix ahead of the epic proper

3. **Slice 51 (opt-back-in)**:
   - Updates guidance to send confirmation emails immediately via `enqueue_email` (no delayed path)

### Rationale:

The schedule queue has **no consumer** and messages dead-letter silently; `ExpirationWarningJob` is the only caller, so expiration warnings are currently dropped in all jobs-enabled regions. This is a real outage, not a design question. Retiring the delayed path (matching the existing jobs-disabled fallback behavior) fixes it immediately and removes a trap for future developers.

The prioritization table grounds the epic's scope in volume context (~10k/month, below bulk-sender thresholds) and real constraints (four production delivery backends, only three support webhooks), enabling teams to ship reputation-critical suppression + feedback ingestion first, then add user-facing features and observability as time allows.

## Related Issues

Fixes the live bug documented in grounding correction 2 (schedule queue has no consumer).

## Test Plan

Documentation only; no code changes to test. Existing specs for `ExpirationWarningJob`, `Publisher`, and `DlqEmailConsumerJob` will be updated as part of slice 61 implementation per the concrete steps listed.

https://claude.ai/code/session_01PbAUetiLY4E4rqwi8nDfuG