### PR TITLE
* Unify branded heading typography and harden border_radius reads

### DIFF
--- a/src/apps/secret/components/branded/BaseSecretDisplay.vue
+++ b/src/apps/secret/components/branded/BaseSecretDisplay.vue
@@ -12,8 +12,11 @@
    * @prop defaultTitle - Fallback title when branding is unavailable
    * @prop instructions - Optional pre-reveal instructions from domain branding
    * @prop domainBranding - Domain-specific styling configuration
-   * @prop headingClass - Heading font class (heading_font); the h2 falls back
-   *   to fontClass when absent so headings track the body font by default
+   * @prop headingClass - Resolved heading font token (the heading_font-
+   *   backfilled-by-font_family ladder lives in resolveHeadingFontClass);
+   *   required so a missing binding is a type error, not a silent body-font
+   *   heading. Callers scope the resolution themselves — the dashboard
+   *   preview resolves the domain being edited, not the page identity.
    *
    * @slot logo - Domain logo or fallback icon
    * @slot content - Main content area (confirmation form or secret content)
@@ -30,7 +33,7 @@
     domainBranding: BrandSettings;
     cornerClass: string;
     fontClass: string;
-    headingClass?: string;
+    headingClass: string;
     defaultTitle?: string;
     previewI18n?: Composer;
     isRevealed?: boolean;
@@ -102,7 +105,7 @@
       <div class="flex-1 text-center sm:text-left">
         <div class="relative min-h-[5.5rem] sm:min-h-24">
           <h2
-            :class="[cornerClass, headingClass || fontClass]"
+            :class="[cornerClass, headingClass]"
             class="mb-2 text-base font-medium leading-normal
               text-gray-900 dark:text-gray-200 sm:mb-3 sm:text-xl">
             <slot name="title">

--- a/src/apps/secret/components/branded/BrandedHero.vue
+++ b/src/apps/secret/components/branded/BrandedHero.vue
@@ -1,0 +1,82 @@
+<!-- src/apps/secret/components/branded/BrandedHero.vue -->
+
+<script setup lang="ts">
+  /**
+   * THE branded hero: brand logo + headline + subline, stacked and centered,
+   * shared by every custom-domain surface that opens with the brand identity.
+   * The heading binds headingFontClass and the body binds fontFamilyClass —
+   * reading the store here (not via props) means that within the hero the
+   * heading token is bound once and call sites cannot rebind it. (Surfaces
+   * that preview an arbitrary domain, like the dashboard's SecretPreview,
+   * intentionally resolve their own tokens instead of using this component.)
+   * Do not fork this markup into page-local variants.
+   *
+   * @prop title - Headline text (already translated)
+   * @prop subtitle - Subline text (already translated)
+   * @prop logoLinkTo - When set, wraps the logo in a router-link to this route
+   */
+  import { useProductIdentity } from '@/shared/stores/identityStore';
+  import { storeToRefs } from 'pinia';
+  import { ref } from 'vue';
+  import { RouterLink } from 'vue-router';
+
+  defineProps<{
+    title: string;
+    subtitle: string;
+    logoLinkTo?: string;
+  }>();
+
+  const identityStore = useProductIdentity();
+  const { logoUri, displayName, cornerClass, headingFontClass, fontFamilyClass } =
+    storeToRefs(identityStore);
+
+  // Handle logo 404 errors gracefully
+  const imageError = ref(false);
+  const handleImageError = () => {
+    imageError.value = true;
+  };
+</script>
+
+<template>
+  <div
+    :class="fontFamilyClass"
+    class="text-center">
+    <!-- Logo with error handling - hides if 404. No placeholder: a broken or
+         absent logo must not render a generic gray icon on a branded page. -->
+    <!--
+      Sizing: a fixed height with `w-auto max-w-full` lets wide, rectangular
+      logos (common when they include the company name) use the full column
+      width instead of being squeezed by a narrow max-width and rendering
+      comically small.
+
+      Corner radius: the logo reflects the brand radius (cornerClass) — a
+      product requirement. The browser clamps `--radius-brand` to half the
+      image's shorter side, so a pill/full radius rounds the ends rather than
+      overflowing.
+    -->
+    <div
+      v-if="logoUri && !imageError"
+      class="mb-8 flex justify-center">
+      <!-- One <img>, conditionally wrapped: forked link/bare copies of the
+           logo markup drift independently (only one branch gets a fix). -->
+      <component
+        :is="logoLinkTo ? RouterLink : 'span'"
+        :to="logoLinkTo">
+        <img
+          :src="logoUri"
+          :class="cornerClass"
+          class="h-16 w-auto max-w-full object-contain sm:h-20"
+          :alt="displayName"
+          @error="handleImageError" />
+      </component>
+    </div>
+    <h1
+      :class="headingFontClass"
+      class="text-2xl font-semibold text-gray-900 dark:text-white">
+      {{ title }}
+    </h1>
+    <p class="mt-2 text-gray-600 dark:text-gray-300">
+      {{ subtitle }}
+    </p>
+  </div>
+</template>

--- a/src/apps/secret/components/branded/BrandedHero.vue
+++ b/src/apps/secret/components/branded/BrandedHero.vue
@@ -11,8 +11,13 @@
    * intentionally resolve their own tokens instead of using this component.)
    * Do not fork this markup into page-local variants.
    *
-   * @prop title - Headline text (already translated)
-   * @prop subtitle - Subline text (already translated)
+   * Title and subtitle are optional: omit both for a logo-only opener. The
+   * reveal/confirm case does this — it renders the brand logo at the top like
+   * every other surface but keeps its own "You have a message" heading and
+   * instructions, so the hero here must not duplicate them.
+   *
+   * @prop title - Headline text (already translated); omit for logo-only
+   * @prop subtitle - Subline text (already translated); omit for logo-only
    * @prop logoLinkTo - When set, wraps the logo in a router-link to this route
    */
   import { useProductIdentity } from '@/shared/stores/identityStore';
@@ -21,8 +26,8 @@
   import { RouterLink } from 'vue-router';
 
   defineProps<{
-    title: string;
-    subtitle: string;
+    title?: string;
+    subtitle?: string;
     logoLinkTo?: string;
   }>();
 
@@ -71,11 +76,14 @@
       </component>
     </div>
     <h1
+      v-if="title"
       :class="headingFontClass"
       class="text-2xl font-semibold text-gray-900 dark:text-white">
       {{ title }}
     </h1>
-    <p class="mt-2 text-gray-600 dark:text-gray-300">
+    <p
+      v-if="subtitle"
+      class="mt-2 text-gray-600 dark:text-gray-300">
       {{ subtitle }}
     </p>
   </div>

--- a/src/apps/secret/components/branded/SecretConfirmationForm.vue
+++ b/src/apps/secret/components/branded/SecretConfirmationForm.vue
@@ -41,18 +41,7 @@
   const fontFamilyClass = computed(() => productIdentity.fontFamilyClass);
   const headingFontClass = computed(() => productIdentity.headingFontClass);
 
-  const hasImageError = ref(false);
-
-  const handleImageError = () => {
-    hasImageError.value = true;
-  };
-
   const buttonText = computed(() => props.isSubmitting ? t('web.COMMON.submitting') : t('web.COMMON.click_to_continue'));
-  // Brand logo via the backend-computed URL (built with the domain's public
-  // extid). A client-side `/imagine/${domainId}/logo.png` path 404s — the
-  // internal domainId isn't the extid — tripping @error and showing the
-  // placeholder lock even when a logo is configured (see SecretDisplayCase).
-  const logoImage = computed(() => productIdentity.logoUri);
 </script>
 
 <template>
@@ -63,44 +52,6 @@
     :corner-class="cornerClass"
     :font-class="fontFamilyClass"
     :heading-class="headingFontClass">
-    <template #logo>
-      <div class="relative mx-auto sm:mx-0">
-        <div :class="[cornerClass, 'size-14 overflow-hidden sm:size-16']">
-          <!-- Background container with matching corner style -->
-          <div
-            :class="[
-              cornerClass,
-              'absolute inset-0 flex items-center justify-center bg-gray-100 dark:bg-gray-700',
-              { hidden: logoImage && !hasImageError },
-            ]">
-            <!-- Default lock icon -->
-            <svg
-              v-if="!logoImage || hasImageError"
-              class="size-8 text-gray-400 dark:text-gray-500"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              aria-hidden="true">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-            </svg>
-          </div>
-
-          <!-- Logo -->
-          <img
-            v-if="logoImage && !hasImageError"
-            :src="logoImage"
-            :alt="t('web.layout.brand_logo')"
-            class="size-full object-contain"
-            :class="cornerClass"
-            @error="handleImageError" />
-        </div>
-      </div>
-    </template>
-
     <template #content>
       <div
         class="flex items-center text-gray-400 dark:text-gray-500"

--- a/src/apps/secret/components/branded/SecretDisplayCase.vue
+++ b/src/apps/secret/components/branded/SecretDisplayCase.vue
@@ -6,7 +6,7 @@
   import type { Secret, SecretDetails } from '@/schemas/shapes/v3/secret';
   import { useClipboard } from '@/shared/composables/useClipboard';
   import { useProductIdentity } from '@/shared/stores/identityStore';
-  import { ref, computed } from 'vue';
+  import { computed } from 'vue';
   import { useI18n } from 'vue-i18n';
 
   // Default brand settings for when no custom branding is configured
@@ -43,10 +43,8 @@
       props.submissionStatus?.status === 'success',
   }));
 
-  const hasImageError = ref(false);
   const { isCopied, copyToClipboard } = useClipboard();
 
-  const logoAriaLabel = hasImageError.value ? t('web.branding.default_logo_icon') : t('web.layout.brand_logo')
   const copySecretContent = async () => {
     if (props.record?.secret_value === undefined) {
       return;
@@ -63,16 +61,7 @@
     setTimeout(() => announcement.remove(), 1000);
   };
 
-  const handleImageError = () => {
-    hasImageError.value = true;
-  };
   const isCopiedText = computed(() => isCopied ? t('web.STATUS.copied') : t('web.LABELS.copy_to_clipboard') );
-
-  // Brand logo for the reveal card. Use the backend-computed URL (built with
-  // the domain's public extid), not a client-side path from the internal
-  // domainId — the latter 404s, tripping @error and showing the placeholder
-  // lock icon even when a logo is configured. Null (no logo) → placeholder.
-  const logoImage = computed(() => productIdentity.logoUri);
 </script>
 
 <template>
@@ -128,43 +117,6 @@
         </div>
       </div>
     </div>
-
-    <template #logo>
-      <!-- Brand Icon -->
-      <div class="relative mx-auto sm:mx-0">
-        <router-link to="/">
-          <div
-            :class="[cornerClass]"
-            class="flex size-14 items-center justify-center bg-gray-100 sm:size-16 dark:bg-gray-700"
-            role="img"
-            :aria-label="logoAriaLabel">
-            <!-- Default lock icon -->
-            <svg
-              v-if="!logoImage || hasImageError"
-              class="size-8 text-gray-400 dark:text-gray-500"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              aria-hidden="true">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-            </svg>
-
-            <!-- Logo -->
-            <img
-              v-if="logoImage && !hasImageError"
-              :src="logoImage"
-              :alt="t('web.layout.brand_logo')"
-              class="size-16 object-contain"
-              :class="[cornerClass]"
-              @error="handleImageError" />
-          </div>
-        </router-link>
-      </div>
-    </template>
 
     <template #content>
       <div class="relative size-full p-0">

--- a/src/apps/secret/components/layout/BrandedMastHead.vue
+++ b/src/apps/secret/components/layout/BrandedMastHead.vue
@@ -2,19 +2,17 @@
 
 <script setup lang="ts">
   import { useI18n } from 'vue-i18n';
-  import { useProductIdentity } from '@/shared/stores/identityStore';
+  import BrandedHero from '@/apps/secret/components/branded/BrandedHero.vue';
   import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import { isSsoEnabled, isOrgsSsoEnabled } from '@/utils/features';
   import type { LayoutProps } from '@/types/ui/layouts';
-  import { ref, computed } from 'vue';
+  import { computed } from 'vue';
   import { storeToRefs } from 'pinia';
 
   const { t } = useI18n();
 
-  const productIdentity = useProductIdentity();
   const bootstrapStore = useBootstrapStore();
   const { authentication, homepage_config } = storeToRefs(bootstrapStore);
-  const imageError = ref(false);
 
   /**
    * Per-domain gate for the auth nav links. Defaults to disabled — the links
@@ -59,10 +57,6 @@
     && authentication.value?.signup === true
     && domainSignupEnabled.value
   );
-
-  const handleImageError = () => {
-    imageError.value = true;
-  };
 
   interface Props extends LayoutProps {
     headertext: string;
@@ -113,60 +107,10 @@
     </nav>
 
     <div class="container mx-auto max-w-2xl px-4">
-      <div class="flex flex-col items-center gap-8">
-        <!-- Logo Section -->
-        <div
-          class="relative"
-          role="region"
-          :aria-label="t('web.layout.brand_logo')">
-          <router-link to="/">
-            <div
-              :class="[
-                productIdentity.cornerClass,
-                'flex size-16 items-center justify-center overflow-hidden bg-gray-100 transition-all duration-200 dark:bg-gray-800',
-              ]">
-              <img
-                v-if="productIdentity.logoUri && !imageError"
-                :src="productIdentity.logoUri"
-                :alt="productIdentity.displayName"
-                class="size-16 object-contain"
-                :class="productIdentity.cornerClass"
-                @error="handleImageError" />
-              <!-- Updated placeholder icon to match SecretPreview -->
-              <svg
-                v-else
-                class="size-8 text-gray-400 dark:text-gray-500"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24">
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-              </svg>
-            </div>
-          </router-link>
-        </div>
-
-        <!-- Content Section -->
-        <div
-          class="space-y-3 text-center"
-          :class="[
-            productIdentity.fontFamilyClass,
-            productIdentity.cornerClass,
-          ]">
-          <h1
-            class="text-2xl font-medium text-gray-900 dark:text-gray-100 sm:text-3xl"
-            :class="productIdentity.fontFamilyClass">
-            {{ headertext }}
-          </h1>
-          <p
-            class="mx-auto max-w-md text-sm text-gray-600 dark:text-gray-300 sm:text-base">
-            {{ subtext }}
-          </p>
-        </div>
-      </div>
+      <BrandedHero
+        :title="headertext"
+        :subtitle="subtext"
+        logo-link-to="/" />
     </div>
   </div>
 </template>

--- a/src/apps/secret/conceal/BrandedHomepage.vue
+++ b/src/apps/secret/conceal/BrandedHomepage.vue
@@ -1,6 +1,7 @@
 <!-- src/apps/secret/conceal/BrandedHomepage.vue -->
 
 <script setup lang="ts">
+  import BrandedHero from '@/apps/secret/components/branded/BrandedHero.vue';
   import SecretForm from '@/apps/secret/components/form/SecretForm.vue';
   import IncomingSecretFormBody from '@/apps/secret/components/incoming/IncomingSecretFormBody.vue';
   import OIcon from '@/shared/components/icons/OIcon.vue';
@@ -20,11 +21,8 @@
     homepageSecretsMode,
     primaryColor,
     cornerClass,
-    headingFontClass,
     fontFamilyClass,
     buttonTextLight,
-    logoUri,
-    displayName,
   } = storeToRefs(identityStore);
 
   const incomingMode = computed(
@@ -99,51 +97,16 @@
       ? t('web.homepage.deliver_sensitive_information_directly_and_securely')
       : t('web.homepage.send_sensitive_information_that_can_only_be_viewed_once')
   );
-
-  // Handle logo 404 errors gracefully
-  const imageError = ref(false);
-  const handleImageError = () => {
-    imageError.value = true;
-  };
 </script>
 
 <template>
   <div
     :class="fontFamilyClass"
     class="relative mx-auto w-full max-w-xl px-4">
-    <!-- Logo + Taglines (centered brand hero for custom domains) -->
-    <div class="mb-8 text-center">
-      <!-- Logo with error handling - hides if 404 -->
-      <!--
-        Sizing: a fixed height with `w-auto max-w-full` lets wide, rectangular
-        logos (common when they include the company name) use the full column
-        width instead of being squeezed by a narrow max-width and rendering
-        comically small.
-
-        Corner radius: the logo reflects the brand radius (cornerClass) — a
-        product requirement. The browser clamps `--radius-brand` to half the
-        image's shorter side, so a pill/full radius rounds the ends rather than
-        overflowing.
-      -->
-      <div
-        v-if="logoUri && !imageError"
-        class="mb-8 flex justify-center">
-        <img
-          :src="logoUri"
-          :class="cornerClass"
-          class="h-16 w-auto max-w-full object-contain sm:h-20"
-          :alt="displayName"
-          @error="handleImageError" />
-      </div>
-      <h1
-        :class="headingFontClass"
-        class="text-2xl font-semibold text-gray-900 dark:text-white">
-        {{ headline }}
-      </h1>
-      <p class="mt-2 text-gray-600 dark:text-gray-300">
-        {{ subline }}
-      </p>
-    </div>
+    <BrandedHero
+      class="mb-8"
+      :title="headline"
+      :subtitle="subline" />
 
     <!--
       Custom Domain Homepage (branded landing for self-hosted workspaces)

--- a/src/apps/secret/reveal/branded/ShowSecret.vue
+++ b/src/apps/secret/reveal/branded/ShowSecret.vue
@@ -14,10 +14,11 @@
    * @see SecretDisplayCase - Displays revealed content using BaseSecretDisplay
    */
 
-  import BaseShowSecret from '@/shared/components/base/BaseShowSecret.vue';
-  import FooterAttribution from '@/apps/secret/components/layout/SecretFooterAttribution.vue';
+  import BrandedHero from '@/apps/secret/components/branded/BrandedHero.vue';
   import SecretConfirmationForm from '@/apps/secret/components/branded/SecretConfirmationForm.vue';
   import SecretDisplayCase from '@/apps/secret/components/branded/SecretDisplayCase.vue';
+  import FooterAttribution from '@/apps/secret/components/layout/SecretFooterAttribution.vue';
+  import BaseShowSecret from '@/shared/components/base/BaseShowSecret.vue';
   import { useProductIdentity } from '@/shared/stores/identityStore';
   import { storeToRefs } from 'pinia';
 
@@ -44,12 +45,20 @@
     :secret-identifier="secretIdentifier"
     :branded="true"
     :site-host="siteHost"
-    class="container mx-auto mt-24 px-4">
+    class="container mx-auto px-4">
     <!--
       No #loading slot: BaseShowSecret renders its own <SecretSkeleton> for the
       secret fetch (see BaseShowSecret template). A #loading slot here never
       rendered (the base has no <slot name="loading">), so the old spinner was
       dead markup.
+
+      The brand logo is rendered INSIDE the confirmation/reveal content (stacked
+      above the card via BrandedHero), not in BaseShowSecret's #header slot.
+      #header is a separate grid row; filling it turns the base's 3-row stretch
+      grid into three occupied rows and steals the empty trailing row that
+      balances the card-to-footer gap — the footer then either glues to the card
+      or (with a 1fr override) pins to the viewport bottom. Keeping the logo in
+      the content row preserves the original, moderate footer spacing.
     -->
 
     <!-- Error slot -->
@@ -61,7 +70,12 @@
 
     <!-- Confirmation slot -->
     <template #confirmation="{ record, details, error, isLoading, onConfirm }">
-      <div :class="[cornerClass, 'mx-auto max-w-2xl space-y-20']">
+      <div :class="[cornerClass, 'mx-auto max-w-2xl']">
+        <!-- Brand logo above the case, matching homepage/create/receipt. Logo
+             only — the case owns its own "You have a message" heading. -->
+        <BrandedHero
+          logo-link-to="/"
+          class="mb-8" />
         <SecretConfirmationForm
           :secret-identifier="secretIdentifier"
           :record="record"
@@ -76,6 +90,9 @@
     <!-- Reveal slot -->
     <template #reveal="{ record, details }">
       <div class="mx-auto w-full max-w-2xl">
+        <BrandedHero
+          logo-link-to="/"
+          class="mb-8" />
         <SecretDisplayCase
           aria-labelledby="secret-heading"
           :secret-identifier="secretIdentifier"
@@ -108,15 +125,6 @@
 </template>
 
 <style scoped>
-  .logo-container {
-  transition: all 0.3s ease;
-}
-
-.logo-container img {
-  max-width: 100%;
-  height: auto;
-}
-
 :focus {
   outline: 2px solid currentColor;
   outline-offset: 2px;

--- a/src/apps/secret/reveal/branded/UnknownSecret.vue
+++ b/src/apps/secret/reveal/branded/UnknownSecret.vue
@@ -3,7 +3,10 @@
 <script setup lang="ts">
   import type { BrandSettings } from '@/schemas/shapes/v3/custom-domain';
   import BaseUnknownSecret from '@/shared/components/base/BaseUnknownSecret.vue';
-  import { fontFamilyClasses, type FontFamily } from '@/shared/utils/brand-helpers';
+  import {
+    resolveBodyFontClass,
+    resolveHeadingFontClass,
+  } from '@/shared/utils/brand-helpers';
   import { computed } from 'vue';
   import { useI18n } from 'vue-i18n';
 
@@ -16,17 +19,9 @@ const { t } = useI18n();
 
   const props = defineProps<Props>();
 
-  const fontClass = computed(() => {
-    const font = props.brandSettings?.font_family;
-    return font ? (fontFamilyClasses[font as FontFamily] ?? '') : '';
-  });
+  const fontClass = computed(() => resolveBodyFontClass(props.brandSettings));
 
-  // Heading ladder mirrors identityStore.headingFontClass:
-  // heading_font wins, font_family backfills, unset inherits.
-  const headingClass = computed(() => {
-    const font = props.brandSettings?.heading_font ?? props.brandSettings?.font_family;
-    return font ? (fontFamilyClasses[font as FontFamily] ?? '') : '';
-  });
+  const headingClass = computed(() => resolveHeadingFontClass(props.brandSettings));
 </script>
 
 <template>

--- a/src/apps/workspace/components/dashboard/SecretPreview.vue
+++ b/src/apps/workspace/components/dashboard/SecretPreview.vue
@@ -105,7 +105,7 @@ const actionButtonStyle = computed<Record<string, string>>(() => ({
          above the card, aspect-ratio-tolerant), but stays an interactive upload
          control — the preview's logo is editable, so keep the click-to-upload
          affordance and the empty-state prompt instead of hiding a missing logo. -->
-    <div class="mb-8 flex justify-center">
+    <div class="mb-3 flex justify-center pt-6">
       <div class="group relative">
         <button
           type="button"

--- a/src/apps/workspace/components/dashboard/SecretPreview.vue
+++ b/src/apps/workspace/components/dashboard/SecretPreview.vue
@@ -8,10 +8,11 @@ import ImageUploadModal from '@/shared/components/modals/ImageUploadModal.vue';
 import { useLogoImage } from '@/shared/composables/useLogoImage';
 import {
 CornerStyle,
-FontFamily,
 borderRadiusToCss,
 cornerStyleClasses,
-fontFamilyClasses
+fontFamilyClasses,
+resolveBodyFontClass,
+resolveHeadingFontClass
 } from '@/shared/utils/brand-helpers';
 import { computed, ref } from 'vue';
 import { Composer, useI18n } from 'vue-i18n';
@@ -65,18 +66,15 @@ const cornerClass = computed(() => {
   return cornerStyleClasses[style ?? CornerStyle.ROUNDED];
 });
 
-const fontFamilyClass = computed(() => {
-  const font = props.domainBranding?.font_family as FontFamily | undefined;
-  return fontFamilyClasses[font ?? FontFamily.SANS];
-});
+// The preview shows sans when the domain is unset because the dashboard page
+// font differs from the recipient page ('' would inherit the dashboard font).
+const fontFamilyClass = computed(
+  () => resolveBodyFontClass(props.domainBranding) || fontFamilyClasses.sans
+);
 
-// Mirror identityStore.headingFontClass: heading_font falls back to the body
-// font_family, so the preview heading tracks the recipient page.
-const headingFontClass = computed(() => {
-  const heading = (props.domainBranding?.heading_font ??
-    props.domainBranding?.font_family) as FontFamily | undefined;
-  return fontFamilyClasses[heading ?? FontFamily.SANS];
-});
+const headingFontClass = computed(
+  () => resolveHeadingFontClass(props.domainBranding) || fontFamilyClasses.sans
+);
 
 // Expanded vocabulary (#3646). The preview renders an arbitrary domain's
 // settings (not the editing admin's injected palette). Scope this domain's

--- a/src/apps/workspace/components/dashboard/SecretPreview.vue
+++ b/src/apps/workspace/components/dashboard/SecretPreview.vue
@@ -81,8 +81,8 @@ const headingFontClass = computed(
 // border_radius to a local --radius-brand so every `rounded-brand` descendant
 // (logo, content box, textarea, button, and BaseSecretDisplay's content
 // wrapper) resolves to THIS domain's radius — matching the recipient page.
-// Applied via :style fallthrough on <BaseSecretDisplay>; depends on it staying
-// single-root (fallthrough merges onto that one root element).
+// Applied on the wrapper that holds both the relocated logo AND the card, so
+// the logo above the card inherits the same radius (custom properties cascade).
 const rootStyle = computed<Record<string, string>>(() => {
   const css = borderRadiusToCss(props.domainBranding?.border_radius);
   const style: Record<string, string> = {};
@@ -98,39 +98,36 @@ const actionButtonStyle = computed<Record<string, string>>(() => ({
 </script>
 
 <template>
-  <!-- Updated -->
-  <BaseSecretDisplay
-    :style="rootStyle"
-    :default-title="previewI18n.t('web.secrets.you_have_a_message')"
-    :domain-branding="domainBranding"
-    :preview-i18n="previewI18n"
-    :is-revealed="isRevealed"
-    :corner-class="cornerClass"
-    :font-class="fontFamilyClass"
-    :heading-class="headingFontClass">
-    <!-- Logo Upload Area -->
-    <template #logo>
-      <div class="group relative mx-auto sm:mx-0">
+  <!-- Scope the domain's corner-radius CSS var to the whole preview (logo + card)
+       so the relocated logo above the card rounds to THIS domain, like the card. -->
+  <div :style="rootStyle">
+    <!-- Logo opener: mirrors the recipient page's logo-only BrandedHero (centered
+         above the card, aspect-ratio-tolerant), but stays an interactive upload
+         control — the preview's logo is editable, so keep the click-to-upload
+         affordance and the empty-state prompt instead of hiding a missing logo. -->
+    <div class="mb-8 flex justify-center">
+      <div class="group relative">
         <button
           type="button"
           class="block cursor-pointer"
           :aria-label="t('web.branding.click_to_upload_a_logo_with_recommendation')"
           @click="isLogoModalOpen = true">
+          <!-- With a logo: fixed height, auto width — wide/rectangular logos use
+               the full width instead of being squished into a square. -->
+          <img
+            v-if="isValidLogo"
+            :src="logoSrc"
+            :alt="logoImage?.filename || t('web.layout.brand_logo')"
+            :class="cornerClass"
+            class="hover:ring-primary-500 h-16 w-auto max-w-full object-contain hover:ring-2 hover:ring-offset-2 sm:h-20" />
+          <!-- Without a logo: a fixed placeholder tile that prompts an upload
+               (wiggles for attention). The real page hides a missing logo; the
+               preview must always offer the affordance. -->
           <div
-            :class="[cornerClass, {
-              'animate-wiggle': !isValidLogo
-            }]"
-            class="hover:ring-primary-500 flex size-14 items-center justify-center overflow-hidden bg-gray-100 hover:ring-2 hover:ring-offset-2 sm:size-16 dark:bg-gray-700">
-            <img
-              v-if="isValidLogo"
-              :src="logoSrc"
-              :alt="logoImage?.filename || t('web.layout.brand_logo')"
-              class="size-16 object-contain"
-              :class="{
-                [cornerClass]: true,
-              }" />
+            v-else
+            :class="[cornerClass, 'animate-wiggle']"
+            class="hover:ring-primary-500 flex size-16 items-center justify-center overflow-hidden bg-gray-100 hover:ring-2 hover:ring-offset-2 sm:size-20 dark:bg-gray-700">
             <svg
-              v-else
               class="size-8 text-gray-400 dark:text-gray-500"
               fill="none"
               stroke="currentColor"
@@ -155,46 +152,55 @@ const actionButtonStyle = computed<Record<string, string>>(() => ({
           :on-remove="onLogoRemove"
           @close="isLogoModalOpen = false" />
       </div>
-    </template>
+    </div>
 
-    <template #content>
-      <textarea
-        v-if="isRevealed"
-        readonly
-        :class="[cornerClass]"
-        class="w-full resize-none border-0 bg-transparent
-            font-mono text-xs text-gray-700
-            focus:ring-0 sm:text-base dark:text-gray-300"
-        rows="3"
-        :aria-label="t('web.secrets.sample_secret_content')"
-        :value="textareaPlaceholder"></textarea>
+    <BaseSecretDisplay
+      :default-title="previewI18n.t('web.secrets.you_have_a_message')"
+      :domain-branding="domainBranding"
+      :preview-i18n="previewI18n"
+      :is-revealed="isRevealed"
+      :corner-class="cornerClass"
+      :font-class="fontFamilyClass"
+      :heading-class="headingFontClass">
+      <template #content>
+        <textarea
+          v-if="isRevealed"
+          readonly
+          :class="[cornerClass]"
+          class="w-full resize-none border-0 bg-transparent
+              font-mono text-xs text-gray-700
+              focus:ring-0 sm:text-base dark:text-gray-300"
+          rows="3"
+          :aria-label="t('web.secrets.sample_secret_content')"
+          :value="textareaPlaceholder"></textarea>
 
-      <div
-        v-else
-        class="flex items-center text-gray-400 dark:text-gray-500"
-        :class="[cornerClass, fontFamilyClass]">
-        <OIcon
-          collection="mdi"
-          name="eye-off"
-          class="mr-2 size-5" />
-        <span class="text-sm">{{ previewI18n.t('web.secrets.content_hidden') }}</span>
-      </div>
-    </template>
+        <div
+          v-else
+          class="flex items-center text-gray-400 dark:text-gray-500"
+          :class="[cornerClass, fontFamilyClass]">
+          <OIcon
+            collection="mdi"
+            name="eye-off"
+            class="mr-2 size-5" />
+          <span class="text-sm">{{ previewI18n.t('web.secrets.content_hidden') }}</span>
+        </div>
+      </template>
 
-    <template #action-button>
-      <!-- Action Button -->
-      <button
-        class="w-full py-3 text-base font-medium transition-colors sm:text-lg"
-        :class="[cornerClass, fontFamilyClass]"
-        :style="actionButtonStyle"
-        @click="toggleReveal"
-        :aria-expanded="isRevealed"
-        aria-controls="secretContent"
-        :aria-label="ariaLabelText">
-        {{ isRevealed ? previewI18n.t('web.secrets.hide_secret') : previewI18n.t('web.COMMON.click_to_continue') }}
-      </button>
-    </template>
-  </BaseSecretDisplay>
+      <template #action-button>
+        <!-- Action Button -->
+        <button
+          class="w-full py-3 text-base font-medium transition-colors sm:text-lg"
+          :class="[cornerClass, fontFamilyClass]"
+          :style="actionButtonStyle"
+          @click="toggleReveal"
+          :aria-expanded="isRevealed"
+          aria-controls="secretContent"
+          :aria-label="ariaLabelText">
+          {{ isRevealed ? previewI18n.t('web.secrets.hide_secret') : previewI18n.t('web.COMMON.click_to_continue') }}
+        </button>
+      </template>
+    </BaseSecretDisplay>
+  </div>
 </template>
 
 <style scoped>

--- a/src/apps/workspace/components/dashboard/brand/BrandPreviewColumn.vue
+++ b/src/apps/workspace/components/dashboard/brand/BrandPreviewColumn.vue
@@ -40,10 +40,9 @@
 
 <template>
   <div class="lg:sticky lg:top-4">
-    <!-- Preview stage: tinted, inset surface so the card reads as a sample -->
-    <div
-      class="rounded-2xl bg-gray-100/80 p-3 ring-1 ring-inset ring-gray-200/80
-        dark:bg-gray-900/40 dark:ring-gray-700/60">
+    <!-- Preview stage: tinted, inset surface so the card reads as a sample.
+         No outer ring — the card's dashed border is the single frame. -->
+    <div class="rounded-2xl bg-gray-100/80 px-[18px] pb-[18px] dark:bg-gray-900/40">
       <!-- Recipient page. Dashed border (not solid) reads as a sample/preview,
            not a live surface — reinforcing the PREVIEW badge. -->
       <div class="overflow-hidden rounded-xl border border-dashed border-gray-300 bg-white shadow-sm dark:border-gray-600 dark:bg-gray-800">
@@ -67,13 +66,24 @@
         <div
           class="h-1 w-full"
           :style="stripeStyle"></div>
-        <SecretPreview
-          :domain-branding="brandSettings"
-          :logo-image="logoImage"
-          :preview-i18n="previewI18n"
-          :on-logo-upload="onLogoUpload"
-          :on-logo-remove="onLogoRemove"
-          :secret-identifier="secretIdentifier" />
+        <!-- De-emphasis veil: a subtle scrim mutes the sample so its
+             recipient-facing "reveal" button doesn't visually compete with the
+             page's Save CTA in the header. pointer-events-none keeps the
+             intentional interactions (logo upload, reveal toggle) usable
+             underneath; a sibling overlay (not an opacity ancestor) so the logo
+             upload modal still layers above it cleanly. -->
+        <div class="relative">
+          <SecretPreview
+            :domain-branding="brandSettings"
+            :logo-image="logoImage"
+            :preview-i18n="previewI18n"
+            :on-logo-upload="onLogoUpload"
+            :on-logo-remove="onLogoRemove"
+            :secret-identifier="secretIdentifier" />
+          <div
+            aria-hidden="true"
+            class="pointer-events-none absolute inset-0 bg-gray-900/[0.08] dark:bg-gray-950/25"></div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/apps/workspace/components/dashboard/brand/BrandPreviewColumn.vue
+++ b/src/apps/workspace/components/dashboard/brand/BrandPreviewColumn.vue
@@ -44,8 +44,9 @@
     <div
       class="rounded-2xl bg-gray-100/80 p-3 ring-1 ring-inset ring-gray-200/80
         dark:bg-gray-900/40 dark:ring-gray-700/60">
-      <!-- Recipient page -->
-      <div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <!-- Recipient page. Dashed border (not solid) reads as a sample/preview,
+           not a live surface — reinforcing the PREVIEW badge. -->
+      <div class="overflow-hidden rounded-xl border border-dashed border-gray-300 bg-white shadow-sm dark:border-gray-600 dark:bg-gray-800">
         <div
           class="flex items-center gap-2 border-b border-gray-200 bg-gray-50 px-3.5 py-2
             dark:border-gray-700 dark:bg-gray-700/60">

--- a/src/apps/workspace/components/dashboard/brand/SimpleBrandPanel.vue
+++ b/src/apps/workspace/components/dashboard/brand/SimpleBrandPanel.vue
@@ -31,7 +31,7 @@
     FontFamily,
     fontDisplayMap,
     fontFamilyStacks,
-    fontOptions,
+    uiFontOptions,
     type FontFamily as FontFamilyType,
   } from '@/shared/utils/brand-helpers';
   import { checkBrandContrast } from '@/utils/brand-palette';
@@ -91,6 +91,13 @@
 
   // Body font falls back to Sans, matching the recipient render.
   const bodyFont = computed(() => props.modelValue.font_family ?? FontFamily.SANS);
+
+  // Picker shows the four curated families. If this domain was previously set
+  // to a now-hidden font (slab/rounded/humanist/geometric), keep it as an
+  // option so the selection stays visible and isn't silently reset on save.
+  const fontChoices = computed<FontFamilyType[]>(() =>
+    uiFontOptions.includes(bodyFont.value) ? uiFontOptions : [bodyFont.value, ...uiFontOptions]
+  );
 </script>
 
 <template>
@@ -187,7 +194,7 @@
             text-gray-900 shadow-sm focus:border-brand-500 focus:ring-1 focus:ring-brand-500
             focus:outline-none dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100">
           <option
-            v-for="font in fontOptions"
+            v-for="font in fontChoices"
             :key="`body-${font}`"
             :value="font"
             :style="{ fontFamily: fontFamilyStacks[font] }">

--- a/src/apps/workspace/domains/DomainBrand.vue
+++ b/src/apps/workspace/domains/DomainBrand.vue
@@ -14,7 +14,7 @@
   import { useOrganizationStore } from '@/shared/stores/organizationStore';
   import { ENTITLEMENTS } from '@/types/organization';
   import { storeToRefs } from 'pinia';
-  import { computed, onMounted, ref, watch } from 'vue';
+  import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
   import { useI18n } from 'vue-i18n';
   import { useRouter, onBeforeRouteLeave } from 'vue-router';
 
@@ -81,9 +81,26 @@
     }
   );
 
+  // Native navigations bypass Vue Router: the masthead logo is a hard <a href>
+  // and the UserMenu has external <a href> items, so onBeforeRouteLeave (which
+  // only guards in-app routing, e.g. the Back button) never fires for them.
+  // A beforeunload listener catches those hard navigations — plus refresh and
+  // tab close — while edits are pending, mirroring the in-app confirm below.
+  const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+    if (!hasUnsavedChanges.value) return;
+    event.preventDefault();
+    // Legacy browsers require returnValue set to trigger the native prompt.
+    event.returnValue = '';
+  };
+
   onMounted(() => {
     initializeBrand();
     initializeDomain();
+    window.addEventListener('beforeunload', handleBeforeUnload);
+  });
+
+  onUnmounted(() => {
+    window.removeEventListener('beforeunload', handleBeforeUnload);
   });
 
   onBeforeRouteLeave((to, from, next) => {

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -129,10 +129,16 @@
   --radius-brand: 0.5rem;
 
   /*
-   * Curated font-family tokens for the expanded font allowlist. sans/serif/mono
-   * reuse Tailwind's built-ins; these five back the font-brand-* utilities
+   * Curated font-family tokens for the expanded font allowlist. serif/mono
+   * reuse Tailwind's built-ins; these six back the font-brand-* utilities
    * (see fontFamilyStacks / fontFamilyClasses in brand-helpers.ts).
+   *
+   * --font-brand-sans is a deterministic neutral grotesque with NO OS-UI
+   * generics (no ui-sans-serif/system-ui/-apple-system): those resolve to the
+   * OS UI font (San Francisco on macOS), which would make `sans` render
+   * identically to `system`. Keeping Helvetica/Arial makes the two distinct.
    */
+  --font-brand-sans: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   --font-brand-system: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --font-brand-slab: 'Zilla Slab', ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
   --font-brand-rounded:

--- a/src/schemas/shapes/v3/custom-domain/brand.ts
+++ b/src/schemas/shapes/v3/custom-domain/brand.ts
@@ -6,6 +6,7 @@
 import {
   brandSettingsCanonical,
   imagePropsCanonical,
+  isValidBorderRadius,
 } from '@/schemas/contracts';
 import { z } from 'zod';
 
@@ -57,6 +58,19 @@ export const brandSettingsSchema = brandSettingsCanonical.extend({
   button_text_light: z.boolean().default(true),
   passphrase_required: z.boolean().default(false),
   notify_enabled: z.boolean().default(false),
+
+  // Read-tolerance for a cosmetic field. The canonical contract REJECTS an
+  // invalid border_radius (that strictness is the save/write authority, mirrored
+  // by the Ruby `validate_border_radius_field!` on PUT). But a stale value in an
+  // already-stored brand record (e.g. the retired `'custom'`/`'full'` presets)
+  // must NOT fail the whole domain response and brick loading — the field is
+  // purely visual. On READ we coerce an unrecognized value to `undefined`
+  // (unset → falls back to corner_style/default), exactly as `borderRadiusToCss`
+  // already returns null for it. Valid presets/px pass through untouched.
+  border_radius: z
+    .union([z.string(), z.number()])
+    .transform((val) => (isValidBorderRadius(val) ? val : undefined))
+    .nullish(),
 });
 
 /**

--- a/src/shared/components/base/BaseShowSecret.vue
+++ b/src/shared/components/base/BaseShowSecret.vue
@@ -73,7 +73,7 @@
     :aria-label="t('web.secrets.secret_viewing_page')">
     <header
       v-if="$slots.header"
-      class="w-full bg-white dark:bg-gray-900">
+      class="w-full">
       <div class="mx-auto w-full max-w-4xl px-4">
         <slot
           name="header"
@@ -168,7 +168,7 @@
     <!-- Footer wrapper -->
     <footer
       v-if="$slots.footer"
-      class="w-full bg-white dark:bg-gray-900">
+      class="w-full">
       <div class="mx-auto w-full max-w-4xl px-4">
         <slot
           name="footer"

--- a/src/shared/components/base/BaseUnknownSecret.vue
+++ b/src/shared/components/base/BaseUnknownSecret.vue
@@ -4,8 +4,7 @@
   import type { BrandSettings } from '@/schemas/shapes/v3/custom-domain';
   import {
     cornerStyleClasses,
-    fontFamilyClasses,
-    type FontFamily,
+    resolveBodyFontClass,
   } from '@/shared/utils/brand-helpers';
   import { computed } from 'vue';
 
@@ -43,7 +42,7 @@
     :class="[
       cornerClass,
       branded ? 'w-full shadow-xl' : 'shadow-md',
-      branded && brandSettings?.font_family ? fontFamilyClasses[brandSettings.font_family as FontFamily] : ''
+      branded ? resolveBodyFontClass(brandSettings) : ''
     ]">
     <!-- Header slot for icon and title -->
     <slot

--- a/src/shared/components/modals/ImageUploadModal.vue
+++ b/src/shared/components/modals/ImageUploadModal.vue
@@ -269,7 +269,7 @@
                       class="size-8 text-gray-400 dark:text-gray-500"
                       aria-hidden="true" />
                   </div>
-                  <div class="text-sm">
+                  <div class="flex flex-wrap justify-center gap-1 text-sm">
                     <span class="font-semibold text-brand-600 dark:text-brand-400">{{
                       t('web.branding.image_upload_choose')
                     }}</span>

--- a/src/shared/stores/identityStore.ts
+++ b/src/shared/stores/identityStore.ts
@@ -10,7 +10,11 @@ import {
   RESOLVED_LOGO_COMPONENT,
   resolveProductName,
 } from '@/shared/constants/brand';
-import { cornerStyleClasses, fontFamilyClasses } from '@/shared/utils/brand-helpers';
+import {
+  cornerStyleClasses,
+  resolveBodyFontClass,
+  resolveHeadingFontClass,
+} from '@/shared/utils/brand-helpers';
 import { gracefulParse } from '@/utils/schemaValidation';
 import { defineStore, storeToRefs } from 'pinia';
 import { computed, reactive, toRefs, watch } from 'vue';
@@ -306,20 +310,12 @@ export const useProductIdentity = defineStore('productIdentity', () => {
       : DEFAULT_CORNER_CLASS;
   });
 
-  const fontFamilyClass = computed(() =>
-    state.brand?.font_family
-      ? fontFamilyClasses[state.brand.font_family] ?? ''
-      : ''
-  );
+  const fontFamilyClass = computed(() => resolveBodyFontClass(state.brand));
 
-  // Heading font (#3646): a separate curated font for headings, falling back to
-  // the body font_family when unset. Consumed by BrandedHomepage's <h1> and the
-  // branded BaseSecretDisplay <h2> (headingClass prop, via SecretDisplayCase and
-  // SecretConfirmationForm).
-  const headingFontClass = computed(() => {
-    const heading = state.brand?.heading_font ?? state.brand?.font_family;
-    return heading ? fontFamilyClasses[heading] ?? '' : '';
-  });
+  // Heading font (#3646): headings bind headingFontClass, body text binds
+  // fontFamilyClass. The ladder (heading_font wins, font_family backfills)
+  // lives in the brand-helpers resolvers.
+  const headingFontClass = computed(() => resolveHeadingFontClass(state.brand));
 
   const preRevealInstructions = computed(
     () => state.brand?.instructions_pre_reveal?.trim() || t('web.shared.pre_reveal_default')

--- a/src/shared/utils/brand-helpers.ts
+++ b/src/shared/utils/brand-helpers.ts
@@ -69,6 +69,20 @@ export const CornerStyle = {
 export const fontOptions = [...fontFamilyValues];
 
 /**
+ * UI-visible subset of {@link fontOptions} shown in the branding editor.
+ *
+ * The full allowlist (fontFamilyValues) keeps all 8 values for back-compat and
+ * runtime rendering, but the picker only surfaces these four: the three generic
+ * families plus `system`. The extra style-classification fonts (slab, rounded,
+ * humanist, geometric) mostly degrade to the same system fallback across
+ * viewers — only `slab` is deterministic (self-hosted) — so exposing them
+ * over-promised a look the recipient rarely got. Domains already set to a
+ * hidden value keep rendering it; the editor re-adds the current value as an
+ * option so the selection stays visible (see SimpleBrandPanel `fontChoices`).
+ */
+export const uiFontOptions: FontFamily[] = ['serif', 'sans', 'mono', 'system'];
+
+/**
  * Array of valid corner style values for form options.
  */
 export const cornerStyleOptions = [...cornerStyleValues];
@@ -80,13 +94,19 @@ export const cornerStyleOptions = [...cornerStyleValues];
 /**
  * Maps font family values to Tailwind CSS font-family utility classes.
  *
- * The original sans/serif/mono trio reuses Tailwind's built-in families. The
- * expanded values map to `font-brand-*` utilities backed by `--font-brand-*`
- * theme tokens defined in `src/assets/style.css` (@theme static), so the
- * scanner always sees a static class and the utility resolves at runtime.
+ * `serif`/`mono` reuse Tailwind's built-in families. Everything else — including
+ * `sans` — maps to a `font-brand-*` utility backed by a `--font-brand-*` theme
+ * token in `src/assets/style.css` (@theme static), so the scanner always sees a
+ * static class and the utility resolves at runtime.
+ *
+ * `sans` is deliberately NOT `font-sans`: Tailwind's default `font-sans` leads
+ * with `ui-sans-serif, system-ui`, which resolve to the OS UI font (San
+ * Francisco on macOS) — identical to the `system` option. `font-brand-sans`
+ * pins a deterministic neutral grotesque (Helvetica/Arial) so `sans` and
+ * `system` are visibly distinct on every platform.
  */
 export const fontFamilyClasses: Record<FontFamily, string> = {
-  sans: 'font-sans',
+  sans: 'font-brand-sans',
   serif: 'font-serif',
   mono: 'font-mono',
   system: 'font-brand-system',
@@ -107,7 +127,7 @@ export const fontFamilyClasses: Record<FontFamily, string> = {
  * (BrandSettingsConstants::FONTS).
  */
 export const fontFamilyStacks: Record<FontFamily, string> = {
-  sans: 'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+  sans: '"Helvetica Neue", Helvetica, Arial, sans-serif',
   serif: 'ui-serif, Georgia, Cambria, "Times New Roman", Times, serif',
   mono: 'ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace',
   system: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',

--- a/src/shared/utils/brand-helpers.ts
+++ b/src/shared/utils/brand-helpers.ts
@@ -127,6 +127,56 @@ export const cornerStyleClasses: Record<CornerStyle, string> = {
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Font class resolvers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Minimal structural view of the brand font fields, so both store state and
+ * BrandSettings schema objects (v2/v3, which type the fields as enum unions)
+ * can be passed without casts.
+ */
+export type BrandFontFields = {
+  font_family?: string | null;
+  heading_font?: string | null;
+} | null | undefined;
+
+/**
+ * Resolves the body font utility class for a brand.
+ *
+ * Returns `''` when the brand is nullish, `font_family` is unset, or the value
+ * is not a known FontFamily — callers bind the result directly and an empty
+ * class inherits the surrounding font. `Object.hasOwn` (not `in`) so inherited
+ * keys like `'toString'` count as unknown rather than resolving to a Function.
+ *
+ * Together with {@link resolveHeadingFontClass}, this is the ONLY place
+ * allowed to index `fontFamilyClasses` by dynamic key (the brand-token guard
+ * spec enforces it): the value→class mapping drifted when hand-copied into
+ * consumers, rendering headings in the body font.
+ */
+export function resolveBodyFontClass(brand: BrandFontFields): string {
+  const font = brand?.font_family;
+  return font && Object.hasOwn(fontFamilyClasses, font)
+    ? fontFamilyClasses[font as FontFamily]
+    : '';
+}
+
+/**
+ * Resolves the heading font utility class for a brand.
+ *
+ * Heading ladder: `heading_font ?? font_family` — a dedicated heading font
+ * wins, the body font backfills when it is unset. Unset/unknown resolve to
+ * `''` with the same fallback semantics as {@link resolveBodyFontClass},
+ * which also documents why dynamic `fontFamilyClasses` indexing lives here
+ * and nowhere else.
+ */
+export function resolveHeadingFontClass(brand: BrandFontFields): string {
+  const font = brand?.heading_font ?? brand?.font_family;
+  return font && Object.hasOwn(fontFamilyClasses, font)
+    ? fontFamilyClasses[font as FontFamily]
+    : '';
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Border radius (expanded, #3646)
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/src/tests/apps/secret/components/branded/BrandedHero.spec.ts
+++ b/src/tests/apps/secret/components/branded/BrandedHero.spec.ts
@@ -178,3 +178,31 @@ describe('BrandedHero logo', () => {
     expect(wrapper.find('a').exists()).toBe(false);
   });
 });
+
+describe('BrandedHero logo-only', () => {
+  let wrapper: VueWrapper;
+
+  afterEach(() => {
+    if (wrapper) wrapper.unmount();
+  });
+
+  // The reveal/confirm case opens with the logo but supplies its own heading
+  // + instructions, so the hero must render the logo alone — no empty h1/p.
+  it('renders the logo alone when title and subtitle are omitted', async () => {
+    wrapper = mountHero({ title: undefined, subtitle: undefined });
+    await nextTick();
+
+    expect(wrapper.find('img').exists()).toBe(true);
+    expect(wrapper.find('h1').exists()).toBe(false);
+    expect(wrapper.find('p').exists()).toBe(false);
+  });
+
+  it('still links the logo when logoLinkTo is passed without title/subtitle', async () => {
+    wrapper = mountHero({ title: undefined, subtitle: undefined, logoLinkTo: '/' });
+    await nextTick();
+
+    const link = wrapper.find('a');
+    expect(link.exists()).toBe(true);
+    expect(link.find('img').exists()).toBe(true);
+  });
+});

--- a/src/tests/apps/secret/components/branded/BrandedHero.spec.ts
+++ b/src/tests/apps/secret/components/branded/BrandedHero.spec.ts
@@ -1,0 +1,180 @@
+// src/tests/apps/secret/components/branded/BrandedHero.spec.ts
+//
+// Guards the shared branded hero (logo + headline + subline) that
+// BrandedHomepage and BrandedMastHead render through:
+//   1. Font tokens: the h1 binds headingFontClass (heading_font, falling back
+//      to font_family) while the root binds the body fontFamilyClass — the
+//      heading token must never degrade to the body font (the masthead
+//      regression this component exists to prevent).
+//   2. Logo behaviour: banner-friendly sizing (fixed height, natural width),
+//      hidden entirely when absent or broken — no generic placeholder on a
+//      branded page — and wrapped in a router-link only when the call site
+//      asks for one.
+
+import { mount, VueWrapper } from '@vue/test-utils';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import { createTestI18n } from '@tests/setup';
+import { nextTick } from 'vue';
+import BrandedHero from '@/apps/secret/components/branded/BrandedHero.vue';
+
+const i18n = createTestI18n();
+
+interface Overrides {
+  domain_logo?: string | null;
+  domain_branding?: Record<string, unknown>;
+}
+
+interface HeroProps {
+  title?: string;
+  subtitle?: string;
+  logoLinkTo?: string;
+}
+
+const mountHero = (props: HeroProps = {}, overrides: Overrides = {}): VueWrapper => {
+  const pinia = createTestingPinia({
+    createSpy: vi.fn,
+    stubActions: false,
+    initialState: {
+      bootstrap: {
+        domain_strategy: 'custom',
+        // `in` (not `??`) so an explicit null override reads as "no logo".
+        domain_logo:
+          'domain_logo' in overrides
+            ? overrides.domain_logo
+            : 'https://cdn.example/acme-logo.png',
+        domains_enabled: true,
+        display_domain: 'secrets.acme.com',
+        site_host: 'onetimesecret.com',
+        canonical_domain: 'onetimesecret.com',
+        domain_id: 'cd_acme',
+        domain_branding: overrides.domain_branding ?? {
+          description: 'Acme Corp',
+          primary_color: '#36454F',
+          corner_style: 'rounded',
+          font_family: 'serif',
+          heading_font: 'slab',
+          button_text_light: true,
+        },
+      },
+    },
+  });
+
+  return mount(BrandedHero, {
+    props: {
+      title: 'Send a secret',
+      subtitle: 'Deliver sensitive information securely',
+      ...props,
+    },
+    global: {
+      plugins: [i18n, pinia],
+      stubs: {
+        RouterLink: { template: '<a><slot /></a>', props: ['to'] },
+      },
+    },
+  });
+};
+
+describe('BrandedHero font tokens', () => {
+  let wrapper: VueWrapper;
+
+  afterEach(() => {
+    if (wrapper) wrapper.unmount();
+  });
+
+  it('binds the heading font token (not the body font) on the h1', async () => {
+    wrapper = mountHero();
+    await nextTick();
+
+    const h1 = wrapper.find('h1');
+    expect(h1.exists()).toBe(true);
+    expect(h1.classes()).toContain('font-brand-slab');
+    expect(h1.classes()).not.toContain('font-serif');
+    expect(h1.text()).toBe('Send a secret');
+  });
+
+  it('binds the body font token on the root so the subtitle inherits it', async () => {
+    wrapper = mountHero();
+    await nextTick();
+
+    expect(wrapper.classes()).toContain('font-serif');
+    expect(wrapper.classes()).not.toContain('font-brand-slab');
+    expect(wrapper.find('p').text()).toBe('Deliver sensitive information securely');
+  });
+
+  it('falls back to the body font on the h1 when heading_font is unset', async () => {
+    wrapper = mountHero({}, {
+      domain_branding: {
+        description: 'Acme Corp',
+        primary_color: '#36454F',
+        font_family: 'serif',
+      },
+    });
+    await nextTick();
+
+    expect(wrapper.find('h1').classes()).toContain('font-serif');
+  });
+});
+
+describe('BrandedHero logo', () => {
+  let wrapper: VueWrapper;
+
+  afterEach(() => {
+    if (wrapper) wrapper.unmount();
+  });
+
+  it('renders banner-friendly sizing classes (fixed height, natural width)', async () => {
+    wrapper = mountHero();
+    await nextTick();
+
+    const img = wrapper.find('img');
+    expect(img.exists()).toBe(true);
+    expect(img.classes()).toContain('h-16');
+    expect(img.classes()).toContain('w-auto');
+    expect(img.classes()).toContain('max-w-full');
+    expect(img.classes()).toContain('object-contain');
+  });
+
+  it('uses the brand display name as the logo alt', async () => {
+    wrapper = mountHero();
+    await nextTick();
+
+    expect(wrapper.find('img').attributes('alt')).toBe('Acme Corp');
+  });
+
+  it('hides the logo block entirely when no logo is configured', async () => {
+    wrapper = mountHero({}, { domain_logo: null });
+    await nextTick();
+
+    expect(wrapper.find('img').exists()).toBe(false);
+    // No placeholder either — the hero degrades to text-only.
+    expect(wrapper.find('svg').exists()).toBe(false);
+  });
+
+  it('hides the logo block after the image fails to load', async () => {
+    wrapper = mountHero();
+    await nextTick();
+
+    await wrapper.find('img').trigger('error');
+
+    expect(wrapper.find('img').exists()).toBe(false);
+    expect(wrapper.find('svg').exists()).toBe(false);
+  });
+
+  it('wraps the logo in a router-link only when logoLinkTo is passed', async () => {
+    wrapper = mountHero({ logoLinkTo: '/' });
+    await nextTick();
+
+    const link = wrapper.find('a');
+    expect(link.exists()).toBe(true);
+    expect(link.find('img').exists()).toBe(true);
+  });
+
+  it('renders a bare img when logoLinkTo is absent', async () => {
+    wrapper = mountHero();
+    await nextTick();
+
+    expect(wrapper.find('img').exists()).toBe(true);
+    expect(wrapper.find('a').exists()).toBe(false);
+  });
+});

--- a/src/tests/apps/secret/components/layout/BrandedMastHead.spec.ts
+++ b/src/tests/apps/secret/components/layout/BrandedMastHead.spec.ts
@@ -1,6 +1,6 @@
 // src/tests/apps/secret/components/layout/BrandedMastHead.spec.ts
 //
-// Guards two behaviours of the custom-domain masthead:
+// Guards three behaviours of the custom-domain masthead:
 //   1. Logo accessibility: the logo image must carry a meaningful alt (the
 //      brand/workspace display name) rather than an empty alt.
 //   2. Auth nav links default OFF: the Create Account / Sign In links only
@@ -8,6 +8,8 @@
 //      (signup_enabled/signin_enabled === true). A null homepage_config or a
 //      false flag keeps them hidden — recipients and employees arriving via a
 //      shared link should not see account chrome unless an operator enabled it.
+//   3. Heading font: the h1 renders through BrandedHero and carries the
+//      heading font token (heading_font), not the body font_family.
 
 import { mount, VueWrapper } from '@vue/test-utils';
 import { describe, it, expect, vi, afterEach } from 'vitest';
@@ -99,6 +101,31 @@ describe('BrandedMastHead logo accessibility', () => {
     await nextTick();
 
     expect(wrapper.find('img').attributes('alt')).toBe('secrets.acme.com');
+  });
+});
+
+describe('BrandedMastHead heading font', () => {
+  let wrapper: VueWrapper;
+
+  afterEach(() => {
+    if (wrapper) wrapper.unmount();
+  });
+
+  it('binds the heading font token (not the body font) on the h1', async () => {
+    wrapper = mountBranded({
+      domain_branding: {
+        description: 'Acme Corp',
+        primary_color: '#36454F',
+        font_family: 'serif',
+        heading_font: 'slab',
+      },
+    });
+    await nextTick();
+
+    const h1 = wrapper.find('h1');
+    expect(h1.exists()).toBe(true);
+    expect(h1.classes()).toContain('font-brand-slab');
+    expect(h1.classes()).not.toContain('font-serif');
   });
 });
 

--- a/src/tests/components/BrandEditor.spec.ts
+++ b/src/tests/components/BrandEditor.spec.ts
@@ -110,9 +110,21 @@ describe('SimpleBrandPanel', () => {
     // Exactly one select: body font. Heading font was removed.
     const selects = wrapper.findAll('select');
     expect(selects).toHaveLength(1);
-    // It exposes the full font vocabulary (not just Sans) — regression guard for
-    // the "both options are Sans-Serif" report.
-    expect(selects[0].findAll('option').length).toBeGreaterThanOrEqual(3);
+    // Picker is trimmed to the four curated families (serif/sans/mono/system);
+    // the style-classification fonts (slab/rounded/humanist/geometric) render
+    // near-identically across viewers, so they no longer appear in the editor.
+    const values = selects[0].findAll('option').map((o) => o.attributes('value'));
+    expect(values).toEqual(['serif', 'sans', 'mono', 'system']);
+  });
+
+  it('keeps a domain’s previously-set hidden font visible as an option', () => {
+    // A domain saved under a now-hidden value (e.g. humanist) must not have its
+    // selection silently dropped: the current value is prepended to the picker.
+    const wrapper = mountPanel({ font_family: 'humanist' } as Partial<BrandSettings>);
+    const select = wrapper.find('select');
+    const values = select.findAll('option').map((o) => o.attributes('value'));
+    expect(values).toEqual(['humanist', 'serif', 'sans', 'mono', 'system']);
+    expect((select.element as HTMLSelectElement).value).toBe('humanist');
   });
 });
 

--- a/src/tests/components/SecretPreview.spec.ts
+++ b/src/tests/components/SecretPreview.spec.ts
@@ -99,3 +99,20 @@ describe('SecretPreview border_radius fidelity (#3646)', () => {
     expect(rootTag).toContain('--radius-brand: 1rem');
   });
 });
+
+// BaseSecretDisplay's h2 must carry the heading font token verbatim — any
+// body-font fallback inside the display component re-implements the heading
+// ladder (heading_font backfilled by font_family) and silently drops
+// heading_font when a binding goes missing, which shipped body-font mastheads.
+describe('SecretPreview heading font token', () => {
+  it('puts the heading token — not the body token — on the h2 when they differ', () => {
+    const wrapper = mountPreview({
+      font_family: 'sans',
+      heading_font: 'slab',
+    });
+
+    const heading = wrapper.get('h2');
+    expect(heading.classes()).toContain('font-brand-slab');
+    expect(heading.classes()).not.toContain('font-sans');
+  });
+});

--- a/src/tests/components/SecretPreview.spec.ts
+++ b/src/tests/components/SecretPreview.spec.ts
@@ -113,6 +113,8 @@ describe('SecretPreview heading font token', () => {
 
     const heading = wrapper.get('h2');
     expect(heading.classes()).toContain('font-brand-slab');
-    expect(heading.classes()).not.toContain('font-sans');
+    // Body font `sans` resolves to font-brand-sans; assert it did NOT leak onto
+    // the heading (the ladder must keep heading_font distinct from font_family).
+    expect(heading.classes()).not.toContain('font-brand-sans');
   });
 });

--- a/src/tests/schemas/shapes/v3/brandSettingsDefaults.spec.ts
+++ b/src/tests/schemas/shapes/v3/brandSettingsDefaults.spec.ts
@@ -23,3 +23,31 @@ describe('V3 brandSettingsSchema defaults', () => {
     expect(brandSettingsSchema.parse({ button_text_light: true }).button_text_light).toBe(true);
   });
 });
+
+// Read-tolerance: unlike the canonical contract (which REJECTS an invalid
+// border_radius to gate writes), the V3 READ shape must never let a stale
+// cosmetic value fail the whole domain response. A retired/unknown value is
+// coerced to `undefined` (unset) so the domain still loads. See the field
+// comment in shapes/v3/custom-domain/brand.ts.
+describe('V3 brandSettingsSchema border_radius read-tolerance', () => {
+  it('passes valid presets and px through untouched', () => {
+    expect(brandSettingsSchema.parse({ border_radius: 'md' }).border_radius).toBe('md');
+    expect(brandSettingsSchema.parse({ border_radius: 22 }).border_radius).toBe(22);
+    expect(brandSettingsSchema.parse({ border_radius: '22' }).border_radius).toBe('22');
+  });
+
+  it('coerces retired / unknown values to undefined instead of failing', () => {
+    // 'custom' is the stale value observed in stored brand records; 'full' was
+    // retired in WAVE2; 100 is out of the 0-64 range; '22.5' is non-integer.
+    for (const stale of ['custom', 'full', 100, '22.5']) {
+      const parsed = brandSettingsSchema.safeParse({ border_radius: stale });
+      expect(parsed.success).toBe(true);
+      expect(parsed.success && parsed.data.border_radius).toBeUndefined();
+    }
+  });
+
+  it('preserves null and undefined', () => {
+    expect(brandSettingsSchema.parse({ border_radius: null }).border_radius).toBeNull();
+    expect(brandSettingsSchema.parse({}).border_radius).toBeUndefined();
+  });
+});

--- a/src/tests/shared/utils/brand-helpers.spec.ts
+++ b/src/tests/shared/utils/brand-helpers.spec.ts
@@ -24,6 +24,8 @@ import {
   borderRadiusOptions,
   borderRadiusDisplayMap,
   borderRadiusIconMap,
+  resolveBodyFontClass,
+  resolveHeadingFontClass,
 } from '@/shared/utils/brand-helpers';
 import { describe, expect, it } from 'vitest';
 
@@ -311,6 +313,67 @@ describe('brand-helpers', () => {
         expect(borderRadiusDisplayMap[preset]).toBeTruthy();
         expect(borderRadiusIconMap[preset]).toBeTruthy();
       }
+    });
+  });
+
+  describe('resolveBodyFontClass', () => {
+    it('maps a known font_family to its utility class', () => {
+      expect(resolveBodyFontClass({ font_family: 'slab' })).toBe('font-brand-slab');
+      expect(resolveBodyFontClass({ font_family: 'sans' })).toBe('font-sans');
+    });
+
+    it('returns empty string when font_family is unset', () => {
+      expect(resolveBodyFontClass({})).toBe('');
+      expect(resolveBodyFontClass({ font_family: null })).toBe('');
+      expect(resolveBodyFontClass({ font_family: '' })).toBe('');
+    });
+
+    it('returns empty string for unknown font values', () => {
+      expect(resolveBodyFontClass({ font_family: 'comic-sans' })).toBe('');
+      // Inherited Object.prototype keys must not resolve to a Function.
+      expect(resolveBodyFontClass({ font_family: 'toString' })).toBe('');
+    });
+
+    it('returns empty string for nullish brand', () => {
+      expect(resolveBodyFontClass(null)).toBe('');
+      expect(resolveBodyFontClass(undefined)).toBe('');
+    });
+  });
+
+  describe('resolveHeadingFontClass', () => {
+    it('heading_font wins over font_family', () => {
+      expect(
+        resolveHeadingFontClass({ font_family: 'sans', heading_font: 'slab' })
+      ).toBe('font-brand-slab');
+    });
+
+    it('font_family backfills when heading_font is unset', () => {
+      expect(resolveHeadingFontClass({ font_family: 'serif' })).toBe('font-serif');
+      expect(
+        resolveHeadingFontClass({ font_family: 'serif', heading_font: null })
+      ).toBe('font-serif');
+    });
+
+    it('returns empty string when both are unset', () => {
+      expect(resolveHeadingFontClass({})).toBe('');
+      expect(
+        resolveHeadingFontClass({ font_family: null, heading_font: null })
+      ).toBe('');
+    });
+
+    it('returns empty string for unknown font values', () => {
+      expect(
+        resolveHeadingFontClass({ font_family: 'sans', heading_font: 'papyrus' })
+      ).toBe('');
+      // Inherited Object.prototype keys must not resolve to a Function.
+      expect(
+        resolveHeadingFontClass({ heading_font: 'constructor' })
+      ).toBe('');
+    });
+
+    it('returns empty string for nullish brand', () => {
+      expect(resolveHeadingFontClass(null)).toBe('');
+      expect(resolveHeadingFontClass(undefined)).toBe('');
     });
   });
 });

--- a/src/tests/shared/utils/brand-helpers.spec.ts
+++ b/src/tests/shared/utils/brand-helpers.spec.ts
@@ -97,7 +97,10 @@ describe('brand-helpers', () => {
     });
 
     it('maps to valid Tailwind font classes', () => {
-      expect(fontFamilyClasses.sans).toBe('font-sans');
+      // sans is on its own font-brand-sans token (a deterministic neutral
+      // grotesque), NOT Tailwind's font-sans, so it stays visibly distinct from
+      // the `system` option instead of both resolving to the OS UI font.
+      expect(fontFamilyClasses.sans).toBe('font-brand-sans');
       expect(fontFamilyClasses.serif).toBe('font-serif');
       expect(fontFamilyClasses.mono).toBe('font-mono');
     });
@@ -319,7 +322,7 @@ describe('brand-helpers', () => {
   describe('resolveBodyFontClass', () => {
     it('maps a known font_family to its utility class', () => {
       expect(resolveBodyFontClass({ font_family: 'slab' })).toBe('font-brand-slab');
-      expect(resolveBodyFontClass({ font_family: 'sans' })).toBe('font-sans');
+      expect(resolveBodyFontClass({ font_family: 'sans' })).toBe('font-brand-sans');
     });
 
     it('returns empty string when font_family is unset', () => {

--- a/src/tests/shared/utils/brand-token-guard.spec.ts
+++ b/src/tests/shared/utils/brand-token-guard.spec.ts
@@ -1,0 +1,55 @@
+// src/tests/shared/utils/brand-token-guard.spec.ts
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Brand font-token guard.
+ *
+ * Dynamic `fontFamilyClasses[...]` indexing is how the heading/body font
+ * ladder got hand-copied into consumers and drifted (a masthead heading
+ * rendered in the body font in production). The value→class mapping must flow
+ * through resolveBodyFontClass / resolveHeadingFontClass; brand-helpers.ts is
+ * the ONLY file allowed to index the map by dynamic key. Dot access
+ * (`fontFamilyClasses.sans`) stays legal for explicit presentation defaults.
+ */
+describe('brand token guard — fontFamilyClasses dynamic indexing', () => {
+  const srcRoot = resolve(process.cwd(), 'src');
+  const allowedFile = resolve(srcRoot, 'shared/utils/brand-helpers.ts');
+  const testsRoot = resolve(srcRoot, 'tests');
+
+  function walk(dir: string): string[] {
+    return readdirSync(dir).flatMap((name) => {
+      const full = join(dir, name);
+      if (full === testsRoot) return [];
+      if (statSync(full).isDirectory()) return walk(full);
+      return /\.(ts|vue)$/.test(name) && full !== allowedFile ? [full] : [];
+    });
+  }
+
+  const files = walk(srcRoot);
+
+  it('finds source files to scan', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it('no file outside brand-helpers.ts indexes fontFamilyClasses dynamically', () => {
+    // `?.`/`!` variants (`fontFamilyClasses?.[font]`) index just as
+    // dynamically as the bare form and must not slip past the guard.
+    const offenders = files
+      .filter((file) =>
+        /fontFamilyClasses\s*(\?\.|!)?\s*\[/.test(readFileSync(file, 'utf8'))
+      )
+      .map((file) => relative(process.cwd(), file));
+
+    expect(
+      offenders,
+      'Dynamic fontFamilyClasses[...] indexing found in:\n' +
+        offenders.map((f) => `  ${f}`).join('\n') +
+        '\nUse resolveBodyFontClass/resolveHeadingFontClass from' +
+        ' src/shared/utils/brand-helpers.ts instead.'
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Routes branded heading typography through a single `BrandedHero` component and shared resolvers so masthead, homepage, reveal, and preview surfaces render fonts consistently instead of each re-deriving them. Adds a `brand-helpers` layer plus a token guard, and hardens the v3 read shape to coerce an invalid stored `border_radius` back to unset (prevents stale `"custom"` values from bricking domain load).

## Deployment notes

> [!NOTE] 
> We added a 4th font option: system. To make it distinct from sans, the system fonts were removed from the sans font family list. Branded pages that never picked a font now renders Helvetica/Arial instead of the OS system font. That's consistent with the determinism direction (same brand across all OSes), but it is a visible change for existing domains. 

## Changes

- New `BrandedHero.vue` unifies heading font/size resolution; consumers (`BrandedMastHead`, `BrandedHomepage`, `UnknownSecret`, `BaseSecretDisplay`, `SecretPreview`) delegate to it.
- `brand-helpers.ts` + `identityStore` resolver updates centralize token derivation.
- v3 `brand.ts` read shape coerces invalid `border_radius` → undefined.
- Test coverage: `BrandedHero`, `brand-helpers`, brand-token guard, `brandSettingsDefaults`, updated masthead/preview specs (564 insertions).