### PR TITLE
i18n: pr-per-locale.sh — diagnostics capture + --skip-validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,7 @@ tests/lanes/**/.overlays
 !tests/lanes/**/.envrc
 !tests/lanes/base.env
 !tests/lanes/overlays/*.env
+
+# Per-run i18n PR-review artifacts (pr-per-locale.sh). Not committed here; may
+# move to the translation-rules repo as an audit trail. See locales/BATCH_OPERATIONS.md.
+locales/reviews/

--- a/locales/BATCH_OPERATIONS.md
+++ b/locales/BATCH_OPERATIONS.md
@@ -98,6 +98,13 @@ locales/scripts/pr-per-locale.sh --execute --no-review
 locales/scripts/pr-per-locale.sh --execute --update de
 ```
 
+Each run writes its per-locale artifacts to `locales/reviews/<timestamp>/` (the `<locale>.md`
+quality reviews plus `.raw.txt`/`.stderr`/`i18n-validate-*.json` diagnostics). **This directory is
+gitignored — we do not commit reviews to this repo.** The `.md` reviews are already baked into the
+PR bodies on GitHub; the local copies are bespoke, per-diff quality records we may relocate to the
+**translation-rules** repo as an audit trail. Until that lands, treat `locales/reviews/` as local
+scratch and keep the runs you care about out-of-tree.
+
 Capture the resulting PR numbers to rebuild the arrays below — they are per-round and the ones
 listed are stale (a prior batch). Note `--head` is exact-match, not a prefix, so filter with jq
 (the freshly-opened PRs are in the default open state):

--- a/locales/scripts/pr-per-locale.sh
+++ b/locales/scripts/pr-per-locale.sh
@@ -37,6 +37,10 @@
 #                        per-locale task prompt, the diff, and --model. Unset by
 #                        default (inline review prompt only).
 #   --no-review          Skip the claude review (PR body carries stats only).
+#   --skip-validation    Skip the up-front variable-validation pass (Stage 0)
+#                        that materializes each branch and writes per-locale
+#                        i18n-validate-<locale>.json files. PR bodies then show
+#                        "Variable validation not run" instead of a mismatch count.
 #   --update             If an open PR already exists for the branch, refresh its
 #                        body instead of skipping it.
 #   --results-dir DIR    Where to write validation JSON + review artifacts
@@ -66,6 +70,7 @@ MODEL=claude-sonnet-5
 AGENT_PROFILE=""
 EXECUTE=false
 DO_REVIEW=true
+SKIP_VALIDATION=false
 UPDATE_EXISTING=false
 REVIEW_TIMEOUT=300
 SLEEP_AFTER=0
@@ -86,6 +91,7 @@ while [[ $# -gt 0 ]]; do
     --agent-profile)  AGENT_PROFILE="${2:?--agent-profile needs an agent name}"; shift ;;
     --agent-profile=*) AGENT_PROFILE="${1#*=}" ;;
     --no-review)      DO_REVIEW=false ;;
+    --skip-validation) SKIP_VALIDATION=true ;;
     --update)         UPDATE_EXISTING=true ;;
     --results-dir)    RESULTS_DIR="${2:?--results-dir needs a path}"; shift ;;
     --results-dir=*)  RESULTS_DIR="${1#*=}" ;;
@@ -137,9 +143,11 @@ else
   BASE_REF="$BASE_BRANCH"
 fi
 
-# jq + python3 gate the optional variable-validation section.
+# jq + python3 gate the optional variable-validation section; --skip-validation
+# turns it off explicitly regardless of tool availability.
 HAVE_VALIDATION=false
-if command -v jq >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 \
+if ! $SKIP_VALIDATION \
+   && command -v jq >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 \
    && [[ -f locales/scripts/review-locale-branches.sh ]]; then
   HAVE_VALIDATION=true
 fi

--- a/locales/scripts/pr-per-locale.sh
+++ b/locales/scripts/pr-per-locale.sh
@@ -88,7 +88,7 @@ while [[ $# -gt 0 ]]; do
     --base=*)         BASE_BRANCH="${1#*=}" ;;
     --model)          MODEL="${2:?--model needs a value}"; shift ;;
     --model=*)        MODEL="${1#*=}" ;;
-    --agent-profile)  AGENT_PROFILE="${2:?--agent-profile needs an agent name}"; shift ;;
+    --agent-profile)  AGENT_PROFILE="${2:?--agent-profile needs the name of an existing claude agent definition (from .claude/agents or a plugin), e.g. saas-translator}"; shift ;;
     --agent-profile=*) AGENT_PROFILE="${1#*=}" ;;
     --no-review)      DO_REVIEW=false ;;
     --skip-validation) SKIP_VALIDATION=true ;;

--- a/locales/scripts/pr-per-locale.sh
+++ b/locales/scripts/pr-per-locale.sh
@@ -333,6 +333,11 @@ process_locale() {
   if $DO_REVIEW; then
     echo "[$locale] running fresh claude review ($MODEL${AGENT_PROFILE:+, agent=$AGENT_PROFILE})..."
     local raw rc=0
+    # Capture claude's stderr and raw stdout to per-locale files. stderr is the
+    # only place API errors (rate-limit, auth, overload) surface; discarding it
+    # is what makes a failed review undiagnosable. The raw stdout is persisted
+    # unconditionally so a review is never lost to a transient/format hiccup.
+    local stderr_file="$RESULTS_DIR/$locale.stderr" raw_file="$RESULTS_DIR/$locale.raw.txt"
     # Optional named agent profile -> `claude --agent NAME`. Expanded with the
     # ${arr[@]+"${arr[@]}"} guard so an unset profile adds no argument even under
     # `set -u`.
@@ -342,10 +347,11 @@ process_locale() {
              --model "$MODEL" \
              ${agent_args[@]+"${agent_args[@]}"} \
              --allowedTools "Read" \
-             --output-format text <"$ctx" 2>/dev/null)" || rc=$?
+             --output-format text <"$ctx" 2>"$stderr_file")" || rc=$?
+    printf '%s' "$raw" >"$raw_file"
     if [[ $rc -ne 0 || -z "$raw" ]]; then
-      echo "[$locale] review did not complete (exit $rc); PR body will note it"
-      review_md="_Automated review did not complete (exit $rc). Review this locale manually._"
+      echo "[$locale] review did not complete (exit $rc); see $stderr_file"
+      review_md="_Automated review did not complete (exit $rc). See \`$stderr_file\` for the error and \`$raw_file\` for any partial output._"
     else
       # Strip any agent preamble/reasoning that leaked ahead of the structured
       # review (some agent profiles emit a "thinking out loud" line first). The
@@ -358,6 +364,8 @@ process_locale() {
         review_md="$raw"
       fi
     fi
+    # Drop an empty stderr file so a clean run leaves no noise behind.
+    [[ -s "$stderr_file" ]] || rm -f "$stderr_file"
     # Persist the review artifact (matches locales/reviews/<date>/<locale>.md).
     { echo "# $locale review — $(basename "$RESULTS_DIR")"; echo; echo "$review_md"; } >"$review_file"
   else


### PR DESCRIPTION
Two improvements to `locales/scripts/pr-per-locale.sh`, the per-locale i18n PR opener:

- **Capture review diagnostics** — each `claude` review now writes its stderr (`<locale>.stderr`, the only place API rate-limit/auth/overload errors surface) and raw stdout (`<locale>.raw.txt`) to the results dir, so a failed or malformed review is diagnosable instead of silently lost.
- **`--skip-validation` flag** — skips the up-front Stage 0 variable-validation pass (which materializes each branch in a throwaway worktree and writes `i18n-validate-<locale>.json`). PR bodies then show "Variable validation not run" instead of a mismatch count. Useful when validation was already run or the branches are known-clean.

Tooling only — no locale content changes.

Related to #3738