### PR TITLE
i18n: update fr_CA translations

### DIFF
--- a/locales/content/fr_CA/00-common.json
+++ b/locales/content/fr_CA/00-common.json
@@ -1267,8 +1267,8 @@
     "source_hash": "cb2f00d1"
   },
   "web.TITLES.organizations_settings": {
-    "text": "Organisations",
-    "source_hash": "2730183d"
+    "text": "Espaces de travail",
+    "source_hash": "1377264b"
   },
   "web.TITLES.organization_settings": {
     "text": "Paramètres de l'organisation",
@@ -1299,8 +1299,8 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Vérifiez toujours que vous êtes sur le site officiel de {product_name}. Les fraudeurs créent parfois de faux sites qui ressemblent exactement à {product_name} pour voler vos secrets. Pour éviter les attaques d'hameçonnage, vérifiez le domaine régional avant de créer de nouveaux liens.",
-    "source_hash": "68ec20f8"
+    "text": "Vérifiez toujours que vous êtes sur le site Web officiel de {product_name}. Des fraudeurs créent parfois de faux sites Web identiques à {product_name} pour voler vos secrets. Pour éviter les attaques d'hameçonnage, vérifiez le domaine de la région dans votre barre d'adresse avant de créer de nouveaux liens.",
+    "source_hash": "2e3b856e"
   },
   "web.pricing.title": {
     "text": "Tarification simple et transparente",
@@ -1523,5 +1523,21 @@
   "web.TITLES.domain_incoming": {
     "text": "Secrets entrants",
     "source_hash": "883dbca9"
+  },
+  "web.LABELS.update": {
+    "text": "Mettre à jour",
+    "source_hash": "c1c1009d"
+  },
+  "web.LABELS.updating": {
+    "text": "Mise à jour...",
+    "source_hash": "0a4e0b71"
+  },
+  "web.TITLES.check_email": {
+    "text": "Vérifiez votre courriel",
+    "source_hash": "0e5fc27d"
+  },
+  "web.TITLES.domain_dns": {
+    "text": "Configuration DNS",
+    "source_hash": "6c63df31"
   }
 }

--- a/locales/content/fr_CA/10-layout.json
+++ b/locales/content/fr_CA/10-layout.json
@@ -101,11 +101,11 @@
   },
   "web.footer.product": {
     "text": "Produit",
-    "source_hash": "7f5540e9"
+    "source_hash": "fb9ef894"
   },
   "web.footer.source_code_purveyor": {
     "text": "Code source",
-    "source_hash": "29c5c68f"
+    "source_hash": "bc47da66"
   },
   "web.navigation.billing": {
     "text": "Facturation",
@@ -148,8 +148,8 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "Vous consultez un message sécurisé qui vous a été partagé au moyen de {product_name}. Ce contenu n'est affiché qu'une seule fois, puis il est supprimé définitivement de nos serveurs.",
-    "source_hash": "e0f1a10c"
+    "text": "Vous consultez un message sécurisé qui vous a été partagé au moyen de {product_name}. Ce contenu n'est affiché qu'une seule fois, puis supprimé définitivement de nos serveurs.",
+    "source_hash": "7a4e9d16"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
     "text": "Puis-je consulter ce secret plus tard ?",
@@ -265,7 +265,7 @@
   },
   "web.layout.visit_onetime_secret_homepage": {
     "text": "Visiter la page d'accueil de {product_name}",
-    "source_hash": "625556d2"
+    "source_hash": "87802af5"
   },
   "web.layout.footer_navigation": {
     "text": "Navigation du pied de page",
@@ -346,5 +346,9 @@
   "web.help.default_content": {
     "text": "Veuillez contacter le soutien pour obtenir de l'aide",
     "source_hash": "752bca14"
+  },
+  "web.layout.colonels_only_badge": {
+    "text": "Réservé aux Colonels",
+    "source_hash": "3f1e2dbd"
   }
 }

--- a/locales/content/fr_CA/admin-audit.json
+++ b/locales/content/fr_CA/admin-audit.json
@@ -1,0 +1,102 @@
+{
+  "web.admin.audit.title": {
+    "text": "Journal d'audit",
+    "source_hash": "47751f88"
+  },
+  "web.admin.audit.description": {
+    "text": "Chaque action administrative modifiante, les plus récentes en premier — qui a fait quoi à qui, et comment cela s'est déroulé.",
+    "source_hash": "2326a1a0"
+  },
+  "web.admin.audit.categories.customer": {
+    "text": "Clients",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.audit.categories.session": {
+    "text": "Sessions",
+    "source_hash": "6fa3cbf4"
+  },
+  "web.admin.audit.categories.domain": {
+    "text": "Domaines",
+    "source_hash": "ced67718"
+  },
+  "web.admin.audit.categories.organization": {
+    "text": "Organisations",
+    "source_hash": "2730183d"
+  },
+  "web.admin.audit.categories.banner": {
+    "text": "Bannière",
+    "source_hash": "b7f4d98f"
+  },
+  "web.admin.audit.categories.queue": {
+    "text": "Files d'attente",
+    "source_hash": "be77db11"
+  },
+  "web.admin.audit.categories.email": {
+    "text": "Courriel",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.audit.categories.ratelimit": {
+    "text": "Limites de débit",
+    "source_hash": "6ed021f7"
+  },
+  "web.admin.audit.categories.ip": {
+    "text": "Bannissements d'IP",
+    "source_hash": "48cdea49"
+  },
+  "web.admin.audit.columns.timestamp": {
+    "text": "Horodatage",
+    "source_hash": "115a2cc9"
+  },
+  "web.admin.audit.columns.actor": {
+    "text": "Auteur",
+    "source_hash": "449995c4"
+  },
+  "web.admin.audit.columns.action": {
+    "text": "Action",
+    "source_hash": "64cff131"
+  },
+  "web.admin.audit.columns.target": {
+    "text": "Cible",
+    "source_hash": "978354db"
+  },
+  "web.admin.audit.columns.result": {
+    "text": "Résultat",
+    "source_hash": "6e7d50e8"
+  },
+  "web.admin.audit.columns.detail": {
+    "text": "Détail",
+    "source_hash": "fb5f27d5"
+  },
+  "web.admin.audit.filters.actorPlaceholder": {
+    "text": "Filtrer par auteur (extid ou courriel)",
+    "source_hash": "966aa580"
+  },
+  "web.admin.audit.filters.actionLabel": {
+    "text": "Action",
+    "source_hash": "64cff131"
+  },
+  "web.admin.audit.filters.allActions": {
+    "text": "Toutes les actions",
+    "source_hash": "83140cf1"
+  },
+  "web.admin.audit.list.loadError": {
+    "text": "Impossible de charger le journal d'audit.",
+    "source_hash": "acf244f4"
+  },
+  "web.admin.audit.list.retry": {
+    "text": "Réessayer",
+    "source_hash": "942087cc"
+  },
+  "web.admin.audit.list.empty": {
+    "text": "Aucun événement d'audit enregistré pour l'instant",
+    "source_hash": "8fe0cac3"
+  },
+  "web.admin.audit.result.success": {
+    "text": "Réussite",
+    "source_hash": "c88a0b90"
+  },
+  "web.admin.audit.result.failure": {
+    "text": "Échec",
+    "source_hash": "7031edbc"
+  }
+}

--- a/locales/content/fr_CA/admin-bannedips.json
+++ b/locales/content/fr_CA/admin-bannedips.json
@@ -1,0 +1,114 @@
+{
+  "web.admin.bannedIps.title": {
+    "text": "IP bannies",
+    "source_hash": "0ece5643"
+  },
+  "web.admin.bannedIps.description": {
+    "text": "Bannir et débannir des adresses IP au périmètre du site.",
+    "source_hash": "69c0c992"
+  },
+  "web.admin.bannedIps.currentIp": {
+    "text": "Votre IP actuelle",
+    "source_hash": "14ff3ec5"
+  },
+  "web.admin.bannedIps.actions.cancel": {
+    "text": "Annuler",
+    "source_hash": "19766ed6"
+  },
+  "web.admin.bannedIps.actions.ban": {
+    "text": "Bannir une IP",
+    "source_hash": "9937d7fd"
+  },
+  "web.admin.bannedIps.actions.quickBan": {
+    "text": "Bannir cette IP",
+    "source_hash": "95720658"
+  },
+  "web.admin.bannedIps.ban.confirmTitle": {
+    "text": "Bannir cette adresse IP ?",
+    "source_hash": "512acd7b"
+  },
+  "web.admin.bannedIps.ban.confirmDescription": {
+    "text": "Cela bloque {ip} au périmètre du site. Saisissez l'IP pour confirmer.",
+    "source_hash": "d8f6142e"
+  },
+  "web.admin.bannedIps.ban.button": {
+    "text": "Bannir l'IP",
+    "source_hash": "f91a5285"
+  },
+  "web.admin.bannedIps.ban.success": {
+    "text": "{ip} banni",
+    "source_hash": "97180685"
+  },
+  "web.admin.bannedIps.columns.ipAddress": {
+    "text": "Adresse IP",
+    "source_hash": "3c3de0c9"
+  },
+  "web.admin.bannedIps.columns.reason": {
+    "text": "Motif",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.bannedIps.columns.bannedAt": {
+    "text": "Banni le",
+    "source_hash": "dfbd120e"
+  },
+  "web.admin.bannedIps.columns.bannedBy": {
+    "text": "Banni par",
+    "source_hash": "9f47db0e"
+  },
+  "web.admin.bannedIps.columns.actions": {
+    "text": "Actions",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.bannedIps.form.title": {
+    "text": "Bannir une adresse IP",
+    "source_hash": "59961746"
+  },
+  "web.admin.bannedIps.form.ipLabel": {
+    "text": "Adresse IP ou CIDR",
+    "source_hash": "133d0819"
+  },
+  "web.admin.bannedIps.form.reasonLabel": {
+    "text": "Motif (facultatif)",
+    "source_hash": "0f7d4664"
+  },
+  "web.admin.bannedIps.form.reasonPlaceholder": {
+    "text": "p. ex. bourrage d'identifiants",
+    "source_hash": "828a15ae"
+  },
+  "web.admin.bannedIps.form.submit": {
+    "text": "Bannir l'IP",
+    "source_hash": "f91a5285"
+  },
+  "web.admin.bannedIps.list.loadError": {
+    "text": "Impossible de charger les IP bannies.",
+    "source_hash": "539f2e34"
+  },
+  "web.admin.bannedIps.list.retry": {
+    "text": "Réessayer",
+    "source_hash": "942087cc"
+  },
+  "web.admin.bannedIps.list.empty": {
+    "text": "Aucune IP n'est actuellement bannie",
+    "source_hash": "b72cc9c5"
+  },
+  "web.admin.bannedIps.stats.total": {
+    "text": "Total banni",
+    "source_hash": "41059c94"
+  },
+  "web.admin.bannedIps.unban.confirmTitle": {
+    "text": "Retirer ce bannissement ?",
+    "source_hash": "88473e59"
+  },
+  "web.admin.bannedIps.unban.confirmDescription": {
+    "text": "Cela débloque {ip}. Saisissez l'IP pour confirmer.",
+    "source_hash": "6bec3191"
+  },
+  "web.admin.bannedIps.unban.button": {
+    "text": "Débannir",
+    "source_hash": "25fb5989"
+  },
+  "web.admin.bannedIps.unban.success": {
+    "text": "{ip} débanni",
+    "source_hash": "79192c36"
+  }
+}

--- a/locales/content/fr_CA/admin-banner.json
+++ b/locales/content/fr_CA/admin-banner.json
@@ -1,0 +1,154 @@
+{
+  "web.admin.banner.title": {
+    "text": "Bannière de diffusion",
+    "source_hash": "0bc449a3"
+  },
+  "web.admin.banner.description": {
+    "text": "Publiez une annonce à l'échelle du site affichée à chaque visiteur, ou effacez celle en cours.",
+    "source_hash": "a0f720d7"
+  },
+  "web.admin.banner.loadError": {
+    "text": "Impossible de charger la bannière actuelle.",
+    "source_hash": "04954e72"
+  },
+  "web.admin.banner.retry": {
+    "text": "Réessayer",
+    "source_hash": "942087cc"
+  },
+  "web.admin.banner.clear.button": {
+    "text": "Effacer la bannière",
+    "source_hash": "da6b2e5d"
+  },
+  "web.admin.banner.clear.confirmTitle": {
+    "text": "Effacer la bannière de diffusion ?",
+    "source_hash": "46d9c35a"
+  },
+  "web.admin.banner.clear.confirmDescription": {
+    "text": "Cela retire la bannière active pour tous les visiteurs. Saisissez le mot de confirmation pour continuer.",
+    "source_hash": "9a56e4be"
+  },
+  "web.admin.banner.clear.success": {
+    "text": "Bannière de diffusion effacée.",
+    "source_hash": "b0f52af4"
+  },
+  "web.admin.banner.current.title": {
+    "text": "Bannière actuelle",
+    "source_hash": "d17ab873"
+  },
+  "web.admin.banner.current.none": {
+    "text": "Aucune bannière n'est actuellement définie.",
+    "source_hash": "487b2cac"
+  },
+  "web.admin.banner.current.status": {
+    "text": "État",
+    "source_hash": "920e413c"
+  },
+  "web.admin.banner.current.live": {
+    "text": "En ligne",
+    "source_hash": "b64ac05f"
+  },
+  "web.admin.banner.current.expiry": {
+    "text": "Expiration",
+    "source_hash": "6956d814"
+  },
+  "web.admin.banner.current.persistent": {
+    "text": "Persistante (sans expiration)",
+    "source_hash": "5f95d1b0"
+  },
+  "web.admin.banner.current.expiresIn": {
+    "text": "Expire dans {duration}",
+    "source_hash": "f353f9a7"
+  },
+  "web.admin.banner.current.audience": {
+    "text": "Public",
+    "source_hash": "545c0235"
+  },
+  "web.admin.banner.current.storedContent": {
+    "text": "Contenu stocké",
+    "source_hash": "3579f3e6"
+  },
+  "web.admin.banner.current.htmlNote": {
+    "text": "Le contenu est en HTML ; le site le nettoie pour ne conserver que les liens lors de l'affichage.",
+    "source_hash": "e45a7dfe"
+  },
+  "web.admin.banner.current.edit": {
+    "text": "Modifier",
+    "source_hash": "464c4ffd"
+  },
+  "web.admin.banner.set.title": {
+    "text": "Définir une bannière",
+    "source_hash": "b6f90d5c"
+  },
+  "web.admin.banner.set.updateTitle": {
+    "text": "Mettre à jour la bannière",
+    "source_hash": "841a0183"
+  },
+  "web.admin.banner.set.contentLabel": {
+    "text": "Message",
+    "source_hash": "2f77668a"
+  },
+  "web.admin.banner.set.contentPlaceholder": {
+    "text": "Maintenance planifiée dim. 02:00 UTC",
+    "source_hash": "4ec99d7d"
+  },
+  "web.admin.banner.set.contentHelp": {
+    "text": "Le HTML est autorisé ; le site le nettoie pour ne conserver que les liens.",
+    "source_hash": "7253d1cd"
+  },
+  "web.admin.banner.set.ttlLabel": {
+    "text": "Expiration automatique après (secondes)",
+    "source_hash": "72134116"
+  },
+  "web.admin.banner.set.ttlPlaceholder": {
+    "text": "Laisser vide pour aucune expiration",
+    "source_hash": "a8fd81e1"
+  },
+  "web.admin.banner.set.ttlHelp": {
+    "text": "Facultatif. La bannière est retirée automatiquement après ce nombre de secondes.",
+    "source_hash": "ba0237f5"
+  },
+  "web.admin.banner.set.scopeLabel": {
+    "text": "Public",
+    "source_hash": "545c0235"
+  },
+  "web.admin.banner.set.scopeHelp": {
+    "text": "Les pages qui affichent la bannière. Les pages à domaine personnalisé ne la voient que lorsqu'elle est réglée sur toutes les pages.",
+    "source_hash": "28cc3018"
+  },
+  "web.admin.banner.set.scopeNoRecipient": {
+    "text": "Tout sauf les pages des destinataires",
+    "source_hash": "8575b3c0"
+  },
+  "web.admin.banner.set.scopeWorkspace": {
+    "text": "Pages d'espace de travail seulement",
+    "source_hash": "563e003e"
+  },
+  "web.admin.banner.set.scopeAll": {
+    "text": "Toutes les pages (y compris les domaines personnalisés)",
+    "source_hash": "b9b74870"
+  },
+  "web.admin.banner.set.publishButton": {
+    "text": "Publier la bannière",
+    "source_hash": "5b7427a1"
+  },
+  "web.admin.banner.set.updateButton": {
+    "text": "Mettre à jour la bannière",
+    "source_hash": "69b6e40e"
+  },
+  "web.admin.banner.set.confirmTitle": {
+    "text": "Publier la bannière de diffusion ?",
+    "source_hash": "8b72b5c3"
+  },
+  "web.admin.banner.set.confirmDescription": {
+    "text": "Cette bannière sera affichée à chaque visiteur sur l'ensemble du site jusqu'à ce qu'elle soit effacée ou qu'elle expire.",
+    "source_hash": "c61bbec1"
+  },
+  "web.admin.banner.set.confirmButton": {
+    "text": "Publier",
+    "source_hash": "859390eb"
+  },
+  "web.admin.banner.set.success": {
+    "text": "Bannière de diffusion publiée.",
+    "source_hash": "55c06cab"
+  }
+}

--- a/locales/content/fr_CA/admin-billing.json
+++ b/locales/content/fr_CA/admin-billing.json
@@ -1,0 +1,126 @@
+{
+  "web.admin.billing.title": {
+    "text": "Catalogue de facturation",
+    "source_hash": "bfde7e68"
+  },
+  "web.admin.billing.description": {
+    "text": "Vue en lecture seule des forfaits configurés et de leurs droits, ainsi que tout écart par rapport au catalogue en direct synchronisé avec Stripe.",
+    "source_hash": "05d5b332"
+  },
+  "web.admin.billing.retry": {
+    "text": "Réessayer",
+    "source_hash": "942087cc"
+  },
+  "web.admin.billing.loadError": {
+    "text": "Impossible de charger le catalogue de facturation.",
+    "source_hash": "c3110f77"
+  },
+  "web.admin.billing.localConfigWarning": {
+    "text": "Le cache des forfaits synchronisés avec Stripe est vide ; les forfaits en direct et les écarts ne peuvent donc pas être évalués. Seul le catalogue configuré (billing.yaml) est affiché — typique en développement ou lorsque Stripe n'est pas configuré.",
+    "source_hash": "905d95f8"
+  },
+  "web.admin.billing.inSync": {
+    "text": "Synchronisé",
+    "source_hash": "5701958c"
+  },
+  "web.admin.billing.driftCount": {
+    "text": "{count} différence(s)",
+    "source_hash": "166538f5"
+  },
+  "web.admin.billing.inSyncDetail": {
+    "text": "Le catalogue configuré correspond aux forfaits en direct. Aucun écart détecté.",
+    "source_hash": "57ab60a6"
+  },
+  "web.admin.billing.columns.planid": {
+    "text": "ID du forfait",
+    "source_hash": "1f0d4dc6"
+  },
+  "web.admin.billing.columns.name": {
+    "text": "Nom",
+    "source_hash": "dcd1d522"
+  },
+  "web.admin.billing.columns.tier": {
+    "text": "Niveau",
+    "source_hash": "cb9e8664"
+  },
+  "web.admin.billing.columns.status": {
+    "text": "État",
+    "source_hash": "920e413c"
+  },
+  "web.admin.billing.diff.title": {
+    "text": "Différence de forfait : {planid}",
+    "source_hash": "bc86e5f7"
+  },
+  "web.admin.billing.diff.subtitle": {
+    "text": "Catalogue configuré (billing.yaml) comparé au forfait en direct synchronisé avec Stripe, côte à côte.",
+    "source_hash": "d92e93ae"
+  },
+  "web.admin.billing.diff.config": {
+    "text": "Configuré (billing.yaml)",
+    "source_hash": "6bf2ff04"
+  },
+  "web.admin.billing.diff.live": {
+    "text": "En direct (cache Stripe)",
+    "source_hash": "4886945d"
+  },
+  "web.admin.billing.diff.absentConfig": {
+    "text": "Ce forfait n'est pas présent dans le catalogue configuré.",
+    "source_hash": "0b594c88"
+  },
+  "web.admin.billing.diff.absentLive": {
+    "text": "Ce forfait n'est pas présent dans le cache en direct synchronisé avec Stripe.",
+    "source_hash": "c53f31c3"
+  },
+  "web.admin.billing.plans.title": {
+    "text": "Forfaits",
+    "source_hash": "dfe8b2f0"
+  },
+  "web.admin.billing.plans.empty": {
+    "text": "Aucun forfait trouvé dans le catalogue.",
+    "source_hash": "39db3c13"
+  },
+  "web.admin.billing.plans.viewDiff": {
+    "text": "Voir la différence",
+    "source_hash": "0e5d6873"
+  },
+  "web.admin.billing.source.stripe": {
+    "text": "Cache Stripe",
+    "source_hash": "b5577327"
+  },
+  "web.admin.billing.source.localConfig": {
+    "text": "Configuration locale",
+    "source_hash": "49de43d2"
+  },
+  "web.admin.billing.stats.configured": {
+    "text": "Forfaits configurés",
+    "source_hash": "4fda4796"
+  },
+  "web.admin.billing.stats.live": {
+    "text": "Forfaits en direct",
+    "source_hash": "faaa88d9"
+  },
+  "web.admin.billing.stats.source": {
+    "text": "Source",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.billing.stats.drift": {
+    "text": "Écart",
+    "source_hash": "8b4c8240"
+  },
+  "web.admin.billing.status.in_sync": {
+    "text": "Synchronisé",
+    "source_hash": "5701958c"
+  },
+  "web.admin.billing.status.only_config": {
+    "text": "Configuration seulement",
+    "source_hash": "15836cba"
+  },
+  "web.admin.billing.status.only_live": {
+    "text": "En direct seulement",
+    "source_hash": "8f4ed495"
+  },
+  "web.admin.billing.status.changed": {
+    "text": "Modifié",
+    "source_hash": "2a6141e4"
+  }
+}

--- a/locales/content/fr_CA/admin-colonel.json
+++ b/locales/content/fr_CA/admin-colonel.json
@@ -802,5 +802,45 @@
   "web.colonel.secrets.state.viewed": {
     "text": "Vu",
     "source_hash": "1b28d178"
+  },
+  "web.colonel.backToSite": {
+    "text": "Retour au site",
+    "source_hash": "4ee0f819"
+  },
+  "web.colonel.customDomains.labels.domain": {
+    "text": "Domaine",
+    "source_hash": "79fa3361"
+  },
+  "web.colonel.customDomains.labels.status": {
+    "text": "État",
+    "source_hash": "920e413c"
+  },
+  "web.colonel.customDomains.labels.actions": {
+    "text": "Actions",
+    "source_hash": "ff8059dc"
+  },
+  "web.colonel.nav.consoleTag": {
+    "text": "Console",
+    "source_hash": "29a40861"
+  },
+  "web.colonel.nav.groups.identity": {
+    "text": "Identité",
+    "source_hash": "999f23fc"
+  },
+  "web.colonel.nav.groups.security": {
+    "text": "Accès et sécurité",
+    "source_hash": "abb29a3f"
+  },
+  "web.colonel.nav.groups.platform": {
+    "text": "Plateforme",
+    "source_hash": "c78ffe19"
+  },
+  "web.colonel.nav.groups.billing": {
+    "text": "Facturation",
+    "source_hash": "3ac8bbca"
+  },
+  "web.colonel.nav.groups.communications": {
+    "text": "Communications",
+    "source_hash": "919a9253"
   }
 }

--- a/locales/content/fr_CA/admin-customers.json
+++ b/locales/content/fr_CA/admin-customers.json
@@ -1,0 +1,486 @@
+{
+  "web.admin.customers.title": {
+    "text": "Clients",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.customers.description": {
+    "text": "Trouvez un client et résolvez les problèmes de soutien sans SSH.",
+    "source_hash": "c8487e68"
+  },
+  "web.admin.customers.actions.plan.label": {
+    "text": "Forfait",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.actions.plan.apply": {
+    "text": "Appliquer",
+    "source_hash": "31e392d1"
+  },
+  "web.admin.customers.actions.plan.confirmTitle": {
+    "text": "Changer de forfait ?",
+    "source_hash": "910a4de9"
+  },
+  "web.admin.customers.actions.plan.confirmDescription": {
+    "text": "Faire passer {email} au forfait {plan}.",
+    "source_hash": "83fb4158"
+  },
+  "web.admin.customers.actions.plan.success": {
+    "text": "Forfait mis à jour.",
+    "source_hash": "ebe8d40c"
+  },
+  "web.admin.customers.actions.plan.localConfigWarning": {
+    "text": "Forfaits chargés depuis la configuration locale — Stripe n'est pas configuré ou est inaccessible.",
+    "source_hash": "df83e326"
+  },
+  "web.admin.customers.actions.purge.button": {
+    "text": "Purger le client",
+    "source_hash": "ff658f69"
+  },
+  "web.admin.customers.actions.purge.confirmTitle": {
+    "text": "Purger le client ?",
+    "source_hash": "9feed9f1"
+  },
+  "web.admin.customers.actions.purge.confirmDescription": {
+    "text": "Cela supprime définitivement {email} et toutes ses données. Cette action est irréversible.",
+    "source_hash": "a74dd5d1"
+  },
+  "web.admin.customers.actions.purge.success": {
+    "text": "Client purgé.",
+    "source_hash": "6145e5c8"
+  },
+  "web.admin.customers.actions.role.label": {
+    "text": "Rôle",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.actions.role.apply": {
+    "text": "Appliquer",
+    "source_hash": "31e392d1"
+  },
+  "web.admin.customers.actions.role.confirmTitle": {
+    "text": "Changer de rôle ?",
+    "source_hash": "227f57d7"
+  },
+  "web.admin.customers.actions.role.confirmDescription": {
+    "text": "Faire passer {email} au rôle {role}.",
+    "source_hash": "9ba063c6"
+  },
+  "web.admin.customers.actions.role.success": {
+    "text": "Rôle mis à jour.",
+    "source_hash": "0c33aa24"
+  },
+  "web.admin.customers.actions.suspend.button": {
+    "text": "Suspendre le compte",
+    "source_hash": "95a04f27"
+  },
+  "web.admin.customers.actions.suspend.reasonLabel": {
+    "text": "Motif (facultatif)",
+    "source_hash": "0f7d4664"
+  },
+  "web.admin.customers.actions.suspend.reasonPlaceholder": {
+    "text": "Pourquoi ce compte est-il suspendu ?",
+    "source_hash": "8eca975e"
+  },
+  "web.admin.customers.actions.suspend.confirmTitle": {
+    "text": "Suspendre le compte ?",
+    "source_hash": "cbfa275b"
+  },
+  "web.admin.customers.actions.suspend.confirmDescription": {
+    "text": "Empêche {email} de se connecter et révoque ses sessions actives. Aucune donnée n'est supprimée — cette action est réversible.",
+    "source_hash": "e5d046bc"
+  },
+  "web.admin.customers.actions.suspend.success": {
+    "text": "Compte suspendu.",
+    "source_hash": "04c5f996"
+  },
+  "web.admin.customers.actions.unsuspend.button": {
+    "text": "Rétablir le compte",
+    "source_hash": "35a10fb5"
+  },
+  "web.admin.customers.actions.unsuspend.confirmTitle": {
+    "text": "Rétablir le compte ?",
+    "source_hash": "6fd78a72"
+  },
+  "web.admin.customers.actions.unsuspend.confirmDescription": {
+    "text": "Rétablit la connexion pour {email}.",
+    "source_hash": "cb2bb4e0"
+  },
+  "web.admin.customers.actions.unsuspend.success": {
+    "text": "Compte rétabli.",
+    "source_hash": "c5b4377f"
+  },
+  "web.admin.customers.actions.unverify.button": {
+    "text": "Annuler la vérification",
+    "source_hash": "b0dee41f"
+  },
+  "web.admin.customers.actions.unverify.confirmTitle": {
+    "text": "Annuler la vérification du client ?",
+    "source_hash": "62ed2854"
+  },
+  "web.admin.customers.actions.unverify.confirmDescription": {
+    "text": "Marquer {email} comme non vérifié.",
+    "source_hash": "592ffd27"
+  },
+  "web.admin.customers.actions.unverify.success": {
+    "text": "Vérification du client annulée.",
+    "source_hash": "a9b7bbac"
+  },
+  "web.admin.customers.actions.verify.button": {
+    "text": "Vérifier",
+    "source_hash": "eea2745e"
+  },
+  "web.admin.customers.actions.verify.confirmTitle": {
+    "text": "Vérifier le client ?",
+    "source_hash": "43037ce1"
+  },
+  "web.admin.customers.actions.verify.confirmDescription": {
+    "text": "Marquer {email} comme vérifié.",
+    "source_hash": "7052d79d"
+  },
+  "web.admin.customers.actions.verify.success": {
+    "text": "Client vérifié.",
+    "source_hash": "19e382dc"
+  },
+  "web.admin.customers.columns.email": {
+    "text": "Courriel",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.customers.columns.role": {
+    "text": "Rôle",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.columns.verified": {
+    "text": "Vérifié",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.columns.plan": {
+    "text": "Forfait",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.columns.secrets": {
+    "text": "Secrets",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.customers.columns.created": {
+    "text": "Créé",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.columns.lastLogin": {
+    "text": "Dernière connexion",
+    "source_hash": "0d39602d"
+  },
+  "web.admin.customers.detail.backToList": {
+    "text": "Retour aux clients",
+    "source_hash": "077807fb"
+  },
+  "web.admin.customers.detail.openFullPage": {
+    "text": "Ouvrir la page complète",
+    "source_hash": "a467911c"
+  },
+  "web.admin.customers.detail.notFound": {
+    "text": "Client introuvable",
+    "source_hash": "5e3f5824"
+  },
+  "web.admin.customers.detail.notFoundDescription": {
+    "text": "Aucun client ne correspond à cet identifiant. Il a peut-être été purgé.",
+    "source_hash": "82b04725"
+  },
+  "web.admin.customers.detail.loadError": {
+    "text": "Impossible de charger ce client.",
+    "source_hash": "cfd1bcca"
+  },
+  "web.admin.customers.detail.retry": {
+    "text": "Réessayer",
+    "source_hash": "942087cc"
+  },
+  "web.admin.customers.detail.yes": {
+    "text": "Oui",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.customers.detail.no": {
+    "text": "Non",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.customers.detail.none": {
+    "text": "Aucun",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.never": {
+    "text": "Jamais",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.customers.detail.billing.plan": {
+    "text": "Forfait",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.detail.billing.organization": {
+    "text": "Organisation de facturation",
+    "source_hash": "90c94ee1"
+  },
+  "web.admin.customers.detail.billing.subscriptionStatus": {
+    "text": "État de l'abonnement",
+    "source_hash": "f0723c4e"
+  },
+  "web.admin.customers.detail.billing.periodEnd": {
+    "text": "Fin de la période en cours",
+    "source_hash": "742b8229"
+  },
+  "web.admin.customers.detail.billing.latestInvoice": {
+    "text": "Dernière facture",
+    "source_hash": "7a6133cc"
+  },
+  "web.admin.customers.detail.billing.noInvoices": {
+    "text": "Aucune facture",
+    "source_hash": "e6b30f93"
+  },
+  "web.admin.customers.detail.billing.openStripe": {
+    "text": "Ouvrir dans le tableau de bord Stripe",
+    "source_hash": "dfa7c41d"
+  },
+  "web.admin.customers.detail.billing.unavailable": {
+    "text": "Données Stripe indisponibles : {reason}",
+    "source_hash": "9fe08e49"
+  },
+  "web.admin.customers.detail.billing.notConfigured": {
+    "text": "La facturation n'est pas configurée sur cette installation.",
+    "source_hash": "6e90375e"
+  },
+  "web.admin.customers.detail.fields.email": {
+    "text": "Courriel",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.customers.detail.fields.publicId": {
+    "text": "ID public",
+    "source_hash": "3705b64f"
+  },
+  "web.admin.customers.detail.fields.role": {
+    "text": "Rôle",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.detail.fields.verified": {
+    "text": "Vérifié",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.detail.fields.plan": {
+    "text": "Forfait",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.detail.fields.locale": {
+    "text": "Langue",
+    "source_hash": "ca3dc612"
+  },
+  "web.admin.customers.detail.fields.created": {
+    "text": "Créé",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.detail.fields.updated": {
+    "text": "Mis à jour",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.customers.detail.fields.lastLogin": {
+    "text": "Dernière connexion",
+    "source_hash": "0d39602d"
+  },
+  "web.admin.customers.detail.fields.suspendedAt": {
+    "text": "Suspendu le",
+    "source_hash": "7227f219"
+  },
+  "web.admin.customers.detail.fields.suspendedBy": {
+    "text": "Suspendu par",
+    "source_hash": "e0830524"
+  },
+  "web.admin.customers.detail.fields.suspendedReason": {
+    "text": "Motif de suspension",
+    "source_hash": "d6b08d8e"
+  },
+  "web.admin.customers.detail.organizations.empty": {
+    "text": "Aucune organisation",
+    "source_hash": "c256efdc"
+  },
+  "web.admin.customers.detail.organizations.default": {
+    "text": "Par défaut",
+    "source_hash": "21b111cb"
+  },
+  "web.admin.customers.detail.receiptColumns.shortId": {
+    "text": "ID court",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.customers.detail.receiptColumns.state": {
+    "text": "État",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.customers.detail.receiptColumns.created": {
+    "text": "Créé",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.detail.receipts.empty": {
+    "text": "Aucun reçu",
+    "source_hash": "fb425a68"
+  },
+  "web.admin.customers.detail.secretColumns.shortId": {
+    "text": "ID court",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.customers.detail.secretColumns.state": {
+    "text": "État",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.customers.detail.secretColumns.created": {
+    "text": "Créé",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.detail.secretColumns.expiration": {
+    "text": "Expiration",
+    "source_hash": "f38d6e0e"
+  },
+  "web.admin.customers.detail.secrets.empty": {
+    "text": "Aucun secret",
+    "source_hash": "c37ab3f7"
+  },
+  "web.admin.customers.detail.sections.profile": {
+    "text": "Profil",
+    "source_hash": "d696a35b"
+  },
+  "web.admin.customers.detail.sections.secrets": {
+    "text": "Secrets",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.customers.detail.sections.receipts": {
+    "text": "Reçus",
+    "source_hash": "60a627df"
+  },
+  "web.admin.customers.detail.sections.organizations": {
+    "text": "Organisations",
+    "source_hash": "2730183d"
+  },
+  "web.admin.customers.detail.sections.actions": {
+    "text": "Actions",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.sections.billing": {
+    "text": "Facturation",
+    "source_hash": "3ac8bbca"
+  },
+  "web.admin.customers.detail.sessions.title": {
+    "text": "Sessions actives",
+    "source_hash": "b58fa4e0"
+  },
+  "web.admin.customers.detail.sessions.empty": {
+    "text": "Aucune session active.",
+    "source_hash": "6f064eb9"
+  },
+  "web.admin.customers.detail.sessions.loadError": {
+    "text": "Impossible de charger les sessions.",
+    "source_hash": "d2884313"
+  },
+  "web.admin.customers.detail.sessions.unknown": {
+    "text": "Inconnu",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.customers.detail.sessions.columns.lastActivity": {
+    "text": "Dernière activité",
+    "source_hash": "06475633"
+  },
+  "web.admin.customers.detail.sessions.columns.ipAddress": {
+    "text": "Adresse IP",
+    "source_hash": "0302a467"
+  },
+  "web.admin.customers.detail.sessions.columns.device": {
+    "text": "Appareil",
+    "source_hash": "6ba0bdec"
+  },
+  "web.admin.customers.detail.sessions.columns.authMethod": {
+    "text": "Méthode d'authentification",
+    "source_hash": "bc4ea262"
+  },
+  "web.admin.customers.detail.sessions.columns.actions": {
+    "text": "Actions",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.sessions.revoke.button": {
+    "text": "Révoquer",
+    "source_hash": "87e6d00b"
+  },
+  "web.admin.customers.detail.sessions.revoke.confirmTitle": {
+    "text": "Révoquer la session ?",
+    "source_hash": "7735d1ef"
+  },
+  "web.admin.customers.detail.sessions.revoke.confirmDescription": {
+    "text": "Cela déconnecte immédiatement l'utilisateur de cette session. Il devra se reconnecter.",
+    "source_hash": "b4291af0"
+  },
+  "web.admin.customers.detail.sessions.revoke.success": {
+    "text": "Session révoquée.",
+    "source_hash": "5e4762e5"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.button": {
+    "text": "Tout révoquer",
+    "source_hash": "c6847a4b"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.confirmTitle": {
+    "text": "Révoquer toutes les sessions ?",
+    "source_hash": "a4fa4c65"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.confirmDescription": {
+    "text": "Cela déconnecte l'utilisateur de tous les appareils et navigateurs — y compris les sessions non affichées dans cette liste — et bloque immédiatement l'accès à ses routes authentifiées. À utiliser pour un départ ou en cas de compromission présumée du compte. Saisissez l'ID de l'utilisateur pour confirmer.",
+    "source_hash": "483cdd88"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.success": {
+    "text": "Toutes les sessions ont été révoquées ({count} interrompues).",
+    "source_hash": "4e1cce55"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.capped": {
+    "text": "{count} sessions interrompues, mais le balayage des sessions non suivies a été tronqué — une session plus ancienne pourrait subsister. Réexécutez pour en avoir la certitude.",
+    "source_hash": "e3d295a6"
+  },
+  "web.admin.customers.detail.stats.secretsCreated": {
+    "text": "Secrets créés",
+    "source_hash": "7d17719e"
+  },
+  "web.admin.customers.detail.stats.secretsShared": {
+    "text": "Secrets partagés",
+    "source_hash": "ba85b265"
+  },
+  "web.admin.customers.detail.stats.emailsSent": {
+    "text": "Courriels envoyés",
+    "source_hash": "be604792"
+  },
+  "web.admin.customers.list.roleFilter": {
+    "text": "Rôle",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.list.empty": {
+    "text": "Aucun client trouvé",
+    "source_hash": "dc754ec0"
+  },
+  "web.admin.customers.list.loadError": {
+    "text": "Impossible de charger les clients.",
+    "source_hash": "81783303"
+  },
+  "web.admin.customers.list.searchPlaceholder": {
+    "text": "Rechercher par courriel, extid ou objid",
+    "source_hash": "c06d5a3b"
+  },
+  "web.admin.customers.list.emptySearch": {
+    "text": "Aucun client ne correspond à cette recherche",
+    "source_hash": "ea7e7012"
+  },
+  "web.admin.customers.roles.colonel": {
+    "text": "Colonel",
+    "source_hash": "02577777"
+  },
+  "web.admin.customers.roles.admin": {
+    "text": "Administrateur",
+    "source_hash": "c1c224b0"
+  },
+  "web.admin.customers.roles.staff": {
+    "text": "Personnel",
+    "source_hash": "681927e3"
+  },
+  "web.admin.customers.roles.customer": {
+    "text": "Client",
+    "source_hash": "bf376338"
+  },
+  "web.admin.customers.suspended.badge": {
+    "text": "Suspendu",
+    "source_hash": "e392a389"
+  }
+}

--- a/locales/content/fr_CA/admin-domains.json
+++ b/locales/content/fr_CA/admin-domains.json
@@ -1,0 +1,194 @@
+{
+  "web.admin.domains.retry": {
+    "text": "Réessayer",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.addDomain.button": {
+    "text": "Ajouter un domaine",
+    "source_hash": "d86476ae"
+  },
+  "web.admin.domains.addDomain.title": {
+    "text": "Ajouter un domaine personnalisé",
+    "source_hash": "592d3314"
+  },
+  "web.admin.domains.addDomain.forOrg": {
+    "text": "Ajout d'un domaine pour {org}.",
+    "source_hash": "f8b8c1ac"
+  },
+  "web.admin.domains.addDomain.domainLabel": {
+    "text": "Domaine",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domains.addDomain.domainPlaceholder": {
+    "text": "secrets.example.com",
+    "source_hash": "9ea4d0d6"
+  },
+  "web.admin.domains.addDomain.strategyLabel": {
+    "text": "Stratégie de validation",
+    "source_hash": "a2e95531"
+  },
+  "web.admin.domains.addDomain.createButton": {
+    "text": "Créer",
+    "source_hash": "4759498a"
+  },
+  "web.admin.domains.addDomain.created": {
+    "text": "{domain} a été créé.",
+    "source_hash": "2263ec6a"
+  },
+  "web.admin.domains.addDomain.strategy.approximated": {
+    "text": "Approximated — vérification de la propriété DNS, sans proxy.",
+    "source_hash": "79a7245c"
+  },
+  "web.admin.domains.addDomain.strategy.passthrough": {
+    "text": "Passthrough — vous pointez le DNS vers le proxy de ce déploiement.",
+    "source_hash": "9702d758"
+  },
+  "web.admin.domains.addDomain.strategy.external": {
+    "text": "External — le DNS est géré à l'extérieur de ce déploiement.",
+    "source_hash": "acaede35"
+  },
+  "web.admin.domains.addDomain.strategy.caddy_on_demand": {
+    "text": "Caddy à la demande — certificats émis automatiquement à la première requête.",
+    "source_hash": "deb90ae6"
+  },
+  "web.admin.domains.addDomain.strategy.caddy": {
+    "text": "Caddy — certificats émis automatiquement à la première requête.",
+    "source_hash": "a0f3c2dc"
+  },
+  "web.admin.domains.addDomain.strategy.unknown": {
+    "text": "Stratégie de validation à l'échelle du déploiement.",
+    "source_hash": "4587f9cf"
+  },
+  "web.admin.domains.attach.cta": {
+    "text": "Rattacher le domaine à l'organisation",
+    "source_hash": "736d74ce"
+  },
+  "web.admin.domains.attach.recordEyebrow": {
+    "text": "Enregistrement en cours",
+    "source_hash": "2fadf983"
+  },
+  "web.admin.domains.attach.rosterError": {
+    "text": "Impossible de charger les domaines de cette organisation.",
+    "source_hash": "d3055fed"
+  },
+  "web.admin.domains.attach.noDomains": {
+    "text": "Aucun domaine n'est encore rattaché à cette organisation.",
+    "source_hash": "e9a25fc4"
+  },
+  "web.admin.domains.attach.openExternal": {
+    "text": "Ouvrir {domain} dans un nouvel onglet",
+    "source_hash": "c5fbdeaa"
+  },
+  "web.admin.domains.dns.heading": {
+    "text": "Enregistrements DNS à publier",
+    "source_hash": "e4efbe2b"
+  },
+  "web.admin.domains.dns.txtStep": {
+    "text": "1. Ajoutez un enregistrement TXT pour prouver la propriété.",
+    "source_hash": "fdcfcfb0"
+  },
+  "web.admin.domains.dns.aStep": {
+    "text": "2. Ajoutez un enregistrement A pointant l'apex vers le proxy.",
+    "source_hash": "aedbf197"
+  },
+  "web.admin.domains.dns.cnameStep": {
+    "text": "2. Ajoutez un enregistrement CNAME pointant le sous-domaine vers le proxy.",
+    "source_hash": "5c626f53"
+  },
+  "web.admin.domains.dns.propagationNote": {
+    "text": "La propagation des changements DNS peut prendre quelques minutes avant que la vérification réussisse.",
+    "source_hash": "7caf70a7"
+  },
+  "web.admin.domains.dns.toggle": {
+    "text": "Détails DNS",
+    "source_hash": "ebf2d44e"
+  },
+  "web.admin.domains.dns.loadError": {
+    "text": "Impossible de charger les détails DNS.",
+    "source_hash": "4c33e23d"
+  },
+  "web.admin.domains.list.loadError": {
+    "text": "Impossible de charger les domaines.",
+    "source_hash": "548deff8"
+  },
+  "web.admin.domains.orgPicker.title": {
+    "text": "Sélectionner une organisation",
+    "source_hash": "48326f52"
+  },
+  "web.admin.domains.orgPicker.searchLabel": {
+    "text": "Organisation",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.orgPicker.searchPlaceholder": {
+    "text": "ID d'objet, ID externe ou courriel",
+    "source_hash": "bb5d0055"
+  },
+  "web.admin.domains.orgPicker.searchHint": {
+    "text": "Rechercher par objid, extid ou l'adresse courriel d'un membre.",
+    "source_hash": "fdef7332"
+  },
+  "web.admin.domains.orgPicker.loadError": {
+    "text": "Impossible de rechercher des organisations.",
+    "source_hash": "b9e45dcf"
+  },
+  "web.admin.domains.orgPicker.parseError": {
+    "text": "Les résultats des organisations n'ont pas pu être lus.",
+    "source_hash": "44e1b9fd"
+  },
+  "web.admin.domains.orgPicker.idle": {
+    "text": "Saisissez une valeur ci-dessus pour rechercher.",
+    "source_hash": "0352e6e6"
+  },
+  "web.admin.domains.orgPicker.noResults": {
+    "text": "Aucune organisation ne correspond à « {term} ».",
+    "source_hash": "761db594"
+  },
+  "web.admin.domains.orgPicker.unnamedOrg": {
+    "text": "Organisation sans nom",
+    "source_hash": "f218dc9d"
+  },
+  "web.admin.domains.orgPicker.domainCount": {
+    "text": "{count} domaines",
+    "source_hash": "cf548c8c"
+  },
+  "web.admin.domains.orgPicker.select": {
+    "text": "Sélectionner",
+    "source_hash": "2a78025d"
+  },
+  "web.admin.domains.verify.button": {
+    "text": "Vérifier",
+    "source_hash": "eea2745e"
+  },
+  "web.admin.domains.verify.confirmTitle": {
+    "text": "Vérifier le domaine ?",
+    "source_hash": "07c4dc4f"
+  },
+  "web.admin.domains.verify.confirmDescription": {
+    "text": "Exécuter les vérifications DNS et SSL pour {domain}.",
+    "source_hash": "06797824"
+  },
+  "web.admin.domains.verify.failed": {
+    "text": "La vérification a échoué. Veuillez réessayer.",
+    "source_hash": "3c8432b0"
+  },
+  "web.admin.domains.verify.success.verified": {
+    "text": "{domain} est vérifié.",
+    "source_hash": "802b5d1e"
+  },
+  "web.admin.domains.verify.success.resolving": {
+    "text": "{domain} se résout, mais n'est pas encore vérifié.",
+    "source_hash": "bc8aecad"
+  },
+  "web.admin.domains.verify.success.pending": {
+    "text": "{domain} est en attente — le DNS ne se résout pas encore.",
+    "source_hash": "0d9f66d5"
+  },
+  "web.admin.domains.verify.success.unverified": {
+    "text": "{domain} n'a pas pu être vérifié.",
+    "source_hash": "630da482"
+  },
+  "web.admin.domains.verify.success.done": {
+    "text": "Vérification terminée pour {domain}.",
+    "source_hash": "ed67e22d"
+  }
+}

--- a/locales/content/fr_CA/admin-domaintoolbox.json
+++ b/locales/content/fr_CA/admin-domaintoolbox.json
@@ -1,0 +1,178 @@
+{
+  "web.admin.domaintoolbox.title": {
+    "text": "Boîte à outils des domaines",
+    "source_hash": "5a9333db"
+  },
+  "web.admin.domaintoolbox.description": {
+    "text": "Diagnostiquez et réparez les relations des domaines personnalisés : recherchez les orphelins, sondez le DNS/SSL, réparez la propriété et transférez entre organisations.",
+    "source_hash": "778537aa"
+  },
+  "web.admin.domaintoolbox.retry": {
+    "text": "Réessayer",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domaintoolbox.preview": {
+    "text": "Aperçu",
+    "source_hash": "324b134f"
+  },
+  "web.admin.domaintoolbox.fields.extid": {
+    "text": "ID externe du domaine",
+    "source_hash": "f52af6c5"
+  },
+  "web.admin.domaintoolbox.fields.extidPlaceholder": {
+    "text": "cd_… (extid du domaine)",
+    "source_hash": "bb9bf49a"
+  },
+  "web.admin.domaintoolbox.orphaned.title": {
+    "text": "Domaines orphelins",
+    "source_hash": "ddcea596"
+  },
+  "web.admin.domaintoolbox.orphaned.description": {
+    "text": "Domaines personnalisés sans organisation propriétaire. Utilisez Réparer pour en réattribuer un.",
+    "source_hash": "967268f5"
+  },
+  "web.admin.domaintoolbox.orphaned.empty": {
+    "text": "Aucun domaine orphelin trouvé.",
+    "source_hash": "06ef9979"
+  },
+  "web.admin.domaintoolbox.orphaned.loadError": {
+    "text": "Impossible de charger les domaines orphelins.",
+    "source_hash": "ca0e33bf"
+  },
+  "web.admin.domaintoolbox.orphaned.repairAction": {
+    "text": "Réparer",
+    "source_hash": "1196b6c5"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.domain": {
+    "text": "Domaine",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.state": {
+    "text": "État",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.verified": {
+    "text": "Vérifié",
+    "source_hash": "4f783840"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.created": {
+    "text": "Créé",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.actions": {
+    "text": "Actions",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domaintoolbox.probe.title": {
+    "text": "Sonder (DNS / SSL)",
+    "source_hash": "ec69a087"
+  },
+  "web.admin.domaintoolbox.probe.description": {
+    "text": "Effectuez une requête HTTPS en direct pour confirmer que le domaine sert du trafic et inspecter son certificat TLS. Lecture seule.",
+    "source_hash": "1eecfa96"
+  },
+  "web.admin.domaintoolbox.probe.button": {
+    "text": "Sonder",
+    "source_hash": "3bd51ab9"
+  },
+  "web.admin.domaintoolbox.probe.healthLabel": {
+    "text": "État de santé",
+    "source_hash": "55898449"
+  },
+  "web.admin.domaintoolbox.repair.title": {
+    "text": "Réparer la relation",
+    "source_hash": "0053d07c"
+  },
+  "web.admin.domaintoolbox.repair.description": {
+    "text": "Corrigez les incohérences de relation avec l'organisation pour un domaine. Prévisualisez d'abord, puis appliquez.",
+    "source_hash": "18ca490b"
+  },
+  "web.admin.domaintoolbox.repair.orgIdLabel": {
+    "text": "Attribuer une organisation (si orphelin)",
+    "source_hash": "f95b010a"
+  },
+  "web.admin.domaintoolbox.repair.orgIdPlaceholder": {
+    "text": "id ou extid de l'organisation",
+    "source_hash": "a87d634e"
+  },
+  "web.admin.domaintoolbox.repair.statusLabel": {
+    "text": "État",
+    "source_hash": "920e413c"
+  },
+  "web.admin.domaintoolbox.repair.noIssues": {
+    "text": "Aucun problème trouvé — les relations sont cohérentes.",
+    "source_hash": "e1a4c49d"
+  },
+  "web.admin.domaintoolbox.repair.applyButton": {
+    "text": "Appliquer les réparations",
+    "source_hash": "3f92b29f"
+  },
+  "web.admin.domaintoolbox.repair.success": {
+    "text": "Réparations appliquées avec succès.",
+    "source_hash": "24f25b9b"
+  },
+  "web.admin.domaintoolbox.repair.confirmTitle": {
+    "text": "Appliquer les réparations du domaine ?",
+    "source_hash": "9429998b"
+  },
+  "web.admin.domaintoolbox.repair.confirmDescription": {
+    "text": "Cela modifiera l'état de propriété/de relation pour {domain}. Saisissez de nouveau l'ID externe du domaine pour confirmer.",
+    "source_hash": "426d267b"
+  },
+  "web.admin.domaintoolbox.reverify.button": {
+    "text": "Revérifier",
+    "source_hash": "0344860a"
+  },
+  "web.admin.domaintoolbox.reverify.success": {
+    "text": "Revérification du domaine terminée.",
+    "source_hash": "497a2348"
+  },
+  "web.admin.domaintoolbox.transfer.title": {
+    "text": "Transférer la propriété",
+    "source_hash": "3667f939"
+  },
+  "web.admin.domaintoolbox.transfer.description": {
+    "text": "Réattribuez un domaine à une autre organisation. Action au rayon d'impact le plus élevé — prévisualisez et confirmez avec soin.",
+    "source_hash": "d4e26e03"
+  },
+  "web.admin.domaintoolbox.transfer.toOrgLabel": {
+    "text": "Organisation de destination",
+    "source_hash": "4e4486eb"
+  },
+  "web.admin.domaintoolbox.transfer.fromOrgLabel": {
+    "text": "Organisation source (facultatif)",
+    "source_hash": "3666815f"
+  },
+  "web.admin.domaintoolbox.transfer.fromOrgPlaceholder": {
+    "text": "confirmer le propriétaire actuel",
+    "source_hash": "cd9e769c"
+  },
+  "web.admin.domaintoolbox.transfer.from": {
+    "text": "De",
+    "source_hash": "21819769"
+  },
+  "web.admin.domaintoolbox.transfer.to": {
+    "text": "À",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.domaintoolbox.transfer.orphaned": {
+    "text": "ORPHELIN",
+    "source_hash": "54dc2166"
+  },
+  "web.admin.domaintoolbox.transfer.applyButton": {
+    "text": "Transférer le domaine",
+    "source_hash": "9517aeb9"
+  },
+  "web.admin.domaintoolbox.transfer.success": {
+    "text": "Domaine transféré avec succès.",
+    "source_hash": "bbca9de9"
+  },
+  "web.admin.domaintoolbox.transfer.confirmTitle": {
+    "text": "Transférer la propriété du domaine ?",
+    "source_hash": "d306a15a"
+  },
+  "web.admin.domaintoolbox.transfer.confirmDescription": {
+    "text": "Cela réattribue la propriété de {domain} à une autre organisation. Saisissez de nouveau l'ID externe du domaine pour confirmer.",
+    "source_hash": "edefd97c"
+  }
+}

--- a/locales/content/fr_CA/admin-emailtools.json
+++ b/locales/content/fr_CA/admin-emailtools.json
@@ -1,0 +1,550 @@
+{
+  "web.admin.emailtools.title": {
+    "text": "Outils de courriel",
+    "source_hash": "f9643d5a"
+  },
+  "web.admin.emailtools.description": {
+    "text": "Prévisualisez les modèles de courriel, envoyez un test de livraison et surveillez la délivrabilité — les diagnostics qui nécessitaient auparavant SSH.",
+    "source_hash": "be85c9e9"
+  },
+  "web.admin.emailtools.config.title": {
+    "text": "Configuration du logiciel de messagerie",
+    "source_hash": "d2a71028"
+  },
+  "web.admin.emailtools.config.description": {
+    "text": "La configuration de messagerie permanente résolue au démarrage. Les identifiants ne sont jamais affichés — seulement leur présence.",
+    "source_hash": "f0e8a118"
+  },
+  "web.admin.emailtools.config.provider": {
+    "text": "Fournisseur de transport",
+    "source_hash": "4f0e5025"
+  },
+  "web.admin.emailtools.config.senderProvider": {
+    "text": "Fournisseur de l'expéditeur",
+    "source_hash": "e881964f"
+  },
+  "web.admin.emailtools.config.senderDiffers": {
+    "text": "L'expéditeur diffère du transport",
+    "source_hash": "ab78e8f6"
+  },
+  "web.admin.emailtools.config.autoDetected": {
+    "text": "Détecté automatiquement",
+    "source_hash": "a69c7f9e"
+  },
+  "web.admin.emailtools.config.fromAddress": {
+    "text": "Adresse de l'expéditeur",
+    "source_hash": "d465bcfa"
+  },
+  "web.admin.emailtools.config.fromName": {
+    "text": "Nom de l'expéditeur",
+    "source_hash": "b28f93ea"
+  },
+  "web.admin.emailtools.config.host": {
+    "text": "Hôte SMTP",
+    "source_hash": "ab328f83"
+  },
+  "web.admin.emailtools.config.port": {
+    "text": "Port",
+    "source_hash": "72e9a59f"
+  },
+  "web.admin.emailtools.config.region": {
+    "text": "Région",
+    "source_hash": "d3a008ef"
+  },
+  "web.admin.emailtools.config.hasCredentials": {
+    "text": "Identifiants configurés",
+    "source_hash": "1c81633a"
+  },
+  "web.admin.emailtools.config.yes": {
+    "text": "Oui",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.emailtools.config.no": {
+    "text": "Non",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.emailtools.config.loggerWarning": {
+    "text": "Les courriels ne sont pas livrés. Le fournisseur de transport est réglé sur un mode sans envoi (journal, désactivé ou aucun) ; aucun courriel ne quitte donc ce serveur — les messages sortants sont écrits dans le journal de l'application ou abandonnés.",
+    "source_hash": "1883dfd5"
+  },
+  "web.admin.emailtools.deliverability.title": {
+    "text": "Délivrabilité",
+    "source_hash": "66b4d300"
+  },
+  "web.admin.emailtools.deliverability.description": {
+    "text": "Ce qui revient après l'envoi : rebonds, plaintes et la liste de suppression qui protège votre réputation d'expéditeur.",
+    "source_hash": "e8363bb5"
+  },
+  "web.admin.emailtools.deliverability.retry": {
+    "text": "Réessayer",
+    "source_hash": "942087cc"
+  },
+  "web.admin.emailtools.deliverability.events.title": {
+    "text": "Événements récents",
+    "source_hash": "8ecce94d"
+  },
+  "web.admin.emailtools.deliverability.events.description": {
+    "text": "Le flux brut des rebonds et des plaintes, les plus récents en premier.",
+    "source_hash": "0e7a533b"
+  },
+  "web.admin.emailtools.deliverability.events.empty": {
+    "text": "Aucune donnée de rebond ou de plainte pour l'instant. Transmettez les retours de votre ESP au moyen de POST /api/colonel/email/deliverability/events (authentifié colonel — voir la documentation du point de terminaison pour le format des enregistrements). Les rebonds durs SMTP synchrones sont enregistrés automatiquement.",
+    "source_hash": "a90f259c"
+  },
+  "web.admin.emailtools.deliverability.events.loadError": {
+    "text": "Impossible de charger les événements récents.",
+    "source_hash": "02244c61"
+  },
+  "web.admin.emailtools.deliverability.events.columns.time": {
+    "text": "Heure",
+    "source_hash": "33b93476"
+  },
+  "web.admin.emailtools.deliverability.events.columns.kind": {
+    "text": "Type",
+    "source_hash": "baaddf70"
+  },
+  "web.admin.emailtools.deliverability.events.columns.address": {
+    "text": "Adresse",
+    "source_hash": "56ef8f20"
+  },
+  "web.admin.emailtools.deliverability.events.columns.source": {
+    "text": "Source",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.emailtools.deliverability.events.columns.reason": {
+    "text": "Motif",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.emailtools.deliverability.events.kinds.bounce": {
+    "text": "rebond",
+    "source_hash": "4d6723e5"
+  },
+  "web.admin.emailtools.deliverability.events.kinds.complaint": {
+    "text": "plainte",
+    "source_hash": "5d08b02d"
+  },
+  "web.admin.emailtools.deliverability.lookup.title": {
+    "text": "Recherche de destinataire",
+    "source_hash": "7569985b"
+  },
+  "web.admin.emailtools.deliverability.lookup.description": {
+    "text": "Vérifiez si une adresse est supprimée, à la fois dans le magasin local et en direct chez le fournisseur de messagerie actif. Les deux sont indexés par la même adresse normalisée.",
+    "source_hash": "c341d614"
+  },
+  "web.admin.emailtools.deliverability.lookup.addressLabel": {
+    "text": "Adresse du destinataire",
+    "source_hash": "454d0391"
+  },
+  "web.admin.emailtools.deliverability.lookup.submit": {
+    "text": "Rechercher",
+    "source_hash": "504101bc"
+  },
+  "web.admin.emailtools.deliverability.lookup.local": {
+    "text": "Magasin local",
+    "source_hash": "c740d116"
+  },
+  "web.admin.emailtools.deliverability.lookup.provider": {
+    "text": "Fournisseur",
+    "source_hash": "472590ae"
+  },
+  "web.admin.emailtools.deliverability.lookup.suppressed": {
+    "text": "Supprimée",
+    "source_hash": "435c7831"
+  },
+  "web.admin.emailtools.deliverability.lookup.notSuppressed": {
+    "text": "Non supprimée",
+    "source_hash": "7b1544d7"
+  },
+  "web.admin.emailtools.deliverability.lookup.reason": {
+    "text": "Motif",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.emailtools.deliverability.lookup.source": {
+    "text": "Source",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.emailtools.deliverability.lookup.unavailable": {
+    "text": "La recherche en direct chez le fournisseur est indisponible ; le magasin local ci-dessus fait autorité.",
+    "source_hash": "aebed0f2"
+  },
+  "web.admin.emailtools.deliverability.messages.title": {
+    "text": "Envois récents",
+    "source_hash": "522e089e"
+  },
+  "web.admin.emailtools.deliverability.messages.description": {
+    "text": "Les messages les plus récents que le fournisseur de messagerie actif a enregistrés, les plus récents en premier. Provenant en direct du fournisseur — jamais stockés ici.",
+    "source_hash": "9970fa0a"
+  },
+  "web.admin.emailtools.deliverability.messages.empty": {
+    "text": "Aucun message récent renvoyé par le fournisseur.",
+    "source_hash": "a7ef4d79"
+  },
+  "web.admin.emailtools.deliverability.messages.notSupported": {
+    "text": "Un journal d'envoi n'est pas disponible sur le transport {provider}, qui n'offre aucune API par message.",
+    "source_hash": "21e6b6f9"
+  },
+  "web.admin.emailtools.deliverability.messages.error": {
+    "text": "Impossible de charger le journal d'envoi depuis le fournisseur. Réessayez.",
+    "source_hash": "4f671e55"
+  },
+  "web.admin.emailtools.deliverability.messages.col.status": {
+    "text": "État",
+    "source_hash": "920e413c"
+  },
+  "web.admin.emailtools.deliverability.messages.col.subject": {
+    "text": "Objet",
+    "source_hash": "68971283"
+  },
+  "web.admin.emailtools.deliverability.messages.col.to": {
+    "text": "À",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.emailtools.deliverability.messages.col.created": {
+    "text": "Envoyé",
+    "source_hash": "c16bc82b"
+  },
+  "web.admin.emailtools.deliverability.messages.status.delivered": {
+    "text": "livré",
+    "source_hash": "373e0712"
+  },
+  "web.admin.emailtools.deliverability.messages.status.opened": {
+    "text": "ouvert",
+    "source_hash": "50236627"
+  },
+  "web.admin.emailtools.deliverability.messages.status.clicked": {
+    "text": "cliqué",
+    "source_hash": "d66440b2"
+  },
+  "web.admin.emailtools.deliverability.messages.status.pending": {
+    "text": "en attente",
+    "source_hash": "62a2fed3"
+  },
+  "web.admin.emailtools.deliverability.messages.status.queued": {
+    "text": "en file d'attente",
+    "source_hash": "d36be649"
+  },
+  "web.admin.emailtools.deliverability.messages.status.processed": {
+    "text": "traité",
+    "source_hash": "58190ffa"
+  },
+  "web.admin.emailtools.deliverability.messages.status.hard_bounced": {
+    "text": "rebond dur",
+    "source_hash": "b0aa6fd4"
+  },
+  "web.admin.emailtools.deliverability.messages.status.soft_bounced": {
+    "text": "rebond souple",
+    "source_hash": "ac844ff2"
+  },
+  "web.admin.emailtools.deliverability.messages.status.complained": {
+    "text": "plainte déposée",
+    "source_hash": "c26fe786"
+  },
+  "web.admin.emailtools.deliverability.messages.status.suppressed": {
+    "text": "supprimé",
+    "source_hash": "f63d5b6b"
+  },
+  "web.admin.emailtools.deliverability.messages.status.unsubscribed": {
+    "text": "désabonné",
+    "source_hash": "621e1970"
+  },
+  "web.admin.emailtools.deliverability.summary.loadError": {
+    "text": "Impossible de charger le résumé de délivrabilité.",
+    "source_hash": "0c16ef96"
+  },
+  "web.admin.emailtools.deliverability.suppressions.title": {
+    "text": "Liste de suppression",
+    "source_hash": "9f3e322f"
+  },
+  "web.admin.emailtools.deliverability.suppressions.description": {
+    "text": "Adresses que le courrier sortant ignore. Les entrées proviennent de l'ingestion des retours des ESP ou d'une importation manuelle ; en retirer une reprend la livraison.",
+    "source_hash": "3651887e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.searchLabel": {
+    "text": "Adresse exacte",
+    "source_hash": "f4338ff8"
+  },
+  "web.admin.emailtools.deliverability.suppressions.searchPlaceholder": {
+    "text": "utilisateur{'@'}example.com",
+    "source_hash": "333f0f15"
+  },
+  "web.admin.emailtools.deliverability.suppressions.searchButton": {
+    "text": "Rechercher",
+    "source_hash": "504101bc"
+  },
+  "web.admin.emailtools.deliverability.suppressions.clearButton": {
+    "text": "Effacer",
+    "source_hash": "83b12c22"
+  },
+  "web.admin.emailtools.deliverability.suppressions.empty": {
+    "text": "Aucune adresse supprimée pour l'instant. Elles apparaîtront ici à mesure que les retours de rebonds et de plaintes seront ingérés.",
+    "source_hash": "dd3f4d61"
+  },
+  "web.admin.emailtools.deliverability.suppressions.emptySearch": {
+    "text": "Aucune entrée de suppression pour {address}.",
+    "source_hash": "200c361e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.loadError": {
+    "text": "Impossible de charger la liste de suppression.",
+    "source_hash": "2a12c8ba"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.addressLabel": {
+    "text": "Ajouter une adresse",
+    "source_hash": "8be5aa33"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.button": {
+    "text": "Supprimer",
+    "source_hash": "60b19987"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.confirmTitle": {
+    "text": "Supprimer cette adresse ?",
+    "source_hash": "40a0d2a6"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.confirmDescription": {
+    "text": "Le courrier sortant vers {address} sera ignoré jusqu'à ce que la suppression soit retirée. Ceci est enregistré comme une entrée manuelle.",
+    "source_hash": "e3d0d799"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.success": {
+    "text": "Adresse {address} supprimée.",
+    "source_hash": "e2cd2c3b"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.successExisting": {
+    "text": "L'adresse {address} était déjà supprimée ; l'entrée a été mise à jour.",
+    "source_hash": "0852101e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.error": {
+    "text": "Impossible de supprimer l'adresse.",
+    "source_hash": "dad9e000"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.address": {
+    "text": "Adresse",
+    "source_hash": "56ef8f20"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.reason": {
+    "text": "Motif",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.source": {
+    "text": "Source",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.added": {
+    "text": "Ajoutée",
+    "source_hash": "6b02e0d3"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.actions": {
+    "text": "Actions",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.button": {
+    "text": "Retirer",
+    "source_hash": "c3812fc4"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.confirmTitle": {
+    "text": "Retirer cette suppression ?",
+    "source_hash": "0b0aec2e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.confirmDescription": {
+    "text": "Le courrier sortant vers {address} reprendra. Cette adresse a précédemment rebondi ou fait l'objet d'une plainte — ne la retirez que si vous savez qu'elle est de nouveau livrable.",
+    "source_hash": "09442f9c"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.success": {
+    "text": "Suppression retirée pour {address}.",
+    "source_hash": "bfc0de36"
+  },
+  "web.admin.emailtools.deliverability.sync.title": {
+    "text": "Synchronisation des retours",
+    "source_hash": "d4056915"
+  },
+  "web.admin.emailtools.deliverability.sync.lastSynced": {
+    "text": "dernière synchronisation",
+    "source_hash": "5a99666b"
+  },
+  "web.admin.emailtools.deliverability.sync.imported": {
+    "text": "{count} importés",
+    "source_hash": "1bc18c45"
+  },
+  "web.admin.emailtools.deliverability.sync.neverRun": {
+    "text": "La synchronisation des retours du fournisseur n'a jamais été exécutée. Les données de rebonds et de plaintes ne sont pas importées automatiquement — configurez une synchronisation du fournisseur ou ingérez les retours au moyen du point de terminaison des événements.",
+    "source_hash": "d19f5755"
+  },
+  "web.admin.emailtools.deliverability.sync.button": {
+    "text": "Synchroniser maintenant",
+    "source_hash": "885e8f48"
+  },
+  "web.admin.emailtools.deliverability.sync.success": {
+    "text": "Synchronisation de {provider} terminée : {accepted} importés, {rejected} rejetés ({fetched} récupérés).",
+    "source_hash": "d36f5578"
+  },
+  "web.admin.emailtools.deliverability.sync.hint": {
+    "text": "Une synchronisation manuelle — l'importation automatique nécessite toujours une tâche cron `ots email sync-feedback` planifiée.",
+    "source_hash": "7a509b75"
+  },
+  "web.admin.emailtools.deliverability.tiles.suppressed": {
+    "text": "Adresses supprimées",
+    "source_hash": "b31a245e"
+  },
+  "web.admin.emailtools.deliverability.tiles.bounces": {
+    "text": "Rebonds ({days} j)",
+    "source_hash": "3a4d0f09"
+  },
+  "web.admin.emailtools.deliverability.tiles.complaints": {
+    "text": "Plaintes ({days} j)",
+    "source_hash": "16ad856f"
+  },
+  "web.admin.emailtools.deliverability.tiles.skipped": {
+    "text": "Envois ignorés",
+    "source_hash": "391467f9"
+  },
+  "web.admin.emailtools.preview.title": {
+    "text": "Aperçu du modèle",
+    "source_hash": "df89bd92"
+  },
+  "web.admin.emailtools.preview.description": {
+    "text": "Générez un modèle avec ses données d'exemple. L'aperçu n'a aucun effet secondaire — aucun courriel n'est envoyé.",
+    "source_hash": "9b0e40f3"
+  },
+  "web.admin.emailtools.preview.templateLabel": {
+    "text": "Modèle",
+    "source_hash": "0575f29d"
+  },
+  "web.admin.emailtools.preview.formatLabel": {
+    "text": "Format",
+    "source_hash": "2f343666"
+  },
+  "web.admin.emailtools.preview.localeLabel": {
+    "text": "Langue",
+    "source_hash": "ca3dc612"
+  },
+  "web.admin.emailtools.preview.button": {
+    "text": "Aperçu",
+    "source_hash": "324b134f"
+  },
+  "web.admin.emailtools.providerStatus.title": {
+    "text": "État du fournisseur",
+    "source_hash": "231b7f03"
+  },
+  "web.admin.emailtools.providerStatus.rateUnavailable": {
+    "text": "Ce fournisseur n'expose aucun taux numérique de rebond ou de plainte ; le niveau de réputation ci-dessus est dérivé uniquement de l'état d'application et du quota d'envoi.",
+    "source_hash": "1e6b82e9"
+  },
+  "web.admin.emailtools.providerStatus.complaintsUnavailable": {
+    "text": "Lettermint ne signale pas les plaintes dans son API de statistiques ; le taux de plaintes est donc affiché comme « — » (non signalé), et non zéro. Le taux de rebond ci-dessus est complet.",
+    "source_hash": "72aaa845"
+  },
+  "web.admin.emailtools.providerStatus.unavailable": {
+    "text": "L'état du fournisseur est temporairement indisponible.",
+    "source_hash": "8e69ff29"
+  },
+  "web.admin.emailtools.providerStatus.notSupported": {
+    "text": "L'état en direct du fournisseur n'est pas disponible sur le transport {provider}.",
+    "source_hash": "125ed6eb"
+  },
+  "web.admin.emailtools.providerStatus.error": {
+    "text": "Impossible de joindre le fournisseur de messagerie pour obtenir l'état. Réessayez.",
+    "source_hash": "594ab7b1"
+  },
+  "web.admin.emailtools.providerStatus.quota.max24h": {
+    "text": "Limite d'envoi sur 24 h",
+    "source_hash": "e5ea4c3d"
+  },
+  "web.admin.emailtools.providerStatus.quota.sent24h": {
+    "text": "Envoyés (dernières 24 h)",
+    "source_hash": "d0c4fe45"
+  },
+  "web.admin.emailtools.providerStatus.quota.maxRate": {
+    "text": "Débit d'envoi max (par sec)",
+    "source_hash": "59e76cf8"
+  },
+  "web.admin.emailtools.providerStatus.rate.bounce": {
+    "text": "Taux de rebond",
+    "source_hash": "9eba32f0"
+  },
+  "web.admin.emailtools.providerStatus.rate.complaint": {
+    "text": "Taux de plaintes",
+    "source_hash": "430a23a9"
+  },
+  "web.admin.emailtools.providerStatus.stats.sent": {
+    "text": "Envoyés ({days} j)",
+    "source_hash": "e553b7e1"
+  },
+  "web.admin.emailtools.providerStatus.stats.delivered": {
+    "text": "Livrés",
+    "source_hash": "90611565"
+  },
+  "web.admin.emailtools.providerStatus.stats.hardBounced": {
+    "text": "Rebonds durs",
+    "source_hash": "c76631c0"
+  },
+  "web.admin.emailtools.providerStatus.stats.complaints": {
+    "text": "Plaintes pour pourriel",
+    "source_hash": "d48953cd"
+  },
+  "web.admin.emailtools.providerStatus.tier.healthy": {
+    "text": "En bonne santé",
+    "source_hash": "7f1e323b"
+  },
+  "web.admin.emailtools.providerStatus.tier.probation": {
+    "text": "En cours d'examen",
+    "source_hash": "9e8a3b64"
+  },
+  "web.admin.emailtools.providerStatus.tier.shutdown": {
+    "text": "Envoi suspendu",
+    "source_hash": "52e6757c"
+  },
+  "web.admin.emailtools.test.title": {
+    "text": "Envoi de test",
+    "source_hash": "5fab5d67"
+  },
+  "web.admin.emailtools.test.description": {
+    "text": "Envoyez un courriel de diagnostic en texte brut pour vérifier la connectivité de livraison. Prévisualisez-le d'abord, puis confirmez pour envoyer un vrai courriel.",
+    "source_hash": "4130741c"
+  },
+  "web.admin.emailtools.test.toLabel": {
+    "text": "Destinataire",
+    "source_hash": "51fac985"
+  },
+  "web.admin.emailtools.test.toPlaceholder": {
+    "text": "vous{'@'}example.com",
+    "source_hash": "cf0a9acc"
+  },
+  "web.admin.emailtools.test.enqueueLabel": {
+    "text": "Via la file d'attente des travailleurs",
+    "source_hash": "97897017"
+  },
+  "web.admin.emailtools.test.previewButton": {
+    "text": "Aperçu (sans envoi)",
+    "source_hash": "747ced83"
+  },
+  "web.admin.emailtools.test.sendButton": {
+    "text": "Envoyer un courriel de test",
+    "source_hash": "46ebd7db"
+  },
+  "web.admin.emailtools.test.provider": {
+    "text": "Fournisseur",
+    "source_hash": "472590ae"
+  },
+  "web.admin.emailtools.test.host": {
+    "text": "Hôte d'origine",
+    "source_hash": "968925cb"
+  },
+  "web.admin.emailtools.test.from": {
+    "text": "De",
+    "source_hash": "21819769"
+  },
+  "web.admin.emailtools.test.subject": {
+    "text": "Objet",
+    "source_hash": "68971283"
+  },
+  "web.admin.emailtools.test.confirmTitle": {
+    "text": "Envoyer un vrai courriel de test ?",
+    "source_hash": "64a16b62"
+  },
+  "web.admin.emailtools.test.confirmDescription": {
+    "text": "Cela envoie un courriel réel à {to} au moyen du logiciel de messagerie configuré.",
+    "source_hash": "10114929"
+  },
+  "web.admin.emailtools.test.success": {
+    "text": "Courriel de test envoyé à {to}.",
+    "source_hash": "daa61a62"
+  }
+}

--- a/locales/content/fr_CA/admin-kit.json
+++ b/locales/content/fr_CA/admin-kit.json
@@ -1,0 +1,66 @@
+{
+  "web.admin.kit.confirmDialog.typePrompt": {
+    "text": "Pour confirmer, saisissez {token} ci-dessous",
+    "source_hash": "282445b6"
+  },
+  "web.admin.kit.confirmDialog.inputLabel": {
+    "text": "Texte de confirmation",
+    "source_hash": "8edc1113"
+  },
+  "web.admin.kit.confirmDialog.mismatchHint": {
+    "text": "Le texte saisi doit correspondre exactement pour continuer.",
+    "source_hash": "f0cc7389"
+  },
+  "web.admin.kit.dataTable.empty": {
+    "text": "Aucun enregistrement trouvé",
+    "source_hash": "6e2ea637"
+  },
+  "web.admin.kit.dataTable.sortBy": {
+    "text": "Trier par {column}",
+    "source_hash": "55fb1bf9"
+  },
+  "web.admin.kit.filterBar.search": {
+    "text": "Rechercher",
+    "source_hash": "49c266ba"
+  },
+  "web.admin.kit.filterBar.searchPlaceholder": {
+    "text": "Rechercher…",
+    "source_hash": "7336265a"
+  },
+  "web.admin.kit.filterBar.clearFilters": {
+    "text": "Effacer les filtres",
+    "source_hash": "7179ea00"
+  },
+  "web.admin.kit.filterBar.all": {
+    "text": "Tous",
+    "source_hash": "a52ace42"
+  },
+  "web.admin.kit.jsonViewer.expandAll": {
+    "text": "Tout développer",
+    "source_hash": "a3e586be"
+  },
+  "web.admin.kit.jsonViewer.collapseAll": {
+    "text": "Tout réduire",
+    "source_hash": "25f7b372"
+  },
+  "web.admin.kit.jsonViewer.empty": {
+    "text": "Aucune donnée",
+    "source_hash": "3b41ba9c"
+  },
+  "web.admin.kit.jsonViewer.copyLabel": {
+    "text": "Copier le JSON",
+    "source_hash": "7708c6e2"
+  },
+  "web.admin.kit.revealEmail.reveal": {
+    "text": "Révéler l'adresse courriel",
+    "source_hash": "f6272277"
+  },
+  "web.admin.kit.revealEmail.hide": {
+    "text": "Masquer l'adresse courriel",
+    "source_hash": "9755e870"
+  },
+  "web.admin.kit.revealEmail.copy": {
+    "text": "Copier l'adresse courriel",
+    "source_hash": "61b94846"
+  }
+}

--- a/locales/content/fr_CA/admin-organizations.json
+++ b/locales/content/fr_CA/admin-organizations.json
@@ -1,0 +1,314 @@
+{
+  "web.admin.organizations.retry": {
+    "text": "Réessayer",
+    "source_hash": "942087cc"
+  },
+  "web.admin.organizations.detail.backToList": {
+    "text": "Retour aux organisations",
+    "source_hash": "2257dc4a"
+  },
+  "web.admin.organizations.detail.notFound": {
+    "text": "Organisation introuvable",
+    "source_hash": "00c50f7a"
+  },
+  "web.admin.organizations.detail.notFoundDescription": {
+    "text": "Cette organisation a peut-être été supprimée, ou l'id est incorrect.",
+    "source_hash": "e5459ef5"
+  },
+  "web.admin.organizations.detail.loadError": {
+    "text": "Impossible de charger cette organisation.",
+    "source_hash": "9df8ad50"
+  },
+  "web.admin.organizations.detail.none": {
+    "text": "—",
+    "source_hash": "bda05058"
+  },
+  "web.admin.organizations.detail.badges.default": {
+    "text": "Espace de travail par défaut",
+    "source_hash": "6d67c6eb"
+  },
+  "web.admin.organizations.detail.badges.archived": {
+    "text": "Archivé",
+    "source_hash": "bdb86505"
+  },
+  "web.admin.organizations.detail.domains.domain": {
+    "text": "Domaine",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.organizations.detail.domains.state": {
+    "text": "État",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.organizations.detail.domains.created": {
+    "text": "Créé",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.organizations.detail.domains.ready": {
+    "text": "Prêt",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.organizations.detail.domains.resolving": {
+    "text": "En cours de résolution",
+    "source_hash": "3287a034"
+  },
+  "web.admin.organizations.detail.domains.empty": {
+    "text": "Aucun domaine.",
+    "source_hash": "1b840c7e"
+  },
+  "web.admin.organizations.detail.entitlements.description": {
+    "text": "Les droits effectifs se résolvent en (forfait ∪ octrois) − révocations. Examinez la ventilation avant d'effectuer une dérogation.",
+    "source_hash": "23080475"
+  },
+  "web.admin.organizations.detail.entitlements.inSync": {
+    "text": "Synchronisé",
+    "source_hash": "5701958c"
+  },
+  "web.admin.organizations.detail.entitlements.driftBadge": {
+    "text": "Écart",
+    "source_hash": "8b4c8240"
+  },
+  "web.admin.organizations.detail.entitlements.staleBadge": {
+    "text": "Forfait obsolète",
+    "source_hash": "ffe63800"
+  },
+  "web.admin.organizations.detail.entitlements.driftWarning": {
+    "text": "Les droits matérialisés ne correspondent pas à l'ensemble attendu. Réconciliez pour rematérialiser.",
+    "source_hash": "4859983a"
+  },
+  "web.admin.organizations.detail.entitlements.driftExtra": {
+    "text": "En trop (matérialisé, non attendu)",
+    "source_hash": "08d60730"
+  },
+  "web.admin.organizations.detail.entitlements.driftMissing": {
+    "text": "Manquant (attendu, non matérialisé)",
+    "source_hash": "fe12c83a"
+  },
+  "web.admin.organizations.detail.entitlements.plan": {
+    "text": "Du forfait",
+    "source_hash": "1d346b26"
+  },
+  "web.admin.organizations.detail.entitlements.materialized": {
+    "text": "Matérialisés (effectifs)",
+    "source_hash": "72ca5f45"
+  },
+  "web.admin.organizations.detail.members.email": {
+    "text": "Membre",
+    "source_hash": "7c968fb7"
+  },
+  "web.admin.organizations.detail.members.role": {
+    "text": "Rôle",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.organizations.detail.members.status": {
+    "text": "État",
+    "source_hash": "920e413c"
+  },
+  "web.admin.organizations.detail.members.joined": {
+    "text": "Adhésion",
+    "source_hash": "69318b0c"
+  },
+  "web.admin.organizations.detail.members.owner": {
+    "text": "Propriétaire",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.detail.members.empty": {
+    "text": "Aucun membre.",
+    "source_hash": "b99c59dc"
+  },
+  "web.admin.organizations.detail.reconcile.button": {
+    "text": "Réconcilier",
+    "source_hash": "b59be565"
+  },
+  "web.admin.organizations.detail.reconcile.confirmTitle": {
+    "text": "Réconcilier la facturation de l'organisation ?",
+    "source_hash": "fc1a2762"
+  },
+  "web.admin.organizations.detail.reconcile.confirmDescription": {
+    "text": "Cela récupère de nouveau les données de Stripe et réécrit l'état de facturation et les droits pour {org}. Saisissez de nouveau l'id de l'organisation pour confirmer.",
+    "source_hash": "b4ef0850"
+  },
+  "web.admin.organizations.detail.reconcile.success": {
+    "text": "Organisation réconciliée.",
+    "source_hash": "caf87844"
+  },
+  "web.admin.organizations.detail.reconcile.resultTitle": {
+    "text": "Résultat de la réconciliation",
+    "source_hash": "11f4c6b8"
+  },
+  "web.admin.organizations.detail.reconcile.before": {
+    "text": "Avant",
+    "source_hash": "9bb72500"
+  },
+  "web.admin.organizations.detail.reconcile.after": {
+    "text": "Après",
+    "source_hash": "7b68fe55"
+  },
+  "web.admin.organizations.detail.reconcile.materializedCount": {
+    "text": "Nombre de droits",
+    "source_hash": "59cede5c"
+  },
+  "web.admin.organizations.detail.reconcile.mode.stripe_sync": {
+    "text": "Synchronisation Stripe",
+    "source_hash": "02f9546c"
+  },
+  "web.admin.organizations.detail.reconcile.mode.entitlements_only": {
+    "text": "Droits seulement",
+    "source_hash": "8cf49a5d"
+  },
+  "web.admin.organizations.detail.sections.billing": {
+    "text": "Facturation",
+    "source_hash": "3ac8bbca"
+  },
+  "web.admin.organizations.detail.sections.members": {
+    "text": "Membres",
+    "source_hash": "1044a4c0"
+  },
+  "web.admin.organizations.detail.sections.domains": {
+    "text": "Domaines",
+    "source_hash": "ced67718"
+  },
+  "web.admin.organizations.detail.sections.investigate": {
+    "text": "Enquêter et réconcilier",
+    "source_hash": "b05aa349"
+  },
+  "web.admin.organizations.entitlements.section": {
+    "text": "Dérogations de droits",
+    "source_hash": "48812068"
+  },
+  "web.admin.organizations.entitlements.description": {
+    "text": "Octroyez ou révoquez des droits indépendamment du forfait. Effectifs = droits du forfait + octrois - révocations.",
+    "source_hash": "4c38425b"
+  },
+  "web.admin.organizations.entitlements.inputLabel": {
+    "text": "Droit",
+    "source_hash": "0d8f0b2d"
+  },
+  "web.admin.organizations.entitlements.placeholder": {
+    "text": "p. ex. custom_domains",
+    "source_hash": "05346c68"
+  },
+  "web.admin.organizations.entitlements.grant": {
+    "text": "Octroyer",
+    "source_hash": "78b7d037"
+  },
+  "web.admin.organizations.entitlements.revoke": {
+    "text": "Révoquer",
+    "source_hash": "87e6d00b"
+  },
+  "web.admin.organizations.entitlements.clear": {
+    "text": "Effacer toutes les dérogations",
+    "source_hash": "f0e485c3"
+  },
+  "web.admin.organizations.entitlements.effective": {
+    "text": "Droits effectifs",
+    "source_hash": "b840f8c8"
+  },
+  "web.admin.organizations.entitlements.grants": {
+    "text": "Octrois",
+    "source_hash": "b3e1c95a"
+  },
+  "web.admin.organizations.entitlements.revokes": {
+    "text": "Révocations",
+    "source_hash": "f0e69b17"
+  },
+  "web.admin.organizations.entitlements.noOverrides": {
+    "text": "Effectuez une action pour afficher l'état actuel des dérogations de cette organisation.",
+    "source_hash": "98d2e30d"
+  },
+  "web.admin.organizations.entitlements.confirm.grantTitle": {
+    "text": "Octroyer le droit ?",
+    "source_hash": "a4b2c57b"
+  },
+  "web.admin.organizations.entitlements.confirm.grantDescription": {
+    "text": "Octroyer « {entitlement} » à {org}. Cela modifie les droits de facturation de l'organisation.",
+    "source_hash": "542ce26a"
+  },
+  "web.admin.organizations.entitlements.confirm.revokeTitle": {
+    "text": "Révoquer le droit ?",
+    "source_hash": "c93d520a"
+  },
+  "web.admin.organizations.entitlements.confirm.revokeDescription": {
+    "text": "Révoquer « {entitlement} » de {org}. Cela modifie les droits de facturation de l'organisation.",
+    "source_hash": "a5d2a8a6"
+  },
+  "web.admin.organizations.entitlements.confirm.clearTitle": {
+    "text": "Effacer toutes les dérogations de droits ?",
+    "source_hash": "e36eb218"
+  },
+  "web.admin.organizations.entitlements.confirm.clearDescription": {
+    "text": "Retirer toutes les dérogations d'octroi et de révocation pour {org}, la réinitialisant aux droits de son forfait.",
+    "source_hash": "96bad079"
+  },
+  "web.admin.organizations.entitlements.success.granted": {
+    "text": "Droit « {entitlement} » octroyé.",
+    "source_hash": "cf52fb0e"
+  },
+  "web.admin.organizations.entitlements.success.revoked": {
+    "text": "Droit « {entitlement} » révoqué.",
+    "source_hash": "279d425d"
+  },
+  "web.admin.organizations.entitlements.success.cleared": {
+    "text": "Toutes les dérogations de droits ont été effacées.",
+    "source_hash": "a482743b"
+  },
+  "web.admin.organizations.fields.contactEmail": {
+    "text": "Courriel de contact",
+    "source_hash": "6d7fce11"
+  },
+  "web.admin.organizations.fields.owner": {
+    "text": "Propriétaire",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.fields.plan": {
+    "text": "Forfait",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.organizations.fields.subscription": {
+    "text": "État de l'abonnement",
+    "source_hash": "f0723c4e"
+  },
+  "web.admin.organizations.fields.periodEnd": {
+    "text": "Fin de la période",
+    "source_hash": "eeae9fdd"
+  },
+  "web.admin.organizations.fields.billingEmail": {
+    "text": "Courriel de facturation",
+    "source_hash": "8805b928"
+  },
+  "web.admin.organizations.fields.stripeCustomer": {
+    "text": "Client Stripe",
+    "source_hash": "8f169be1"
+  },
+  "web.admin.organizations.fields.stripeSubscription": {
+    "text": "Abonnement Stripe",
+    "source_hash": "53f71e08"
+  },
+  "web.admin.organizations.fields.orgId": {
+    "text": "ID de l'organisation",
+    "source_hash": "1f466322"
+  },
+  "web.admin.organizations.fields.created": {
+    "text": "Créé",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.organizations.fields.updated": {
+    "text": "Mis à jour",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.organizations.investigate.description": {
+    "text": "Comparez l'état de facturation local à l'abonnement Stripe en direct.",
+    "source_hash": "d7bbe9ed"
+  },
+  "web.admin.organizations.investigate.rawPayload": {
+    "text": "Charge utile d'enquête brute",
+    "source_hash": "29ca7df2"
+  },
+  "web.admin.organizations.investigate.parseError": {
+    "text": "La réponse de l'enquête ne correspond pas au format attendu.",
+    "source_hash": "db59cab1"
+  },
+  "web.admin.organizations.list.loadError": {
+    "text": "Impossible de charger les organisations.",
+    "source_hash": "130d5e70"
+  }
+}

--- a/locales/content/fr_CA/admin-overview.json
+++ b/locales/content/fr_CA/admin-overview.json
@@ -1,0 +1,94 @@
+{
+  "web.admin.overview.retry": {
+    "text": "Réessayer",
+    "source_hash": "942087cc"
+  },
+  "web.admin.overview.feedback.title": {
+    "text": "Commentaires des utilisateurs",
+    "source_hash": "cb7b24c6"
+  },
+  "web.admin.overview.feedback.total": {
+    "text": "{count} au cours des 30 derniers jours",
+    "source_hash": "b6b9147c"
+  },
+  "web.admin.overview.feedback.today": {
+    "text": "Aujourd'hui",
+    "source_hash": "2b065c7c"
+  },
+  "web.admin.overview.feedback.yesterday": {
+    "text": "Hier",
+    "source_hash": "56618125"
+  },
+  "web.admin.overview.feedback.older": {
+    "text": "Plus anciens",
+    "source_hash": "03281c88"
+  },
+  "web.admin.overview.feedback.empty": {
+    "text": "Aucun commentaire pour cette période",
+    "source_hash": "e09d594d"
+  },
+  "web.admin.overview.feedback.loadError": {
+    "text": "Impossible de charger les commentaires.",
+    "source_hash": "4011c408"
+  },
+  "web.admin.overview.stats.heading": {
+    "text": "Statistiques de la plateforme",
+    "source_hash": "77728e4d"
+  },
+  "web.admin.overview.stats.customers": {
+    "text": "Clients",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.overview.stats.secrets": {
+    "text": "Secrets actifs",
+    "source_hash": "8db4c552"
+  },
+  "web.admin.overview.stats.sessions": {
+    "text": "Sessions actives",
+    "source_hash": "61ad9909"
+  },
+  "web.admin.overview.stats.receipts": {
+    "text": "Reçus",
+    "source_hash": "60a627df"
+  },
+  "web.admin.overview.stats.secretsCreated": {
+    "text": "Secrets créés (à vie)",
+    "source_hash": "bdb49794"
+  },
+  "web.admin.overview.stats.emailsSent": {
+    "text": "Courriels envoyés (à vie)",
+    "source_hash": "1c9a7518"
+  },
+  "web.admin.overview.stats.loadError": {
+    "text": "Impossible de charger les statistiques de la plateforme.",
+    "source_hash": "5f13cf7a"
+  },
+  "web.admin.overview.trends.title": {
+    "text": "30 derniers jours",
+    "source_hash": "f8f03fb4"
+  },
+  "web.admin.overview.trends.signups": {
+    "text": "Inscriptions par jour",
+    "source_hash": "8db399dc"
+  },
+  "web.admin.overview.trends.secretsCreated": {
+    "text": "Secrets créés par jour",
+    "source_hash": "d6852656"
+  },
+  "web.admin.overview.trends.today": {
+    "text": "aujourd'hui",
+    "source_hash": "e0f4f767"
+  },
+  "web.admin.overview.trends.collectingNote": {
+    "text": "Collecte depuis le premier point de données — les jours antérieurs affichent zéro.",
+    "source_hash": "269ee1eb"
+  },
+  "web.admin.overview.trends.sparklineAria": {
+    "text": "{label} : tendance sur 30 jours, {count} aujourd'hui",
+    "source_hash": "eb57a7b2"
+  },
+  "web.admin.overview.trends.loadError": {
+    "text": "Impossible de charger les tendances.",
+    "source_hash": "9cf97f63"
+  }
+}

--- a/locales/content/fr_CA/admin-secrets.json
+++ b/locales/content/fr_CA/admin-secrets.json
@@ -1,0 +1,218 @@
+{
+  "web.admin.secrets.title": {
+    "text": "Secrets",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.secrets.description": {
+    "text": "Inspectez le reçu d'un secret et supprimez-le sans SSH — recherchez-le par sa clé.",
+    "source_hash": "07775a11"
+  },
+  "web.admin.secrets.never": {
+    "text": "Jamais",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.secrets.anonymous": {
+    "text": "Anonyme",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.admin.secrets.ageDays": {
+    "text": "{days} jours",
+    "source_hash": "a2246fbc"
+  },
+  "web.admin.secrets.actions.delete.button": {
+    "text": "Supprimer le secret",
+    "source_hash": "1a48c8c8"
+  },
+  "web.admin.secrets.actions.delete.confirmTitle": {
+    "text": "Supprimer le secret ?",
+    "source_hash": "4a779a67"
+  },
+  "web.admin.secrets.actions.delete.confirmDescription": {
+    "text": "Cela supprime définitivement le secret {shortid} et son reçu. Cette action est irréversible.",
+    "source_hash": "51f807ad"
+  },
+  "web.admin.secrets.actions.delete.success": {
+    "text": "Secret supprimé.",
+    "source_hash": "52f1640f"
+  },
+  "web.admin.secrets.detail.yes": {
+    "text": "Oui",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.secrets.detail.no": {
+    "text": "Non",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.secrets.detail.none": {
+    "text": "Aucun",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.secrets.fields.secretId": {
+    "text": "ID du secret",
+    "source_hash": "79592419"
+  },
+  "web.admin.secrets.fields.shortId": {
+    "text": "ID court",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.secrets.fields.state": {
+    "text": "État",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.secrets.fields.created": {
+    "text": "Créé",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.secrets.fields.updated": {
+    "text": "Mis à jour",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.secrets.fields.expiration": {
+    "text": "Expiration",
+    "source_hash": "f38d6e0e"
+  },
+  "web.admin.secrets.fields.age": {
+    "text": "Âge",
+    "source_hash": "39b7370f"
+  },
+  "web.admin.secrets.fields.lifespan": {
+    "text": "Durée de vie",
+    "source_hash": "58994285"
+  },
+  "web.admin.secrets.fields.owner": {
+    "text": "Propriétaire",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.secrets.fields.receiptId": {
+    "text": "ID du reçu",
+    "source_hash": "2c13d799"
+  },
+  "web.admin.secrets.fields.hasCiphertext": {
+    "text": "Possède un texte chiffré",
+    "source_hash": "e9188bad"
+  },
+  "web.admin.secrets.fields.ciphertextLength": {
+    "text": "Longueur du texte chiffré",
+    "source_hash": "0f1744fd"
+  },
+  "web.admin.secrets.lookup.label": {
+    "text": "Clé du secret",
+    "source_hash": "f47a99eb"
+  },
+  "web.admin.secrets.lookup.placeholder": {
+    "text": "Identifiant du secret",
+    "source_hash": "cbcfd49f"
+  },
+  "web.admin.secrets.lookup.button": {
+    "text": "Rechercher",
+    "source_hash": "504101bc"
+  },
+  "web.admin.secrets.lookup.resultTitle": {
+    "text": "Secret {shortid}",
+    "source_hash": "8b311d32"
+  },
+  "web.admin.secrets.lookup.notFound": {
+    "text": "Secret introuvable",
+    "source_hash": "70a9532c"
+  },
+  "web.admin.secrets.lookup.notFoundDescription": {
+    "text": "Aucun secret n'existe avec cette clé. Il a peut-être expiré ou été supprimé.",
+    "source_hash": "9f068a81"
+  },
+  "web.admin.secrets.lookup.loadError": {
+    "text": "Impossible de charger ce secret.",
+    "source_hash": "c96672e4"
+  },
+  "web.admin.secrets.lookup.retry": {
+    "text": "Réessayer",
+    "source_hash": "942087cc"
+  },
+  "web.admin.secrets.owner.anonymous": {
+    "text": "Anonyme (sans propriétaire)",
+    "source_hash": "390f11ad"
+  },
+  "web.admin.secrets.ownerFields.email": {
+    "text": "Courriel",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.secrets.ownerFields.userId": {
+    "text": "ID de l'utilisateur",
+    "source_hash": "7967e089"
+  },
+  "web.admin.secrets.ownerFields.role": {
+    "text": "Rôle",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.secrets.ownerFields.verified": {
+    "text": "Vérifié",
+    "source_hash": "4f783840"
+  },
+  "web.admin.secrets.receipt.none": {
+    "text": "Aucun reçu n'est associé à ce secret.",
+    "source_hash": "5ddceaed"
+  },
+  "web.admin.secrets.receiptFields.receiptId": {
+    "text": "ID du reçu",
+    "source_hash": "2c13d799"
+  },
+  "web.admin.secrets.receiptFields.shortId": {
+    "text": "ID court",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.secrets.receiptFields.state": {
+    "text": "État",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.secrets.receiptFields.secretTtl": {
+    "text": "TTL du secret",
+    "source_hash": "b89c0b51"
+  },
+  "web.admin.secrets.receiptFields.recipients": {
+    "text": "Destinataires",
+    "source_hash": "1e8568a8"
+  },
+  "web.admin.secrets.receiptFields.hasPassphrase": {
+    "text": "Possède une phrase secrète",
+    "source_hash": "af458f26"
+  },
+  "web.admin.secrets.receiptFields.shareDomain": {
+    "text": "Domaine de partage",
+    "source_hash": "db963805"
+  },
+  "web.admin.secrets.receiptFields.created": {
+    "text": "Créé",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.secrets.receiptFields.secretExpired": {
+    "text": "Secret expiré",
+    "source_hash": "c127dab6"
+  },
+  "web.admin.secrets.sections.secret": {
+    "text": "Secret",
+    "source_hash": "7e32a729"
+  },
+  "web.admin.secrets.sections.receipt": {
+    "text": "Reçu",
+    "source_hash": "dad5a969"
+  },
+  "web.admin.secrets.sections.owner": {
+    "text": "Propriétaire",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.secrets.sections.raw": {
+    "text": "Brut",
+    "source_hash": "848123d1"
+  },
+  "web.admin.secrets.state.new": {
+    "text": "Nouveau",
+    "source_hash": "18fdd549"
+  },
+  "web.admin.secrets.state.received": {
+    "text": "Reçu",
+    "source_hash": "49f19bee"
+  },
+  "web.admin.secrets.state.viewed": {
+    "text": "Consulté",
+    "source_hash": "1b28d178"
+  }
+}

--- a/locales/content/fr_CA/admin-sessions.json
+++ b/locales/content/fr_CA/admin-sessions.json
@@ -1,0 +1,210 @@
+{
+  "web.admin.sessions.title": {
+    "text": "Sessions",
+    "source_hash": "6fa3cbf4"
+  },
+  "web.admin.sessions.description": {
+    "text": "Inspectez, recherchez et révoquez les sessions actives pour la réponse aux incidents.",
+    "source_hash": "784a3a44"
+  },
+  "web.admin.sessions.anonymous": {
+    "text": "Anonyme",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.admin.sessions.columns.sessionId": {
+    "text": "ID de session",
+    "source_hash": "cb9ac5c5"
+  },
+  "web.admin.sessions.columns.authenticated": {
+    "text": "Auth",
+    "source_hash": "8eb3ea9b"
+  },
+  "web.admin.sessions.columns.email": {
+    "text": "Courriel",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.sessions.columns.externalId": {
+    "text": "ID externe",
+    "source_hash": "69da56ba"
+  },
+  "web.admin.sessions.columns.ipAddress": {
+    "text": "Adresse IP",
+    "source_hash": "3c3de0c9"
+  },
+  "web.admin.sessions.columns.created": {
+    "text": "Authentifié le",
+    "source_hash": "8d6c9b01"
+  },
+  "web.admin.sessions.columns.actions": {
+    "text": "Actions",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.sessions.columns.role": {
+    "text": "Rôle",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.sessions.detail.yes": {
+    "text": "Oui",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.sessions.detail.no": {
+    "text": "Non",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.sessions.detail.none": {
+    "text": "Aucun",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.sessions.detail.unknown": {
+    "text": "Inconnu",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.sessions.detail.noExpiry": {
+    "text": "Sans expiration",
+    "source_hash": "fe06351d"
+  },
+  "web.admin.sessions.detail.expired": {
+    "text": "Expiré",
+    "source_hash": "424a2551"
+  },
+  "web.admin.sessions.detail.ttlSeconds": {
+    "text": "{seconds} s restantes",
+    "source_hash": "3c9d75ce"
+  },
+  "web.admin.sessions.drawer.title": {
+    "text": "Session {id}",
+    "source_hash": "29dcbd66"
+  },
+  "web.admin.sessions.drawer.notFound": {
+    "text": "Session introuvable",
+    "source_hash": "0969eab8"
+  },
+  "web.admin.sessions.drawer.notFoundDescription": {
+    "text": "Cette session n'existe plus dans Redis. Elle a peut-être expiré ou déjà été révoquée.",
+    "source_hash": "11e3ef05"
+  },
+  "web.admin.sessions.drawer.loadError": {
+    "text": "Impossible de charger cette session.",
+    "source_hash": "82ae90fb"
+  },
+  "web.admin.sessions.drawer.retry": {
+    "text": "Réessayer",
+    "source_hash": "942087cc"
+  },
+  "web.admin.sessions.fields.sessionId": {
+    "text": "ID de session",
+    "source_hash": "cb9ac5c5"
+  },
+  "web.admin.sessions.fields.key": {
+    "text": "Clé Redis",
+    "source_hash": "0b196725"
+  },
+  "web.admin.sessions.fields.ttl": {
+    "text": "TTL",
+    "source_hash": "76f6014f"
+  },
+  "web.admin.sessions.fields.authenticated": {
+    "text": "Authentifié",
+    "source_hash": "6ab694cf"
+  },
+  "web.admin.sessions.fields.email": {
+    "text": "Courriel",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.sessions.fields.externalId": {
+    "text": "ID externe",
+    "source_hash": "69da56ba"
+  },
+  "web.admin.sessions.fields.accountId": {
+    "text": "ID de compte",
+    "source_hash": "919bb4cb"
+  },
+  "web.admin.sessions.fields.role": {
+    "text": "Rôle",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.sessions.fields.locale": {
+    "text": "Langue",
+    "source_hash": "ca3dc612"
+  },
+  "web.admin.sessions.fields.ipAddress": {
+    "text": "Adresse IP",
+    "source_hash": "3c3de0c9"
+  },
+  "web.admin.sessions.fields.authenticatedAt": {
+    "text": "Authentifié le",
+    "source_hash": "8d6c9b01"
+  },
+  "web.admin.sessions.fields.authenticatedBy": {
+    "text": "Authentifié par",
+    "source_hash": "3ebbabfe"
+  },
+  "web.admin.sessions.fields.activeSessionId": {
+    "text": "ID de session active",
+    "source_hash": "f32b1158"
+  },
+  "web.admin.sessions.fields.userAgent": {
+    "text": "Agent utilisateur",
+    "source_hash": "62e01345"
+  },
+  "web.admin.sessions.fields.orgContext": {
+    "text": "Contexte de l'organisation",
+    "source_hash": "a596d9f2"
+  },
+  "web.admin.sessions.list.loadError": {
+    "text": "Impossible de charger les sessions.",
+    "source_hash": "00c678d9"
+  },
+  "web.admin.sessions.list.retry": {
+    "text": "Réessayer",
+    "source_hash": "942087cc"
+  },
+  "web.admin.sessions.list.empty": {
+    "text": "Aucune session active trouvée",
+    "source_hash": "e35312d6"
+  },
+  "web.admin.sessions.revoke.button": {
+    "text": "Révoquer",
+    "source_hash": "87e6d00b"
+  },
+  "web.admin.sessions.revoke.confirmTitle": {
+    "text": "Révoquer cette session ?",
+    "source_hash": "0c6605c1"
+  },
+  "web.admin.sessions.revoke.confirmDescription": {
+    "text": "Cela déconnecte immédiatement l'utilisateur en supprimant la session {id}. Saisissez l'ID de session pour confirmer.",
+    "source_hash": "9e08b1b8"
+  },
+  "web.admin.sessions.revoke.success": {
+    "text": "Session révoquée",
+    "source_hash": "0af5e14d"
+  },
+  "web.admin.sessions.scan.summary": {
+    "text": "Affichage de {shown} authentifiées · {anonymous} anonymes masquées · {scanned} analysées",
+    "source_hash": "34cb67a4"
+  },
+  "web.admin.sessions.scan.capped": {
+    "text": "Analyse limitée aux {scanned} premières clés — les sessions authentifiées au-delà de cette fenêtre ne sont pas listées. Inspectez une session précise par son ID pour l'atteindre.",
+    "source_hash": "fa418b4e"
+  },
+  "web.admin.sessions.search.placeholder": {
+    "text": "Rechercher par courriel ou ID externe",
+    "source_hash": "f2dc5c06"
+  },
+  "web.admin.sessions.sections.session": {
+    "text": "Session",
+    "source_hash": "6959b415"
+  },
+  "web.admin.sessions.sections.raw": {
+    "text": "Données de session brutes",
+    "source_hash": "c9f11eb4"
+  },
+  "web.admin.sessions.status.authenticated": {
+    "text": "Authentifié",
+    "source_hash": "6ab694cf"
+  },
+  "web.admin.sessions.status.anonymous": {
+    "text": "Anonyme",
+    "source_hash": "e7a8aa2d"
+  }
+}

--- a/locales/content/fr_CA/admin-system.json
+++ b/locales/content/fr_CA/admin-system.json
@@ -1,0 +1,158 @@
+{
+  "web.admin.system.title": {
+    "text": "Système",
+    "source_hash": "6725e7bb"
+  },
+  "web.admin.system.description": {
+    "text": "État de la base de données, de la file d'attente et de l'infrastructure.",
+    "source_hash": "0115f495"
+  },
+  "web.admin.system.retry": {
+    "text": "Réessayer",
+    "source_hash": "942087cc"
+  },
+  "web.admin.system.database.title": {
+    "text": "Base de données principale ({engine})",
+    "source_hash": "1391230b"
+  },
+  "web.admin.system.database.loadError": {
+    "text": "Impossible de charger les métriques de la base de données.",
+    "source_hash": "905055c6"
+  },
+  "web.admin.system.database.server": {
+    "text": "Serveur",
+    "source_hash": "aef7de28"
+  },
+  "web.admin.system.database.memory": {
+    "text": "Mémoire",
+    "source_hash": "c3963aed"
+  },
+  "web.admin.system.database.databases": {
+    "text": "Bases de données",
+    "source_hash": "61d2afe2"
+  },
+  "web.admin.system.database.dbSummary": {
+    "text": "{keys} clés, {expires} avec TTL",
+    "source_hash": "26b9e17c"
+  },
+  "web.admin.system.database.fields.version": {
+    "text": "Version",
+    "source_hash": "dd167905"
+  },
+  "web.admin.system.database.fields.mode": {
+    "text": "Mode",
+    "source_hash": "5e23ec6a"
+  },
+  "web.admin.system.database.fields.uptimeDays": {
+    "text": "Temps de fonctionnement (jours)",
+    "source_hash": "7ab314f8"
+  },
+  "web.admin.system.database.fields.connectedClients": {
+    "text": "Clients connectés",
+    "source_hash": "434adc3a"
+  },
+  "web.admin.system.database.fields.opsPerSec": {
+    "text": "Ops/sec",
+    "source_hash": "6634251d"
+  },
+  "web.admin.system.database.fields.totalCommands": {
+    "text": "Total des commandes",
+    "source_hash": "c5ce5aaf"
+  },
+  "web.admin.system.database.fields.usedMemory": {
+    "text": "Mémoire utilisée",
+    "source_hash": "bac68a65"
+  },
+  "web.admin.system.database.fields.rssMemory": {
+    "text": "Mémoire RSS",
+    "source_hash": "7fe77d15"
+  },
+  "web.admin.system.database.fields.peakMemory": {
+    "text": "Mémoire maximale",
+    "source_hash": "9d44afa6"
+  },
+  "web.admin.system.database.fields.fragmentation": {
+    "text": "Taux de fragmentation",
+    "source_hash": "721494dd"
+  },
+  "web.admin.system.database.stats.customers": {
+    "text": "Clients",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.system.database.stats.secrets": {
+    "text": "Secrets",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.system.database.stats.receipts": {
+    "text": "Reçus",
+    "source_hash": "60a627df"
+  },
+  "web.admin.system.database.stats.totalKeys": {
+    "text": "Total des clés",
+    "source_hash": "4e0d27f5"
+  },
+  "web.admin.system.queue.title": {
+    "text": "File d'attente",
+    "source_hash": "3b2fe03e"
+  },
+  "web.admin.system.queue.loadError": {
+    "text": "Impossible de charger les métriques de la file d'attente.",
+    "source_hash": "715bdc88"
+  },
+  "web.admin.system.queue.empty": {
+    "text": "Aucune file d'attente trouvée",
+    "source_hash": "3cd4eb88"
+  },
+  "web.admin.system.queue.connected": {
+    "text": "Connecté",
+    "source_hash": "22965568"
+  },
+  "web.admin.system.queue.disconnected": {
+    "text": "Déconnecté",
+    "source_hash": "04dfac36"
+  },
+  "web.admin.system.queue.activeWorkers": {
+    "text": "{count} travailleurs actifs",
+    "source_hash": "49e6369c"
+  },
+  "web.admin.system.queue.columns.name": {
+    "text": "File d'attente",
+    "source_hash": "3b2fe03e"
+  },
+  "web.admin.system.queue.columns.pending": {
+    "text": "En attente",
+    "source_hash": "331551b0"
+  },
+  "web.admin.system.queue.columns.consumers": {
+    "text": "Consommateurs",
+    "source_hash": "212b350d"
+  },
+  "web.admin.system.queue.health.healthy": {
+    "text": "En bonne santé",
+    "source_hash": "7f1e323b"
+  },
+  "web.admin.system.queue.health.degraded": {
+    "text": "Dégradé",
+    "source_hash": "a8494c12"
+  },
+  "web.admin.system.queue.health.unhealthy": {
+    "text": "En mauvaise santé",
+    "source_hash": "317b1fbc"
+  },
+  "web.admin.system.queue.health.unknown": {
+    "text": "Inconnu",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.system.redis.title": {
+    "text": "Redis INFO",
+    "source_hash": "e762bd3c"
+  },
+  "web.admin.system.redis.loadError": {
+    "text": "Impossible de charger les métriques Redis.",
+    "source_hash": "ca5945d6"
+  },
+  "web.admin.system.redis.captured": {
+    "text": "Capturé le {at}",
+    "source_hash": "57b40c0f"
+  }
+}

--- a/locales/content/fr_CA/admin-usage.json
+++ b/locales/content/fr_CA/admin-usage.json
@@ -1,0 +1,78 @@
+{
+  "web.admin.usage.title": {
+    "text": "Utilisation",
+    "source_hash": "8d59829c"
+  },
+  "web.admin.usage.description": {
+    "text": "Exportez les métriques d'utilisation pour une plage de dates.",
+    "source_hash": "97bd3325"
+  },
+  "web.admin.usage.startDate": {
+    "text": "Date de début",
+    "source_hash": "4c52faad"
+  },
+  "web.admin.usage.endDate": {
+    "text": "Date de fin",
+    "source_hash": "e970951c"
+  },
+  "web.admin.usage.fetch": {
+    "text": "Récupérer les données",
+    "source_hash": "429532fe"
+  },
+  "web.admin.usage.loadError": {
+    "text": "Impossible de charger les données d'utilisation.",
+    "source_hash": "ffb557d7"
+  },
+  "web.admin.usage.retry": {
+    "text": "Réessayer",
+    "source_hash": "942087cc"
+  },
+  "web.admin.usage.empty": {
+    "text": "Aucune donnée pour cette plage",
+    "source_hash": "5fed1795"
+  },
+  "web.admin.usage.byState": {
+    "text": "Secrets par état",
+    "source_hash": "916bbcb6"
+  },
+  "web.admin.usage.secretsByDay": {
+    "text": "Secrets par jour",
+    "source_hash": "24a01e8e"
+  },
+  "web.admin.usage.usersByDay": {
+    "text": "Nouveaux utilisateurs par jour",
+    "source_hash": "8c1f089f"
+  },
+  "web.admin.usage.exportJson": {
+    "text": "Télécharger le JSON",
+    "source_hash": "49e0e6d5"
+  },
+  "web.admin.usage.exportCsv": {
+    "text": "Télécharger le CSV",
+    "source_hash": "a4023b89"
+  },
+  "web.admin.usage.columns.date": {
+    "text": "Date",
+    "source_hash": "99c40ab4"
+  },
+  "web.admin.usage.columns.count": {
+    "text": "Nombre",
+    "source_hash": "37bac495"
+  },
+  "web.admin.usage.stats.totalSecrets": {
+    "text": "Total des secrets",
+    "source_hash": "e17a5459"
+  },
+  "web.admin.usage.stats.newUsers": {
+    "text": "Nouveaux utilisateurs",
+    "source_hash": "d3ee48b0"
+  },
+  "web.admin.usage.stats.avgSecrets": {
+    "text": "Secrets moy./jour",
+    "source_hash": "948b0701"
+  },
+  "web.admin.usage.stats.avgUsers": {
+    "text": "Utilisateurs moy./jour",
+    "source_hash": "491f626d"
+  }
+}

--- a/locales/content/fr_CA/api-domains-errors.json
+++ b/locales/content/fr_CA/api-domains-errors.json
@@ -34,5 +34,17 @@
   "api.domains.errors.recipients_duplicate": {
     "text": "Les courriels de destinataires en double ne sont pas autorisés",
     "source_hash": "6de22182"
+  },
+  "api.domains.errors.homepage_secrets_mode_invalid": {
+    "text": "secrets_mode invalide : %{secrets_mode}",
+    "source_hash": "cf093a04"
+  },
+  "api.domains.errors.homepage_incoming_entitlement_required": {
+    "text": "Le mode de secrets entrants nécessite le droit incoming_secrets. Veuillez mettre à niveau votre forfait.",
+    "source_hash": "d68b13d8"
+  },
+  "api.domains.errors.homepage_incoming_not_ready": {
+    "text": "Les secrets entrants doivent être activés avec au moins un destinataire avant de pouvoir être utilisés comme page d'accueil.",
+    "source_hash": "556da6e2"
   }
 }

--- a/locales/content/fr_CA/api-invite-errors.json
+++ b/locales/content/fr_CA/api-invite-errors.json
@@ -12,8 +12,8 @@
     "source_hash": "a5df7d22"
   },
   "api.invite.errors.invitation_already_processed": {
-    "text": "L'invitation a déjà été %{status}",
-    "source_hash": "130c87e0"
+    "text": "Cette invitation a déjà été traitée",
+    "source_hash": "4cfedf4f"
   },
   "api.invite.errors.invitation_expired": {
     "text": "L'invitation a expiré",
@@ -26,5 +26,13 @@
   "api.invite.errors.already_member": {
     "text": "Vous êtes déjà membre de cette organisation",
     "source_hash": "f56ad547"
+  },
+  "api.invite.errors.invitation_already_accepted": {
+    "text": "Cette invitation a déjà été acceptée",
+    "source_hash": "8f9daf0f"
+  },
+  "api.invite.errors.invitation_already_declined": {
+    "text": "Cette invitation a déjà été refusée",
+    "source_hash": "96e0d626"
   }
 }

--- a/locales/content/fr_CA/api-secrets-errors.json
+++ b/locales/content/fr_CA/api-secrets-errors.json
@@ -10,5 +10,9 @@
   "api.secrets.errors.domain_permission_anonymous_cross_domain": {
     "text": "Vous n'avez pas la permission d'utiliser le domaine : %{domain}",
     "source_hash": "b41920ba"
+  },
+  "api.secrets.errors.secret_undecryptable": {
+    "text": "Ce secret ne peut pas être déchiffré pour le moment. Le lien est toujours intact — l'exploitant du site doit restaurer la clé de chiffrement avant qu'il puisse être révélé.",
+    "source_hash": "56e283ee"
   }
 }

--- a/locales/content/fr_CA/email.json
+++ b/locales/content/fr_CA/email.json
@@ -62,7 +62,7 @@
   "email.welcome.signature": {
     "text": "L'équipe de soutien",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.welcome.postscript": {
     "text": "P.-S. Ce courriel a été envoyé à %{email_address}. Si vous n'avez pas créé de compte, vous pouvez ignorer ce message en toute sécurité.",
@@ -102,7 +102,7 @@
   "email.password_request.signature": {
     "text": "L'équipe de soutien",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.password_request.postscript": {
     "text": "P.-S. Ce courriel a été envoyé à %{email_address}.",
@@ -147,7 +147,7 @@
   "email.magic_link.signature": {
     "text": "L'équipe de soutien",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.magic_link.postscript": {
     "text": "P.-S. Ce courriel a été envoyé à %{email_address}.",
@@ -232,7 +232,7 @@
   "email.secret_revealed.signature": {
     "text": "L'équipe de soutien",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.secret_revealed.manage_preferences": {
     "text": "Gérer les préférences de notification",
@@ -357,7 +357,7 @@
   "email.organization_invitation.signature": {
     "text": "L'équipe de soutien",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.organization_invitation.postscript": {
     "text": "P.-S. Ce courriel a été envoyé à %{invited_email}. Si vous n'attendiez pas cette invitation, vous pouvez ignorer ce message en toute sécurité.",
@@ -397,17 +397,17 @@
   "email.password_changed.signature": {
     "text": "L'équipe de soutien",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_changed.subject": {
     "text": "Votre adresse courriel a été modifiée (%{display_domain})",
     "renderer": "erb",
-    "source_hash": "d68d2f4c"
+    "source_hash": "4386fc57"
   },
   "email.email_changed.title": {
     "text": "Votre adresse courriel a été modifiée",
     "renderer": "erb",
-    "source_hash": "62b07299"
+    "source_hash": "db70f965"
   },
   "email.email_changed.security_notice": {
     "text": "Si vous n'avez pas effectué cette modification, veuillez contacter le soutien immédiatement, car votre compte pourrait être compromis.",
@@ -417,7 +417,7 @@
   "email.email_changed.change_notice": {
     "text": "L'adresse courriel de votre compte %{product_name} a été modifiée.",
     "renderer": "erb",
-    "source_hash": "bb467ebc"
+    "source_hash": "7fc0e27c"
   },
   "email.email_changed.new_email_label": {
     "text": "Nouveau courriel :",
@@ -447,7 +447,7 @@
   "email.email_changed.signature": {
     "text": "L'équipe de soutien",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_changed.postscript": {
     "text": "P.S. Ce courriel a été envoyé à %{email_address} pour vous informer d'un changement d'adresse courriel.",
@@ -497,7 +497,7 @@
   "email.email_change_requested.signature": {
     "text": "L'équipe de soutien",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_change_requested.postscript": {
     "text": "P.S. Ce courriel a été envoyé à %{email_address} car une demande de changement de courriel a été faite pour votre compte.",
@@ -552,7 +552,7 @@
   "email.email_change_confirmation.signature": {
     "text": "L'équipe de soutien",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_change_confirmation.postscript": {
     "text": "P.S. Ce courriel a été envoyé à %{email_address} pour confirmer un changement d'adresse courriel.",
@@ -582,7 +582,7 @@
   "email.mfa_enabled.signature": {
     "text": "L'équipe de soutien",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.mfa_disabled.subject": {
     "text": "Authentification à deux facteurs désactivée (%{display_domain})",
@@ -607,7 +607,7 @@
   "email.mfa_disabled.signature": {
     "text": "L'équipe de soutien",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.new_login_alert.subject": {
     "text": "Nouvelle connexion à votre compte (%{display_domain})",
@@ -652,7 +652,7 @@
   "email.new_login_alert.signature": {
     "text": "L'équipe de soutien",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.member_removed.subject": {
     "text": "Vous avez été retiré de %{organization_name}",
@@ -672,7 +672,7 @@
   "email.member_removed.signature": {
     "text": "L'équipe de soutien",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.role_changed.subject": {
     "text": "Votre rôle a été modifié dans %{organization_name}",
@@ -692,7 +692,7 @@
   "email.role_changed.signature": {
     "text": "L'équipe de soutien",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.organization_deleted.subject": {
     "text": "L'organisation « %{organization_name} » a été supprimée",
@@ -712,7 +712,7 @@
   "email.organization_deleted.signature": {
     "text": "L'équipe de soutien",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.trial_expiring.subject": {
     "text": "Votre essai %{product_name} expire dans %{days_remaining} jours",
@@ -737,7 +737,7 @@
   "email.trial_expiring.signature": {
     "text": "L'équipe de soutien",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.subscription_changed.subject": {
     "text": "Votre abonnement %{product_name} a été modifié",
@@ -762,7 +762,7 @@
   "email.subscription_changed.signature": {
     "text": "L'équipe de soutien",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.common.greeting": {
     "text": "Bonjour,",

--- a/locales/content/fr_CA/feature-regions.json
+++ b/locales/content/fr_CA/feature-regions.json
@@ -152,8 +152,8 @@
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "Si votre courriel de contact de facturation diffère du courriel de votre compte {product_name}, utilisez le courriel de contact de facturation du compte de la nouvelle région pour conserver les avantages de votre abonnement.",
-    "source_hash": "dac1cc28"
+    "text": "Si votre courriel de contact de facturation diffère du courriel de votre compte {product_name}, utilisez le courriel de contact de facturation pour le compte de la nouvelle région afin de conserver les avantages de votre abonnement.",
+    "source_hash": "d49662b0"
   },
   "web.regions.changing_regions_subscription_note": {
     "text": "Vos avantages d'abonnement s'appliqueront automatiquement à tout compte créé avec votre adresse courriel de facturation.",

--- a/locales/content/fr_CA/feature-translations.json
+++ b/locales/content/fr_CA/feature-translations.json
@@ -65,7 +65,7 @@
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
     "text": "Les personnes suivantes ont donné de leur temps pour aider à étendre la portée de {product_name} :",
-    "source_hash": "85a766af"
+    "source_hash": "6cc876ae"
   },
   "web.translations.translations": {
     "text": "Traductions",
@@ -84,8 +84,8 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "Depuis 2012, {product_name} offre un moyen sûr de partager des informations sensibles dans le monde entier. Avec des utilisateurs dans des régions où l'anglais n'est pas la langue principale, des traductions précises sont essentielles pour rendre la communication sécurisée accessible à tous.",
-    "source_hash": "87a6e9af"
+    "text": "Depuis 2012, {product_name} offre une façon sécurisée de partager des renseignements sensibles partout dans le monde. Avec des utilisateurs dans des régions où l'anglais n'est pas la langue principale, des traductions exactes sont essentielles pour rendre la communication sécurisée accessible à tous.",
+    "source_hash": "ded965d5"
   },
   "web.translations.help_secure_communication_go_global": {
     "text": "Aidez la communication sécurisée à devenir mondiale",

--- a/locales/content/fr_CA/secret-homepage.json
+++ b/locales/content/fr_CA/secret-homepage.json
@@ -57,7 +57,7 @@
   },
   "web.homepage.visit_onetime_secret_home": {
     "text": "Visiter la page d'accueil de {product_name}",
-    "source_hash": "625556d2"
+    "source_hash": "87802af5"
   },
   "web.homepage.password_generation_title": {
     "text": "Générateur de mot de passe",
@@ -109,15 +109,15 @@
   },
   "web.homepage.about_onetime_secret_0": {
     "text": "À propos de {product_name}",
-    "source_hash": "971c50da"
+    "source_hash": "b3046356"
   },
   "web.homepage.log_in_to_onetime_secret": {
     "text": "Se connecter à {product_name}",
-    "source_hash": "bd6be8d6"
+    "source_hash": "b2e364a4"
   },
   "web.homepage.about_onetime_secret": {
     "text": "À propos de {product_name}",
-    "source_hash": "971c50da"
+    "source_hash": "b3046356"
   },
   "web.homepage.signup_individual_and_business_plans": {
     "text": "Inscription - Forfaits individuel et entreprise",
@@ -137,19 +137,19 @@
   },
   "web.homepage.onetime_secret": {
     "text": "{product_name}",
-    "source_hash": "1cd0194a"
+    "source_hash": "7bec5899"
   },
   "web.homepage.onetime_secret_literal": {
     "text": "{product_name}",
-    "source_hash": "1cd0194a"
+    "source_hash": "7bec5899"
   },
   "web.homepage.one_time_secret_literal": {
     "text": "{product_name}",
-    "source_hash": "7872e050"
+    "source_hash": "7bec5899"
   },
   "web.homepage.onetime_secret_homepage": {
     "text": "Page d'accueil de {product_name}",
-    "source_hash": "44bb0581"
+    "source_hash": "0792b61e"
   },
   "web.homepage.send_sensitive_information_that_can_only_be_viewed_once": {
     "text": "Envoyez des informations sensibles qui ne peuvent être consultées qu'une seule fois",
@@ -169,11 +169,11 @@
   },
   "web.homepage.welcome_to_onetime_secret": {
     "text": "Bienvenue sur {product_name}.",
-    "source_hash": "0990d163"
+    "source_hash": "f4f49058"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "{product_name} nous aide à partager des informations sensibles en toute sécurité tout en préservant notre image professionnelle.",
-    "source_hash": "986a0856"
+    "text": "{product_name} nous aide à partager des renseignements sensibles en toute sécurité tout en conservant notre façade professionnelle.",
+    "source_hash": "7e9192bd"
   },
   "web.homepage.information_shared_through_this_service_can_only": {
     "text": "Les informations partagées par l'intermédiaire de ce service ne peuvent être consultées qu'une seule fois. Une fois consulté, le contenu est définitivement supprimé afin de garantir la confidentialité.",
@@ -182,5 +182,13 @@
   "web.homepage.welcome_to_the_global_broadcast": {
     "text": "Bienvenue dans la diffusion mondiale !",
     "source_hash": "210e1894"
+  },
+  "web.homepage.send_a_secret": {
+    "text": "Envoyer un secret",
+    "source_hash": "31fd9e03"
+  },
+  "web.homepage.deliver_sensitive_information_directly_and_securely": {
+    "text": "Transmettez des renseignements sensibles directement à notre équipe. Ils ne peuvent être consultés qu'une seule fois.",
+    "source_hash": "9976cf01"
   }
 }

--- a/locales/content/fr_CA/secret-manage.json
+++ b/locales/content/fr_CA/secret-manage.json
@@ -56,8 +56,8 @@
     "source_hash": "2e5a27e1"
   },
   "web.secrets.sample_secret_content_this_could_be_sensitive_data": {
-    "text": "Exemple de contenu secret Il peut s'agir de données sensibles ou d'un message de plusieurs lignes",
-    "source_hash": "b3be3902"
+    "text": "Contenu de secret d'exemple. Cela pourrait être des données sensibles\n\nOu un message sur plusieurs lignes",
+    "source_hash": "5e1bffcb"
   },
   "web.secrets.sample_secret_content": {
     "text": "Exemple de contenu secret",
@@ -128,8 +128,8 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "{product_name} est un moyen sûr de partager des informations sensibles qui s'autodétruisent après une seule consultation.",
-    "source_hash": "8a163297"
+    "text": "{product_name} est une façon sécurisée de partager des renseignements sensibles qui s'autodétruisent après une seule consultation.",
+    "source_hash": "bd0c6182"
   },
   "web.secrets.what_is_this": {
     "text": "Qu'est-ce que c'est ?",

--- a/locales/content/fr_CA/session-auth-extended.json
+++ b/locales/content/fr_CA/session-auth-extended.json
@@ -155,8 +155,8 @@
     "source_hash": "d726c0da"
   },
   "web.auth.magicLink.sessionExpired": {
-    "text": "Votre session a expiré. Veuillez rafraîchir la page et réessayer.",
-    "source_hash": "a7c3e901"
+    "text": "Votre session a expiré. Veuillez actualiser la page et réessayer.",
+    "source_hash": "be9ed96d"
   },
   "web.auth.magicLink.loginFailed": {
     "text": "Échec de la connexion. Veuillez réessayer.",

--- a/locales/content/fr_CA/session-auth.json
+++ b/locales/content/fr_CA/session-auth.json
@@ -373,8 +373,8 @@
     "source_hash": "afd25fdf"
   },
   "web.help.use_magic_link_instead": {
-    "text": "Utilisez l'option Lien magique pour vous connecter sans mot de passe. Une fois connecté, vous pourrez modifier votre mot de passe dans les Paramètres du compte.",
-    "source_hash": "2a058600"
+    "text": "Vous pouvez demander un lien de réinitialisation de mot de passe pour créer un nouveau mot de passe.",
+    "source_hash": "3c3eabad"
   },
   "web.help.account_locked": {
     "text": "Compte temporairement verrouillé ?",
@@ -431,5 +431,57 @@
   "web.login.errors.domain_not_allowed": {
     "text": "Le domaine de votre courriel n'est pas autorisé pour l'inscription par SSO. Veuillez communiquer avec votre administrateur.",
     "source_hash": "87603782"
+  },
+  "web.auth.check_email.title": {
+    "text": "Vérifiez votre courriel",
+    "source_hash": "77322879"
+  },
+  "web.auth.check_email.sent_to_generic": {
+    "text": "Nous avons envoyé un lien de vérification à votre adresse courriel.",
+    "source_hash": "4e5510af"
+  },
+  "web.auth.check_email.help": {
+    "text": "Nous avons envoyé un lien de vérification à cette adresse — ouvrez le courriel et cliquez sur le lien pour activer votre compte.",
+    "source_hash": "8babedc4"
+  },
+  "web.auth.check_email.spam_hint": {
+    "text": "Vous ne le trouvez pas ? Vérifiez votre dossier de pourriel.",
+    "source_hash": "d166d9a4"
+  },
+  "web.auth.check_email.wrong_email": {
+    "text": "Vous avez saisi la mauvaise adresse ?",
+    "source_hash": "0aa863e5"
+  },
+  "web.auth.check_email.start_over": {
+    "text": "Recommencer",
+    "source_hash": "5eed7e9f"
+  },
+  "web.auth.field-errors.password": {
+    "text": "Mot de passe",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.auth.verify.resend_help_text": {
+    "text": "Vous n'avez pas reçu le courriel de vérification ? Saisissez votre courriel pour le renvoyer.",
+    "source_hash": "e0df48bb"
+  },
+  "web.auth.verify.resend_button": {
+    "text": "Renvoyer le courriel de vérification",
+    "source_hash": "5173cc04"
+  },
+  "web.auth.verify.resend_sent": {
+    "text": "Si un compte nécessite une vérification, un nouveau courriel a été envoyé. Veuillez vérifier votre boîte de réception et votre dossier de pourriel.",
+    "source_hash": "6f838ffb"
+  },
+  "web.auth.verify.resend_error": {
+    "text": "Impossible d'envoyer le courriel de vérification. Veuillez vérifier votre connexion et réessayer.",
+    "source_hash": "15149f46"
+  },
+  "web.auth.verify.resend_short": {
+    "text": "Renvoyer le courriel",
+    "source_hash": "4f44603e"
+  },
+  "web.login.verified_notice": {
+    "text": "Votre courriel a été vérifié — vous pouvez maintenant vous connecter.",
+    "source_hash": "c8d4b5a8"
   }
 }

--- a/locales/content/fr_CA/workspace-account.json
+++ b/locales/content/fr_CA/workspace-account.json
@@ -136,8 +136,8 @@
     "source_hash": "05986d95"
   },
   "web.account.keep_this_token_secure_it_provides_full_access_t": {
-    "text": "🔐 Conservez ce jeton en lieu sûr ! Il donne un accès complet à votre compte.",
-    "source_hash": "8839aa4d"
+    "text": "Gardez ce jeton en sécurité. Il peut servir à créer et à gérer des secrets au moyen de l'API.",
+    "source_hash": "a63cc8ec"
   },
   "web.account.confirm_with_your_password": {
     "text": "Confirmez avec votre mot de passe",
@@ -328,8 +328,8 @@
     "source_hash": "f7cfed6e"
   },
   "web.settings.profile.email_change_success": {
-    "text": "Courriel mis à jour avec succès. Veuillez vérifier votre boîte de réception pour confirmer votre nouvelle adresse courriel.",
-    "source_hash": "58de2536"
+    "text": "Courriel de vérification envoyé. Veuillez vérifier votre nouvelle boîte de réception et cliquer sur le lien de confirmation pour terminer le changement.",
+    "source_hash": "45f0a4b5"
   },
   "web.settings.profile.email_change_error": {
     "text": "Échec de la mise à jour du courriel. Veuillez réessayer.",
@@ -477,7 +477,7 @@
   },
   "web.settings.api.documentation_description": {
     "text": "Apprenez à intégrer {product_name} dans vos applications",
-    "source_hash": "6e8f910f"
+    "source_hash": "9bba1ae8"
   },
   "web.settings.api.rest_api_reference": {
     "text": "Référence de l'API REST",

--- a/locales/content/fr_CA/workspace-billing.json
+++ b/locales/content/fr_CA/workspace-billing.json
@@ -140,12 +140,12 @@
     "source_hash": "1f981aaf"
   },
   "web.billing.overview.no_organizations_title": {
-    "text": "Aucune organisation",
-    "source_hash": "12420110"
+    "text": "Aucun espace de travail",
+    "source_hash": "c7f70723"
   },
   "web.billing.overview.no_organizations_description": {
-    "text": "Créer une organisation pour gérer votre facturation et votre abonnement",
-    "source_hash": "41e922d2"
+    "text": "Créez un espace de travail pour gérer votre facturation et votre abonnement",
+    "source_hash": "e0fd27a5"
   },
   "web.billing.overview.load_error": {
     "text": "Échec du chargement des informations de facturation",
@@ -204,8 +204,8 @@
     "source_hash": "883dbca9"
   },
   "web.billing.overview.entitlements.manage_org": {
-    "text": "Gérer les organisations",
-    "source_hash": "be0fe4c3"
+    "text": "Gérer l'organisation",
+    "source_hash": "f03a4985"
   },
   "web.billing.overview.entitlements.manage_teams": {
     "text": "Gérer les équipes",
@@ -220,8 +220,8 @@
     "source_hash": "5428d7fe"
   },
   "web.billing.overview.entitlements.sso": {
-    "text": "Authentification unique",
-    "source_hash": "cf7cd744"
+    "text": "Authentification unique (SSO)",
+    "source_hash": "5db5c812"
   },
   "web.billing.overview.entitlements.priority_support": {
     "text": "Soutien prioritaire",
@@ -280,8 +280,8 @@
     "source_hash": "5428d7fe"
   },
   "web.billing.features.sso": {
-    "text": "Authentification unique (SSO)",
-    "source_hash": "5db5c812"
+    "text": "SSO",
+    "source_hash": "5ba3ac9f"
   },
   "web.billing.features.priority_support": {
     "text": "Support prioritaire",
@@ -577,7 +577,7 @@
   },
   "web.billing.invoices.draft": {
     "text": "Brouillon",
-    "source_hash": "d2e16e61"
+    "source_hash": "ebf12ef4"
   },
   "web.billing.invoices.open": {
     "text": "Ouverte",

--- a/locales/content/fr_CA/workspace-branding.json
+++ b/locales/content/fr_CA/workspace-branding.json
@@ -28,8 +28,8 @@
     "source_hash": "199c165f"
   },
   "web.branding.preview_and_customize": {
-    "text": "Aperçu et personnalisation",
-    "source_hash": "215d3659"
+    "text": "Personnaliser et prévisualiser",
+    "source_hash": "fc68a28c"
   },
   "web.branding.switch_to_safari_browser_view": {
     "text": "Passer à la vue du navigateur Safari",
@@ -88,8 +88,8 @@
     "source_hash": "43e9a2d7"
   },
   "web.branding.click_to_upload_a_logo_with_recommendation": {
-    "text": "Cliquez pour importer un logo. Dimensions recommandées : 128x128 pixels. Taille maximale : 1 Mo. Formats acceptés : PNG, JPG, SVG",
-    "source_hash": "a35452bf"
+    "text": "Cliquez pour gérer votre logo. Taille recommandée : 128 x 128 pixels. Taille de fichier maximale : 1 Mo. Formats pris en charge : PNG, JPG, SVG",
+    "source_hash": "7bb92395"
   },
   "web.branding.upload_logo": {
     "text": "Téléverser un logo",
@@ -186,5 +186,225 @@
   "web.branding.keyhole_logo_icon": {
     "text": "Icône de trou de serrure représentant un partage sécurisé et privé",
     "source_hash": "c868ac60"
+  },
+  "web.branding.secondary_color": {
+    "text": "Couleur secondaire",
+    "source_hash": "1f4728f6"
+  },
+  "web.branding.background_color": {
+    "text": "Couleur d'arrière-plan",
+    "source_hash": "b48bc969"
+  },
+  "web.branding.text_color": {
+    "text": "Couleur du texte",
+    "source_hash": "2ea23234"
+  },
+  "web.branding.border_radius": {
+    "text": "Rayon de la bordure",
+    "source_hash": "e758d7db"
+  },
+  "web.branding.heading_font": {
+    "text": "Police des titres",
+    "source_hash": "6b5d30dc"
+  },
+  "web.branding.theme_presets": {
+    "text": "Préréglages de thème",
+    "source_hash": "931eeb74"
+  },
+  "web.branding.logo": {
+    "text": "Logo",
+    "source_hash": "d707dc2f"
+  },
+  "web.branding.replace_logo": {
+    "text": "Remplacer",
+    "source_hash": "95e15439"
+  },
+  "web.branding.logo_field_hint": {
+    "text": "Prévisualisez avant que vos changements soient publiés.",
+    "source_hash": "e9e222fc"
+  },
+  "web.branding.logo_modal_title": {
+    "text": "Logo du domaine",
+    "source_hash": "5260dda5"
+  },
+  "web.branding.logo_modal_hint": {
+    "text": "PNG, JPG ou SVG. Recommandé 128 x 128 px, jusqu'à 1 Mo.",
+    "source_hash": "75d00802"
+  },
+  "web.branding.logo_modal_save": {
+    "text": "Enregistrer le logo",
+    "source_hash": "8b028a6f"
+  },
+  "web.branding.remove_logo": {
+    "text": "Retirer le logo",
+    "source_hash": "f1c1afa4"
+  },
+  "web.branding.image_upload_choose": {
+    "text": "Choisir une image",
+    "source_hash": "ceed9fd5"
+  },
+  "web.branding.image_upload_drag_hint": {
+    "text": "ou glisser-déposer",
+    "source_hash": "6613b73c"
+  },
+  "web.branding.image_invalid_type": {
+    "text": "Ce type de fichier n'est pas pris en charge. Veuillez choisir une image.",
+    "source_hash": "50e18866"
+  },
+  "web.branding.image_too_large": {
+    "text": "L'image est trop grande. La taille maximale est de {max}.",
+    "source_hash": "b50b55e2"
+  },
+  "web.branding.image_will_be_removed": {
+    "text": "Ce logo sera retiré lorsque vous enregistrerez.",
+    "source_hash": "d94fa99a"
+  },
+  "web.branding.image_upload_failed": {
+    "text": "Une erreur s'est produite. Veuillez réessayer.",
+    "source_hash": "3ccd9d65"
+  },
+  "web.branding.undo": {
+    "text": "Annuler",
+    "source_hash": "a8283ade"
+  },
+  "web.branding.low_contrast_text_bg_warning": {
+    "text": "Faible contraste texte/arrière-plan",
+    "source_hash": "1c676370"
+  },
+  "web.branding.path_simple": {
+    "text": "Simple",
+    "source_hash": "3fee95da"
+  },
+  "web.branding.path_match": {
+    "text": "Reproduire mon site",
+    "source_hash": "776679cf"
+  },
+  "web.branding.path_advanced": {
+    "text": "Avancé",
+    "source_hash": "9f088dbe"
+  },
+  "web.branding.path_simple_tag": {
+    "text": "L'essentiel de votre marque.",
+    "source_hash": "7c9c0cca"
+  },
+  "web.branding.path_match_tag": {
+    "text": "Copiez les paramètres d'un site existant.",
+    "source_hash": "e4b0d1cd"
+  },
+  "web.branding.path_advanced_tag": {
+    "text": "Créez votre propre CSS Tailwind v4.",
+    "source_hash": "2405bb6d"
+  },
+  "web.branding.badge_default": {
+    "text": "Par défaut",
+    "source_hash": "21b111cb"
+  },
+  "web.branding.badge_coming_soon": {
+    "text": "Bientôt disponible",
+    "source_hash": "4f7d6401"
+  },
+  "web.branding.your_brand": {
+    "text": "Votre marque",
+    "source_hash": "406265d3"
+  },
+  "web.branding.your_brand_subtitle": {
+    "text": "Quelques choix rapides — nous nous occupons du reste.",
+    "source_hash": "dbc8ec33"
+  },
+  "web.branding.corners": {
+    "text": "Coins",
+    "source_hash": "1d3cc47e"
+  },
+  "web.branding.more_options": {
+    "text": "Plus d'options",
+    "source_hash": "bc79cdff"
+  },
+  "web.branding.paths_carryover_hint": {
+    "text": "Ceci est un aperçu en direct — vos changements ne seront pas visibles par les visiteurs tant que vous n'aurez pas enregistré.",
+    "source_hash": "cb4b82de"
+  },
+  "web.branding.coming_soon_match_blurb": {
+    "text": "Indiquez-nous votre site Web et nous lirons ses couleurs et ses polices, puis comblerons l'écart en un clic.",
+    "source_hash": "42c34cc1"
+  },
+  "web.branding.coming_soon_advanced_blurb": {
+    "text": "Modifiez directement les jetons {'@'}theme de Tailwind v4, ou collez votre propre feuille de style.",
+    "source_hash": "5a8473f5"
+  },
+  "web.branding.preview_recipient_page": {
+    "text": "Page du destinataire",
+    "source_hash": "de8aa19f"
+  },
+  "web.branding.preview_badge": {
+    "text": "Aperçu",
+    "source_hash": "324b134f"
+  },
+  "web.branding.preview_homepage_enabled": {
+    "text": "Page d'accueil · activée",
+    "source_hash": "2edd85f1"
+  },
+  "web.branding.preview_homepage_disabled": {
+    "text": "Page d'accueil · désactivée",
+    "source_hash": "15d87050"
+  },
+  "web.branding.preview_live": {
+    "text": "Aperçu en direct",
+    "source_hash": "f65ddc1f"
+  },
+  "web.branding.tile_share_secret": {
+    "text": "Partager un secret",
+    "source_hash": "5384461b"
+  },
+  "web.branding.tile_create_link": {
+    "text": "Créer un lien secret",
+    "source_hash": "610fd42e"
+  },
+  "web.branding.tile_delivery_only": {
+    "text": "Livraison sécurisée de messages seulement",
+    "source_hash": "dc24dec2"
+  },
+  "web.branding.tile_no_create": {
+    "text": "Les visiteurs ne peuvent pas créer de secrets ici.",
+    "source_hash": "17361d81"
+  },
+  "web.branding.recipient_page_content": {
+    "text": "Contenu de la page du destinataire",
+    "source_hash": "937733bd"
+  },
+  "web.branding.recipient_page_content_hint": {
+    "text": "Langue et instructions de révélation affichées aux destinataires sur ce domaine.",
+    "source_hash": "04162b70"
+  },
+  "web.branding.tab_brand": {
+    "text": "Marque",
+    "source_hash": "090ed431"
+  },
+  "web.branding.tab_delivery": {
+    "text": "Livraison",
+    "source_hash": "52bfe584"
+  },
+  "web.branding.delivery_language": {
+    "text": "Langue",
+    "source_hash": "a4fe6526"
+  },
+  "web.branding.delivery_language_hint": {
+    "text": "Valeur par défaut pour les pages des destinataires et les courriels sur ce domaine. Les destinataires peuvent changer de langue sur la page.",
+    "source_hash": "bfbc5599"
+  },
+  "web.branding.delivery_reveal_instructions": {
+    "text": "Instructions de révélation",
+    "source_hash": "7e1331f7"
+  },
+  "web.branding.delivery_reveal_instructions_hint": {
+    "text": "Affichées sur la page du destinataire. Laissez vide pour utiliser le texte intégré dans la langue sélectionnée.",
+    "source_hash": "51b9811d"
+  },
+  "web.branding.delivery_before_reveal": {
+    "text": "Avant la révélation",
+    "source_hash": "5ce82b01"
+  },
+  "web.branding.delivery_after_reveal": {
+    "text": "Après la révélation",
+    "source_hash": "d5bfe7fd"
   }
 }

--- a/locales/content/fr_CA/workspace-domains.json
+++ b/locales/content/fr_CA/workspace-domains.json
@@ -76,8 +76,8 @@
     "source_hash": "59be7133"
   },
   "web.domains.enabled": {
-    "text": "Activé",
-    "source_hash": "92c1cdfd"
+    "text": "Activer",
+    "source_hash": "5342e09f"
   },
   "web.domains.disabled": {
     "text": "Désactivé",
@@ -1358,5 +1358,189 @@
   "web.domains.sso.upgrade_required": {
     "text": "Mettre à niveau pour configurer",
     "source_hash": "571cfa98"
+  },
+  "web.domains.add.field_label": {
+    "text": "Domaine personnalisé",
+    "source_hash": "d7d4c1e4"
+  },
+  "web.domains.add.field_help": {
+    "text": "Le nom d'hôte exact que votre équipe utilisera, comme {example}.",
+    "source_hash": "3ba71f78"
+  },
+  "web.domains.add.echo_label": {
+    "text": "Vos liens secrets se trouveront à",
+    "source_hash": "ad60b17d"
+  },
+  "web.domains.add.apex_question": {
+    "text": "C'est votre domaine complet — où les liens secrets doivent-ils se trouver ?",
+    "source_hash": "efacad1b"
+  },
+  "web.domains.add.apex_help": {
+    "text": "Un sous-domaine laisse le reste de {domain} intact.",
+    "source_hash": "0f7e6181"
+  },
+  "web.domains.add.recommended": {
+    "text": "Recommandé",
+    "source_hash": "d70604e8"
+  },
+  "web.domains.add.no_wrong_answer": {
+    "text": "Il n'y a pas de mauvais choix — choisissez celui que votre équipe reconnaîtra.",
+    "source_hash": "a04f0086"
+  },
+  "web.domains.add.subdomains_label": {
+    "text": "Sous-domaines populaires",
+    "source_hash": "d6ee8eac"
+  },
+  "web.domains.add.root_group_label": {
+    "text": "Ou utilisez votre domaine complet",
+    "source_hash": "5c23c007"
+  },
+  "web.domains.add.root_domain_label": {
+    "text": "Utiliser mon domaine racine",
+    "source_hash": "9fbbe253"
+  },
+  "web.domains.add.root_domain_description": {
+    "text": "Cela pointe l'ensemble de {domain} vers nous — le site qui s'y trouve cesse de se résoudre — et nécessite un enregistrement A / ALIAS.",
+    "source_hash": "fae93847"
+  },
+  "web.domains.add.error_unrecognized_suffix": {
+    "text": "« .{0} » n'est pas une terminaison de domaine reconnue — vérifiez s'il y a une faute de frappe (p. ex. {1}).",
+    "source_hash": "4b90033d"
+  },
+  "web.domains.add.error_invalid_hostname": {
+    "text": "Saisissez un nom d'hôte valide — lettres, chiffres, points simples et tirets (p. ex. {0}).",
+    "source_hash": "c4ceabc1"
+  },
+  "web.domains.add.error_empty": {
+    "text": "Veuillez saisir un nom de domaine.",
+    "source_hash": "d8e2c1e4"
+  },
+  "web.domains.add.continue_with": {
+    "text": "Continuer avec {0}",
+    "source_hash": "73f8ab40"
+  },
+  "web.domains.auth_override.workspace_default_badge": {
+    "text": "Valeur par défaut de l'espace de travail",
+    "source_hash": "da3706ee"
+  },
+  "web.domains.detail.dns_title": {
+    "text": "Configuration DNS",
+    "source_hash": "6c63df31"
+  },
+  "web.domains.detail.dns_description": {
+    "text": "Pointez votre domaine vers ce serveur au moyen d'un enregistrement CNAME",
+    "source_hash": "080f84f0"
+  },
+  "web.domains.dns.title": {
+    "text": "Configuration DNS",
+    "source_hash": "da78c35d"
+  },
+  "web.domains.dns.point_domain_intro": {
+    "text": "Pointez",
+    "source_hash": "2fc0c524"
+  },
+  "web.domains.dns.point_domain_outro": {
+    "text": "vers ce serveur en ajoutant l'enregistrement DNS suivant chez votre fournisseur.",
+    "source_hash": "8d260c05"
+  },
+  "web.domains.dns.cname_heading": {
+    "text": "Créez un enregistrement CNAME",
+    "source_hash": "11aeef5a"
+  },
+  "web.domains.dns.apex_heading": {
+    "text": "Créez un enregistrement ALIAS ou ANAME",
+    "source_hash": "41135375"
+  },
+  "web.domains.dns.apex_notice": {
+    "text": "Les domaines apex (racine) ne peuvent pas utiliser d'enregistrement CNAME. Utilisez plutôt l'enregistrement ALIAS ou ANAME de votre fournisseur DNS, ou pointez un enregistrement A vers l'adresse IP de votre serveur.",
+    "source_hash": "2d1c3298"
+  },
+  "web.domains.email.from_address_local_placeholder": {
+    "text": "no-reply",
+    "source_hash": "510d274d"
+  },
+  "web.domains.homepage.title": {
+    "text": "Page d'accueil",
+    "source_hash": "9e3391e9"
+  },
+  "web.domains.homepage.description": {
+    "text": "Ce que les visiteurs peuvent faire sur la page d'accueil de votre domaine",
+    "source_hash": "974d159e"
+  },
+  "web.domains.homepage.option_private_title": {
+    "text": "Page de destination privée",
+    "source_hash": "dfd5bd1c"
+  },
+  "web.domains.homepage.option_private_description": {
+    "text": "Les visiteurs voient une page de destination privée sans formulaire interactif",
+    "source_hash": "4d9aaf6f"
+  },
+  "web.domains.homepage.option_create_title": {
+    "text": "Formulaire de création de secret",
+    "source_hash": "6539dfc1"
+  },
+  "web.domains.homepage.option_create_description": {
+    "text": "Les visiteurs peuvent créer leurs propres liens secrets",
+    "source_hash": "884310f4"
+  },
+  "web.domains.homepage.option_incoming_title": {
+    "text": "Formulaire de secrets entrants",
+    "source_hash": "882997bf"
+  },
+  "web.domains.homepage.option_incoming_description": {
+    "text": "Les visiteurs peuvent envoyer des secrets aux destinataires que vous avez configurés",
+    "source_hash": "86bdaedb"
+  },
+  "web.domains.homepage.incoming_requires_recipients": {
+    "text": "Nécessite que les secrets entrants soient activés avec au moins un destinataire",
+    "source_hash": "0462611d"
+  },
+  "web.domains.homepage.configure_recipients": {
+    "text": "Configurer les destinataires",
+    "source_hash": "1c3df8b4"
+  },
+  "web.domains.homepage.status_private": {
+    "text": "Page de destination privée",
+    "source_hash": "dfd5bd1c"
+  },
+  "web.domains.homepage.status_create": {
+    "text": "Public : les visiteurs créent des secrets",
+    "source_hash": "251cfb95"
+  },
+  "web.domains.homepage.status_incoming": {
+    "text": "Public : les visiteurs vous envoient des secrets",
+    "source_hash": "baa926b8"
+  },
+  "web.domains.homepage.status_incoming_unready": {
+    "text": "Entrants non prêts — affichage de la page de destination privée",
+    "source_hash": "a5cc237c"
+  },
+  "web.domains.homepage.badge_incoming": {
+    "text": "Entrants",
+    "source_hash": "e301820a"
+  },
+  "web.domains.homepage.update_success": {
+    "text": "Paramètres de la page d'accueil enregistrés",
+    "source_hash": "4eac9f45"
+  },
+  "web.domains.homepage.homepage_uses_incoming_warning": {
+    "text": "La page d'accueil de ce domaine présente actuellement le formulaire de secrets entrants. Désactiver les secrets entrants ou retirer tous les destinataires basculera la page d'accueil vers une page de destination privée jusqu'à ce que les entrants soient de nouveau prêts.",
+    "source_hash": "cc0d4997"
+  },
+  "web.domains.signin.effective_status_label": {
+    "text": "Connexion sur ce domaine",
+    "source_hash": "d8b884c3"
+  },
+  "web.domains.signin.dormant_notice": {
+    "text": "La connexion est désactivée pour l'ensemble de l'espace de travail ; elle est donc indisponible sur chaque domaine. Vos paramètres ici sont conservés et prennent effet lorsque la connexion à l'espace de travail est de nouveau activée.",
+    "source_hash": "723d35dc"
+  },
+  "web.domains.signup.effective_status_label": {
+    "text": "Inscriptions sur ce domaine",
+    "source_hash": "115ab21b"
+  },
+  "web.domains.signup.dormant_notice": {
+    "text": "Les inscriptions sont désactivées pour l'ensemble de l'espace de travail ; elles sont donc indisponibles sur chaque domaine. Vos paramètres ici sont conservés et prennent effet lorsque les inscriptions à l'espace de travail sont de nouveau activées.",
+    "source_hash": "49faefe4"
   }
 }

--- a/locales/content/fr_CA/workspace-organizations.json
+++ b/locales/content/fr_CA/workspace-organizations.json
@@ -4,8 +4,8 @@
     "source_hash": "2730183d"
   },
   "web.organizations.organization": {
-    "text": "Organisation",
-    "source_hash": "d764d425"
+    "text": "Espace de travail",
+    "source_hash": "87bb59ba"
   },
   "web.organizations.organization_plural": {
     "text": "Organisations",
@@ -16,24 +16,24 @@
     "source_hash": "dbaa4f92"
   },
   "web.organizations.my_organizations": {
-    "text": "Organisations",
-    "source_hash": "2730183d"
+    "text": "Espaces de travail",
+    "source_hash": "1377264b"
   },
   "web.organizations.manage_organizations": {
-    "text": "Gérer les organisations",
-    "source_hash": "be0fe4c3"
+    "text": "Gérer les espaces de travail",
+    "source_hash": "cc2d65f8"
   },
   "web.organizations.new_organization": {
     "text": "Nouvelle organisation",
     "source_hash": "4876e647"
   },
   "web.organizations.no_organizations": {
-    "text": "Aucune organisation pour le moment",
-    "source_hash": "5b7a7cbd"
+    "text": "Aucun espace de travail pour l'instant",
+    "source_hash": "97d0b117"
   },
   "web.organizations.no_organizations_description": {
-    "text": "Les organisations offrent une facturation et une administration unifiées. Commencez par créer votre première organisation.",
-    "source_hash": "deab4304"
+    "text": "Les espaces de travail offrent une facturation et une administration unifiées. Commencez en créant votre premier espace de travail.",
+    "source_hash": "f09d4987"
   },
   "web.organizations.no_description": {
     "text": "Aucune description fournie",
@@ -48,24 +48,24 @@
     "source_hash": "e27f4540"
   },
   "web.organizations.create_first_organization": {
-    "text": "Créer la première organisation",
-    "source_hash": "27bae486"
+    "text": "Créer le premier espace de travail",
+    "source_hash": "98a583b4"
   },
   "web.organizations.create_organization_description": {
-    "text": "Créer une nouvelle organisation",
-    "source_hash": "67cd5950"
+    "text": "Créer un nouvel espace de travail",
+    "source_hash": "6ac2b5fc"
   },
   "web.organizations.create": {
     "text": "Créer",
     "source_hash": "4759498a"
   },
   "web.organizations.create_error": {
-    "text": "Échec de la création de l'organisation",
-    "source_hash": "f2204373"
+    "text": "Échec de la création de l'espace de travail",
+    "source_hash": "0a8d4fd6"
   },
   "web.organizations.organization_name": {
-    "text": "Nom de l'organisation",
-    "source_hash": "4cbd9073"
+    "text": "Nom de l'espace de travail",
+    "source_hash": "6fa5a5b1"
   },
   "web.organizations.organization_name_placeholder": {
     "text": "ex. : Société Acme",
@@ -92,12 +92,12 @@
     "source_hash": "ee81c03d"
   },
   "web.organizations.select_organization": {
-    "text": "Sélectionner une organisation",
-    "source_hash": "48326f52"
+    "text": "Sélectionnez un espace de travail",
+    "source_hash": "70a8ce66"
   },
   "web.organizations.switcher_locked": {
-    "text": "Le changement d'organisation n'est pas disponible sur cette page",
-    "source_hash": "da0cf810"
+    "text": "Le changement d'espace de travail n'est pas disponible sur cette page",
+    "source_hash": "c34114ac"
   },
   "web.organizations.not_found": {
     "text": "Organisation non trouvée",
@@ -208,8 +208,8 @@
     "source_hash": "7ecc5d35"
   },
   "web.organizations.tabs.members": {
-    "text": "Équipe",
-    "source_hash": "5985039f"
+    "text": "Membres",
+    "source_hash": "1044a4c0"
   },
   "web.organizations.tabs.billing": {
     "text": "Facturation",
@@ -468,8 +468,8 @@
     "source_hash": "424a2551"
   },
   "web.organizations.invitations.roles.member": {
-    "text": "Membre",
-    "source_hash": "7c968fb7"
+    "text": "Membre de l'équipe",
+    "source_hash": "d4e55dfa"
   },
   "web.organizations.invitations.roles.admin": {
     "text": "Administrateur",
@@ -532,8 +532,8 @@
     "source_hash": "5e3f8df8"
   },
   "web.organizations.invitations.upgrade_prompt": {
-    "text": "Les invitations de membres d'équipe nécessitent un forfait avec gestion d'équipe. Mettez à niveau pour ajouter des collaborateurs à votre organisation.",
-    "source_hash": "cf10d623"
+    "text": "Les invitations de membres nécessitent un forfait payant. Mettez à niveau pour ajouter des collaborateurs à votre organisation.",
+    "source_hash": "47d0eeab"
   },
   "web.organizations.paid_badge": {
     "text": "Pro",
@@ -556,8 +556,8 @@
     "source_hash": "ced67718"
   },
   "web.organizations.invitations.email_mismatch_title": {
-    "text": "Connecté avec un autre compte",
-    "source_hash": "4a2f91c3"
+    "text": "Un compte différent est connecté",
+    "source_hash": "6516362a"
   },
   "web.organizations.invitations.email_mismatch_body": {
     "text": "Cette invitation est pour {invitedEmail}. Vous êtes présentement connecté en tant que {currentEmail}.",
@@ -565,7 +565,7 @@
   },
   "web.organizations.invitations.continue_as_invited_email": {
     "text": "Continuer en tant que {email}",
-    "source_hash": "6c9a1d4e"
+    "source_hash": "ccf9745d"
   },
   "web.organizations.invitations.expires_in_days": {
     "text": "{days} j restants",
@@ -1026,5 +1026,9 @@
   "web.organizations.tabs.sso": {
     "text": "SSO",
     "source_hash": "5ba3ac9f"
+  },
+  "web.organizations.create_workspace": {
+    "text": "Créer un espace de travail",
+    "source_hash": "c63c14cf"
   }
 }


### PR DESCRIPTION
## `fr_CA` translation update

Automated export of completed **fr_CA** translations from the translation task DB.
Scope: `locales/content/fr_CA/` only — 33 file(s), +3702/-108.

ℹ️ Variable validation not run.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-opus-4-8`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ✅ Looks good — tokens intact, terminology sound

**Summary:** Large update: 13 new `admin-*.json` console files plus edits across common/layout/email/domains/branding/organizations and API errors. All `{var}`, `%{var}`, `{0}/{1}` placeholders and `{'@'}` vue-i18n escapes are preserved; brand/product terms and technical identifiers (Stripe, Redis, Caddy, DNS/CNAME/ALIAS, Colonel, SSO, TTL, CIDR) correctly left untranslated.

**Critical (must fix):** None
- `api.invite.errors.invitation_already_processed` correctly drops `%{status}` — matches the new source_hash (English removed the variable). Not a regression.

**Warnings:**
- Variable-consistency check was **Not run**. Spot-checked all changed strings by hand (incl. multi-var: `sync.success` {provider}/{accepted}/{rejected}/{fetched}, `scan.summary`, `revokeAll.capped`) — no mismatches found, but no automated confirmation.
- Partial Organisation→Espace de travail rename: renamed where source_hash changed, but `new_organization`, `not_found`, and several `entitlements/invitations.upgrade_prompt` strings still say "organisation." Tracks the mixed English source, so acceptable — confirm the product intends the mixed surface.

**Notes:**
- `web.domains.enabled` flipped "Activé"→"Activer" and `billing.features.sso`→"SSO" follow legitimate source_hash changes.
- Canadian-French refinements applied (informations→renseignements, moyen sûr→façon sécurisée, précises→exactes); straight apostrophes throughout, per fr_CA convention.
- Email `signature` source_hash churn with identical text "L'équipe de soutien" — no translation impact.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
