### PR TITLE
ci(C7 2b): installer matrix + run.sh container harness

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -1,0 +1,85 @@
+# ==============================================================================
+# Installer matrix (install-onboarding testing-strategy §2b)
+# ==============================================================================
+# Runs the Tier-1 clean-room harness (scripts/test-install/run.sh) in CI — the
+# SAME artifact a maintainer runs locally, so local and CI cannot diverge. Each
+# lane installs a documented path from zero inside a pinned base image:
+#
+#   baremetal  ruby:3.4.9-slim  — install.sh init succeeds + is idempotent
+#   posix      ruby:3.4.9-slim, empty locale — the fresh-server locale repro
+#   ruby-old   ruby:3.3-slim    — install.sh init MUST fail with the version gate
+#
+# Plus a cheap bash-3.2 syntax gate (macOS ships bash 3.2; install.sh is the
+# bare-metal entrypoint that must parse there). Path-filtered + weekly cron.
+#
+# Reference: tailscale runs its installer in ~22 distro containers on a daily
+# cron + path-filtered PRs; chezmoi tests the actual piped invocation.
+# ==============================================================================
+name: Installer matrix
+
+on:
+  pull_request:
+    paths:
+      - 'install.sh'
+      - 'install-dev.sh'
+      - 'install-test.sh'
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '.ruby-version'
+      - '.node-version'
+      - 'etc/defaults/**'
+      - 'scripts/test-install/run.sh'
+      - '.github/workflows/installer.yml'
+  schedule:
+    - cron: '53 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  clean-room:
+    name: "install.sh from zero (${{ matrix.lane }})"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        lane: [baremetal, posix, ruby-old]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # Docker is preinstalled on ubuntu runners; the harness does the rest
+      # (pinned image + git archive HEAD, no host state leaks in).
+      - name: Run clean-room lane
+        env:
+          LANE: ${{ matrix.lane }}
+        run: ./scripts/test-install/run.sh --lane "$LANE"
+
+  bash-32-gate:
+    name: bash 3.2 syntax gate (macOS parity)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # macOS ships bash 3.2. The bare-metal entrypoint and the harness scripts
+      # must at least PARSE there (catches bashisms newer than 3.2). install-dev.sh
+      # is intentionally excluded — it requires bash 4+ by design.
+      - name: Parse install scripts under bash 3.2
+        run: |
+          docker run --rm -i -v "$PWD:/src" -w /src bash:3.2 sh -c '
+            set -e
+            for f in install.sh install-test.sh \
+                     scripts/test-install/run.sh \
+                     scripts/test-install/proof-of-life.sh \
+                     scripts/test-install/check-docs-commands.sh; do
+              echo "bash -n $f"
+              bash -n "$f"
+            done
+            echo "all scripts parse under bash 3.2"
+          '

--- a/scripts/test-install/run.sh
+++ b/scripts/test-install/run.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# scripts/test-install/run.sh
+#
+# Tier-1 clean-room harness (install-onboarding testing-strategy §2). Runs a
+# documented install path from ZERO inside a pinned base image, so a maintainer
+# can experience a fresh install from a poisoned laptop, and CI runs the exact
+# same artifact (installer.yml — testing-strategy §2b).
+#
+# Each lane = one `docker run --rm` against a PINNED image. The repo is copied
+# in with `git archive HEAD` (never a writable bind-mount — that would leak host
+# state, caches, and your working tree into the "clean" room).
+#
+# Lanes:
+#   baremetal   ruby:3.4.9-slim — the documented floor. install.sh init must
+#               succeed, produce a .env with a real SECRET, and be idempotent.
+#   ruby-old    ruby:3.3-slim   — install.sh init must FAIL with a clear
+#               "need exactly 3.4.9" message (an asserted-error lane; NF-5).
+#   posix       ruby:3.4.9-slim with an empty locale — the container default IS
+#               POSIX, which is the fresh-server repro for the old locale crash
+#               (must now pass; C3 fixed it). We assert LANG stays unset.
+#
+# Usage:
+#   scripts/test-install/run.sh --lane baremetal
+#   scripts/test-install/run.sh --lane ruby-old
+#   scripts/test-install/run.sh --lane posix
+#   scripts/test-install/run.sh --lane all
+#
+# Requires a working Docker daemon. Not run by the fresh-clone lane (that one
+# needs no container); this is the installer-matrix harness.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+LANE="baremetal"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --lane) LANE="${2:?--lane needs a value}"; shift 2 ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 64 ;;
+  esac
+done
+
+# Pinned base images per lane (exact patch for the Ruby-version gate).
+IMAGE_BAREMETAL="ruby:3.4.9-slim"
+IMAGE_RUBY_OLD="ruby:3.3-slim"
+
+# Toolchain setup mirrored from docker/base.dockerfile so the container has
+# exactly what a documented bare-metal install needs — no more, no less.
+# (build deps for pg/sqlite3/argon2/bcrypt/puma, Node 22, pnpm, redis, procps.)
+read -r -d '' SETUP_TOOLCHAIN <<'SETUP' || true
+  set -eux
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update
+  apt-get install -y --no-install-recommends \
+    build-essential libssl-dev libffi-dev libyaml-dev libsqlite3-dev \
+    libpq-dev libsodium23 pkg-config git curl ca-certificates \
+    python3 procps redis-server
+  # Node 22 (matches .node-version) via NodeSource; pnpm pinned to packageManager.
+  curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+  apt-get install -y --no-install-recommends nodejs
+  npm install -g pnpm@11.10.0
+  redis-server --daemonize yes
+  node --version; ruby --version; pnpm --version
+SETUP
+
+# Post-conditions asserted after a successful install (behavior, not exit code
+# alone): a .env exists with a >=32-char SECRET, and a second run is clean.
+read -r -d '' ASSERT_AND_IDEMPOTENT <<'ASSERT' || true
+  echo "--- post-conditions ---"
+  test -s .env || { echo "FAIL: .env missing/empty"; exit 1; }
+  grep -qE '^SECRET=.{32,}' .env || { echo "FAIL: .env has no >=32-char SECRET"; exit 1; }
+  echo "OK: .env present with a real SECRET"
+  echo "--- idempotency re-run ---"
+  ./install.sh init
+  echo "OK: second install.sh init succeeded (idempotent)"
+ASSERT
+
+# run_in_image <image> <lane-label> <inner-script>
+# Copies HEAD into the container via git archive and runs the inner script.
+run_in_image() {
+  local image="$1" label="$2" inner="$3"
+  echo "==================================================================="
+  echo "  lane: $label   image: $image"
+  echo "==================================================================="
+  git archive --format=tar HEAD | docker run --rm -i \
+    -e DEBIAN_FRONTEND=noninteractive \
+    "$image" bash -c '
+      set -euo pipefail
+      mkdir -p /src && cd /src && tar -x
+      '"$inner"'
+    '
+}
+
+lane_baremetal() {
+  run_in_image "$IMAGE_BAREMETAL" "baremetal" "
+    $SETUP_TOOLCHAIN
+    echo '--- install.sh init (documented floor) ---'
+    ./install.sh init
+    $ASSERT_AND_IDEMPOTENT
+  "
+}
+
+lane_posix() {
+  # Explicitly assert the environment is a POSIX/empty locale — the fresh-server
+  # condition that used to crash rake ots:secrets / puma boot.
+  run_in_image "$IMAGE_BAREMETAL" "posix-locale" "
+    unset LANG LC_ALL LANGUAGE || true
+    echo \"locale is: LANG='\${LANG:-}' LC_ALL='\${LC_ALL:-}'\"
+    [ -z \"\${LANG:-}\" ] || { echo 'FAIL: expected empty LANG'; exit 1; }
+    $SETUP_TOOLCHAIN
+    echo '--- install.sh init under POSIX locale ---'
+    ./install.sh init
+    $ASSERT_AND_IDEMPOTENT
+  "
+}
+
+lane_ruby_old() {
+  # Asserted-error lane: install.sh init MUST fail fast with the exact-match
+  # Ruby gate (NF-5). A clean, actionable failure is the pass condition here.
+  echo "==================================================================="
+  echo "  lane: ruby-old (expect a clear version-gate failure)   image: $IMAGE_RUBY_OLD"
+  echo "==================================================================="
+  local out status
+  out="$(git archive --format=tar HEAD | docker run --rm -i "$IMAGE_RUBY_OLD" bash -c '
+    set -uo pipefail
+    mkdir -p /src && cd /src && tar -x
+    ./install.sh init
+  ' 2>&1)" && status=0 || status=$?
+  echo "$out"
+  if [[ "$status" -eq 0 ]]; then
+    echo "FAIL: install.sh init succeeded on old Ruby — the version gate did not fire"
+    exit 1
+  fi
+  if echo "$out" | grep -qiE 'need exactly 3\.4\.9|version mismatch|too old'; then
+    echo "OK: install.sh init failed with a clear Ruby-version message (exit $status)"
+  else
+    echo "FAIL: install.sh init failed (exit $status) but not with the expected version message"
+    exit 1
+  fi
+}
+
+case "$LANE" in
+  baremetal) lane_baremetal ;;
+  posix)     lane_posix ;;
+  ruby-old)  lane_ruby_old ;;
+  all)       lane_baremetal; lane_posix; lane_ruby_old ;;
+  *) echo "unknown lane: $LANE (want: baremetal|posix|ruby-old|all)" >&2; exit 64 ;;
+esac
+
+echo ""
+echo "clean-room lane(s) passed: $LANE"


### PR DESCRIPTION
## What

C7 slice **2b** (install-onboarding [testing-strategy §2/§2b](docs/specs/install-onboarding/install-onboarding-testing-strategy.md)) — the Tier-1 clean-room harness. A maintainer runs it from a poisoned laptop; CI runs the same artifact.

Independent of 2a (#3712); based directly on `integration/onboarding` (which already has `proof-of-life.sh` from #3711).

### `scripts/test-install/run.sh`
Each lane = one `docker run --rm` against a pinned base image, repo copied in via `git archive HEAD` (no host-state leak). Toolchain mirrors `docker/base.dockerfile` (build-essential + pg/sqlite3/ssl/yaml headers, Node 22 via NodeSource, pnpm 11.10.0, redis).

| Lane | Image | Assertion |
|---|---|---|
| `baremetal` | `ruby:3.4.9-slim` | `install.sh init` succeeds → `.env` has a real SECRET → second run idempotent |
| `posix` | `ruby:3.4.9-slim`, empty locale | the fresh-server locale repro must **pass** (C3 fixed the `Encoding` crash) |
| `ruby-old` | `ruby:3.3-slim` | `install.sh init` **must fail** with the exact-3.4.9 gate (NF-5) — asserted-error lane |

### `installer.yml`
Matrix over the three lanes (path-filtered on `install*.sh`/lockfiles/version-files + weekly cron) + a bash-3.2 syntax gate (macOS parity; `install-dev.sh` excluded — needs bash 4+).

## Verification
`run.sh` shellcheck-clean, `bash -n` clean, `--help` works. The container lanes can only be proven on a runner with Docker — watching this PR's Actions. Known first-run risks: the `ruby:3.4.9-slim` exact tag existing, NodeSource/apt availability, and native-gem build deps — all diagnosable from lane logs.

## Deferred (documented follow-ups)
macOS runner lane, `docker diff` footprint assertion, and an `install-dev.sh` dev lane — noted in the harness header.