### PR TITLE
ci(C7 2a): compose-smoke lane + app healthcheck (CP-11)

### DIFF
--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -42,11 +42,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      # Compose reads SECRET (${SECRET:?...}) even for `config`, so seed a .env
-      # at the repo root (where the compose files' `env_file: ../../.env`
-      # resolves to). A throwaway secret is fine — this stack is torn down.
-      - name: Seed .env with a throwaway SECRET
-        run: echo "SECRET=$(openssl rand -hex 32)" > .env
+      # Compose interpolates ${SECRET:?...} even for `config`. Interpolation
+      # variables come from the shell environment and the project-directory
+      # .env — NOT from a service's `env_file:` (that only feeds the container
+      # at runtime). Because `-f docker/compose/<file>` shifts the project dir
+      # to docker/compose/, a repo-root .env alone would be missed. So export
+      # SECRET into the job env (satisfies interpolation for every compose
+      # invocation) AND write repo-root .env (the `env_file: ../../.env` target,
+      # which must exist for `up`). Throwaway secret — the stack is torn down.
+      - name: Seed SECRET (interpolation) and .env (env_file target)
+        run: |
+          secret="$(openssl rand -hex 32)"
+          echo "SECRET=$secret" >> "$GITHUB_ENV"
+          echo "SECRET=$secret" > .env
 
       # Zero-cost lint of every documented file combination first (Mattermost
       # pattern) — a broken include/merge fails here before anything is pulled.

--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -1,0 +1,144 @@
+# ==============================================================================
+# Compose / docker smoke (install-onboarding testing-strategy §2a)
+# ==============================================================================
+# The #1 self-host funnel: the documented `docker compose up` and `docker run`
+# quick starts. Two jobs:
+#
+#   compose-smoke      (PR on docker/** changes + weekly cron): lint every
+#                      documented compose combo with `config -q`, then bring up
+#                      the simple stack with `--wait` (the app healthcheck is the
+#                      readiness assertion) and run the shared proof-of-life.
+#   docker-run-readme  (weekly cron + manual): the README `docker run` quick
+#                      start, verbatim, against the exact published tag the
+#                      README shows — the only thing that catches "the docs
+#                      point at a broken/missing tag".
+#
+# Reference shape: Supabase smoke-tests its self-host compose with published
+# pinned images on every docker/** PR; Sentry runs its install path on a cron.
+# ==============================================================================
+name: Compose smoke
+
+on:
+  pull_request:
+    paths:
+      - 'docker-compose.yml'
+      - 'docker/compose/**'
+      - 'scripts/test-install/proof-of-life.sh'
+      - '.github/workflows/compose-smoke.yml'
+  schedule:
+    # Weekly: catches published-image / registry / tag rot with no commit.
+    - cron: '41 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  compose-smoke:
+    name: docker compose up (simple)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # Compose reads SECRET (${SECRET:?...}) even for `config`, so seed a .env
+      # at the repo root (where the compose files' `env_file: ../../.env`
+      # resolves to). A throwaway secret is fine — this stack is torn down.
+      - name: Seed .env with a throwaway SECRET
+        run: echo "SECRET=$(openssl rand -hex 32)" > .env
+
+      # Zero-cost lint of every documented file combination first (Mattermost
+      # pattern) — a broken include/merge fails here before anything is pulled.
+      - name: Lint all documented compose combos (config -q)
+        run: |
+          set -x
+          docker compose config -q
+          docker compose -f docker/compose/docker-compose.simple.yml config -q
+          docker compose -f docker/compose/docker-compose.full.yml config -q
+          docker compose \
+            -f docker/compose/docker-compose.simple.yml \
+            -f docker/compose/docker-compose.mailpit.yml config -q
+
+      # CP-5 workaround: the bind-mounted ./data must be writable by the image's
+      # appuser (uid 1001) or the container can't write to /app/data. The real
+      # fix (named volume or documented chown) is C5; here we just make the lane
+      # honest without blocking on it.
+      - name: Prepare writable data dir (CP-5 workaround, pending C5)
+        run: |
+          mkdir -p data
+          sudo chown -R 1001:1001 data
+
+      - name: Bring up the simple stack (--wait on app healthcheck)
+        run: |
+          docker compose -f docker/compose/docker-compose.simple.yml \
+            up -d --wait --wait-timeout 180 --quiet-pull --renew-anon-volumes
+
+      - name: Proof of life
+        run: ./scripts/test-install/proof-of-life.sh http://127.0.0.1:3000
+
+      - name: Dump logs on failure
+        if: failure()
+        run: docker compose -f docker/compose/docker-compose.simple.yml logs --no-color
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker/compose/docker-compose.simple.yml down -v
+
+  docker-run-readme:
+    name: docker run (README verbatim)
+    # Heavy (pulls the full published image); it guards the published quick
+    # start against tag/registry rot, not per-PR compose wiring — so cron only.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # Read the exact image tag the README documents so this test can never
+      # drift from the docs (the whole point — testing the documented path).
+      - name: Resolve README docker-run image tag
+        id: tag
+        run: |
+          tag="$(grep -oE 'onetimesecret/onetimesecret:v[0-9]+\.[0-9]+\.[0-9]+' README.md | head -n1)"
+          if [[ -z "$tag" ]]; then
+            echo "::error::could not find a pinned onetimesecret/onetimesecret:vX.Y.Z tag in README.md"
+            exit 1
+          fi
+          echo "image=$tag" >> "$GITHUB_OUTPUT"
+          echo "Testing documented image: $tag"
+
+      # The README quick start, run verbatim (the two `docker run` commands and
+      # the secret-file step from README §Quick start).
+      - name: Start Redis (README step 1)
+        run: docker run -p 6379:6379 -d redis:bookworm
+
+      - name: Generate persistent secret key (README step 2)
+        run: |
+          openssl rand -hex 32 > .ots_secret
+          chmod 600 .ots_secret
+
+      - name: Run the app container (README step 2, verbatim flags)
+        env:
+          OTS_IMAGE: ${{ steps.tag.outputs.image }}
+        run: |
+          docker run -p 3000:3000 -d \
+            --add-host=host.docker.internal:host-gateway \
+            -e REDIS_URL=redis://host.docker.internal:6379/0 \
+            -e SECRET="$(cat .ots_secret)" \
+            -e HOST=localhost:3000 \
+            -e AUTH_REQUIRED=false \
+            -e SSL=false \
+            "$OTS_IMAGE"
+
+      - name: Proof of life
+        run: ./scripts/test-install/proof-of-life.sh http://127.0.0.1:3000
+
+      - name: Dump container logs on failure
+        if: failure()
+        env:
+          OTS_IMAGE: ${{ steps.tag.outputs.image }}
+        run: |
+          docker ps -a
+          docker logs "$(docker ps -aq --filter "ancestor=$OTS_IMAGE" | head -n1)" || true

--- a/docker/compose/docker-compose.full.yml
+++ b/docker/compose/docker-compose.full.yml
@@ -5,7 +5,7 @@
 # background workers, and scheduler.
 #
 # App uses pre-built images from Docker Hub. To pin a version:
-#   OTS_IMAGE_TAG=v0.24.6 docker compose up
+#   OTS_IMAGE_TAG=v0.25.11 docker compose up
 #
 # Caddy proxy requires building (plugins: ratelimit, security, transform-encoder):
 #   docker compose build proxy
@@ -26,7 +26,7 @@ services:
     container_name: onetime-proxy
     depends_on:
       app:
-        condition: service_started
+        condition: service_healthy
     environment:
       - DOMAIN=${DOMAIN:-localhost}
       - CERTIFICATE_EMAIL=${CERTIFICATE_EMAIL:-admin@example.com}
@@ -86,6 +86,14 @@ services:
     restart: unless-stopped
     volumes:
       - ../../data:/app/data
+    # Readiness contract (see docker-compose.simple.yml for rationale). Lets the
+    # proxy depend on the app being healthy, not just started.
+    healthcheck:
+      test: ['CMD', 'bin/healthcheck.sh']
+      interval: 10s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
 
   maindb:
     image: valkey/valkey:8.1-bookworm@sha256:fea8b3e67b15729d4bb70589eb03367bab9ad1ee89c876f54327fc7c6e618571

--- a/docker/compose/docker-compose.simple.yml
+++ b/docker/compose/docker-compose.simple.yml
@@ -5,7 +5,7 @@
 # No reverse proxy, no message queue, no workers.
 #
 # Uses pre-built images from Docker Hub. To pin a version:
-#   OTS_IMAGE_TAG=v0.24.6 docker compose up
+#   OTS_IMAGE_TAG=v0.25.11 docker compose up
 #
 # To build from source instead, use Docker Bake:
 #   docker buildx bake -f docker/bake.hcl main
@@ -43,6 +43,17 @@ services:
     restart: unless-stopped
     volumes:
       - ../../data:/app/data
+    # Explicit readiness contract so `docker compose up --wait` blocks until the
+    # web app is actually serving (not merely "running"). Reuses the image's
+    # role-aware bin/healthcheck.sh (web role -> curl /health/advanced, then
+    # /health); the shorter interval/start_period here just polls faster than
+    # the image's baked-in HEALTHCHECK for quicker readiness in CI and local up.
+    healthcheck:
+      test: ['CMD', 'bin/healthcheck.sh']
+      interval: 10s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
 
   maindb:
     image: valkey/valkey:8.1-bookworm@sha256:fea8b3e67b15729d4bb70589eb03367bab9ad1ee89c876f54327fc7c6e618571


### PR DESCRIPTION
## What

C7 slice **2a** (install-onboarding [testing-strategy §2a](docs/specs/install-onboarding/install-onboarding-testing-strategy.md)) — guards the #1 self-host funnel.

> **Stacked on #3711** (uses `scripts/test-install/proof-of-life.sh` from that PR). Base is `feature/c7-clean-room`; merge #3711 first, or this retargets to `integration/onboarding` after.

### App healthcheck (CP-11) — `docker-compose.{simple,full}.yml`
The `app` service had no compose `healthcheck:`, so `docker compose up --wait` couldn't use it as a readiness gate. Added one reusing the image's role-aware `bin/healthcheck.sh` (web role → `/health/advanced` then `/health`), tuned for faster `--wait` polling. Upgraded full's proxy `depends_on: app` to `service_healthy`.

### `compose-smoke.yml`
- **`compose-smoke`** (PR on `docker/**` + weekly cron): `config -q` on every documented combo (root / simple / full / simple+mailpit), then `up` the simple stack with `--wait` (the healthcheck is the assertion) + shared `proof-of-life.sh`. Includes a CP-5 data-uid (1001) workaround — the real fix is a named volume/chown in C5.
- **`docker-run-readme`** (cron + manual, not per-PR): the README `docker run` quick start run **verbatim** against the exact pinned tag *scraped from README* so it can't drift from the docs.

## Verification
YAML valid, `config -q` parses clean client-side. The `up --wait` + proof-of-life path can only be proven on a runner with Docker — watching this PR's Actions is the point. Known risk being tested: whether the published `:latest` image goes healthy under the simple stack in CI (data perms / boot config).