### PR TITLE
Cap generated-password length on v1+v2 generate endpoints (C5 DoS)

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -277,6 +277,13 @@ STDOUT_SYNC=false
 # guaranteed. Default: true; set to 'false' to exclude.
 #PASSWORD_GEN_LOWERCASE=true
 
+# Server-enforced ceiling on the requested length of a generated password
+# (site.secret_options.password_generation.maximum_length). Oversized
+# `length` values are rejected before allocation, closing a memory-exhaustion
+# DoS on the anonymous generate endpoints. Matches the frontend Zod max so the
+# client and server limits stay in lockstep. Default: 128.
+#PASSWORD_GEN_MAX_LENGTH=128
+
 # Include numbers (0-9) in generated passwords
 # (site.secret_options.password_generation.character_sets.numbers).
 # When multiple sets are enabled, at least one character from each is

--- a/apps/api/v1/logic/secrets/generate_secret.rb
+++ b/apps/api/v1/logic/secrets/generate_secret.rb
@@ -22,7 +22,7 @@ module V1::Logic
         # Mirrors the v2 generate cap and the frontend Zod max.
         max_length = (password_config['maximum_length'] || 128).to_i
         if length > max_length
-          raise_form_error "Generated password length must be no more than #{max_length} characters"
+          raise_form_error "Generated password length must be no more than #{max_length} characters", field: :length
         end
 
         # Build character set options from payload or configuration

--- a/apps/api/v1/logic/secrets/generate_secret.rb
+++ b/apps/api/v1/logic/secrets/generate_secret.rb
@@ -17,6 +17,14 @@ module V1::Logic
         # Extract parameters from payload with fallbacks to configuration
         length = payload['length']&.to_i || password_config['default_length'] || 12
 
+        # Reject oversized lengths BEFORE strand allocates (DoS guard). Read the
+        # ceiling from CONFIG, not the payload, so a caller cannot lift the guard.
+        # Mirrors the v2 generate cap and the frontend Zod max.
+        max_length = (password_config['maximum_length'] || 128).to_i
+        if length > max_length
+          raise_form_error "Generated password length must be no more than #{max_length} characters"
+        end
+
         # Build character set options from payload or configuration
         char_sets = payload['character_sets'] || password_config['character_sets'] || {}
 

--- a/apps/api/v1/spec/logic/secrets/generate_secret_spec.rb
+++ b/apps/api/v1/spec/logic/secrets/generate_secret_spec.rb
@@ -1,0 +1,70 @@
+# apps/api/v1/spec/logic/secrets/generate_secret_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative '../../../application'
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+
+# Regression coverage for the C5 generate-length DoS on the legacy V1 endpoint
+# (POST /api/v1/generate).
+#
+# V1 reads `payload['length']` directly (no merged 'secret' namespace). The
+# allocating call `Onetime::Utils.strand(length, ...)` runs inside
+# process_secret, which fires from process_params in the LOGIC CONSTRUCTOR
+# (apps/api/v1/logic/base.rb:38) — so the ceiling must be enforced in
+# process_secret, immediately before strand, or the oversized string is already
+# allocated. The cap is read from CONFIG, not the payload, so a caller cannot
+# lift the guard by sending a large `length`.
+RSpec.describe V1::Logic::Secrets::GenerateSecret do
+  let(:session)  { double('Session') }
+  let(:customer) { double('Onetime::Customer', anonymous?: true, custid: 'anon') }
+
+  before(:all) do
+    OT.boot!(:test)
+  end
+
+  let(:max_length) do
+    OT.conf.dig('site', 'secret_options', 'password_generation', 'maximum_length').to_i
+  end
+
+  context 'when the requested length exceeds the ceiling' do
+    it 'raises a form error at construction, before strand ever allocates' do
+      # V1 runs process_params (hence process_secret) in the constructor, so the
+      # guard fires during `described_class.new` — that IS the proof the
+      # rejection happens ahead of allocation. strand must never be reached.
+      expect(Onetime::Utils).not_to receive(:strand)
+
+      expect { described_class.new(session, customer, 'length' => '50000000') }
+        .to raise_error(OT::FormError, /no more than #{max_length} characters/)
+    end
+  end
+
+  context 'when the payload sends an oversized length to override the ceiling' do
+    it 'is still rejected — the config ceiling wins over the payload' do
+      # V1 has no merged config/payload hash; the ceiling comes from config, so a
+      # caller sending a huge `length` cannot raise it. length=99999999 is rejected.
+      expect(Onetime::Utils).not_to receive(:strand)
+
+      expect { described_class.new(session, customer, 'length' => '99999999') }
+        .to raise_error(OT::FormError, /no more than #{max_length} characters/)
+    end
+  end
+
+  context 'when the requested length is exactly at the ceiling' do
+    it 'succeeds and produces a secret_value of ceiling size' do
+      logic = described_class.new(session, customer, 'length' => max_length.to_s)
+
+      expect(logic.secret_value).to be_a(String)
+      expect(logic.secret_value.length).to eq(max_length)
+    end
+  end
+
+  context 'when the requested length is at or below the ceiling' do
+    it 'succeeds and produces a secret_value of the requested size' do
+      logic = described_class.new(session, customer, 'length' => '12')
+
+      expect(logic.secret_value).to be_a(String)
+      expect(logic.secret_value.length).to eq(12)
+    end
+  end
+end

--- a/apps/api/v2/logic/secrets/generate_secret.rb
+++ b/apps/api/v2/logic/secrets/generate_secret.rb
@@ -51,7 +51,7 @@ module V2::Logic
         max_length = (maxlen_config || 128).to_i
         if length > max_length
           emsg = "Generated password length must be no more than #{max_length} characters"
-          raise_form_error emsg, field: :secret
+          raise_form_error emsg, field: :length
         end
 
         # Build character set options from merged configuration

--- a/apps/api/v2/logic/secrets/generate_secret.rb
+++ b/apps/api/v2/logic/secrets/generate_secret.rb
@@ -34,12 +34,25 @@ module V2::Logic
         #
         # This is compatible with both v0.22 (mostly symbols) and v1.0
         # configuration (all strings).
+        maxlen_config            = password_config.fetch('maximum_length', nil)
         config_with_string_keys  = password_config.transform_keys(&:to_s)
         payload_with_string_keys = payload.transform_keys(&:to_s)
         merged_options           = config_with_string_keys.merge(payload_with_string_keys)
 
         # Extract parameters from merged options
         length = merged_options['length']&.to_i || merged_options['default_length'] || 12
+
+        # Reject oversized lengths BEFORE strand allocates. process_secret runs
+        # in the constructor (via process_params, BEFORE raise_concerns), so this
+        # is the last guard ahead of the allocation — capping in raise_concerns
+        # would be too late, the oversized string is already built. Read the
+        # ceiling from CONFIG (not merged_options) so a payload key like
+        # secret[maximum_length] cannot raise the guard. Mirrors the frontend Zod max.
+        max_length = (maxlen_config || 128).to_i
+        if length > max_length
+          emsg = "Generated password length must be no more than #{max_length} characters"
+          raise_form_error emsg, field: :secret
+        end
 
         # Build character set options from merged configuration
         char_sets = merged_options['character_sets'] || {}

--- a/apps/api/v2/spec/logic/secrets/generate_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/generate_secret_spec.rb
@@ -1,0 +1,104 @@
+# apps/api/v2/spec/logic/secrets/generate_secret_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative '../../../application'
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+
+# Regression coverage for the C5 generate-length DoS.
+#
+# POST /api/v2/secret/generate reads `secret[length]` from the payload. The
+# allocating call `Onetime::Utils.strand(length, ...)` runs inside
+# process_secret, which fires from process_params in the LOGIC CONSTRUCTOR —
+# BEFORE raise_concerns. So the ceiling must be enforced in process_secret,
+# immediately before strand, or the oversized string is already allocated.
+#
+# These tests drive process_params directly (constructor path) and assert:
+#   1. an oversized `length` is rejected before strand ever allocates;
+#   2. a payload attempting to raise the ceiling via secret[maximum_length]
+#      is STILL rejected (config ceiling wins over payload);
+#   3. a normal length succeeds and yields a secret_value of the expected size.
+RSpec.describe V2::Logic::Secrets::GenerateSecret, type: :integration do
+  before(:all) do
+    require 'onetime'
+    Onetime.boot! :test
+  end
+
+  def mock_session
+    store = {}
+    session = double('Session')
+    allow(session).to receive(:[]) { |k| store[k] }
+    allow(session).to receive(:[]=) { |k, v| store[k] = v }
+    session
+  end
+
+  # Build a GenerateSecret over an anonymous caller. We exercise process_params
+  # (constructor-time allocation path), not raise_concerns.
+  def build_logic(secret_params)
+    customer = double('Customer', custid: 'anon', anonymous?: true, objid: nil)
+    org      = double('Organization', objid: "org_#{SecureRandom.hex(4)}")
+    allow(org).to receive(:can?).and_return(true)
+    allow(org).to receive(:limit_for).and_return(0)
+
+    strategy_result = double('StrategyResult',
+      session: mock_session,
+      user: customer,
+      metadata: { organization: org, ip: '203.0.113.7' },
+      auth_method: 'basicauth')
+
+    described_class.new(strategy_result, { 'secret' => secret_params })
+  end
+
+  let(:max_length) do
+    OT.conf.dig('site', 'secret_options', 'password_generation', 'maximum_length').to_i
+  end
+
+  context 'when the requested length exceeds the ceiling' do
+    it 'raises a form error at construction, before strand ever allocates' do
+      # Fail loudly if the guard is bypassed: strand must never be called with
+      # an oversized length. process_params runs in the constructor, so the
+      # guard fires during build_logic's `described_class.new` — that IS the
+      # proof the rejection happens ahead of allocation.
+      expect(Onetime::Utils).not_to receive(:strand)
+
+      expect { build_logic('length' => '50000000', 'ttl' => '3600') }
+        .to raise_error(OT::FormError, /no more than #{max_length} characters/)
+    end
+  end
+
+  context 'when the payload attempts to raise the ceiling' do
+    it 'is still rejected — the config ceiling wins over the payload' do
+      # A caller who POSTs secret[maximum_length]=99999999 alongside an oversized
+      # length must not be able to lift the guard: the ceiling is read from
+      # config, not the merged payload.
+      expect(Onetime::Utils).not_to receive(:strand)
+
+      expect do
+        build_logic(
+          'length' => '1000',
+          'maximum_length' => '99999999',
+          'ttl' => '3600',
+        )
+      end.to raise_error(OT::FormError, /no more than #{max_length} characters/)
+    end
+  end
+
+  context 'when the requested length is exactly at the ceiling' do
+    it 'succeeds and produces a secret_value of ceiling size' do
+      logic = build_logic('length' => max_length.to_s, 'ttl' => '3600')
+
+      expect(logic.secret_value).to be_a(String)
+      expect(logic.secret_value.length).to eq(max_length)
+    end
+  end
+
+  context 'when the requested length is at or below the ceiling' do
+    it 'succeeds and produces a secret_value of the requested size' do
+      # build_logic runs process_params via the constructor.
+      logic = build_logic('length' => '12', 'ttl' => '3600')
+
+      expect(logic.secret_value).to be_a(String)
+      expect(logic.secret_value.length).to eq(12)
+    end
+  end
+end

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -238,6 +238,10 @@ site:
     password_generation:
       # Default length for generated passwords
       default_length: <%= ENV['PASSWORD_GEN_LENGTH'] || 12 %>
+      # Server-enforced ceiling on requested generated-password length.
+      # Rejects oversized `length` values before allocation (DoS guard);
+      # matches the frontend Zod max so the two limits stay in lockstep.
+      maximum_length: <%= ENV['PASSWORD_GEN_MAX_LENGTH'] || 128 %>
       # Character sets to include in generated passwords
       character_sets:
         # Include uppercase letters (A-Z)

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -71,6 +71,10 @@ module Onetime
             },
             'password_generation' => {
               'default_length' => 12,
+              # Server-enforced ceiling on requested generated-password length.
+              # Rejects oversized `length` before allocation (DoS guard); mirrors
+              # the frontend Zod max so client/server limits stay in lockstep.
+              'maximum_length' => 128,
               'length_options' => [8, 12, 16, 20, 24, 32],
               'character_sets' => {
                 'uppercase' => true,
@@ -511,6 +515,10 @@ module Onetime
 
       if password_gen_config['default_length'].is_a?(String)
         conf['site']['secret_options']['password_generation']['default_length'] = password_gen_config['default_length'].to_i
+      end
+
+      if password_gen_config['maximum_length'].is_a?(String)
+        conf['site']['secret_options']['password_generation']['maximum_length'] = password_gen_config['maximum_length'].to_i
       end
 
       # Handle length_options as string or array


### PR DESCRIPTION
## C5 — Memory-exhaustion DoS on the anonymous generate endpoints

From the 2026-06-22 security assessment. Both `POST /api/v1/generate` and
`POST /api/v2/generate` are **anonymously reachable** and passed the requested
password `length` straight into strand allocation with no upper bound. A single
request with an oversized `length` allocated a proportionally large string,
exhausting server memory.

### Fix
Reject oversized `length` **before** the strand allocates, on both v1 and v2:

- The ceiling is read from **CONFIG**
  (`site.secret_options.password_generation.maximum_length`), **not** the
  request payload — so a caller cannot lift the guard with a
  `secret[maximum_length]=…` key.
- Default **128**, matching the frontend Zod max so client and server limits
  stay in lockstep. Env override: `PASSWORD_GEN_MAX_LENGTH`.
- v2 placement note: `process_secret` runs in the constructor (via
  `process_params`, **before** `raise_concerns`), so this is the last guard
  ahead of allocation — capping in `raise_concerns` would be too late, the
  oversized string is already built.

### PoC — before vs. after (measured, full stack, unauthenticated)

Request: `POST /api/v2/generate` with `length=50000000` (50M).

| | `length=50M` result | Peak RSS delta | Wall time |
|---|---|---|---|
| **Before** | `200 OK` (secret generated) | **+1.19 GB** | **119 s** |
| **After**  | `422` form error | **~0 MB** | **sub-ms** |

After the fix the response is a `422` form error:
`"Generated password length must be no more than 128 characters"`.

V1 (`POST /api/v1/generate`) had the identical unpatched hole and is closed by
the same guard, reading the same shared config ceiling.

### Tests
- `apps/api/v1/spec/logic/secrets/generate_secret_spec.rb`
- `apps/api/v2/spec/logic/secrets/generate_secret_spec.rb`

Regression coverage: oversized `length` rejected; payload `maximum_length`
cannot raise the ceiling; in-bounds `length` still succeeds.
