### PR TITLE
i18n: translate 'Secret Support' sign-off + reconcile workspace labels (29 locales)

### DIFF
--- a/locales/content/ar/email.json
+++ b/locales/content/ar/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "دعم الأسرار",
+    "text": "فريق دعم Onetime Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/bg/10-layout.json
+++ b/locales/content/bg/10-layout.json
@@ -340,7 +340,7 @@
     "source_hash": "dc6fa4f5"
   },
   "web.footer.workspace": {
-    "text": "Работна област",
+    "text": "Работно пространство",
     "source_hash": "87bb59ba"
   },
   "web.help.default_content": {

--- a/locales/content/bg/email.json
+++ b/locales/content/bg/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Поддръжка на тайни",
+    "text": "Екип за поддръжка на Onetime Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/ca_ES/email.json
+++ b/locales/content/ca_ES/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Secret Support",
+    "text": "Equip de suport d'Onetime Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/cs/email.json
+++ b/locales/content/cs/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Secret Support",
+    "text": "Tým podpory Onetime Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/da_DK/10-layout.json
+++ b/locales/content/da_DK/10-layout.json
@@ -340,7 +340,7 @@
     "source_hash": "dc6fa4f5"
   },
   "web.footer.workspace": {
-    "text": "Workspace",
+    "text": "Arbejdsområde",
     "source_hash": "87bb59ba"
   },
   "web.help.default_content": {

--- a/locales/content/da_DK/email.json
+++ b/locales/content/da_DK/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Secret Support",
+    "text": "Onetime Secret-support",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/de/email.json
+++ b/locales/content/de/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Secret Support",
+    "text": "Onetime Secret Support-Team",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/de_AT/10-layout.json
+++ b/locales/content/de_AT/10-layout.json
@@ -340,7 +340,7 @@
     "source_hash": "dc6fa4f5"
   },
   "web.footer.workspace": {
-    "text": "Workspace",
+    "text": "Arbeitsbereich",
     "source_hash": "87bb59ba"
   },
   "web.help.default_content": {

--- a/locales/content/de_AT/email.json
+++ b/locales/content/de_AT/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Secret Support",
+    "text": "Onetime Secret Support-Team",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/el_GR/email.json
+++ b/locales/content/el_GR/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Υποστήριξη μυστικών",
+    "text": "Ομάδα υποστήριξης του Onetime Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/eo/email.json
+++ b/locales/content/eo/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Sekreta Subteno",
+    "text": "Subtena teamo de Onetime Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/es/email.json
+++ b/locales/content/es/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Soporte Secreto",
+    "text": "Equipo de soporte de Onetime Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/fr_CA/email.json
+++ b/locales/content/fr_CA/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Soutien aux secrets",
+    "text": "L'équipe de soutien d'Onetime Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/fr_FR/email.json
+++ b/locales/content/fr_FR/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Support des secrets",
+    "text": "L'équipe d'assistance Onetime Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/he/email.json
+++ b/locales/content/he/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "צוות התמיכה",
+    "text": "צוות התמיכה של Onetime Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/hu/email.json
+++ b/locales/content/hu/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Secret Support",
+    "text": "Onetime Secret ügyfélszolgálat",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/it_IT/10-layout.json
+++ b/locales/content/it_IT/10-layout.json
@@ -340,7 +340,7 @@
     "source_hash": "dc6fa4f5"
   },
   "web.footer.workspace": {
-    "text": "Workspace",
+    "text": "Area di lavoro",
     "source_hash": "87bb59ba"
   },
   "web.help.default_content": {

--- a/locales/content/it_IT/email.json
+++ b/locales/content/it_IT/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Secret Support",
+    "text": "Team di supporto di Onetime Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/ja/email.json
+++ b/locales/content/ja/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "シークレットサポート",
+    "text": "Onetime Secret サポートチーム",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/ko/10-layout.json
+++ b/locales/content/ko/10-layout.json
@@ -340,7 +340,7 @@
     "source_hash": "dc6fa4f5"
   },
   "web.footer.workspace": {
-    "text": "워크스페이스",
+    "text": "작업 공간",
     "source_hash": "87bb59ba"
   },
   "web.help.default_content": {

--- a/locales/content/ko/email.json
+++ b/locales/content/ko/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Secret Support",
+    "text": "Onetime Secret 지원팀",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/mi_NZ/email.json
+++ b/locales/content/mi_NZ/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Tautoko Huna",
+    "text": "Te Kapa Tautoko o Onetime Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/nl/email.json
+++ b/locales/content/nl/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Secret Support",
+    "text": "Onetime Secret-supportteam",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/pl/10-layout.json
+++ b/locales/content/pl/10-layout.json
@@ -340,7 +340,7 @@
     "source_hash": "dc6fa4f5"
   },
   "web.footer.workspace": {
-    "text": "Obszar roboczy",
+    "text": "Przestrzeń robocza",
     "source_hash": "87bb59ba"
   },
   "web.help.default_content": {

--- a/locales/content/pl/email.json
+++ b/locales/content/pl/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Wsparcie Secret",
+    "text": "Zespół pomocy Onetime Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/pt_BR/10-layout.json
+++ b/locales/content/pt_BR/10-layout.json
@@ -340,7 +340,7 @@
     "source_hash": "dc6fa4f5"
   },
   "web.footer.workspace": {
-    "text": "Workspace",
+    "text": "Área de Trabalho",
     "source_hash": "87bb59ba"
   },
   "web.help.default_content": {

--- a/locales/content/pt_BR/email.json
+++ b/locales/content/pt_BR/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Suporte Secret",
+    "text": "Equipe de Suporte do Onetime Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/pt_PT/10-layout.json
+++ b/locales/content/pt_PT/10-layout.json
@@ -332,7 +332,7 @@
     "source_hash": "e1d200cb"
   },
   "web.layout.workspace": {
-    "text": "Área de trabalho",
+    "text": "Espaço de trabalho",
     "source_hash": "87bb59ba"
   },
   "web.layout.workspace_context": {

--- a/locales/content/pt_PT/email.json
+++ b/locales/content/pt_PT/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Suporte Secret",
+    "text": "Equipa de Suporte do Onetime Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/ru/email.json
+++ b/locales/content/ru/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Secret Support",
+    "text": "Служба поддержки Onetime Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/sl_SI/email.json
+++ b/locales/content/sl_SI/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Ekipa za podporo",
+    "text": "Ekipa za podporo Onetime Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/sv_SE/email.json
+++ b/locales/content/sv_SE/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Hemlig Support",
+    "text": "Onetime Secret-supporten",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/tr/email.json
+++ b/locales/content/tr/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Destek Ekibi",
+    "text": "Onetime Secret Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/uk/email.json
+++ b/locales/content/uk/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Служба підтримки Secret",
+    "text": "Служба підтримки Onetime Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/vi/email.json
+++ b/locales/content/vi/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "Đội ngũ hỗ trợ",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "Đội ngũ hỗ trợ",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "Đội ngũ hỗ trợ",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "Đội ngũ hỗ trợ",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Hỗ trợ bí mật",
+    "text": "Đội ngũ hỗ trợ Onetime Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "Đội ngũ hỗ trợ",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "Đội ngũ hỗ trợ",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "Đội ngũ hỗ trợ",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "Đội ngũ hỗ trợ",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "Đội ngũ hỗ trợ",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "Đội ngũ hỗ trợ",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "Đội ngũ hỗ trợ",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "Đội ngũ hỗ trợ",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "Đội ngũ hỗ trợ",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "Đội ngũ hỗ trợ",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "Đội ngũ hỗ trợ",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -735,7 +735,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "Đội ngũ hỗ trợ",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -760,7 +760,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "Đội ngũ hỗ trợ",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -802,7 +802,7 @@
     "source_hash": "be91940b"
   },
   "email.expiration_warning.signature": {
-    "text": "Delano",
+    "text": "Đội ngũ hỗ trợ",
     "source_hash": "dc75bf9f"
   },
   "email.expiration_warning.footer_note": {

--- a/locales/content/zh/email.json
+++ b/locales/content/zh/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Secret Support",
+    "text": "Onetime Secret 支持团队",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },


### PR DESCRIPTION
## What

Content corrections mandated by the translation-rules **2026-07-02 ruling** ('Secret Support' and 'Workspace' are not brands — translate by meaning; retro `2026-07-02-signature-brand-vs-translatable`), signed off in [translation-rules#55](https://github.com/onetimesecret/translation-rules/pull/55) and encoded as glossary terms in [translation-rules#56](https://github.com/onetimesecret/translation-rules/pull/56).

**55 string edits, 37 files, `text` only** — `source_hash` fields untouched (the en source text is unchanged).

### 1. `email.feedback_email.signature` — all 29 locales

New pattern: brand anchor **'Onetime Secret' (kept English) + the locale's support-team phrase**, keeping the sign-off distinct from the ~20 generic 'Support Team' signatures (the en source separates them by content_hash `f6a6c90f` vs `dc75bf9f`). Fixes every defect class from the wave review: 11 English leaks, partial splices ('Suporte Secret', 'Wsparcie Secret', 'Служба підтримки Secret'), wrong-sense calques ('Soporte Secreto', 'Hỗ trợ bí mật', 'Tautoko Huna'), generic collapses (he, sl_SI, tr), and the ja katakana transliteration.

### 2. vi 'Delano' repair

18 generic signatures in `vi/email.json` were still signed **'Delano'** — vi is the lone locale that never received commit `1664dd6a4`'s Delano→Support Team retirement. Now 'Đội ngũ hỗ trợ'.

### 3. Workspace label reconciliation (8 keys)

To the glossary canonical form: `web.footer.workspace` for bg (variant 'Работна област'), da_DK / de_AT / it_IT / pt_BR (English leaks), ko (katakana '워크스페이스' → '작업 공간'), pl (variant 'Obszar roboczy'); `web.layout.workspace` for pt_PT ('Área de trabalho' → 'Espaço de trabalho').

## mi_NZ caveat

The mi_NZ values follow the sign-off review's flag: encoded as drafted but **pending external native validation** (kapa vs rōpū tautoko; possessive particle 'o'; 'Wāhi Mahi' calque). The glossary entries in translation-rules#56 carry the same CONFIDENCE: LOW marker.

## Verification

All 29 changed locales pass `lint_content.py` locally against models derived from the updated translation-rules tree (register forbidden-token scan, same engine as the validate-register gate).

## Follow-up

Once this and translation-rules#56 merge, the retro `2026-07-02-signature-brand-vs-translatable` flips to `applied` and its CI grace waiver is dropped (closing PR in translation-rules).