### PR TITLE
config: align notifications worker prefetch default (10 → 5)

### DIFF
--- a/changelog.d/20260713_205719_claude_notifications_prefetch_default.rst
+++ b/changelog.d/20260713_205719_claude_notifications_prefetch_default.rst
@@ -1,0 +1,15 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- The notifications worker's prefetch default in
+  ``etc/defaults/config.defaults.yaml`` now reads ``5`` instead of ``10``,
+  matching the value the worker actually runs with. ``NotificationWorker``
+  declares its queue with ``ENV.fetch('NOTIFICATION_WORKER_PREFETCH', 5)``, so
+  when the env var is unset the worker has always prefetched 5 messages while
+  the config file misreported 10. This aligns the documented default with
+  runtime and with the sibling ``billing`` worker (also 5); the high-throughput
+  ``email`` worker keeps its 10. No runtime behaviour changes for a default
+  deployment. Surfaced during #3777 review.
+  (#3777)

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -863,7 +863,7 @@ jobs:
       prefetch: <%= ENV['EMAIL_WORKER_PREFETCH']&.to_i || 10 %>
     notifications:
       threads: <%= ENV['NOTIFICATION_WORKER_THREADS']&.to_i || 2 %>
-      prefetch: <%= ENV['NOTIFICATION_WORKER_PREFETCH']&.to_i || 10 %>
+      prefetch: <%= ENV['NOTIFICATION_WORKER_PREFETCH']&.to_i || 5 %>
     billing:
       threads: <%= ENV['BILLING_WORKER_THREADS']&.to_i || 2 %>
       prefetch: <%= ENV['BILLING_WORKER_PREFETCH']&.to_i || 5 %>


### PR DESCRIPTION
## Summary

Aligns the notifications worker's `prefetch` default in `etc/defaults/config.defaults.yaml` with the value the worker actually runs at.

`NotificationWorker` declares its queue with `ENV.fetch('NOTIFICATION_WORKER_PREFETCH', 5)` (`lib/onetime/jobs/workers/notification_worker.rb:43`), so with the env var unset the worker has **always prefetched 5** messages — while the config file misreported **10**. The `from_queue` declaration reads the env var directly; nothing feeds the YAML `jobs.workers.notifications.prefetch` path into the worker, so the `10` was a dead, misleading value.

The other two workers are already internally consistent; notifications was the odd one out:

| worker | threads | prefetch before | prefetch after |
|---|---|---|---|
| email | 4 | 10 = 10 ✓ | 10 = 10 |
| notifications | 2 | 10 ≠ **5** ✗ | **5 = 5** ✓ |
| billing | 2 | 5 = 5 ✓ | 5 = 5 |

**No runtime behaviour change** for a default deployment — the worker already ran at 5. This corrects the config's documented default only, and brings notifications in line with the sibling `billing` worker (also a light, 2-thread worker). The high-throughput `email` worker keeps its 10.

## Context

Pre-existing — the `|| 10` dates to the original jobs config (`221f49fce4`, 2025-11-27), untouched since. Flagged as out-of-scope during the #3777 review ("real pre-existing bug worth a separate issue — not this PR's scope"); this is that follow-up.

## Changes

- `etc/defaults/config.defaults.yaml` — notifications `prefetch` default `10 → 5`
- changelog fragment (Fixed)
