### PR TITLE
docs(adr): ADR authoring guidance — splitting vs. combining decisions

### DIFF
--- a/docs/architecture/decision-records/README.md
+++ b/docs/architecture/decision-records/README.md
@@ -17,6 +17,19 @@ Documents that capture important architectural decisions along with their contex
 - **Numbered sequentially**: Makes referencing easy (`ADR-001`, `ADR-002`, etc.)
 - **One decision per ADR**: Don't bundle multiple choices together
 
+### Splitting vs. Combining Decisions
+
+This expands the "One decision per ADR" key above: when two choices show up together, default to **separate ADRs — one decision per record**. Four reasons:
+
+1. **One decision per record (atomicity).** The founding convention — Nygard's original format, `adr-tools`, MADR, the adr.github.io community, and AWS/Google/Microsoft's ADR guidance — is one architecturally-significant decision per file. The unit is "things that stand or fall together." Two choices that can be evaluated independently don't.
+2. **Different owners and review triggers.** A naming/structure decision and, say, a privacy/legal decision have different reviewers. Bundling forces a lawyer to wade through structural debates, and an engineer to wade through legal nuance.
+3. **Different lifecycles + immutability.** Quality ADR sets treat accepted records as immutable and **supersede rather than edit**. The volatile decision is usually the one most likely to change; if it's welded to a stable decision, revising one paragraph means superseding the whole record. Split, and you supersede just the part that moved.
+4. **Precise traceability.** A 1:1 decision↔ADR mapping keeps `git blame` and PR references clean: code that implements a decision links to *that* ADR, not to a grab-bag.
+
+**What mature ADR sets do:** sequentially numbered, immutable, short, single-topic records with a consistent template and a *liberal* "Related / References" section that cross-links siblings (Kubernetes KEPs, Arachne, AWS Prescriptive Guidance all do this). Cross-linking is how you get the "these belong together" benefit without a monolith. Keep the status lifecycle explicit (Proposed → Accepted → Superseded) and date every amendment.
+
+**Don't over-split, either.** If a decision is a single sentence with no trade-offs, a code comment at the call site suffices — it doesn't need a record. A choice earns its own ADR when it has real trade-offs, a regulatory or cross-cutting dimension, or a test/contract obligation attached to it.
+
 ### Implementation Notes Section
 
 Optional addenda for clarifications and execution details. Use it for:


### PR DESCRIPTION
## Summary

Expands the decision-records `README.md` (this repo's ADR best-practices guide) with a new **"Splitting vs. Combining Decisions"** section, deepening the existing one-line "One decision per ADR" key.

It captures the rationale for defaulting to separate records — atomicity (one architecturally-significant decision per file), different owners/review triggers, different lifecycles under immutability (supersede rather than edit the volatile part), and precise traceability — plus what mature ADR sets do (numbered, immutable, short, single-topic, liberal cross-linking) and a don't-over-split caveat.

Guidance, not a decision, so it's a README section — deliberately **not** numbered as an ADR (numbering it would violate the "one decision per record" rule it describes). Existing README content is left unchanged.

## Related Issues

None (documentation). Companion to the ADR-021 / ADR-022 work in this series.

## Test Plan

Documentation only — Markdown renders correctly; existing sections unmodified. No build or test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S57TVKW6YZVvyiSEj8dsY

---
_Generated by [Claude Code](https://claude.ai/code/session_011S57TVKW6YZVvyiSEj8dsY)_