### PR TITLE
i18n: update pt_PT translations

### DIFF
--- a/locales/content/pt_PT/00-common.json
+++ b/locales/content/pt_PT/00-common.json
@@ -1267,8 +1267,8 @@
     "source_hash": "cb2f00d1"
   },
   "web.TITLES.organizations_settings": {
-    "text": "Organizações",
-    "source_hash": "2730183d"
+    "text": "Espaços de trabalho",
+    "source_hash": "1377264b"
   },
   "web.TITLES.organization_settings": {
     "text": "Definições da organização",
@@ -1299,8 +1299,8 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Verifica sempre se estás no site oficial do {product_name}. Os burlões criam por vezes sites falsos que parecem exatamente iguais ao {product_name} para roubar as tuas mensagens confidenciais. Para evitares ataques de phishing, confirma o domínio da região antes de criares novos links.",
-    "source_hash": "68ec20f8"
+    "text": "Verifica sempre se estás no site oficial do {product_name}. Os burlões criam por vezes sites falsos que parecem exatamente iguais ao {product_name} para roubar as tuas mensagens confidenciais. Para evitar ataques de phishing, verifica o domínio da região na barra de endereço antes de criares novos links.",
+    "source_hash": "2e3b856e"
   },
   "web.pricing.title": {
     "text": "Preços simples e transparentes",
@@ -1523,5 +1523,21 @@
   "web.TITLES.domain_incoming": {
     "text": "Mensagens confidenciais recebidas",
     "source_hash": "883dbca9"
+  },
+  "web.LABELS.update": {
+    "text": "Atualizar",
+    "source_hash": "c1c1009d"
+  },
+  "web.LABELS.updating": {
+    "text": "A atualizar...",
+    "source_hash": "0a4e0b71"
+  },
+  "web.TITLES.check_email": {
+    "text": "Verifica o teu e-mail",
+    "source_hash": "0e5fc27d"
+  },
+  "web.TITLES.domain_dns": {
+    "text": "Configuração de DNS",
+    "source_hash": "6c63df31"
   }
 }

--- a/locales/content/pt_PT/10-layout.json
+++ b/locales/content/pt_PT/10-layout.json
@@ -101,11 +101,11 @@
   },
   "web.footer.product": {
     "text": "Produto",
-    "source_hash": "7f5540e9"
+    "source_hash": "fb9ef894"
   },
   "web.footer.source_code_purveyor": {
     "text": "Código-fonte",
-    "source_hash": "29c5c68f"
+    "source_hash": "bc47da66"
   },
   "web.navigation.billing": {
     "text": "Faturação",
@@ -149,7 +149,7 @@
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
     "text": "Estás a ver uma mensagem segura que foi partilhada contigo através do {product_name}. Este conteúdo é apresentado apenas uma vez e depois eliminado permanentemente dos nossos servidores.",
-    "source_hash": "e0f1a10c"
+    "source_hash": "7a4e9d16"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
     "text": "Posso ver esta mensagem confidencial novamente mais tarde?",
@@ -265,7 +265,7 @@
   },
   "web.layout.visit_onetime_secret_homepage": {
     "text": "Visitar a página inicial do {product_name}",
-    "source_hash": "625556d2"
+    "source_hash": "87802af5"
   },
   "web.layout.footer_navigation": {
     "text": "Navegação do rodapé",
@@ -346,5 +346,9 @@
   "web.help.default_content": {
     "text": "Contacta o suporte para obteres assistência",
     "source_hash": "752bca14"
+  },
+  "web.layout.colonels_only_badge": {
+    "text": "Apenas Colonels",
+    "source_hash": "3f1e2dbd"
   }
 }

--- a/locales/content/pt_PT/admin-audit.json
+++ b/locales/content/pt_PT/admin-audit.json
@@ -1,0 +1,102 @@
+{
+  "web.admin.audit.title": {
+    "text": "Registo de auditoria",
+    "source_hash": "47751f88"
+  },
+  "web.admin.audit.description": {
+    "text": "Todas as ações administrativas que efetuam alterações, das mais recentes para as mais antigas — quem fez o quê a quem, e como correu.",
+    "source_hash": "2326a1a0"
+  },
+  "web.admin.audit.categories.customer": {
+    "text": "Clientes",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.audit.categories.session": {
+    "text": "Sessões",
+    "source_hash": "6fa3cbf4"
+  },
+  "web.admin.audit.categories.domain": {
+    "text": "Domínios",
+    "source_hash": "ced67718"
+  },
+  "web.admin.audit.categories.organization": {
+    "text": "Organizações",
+    "source_hash": "2730183d"
+  },
+  "web.admin.audit.categories.banner": {
+    "text": "Banner",
+    "source_hash": "b7f4d98f"
+  },
+  "web.admin.audit.categories.queue": {
+    "text": "Filas",
+    "source_hash": "be77db11"
+  },
+  "web.admin.audit.categories.email": {
+    "text": "E-mail",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.audit.categories.ratelimit": {
+    "text": "Limites de taxa",
+    "source_hash": "6ed021f7"
+  },
+  "web.admin.audit.categories.ip": {
+    "text": "Banimentos de IP",
+    "source_hash": "48cdea49"
+  },
+  "web.admin.audit.columns.timestamp": {
+    "text": "Data/hora",
+    "source_hash": "115a2cc9"
+  },
+  "web.admin.audit.columns.actor": {
+    "text": "Autor",
+    "source_hash": "449995c4"
+  },
+  "web.admin.audit.columns.action": {
+    "text": "Ação",
+    "source_hash": "64cff131"
+  },
+  "web.admin.audit.columns.target": {
+    "text": "Alvo",
+    "source_hash": "978354db"
+  },
+  "web.admin.audit.columns.result": {
+    "text": "Resultado",
+    "source_hash": "6e7d50e8"
+  },
+  "web.admin.audit.columns.detail": {
+    "text": "Detalhe",
+    "source_hash": "fb5f27d5"
+  },
+  "web.admin.audit.filters.actorPlaceholder": {
+    "text": "Filtrar por autor (extid ou e-mail)",
+    "source_hash": "966aa580"
+  },
+  "web.admin.audit.filters.actionLabel": {
+    "text": "Ação",
+    "source_hash": "64cff131"
+  },
+  "web.admin.audit.filters.allActions": {
+    "text": "Todas as ações",
+    "source_hash": "83140cf1"
+  },
+  "web.admin.audit.list.loadError": {
+    "text": "Não foi possível carregar o registo de auditoria.",
+    "source_hash": "acf244f4"
+  },
+  "web.admin.audit.list.retry": {
+    "text": "Tentar novamente",
+    "source_hash": "942087cc"
+  },
+  "web.admin.audit.list.empty": {
+    "text": "Ainda não foram registados eventos de auditoria",
+    "source_hash": "8fe0cac3"
+  },
+  "web.admin.audit.result.success": {
+    "text": "Sucesso",
+    "source_hash": "c88a0b90"
+  },
+  "web.admin.audit.result.failure": {
+    "text": "Falha",
+    "source_hash": "7031edbc"
+  }
+}

--- a/locales/content/pt_PT/admin-bannedips.json
+++ b/locales/content/pt_PT/admin-bannedips.json
@@ -1,0 +1,114 @@
+{
+  "web.admin.bannedIps.title": {
+    "text": "IP banidos",
+    "source_hash": "0ece5643"
+  },
+  "web.admin.bannedIps.description": {
+    "text": "Banir e desbanir endereços IP no perímetro do site.",
+    "source_hash": "69c0c992"
+  },
+  "web.admin.bannedIps.currentIp": {
+    "text": "O teu IP atual",
+    "source_hash": "14ff3ec5"
+  },
+  "web.admin.bannedIps.actions.cancel": {
+    "text": "Cancelar",
+    "source_hash": "19766ed6"
+  },
+  "web.admin.bannedIps.actions.ban": {
+    "text": "Banir um IP",
+    "source_hash": "9937d7fd"
+  },
+  "web.admin.bannedIps.actions.quickBan": {
+    "text": "Banir este IP",
+    "source_hash": "95720658"
+  },
+  "web.admin.bannedIps.ban.confirmTitle": {
+    "text": "Banir este endereço IP?",
+    "source_hash": "512acd7b"
+  },
+  "web.admin.bannedIps.ban.confirmDescription": {
+    "text": "Isto bloqueia {ip} no perímetro do site. Escreve o IP para confirmar.",
+    "source_hash": "d8f6142e"
+  },
+  "web.admin.bannedIps.ban.button": {
+    "text": "Banir IP",
+    "source_hash": "f91a5285"
+  },
+  "web.admin.bannedIps.ban.success": {
+    "text": "{ip} banido",
+    "source_hash": "97180685"
+  },
+  "web.admin.bannedIps.columns.ipAddress": {
+    "text": "Endereço IP",
+    "source_hash": "3c3de0c9"
+  },
+  "web.admin.bannedIps.columns.reason": {
+    "text": "Motivo",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.bannedIps.columns.bannedAt": {
+    "text": "Banido em",
+    "source_hash": "dfbd120e"
+  },
+  "web.admin.bannedIps.columns.bannedBy": {
+    "text": "Banido por",
+    "source_hash": "9f47db0e"
+  },
+  "web.admin.bannedIps.columns.actions": {
+    "text": "Ações",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.bannedIps.form.title": {
+    "text": "Banir um endereço IP",
+    "source_hash": "59961746"
+  },
+  "web.admin.bannedIps.form.ipLabel": {
+    "text": "Endereço IP ou CIDR",
+    "source_hash": "133d0819"
+  },
+  "web.admin.bannedIps.form.reasonLabel": {
+    "text": "Motivo (opcional)",
+    "source_hash": "0f7d4664"
+  },
+  "web.admin.bannedIps.form.reasonPlaceholder": {
+    "text": "p. ex. credential stuffing",
+    "source_hash": "828a15ae"
+  },
+  "web.admin.bannedIps.form.submit": {
+    "text": "Banir IP",
+    "source_hash": "f91a5285"
+  },
+  "web.admin.bannedIps.list.loadError": {
+    "text": "Não foi possível carregar os IP banidos.",
+    "source_hash": "539f2e34"
+  },
+  "web.admin.bannedIps.list.retry": {
+    "text": "Tentar novamente",
+    "source_hash": "942087cc"
+  },
+  "web.admin.bannedIps.list.empty": {
+    "text": "Não existem IP banidos de momento",
+    "source_hash": "b72cc9c5"
+  },
+  "web.admin.bannedIps.stats.total": {
+    "text": "Total de banidos",
+    "source_hash": "41059c94"
+  },
+  "web.admin.bannedIps.unban.confirmTitle": {
+    "text": "Remover este banimento?",
+    "source_hash": "88473e59"
+  },
+  "web.admin.bannedIps.unban.confirmDescription": {
+    "text": "Isto desbloqueia {ip}. Escreve o IP para confirmar.",
+    "source_hash": "6bec3191"
+  },
+  "web.admin.bannedIps.unban.button": {
+    "text": "Desbanir",
+    "source_hash": "25fb5989"
+  },
+  "web.admin.bannedIps.unban.success": {
+    "text": "{ip} desbanido",
+    "source_hash": "79192c36"
+  }
+}

--- a/locales/content/pt_PT/admin-banner.json
+++ b/locales/content/pt_PT/admin-banner.json
@@ -1,0 +1,154 @@
+{
+  "web.admin.banner.title": {
+    "text": "Banner de difusão",
+    "source_hash": "0bc449a3"
+  },
+  "web.admin.banner.description": {
+    "text": "Publica um anúncio em todo o site apresentado a todos os visitantes, ou limpa o atual.",
+    "source_hash": "a0f720d7"
+  },
+  "web.admin.banner.loadError": {
+    "text": "Não foi possível carregar o banner atual.",
+    "source_hash": "04954e72"
+  },
+  "web.admin.banner.retry": {
+    "text": "Tentar novamente",
+    "source_hash": "942087cc"
+  },
+  "web.admin.banner.clear.button": {
+    "text": "Limpar banner",
+    "source_hash": "da6b2e5d"
+  },
+  "web.admin.banner.clear.confirmTitle": {
+    "text": "Limpar o banner de difusão?",
+    "source_hash": "46d9c35a"
+  },
+  "web.admin.banner.clear.confirmDescription": {
+    "text": "Isto remove o banner ativo para todos os visitantes. Escreve a palavra de confirmação para continuar.",
+    "source_hash": "9a56e4be"
+  },
+  "web.admin.banner.clear.success": {
+    "text": "Banner de difusão limpo.",
+    "source_hash": "b0f52af4"
+  },
+  "web.admin.banner.current.title": {
+    "text": "Banner atual",
+    "source_hash": "d17ab873"
+  },
+  "web.admin.banner.current.none": {
+    "text": "Nenhum banner está definido de momento.",
+    "source_hash": "487b2cac"
+  },
+  "web.admin.banner.current.status": {
+    "text": "Estado",
+    "source_hash": "920e413c"
+  },
+  "web.admin.banner.current.live": {
+    "text": "Ativo",
+    "source_hash": "b64ac05f"
+  },
+  "web.admin.banner.current.expiry": {
+    "text": "Validade",
+    "source_hash": "6956d814"
+  },
+  "web.admin.banner.current.persistent": {
+    "text": "Persistente (sem validade)",
+    "source_hash": "5f95d1b0"
+  },
+  "web.admin.banner.current.expiresIn": {
+    "text": "Expira em {duration}",
+    "source_hash": "f353f9a7"
+  },
+  "web.admin.banner.current.audience": {
+    "text": "Público",
+    "source_hash": "545c0235"
+  },
+  "web.admin.banner.current.storedContent": {
+    "text": "Conteúdo armazenado",
+    "source_hash": "3579f3e6"
+  },
+  "web.admin.banner.current.htmlNote": {
+    "text": "O conteúdo é HTML; o site limpa-o para apenas ligações quando apresentado.",
+    "source_hash": "e45a7dfe"
+  },
+  "web.admin.banner.current.edit": {
+    "text": "Editar",
+    "source_hash": "464c4ffd"
+  },
+  "web.admin.banner.set.title": {
+    "text": "Definir um banner",
+    "source_hash": "b6f90d5c"
+  },
+  "web.admin.banner.set.updateTitle": {
+    "text": "Atualizar o banner",
+    "source_hash": "841a0183"
+  },
+  "web.admin.banner.set.contentLabel": {
+    "text": "Mensagem",
+    "source_hash": "2f77668a"
+  },
+  "web.admin.banner.set.contentPlaceholder": {
+    "text": "Manutenção agendada dom. 02:00 UTC",
+    "source_hash": "4ec99d7d"
+  },
+  "web.admin.banner.set.contentHelp": {
+    "text": "É permitido HTML; o site limpa-o para apenas ligações.",
+    "source_hash": "7253d1cd"
+  },
+  "web.admin.banner.set.ttlLabel": {
+    "text": "Expirar automaticamente após (segundos)",
+    "source_hash": "72134116"
+  },
+  "web.admin.banner.set.ttlPlaceholder": {
+    "text": "Deixa em branco para não expirar",
+    "source_hash": "a8fd81e1"
+  },
+  "web.admin.banner.set.ttlHelp": {
+    "text": "Opcional. O banner é removido automaticamente após este número de segundos.",
+    "source_hash": "ba0237f5"
+  },
+  "web.admin.banner.set.scopeLabel": {
+    "text": "Público",
+    "source_hash": "545c0235"
+  },
+  "web.admin.banner.set.scopeHelp": {
+    "text": "Que páginas mostram o banner. As páginas de domínio personalizado só o veem quando definido para todas as páginas.",
+    "source_hash": "28cc3018"
+  },
+  "web.admin.banner.set.scopeNoRecipient": {
+    "text": "Tudo exceto páginas de destinatário",
+    "source_hash": "8575b3c0"
+  },
+  "web.admin.banner.set.scopeWorkspace": {
+    "text": "Apenas páginas de espaço de trabalho",
+    "source_hash": "563e003e"
+  },
+  "web.admin.banner.set.scopeAll": {
+    "text": "Todas as páginas (incluindo domínios personalizados)",
+    "source_hash": "b9b74870"
+  },
+  "web.admin.banner.set.publishButton": {
+    "text": "Publicar banner",
+    "source_hash": "5b7427a1"
+  },
+  "web.admin.banner.set.updateButton": {
+    "text": "Atualizar banner",
+    "source_hash": "69b6e40e"
+  },
+  "web.admin.banner.set.confirmTitle": {
+    "text": "Publicar banner de difusão?",
+    "source_hash": "8b72b5c3"
+  },
+  "web.admin.banner.set.confirmDescription": {
+    "text": "Este banner será apresentado a todos os visitantes em todo o site até ser limpo ou expirar.",
+    "source_hash": "c61bbec1"
+  },
+  "web.admin.banner.set.confirmButton": {
+    "text": "Publicar",
+    "source_hash": "859390eb"
+  },
+  "web.admin.banner.set.success": {
+    "text": "Banner de difusão publicado.",
+    "source_hash": "55c06cab"
+  }
+}

--- a/locales/content/pt_PT/admin-billing.json
+++ b/locales/content/pt_PT/admin-billing.json
@@ -1,0 +1,126 @@
+{
+  "web.admin.billing.title": {
+    "text": "Catálogo de faturação",
+    "source_hash": "bfde7e68"
+  },
+  "web.admin.billing.description": {
+    "text": "Vista só de leitura dos planos configurados e dos respetivos direitos, e de qualquer divergência em relação ao catálogo ativo sincronizado com o Stripe.",
+    "source_hash": "05d5b332"
+  },
+  "web.admin.billing.retry": {
+    "text": "Tentar novamente",
+    "source_hash": "942087cc"
+  },
+  "web.admin.billing.loadError": {
+    "text": "Não foi possível carregar o catálogo de faturação.",
+    "source_hash": "c3110f77"
+  },
+  "web.admin.billing.localConfigWarning": {
+    "text": "A cache de planos sincronizada com o Stripe está vazia, pelo que os planos ativos e a divergência não podem ser avaliados. A mostrar apenas o catálogo configurado (billing.yaml) — habitual em dev ou quando o Stripe não está configurado.",
+    "source_hash": "905d95f8"
+  },
+  "web.admin.billing.inSync": {
+    "text": "Sincronizado",
+    "source_hash": "5701958c"
+  },
+  "web.admin.billing.driftCount": {
+    "text": "{count} diferença(s)",
+    "source_hash": "166538f5"
+  },
+  "web.admin.billing.inSyncDetail": {
+    "text": "O catálogo configurado corresponde aos planos ativos. Nenhuma divergência detetada.",
+    "source_hash": "57ab60a6"
+  },
+  "web.admin.billing.columns.planid": {
+    "text": "ID do plano",
+    "source_hash": "1f0d4dc6"
+  },
+  "web.admin.billing.columns.name": {
+    "text": "Nome",
+    "source_hash": "dcd1d522"
+  },
+  "web.admin.billing.columns.tier": {
+    "text": "Nível",
+    "source_hash": "cb9e8664"
+  },
+  "web.admin.billing.columns.status": {
+    "text": "Estado",
+    "source_hash": "920e413c"
+  },
+  "web.admin.billing.diff.title": {
+    "text": "Diferença do plano: {planid}",
+    "source_hash": "bc86e5f7"
+  },
+  "web.admin.billing.diff.subtitle": {
+    "text": "Catálogo configurado (billing.yaml) vs plano ativo sincronizado com o Stripe, lado a lado.",
+    "source_hash": "d92e93ae"
+  },
+  "web.admin.billing.diff.config": {
+    "text": "Configurado (billing.yaml)",
+    "source_hash": "6bf2ff04"
+  },
+  "web.admin.billing.diff.live": {
+    "text": "Ativo (cache do Stripe)",
+    "source_hash": "4886945d"
+  },
+  "web.admin.billing.diff.absentConfig": {
+    "text": "Este plano não está presente no catálogo configurado.",
+    "source_hash": "0b594c88"
+  },
+  "web.admin.billing.diff.absentLive": {
+    "text": "Este plano não está presente na cache ativa sincronizada com o Stripe.",
+    "source_hash": "c53f31c3"
+  },
+  "web.admin.billing.plans.title": {
+    "text": "Planos",
+    "source_hash": "dfe8b2f0"
+  },
+  "web.admin.billing.plans.empty": {
+    "text": "Nenhum plano encontrado no catálogo.",
+    "source_hash": "39db3c13"
+  },
+  "web.admin.billing.plans.viewDiff": {
+    "text": "Ver diferença",
+    "source_hash": "0e5d6873"
+  },
+  "web.admin.billing.source.stripe": {
+    "text": "Cache do Stripe",
+    "source_hash": "b5577327"
+  },
+  "web.admin.billing.source.localConfig": {
+    "text": "Configuração local",
+    "source_hash": "49de43d2"
+  },
+  "web.admin.billing.stats.configured": {
+    "text": "Planos configurados",
+    "source_hash": "4fda4796"
+  },
+  "web.admin.billing.stats.live": {
+    "text": "Planos ativos",
+    "source_hash": "faaa88d9"
+  },
+  "web.admin.billing.stats.source": {
+    "text": "Origem",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.billing.stats.drift": {
+    "text": "Divergência",
+    "source_hash": "8b4c8240"
+  },
+  "web.admin.billing.status.in_sync": {
+    "text": "Sincronizado",
+    "source_hash": "5701958c"
+  },
+  "web.admin.billing.status.only_config": {
+    "text": "Apenas configurado",
+    "source_hash": "15836cba"
+  },
+  "web.admin.billing.status.only_live": {
+    "text": "Apenas ativo",
+    "source_hash": "8f4ed495"
+  },
+  "web.admin.billing.status.changed": {
+    "text": "Alterado",
+    "source_hash": "2a6141e4"
+  }
+}

--- a/locales/content/pt_PT/admin-colonel.json
+++ b/locales/content/pt_PT/admin-colonel.json
@@ -802,5 +802,45 @@
   "web.colonel.secrets.state.viewed": {
     "text": "Visto",
     "source_hash": "1b28d178"
+  },
+  "web.colonel.backToSite": {
+    "text": "Voltar ao site",
+    "source_hash": "4ee0f819"
+  },
+  "web.colonel.customDomains.labels.domain": {
+    "text": "Domínio",
+    "source_hash": "79fa3361"
+  },
+  "web.colonel.customDomains.labels.status": {
+    "text": "Estado",
+    "source_hash": "920e413c"
+  },
+  "web.colonel.customDomains.labels.actions": {
+    "text": "Ações",
+    "source_hash": "ff8059dc"
+  },
+  "web.colonel.nav.consoleTag": {
+    "text": "Consola",
+    "source_hash": "29a40861"
+  },
+  "web.colonel.nav.groups.identity": {
+    "text": "Identidade",
+    "source_hash": "999f23fc"
+  },
+  "web.colonel.nav.groups.security": {
+    "text": "Acesso e segurança",
+    "source_hash": "abb29a3f"
+  },
+  "web.colonel.nav.groups.platform": {
+    "text": "Plataforma",
+    "source_hash": "c78ffe19"
+  },
+  "web.colonel.nav.groups.billing": {
+    "text": "Faturação",
+    "source_hash": "3ac8bbca"
+  },
+  "web.colonel.nav.groups.communications": {
+    "text": "Comunicações",
+    "source_hash": "919a9253"
   }
 }

--- a/locales/content/pt_PT/admin-customers.json
+++ b/locales/content/pt_PT/admin-customers.json
@@ -1,0 +1,486 @@
+{
+  "web.admin.customers.title": {
+    "text": "Clientes",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.customers.description": {
+    "text": "Encontra um cliente e resolve problemas de suporte sem SSH.",
+    "source_hash": "c8487e68"
+  },
+  "web.admin.customers.actions.plan.label": {
+    "text": "Plano",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.actions.plan.apply": {
+    "text": "Aplicar",
+    "source_hash": "31e392d1"
+  },
+  "web.admin.customers.actions.plan.confirmTitle": {
+    "text": "Alterar plano?",
+    "source_hash": "910a4de9"
+  },
+  "web.admin.customers.actions.plan.confirmDescription": {
+    "text": "Alterar {email} para o plano {plan}.",
+    "source_hash": "83fb4158"
+  },
+  "web.admin.customers.actions.plan.success": {
+    "text": "Plano atualizado.",
+    "source_hash": "ebe8d40c"
+  },
+  "web.admin.customers.actions.plan.localConfigWarning": {
+    "text": "Planos carregados a partir da configuração local — o Stripe não está configurado ou está inacessível.",
+    "source_hash": "df83e326"
+  },
+  "web.admin.customers.actions.purge.button": {
+    "text": "Purgar cliente",
+    "source_hash": "ff658f69"
+  },
+  "web.admin.customers.actions.purge.confirmTitle": {
+    "text": "Purgar cliente?",
+    "source_hash": "9feed9f1"
+  },
+  "web.admin.customers.actions.purge.confirmDescription": {
+    "text": "Isto elimina permanentemente {email} e todos os respetivos dados. Esta ação não pode ser anulada.",
+    "source_hash": "a74dd5d1"
+  },
+  "web.admin.customers.actions.purge.success": {
+    "text": "Cliente purgado.",
+    "source_hash": "6145e5c8"
+  },
+  "web.admin.customers.actions.role.label": {
+    "text": "Função",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.actions.role.apply": {
+    "text": "Aplicar",
+    "source_hash": "31e392d1"
+  },
+  "web.admin.customers.actions.role.confirmTitle": {
+    "text": "Alterar função?",
+    "source_hash": "227f57d7"
+  },
+  "web.admin.customers.actions.role.confirmDescription": {
+    "text": "Alterar {email} para a função {role}.",
+    "source_hash": "9ba063c6"
+  },
+  "web.admin.customers.actions.role.success": {
+    "text": "Função atualizada.",
+    "source_hash": "0c33aa24"
+  },
+  "web.admin.customers.actions.suspend.button": {
+    "text": "Suspender conta",
+    "source_hash": "95a04f27"
+  },
+  "web.admin.customers.actions.suspend.reasonLabel": {
+    "text": "Motivo (opcional)",
+    "source_hash": "0f7d4664"
+  },
+  "web.admin.customers.actions.suspend.reasonPlaceholder": {
+    "text": "Porque é que esta conta está a ser suspensa?",
+    "source_hash": "8eca975e"
+  },
+  "web.admin.customers.actions.suspend.confirmTitle": {
+    "text": "Suspender conta?",
+    "source_hash": "cbfa275b"
+  },
+  "web.admin.customers.actions.suspend.confirmDescription": {
+    "text": "Bloqueia o início de sessão de {email} e revoga as respetivas sessões ativas. Nenhum dado é eliminado — esta ação é reversível.",
+    "source_hash": "e5d046bc"
+  },
+  "web.admin.customers.actions.suspend.success": {
+    "text": "Conta suspensa.",
+    "source_hash": "04c5f996"
+  },
+  "web.admin.customers.actions.unsuspend.button": {
+    "text": "Anular suspensão da conta",
+    "source_hash": "35a10fb5"
+  },
+  "web.admin.customers.actions.unsuspend.confirmTitle": {
+    "text": "Anular suspensão da conta?",
+    "source_hash": "6fd78a72"
+  },
+  "web.admin.customers.actions.unsuspend.confirmDescription": {
+    "text": "Restaura o início de sessão de {email}.",
+    "source_hash": "cb2bb4e0"
+  },
+  "web.admin.customers.actions.unsuspend.success": {
+    "text": "Suspensão da conta anulada.",
+    "source_hash": "c5b4377f"
+  },
+  "web.admin.customers.actions.unverify.button": {
+    "text": "Anular verificação",
+    "source_hash": "b0dee41f"
+  },
+  "web.admin.customers.actions.unverify.confirmTitle": {
+    "text": "Anular verificação do cliente?",
+    "source_hash": "62ed2854"
+  },
+  "web.admin.customers.actions.unverify.confirmDescription": {
+    "text": "Marcar {email} como não verificado.",
+    "source_hash": "592ffd27"
+  },
+  "web.admin.customers.actions.unverify.success": {
+    "text": "Verificação do cliente anulada.",
+    "source_hash": "a9b7bbac"
+  },
+  "web.admin.customers.actions.verify.button": {
+    "text": "Verificar",
+    "source_hash": "eea2745e"
+  },
+  "web.admin.customers.actions.verify.confirmTitle": {
+    "text": "Verificar cliente?",
+    "source_hash": "43037ce1"
+  },
+  "web.admin.customers.actions.verify.confirmDescription": {
+    "text": "Marcar {email} como verificado.",
+    "source_hash": "7052d79d"
+  },
+  "web.admin.customers.actions.verify.success": {
+    "text": "Cliente verificado.",
+    "source_hash": "19e382dc"
+  },
+  "web.admin.customers.columns.email": {
+    "text": "E-mail",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.customers.columns.role": {
+    "text": "Função",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.columns.verified": {
+    "text": "Verificado",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.columns.plan": {
+    "text": "Plano",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.columns.secrets": {
+    "text": "Mensagens confidenciais",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.customers.columns.created": {
+    "text": "Criado",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.columns.lastLogin": {
+    "text": "Último início de sessão",
+    "source_hash": "0d39602d"
+  },
+  "web.admin.customers.detail.backToList": {
+    "text": "Voltar aos clientes",
+    "source_hash": "077807fb"
+  },
+  "web.admin.customers.detail.openFullPage": {
+    "text": "Abrir página completa",
+    "source_hash": "a467911c"
+  },
+  "web.admin.customers.detail.notFound": {
+    "text": "Cliente não encontrado",
+    "source_hash": "5e3f5824"
+  },
+  "web.admin.customers.detail.notFoundDescription": {
+    "text": "Nenhum cliente corresponde a este identificador. Pode ter sido purgado.",
+    "source_hash": "82b04725"
+  },
+  "web.admin.customers.detail.loadError": {
+    "text": "Não foi possível carregar este cliente.",
+    "source_hash": "cfd1bcca"
+  },
+  "web.admin.customers.detail.retry": {
+    "text": "Tentar novamente",
+    "source_hash": "942087cc"
+  },
+  "web.admin.customers.detail.yes": {
+    "text": "Sim",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.customers.detail.no": {
+    "text": "Não",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.customers.detail.none": {
+    "text": "Nenhum",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.never": {
+    "text": "Nunca",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.customers.detail.billing.plan": {
+    "text": "Plano",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.detail.billing.organization": {
+    "text": "Organização de faturação",
+    "source_hash": "90c94ee1"
+  },
+  "web.admin.customers.detail.billing.subscriptionStatus": {
+    "text": "Estado da subscrição",
+    "source_hash": "f0723c4e"
+  },
+  "web.admin.customers.detail.billing.periodEnd": {
+    "text": "O período atual termina",
+    "source_hash": "742b8229"
+  },
+  "web.admin.customers.detail.billing.latestInvoice": {
+    "text": "Última fatura",
+    "source_hash": "7a6133cc"
+  },
+  "web.admin.customers.detail.billing.noInvoices": {
+    "text": "Sem faturas",
+    "source_hash": "e6b30f93"
+  },
+  "web.admin.customers.detail.billing.openStripe": {
+    "text": "Abrir no painel do Stripe",
+    "source_hash": "dfa7c41d"
+  },
+  "web.admin.customers.detail.billing.unavailable": {
+    "text": "Dados do Stripe indisponíveis: {reason}",
+    "source_hash": "9fe08e49"
+  },
+  "web.admin.customers.detail.billing.notConfigured": {
+    "text": "A faturação não está configurada nesta instalação.",
+    "source_hash": "6e90375e"
+  },
+  "web.admin.customers.detail.fields.email": {
+    "text": "E-mail",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.customers.detail.fields.publicId": {
+    "text": "ID público",
+    "source_hash": "3705b64f"
+  },
+  "web.admin.customers.detail.fields.role": {
+    "text": "Função",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.detail.fields.verified": {
+    "text": "Verificado",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.detail.fields.plan": {
+    "text": "Plano",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.detail.fields.locale": {
+    "text": "Idioma",
+    "source_hash": "ca3dc612"
+  },
+  "web.admin.customers.detail.fields.created": {
+    "text": "Criado",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.detail.fields.updated": {
+    "text": "Atualizado",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.customers.detail.fields.lastLogin": {
+    "text": "Último início de sessão",
+    "source_hash": "0d39602d"
+  },
+  "web.admin.customers.detail.fields.suspendedAt": {
+    "text": "Suspenso em",
+    "source_hash": "7227f219"
+  },
+  "web.admin.customers.detail.fields.suspendedBy": {
+    "text": "Suspenso por",
+    "source_hash": "e0830524"
+  },
+  "web.admin.customers.detail.fields.suspendedReason": {
+    "text": "Motivo da suspensão",
+    "source_hash": "d6b08d8e"
+  },
+  "web.admin.customers.detail.organizations.empty": {
+    "text": "Sem organizações",
+    "source_hash": "c256efdc"
+  },
+  "web.admin.customers.detail.organizations.default": {
+    "text": "Predefinida",
+    "source_hash": "21b111cb"
+  },
+  "web.admin.customers.detail.receiptColumns.shortId": {
+    "text": "ID curto",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.customers.detail.receiptColumns.state": {
+    "text": "Estado",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.customers.detail.receiptColumns.created": {
+    "text": "Criado",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.detail.receipts.empty": {
+    "text": "Sem comprovativos",
+    "source_hash": "fb425a68"
+  },
+  "web.admin.customers.detail.secretColumns.shortId": {
+    "text": "ID curto",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.customers.detail.secretColumns.state": {
+    "text": "Estado",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.customers.detail.secretColumns.created": {
+    "text": "Criado",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.detail.secretColumns.expiration": {
+    "text": "Validade",
+    "source_hash": "f38d6e0e"
+  },
+  "web.admin.customers.detail.secrets.empty": {
+    "text": "Sem mensagens confidenciais",
+    "source_hash": "c37ab3f7"
+  },
+  "web.admin.customers.detail.sections.profile": {
+    "text": "Perfil",
+    "source_hash": "d696a35b"
+  },
+  "web.admin.customers.detail.sections.secrets": {
+    "text": "Mensagens confidenciais",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.customers.detail.sections.receipts": {
+    "text": "Comprovativos",
+    "source_hash": "60a627df"
+  },
+  "web.admin.customers.detail.sections.organizations": {
+    "text": "Organizações",
+    "source_hash": "2730183d"
+  },
+  "web.admin.customers.detail.sections.actions": {
+    "text": "Ações",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.sections.billing": {
+    "text": "Faturação",
+    "source_hash": "3ac8bbca"
+  },
+  "web.admin.customers.detail.sessions.title": {
+    "text": "Sessões ativas",
+    "source_hash": "b58fa4e0"
+  },
+  "web.admin.customers.detail.sessions.empty": {
+    "text": "Sem sessões ativas.",
+    "source_hash": "6f064eb9"
+  },
+  "web.admin.customers.detail.sessions.loadError": {
+    "text": "Não foi possível carregar as sessões.",
+    "source_hash": "d2884313"
+  },
+  "web.admin.customers.detail.sessions.unknown": {
+    "text": "Desconhecido",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.customers.detail.sessions.columns.lastActivity": {
+    "text": "Última atividade",
+    "source_hash": "06475633"
+  },
+  "web.admin.customers.detail.sessions.columns.ipAddress": {
+    "text": "Endereço IP",
+    "source_hash": "0302a467"
+  },
+  "web.admin.customers.detail.sessions.columns.device": {
+    "text": "Dispositivo",
+    "source_hash": "6ba0bdec"
+  },
+  "web.admin.customers.detail.sessions.columns.authMethod": {
+    "text": "Método de autenticação",
+    "source_hash": "bc4ea262"
+  },
+  "web.admin.customers.detail.sessions.columns.actions": {
+    "text": "Ações",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.sessions.revoke.button": {
+    "text": "Revogar",
+    "source_hash": "87e6d00b"
+  },
+  "web.admin.customers.detail.sessions.revoke.confirmTitle": {
+    "text": "Revogar sessão?",
+    "source_hash": "7735d1ef"
+  },
+  "web.admin.customers.detail.sessions.revoke.confirmDescription": {
+    "text": "Isto termina imediatamente a sessão do utilizador. Terá de iniciar sessão novamente.",
+    "source_hash": "b4291af0"
+  },
+  "web.admin.customers.detail.sessions.revoke.success": {
+    "text": "Sessão revogada.",
+    "source_hash": "5e4762e5"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.button": {
+    "text": "Revogar todas",
+    "source_hash": "c6847a4b"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.confirmTitle": {
+    "text": "Revogar todas as sessões?",
+    "source_hash": "a4fa4c65"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.confirmDescription": {
+    "text": "Isto termina a sessão do utilizador em todos os dispositivos e navegadores — incluindo sessões não apresentadas nesta lista — e bloqueia imediatamente as suas rotas autenticadas. Utiliza em processos de saída ou numa suspeita de apropriação de conta. Escreve o ID do utilizador para confirmar.",
+    "source_hash": "483cdd88"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.success": {
+    "text": "Todas as sessões revogadas ({count} terminadas).",
+    "source_hash": "4e1cce55"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.capped": {
+    "text": "Terminadas {count} sessões, mas a varredura de sessões não rastreadas foi truncada — pode restar uma sessão mais antiga. Executa novamente para ter a certeza.",
+    "source_hash": "e3d295a6"
+  },
+  "web.admin.customers.detail.stats.secretsCreated": {
+    "text": "Mensagens confidenciais criadas",
+    "source_hash": "7d17719e"
+  },
+  "web.admin.customers.detail.stats.secretsShared": {
+    "text": "Mensagens confidenciais partilhadas",
+    "source_hash": "ba85b265"
+  },
+  "web.admin.customers.detail.stats.emailsSent": {
+    "text": "E-mails enviados",
+    "source_hash": "be604792"
+  },
+  "web.admin.customers.list.roleFilter": {
+    "text": "Função",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.list.empty": {
+    "text": "Nenhum cliente encontrado",
+    "source_hash": "dc754ec0"
+  },
+  "web.admin.customers.list.loadError": {
+    "text": "Não foi possível carregar os clientes.",
+    "source_hash": "81783303"
+  },
+  "web.admin.customers.list.searchPlaceholder": {
+    "text": "Pesquisar por e-mail, extid ou objid",
+    "source_hash": "c06d5a3b"
+  },
+  "web.admin.customers.list.emptySearch": {
+    "text": "Nenhum cliente corresponde a esta pesquisa",
+    "source_hash": "ea7e7012"
+  },
+  "web.admin.customers.roles.colonel": {
+    "text": "Colonel",
+    "source_hash": "02577777"
+  },
+  "web.admin.customers.roles.admin": {
+    "text": "Administrador",
+    "source_hash": "c1c224b0"
+  },
+  "web.admin.customers.roles.staff": {
+    "text": "Pessoal",
+    "source_hash": "681927e3"
+  },
+  "web.admin.customers.roles.customer": {
+    "text": "Cliente",
+    "source_hash": "bf376338"
+  },
+  "web.admin.customers.suspended.badge": {
+    "text": "Suspensa",
+    "source_hash": "e392a389"
+  }
+}

--- a/locales/content/pt_PT/admin-domains.json
+++ b/locales/content/pt_PT/admin-domains.json
@@ -1,0 +1,194 @@
+{
+  "web.admin.domains.retry": {
+    "text": "Tentar novamente",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.addDomain.button": {
+    "text": "Adicionar domínio",
+    "source_hash": "d86476ae"
+  },
+  "web.admin.domains.addDomain.title": {
+    "text": "Adicionar um domínio personalizado",
+    "source_hash": "592d3314"
+  },
+  "web.admin.domains.addDomain.forOrg": {
+    "text": "A adicionar um domínio para {org}.",
+    "source_hash": "f8b8c1ac"
+  },
+  "web.admin.domains.addDomain.domainLabel": {
+    "text": "Domínio",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domains.addDomain.domainPlaceholder": {
+    "text": "secrets.example.com",
+    "source_hash": "9ea4d0d6"
+  },
+  "web.admin.domains.addDomain.strategyLabel": {
+    "text": "Estratégia de validação",
+    "source_hash": "a2e95531"
+  },
+  "web.admin.domains.addDomain.createButton": {
+    "text": "Criar",
+    "source_hash": "4759498a"
+  },
+  "web.admin.domains.addDomain.created": {
+    "text": "{domain} foi criado.",
+    "source_hash": "2263ec6a"
+  },
+  "web.admin.domains.addDomain.strategy.approximated": {
+    "text": "Approximated — verificação de propriedade por DNS, sem proxy.",
+    "source_hash": "79a7245c"
+  },
+  "web.admin.domains.addDomain.strategy.passthrough": {
+    "text": "Passthrough — apontas o DNS para o proxy desta implementação.",
+    "source_hash": "9702d758"
+  },
+  "web.admin.domains.addDomain.strategy.external": {
+    "text": "External — o DNS é gerido fora desta implementação.",
+    "source_hash": "acaede35"
+  },
+  "web.admin.domains.addDomain.strategy.caddy_on_demand": {
+    "text": "Caddy a pedido — certificados emitidos automaticamente no primeiro pedido.",
+    "source_hash": "deb90ae6"
+  },
+  "web.admin.domains.addDomain.strategy.caddy": {
+    "text": "Caddy — certificados emitidos automaticamente no primeiro pedido.",
+    "source_hash": "a0f3c2dc"
+  },
+  "web.admin.domains.addDomain.strategy.unknown": {
+    "text": "Estratégia de validação para toda a implementação.",
+    "source_hash": "4587f9cf"
+  },
+  "web.admin.domains.attach.cta": {
+    "text": "Anexar domínio à organização",
+    "source_hash": "736d74ce"
+  },
+  "web.admin.domains.attach.recordEyebrow": {
+    "text": "Registo em curso",
+    "source_hash": "2fadf983"
+  },
+  "web.admin.domains.attach.rosterError": {
+    "text": "Não foi possível carregar os domínios desta organização.",
+    "source_hash": "d3055fed"
+  },
+  "web.admin.domains.attach.noDomains": {
+    "text": "Ainda não há domínios anexados a esta organização.",
+    "source_hash": "e9a25fc4"
+  },
+  "web.admin.domains.attach.openExternal": {
+    "text": "Abrir {domain} num novo separador",
+    "source_hash": "c5fbdeaa"
+  },
+  "web.admin.domains.dns.heading": {
+    "text": "Registos DNS a publicar",
+    "source_hash": "e4efbe2b"
+  },
+  "web.admin.domains.dns.txtStep": {
+    "text": "1. Adiciona um registo TXT para comprovar a propriedade.",
+    "source_hash": "fdcfcfb0"
+  },
+  "web.admin.domains.dns.aStep": {
+    "text": "2. Adiciona um registo A a apontar o apex para o proxy.",
+    "source_hash": "aedbf197"
+  },
+  "web.admin.domains.dns.cnameStep": {
+    "text": "2. Adiciona um registo CNAME a apontar o subdomínio para o proxy.",
+    "source_hash": "5c626f53"
+  },
+  "web.admin.domains.dns.propagationNote": {
+    "text": "As alterações de DNS podem demorar alguns minutos a propagar-se antes de a verificação ser bem-sucedida.",
+    "source_hash": "7caf70a7"
+  },
+  "web.admin.domains.dns.toggle": {
+    "text": "Detalhes de DNS",
+    "source_hash": "ebf2d44e"
+  },
+  "web.admin.domains.dns.loadError": {
+    "text": "Não foi possível carregar os detalhes de DNS.",
+    "source_hash": "4c33e23d"
+  },
+  "web.admin.domains.list.loadError": {
+    "text": "Não foi possível carregar os domínios.",
+    "source_hash": "548deff8"
+  },
+  "web.admin.domains.orgPicker.title": {
+    "text": "Seleciona uma organização",
+    "source_hash": "48326f52"
+  },
+  "web.admin.domains.orgPicker.searchLabel": {
+    "text": "Organização",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.orgPicker.searchPlaceholder": {
+    "text": "ID do objeto, ID externo ou e-mail",
+    "source_hash": "bb5d0055"
+  },
+  "web.admin.domains.orgPicker.searchHint": {
+    "text": "Pesquisa por objid, extid ou o endereço de e-mail de um membro.",
+    "source_hash": "fdef7332"
+  },
+  "web.admin.domains.orgPicker.loadError": {
+    "text": "Não foi possível pesquisar organizações.",
+    "source_hash": "b9e45dcf"
+  },
+  "web.admin.domains.orgPicker.parseError": {
+    "text": "Não foi possível ler os resultados das organizações.",
+    "source_hash": "44e1b9fd"
+  },
+  "web.admin.domains.orgPicker.idle": {
+    "text": "Introduz um valor acima para pesquisar.",
+    "source_hash": "0352e6e6"
+  },
+  "web.admin.domains.orgPicker.noResults": {
+    "text": "Nenhuma organização corresponde a “{term}”.",
+    "source_hash": "761db594"
+  },
+  "web.admin.domains.orgPicker.unnamedOrg": {
+    "text": "Organização sem nome",
+    "source_hash": "f218dc9d"
+  },
+  "web.admin.domains.orgPicker.domainCount": {
+    "text": "{count} domínios",
+    "source_hash": "cf548c8c"
+  },
+  "web.admin.domains.orgPicker.select": {
+    "text": "Selecionar",
+    "source_hash": "2a78025d"
+  },
+  "web.admin.domains.verify.button": {
+    "text": "Verificar",
+    "source_hash": "eea2745e"
+  },
+  "web.admin.domains.verify.confirmTitle": {
+    "text": "Verificar domínio?",
+    "source_hash": "07c4dc4f"
+  },
+  "web.admin.domains.verify.confirmDescription": {
+    "text": "Executar verificações de DNS e SSL para {domain}.",
+    "source_hash": "06797824"
+  },
+  "web.admin.domains.verify.failed": {
+    "text": "A verificação falhou. Tenta novamente.",
+    "source_hash": "3c8432b0"
+  },
+  "web.admin.domains.verify.success.verified": {
+    "text": "{domain} está verificado.",
+    "source_hash": "802b5d1e"
+  },
+  "web.admin.domains.verify.success.resolving": {
+    "text": "{domain} está a resolver mas ainda não está verificado.",
+    "source_hash": "bc8aecad"
+  },
+  "web.admin.domains.verify.success.pending": {
+    "text": "{domain} está pendente — o DNS ainda não está a resolver.",
+    "source_hash": "0d9f66d5"
+  },
+  "web.admin.domains.verify.success.unverified": {
+    "text": "Não foi possível verificar {domain}.",
+    "source_hash": "630da482"
+  },
+  "web.admin.domains.verify.success.done": {
+    "text": "Verificação concluída para {domain}.",
+    "source_hash": "ed67e22d"
+  }
+}

--- a/locales/content/pt_PT/admin-domaintoolbox.json
+++ b/locales/content/pt_PT/admin-domaintoolbox.json
@@ -1,0 +1,178 @@
+{
+  "web.admin.domaintoolbox.title": {
+    "text": "Caixa de ferramentas de domínios",
+    "source_hash": "5a9333db"
+  },
+  "web.admin.domaintoolbox.description": {
+    "text": "Diagnostica e repara as relações de domínios personalizados: procura órfãos, testa DNS/SSL, repara a propriedade e transfere entre organizações.",
+    "source_hash": "778537aa"
+  },
+  "web.admin.domaintoolbox.retry": {
+    "text": "Tentar novamente",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domaintoolbox.preview": {
+    "text": "Pré-visualizar",
+    "source_hash": "324b134f"
+  },
+  "web.admin.domaintoolbox.fields.extid": {
+    "text": "ID externo do domínio",
+    "source_hash": "f52af6c5"
+  },
+  "web.admin.domaintoolbox.fields.extidPlaceholder": {
+    "text": "cd_… (extid do domínio)",
+    "source_hash": "bb9bf49a"
+  },
+  "web.admin.domaintoolbox.orphaned.title": {
+    "text": "Domínios órfãos",
+    "source_hash": "ddcea596"
+  },
+  "web.admin.domaintoolbox.orphaned.description": {
+    "text": "Domínios personalizados sem organização proprietária. Utiliza Reparar para reatribuir um.",
+    "source_hash": "967268f5"
+  },
+  "web.admin.domaintoolbox.orphaned.empty": {
+    "text": "Nenhum domínio órfão encontrado.",
+    "source_hash": "06ef9979"
+  },
+  "web.admin.domaintoolbox.orphaned.loadError": {
+    "text": "Não foi possível carregar os domínios órfãos.",
+    "source_hash": "ca0e33bf"
+  },
+  "web.admin.domaintoolbox.orphaned.repairAction": {
+    "text": "Reparar",
+    "source_hash": "1196b6c5"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.domain": {
+    "text": "Domínio",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.state": {
+    "text": "Estado",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.verified": {
+    "text": "Verificado",
+    "source_hash": "4f783840"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.created": {
+    "text": "Criado",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.actions": {
+    "text": "Ações",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domaintoolbox.probe.title": {
+    "text": "Testar (DNS / SSL)",
+    "source_hash": "ec69a087"
+  },
+  "web.admin.domaintoolbox.probe.description": {
+    "text": "Faz um pedido HTTPS em direto para confirmar que o domínio serve tráfego e inspeciona o respetivo certificado TLS. Só de leitura.",
+    "source_hash": "1eecfa96"
+  },
+  "web.admin.domaintoolbox.probe.button": {
+    "text": "Testar",
+    "source_hash": "3bd51ab9"
+  },
+  "web.admin.domaintoolbox.probe.healthLabel": {
+    "text": "Estado de funcionamento",
+    "source_hash": "55898449"
+  },
+  "web.admin.domaintoolbox.repair.title": {
+    "text": "Reparar relação",
+    "source_hash": "0053d07c"
+  },
+  "web.admin.domaintoolbox.repair.description": {
+    "text": "Corrige inconsistências na relação com a organização de um domínio. Pré-visualiza primeiro, depois aplica.",
+    "source_hash": "18ca490b"
+  },
+  "web.admin.domaintoolbox.repair.orgIdLabel": {
+    "text": "Atribuir organização (se órfão)",
+    "source_hash": "f95b010a"
+  },
+  "web.admin.domaintoolbox.repair.orgIdPlaceholder": {
+    "text": "id ou extid da organização",
+    "source_hash": "a87d634e"
+  },
+  "web.admin.domaintoolbox.repair.statusLabel": {
+    "text": "Estado",
+    "source_hash": "920e413c"
+  },
+  "web.admin.domaintoolbox.repair.noIssues": {
+    "text": "Nenhum problema encontrado — as relações estão consistentes.",
+    "source_hash": "e1a4c49d"
+  },
+  "web.admin.domaintoolbox.repair.applyButton": {
+    "text": "Aplicar reparações",
+    "source_hash": "3f92b29f"
+  },
+  "web.admin.domaintoolbox.repair.success": {
+    "text": "Reparações aplicadas com sucesso.",
+    "source_hash": "24f25b9b"
+  },
+  "web.admin.domaintoolbox.repair.confirmTitle": {
+    "text": "Aplicar reparações do domínio?",
+    "source_hash": "9429998b"
+  },
+  "web.admin.domaintoolbox.repair.confirmDescription": {
+    "text": "Isto vai modificar o estado de propriedade/relação de {domain}. Volta a escrever o ID externo do domínio para confirmar.",
+    "source_hash": "426d267b"
+  },
+  "web.admin.domaintoolbox.reverify.button": {
+    "text": "Verificar novamente",
+    "source_hash": "0344860a"
+  },
+  "web.admin.domaintoolbox.reverify.success": {
+    "text": "Nova verificação do domínio concluída.",
+    "source_hash": "497a2348"
+  },
+  "web.admin.domaintoolbox.transfer.title": {
+    "text": "Transferir propriedade",
+    "source_hash": "3667f939"
+  },
+  "web.admin.domaintoolbox.transfer.description": {
+    "text": "Reatribui um domínio a uma organização diferente. Ação com o maior raio de impacto — pré-visualiza e confirma com cuidado.",
+    "source_hash": "d4e26e03"
+  },
+  "web.admin.domaintoolbox.transfer.toOrgLabel": {
+    "text": "Organização de destino",
+    "source_hash": "4e4486eb"
+  },
+  "web.admin.domaintoolbox.transfer.fromOrgLabel": {
+    "text": "Organização de origem (opcional)",
+    "source_hash": "3666815f"
+  },
+  "web.admin.domaintoolbox.transfer.fromOrgPlaceholder": {
+    "text": "confirmar o proprietário atual",
+    "source_hash": "cd9e769c"
+  },
+  "web.admin.domaintoolbox.transfer.from": {
+    "text": "De",
+    "source_hash": "21819769"
+  },
+  "web.admin.domaintoolbox.transfer.to": {
+    "text": "Para",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.domaintoolbox.transfer.orphaned": {
+    "text": "ÓRFÃO",
+    "source_hash": "54dc2166"
+  },
+  "web.admin.domaintoolbox.transfer.applyButton": {
+    "text": "Transferir domínio",
+    "source_hash": "9517aeb9"
+  },
+  "web.admin.domaintoolbox.transfer.success": {
+    "text": "Domínio transferido com sucesso.",
+    "source_hash": "bbca9de9"
+  },
+  "web.admin.domaintoolbox.transfer.confirmTitle": {
+    "text": "Transferir a propriedade do domínio?",
+    "source_hash": "d306a15a"
+  },
+  "web.admin.domaintoolbox.transfer.confirmDescription": {
+    "text": "Isto reatribui a propriedade de {domain} a outra organização. Volta a escrever o ID externo do domínio para confirmar.",
+    "source_hash": "edefd97c"
+  }
+}

--- a/locales/content/pt_PT/admin-emailtools.json
+++ b/locales/content/pt_PT/admin-emailtools.json
@@ -1,0 +1,550 @@
+{
+  "web.admin.emailtools.title": {
+    "text": "Ferramentas de e-mail",
+    "source_hash": "f9643d5a"
+  },
+  "web.admin.emailtools.description": {
+    "text": "Pré-visualiza modelos de e-mail, envia um teste de entrega e monitoriza a capacidade de entrega — os diagnósticos que anteriormente exigiam SSH.",
+    "source_hash": "be85c9e9"
+  },
+  "web.admin.emailtools.config.title": {
+    "text": "Configuração do serviço de e-mail",
+    "source_hash": "d2a71028"
+  },
+  "web.admin.emailtools.config.description": {
+    "text": "A configuração de e-mail permanente resolvida no arranque. As credenciais nunca são apresentadas — apenas se estão presentes.",
+    "source_hash": "f0e8a118"
+  },
+  "web.admin.emailtools.config.provider": {
+    "text": "Fornecedor de transporte",
+    "source_hash": "4f0e5025"
+  },
+  "web.admin.emailtools.config.senderProvider": {
+    "text": "Fornecedor de envio",
+    "source_hash": "e881964f"
+  },
+  "web.admin.emailtools.config.senderDiffers": {
+    "text": "O remetente difere do transporte",
+    "source_hash": "ab78e8f6"
+  },
+  "web.admin.emailtools.config.autoDetected": {
+    "text": "Detetado automaticamente",
+    "source_hash": "a69c7f9e"
+  },
+  "web.admin.emailtools.config.fromAddress": {
+    "text": "Endereço do remetente",
+    "source_hash": "d465bcfa"
+  },
+  "web.admin.emailtools.config.fromName": {
+    "text": "Nome do remetente",
+    "source_hash": "b28f93ea"
+  },
+  "web.admin.emailtools.config.host": {
+    "text": "Host SMTP",
+    "source_hash": "ab328f83"
+  },
+  "web.admin.emailtools.config.port": {
+    "text": "Porta",
+    "source_hash": "72e9a59f"
+  },
+  "web.admin.emailtools.config.region": {
+    "text": "Região",
+    "source_hash": "d3a008ef"
+  },
+  "web.admin.emailtools.config.hasCredentials": {
+    "text": "Credenciais configuradas",
+    "source_hash": "1c81633a"
+  },
+  "web.admin.emailtools.config.yes": {
+    "text": "Sim",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.emailtools.config.no": {
+    "text": "Não",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.emailtools.config.loggerWarning": {
+    "text": "O e-mail não está a ser entregue. O fornecedor de transporte está definido para um modo sem envio (logger, desativado ou nenhum), pelo que nenhum e-mail sai deste servidor — as mensagens de saída são escritas no registo da aplicação ou descartadas.",
+    "source_hash": "1883dfd5"
+  },
+  "web.admin.emailtools.deliverability.title": {
+    "text": "Capacidade de entrega",
+    "source_hash": "66b4d300"
+  },
+  "web.admin.emailtools.deliverability.description": {
+    "text": "O que regressa após o envio: devoluções, reclamações e a lista de supressão que protege a tua reputação de remetente.",
+    "source_hash": "e8363bb5"
+  },
+  "web.admin.emailtools.deliverability.retry": {
+    "text": "Tentar novamente",
+    "source_hash": "942087cc"
+  },
+  "web.admin.emailtools.deliverability.events.title": {
+    "text": "Eventos recentes",
+    "source_hash": "8ecce94d"
+  },
+  "web.admin.emailtools.deliverability.events.description": {
+    "text": "O feed em bruto de devoluções e reclamações, mais recentes primeiro.",
+    "source_hash": "0e7a533b"
+  },
+  "web.admin.emailtools.deliverability.events.empty": {
+    "text": "Ainda não há dados de devoluções ou reclamações. Encaminha o feedback do teu ESP através de POST /api/colonel/email/deliverability/events (autenticado como colonel — consulta a documentação do endpoint para o formato do registo). As devoluções definitivas síncronas de SMTP são registadas automaticamente.",
+    "source_hash": "a90f259c"
+  },
+  "web.admin.emailtools.deliverability.events.loadError": {
+    "text": "Não foi possível carregar os eventos recentes.",
+    "source_hash": "02244c61"
+  },
+  "web.admin.emailtools.deliverability.events.columns.time": {
+    "text": "Hora",
+    "source_hash": "33b93476"
+  },
+  "web.admin.emailtools.deliverability.events.columns.kind": {
+    "text": "Tipo",
+    "source_hash": "baaddf70"
+  },
+  "web.admin.emailtools.deliverability.events.columns.address": {
+    "text": "Endereço",
+    "source_hash": "56ef8f20"
+  },
+  "web.admin.emailtools.deliverability.events.columns.source": {
+    "text": "Origem",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.emailtools.deliverability.events.columns.reason": {
+    "text": "Motivo",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.emailtools.deliverability.events.kinds.bounce": {
+    "text": "devolução",
+    "source_hash": "4d6723e5"
+  },
+  "web.admin.emailtools.deliverability.events.kinds.complaint": {
+    "text": "reclamação",
+    "source_hash": "5d08b02d"
+  },
+  "web.admin.emailtools.deliverability.lookup.title": {
+    "text": "Consulta de destinatário",
+    "source_hash": "7569985b"
+  },
+  "web.admin.emailtools.deliverability.lookup.description": {
+    "text": "Verifica se um endereço está suprimido, tanto no armazenamento local como em direto no fornecedor de e-mail ativo. Ambos são indexados pelo mesmo endereço normalizado.",
+    "source_hash": "c341d614"
+  },
+  "web.admin.emailtools.deliverability.lookup.addressLabel": {
+    "text": "Endereço do destinatário",
+    "source_hash": "454d0391"
+  },
+  "web.admin.emailtools.deliverability.lookup.submit": {
+    "text": "Consultar",
+    "source_hash": "504101bc"
+  },
+  "web.admin.emailtools.deliverability.lookup.local": {
+    "text": "Armazenamento local",
+    "source_hash": "c740d116"
+  },
+  "web.admin.emailtools.deliverability.lookup.provider": {
+    "text": "Fornecedor",
+    "source_hash": "472590ae"
+  },
+  "web.admin.emailtools.deliverability.lookup.suppressed": {
+    "text": "Suprimido",
+    "source_hash": "435c7831"
+  },
+  "web.admin.emailtools.deliverability.lookup.notSuppressed": {
+    "text": "Não suprimido",
+    "source_hash": "7b1544d7"
+  },
+  "web.admin.emailtools.deliverability.lookup.reason": {
+    "text": "Motivo",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.emailtools.deliverability.lookup.source": {
+    "text": "Origem",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.emailtools.deliverability.lookup.unavailable": {
+    "text": "A consulta em direto ao fornecedor está indisponível; o armazenamento local acima é a fonte autoritativa.",
+    "source_hash": "aebed0f2"
+  },
+  "web.admin.emailtools.deliverability.messages.title": {
+    "text": "Envios recentes",
+    "source_hash": "522e089e"
+  },
+  "web.admin.emailtools.deliverability.messages.description": {
+    "text": "As mensagens mais recentes que o fornecedor de e-mail ativo registou, mais recentes primeiro. Obtidas em direto do fornecedor — nunca armazenadas aqui.",
+    "source_hash": "9970fa0a"
+  },
+  "web.admin.emailtools.deliverability.messages.empty": {
+    "text": "O fornecedor não devolveu mensagens recentes.",
+    "source_hash": "a7ef4d79"
+  },
+  "web.admin.emailtools.deliverability.messages.notSupported": {
+    "text": "Não está disponível um registo de envios no transporte {provider}, que não oferece API por mensagem.",
+    "source_hash": "21e6b6f9"
+  },
+  "web.admin.emailtools.deliverability.messages.error": {
+    "text": "Não foi possível carregar o registo de envios do fornecedor. Tenta novamente.",
+    "source_hash": "4f671e55"
+  },
+  "web.admin.emailtools.deliverability.messages.col.status": {
+    "text": "Estado",
+    "source_hash": "920e413c"
+  },
+  "web.admin.emailtools.deliverability.messages.col.subject": {
+    "text": "Assunto",
+    "source_hash": "68971283"
+  },
+  "web.admin.emailtools.deliverability.messages.col.to": {
+    "text": "Para",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.emailtools.deliverability.messages.col.created": {
+    "text": "Enviado",
+    "source_hash": "c16bc82b"
+  },
+  "web.admin.emailtools.deliverability.messages.status.delivered": {
+    "text": "entregue",
+    "source_hash": "373e0712"
+  },
+  "web.admin.emailtools.deliverability.messages.status.opened": {
+    "text": "aberto",
+    "source_hash": "50236627"
+  },
+  "web.admin.emailtools.deliverability.messages.status.clicked": {
+    "text": "clicado",
+    "source_hash": "d66440b2"
+  },
+  "web.admin.emailtools.deliverability.messages.status.pending": {
+    "text": "pendente",
+    "source_hash": "62a2fed3"
+  },
+  "web.admin.emailtools.deliverability.messages.status.queued": {
+    "text": "em fila",
+    "source_hash": "d36be649"
+  },
+  "web.admin.emailtools.deliverability.messages.status.processed": {
+    "text": "processado",
+    "source_hash": "58190ffa"
+  },
+  "web.admin.emailtools.deliverability.messages.status.hard_bounced": {
+    "text": "devolvido definitivamente",
+    "source_hash": "b0aa6fd4"
+  },
+  "web.admin.emailtools.deliverability.messages.status.soft_bounced": {
+    "text": "devolvido temporariamente",
+    "source_hash": "ac844ff2"
+  },
+  "web.admin.emailtools.deliverability.messages.status.complained": {
+    "text": "reclamado",
+    "source_hash": "c26fe786"
+  },
+  "web.admin.emailtools.deliverability.messages.status.suppressed": {
+    "text": "suprimido",
+    "source_hash": "f63d5b6b"
+  },
+  "web.admin.emailtools.deliverability.messages.status.unsubscribed": {
+    "text": "subscrição cancelada",
+    "source_hash": "621e1970"
+  },
+  "web.admin.emailtools.deliverability.summary.loadError": {
+    "text": "Não foi possível carregar o resumo da capacidade de entrega.",
+    "source_hash": "0c16ef96"
+  },
+  "web.admin.emailtools.deliverability.suppressions.title": {
+    "text": "Lista de supressão",
+    "source_hash": "9f3e322f"
+  },
+  "web.admin.emailtools.deliverability.suppressions.description": {
+    "text": "Endereços que o e-mail de saída ignora. As entradas provêm da ingestão de feedback do ESP ou de importação manual; remover uma retoma a entrega.",
+    "source_hash": "3651887e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.searchLabel": {
+    "text": "Endereço exato",
+    "source_hash": "f4338ff8"
+  },
+  "web.admin.emailtools.deliverability.suppressions.searchPlaceholder": {
+    "text": "utilizador{'@'}exemplo.com",
+    "source_hash": "333f0f15"
+  },
+  "web.admin.emailtools.deliverability.suppressions.searchButton": {
+    "text": "Consultar",
+    "source_hash": "504101bc"
+  },
+  "web.admin.emailtools.deliverability.suppressions.clearButton": {
+    "text": "Limpar",
+    "source_hash": "83b12c22"
+  },
+  "web.admin.emailtools.deliverability.suppressions.empty": {
+    "text": "Ainda não há endereços suprimidos. Aparecerão aqui à medida que o feedback de devoluções e reclamações for ingerido.",
+    "source_hash": "dd3f4d61"
+  },
+  "web.admin.emailtools.deliverability.suppressions.emptySearch": {
+    "text": "Nenhuma entrada de supressão para {address}.",
+    "source_hash": "200c361e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.loadError": {
+    "text": "Não foi possível carregar a lista de supressão.",
+    "source_hash": "2a12c8ba"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.addressLabel": {
+    "text": "Adicionar endereço",
+    "source_hash": "8be5aa33"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.button": {
+    "text": "Suprimir",
+    "source_hash": "60b19987"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.confirmTitle": {
+    "text": "Suprimir este endereço?",
+    "source_hash": "40a0d2a6"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.confirmDescription": {
+    "text": "O e-mail de saída para {address} será ignorado até a supressão ser removida. Isto é registado como uma entrada manual.",
+    "source_hash": "e3d0d799"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.success": {
+    "text": "Endereço {address} suprimido.",
+    "source_hash": "e2cd2c3b"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.successExisting": {
+    "text": "O endereço {address} já estava suprimido; entrada atualizada.",
+    "source_hash": "0852101e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.error": {
+    "text": "Não foi possível suprimir o endereço.",
+    "source_hash": "dad9e000"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.address": {
+    "text": "Endereço",
+    "source_hash": "56ef8f20"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.reason": {
+    "text": "Motivo",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.source": {
+    "text": "Origem",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.added": {
+    "text": "Adicionado",
+    "source_hash": "6b02e0d3"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.actions": {
+    "text": "Ações",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.button": {
+    "text": "Remover",
+    "source_hash": "c3812fc4"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.confirmTitle": {
+    "text": "Remover esta supressão?",
+    "source_hash": "0b0aec2e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.confirmDescription": {
+    "text": "O e-mail de saída para {address} será retomado. Este endereço foi anteriormente devolvido ou reclamado — remove-o apenas se souberes que já é entregável novamente.",
+    "source_hash": "09442f9c"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.success": {
+    "text": "Supressão removida para {address}.",
+    "source_hash": "bfc0de36"
+  },
+  "web.admin.emailtools.deliverability.sync.title": {
+    "text": "Sincronização de feedback",
+    "source_hash": "d4056915"
+  },
+  "web.admin.emailtools.deliverability.sync.lastSynced": {
+    "text": "última sincronização",
+    "source_hash": "5a99666b"
+  },
+  "web.admin.emailtools.deliverability.sync.imported": {
+    "text": "{count} importados",
+    "source_hash": "1bc18c45"
+  },
+  "web.admin.emailtools.deliverability.sync.neverRun": {
+    "text": "A sincronização de feedback do fornecedor nunca foi executada. Os dados de devoluções e reclamações não estão a ser importados automaticamente — configura uma sincronização do fornecedor ou ingere feedback através do endpoint de eventos.",
+    "source_hash": "d19f5755"
+  },
+  "web.admin.emailtools.deliverability.sync.button": {
+    "text": "Sincronizar agora",
+    "source_hash": "885e8f48"
+  },
+  "web.admin.emailtools.deliverability.sync.success": {
+    "text": "Sincronização do {provider} concluída: {accepted} importados, {rejected} rejeitados ({fetched} obtidos).",
+    "source_hash": "d36f5578"
+  },
+  "web.admin.emailtools.deliverability.sync.hint": {
+    "text": "Uma sincronização manual — a importação automática continua a exigir um cron agendado `ots email sync-feedback`.",
+    "source_hash": "7a509b75"
+  },
+  "web.admin.emailtools.deliverability.tiles.suppressed": {
+    "text": "Endereços suprimidos",
+    "source_hash": "b31a245e"
+  },
+  "web.admin.emailtools.deliverability.tiles.bounces": {
+    "text": "Devoluções ({days}d)",
+    "source_hash": "3a4d0f09"
+  },
+  "web.admin.emailtools.deliverability.tiles.complaints": {
+    "text": "Reclamações ({days}d)",
+    "source_hash": "16ad856f"
+  },
+  "web.admin.emailtools.deliverability.tiles.skipped": {
+    "text": "Envios ignorados",
+    "source_hash": "391467f9"
+  },
+  "web.admin.emailtools.preview.title": {
+    "text": "Pré-visualização do modelo",
+    "source_hash": "df89bd92"
+  },
+  "web.admin.emailtools.preview.description": {
+    "text": "Compõe um modelo com os respetivos dados de exemplo. A pré-visualização não tem efeitos secundários — nenhum e-mail é enviado.",
+    "source_hash": "9b0e40f3"
+  },
+  "web.admin.emailtools.preview.templateLabel": {
+    "text": "Modelo",
+    "source_hash": "0575f29d"
+  },
+  "web.admin.emailtools.preview.formatLabel": {
+    "text": "Formato",
+    "source_hash": "2f343666"
+  },
+  "web.admin.emailtools.preview.localeLabel": {
+    "text": "Idioma",
+    "source_hash": "ca3dc612"
+  },
+  "web.admin.emailtools.preview.button": {
+    "text": "Pré-visualizar",
+    "source_hash": "324b134f"
+  },
+  "web.admin.emailtools.providerStatus.title": {
+    "text": "Estado do fornecedor",
+    "source_hash": "231b7f03"
+  },
+  "web.admin.emailtools.providerStatus.rateUnavailable": {
+    "text": "Este fornecedor não expõe qualquer taxa numérica de devoluções ou reclamações; o nível de reputação acima é derivado apenas do estado de aplicação e da quota de envio.",
+    "source_hash": "1e6b82e9"
+  },
+  "web.admin.emailtools.providerStatus.complaintsUnavailable": {
+    "text": "O Lettermint não reporta reclamações na sua API de estatísticas, pelo que a taxa de reclamações é apresentada como “—” (não reportada), e não zero. A taxa de devoluções acima está completa.",
+    "source_hash": "72aaa845"
+  },
+  "web.admin.emailtools.providerStatus.unavailable": {
+    "text": "O estado do fornecedor está temporariamente indisponível.",
+    "source_hash": "8e69ff29"
+  },
+  "web.admin.emailtools.providerStatus.notSupported": {
+    "text": "O estado em direto do fornecedor não está disponível no transporte {provider}.",
+    "source_hash": "125ed6eb"
+  },
+  "web.admin.emailtools.providerStatus.error": {
+    "text": "Não foi possível contactar o fornecedor de e-mail para obter o estado. Tenta novamente.",
+    "source_hash": "594ab7b1"
+  },
+  "web.admin.emailtools.providerStatus.quota.max24h": {
+    "text": "Limite de envio em 24h",
+    "source_hash": "e5ea4c3d"
+  },
+  "web.admin.emailtools.providerStatus.quota.sent24h": {
+    "text": "Enviados (últimas 24h)",
+    "source_hash": "d0c4fe45"
+  },
+  "web.admin.emailtools.providerStatus.quota.maxRate": {
+    "text": "Taxa máxima de envio (por seg.)",
+    "source_hash": "59e76cf8"
+  },
+  "web.admin.emailtools.providerStatus.rate.bounce": {
+    "text": "Taxa de devoluções",
+    "source_hash": "9eba32f0"
+  },
+  "web.admin.emailtools.providerStatus.rate.complaint": {
+    "text": "Taxa de reclamações",
+    "source_hash": "430a23a9"
+  },
+  "web.admin.emailtools.providerStatus.stats.sent": {
+    "text": "Enviados ({days}d)",
+    "source_hash": "e553b7e1"
+  },
+  "web.admin.emailtools.providerStatus.stats.delivered": {
+    "text": "Entregues",
+    "source_hash": "90611565"
+  },
+  "web.admin.emailtools.providerStatus.stats.hardBounced": {
+    "text": "Devolvidos definitivamente",
+    "source_hash": "c76631c0"
+  },
+  "web.admin.emailtools.providerStatus.stats.complaints": {
+    "text": "Reclamações de spam",
+    "source_hash": "d48953cd"
+  },
+  "web.admin.emailtools.providerStatus.tier.healthy": {
+    "text": "Saudável",
+    "source_hash": "7f1e323b"
+  },
+  "web.admin.emailtools.providerStatus.tier.probation": {
+    "text": "Em análise",
+    "source_hash": "9e8a3b64"
+  },
+  "web.admin.emailtools.providerStatus.tier.shutdown": {
+    "text": "Envio em pausa",
+    "source_hash": "52e6757c"
+  },
+  "web.admin.emailtools.test.title": {
+    "text": "Envio de teste",
+    "source_hash": "5fab5d67"
+  },
+  "web.admin.emailtools.test.description": {
+    "text": "Envia um e-mail de diagnóstico em texto simples para verificar a conetividade de entrega. Pré-visualiza primeiro, depois confirma para enviar um e-mail real.",
+    "source_hash": "4130741c"
+  },
+  "web.admin.emailtools.test.toLabel": {
+    "text": "Destinatário",
+    "source_hash": "51fac985"
+  },
+  "web.admin.emailtools.test.toPlaceholder": {
+    "text": "utilizador{'@'}exemplo.com",
+    "source_hash": "cf0a9acc"
+  },
+  "web.admin.emailtools.test.enqueueLabel": {
+    "text": "Através da fila de workers",
+    "source_hash": "97897017"
+  },
+  "web.admin.emailtools.test.previewButton": {
+    "text": "Pré-visualizar (sem envio)",
+    "source_hash": "747ced83"
+  },
+  "web.admin.emailtools.test.sendButton": {
+    "text": "Enviar e-mail de teste",
+    "source_hash": "46ebd7db"
+  },
+  "web.admin.emailtools.test.provider": {
+    "text": "Fornecedor",
+    "source_hash": "472590ae"
+  },
+  "web.admin.emailtools.test.host": {
+    "text": "Host de origem",
+    "source_hash": "968925cb"
+  },
+  "web.admin.emailtools.test.from": {
+    "text": "Remetente",
+    "source_hash": "21819769"
+  },
+  "web.admin.emailtools.test.subject": {
+    "text": "Assunto",
+    "source_hash": "68971283"
+  },
+  "web.admin.emailtools.test.confirmTitle": {
+    "text": "Enviar um e-mail de teste real?",
+    "source_hash": "64a16b62"
+  },
+  "web.admin.emailtools.test.confirmDescription": {
+    "text": "Isto envia um e-mail em direto para {to} através do serviço de e-mail configurado.",
+    "source_hash": "10114929"
+  },
+  "web.admin.emailtools.test.success": {
+    "text": "E-mail de teste enviado para {to}.",
+    "source_hash": "daa61a62"
+  }
+}

--- a/locales/content/pt_PT/admin-kit.json
+++ b/locales/content/pt_PT/admin-kit.json
@@ -1,0 +1,66 @@
+{
+  "web.admin.kit.confirmDialog.typePrompt": {
+    "text": "Para confirmar, escreve {token} abaixo",
+    "source_hash": "282445b6"
+  },
+  "web.admin.kit.confirmDialog.inputLabel": {
+    "text": "Texto de confirmação",
+    "source_hash": "8edc1113"
+  },
+  "web.admin.kit.confirmDialog.mismatchHint": {
+    "text": "O texto introduzido tem de corresponder exatamente para continuar.",
+    "source_hash": "f0cc7389"
+  },
+  "web.admin.kit.dataTable.empty": {
+    "text": "Nenhum registo encontrado",
+    "source_hash": "6e2ea637"
+  },
+  "web.admin.kit.dataTable.sortBy": {
+    "text": "Ordenar por {column}",
+    "source_hash": "55fb1bf9"
+  },
+  "web.admin.kit.filterBar.search": {
+    "text": "Pesquisar",
+    "source_hash": "49c266ba"
+  },
+  "web.admin.kit.filterBar.searchPlaceholder": {
+    "text": "Pesquisar…",
+    "source_hash": "7336265a"
+  },
+  "web.admin.kit.filterBar.clearFilters": {
+    "text": "Limpar filtros",
+    "source_hash": "7179ea00"
+  },
+  "web.admin.kit.filterBar.all": {
+    "text": "Todos",
+    "source_hash": "a52ace42"
+  },
+  "web.admin.kit.jsonViewer.expandAll": {
+    "text": "Expandir tudo",
+    "source_hash": "a3e586be"
+  },
+  "web.admin.kit.jsonViewer.collapseAll": {
+    "text": "Recolher tudo",
+    "source_hash": "25f7b372"
+  },
+  "web.admin.kit.jsonViewer.empty": {
+    "text": "Sem dados",
+    "source_hash": "3b41ba9c"
+  },
+  "web.admin.kit.jsonViewer.copyLabel": {
+    "text": "Copiar JSON",
+    "source_hash": "7708c6e2"
+  },
+  "web.admin.kit.revealEmail.reveal": {
+    "text": "Mostrar endereço de e-mail",
+    "source_hash": "f6272277"
+  },
+  "web.admin.kit.revealEmail.hide": {
+    "text": "Ocultar endereço de e-mail",
+    "source_hash": "9755e870"
+  },
+  "web.admin.kit.revealEmail.copy": {
+    "text": "Copiar endereço de e-mail",
+    "source_hash": "61b94846"
+  }
+}

--- a/locales/content/pt_PT/admin-organizations.json
+++ b/locales/content/pt_PT/admin-organizations.json
@@ -1,0 +1,314 @@
+{
+  "web.admin.organizations.retry": {
+    "text": "Tentar novamente",
+    "source_hash": "942087cc"
+  },
+  "web.admin.organizations.detail.backToList": {
+    "text": "Voltar às organizações",
+    "source_hash": "2257dc4a"
+  },
+  "web.admin.organizations.detail.notFound": {
+    "text": "Organização não encontrada",
+    "source_hash": "00c50f7a"
+  },
+  "web.admin.organizations.detail.notFoundDescription": {
+    "text": "Esta organização pode ter sido eliminada, ou o id está incorreto.",
+    "source_hash": "e5459ef5"
+  },
+  "web.admin.organizations.detail.loadError": {
+    "text": "Não foi possível carregar esta organização.",
+    "source_hash": "9df8ad50"
+  },
+  "web.admin.organizations.detail.none": {
+    "text": "—",
+    "source_hash": "bda05058"
+  },
+  "web.admin.organizations.detail.badges.default": {
+    "text": "Espaço de trabalho predefinido",
+    "source_hash": "6d67c6eb"
+  },
+  "web.admin.organizations.detail.badges.archived": {
+    "text": "Arquivado",
+    "source_hash": "bdb86505"
+  },
+  "web.admin.organizations.detail.domains.domain": {
+    "text": "Domínio",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.organizations.detail.domains.state": {
+    "text": "Estado",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.organizations.detail.domains.created": {
+    "text": "Criado",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.organizations.detail.domains.ready": {
+    "text": "Pronto",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.organizations.detail.domains.resolving": {
+    "text": "A resolver",
+    "source_hash": "3287a034"
+  },
+  "web.admin.organizations.detail.domains.empty": {
+    "text": "Sem domínios.",
+    "source_hash": "1b840c7e"
+  },
+  "web.admin.organizations.detail.entitlements.description": {
+    "text": "Os direitos efetivos resolvem-se para (plano ∪ concessões) − revogações. Revê a repartição antes de fazer uma substituição.",
+    "source_hash": "23080475"
+  },
+  "web.admin.organizations.detail.entitlements.inSync": {
+    "text": "Sincronizado",
+    "source_hash": "5701958c"
+  },
+  "web.admin.organizations.detail.entitlements.driftBadge": {
+    "text": "Divergência",
+    "source_hash": "8b4c8240"
+  },
+  "web.admin.organizations.detail.entitlements.staleBadge": {
+    "text": "Plano desatualizado",
+    "source_hash": "ffe63800"
+  },
+  "web.admin.organizations.detail.entitlements.driftWarning": {
+    "text": "Os direitos materializados não correspondem ao conjunto esperado. Reconcilia para materializar novamente.",
+    "source_hash": "4859983a"
+  },
+  "web.admin.organizations.detail.entitlements.driftExtra": {
+    "text": "Adicionais (materializados, não esperados)",
+    "source_hash": "08d60730"
+  },
+  "web.admin.organizations.detail.entitlements.driftMissing": {
+    "text": "Em falta (esperados, não materializados)",
+    "source_hash": "fe12c83a"
+  },
+  "web.admin.organizations.detail.entitlements.plan": {
+    "text": "Do plano",
+    "source_hash": "1d346b26"
+  },
+  "web.admin.organizations.detail.entitlements.materialized": {
+    "text": "Materializados (efetivos)",
+    "source_hash": "72ca5f45"
+  },
+  "web.admin.organizations.detail.members.email": {
+    "text": "Membro",
+    "source_hash": "7c968fb7"
+  },
+  "web.admin.organizations.detail.members.role": {
+    "text": "Função",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.organizations.detail.members.status": {
+    "text": "Estado",
+    "source_hash": "920e413c"
+  },
+  "web.admin.organizations.detail.members.joined": {
+    "text": "Aderiu",
+    "source_hash": "69318b0c"
+  },
+  "web.admin.organizations.detail.members.owner": {
+    "text": "Proprietário",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.detail.members.empty": {
+    "text": "Sem membros.",
+    "source_hash": "b99c59dc"
+  },
+  "web.admin.organizations.detail.reconcile.button": {
+    "text": "Reconciliar",
+    "source_hash": "b59be565"
+  },
+  "web.admin.organizations.detail.reconcile.confirmTitle": {
+    "text": "Reconciliar a faturação da organização?",
+    "source_hash": "fc1a2762"
+  },
+  "web.admin.organizations.detail.reconcile.confirmDescription": {
+    "text": "Isto volta a obter os dados do Stripe e reescreve o estado de faturação e os direitos de {org}. Volta a escrever o id da organização para confirmar.",
+    "source_hash": "b4ef0850"
+  },
+  "web.admin.organizations.detail.reconcile.success": {
+    "text": "Organização reconciliada.",
+    "source_hash": "caf87844"
+  },
+  "web.admin.organizations.detail.reconcile.resultTitle": {
+    "text": "Resultado da reconciliação",
+    "source_hash": "11f4c6b8"
+  },
+  "web.admin.organizations.detail.reconcile.before": {
+    "text": "Antes",
+    "source_hash": "9bb72500"
+  },
+  "web.admin.organizations.detail.reconcile.after": {
+    "text": "Depois",
+    "source_hash": "7b68fe55"
+  },
+  "web.admin.organizations.detail.reconcile.materializedCount": {
+    "text": "Número de direitos",
+    "source_hash": "59cede5c"
+  },
+  "web.admin.organizations.detail.reconcile.mode.stripe_sync": {
+    "text": "Sincronização com o Stripe",
+    "source_hash": "02f9546c"
+  },
+  "web.admin.organizations.detail.reconcile.mode.entitlements_only": {
+    "text": "Apenas direitos",
+    "source_hash": "8cf49a5d"
+  },
+  "web.admin.organizations.detail.sections.billing": {
+    "text": "Faturação",
+    "source_hash": "3ac8bbca"
+  },
+  "web.admin.organizations.detail.sections.members": {
+    "text": "Membros",
+    "source_hash": "1044a4c0"
+  },
+  "web.admin.organizations.detail.sections.domains": {
+    "text": "Domínios",
+    "source_hash": "ced67718"
+  },
+  "web.admin.organizations.detail.sections.investigate": {
+    "text": "Investigar e reconciliar",
+    "source_hash": "b05aa349"
+  },
+  "web.admin.organizations.entitlements.section": {
+    "text": "Substituições de direitos",
+    "source_hash": "48812068"
+  },
+  "web.admin.organizations.entitlements.description": {
+    "text": "Concede ou revoga direitos independentemente do plano. Efetivos = direitos do plano + concessões - revogações.",
+    "source_hash": "4c38425b"
+  },
+  "web.admin.organizations.entitlements.inputLabel": {
+    "text": "Direito",
+    "source_hash": "0d8f0b2d"
+  },
+  "web.admin.organizations.entitlements.placeholder": {
+    "text": "p. ex. custom_domains",
+    "source_hash": "05346c68"
+  },
+  "web.admin.organizations.entitlements.grant": {
+    "text": "Conceder",
+    "source_hash": "78b7d037"
+  },
+  "web.admin.organizations.entitlements.revoke": {
+    "text": "Revogar",
+    "source_hash": "87e6d00b"
+  },
+  "web.admin.organizations.entitlements.clear": {
+    "text": "Limpar todas as substituições",
+    "source_hash": "f0e485c3"
+  },
+  "web.admin.organizations.entitlements.effective": {
+    "text": "Direitos efetivos",
+    "source_hash": "b840f8c8"
+  },
+  "web.admin.organizations.entitlements.grants": {
+    "text": "Concessões",
+    "source_hash": "b3e1c95a"
+  },
+  "web.admin.organizations.entitlements.revokes": {
+    "text": "Revogações",
+    "source_hash": "f0e69b17"
+  },
+  "web.admin.organizations.entitlements.noOverrides": {
+    "text": "Executa uma ação para ver o estado atual das substituições desta organização.",
+    "source_hash": "98d2e30d"
+  },
+  "web.admin.organizations.entitlements.confirm.grantTitle": {
+    "text": "Conceder direito?",
+    "source_hash": "a4b2c57b"
+  },
+  "web.admin.organizations.entitlements.confirm.grantDescription": {
+    "text": "Conceder “{entitlement}” a {org}. Isto altera os direitos de faturação da organização.",
+    "source_hash": "542ce26a"
+  },
+  "web.admin.organizations.entitlements.confirm.revokeTitle": {
+    "text": "Revogar direito?",
+    "source_hash": "c93d520a"
+  },
+  "web.admin.organizations.entitlements.confirm.revokeDescription": {
+    "text": "Revogar “{entitlement}” de {org}. Isto altera os direitos de faturação da organização.",
+    "source_hash": "a5d2a8a6"
+  },
+  "web.admin.organizations.entitlements.confirm.clearTitle": {
+    "text": "Limpar todas as substituições de direitos?",
+    "source_hash": "e36eb218"
+  },
+  "web.admin.organizations.entitlements.confirm.clearDescription": {
+    "text": "Remover todas as substituições de concessão e revogação de {org}, repondo-a nos direitos do seu plano.",
+    "source_hash": "96bad079"
+  },
+  "web.admin.organizations.entitlements.success.granted": {
+    "text": "Direito “{entitlement}” concedido.",
+    "source_hash": "cf52fb0e"
+  },
+  "web.admin.organizations.entitlements.success.revoked": {
+    "text": "Direito “{entitlement}” revogado.",
+    "source_hash": "279d425d"
+  },
+  "web.admin.organizations.entitlements.success.cleared": {
+    "text": "Todas as substituições de direitos foram limpas.",
+    "source_hash": "a482743b"
+  },
+  "web.admin.organizations.fields.contactEmail": {
+    "text": "E-mail de contacto",
+    "source_hash": "6d7fce11"
+  },
+  "web.admin.organizations.fields.owner": {
+    "text": "Proprietário",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.fields.plan": {
+    "text": "Plano",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.organizations.fields.subscription": {
+    "text": "Estado da subscrição",
+    "source_hash": "f0723c4e"
+  },
+  "web.admin.organizations.fields.periodEnd": {
+    "text": "Fim do período",
+    "source_hash": "eeae9fdd"
+  },
+  "web.admin.organizations.fields.billingEmail": {
+    "text": "E-mail de faturação",
+    "source_hash": "8805b928"
+  },
+  "web.admin.organizations.fields.stripeCustomer": {
+    "text": "Cliente Stripe",
+    "source_hash": "8f169be1"
+  },
+  "web.admin.organizations.fields.stripeSubscription": {
+    "text": "Subscrição Stripe",
+    "source_hash": "53f71e08"
+  },
+  "web.admin.organizations.fields.orgId": {
+    "text": "ID da organização",
+    "source_hash": "1f466322"
+  },
+  "web.admin.organizations.fields.created": {
+    "text": "Criado",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.organizations.fields.updated": {
+    "text": "Atualizado",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.organizations.investigate.description": {
+    "text": "Compara o estado de faturação local com a subscrição ativa do Stripe.",
+    "source_hash": "d7bbe9ed"
+  },
+  "web.admin.organizations.investigate.rawPayload": {
+    "text": "Payload de investigação em bruto",
+    "source_hash": "29ca7df2"
+  },
+  "web.admin.organizations.investigate.parseError": {
+    "text": "A resposta de investigação não correspondeu ao formato esperado.",
+    "source_hash": "db59cab1"
+  },
+  "web.admin.organizations.list.loadError": {
+    "text": "Não foi possível carregar as organizações.",
+    "source_hash": "130d5e70"
+  }
+}

--- a/locales/content/pt_PT/admin-overview.json
+++ b/locales/content/pt_PT/admin-overview.json
@@ -1,0 +1,94 @@
+{
+  "web.admin.overview.retry": {
+    "text": "Tentar novamente",
+    "source_hash": "942087cc"
+  },
+  "web.admin.overview.feedback.title": {
+    "text": "Comentários dos utilizadores",
+    "source_hash": "cb7b24c6"
+  },
+  "web.admin.overview.feedback.total": {
+    "text": "{count} nos últimos 30 dias",
+    "source_hash": "b6b9147c"
+  },
+  "web.admin.overview.feedback.today": {
+    "text": "Hoje",
+    "source_hash": "2b065c7c"
+  },
+  "web.admin.overview.feedback.yesterday": {
+    "text": "Ontem",
+    "source_hash": "56618125"
+  },
+  "web.admin.overview.feedback.older": {
+    "text": "Mais antigos",
+    "source_hash": "03281c88"
+  },
+  "web.admin.overview.feedback.empty": {
+    "text": "Sem comentários neste período",
+    "source_hash": "e09d594d"
+  },
+  "web.admin.overview.feedback.loadError": {
+    "text": "Não foi possível carregar os comentários.",
+    "source_hash": "4011c408"
+  },
+  "web.admin.overview.stats.heading": {
+    "text": "Estatísticas da plataforma",
+    "source_hash": "77728e4d"
+  },
+  "web.admin.overview.stats.customers": {
+    "text": "Clientes",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.overview.stats.secrets": {
+    "text": "Mensagens confidenciais ativas",
+    "source_hash": "8db4c552"
+  },
+  "web.admin.overview.stats.sessions": {
+    "text": "Sessões ativas",
+    "source_hash": "61ad9909"
+  },
+  "web.admin.overview.stats.receipts": {
+    "text": "Comprovativos",
+    "source_hash": "60a627df"
+  },
+  "web.admin.overview.stats.secretsCreated": {
+    "text": "Mensagens confidenciais criadas (total)",
+    "source_hash": "bdb49794"
+  },
+  "web.admin.overview.stats.emailsSent": {
+    "text": "E-mails enviados (total)",
+    "source_hash": "1c9a7518"
+  },
+  "web.admin.overview.stats.loadError": {
+    "text": "Não foi possível carregar as estatísticas da plataforma.",
+    "source_hash": "5f13cf7a"
+  },
+  "web.admin.overview.trends.title": {
+    "text": "Últimos 30 dias",
+    "source_hash": "f8f03fb4"
+  },
+  "web.admin.overview.trends.signups": {
+    "text": "Registos por dia",
+    "source_hash": "8db399dc"
+  },
+  "web.admin.overview.trends.secretsCreated": {
+    "text": "Mensagens confidenciais criadas por dia",
+    "source_hash": "d6852656"
+  },
+  "web.admin.overview.trends.today": {
+    "text": "hoje",
+    "source_hash": "e0f4f767"
+  },
+  "web.admin.overview.trends.collectingNote": {
+    "text": "A recolher desde o primeiro ponto de dados — os dias anteriores mostram zero.",
+    "source_hash": "269ee1eb"
+  },
+  "web.admin.overview.trends.sparklineAria": {
+    "text": "{label}: tendência de 30 dias, {count} hoje",
+    "source_hash": "eb57a7b2"
+  },
+  "web.admin.overview.trends.loadError": {
+    "text": "Não foi possível carregar as tendências.",
+    "source_hash": "9cf97f63"
+  }
+}

--- a/locales/content/pt_PT/admin-secrets.json
+++ b/locales/content/pt_PT/admin-secrets.json
@@ -1,0 +1,218 @@
+{
+  "web.admin.secrets.title": {
+    "text": "Mensagens confidenciais",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.secrets.description": {
+    "text": "Inspeciona o comprovativo de uma mensagem confidencial e elimina-a sem SSH — consulta-a pela respetiva chave.",
+    "source_hash": "07775a11"
+  },
+  "web.admin.secrets.never": {
+    "text": "Nunca",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.secrets.anonymous": {
+    "text": "Anónimo",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.admin.secrets.ageDays": {
+    "text": "{days} dias",
+    "source_hash": "a2246fbc"
+  },
+  "web.admin.secrets.actions.delete.button": {
+    "text": "Eliminar mensagem confidencial",
+    "source_hash": "1a48c8c8"
+  },
+  "web.admin.secrets.actions.delete.confirmTitle": {
+    "text": "Eliminar mensagem confidencial?",
+    "source_hash": "4a779a67"
+  },
+  "web.admin.secrets.actions.delete.confirmDescription": {
+    "text": "Isto elimina permanentemente a mensagem confidencial {shortid} e o respetivo comprovativo. Esta ação não pode ser anulada.",
+    "source_hash": "51f807ad"
+  },
+  "web.admin.secrets.actions.delete.success": {
+    "text": "Mensagem confidencial eliminada.",
+    "source_hash": "52f1640f"
+  },
+  "web.admin.secrets.detail.yes": {
+    "text": "Sim",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.secrets.detail.no": {
+    "text": "Não",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.secrets.detail.none": {
+    "text": "Nenhum",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.secrets.fields.secretId": {
+    "text": "ID da mensagem confidencial",
+    "source_hash": "79592419"
+  },
+  "web.admin.secrets.fields.shortId": {
+    "text": "ID curto",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.secrets.fields.state": {
+    "text": "Estado",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.secrets.fields.created": {
+    "text": "Criado",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.secrets.fields.updated": {
+    "text": "Atualizado",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.secrets.fields.expiration": {
+    "text": "Validade",
+    "source_hash": "f38d6e0e"
+  },
+  "web.admin.secrets.fields.age": {
+    "text": "Idade",
+    "source_hash": "39b7370f"
+  },
+  "web.admin.secrets.fields.lifespan": {
+    "text": "Duração",
+    "source_hash": "58994285"
+  },
+  "web.admin.secrets.fields.owner": {
+    "text": "Proprietário",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.secrets.fields.receiptId": {
+    "text": "ID do comprovativo",
+    "source_hash": "2c13d799"
+  },
+  "web.admin.secrets.fields.hasCiphertext": {
+    "text": "Tem texto cifrado",
+    "source_hash": "e9188bad"
+  },
+  "web.admin.secrets.fields.ciphertextLength": {
+    "text": "Comprimento do texto cifrado",
+    "source_hash": "0f1744fd"
+  },
+  "web.admin.secrets.lookup.label": {
+    "text": "Chave da mensagem confidencial",
+    "source_hash": "f47a99eb"
+  },
+  "web.admin.secrets.lookup.placeholder": {
+    "text": "Identificador da mensagem confidencial",
+    "source_hash": "cbcfd49f"
+  },
+  "web.admin.secrets.lookup.button": {
+    "text": "Consultar",
+    "source_hash": "504101bc"
+  },
+  "web.admin.secrets.lookup.resultTitle": {
+    "text": "Mensagem confidencial {shortid}",
+    "source_hash": "8b311d32"
+  },
+  "web.admin.secrets.lookup.notFound": {
+    "text": "Mensagem confidencial não encontrada",
+    "source_hash": "70a9532c"
+  },
+  "web.admin.secrets.lookup.notFoundDescription": {
+    "text": "Não existe nenhuma mensagem confidencial com esta chave. Pode ter expirado ou sido eliminada.",
+    "source_hash": "9f068a81"
+  },
+  "web.admin.secrets.lookup.loadError": {
+    "text": "Não foi possível carregar esta mensagem confidencial.",
+    "source_hash": "c96672e4"
+  },
+  "web.admin.secrets.lookup.retry": {
+    "text": "Tentar novamente",
+    "source_hash": "942087cc"
+  },
+  "web.admin.secrets.owner.anonymous": {
+    "text": "Anónimo (sem proprietário)",
+    "source_hash": "390f11ad"
+  },
+  "web.admin.secrets.ownerFields.email": {
+    "text": "E-mail",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.secrets.ownerFields.userId": {
+    "text": "ID do utilizador",
+    "source_hash": "7967e089"
+  },
+  "web.admin.secrets.ownerFields.role": {
+    "text": "Função",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.secrets.ownerFields.verified": {
+    "text": "Verificado",
+    "source_hash": "4f783840"
+  },
+  "web.admin.secrets.receipt.none": {
+    "text": "Não há nenhum comprovativo associado a esta mensagem confidencial.",
+    "source_hash": "5ddceaed"
+  },
+  "web.admin.secrets.receiptFields.receiptId": {
+    "text": "ID do comprovativo",
+    "source_hash": "2c13d799"
+  },
+  "web.admin.secrets.receiptFields.shortId": {
+    "text": "ID curto",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.secrets.receiptFields.state": {
+    "text": "Estado",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.secrets.receiptFields.secretTtl": {
+    "text": "TTL da mensagem confidencial",
+    "source_hash": "b89c0b51"
+  },
+  "web.admin.secrets.receiptFields.recipients": {
+    "text": "Destinatários",
+    "source_hash": "1e8568a8"
+  },
+  "web.admin.secrets.receiptFields.hasPassphrase": {
+    "text": "Tem frase secreta",
+    "source_hash": "af458f26"
+  },
+  "web.admin.secrets.receiptFields.shareDomain": {
+    "text": "Domínio de partilha",
+    "source_hash": "db963805"
+  },
+  "web.admin.secrets.receiptFields.created": {
+    "text": "Criado",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.secrets.receiptFields.secretExpired": {
+    "text": "Mensagem confidencial expirada",
+    "source_hash": "c127dab6"
+  },
+  "web.admin.secrets.sections.secret": {
+    "text": "Mensagem confidencial",
+    "source_hash": "7e32a729"
+  },
+  "web.admin.secrets.sections.receipt": {
+    "text": "Comprovativo",
+    "source_hash": "dad5a969"
+  },
+  "web.admin.secrets.sections.owner": {
+    "text": "Proprietário",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.secrets.sections.raw": {
+    "text": "Em bruto",
+    "source_hash": "848123d1"
+  },
+  "web.admin.secrets.state.new": {
+    "text": "Novo",
+    "source_hash": "18fdd549"
+  },
+  "web.admin.secrets.state.received": {
+    "text": "Recebido",
+    "source_hash": "49f19bee"
+  },
+  "web.admin.secrets.state.viewed": {
+    "text": "Visto",
+    "source_hash": "1b28d178"
+  }
+}

--- a/locales/content/pt_PT/admin-sessions.json
+++ b/locales/content/pt_PT/admin-sessions.json
@@ -1,0 +1,210 @@
+{
+  "web.admin.sessions.title": {
+    "text": "Sessões",
+    "source_hash": "6fa3cbf4"
+  },
+  "web.admin.sessions.description": {
+    "text": "Inspeciona, pesquisa e revoga sessões ativas para resposta a incidentes.",
+    "source_hash": "784a3a44"
+  },
+  "web.admin.sessions.anonymous": {
+    "text": "Anónimo",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.admin.sessions.columns.sessionId": {
+    "text": "ID da sessão",
+    "source_hash": "cb9ac5c5"
+  },
+  "web.admin.sessions.columns.authenticated": {
+    "text": "Autenticação",
+    "source_hash": "8eb3ea9b"
+  },
+  "web.admin.sessions.columns.email": {
+    "text": "E-mail",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.sessions.columns.externalId": {
+    "text": "ID externo",
+    "source_hash": "69da56ba"
+  },
+  "web.admin.sessions.columns.ipAddress": {
+    "text": "Endereço IP",
+    "source_hash": "3c3de0c9"
+  },
+  "web.admin.sessions.columns.created": {
+    "text": "Autenticado em",
+    "source_hash": "8d6c9b01"
+  },
+  "web.admin.sessions.columns.actions": {
+    "text": "Ações",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.sessions.columns.role": {
+    "text": "Função",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.sessions.detail.yes": {
+    "text": "Sim",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.sessions.detail.no": {
+    "text": "Não",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.sessions.detail.none": {
+    "text": "Nenhum",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.sessions.detail.unknown": {
+    "text": "Desconhecido",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.sessions.detail.noExpiry": {
+    "text": "Sem validade",
+    "source_hash": "fe06351d"
+  },
+  "web.admin.sessions.detail.expired": {
+    "text": "Expirada",
+    "source_hash": "424a2551"
+  },
+  "web.admin.sessions.detail.ttlSeconds": {
+    "text": "{seconds}s restantes",
+    "source_hash": "3c9d75ce"
+  },
+  "web.admin.sessions.drawer.title": {
+    "text": "Sessão {id}",
+    "source_hash": "29dcbd66"
+  },
+  "web.admin.sessions.drawer.notFound": {
+    "text": "Sessão não encontrada",
+    "source_hash": "0969eab8"
+  },
+  "web.admin.sessions.drawer.notFoundDescription": {
+    "text": "Esta sessão já não existe no Redis. Pode ter expirado ou já ter sido revogada.",
+    "source_hash": "11e3ef05"
+  },
+  "web.admin.sessions.drawer.loadError": {
+    "text": "Não foi possível carregar esta sessão.",
+    "source_hash": "82ae90fb"
+  },
+  "web.admin.sessions.drawer.retry": {
+    "text": "Tentar novamente",
+    "source_hash": "942087cc"
+  },
+  "web.admin.sessions.fields.sessionId": {
+    "text": "ID da sessão",
+    "source_hash": "cb9ac5c5"
+  },
+  "web.admin.sessions.fields.key": {
+    "text": "Chave Redis",
+    "source_hash": "0b196725"
+  },
+  "web.admin.sessions.fields.ttl": {
+    "text": "TTL",
+    "source_hash": "76f6014f"
+  },
+  "web.admin.sessions.fields.authenticated": {
+    "text": "Autenticado",
+    "source_hash": "6ab694cf"
+  },
+  "web.admin.sessions.fields.email": {
+    "text": "E-mail",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.sessions.fields.externalId": {
+    "text": "ID externo",
+    "source_hash": "69da56ba"
+  },
+  "web.admin.sessions.fields.accountId": {
+    "text": "ID da conta",
+    "source_hash": "919bb4cb"
+  },
+  "web.admin.sessions.fields.role": {
+    "text": "Função",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.sessions.fields.locale": {
+    "text": "Idioma",
+    "source_hash": "ca3dc612"
+  },
+  "web.admin.sessions.fields.ipAddress": {
+    "text": "Endereço IP",
+    "source_hash": "3c3de0c9"
+  },
+  "web.admin.sessions.fields.authenticatedAt": {
+    "text": "Autenticado em",
+    "source_hash": "8d6c9b01"
+  },
+  "web.admin.sessions.fields.authenticatedBy": {
+    "text": "Autenticado por",
+    "source_hash": "3ebbabfe"
+  },
+  "web.admin.sessions.fields.activeSessionId": {
+    "text": "ID da sessão ativa",
+    "source_hash": "f32b1158"
+  },
+  "web.admin.sessions.fields.userAgent": {
+    "text": "User Agent",
+    "source_hash": "62e01345"
+  },
+  "web.admin.sessions.fields.orgContext": {
+    "text": "Contexto da organização",
+    "source_hash": "a596d9f2"
+  },
+  "web.admin.sessions.list.loadError": {
+    "text": "Não foi possível carregar as sessões.",
+    "source_hash": "00c678d9"
+  },
+  "web.admin.sessions.list.retry": {
+    "text": "Tentar novamente",
+    "source_hash": "942087cc"
+  },
+  "web.admin.sessions.list.empty": {
+    "text": "Nenhuma sessão ativa encontrada",
+    "source_hash": "e35312d6"
+  },
+  "web.admin.sessions.revoke.button": {
+    "text": "Revogar",
+    "source_hash": "87e6d00b"
+  },
+  "web.admin.sessions.revoke.confirmTitle": {
+    "text": "Revogar esta sessão?",
+    "source_hash": "0c6605c1"
+  },
+  "web.admin.sessions.revoke.confirmDescription": {
+    "text": "Isto termina imediatamente a sessão do utilizador ao eliminar a sessão {id}. Escreve o ID da sessão para confirmar.",
+    "source_hash": "9e08b1b8"
+  },
+  "web.admin.sessions.revoke.success": {
+    "text": "Sessão revogada",
+    "source_hash": "0af5e14d"
+  },
+  "web.admin.sessions.scan.summary": {
+    "text": "A mostrar {shown} autenticadas · {anonymous} anónimas ocultas · {scanned} analisadas",
+    "source_hash": "34cb67a4"
+  },
+  "web.admin.sessions.scan.capped": {
+    "text": "Análise limitada às primeiras {scanned} chaves — as sessões autenticadas além desta janela não são listadas. Inspeciona uma sessão específica pelo ID para lá chegares.",
+    "source_hash": "fa418b4e"
+  },
+  "web.admin.sessions.search.placeholder": {
+    "text": "Pesquisar por e-mail ou ID externo",
+    "source_hash": "f2dc5c06"
+  },
+  "web.admin.sessions.sections.session": {
+    "text": "Sessão",
+    "source_hash": "6959b415"
+  },
+  "web.admin.sessions.sections.raw": {
+    "text": "Dados da sessão em bruto",
+    "source_hash": "c9f11eb4"
+  },
+  "web.admin.sessions.status.authenticated": {
+    "text": "Autenticado",
+    "source_hash": "6ab694cf"
+  },
+  "web.admin.sessions.status.anonymous": {
+    "text": "Anónimo",
+    "source_hash": "e7a8aa2d"
+  }
+}

--- a/locales/content/pt_PT/admin-system.json
+++ b/locales/content/pt_PT/admin-system.json
@@ -1,0 +1,158 @@
+{
+  "web.admin.system.title": {
+    "text": "Sistema",
+    "source_hash": "6725e7bb"
+  },
+  "web.admin.system.description": {
+    "text": "Estado da base de dados, das filas e da infraestrutura.",
+    "source_hash": "0115f495"
+  },
+  "web.admin.system.retry": {
+    "text": "Tentar novamente",
+    "source_hash": "942087cc"
+  },
+  "web.admin.system.database.title": {
+    "text": "Base de dados principal ({engine})",
+    "source_hash": "1391230b"
+  },
+  "web.admin.system.database.loadError": {
+    "text": "Não foi possível carregar as métricas da base de dados.",
+    "source_hash": "905055c6"
+  },
+  "web.admin.system.database.server": {
+    "text": "Servidor",
+    "source_hash": "aef7de28"
+  },
+  "web.admin.system.database.memory": {
+    "text": "Memória",
+    "source_hash": "c3963aed"
+  },
+  "web.admin.system.database.databases": {
+    "text": "Bases de dados",
+    "source_hash": "61d2afe2"
+  },
+  "web.admin.system.database.dbSummary": {
+    "text": "{keys} chaves, {expires} com TTL",
+    "source_hash": "26b9e17c"
+  },
+  "web.admin.system.database.fields.version": {
+    "text": "Versão",
+    "source_hash": "dd167905"
+  },
+  "web.admin.system.database.fields.mode": {
+    "text": "Modo",
+    "source_hash": "5e23ec6a"
+  },
+  "web.admin.system.database.fields.uptimeDays": {
+    "text": "Tempo de atividade (dias)",
+    "source_hash": "7ab314f8"
+  },
+  "web.admin.system.database.fields.connectedClients": {
+    "text": "Clientes ligados",
+    "source_hash": "434adc3a"
+  },
+  "web.admin.system.database.fields.opsPerSec": {
+    "text": "Ops/seg.",
+    "source_hash": "6634251d"
+  },
+  "web.admin.system.database.fields.totalCommands": {
+    "text": "Total de comandos",
+    "source_hash": "c5ce5aaf"
+  },
+  "web.admin.system.database.fields.usedMemory": {
+    "text": "Memória utilizada",
+    "source_hash": "bac68a65"
+  },
+  "web.admin.system.database.fields.rssMemory": {
+    "text": "Memória RSS",
+    "source_hash": "7fe77d15"
+  },
+  "web.admin.system.database.fields.peakMemory": {
+    "text": "Memória máxima",
+    "source_hash": "9d44afa6"
+  },
+  "web.admin.system.database.fields.fragmentation": {
+    "text": "Rácio de fragmentação",
+    "source_hash": "721494dd"
+  },
+  "web.admin.system.database.stats.customers": {
+    "text": "Clientes",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.system.database.stats.secrets": {
+    "text": "Mensagens confidenciais",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.system.database.stats.receipts": {
+    "text": "Comprovativos",
+    "source_hash": "60a627df"
+  },
+  "web.admin.system.database.stats.totalKeys": {
+    "text": "Total de chaves",
+    "source_hash": "4e0d27f5"
+  },
+  "web.admin.system.queue.title": {
+    "text": "Fila",
+    "source_hash": "3b2fe03e"
+  },
+  "web.admin.system.queue.loadError": {
+    "text": "Não foi possível carregar as métricas da fila.",
+    "source_hash": "715bdc88"
+  },
+  "web.admin.system.queue.empty": {
+    "text": "Nenhuma fila encontrada",
+    "source_hash": "3cd4eb88"
+  },
+  "web.admin.system.queue.connected": {
+    "text": "Ligado",
+    "source_hash": "22965568"
+  },
+  "web.admin.system.queue.disconnected": {
+    "text": "Desligado",
+    "source_hash": "04dfac36"
+  },
+  "web.admin.system.queue.activeWorkers": {
+    "text": "{count} workers ativos",
+    "source_hash": "49e6369c"
+  },
+  "web.admin.system.queue.columns.name": {
+    "text": "Fila",
+    "source_hash": "3b2fe03e"
+  },
+  "web.admin.system.queue.columns.pending": {
+    "text": "Pendentes",
+    "source_hash": "331551b0"
+  },
+  "web.admin.system.queue.columns.consumers": {
+    "text": "Consumidores",
+    "source_hash": "212b350d"
+  },
+  "web.admin.system.queue.health.healthy": {
+    "text": "Saudável",
+    "source_hash": "7f1e323b"
+  },
+  "web.admin.system.queue.health.degraded": {
+    "text": "Degradado",
+    "source_hash": "a8494c12"
+  },
+  "web.admin.system.queue.health.unhealthy": {
+    "text": "Não saudável",
+    "source_hash": "317b1fbc"
+  },
+  "web.admin.system.queue.health.unknown": {
+    "text": "Desconhecido",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.system.redis.title": {
+    "text": "Redis INFO",
+    "source_hash": "e762bd3c"
+  },
+  "web.admin.system.redis.loadError": {
+    "text": "Não foi possível carregar as métricas do Redis.",
+    "source_hash": "ca5945d6"
+  },
+  "web.admin.system.redis.captured": {
+    "text": "Capturado em {at}",
+    "source_hash": "57b40c0f"
+  }
+}

--- a/locales/content/pt_PT/admin-usage.json
+++ b/locales/content/pt_PT/admin-usage.json
@@ -1,0 +1,78 @@
+{
+  "web.admin.usage.title": {
+    "text": "Utilização",
+    "source_hash": "8d59829c"
+  },
+  "web.admin.usage.description": {
+    "text": "Exporta métricas de utilização para um intervalo de datas.",
+    "source_hash": "97bd3325"
+  },
+  "web.admin.usage.startDate": {
+    "text": "Data de início",
+    "source_hash": "4c52faad"
+  },
+  "web.admin.usage.endDate": {
+    "text": "Data de fim",
+    "source_hash": "e970951c"
+  },
+  "web.admin.usage.fetch": {
+    "text": "Obter dados",
+    "source_hash": "429532fe"
+  },
+  "web.admin.usage.loadError": {
+    "text": "Não foi possível carregar os dados de utilização.",
+    "source_hash": "ffb557d7"
+  },
+  "web.admin.usage.retry": {
+    "text": "Tentar novamente",
+    "source_hash": "942087cc"
+  },
+  "web.admin.usage.empty": {
+    "text": "Sem dados para este intervalo",
+    "source_hash": "5fed1795"
+  },
+  "web.admin.usage.byState": {
+    "text": "Mensagens confidenciais por estado",
+    "source_hash": "916bbcb6"
+  },
+  "web.admin.usage.secretsByDay": {
+    "text": "Mensagens confidenciais por dia",
+    "source_hash": "24a01e8e"
+  },
+  "web.admin.usage.usersByDay": {
+    "text": "Novos utilizadores por dia",
+    "source_hash": "8c1f089f"
+  },
+  "web.admin.usage.exportJson": {
+    "text": "Transferir JSON",
+    "source_hash": "49e0e6d5"
+  },
+  "web.admin.usage.exportCsv": {
+    "text": "Transferir CSV",
+    "source_hash": "a4023b89"
+  },
+  "web.admin.usage.columns.date": {
+    "text": "Data",
+    "source_hash": "99c40ab4"
+  },
+  "web.admin.usage.columns.count": {
+    "text": "Contagem",
+    "source_hash": "37bac495"
+  },
+  "web.admin.usage.stats.totalSecrets": {
+    "text": "Total de mensagens confidenciais",
+    "source_hash": "e17a5459"
+  },
+  "web.admin.usage.stats.newUsers": {
+    "text": "Novos utilizadores",
+    "source_hash": "d3ee48b0"
+  },
+  "web.admin.usage.stats.avgSecrets": {
+    "text": "Média de mensagens/dia",
+    "source_hash": "948b0701"
+  },
+  "web.admin.usage.stats.avgUsers": {
+    "text": "Média de utilizadores/dia",
+    "source_hash": "491f626d"
+  }
+}

--- a/locales/content/pt_PT/api-domains-errors.json
+++ b/locales/content/pt_PT/api-domains-errors.json
@@ -34,5 +34,17 @@
   "api.domains.errors.recipients_duplicate": {
     "text": "Não são permitidos e-mails de destinatário duplicados",
     "source_hash": "6de22182"
+  },
+  "api.domains.errors.homepage_secrets_mode_invalid": {
+    "text": "secrets_mode inválido: %{secrets_mode}",
+    "source_hash": "cf093a04"
+  },
+  "api.domains.errors.homepage_incoming_entitlement_required": {
+    "text": "O modo de mensagens confidenciais recebidas requer o direito incoming_secrets. Faz upgrade do teu plano.",
+    "source_hash": "d68b13d8"
+  },
+  "api.domains.errors.homepage_incoming_not_ready": {
+    "text": "As mensagens confidenciais recebidas têm de estar ativadas com pelo menos um destinatário antes de poderem ser usadas como página inicial.",
+    "source_hash": "556da6e2"
   }
 }

--- a/locales/content/pt_PT/api-invite-errors.json
+++ b/locales/content/pt_PT/api-invite-errors.json
@@ -12,8 +12,8 @@
     "source_hash": "a5df7d22"
   },
   "api.invite.errors.invitation_already_processed": {
-    "text": "O convite já foi %{status}",
-    "source_hash": "130c87e0"
+    "text": "Este convite já foi processado",
+    "source_hash": "4cfedf4f"
   },
   "api.invite.errors.invitation_expired": {
     "text": "O convite expirou",
@@ -26,5 +26,13 @@
   "api.invite.errors.already_member": {
     "text": "Já és membro desta organização",
     "source_hash": "f56ad547"
+  },
+  "api.invite.errors.invitation_already_accepted": {
+    "text": "Este convite já foi aceite",
+    "source_hash": "8f9daf0f"
+  },
+  "api.invite.errors.invitation_already_declined": {
+    "text": "Este convite já foi recusado",
+    "source_hash": "96e0d626"
   }
 }

--- a/locales/content/pt_PT/api-secrets-errors.json
+++ b/locales/content/pt_PT/api-secrets-errors.json
@@ -10,5 +10,9 @@
   "api.secrets.errors.domain_permission_anonymous_cross_domain": {
     "text": "Não tens permissão para usar o domínio: %{domain}",
     "source_hash": "b41920ba"
+  },
+  "api.secrets.errors.secret_undecryptable": {
+    "text": "Esta mensagem confidencial não pode ser desencriptada neste momento. O link continua intacto — o operador do site tem de restaurar a chave de encriptação antes de poder ser revelada.",
+    "source_hash": "56e283ee"
   }
 }

--- a/locales/content/pt_PT/email.json
+++ b/locales/content/pt_PT/email.json
@@ -62,7 +62,7 @@
   "email.welcome.signature": {
     "text": "Equipa de Suporte",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.welcome.postscript": {
     "text": "P.S. Este e-mail foi enviado para %{email_address}. Se não criaste uma conta, podes ignorar esta mensagem com segurança.",
@@ -102,7 +102,7 @@
   "email.password_request.signature": {
     "text": "Equipa de Suporte",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.password_request.postscript": {
     "text": "P.S. Este e-mail foi enviado para %{email_address}.",
@@ -147,7 +147,7 @@
   "email.magic_link.signature": {
     "text": "Equipa de Suporte",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.magic_link.postscript": {
     "text": "P.S. Este e-mail foi enviado para %{email_address}.",
@@ -232,7 +232,7 @@
   "email.secret_revealed.signature": {
     "text": "Equipa de Suporte",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.secret_revealed.manage_preferences": {
     "text": "Gerir preferências de notificação",
@@ -357,7 +357,7 @@
   "email.organization_invitation.signature": {
     "text": "Equipa de Suporte",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.organization_invitation.postscript": {
     "text": "P.S. Este e-mail foi enviado para %{invited_email}. Se não estavas à espera deste convite, podes ignorar esta mensagem com segurança.",
@@ -397,17 +397,17 @@
   "email.password_changed.signature": {
     "text": "Equipa de Suporte",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_changed.subject": {
     "text": "O teu endereço de e-mail foi alterado (%{display_domain})",
     "renderer": "erb",
-    "source_hash": "d68d2f4c"
+    "source_hash": "4386fc57"
   },
   "email.email_changed.title": {
     "text": "O teu endereço de e-mail foi alterado",
     "renderer": "erb",
-    "source_hash": "62b07299"
+    "source_hash": "db70f965"
   },
   "email.email_changed.security_notice": {
     "text": "Se não fizeste esta alteração, por favor contacta o suporte imediatamente pois a tua conta pode estar comprometida.",
@@ -415,9 +415,9 @@
     "source_hash": "f505b562"
   },
   "email.email_changed.change_notice": {
-    "text": "O endereço de e-mail da sua conta %{product_name} foi alterado.",
+    "text": "O endereço de e-mail da tua conta %{product_name} foi alterado.",
     "renderer": "erb",
-    "source_hash": "bb467ebc"
+    "source_hash": "7fc0e27c"
   },
   "email.email_changed.new_email_label": {
     "text": "Novo e-mail:",
@@ -447,7 +447,7 @@
   "email.email_changed.signature": {
     "text": "Equipa de Suporte",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_changed.postscript": {
     "text": "P.S. Este e-mail foi enviado para %{email_address} para o notificar de uma alteração de endereço de e-mail.",
@@ -497,7 +497,7 @@
   "email.email_change_requested.signature": {
     "text": "Equipa de Suporte",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_change_requested.postscript": {
     "text": "P.S. Este e-mail foi enviado para %{email_address} porque foi solicitada uma alteração de e-mail para a sua conta.",
@@ -552,7 +552,7 @@
   "email.email_change_confirmation.signature": {
     "text": "Equipa de Suporte",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_change_confirmation.postscript": {
     "text": "P.S. Este e-mail foi enviado para %{email_address} para confirmar uma alteração de endereço de e-mail.",
@@ -582,7 +582,7 @@
   "email.mfa_enabled.signature": {
     "text": "Equipa de Suporte",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.mfa_disabled.subject": {
     "text": "Autenticação de dois fatores desativada (%{display_domain})",
@@ -607,7 +607,7 @@
   "email.mfa_disabled.signature": {
     "text": "Equipa de Suporte",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.new_login_alert.subject": {
     "text": "Novo início de sessão na tua conta (%{display_domain})",
@@ -652,7 +652,7 @@
   "email.new_login_alert.signature": {
     "text": "Equipa de Suporte",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.member_removed.subject": {
     "text": "Foste removido de %{organization_name}",
@@ -672,7 +672,7 @@
   "email.member_removed.signature": {
     "text": "Equipa de Suporte",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.role_changed.subject": {
     "text": "O teu papel foi alterado em %{organization_name}",
@@ -692,7 +692,7 @@
   "email.role_changed.signature": {
     "text": "Equipa de Suporte",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.organization_deleted.subject": {
     "text": "A organização \"%{organization_name}\" foi eliminada",
@@ -712,7 +712,7 @@
   "email.organization_deleted.signature": {
     "text": "Equipa de Suporte",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.trial_expiring.subject": {
     "text": "O teu período de teste %{product_name} expira em %{days_remaining} dias",
@@ -737,7 +737,7 @@
   "email.trial_expiring.signature": {
     "text": "Equipa de Suporte",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.subscription_changed.subject": {
     "text": "A tua subscrição %{product_name} foi alterada",
@@ -762,7 +762,7 @@
   "email.subscription_changed.signature": {
     "text": "Equipa de Suporte",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.common.greeting": {
     "text": "Olá,",

--- a/locales/content/pt_PT/feature-regions.json
+++ b/locales/content/pt_PT/feature-regions.json
@@ -152,8 +152,8 @@
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "Se o teu e-mail de contacto de faturação for diferente do e-mail da tua conta {product_name}, utiliza o e-mail de contacto de faturação da conta da nova região para manter os benefícios da tua subscrição.",
-    "source_hash": "dac1cc28"
+    "text": "Se o teu e-mail de contacto de faturação for diferente do e-mail da tua conta {product_name}, usa o e-mail de contacto de faturação para a conta da nova região a fim de manteres os benefícios da tua subscrição.",
+    "source_hash": "d49662b0"
   },
   "web.regions.changing_regions_subscription_note": {
     "text": "Os benefícios da sua subscrição serão aplicados automaticamente a qualquer conta criada com o seu endereço de e-mail de faturação.",

--- a/locales/content/pt_PT/feature-translations.json
+++ b/locales/content/pt_PT/feature-translations.json
@@ -65,7 +65,7 @@
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
     "text": "As seguintes pessoas doaram o seu tempo para ajudar a ampliar o alcance do {product_name}:",
-    "source_hash": "85a766af"
+    "source_hash": "6cc876ae"
   },
   "web.translations.translations": {
     "text": "Traduções",
@@ -84,8 +84,8 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "Desde 2012, o {product_name} oferece uma forma segura de partilhar informação sensível em todo o mundo. Com utilizadores em regiões onde o inglês não é a língua principal, traduções rigorosas são essenciais para tornar a comunicação segura acessível a todos.",
-    "source_hash": "87a6e9af"
+    "text": "Desde 2012, o {product_name} tem proporcionado uma forma segura de partilhar informação sensível em todo o mundo. Com utilizadores em regiões onde o inglês não é a língua principal, as traduções rigorosas são essenciais para tornar a comunicação segura acessível a todos.",
+    "source_hash": "ded965d5"
   },
   "web.translations.help_secure_communication_go_global": {
     "text": "Ajuda a comunicação segura a tornar-se global",

--- a/locales/content/pt_PT/secret-homepage.json
+++ b/locales/content/pt_PT/secret-homepage.json
@@ -57,7 +57,7 @@
   },
   "web.homepage.visit_onetime_secret_home": {
     "text": "Visitar a página inicial do {product_name}",
-    "source_hash": "625556d2"
+    "source_hash": "87802af5"
   },
   "web.homepage.password_generation_title": {
     "text": "Gerador de palavras-passe",
@@ -108,16 +108,16 @@
     "source_hash": "107093e4"
   },
   "web.homepage.about_onetime_secret_0": {
-    "text": "Acerca do {product_name}",
-    "source_hash": "971c50da"
+    "text": "Sobre o {product_name}",
+    "source_hash": "b3046356"
   },
   "web.homepage.log_in_to_onetime_secret": {
     "text": "Iniciar sessão no {product_name}",
-    "source_hash": "bd6be8d6"
+    "source_hash": "b2e364a4"
   },
   "web.homepage.about_onetime_secret": {
-    "text": "Acerca do {product_name}",
-    "source_hash": "971c50da"
+    "text": "Sobre o {product_name}",
+    "source_hash": "b3046356"
   },
   "web.homepage.signup_individual_and_business_plans": {
     "text": "Registo - Planos individuais e empresariais",
@@ -137,19 +137,19 @@
   },
   "web.homepage.onetime_secret": {
     "text": "{product_name}",
-    "source_hash": "1cd0194a"
+    "source_hash": "7bec5899"
   },
   "web.homepage.onetime_secret_literal": {
     "text": "{product_name}",
-    "source_hash": "1cd0194a"
+    "source_hash": "7bec5899"
   },
   "web.homepage.one_time_secret_literal": {
     "text": "{product_name}",
-    "source_hash": "7872e050"
+    "source_hash": "7bec5899"
   },
   "web.homepage.onetime_secret_homepage": {
     "text": "Página inicial do {product_name}",
-    "source_hash": "44bb0581"
+    "source_hash": "0792b61e"
   },
   "web.homepage.send_sensitive_information_that_can_only_be_viewed_once": {
     "text": "Envia informação sensível que só pode ser visualizada uma vez",
@@ -169,11 +169,11 @@
   },
   "web.homepage.welcome_to_onetime_secret": {
     "text": "Bem-vindo ao {product_name}.",
-    "source_hash": "0990d163"
+    "source_hash": "f4f49058"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
     "text": "O {product_name} ajuda-nos a partilhar informação sensível de forma segura, mantendo a nossa fachada profissional.",
-    "source_hash": "986a0856"
+    "source_hash": "7e9192bd"
   },
   "web.homepage.information_shared_through_this_service_can_only": {
     "text": "As informações partilhadas através deste serviço só podem ser acedidas uma vez. Uma vez visualizado, o conteúdo é permanentemente eliminado para garantir a confidencialidade.",
@@ -182,5 +182,13 @@
   "web.homepage.welcome_to_the_global_broadcast": {
     "text": "Bem-vindo à transmissão global!",
     "source_hash": "210e1894"
+  },
+  "web.homepage.send_a_secret": {
+    "text": "Enviar uma mensagem confidencial",
+    "source_hash": "31fd9e03"
+  },
+  "web.homepage.deliver_sensitive_information_directly_and_securely": {
+    "text": "Entrega informação sensível diretamente à nossa equipa. Só pode ser vista uma vez.",
+    "source_hash": "9976cf01"
   }
 }

--- a/locales/content/pt_PT/secret-manage.json
+++ b/locales/content/pt_PT/secret-manage.json
@@ -56,8 +56,8 @@
     "source_hash": "2e5a27e1"
   },
   "web.secrets.sample_secret_content_this_could_be_sensitive_data": {
-    "text": "Conteúdo confidencial de exemplo Isto pode ser dados sensíveis Ou uma mensagem de várias linhas",
-    "source_hash": "b3be3902"
+    "text": "Conteúdo confidencial de exemplo. Podem ser dados sensíveis\n\nOu uma mensagem de várias linhas",
+    "source_hash": "5e1bffcb"
   },
   "web.secrets.sample_secret_content": {
     "text": "Conteúdo confidencial de exemplo",
@@ -129,7 +129,7 @@
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
     "text": "O {product_name} é uma forma segura de partilhar informação sensível que se autodestrói após uma única visualização.",
-    "source_hash": "8a163297"
+    "source_hash": "bd0c6182"
   },
   "web.secrets.what_is_this": {
     "text": "O que é isto?",

--- a/locales/content/pt_PT/session-auth-extended.json
+++ b/locales/content/pt_PT/session-auth-extended.json
@@ -155,8 +155,8 @@
     "source_hash": "d726c0da"
   },
   "web.auth.magicLink.sessionExpired": {
-    "text": "A sua sessão expirou. Atualize a página e tente novamente.",
-    "source_hash": "a7c3e901"
+    "text": "A tua sessão expirou. Atualiza a página e tenta novamente.",
+    "source_hash": "be9ed96d"
   },
   "web.auth.magicLink.loginFailed": {
     "text": "Início de sessão falhou. Por favor tenta novamente.",

--- a/locales/content/pt_PT/session-auth.json
+++ b/locales/content/pt_PT/session-auth.json
@@ -373,8 +373,8 @@
     "source_hash": "afd25fdf"
   },
   "web.help.use_magic_link_instead": {
-    "text": "Utilize a opção Link Mágico para iniciar sessão sem palavra-passe. Após iniciar sessão, pode alterar a sua palavra-passe nas Definições da Conta.",
-    "source_hash": "2a058600"
+    "text": "Podes pedir um link de redefinição de palavra-passe para criar uma nova palavra-passe.",
+    "source_hash": "3c3eabad"
   },
   "web.help.account_locked": {
     "text": "Conta temporariamente bloqueada?",
@@ -431,5 +431,57 @@
   "web.login.errors.domain_not_allowed": {
     "text": "O teu domínio de e-mail não está autorizado para o registo via SSO. Contacta o teu administrador.",
     "source_hash": "87603782"
+  },
+  "web.auth.check_email.title": {
+    "text": "Verifica o teu e-mail",
+    "source_hash": "77322879"
+  },
+  "web.auth.check_email.sent_to_generic": {
+    "text": "Enviámos um link de verificação para o teu endereço de e-mail.",
+    "source_hash": "4e5510af"
+  },
+  "web.auth.check_email.help": {
+    "text": "Enviámos um link de verificação para este endereço — abre o e-mail e clica no link para ativar a tua conta.",
+    "source_hash": "8babedc4"
+  },
+  "web.auth.check_email.spam_hint": {
+    "text": "Não o encontras? Verifica a tua pasta de spam.",
+    "source_hash": "d166d9a4"
+  },
+  "web.auth.check_email.wrong_email": {
+    "text": "Introduziste o endereço errado?",
+    "source_hash": "0aa863e5"
+  },
+  "web.auth.check_email.start_over": {
+    "text": "Começar de novo",
+    "source_hash": "5eed7e9f"
+  },
+  "web.auth.field-errors.password": {
+    "text": "Palavra-passe",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.auth.verify.resend_help_text": {
+    "text": "Não recebeste o e-mail de verificação? Introduz o teu e-mail para o reenviar.",
+    "source_hash": "e0df48bb"
+  },
+  "web.auth.verify.resend_button": {
+    "text": "Reenviar e-mail de verificação",
+    "source_hash": "5173cc04"
+  },
+  "web.auth.verify.resend_sent": {
+    "text": "Se alguma conta precisar de verificação, foi enviado um novo e-mail. Verifica a tua caixa de entrada e a pasta de spam.",
+    "source_hash": "6f838ffb"
+  },
+  "web.auth.verify.resend_error": {
+    "text": "Não foi possível enviar o e-mail de verificação. Verifica a tua ligação e tenta novamente.",
+    "source_hash": "15149f46"
+  },
+  "web.auth.verify.resend_short": {
+    "text": "Reenviar e-mail",
+    "source_hash": "4f44603e"
+  },
+  "web.login.verified_notice": {
+    "text": "O teu e-mail foi verificado — já podes iniciar sessão.",
+    "source_hash": "c8d4b5a8"
   }
 }

--- a/locales/content/pt_PT/workspace-account.json
+++ b/locales/content/pt_PT/workspace-account.json
@@ -136,8 +136,8 @@
     "source_hash": "05986d95"
   },
   "web.account.keep_this_token_secure_it_provides_full_access_t": {
-    "text": "🔐 Mantenha este token seguro! Ele fornece acesso total à sua conta.",
-    "source_hash": "8839aa4d"
+    "text": "Mantém este token seguro. Pode ser usado para criar e gerir mensagens confidenciais através da API.",
+    "source_hash": "a63cc8ec"
   },
   "web.account.confirm_with_your_password": {
     "text": "Confirme com a sua palavra-passe",
@@ -328,8 +328,8 @@
     "source_hash": "f7cfed6e"
   },
   "web.settings.profile.email_change_success": {
-    "text": "E-mail atualizado com sucesso. Por favor, verifique a sua caixa de entrada para verificar o seu novo endereço de e-mail.",
-    "source_hash": "58de2536"
+    "text": "E-mail de verificação enviado. Verifica a tua nova caixa de entrada e clica no link de confirmação para concluir a alteração.",
+    "source_hash": "45f0a4b5"
   },
   "web.settings.profile.email_change_error": {
     "text": "Falha ao atualizar e-mail. Por favor, tente novamente.",
@@ -477,7 +477,7 @@
   },
   "web.settings.api.documentation_description": {
     "text": "Saber como integrar o {product_name} nas tuas aplicações",
-    "source_hash": "6e8f910f"
+    "source_hash": "9bba1ae8"
   },
   "web.settings.api.rest_api_reference": {
     "text": "Referência da API REST",

--- a/locales/content/pt_PT/workspace-billing.json
+++ b/locales/content/pt_PT/workspace-billing.json
@@ -140,12 +140,12 @@
     "source_hash": "1f981aaf"
   },
   "web.billing.overview.no_organizations_title": {
-    "text": "Sem Organizações",
-    "source_hash": "12420110"
+    "text": "Sem espaços de trabalho",
+    "source_hash": "c7f70723"
   },
   "web.billing.overview.no_organizations_description": {
-    "text": "Crie uma organização para gerir a sua faturação e subscrição",
-    "source_hash": "41e922d2"
+    "text": "Cria um espaço de trabalho para gerir a tua faturação e subscrição",
+    "source_hash": "e0fd27a5"
   },
   "web.billing.overview.load_error": {
     "text": "Falha ao carregar informações de faturação",
@@ -204,8 +204,8 @@
     "source_hash": "883dbca9"
   },
   "web.billing.overview.entitlements.manage_org": {
-    "text": "Gerir Organizações",
-    "source_hash": "be0fe4c3"
+    "text": "Gerir Organização",
+    "source_hash": "f03a4985"
   },
   "web.billing.overview.entitlements.manage_teams": {
     "text": "Gerir Equipas",
@@ -220,8 +220,8 @@
     "source_hash": "5428d7fe"
   },
   "web.billing.overview.entitlements.sso": {
-    "text": "Single Sign-On",
-    "source_hash": "cf7cd744"
+    "text": "Single Sign-On (SSO)",
+    "source_hash": "5db5c812"
   },
   "web.billing.overview.entitlements.priority_support": {
     "text": "Suporte Prioritário",
@@ -280,8 +280,8 @@
     "source_hash": "5428d7fe"
   },
   "web.billing.features.sso": {
-    "text": "Single Sign-On (SSO)",
-    "source_hash": "5db5c812"
+    "text": "SSO",
+    "source_hash": "5ba3ac9f"
   },
   "web.billing.features.priority_support": {
     "text": "Suporte Prioritário",
@@ -577,7 +577,7 @@
   },
   "web.billing.invoices.draft": {
     "text": "Rascunho",
-    "source_hash": "d2e16e61"
+    "source_hash": "ebf12ef4"
   },
   "web.billing.invoices.open": {
     "text": "Em aberto",

--- a/locales/content/pt_PT/workspace-branding.json
+++ b/locales/content/pt_PT/workspace-branding.json
@@ -28,8 +28,8 @@
     "source_hash": "199c165f"
   },
   "web.branding.preview_and_customize": {
-    "text": "Pré-visualizar e Personalizar",
-    "source_hash": "215d3659"
+    "text": "Personalizar e pré-visualizar",
+    "source_hash": "fc68a28c"
   },
   "web.branding.switch_to_safari_browser_view": {
     "text": "Mudar para vista do navegador Safari",
@@ -88,8 +88,8 @@
     "source_hash": "43e9a2d7"
   },
   "web.branding.click_to_upload_a_logo_with_recommendation": {
-    "text": "Clique para carregar um logotipo. Tamanho recomendado: 128x128 pixels. Tamanho máximo do ficheiro: 1MB. Formatos suportados: PNG, JPG, SVG",
-    "source_hash": "a35452bf"
+    "text": "Clica para gerir o teu logótipo. Tamanho recomendado: 128x128 píxeis. Tamanho máximo do ficheiro: 1 MB. Formatos suportados: PNG, JPG, SVG",
+    "source_hash": "7bb92395"
   },
   "web.branding.upload_logo": {
     "text": "Carregar logótipo",
@@ -186,5 +186,225 @@
   "web.branding.keyhole_logo_icon": {
     "text": "Ícone de buraco de fechadura que representa a partilha segura e privada",
     "source_hash": "c868ac60"
+  },
+  "web.branding.secondary_color": {
+    "text": "Cor secundária",
+    "source_hash": "1f4728f6"
+  },
+  "web.branding.background_color": {
+    "text": "Cor de fundo",
+    "source_hash": "b48bc969"
+  },
+  "web.branding.text_color": {
+    "text": "Cor do texto",
+    "source_hash": "2ea23234"
+  },
+  "web.branding.border_radius": {
+    "text": "Raio do contorno",
+    "source_hash": "e758d7db"
+  },
+  "web.branding.heading_font": {
+    "text": "Tipo de letra dos títulos",
+    "source_hash": "6b5d30dc"
+  },
+  "web.branding.theme_presets": {
+    "text": "Predefinições de tema",
+    "source_hash": "931eeb74"
+  },
+  "web.branding.logo": {
+    "text": "Logótipo",
+    "source_hash": "d707dc2f"
+  },
+  "web.branding.replace_logo": {
+    "text": "Substituir",
+    "source_hash": "95e15439"
+  },
+  "web.branding.logo_field_hint": {
+    "text": "Pré-visualiza antes de as tuas alterações entrarem em vigor.",
+    "source_hash": "e9e222fc"
+  },
+  "web.branding.logo_modal_title": {
+    "text": "Logótipo do domínio",
+    "source_hash": "5260dda5"
+  },
+  "web.branding.logo_modal_hint": {
+    "text": "PNG, JPG ou SVG. Recomendado 128x128px, até 1 MB.",
+    "source_hash": "75d00802"
+  },
+  "web.branding.logo_modal_save": {
+    "text": "Guardar logótipo",
+    "source_hash": "8b028a6f"
+  },
+  "web.branding.remove_logo": {
+    "text": "Remover logótipo",
+    "source_hash": "f1c1afa4"
+  },
+  "web.branding.image_upload_choose": {
+    "text": "Escolher uma imagem",
+    "source_hash": "ceed9fd5"
+  },
+  "web.branding.image_upload_drag_hint": {
+    "text": "ou arrasta e larga",
+    "source_hash": "6613b73c"
+  },
+  "web.branding.image_invalid_type": {
+    "text": "Esse tipo de ficheiro não é suportado. Escolhe uma imagem.",
+    "source_hash": "50e18866"
+  },
+  "web.branding.image_too_large": {
+    "text": "A imagem é demasiado grande. O tamanho máximo é {max}.",
+    "source_hash": "b50b55e2"
+  },
+  "web.branding.image_will_be_removed": {
+    "text": "Este logótipo será removido ao guardar.",
+    "source_hash": "d94fa99a"
+  },
+  "web.branding.image_upload_failed": {
+    "text": "Algo correu mal. Tenta novamente.",
+    "source_hash": "3ccd9d65"
+  },
+  "web.branding.undo": {
+    "text": "Anular",
+    "source_hash": "a8283ade"
+  },
+  "web.branding.low_contrast_text_bg_warning": {
+    "text": "Contraste texto/fundo baixo",
+    "source_hash": "1c676370"
+  },
+  "web.branding.path_simple": {
+    "text": "Simples",
+    "source_hash": "3fee95da"
+  },
+  "web.branding.path_match": {
+    "text": "Corresponder ao meu site",
+    "source_hash": "776679cf"
+  },
+  "web.branding.path_advanced": {
+    "text": "Avançado",
+    "source_hash": "9f088dbe"
+  },
+  "web.branding.path_simple_tag": {
+    "text": "Os essenciais da tua marca.",
+    "source_hash": "7c9c0cca"
+  },
+  "web.branding.path_match_tag": {
+    "text": "Copia as definições de um site existente.",
+    "source_hash": "e4b0d1cd"
+  },
+  "web.branding.path_advanced_tag": {
+    "text": "Cria o teu próprio CSS Tailwind v4.",
+    "source_hash": "2405bb6d"
+  },
+  "web.branding.badge_default": {
+    "text": "Predefinido",
+    "source_hash": "21b111cb"
+  },
+  "web.branding.badge_coming_soon": {
+    "text": "Em breve",
+    "source_hash": "4f7d6401"
+  },
+  "web.branding.your_brand": {
+    "text": "A tua marca",
+    "source_hash": "406265d3"
+  },
+  "web.branding.your_brand_subtitle": {
+    "text": "Algumas escolhas rápidas — tratamos do resto.",
+    "source_hash": "dbc8ec33"
+  },
+  "web.branding.corners": {
+    "text": "Cantos",
+    "source_hash": "1d3cc47e"
+  },
+  "web.branding.more_options": {
+    "text": "Mais opções",
+    "source_hash": "bc79cdff"
+  },
+  "web.branding.paths_carryover_hint": {
+    "text": "Esta é uma pré-visualização em direto — as tuas alterações não serão visíveis para os visitantes até guardares.",
+    "source_hash": "cb4b82de"
+  },
+  "web.branding.coming_soon_match_blurb": {
+    "text": "Indica-nos o teu site e leremos as suas cores e tipos de letra, depois fechamos a diferença com um clique.",
+    "source_hash": "42c34cc1"
+  },
+  "web.branding.coming_soon_advanced_blurb": {
+    "text": "Edita diretamente os tokens {'@'}theme do Tailwind v4, ou cola a tua própria folha de estilos.",
+    "source_hash": "5a8473f5"
+  },
+  "web.branding.preview_recipient_page": {
+    "text": "Página do destinatário",
+    "source_hash": "de8aa19f"
+  },
+  "web.branding.preview_badge": {
+    "text": "Pré-visualização",
+    "source_hash": "324b134f"
+  },
+  "web.branding.preview_homepage_enabled": {
+    "text": "Página inicial · ativada",
+    "source_hash": "2edd85f1"
+  },
+  "web.branding.preview_homepage_disabled": {
+    "text": "Página inicial · desativada",
+    "source_hash": "15d87050"
+  },
+  "web.branding.preview_live": {
+    "text": "Pré-visualização em direto",
+    "source_hash": "f65ddc1f"
+  },
+  "web.branding.tile_share_secret": {
+    "text": "Partilhar uma mensagem confidencial",
+    "source_hash": "5384461b"
+  },
+  "web.branding.tile_create_link": {
+    "text": "Criar link confidencial",
+    "source_hash": "610fd42e"
+  },
+  "web.branding.tile_delivery_only": {
+    "text": "Apenas entrega segura de mensagens",
+    "source_hash": "dc24dec2"
+  },
+  "web.branding.tile_no_create": {
+    "text": "Os visitantes não podem criar mensagens confidenciais aqui.",
+    "source_hash": "17361d81"
+  },
+  "web.branding.recipient_page_content": {
+    "text": "Conteúdo da página do destinatário",
+    "source_hash": "937733bd"
+  },
+  "web.branding.recipient_page_content_hint": {
+    "text": "Idioma e instruções de revelação apresentados aos destinatários neste domínio.",
+    "source_hash": "04162b70"
+  },
+  "web.branding.tab_brand": {
+    "text": "Marca",
+    "source_hash": "090ed431"
+  },
+  "web.branding.tab_delivery": {
+    "text": "Entrega",
+    "source_hash": "52bfe584"
+  },
+  "web.branding.delivery_language": {
+    "text": "Idioma",
+    "source_hash": "a4fe6526"
+  },
+  "web.branding.delivery_language_hint": {
+    "text": "Predefinição para páginas de destinatário e e-mails neste domínio. Os destinatários podem mudar de idioma na página.",
+    "source_hash": "bfbc5599"
+  },
+  "web.branding.delivery_reveal_instructions": {
+    "text": "Instruções de revelação",
+    "source_hash": "7e1331f7"
+  },
+  "web.branding.delivery_reveal_instructions_hint": {
+    "text": "Apresentado na página do destinatário. Deixa em branco para usar o texto predefinido no idioma selecionado.",
+    "source_hash": "51b9811d"
+  },
+  "web.branding.delivery_before_reveal": {
+    "text": "Antes da revelação",
+    "source_hash": "5ce82b01"
+  },
+  "web.branding.delivery_after_reveal": {
+    "text": "Depois da revelação",
+    "source_hash": "d5bfe7fd"
   }
 }

--- a/locales/content/pt_PT/workspace-domains.json
+++ b/locales/content/pt_PT/workspace-domains.json
@@ -76,8 +76,8 @@
     "source_hash": "59be7133"
   },
   "web.domains.enabled": {
-    "text": "Ativado",
-    "source_hash": "92c1cdfd"
+    "text": "Ativar",
+    "source_hash": "5342e09f"
   },
   "web.domains.disabled": {
     "text": "Desativado",
@@ -1358,5 +1358,189 @@
   "web.domains.sso.upgrade_required": {
     "text": "Faz upgrade para configurar",
     "source_hash": "571cfa98"
+  },
+  "web.domains.add.field_label": {
+    "text": "Domínio personalizado",
+    "source_hash": "d7d4c1e4"
+  },
+  "web.domains.add.field_help": {
+    "text": "O nome de anfitrião exato que a tua equipa irá usar, como {example}.",
+    "source_hash": "3ba71f78"
+  },
+  "web.domains.add.echo_label": {
+    "text": "Os teus links confidenciais ficarão em",
+    "source_hash": "ad60b17d"
+  },
+  "web.domains.add.apex_question": {
+    "text": "Esse é o teu domínio completo — onde devem ficar os links confidenciais?",
+    "source_hash": "efacad1b"
+  },
+  "web.domains.add.apex_help": {
+    "text": "Um subdomínio mantém o resto de {domain} intacto.",
+    "source_hash": "0f7e6181"
+  },
+  "web.domains.add.recommended": {
+    "text": "Recomendado",
+    "source_hash": "d70604e8"
+  },
+  "web.domains.add.no_wrong_answer": {
+    "text": "Não há escolha errada — escolhe a que a tua equipa reconhecer.",
+    "source_hash": "a04f0086"
+  },
+  "web.domains.add.subdomains_label": {
+    "text": "Subdomínios populares",
+    "source_hash": "d6ee8eac"
+  },
+  "web.domains.add.root_group_label": {
+    "text": "Ou usa o teu domínio completo",
+    "source_hash": "5c23c007"
+  },
+  "web.domains.add.root_domain_label": {
+    "text": "Usar o meu domínio de raiz",
+    "source_hash": "9fbbe253"
+  },
+  "web.domains.add.root_domain_description": {
+    "text": "Isto aponta a totalidade de {domain} para nós — o site aí deixa de resolver — e precisa de um registo A / ALIAS.",
+    "source_hash": "fae93847"
+  },
+  "web.domains.add.error_unrecognized_suffix": {
+    "text": "“.{0}” não é uma terminação de domínio reconhecida — verifica se há um erro de escrita (p. ex. {1}).",
+    "source_hash": "4b90033d"
+  },
+  "web.domains.add.error_invalid_hostname": {
+    "text": "Introduz um nome de anfitrião válido — letras, números, pontos simples e traços (p. ex. {0}).",
+    "source_hash": "c4ceabc1"
+  },
+  "web.domains.add.error_empty": {
+    "text": "Introduz um nome de domínio.",
+    "source_hash": "d8e2c1e4"
+  },
+  "web.domains.add.continue_with": {
+    "text": "Continuar com {0}",
+    "source_hash": "73f8ab40"
+  },
+  "web.domains.auth_override.workspace_default_badge": {
+    "text": "Predefinição do espaço de trabalho",
+    "source_hash": "da3706ee"
+  },
+  "web.domains.detail.dns_title": {
+    "text": "Configuração de DNS",
+    "source_hash": "6c63df31"
+  },
+  "web.domains.detail.dns_description": {
+    "text": "Aponta o teu domínio para este servidor com um registo CNAME",
+    "source_hash": "080f84f0"
+  },
+  "web.domains.dns.title": {
+    "text": "Configuração de DNS",
+    "source_hash": "da78c35d"
+  },
+  "web.domains.dns.point_domain_intro": {
+    "text": "Aponta",
+    "source_hash": "2fc0c524"
+  },
+  "web.domains.dns.point_domain_outro": {
+    "text": "para este servidor adicionando o seguinte registo DNS junto do teu fornecedor.",
+    "source_hash": "8d260c05"
+  },
+  "web.domains.dns.cname_heading": {
+    "text": "Cria um registo CNAME",
+    "source_hash": "11aeef5a"
+  },
+  "web.domains.dns.apex_heading": {
+    "text": "Cria um registo ALIAS ou ANAME",
+    "source_hash": "41135375"
+  },
+  "web.domains.dns.apex_notice": {
+    "text": "Os domínios apex (de raiz) não podem usar um registo CNAME. Usa antes o registo ALIAS ou ANAME do teu fornecedor de DNS, ou aponta um registo A para o endereço IP do teu servidor.",
+    "source_hash": "2d1c3298"
+  },
+  "web.domains.email.from_address_local_placeholder": {
+    "text": "no-reply",
+    "source_hash": "510d274d"
+  },
+  "web.domains.homepage.title": {
+    "text": "Página inicial",
+    "source_hash": "9e3391e9"
+  },
+  "web.domains.homepage.description": {
+    "text": "O que os visitantes podem fazer na página inicial do teu domínio",
+    "source_hash": "974d159e"
+  },
+  "web.domains.homepage.option_private_title": {
+    "text": "Página de destino privada",
+    "source_hash": "dfd5bd1c"
+  },
+  "web.domains.homepage.option_private_description": {
+    "text": "Os visitantes veem uma página de destino privada sem formulário interativo",
+    "source_hash": "4d9aaf6f"
+  },
+  "web.domains.homepage.option_create_title": {
+    "text": "Formulário de criação de mensagens confidenciais",
+    "source_hash": "6539dfc1"
+  },
+  "web.domains.homepage.option_create_description": {
+    "text": "Os visitantes podem criar os seus próprios links confidenciais",
+    "source_hash": "884310f4"
+  },
+  "web.domains.homepage.option_incoming_title": {
+    "text": "Formulário de mensagens confidenciais recebidas",
+    "source_hash": "882997bf"
+  },
+  "web.domains.homepage.option_incoming_description": {
+    "text": "Os visitantes podem enviar mensagens confidenciais para os destinatários configurados",
+    "source_hash": "86bdaedb"
+  },
+  "web.domains.homepage.incoming_requires_recipients": {
+    "text": "Requer que as mensagens confidenciais recebidas estejam ativadas com pelo menos um destinatário",
+    "source_hash": "0462611d"
+  },
+  "web.domains.homepage.configure_recipients": {
+    "text": "Configurar destinatários",
+    "source_hash": "1c3df8b4"
+  },
+  "web.domains.homepage.status_private": {
+    "text": "Página de destino privada",
+    "source_hash": "dfd5bd1c"
+  },
+  "web.domains.homepage.status_create": {
+    "text": "Público: os visitantes criam mensagens confidenciais",
+    "source_hash": "251cfb95"
+  },
+  "web.domains.homepage.status_incoming": {
+    "text": "Público: os visitantes enviam-te mensagens confidenciais",
+    "source_hash": "baa926b8"
+  },
+  "web.domains.homepage.status_incoming_unready": {
+    "text": "Recebidas não prontas — a mostrar página de destino privada",
+    "source_hash": "a5cc237c"
+  },
+  "web.domains.homepage.badge_incoming": {
+    "text": "Recebidas",
+    "source_hash": "e301820a"
+  },
+  "web.domains.homepage.update_success": {
+    "text": "Definições da página inicial guardadas",
+    "source_hash": "4eac9f45"
+  },
+  "web.domains.homepage.homepage_uses_incoming_warning": {
+    "text": "A página inicial deste domínio apresenta atualmente o formulário de mensagens confidenciais recebidas. Desativar as mensagens confidenciais recebidas ou remover todos os destinatários mudará a página inicial para uma página de destino privada até as recebidas estarem prontas novamente.",
+    "source_hash": "cc0d4997"
+  },
+  "web.domains.signin.effective_status_label": {
+    "text": "Início de sessão neste domínio",
+    "source_hash": "d8b884c3"
+  },
+  "web.domains.signin.dormant_notice": {
+    "text": "O início de sessão está desativado em todo o espaço de trabalho, pelo que está indisponível em todos os domínios. As tuas definições aqui são mantidas e entram em vigor quando o início de sessão do espaço de trabalho for reativado.",
+    "source_hash": "723d35dc"
+  },
+  "web.domains.signup.effective_status_label": {
+    "text": "Registos neste domínio",
+    "source_hash": "115ab21b"
+  },
+  "web.domains.signup.dormant_notice": {
+    "text": "Os registos estão desativados em todo o espaço de trabalho, pelo que estão indisponíveis em todos os domínios. As tuas definições aqui são mantidas e entram em vigor quando os registos do espaço de trabalho forem reativados.",
+    "source_hash": "49faefe4"
   }
 }

--- a/locales/content/pt_PT/workspace-organizations.json
+++ b/locales/content/pt_PT/workspace-organizations.json
@@ -4,8 +4,8 @@
     "source_hash": "2730183d"
   },
   "web.organizations.organization": {
-    "text": "Organização",
-    "source_hash": "d764d425"
+    "text": "Espaço de trabalho",
+    "source_hash": "87bb59ba"
   },
   "web.organizations.organization_plural": {
     "text": "Organizações",
@@ -16,24 +16,24 @@
     "source_hash": "dbaa4f92"
   },
   "web.organizations.my_organizations": {
-    "text": "Organizações",
-    "source_hash": "2730183d"
+    "text": "Espaços de trabalho",
+    "source_hash": "1377264b"
   },
   "web.organizations.manage_organizations": {
-    "text": "Gerir Organizações",
-    "source_hash": "be0fe4c3"
+    "text": "Gerir espaços de trabalho",
+    "source_hash": "cc2d65f8"
   },
   "web.organizations.new_organization": {
     "text": "Nova Organização",
     "source_hash": "4876e647"
   },
   "web.organizations.no_organizations": {
-    "text": "Ainda sem organizações",
-    "source_hash": "5b7a7cbd"
+    "text": "Ainda sem espaços de trabalho",
+    "source_hash": "97d0b117"
   },
   "web.organizations.no_organizations_description": {
-    "text": "As organizações fornecem faturação e administração unificadas. Comece por criar a sua primeira organização.",
-    "source_hash": "deab4304"
+    "text": "Os espaços de trabalho fornecem faturação e administração unificadas. Começa por criar o teu primeiro espaço de trabalho.",
+    "source_hash": "f09d4987"
   },
   "web.organizations.no_description": {
     "text": "Nenhuma descrição fornecida",
@@ -48,24 +48,24 @@
     "source_hash": "e27f4540"
   },
   "web.organizations.create_first_organization": {
-    "text": "Criar Primeira Organização",
-    "source_hash": "27bae486"
+    "text": "Criar primeiro espaço de trabalho",
+    "source_hash": "98a583b4"
   },
   "web.organizations.create_organization_description": {
-    "text": "Criar uma nova organização",
-    "source_hash": "67cd5950"
+    "text": "Criar um novo espaço de trabalho",
+    "source_hash": "6ac2b5fc"
   },
   "web.organizations.create": {
     "text": "Criar",
     "source_hash": "4759498a"
   },
   "web.organizations.create_error": {
-    "text": "Falha ao criar organização",
-    "source_hash": "f2204373"
+    "text": "Falha ao criar o espaço de trabalho",
+    "source_hash": "0a8d4fd6"
   },
   "web.organizations.organization_name": {
-    "text": "Nome da Organização",
-    "source_hash": "4cbd9073"
+    "text": "Nome do espaço de trabalho",
+    "source_hash": "6fa5a5b1"
   },
   "web.organizations.organization_name_placeholder": {
     "text": "ex. Empresa Exemplo",
@@ -92,12 +92,12 @@
     "source_hash": "ee81c03d"
   },
   "web.organizations.select_organization": {
-    "text": "Selecionar uma organização",
-    "source_hash": "48326f52"
+    "text": "Seleciona um espaço de trabalho",
+    "source_hash": "70a8ce66"
   },
   "web.organizations.switcher_locked": {
-    "text": "Mudança de organização não disponível nesta página",
-    "source_hash": "da0cf810"
+    "text": "Mudança de espaço de trabalho não disponível nesta página",
+    "source_hash": "c34114ac"
   },
   "web.organizations.not_found": {
     "text": "Organização não encontrada",
@@ -208,8 +208,8 @@
     "source_hash": "7ecc5d35"
   },
   "web.organizations.tabs.members": {
-    "text": "Equipa",
-    "source_hash": "5985039f"
+    "text": "Membros",
+    "source_hash": "1044a4c0"
   },
   "web.organizations.tabs.billing": {
     "text": "Faturação",
@@ -468,8 +468,8 @@
     "source_hash": "424a2551"
   },
   "web.organizations.invitations.roles.member": {
-    "text": "Membro",
-    "source_hash": "7c968fb7"
+    "text": "Membro da equipa",
+    "source_hash": "d4e55dfa"
   },
   "web.organizations.invitations.roles.admin": {
     "text": "Administrador",
@@ -532,8 +532,8 @@
     "source_hash": "5e3f8df8"
   },
   "web.organizations.invitations.upgrade_prompt": {
-    "text": "Os convites para membros da equipa requerem um plano com gestão de equipas. Atualize para adicionar colaboradores à sua organização.",
-    "source_hash": "cf10d623"
+    "text": "Os convites de membros requerem um plano pago. Faz upgrade para adicionar colaboradores à tua organização.",
+    "source_hash": "47d0eeab"
   },
   "web.organizations.paid_badge": {
     "text": "Pro",
@@ -556,8 +556,8 @@
     "source_hash": "ced67718"
   },
   "web.organizations.invitations.email_mismatch_title": {
-    "text": "Sessão iniciada com outra conta",
-    "source_hash": "4a2f91c3"
+    "text": "Conta diferente com sessão iniciada",
+    "source_hash": "6516362a"
   },
   "web.organizations.invitations.email_mismatch_body": {
     "text": "Este convite é para {invitedEmail}. Tem sessão iniciada como {currentEmail}.",
@@ -565,7 +565,7 @@
   },
   "web.organizations.invitations.continue_as_invited_email": {
     "text": "Continuar como {email}",
-    "source_hash": "6c9a1d4e"
+    "source_hash": "ccf9745d"
   },
   "web.organizations.invitations.expires_in_days": {
     "text": "{days}d restantes",
@@ -1026,5 +1026,9 @@
   "web.organizations.tabs.sso": {
     "text": "SSO",
     "source_hash": "5ba3ac9f"
+  },
+  "web.organizations.create_workspace": {
+    "text": "Criar espaço de trabalho",
+    "source_hash": "c63c14cf"
   }
 }


### PR DESCRIPTION
## `pt_PT` translation update

Automated export of completed **pt_PT** translations from the translation task DB.
Scope: `locales/content/pt_PT/` only — 33 file(s), +3702/-108.

ℹ️ Variable validation not run.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-opus-4-8`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ✅ Looks good — variables and brand terms intact.

**Summary:** Large additive update (14 new `admin-*` files plus edits across common/layout/email/domains/branding/organizations) plus the org→workspace rename applied to user-facing surfaces. All interpolation tokens and brand terms are preserved; no empty or untranslated values.

**Critical (must fix):** None.
- Spot-checked all placeholders — `{count}`, `{ip}`, `{email}`, `{org}`, `{domain}`, `{provider}`, `{accepted}/{rejected}/{fetched}`, `{0}/{1}`, `%{secrets_mode}`, `%{domain}`, and vue-i18n `{'@'}` escapes in email placeholders — every one matches source in set and count.
- `api.invite.errors.invitation_already_processed` dropped `%{status}`, but its `source_hash` changed (English removed the interpolation via the per-status key refactor), so this is correct, not a lost variable.

**Warnings:** None.

**Notes:**
- Brand/technical carve-outs kept English as expected: Colonel, Stripe, Lettermint, Redis INFO, TTL, DNS/SSL/CNAME/ALIAS/ANAME, CIDR, User Agent, worker(s), extid/objid, no-reply, and strategy proper names (Approximated/Passthrough/External/Caddy).
- `reasonPlaceholder`: "p. ex. credential stuffing" left in English — acceptable as an example attack term, but flag if pt_PT prefers a localized example.
- Register: new strings correctly use informal *tu*; several touched strings were converted formal→informal (good). Untouched legacy strings still mix *você* forms — pre-existing, out of this diff's scope.
- Workspace rename (Organização → Espaço de trabalho) is consistent with the other locales in this batch.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
