### PR TITLE
Secret Activity: actor identity on lifecycle events (revealed/burned)

### DIFF
--- a/apps/api/v2/logic/secrets.rb
+++ b/apps/api/v2/logic/secrets.rb
@@ -13,6 +13,7 @@ module V2
 end
 
 require_relative 'secrets/access_telemetry'
+require_relative 'secrets/actor_attribution'
 require_relative 'secrets/burn_secret'
 require_relative 'secrets/conceal_secret'
 require_relative 'secrets/generate_secret'

--- a/apps/api/v2/logic/secrets/actor_attribution.rb
+++ b/apps/api/v2/logic/secrets/actor_attribution.rb
@@ -1,0 +1,66 @@
+# apps/api/v2/logic/secrets/actor_attribution.rb
+#
+# frozen_string_literal: true
+
+module V2::Logic
+  module Secrets
+    # Computes the request-scoped actor attribution for secret lifecycle events
+    # (revealed / burned) and threads it into the model cascade (#3639).
+    #
+    # The lifecycle emit happens deep inside the atomic consume cascade
+    # (Secret#reveal!/#burned! -> Receipt#revealed!/#burned! ->
+    # record_org_audit_event), which has no request context. So the discriminator
+    # is computed HERE, where the request's customer (`cust`) is in scope, and
+    # threaded down as an opaque `actor_context` hash.
+    #
+    # "Who revealed it" is the first question an auditor asks; before this the
+    # revealed/burned events carried no actor at all — the highest-value gap in
+    # the org audit pipeline.
+    module ActorAttribution
+      private
+
+      # Build the actor-attribution audit context for a lifecycle transition.
+      #
+      # The ownership test mirrors the fetch-side telemetry
+      # (AccessTelemetry#record_access_telemetry) EXACTLY, including the critical
+      # anonymous guard: Secret#owner? compares objids, so a guest-created secret
+      # (owner_id nil) inspected by an anonymous caller (objid nil) would match
+      # `nil == nil` and misattribute the access to "the creator". Gating on
+      # `!anonymous_user?` first means an anonymous caller never reaches owner?,
+      # so an anonymous reveal/burn of a guest link is always 'anonymous' and
+      # never 'creator'. See the same precedent in access_telemetry.rb.
+      #
+      #   creator             — authenticated caller who owns the secret
+      #   authenticated_other — authenticated caller who does NOT own it
+      #   anonymous           — unauthenticated caller (or unknown)
+      #
+      # The optional 'actor_id' is a SHORTID of the acting customer's internal
+      # object identifier (never the email or full custid), matching the
+      # shortids-only convention the trail already uses for receipt/secret ids
+      # (Receipt#shortid). It is included only for authenticated actors, where a
+      # real objid exists; anonymous events carry the discriminator alone.
+      #
+      # @param target_secret [Onetime::Secret, nil] the secret being consumed.
+      # @return [Hash] string-keyed audit attrs, always carrying 'actor'.
+      def lifecycle_actor_context(target_secret)
+        return { 'actor' => 'anonymous' } if anonymous_user?
+
+        actor               = target_secret&.owner?(cust) ? 'creator' : 'authenticated_other'
+        context             = { 'actor' => actor }
+        # Only attach an id when we actually resolved one; never store a nil.
+        shortid             = actor_shortid
+        context['actor_id'] = shortid unless shortid.nil?
+        context
+      end
+
+      # An 8-char shortid of the acting customer's object identifier, mirroring
+      # Receipt#shortid (identifier.slice(0, 8)). Kept short and non-sensitive so
+      # it can never leak an email or a capability token into the trail. Returns
+      # nil (dropped by the caller) when no stable objid is available.
+      def actor_shortid
+        objid = cust&.objid.to_s
+        objid.empty? ? nil : objid.slice(0, 8)
+      end
+    end
+  end
+end

--- a/apps/api/v2/logic/secrets/actor_attribution.rb
+++ b/apps/api/v2/logic/secrets/actor_attribution.rb
@@ -45,6 +45,18 @@ module V2::Logic
       def lifecycle_actor_context(target_secret)
         return { 'actor' => 'anonymous' } if anonymous_user?
 
+        # target_secret is the secret being consumed and is always in hand at
+        # the reveal/burn call sites. Guard nil explicitly: without a secret we
+        # cannot establish ownership, and letting it fall through owner? would
+        # silently bucket the caller as `authenticated_other` -- a misleading
+        # actor that also hides the programmer error. Surface it, but never
+        # raise: attribution is best-effort observability and must not break
+        # the consume path.
+        if target_secret.nil?
+          OT.le '[actor-attribution] nil target_secret for an authenticated ' \
+                'caller; ownership indeterminate, recording actor=authenticated_other'
+        end
+
         actor               = target_secret&.owner?(cust) ? 'creator' : 'authenticated_other'
         context             = { 'actor' => actor }
         # Only attach an id when we actually resolved one; never store a nil.

--- a/apps/api/v2/logic/secrets/burn_secret.rb
+++ b/apps/api/v2/logic/secrets/burn_secret.rb
@@ -31,6 +31,7 @@ module V2::Logic
       include Onetime::LoggerMethods
       include Onetime::Logic::GuestRouteGating
       include Onetime::Security::PassphraseRateLimiter
+      include ActorAttribution
 
       SCHEMAS = { response: 'receipt' }.freeze
 
@@ -84,12 +85,17 @@ module V2::Logic
           # Clear any rate limit state on successful passphrase entry
           clear_passphrase_rate_limit!(secret.identifier) if secret.has_passphrase?
 
+          # Attribute the burn BEFORE burned! consumes the secret: owner?(cust)
+          # reads the still-in-memory owner_id, so the 'burned' audit event
+          # records who acted (#3639). Anonymous guard in lifecycle_actor_context.
+          actor_context = lifecycle_actor_context(secret)
+
           # Gate all bookkeeping on winning the atomic burn claim: burned!
           # returns true only for the single caller that flips the state. When
           # a concurrent reveal or burn already consumed the secret, this
           # request lost the race -- it must not count the burn, log success,
           # or report success to the client.
-          @greenlighted = secret.burned!
+          @greenlighted = secret.burned!(actor_context: actor_context)
 
           if greenlighted
             owner = secret.load_owner

--- a/apps/api/v2/logic/secrets/reveal_secret.rb
+++ b/apps/api/v2/logic/secrets/reveal_secret.rb
@@ -33,6 +33,7 @@ module V2::Logic
       include Onetime::LoggerMethods
       include Onetime::Logic::GuestRouteGating
       include Onetime::Security::PassphraseRateLimiter
+      include ActorAttribution
 
       SCHEMAS = { response: 'secret' }.freeze
 
@@ -87,6 +88,12 @@ module V2::Logic
 
         owner = secret.load_owner
         if show_secret
+          # Compute the actor attribution BEFORE reveal! consumes the secret:
+          # owner?(cust) reads the still-in-memory owner_id. Threaded into every
+          # reveal! path below so the 'revealed' audit event records who acted
+          # (#3639). The anonymous guard lives in lifecycle_actor_context.
+          actor_context = lifecycle_actor_context(secret)
+
           # Clear any rate limit state on successful passphrase entry
           clear_passphrase_rate_limit!(secret.identifier) if secret.has_passphrase?
 
@@ -131,7 +138,7 @@ module V2::Logic
               # (which updates the receipt record and then expunges the secret
               # record) and allow the user to carry on. reveal! returns the
               # plaintext only if this caller won the one-shot claim.
-              @secret_value = secret.reveal!(passphrase_input: @passphrase)
+              @secret_value = secret.reveal!(passphrase_input: @passphrase, actor_context: actor_context)
 
             elsif owner && (cust&.anonymous? || (cust&.custid == owner.custid && !owner.verified?))
               secret_logger.info 'Owner verification successful',
@@ -147,7 +154,7 @@ module V2::Logic
               owner.reset_secret.delete!
               # Skip for stateless auth (BasicAuth provides empty session)
               sess.clear unless sess.empty?
-              @secret_value     = secret.reveal!(passphrase_input: @passphrase)
+              @secret_value     = secret.reveal!(passphrase_input: @passphrase, actor_context: actor_context)
 
             else
               secret_logger.error 'Invalid verification - user already logged in',
@@ -175,7 +182,7 @@ module V2::Logic
             # nil. The success log and the shared-secret counters are therefore
             # gated on winning, so a losing request neither claims success nor
             # inflates the metrics.
-            @secret_value = secret.reveal!(passphrase_input: @passphrase)
+            @secret_value = secret.reveal!(passphrase_input: @passphrase, actor_context: actor_context)
 
             if @secret_value
               secret_logger.info 'Secret revealed successfully',

--- a/apps/api/v2/logic/secrets/show_secret.rb
+++ b/apps/api/v2/logic/secrets/show_secret.rb
@@ -17,6 +17,7 @@ module V2::Logic
     #   only be viewed once.
     class ShowSecret < V2::Logic::Base
       include AccessTelemetry
+      include ActorAttribution
       include Onetime::Logic::GuestRouteGating
       include Onetime::Security::PassphraseRateLimiter
 
@@ -152,7 +153,9 @@ module V2::Logic
           # which exposes no public destroy method. clear is the correct call.
           # Skip for stateless auth (BasicAuth provides empty session)
           sess.clear unless sess.empty?
-          secret.reveal!(passphrase_input: passphrase)
+          # actor_context attributes the reveal (#3639); computed before reveal!
+          # consumes the secret so owner?(cust) sees the in-memory owner_id.
+          secret.reveal!(passphrase_input: passphrase, actor_context: lifecycle_actor_context(secret))
         else
           raise_form_error "You can't verify an account when you're already logged in."
         end
@@ -168,7 +171,9 @@ module V2::Logic
       # reveal claim; a request that lost the race gets nil, so the shared-secret
       # counters are gated on winning to avoid inflating them on a lost race.
       def reveal_secret(owner)
-        plaintext = secret.reveal!(passphrase_input: passphrase)
+        # actor_context attributes the reveal (#3639); computed before reveal!
+        # consumes the secret so owner?(cust) sees the in-memory owner_id.
+        plaintext = secret.reveal!(passphrase_input: passphrase, actor_context: lifecycle_actor_context(secret))
         return plaintext if plaintext.nil?
 
         owner&.increment_field :secrets_shared unless owner&.anonymous?

--- a/apps/api/v2/spec/logic/secrets/burn_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/burn_secret_spec.rb
@@ -4,6 +4,7 @@
 
 require_relative '../../../application'
 require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require_relative '../../support/actor_attribution_helpers'
 
 # Regression coverage for the v2 burn confirmation flag.
 #
@@ -19,6 +20,8 @@ require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
 # Uses real Receipt/Secret objects (spawn_pair) so process -> success_data runs
 # end-to-end without stubbing the URL/serialization helpers.
 RSpec.describe V2::Logic::Secrets::BurnSecret, type: :integration do
+  include ActorAttributionSpecHelpers
+
   before(:all) do
     require 'onetime'
     Onetime.boot! :test
@@ -52,23 +55,6 @@ RSpec.describe V2::Logic::Secrets::BurnSecret, type: :integration do
     # process derives cust from strategy_result.user and never calls org, so no
     # accessor stubbing is needed (we exercise process directly, not raise_concerns).
     described_class.new(strategy_result, params)
-  end
-
-  # Persist an org on the receipt so the burn cascade fans the 'burned' event
-  # (with its actor attribution) out to a real, inspectable trail.
-  def link_receipt_to_org!(receipt)
-    org = Onetime::Organization.new(
-      display_name: 'Actor Attribution Org',
-      contact_email: "actor-#{SecureRandom.hex(6)}@example.com",
-    ).tap(&:save)
-    receipt.org_id = org.objid
-    receipt.save_fields(:org_id)
-    org
-  end
-
-  # An authenticated caller who owns `owner_objid`'s secret.
-  def owner_double(owner_objid)
-    double('Customer', custid: owner_objid, objid: owner_objid, anonymous?: false)
   end
 
   # Hold the race window open: both requests loaded the secret before the

--- a/apps/api/v2/spec/logic/secrets/burn_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/burn_secret_spec.rb
@@ -34,9 +34,13 @@ RSpec.describe V2::Logic::Secrets::BurnSecret, type: :integration do
 
   # Build a BurnSecret instance over a real receipt with the api_access
   # entitlement granted (we exercise process directly, not raise_concerns).
-  def build_logic(params)
-    customer = double('Customer', custid: 'anon', anonymous?: true, objid: nil)
-    org      = double('Organization', objid: "org_#{SecureRandom.hex(4)}")
+  # customer overrides the default anonymous caller for actor-attribution
+  # coverage (#3639). Positional (not a kwarg) so the existing bare-hash
+  # `build_logic('identifier' => ...)` call sites keep working — a trailing
+  # kwarg would otherwise swallow the bare params hash as keywords.
+  def build_logic(params, customer = nil)
+    customer ||= double('Customer', custid: 'anon', anonymous?: true, objid: nil)
+    org        = double('Organization', objid: "org_#{SecureRandom.hex(4)}")
     allow(org).to receive(:can?).and_return(true)
 
     strategy_result = double('StrategyResult',
@@ -48,6 +52,23 @@ RSpec.describe V2::Logic::Secrets::BurnSecret, type: :integration do
     # process derives cust from strategy_result.user and never calls org, so no
     # accessor stubbing is needed (we exercise process directly, not raise_concerns).
     described_class.new(strategy_result, params)
+  end
+
+  # Persist an org on the receipt so the burn cascade fans the 'burned' event
+  # (with its actor attribution) out to a real, inspectable trail.
+  def link_receipt_to_org!(receipt)
+    org = Onetime::Organization.new(
+      display_name: 'Actor Attribution Org',
+      contact_email: "actor-#{SecureRandom.hex(6)}@example.com",
+    ).tap(&:save)
+    receipt.org_id = org.objid
+    receipt.save_fields(:org_id)
+    org
+  end
+
+  # An authenticated caller who owns `owner_objid`'s secret.
+  def owner_double(owner_objid)
+    double('Customer', custid: owner_objid, objid: owner_objid, anonymous?: false)
   end
 
   # Hold the race window open: both requests loaded the secret before the
@@ -149,6 +170,65 @@ RSpec.describe V2::Logic::Secrets::BurnSecret, type: :integration do
       expect(stale).not_to have_received(:load_owner)
       # Branch-entry pin -- see the concurrent-reveal case above.
       expect(logic.secret).to be(stale)
+    end
+  end
+
+  # Actor attribution on burn (#3639). The burned event must carry the actor
+  # discriminator computed from the request's customer, with the same anonymous
+  # guard as reveal so an anonymous burn of a guest link is never misattributed.
+  context 'actor attribution (#3639)' do
+    it 'records actor=creator when the authenticated owner burns' do
+      owner_objid = "objid_#{SecureRandom.hex(6)}"
+      owner_pair  = Onetime::Receipt.spawn_pair(owner_objid, 3600, 'a secret value')
+      org         = link_receipt_to_org!(owner_pair.first)
+
+      logic = build_logic(
+        { 'identifier' => owner_pair.first.identifier, 'continue' => 'true' },
+        owner_double(owner_objid),
+      )
+      logic.process_params
+      logic.process
+
+      expect(logic.greenlighted).to be true
+      event = org.audit_events_page.first
+      expect(event['kind']).to eq('burned')
+      expect(event['actor']).to eq('creator')
+      expect(event['actor_id']).to eq(owner_objid.slice(0, 8))
+    end
+
+    it 'records actor=authenticated_other when an authenticated non-owner burns' do
+      owner_objid = "objid_#{SecureRandom.hex(6)}"
+      other_objid = "objid_#{SecureRandom.hex(6)}"
+      owner_pair  = Onetime::Receipt.spawn_pair(owner_objid, 3600, 'a secret value')
+      org         = link_receipt_to_org!(owner_pair.first)
+
+      logic = build_logic(
+        { 'identifier' => owner_pair.first.identifier, 'continue' => 'true' },
+        owner_double(other_objid),
+      )
+      logic.process_params
+      logic.process
+
+      expect(logic.greenlighted).to be true
+      event = org.audit_events_page.first
+      expect(event['actor']).to eq('authenticated_other')
+      expect(event['actor_id']).to eq(other_objid.slice(0, 8))
+    end
+
+    # THE privacy pin (burn variant): an anonymous burn of a guest link
+    # (owner_id nil, caller objid nil) must be 'anonymous', never 'creator'.
+    it 'records actor=anonymous for an anonymous burn of a guest link (never creator)' do
+      org   = link_receipt_to_org!(receipt) # default pair is a guest secret
+      logic = build_logic('identifier' => receipt.identifier, 'continue' => 'true')
+      logic.process_params
+      logic.process
+
+      expect(logic.greenlighted).to be true
+      event = org.audit_events_page.first
+      expect(event['kind']).to eq('burned')
+      expect(event['actor']).to eq('anonymous')
+      expect(event['actor']).not_to eq('creator')
+      expect(event).not_to have_key('actor_id')
     end
   end
 

--- a/apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb
@@ -4,6 +4,7 @@
 
 require_relative '../../../application'
 require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require_relative '../../support/actor_attribution_helpers'
 
 # Security regression coverage for the double-reveal race.
 #
@@ -18,6 +19,8 @@ require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
 # (raise_concerns, which handles guest-gating/entitlements/rate-limits, is out
 # of scope here).
 RSpec.describe V2::Logic::Secrets::RevealSecret, type: :integration do
+  include ActorAttributionSpecHelpers
+
   before(:all) do
     require 'onetime'
     Onetime.boot! :test
@@ -62,25 +65,6 @@ RSpec.describe V2::Logic::Secrets::RevealSecret, type: :integration do
   def flag_as_verification!(secret)
     secret.verification = 'true'
     secret.save_fields(:verification)
-  end
-
-  # Persist an org on the receipt so the reveal cascade fans the 'revealed'
-  # event (with its actor attribution) out to a real, inspectable trail. The
-  # cascade reloads the receipt from Redis, so org_id must be saved, not just
-  # set in memory.
-  def link_receipt_to_org!(receipt)
-    org = Onetime::Organization.new(
-      display_name: 'Actor Attribution Org',
-      contact_email: "actor-#{SecureRandom.hex(6)}@example.com",
-    ).tap(&:save)
-    receipt.org_id = org.objid
-    receipt.save_fields(:org_id)
-    org
-  end
-
-  # An authenticated caller who owns `owner_objid`'s secret.
-  def owner_double(owner_objid)
-    double('Customer', custid: owner_objid, objid: owner_objid, anonymous?: false)
   end
 
   let!(:pair)   { Onetime::Receipt.spawn_pair(nil, 3600, 'a secret value') }

--- a/apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb
@@ -64,6 +64,25 @@ RSpec.describe V2::Logic::Secrets::RevealSecret, type: :integration do
     secret.save_fields(:verification)
   end
 
+  # Persist an org on the receipt so the reveal cascade fans the 'revealed'
+  # event (with its actor attribution) out to a real, inspectable trail. The
+  # cascade reloads the receipt from Redis, so org_id must be saved, not just
+  # set in memory.
+  def link_receipt_to_org!(receipt)
+    org = Onetime::Organization.new(
+      display_name: 'Actor Attribution Org',
+      contact_email: "actor-#{SecureRandom.hex(6)}@example.com",
+    ).tap(&:save)
+    receipt.org_id = org.objid
+    receipt.save_fields(:org_id)
+    org
+  end
+
+  # An authenticated caller who owns `owner_objid`'s secret.
+  def owner_double(owner_objid)
+    double('Customer', custid: owner_objid, objid: owner_objid, anonymous?: false)
+  end
+
   let!(:pair)   { Onetime::Receipt.spawn_pair(nil, 3600, 'a secret value') }
   let(:receipt) { pair.first }
   let(:secret)  { pair.last }
@@ -99,6 +118,70 @@ RSpec.describe V2::Logic::Secrets::RevealSecret, type: :integration do
       expect(logic.show_secret).to be false
       expect(logic.secret_value).to be_nil
       expect(logic.success_data[:record]).not_to have_key(:secret_value)
+    end
+  end
+
+  # Actor attribution on reveal (#3639). "Who revealed it" is the first
+  # question an auditor asks; the revealed event must carry the actor
+  # discriminator computed from the request's customer. The ownership test
+  # mirrors the fetch-side telemetry EXACTLY, including the anonymous guard
+  # that keeps a guest link (owner_id nil) revealed by an anonymous caller
+  # (objid nil) from matching nil == nil and being misattributed to "creator".
+  context 'actor attribution (#3639)' do
+    it 'records actor=creator when the authenticated owner reveals' do
+      owner_objid = "objid_#{SecureRandom.hex(6)}"
+      owner_pair  = Onetime::Receipt.spawn_pair(owner_objid, 3600, 'a secret value')
+      org         = link_receipt_to_org!(owner_pair.first)
+
+      logic = build_logic(
+        { 'identifier' => owner_pair.last.identifier, 'continue' => 'true' },
+        customer: owner_double(owner_objid),
+      )
+      logic.process_params
+      logic.process
+
+      expect(logic.secret_value).to eq('a secret value')
+      event = org.audit_events_page.first
+      expect(event['kind']).to eq('revealed')
+      expect(event['actor']).to eq('creator')
+      expect(event['actor_id']).to eq(owner_objid.slice(0, 8))
+    end
+
+    it 'records actor=authenticated_other when an authenticated non-owner reveals' do
+      owner_objid = "objid_#{SecureRandom.hex(6)}"
+      other_objid = "objid_#{SecureRandom.hex(6)}"
+      owner_pair  = Onetime::Receipt.spawn_pair(owner_objid, 3600, 'a secret value')
+      org         = link_receipt_to_org!(owner_pair.first)
+
+      logic = build_logic(
+        { 'identifier' => owner_pair.last.identifier, 'continue' => 'true' },
+        customer: owner_double(other_objid), # authenticated, but not the owner
+      )
+      logic.process_params
+      logic.process
+
+      expect(logic.secret_value).to eq('a secret value')
+      event = org.audit_events_page.first
+      expect(event['actor']).to eq('authenticated_other')
+      expect(event['actor_id']).to eq(other_objid.slice(0, 8))
+    end
+
+    # THE privacy pin: an anonymous reveal of a guest link (secret owner_id nil,
+    # caller objid nil) must be 'anonymous' and NEVER 'creator', even though
+    # owner?(cust) would match nil == nil without the anonymous_user? guard.
+    it 'records actor=anonymous for an anonymous reveal of a guest link (never creator)' do
+      org = link_receipt_to_org!(receipt) # default pair is a guest secret (owner_id nil)
+
+      logic = build_logic({ 'identifier' => secret.identifier, 'continue' => 'true' })
+      logic.process_params
+      logic.process
+
+      expect(logic.secret_value).to eq('a secret value')
+      event = org.audit_events_page.first
+      expect(event['kind']).to eq('revealed')
+      expect(event['actor']).to eq('anonymous')
+      expect(event['actor']).not_to eq('creator')
+      expect(event).not_to have_key('actor_id')
     end
   end
 

--- a/apps/api/v2/spec/logic/secrets/show_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/show_secret_spec.rb
@@ -59,6 +59,22 @@ RSpec.describe V2::Logic::Secrets::ShowSecret, type: :integration do
     secret.save_fields(:verification)
   end
 
+  # Persist an org on the receipt so the reveal cascade fans the 'revealed'
+  # event (with its actor attribution, #3639) out to a real, inspectable trail.
+  def link_receipt_to_org!(receipt)
+    org = Onetime::Organization.new(
+      display_name: 'Actor Attribution Org',
+      contact_email: "actor-#{SecureRandom.hex(6)}@example.com",
+    ).tap(&:save)
+    receipt.org_id = org.objid
+    receipt.save_fields(:org_id)
+    org
+  end
+
+  def owner_double(owner_objid)
+    double('Customer', custid: owner_objid, objid: owner_objid, anonymous?: false)
+  end
+
   let!(:pair)   { Onetime::Receipt.spawn_pair(nil, 3600, 'a secret value') }
   let(:receipt) { pair.first }
   let(:secret)  { pair.last }
@@ -130,6 +146,65 @@ RSpec.describe V2::Logic::Secrets::ShowSecret, type: :integration do
       expect(logic.show_secret).to be false
       expect(logic.secret_value).to be_nil
       expect(logic.success_data[:record]).not_to have_key(:secret_value)
+    end
+  end
+
+  # Actor attribution on the ShowSecret reveal path (#3639). ShowSecret reveals
+  # via reveal_secret/verify_owner, both of which now thread the actor context.
+  context 'actor attribution (#3639)' do
+    it 'records actor=creator when the authenticated owner reveals' do
+      owner_objid = "objid_#{SecureRandom.hex(6)}"
+      owner_pair  = Onetime::Receipt.spawn_pair(owner_objid, 3600, 'a secret value')
+      org         = link_receipt_to_org!(owner_pair.first)
+
+      logic = build_logic(
+        { 'identifier' => owner_pair.last.identifier, 'continue' => 'true' },
+        customer: owner_double(owner_objid),
+      )
+      logic.process_params
+      logic.process
+
+      expect(logic.secret_value).to eq('a secret value')
+      event = org.audit_events_page.first
+      expect(event['kind']).to eq('revealed')
+      expect(event['actor']).to eq('creator')
+      expect(event['actor_id']).to eq(owner_objid.slice(0, 8))
+    end
+
+    it 'records actor=authenticated_other when an authenticated non-owner reveals' do
+      owner_objid = "objid_#{SecureRandom.hex(6)}"
+      other_objid = "objid_#{SecureRandom.hex(6)}"
+      owner_pair  = Onetime::Receipt.spawn_pair(owner_objid, 3600, 'a secret value')
+      org         = link_receipt_to_org!(owner_pair.first)
+
+      logic = build_logic(
+        { 'identifier' => owner_pair.last.identifier, 'continue' => 'true' },
+        customer: owner_double(other_objid),
+      )
+      logic.process_params
+      logic.process
+
+      expect(logic.secret_value).to eq('a secret value')
+      event = org.audit_events_page.first
+      expect(event['actor']).to eq('authenticated_other')
+      expect(event['actor_id']).to eq(other_objid.slice(0, 8))
+    end
+
+    # THE privacy pin: an anonymous reveal of a guest link (owner_id nil, caller
+    # objid nil) must be 'anonymous', never 'creator'.
+    it 'records actor=anonymous for an anonymous reveal of a guest link (never creator)' do
+      org = link_receipt_to_org!(receipt) # default pair is a guest secret
+
+      logic = build_logic({ 'identifier' => secret.identifier, 'continue' => 'true' })
+      logic.process_params
+      logic.process
+
+      expect(logic.secret_value).to eq('a secret value')
+      event = org.audit_events_page.first
+      expect(event['kind']).to eq('revealed')
+      expect(event['actor']).to eq('anonymous')
+      expect(event['actor']).not_to eq('creator')
+      expect(event).not_to have_key('actor_id')
     end
   end
 

--- a/apps/api/v2/spec/logic/secrets/show_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/show_secret_spec.rb
@@ -4,6 +4,7 @@
 
 require_relative '../../../application'
 require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require_relative '../../support/actor_attribution_helpers'
 
 # Security regression coverage for the double-reveal race (ShowSecret variant).
 #
@@ -15,6 +16,8 @@ require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
 # duplicated per controller by design (v1 legacy and each v2 endpoint own their
 # own copy rather than sharing a base implementation).
 RSpec.describe V2::Logic::Secrets::ShowSecret, type: :integration do
+  include ActorAttributionSpecHelpers
+
   before(:all) do
     require 'onetime'
     Onetime.boot! :test
@@ -57,22 +60,6 @@ RSpec.describe V2::Logic::Secrets::ShowSecret, type: :integration do
   def flag_as_verification!(secret)
     secret.verification = 'true'
     secret.save_fields(:verification)
-  end
-
-  # Persist an org on the receipt so the reveal cascade fans the 'revealed'
-  # event (with its actor attribution, #3639) out to a real, inspectable trail.
-  def link_receipt_to_org!(receipt)
-    org = Onetime::Organization.new(
-      display_name: 'Actor Attribution Org',
-      contact_email: "actor-#{SecureRandom.hex(6)}@example.com",
-    ).tap(&:save)
-    receipt.org_id = org.objid
-    receipt.save_fields(:org_id)
-    org
-  end
-
-  def owner_double(owner_objid)
-    double('Customer', custid: owner_objid, objid: owner_objid, anonymous?: false)
   end
 
   let!(:pair)   { Onetime::Receipt.spawn_pair(nil, 3600, 'a secret value') }

--- a/apps/api/v2/spec/models/organization_audit_trail_spec.rb
+++ b/apps/api/v2/spec/models/organization_audit_trail_spec.rb
@@ -210,6 +210,91 @@ RSpec.describe Onetime::Organization, type: :integration do
     end
   end
 
+  # Actor attribution on lifecycle events (#3639). The revealed/burned events
+  # must carry WHO acted; the discriminator is computed at the request-scoped
+  # logic layer and threaded through the atomic consume cascade. These model
+  # specs pin the trail-facing half of that contract:
+  #   * record_org_audit_event forwards arbitrary string-keyed event_attrs;
+  #   * revealed!/burned! record the threaded actor exactly once (CAS-gated);
+  #   * a missing actor context fails safe to 'anonymous' (never 'creator');
+  #   * the full Secret -> Receipt -> Org cascade carries the actor down.
+  describe 'actor attribution on lifecycle events (#3639)' do
+    before { link_to_org!(receipt, org) }
+
+    it 'record_org_audit_event forwards extra string-keyed attrs into the event' do
+      receipt.record_org_audit_event('revealed', 'actor' => 'creator', 'actor_id' => 'abcd1234')
+
+      event = org.audit_events_page.first
+      expect(event['kind']).to eq('revealed')
+      expect(event['actor']).to eq('creator')
+      expect(event['actor_id']).to eq('abcd1234')
+    end
+
+    it 'threads the actor through revealed! into the trail' do
+      receipt.revealed!(actor_context: { 'actor' => 'creator', 'actor_id' => 'abcd1234' })
+
+      event = org.audit_events_page.first
+      expect(event['kind']).to eq('revealed')
+      expect(event['actor']).to eq('creator')
+      expect(event['actor_id']).to eq('abcd1234')
+    end
+
+    it 'threads the actor through burned! into the trail' do
+      receipt.burned!(actor_context: { 'actor' => 'authenticated_other', 'actor_id' => 'beef5678' })
+
+      event = org.audit_events_page.first
+      expect(event['kind']).to eq('burned')
+      expect(event['actor']).to eq('authenticated_other')
+      expect(event['actor_id']).to eq('beef5678')
+    end
+
+    it 'defaults a missing actor context to anonymous on revealed! (never misattributed)' do
+      receipt.revealed! # v1 / account-verification path: no request context
+
+      event = org.audit_events_page.first
+      expect(event['actor']).to eq('anonymous')
+      expect(event).not_to have_key('actor_id')
+    end
+
+    it 'defaults a blank actor to anonymous on burned! (never misattributed)' do
+      receipt.burned!(actor_context: { 'actor' => '' })
+
+      event = org.audit_events_page.first
+      expect(event['actor']).to eq('anonymous')
+    end
+
+    it 'records the threaded actor exactly once; a race-loser records nothing' do
+      loser = Onetime::Receipt.load(receipt.identifier)
+
+      expect(receipt.revealed!(actor_context: { 'actor' => 'creator', 'actor_id' => 'abcd1234' })).to be true
+      # The loser lost the CAS: it neither transitions nor appends an event.
+      expect(loser.revealed!(actor_context: { 'actor' => 'authenticated_other' })).to be_falsey
+
+      events = org.audit_events_page
+      expect(events.map { |e| e['kind'] }).to eq(['revealed'])
+      expect(events.first['actor']).to eq('creator')
+    end
+
+    it 'carries the actor down the full Secret -> Receipt -> Org reveal cascade' do
+      expect(secret.reveal!(actor_context: { 'actor' => 'authenticated_other', 'actor_id' => 'beef5678' }))
+        .to eq('a secret value')
+
+      event = org.audit_events_page.first
+      expect(event['kind']).to eq('revealed')
+      expect(event['actor']).to eq('authenticated_other')
+      expect(event['actor_id']).to eq('beef5678')
+    end
+
+    it 'carries the actor down the full Secret -> Receipt -> Org burn cascade' do
+      expect(secret.burned!(actor_context: { 'actor' => 'creator', 'actor_id' => 'abcd1234' })).to be true
+
+      event = org.audit_events_page.first
+      expect(event['kind']).to eq('burned')
+      expect(event['actor']).to eq('creator')
+      expect(event['actor_id']).to eq('abcd1234')
+    end
+  end
+
   describe 'isolation' do
     let(:other_org) do
       described_class.new(

--- a/apps/api/v2/spec/models/organization_audit_trail_spec.rb
+++ b/apps/api/v2/spec/models/organization_audit_trail_spec.rb
@@ -263,6 +263,41 @@ RSpec.describe Onetime::Organization, type: :integration do
       expect(event['actor']).to eq('anonymous')
     end
 
+    # Privacy no-regression guards for lifecycle_audit_attrs normalization.
+    # These pin the three ways an actor context is reduced before it is stored,
+    # so a future change can't silently start leaking identity into the trail.
+    it 'never attaches an actor_id to an anonymous event, even if one is supplied' do
+      # An anonymous actor has no identity to record; an id riding along on the
+      # context must be dropped, not stored against 'anonymous'.
+      receipt.revealed!(actor_context: { 'actor' => 'anonymous', 'actor_id' => 'abcd1234' })
+
+      event = org.audit_events_page.first
+      expect(event['actor']).to eq('anonymous')
+      expect(event).not_to have_key('actor_id')
+    end
+
+    it 'fails an unrecognized actor safe to anonymous and drops its id' do
+      # An actor label outside the known set is never recorded verbatim: it
+      # fails safe to anonymous (never misattributed to the creator) and any
+      # id it carried is dropped with it.
+      receipt.revealed!(actor_context: { 'actor' => 'root', 'actor_id' => 'abcd1234' })
+
+      event = org.audit_events_page.first
+      expect(event['actor']).to eq('anonymous')
+      expect(event).not_to have_key('actor_id')
+    end
+
+    it 'clamps an over-long actor_id to the 8-char shortid policy' do
+      # Defense in depth: even if a caller supplies an unreduced objid/custid,
+      # the trail stores only the 8-char shortid -- a full identifier (which
+      # could be a capability token) can never leak in.
+      receipt.burned!(actor_context: { 'actor' => 'creator', 'actor_id' => 'abcd1234efgh5678' })
+
+      event = org.audit_events_page.first
+      expect(event['actor']).to eq('creator')
+      expect(event['actor_id']).to eq('abcd1234')
+    end
+
     it 'records the threaded actor exactly once; a race-loser records nothing' do
       loser = Onetime::Receipt.load(receipt.identifier)
 

--- a/apps/api/v2/spec/support/actor_attribution_helpers.rb
+++ b/apps/api/v2/spec/support/actor_attribution_helpers.rb
@@ -1,0 +1,39 @@
+# apps/api/v2/spec/support/actor_attribution_helpers.rb
+#
+# frozen_string_literal: true
+
+# Shared helpers for the secret lifecycle actor-attribution specs (#3639).
+#
+# `link_receipt_to_org!` and `owner_double` were copy-pasted identically across
+# the burn/reveal/show logic specs; extracted here so sibling actor-attribution
+# specs (#3640) reuse them and they cannot silently diverge if spawn_pair's
+# field names ever change (PR #3696 review).
+#
+# `build_logic` is intentionally NOT shared: its signature differs per logic
+# class (BurnSecret takes a positional customer to avoid swallowing bare-hash
+# call sites; Reveal/ShowSecret take a keyword `customer:`).
+#
+# Methods run in the example instance, so RSpec's `double` and the Onetime
+# models resolve exactly as they did inline. Include per example group:
+#
+#   RSpec.describe ... do
+#     include ActorAttributionSpecHelpers
+module ActorAttributionSpecHelpers
+  # Persist an org on the receipt so the reveal/burn cascade fans its lifecycle
+  # event (with actor attribution) out to a real, inspectable trail. The cascade
+  # reloads the receipt from Redis, so org_id must be saved, not just set.
+  def link_receipt_to_org!(receipt)
+    org = Onetime::Organization.new(
+      display_name: 'Actor Attribution Org',
+      contact_email: "actor-#{SecureRandom.hex(6)}@example.com",
+    ).tap(&:save)
+    receipt.org_id = org.objid
+    receipt.save_fields(:org_id)
+    org
+  end
+
+  # An authenticated caller who owns `owner_objid`'s secret.
+  def owner_double(owner_objid)
+    double('Customer', custid: owner_objid, objid: owner_objid, anonymous?: false)
+  end
+end

--- a/docs/architecture/decision-records/adr-021-audit-log-terminology-and-stream-scoping.md
+++ b/docs/architecture/decision-records/adr-021-audit-log-terminology-and-stream-scoping.md
@@ -147,3 +147,5 @@ because it concerns the #2799 stream; ADR-022 governs the #3640 stream.
 - SIEM data normalization (SearchInform); NIST SP 800-92
 - Vendor patterns — 1Password Events API, Doppler security fact sheet
 - ADR-022 — Secret Activity network-capture privacy stance (#3640)
+- ADR-023 — Audit actor attribution accuracy (refines Decision 4: what to record
+  when the actor is unresolved)

--- a/docs/architecture/decision-records/adr-022-secret-activity-network-capture-privacy.md
+++ b/docs/architecture/decision-records/adr-022-secret-activity-network-capture-privacy.md
@@ -153,3 +153,6 @@ granularity stands and is documented inline at the hash site
   `RequestContext.mask_user_agent` delegate instead of copying Otto's private
   version/build-stripping regexes; a cross-implementation spec guards the drift
   until it lands.
+- ADR-023 (audit actor attribution accuracy) — never fabricate an actor; record
+  an explicit `unknown` when attribution is indeterminate. Same shortids-only,
+  minimized posture applied to the actor dimension.

--- a/docs/architecture/decision-records/adr-023-audit-actor-attribution-accuracy.md
+++ b/docs/architecture/decision-records/adr-023-audit-actor-attribution-accuracy.md
@@ -1,0 +1,123 @@
+---
+id: "023"
+status: proposed
+title: "ADR-023: Audit Actor Attribution Accuracy — Never Fabricate an Actor"
+---
+
+## Status
+
+Proposed
+
+## Date
+
+2026-07-09
+
+<!--
+Owner:  ops@solutious.com
+Affects: #2799 (Security Events actor), #3639 (Secret Activity lifecycle actor)
+Refines: ADR-021 Decision 4 (actor / subject / org model)
+-->
+
+## Context
+
+Adding actor identity to Secret Activity lifecycle events (#3639) surfaced a
+small but revealing question. The actor discriminator — `creator` /
+`authenticated_other` / `anonymous` — is computed from the acting customer and
+the secret being consumed. On one defensive branch the secret is absent
+(`target_secret` nil): the caller is authenticated, but we cannot establish
+their relationship to a secret we don't have. What actor do we record?
+
+The change was first framed as a binary — default the nil case to
+`authenticated_other` (its current behavior, since `nil&.owner? → false`) or to
+`anonymous`. Researching how mature audit systems and data-protection law treat
+an *unresolved* actor showed that **both options are wrong for the same reason**,
+and that the lesson generalizes well beyond this one branch.
+
+## Decision
+
+**An audit event must never record a fabricated or guessed actor. Where the
+actor — or its relationship to the subject — cannot be established, record an
+explicit `unknown`; never a value that asserts a fact we cannot support.**
+
+Four rules follow:
+
+1. **No convenient default.** `authenticated_other` asserts "authenticated **and
+   not the owner**" — the "not owner" half is unsubstantiated when there is no
+   secret. `anonymous` asserts "**unauthenticated**" — outright false for an
+   authenticated caller, and strictly worse, because it discards a fact we *do*
+   know to assert one that is false. Neither is acceptable.
+2. **Record what is known; mark the rest unknown.** Emit `actor: 'unknown'`
+   while keeping the authenticated principal's shortid (`actor_id`) when we have
+   one. The truthful statement is "an authenticated principal `<id>` acted;
+   ownership indeterminate" — accurate and minimal.
+3. **Separate "who acted" from "their relation to the subject."** Collapsing
+   both into a single enum is what forced the false choice; `unknown` keeps the
+   two dimensions honest.
+4. **Alert, don't raise.** The indeterminate branch signals a programmer error,
+   so it logs (`OT.le`) — but it never raises. Attribution is best-effort
+   observability and must not break the consume path (#3633; CAS-gated reveal,
+   ADR-019). Accuracy is fixed by the *value* recorded, not by changing control
+   flow.
+
+This governs **every** actor-attributed stream: Security Events (#2799) and the
+Secret Activity lifecycle actor (#3639). It refines ADR-021 Decision 4, which
+models each event as actor / subject / org but did not say what to record when
+the actor is unresolved.
+
+## Rationale
+
+- **Accuracy is a legal obligation, not a nicety.** An actor attribution is
+  personal data about an identifiable person, so GDPR Art. 5(1)(d) ("accurate
+  and, where necessary, kept up to date") applies directly. A *false*
+  attribution is a compliance defect, not a harmless default — the decisive
+  argument against both `authenticated_other` and `anonymous` in the unresolved
+  case. `unknown` is the accurate representation.
+- **Data minimization aligns.** `unknown` + shortid stores the least identifying
+  thing that still serves the purpose (Art. 5(1)(c); pseudonymization, Art. 4(5)
+  / Recital 26) — consistent with the trail's existing shortids-only, masked-IP
+  posture (ADR-022).
+- **Never misattribute to the creator.** `unknown` satisfies the trail's
+  standing "never assume the creator" guard (the anonymous-guest nil-objid
+  precedent) without the collateral inaccuracy of `anonymous`.
+- **The reference implementations agree.** Microsoft's Entra ID / Office 365 /
+  Exchange audit logs record an explicit **`Unknown`** principal when the actor
+  cannot be resolved, rather than guessing. Clerk **omits** the `act` (actor)
+  claim entirely unless a real impersonator exists — presence recorded honestly,
+  never defaulted. Typed actor schemas (`user` / `service` / `system`) treat
+  "unresolved" as its own type, never a mislabeled user.
+
+## Consequences
+
+- Add `unknown` to the recognized lifecycle actors (`LIFECYCLE_ACTORS`) and have
+  `lifecycle_actor_context` return `{ 'actor' => 'unknown', 'actor_id' => … }`
+  on the nil-`target_secret` branch instead of `authenticated_other`
+  (`apps/api/v2/logic/secrets/actor_attribution.rb`,
+  `receipt/features/deprecated_fields.rb`). Today that branch logs and records
+  `authenticated_other`; this ADR proposes `unknown`. It is genuinely a
+  can't-happen path (all call sites pass a loaded secret), so this is
+  correctness-of-principle on a defensive branch, not a live bug.
+- Any future actor-attributed surface (Security Events #2799 included) adopts the
+  same `unknown` sentinel + alert rather than inventing a stream-local default.
+- Consumers / UI that render `actor` must handle `unknown` explicitly (show
+  "unknown", not a blank or a misleading label).
+
+## References
+
+- GDPR — Art. 5(1)(d) accuracy; Art. 5(1)(c) data minimization; Art. 4(5) /
+  Recital 26 pseudonymization; Art. 5(2) accountability; Art. 6(1)(f) legitimate
+  interest (lawful basis for security logging).
+- Microsoft — ["Unknown actors in audit reports" (Entra ID)](https://learn.microsoft.com/en-us/troubleshoot/entra/entra-id/governance/unknown-actors-in-audit-reports);
+  [Office 365 "Unknown" principal in the audit log](https://michev.info/blog/post/2151/login-events-in-the-office-365-audit-log-for-the-unknown-principal);
+  ["ActorInfoString … audit log accuracy" (Exchange Online)](https://techcommunity.microsoft.com/blog/microsoft-security-blog/introducing-actorinfostring-a-new-era-of-audit-log-accuracy-in-exchange-online/4408093).
+- Clerk — [session-token `act` (actor) claim](https://clerk.com/docs/guides/sessions/session-tokens)
+  (present only under impersonation); [user impersonation](https://clerk.com/docs/guides/users/impersonation)
+  (impersonator and subject kept as distinct fields).
+- General guidance — record what is known rather than fabricate
+  ([LoginRadius](https://www.loginradius.com/blog/engineering/auditing-and-logging-ai-agent-activity),
+  [Prefactor](https://prefactor.tech/blog/audit-trails-in-ci-cd-best-practices-for-ai-agents));
+  typed actor schemas ([Sonar](https://www.sonarsource.com/resources/library/audit-logging/),
+  [Infisical audit-log guide](https://medium.com/@tony.infisical/guide-to-building-audit-logs-for-application-software-b0083bb58604)).
+- Internal — ADR-021 (actor / subject / org model; this refines Decision 4);
+  ADR-022 (Secret Activity network-capture privacy; same shortids-only,
+  minimized posture); ADR-019 (at-most-once reveal; CAS-gated, best-effort audit
+  path); #3639 (Secret Activity actor identity); #2799 (Security Events).

--- a/lib/onetime/models/receipt/features/access_timeline.rb
+++ b/lib/onetime/models/receipt/features/access_timeline.rb
@@ -113,11 +113,15 @@ module Onetime::Receipt::Features
         organization.record_audit_event(
           kind,
           at: at,
+          **event_attrs,
           # Shortids only: full identifiers are capability tokens (the
           # secret identifier IS the link) and must not leak into the trail.
+          # Placed AFTER the splat so these canonical fields always win over a
+          # caller-supplied attr sharing the same key -- a composed caller
+          # (#3639 actor, #3640 network context) can never override the
+          # receipt/secret identity of the event it is annotating.
           'receipt' => shortid,
           'secret' => secret_shortid.to_s,
-          **event_attrs,
         )
       rescue StandardError => ex
         OT.le "[audit-trail] #{ex.class}: #{ex.message} (kind=#{kind}, receipt=#{shortid})"

--- a/lib/onetime/models/receipt/features/access_timeline.rb
+++ b/lib/onetime/models/receipt/features/access_timeline.rb
@@ -103,8 +103,10 @@ module Onetime::Receipt::Features
       # @param at [Numeric] event time as epoch seconds; defaults to now.
       # @param organization [Onetime::Organization, nil] pass when the
       #   caller already holds the org to skip the extra load.
+      # @param event_attrs [Hash] additional string-keyed context merged into
+      #   the recorded event (e.g. the lifecycle actor discriminator, #3639).
       # @return [Hash, nil] the recorded event, or nil when skipped.
-      def record_org_audit_event(kind, at: Familia.now, organization: nil)
+      def record_org_audit_event(kind, at: Familia.now, organization: nil, **event_attrs)
         organization ||= Onetime::Organization.load(org_id) unless org_id.to_s.empty?
         return if organization.nil?
 
@@ -115,6 +117,7 @@ module Onetime::Receipt::Features
           # secret identifier IS the link) and must not leak into the trail.
           'receipt' => shortid,
           'secret' => secret_shortid.to_s,
+          **event_attrs,
         )
       rescue StandardError => ex
         OT.le "[audit-trail] #{ex.class}: #{ex.message} (kind=#{kind}, receipt=#{shortid})"

--- a/lib/onetime/models/receipt/features/deprecated_fields.rb
+++ b/lib/onetime/models/receipt/features/deprecated_fields.rb
@@ -140,9 +140,13 @@ module Onetime::Receipt::Features
       # - Sets `revealed` timestamp (legacy `received` kept for backward compat in safe_dump)
       # - Clears secret_identifier
       #
+      # @param actor_context [Hash, nil] request-scoped audit context (e.g. the
+      #   actor discriminator) threaded down from the reveal cascade (#3639).
+      #   Forwarded to the org audit trail; nil is treated as an unknown/anonymous
+      #   actor (never misattributed to the creator). See #lifecycle_audit_attrs.
       # @return [Boolean, nil] true if THIS caller performed the transition;
       #   a falsy value if the in-memory guard or the atomic claim lost.
-      def revealed!
+      def revealed!(actor_context: nil)
         # In-memory fast-path: short-circuit an already-terminal instance before
         # touching Redis. The authoritative, resurrection-proof guard is the CAS.
         return unless state?(:new) || state?(:previewed)
@@ -164,7 +168,9 @@ module Onetime::Receipt::Features
             timestamp: revealed,
           }
 
-        record_org_audit_event('revealed')
+        # The audit event fires only inside the won-CAS branch, so the actor is
+        # recorded exactly once; a race loser returned above and records nothing.
+        record_org_audit_event('revealed', **lifecycle_audit_attrs(actor_context))
         true
       end
 
@@ -200,7 +206,10 @@ module Onetime::Receipt::Features
         true
       end
 
-      def burned!
+      # @param actor_context [Hash, nil] request-scoped audit context threaded
+      #   down from the burn cascade (#3639); see #revealed! and
+      #   #lifecycle_audit_attrs. nil is treated as an unknown/anonymous actor.
+      def burned!(actor_context: nil)
         # See guard comment on `revealed!` (was `received!`)
         return unless state?(:new) || state?(:previewed)
         return unless compare_and_set_state!(:burned, [:new, :previewed])
@@ -221,7 +230,8 @@ module Onetime::Receipt::Features
             timestamp: burned,
           }
 
-        record_org_audit_event('burned')
+        # Actor recorded exactly once inside the won-CAS branch (see revealed!).
+        record_org_audit_event('burned', **lifecycle_audit_attrs(actor_context))
         true
       end
 
@@ -269,6 +279,28 @@ module Onetime::Receipt::Features
 
       def truncated?
         truncate.to_s == 'true'
+      end
+
+      private
+
+      # Normalize the request-scoped actor context threaded into a lifecycle
+      # transition (revealed!/burned!, #3639) into string-keyed audit attributes.
+      #
+      # The org audit trail records the terminal lifecycle events with WHO acted
+      # ('actor' => 'creator' | 'authenticated_other' | 'anonymous'), computed at
+      # the logic layer where the request's customer is in scope. This model
+      # method never sees request context, so it fails safe: a missing/blank
+      # actor context is recorded as 'anonymous' — the same "never misattribute an
+      # unknown actor to the creator" precedent the fetch-side telemetry follows.
+      # Callers without request context (v1 paths, account verification, direct
+      # receipt.revealed! test calls) therefore still emit a well-formed actor.
+      #
+      # @param actor_context [Hash, nil] string- or symbol-keyed audit attrs.
+      # @return [Hash] string-keyed attrs with a guaranteed non-blank 'actor'.
+      def lifecycle_audit_attrs(actor_context)
+        attrs          = actor_context.is_a?(Hash) ? actor_context.transform_keys(&:to_s) : {}
+        attrs['actor'] = 'anonymous' if attrs['actor'].to_s.empty?
+        attrs
       end
 
       # See Onetime::Models::Features::StateCas for +compare_and_set_state!+,

--- a/lib/onetime/models/receipt/features/deprecated_fields.rb
+++ b/lib/onetime/models/receipt/features/deprecated_fields.rb
@@ -281,6 +281,19 @@ module Onetime::Receipt::Features
         truncate.to_s == 'true'
       end
 
+      # Recognized actor discriminators for lifecycle audit events (#3639). An
+      # empty or unexpected value fails safe to 'anonymous' rather than being
+      # recorded verbatim: the trail must never carry an actor label the rest of
+      # the system doesn't understand, and an unknown actor must never be
+      # misattributed to the creator. (Defined above `private` -- `private` does
+      # not scope constants; see RuboCop Lint/UselessConstantScoping.)
+      LIFECYCLE_ACTORS = %w[creator authenticated_other anonymous].freeze
+
+      # Max length of a stored actor_id, matching Receipt#shortid
+      # (objid.slice(0, 8)). Clamping is defense in depth so a full objid/custid
+      # can never leak into the trail even if a caller supplies an unreduced value.
+      ACTOR_ID_MAX_LENGTH = 8
+
       private
 
       # Normalize the request-scoped actor context threaded into a lifecycle
@@ -295,18 +308,6 @@ module Onetime::Receipt::Features
       # Callers without request context (v1 paths, account verification, direct
       # receipt.revealed! test calls) therefore still emit a well-formed actor.
       #
-      # Recognized actor discriminators. An empty or unexpected value fails
-      # safe to 'anonymous' rather than being recorded verbatim: the trail must
-      # never carry an actor label the rest of the system doesn't understand,
-      # and an unknown actor must never be misattributed to the creator.
-      LIFECYCLE_ACTORS = %w[creator authenticated_other anonymous].freeze
-
-      # Max length of a stored actor_id, matching Receipt#shortid
-      # (objid.slice(0, 8)). Clamping here is defense in depth so a full
-      # objid/custid can never leak into the trail even if a caller supplies an
-      # unreduced value.
-      ACTOR_ID_MAX_LENGTH = 8
-
       # @param actor_context [Hash, nil] string- or symbol-keyed audit attrs.
       # @return [Hash] string-keyed attrs with a guaranteed known 'actor' and,
       #   for authenticated actors only, an 8-char 'actor_id'.

--- a/lib/onetime/models/receipt/features/deprecated_fields.rb
+++ b/lib/onetime/models/receipt/features/deprecated_fields.rb
@@ -295,11 +295,44 @@ module Onetime::Receipt::Features
       # Callers without request context (v1 paths, account verification, direct
       # receipt.revealed! test calls) therefore still emit a well-formed actor.
       #
+      # Recognized actor discriminators. An empty or unexpected value fails
+      # safe to 'anonymous' rather than being recorded verbatim: the trail must
+      # never carry an actor label the rest of the system doesn't understand,
+      # and an unknown actor must never be misattributed to the creator.
+      LIFECYCLE_ACTORS = %w[creator authenticated_other anonymous].freeze
+
+      # Max length of a stored actor_id, matching Receipt#shortid
+      # (objid.slice(0, 8)). Clamping here is defense in depth so a full
+      # objid/custid can never leak into the trail even if a caller supplies an
+      # unreduced value.
+      ACTOR_ID_MAX_LENGTH = 8
+
       # @param actor_context [Hash, nil] string- or symbol-keyed audit attrs.
-      # @return [Hash] string-keyed attrs with a guaranteed non-blank 'actor'.
+      # @return [Hash] string-keyed attrs with a guaranteed known 'actor' and,
+      #   for authenticated actors only, an 8-char 'actor_id'.
       def lifecycle_audit_attrs(actor_context)
-        attrs          = actor_context.is_a?(Hash) ? actor_context.transform_keys(&:to_s) : {}
-        attrs['actor'] = 'anonymous' if attrs['actor'].to_s.empty?
+        attrs = actor_context.is_a?(Hash) ? actor_context.transform_keys(&:to_s) : {}
+
+        # Fail safe: an empty or unrecognized actor becomes 'anonymous'.
+        actor          = attrs['actor'].to_s
+        actor          = 'anonymous' unless LIFECYCLE_ACTORS.include?(actor)
+        attrs['actor'] = actor
+
+        if actor == 'anonymous'
+          # An anonymous event has no identity: never attach an id to it, even
+          # if a caller supplied one.
+          attrs.delete('actor_id')
+        elsif attrs.key?('actor_id')
+          # Authenticated actor: keep the id but clamp it to the shortid policy;
+          # drop it entirely if blank so we never store an empty token.
+          id = attrs['actor_id'].to_s
+          if id.empty?
+            attrs.delete('actor_id')
+          else
+            attrs['actor_id'] = id.slice(0, ACTOR_ID_MAX_LENGTH)
+          end
+        end
+
         attrs
       end
 

--- a/lib/onetime/models/secret/features/secret_state_management.rb
+++ b/lib/onetime/models/secret/features/secret_state_management.rb
@@ -62,12 +62,17 @@ module Onetime::Secret::Features
       # gates its own output. Read controllers that must hand back the plaintext
       # should prefer {#reveal!}, which cannot be decoupled from the claim.
       #
+      # @param actor_context [Hash, nil] request-scoped audit context (the actor
+      #   discriminator) forwarded to the receipt cascade and, from there, the
+      #   org audit trail (#3639). Defaults to nil so callers without request
+      #   context (v1, account verification) keep working; a nil actor is
+      #   recorded as anonymous/unknown, never misattributed to the creator.
       # @return [Boolean] true if THIS caller performed the reveal, false if a
       #   concurrent caller won the race or the secret was already terminal.
-      def revealed!
+      def revealed!(actor_context: nil)
         return false unless win_reveal_claim!
 
-        consume_after_reveal!
+        consume_after_reveal!(actor_context: actor_context)
         true
       end
 
@@ -85,20 +90,24 @@ module Onetime::Secret::Features
       #
       # @param passphrase_input [String, nil] passphrase supplied by the caller,
       #   forwarded to decryption.
+      # @param actor_context [Hash, nil] request-scoped audit context forwarded
+      #   to the receipt cascade / org audit trail (#3639); see {#revealed!}.
       # @return [String, nil] the decrypted plaintext for the single winning
       #   caller; nil for a loser or an already-terminal secret.
-      def reveal!(passphrase_input: nil)
+      def reveal!(passphrase_input: nil, actor_context: nil)
         return unless win_reveal_claim!
 
         # Decrypt from the still-in-memory ciphertext BEFORE consume clears it.
         plaintext = decrypted_secret_value(passphrase_input: passphrase_input)
-        consume_after_reveal!
+        consume_after_reveal!(actor_context: actor_context)
         plaintext
       end
 
+      # @param actor_context [Hash, nil] request-scoped audit context forwarded
+      #   to the receipt cascade / org audit trail (#3639); see {#revealed!}.
       # @return [Boolean] true if THIS caller performed the burn, false if a
       #   concurrent caller won the race or the secret was already terminal.
-      def burned!
+      def burned!(actor_context: nil)
         # A guard to allow only a fresh, new secret to be burned. Also ensures that
         # we don't support going from :burned back to something else.
         return false unless state?(:new) || state?(:previewed)
@@ -109,7 +118,7 @@ module Onetime::Secret::Features
         return false unless compare_and_set_state!(:burned, [:new, :previewed])
 
         md               = load_receipt
-        md.burned! unless md.nil?
+        md.burned!(actor_context: actor_context) unless md.nil?
         @passphrase_temp = nil
         destroy!
         true
@@ -165,10 +174,12 @@ module Onetime::Secret::Features
       # payload is not recoverable from this instance; other fields (state,
       # lifespan, ...) remain for safe_dump / success_data.
       #
+      # @param actor_context [Hash, nil] request-scoped audit context forwarded
+      #   to the receipt's revealed! cascade (#3639); see {#revealed!}.
       # @return [void]
-      def consume_after_reveal!
+      def consume_after_reveal!(actor_context: nil)
         md = load_receipt
-        md.revealed! unless md.nil?
+        md.revealed!(actor_context: actor_context) unless md.nil?
 
         @state           = 'revealed'
         @ciphertext      = nil


### PR DESCRIPTION
## Summary

[#3639](https://github.com/onetimesecret/onetimesecret/issues/3639)

Threads request-scoped **actor identity** onto the `revealed` / `burned` audit events. Fetch events already distinguished creator self-access from third-party access; lifecycle events carried no actor at all. This closes that gap — "who revealed it" is the first question an auditor asks.

- New `V2::Logic::Secrets::ActorAttribution` mixin computes the discriminator at the logic layer (where `cust` is in scope), mirroring the exact ownership logic + `anonymous_user?` guard already used by `AccessTelemetry`.
- Actor context is threaded through `Secret#reveal!` / `#revealed!` / `#burned!` → the receipt cascade → `Receipt#record_org_audit_event`, which gains the additive `**event_attrs` splat (the shared seam with #3640).
- Events now carry `actor` (`creator` / `authenticated_other` / `anonymous`) and, for authenticated actors only, `actor_id` — an 8-char **objid** shortid (never an email or full custid; anonymous carries no id), honoring the trail's "shortids only" rule.
- Anonymous-guest nil-objid misattribution is guarded twice: an early return in the logic mixin before `owner?`, plus a model-layer nil→`anonymous` coercion covering v1 and direct-cascade paths.

## Related Issues

Closes #3639
Part of the event-side capture umbrella #3633 (shipped in PR #3635).
Sibling capture PR: #3640 (network context) — shares the `record_org_audit_event(**event_attrs)` seam; the two branches compose (only a one-line `@param` doc comment differs).

## Test Plan

`bundle exec rspec` under Ruby 3.4.9, test datastore on port 2121:

- `organization_audit_trail_spec.rb` → 27 examples (+8), 0 failures — end-to-end actor fidelity through a real org trail.
- `reveal_secret_spec.rb` +3, `burn_secret_spec.rb` +3, `show_secret_spec.rb` +3.
- New assertions: creator / authenticated_other / anonymous for both reveal and burn; the explicit "anonymous guest reveal/burn is `anonymous` and NEVER `creator`" pin; exactly-once emission with actor present; CAS race-loser records nothing; nil/blank actor → anonymous.
- Broader regression: v2 models + secrets logic (241 examples) and v1/account paths (48 examples) green. Changed source files RuboCop-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S57TVKW6YZVvyiSEj8dsY

---
_Generated by [Claude Code](https://claude.ai/code/session_011S57TVKW6YZVvyiSEj8dsY)_