### PR TITLE
i18n: update tr translations

### DIFF
--- a/locales/content/tr/00-common.json
+++ b/locales/content/tr/00-common.json
@@ -1267,8 +1267,8 @@
     "source_hash": "cb2f00d1"
   },
   "web.TITLES.organizations_settings": {
-    "text": "Kuruluşlar",
-    "source_hash": "2730183d"
+    "text": "Çalışma Alanları",
+    "source_hash": "1377264b"
   },
   "web.TITLES.organization_settings": {
     "text": "Kuruluş Ayarları",
@@ -1299,8 +1299,8 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Her zaman resmi {product_name} web sitesinde olduğunuzu doğrulayın. Dolandırıcılar bazen gizli mesajlarınızı çalmak için {product_name}'a tıpatıp benzeyen sahte web siteleri oluştururlar. Kimlik avı saldırılarından kaçınmak için yeni bağlantılar oluşturmadan önce bölge alan adını kontrol edin.",
-    "source_hash": "68ec20f8"
+    "text": "Her zaman resmi {product_name} web sitesinde olduğunuzdan emin olun. Dolandırıcılar bazen gizli mesajlarınızı çalmak için {product_name} sitesine birebir benzeyen sahte web siteleri oluşturabilir. Kimlik avı saldırılarından kaçınmak için yeni bağlantılar oluşturmadan önce adres çubuğunuzdaki bölgenin alan adını doğrulayın.",
+    "source_hash": "2e3b856e"
   },
   "web.pricing.title": {
     "text": "Basit, Şeffaf Fiyatlandırma",
@@ -1523,5 +1523,21 @@
   "web.TITLES.domain_incoming": {
     "text": "Gelen Gizli Mesajlar",
     "source_hash": "883dbca9"
+  },
+  "web.LABELS.update": {
+    "text": "Güncelle",
+    "source_hash": "c1c1009d"
+  },
+  "web.LABELS.updating": {
+    "text": "Güncelleniyor...",
+    "source_hash": "0a4e0b71"
+  },
+  "web.TITLES.check_email": {
+    "text": "E-postanızı Kontrol Edin",
+    "source_hash": "0e5fc27d"
+  },
+  "web.TITLES.domain_dns": {
+    "text": "DNS Kurulumu",
+    "source_hash": "6c63df31"
   }
 }

--- a/locales/content/tr/10-layout.json
+++ b/locales/content/tr/10-layout.json
@@ -101,11 +101,11 @@
   },
   "web.footer.product": {
     "text": "Ürün",
-    "source_hash": "7f5540e9"
+    "source_hash": "fb9ef894"
   },
   "web.footer.source_code_purveyor": {
     "text": "Kaynak Kodu",
-    "source_hash": "29c5c68f"
+    "source_hash": "bc47da66"
   },
   "web.navigation.billing": {
     "text": "Faturalandırma",
@@ -149,7 +149,7 @@
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
     "text": "{product_name} aracılığıyla sizinle paylaşılan güvenli bir mesajı görüntülüyorsunuz. Bu içerik yalnızca bir kez gösterilir ve ardından sunucularımızdan kalıcı olarak silinir.",
-    "source_hash": "e0f1a10c"
+    "source_hash": "7a4e9d16"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
     "text": "Bu gizli mesajı daha sonra tekrar görüntüleyebilir miyim?",
@@ -265,7 +265,7 @@
   },
   "web.layout.visit_onetime_secret_homepage": {
     "text": "{product_name} ana sayfasını ziyaret edin",
-    "source_hash": "625556d2"
+    "source_hash": "87802af5"
   },
   "web.layout.footer_navigation": {
     "text": "Altbilgi navigasyonu",
@@ -346,5 +346,9 @@
   "web.help.default_content": {
     "text": "Yardım için lütfen destekle iletişime geçin",
     "source_hash": "752bca14"
+  },
+  "web.layout.colonels_only_badge": {
+    "text": "Yalnızca Colonel'lere Özel",
+    "source_hash": "3f1e2dbd"
   }
 }

--- a/locales/content/tr/admin-audit.json
+++ b/locales/content/tr/admin-audit.json
@@ -1,0 +1,102 @@
+{
+  "web.admin.audit.title": {
+    "text": "Denetim Günlüğü",
+    "source_hash": "47751f88"
+  },
+  "web.admin.audit.description": {
+    "text": "Değişiklik yapan her yönetici işlemi, en yenisi en üstte — kim, kime, ne yaptı ve nasıl sonuçlandı.",
+    "source_hash": "2326a1a0"
+  },
+  "web.admin.audit.categories.customer": {
+    "text": "Müşteriler",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.audit.categories.session": {
+    "text": "Oturumlar",
+    "source_hash": "6fa3cbf4"
+  },
+  "web.admin.audit.categories.domain": {
+    "text": "Alan Adları",
+    "source_hash": "ced67718"
+  },
+  "web.admin.audit.categories.organization": {
+    "text": "Kuruluşlar",
+    "source_hash": "2730183d"
+  },
+  "web.admin.audit.categories.banner": {
+    "text": "Afiş",
+    "source_hash": "b7f4d98f"
+  },
+  "web.admin.audit.categories.queue": {
+    "text": "Kuyruklar",
+    "source_hash": "be77db11"
+  },
+  "web.admin.audit.categories.email": {
+    "text": "E-posta",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.audit.categories.ratelimit": {
+    "text": "Hız sınırları",
+    "source_hash": "6ed021f7"
+  },
+  "web.admin.audit.categories.ip": {
+    "text": "IP yasakları",
+    "source_hash": "48cdea49"
+  },
+  "web.admin.audit.columns.timestamp": {
+    "text": "Zaman Damgası",
+    "source_hash": "115a2cc9"
+  },
+  "web.admin.audit.columns.actor": {
+    "text": "Aktör",
+    "source_hash": "449995c4"
+  },
+  "web.admin.audit.columns.action": {
+    "text": "İşlem",
+    "source_hash": "64cff131"
+  },
+  "web.admin.audit.columns.target": {
+    "text": "Hedef",
+    "source_hash": "978354db"
+  },
+  "web.admin.audit.columns.result": {
+    "text": "Sonuç",
+    "source_hash": "6e7d50e8"
+  },
+  "web.admin.audit.columns.detail": {
+    "text": "Ayrıntı",
+    "source_hash": "fb5f27d5"
+  },
+  "web.admin.audit.filters.actorPlaceholder": {
+    "text": "Aktöre göre filtrele (extid veya e-posta)",
+    "source_hash": "966aa580"
+  },
+  "web.admin.audit.filters.actionLabel": {
+    "text": "İşlem",
+    "source_hash": "64cff131"
+  },
+  "web.admin.audit.filters.allActions": {
+    "text": "Tüm işlemler",
+    "source_hash": "83140cf1"
+  },
+  "web.admin.audit.list.loadError": {
+    "text": "Denetim günlüğü yüklenemedi.",
+    "source_hash": "acf244f4"
+  },
+  "web.admin.audit.list.retry": {
+    "text": "Yeniden Dene",
+    "source_hash": "942087cc"
+  },
+  "web.admin.audit.list.empty": {
+    "text": "Henüz kaydedilmiş bir denetim olayı yok",
+    "source_hash": "8fe0cac3"
+  },
+  "web.admin.audit.result.success": {
+    "text": "Başarılı",
+    "source_hash": "c88a0b90"
+  },
+  "web.admin.audit.result.failure": {
+    "text": "Başarısız",
+    "source_hash": "7031edbc"
+  }
+}

--- a/locales/content/tr/admin-bannedips.json
+++ b/locales/content/tr/admin-bannedips.json
@@ -1,0 +1,114 @@
+{
+  "web.admin.bannedIps.title": {
+    "text": "Yasaklı IP'ler",
+    "source_hash": "0ece5643"
+  },
+  "web.admin.bannedIps.description": {
+    "text": "Site çevresinde IP adreslerini yasaklayın ve yasağı kaldırın.",
+    "source_hash": "69c0c992"
+  },
+  "web.admin.bannedIps.currentIp": {
+    "text": "Mevcut IP adresiniz",
+    "source_hash": "14ff3ec5"
+  },
+  "web.admin.bannedIps.actions.cancel": {
+    "text": "İptal",
+    "source_hash": "19766ed6"
+  },
+  "web.admin.bannedIps.actions.ban": {
+    "text": "Bir IP'yi yasakla",
+    "source_hash": "9937d7fd"
+  },
+  "web.admin.bannedIps.actions.quickBan": {
+    "text": "Bu IP'yi yasakla",
+    "source_hash": "95720658"
+  },
+  "web.admin.bannedIps.ban.confirmTitle": {
+    "text": "Bu IP adresi yasaklansın mı?",
+    "source_hash": "512acd7b"
+  },
+  "web.admin.bannedIps.ban.confirmDescription": {
+    "text": "Bu işlem {ip} adresini site çevresinde engeller. Onaylamak için IP'yi yazın.",
+    "source_hash": "d8f6142e"
+  },
+  "web.admin.bannedIps.ban.button": {
+    "text": "IP'yi Yasakla",
+    "source_hash": "f91a5285"
+  },
+  "web.admin.bannedIps.ban.success": {
+    "text": "{ip} yasaklandı",
+    "source_hash": "97180685"
+  },
+  "web.admin.bannedIps.columns.ipAddress": {
+    "text": "IP Adresi",
+    "source_hash": "3c3de0c9"
+  },
+  "web.admin.bannedIps.columns.reason": {
+    "text": "Neden",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.bannedIps.columns.bannedAt": {
+    "text": "Yasaklanma Zamanı",
+    "source_hash": "dfbd120e"
+  },
+  "web.admin.bannedIps.columns.bannedBy": {
+    "text": "Yasaklayan",
+    "source_hash": "9f47db0e"
+  },
+  "web.admin.bannedIps.columns.actions": {
+    "text": "İşlemler",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.bannedIps.form.title": {
+    "text": "Bir IP adresini yasakla",
+    "source_hash": "59961746"
+  },
+  "web.admin.bannedIps.form.ipLabel": {
+    "text": "IP Adresi veya CIDR",
+    "source_hash": "133d0819"
+  },
+  "web.admin.bannedIps.form.reasonLabel": {
+    "text": "Neden (isteğe bağlı)",
+    "source_hash": "0f7d4664"
+  },
+  "web.admin.bannedIps.form.reasonPlaceholder": {
+    "text": "örn. kimlik bilgisi doldurma",
+    "source_hash": "828a15ae"
+  },
+  "web.admin.bannedIps.form.submit": {
+    "text": "IP'yi Yasakla",
+    "source_hash": "f91a5285"
+  },
+  "web.admin.bannedIps.list.loadError": {
+    "text": "Yasaklı IP'ler yüklenemedi.",
+    "source_hash": "539f2e34"
+  },
+  "web.admin.bannedIps.list.retry": {
+    "text": "Yeniden Dene",
+    "source_hash": "942087cc"
+  },
+  "web.admin.bannedIps.list.empty": {
+    "text": "Şu anda yasaklı IP yok",
+    "source_hash": "b72cc9c5"
+  },
+  "web.admin.bannedIps.stats.total": {
+    "text": "Toplam Yasaklı",
+    "source_hash": "41059c94"
+  },
+  "web.admin.bannedIps.unban.confirmTitle": {
+    "text": "Bu yasak kaldırılsın mı?",
+    "source_hash": "88473e59"
+  },
+  "web.admin.bannedIps.unban.confirmDescription": {
+    "text": "Bu işlem {ip} adresinin engelini kaldırır. Onaylamak için IP'yi yazın.",
+    "source_hash": "6bec3191"
+  },
+  "web.admin.bannedIps.unban.button": {
+    "text": "Yasağı Kaldır",
+    "source_hash": "25fb5989"
+  },
+  "web.admin.bannedIps.unban.success": {
+    "text": "{ip} adresinin yasağı kaldırıldı",
+    "source_hash": "79192c36"
+  }
+}

--- a/locales/content/tr/admin-banner.json
+++ b/locales/content/tr/admin-banner.json
@@ -1,0 +1,154 @@
+{
+  "web.admin.banner.title": {
+    "text": "Yayın Afişi",
+    "source_hash": "0bc449a3"
+  },
+  "web.admin.banner.description": {
+    "text": "Her ziyaretçiye gösterilen site geneli bir duyuru yayınlayın veya mevcut olanı kaldırın.",
+    "source_hash": "a0f720d7"
+  },
+  "web.admin.banner.loadError": {
+    "text": "Mevcut afiş yüklenemedi.",
+    "source_hash": "04954e72"
+  },
+  "web.admin.banner.retry": {
+    "text": "Yeniden Dene",
+    "source_hash": "942087cc"
+  },
+  "web.admin.banner.clear.button": {
+    "text": "Afişi kaldır",
+    "source_hash": "da6b2e5d"
+  },
+  "web.admin.banner.clear.confirmTitle": {
+    "text": "Yayın afişi kaldırılsın mı?",
+    "source_hash": "46d9c35a"
+  },
+  "web.admin.banner.clear.confirmDescription": {
+    "text": "Bu işlem, her ziyaretçi için yayındaki afişi kaldırır. Devam etmek için onay kelimesini yazın.",
+    "source_hash": "9a56e4be"
+  },
+  "web.admin.banner.clear.success": {
+    "text": "Yayın afişi kaldırıldı.",
+    "source_hash": "b0f52af4"
+  },
+  "web.admin.banner.current.title": {
+    "text": "Mevcut afiş",
+    "source_hash": "d17ab873"
+  },
+  "web.admin.banner.current.none": {
+    "text": "Şu anda ayarlanmış bir afiş yok.",
+    "source_hash": "487b2cac"
+  },
+  "web.admin.banner.current.status": {
+    "text": "Durum",
+    "source_hash": "920e413c"
+  },
+  "web.admin.banner.current.live": {
+    "text": "Yayında",
+    "source_hash": "b64ac05f"
+  },
+  "web.admin.banner.current.expiry": {
+    "text": "Sona Erme",
+    "source_hash": "6956d814"
+  },
+  "web.admin.banner.current.persistent": {
+    "text": "Kalıcı (sona erme yok)",
+    "source_hash": "5f95d1b0"
+  },
+  "web.admin.banner.current.expiresIn": {
+    "text": "{duration} içinde sona erer",
+    "source_hash": "f353f9a7"
+  },
+  "web.admin.banner.current.audience": {
+    "text": "Hedef Kitle",
+    "source_hash": "545c0235"
+  },
+  "web.admin.banner.current.storedContent": {
+    "text": "Depolanan içerik",
+    "source_hash": "3579f3e6"
+  },
+  "web.admin.banner.current.htmlNote": {
+    "text": "İçerik HTML'dir; site, görüntülenirken içeriği yalnızca bağlantılar kalacak şekilde temizler.",
+    "source_hash": "e45a7dfe"
+  },
+  "web.admin.banner.current.edit": {
+    "text": "Düzenle",
+    "source_hash": "464c4ffd"
+  },
+  "web.admin.banner.set.title": {
+    "text": "Bir afiş ayarla",
+    "source_hash": "b6f90d5c"
+  },
+  "web.admin.banner.set.updateTitle": {
+    "text": "Afişi güncelle",
+    "source_hash": "841a0183"
+  },
+  "web.admin.banner.set.contentLabel": {
+    "text": "Mesaj",
+    "source_hash": "2f77668a"
+  },
+  "web.admin.banner.set.contentPlaceholder": {
+    "text": "Planlı bakım Paz 02:00 UTC",
+    "source_hash": "4ec99d7d"
+  },
+  "web.admin.banner.set.contentHelp": {
+    "text": "HTML'e izin verilir; site bunu yalnızca bağlantılar kalacak şekilde temizler.",
+    "source_hash": "7253d1cd"
+  },
+  "web.admin.banner.set.ttlLabel": {
+    "text": "Otomatik sona erme (saniye)",
+    "source_hash": "72134116"
+  },
+  "web.admin.banner.set.ttlPlaceholder": {
+    "text": "Sona erme istemiyorsanız boş bırakın",
+    "source_hash": "a8fd81e1"
+  },
+  "web.admin.banner.set.ttlHelp": {
+    "text": "İsteğe bağlı. Afiş, bu kadar saniye sonra otomatik olarak kaldırılır.",
+    "source_hash": "ba0237f5"
+  },
+  "web.admin.banner.set.scopeLabel": {
+    "text": "Hedef Kitle",
+    "source_hash": "545c0235"
+  },
+  "web.admin.banner.set.scopeHelp": {
+    "text": "Afişi hangi sayfaların göstereceği. Özel alan adı sayfaları, afişi yalnızca tüm sayfalar seçildiğinde görür.",
+    "source_hash": "28cc3018"
+  },
+  "web.admin.banner.set.scopeNoRecipient": {
+    "text": "Alıcı sayfaları hariç her yer",
+    "source_hash": "8575b3c0"
+  },
+  "web.admin.banner.set.scopeWorkspace": {
+    "text": "Yalnızca çalışma alanı sayfaları",
+    "source_hash": "563e003e"
+  },
+  "web.admin.banner.set.scopeAll": {
+    "text": "Tüm sayfalar (özel alan adları dahil)",
+    "source_hash": "b9b74870"
+  },
+  "web.admin.banner.set.publishButton": {
+    "text": "Afişi yayınla",
+    "source_hash": "5b7427a1"
+  },
+  "web.admin.banner.set.updateButton": {
+    "text": "Afişi güncelle",
+    "source_hash": "69b6e40e"
+  },
+  "web.admin.banner.set.confirmTitle": {
+    "text": "Yayın afişi yayınlansın mı?",
+    "source_hash": "8b72b5c3"
+  },
+  "web.admin.banner.set.confirmDescription": {
+    "text": "Bu afiş, kaldırılana veya sona erene kadar site genelinde her ziyaretçiye gösterilecektir.",
+    "source_hash": "c61bbec1"
+  },
+  "web.admin.banner.set.confirmButton": {
+    "text": "Yayınla",
+    "source_hash": "859390eb"
+  },
+  "web.admin.banner.set.success": {
+    "text": "Yayın afişi yayınlandı.",
+    "source_hash": "55c06cab"
+  }
+}

--- a/locales/content/tr/admin-billing.json
+++ b/locales/content/tr/admin-billing.json
@@ -1,0 +1,126 @@
+{
+  "web.admin.billing.title": {
+    "text": "Faturalandırma Kataloğu",
+    "source_hash": "bfde7e68"
+  },
+  "web.admin.billing.description": {
+    "text": "Yapılandırılmış planların ve yetkilerinin, ayrıca canlı Stripe ile senkronize edilen katalogdan herhangi bir sapmanın salt okunur görünümü.",
+    "source_hash": "05d5b332"
+  },
+  "web.admin.billing.retry": {
+    "text": "Yeniden Dene",
+    "source_hash": "942087cc"
+  },
+  "web.admin.billing.loadError": {
+    "text": "Faturalandırma kataloğu yüklenemedi.",
+    "source_hash": "c3110f77"
+  },
+  "web.admin.billing.localConfigWarning": {
+    "text": "Stripe ile senkronize plan önbelleği boş, bu nedenle canlı planlar ve sapma değerlendirilemiyor. Yalnızca yapılandırılmış katalog (billing.yaml) gösteriliyor — geliştirme ortamında veya Stripe yapılandırılmadığında normaldir.",
+    "source_hash": "905d95f8"
+  },
+  "web.admin.billing.inSync": {
+    "text": "Senkronize",
+    "source_hash": "5701958c"
+  },
+  "web.admin.billing.driftCount": {
+    "text": "{count} fark",
+    "source_hash": "166538f5"
+  },
+  "web.admin.billing.inSyncDetail": {
+    "text": "Yapılandırılmış katalog, canlı planlarla eşleşiyor. Sapma tespit edilmedi.",
+    "source_hash": "57ab60a6"
+  },
+  "web.admin.billing.columns.planid": {
+    "text": "Plan Kimliği",
+    "source_hash": "1f0d4dc6"
+  },
+  "web.admin.billing.columns.name": {
+    "text": "Ad",
+    "source_hash": "dcd1d522"
+  },
+  "web.admin.billing.columns.tier": {
+    "text": "Kademe",
+    "source_hash": "cb9e8664"
+  },
+  "web.admin.billing.columns.status": {
+    "text": "Durum",
+    "source_hash": "920e413c"
+  },
+  "web.admin.billing.diff.title": {
+    "text": "Plan farkı: {planid}",
+    "source_hash": "bc86e5f7"
+  },
+  "web.admin.billing.diff.subtitle": {
+    "text": "Yapılandırılmış katalog (billing.yaml) ile canlı Stripe senkronize planı yan yana.",
+    "source_hash": "d92e93ae"
+  },
+  "web.admin.billing.diff.config": {
+    "text": "Yapılandırılmış (billing.yaml)",
+    "source_hash": "6bf2ff04"
+  },
+  "web.admin.billing.diff.live": {
+    "text": "Canlı (Stripe önbelleği)",
+    "source_hash": "4886945d"
+  },
+  "web.admin.billing.diff.absentConfig": {
+    "text": "Bu plan, yapılandırılmış katalogda bulunmuyor.",
+    "source_hash": "0b594c88"
+  },
+  "web.admin.billing.diff.absentLive": {
+    "text": "Bu plan, canlı Stripe ile senkronize önbellekte bulunmuyor.",
+    "source_hash": "c53f31c3"
+  },
+  "web.admin.billing.plans.title": {
+    "text": "Planlar",
+    "source_hash": "dfe8b2f0"
+  },
+  "web.admin.billing.plans.empty": {
+    "text": "Katalogda plan bulunamadı.",
+    "source_hash": "39db3c13"
+  },
+  "web.admin.billing.plans.viewDiff": {
+    "text": "Farkı görüntüle",
+    "source_hash": "0e5d6873"
+  },
+  "web.admin.billing.source.stripe": {
+    "text": "Stripe önbelleği",
+    "source_hash": "b5577327"
+  },
+  "web.admin.billing.source.localConfig": {
+    "text": "Yerel yapılandırma",
+    "source_hash": "49de43d2"
+  },
+  "web.admin.billing.stats.configured": {
+    "text": "Yapılandırılmış planlar",
+    "source_hash": "4fda4796"
+  },
+  "web.admin.billing.stats.live": {
+    "text": "Canlı planlar",
+    "source_hash": "faaa88d9"
+  },
+  "web.admin.billing.stats.source": {
+    "text": "Kaynak",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.billing.stats.drift": {
+    "text": "Sapma",
+    "source_hash": "8b4c8240"
+  },
+  "web.admin.billing.status.in_sync": {
+    "text": "Senkronize",
+    "source_hash": "5701958c"
+  },
+  "web.admin.billing.status.only_config": {
+    "text": "Yalnızca yapılandırma",
+    "source_hash": "15836cba"
+  },
+  "web.admin.billing.status.only_live": {
+    "text": "Yalnızca canlı",
+    "source_hash": "8f4ed495"
+  },
+  "web.admin.billing.status.changed": {
+    "text": "Değişti",
+    "source_hash": "2a6141e4"
+  }
+}

--- a/locales/content/tr/admin-colonel.json
+++ b/locales/content/tr/admin-colonel.json
@@ -802,5 +802,45 @@
   "web.colonel.secrets.state.viewed": {
     "text": "Görüntülendi",
     "source_hash": "1b28d178"
+  },
+  "web.colonel.backToSite": {
+    "text": "Siteye dön",
+    "source_hash": "4ee0f819"
+  },
+  "web.colonel.customDomains.labels.domain": {
+    "text": "Alan Adı",
+    "source_hash": "79fa3361"
+  },
+  "web.colonel.customDomains.labels.status": {
+    "text": "Durum",
+    "source_hash": "920e413c"
+  },
+  "web.colonel.customDomains.labels.actions": {
+    "text": "İşlemler",
+    "source_hash": "ff8059dc"
+  },
+  "web.colonel.nav.consoleTag": {
+    "text": "Konsol",
+    "source_hash": "29a40861"
+  },
+  "web.colonel.nav.groups.identity": {
+    "text": "Kimlik",
+    "source_hash": "999f23fc"
+  },
+  "web.colonel.nav.groups.security": {
+    "text": "Erişim ve Güvenlik",
+    "source_hash": "abb29a3f"
+  },
+  "web.colonel.nav.groups.platform": {
+    "text": "Platform",
+    "source_hash": "c78ffe19"
+  },
+  "web.colonel.nav.groups.billing": {
+    "text": "Faturalandırma",
+    "source_hash": "3ac8bbca"
+  },
+  "web.colonel.nav.groups.communications": {
+    "text": "İletişim",
+    "source_hash": "919a9253"
   }
 }

--- a/locales/content/tr/admin-customers.json
+++ b/locales/content/tr/admin-customers.json
@@ -1,0 +1,486 @@
+{
+  "web.admin.customers.title": {
+    "text": "Müşteriler",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.customers.description": {
+    "text": "SSH kullanmadan bir müşteri bulun ve destek sorunlarını çözün.",
+    "source_hash": "c8487e68"
+  },
+  "web.admin.customers.actions.plan.label": {
+    "text": "Plan",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.actions.plan.apply": {
+    "text": "Uygula",
+    "source_hash": "31e392d1"
+  },
+  "web.admin.customers.actions.plan.confirmTitle": {
+    "text": "Plan değiştirilsin mi?",
+    "source_hash": "910a4de9"
+  },
+  "web.admin.customers.actions.plan.confirmDescription": {
+    "text": "{email} adresini {plan} planına değiştir.",
+    "source_hash": "83fb4158"
+  },
+  "web.admin.customers.actions.plan.success": {
+    "text": "Plan güncellendi.",
+    "source_hash": "ebe8d40c"
+  },
+  "web.admin.customers.actions.plan.localConfigWarning": {
+    "text": "Planlar yerel yapılandırmadan yüklendi — Stripe yapılandırılmamış veya erişilemiyor.",
+    "source_hash": "df83e326"
+  },
+  "web.admin.customers.actions.purge.button": {
+    "text": "Müşteriyi kalıcı olarak sil",
+    "source_hash": "ff658f69"
+  },
+  "web.admin.customers.actions.purge.confirmTitle": {
+    "text": "Müşteri kalıcı olarak silinsin mi?",
+    "source_hash": "9feed9f1"
+  },
+  "web.admin.customers.actions.purge.confirmDescription": {
+    "text": "Bu işlem {email} adresini ve tüm verilerini kalıcı olarak siler. Bu işlem geri alınamaz.",
+    "source_hash": "a74dd5d1"
+  },
+  "web.admin.customers.actions.purge.success": {
+    "text": "Müşteri kalıcı olarak silindi.",
+    "source_hash": "6145e5c8"
+  },
+  "web.admin.customers.actions.role.label": {
+    "text": "Rol",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.actions.role.apply": {
+    "text": "Uygula",
+    "source_hash": "31e392d1"
+  },
+  "web.admin.customers.actions.role.confirmTitle": {
+    "text": "Rol değiştirilsin mi?",
+    "source_hash": "227f57d7"
+  },
+  "web.admin.customers.actions.role.confirmDescription": {
+    "text": "{email} adresini {role} rolüne değiştir.",
+    "source_hash": "9ba063c6"
+  },
+  "web.admin.customers.actions.role.success": {
+    "text": "Rol güncellendi.",
+    "source_hash": "0c33aa24"
+  },
+  "web.admin.customers.actions.suspend.button": {
+    "text": "Hesabı askıya al",
+    "source_hash": "95a04f27"
+  },
+  "web.admin.customers.actions.suspend.reasonLabel": {
+    "text": "Neden (isteğe bağlı)",
+    "source_hash": "0f7d4664"
+  },
+  "web.admin.customers.actions.suspend.reasonPlaceholder": {
+    "text": "Bu hesap neden askıya alınıyor?",
+    "source_hash": "8eca975e"
+  },
+  "web.admin.customers.actions.suspend.confirmTitle": {
+    "text": "Hesap askıya alınsın mı?",
+    "source_hash": "cbfa275b"
+  },
+  "web.admin.customers.actions.suspend.confirmDescription": {
+    "text": "{email} adresinin oturum açmasını engeller ve etkin oturumlarını sonlandırır. Hiçbir veri silinmez — bu işlem geri alınabilir.",
+    "source_hash": "e5d046bc"
+  },
+  "web.admin.customers.actions.suspend.success": {
+    "text": "Hesap askıya alındı.",
+    "source_hash": "04c5f996"
+  },
+  "web.admin.customers.actions.unsuspend.button": {
+    "text": "Hesap askısını kaldır",
+    "source_hash": "35a10fb5"
+  },
+  "web.admin.customers.actions.unsuspend.confirmTitle": {
+    "text": "Hesap askısı kaldırılsın mı?",
+    "source_hash": "6fd78a72"
+  },
+  "web.admin.customers.actions.unsuspend.confirmDescription": {
+    "text": "{email} için oturum açmayı geri yükler.",
+    "source_hash": "cb2bb4e0"
+  },
+  "web.admin.customers.actions.unsuspend.success": {
+    "text": "Hesap askısı kaldırıldı.",
+    "source_hash": "c5b4377f"
+  },
+  "web.admin.customers.actions.unverify.button": {
+    "text": "Doğrulamayı kaldır",
+    "source_hash": "b0dee41f"
+  },
+  "web.admin.customers.actions.unverify.confirmTitle": {
+    "text": "Müşteri doğrulaması kaldırılsın mı?",
+    "source_hash": "62ed2854"
+  },
+  "web.admin.customers.actions.unverify.confirmDescription": {
+    "text": "{email} adresini doğrulanmamış olarak işaretle.",
+    "source_hash": "592ffd27"
+  },
+  "web.admin.customers.actions.unverify.success": {
+    "text": "Müşteri doğrulaması kaldırıldı.",
+    "source_hash": "a9b7bbac"
+  },
+  "web.admin.customers.actions.verify.button": {
+    "text": "Doğrula",
+    "source_hash": "eea2745e"
+  },
+  "web.admin.customers.actions.verify.confirmTitle": {
+    "text": "Müşteri doğrulansın mı?",
+    "source_hash": "43037ce1"
+  },
+  "web.admin.customers.actions.verify.confirmDescription": {
+    "text": "{email} adresini doğrulanmış olarak işaretle.",
+    "source_hash": "7052d79d"
+  },
+  "web.admin.customers.actions.verify.success": {
+    "text": "Müşteri doğrulandı.",
+    "source_hash": "19e382dc"
+  },
+  "web.admin.customers.columns.email": {
+    "text": "E-posta",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.customers.columns.role": {
+    "text": "Rol",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.columns.verified": {
+    "text": "Doğrulandı",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.columns.plan": {
+    "text": "Plan",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.columns.secrets": {
+    "text": "Gizli Mesajlar",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.customers.columns.created": {
+    "text": "Oluşturulma",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.columns.lastLogin": {
+    "text": "Son giriş",
+    "source_hash": "0d39602d"
+  },
+  "web.admin.customers.detail.backToList": {
+    "text": "Müşterilere dön",
+    "source_hash": "077807fb"
+  },
+  "web.admin.customers.detail.openFullPage": {
+    "text": "Tam sayfayı aç",
+    "source_hash": "a467911c"
+  },
+  "web.admin.customers.detail.notFound": {
+    "text": "Müşteri bulunamadı",
+    "source_hash": "5e3f5824"
+  },
+  "web.admin.customers.detail.notFoundDescription": {
+    "text": "Bu tanımlayıcıyla eşleşen bir müşteri yok. Kalıcı olarak silinmiş olabilir.",
+    "source_hash": "82b04725"
+  },
+  "web.admin.customers.detail.loadError": {
+    "text": "Bu müşteri yüklenemedi.",
+    "source_hash": "cfd1bcca"
+  },
+  "web.admin.customers.detail.retry": {
+    "text": "Yeniden Dene",
+    "source_hash": "942087cc"
+  },
+  "web.admin.customers.detail.yes": {
+    "text": "Evet",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.customers.detail.no": {
+    "text": "Hayır",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.customers.detail.none": {
+    "text": "Yok",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.never": {
+    "text": "Hiçbir zaman",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.customers.detail.billing.plan": {
+    "text": "Plan",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.detail.billing.organization": {
+    "text": "Faturalandırma kuruluşu",
+    "source_hash": "90c94ee1"
+  },
+  "web.admin.customers.detail.billing.subscriptionStatus": {
+    "text": "Abonelik durumu",
+    "source_hash": "f0723c4e"
+  },
+  "web.admin.customers.detail.billing.periodEnd": {
+    "text": "Mevcut dönem bitişi",
+    "source_hash": "742b8229"
+  },
+  "web.admin.customers.detail.billing.latestInvoice": {
+    "text": "En son fatura",
+    "source_hash": "7a6133cc"
+  },
+  "web.admin.customers.detail.billing.noInvoices": {
+    "text": "Fatura yok",
+    "source_hash": "e6b30f93"
+  },
+  "web.admin.customers.detail.billing.openStripe": {
+    "text": "Stripe kontrol panelinde aç",
+    "source_hash": "dfa7c41d"
+  },
+  "web.admin.customers.detail.billing.unavailable": {
+    "text": "Stripe verileri kullanılamıyor: {reason}",
+    "source_hash": "9fe08e49"
+  },
+  "web.admin.customers.detail.billing.notConfigured": {
+    "text": "Bu kurulumda faturalandırma yapılandırılmamış.",
+    "source_hash": "6e90375e"
+  },
+  "web.admin.customers.detail.fields.email": {
+    "text": "E-posta",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.customers.detail.fields.publicId": {
+    "text": "Herkese Açık Kimlik",
+    "source_hash": "3705b64f"
+  },
+  "web.admin.customers.detail.fields.role": {
+    "text": "Rol",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.detail.fields.verified": {
+    "text": "Doğrulandı",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.detail.fields.plan": {
+    "text": "Plan",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.detail.fields.locale": {
+    "text": "Dil",
+    "source_hash": "ca3dc612"
+  },
+  "web.admin.customers.detail.fields.created": {
+    "text": "Oluşturulma",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.detail.fields.updated": {
+    "text": "Güncellenme",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.customers.detail.fields.lastLogin": {
+    "text": "Son giriş",
+    "source_hash": "0d39602d"
+  },
+  "web.admin.customers.detail.fields.suspendedAt": {
+    "text": "Askıya alınma zamanı",
+    "source_hash": "7227f219"
+  },
+  "web.admin.customers.detail.fields.suspendedBy": {
+    "text": "Askıya alan",
+    "source_hash": "e0830524"
+  },
+  "web.admin.customers.detail.fields.suspendedReason": {
+    "text": "Askıya alma nedeni",
+    "source_hash": "d6b08d8e"
+  },
+  "web.admin.customers.detail.organizations.empty": {
+    "text": "Kuruluş yok",
+    "source_hash": "c256efdc"
+  },
+  "web.admin.customers.detail.organizations.default": {
+    "text": "Varsayılan",
+    "source_hash": "21b111cb"
+  },
+  "web.admin.customers.detail.receiptColumns.shortId": {
+    "text": "Kısa Kimlik",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.customers.detail.receiptColumns.state": {
+    "text": "Durum",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.customers.detail.receiptColumns.created": {
+    "text": "Oluşturulma",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.detail.receipts.empty": {
+    "text": "Makbuz yok",
+    "source_hash": "fb425a68"
+  },
+  "web.admin.customers.detail.secretColumns.shortId": {
+    "text": "Kısa Kimlik",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.customers.detail.secretColumns.state": {
+    "text": "Durum",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.customers.detail.secretColumns.created": {
+    "text": "Oluşturulma",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.customers.detail.secretColumns.expiration": {
+    "text": "Son Kullanım Tarihi",
+    "source_hash": "f38d6e0e"
+  },
+  "web.admin.customers.detail.secrets.empty": {
+    "text": "Gizli mesaj yok",
+    "source_hash": "c37ab3f7"
+  },
+  "web.admin.customers.detail.sections.profile": {
+    "text": "Profil",
+    "source_hash": "d696a35b"
+  },
+  "web.admin.customers.detail.sections.secrets": {
+    "text": "Gizli Mesajlar",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.customers.detail.sections.receipts": {
+    "text": "Makbuzlar",
+    "source_hash": "60a627df"
+  },
+  "web.admin.customers.detail.sections.organizations": {
+    "text": "Kuruluşlar",
+    "source_hash": "2730183d"
+  },
+  "web.admin.customers.detail.sections.actions": {
+    "text": "İşlemler",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.sections.billing": {
+    "text": "Faturalandırma",
+    "source_hash": "3ac8bbca"
+  },
+  "web.admin.customers.detail.sessions.title": {
+    "text": "Etkin Oturumlar",
+    "source_hash": "b58fa4e0"
+  },
+  "web.admin.customers.detail.sessions.empty": {
+    "text": "Etkin oturum yok.",
+    "source_hash": "6f064eb9"
+  },
+  "web.admin.customers.detail.sessions.loadError": {
+    "text": "Oturumlar yüklenemedi.",
+    "source_hash": "d2884313"
+  },
+  "web.admin.customers.detail.sessions.unknown": {
+    "text": "Bilinmiyor",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.customers.detail.sessions.columns.lastActivity": {
+    "text": "Son etkinlik",
+    "source_hash": "06475633"
+  },
+  "web.admin.customers.detail.sessions.columns.ipAddress": {
+    "text": "IP adresi",
+    "source_hash": "0302a467"
+  },
+  "web.admin.customers.detail.sessions.columns.device": {
+    "text": "Cihaz",
+    "source_hash": "6ba0bdec"
+  },
+  "web.admin.customers.detail.sessions.columns.authMethod": {
+    "text": "Kimlik doğrulama yöntemi",
+    "source_hash": "bc4ea262"
+  },
+  "web.admin.customers.detail.sessions.columns.actions": {
+    "text": "İşlemler",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.sessions.revoke.button": {
+    "text": "İptal et",
+    "source_hash": "87e6d00b"
+  },
+  "web.admin.customers.detail.sessions.revoke.confirmTitle": {
+    "text": "Oturum iptal edilsin mi?",
+    "source_hash": "7735d1ef"
+  },
+  "web.admin.customers.detail.sessions.revoke.confirmDescription": {
+    "text": "Bu işlem, kullanıcının bu oturumdaki bağlantısını hemen sonlandırır. Kullanıcının yeniden oturum açması gerekir.",
+    "source_hash": "b4291af0"
+  },
+  "web.admin.customers.detail.sessions.revoke.success": {
+    "text": "Oturum iptal edildi.",
+    "source_hash": "5e4762e5"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.button": {
+    "text": "Tümünü iptal et",
+    "source_hash": "c6847a4b"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.confirmTitle": {
+    "text": "Tüm oturumlar iptal edilsin mi?",
+    "source_hash": "a4fa4c65"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.confirmDescription": {
+    "text": "Bu işlem, kullanıcının oturumunu her cihazdan ve tarayıcıdan kapatır — bu listede gösterilmeyen oturumlar dahil — ve kimlik doğrulaması gerektiren rotalarını hemen kilitler. Hesaptan çıkarma veya şüpheli bir hesap ele geçirme durumunda kullanın. Onaylamak için kullanıcının kimliğini yazın.",
+    "source_hash": "483cdd88"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.success": {
+    "text": "Tüm oturumlar iptal edildi ({count} sonlandırıldı).",
+    "source_hash": "4e1cce55"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.capped": {
+    "text": "{count} oturum sonlandırıldı, ancak izlenmeyen oturum taraması kesintiye uğradı — daha eski bir oturum kalmış olabilir. Emin olmak için yeniden çalıştırın.",
+    "source_hash": "e3d295a6"
+  },
+  "web.admin.customers.detail.stats.secretsCreated": {
+    "text": "Oluşturulan gizli mesajlar",
+    "source_hash": "7d17719e"
+  },
+  "web.admin.customers.detail.stats.secretsShared": {
+    "text": "Paylaşılan gizli mesajlar",
+    "source_hash": "ba85b265"
+  },
+  "web.admin.customers.detail.stats.emailsSent": {
+    "text": "Gönderilen e-postalar",
+    "source_hash": "be604792"
+  },
+  "web.admin.customers.list.roleFilter": {
+    "text": "Rol",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.customers.list.empty": {
+    "text": "Müşteri bulunamadı",
+    "source_hash": "dc754ec0"
+  },
+  "web.admin.customers.list.loadError": {
+    "text": "Müşteriler yüklenemedi.",
+    "source_hash": "81783303"
+  },
+  "web.admin.customers.list.searchPlaceholder": {
+    "text": "E-posta, extid veya objid ile ara",
+    "source_hash": "c06d5a3b"
+  },
+  "web.admin.customers.list.emptySearch": {
+    "text": "Bu aramayla eşleşen müşteri yok",
+    "source_hash": "ea7e7012"
+  },
+  "web.admin.customers.roles.colonel": {
+    "text": "Colonel",
+    "source_hash": "02577777"
+  },
+  "web.admin.customers.roles.admin": {
+    "text": "Yönetici",
+    "source_hash": "c1c224b0"
+  },
+  "web.admin.customers.roles.staff": {
+    "text": "Personel",
+    "source_hash": "681927e3"
+  },
+  "web.admin.customers.roles.customer": {
+    "text": "Müşteri",
+    "source_hash": "bf376338"
+  },
+  "web.admin.customers.suspended.badge": {
+    "text": "Askıya Alındı",
+    "source_hash": "e392a389"
+  }
+}

--- a/locales/content/tr/admin-domains.json
+++ b/locales/content/tr/admin-domains.json
@@ -1,0 +1,194 @@
+{
+  "web.admin.domains.retry": {
+    "text": "Yeniden Dene",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.addDomain.button": {
+    "text": "Alan adı ekle",
+    "source_hash": "d86476ae"
+  },
+  "web.admin.domains.addDomain.title": {
+    "text": "Özel bir alan adı ekle",
+    "source_hash": "592d3314"
+  },
+  "web.admin.domains.addDomain.forOrg": {
+    "text": "{org} için bir alan adı ekleniyor.",
+    "source_hash": "f8b8c1ac"
+  },
+  "web.admin.domains.addDomain.domainLabel": {
+    "text": "Alan Adı",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domains.addDomain.domainPlaceholder": {
+    "text": "secrets.example.com",
+    "source_hash": "9ea4d0d6"
+  },
+  "web.admin.domains.addDomain.strategyLabel": {
+    "text": "Doğrulama stratejisi",
+    "source_hash": "a2e95531"
+  },
+  "web.admin.domains.addDomain.createButton": {
+    "text": "Oluştur",
+    "source_hash": "4759498a"
+  },
+  "web.admin.domains.addDomain.created": {
+    "text": "{domain} oluşturuldu.",
+    "source_hash": "2263ec6a"
+  },
+  "web.admin.domains.addDomain.strategy.approximated": {
+    "text": "Yaklaşık — DNS sahiplik denetimi, proxy yok.",
+    "source_hash": "79a7245c"
+  },
+  "web.admin.domains.addDomain.strategy.passthrough": {
+    "text": "Doğrudan geçiş — DNS'i bu dağıtımın proxy'sine yönlendirirsiniz.",
+    "source_hash": "9702d758"
+  },
+  "web.admin.domains.addDomain.strategy.external": {
+    "text": "Harici — DNS bu dağıtımın dışında yönetilir.",
+    "source_hash": "acaede35"
+  },
+  "web.admin.domains.addDomain.strategy.caddy_on_demand": {
+    "text": "Caddy isteğe bağlı — sertifikalar ilk istekte otomatik olarak verilir.",
+    "source_hash": "deb90ae6"
+  },
+  "web.admin.domains.addDomain.strategy.caddy": {
+    "text": "Caddy — sertifikalar ilk istekte otomatik olarak verilir.",
+    "source_hash": "a0f3c2dc"
+  },
+  "web.admin.domains.addDomain.strategy.unknown": {
+    "text": "Dağıtım geneli doğrulama stratejisi.",
+    "source_hash": "4587f9cf"
+  },
+  "web.admin.domains.attach.cta": {
+    "text": "Alan adını kuruluşa bağla",
+    "source_hash": "736d74ce"
+  },
+  "web.admin.domains.attach.recordEyebrow": {
+    "text": "Çalışma kaydı",
+    "source_hash": "2fadf983"
+  },
+  "web.admin.domains.attach.rosterError": {
+    "text": "Bu kuruluşun alan adları yüklenemedi.",
+    "source_hash": "d3055fed"
+  },
+  "web.admin.domains.attach.noDomains": {
+    "text": "Bu kuruluşa henüz bağlı alan adı yok.",
+    "source_hash": "e9a25fc4"
+  },
+  "web.admin.domains.attach.openExternal": {
+    "text": "{domain} adresini yeni sekmede aç",
+    "source_hash": "c5fbdeaa"
+  },
+  "web.admin.domains.dns.heading": {
+    "text": "Yayınlanacak DNS kayıtları",
+    "source_hash": "e4efbe2b"
+  },
+  "web.admin.domains.dns.txtStep": {
+    "text": "1. Sahipliği kanıtlamak için bir TXT kaydı ekleyin.",
+    "source_hash": "fdcfcfb0"
+  },
+  "web.admin.domains.dns.aStep": {
+    "text": "2. Apex'i proxy'ye yönlendiren bir A kaydı ekleyin.",
+    "source_hash": "aedbf197"
+  },
+  "web.admin.domains.dns.cnameStep": {
+    "text": "2. Alt alan adını proxy'ye yönlendiren bir CNAME kaydı ekleyin.",
+    "source_hash": "5c626f53"
+  },
+  "web.admin.domains.dns.propagationNote": {
+    "text": "DNS değişikliklerinin yayılması ve doğrulamanın başarılı olması birkaç dakika sürebilir.",
+    "source_hash": "7caf70a7"
+  },
+  "web.admin.domains.dns.toggle": {
+    "text": "DNS ayrıntıları",
+    "source_hash": "ebf2d44e"
+  },
+  "web.admin.domains.dns.loadError": {
+    "text": "DNS ayrıntıları yüklenemedi.",
+    "source_hash": "4c33e23d"
+  },
+  "web.admin.domains.list.loadError": {
+    "text": "Alan adları yüklenemedi.",
+    "source_hash": "548deff8"
+  },
+  "web.admin.domains.orgPicker.title": {
+    "text": "Bir kuruluş seçin",
+    "source_hash": "48326f52"
+  },
+  "web.admin.domains.orgPicker.searchLabel": {
+    "text": "Kuruluş",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.orgPicker.searchPlaceholder": {
+    "text": "Nesne kimliği, harici kimlik veya e-posta",
+    "source_hash": "bb5d0055"
+  },
+  "web.admin.domains.orgPicker.searchHint": {
+    "text": "objid, extid veya bir üyenin e-posta adresiyle arayın.",
+    "source_hash": "fdef7332"
+  },
+  "web.admin.domains.orgPicker.loadError": {
+    "text": "Kuruluşlar aranamadı.",
+    "source_hash": "b9e45dcf"
+  },
+  "web.admin.domains.orgPicker.parseError": {
+    "text": "Kuruluş sonuçları okunamadı.",
+    "source_hash": "44e1b9fd"
+  },
+  "web.admin.domains.orgPicker.idle": {
+    "text": "Aramak için yukarıya bir değer girin.",
+    "source_hash": "0352e6e6"
+  },
+  "web.admin.domains.orgPicker.noResults": {
+    "text": "“{term}” ile eşleşen kuruluş yok.",
+    "source_hash": "761db594"
+  },
+  "web.admin.domains.orgPicker.unnamedOrg": {
+    "text": "Adsız kuruluş",
+    "source_hash": "f218dc9d"
+  },
+  "web.admin.domains.orgPicker.domainCount": {
+    "text": "{count} alan adı",
+    "source_hash": "cf548c8c"
+  },
+  "web.admin.domains.orgPicker.select": {
+    "text": "Seç",
+    "source_hash": "2a78025d"
+  },
+  "web.admin.domains.verify.button": {
+    "text": "Doğrula",
+    "source_hash": "eea2745e"
+  },
+  "web.admin.domains.verify.confirmTitle": {
+    "text": "Alan adı doğrulansın mı?",
+    "source_hash": "07c4dc4f"
+  },
+  "web.admin.domains.verify.confirmDescription": {
+    "text": "{domain} için DNS ve SSL doğrulama denetimlerini çalıştır.",
+    "source_hash": "06797824"
+  },
+  "web.admin.domains.verify.failed": {
+    "text": "Doğrulama başarısız oldu. Lütfen tekrar deneyin.",
+    "source_hash": "3c8432b0"
+  },
+  "web.admin.domains.verify.success.verified": {
+    "text": "{domain} doğrulandı.",
+    "source_hash": "802b5d1e"
+  },
+  "web.admin.domains.verify.success.resolving": {
+    "text": "{domain} çözümleniyor ancak henüz doğrulanmadı.",
+    "source_hash": "bc8aecad"
+  },
+  "web.admin.domains.verify.success.pending": {
+    "text": "{domain} beklemede — DNS henüz çözümlenmiyor.",
+    "source_hash": "0d9f66d5"
+  },
+  "web.admin.domains.verify.success.unverified": {
+    "text": "{domain} doğrulanamadı.",
+    "source_hash": "630da482"
+  },
+  "web.admin.domains.verify.success.done": {
+    "text": "{domain} için doğrulama tamamlandı.",
+    "source_hash": "ed67e22d"
+  }
+}

--- a/locales/content/tr/admin-domaintoolbox.json
+++ b/locales/content/tr/admin-domaintoolbox.json
@@ -1,0 +1,178 @@
+{
+  "web.admin.domaintoolbox.title": {
+    "text": "Alan Adı Araç Kutusu",
+    "source_hash": "5a9333db"
+  },
+  "web.admin.domaintoolbox.description": {
+    "text": "Özel alan adı ilişkilerini teşhis edin ve onarın: sahipsizleri tarayın, DNS/SSL denetleyin, sahipliği onarın ve kuruluşlar arasında aktarın.",
+    "source_hash": "778537aa"
+  },
+  "web.admin.domaintoolbox.retry": {
+    "text": "Yeniden Dene",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domaintoolbox.preview": {
+    "text": "Önizleme",
+    "source_hash": "324b134f"
+  },
+  "web.admin.domaintoolbox.fields.extid": {
+    "text": "Alan adı harici kimliği",
+    "source_hash": "f52af6c5"
+  },
+  "web.admin.domaintoolbox.fields.extidPlaceholder": {
+    "text": "cd_… (alan adı extid)",
+    "source_hash": "bb9bf49a"
+  },
+  "web.admin.domaintoolbox.orphaned.title": {
+    "text": "Sahipsiz alan adları",
+    "source_hash": "ddcea596"
+  },
+  "web.admin.domaintoolbox.orphaned.description": {
+    "text": "Sahip kuruluşu olmayan özel alan adları. Birini yeniden atamak için Onar'ı kullanın.",
+    "source_hash": "967268f5"
+  },
+  "web.admin.domaintoolbox.orphaned.empty": {
+    "text": "Sahipsiz alan adı bulunamadı.",
+    "source_hash": "06ef9979"
+  },
+  "web.admin.domaintoolbox.orphaned.loadError": {
+    "text": "Sahipsiz alan adları yüklenemedi.",
+    "source_hash": "ca0e33bf"
+  },
+  "web.admin.domaintoolbox.orphaned.repairAction": {
+    "text": "Onar",
+    "source_hash": "1196b6c5"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.domain": {
+    "text": "Alan Adı",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.state": {
+    "text": "Durum",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.verified": {
+    "text": "Doğrulandı",
+    "source_hash": "4f783840"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.created": {
+    "text": "Oluşturulma",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domaintoolbox.orphaned.columns.actions": {
+    "text": "İşlemler",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domaintoolbox.probe.title": {
+    "text": "Denetle (DNS / SSL)",
+    "source_hash": "ec69a087"
+  },
+  "web.admin.domaintoolbox.probe.description": {
+    "text": "Alan adının trafiği sunduğunu doğrulamak için canlı bir HTTPS isteği yapın ve TLS sertifikasını inceleyin. Salt okunur.",
+    "source_hash": "1eecfa96"
+  },
+  "web.admin.domaintoolbox.probe.button": {
+    "text": "Denetle",
+    "source_hash": "3bd51ab9"
+  },
+  "web.admin.domaintoolbox.probe.healthLabel": {
+    "text": "Sağlık",
+    "source_hash": "55898449"
+  },
+  "web.admin.domaintoolbox.repair.title": {
+    "text": "İlişkiyi onar",
+    "source_hash": "0053d07c"
+  },
+  "web.admin.domaintoolbox.repair.description": {
+    "text": "Bir alan adı için kuruluş ilişkisi tutarsızlıklarını düzeltin. Önce önizleyin, ardından uygulayın.",
+    "source_hash": "18ca490b"
+  },
+  "web.admin.domaintoolbox.repair.orgIdLabel": {
+    "text": "Kuruluş ata (sahipsizse)",
+    "source_hash": "f95b010a"
+  },
+  "web.admin.domaintoolbox.repair.orgIdPlaceholder": {
+    "text": "kuruluş kimliği veya extid",
+    "source_hash": "a87d634e"
+  },
+  "web.admin.domaintoolbox.repair.statusLabel": {
+    "text": "Durum",
+    "source_hash": "920e413c"
+  },
+  "web.admin.domaintoolbox.repair.noIssues": {
+    "text": "Sorun bulunamadı — ilişkiler tutarlı.",
+    "source_hash": "e1a4c49d"
+  },
+  "web.admin.domaintoolbox.repair.applyButton": {
+    "text": "Onarımları uygula",
+    "source_hash": "3f92b29f"
+  },
+  "web.admin.domaintoolbox.repair.success": {
+    "text": "Onarımlar başarıyla uygulandı.",
+    "source_hash": "24f25b9b"
+  },
+  "web.admin.domaintoolbox.repair.confirmTitle": {
+    "text": "Alan adı onarımları uygulansın mı?",
+    "source_hash": "9429998b"
+  },
+  "web.admin.domaintoolbox.repair.confirmDescription": {
+    "text": "Bu işlem, {domain} için sahiplik/ilişki durumunu değiştirir. Onaylamak için alan adı harici kimliğini yeniden yazın.",
+    "source_hash": "426d267b"
+  },
+  "web.admin.domaintoolbox.reverify.button": {
+    "text": "Yeniden doğrula",
+    "source_hash": "0344860a"
+  },
+  "web.admin.domaintoolbox.reverify.success": {
+    "text": "Alan adı yeniden doğrulaması tamamlandı.",
+    "source_hash": "497a2348"
+  },
+  "web.admin.domaintoolbox.transfer.title": {
+    "text": "Sahipliği aktar",
+    "source_hash": "3667f939"
+  },
+  "web.admin.domaintoolbox.transfer.description": {
+    "text": "Bir alan adını farklı bir kuruluşa yeniden atayın. En yüksek etki alanına sahip işlem — dikkatlice önizleyin ve onaylayın.",
+    "source_hash": "d4e26e03"
+  },
+  "web.admin.domaintoolbox.transfer.toOrgLabel": {
+    "text": "Hedef kuruluş",
+    "source_hash": "4e4486eb"
+  },
+  "web.admin.domaintoolbox.transfer.fromOrgLabel": {
+    "text": "Kaynak kuruluş (isteğe bağlı)",
+    "source_hash": "3666815f"
+  },
+  "web.admin.domaintoolbox.transfer.fromOrgPlaceholder": {
+    "text": "mevcut sahibi doğrula",
+    "source_hash": "cd9e769c"
+  },
+  "web.admin.domaintoolbox.transfer.from": {
+    "text": "Kimden",
+    "source_hash": "21819769"
+  },
+  "web.admin.domaintoolbox.transfer.to": {
+    "text": "Kime",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.domaintoolbox.transfer.orphaned": {
+    "text": "SAHİPSİZ",
+    "source_hash": "54dc2166"
+  },
+  "web.admin.domaintoolbox.transfer.applyButton": {
+    "text": "Alan adını aktar",
+    "source_hash": "9517aeb9"
+  },
+  "web.admin.domaintoolbox.transfer.success": {
+    "text": "Alan adı başarıyla aktarıldı.",
+    "source_hash": "bbca9de9"
+  },
+  "web.admin.domaintoolbox.transfer.confirmTitle": {
+    "text": "Alan adı sahipliği aktarılsın mı?",
+    "source_hash": "d306a15a"
+  },
+  "web.admin.domaintoolbox.transfer.confirmDescription": {
+    "text": "Bu işlem, {domain} sahipliğini başka bir kuruluşa yeniden atar. Onaylamak için alan adı harici kimliğini yeniden yazın.",
+    "source_hash": "edefd97c"
+  }
+}

--- a/locales/content/tr/admin-emailtools.json
+++ b/locales/content/tr/admin-emailtools.json
@@ -1,0 +1,550 @@
+{
+  "web.admin.emailtools.title": {
+    "text": "E-posta Araçları",
+    "source_hash": "f9643d5a"
+  },
+  "web.admin.emailtools.description": {
+    "text": "E-posta şablonlarını önizleyin, bir teslimat testi gönderin ve teslim edilebilirliği izleyin — daha önce SSH gerektiren tanılamalar.",
+    "source_hash": "be85c9e9"
+  },
+  "web.admin.emailtools.config.title": {
+    "text": "Posta yapılandırması",
+    "source_hash": "d2a71028"
+  },
+  "web.admin.emailtools.config.description": {
+    "text": "Önyükleme sırasında çözümlenen sabit posta yapılandırması. Kimlik bilgileri asla gösterilmez — yalnızca mevcut olup olmadıkları gösterilir.",
+    "source_hash": "f0e8a118"
+  },
+  "web.admin.emailtools.config.provider": {
+    "text": "Aktarım sağlayıcısı",
+    "source_hash": "4f0e5025"
+  },
+  "web.admin.emailtools.config.senderProvider": {
+    "text": "Gönderen sağlayıcısı",
+    "source_hash": "e881964f"
+  },
+  "web.admin.emailtools.config.senderDiffers": {
+    "text": "Gönderen, aktarımdan farklı",
+    "source_hash": "ab78e8f6"
+  },
+  "web.admin.emailtools.config.autoDetected": {
+    "text": "Otomatik algılandı",
+    "source_hash": "a69c7f9e"
+  },
+  "web.admin.emailtools.config.fromAddress": {
+    "text": "Gönderen adresi",
+    "source_hash": "d465bcfa"
+  },
+  "web.admin.emailtools.config.fromName": {
+    "text": "Gönderen adı",
+    "source_hash": "b28f93ea"
+  },
+  "web.admin.emailtools.config.host": {
+    "text": "SMTP ana bilgisayarı",
+    "source_hash": "ab328f83"
+  },
+  "web.admin.emailtools.config.port": {
+    "text": "Bağlantı noktası",
+    "source_hash": "72e9a59f"
+  },
+  "web.admin.emailtools.config.region": {
+    "text": "Bölge",
+    "source_hash": "d3a008ef"
+  },
+  "web.admin.emailtools.config.hasCredentials": {
+    "text": "Kimlik bilgileri yapılandırıldı",
+    "source_hash": "1c81633a"
+  },
+  "web.admin.emailtools.config.yes": {
+    "text": "Evet",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.emailtools.config.no": {
+    "text": "Hayır",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.emailtools.config.loggerWarning": {
+    "text": "Posta teslim edilmiyor. Aktarım sağlayıcısı gönderimsiz bir moda (logger, devre dışı veya yok) ayarlanmış, bu nedenle bu sunucudan hiçbir e-posta çıkmıyor — giden iletiler uygulama günlüğüne yazılıyor veya bırakılıyor.",
+    "source_hash": "1883dfd5"
+  },
+  "web.admin.emailtools.deliverability.title": {
+    "text": "Teslim edilebilirlik",
+    "source_hash": "66b4d300"
+  },
+  "web.admin.emailtools.deliverability.description": {
+    "text": "Gönderimden sonra geri gelenler: geri dönenler, şikayetler ve gönderen itibarınızı koruyan engelleme listesi.",
+    "source_hash": "e8363bb5"
+  },
+  "web.admin.emailtools.deliverability.retry": {
+    "text": "Yeniden Dene",
+    "source_hash": "942087cc"
+  },
+  "web.admin.emailtools.deliverability.events.title": {
+    "text": "Son olaylar",
+    "source_hash": "8ecce94d"
+  },
+  "web.admin.emailtools.deliverability.events.description": {
+    "text": "Ham geri dönen ve şikayet akışı, en yenisi en üstte.",
+    "source_hash": "0e7a533b"
+  },
+  "web.admin.emailtools.deliverability.events.empty": {
+    "text": "Henüz geri dönen veya şikayet verisi yok. ESP'nizin geri bildirimini POST /api/colonel/email/deliverability/events üzerinden aktarın (colonel kimlik doğrulamalı — kayıt biçimi için uç noktanın belgelerine bakın). Eşzamanlı SMTP kalıcı geri dönüşleri otomatik olarak kaydedilir.",
+    "source_hash": "a90f259c"
+  },
+  "web.admin.emailtools.deliverability.events.loadError": {
+    "text": "Son olaylar yüklenemedi.",
+    "source_hash": "02244c61"
+  },
+  "web.admin.emailtools.deliverability.events.columns.time": {
+    "text": "Zaman",
+    "source_hash": "33b93476"
+  },
+  "web.admin.emailtools.deliverability.events.columns.kind": {
+    "text": "Tür",
+    "source_hash": "baaddf70"
+  },
+  "web.admin.emailtools.deliverability.events.columns.address": {
+    "text": "Adres",
+    "source_hash": "56ef8f20"
+  },
+  "web.admin.emailtools.deliverability.events.columns.source": {
+    "text": "Kaynak",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.emailtools.deliverability.events.columns.reason": {
+    "text": "Neden",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.emailtools.deliverability.events.kinds.bounce": {
+    "text": "geri dönüş",
+    "source_hash": "4d6723e5"
+  },
+  "web.admin.emailtools.deliverability.events.kinds.complaint": {
+    "text": "şikayet",
+    "source_hash": "5d08b02d"
+  },
+  "web.admin.emailtools.deliverability.lookup.title": {
+    "text": "Alıcı sorgulama",
+    "source_hash": "7569985b"
+  },
+  "web.admin.emailtools.deliverability.lookup.description": {
+    "text": "Bir adresin hem yerel depoda hem de etkin posta sağlayıcısında canlı olarak engellenip engellenmediğini denetleyin. Her ikisi de aynı normalleştirilmiş adresle anahtarlanır.",
+    "source_hash": "c341d614"
+  },
+  "web.admin.emailtools.deliverability.lookup.addressLabel": {
+    "text": "Alıcı adresi",
+    "source_hash": "454d0391"
+  },
+  "web.admin.emailtools.deliverability.lookup.submit": {
+    "text": "Sorgula",
+    "source_hash": "504101bc"
+  },
+  "web.admin.emailtools.deliverability.lookup.local": {
+    "text": "Yerel depo",
+    "source_hash": "c740d116"
+  },
+  "web.admin.emailtools.deliverability.lookup.provider": {
+    "text": "Sağlayıcı",
+    "source_hash": "472590ae"
+  },
+  "web.admin.emailtools.deliverability.lookup.suppressed": {
+    "text": "Engellendi",
+    "source_hash": "435c7831"
+  },
+  "web.admin.emailtools.deliverability.lookup.notSuppressed": {
+    "text": "Engellenmedi",
+    "source_hash": "7b1544d7"
+  },
+  "web.admin.emailtools.deliverability.lookup.reason": {
+    "text": "Neden",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.emailtools.deliverability.lookup.source": {
+    "text": "Kaynak",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.emailtools.deliverability.lookup.unavailable": {
+    "text": "Canlı sağlayıcı sorgulaması kullanılamıyor; yukarıdaki yerel depo geçerlidir.",
+    "source_hash": "aebed0f2"
+  },
+  "web.admin.emailtools.deliverability.messages.title": {
+    "text": "Son gönderimler",
+    "source_hash": "522e089e"
+  },
+  "web.admin.emailtools.deliverability.messages.description": {
+    "text": "Etkin posta sağlayıcısının kaydettiği en son iletiler, en yenisi en üstte. Sağlayıcıdan canlı olarak alınır — burada asla saklanmaz.",
+    "source_hash": "9970fa0a"
+  },
+  "web.admin.emailtools.deliverability.messages.empty": {
+    "text": "Sağlayıcı tarafından döndürülen yeni ileti yok.",
+    "source_hash": "a7ef4d79"
+  },
+  "web.admin.emailtools.deliverability.messages.notSupported": {
+    "text": "{provider} aktarımında gönderim günlüğü kullanılamıyor; bu aktarım, ileti başına API sunmaz.",
+    "source_hash": "21e6b6f9"
+  },
+  "web.admin.emailtools.deliverability.messages.error": {
+    "text": "Gönderim günlüğü sağlayıcıdan yüklenemedi. Tekrar deneyin.",
+    "source_hash": "4f671e55"
+  },
+  "web.admin.emailtools.deliverability.messages.col.status": {
+    "text": "Durum",
+    "source_hash": "920e413c"
+  },
+  "web.admin.emailtools.deliverability.messages.col.subject": {
+    "text": "Konu",
+    "source_hash": "68971283"
+  },
+  "web.admin.emailtools.deliverability.messages.col.to": {
+    "text": "Alıcı",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.emailtools.deliverability.messages.col.created": {
+    "text": "Gönderildi",
+    "source_hash": "c16bc82b"
+  },
+  "web.admin.emailtools.deliverability.messages.status.delivered": {
+    "text": "teslim edildi",
+    "source_hash": "373e0712"
+  },
+  "web.admin.emailtools.deliverability.messages.status.opened": {
+    "text": "açıldı",
+    "source_hash": "50236627"
+  },
+  "web.admin.emailtools.deliverability.messages.status.clicked": {
+    "text": "tıklandı",
+    "source_hash": "d66440b2"
+  },
+  "web.admin.emailtools.deliverability.messages.status.pending": {
+    "text": "beklemede",
+    "source_hash": "62a2fed3"
+  },
+  "web.admin.emailtools.deliverability.messages.status.queued": {
+    "text": "kuyruğa alındı",
+    "source_hash": "d36be649"
+  },
+  "web.admin.emailtools.deliverability.messages.status.processed": {
+    "text": "işlendi",
+    "source_hash": "58190ffa"
+  },
+  "web.admin.emailtools.deliverability.messages.status.hard_bounced": {
+    "text": "kalıcı geri döndü",
+    "source_hash": "b0aa6fd4"
+  },
+  "web.admin.emailtools.deliverability.messages.status.soft_bounced": {
+    "text": "geçici geri döndü",
+    "source_hash": "ac844ff2"
+  },
+  "web.admin.emailtools.deliverability.messages.status.complained": {
+    "text": "şikayet edildi",
+    "source_hash": "c26fe786"
+  },
+  "web.admin.emailtools.deliverability.messages.status.suppressed": {
+    "text": "engellendi",
+    "source_hash": "f63d5b6b"
+  },
+  "web.admin.emailtools.deliverability.messages.status.unsubscribed": {
+    "text": "abonelikten çıkıldı",
+    "source_hash": "621e1970"
+  },
+  "web.admin.emailtools.deliverability.summary.loadError": {
+    "text": "Teslim edilebilirlik özeti yüklenemedi.",
+    "source_hash": "0c16ef96"
+  },
+  "web.admin.emailtools.deliverability.suppressions.title": {
+    "text": "Engelleme listesi",
+    "source_hash": "9f3e322f"
+  },
+  "web.admin.emailtools.deliverability.suppressions.description": {
+    "text": "Giden postanın atladığı adresler. Girdiler, ESP geri bildirim alımından veya manuel içe aktarmadan gelir; birini kaldırmak teslimatı yeniden başlatır.",
+    "source_hash": "3651887e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.searchLabel": {
+    "text": "Tam adres",
+    "source_hash": "f4338ff8"
+  },
+  "web.admin.emailtools.deliverability.suppressions.searchPlaceholder": {
+    "text": "user{'@'}example.com",
+    "source_hash": "333f0f15"
+  },
+  "web.admin.emailtools.deliverability.suppressions.searchButton": {
+    "text": "Sorgula",
+    "source_hash": "504101bc"
+  },
+  "web.admin.emailtools.deliverability.suppressions.clearButton": {
+    "text": "Temizle",
+    "source_hash": "83b12c22"
+  },
+  "web.admin.emailtools.deliverability.suppressions.empty": {
+    "text": "Henüz engellenmiş adres yok. Geri dönüş ve şikayet geri bildirimleri alındıkça burada görünürler.",
+    "source_hash": "dd3f4d61"
+  },
+  "web.admin.emailtools.deliverability.suppressions.emptySearch": {
+    "text": "{address} için engelleme kaydı yok.",
+    "source_hash": "200c361e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.loadError": {
+    "text": "Engelleme listesi yüklenemedi.",
+    "source_hash": "2a12c8ba"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.addressLabel": {
+    "text": "Adres ekle",
+    "source_hash": "8be5aa33"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.button": {
+    "text": "Engelle",
+    "source_hash": "60b19987"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.confirmTitle": {
+    "text": "Bu adres engellensin mi?",
+    "source_hash": "40a0d2a6"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.confirmDescription": {
+    "text": "Engelleme kaldırılana kadar {address} adresine giden posta atlanacaktır. Bu, manuel bir girdi olarak kaydedilir.",
+    "source_hash": "e3d0d799"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.success": {
+    "text": "{address} adresi engellendi.",
+    "source_hash": "e2cd2c3b"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.successExisting": {
+    "text": "{address} adresi zaten engellenmişti; girdi güncellendi.",
+    "source_hash": "0852101e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.add.error": {
+    "text": "Adres engellenemedi.",
+    "source_hash": "dad9e000"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.address": {
+    "text": "Adres",
+    "source_hash": "56ef8f20"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.reason": {
+    "text": "Neden",
+    "source_hash": "f81ab834"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.source": {
+    "text": "Kaynak",
+    "source_hash": "0e570ca6"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.added": {
+    "text": "Eklenme",
+    "source_hash": "6b02e0d3"
+  },
+  "web.admin.emailtools.deliverability.suppressions.columns.actions": {
+    "text": "İşlemler",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.button": {
+    "text": "Kaldır",
+    "source_hash": "c3812fc4"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.confirmTitle": {
+    "text": "Bu engelleme kaldırılsın mı?",
+    "source_hash": "0b0aec2e"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.confirmDescription": {
+    "text": "{address} adresine giden posta yeniden başlayacaktır. Bu adres daha önce geri döndü veya şikayet aldı — yalnızca yeniden teslim edilebilir olduğundan eminseniz kaldırın.",
+    "source_hash": "09442f9c"
+  },
+  "web.admin.emailtools.deliverability.suppressions.remove.success": {
+    "text": "{address} için engelleme kaldırıldı.",
+    "source_hash": "bfc0de36"
+  },
+  "web.admin.emailtools.deliverability.sync.title": {
+    "text": "Geri bildirim senkronizasyonu",
+    "source_hash": "d4056915"
+  },
+  "web.admin.emailtools.deliverability.sync.lastSynced": {
+    "text": "son senkronize edilme",
+    "source_hash": "5a99666b"
+  },
+  "web.admin.emailtools.deliverability.sync.imported": {
+    "text": "{count} içe aktarıldı",
+    "source_hash": "1bc18c45"
+  },
+  "web.admin.emailtools.deliverability.sync.neverRun": {
+    "text": "Sağlayıcı geri bildirim senkronizasyonu hiç çalışmadı. Geri dönüş ve şikayet verileri otomatik olarak içe aktarılmıyor — bir sağlayıcı senkronizasyonu yapılandırın veya geri bildirimi olaylar uç noktası aracılığıyla alın.",
+    "source_hash": "d19f5755"
+  },
+  "web.admin.emailtools.deliverability.sync.button": {
+    "text": "Şimdi senkronize et",
+    "source_hash": "885e8f48"
+  },
+  "web.admin.emailtools.deliverability.sync.success": {
+    "text": "{provider} senkronizasyonu tamamlandı: {accepted} içe aktarıldı, {rejected} reddedildi ({fetched} alındı).",
+    "source_hash": "d36f5578"
+  },
+  "web.admin.emailtools.deliverability.sync.hint": {
+    "text": "Manuel bir senkronizasyon — otomatik içe aktarma yine de zamanlanmış bir `ots email sync-feedback` cron gerektirir.",
+    "source_hash": "7a509b75"
+  },
+  "web.admin.emailtools.deliverability.tiles.suppressed": {
+    "text": "Engellenen adresler",
+    "source_hash": "b31a245e"
+  },
+  "web.admin.emailtools.deliverability.tiles.bounces": {
+    "text": "Geri dönüşler ({days}g)",
+    "source_hash": "3a4d0f09"
+  },
+  "web.admin.emailtools.deliverability.tiles.complaints": {
+    "text": "Şikayetler ({days}g)",
+    "source_hash": "16ad856f"
+  },
+  "web.admin.emailtools.deliverability.tiles.skipped": {
+    "text": "Atlanan gönderimler",
+    "source_hash": "391467f9"
+  },
+  "web.admin.emailtools.preview.title": {
+    "text": "Şablon önizlemesi",
+    "source_hash": "df89bd92"
+  },
+  "web.admin.emailtools.preview.description": {
+    "text": "Bir şablonu örnek verileriyle oluşturun. Önizlemenin hiçbir yan etkisi yoktur — hiçbir e-posta gönderilmez.",
+    "source_hash": "9b0e40f3"
+  },
+  "web.admin.emailtools.preview.templateLabel": {
+    "text": "Şablon",
+    "source_hash": "0575f29d"
+  },
+  "web.admin.emailtools.preview.formatLabel": {
+    "text": "Biçim",
+    "source_hash": "2f343666"
+  },
+  "web.admin.emailtools.preview.localeLabel": {
+    "text": "Dil",
+    "source_hash": "ca3dc612"
+  },
+  "web.admin.emailtools.preview.button": {
+    "text": "Önizle",
+    "source_hash": "324b134f"
+  },
+  "web.admin.emailtools.providerStatus.title": {
+    "text": "Sağlayıcı durumu",
+    "source_hash": "231b7f03"
+  },
+  "web.admin.emailtools.providerStatus.rateUnavailable": {
+    "text": "Bu sağlayıcı, sayısal geri dönüş veya şikayet oranı sunmaz; yukarıdaki itibar kademesi yalnızca uygulama durumundan ve gönderim kotasından türetilir.",
+    "source_hash": "1e6b82e9"
+  },
+  "web.admin.emailtools.providerStatus.complaintsUnavailable": {
+    "text": "Lettermint, istatistik API'sinde şikayetleri raporlamaz, bu nedenle şikayet oranı sıfır olarak değil “—” (raporlanmadı) olarak gösterilir. Yukarıdaki geri dönüş oranı tamdır.",
+    "source_hash": "72aaa845"
+  },
+  "web.admin.emailtools.providerStatus.unavailable": {
+    "text": "Sağlayıcı durumu geçici olarak kullanılamıyor.",
+    "source_hash": "8e69ff29"
+  },
+  "web.admin.emailtools.providerStatus.notSupported": {
+    "text": "{provider} aktarımında canlı sağlayıcı durumu kullanılamıyor.",
+    "source_hash": "125ed6eb"
+  },
+  "web.admin.emailtools.providerStatus.error": {
+    "text": "Durum için posta sağlayıcısına ulaşılamadı. Tekrar deneyin.",
+    "source_hash": "594ab7b1"
+  },
+  "web.admin.emailtools.providerStatus.quota.max24h": {
+    "text": "24 saatlik gönderim sınırı",
+    "source_hash": "e5ea4c3d"
+  },
+  "web.admin.emailtools.providerStatus.quota.sent24h": {
+    "text": "Gönderilen (son 24 saat)",
+    "source_hash": "d0c4fe45"
+  },
+  "web.admin.emailtools.providerStatus.quota.maxRate": {
+    "text": "Maksimum gönderim hızı (saniye başına)",
+    "source_hash": "59e76cf8"
+  },
+  "web.admin.emailtools.providerStatus.rate.bounce": {
+    "text": "Geri dönüş oranı",
+    "source_hash": "9eba32f0"
+  },
+  "web.admin.emailtools.providerStatus.rate.complaint": {
+    "text": "Şikayet oranı",
+    "source_hash": "430a23a9"
+  },
+  "web.admin.emailtools.providerStatus.stats.sent": {
+    "text": "Gönderilen ({days}g)",
+    "source_hash": "e553b7e1"
+  },
+  "web.admin.emailtools.providerStatus.stats.delivered": {
+    "text": "Teslim edildi",
+    "source_hash": "90611565"
+  },
+  "web.admin.emailtools.providerStatus.stats.hardBounced": {
+    "text": "Kalıcı geri döndü",
+    "source_hash": "c76631c0"
+  },
+  "web.admin.emailtools.providerStatus.stats.complaints": {
+    "text": "Spam şikayetleri",
+    "source_hash": "d48953cd"
+  },
+  "web.admin.emailtools.providerStatus.tier.healthy": {
+    "text": "Sağlıklı",
+    "source_hash": "7f1e323b"
+  },
+  "web.admin.emailtools.providerStatus.tier.probation": {
+    "text": "İnceleme altında",
+    "source_hash": "9e8a3b64"
+  },
+  "web.admin.emailtools.providerStatus.tier.shutdown": {
+    "text": "Gönderim duraklatıldı",
+    "source_hash": "52e6757c"
+  },
+  "web.admin.emailtools.test.title": {
+    "text": "Test gönderimi",
+    "source_hash": "5fab5d67"
+  },
+  "web.admin.emailtools.test.description": {
+    "text": "Teslimat bağlantısını doğrulamak için düz metin bir tanılama e-postası gönderin. Önce önizleyin, ardından gerçek bir e-posta göndermek için onaylayın.",
+    "source_hash": "4130741c"
+  },
+  "web.admin.emailtools.test.toLabel": {
+    "text": "Alıcı",
+    "source_hash": "51fac985"
+  },
+  "web.admin.emailtools.test.toPlaceholder": {
+    "text": "you{'@'}example.com",
+    "source_hash": "cf0a9acc"
+  },
+  "web.admin.emailtools.test.enqueueLabel": {
+    "text": "İşleyici kuyruğu aracılığıyla",
+    "source_hash": "97897017"
+  },
+  "web.admin.emailtools.test.previewButton": {
+    "text": "Önizle (gönderme yok)",
+    "source_hash": "747ced83"
+  },
+  "web.admin.emailtools.test.sendButton": {
+    "text": "Test e-postası gönder",
+    "source_hash": "46ebd7db"
+  },
+  "web.admin.emailtools.test.provider": {
+    "text": "Sağlayıcı",
+    "source_hash": "472590ae"
+  },
+  "web.admin.emailtools.test.host": {
+    "text": "Kaynak ana bilgisayarı",
+    "source_hash": "968925cb"
+  },
+  "web.admin.emailtools.test.from": {
+    "text": "Gönderen",
+    "source_hash": "21819769"
+  },
+  "web.admin.emailtools.test.subject": {
+    "text": "Konu",
+    "source_hash": "68971283"
+  },
+  "web.admin.emailtools.test.confirmTitle": {
+    "text": "Gerçek bir test e-postası gönderilsin mi?",
+    "source_hash": "64a16b62"
+  },
+  "web.admin.emailtools.test.confirmDescription": {
+    "text": "Bu işlem, yapılandırılmış posta gönderici aracılığıyla {to} adresine canlı bir e-posta gönderir.",
+    "source_hash": "10114929"
+  },
+  "web.admin.emailtools.test.success": {
+    "text": "Test e-postası {to} adresine gönderildi.",
+    "source_hash": "daa61a62"
+  }
+}

--- a/locales/content/tr/admin-kit.json
+++ b/locales/content/tr/admin-kit.json
@@ -1,0 +1,66 @@
+{
+  "web.admin.kit.confirmDialog.typePrompt": {
+    "text": "Onaylamak için aşağıya {token} yazın",
+    "source_hash": "282445b6"
+  },
+  "web.admin.kit.confirmDialog.inputLabel": {
+    "text": "Onay metni",
+    "source_hash": "8edc1113"
+  },
+  "web.admin.kit.confirmDialog.mismatchHint": {
+    "text": "Devam etmek için girilen metnin tam olarak eşleşmesi gerekir.",
+    "source_hash": "f0cc7389"
+  },
+  "web.admin.kit.dataTable.empty": {
+    "text": "Kayıt bulunamadı",
+    "source_hash": "6e2ea637"
+  },
+  "web.admin.kit.dataTable.sortBy": {
+    "text": "{column} sütununa göre sırala",
+    "source_hash": "55fb1bf9"
+  },
+  "web.admin.kit.filterBar.search": {
+    "text": "Ara",
+    "source_hash": "49c266ba"
+  },
+  "web.admin.kit.filterBar.searchPlaceholder": {
+    "text": "Ara…",
+    "source_hash": "7336265a"
+  },
+  "web.admin.kit.filterBar.clearFilters": {
+    "text": "Filtreleri temizle",
+    "source_hash": "7179ea00"
+  },
+  "web.admin.kit.filterBar.all": {
+    "text": "Tümü",
+    "source_hash": "a52ace42"
+  },
+  "web.admin.kit.jsonViewer.expandAll": {
+    "text": "Tümünü genişlet",
+    "source_hash": "a3e586be"
+  },
+  "web.admin.kit.jsonViewer.collapseAll": {
+    "text": "Tümünü daralt",
+    "source_hash": "25f7b372"
+  },
+  "web.admin.kit.jsonViewer.empty": {
+    "text": "Veri yok",
+    "source_hash": "3b41ba9c"
+  },
+  "web.admin.kit.jsonViewer.copyLabel": {
+    "text": "JSON'u kopyala",
+    "source_hash": "7708c6e2"
+  },
+  "web.admin.kit.revealEmail.reveal": {
+    "text": "E-posta adresini göster",
+    "source_hash": "f6272277"
+  },
+  "web.admin.kit.revealEmail.hide": {
+    "text": "E-posta adresini gizle",
+    "source_hash": "9755e870"
+  },
+  "web.admin.kit.revealEmail.copy": {
+    "text": "E-posta adresini kopyala",
+    "source_hash": "61b94846"
+  }
+}

--- a/locales/content/tr/admin-organizations.json
+++ b/locales/content/tr/admin-organizations.json
@@ -1,0 +1,314 @@
+{
+  "web.admin.organizations.retry": {
+    "text": "Yeniden Dene",
+    "source_hash": "942087cc"
+  },
+  "web.admin.organizations.detail.backToList": {
+    "text": "Kuruluşlara dön",
+    "source_hash": "2257dc4a"
+  },
+  "web.admin.organizations.detail.notFound": {
+    "text": "Kuruluş bulunamadı",
+    "source_hash": "00c50f7a"
+  },
+  "web.admin.organizations.detail.notFoundDescription": {
+    "text": "Bu kuruluş silinmiş olabilir veya kimlik yanlış.",
+    "source_hash": "e5459ef5"
+  },
+  "web.admin.organizations.detail.loadError": {
+    "text": "Bu kuruluş yüklenemedi.",
+    "source_hash": "9df8ad50"
+  },
+  "web.admin.organizations.detail.none": {
+    "text": "—",
+    "source_hash": "bda05058"
+  },
+  "web.admin.organizations.detail.badges.default": {
+    "text": "Varsayılan çalışma alanı",
+    "source_hash": "6d67c6eb"
+  },
+  "web.admin.organizations.detail.badges.archived": {
+    "text": "Arşivlendi",
+    "source_hash": "bdb86505"
+  },
+  "web.admin.organizations.detail.domains.domain": {
+    "text": "Alan Adı",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.organizations.detail.domains.state": {
+    "text": "Durum",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.organizations.detail.domains.created": {
+    "text": "Oluşturulma",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.organizations.detail.domains.ready": {
+    "text": "Hazır",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.organizations.detail.domains.resolving": {
+    "text": "Çözümleniyor",
+    "source_hash": "3287a034"
+  },
+  "web.admin.organizations.detail.domains.empty": {
+    "text": "Alan adı yok.",
+    "source_hash": "1b840c7e"
+  },
+  "web.admin.organizations.detail.entitlements.description": {
+    "text": "Etkin yetkilendirmeler (plan ∪ verilenler) − iptal edilenler olarak çözümlenir. Bir geçersiz kılma yapmadan önce dökümü inceleyin.",
+    "source_hash": "23080475"
+  },
+  "web.admin.organizations.detail.entitlements.inSync": {
+    "text": "Senkronize",
+    "source_hash": "5701958c"
+  },
+  "web.admin.organizations.detail.entitlements.driftBadge": {
+    "text": "Sapma",
+    "source_hash": "8b4c8240"
+  },
+  "web.admin.organizations.detail.entitlements.staleBadge": {
+    "text": "Plan eski",
+    "source_hash": "ffe63800"
+  },
+  "web.admin.organizations.detail.entitlements.driftWarning": {
+    "text": "Somutlaştırılan yetkilendirmeler beklenen kümeyle eşleşmiyor. Yeniden somutlaştırmak için uzlaştırın.",
+    "source_hash": "4859983a"
+  },
+  "web.admin.organizations.detail.entitlements.driftExtra": {
+    "text": "Fazladan (somutlaştırıldı, beklenmiyordu)",
+    "source_hash": "08d60730"
+  },
+  "web.admin.organizations.detail.entitlements.driftMissing": {
+    "text": "Eksik (beklenen, somutlaştırılmadı)",
+    "source_hash": "fe12c83a"
+  },
+  "web.admin.organizations.detail.entitlements.plan": {
+    "text": "Plandan",
+    "source_hash": "1d346b26"
+  },
+  "web.admin.organizations.detail.entitlements.materialized": {
+    "text": "Somutlaştırıldı (etkin)",
+    "source_hash": "72ca5f45"
+  },
+  "web.admin.organizations.detail.members.email": {
+    "text": "Üye",
+    "source_hash": "7c968fb7"
+  },
+  "web.admin.organizations.detail.members.role": {
+    "text": "Rol",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.organizations.detail.members.status": {
+    "text": "Durum",
+    "source_hash": "920e413c"
+  },
+  "web.admin.organizations.detail.members.joined": {
+    "text": "Katılma",
+    "source_hash": "69318b0c"
+  },
+  "web.admin.organizations.detail.members.owner": {
+    "text": "Sahip",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.detail.members.empty": {
+    "text": "Üye yok.",
+    "source_hash": "b99c59dc"
+  },
+  "web.admin.organizations.detail.reconcile.button": {
+    "text": "Uzlaştır",
+    "source_hash": "b59be565"
+  },
+  "web.admin.organizations.detail.reconcile.confirmTitle": {
+    "text": "Kuruluş faturalandırması uzlaştırılsın mı?",
+    "source_hash": "fc1a2762"
+  },
+  "web.admin.organizations.detail.reconcile.confirmDescription": {
+    "text": "Bu işlem, Stripe'ı yeniden çeker ve {org} için faturalandırma durumunu ve yetkilendirmeleri yeniden yazar. Onaylamak için kuruluş kimliğini yeniden yazın.",
+    "source_hash": "b4ef0850"
+  },
+  "web.admin.organizations.detail.reconcile.success": {
+    "text": "Kuruluş uzlaştırıldı.",
+    "source_hash": "caf87844"
+  },
+  "web.admin.organizations.detail.reconcile.resultTitle": {
+    "text": "Uzlaştırma sonucu",
+    "source_hash": "11f4c6b8"
+  },
+  "web.admin.organizations.detail.reconcile.before": {
+    "text": "Öncesi",
+    "source_hash": "9bb72500"
+  },
+  "web.admin.organizations.detail.reconcile.after": {
+    "text": "Sonrası",
+    "source_hash": "7b68fe55"
+  },
+  "web.admin.organizations.detail.reconcile.materializedCount": {
+    "text": "Yetkilendirme sayısı",
+    "source_hash": "59cede5c"
+  },
+  "web.admin.organizations.detail.reconcile.mode.stripe_sync": {
+    "text": "Stripe senkronizasyonu",
+    "source_hash": "02f9546c"
+  },
+  "web.admin.organizations.detail.reconcile.mode.entitlements_only": {
+    "text": "Yalnızca yetkilendirmeler",
+    "source_hash": "8cf49a5d"
+  },
+  "web.admin.organizations.detail.sections.billing": {
+    "text": "Faturalandırma",
+    "source_hash": "3ac8bbca"
+  },
+  "web.admin.organizations.detail.sections.members": {
+    "text": "Üyeler",
+    "source_hash": "1044a4c0"
+  },
+  "web.admin.organizations.detail.sections.domains": {
+    "text": "Alan Adları",
+    "source_hash": "ced67718"
+  },
+  "web.admin.organizations.detail.sections.investigate": {
+    "text": "İncele ve uzlaştır",
+    "source_hash": "b05aa349"
+  },
+  "web.admin.organizations.entitlements.section": {
+    "text": "Yetkilendirme geçersiz kılmaları",
+    "source_hash": "48812068"
+  },
+  "web.admin.organizations.entitlements.description": {
+    "text": "Yetkilendirmeleri plandan bağımsız olarak verin veya iptal edin. Etkin = plan yetkilendirmeleri + verilenler - iptal edilenler.",
+    "source_hash": "4c38425b"
+  },
+  "web.admin.organizations.entitlements.inputLabel": {
+    "text": "Yetkilendirme",
+    "source_hash": "0d8f0b2d"
+  },
+  "web.admin.organizations.entitlements.placeholder": {
+    "text": "örn. custom_domains",
+    "source_hash": "05346c68"
+  },
+  "web.admin.organizations.entitlements.grant": {
+    "text": "Ver",
+    "source_hash": "78b7d037"
+  },
+  "web.admin.organizations.entitlements.revoke": {
+    "text": "İptal et",
+    "source_hash": "87e6d00b"
+  },
+  "web.admin.organizations.entitlements.clear": {
+    "text": "Tüm geçersiz kılmaları temizle",
+    "source_hash": "f0e485c3"
+  },
+  "web.admin.organizations.entitlements.effective": {
+    "text": "Etkin yetkilendirmeler",
+    "source_hash": "b840f8c8"
+  },
+  "web.admin.organizations.entitlements.grants": {
+    "text": "Verilenler",
+    "source_hash": "b3e1c95a"
+  },
+  "web.admin.organizations.entitlements.revokes": {
+    "text": "İptal edilenler",
+    "source_hash": "f0e69b17"
+  },
+  "web.admin.organizations.entitlements.noOverrides": {
+    "text": "Bu kuruluşun mevcut geçersiz kılma durumunu görmek için bir işlem gerçekleştirin.",
+    "source_hash": "98d2e30d"
+  },
+  "web.admin.organizations.entitlements.confirm.grantTitle": {
+    "text": "Yetkilendirme verilsin mi?",
+    "source_hash": "a4b2c57b"
+  },
+  "web.admin.organizations.entitlements.confirm.grantDescription": {
+    "text": "{org} kuruluşuna “{entitlement}” ver. Bu, kuruluşun faturalandırma yetkilendirmelerini değiştirir.",
+    "source_hash": "542ce26a"
+  },
+  "web.admin.organizations.entitlements.confirm.revokeTitle": {
+    "text": "Yetkilendirme iptal edilsin mi?",
+    "source_hash": "c93d520a"
+  },
+  "web.admin.organizations.entitlements.confirm.revokeDescription": {
+    "text": "{org} kuruluşundan “{entitlement}” iptal et. Bu, kuruluşun faturalandırma yetkilendirmelerini değiştirir.",
+    "source_hash": "a5d2a8a6"
+  },
+  "web.admin.organizations.entitlements.confirm.clearTitle": {
+    "text": "Tüm yetkilendirme geçersiz kılmaları temizlensin mi?",
+    "source_hash": "e36eb218"
+  },
+  "web.admin.organizations.entitlements.confirm.clearDescription": {
+    "text": "{org} için her verme ve iptal etme geçersiz kılmasını kaldırıp plan yetkilendirmelerine sıfırlayın.",
+    "source_hash": "96bad079"
+  },
+  "web.admin.organizations.entitlements.success.granted": {
+    "text": "“{entitlement}” yetkilendirmesi verildi.",
+    "source_hash": "cf52fb0e"
+  },
+  "web.admin.organizations.entitlements.success.revoked": {
+    "text": "“{entitlement}” yetkilendirmesi iptal edildi.",
+    "source_hash": "279d425d"
+  },
+  "web.admin.organizations.entitlements.success.cleared": {
+    "text": "Tüm yetkilendirme geçersiz kılmaları temizlendi.",
+    "source_hash": "a482743b"
+  },
+  "web.admin.organizations.fields.contactEmail": {
+    "text": "İletişim e-postası",
+    "source_hash": "6d7fce11"
+  },
+  "web.admin.organizations.fields.owner": {
+    "text": "Sahip",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.fields.plan": {
+    "text": "Plan",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.organizations.fields.subscription": {
+    "text": "Abonelik durumu",
+    "source_hash": "f0723c4e"
+  },
+  "web.admin.organizations.fields.periodEnd": {
+    "text": "Dönem bitişi",
+    "source_hash": "eeae9fdd"
+  },
+  "web.admin.organizations.fields.billingEmail": {
+    "text": "Faturalandırma e-postası",
+    "source_hash": "8805b928"
+  },
+  "web.admin.organizations.fields.stripeCustomer": {
+    "text": "Stripe müşterisi",
+    "source_hash": "8f169be1"
+  },
+  "web.admin.organizations.fields.stripeSubscription": {
+    "text": "Stripe aboneliği",
+    "source_hash": "53f71e08"
+  },
+  "web.admin.organizations.fields.orgId": {
+    "text": "Kuruluş Kimliği",
+    "source_hash": "1f466322"
+  },
+  "web.admin.organizations.fields.created": {
+    "text": "Oluşturulma",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.organizations.fields.updated": {
+    "text": "Güncellenme",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.organizations.investigate.description": {
+    "text": "Yerel faturalandırma durumunu canlı Stripe aboneliğiyle karşılaştırın.",
+    "source_hash": "d7bbe9ed"
+  },
+  "web.admin.organizations.investigate.rawPayload": {
+    "text": "Ham inceleme yükü",
+    "source_hash": "29ca7df2"
+  },
+  "web.admin.organizations.investigate.parseError": {
+    "text": "İnceleme yanıtı beklenen biçimle eşleşmedi.",
+    "source_hash": "db59cab1"
+  },
+  "web.admin.organizations.list.loadError": {
+    "text": "Kuruluşlar yüklenemedi.",
+    "source_hash": "130d5e70"
+  }
+}

--- a/locales/content/tr/admin-overview.json
+++ b/locales/content/tr/admin-overview.json
@@ -1,0 +1,94 @@
+{
+  "web.admin.overview.retry": {
+    "text": "Yeniden Dene",
+    "source_hash": "942087cc"
+  },
+  "web.admin.overview.feedback.title": {
+    "text": "Kullanıcı geri bildirimi",
+    "source_hash": "cb7b24c6"
+  },
+  "web.admin.overview.feedback.total": {
+    "text": "Son 30 günde {count}",
+    "source_hash": "b6b9147c"
+  },
+  "web.admin.overview.feedback.today": {
+    "text": "Bugün",
+    "source_hash": "2b065c7c"
+  },
+  "web.admin.overview.feedback.yesterday": {
+    "text": "Dün",
+    "source_hash": "56618125"
+  },
+  "web.admin.overview.feedback.older": {
+    "text": "Daha eski",
+    "source_hash": "03281c88"
+  },
+  "web.admin.overview.feedback.empty": {
+    "text": "Bu dönemde geri bildirim yok",
+    "source_hash": "e09d594d"
+  },
+  "web.admin.overview.feedback.loadError": {
+    "text": "Geri bildirim yüklenemedi.",
+    "source_hash": "4011c408"
+  },
+  "web.admin.overview.stats.heading": {
+    "text": "Platform istatistikleri",
+    "source_hash": "77728e4d"
+  },
+  "web.admin.overview.stats.customers": {
+    "text": "Müşteriler",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.overview.stats.secrets": {
+    "text": "Etkin gizli mesajlar",
+    "source_hash": "8db4c552"
+  },
+  "web.admin.overview.stats.sessions": {
+    "text": "Etkin oturumlar",
+    "source_hash": "61ad9909"
+  },
+  "web.admin.overview.stats.receipts": {
+    "text": "Makbuzlar",
+    "source_hash": "60a627df"
+  },
+  "web.admin.overview.stats.secretsCreated": {
+    "text": "Oluşturulan gizli mesajlar (tüm zamanlar)",
+    "source_hash": "bdb49794"
+  },
+  "web.admin.overview.stats.emailsSent": {
+    "text": "Gönderilen e-postalar (tüm zamanlar)",
+    "source_hash": "1c9a7518"
+  },
+  "web.admin.overview.stats.loadError": {
+    "text": "Platform istatistikleri yüklenemedi.",
+    "source_hash": "5f13cf7a"
+  },
+  "web.admin.overview.trends.title": {
+    "text": "Son 30 gün",
+    "source_hash": "f8f03fb4"
+  },
+  "web.admin.overview.trends.signups": {
+    "text": "Günlük kayıtlar",
+    "source_hash": "8db399dc"
+  },
+  "web.admin.overview.trends.secretsCreated": {
+    "text": "Günlük oluşturulan gizli mesajlar",
+    "source_hash": "d6852656"
+  },
+  "web.admin.overview.trends.today": {
+    "text": "bugün",
+    "source_hash": "e0f4f767"
+  },
+  "web.admin.overview.trends.collectingNote": {
+    "text": "İlk veri noktasından bu yana toplanıyor — ondan önceki günler sıfır gösterir.",
+    "source_hash": "269ee1eb"
+  },
+  "web.admin.overview.trends.sparklineAria": {
+    "text": "{label}: 30 günlük eğilim, bugün {count}",
+    "source_hash": "eb57a7b2"
+  },
+  "web.admin.overview.trends.loadError": {
+    "text": "Eğilimler yüklenemedi.",
+    "source_hash": "9cf97f63"
+  }
+}

--- a/locales/content/tr/admin-secrets.json
+++ b/locales/content/tr/admin-secrets.json
@@ -1,0 +1,218 @@
+{
+  "web.admin.secrets.title": {
+    "text": "Gizli Mesajlar",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.secrets.description": {
+    "text": "Bir gizli mesajın makbuzunu inceleyin ve SSH kullanmadan silin — anahtarıyla arayın.",
+    "source_hash": "07775a11"
+  },
+  "web.admin.secrets.never": {
+    "text": "Hiçbir zaman",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.secrets.anonymous": {
+    "text": "Anonim",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.admin.secrets.ageDays": {
+    "text": "{days} gün",
+    "source_hash": "a2246fbc"
+  },
+  "web.admin.secrets.actions.delete.button": {
+    "text": "Gizli mesajı sil",
+    "source_hash": "1a48c8c8"
+  },
+  "web.admin.secrets.actions.delete.confirmTitle": {
+    "text": "Gizli mesaj silinsin mi?",
+    "source_hash": "4a779a67"
+  },
+  "web.admin.secrets.actions.delete.confirmDescription": {
+    "text": "Bu işlem, {shortid} gizli mesajını ve makbuzunu kalıcı olarak siler. Bu işlem geri alınamaz.",
+    "source_hash": "51f807ad"
+  },
+  "web.admin.secrets.actions.delete.success": {
+    "text": "Gizli mesaj silindi.",
+    "source_hash": "52f1640f"
+  },
+  "web.admin.secrets.detail.yes": {
+    "text": "Evet",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.secrets.detail.no": {
+    "text": "Hayır",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.secrets.detail.none": {
+    "text": "Yok",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.secrets.fields.secretId": {
+    "text": "Gizli Mesaj Kimliği",
+    "source_hash": "79592419"
+  },
+  "web.admin.secrets.fields.shortId": {
+    "text": "Kısa Kimlik",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.secrets.fields.state": {
+    "text": "Durum",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.secrets.fields.created": {
+    "text": "Oluşturulma",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.secrets.fields.updated": {
+    "text": "Güncellenme",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.secrets.fields.expiration": {
+    "text": "Son Kullanım Tarihi",
+    "source_hash": "f38d6e0e"
+  },
+  "web.admin.secrets.fields.age": {
+    "text": "Yaş",
+    "source_hash": "39b7370f"
+  },
+  "web.admin.secrets.fields.lifespan": {
+    "text": "Yaşam süresi",
+    "source_hash": "58994285"
+  },
+  "web.admin.secrets.fields.owner": {
+    "text": "Sahip",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.secrets.fields.receiptId": {
+    "text": "Makbuz Kimliği",
+    "source_hash": "2c13d799"
+  },
+  "web.admin.secrets.fields.hasCiphertext": {
+    "text": "Şifreli metin var",
+    "source_hash": "e9188bad"
+  },
+  "web.admin.secrets.fields.ciphertextLength": {
+    "text": "Şifreli metin uzunluğu",
+    "source_hash": "0f1744fd"
+  },
+  "web.admin.secrets.lookup.label": {
+    "text": "Gizli mesaj anahtarı",
+    "source_hash": "f47a99eb"
+  },
+  "web.admin.secrets.lookup.placeholder": {
+    "text": "Gizli mesaj tanımlayıcısı",
+    "source_hash": "cbcfd49f"
+  },
+  "web.admin.secrets.lookup.button": {
+    "text": "Sorgula",
+    "source_hash": "504101bc"
+  },
+  "web.admin.secrets.lookup.resultTitle": {
+    "text": "{shortid} gizli mesajı",
+    "source_hash": "8b311d32"
+  },
+  "web.admin.secrets.lookup.notFound": {
+    "text": "Gizli mesaj bulunamadı",
+    "source_hash": "70a9532c"
+  },
+  "web.admin.secrets.lookup.notFoundDescription": {
+    "text": "Bu anahtarla bir gizli mesaj yok. Süresi dolmuş veya silinmiş olabilir.",
+    "source_hash": "9f068a81"
+  },
+  "web.admin.secrets.lookup.loadError": {
+    "text": "Bu gizli mesaj yüklenemedi.",
+    "source_hash": "c96672e4"
+  },
+  "web.admin.secrets.lookup.retry": {
+    "text": "Yeniden Dene",
+    "source_hash": "942087cc"
+  },
+  "web.admin.secrets.owner.anonymous": {
+    "text": "Anonim (sahipsiz)",
+    "source_hash": "390f11ad"
+  },
+  "web.admin.secrets.ownerFields.email": {
+    "text": "E-posta",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.secrets.ownerFields.userId": {
+    "text": "Kullanıcı Kimliği",
+    "source_hash": "7967e089"
+  },
+  "web.admin.secrets.ownerFields.role": {
+    "text": "Rol",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.secrets.ownerFields.verified": {
+    "text": "Doğrulandı",
+    "source_hash": "4f783840"
+  },
+  "web.admin.secrets.receipt.none": {
+    "text": "Bu gizli mesajla ilişkili bir makbuz yok.",
+    "source_hash": "5ddceaed"
+  },
+  "web.admin.secrets.receiptFields.receiptId": {
+    "text": "Makbuz Kimliği",
+    "source_hash": "2c13d799"
+  },
+  "web.admin.secrets.receiptFields.shortId": {
+    "text": "Kısa Kimlik",
+    "source_hash": "7eaeb4a7"
+  },
+  "web.admin.secrets.receiptFields.state": {
+    "text": "Durum",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.secrets.receiptFields.secretTtl": {
+    "text": "Gizli mesaj TTL",
+    "source_hash": "b89c0b51"
+  },
+  "web.admin.secrets.receiptFields.recipients": {
+    "text": "Alıcılar",
+    "source_hash": "1e8568a8"
+  },
+  "web.admin.secrets.receiptFields.hasPassphrase": {
+    "text": "Güvenlik ifadesi var",
+    "source_hash": "af458f26"
+  },
+  "web.admin.secrets.receiptFields.shareDomain": {
+    "text": "Paylaşım alan adı",
+    "source_hash": "db963805"
+  },
+  "web.admin.secrets.receiptFields.created": {
+    "text": "Oluşturulma",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.secrets.receiptFields.secretExpired": {
+    "text": "Gizli mesajın süresi doldu",
+    "source_hash": "c127dab6"
+  },
+  "web.admin.secrets.sections.secret": {
+    "text": "Gizli Mesaj",
+    "source_hash": "7e32a729"
+  },
+  "web.admin.secrets.sections.receipt": {
+    "text": "Makbuz",
+    "source_hash": "dad5a969"
+  },
+  "web.admin.secrets.sections.owner": {
+    "text": "Sahip",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.secrets.sections.raw": {
+    "text": "Ham",
+    "source_hash": "848123d1"
+  },
+  "web.admin.secrets.state.new": {
+    "text": "Yeni",
+    "source_hash": "18fdd549"
+  },
+  "web.admin.secrets.state.received": {
+    "text": "Alındı",
+    "source_hash": "49f19bee"
+  },
+  "web.admin.secrets.state.viewed": {
+    "text": "Görüntülendi",
+    "source_hash": "1b28d178"
+  }
+}

--- a/locales/content/tr/admin-sessions.json
+++ b/locales/content/tr/admin-sessions.json
@@ -1,0 +1,210 @@
+{
+  "web.admin.sessions.title": {
+    "text": "Oturumlar",
+    "source_hash": "6fa3cbf4"
+  },
+  "web.admin.sessions.description": {
+    "text": "Olaylara müdahale için etkin oturumları inceleyin, arayın ve iptal edin.",
+    "source_hash": "784a3a44"
+  },
+  "web.admin.sessions.anonymous": {
+    "text": "Anonim",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.admin.sessions.columns.sessionId": {
+    "text": "Oturum Kimliği",
+    "source_hash": "cb9ac5c5"
+  },
+  "web.admin.sessions.columns.authenticated": {
+    "text": "Kimlik Doğrulama",
+    "source_hash": "8eb3ea9b"
+  },
+  "web.admin.sessions.columns.email": {
+    "text": "E-posta",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.sessions.columns.externalId": {
+    "text": "Harici Kimlik",
+    "source_hash": "69da56ba"
+  },
+  "web.admin.sessions.columns.ipAddress": {
+    "text": "IP Adresi",
+    "source_hash": "3c3de0c9"
+  },
+  "web.admin.sessions.columns.created": {
+    "text": "Kimlik Doğrulama Zamanı",
+    "source_hash": "8d6c9b01"
+  },
+  "web.admin.sessions.columns.actions": {
+    "text": "İşlemler",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.sessions.columns.role": {
+    "text": "Rol",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.sessions.detail.yes": {
+    "text": "Evet",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.sessions.detail.no": {
+    "text": "Hayır",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.sessions.detail.none": {
+    "text": "Yok",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.sessions.detail.unknown": {
+    "text": "Bilinmiyor",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.sessions.detail.noExpiry": {
+    "text": "Sona erme yok",
+    "source_hash": "fe06351d"
+  },
+  "web.admin.sessions.detail.expired": {
+    "text": "Süresi doldu",
+    "source_hash": "424a2551"
+  },
+  "web.admin.sessions.detail.ttlSeconds": {
+    "text": "{seconds}sn kaldı",
+    "source_hash": "3c9d75ce"
+  },
+  "web.admin.sessions.drawer.title": {
+    "text": "{id} oturumu",
+    "source_hash": "29dcbd66"
+  },
+  "web.admin.sessions.drawer.notFound": {
+    "text": "Oturum bulunamadı",
+    "source_hash": "0969eab8"
+  },
+  "web.admin.sessions.drawer.notFoundDescription": {
+    "text": "Bu oturum artık Redis'te yok. Süresi dolmuş veya zaten iptal edilmiş olabilir.",
+    "source_hash": "11e3ef05"
+  },
+  "web.admin.sessions.drawer.loadError": {
+    "text": "Bu oturum yüklenemedi.",
+    "source_hash": "82ae90fb"
+  },
+  "web.admin.sessions.drawer.retry": {
+    "text": "Yeniden Dene",
+    "source_hash": "942087cc"
+  },
+  "web.admin.sessions.fields.sessionId": {
+    "text": "Oturum Kimliği",
+    "source_hash": "cb9ac5c5"
+  },
+  "web.admin.sessions.fields.key": {
+    "text": "Redis Anahtarı",
+    "source_hash": "0b196725"
+  },
+  "web.admin.sessions.fields.ttl": {
+    "text": "TTL",
+    "source_hash": "76f6014f"
+  },
+  "web.admin.sessions.fields.authenticated": {
+    "text": "Kimliği doğrulandı",
+    "source_hash": "6ab694cf"
+  },
+  "web.admin.sessions.fields.email": {
+    "text": "E-posta",
+    "source_hash": "969ccbd3"
+  },
+  "web.admin.sessions.fields.externalId": {
+    "text": "Harici Kimlik",
+    "source_hash": "69da56ba"
+  },
+  "web.admin.sessions.fields.accountId": {
+    "text": "Hesap Kimliği",
+    "source_hash": "919bb4cb"
+  },
+  "web.admin.sessions.fields.role": {
+    "text": "Rol",
+    "source_hash": "14736a2e"
+  },
+  "web.admin.sessions.fields.locale": {
+    "text": "Dil",
+    "source_hash": "ca3dc612"
+  },
+  "web.admin.sessions.fields.ipAddress": {
+    "text": "IP Adresi",
+    "source_hash": "3c3de0c9"
+  },
+  "web.admin.sessions.fields.authenticatedAt": {
+    "text": "Kimlik Doğrulama Zamanı",
+    "source_hash": "8d6c9b01"
+  },
+  "web.admin.sessions.fields.authenticatedBy": {
+    "text": "Kimliği Doğrulayan",
+    "source_hash": "3ebbabfe"
+  },
+  "web.admin.sessions.fields.activeSessionId": {
+    "text": "Etkin Oturum Kimliği",
+    "source_hash": "f32b1158"
+  },
+  "web.admin.sessions.fields.userAgent": {
+    "text": "Kullanıcı Aracısı",
+    "source_hash": "62e01345"
+  },
+  "web.admin.sessions.fields.orgContext": {
+    "text": "Kuruluş Bağlamı",
+    "source_hash": "a596d9f2"
+  },
+  "web.admin.sessions.list.loadError": {
+    "text": "Oturumlar yüklenemedi.",
+    "source_hash": "00c678d9"
+  },
+  "web.admin.sessions.list.retry": {
+    "text": "Yeniden Dene",
+    "source_hash": "942087cc"
+  },
+  "web.admin.sessions.list.empty": {
+    "text": "Etkin oturum bulunamadı",
+    "source_hash": "e35312d6"
+  },
+  "web.admin.sessions.revoke.button": {
+    "text": "İptal et",
+    "source_hash": "87e6d00b"
+  },
+  "web.admin.sessions.revoke.confirmTitle": {
+    "text": "Bu oturum iptal edilsin mi?",
+    "source_hash": "0c6605c1"
+  },
+  "web.admin.sessions.revoke.confirmDescription": {
+    "text": "Bu işlem, {id} oturumunu silerek kullanıcının oturumunu hemen kapatır. Onaylamak için oturum kimliğini yazın.",
+    "source_hash": "9e08b1b8"
+  },
+  "web.admin.sessions.revoke.success": {
+    "text": "Oturum iptal edildi",
+    "source_hash": "0af5e14d"
+  },
+  "web.admin.sessions.scan.summary": {
+    "text": "Gösteriliyor: {shown} kimliği doğrulanmış · {anonymous} anonim gizlendi · {scanned} tarandı",
+    "source_hash": "34cb67a4"
+  },
+  "web.admin.sessions.scan.capped": {
+    "text": "Tarama ilk {scanned} anahtarla sınırlandırıldı — bu pencerenin ötesindeki kimliği doğrulanmış oturumlar listelenmez. Bir oturuma ulaşmak için onu kimliğiyle inceleyin.",
+    "source_hash": "fa418b4e"
+  },
+  "web.admin.sessions.search.placeholder": {
+    "text": "E-posta veya harici kimlik ile ara",
+    "source_hash": "f2dc5c06"
+  },
+  "web.admin.sessions.sections.session": {
+    "text": "Oturum",
+    "source_hash": "6959b415"
+  },
+  "web.admin.sessions.sections.raw": {
+    "text": "Ham oturum verileri",
+    "source_hash": "c9f11eb4"
+  },
+  "web.admin.sessions.status.authenticated": {
+    "text": "Kimliği doğrulandı",
+    "source_hash": "6ab694cf"
+  },
+  "web.admin.sessions.status.anonymous": {
+    "text": "Anonim",
+    "source_hash": "e7a8aa2d"
+  }
+}

--- a/locales/content/tr/admin-system.json
+++ b/locales/content/tr/admin-system.json
@@ -1,0 +1,158 @@
+{
+  "web.admin.system.title": {
+    "text": "Sistem",
+    "source_hash": "6725e7bb"
+  },
+  "web.admin.system.description": {
+    "text": "Veritabanı, kuyruk ve altyapı durumu.",
+    "source_hash": "0115f495"
+  },
+  "web.admin.system.retry": {
+    "text": "Yeniden Dene",
+    "source_hash": "942087cc"
+  },
+  "web.admin.system.database.title": {
+    "text": "Ana Veritabanı ({engine})",
+    "source_hash": "1391230b"
+  },
+  "web.admin.system.database.loadError": {
+    "text": "Veritabanı ölçümleri yüklenemedi.",
+    "source_hash": "905055c6"
+  },
+  "web.admin.system.database.server": {
+    "text": "Sunucu",
+    "source_hash": "aef7de28"
+  },
+  "web.admin.system.database.memory": {
+    "text": "Bellek",
+    "source_hash": "c3963aed"
+  },
+  "web.admin.system.database.databases": {
+    "text": "Veritabanları",
+    "source_hash": "61d2afe2"
+  },
+  "web.admin.system.database.dbSummary": {
+    "text": "{keys} anahtar, {expires} tanesi TTL ile",
+    "source_hash": "26b9e17c"
+  },
+  "web.admin.system.database.fields.version": {
+    "text": "Sürüm",
+    "source_hash": "dd167905"
+  },
+  "web.admin.system.database.fields.mode": {
+    "text": "Mod",
+    "source_hash": "5e23ec6a"
+  },
+  "web.admin.system.database.fields.uptimeDays": {
+    "text": "Çalışma süresi (gün)",
+    "source_hash": "7ab314f8"
+  },
+  "web.admin.system.database.fields.connectedClients": {
+    "text": "Bağlı İstemciler",
+    "source_hash": "434adc3a"
+  },
+  "web.admin.system.database.fields.opsPerSec": {
+    "text": "İşlem/sn",
+    "source_hash": "6634251d"
+  },
+  "web.admin.system.database.fields.totalCommands": {
+    "text": "Toplam Komut",
+    "source_hash": "c5ce5aaf"
+  },
+  "web.admin.system.database.fields.usedMemory": {
+    "text": "Kullanılan Bellek",
+    "source_hash": "bac68a65"
+  },
+  "web.admin.system.database.fields.rssMemory": {
+    "text": "RSS Bellek",
+    "source_hash": "7fe77d15"
+  },
+  "web.admin.system.database.fields.peakMemory": {
+    "text": "Tepe Bellek",
+    "source_hash": "9d44afa6"
+  },
+  "web.admin.system.database.fields.fragmentation": {
+    "text": "Parçalanma Oranı",
+    "source_hash": "721494dd"
+  },
+  "web.admin.system.database.stats.customers": {
+    "text": "Müşteriler",
+    "source_hash": "aabe76f1"
+  },
+  "web.admin.system.database.stats.secrets": {
+    "text": "Gizli Mesajlar",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.system.database.stats.receipts": {
+    "text": "Makbuzlar",
+    "source_hash": "60a627df"
+  },
+  "web.admin.system.database.stats.totalKeys": {
+    "text": "Toplam Anahtar",
+    "source_hash": "4e0d27f5"
+  },
+  "web.admin.system.queue.title": {
+    "text": "Kuyruk",
+    "source_hash": "3b2fe03e"
+  },
+  "web.admin.system.queue.loadError": {
+    "text": "Kuyruk ölçümleri yüklenemedi.",
+    "source_hash": "715bdc88"
+  },
+  "web.admin.system.queue.empty": {
+    "text": "Kuyruk bulunamadı",
+    "source_hash": "3cd4eb88"
+  },
+  "web.admin.system.queue.connected": {
+    "text": "Bağlı",
+    "source_hash": "22965568"
+  },
+  "web.admin.system.queue.disconnected": {
+    "text": "Bağlantı kesildi",
+    "source_hash": "04dfac36"
+  },
+  "web.admin.system.queue.activeWorkers": {
+    "text": "{count} aktif işleyici",
+    "source_hash": "49e6369c"
+  },
+  "web.admin.system.queue.columns.name": {
+    "text": "Kuyruk",
+    "source_hash": "3b2fe03e"
+  },
+  "web.admin.system.queue.columns.pending": {
+    "text": "Beklemede",
+    "source_hash": "331551b0"
+  },
+  "web.admin.system.queue.columns.consumers": {
+    "text": "Tüketiciler",
+    "source_hash": "212b350d"
+  },
+  "web.admin.system.queue.health.healthy": {
+    "text": "Sağlıklı",
+    "source_hash": "7f1e323b"
+  },
+  "web.admin.system.queue.health.degraded": {
+    "text": "Bozulmuş",
+    "source_hash": "a8494c12"
+  },
+  "web.admin.system.queue.health.unhealthy": {
+    "text": "Sağlıksız",
+    "source_hash": "317b1fbc"
+  },
+  "web.admin.system.queue.health.unknown": {
+    "text": "Bilinmiyor",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.system.redis.title": {
+    "text": "Redis INFO",
+    "source_hash": "e762bd3c"
+  },
+  "web.admin.system.redis.loadError": {
+    "text": "Redis ölçümleri yüklenemedi.",
+    "source_hash": "ca5945d6"
+  },
+  "web.admin.system.redis.captured": {
+    "text": "{at} tarihinde yakalandı",
+    "source_hash": "57b40c0f"
+  }
+}

--- a/locales/content/tr/admin-usage.json
+++ b/locales/content/tr/admin-usage.json
@@ -1,0 +1,78 @@
+{
+  "web.admin.usage.title": {
+    "text": "Kullanım",
+    "source_hash": "8d59829c"
+  },
+  "web.admin.usage.description": {
+    "text": "Bir tarih aralığı için kullanım ölçümlerini dışa aktarın.",
+    "source_hash": "97bd3325"
+  },
+  "web.admin.usage.startDate": {
+    "text": "Başlangıç Tarihi",
+    "source_hash": "4c52faad"
+  },
+  "web.admin.usage.endDate": {
+    "text": "Bitiş Tarihi",
+    "source_hash": "e970951c"
+  },
+  "web.admin.usage.fetch": {
+    "text": "Verileri Getir",
+    "source_hash": "429532fe"
+  },
+  "web.admin.usage.loadError": {
+    "text": "Kullanım verileri yüklenemedi.",
+    "source_hash": "ffb557d7"
+  },
+  "web.admin.usage.retry": {
+    "text": "Yeniden Dene",
+    "source_hash": "942087cc"
+  },
+  "web.admin.usage.empty": {
+    "text": "Bu aralık için veri yok",
+    "source_hash": "5fed1795"
+  },
+  "web.admin.usage.byState": {
+    "text": "Duruma Göre Gizli Mesajlar",
+    "source_hash": "916bbcb6"
+  },
+  "web.admin.usage.secretsByDay": {
+    "text": "Güne Göre Gizli Mesajlar",
+    "source_hash": "24a01e8e"
+  },
+  "web.admin.usage.usersByDay": {
+    "text": "Güne Göre Yeni Kullanıcılar",
+    "source_hash": "8c1f089f"
+  },
+  "web.admin.usage.exportJson": {
+    "text": "JSON İndir",
+    "source_hash": "49e0e6d5"
+  },
+  "web.admin.usage.exportCsv": {
+    "text": "CSV İndir",
+    "source_hash": "a4023b89"
+  },
+  "web.admin.usage.columns.date": {
+    "text": "Tarih",
+    "source_hash": "99c40ab4"
+  },
+  "web.admin.usage.columns.count": {
+    "text": "Sayı",
+    "source_hash": "37bac495"
+  },
+  "web.admin.usage.stats.totalSecrets": {
+    "text": "Toplam Gizli Mesaj",
+    "source_hash": "e17a5459"
+  },
+  "web.admin.usage.stats.newUsers": {
+    "text": "Yeni Kullanıcılar",
+    "source_hash": "d3ee48b0"
+  },
+  "web.admin.usage.stats.avgSecrets": {
+    "text": "Ort. Gizli Mesaj/Gün",
+    "source_hash": "948b0701"
+  },
+  "web.admin.usage.stats.avgUsers": {
+    "text": "Ort. Kullanıcı/Gün",
+    "source_hash": "491f626d"
+  }
+}

--- a/locales/content/tr/api-domains-errors.json
+++ b/locales/content/tr/api-domains-errors.json
@@ -34,5 +34,17 @@
   "api.domains.errors.recipients_duplicate": {
     "text": "Yinelenen alıcı e-postalarına izin verilmez",
     "source_hash": "6de22182"
+  },
+  "api.domains.errors.homepage_secrets_mode_invalid": {
+    "text": "Geçersiz secrets_mode: %{secrets_mode}",
+    "source_hash": "cf093a04"
+  },
+  "api.domains.errors.homepage_incoming_entitlement_required": {
+    "text": "Gelen gizli mesaj modu, incoming_secrets yetkisini gerektirir. Lütfen planınızı yükseltin.",
+    "source_hash": "d68b13d8"
+  },
+  "api.domains.errors.homepage_incoming_not_ready": {
+    "text": "Gelen gizli mesajlar, ana sayfa olarak kullanılabilmesi için en az bir alıcıyla etkinleştirilmelidir.",
+    "source_hash": "556da6e2"
   }
 }

--- a/locales/content/tr/api-invite-errors.json
+++ b/locales/content/tr/api-invite-errors.json
@@ -12,8 +12,8 @@
     "source_hash": "a5df7d22"
   },
   "api.invite.errors.invitation_already_processed": {
-    "text": "Davet zaten %{status} durumunda",
-    "source_hash": "130c87e0"
+    "text": "Bu davet zaten işlendi",
+    "source_hash": "4cfedf4f"
   },
   "api.invite.errors.invitation_expired": {
     "text": "Davetin süresi doldu",
@@ -26,5 +26,13 @@
   "api.invite.errors.already_member": {
     "text": "Zaten bu kuruluşun üyesisiniz",
     "source_hash": "f56ad547"
+  },
+  "api.invite.errors.invitation_already_accepted": {
+    "text": "Bu davet zaten kabul edildi",
+    "source_hash": "8f9daf0f"
+  },
+  "api.invite.errors.invitation_already_declined": {
+    "text": "Bu davet zaten reddedildi",
+    "source_hash": "96e0d626"
   }
 }

--- a/locales/content/tr/api-secrets-errors.json
+++ b/locales/content/tr/api-secrets-errors.json
@@ -10,5 +10,9 @@
   "api.secrets.errors.domain_permission_anonymous_cross_domain": {
     "text": "Şu alan adını kullanma izniniz yok: %{domain}",
     "source_hash": "b41920ba"
+  },
+  "api.secrets.errors.secret_undecryptable": {
+    "text": "Bu gizli mesajın şifresi şu anda çözülemez. Bağlantı hâlâ bozulmamış — açığa çıkarılabilmesi için site operatörünün şifreleme anahtarını geri yüklemesi gerekir.",
+    "source_hash": "56e283ee"
   }
 }

--- a/locales/content/tr/email.json
+++ b/locales/content/tr/email.json
@@ -62,7 +62,7 @@
   "email.welcome.signature": {
     "text": "Destek Ekibi",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.welcome.postscript": {
     "text": "Not: Bu e-posta %{email_address} adresine gönderildi. Bir hesap oluşturmadıysanız, bu mesajı güvenle görmezden gelebilirsiniz.",
@@ -102,7 +102,7 @@
   "email.password_request.signature": {
     "text": "Destek Ekibi",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.password_request.postscript": {
     "text": "Not: Bu e-posta %{email_address} adresine gönderildi.",
@@ -147,7 +147,7 @@
   "email.magic_link.signature": {
     "text": "Destek Ekibi",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.magic_link.postscript": {
     "text": "Not: Bu e-posta %{email_address} adresine gönderildi.",
@@ -232,7 +232,7 @@
   "email.secret_revealed.signature": {
     "text": "Destek Ekibi",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.secret_revealed.manage_preferences": {
     "text": "Bildirim tercihlerini yönet",
@@ -357,7 +357,7 @@
   "email.organization_invitation.signature": {
     "text": "Destek Ekibi",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.organization_invitation.postscript": {
     "text": "Not: Bu e-posta %{invited_email} adresine gönderildi. Bu daveti beklemiyorsanız, bu mesajı güvenle görmezden gelebilirsiniz.",
@@ -397,17 +397,17 @@
   "email.password_changed.signature": {
     "text": "Destek Ekibi",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_changed.subject": {
     "text": "E-posta adresiniz değiştirildi (%{display_domain})",
     "renderer": "erb",
-    "source_hash": "d68d2f4c"
+    "source_hash": "4386fc57"
   },
   "email.email_changed.title": {
     "text": "E-posta Adresiniz Değiştirildi",
     "renderer": "erb",
-    "source_hash": "62b07299"
+    "source_hash": "db70f965"
   },
   "email.email_changed.security_notice": {
     "text": "Bu değişikliği siz yapmadıysanız, hesabınız tehlikede olabileceğinden lütfen derhal destekle iletişime geçin.",
@@ -417,7 +417,7 @@
   "email.email_changed.change_notice": {
     "text": "%{product_name} hesabınızdaki e-posta adresi değiştirildi.",
     "renderer": "erb",
-    "source_hash": "bb467ebc"
+    "source_hash": "7fc0e27c"
   },
   "email.email_changed.new_email_label": {
     "text": "Yeni e-posta:",
@@ -447,7 +447,7 @@
   "email.email_changed.signature": {
     "text": "Destek Ekibi",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_changed.postscript": {
     "text": "Not: Bu e-posta, e-posta adresi değişikliği hakkında sizi bilgilendirmek için %{email_address} adresine gönderilmiştir.",
@@ -497,7 +497,7 @@
   "email.email_change_requested.signature": {
     "text": "Destek Ekibi",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_change_requested.postscript": {
     "text": "Not: Bu e-posta, hesabınız için bir e-posta değişikliği talep edildiğinden %{email_address} adresine gönderilmiştir.",
@@ -552,7 +552,7 @@
   "email.email_change_confirmation.signature": {
     "text": "Destek Ekibi",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.email_change_confirmation.postscript": {
     "text": "Not: Bu e-posta, e-posta adresi değişikliğini onaylamak için %{email_address} adresine gönderilmiştir.",
@@ -582,7 +582,7 @@
   "email.mfa_enabled.signature": {
     "text": "Destek Ekibi",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.mfa_disabled.subject": {
     "text": "İki faktörlü kimlik doğrulama devre dışı bırakıldı (%{display_domain})",
@@ -607,7 +607,7 @@
   "email.mfa_disabled.signature": {
     "text": "Destek Ekibi",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.new_login_alert.subject": {
     "text": "Hesabınıza yeni giriş yapıldı (%{display_domain})",
@@ -652,7 +652,7 @@
   "email.new_login_alert.signature": {
     "text": "Destek Ekibi",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.member_removed.subject": {
     "text": "%{organization_name} kuruluşundan çıkarıldınız",
@@ -672,7 +672,7 @@
   "email.member_removed.signature": {
     "text": "Destek Ekibi",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.role_changed.subject": {
     "text": "%{organization_name} kuruluşunda rolünüz değiştirildi",
@@ -692,7 +692,7 @@
   "email.role_changed.signature": {
     "text": "Destek Ekibi",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.organization_deleted.subject": {
     "text": "\"%{organization_name}\" kuruluşu silindi",
@@ -712,7 +712,7 @@
   "email.organization_deleted.signature": {
     "text": "Destek Ekibi",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.trial_expiring.subject": {
     "text": "%{product_name} deneme süreniz %{days_remaining} gün içinde sona eriyor",
@@ -737,7 +737,7 @@
   "email.trial_expiring.signature": {
     "text": "Destek Ekibi",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.subscription_changed.subject": {
     "text": "%{product_name} aboneliğiniz değiştirildi",
@@ -762,7 +762,7 @@
   "email.subscription_changed.signature": {
     "text": "Destek Ekibi",
     "renderer": "erb",
-    "source_hash": "f58154f7"
+    "source_hash": "dc75bf9f"
   },
   "email.common.greeting": {
     "text": "Merhaba,",

--- a/locales/content/tr/feature-regions.json
+++ b/locales/content/tr/feature-regions.json
@@ -152,8 +152,8 @@
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "Fatura iletişim e-postanız {product_name} hesap e-postanızdan farklıysa, abonelik avantajlarınızı korumak için yeni bölge hesabında fatura iletişim e-postasını kullanın.",
-    "source_hash": "dac1cc28"
+    "text": "Faturalandırma iletişim e-postanız {product_name} hesap e-postanızdan farklıysa, abonelik avantajlarınızı korumak için yeni bölge hesabı için faturalandırma iletişim e-postasını kullanın.",
+    "source_hash": "d49662b0"
   },
   "web.regions.changing_regions_subscription_note": {
     "text": "Abonelik avantajlarınız, fatura e-posta adresinizle oluşturulan tüm hesaplara otomatik olarak uygulanır.",

--- a/locales/content/tr/feature-translations.json
+++ b/locales/content/tr/feature-translations.json
@@ -64,8 +64,8 @@
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "Aşağıdaki kişiler {product_name} ürününün erişimini genişletmek için zamanlarını bağışladılar:",
-    "source_hash": "85a766af"
+    "text": "Aşağıdaki kişiler, {product_name} hizmetinin erişimini genişletmeye yardımcı olmak için zamanlarını gönüllü olarak ayırdı:",
+    "source_hash": "6cc876ae"
   },
   "web.translations.translations": {
     "text": "Çeviriler",
@@ -84,8 +84,8 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "2012 yılından bu yana {product_name}, dünya genelinde hassas bilgileri güvenli bir şekilde paylaşma imkanı sunmaktadır. İngilizcenin ana dil olmadığı bölgelerdeki kullanıcılarımız için doğru çeviriler, güvenli iletişimin herkes için erişilebilir olmasında büyük önem taşımaktadır.",
-    "source_hash": "87a6e9af"
+    "text": "2012'den bu yana {product_name}, dünya çapında hassas bilgileri paylaşmanın güvenli bir yolunu sundu. Ana dili İngilizce olmayan bölgelerdeki kullanıcılarla birlikte, güvenli iletişimi herkes için erişilebilir kılmada doğru çeviriler çok önemlidir.",
+    "source_hash": "ded965d5"
   },
   "web.translations.help_secure_communication_go_global": {
     "text": "Güvenli İletişimi Küresel Hale Getirmeye Yardımcı Olun",

--- a/locales/content/tr/secret-homepage.json
+++ b/locales/content/tr/secret-homepage.json
@@ -57,7 +57,7 @@
   },
   "web.homepage.visit_onetime_secret_home": {
     "text": "{product_name} ana sayfasını ziyaret edin",
-    "source_hash": "625556d2"
+    "source_hash": "87802af5"
   },
   "web.homepage.password_generation_title": {
     "text": "Parola Oluşturucu",
@@ -108,16 +108,16 @@
     "source_hash": "107093e4"
   },
   "web.homepage.about_onetime_secret_0": {
-    "text": "{product_name} hakkında",
-    "source_hash": "971c50da"
+    "text": "{product_name} Hakkında",
+    "source_hash": "b3046356"
   },
   "web.homepage.log_in_to_onetime_secret": {
-    "text": "{product_name} hesabına giriş yapın",
-    "source_hash": "bd6be8d6"
+    "text": "{product_name} hesabınıza giriş yapın",
+    "source_hash": "b2e364a4"
   },
   "web.homepage.about_onetime_secret": {
-    "text": "{product_name} hakkında",
-    "source_hash": "971c50da"
+    "text": "{product_name} Hakkında",
+    "source_hash": "b3046356"
   },
   "web.homepage.signup_individual_and_business_plans": {
     "text": "Kaydolun - Bireysel ve İş planları",
@@ -137,19 +137,19 @@
   },
   "web.homepage.onetime_secret": {
     "text": "{product_name}",
-    "source_hash": "1cd0194a"
+    "source_hash": "7bec5899"
   },
   "web.homepage.onetime_secret_literal": {
     "text": "{product_name}",
-    "source_hash": "1cd0194a"
+    "source_hash": "7bec5899"
   },
   "web.homepage.one_time_secret_literal": {
     "text": "{product_name}",
-    "source_hash": "7872e050"
+    "source_hash": "7bec5899"
   },
   "web.homepage.onetime_secret_homepage": {
-    "text": "{product_name} Ana Sayfası",
-    "source_hash": "44bb0581"
+    "text": "{product_name} ana sayfası",
+    "source_hash": "0792b61e"
   },
   "web.homepage.send_sensitive_information_that_can_only_be_viewed_once": {
     "text": "Yalnızca bir kez görüntülenebilen hassas bilgileri gönderin",
@@ -168,12 +168,12 @@
     "source_hash": "e1073c60"
   },
   "web.homepage.welcome_to_onetime_secret": {
-    "text": "{product_name} uygulamasına hoş geldiniz.",
-    "source_hash": "0990d163"
+    "text": "{product_name} hizmetine hoş geldiniz.",
+    "source_hash": "f4f49058"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "{product_name}, profesyonel imajımızı korurken hassas bilgileri güvenli bir şekilde paylaşmamıza yardımcı olur.",
-    "source_hash": "986a0856"
+    "text": "{product_name}, profesyonel görünümümüzü korurken hassas bilgileri güvenli bir şekilde paylaşmamıza yardımcı olur.",
+    "source_hash": "7e9192bd"
   },
   "web.homepage.information_shared_through_this_service_can_only": {
     "text": "Bu hizmet aracılığıyla paylaşılan bilgilere yalnızca bir kez erişilebilir. Görüntülendikten sonra, içerik gizliliği sağlamak için kalıcı olarak silinir.",
@@ -182,5 +182,13 @@
   "web.homepage.welcome_to_the_global_broadcast": {
     "text": "Küresel Yayına Hoş Geldiniz!",
     "source_hash": "210e1894"
+  },
+  "web.homepage.send_a_secret": {
+    "text": "Bir gizli mesaj gönder",
+    "source_hash": "31fd9e03"
+  },
+  "web.homepage.deliver_sensitive_information_directly_and_securely": {
+    "text": "Hassas bilgileri doğrudan ekibimize iletin. Yalnızca bir kez görüntülenebilir.",
+    "source_hash": "9976cf01"
   }
 }

--- a/locales/content/tr/secret-manage.json
+++ b/locales/content/tr/secret-manage.json
@@ -56,8 +56,8 @@
     "source_hash": "2e5a27e1"
   },
   "web.secrets.sample_secret_content_this_could_be_sensitive_data": {
-    "text": "Örnek mesaj içeriği Bu hassas veri olabilir Veya çok satırlı bir mesaj",
-    "source_hash": "b3be3902"
+    "text": "Örnek gizli mesaj içeriği. Bu, hassas veri olabilir\n\nVeya çok satırlı bir mesaj",
+    "source_hash": "5e1bffcb"
   },
   "web.secrets.sample_secret_content": {
     "text": "Örnek gizli içerik",
@@ -128,8 +128,8 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "{product_name}, tek görüntülemeden sonra kendini imha eden hassas bilgileri güvenli bir şekilde paylaşmanın yoludur.",
-    "source_hash": "8a163297"
+    "text": "{product_name}, tek görüntülemeden sonra kendini imha eden, hassas bilgileri paylaşmanın güvenli bir yoludur.",
+    "source_hash": "bd0c6182"
   },
   "web.secrets.what_is_this": {
     "text": "Bu nedir?",

--- a/locales/content/tr/session-auth-extended.json
+++ b/locales/content/tr/session-auth-extended.json
@@ -155,8 +155,8 @@
     "source_hash": "d726c0da"
   },
   "web.auth.magicLink.sessionExpired": {
-    "text": "Oturumunuzun süresi doldu. Lütfen sayfayı yenileyip tekrar deneyin.",
-    "source_hash": "a7c3e901"
+    "text": "Oturumunuzun süresi doldu. Lütfen sayfayı yenileyin ve tekrar deneyin.",
+    "source_hash": "be9ed96d"
   },
   "web.auth.magicLink.loginFailed": {
     "text": "Giriş başarısız. Lütfen tekrar deneyin.",

--- a/locales/content/tr/session-auth.json
+++ b/locales/content/tr/session-auth.json
@@ -373,8 +373,8 @@
     "source_hash": "afd25fdf"
   },
   "web.help.use_magic_link_instead": {
-    "text": "Parola olmadan giriş yapmak için Sihirli Bağlantı seçeneğini kullanın. Giriş yaptıktan sonra Hesap Ayarlarında parolanızı değiştirebilirsiniz.",
-    "source_hash": "2a058600"
+    "text": "Yeni bir parola oluşturmak için bir parola sıfırlama bağlantısı talep edebilirsiniz.",
+    "source_hash": "3c3eabad"
   },
   "web.help.account_locked": {
     "text": "Hesap geçici olarak kilitlendi mi?",
@@ -431,5 +431,57 @@
   "web.login.errors.domain_not_allowed": {
     "text": "E-posta alan adınız SSO ile kayıt için yetkili değil. Lütfen yöneticinizle iletişime geçin.",
     "source_hash": "87603782"
+  },
+  "web.auth.check_email.title": {
+    "text": "E-postanızı kontrol edin",
+    "source_hash": "77322879"
+  },
+  "web.auth.check_email.sent_to_generic": {
+    "text": "E-posta adresinize bir doğrulama bağlantısı gönderdik.",
+    "source_hash": "4e5510af"
+  },
+  "web.auth.check_email.help": {
+    "text": "Bu adrese bir doğrulama bağlantısı gönderdik — hesabınızı etkinleştirmek için e-postayı açın ve bağlantıya tıklayın.",
+    "source_hash": "8babedc4"
+  },
+  "web.auth.check_email.spam_hint": {
+    "text": "Bulamıyor musunuz? Spam klasörünüzü kontrol edin.",
+    "source_hash": "d166d9a4"
+  },
+  "web.auth.check_email.wrong_email": {
+    "text": "Yanlış adres mi girdiniz?",
+    "source_hash": "0aa863e5"
+  },
+  "web.auth.check_email.start_over": {
+    "text": "Baştan başla",
+    "source_hash": "5eed7e9f"
+  },
+  "web.auth.field-errors.password": {
+    "text": "Parola",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.auth.verify.resend_help_text": {
+    "text": "Doğrulama e-postasını almadınız mı? Yeniden göndermek için e-postanızı girin.",
+    "source_hash": "e0df48bb"
+  },
+  "web.auth.verify.resend_button": {
+    "text": "Doğrulama E-postasını Yeniden Gönder",
+    "source_hash": "5173cc04"
+  },
+  "web.auth.verify.resend_sent": {
+    "text": "Bir hesabın doğrulanması gerekiyorsa, yeni bir e-posta gönderildi. Lütfen gelen kutunuzu ve spam klasörünüzü kontrol edin.",
+    "source_hash": "6f838ffb"
+  },
+  "web.auth.verify.resend_error": {
+    "text": "Doğrulama e-postası gönderilemedi. Lütfen bağlantınızı kontrol edin ve tekrar deneyin.",
+    "source_hash": "15149f46"
+  },
+  "web.auth.verify.resend_short": {
+    "text": "E-postayı yeniden gönder",
+    "source_hash": "4f44603e"
+  },
+  "web.login.verified_notice": {
+    "text": "E-postanız doğrulandı — artık oturum açabilirsiniz.",
+    "source_hash": "c8d4b5a8"
   }
 }

--- a/locales/content/tr/workspace-account.json
+++ b/locales/content/tr/workspace-account.json
@@ -136,8 +136,8 @@
     "source_hash": "05986d95"
   },
   "web.account.keep_this_token_secure_it_provides_full_access_t": {
-    "text": "🔐 Bu belirteci güvende tutun! Hesabınıza tam erişim sağlar.",
-    "source_hash": "8839aa4d"
+    "text": "Bu belirteci güvende tutun. API aracılığıyla gizli mesaj oluşturmak ve yönetmek için kullanılabilir.",
+    "source_hash": "a63cc8ec"
   },
   "web.account.confirm_with_your_password": {
     "text": "Parolanızla onaylayın",
@@ -328,8 +328,8 @@
     "source_hash": "f7cfed6e"
   },
   "web.settings.profile.email_change_success": {
-    "text": "E-posta başarıyla güncellendi. Yeni e-posta adresinizi doğrulamak için lütfen gelen kutunuzu kontrol edin.",
-    "source_hash": "58de2536"
+    "text": "Doğrulama e-postası gönderildi. Değişikliği tamamlamak için lütfen yeni gelen kutunuzu kontrol edin ve onay bağlantısına tıklayın.",
+    "source_hash": "45f0a4b5"
   },
   "web.settings.profile.email_change_error": {
     "text": "E-posta güncellenemedi. Lütfen tekrar deneyin.",
@@ -476,8 +476,8 @@
     "source_hash": "1cc77e60"
   },
   "web.settings.api.documentation_description": {
-    "text": "{product_name} ürününü uygulamalarınıza nasıl entegre edeceğinizi öğrenin",
-    "source_hash": "6e8f910f"
+    "text": "{product_name} hizmetini uygulamalarınıza nasıl entegre edeceğinizi öğrenin",
+    "source_hash": "9bba1ae8"
   },
   "web.settings.api.rest_api_reference": {
     "text": "REST API Referansı",

--- a/locales/content/tr/workspace-billing.json
+++ b/locales/content/tr/workspace-billing.json
@@ -140,12 +140,12 @@
     "source_hash": "1f981aaf"
   },
   "web.billing.overview.no_organizations_title": {
-    "text": "Kuruluş Yok",
-    "source_hash": "12420110"
+    "text": "Çalışma Alanı Yok",
+    "source_hash": "c7f70723"
   },
   "web.billing.overview.no_organizations_description": {
-    "text": "Faturalandırmanızı ve aboneliğinizi yönetmek için bir kuruluş oluşturun",
-    "source_hash": "41e922d2"
+    "text": "Faturalandırmanızı ve aboneliğinizi yönetmek için bir çalışma alanı oluşturun",
+    "source_hash": "e0fd27a5"
   },
   "web.billing.overview.load_error": {
     "text": "Fatura bilgileri yüklenemedi",
@@ -204,8 +204,8 @@
     "source_hash": "883dbca9"
   },
   "web.billing.overview.entitlements.manage_org": {
-    "text": "Kuruluşları Yönet",
-    "source_hash": "be0fe4c3"
+    "text": "Kuruluşu Yönet",
+    "source_hash": "f03a4985"
   },
   "web.billing.overview.entitlements.manage_teams": {
     "text": "Takımları Yönet",
@@ -220,8 +220,8 @@
     "source_hash": "5428d7fe"
   },
   "web.billing.overview.entitlements.sso": {
-    "text": "Tek Oturum Açma",
-    "source_hash": "cf7cd744"
+    "text": "Tek Oturum Açma (SSO)",
+    "source_hash": "5db5c812"
   },
   "web.billing.overview.entitlements.priority_support": {
     "text": "Öncelikli Destek",
@@ -281,7 +281,7 @@
   },
   "web.billing.features.sso": {
     "text": "Tek Oturum Açma (SSO)",
-    "source_hash": "5db5c812"
+    "source_hash": "5ba3ac9f"
   },
   "web.billing.features.priority_support": {
     "text": "Öncelikli Destek",
@@ -577,7 +577,7 @@
   },
   "web.billing.invoices.draft": {
     "text": "Taslak",
-    "source_hash": "d2e16e61"
+    "source_hash": "ebf12ef4"
   },
   "web.billing.invoices.open": {
     "text": "Açık",

--- a/locales/content/tr/workspace-branding.json
+++ b/locales/content/tr/workspace-branding.json
@@ -28,8 +28,8 @@
     "source_hash": "199c165f"
   },
   "web.branding.preview_and_customize": {
-    "text": "Önizle ve Özelleştir",
-    "source_hash": "215d3659"
+    "text": "Özelleştir ve Önizle",
+    "source_hash": "fc68a28c"
   },
   "web.branding.switch_to_safari_browser_view": {
     "text": "Safari tarayıcı görünümüne geç",
@@ -88,8 +88,8 @@
     "source_hash": "43e9a2d7"
   },
   "web.branding.click_to_upload_a_logo_with_recommendation": {
-    "text": "Logo yüklemek için tıklayın. Önerilen boyut: 128x128 piksel. Maksimum dosya boyutu: 1MB. Desteklenen formatlar: PNG, JPG, SVG",
-    "source_hash": "a35452bf"
+    "text": "Logonuzu yönetmek için tıklayın. Önerilen boyut: 128x128 piksel. Maksimum dosya boyutu: 1MB. Desteklenen biçimler: PNG, JPG, SVG",
+    "source_hash": "7bb92395"
   },
   "web.branding.upload_logo": {
     "text": "Logo yükle",
@@ -186,5 +186,225 @@
   "web.branding.keyhole_logo_icon": {
     "text": "Güvenli ve gizli paylaşımı temsil eden anahtar deliği simgesi",
     "source_hash": "c868ac60"
+  },
+  "web.branding.secondary_color": {
+    "text": "İkincil Renk",
+    "source_hash": "1f4728f6"
+  },
+  "web.branding.background_color": {
+    "text": "Arka Plan Rengi",
+    "source_hash": "b48bc969"
+  },
+  "web.branding.text_color": {
+    "text": "Metin Rengi",
+    "source_hash": "2ea23234"
+  },
+  "web.branding.border_radius": {
+    "text": "Kenar Yuvarlaklığı",
+    "source_hash": "e758d7db"
+  },
+  "web.branding.heading_font": {
+    "text": "Başlık Yazı Tipi",
+    "source_hash": "6b5d30dc"
+  },
+  "web.branding.theme_presets": {
+    "text": "Tema Ön Ayarları",
+    "source_hash": "931eeb74"
+  },
+  "web.branding.logo": {
+    "text": "Logo",
+    "source_hash": "d707dc2f"
+  },
+  "web.branding.replace_logo": {
+    "text": "Değiştir",
+    "source_hash": "95e15439"
+  },
+  "web.branding.logo_field_hint": {
+    "text": "Değişiklikleriniz yayına geçmeden önce önizleyin.",
+    "source_hash": "e9e222fc"
+  },
+  "web.branding.logo_modal_title": {
+    "text": "Alan adı logosu",
+    "source_hash": "5260dda5"
+  },
+  "web.branding.logo_modal_hint": {
+    "text": "PNG, JPG veya SVG. Önerilen 128x128 piksel, en fazla 1MB.",
+    "source_hash": "75d00802"
+  },
+  "web.branding.logo_modal_save": {
+    "text": "Logoyu kaydet",
+    "source_hash": "8b028a6f"
+  },
+  "web.branding.remove_logo": {
+    "text": "Logoyu kaldır",
+    "source_hash": "f1c1afa4"
+  },
+  "web.branding.image_upload_choose": {
+    "text": "Bir görsel seçin",
+    "source_hash": "ceed9fd5"
+  },
+  "web.branding.image_upload_drag_hint": {
+    "text": "veya sürükleyip bırakın",
+    "source_hash": "6613b73c"
+  },
+  "web.branding.image_invalid_type": {
+    "text": "Bu dosya türü desteklenmiyor. Lütfen bir görsel seçin.",
+    "source_hash": "50e18866"
+  },
+  "web.branding.image_too_large": {
+    "text": "Görsel çok büyük. Maksimum boyut {max}.",
+    "source_hash": "b50b55e2"
+  },
+  "web.branding.image_will_be_removed": {
+    "text": "Bu logo, kaydettiğinizde kaldırılacaktır.",
+    "source_hash": "d94fa99a"
+  },
+  "web.branding.image_upload_failed": {
+    "text": "Bir şeyler ters gitti. Lütfen tekrar deneyin.",
+    "source_hash": "3ccd9d65"
+  },
+  "web.branding.undo": {
+    "text": "Geri al",
+    "source_hash": "a8283ade"
+  },
+  "web.branding.low_contrast_text_bg_warning": {
+    "text": "Düşük metin/arka plan kontrastı",
+    "source_hash": "1c676370"
+  },
+  "web.branding.path_simple": {
+    "text": "Basit",
+    "source_hash": "3fee95da"
+  },
+  "web.branding.path_match": {
+    "text": "Siteme uydur",
+    "source_hash": "776679cf"
+  },
+  "web.branding.path_advanced": {
+    "text": "Gelişmiş",
+    "source_hash": "9f088dbe"
+  },
+  "web.branding.path_simple_tag": {
+    "text": "Markanızın temelleri.",
+    "source_hash": "7c9c0cca"
+  },
+  "web.branding.path_match_tag": {
+    "text": "Mevcut bir siteden ayarları kopyalayın.",
+    "source_hash": "e4b0d1cd"
+  },
+  "web.branding.path_advanced_tag": {
+    "text": "Kendi Tailwind v4 CSS'inizi yazın.",
+    "source_hash": "2405bb6d"
+  },
+  "web.branding.badge_default": {
+    "text": "Varsayılan",
+    "source_hash": "21b111cb"
+  },
+  "web.branding.badge_coming_soon": {
+    "text": "Yakında",
+    "source_hash": "4f7d6401"
+  },
+  "web.branding.your_brand": {
+    "text": "Markanız",
+    "source_hash": "406265d3"
+  },
+  "web.branding.your_brand_subtitle": {
+    "text": "Birkaç hızlı seçim — gerisini biz hallederiz.",
+    "source_hash": "dbc8ec33"
+  },
+  "web.branding.corners": {
+    "text": "Köşeler",
+    "source_hash": "1d3cc47e"
+  },
+  "web.branding.more_options": {
+    "text": "Daha fazla seçenek",
+    "source_hash": "bc79cdff"
+  },
+  "web.branding.paths_carryover_hint": {
+    "text": "Bu, canlı bir önizlemedir — değişiklikleriniz siz kaydedene kadar ziyaretçilere görünmez.",
+    "source_hash": "cb4b82de"
+  },
+  "web.branding.coming_soon_match_blurb": {
+    "text": "Bize web sitenizi gösterin, renklerini ve yazı tiplerini okuyalım, ardından tek tıkla aradaki farkı kapatalım.",
+    "source_hash": "42c34cc1"
+  },
+  "web.branding.coming_soon_advanced_blurb": {
+    "text": "Tailwind v4 {'@'}theme belirteçlerini doğrudan düzenleyin veya kendi stil sayfanızı yapıştırın.",
+    "source_hash": "5a8473f5"
+  },
+  "web.branding.preview_recipient_page": {
+    "text": "Alıcı sayfası",
+    "source_hash": "de8aa19f"
+  },
+  "web.branding.preview_badge": {
+    "text": "Önizleme",
+    "source_hash": "324b134f"
+  },
+  "web.branding.preview_homepage_enabled": {
+    "text": "Ana sayfa · etkin",
+    "source_hash": "2edd85f1"
+  },
+  "web.branding.preview_homepage_disabled": {
+    "text": "Ana sayfa · devre dışı",
+    "source_hash": "15d87050"
+  },
+  "web.branding.preview_live": {
+    "text": "Canlı önizleme",
+    "source_hash": "f65ddc1f"
+  },
+  "web.branding.tile_share_secret": {
+    "text": "Bir gizli mesaj paylaş",
+    "source_hash": "5384461b"
+  },
+  "web.branding.tile_create_link": {
+    "text": "Gizli mesaj bağlantısı oluştur",
+    "source_hash": "610fd42e"
+  },
+  "web.branding.tile_delivery_only": {
+    "text": "Yalnızca güvenli mesaj teslimi",
+    "source_hash": "dc24dec2"
+  },
+  "web.branding.tile_no_create": {
+    "text": "Ziyaretçiler burada gizli mesaj oluşturamaz.",
+    "source_hash": "17361d81"
+  },
+  "web.branding.recipient_page_content": {
+    "text": "Alıcı sayfası içeriği",
+    "source_hash": "937733bd"
+  },
+  "web.branding.recipient_page_content_hint": {
+    "text": "Bu alan adındaki alıcılara gösterilen dil ve açığa çıkarma talimatları.",
+    "source_hash": "04162b70"
+  },
+  "web.branding.tab_brand": {
+    "text": "Marka",
+    "source_hash": "090ed431"
+  },
+  "web.branding.tab_delivery": {
+    "text": "Teslimat",
+    "source_hash": "52bfe584"
+  },
+  "web.branding.delivery_language": {
+    "text": "Dil",
+    "source_hash": "a4fe6526"
+  },
+  "web.branding.delivery_language_hint": {
+    "text": "Bu alan adındaki alıcı sayfaları ve e-postalar için varsayılan. Alıcılar sayfada dili değiştirebilir.",
+    "source_hash": "bfbc5599"
+  },
+  "web.branding.delivery_reveal_instructions": {
+    "text": "Açığa çıkarma talimatları",
+    "source_hash": "7e1331f7"
+  },
+  "web.branding.delivery_reveal_instructions_hint": {
+    "text": "Alıcı sayfasında gösterilir. Seçilen dildeki yerleşik metni kullanmak için boş bırakın.",
+    "source_hash": "51b9811d"
+  },
+  "web.branding.delivery_before_reveal": {
+    "text": "Açığa çıkarmadan önce",
+    "source_hash": "5ce82b01"
+  },
+  "web.branding.delivery_after_reveal": {
+    "text": "Açığa çıkardıktan sonra",
+    "source_hash": "d5bfe7fd"
   }
 }

--- a/locales/content/tr/workspace-domains.json
+++ b/locales/content/tr/workspace-domains.json
@@ -76,8 +76,8 @@
     "source_hash": "59be7133"
   },
   "web.domains.enabled": {
-    "text": "Etkinleştirildi",
-    "source_hash": "92c1cdfd"
+    "text": "Etkinleştir",
+    "source_hash": "5342e09f"
   },
   "web.domains.disabled": {
     "text": "Devre Dışı",
@@ -1358,5 +1358,189 @@
   "web.domains.sso.upgrade_required": {
     "text": "Yapılandırmak için yükseltin",
     "source_hash": "571cfa98"
+  },
+  "web.domains.add.field_label": {
+    "text": "Özel alan adı",
+    "source_hash": "d7d4c1e4"
+  },
+  "web.domains.add.field_help": {
+    "text": "Ekibinizin kullanacağı tam ana bilgisayar adı, {example} gibi.",
+    "source_hash": "3ba71f78"
+  },
+  "web.domains.add.echo_label": {
+    "text": "Gizli mesaj bağlantılarınız şurada yer alacak:",
+    "source_hash": "ad60b17d"
+  },
+  "web.domains.add.apex_question": {
+    "text": "Bu, tüm alan adınız — gizli mesaj bağlantıları nerede yer almalı?",
+    "source_hash": "efacad1b"
+  },
+  "web.domains.add.apex_help": {
+    "text": "Bir alt alan adı, {domain} adresinin geri kalanını dokunulmadan bırakır.",
+    "source_hash": "0f7e6181"
+  },
+  "web.domains.add.recommended": {
+    "text": "Önerilen",
+    "source_hash": "d70604e8"
+  },
+  "web.domains.add.no_wrong_answer": {
+    "text": "Yanlış seçim yok — ekibinizin tanıyacağı hangisiyse onu seçin.",
+    "source_hash": "a04f0086"
+  },
+  "web.domains.add.subdomains_label": {
+    "text": "Popüler alt alan adları",
+    "source_hash": "d6ee8eac"
+  },
+  "web.domains.add.root_group_label": {
+    "text": "Veya tüm alan adınızı kullanın",
+    "source_hash": "5c23c007"
+  },
+  "web.domains.add.root_domain_label": {
+    "text": "Kök alan adımı kullan",
+    "source_hash": "9fbbe253"
+  },
+  "web.domains.add.root_domain_description": {
+    "text": "Bu, {domain} adresinin tamamını bize yönlendirir — oradaki site artık çözümlenmez — ve bir A / ALIAS kaydı gerektirir.",
+    "source_hash": "fae93847"
+  },
+  "web.domains.add.error_unrecognized_suffix": {
+    "text": "“.{0}” tanınan bir alan adı sonu değil — bir yazım hatası olup olmadığını kontrol edin (örn. {1}).",
+    "source_hash": "4b90033d"
+  },
+  "web.domains.add.error_invalid_hostname": {
+    "text": "Geçerli bir ana bilgisayar adı girin — harfler, rakamlar, tek noktalar ve tireler (örn. {0}).",
+    "source_hash": "c4ceabc1"
+  },
+  "web.domains.add.error_empty": {
+    "text": "Lütfen bir alan adı girin.",
+    "source_hash": "d8e2c1e4"
+  },
+  "web.domains.add.continue_with": {
+    "text": "{0} ile devam et",
+    "source_hash": "73f8ab40"
+  },
+  "web.domains.auth_override.workspace_default_badge": {
+    "text": "Çalışma alanı varsayılanı",
+    "source_hash": "da3706ee"
+  },
+  "web.domains.detail.dns_title": {
+    "text": "DNS Kurulumu",
+    "source_hash": "6c63df31"
+  },
+  "web.domains.detail.dns_description": {
+    "text": "Alan adınızı bir CNAME kaydıyla bu sunucuya yönlendirin",
+    "source_hash": "080f84f0"
+  },
+  "web.domains.dns.title": {
+    "text": "DNS yapılandırması",
+    "source_hash": "da78c35d"
+  },
+  "web.domains.dns.point_domain_intro": {
+    "text": "Şunu yönlendirin:",
+    "source_hash": "2fc0c524"
+  },
+  "web.domains.dns.point_domain_outro": {
+    "text": "sağlayıcınızda aşağıdaki DNS kaydını ekleyerek bu sunucuya.",
+    "source_hash": "8d260c05"
+  },
+  "web.domains.dns.cname_heading": {
+    "text": "Bir CNAME kaydı oluşturun",
+    "source_hash": "11aeef5a"
+  },
+  "web.domains.dns.apex_heading": {
+    "text": "Bir ALIAS veya ANAME kaydı oluşturun",
+    "source_hash": "41135375"
+  },
+  "web.domains.dns.apex_notice": {
+    "text": "Apex (kök) alan adları CNAME kaydı kullanamaz. Bunun yerine DNS sağlayıcınızın ALIAS veya ANAME kaydını kullanın ya da bir A kaydını sunucunuzun IP adresine yönlendirin.",
+    "source_hash": "2d1c3298"
+  },
+  "web.domains.email.from_address_local_placeholder": {
+    "text": "no-reply",
+    "source_hash": "510d274d"
+  },
+  "web.domains.homepage.title": {
+    "text": "Ana Sayfa",
+    "source_hash": "9e3391e9"
+  },
+  "web.domains.homepage.description": {
+    "text": "Ziyaretçilerin alan adı ana sayfanızda neler yapabileceği",
+    "source_hash": "974d159e"
+  },
+  "web.domains.homepage.option_private_title": {
+    "text": "Özel açılış sayfası",
+    "source_hash": "dfd5bd1c"
+  },
+  "web.domains.homepage.option_private_description": {
+    "text": "Ziyaretçiler, etkileşimli form içermeyen özel bir açılış sayfası görür",
+    "source_hash": "4d9aaf6f"
+  },
+  "web.domains.homepage.option_create_title": {
+    "text": "Gizli mesaj oluşturma formu",
+    "source_hash": "6539dfc1"
+  },
+  "web.domains.homepage.option_create_description": {
+    "text": "Ziyaretçiler kendi gizli mesaj bağlantılarını oluşturabilir",
+    "source_hash": "884310f4"
+  },
+  "web.domains.homepage.option_incoming_title": {
+    "text": "Gelen gizli mesajlar formu",
+    "source_hash": "882997bf"
+  },
+  "web.domains.homepage.option_incoming_description": {
+    "text": "Ziyaretçiler, yapılandırdığınız alıcılara gizli mesaj gönderebilir",
+    "source_hash": "86bdaedb"
+  },
+  "web.domains.homepage.incoming_requires_recipients": {
+    "text": "Gelen gizli mesajların en az bir alıcıyla etkinleştirilmesini gerektirir",
+    "source_hash": "0462611d"
+  },
+  "web.domains.homepage.configure_recipients": {
+    "text": "Alıcıları yapılandır",
+    "source_hash": "1c3df8b4"
+  },
+  "web.domains.homepage.status_private": {
+    "text": "Özel açılış sayfası",
+    "source_hash": "dfd5bd1c"
+  },
+  "web.domains.homepage.status_create": {
+    "text": "Herkese açık: ziyaretçiler gizli mesaj oluşturur",
+    "source_hash": "251cfb95"
+  },
+  "web.domains.homepage.status_incoming": {
+    "text": "Herkese açık: ziyaretçiler size gizli mesaj gönderir",
+    "source_hash": "baa926b8"
+  },
+  "web.domains.homepage.status_incoming_unready": {
+    "text": "Gelen hazır değil — özel açılış sayfası gösteriliyor",
+    "source_hash": "a5cc237c"
+  },
+  "web.domains.homepage.badge_incoming": {
+    "text": "Gelen",
+    "source_hash": "e301820a"
+  },
+  "web.domains.homepage.update_success": {
+    "text": "Ana sayfa ayarları kaydedildi",
+    "source_hash": "4eac9f45"
+  },
+  "web.domains.homepage.homepage_uses_incoming_warning": {
+    "text": "Bu alan adının ana sayfası şu anda gelen gizli mesajlar formunu sunuyor. Gelen gizli mesajları devre dışı bırakmak veya tüm alıcıları kaldırmak, gelen yeniden hazır olana kadar ana sayfayı özel bir açılış sayfasına geçirir.",
+    "source_hash": "cc0d4997"
+  },
+  "web.domains.signin.effective_status_label": {
+    "text": "Bu alan adında oturum açma",
+    "source_hash": "d8b884c3"
+  },
+  "web.domains.signin.dormant_notice": {
+    "text": "Oturum açma, çalışma alanı genelinde kapatılmış, bu nedenle her alan adında kullanılamaz. Buradaki ayarlarınız korunur ve çalışma alanı oturum açma yeniden etkinleştirildiğinde geçerli olur.",
+    "source_hash": "723d35dc"
+  },
+  "web.domains.signup.effective_status_label": {
+    "text": "Bu alan adında kayıtlar",
+    "source_hash": "115ab21b"
+  },
+  "web.domains.signup.dormant_notice": {
+    "text": "Kayıtlar, çalışma alanı genelinde kapatılmış, bu nedenle her alan adında kullanılamaz. Buradaki ayarlarınız korunur ve çalışma alanı kayıtları yeniden etkinleştirildiğinde geçerli olur.",
+    "source_hash": "49faefe4"
   }
 }

--- a/locales/content/tr/workspace-organizations.json
+++ b/locales/content/tr/workspace-organizations.json
@@ -4,8 +4,8 @@
     "source_hash": "2730183d"
   },
   "web.organizations.organization": {
-    "text": "Kuruluş",
-    "source_hash": "d764d425"
+    "text": "Çalışma Alanı",
+    "source_hash": "87bb59ba"
   },
   "web.organizations.organization_plural": {
     "text": "Kuruluşlar",
@@ -16,24 +16,24 @@
     "source_hash": "dbaa4f92"
   },
   "web.organizations.my_organizations": {
-    "text": "Kuruluşlar",
-    "source_hash": "2730183d"
+    "text": "Çalışma Alanları",
+    "source_hash": "1377264b"
   },
   "web.organizations.manage_organizations": {
-    "text": "Kuruluşları Yönet",
-    "source_hash": "be0fe4c3"
+    "text": "Çalışma Alanlarını Yönet",
+    "source_hash": "cc2d65f8"
   },
   "web.organizations.new_organization": {
     "text": "Yeni Kuruluş",
     "source_hash": "4876e647"
   },
   "web.organizations.no_organizations": {
-    "text": "Henüz kuruluş yok",
-    "source_hash": "5b7a7cbd"
+    "text": "Henüz çalışma alanı yok",
+    "source_hash": "97d0b117"
   },
   "web.organizations.no_organizations_description": {
-    "text": "Kuruluşlar birleşik faturalandırma ve yönetim sağlar. İlk kuruluşunuzu oluşturarak başlayın.",
-    "source_hash": "deab4304"
+    "text": "Çalışma alanları, birleşik faturalandırma ve yönetim sağlar. İlk çalışma alanınızı oluşturarak başlayın.",
+    "source_hash": "f09d4987"
   },
   "web.organizations.no_description": {
     "text": "Açıklama sağlanmadı",
@@ -48,24 +48,24 @@
     "source_hash": "e27f4540"
   },
   "web.organizations.create_first_organization": {
-    "text": "İlk Kuruluşu Oluşturun",
-    "source_hash": "27bae486"
+    "text": "İlk Çalışma Alanını Oluştur",
+    "source_hash": "98a583b4"
   },
   "web.organizations.create_organization_description": {
-    "text": "Yeni bir kuruluş oluşturun",
-    "source_hash": "67cd5950"
+    "text": "Yeni bir çalışma alanı oluştur",
+    "source_hash": "6ac2b5fc"
   },
   "web.organizations.create": {
     "text": "Oluştur",
     "source_hash": "4759498a"
   },
   "web.organizations.create_error": {
-    "text": "Kuruluş oluşturulamadı",
-    "source_hash": "f2204373"
+    "text": "Çalışma alanı oluşturulamadı",
+    "source_hash": "0a8d4fd6"
   },
   "web.organizations.organization_name": {
-    "text": "Kuruluş Adı",
-    "source_hash": "4cbd9073"
+    "text": "Çalışma Alanı Adı",
+    "source_hash": "6fa5a5b1"
   },
   "web.organizations.organization_name_placeholder": {
     "text": "örn. ABC Şirketi",
@@ -92,12 +92,12 @@
     "source_hash": "ee81c03d"
   },
   "web.organizations.select_organization": {
-    "text": "Bir kuruluş seçin",
-    "source_hash": "48326f52"
+    "text": "Bir çalışma alanı seçin",
+    "source_hash": "70a8ce66"
   },
   "web.organizations.switcher_locked": {
-    "text": "Bu sayfada kuruluş değiştirme kullanılamıyor",
-    "source_hash": "da0cf810"
+    "text": "Bu sayfada çalışma alanı değiştirme kullanılamaz",
+    "source_hash": "c34114ac"
   },
   "web.organizations.not_found": {
     "text": "Kuruluş bulunamadı",
@@ -208,8 +208,8 @@
     "source_hash": "7ecc5d35"
   },
   "web.organizations.tabs.members": {
-    "text": "Takım",
-    "source_hash": "5985039f"
+    "text": "Üyeler",
+    "source_hash": "1044a4c0"
   },
   "web.organizations.tabs.billing": {
     "text": "Faturalandırma",
@@ -468,8 +468,8 @@
     "source_hash": "424a2551"
   },
   "web.organizations.invitations.roles.member": {
-    "text": "Üye",
-    "source_hash": "7c968fb7"
+    "text": "Ekip Üyesi",
+    "source_hash": "d4e55dfa"
   },
   "web.organizations.invitations.roles.admin": {
     "text": "Yönetici",
@@ -532,8 +532,8 @@
     "source_hash": "5e3f8df8"
   },
   "web.organizations.invitations.upgrade_prompt": {
-    "text": "Takım üyesi davetleri, takım yönetimi içeren bir plan gerektirir. Kuruluşunuza işbirlikçiler eklemek için yükseltin.",
-    "source_hash": "cf10d623"
+    "text": "Üye davetleri ücretli bir plan gerektirir. Kuruluşunuza iş arkadaşları eklemek için planınızı yükseltin.",
+    "source_hash": "47d0eeab"
   },
   "web.organizations.paid_badge": {
     "text": "Pro",
@@ -556,8 +556,8 @@
     "source_hash": "ced67718"
   },
   "web.organizations.invitations.email_mismatch_title": {
-    "text": "Farklı bir hesapla giriş yapılmış",
-    "source_hash": "4a2f91c3"
+    "text": "Farklı bir hesapla oturum açıldı",
+    "source_hash": "6516362a"
   },
   "web.organizations.invitations.email_mismatch_body": {
     "text": "Bu davet {invitedEmail} için. Şu anda {currentEmail} olarak giriş yapmış durumdasınız.",
@@ -565,7 +565,7 @@
   },
   "web.organizations.invitations.continue_as_invited_email": {
     "text": "{email} olarak devam et",
-    "source_hash": "6c9a1d4e"
+    "source_hash": "ccf9745d"
   },
   "web.organizations.invitations.expires_in_days": {
     "text": "{days}g kaldı",
@@ -1026,5 +1026,9 @@
   "web.organizations.tabs.sso": {
     "text": "SSO",
     "source_hash": "5ba3ac9f"
+  },
+  "web.organizations.create_workspace": {
+    "text": "Çalışma Alanı Oluştur",
+    "source_hash": "c63c14cf"
   }
 }


### PR DESCRIPTION
## `tr` translation update

Automated export of completed **tr** translations from the translation task DB.
Scope: `locales/content/tr/` only — 33 file(s), +3707/-113.

ℹ️ Variable validation not run.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-opus-4-8`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ✅ Looks good — tokens intact, brand terms preserved.

**Summary:** Large additive update (15 new `admin-*.json` files plus edits across common, email, domains, branding, auth, organizations). Placeholders, brand terms, and technical carve-outs are all correctly preserved; the org→workspace rename mirrors the English source's `source_hash` changes.

**Critical (must fix):** None

**Warnings:** None

**Notes:**
- Variable-consistency check was **not run**; I hand-verified interpolations. All `{ip} {email} {plan} {role} {org} {domain} {count} {entitlement} {address} {provider} {duration} {days} {shown} {anonymous} {scanned} {accepted} {rejected} {fetched} {label} {seconds} {token} {column} {max}` and `%{secrets_mode}` / `%{status}` match their keys. Recommend running the validator before merge as a formality.
- `api.invite.errors.invitation_already_processed` intentionally drops `%{status}` ("Davet zaten %{status}…" → "Bu davet zaten işlendi"); this matches the upstream refactor to status-specific keys — not a lost variable.
- Vue escape `{'@'}` preserved in email placeholders and `{'@'}theme` blurb.
- org→workspace rename is **partial/inconsistent** within `workspace-organizations.json` (e.g. `organization`→"Çalışma Alanı" but `organization_plural`/`new_organization` stay "Kuruluş"). This tracks the source — only keys with changed `source_hash` were renamed — so it's faithful, not a defect. Flagging so a maintainer confirms the English source is itself intentionally mixed.
- Carve-outs kept English correctly: Colonel, Stripe, Redis INFO, SSO, DNS/CNAME/CIDR/TTL/SMTP, `no-reply`, endpoint paths, `ots email sync-feedback`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
