### PR TITLE
[i18n] Replace raw %{status} enum in invite errors with per-status keys

### DIFF
--- a/apps/api/invite/logic/base.rb
+++ b/apps/api/invite/logic/base.rb
@@ -79,19 +79,27 @@ module InviteAPI
       # can't honour. Each status maps to its own complete sentence key; any
       # unexpected status falls back to the generic "processed" key.
       def raise_already_processed(invitation)
-        error_key, msg =
-          case invitation.status
-          when 'accepted', 'active'
-            ['api.invite.errors.invitation_already_accepted',
-             'This invitation has already been accepted']
-          when 'declined'
-            ['api.invite.errors.invitation_already_declined',
-             'This invitation has already been declined']
-          else
-            ['api.invite.errors.invitation_already_processed',
-             'This invitation has already been processed']
-          end
-        raise_form_error(msg, error_key: error_key, field: :token, error_type: :invalid)
+        opts = { field: :token, error_type: :invalid }
+        case invitation.status
+        when 'accepted', 'active'
+          raise_form_error(
+            'This invitation has already been accepted',
+            error_key: 'api.invite.errors.invitation_already_accepted',
+            **opts,
+          )
+        when 'declined'
+          raise_form_error(
+            'This invitation has already been declined',
+            error_key: 'api.invite.errors.invitation_already_declined',
+            **opts,
+          )
+        else
+          raise_form_error(
+            'This invitation has already been processed',
+            error_key: 'api.invite.errors.invitation_already_processed',
+            **opts,
+          )
+        end
       end
 
       # Serialize brand settings for public API response (guest-safe)

--- a/apps/api/invite/logic/base.rb
+++ b/apps/api/invite/logic/base.rb
@@ -71,6 +71,29 @@ module InviteAPI
         invitation.status
       end
 
+      # Raise the "already processed" form error with a status-specific,
+      # fully-translatable message key. The invitation status ('accepted' /
+      # 'active' / 'declined') is a raw backend enum, so it must never be
+      # interpolated into a single "already been %{status}" frame — that leaks
+      # an untranslated English token and assumes a word order many languages
+      # can't honour. Each status maps to its own complete sentence key; any
+      # unexpected status falls back to the generic "processed" key.
+      def raise_already_processed(invitation)
+        error_key, msg =
+          case invitation.status
+          when 'accepted', 'active'
+            ['api.invite.errors.invitation_already_accepted',
+             'This invitation has already been accepted']
+          when 'declined'
+            ['api.invite.errors.invitation_already_declined',
+             'This invitation has already been declined']
+          else
+            ['api.invite.errors.invitation_already_processed',
+             'This invitation has already been processed']
+          end
+        raise_form_error(msg, error_key: error_key, field: :token, error_type: :invalid)
+      end
+
       # Serialize brand settings for public API response (guest-safe)
       def serialize_brand_public(brand_settings, custom_domain)
         return nil unless brand_settings && custom_domain

--- a/apps/api/invite/logic/invites/accept_invite.rb
+++ b/apps/api/invite/logic/invites/accept_invite.rb
@@ -48,15 +48,7 @@ module InviteAPI::Logic
         end
 
         # Check if invitation is still pending
-        unless @invitation.pending?
-          raise_form_error(
-            "Invitation has already been #{@invitation.status}",
-            error_key: 'api.invite.errors.invitation_already_processed',
-            args: { status: @invitation.status },
-            field: :token,
-            error_type: :invalid,
-          )
-        end
+        raise_already_processed(@invitation) unless @invitation.pending?
 
         # Check if invitation has expired
         if @invitation.expired?

--- a/apps/api/invite/logic/invites/decline_invite.rb
+++ b/apps/api/invite/logic/invites/decline_invite.rb
@@ -44,12 +44,7 @@ module InviteAPI::Logic
         # Check if invitation is still pending
         return if @invitation.pending?
 
-        raise_form_error(
-          error_key: 'api.invite.errors.invitation_already_processed',
-          args: { status: @invitation.status },
-          field: :token,
-          error_type: :invalid,
-        )
+        raise_already_processed(@invitation)
 
         # NOTE: We allow declining expired invitations since the user
         # is explicitly rejecting it. No harm in processing the decline.

--- a/apps/api/invite/logic/invites/signup_and_accept.rb
+++ b/apps/api/invite/logic/invites/signup_and_accept.rb
@@ -70,12 +70,7 @@ module InviteAPI::Logic
         end
 
         # Check if invitation is still pending
-        unless @invitation.pending?
-          raise_form_error(
-            "Invitation has already been #{@invitation.status}",
-            field: :token,
-          )
-        end
+        raise_already_processed(@invitation) unless @invitation.pending?
 
         # Check if invitation has expired
         if @invitation.expired?

--- a/apps/api/invite/spec/logic/invites/accept_invite_spec.rb
+++ b/apps/api/invite/spec/logic/invites/accept_invite_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe InviteAPI::Logic::Invites::AcceptInvite do
 
       it 'raises form error for already accepted invitation' do
         expect { logic.raise_concerns }.to raise_error(Onetime::FormError) do |error|
-          expect(error.error_key).to eq('api.invite.errors.invitation_already_processed')
+          expect(error.error_key).to eq('api.invite.errors.invitation_already_accepted')
         end
       end
     end

--- a/locales/content/ar/workspace-organizations.json
+++ b/locales/content/ar/workspace-organizations.json
@@ -663,10 +663,6 @@
     "text": "المؤسسة لم تعد موجودة",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "تم بالفعل %{status} الدعوة",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "انتهت صلاحية الدعوة",
     "source_hash": "7186297b"

--- a/locales/content/bg/workspace-organizations.json
+++ b/locales/content/bg/workspace-organizations.json
@@ -663,10 +663,6 @@
     "text": "Организацията вече не съществува",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "Поканата вече е %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "Поканата е изтекла",
     "source_hash": "7186297b"

--- a/locales/content/ca_ES/workspace-organizations.json
+++ b/locales/content/ca_ES/workspace-organizations.json
@@ -663,10 +663,6 @@
     "text": "L'organització ja no existeix",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "La invitació ja consta com a %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "La invitació ha caducat",
     "source_hash": "7186297b"

--- a/locales/content/cs/workspace-organizations.json
+++ b/locales/content/cs/workspace-organizations.json
@@ -663,10 +663,6 @@
     "text": "Organizace již neexistuje",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "Pozvánka již má stav: %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "Platnost pozvánky vypršela",
     "source_hash": "7186297b"

--- a/locales/content/da_DK/workspace-organizations.json
+++ b/locales/content/da_DK/workspace-organizations.json
@@ -663,10 +663,6 @@
     "text": "Organisationen findes ikke længere",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "Invitationen er allerede blevet %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "Invitationen er udløbet",
     "source_hash": "7186297b"

--- a/locales/content/de/workspace-organizations.json
+++ b/locales/content/de/workspace-organizations.json
@@ -855,10 +855,6 @@
     "text": "Die Organisation existiert nicht mehr",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "Die Einladung wurde bereits %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "Die Einladung ist abgelaufen",
     "source_hash": "7186297b"

--- a/locales/content/de_AT/workspace-organizations.json
+++ b/locales/content/de_AT/workspace-organizations.json
@@ -663,10 +663,6 @@
     "text": "Die Organisation existiert nicht mehr",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "Die Einladung wurde bereits %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "Die Einladung ist abgelaufen",
     "source_hash": "7186297b"

--- a/locales/content/el_GR/workspace-organizations.json
+++ b/locales/content/el_GR/workspace-organizations.json
@@ -663,10 +663,6 @@
     "text": "Ο οργανισμός δεν υπάρχει πλέον",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "Η πρόσκληση έχει ήδη %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "Η πρόσκληση έχει λήξει",
     "source_hash": "7186297b"

--- a/locales/content/en/api-invite-errors.json
+++ b/locales/content/en/api-invite-errors.json
@@ -15,9 +15,19 @@
     "content_hash": "a5df7d22"
   },
   "api.invite.errors.invitation_already_processed": {
-    "text": "Invitation has already been %{status}",
-    "context": "Returned when an invitation has already been accepted/declined/revoked",
-    "content_hash": "130c87e0"
+    "text": "This invitation has already been processed",
+    "context": "Generic fallback when an invitation is no longer pending and its status is not specifically accepted or declined",
+    "content_hash": "4cfedf4f"
+  },
+  "api.invite.errors.invitation_already_accepted": {
+    "text": "This invitation has already been accepted",
+    "context": "Returned when accepting or declining an invitation that was already accepted (status accepted/active)",
+    "content_hash": "8f9daf0f"
+  },
+  "api.invite.errors.invitation_already_declined": {
+    "text": "This invitation has already been declined",
+    "context": "Returned when accepting or declining an invitation that was already declined",
+    "content_hash": "96e0d626"
   },
   "api.invite.errors.invitation_expired": {
     "text": "Invitation has expired",

--- a/locales/content/en/workspace-organizations.json
+++ b/locales/content/en/workspace-organizations.json
@@ -1048,11 +1048,6 @@
     "context": "Returned when the invitation's org was deleted",
     "content_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "Invitation has already been %{status}",
-    "context": "Returned when accepting an invitation already accepted/declined/expired",
-    "content_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "Invitation has expired",
     "context": "Returned when the invitation has expired",

--- a/locales/content/eo/workspace-organizations.json
+++ b/locales/content/eo/workspace-organizations.json
@@ -855,10 +855,6 @@
     "text": "La organizo ne plu ekzistas",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "La invito jam estis %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "La invito eksvalidiĝis",
     "source_hash": "7186297b"

--- a/locales/content/es/workspace-organizations.json
+++ b/locales/content/es/workspace-organizations.json
@@ -855,10 +855,6 @@
     "text": "La organización ya no existe",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "La invitación ya se ha %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "La invitación ha caducado",
     "source_hash": "7186297b"

--- a/locales/content/fr_CA/workspace-organizations.json
+++ b/locales/content/fr_CA/workspace-organizations.json
@@ -855,10 +855,6 @@
     "text": "L'organisation n'existe plus",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "L'invitation a déjà été %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "L'invitation a expiré",
     "source_hash": "7186297b"

--- a/locales/content/fr_FR/workspace-organizations.json
+++ b/locales/content/fr_FR/workspace-organizations.json
@@ -855,10 +855,6 @@
     "text": "L'organisation n'existe plus",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "L'invitation a déjà été %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "L'invitation a expiré",
     "source_hash": "7186297b"

--- a/locales/content/he/workspace-organizations.json
+++ b/locales/content/he/workspace-organizations.json
@@ -663,10 +663,6 @@
     "text": "הארגון כבר אינו קיים",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "ההזמנה כבר %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "תוקף ההזמנה פג",
     "source_hash": "7186297b"

--- a/locales/content/hu/workspace-organizations.json
+++ b/locales/content/hu/workspace-organizations.json
@@ -663,10 +663,6 @@
     "text": "A szervezet már nem létezik",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "A meghívás állapota már: %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "A meghívás lejárt",
     "source_hash": "7186297b"

--- a/locales/content/it_IT/workspace-organizations.json
+++ b/locales/content/it_IT/workspace-organizations.json
@@ -663,10 +663,6 @@
     "text": "L'organizzazione non esiste più",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "L'invito è già stato %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "L'invito è scaduto",
     "source_hash": "7186297b"

--- a/locales/content/ja/workspace-organizations.json
+++ b/locales/content/ja/workspace-organizations.json
@@ -855,10 +855,6 @@
     "text": "組織はすでに存在しません",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "この招待はすでに処理されています(%{status})",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "招待の有効期限が切れています",
     "source_hash": "7186297b"

--- a/locales/content/ko/workspace-organizations.json
+++ b/locales/content/ko/workspace-organizations.json
@@ -855,10 +855,6 @@
     "text": "조직이 더 이상 존재하지 않습니다",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "이 초대는 이미 %{status} 상태입니다",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "초대가 만료되었습니다",
     "source_hash": "7186297b"

--- a/locales/content/mi_NZ/workspace-organizations.json
+++ b/locales/content/mi_NZ/workspace-organizations.json
@@ -663,10 +663,6 @@
     "text": "Kāore te whakahaere e noho tonu ana",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "Kua %{status} kē te tono",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "Kua pau te tono",
     "source_hash": "7186297b"

--- a/locales/content/nl/workspace-organizations.json
+++ b/locales/content/nl/workspace-organizations.json
@@ -855,10 +855,6 @@
     "text": "Organisatie bestaat niet meer",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "Uitnodiging is al %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "Uitnodiging is verlopen",
     "source_hash": "7186297b"

--- a/locales/content/pl/workspace-organizations.json
+++ b/locales/content/pl/workspace-organizations.json
@@ -663,10 +663,6 @@
     "text": "Organizacja już nie istnieje",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "Zaproszenie zostało już obsłużone: %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "Zaproszenie wygasło",
     "source_hash": "7186297b"

--- a/locales/content/pt_BR/workspace-organizations.json
+++ b/locales/content/pt_BR/workspace-organizations.json
@@ -855,10 +855,6 @@
     "text": "A organização não existe mais",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "O convite já foi %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "O convite expirou",
     "source_hash": "7186297b"

--- a/locales/content/pt_PT/workspace-organizations.json
+++ b/locales/content/pt_PT/workspace-organizations.json
@@ -663,10 +663,6 @@
     "text": "A organização já não existe",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "O convite já foi %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "O convite expirou",
     "source_hash": "7186297b"

--- a/locales/content/ru/workspace-organizations.json
+++ b/locales/content/ru/workspace-organizations.json
@@ -855,10 +855,6 @@
     "text": "Организация больше не существует",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "Приглашение уже обработано: %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "Срок действия приглашения истёк",
     "source_hash": "7186297b"

--- a/locales/content/sl_SI/workspace-organizations.json
+++ b/locales/content/sl_SI/workspace-organizations.json
@@ -663,10 +663,6 @@
     "text": "Organizacija ne obstaja več",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "Povabilo je bilo že %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "Povabilo je poteklo",
     "source_hash": "7186297b"

--- a/locales/content/sv_SE/workspace-organizations.json
+++ b/locales/content/sv_SE/workspace-organizations.json
@@ -663,10 +663,6 @@
     "text": "Organisationen finns inte längre",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "Inbjudan har redan blivit %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "Inbjudan har gått ut",
     "source_hash": "7186297b"

--- a/locales/content/tr/workspace-organizations.json
+++ b/locales/content/tr/workspace-organizations.json
@@ -663,10 +663,6 @@
     "text": "Kuruluş artık mevcut değil",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "Davet zaten %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "Davetin süresi doldu",
     "source_hash": "7186297b"

--- a/locales/content/uk/workspace-organizations.json
+++ b/locales/content/uk/workspace-organizations.json
@@ -663,10 +663,6 @@
     "text": "Організація більше не існує",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "Запрошення вже %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "Термін дії запрошення закінчився",
     "source_hash": "7186297b"

--- a/locales/content/vi/workspace-organizations.json
+++ b/locales/content/vi/workspace-organizations.json
@@ -663,10 +663,6 @@
     "text": "Tổ chức không còn tồn tại",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "Lời mời đã được %{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "Lời mời đã hết hạn",
     "source_hash": "7186297b"

--- a/locales/content/zh/workspace-organizations.json
+++ b/locales/content/zh/workspace-organizations.json
@@ -855,10 +855,6 @@
     "text": "组织不再存在",
     "source_hash": "a5df7d22"
   },
-  "api.organizations.invitations.errors.accept_already_acted": {
-    "text": "邀请已被%{status}",
-    "source_hash": "130c87e0"
-  },
   "api.organizations.invitations.errors.accept_expired": {
     "text": "邀请已过期",
     "source_hash": "7186297b"


### PR DESCRIPTION
Follow-up to #3730, which deferred this as app-layer work (`%{status}` enum in invite errors).

## Problem
The invite "already processed" error interpolated `@invitation.status` — a raw backend enum (`accepted`/`active`/`declined`) — into a single `"Invitation has already been %{status}"` frame. That leaks an untranslated English token into every locale (a French user got *"L'invitation a déjà été declined"*) and assumes a fixed word order many languages can't honour.

The leak was in **four** places, not the two originally scoped:
- `accept_invite.rb`, `decline_invite.rb`, `signup_and_accept.rb` (three live callsites)
- an orphan key `api.organizations.invitations.errors.accept_already_acted` carrying the same defect

## Changes
- **New shared helper** `raise_already_processed(invitation)` in `apps/api/invite/logic/base.rb` — maps status to its own complete-sentence i18n key, with a generic fallback for any unexpected status. Statuses reaching this path are `active`/`accepted` and `declined` (revoke destroys the record; expired hits its own branch first).
- All three callsites routed through the helper.
- `en/api-invite-errors.json`: reworded `invitation_already_processed` (dropped `%{status}`), added `invitation_already_accepted` / `invitation_already_declined`; content hashes regenerated via `content hashes --apply`.
- Deleted orphan `accept_already_acted` from all 30 locales — accept lives in `InviteAPI::Logic`, not the organizations namespace, so it had zero consumers.
- `accept_invite_spec.rb` assertion updated to the status-specific key.

The 2 new en keys enter the 29 locales as *missing* (translation-workflow drain); the reworded `..._processed` correctly flags existing translations stale via the content-hash watermark.

## Not in this PR
The rest of the `api.organizations.invitations.errors.accept_*` cluster (`accept_token_required`, `accept_organization_gone`, `accept_expired`, `accept_email_mismatch`, `accept_already_member`) is also orphaned — accept isn't served from that namespace. Recommend a small follow-up prune.

## Verification
- Invite logic specs: 51 examples, 0 failures
- `rubocop`: clean (4 files)
- `i18n validate hashes`: 3487 en keys, 0 stale, 0 missing
- i18n CLI tests: 27/27