### PR TITLE
Fix org context switcher hidden for paid solo-default workspaces

### DIFF
--- a/src/shared/composables/useScopeSwitcherVisibility.ts
+++ b/src/shared/composables/useScopeSwitcherVisibility.ts
@@ -73,6 +73,12 @@ export function useScopeSwitcherVisibility() {
    * (non-default) org still sees the switcher and org chip — that org is a
    * deliberate choice, not a trivial artifact of signup.
    *
+   * Limited to free-tier plans: this suppression exists to declutter brand-new
+   * *free* signups. A paying customer working solo inside their default
+   * workspace is a deliberate, non-trivial account and must keep the org
+   * context surface. A missing planid is treated as free so the switcher stays
+   * hidden while the list is still loading (matching the member_count guard).
+   *
    * member_count comes from the organizations list safe_dump. When the list
    * hasn't loaded yet (length 0) or the count is unknown, this stays false so
    * the switcher is never hidden prematurely.
@@ -81,6 +87,8 @@ export function useScopeSwitcherVisibility() {
     const orgs = organizationStore.organizations;
     if (orgs.length !== 1) return false;
     if (!orgs[0].is_default) return false;
+    const planid = orgs[0].planid;
+    if (planid && !/^free_v\d+$/.test(planid)) return false;
     const memberCount = orgs[0].member_count;
     return typeof memberCount === 'number' && memberCount <= 1;
   });

--- a/src/tests/composables/useScopeSwitcherVisibility.spec.ts
+++ b/src/tests/composables/useScopeSwitcherVisibility.spec.ts
@@ -47,7 +47,7 @@ vi.mock('@/shared/stores/identityStore', () => ({
 // entitlements, and the organizations list for solo-context detection.
 // Wrap in reactive() so refs auto-unwrap when accessed as store properties.
 type MockOrg = { current_user_role?: string | null; entitlements?: string[] | null } | null;
-type MockListOrg = { member_count?: number; is_default?: boolean };
+type MockListOrg = { member_count?: number; is_default?: boolean; planid?: string };
 const mockCurrentOrganization = ref<MockOrg>({
   current_user_role: 'owner',
   entitlements: null,
@@ -593,6 +593,60 @@ describe('useScopeSwitcherVisibility', () => {
       expect(showOrgSwitcher.value).toBe(false);
 
       mockOrganizations.value = [{ member_count: 2, is_default: true }];
+      await nextTick();
+
+      expect(showOrgSwitcher.value).toBe(true);
+    });
+  });
+
+  // The solo-default suppression exists to declutter brand-new *free* signups.
+  // It must never hide the org context for a paying customer, even one who
+  // works solo inside their (single) default workspace — the plan makes them a
+  // deliberate, non-trivial account.
+  describe('solo-default suppression is limited to free-tier plans', () => {
+    beforeEach(() => {
+      mockRoute.meta = { scopesAvailable: { organization: 'show' } };
+      mockCurrentOrganization.value = { current_user_role: 'owner', entitlements: null };
+      mockBillingEnabled.value = false;
+    });
+
+    it('shows the switcher for a paid solo default org (team_plus_v1)', () => {
+      mockOrganizations.value = [{ member_count: 1, is_default: true, planid: 'team_plus_v1' }];
+
+      const { showOrgSwitcher, isSoloDefaultContext } = useScopeSwitcherVisibility();
+      expect(isSoloDefaultContext.value).toBe(false);
+      expect(showOrgSwitcher.value).toBe(true);
+    });
+
+    it('shows the switcher for a paid solo default org (identity_plus_v1)', () => {
+      mockOrganizations.value = [{ member_count: 1, is_default: true, planid: 'identity_plus_v1' }];
+
+      const { isSoloDefaultContext } = useScopeSwitcherVisibility();
+      expect(isSoloDefaultContext.value).toBe(false);
+    });
+
+    it('still hides the switcher for a free solo default org (free_v1)', () => {
+      mockOrganizations.value = [{ member_count: 1, is_default: true, planid: 'free_v1' }];
+
+      const { showOrgSwitcher, isSoloDefaultContext } = useScopeSwitcherVisibility();
+      expect(isSoloDefaultContext.value).toBe(true);
+      expect(showOrgSwitcher.value).toBe(false);
+    });
+
+    it('treats a missing planid as free (hides the solo default) so the list can still be loading', () => {
+      mockOrganizations.value = [{ member_count: 1, is_default: true }];
+
+      const { isSoloDefaultContext } = useScopeSwitcherVisibility();
+      expect(isSoloDefaultContext.value).toBe(true);
+    });
+
+    it('reveals the switcher reactively when a free solo default upgrades to a paid plan', async () => {
+      mockOrganizations.value = [{ member_count: 1, is_default: true, planid: 'free_v1' }];
+
+      const { showOrgSwitcher } = useScopeSwitcherVisibility();
+      expect(showOrgSwitcher.value).toBe(false);
+
+      mockOrganizations.value = [{ member_count: 1, is_default: true, planid: 'team_plus_v1' }];
       await nextTick();
 
       expect(showOrgSwitcher.value).toBe(true);


### PR DESCRIPTION
## Problem

The Organization Context switcher (and its static org-name fallback chip) disappeared for paying customers. A Team Plus owner with an active plan and custom domains saw no org context at all.

## Root cause

`isSoloDefaultContext` in `useScopeSwitcherVisibility.ts` suppresses the switcher whenever the user has a **single default workspace with ≤1 member** — to declutter brand-new signups. But the condition keyed on *org shape only* and never looked at the plan, so it misfired for any paying customer working solo inside their default workspace.

The bar's outer guard (`OrganizationContextBar.vue` `shouldShow`) then hid the whole bar. All five visibility gates actually passed — the suppression was the sole cause.

## Fix

Limit the suppression to free-tier plans (`free_v{N}`). Any paid plan keeps the org context surface:

```js
const planid = orgs[0].planid;
if (planid && !/^free_v\d+$/.test(planid)) return false;
```

A missing `planid` is still treated as free, preserving the "don't hide prematurely while the org list is loading" guard.

## Behavior

- Paid solo default workspace (`team_plus_v1`, `identity_plus_v1`, …) → **switcher shows** (was hidden)
- Free solo default (`free_v1`) → still hidden (unchanged)
- Free → paid upgrade → switcher appears reactively

## Tests (TDD)

Added a `solo-default suppression is limited to free-tier plans` describe block (5 cases) to `useScopeSwitcherVisibility.spec.ts`. Wrote failing tests first, then implemented. **53/53** composable tests + **7/7** `OrganizationContextBar` tests pass; typecheck clean.