### PR TITLE
i18n: update da_DK translations

### DIFF
--- a/locales/content/da_DK/00-common.json
+++ b/locales/content/da_DK/00-common.json
@@ -1267,8 +1267,8 @@
     "source_hash": "cb2f00d1"
   },
   "web.TITLES.organizations_settings": {
-    "text": "Organisationer",
-    "source_hash": "2730183d"
+    "text": "Workspaces",
+    "source_hash": "1377264b"
   },
   "web.TITLES.organization_settings": {
     "text": "Organisationsindstillinger",
@@ -1299,8 +1299,8 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Bekræft altid, at du er på det officielle {product_name}-websted. Bedragere opretter undertiden falske websteder, der ligner {product_name} fuldstændig, for at stjæle dine beskeder. For at undgå phishingangreb skal du tjekke regionsdomænet, før du opretter nye links.",
-    "source_hash": "68ec20f8"
+    "text": "Bekræft altid, at du er på det officielle {product_name}-websted. Bedragere opretter nogle gange falske websteder, der ligner {product_name} til forveksling, for at stjæle dine beskeder. For at undgå phishingangreb skal du bekræfte regionens domæne i din adresselinje, før du opretter nye links.",
+    "source_hash": "2e3b856e"
   },
   "web.pricing.title": {
     "text": "Enkle, gennemsigtige priser",
@@ -1523,5 +1523,21 @@
   "web.TITLES.domain_incoming": {
     "text": "Indkommende beskeder",
     "source_hash": "883dbca9"
+  },
+  "web.LABELS.update": {
+    "text": "Opdater",
+    "source_hash": "c1c1009d"
+  },
+  "web.LABELS.updating": {
+    "text": "Opdaterer...",
+    "source_hash": "0a4e0b71"
+  },
+  "web.TITLES.check_email": {
+    "text": "Tjek din e-mail",
+    "source_hash": "0e5fc27d"
+  },
+  "web.TITLES.domain_dns": {
+    "text": "DNS-opsætning",
+    "source_hash": "6c63df31"
   }
 }

--- a/locales/content/da_DK/10-layout.json
+++ b/locales/content/da_DK/10-layout.json
@@ -101,11 +101,11 @@
   },
   "web.footer.product": {
     "text": "Produkt",
-    "source_hash": "7f5540e9"
+    "source_hash": "fb9ef894"
   },
   "web.footer.source_code_purveyor": {
     "text": "Kildekode",
-    "source_hash": "29c5c68f"
+    "source_hash": "bc47da66"
   },
   "web.navigation.billing": {
     "text": "Fakturering",
@@ -149,7 +149,7 @@
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
     "text": "Du ser en sikker besked, der blev delt med dig via {product_name}. Dette indhold vises kun én gang og bliver derefter permanent slettet fra vores servere.",
-    "source_hash": "e0f1a10c"
+    "source_hash": "7a4e9d16"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
     "text": "Kan jeg se denne besked igen senere?",
@@ -265,7 +265,7 @@
   },
   "web.layout.visit_onetime_secret_homepage": {
     "text": "Besøg {product_name}-hjemmesiden",
-    "source_hash": "625556d2"
+    "source_hash": "87802af5"
   },
   "web.layout.footer_navigation": {
     "text": "Sidefodnavigation",
@@ -346,5 +346,9 @@
   "web.help.default_content": {
     "text": "Kontakt venligst support for at få hjælp",
     "source_hash": "752bca14"
+  },
+  "web.layout.colonels_only_badge": {
+    "text": "Kun Colonels",
+    "source_hash": "3f1e2dbd"
   }
 }

--- a/locales/content/da_DK/admin-audit.json
+++ b/locales/content/da_DK/admin-audit.json
@@ -1,0 +1,102 @@
+{
+  "web.admin.audit.title": {
+    "text": "Revisionslog",
+    "source_hash": "47751f88"
+  },
+  "web.admin.audit.description": {
+    "text": "Alle ændrende administratorhandlinger, nyeste først — hvem gjorde hvad ved hvem, og hvordan det gik.",
+    "source_hash": "2326a1a0"
+  },
+  "web.admin.audit.categories.customer": {
+    "text": "Kunder",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.audit.categories.session": {
+    "text": "Sessioner",
+    "source_hash": "6fa3cbf4"
+  },
+  "web.admin.audit.categories.domain": {
+    "text": "Domæner",
+    "source_hash": "ced67718"
+  },
+  "web.admin.audit.categories.organization": {
+    "text": "Organisationer",
+    "source_hash": "2730183d"
+  },
+  "web.admin.audit.categories.banner": {
+    "text": "Banner",
+    "source_hash": "b7f4d98f"
+  },
+  "web.admin.audit.categories.queue": {
+    "text": "Køer",
+    "source_hash": "be77db11"
+  },
+  "web.admin.audit.categories.email": {
+    "text": "E-mail",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.audit.categories.ratelimit": {
+    "text": "Hastighedsgrænser",
+    "source_hash": "6ed021f7"
+  },
+  "web.admin.audit.categories.ip": {
+    "text": "IP-bandlysninger",
+    "source_hash": "48cdea49"
+  },
+  "web.admin.audit.columns.timestamp": {
+    "text": "Tidsstempel",
+    "source_hash": "115a2cc9"
+  },
+  "web.admin.audit.columns.actor": {
+    "text": "Aktør",
+    "source_hash": "449995c4"
+  },
+  "web.admin.audit.columns.action": {
+    "text": "Handling",
+    "source_hash": "64cff131"
+  },
+  "web.admin.audit.columns.target": {
+    "text": "Mål",
+    "source_hash": "978354db"
+  },
+  "web.admin.audit.columns.result": {
+    "text": "Resultat",
+    "source_hash": "6e7d50e8"
+  },
+  "web.admin.audit.columns.detail": {
+    "text": "Detalje",
+    "source_hash": "fb5f27d5"
+  },
+  "web.admin.audit.filters.actorPlaceholder": {
+    "text": "Filtrer efter aktør (extid eller e-mail)",
+    "source_hash": "966aa580"
+  },
+  "web.admin.audit.filters.actionLabel": {
+    "text": "Handling",
+    "source_hash": "64cff131"
+  },
+  "web.admin.audit.filters.allActions": {
+    "text": "Alle handlinger",
+    "source_hash": "83140cf1"
+  },
+  "web.admin.audit.list.loadError": {
+    "text": "Revisionsloggen kunne ikke indlæses.",
+    "source_hash": "acf244f4"
+  },
+  "web.admin.audit.list.retry": {
+    "text": "Prøv igen",
+    "source_hash": "942087cc"
+  },
+  "web.admin.audit.list.empty": {
+    "text": "Der er endnu ikke registreret nogen revisionshændelser",
+    "source_hash": "8fe0cac3"
+  },
+  "web.admin.audit.result.success": {
+    "text": "Lykkedes",
+    "source_hash": "c88a0b90"
+  },
+  "web.admin.audit.result.failure": {
+    "text": "Mislykkedes",
+    "source_hash": "7031edbc"
+  }
+}

--- a/locales/content/da_DK/admin-bannedips.json
+++ b/locales/content/da_DK/admin-bannedips.json
@@ -1,0 +1,114 @@
+{
+  "web.admin.bannedIps.title": {
+    "text": "Bandlyste IP'er",
+    "source_hash": "0ece5643"
+  },
+  "web.admin.bannedIps.description": {
+    "text": "Bandlys og ophæv bandlysning af IP-adresser ved webstedets perimeter.",
+    "source_hash": "69c0c992"
+  },
+  "web.admin.bannedIps.currentIp": {
+    "text": "Din nuværende IP",
+    "source_hash": "14ff3ec5"
+  },
+  "web.admin.bannedIps.actions.cancel": {
+    "text": "Annuller",
+    "source_hash": "19766ed6"
+  },
+  "web.admin.bannedIps.actions.ban": {
+    "text": "Bandlys en IP",
+    "source_hash": "9937d7fd"
+  },
+  "web.admin.bannedIps.actions.quickBan": {
+    "text": "Bandlys denne IP",
+    "source_hash": "95720658"
+  },
+  "web.admin.bannedIps.ban.confirmTitle": {
+    "text": "Bandlys denne IP-adresse?",
+    "source_hash": "512acd7b"
+  },
+  "web.admin.bannedIps.ban.confirmDescription": {
+    "text": "Dette blokerer {ip} ved webstedets perimeter. Skriv IP'en for at bekræfte.",
+    "source_hash": "d8f6142e"
+  },
+  "web.admin.bannedIps.ban.button": {
+    "text": "Bandlys IP",
+    "source_hash": "f91a5285"
+  },
+  "web.admin.bannedIps.ban.success": {
+    "text": "Bandlyste {ip}",
+    "source_hash": "97180685"
+  },
+  "web.admin.bannedIps.columns.ipAddress": {
+    "text": "IP-adresse",
+    "source_hash": "3c3de0c9"
+  },
+  "web.admin.bannedIps.columns.reason": {
+    "text": "Årsag",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.bannedIps.columns.bannedAt": {
+    "text": "Bandlyst den",
+    "source_hash": "dfbd120e"
+  },
+  "web.admin.bannedIps.columns.bannedBy": {
+    "text": "Bandlyst af",
+    "source_hash": "9f47db0e"
+  },
+  "web.admin.bannedIps.columns.actions": {
+    "text": "Handlinger",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.bannedIps.form.title": {
+    "text": "Bandlys en IP-adresse",
+    "source_hash": "59961746"
+  },
+  "web.admin.bannedIps.form.ipLabel": {
+    "text": "IP-adresse eller CIDR",
+    "source_hash": "133d0819"
+  },
+  "web.admin.bannedIps.form.reasonLabel": {
+    "text": "Årsag (valgfrit)",
+    "source_hash": "0f7d4664"
+  },
+  "web.admin.bannedIps.form.reasonPlaceholder": {
+    "text": "f.eks. credential stuffing",
+    "source_hash": "828a15ae"
+  },
+  "web.admin.bannedIps.form.submit": {
+    "text": "Bandlys IP",
+    "source_hash": "f91a5285"
+  },
+  "web.admin.bannedIps.list.loadError": {
+    "text": "Bandlyste IP'er kunne ikke indlæses.",
+    "source_hash": "539f2e34"
+  },
+  "web.admin.bannedIps.list.retry": {
+    "text": "Prøv igen",
+    "source_hash": "942087cc"
+  },
+  "web.admin.bannedIps.list.empty": {
+    "text": "Der er i øjeblikket ingen bandlyste IP'er",
+    "source_hash": "b72cc9c5"
+  },
+  "web.admin.bannedIps.stats.total": {
+    "text": "Bandlyste i alt",
+    "source_hash": "41059c94"
+  },
+  "web.admin.bannedIps.unban.confirmTitle": {
+    "text": "Fjern denne bandlysning?",
+    "source_hash": "88473e59"
+  },
+  "web.admin.bannedIps.unban.confirmDescription": {
+    "text": "Dette ophæver blokeringen af {ip}. Skriv IP'en for at bekræfte.",
+    "source_hash": "6bec3191"
+  },
+  "web.admin.bannedIps.unban.button": {
+    "text": "Ophæv bandlysning",
+    "source_hash": "25fb5989"
+  },
+  "web.admin.bannedIps.unban.success": {
+    "text": "Bandlysning ophævet for {ip}",
+    "source_hash": "79192c36"
+  }
+}

--- a/locales/content/da_DK/admin-banner.json
+++ b/locales/content/da_DK/admin-banner.json
@@ -1,0 +1,154 @@
+{
+  "web.admin.banner.title": {
+    "text": "Udsendelsesbanner",
+    "source_hash": "0bc449a3"
+  },
+  "web.admin.banner.description": {
+    "text": "Udgiv en meddelelse for hele webstedet, der vises for alle besøgende, eller ryd den nuværende.",
+    "source_hash": "a0f720d7"
+  },
+  "web.admin.banner.loadError": {
+    "text": "Det nuværende banner kunne ikke indlæses.",
+    "source_hash": "04954e72"
+  },
+  "web.admin.banner.retry": {
+    "text": "Prøv igen",
+    "source_hash": "942087cc"
+  },
+  "web.admin.banner.clear.button": {
+    "text": "Ryd banner",
+    "source_hash": "da6b2e5d"
+  },
+  "web.admin.banner.clear.confirmTitle": {
+    "text": "Ryd udsendelsesbanneret?",
+    "source_hash": "46d9c35a"
+  },
+  "web.admin.banner.clear.confirmDescription": {
+    "text": "Dette fjerner det aktive banner for alle besøgende. Skriv bekræftelsesordet for at fortsætte.",
+    "source_hash": "9a56e4be"
+  },
+  "web.admin.banner.clear.success": {
+    "text": "Udsendelsesbanner ryddet.",
+    "source_hash": "b0f52af4"
+  },
+  "web.admin.banner.current.title": {
+    "text": "Nuværende banner",
+    "source_hash": "d17ab873"
+  },
+  "web.admin.banner.current.none": {
+    "text": "Der er i øjeblikket ikke angivet noget banner.",
+    "source_hash": "487b2cac"
+  },
+  "web.admin.banner.current.status": {
+    "text": "Status",
+    "source_hash": "920e413c"
+  },
+  "web.admin.banner.current.live": {
+    "text": "Aktiv",
+    "source_hash": "b64ac05f"
+  },
+  "web.admin.banner.current.expiry": {
+    "text": "Udløb",
+    "source_hash": "6956d814"
+  },
+  "web.admin.banner.current.persistent": {
+    "text": "Vedvarende (intet udløb)",
+    "source_hash": "5f95d1b0"
+  },
+  "web.admin.banner.current.expiresIn": {
+    "text": "Udløber om {duration}",
+    "source_hash": "f353f9a7"
+  },
+  "web.admin.banner.current.audience": {
+    "text": "Målgruppe",
+    "source_hash": "545c0235"
+  },
+  "web.admin.banner.current.storedContent": {
+    "text": "Gemt indhold",
+    "source_hash": "3579f3e6"
+  },
+  "web.admin.banner.current.htmlNote": {
+    "text": "Indholdet er HTML; webstedet renser det, så kun links vises.",
+    "source_hash": "e45a7dfe"
+  },
+  "web.admin.banner.current.edit": {
+    "text": "Rediger",
+    "source_hash": "464c4ffd"
+  },
+  "web.admin.banner.set.title": {
+    "text": "Angiv et banner",
+    "source_hash": "b6f90d5c"
+  },
+  "web.admin.banner.set.updateTitle": {
+    "text": "Opdater banneret",
+    "source_hash": "841a0183"
+  },
+  "web.admin.banner.set.contentLabel": {
+    "text": "Besked",
+    "source_hash": "2f77668a"
+  },
+  "web.admin.banner.set.contentPlaceholder": {
+    "text": "Planlagt vedligeholdelse søn 02:00 UTC",
+    "source_hash": "4ec99d7d"
+  },
+  "web.admin.banner.set.contentHelp": {
+    "text": "HTML er tilladt; webstedet renser det, så kun links vises.",
+    "source_hash": "7253d1cd"
+  },
+  "web.admin.banner.set.ttlLabel": {
+    "text": "Udløb automatisk efter (sekunder)",
+    "source_hash": "72134116"
+  },
+  "web.admin.banner.set.ttlPlaceholder": {
+    "text": "Lad stå tom for intet udløb",
+    "source_hash": "a8fd81e1"
+  },
+  "web.admin.banner.set.ttlHelp": {
+    "text": "Valgfrit. Banneret fjernes automatisk efter så mange sekunder.",
+    "source_hash": "ba0237f5"
+  },
+  "web.admin.banner.set.scopeLabel": {
+    "text": "Målgruppe",
+    "source_hash": "545c0235"
+  },
+  "web.admin.banner.set.scopeHelp": {
+    "text": "Hvilke sider viser banneret. Sider med brugerdefinerede domæner ser det kun, når det er angivet til alle sider.",
+    "source_hash": "28cc3018"
+  },
+  "web.admin.banner.set.scopeNoRecipient": {
+    "text": "Alt undtagen modtagersider",
+    "source_hash": "8575b3c0"
+  },
+  "web.admin.banner.set.scopeWorkspace": {
+    "text": "Kun workspace-sider",
+    "source_hash": "563e003e"
+  },
+  "web.admin.banner.set.scopeAll": {
+    "text": "Alle sider (inkl. brugerdefinerede domæner)",
+    "source_hash": "b9b74870"
+  },
+  "web.admin.banner.set.publishButton": {
+    "text": "Udgiv banner",
+    "source_hash": "5b7427a1"
+  },
+  "web.admin.banner.set.updateButton": {
+    "text": "Opdater banner",
+    "source_hash": "69b6e40e"
+  },
+  "web.admin.banner.set.confirmTitle": {
+    "text": "Udgiv udsendelsesbanner?",
+    "source_hash": "8b72b5c3"
+  },
+  "web.admin.banner.set.confirmDescription": {
+    "text": "Dette banner vises for alle besøgende på hele webstedet, indtil det ryddes eller udløber.",
+    "source_hash": "c61bbec1"
+  },
+  "web.admin.banner.set.confirmButton": {
+    "text": "Udgiv",
+    "source_hash": "859390eb"
+  },
+  "web.admin.banner.set.success": {
+    "text": "Udsendelsesbanner udgivet.",
+    "source_hash": "55c06cab"
+  }
+}

--- a/locales/content/da_DK/admin-billing.json
+++ b/locales/content/da_DK/admin-billing.json
@@ -1,0 +1,126 @@
+{
+  "web.admin.billing.title": {
+    "text": "Faktureringskatalog",
+    "source_hash": "bfde7e68"
+  },
+  "web.admin.billing.description": {
+    "text": "Skrivebeskyttet visning af konfigurerede planer og deres rettigheder samt eventuel afvigelse fra det aktive Stripe-synkroniserede katalog.",
+    "source_hash": "05d5b332"
+  },
+  "web.admin.billing.retry": {
+    "text": "Prøv igen",
+    "source_hash": "942087cc"
+  },
+  "web.admin.billing.loadError": {
+    "text": "Faktureringskataloget kunne ikke indlæses.",
+    "source_hash": "c3110f77"
+  },
+  "web.admin.billing.localConfigWarning": {
+    "text": "Cachen med Stripe-synkroniserede planer er tom, så aktive planer og afvigelse kan ikke evalueres. Viser kun det konfigurerede katalog (billing.yaml) — typisk i dev, eller når Stripe ikke er konfigureret.",
+    "source_hash": "905d95f8"
+  },
+  "web.admin.billing.inSync": {
+    "text": "Synkroniseret",
+    "source_hash": "5701958c"
+  },
+  "web.admin.billing.driftCount": {
+    "text": "{count} forskel(le)",
+    "source_hash": "166538f5"
+  },
+  "web.admin.billing.inSyncDetail": {
+    "text": "Det konfigurerede katalog matcher de aktive planer. Ingen afvigelse registreret.",
+    "source_hash": "57ab60a6"
+  },
+  "web.admin.billing.columns.planid": {
+    "text": "Plan-ID",
+    "source_hash": "1f0d4dc6"
+  },
+  "web.admin.billing.columns.name": {
+    "text": "Navn",
+    "source_hash": "dcd1d522"
+  },
+  "web.admin.billing.columns.tier": {
+    "text": "Niveau",
+    "source_hash": "cb9e8664"
+  },
+  "web.admin.billing.columns.status": {
+    "text": "Status",
+    "source_hash": "920e413c"
+  },
+  "web.admin.billing.diff.title": {
+    "text": "Planforskel: {planid}",
+    "source_hash": "bc86e5f7"
+  },
+  "web.admin.billing.diff.subtitle": {
+    "text": "Konfigureret katalog (billing.yaml) vs. aktiv Stripe-synkroniseret plan, side om side.",
+    "source_hash": "d92e93ae"
+  },
+  "web.admin.billing.diff.config": {
+    "text": "Konfigureret (billing.yaml)",
+    "source_hash": "6bf2ff04"
+  },
+  "web.admin.billing.diff.live": {
+    "text": "Aktiv (Stripe-cache)",
+    "source_hash": "4886945d"
+  },
+  "web.admin.billing.diff.absentConfig": {
+    "text": "Denne plan findes ikke i det konfigurerede katalog.",
+    "source_hash": "0b594c88"
+  },
+  "web.admin.billing.diff.absentLive": {
+    "text": "Denne plan findes ikke i den aktive Stripe-synkroniserede cache.",
+    "source_hash": "c53f31c3"
+  },
+  "web.admin.billing.plans.title": {
+    "text": "Planer",
+    "source_hash": "dfe8b2f0"
+  },
+  "web.admin.billing.plans.empty": {
+    "text": "Ingen planer fundet i kataloget.",
+    "source_hash": "39db3c13"
+  },
+  "web.admin.billing.plans.viewDiff": {
+    "text": "Vis forskel",
+    "source_hash": "0e5d6873"
+  },
+  "web.admin.billing.source.stripe": {
+    "text": "Stripe-cache",
+    "source_hash": "b5577327"
+  },
+  "web.admin.billing.source.localConfig": {
+    "text": "Lokal konfiguration",
+    "source_hash": "49de43d2"
+  },
+  "web.admin.billing.stats.configured": {
+    "text": "Konfigurerede planer",
+    "source_hash": "4fda4796"
+  },
+  "web.admin.billing.stats.live": {
+    "text": "Aktive planer",
+    "source_hash": "faaa88d9"
+  },
+  "web.admin.billing.stats.source": {
+    "text": "Kilde",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.billing.stats.drift": {
+    "text": "Afvigelse",
+    "source_hash": "8b4c8240"
+  },
+  "web.admin.billing.status.in_sync": {
+    "text": "Synkroniseret",
+    "source_hash": "5701958c"
+  },
+  "web.admin.billing.status.only_config": {
+    "text": "Kun konfiguration",
+    "source_hash": "15836cba"
+  },
+  "web.admin.billing.status.only_live": {
+    "text": "Kun aktiv",
+    "source_hash": "8f4ed495"
+  },
+  "web.admin.billing.status.changed": {
+    "text": "Ændret",
+    "source_hash": "2a6141e4"
+  }
+}

--- a/locales/content/da_DK/admin-colonel.json
+++ b/locales/content/da_DK/admin-colonel.json
@@ -802,5 +802,45 @@
   "web.colonel.secrets.state.viewed": {
     "text": "Vist",
     "source_hash": "1b28d178"
+  },
+  "web.colonel.backToSite": {
+    "text": "Tilbage til webstedet",
+    "source_hash": "4ee0f819"
+  },
+  "web.colonel.customDomains.labels.domain": {
+    "text": "Domæne",
+    "source_hash": "79fa3361"
+  },
+  "web.colonel.customDomains.labels.status": {
+    "text": "Status",
+    "source_hash": "920e413c"
+  },
+  "web.colonel.customDomains.labels.actions": {
+    "text": "Handlinger",
+    "source_hash": "ff8059dc"
+  },
+  "web.colonel.nav.consoleTag": {
+    "text": "Konsol",
+    "source_hash": "29a40861"
+  },
+  "web.colonel.nav.groups.identity": {
+    "text": "Identitet",
+    "source_hash": "999f23fc"
+  },
+  "web.colonel.nav.groups.security": {
+    "text": "Adgang og sikkerhed",
+    "source_hash": "abb29a3f"
+  },
+  "web.colonel.nav.groups.platform": {
+    "text": "Platform",
+    "source_hash": "c78ffe19"
+  },
+  "web.colonel.nav.groups.billing": {
+    "text": "Fakturering",
+    "source_hash": "3ac8bbca"
+  },
+  "web.colonel.nav.groups.communications": {
+    "text": "Kommunikation",
+    "source_hash": "919a9253"
   }
 }

--- a/locales/content/da_DK/admin-customers.json
+++ b/locales/content/da_DK/admin-customers.json
@@ -1,0 +1,486 @@
+{
+  "web.admin.customers.title": {
+    "text": "Kunder",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.customers.description": {
+    "text": "Find en kunde og løs supportproblemer uden SSH.",
+    "source_hash": "c8487e68"
+  },
+  "web.admin.customers.actions.plan.label": {
+    "text": "Plan",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.actions.plan.apply": {
+    "text": "Anvend",
+    "source_hash": "31e392d1"
+  },
+  "web.admin.customers.actions.plan.confirmTitle": {
+    "text": "Skift plan?",
+    "source_hash": "910a4de9"
+  },
+  "web.admin.customers.actions.plan.confirmDescription": {
+    "text": "Skift {email} til {plan}-planen.",
+    "source_hash": "83fb4158"
+  },
+  "web.admin.customers.actions.plan.success": {
+    "text": "Plan opdateret.",
+    "source_hash": "ebe8d40c"
+  },
+  "web.admin.customers.actions.plan.localConfigWarning": {
+    "text": "Planer indlæst fra lokal konfiguration — Stripe er ikke konfigureret eller kan ikke nås.",
+    "source_hash": "df83e326"
+  },
+  "web.admin.customers.actions.purge.button": {
+    "text": "Udrens kunde",
+    "source_hash": "ff658f69"
+  },
+  "web.admin.customers.actions.purge.confirmTitle": {
+    "text": "Udrens kunde?",
+    "source_hash": "9feed9f1"
+  },
+  "web.admin.customers.actions.purge.confirmDescription": {
+    "text": "Dette sletter {email} permanent sammen med alle deres data. Dette kan ikke fortrydes.",
+    "source_hash": "a74dd5d1"
+  },
+  "web.admin.customers.actions.purge.success": {
+    "text": "Kunde udrenset.",
+    "source_hash": "6145e5c8"
+  },
+  "web.admin.customers.actions.role.label": {
+    "text": "Rolle",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.actions.role.apply": {
+    "text": "Anvend",
+    "source_hash": "31e392d1"
+  },
+  "web.admin.customers.actions.role.confirmTitle": {
+    "text": "Skift rolle?",
+    "source_hash": "227f57d7"
+  },
+  "web.admin.customers.actions.role.confirmDescription": {
+    "text": "Skift {email} til rollen {role}.",
+    "source_hash": "9ba063c6"
+  },
+  "web.admin.customers.actions.role.success": {
+    "text": "Rolle opdateret.",
+    "source_hash": "0c33aa24"
+  },
+  "web.admin.customers.actions.suspend.button": {
+    "text": "Suspender konto",
+    "source_hash": "95a04f27"
+  },
+  "web.admin.customers.actions.suspend.reasonLabel": {
+    "text": "Årsag (valgfrit)",
+    "source_hash": "0f7d4664"
+  },
+  "web.admin.customers.actions.suspend.reasonPlaceholder": {
+    "text": "Hvorfor bliver denne konto suspenderet?",
+    "source_hash": "8eca975e"
+  },
+  "web.admin.customers.actions.suspend.confirmTitle": {
+    "text": "Suspender konto?",
+    "source_hash": "cbfa275b"
+  },
+  "web.admin.customers.actions.suspend.confirmDescription": {
+    "text": "Blokerer {email} fra at logge ind og tilbagekalder deres aktive sessioner. Ingen data slettes — dette kan fortrydes.",
+    "source_hash": "e5d046bc"
+  },
+  "web.admin.customers.actions.suspend.success": {
+    "text": "Konto suspenderet.",
+    "source_hash": "04c5f996"
+  },
+  "web.admin.customers.actions.unsuspend.button": {
+    "text": "Ophæv suspendering af konto",
+    "source_hash": "35a10fb5"
+  },
+  "web.admin.customers.actions.unsuspend.confirmTitle": {
+    "text": "Ophæv suspendering af konto?",
+    "source_hash": "6fd78a72"
+  },
+  "web.admin.customers.actions.unsuspend.confirmDescription": {
+    "text": "Genopretter login for {email}.",
+    "source_hash": "cb2bb4e0"
+  },
+  "web.admin.customers.actions.unsuspend.success": {
+    "text": "Kontosuspendering ophævet.",
+    "source_hash": "c5b4377f"
+  },
+  "web.admin.customers.actions.unverify.button": {
+    "text": "Fjern bekræftelse",
+    "source_hash": "b0dee41f"
+  },
+  "web.admin.customers.actions.unverify.confirmTitle": {
+    "text": "Fjern bekræftelse af kunde?",
+    "source_hash": "62ed2854"
+  },
+  "web.admin.customers.actions.unverify.confirmDescription": {
+    "text": "Marker {email} som ikke bekræftet.",
+    "source_hash": "592ffd27"
+  },
+  "web.admin.customers.actions.unverify.success": {
+    "text": "Kundebekræftelse fjernet.",
+    "source_hash": "a9b7bbac"
+  },
+  "web.admin.customers.actions.verify.button": {
+    "text": "Bekræft",
+    "source_hash": "eea2745e"
+  },
+  "web.admin.customers.actions.verify.confirmTitle": {
+    "text": "Bekræft kunde?",
+    "source_hash": "43037ce1"
+  },
+  "web.admin.customers.actions.verify.confirmDescription": {
+    "text": "Marker {email} som bekræftet.",
+    "source_hash": "7052d79d"
+  },
+  "web.admin.customers.actions.verify.success": {
+    "text": "Kunde bekræftet.",
+    "source_hash": "19e382dc"
+  },
+  "web.admin.customers.columns.email": {
+    "text": "E-mail",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.customers.columns.role": {
+    "text": "Rolle",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.columns.verified": {
+    "text": "Bekræftet",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.columns.plan": {
+    "text": "Plan",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.columns.secrets": {
+    "text": "Beskeder",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.customers.columns.created": {
+    "text": "Oprettet",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.columns.lastLogin": {
+    "text": "Sidste login",
+    "source_hash": "0d39602d"
+  },
+  "web.admin.customers.detail.backToList": {
+    "text": "Tilbage til kunder",
+    "source_hash": "077807fb"
+  },
+  "web.admin.customers.detail.openFullPage": {
+    "text": "Åbn hele siden",
+    "source_hash": "a467911c"
+  },
+  "web.admin.customers.detail.notFound": {
+    "text": "Kunde ikke fundet",
+    "source_hash": "5e3f5824"
+  },
+  "web.admin.customers.detail.notFoundDescription": {
+    "text": "Ingen kunde matcher denne identifikator. De kan være blevet udrenset.",
+    "source_hash": "82b04725"
+  },
+  "web.admin.customers.detail.loadError": {
+    "text": "Denne kunde kunne ikke indlæses.",
+    "source_hash": "cfd1bcca"
+  },
+  "web.admin.customers.detail.retry": {
+    "text": "Prøv igen",
+    "source_hash": "942087cc"
+  },
+  "web.admin.customers.detail.yes": {
+    "text": "Ja",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.customers.detail.no": {
+    "text": "Nej",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.customers.detail.none": {
+    "text": "Ingen",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.never": {
+    "text": "Aldrig",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.customers.detail.billing.plan": {
+    "text": "Plan",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.detail.billing.organization": {
+    "text": "Faktureringsorganisation",
+    "source_hash": "90c94ee1"
+  },
+  "web.admin.customers.detail.billing.subscriptionStatus": {
+    "text": "Abonnementsstatus",
+    "source_hash": "f0723c4e"
+  },
+  "web.admin.customers.detail.billing.periodEnd": {
+    "text": "Nuværende periode slutter",
+    "source_hash": "742b8229"
+  },
+  "web.admin.customers.detail.billing.latestInvoice": {
+    "text": "Seneste faktura",
+    "source_hash": "7a6133cc"
+  },
+  "web.admin.customers.detail.billing.noInvoices": {
+    "text": "Ingen fakturaer",
+    "source_hash": "e6b30f93"
+  },
+  "web.admin.customers.detail.billing.openStripe": {
+    "text": "Åbn i Stripe-dashboard",
+    "source_hash": "dfa7c41d"
+  },
+  "web.admin.customers.detail.billing.unavailable": {
+    "text": "Stripe-data er ikke tilgængelige: {reason}",
+    "source_hash": "9fe08e49"
+  },
+  "web.admin.customers.detail.billing.notConfigured": {
+    "text": "Fakturering er ikke konfigureret på denne installation.",
+    "source_hash": "6e90375e"
+  },
+  "web.admin.customers.detail.fields.email": {
+    "text": "E-mail",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.customers.detail.fields.publicId": {
+    "text": "Offentligt ID",
+    "source_hash": "3705b64f"
+  },
+  "web.admin.customers.detail.fields.role": {
+    "text": "Rolle",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.detail.fields.verified": {
+    "text": "Bekræftet",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.detail.fields.plan": {
+    "text": "Plan",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.detail.fields.locale": {
+    "text": "Sprogområde",
+    "source_hash": "ca3dc612"
+  },
+  "web.admin.customers.detail.fields.created": {
+    "text": "Oprettet",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.detail.fields.updated": {
+    "text": "Opdateret",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.customers.detail.fields.lastLogin": {
+    "text": "Sidste login",
+    "source_hash": "0d39602d"
+  },
+  "web.admin.customers.detail.fields.suspendedAt": {
+    "text": "Suspenderet den",
+    "source_hash": "7227f219"
+  },
+  "web.admin.customers.detail.fields.suspendedBy": {
+    "text": "Suspenderet af",
+    "source_hash": "e0830524"
+  },
+  "web.admin.customers.detail.fields.suspendedReason": {
+    "text": "Årsag til suspendering",
+    "source_hash": "d6b08d8e"
+  },
+  "web.admin.customers.detail.organizations.empty": {
+    "text": "Ingen organisationer",
+    "source_hash": "c256efdc"
+  },
+  "web.admin.customers.detail.organizations.default": {
+    "text": "Standard",
+    "source_hash": "21b111cb"
+  },
+  "web.admin.customers.detail.receiptColumns.shortId": {
+    "text": "Kort ID",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.customers.detail.receiptColumns.state": {
+    "text": "Tilstand",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.customers.detail.receiptColumns.created": {
+    "text": "Oprettet",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.detail.receipts.empty": {
+    "text": "Ingen kvitteringer",
+    "source_hash": "fb425a68"
+  },
+  "web.admin.customers.detail.secretColumns.shortId": {
+    "text": "Kort ID",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.customers.detail.secretColumns.state": {
+    "text": "Tilstand",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.customers.detail.secretColumns.created": {
+    "text": "Oprettet",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.detail.secretColumns.expiration": {
+    "text": "Udløb",
+    "source_hash": "f38d6e0e"
+  },
+  "web.admin.customers.detail.secrets.empty": {
+    "text": "Ingen beskeder",
+    "source_hash": "c37ab3f7"
+  },
+  "web.admin.customers.detail.sections.profile": {
+    "text": "Profil",
+    "source_hash": "d696a35b"
+  },
+  "web.admin.customers.detail.sections.secrets": {
+    "text": "Beskeder",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.customers.detail.sections.receipts": {
+    "text": "Kvitteringer",
+    "source_hash": "60a627df"
+  },
+  "web.admin.customers.detail.sections.organizations": {
+    "text": "Organisationer",
+    "source_hash": "2730183d"
+  },
+  "web.admin.customers.detail.sections.actions": {
+    "text": "Handlinger",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.sections.billing": {
+    "text": "Fakturering",
+    "source_hash": "3ac8bbca"
+  },
+  "web.admin.customers.detail.sessions.title": {
+    "text": "Aktive sessioner",
+    "source_hash": "b58fa4e0"
+  },
+  "web.admin.customers.detail.sessions.empty": {
+    "text": "Ingen aktive sessioner.",
+    "source_hash": "6f064eb9"
+  },
+  "web.admin.customers.detail.sessions.loadError": {
+    "text": "Sessioner kan ikke indlæses.",
+    "source_hash": "d2884313"
+  },
+  "web.admin.customers.detail.sessions.unknown": {
+    "text": "Ukendt",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.customers.detail.sessions.columns.lastActivity": {
+    "text": "Sidste aktivitet",
+    "source_hash": "06475633"
+  },
+  "web.admin.customers.detail.sessions.columns.ipAddress": {
+    "text": "IP-adresse",
+    "source_hash": "0302a467"
+  },
+  "web.admin.customers.detail.sessions.columns.device": {
+    "text": "Enhed",
+    "source_hash": "6ba0bdec"
+  },
+  "web.admin.customers.detail.sessions.columns.authMethod": {
+    "text": "Godkendelsesmetode",
+    "source_hash": "bc4ea262"
+  },
+  "web.admin.customers.detail.sessions.columns.actions": {
+    "text": "Handlinger",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.sessions.revoke.button": {
+    "text": "Tilbagekald",
+    "source_hash": "87e6d00b"
+  },
+  "web.admin.customers.detail.sessions.revoke.confirmTitle": {
+    "text": "Tilbagekald session?",
+    "source_hash": "7735d1ef"
+  },
+  "web.admin.customers.detail.sessions.revoke.confirmDescription": {
+    "text": "Dette logger straks brugeren ud af denne session. De skal logge ind igen.",
+    "source_hash": "b4291af0"
+  },
+  "web.admin.customers.detail.sessions.revoke.success": {
+    "text": "Session tilbagekaldt.",
+    "source_hash": "5e4762e5"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.button": {
+    "text": "Tilbagekald alle",
+    "source_hash": "c6847a4b"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.confirmTitle": {
+    "text": "Tilbagekald alle sessioner?",
+    "source_hash": "a4fa4c65"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.confirmDescription": {
+    "text": "Dette logger brugeren ud af alle enheder og browsere — inklusive sessioner, der ikke vises på denne liste — og spærrer straks deres godkendte ruter. Brug ved offboarding eller ved mistanke om kontoovertagelse. Skriv brugerens ID for at bekræfte.",
+    "source_hash": "483cdd88"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.success": {
+    "text": "Tilbagekaldte alle sessioner ({count} afsluttet).",
+    "source_hash": "4e1cce55"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.capped": {
+    "text": "Afsluttede {count} sessioner, men gennemgangen af ikke-sporede sessioner blev afkortet — en ældre session kan stadig eksistere. Kør igen for at være sikker.",
+    "source_hash": "e3d295a6"
+  },
+  "web.admin.customers.detail.stats.secretsCreated": {
+    "text": "Beskeder oprettet",
+    "source_hash": "7d17719e"
+  },
+  "web.admin.customers.detail.stats.secretsShared": {
+    "text": "Beskeder delt",
+    "source_hash": "ba85b265"
+  },
+  "web.admin.customers.detail.stats.emailsSent": {
+    "text": "E-mails sendt",
+    "source_hash": "be604792"
+  },
+  "web.admin.customers.list.roleFilter": {
+    "text": "Rolle",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.list.empty": {
+    "text": "Ingen kunder fundet",
+    "source_hash": "dc754ec0"
+  },
+  "web.admin.customers.list.loadError": {
+    "text": "Kunder kunne ikke indlæses.",
+    "source_hash": "81783303"
+  },
+  "web.admin.customers.list.searchPlaceholder": {
+    "text": "Søg efter e-mail, extid eller objid",
+    "source_hash": "c06d5a3b"
+  },
+  "web.admin.customers.list.emptySearch": {
+    "text": "Ingen kunder matcher denne søgning",
+    "source_hash": "ea7e7012"
+  },
+  "web.admin.customers.roles.colonel": {
+    "text": "Colonel",
+    "source_hash": "02577777"
+  },
+  "web.admin.customers.roles.admin": {
+    "text": "Administrator",
+    "source_hash": "c1c224b0"
+  },
+  "web.admin.customers.roles.staff": {
+    "text": "Personale",
+    "source_hash": "681927e3"
+  },
+  "web.admin.customers.roles.customer": {
+    "text": "Kunde",
+    "source_hash": "bf376338"
+  },
+  "web.admin.customers.suspended.badge": {
+    "text": "Suspenderet",
+    "source_hash": "e392a389"
+  }
+}

--- a/locales/content/da_DK/admin-domains.json
+++ b/locales/content/da_DK/admin-domains.json
@@ -1,0 +1,194 @@
+{
+  "web.admin.domains.retry": {
+    "text": "Prøv igen",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.addDomain.button": {
+    "text": "Tilføj domæne",
+    "source_hash": "d86476ae"
+  },
+  "web.admin.domains.addDomain.title": {
+    "text": "Tilføj et brugerdefineret domæne",
+    "source_hash": "592d3314"
+  },
+  "web.admin.domains.addDomain.forOrg": {
+    "text": "Tilføjer et domæne for {org}.",
+    "source_hash": "f8b8c1ac"
+  },
+  "web.admin.domains.addDomain.domainLabel": {
+    "text": "Domæne",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domains.addDomain.domainPlaceholder": {
+    "text": "secrets.example.com",
+    "source_hash": "9ea4d0d6"
+  },
+  "web.admin.domains.addDomain.strategyLabel": {
+    "text": "Valideringsstrategi",
+    "source_hash": "a2e95531"
+  },
+  "web.admin.domains.addDomain.createButton": {
+    "text": "Opret",
+    "source_hash": "4759498a"
+  },
+  "web.admin.domains.addDomain.created": {
+    "text": "{domain} blev oprettet.",
+    "source_hash": "2263ec6a"
+  },
+  "web.admin.domains.addDomain.strategy.approximated": {
+    "text": "Approximated — DNS-ejerskabskontrol, ingen proxyering.",
+    "source_hash": "79a7245c"
+  },
+  "web.admin.domains.addDomain.strategy.passthrough": {
+    "text": "Passthrough — du peger DNS mod denne installations proxy.",
+    "source_hash": "9702d758"
+  },
+  "web.admin.domains.addDomain.strategy.external": {
+    "text": "External — DNS administreres uden for denne installation.",
+    "source_hash": "acaede35"
+  },
+  "web.admin.domains.addDomain.strategy.caddy_on_demand": {
+    "text": "Caddy on-demand — certifikater udstedes automatisk ved første anmodning.",
+    "source_hash": "deb90ae6"
+  },
+  "web.admin.domains.addDomain.strategy.caddy": {
+    "text": "Caddy — certifikater udstedes automatisk ved første anmodning.",
+    "source_hash": "a0f3c2dc"
+  },
+  "web.admin.domains.addDomain.strategy.unknown": {
+    "text": "Valideringsstrategi for hele installationen.",
+    "source_hash": "4587f9cf"
+  },
+  "web.admin.domains.attach.cta": {
+    "text": "Tilknyt domæne til organisation",
+    "source_hash": "736d74ce"
+  },
+  "web.admin.domains.attach.recordEyebrow": {
+    "text": "Arbejdspost",
+    "source_hash": "2fadf983"
+  },
+  "web.admin.domains.attach.rosterError": {
+    "text": "Denne organisations domæner kunne ikke indlæses.",
+    "source_hash": "d3055fed"
+  },
+  "web.admin.domains.attach.noDomains": {
+    "text": "Der er endnu ikke tilknyttet nogen domæner til denne organisation.",
+    "source_hash": "e9a25fc4"
+  },
+  "web.admin.domains.attach.openExternal": {
+    "text": "Åbn {domain} i en ny fane",
+    "source_hash": "c5fbdeaa"
+  },
+  "web.admin.domains.dns.heading": {
+    "text": "DNS-poster, der skal offentliggøres",
+    "source_hash": "e4efbe2b"
+  },
+  "web.admin.domains.dns.txtStep": {
+    "text": "1. Tilføj en TXT-post for at bevise ejerskab.",
+    "source_hash": "fdcfcfb0"
+  },
+  "web.admin.domains.dns.aStep": {
+    "text": "2. Tilføj en A-post, der peger apex mod proxyen.",
+    "source_hash": "aedbf197"
+  },
+  "web.admin.domains.dns.cnameStep": {
+    "text": "2. Tilføj en CNAME-post, der peger underdomænet mod proxyen.",
+    "source_hash": "5c626f53"
+  },
+  "web.admin.domains.dns.propagationNote": {
+    "text": "DNS-ændringer kan tage et par minutter at udbrede, før bekræftelsen lykkes.",
+    "source_hash": "7caf70a7"
+  },
+  "web.admin.domains.dns.toggle": {
+    "text": "DNS-detaljer",
+    "source_hash": "ebf2d44e"
+  },
+  "web.admin.domains.dns.loadError": {
+    "text": "DNS-detaljer kunne ikke indlæses.",
+    "source_hash": "4c33e23d"
+  },
+  "web.admin.domains.list.loadError": {
+    "text": "Domæner kunne ikke indlæses.",
+    "source_hash": "548deff8"
+  },
+  "web.admin.domains.orgPicker.title": {
+    "text": "Vælg en organisation",
+    "source_hash": "48326f52"
+  },
+  "web.admin.domains.orgPicker.searchLabel": {
+    "text": "Organisation",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.orgPicker.searchPlaceholder": {
+    "text": "Objekt-ID, eksternt ID eller e-mail",
+    "source_hash": "bb5d0055"
+  },
+  "web.admin.domains.orgPicker.searchHint": {
+    "text": "Søg efter objid, extid eller et medlems e-mailadresse.",
+    "source_hash": "fdef7332"
+  },
+  "web.admin.domains.orgPicker.loadError": {
+    "text": "Organisationer kunne ikke søges.",
+    "source_hash": "b9e45dcf"
+  },
+  "web.admin.domains.orgPicker.parseError": {
+    "text": "Organisationsresultaterne kunne ikke læses.",
+    "source_hash": "44e1b9fd"
+  },
+  "web.admin.domains.orgPicker.idle": {
+    "text": "Indtast en værdi ovenfor for at søge.",
+    "source_hash": "0352e6e6"
+  },
+  "web.admin.domains.orgPicker.noResults": {
+    "text": "Ingen organisationer matcher “{term}”.",
+    "source_hash": "761db594"
+  },
+  "web.admin.domains.orgPicker.unnamedOrg": {
+    "text": "Unavngivet organisation",
+    "source_hash": "f218dc9d"
+  },
+  "web.admin.domains.orgPicker.domainCount": {
+    "text": "{count} domæner",
+    "source_hash": "cf548c8c"
+  },
+  "web.admin.domains.orgPicker.select": {
+    "text": "Vælg",
+    "source_hash": "2a78025d"
+  },
+  "web.admin.domains.verify.button": {
+    "text": "Bekræft",
+    "source_hash": "eea2745e"
+  },
+  "web.admin.domains.verify.confirmTitle": {
+    "text": "Bekræft domæne?",
+    "source_hash": "07c4dc4f"
+  },
+  "web.admin.domains.verify.confirmDescription": {
+    "text": "Kør DNS- og SSL-bekræftelseskontroller for {domain}.",
+    "source_hash": "06797824"
+  },
+  "web.admin.domains.verify.failed": {
+    "text": "Bekræftelsen mislykkedes. Prøv igen.",
+    "source_hash": "3c8432b0"
+  },
+  "web.admin.domains.verify.success.verified": {
+    "text": "{domain} er bekræftet.",
+    "source_hash": "802b5d1e"
+  },
+  "web.admin.domains.verify.success.resolving": {
+    "text": "{domain} slår op, men er endnu ikke bekræftet.",
+    "source_hash": "bc8aecad"
+  },
+  "web.admin.domains.verify.success.pending": {
+    "text": "{domain} afventer — DNS slår ikke op endnu.",
+    "source_hash": "0d9f66d5"
+  },
+  "web.admin.domains.verify.success.unverified": {
+    "text": "{domain} kunne ikke bekræftes.",
+    "source_hash": "630da482"
+  },
+  "web.admin.domains.verify.success.done": {
+    "text": "Bekræftelse fuldført for {domain}.",
+    "source_hash": "ed67e22d"
+  }
+}

--- a/locales/content/da_DK/admin-domaintoolbox.json
+++ b/locales/content/da_DK/admin-domaintoolbox.json
@@ -1,0 +1,178 @@
+{
+  "web.admin.domaintoolbox.title": {
+    "text": "Domæneværktøjskasse",
+    "source_hash": "5a9333db"
+  },
+  "web.admin.domaintoolbox.description": {
+    "text": "Diagnosticér og reparér relationer for brugerdefinerede domæner: scan forældreløse poster, undersøg DNS/SSL, reparér ejerskab, og overfør mellem organisationer.",
+    "source_hash": "778537aa"
+  },
+  "web.admin.domaintoolbox.retry": {
+    "text": "Prøv igen",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domaintoolbox.preview": {
+    "text": "Forhåndsvisning",
+    "source_hash": "324b134f"
+  },
+  "web.admin.domaintoolbox.fields.extid": {
+    "text": "Eksternt domæne-ID",
+    "source_hash": "f52af6c5"
+  },
+  "web.admin.domaintoolbox.fields.extidPlaceholder": {
+    "text": "cd_… (domæne-extid)",
+    "source_hash": "bb9bf49a"
+  },
+  "web.admin.domaintoolbox.orphaned.title": {
+    "text": "Forældreløse domæner",
+    "source_hash": "ddcea596"
+  },
+  "web.admin.domaintoolbox.orphaned.description": {
+    "text": "Brugerdefinerede domæner uden en ejende organisation. Brug Reparér for at tildele et igen.",
+    "source_hash": "967268f5"
+  },
+  "web.admin.domaintoolbox.orphaned.empty": {
+    "text": "Ingen forældreløse domæner fundet.",
+    "source_hash": "06ef9979"
+  },
+  "web.admin.domaintoolbox.orphaned.loadError": {
+    "text": "Forældreløse domæner kunne ikke indlæses.",
+    "source_hash": "ca0e33bf"
+  },
+  "web.admin.domaintoolbox.orphaned.repairAction": {
+    "text": "Reparér",
+    "source_hash": "1196b6c5"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.domain": {
+    "text": "Domæne",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.state": {
+    "text": "Tilstand",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.verified": {
+    "text": "Bekræftet",
+    "source_hash": "4f783840"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.created": {
+    "text": "Oprettet",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.actions": {
+    "text": "Handlinger",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domaintoolbox.probe.title": {
+    "text": "Undersøg (DNS / SSL)",
+    "source_hash": "ec69a087"
+  },
+  "web.admin.domaintoolbox.probe.description": {
+    "text": "Foretag en aktiv HTTPS-anmodning for at bekræfte, at domænet betjener trafik, og inspicer dets TLS-certifikat. Skrivebeskyttet.",
+    "source_hash": "1eecfa96"
+  },
+  "web.admin.domaintoolbox.probe.button": {
+    "text": "Undersøg",
+    "source_hash": "3bd51ab9"
+  },
+  "web.admin.domaintoolbox.probe.healthLabel": {
+    "text": "Sundhed",
+    "source_hash": "55898449"
+  },
+  "web.admin.domaintoolbox.repair.title": {
+    "text": "Reparér relation",
+    "source_hash": "0053d07c"
+  },
+  "web.admin.domaintoolbox.repair.description": {
+    "text": "Ret uoverensstemmelser i organisationsrelationer for et domæne. Forhåndsvis først, anvend derefter.",
+    "source_hash": "18ca490b"
+  },
+  "web.admin.domaintoolbox.repair.orgIdLabel": {
+    "text": "Tildel organisation (hvis forældreløs)",
+    "source_hash": "f95b010a"
+  },
+  "web.admin.domaintoolbox.repair.orgIdPlaceholder": {
+    "text": "org-id eller extid",
+    "source_hash": "a87d634e"
+  },
+  "web.admin.domaintoolbox.repair.statusLabel": {
+    "text": "Status",
+    "source_hash": "920e413c"
+  },
+  "web.admin.domaintoolbox.repair.noIssues": {
+    "text": "Ingen problemer fundet — relationerne er konsistente.",
+    "source_hash": "e1a4c49d"
+  },
+  "web.admin.domaintoolbox.repair.applyButton": {
+    "text": "Anvend reparationer",
+    "source_hash": "3f92b29f"
+  },
+  "web.admin.domaintoolbox.repair.success": {
+    "text": "Reparationer anvendt.",
+    "source_hash": "24f25b9b"
+  },
+  "web.admin.domaintoolbox.repair.confirmTitle": {
+    "text": "Anvend domænereparationer?",
+    "source_hash": "9429998b"
+  },
+  "web.admin.domaintoolbox.repair.confirmDescription": {
+    "text": "Dette ændrer ejerskabs-/relationstilstanden for {domain}. Skriv det eksterne domæne-ID igen for at bekræfte.",
+    "source_hash": "426d267b"
+  },
+  "web.admin.domaintoolbox.reverify.button": {
+    "text": "Bekræft igen",
+    "source_hash": "0344860a"
+  },
+  "web.admin.domaintoolbox.reverify.success": {
+    "text": "Fornyet bekræftelse af domæne fuldført.",
+    "source_hash": "497a2348"
+  },
+  "web.admin.domaintoolbox.transfer.title": {
+    "text": "Overfør ejerskab",
+    "source_hash": "3667f939"
+  },
+  "web.admin.domaintoolbox.transfer.description": {
+    "text": "Tildel et domæne til en anden organisation. Den mest vidtrækkende handling — forhåndsvis og bekræft omhyggeligt.",
+    "source_hash": "d4e26e03"
+  },
+  "web.admin.domaintoolbox.transfer.toOrgLabel": {
+    "text": "Destinationsorganisation",
+    "source_hash": "4e4486eb"
+  },
+  "web.admin.domaintoolbox.transfer.fromOrgLabel": {
+    "text": "Kildeorganisation (valgfrit)",
+    "source_hash": "3666815f"
+  },
+  "web.admin.domaintoolbox.transfer.fromOrgPlaceholder": {
+    "text": "bekræft nuværende ejer",
+    "source_hash": "cd9e769c"
+  },
+  "web.admin.domaintoolbox.transfer.from": {
+    "text": "Fra",
+    "source_hash": "21819769"
+  },
+  "web.admin.domaintoolbox.transfer.to": {
+    "text": "Til",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.domaintoolbox.transfer.orphaned": {
+    "text": "FORÆLDRELØS",
+    "source_hash": "54dc2166"
+  },
+  "web.admin.domaintoolbox.transfer.applyButton": {
+    "text": "Overfør domæne",
+    "source_hash": "9517aeb9"
+  },
+  "web.admin.domaintoolbox.transfer.success": {
+    "text": "Domæne overført.",
+    "source_hash": "bbca9de9"
+  },
+  "web.admin.domaintoolbox.transfer.confirmTitle": {
+    "text": "Overfør ejerskab af domæne?",
+    "source_hash": "d306a15a"
+  },
+  "web.admin.domaintoolbox.transfer.confirmDescription": {
+    "text": "Dette tildeler ejerskabet af {domain} til en anden organisation. Skriv det eksterne domæne-ID igen for at bekræfte.",
+    "source_hash": "edefd97c"
+  }
+}

--- a/locales/content/da_DK/admin-emailtools.json
+++ b/locales/content/da_DK/admin-emailtools.json
@@ -1,0 +1,550 @@
+{
+  "web.admin.emailtools.title": {
+    "text": "E-mailværktøjer",
+    "source_hash": "f9643d5a"
+  },
+  "web.admin.emailtools.description": {
+    "text": "Forhåndsvis e-mailskabeloner, send en leveringstest, og overvåg leveringsdygtighed — de diagnoser, der tidligere krævede SSH.",
+    "source_hash": "be85c9e9"
+  },
+  "web.admin.emailtools.config.title": {
+    "text": "Mailerkonfiguration",
+    "source_hash": "d2a71028"
+  },
+  "web.admin.emailtools.config.description": {
+    "text": "Den gældende mailkonfiguration, der løses ved opstart. Legitimationsoplysninger vises aldrig — kun om de er til stede.",
+    "source_hash": "f0e8a118"
+  },
+  "web.admin.emailtools.config.provider": {
+    "text": "Transportudbyder",
+    "source_hash": "4f0e5025"
+  },
+  "web.admin.emailtools.config.senderProvider": {
+    "text": "Afsenderudbyder",
+    "source_hash": "e881964f"
+  },
+  "web.admin.emailtools.config.senderDiffers": {
+    "text": "Afsender adskiller sig fra transport",
+    "source_hash": "ab78e8f6"
+  },
+  "web.admin.emailtools.config.autoDetected": {
+    "text": "Autoregistreret",
+    "source_hash": "a69c7f9e"
+  },
+  "web.admin.emailtools.config.fromAddress": {
+    "text": "Afsenderadresse",
+    "source_hash": "d465bcfa"
+  },
+  "web.admin.emailtools.config.fromName": {
+    "text": "Afsendernavn",
+    "source_hash": "b28f93ea"
+  },
+  "web.admin.emailtools.config.host": {
+    "text": "SMTP-host",
+    "source_hash": "ab328f83"
+  },
+  "web.admin.emailtools.config.port": {
+    "text": "Port",
+    "source_hash": "72e9a59f"
+  },
+  "web.admin.emailtools.config.region": {
+    "text": "Region",
+    "source_hash": "d3a008ef"
+  },
+  "web.admin.emailtools.config.hasCredentials": {
+    "text": "Legitimationsoplysninger konfigureret",
+    "source_hash": "1c81633a"
+  },
+  "web.admin.emailtools.config.yes": {
+    "text": "Ja",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.emailtools.config.no": {
+    "text": "Nej",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.emailtools.config.loggerWarning": {
+    "text": "Mail leveres ikke. Transportudbyderen er indstillet til en tilstand uden afsendelse (logger, disabled eller none), så ingen e-mail forlader denne server — udgående beskeder skrives til applikationsloggen eller kasseres.",
+    "source_hash": "1883dfd5"
+  },
+  "web.admin.emailtools.deliverability.title": {
+    "text": "Leveringsdygtighed",
+    "source_hash": "66b4d300"
+  },
+  "web.admin.emailtools.deliverability.description": {
+    "text": "Hvad der kommer tilbage efter afsendelse: afvisninger, klager, og undertrykkelseslisten, der beskytter dit afsenderomdømme.",
+    "source_hash": "e8363bb5"
+  },
+  "web.admin.emailtools.deliverability.retry": {
+    "text": "Prøv igen",
+    "source_hash": "942087cc"
+  },
+  "web.admin.emailtools.deliverability.events.title": {
+    "text": "Seneste hændelser",
+    "source_hash": "8ecce94d"
+  },
+  "web.admin.emailtools.deliverability.events.description": {
+    "text": "Det rå feed med afvisninger og klager, nyeste først.",
+    "source_hash": "0e7a533b"
+  },
+  "web.admin.emailtools.deliverability.events.empty": {
+    "text": "Endnu ingen data om afvisninger eller klager. Send din ESP's feedback ind via POST /api/colonel/email/deliverability/events (colonel-godkendt — se endepunktets dokumentation for postformatet). Synkrone hårde SMTP-afvisninger registreres automatisk.",
+    "source_hash": "a90f259c"
+  },
+  "web.admin.emailtools.deliverability.events.loadError": {
+    "text": "Seneste hændelser kunne ikke indlæses.",
+    "source_hash": "02244c61"
+  },
+  "web.admin.emailtools.deliverability.events.columns.time": {
+    "text": "Tidspunkt",
+    "source_hash": "33b93476"
+  },
+  "web.admin.emailtools.deliverability.events.columns.kind": {
+    "text": "Type",
+    "source_hash": "baaddf70"
+  },
+  "web.admin.emailtools.deliverability.events.columns.address": {
+    "text": "Adresse",
+    "source_hash": "56ef8f20"
+  },
+  "web.admin.emailtools.deliverability.events.columns.source": {
+    "text": "Kilde",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.emailtools.deliverability.events.columns.reason": {
+    "text": "Årsag",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.emailtools.deliverability.events.kinds.bounce": {
+    "text": "afvisning",
+    "source_hash": "4d6723e5"
+  },
+  "web.admin.emailtools.deliverability.events.kinds.complaint": {
+    "text": "klage",
+    "source_hash": "5d08b02d"
+  },
+  "web.admin.emailtools.deliverability.lookup.title": {
+    "text": "Modtageropslag",
+    "source_hash": "7569985b"
+  },
+  "web.admin.emailtools.deliverability.lookup.description": {
+    "text": "Tjek, om en adresse er undertrykt, både i det lokale lager og aktivt hos den aktive mailudbyder. Begge indekseres efter den samme normaliserede adresse.",
+    "source_hash": "c341d614"
+  },
+  "web.admin.emailtools.deliverability.lookup.addressLabel": {
+    "text": "Modtageradresse",
+    "source_hash": "454d0391"
+  },
+  "web.admin.emailtools.deliverability.lookup.submit": {
+    "text": "Slå op",
+    "source_hash": "504101bc"
+  },
+  "web.admin.emailtools.deliverability.lookup.local": {
+    "text": "Lokalt lager",
+    "source_hash": "c740d116"
+  },
+  "web.admin.emailtools.deliverability.lookup.provider": {
+    "text": "Udbyder",
+    "source_hash": "472590ae"
+  },
+  "web.admin.emailtools.deliverability.lookup.suppressed": {
+    "text": "Undertrykt",
+    "source_hash": "435c7831"
+  },
+  "web.admin.emailtools.deliverability.lookup.notSuppressed": {
+    "text": "Ikke undertrykt",
+    "source_hash": "7b1544d7"
+  },
+  "web.admin.emailtools.deliverability.lookup.reason": {
+    "text": "Årsag",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.emailtools.deliverability.lookup.source": {
+    "text": "Kilde",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.emailtools.deliverability.lookup.unavailable": {
+    "text": "Opslag hos den aktive udbyder er ikke tilgængeligt; det lokale lager ovenfor er autoritativt.",
+    "source_hash": "aebed0f2"
+  },
+  "web.admin.emailtools.deliverability.messages.title": {
+    "text": "Seneste afsendelser",
+    "source_hash": "522e089e"
+  },
+  "web.admin.emailtools.deliverability.messages.description": {
+    "text": "De seneste beskeder, som den aktive mailudbyder har registreret, nyeste først. Hentes aktivt fra udbyderen — gemmes aldrig her.",
+    "source_hash": "9970fa0a"
+  },
+  "web.admin.emailtools.deliverability.messages.empty": {
+    "text": "Udbyderen returnerede ingen seneste beskeder.",
+    "source_hash": "a7ef4d79"
+  },
+  "web.admin.emailtools.deliverability.messages.notSupported": {
+    "text": "En afsendelseslog er ikke tilgængelig på {provider}-transporten, som ikke tilbyder nogen API pr. besked.",
+    "source_hash": "21e6b6f9"
+  },
+  "web.admin.emailtools.deliverability.messages.error": {
+    "text": "Afsendelsesloggen kunne ikke indlæses fra udbyderen. Prøv igen.",
+    "source_hash": "4f671e55"
+  },
+  "web.admin.emailtools.deliverability.messages.col.status": {
+    "text": "Status",
+    "source_hash": "920e413c"
+  },
+  "web.admin.emailtools.deliverability.messages.col.subject": {
+    "text": "Emne",
+    "source_hash": "68971283"
+  },
+  "web.admin.emailtools.deliverability.messages.col.to": {
+    "text": "Til",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.emailtools.deliverability.messages.col.created": {
+    "text": "Sendt",
+    "source_hash": "c16bc82b"
+  },
+  "web.admin.emailtools.deliverability.messages.status.delivered": {
+    "text": "leveret",
+    "source_hash": "373e0712"
+  },
+  "web.admin.emailtools.deliverability.messages.status.opened": {
+    "text": "åbnet",
+    "source_hash": "50236627"
+  },
+  "web.admin.emailtools.deliverability.messages.status.clicked": {
+    "text": "klikket",
+    "source_hash": "d66440b2"
+  },
+  "web.admin.emailtools.deliverability.messages.status.pending": {
+    "text": "afventer",
+    "source_hash": "62a2fed3"
+  },
+  "web.admin.emailtools.deliverability.messages.status.queued": {
+    "text": "i kø",
+    "source_hash": "d36be649"
+  },
+  "web.admin.emailtools.deliverability.messages.status.processed": {
+    "text": "behandlet",
+    "source_hash": "58190ffa"
+  },
+  "web.admin.emailtools.deliverability.messages.status.hard_bounced": {
+    "text": "hårdt afvist",
+    "source_hash": "b0aa6fd4"
+  },
+  "web.admin.emailtools.deliverability.messages.status.soft_bounced": {
+    "text": "blødt afvist",
+    "source_hash": "ac844ff2"
+  },
+  "web.admin.emailtools.deliverability.messages.status.complained": {
+    "text": "klaget",
+    "source_hash": "c26fe786"
+  },
+  "web.admin.emailtools.deliverability.messages.status.suppressed": {
+    "text": "undertrykt",
+    "source_hash": "f63d5b6b"
+  },
+  "web.admin.emailtools.deliverability.messages.status.unsubscribed": {
+    "text": "afmeldt",
+    "source_hash": "621e1970"
+  },
+  "web.admin.emailtools.deliverability.summary.loadError": {
+    "text": "Oversigten over leveringsdygtighed kunne ikke indlæses.",
+    "source_hash": "0c16ef96"
+  },
+  "web.admin.emailtools.deliverability.suppressions.title": {
+    "text": "Undertrykkelsesliste",
+    "source_hash": "9f3e322f"
+  },
+  "web.admin.emailtools.deliverability.suppressions.description": {
+    "text": "Adresser, som udgående mail springer over. Poster kommer fra indhentning af ESP-feedback eller manuel import; fjernelse af en genoptager levering.",
+    "source_hash": "3651887e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.searchLabel": {
+    "text": "Præcis adresse",
+    "source_hash": "f4338ff8"
+  },
+  "web.admin.emailtools.deliverability.suppressions.searchPlaceholder": {
+    "text": "user{'@'}example.com",
+    "source_hash": "333f0f15"
+  },
+  "web.admin.emailtools.deliverability.suppressions.searchButton": {
+    "text": "Slå op",
+    "source_hash": "504101bc"
+  },
+  "web.admin.emailtools.deliverability.suppressions.clearButton": {
+    "text": "Ryd",
+    "source_hash": "83b12c22"
+  },
+  "web.admin.emailtools.deliverability.suppressions.empty": {
+    "text": "Endnu ingen undertrykte adresser. De vises her, efterhånden som feedback om afvisninger og klager indhentes.",
+    "source_hash": "dd3f4d61"
+  },
+  "web.admin.emailtools.deliverability.suppressions.emptySearch": {
+    "text": "Ingen undertrykkelsespost for {address}.",
+    "source_hash": "200c361e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.loadError": {
+    "text": "Undertrykkelseslisten kunne ikke indlæses.",
+    "source_hash": "2a12c8ba"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.addressLabel": {
+    "text": "Tilføj adresse",
+    "source_hash": "8be5aa33"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.button": {
+    "text": "Undertryk",
+    "source_hash": "60b19987"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.confirmTitle": {
+    "text": "Undertryk denne adresse?",
+    "source_hash": "40a0d2a6"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.confirmDescription": {
+    "text": "Udgående mail til {address} springes over, indtil undertrykkelsen fjernes. Dette registreres som en manuel post.",
+    "source_hash": "e3d0d799"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.success": {
+    "text": "Adresse {address} undertrykt.",
+    "source_hash": "e2cd2c3b"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.successExisting": {
+    "text": "Adresse {address} var allerede undertrykt; posten er opdateret.",
+    "source_hash": "0852101e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.error": {
+    "text": "Adressen kunne ikke undertrykkes.",
+    "source_hash": "dad9e000"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.address": {
+    "text": "Adresse",
+    "source_hash": "56ef8f20"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.reason": {
+    "text": "Årsag",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.source": {
+    "text": "Kilde",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.added": {
+    "text": "Tilføjet",
+    "source_hash": "6b02e0d3"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.actions": {
+    "text": "Handlinger",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.button": {
+    "text": "Fjern",
+    "source_hash": "c3812fc4"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.confirmTitle": {
+    "text": "Fjern denne undertrykkelse?",
+    "source_hash": "0b0aec2e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.confirmDescription": {
+    "text": "Udgående mail til {address} genoptages. Denne adresse blev tidligere afvist eller klagede — fjern den kun, hvis du ved, at den kan leveres til igen.",
+    "source_hash": "09442f9c"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.success": {
+    "text": "Undertrykkelse fjernet for {address}.",
+    "source_hash": "bfc0de36"
+  },
+  "web.admin.emailtools.deliverability.sync.title": {
+    "text": "Feedbacksynkronisering",
+    "source_hash": "d4056915"
+  },
+  "web.admin.emailtools.deliverability.sync.lastSynced": {
+    "text": "sidst synkroniseret",
+    "source_hash": "5a99666b"
+  },
+  "web.admin.emailtools.deliverability.sync.imported": {
+    "text": "{count} importeret",
+    "source_hash": "1bc18c45"
+  },
+  "web.admin.emailtools.deliverability.sync.neverRun": {
+    "text": "Udbyderens feedbacksynkronisering er aldrig kørt. Data om afvisninger og klager importeres ikke automatisk — konfigurer en udbydersynkronisering, eller indhent feedback via hændelsesendepunktet.",
+    "source_hash": "d19f5755"
+  },
+  "web.admin.emailtools.deliverability.sync.button": {
+    "text": "Synkroniser nu",
+    "source_hash": "885e8f48"
+  },
+  "web.admin.emailtools.deliverability.sync.success": {
+    "text": "{provider}-synkronisering fuldført: {accepted} importeret, {rejected} afvist ({fetched} hentet).",
+    "source_hash": "d36f5578"
+  },
+  "web.admin.emailtools.deliverability.sync.hint": {
+    "text": "En manuel synkronisering — automatisk import kræver stadig et planlagt `ots email sync-feedback`-cronjob.",
+    "source_hash": "7a509b75"
+  },
+  "web.admin.emailtools.deliverability.tiles.suppressed": {
+    "text": "Undertrykte adresser",
+    "source_hash": "b31a245e"
+  },
+  "web.admin.emailtools.deliverability.tiles.bounces": {
+    "text": "Afvisninger ({days}d)",
+    "source_hash": "3a4d0f09"
+  },
+  "web.admin.emailtools.deliverability.tiles.complaints": {
+    "text": "Klager ({days}d)",
+    "source_hash": "16ad856f"
+  },
+  "web.admin.emailtools.deliverability.tiles.skipped": {
+    "text": "Afsendelser sprunget over",
+    "source_hash": "391467f9"
+  },
+  "web.admin.emailtools.preview.title": {
+    "text": "Skabelonforhåndsvisning",
+    "source_hash": "df89bd92"
+  },
+  "web.admin.emailtools.preview.description": {
+    "text": "Gengiv en skabelon med dens eksempeldata. Forhåndsvisning har ingen bivirkninger — der sendes ingen e-mail.",
+    "source_hash": "9b0e40f3"
+  },
+  "web.admin.emailtools.preview.templateLabel": {
+    "text": "Skabelon",
+    "source_hash": "0575f29d"
+  },
+  "web.admin.emailtools.preview.formatLabel": {
+    "text": "Format",
+    "source_hash": "2f343666"
+  },
+  "web.admin.emailtools.preview.localeLabel": {
+    "text": "Sprogområde",
+    "source_hash": "ca3dc612"
+  },
+  "web.admin.emailtools.preview.button": {
+    "text": "Forhåndsvis",
+    "source_hash": "324b134f"
+  },
+  "web.admin.emailtools.providerStatus.title": {
+    "text": "Udbyderstatus",
+    "source_hash": "231b7f03"
+  },
+  "web.admin.emailtools.providerStatus.rateUnavailable": {
+    "text": "Denne udbyder eksponerer ingen numerisk afvisnings- eller klagerate; omdømmeniveauet ovenfor udledes kun af håndhævelsesstatussen og afsendelseskvoten.",
+    "source_hash": "1e6b82e9"
+  },
+  "web.admin.emailtools.providerStatus.complaintsUnavailable": {
+    "text": "Lettermint rapporterer ikke klager i sin stats-API, så klageraten vises som “—” (ikke rapporteret), ikke nul. Afvisningsraten ovenfor er fuldstændig.",
+    "source_hash": "72aaa845"
+  },
+  "web.admin.emailtools.providerStatus.unavailable": {
+    "text": "Udbyderstatus er midlertidigt utilgængelig.",
+    "source_hash": "8e69ff29"
+  },
+  "web.admin.emailtools.providerStatus.notSupported": {
+    "text": "Aktiv udbyderstatus er ikke tilgængelig på {provider}-transporten.",
+    "source_hash": "125ed6eb"
+  },
+  "web.admin.emailtools.providerStatus.error": {
+    "text": "Mailudbyderen kunne ikke nås for status. Prøv igen.",
+    "source_hash": "594ab7b1"
+  },
+  "web.admin.emailtools.providerStatus.quota.max24h": {
+    "text": "Afsendelsesgrænse for 24 t",
+    "source_hash": "e5ea4c3d"
+  },
+  "web.admin.emailtools.providerStatus.quota.sent24h": {
+    "text": "Sendt (seneste 24 t)",
+    "source_hash": "d0c4fe45"
+  },
+  "web.admin.emailtools.providerStatus.quota.maxRate": {
+    "text": "Maks. afsendelsesrate (pr. sek.)",
+    "source_hash": "59e76cf8"
+  },
+  "web.admin.emailtools.providerStatus.rate.bounce": {
+    "text": "Afvisningsrate",
+    "source_hash": "9eba32f0"
+  },
+  "web.admin.emailtools.providerStatus.rate.complaint": {
+    "text": "Klagerate",
+    "source_hash": "430a23a9"
+  },
+  "web.admin.emailtools.providerStatus.stats.sent": {
+    "text": "Sendt ({days}d)",
+    "source_hash": "e553b7e1"
+  },
+  "web.admin.emailtools.providerStatus.stats.delivered": {
+    "text": "Leveret",
+    "source_hash": "90611565"
+  },
+  "web.admin.emailtools.providerStatus.stats.hardBounced": {
+    "text": "Hårdt afvist",
+    "source_hash": "c76631c0"
+  },
+  "web.admin.emailtools.providerStatus.stats.complaints": {
+    "text": "Spamklager",
+    "source_hash": "d48953cd"
+  },
+  "web.admin.emailtools.providerStatus.tier.healthy": {
+    "text": "Sund",
+    "source_hash": "7f1e323b"
+  },
+  "web.admin.emailtools.providerStatus.tier.probation": {
+    "text": "Under gennemgang",
+    "source_hash": "9e8a3b64"
+  },
+  "web.admin.emailtools.providerStatus.tier.shutdown": {
+    "text": "Afsendelse sat på pause",
+    "source_hash": "52e6757c"
+  },
+  "web.admin.emailtools.test.title": {
+    "text": "Testafsendelse",
+    "source_hash": "5fab5d67"
+  },
+  "web.admin.emailtools.test.description": {
+    "text": "Send en diagnostisk e-mail i almindelig tekst for at verificere leveringsforbindelsen. Forhåndsvis den først, bekræft derefter for at sende en rigtig e-mail.",
+    "source_hash": "4130741c"
+  },
+  "web.admin.emailtools.test.toLabel": {
+    "text": "Modtager",
+    "source_hash": "51fac985"
+  },
+  "web.admin.emailtools.test.toPlaceholder": {
+    "text": "you{'@'}example.com",
+    "source_hash": "cf0a9acc"
+  },
+  "web.admin.emailtools.test.enqueueLabel": {
+    "text": "Via worker-kø",
+    "source_hash": "97897017"
+  },
+  "web.admin.emailtools.test.previewButton": {
+    "text": "Forhåndsvis (ingen afsendelse)",
+    "source_hash": "747ced83"
+  },
+  "web.admin.emailtools.test.sendButton": {
+    "text": "Send test-e-mail",
+    "source_hash": "46ebd7db"
+  },
+  "web.admin.emailtools.test.provider": {
+    "text": "Udbyder",
+    "source_hash": "472590ae"
+  },
+  "web.admin.emailtools.test.host": {
+    "text": "Oprindelses-host",
+    "source_hash": "968925cb"
+  },
+  "web.admin.emailtools.test.from": {
+    "text": "Fra",
+    "source_hash": "21819769"
+  },
+  "web.admin.emailtools.test.subject": {
+    "text": "Emne",
+    "source_hash": "68971283"
+  },
+  "web.admin.emailtools.test.confirmTitle": {
+    "text": "Send en rigtig test-e-mail?",
+    "source_hash": "64a16b62"
+  },
+  "web.admin.emailtools.test.confirmDescription": {
+    "text": "Dette afsender en aktiv e-mail til {to} via den konfigurerede mailer.",
+    "source_hash": "10114929"
+  },
+  "web.admin.emailtools.test.success": {
+    "text": "Test-e-mail sendt til {to}.",
+    "source_hash": "daa61a62"
+  }
+}

--- a/locales/content/da_DK/admin-kit.json
+++ b/locales/content/da_DK/admin-kit.json
@@ -1,0 +1,66 @@
+{
+  "web.admin.kit.confirmDialog.typePrompt": {
+    "text": "For at bekræfte skal du skrive {token} nedenfor",
+    "source_hash": "282445b6"
+  },
+  "web.admin.kit.confirmDialog.inputLabel": {
+    "text": "Bekræftelsestekst",
+    "source_hash": "8edc1113"
+  },
+  "web.admin.kit.confirmDialog.mismatchHint": {
+    "text": "Den indtastede tekst skal matche præcist for at fortsætte.",
+    "source_hash": "f0cc7389"
+  },
+  "web.admin.kit.dataTable.empty": {
+    "text": "Ingen poster fundet",
+    "source_hash": "6e2ea637"
+  },
+  "web.admin.kit.dataTable.sortBy": {
+    "text": "Sorter efter {column}",
+    "source_hash": "55fb1bf9"
+  },
+  "web.admin.kit.filterBar.search": {
+    "text": "Søg",
+    "source_hash": "49c266ba"
+  },
+  "web.admin.kit.filterBar.searchPlaceholder": {
+    "text": "Søg…",
+    "source_hash": "7336265a"
+  },
+  "web.admin.kit.filterBar.clearFilters": {
+    "text": "Ryd filtre",
+    "source_hash": "7179ea00"
+  },
+  "web.admin.kit.filterBar.all": {
+    "text": "Alle",
+    "source_hash": "a52ace42"
+  },
+  "web.admin.kit.jsonViewer.expandAll": {
+    "text": "Udvid alle",
+    "source_hash": "a3e586be"
+  },
+  "web.admin.kit.jsonViewer.collapseAll": {
+    "text": "Skjul alle",
+    "source_hash": "25f7b372"
+  },
+  "web.admin.kit.jsonViewer.empty": {
+    "text": "Ingen data",
+    "source_hash": "3b41ba9c"
+  },
+  "web.admin.kit.jsonViewer.copyLabel": {
+    "text": "Kopier JSON",
+    "source_hash": "7708c6e2"
+  },
+  "web.admin.kit.revealEmail.reveal": {
+    "text": "Vis e-mailadresse",
+    "source_hash": "f6272277"
+  },
+  "web.admin.kit.revealEmail.hide": {
+    "text": "Skjul e-mailadresse",
+    "source_hash": "9755e870"
+  },
+  "web.admin.kit.revealEmail.copy": {
+    "text": "Kopier e-mailadresse",
+    "source_hash": "61b94846"
+  }
+}

--- a/locales/content/da_DK/admin-organizations.json
+++ b/locales/content/da_DK/admin-organizations.json
@@ -1,0 +1,314 @@
+{
+  "web.admin.organizations.retry": {
+    "text": "Prøv igen",
+    "source_hash": "942087cc"
+  },
+  "web.admin.organizations.detail.backToList": {
+    "text": "Tilbage til organisationer",
+    "source_hash": "2257dc4a"
+  },
+  "web.admin.organizations.detail.notFound": {
+    "text": "Organisation ikke fundet",
+    "source_hash": "00c50f7a"
+  },
+  "web.admin.organizations.detail.notFoundDescription": {
+    "text": "Denne organisation kan være blevet slettet, eller id'et er forkert.",
+    "source_hash": "e5459ef5"
+  },
+  "web.admin.organizations.detail.loadError": {
+    "text": "Denne organisation kunne ikke indlæses.",
+    "source_hash": "9df8ad50"
+  },
+  "web.admin.organizations.detail.none": {
+    "text": "—",
+    "source_hash": "bda05058"
+  },
+  "web.admin.organizations.detail.badges.default": {
+    "text": "Standard-workspace",
+    "source_hash": "6d67c6eb"
+  },
+  "web.admin.organizations.detail.badges.archived": {
+    "text": "Arkiveret",
+    "source_hash": "bdb86505"
+  },
+  "web.admin.organizations.detail.domains.domain": {
+    "text": "Domæne",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.organizations.detail.domains.state": {
+    "text": "Tilstand",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.organizations.detail.domains.created": {
+    "text": "Oprettet",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.organizations.detail.domains.ready": {
+    "text": "Klar",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.organizations.detail.domains.resolving": {
+    "text": "Slår op",
+    "source_hash": "3287a034"
+  },
+  "web.admin.organizations.detail.domains.empty": {
+    "text": "Ingen domæner.",
+    "source_hash": "1b840c7e"
+  },
+  "web.admin.organizations.detail.entitlements.description": {
+    "text": "Effektive rettigheder løses til (plan ∪ tildelinger) − tilbagekaldelser. Gennemgå fordelingen, før du foretager en tilsidesættelse.",
+    "source_hash": "23080475"
+  },
+  "web.admin.organizations.detail.entitlements.inSync": {
+    "text": "Synkroniseret",
+    "source_hash": "5701958c"
+  },
+  "web.admin.organizations.detail.entitlements.driftBadge": {
+    "text": "Afvigelse",
+    "source_hash": "8b4c8240"
+  },
+  "web.admin.organizations.detail.entitlements.staleBadge": {
+    "text": "Plan forældet",
+    "source_hash": "ffe63800"
+  },
+  "web.admin.organizations.detail.entitlements.driftWarning": {
+    "text": "Materialiserede rettigheder matcher ikke det forventede sæt. Afstem for at materialisere igen.",
+    "source_hash": "4859983a"
+  },
+  "web.admin.organizations.detail.entitlements.driftExtra": {
+    "text": "Ekstra (materialiseret, ikke forventet)",
+    "source_hash": "08d60730"
+  },
+  "web.admin.organizations.detail.entitlements.driftMissing": {
+    "text": "Mangler (forventet, ikke materialiseret)",
+    "source_hash": "fe12c83a"
+  },
+  "web.admin.organizations.detail.entitlements.plan": {
+    "text": "Fra plan",
+    "source_hash": "1d346b26"
+  },
+  "web.admin.organizations.detail.entitlements.materialized": {
+    "text": "Materialiseret (effektiv)",
+    "source_hash": "72ca5f45"
+  },
+  "web.admin.organizations.detail.members.email": {
+    "text": "Medlem",
+    "source_hash": "7c968fb7"
+  },
+  "web.admin.organizations.detail.members.role": {
+    "text": "Rolle",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.organizations.detail.members.status": {
+    "text": "Status",
+    "source_hash": "920e413c"
+  },
+  "web.admin.organizations.detail.members.joined": {
+    "text": "Tilmeldt",
+    "source_hash": "69318b0c"
+  },
+  "web.admin.organizations.detail.members.owner": {
+    "text": "Ejer",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.detail.members.empty": {
+    "text": "Ingen medlemmer.",
+    "source_hash": "b99c59dc"
+  },
+  "web.admin.organizations.detail.reconcile.button": {
+    "text": "Afstem",
+    "source_hash": "b59be565"
+  },
+  "web.admin.organizations.detail.reconcile.confirmTitle": {
+    "text": "Afstem organisationens fakturering?",
+    "source_hash": "fc1a2762"
+  },
+  "web.admin.organizations.detail.reconcile.confirmDescription": {
+    "text": "Dette henter Stripe igen og genskriver faktureringstilstanden og rettighederne for {org}. Skriv organisationens id igen for at bekræfte.",
+    "source_hash": "b4ef0850"
+  },
+  "web.admin.organizations.detail.reconcile.success": {
+    "text": "Organisation afstemt.",
+    "source_hash": "caf87844"
+  },
+  "web.admin.organizations.detail.reconcile.resultTitle": {
+    "text": "Afstemningsresultat",
+    "source_hash": "11f4c6b8"
+  },
+  "web.admin.organizations.detail.reconcile.before": {
+    "text": "Før",
+    "source_hash": "9bb72500"
+  },
+  "web.admin.organizations.detail.reconcile.after": {
+    "text": "Efter",
+    "source_hash": "7b68fe55"
+  },
+  "web.admin.organizations.detail.reconcile.materializedCount": {
+    "text": "Antal rettigheder",
+    "source_hash": "59cede5c"
+  },
+  "web.admin.organizations.detail.reconcile.mode.stripe_sync": {
+    "text": "Stripe-synkronisering",
+    "source_hash": "02f9546c"
+  },
+  "web.admin.organizations.detail.reconcile.mode.entitlements_only": {
+    "text": "Kun rettigheder",
+    "source_hash": "8cf49a5d"
+  },
+  "web.admin.organizations.detail.sections.billing": {
+    "text": "Fakturering",
+    "source_hash": "3ac8bbca"
+  },
+  "web.admin.organizations.detail.sections.members": {
+    "text": "Medlemmer",
+    "source_hash": "1044a4c0"
+  },
+  "web.admin.organizations.detail.sections.domains": {
+    "text": "Domæner",
+    "source_hash": "ced67718"
+  },
+  "web.admin.organizations.detail.sections.investigate": {
+    "text": "Undersøg og afstem",
+    "source_hash": "b05aa349"
+  },
+  "web.admin.organizations.entitlements.section": {
+    "text": "Rettighedstilsidesættelser",
+    "source_hash": "48812068"
+  },
+  "web.admin.organizations.entitlements.description": {
+    "text": "Tildel eller tilbagekald rettigheder uafhængigt af planen. Effektiv = planrettigheder + tildelinger - tilbagekaldelser.",
+    "source_hash": "4c38425b"
+  },
+  "web.admin.organizations.entitlements.inputLabel": {
+    "text": "Rettighed",
+    "source_hash": "0d8f0b2d"
+  },
+  "web.admin.organizations.entitlements.placeholder": {
+    "text": "f.eks. custom_domains",
+    "source_hash": "05346c68"
+  },
+  "web.admin.organizations.entitlements.grant": {
+    "text": "Tildel",
+    "source_hash": "78b7d037"
+  },
+  "web.admin.organizations.entitlements.revoke": {
+    "text": "Tilbagekald",
+    "source_hash": "87e6d00b"
+  },
+  "web.admin.organizations.entitlements.clear": {
+    "text": "Ryd alle tilsidesættelser",
+    "source_hash": "f0e485c3"
+  },
+  "web.admin.organizations.entitlements.effective": {
+    "text": "Effektive rettigheder",
+    "source_hash": "b840f8c8"
+  },
+  "web.admin.organizations.entitlements.grants": {
+    "text": "Tildelinger",
+    "source_hash": "b3e1c95a"
+  },
+  "web.admin.organizations.entitlements.revokes": {
+    "text": "Tilbagekaldelser",
+    "source_hash": "f0e69b17"
+  },
+  "web.admin.organizations.entitlements.noOverrides": {
+    "text": "Udfør en handling for at se denne organisations nuværende tilsidesættelsestilstand.",
+    "source_hash": "98d2e30d"
+  },
+  "web.admin.organizations.entitlements.confirm.grantTitle": {
+    "text": "Tildel rettighed?",
+    "source_hash": "a4b2c57b"
+  },
+  "web.admin.organizations.entitlements.confirm.grantDescription": {
+    "text": "Tildel “{entitlement}” til {org}. Dette ændrer organisationens faktureringsrettigheder.",
+    "source_hash": "542ce26a"
+  },
+  "web.admin.organizations.entitlements.confirm.revokeTitle": {
+    "text": "Tilbagekald rettighed?",
+    "source_hash": "c93d520a"
+  },
+  "web.admin.organizations.entitlements.confirm.revokeDescription": {
+    "text": "Tilbagekald “{entitlement}” fra {org}. Dette ændrer organisationens faktureringsrettigheder.",
+    "source_hash": "a5d2a8a6"
+  },
+  "web.admin.organizations.entitlements.confirm.clearTitle": {
+    "text": "Ryd alle rettighedstilsidesættelser?",
+    "source_hash": "e36eb218"
+  },
+  "web.admin.organizations.entitlements.confirm.clearDescription": {
+    "text": "Fjern alle tildelings- og tilbagekaldelsestilsidesættelser for {org}, og nulstil den til dens planrettigheder.",
+    "source_hash": "96bad079"
+  },
+  "web.admin.organizations.entitlements.success.granted": {
+    "text": "Rettighed “{entitlement}” tildelt.",
+    "source_hash": "cf52fb0e"
+  },
+  "web.admin.organizations.entitlements.success.revoked": {
+    "text": "Rettighed “{entitlement}” tilbagekaldt.",
+    "source_hash": "279d425d"
+  },
+  "web.admin.organizations.entitlements.success.cleared": {
+    "text": "Alle rettighedstilsidesættelser ryddet.",
+    "source_hash": "a482743b"
+  },
+  "web.admin.organizations.fields.contactEmail": {
+    "text": "Kontakt-e-mail",
+    "source_hash": "6d7fce11"
+  },
+  "web.admin.organizations.fields.owner": {
+    "text": "Ejer",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.fields.plan": {
+    "text": "Plan",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.organizations.fields.subscription": {
+    "text": "Abonnementsstatus",
+    "source_hash": "f0723c4e"
+  },
+  "web.admin.organizations.fields.periodEnd": {
+    "text": "Periodeslut",
+    "source_hash": "eeae9fdd"
+  },
+  "web.admin.organizations.fields.billingEmail": {
+    "text": "Fakturerings-e-mail",
+    "source_hash": "8805b928"
+  },
+  "web.admin.organizations.fields.stripeCustomer": {
+    "text": "Stripe-kunde",
+    "source_hash": "8f169be1"
+  },
+  "web.admin.organizations.fields.stripeSubscription": {
+    "text": "Stripe-abonnement",
+    "source_hash": "53f71e08"
+  },
+  "web.admin.organizations.fields.orgId": {
+    "text": "Organisations-ID",
+    "source_hash": "1f466322"
+  },
+  "web.admin.organizations.fields.created": {
+    "text": "Oprettet",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.organizations.fields.updated": {
+    "text": "Opdateret",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.organizations.investigate.description": {
+    "text": "Sammenlign den lokale faktureringstilstand med det aktive Stripe-abonnement.",
+    "source_hash": "d7bbe9ed"
+  },
+  "web.admin.organizations.investigate.rawPayload": {
+    "text": "Rå undersøgelsespayload",
+    "source_hash": "29ca7df2"
+  },
+  "web.admin.organizations.investigate.parseError": {
+    "text": "Undersøgelsessvaret matchede ikke det forventede format.",
+    "source_hash": "db59cab1"
+  },
+  "web.admin.organizations.list.loadError": {
+    "text": "Organisationer kunne ikke indlæses.",
+    "source_hash": "130d5e70"
+  }
+}

--- a/locales/content/da_DK/admin-overview.json
+++ b/locales/content/da_DK/admin-overview.json
@@ -1,0 +1,94 @@
+{
+  "web.admin.overview.retry": {
+    "text": "Prøv igen",
+    "source_hash": "942087cc"
+  },
+  "web.admin.overview.feedback.title": {
+    "text": "Brugerfeedback",
+    "source_hash": "cb7b24c6"
+  },
+  "web.admin.overview.feedback.total": {
+    "text": "{count} i de seneste 30 dage",
+    "source_hash": "b6b9147c"
+  },
+  "web.admin.overview.feedback.today": {
+    "text": "I dag",
+    "source_hash": "2b065c7c"
+  },
+  "web.admin.overview.feedback.yesterday": {
+    "text": "I går",
+    "source_hash": "56618125"
+  },
+  "web.admin.overview.feedback.older": {
+    "text": "Ældre",
+    "source_hash": "03281c88"
+  },
+  "web.admin.overview.feedback.empty": {
+    "text": "Ingen feedback i denne periode",
+    "source_hash": "e09d594d"
+  },
+  "web.admin.overview.feedback.loadError": {
+    "text": "Feedback kunne ikke indlæses.",
+    "source_hash": "4011c408"
+  },
+  "web.admin.overview.stats.heading": {
+    "text": "Platformsstatistik",
+    "source_hash": "77728e4d"
+  },
+  "web.admin.overview.stats.customers": {
+    "text": "Kunder",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.overview.stats.secrets": {
+    "text": "Aktive beskeder",
+    "source_hash": "8db4c552"
+  },
+  "web.admin.overview.stats.sessions": {
+    "text": "Aktive sessioner",
+    "source_hash": "61ad9909"
+  },
+  "web.admin.overview.stats.receipts": {
+    "text": "Kvitteringer",
+    "source_hash": "60a627df"
+  },
+  "web.admin.overview.stats.secretsCreated": {
+    "text": "Beskeder oprettet (i alt)",
+    "source_hash": "bdb49794"
+  },
+  "web.admin.overview.stats.emailsSent": {
+    "text": "E-mails sendt (i alt)",
+    "source_hash": "1c9a7518"
+  },
+  "web.admin.overview.stats.loadError": {
+    "text": "Platformsstatistik kunne ikke indlæses.",
+    "source_hash": "5f13cf7a"
+  },
+  "web.admin.overview.trends.title": {
+    "text": "Seneste 30 dage",
+    "source_hash": "f8f03fb4"
+  },
+  "web.admin.overview.trends.signups": {
+    "text": "Tilmeldinger pr. dag",
+    "source_hash": "8db399dc"
+  },
+  "web.admin.overview.trends.secretsCreated": {
+    "text": "Beskeder oprettet pr. dag",
+    "source_hash": "d6852656"
+  },
+  "web.admin.overview.trends.today": {
+    "text": "i dag",
+    "source_hash": "e0f4f767"
+  },
+  "web.admin.overview.trends.collectingNote": {
+    "text": "Indsamler siden første datapunkt — dage før det viser nul.",
+    "source_hash": "269ee1eb"
+  },
+  "web.admin.overview.trends.sparklineAria": {
+    "text": "{label}: 30-dages tendens, {count} i dag",
+    "source_hash": "eb57a7b2"
+  },
+  "web.admin.overview.trends.loadError": {
+    "text": "Tendenser kunne ikke indlæses.",
+    "source_hash": "9cf97f63"
+  }
+}

--- a/locales/content/da_DK/admin-secrets.json
+++ b/locales/content/da_DK/admin-secrets.json
@@ -1,0 +1,218 @@
+{
+  "web.admin.secrets.title": {
+    "text": "Beskeder",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.secrets.description": {
+    "text": "Inspicer en beskeds kvittering, og slet den uden SSH — slå den op via dens nøgle.",
+    "source_hash": "07775a11"
+  },
+  "web.admin.secrets.never": {
+    "text": "Aldrig",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.secrets.anonymous": {
+    "text": "Anonym",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.admin.secrets.ageDays": {
+    "text": "{days} dage",
+    "source_hash": "a2246fbc"
+  },
+  "web.admin.secrets.actions.delete.button": {
+    "text": "Slet besked",
+    "source_hash": "1a48c8c8"
+  },
+  "web.admin.secrets.actions.delete.confirmTitle": {
+    "text": "Slet besked?",
+    "source_hash": "4a779a67"
+  },
+  "web.admin.secrets.actions.delete.confirmDescription": {
+    "text": "Dette sletter besked {shortid} og dens kvittering permanent. Dette kan ikke fortrydes.",
+    "source_hash": "51f807ad"
+  },
+  "web.admin.secrets.actions.delete.success": {
+    "text": "Besked slettet.",
+    "source_hash": "52f1640f"
+  },
+  "web.admin.secrets.detail.yes": {
+    "text": "Ja",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.secrets.detail.no": {
+    "text": "Nej",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.secrets.detail.none": {
+    "text": "Ingen",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.secrets.fields.secretId": {
+    "text": "Besked-ID",
+    "source_hash": "79592419"
+  },
+  "web.admin.secrets.fields.shortId": {
+    "text": "Kort ID",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.secrets.fields.state": {
+    "text": "Tilstand",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.secrets.fields.created": {
+    "text": "Oprettet",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.secrets.fields.updated": {
+    "text": "Opdateret",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.secrets.fields.expiration": {
+    "text": "Udløb",
+    "source_hash": "f38d6e0e"
+  },
+  "web.admin.secrets.fields.age": {
+    "text": "Alder",
+    "source_hash": "39b7370f"
+  },
+  "web.admin.secrets.fields.lifespan": {
+    "text": "Levetid",
+    "source_hash": "58994285"
+  },
+  "web.admin.secrets.fields.owner": {
+    "text": "Ejer",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.secrets.fields.receiptId": {
+    "text": "Kvitterings-ID",
+    "source_hash": "2c13d799"
+  },
+  "web.admin.secrets.fields.hasCiphertext": {
+    "text": "Har chiffertekst",
+    "source_hash": "e9188bad"
+  },
+  "web.admin.secrets.fields.ciphertextLength": {
+    "text": "Chiffertekstlængde",
+    "source_hash": "0f1744fd"
+  },
+  "web.admin.secrets.lookup.label": {
+    "text": "Beskednøgle",
+    "source_hash": "f47a99eb"
+  },
+  "web.admin.secrets.lookup.placeholder": {
+    "text": "Beskedidentifikator",
+    "source_hash": "cbcfd49f"
+  },
+  "web.admin.secrets.lookup.button": {
+    "text": "Slå op",
+    "source_hash": "504101bc"
+  },
+  "web.admin.secrets.lookup.resultTitle": {
+    "text": "Besked {shortid}",
+    "source_hash": "8b311d32"
+  },
+  "web.admin.secrets.lookup.notFound": {
+    "text": "Besked ikke fundet",
+    "source_hash": "70a9532c"
+  },
+  "web.admin.secrets.lookup.notFoundDescription": {
+    "text": "Der findes ingen besked med denne nøgle. Den kan være udløbet eller blevet slettet.",
+    "source_hash": "9f068a81"
+  },
+  "web.admin.secrets.lookup.loadError": {
+    "text": "Denne besked kunne ikke indlæses.",
+    "source_hash": "c96672e4"
+  },
+  "web.admin.secrets.lookup.retry": {
+    "text": "Prøv igen",
+    "source_hash": "942087cc"
+  },
+  "web.admin.secrets.owner.anonymous": {
+    "text": "Anonym (ingen ejer)",
+    "source_hash": "390f11ad"
+  },
+  "web.admin.secrets.ownerFields.email": {
+    "text": "E-mail",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.secrets.ownerFields.userId": {
+    "text": "Bruger-ID",
+    "source_hash": "7967e089"
+  },
+  "web.admin.secrets.ownerFields.role": {
+    "text": "Rolle",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.secrets.ownerFields.verified": {
+    "text": "Bekræftet",
+    "source_hash": "4f783840"
+  },
+  "web.admin.secrets.receipt.none": {
+    "text": "Ingen kvittering er knyttet til denne besked.",
+    "source_hash": "5ddceaed"
+  },
+  "web.admin.secrets.receiptFields.receiptId": {
+    "text": "Kvitterings-ID",
+    "source_hash": "2c13d799"
+  },
+  "web.admin.secrets.receiptFields.shortId": {
+    "text": "Kort ID",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.secrets.receiptFields.state": {
+    "text": "Tilstand",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.secrets.receiptFields.secretTtl": {
+    "text": "Besked-TTL",
+    "source_hash": "b89c0b51"
+  },
+  "web.admin.secrets.receiptFields.recipients": {
+    "text": "Modtagere",
+    "source_hash": "1e8568a8"
+  },
+  "web.admin.secrets.receiptFields.hasPassphrase": {
+    "text": "Har adgangssætning",
+    "source_hash": "af458f26"
+  },
+  "web.admin.secrets.receiptFields.shareDomain": {
+    "text": "Delingsdomæne",
+    "source_hash": "db963805"
+  },
+  "web.admin.secrets.receiptFields.created": {
+    "text": "Oprettet",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.secrets.receiptFields.secretExpired": {
+    "text": "Besked udløbet",
+    "source_hash": "c127dab6"
+  },
+  "web.admin.secrets.sections.secret": {
+    "text": "Besked",
+    "source_hash": "7e32a729"
+  },
+  "web.admin.secrets.sections.receipt": {
+    "text": "Kvittering",
+    "source_hash": "dad5a969"
+  },
+  "web.admin.secrets.sections.owner": {
+    "text": "Ejer",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.secrets.sections.raw": {
+    "text": "Rå",
+    "source_hash": "848123d1"
+  },
+  "web.admin.secrets.state.new": {
+    "text": "Ny",
+    "source_hash": "18fdd549"
+  },
+  "web.admin.secrets.state.received": {
+    "text": "Modtaget",
+    "source_hash": "49f19bee"
+  },
+  "web.admin.secrets.state.viewed": {
+    "text": "Vist",
+    "source_hash": "1b28d178"
+  }
+}

--- a/locales/content/da_DK/admin-sessions.json
+++ b/locales/content/da_DK/admin-sessions.json
@@ -1,0 +1,210 @@
+{
+  "web.admin.sessions.title": {
+    "text": "Sessioner",
+    "source_hash": "6fa3cbf4"
+  },
+  "web.admin.sessions.description": {
+    "text": "Inspicer, søg og tilbagekald aktive sessioner ved hændelseshåndtering.",
+    "source_hash": "784a3a44"
+  },
+  "web.admin.sessions.anonymous": {
+    "text": "Anonym",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.admin.sessions.columns.sessionId": {
+    "text": "Sessions-ID",
+    "source_hash": "cb9ac5c5"
+  },
+  "web.admin.sessions.columns.authenticated": {
+    "text": "Godkendt",
+    "source_hash": "8eb3ea9b"
+  },
+  "web.admin.sessions.columns.email": {
+    "text": "E-mail",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.sessions.columns.externalId": {
+    "text": "Eksternt ID",
+    "source_hash": "69da56ba"
+  },
+  "web.admin.sessions.columns.ipAddress": {
+    "text": "IP-adresse",
+    "source_hash": "3c3de0c9"
+  },
+  "web.admin.sessions.columns.created": {
+    "text": "Godkendt den",
+    "source_hash": "8d6c9b01"
+  },
+  "web.admin.sessions.columns.actions": {
+    "text": "Handlinger",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.sessions.columns.role": {
+    "text": "Rolle",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.sessions.detail.yes": {
+    "text": "Ja",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.sessions.detail.no": {
+    "text": "Nej",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.sessions.detail.none": {
+    "text": "Ingen",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.sessions.detail.unknown": {
+    "text": "Ukendt",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.sessions.detail.noExpiry": {
+    "text": "Intet udløb",
+    "source_hash": "fe06351d"
+  },
+  "web.admin.sessions.detail.expired": {
+    "text": "Udløbet",
+    "source_hash": "424a2551"
+  },
+  "web.admin.sessions.detail.ttlSeconds": {
+    "text": "{seconds}s tilbage",
+    "source_hash": "3c9d75ce"
+  },
+  "web.admin.sessions.drawer.title": {
+    "text": "Session {id}",
+    "source_hash": "29dcbd66"
+  },
+  "web.admin.sessions.drawer.notFound": {
+    "text": "Session ikke fundet",
+    "source_hash": "0969eab8"
+  },
+  "web.admin.sessions.drawer.notFoundDescription": {
+    "text": "Denne session findes ikke længere i Redis. Den kan være udløbet eller allerede være tilbagekaldt.",
+    "source_hash": "11e3ef05"
+  },
+  "web.admin.sessions.drawer.loadError": {
+    "text": "Denne session kunne ikke indlæses.",
+    "source_hash": "82ae90fb"
+  },
+  "web.admin.sessions.drawer.retry": {
+    "text": "Prøv igen",
+    "source_hash": "942087cc"
+  },
+  "web.admin.sessions.fields.sessionId": {
+    "text": "Sessions-ID",
+    "source_hash": "cb9ac5c5"
+  },
+  "web.admin.sessions.fields.key": {
+    "text": "Redis-nøgle",
+    "source_hash": "0b196725"
+  },
+  "web.admin.sessions.fields.ttl": {
+    "text": "TTL",
+    "source_hash": "76f6014f"
+  },
+  "web.admin.sessions.fields.authenticated": {
+    "text": "Godkendt",
+    "source_hash": "6ab694cf"
+  },
+  "web.admin.sessions.fields.email": {
+    "text": "E-mail",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.sessions.fields.externalId": {
+    "text": "Eksternt ID",
+    "source_hash": "69da56ba"
+  },
+  "web.admin.sessions.fields.accountId": {
+    "text": "Konto-ID",
+    "source_hash": "919bb4cb"
+  },
+  "web.admin.sessions.fields.role": {
+    "text": "Rolle",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.sessions.fields.locale": {
+    "text": "Sprogområde",
+    "source_hash": "ca3dc612"
+  },
+  "web.admin.sessions.fields.ipAddress": {
+    "text": "IP-adresse",
+    "source_hash": "3c3de0c9"
+  },
+  "web.admin.sessions.fields.authenticatedAt": {
+    "text": "Godkendt den",
+    "source_hash": "8d6c9b01"
+  },
+  "web.admin.sessions.fields.authenticatedBy": {
+    "text": "Godkendt af",
+    "source_hash": "3ebbabfe"
+  },
+  "web.admin.sessions.fields.activeSessionId": {
+    "text": "Aktiv sessions-ID",
+    "source_hash": "f32b1158"
+  },
+  "web.admin.sessions.fields.userAgent": {
+    "text": "User Agent",
+    "source_hash": "62e01345"
+  },
+  "web.admin.sessions.fields.orgContext": {
+    "text": "Org-kontekst",
+    "source_hash": "a596d9f2"
+  },
+  "web.admin.sessions.list.loadError": {
+    "text": "Sessioner kunne ikke indlæses.",
+    "source_hash": "00c678d9"
+  },
+  "web.admin.sessions.list.retry": {
+    "text": "Prøv igen",
+    "source_hash": "942087cc"
+  },
+  "web.admin.sessions.list.empty": {
+    "text": "Ingen aktive sessioner fundet",
+    "source_hash": "e35312d6"
+  },
+  "web.admin.sessions.revoke.button": {
+    "text": "Tilbagekald",
+    "source_hash": "87e6d00b"
+  },
+  "web.admin.sessions.revoke.confirmTitle": {
+    "text": "Tilbagekald denne session?",
+    "source_hash": "0c6605c1"
+  },
+  "web.admin.sessions.revoke.confirmDescription": {
+    "text": "Dette logger straks brugeren ud ved at slette session {id}. Skriv sessions-ID'et for at bekræfte.",
+    "source_hash": "9e08b1b8"
+  },
+  "web.admin.sessions.revoke.success": {
+    "text": "Session tilbagekaldt",
+    "source_hash": "0af5e14d"
+  },
+  "web.admin.sessions.scan.summary": {
+    "text": "Viser {shown} godkendte · {anonymous} anonyme skjult · {scanned} scannet",
+    "source_hash": "34cb67a4"
+  },
+  "web.admin.sessions.scan.capped": {
+    "text": "Scanning begrænset til de første {scanned} nøgler — godkendte sessioner ud over dette vindue vises ikke. Inspicer en bestemt session via ID for at nå den.",
+    "source_hash": "fa418b4e"
+  },
+  "web.admin.sessions.search.placeholder": {
+    "text": "Søg efter e-mail eller eksternt ID",
+    "source_hash": "f2dc5c06"
+  },
+  "web.admin.sessions.sections.session": {
+    "text": "Session",
+    "source_hash": "6959b415"
+  },
+  "web.admin.sessions.sections.raw": {
+    "text": "Rå sessionsdata",
+    "source_hash": "c9f11eb4"
+  },
+  "web.admin.sessions.status.authenticated": {
+    "text": "Godkendt",
+    "source_hash": "6ab694cf"
+  },
+  "web.admin.sessions.status.anonymous": {
+    "text": "Anonym",
+    "source_hash": "e7a8aa2d"
+  }
+}

--- a/locales/content/da_DK/admin-system.json
+++ b/locales/content/da_DK/admin-system.json
@@ -1,0 +1,158 @@
+{
+  "web.admin.system.title": {
+    "text": "System",
+    "source_hash": "6725e7bb"
+  },
+  "web.admin.system.description": {
+    "text": "Status for database, kø og infrastruktur.",
+    "source_hash": "0115f495"
+  },
+  "web.admin.system.retry": {
+    "text": "Prøv igen",
+    "source_hash": "942087cc"
+  },
+  "web.admin.system.database.title": {
+    "text": "Hoveddatabase ({engine})",
+    "source_hash": "1391230b"
+  },
+  "web.admin.system.database.loadError": {
+    "text": "Databasemålinger kunne ikke indlæses.",
+    "source_hash": "905055c6"
+  },
+  "web.admin.system.database.server": {
+    "text": "Server",
+    "source_hash": "aef7de28"
+  },
+  "web.admin.system.database.memory": {
+    "text": "Hukommelse",
+    "source_hash": "c3963aed"
+  },
+  "web.admin.system.database.databases": {
+    "text": "Databaser",
+    "source_hash": "61d2afe2"
+  },
+  "web.admin.system.database.dbSummary": {
+    "text": "{keys} nøgler, {expires} med TTL",
+    "source_hash": "26b9e17c"
+  },
+  "web.admin.system.database.fields.version": {
+    "text": "Version",
+    "source_hash": "dd167905"
+  },
+  "web.admin.system.database.fields.mode": {
+    "text": "Tilstand",
+    "source_hash": "5e23ec6a"
+  },
+  "web.admin.system.database.fields.uptimeDays": {
+    "text": "Oppetid (dage)",
+    "source_hash": "7ab314f8"
+  },
+  "web.admin.system.database.fields.connectedClients": {
+    "text": "Forbundne klienter",
+    "source_hash": "434adc3a"
+  },
+  "web.admin.system.database.fields.opsPerSec": {
+    "text": "Ops/sek.",
+    "source_hash": "6634251d"
+  },
+  "web.admin.system.database.fields.totalCommands": {
+    "text": "Kommandoer i alt",
+    "source_hash": "c5ce5aaf"
+  },
+  "web.admin.system.database.fields.usedMemory": {
+    "text": "Brugt hukommelse",
+    "source_hash": "bac68a65"
+  },
+  "web.admin.system.database.fields.rssMemory": {
+    "text": "RSS-hukommelse",
+    "source_hash": "7fe77d15"
+  },
+  "web.admin.system.database.fields.peakMemory": {
+    "text": "Maks. hukommelse",
+    "source_hash": "9d44afa6"
+  },
+  "web.admin.system.database.fields.fragmentation": {
+    "text": "Fragmenteringsforhold",
+    "source_hash": "721494dd"
+  },
+  "web.admin.system.database.stats.customers": {
+    "text": "Kunder",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.system.database.stats.secrets": {
+    "text": "Beskeder",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.system.database.stats.receipts": {
+    "text": "Kvitteringer",
+    "source_hash": "60a627df"
+  },
+  "web.admin.system.database.stats.totalKeys": {
+    "text": "Nøgler i alt",
+    "source_hash": "4e0d27f5"
+  },
+  "web.admin.system.queue.title": {
+    "text": "Kø",
+    "source_hash": "3b2fe03e"
+  },
+  "web.admin.system.queue.loadError": {
+    "text": "Kømålinger kunne ikke indlæses.",
+    "source_hash": "715bdc88"
+  },
+  "web.admin.system.queue.empty": {
+    "text": "Ingen køer fundet",
+    "source_hash": "3cd4eb88"
+  },
+  "web.admin.system.queue.connected": {
+    "text": "Forbundet",
+    "source_hash": "22965568"
+  },
+  "web.admin.system.queue.disconnected": {
+    "text": "Afbrudt",
+    "source_hash": "04dfac36"
+  },
+  "web.admin.system.queue.activeWorkers": {
+    "text": "{count} aktive workers",
+    "source_hash": "49e6369c"
+  },
+  "web.admin.system.queue.columns.name": {
+    "text": "Kø",
+    "source_hash": "3b2fe03e"
+  },
+  "web.admin.system.queue.columns.pending": {
+    "text": "Afventer",
+    "source_hash": "331551b0"
+  },
+  "web.admin.system.queue.columns.consumers": {
+    "text": "Consumers",
+    "source_hash": "212b350d"
+  },
+  "web.admin.system.queue.health.healthy": {
+    "text": "Sund",
+    "source_hash": "7f1e323b"
+  },
+  "web.admin.system.queue.health.degraded": {
+    "text": "Forringet",
+    "source_hash": "a8494c12"
+  },
+  "web.admin.system.queue.health.unhealthy": {
+    "text": "Usund",
+    "source_hash": "317b1fbc"
+  },
+  "web.admin.system.queue.health.unknown": {
+    "text": "Ukendt",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.system.redis.title": {
+    "text": "Redis INFO",
+    "source_hash": "e762bd3c"
+  },
+  "web.admin.system.redis.loadError": {
+    "text": "Redis-målinger kunne ikke indlæses.",
+    "source_hash": "ca5945d6"
+  },
+  "web.admin.system.redis.captured": {
+    "text": "Registreret {at}",
+    "source_hash": "57b40c0f"
+  }
+}

--- a/locales/content/da_DK/admin-usage.json
+++ b/locales/content/da_DK/admin-usage.json
@@ -1,0 +1,78 @@
+{
+  "web.admin.usage.title": {
+    "text": "Forbrug",
+    "source_hash": "8d59829c"
+  },
+  "web.admin.usage.description": {
+    "text": "Eksportér forbrugsmålinger for et datointerval.",
+    "source_hash": "97bd3325"
+  },
+  "web.admin.usage.startDate": {
+    "text": "Startdato",
+    "source_hash": "4c52faad"
+  },
+  "web.admin.usage.endDate": {
+    "text": "Slutdato",
+    "source_hash": "e970951c"
+  },
+  "web.admin.usage.fetch": {
+    "text": "Hent data",
+    "source_hash": "429532fe"
+  },
+  "web.admin.usage.loadError": {
+    "text": "Forbrugsdata kunne ikke indlæses.",
+    "source_hash": "ffb557d7"
+  },
+  "web.admin.usage.retry": {
+    "text": "Prøv igen",
+    "source_hash": "942087cc"
+  },
+  "web.admin.usage.empty": {
+    "text": "Ingen data for dette interval",
+    "source_hash": "5fed1795"
+  },
+  "web.admin.usage.byState": {
+    "text": "Beskeder efter tilstand",
+    "source_hash": "916bbcb6"
+  },
+  "web.admin.usage.secretsByDay": {
+    "text": "Beskeder pr. dag",
+    "source_hash": "24a01e8e"
+  },
+  "web.admin.usage.usersByDay": {
+    "text": "Nye brugere pr. dag",
+    "source_hash": "8c1f089f"
+  },
+  "web.admin.usage.exportJson": {
+    "text": "Download JSON",
+    "source_hash": "49e0e6d5"
+  },
+  "web.admin.usage.exportCsv": {
+    "text": "Download CSV",
+    "source_hash": "a4023b89"
+  },
+  "web.admin.usage.columns.date": {
+    "text": "Dato",
+    "source_hash": "99c40ab4"
+  },
+  "web.admin.usage.columns.count": {
+    "text": "Antal",
+    "source_hash": "37bac495"
+  },
+  "web.admin.usage.stats.totalSecrets": {
+    "text": "Beskeder i alt",
+    "source_hash": "e17a5459"
+  },
+  "web.admin.usage.stats.newUsers": {
+    "text": "Nye brugere",
+    "source_hash": "d3ee48b0"
+  },
+  "web.admin.usage.stats.avgSecrets": {
+    "text": "Gns. beskeder/dag",
+    "source_hash": "948b0701"
+  },
+  "web.admin.usage.stats.avgUsers": {
+    "text": "Gns. brugere/dag",
+    "source_hash": "491f626d"
+  }
+}

--- a/locales/content/da_DK/api-domains-errors.json
+++ b/locales/content/da_DK/api-domains-errors.json
@@ -34,5 +34,17 @@
   "api.domains.errors.recipients_duplicate": {
     "text": "Dublerede modtager-e-mails er ikke tilladt",
     "source_hash": "6de22182"
+  },
+  "api.domains.errors.homepage_secrets_mode_invalid": {
+    "text": "Ugyldig secrets_mode: %{secrets_mode}",
+    "source_hash": "cf093a04"
+  },
+  "api.domains.errors.homepage_incoming_entitlement_required": {
+    "text": "Indgående besked-tilstand kræver rettigheden incoming_secrets. Opgrader din plan.",
+    "source_hash": "d68b13d8"
+  },
+  "api.domains.errors.homepage_incoming_not_ready": {
+    "text": "Indgående beskeder skal være aktiveret med mindst én modtager, før det kan bruges som hjemmeside.",
+    "source_hash": "556da6e2"
   }
 }

--- a/locales/content/da_DK/api-invite-errors.json
+++ b/locales/content/da_DK/api-invite-errors.json
@@ -12,8 +12,8 @@
     "source_hash": "a5df7d22"
   },
   "api.invite.errors.invitation_already_processed": {
-    "text": "Invitationen er allerede blevet %{status}",
-    "source_hash": "130c87e0"
+    "text": "Denne invitation er allerede behandlet",
+    "source_hash": "4cfedf4f"
   },
   "api.invite.errors.invitation_expired": {
     "text": "Invitationen er udløbet",
@@ -26,5 +26,13 @@
   "api.invite.errors.already_member": {
     "text": "Du er allerede medlem af denne organisation",
     "source_hash": "f56ad547"
+  },
+  "api.invite.errors.invitation_already_accepted": {
+    "text": "Denne invitation er allerede accepteret",
+    "source_hash": "8f9daf0f"
+  },
+  "api.invite.errors.invitation_already_declined": {
+    "text": "Denne invitation er allerede afvist",
+    "source_hash": "96e0d626"
   }
 }

--- a/locales/content/da_DK/api-secrets-errors.json
+++ b/locales/content/da_DK/api-secrets-errors.json
@@ -10,5 +10,9 @@
   "api.secrets.errors.domain_permission_anonymous_cross_domain": {
     "text": "Du har ikke tilladelse til at bruge domæne: %{domain}",
     "source_hash": "b41920ba"
+  },
+  "api.secrets.errors.secret_undecryptable": {
+    "text": "Denne besked kan ikke dekrypteres lige nu. Linket er stadig intakt — webstedsoperatøren skal gendanne krypteringsnøglen, før den kan vises.",
+    "source_hash": "56e283ee"
   }
 }

--- a/locales/content/da_DK/email.json
+++ b/locales/content/da_DK/email.json
@@ -62,7 +62,7 @@
   "email.welcome.signature": {
     "text": "Supportteamet",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.welcome.postscript": {
     "text": "P.S. Denne e-mail blev sendt til %{email_address}. Hvis du ikke har oprettet en konto, kan du trygt ignorere denne meddelelse.",
@@ -102,7 +102,7 @@
   "email.password_request.signature": {
     "text": "Supportteamet",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.password_request.postscript": {
     "text": "P.S. Denne e-mail blev sendt til %{email_address}.",
@@ -147,7 +147,7 @@
   "email.magic_link.signature": {
     "text": "Supportteamet",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.magic_link.postscript": {
     "text": "P.S. Denne e-mail blev sendt til %{email_address}.",
@@ -232,7 +232,7 @@
   "email.secret_revealed.signature": {
     "text": "Supportteamet",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.secret_revealed.manage_preferences": {
     "text": "Administrer notifikationspræferencer",
@@ -357,7 +357,7 @@
   "email.organization_invitation.signature": {
     "text": "Supportteamet",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.organization_invitation.postscript": {
     "text": "P.S. Denne e-mail blev sendt til %{invited_email}. Hvis du ikke forventede denne invitation, kan du trygt ignorere denne meddelelse.",
@@ -397,17 +397,17 @@
   "email.password_changed.signature": {
     "text": "Supportteamet",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_changed.subject": {
     "text": "Din e-mailadresse er blevet ændret (%{display_domain})",
     "renderer": "erb",
-    "source_hash": "d68d2f4c"
+    "source_hash": "4386fc57"
   },
   "email.email_changed.title": {
     "text": "Din e-mailadresse er blevet ændret",
     "renderer": "erb",
-    "source_hash": "62b07299"
+    "source_hash": "db70f965"
   },
   "email.email_changed.security_notice": {
     "text": "Hvis du ikke har foretaget denne ændring, kontakt venligst support med det samme, da din konto kan være kompromitteret.",
@@ -417,7 +417,7 @@
   "email.email_changed.change_notice": {
     "text": "E-mailadressen på din %{product_name}-konto er blevet ændret.",
     "renderer": "erb",
-    "source_hash": "bb467ebc"
+    "source_hash": "7fc0e27c"
   },
   "email.email_changed.new_email_label": {
     "text": "Ny e-mail:",
@@ -447,7 +447,7 @@
   "email.email_changed.signature": {
     "text": "Supportteamet",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_changed.postscript": {
     "text": "P.S. Denne e-mail blev sendt til %{email_address} for at informere dig om en ændring af e-mailadresse.",
@@ -497,7 +497,7 @@
   "email.email_change_requested.signature": {
     "text": "Supportteamet",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_change_requested.postscript": {
     "text": "P.S. Denne e-mail blev sendt til %{email_address}, fordi der blev anmodet om en ændring af e-mailadresse for din konto.",
@@ -552,7 +552,7 @@
   "email.email_change_confirmation.signature": {
     "text": "Supportteamet",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_change_confirmation.postscript": {
     "text": "P.S. Denne e-mail blev sendt til %{email_address} for at bekræfte en ændring af e-mailadresse.",
@@ -582,7 +582,7 @@
   "email.mfa_enabled.signature": {
     "text": "Supportteamet",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.mfa_disabled.subject": {
     "text": "To-faktor-godkendelse deaktiveret (%{display_domain})",
@@ -607,7 +607,7 @@
   "email.mfa_disabled.signature": {
     "text": "Supportteamet",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.new_login_alert.subject": {
     "text": "Nyt login på din konto (%{display_domain})",
@@ -652,7 +652,7 @@
   "email.new_login_alert.signature": {
     "text": "Supportteamet",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.member_removed.subject": {
     "text": "Du er blevet fjernet fra %{organization_name}",
@@ -672,7 +672,7 @@
   "email.member_removed.signature": {
     "text": "Supportteamet",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.role_changed.subject": {
     "text": "Din rolle er blevet ændret i %{organization_name}",
@@ -692,7 +692,7 @@
   "email.role_changed.signature": {
     "text": "Supportteamet",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.organization_deleted.subject": {
     "text": "Organisationen \"%{organization_name}\" blev slettet",
@@ -712,7 +712,7 @@
   "email.organization_deleted.signature": {
     "text": "Supportteamet",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.trial_expiring.subject": {
     "text": "Din %{product_name}-prøveperiode udløber om %{days_remaining} dage",
@@ -737,7 +737,7 @@
   "email.trial_expiring.signature": {
     "text": "Supportteamet",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.subscription_changed.subject": {
     "text": "Dit %{product_name}-abonnement er blevet ændret",
@@ -762,7 +762,7 @@
   "email.subscription_changed.signature": {
     "text": "Supportteamet",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.common.greeting": {
     "text": "Hej,",

--- a/locales/content/da_DK/feature-regions.json
+++ b/locales/content/da_DK/feature-regions.json
@@ -152,8 +152,8 @@
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "Hvis din e-mail til faktureringskontakt afviger fra din {product_name}-konto-e-mail, skal du bruge e-mailen til faktureringskontakt for den nye regionskonto for at bevare dine abonnementsfordele.",
-    "source_hash": "dac1cc28"
+    "text": "Hvis din e-mail til faktureringskontakt adskiller sig fra din {product_name}-konto-e-mail, skal du bruge e-mailen til faktureringskontakt for kontoen i den nye region for at bevare dine abonnementsfordele.",
+    "source_hash": "d49662b0"
   },
   "web.regions.changing_regions_subscription_note": {
     "text": "Dine abonnementsfordele gælder automatisk for enhver konto oprettet med din fakturerings-e-mailadresse.",

--- a/locales/content/da_DK/feature-translations.json
+++ b/locales/content/da_DK/feature-translations.json
@@ -65,7 +65,7 @@
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
     "text": "Følgende personer har doneret deres tid for at hjælpe med at udbrede {product_name}:",
-    "source_hash": "85a766af"
+    "source_hash": "6cc876ae"
   },
   "web.translations.translations": {
     "text": "Oversættelser",
@@ -84,8 +84,8 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "Siden 2012 har {product_name} tilbudt en sikker måde at dele følsomme oplysninger på verden over. Med brugere i regioner, hvor engelsk ikke er hovedsproget, er nøjagtige oversættelser afgørende for at gøre sikker kommunikation tilgængelig for alle.",
-    "source_hash": "87a6e9af"
+    "text": "Siden 2012 har {product_name} tilbudt en sikker måde at dele følsomme oplysninger på verden over. Med brugere på tværs af regioner, hvor engelsk ikke er hovedsproget, er nøjagtige oversættelser afgørende for at gøre sikker kommunikation tilgængelig for alle.",
+    "source_hash": "ded965d5"
   },
   "web.translations.help_secure_communication_go_global": {
     "text": "Hjælp sikker kommunikation med at blive global",

--- a/locales/content/da_DK/secret-homepage.json
+++ b/locales/content/da_DK/secret-homepage.json
@@ -57,7 +57,7 @@
   },
   "web.homepage.visit_onetime_secret_home": {
     "text": "Besøg {product_name}-hjemmesiden",
-    "source_hash": "625556d2"
+    "source_hash": "87802af5"
   },
   "web.homepage.password_generation_title": {
     "text": "Adgangskodegenerator",
@@ -109,15 +109,15 @@
   },
   "web.homepage.about_onetime_secret_0": {
     "text": "Om {product_name}",
-    "source_hash": "971c50da"
+    "source_hash": "b3046356"
   },
   "web.homepage.log_in_to_onetime_secret": {
     "text": "Log ind på {product_name}",
-    "source_hash": "bd6be8d6"
+    "source_hash": "b2e364a4"
   },
   "web.homepage.about_onetime_secret": {
     "text": "Om {product_name}",
-    "source_hash": "971c50da"
+    "source_hash": "b3046356"
   },
   "web.homepage.signup_individual_and_business_plans": {
     "text": "Tilmelding - Individuelle planer og forretningsplaner",
@@ -137,19 +137,19 @@
   },
   "web.homepage.onetime_secret": {
     "text": "{product_name}",
-    "source_hash": "1cd0194a"
+    "source_hash": "7bec5899"
   },
   "web.homepage.onetime_secret_literal": {
     "text": "{product_name}",
-    "source_hash": "1cd0194a"
+    "source_hash": "7bec5899"
   },
   "web.homepage.one_time_secret_literal": {
     "text": "{product_name}",
-    "source_hash": "7872e050"
+    "source_hash": "7bec5899"
   },
   "web.homepage.onetime_secret_homepage": {
     "text": "{product_name}-hjemmeside",
-    "source_hash": "44bb0581"
+    "source_hash": "0792b61e"
   },
   "web.homepage.send_sensitive_information_that_can_only_be_viewed_once": {
     "text": "Send følsomme oplysninger, der kun kan ses én gang",
@@ -169,11 +169,11 @@
   },
   "web.homepage.welcome_to_onetime_secret": {
     "text": "Velkommen til {product_name}.",
-    "source_hash": "0990d163"
+    "source_hash": "f4f49058"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "{product_name} hjælper os med at dele følsomme oplysninger sikkert, samtidig med at vi bevarer vores professionelle facade.",
-    "source_hash": "986a0856"
+    "text": "{product_name} hjælper os med at dele følsomme oplysninger sikkert, mens vi bevarer vores professionelle facade.",
+    "source_hash": "7e9192bd"
   },
   "web.homepage.information_shared_through_this_service_can_only": {
     "text": "Oplysninger, der deles via denne tjeneste, kan kun tilgås én gang. Når indholdet er set, slettes det permanent for at sikre fortrolighed.",
@@ -182,5 +182,13 @@
   "web.homepage.welcome_to_the_global_broadcast": {
     "text": "Velkommen til den globale udsendelse!",
     "source_hash": "210e1894"
+  },
+  "web.homepage.send_a_secret": {
+    "text": "Send en besked",
+    "source_hash": "31fd9e03"
+  },
+  "web.homepage.deliver_sensitive_information_directly_and_securely": {
+    "text": "Lever følsomme oplysninger direkte til vores team. Den kan kun ses én gang.",
+    "source_hash": "9976cf01"
   }
 }

--- a/locales/content/da_DK/secret-manage.json
+++ b/locales/content/da_DK/secret-manage.json
@@ -56,8 +56,8 @@
     "source_hash": "2e5a27e1"
   },
   "web.secrets.sample_secret_content_this_could_be_sensitive_data": {
-    "text": "Eksempel på sikkert indhold Dette kan være følsomme data Eller en besked med flere linjer",
-    "source_hash": "b3be3902"
+    "text": "Eksempel på beskedindhold. Dette kan være følsomme data\n\nEller en besked med flere linjer",
+    "source_hash": "5e1bffcb"
   },
   "web.secrets.sample_secret_content": {
     "text": "Eksempel på beskedindhold",
@@ -128,8 +128,8 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "{product_name} er en sikker måde at dele følsomme oplysninger på, der selvdestruerer efter en enkelt visning.",
-    "source_hash": "8a163297"
+    "text": "{product_name} er en sikker måde at dele følsomme oplysninger på, som selvdestruerer efter en enkelt visning.",
+    "source_hash": "bd0c6182"
   },
   "web.secrets.what_is_this": {
     "text": "Hvad er dette?",

--- a/locales/content/da_DK/session-auth-extended.json
+++ b/locales/content/da_DK/session-auth-extended.json
@@ -155,8 +155,8 @@
     "source_hash": "d726c0da"
   },
   "web.auth.magicLink.sessionExpired": {
-    "text": "Din session er udløbet. Opdater venligst siden og prøv igen.",
-    "source_hash": "a7c3e901"
+    "text": "Din session er udløbet. Opdater siden, og prøv igen.",
+    "source_hash": "be9ed96d"
   },
   "web.auth.magicLink.loginFailed": {
     "text": "Login mislykkedes. Prøv venligst igen.",

--- a/locales/content/da_DK/session-auth.json
+++ b/locales/content/da_DK/session-auth.json
@@ -373,8 +373,8 @@
     "source_hash": "afd25fdf"
   },
   "web.help.use_magic_link_instead": {
-    "text": "Brug Magisk link-muligheden for at logge ind uden adgangskode. Når du er logget ind, kan du ændre din adgangskode under Kontoindstillinger.",
-    "source_hash": "2a058600"
+    "text": "Du kan anmode om et link til nulstilling af adgangskode for at oprette en ny adgangskode.",
+    "source_hash": "3c3eabad"
   },
   "web.help.account_locked": {
     "text": "Konto midlertidigt låst?",
@@ -431,5 +431,57 @@
   "web.login.errors.domain_not_allowed": {
     "text": "Dit e-maildomæne er ikke godkendt til SSO-tilmelding. Kontakt din administrator.",
     "source_hash": "87603782"
+  },
+  "web.auth.check_email.title": {
+    "text": "Tjek din e-mail",
+    "source_hash": "77322879"
+  },
+  "web.auth.check_email.sent_to_generic": {
+    "text": "Vi har sendt et bekræftelseslink til din e-mailadresse.",
+    "source_hash": "4e5510af"
+  },
+  "web.auth.check_email.help": {
+    "text": "Vi har sendt et bekræftelseslink til denne adresse — åbn e-mailen, og klik på linket for at aktivere din konto.",
+    "source_hash": "8babedc4"
+  },
+  "web.auth.check_email.spam_hint": {
+    "text": "Kan du ikke finde det? Tjek din spammappe.",
+    "source_hash": "d166d9a4"
+  },
+  "web.auth.check_email.wrong_email": {
+    "text": "Indtastede du den forkerte adresse?",
+    "source_hash": "0aa863e5"
+  },
+  "web.auth.check_email.start_over": {
+    "text": "Start forfra",
+    "source_hash": "5eed7e9f"
+  },
+  "web.auth.field-errors.password": {
+    "text": "Adgangskode",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.auth.verify.resend_help_text": {
+    "text": "Modtog du ikke bekræftelses-e-mailen? Indtast din e-mail for at sende den igen.",
+    "source_hash": "e0df48bb"
+  },
+  "web.auth.verify.resend_button": {
+    "text": "Send bekræftelses-e-mail igen",
+    "source_hash": "5173cc04"
+  },
+  "web.auth.verify.resend_sent": {
+    "text": "Hvis en konto kræver bekræftelse, er der sendt en ny e-mail. Tjek din indbakke og spammappe.",
+    "source_hash": "6f838ffb"
+  },
+  "web.auth.verify.resend_error": {
+    "text": "Bekræftelses-e-mailen kunne ikke sendes. Tjek din forbindelse, og prøv igen.",
+    "source_hash": "15149f46"
+  },
+  "web.auth.verify.resend_short": {
+    "text": "Send e-mail igen",
+    "source_hash": "4f44603e"
+  },
+  "web.login.verified_notice": {
+    "text": "Din e-mail er blevet bekræftet — du kan nu logge ind.",
+    "source_hash": "c8d4b5a8"
   }
 }

--- a/locales/content/da_DK/workspace-account.json
+++ b/locales/content/da_DK/workspace-account.json
@@ -136,8 +136,8 @@
     "source_hash": "05986d95"
   },
   "web.account.keep_this_token_secure_it_provides_full_access_t": {
-    "text": "🔐 Hold dette token sikkert! Det giver fuld adgang til din konto.",
-    "source_hash": "8839aa4d"
+    "text": "Hold dette token sikkert. Det kan bruges til at oprette og administrere beskeder via API'en.",
+    "source_hash": "a63cc8ec"
   },
   "web.account.confirm_with_your_password": {
     "text": "Bekræft med din adgangskode",
@@ -328,8 +328,8 @@
     "source_hash": "f7cfed6e"
   },
   "web.settings.profile.email_change_success": {
-    "text": "E-mail opdateret. Tjek venligst din indbakke for at bekræfte din nye e-mailadresse.",
-    "source_hash": "58de2536"
+    "text": "Bekræftelses-e-mail sendt. Tjek din nye indbakke, og klik på bekræftelseslinket for at fuldføre ændringen.",
+    "source_hash": "45f0a4b5"
   },
   "web.settings.profile.email_change_error": {
     "text": "Kunne ikke opdatere e-mail. Prøv venligst igen.",
@@ -477,7 +477,7 @@
   },
   "web.settings.api.documentation_description": {
     "text": "Lær, hvordan du integrerer {product_name} i dine applikationer",
-    "source_hash": "6e8f910f"
+    "source_hash": "9bba1ae8"
   },
   "web.settings.api.rest_api_reference": {
     "text": "REST API-reference",

--- a/locales/content/da_DK/workspace-billing.json
+++ b/locales/content/da_DK/workspace-billing.json
@@ -140,12 +140,12 @@
     "source_hash": "1f981aaf"
   },
   "web.billing.overview.no_organizations_title": {
-    "text": "Ingen organisationer",
-    "source_hash": "12420110"
+    "text": "Ingen workspaces",
+    "source_hash": "c7f70723"
   },
   "web.billing.overview.no_organizations_description": {
-    "text": "Opret en organisation for at administrere din fakturering og dit abonnement",
-    "source_hash": "41e922d2"
+    "text": "Opret en workspace for at administrere din fakturering og dit abonnement",
+    "source_hash": "e0fd27a5"
   },
   "web.billing.overview.load_error": {
     "text": "Kunne ikke indlæse faktureringsoplysninger",
@@ -204,8 +204,8 @@
     "source_hash": "883dbca9"
   },
   "web.billing.overview.entitlements.manage_org": {
-    "text": "Administrer organisationer",
-    "source_hash": "be0fe4c3"
+    "text": "Administrer organisation",
+    "source_hash": "f03a4985"
   },
   "web.billing.overview.entitlements.manage_teams": {
     "text": "Administrer teams",
@@ -220,8 +220,8 @@
     "source_hash": "5428d7fe"
   },
   "web.billing.overview.entitlements.sso": {
-    "text": "Enkelt login",
-    "source_hash": "cf7cd744"
+    "text": "Single Sign-On (SSO)",
+    "source_hash": "5db5c812"
   },
   "web.billing.overview.entitlements.priority_support": {
     "text": "Prioriteret support",
@@ -280,8 +280,8 @@
     "source_hash": "5428d7fe"
   },
   "web.billing.features.sso": {
-    "text": "Enkelt login (SSO)",
-    "source_hash": "5db5c812"
+    "text": "SSO",
+    "source_hash": "5ba3ac9f"
   },
   "web.billing.features.priority_support": {
     "text": "Prioriteret support",
@@ -577,7 +577,7 @@
   },
   "web.billing.invoices.draft": {
     "text": "Kladde",
-    "source_hash": "d2e16e61"
+    "source_hash": "ebf12ef4"
   },
   "web.billing.invoices.open": {
     "text": "Åben",

--- a/locales/content/da_DK/workspace-branding.json
+++ b/locales/content/da_DK/workspace-branding.json
@@ -28,8 +28,8 @@
     "source_hash": "199c165f"
   },
   "web.branding.preview_and_customize": {
-    "text": "Forhåndsvis og tilpas",
-    "source_hash": "215d3659"
+    "text": "Tilpas og forhåndsvis",
+    "source_hash": "fc68a28c"
   },
   "web.branding.switch_to_safari_browser_view": {
     "text": "Skift til Safari-browservisning",
@@ -88,8 +88,8 @@
     "source_hash": "43e9a2d7"
   },
   "web.branding.click_to_upload_a_logo_with_recommendation": {
-    "text": "Klik for at uploade et logo. Anbefalet størrelse: 128x128 pixels. Maksimal filstørrelse: 1 MB. Understøttede formater: PNG, JPG, SVG",
-    "source_hash": "a35452bf"
+    "text": "Klik for at administrere dit logo. Anbefalet størrelse: 128x128 pixels. Maksimal filstørrelse: 1 MB. Understøttede formater: PNG, JPG, SVG",
+    "source_hash": "7bb92395"
   },
   "web.branding.upload_logo": {
     "text": "Upload logo",
@@ -186,5 +186,225 @@
   "web.branding.keyhole_logo_icon": {
     "text": "Nøglehulsikon, der symboliserer sikker og privat deling",
     "source_hash": "c868ac60"
+  },
+  "web.branding.secondary_color": {
+    "text": "Sekundær farve",
+    "source_hash": "1f4728f6"
+  },
+  "web.branding.background_color": {
+    "text": "Baggrundsfarve",
+    "source_hash": "b48bc969"
+  },
+  "web.branding.text_color": {
+    "text": "Tekstfarve",
+    "source_hash": "2ea23234"
+  },
+  "web.branding.border_radius": {
+    "text": "Kantradius",
+    "source_hash": "e758d7db"
+  },
+  "web.branding.heading_font": {
+    "text": "Overskriftsskrifttype",
+    "source_hash": "6b5d30dc"
+  },
+  "web.branding.theme_presets": {
+    "text": "Temaforudindstillinger",
+    "source_hash": "931eeb74"
+  },
+  "web.branding.logo": {
+    "text": "Logo",
+    "source_hash": "d707dc2f"
+  },
+  "web.branding.replace_logo": {
+    "text": "Erstat",
+    "source_hash": "95e15439"
+  },
+  "web.branding.logo_field_hint": {
+    "text": "Forhåndsvis, før dine ændringer bliver aktive.",
+    "source_hash": "e9e222fc"
+  },
+  "web.branding.logo_modal_title": {
+    "text": "Domænelogo",
+    "source_hash": "5260dda5"
+  },
+  "web.branding.logo_modal_hint": {
+    "text": "PNG, JPG eller SVG. Anbefalet 128x128px, op til 1 MB.",
+    "source_hash": "75d00802"
+  },
+  "web.branding.logo_modal_save": {
+    "text": "Gem logo",
+    "source_hash": "8b028a6f"
+  },
+  "web.branding.remove_logo": {
+    "text": "Fjern logo",
+    "source_hash": "f1c1afa4"
+  },
+  "web.branding.image_upload_choose": {
+    "text": "Vælg et billede",
+    "source_hash": "ceed9fd5"
+  },
+  "web.branding.image_upload_drag_hint": {
+    "text": "eller træk og slip",
+    "source_hash": "6613b73c"
+  },
+  "web.branding.image_invalid_type": {
+    "text": "Denne filtype understøttes ikke. Vælg et billede.",
+    "source_hash": "50e18866"
+  },
+  "web.branding.image_too_large": {
+    "text": "Billedet er for stort. Maksimal størrelse er {max}.",
+    "source_hash": "b50b55e2"
+  },
+  "web.branding.image_will_be_removed": {
+    "text": "Dette logo fjernes, når du gemmer.",
+    "source_hash": "d94fa99a"
+  },
+  "web.branding.image_upload_failed": {
+    "text": "Noget gik galt. Prøv igen.",
+    "source_hash": "3ccd9d65"
+  },
+  "web.branding.undo": {
+    "text": "Fortryd",
+    "source_hash": "a8283ade"
+  },
+  "web.branding.low_contrast_text_bg_warning": {
+    "text": "Lav tekst-/baggrundskontrast",
+    "source_hash": "1c676370"
+  },
+  "web.branding.path_simple": {
+    "text": "Enkel",
+    "source_hash": "3fee95da"
+  },
+  "web.branding.path_match": {
+    "text": "Match mit websted",
+    "source_hash": "776679cf"
+  },
+  "web.branding.path_advanced": {
+    "text": "Avanceret",
+    "source_hash": "9f088dbe"
+  },
+  "web.branding.path_simple_tag": {
+    "text": "Det væsentlige for dit brand.",
+    "source_hash": "7c9c0cca"
+  },
+  "web.branding.path_match_tag": {
+    "text": "Kopiér indstillinger fra et eksisterende websted.",
+    "source_hash": "e4b0d1cd"
+  },
+  "web.branding.path_advanced_tag": {
+    "text": "Lav din egen Tailwind v4-CSS.",
+    "source_hash": "2405bb6d"
+  },
+  "web.branding.badge_default": {
+    "text": "Standard",
+    "source_hash": "21b111cb"
+  },
+  "web.branding.badge_coming_soon": {
+    "text": "Kommer snart",
+    "source_hash": "4f7d6401"
+  },
+  "web.branding.your_brand": {
+    "text": "Dit brand",
+    "source_hash": "406265d3"
+  },
+  "web.branding.your_brand_subtitle": {
+    "text": "Nogle få hurtige valg — vi klarer resten.",
+    "source_hash": "dbc8ec33"
+  },
+  "web.branding.corners": {
+    "text": "Hjørner",
+    "source_hash": "1d3cc47e"
+  },
+  "web.branding.more_options": {
+    "text": "Flere indstillinger",
+    "source_hash": "bc79cdff"
+  },
+  "web.branding.paths_carryover_hint": {
+    "text": "Dette er en live-forhåndsvisning — dine ændringer bliver ikke synlige for besøgende, før du gemmer.",
+    "source_hash": "cb4b82de"
+  },
+  "web.branding.coming_soon_match_blurb": {
+    "text": "Peg os mod dit websted, så læser vi dets farver og skrifttyper og lukker derefter hullet med et enkelt klik.",
+    "source_hash": "42c34cc1"
+  },
+  "web.branding.coming_soon_advanced_blurb": {
+    "text": "Rediger Tailwind v4 {'@'}theme-tokens direkte, eller indsæt dit eget stylesheet.",
+    "source_hash": "5a8473f5"
+  },
+  "web.branding.preview_recipient_page": {
+    "text": "Modtagerside",
+    "source_hash": "de8aa19f"
+  },
+  "web.branding.preview_badge": {
+    "text": "Forhåndsvisning",
+    "source_hash": "324b134f"
+  },
+  "web.branding.preview_homepage_enabled": {
+    "text": "Hjemmeside · aktiveret",
+    "source_hash": "2edd85f1"
+  },
+  "web.branding.preview_homepage_disabled": {
+    "text": "Hjemmeside · deaktiveret",
+    "source_hash": "15d87050"
+  },
+  "web.branding.preview_live": {
+    "text": "Live-forhåndsvisning",
+    "source_hash": "f65ddc1f"
+  },
+  "web.branding.tile_share_secret": {
+    "text": "Del en besked",
+    "source_hash": "5384461b"
+  },
+  "web.branding.tile_create_link": {
+    "text": "Opret besked-link",
+    "source_hash": "610fd42e"
+  },
+  "web.branding.tile_delivery_only": {
+    "text": "Kun sikker beskedlevering",
+    "source_hash": "dc24dec2"
+  },
+  "web.branding.tile_no_create": {
+    "text": "Besøgende kan ikke oprette beskeder her.",
+    "source_hash": "17361d81"
+  },
+  "web.branding.recipient_page_content": {
+    "text": "Indhold på modtagerside",
+    "source_hash": "937733bd"
+  },
+  "web.branding.recipient_page_content_hint": {
+    "text": "Sprog og visningsinstruktioner, der vises for modtagere på dette domæne.",
+    "source_hash": "04162b70"
+  },
+  "web.branding.tab_brand": {
+    "text": "Brand",
+    "source_hash": "090ed431"
+  },
+  "web.branding.tab_delivery": {
+    "text": "Levering",
+    "source_hash": "52bfe584"
+  },
+  "web.branding.delivery_language": {
+    "text": "Sprog",
+    "source_hash": "a4fe6526"
+  },
+  "web.branding.delivery_language_hint": {
+    "text": "Standard for modtagersider og e-mails på dette domæne. Modtagere kan skifte sprog på siden.",
+    "source_hash": "bfbc5599"
+  },
+  "web.branding.delivery_reveal_instructions": {
+    "text": "Visningsinstruktioner",
+    "source_hash": "7e1331f7"
+  },
+  "web.branding.delivery_reveal_instructions_hint": {
+    "text": "Vises på modtagersiden. Lad stå tom for at bruge den indbyggede tekst på det valgte sprog.",
+    "source_hash": "51b9811d"
+  },
+  "web.branding.delivery_before_reveal": {
+    "text": "Før visning",
+    "source_hash": "5ce82b01"
+  },
+  "web.branding.delivery_after_reveal": {
+    "text": "Efter visning",
+    "source_hash": "d5bfe7fd"
   }
 }

--- a/locales/content/da_DK/workspace-domains.json
+++ b/locales/content/da_DK/workspace-domains.json
@@ -76,8 +76,8 @@
     "source_hash": "59be7133"
   },
   "web.domains.enabled": {
-    "text": "Aktiveret",
-    "source_hash": "92c1cdfd"
+    "text": "Aktivér",
+    "source_hash": "5342e09f"
   },
   "web.domains.disabled": {
     "text": "Deaktiveret",
@@ -1358,5 +1358,189 @@
   "web.domains.sso.upgrade_required": {
     "text": "Opgrader for at konfigurere",
     "source_hash": "571cfa98"
+  },
+  "web.domains.add.field_label": {
+    "text": "Brugerdefineret domæne",
+    "source_hash": "d7d4c1e4"
+  },
+  "web.domains.add.field_help": {
+    "text": "Det præcise værtsnavn, dit team vil bruge, f.eks. {example}.",
+    "source_hash": "3ba71f78"
+  },
+  "web.domains.add.echo_label": {
+    "text": "Dine besked-links vil ligge på",
+    "source_hash": "ad60b17d"
+  },
+  "web.domains.add.apex_question": {
+    "text": "Det er hele dit domæne — hvor skal besked-links ligge?",
+    "source_hash": "efacad1b"
+  },
+  "web.domains.add.apex_help": {
+    "text": "Et underdomæne lader resten af {domain} være urørt.",
+    "source_hash": "0f7e6181"
+  },
+  "web.domains.add.recommended": {
+    "text": "Anbefalet",
+    "source_hash": "d70604e8"
+  },
+  "web.domains.add.no_wrong_answer": {
+    "text": "Der er ikke noget forkert valg — vælg det, dit team vil genkende.",
+    "source_hash": "a04f0086"
+  },
+  "web.domains.add.subdomains_label": {
+    "text": "Populære underdomæner",
+    "source_hash": "d6ee8eac"
+  },
+  "web.domains.add.root_group_label": {
+    "text": "Eller brug hele dit domæne",
+    "source_hash": "5c23c007"
+  },
+  "web.domains.add.root_domain_label": {
+    "text": "Brug mit roddomæne",
+    "source_hash": "9fbbe253"
+  },
+  "web.domains.add.root_domain_description": {
+    "text": "Dette peger hele {domain} mod os — webstedet der holder op med at slå op — og kræver en A-/ALIAS-post.",
+    "source_hash": "fae93847"
+  },
+  "web.domains.add.error_unrecognized_suffix": {
+    "text": "“.{0}” er ikke en genkendt domæneendelse — tjek for en tastefejl (f.eks. {1}).",
+    "source_hash": "4b90033d"
+  },
+  "web.domains.add.error_invalid_hostname": {
+    "text": "Indtast et gyldigt værtsnavn — bogstaver, tal, enkelte punktummer og bindestreger (f.eks. {0}).",
+    "source_hash": "c4ceabc1"
+  },
+  "web.domains.add.error_empty": {
+    "text": "Indtast et domænenavn.",
+    "source_hash": "d8e2c1e4"
+  },
+  "web.domains.add.continue_with": {
+    "text": "Fortsæt med {0}",
+    "source_hash": "73f8ab40"
+  },
+  "web.domains.auth_override.workspace_default_badge": {
+    "text": "Workspace-standard",
+    "source_hash": "da3706ee"
+  },
+  "web.domains.detail.dns_title": {
+    "text": "DNS-opsætning",
+    "source_hash": "6c63df31"
+  },
+  "web.domains.detail.dns_description": {
+    "text": "Peg dit domæne mod denne server med en CNAME-post",
+    "source_hash": "080f84f0"
+  },
+  "web.domains.dns.title": {
+    "text": "DNS-konfiguration",
+    "source_hash": "da78c35d"
+  },
+  "web.domains.dns.point_domain_intro": {
+    "text": "Peg",
+    "source_hash": "2fc0c524"
+  },
+  "web.domains.dns.point_domain_outro": {
+    "text": "mod denne server ved at tilføje følgende DNS-post hos din udbyder.",
+    "source_hash": "8d260c05"
+  },
+  "web.domains.dns.cname_heading": {
+    "text": "Opret en CNAME-post",
+    "source_hash": "11aeef5a"
+  },
+  "web.domains.dns.apex_heading": {
+    "text": "Opret en ALIAS- eller ANAME-post",
+    "source_hash": "41135375"
+  },
+  "web.domains.dns.apex_notice": {
+    "text": "Apex-domæner (rod) kan ikke bruge en CNAME-post. Brug i stedet din DNS-udbyders ALIAS- eller ANAME-post, eller peg en A-post mod din servers IP-adresse.",
+    "source_hash": "2d1c3298"
+  },
+  "web.domains.email.from_address_local_placeholder": {
+    "text": "no-reply",
+    "source_hash": "510d274d"
+  },
+  "web.domains.homepage.title": {
+    "text": "Hjemmeside",
+    "source_hash": "9e3391e9"
+  },
+  "web.domains.homepage.description": {
+    "text": "Hvad besøgende kan gøre på din domænehjemmeside",
+    "source_hash": "974d159e"
+  },
+  "web.domains.homepage.option_private_title": {
+    "text": "Privat landingsside",
+    "source_hash": "dfd5bd1c"
+  },
+  "web.domains.homepage.option_private_description": {
+    "text": "Besøgende ser en privat landingsside uden interaktiv formular",
+    "source_hash": "4d9aaf6f"
+  },
+  "web.domains.homepage.option_create_title": {
+    "text": "Formular til oprettelse af besked",
+    "source_hash": "6539dfc1"
+  },
+  "web.domains.homepage.option_create_description": {
+    "text": "Besøgende kan oprette deres egne besked-links",
+    "source_hash": "884310f4"
+  },
+  "web.domains.homepage.option_incoming_title": {
+    "text": "Formular til indgående beskeder",
+    "source_hash": "882997bf"
+  },
+  "web.domains.homepage.option_incoming_description": {
+    "text": "Besøgende kan sende beskeder til dine konfigurerede modtagere",
+    "source_hash": "86bdaedb"
+  },
+  "web.domains.homepage.incoming_requires_recipients": {
+    "text": "Kræver, at indgående beskeder er aktiveret med mindst én modtager",
+    "source_hash": "0462611d"
+  },
+  "web.domains.homepage.configure_recipients": {
+    "text": "Konfigurer modtagere",
+    "source_hash": "1c3df8b4"
+  },
+  "web.domains.homepage.status_private": {
+    "text": "Privat landingsside",
+    "source_hash": "dfd5bd1c"
+  },
+  "web.domains.homepage.status_create": {
+    "text": "Offentlig: besøgende opretter beskeder",
+    "source_hash": "251cfb95"
+  },
+  "web.domains.homepage.status_incoming": {
+    "text": "Offentlig: besøgende sender dig beskeder",
+    "source_hash": "baa926b8"
+  },
+  "web.domains.homepage.status_incoming_unready": {
+    "text": "Indgående ikke klar — viser privat landingsside",
+    "source_hash": "a5cc237c"
+  },
+  "web.domains.homepage.badge_incoming": {
+    "text": "Indgående",
+    "source_hash": "e301820a"
+  },
+  "web.domains.homepage.update_success": {
+    "text": "Hjemmesideindstillinger gemt",
+    "source_hash": "4eac9f45"
+  },
+  "web.domains.homepage.homepage_uses_incoming_warning": {
+    "text": "Dette domænes hjemmeside præsenterer i øjeblikket formularen til indgående beskeder. Hvis du deaktiverer indgående beskeder eller fjerner alle modtagere, skifter hjemmesiden til en privat landingsside, indtil indgående er klar igen.",
+    "source_hash": "cc0d4997"
+  },
+  "web.domains.signin.effective_status_label": {
+    "text": "Login på dette domæne",
+    "source_hash": "d8b884c3"
+  },
+  "web.domains.signin.dormant_notice": {
+    "text": "Login er slået fra for hele workspacet, så det er utilgængeligt på alle domæner. Dine indstillinger her bevares og træder i kraft, når login for workspacet aktiveres igen.",
+    "source_hash": "723d35dc"
+  },
+  "web.domains.signup.effective_status_label": {
+    "text": "Tilmeldinger på dette domæne",
+    "source_hash": "115ab21b"
+  },
+  "web.domains.signup.dormant_notice": {
+    "text": "Tilmeldinger er slået fra for hele workspacet, så de er utilgængelige på alle domæner. Dine indstillinger her bevares og træder i kraft, når tilmeldinger for workspacet aktiveres igen.",
+    "source_hash": "49faefe4"
   }
 }

--- a/locales/content/da_DK/workspace-organizations.json
+++ b/locales/content/da_DK/workspace-organizations.json
@@ -4,8 +4,8 @@
     "source_hash": "2730183d"
   },
   "web.organizations.organization": {
-    "text": "Organisation",
-    "source_hash": "d764d425"
+    "text": "Workspace",
+    "source_hash": "87bb59ba"
   },
   "web.organizations.organization_plural": {
     "text": "Organisationer",
@@ -16,24 +16,24 @@
     "source_hash": "dbaa4f92"
   },
   "web.organizations.my_organizations": {
-    "text": "Organisationer",
-    "source_hash": "2730183d"
+    "text": "Workspaces",
+    "source_hash": "1377264b"
   },
   "web.organizations.manage_organizations": {
-    "text": "Administrer organisationer",
-    "source_hash": "be0fe4c3"
+    "text": "Administrer workspaces",
+    "source_hash": "cc2d65f8"
   },
   "web.organizations.new_organization": {
     "text": "Ny organisation",
     "source_hash": "4876e647"
   },
   "web.organizations.no_organizations": {
-    "text": "Ingen organisationer endnu",
-    "source_hash": "5b7a7cbd"
+    "text": "Ingen workspaces endnu",
+    "source_hash": "97d0b117"
   },
   "web.organizations.no_organizations_description": {
-    "text": "Organisationer giver samlet fakturering og administration. Kom i gang ved at oprette din første organisation.",
-    "source_hash": "deab4304"
+    "text": "Workspaces giver samlet fakturering og administration. Kom i gang ved at oprette dit første workspace.",
+    "source_hash": "f09d4987"
   },
   "web.organizations.no_description": {
     "text": "Ingen beskrivelse angivet",
@@ -48,24 +48,24 @@
     "source_hash": "e27f4540"
   },
   "web.organizations.create_first_organization": {
-    "text": "Opret første organisation",
-    "source_hash": "27bae486"
+    "text": "Opret første workspace",
+    "source_hash": "98a583b4"
   },
   "web.organizations.create_organization_description": {
-    "text": "Opret en ny organisation",
-    "source_hash": "67cd5950"
+    "text": "Opret et nyt workspace",
+    "source_hash": "6ac2b5fc"
   },
   "web.organizations.create": {
     "text": "Opret",
     "source_hash": "4759498a"
   },
   "web.organizations.create_error": {
-    "text": "Kunne ikke oprette organisation",
-    "source_hash": "f2204373"
+    "text": "Kunne ikke oprette workspace",
+    "source_hash": "0a8d4fd6"
   },
   "web.organizations.organization_name": {
-    "text": "Organisationsnavn",
-    "source_hash": "4cbd9073"
+    "text": "Workspace-navn",
+    "source_hash": "6fa5a5b1"
   },
   "web.organizations.organization_name_placeholder": {
     "text": "f.eks. Acme Corporation",
@@ -92,12 +92,12 @@
     "source_hash": "ee81c03d"
   },
   "web.organizations.select_organization": {
-    "text": "Vælg en organisation",
-    "source_hash": "48326f52"
+    "text": "Vælg et workspace",
+    "source_hash": "70a8ce66"
   },
   "web.organizations.switcher_locked": {
-    "text": "Organisationsskift ikke tilgængeligt på denne side",
-    "source_hash": "da0cf810"
+    "text": "Skift af workspace er ikke tilgængeligt på denne side",
+    "source_hash": "c34114ac"
   },
   "web.organizations.not_found": {
     "text": "Organisation ikke fundet",
@@ -208,8 +208,8 @@
     "source_hash": "7ecc5d35"
   },
   "web.organizations.tabs.members": {
-    "text": "Team",
-    "source_hash": "5985039f"
+    "text": "Medlemmer",
+    "source_hash": "1044a4c0"
   },
   "web.organizations.tabs.billing": {
     "text": "Fakturering",
@@ -468,8 +468,8 @@
     "source_hash": "424a2551"
   },
   "web.organizations.invitations.roles.member": {
-    "text": "Medlem",
-    "source_hash": "7c968fb7"
+    "text": "Teammedlem",
+    "source_hash": "d4e55dfa"
   },
   "web.organizations.invitations.roles.admin": {
     "text": "Administrator",
@@ -532,8 +532,8 @@
     "source_hash": "5e3f8df8"
   },
   "web.organizations.invitations.upgrade_prompt": {
-    "text": "Teammedlemsinvitationer kræver et abonnement med teamadministration. Opgrader for at tilføje samarbejdspartnere til din organisation.",
-    "source_hash": "cf10d623"
+    "text": "Medlemsinvitationer kræver en betalt plan. Opgrader for at tilføje samarbejdspartnere til din organisation.",
+    "source_hash": "47d0eeab"
   },
   "web.organizations.paid_badge": {
     "text": "Pro",
@@ -556,8 +556,8 @@
     "source_hash": "ced67718"
   },
   "web.organizations.invitations.email_mismatch_title": {
-    "text": "Logget ind med en anden konto",
-    "source_hash": "4a2f91c3"
+    "text": "Anden konto er logget ind",
+    "source_hash": "6516362a"
   },
   "web.organizations.invitations.email_mismatch_body": {
     "text": "Denne invitation er til {invitedEmail}. Du er i øjeblikket logget ind som {currentEmail}.",
@@ -565,7 +565,7 @@
   },
   "web.organizations.invitations.continue_as_invited_email": {
     "text": "Fortsæt som {email}",
-    "source_hash": "6c9a1d4e"
+    "source_hash": "ccf9745d"
   },
   "web.organizations.invitations.expires_in_days": {
     "text": "{days}d tilbage",
@@ -1026,5 +1026,9 @@
   "web.organizations.tabs.sso": {
     "text": "SSO",
     "source_hash": "5ba3ac9f"
+  },
+  "web.organizations.create_workspace": {
+    "text": "Opret workspace",
+    "source_hash": "c63c14cf"
   }
 }


### PR DESCRIPTION
## `da_DK` translation update

Automated export of completed **da_DK** translations from the translation task DB.
Scope: `locales/content/da_DK/` only — 33 file(s), +3701/-107.

ℹ️ Variable validation not run.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-opus-4-8`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ✅ Looks good — faithful, placeholders intact

**Summary:** Large da_DK update: 14 new `admin-*.json` files plus edits across common/layout/email/domains/branding/organizations and API error files. Danish throughout, variables and brand terms preserved. Variable validator was not run, but manual inspection found no placeholder defects.

**Critical (must fix):** None

**Warnings:** None

**Notes:**
- Variable check was **not run**. Spot-verified manually: `%{secrets_mode}`, `{provider}/{accepted}/{rejected}/{fetched}`, `{org}`, `{ip}`, `{address}`, `{count}`, `{domain}`, `{term}`, and vue-i18n literals `{'@'}` all match source. Recommend running the validator before merge for full coverage.
- Intentional Workspace terminology migration is **partial**: keys whose English source changed render "Workspace" (`web.organizations.*`, `web.billing.overview.no_organizations_*`, TITLES.organizations_settings), while unchanged-source keys stay "Organisation" (`new_organization`, `not_found`, all `admin.audit/organizations` category labels). Faithful to each key's source_hash, but expect mixed "Workspace"/"Organisation" in the UI — confirm this is the desired transitional state.
- English carve-outs left untranslated by design: `Consumers`, `User Agent`, `Redis INFO`, `SSO`, `Single Sign-On (SSO)`, `Stripe`, `Caddy`, `Lettermint`, `Colonel(s)`, `no-reply`, literal command `ots email sync-feedback`, path `/api/colonel/email/deliverability/events`.
- `web.homepage.deliver_sensitive_information_directly_and_securely` drops the "securely" nuance ("direkte til vores team") — acceptable, minor.
- `\n\n` in `web.secrets.sample_secret_content_this_could_be_sensitive_data` preserved correctly.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
