### PR TITLE
i18n: update ko translations

### DIFF
--- a/locales/content/ko/00-common.json
+++ b/locales/content/ko/00-common.json
@@ -1267,8 +1267,8 @@
     "source_hash": "cb2f00d1"
   },
   "web.TITLES.organizations_settings": {
-    "text": "조직",
-    "source_hash": "2730183d"
+    "text": "워크스페이스",
+    "source_hash": "1377264b"
   },
   "web.TITLES.organization_settings": {
     "text": "조직 설정",
@@ -1299,8 +1299,8 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "항상 공식 {product_name} 웹사이트에 있는지 확인하세요. 사기꾼들은 때때로 비밀을 훔치기 위해 {product_name}과 똑같이 생긴 가짜 웹사이트를 만듭니다. 피싱 공격을 피하려면 새 링크를 만들기 전에 지역 도메인을 확인하세요.",
-    "source_hash": "68ec20f8"
+    "text": "항상 공식 {product_name} 웹사이트에 접속했는지 확인하세요. 사기꾼은 때때로 여러분의 비밀 메시지를 훔치기 위해 {product_name}과 똑같이 보이는 가짜 웹사이트를 만들기도 합니다. 피싱 공격을 방지하려면 새 링크를 생성하기 전에 주소 표시줄에서 해당 지역의 도메인을 확인하세요.",
+    "source_hash": "2e3b856e"
   },
   "web.pricing.title": {
     "text": "간단하고 투명한 요금제",
@@ -1523,5 +1523,21 @@
   "web.TITLES.domain_incoming": {
     "text": "수신 비밀 메시지",
     "source_hash": "883dbca9"
+  },
+  "web.LABELS.update": {
+    "text": "업데이트",
+    "source_hash": "c1c1009d"
+  },
+  "web.LABELS.updating": {
+    "text": "업데이트 중...",
+    "source_hash": "0a4e0b71"
+  },
+  "web.TITLES.check_email": {
+    "text": "이메일을 확인하세요",
+    "source_hash": "0e5fc27d"
+  },
+  "web.TITLES.domain_dns": {
+    "text": "DNS 설정",
+    "source_hash": "6c63df31"
   }
 }

--- a/locales/content/ko/10-layout.json
+++ b/locales/content/ko/10-layout.json
@@ -101,11 +101,11 @@
   },
   "web.footer.product": {
     "text": "제품",
-    "source_hash": "7f5540e9"
+    "source_hash": "fb9ef894"
   },
   "web.footer.source_code_purveyor": {
     "text": "소스 코드",
-    "source_hash": "29c5c68f"
+    "source_hash": "bc47da66"
   },
   "web.navigation.billing": {
     "text": "결제",
@@ -148,8 +148,8 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "{product_name}을 통해 공유된 보안 메시지를 보고 계십니다. 이 내용은 한 번만 표시된 후 서버에서 영구적으로 삭제됩니다.",
-    "source_hash": "e0f1a10c"
+    "text": "{product_name}을(를) 통해 공유된 안전한 메시지를 보고 계십니다. 이 콘텐츠는 한 번만 표시된 후 저희 서버에서 영구적으로 삭제됩니다.",
+    "source_hash": "7a4e9d16"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
     "text": "이 비밀 메시지를 나중에 다시 볼 수 있나요?",
@@ -265,7 +265,7 @@
   },
   "web.layout.visit_onetime_secret_homepage": {
     "text": "{product_name} 홈페이지 방문",
-    "source_hash": "625556d2"
+    "source_hash": "87802af5"
   },
   "web.layout.footer_navigation": {
     "text": "푸터 탐색",
@@ -346,5 +346,9 @@
   "web.help.default_content": {
     "text": "도움이 필요하시면 지원팀에 문의해 주세요",
     "source_hash": "752bca14"
+  },
+  "web.layout.colonels_only_badge": {
+    "text": "Colonel 전용",
+    "source_hash": "3f1e2dbd"
   }
 }

--- a/locales/content/ko/admin-audit.json
+++ b/locales/content/ko/admin-audit.json
@@ -1,0 +1,102 @@
+{
+  "web.admin.audit.title": {
+    "text": "감사 로그",
+    "source_hash": "47751f88"
+  },
+  "web.admin.audit.description": {
+    "text": "데이터를 변경하는 모든 관리 작업을 최신순으로 표시합니다 — 누가 누구에게 무엇을 했고 어떻게 처리되었는지 보여줍니다.",
+    "source_hash": "2326a1a0"
+  },
+  "web.admin.audit.categories.customer": {
+    "text": "고객",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.audit.categories.session": {
+    "text": "세션",
+    "source_hash": "6fa3cbf4"
+  },
+  "web.admin.audit.categories.domain": {
+    "text": "도메인",
+    "source_hash": "ced67718"
+  },
+  "web.admin.audit.categories.organization": {
+    "text": "조직",
+    "source_hash": "2730183d"
+  },
+  "web.admin.audit.categories.banner": {
+    "text": "배너",
+    "source_hash": "b7f4d98f"
+  },
+  "web.admin.audit.categories.queue": {
+    "text": "대기열",
+    "source_hash": "be77db11"
+  },
+  "web.admin.audit.categories.email": {
+    "text": "이메일",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.audit.categories.ratelimit": {
+    "text": "속도 제한",
+    "source_hash": "6ed021f7"
+  },
+  "web.admin.audit.categories.ip": {
+    "text": "IP 차단",
+    "source_hash": "48cdea49"
+  },
+  "web.admin.audit.columns.timestamp": {
+    "text": "타임스탬프",
+    "source_hash": "115a2cc9"
+  },
+  "web.admin.audit.columns.actor": {
+    "text": "실행 주체",
+    "source_hash": "449995c4"
+  },
+  "web.admin.audit.columns.action": {
+    "text": "작업",
+    "source_hash": "64cff131"
+  },
+  "web.admin.audit.columns.target": {
+    "text": "대상",
+    "source_hash": "978354db"
+  },
+  "web.admin.audit.columns.result": {
+    "text": "결과",
+    "source_hash": "6e7d50e8"
+  },
+  "web.admin.audit.columns.detail": {
+    "text": "세부 정보",
+    "source_hash": "fb5f27d5"
+  },
+  "web.admin.audit.filters.actorPlaceholder": {
+    "text": "실행 주체로 필터링 (extid 또는 이메일)",
+    "source_hash": "966aa580"
+  },
+  "web.admin.audit.filters.actionLabel": {
+    "text": "작업",
+    "source_hash": "64cff131"
+  },
+  "web.admin.audit.filters.allActions": {
+    "text": "모든 작업",
+    "source_hash": "83140cf1"
+  },
+  "web.admin.audit.list.loadError": {
+    "text": "감사 로그를 불러올 수 없습니다.",
+    "source_hash": "acf244f4"
+  },
+  "web.admin.audit.list.retry": {
+    "text": "다시 시도",
+    "source_hash": "942087cc"
+  },
+  "web.admin.audit.list.empty": {
+    "text": "아직 기록된 감사 이벤트가 없습니다",
+    "source_hash": "8fe0cac3"
+  },
+  "web.admin.audit.result.success": {
+    "text": "성공",
+    "source_hash": "c88a0b90"
+  },
+  "web.admin.audit.result.failure": {
+    "text": "실패",
+    "source_hash": "7031edbc"
+  }
+}

--- a/locales/content/ko/admin-bannedips.json
+++ b/locales/content/ko/admin-bannedips.json
@@ -1,0 +1,114 @@
+{
+  "web.admin.bannedIps.title": {
+    "text": "차단된 IP",
+    "source_hash": "0ece5643"
+  },
+  "web.admin.bannedIps.description": {
+    "text": "사이트 경계에서 IP 주소를 차단하거나 차단 해제합니다.",
+    "source_hash": "69c0c992"
+  },
+  "web.admin.bannedIps.currentIp": {
+    "text": "현재 IP",
+    "source_hash": "14ff3ec5"
+  },
+  "web.admin.bannedIps.actions.cancel": {
+    "text": "취소",
+    "source_hash": "19766ed6"
+  },
+  "web.admin.bannedIps.actions.ban": {
+    "text": "IP 차단",
+    "source_hash": "9937d7fd"
+  },
+  "web.admin.bannedIps.actions.quickBan": {
+    "text": "이 IP 차단",
+    "source_hash": "95720658"
+  },
+  "web.admin.bannedIps.ban.confirmTitle": {
+    "text": "이 IP 주소를 차단하시겠습니까?",
+    "source_hash": "512acd7b"
+  },
+  "web.admin.bannedIps.ban.confirmDescription": {
+    "text": "사이트 경계에서 {ip}을(를) 차단합니다. 확인하려면 IP를 입력하세요.",
+    "source_hash": "d8f6142e"
+  },
+  "web.admin.bannedIps.ban.button": {
+    "text": "IP 차단",
+    "source_hash": "f91a5285"
+  },
+  "web.admin.bannedIps.ban.success": {
+    "text": "{ip}을(를) 차단했습니다",
+    "source_hash": "97180685"
+  },
+  "web.admin.bannedIps.columns.ipAddress": {
+    "text": "IP 주소",
+    "source_hash": "3c3de0c9"
+  },
+  "web.admin.bannedIps.columns.reason": {
+    "text": "사유",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.bannedIps.columns.bannedAt": {
+    "text": "차단 일시",
+    "source_hash": "dfbd120e"
+  },
+  "web.admin.bannedIps.columns.bannedBy": {
+    "text": "차단한 사람",
+    "source_hash": "9f47db0e"
+  },
+  "web.admin.bannedIps.columns.actions": {
+    "text": "작업",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.bannedIps.form.title": {
+    "text": "IP 주소 차단",
+    "source_hash": "59961746"
+  },
+  "web.admin.bannedIps.form.ipLabel": {
+    "text": "IP 주소 또는 CIDR",
+    "source_hash": "133d0819"
+  },
+  "web.admin.bannedIps.form.reasonLabel": {
+    "text": "사유 (선택 사항)",
+    "source_hash": "0f7d4664"
+  },
+  "web.admin.bannedIps.form.reasonPlaceholder": {
+    "text": "예: 자격 증명 스터핑",
+    "source_hash": "828a15ae"
+  },
+  "web.admin.bannedIps.form.submit": {
+    "text": "IP 차단",
+    "source_hash": "f91a5285"
+  },
+  "web.admin.bannedIps.list.loadError": {
+    "text": "차단된 IP를 불러올 수 없습니다.",
+    "source_hash": "539f2e34"
+  },
+  "web.admin.bannedIps.list.retry": {
+    "text": "다시 시도",
+    "source_hash": "942087cc"
+  },
+  "web.admin.bannedIps.list.empty": {
+    "text": "현재 차단된 IP가 없습니다",
+    "source_hash": "b72cc9c5"
+  },
+  "web.admin.bannedIps.stats.total": {
+    "text": "총 차단 수",
+    "source_hash": "41059c94"
+  },
+  "web.admin.bannedIps.unban.confirmTitle": {
+    "text": "이 차단을 해제하시겠습니까?",
+    "source_hash": "88473e59"
+  },
+  "web.admin.bannedIps.unban.confirmDescription": {
+    "text": "{ip}의 차단을 해제합니다. 확인하려면 IP를 입력하세요.",
+    "source_hash": "6bec3191"
+  },
+  "web.admin.bannedIps.unban.button": {
+    "text": "차단 해제",
+    "source_hash": "25fb5989"
+  },
+  "web.admin.bannedIps.unban.success": {
+    "text": "{ip}의 차단을 해제했습니다",
+    "source_hash": "79192c36"
+  }
+}

--- a/locales/content/ko/admin-banner.json
+++ b/locales/content/ko/admin-banner.json
@@ -1,0 +1,154 @@
+{
+  "web.admin.banner.title": {
+    "text": "브로드캐스트 배너",
+    "source_hash": "0bc449a3"
+  },
+  "web.admin.banner.description": {
+    "text": "모든 방문자에게 표시되는 사이트 전체 공지를 게시하거나 현재 공지를 삭제합니다.",
+    "source_hash": "a0f720d7"
+  },
+  "web.admin.banner.loadError": {
+    "text": "현재 배너를 불러올 수 없습니다.",
+    "source_hash": "04954e72"
+  },
+  "web.admin.banner.retry": {
+    "text": "다시 시도",
+    "source_hash": "942087cc"
+  },
+  "web.admin.banner.clear.button": {
+    "text": "배너 삭제",
+    "source_hash": "da6b2e5d"
+  },
+  "web.admin.banner.clear.confirmTitle": {
+    "text": "브로드캐스트 배너를 삭제하시겠습니까?",
+    "source_hash": "46d9c35a"
+  },
+  "web.admin.banner.clear.confirmDescription": {
+    "text": "모든 방문자에게 표시되는 실시간 배너가 제거됩니다. 진행하려면 확인 단어를 입력하세요.",
+    "source_hash": "9a56e4be"
+  },
+  "web.admin.banner.clear.success": {
+    "text": "브로드캐스트 배너가 삭제되었습니다.",
+    "source_hash": "b0f52af4"
+  },
+  "web.admin.banner.current.title": {
+    "text": "현재 배너",
+    "source_hash": "d17ab873"
+  },
+  "web.admin.banner.current.none": {
+    "text": "현재 설정된 배너가 없습니다.",
+    "source_hash": "487b2cac"
+  },
+  "web.admin.banner.current.status": {
+    "text": "상태",
+    "source_hash": "920e413c"
+  },
+  "web.admin.banner.current.live": {
+    "text": "게시 중",
+    "source_hash": "b64ac05f"
+  },
+  "web.admin.banner.current.expiry": {
+    "text": "만료",
+    "source_hash": "6956d814"
+  },
+  "web.admin.banner.current.persistent": {
+    "text": "지속 (만료 없음)",
+    "source_hash": "5f95d1b0"
+  },
+  "web.admin.banner.current.expiresIn": {
+    "text": "{duration} 후 만료",
+    "source_hash": "f353f9a7"
+  },
+  "web.admin.banner.current.audience": {
+    "text": "대상",
+    "source_hash": "545c0235"
+  },
+  "web.admin.banner.current.storedContent": {
+    "text": "저장된 콘텐츠",
+    "source_hash": "3579f3e6"
+  },
+  "web.admin.banner.current.htmlNote": {
+    "text": "콘텐츠는 HTML이며, 표시될 때 사이트에서 링크만 남기고 정리합니다.",
+    "source_hash": "e45a7dfe"
+  },
+  "web.admin.banner.current.edit": {
+    "text": "편집",
+    "source_hash": "464c4ffd"
+  },
+  "web.admin.banner.set.title": {
+    "text": "배너 설정",
+    "source_hash": "b6f90d5c"
+  },
+  "web.admin.banner.set.updateTitle": {
+    "text": "배너 업데이트",
+    "source_hash": "841a0183"
+  },
+  "web.admin.banner.set.contentLabel": {
+    "text": "메시지",
+    "source_hash": "2f77668a"
+  },
+  "web.admin.banner.set.contentPlaceholder": {
+    "text": "일요일 02:00 UTC 예정된 유지 보수",
+    "source_hash": "4ec99d7d"
+  },
+  "web.admin.banner.set.contentHelp": {
+    "text": "HTML을 사용할 수 있습니다. 사이트에서 링크만 남기고 정리합니다.",
+    "source_hash": "7253d1cd"
+  },
+  "web.admin.banner.set.ttlLabel": {
+    "text": "자동 만료 시간 (초)",
+    "source_hash": "72134116"
+  },
+  "web.admin.banner.set.ttlPlaceholder": {
+    "text": "만료가 없으면 비워 두세요",
+    "source_hash": "a8fd81e1"
+  },
+  "web.admin.banner.set.ttlHelp": {
+    "text": "선택 사항입니다. 이 시간(초)이 지나면 배너가 자동으로 제거됩니다.",
+    "source_hash": "ba0237f5"
+  },
+  "web.admin.banner.set.scopeLabel": {
+    "text": "대상",
+    "source_hash": "545c0235"
+  },
+  "web.admin.banner.set.scopeHelp": {
+    "text": "배너를 표시할 페이지입니다. 사용자 지정 도메인 페이지는 모든 페이지로 설정된 경우에만 표시됩니다.",
+    "source_hash": "28cc3018"
+  },
+  "web.admin.banner.set.scopeNoRecipient": {
+    "text": "수신자 페이지를 제외한 모든 페이지",
+    "source_hash": "8575b3c0"
+  },
+  "web.admin.banner.set.scopeWorkspace": {
+    "text": "워크스페이스 페이지만",
+    "source_hash": "563e003e"
+  },
+  "web.admin.banner.set.scopeAll": {
+    "text": "모든 페이지 (사용자 지정 도메인 포함)",
+    "source_hash": "b9b74870"
+  },
+  "web.admin.banner.set.publishButton": {
+    "text": "배너 게시",
+    "source_hash": "5b7427a1"
+  },
+  "web.admin.banner.set.updateButton": {
+    "text": "배너 업데이트",
+    "source_hash": "69b6e40e"
+  },
+  "web.admin.banner.set.confirmTitle": {
+    "text": "브로드캐스트 배너를 게시하시겠습니까?",
+    "source_hash": "8b72b5c3"
+  },
+  "web.admin.banner.set.confirmDescription": {
+    "text": "이 배너는 삭제되거나 만료될 때까지 사이트 전체의 모든 방문자에게 표시됩니다.",
+    "source_hash": "c61bbec1"
+  },
+  "web.admin.banner.set.confirmButton": {
+    "text": "게시",
+    "source_hash": "859390eb"
+  },
+  "web.admin.banner.set.success": {
+    "text": "브로드캐스트 배너가 게시되었습니다.",
+    "source_hash": "55c06cab"
+  }
+}

--- a/locales/content/ko/admin-billing.json
+++ b/locales/content/ko/admin-billing.json
@@ -1,0 +1,126 @@
+{
+  "web.admin.billing.title": {
+    "text": "결제 카탈로그",
+    "source_hash": "bfde7e68"
+  },
+  "web.admin.billing.description": {
+    "text": "구성된 요금제와 해당 이용 권한, 그리고 실시간 Stripe 동기화 카탈로그와의 편차를 읽기 전용으로 표시합니다.",
+    "source_hash": "05d5b332"
+  },
+  "web.admin.billing.retry": {
+    "text": "다시 시도",
+    "source_hash": "942087cc"
+  },
+  "web.admin.billing.loadError": {
+    "text": "결제 카탈로그를 불러올 수 없습니다.",
+    "source_hash": "c3110f77"
+  },
+  "web.admin.billing.localConfigWarning": {
+    "text": "Stripe 동기화 요금제 캐시가 비어 있어 실시간 요금제와 편차를 평가할 수 없습니다. 구성된 카탈로그(billing.yaml)만 표시합니다 — 개발 환경이거나 Stripe가 구성되지 않은 경우에 일반적입니다.",
+    "source_hash": "905d95f8"
+  },
+  "web.admin.billing.inSync": {
+    "text": "동기화됨",
+    "source_hash": "5701958c"
+  },
+  "web.admin.billing.driftCount": {
+    "text": "{count}개의 차이",
+    "source_hash": "166538f5"
+  },
+  "web.admin.billing.inSyncDetail": {
+    "text": "구성된 카탈로그가 실시간 요금제와 일치합니다. 편차가 감지되지 않았습니다.",
+    "source_hash": "57ab60a6"
+  },
+  "web.admin.billing.columns.planid": {
+    "text": "요금제 ID",
+    "source_hash": "1f0d4dc6"
+  },
+  "web.admin.billing.columns.name": {
+    "text": "이름",
+    "source_hash": "dcd1d522"
+  },
+  "web.admin.billing.columns.tier": {
+    "text": "등급",
+    "source_hash": "cb9e8664"
+  },
+  "web.admin.billing.columns.status": {
+    "text": "상태",
+    "source_hash": "920e413c"
+  },
+  "web.admin.billing.diff.title": {
+    "text": "요금제 차이: {planid}",
+    "source_hash": "bc86e5f7"
+  },
+  "web.admin.billing.diff.subtitle": {
+    "text": "구성된 카탈로그(billing.yaml)와 실시간 Stripe 동기화 요금제를 나란히 비교합니다.",
+    "source_hash": "d92e93ae"
+  },
+  "web.admin.billing.diff.config": {
+    "text": "구성됨 (billing.yaml)",
+    "source_hash": "6bf2ff04"
+  },
+  "web.admin.billing.diff.live": {
+    "text": "실시간 (Stripe 캐시)",
+    "source_hash": "4886945d"
+  },
+  "web.admin.billing.diff.absentConfig": {
+    "text": "이 요금제는 구성된 카탈로그에 존재하지 않습니다.",
+    "source_hash": "0b594c88"
+  },
+  "web.admin.billing.diff.absentLive": {
+    "text": "이 요금제는 실시간 Stripe 동기화 캐시에 존재하지 않습니다.",
+    "source_hash": "c53f31c3"
+  },
+  "web.admin.billing.plans.title": {
+    "text": "요금제",
+    "source_hash": "dfe8b2f0"
+  },
+  "web.admin.billing.plans.empty": {
+    "text": "카탈로그에서 요금제를 찾을 수 없습니다.",
+    "source_hash": "39db3c13"
+  },
+  "web.admin.billing.plans.viewDiff": {
+    "text": "차이 보기",
+    "source_hash": "0e5d6873"
+  },
+  "web.admin.billing.source.stripe": {
+    "text": "Stripe 캐시",
+    "source_hash": "b5577327"
+  },
+  "web.admin.billing.source.localConfig": {
+    "text": "로컬 구성",
+    "source_hash": "49de43d2"
+  },
+  "web.admin.billing.stats.configured": {
+    "text": "구성된 요금제",
+    "source_hash": "4fda4796"
+  },
+  "web.admin.billing.stats.live": {
+    "text": "실시간 요금제",
+    "source_hash": "faaa88d9"
+  },
+  "web.admin.billing.stats.source": {
+    "text": "출처",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.billing.stats.drift": {
+    "text": "편차",
+    "source_hash": "8b4c8240"
+  },
+  "web.admin.billing.status.in_sync": {
+    "text": "동기화됨",
+    "source_hash": "5701958c"
+  },
+  "web.admin.billing.status.only_config": {
+    "text": "구성에만 있음",
+    "source_hash": "15836cba"
+  },
+  "web.admin.billing.status.only_live": {
+    "text": "실시간에만 있음",
+    "source_hash": "8f4ed495"
+  },
+  "web.admin.billing.status.changed": {
+    "text": "변경됨",
+    "source_hash": "2a6141e4"
+  }
+}

--- a/locales/content/ko/admin-colonel.json
+++ b/locales/content/ko/admin-colonel.json
@@ -802,5 +802,45 @@
   "web.colonel.secrets.state.viewed": {
     "text": "열람됨",
     "source_hash": "1b28d178"
+  },
+  "web.colonel.backToSite": {
+    "text": "사이트로 돌아가기",
+    "source_hash": "4ee0f819"
+  },
+  "web.colonel.customDomains.labels.domain": {
+    "text": "도메인",
+    "source_hash": "79fa3361"
+  },
+  "web.colonel.customDomains.labels.status": {
+    "text": "상태",
+    "source_hash": "920e413c"
+  },
+  "web.colonel.customDomains.labels.actions": {
+    "text": "작업",
+    "source_hash": "ff8059dc"
+  },
+  "web.colonel.nav.consoleTag": {
+    "text": "콘솔",
+    "source_hash": "29a40861"
+  },
+  "web.colonel.nav.groups.identity": {
+    "text": "신원",
+    "source_hash": "999f23fc"
+  },
+  "web.colonel.nav.groups.security": {
+    "text": "접근 및 보안",
+    "source_hash": "abb29a3f"
+  },
+  "web.colonel.nav.groups.platform": {
+    "text": "플랫폼",
+    "source_hash": "c78ffe19"
+  },
+  "web.colonel.nav.groups.billing": {
+    "text": "결제",
+    "source_hash": "3ac8bbca"
+  },
+  "web.colonel.nav.groups.communications": {
+    "text": "커뮤니케이션",
+    "source_hash": "919a9253"
   }
 }

--- a/locales/content/ko/admin-customers.json
+++ b/locales/content/ko/admin-customers.json
@@ -1,0 +1,486 @@
+{
+  "web.admin.customers.title": {
+    "text": "고객",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.customers.description": {
+    "text": "SSH 없이 고객을 찾고 지원 문제를 해결합니다.",
+    "source_hash": "c8487e68"
+  },
+  "web.admin.customers.actions.plan.label": {
+    "text": "요금제",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.actions.plan.apply": {
+    "text": "적용",
+    "source_hash": "31e392d1"
+  },
+  "web.admin.customers.actions.plan.confirmTitle": {
+    "text": "요금제를 변경하시겠습니까?",
+    "source_hash": "910a4de9"
+  },
+  "web.admin.customers.actions.plan.confirmDescription": {
+    "text": "{email}을(를) {plan} 요금제로 변경합니다.",
+    "source_hash": "83fb4158"
+  },
+  "web.admin.customers.actions.plan.success": {
+    "text": "요금제가 업데이트되었습니다.",
+    "source_hash": "ebe8d40c"
+  },
+  "web.admin.customers.actions.plan.localConfigWarning": {
+    "text": "로컬 구성에서 요금제를 불러왔습니다 — Stripe가 구성되지 않았거나 연결할 수 없습니다.",
+    "source_hash": "df83e326"
+  },
+  "web.admin.customers.actions.purge.button": {
+    "text": "고객 완전 삭제",
+    "source_hash": "ff658f69"
+  },
+  "web.admin.customers.actions.purge.confirmTitle": {
+    "text": "고객을 완전 삭제하시겠습니까?",
+    "source_hash": "9feed9f1"
+  },
+  "web.admin.customers.actions.purge.confirmDescription": {
+    "text": "{email}과(와) 해당 고객의 모든 데이터를 영구적으로 삭제합니다. 이 작업은 취소할 수 없습니다.",
+    "source_hash": "a74dd5d1"
+  },
+  "web.admin.customers.actions.purge.success": {
+    "text": "고객이 완전 삭제되었습니다.",
+    "source_hash": "6145e5c8"
+  },
+  "web.admin.customers.actions.role.label": {
+    "text": "역할",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.actions.role.apply": {
+    "text": "적용",
+    "source_hash": "31e392d1"
+  },
+  "web.admin.customers.actions.role.confirmTitle": {
+    "text": "역할을 변경하시겠습니까?",
+    "source_hash": "227f57d7"
+  },
+  "web.admin.customers.actions.role.confirmDescription": {
+    "text": "{email}을(를) {role} 역할로 변경합니다.",
+    "source_hash": "9ba063c6"
+  },
+  "web.admin.customers.actions.role.success": {
+    "text": "역할이 업데이트되었습니다.",
+    "source_hash": "0c33aa24"
+  },
+  "web.admin.customers.actions.suspend.button": {
+    "text": "계정 정지",
+    "source_hash": "95a04f27"
+  },
+  "web.admin.customers.actions.suspend.reasonLabel": {
+    "text": "사유 (선택 사항)",
+    "source_hash": "0f7d4664"
+  },
+  "web.admin.customers.actions.suspend.reasonPlaceholder": {
+    "text": "이 계정을 정지하는 이유는 무엇입니까?",
+    "source_hash": "8eca975e"
+  },
+  "web.admin.customers.actions.suspend.confirmTitle": {
+    "text": "계정을 정지하시겠습니까?",
+    "source_hash": "cbfa275b"
+  },
+  "web.admin.customers.actions.suspend.confirmDescription": {
+    "text": "{email}의 로그인을 차단하고 활성 세션을 취소합니다. 데이터는 삭제되지 않으며 — 되돌릴 수 있습니다.",
+    "source_hash": "e5d046bc"
+  },
+  "web.admin.customers.actions.suspend.success": {
+    "text": "계정이 정지되었습니다.",
+    "source_hash": "04c5f996"
+  },
+  "web.admin.customers.actions.unsuspend.button": {
+    "text": "계정 정지 해제",
+    "source_hash": "35a10fb5"
+  },
+  "web.admin.customers.actions.unsuspend.confirmTitle": {
+    "text": "계정 정지를 해제하시겠습니까?",
+    "source_hash": "6fd78a72"
+  },
+  "web.admin.customers.actions.unsuspend.confirmDescription": {
+    "text": "{email}의 로그인을 복구합니다.",
+    "source_hash": "cb2bb4e0"
+  },
+  "web.admin.customers.actions.unsuspend.success": {
+    "text": "계정 정지가 해제되었습니다.",
+    "source_hash": "c5b4377f"
+  },
+  "web.admin.customers.actions.unverify.button": {
+    "text": "인증 해제",
+    "source_hash": "b0dee41f"
+  },
+  "web.admin.customers.actions.unverify.confirmTitle": {
+    "text": "고객 인증을 해제하시겠습니까?",
+    "source_hash": "62ed2854"
+  },
+  "web.admin.customers.actions.unverify.confirmDescription": {
+    "text": "{email}을(를) 인증되지 않음으로 표시합니다.",
+    "source_hash": "592ffd27"
+  },
+  "web.admin.customers.actions.unverify.success": {
+    "text": "고객 인증이 해제되었습니다.",
+    "source_hash": "a9b7bbac"
+  },
+  "web.admin.customers.actions.verify.button": {
+    "text": "인증",
+    "source_hash": "eea2745e"
+  },
+  "web.admin.customers.actions.verify.confirmTitle": {
+    "text": "고객을 인증하시겠습니까?",
+    "source_hash": "43037ce1"
+  },
+  "web.admin.customers.actions.verify.confirmDescription": {
+    "text": "{email}을(를) 인증됨으로 표시합니다.",
+    "source_hash": "7052d79d"
+  },
+  "web.admin.customers.actions.verify.success": {
+    "text": "고객이 인증되었습니다.",
+    "source_hash": "19e382dc"
+  },
+  "web.admin.customers.columns.email": {
+    "text": "이메일",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.customers.columns.role": {
+    "text": "역할",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.columns.verified": {
+    "text": "인증됨",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.columns.plan": {
+    "text": "요금제",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.columns.secrets": {
+    "text": "비밀 메시지",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.customers.columns.created": {
+    "text": "생성됨",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.columns.lastLogin": {
+    "text": "마지막 로그인",
+    "source_hash": "0d39602d"
+  },
+  "web.admin.customers.detail.backToList": {
+    "text": "고객 목록으로 돌아가기",
+    "source_hash": "077807fb"
+  },
+  "web.admin.customers.detail.openFullPage": {
+    "text": "전체 페이지 열기",
+    "source_hash": "a467911c"
+  },
+  "web.admin.customers.detail.notFound": {
+    "text": "고객을 찾을 수 없음",
+    "source_hash": "5e3f5824"
+  },
+  "web.admin.customers.detail.notFoundDescription": {
+    "text": "이 식별자와 일치하는 고객이 없습니다. 완전 삭제되었을 수 있습니다.",
+    "source_hash": "82b04725"
+  },
+  "web.admin.customers.detail.loadError": {
+    "text": "이 고객을 불러올 수 없습니다.",
+    "source_hash": "cfd1bcca"
+  },
+  "web.admin.customers.detail.retry": {
+    "text": "다시 시도",
+    "source_hash": "942087cc"
+  },
+  "web.admin.customers.detail.yes": {
+    "text": "예",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.customers.detail.no": {
+    "text": "아니요",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.customers.detail.none": {
+    "text": "없음",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.never": {
+    "text": "한 번도 없음",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.customers.detail.billing.plan": {
+    "text": "요금제",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.detail.billing.organization": {
+    "text": "결제 조직",
+    "source_hash": "90c94ee1"
+  },
+  "web.admin.customers.detail.billing.subscriptionStatus": {
+    "text": "구독 상태",
+    "source_hash": "f0723c4e"
+  },
+  "web.admin.customers.detail.billing.periodEnd": {
+    "text": "현재 기간 종료일",
+    "source_hash": "742b8229"
+  },
+  "web.admin.customers.detail.billing.latestInvoice": {
+    "text": "최근 청구서",
+    "source_hash": "7a6133cc"
+  },
+  "web.admin.customers.detail.billing.noInvoices": {
+    "text": "청구서 없음",
+    "source_hash": "e6b30f93"
+  },
+  "web.admin.customers.detail.billing.openStripe": {
+    "text": "Stripe 대시보드에서 열기",
+    "source_hash": "dfa7c41d"
+  },
+  "web.admin.customers.detail.billing.unavailable": {
+    "text": "Stripe 데이터를 사용할 수 없습니다: {reason}",
+    "source_hash": "9fe08e49"
+  },
+  "web.admin.customers.detail.billing.notConfigured": {
+    "text": "이 설치 환경에서는 결제가 구성되어 있지 않습니다.",
+    "source_hash": "6e90375e"
+  },
+  "web.admin.customers.detail.fields.email": {
+    "text": "이메일",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.customers.detail.fields.publicId": {
+    "text": "공개 ID",
+    "source_hash": "3705b64f"
+  },
+  "web.admin.customers.detail.fields.role": {
+    "text": "역할",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.detail.fields.verified": {
+    "text": "인증됨",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.detail.fields.plan": {
+    "text": "요금제",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.detail.fields.locale": {
+    "text": "로캘",
+    "source_hash": "ca3dc612"
+  },
+  "web.admin.customers.detail.fields.created": {
+    "text": "생성됨",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.detail.fields.updated": {
+    "text": "업데이트됨",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.customers.detail.fields.lastLogin": {
+    "text": "마지막 로그인",
+    "source_hash": "0d39602d"
+  },
+  "web.admin.customers.detail.fields.suspendedAt": {
+    "text": "정지 일시",
+    "source_hash": "7227f219"
+  },
+  "web.admin.customers.detail.fields.suspendedBy": {
+    "text": "정지한 사람",
+    "source_hash": "e0830524"
+  },
+  "web.admin.customers.detail.fields.suspendedReason": {
+    "text": "정지 사유",
+    "source_hash": "d6b08d8e"
+  },
+  "web.admin.customers.detail.organizations.empty": {
+    "text": "조직 없음",
+    "source_hash": "c256efdc"
+  },
+  "web.admin.customers.detail.organizations.default": {
+    "text": "기본값",
+    "source_hash": "21b111cb"
+  },
+  "web.admin.customers.detail.receiptColumns.shortId": {
+    "text": "짧은 ID",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.customers.detail.receiptColumns.state": {
+    "text": "상태",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.customers.detail.receiptColumns.created": {
+    "text": "생성됨",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.detail.receipts.empty": {
+    "text": "영수증 없음",
+    "source_hash": "fb425a68"
+  },
+  "web.admin.customers.detail.secretColumns.shortId": {
+    "text": "짧은 ID",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.customers.detail.secretColumns.state": {
+    "text": "상태",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.customers.detail.secretColumns.created": {
+    "text": "생성됨",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.detail.secretColumns.expiration": {
+    "text": "만료",
+    "source_hash": "f38d6e0e"
+  },
+  "web.admin.customers.detail.secrets.empty": {
+    "text": "비밀 메시지 없음",
+    "source_hash": "c37ab3f7"
+  },
+  "web.admin.customers.detail.sections.profile": {
+    "text": "프로필",
+    "source_hash": "d696a35b"
+  },
+  "web.admin.customers.detail.sections.secrets": {
+    "text": "비밀 메시지",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.customers.detail.sections.receipts": {
+    "text": "영수증",
+    "source_hash": "60a627df"
+  },
+  "web.admin.customers.detail.sections.organizations": {
+    "text": "조직",
+    "source_hash": "2730183d"
+  },
+  "web.admin.customers.detail.sections.actions": {
+    "text": "작업",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.sections.billing": {
+    "text": "결제",
+    "source_hash": "3ac8bbca"
+  },
+  "web.admin.customers.detail.sessions.title": {
+    "text": "활성 세션",
+    "source_hash": "b58fa4e0"
+  },
+  "web.admin.customers.detail.sessions.empty": {
+    "text": "활성 세션이 없습니다.",
+    "source_hash": "6f064eb9"
+  },
+  "web.admin.customers.detail.sessions.loadError": {
+    "text": "세션을 불러올 수 없습니다.",
+    "source_hash": "d2884313"
+  },
+  "web.admin.customers.detail.sessions.unknown": {
+    "text": "알 수 없음",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.customers.detail.sessions.columns.lastActivity": {
+    "text": "마지막 활동",
+    "source_hash": "06475633"
+  },
+  "web.admin.customers.detail.sessions.columns.ipAddress": {
+    "text": "IP 주소",
+    "source_hash": "0302a467"
+  },
+  "web.admin.customers.detail.sessions.columns.device": {
+    "text": "기기",
+    "source_hash": "6ba0bdec"
+  },
+  "web.admin.customers.detail.sessions.columns.authMethod": {
+    "text": "인증 방법",
+    "source_hash": "bc4ea262"
+  },
+  "web.admin.customers.detail.sessions.columns.actions": {
+    "text": "작업",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.sessions.revoke.button": {
+    "text": "취소",
+    "source_hash": "87e6d00b"
+  },
+  "web.admin.customers.detail.sessions.revoke.confirmTitle": {
+    "text": "세션을 취소하시겠습니까?",
+    "source_hash": "7735d1ef"
+  },
+  "web.admin.customers.detail.sessions.revoke.confirmDescription": {
+    "text": "이 세션에서 사용자를 즉시 로그아웃시킵니다. 다시 로그인해야 합니다.",
+    "source_hash": "b4291af0"
+  },
+  "web.admin.customers.detail.sessions.revoke.success": {
+    "text": "세션이 취소되었습니다.",
+    "source_hash": "5e4762e5"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.button": {
+    "text": "모두 취소",
+    "source_hash": "c6847a4b"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.confirmTitle": {
+    "text": "모든 세션을 취소하시겠습니까?",
+    "source_hash": "a4fa4c65"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.confirmDescription": {
+    "text": "이 목록에 표시되지 않은 세션을 포함하여 모든 기기와 브라우저에서 사용자를 로그아웃시키고 인증된 경로에 대한 접근을 즉시 차단합니다. 오프보딩 또는 계정 탈취가 의심될 때 사용하세요. 확인하려면 사용자의 ID를 입력하세요.",
+    "source_hash": "483cdd88"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.success": {
+    "text": "모든 세션을 취소했습니다 ({count}개 종료).",
+    "source_hash": "4e1cce55"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.capped": {
+    "text": "{count}개의 세션을 종료했지만, 추적되지 않은 세션 정리가 중단되었습니다 — 이전 세션이 남아 있을 수 있습니다. 확실히 하려면 다시 실행하세요.",
+    "source_hash": "e3d295a6"
+  },
+  "web.admin.customers.detail.stats.secretsCreated": {
+    "text": "생성된 비밀 메시지",
+    "source_hash": "7d17719e"
+  },
+  "web.admin.customers.detail.stats.secretsShared": {
+    "text": "공유된 비밀 메시지",
+    "source_hash": "ba85b265"
+  },
+  "web.admin.customers.detail.stats.emailsSent": {
+    "text": "발송된 이메일",
+    "source_hash": "be604792"
+  },
+  "web.admin.customers.list.roleFilter": {
+    "text": "역할",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.list.empty": {
+    "text": "고객을 찾을 수 없음",
+    "source_hash": "dc754ec0"
+  },
+  "web.admin.customers.list.loadError": {
+    "text": "고객을 불러올 수 없습니다.",
+    "source_hash": "81783303"
+  },
+  "web.admin.customers.list.searchPlaceholder": {
+    "text": "이메일, extid 또는 objid로 검색",
+    "source_hash": "c06d5a3b"
+  },
+  "web.admin.customers.list.emptySearch": {
+    "text": "이 검색과 일치하는 고객이 없습니다",
+    "source_hash": "ea7e7012"
+  },
+  "web.admin.customers.roles.colonel": {
+    "text": "Colonel",
+    "source_hash": "02577777"
+  },
+  "web.admin.customers.roles.admin": {
+    "text": "관리자",
+    "source_hash": "c1c224b0"
+  },
+  "web.admin.customers.roles.staff": {
+    "text": "직원",
+    "source_hash": "681927e3"
+  },
+  "web.admin.customers.roles.customer": {
+    "text": "고객",
+    "source_hash": "bf376338"
+  },
+  "web.admin.customers.suspended.badge": {
+    "text": "정지됨",
+    "source_hash": "e392a389"
+  }
+}

--- a/locales/content/ko/admin-domains.json
+++ b/locales/content/ko/admin-domains.json
@@ -1,0 +1,194 @@
+{
+  "web.admin.domains.retry": {
+    "text": "다시 시도",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.addDomain.button": {
+    "text": "도메인 추가",
+    "source_hash": "d86476ae"
+  },
+  "web.admin.domains.addDomain.title": {
+    "text": "사용자 지정 도메인 추가",
+    "source_hash": "592d3314"
+  },
+  "web.admin.domains.addDomain.forOrg": {
+    "text": "{org}의 도메인을 추가합니다.",
+    "source_hash": "f8b8c1ac"
+  },
+  "web.admin.domains.addDomain.domainLabel": {
+    "text": "도메인",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domains.addDomain.domainPlaceholder": {
+    "text": "secrets.example.com",
+    "source_hash": "9ea4d0d6"
+  },
+  "web.admin.domains.addDomain.strategyLabel": {
+    "text": "검증 전략",
+    "source_hash": "a2e95531"
+  },
+  "web.admin.domains.addDomain.createButton": {
+    "text": "생성",
+    "source_hash": "4759498a"
+  },
+  "web.admin.domains.addDomain.created": {
+    "text": "{domain}이(가) 생성되었습니다.",
+    "source_hash": "2263ec6a"
+  },
+  "web.admin.domains.addDomain.strategy.approximated": {
+    "text": "Approximated — DNS 소유권 확인, 프록시 없음.",
+    "source_hash": "79a7245c"
+  },
+  "web.admin.domains.addDomain.strategy.passthrough": {
+    "text": "Passthrough — 이 배포 환경의 프록시로 DNS를 지정합니다.",
+    "source_hash": "9702d758"
+  },
+  "web.admin.domains.addDomain.strategy.external": {
+    "text": "External — DNS가 이 배포 환경 외부에서 관리됩니다.",
+    "source_hash": "acaede35"
+  },
+  "web.admin.domains.addDomain.strategy.caddy_on_demand": {
+    "text": "Caddy 온디맨드 — 첫 요청 시 인증서가 자동으로 발급됩니다.",
+    "source_hash": "deb90ae6"
+  },
+  "web.admin.domains.addDomain.strategy.caddy": {
+    "text": "Caddy — 첫 요청 시 인증서가 자동으로 발급됩니다.",
+    "source_hash": "a0f3c2dc"
+  },
+  "web.admin.domains.addDomain.strategy.unknown": {
+    "text": "배포 전체 검증 전략입니다.",
+    "source_hash": "4587f9cf"
+  },
+  "web.admin.domains.attach.cta": {
+    "text": "조직에 도메인 연결",
+    "source_hash": "736d74ce"
+  },
+  "web.admin.domains.attach.recordEyebrow": {
+    "text": "작업 레코드",
+    "source_hash": "2fadf983"
+  },
+  "web.admin.domains.attach.rosterError": {
+    "text": "이 조직의 도메인을 불러올 수 없습니다.",
+    "source_hash": "d3055fed"
+  },
+  "web.admin.domains.attach.noDomains": {
+    "text": "아직 이 조직에 연결된 도메인이 없습니다.",
+    "source_hash": "e9a25fc4"
+  },
+  "web.admin.domains.attach.openExternal": {
+    "text": "{domain}을(를) 새 탭에서 열기",
+    "source_hash": "c5fbdeaa"
+  },
+  "web.admin.domains.dns.heading": {
+    "text": "게시할 DNS 레코드",
+    "source_hash": "e4efbe2b"
+  },
+  "web.admin.domains.dns.txtStep": {
+    "text": "1. 소유권을 증명하기 위해 TXT 레코드를 추가합니다.",
+    "source_hash": "fdcfcfb0"
+  },
+  "web.admin.domains.dns.aStep": {
+    "text": "2. 최상위 도메인을 프록시로 지정하는 A 레코드를 추가합니다.",
+    "source_hash": "aedbf197"
+  },
+  "web.admin.domains.dns.cnameStep": {
+    "text": "2. 하위 도메인을 프록시로 지정하는 CNAME 레코드를 추가합니다.",
+    "source_hash": "5c626f53"
+  },
+  "web.admin.domains.dns.propagationNote": {
+    "text": "DNS 변경 사항이 전파되어 검증이 완료되기까지 몇 분이 걸릴 수 있습니다.",
+    "source_hash": "7caf70a7"
+  },
+  "web.admin.domains.dns.toggle": {
+    "text": "DNS 세부 정보",
+    "source_hash": "ebf2d44e"
+  },
+  "web.admin.domains.dns.loadError": {
+    "text": "DNS 세부 정보를 불러올 수 없습니다.",
+    "source_hash": "4c33e23d"
+  },
+  "web.admin.domains.list.loadError": {
+    "text": "도메인을 불러올 수 없습니다.",
+    "source_hash": "548deff8"
+  },
+  "web.admin.domains.orgPicker.title": {
+    "text": "조직 선택",
+    "source_hash": "48326f52"
+  },
+  "web.admin.domains.orgPicker.searchLabel": {
+    "text": "조직",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.orgPicker.searchPlaceholder": {
+    "text": "객체 ID, 외부 ID 또는 이메일",
+    "source_hash": "bb5d0055"
+  },
+  "web.admin.domains.orgPicker.searchHint": {
+    "text": "objid, extid 또는 구성원의 이메일 주소로 검색합니다.",
+    "source_hash": "fdef7332"
+  },
+  "web.admin.domains.orgPicker.loadError": {
+    "text": "조직을 검색할 수 없습니다.",
+    "source_hash": "b9e45dcf"
+  },
+  "web.admin.domains.orgPicker.parseError": {
+    "text": "조직 검색 결과를 읽을 수 없습니다.",
+    "source_hash": "44e1b9fd"
+  },
+  "web.admin.domains.orgPicker.idle": {
+    "text": "검색하려면 위에 값을 입력하세요.",
+    "source_hash": "0352e6e6"
+  },
+  "web.admin.domains.orgPicker.noResults": {
+    "text": "“{term}”과(와) 일치하는 조직이 없습니다.",
+    "source_hash": "761db594"
+  },
+  "web.admin.domains.orgPicker.unnamedOrg": {
+    "text": "이름 없는 조직",
+    "source_hash": "f218dc9d"
+  },
+  "web.admin.domains.orgPicker.domainCount": {
+    "text": "도메인 {count}개",
+    "source_hash": "cf548c8c"
+  },
+  "web.admin.domains.orgPicker.select": {
+    "text": "선택",
+    "source_hash": "2a78025d"
+  },
+  "web.admin.domains.verify.button": {
+    "text": "검증",
+    "source_hash": "eea2745e"
+  },
+  "web.admin.domains.verify.confirmTitle": {
+    "text": "도메인을 검증하시겠습니까?",
+    "source_hash": "07c4dc4f"
+  },
+  "web.admin.domains.verify.confirmDescription": {
+    "text": "{domain}에 대한 DNS 및 SSL 검증 검사를 실행합니다.",
+    "source_hash": "06797824"
+  },
+  "web.admin.domains.verify.failed": {
+    "text": "검증에 실패했습니다. 다시 시도하세요.",
+    "source_hash": "3c8432b0"
+  },
+  "web.admin.domains.verify.success.verified": {
+    "text": "{domain}이(가) 검증되었습니다.",
+    "source_hash": "802b5d1e"
+  },
+  "web.admin.domains.verify.success.resolving": {
+    "text": "{domain}이(가) 확인되고 있지만 아직 검증되지 않았습니다.",
+    "source_hash": "bc8aecad"
+  },
+  "web.admin.domains.verify.success.pending": {
+    "text": "{domain}이(가) 대기 중입니다 — DNS가 아직 확인되지 않았습니다.",
+    "source_hash": "0d9f66d5"
+  },
+  "web.admin.domains.verify.success.unverified": {
+    "text": "{domain}을(를) 검증할 수 없습니다.",
+    "source_hash": "630da482"
+  },
+  "web.admin.domains.verify.success.done": {
+    "text": "{domain}에 대한 검증이 완료되었습니다.",
+    "source_hash": "ed67e22d"
+  }
+}

--- a/locales/content/ko/admin-domaintoolbox.json
+++ b/locales/content/ko/admin-domaintoolbox.json
@@ -1,0 +1,178 @@
+{
+  "web.admin.domaintoolbox.title": {
+    "text": "도메인 도구 상자",
+    "source_hash": "5a9333db"
+  },
+  "web.admin.domaintoolbox.description": {
+    "text": "사용자 지정 도메인 관계를 진단하고 복구합니다: 고아 항목 검사, DNS/SSL 조사, 소유권 복구, 조직 간 이전.",
+    "source_hash": "778537aa"
+  },
+  "web.admin.domaintoolbox.retry": {
+    "text": "다시 시도",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domaintoolbox.preview": {
+    "text": "미리 보기",
+    "source_hash": "324b134f"
+  },
+  "web.admin.domaintoolbox.fields.extid": {
+    "text": "도메인 외부 ID",
+    "source_hash": "f52af6c5"
+  },
+  "web.admin.domaintoolbox.fields.extidPlaceholder": {
+    "text": "cd_… (도메인 extid)",
+    "source_hash": "bb9bf49a"
+  },
+  "web.admin.domaintoolbox.orphaned.title": {
+    "text": "고아 도메인",
+    "source_hash": "ddcea596"
+  },
+  "web.admin.domaintoolbox.orphaned.description": {
+    "text": "소유 조직이 없는 사용자 지정 도메인입니다. 재할당하려면 복구를 사용하세요.",
+    "source_hash": "967268f5"
+  },
+  "web.admin.domaintoolbox.orphaned.empty": {
+    "text": "고아 도메인을 찾을 수 없습니다.",
+    "source_hash": "06ef9979"
+  },
+  "web.admin.domaintoolbox.orphaned.loadError": {
+    "text": "고아 도메인을 불러올 수 없습니다.",
+    "source_hash": "ca0e33bf"
+  },
+  "web.admin.domaintoolbox.orphaned.repairAction": {
+    "text": "복구",
+    "source_hash": "1196b6c5"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.domain": {
+    "text": "도메인",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.state": {
+    "text": "상태",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.verified": {
+    "text": "인증됨",
+    "source_hash": "4f783840"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.created": {
+    "text": "생성됨",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.actions": {
+    "text": "작업",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domaintoolbox.probe.title": {
+    "text": "조사 (DNS / SSL)",
+    "source_hash": "ec69a087"
+  },
+  "web.admin.domaintoolbox.probe.description": {
+    "text": "실시간 HTTPS 요청을 보내 도메인이 트래픽을 처리하는지 확인하고 TLS 인증서를 검사합니다. 읽기 전용입니다.",
+    "source_hash": "1eecfa96"
+  },
+  "web.admin.domaintoolbox.probe.button": {
+    "text": "조사",
+    "source_hash": "3bd51ab9"
+  },
+  "web.admin.domaintoolbox.probe.healthLabel": {
+    "text": "상태",
+    "source_hash": "55898449"
+  },
+  "web.admin.domaintoolbox.repair.title": {
+    "text": "관계 복구",
+    "source_hash": "0053d07c"
+  },
+  "web.admin.domaintoolbox.repair.description": {
+    "text": "도메인의 조직 관계 불일치를 수정합니다. 먼저 미리 보기를 한 다음 적용하세요.",
+    "source_hash": "18ca490b"
+  },
+  "web.admin.domaintoolbox.repair.orgIdLabel": {
+    "text": "조직 할당 (고아 상태인 경우)",
+    "source_hash": "f95b010a"
+  },
+  "web.admin.domaintoolbox.repair.orgIdPlaceholder": {
+    "text": "조직 id 또는 extid",
+    "source_hash": "a87d634e"
+  },
+  "web.admin.domaintoolbox.repair.statusLabel": {
+    "text": "상태",
+    "source_hash": "920e413c"
+  },
+  "web.admin.domaintoolbox.repair.noIssues": {
+    "text": "문제가 발견되지 않았습니다 — 관계가 일관됩니다.",
+    "source_hash": "e1a4c49d"
+  },
+  "web.admin.domaintoolbox.repair.applyButton": {
+    "text": "복구 적용",
+    "source_hash": "3f92b29f"
+  },
+  "web.admin.domaintoolbox.repair.success": {
+    "text": "복구가 성공적으로 적용되었습니다.",
+    "source_hash": "24f25b9b"
+  },
+  "web.admin.domaintoolbox.repair.confirmTitle": {
+    "text": "도메인 복구를 적용하시겠습니까?",
+    "source_hash": "9429998b"
+  },
+  "web.admin.domaintoolbox.repair.confirmDescription": {
+    "text": "{domain}의 소유권/관계 상태를 수정합니다. 확인하려면 도메인 외부 ID를 다시 입력하세요.",
+    "source_hash": "426d267b"
+  },
+  "web.admin.domaintoolbox.reverify.button": {
+    "text": "재검증",
+    "source_hash": "0344860a"
+  },
+  "web.admin.domaintoolbox.reverify.success": {
+    "text": "도메인 재검증이 완료되었습니다.",
+    "source_hash": "497a2348"
+  },
+  "web.admin.domaintoolbox.transfer.title": {
+    "text": "소유권 이전",
+    "source_hash": "3667f939"
+  },
+  "web.admin.domaintoolbox.transfer.description": {
+    "text": "도메인을 다른 조직으로 재할당합니다. 영향 범위가 가장 큰 작업이므로 — 미리 보기 후 신중하게 확인하세요.",
+    "source_hash": "d4e26e03"
+  },
+  "web.admin.domaintoolbox.transfer.toOrgLabel": {
+    "text": "대상 조직",
+    "source_hash": "4e4486eb"
+  },
+  "web.admin.domaintoolbox.transfer.fromOrgLabel": {
+    "text": "원본 조직 (선택 사항)",
+    "source_hash": "3666815f"
+  },
+  "web.admin.domaintoolbox.transfer.fromOrgPlaceholder": {
+    "text": "현재 소유자 확인",
+    "source_hash": "cd9e769c"
+  },
+  "web.admin.domaintoolbox.transfer.from": {
+    "text": "보낸 조직",
+    "source_hash": "21819769"
+  },
+  "web.admin.domaintoolbox.transfer.to": {
+    "text": "받는 조직",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.domaintoolbox.transfer.orphaned": {
+    "text": "고아 상태",
+    "source_hash": "54dc2166"
+  },
+  "web.admin.domaintoolbox.transfer.applyButton": {
+    "text": "도메인 이전",
+    "source_hash": "9517aeb9"
+  },
+  "web.admin.domaintoolbox.transfer.success": {
+    "text": "도메인이 성공적으로 이전되었습니다.",
+    "source_hash": "bbca9de9"
+  },
+  "web.admin.domaintoolbox.transfer.confirmTitle": {
+    "text": "도메인 소유권을 이전하시겠습니까?",
+    "source_hash": "d306a15a"
+  },
+  "web.admin.domaintoolbox.transfer.confirmDescription": {
+    "text": "{domain}의 소유권을 다른 조직으로 재할당합니다. 확인하려면 도메인 외부 ID를 다시 입력하세요.",
+    "source_hash": "edefd97c"
+  }
+}

--- a/locales/content/ko/admin-emailtools.json
+++ b/locales/content/ko/admin-emailtools.json
@@ -1,0 +1,550 @@
+{
+  "web.admin.emailtools.title": {
+    "text": "이메일 도구",
+    "source_hash": "f9643d5a"
+  },
+  "web.admin.emailtools.description": {
+    "text": "이메일 템플릿을 미리 보고, 전달 테스트를 보내고, 전달 가능성을 모니터링합니다 — 이전에는 SSH가 필요했던 진단 기능입니다.",
+    "source_hash": "be85c9e9"
+  },
+  "web.admin.emailtools.config.title": {
+    "text": "메일러 구성",
+    "source_hash": "d2a71028"
+  },
+  "web.admin.emailtools.config.description": {
+    "text": "부팅 시 확인된 상시 메일 구성입니다. 자격 증명은 표시되지 않으며 — 존재 여부만 표시됩니다.",
+    "source_hash": "f0e8a118"
+  },
+  "web.admin.emailtools.config.provider": {
+    "text": "전송 공급자",
+    "source_hash": "4f0e5025"
+  },
+  "web.admin.emailtools.config.senderProvider": {
+    "text": "발신자 공급자",
+    "source_hash": "e881964f"
+  },
+  "web.admin.emailtools.config.senderDiffers": {
+    "text": "발신자가 전송과 다름",
+    "source_hash": "ab78e8f6"
+  },
+  "web.admin.emailtools.config.autoDetected": {
+    "text": "자동 감지됨",
+    "source_hash": "a69c7f9e"
+  },
+  "web.admin.emailtools.config.fromAddress": {
+    "text": "보내는 주소",
+    "source_hash": "d465bcfa"
+  },
+  "web.admin.emailtools.config.fromName": {
+    "text": "보내는 이름",
+    "source_hash": "b28f93ea"
+  },
+  "web.admin.emailtools.config.host": {
+    "text": "SMTP 호스트",
+    "source_hash": "ab328f83"
+  },
+  "web.admin.emailtools.config.port": {
+    "text": "포트",
+    "source_hash": "72e9a59f"
+  },
+  "web.admin.emailtools.config.region": {
+    "text": "지역",
+    "source_hash": "d3a008ef"
+  },
+  "web.admin.emailtools.config.hasCredentials": {
+    "text": "자격 증명 구성됨",
+    "source_hash": "1c81633a"
+  },
+  "web.admin.emailtools.config.yes": {
+    "text": "예",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.emailtools.config.no": {
+    "text": "아니요",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.emailtools.config.loggerWarning": {
+    "text": "메일이 전달되지 않고 있습니다. 전송 공급자가 비전송 모드(logger, disabled 또는 none)로 설정되어 있어 이 서버에서 이메일이 발송되지 않습니다 — 발신 메시지는 애플리케이션 로그에 기록되거나 삭제됩니다.",
+    "source_hash": "1883dfd5"
+  },
+  "web.admin.emailtools.deliverability.title": {
+    "text": "전달 가능성",
+    "source_hash": "66b4d300"
+  },
+  "web.admin.emailtools.deliverability.description": {
+    "text": "발송 후 돌아오는 결과입니다: 반송, 불만 신고, 그리고 발신자 평판을 보호하는 발송 억제 목록.",
+    "source_hash": "e8363bb5"
+  },
+  "web.admin.emailtools.deliverability.retry": {
+    "text": "다시 시도",
+    "source_hash": "942087cc"
+  },
+  "web.admin.emailtools.deliverability.events.title": {
+    "text": "최근 이벤트",
+    "source_hash": "8ecce94d"
+  },
+  "web.admin.emailtools.deliverability.events.description": {
+    "text": "원시 반송 및 불만 신고 피드를 최신순으로 표시합니다.",
+    "source_hash": "0e7a533b"
+  },
+  "web.admin.emailtools.deliverability.events.empty": {
+    "text": "아직 반송 또는 불만 신고 데이터가 없습니다. POST /api/colonel/email/deliverability/events(colonel 인증 필요 — 레코드 형식은 엔드포인트 문서 참조)를 통해 ESP의 피드백을 전달하세요. 동기식 SMTP 하드 반송은 자동으로 기록됩니다.",
+    "source_hash": "a90f259c"
+  },
+  "web.admin.emailtools.deliverability.events.loadError": {
+    "text": "최근 이벤트를 불러올 수 없습니다.",
+    "source_hash": "02244c61"
+  },
+  "web.admin.emailtools.deliverability.events.columns.time": {
+    "text": "시간",
+    "source_hash": "33b93476"
+  },
+  "web.admin.emailtools.deliverability.events.columns.kind": {
+    "text": "유형",
+    "source_hash": "baaddf70"
+  },
+  "web.admin.emailtools.deliverability.events.columns.address": {
+    "text": "주소",
+    "source_hash": "56ef8f20"
+  },
+  "web.admin.emailtools.deliverability.events.columns.source": {
+    "text": "출처",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.emailtools.deliverability.events.columns.reason": {
+    "text": "사유",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.emailtools.deliverability.events.kinds.bounce": {
+    "text": "반송",
+    "source_hash": "4d6723e5"
+  },
+  "web.admin.emailtools.deliverability.events.kinds.complaint": {
+    "text": "불만 신고",
+    "source_hash": "5d08b02d"
+  },
+  "web.admin.emailtools.deliverability.lookup.title": {
+    "text": "수신자 조회",
+    "source_hash": "7569985b"
+  },
+  "web.admin.emailtools.deliverability.lookup.description": {
+    "text": "주소가 억제되었는지 로컬 저장소와 활성 메일 공급자 양쪽에서 실시간으로 확인합니다. 둘 다 동일한 정규화된 주소를 키로 사용합니다.",
+    "source_hash": "c341d614"
+  },
+  "web.admin.emailtools.deliverability.lookup.addressLabel": {
+    "text": "수신자 주소",
+    "source_hash": "454d0391"
+  },
+  "web.admin.emailtools.deliverability.lookup.submit": {
+    "text": "조회",
+    "source_hash": "504101bc"
+  },
+  "web.admin.emailtools.deliverability.lookup.local": {
+    "text": "로컬 저장소",
+    "source_hash": "c740d116"
+  },
+  "web.admin.emailtools.deliverability.lookup.provider": {
+    "text": "공급자",
+    "source_hash": "472590ae"
+  },
+  "web.admin.emailtools.deliverability.lookup.suppressed": {
+    "text": "억제됨",
+    "source_hash": "435c7831"
+  },
+  "web.admin.emailtools.deliverability.lookup.notSuppressed": {
+    "text": "억제되지 않음",
+    "source_hash": "7b1544d7"
+  },
+  "web.admin.emailtools.deliverability.lookup.reason": {
+    "text": "사유",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.emailtools.deliverability.lookup.source": {
+    "text": "출처",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.emailtools.deliverability.lookup.unavailable": {
+    "text": "실시간 공급자 조회를 사용할 수 없습니다. 위의 로컬 저장소가 기준입니다.",
+    "source_hash": "aebed0f2"
+  },
+  "web.admin.emailtools.deliverability.messages.title": {
+    "text": "최근 발송",
+    "source_hash": "522e089e"
+  },
+  "web.admin.emailtools.deliverability.messages.description": {
+    "text": "활성 메일 공급자가 기록한 가장 최근 메시지를 최신순으로 표시합니다. 공급자에서 실시간으로 가져오며 — 이곳에는 저장되지 않습니다.",
+    "source_hash": "9970fa0a"
+  },
+  "web.admin.emailtools.deliverability.messages.empty": {
+    "text": "공급자가 반환한 최근 메시지가 없습니다.",
+    "source_hash": "a7ef4d79"
+  },
+  "web.admin.emailtools.deliverability.messages.notSupported": {
+    "text": "{provider} 전송에서는 메시지별 API를 제공하지 않으므로 발송 로그를 사용할 수 없습니다.",
+    "source_hash": "21e6b6f9"
+  },
+  "web.admin.emailtools.deliverability.messages.error": {
+    "text": "공급자에서 발송 로그를 불러올 수 없습니다. 다시 시도하세요.",
+    "source_hash": "4f671e55"
+  },
+  "web.admin.emailtools.deliverability.messages.col.status": {
+    "text": "상태",
+    "source_hash": "920e413c"
+  },
+  "web.admin.emailtools.deliverability.messages.col.subject": {
+    "text": "제목",
+    "source_hash": "68971283"
+  },
+  "web.admin.emailtools.deliverability.messages.col.to": {
+    "text": "받는 사람",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.emailtools.deliverability.messages.col.created": {
+    "text": "발송됨",
+    "source_hash": "c16bc82b"
+  },
+  "web.admin.emailtools.deliverability.messages.status.delivered": {
+    "text": "전달됨",
+    "source_hash": "373e0712"
+  },
+  "web.admin.emailtools.deliverability.messages.status.opened": {
+    "text": "열림",
+    "source_hash": "50236627"
+  },
+  "web.admin.emailtools.deliverability.messages.status.clicked": {
+    "text": "클릭됨",
+    "source_hash": "d66440b2"
+  },
+  "web.admin.emailtools.deliverability.messages.status.pending": {
+    "text": "대기 중",
+    "source_hash": "62a2fed3"
+  },
+  "web.admin.emailtools.deliverability.messages.status.queued": {
+    "text": "대기열에 있음",
+    "source_hash": "d36be649"
+  },
+  "web.admin.emailtools.deliverability.messages.status.processed": {
+    "text": "처리됨",
+    "source_hash": "58190ffa"
+  },
+  "web.admin.emailtools.deliverability.messages.status.hard_bounced": {
+    "text": "하드 반송됨",
+    "source_hash": "b0aa6fd4"
+  },
+  "web.admin.emailtools.deliverability.messages.status.soft_bounced": {
+    "text": "소프트 반송됨",
+    "source_hash": "ac844ff2"
+  },
+  "web.admin.emailtools.deliverability.messages.status.complained": {
+    "text": "불만 신고됨",
+    "source_hash": "c26fe786"
+  },
+  "web.admin.emailtools.deliverability.messages.status.suppressed": {
+    "text": "억제됨",
+    "source_hash": "f63d5b6b"
+  },
+  "web.admin.emailtools.deliverability.messages.status.unsubscribed": {
+    "text": "구독 취소됨",
+    "source_hash": "621e1970"
+  },
+  "web.admin.emailtools.deliverability.summary.loadError": {
+    "text": "전달 가능성 요약을 불러올 수 없습니다.",
+    "source_hash": "0c16ef96"
+  },
+  "web.admin.emailtools.deliverability.suppressions.title": {
+    "text": "발송 억제 목록",
+    "source_hash": "9f3e322f"
+  },
+  "web.admin.emailtools.deliverability.suppressions.description": {
+    "text": "발신 메일이 건너뛰는 주소입니다. 항목은 ESP 피드백 수집 또는 수동 가져오기를 통해 추가되며, 항목을 제거하면 전달이 재개됩니다.",
+    "source_hash": "3651887e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.searchLabel": {
+    "text": "정확한 주소",
+    "source_hash": "f4338ff8"
+  },
+  "web.admin.emailtools.deliverability.suppressions.searchPlaceholder": {
+    "text": "user{'@'}example.com",
+    "source_hash": "333f0f15"
+  },
+  "web.admin.emailtools.deliverability.suppressions.searchButton": {
+    "text": "조회",
+    "source_hash": "504101bc"
+  },
+  "web.admin.emailtools.deliverability.suppressions.clearButton": {
+    "text": "지우기",
+    "source_hash": "83b12c22"
+  },
+  "web.admin.emailtools.deliverability.suppressions.empty": {
+    "text": "아직 억제된 주소가 없습니다. 반송 및 불만 신고 피드백이 수집되면 여기에 표시됩니다.",
+    "source_hash": "dd3f4d61"
+  },
+  "web.admin.emailtools.deliverability.suppressions.emptySearch": {
+    "text": "{address}에 대한 억제 항목이 없습니다.",
+    "source_hash": "200c361e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.loadError": {
+    "text": "발송 억제 목록을 불러올 수 없습니다.",
+    "source_hash": "2a12c8ba"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.addressLabel": {
+    "text": "주소 추가",
+    "source_hash": "8be5aa33"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.button": {
+    "text": "억제",
+    "source_hash": "60b19987"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.confirmTitle": {
+    "text": "이 주소를 억제하시겠습니까?",
+    "source_hash": "40a0d2a6"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.confirmDescription": {
+    "text": "억제가 제거될 때까지 {address}(으)로의 발신 메일이 건너뛰어집니다. 이는 수동 항목으로 기록됩니다.",
+    "source_hash": "e3d0d799"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.success": {
+    "text": "{address} 주소가 억제되었습니다.",
+    "source_hash": "e2cd2c3b"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.successExisting": {
+    "text": "{address} 주소가 이미 억제되어 있었습니다. 항목이 업데이트되었습니다.",
+    "source_hash": "0852101e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.error": {
+    "text": "주소를 억제할 수 없습니다.",
+    "source_hash": "dad9e000"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.address": {
+    "text": "주소",
+    "source_hash": "56ef8f20"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.reason": {
+    "text": "사유",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.source": {
+    "text": "출처",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.added": {
+    "text": "추가됨",
+    "source_hash": "6b02e0d3"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.actions": {
+    "text": "작업",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.button": {
+    "text": "제거",
+    "source_hash": "c3812fc4"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.confirmTitle": {
+    "text": "이 억제를 제거하시겠습니까?",
+    "source_hash": "0b0aec2e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.confirmDescription": {
+    "text": "{address}(으)로의 발신 메일이 재개됩니다. 이 주소는 이전에 반송되거나 불만 신고되었습니다 — 다시 전달 가능하다는 것을 확인한 경우에만 제거하세요.",
+    "source_hash": "09442f9c"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.success": {
+    "text": "{address}에 대한 억제가 제거되었습니다.",
+    "source_hash": "bfc0de36"
+  },
+  "web.admin.emailtools.deliverability.sync.title": {
+    "text": "피드백 동기화",
+    "source_hash": "d4056915"
+  },
+  "web.admin.emailtools.deliverability.sync.lastSynced": {
+    "text": "마지막 동기화",
+    "source_hash": "5a99666b"
+  },
+  "web.admin.emailtools.deliverability.sync.imported": {
+    "text": "{count}개 가져옴",
+    "source_hash": "1bc18c45"
+  },
+  "web.admin.emailtools.deliverability.sync.neverRun": {
+    "text": "공급자 피드백 동기화가 한 번도 실행되지 않았습니다. 반송 및 불만 신고 데이터가 자동으로 가져와지지 않고 있습니다 — 공급자 동기화를 구성하거나 이벤트 엔드포인트를 통해 피드백을 수집하세요.",
+    "source_hash": "d19f5755"
+  },
+  "web.admin.emailtools.deliverability.sync.button": {
+    "text": "지금 동기화",
+    "source_hash": "885e8f48"
+  },
+  "web.admin.emailtools.deliverability.sync.success": {
+    "text": "{provider} 동기화 완료: {accepted}개 가져옴, {rejected}개 거부됨 ({fetched}개 조회됨).",
+    "source_hash": "d36f5578"
+  },
+  "web.admin.emailtools.deliverability.sync.hint": {
+    "text": "수동 동기화입니다 — 자동 가져오기는 여전히 예약된 `ots email sync-feedback` 크론이 필요합니다.",
+    "source_hash": "7a509b75"
+  },
+  "web.admin.emailtools.deliverability.tiles.suppressed": {
+    "text": "억제된 주소",
+    "source_hash": "b31a245e"
+  },
+  "web.admin.emailtools.deliverability.tiles.bounces": {
+    "text": "반송 ({days}일)",
+    "source_hash": "3a4d0f09"
+  },
+  "web.admin.emailtools.deliverability.tiles.complaints": {
+    "text": "불만 신고 ({days}일)",
+    "source_hash": "16ad856f"
+  },
+  "web.admin.emailtools.deliverability.tiles.skipped": {
+    "text": "건너뛴 발송",
+    "source_hash": "391467f9"
+  },
+  "web.admin.emailtools.preview.title": {
+    "text": "템플릿 미리 보기",
+    "source_hash": "df89bd92"
+  },
+  "web.admin.emailtools.preview.description": {
+    "text": "샘플 데이터로 템플릿을 렌더링합니다. 미리 보기는 부작용이 없으며 — 이메일이 발송되지 않습니다.",
+    "source_hash": "9b0e40f3"
+  },
+  "web.admin.emailtools.preview.templateLabel": {
+    "text": "템플릿",
+    "source_hash": "0575f29d"
+  },
+  "web.admin.emailtools.preview.formatLabel": {
+    "text": "형식",
+    "source_hash": "2f343666"
+  },
+  "web.admin.emailtools.preview.localeLabel": {
+    "text": "로캘",
+    "source_hash": "ca3dc612"
+  },
+  "web.admin.emailtools.preview.button": {
+    "text": "미리 보기",
+    "source_hash": "324b134f"
+  },
+  "web.admin.emailtools.providerStatus.title": {
+    "text": "공급자 상태",
+    "source_hash": "231b7f03"
+  },
+  "web.admin.emailtools.providerStatus.rateUnavailable": {
+    "text": "이 공급자는 반송 또는 불만 신고율을 수치로 제공하지 않습니다. 위의 평판 등급은 시행 상태와 발송 할당량만을 기반으로 산출됩니다.",
+    "source_hash": "1e6b82e9"
+  },
+  "web.admin.emailtools.providerStatus.complaintsUnavailable": {
+    "text": "Lettermint은 통계 API에서 불만 신고를 보고하지 않으므로, 불만 신고율은 0이 아니라 “—”(보고되지 않음)으로 표시됩니다. 위의 반송률은 완전합니다.",
+    "source_hash": "72aaa845"
+  },
+  "web.admin.emailtools.providerStatus.unavailable": {
+    "text": "공급자 상태를 일시적으로 사용할 수 없습니다.",
+    "source_hash": "8e69ff29"
+  },
+  "web.admin.emailtools.providerStatus.notSupported": {
+    "text": "{provider} 전송에서는 실시간 공급자 상태를 사용할 수 없습니다.",
+    "source_hash": "125ed6eb"
+  },
+  "web.admin.emailtools.providerStatus.error": {
+    "text": "상태 확인을 위해 메일 공급자에 연결할 수 없습니다. 다시 시도하세요.",
+    "source_hash": "594ab7b1"
+  },
+  "web.admin.emailtools.providerStatus.quota.max24h": {
+    "text": "24시간 발송 한도",
+    "source_hash": "e5ea4c3d"
+  },
+  "web.admin.emailtools.providerStatus.quota.sent24h": {
+    "text": "발송됨 (최근 24시간)",
+    "source_hash": "d0c4fe45"
+  },
+  "web.admin.emailtools.providerStatus.quota.maxRate": {
+    "text": "최대 발송 속도 (초당)",
+    "source_hash": "59e76cf8"
+  },
+  "web.admin.emailtools.providerStatus.rate.bounce": {
+    "text": "반송률",
+    "source_hash": "9eba32f0"
+  },
+  "web.admin.emailtools.providerStatus.rate.complaint": {
+    "text": "불만 신고율",
+    "source_hash": "430a23a9"
+  },
+  "web.admin.emailtools.providerStatus.stats.sent": {
+    "text": "발송됨 ({days}일)",
+    "source_hash": "e553b7e1"
+  },
+  "web.admin.emailtools.providerStatus.stats.delivered": {
+    "text": "전달됨",
+    "source_hash": "90611565"
+  },
+  "web.admin.emailtools.providerStatus.stats.hardBounced": {
+    "text": "하드 반송됨",
+    "source_hash": "c76631c0"
+  },
+  "web.admin.emailtools.providerStatus.stats.complaints": {
+    "text": "스팸 신고",
+    "source_hash": "d48953cd"
+  },
+  "web.admin.emailtools.providerStatus.tier.healthy": {
+    "text": "정상",
+    "source_hash": "7f1e323b"
+  },
+  "web.admin.emailtools.providerStatus.tier.probation": {
+    "text": "검토 중",
+    "source_hash": "9e8a3b64"
+  },
+  "web.admin.emailtools.providerStatus.tier.shutdown": {
+    "text": "발송 일시 중지됨",
+    "source_hash": "52e6757c"
+  },
+  "web.admin.emailtools.test.title": {
+    "text": "테스트 발송",
+    "source_hash": "5fab5d67"
+  },
+  "web.admin.emailtools.test.description": {
+    "text": "전달 연결을 확인하기 위해 일반 텍스트 진단 이메일을 보냅니다. 먼저 미리 본 다음 확인하여 실제 이메일을 보내세요.",
+    "source_hash": "4130741c"
+  },
+  "web.admin.emailtools.test.toLabel": {
+    "text": "수신자",
+    "source_hash": "51fac985"
+  },
+  "web.admin.emailtools.test.toPlaceholder": {
+    "text": "you{'@'}example.com",
+    "source_hash": "cf0a9acc"
+  },
+  "web.admin.emailtools.test.enqueueLabel": {
+    "text": "워커 대기열을 통해",
+    "source_hash": "97897017"
+  },
+  "web.admin.emailtools.test.previewButton": {
+    "text": "미리 보기 (발송 안 함)",
+    "source_hash": "747ced83"
+  },
+  "web.admin.emailtools.test.sendButton": {
+    "text": "테스트 이메일 발송",
+    "source_hash": "46ebd7db"
+  },
+  "web.admin.emailtools.test.provider": {
+    "text": "공급자",
+    "source_hash": "472590ae"
+  },
+  "web.admin.emailtools.test.host": {
+    "text": "출처 호스트",
+    "source_hash": "968925cb"
+  },
+  "web.admin.emailtools.test.from": {
+    "text": "보낸 사람",
+    "source_hash": "21819769"
+  },
+  "web.admin.emailtools.test.subject": {
+    "text": "제목",
+    "source_hash": "68971283"
+  },
+  "web.admin.emailtools.test.confirmTitle": {
+    "text": "실제 테스트 이메일을 보내시겠습니까?",
+    "source_hash": "64a16b62"
+  },
+  "web.admin.emailtools.test.confirmDescription": {
+    "text": "구성된 메일러를 통해 {to}(으)로 실제 이메일을 발송합니다.",
+    "source_hash": "10114929"
+  },
+  "web.admin.emailtools.test.success": {
+    "text": "{to}(으)로 테스트 이메일을 보냈습니다.",
+    "source_hash": "daa61a62"
+  }
+}

--- a/locales/content/ko/admin-kit.json
+++ b/locales/content/ko/admin-kit.json
@@ -1,0 +1,66 @@
+{
+  "web.admin.kit.confirmDialog.typePrompt": {
+    "text": "확인하려면 아래에 {token}을(를) 입력하세요",
+    "source_hash": "282445b6"
+  },
+  "web.admin.kit.confirmDialog.inputLabel": {
+    "text": "확인 텍스트",
+    "source_hash": "8edc1113"
+  },
+  "web.admin.kit.confirmDialog.mismatchHint": {
+    "text": "계속하려면 입력한 텍스트가 정확히 일치해야 합니다.",
+    "source_hash": "f0cc7389"
+  },
+  "web.admin.kit.dataTable.empty": {
+    "text": "레코드를 찾을 수 없음",
+    "source_hash": "6e2ea637"
+  },
+  "web.admin.kit.dataTable.sortBy": {
+    "text": "{column} 기준 정렬",
+    "source_hash": "55fb1bf9"
+  },
+  "web.admin.kit.filterBar.search": {
+    "text": "검색",
+    "source_hash": "49c266ba"
+  },
+  "web.admin.kit.filterBar.searchPlaceholder": {
+    "text": "검색…",
+    "source_hash": "7336265a"
+  },
+  "web.admin.kit.filterBar.clearFilters": {
+    "text": "필터 지우기",
+    "source_hash": "7179ea00"
+  },
+  "web.admin.kit.filterBar.all": {
+    "text": "전체",
+    "source_hash": "a52ace42"
+  },
+  "web.admin.kit.jsonViewer.expandAll": {
+    "text": "모두 펼치기",
+    "source_hash": "a3e586be"
+  },
+  "web.admin.kit.jsonViewer.collapseAll": {
+    "text": "모두 접기",
+    "source_hash": "25f7b372"
+  },
+  "web.admin.kit.jsonViewer.empty": {
+    "text": "데이터 없음",
+    "source_hash": "3b41ba9c"
+  },
+  "web.admin.kit.jsonViewer.copyLabel": {
+    "text": "JSON 복사",
+    "source_hash": "7708c6e2"
+  },
+  "web.admin.kit.revealEmail.reveal": {
+    "text": "이메일 주소 표시",
+    "source_hash": "f6272277"
+  },
+  "web.admin.kit.revealEmail.hide": {
+    "text": "이메일 주소 숨기기",
+    "source_hash": "9755e870"
+  },
+  "web.admin.kit.revealEmail.copy": {
+    "text": "이메일 주소 복사",
+    "source_hash": "61b94846"
+  }
+}

--- a/locales/content/ko/admin-organizations.json
+++ b/locales/content/ko/admin-organizations.json
@@ -1,0 +1,314 @@
+{
+  "web.admin.organizations.retry": {
+    "text": "다시 시도",
+    "source_hash": "942087cc"
+  },
+  "web.admin.organizations.detail.backToList": {
+    "text": "조직 목록으로 돌아가기",
+    "source_hash": "2257dc4a"
+  },
+  "web.admin.organizations.detail.notFound": {
+    "text": "조직을 찾을 수 없음",
+    "source_hash": "00c50f7a"
+  },
+  "web.admin.organizations.detail.notFoundDescription": {
+    "text": "이 조직이 삭제되었거나 id가 올바르지 않을 수 있습니다.",
+    "source_hash": "e5459ef5"
+  },
+  "web.admin.organizations.detail.loadError": {
+    "text": "이 조직을 불러올 수 없습니다.",
+    "source_hash": "9df8ad50"
+  },
+  "web.admin.organizations.detail.none": {
+    "text": "—",
+    "source_hash": "bda05058"
+  },
+  "web.admin.organizations.detail.badges.default": {
+    "text": "기본 워크스페이스",
+    "source_hash": "6d67c6eb"
+  },
+  "web.admin.organizations.detail.badges.archived": {
+    "text": "보관됨",
+    "source_hash": "bdb86505"
+  },
+  "web.admin.organizations.detail.domains.domain": {
+    "text": "도메인",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.organizations.detail.domains.state": {
+    "text": "상태",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.organizations.detail.domains.created": {
+    "text": "생성됨",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.organizations.detail.domains.ready": {
+    "text": "준비됨",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.organizations.detail.domains.resolving": {
+    "text": "확인 중",
+    "source_hash": "3287a034"
+  },
+  "web.admin.organizations.detail.domains.empty": {
+    "text": "도메인 없음.",
+    "source_hash": "1b840c7e"
+  },
+  "web.admin.organizations.detail.entitlements.description": {
+    "text": "유효 이용 권한은 (요금제 ∪ 부여) − 취소로 확인됩니다. 재정의하기 전에 세부 내역을 검토하세요.",
+    "source_hash": "23080475"
+  },
+  "web.admin.organizations.detail.entitlements.inSync": {
+    "text": "동기화됨",
+    "source_hash": "5701958c"
+  },
+  "web.admin.organizations.detail.entitlements.driftBadge": {
+    "text": "편차",
+    "source_hash": "8b4c8240"
+  },
+  "web.admin.organizations.detail.entitlements.staleBadge": {
+    "text": "요금제 오래됨",
+    "source_hash": "ffe63800"
+  },
+  "web.admin.organizations.detail.entitlements.driftWarning": {
+    "text": "구체화된 이용 권한이 예상 집합과 일치하지 않습니다. 재구체화하려면 조정하세요.",
+    "source_hash": "4859983a"
+  },
+  "web.admin.organizations.detail.entitlements.driftExtra": {
+    "text": "추가 (구체화됨, 예상되지 않음)",
+    "source_hash": "08d60730"
+  },
+  "web.admin.organizations.detail.entitlements.driftMissing": {
+    "text": "누락 (예상됨, 구체화되지 않음)",
+    "source_hash": "fe12c83a"
+  },
+  "web.admin.organizations.detail.entitlements.plan": {
+    "text": "요금제에서",
+    "source_hash": "1d346b26"
+  },
+  "web.admin.organizations.detail.entitlements.materialized": {
+    "text": "구체화됨 (유효)",
+    "source_hash": "72ca5f45"
+  },
+  "web.admin.organizations.detail.members.email": {
+    "text": "구성원",
+    "source_hash": "7c968fb7"
+  },
+  "web.admin.organizations.detail.members.role": {
+    "text": "역할",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.organizations.detail.members.status": {
+    "text": "상태",
+    "source_hash": "920e413c"
+  },
+  "web.admin.organizations.detail.members.joined": {
+    "text": "가입일",
+    "source_hash": "69318b0c"
+  },
+  "web.admin.organizations.detail.members.owner": {
+    "text": "소유자",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.detail.members.empty": {
+    "text": "구성원 없음.",
+    "source_hash": "b99c59dc"
+  },
+  "web.admin.organizations.detail.reconcile.button": {
+    "text": "조정",
+    "source_hash": "b59be565"
+  },
+  "web.admin.organizations.detail.reconcile.confirmTitle": {
+    "text": "조직 결제를 조정하시겠습니까?",
+    "source_hash": "fc1a2762"
+  },
+  "web.admin.organizations.detail.reconcile.confirmDescription": {
+    "text": "Stripe를 다시 가져와 {org}의 결제 상태와 이용 권한을 다시 작성합니다. 확인하려면 조직 id를 다시 입력하세요.",
+    "source_hash": "b4ef0850"
+  },
+  "web.admin.organizations.detail.reconcile.success": {
+    "text": "조직이 조정되었습니다.",
+    "source_hash": "caf87844"
+  },
+  "web.admin.organizations.detail.reconcile.resultTitle": {
+    "text": "조정 결과",
+    "source_hash": "11f4c6b8"
+  },
+  "web.admin.organizations.detail.reconcile.before": {
+    "text": "이전",
+    "source_hash": "9bb72500"
+  },
+  "web.admin.organizations.detail.reconcile.after": {
+    "text": "이후",
+    "source_hash": "7b68fe55"
+  },
+  "web.admin.organizations.detail.reconcile.materializedCount": {
+    "text": "이용 권한 수",
+    "source_hash": "59cede5c"
+  },
+  "web.admin.organizations.detail.reconcile.mode.stripe_sync": {
+    "text": "Stripe 동기화",
+    "source_hash": "02f9546c"
+  },
+  "web.admin.organizations.detail.reconcile.mode.entitlements_only": {
+    "text": "이용 권한만",
+    "source_hash": "8cf49a5d"
+  },
+  "web.admin.organizations.detail.sections.billing": {
+    "text": "결제",
+    "source_hash": "3ac8bbca"
+  },
+  "web.admin.organizations.detail.sections.members": {
+    "text": "구성원",
+    "source_hash": "1044a4c0"
+  },
+  "web.admin.organizations.detail.sections.domains": {
+    "text": "도메인",
+    "source_hash": "ced67718"
+  },
+  "web.admin.organizations.detail.sections.investigate": {
+    "text": "조사 및 조정",
+    "source_hash": "b05aa349"
+  },
+  "web.admin.organizations.entitlements.section": {
+    "text": "이용 권한 재정의",
+    "source_hash": "48812068"
+  },
+  "web.admin.organizations.entitlements.description": {
+    "text": "요금제와 별개로 이용 권한을 부여하거나 취소합니다. 유효 = 요금제 이용 권한 + 부여 - 취소.",
+    "source_hash": "4c38425b"
+  },
+  "web.admin.organizations.entitlements.inputLabel": {
+    "text": "이용 권한",
+    "source_hash": "0d8f0b2d"
+  },
+  "web.admin.organizations.entitlements.placeholder": {
+    "text": "예: custom_domains",
+    "source_hash": "05346c68"
+  },
+  "web.admin.organizations.entitlements.grant": {
+    "text": "부여",
+    "source_hash": "78b7d037"
+  },
+  "web.admin.organizations.entitlements.revoke": {
+    "text": "취소",
+    "source_hash": "87e6d00b"
+  },
+  "web.admin.organizations.entitlements.clear": {
+    "text": "모든 재정의 지우기",
+    "source_hash": "f0e485c3"
+  },
+  "web.admin.organizations.entitlements.effective": {
+    "text": "유효 이용 권한",
+    "source_hash": "b840f8c8"
+  },
+  "web.admin.organizations.entitlements.grants": {
+    "text": "부여",
+    "source_hash": "b3e1c95a"
+  },
+  "web.admin.organizations.entitlements.revokes": {
+    "text": "취소",
+    "source_hash": "f0e69b17"
+  },
+  "web.admin.organizations.entitlements.noOverrides": {
+    "text": "이 조직의 현재 재정의 상태를 보려면 작업을 수행하세요.",
+    "source_hash": "98d2e30d"
+  },
+  "web.admin.organizations.entitlements.confirm.grantTitle": {
+    "text": "이용 권한을 부여하시겠습니까?",
+    "source_hash": "a4b2c57b"
+  },
+  "web.admin.organizations.entitlements.confirm.grantDescription": {
+    "text": "{org}에 “{entitlement}”을(를) 부여합니다. 이는 조직의 결제 이용 권한을 변경합니다.",
+    "source_hash": "542ce26a"
+  },
+  "web.admin.organizations.entitlements.confirm.revokeTitle": {
+    "text": "이용 권한을 취소하시겠습니까?",
+    "source_hash": "c93d520a"
+  },
+  "web.admin.organizations.entitlements.confirm.revokeDescription": {
+    "text": "{org}에서 “{entitlement}”을(를) 취소합니다. 이는 조직의 결제 이용 권한을 변경합니다.",
+    "source_hash": "a5d2a8a6"
+  },
+  "web.admin.organizations.entitlements.confirm.clearTitle": {
+    "text": "모든 이용 권한 재정의를 지우시겠습니까?",
+    "source_hash": "e36eb218"
+  },
+  "web.admin.organizations.entitlements.confirm.clearDescription": {
+    "text": "{org}의 모든 부여 및 취소 재정의를 제거하여 요금제 이용 권한으로 재설정합니다.",
+    "source_hash": "96bad079"
+  },
+  "web.admin.organizations.entitlements.success.granted": {
+    "text": "이용 권한 “{entitlement}”이(가) 부여되었습니다.",
+    "source_hash": "cf52fb0e"
+  },
+  "web.admin.organizations.entitlements.success.revoked": {
+    "text": "이용 권한 “{entitlement}”이(가) 취소되었습니다.",
+    "source_hash": "279d425d"
+  },
+  "web.admin.organizations.entitlements.success.cleared": {
+    "text": "모든 이용 권한 재정의가 지워졌습니다.",
+    "source_hash": "a482743b"
+  },
+  "web.admin.organizations.fields.contactEmail": {
+    "text": "연락처 이메일",
+    "source_hash": "6d7fce11"
+  },
+  "web.admin.organizations.fields.owner": {
+    "text": "소유자",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.fields.plan": {
+    "text": "요금제",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.organizations.fields.subscription": {
+    "text": "구독 상태",
+    "source_hash": "f0723c4e"
+  },
+  "web.admin.organizations.fields.periodEnd": {
+    "text": "기간 종료",
+    "source_hash": "eeae9fdd"
+  },
+  "web.admin.organizations.fields.billingEmail": {
+    "text": "결제 이메일",
+    "source_hash": "8805b928"
+  },
+  "web.admin.organizations.fields.stripeCustomer": {
+    "text": "Stripe 고객",
+    "source_hash": "8f169be1"
+  },
+  "web.admin.organizations.fields.stripeSubscription": {
+    "text": "Stripe 구독",
+    "source_hash": "53f71e08"
+  },
+  "web.admin.organizations.fields.orgId": {
+    "text": "조직 ID",
+    "source_hash": "1f466322"
+  },
+  "web.admin.organizations.fields.created": {
+    "text": "생성됨",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.organizations.fields.updated": {
+    "text": "업데이트됨",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.organizations.investigate.description": {
+    "text": "로컬 결제 상태를 실시간 Stripe 구독과 비교합니다.",
+    "source_hash": "d7bbe9ed"
+  },
+  "web.admin.organizations.investigate.rawPayload": {
+    "text": "원시 조사 페이로드",
+    "source_hash": "29ca7df2"
+  },
+  "web.admin.organizations.investigate.parseError": {
+    "text": "조사 응답이 예상 형식과 일치하지 않았습니다.",
+    "source_hash": "db59cab1"
+  },
+  "web.admin.organizations.list.loadError": {
+    "text": "조직을 불러올 수 없습니다.",
+    "source_hash": "130d5e70"
+  }
+}

--- a/locales/content/ko/admin-overview.json
+++ b/locales/content/ko/admin-overview.json
@@ -1,0 +1,94 @@
+{
+  "web.admin.overview.retry": {
+    "text": "다시 시도",
+    "source_hash": "942087cc"
+  },
+  "web.admin.overview.feedback.title": {
+    "text": "사용자 피드백",
+    "source_hash": "cb7b24c6"
+  },
+  "web.admin.overview.feedback.total": {
+    "text": "지난 30일 동안 {count}개",
+    "source_hash": "b6b9147c"
+  },
+  "web.admin.overview.feedback.today": {
+    "text": "오늘",
+    "source_hash": "2b065c7c"
+  },
+  "web.admin.overview.feedback.yesterday": {
+    "text": "어제",
+    "source_hash": "56618125"
+  },
+  "web.admin.overview.feedback.older": {
+    "text": "이전",
+    "source_hash": "03281c88"
+  },
+  "web.admin.overview.feedback.empty": {
+    "text": "이 기간에 피드백이 없습니다",
+    "source_hash": "e09d594d"
+  },
+  "web.admin.overview.feedback.loadError": {
+    "text": "피드백을 불러올 수 없습니다.",
+    "source_hash": "4011c408"
+  },
+  "web.admin.overview.stats.heading": {
+    "text": "플랫폼 통계",
+    "source_hash": "77728e4d"
+  },
+  "web.admin.overview.stats.customers": {
+    "text": "고객",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.overview.stats.secrets": {
+    "text": "활성 비밀 메시지",
+    "source_hash": "8db4c552"
+  },
+  "web.admin.overview.stats.sessions": {
+    "text": "활성 세션",
+    "source_hash": "61ad9909"
+  },
+  "web.admin.overview.stats.receipts": {
+    "text": "영수증",
+    "source_hash": "60a627df"
+  },
+  "web.admin.overview.stats.secretsCreated": {
+    "text": "생성된 비밀 메시지 (누적)",
+    "source_hash": "bdb49794"
+  },
+  "web.admin.overview.stats.emailsSent": {
+    "text": "발송된 이메일 (누적)",
+    "source_hash": "1c9a7518"
+  },
+  "web.admin.overview.stats.loadError": {
+    "text": "플랫폼 통계를 불러올 수 없습니다.",
+    "source_hash": "5f13cf7a"
+  },
+  "web.admin.overview.trends.title": {
+    "text": "지난 30일",
+    "source_hash": "f8f03fb4"
+  },
+  "web.admin.overview.trends.signups": {
+    "text": "일일 가입 수",
+    "source_hash": "8db399dc"
+  },
+  "web.admin.overview.trends.secretsCreated": {
+    "text": "일일 생성된 비밀 메시지",
+    "source_hash": "d6852656"
+  },
+  "web.admin.overview.trends.today": {
+    "text": "오늘",
+    "source_hash": "e0f4f767"
+  },
+  "web.admin.overview.trends.collectingNote": {
+    "text": "첫 데이터 지점부터 수집합니다 — 그 이전 날짜는 0으로 표시됩니다.",
+    "source_hash": "269ee1eb"
+  },
+  "web.admin.overview.trends.sparklineAria": {
+    "text": "{label}: 30일 추세, 오늘 {count}개",
+    "source_hash": "eb57a7b2"
+  },
+  "web.admin.overview.trends.loadError": {
+    "text": "추세를 불러올 수 없습니다.",
+    "source_hash": "9cf97f63"
+  }
+}

--- a/locales/content/ko/admin-secrets.json
+++ b/locales/content/ko/admin-secrets.json
@@ -1,0 +1,218 @@
+{
+  "web.admin.secrets.title": {
+    "text": "비밀 메시지",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.secrets.description": {
+    "text": "비밀 메시지의 영수증을 검사하고 SSH 없이 삭제합니다 — 키로 조회하세요.",
+    "source_hash": "07775a11"
+  },
+  "web.admin.secrets.never": {
+    "text": "한 번도 없음",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.secrets.anonymous": {
+    "text": "익명",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.admin.secrets.ageDays": {
+    "text": "{days}일",
+    "source_hash": "a2246fbc"
+  },
+  "web.admin.secrets.actions.delete.button": {
+    "text": "비밀 메시지 삭제",
+    "source_hash": "1a48c8c8"
+  },
+  "web.admin.secrets.actions.delete.confirmTitle": {
+    "text": "비밀 메시지를 삭제하시겠습니까?",
+    "source_hash": "4a779a67"
+  },
+  "web.admin.secrets.actions.delete.confirmDescription": {
+    "text": "비밀 메시지 {shortid}과(와) 해당 영수증을 영구적으로 삭제합니다. 이 작업은 취소할 수 없습니다.",
+    "source_hash": "51f807ad"
+  },
+  "web.admin.secrets.actions.delete.success": {
+    "text": "비밀 메시지가 삭제되었습니다.",
+    "source_hash": "52f1640f"
+  },
+  "web.admin.secrets.detail.yes": {
+    "text": "예",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.secrets.detail.no": {
+    "text": "아니요",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.secrets.detail.none": {
+    "text": "없음",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.secrets.fields.secretId": {
+    "text": "비밀 메시지 ID",
+    "source_hash": "79592419"
+  },
+  "web.admin.secrets.fields.shortId": {
+    "text": "짧은 ID",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.secrets.fields.state": {
+    "text": "상태",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.secrets.fields.created": {
+    "text": "생성됨",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.secrets.fields.updated": {
+    "text": "업데이트됨",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.secrets.fields.expiration": {
+    "text": "만료",
+    "source_hash": "f38d6e0e"
+  },
+  "web.admin.secrets.fields.age": {
+    "text": "경과 시간",
+    "source_hash": "39b7370f"
+  },
+  "web.admin.secrets.fields.lifespan": {
+    "text": "수명",
+    "source_hash": "58994285"
+  },
+  "web.admin.secrets.fields.owner": {
+    "text": "소유자",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.secrets.fields.receiptId": {
+    "text": "영수증 ID",
+    "source_hash": "2c13d799"
+  },
+  "web.admin.secrets.fields.hasCiphertext": {
+    "text": "암호문 있음",
+    "source_hash": "e9188bad"
+  },
+  "web.admin.secrets.fields.ciphertextLength": {
+    "text": "암호문 길이",
+    "source_hash": "0f1744fd"
+  },
+  "web.admin.secrets.lookup.label": {
+    "text": "비밀 메시지 키",
+    "source_hash": "f47a99eb"
+  },
+  "web.admin.secrets.lookup.placeholder": {
+    "text": "비밀 메시지 식별자",
+    "source_hash": "cbcfd49f"
+  },
+  "web.admin.secrets.lookup.button": {
+    "text": "조회",
+    "source_hash": "504101bc"
+  },
+  "web.admin.secrets.lookup.resultTitle": {
+    "text": "비밀 메시지 {shortid}",
+    "source_hash": "8b311d32"
+  },
+  "web.admin.secrets.lookup.notFound": {
+    "text": "비밀 메시지를 찾을 수 없음",
+    "source_hash": "70a9532c"
+  },
+  "web.admin.secrets.lookup.notFoundDescription": {
+    "text": "이 키에 해당하는 비밀 메시지가 없습니다. 만료되었거나 삭제되었을 수 있습니다.",
+    "source_hash": "9f068a81"
+  },
+  "web.admin.secrets.lookup.loadError": {
+    "text": "이 비밀 메시지를 불러올 수 없습니다.",
+    "source_hash": "c96672e4"
+  },
+  "web.admin.secrets.lookup.retry": {
+    "text": "다시 시도",
+    "source_hash": "942087cc"
+  },
+  "web.admin.secrets.owner.anonymous": {
+    "text": "익명 (소유자 없음)",
+    "source_hash": "390f11ad"
+  },
+  "web.admin.secrets.ownerFields.email": {
+    "text": "이메일",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.secrets.ownerFields.userId": {
+    "text": "사용자 ID",
+    "source_hash": "7967e089"
+  },
+  "web.admin.secrets.ownerFields.role": {
+    "text": "역할",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.secrets.ownerFields.verified": {
+    "text": "인증됨",
+    "source_hash": "4f783840"
+  },
+  "web.admin.secrets.receipt.none": {
+    "text": "이 비밀 메시지에 연결된 영수증이 없습니다.",
+    "source_hash": "5ddceaed"
+  },
+  "web.admin.secrets.receiptFields.receiptId": {
+    "text": "영수증 ID",
+    "source_hash": "2c13d799"
+  },
+  "web.admin.secrets.receiptFields.shortId": {
+    "text": "짧은 ID",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.secrets.receiptFields.state": {
+    "text": "상태",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.secrets.receiptFields.secretTtl": {
+    "text": "비밀 메시지 TTL",
+    "source_hash": "b89c0b51"
+  },
+  "web.admin.secrets.receiptFields.recipients": {
+    "text": "수신자",
+    "source_hash": "1e8568a8"
+  },
+  "web.admin.secrets.receiptFields.hasPassphrase": {
+    "text": "접근 문구 있음",
+    "source_hash": "af458f26"
+  },
+  "web.admin.secrets.receiptFields.shareDomain": {
+    "text": "공유 도메인",
+    "source_hash": "db963805"
+  },
+  "web.admin.secrets.receiptFields.created": {
+    "text": "생성됨",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.secrets.receiptFields.secretExpired": {
+    "text": "비밀 메시지 만료됨",
+    "source_hash": "c127dab6"
+  },
+  "web.admin.secrets.sections.secret": {
+    "text": "비밀 메시지",
+    "source_hash": "7e32a729"
+  },
+  "web.admin.secrets.sections.receipt": {
+    "text": "영수증",
+    "source_hash": "dad5a969"
+  },
+  "web.admin.secrets.sections.owner": {
+    "text": "소유자",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.secrets.sections.raw": {
+    "text": "원시 데이터",
+    "source_hash": "848123d1"
+  },
+  "web.admin.secrets.state.new": {
+    "text": "신규",
+    "source_hash": "18fdd549"
+  },
+  "web.admin.secrets.state.received": {
+    "text": "수신됨",
+    "source_hash": "49f19bee"
+  },
+  "web.admin.secrets.state.viewed": {
+    "text": "조회됨",
+    "source_hash": "1b28d178"
+  }
+}

--- a/locales/content/ko/admin-sessions.json
+++ b/locales/content/ko/admin-sessions.json
@@ -1,0 +1,210 @@
+{
+  "web.admin.sessions.title": {
+    "text": "세션",
+    "source_hash": "6fa3cbf4"
+  },
+  "web.admin.sessions.description": {
+    "text": "인시던트 대응을 위해 활성 세션을 검사, 검색, 취소합니다.",
+    "source_hash": "784a3a44"
+  },
+  "web.admin.sessions.anonymous": {
+    "text": "익명",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.admin.sessions.columns.sessionId": {
+    "text": "세션 ID",
+    "source_hash": "cb9ac5c5"
+  },
+  "web.admin.sessions.columns.authenticated": {
+    "text": "인증",
+    "source_hash": "8eb3ea9b"
+  },
+  "web.admin.sessions.columns.email": {
+    "text": "이메일",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.sessions.columns.externalId": {
+    "text": "외부 ID",
+    "source_hash": "69da56ba"
+  },
+  "web.admin.sessions.columns.ipAddress": {
+    "text": "IP 주소",
+    "source_hash": "3c3de0c9"
+  },
+  "web.admin.sessions.columns.created": {
+    "text": "인증 일시",
+    "source_hash": "8d6c9b01"
+  },
+  "web.admin.sessions.columns.actions": {
+    "text": "작업",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.sessions.columns.role": {
+    "text": "역할",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.sessions.detail.yes": {
+    "text": "예",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.sessions.detail.no": {
+    "text": "아니요",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.sessions.detail.none": {
+    "text": "없음",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.sessions.detail.unknown": {
+    "text": "알 수 없음",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.sessions.detail.noExpiry": {
+    "text": "만료 없음",
+    "source_hash": "fe06351d"
+  },
+  "web.admin.sessions.detail.expired": {
+    "text": "만료됨",
+    "source_hash": "424a2551"
+  },
+  "web.admin.sessions.detail.ttlSeconds": {
+    "text": "{seconds}초 남음",
+    "source_hash": "3c9d75ce"
+  },
+  "web.admin.sessions.drawer.title": {
+    "text": "세션 {id}",
+    "source_hash": "29dcbd66"
+  },
+  "web.admin.sessions.drawer.notFound": {
+    "text": "세션을 찾을 수 없음",
+    "source_hash": "0969eab8"
+  },
+  "web.admin.sessions.drawer.notFoundDescription": {
+    "text": "이 세션이 더 이상 Redis에 존재하지 않습니다. 만료되었거나 이미 취소되었을 수 있습니다.",
+    "source_hash": "11e3ef05"
+  },
+  "web.admin.sessions.drawer.loadError": {
+    "text": "이 세션을 불러올 수 없습니다.",
+    "source_hash": "82ae90fb"
+  },
+  "web.admin.sessions.drawer.retry": {
+    "text": "다시 시도",
+    "source_hash": "942087cc"
+  },
+  "web.admin.sessions.fields.sessionId": {
+    "text": "세션 ID",
+    "source_hash": "cb9ac5c5"
+  },
+  "web.admin.sessions.fields.key": {
+    "text": "Redis 키",
+    "source_hash": "0b196725"
+  },
+  "web.admin.sessions.fields.ttl": {
+    "text": "TTL",
+    "source_hash": "76f6014f"
+  },
+  "web.admin.sessions.fields.authenticated": {
+    "text": "인증됨",
+    "source_hash": "6ab694cf"
+  },
+  "web.admin.sessions.fields.email": {
+    "text": "이메일",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.sessions.fields.externalId": {
+    "text": "외부 ID",
+    "source_hash": "69da56ba"
+  },
+  "web.admin.sessions.fields.accountId": {
+    "text": "계정 ID",
+    "source_hash": "919bb4cb"
+  },
+  "web.admin.sessions.fields.role": {
+    "text": "역할",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.sessions.fields.locale": {
+    "text": "로캘",
+    "source_hash": "ca3dc612"
+  },
+  "web.admin.sessions.fields.ipAddress": {
+    "text": "IP 주소",
+    "source_hash": "3c3de0c9"
+  },
+  "web.admin.sessions.fields.authenticatedAt": {
+    "text": "인증 일시",
+    "source_hash": "8d6c9b01"
+  },
+  "web.admin.sessions.fields.authenticatedBy": {
+    "text": "인증 방법",
+    "source_hash": "3ebbabfe"
+  },
+  "web.admin.sessions.fields.activeSessionId": {
+    "text": "활성 세션 ID",
+    "source_hash": "f32b1158"
+  },
+  "web.admin.sessions.fields.userAgent": {
+    "text": "User Agent",
+    "source_hash": "62e01345"
+  },
+  "web.admin.sessions.fields.orgContext": {
+    "text": "조직 컨텍스트",
+    "source_hash": "a596d9f2"
+  },
+  "web.admin.sessions.list.loadError": {
+    "text": "세션을 불러올 수 없습니다.",
+    "source_hash": "00c678d9"
+  },
+  "web.admin.sessions.list.retry": {
+    "text": "다시 시도",
+    "source_hash": "942087cc"
+  },
+  "web.admin.sessions.list.empty": {
+    "text": "활성 세션을 찾을 수 없음",
+    "source_hash": "e35312d6"
+  },
+  "web.admin.sessions.revoke.button": {
+    "text": "취소",
+    "source_hash": "87e6d00b"
+  },
+  "web.admin.sessions.revoke.confirmTitle": {
+    "text": "이 세션을 취소하시겠습니까?",
+    "source_hash": "0c6605c1"
+  },
+  "web.admin.sessions.revoke.confirmDescription": {
+    "text": "세션 {id}을(를) 삭제하여 사용자를 즉시 로그아웃시킵니다. 확인하려면 세션 ID를 입력하세요.",
+    "source_hash": "9e08b1b8"
+  },
+  "web.admin.sessions.revoke.success": {
+    "text": "세션이 취소되었습니다",
+    "source_hash": "0af5e14d"
+  },
+  "web.admin.sessions.scan.summary": {
+    "text": "인증된 {shown}개 표시 · 익명 {anonymous}개 숨김 · {scanned}개 검사됨",
+    "source_hash": "34cb67a4"
+  },
+  "web.admin.sessions.scan.capped": {
+    "text": "검사가 처음 {scanned}개 키로 제한되었습니다 — 이 범위를 벗어난 인증된 세션은 나열되지 않습니다. 특정 세션에 접근하려면 ID로 검사하세요.",
+    "source_hash": "fa418b4e"
+  },
+  "web.admin.sessions.search.placeholder": {
+    "text": "이메일 또는 외부 ID로 검색",
+    "source_hash": "f2dc5c06"
+  },
+  "web.admin.sessions.sections.session": {
+    "text": "세션",
+    "source_hash": "6959b415"
+  },
+  "web.admin.sessions.sections.raw": {
+    "text": "원시 세션 데이터",
+    "source_hash": "c9f11eb4"
+  },
+  "web.admin.sessions.status.authenticated": {
+    "text": "인증됨",
+    "source_hash": "6ab694cf"
+  },
+  "web.admin.sessions.status.anonymous": {
+    "text": "익명",
+    "source_hash": "e7a8aa2d"
+  }
+}

--- a/locales/content/ko/admin-system.json
+++ b/locales/content/ko/admin-system.json
@@ -1,0 +1,158 @@
+{
+  "web.admin.system.title": {
+    "text": "시스템",
+    "source_hash": "6725e7bb"
+  },
+  "web.admin.system.description": {
+    "text": "데이터베이스, 대기열 및 인프라 상태입니다.",
+    "source_hash": "0115f495"
+  },
+  "web.admin.system.retry": {
+    "text": "다시 시도",
+    "source_hash": "942087cc"
+  },
+  "web.admin.system.database.title": {
+    "text": "메인 데이터베이스 ({engine})",
+    "source_hash": "1391230b"
+  },
+  "web.admin.system.database.loadError": {
+    "text": "데이터베이스 지표를 불러올 수 없습니다.",
+    "source_hash": "905055c6"
+  },
+  "web.admin.system.database.server": {
+    "text": "서버",
+    "source_hash": "aef7de28"
+  },
+  "web.admin.system.database.memory": {
+    "text": "메모리",
+    "source_hash": "c3963aed"
+  },
+  "web.admin.system.database.databases": {
+    "text": "데이터베이스",
+    "source_hash": "61d2afe2"
+  },
+  "web.admin.system.database.dbSummary": {
+    "text": "키 {keys}개, TTL이 있는 키 {expires}개",
+    "source_hash": "26b9e17c"
+  },
+  "web.admin.system.database.fields.version": {
+    "text": "버전",
+    "source_hash": "dd167905"
+  },
+  "web.admin.system.database.fields.mode": {
+    "text": "모드",
+    "source_hash": "5e23ec6a"
+  },
+  "web.admin.system.database.fields.uptimeDays": {
+    "text": "가동 시간 (일)",
+    "source_hash": "7ab314f8"
+  },
+  "web.admin.system.database.fields.connectedClients": {
+    "text": "연결된 클라이언트",
+    "source_hash": "434adc3a"
+  },
+  "web.admin.system.database.fields.opsPerSec": {
+    "text": "초당 작업 수",
+    "source_hash": "6634251d"
+  },
+  "web.admin.system.database.fields.totalCommands": {
+    "text": "총 명령 수",
+    "source_hash": "c5ce5aaf"
+  },
+  "web.admin.system.database.fields.usedMemory": {
+    "text": "사용된 메모리",
+    "source_hash": "bac68a65"
+  },
+  "web.admin.system.database.fields.rssMemory": {
+    "text": "RSS 메모리",
+    "source_hash": "7fe77d15"
+  },
+  "web.admin.system.database.fields.peakMemory": {
+    "text": "최대 메모리",
+    "source_hash": "9d44afa6"
+  },
+  "web.admin.system.database.fields.fragmentation": {
+    "text": "단편화 비율",
+    "source_hash": "721494dd"
+  },
+  "web.admin.system.database.stats.customers": {
+    "text": "고객",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.system.database.stats.secrets": {
+    "text": "비밀 메시지",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.system.database.stats.receipts": {
+    "text": "영수증",
+    "source_hash": "60a627df"
+  },
+  "web.admin.system.database.stats.totalKeys": {
+    "text": "총 키 수",
+    "source_hash": "4e0d27f5"
+  },
+  "web.admin.system.queue.title": {
+    "text": "대기열",
+    "source_hash": "3b2fe03e"
+  },
+  "web.admin.system.queue.loadError": {
+    "text": "대기열 지표를 불러올 수 없습니다.",
+    "source_hash": "715bdc88"
+  },
+  "web.admin.system.queue.empty": {
+    "text": "대기열을 찾을 수 없음",
+    "source_hash": "3cd4eb88"
+  },
+  "web.admin.system.queue.connected": {
+    "text": "연결됨",
+    "source_hash": "22965568"
+  },
+  "web.admin.system.queue.disconnected": {
+    "text": "연결 끊김",
+    "source_hash": "04dfac36"
+  },
+  "web.admin.system.queue.activeWorkers": {
+    "text": "활성 워커 {count}개",
+    "source_hash": "49e6369c"
+  },
+  "web.admin.system.queue.columns.name": {
+    "text": "대기열",
+    "source_hash": "3b2fe03e"
+  },
+  "web.admin.system.queue.columns.pending": {
+    "text": "대기 중",
+    "source_hash": "331551b0"
+  },
+  "web.admin.system.queue.columns.consumers": {
+    "text": "컨슈머",
+    "source_hash": "212b350d"
+  },
+  "web.admin.system.queue.health.healthy": {
+    "text": "정상",
+    "source_hash": "7f1e323b"
+  },
+  "web.admin.system.queue.health.degraded": {
+    "text": "저하됨",
+    "source_hash": "a8494c12"
+  },
+  "web.admin.system.queue.health.unhealthy": {
+    "text": "비정상",
+    "source_hash": "317b1fbc"
+  },
+  "web.admin.system.queue.health.unknown": {
+    "text": "알 수 없음",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.system.redis.title": {
+    "text": "Redis INFO",
+    "source_hash": "e762bd3c"
+  },
+  "web.admin.system.redis.loadError": {
+    "text": "Redis 지표를 불러올 수 없습니다.",
+    "source_hash": "ca5945d6"
+  },
+  "web.admin.system.redis.captured": {
+    "text": "{at}에 캡처됨",
+    "source_hash": "57b40c0f"
+  }
+}

--- a/locales/content/ko/admin-usage.json
+++ b/locales/content/ko/admin-usage.json
@@ -1,0 +1,78 @@
+{
+  "web.admin.usage.title": {
+    "text": "사용량",
+    "source_hash": "8d59829c"
+  },
+  "web.admin.usage.description": {
+    "text": "날짜 범위에 대한 사용량 지표를 내보냅니다.",
+    "source_hash": "97bd3325"
+  },
+  "web.admin.usage.startDate": {
+    "text": "시작 날짜",
+    "source_hash": "4c52faad"
+  },
+  "web.admin.usage.endDate": {
+    "text": "종료 날짜",
+    "source_hash": "e970951c"
+  },
+  "web.admin.usage.fetch": {
+    "text": "데이터 가져오기",
+    "source_hash": "429532fe"
+  },
+  "web.admin.usage.loadError": {
+    "text": "사용량 데이터를 불러올 수 없습니다.",
+    "source_hash": "ffb557d7"
+  },
+  "web.admin.usage.retry": {
+    "text": "다시 시도",
+    "source_hash": "942087cc"
+  },
+  "web.admin.usage.empty": {
+    "text": "이 범위에 대한 데이터가 없습니다",
+    "source_hash": "5fed1795"
+  },
+  "web.admin.usage.byState": {
+    "text": "상태별 비밀 메시지",
+    "source_hash": "916bbcb6"
+  },
+  "web.admin.usage.secretsByDay": {
+    "text": "일별 비밀 메시지",
+    "source_hash": "24a01e8e"
+  },
+  "web.admin.usage.usersByDay": {
+    "text": "일별 신규 사용자",
+    "source_hash": "8c1f089f"
+  },
+  "web.admin.usage.exportJson": {
+    "text": "JSON 다운로드",
+    "source_hash": "49e0e6d5"
+  },
+  "web.admin.usage.exportCsv": {
+    "text": "CSV 다운로드",
+    "source_hash": "a4023b89"
+  },
+  "web.admin.usage.columns.date": {
+    "text": "날짜",
+    "source_hash": "99c40ab4"
+  },
+  "web.admin.usage.columns.count": {
+    "text": "개수",
+    "source_hash": "37bac495"
+  },
+  "web.admin.usage.stats.totalSecrets": {
+    "text": "총 비밀 메시지",
+    "source_hash": "e17a5459"
+  },
+  "web.admin.usage.stats.newUsers": {
+    "text": "신규 사용자",
+    "source_hash": "d3ee48b0"
+  },
+  "web.admin.usage.stats.avgSecrets": {
+    "text": "일평균 비밀 메시지",
+    "source_hash": "948b0701"
+  },
+  "web.admin.usage.stats.avgUsers": {
+    "text": "일평균 사용자",
+    "source_hash": "491f626d"
+  }
+}

--- a/locales/content/ko/api-domains-errors.json
+++ b/locales/content/ko/api-domains-errors.json
@@ -34,5 +34,17 @@
   "api.domains.errors.recipients_duplicate": {
     "text": "중복된 수신자 이메일은 허용되지 않습니다",
     "source_hash": "6de22182"
+  },
+  "api.domains.errors.homepage_secrets_mode_invalid": {
+    "text": "잘못된 secrets_mode: %{secrets_mode}",
+    "source_hash": "cf093a04"
+  },
+  "api.domains.errors.homepage_incoming_entitlement_required": {
+    "text": "수신 비밀 메시지 모드에는 incoming_secrets 이용 권한이 필요합니다. 요금제를 업그레이드하세요.",
+    "source_hash": "d68b13d8"
+  },
+  "api.domains.errors.homepage_incoming_not_ready": {
+    "text": "수신 비밀 메시지를 홈페이지로 사용하려면 먼저 하나 이상의 수신자와 함께 활성화해야 합니다.",
+    "source_hash": "556da6e2"
   }
 }

--- a/locales/content/ko/api-invite-errors.json
+++ b/locales/content/ko/api-invite-errors.json
@@ -12,8 +12,8 @@
     "source_hash": "a5df7d22"
   },
   "api.invite.errors.invitation_already_processed": {
-    "text": "이 초대는 이미 %{status} 상태입니다",
-    "source_hash": "130c87e0"
+    "text": "이 초대는 이미 처리되었습니다",
+    "source_hash": "4cfedf4f"
   },
   "api.invite.errors.invitation_expired": {
     "text": "초대가 만료되었습니다",
@@ -26,5 +26,13 @@
   "api.invite.errors.already_member": {
     "text": "이미 이 조직의 멤버입니다",
     "source_hash": "f56ad547"
+  },
+  "api.invite.errors.invitation_already_accepted": {
+    "text": "이 초대는 이미 수락되었습니다",
+    "source_hash": "8f9daf0f"
+  },
+  "api.invite.errors.invitation_already_declined": {
+    "text": "이 초대는 이미 거절되었습니다",
+    "source_hash": "96e0d626"
   }
 }

--- a/locales/content/ko/api-secrets-errors.json
+++ b/locales/content/ko/api-secrets-errors.json
@@ -10,5 +10,9 @@
   "api.secrets.errors.domain_permission_anonymous_cross_domain": {
     "text": "이 도메인을 사용할 권한이 없습니다: %{domain}",
     "source_hash": "b41920ba"
+  },
+  "api.secrets.errors.secret_undecryptable": {
+    "text": "지금은 이 비밀 메시지를 복호화할 수 없습니다. 링크는 여전히 유효하지만 — 사이트 운영자가 암호화 키를 복원해야 표시할 수 있습니다.",
+    "source_hash": "56e283ee"
   }
 }

--- a/locales/content/ko/email.json
+++ b/locales/content/ko/email.json
@@ -62,7 +62,7 @@
   "email.welcome.signature": {
     "text": "지원팀",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.welcome.postscript": {
     "text": "추신: 이 이메일은 %{email_address}(으)로 발송되었습니다. 계정을 만들지 않으셨다면 이 메시지를 무시하셔도 됩니다.",
@@ -102,7 +102,7 @@
   "email.password_request.signature": {
     "text": "지원팀",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.password_request.postscript": {
     "text": "추신: 이 이메일은 %{email_address}(으)로 발송되었습니다.",
@@ -147,7 +147,7 @@
   "email.magic_link.signature": {
     "text": "지원팀",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.magic_link.postscript": {
     "text": "추신: 이 이메일은 %{email_address}(으)로 발송되었습니다.",
@@ -232,7 +232,7 @@
   "email.secret_revealed.signature": {
     "text": "지원팀",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.secret_revealed.manage_preferences": {
     "text": "알림 설정 관리",
@@ -357,7 +357,7 @@
   "email.organization_invitation.signature": {
     "text": "지원팀",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.organization_invitation.postscript": {
     "text": "추신: 이 이메일은 %{invited_email}(으)로 발송되었습니다. 이 초대를 예상하지 않으셨다면 이 메시지를 무시하셔도 됩니다.",
@@ -397,17 +397,17 @@
   "email.password_changed.signature": {
     "text": "지원팀",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_changed.subject": {
     "text": "이메일 주소가 변경되었습니다 (%{display_domain})",
     "renderer": "erb",
-    "source_hash": "d68d2f4c"
+    "source_hash": "4386fc57"
   },
   "email.email_changed.title": {
     "text": "이메일 주소가 변경되었습니다",
     "renderer": "erb",
-    "source_hash": "62b07299"
+    "source_hash": "db70f965"
   },
   "email.email_changed.security_notice": {
     "text": "본인이 변경하지 않았다면 계정이 손상되었을 수 있으니 즉시 고객 지원에 문의해 주세요.",
@@ -417,7 +417,7 @@
   "email.email_changed.change_notice": {
     "text": "%{product_name} 계정의 이메일 주소가 변경되었습니다.",
     "renderer": "erb",
-    "source_hash": "bb467ebc"
+    "source_hash": "7fc0e27c"
   },
   "email.email_changed.new_email_label": {
     "text": "새 이메일:",
@@ -447,7 +447,7 @@
   "email.email_changed.signature": {
     "text": "지원팀",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_changed.postscript": {
     "text": "추신: 이 이메일은 이메일 주소 변경을 알려드리기 위해 %{email_address}(으)로 발송되었습니다.",
@@ -497,7 +497,7 @@
   "email.email_change_requested.signature": {
     "text": "지원팀",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_change_requested.postscript": {
     "text": "추신: 이 이메일은 계정의 이메일 변경이 요청되어 %{email_address}(으)로 발송되었습니다.",
@@ -552,7 +552,7 @@
   "email.email_change_confirmation.signature": {
     "text": "지원팀",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_change_confirmation.postscript": {
     "text": "추신: 이 이메일은 이메일 주소 변경을 확인하기 위해 %{email_address}(으)로 발송되었습니다.",
@@ -582,7 +582,7 @@
   "email.mfa_enabled.signature": {
     "text": "지원팀",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.mfa_disabled.subject": {
     "text": "2단계 인증 비활성화됨 (%{display_domain})",
@@ -607,7 +607,7 @@
   "email.mfa_disabled.signature": {
     "text": "지원팀",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.new_login_alert.subject": {
     "text": "계정에 새 로그인 (%{display_domain})",
@@ -652,7 +652,7 @@
   "email.new_login_alert.signature": {
     "text": "지원팀",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.member_removed.subject": {
     "text": "%{organization_name}에서 제외되었습니다",
@@ -672,7 +672,7 @@
   "email.member_removed.signature": {
     "text": "지원팀",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.role_changed.subject": {
     "text": "%{organization_name}에서 역할이 변경되었습니다",
@@ -692,7 +692,7 @@
   "email.role_changed.signature": {
     "text": "지원팀",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.organization_deleted.subject": {
     "text": "\"%{organization_name}\" 조직이 삭제되었습니다",
@@ -712,7 +712,7 @@
   "email.organization_deleted.signature": {
     "text": "지원팀",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.trial_expiring.subject": {
     "text": "%{product_name} 체험 기간이 %{days_remaining}일 후에 만료됩니다",
@@ -737,7 +737,7 @@
   "email.trial_expiring.signature": {
     "text": "지원팀",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.subscription_changed.subject": {
     "text": "%{product_name} 구독이 변경되었습니다",
@@ -762,7 +762,7 @@
   "email.subscription_changed.signature": {
     "text": "지원팀",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.common.greeting": {
     "text": "안녕하세요,",

--- a/locales/content/ko/feature-regions.json
+++ b/locales/content/ko/feature-regions.json
@@ -152,8 +152,8 @@
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "결제 담당자 이메일이 {product_name} 계정 이메일과 다른 경우, 구독 혜택을 유지하려면 새 지역 계정에 결제 담당자 이메일을 사용하세요.",
-    "source_hash": "dac1cc28"
+    "text": "결제 연락처 이메일이 {product_name} 계정 이메일과 다른 경우, 구독 혜택을 유지하려면 새 지역 계정에 결제 연락처 이메일을 사용하세요.",
+    "source_hash": "d49662b0"
   },
   "web.regions.changing_regions_subscription_note": {
     "text": "결제 이메일 주소로 생성된 모든 계정에 구독 혜택이 자동으로 적용됩니다.",

--- a/locales/content/ko/feature-translations.json
+++ b/locales/content/ko/feature-translations.json
@@ -64,8 +64,8 @@
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "다음 분들이 {product_name}의 도달 범위를 넓히는 데 시간을 기부해 주셨습니다:",
-    "source_hash": "85a766af"
+    "text": "다음 분들이 {product_name}의 영향력을 확대하는 데 시간을 기부해 주셨습니다:",
+    "source_hash": "6cc876ae"
   },
   "web.translations.translations": {
     "text": "번역",
@@ -84,8 +84,8 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "2012년부터 {product_name}은 전 세계에 민감한 정보를 안전하게 공유할 수 있는 방법을 제공해 왔습니다. 영어가 주요 언어가 아닌 지역의 사용자들이 있기에, 정확한 번역은 모든 사람이 안전한 커뮤니케이션에 접근할 수 있도록 하는 데 필수적입니다.",
-    "source_hash": "87a6e9af"
+    "text": "2012년부터 {product_name}은(는) 전 세계적으로 민감한 정보를 공유하는 안전한 방법을 제공해 왔습니다. 영어가 주 언어가 아닌 지역의 사용자들에게 정확한 번역은 안전한 커뮤니케이션을 모든 사람이 이용할 수 있도록 하는 데 필수적입니다.",
+    "source_hash": "ded965d5"
   },
   "web.translations.help_secure_communication_go_global": {
     "text": "안전한 소통을 전 세계로 확장하는 데 도움을 주세요",

--- a/locales/content/ko/secret-homepage.json
+++ b/locales/content/ko/secret-homepage.json
@@ -57,7 +57,7 @@
   },
   "web.homepage.visit_onetime_secret_home": {
     "text": "{product_name} 홈페이지 방문",
-    "source_hash": "625556d2"
+    "source_hash": "87802af5"
   },
   "web.homepage.password_generation_title": {
     "text": "비밀번호 생성기",
@@ -109,15 +109,15 @@
   },
   "web.homepage.about_onetime_secret_0": {
     "text": "{product_name} 소개",
-    "source_hash": "971c50da"
+    "source_hash": "b3046356"
   },
   "web.homepage.log_in_to_onetime_secret": {
     "text": "{product_name}에 로그인",
-    "source_hash": "bd6be8d6"
+    "source_hash": "b2e364a4"
   },
   "web.homepage.about_onetime_secret": {
     "text": "{product_name} 소개",
-    "source_hash": "971c50da"
+    "source_hash": "b3046356"
   },
   "web.homepage.signup_individual_and_business_plans": {
     "text": "가입 - 개인 및 비즈니스 플랜",
@@ -137,19 +137,19 @@
   },
   "web.homepage.onetime_secret": {
     "text": "{product_name}",
-    "source_hash": "1cd0194a"
+    "source_hash": "7bec5899"
   },
   "web.homepage.onetime_secret_literal": {
     "text": "{product_name}",
-    "source_hash": "1cd0194a"
+    "source_hash": "7bec5899"
   },
   "web.homepage.one_time_secret_literal": {
     "text": "{product_name}",
-    "source_hash": "7872e050"
+    "source_hash": "7bec5899"
   },
   "web.homepage.onetime_secret_homepage": {
     "text": "{product_name} 홈페이지",
-    "source_hash": "44bb0581"
+    "source_hash": "0792b61e"
   },
   "web.homepage.send_sensitive_information_that_can_only_be_viewed_once": {
     "text": "단 한 번만 볼 수 있는 민감한 정보 보내기",
@@ -169,11 +169,11 @@
   },
   "web.homepage.welcome_to_onetime_secret": {
     "text": "{product_name}에 오신 것을 환영합니다.",
-    "source_hash": "0990d163"
+    "source_hash": "f4f49058"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "{product_name}은 전문적인 이미지를 유지하면서 민감한 정보를 안전하게 공유할 수 있도록 도와줍니다.",
-    "source_hash": "986a0856"
+    "text": "{product_name}은(는) 전문적인 이미지를 유지하면서 민감한 정보를 안전하게 공유할 수 있도록 도와줍니다.",
+    "source_hash": "7e9192bd"
   },
   "web.homepage.information_shared_through_this_service_can_only": {
     "text": "이 서비스를 통해 공유된 정보는 단 한 번만 접근할 수 있습니다. 열람 후에는 기밀성을 보장하기 위해 내용이 영구적으로 삭제됩니다.",
@@ -182,5 +182,13 @@
   "web.homepage.welcome_to_the_global_broadcast": {
     "text": "글로벌 방송에 오신 것을 환영합니다!",
     "source_hash": "210e1894"
+  },
+  "web.homepage.send_a_secret": {
+    "text": "비밀 메시지 보내기",
+    "source_hash": "31fd9e03"
+  },
+  "web.homepage.deliver_sensitive_information_directly_and_securely": {
+    "text": "민감한 정보를 저희 팀에 직접 전달하세요. 한 번만 볼 수 있습니다.",
+    "source_hash": "9976cf01"
   }
 }

--- a/locales/content/ko/secret-manage.json
+++ b/locales/content/ko/secret-manage.json
@@ -56,8 +56,8 @@
     "source_hash": "2e5a27e1"
   },
   "web.secrets.sample_secret_content_this_could_be_sensitive_data": {
-    "text": "비밀 콘텐츠 예시 이것은 민감한 데이터일 수 있습니다 또는 여러 줄의 메시지",
-    "source_hash": "b3be3902"
+    "text": "샘플 비밀 메시지 내용입니다. 민감한 데이터일 수 있습니다\n\n또는 여러 줄로 된 메시지",
+    "source_hash": "5e1bffcb"
   },
   "web.secrets.sample_secret_content": {
     "text": "샘플 비밀 내용",
@@ -128,8 +128,8 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "{product_name}은 한 번 열람 후 자동으로 삭제되는 민감한 정보를 안전하게 공유하는 방법입니다.",
-    "source_hash": "8a163297"
+    "text": "{product_name}은(는) 한 번 조회한 후 자동으로 소멸되는, 민감한 정보를 공유하는 안전한 방법입니다.",
+    "source_hash": "bd0c6182"
   },
   "web.secrets.what_is_this": {
     "text": "이것은 무엇인가요?",

--- a/locales/content/ko/session-auth-extended.json
+++ b/locales/content/ko/session-auth-extended.json
@@ -155,8 +155,8 @@
     "source_hash": "d726c0da"
   },
   "web.auth.magicLink.sessionExpired": {
-    "text": "세션이 만료되었습니다. 페이지를 새로고침한 후 다시 시도해 주세요.",
-    "source_hash": "a7c3e901"
+    "text": "세션이 만료되었습니다. 페이지를 새로 고친 후 다시 시도하세요.",
+    "source_hash": "be9ed96d"
   },
   "web.auth.magicLink.loginFailed": {
     "text": "로그인 실패. 다시 시도해 주세요.",

--- a/locales/content/ko/session-auth.json
+++ b/locales/content/ko/session-auth.json
@@ -373,8 +373,8 @@
     "source_hash": "afd25fdf"
   },
   "web.help.use_magic_link_instead": {
-    "text": "매직 링크 옵션을 사용하여 비밀번호 없이 로그인하세요. 로그인 후 계정 설정에서 비밀번호를 변경할 수 있습니다.",
-    "source_hash": "2a058600"
+    "text": "새 비밀번호를 만들기 위해 비밀번호 재설정 링크를 요청할 수 있습니다.",
+    "source_hash": "3c3eabad"
   },
   "web.help.account_locked": {
     "text": "계정이 일시적으로 잠겼나요?",
@@ -431,5 +431,57 @@
   "web.login.errors.domain_not_allowed": {
     "text": "회원님의 이메일 도메인은 SSO 가입이 허용되지 않습니다. 관리자에게 문의하세요.",
     "source_hash": "87603782"
+  },
+  "web.auth.check_email.title": {
+    "text": "이메일을 확인하세요",
+    "source_hash": "77322879"
+  },
+  "web.auth.check_email.sent_to_generic": {
+    "text": "귀하의 이메일 주소로 인증 링크를 보냈습니다.",
+    "source_hash": "4e5510af"
+  },
+  "web.auth.check_email.help": {
+    "text": "이 주소로 인증 링크를 보냈습니다 — 이메일을 열고 링크를 클릭하여 계정을 활성화하세요.",
+    "source_hash": "8babedc4"
+  },
+  "web.auth.check_email.spam_hint": {
+    "text": "찾을 수 없나요? 스팸 폴더를 확인하세요.",
+    "source_hash": "d166d9a4"
+  },
+  "web.auth.check_email.wrong_email": {
+    "text": "잘못된 주소를 입력하셨나요?",
+    "source_hash": "0aa863e5"
+  },
+  "web.auth.check_email.start_over": {
+    "text": "다시 시작",
+    "source_hash": "5eed7e9f"
+  },
+  "web.auth.field-errors.password": {
+    "text": "비밀번호",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.auth.verify.resend_help_text": {
+    "text": "인증 이메일을 받지 못하셨나요? 다시 보내려면 이메일을 입력하세요.",
+    "source_hash": "e0df48bb"
+  },
+  "web.auth.verify.resend_button": {
+    "text": "인증 이메일 다시 보내기",
+    "source_hash": "5173cc04"
+  },
+  "web.auth.verify.resend_sent": {
+    "text": "인증이 필요한 계정이 있으면 새 이메일이 발송되었습니다. 받은 편지함과 스팸 폴더를 확인하세요.",
+    "source_hash": "6f838ffb"
+  },
+  "web.auth.verify.resend_error": {
+    "text": "인증 이메일을 보낼 수 없습니다. 연결 상태를 확인한 후 다시 시도하세요.",
+    "source_hash": "15149f46"
+  },
+  "web.auth.verify.resend_short": {
+    "text": "이메일 다시 보내기",
+    "source_hash": "4f44603e"
+  },
+  "web.login.verified_notice": {
+    "text": "이메일이 인증되었습니다 — 이제 로그인할 수 있습니다.",
+    "source_hash": "c8d4b5a8"
   }
 }

--- a/locales/content/ko/workspace-account.json
+++ b/locales/content/ko/workspace-account.json
@@ -136,8 +136,8 @@
     "source_hash": "05986d95"
   },
   "web.account.keep_this_token_secure_it_provides_full_access_t": {
-    "text": "🔐 이 토큰을 안전하게 보관하세요! 계정에 대한 전체 접근 권한을 제공합니다.",
-    "source_hash": "8839aa4d"
+    "text": "이 토큰을 안전하게 보관하세요. API를 통해 비밀 메시지를 생성하고 관리하는 데 사용할 수 있습니다.",
+    "source_hash": "a63cc8ec"
   },
   "web.account.confirm_with_your_password": {
     "text": "비밀번호로 확인",
@@ -328,8 +328,8 @@
     "source_hash": "f7cfed6e"
   },
   "web.settings.profile.email_change_success": {
-    "text": "이메일이 성공적으로 업데이트되었습니다. 새 이메일 주소를 인증하려면 받은 편지함을 확인해 주세요.",
-    "source_hash": "58de2536"
+    "text": "인증 이메일이 발송되었습니다. 새 받은 편지함을 확인하고 확인 링크를 클릭하여 변경을 완료하세요.",
+    "source_hash": "45f0a4b5"
   },
   "web.settings.profile.email_change_error": {
     "text": "이메일 업데이트 실패. 다시 시도해 주세요.",
@@ -476,8 +476,8 @@
     "source_hash": "1cc77e60"
   },
   "web.settings.api.documentation_description": {
-    "text": "{product_name}을 애플리케이션에 통합하는 방법을 알아보세요",
-    "source_hash": "6e8f910f"
+    "text": "{product_name}을(를) 애플리케이션에 통합하는 방법을 알아보세요",
+    "source_hash": "9bba1ae8"
   },
   "web.settings.api.rest_api_reference": {
     "text": "REST API 참조",

--- a/locales/content/ko/workspace-billing.json
+++ b/locales/content/ko/workspace-billing.json
@@ -140,12 +140,12 @@
     "source_hash": "1f981aaf"
   },
   "web.billing.overview.no_organizations_title": {
-    "text": "조직 없음",
-    "source_hash": "12420110"
+    "text": "워크스페이스 없음",
+    "source_hash": "c7f70723"
   },
   "web.billing.overview.no_organizations_description": {
-    "text": "결제 및 구독을 관리하려면 조직을 만드세요",
-    "source_hash": "41e922d2"
+    "text": "결제 및 구독을 관리하려면 워크스페이스를 생성하세요",
+    "source_hash": "e0fd27a5"
   },
   "web.billing.overview.load_error": {
     "text": "결제 정보를 불러오지 못했습니다",
@@ -205,7 +205,7 @@
   },
   "web.billing.overview.entitlements.manage_org": {
     "text": "조직 관리",
-    "source_hash": "be0fe4c3"
+    "source_hash": "f03a4985"
   },
   "web.billing.overview.entitlements.manage_teams": {
     "text": "팀 관리",
@@ -220,8 +220,8 @@
     "source_hash": "5428d7fe"
   },
   "web.billing.overview.entitlements.sso": {
-    "text": "싱글 사인온",
-    "source_hash": "cf7cd744"
+    "text": "Single Sign-On (SSO)",
+    "source_hash": "5db5c812"
   },
   "web.billing.overview.entitlements.priority_support": {
     "text": "우선 지원",
@@ -280,8 +280,8 @@
     "source_hash": "5428d7fe"
   },
   "web.billing.features.sso": {
-    "text": "싱글 사인온(SSO)",
-    "source_hash": "5db5c812"
+    "text": "SSO",
+    "source_hash": "5ba3ac9f"
   },
   "web.billing.features.priority_support": {
     "text": "우선 지원",
@@ -577,7 +577,7 @@
   },
   "web.billing.invoices.draft": {
     "text": "초안",
-    "source_hash": "d2e16e61"
+    "source_hash": "ebf12ef4"
   },
   "web.billing.invoices.open": {
     "text": "미결제",

--- a/locales/content/ko/workspace-branding.json
+++ b/locales/content/ko/workspace-branding.json
@@ -28,8 +28,8 @@
     "source_hash": "199c165f"
   },
   "web.branding.preview_and_customize": {
-    "text": "미리보기 및 사용자 지정",
-    "source_hash": "215d3659"
+    "text": "사용자 지정 및 미리 보기",
+    "source_hash": "fc68a28c"
   },
   "web.branding.switch_to_safari_browser_view": {
     "text": "Safari 브라우저 보기로 전환",
@@ -88,8 +88,8 @@
     "source_hash": "43e9a2d7"
   },
   "web.branding.click_to_upload_a_logo_with_recommendation": {
-    "text": "로고를 업로드하려면 클릭하세요. 권장 크기: 128x128 픽셀. 최대 파일 크기: 1MB. 지원 형식: PNG, JPG, SVG",
-    "source_hash": "a35452bf"
+    "text": "로고를 관리하려면 클릭하세요. 권장 크기: 128x128픽셀. 최대 파일 크기: 1MB. 지원 형식: PNG, JPG, SVG",
+    "source_hash": "7bb92395"
   },
   "web.branding.upload_logo": {
     "text": "로고 업로드",
@@ -186,5 +186,225 @@
   "web.branding.keyhole_logo_icon": {
     "text": "안전한 비공개 공유를 나타내는 열쇠구멍 아이콘",
     "source_hash": "c868ac60"
+  },
+  "web.branding.secondary_color": {
+    "text": "보조 색상",
+    "source_hash": "1f4728f6"
+  },
+  "web.branding.background_color": {
+    "text": "배경 색상",
+    "source_hash": "b48bc969"
+  },
+  "web.branding.text_color": {
+    "text": "텍스트 색상",
+    "source_hash": "2ea23234"
+  },
+  "web.branding.border_radius": {
+    "text": "테두리 반경",
+    "source_hash": "e758d7db"
+  },
+  "web.branding.heading_font": {
+    "text": "제목 글꼴",
+    "source_hash": "6b5d30dc"
+  },
+  "web.branding.theme_presets": {
+    "text": "테마 사전 설정",
+    "source_hash": "931eeb74"
+  },
+  "web.branding.logo": {
+    "text": "로고",
+    "source_hash": "d707dc2f"
+  },
+  "web.branding.replace_logo": {
+    "text": "교체",
+    "source_hash": "95e15439"
+  },
+  "web.branding.logo_field_hint": {
+    "text": "변경 사항이 적용되기 전에 미리 보세요.",
+    "source_hash": "e9e222fc"
+  },
+  "web.branding.logo_modal_title": {
+    "text": "도메인 로고",
+    "source_hash": "5260dda5"
+  },
+  "web.branding.logo_modal_hint": {
+    "text": "PNG, JPG 또는 SVG. 권장 128x128px, 최대 1MB.",
+    "source_hash": "75d00802"
+  },
+  "web.branding.logo_modal_save": {
+    "text": "로고 저장",
+    "source_hash": "8b028a6f"
+  },
+  "web.branding.remove_logo": {
+    "text": "로고 제거",
+    "source_hash": "f1c1afa4"
+  },
+  "web.branding.image_upload_choose": {
+    "text": "이미지 선택",
+    "source_hash": "ceed9fd5"
+  },
+  "web.branding.image_upload_drag_hint": {
+    "text": "또는 끌어다 놓기",
+    "source_hash": "6613b73c"
+  },
+  "web.branding.image_invalid_type": {
+    "text": "지원되지 않는 파일 형식입니다. 이미지를 선택하세요.",
+    "source_hash": "50e18866"
+  },
+  "web.branding.image_too_large": {
+    "text": "이미지가 너무 큽니다. 최대 크기는 {max}입니다.",
+    "source_hash": "b50b55e2"
+  },
+  "web.branding.image_will_be_removed": {
+    "text": "저장하면 이 로고가 제거됩니다.",
+    "source_hash": "d94fa99a"
+  },
+  "web.branding.image_upload_failed": {
+    "text": "문제가 발생했습니다. 다시 시도하세요.",
+    "source_hash": "3ccd9d65"
+  },
+  "web.branding.undo": {
+    "text": "실행 취소",
+    "source_hash": "a8283ade"
+  },
+  "web.branding.low_contrast_text_bg_warning": {
+    "text": "텍스트/배경 대비가 낮음",
+    "source_hash": "1c676370"
+  },
+  "web.branding.path_simple": {
+    "text": "간단",
+    "source_hash": "3fee95da"
+  },
+  "web.branding.path_match": {
+    "text": "내 사이트에 맞추기",
+    "source_hash": "776679cf"
+  },
+  "web.branding.path_advanced": {
+    "text": "고급",
+    "source_hash": "9f088dbe"
+  },
+  "web.branding.path_simple_tag": {
+    "text": "브랜드 필수 요소.",
+    "source_hash": "7c9c0cca"
+  },
+  "web.branding.path_match_tag": {
+    "text": "기존 사이트에서 설정을 복사합니다.",
+    "source_hash": "e4b0d1cd"
+  },
+  "web.branding.path_advanced_tag": {
+    "text": "직접 Tailwind v4 CSS를 작성합니다.",
+    "source_hash": "2405bb6d"
+  },
+  "web.branding.badge_default": {
+    "text": "기본값",
+    "source_hash": "21b111cb"
+  },
+  "web.branding.badge_coming_soon": {
+    "text": "곧 제공 예정",
+    "source_hash": "4f7d6401"
+  },
+  "web.branding.your_brand": {
+    "text": "귀하의 브랜드",
+    "source_hash": "406265d3"
+  },
+  "web.branding.your_brand_subtitle": {
+    "text": "몇 가지 간단한 선택만 하면 — 나머지는 저희가 처리합니다.",
+    "source_hash": "dbc8ec33"
+  },
+  "web.branding.corners": {
+    "text": "모서리",
+    "source_hash": "1d3cc47e"
+  },
+  "web.branding.more_options": {
+    "text": "추가 옵션",
+    "source_hash": "bc79cdff"
+  },
+  "web.branding.paths_carryover_hint": {
+    "text": "실시간 미리 보기입니다 — 변경 사항은 저장하기 전까지 방문자에게 표시되지 않습니다.",
+    "source_hash": "cb4b82de"
+  },
+  "web.branding.coming_soon_match_blurb": {
+    "text": "웹사이트를 알려주시면 색상과 글꼴을 읽어들여 한 번의 클릭으로 격차를 좁혀 드립니다.",
+    "source_hash": "42c34cc1"
+  },
+  "web.branding.coming_soon_advanced_blurb": {
+    "text": "Tailwind v4 {'@'}theme 토큰을 직접 편집하거나 자체 스타일시트를 붙여넣으세요.",
+    "source_hash": "5a8473f5"
+  },
+  "web.branding.preview_recipient_page": {
+    "text": "수신자 페이지",
+    "source_hash": "de8aa19f"
+  },
+  "web.branding.preview_badge": {
+    "text": "미리 보기",
+    "source_hash": "324b134f"
+  },
+  "web.branding.preview_homepage_enabled": {
+    "text": "홈페이지 · 활성화됨",
+    "source_hash": "2edd85f1"
+  },
+  "web.branding.preview_homepage_disabled": {
+    "text": "홈페이지 · 비활성화됨",
+    "source_hash": "15d87050"
+  },
+  "web.branding.preview_live": {
+    "text": "실시간 미리 보기",
+    "source_hash": "f65ddc1f"
+  },
+  "web.branding.tile_share_secret": {
+    "text": "비밀 메시지 공유",
+    "source_hash": "5384461b"
+  },
+  "web.branding.tile_create_link": {
+    "text": "비밀 링크 생성",
+    "source_hash": "610fd42e"
+  },
+  "web.branding.tile_delivery_only": {
+    "text": "안전한 메시지 전달만",
+    "source_hash": "dc24dec2"
+  },
+  "web.branding.tile_no_create": {
+    "text": "방문자는 여기서 비밀 메시지를 생성할 수 없습니다.",
+    "source_hash": "17361d81"
+  },
+  "web.branding.recipient_page_content": {
+    "text": "수신자 페이지 콘텐츠",
+    "source_hash": "937733bd"
+  },
+  "web.branding.recipient_page_content_hint": {
+    "text": "이 도메인의 수신자에게 표시되는 언어 및 표시 안내입니다.",
+    "source_hash": "04162b70"
+  },
+  "web.branding.tab_brand": {
+    "text": "브랜드",
+    "source_hash": "090ed431"
+  },
+  "web.branding.tab_delivery": {
+    "text": "전달",
+    "source_hash": "52bfe584"
+  },
+  "web.branding.delivery_language": {
+    "text": "언어",
+    "source_hash": "a4fe6526"
+  },
+  "web.branding.delivery_language_hint": {
+    "text": "이 도메인의 수신자 페이지 및 이메일 기본값입니다. 수신자는 페이지에서 언어를 변경할 수 있습니다.",
+    "source_hash": "bfbc5599"
+  },
+  "web.branding.delivery_reveal_instructions": {
+    "text": "표시 안내",
+    "source_hash": "7e1331f7"
+  },
+  "web.branding.delivery_reveal_instructions_hint": {
+    "text": "수신자 페이지에 표시됩니다. 비워 두면 선택한 언어의 기본 문구가 사용됩니다.",
+    "source_hash": "51b9811d"
+  },
+  "web.branding.delivery_before_reveal": {
+    "text": "표시 전",
+    "source_hash": "5ce82b01"
+  },
+  "web.branding.delivery_after_reveal": {
+    "text": "표시 후",
+    "source_hash": "d5bfe7fd"
   }
 }

--- a/locales/content/ko/workspace-domains.json
+++ b/locales/content/ko/workspace-domains.json
@@ -76,8 +76,8 @@
     "source_hash": "59be7133"
   },
   "web.domains.enabled": {
-    "text": "활성화됨",
-    "source_hash": "92c1cdfd"
+    "text": "활성화",
+    "source_hash": "5342e09f"
   },
   "web.domains.disabled": {
     "text": "비활성화됨",
@@ -1358,5 +1358,189 @@
   "web.domains.sso.upgrade_required": {
     "text": "구성하려면 업그레이드",
     "source_hash": "571cfa98"
+  },
+  "web.domains.add.field_label": {
+    "text": "사용자 지정 도메인",
+    "source_hash": "d7d4c1e4"
+  },
+  "web.domains.add.field_help": {
+    "text": "팀에서 사용할 정확한 호스트 이름입니다. 예: {example}.",
+    "source_hash": "3ba71f78"
+  },
+  "web.domains.add.echo_label": {
+    "text": "비밀 링크는 다음 위치에 생성됩니다",
+    "source_hash": "ad60b17d"
+  },
+  "web.domains.add.apex_question": {
+    "text": "이것은 전체 도메인입니다 — 비밀 링크를 어디에 두시겠습니까?",
+    "source_hash": "efacad1b"
+  },
+  "web.domains.add.apex_help": {
+    "text": "하위 도메인을 사용하면 {domain}의 나머지 부분은 그대로 유지됩니다.",
+    "source_hash": "0f7e6181"
+  },
+  "web.domains.add.recommended": {
+    "text": "권장",
+    "source_hash": "d70604e8"
+  },
+  "web.domains.add.no_wrong_answer": {
+    "text": "잘못된 선택은 없습니다 — 팀에서 알아볼 수 있는 것을 선택하세요.",
+    "source_hash": "a04f0086"
+  },
+  "web.domains.add.subdomains_label": {
+    "text": "인기 있는 하위 도메인",
+    "source_hash": "d6ee8eac"
+  },
+  "web.domains.add.root_group_label": {
+    "text": "또는 전체 도메인 사용",
+    "source_hash": "5c23c007"
+  },
+  "web.domains.add.root_domain_label": {
+    "text": "루트 도메인 사용",
+    "source_hash": "9fbbe253"
+  },
+  "web.domains.add.root_domain_description": {
+    "text": "이렇게 하면 {domain} 전체가 저희를 가리키게 되며 — 해당 사이트는 더 이상 확인되지 않습니다 — A / ALIAS 레코드가 필요합니다.",
+    "source_hash": "fae93847"
+  },
+  "web.domains.add.error_unrecognized_suffix": {
+    "text": "“.{0}”은(는) 인식되지 않는 도메인 끝입니다 — 오타를 확인하세요 (예: {1}).",
+    "source_hash": "4b90033d"
+  },
+  "web.domains.add.error_invalid_hostname": {
+    "text": "유효한 호스트 이름을 입력하세요 — 문자, 숫자, 단일 점 및 대시 (예: {0}).",
+    "source_hash": "c4ceabc1"
+  },
+  "web.domains.add.error_empty": {
+    "text": "도메인 이름을 입력하세요.",
+    "source_hash": "d8e2c1e4"
+  },
+  "web.domains.add.continue_with": {
+    "text": "{0}(으)로 계속",
+    "source_hash": "73f8ab40"
+  },
+  "web.domains.auth_override.workspace_default_badge": {
+    "text": "워크스페이스 기본값",
+    "source_hash": "da3706ee"
+  },
+  "web.domains.detail.dns_title": {
+    "text": "DNS 설정",
+    "source_hash": "6c63df31"
+  },
+  "web.domains.detail.dns_description": {
+    "text": "CNAME 레코드로 도메인을 이 서버로 지정하세요",
+    "source_hash": "080f84f0"
+  },
+  "web.domains.dns.title": {
+    "text": "DNS 구성",
+    "source_hash": "da78c35d"
+  },
+  "web.domains.dns.point_domain_intro": {
+    "text": "다음 DNS 레코드를 공급자에 추가하여",
+    "source_hash": "2fc0c524"
+  },
+  "web.domains.dns.point_domain_outro": {
+    "text": "을(를) 이 서버로 지정하세요.",
+    "source_hash": "8d260c05"
+  },
+  "web.domains.dns.cname_heading": {
+    "text": "CNAME 레코드 생성",
+    "source_hash": "11aeef5a"
+  },
+  "web.domains.dns.apex_heading": {
+    "text": "ALIAS 또는 ANAME 레코드 생성",
+    "source_hash": "41135375"
+  },
+  "web.domains.dns.apex_notice": {
+    "text": "최상위(루트) 도메인은 CNAME 레코드를 사용할 수 없습니다. 대신 DNS 공급자의 ALIAS 또는 ANAME 레코드를 사용하거나, A 레코드를 서버의 IP 주소로 지정하세요.",
+    "source_hash": "2d1c3298"
+  },
+  "web.domains.email.from_address_local_placeholder": {
+    "text": "no-reply",
+    "source_hash": "510d274d"
+  },
+  "web.domains.homepage.title": {
+    "text": "홈페이지",
+    "source_hash": "9e3391e9"
+  },
+  "web.domains.homepage.description": {
+    "text": "방문자가 도메인 홈페이지에서 할 수 있는 작업",
+    "source_hash": "974d159e"
+  },
+  "web.domains.homepage.option_private_title": {
+    "text": "비공개 랜딩 페이지",
+    "source_hash": "dfd5bd1c"
+  },
+  "web.domains.homepage.option_private_description": {
+    "text": "방문자에게 상호작용 양식이 없는 비공개 랜딩 페이지가 표시됩니다",
+    "source_hash": "4d9aaf6f"
+  },
+  "web.domains.homepage.option_create_title": {
+    "text": "비밀 메시지 생성 양식",
+    "source_hash": "6539dfc1"
+  },
+  "web.domains.homepage.option_create_description": {
+    "text": "방문자가 자신의 비밀 링크를 생성할 수 있습니다",
+    "source_hash": "884310f4"
+  },
+  "web.domains.homepage.option_incoming_title": {
+    "text": "수신 비밀 메시지 양식",
+    "source_hash": "882997bf"
+  },
+  "web.domains.homepage.option_incoming_description": {
+    "text": "방문자가 구성된 수신자에게 비밀 메시지를 보낼 수 있습니다",
+    "source_hash": "86bdaedb"
+  },
+  "web.domains.homepage.incoming_requires_recipients": {
+    "text": "수신 비밀 메시지가 하나 이상의 수신자와 함께 활성화되어 있어야 합니다",
+    "source_hash": "0462611d"
+  },
+  "web.domains.homepage.configure_recipients": {
+    "text": "수신자 구성",
+    "source_hash": "1c3df8b4"
+  },
+  "web.domains.homepage.status_private": {
+    "text": "비공개 랜딩 페이지",
+    "source_hash": "dfd5bd1c"
+  },
+  "web.domains.homepage.status_create": {
+    "text": "공개: 방문자가 비밀 메시지를 생성합니다",
+    "source_hash": "251cfb95"
+  },
+  "web.domains.homepage.status_incoming": {
+    "text": "공개: 방문자가 비밀 메시지를 보냅니다",
+    "source_hash": "baa926b8"
+  },
+  "web.domains.homepage.status_incoming_unready": {
+    "text": "수신 준비 안 됨 — 비공개 랜딩 페이지 표시 중",
+    "source_hash": "a5cc237c"
+  },
+  "web.domains.homepage.badge_incoming": {
+    "text": "수신",
+    "source_hash": "e301820a"
+  },
+  "web.domains.homepage.update_success": {
+    "text": "홈페이지 설정이 저장되었습니다",
+    "source_hash": "4eac9f45"
+  },
+  "web.domains.homepage.homepage_uses_incoming_warning": {
+    "text": "이 도메인의 홈페이지는 현재 수신 비밀 메시지 양식을 표시하고 있습니다. 수신 비밀 메시지를 비활성화하거나 모든 수신자를 제거하면 수신이 다시 준비될 때까지 홈페이지가 비공개 랜딩 페이지로 전환됩니다.",
+    "source_hash": "cc0d4997"
+  },
+  "web.domains.signin.effective_status_label": {
+    "text": "이 도메인의 로그인",
+    "source_hash": "d8b884c3"
+  },
+  "web.domains.signin.dormant_notice": {
+    "text": "로그인이 워크스페이스 전체에서 꺼져 있어 모든 도메인에서 사용할 수 없습니다. 여기서 설정한 내용은 유지되며 워크스페이스 로그인이 다시 활성화되면 적용됩니다.",
+    "source_hash": "723d35dc"
+  },
+  "web.domains.signup.effective_status_label": {
+    "text": "이 도메인의 가입",
+    "source_hash": "115ab21b"
+  },
+  "web.domains.signup.dormant_notice": {
+    "text": "가입이 워크스페이스 전체에서 꺼져 있어 모든 도메인에서 사용할 수 없습니다. 여기서 설정한 내용은 유지되며 워크스페이스 가입이 다시 활성화되면 적용됩니다.",
+    "source_hash": "49faefe4"
   }
 }

--- a/locales/content/ko/workspace-organizations.json
+++ b/locales/content/ko/workspace-organizations.json
@@ -4,8 +4,8 @@
     "source_hash": "2730183d"
   },
   "web.organizations.organization": {
-    "text": "조직",
-    "source_hash": "d764d425"
+    "text": "워크스페이스",
+    "source_hash": "87bb59ba"
   },
   "web.organizations.organization_plural": {
     "text": "조직",
@@ -16,24 +16,24 @@
     "source_hash": "dbaa4f92"
   },
   "web.organizations.my_organizations": {
-    "text": "조직",
-    "source_hash": "2730183d"
+    "text": "워크스페이스",
+    "source_hash": "1377264b"
   },
   "web.organizations.manage_organizations": {
-    "text": "조직 관리",
-    "source_hash": "be0fe4c3"
+    "text": "워크스페이스 관리",
+    "source_hash": "cc2d65f8"
   },
   "web.organizations.new_organization": {
     "text": "새 조직",
     "source_hash": "4876e647"
   },
   "web.organizations.no_organizations": {
-    "text": "아직 조직이 없습니다",
-    "source_hash": "5b7a7cbd"
+    "text": "아직 워크스페이스가 없습니다",
+    "source_hash": "97d0b117"
   },
   "web.organizations.no_organizations_description": {
-    "text": "조직은 통합 결제 및 관리를 제공합니다. 첫 번째 조직을 만들어 시작하세요.",
-    "source_hash": "deab4304"
+    "text": "워크스페이스는 통합 결제 및 관리 기능을 제공합니다. 첫 워크스페이스를 생성하여 시작하세요.",
+    "source_hash": "f09d4987"
   },
   "web.organizations.no_description": {
     "text": "설명이 제공되지 않았습니다",
@@ -48,24 +48,24 @@
     "source_hash": "e27f4540"
   },
   "web.organizations.create_first_organization": {
-    "text": "첫 번째 조직 생성",
-    "source_hash": "27bae486"
+    "text": "첫 워크스페이스 생성",
+    "source_hash": "98a583b4"
   },
   "web.organizations.create_organization_description": {
-    "text": "새 조직 생성",
-    "source_hash": "67cd5950"
+    "text": "새 워크스페이스 생성",
+    "source_hash": "6ac2b5fc"
   },
   "web.organizations.create": {
     "text": "생성",
     "source_hash": "4759498a"
   },
   "web.organizations.create_error": {
-    "text": "조직 생성 실패",
-    "source_hash": "f2204373"
+    "text": "워크스페이스 생성에 실패했습니다",
+    "source_hash": "0a8d4fd6"
   },
   "web.organizations.organization_name": {
-    "text": "조직 이름",
-    "source_hash": "4cbd9073"
+    "text": "워크스페이스 이름",
+    "source_hash": "6fa5a5b1"
   },
   "web.organizations.organization_name_placeholder": {
     "text": "예: Acme Corporation",
@@ -92,12 +92,12 @@
     "source_hash": "ee81c03d"
   },
   "web.organizations.select_organization": {
-    "text": "조직 선택",
-    "source_hash": "48326f52"
+    "text": "워크스페이스 선택",
+    "source_hash": "70a8ce66"
   },
   "web.organizations.switcher_locked": {
-    "text": "이 페이지에서는 조직 전환을 사용할 수 없습니다",
-    "source_hash": "da0cf810"
+    "text": "이 페이지에서는 워크스페이스 전환을 사용할 수 없습니다",
+    "source_hash": "c34114ac"
   },
   "web.organizations.not_found": {
     "text": "조직을 찾을 수 없습니다",
@@ -208,8 +208,8 @@
     "source_hash": "7ecc5d35"
   },
   "web.organizations.tabs.members": {
-    "text": "팀",
-    "source_hash": "5985039f"
+    "text": "구성원",
+    "source_hash": "1044a4c0"
   },
   "web.organizations.tabs.billing": {
     "text": "결제",
@@ -468,8 +468,8 @@
     "source_hash": "424a2551"
   },
   "web.organizations.invitations.roles.member": {
-    "text": "멤버",
-    "source_hash": "7c968fb7"
+    "text": "팀 구성원",
+    "source_hash": "d4e55dfa"
   },
   "web.organizations.invitations.roles.admin": {
     "text": "관리자",
@@ -532,8 +532,8 @@
     "source_hash": "5e3f8df8"
   },
   "web.organizations.invitations.upgrade_prompt": {
-    "text": "팀 멤버 초대는 팀 관리가 포함된 요금제가 필요합니다. 조직에 협력자를 추가하려면 업그레이드하세요.",
-    "source_hash": "cf10d623"
+    "text": "구성원 초대에는 유료 요금제가 필요합니다. 조직에 협업자를 추가하려면 업그레이드하세요.",
+    "source_hash": "47d0eeab"
   },
   "web.organizations.paid_badge": {
     "text": "Pro",
@@ -557,7 +557,7 @@
   },
   "web.organizations.invitations.email_mismatch_title": {
     "text": "다른 계정으로 로그인됨",
-    "source_hash": "4a2f91c3"
+    "source_hash": "6516362a"
   },
   "web.organizations.invitations.email_mismatch_body": {
     "text": "이 초대는 {invitedEmail} 대상입니다. 현재 {currentEmail}(으)로 로그인되어 있습니다.",
@@ -565,7 +565,7 @@
   },
   "web.organizations.invitations.continue_as_invited_email": {
     "text": "{email}(으)로 계속",
-    "source_hash": "6c9a1d4e"
+    "source_hash": "ccf9745d"
   },
   "web.organizations.invitations.expires_in_days": {
     "text": "{days}일 남음",
@@ -1026,5 +1026,9 @@
   "web.organizations.tabs.sso": {
     "text": "SSO",
     "source_hash": "5ba3ac9f"
+  },
+  "web.organizations.create_workspace": {
+    "text": "워크스페이스 생성",
+    "source_hash": "c63c14cf"
   }
 }


### PR DESCRIPTION
## `ko` translation update

Automated export of completed **ko** translations from the translation task DB.
Scope: `locales/content/ko/` only — 33 file(s), +3702/-108.

ℹ️ Variable validation not run.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-opus-4-8`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ✅ Looks good — variables & brands intact.

**Summary:** Large ko update: 14 new `admin-*.json` files plus edits across common/layout/email/branding/domains/organizations, driven by an org→workspace terminology shift and admin-console additions. Placeholders and brand terms are preserved; no empties or mojibake.

**Critical (must fix):** None.

**Warnings:**
- Variable-consistency check was **not run**. Manual spot-check passed (`{product_name}`, `{ip}`, `{count}`, `{0}/{1}`, `%{secrets_mode}`, `%{status}` removal, multi-var strings like `sync.success`, `scan.summary`, `dbSummary` all match), but run the validator before merge to be certain.
- `api.invite.errors.invitation_already_processed` dropped `%{status}` ("이미 처리되었습니다"). This is correct — the EN source itself removed the variable (source_hash changed) — flagging only because it's a placeholder deletion.

**Notes:**
- org→workspace rename is a **partial mirror**: some keys → 워크스페이스 (e.g. `organizations.organization`, `my_organizations`, billing `no_organizations_*`), while sibling keys keep 조직 (`organization_plural`, `new_organization`, `not_found`). The retained ones have unchanged source_hash, so the mix reflects the EN source, not translator drift.
- Deliberate English carve-outs present and correct: Colonel, Stripe, Redis INFO, SSO, DNS/CNAME/ALIAS/ANAME/TXT, CIDR, Caddy, Lettermint, User Agent, Approximated/Passthrough/External.
- Vue `@`-escapes (`user{'@'}example.com`, `{'@'}theme`) preserved intact.
- `billing.features.sso` "싱글 사인온(SSO)"→"SSO" and `entitlements.sso`→"Single Sign-On (SSO)" are source-driven.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
