### PR TITLE
Domains remove Operation + colonel & CLI adapters (P3 of #3731)

### DIFF
--- a/apps/api/colonel/logic/colonel.rb
+++ b/apps/api/colonel/logic/colonel.rb
@@ -48,6 +48,7 @@ require_relative 'colonel/list_custom_domains'
 require_relative 'colonel/verify_custom_domain'
 require_relative 'colonel/create_custom_domain'
 require_relative 'colonel/get_custom_domain'
+require_relative 'colonel/remove_custom_domain'
 
 # Organizations
 require_relative 'colonel/list_organizations'

--- a/apps/api/colonel/logic/colonel/remove_custom_domain.rb
+++ b/apps/api/colonel/logic/colonel/remove_custom_domain.rb
@@ -1,0 +1,83 @@
+# apps/api/colonel/logic/colonel/remove_custom_domain.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/domains/remove'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Remove (permanently delete) a custom domain (Colonel) — surfaces the
+      # CLI-only `bin/ots domains remove` toolbox verb (#3731 P3).
+      #
+      # Thin adapter over {Onetime::Operations::Domains::Remove} — the single,
+      # audited implementation of the remove verb. The op owns the teardown, the
+      # display_domain_index re-assertion, and the AdminAuditEvent; this class
+      # resolves the domain and threads the `dry_run` flag.
+      #
+      # `dry_run` defaults to TRUE (dry-run default): the screen previews the
+      # domain details, then re-issues with `dry_run: false` behind a
+      # typed-confirmation dialog to apply.
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class RemoveCustomDomain < ColonelAPI::Logic::Base
+        attr_reader :extid, :dry_run, :custom_domain, :result
+
+        def process_params
+          @extid = sanitize_identifier(params['extid'])
+          raise_form_error('Domain ID is required', field: :extid) if extid.to_s.empty?
+
+          @dry_run = params.key?('dry_run') ? truthy?(params['dry_run']) : true
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+
+          @custom_domain = Onetime::CustomDomain.find_by_extid(extid)
+          raise_not_found('Domain not found') unless custom_domain
+        end
+
+        def process
+          @result = Onetime::Operations::Domains::Remove.new(
+            domain: custom_domain,
+            actor: cust.extid, # acting colonel's PUBLIC id (never an objid)
+            dry_run: dry_run,
+          ).call
+
+          OT.info "[RemoveCustomDomain] #{custom_domain.display_domain} -> " \
+                  "status=#{result.status}, dry_run=#{dry_run}, org=#{result.org_id}"
+
+          # NOTE: no audit here — the op owns the single AdminAuditEvent
+          # (exactly-once, applied path only). This adapter never audits.
+          success_data
+        end
+
+        def success_data
+          {
+            record: {
+              deleted: result.status == :removed,
+              domain_id: result.domain_id,
+              extid: result.extid,
+              display_domain: result.display_domain,
+            },
+            details: {
+              status: result.status.to_s,
+              dry_run: result.dry_run,
+              org_id: result.org_id.to_s,
+              org_name: result.org_name,
+              reasserts_survivor: result.reasserts_survivor,
+            },
+          }
+        end
+
+        private
+
+        def truthy?(value)
+          %w[true 1 yes on].include?(value.to_s.strip.downcase)
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/remove_custom_domain.rb
+++ b/apps/api/colonel/logic/colonel/remove_custom_domain.rb
@@ -46,7 +46,9 @@ module ColonelAPI
             dry_run: dry_run,
           ).call
 
-          OT.info "[RemoveCustomDomain] #{custom_domain.display_domain} -> " \
+          # Log from result (snapshotted pre-destroy!) — on the applied path
+          # destroy! nils custom_domain.display_domain in memory.
+          OT.info "[RemoveCustomDomain] #{result.display_domain} -> " \
                   "status=#{result.status}, dry_run=#{dry_run}, org=#{result.org_id}"
 
           # NOTE: no audit here — the op owns the single AdminAuditEvent

--- a/apps/api/colonel/routes.txt
+++ b/apps/api/colonel/routes.txt
@@ -52,6 +52,7 @@ POST   /domains/:extid/repair            ColonelAPI::Logic::Colonel::RepairDomai
 POST   /domains/:extid/transfer          ColonelAPI::Logic::Colonel::TransferDomain response=json auth=sessionauth role=colonel scope=internal
 # Per-domain detail (DNS panel + post-verify refresh). Literal /domains/orphaned above still wins.
 GET    /domains/:extid                   ColonelAPI::Logic::Colonel::GetCustomDomain response=json auth=sessionauth role=colonel scope=internal
+DELETE /domains/:extid                   ColonelAPI::Logic::Colonel::RemoveCustomDomain response=json auth=sessionauth role=colonel scope=internal
 
 # Organizations
 GET    /organizations                     ColonelAPI::Logic::Colonel::ListOrganizations response=json auth=sessionauth role=colonel scope=internal

--- a/apps/api/domains/cli/remove_command.rb
+++ b/apps/api/domains/cli/remove_command.rb
@@ -1,0 +1,84 @@
+# apps/api/domains/cli/remove_command.rb
+#
+# frozen_string_literal: true
+
+require_relative 'helpers'
+require 'onetime/operations/domains/remove'
+
+module Onetime
+  module CLI
+    # Remove (permanently delete) a custom domain
+    class DomainsRemoveCommand < Command
+      include DomainsHelpers
+
+      # Audit actor recorded for CLI-initiated mutations (see transfer command).
+      CLI_ACTOR = 'cli'
+
+      desc 'Remove (permanently delete) a custom domain'
+
+      argument :domain_name, type: :string, required: true, desc: 'Domain name, extid, or ID'
+
+      option :force,
+        type: :boolean,
+        default: false,
+        desc: 'Skip confirmation prompt'
+
+      def call(domain_name:, force: false, **)
+        boot_application!
+
+        domain = load_domain(domain_name)
+        return unless domain
+
+        # Dry-run to compute the removal plan (org details, survivor re-assertion).
+        plan = Onetime::Operations::Domains::Remove.new(
+          domain: domain,
+          actor: CLI_ACTOR,
+          dry_run: true,
+        ).call
+
+        # Display removal details from the plan.
+        puts 'Removal Details:'
+        puts "  Domain:               #{plan.display_domain}"
+        if plan.org_id.to_s.empty?
+          puts '  Organization:         ORPHANED'
+        else
+          puts "  Organization:         #{plan.org_name || 'N/A'} (#{plan.org_id})"
+        end
+        if plan.reasserts_survivor
+          puts '  Note:                 removing a shadow record; the canonical'
+          puts '                        display_domain index entry will survive'
+        end
+        puts
+
+        unless force
+          print 'Permanently remove this domain? [y/N]: '
+          response = $stdin.gets.chomp
+          unless response.downcase == 'y'
+            puts 'Cancelled'
+            return
+          end
+        end
+
+        # Perform the removal — the op mutates + records exactly one audit event.
+        begin
+          result = Onetime::Operations::Domains::Remove.new(
+            domain: domain,
+            actor: CLI_ACTOR,
+            dry_run: false,
+          ).call
+
+          puts "  Removed #{result.display_domain}"
+
+          OT.info "[CLI] Domain remove: #{result.display_domain} (#{result.extid})"
+          puts
+          puts 'Removal complete'
+        rescue StandardError => ex
+          puts "Error during removal: #{ex.message}"
+          OT.le "[CLI] Domain remove failed: #{ex.message}"
+        end
+      end
+    end
+  end
+end
+
+Onetime::CLI.register 'domains remove', Onetime::CLI::DomainsRemoveCommand

--- a/apps/api/domains/cli/remove_command.rb
+++ b/apps/api/domains/cli/remove_command.rb
@@ -52,8 +52,9 @@ module Onetime
 
         unless force
           print 'Permanently remove this domain? [y/N]: '
-          response = $stdin.gets.chomp
-          unless response.downcase == 'y'
+          # gets returns nil at EOF (closed stdin / piped / CI) — treat as decline.
+          response = $stdin.gets&.chomp
+          unless response&.downcase == 'y'
             puts 'Cancelled'
             return
           end

--- a/lib/onetime/operations/domains/remove.rb
+++ b/lib/onetime/operations/domains/remove.rb
@@ -1,0 +1,150 @@
+# lib/onetime/operations/domains/remove.rb
+#
+# frozen_string_literal: true
+
+# Domain-owned (app-scoped) operation — mirrors Operations::Domains::Transfer.
+# Loaded at the call site (colonel logic + CLI), so require deps explicitly.
+require 'onetime/models/admin_audit_event'
+require 'onetime/domain_validation/strategy'
+require 'onetime/operations/delete_sender_domain'
+
+module Onetime
+  module Operations
+    module Domains
+      # Remove (permanently delete) a custom domain — the SINGLE toolbox
+      # implementation of the remove verb (#3731 P3). The colonel endpoint
+      # (DELETE /api/colonel/domains/:extid) and 'bin/ots domains remove' are
+      # thin adapters over it. Mirrors the Transfer op: dry_run:true default,
+      # exactly-once AdminAuditEvent emitted FROM THE OP ONLY, Result Data.
+      #
+      # ## Teardown parity
+      #
+      # The apply path mirrors DomainsAPI::Logic::Domains::RemoveDomain#process
+      # VERBATIM: delete the external vhost (strategy), delete the external sender
+      # identity BEFORE destroy! wipes mailer_config, then destroy!. It does NOT
+      # call org.remove_domain — CustomDomain#destroy! already removes org
+      # participation internally (custom_domain.rb:457-460); adding it would be a
+      # redundant second removal against the same collection.
+      #
+      # ## display_domain_index re-assertion (the crux)
+      #
+      # CustomDomain#destroy! ends in a bare 'super' (Familia) whose transaction
+      # UNCONDITIONALLY HDELs display_domain_index[fqdn], keyed on THIS record's
+      # own display_domain, with NO check of which objid the entry holds
+      # (unique_index_generators). Two live records cannot legitimately share one
+      # FQDN (create! gates on HSETNX), but a drift-produced SHADOW hash can
+      # coexist while the index points at the single canonical owner. If we are
+      # removing such a shadow, destroy!'s blind HDEL wipes the survivor's
+      # pointer. So: snapshot index_owner_id = display_domain_index.get(fqdn) and
+      # victim_objid = domain.objid BEFORE destroy!, then AFTER destroy! re-assert
+      # ONLY when index_owner_id is present AND != victim_objid (reload the
+      # survivor + confirm its display_domain still == fqdn before re-pointing).
+      class Remove
+        AUDIT_VERB = 'domain.remove'
+
+        # @!attribute status [r] Symbol — :planned (dry-run) | :removed (applied)
+        Result = Data.define(
+          :status,
+          :domain_id,
+          :extid,
+          :display_domain,
+          :org_id,
+          :org_name,
+          :dry_run,
+          :reasserts_survivor,
+        )
+
+        # @param domain [Onetime::CustomDomain] resolved target (caller ensures non-nil).
+        # @param actor [String, #extid] acting principal's PUBLIC id (colonel extid
+        #   or the 'cli' sentinel) — never an objid.
+        # @param dry_run [Boolean] preview only when true (default).
+        def initialize(domain:, actor:, dry_run: true)
+          @domain  = domain
+          @actor   = actor
+          @dry_run = dry_run
+        end
+
+        # @return [Result]
+        def call
+          org_id = @domain.org_id
+          org    = org_id.to_s.empty? ? nil : Onetime::Organization.load(org_id)
+
+          # --- INDEX SNAPSHOT (before ANY mutation) ---
+          index          = Onetime::CustomDomain.display_domain_index
+          fqdn           = @domain.display_domain.to_s.downcase
+          victim_objid   = @domain.objid
+          index_owner_id = fqdn.empty? ? nil : index.get(fqdn)  # .get => plain objid string
+          reasserts      = !fqdn.empty? && !index_owner_id.nil? && index_owner_id != victim_objid
+
+          # Build the full Result NOW, before destroy! nils the domain's fields.
+          plan = Result.new(
+            status: :planned,
+            domain_id: @domain.domainid,
+            extid: @domain.extid,
+            display_domain: @domain.display_domain,
+            org_id: org_id,
+            org_name: org&.display_name,
+            dry_run: @dry_run,
+            reasserts_survivor: reasserts,
+          )
+
+          # --- DRY RUN: preview only, mutate nothing, audit nothing ---
+          return plan if @dry_run
+
+          # --- APPLY: teardown mirrors RemoveDomain#process (NO org.remove_domain) ---
+          delete_vhost(@domain)
+          Onetime::Operations::DeleteSenderDomain.new(mailer_config: @domain.mailer_config).call
+          @domain.destroy! # Familia 'super' HDELs display_domain_index[fqdn] here
+
+          # --- CONDITIONAL INDEX RE-ASSERTION ---
+          # Best-effort: destroy! has already committed, so a failure here must
+          # NOT abort the call — that would skip the audit of a destroy that DID
+          # happen and leave the action untraced. On any error we log and press
+          # on; a cleared survivor pointer is recoverable by the index-rebuild
+          # maintenance job. (The re-assert is also not atomic with destroy!'s
+          # HDEL: a concurrent lookup in that sub-ms window sees nil — acceptable
+          # on this single-actor drift-repair path.)
+          if reasserts
+            begin
+              survivor = Onetime::CustomDomain.load(index_owner_id)
+              if survivor && survivor.display_domain.to_s.downcase == fqdn
+                index.put(fqdn, index_owner_id)
+                OT.info "[Domains::Remove] Re-asserted display_domain_index[#{fqdn}] -> " \
+                        "#{index_owner_id} (survivor) after destroying shadow #{victim_objid}"
+              else
+                OT.le "[Domains::Remove] display_domain_index[#{fqdn}] owner #{index_owner_id} " \
+                      "no longer valid after destroying #{victim_objid}; leaving entry cleared"
+              end
+            rescue StandardError => ex
+              OT.le "[Domains::Remove] re-assertion of display_domain_index[#{fqdn}] failed " \
+                    "after destroying shadow #{victim_objid}: #{ex.class} #{ex.message}"
+            end
+          end
+
+          # --- EXACTLY ONE audit event, applied path only ---
+          Onetime::AdminAuditEvent.record(
+            actor: @actor,
+            verb: AUDIT_VERB,
+            target: plan.extid,
+            result: :success,
+            detail: { org_id: org_id.to_s, reasserted: reasserts },
+          )
+
+          plan.with(status: :removed)
+        end
+
+        private
+
+        # Mirrors RemoveDomain#delete_vhost: no-op for non-Approximated strategies,
+        # swallows provider/transport errors so removal proceeds regardless.
+        def delete_vhost(domain)
+          strategy = Onetime::DomainValidation::Strategy.for_config(OT.conf)
+          result   = strategy.delete_vhost(domain)
+          OT.info "[Domains::Remove.delete_vhost] #{domain.display_domain} -> #{result && result[:message]}"
+        rescue HTTParty::ResponseError, Timeout::Error, Errno::ECONNREFUSED => ex
+          OT.le "[Domains::Remove.delete_vhost error] #{domain.display_domain} #{ex}"
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/onetime/operations/domains/remove_spec.rb
+++ b/spec/unit/onetime/operations/domains/remove_spec.rb
@@ -1,0 +1,286 @@
+# spec/unit/onetime/operations/domains/remove_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for Onetime::Operations::Domains::Remove (#3731 P3) — the single
+# toolbox implementation of the domain remove verb behind the colonel endpoint
+# and 'bin/ots domains remove'.
+#
+# Two layers:
+#
+#   1. Mocked contract — dry-run previews nothing, apply tears down in the
+#      RemoveDomain#process order (delete_vhost -> DeleteSenderDomain -> destroy!),
+#      emits EXACTLY ONE AdminAuditEvent, and never calls org.remove_domain
+#      (destroy! owns org participation). No datastore.
+#
+#   2. Real datastore — the display_domain_index re-assertion crux. Familia's
+#      destroy! ends in a bare `super` whose transaction UNCONDITIONALLY HDELs
+#      display_domain_index[fqdn] with no owner check, so removing a drift-shadow
+#      would wipe the surviving canonical owner's pointer. These examples build
+#      REAL CustomDomain records (super's HDEL only fires against real Redis) and
+#      prove the survivor pointer is re-asserted, that a normal removal clears the
+#      index (not resurrected), and that a pre-drifted nil owner is a no-op.
+#
+# Run: RACK_ENV=test bundle exec rspec spec/unit/onetime/operations/domains/remove_spec.rb
+
+require 'spec_helper'
+require 'onetime/models/admin_audit_event'
+require 'onetime/operations/domains/remove'
+
+RSpec.describe Onetime::Operations::Domains::Remove do
+  # ------------------------------------------------------------------ #
+  # Layer 1 — mocked contract (no datastore)
+  # ------------------------------------------------------------------ #
+  describe 'mocked contract' do
+    let(:actor) { 'ur_col_public_extid' } # PUBLIC identity (extid), never an objid
+
+    let(:mailer_config) { double('MailerConfig') }
+
+    let(:domain) do
+      instance_double(
+        Onetime::CustomDomain,
+        objid: 'cd-obj-1',
+        domainid: 'cd-obj-1',
+        extid: 'cd_ext1',
+        display_domain: 'secrets.example.com',
+        org_id: 'org-1',
+        mailer_config: mailer_config,
+        destroy!: true,
+      )
+    end
+
+    let(:org) { double('Organization', display_name: 'Acme Inc', remove_domain: nil) }
+
+    # The FQDN index: .get returns the victim's own objid, i.e. NO drift — the
+    # index points at the record being removed (reasserts_survivor false).
+    let(:index) { double('display_domain_index', get: 'cd-obj-1', put: nil) }
+
+    let(:strategy) { double('Strategy', delete_vhost: { message: 'noop' }) }
+
+    let(:sender_op) { double('DeleteSenderDomain', call: nil) }
+
+    before do
+      allow(Onetime::AdminAuditEvent).to receive(:record)
+      allow(Onetime::Organization).to receive(:load).with('org-1').and_return(org)
+      allow(Onetime::CustomDomain).to receive(:display_domain_index).and_return(index)
+      allow(Onetime::DomainValidation::Strategy).to receive(:for_config).and_return(strategy)
+      allow(Onetime::Operations::DeleteSenderDomain).to receive(:new).and_return(sender_op)
+    end
+
+    # 1. dry-run (default) previews everything, mutates and audits nothing.
+    describe 'dry run (default)' do
+      it 'returns status :planned with the full echoed Result and mutates nothing' do
+        result = described_class.new(domain: domain, actor: actor).call
+
+        expect(result.status).to eq(:planned)
+        expect(result.dry_run).to be true
+        expect(result.domain_id).to eq('cd-obj-1')
+        expect(result.extid).to eq('cd_ext1')
+        expect(result.display_domain).to eq('secrets.example.com')
+        expect(result.org_id).to eq('org-1')
+        expect(result.org_name).to eq('Acme Inc')
+        expect(result.reasserts_survivor).to be false
+
+        expect(domain).not_to have_received(:destroy!)
+        expect(Onetime::AdminAuditEvent).not_to have_received(:record)
+      end
+    end
+
+    # 2. apply teardown order + exactly-one audit + no org.remove_domain.
+    describe 'apply (dry_run: false)' do
+      it 'tears down the vhost, sender domain, then destroys the record' do
+        described_class.new(domain: domain, actor: actor, dry_run: false).call
+
+        expect(strategy).to have_received(:delete_vhost).with(domain)
+        expect(Onetime::Operations::DeleteSenderDomain)
+          .to have_received(:new).with(mailer_config: mailer_config)
+        expect(sender_op).to have_received(:call)
+        expect(domain).to have_received(:destroy!)
+      end
+
+      it 'records EXACTLY ONE audit event (verb domain.remove, success, reasserted false)' do
+        result = described_class.new(domain: domain, actor: actor, dry_run: false).call
+
+        expect(result.status).to eq(:removed)
+        expect(Onetime::AdminAuditEvent).to have_received(:record).once.with(
+          actor: actor,
+          verb: 'domain.remove',
+          target: 'cd_ext1',
+          result: :success,
+          detail: hash_including(reasserted: false),
+        )
+      end
+
+      it 'does NOT call org.remove_domain (destroy! owns org participation)' do
+        described_class.new(domain: domain, actor: actor, dry_run: false).call
+
+        expect(org).not_to have_received(:remove_domain)
+      end
+    end
+
+    # 3. orphaned domain (org_id blank) — org loads nil, still destroys + audits.
+    describe 'orphaned domain (blank org_id)' do
+      let(:domain) do
+        instance_double(
+          Onetime::CustomDomain,
+          objid: 'cd-orphan',
+          domainid: 'cd-orphan',
+          extid: 'cd_orphan',
+          display_domain: 'orphan.example.com',
+          org_id: '',
+          mailer_config: mailer_config,
+          destroy!: true,
+        )
+      end
+      let(:index) { double('display_domain_index', get: 'cd-orphan', put: nil) }
+
+      it 'destroys, audits once, and reports org_name nil' do
+        result = described_class.new(domain: domain, actor: actor, dry_run: false).call
+
+        expect(Onetime::Organization).not_to have_received(:load)
+        expect(result.status).to eq(:removed)
+        expect(result.org_name).to be_nil
+        expect(domain).to have_received(:destroy!)
+        expect(Onetime::AdminAuditEvent).to have_received(:record).once
+      end
+    end
+
+    # 4. delete_vhost transport error is swallowed; removal + audit still proceed.
+    describe 'when delete_vhost raises a transport error' do
+      before { allow(strategy).to receive(:delete_vhost).and_raise(Timeout::Error) }
+
+      it 'swallows it, still destroys the record and audits exactly once' do
+        result = described_class.new(domain: domain, actor: actor, dry_run: false).call
+
+        expect(result.status).to eq(:removed)
+        expect(domain).to have_received(:destroy!)
+        expect(Onetime::AdminAuditEvent).to have_received(:record).once
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Layer 2 — real datastore (the display_domain_index re-assertion crux)
+  #
+  # These require the test Valkey (spec/config.test.yaml -> :2121). No blanket
+  # flush: each example registers its records/fqdns and the after(:each) hook
+  # tears down only those, so nothing clobbers another example's fixtures.
+  # ------------------------------------------------------------------ #
+  describe 'real datastore', :datastore do
+    let(:index) { Onetime::CustomDomain.display_domain_index }
+
+    before do
+      # Stub only the audit sink so we can count/inspect events without writing
+      # to the shared capped audit set. Everything else (destroy!, the index,
+      # the passthrough strategy, DeleteSenderDomain) runs for real.
+      allow(Onetime::AdminAuditEvent).to receive(:record)
+      @records = []
+      @fqdns   = []
+    end
+
+    after do
+      @records.each do |rec|
+        rec.destroy! if rec.exists?
+      rescue StandardError => ex
+        warn "[remove_spec cleanup] #{ex.class}: #{ex.message}"
+      end
+      @fqdns.uniq.each { |fqdn| index.remove(fqdn) }
+    end
+
+    # Create a real, fully-persisted canonical domain and register it for cleanup.
+    def create_domain(fqdn, org_id)
+      rec = Onetime::CustomDomain.create!(fqdn, org_id)
+      @records << rec
+      @fqdns << fqdn
+      rec
+    end
+
+    # Fabricate a drift SHADOW hash for an fqdn already owned by `survivor`.
+    #
+    # Familia 2.11's save now guards unique indexes (RecordExistsError if the
+    # index already points at another record), so the raw "parse + save" bypass
+    # the op's docstring describes no longer works directly. We reproduce the
+    # SAME end state deterministically: drop the index entry so the guard passes,
+    # save the shadow (which repoints the index at itself), then FORCE the index
+    # back to the survivor. Result: two live hashes for one fqdn, index -> survivor.
+    def create_shadow(fqdn, org_id, survivor)
+      index.remove(fqdn)
+      shadow = Onetime::CustomDomain.parse(fqdn, org_id)
+      shadow.save
+      @records << shadow
+      index.put(fqdn, survivor.objid)
+      shadow
+    end
+
+    def unique_fqdn(prefix)
+      fqdn = "#{prefix}-#{SecureRandom.hex(4)}.example.com"
+      @fqdns << fqdn
+      fqdn
+    end
+
+    # 5. Re-assertion: removing a shadow must re-point the index at the survivor.
+    it 're-asserts the survivor pointer after destroying a shared-hostname shadow' do
+      fqdn      = unique_fqdn('reassert')
+      survivor  = create_domain(fqdn, "orgA-#{SecureRandom.hex(3)}")
+      shadow    = create_shadow(fqdn, "orgB-#{SecureRandom.hex(3)}", survivor)
+
+      # Setup confirmation: a dry-run on the shadow sees the drift.
+      preview = described_class.new(domain: shadow, actor: 'cli', dry_run: true).call
+      expect(preview.reasserts_survivor).to be true
+
+      result = described_class.new(domain: shadow, actor: 'cli', dry_run: false).call
+
+      expect(result.status).to eq(:removed)
+      expect(result.reasserts_survivor).to be true
+      # (a) the shadow hash is gone
+      expect(shadow.exists?).to be false
+      # (b) the index STILL points at the survivor (re-asserted, not wiped)
+      expect(index.get(fqdn)).to eq(survivor.objid)
+      # (c) resolution follows the index to the survivor
+      expect(Onetime::CustomDomain.load_by_display_domain(fqdn).objid).to eq(survivor.objid)
+      # (d) exactly one audit, flagged as a re-assertion
+      expect(Onetime::AdminAuditEvent).to have_received(:record).once.with(
+        hash_including(verb: 'domain.remove', result: :success, detail: hash_including(reasserted: true))
+      )
+    end
+
+    # 6. Normal removal clears the index — the entry is NOT resurrected.
+    it 'clears the index on a normal removal (no re-assertion)' do
+      fqdn   = unique_fqdn('clear')
+      domain = create_domain(fqdn, "org-#{SecureRandom.hex(3)}")
+
+      expect(index.get(fqdn)).to eq(domain.objid) # sanity: index points at it
+
+      result = described_class.new(domain: domain, actor: 'cli', dry_run: false).call
+
+      expect(result.status).to eq(:removed)
+      expect(result.reasserts_survivor).to be false
+      expect(index.get(fqdn)).to be_nil
+      expect(Onetime::AdminAuditEvent).to have_received(:record).once.with(
+        hash_including(detail: hash_including(reasserted: false))
+      )
+    end
+
+    # 7. Pre-drifted index (owner already nil): removal is a clean no-op re index.
+    it 'handles a pre-drifted nil index owner without error or re-assertion' do
+      fqdn   = unique_fqdn('predrift')
+      domain = create_domain(fqdn, "org-#{SecureRandom.hex(3)}")
+
+      # Drift: HDEL the index entry directly, leaving the record hash intact.
+      index.remove(fqdn)
+      expect(index.get(fqdn)).to be_nil
+      expect(domain.exists?).to be true
+
+      result = nil
+      expect {
+        result = described_class.new(domain: domain, actor: 'cli', dry_run: false).call
+      }.not_to raise_error
+
+      expect(result.status).to eq(:removed)
+      expect(result.reasserts_survivor).to be false
+      expect(index.get(fqdn)).to be_nil
+      expect(domain.exists?).to be false
+      expect(Onetime::AdminAuditEvent).to have_received(:record).once
+    end
+  end
+end


### PR DESCRIPTION
## Summary

P3 / Bucket C of #3731 — **CLI support commands over the Operations layer.** Domain removal becomes a reusable **Operation** wrapped by a colonel `DELETE` endpoint and a `bin/ots domains remove` command, so the toolbox and the admin UI share one audited code path. Mirrors the P1 (customers) and P2 (memberships, #3736) shape.

## What's here

- **`Onetime::Operations::Domains::Remove`** (`lib/onetime/operations/domains/remove.rb`) — mirrors the existing `Domains::Transfer` op: `dry_run: true` default, exactly-once `AdminAuditEvent` emitted **from the op only**, `Result` Data.
  - **Teardown parity**: mirrors `DomainsAPI::Logic::Domains::RemoveDomain#process` verbatim — `delete_vhost` → `DeleteSenderDomain` (before `destroy!` wipes `mailer_config`) → `destroy!`. It deliberately does **not** call `org.remove_domain`; `CustomDomain#destroy!` already removes org participation (`custom_domain.rb:457-460`).
  - **`display_domain_index` re-assertion (the crux)**: `CustomDomain#destroy!` ends in a bare Familia `super` whose transaction **unconditionally** `HDEL`s `display_domain_index[fqdn]`, keyed on the destroyed record's own `display_domain`, with no check of which objid the entry holds. Two live records can't legitimately share an FQDN (the `create!` `HSETNX` gate), but a drift-produced **shadow** hash can coexist while the index points at the single canonical owner. Removing that shadow would clobber the survivor's pointer — so the op snapshots `index_owner_id` + `victim_objid` **before** `destroy!`, then re-asserts the survivor's pointer **only** when the index pointed at a *different* record (reload + confirm the FQDN still matches first). Re-assertion is best-effort so it never blocks the audit of a `destroy!` that already committed.

- **Colonel adapter** `RemoveCustomDomain` + route `DELETE /domains/:extid` (below the literal `/domains/orphaned`; require wired into `colonel.rb`). Thin — resolves the domain, threads `dry_run`, never audits.
- **CLI** `bin/ots domains remove` (auto-discovered via `apps/*/cli/**/*_command.rb`) — dry-run preview → typed confirmation unless `--force` → apply.

## Testing

- **9 RSpec examples, 0 failures** (`spec/unit/onetime/operations/domains/remove_spec.rb`) — mocked contract + real-datastore tier.
  - Real-datastore proof: a shared-hostname **survivor's index pointer is re-asserted** after destroying a shadow; a **normal removal clears** the index (not resurrected); a pre-drifted nil-owner case is a clean no-op.
- CLI registration/load verified end-to-end (`bin/ots domains remove --help`).
- RuboCop clean.

## Design provenance

Design + adversarial review ran through a multi-agent workflow; the reviewer confirmed the snapshot → `destroy!` → conditional re-assert logic is correct across all four branches (owner==victim / owner!=victim / owner nil / blank fqdn). Two corrections were made to the initial design during ratification: dropped an erroneous `org.remove_domain` call (redundant with `destroy!`) and dropped a speculative `expected_org`/`:mismatch` guard with no consumer.

## Scope notes

- Independent of the P2 memberships PR (#3736); branched off `main`.
- **Follow-up (out of scope):** rewire the customer-facing `RemoveDomain#process` to delegate to this op so there is a single destroy path. Left as a separate change since it touches a live user endpoint.