### PR TITLE
Secret Activity: capture request context (IP / user agent) with an explicit privacy stance

### DIFF
--- a/apps/api/v2/logic/secrets/access_telemetry.rb
+++ b/apps/api/v2/logic/secrets/access_telemetry.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require 'onetime/security/request_context'
+
 module V2::Logic
   module Secrets
     # Records secret accesses on the receipt's access timeline
@@ -38,10 +40,37 @@ module V2::Logic
         end
 
         receipt = secret.load_receipt
-        receipt&.record_access_event(kind)
+        receipt&.record_access_event(kind, context: request_network_context)
       rescue StandardError => ex
         OT.le "[access-telemetry] #{ex.class}: #{ex.message} (kind=#{kind})"
         nil
+      end
+
+      # Privacy-safe network context (#3640) for the fetch event, threaded down
+      # to the model layer's org-trail fan-out (which has no request object of
+      # its own). Reads the IP / User-Agent the auth strategy resolved into the
+      # StrategyResult metadata -- in production these are ALREADY edge-masked
+      # by Otto's IPPrivacyMiddleware -- and reduces them again, unconditionally,
+      # to the stored representation: partial IP, partial UA, and a keyed
+      # correlation hash. Raw IP / full UA are never stored; see
+      # Onetime::Security::RequestContext and ADR-022 for the full stance.
+      #
+      # @return [Hash{String=>String}] string-keyed network attrs, forwarded via
+      #   record_access_event(context:) -> record_org_audit_event(**event_attrs).
+      #   Empty when no request context is available (e.g. in unit tests that
+      #   supply no metadata), in which case the event records without them.
+      def request_network_context
+        metadata = strategy_result&.metadata || {}
+
+        Onetime::Security::RequestContext.capture(
+          ip: metadata[:ip],
+          user_agent: metadata[:user_agent],
+        )
+      rescue StandardError => ex
+        # Capture must never break the (best-effort) telemetry path; on any
+        # failure fall back to recording the event with no network context.
+        OT.le "[access-telemetry] network-context capture failed: #{ex.class}: #{ex.message}"
+        {}
       end
     end
   end

--- a/apps/api/v2/spec/logic/secrets/show_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/show_secret_spec.rb
@@ -4,6 +4,7 @@
 
 require_relative '../../../application'
 require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'onetime/security/request_context'
 
 # Security regression coverage for the double-reveal race (ShowSecret variant).
 #
@@ -32,15 +33,22 @@ RSpec.describe V2::Logic::Secrets::ShowSecret, type: :integration do
   # customer: overrides the default anonymous caller for the verification
   # branches that depend on who is logged in. Pass params as a braced hash --
   # the customer: kwarg would otherwise swallow a bare trailing hash.
-  def build_logic(params, customer: nil)
+  # ip:/user_agent: model the request context the auth strategy resolves into
+  # StrategyResult metadata (already edge-masked by Otto in production); nil by
+  # default so pre-existing examples run the no-network-context path unchanged.
+  def build_logic(params, customer: nil, ip: nil, user_agent: nil)
     customer ||= double('Customer', custid: 'anon', anonymous?: true, objid: nil)
     org      = double('Organization', objid: "org_#{SecureRandom.hex(4)}")
     allow(org).to receive(:can?).and_return(true)
 
+    metadata = { organization: org }
+    metadata[:ip] = ip if ip
+    metadata[:user_agent] = user_agent if user_agent
+
     strategy_result = double('StrategyResult',
       session: mock_session,
       user: customer,
-      metadata: { organization: org },
+      metadata: metadata,
       auth_method: 'basicauth')
 
     described_class.new(strategy_result, params)
@@ -110,6 +118,61 @@ RSpec.describe V2::Logic::Secrets::ShowSecret, type: :integration do
       timeline = Onetime::Receipt.load(owner_pair.first.identifier)
       expect(timeline.access_events.last).to start_with('previewed:')
       expect(Onetime::Secret.load(owner_pair.last.identifier).state).to eq('new')
+    end
+  end
+
+  # End-to-end network context capture (#3640, ADR-022): a metadata fetch
+  # (GET without continue) reads the request IP/UA from StrategyResult metadata,
+  # reduces them to the privacy-safe representation, and threads them through
+  # the receipt to the org trail. A winning reveal is deliberately NOT covered
+  # here: that access is captured as the `revealed` lifecycle event, not as a
+  # `secret_get` (see ShowSecret#process), so it never reaches this path.
+  context 'network context capture (metadata fetch)' do
+    let(:trail_org) do
+      Onetime::Organization.new(
+        display_name: 'Show Trail Org',
+        contact_email: "show-trail-#{SecureRandom.hex(6)}@example.com",
+      ).tap(&:save)
+    end
+
+    let!(:pair) { Onetime::Receipt.spawn_pair(nil, 3600, 'a secret value') }
+
+    before do
+      receipt.org_id = trail_org.objid
+      receipt.save_fields(:org_id)
+    end
+
+    it 'records the masked partial IP, partial UA, and keyed hash on the fetch' do
+      logic = build_logic(
+        { 'identifier' => secret.identifier },
+        ip: '203.0.113.42',
+        user_agent: 'Mozilla/5.0 (X11; Linux x86_64) Chrome/119.0.0.0 Safari/537.36',
+      )
+      logic.process_params
+      logic.process
+
+      event = Onetime::Organization.load(trail_org.objid).audit_events_page.first
+      expect(event['kind']).to eq('secret_get')
+      expect(event['net_ip_partial']).to eq('203.0.113.0')
+      expect(event['net_ip_hash']).to match(/\A[0-9a-f]{64}\z/)
+      expect(event['net_ua_partial']).to include('Chrome')
+      expect(event['net_ua_partial']).not_to include('119.0.0.0')
+    end
+
+    # THE NO-REGRESSION GUARD at the endpoint boundary.
+    it 'never persists the raw IP or full UA sent by the caller' do
+      raw_ip  = '203.0.113.42'
+      full_ua = 'Mozilla/5.0 (X11; Linux x86_64) Chrome/119.0.0.0 Safari/537.36'
+
+      logic = build_logic({ 'identifier' => secret.identifier }, ip: raw_ip, user_agent: full_ua)
+      logic.process_params
+      logic.process
+
+      trail = Onetime::Organization.load(trail_org.objid)
+      raw   = trail.audit_events.membersraw.join
+      expect(raw).not_to include(raw_ip)
+      expect(raw).not_to include(full_ua)
+      expect(raw).not_to include('119.0.0.0')
     end
   end
 

--- a/apps/api/v2/spec/logic/secrets/show_secret_status_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/show_secret_status_spec.rb
@@ -4,6 +4,7 @@
 
 require_relative '../../../application'
 require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'onetime/security/request_context'
 
 # Safe-method coverage for the status endpoint (#3633).
 #
@@ -25,15 +26,23 @@ RSpec.describe V2::Logic::Secrets::ShowSecretStatus, type: :integration do
     session
   end
 
-  def build_logic(params)
+  # ip:/user_agent: model the request context the auth strategy resolves into
+  # StrategyResult metadata (already edge-masked by Otto in production). Left
+  # nil by default so pre-existing examples exercise the no-network-context
+  # path unchanged.
+  def build_logic(params, ip: nil, user_agent: nil)
     customer = double('Customer', custid: 'anon', anonymous?: true, objid: nil)
     org      = double('Organization', objid: "org_#{SecureRandom.hex(4)}")
     allow(org).to receive(:can?).and_return(true)
 
+    metadata = { organization: org }
+    metadata[:ip] = ip if ip
+    metadata[:user_agent] = user_agent if user_agent
+
     strategy_result = double('StrategyResult',
       session: mock_session,
       user: customer,
-      metadata: { organization: org },
+      metadata: metadata,
       auth_method: 'basicauth')
 
     described_class.new(strategy_result, params)
@@ -144,6 +153,69 @@ RSpec.describe V2::Logic::Secrets::ShowSecretStatus, type: :integration do
 
       result = logic.process
       expect(result[:record][:state]).to eq('new')
+    end
+  end
+
+  # End-to-end network context capture (#3640, ADR-022): logic layer reads the
+  # request IP/UA from StrategyResult metadata, reduces them to the privacy-safe
+  # representation, and threads them through the receipt to the org trail.
+  context 'network context capture' do
+    let(:trail_org) do
+      Onetime::Organization.new(
+        display_name: 'Status Trail Org',
+        contact_email: "status-trail-#{SecureRandom.hex(6)}@example.com",
+      ).tap(&:save)
+    end
+
+    let!(:pair) { Onetime::Receipt.spawn_pair(nil, 3600, 'a secret value') }
+
+    before do
+      receipt.org_id = trail_org.objid
+      receipt.save_fields(:org_id)
+    end
+
+    it 'records the masked partial IP, partial UA, and keyed hash on the status fetch' do
+      logic = build_logic(
+        { 'identifier' => secret.identifier },
+        ip: '203.0.113.42',
+        user_agent: 'Mozilla/5.0 (X11; Linux x86_64) Chrome/119.0.0.0 Safari/537.36',
+      )
+      logic.process_params
+      logic.process
+
+      event = Onetime::Organization.load(trail_org.objid).audit_events_page.first
+      expect(event['kind']).to eq('status_get')
+      expect(event['net_ip_partial']).to eq('203.0.113.0')
+      expect(event['net_ip_hash']).to match(/\A[0-9a-f]{64}\z/)
+      expect(event['net_ua_partial']).to include('Chrome')
+      expect(event['net_ua_partial']).not_to include('119.0.0.0')
+    end
+
+    # THE NO-REGRESSION GUARD at the endpoint boundary: a raw dotted-quad IP or
+    # the full UA the caller sent must never survive into the recorded event.
+    it 'never persists the raw IP or full UA sent by the caller' do
+      raw_ip  = '203.0.113.42'
+      full_ua = 'Mozilla/5.0 (X11; Linux x86_64) Chrome/119.0.0.0 Safari/537.36'
+
+      logic = build_logic({ 'identifier' => secret.identifier }, ip: raw_ip, user_agent: full_ua)
+      logic.process_params
+      logic.process
+
+      trail = Onetime::Organization.load(trail_org.objid)
+      raw   = trail.audit_events.membersraw.join
+      expect(raw).not_to include(raw_ip)
+      expect(raw).not_to include(full_ua)
+      expect(raw).not_to include('119.0.0.0')
+    end
+
+    it 'records the event with shortids only when no request context is present' do
+      logic = build_logic({ 'identifier' => secret.identifier })
+      logic.process_params
+      logic.process
+
+      event = Onetime::Organization.load(trail_org.objid).audit_events_page.first
+      expect(event['kind']).to eq('status_get')
+      expect(event.keys).not_to include('net_ip_partial', 'net_ua_partial', 'net_ip_hash')
     end
   end
 end

--- a/apps/api/v2/spec/models/organization_audit_trail_spec.rb
+++ b/apps/api/v2/spec/models/organization_audit_trail_spec.rb
@@ -4,6 +4,7 @@
 
 require_relative '../../application'
 require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'onetime/security/request_context'
 
 # Audit-fidelity coverage for the organization audit trail (#3633).
 #
@@ -122,6 +123,90 @@ RSpec.describe Onetime::Organization, type: :integration do
       raw = org.audit_events.membersraw.join
       expect(raw).not_to include(secret.identifier)
       expect(raw).not_to include(receipt.identifier)
+    end
+
+    # Network context capture (#3640, ADR-022). The fetch path threads a
+    # privacy-safe context hash into record_access_event, which forwards it to
+    # the trail. These specs pin that the AGREED representation lands -- masked
+    # partial IP, partial UA, keyed correlation hash -- and, critically, that a
+    # raw IP or full UA can NEVER reach the stored event.
+    describe 'network context fan-out' do
+      # Represents what the capture layer produces: already-reduced values.
+      let(:context) do
+        {
+          'net_ip_partial' => '203.0.113.0',
+          'net_ua_partial' => 'Mozilla/*.* Chrome/*.*.*.*',
+          'net_ip_hash' => 'd5cc375856c803a88c2aed517a5ae82244be6819a7ac0c11e08deeb679ecff39',
+        }
+      end
+
+      before { link_to_org!(receipt, org) }
+
+      it 'carries the masked partial IP, partial UA, and keyed hash into the trail' do
+        receipt.record_access_event('secret_get', context: context)
+
+        event = org.audit_events_page.first
+        expect(event['kind']).to eq('secret_get')
+        expect(event['net_ip_partial']).to eq('203.0.113.0')
+        expect(event['net_ua_partial']).to eq('Mozilla/*.* Chrome/*.*.*.*')
+        expect(event['net_ip_hash']).to eq(context['net_ip_hash'])
+        # Alongside the existing shortid context, not instead of it.
+        expect(event['receipt']).to eq(receipt.shortid)
+      end
+
+      it 'keeps the shortid-only context intact when no network context is given' do
+        receipt.record_access_event('status_get')
+
+        event = org.audit_events_page.first
+        expect(event).to include('receipt', 'secret', 'kind', 'at')
+        expect(event.keys).not_to include('net_ip_partial', 'net_ua_partial', 'net_ip_hash')
+      end
+
+      # NO-REGRESSION GUARD (primary privacy safety net): a raw dotted-quad IP
+      # or a full user-agent string must NEVER appear in any recorded event
+      # attribute. Even if a caller hands record_access_event a context built
+      # from raw values, only the masked representation may be persisted -- so
+      # here we build the context through the real capture helper from RAW
+      # inputs and assert the raw values are absent from the stored trail.
+      it 'never persists a raw IP or full UA anywhere in the recorded event' do
+        raw_ip   = '203.0.113.42'
+        raw_ipv6 = '2001:db8:1234:5678:9abc:def0:1234:5678'
+        full_ua  = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' \
+                   '(KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36'
+
+        [raw_ip, raw_ipv6].each do |ip|
+          real_context = Onetime::Security::RequestContext.capture(ip: ip, user_agent: full_ua)
+          receipt.record_access_event('secret_get', context: real_context)
+        end
+
+        raw = org.audit_events.membersraw.join
+
+        # No raw dotted-quad IPv4, no full IPv6, no full UA, no version token.
+        expect(raw).not_to include(raw_ip)
+        expect(raw).not_to include(raw_ipv6)
+        expect(raw).not_to include(full_ua)
+        expect(raw).not_to include('119.0.0.0')
+
+        # Belt and suspenders: scan every stored attribute value directly.
+        org.audit_events_page(limit: 200).each do |event|
+          event.each_value do |value|
+            expect(value.to_s).not_to include(raw_ip)
+            expect(value.to_s).not_to include(raw_ipv6)
+            expect(value.to_s).not_to include(full_ua)
+          end
+        end
+      end
+
+      it 'records a stable, keyed correlation hash across two events from the same source' do
+        real_context = Onetime::Security::RequestContext.capture(
+          ip: '203.0.113.42', user_agent: 'UA/1.0',
+        )
+        2.times { receipt.record_access_event('status_get', context: real_context) }
+
+        hashes = org.audit_events_page.map { |e| e['net_ip_hash'] }
+        expect(hashes.uniq.size).to eq(1)
+        expect(hashes.first).to match(/\A[0-9a-f]{64}\z/)
+      end
     end
 
     it 'writes nowhere and raises nothing for receipts without org context' do

--- a/apps/api/v2/spec/models/receipt_access_timeline_spec.rb
+++ b/apps/api/v2/spec/models/receipt_access_timeline_spec.rb
@@ -90,6 +90,37 @@ RSpec.describe Onetime::Receipt, type: :integration do
     end
   end
 
+  # Network context threading (#3640): the fetch path passes privacy-safe
+  # request context (masked IP / UA, keyed hash) down to the org-trail fan-out,
+  # which has no request object of its own. record_access_event forwards the
+  # string-keyed context to record_org_audit_event verbatim; when absent it
+  # forwards nothing (backward-compatible with lifecycle callers).
+  describe '#record_access_event context threading' do
+    it 'forwards a present context to the org-trail fan-out' do
+      context = { 'net_ip_partial' => '203.0.113.0', 'net_ip_hash' => 'abc123' }
+
+      expect(receipt).to receive(:record_org_audit_event)
+        .with('status_get', hash_including(at: anything, **context))
+
+      receipt.record_access_event('status_get', context: context)
+    end
+
+    it 'forwards no extra attrs when context is nil (default)' do
+      expect(receipt).to receive(:record_org_audit_event) do |kind, **kwargs|
+        expect(kind).to eq('status_get')
+        expect(kwargs.keys).to contain_exactly(:at)
+      end
+
+      receipt.record_access_event('status_get')
+    end
+
+    it 'still records the member regardless of context' do
+      member = receipt.record_access_event('status_get', context: { 'net_ip_partial' => '203.0.113.0' })
+      expect(member).to start_with('status_get:')
+      expect(receipt.access_count).to eq(1)
+    end
+  end
+
   describe 'lifecycle isolation' do
     it 'recording an access does not touch the receipt or secret state' do
       receipt.record_access_event('secret_get')

--- a/docs/architecture/decision-records/adr-022-secret-activity-network-capture-privacy.md
+++ b/docs/architecture/decision-records/adr-022-secret-activity-network-capture-privacy.md
@@ -116,6 +116,30 @@ fan-out guard is unchanged.
   the actor-identity capture (#3639), which shares the same
   `record_org_audit_event(**event_attrs)` seam.
 
+## Implementation Notes
+
+### The /24 correlation granularity is temporary (2026-07-09)
+
+Hashing the *partial* IP (Decision: "We hash the partial IP, not the raw") is a
+consequence of the raw IP being architecturally unavailable at this layer, not
+a target end state. It yields only /24-granular correlation. This is a **known,
+tracked limitation**, not a permanent design choice.
+
+The proper fix lives in Otto: **otto#192** requests that Otto expose a
+*stable-keyed* HMAC correlation hash derived from the **full** client IP,
+computed inside `IPPrivacyMiddleware` before masking (the one place the full IP
+briefly exists), so a consumer can get per-host correlation without ever
+handling the raw IP. Otto already computes a full-IP hash (`otto.privacy.hashed_ip`),
+but it is keyed with a **daily-rotating** key — unusable for a long-lived audit
+trail — which is why this ADR fell back to hashing the masked IP with a stable
+app secret.
+
+When otto#192 lands: switch `net_ip_hash` to consume Otto's stable full-IP
+correlation hash, upgrading correlation from /24 to per-host, with no change to
+this pipeline's "raw IP never reaches app code" invariant. Until then, the /24
+granularity stands and is documented inline at the hash site
+(`lib/onetime/security/request_context.rb`).
+
 ## Cross-references
 
 - Ticket #3640 (this work); event-side capture umbrella #3633 / PR #3635.
@@ -123,3 +147,5 @@ fan-out guard is unchanged.
   data lands in.
 - Sibling capture: #3639 (actor identity on revealed/burned), same
   `record_org_audit_event` extension point.
+- Upstream follow-up: otto#192 (stable-keyed full-IP correlation hash) — see
+  Implementation Notes; unblocks per-host correlation.

--- a/docs/architecture/decision-records/adr-022-secret-activity-network-capture-privacy.md
+++ b/docs/architecture/decision-records/adr-022-secret-activity-network-capture-privacy.md
@@ -149,3 +149,7 @@ granularity stands and is documented inline at the hash site
   `record_org_audit_event` extension point.
 - Upstream follow-up: otto#192 (stable-keyed full-IP correlation hash) — see
   Implementation Notes; unblocks per-host correlation.
+- Upstream follow-up: otto#194 (public UA-anonymization surface) — lets
+  `RequestContext.mask_user_agent` delegate instead of copying Otto's private
+  version/build-stripping regexes; a cross-implementation spec guards the drift
+  until it lands.

--- a/docs/architecture/decision-records/adr-022-secret-activity-network-capture-privacy.md
+++ b/docs/architecture/decision-records/adr-022-secret-activity-network-capture-privacy.md
@@ -1,0 +1,125 @@
+---
+id: "022"
+status: proposed
+title: "ADR-022: Secret Activity Network-Context Capture Privacy"
+---
+
+## Status
+
+Proposed
+
+## Date
+
+2026-07-09
+
+## Context
+
+The org audit trail (`Organization::Features::AuditTrail`, #3633) and the
+per-receipt access timeline (`Receipt::Features::AccessTimeline`) record *what*
+happened to a secret and *when*, but capture no network context. For org
+customers, "from where" is the second question after "who"; a trail with no IP
+or user agent cannot answer it.
+
+We want to add network context to the fetch events (`status_get`, `secret_get`,
+and the `creator_` / `previewed` variants) without regressing the trail's
+privacy posture. That posture is deliberate and already established: the trail
+stores **shortids only, never full identifiers**, because a secret identifier
+*is* a capability token (it is the link). Network identity is the same class of
+problem in a different dimension — a raw IP and a full user-agent string are
+directly personal and directly identifying.
+
+Two facts shape the decision:
+
+1. **Prior art.** The auth audit log (`apps/web/auth/config/hooks/audit_logging.rb`)
+   already records `ip` and `user_agent` for login/MFA events, and Otto ships
+   the privacy primitives it relies on: `Otto::Privacy::IPPrivacy.mask_ip`
+   (zero the last IPv4 octet / last 80 IPv6 bits), `IPPrivacy.hash_ip`
+   (keyed HMAC-SHA256), and `RedactedFingerprint#anonymize_user_agent`
+   (strip version/build identifiers, truncate).
+
+2. **The raw IP is already gone at the application layer.** Otto's
+   `IPPrivacyMiddleware` runs first in the stack and rewrites `REMOTE_ADDR` /
+   `otto.client_ip` to the masked IP and scrubs `HTTP_USER_AGENT` to the
+   anonymized form before any application code runs. So the values that reach
+   the logic layer via the auth `StrategyResult` metadata are, in production,
+   already reduced. This is a defense-in-depth property we want to preserve and
+   lean on, not bypass.
+
+The plumbing constraint: the org-trail emit happens at the **model** layer
+(`Receipt#record_org_audit_event`), which has no request object. The request
+context is only available at the **logic** layer, so it must be threaded down.
+
+## Decision
+
+**Store, for each fetch event, three reduced attributes and never the raw
+values:**
+
+| Attribute | Representation | Purpose |
+|---|---|---|
+| `net_ip_partial` | IPv4 last octet zeroed (IPv6 last 80 bits) via `IPPrivacy.mask_ip` | Coarse "from where" — balance of forensics and personal privacy |
+| `net_ua_partial` | User agent with version/build identifiers stripped and truncated | Client family without a high-entropy fingerprint |
+| `net_ip_hash` | Keyed HMAC-SHA256 over the **partial** IP | Correlation without disclosure |
+
+**The raw dotted-quad IP and the full User-Agent string are never stored,
+anywhere in this pipeline.** This mirrors the trail's existing "shortids only,
+no capability tokens" rule.
+
+**Capture is centralized and unconditional.** `Onetime::Security::RequestContext`
+reads the ip / user-agent from the `StrategyResult` metadata and re-applies the
+reduction *every time*, idempotently. Masking an already-masked IP is a no-op;
+stripping versions from an already-stripped UA is a no-op. So even if the edge
+middleware is disabled or a future change routes a raw value here, the stored
+attributes stay masked. The raw IP is touched by exactly one operation
+(`mask_ip`) and reduced immediately.
+
+**The correlation hash is keyed by the app's server secret.** We key
+`net_ip_hash` with `OT.global_secret` (== `site.secret`), the same root the app
+already uses for keyed digests (`Onetime::KeyDerivation`, IncomingConfig
+recipient hashing). It is stable across requests, so the same partial IP always
+yields the same hash (correlatable across events), while the hash is not
+reversible without the secret. We deliberately do **not** use Otto's
+daily-rotating hash key, whose rotation would break long-horizon correlation.
+
+**We hash the partial IP, not the raw.** Because the raw IP is architecturally
+unavailable at this layer (see Context #2), the hash is computed over the
+already-masked IP. It therefore correlates at /24 granularity and provably
+cannot encode anything finer than the partial we already store. Its residual
+value over the stored partial is as an opaque, fixed-width token that can be
+shared or exported without disclosing even the network prefix, and that stays
+stable across the trail's lifetime.
+
+**Threading.** `record_access_event(kind, context:)` accepts an optional
+string-keyed context hash and forwards it through
+`record_org_audit_event(..., **event_attrs)`, which splats it into the org
+audit event. Only the fetch/telemetry path supplies it today. The saturation
+fan-out guard is unchanged.
+
+## Trade-offs
+
+- **We lose**: full-IP correlation. Two callers in the same /24 are
+  indistinguishable in the hash. This is an acceptable and deliberate cost of
+  never handling the raw IP.
+- **We gain**: a trail that answers "from where" at neighborhood granularity, a
+  stable correlation token, and a capture path that is safe by construction —
+  it cannot persist raw network data even under misconfiguration.
+- **Risk**: the masked IP is low-entropy, so an attacker *holding the server
+  secret* could brute-force the /24 behind a hash. Mitigated by the fact that
+  the server secret compromising this is the same secret that decrypts every
+  stored secret; this hash is not the weak link in that scenario.
+
+## Consequences
+
+- A dedicated no-regression spec asserts that no recorded event attribute ever
+  contains a raw dotted-quad IPv4/IPv6 or the full user-agent string — the
+  primary safety net against a future change silently persisting raw data.
+- Key names are namespaced (`net_`) so this capture composes additively with
+  the actor-identity capture (#3639), which shares the same
+  `record_org_audit_event(**event_attrs)` seam.
+
+## Cross-references
+
+- Ticket #3640 (this work); event-side capture umbrella #3633 / PR #3635.
+- ADR-021 (audit-log stream terminology / scoping) — naming of the stream this
+  data lands in.
+- Sibling capture: #3639 (actor identity on revealed/burned), same
+  `record_org_audit_event` extension point.

--- a/lib/onetime/models/receipt/features/access_timeline.rb
+++ b/lib/onetime/models/receipt/features/access_timeline.rb
@@ -48,10 +48,16 @@ module Onetime::Receipt::Features
       #   endpoint was fetched). Kept open-ended so higher-fidelity tiers
       #   (e.g. a client-confirmed render beacon) can append richer kinds.
       # @param at [Numeric] event time as epoch seconds; defaults to now.
+      # @param context [Hash, nil] optional privacy-safe request context to
+      #   attach to the org-trail event (e.g. the masked-partial IP / UA and the
+      #   keyed correlation hash from Onetime::Security::RequestContext; #3640).
+      #   String-keyed and forwarded verbatim to record_org_audit_event, which
+      #   splats it into the org audit event. nil / empty records no extra
+      #   context. Only the fetch/telemetry path supplies this today.
       # @return [String, nil] the recorded member, or nil when nothing was
       #   recorded (blank kind, or the receipt no longer exists -- appending
       #   would orphan a timeline key next to a destroyed/expired receipt).
-      def record_access_event(kind, at: Familia.now)
+      def record_access_event(kind, at: Familia.now, context: nil)
         return if kind.to_s.empty?
         return unless exists?
 
@@ -84,8 +90,11 @@ module Onetime::Receipt::Features
 
         # Fan out to the organization's audit trail (no-op without org
         # context). The org trail is the durable, org-wide view of the same
-        # activity; see Organization::Features::AuditTrail.
-        record_org_audit_event(kind, at: at) unless saturated
+        # activity; see Organization::Features::AuditTrail. Forward any
+        # privacy-safe request context (masked IP / UA, keyed hash; #3640) as
+        # extra string-keyed event attrs.
+        context_attrs = context || {}
+        record_org_audit_event(kind, at: at, **context_attrs) unless saturated
 
         member
       end
@@ -103,8 +112,13 @@ module Onetime::Receipt::Features
       # @param at [Numeric] event time as epoch seconds; defaults to now.
       # @param organization [Onetime::Organization, nil] pass when the
       #   caller already holds the org to skip the extra load.
+      # @param event_attrs [Hash] additional string-keyed context spliced into
+      #   the org audit event -- e.g. privacy-safe network context (#3640) or
+      #   actor identity (#3639). Kept additive so independent capture tickets
+      #   compose without touching this method's core. Values must already be
+      #   audit-safe (short, non-sensitive; never raw IPs or capability tokens).
       # @return [Hash, nil] the recorded event, or nil when skipped.
-      def record_org_audit_event(kind, at: Familia.now, organization: nil)
+      def record_org_audit_event(kind, at: Familia.now, organization: nil, **event_attrs)
         organization ||= Onetime::Organization.load(org_id) unless org_id.to_s.empty?
         return if organization.nil?
 
@@ -115,6 +129,7 @@ module Onetime::Receipt::Features
           # secret identifier IS the link) and must not leak into the trail.
           'receipt' => shortid,
           'secret' => secret_shortid.to_s,
+          **event_attrs,
         )
       rescue StandardError => ex
         OT.le "[audit-trail] #{ex.class}: #{ex.message} (kind=#{kind}, receipt=#{shortid})"

--- a/lib/onetime/security/request_context.rb
+++ b/lib/onetime/security/request_context.rb
@@ -157,6 +157,15 @@ module Onetime
       # at the edge and one reduced here agree. Idempotent: re-stripping an
       # already-stripped UA changes nothing.
       #
+      # KNOWN ISSUE (temporary; tracked in otto#194). The regexes below are
+      # copied from Otto's private #anonymize_user_agent; the two will silently
+      # drift if Otto adjusts its patterns without a matching change here. A
+      # cross-implementation idempotency spec (request_context_spec.rb) feeds
+      # Otto's ACTUAL output back through this method to catch that drift. otto#194
+      # asks Otto to expose a public UA-anonymization surface (the analogue of
+      # the public IP primitives / otto#192); when it lands, this copy is
+      # replaced by a delegation and the drift risk goes away.
+      #
       # @param ua [String, nil]
       # @return [String, nil] the partial UA, or nil for blank input.
       def mask_user_agent(ua)

--- a/lib/onetime/security/request_context.rb
+++ b/lib/onetime/security/request_context.rb
@@ -36,6 +36,17 @@ module Onetime
     #    one operation (mask_ip) and reduced immediately; it never flows into a
     #    second code path.
     #
+    #    KNOWN ISSUE (temporary; tracked in otto#192). The /24 correlation is a
+    #    consequence of the raw IP being unavailable at this layer, not a target
+    #    end state. Otto already computes a full-IP hash (otto.privacy.hashed_ip),
+    #    but keys it with a DAILY-ROTATING key -- unusable for a long-lived audit
+    #    trail -- which is why we fall back to hashing the masked IP with a stable
+    #    app secret. otto#192 asks Otto to expose a stable-keyed full-IP
+    #    correlation hash (computed in IPPrivacyMiddleware before masking). When
+    #    it lands, switch NET_IP_HASH to consume it and correlation upgrades from
+    #    /24 to per-host, with no change to the "raw IP never reaches app code"
+    #    invariant. See ADR-022 Implementation Notes.
+    #
     # 2. Defense in depth. Otto's IPPrivacyMiddleware already masks REMOTE_ADDR /
     #    otto.client_ip and scrubs the User-Agent at the edge, so the values that
     #    reach this layer are typically already reduced. This helper re-applies
@@ -83,6 +94,9 @@ module Onetime
         partial_ip = mask_ip(ip)
         if partial_ip
           attrs[NET_IP_PARTIAL] = partial_ip
+          # KNOWN ISSUE (otto#192, temporary): hashing the PARTIAL IP yields only
+          # /24-granular correlation. Swap to Otto's stable full-IP hash when it
+          # exists (see class docstring note 1 and ADR-022 Implementation Notes).
           correlation           = hash_ip(partial_ip, key)
           attrs[NET_IP_HASH]    = correlation if correlation
         end

--- a/lib/onetime/security/request_context.rb
+++ b/lib/onetime/security/request_context.rb
@@ -1,0 +1,165 @@
+# lib/onetime/security/request_context.rb
+#
+# frozen_string_literal: true
+
+require 'otto'
+
+module Onetime
+  module Security
+    # Privacy-safe capture of per-request network context for the secret
+    # activity audit pipeline (#3640).
+    #
+    # ---------------------------------------------------------------------------
+    # PRIVACY STANCE (authoritative decision: ADR-022)
+    # ---------------------------------------------------------------------------
+    # The org audit trail records only a REDUCED, non-reversible view of the
+    # caller's network identity -- never the raw values:
+    #
+    #   net_ip_partial : IPv4 with the last octet zeroed (IPv6 last 80 bits),
+    #                    a balance of forensic value and personal privacy.
+    #   net_ua_partial : user agent with version/build identifiers stripped and
+    #                    the remainder truncated.
+    #   net_ip_hash    : keyed HMAC-SHA256 over the PARTIAL IP -- an opaque,
+    #                    stable correlation token (correlation without
+    #                    disclosure), matching the trail's "shortids only, no
+    #                    capability tokens" posture.
+    #
+    # The raw dotted-quad IP and the full User-Agent string are NEVER stored,
+    # anywhere in this pipeline.
+    #
+    # Two deliberate properties:
+    #
+    # 1. Hash the PARTIAL, not the raw. The keyed hash is computed over the
+    #    already-masked IP, so it can never encode anything finer than the /24
+    #    we are willing to store. Correlation is therefore at /24 granularity.
+    #    This is the most conservative posture: the raw IP is handled by exactly
+    #    one operation (mask_ip) and reduced immediately; it never flows into a
+    #    second code path.
+    #
+    # 2. Defense in depth. Otto's IPPrivacyMiddleware already masks REMOTE_ADDR /
+    #    otto.client_ip and scrubs the User-Agent at the edge, so the values that
+    #    reach this layer are typically already reduced. This helper re-applies
+    #    the reduction UNCONDITIONALLY and idempotently, so even if that
+    #    middleware is ever disabled or a future change routes a raw value here,
+    #    the stored attributes stay masked. Masking an already-masked IP is a
+    #    no-op; stripping versions from an already-stripped UA is a no-op.
+    #
+    # Layer-agnostic: no Rack dependency. Callers pass plain ip / user_agent
+    # strings (e.g. read from the auth StrategyResult metadata), so this is
+    # equally usable from request handlers, jobs, or specs.
+    module RequestContext
+      extend self
+
+      # String keys so they splat cleanly through the model layer's **event_attrs
+      # (see Receipt#record_org_audit_event) and JSON round-trip in the trail.
+      NET_IP_PARTIAL = 'net_ip_partial'
+      NET_UA_PARTIAL = 'net_ua_partial'
+      NET_IP_HASH    = 'net_ip_hash'
+
+      # Trailing octets to zero when masking an IP (1 => last IPv4 octet).
+      IP_MASK_OCTETS = 1
+
+      # Upper bound on the stored partial user agent. Well under Otto's own 500
+      # so the stored value is unambiguously a truncated partial.
+      UA_MAX_LENGTH = 200
+
+      # Build the string-keyed network-context attributes for an audit event.
+      #
+      # Every key is present only when its value could be derived, so a request
+      # with no network context (e.g. an internal caller with no ip/ua) yields
+      # an empty hash and records the event with no network attributes rather
+      # than nils.
+      #
+      # @param ip [String, nil] client IP as seen at the calling layer (already
+      #   edge-masked in production; re-masked here defensively).
+      # @param user_agent [String, nil] client User-Agent header value.
+      # @param key [String, nil] HMAC key for the correlation hash. Defaults to
+      #   the app's server secret; when blank the hash is omitted rather than
+      #   computed under a weak key.
+      # @return [Hash{String=>String}] masked/partial/hashed attributes only.
+      def capture(ip:, user_agent:, key: default_key)
+        attrs = {}
+
+        partial_ip = mask_ip(ip)
+        if partial_ip
+          attrs[NET_IP_PARTIAL] = partial_ip
+          correlation           = hash_ip(partial_ip, key)
+          attrs[NET_IP_HASH]    = correlation if correlation
+        end
+
+        partial_ua            = mask_user_agent(user_agent)
+        attrs[NET_UA_PARTIAL] = partial_ua if partial_ua
+
+        attrs
+      end
+
+      # The server-side secret used to key the correlation hash.
+      #
+      # This is the application's global secret (== site.secret), already the
+      # root the app uses for keyed digests (see Onetime::KeyDerivation and the
+      # IncomingConfig recipient hashing). It is stable across requests, so the
+      # same partial IP always yields the same hash (correlatable), while the
+      # hash stays non-reversible without the secret. We deliberately do NOT use
+      # Otto's daily-rotating hash key, whose rotation would break long-horizon
+      # correlation in the trail.
+      #
+      # @return [String, nil]
+      def default_key
+        OT.global_secret
+      end
+
+      # Zero the last IPv4 octet (or last 80 IPv6 bits) via Otto's masking
+      # helper. Idempotent on an already-masked address. Returns nil for blank
+      # or malformed input so a bad value can never fall through as a raw string.
+      #
+      # @param ip [String, nil]
+      # @return [String, nil] masked IP, or nil.
+      def mask_ip(ip)
+        return nil if ip.to_s.strip.empty?
+
+        Otto::Privacy::IPPrivacy.mask_ip(ip.to_s, IP_MASK_OCTETS)
+      rescue ArgumentError
+        # Not a parseable IP -- drop it rather than store an un-masked token.
+        nil
+      end
+
+      # Keyed HMAC-SHA256 correlation hash over the (already partial) IP.
+      #
+      # @param partial_ip [String, nil] the masked IP.
+      # @param key [String, nil] HMAC key (the server secret).
+      # @return [String, nil] 64-char hex digest, or nil when ip/key is blank.
+      def hash_ip(partial_ip, key)
+        return nil if partial_ip.to_s.strip.empty? || key.to_s.empty?
+
+        Otto::Privacy::IPPrivacy.hash_ip(partial_ip.to_s, key.to_s)
+      rescue ArgumentError
+        nil
+      end
+
+      # Strip version and build identifiers, then truncate.
+      #
+      # Mirrors Otto::Privacy::RedactedFingerprint#anonymize_user_agent (a
+      # private instance method, so we cannot call it directly) so a UA reduced
+      # at the edge and one reduced here agree. Idempotent: re-stripping an
+      # already-stripped UA changes nothing.
+      #
+      # @param ua [String, nil]
+      # @return [String, nil] the partial UA, or nil for blank input.
+      def mask_user_agent(ua)
+        return nil if ua.to_s.strip.empty?
+
+        # Build identifiers first (must precede version stripping, else the
+        # asterisks it inserts break the version regex -- see Otto's note).
+        reduced = ua.to_s.gsub(%r{Build/[\w.-]+}, 'Build/*')
+
+        # Version patterns (longest first), dot- or underscore-separated.
+        reduced = reduced
+          .gsub(/\d+[._]\d+[._]\d+[._]\d+/, '*.*.*.*')
+          .gsub(/\d+[._]\d+[._]\d+/, '*.*.*')
+          .gsub(/\d+[._]\d+/, '*.*')
+
+        reduced.length > UA_MAX_LENGTH ? reduced[0, UA_MAX_LENGTH] : reduced
+      end
+    end
+  end
+end

--- a/spec/unit/onetime/security/request_context_spec.rb
+++ b/spec/unit/onetime/security/request_context_spec.rb
@@ -101,6 +101,46 @@ RSpec.describe Onetime::Security::RequestContext do
       expect(twice).to eq(once)
     end
 
+    # Cross-implementation idempotency (the real regression risk). The privacy
+    # stance relies on this helper AGREEING with Otto's edge reduction: a UA
+    # already anonymized by Otto::Privacy must pass back through mask_user_agent
+    # unchanged. mask_user_agent copies its regexes from Otto's private
+    # RedactedFingerprint#anonymize_user_agent, so if Otto ever adjusts those
+    # patterns this test fails -- catching the drift here instead of silently
+    # double-reducing (or leaking) in production. We feed Otto's ACTUAL output
+    # (not a hand-written fixture) so the two implementations are compared for
+    # real. Tracked upstream as otto#194 (request a public UA-anonymization
+    # surface so this copy can be retired).
+    it "is idempotent against Otto's own anonymized UA output" do
+      require 'otto/privacy/redacted_fingerprint'
+
+      # geo_enabled: false keeps fingerprint construction self-contained (no
+      # GeoResolver/GeoIP dependency); the rotation key falls back to an
+      # in-memory store when no Redis is configured.
+      config = Otto::Privacy::Config.new(geo_enabled: false)
+      env    = { 'REMOTE_ADDR' => '203.0.113.42', 'HTTP_USER_AGENT' => full_ua }
+      otto_reduced = Otto::Privacy::RedactedFingerprint.new(env, config).anonymized_ua
+
+      # Sanity: Otto did reduce the UA (versions stripped) and stayed within our
+      # cap, so equality is a meaningful idempotency assertion.
+      expect(otto_reduced).not_to include('119.0.0.0')
+      expect(otto_reduced.length).to be <= described_class::UA_MAX_LENGTH
+
+      expect(described_class.mask_user_agent(otto_reduced)).to eq(otto_reduced)
+    end
+
+    it "is idempotent against Otto's build-identifier stripping" do
+      require 'otto/privacy/redacted_fingerprint'
+
+      ua     = 'Dalvik/2.1.0 (Linux; U; Android 9; SM-G960F Build/PPR1.180610.011)'
+      config = Otto::Privacy::Config.new(geo_enabled: false)
+      env    = { 'REMOTE_ADDR' => '203.0.113.42', 'HTTP_USER_AGENT' => ua }
+      otto_reduced = Otto::Privacy::RedactedFingerprint.new(env, config).anonymized_ua
+
+      expect(otto_reduced).to include('Build/*')
+      expect(described_class.mask_user_agent(otto_reduced)).to eq(otto_reduced)
+    end
+
     it 'returns nil for blank input' do
       expect(described_class.mask_user_agent(nil)).to be_nil
       expect(described_class.mask_user_agent('')).to be_nil

--- a/spec/unit/onetime/security/request_context_spec.rb
+++ b/spec/unit/onetime/security/request_context_spec.rb
@@ -1,0 +1,163 @@
+# spec/unit/onetime/security/request_context_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'onetime/security/request_context'
+
+# Unit coverage for the privacy-safe network-context capture (#3640, ADR-022).
+#
+# This is the primary safety net for the privacy stance: the stored
+# representation must ALWAYS be the masked partial IP, the partial UA, and the
+# keyed correlation hash -- and NEVER a raw dotted-quad IP or a full user-agent
+# string. The examples below pin masking, keyed hashing (stable + keyed), UA
+# reduction, and -- critically -- that no raw value can survive capture.
+RSpec.describe Onetime::Security::RequestContext do
+  # A deliberately raw, un-masked public IPv4 and a full real-browser UA. In
+  # production these are already edge-masked by Otto before reaching the app;
+  # feeding the RAW values here proves the helper reduces them regardless.
+  let(:raw_ipv4) { '203.0.113.42' }
+  let(:raw_ipv6) { '2001:db8:1234:5678:9abc:def0:1234:5678' }
+  let(:full_ua) do
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' \
+      '(KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36'
+  end
+  let(:key) { 'a-stable-server-secret' }
+
+  describe '.mask_ip' do
+    it 'zeros the last IPv4 octet' do
+      expect(described_class.mask_ip('203.0.113.42')).to eq('203.0.113.0')
+    end
+
+    it 'masks the trailing IPv6 bits' do
+      expect(described_class.mask_ip(raw_ipv6)).to eq('2001:db8:1234::')
+    end
+
+    it 'is idempotent on an already-masked address' do
+      once  = described_class.mask_ip(raw_ipv4)
+      twice = described_class.mask_ip(once)
+      expect(twice).to eq(once)
+    end
+
+    it 'returns nil for blank or malformed input (never a raw fall-through)' do
+      expect(described_class.mask_ip(nil)).to be_nil
+      expect(described_class.mask_ip('')).to be_nil
+      expect(described_class.mask_ip('   ')).to be_nil
+      expect(described_class.mask_ip('not-an-ip')).to be_nil
+    end
+  end
+
+  describe '.hash_ip' do
+    it 'is a 64-char hex HMAC that is stable for the same input + key' do
+      h1 = described_class.hash_ip('203.0.113.0', key)
+      h2 = described_class.hash_ip('203.0.113.0', key)
+      expect(h1).to match(/\A[0-9a-f]{64}\z/)
+      expect(h1).to eq(h2)
+    end
+
+    it 'differs for a different key (keyed, not a plain digest)' do
+      expect(described_class.hash_ip('203.0.113.0', 'key-a'))
+        .not_to eq(described_class.hash_ip('203.0.113.0', 'key-b'))
+    end
+
+    it 'differs for different inputs' do
+      expect(described_class.hash_ip('203.0.113.0', key))
+        .not_to eq(described_class.hash_ip('198.51.100.0', key))
+    end
+
+    it 'omits the hash when the key is blank rather than using a weak key' do
+      expect(described_class.hash_ip('203.0.113.0', nil)).to be_nil
+      expect(described_class.hash_ip('203.0.113.0', '')).to be_nil
+    end
+  end
+
+  describe '.mask_user_agent' do
+    it 'strips version numbers so the full UA is never retained verbatim' do
+      partial = described_class.mask_user_agent(full_ua)
+
+      expect(partial).not_to eq(full_ua)
+      expect(partial).not_to include('119.0.0.0')
+      expect(partial).not_to include('10.0')
+      # Family/OS info survives -- the point is a partial, not a redaction.
+      expect(partial).to include('Windows NT')
+      expect(partial).to include('Chrome')
+    end
+
+    it 'strips build identifiers' do
+      ua = 'Dalvik/2.1.0 (Linux; U; Android 9; SM-G960F Build/PPR1.180610.011)'
+      expect(described_class.mask_user_agent(ua)).to include('Build/*')
+      expect(described_class.mask_user_agent(ua)).not_to include('PPR1.180610.011')
+    end
+
+    it 'truncates to UA_MAX_LENGTH' do
+      long = "Agent/#{'x' * 1000}"
+      expect(described_class.mask_user_agent(long).length)
+        .to eq(described_class::UA_MAX_LENGTH)
+    end
+
+    it 'is idempotent on an already-stripped UA' do
+      once  = described_class.mask_user_agent(full_ua)
+      twice = described_class.mask_user_agent(once)
+      expect(twice).to eq(once)
+    end
+
+    it 'returns nil for blank input' do
+      expect(described_class.mask_user_agent(nil)).to be_nil
+      expect(described_class.mask_user_agent('')).to be_nil
+    end
+  end
+
+  describe '.capture' do
+    subject(:attrs) { described_class.capture(ip: raw_ipv4, user_agent: full_ua, key: key) }
+
+    it 'returns exactly the three privacy-safe, string-keyed attributes' do
+      expect(attrs.keys).to contain_exactly(
+        'net_ip_partial', 'net_ua_partial', 'net_ip_hash'
+      )
+    end
+
+    it 'stores the masked partial IP, not the raw IP' do
+      expect(attrs['net_ip_partial']).to eq('203.0.113.0')
+    end
+
+    it 'produces a stable, keyed correlation hash over the PARTIAL IP' do
+      # Hash is computed over the /24, so a different host in the same /24
+      # correlates to the same token; a different /24 does not.
+      same_24  = described_class.capture(ip: '203.0.113.9', user_agent: full_ua, key: key)
+      other_24 = described_class.capture(ip: '198.51.100.7', user_agent: full_ua, key: key)
+
+      expect(attrs['net_ip_hash']).to eq(described_class.hash_ip('203.0.113.0', key))
+      expect(same_24['net_ip_hash']).to eq(attrs['net_ip_hash'])
+      expect(other_24['net_ip_hash']).not_to eq(attrs['net_ip_hash'])
+    end
+
+    it 'omits keys whose value could not be derived' do
+      expect(described_class.capture(ip: nil, user_agent: nil, key: key)).to eq({})
+      ip_only = described_class.capture(ip: raw_ipv4, user_agent: nil, key: key)
+      expect(ip_only.keys).to contain_exactly('net_ip_partial', 'net_ip_hash')
+    end
+
+    # THE NO-REGRESSION GUARANTEE: no captured value may contain the raw IP or
+    # the full UA -- not in a partial, not embedded in the hash, nowhere.
+    it 'never emits a raw dotted-quad IP or the full user-agent string' do
+      serialized = attrs.to_json
+
+      expect(serialized).not_to include(raw_ipv4)
+      expect(serialized).not_to include(full_ua)
+      expect(serialized).not_to include('119.0.0.0')
+      attrs.each_value { |v| expect(v).not_to include(raw_ipv4) }
+    end
+
+    it 'reduces even a raw IPv6 address to its masked prefix' do
+      out = described_class.capture(ip: raw_ipv6, user_agent: nil, key: key)
+      expect(out['net_ip_partial']).to eq('2001:db8:1234::')
+      expect(out.to_json).not_to include(raw_ipv6)
+    end
+
+    it 'defaults the hash key to the app global secret' do
+      allow(OT).to receive(:global_secret).and_return('global-secret-xyz')
+      out = described_class.capture(ip: raw_ipv4, user_agent: nil)
+      expect(out['net_ip_hash']).to eq(described_class.hash_ip('203.0.113.0', 'global-secret-xyz'))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

[#3640](https://github.com/onetimesecret/onetimesecret/issues/3640)

Adds **privacy-safe network context** to secret fetch events (`status_get`, `secret_get`, and the `creator_` / `previewed` variants), threaded from the logic layer down to the org audit trail without ever storing raw values.

Each fetch event records three reduced attributes:
- `net_ip_partial` — IPv4 last octet zeroed / IPv6 last 80 bits (via `Otto::Privacy::IPPrivacy.mask_ip`).
- `net_ua_partial` — user agent with version/build identifiers stripped, truncated to 200 chars.
- `net_ip_hash` — keyed HMAC-SHA256 for correlation-without-disclosure, keyed with `OT.global_secret` (the app's existing keyed-digest root, stable across requests).

The **raw dotted-quad IP and full user agent are never stored, anywhere.** Capture is centralized in `Onetime::Security::RequestContext` and re-applies the reduction unconditionally/idempotently, so a raw value can never be persisted even if the edge middleware is disabled. `Receipt#record_org_audit_event` gains the additive `**event_attrs` splat (shared seam with #3639).

The privacy decision is recorded in **ADR-022** (proposed). Because Otto destroys the raw IP at the edge, the hash is computed over the masked `/24` today — a documented, temporary trade-off; **otto#192** (delano/otto) tracks exposing a stable-keyed full-IP hash to upgrade correlation to per-host, noted in ADR-022 Implementation Notes and inline at the hash site.

## Related Issues

Closes #3640
Part of the event-side capture umbrella #3633 (shipped in PR #3635).
Sibling capture PR: #3639 (actor identity) — shares the `record_org_audit_event(**event_attrs)` seam. Upstream follow-up: delano/otto#192. Related ADR: #3637-series terminology in ADR-021.

## Test Plan

`bundle exec rspec` under Ruby 3.4.9, test datastore on port 2121:

- `spec/unit/onetime/security/request_context_spec.rb` → 20 examples (new), 0 failures.
- `receipt_access_timeline_spec.rb` +3, `organization_audit_trail_spec.rb` +4 (incl. no-raw-IP/UA regression guard), `show_secret_spec.rb` +2, `show_secret_status_spec.rb` +3 (endpoint-level guards).
- **No-regression guard at three levels** (unit, model fan-out, endpoint): feeds a real IPv4/IPv6 and a full browser UA through the pipeline and asserts none of those raw strings — nor the version token — appears in any recorded attribute.
- Broad regression: v2 models + secrets logic → 236 examples, 0 failures (5 pre-existing pending). New source files RuboCop-clean.

> Merge-order note: shares one method with #3639. If #3639 merges first, this branch's only conflict is a one-line `@param event_attrs` doc comment — keep this branch's version (it names both tickets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S57TVKW6YZVvyiSEj8dsY

---
_Generated by [Claude Code](https://claude.ai/code/session_011S57TVKW6YZVvyiSEj8dsY)_