### PR TITLE
Visual regression archive: PR artifacts + OCI releases for cross-version diffs (PR 3/3)

### DIFF
--- a/.github/workflows/visual-archive.yml
+++ b/.github/workflows/visual-archive.yml
@@ -1,0 +1,144 @@
+# ==============================================================================
+# Visual archive — OCI release half of the dual-artifact archive
+# (PR 3 of docs/specs/qa/visual-regressions/)
+# ==============================================================================
+# On every published release, render the full visual matrix at that tag and
+# push the screenshot set to ghcr.io as an OCI artifact:
+#
+#   ghcr.io/<repo>/visual-baselines:<release tag>
+#
+# This is the durable store cross-version diffs pull from (workflow artifacts
+# expire; releases don't). To diff any archived version against a working
+# tree:
+#
+#   oras pull ghcr.io/onetimesecret/onetimesecret/visual-baselines:v0.26.0 \
+#     -o e2e/visual/.artifacts/v0.26.0
+#   bin/visual --compare e2e/visual/.artifacts/v0.26.0
+#
+# Every reported diff is a customer-visible change between that release and
+# the tree. Caveat: only compare sets rendered with the same Playwright
+# container tag (metadata.json inside the set records it) — browser/font
+# drift across image versions produces phantom diffs.
+#
+# The render pipeline is byte-for-byte the PR lane's (see visual.yml for the
+# env/service rationale): bin/setup → pnpm build → bin/visual --archive, with
+# the pinned Playwright container doing the screenshotting.
+# ==============================================================================
+name: Visual archive
+
+on:
+  release:
+    types: [published]
+  # Manual runs archive whatever ref you dispatch from, tagged sha-<short>.
+  # Useful for backfilling an old tag: dispatch from that tag's ref.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  archive:
+    name: Render matrix and push to ghcr.io
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    services:
+      valkey:
+        image: ghcr.io/valkey-io/valkey:8.1.3-bookworm@sha256:fea8b3e67b15729d4bb70589eb03367bab9ad1ee89c876f54327fc7c6e618571
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping || exit 1"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Ruby (.ruby-version)
+        uses: ruby/setup-ruby@97b333846670e3cb692f29c0c5d42b71efc6bc93
+        with:
+          bundler-cache: false  # bin/setup runs `bundle install` itself
+
+      - name: Setup Node (.node-version)
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.node-version'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+
+      - name: Setup Python (locales:sync)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      - name: Run bin/setup
+        run: bin/setup
+
+      - name: Build frontend assets
+        run: pnpm run build
+
+      - name: Render archive set
+        run: |
+          export OTS_ENV_LOADED=1
+          SECRET="$(openssl rand -hex 32)"
+          export SECRET
+          export REDIS_URL=redis://127.0.0.1:6379/0
+          bin/visual --archive e2e/visual/.artifacts/render
+
+      - name: Setup ORAS
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
+        with:
+          version: 1.3.3
+
+      - name: Push to ghcr.io
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Empty on workflow_dispatch; the sha-<short> fallback below covers it.
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          TAG="${RELEASE_TAG:-sha-${GITHUB_SHA::7}}"
+          # OCI tag charset guard — release tag names are maintainer-created
+          # but flow into a shell-adjacent context; fail loudly on surprises.
+          if ! printf '%s' "$TAG" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$'; then
+            echo "Error: release tag '$TAG' is not a valid OCI tag." >&2
+            exit 1
+          fi
+          REF="ghcr.io/${GITHUB_REPOSITORY}/visual-baselines:${TAG}"
+
+          echo "$GHCR_TOKEN" | oras login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+
+          # Push from inside the set so the artifact unpacks flat
+          # (*-snapshots/ + metadata.json), ready for bin/visual --compare.
+          cd e2e/visual/.artifacts/render
+          PLAYWRIGHT_IMAGE="$(jq -r .playwrightImage metadata.json)"
+          oras push "$REF" \
+            --artifact-type application/vnd.onetimesecret.visual-baselines.v1 \
+            --annotation "org.opencontainers.image.revision=${GITHUB_SHA}" \
+            --annotation "org.opencontainers.image.version=${TAG}" \
+            --annotation "com.onetimesecret.playwright-image=${PLAYWRIGHT_IMAGE}" \
+            .
+          echo "Pushed $REF"
+
+      # Belt-and-suspenders copy on the run itself (and the only artifact a
+      # fork PR of this workflow could produce — forks can't push to ghcr).
+      - name: Upload rendered set as workflow artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: visual-render-${{ github.sha }}
+          path: e2e/visual/.artifacts/render/
+          retention-days: 90
+
+      - name: Server log on failure
+        if: failure()
+        run: |
+          echo "=== tmp/visual-server.log (last 100 lines) ==="
+          tail -n 100 tmp/visual-server.log || true

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -108,6 +108,31 @@ jobs:
           # fixture hosts (*.example.com/org) to 127.0.0.1.
           bin/visual
 
+      # PR-artifact half of the dual-artifact archive (PR 3 of the spec).
+      # A fresh render of the full matrix, uploaded on green so reviewers can
+      # eyeball exactly what this PR's pages look like without checking out
+      # the branch. Same directory format the release workflow
+      # (visual-archive.yml) pushes to ghcr.io, so any two sets are
+      # directory-diffable. A second bin/visual invocation re-boots and
+      # re-seeds — required anyway, because the compare pass consumed the
+      # destructive cells (reveal destroys, first receipt view stamps).
+      - name: Render archive set
+        if: success()
+        run: |
+          export OTS_ENV_LOADED=1
+          SECRET="$(openssl rand -hex 32)"
+          export SECRET
+          export REDIS_URL=redis://127.0.0.1:6379/0
+          bin/visual --archive e2e/visual/.artifacts/render
+
+      - name: Upload rendered set
+        if: success()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: visual-render-${{ github.event.pull_request.head.sha || github.sha }}
+          path: e2e/visual/.artifacts/render/
+          retention-days: 30
+
       - name: Upload Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -39,6 +39,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write  # sticky diff-summary comment (upserted on the PR)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -94,6 +95,7 @@ jobs:
         run: pnpm run build
 
       - name: Run visual regression suite
+        id: visual
         run: |
           # bin/visual's env guards expect a direnv-loaded shell; CI provides
           # the equivalent env explicitly. SECRET is ephemeral (production-
@@ -157,3 +159,69 @@ jobs:
         run: |
           echo "=== tmp/visual-server.log (last 100 lines) ==="
           tail -n 100 tmp/visual-server.log || true
+
+      # Upsert one sticky comment on the PR summarizing the run. On failure it
+      # lists the changed shots (globbed from the diff PNGs Playwright wrote)
+      # and links to the artifacts; on success it flips the same comment to a
+      # pass marker so a fixed PR doesn't leave a stale red comment behind.
+      # The PNGs themselves stay in the artifact zip — GitHub can't host them
+      # inline without a screenshots branch, which we deliberately avoid.
+      - name: Comment visual summary on PR
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          SUITE_OUTCOME: ${{ steps.visual.outcome }}
+          JOB_STATUS: ${{ job.status }}
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const MARKER = '<!-- visual-regression-report -->';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const failed = process.env.SUITE_OUTCOME === 'failure';
+
+            // Collect the diff PNGs Playwright emitted (…-diff.png under test-results).
+            const shots = [];
+            const root = 'e2e/test-results';
+            const walk = (dir) => {
+              let entries = [];
+              try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+              for (const e of entries) {
+                const p = path.join(dir, e.name);
+                if (e.isDirectory()) walk(p);
+                else if (e.name.endsWith('-diff.png')) shots.push(p);
+              }
+            };
+            walk(root);
+
+            let body;
+            if (!failed && process.env.JOB_STATUS !== 'success') {
+              // Comparison passed but a later step (archive render/upload)
+              // failed — never post a green comment on a red lane.
+              body = `${MARKER}\n### ⚠️ Visual comparison passed, but the lane failed\nAll shots matched the committed linux baselines; a post-comparison step (archive render/upload) failed. · [run](${runUrl})`;
+            } else if (!failed) {
+              body = `${MARKER}\n### ✅ Visual regression passed\nAll shots matched the committed linux baselines. · [run](${runUrl})`;
+            } else {
+              const list = shots.length
+                ? shots.map((s) => `- \`${path.relative(root, s).replace(/-diff\.png$/, '')}\``).join('\n')
+                : '_No diff PNGs were written — the lane likely failed before comparison (boot/seed/build). Check the run log._';
+              body = [
+                `${MARKER}`,
+                `### ❌ Visual regression failed — ${shots.length} shot(s) changed`,
+                '',
+                list,
+                '',
+                `The expected/actual/diff triptychs are in the **\`visual-test-results\`** artifact (7-day retention).`,
+                `Download → [run summary](${runUrl}) · report → **\`visual-playwright-report\`** artifact.`,
+              ].join('\n');
+            }
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 100 });
+            const existing = comments.find((c) => c.body && c.body.includes(MARKER));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -94,21 +94,34 @@ jobs:
       - name: Build frontend assets
         run: pnpm run build
 
+      # bin/visual's env guards expect a direnv-loaded shell; CI provides the
+      # equivalent env explicitly. Provision it ONCE, into $GITHUB_ENV, so the
+      # compare pass and the archive pass below share it. SECRET in particular
+      # MUST be stable across both passes: they run against the one persistent
+      # Valkey service, and the first boot adopts the C10 secret-verifier for
+      # whatever SECRET it saw. A second, different `openssl rand` SECRET for
+      # the archive pass makes that boot's verifier report :mismatch, and
+      # RevealSecret's fast-fail (continue && verifier == :mismatch) then 503s
+      # every reveal — the archive pass's freshly-seeded secrets are encrypted
+      # with the new SECRET and would decrypt fine, but the stale verifier
+      # refuses them before the attempt. One SECRET keeps the verifier :ok.
+      # SECRET is ephemeral (production-mode boot requires one; nothing
+      # persists past the job); ACCOUNT_ID_SECRET is derived from it in
+      # bin/visual.
+      - name: Provision ephemeral visual-lane env
+        run: |
+          {
+            echo "OTS_ENV_LOADED=1"
+            echo "SECRET=$(openssl rand -hex 32)"
+            echo "REDIS_URL=redis://127.0.0.1:6379/0"
+          } >> "$GITHUB_ENV"
+
       - name: Run visual regression suite
         id: visual
-        run: |
-          # bin/visual's env guards expect a direnv-loaded shell; CI provides
-          # the equivalent env explicitly. SECRET is ephemeral (production-
-          # mode boot requires one; nothing persists past the job).
-          # ACCOUNT_ID_SECRET is derived from it inside bin/visual.
-          export OTS_ENV_LOADED=1
-          SECRET="$(openssl rand -hex 32)"
-          export SECRET
-          export REDIS_URL=redis://127.0.0.1:6379/0
-          # CONTAINER_RUNTIME auto-detects docker; on linux bin/visual runs
-          # the Playwright container with --network host and resolves the
-          # fixture hosts (*.example.com/org) to 127.0.0.1.
-          bin/visual
+        # CONTAINER_RUNTIME auto-detects docker; on linux bin/visual runs the
+        # Playwright container with --network host and resolves the fixture
+        # hosts (*.example.com/org) to 127.0.0.1.
+        run: bin/visual
 
       # PR-artifact half of the dual-artifact archive (PR 3 of the spec).
       # A fresh render of the full matrix, uploaded on green so reviewers can
@@ -120,12 +133,10 @@ jobs:
       # destructive cells (reveal destroys, first receipt view stamps).
       - name: Render archive set
         if: success()
-        run: |
-          export OTS_ENV_LOADED=1
-          SECRET="$(openssl rand -hex 32)"
-          export SECRET
-          export REDIS_URL=redis://127.0.0.1:6379/0
-          bin/visual --archive e2e/visual/.artifacts/render
+        # Reuses the SAME SECRET/REDIS_URL provisioned above (see that step's
+        # comment): a fresh SECRET here would trip the secret-verifier and 503
+        # every reveal against the shared Valkey.
+        run: bin/visual --archive e2e/visual/.artifacts/render
 
       - name: Upload rendered set
         if: success()

--- a/bin/visual
+++ b/bin/visual
@@ -3,9 +3,25 @@
 # bin/visual - Visual regression suite runner (Playwright screenshots)
 #
 # USAGE:
-#   $ bin/visual               # seed fixtures, boot server, compare against baselines
-#   $ bin/visual --update      # same, but rewrite baselines (--update-snapshots)
-#   $ bin/visual --seed-only   # seed fixtures only (no server boot, no screenshots)
+#   $ bin/visual                  # seed fixtures, boot server, compare against baselines
+#   $ bin/visual --update         # same, but rewrite baselines (--update-snapshots)
+#   $ bin/visual --seed-only      # seed fixtures only (no server boot, no screenshots)
+#   $ bin/visual --archive [DIR]  # render the full set into DIR (default
+#                                 # e2e/visual/.artifacts/render); committed
+#                                 # baselines are not read or written
+#   $ bin/visual --compare DIR    # compare the current tree's render against an
+#                                 # archived set in DIR (e.g. an oras-pulled
+#                                 # release archive) instead of the baselines
+#
+# ARCHIVES (PR 3 of the spec — dual-artifact):
+#   --archive is the producer for both artifact channels: CI uploads the
+#   rendered set as a PR artifact on green runs, and the release workflow
+#   (.github/workflows/visual-archive.yml) pushes the same directory to
+#   ghcr.io as an OCI artifact tagged with the release version. --compare is
+#   the consumer: pull any release's set and every diff is a customer-visible
+#   change between that version and this tree. Cross-version caveat: only
+#   compare sets rendered with the same PLAYWRIGHT_IMAGE tag (metadata.json
+#   records it) — browser/font-stack drift produces phantom diffs.
 #
 # WHAT IT DOES:
 #   1. Boots `bin/ots server` (RACK_ENV=production) on :7143 with the visual
@@ -115,14 +131,18 @@ VISUAL_ENV=(
 # derived from SECRET, which is only validated there.
 
 usage() {
-  echo "Usage: bin/visual [--update | --seed-only]"
-  echo "  (no flag)     seed fixtures, boot server, compare against committed baselines"
-  echo "  --update      same, but rewrite baselines (passes --update-snapshots)"
-  echo "  --seed-only   run the fixture seed task only; no server, no screenshots"
+  echo "Usage: bin/visual [--update | --seed-only | --archive [DIR] | --compare DIR]"
+  echo "  (no flag)        seed fixtures, boot server, compare against committed baselines"
+  echo "  --update         same, but rewrite baselines (passes --update-snapshots)"
+  echo "  --seed-only      run the fixture seed task only; no server, no screenshots"
+  echo "  --archive [DIR]  render the full screenshot set into DIR (default"
+  echo "                   e2e/visual/.artifacts/render); baselines untouched"
+  echo "  --compare DIR    compare against an archived set in DIR instead of baselines"
 }
 
 # --- Argument parsing (fail fast on anything unknown) ------------------------
 MODE="run"
+SNAPSHOT_DIR=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --update)
@@ -131,6 +151,27 @@ while [[ $# -gt 0 ]]; do
       ;;
     --seed-only)
       MODE="seed-only"
+      shift
+      ;;
+    --archive)
+      MODE="archive"
+      shift
+      if [[ $# -gt 0 && "$1" != -* ]]; then
+        SNAPSHOT_DIR="$1"
+        shift
+      else
+        SNAPSHOT_DIR="e2e/visual/.artifacts/render"
+      fi
+      ;;
+    --compare)
+      MODE="compare"
+      shift
+      if [[ $# -eq 0 || "$1" == -* ]]; then
+        echo "Error: --compare requires a directory argument." >&2
+        usage >&2
+        exit 1
+      fi
+      SNAPSHOT_DIR="$1"
       shift
       ;;
     -h|--help)
@@ -144,6 +185,39 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+# The Playwright container mounts only REPO_ROOT (at /work), so the snapshot
+# directory must live inside the repo. Normalize to a repo-relative path and
+# derive the in-container absolute path the config's snapshotPathTemplate
+# needs (a relative VISUAL_SNAPSHOT_DIR would resolve against e2e/, not cwd).
+SNAPSHOT_REL=""
+SNAPSHOT_CONTAINER=""
+if [[ -n "$SNAPSHOT_DIR" ]]; then
+  case "$SNAPSHOT_DIR" in
+    "$REPO_ROOT"/*) SNAPSHOT_REL="${SNAPSHOT_DIR#"$REPO_ROOT"/}" ;;
+    /*)
+      echo "Error: '$SNAPSHOT_DIR' is outside the repository — the Playwright" >&2
+      echo "  container only mounts $REPO_ROOT. Use a path inside the repo" >&2
+      echo "  (e.g. e2e/visual/.artifacts/render)." >&2
+      exit 1
+      ;;
+    *) SNAPSHOT_REL="${SNAPSHOT_DIR#./}" ;;
+  esac
+  if [[ -z "$SNAPSHOT_REL" || "$SNAPSHOT_REL" == "." || "$SNAPSHOT_REL" == *..* ]]; then
+    echo "Error: refusing snapshot directory '$SNAPSHOT_DIR' (must be a subdirectory of the repo)." >&2
+    exit 1
+  fi
+  SNAPSHOT_CONTAINER="/work/$SNAPSHOT_REL"
+
+  if [[ "$MODE" == "compare" ]]; then
+    if ! compgen -G "$REPO_ROOT/$SNAPSHOT_REL"/*-snapshots/*.png >/dev/null; then
+      echo "Error: no archived snapshots found under $SNAPSHOT_REL/*-snapshots/." >&2
+      echo "  Expected the layout produced by 'bin/visual --archive' (or an" >&2
+      echo "  'oras pull' of a visual-baselines release artifact)." >&2
+      exit 1
+    fi
+  fi
+fi
 
 # --- Dependency checks --------------------------------------------------------
 require_cmd() {
@@ -317,6 +391,20 @@ fi
 UPDATE_ARG=""
 if [[ "$MODE" == "update" ]]; then
   UPDATE_ARG="--update-snapshots"
+elif [[ "$MODE" == "archive" ]]; then
+  # Archive = write every snapshot fresh into an empty directory. Stale files
+  # from a previous render would silently mix two versions in one archive.
+  UPDATE_ARG="--update-snapshots"
+  rm -rf "${REPO_ROOT:?}/${SNAPSHOT_REL:?}"
+  mkdir -p "$REPO_ROOT/$SNAPSHOT_REL"
+fi
+
+# VISUAL_SNAPSHOT_DIR redirects snapshot reads/writes away from the committed
+# baselines (see the visual projects in e2e/playwright.config.ts). Only set
+# for archive/compare; the empty-string case must stay unset.
+SNAPSHOT_ENV_ARGS=()
+if [[ -n "$SNAPSHOT_CONTAINER" ]]; then
+  SNAPSHOT_ENV_ARGS=(-e "VISUAL_SNAPSHOT_DIR=$SNAPSHOT_CONTAINER")
 fi
 
 # Networking differs by HOST OS, not by runtime (GitHub runners preinstall
@@ -349,6 +437,7 @@ echo "Running Playwright in $PLAYWRIGHT_IMAGE ($CONTAINER_RUNTIME)..."
   -w /work \
   -e "PLAYWRIGHT_BASE_URL=http://$CANONICAL_HOST:$PORT" \
   -e "VISUAL_RESOLVER_TARGET=${VISUAL_RESOLVER_TARGET:-$RESOLVER_DEFAULT}" \
+  ${SNAPSHOT_ENV_ARGS[@]+"${SNAPSHOT_ENV_ARGS[@]}"} \
   "$PLAYWRIGHT_IMAGE" \
   npx playwright test \
     --config=e2e/playwright.config.ts \
@@ -356,9 +445,35 @@ echo "Running Playwright in $PLAYWRIGHT_IMAGE ($CONTAINER_RUNTIME)..."
     --project=visual-mobile \
     ${UPDATE_ARG:+"$UPDATE_ARG"}
 
+if [[ "$MODE" == "archive" ]]; then
+  # Provenance stamp. The consumer-side contract: --compare is only valid
+  # against a set rendered with the same playwrightImage (font/browser drift
+  # otherwise produces phantom diffs), and `version`/`commit` identify what
+  # the pixels actually show. commit comes from git, not .commit_hash.txt —
+  # that file is pinned to 0000000 during the run (see above).
+  node -e '
+    const fs = require("fs");
+    const meta = {
+      version: require("./package.json").version,
+      commit: process.argv[1],
+      playwrightImage: process.argv[2],
+      platform: "linux",
+      generatedAt: new Date().toISOString(),
+    };
+    fs.writeFileSync(process.argv[3] + "/metadata.json", JSON.stringify(meta, null, 2) + "\n");
+  ' "$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)" \
+    "$PLAYWRIGHT_IMAGE" \
+    "$REPO_ROOT/$SNAPSHOT_REL"
+fi
+
 echo
 echo "HTML report: e2e/playwright-report/  (view: pnpm exec playwright show-report e2e/playwright-report)"
 if [[ "$MODE" == "update" ]]; then
   echo "Baselines updated. Check 'git status': ONLY *-linux.png files should appear."
   echo "Any *-darwin.png means a bare-metal run leaked in — do not commit those."
+elif [[ "$MODE" == "archive" ]]; then
+  count="$(find "$REPO_ROOT/$SNAPSHOT_REL" -name '*.png' | wc -l | tr -d ' ')"
+  echo "Archived $count screenshots to $SNAPSHOT_REL/ (metadata.json alongside)."
+elif [[ "$MODE" == "compare" ]]; then
+  echo "Compared against archived set in $SNAPSHOT_REL/ (not the committed baselines)."
 fi

--- a/docs/specs/qa/visual-regressions/qa-visual-regressions-approach.md
+++ b/docs/specs/qa/visual-regressions/qa-visual-regressions-approach.md
@@ -143,6 +143,30 @@ Two operational caveats for the two-worktree run:
 - Each worktree seeds through **its own tree's** rake task (the seed boots that tree's models against that tree's config). `v0.25.11` predates `qa:visual:seed`, so copy the task file into the v0.25 worktree before seeding it.
 - v0.25-vs-v0.26 diffs on the branded cells will include rendering of brand fields that didn't exist in v0.25 — expected triage noise, not regression signal. Read those diffs with that in mind before blaming the pipeline.
 
+## 7. Cross-version archives — dual-artifact
+
+§6's two-worktree dance answers "what changed since v0.25?" exactly once, at the cost of a second checkout, seed, and render. The permanent answer is to **archive the rendered set at every release** and diff against archives instead of rebuilding old versions. Two channels, one format (`bin/visual --archive` output: `*-snapshots/` dirs + `metadata.json`):
+
+| Channel | Trigger | Where | Retention | Purpose |
+| --- | --- | --- | --- | --- |
+| PR artifact | green `visual.yml` run | workflow artifact `visual-render-<sha>` | 30 days | reviewers eyeball the PR's actual renders without checking out the branch |
+| OCI release | release published (`visual-archive.yml`) | `ghcr.io/<repo>/visual-baselines:<tag>` | permanent | cross-version diffs |
+
+Consuming an archive:
+
+```bash
+oras pull ghcr.io/onetimesecret/onetimesecret/visual-baselines:v0.26.0 \
+  -o e2e/visual/.artifacts/v0.26.0
+bin/visual --compare e2e/visual/.artifacts/v0.26.0
+```
+
+Every diff in the report is a customer-visible change between that release and your working tree. Mechanically this works by redirecting Playwright's `snapshotPathTemplate` (`VISUAL_SNAPSHOT_DIR`, set by `bin/visual`) — snapshot names are keyed by the path template (`<page>--<state>--<fixture>` + project + platform), which is stable across versions, so the sets line up file-for-file. A cell that exists in the tree but not the archive fails as "snapshot missing" — the correct signal ("this page didn't exist in that version"), triage it as such.
+
+Two caveats:
+
+- **Same Playwright image only.** Compare sets rendered with the same pinned container tag (`metadata.json` records `playwrightImage`); browser/font-stack drift across image versions produces phantom diffs. When bumping the image, regenerate baselines (already required) and expect pre-bump archives to diff noisily.
+- Archives are *renders of a version*, not approval state. The committed `e2e/visual/*-snapshots/` baselines remain the only thing PRs gate on; archives never feed back into them automatically.
+
 ## Component consistency — enforce, don't catalog
 
 Screenshot tests catch pipeline breakage; they don't manage consistency across a growing component surface. Neither does a catalog: Storybook *documents* consistency, and a catalog of 150 stories drifts as fast as the components do. For a solo maintainer the sync tax and the benefit land on the same person — the economics never invert the way they do on a team where one author pays and ten consumers benefit.

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -67,6 +67,22 @@ const visualLaunchOptions = {
 };
 
 /**
+ * Snapshot redirection for the archive/compare modes (bin/visual --archive /
+ * --compare). When VISUAL_SNAPSHOT_DIR is set, the visual projects read and
+ * write snapshots under that directory instead of the committed
+ * e2e/visual/*.spec.ts-snapshots/ baselines. The template preserves the
+ * per-spec-file layout and the default {arg}{-projectName}{-platform} naming,
+ * so an archived set is directory-diffable 1:1 against the committed
+ * baselines. bin/visual always passes an absolute (in-container) path; a
+ * relative value would resolve against this config's directory.
+ */
+const visualSnapshotOverride = process.env.VISUAL_SNAPSHOT_DIR
+  ? {
+      snapshotPathTemplate: `${process.env.VISUAL_SNAPSHOT_DIR}/{testFileName}-snapshots/{arg}{-projectName}{-platform}{ext}`,
+    }
+  : {};
+
+/**
  * Authenticated session produced by global.setup.ts and consumed by the
  * `full` / `full-billing` projects via `storageState`. Absolute on purpose
  * so writer (setup script) and readers (project `use` blocks) agree on one
@@ -232,6 +248,7 @@ export default defineConfig({
     {
       name: 'visual-desktop',
       testMatch: 'visual/**/*.spec.ts',
+      ...visualSnapshotOverride,
       expect: {
         toHaveScreenshot: { maxDiffPixels: 100 },
       },
@@ -248,6 +265,7 @@ export default defineConfig({
     {
       name: 'visual-mobile',
       testMatch: 'visual/**/*.spec.ts',
+      ...visualSnapshotOverride,
       // Cells baselined at desktop only (secret--passphrase,
       // receipt--viewed, receipt--burned) are tagged @desktop-only;
       // excluding them here keeps `--list` exact instead of runtime-skipping.


### PR DESCRIPTION
Final PR of the visual-regression spec (#3722 → #3723 → this). Archives the rendered screenshot set through two channels in one format, so any two versions can be diffed without rebuilding old checkouts.

## Dual-artifact archive

| Channel | Trigger | Where | Retention |
| --- | --- | --- | --- |
| PR artifact | green `visual.yml` run | `visual-render-<sha>` workflow artifact | 30 days |
| OCI release | release published (`visual-archive.yml`, new) | `ghcr.io/<repo>/visual-baselines:<tag>` | permanent |

Consuming an archive for a cross-version diff:

```bash
oras pull ghcr.io/onetimesecret/onetimesecret/visual-baselines:v0.26.0 -o e2e/visual/.artifacts/v0.26.0
bin/visual --compare e2e/visual/.artifacts/v0.26.0
```

Every diff in the report is a customer-visible change between that release and the working tree — the §6 two-worktree release gate, made permanent.

## How

- **`bin/visual --archive [DIR]`** renders the full 52-shot matrix into DIR (default `e2e/visual/.artifacts/render`, gitignored) plus a `metadata.json` provenance stamp (version, commit, Playwright image tag). Committed baselines are never read or written: the run redirects Playwright's `snapshotPathTemplate` via `VISUAL_SNAPSHOT_DIR`, preserving the per-spec-file layout and default `{arg}{-projectName}{-platform}` naming so sets stay directory-diffable 1:1 against `e2e/visual/*-snapshots/`.
- **`bin/visual --compare DIR`** runs the comparison against an archived set instead of the baselines. A cell missing from the archive fails as snapshot-missing — the correct signal that the page didn't exist in that version. The snapshot dir must live inside the repo (the Playwright container mounts only the repo root); the script validates and translates the path.
- **`visual.yml`**: on green, a second `bin/visual --archive` invocation renders the upload set (re-boot + re-seed is required regardless — the compare pass consumed the destructive cells: reveal destroys, first receipt view stamps). Also adds a sticky upserted PR comment summarizing the run (changed-shot list on red, pass marker on green, explicit warning when comparison passed but a later step failed).
- **`visual-archive.yml`** (new): on `release: published`, render at the tag and `oras push` to ghcr (`packages: write`, token via env, OCI tag charset guard, `workflow_dispatch` fallback tag `sha-<short>` for backfilling from a tag's ref).

## Caveat pinned in the spec (§7)

Only compare sets rendered with the same pinned Playwright container tag (`metadata.json` records it) — browser/font-stack drift across image versions produces phantom diffs. Archives are renders of a version, not approval state: the committed baselines remain the only thing PRs gate on.

## Verified

- `bin/visual --archive` live: 52 shots + metadata.json written, baselines untouched (`git status` clean of PNGs).
- `bin/visual --compare` against that set: 52/52 pass.
- Default baseline mode after the config change: 52/52 pass (override is inert without `VISUAL_SNAPSHOT_DIR`).
- `actionlint` clean on both workflows.