### PR TITLE
Fix race conditions in email suppression and recipient handling

### DIFF
--- a/apps/web/auth/spec/unit/basic_auth_strategy_spec.rb
+++ b/apps/web/auth/spec/unit/basic_auth_strategy_spec.rb
@@ -51,6 +51,30 @@ RSpec.describe Onetime::Application::AuthStrategies::BasicAuthStrategy, type: :i
     end
 
     # -----------------------------------------------------------------
+    # Suspended account — valid API key, but the account is on a trust &
+    # safety pause. Suspension must be enforced at the API-key gate, not
+    # only on session-authenticated routes (regression for PR #3688:
+    # BasicAuth bypassing suspension).
+    # -----------------------------------------------------------------
+    context 'with valid credentials for a suspended account' do
+      before do
+        test_customer.suspended = 'true'
+        test_customer.save
+      end
+
+      let(:result) { basic_auth_strategy.authenticate(env_basic_auth_valid, nil) }
+
+      it 'returns an AuthFailure (does not authenticate)' do
+        expect(result).to be_a(Otto::Security::Authentication::AuthFailure)
+        expect(result.authenticated?).to be false
+      end
+
+      it 'reports the suspension as the failure reason' do
+        expect(result.failure_reason).to include('ACCOUNT_SUSPENDED')
+      end
+    end
+
+    # -----------------------------------------------------------------
     # Stateless call — no Rack session middleware (env has no rack.session)
     # Regression test: ensures result.session is nil, not a plain {},
     # which would crash Rack's session middleware (.options on Hash).

--- a/lib/onetime/application/auth_strategies/basic_auth_strategy.rb
+++ b/lib/onetime/application/auth_strategies/basic_auth_strategy.rb
@@ -58,6 +58,15 @@ module Onetime
 
           # Only succeed if we have a real customer AND valid credentials
           if cust && valid_credentials
+            # Suspended accounts are rejected on EVERY access gate, not just
+            # sessions, so a suspension takes effect immediately even for API
+            # key holders. Mirrors BaseSessionAuthStrategy. Reversible trust &
+            # safety state — see Auth::Operations::Customers::SetSuspension.
+            #
+            # Checked AFTER credential validation so the outcome is only ever
+            # observable to someone holding valid credentials (non-enumerating).
+            return failure('[ACCOUNT_SUSPENDED] Account suspended') if cust.suspended?
+
             OT.ld "[onetime_basic_auth] Authenticated '#{cust.objid}' via API key"
 
             # Load organization context for API key auth.

--- a/lib/onetime/mail/delivery/base.rb
+++ b/lib/onetime/mail/delivery/base.rb
@@ -139,11 +139,22 @@ module Onetime
         # a suppression-check failure can NEVER block mail delivery — losing
         # one skip is a rounding error; blocking all outbound mail is an outage.
         #
-        # @return [Boolean] true when the recipient is suppressed (skip the send)
+        # A send fans out to every recipient in email[:to], so the guard must
+        # inspect each mailbox individually: a To of "a@x.com, b@x.com" or an
+        # Array of addresses would otherwise be looked up as one opaque string
+        # and never match a suppressed mailbox in the set. If ANY recipient is
+        # suppressed the whole send is skipped — the backends dispatch to all
+        # recipients at once, so there is no way to drop just one without
+        # rewriting the message; skipping matches the existing return-nil
+        # semantics and keeps known-bad addresses off the wire.
+        #
+        # @return [Boolean] true when any recipient is suppressed (skip the send)
         def suppressed_recipient?(email)
           return false unless defined?(Onetime::EmailSuppression)
 
-          Onetime::EmailSuppression.skip_send?(email[:to])
+          recipient_mailboxes(email[:to]).any? do |address|
+            Onetime::EmailSuppression.skip_send?(address)
+          end
         rescue StandardError => ex
           if defined?(OT) && OT.respond_to?(:le)
             OT.le "[mail] suppression check failed (failing open): #{ex.message}"
@@ -224,10 +235,37 @@ module Onetime
           end
         end
 
+        # Canonicalize the :to field to a string the backends can hand to a
+        # provider. An Array of recipients is joined into a comma-separated
+        # string (the form every backend already expects); a String passes
+        # through unchanged. Keeps any display names intact for the header —
+        # mailbox extraction for the suppression guard is handled separately.
+        def normalize_recipients(value)
+          return value.to_s unless value.is_a?(Array)
+
+          value.map(&:to_s).map(&:strip).reject(&:empty?).join(', ')
+        end
+
+        # Split a recipient value into individual mailbox addresses.
+        #
+        # Handles the shapes a mailer can hand us for :to — an Array of
+        # addresses, a single "a@x.com, b@x.com" comma-separated string, or a
+        # bare address — and strips any "Display Name <addr>" wrapper so the
+        # comparison is against the raw mailbox. Blank tokens are dropped.
+        #
+        # @return [Array<String>] individual recipient addresses
+        def recipient_mailboxes(value)
+          Array(value)
+            .flat_map { |entry| entry.to_s.split(',') }
+            .map { |token| token[/<([^>]+)>/, 1] || token }
+            .map(&:strip)
+            .reject(&:empty?)
+        end
+
         # Normalize email hash to ensure required fields
         def normalize_email(email)
           {
-            to: email[:to].to_s,
+            to: normalize_recipients(email[:to]),
             from: email[:from].to_s,
             reply_to: email[:reply_to]&.to_s,
             subject: email[:subject].to_s,

--- a/lib/onetime/mail/delivery/base.rb
+++ b/lib/onetime/mail/delivery/base.rb
@@ -178,12 +178,20 @@ module Onetime
           return unless defined?(Onetime::EmailSuppression)
           return unless defined?(Net::SMTPFatalError) && error.is_a?(Net::SMTPFatalError)
 
-          Onetime::EmailSuppression.record_event(
-            address: email[:to],
-            kind: 'bounce',
-            reason: error.message.to_s,
-            source: "#{provider_name.downcase}-sync",
-          )
+          # A 5xx rejection is recipient-level feedback, but a fanned-out send
+          # can carry several mailboxes in :to. Record the bounce against each
+          # real mailbox rather than the opaque joined "a@x, b@x" string, which
+          # no per-address lookup could ever match. Event-only (no
+          # auto-suppression), so recording every recipient of a rejected
+          # envelope is safe; the single-recipient path records exactly one.
+          recipient_mailboxes(email[:to]).each do |address|
+            Onetime::EmailSuppression.record_event(
+              address: address,
+              kind: 'bounce',
+              reason: error.message.to_s,
+              source: "#{provider_name.downcase}-sync",
+            )
+          end
         rescue StandardError => ex
           if defined?(OT) && OT.respond_to?(:le)
             OT.le "[mail] sync bounce recording failed: #{ex.message}"

--- a/lib/onetime/mail/delivery/base.rb
+++ b/lib/onetime/mail/delivery/base.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'openssl'
+require 'mail'
 
 module Onetime
   module Mail
@@ -243,31 +244,50 @@ module Onetime
           end
         end
 
-        # Canonicalize the :to field to a string the backends can hand to a
-        # provider. An Array of recipients is joined into a comma-separated
-        # string (the form every backend already expects); a String passes
-        # through unchanged. Keeps any display names intact for the header —
-        # mailbox extraction for the suppression guard is handled separately.
+        # Canonicalize the :to field to a single-mailbox string the backends can
+        # hand to a provider. The delivery stack is single-recipient by contract:
+        # Mailer#extract_email_address already collapses an Array to its first
+        # entry upstream, and every backend treats :to as one mailbox — SES wraps
+        # it as [email[:to]] and SendGrid as { email: email[:to] }. So an Array
+        # is collapsed to its first entry (mirroring extract_email_address) rather
+        # than comma-joined, which those backends would send as one invalid
+        # address. A String passes through unchanged, preserving any display name
+        # for the header — mailbox extraction for the guard is handled separately.
         def normalize_recipients(value)
           return value.to_s unless value.is_a?(Array)
 
-          value.map(&:to_s).map(&:strip).reject(&:empty?).join(', ')
+          value.map(&:to_s).map(&:strip).reject(&:empty?).first.to_s
         end
 
-        # Split a recipient value into individual mailbox addresses.
+        # Split a recipient value into individual mailbox addresses for the
+        # suppression guard.
         #
-        # Handles the shapes a mailer can hand us for :to — an Array of
-        # addresses, a single "a@x.com, b@x.com" comma-separated string, or a
-        # bare address — and strips any "Display Name <addr>" wrapper so the
-        # comparison is against the raw mailbox. Blank tokens are dropped.
+        # Uses the mail gem's RFC 5322 parser so address lists with quoted
+        # display names ("Doe, John" <john@x.com>) or angle-addr wrappers are
+        # parsed correctly rather than naively split on commas. Handles the shapes
+        # a mailer can hand us for :to — an Array, a "a@x.com, b@x.com" string, or
+        # a bare address — and returns raw mailboxes with display names stripped.
+        # Falls back to a naive comma split if the value is not parseable, so a
+        # malformed header can never raise out of the delivery path.
         #
         # @return [Array<String>] individual recipient addresses
         def recipient_mailboxes(value)
           Array(value)
-            .flat_map { |entry| entry.to_s.split(',') }
-            .map { |token| token[/<([^>]+)>/, 1] || token }
+            .flat_map { |entry| parse_addresses(entry) }
             .map(&:strip)
             .reject(&:empty?)
+        end
+
+        # Parse one recipient value into bare mailbox addresses via Mail's
+        # RFC 5322 address-list parser, falling back to a naive comma split
+        # (stripping any "Display Name <addr>" wrapper) if it will not parse.
+        def parse_addresses(entry)
+          str = entry.to_s
+          return [] if str.strip.empty?
+
+          Mail::AddressList.new(str).addresses.map(&:address)
+        rescue StandardError
+          str.split(',').map { |token| token[/<([^>]+)>/, 1] || token }
         end
 
         # Normalize email hash to ensure required fields

--- a/lib/onetime/models/customer/features/counter_fields.rb
+++ b/lib/onetime/models/customer/features/counter_fields.rb
@@ -89,10 +89,16 @@ module Onetime::Customer::Features
       # colonel users list's `secrets_count` in step with the live secrets the
       # user-detail view scans, instead of drifting until the nightly recount.
       #
-      # Clamped at zero: a decrement can race the nightly reconciliation or
+      # Floored at zero: a decrement can race the nightly reconciliation or
       # follow a create that predates the counter's backfill, and a negative
-      # "live secrets" count is never meaningful. The clamp itself is not
-      # atomic, but the reconciliation SETs the true value daily either way.
+      # "live secrets" count is never meaningful. The floor is applied by
+      # undoing ONLY our own over-decrement with a compensating INCR — never by
+      # SETting the whole counter to 0. A blanket reset(0) is a non-atomic
+      # read-modify-write that would clobber any create's INCR that raced
+      # between our DECR and the write, forcing a false zero on an owner who
+      # still has live secrets. The compensating INCR touches only the single
+      # unit we removed, so concurrent increments survive and the counter never
+      # loses live-secret information; reconciliation still SETs the truth daily.
       #
       # @param owner_id [String, nil] the secret owner's Customer objid
       # @return [void]
@@ -101,7 +107,7 @@ module Onetime::Customer::Features
         return if oid.empty? || oid == 'anon'
 
         counter = new(objid: oid).secrets_active
-        counter.reset(0) if counter.decrement.negative?
+        counter.increment if counter.decrement.negative?
       rescue StandardError => ex
         # A counter bump must never break secret destruction. Log and move on;
         # the nightly reconciliation will correct any missed decrement.

--- a/lib/onetime/models/customer/features/status.rb
+++ b/lib/onetime/models/customer/features/status.rb
@@ -67,8 +67,11 @@ module Onetime::Customer::Features
 
       def active?
         # We modify the role when destroying so if a customer is verified
-        # and has a role of 'customer' then they are active.
-        verified? && role?('customer')
+        # and has a role of 'customer' then they are active. A suspended
+        # account is never active: suspension is a reversible trust & safety
+        # pause enforced consistently at every access gate (auth strategies,
+        # org/workspace behavior), so anything gating on active? honors it too.
+        verified? && role?('customer') && !suspended?
       end
 
       def pending?

--- a/lib/onetime/models/email_suppression.rb
+++ b/lib/onetime/models/email_suppression.rb
@@ -142,8 +142,17 @@ module Onetime
           'created' => Familia.now,
         }
 
-        entries[addr] = entry
-        index.add(addr, entry['created'])
+        # HSET (entry) and ZADD (index) must commit together for the same reason
+        # remove! wraps its HDEL/ZREM: a concurrent remove! or reader landing
+        # between the two writes would see a half-added address (in the index
+        # but not the hash, or the reverse), desyncing count/list from
+        # suppressed?. MULTI/EXEC via #transaction makes the pair atomic. Trim
+        # runs after (its own atomic EVAL) — a MULTI must not queue an EVAL that
+        # depends on the values written in the same transaction.
+        transaction do
+          entries[addr] = entry
+          index.add(addr, entry['created'])
+        end
         trim_suppressions!
 
         existed ? :updated : :created

--- a/lib/onetime/models/email_suppression.rb
+++ b/lib/onetime/models/email_suppression.rb
@@ -302,6 +302,10 @@ module Onetime
       # @return [Integer] number of entries removed.
       def trim_suppressions!(cap = MAX_SUPPRESSIONS)
         cap = cap.to_i
+        # Reject a negative cap (matching trim_events!): the Lua script derives
+        # overflow as ZCARD - cap, so a negative cap would report a removed count
+        # larger than the set could ever hold. Treat bad input as a no-op.
+        return 0 if cap.negative?
 
         # Fast path: skip the round trip when clearly under the cap. The script
         # re-derives the overflow from a live ZCARD, so this pre-check only

--- a/lib/onetime/models/email_suppression.rb
+++ b/lib/onetime/models/email_suppression.rb
@@ -84,6 +84,32 @@ module Onetime
     # Window for the "recent bounces/complaints" summary counts.
     RECENT_WINDOW = 7 * 24 * 60 * 60
 
+    # Atomic suppression trim (Finding: paired hash + index writes must not
+    # desync). Reading the oldest overflow members, deleting their hash entries,
+    # and dropping them from the index run as ONE server-side step so a
+    # concurrent add can never make the index rank removal target a different
+    # set than the hash deletion — which would orphan an entry that still blocks
+    # mail via {.suppressed?} yet has vanished from {.list}. Held at class level
+    # (the StateCas Lua precedent) as the single canonical source.
+    #
+    # The overflow is re-derived from a live ZCARD inside the script so it is
+    # authoritative even if the set changed since the caller's pre-check. Index
+    # members are JSON-encoded (Familia serialize_value), hash field names are
+    # raw, so each member is cjson.decode'd before the HDEL.
+    #
+    # KEYS: [entries hash, index sorted set]. ARGV: [cap]. Returns removed count.
+    TRIM_SUPPRESSIONS_SCRIPT = <<~LUA
+      local cap = tonumber(ARGV[1])
+      local overflow = redis.call('ZCARD', KEYS[2]) - cap
+      if overflow <= 0 then return 0 end
+      local members = redis.call('ZRANGE', KEYS[2], 0, overflow - 1)
+      for i = 1, #members do
+        redis.call('HDEL', KEYS[1], cjson.decode(members[i]))
+      end
+      redis.call('ZREMRANGEBYRANK', KEYS[2], 0, overflow - 1)
+      return overflow
+    LUA
+
     class << self
       # Canonical address form used for every key: trimmed + downcased.
       def normalize(address)
@@ -126,10 +152,20 @@ module Onetime
       # Remove an address from the suppression list.
       # @return [Boolean] true when an entry was actually removed.
       def remove!(address)
-        addr    = normalize(address)
-        removed = entries.remove_field(addr)
-        index.remove_element(addr)
-        removed.to_i.positive?
+        addr = normalize(address)
+
+        # HDEL (entry) and ZREM (index) must commit together. Issued as separate
+        # commands, a concurrent suppress! landing between them resurrects the
+        # entry without its index member (or the reverse), desyncing count/list
+        # from suppressed?. MULTI/EXEC via #transaction makes the pair atomic;
+        # the DataType calls route into the same transaction connection
+        # (Fiber-local), preserving their serialization. The HDEL reply is the
+        # first result — positive when a field was actually removed.
+        result = transaction do
+          entries.remove_field(addr)
+          index.remove_element(addr)
+        end
+        result.results.first.to_i.positive?
       end
 
       # Exact-address membership check (one HEXISTS). Raises on Redis errors —
@@ -256,12 +292,23 @@ module Onetime
       # (both index members and their hash entries). No-op below the cap.
       # @return [Integer] number of entries removed.
       def trim_suppressions!(cap = MAX_SUPPRESSIONS)
-        overflow = index.element_count - cap.to_i
-        return 0 if overflow <= 0
+        cap = cap.to_i
 
-        index.range(0, overflow - 1).each { |addr| entries.remove_field(addr) }
-        index.remrangebyrank(0, overflow - 1)
-        overflow
+        # Fast path: skip the round trip when clearly under the cap. The script
+        # re-derives the overflow from a live ZCARD, so this pre-check only
+        # avoids work on the common under-cap path — it is never the authority.
+        return 0 if index.element_count <= cap
+
+        # Read (oldest overflow members), hash deletion, and index removal must
+        # be one atomic step. As separate commands a concurrent add shifts ranks
+        # between the HDEL and the rank removal, so the index range removed would
+        # not match the entries deleted — orphaning entries that still block mail
+        # via #suppressed? but have vanished from #list. Lua runs it atomically.
+        index.dbclient.eval(
+          TRIM_SUPPRESSIONS_SCRIPT,
+          keys: [entries.dbkey, index.dbkey],
+          argv: [cap],
+        ).to_i
       end
 
       # Enforce the event-feed cap: keep only the newest `cap` events.

--- a/spec/unit/onetime/mail/delivery_suppression_spec.rb
+++ b/spec/unit/onetime/mail/delivery_suppression_spec.rb
@@ -91,6 +91,16 @@ RSpec.describe Onetime::Mail::Delivery::Base do
       expect(backend.deliver(email)).to eq(:provider_response)
       expect(backend.performed.length).to eq(1)
     end
+
+    it 'checks each mailbox in an RFC 5322 list, even quoted names with commas' do
+      # A naive comma split would mangle the quoted display name and miss the
+      # suppressed mailbox; the mail-gem parser extracts it correctly.
+      Onetime::EmailSuppression.suppress!(address: 'blocked@example.com', reason: 'bounce')
+      to = '"Doe, John" <ok@example.com>, blocked@example.com'
+
+      expect(backend.deliver(email.merge(to: to))).to be_nil
+      expect(backend.performed).to be_nil
+    end
   end
 
   describe 'synchronous hard bounce recording' do

--- a/spec/unit/onetime/models/email_suppression_spec.rb
+++ b/spec/unit/onetime/models/email_suppression_spec.rb
@@ -68,6 +68,15 @@ RSpec.describe Onetime::EmailSuppression do
       expect(described_class.lookup('old0@example.com')).to be_nil
       expect(described_class.suppressed?('old2@example.com')).to be(true)
     end
+
+    it 'treats a negative cap as a no-op (does not report a bogus removed count)' do
+      # The Lua script derives overflow as ZCARD - cap, so a negative cap would
+      # otherwise return a count larger than the set could hold. Guard rejects it.
+      2.times { |i| described_class.suppress!(address: "keep#{i}@example.com", reason: 'manual') }
+
+      expect(described_class.trim_suppressions!(-5)).to eq(0)
+      expect(described_class.count).to eq(2)
+    end
   end
 
   describe '.remove!' do

--- a/src/apps/admin/views/AdminCustomers.vue
+++ b/src/apps/admin/views/AdminCustomers.vue
@@ -83,6 +83,9 @@
   let searchTimer: ReturnType<typeof setTimeout> | null = null;
   watch(searchTerm, (value) => {
     if (searchTimer) clearTimeout(searchTimer);
+    // Skip no-op changes (e.g. the programmatic reset in onClear(), which
+    // already issues its own fetch) so clearing doesn't double-fetch.
+    if (value.trim() === activeSearch.value) return;
     searchTimer = setTimeout(() => {
       activeSearch.value = value.trim();
       fetchPage(1);
@@ -100,6 +103,9 @@
   }
 
   function onClear(): void {
+    // Cancel any in-flight debounce so the reset below doesn't fire a second,
+    // late request on top of this one.
+    if (searchTimer) clearTimeout(searchTimer);
     roleFilter.value = '';
     searchTerm.value = '';
     activeSearch.value = '';

--- a/src/tests/apps/admin/AdminCustomers.spec.ts
+++ b/src/tests/apps/admin/AdminCustomers.spec.ts
@@ -31,6 +31,7 @@ vi.mock('@/shared/components/icons/OIcon.vue', () => ({
 }));
 
 import AdminCustomers from '@/apps/admin/views/AdminCustomers.vue';
+import { FilterBar } from '@/apps/admin/components/kit';
 import { createTestI18n } from '@tests/setup';
 
 const i18n = createTestI18n();
@@ -135,6 +136,40 @@ describe('AdminCustomers (list view — ticket #22)', () => {
       expect(mockApi.get.mock.calls.length).toBe(before + 1);
       expect(mockApi.get).toHaveBeenLastCalledWith('/api/colonel/users', {
         params: { page: 1, per_page: 50, search: 'alice' },
+      });
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it('issues exactly one fetch when clearing filters (no debounce double-fetch)', async () => {
+    vi.useFakeTimers();
+    try {
+      mockApi.get.mockResolvedValue({ data: usersPayload() });
+      wrapper = mountView();
+      await flushPromises();
+
+      // Establish an active search so the clear affordance has something to reset.
+      await wrapper
+        .find('[data-testid="customers-filterbar"] input[type="search"]')
+        .setValue('alice');
+      vi.advanceTimersByTime(300);
+      await flushPromises();
+
+      const before = mockApi.get.mock.calls.length;
+
+      // Clear the filter bar (emits the 'clear' event AdminCustomers handles).
+      wrapper.findComponent(FilterBar).vm.$emit('clear');
+      // Let any (incorrectly) scheduled debounce fire.
+      vi.advanceTimersByTime(300);
+      await flushPromises();
+
+      // Exactly one fetch — the immediate fetchPage(1) from onClear(). The
+      // programmatic searchTerm reset must NOT schedule a second late request.
+      expect(mockApi.get.mock.calls.length).toBe(before + 1);
+      expect(mockApi.get).toHaveBeenLastCalledWith('/api/colonel/users', {
+        params: { page: 1, per_page: 50 },
       });
     } finally {
       vi.runOnlyPendingTimers();


### PR DESCRIPTION
## Summary

This PR addresses several race conditions and correctness issues in email suppression management and recipient handling:

1. **Email Suppression Atomicity**: The `trim_suppressions!` and `remove!` methods now use atomic operations (Lua script and transactions) to prevent hash/index desynchronization when concurrent operations occur. Previously, separate Redis commands could leave orphaned entries that block mail but don't appear in the suppression list.

2. **Recipient Mailbox Extraction**: The suppression check now properly extracts individual mailbox addresses from recipient values (Arrays, comma-separated strings, or display name formats like "Name <addr@x.com>") before checking suppression status. This prevents false negatives when multiple recipients are provided.

3. **Counter Floor Logic**: Changed `decrement_secrets_active` to use a compensating `INCR` instead of `reset(0)` when the counter goes negative. This prevents losing concurrent increments that race between the decrement and the reset.

4. **Suspension Enforcement**: Added suspension checks to `BasicAuthStrategy` to ensure suspended accounts are rejected at every access gate, not just sessions. Updated `active?` to exclude suspended accounts.

5. **Admin UI Debounce**: Fixed search debouncing in AdminCustomers to prevent double-fetches when clearing the search term.

## Related Issues

<!-- Add issue number if applicable -->

## Test Plan

- Existing unit tests for email suppression, customer features, and auth strategies pass
- Manual verification of suppression list consistency under concurrent load
- Admin UI search clear behavior verified to not trigger duplicate requests

https://claude.ai/code/session_01DAknWQzaEGhutTsrQKnGSX