### PR TITLE
i18n: update mi_NZ translations

### DIFF
--- a/locales/content/mi_NZ/00-common.json
+++ b/locales/content/mi_NZ/00-common.json
@@ -1267,8 +1267,8 @@
     "source_hash": "cb2f00d1"
   },
   "web.TITLES.organizations_settings": {
-    "text": "Whakahaere",
-    "source_hash": "2730183d"
+    "text": "Ngā Wāhi Mahi",
+    "source_hash": "1377264b"
   },
   "web.TITLES.organization_settings": {
     "text": "Tautuhinga Whakahaere",
@@ -1299,8 +1299,8 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Me manatoko tonu koe kei runga koe i te paetukutuku mana o {product_name}. He wā tā ngā tāhae e waihanga ana i ngā paetukutuku tinihanga e tino rite ana ki {product_name} hei tāhae i āu karere huna. Hei karo i ngā whakaeke phishing, tirohia te rohe ā-takiwā i mua i te waihanga hononga hou.",
-    "source_hash": "68ec20f8"
+    "text": "Manatokona i ngā wā katoa kei te paetukutuku mana o {product_name} koe. He wā ka waihanga ngā tāhae i ngā paetukutuku horihori e rite tonu ana ki a {product_name} hei tāhae i ō karere huna. Hei karo i ngā whakaeke phishing, manatokona te rohe ā-takiwā i tō pae wāhitau i mua i te waihanga hononga hou.",
+    "source_hash": "2e3b856e"
   },
   "web.pricing.title": {
     "text": "Utu Mārama, Pono",
@@ -1523,5 +1523,21 @@
   "web.TITLES.domain_incoming": {
     "text": "Ngā Karere Huna Taemai",
     "source_hash": "883dbca9"
+  },
+  "web.LABELS.update": {
+    "text": "Whakahou",
+    "source_hash": "c1c1009d"
+  },
+  "web.LABELS.updating": {
+    "text": "E whakahou ana...",
+    "source_hash": "0a4e0b71"
+  },
+  "web.TITLES.check_email": {
+    "text": "Tirohia Tō Īmēra",
+    "source_hash": "0e5fc27d"
+  },
+  "web.TITLES.domain_dns": {
+    "text": "Whakaritenga DNS",
+    "source_hash": "6c63df31"
   }
 }

--- a/locales/content/mi_NZ/10-layout.json
+++ b/locales/content/mi_NZ/10-layout.json
@@ -101,11 +101,11 @@
   },
   "web.footer.product": {
     "text": "Hua",
-    "source_hash": "7f5540e9"
+    "source_hash": "fb9ef894"
   },
   "web.footer.source_code_purveyor": {
-    "text": "Waehere Pūtake",
-    "source_hash": "29c5c68f"
+    "text": "Waehere Puna",
+    "source_hash": "bc47da66"
   },
   "web.navigation.billing": {
     "text": "Nama",
@@ -149,7 +149,7 @@
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
     "text": "Kei te tiro koe i tētahi karere haumaru i tohatohaina ki a koe mā {product_name}. Ka whakaaturia tēnei ihirangi kotahi anake, kātahi ka murua rawatia i ā mātou tūmau.",
-    "source_hash": "e0f1a10c"
+    "source_hash": "7a4e9d16"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
     "text": "Ka taea e au te tiro anō i tēnei karere huna ā muri ake?",
@@ -265,7 +265,7 @@
   },
   "web.layout.visit_onetime_secret_homepage": {
     "text": "Toro ki te whārangi kāinga o {product_name}",
-    "source_hash": "625556d2"
+    "source_hash": "87802af5"
   },
   "web.layout.footer_navigation": {
     "text": "Whakatere waewae",
@@ -346,5 +346,9 @@
   "web.help.default_content": {
     "text": "Tēnā whakapā atu ki te tautoko mō te āwhina",
     "source_hash": "752bca14"
+  },
+  "web.layout.colonels_only_badge": {
+    "text": "Mō ngā Colonel Anake",
+    "source_hash": "3f1e2dbd"
   }
 }

--- a/locales/content/mi_NZ/admin-audit.json
+++ b/locales/content/mi_NZ/admin-audit.json
@@ -1,0 +1,102 @@
+{
+  "web.admin.audit.title": {
+    "text": "Rangitaki Arotake",
+    "source_hash": "47751f88"
+  },
+  "web.admin.audit.description": {
+    "text": "Ia mahi kaiwhakahaere panoni, te mea hou tuatahi — ko wai i aha ki a wai, me tōna otinga.",
+    "source_hash": "2326a1a0"
+  },
+  "web.admin.audit.categories.customer": {
+    "text": "Ngā Kiritaki",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.audit.categories.session": {
+    "text": "Ngā Wātū",
+    "source_hash": "6fa3cbf4"
+  },
+  "web.admin.audit.categories.domain": {
+    "text": "Ngā Rohe",
+    "source_hash": "ced67718"
+  },
+  "web.admin.audit.categories.organization": {
+    "text": "Ngā Whakahaere",
+    "source_hash": "2730183d"
+  },
+  "web.admin.audit.categories.banner": {
+    "text": "Pānui",
+    "source_hash": "b7f4d98f"
+  },
+  "web.admin.audit.categories.queue": {
+    "text": "Ngā Rārangi Tatari",
+    "source_hash": "be77db11"
+  },
+  "web.admin.audit.categories.email": {
+    "text": "Īmēra",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.audit.categories.ratelimit": {
+    "text": "Ngā Tepe Reeti",
+    "source_hash": "6ed021f7"
+  },
+  "web.admin.audit.categories.ip": {
+    "text": "Ngā Aukati IP",
+    "source_hash": "48cdea49"
+  },
+  "web.admin.audit.columns.timestamp": {
+    "text": "Tāpā Wā",
+    "source_hash": "115a2cc9"
+  },
+  "web.admin.audit.columns.actor": {
+    "text": "Kaimahi",
+    "source_hash": "449995c4"
+  },
+  "web.admin.audit.columns.action": {
+    "text": "Mahi",
+    "source_hash": "64cff131"
+  },
+  "web.admin.audit.columns.target": {
+    "text": "Whāinga",
+    "source_hash": "978354db"
+  },
+  "web.admin.audit.columns.result": {
+    "text": "Otinga",
+    "source_hash": "6e7d50e8"
+  },
+  "web.admin.audit.columns.detail": {
+    "text": "Taipitopito",
+    "source_hash": "fb5f27d5"
+  },
+  "web.admin.audit.filters.actorPlaceholder": {
+    "text": "Tātari mā te kaimahi (extid, īmēra rānei)",
+    "source_hash": "966aa580"
+  },
+  "web.admin.audit.filters.actionLabel": {
+    "text": "Mahi",
+    "source_hash": "64cff131"
+  },
+  "web.admin.audit.filters.allActions": {
+    "text": "Ngā mahi katoa",
+    "source_hash": "83140cf1"
+  },
+  "web.admin.audit.list.loadError": {
+    "text": "Kāore i taea te uta i te rangitaki arotake.",
+    "source_hash": "acf244f4"
+  },
+  "web.admin.audit.list.retry": {
+    "text": "Ngana anō",
+    "source_hash": "942087cc"
+  },
+  "web.admin.audit.list.empty": {
+    "text": "Kāore anō he takahanga arotake kia tāmauria",
+    "source_hash": "8fe0cac3"
+  },
+  "web.admin.audit.result.success": {
+    "text": "Angitu",
+    "source_hash": "c88a0b90"
+  },
+  "web.admin.audit.result.failure": {
+    "text": "Rahunga",
+    "source_hash": "7031edbc"
+  }
+}

--- a/locales/content/mi_NZ/admin-bannedips.json
+++ b/locales/content/mi_NZ/admin-bannedips.json
@@ -1,0 +1,114 @@
+{
+  "web.admin.bannedIps.title": {
+    "text": "Ngā IP Aukati",
+    "source_hash": "0ece5643"
+  },
+  "web.admin.bannedIps.description": {
+    "text": "Aukati me te whakawātea i ngā wāhitau IP i te taiepa o te pae.",
+    "source_hash": "69c0c992"
+  },
+  "web.admin.bannedIps.currentIp": {
+    "text": "Tō IP o nāianei",
+    "source_hash": "14ff3ec5"
+  },
+  "web.admin.bannedIps.actions.cancel": {
+    "text": "Whakakore",
+    "source_hash": "19766ed6"
+  },
+  "web.admin.bannedIps.actions.ban": {
+    "text": "Aukati i tētahi IP",
+    "source_hash": "9937d7fd"
+  },
+  "web.admin.bannedIps.actions.quickBan": {
+    "text": "Aukati i tēnei IP",
+    "source_hash": "95720658"
+  },
+  "web.admin.bannedIps.ban.confirmTitle": {
+    "text": "Aukati i tēnei wāhitau IP?",
+    "source_hash": "512acd7b"
+  },
+  "web.admin.bannedIps.ban.confirmDescription": {
+    "text": "Ka ārai tēnei i {ip} i te taiepa o te pae. Patohia te IP hei whakaū.",
+    "source_hash": "d8f6142e"
+  },
+  "web.admin.bannedIps.ban.button": {
+    "text": "Aukati IP",
+    "source_hash": "f91a5285"
+  },
+  "web.admin.bannedIps.ban.success": {
+    "text": "Kua aukatia a {ip}",
+    "source_hash": "97180685"
+  },
+  "web.admin.bannedIps.columns.ipAddress": {
+    "text": "Wāhitau IP",
+    "source_hash": "3c3de0c9"
+  },
+  "web.admin.bannedIps.columns.reason": {
+    "text": "Take",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.bannedIps.columns.bannedAt": {
+    "text": "I Aukatia",
+    "source_hash": "dfbd120e"
+  },
+  "web.admin.bannedIps.columns.bannedBy": {
+    "text": "Nā Wai i Aukati",
+    "source_hash": "9f47db0e"
+  },
+  "web.admin.bannedIps.columns.actions": {
+    "text": "Ngā Mahi",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.bannedIps.form.title": {
+    "text": "Aukati i tētahi wāhitau IP",
+    "source_hash": "59961746"
+  },
+  "web.admin.bannedIps.form.ipLabel": {
+    "text": "Wāhitau IP, CIDR rānei",
+    "source_hash": "133d0819"
+  },
+  "web.admin.bannedIps.form.reasonLabel": {
+    "text": "Take (kōwhiringa)",
+    "source_hash": "0f7d4664"
+  },
+  "web.admin.bannedIps.form.reasonPlaceholder": {
+    "text": "hei tauira, whakakī pūnga whaimana",
+    "source_hash": "828a15ae"
+  },
+  "web.admin.bannedIps.form.submit": {
+    "text": "Aukati IP",
+    "source_hash": "f91a5285"
+  },
+  "web.admin.bannedIps.list.loadError": {
+    "text": "Kāore i taea te uta i ngā IP aukati.",
+    "source_hash": "539f2e34"
+  },
+  "web.admin.bannedIps.list.retry": {
+    "text": "Ngana anō",
+    "source_hash": "942087cc"
+  },
+  "web.admin.bannedIps.list.empty": {
+    "text": "Kāore he IP kua aukatia i tēnei wā",
+    "source_hash": "b72cc9c5"
+  },
+  "web.admin.bannedIps.stats.total": {
+    "text": "Tapeke Aukati",
+    "source_hash": "41059c94"
+  },
+  "web.admin.bannedIps.unban.confirmTitle": {
+    "text": "Tangohia tēnei aukati?",
+    "source_hash": "88473e59"
+  },
+  "web.admin.bannedIps.unban.confirmDescription": {
+    "text": "Ka whakawātea tēnei i {ip}. Patohia te IP hei whakaū.",
+    "source_hash": "6bec3191"
+  },
+  "web.admin.bannedIps.unban.button": {
+    "text": "Whakawātea",
+    "source_hash": "25fb5989"
+  },
+  "web.admin.bannedIps.unban.success": {
+    "text": "Kua whakawāteatia a {ip}",
+    "source_hash": "79192c36"
+  }
+}

--- a/locales/content/mi_NZ/admin-banner.json
+++ b/locales/content/mi_NZ/admin-banner.json
@@ -1,0 +1,154 @@
+{
+  "web.admin.banner.title": {
+    "text": "Pānui Pāpāho",
+    "source_hash": "0bc449a3"
+  },
+  "web.admin.banner.description": {
+    "text": "Whakaputaina he pānui puta noa i te pae ka whakaaturia ki ia manuhiri, mukua rānei te mea o nāianei.",
+    "source_hash": "a0f720d7"
+  },
+  "web.admin.banner.loadError": {
+    "text": "Kāore i taea te uta i te pānui o nāianei.",
+    "source_hash": "04954e72"
+  },
+  "web.admin.banner.retry": {
+    "text": "Ngana anō",
+    "source_hash": "942087cc"
+  },
+  "web.admin.banner.clear.button": {
+    "text": "Muku pānui",
+    "source_hash": "da6b2e5d"
+  },
+  "web.admin.banner.clear.confirmTitle": {
+    "text": "Muku i te pānui pāpāho?",
+    "source_hash": "46d9c35a"
+  },
+  "web.admin.banner.clear.confirmDescription": {
+    "text": "Ka tangohia tēnei i te pānui ora mō ia manuhiri. Patohia te kupu whakaū kia haere tonu.",
+    "source_hash": "9a56e4be"
+  },
+  "web.admin.banner.clear.success": {
+    "text": "Kua mukua te pānui pāpāho.",
+    "source_hash": "b0f52af4"
+  },
+  "web.admin.banner.current.title": {
+    "text": "Pānui o nāianei",
+    "source_hash": "d17ab873"
+  },
+  "web.admin.banner.current.none": {
+    "text": "Kāore he pānui kua tautuhia i tēnei wā.",
+    "source_hash": "487b2cac"
+  },
+  "web.admin.banner.current.status": {
+    "text": "Tūnga",
+    "source_hash": "920e413c"
+  },
+  "web.admin.banner.current.live": {
+    "text": "Ora",
+    "source_hash": "b64ac05f"
+  },
+  "web.admin.banner.current.expiry": {
+    "text": "Paunga",
+    "source_hash": "6956d814"
+  },
+  "web.admin.banner.current.persistent": {
+    "text": "Pūmau (kāore he paunga)",
+    "source_hash": "5f95d1b0"
+  },
+  "web.admin.banner.current.expiresIn": {
+    "text": "Ka pau i roto i {duration}",
+    "source_hash": "f353f9a7"
+  },
+  "web.admin.banner.current.audience": {
+    "text": "Hunga Mātaki",
+    "source_hash": "545c0235"
+  },
+  "web.admin.banner.current.storedContent": {
+    "text": "Ihirangi Penapena",
+    "source_hash": "3579f3e6"
+  },
+  "web.admin.banner.current.htmlNote": {
+    "text": "He HTML te ihirangi; ka whakamā te pae ki ngā hononga anake i te wā e whakaaturia ana.",
+    "source_hash": "e45a7dfe"
+  },
+  "web.admin.banner.current.edit": {
+    "text": "Whakatika",
+    "source_hash": "464c4ffd"
+  },
+  "web.admin.banner.set.title": {
+    "text": "Tautuhi pānui",
+    "source_hash": "b6f90d5c"
+  },
+  "web.admin.banner.set.updateTitle": {
+    "text": "Whakahou i te pānui",
+    "source_hash": "841a0183"
+  },
+  "web.admin.banner.set.contentLabel": {
+    "text": "Karere",
+    "source_hash": "2f77668a"
+  },
+  "web.admin.banner.set.contentPlaceholder": {
+    "text": "Whakapainga whakaritea Rātapu 02:00 UTC",
+    "source_hash": "4ec99d7d"
+  },
+  "web.admin.banner.set.contentHelp": {
+    "text": "Ka whakaaetia te HTML; ka whakamā te pae ki ngā hononga anake.",
+    "source_hash": "7253d1cd"
+  },
+  "web.admin.banner.set.ttlLabel": {
+    "text": "Pau aunoa i muri (hēkona)",
+    "source_hash": "72134116"
+  },
+  "web.admin.banner.set.ttlPlaceholder": {
+    "text": "Waiho wātea kia kore ai he paunga",
+    "source_hash": "a8fd81e1"
+  },
+  "web.admin.banner.set.ttlHelp": {
+    "text": "Kōwhiringa. Ka tangohia aunoatia te pānui i muri i tēnei maha o ngā hēkona.",
+    "source_hash": "ba0237f5"
+  },
+  "web.admin.banner.set.scopeLabel": {
+    "text": "Hunga Mātaki",
+    "source_hash": "545c0235"
+  },
+  "web.admin.banner.set.scopeHelp": {
+    "text": "Ko ēhea whārangi e whakaatu ana i te pānui. Ka kite noa ngā whārangi rohe-ritenga i te wā ka tautuhia ki ngā whārangi katoa.",
+    "source_hash": "28cc3018"
+  },
+  "web.admin.banner.set.scopeNoRecipient": {
+    "text": "Ngā mea katoa engari ngā whārangi kaiwhiwhi",
+    "source_hash": "8575b3c0"
+  },
+  "web.admin.banner.set.scopeWorkspace": {
+    "text": "Ngā whārangi Wāhi Mahi anake",
+    "source_hash": "563e003e"
+  },
+  "web.admin.banner.set.scopeAll": {
+    "text": "Ngā whārangi katoa (tae atu ki ngā rohe ritenga)",
+    "source_hash": "b9b74870"
+  },
+  "web.admin.banner.set.publishButton": {
+    "text": "Whakaputa pānui",
+    "source_hash": "5b7427a1"
+  },
+  "web.admin.banner.set.updateButton": {
+    "text": "Whakahou pānui",
+    "source_hash": "69b6e40e"
+  },
+  "web.admin.banner.set.confirmTitle": {
+    "text": "Whakaputa i te pānui pāpāho?",
+    "source_hash": "8b72b5c3"
+  },
+  "web.admin.banner.set.confirmDescription": {
+    "text": "Ka whakaaturia tēnei pānui ki ia manuhiri puta noa i te pae kia mukua, kia pau rānei.",
+    "source_hash": "c61bbec1"
+  },
+  "web.admin.banner.set.confirmButton": {
+    "text": "Whakaputa",
+    "source_hash": "859390eb"
+  },
+  "web.admin.banner.set.success": {
+    "text": "Kua whakaputaina te pānui pāpāho.",
+    "source_hash": "55c06cab"
+  }
+}

--- a/locales/content/mi_NZ/admin-billing.json
+++ b/locales/content/mi_NZ/admin-billing.json
@@ -1,0 +1,126 @@
+{
+  "web.admin.billing.title": {
+    "text": "Kātarauka Nama",
+    "source_hash": "bfde7e68"
+  },
+  "web.admin.billing.description": {
+    "text": "Tirohanga pānui-anake o ngā mahere kua whirihorahia me ō rātou whaimana, me ngā rerenga kē mai i te kātarauka ora kua tukutahingia ki a Stripe.",
+    "source_hash": "05d5b332"
+  },
+  "web.admin.billing.retry": {
+    "text": "Ngana anō",
+    "source_hash": "942087cc"
+  },
+  "web.admin.billing.loadError": {
+    "text": "Kāore i taea te uta i te kātarauka nama.",
+    "source_hash": "c3110f77"
+  },
+  "web.admin.billing.localConfigWarning": {
+    "text": "Kua takoto kau te keteroki mahere kua tukutahingia ki a Stripe, nō reira kāore e taea te aromatawai i ngā mahere ora me ngā rerenga kē. E whakaatu ana i te kātarauka kua whirihorahia (billing.yaml) anake — he mea noa i te whanaketanga, i te wā rānei kāore a Stripe i whirihorahia.",
+    "source_hash": "905d95f8"
+  },
+  "web.admin.billing.inSync": {
+    "text": "Kei te tukutahi",
+    "source_hash": "5701958c"
+  },
+  "web.admin.billing.driftCount": {
+    "text": "{count} rerekētanga",
+    "source_hash": "166538f5"
+  },
+  "web.admin.billing.inSyncDetail": {
+    "text": "E rite ana te kātarauka kua whirihorahia ki ngā mahere ora. Kāore he rerenga kē i kitea.",
+    "source_hash": "57ab60a6"
+  },
+  "web.admin.billing.columns.planid": {
+    "text": "ID Mahere",
+    "source_hash": "1f0d4dc6"
+  },
+  "web.admin.billing.columns.name": {
+    "text": "Ingoa",
+    "source_hash": "dcd1d522"
+  },
+  "web.admin.billing.columns.tier": {
+    "text": "Taumata",
+    "source_hash": "cb9e8664"
+  },
+  "web.admin.billing.columns.status": {
+    "text": "Tūnga",
+    "source_hash": "920e413c"
+  },
+  "web.admin.billing.diff.title": {
+    "text": "Rerekētanga mahere: {planid}",
+    "source_hash": "bc86e5f7"
+  },
+  "web.admin.billing.diff.subtitle": {
+    "text": "Kātarauka kua whirihorahia (billing.yaml) me te mahere ora kua tukutahingia ki a Stripe, taha ki te taha.",
+    "source_hash": "d92e93ae"
+  },
+  "web.admin.billing.diff.config": {
+    "text": "Kua whirihorahia (billing.yaml)",
+    "source_hash": "6bf2ff04"
+  },
+  "web.admin.billing.diff.live": {
+    "text": "Ora (keteroki Stripe)",
+    "source_hash": "4886945d"
+  },
+  "web.admin.billing.diff.absentConfig": {
+    "text": "Kāore tēnei mahere i te kātarauka kua whirihorahia.",
+    "source_hash": "0b594c88"
+  },
+  "web.admin.billing.diff.absentLive": {
+    "text": "Kāore tēnei mahere i te keteroki ora kua tukutahingia ki a Stripe.",
+    "source_hash": "c53f31c3"
+  },
+  "web.admin.billing.plans.title": {
+    "text": "Ngā Mahere",
+    "source_hash": "dfe8b2f0"
+  },
+  "web.admin.billing.plans.empty": {
+    "text": "Kāore he mahere i kitea i te kātarauka.",
+    "source_hash": "39db3c13"
+  },
+  "web.admin.billing.plans.viewDiff": {
+    "text": "Tirohia te rerekētanga",
+    "source_hash": "0e5d6873"
+  },
+  "web.admin.billing.source.stripe": {
+    "text": "Keteroki Stripe",
+    "source_hash": "b5577327"
+  },
+  "web.admin.billing.source.localConfig": {
+    "text": "Whirihoranga ā-kāinga",
+    "source_hash": "49de43d2"
+  },
+  "web.admin.billing.stats.configured": {
+    "text": "Ngā mahere kua whirihorahia",
+    "source_hash": "4fda4796"
+  },
+  "web.admin.billing.stats.live": {
+    "text": "Ngā mahere ora",
+    "source_hash": "faaa88d9"
+  },
+  "web.admin.billing.stats.source": {
+    "text": "Puna",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.billing.stats.drift": {
+    "text": "Rerenga kē",
+    "source_hash": "8b4c8240"
+  },
+  "web.admin.billing.status.in_sync": {
+    "text": "Kei te tukutahi",
+    "source_hash": "5701958c"
+  },
+  "web.admin.billing.status.only_config": {
+    "text": "Whirihoranga anake",
+    "source_hash": "15836cba"
+  },
+  "web.admin.billing.status.only_live": {
+    "text": "Ora anake",
+    "source_hash": "8f4ed495"
+  },
+  "web.admin.billing.status.changed": {
+    "text": "Kua panonitia",
+    "source_hash": "2a6141e4"
+  }
+}

--- a/locales/content/mi_NZ/admin-colonel.json
+++ b/locales/content/mi_NZ/admin-colonel.json
@@ -802,5 +802,45 @@
   "web.colonel.secrets.state.viewed": {
     "text": "Kua Tirohia",
     "source_hash": "1b28d178"
+  },
+  "web.colonel.backToSite": {
+    "text": "Hoki ki te pae",
+    "source_hash": "4ee0f819"
+  },
+  "web.colonel.customDomains.labels.domain": {
+    "text": "Rohe",
+    "source_hash": "79fa3361"
+  },
+  "web.colonel.customDomains.labels.status": {
+    "text": "Tūnga",
+    "source_hash": "920e413c"
+  },
+  "web.colonel.customDomains.labels.actions": {
+    "text": "Ngā Mahi",
+    "source_hash": "ff8059dc"
+  },
+  "web.colonel.nav.consoleTag": {
+    "text": "Papatono",
+    "source_hash": "29a40861"
+  },
+  "web.colonel.nav.groups.identity": {
+    "text": "Tuakiri",
+    "source_hash": "999f23fc"
+  },
+  "web.colonel.nav.groups.security": {
+    "text": "Urunga & Haumarutanga",
+    "source_hash": "abb29a3f"
+  },
+  "web.colonel.nav.groups.platform": {
+    "text": "Papa",
+    "source_hash": "c78ffe19"
+  },
+  "web.colonel.nav.groups.billing": {
+    "text": "Nama",
+    "source_hash": "3ac8bbca"
+  },
+  "web.colonel.nav.groups.communications": {
+    "text": "Ngā Whakawhitiwhiti Kōrero",
+    "source_hash": "919a9253"
   }
 }

--- a/locales/content/mi_NZ/admin-customers.json
+++ b/locales/content/mi_NZ/admin-customers.json
@@ -1,0 +1,486 @@
+{
+  "web.admin.customers.title": {
+    "text": "Ngā Kiritaki",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.customers.description": {
+    "text": "Rapua he kiritaki, whakaotia ngā take tautoko me te kore SSH.",
+    "source_hash": "c8487e68"
+  },
+  "web.admin.customers.actions.plan.label": {
+    "text": "Mahere",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.actions.plan.apply": {
+    "text": "Whakamahia",
+    "source_hash": "31e392d1"
+  },
+  "web.admin.customers.actions.plan.confirmTitle": {
+    "text": "Panoni mahere?",
+    "source_hash": "910a4de9"
+  },
+  "web.admin.customers.actions.plan.confirmDescription": {
+    "text": "Panonihia a {email} ki te mahere {plan}.",
+    "source_hash": "83fb4158"
+  },
+  "web.admin.customers.actions.plan.success": {
+    "text": "Kua whakahoutia te mahere.",
+    "source_hash": "ebe8d40c"
+  },
+  "web.admin.customers.actions.plan.localConfigWarning": {
+    "text": "Kua utaina ngā mahere mai i te whirihoranga ā-kāinga — kāore a Stripe i whirihorahia, kāore rānei e taea te toro atu.",
+    "source_hash": "df83e326"
+  },
+  "web.admin.customers.actions.purge.button": {
+    "text": "Horoi kiritaki",
+    "source_hash": "ff658f69"
+  },
+  "web.admin.customers.actions.purge.confirmTitle": {
+    "text": "Horoi kiritaki?",
+    "source_hash": "9feed9f1"
+  },
+  "web.admin.customers.actions.purge.confirmDescription": {
+    "text": "Ka mukua rawatia tēnei i {email} me ā rātou raraunga katoa. Kāore e taea te whakakore.",
+    "source_hash": "a74dd5d1"
+  },
+  "web.admin.customers.actions.purge.success": {
+    "text": "Kua horoia te kiritaki.",
+    "source_hash": "6145e5c8"
+  },
+  "web.admin.customers.actions.role.label": {
+    "text": "Tūranga",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.actions.role.apply": {
+    "text": "Whakamahia",
+    "source_hash": "31e392d1"
+  },
+  "web.admin.customers.actions.role.confirmTitle": {
+    "text": "Panoni tūranga?",
+    "source_hash": "227f57d7"
+  },
+  "web.admin.customers.actions.role.confirmDescription": {
+    "text": "Panonihia a {email} ki te tūranga {role}.",
+    "source_hash": "9ba063c6"
+  },
+  "web.admin.customers.actions.role.success": {
+    "text": "Kua whakahoutia te tūranga.",
+    "source_hash": "0c33aa24"
+  },
+  "web.admin.customers.actions.suspend.button": {
+    "text": "Whakatārewa pūkete",
+    "source_hash": "95a04f27"
+  },
+  "web.admin.customers.actions.suspend.reasonLabel": {
+    "text": "Take (kōwhiringa)",
+    "source_hash": "0f7d4664"
+  },
+  "web.admin.customers.actions.suspend.reasonPlaceholder": {
+    "text": "He aha tēnei pūkete e whakatārewatia ana?",
+    "source_hash": "8eca975e"
+  },
+  "web.admin.customers.actions.suspend.confirmTitle": {
+    "text": "Whakatārewa pūkete?",
+    "source_hash": "cbfa275b"
+  },
+  "web.admin.customers.actions.suspend.confirmDescription": {
+    "text": "Ka ārai i {email} kia kore e takiuru, ka whakakore hoki i ā rātou wātū hohe. Kāore he raraunga ka mukua — ka taea te whakahoki.",
+    "source_hash": "e5d046bc"
+  },
+  "web.admin.customers.actions.suspend.success": {
+    "text": "Kua whakatārewatia te pūkete.",
+    "source_hash": "04c5f996"
+  },
+  "web.admin.customers.actions.unsuspend.button": {
+    "text": "Whakaara pūkete",
+    "source_hash": "35a10fb5"
+  },
+  "web.admin.customers.actions.unsuspend.confirmTitle": {
+    "text": "Whakaara pūkete?",
+    "source_hash": "6fd78a72"
+  },
+  "web.admin.customers.actions.unsuspend.confirmDescription": {
+    "text": "Ka whakahoki i te takiuru mō {email}.",
+    "source_hash": "cb2bb4e0"
+  },
+  "web.admin.customers.actions.unsuspend.success": {
+    "text": "Kua whakaarahia te pūkete.",
+    "source_hash": "c5b4377f"
+  },
+  "web.admin.customers.actions.unverify.button": {
+    "text": "Whakakore manatoko",
+    "source_hash": "b0dee41f"
+  },
+  "web.admin.customers.actions.unverify.confirmTitle": {
+    "text": "Whakakore manatoko kiritaki?",
+    "source_hash": "62ed2854"
+  },
+  "web.admin.customers.actions.unverify.confirmDescription": {
+    "text": "Tohua a {email} kāore anō kia manatokona.",
+    "source_hash": "592ffd27"
+  },
+  "web.admin.customers.actions.unverify.success": {
+    "text": "Kua whakakorea te manatoko o te kiritaki.",
+    "source_hash": "a9b7bbac"
+  },
+  "web.admin.customers.actions.verify.button": {
+    "text": "Manatoko",
+    "source_hash": "eea2745e"
+  },
+  "web.admin.customers.actions.verify.confirmTitle": {
+    "text": "Manatoko kiritaki?",
+    "source_hash": "43037ce1"
+  },
+  "web.admin.customers.actions.verify.confirmDescription": {
+    "text": "Tohua a {email} kua manatokona.",
+    "source_hash": "7052d79d"
+  },
+  "web.admin.customers.actions.verify.success": {
+    "text": "Kua manatokona te kiritaki.",
+    "source_hash": "19e382dc"
+  },
+  "web.admin.customers.columns.email": {
+    "text": "Īmēra",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.customers.columns.role": {
+    "text": "Tūranga",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.columns.verified": {
+    "text": "Kua Manatokona",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.columns.plan": {
+    "text": "Mahere",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.columns.secrets": {
+    "text": "Ngā Karere Huna",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.customers.columns.created": {
+    "text": "I Hangaia",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.columns.lastLogin": {
+    "text": "Takiuru Whakamutunga",
+    "source_hash": "0d39602d"
+  },
+  "web.admin.customers.detail.backToList": {
+    "text": "Hoki ki ngā kiritaki",
+    "source_hash": "077807fb"
+  },
+  "web.admin.customers.detail.openFullPage": {
+    "text": "Whakatuwhera i te whārangi katoa",
+    "source_hash": "a467911c"
+  },
+  "web.admin.customers.detail.notFound": {
+    "text": "Kāore i kitea te kiritaki",
+    "source_hash": "5e3f5824"
+  },
+  "web.admin.customers.detail.notFoundDescription": {
+    "text": "Kāore he kiritaki e ōrite ana ki tēnei tautuhi. Kua horoia pea rātou.",
+    "source_hash": "82b04725"
+  },
+  "web.admin.customers.detail.loadError": {
+    "text": "Kāore i taea te uta i tēnei kiritaki.",
+    "source_hash": "cfd1bcca"
+  },
+  "web.admin.customers.detail.retry": {
+    "text": "Ngana anō",
+    "source_hash": "942087cc"
+  },
+  "web.admin.customers.detail.yes": {
+    "text": "Āe",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.customers.detail.no": {
+    "text": "Kāo",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.customers.detail.none": {
+    "text": "Kāore",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.never": {
+    "text": "Kāore rawa",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.customers.detail.billing.plan": {
+    "text": "Mahere",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.detail.billing.organization": {
+    "text": "Whakahaere nama",
+    "source_hash": "90c94ee1"
+  },
+  "web.admin.customers.detail.billing.subscriptionStatus": {
+    "text": "Tūnga ohaurunga",
+    "source_hash": "f0723c4e"
+  },
+  "web.admin.customers.detail.billing.periodEnd": {
+    "text": "Ka mutu te wā o nāianei",
+    "source_hash": "742b8229"
+  },
+  "web.admin.customers.detail.billing.latestInvoice": {
+    "text": "Pire-utu hou",
+    "source_hash": "7a6133cc"
+  },
+  "web.admin.customers.detail.billing.noInvoices": {
+    "text": "Kāore he pire-utu",
+    "source_hash": "e6b30f93"
+  },
+  "web.admin.customers.detail.billing.openStripe": {
+    "text": "Whakatuwhera i te papatohu Stripe",
+    "source_hash": "dfa7c41d"
+  },
+  "web.admin.customers.detail.billing.unavailable": {
+    "text": "Kāore i te wātea te raraunga Stripe: {reason}",
+    "source_hash": "9fe08e49"
+  },
+  "web.admin.customers.detail.billing.notConfigured": {
+    "text": "Kāore te nama i whirihorahia i tēnei tāuta.",
+    "source_hash": "6e90375e"
+  },
+  "web.admin.customers.detail.fields.email": {
+    "text": "Īmēra",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.customers.detail.fields.publicId": {
+    "text": "ID Tūmatanui",
+    "source_hash": "3705b64f"
+  },
+  "web.admin.customers.detail.fields.role": {
+    "text": "Tūranga",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.detail.fields.verified": {
+    "text": "Kua Manatokona",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.detail.fields.plan": {
+    "text": "Mahere",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.detail.fields.locale": {
+    "text": "Reo takiwā",
+    "source_hash": "ca3dc612"
+  },
+  "web.admin.customers.detail.fields.created": {
+    "text": "I Hangaia",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.detail.fields.updated": {
+    "text": "I Whakahoutia",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.customers.detail.fields.lastLogin": {
+    "text": "Takiuru Whakamutunga",
+    "source_hash": "0d39602d"
+  },
+  "web.admin.customers.detail.fields.suspendedAt": {
+    "text": "I Whakatārewatia",
+    "source_hash": "7227f219"
+  },
+  "web.admin.customers.detail.fields.suspendedBy": {
+    "text": "Nā Wai i Whakatārewa",
+    "source_hash": "e0830524"
+  },
+  "web.admin.customers.detail.fields.suspendedReason": {
+    "text": "Take whakatārewa",
+    "source_hash": "d6b08d8e"
+  },
+  "web.admin.customers.detail.organizations.empty": {
+    "text": "Kāore he whakahaere",
+    "source_hash": "c256efdc"
+  },
+  "web.admin.customers.detail.organizations.default": {
+    "text": "Taunoa",
+    "source_hash": "21b111cb"
+  },
+  "web.admin.customers.detail.receiptColumns.shortId": {
+    "text": "ID Poto",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.customers.detail.receiptColumns.state": {
+    "text": "Tūnga",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.customers.detail.receiptColumns.created": {
+    "text": "I Hangaia",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.detail.receipts.empty": {
+    "text": "Kāore he rīhiti",
+    "source_hash": "fb425a68"
+  },
+  "web.admin.customers.detail.secretColumns.shortId": {
+    "text": "ID Poto",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.customers.detail.secretColumns.state": {
+    "text": "Tūnga",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.customers.detail.secretColumns.created": {
+    "text": "I Hangaia",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.detail.secretColumns.expiration": {
+    "text": "Paunga",
+    "source_hash": "f38d6e0e"
+  },
+  "web.admin.customers.detail.secrets.empty": {
+    "text": "Kāore he karere huna",
+    "source_hash": "c37ab3f7"
+  },
+  "web.admin.customers.detail.sections.profile": {
+    "text": "Kōtaha",
+    "source_hash": "d696a35b"
+  },
+  "web.admin.customers.detail.sections.secrets": {
+    "text": "Ngā Karere Huna",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.customers.detail.sections.receipts": {
+    "text": "Ngā Rīhiti",
+    "source_hash": "60a627df"
+  },
+  "web.admin.customers.detail.sections.organizations": {
+    "text": "Ngā Whakahaere",
+    "source_hash": "2730183d"
+  },
+  "web.admin.customers.detail.sections.actions": {
+    "text": "Ngā Mahi",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.sections.billing": {
+    "text": "Nama",
+    "source_hash": "3ac8bbca"
+  },
+  "web.admin.customers.detail.sessions.title": {
+    "text": "Ngā Wātū Hohe",
+    "source_hash": "b58fa4e0"
+  },
+  "web.admin.customers.detail.sessions.empty": {
+    "text": "Kāore he wātū hohe.",
+    "source_hash": "6f064eb9"
+  },
+  "web.admin.customers.detail.sessions.loadError": {
+    "text": "Kāore i taea te uta i ngā wātū.",
+    "source_hash": "d2884313"
+  },
+  "web.admin.customers.detail.sessions.unknown": {
+    "text": "Kāore e mōhiotia",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.customers.detail.sessions.columns.lastActivity": {
+    "text": "Mahi Whakamutunga",
+    "source_hash": "06475633"
+  },
+  "web.admin.customers.detail.sessions.columns.ipAddress": {
+    "text": "Wāhitau IP",
+    "source_hash": "0302a467"
+  },
+  "web.admin.customers.detail.sessions.columns.device": {
+    "text": "Pūrere",
+    "source_hash": "6ba0bdec"
+  },
+  "web.admin.customers.detail.sessions.columns.authMethod": {
+    "text": "Tikanga Whakamotuhēhē",
+    "source_hash": "bc4ea262"
+  },
+  "web.admin.customers.detail.sessions.columns.actions": {
+    "text": "Ngā Mahi",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.sessions.revoke.button": {
+    "text": "Whakakore",
+    "source_hash": "87e6d00b"
+  },
+  "web.admin.customers.detail.sessions.revoke.confirmTitle": {
+    "text": "Whakakore wātū?",
+    "source_hash": "7735d1ef"
+  },
+  "web.admin.customers.detail.sessions.revoke.confirmDescription": {
+    "text": "Ka takiputa tonu tēnei i te kaiwhakamahi mai i tēnei wātū. Me takiuru anō rātou.",
+    "source_hash": "b4291af0"
+  },
+  "web.admin.customers.detail.sessions.revoke.success": {
+    "text": "Kua whakakorea te wātū.",
+    "source_hash": "5e4762e5"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.button": {
+    "text": "Whakakore katoa",
+    "source_hash": "c6847a4b"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.confirmTitle": {
+    "text": "Whakakore i ngā wātū katoa?",
+    "source_hash": "a4fa4c65"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.confirmDescription": {
+    "text": "Ka takiputa tēnei i te kaiwhakamahi mai i ia pūrere me ia pūtirotiro — tae atu ki ngā wātū kāore i te whakaaturia i tēnei rārangi — ka raka tonu hoki i ō rātou ara kua whakamotuhēhētia. Whakamahia mō te wehenga, mō te riro pea rānei o te pūkete. Patohia te ID o te kaiwhakamahi hei whakaū.",
+    "source_hash": "483cdd88"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.success": {
+    "text": "Kua whakakorea ngā wātū katoa (kua patua {count}).",
+    "source_hash": "4e1cce55"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.capped": {
+    "text": "Kua patua {count} wātū, engari kua poroa te tahi wātū kāore i te aroturukitia — kei te noho tonu pea tētahi wātū tawhito. Rerea anō kia tino mōhio ai.",
+    "source_hash": "e3d295a6"
+  },
+  "web.admin.customers.detail.stats.secretsCreated": {
+    "text": "Ngā karere huna i hangaia",
+    "source_hash": "7d17719e"
+  },
+  "web.admin.customers.detail.stats.secretsShared": {
+    "text": "Ngā karere huna i tohatohaina",
+    "source_hash": "ba85b265"
+  },
+  "web.admin.customers.detail.stats.emailsSent": {
+    "text": "Ngā īmēra i tukua",
+    "source_hash": "be604792"
+  },
+  "web.admin.customers.list.roleFilter": {
+    "text": "Tūranga",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.list.empty": {
+    "text": "Kāore i kitea he kiritaki",
+    "source_hash": "dc754ec0"
+  },
+  "web.admin.customers.list.loadError": {
+    "text": "Kāore i taea te uta i ngā kiritaki.",
+    "source_hash": "81783303"
+  },
+  "web.admin.customers.list.searchPlaceholder": {
+    "text": "Rapua mā te īmēra, extid, objid rānei",
+    "source_hash": "c06d5a3b"
+  },
+  "web.admin.customers.list.emptySearch": {
+    "text": "Kāore he kiritaki e ōrite ana ki tēnei rapunga",
+    "source_hash": "ea7e7012"
+  },
+  "web.admin.customers.roles.colonel": {
+    "text": "Colonel",
+    "source_hash": "02577777"
+  },
+  "web.admin.customers.roles.admin": {
+    "text": "Kaiwhakahaere",
+    "source_hash": "c1c224b0"
+  },
+  "web.admin.customers.roles.staff": {
+    "text": "Kaimahi",
+    "source_hash": "681927e3"
+  },
+  "web.admin.customers.roles.customer": {
+    "text": "Kiritaki",
+    "source_hash": "bf376338"
+  },
+  "web.admin.customers.suspended.badge": {
+    "text": "Kua Whakatārewatia",
+    "source_hash": "e392a389"
+  }
+}

--- a/locales/content/mi_NZ/admin-domains.json
+++ b/locales/content/mi_NZ/admin-domains.json
@@ -1,0 +1,194 @@
+{
+  "web.admin.domains.retry": {
+    "text": "Ngana anō",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.addDomain.button": {
+    "text": "Tāpiri rohe",
+    "source_hash": "d86476ae"
+  },
+  "web.admin.domains.addDomain.title": {
+    "text": "Tāpiri i tētahi rohe ritenga",
+    "source_hash": "592d3314"
+  },
+  "web.admin.domains.addDomain.forOrg": {
+    "text": "E tāpiri ana i tētahi rohe mō {org}.",
+    "source_hash": "f8b8c1ac"
+  },
+  "web.admin.domains.addDomain.domainLabel": {
+    "text": "Rohe",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domains.addDomain.domainPlaceholder": {
+    "text": "secrets.example.com",
+    "source_hash": "9ea4d0d6"
+  },
+  "web.admin.domains.addDomain.strategyLabel": {
+    "text": "Rautaki whakamana",
+    "source_hash": "a2e95531"
+  },
+  "web.admin.domains.addDomain.createButton": {
+    "text": "Waihanga",
+    "source_hash": "4759498a"
+  },
+  "web.admin.domains.addDomain.created": {
+    "text": "Kua hangaia a {domain}.",
+    "source_hash": "2263ec6a"
+  },
+  "web.admin.domains.addDomain.strategy.approximated": {
+    "text": "Approximated — he arowhai rangatiratanga DNS, kāore he takawaenga.",
+    "source_hash": "79a7245c"
+  },
+  "web.admin.domains.addDomain.strategy.passthrough": {
+    "text": "Passthrough — ka tohu koe i te DNS ki te takawaenga o tēnei tukunga.",
+    "source_hash": "9702d758"
+  },
+  "web.admin.domains.addDomain.strategy.external": {
+    "text": "External — ka whakahaerea te DNS i waho o tēnei tukunga.",
+    "source_hash": "acaede35"
+  },
+  "web.admin.domains.addDomain.strategy.caddy_on_demand": {
+    "text": "Caddy on-demand — ka tukuna aunoatia ngā tiwhikete i te tono tuatahi.",
+    "source_hash": "deb90ae6"
+  },
+  "web.admin.domains.addDomain.strategy.caddy": {
+    "text": "Caddy — ka tukuna aunoatia ngā tiwhikete i te tono tuatahi.",
+    "source_hash": "a0f3c2dc"
+  },
+  "web.admin.domains.addDomain.strategy.unknown": {
+    "text": "Rautaki whakamana puta noa i te tukunga.",
+    "source_hash": "4587f9cf"
+  },
+  "web.admin.domains.attach.cta": {
+    "text": "Tāpiri rohe ki te whakahaere",
+    "source_hash": "736d74ce"
+  },
+  "web.admin.domains.attach.recordEyebrow": {
+    "text": "Rekoata mahi",
+    "source_hash": "2fadf983"
+  },
+  "web.admin.domains.attach.rosterError": {
+    "text": "Kāore i taea te uta i ngā rohe o tēnei whakahaere.",
+    "source_hash": "d3055fed"
+  },
+  "web.admin.domains.attach.noDomains": {
+    "text": "Kāore anō he rohe kua tāpiritia ki tēnei whakahaere.",
+    "source_hash": "e9a25fc4"
+  },
+  "web.admin.domains.attach.openExternal": {
+    "text": "Whakatuwhera i {domain} ki tētahi ripa hou",
+    "source_hash": "c5fbdeaa"
+  },
+  "web.admin.domains.dns.heading": {
+    "text": "Ngā tuhinga DNS hei whakaputa",
+    "source_hash": "e4efbe2b"
+  },
+  "web.admin.domains.dns.txtStep": {
+    "text": "1. Tāpirihia he tuhinga TXT hei whakaū i te rangatiratanga.",
+    "source_hash": "fdcfcfb0"
+  },
+  "web.admin.domains.dns.aStep": {
+    "text": "2. Tāpirihia he tuhinga A e tohu ana i te rohe tihi ki te takawaenga.",
+    "source_hash": "aedbf197"
+  },
+  "web.admin.domains.dns.cnameStep": {
+    "text": "2. Tāpirihia he tuhinga CNAME e tohu ana i te rohe-iti ki te takawaenga.",
+    "source_hash": "5c626f53"
+  },
+  "web.admin.domains.dns.propagationNote": {
+    "text": "Ka roa pea ētahi meneti kia hōrapa ai ngā panonitanga DNS i mua i te angitu o te manatoko.",
+    "source_hash": "7caf70a7"
+  },
+  "web.admin.domains.dns.toggle": {
+    "text": "Ngā taipitopito DNS",
+    "source_hash": "ebf2d44e"
+  },
+  "web.admin.domains.dns.loadError": {
+    "text": "Kāore i taea te uta i ngā taipitopito DNS.",
+    "source_hash": "4c33e23d"
+  },
+  "web.admin.domains.list.loadError": {
+    "text": "Kāore i taea te uta i ngā rohe.",
+    "source_hash": "548deff8"
+  },
+  "web.admin.domains.orgPicker.title": {
+    "text": "Tīpakohia tētahi whakahaere",
+    "source_hash": "48326f52"
+  },
+  "web.admin.domains.orgPicker.searchLabel": {
+    "text": "Whakahaere",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.orgPicker.searchPlaceholder": {
+    "text": "ID Ahanoa, ID ā-waho, īmēra rānei",
+    "source_hash": "bb5d0055"
+  },
+  "web.admin.domains.orgPicker.searchHint": {
+    "text": "Rapua mā te objid, extid, wāhitau īmēra rānei o tētahi mema.",
+    "source_hash": "fdef7332"
+  },
+  "web.admin.domains.orgPicker.loadError": {
+    "text": "Kāore i taea te rapu i ngā whakahaere.",
+    "source_hash": "b9e45dcf"
+  },
+  "web.admin.domains.orgPicker.parseError": {
+    "text": "Kāore i taea te pānui i ngā hua whakahaere.",
+    "source_hash": "44e1b9fd"
+  },
+  "web.admin.domains.orgPicker.idle": {
+    "text": "Whakauruhia he uara ki runga hei rapu.",
+    "source_hash": "0352e6e6"
+  },
+  "web.admin.domains.orgPicker.noResults": {
+    "text": "Kāore he whakahaere e ōrite ana ki a “{term}”.",
+    "source_hash": "761db594"
+  },
+  "web.admin.domains.orgPicker.unnamedOrg": {
+    "text": "Whakahaere kore-ingoa",
+    "source_hash": "f218dc9d"
+  },
+  "web.admin.domains.orgPicker.domainCount": {
+    "text": "{count} rohe",
+    "source_hash": "cf548c8c"
+  },
+  "web.admin.domains.orgPicker.select": {
+    "text": "Tīpako",
+    "source_hash": "2a78025d"
+  },
+  "web.admin.domains.verify.button": {
+    "text": "Manatoko",
+    "source_hash": "eea2745e"
+  },
+  "web.admin.domains.verify.confirmTitle": {
+    "text": "Manatoko rohe?",
+    "source_hash": "07c4dc4f"
+  },
+  "web.admin.domains.verify.confirmDescription": {
+    "text": "Whakahaerea ngā arowhai manatoko DNS me te SSL mō {domain}.",
+    "source_hash": "06797824"
+  },
+  "web.admin.domains.verify.failed": {
+    "text": "I rahu te manatoko. Tēnā, ngana anō.",
+    "source_hash": "3c8432b0"
+  },
+  "web.admin.domains.verify.success.verified": {
+    "text": "Kua manatokona a {domain}.",
+    "source_hash": "802b5d1e"
+  },
+  "web.admin.domains.verify.success.resolving": {
+    "text": "Kei te whakatau a {domain} engari kāore anō kia manatokona.",
+    "source_hash": "bc8aecad"
+  },
+  "web.admin.domains.verify.success.pending": {
+    "text": "Kei te tārewa a {domain} — kāore anō te DNS kia whakatau.",
+    "source_hash": "0d9f66d5"
+  },
+  "web.admin.domains.verify.success.unverified": {
+    "text": "Kāore i taea te manatoko i {domain}.",
+    "source_hash": "630da482"
+  },
+  "web.admin.domains.verify.success.done": {
+    "text": "Kua oti te manatoko mō {domain}.",
+    "source_hash": "ed67e22d"
+  }
+}

--- a/locales/content/mi_NZ/admin-domaintoolbox.json
+++ b/locales/content/mi_NZ/admin-domaintoolbox.json
@@ -1,0 +1,178 @@
+{
+  "web.admin.domaintoolbox.title": {
+    "text": "Pouaka Utauta Rohe",
+    "source_hash": "5a9333db"
+  },
+  "web.admin.domaintoolbox.description": {
+    "text": "Tātari me te whakatika i ngā hononga rohe-ritenga: matawai i ngā pani, whakamātau DNS/SSL, whakatika rangatiratanga, me te whakawhiti i waenga i ngā whakahaere.",
+    "source_hash": "778537aa"
+  },
+  "web.admin.domaintoolbox.retry": {
+    "text": "Ngana anō",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domaintoolbox.preview": {
+    "text": "Arokite",
+    "source_hash": "324b134f"
+  },
+  "web.admin.domaintoolbox.fields.extid": {
+    "text": "ID ā-waho rohe",
+    "source_hash": "f52af6c5"
+  },
+  "web.admin.domaintoolbox.fields.extidPlaceholder": {
+    "text": "cd_… (extid rohe)",
+    "source_hash": "bb9bf49a"
+  },
+  "web.admin.domaintoolbox.orphaned.title": {
+    "text": "Ngā rohe pani",
+    "source_hash": "ddcea596"
+  },
+  "web.admin.domaintoolbox.orphaned.description": {
+    "text": "Ngā rohe ritenga kāore he whakahaere rangatira. Whakamahia te Whakatika hei tautuhi anō i tētahi.",
+    "source_hash": "967268f5"
+  },
+  "web.admin.domaintoolbox.orphaned.empty": {
+    "text": "Kāore i kitea he rohe pani.",
+    "source_hash": "06ef9979"
+  },
+  "web.admin.domaintoolbox.orphaned.loadError": {
+    "text": "Kāore i taea te uta i ngā rohe pani.",
+    "source_hash": "ca0e33bf"
+  },
+  "web.admin.domaintoolbox.orphaned.repairAction": {
+    "text": "Whakatika",
+    "source_hash": "1196b6c5"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.domain": {
+    "text": "Rohe",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.state": {
+    "text": "Tūnga",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.verified": {
+    "text": "Kua Manatokona",
+    "source_hash": "4f783840"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.created": {
+    "text": "I Hangaia",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.actions": {
+    "text": "Ngā Mahi",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domaintoolbox.probe.title": {
+    "text": "Whakamātau (DNS / SSL)",
+    "source_hash": "ec69a087"
+  },
+  "web.admin.domaintoolbox.probe.description": {
+    "text": "Tukua he tono HTTPS ora hei whakaū e whakautu ana te rohe ki ngā tono, me te tirotiro i tōna tiwhikete TLS. Pānui-anake.",
+    "source_hash": "1eecfa96"
+  },
+  "web.admin.domaintoolbox.probe.button": {
+    "text": "Whakamātau",
+    "source_hash": "3bd51ab9"
+  },
+  "web.admin.domaintoolbox.probe.healthLabel": {
+    "text": "Hauora",
+    "source_hash": "55898449"
+  },
+  "web.admin.domaintoolbox.repair.title": {
+    "text": "Whakatika hononga",
+    "source_hash": "0053d07c"
+  },
+  "web.admin.domaintoolbox.repair.description": {
+    "text": "Whakatikahia ngā rerekētanga hononga-whakahaere mō tētahi rohe. Arokite tuatahi, kātahi ka whakamahi.",
+    "source_hash": "18ca490b"
+  },
+  "web.admin.domaintoolbox.repair.orgIdLabel": {
+    "text": "Tautuhi whakahaere (mēnā he pani)",
+    "source_hash": "f95b010a"
+  },
+  "web.admin.domaintoolbox.repair.orgIdPlaceholder": {
+    "text": "id whakahaere, extid rānei",
+    "source_hash": "a87d634e"
+  },
+  "web.admin.domaintoolbox.repair.statusLabel": {
+    "text": "Tūnga",
+    "source_hash": "920e413c"
+  },
+  "web.admin.domaintoolbox.repair.noIssues": {
+    "text": "Kāore he raru i kitea — e ōrite ana ngā hononga.",
+    "source_hash": "e1a4c49d"
+  },
+  "web.admin.domaintoolbox.repair.applyButton": {
+    "text": "Whakamahi whakatika",
+    "source_hash": "3f92b29f"
+  },
+  "web.admin.domaintoolbox.repair.success": {
+    "text": "Kua whakamahia pai ngā whakatika.",
+    "source_hash": "24f25b9b"
+  },
+  "web.admin.domaintoolbox.repair.confirmTitle": {
+    "text": "Whakamahi whakatika rohe?",
+    "source_hash": "9429998b"
+  },
+  "web.admin.domaintoolbox.repair.confirmDescription": {
+    "text": "Ka whakarerekē tēnei i te tūnga rangatiratanga/hononga mō {domain}. Patohia anō te ID ā-waho rohe hei whakaū.",
+    "source_hash": "426d267b"
+  },
+  "web.admin.domaintoolbox.reverify.button": {
+    "text": "Manatoko anō",
+    "source_hash": "0344860a"
+  },
+  "web.admin.domaintoolbox.reverify.success": {
+    "text": "Kua oti te manatoko anō o te rohe.",
+    "source_hash": "497a2348"
+  },
+  "web.admin.domaintoolbox.transfer.title": {
+    "text": "Whakawhiti rangatiratanga",
+    "source_hash": "3667f939"
+  },
+  "web.admin.domaintoolbox.transfer.description": {
+    "text": "Tautuhia anō he rohe ki tētahi whakahaere kē. Ko te mahi pāpātanga-nui rawa — arokite me te whakaū me te tūpato.",
+    "source_hash": "d4e26e03"
+  },
+  "web.admin.domaintoolbox.transfer.toOrgLabel": {
+    "text": "Whakahaere ū atu",
+    "source_hash": "4e4486eb"
+  },
+  "web.admin.domaintoolbox.transfer.fromOrgLabel": {
+    "text": "Whakahaere puna (kōwhiringa)",
+    "source_hash": "3666815f"
+  },
+  "web.admin.domaintoolbox.transfer.fromOrgPlaceholder": {
+    "text": "whakaū i te rangatira o nāianei",
+    "source_hash": "cd9e769c"
+  },
+  "web.admin.domaintoolbox.transfer.from": {
+    "text": "Mai i",
+    "source_hash": "21819769"
+  },
+  "web.admin.domaintoolbox.transfer.to": {
+    "text": "Ki",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.domaintoolbox.transfer.orphaned": {
+    "text": "PANI",
+    "source_hash": "54dc2166"
+  },
+  "web.admin.domaintoolbox.transfer.applyButton": {
+    "text": "Whakawhiti rohe",
+    "source_hash": "9517aeb9"
+  },
+  "web.admin.domaintoolbox.transfer.success": {
+    "text": "Kua whakawhitia pai te rohe.",
+    "source_hash": "bbca9de9"
+  },
+  "web.admin.domaintoolbox.transfer.confirmTitle": {
+    "text": "Whakawhiti rangatiratanga rohe?",
+    "source_hash": "d306a15a"
+  },
+  "web.admin.domaintoolbox.transfer.confirmDescription": {
+    "text": "Ka tautuhia anō te rangatiratanga o {domain} ki tētahi whakahaere kē. Patohia anō te ID ā-waho rohe hei whakaū.",
+    "source_hash": "edefd97c"
+  }
+}

--- a/locales/content/mi_NZ/admin-emailtools.json
+++ b/locales/content/mi_NZ/admin-emailtools.json
@@ -1,0 +1,550 @@
+{
+  "web.admin.emailtools.title": {
+    "text": "Ngā Utauta Īmēra",
+    "source_hash": "f9643d5a"
+  },
+  "web.admin.emailtools.description": {
+    "text": "Arokite i ngā tātauira īmēra, tukua he whakamātau tuku, me te aroturuki i te taea-te-tuku — ngā tātaritanga i hiahiatia i mua ki te SSH.",
+    "source_hash": "be85c9e9"
+  },
+  "web.admin.emailtools.config.title": {
+    "text": "Whirihoranga pūtuku īmēra",
+    "source_hash": "d2a71028"
+  },
+  "web.admin.emailtools.config.description": {
+    "text": "Te whirihoranga īmēra tūmau i whakataua i te whakaoho. Kāore rawa ngā pūnga whaimana e whakaaturia — ko te mea anake ka whakaaturia mēnā kei reira.",
+    "source_hash": "f0e8a118"
+  },
+  "web.admin.emailtools.config.provider": {
+    "text": "Kaiwhakarato kawe",
+    "source_hash": "4f0e5025"
+  },
+  "web.admin.emailtools.config.senderProvider": {
+    "text": "Kaiwhakarato kaituku",
+    "source_hash": "e881964f"
+  },
+  "web.admin.emailtools.config.senderDiffers": {
+    "text": "He rerekē te kaituku i te kawe",
+    "source_hash": "ab78e8f6"
+  },
+  "web.admin.emailtools.config.autoDetected": {
+    "text": "Kua kitea aunoatia",
+    "source_hash": "a69c7f9e"
+  },
+  "web.admin.emailtools.config.fromAddress": {
+    "text": "Wāhitau Nā",
+    "source_hash": "d465bcfa"
+  },
+  "web.admin.emailtools.config.fromName": {
+    "text": "Ingoa Nā",
+    "source_hash": "b28f93ea"
+  },
+  "web.admin.emailtools.config.host": {
+    "text": "Kaihautū SMTP",
+    "source_hash": "ab328f83"
+  },
+  "web.admin.emailtools.config.port": {
+    "text": "Tauwaha",
+    "source_hash": "72e9a59f"
+  },
+  "web.admin.emailtools.config.region": {
+    "text": "Rohe",
+    "source_hash": "d3a008ef"
+  },
+  "web.admin.emailtools.config.hasCredentials": {
+    "text": "Kua whirihorahia ngā pūnga whaimana",
+    "source_hash": "1c81633a"
+  },
+  "web.admin.emailtools.config.yes": {
+    "text": "Āe",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.emailtools.config.no": {
+    "text": "Kāo",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.emailtools.config.loggerWarning": {
+    "text": "Kāore te īmēra e tukuna ana. Kua tautuhia te kaiwhakarato kawe ki tētahi aratau kore-tuku (logger, kua monokia, kāore rānei), nā reira kāore he īmēra e wehe atu ana i tēnei tūmau — ka tuhia ngā karere puta ki te rangitaki taupānga, ka tukua rānei ki te kore.",
+    "source_hash": "1883dfd5"
+  },
+  "web.admin.emailtools.deliverability.title": {
+    "text": "Te taea-te-tuku",
+    "source_hash": "66b4d300"
+  },
+  "web.admin.emailtools.deliverability.description": {
+    "text": "Ngā mea ka hoki mai i muri i te tuku: ngā tuku-hoki, ngā amuamu, me te rārangi ārai e tiaki ana i tō rongo kaituku.",
+    "source_hash": "e8363bb5"
+  },
+  "web.admin.emailtools.deliverability.retry": {
+    "text": "Ngana anō",
+    "source_hash": "942087cc"
+  },
+  "web.admin.emailtools.deliverability.events.title": {
+    "text": "Ngā takahanga tata",
+    "source_hash": "8ecce94d"
+  },
+  "web.admin.emailtools.deliverability.events.description": {
+    "text": "Te whāngai tuku-hoki me te amuamu mata, te mea hou tuatahi.",
+    "source_hash": "0e7a533b"
+  },
+  "web.admin.emailtools.deliverability.events.empty": {
+    "text": "Kāore anō he raraunga tuku-hoki, amuamu rānei. Tukua te urupare a tō ESP mā POST /api/colonel/email/deliverability/events (kua whakamotuhēhētia-colonel — tirohia ngā tuhinga o te pito mutunga mō te hōputu rekoata). Ka rēkoatatia aunoatia ngā tuku-hoki mārō SMTP tukutahi.",
+    "source_hash": "a90f259c"
+  },
+  "web.admin.emailtools.deliverability.events.loadError": {
+    "text": "Kāore i taea te uta i ngā takahanga tata.",
+    "source_hash": "02244c61"
+  },
+  "web.admin.emailtools.deliverability.events.columns.time": {
+    "text": "Wā",
+    "source_hash": "33b93476"
+  },
+  "web.admin.emailtools.deliverability.events.columns.kind": {
+    "text": "Momo",
+    "source_hash": "baaddf70"
+  },
+  "web.admin.emailtools.deliverability.events.columns.address": {
+    "text": "Wāhitau",
+    "source_hash": "56ef8f20"
+  },
+  "web.admin.emailtools.deliverability.events.columns.source": {
+    "text": "Puna",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.emailtools.deliverability.events.columns.reason": {
+    "text": "Take",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.emailtools.deliverability.events.kinds.bounce": {
+    "text": "tuku-hoki",
+    "source_hash": "4d6723e5"
+  },
+  "web.admin.emailtools.deliverability.events.kinds.complaint": {
+    "text": "amuamu",
+    "source_hash": "5d08b02d"
+  },
+  "web.admin.emailtools.deliverability.lookup.title": {
+    "text": "Rapunga kaiwhiwhi",
+    "source_hash": "7569985b"
+  },
+  "web.admin.emailtools.deliverability.lookup.description": {
+    "text": "Tirohia mēnā kua āraia tētahi wāhitau, i te toa ā-kāinga me te ora i te kaiwhakarato īmēra hohe. Ka whakakīa ngā mea e rua mā te wāhitau kua whakahāngaitia kotahi.",
+    "source_hash": "c341d614"
+  },
+  "web.admin.emailtools.deliverability.lookup.addressLabel": {
+    "text": "Wāhitau kaiwhiwhi",
+    "source_hash": "454d0391"
+  },
+  "web.admin.emailtools.deliverability.lookup.submit": {
+    "text": "Rapua",
+    "source_hash": "504101bc"
+  },
+  "web.admin.emailtools.deliverability.lookup.local": {
+    "text": "Toa ā-kāinga",
+    "source_hash": "c740d116"
+  },
+  "web.admin.emailtools.deliverability.lookup.provider": {
+    "text": "Kaiwhakarato",
+    "source_hash": "472590ae"
+  },
+  "web.admin.emailtools.deliverability.lookup.suppressed": {
+    "text": "Kua āraia",
+    "source_hash": "435c7831"
+  },
+  "web.admin.emailtools.deliverability.lookup.notSuppressed": {
+    "text": "Kāore i āraia",
+    "source_hash": "7b1544d7"
+  },
+  "web.admin.emailtools.deliverability.lookup.reason": {
+    "text": "Take",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.emailtools.deliverability.lookup.source": {
+    "text": "Puna",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.emailtools.deliverability.lookup.unavailable": {
+    "text": "Kāore i te wātea te rapunga kaiwhakarato ora; ko te toa ā-kāinga i runga te mana.",
+    "source_hash": "aebed0f2"
+  },
+  "web.admin.emailtools.deliverability.messages.title": {
+    "text": "Ngā tuku tata",
+    "source_hash": "522e089e"
+  },
+  "web.admin.emailtools.deliverability.messages.description": {
+    "text": "Ngā karere hou rawa i rēkoatatia e te kaiwhakarato īmēra hohe, te mea hou tuatahi. I ahu ora mai i te kaiwhakarato — kāore rawa e rokirokitia ki konei.",
+    "source_hash": "9970fa0a"
+  },
+  "web.admin.emailtools.deliverability.messages.empty": {
+    "text": "Kāore he karere tata i whakahokia e te kaiwhakarato.",
+    "source_hash": "a7ef4d79"
+  },
+  "web.admin.emailtools.deliverability.messages.notSupported": {
+    "text": "Kāore he rangitaki tuku e wātea ana i te kawe {provider}, kāore nei he API ā-karere.",
+    "source_hash": "21e6b6f9"
+  },
+  "web.admin.emailtools.deliverability.messages.error": {
+    "text": "Kāore i taea te uta i te rangitaki tuku mai i te kaiwhakarato. Ngana anō.",
+    "source_hash": "4f671e55"
+  },
+  "web.admin.emailtools.deliverability.messages.col.status": {
+    "text": "Tūnga",
+    "source_hash": "920e413c"
+  },
+  "web.admin.emailtools.deliverability.messages.col.subject": {
+    "text": "Kaupapa",
+    "source_hash": "68971283"
+  },
+  "web.admin.emailtools.deliverability.messages.col.to": {
+    "text": "Ki",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.emailtools.deliverability.messages.col.created": {
+    "text": "I Tukua",
+    "source_hash": "c16bc82b"
+  },
+  "web.admin.emailtools.deliverability.messages.status.delivered": {
+    "text": "kua tukuna",
+    "source_hash": "373e0712"
+  },
+  "web.admin.emailtools.deliverability.messages.status.opened": {
+    "text": "kua tuwhera",
+    "source_hash": "50236627"
+  },
+  "web.admin.emailtools.deliverability.messages.status.clicked": {
+    "text": "kua pāwhiritia",
+    "source_hash": "d66440b2"
+  },
+  "web.admin.emailtools.deliverability.messages.status.pending": {
+    "text": "tārewa",
+    "source_hash": "62a2fed3"
+  },
+  "web.admin.emailtools.deliverability.messages.status.queued": {
+    "text": "kei te rārangi",
+    "source_hash": "d36be649"
+  },
+  "web.admin.emailtools.deliverability.messages.status.processed": {
+    "text": "kua tukatukatia",
+    "source_hash": "58190ffa"
+  },
+  "web.admin.emailtools.deliverability.messages.status.hard_bounced": {
+    "text": "tuku-hoki mārō",
+    "source_hash": "b0aa6fd4"
+  },
+  "web.admin.emailtools.deliverability.messages.status.soft_bounced": {
+    "text": "tuku-hoki ngohe",
+    "source_hash": "ac844ff2"
+  },
+  "web.admin.emailtools.deliverability.messages.status.complained": {
+    "text": "kua amuamu",
+    "source_hash": "c26fe786"
+  },
+  "web.admin.emailtools.deliverability.messages.status.suppressed": {
+    "text": "kua āraia",
+    "source_hash": "f63d5b6b"
+  },
+  "web.admin.emailtools.deliverability.messages.status.unsubscribed": {
+    "text": "kua wetehono",
+    "source_hash": "621e1970"
+  },
+  "web.admin.emailtools.deliverability.summary.loadError": {
+    "text": "Kāore i taea te uta i te whakarāpopoto taea-te-tuku.",
+    "source_hash": "0c16ef96"
+  },
+  "web.admin.emailtools.deliverability.suppressions.title": {
+    "text": "Rārangi ārai",
+    "source_hash": "9f3e322f"
+  },
+  "web.admin.emailtools.deliverability.suppressions.description": {
+    "text": "Ngā wāhitau ka whakarērea e te īmēra puta. Ka ahu mai ngā tāurunga mai i te horonga urupare ESP, i te kawe mai ā-ringa rānei; ki te tango i tētahi, ka haere anō te tuku.",
+    "source_hash": "3651887e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.searchLabel": {
+    "text": "Wāhitau tōtika",
+    "source_hash": "f4338ff8"
+  },
+  "web.admin.emailtools.deliverability.suppressions.searchPlaceholder": {
+    "text": "user{'@'}example.com",
+    "source_hash": "333f0f15"
+  },
+  "web.admin.emailtools.deliverability.suppressions.searchButton": {
+    "text": "Rapua",
+    "source_hash": "504101bc"
+  },
+  "web.admin.emailtools.deliverability.suppressions.clearButton": {
+    "text": "Muku",
+    "source_hash": "83b12c22"
+  },
+  "web.admin.emailtools.deliverability.suppressions.empty": {
+    "text": "Kāore anō he wāhitau kua āraia. Ka puta mai ki konei i te horonga o te urupare tuku-hoki me te amuamu.",
+    "source_hash": "dd3f4d61"
+  },
+  "web.admin.emailtools.deliverability.suppressions.emptySearch": {
+    "text": "Kāore he tāurunga ārai mō {address}.",
+    "source_hash": "200c361e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.loadError": {
+    "text": "Kāore i taea te uta i te rārangi ārai.",
+    "source_hash": "2a12c8ba"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.addressLabel": {
+    "text": "Tāpiri wāhitau",
+    "source_hash": "8be5aa33"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.button": {
+    "text": "Ārai",
+    "source_hash": "60b19987"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.confirmTitle": {
+    "text": "Ārai i tēnei wāhitau?",
+    "source_hash": "40a0d2a6"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.confirmDescription": {
+    "text": "Ka whakarērea te īmēra puta ki {address} kia tangohia rā anō te ārai. Ka rēkoatatia hei tāurunga ā-ringa.",
+    "source_hash": "e3d0d799"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.success": {
+    "text": "Kua āraia te wāhitau {address}.",
+    "source_hash": "e2cd2c3b"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.successExisting": {
+    "text": "Kua āraia kētia te wāhitau {address}; kua whakahoutia te tāurunga.",
+    "source_hash": "0852101e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.error": {
+    "text": "Kāore i taea te ārai i te wāhitau.",
+    "source_hash": "dad9e000"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.address": {
+    "text": "Wāhitau",
+    "source_hash": "56ef8f20"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.reason": {
+    "text": "Take",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.source": {
+    "text": "Puna",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.added": {
+    "text": "I Tāpiritia",
+    "source_hash": "6b02e0d3"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.actions": {
+    "text": "Ngā Mahi",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.button": {
+    "text": "Tango",
+    "source_hash": "c3812fc4"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.confirmTitle": {
+    "text": "Tango i tēnei ārai?",
+    "source_hash": "0b0aec2e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.confirmDescription": {
+    "text": "Ka haere anō te īmēra puta ki {address}. I tuku-hoki, i amuamu rānei tēnei wāhitau i mua — tangohia anake mēnā e mōhio ana koe ka taea anō te tuku.",
+    "source_hash": "09442f9c"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.success": {
+    "text": "Kua tangohia te ārai mō {address}.",
+    "source_hash": "bfc0de36"
+  },
+  "web.admin.emailtools.deliverability.sync.title": {
+    "text": "Tukutahi urupare",
+    "source_hash": "d4056915"
+  },
+  "web.admin.emailtools.deliverability.sync.lastSynced": {
+    "text": "i tukutahingia whakamutunga",
+    "source_hash": "5a99666b"
+  },
+  "web.admin.emailtools.deliverability.sync.imported": {
+    "text": "{count} i kawea mai",
+    "source_hash": "1bc18c45"
+  },
+  "web.admin.emailtools.deliverability.sync.neverRun": {
+    "text": "Kāore anō te tukutahi urupare kaiwhakarato kia rere. Kāore ngā raraunga tuku-hoki me te amuamu e kawea mai aunoatia ana — whirihorahia he tukutahi kaiwhakarato, horomia rānei te urupare mā te pito mutunga takahanga.",
+    "source_hash": "d19f5755"
+  },
+  "web.admin.emailtools.deliverability.sync.button": {
+    "text": "Tukutahi ināianei",
+    "source_hash": "885e8f48"
+  },
+  "web.admin.emailtools.deliverability.sync.success": {
+    "text": "Kua oti te tukutahi {provider}: {accepted} i kawea mai, {rejected} i paopaongia ({fetched} i tīkina).",
+    "source_hash": "d36f5578"
+  },
+  "web.admin.emailtools.deliverability.sync.hint": {
+    "text": "He tukutahi ā-ringa — me whai tonu te kawe-mai aunoa i tētahi cron `ots email sync-feedback` kua whakaritea.",
+    "source_hash": "7a509b75"
+  },
+  "web.admin.emailtools.deliverability.tiles.suppressed": {
+    "text": "Ngā wāhitau kua āraia",
+    "source_hash": "b31a245e"
+  },
+  "web.admin.emailtools.deliverability.tiles.bounces": {
+    "text": "Ngā tuku-hoki ({days}r)",
+    "source_hash": "3a4d0f09"
+  },
+  "web.admin.emailtools.deliverability.tiles.complaints": {
+    "text": "Ngā amuamu ({days}r)",
+    "source_hash": "16ad856f"
+  },
+  "web.admin.emailtools.deliverability.tiles.skipped": {
+    "text": "Ngā tuku i whakarērea",
+    "source_hash": "391467f9"
+  },
+  "web.admin.emailtools.preview.title": {
+    "text": "Arokite tātauira",
+    "source_hash": "df89bd92"
+  },
+  "web.admin.emailtools.preview.description": {
+    "text": "Whakaputa i tētahi tātauira me ōna raraunga tauira. Kāore he pānga taha o te arokite — kāore he īmēra ka tukua.",
+    "source_hash": "9b0e40f3"
+  },
+  "web.admin.emailtools.preview.templateLabel": {
+    "text": "Tātauira",
+    "source_hash": "0575f29d"
+  },
+  "web.admin.emailtools.preview.formatLabel": {
+    "text": "Hōputu",
+    "source_hash": "2f343666"
+  },
+  "web.admin.emailtools.preview.localeLabel": {
+    "text": "Reo takiwā",
+    "source_hash": "ca3dc612"
+  },
+  "web.admin.emailtools.preview.button": {
+    "text": "Arokite",
+    "source_hash": "324b134f"
+  },
+  "web.admin.emailtools.providerStatus.title": {
+    "text": "Tūnga kaiwhakarato",
+    "source_hash": "231b7f03"
+  },
+  "web.admin.emailtools.providerStatus.rateUnavailable": {
+    "text": "Kāore tēnei kaiwhakarato e whakaatu i tētahi reeti tuku-hoki, amuamu rānei ā-tau; ka ahu mai te taumata rongo i runga i te tūnga whakatinana me te tapeke tuku anake.",
+    "source_hash": "1e6b82e9"
+  },
+  "web.admin.emailtools.providerStatus.complaintsUnavailable": {
+    "text": "Kāore a Lettermint e pūrongo i ngā amuamu i tāna API tatauranga, nā reira ka whakaaturia te reeti amuamu hei “—” (kāore i pūrongotia), ehara i te kore. Kua oti te reeti tuku-hoki i runga.",
+    "source_hash": "72aaa845"
+  },
+  "web.admin.emailtools.providerStatus.unavailable": {
+    "text": "Kāore i te wātea te tūnga kaiwhakarato mō te wā poto.",
+    "source_hash": "8e69ff29"
+  },
+  "web.admin.emailtools.providerStatus.notSupported": {
+    "text": "Kāore te tūnga kaiwhakarato ora e wātea ana i te kawe {provider}.",
+    "source_hash": "125ed6eb"
+  },
+  "web.admin.emailtools.providerStatus.error": {
+    "text": "Kāore i taea te toro atu ki te kaiwhakarato īmēra mō te tūnga. Ngana anō.",
+    "source_hash": "594ab7b1"
+  },
+  "web.admin.emailtools.providerStatus.quota.max24h": {
+    "text": "Tepe tuku 24h",
+    "source_hash": "e5ea4c3d"
+  },
+  "web.admin.emailtools.providerStatus.quota.sent24h": {
+    "text": "I tukua (24h whakamutunga)",
+    "source_hash": "d0c4fe45"
+  },
+  "web.admin.emailtools.providerStatus.quota.maxRate": {
+    "text": "Reeti tuku mōrahi (ia hēkona)",
+    "source_hash": "59e76cf8"
+  },
+  "web.admin.emailtools.providerStatus.rate.bounce": {
+    "text": "Reeti tuku-hoki",
+    "source_hash": "9eba32f0"
+  },
+  "web.admin.emailtools.providerStatus.rate.complaint": {
+    "text": "Reeti amuamu",
+    "source_hash": "430a23a9"
+  },
+  "web.admin.emailtools.providerStatus.stats.sent": {
+    "text": "I tukua ({days}r)",
+    "source_hash": "e553b7e1"
+  },
+  "web.admin.emailtools.providerStatus.stats.delivered": {
+    "text": "Kua tukuna",
+    "source_hash": "90611565"
+  },
+  "web.admin.emailtools.providerStatus.stats.hardBounced": {
+    "text": "Tuku-hoki mārō",
+    "source_hash": "c76631c0"
+  },
+  "web.admin.emailtools.providerStatus.stats.complaints": {
+    "text": "Ngā amuamu tāwaru",
+    "source_hash": "d48953cd"
+  },
+  "web.admin.emailtools.providerStatus.tier.healthy": {
+    "text": "Hauora",
+    "source_hash": "7f1e323b"
+  },
+  "web.admin.emailtools.providerStatus.tier.probation": {
+    "text": "Kei te arotakengia",
+    "source_hash": "9e8a3b64"
+  },
+  "web.admin.emailtools.providerStatus.tier.shutdown": {
+    "text": "Kua tāritia te tuku",
+    "source_hash": "52e6757c"
+  },
+  "web.admin.emailtools.test.title": {
+    "text": "Whakamātau tuku",
+    "source_hash": "5fab5d67"
+  },
+  "web.admin.emailtools.test.description": {
+    "text": "Tukua he īmēra tātari kuputuhi-māmā hei manatoko i te tūhonohono tuku. Arokitea tuatahi, kātahi ka whakaū kia tukua he īmēra tūturu.",
+    "source_hash": "4130741c"
+  },
+  "web.admin.emailtools.test.toLabel": {
+    "text": "Kaiwhiwhi",
+    "source_hash": "51fac985"
+  },
+  "web.admin.emailtools.test.toPlaceholder": {
+    "text": "you{'@'}example.com",
+    "source_hash": "cf0a9acc"
+  },
+  "web.admin.emailtools.test.enqueueLabel": {
+    "text": "Mā te rārangi kaimahi",
+    "source_hash": "97897017"
+  },
+  "web.admin.emailtools.test.previewButton": {
+    "text": "Arokite (kāore he tuku)",
+    "source_hash": "747ced83"
+  },
+  "web.admin.emailtools.test.sendButton": {
+    "text": "Tukua te īmēra whakamātau",
+    "source_hash": "46ebd7db"
+  },
+  "web.admin.emailtools.test.provider": {
+    "text": "Kaiwhakarato",
+    "source_hash": "472590ae"
+  },
+  "web.admin.emailtools.test.host": {
+    "text": "Kaihautū takenga",
+    "source_hash": "968925cb"
+  },
+  "web.admin.emailtools.test.from": {
+    "text": "Nā",
+    "source_hash": "21819769"
+  },
+  "web.admin.emailtools.test.subject": {
+    "text": "Kaupapa",
+    "source_hash": "68971283"
+  },
+  "web.admin.emailtools.test.confirmTitle": {
+    "text": "Tukua he īmēra whakamātau tūturu?",
+    "source_hash": "64a16b62"
+  },
+  "web.admin.emailtools.test.confirmDescription": {
+    "text": "Ka tukua tēnei he īmēra ora ki {to} mā te pūtuku īmēra kua whirihorahia.",
+    "source_hash": "10114929"
+  },
+  "web.admin.emailtools.test.success": {
+    "text": "Kua tukua te īmēra whakamātau ki {to}.",
+    "source_hash": "daa61a62"
+  }
+}

--- a/locales/content/mi_NZ/admin-kit.json
+++ b/locales/content/mi_NZ/admin-kit.json
@@ -1,0 +1,66 @@
+{
+  "web.admin.kit.confirmDialog.typePrompt": {
+    "text": "Hei whakaū, patohia {token} ki raro",
+    "source_hash": "282445b6"
+  },
+  "web.admin.kit.confirmDialog.inputLabel": {
+    "text": "Kuputuhi whakaū",
+    "source_hash": "8edc1113"
+  },
+  "web.admin.kit.confirmDialog.mismatchHint": {
+    "text": "Me tino ōrite te kuputuhi i whakauruhia kia haere tonu ai.",
+    "source_hash": "f0cc7389"
+  },
+  "web.admin.kit.dataTable.empty": {
+    "text": "Kāore he rekoata i kitea",
+    "source_hash": "6e2ea637"
+  },
+  "web.admin.kit.dataTable.sortBy": {
+    "text": "Kōmaka mā {column}",
+    "source_hash": "55fb1bf9"
+  },
+  "web.admin.kit.filterBar.search": {
+    "text": "Rapu",
+    "source_hash": "49c266ba"
+  },
+  "web.admin.kit.filterBar.searchPlaceholder": {
+    "text": "Rapua…",
+    "source_hash": "7336265a"
+  },
+  "web.admin.kit.filterBar.clearFilters": {
+    "text": "Muku tātari",
+    "source_hash": "7179ea00"
+  },
+  "web.admin.kit.filterBar.all": {
+    "text": "Katoa",
+    "source_hash": "a52ace42"
+  },
+  "web.admin.kit.jsonViewer.expandAll": {
+    "text": "Whakatuwhera katoa",
+    "source_hash": "a3e586be"
+  },
+  "web.admin.kit.jsonViewer.collapseAll": {
+    "text": "Kopeke katoa",
+    "source_hash": "25f7b372"
+  },
+  "web.admin.kit.jsonViewer.empty": {
+    "text": "Kāore he raraunga",
+    "source_hash": "3b41ba9c"
+  },
+  "web.admin.kit.jsonViewer.copyLabel": {
+    "text": "Tārua JSON",
+    "source_hash": "7708c6e2"
+  },
+  "web.admin.kit.revealEmail.reveal": {
+    "text": "Whakaatu i te wāhitau īmēra",
+    "source_hash": "f6272277"
+  },
+  "web.admin.kit.revealEmail.hide": {
+    "text": "Huna i te wāhitau īmēra",
+    "source_hash": "9755e870"
+  },
+  "web.admin.kit.revealEmail.copy": {
+    "text": "Tārua i te wāhitau īmēra",
+    "source_hash": "61b94846"
+  }
+}

--- a/locales/content/mi_NZ/admin-organizations.json
+++ b/locales/content/mi_NZ/admin-organizations.json
@@ -1,0 +1,314 @@
+{
+  "web.admin.organizations.retry": {
+    "text": "Ngana anō",
+    "source_hash": "942087cc"
+  },
+  "web.admin.organizations.detail.backToList": {
+    "text": "Hoki ki ngā whakahaere",
+    "source_hash": "2257dc4a"
+  },
+  "web.admin.organizations.detail.notFound": {
+    "text": "Kāore i kitea te whakahaere",
+    "source_hash": "00c50f7a"
+  },
+  "web.admin.organizations.detail.notFoundDescription": {
+    "text": "Kua mukua pea tēnei whakahaere, kei te hē rānei te id.",
+    "source_hash": "e5459ef5"
+  },
+  "web.admin.organizations.detail.loadError": {
+    "text": "Kāore i taea te uta i tēnei whakahaere.",
+    "source_hash": "9df8ad50"
+  },
+  "web.admin.organizations.detail.none": {
+    "text": "—",
+    "source_hash": "bda05058"
+  },
+  "web.admin.organizations.detail.badges.default": {
+    "text": "Wāhi Mahi taunoa",
+    "source_hash": "6d67c6eb"
+  },
+  "web.admin.organizations.detail.badges.archived": {
+    "text": "Kua Pūrangatia",
+    "source_hash": "bdb86505"
+  },
+  "web.admin.organizations.detail.domains.domain": {
+    "text": "Rohe",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.organizations.detail.domains.state": {
+    "text": "Tūnga",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.organizations.detail.domains.created": {
+    "text": "I Hangaia",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.organizations.detail.domains.ready": {
+    "text": "Kua Rite",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.organizations.detail.domains.resolving": {
+    "text": "Kei te Whakatau",
+    "source_hash": "3287a034"
+  },
+  "web.admin.organizations.detail.domains.empty": {
+    "text": "Kāore he rohe.",
+    "source_hash": "1b840c7e"
+  },
+  "web.admin.organizations.detail.entitlements.description": {
+    "text": "Ka whakataua ngā whaimana whaitake ki te (mahere ∪ ngā tuku) − ngā whakakore. Arotakengia te wāwāhanga i mua i te hanga whakakapi.",
+    "source_hash": "23080475"
+  },
+  "web.admin.organizations.detail.entitlements.inSync": {
+    "text": "Kei te tukutahi",
+    "source_hash": "5701958c"
+  },
+  "web.admin.organizations.detail.entitlements.driftBadge": {
+    "text": "Rerenga kē",
+    "source_hash": "8b4c8240"
+  },
+  "web.admin.organizations.detail.entitlements.staleBadge": {
+    "text": "Mahere tawhito",
+    "source_hash": "ffe63800"
+  },
+  "web.admin.organizations.detail.entitlements.driftWarning": {
+    "text": "Kāore ngā whaimana kua whakatinanahia e ōrite ana ki te huinga i whakaarohia. Whakataurite kia whakatinana anō.",
+    "source_hash": "4859983a"
+  },
+  "web.admin.organizations.detail.entitlements.driftExtra": {
+    "text": "Tāpiri (kua whakatinanahia, kāore i whakaarohia)",
+    "source_hash": "08d60730"
+  },
+  "web.admin.organizations.detail.entitlements.driftMissing": {
+    "text": "Ngaro (i whakaarohia, kāore i whakatinanahia)",
+    "source_hash": "fe12c83a"
+  },
+  "web.admin.organizations.detail.entitlements.plan": {
+    "text": "Nā te mahere",
+    "source_hash": "1d346b26"
+  },
+  "web.admin.organizations.detail.entitlements.materialized": {
+    "text": "Kua whakatinanahia (whaitake)",
+    "source_hash": "72ca5f45"
+  },
+  "web.admin.organizations.detail.members.email": {
+    "text": "Mema",
+    "source_hash": "7c968fb7"
+  },
+  "web.admin.organizations.detail.members.role": {
+    "text": "Tūranga",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.organizations.detail.members.status": {
+    "text": "Tūnga",
+    "source_hash": "920e413c"
+  },
+  "web.admin.organizations.detail.members.joined": {
+    "text": "I Hono",
+    "source_hash": "69318b0c"
+  },
+  "web.admin.organizations.detail.members.owner": {
+    "text": "Rangatira",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.detail.members.empty": {
+    "text": "Kāore he mema.",
+    "source_hash": "b99c59dc"
+  },
+  "web.admin.organizations.detail.reconcile.button": {
+    "text": "Whakataurite",
+    "source_hash": "b59be565"
+  },
+  "web.admin.organizations.detail.reconcile.confirmTitle": {
+    "text": "Whakataurite i te nama whakahaere?",
+    "source_hash": "fc1a2762"
+  },
+  "web.admin.organizations.detail.reconcile.confirmDescription": {
+    "text": "Ka kukume anō tēnei i a Stripe, ka tuhi anō i te tūnga nama me ngā whaimana mō {org}. Patohia anō te id whakahaere hei whakaū.",
+    "source_hash": "b4ef0850"
+  },
+  "web.admin.organizations.detail.reconcile.success": {
+    "text": "Kua whakatauritea te whakahaere.",
+    "source_hash": "caf87844"
+  },
+  "web.admin.organizations.detail.reconcile.resultTitle": {
+    "text": "Otinga whakataurite",
+    "source_hash": "11f4c6b8"
+  },
+  "web.admin.organizations.detail.reconcile.before": {
+    "text": "I mua",
+    "source_hash": "9bb72500"
+  },
+  "web.admin.organizations.detail.reconcile.after": {
+    "text": "I muri",
+    "source_hash": "7b68fe55"
+  },
+  "web.admin.organizations.detail.reconcile.materializedCount": {
+    "text": "Tatau whaimana",
+    "source_hash": "59cede5c"
+  },
+  "web.admin.organizations.detail.reconcile.mode.stripe_sync": {
+    "text": "Tukutahi Stripe",
+    "source_hash": "02f9546c"
+  },
+  "web.admin.organizations.detail.reconcile.mode.entitlements_only": {
+    "text": "Ngā whaimana anake",
+    "source_hash": "8cf49a5d"
+  },
+  "web.admin.organizations.detail.sections.billing": {
+    "text": "Nama",
+    "source_hash": "3ac8bbca"
+  },
+  "web.admin.organizations.detail.sections.members": {
+    "text": "Ngā Mema",
+    "source_hash": "1044a4c0"
+  },
+  "web.admin.organizations.detail.sections.domains": {
+    "text": "Ngā Rohe",
+    "source_hash": "ced67718"
+  },
+  "web.admin.organizations.detail.sections.investigate": {
+    "text": "Tūhura & whakataurite",
+    "source_hash": "b05aa349"
+  },
+  "web.admin.organizations.entitlements.section": {
+    "text": "Ngā whakakapi whaimana",
+    "source_hash": "48812068"
+  },
+  "web.admin.organizations.entitlements.description": {
+    "text": "Tukua, whakakorea rānei ngā whaimana motuhake i te mahere. Whaitake = ngā whaimana mahere + ngā tuku - ngā whakakore.",
+    "source_hash": "4c38425b"
+  },
+  "web.admin.organizations.entitlements.inputLabel": {
+    "text": "Whaimana",
+    "source_hash": "0d8f0b2d"
+  },
+  "web.admin.organizations.entitlements.placeholder": {
+    "text": "hei tauira, custom_domains",
+    "source_hash": "05346c68"
+  },
+  "web.admin.organizations.entitlements.grant": {
+    "text": "Tuku",
+    "source_hash": "78b7d037"
+  },
+  "web.admin.organizations.entitlements.revoke": {
+    "text": "Whakakore",
+    "source_hash": "87e6d00b"
+  },
+  "web.admin.organizations.entitlements.clear": {
+    "text": "Muku i ngā whakakapi katoa",
+    "source_hash": "f0e485c3"
+  },
+  "web.admin.organizations.entitlements.effective": {
+    "text": "Ngā whaimana whaitake",
+    "source_hash": "b840f8c8"
+  },
+  "web.admin.organizations.entitlements.grants": {
+    "text": "Ngā tuku",
+    "source_hash": "b3e1c95a"
+  },
+  "web.admin.organizations.entitlements.revokes": {
+    "text": "Ngā whakakore",
+    "source_hash": "f0e69b17"
+  },
+  "web.admin.organizations.entitlements.noOverrides": {
+    "text": "Mahia tētahi mahi hei tiro i te tūnga whakakapi o tēnei whakahaere o nāianei.",
+    "source_hash": "98d2e30d"
+  },
+  "web.admin.organizations.entitlements.confirm.grantTitle": {
+    "text": "Tuku whaimana?",
+    "source_hash": "a4b2c57b"
+  },
+  "web.admin.organizations.entitlements.confirm.grantDescription": {
+    "text": "Tukua “{entitlement}” ki {org}. Ka whakarerekē tēnei i ngā whaimana nama o te whakahaere.",
+    "source_hash": "542ce26a"
+  },
+  "web.admin.organizations.entitlements.confirm.revokeTitle": {
+    "text": "Whakakore whaimana?",
+    "source_hash": "c93d520a"
+  },
+  "web.admin.organizations.entitlements.confirm.revokeDescription": {
+    "text": "Whakakorea “{entitlement}” mai i {org}. Ka whakarerekē tēnei i ngā whaimana nama o te whakahaere.",
+    "source_hash": "a5d2a8a6"
+  },
+  "web.admin.organizations.entitlements.confirm.clearTitle": {
+    "text": "Muku i ngā whakakapi whaimana katoa?",
+    "source_hash": "e36eb218"
+  },
+  "web.admin.organizations.entitlements.confirm.clearDescription": {
+    "text": "Tangohia ia whakakapi tuku me te whakakore mō {org}, kia tautuhia anō ki ōna whaimana mahere.",
+    "source_hash": "96bad079"
+  },
+  "web.admin.organizations.entitlements.success.granted": {
+    "text": "Kua tukua te whaimana “{entitlement}”.",
+    "source_hash": "cf52fb0e"
+  },
+  "web.admin.organizations.entitlements.success.revoked": {
+    "text": "Kua whakakorea te whaimana “{entitlement}”.",
+    "source_hash": "279d425d"
+  },
+  "web.admin.organizations.entitlements.success.cleared": {
+    "text": "Kua mukua ngā whakakapi whaimana katoa.",
+    "source_hash": "a482743b"
+  },
+  "web.admin.organizations.fields.contactEmail": {
+    "text": "Īmēra whakapā",
+    "source_hash": "6d7fce11"
+  },
+  "web.admin.organizations.fields.owner": {
+    "text": "Rangatira",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.fields.plan": {
+    "text": "Mahere",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.organizations.fields.subscription": {
+    "text": "Tūnga ohaurunga",
+    "source_hash": "f0723c4e"
+  },
+  "web.admin.organizations.fields.periodEnd": {
+    "text": "Mutunga o te wā",
+    "source_hash": "eeae9fdd"
+  },
+  "web.admin.organizations.fields.billingEmail": {
+    "text": "Īmēra nama",
+    "source_hash": "8805b928"
+  },
+  "web.admin.organizations.fields.stripeCustomer": {
+    "text": "Kiritaki Stripe",
+    "source_hash": "8f169be1"
+  },
+  "web.admin.organizations.fields.stripeSubscription": {
+    "text": "Ohaurunga Stripe",
+    "source_hash": "53f71e08"
+  },
+  "web.admin.organizations.fields.orgId": {
+    "text": "ID Whakahaere",
+    "source_hash": "1f466322"
+  },
+  "web.admin.organizations.fields.created": {
+    "text": "I Hangaia",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.organizations.fields.updated": {
+    "text": "I Whakahoutia",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.organizations.investigate.description": {
+    "text": "Whakatairitea te tūnga nama ā-kāinga ki te ohaurunga ora Stripe.",
+    "source_hash": "d7bbe9ed"
+  },
+  "web.admin.organizations.investigate.rawPayload": {
+    "text": "Utanga tūhura mata",
+    "source_hash": "29ca7df2"
+  },
+  "web.admin.organizations.investigate.parseError": {
+    "text": "Kāore te whakautu tūhura i ōrite ki te hōputu i whakaarohia.",
+    "source_hash": "db59cab1"
+  },
+  "web.admin.organizations.list.loadError": {
+    "text": "Kāore i taea te uta i ngā whakahaere.",
+    "source_hash": "130d5e70"
+  }
+}

--- a/locales/content/mi_NZ/admin-overview.json
+++ b/locales/content/mi_NZ/admin-overview.json
@@ -1,0 +1,94 @@
+{
+  "web.admin.overview.retry": {
+    "text": "Ngana anō",
+    "source_hash": "942087cc"
+  },
+  "web.admin.overview.feedback.title": {
+    "text": "Urupare kaiwhakamahi",
+    "source_hash": "cb7b24c6"
+  },
+  "web.admin.overview.feedback.total": {
+    "text": "{count} i roto i ngā rā 30 kua hipa",
+    "source_hash": "b6b9147c"
+  },
+  "web.admin.overview.feedback.today": {
+    "text": "I tēnei rā",
+    "source_hash": "2b065c7c"
+  },
+  "web.admin.overview.feedback.yesterday": {
+    "text": "Inanahi",
+    "source_hash": "56618125"
+  },
+  "web.admin.overview.feedback.older": {
+    "text": "Tawhito ake",
+    "source_hash": "03281c88"
+  },
+  "web.admin.overview.feedback.empty": {
+    "text": "Kāore he urupare i tēnei wā",
+    "source_hash": "e09d594d"
+  },
+  "web.admin.overview.feedback.loadError": {
+    "text": "Kāore i taea te uta i te urupare.",
+    "source_hash": "4011c408"
+  },
+  "web.admin.overview.stats.heading": {
+    "text": "Ngā tatauranga papa",
+    "source_hash": "77728e4d"
+  },
+  "web.admin.overview.stats.customers": {
+    "text": "Ngā Kiritaki",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.overview.stats.secrets": {
+    "text": "Ngā karere huna hohe",
+    "source_hash": "8db4c552"
+  },
+  "web.admin.overview.stats.sessions": {
+    "text": "Ngā wātū hohe",
+    "source_hash": "61ad9909"
+  },
+  "web.admin.overview.stats.receipts": {
+    "text": "Ngā Rīhiti",
+    "source_hash": "60a627df"
+  },
+  "web.admin.overview.stats.secretsCreated": {
+    "text": "Ngā karere huna i hangaia (mō ake)",
+    "source_hash": "bdb49794"
+  },
+  "web.admin.overview.stats.emailsSent": {
+    "text": "Ngā īmēra i tukua (mō ake)",
+    "source_hash": "1c9a7518"
+  },
+  "web.admin.overview.stats.loadError": {
+    "text": "Kāore i taea te uta i ngā tatauranga papa.",
+    "source_hash": "5f13cf7a"
+  },
+  "web.admin.overview.trends.title": {
+    "text": "Ngā rā 30 kua hipa",
+    "source_hash": "f8f03fb4"
+  },
+  "web.admin.overview.trends.signups": {
+    "text": "Ngā rēhitatanga ia rā",
+    "source_hash": "8db399dc"
+  },
+  "web.admin.overview.trends.secretsCreated": {
+    "text": "Ngā karere huna i hangaia ia rā",
+    "source_hash": "d6852656"
+  },
+  "web.admin.overview.trends.today": {
+    "text": "i tēnei rā",
+    "source_hash": "e0f4f767"
+  },
+  "web.admin.overview.trends.collectingNote": {
+    "text": "E kohi ana mai i te ira raraunga tuatahi — ka whakaatu kore ngā rā i mua atu.",
+    "source_hash": "269ee1eb"
+  },
+  "web.admin.overview.trends.sparklineAria": {
+    "text": "{label}: aronga 30-rā, {count} i tēnei rā",
+    "source_hash": "eb57a7b2"
+  },
+  "web.admin.overview.trends.loadError": {
+    "text": "Kāore i taea te uta i ngā aronga.",
+    "source_hash": "9cf97f63"
+  }
+}

--- a/locales/content/mi_NZ/admin-secrets.json
+++ b/locales/content/mi_NZ/admin-secrets.json
@@ -1,0 +1,218 @@
+{
+  "web.admin.secrets.title": {
+    "text": "Ngā Karere Huna",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.secrets.description": {
+    "text": "Tirohia te rīhiti o tētahi karere huna, ka mukua me te kore SSH — rapua mā tōna kī.",
+    "source_hash": "07775a11"
+  },
+  "web.admin.secrets.never": {
+    "text": "Kāore rawa",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.secrets.anonymous": {
+    "text": "Ingoakore",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.admin.secrets.ageDays": {
+    "text": "{days} rā",
+    "source_hash": "a2246fbc"
+  },
+  "web.admin.secrets.actions.delete.button": {
+    "text": "Muku karere huna",
+    "source_hash": "1a48c8c8"
+  },
+  "web.admin.secrets.actions.delete.confirmTitle": {
+    "text": "Muku karere huna?",
+    "source_hash": "4a779a67"
+  },
+  "web.admin.secrets.actions.delete.confirmDescription": {
+    "text": "Ka mukua rawatia tēnei te karere huna {shortid} me tōna rīhiti. Kāore e taea te whakakore.",
+    "source_hash": "51f807ad"
+  },
+  "web.admin.secrets.actions.delete.success": {
+    "text": "Kua mukua te karere huna.",
+    "source_hash": "52f1640f"
+  },
+  "web.admin.secrets.detail.yes": {
+    "text": "Āe",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.secrets.detail.no": {
+    "text": "Kāo",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.secrets.detail.none": {
+    "text": "Kāore",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.secrets.fields.secretId": {
+    "text": "ID Karere Huna",
+    "source_hash": "79592419"
+  },
+  "web.admin.secrets.fields.shortId": {
+    "text": "ID Poto",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.secrets.fields.state": {
+    "text": "Tūnga",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.secrets.fields.created": {
+    "text": "I Hangaia",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.secrets.fields.updated": {
+    "text": "I Whakahoutia",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.secrets.fields.expiration": {
+    "text": "Paunga",
+    "source_hash": "f38d6e0e"
+  },
+  "web.admin.secrets.fields.age": {
+    "text": "Pakeke",
+    "source_hash": "39b7370f"
+  },
+  "web.admin.secrets.fields.lifespan": {
+    "text": "Roanga ora",
+    "source_hash": "58994285"
+  },
+  "web.admin.secrets.fields.owner": {
+    "text": "Rangatira",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.secrets.fields.receiptId": {
+    "text": "ID Rīhiti",
+    "source_hash": "2c13d799"
+  },
+  "web.admin.secrets.fields.hasCiphertext": {
+    "text": "He tuhinga muhumuhu",
+    "source_hash": "e9188bad"
+  },
+  "web.admin.secrets.fields.ciphertextLength": {
+    "text": "Roa tuhinga muhumuhu",
+    "source_hash": "0f1744fd"
+  },
+  "web.admin.secrets.lookup.label": {
+    "text": "Kī karere huna",
+    "source_hash": "f47a99eb"
+  },
+  "web.admin.secrets.lookup.placeholder": {
+    "text": "Tautuhi karere huna",
+    "source_hash": "cbcfd49f"
+  },
+  "web.admin.secrets.lookup.button": {
+    "text": "Rapua",
+    "source_hash": "504101bc"
+  },
+  "web.admin.secrets.lookup.resultTitle": {
+    "text": "Karere huna {shortid}",
+    "source_hash": "8b311d32"
+  },
+  "web.admin.secrets.lookup.notFound": {
+    "text": "Kāore i kitea te karere huna",
+    "source_hash": "70a9532c"
+  },
+  "web.admin.secrets.lookup.notFoundDescription": {
+    "text": "Kāore he karere huna e ora ana mā tēnei kī. Kua pau pea, kua mukua rānei.",
+    "source_hash": "9f068a81"
+  },
+  "web.admin.secrets.lookup.loadError": {
+    "text": "Kāore i taea te uta i tēnei karere huna.",
+    "source_hash": "c96672e4"
+  },
+  "web.admin.secrets.lookup.retry": {
+    "text": "Ngana anō",
+    "source_hash": "942087cc"
+  },
+  "web.admin.secrets.owner.anonymous": {
+    "text": "Ingoakore (kāore he rangatira)",
+    "source_hash": "390f11ad"
+  },
+  "web.admin.secrets.ownerFields.email": {
+    "text": "Īmēra",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.secrets.ownerFields.userId": {
+    "text": "ID Kaiwhakamahi",
+    "source_hash": "7967e089"
+  },
+  "web.admin.secrets.ownerFields.role": {
+    "text": "Tūranga",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.secrets.ownerFields.verified": {
+    "text": "Kua Manatokona",
+    "source_hash": "4f783840"
+  },
+  "web.admin.secrets.receipt.none": {
+    "text": "Kāore he rīhiti e hono ana ki tēnei karere huna.",
+    "source_hash": "5ddceaed"
+  },
+  "web.admin.secrets.receiptFields.receiptId": {
+    "text": "ID Rīhiti",
+    "source_hash": "2c13d799"
+  },
+  "web.admin.secrets.receiptFields.shortId": {
+    "text": "ID Poto",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.secrets.receiptFields.state": {
+    "text": "Tūnga",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.secrets.receiptFields.secretTtl": {
+    "text": "TTL Karere Huna",
+    "source_hash": "b89c0b51"
+  },
+  "web.admin.secrets.receiptFields.recipients": {
+    "text": "Ngā Kaiwhiwhi",
+    "source_hash": "1e8568a8"
+  },
+  "web.admin.secrets.receiptFields.hasPassphrase": {
+    "text": "He kupu karapa tōna",
+    "source_hash": "af458f26"
+  },
+  "web.admin.secrets.receiptFields.shareDomain": {
+    "text": "Rohe tohatoha",
+    "source_hash": "db963805"
+  },
+  "web.admin.secrets.receiptFields.created": {
+    "text": "I Hangaia",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.secrets.receiptFields.secretExpired": {
+    "text": "Kua pau te karere huna",
+    "source_hash": "c127dab6"
+  },
+  "web.admin.secrets.sections.secret": {
+    "text": "Karere Huna",
+    "source_hash": "7e32a729"
+  },
+  "web.admin.secrets.sections.receipt": {
+    "text": "Rīhiti",
+    "source_hash": "dad5a969"
+  },
+  "web.admin.secrets.sections.owner": {
+    "text": "Rangatira",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.secrets.sections.raw": {
+    "text": "Mata",
+    "source_hash": "848123d1"
+  },
+  "web.admin.secrets.state.new": {
+    "text": "Hou",
+    "source_hash": "18fdd549"
+  },
+  "web.admin.secrets.state.received": {
+    "text": "Kua Whiwhia",
+    "source_hash": "49f19bee"
+  },
+  "web.admin.secrets.state.viewed": {
+    "text": "Kua Tirohia",
+    "source_hash": "1b28d178"
+  }
+}

--- a/locales/content/mi_NZ/admin-sessions.json
+++ b/locales/content/mi_NZ/admin-sessions.json
@@ -1,0 +1,210 @@
+{
+  "web.admin.sessions.title": {
+    "text": "Ngā Wātū",
+    "source_hash": "6fa3cbf4"
+  },
+  "web.admin.sessions.description": {
+    "text": "Tirohia, rapua me te whakakore i ngā wātū hohe mō te urupare aituā.",
+    "source_hash": "784a3a44"
+  },
+  "web.admin.sessions.anonymous": {
+    "text": "Ingoakore",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.admin.sessions.columns.sessionId": {
+    "text": "ID Wātū",
+    "source_hash": "cb9ac5c5"
+  },
+  "web.admin.sessions.columns.authenticated": {
+    "text": "Whakamotuhēhē",
+    "source_hash": "8eb3ea9b"
+  },
+  "web.admin.sessions.columns.email": {
+    "text": "Īmēra",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.sessions.columns.externalId": {
+    "text": "ID ā-waho",
+    "source_hash": "69da56ba"
+  },
+  "web.admin.sessions.columns.ipAddress": {
+    "text": "Wāhitau IP",
+    "source_hash": "3c3de0c9"
+  },
+  "web.admin.sessions.columns.created": {
+    "text": "I Whakamotuhēhētia",
+    "source_hash": "8d6c9b01"
+  },
+  "web.admin.sessions.columns.actions": {
+    "text": "Ngā Mahi",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.sessions.columns.role": {
+    "text": "Tūranga",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.sessions.detail.yes": {
+    "text": "Āe",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.sessions.detail.no": {
+    "text": "Kāo",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.sessions.detail.none": {
+    "text": "Kāore",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.sessions.detail.unknown": {
+    "text": "Kāore e mōhiotia",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.sessions.detail.noExpiry": {
+    "text": "Kāore he paunga",
+    "source_hash": "fe06351d"
+  },
+  "web.admin.sessions.detail.expired": {
+    "text": "Kua pau",
+    "source_hash": "424a2551"
+  },
+  "web.admin.sessions.detail.ttlSeconds": {
+    "text": "{seconds}s e toe",
+    "source_hash": "3c9d75ce"
+  },
+  "web.admin.sessions.drawer.title": {
+    "text": "Wātū {id}",
+    "source_hash": "29dcbd66"
+  },
+  "web.admin.sessions.drawer.notFound": {
+    "text": "Kāore i kitea te wātū",
+    "source_hash": "0969eab8"
+  },
+  "web.admin.sessions.drawer.notFoundDescription": {
+    "text": "Kāore tēnei wātū e ora ana i roto i a Redis. Kua pau pea, kua whakakorea kētia rānei.",
+    "source_hash": "11e3ef05"
+  },
+  "web.admin.sessions.drawer.loadError": {
+    "text": "Kāore i taea te uta i tēnei wātū.",
+    "source_hash": "82ae90fb"
+  },
+  "web.admin.sessions.drawer.retry": {
+    "text": "Ngana anō",
+    "source_hash": "942087cc"
+  },
+  "web.admin.sessions.fields.sessionId": {
+    "text": "ID Wātū",
+    "source_hash": "cb9ac5c5"
+  },
+  "web.admin.sessions.fields.key": {
+    "text": "Kī Redis",
+    "source_hash": "0b196725"
+  },
+  "web.admin.sessions.fields.ttl": {
+    "text": "TTL",
+    "source_hash": "76f6014f"
+  },
+  "web.admin.sessions.fields.authenticated": {
+    "text": "Kua Whakamotuhēhētia",
+    "source_hash": "6ab694cf"
+  },
+  "web.admin.sessions.fields.email": {
+    "text": "Īmēra",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.sessions.fields.externalId": {
+    "text": "ID ā-waho",
+    "source_hash": "69da56ba"
+  },
+  "web.admin.sessions.fields.accountId": {
+    "text": "ID Pūkete",
+    "source_hash": "919bb4cb"
+  },
+  "web.admin.sessions.fields.role": {
+    "text": "Tūranga",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.sessions.fields.locale": {
+    "text": "Reo takiwā",
+    "source_hash": "ca3dc612"
+  },
+  "web.admin.sessions.fields.ipAddress": {
+    "text": "Wāhitau IP",
+    "source_hash": "3c3de0c9"
+  },
+  "web.admin.sessions.fields.authenticatedAt": {
+    "text": "I Whakamotuhēhētia",
+    "source_hash": "8d6c9b01"
+  },
+  "web.admin.sessions.fields.authenticatedBy": {
+    "text": "Nā Wai i Whakamotuhēhē",
+    "source_hash": "3ebbabfe"
+  },
+  "web.admin.sessions.fields.activeSessionId": {
+    "text": "ID Wātū Hohe",
+    "source_hash": "f32b1158"
+  },
+  "web.admin.sessions.fields.userAgent": {
+    "text": "User Agent",
+    "source_hash": "62e01345"
+  },
+  "web.admin.sessions.fields.orgContext": {
+    "text": "Horopaki Whakahaere",
+    "source_hash": "a596d9f2"
+  },
+  "web.admin.sessions.list.loadError": {
+    "text": "Kāore i taea te uta i ngā wātū.",
+    "source_hash": "00c678d9"
+  },
+  "web.admin.sessions.list.retry": {
+    "text": "Ngana anō",
+    "source_hash": "942087cc"
+  },
+  "web.admin.sessions.list.empty": {
+    "text": "Kāore i kitea he wātū hohe",
+    "source_hash": "e35312d6"
+  },
+  "web.admin.sessions.revoke.button": {
+    "text": "Whakakore",
+    "source_hash": "87e6d00b"
+  },
+  "web.admin.sessions.revoke.confirmTitle": {
+    "text": "Whakakore i tēnei wātū?",
+    "source_hash": "0c6605c1"
+  },
+  "web.admin.sessions.revoke.confirmDescription": {
+    "text": "Ka takiputa tonu tēnei i te kaiwhakamahi mā te muku i te wātū {id}. Patohia te ID wātū hei whakaū.",
+    "source_hash": "9e08b1b8"
+  },
+  "web.admin.sessions.revoke.success": {
+    "text": "Kua whakakorea te wātū",
+    "source_hash": "0af5e14d"
+  },
+  "web.admin.sessions.scan.summary": {
+    "text": "E whakaatu ana i {shown} kua whakamotuhēhētia · {anonymous} ingoakore kua huna · {scanned} kua matawaia",
+    "source_hash": "34cb67a4"
+  },
+  "web.admin.sessions.scan.capped": {
+    "text": "Kua tepea te matawai ki ngā kī tuatahi {scanned} — kāore ngā wātū kua whakamotuhēhētia kei tua atu i tēnei matapihi e whakarārangihia. Tirohia tētahi wātū motuhake mā te ID kia tae atu ki reira.",
+    "source_hash": "fa418b4e"
+  },
+  "web.admin.sessions.search.placeholder": {
+    "text": "Rapua mā te īmēra, ID ā-waho rānei",
+    "source_hash": "f2dc5c06"
+  },
+  "web.admin.sessions.sections.session": {
+    "text": "Wātū",
+    "source_hash": "6959b415"
+  },
+  "web.admin.sessions.sections.raw": {
+    "text": "Raraunga wātū mata",
+    "source_hash": "c9f11eb4"
+  },
+  "web.admin.sessions.status.authenticated": {
+    "text": "Kua Whakamotuhēhētia",
+    "source_hash": "6ab694cf"
+  },
+  "web.admin.sessions.status.anonymous": {
+    "text": "Ingoakore",
+    "source_hash": "e7a8aa2d"
+  }
+}

--- a/locales/content/mi_NZ/admin-system.json
+++ b/locales/content/mi_NZ/admin-system.json
@@ -1,0 +1,158 @@
+{
+  "web.admin.system.title": {
+    "text": "Pūnaha",
+    "source_hash": "6725e7bb"
+  },
+  "web.admin.system.description": {
+    "text": "Te tūnga o te pātengi raraunga, te rārangi tatari, me te tūāpapa.",
+    "source_hash": "0115f495"
+  },
+  "web.admin.system.retry": {
+    "text": "Ngana anō",
+    "source_hash": "942087cc"
+  },
+  "web.admin.system.database.title": {
+    "text": "Pātengi Raraunga Matua ({engine})",
+    "source_hash": "1391230b"
+  },
+  "web.admin.system.database.loadError": {
+    "text": "Kāore i taea te uta i ngā ine pātengi raraunga.",
+    "source_hash": "905055c6"
+  },
+  "web.admin.system.database.server": {
+    "text": "Tūmau",
+    "source_hash": "aef7de28"
+  },
+  "web.admin.system.database.memory": {
+    "text": "Pūmahara",
+    "source_hash": "c3963aed"
+  },
+  "web.admin.system.database.databases": {
+    "text": "Ngā Pātengi Raraunga",
+    "source_hash": "61d2afe2"
+  },
+  "web.admin.system.database.dbSummary": {
+    "text": "{keys} kī, {expires} me te TTL",
+    "source_hash": "26b9e17c"
+  },
+  "web.admin.system.database.fields.version": {
+    "text": "Putanga",
+    "source_hash": "dd167905"
+  },
+  "web.admin.system.database.fields.mode": {
+    "text": "Aratau",
+    "source_hash": "5e23ec6a"
+  },
+  "web.admin.system.database.fields.uptimeDays": {
+    "text": "Wā oranga (rā)",
+    "source_hash": "7ab314f8"
+  },
+  "web.admin.system.database.fields.connectedClients": {
+    "text": "Ngā Kiritaki Honoa",
+    "source_hash": "434adc3a"
+  },
+  "web.admin.system.database.fields.opsPerSec": {
+    "text": "Mahi/hēkona",
+    "source_hash": "6634251d"
+  },
+  "web.admin.system.database.fields.totalCommands": {
+    "text": "Tapeke Whakahau",
+    "source_hash": "c5ce5aaf"
+  },
+  "web.admin.system.database.fields.usedMemory": {
+    "text": "Pūmahara Whakamahia",
+    "source_hash": "bac68a65"
+  },
+  "web.admin.system.database.fields.rssMemory": {
+    "text": "Pūmahara RSS",
+    "source_hash": "7fe77d15"
+  },
+  "web.admin.system.database.fields.peakMemory": {
+    "text": "Pūmahara Tihi",
+    "source_hash": "9d44afa6"
+  },
+  "web.admin.system.database.fields.fragmentation": {
+    "text": "Ōwehe Kongakonga",
+    "source_hash": "721494dd"
+  },
+  "web.admin.system.database.stats.customers": {
+    "text": "Ngā Kiritaki",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.system.database.stats.secrets": {
+    "text": "Ngā Karere Huna",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.system.database.stats.receipts": {
+    "text": "Ngā Rīhiti",
+    "source_hash": "60a627df"
+  },
+  "web.admin.system.database.stats.totalKeys": {
+    "text": "Tapeke Kī",
+    "source_hash": "4e0d27f5"
+  },
+  "web.admin.system.queue.title": {
+    "text": "Rārangi Tatari",
+    "source_hash": "3b2fe03e"
+  },
+  "web.admin.system.queue.loadError": {
+    "text": "Kāore i taea te uta i ngā ine rārangi tatari.",
+    "source_hash": "715bdc88"
+  },
+  "web.admin.system.queue.empty": {
+    "text": "Kāore i kitea he rārangi tatari",
+    "source_hash": "3cd4eb88"
+  },
+  "web.admin.system.queue.connected": {
+    "text": "Kua Honoa",
+    "source_hash": "22965568"
+  },
+  "web.admin.system.queue.disconnected": {
+    "text": "Kua Motuhia",
+    "source_hash": "04dfac36"
+  },
+  "web.admin.system.queue.activeWorkers": {
+    "text": "{count} kaimahi hohe",
+    "source_hash": "49e6369c"
+  },
+  "web.admin.system.queue.columns.name": {
+    "text": "Rārangi Tatari",
+    "source_hash": "3b2fe03e"
+  },
+  "web.admin.system.queue.columns.pending": {
+    "text": "Tārewa",
+    "source_hash": "331551b0"
+  },
+  "web.admin.system.queue.columns.consumers": {
+    "text": "Ngā Kaipau",
+    "source_hash": "212b350d"
+  },
+  "web.admin.system.queue.health.healthy": {
+    "text": "Hauora",
+    "source_hash": "7f1e323b"
+  },
+  "web.admin.system.queue.health.degraded": {
+    "text": "Kua Heke",
+    "source_hash": "a8494c12"
+  },
+  "web.admin.system.queue.health.unhealthy": {
+    "text": "Māuiui",
+    "source_hash": "317b1fbc"
+  },
+  "web.admin.system.queue.health.unknown": {
+    "text": "Kāore e mōhiotia",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.system.redis.title": {
+    "text": "Redis INFO",
+    "source_hash": "e762bd3c"
+  },
+  "web.admin.system.redis.loadError": {
+    "text": "Kāore i taea te uta i ngā ine Redis.",
+    "source_hash": "ca5945d6"
+  },
+  "web.admin.system.redis.captured": {
+    "text": "I hopukina {at}",
+    "source_hash": "57b40c0f"
+  }
+}

--- a/locales/content/mi_NZ/admin-usage.json
+++ b/locales/content/mi_NZ/admin-usage.json
@@ -1,0 +1,78 @@
+{
+  "web.admin.usage.title": {
+    "text": "Whakamahinga",
+    "source_hash": "8d59829c"
+  },
+  "web.admin.usage.description": {
+    "text": "Kaweakengia ngā ine whakamahinga mō tētahi awhe rā.",
+    "source_hash": "97bd3325"
+  },
+  "web.admin.usage.startDate": {
+    "text": "Rā Tīmata",
+    "source_hash": "4c52faad"
+  },
+  "web.admin.usage.endDate": {
+    "text": "Rā Mutu",
+    "source_hash": "e970951c"
+  },
+  "web.admin.usage.fetch": {
+    "text": "Tīkina Raraunga",
+    "source_hash": "429532fe"
+  },
+  "web.admin.usage.loadError": {
+    "text": "Kāore i taea te uta i ngā raraunga whakamahinga.",
+    "source_hash": "ffb557d7"
+  },
+  "web.admin.usage.retry": {
+    "text": "Ngana anō",
+    "source_hash": "942087cc"
+  },
+  "web.admin.usage.empty": {
+    "text": "Kāore he raraunga mō tēnei awhe",
+    "source_hash": "5fed1795"
+  },
+  "web.admin.usage.byState": {
+    "text": "Ngā Karere Huna mā te Tūnga",
+    "source_hash": "916bbcb6"
+  },
+  "web.admin.usage.secretsByDay": {
+    "text": "Ngā Karere Huna ia Rā",
+    "source_hash": "24a01e8e"
+  },
+  "web.admin.usage.usersByDay": {
+    "text": "Ngā Kaiwhakamahi Hou ia Rā",
+    "source_hash": "8c1f089f"
+  },
+  "web.admin.usage.exportJson": {
+    "text": "Tikiake JSON",
+    "source_hash": "49e0e6d5"
+  },
+  "web.admin.usage.exportCsv": {
+    "text": "Tikiake CSV",
+    "source_hash": "a4023b89"
+  },
+  "web.admin.usage.columns.date": {
+    "text": "Rā",
+    "source_hash": "99c40ab4"
+  },
+  "web.admin.usage.columns.count": {
+    "text": "Tatau",
+    "source_hash": "37bac495"
+  },
+  "web.admin.usage.stats.totalSecrets": {
+    "text": "Tapeke Karere Huna",
+    "source_hash": "e17a5459"
+  },
+  "web.admin.usage.stats.newUsers": {
+    "text": "Ngā Kaiwhakamahi Hou",
+    "source_hash": "d3ee48b0"
+  },
+  "web.admin.usage.stats.avgSecrets": {
+    "text": "Toharite Karere Huna/Rā",
+    "source_hash": "948b0701"
+  },
+  "web.admin.usage.stats.avgUsers": {
+    "text": "Toharite Kaiwhakamahi/Rā",
+    "source_hash": "491f626d"
+  }
+}

--- a/locales/content/mi_NZ/api-domains-errors.json
+++ b/locales/content/mi_NZ/api-domains-errors.json
@@ -34,5 +34,17 @@
   "api.domains.errors.recipients_duplicate": {
     "text": "Kāore e whakaaetia ngā īmēra kaiwhiwhi tārua",
     "source_hash": "6de22182"
+  },
+  "api.domains.errors.homepage_secrets_mode_invalid": {
+    "text": "secrets_mode muhu: %{secrets_mode}",
+    "source_hash": "cf093a04"
+  },
+  "api.domains.errors.homepage_incoming_entitlement_required": {
+    "text": "Me whai te aratau karere huna tae mai i te whaimana incoming_secrets. Tēnā, whakapikihia tō mahere.",
+    "source_hash": "d68b13d8"
+  },
+  "api.domains.errors.homepage_incoming_not_ready": {
+    "text": "Me whakahohe te karere huna tae mai me te kaiwhiwhi kotahi neke atu i mua i te whakamahi hei whārangi kāinga.",
+    "source_hash": "556da6e2"
   }
 }

--- a/locales/content/mi_NZ/api-invite-errors.json
+++ b/locales/content/mi_NZ/api-invite-errors.json
@@ -12,8 +12,8 @@
     "source_hash": "a5df7d22"
   },
   "api.invite.errors.invitation_already_processed": {
-    "text": "Kua %{status} kētia te tono",
-    "source_hash": "130c87e0"
+    "text": "Kua tukatukatia kētia tēnei tono",
+    "source_hash": "4cfedf4f"
   },
   "api.invite.errors.invitation_expired": {
     "text": "Kua pau te tono",
@@ -26,5 +26,13 @@
   "api.invite.errors.already_member": {
     "text": "He mema kē koe nō tēnei whakahaere",
     "source_hash": "f56ad547"
+  },
+  "api.invite.errors.invitation_already_accepted": {
+    "text": "Kua whakaaetia kētia tēnei tono",
+    "source_hash": "8f9daf0f"
+  },
+  "api.invite.errors.invitation_already_declined": {
+    "text": "Kua whakakāhoretia kētia tēnei tono",
+    "source_hash": "96e0d626"
   }
 }

--- a/locales/content/mi_NZ/api-secrets-errors.json
+++ b/locales/content/mi_NZ/api-secrets-errors.json
@@ -10,5 +10,9 @@
   "api.secrets.errors.domain_permission_anonymous_cross_domain": {
     "text": "Kāore ōu whaimana ki te whakamahi i te rohe: %{domain}",
     "source_hash": "b41920ba"
+  },
+  "api.secrets.errors.secret_undecryptable": {
+    "text": "Kāore e taea te wetemuhu i tēnei karere huna i tēnei wā. Kei te ora tonu te hononga — me whakahoki te kaiwhakahaere pae i te kī whakamuhumuhu i mua i te whakaaturia.",
+    "source_hash": "56e283ee"
   }
 }

--- a/locales/content/mi_NZ/email.json
+++ b/locales/content/mi_NZ/email.json
@@ -62,7 +62,7 @@
   "email.welcome.signature": {
     "text": "Te Kapa Tautoko",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.welcome.postscript": {
     "text": "P.S. I tukuna tēnei īmēra ki %{email_address}. Mēnā kāore koe i waihanga pūkete, ka taea e koe te waiho i tēnei karere.",
@@ -102,7 +102,7 @@
   "email.password_request.signature": {
     "text": "Te Kapa Tautoko",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.password_request.postscript": {
     "text": "P.S. I tukuna tēnei īmēra ki %{email_address}.",
@@ -147,7 +147,7 @@
   "email.magic_link.signature": {
     "text": "Te Kapa Tautoko",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.magic_link.postscript": {
     "text": "P.S. I tukuna tēnei īmēra ki %{email_address}.",
@@ -232,7 +232,7 @@
   "email.secret_revealed.signature": {
     "text": "Te Kapa Tautoko",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.secret_revealed.manage_preferences": {
     "text": "Whakahaere manakohanga whakamōhiotanga",
@@ -357,7 +357,7 @@
   "email.organization_invitation.signature": {
     "text": "Te Kapa Tautoko",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.organization_invitation.postscript": {
     "text": "P.S. I tukuna tēnei īmēra ki %{invited_email}. Mēnā kāore koe i te tūmanako ki tēnei pōhiri, ka taea e koe te waiho i tēnei karere.",
@@ -397,17 +397,17 @@
   "email.password_changed.signature": {
     "text": "Te Kapa Tautoko",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_changed.subject": {
-    "text": "Kua hurihia tō wāhitau īmēra (%{display_domain})",
+    "text": "Kua panonihia tō wāhitau īmēra (%{display_domain})",
     "renderer": "erb",
-    "source_hash": "d68d2f4c"
+    "source_hash": "4386fc57"
   },
   "email.email_changed.title": {
-    "text": "Kua Hurihia Tō Wāhitau Īmēra",
+    "text": "Kua Panonihia Tō Wāhitau Īmēra",
     "renderer": "erb",
-    "source_hash": "62b07299"
+    "source_hash": "db70f965"
   },
   "email.email_changed.security_notice": {
     "text": "Mēnā ehara i a koe i huri i tēnei, tēnā whakapā tere ki te tautoko nā te mea tērā pea kua whakaekea tō pūkete.",
@@ -415,9 +415,9 @@
     "source_hash": "f505b562"
   },
   "email.email_changed.change_notice": {
-    "text": "Kua hurihia te wāhitau īmēra o tō pūkete %{product_name}.",
+    "text": "Kua panonihia te wāhitau īmēra i tō pūkete %{product_name}.",
     "renderer": "erb",
-    "source_hash": "bb467ebc"
+    "source_hash": "7fc0e27c"
   },
   "email.email_changed.new_email_label": {
     "text": "Īmēra hou:",
@@ -447,7 +447,7 @@
   "email.email_changed.signature": {
     "text": "Te Kapa Tautoko",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_changed.postscript": {
     "text": "Tāpiritanga: I tukuna tēnei īmēra ki %{email_address} hei whakamōhio i a koe mō te huringa wāhitau īmēra.",
@@ -497,7 +497,7 @@
   "email.email_change_requested.signature": {
     "text": "Te Kapa Tautoko",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_change_requested.postscript": {
     "text": "Tāpiritanga: I tukuna tēnei īmēra ki %{email_address} nā te mea i tonoa he huringa īmēra mō tō pūkete.",
@@ -552,7 +552,7 @@
   "email.email_change_confirmation.signature": {
     "text": "Te Kapa Tautoko",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_change_confirmation.postscript": {
     "text": "Tāpiritanga: I tukuna tēnei īmēra ki %{email_address} hei whakaū i te huringa wāhitau īmēra.",
@@ -582,7 +582,7 @@
   "email.mfa_enabled.signature": {
     "text": "Te Kapa Tautoko",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.mfa_disabled.subject": {
     "text": "Kua monokia te manatoko rua-āhuatanga (%{display_domain})",
@@ -607,7 +607,7 @@
   "email.mfa_disabled.signature": {
     "text": "Te Kapa Tautoko",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.new_login_alert.subject": {
     "text": "Takiuru hou ki tō pūkete (%{display_domain})",
@@ -652,7 +652,7 @@
   "email.new_login_alert.signature": {
     "text": "Te Kapa Tautoko",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.member_removed.subject": {
     "text": "Kua tangohia koe mai i %{organization_name}",
@@ -672,7 +672,7 @@
   "email.member_removed.signature": {
     "text": "Te Kapa Tautoko",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.role_changed.subject": {
     "text": "Kua hurihia tō tūranga i %{organization_name}",
@@ -692,7 +692,7 @@
   "email.role_changed.signature": {
     "text": "Te Kapa Tautoko",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.organization_deleted.subject": {
     "text": "Kua mukua te whakahaere \"%{organization_name}\"",
@@ -712,7 +712,7 @@
   "email.organization_deleted.signature": {
     "text": "Te Kapa Tautoko",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.trial_expiring.subject": {
     "text": "Ka pau tō whakamātautau %{product_name} i roto i ngā rā %{days_remaining}",
@@ -737,7 +737,7 @@
   "email.trial_expiring.signature": {
     "text": "Te Kapa Tautoko",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.subscription_changed.subject": {
     "text": "Kua hurihia tō ohaurunga %{product_name}",
@@ -762,7 +762,7 @@
   "email.subscription_changed.signature": {
     "text": "Te Kapa Tautoko",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.common.greeting": {
     "text": "Kia ora,",

--- a/locales/content/mi_NZ/feature-regions.json
+++ b/locales/content/mi_NZ/feature-regions.json
@@ -152,8 +152,8 @@
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "Mēnā he rerekē tō īmēra whakapā nama i tō īmēra pūkete {product_name}, whakamahia te īmēra whakapā nama mō te pūkete rohe hou kia pupuri ai i ngā painga o tō ohaurunga.",
-    "source_hash": "dac1cc28"
+    "text": "Mēnā he rerekē tō īmēra whakapā nama i te īmēra o tō pūkete {product_name}, whakamahia te īmēra whakapā nama mō te pūkete rohe hou hei pupuri i ngā painga o tō ohaurunga.",
+    "source_hash": "d49662b0"
   },
   "web.regions.changing_regions_subscription_note": {
     "text": "Ka tukuna aunoa ō painga ohaurunga ki ngā pūkete katoa i hangaia mā tō wāhitau īmēra nama.",

--- a/locales/content/mi_NZ/feature-translations.json
+++ b/locales/content/mi_NZ/feature-translations.json
@@ -65,7 +65,7 @@
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
     "text": "Kua tukua e ngā tāngata e whai ake nei tō rātou wā hei āwhina ki te whakawhānui i te toronga o {product_name}:",
-    "source_hash": "85a766af"
+    "source_hash": "6cc876ae"
   },
   "web.translations.translations": {
     "text": "Whakamāoritanga",
@@ -84,8 +84,8 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "Mai i te tau 2012, kua tuku {product_name} i tētahi ara haumaru ki te tohatoha mōhiohio tūmataiti puta noa i te ao. I te mea kei ngā rohe maha ngā kaiwhakamahi kāore te reo Ingarihi e noho hei reo matua, he mea waiwai ngā whakamāoritanga tika kia wātea ai te whakawhitiwhiti kōrero haumaru ki te katoa.",
-    "source_hash": "87a6e9af"
+    "text": "Mai i te tau 2012, kua whakaratohia e {product_name} tētahi huarahi haumaru ki te tohatoha i ngā mōhiohio tūmataiti puta noa i te ao. Nā te maha o ngā kaiwhakamahi puta noa i ngā rohe ehara nei te reo Ingarihi te reo matua, he mea nui ngā whakamāoritanga tōtika kia wātea ai te whakawhitiwhiti kōrero haumaru ki te katoa.",
+    "source_hash": "ded965d5"
   },
   "web.translations.help_secure_communication_go_global": {
     "text": "Āwhinatia te Whakapānga Haumaru Kia Ao Whānui",

--- a/locales/content/mi_NZ/secret-homepage.json
+++ b/locales/content/mi_NZ/secret-homepage.json
@@ -57,7 +57,7 @@
   },
   "web.homepage.visit_onetime_secret_home": {
     "text": "Toro ki te whārangi kāinga o {product_name}",
-    "source_hash": "625556d2"
+    "source_hash": "87802af5"
   },
   "web.homepage.password_generation_title": {
     "text": "Kaihanga Kupuhipa",
@@ -109,15 +109,15 @@
   },
   "web.homepage.about_onetime_secret_0": {
     "text": "Mō {product_name}",
-    "source_hash": "971c50da"
+    "source_hash": "b3046356"
   },
   "web.homepage.log_in_to_onetime_secret": {
     "text": "Takiuru ki {product_name}",
-    "source_hash": "bd6be8d6"
+    "source_hash": "b2e364a4"
   },
   "web.homepage.about_onetime_secret": {
     "text": "Mō {product_name}",
-    "source_hash": "971c50da"
+    "source_hash": "b3046356"
   },
   "web.homepage.signup_individual_and_business_plans": {
     "text": "Rēhita - Ngā mahere whaiaro me ngā mahere pakihi",
@@ -137,19 +137,19 @@
   },
   "web.homepage.onetime_secret": {
     "text": "{product_name}",
-    "source_hash": "1cd0194a"
+    "source_hash": "7bec5899"
   },
   "web.homepage.onetime_secret_literal": {
     "text": "{product_name}",
-    "source_hash": "1cd0194a"
+    "source_hash": "7bec5899"
   },
   "web.homepage.one_time_secret_literal": {
     "text": "{product_name}",
-    "source_hash": "7872e050"
+    "source_hash": "7bec5899"
   },
   "web.homepage.onetime_secret_homepage": {
-    "text": "Whārangi Kāinga {product_name}",
-    "source_hash": "44bb0581"
+    "text": "whārangi kāinga o {product_name}",
+    "source_hash": "0792b61e"
   },
   "web.homepage.send_sensitive_information_that_can_only_be_viewed_once": {
     "text": "Tukuna ngā mōhiohio hira kotahi noa te wā e taea ai te tiro",
@@ -169,11 +169,11 @@
   },
   "web.homepage.welcome_to_onetime_secret": {
     "text": "Nau mai ki {product_name}.",
-    "source_hash": "0990d163"
+    "source_hash": "f4f49058"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "Ka āwhina {product_name} i a mātou ki te tohatoha mōhiohio tūmataiti i runga i te āhua haumaru, me te pupuri tonu i tō mātou āhua ngaio.",
-    "source_hash": "986a0856"
+    "text": "Ka āwhina {product_name} i a mātou ki te tohatoha i ngā mōhiohio tūmataiti i runga i te haumaru me te pupuri i tō mātou āhua ngaio.",
+    "source_hash": "7e9192bd"
   },
   "web.homepage.information_shared_through_this_service_can_only": {
     "text": "Ko ngā mōhiohio i tuari mā tēnei ratonga ka taea te uru kotahi anake. Ka tirohia ana, ka mukua pūmautia te ihirangi hei whakaū i te noho muna.",
@@ -182,5 +182,13 @@
   "web.homepage.welcome_to_the_global_broadcast": {
     "text": "Nau mai ki te Pāho Ao!",
     "source_hash": "210e1894"
+  },
+  "web.homepage.send_a_secret": {
+    "text": "Tukua he karere huna",
+    "source_hash": "31fd9e03"
+  },
+  "web.homepage.deliver_sensitive_information_directly_and_securely": {
+    "text": "Tukua tōtika ngā mōhiohio tūmataiti ki tō mātou kapa. Kotahi anake te wā e taea ai te tiro.",
+    "source_hash": "9976cf01"
   }
 }

--- a/locales/content/mi_NZ/secret-manage.json
+++ b/locales/content/mi_NZ/secret-manage.json
@@ -56,8 +56,8 @@
     "source_hash": "2e5a27e1"
   },
   "web.secrets.sample_secret_content_this_could_be_sensitive_data": {
-    "text": "Tauira ihirangi karere huna Ka taea tēnei te raraunga tairongo Ko tētahi karere maha-rārangi rānei",
-    "source_hash": "b3be3902"
+    "text": "Ihirangi karere huna tauira. He raraunga tūmataiti pea tēnei\n\nHe karere rārangi-maha rānei",
+    "source_hash": "5e1bffcb"
   },
   "web.secrets.sample_secret_content": {
     "text": "Ihirangi karere huna tauira",
@@ -128,8 +128,8 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "Ko {product_name} he huarahi haumaru ki te tohatoha mōhiohio whakatakariri ka whakangaro ā-māia i muri i te tirohanga kotahi.",
-    "source_hash": "8a163297"
+    "text": "He huarahi haumaru {product_name} ki te tohatoha i ngā mōhiohio tūmataiti ka whakangaro i a ia anō i muri i te tirohanga kotahi.",
+    "source_hash": "bd0c6182"
   },
   "web.secrets.what_is_this": {
     "text": "He aha tēnei?",

--- a/locales/content/mi_NZ/session-auth-extended.json
+++ b/locales/content/mi_NZ/session-auth-extended.json
@@ -155,8 +155,8 @@
     "source_hash": "d726c0da"
   },
   "web.auth.magicLink.sessionExpired": {
-    "text": "Kua pau tō wātū. Whakahoutia te whārangi ka ngana anō.",
-    "source_hash": "a7c3e901"
+    "text": "Kua pau tō wātū. Tēnā, whakahouhia te whārangi ka ngana anō.",
+    "source_hash": "be9ed96d"
   },
   "web.auth.magicLink.loginFailed": {
     "text": "I rahua te takiuru. Tēnā whakamātauria anō.",

--- a/locales/content/mi_NZ/session-auth.json
+++ b/locales/content/mi_NZ/session-auth.json
@@ -373,8 +373,8 @@
     "source_hash": "afd25fdf"
   },
   "web.help.use_magic_link_instead": {
-    "text": "Whakamahia te kōwhiringa Hononga Karakia hei takiuru me te kore kupuhipa. Kia takiuru ana, ka taea e koe te huri i tō kupuhipa i ngā Tautuhinga Pūkete.",
-    "source_hash": "2a058600"
+    "text": "Ka taea e koe te tono i tētahi hononga tautuhi anō kupuhipa hei waihanga kupuhipa hou.",
+    "source_hash": "3c3eabad"
   },
   "web.help.account_locked": {
     "text": "Kua rakaina te pūkete mō te wā poto?",
@@ -431,5 +431,57 @@
   "web.login.errors.domain_not_allowed": {
     "text": "Kāore tō rohe īmēra i whakaaetia mō te rēhitatanga SSO. Tēnā whakapā atu ki tō kaiwhakahaere.",
     "source_hash": "87603782"
+  },
+  "web.auth.check_email.title": {
+    "text": "Tirohia tō īmēra",
+    "source_hash": "77322879"
+  },
+  "web.auth.check_email.sent_to_generic": {
+    "text": "Kua tukua e mātou he hononga manatoko ki tō wāhitau īmēra.",
+    "source_hash": "4e5510af"
+  },
+  "web.auth.check_email.help": {
+    "text": "Kua tukua e mātou he hononga manatoko ki tēnei wāhitau — whakatuwherahia te īmēra, ka pāwhiri i te hononga hei whakahohe i tō pūkete.",
+    "source_hash": "8babedc4"
+  },
+  "web.auth.check_email.spam_hint": {
+    "text": "Kāore e kitea? Tirohia tō kōpaki tāwaru.",
+    "source_hash": "d166d9a4"
+  },
+  "web.auth.check_email.wrong_email": {
+    "text": "I whakauru koe i te wāhitau hē?",
+    "source_hash": "0aa863e5"
+  },
+  "web.auth.check_email.start_over": {
+    "text": "Tīmata anō",
+    "source_hash": "5eed7e9f"
+  },
+  "web.auth.field-errors.password": {
+    "text": "Kupuhipa",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.auth.verify.resend_help_text": {
+    "text": "Kāore i tae te īmēra manatoko? Whakauruhia tō īmēra kia tukua anō.",
+    "source_hash": "e0df48bb"
+  },
+  "web.auth.verify.resend_button": {
+    "text": "Tuku Anō i te Īmēra Manatoko",
+    "source_hash": "5173cc04"
+  },
+  "web.auth.verify.resend_sent": {
+    "text": "Mēnā me manatoko tētahi pūkete, kua tukua he īmēra hou. Tēnā, tirohia tō pouaka tae mai me tō kōpaki tāwaru.",
+    "source_hash": "6f838ffb"
+  },
+  "web.auth.verify.resend_error": {
+    "text": "Kāore i taea te tuku i te īmēra manatoko. Tēnā, tirohia tō hononga ka ngana anō.",
+    "source_hash": "15149f46"
+  },
+  "web.auth.verify.resend_short": {
+    "text": "Tuku anō īmēra",
+    "source_hash": "4f44603e"
+  },
+  "web.login.verified_notice": {
+    "text": "Kua manatokona tō īmēra — ka taea e koe te takiuru ināianei.",
+    "source_hash": "c8d4b5a8"
   }
 }

--- a/locales/content/mi_NZ/workspace-account.json
+++ b/locales/content/mi_NZ/workspace-account.json
@@ -136,8 +136,8 @@
     "source_hash": "05986d95"
   },
   "web.account.keep_this_token_secure_it_provides_full_access_t": {
-    "text": "🔐 Tiakina tēnei tohu! Ka whakarato i te urunga katoa ki tō pūkete.",
-    "source_hash": "8839aa4d"
+    "text": "Kia haumaru tēnei tokena. Ka taea te whakamahi hei waihanga me te whakahaere karere huna mā te API.",
+    "source_hash": "a63cc8ec"
   },
   "web.account.confirm_with_your_password": {
     "text": "Whakaū ki tō kupuhipa",
@@ -328,8 +328,8 @@
     "source_hash": "f7cfed6e"
   },
   "web.settings.profile.email_change_success": {
-    "text": "Kua whakahōu te īmēra. Tēnā tirohia tō pouaka waipuke hei manatoko i tō wāhitau īmēra hou.",
-    "source_hash": "58de2536"
+    "text": "Kua tukua te īmēra manatoko. Tēnā, tirohia tō pouaka tae mai hou, ka pāwhiri i te hononga whakaū hei whakaoti i te panonitanga.",
+    "source_hash": "45f0a4b5"
   },
   "web.settings.profile.email_change_error": {
     "text": "I rahua te whakahōu i te īmēra. Tēnā whakamātauria anō.",
@@ -476,8 +476,8 @@
     "source_hash": "1cc77e60"
   },
   "web.settings.api.documentation_description": {
-    "text": "Akohia me pēhea te whakakotahi i a {product_name} ki ō taupānga",
-    "source_hash": "6e8f910f"
+    "text": "Akona te huarahi ki te whakauru i {product_name} ki ō taupānga",
+    "source_hash": "9bba1ae8"
   },
   "web.settings.api.rest_api_reference": {
     "text": "Tohutoro REST API",

--- a/locales/content/mi_NZ/workspace-billing.json
+++ b/locales/content/mi_NZ/workspace-billing.json
@@ -140,12 +140,12 @@
     "source_hash": "1f981aaf"
   },
   "web.billing.overview.no_organizations_title": {
-    "text": "Kāore he Whakahaere",
-    "source_hash": "12420110"
+    "text": "Kāore he Wāhi Mahi",
+    "source_hash": "c7f70723"
   },
   "web.billing.overview.no_organizations_description": {
-    "text": "Waihanga he whakahaere hei whakahaere i tō pire me te ohaurunga",
-    "source_hash": "41e922d2"
+    "text": "Waihanga i tētahi Wāhi Mahi hei whakahaere i tō nama me tō ohaurunga",
+    "source_hash": "e0fd27a5"
   },
   "web.billing.overview.load_error": {
     "text": "I hapa te uta i ngā mōhiohio nama",
@@ -204,8 +204,8 @@
     "source_hash": "883dbca9"
   },
   "web.billing.overview.entitlements.manage_org": {
-    "text": "Whakahaere ngā Whakahaere",
-    "source_hash": "be0fe4c3"
+    "text": "Whakahaere Rōpū",
+    "source_hash": "f03a4985"
   },
   "web.billing.overview.entitlements.manage_teams": {
     "text": "Whakahaere ngā Rōpū",
@@ -220,8 +220,8 @@
     "source_hash": "5428d7fe"
   },
   "web.billing.overview.entitlements.sso": {
-    "text": "Takiuru Kotahi",
-    "source_hash": "cf7cd744"
+    "text": "Takiuru Kotahi (SSO)",
+    "source_hash": "5db5c812"
   },
   "web.billing.overview.entitlements.priority_support": {
     "text": "Tautoko Tuatahi",
@@ -281,7 +281,7 @@
   },
   "web.billing.features.sso": {
     "text": "Takiuru Kotahi (SSO)",
-    "source_hash": "5db5c812"
+    "source_hash": "5ba3ac9f"
   },
   "web.billing.features.priority_support": {
     "text": "Tautoko Tuatahi",
@@ -577,7 +577,7 @@
   },
   "web.billing.invoices.draft": {
     "text": "Tauira",
-    "source_hash": "d2e16e61"
+    "source_hash": "ebf12ef4"
   },
   "web.billing.invoices.open": {
     "text": "Tuwhera",

--- a/locales/content/mi_NZ/workspace-branding.json
+++ b/locales/content/mi_NZ/workspace-branding.json
@@ -28,8 +28,8 @@
     "source_hash": "199c165f"
   },
   "web.branding.preview_and_customize": {
-    "text": "Arokite & Whakaritenga",
-    "source_hash": "215d3659"
+    "text": "Whakarite & Arokite",
+    "source_hash": "fc68a28c"
   },
   "web.branding.switch_to_safari_browser_view": {
     "text": "Huri ki te tirohanga tirotiro Safari",
@@ -88,8 +88,8 @@
     "source_hash": "43e9a2d7"
   },
   "web.branding.click_to_upload_a_logo_with_recommendation": {
-    "text": "Pāwhiri ki te tukuake i tētahi tohu. Rahinga tūtohu: 128x128 ngā pika. Rahi kōnae mōrahi: 1MB. Ngā whakatakotoranga tautokona: PNG, JPG, SVG",
-    "source_hash": "a35452bf"
+    "text": "Pāwhiri hei whakahaere i tō tohu. Rahi tūtohua: 128x128 pika. Rahi kōnae mōrahi: 1MB. Ngā hōputu tautoko: PNG, JPG, SVG",
+    "source_hash": "7bb92395"
   },
   "web.branding.upload_logo": {
     "text": "Tukuake moko",
@@ -186,5 +186,225 @@
   "web.branding.keyhole_logo_icon": {
     "text": "Ata pūwhare e tohu ana i te tohatoha haumaru, tūmataiti",
     "source_hash": "c868ac60"
+  },
+  "web.branding.secondary_color": {
+    "text": "Tae Tuarua",
+    "source_hash": "1f4728f6"
+  },
+  "web.branding.background_color": {
+    "text": "Tae Papamuri",
+    "source_hash": "b48bc969"
+  },
+  "web.branding.text_color": {
+    "text": "Tae Kuputuhi",
+    "source_hash": "2ea23234"
+  },
+  "web.branding.border_radius": {
+    "text": "Pūrā Tapa",
+    "source_hash": "e758d7db"
+  },
+  "web.branding.heading_font": {
+    "text": "Momotuhi Pane",
+    "source_hash": "6b5d30dc"
+  },
+  "web.branding.theme_presets": {
+    "text": "Ngā Tautuhinga Kaupapa",
+    "source_hash": "931eeb74"
+  },
+  "web.branding.logo": {
+    "text": "Tohu",
+    "source_hash": "d707dc2f"
+  },
+  "web.branding.replace_logo": {
+    "text": "Whakakapi",
+    "source_hash": "95e15439"
+  },
+  "web.branding.logo_field_hint": {
+    "text": "Arokitea i mua i te ora o ō huringa.",
+    "source_hash": "e9e222fc"
+  },
+  "web.branding.logo_modal_title": {
+    "text": "Tohu rohe",
+    "source_hash": "5260dda5"
+  },
+  "web.branding.logo_modal_hint": {
+    "text": "PNG, JPG, SVG rānei. Tūtohua 128x128px, tae atu ki te 1MB.",
+    "source_hash": "75d00802"
+  },
+  "web.branding.logo_modal_save": {
+    "text": "Tiaki tohu",
+    "source_hash": "8b028a6f"
+  },
+  "web.branding.remove_logo": {
+    "text": "Tango tohu",
+    "source_hash": "f1c1afa4"
+  },
+  "web.branding.image_upload_choose": {
+    "text": "Kōwhiria he whakaahua",
+    "source_hash": "ceed9fd5"
+  },
+  "web.branding.image_upload_drag_hint": {
+    "text": "tō, tuku rānei",
+    "source_hash": "6613b73c"
+  },
+  "web.branding.image_invalid_type": {
+    "text": "Kāore taua momo kōnae e tautokona. Tēnā, kōwhiria he whakaahua.",
+    "source_hash": "50e18866"
+  },
+  "web.branding.image_too_large": {
+    "text": "He rahi rawa te whakaahua. Ko te rahi mōrahi ko {max}.",
+    "source_hash": "b50b55e2"
+  },
+  "web.branding.image_will_be_removed": {
+    "text": "Ka tangohia tēnei tohu ina tiaki koe.",
+    "source_hash": "d94fa99a"
+  },
+  "web.branding.image_upload_failed": {
+    "text": "I hē tētahi mea. Tēnā, ngana anō.",
+    "source_hash": "3ccd9d65"
+  },
+  "web.branding.undo": {
+    "text": "Whakahoki",
+    "source_hash": "a8283ade"
+  },
+  "web.branding.low_contrast_text_bg_warning": {
+    "text": "He iti te rerekētanga kuputuhi/papamuri",
+    "source_hash": "1c676370"
+  },
+  "web.branding.path_simple": {
+    "text": "Māmā",
+    "source_hash": "3fee95da"
+  },
+  "web.branding.path_match": {
+    "text": "Whakaōrite ki taku pae",
+    "source_hash": "776679cf"
+  },
+  "web.branding.path_advanced": {
+    "text": "Matatau",
+    "source_hash": "9f088dbe"
+  },
+  "web.branding.path_simple_tag": {
+    "text": "Ō waitohu matua.",
+    "source_hash": "7c9c0cca"
+  },
+  "web.branding.path_match_tag": {
+    "text": "Tāruatia ngā tautuhinga mai i tētahi pae kua tū.",
+    "source_hash": "e4b0d1cd"
+  },
+  "web.branding.path_advanced_tag": {
+    "text": "Hangaia tāu ake CSS Tailwind v4.",
+    "source_hash": "2405bb6d"
+  },
+  "web.branding.badge_default": {
+    "text": "Taunoa",
+    "source_hash": "21b111cb"
+  },
+  "web.branding.badge_coming_soon": {
+    "text": "E tae mai ana",
+    "source_hash": "4f7d6401"
+  },
+  "web.branding.your_brand": {
+    "text": "Tō waitohu",
+    "source_hash": "406265d3"
+  },
+  "web.branding.your_brand_subtitle": {
+    "text": "He kōwhiringa tere torutoru — mā mātou te toenga.",
+    "source_hash": "dbc8ec33"
+  },
+  "web.branding.corners": {
+    "text": "Ngā Koki",
+    "source_hash": "1d3cc47e"
+  },
+  "web.branding.more_options": {
+    "text": "Ētahi atu kōwhiringa",
+    "source_hash": "bc79cdff"
+  },
+  "web.branding.paths_carryover_hint": {
+    "text": "He arokite ora tēnei — kāore ō huringa e kitea e ngā manuhiri kia tiaki rā anō koe.",
+    "source_hash": "cb4b82de"
+  },
+  "web.branding.coming_soon_match_blurb": {
+    "text": "Tohua mai tō paetukutuku, ka pānui mātou i ōna tae me ōna momotuhi, kātahi ka kati i te āputa i te pāwhiri kotahi.",
+    "source_hash": "42c34cc1"
+  },
+  "web.branding.coming_soon_advanced_blurb": {
+    "text": "Whakatikahia ngā tokena {'@'}theme Tailwind v4 tōtika, whakapiritia rānei tāu ake pepa kāhua.",
+    "source_hash": "5a8473f5"
+  },
+  "web.branding.preview_recipient_page": {
+    "text": "Whārangi kaiwhiwhi",
+    "source_hash": "de8aa19f"
+  },
+  "web.branding.preview_badge": {
+    "text": "Arokite",
+    "source_hash": "324b134f"
+  },
+  "web.branding.preview_homepage_enabled": {
+    "text": "Whārangi kāinga · kua whakahohea",
+    "source_hash": "2edd85f1"
+  },
+  "web.branding.preview_homepage_disabled": {
+    "text": "Whārangi kāinga · kua monokia",
+    "source_hash": "15d87050"
+  },
+  "web.branding.preview_live": {
+    "text": "Arokite ora",
+    "source_hash": "f65ddc1f"
+  },
+  "web.branding.tile_share_secret": {
+    "text": "Tohatoha i tētahi karere huna",
+    "source_hash": "5384461b"
+  },
+  "web.branding.tile_create_link": {
+    "text": "Waihanga hononga huna",
+    "source_hash": "610fd42e"
+  },
+  "web.branding.tile_delivery_only": {
+    "text": "Te tuku karere haumaru anake",
+    "source_hash": "dc24dec2"
+  },
+  "web.branding.tile_no_create": {
+    "text": "Kāore e taea e ngā manuhiri te waihanga karere huna ki konei.",
+    "source_hash": "17361d81"
+  },
+  "web.branding.recipient_page_content": {
+    "text": "Ihirangi whārangi kaiwhiwhi",
+    "source_hash": "937733bd"
+  },
+  "web.branding.recipient_page_content_hint": {
+    "text": "Ngā tohutohu reo me te whakaatu ka whakaaturia ki ngā kaiwhiwhi i tēnei rohe.",
+    "source_hash": "04162b70"
+  },
+  "web.branding.tab_brand": {
+    "text": "Waitohu",
+    "source_hash": "090ed431"
+  },
+  "web.branding.tab_delivery": {
+    "text": "Tuku",
+    "source_hash": "52bfe584"
+  },
+  "web.branding.delivery_language": {
+    "text": "Reo",
+    "source_hash": "a4fe6526"
+  },
+  "web.branding.delivery_language_hint": {
+    "text": "Taunoa mō ngā whārangi kaiwhiwhi me ngā īmēra i tēnei rohe. Ka taea e ngā kaiwhiwhi te huri reo i te whārangi.",
+    "source_hash": "bfbc5599"
+  },
+  "web.branding.delivery_reveal_instructions": {
+    "text": "Tohutohu whakaatu",
+    "source_hash": "7e1331f7"
+  },
+  "web.branding.delivery_reveal_instructions_hint": {
+    "text": "Ka whakaaturia i te whārangi kaiwhiwhi. Waiho wātea hei whakamahi i te kuputuhi tōmua i te reo kua tīpakohia.",
+    "source_hash": "51b9811d"
+  },
+  "web.branding.delivery_before_reveal": {
+    "text": "I mua i te whakaatu",
+    "source_hash": "5ce82b01"
+  },
+  "web.branding.delivery_after_reveal": {
+    "text": "I muri i te whakaatu",
+    "source_hash": "d5bfe7fd"
   }
 }

--- a/locales/content/mi_NZ/workspace-domains.json
+++ b/locales/content/mi_NZ/workspace-domains.json
@@ -76,8 +76,8 @@
     "source_hash": "59be7133"
   },
   "web.domains.enabled": {
-    "text": "Kua Whakahohea",
-    "source_hash": "92c1cdfd"
+    "text": "Whakahohe",
+    "source_hash": "5342e09f"
   },
   "web.domains.disabled": {
     "text": "Kua Monokia",
@@ -1358,5 +1358,189 @@
   "web.domains.sso.upgrade_required": {
     "text": "Whakapiki kia whirihora",
     "source_hash": "571cfa98"
+  },
+  "web.domains.add.field_label": {
+    "text": "Rohe ritenga",
+    "source_hash": "d7d4c1e4"
+  },
+  "web.domains.add.field_help": {
+    "text": "Te ingoa kaihautū tōtika ka whakamahia e tō kapa, pēnei i {example}.",
+    "source_hash": "3ba71f78"
+  },
+  "web.domains.add.echo_label": {
+    "text": "Ka noho ō hononga huna ki",
+    "source_hash": "ad60b17d"
+  },
+  "web.domains.add.apex_question": {
+    "text": "Koinā tō rohe katoa — ki hea ngā hononga huna noho ai?",
+    "source_hash": "efacad1b"
+  },
+  "web.domains.add.apex_help": {
+    "text": "Ka waiho te rohe-iti i te toenga o {domain} kia pā-kore.",
+    "source_hash": "0f7e6181"
+  },
+  "web.domains.add.recommended": {
+    "text": "Tūtohua",
+    "source_hash": "d70604e8"
+  },
+  "web.domains.add.no_wrong_answer": {
+    "text": "Kāore he kōwhiringa hē — tīpakohia te mea ka mōhio tō kapa.",
+    "source_hash": "a04f0086"
+  },
+  "web.domains.add.subdomains_label": {
+    "text": "Ngā rohe-iti rongonui",
+    "source_hash": "d6ee8eac"
+  },
+  "web.domains.add.root_group_label": {
+    "text": "Whakamahia rānei tō rohe katoa",
+    "source_hash": "5c23c007"
+  },
+  "web.domains.add.root_domain_label": {
+    "text": "Whakamahia taku rohe pakiaka",
+    "source_hash": "9fbbe253"
+  },
+  "web.domains.add.root_domain_description": {
+    "text": "Ka tohu tēnei i te katoa o {domain} ki a mātou — ka mutu te whakatau o te pae i reira — me whai i tētahi tuhinga A / ALIAS.",
+    "source_hash": "fae93847"
+  },
+  "web.domains.add.error_unrecognized_suffix": {
+    "text": "Ehara “.{0}” i te mutunga rohe e mōhiotia ana — tirohia mō te hapa (hei tauira, {1}).",
+    "source_hash": "4b90033d"
+  },
+  "web.domains.add.error_invalid_hostname": {
+    "text": "Whakauruhia he ingoa kaihautū whaimana — ngā reta, tau, ira takitahi me ngā tākupu (hei tauira, {0}).",
+    "source_hash": "c4ceabc1"
+  },
+  "web.domains.add.error_empty": {
+    "text": "Tēnā, whakauruhia he ingoa rohe.",
+    "source_hash": "d8e2c1e4"
+  },
+  "web.domains.add.continue_with": {
+    "text": "Haere tonu me {0}",
+    "source_hash": "73f8ab40"
+  },
+  "web.domains.auth_override.workspace_default_badge": {
+    "text": "Taunoa Wāhi Mahi",
+    "source_hash": "da3706ee"
+  },
+  "web.domains.detail.dns_title": {
+    "text": "Whakaritenga DNS",
+    "source_hash": "6c63df31"
+  },
+  "web.domains.detail.dns_description": {
+    "text": "Tohua tō rohe ki tēnei tūmau mā tētahi tuhinga CNAME",
+    "source_hash": "080f84f0"
+  },
+  "web.domains.dns.title": {
+    "text": "Whirihoranga DNS",
+    "source_hash": "da78c35d"
+  },
+  "web.domains.dns.point_domain_intro": {
+    "text": "Tohua",
+    "source_hash": "2fc0c524"
+  },
+  "web.domains.dns.point_domain_outro": {
+    "text": "ki tēnei tūmau mā te tāpiri i te tuhinga DNS e whai ake nei me tō kaiwhakarato.",
+    "source_hash": "8d260c05"
+  },
+  "web.domains.dns.cname_heading": {
+    "text": "Waihanga i tētahi tuhinga CNAME",
+    "source_hash": "11aeef5a"
+  },
+  "web.domains.dns.apex_heading": {
+    "text": "Waihanga i tētahi tuhinga ALIAS, ANAME rānei",
+    "source_hash": "41135375"
+  },
+  "web.domains.dns.apex_notice": {
+    "text": "Kāore e taea e ngā rohe tihi (pakiaka) te whakamahi tuhinga CNAME. Engari, whakamahia te tuhinga ALIAS, ANAME rānei a tō kaiwhakarato DNS, tohua rānei he tuhinga A ki te wāhitau IP o tō tūmau.",
+    "source_hash": "2d1c3298"
+  },
+  "web.domains.email.from_address_local_placeholder": {
+    "text": "no-reply",
+    "source_hash": "510d274d"
+  },
+  "web.domains.homepage.title": {
+    "text": "Whārangi kāinga",
+    "source_hash": "9e3391e9"
+  },
+  "web.domains.homepage.description": {
+    "text": "Ngā mea ka taea e ngā manuhiri i tō whārangi kāinga rohe",
+    "source_hash": "974d159e"
+  },
+  "web.domains.homepage.option_private_title": {
+    "text": "Whārangi taunga tūmataiti",
+    "source_hash": "dfd5bd1c"
+  },
+  "web.domains.homepage.option_private_description": {
+    "text": "Ka kite ngā manuhiri i tētahi whārangi taunga tūmataiti, kāore he puka pāhekoheko",
+    "source_hash": "4d9aaf6f"
+  },
+  "web.domains.homepage.option_create_title": {
+    "text": "Puka waihanga karere huna",
+    "source_hash": "6539dfc1"
+  },
+  "web.domains.homepage.option_create_description": {
+    "text": "Ka taea e ngā manuhiri te waihanga i ā rātou ake hononga huna",
+    "source_hash": "884310f4"
+  },
+  "web.domains.homepage.option_incoming_title": {
+    "text": "Puka karere huna tae mai",
+    "source_hash": "882997bf"
+  },
+  "web.domains.homepage.option_incoming_description": {
+    "text": "Ka taea e ngā manuhiri te tuku karere huna ki ō kaiwhiwhi kua whirihorahia",
+    "source_hash": "86bdaedb"
+  },
+  "web.domains.homepage.incoming_requires_recipients": {
+    "text": "Me whakahohe te karere huna tae mai me te kaiwhiwhi kotahi neke atu",
+    "source_hash": "0462611d"
+  },
+  "web.domains.homepage.configure_recipients": {
+    "text": "Whirihora kaiwhiwhi",
+    "source_hash": "1c3df8b4"
+  },
+  "web.domains.homepage.status_private": {
+    "text": "Whārangi taunga tūmataiti",
+    "source_hash": "dfd5bd1c"
+  },
+  "web.domains.homepage.status_create": {
+    "text": "Tūmatanui: ka waihanga ngā manuhiri i ngā karere huna",
+    "source_hash": "251cfb95"
+  },
+  "web.domains.homepage.status_incoming": {
+    "text": "Tūmatanui: ka tukua e ngā manuhiri he karere huna ki a koe",
+    "source_hash": "baa926b8"
+  },
+  "web.domains.homepage.status_incoming_unready": {
+    "text": "Kāore anō te tae mai kia rite — e whakaatu ana i te whārangi taunga tūmataiti",
+    "source_hash": "a5cc237c"
+  },
+  "web.domains.homepage.badge_incoming": {
+    "text": "Tae Mai",
+    "source_hash": "e301820a"
+  },
+  "web.domains.homepage.update_success": {
+    "text": "Kua tiakina ngā tautuhinga whārangi kāinga",
+    "source_hash": "4eac9f45"
+  },
+  "web.domains.homepage.homepage_uses_incoming_warning": {
+    "text": "Kei te whakaatu te whārangi kāinga o tēnei rohe i te puka karere huna tae mai i tēnei wā. Ki te monokia te karere huna tae mai, ki te tangohia rānei ngā kaiwhiwhi katoa, ka huri te whārangi kāinga ki tētahi whārangi taunga tūmataiti kia rite anō te tae mai.",
+    "source_hash": "cc0d4997"
+  },
+  "web.domains.signin.effective_status_label": {
+    "text": "Takiuru i tēnei rohe",
+    "source_hash": "d8b884c3"
+  },
+  "web.domains.signin.dormant_notice": {
+    "text": "Kua whakawetohia te takiuru puta noa i te Wāhi Mahi, nā reira kāore e wātea ana i ia rohe. Ka puritia ō tautuhinga ki konei, ka mana ina whakahohea anō te takiuru Wāhi Mahi.",
+    "source_hash": "723d35dc"
+  },
+  "web.domains.signup.effective_status_label": {
+    "text": "Ngā rēhitatanga i tēnei rohe",
+    "source_hash": "115ab21b"
+  },
+  "web.domains.signup.dormant_notice": {
+    "text": "Kua whakawetohia ngā rēhitatanga puta noa i te Wāhi Mahi, nā reira kāore e wātea ana i ia rohe. Ka puritia ō tautuhinga ki konei, ka mana ina whakahohea anō ngā rēhitatanga Wāhi Mahi.",
+    "source_hash": "49faefe4"
   }
 }

--- a/locales/content/mi_NZ/workspace-organizations.json
+++ b/locales/content/mi_NZ/workspace-organizations.json
@@ -4,8 +4,8 @@
     "source_hash": "2730183d"
   },
   "web.organizations.organization": {
-    "text": "Whakahaere",
-    "source_hash": "d764d425"
+    "text": "Wāhi Mahi",
+    "source_hash": "87bb59ba"
   },
   "web.organizations.organization_plural": {
     "text": "Ngā Whakahaere",
@@ -16,24 +16,24 @@
     "source_hash": "dbaa4f92"
   },
   "web.organizations.my_organizations": {
-    "text": "Ngā Whakahaere",
-    "source_hash": "2730183d"
+    "text": "Ngā Wāhi Mahi",
+    "source_hash": "1377264b"
   },
   "web.organizations.manage_organizations": {
-    "text": "Whakahaere ngā Whakahaere",
-    "source_hash": "be0fe4c3"
+    "text": "Whakahaere Wāhi Mahi",
+    "source_hash": "cc2d65f8"
   },
   "web.organizations.new_organization": {
     "text": "Whakahaere Hou",
     "source_hash": "4876e647"
   },
   "web.organizations.no_organizations": {
-    "text": "Kāore anō he whakahaere",
-    "source_hash": "5b7a7cbd"
+    "text": "Kāore anō he Wāhi Mahi",
+    "source_hash": "97d0b117"
   },
   "web.organizations.no_organizations_description": {
-    "text": "He pire me te whakahaere kotahi e whakaratohia ana e ngā whakahaere. Tīmata mā te waihanga i tō whakahaere tuatahi.",
-    "source_hash": "deab4304"
+    "text": "Ka whakaratohia e ngā Wāhi Mahi te nama me te whakahaere kotahitanga. Tīmata mā te waihanga i tō Wāhi Mahi tuatahi.",
+    "source_hash": "f09d4987"
   },
   "web.organizations.no_description": {
     "text": "Kāore he whakamārama i whakaratohia",
@@ -48,24 +48,24 @@
     "source_hash": "e27f4540"
   },
   "web.organizations.create_first_organization": {
-    "text": "Waihanga Whakahaere Tuatahi",
-    "source_hash": "27bae486"
+    "text": "Waihanga Wāhi Mahi Tuatahi",
+    "source_hash": "98a583b4"
   },
   "web.organizations.create_organization_description": {
-    "text": "Waihanga whakahaere hou",
-    "source_hash": "67cd5950"
+    "text": "Waihanga i tētahi Wāhi Mahi hou",
+    "source_hash": "6ac2b5fc"
   },
   "web.organizations.create": {
     "text": "Waihanga",
     "source_hash": "4759498a"
   },
   "web.organizations.create_error": {
-    "text": "I rahua te waihanga i te whakahaere",
-    "source_hash": "f2204373"
+    "text": "I rahu te waihanga Wāhi Mahi",
+    "source_hash": "0a8d4fd6"
   },
   "web.organizations.organization_name": {
-    "text": "Ingoa Whakahaere",
-    "source_hash": "4cbd9073"
+    "text": "Ingoa Wāhi Mahi",
+    "source_hash": "6fa5a5b1"
   },
   "web.organizations.organization_name_placeholder": {
     "text": "hei tauira, Acme Corporation",
@@ -92,12 +92,12 @@
     "source_hash": "ee81c03d"
   },
   "web.organizations.select_organization": {
-    "text": "Kōwhiria he whakahaere",
-    "source_hash": "48326f52"
+    "text": "Tīpakohia tētahi Wāhi Mahi",
+    "source_hash": "70a8ce66"
   },
   "web.organizations.switcher_locked": {
-    "text": "Kāore e wātea ana te huri whakahaere i tēnei whārangi",
-    "source_hash": "da0cf810"
+    "text": "Kāore te huri Wāhi Mahi e wātea ana i tēnei whārangi",
+    "source_hash": "c34114ac"
   },
   "web.organizations.not_found": {
     "text": "Kāore i kitea te whakahaere",
@@ -208,8 +208,8 @@
     "source_hash": "7ecc5d35"
   },
   "web.organizations.tabs.members": {
-    "text": "Rōpū",
-    "source_hash": "5985039f"
+    "text": "Ngā Mema",
+    "source_hash": "1044a4c0"
   },
   "web.organizations.tabs.billing": {
     "text": "Pire",
@@ -468,8 +468,8 @@
     "source_hash": "424a2551"
   },
   "web.organizations.invitations.roles.member": {
-    "text": "Mema",
-    "source_hash": "7c968fb7"
+    "text": "Mema Kapa",
+    "source_hash": "d4e55dfa"
   },
   "web.organizations.invitations.roles.admin": {
     "text": "Kaiwhakahaere",
@@ -532,8 +532,8 @@
     "source_hash": "5e3f8df8"
   },
   "web.organizations.invitations.upgrade_prompt": {
-    "text": "Me whai mahere me te whakahaere rōpū mō ngā pōhiri mema rōpū. Whakapiki hei tāpiri kaihonohono ki tō whakahaere.",
-    "source_hash": "cf10d623"
+    "text": "Me whai te tono mema i tētahi mahere utu. Whakapikihia hei tāpiri kaimahi tahi ki tō whakahaere.",
+    "source_hash": "47d0eeab"
   },
   "web.organizations.paid_badge": {
     "text": "Pro",
@@ -556,8 +556,8 @@
     "source_hash": "ced67718"
   },
   "web.organizations.invitations.email_mismatch_title": {
-    "text": "Kua takiuru ki pūkete kē",
-    "source_hash": "4a2f91c3"
+    "text": "He pūkete kē kua takiuru",
+    "source_hash": "6516362a"
   },
   "web.organizations.invitations.email_mismatch_body": {
     "text": "Ko tēnei pōhiri mō {invitedEmail}. Kei te takiuru koe ināianei hei {currentEmail}.",
@@ -565,7 +565,7 @@
   },
   "web.organizations.invitations.continue_as_invited_email": {
     "text": "Haere tonu hei {email}",
-    "source_hash": "6c9a1d4e"
+    "source_hash": "ccf9745d"
   },
   "web.organizations.invitations.expires_in_days": {
     "text": "{days}r e toe ana",
@@ -1026,5 +1026,9 @@
   "web.organizations.tabs.sso": {
     "text": "SSO",
     "source_hash": "5ba3ac9f"
+  },
+  "web.organizations.create_workspace": {
+    "text": "Waihanga Wāhi Mahi",
+    "source_hash": "c63c14cf"
   }
 }


### PR DESCRIPTION
## `mi_NZ` translation update

Automated export of completed **mi_NZ** translations from the translation task DB.
Scope: `locales/content/mi_NZ/` only — 33 file(s), +3706/-112.

ℹ️ Variable validation not run.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-opus-4-8`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ✅ Looks good — vars intact, terminology consistent

**Summary:** New admin-console suite (16 files) plus content edits for mi_NZ. Manually verified every placeholder against source since the variable check was not run; all preserved. Brand/technical carve-outs (Colonel, Stripe, Redis INFO, DNS, SSO, CIDR, User Agent, Approximated/Passthrough/External, `{'@'}` Vue escapes) match established mi_NZ conventions.

**Critical (must fix):** None

**Warnings:** None

**Notes:**
- Variable validator reported "Not run." I hand-checked all interpolations: `{count}`, `{ip}`, `{email}`, `{org}`, `{domain}`, `{provider}`, `{accepted}/{rejected}/{fetched}`, `{shown}/{anonymous}/{scanned}`, numbered `{0}/{1}`, `%{secrets_mode}`, `{'@'}` literals — all match English source, none dropped/renamed/added.
- Ongoing org→Wāhi Mahi (Workspace) rename is partial within `workspace-organizations.json`: user-facing keys renamed (`my_organizations`, `create_first_organization`) while others retain "Whakahaere" (`new_organization`, `not_found`, `organization_plural`). This is the deliberate partial-mirror split (billing/user surfaces → Workspace; admin/plural → Organization) applied across all locales this round, not a defect.
- Signature source_hash churn (`f58154f7`→`dc75bf9f`) with unchanged text "Te Kapa Tautoko" is a source-hash bump only.
- `email_changed`: "hurihia"→"panonihia" and homepage/manage prose rewrites are quality edits, semantically equivalent to source.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
