### PR TITLE
Fix stale CLI paths in translation docs and help text

### DIFF
--- a/locales/AGENT_TRANSLATION_PROTOCOL.md
+++ b/locales/AGENT_TRANSLATION_PROTOCOL.md
@@ -2,8 +2,9 @@
 
 > **Audience: a single automated background translator agent draining one
 > locale.** This is the machine-executable spec the orchestration slash commands
-> (`/d:translate-parallel-agents`, `/d:start-translation-session`,
-> `/d:translate-workflow`) point their `saas-translator` agents at. It is
+> (`translate-parallel-agents`, `start-translation-session`,
+> `translate-workflow` — vendored in `locales/slash_commands/`, installed under a
+> command namespace such as `/i18n:`) point their `saas-translator` agents at. It is
 > self-contained and executable by reference: an agent given a locale and this
 > file has everything it needs to drain that locale's task queue.
 >
@@ -110,7 +111,7 @@ Loop this until the queue is dry:
    ```bash
    python3 locales/scripts/i18n tasks next <LOCALE> --stats
    ```
-   shows **0 pending**.
+   shows `pending: 0`.
 
 ## Translation rules
 
@@ -170,4 +171,4 @@ Do **not** export (`tasks export`), do **not** sync (`pnpm run locales:sync` /
 `content compile`), do **not** commit or create branches, and do **not** write
 the glossary/committable DB tables. Those are human/orchestrator steps
 documented in `TRANSLATION_PROTOCOL.md`. The agent's job ends when the locale
-shows 0 pending, the audit is clean, and the glossary candidates are reported.
+shows `pending: 0`, the audit is clean, and the glossary candidates are reported.

--- a/locales/BATCH_OPERATIONS.md
+++ b/locales/BATCH_OPERATIONS.md
@@ -10,6 +10,7 @@ workflow checks etc, and to avoid any conflicts merging back into main)
 
 ```bash
 git fetch origin
+start=$(git branch --show-current)
 failed=()
 for b in $(git branch --list 'i18n/update-*' --format='%(refname:short)'); do
   echo "=== $b ==="
@@ -19,7 +20,7 @@ for b in $(git branch --list 'i18n/update-*' --format='%(refname:short)'); do
     echo ">>> conflict, left $b untouched"
   fi
 done
-git switch chore/i18n-content-hashes-command
+git switch "$start"   # rebases pollute @{-1}, so `git switch -` lands wrong
 echo "Rebased cleanly; needs manual attention: ${failed[*]:-none}"
 ```
 

--- a/locales/README.md
+++ b/locales/README.md
@@ -6,7 +6,7 @@ Locale translations tracked as SQLite tasks, translated by agents, exported back
 
 - `content/` — source of truth, all locales, flat keys (`content/en/` is the authoritative source text)
 - `db/` — SQLite task DB (ephemeral working state; hydrated on demand, real only after export)
-- `guides/` — translation guides and per-locale references
+- `guides/` — static shared guides (security, UX); per-locale guides are derived into gitignored `generated/i18n/` by `scripts/derive-governance.sh`, never committed here
 - `scripts/` — orchestration tooling
 - `generated/locales/` — build output the app consumes (never edit; `pnpm run locales:sync`)
 
@@ -25,7 +25,7 @@ python3 locales/scripts/i18n db migrate
 
 # 3. Drain all locales with parallel agents (creates tasks --missing-only,
 #    translates, verifies; agents report glossary candidates, they don't write them)
-/d:translate-parallel-agents
+/i18n:translate-parallel-agents        # installed from locales/slash_commands/
 
 # 4. Export each fully drained locale, then the shared tables once
 python3 locales/scripts/i18n tasks next <locale> --stats   # must show pending: 0
@@ -35,7 +35,7 @@ python3 locales/scripts/i18n db export                     # once, after all loc
 # 5. Commit content + db tables, then split into review branches
 git add locales/content/ locales/db/*.sql
 locales/scripts/branch-per-locale.sh --changed --execute   # one i18n/update-{locale} branch each
-/d:review-locale-branches
+locales/scripts/review-locale-branches.sh validate         # deterministic checks; full agent review: locales/slash_commands/review-locale-branches.md
 ```
 
 Two rules that bite:

--- a/locales/TRANSLATION_PROTOCOL.md
+++ b/locales/TRANSLATION_PROTOCOL.md
@@ -129,7 +129,7 @@ Creates `i18n/update-{locale}` branches off develop. Each branch contains only o
 
 ### 9. Review branches
 
-Run `/d:review-locale-branches` to orchestrate parallel code-reviewer agents grouped by language family. The workflow:
+Follow `locales/slash_commands/review-locale-branches.md` (installable as a slash command) to orchestrate parallel code-reviewer agents grouped by language family; it drives `locales/scripts/review-locale-branches.sh` (`validate|consolidate|init|families`) for the deterministic stages. The workflow:
 1. Automated variable validation (catches mechanical issues)
 2. Agent review by family (linguistic/quality checks)
 3. Triage and fix critical findings before merge

--- a/locales/scripts/i18n/commands/tasks.py
+++ b/locales/scripts/i18n/commands/tasks.py
@@ -55,8 +55,8 @@ def _register_create(gsub) -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-    python create.py fr_CA           # Generate tasks for Canadian French
-    python create.py eo --dry-run    # Preview without writing
+    python3 locales/scripts/i18n tasks create fr_CA            # Generate tasks for Canadian French
+    python3 locales/scripts/i18n tasks create eo --dry-run     # Preview without writing
         """,
     )
     c.add_argument(
@@ -72,8 +72,9 @@ Examples:
         "--missing-only",
         action="store_true",
         help=(
-            "Enqueue only keys untranslated in content/<locale> (absent, or "
-            "empty text without skip), skipping levels with no work. Catches a "
+            "Enqueue keys untranslated in content/<locale> (absent, or empty "
+            "text without skip) plus stale ones (translated, but the en source "
+            "changed since), skipping levels with no work. Catches a "
             "locale up to a grown English source without re-touching reviewed "
             "translations. Run once per locale (re-running rewrites keys_json)."
         ),
@@ -89,13 +90,13 @@ def _register_next(gsub) -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-    python next.py eo                    # Show next pending task
-    python next.py eo --claim            # Claim task (mark in_progress)
-    python next.py eo --json             # Output as JSON
-    python next.py eo --file auth.json   # Filter by file
-    python next.py eo --filter web.COMMON  # Filter by key path prefix
-    python next.py eo --stats            # Show task statistics
-    python next.py eo --id 42            # Get specific task by ID
+    python3 locales/scripts/i18n tasks next eo                    # Show next pending task
+    python3 locales/scripts/i18n tasks next eo --claim            # Claim task (mark in_progress)
+    python3 locales/scripts/i18n tasks next eo --json             # Output as JSON
+    python3 locales/scripts/i18n tasks next eo --file auth.json   # Filter by file
+    python3 locales/scripts/i18n tasks next eo --filter web.COMMON  # Filter by key path prefix
+    python3 locales/scripts/i18n tasks next eo --stats            # Show task statistics
+    python3 locales/scripts/i18n tasks next eo --id 42            # Get specific task by ID
         """,
     )
     c.add_argument(
@@ -145,11 +146,11 @@ def _register_update(gsub) -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-    python update.py 42 '{"submit": "Sendi", "cancel": "Nuligi"}'
-    python update.py 42 --file translations.json
-    python update.py 42 --skip --note "Not applicable"
-    python update.py 42 --status pending  # Reset to pending
-    python update.py 42 --status in_progress  # Mark as in progress
+    python3 locales/scripts/i18n tasks update 42 '{"submit": "Sendi", "cancel": "Nuligi"}'
+    python3 locales/scripts/i18n tasks update 42 --file translations.json --validate
+    python3 locales/scripts/i18n tasks update 42 --skip --note "Not applicable"
+    python3 locales/scripts/i18n tasks update 42 --status pending  # Reset to pending
+    python3 locales/scripts/i18n tasks update 42 --status in_progress  # Mark as in progress
         """,
     )
     c.add_argument(
@@ -211,9 +212,9 @@ def _register_export(gsub) -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-    python export.py eo --dry-run
-    python export.py eo
-    python export.py eo --file 00-common.json
+    python3 locales/scripts/i18n tasks export eo --dry-run
+    python3 locales/scripts/i18n tasks export eo
+    python3 locales/scripts/i18n tasks export eo --file 00-common.json
         """,
     )
     c.add_argument(
@@ -496,7 +497,7 @@ def insert_tasks(tasks: list[TranslationTask]) -> int:
     if not DB_FILE.exists():
         raise FileNotFoundError(
             f"Database not found: {DB_FILE}\n"
-            "Run 'python locales/scripts/store.py init' to create it first."
+            "Run 'python3 locales/scripts/i18n db init' to create it first."
         )
 
     count = 0
@@ -606,7 +607,7 @@ def get_next_task(
     if not DB_FILE.exists():
         raise FileNotFoundError(
             f"Database not found: {DB_FILE}\n"
-            "Run 'python locales/scripts/store.py init' to create it first."
+            "Run 'python3 locales/scripts/i18n db init' to create it first."
         )
 
     with get_connection() as conn:
@@ -713,7 +714,12 @@ def get_task_stats(locale: str) -> dict:
             (locale,),
         )
         rows = cursor.fetchall()
-        return {row[0]: row[1] for row in rows}
+        # Always report pending/completed, even at 0: every documented loop and
+        # monitor condition is "stop when pending: 0", and GROUP BY alone drops
+        # zero-count statuses so that line would otherwise never print.
+        stats = {"pending": 0, "completed": 0}
+        stats.update({row[0]: row[1] for row in rows})
+        return stats
 
 
 def compute_coverage(locale: str) -> dict[str, int]:
@@ -865,7 +871,7 @@ def update_task(
     if not DB_FILE.exists():
         raise FileNotFoundError(
             f"Database not found: {DB_FILE}\n"
-            "Run 'python locales/scripts/store.py init' to create it first."
+            "Run 'python3 locales/scripts/i18n db init' to create it first."
         )
 
     if status and status not in VALID_STATUSES:

--- a/locales/slash_commands/start-translation-session.md
+++ b/locales/slash_commands/start-translation-session.md
@@ -59,10 +59,11 @@ python3 locales/scripts/i18n tasks next fr_CA --stats
 
 ### 1. Create Tasks (if needed)
 
-For each eligible locale that needs tasks generated, enqueue only the keys still
-untranslated in `content/LOCALE` so a DB rebuild never requeues already-translated
-(reviewed) strings. Use `--missing-only` for existing locales; drop it only to
-bootstrap a brand-new, empty locale:
+For each eligible locale that needs tasks generated, enqueue the keys still
+untranslated in `content/LOCALE` **plus** stale ones (translated, but en changed
+since) — already-translated, still-current reviewed strings are never requeued.
+Use `--missing-only` for existing locales; drop it only to bootstrap a
+brand-new, empty locale:
 
 ```bash
 python3 locales/scripts/i18n tasks create LOCALE --missing-only

--- a/locales/slash_commands/translate-new-language.md
+++ b/locales/slash_commands/translate-new-language.md
@@ -1,7 +1,7 @@
 ---
 description: Translate locale files for a single target language using git diff detection, routed through the agent protocol
 argument-hint: <lang-code>
-allowed-tools: Bash(git diff:*), Bash(cp:*), Bash(ls:*), Bash(cat:*), Bash([ -f:*), Bash(jq:*), Bash(python3 locales/scripts/i18n tasks:*), Task, Read, Glob
+allowed-tools: Bash(git diff:*), Bash(ls:*), Bash([ -f:*), Bash(jq:*), Bash(locales/scripts/derive-governance.sh:*), Bash(python3 locales/scripts/i18n tasks:*), Task, Read, Glob
 ---
 
 # Translate a Single Language
@@ -32,7 +32,8 @@ ls locales/content/en/*.json 2>/dev/null && echo "MODERN_STRUCTURE"
 
 Source of truth is `./locales/content/{lang}/`.
 
-**Paths to IGNORE** (do not edit): `./generate/`, `./src/locales/` — compiled/legacy, not source.
+**Paths to IGNORE** (do not edit): `./generated/locales/`, `./generated/types/` —
+compiled output. `generated/i18n/.resolved/` is required input, not output to ignore.
 
 ## Eligibility gate
 
@@ -67,11 +68,10 @@ If not eligible, stop and report — do not translate without the resolved artif
    git diff --no-index locales/content/en locales/content/{lang} 2>/dev/null || echo "New locale"
    ```
 
-2. **For a brand-new language**, seed the directory from English structure so the
-   keys exist to be drained:
-   ```bash
-   cp -r locales/content/en locales/content/{lang}
-   ```
+2. **For a brand-new language**, do NOT seed the directory by copying
+   `locales/content/en` — that plants ~3,500 English strings as if they were
+   translations. `tasks create` reads only the English source, and `tasks export`
+   creates the per-file target JSON on first write; no seeding is needed.
 
 3. **Build the task queue** so the agent has pending work:
    ```bash
@@ -103,6 +103,6 @@ Verify, then report. Do NOT export or commit — that's a separate human step.
 
 ## For Multiple Locales in Parallel
 
-Use `/d:translate-parallel-agents` to orchestrate multiple `saas-translator`
+Use `/i18n:translate-parallel-agents` to orchestrate multiple `saas-translator`
 background agents translating different locales simultaneously. This is more
 efficient for batch translation work.

--- a/locales/slash_commands/translate-parallel-agents.md
+++ b/locales/slash_commands/translate-parallel-agents.md
@@ -29,7 +29,9 @@ setup or retry handling here.
 3. Per-locale governance at `generated/i18n/.resolved/{LOCALE}.json`, derived on
    demand by `locales/scripts/derive-governance.sh` (see eligibility gate).
 4. Source locale JSON at `./locales/content/{locale}/*.json`.
-5. **Paths to IGNORE**: `./generate/`, `./src/locales/` (compiled/legacy, not source).
+5. **Paths to IGNORE**: `./generated/locales/`, `./generated/types/` (compiled
+   output — never edit). `generated/i18n/` is NOT ignorable output: `.resolved/`
+   there is required agent input (see eligibility gate).
 
 ## Arguments
 
@@ -121,7 +123,7 @@ loops.** Proactively run a single poll, read the result, then poll again when re
 ```bash
 for locale in fr_CA de es pt_BR eo; do
   printf "%-6s: " "$locale"
-  python3 locales/scripts/i18n tasks next $locale --stats 2>/dev/null | grep -oE "[0-9]+ pending|[0-9]+ completed" | tr '\n' ' '
+  python3 locales/scripts/i18n tasks next $locale --stats 2>/dev/null | grep -oE "(pending|completed): [0-9]+" | tr '\n' ' '
   echo
 done
 ```
@@ -159,23 +161,23 @@ Do NOT run export until the user explicitly requests it.
 
 ```bash
 # Start fresh with 3 locales, max 5 agents
-/d:translate-parallel-agents fr_CA de es --max-agents 5
+/i18n:translate-parallel-agents fr_CA de es --max-agents 5
 
 # Check progress only
-/d:translate-parallel-agents --stats
+/i18n:translate-parallel-agents --stats
 
 # Resume monitoring after /compact
-/d:translate-parallel-agents --resume
+/i18n:translate-parallel-agents --resume
 
 # Add more locales to existing run
-/d:translate-parallel-agents pt_BR eo --max-agents 5
+/i18n:translate-parallel-agents pt_BR eo --max-agents 5
 ```
 
 ## Common Mistakes (Avoid These)
 
 1. **Wrong table name**: the SQLite table is `translation_tasks`, NOT `tasks`.
 2. **Wrong locale file path**: source translations live in `./locales/content/`,
-   not `src/locales/` or `./generate/`.
+   not `./generated/locales/` (compiled output).
 3. **Passive waiting**: do NOT just wait for completion notifications — actively
    poll with `tasks next LOCALE --stats`.
 4. **Raw database queries**: use the CLI (`tasks next LOCALE --stats`), not raw
@@ -222,7 +224,7 @@ python3 locales/scripts/i18n db query \
    VALUES ('<LOCALE>', '<term>', '<rendering>', '<why>')"
 ```
 
-This is the drain's substitute for the manual step 7; without it, an
+This is the drain's substitute for the manual protocol's glossary step (step 5); without it, an
 agent-drained locale accrues no glossary entries (only the standing QC pass
 would). Optionally audit the drained result against the bound renderings:
 


### PR DESCRIPTION
## Summary

Follow-up to #3724. Updates translation tooling docs and CLI help text that still referenced retired paths and commands:

- CLI `--help` epilogs in `tasks.py` now show the real invocation (`python3 locales/scripts/i18n tasks ...`) instead of the old standalone `create.py`/`next.py`/`update.py` scripts, and the `--missing-only` help mentions stale-key enqueueing.
- Doc references to personal `/d:*` slash commands replaced with the vendored `locales/slash_commands/` names (installable under a namespace like `/i18n:`), so the docs work for any contributor.
- `README.md` clarifies that per-locale guides are derived into gitignored `generated/i18n/` by `derive-governance.sh`, not committed under `guides/`.
- `BATCH_OPERATIONS.md` rebase loop returns to the captured starting branch instead of a hardcoded one.

Docs-only plus help-text strings; no behavior change.