### PR TITLE
[#3812] Fix login alert emails queued with empty locale

### DIFF
--- a/apps/api/account/logic/account/confirm_email_change.rb
+++ b/apps/api/account/logic/account/confirm_email_change.rb
@@ -76,6 +76,11 @@ module AccountAPI::Logic
         # Invalidate all sessions for this customer
         invalidate_sessions(@owner)
 
+        # Blank ("") locales are truthy and slip past a bare `||`; treat as missing.
+        email_locale = locale
+        email_locale = @owner.locale if email_locale.to_s.strip.empty?
+        email_locale = OT.default_locale if email_locale.to_s.strip.empty?
+
         # Send confirmation notification to the OLD email (the email has now changed)
         begin
           Onetime::Jobs::Publisher.enqueue_email(
@@ -83,7 +88,7 @@ module AccountAPI::Logic
             {
               old_email: old_email,
               new_email: new_email,
-              locale: locale || @owner.locale || OT.default_locale,
+              locale: email_locale,
             },
             fallback: :async_thread,
           )

--- a/apps/api/account/logic/account/request_email_change.rb
+++ b/apps/api/account/logic/account/request_email_change.rb
@@ -130,6 +130,11 @@ module AccountAPI::Logic
 
         OT.info "[request-email-change] Email change requested cid/#{cust.objid} new_email/#{OT::Utils.obscure_email(@new_email)}"
 
+        # Blank ("") locales are truthy and slip past a bare `||`; treat as missing.
+        email_locale = locale
+        email_locale = cust.locale if email_locale.to_s.strip.empty?
+        email_locale = OT.default_locale if email_locale.to_s.strip.empty?
+
         # Send confirmation email to the NEW address
         begin
           Onetime::Jobs::Publisher.enqueue_email(
@@ -138,7 +143,7 @@ module AccountAPI::Logic
               new_email: @new_email,
               confirmation_token: secret.identifier,
               customer_objid: cust.objid,
-              locale: locale || cust.locale || OT.default_locale,
+              locale: email_locale,
             },
             fallback: :sync,
           )
@@ -153,7 +158,7 @@ module AccountAPI::Logic
             {
               old_email: cust.email,
               new_email: @new_email,
-              locale: locale || cust.locale || OT.default_locale,
+              locale: email_locale,
             },
             fallback: :async_thread,
           )

--- a/apps/api/account/logic/account/resend_email_change_confirmation.rb
+++ b/apps/api/account/logic/account/resend_email_change_confirmation.rb
@@ -73,13 +73,18 @@ module AccountAPI::Logic
 
         OT.info "[resend-email-change] Resending confirmation cid/#{cust.objid} new_email/#{OT::Utils.obscure_email(new_email)} (count: #{resend_count})"
 
+        # Blank ("") locales are truthy and slip past a bare `||`; treat as missing.
+        email_locale = locale
+        email_locale = cust.locale if email_locale.to_s.strip.empty?
+        email_locale = OT.default_locale if email_locale.to_s.strip.empty?
+
         # Re-send confirmation email to the NEW address
         Onetime::Jobs::Publisher.enqueue_email(
           :email_change_confirmation,
           {
             new_email: new_email,
             confirmation_token: @secret.identifier,
-            locale: locale || cust.locale || OT.default_locale,
+            locale: email_locale,
           },
           fallback: :sync,
         )

--- a/apps/api/account/logic/authentication/reset_password_request.rb
+++ b/apps/api/account/logic/authentication/reset_password_request.rb
@@ -93,12 +93,16 @@ module AccountAPI::Logic
         # and the user can request another. We return the same generic response
         # whether or not delivery succeeds, so the result never reveals delivery
         # status.
-        queued = Onetime::Jobs::Publisher.enqueue_email(
+        # Blank ("") locales are truthy and slip past a bare `||`; treat as missing.
+        email_locale = locale
+        email_locale = cust.locale if email_locale.to_s.strip.empty?
+        email_locale = OT.default_locale if email_locale.to_s.strip.empty?
+        queued       = Onetime::Jobs::Publisher.enqueue_email(
           :password_request,
           {
             email_address: cust.email,
             secret: secret,
-            locale: locale || cust.locale || OT.default_locale,
+            locale: email_locale,
           },
           fallback: :sync,
         )

--- a/apps/api/incoming/logic/create_incoming_secret.rb
+++ b/apps/api/incoming/logic/create_incoming_secret.rb
@@ -285,6 +285,10 @@ module Incoming
         # selection (nil on the canonical domain).
         domain_id = resolved_domain_id
 
+        # Blank ("") locales are truthy and slip past a bare `||`; treat as missing.
+        email_locale = locale
+        email_locale = OT.default_locale if email_locale.to_s.strip.empty?
+
         Onetime::Jobs::Publisher.enqueue_email(
           :incoming_secret,
           {
@@ -293,7 +297,7 @@ module Incoming
             recipient: recipient_email,
             memo: memo,
             has_passphrase: !passphrase.to_s.empty?,
-            locale: locale || OT.default_locale,
+            locale: email_locale,
           },
           domain_id: domain_id,
         )

--- a/apps/api/organizations/logic/invitations/create_invitation.rb
+++ b/apps/api/organizations/logic/invitations/create_invitation.rb
@@ -95,7 +95,11 @@ module OrganizationAPI::Logic
         )
 
         # Queue invitation email via RabbitMQ
-        # Use inviter's locale since they initiated the action
+        # Use inviter's locale since they initiated the action.
+        # Blank ("") locales are truthy and slip past a bare `||`; treat as missing.
+        email_locale = locale
+        email_locale = cust.locale if email_locale.to_s.strip.empty?
+        email_locale = OT.default_locale if email_locale.to_s.strip.empty?
         Onetime::Jobs::Publisher.enqueue_email(
           :organization_invitation,
           {
@@ -104,7 +108,7 @@ module OrganizationAPI::Logic
             inviter_email: cust.email,
             role: @role,
             invite_token: @membership.token,
-            locale: locale || cust.locale || OT.default_locale,
+            locale: email_locale,
           },
           fallback: :sync,
         )

--- a/apps/api/organizations/logic/invitations/resend_invitation.rb
+++ b/apps/api/organizations/logic/invitations/resend_invitation.rb
@@ -78,7 +78,11 @@ module OrganizationAPI::Logic
         @invitation.update_in_class_token_lookup(old_token)
 
         # Queue invitation email via RabbitMQ
-        # Use inviter's locale since they initiated the action
+        # Use inviter's locale since they initiated the action.
+        # Blank ("") locales are truthy and slip past a bare `||`; treat as missing.
+        email_locale = locale
+        email_locale = cust.locale if email_locale.to_s.strip.empty?
+        email_locale = OT.default_locale if email_locale.to_s.strip.empty?
         Onetime::Jobs::Publisher.enqueue_email(
           :organization_invitation,
           {
@@ -87,7 +91,7 @@ module OrganizationAPI::Logic
             inviter_email: cust.email,
             role: @invitation.role,
             invite_token: @invitation.token,
-            locale: locale || cust.locale || OT.default_locale,
+            locale: email_locale,
           },
           fallback: :sync,
         )

--- a/apps/api/organizations/logic/members/remove_member.rb
+++ b/apps/api/organizations/logic/members/remove_member.rb
@@ -90,6 +90,9 @@ module OrganizationAPI::Logic
       # so its email/locale remain valid. A delivery failure must never fail
       # the removal.
       def notify_member_removed
+        # Blank ("") locales are truthy and slip past a bare `||`; treat as missing.
+        email_locale = @target_member.locale
+        email_locale = OT.default_locale if email_locale.to_s.strip.empty?
         Onetime::Jobs::Publisher.enqueue_email(
           :member_removed,
           {
@@ -97,7 +100,7 @@ module OrganizationAPI::Logic
             organization_name: @organization.display_name,
             removed_by: cust.email,
             removed_at: Time.now.utc.iso8601,
-            locale: @target_member.locale || OT.default_locale,
+            locale: email_locale,
           },
           fallback: :async_thread,
         )

--- a/apps/api/organizations/logic/members/update_member_role.rb
+++ b/apps/api/organizations/logic/members/update_member_role.rb
@@ -103,6 +103,9 @@ module OrganizationAPI::Logic
       # Best-effort security notification to the member whose role changed.
       # Queued via RabbitMQ; a delivery failure must never fail the role change.
       def notify_role_changed
+        # Blank ("") locales are truthy and slip past a bare `||`; treat as missing.
+        email_locale = @target_member.locale
+        email_locale = OT.default_locale if email_locale.to_s.strip.empty?
         Onetime::Jobs::Publisher.enqueue_email(
           :role_changed,
           {
@@ -112,7 +115,7 @@ module OrganizationAPI::Logic
             new_role: @new_role,
             changed_by: cust.email,
             changed_at: Time.now.utc.iso8601,
-            locale: @target_member.locale || OT.default_locale,
+            locale: email_locale,
           },
           fallback: :async_thread,
         )

--- a/apps/api/organizations/logic/organizations/delete_organization.rb
+++ b/apps/api/organizations/logic/organizations/delete_organization.rb
@@ -78,6 +78,9 @@ module OrganizationAPI::Logic
       # and no failure may affect the (already-completed) deletion.
       def notify_members_deleted(recipients, display_name)
         recipients.each do |recipient|
+          # Blank ("") locales are truthy and slip past a bare `||`; treat as missing.
+          email_locale = recipient[:locale]
+          email_locale = OT.default_locale if email_locale.to_s.strip.empty?
           Onetime::Jobs::Publisher.enqueue_email(
             :organization_deleted,
             {
@@ -85,7 +88,7 @@ module OrganizationAPI::Logic
               organization_name: display_name,
               deleted_by: cust.email,
               deleted_at: Time.now.utc.iso8601,
-              locale: recipient[:locale] || OT.default_locale,
+              locale: email_locale,
             },
             fallback: :async_thread,
           )

--- a/apps/api/organizations/spec/logic/invitations/create_invitation_spec.rb
+++ b/apps/api/organizations/spec/logic/invitations/create_invitation_spec.rb
@@ -349,6 +349,62 @@ RSpec.describe OrganizationAPI::Logic::Invitations::CreateInvitation do
       expect(OT).to receive(:info).with(/Created invitation/)
       logic.process
     end
+
+    # #3812 regression: blank ("") locales are truthy and would slip past the
+    # `locale || cust.locale || OT.default_locale` chain — a blank request
+    # locale must fall through to the inviter's stored locale, and a blank
+    # stored locale must fall through to the default.
+    describe 'locale normalization on the :organization_invitation email' do
+      def enqueued_invitation_locale
+        captured = []
+        allow(Onetime::Jobs::Publisher).to receive(:enqueue_email) do |template, payload, **_kwargs|
+          captured << payload[:locale] if template == :organization_invitation
+          nil
+        end
+
+        logic.process
+
+        expect(captured.size).to eq(1),
+          "Expected exactly one :organization_invitation email, got #{captured.size}"
+        captured.first
+      end
+
+      context 'when the request locale is blank and the inviter has a stored locale' do
+        let(:params) do
+          { 'extid' => 'ext-org-123', 'email' => 'invitee@example.com', 'role' => 'member', 'locale' => '' }
+        end
+
+        before { allow(customer).to receive(:locale).and_return('fr') }
+
+        it 'falls through to the inviter locale' do
+          expect(enqueued_invitation_locale).to eq('fr')
+        end
+      end
+
+      context 'when both the request locale and the inviter locale are blank' do
+        let(:params) do
+          { 'extid' => 'ext-org-123', 'email' => 'invitee@example.com', 'role' => 'member', 'locale' => '' }
+        end
+
+        before { allow(customer).to receive(:locale).and_return('') }
+
+        it 'falls back to the default locale' do
+          expect(enqueued_invitation_locale).to eq(OT.default_locale)
+        end
+      end
+
+      context 'when the request carries a locale' do
+        let(:params) do
+          { 'extid' => 'ext-org-123', 'email' => 'invitee@example.com', 'role' => 'member', 'locale' => 'de' }
+        end
+
+        before { allow(customer).to receive(:locale).and_return('fr') }
+
+        it 'wins over the inviter locale' do
+          expect(enqueued_invitation_locale).to eq('de')
+        end
+      end
+    end
   end
 
   describe '#form_fields' do

--- a/apps/api/organizations/spec/logic/members/update_member_role_spec.rb
+++ b/apps/api/organizations/spec/logic/members/update_member_role_spec.rb
@@ -356,6 +356,40 @@ RSpec.describe OrganizationAPI::Logic::Members::UpdateMemberRole do
       expect(result[:record][:previous_role]).to eq('member')
       expect(result[:record][:role]).to eq('admin')
     end
+
+    # #3812 regression: Customer locales load as "" from Redis, which is truthy
+    # and would slip past a bare `@target_member.locale || OT.default_locale`,
+    # queueing a :role_changed email with a locale I18n cannot resolve.
+    describe 'locale normalization on the :role_changed email' do
+      def enqueued_role_changed_locale
+        captured = []
+        allow(Onetime::Jobs::Publisher).to receive(:enqueue_email) do |template, payload, **_kwargs|
+          captured << payload[:locale] if template == :role_changed
+          nil
+        end
+
+        logic.process
+
+        expect(captured.size).to eq(1),
+          "Expected exactly one :role_changed email, got #{captured.size}"
+        captured.first
+      end
+
+      it 'falls back to the default locale when the member locale is blank' do
+        allow(target_member).to receive(:locale).and_return('')
+        expect(enqueued_role_changed_locale).to eq(OT.default_locale)
+      end
+
+      it 'falls back to the default locale when the member locale is whitespace-only' do
+        allow(target_member).to receive(:locale).and_return('   ')
+        expect(enqueued_role_changed_locale).to eq(OT.default_locale)
+      end
+
+      it 'carries a set member locale through to the payload' do
+        allow(target_member).to receive(:locale).and_return('fr')
+        expect(enqueued_role_changed_locale).to eq('fr')
+      end
+    end
   end
 
   describe '#success_data' do

--- a/apps/api/v3/logic/feedback.rb
+++ b/apps/api/v3/logic/feedback.rb
@@ -125,6 +125,10 @@ module V3
         is_anonymous = sender.nil? || sender.anonymous?
         display_from = is_anonymous ? 'anonymous' : OT::Utils.obscure_email(sender.email)
 
+        # Blank ("") locales are truthy and slip past a bare `||`; treat as missing.
+        email_locale = locale
+        email_locale = OT.default_locale if email_locale.to_s.strip.empty?
+
         email_data = {
           recipient_email: recipient_email,
           email_address: display_from,
@@ -134,7 +138,7 @@ module V3
           message: message,
           display_domain: effective_domain,
           domain_strategy: domain_strategy || :default,
-          locale: locale || OT.default_locale,
+          locale: email_locale,
         }
 
         # When the submitter is authenticated, set Reply-To to their real email

--- a/apps/api/v3/logic/secrets.rb
+++ b/apps/api/v3/logic/secrets.rb
@@ -109,7 +109,7 @@ module V3
         def notify_owner_of_reveal
           owner = secret.load_owner
           return if owner.nil? || owner.anonymous?
-          return unless owner.email.to_s.present?
+          return if owner.email.to_s.empty?
           return unless owner.notify_on_reveal?
 
           Onetime::Jobs::Publisher.enqueue_email(

--- a/apps/web/auth/config/hooks/account.rb
+++ b/apps/web/auth/config/hooks/account.rb
@@ -651,12 +651,16 @@ module Auth::Config::Hooks
         # let a delivery problem surface as a password-change failure.
         Onetime::ErrorHandler.safe_execute('password_changed_email', account_id: account_id) do
           recipient = Onetime::Customer.find_by_email(account[:email])
+          # Customers default locale to "" (matches Redis string load), which is
+          # truthy and would slip past a bare `||`. Treat blank as missing.
+          locale    = recipient&.locale
+          locale    = OT.default_locale if locale.to_s.strip.empty?
           Onetime::Jobs::Publisher.enqueue_email(
             :password_changed,
             {
               email_address: account[:email],
               changed_at: Time.now.utc.iso8601,
-              locale: recipient&.locale || OT.default_locale,
+              locale: locale,
             },
             fallback: :async_thread,
           )

--- a/apps/web/auth/config/hooks/login.rb
+++ b/apps/web/auth/config/hooks/login.rb
@@ -219,6 +219,10 @@ module Auth::Config::Hooks
           # service is wired, so the request IP is the best available location.
           Onetime::ErrorHandler.safe_execute('new_login_alert_email', account_id: account_id) do
             recipient = Onetime::Customer.find_by_email(account[:email])
+            # Customers default locale to "" (matches Redis string load), which is
+            # truthy and would slip past a bare `||`. Treat blank as missing.
+            locale    = recipient&.locale
+            locale    = OT.default_locale if locale.to_s.strip.empty?
             Onetime::Jobs::Publisher.enqueue_email(
               :new_login_alert,
               {
@@ -226,7 +230,7 @@ module Auth::Config::Hooks
                 device_info: request.user_agent || 'Unknown device',
                 location: request.ip,
                 login_at: Time.now.utc.iso8601,
-                locale: recipient&.locale || OT.default_locale,
+                locale: locale,
               },
               fallback: :async_thread,
             )

--- a/apps/web/auth/config/hooks/mfa.rb
+++ b/apps/web/auth/config/hooks/mfa.rb
@@ -183,6 +183,10 @@ module Auth::Config::Hooks
         # the request IP is the best available location.
         Onetime::ErrorHandler.safe_execute('new_login_alert_email', account_id: account_id) do
           recipient = Onetime::Customer.find_by_email(account[:email])
+          # Customers default locale to "" (matches Redis string load), which is
+          # truthy and would slip past a bare `||`. Treat blank as missing.
+          locale    = recipient&.locale
+          locale    = OT.default_locale if locale.to_s.strip.empty?
           Onetime::Jobs::Publisher.enqueue_email(
             :new_login_alert,
             {
@@ -190,7 +194,7 @@ module Auth::Config::Hooks
               device_info: request.user_agent || 'Unknown device',
               location: request.ip,
               login_at: Time.now.utc.iso8601,
-              locale: recipient&.locale || OT.default_locale,
+              locale: locale,
             },
             fallback: :async_thread,
           )

--- a/apps/web/auth/config/hooks/mfa.rb
+++ b/apps/web/auth/config/hooks/mfa.rb
@@ -240,12 +240,16 @@ module Auth::Config::Hooks
         # Best-effort security notification that MFA was turned off.
         Onetime::ErrorHandler.safe_execute('mfa_disabled_email', account_id: account_id) do
           recipient = Onetime::Customer.find_by_email(account[:email])
+          # Customers default locale to "" (matches Redis string load), which is
+          # truthy and would slip past a bare `||`. Treat blank as missing.
+          locale    = recipient&.locale
+          locale    = OT.default_locale if locale.to_s.strip.empty?
           Onetime::Jobs::Publisher.enqueue_email(
             :mfa_disabled,
             {
               email_address: account[:email],
               disabled_at: Time.now.utc.iso8601,
-              locale: recipient&.locale || OT.default_locale,
+              locale: locale,
             },
             fallback: :async_thread,
           )
@@ -288,12 +292,16 @@ module Auth::Config::Hooks
         # Best-effort security notification that MFA was enabled.
         Onetime::ErrorHandler.safe_execute('mfa_enabled_email', account_id: account_id) do
           recipient = Onetime::Customer.find_by_email(account[:email])
+          # Customers default locale to "" (matches Redis string load), which is
+          # truthy and would slip past a bare `||`. Treat blank as missing.
+          locale    = recipient&.locale
+          locale    = OT.default_locale if locale.to_s.strip.empty?
           Onetime::Jobs::Publisher.enqueue_email(
             :mfa_enabled,
             {
               email_address: account[:email],
               enabled_at: Time.now.utc.iso8601,
-              locale: recipient&.locale || OT.default_locale,
+              locale: locale,
             },
             fallback: :async_thread,
           )

--- a/apps/web/auth/operations/disable_mfa.rb
+++ b/apps/web/auth/operations/disable_mfa.rb
@@ -58,12 +58,15 @@ module Auth
       # attempted before a one-shot console script exits, but a delivery
       # failure must not fail (or raise out of) the recovery operation.
       def notify_customer
+        # Blank ("") locales are truthy and slip past a bare `||`; treat as missing.
+        email_locale = @customer.respond_to?(:locale) ? @customer.locale : nil
+        email_locale = OT.default_locale if email_locale.to_s.strip.empty?
         Onetime::Jobs::Publisher.enqueue_email(
           :mfa_disabled,
           {
             email_address: @email,
             disabled_at: Time.now.utc.iso8601,
-            locale: (@customer.respond_to?(:locale) ? @customer.locale : nil) || OT.default_locale,
+            locale: email_locale,
           },
           fallback: :sync,
         )

--- a/apps/web/billing/logic/welcome.rb
+++ b/apps/web/billing/logic/welcome.rb
@@ -219,7 +219,7 @@ module Billing
           existing_id = customer.stripe_customer_id.to_s
           new_id      = fields[:stripe_customer_id].to_s
 
-          if existing_id.present? && existing_id != new_id
+          if !existing_id.empty? && existing_id != new_id
             billing_logger.warn '[FromStripePaymentLink] Customer already has stripe_customer_id, keeping existing',
               existing: existing_id,
               new: new_id,

--- a/apps/web/billing/operations/webhook_handlers/subscription_updated.rb
+++ b/apps/web/billing/operations/webhook_handlers/subscription_updated.rb
@@ -97,6 +97,10 @@ module Billing
           owner = org.owner
           return unless owner&.email
 
+          # Blank ("") locales are truthy and slip past a bare `||`; treat as missing.
+          email_locale = owner.respond_to?(:locale) ? owner.locale : nil
+          email_locale = OT.default_locale if email_locale.to_s.strip.empty?
+
           Onetime::Jobs::Publisher.enqueue_email(
             :subscription_changed,
             {
@@ -104,7 +108,7 @@ module Billing
               old_plan: old_plan,
               new_plan: new_plan,
               effective_date: Time.now.utc.iso8601,
-              locale: (owner.respond_to?(:locale) ? owner.locale : nil) || OT.default_locale,
+              locale: email_locale,
             },
             fallback: :async_thread,
           )

--- a/apps/web/billing/operations/webhook_handlers/trial_will_end.rb
+++ b/apps/web/billing/operations/webhook_handlers/trial_will_end.rb
@@ -47,6 +47,10 @@ module Billing
           ends_at        = Time.at(trial_end).utc
           days_remaining = [((ends_at - Time.now.utc) / SECONDS_PER_DAY).ceil, 0].max
 
+          # Blank ("") locales are truthy and slip past a bare `||`; treat as missing.
+          email_locale = owner.respond_to?(:locale) ? owner.locale : nil
+          email_locale = OT.default_locale if email_locale.to_s.strip.empty?
+
           Onetime::Jobs::Publisher.enqueue_email(
             :trial_expiring,
             {
@@ -54,7 +58,7 @@ module Billing
               plan_name: org.planid,
               trial_ends_at: ends_at.iso8601,
               days_remaining: days_remaining,
-              locale: (owner.respond_to?(:locale) ? owner.locale : nil) || OT.default_locale,
+              locale: email_locale,
             },
             fallback: :async_thread,
           )

--- a/apps/web/core/spec/logic/authentication/authenticate_session_spec.rb
+++ b/apps/web/core/spec/logic/authentication/authenticate_session_spec.rb
@@ -493,4 +493,40 @@ RSpec.describe Core::Logic::Authentication::AuthenticateSession do
       logic.process
     end
   end
+
+  # Regression for #3812: the synchronous verification-email path bypasses the
+  # EmailWorker locale-normalization chokepoint. A blank @locale ("") is truthy,
+  # so it would slip past the delivery site's `||` into an invalid I18n lookup
+  # (:"") and raise I18n::InvalidLocale, silently failing the email.
+  describe '#send_verification_email locale normalization' do
+    subject(:blank_locale_logic) { described_class.new(strategy_result, params, '') }
+
+    let(:secret) do
+      double('Secret', identifier: 'sec_abc123').tap do |s|
+        allow(s).to receive(:verification=)
+        allow(s).to receive(:custid=)
+        allow(s).to receive(:save)
+      end
+    end
+
+    before do
+      allow(customer).to receive(:reset_secret=)
+      allow(Onetime::Receipt).to receive(:spawn_pair).and_return([double('Receipt'), secret])
+      allow(Onetime::Mail::Mailer).to receive(:deliver)
+    end
+
+    it 'reproduces the blank @locale from a blank locale param' do
+      expect(blank_locale_logic.locale).to eq('')
+    end
+
+    it 'delivers the welcome email with the default locale when @locale is blank' do
+      blank_locale_logic.send(:send_verification_email, nil, customer: customer)
+
+      expect(Onetime::Mail::Mailer).to have_received(:deliver).with(
+        :welcome,
+        hash_including(email_address: test_email),
+        locale: OT.default_locale,
+      )
+    end
+  end
 end

--- a/lib/onetime/jobs/workers/email_worker.rb
+++ b/lib/onetime/jobs/workers/email_worker.rb
@@ -153,8 +153,11 @@ module Onetime
             raise ArgumentError, 'Missing template in message payload'
           end
 
-          # Extract locale from payload, fall back to configured default locale
-          locale = email_data.delete(:locale) || email_data.delete('locale') || OT.default_locale
+          # Extract locale from payload, fall back to configured default locale.
+          # A blank locale ("") is truthy in Ruby and would slip past a bare `||`,
+          # so treat blank/whitespace the same as missing.
+          locale = email_data.delete(:locale) || email_data.delete('locale')
+          locale = OT.default_locale if locale.to_s.strip.empty?
 
           Onetime::Mail.deliver(template, email_data, locale: locale, sender_config: sender_config)
         end

--- a/lib/onetime/jobs/workers/email_worker.rb
+++ b/lib/onetime/jobs/workers/email_worker.rb
@@ -155,9 +155,12 @@ module Onetime
 
           # Extract locale from payload, fall back to configured default locale.
           # A blank locale ("") is truthy in Ruby and would slip past a bare `||`,
-          # so treat blank/whitespace the same as missing.
-          locale = email_data.delete(:locale) || email_data.delete('locale')
-          locale = OT.default_locale if locale.to_s.strip.empty?
+          # so normalize (strip) first and treat blank/whitespace the same as missing.
+          # Stripping here canonicalizes the value for every enqueue site on the queued
+          # delivery path, avoiding an invalid I18n locale like :" en ". (The in-process
+          # Publisher fallback path takes a different route and always renders 'en'.)
+          locale = (email_data.delete(:locale) || email_data.delete('locale')).to_s.strip
+          locale = OT.default_locale if locale.empty?
 
           Onetime::Mail.deliver(template, email_data, locale: locale, sender_config: sender_config)
         end

--- a/lib/onetime/logic/base.rb
+++ b/lib/onetime/logic/base.rb
@@ -404,6 +404,13 @@ module Onetime
         # immediately. e.g. customer:abcd1234:reset_secret
         customer.reset_secret = secret.identifier
 
+        # @locale can arrive blank ("") from params (see #initialize) — an empty
+        # string is truthy, so it slips past a bare `||` into an invalid I18n
+        # lookup (:"") that raises I18n::InvalidLocale, which the rescue below
+        # swallows as a silent delivery failure. This synchronous path bypasses
+        # the EmailWorker locale-normalization chokepoint, so normalize here. (#3812)
+        email_locale = locale.to_s.strip.empty? ? OT.default_locale : locale
+
         begin
           Onetime::Mail::Mailer.deliver(
             :welcome,
@@ -411,7 +418,7 @@ module Onetime
               email_address: customer.email,
               secret: secret,
             },
-            locale: locale || 'en',
+            locale: email_locale,
           )
           true
         rescue StandardError => ex

--- a/lib/onetime/models/custom_domain/features/migration_fields.rb
+++ b/lib/onetime/models/custom_domain/features/migration_fields.rb
@@ -46,7 +46,7 @@ module Onetime::CustomDomain::Features
       def pending_org_migration
         instances.revrangeraw(0, -1).collect do |identifier|
           domain = load(identifier)
-          domain if domain&.v1_custid.to_s.present? && domain.org_id.to_s.empty?
+          domain if !domain&.v1_custid.to_s.empty? && domain.org_id.to_s.empty?
         end.compact
       end
 
@@ -72,7 +72,7 @@ module Onetime::CustomDomain::Features
       # @param email_to_org_mapping [Hash] email => org_objid mapping
       # @return [Boolean] Success status
       def migrate_to_org!(email_to_org_mapping)
-        return true if org_id.to_s.present? # Already migrated
+        return true unless org_id.to_s.empty? # Already migrated
 
         email = v1_custid
         return false if email.to_s.empty?
@@ -109,7 +109,7 @@ module Onetime::CustomDomain::Features
       #
       # @return [Boolean]
       def needs_org_migration?
-        v1_custid.to_s.present? && org_id.to_s.empty?
+        !v1_custid.to_s.empty? && org_id.to_s.empty?
       end
 
       # Get the owning organization (v2) or nil

--- a/lib/onetime/models/customer/features/migration_fields.rb
+++ b/lib/onetime/models/customer/features/migration_fields.rb
@@ -99,7 +99,7 @@ module Onetime::Customer::Features
       #
       # @return [Boolean]
       def needs_billing_migration?
-        stripe_customer_id.to_s.present? || stripe_subscription_id.to_s.present?
+        !stripe_customer_id.to_s.empty? || !stripe_subscription_id.to_s.empty?
       end
     end
   end

--- a/lib/onetime/models/organization/features/migration_fields.rb
+++ b/lib/onetime/models/organization/features/migration_fields.rb
@@ -81,7 +81,7 @@ module Onetime
             stripe_cust_id = v1_data[:stripe_customer_id] || v1_data['stripe_customer_id']
             stripe_sub_id  = v1_data[:stripe_subscription_id] || v1_data['stripe_subscription_id']
 
-            if stripe_cust_id.to_s.present?
+            unless stripe_cust_id.to_s.empty?
               org.stripe_customer_id     = stripe_cust_id
               org.stripe_subscription_id = stripe_sub_id
               org.stripe_checkout_email  = email
@@ -95,7 +95,7 @@ module Onetime
               {
                 customer_extid: customer.extid,
                 org_extid: org.extid,
-                has_billing: stripe_cust_id.to_s.present?,
+                has_billing: !stripe_cust_id.to_s.empty?,
               }
 
             org
@@ -158,8 +158,8 @@ module Onetime
           #
           # @return [Boolean]
           def from_v1_migration?
-            v1_source_custid.to_s.present? ||
-              migration_metadata('source_customer_email').present?
+            !v1_source_custid.to_s.empty? ||
+              !migration_metadata('source_customer_email').to_s.empty?
           end
 
           # Store v1 migration source info in caboose

--- a/lib/onetime/models/organization/features/with_organization_billing.rb
+++ b/lib/onetime/models/organization/features/with_organization_billing.rb
@@ -426,11 +426,10 @@ module Onetime
           #
           # @return [Stripe::Customer, nil] Stripe customer or nil if not found
           def get_stripe_customer_by_email
-            email_to_try = billing_email.to_s.presence ||
-                           stripe_checkout_email.to_s.presence ||
-                           contact_email.to_s.presence
+            email_to_try = [billing_email, stripe_checkout_email, contact_email]
+              .map(&:to_s).find { |email| !email.strip.empty? }
 
-            return nil if email_to_try.blank?
+            return nil if email_to_try.nil?
 
             OT.info "[Organization.get_stripe_customer_by_email] Searching for: #{email_to_try}"
             customers = Stripe::Customer.list(email: email_to_try, limit: 1)

--- a/lib/onetime/models/organization/features/with_organization_billing.rb
+++ b/lib/onetime/models/organization/features/with_organization_billing.rb
@@ -409,7 +409,7 @@ module Onetime
           #
           # @return [Stripe::Customer, nil] Stripe customer or nil if not found
           def get_stripe_customer
-            return stripe_customer if stripe_customer_id.to_s.present?
+            return stripe_customer unless stripe_customer_id.to_s.empty?
 
             get_stripe_customer_by_email
           rescue Stripe::StripeError => ex
@@ -458,7 +458,7 @@ module Onetime
           #
           # @return [Stripe::Subscription, nil] Stripe subscription or nil if not found
           def get_stripe_subscription
-            return stripe_subscription if stripe_subscription_id.to_s.present?
+            return stripe_subscription unless stripe_subscription_id.to_s.empty?
 
             # Fallback: Get customer's subscriptions and take first active one
             customer = get_stripe_customer

--- a/lib/onetime/models/receipt/features/deprecated_fields.rb
+++ b/lib/onetime/models/receipt/features/deprecated_fields.rb
@@ -97,6 +97,9 @@ module Onetime::Receipt::Features
         # be serialized to JSON for the message queue - it becomes "#<Secret:0x...>".
         # The template uses secret_key for the URL and share_domain for custom domains.
         # Use secret.identifier (not deprecated secret.key which may be nil)
+        # Blank ("") locales are truthy and slip past a bare `||`; treat as missing.
+        locale = OT.default_locale if locale.to_s.strip.empty?
+
         Onetime::Jobs::Publisher.enqueue_email(
           :secret_link,
           {
@@ -105,7 +108,7 @@ module Onetime::Receipt::Features
             recipient: email_address,
             sender_email: cust.email,
             has_passphrase: secret.has_passphrase?,
-            locale: locale || OT.default_locale,
+            locale: locale,
           },
           domain_id: domain_id,
         ) # fallback: :async_thread is the default

--- a/lib/onetime/models/receipt/features/migration_fields.rb
+++ b/lib/onetime/models/receipt/features/migration_fields.rb
@@ -38,7 +38,7 @@ module Onetime::Receipt::Features
       def pending_owner_migration
         instances.revrangeraw(0, -1).collect do |identifier|
           receipt = load(identifier)
-          receipt if receipt&.v1_custid.to_s.present? && receipt.owner_id.to_s.empty?
+          receipt if !receipt&.v1_custid.to_s.empty? && receipt.owner_id.to_s.empty?
         end.compact
       end
 
@@ -69,7 +69,7 @@ module Onetime::Receipt::Features
       # @param email_to_org_mapping [Hash] email => org_objid mapping (optional)
       # @return [Boolean] Success status
       def migrate_owner!(email_to_objid_mapping, email_to_org_mapping = {})
-        return true if owner_id.to_s.present? # Already migrated
+        return true unless owner_id.to_s.empty? # Already migrated
 
         custid = v1_custid
         return false if custid.to_s.empty?
@@ -108,11 +108,11 @@ module Onetime::Receipt::Features
       # @return [Boolean] Save result
       def migrate_field_names!
         # Only migrate if new fields are empty and old fields have values
-        if previewed.to_s.empty? && viewed.to_s.present?
+        if previewed.to_s.empty? && !viewed.to_s.empty?
           self.previewed = viewed
         end
 
-        if revealed.to_s.empty? && received.to_s.present?
+        if revealed.to_s.empty? && !received.to_s.empty?
           self.revealed = received
         end
 
@@ -123,7 +123,7 @@ module Onetime::Receipt::Features
       #
       # @return [Boolean]
       def needs_owner_migration?
-        v1_custid.to_s.present? && owner_id.to_s.empty?
+        !v1_custid.to_s.empty? && owner_id.to_s.empty?
       end
 
       # Check if receipt is from anonymous user

--- a/lib/onetime/models/secret/features/migration_fields.rb
+++ b/lib/onetime/models/secret/features/migration_fields.rb
@@ -46,7 +46,7 @@ module Onetime::Secret::Features
       def pending_owner_migration
         instances.revrangeraw(0, -1).collect do |identifier|
           secret = load(identifier)
-          secret if secret&.v1_custid.to_s.present? && secret.owner_id.to_s.empty?
+          secret if !secret&.v1_custid.to_s.empty? && secret.owner_id.to_s.empty?
         end.compact
       end
 
@@ -78,7 +78,7 @@ module Onetime::Secret::Features
       # @param email_to_objid_mapping [Hash] email => customer_objid mapping
       # @return [Boolean] Success status
       def migrate_owner!(email_to_objid_mapping)
-        return true if owner_id.to_s.present? # Already migrated
+        return true unless owner_id.to_s.empty? # Already migrated
 
         custid = v1_custid
         return false if custid.to_s.empty?
@@ -122,7 +122,7 @@ module Onetime::Secret::Features
       #
       # @return [Boolean]
       def needs_owner_migration?
-        v1_custid.to_s.present? && owner_id.to_s.empty?
+        !v1_custid.to_s.empty? && owner_id.to_s.empty?
       end
 
       # Check if secret is from anonymous user

--- a/spec/integration/all/jobs/workers/email_worker_spec.rb
+++ b/spec/integration/all/jobs/workers/email_worker_spec.rb
@@ -166,6 +166,87 @@ RSpec.describe Onetime::Jobs::Workers::EmailWorker, type: :integration do
         )
       end
 
+      it 'falls back to the default locale when the payload locale is an empty string' do
+        message_with_empty_locale = JSON.generate(
+          template: 'secret_link',
+          data: {
+            secret_key: 'abc123',
+            share_domain: nil,
+            recipient: 'user@example.com',
+            sender_email: 'sender@example.com',
+            locale: ''
+          }
+        )
+
+        worker.work_with_params(message_with_empty_locale, delivery_info, metadata)
+
+        expect(Onetime::Mail).to have_received(:deliver).with(
+          :secret_link,
+          {
+            secret_key: 'abc123',
+            share_domain: nil,
+            recipient: 'user@example.com',
+            sender_email: 'sender@example.com'
+          },
+          locale: 'en',
+          sender_config: nil
+        )
+      end
+
+      it 'falls back to the default locale when the payload locale is whitespace-only' do
+        message_with_whitespace_locale = JSON.generate(
+          template: 'secret_link',
+          data: {
+            secret_key: 'abc123',
+            share_domain: nil,
+            recipient: 'user@example.com',
+            sender_email: 'sender@example.com',
+            locale: '   '
+          }
+        )
+
+        worker.work_with_params(message_with_whitespace_locale, delivery_info, metadata)
+
+        expect(Onetime::Mail).to have_received(:deliver).with(
+          :secret_link,
+          {
+            secret_key: 'abc123',
+            share_domain: nil,
+            recipient: 'user@example.com',
+            sender_email: 'sender@example.com'
+          },
+          locale: 'en',
+          sender_config: nil
+        )
+      end
+
+      it 'strips surrounding whitespace from a valid payload locale' do
+        message_with_padded_locale = JSON.generate(
+          template: 'secret_link',
+          data: {
+            secret_key: 'abc123',
+            share_domain: nil,
+            recipient: 'user@example.com',
+            sender_email: 'sender@example.com',
+            locale: ' fr '
+          }
+        )
+
+        worker.work_with_params(message_with_padded_locale, delivery_info, metadata)
+
+        expect(Onetime::Mail).to have_received(:deliver).with(
+          :secret_link,
+          {
+            secret_key: 'abc123',
+            share_domain: nil,
+            recipient: 'user@example.com',
+            sender_email: 'sender@example.com'
+          },
+          locale: 'fr',
+          sender_config: nil
+        )
+      end
+
       it 'acknowledges the message after successful delivery' do
         worker.work_with_params(message, delivery_info, metadata)
 

--- a/spec/integration/full/hooks/account_lifecycle_spec.rb
+++ b/spec/integration/full/hooks/account_lifecycle_spec.rb
@@ -341,6 +341,59 @@ RSpec.describe 'Rodauth Hook Side Effects', :full_auth_mode, type: :integration 
         expect(Auth::Logging).not_to have_received(:log_auth_event)
           .with(:sessions_revoke_skipped_no_identity, any_args)
       end
+
+      # -----------------------------------------------------------------------
+      # #3812 regression: the notification email must carry a resolvable locale.
+      #
+      # A Customer whose locale loaded blank ("") from Redis is truthy and would
+      # slip past a bare `recipient&.locale || OT.default_locale`, queueing a
+      # :password_changed email with locale "" that I18n cannot resolve. The
+      # hook normalizes blank/whitespace to the default. These pin the enqueued
+      # value at the hook boundary; the worker sink is covered independently in
+      # spec/integration/all/jobs/workers/email_worker_spec.rb.
+      # -----------------------------------------------------------------------
+      def enqueued_password_changed_locale
+        captured = []
+        allow(Onetime::Jobs::Publisher).to receive(:enqueue_email) do |template, payload, **_kwargs|
+          captured << payload if template == :password_changed
+          nil
+        end
+
+        change_password
+
+        expect(last_response.status).to eq(200),
+          "Expected change to succeed but got #{last_response.status}: #{last_response.body[0..500]}"
+        expect(captured.size).to eq(1),
+          "Expected exactly one :password_changed email, got #{captured.size}"
+        captured.first[:locale]
+      end
+
+      it 'normalizes a blank Customer locale to the default when enqueueing :password_changed' do
+        customer = find_customer_by_email(cred_email)
+        expect(customer).not_to be_nil
+        customer.locale = ''
+        customer.save
+
+        expect(enqueued_password_changed_locale).to eq(OT.default_locale)
+      end
+
+      it 'normalizes a whitespace-only Customer locale to the default' do
+        customer = find_customer_by_email(cred_email)
+        expect(customer).not_to be_nil
+        customer.locale = '   '
+        customer.save
+
+        expect(enqueued_password_changed_locale).to eq(OT.default_locale)
+      end
+
+      it 'carries a set Customer locale through to the :password_changed email' do
+        customer = find_customer_by_email(cred_email)
+        expect(customer).not_to be_nil
+        customer.locale = 'fr'
+        customer.save
+
+        expect(enqueued_password_changed_locale).to eq('fr')
+      end
     end
 
     describe 'after_reset_password hook' do

--- a/spec/unit/onetime/jobs/enqueue_email_locale_normalization_spec.rb
+++ b/spec/unit/onetime/jobs/enqueue_email_locale_normalization_spec.rb
@@ -1,0 +1,160 @@
+# spec/unit/onetime/jobs/enqueue_email_locale_normalization_spec.rb
+#
+# frozen_string_literal: true
+
+# #3812 regression: enqueue sites must not queue emails with a blank locale.
+#
+# Customer locales load as "" from Redis (Familia string fields default to the
+# empty string), which is truthy and slips past a bare
+# `record.locale || OT.default_locale`. Every enqueue site normalizes with
+# `locale = OT.default_locale if locale.to_s.strip.empty?` instead.
+#
+# This file covers one representative per remaining call-site shape; the other
+# shapes are pinned elsewhere:
+# - Rodauth hooks: spec/integration/full/hooks/account_lifecycle_spec.rb
+# - Worker sink:   spec/integration/all/jobs/workers/email_worker_spec.rb
+# - `locale || cust.locale` chain: apps/api/organizations/spec/logic/invitations/create_invitation_spec.rb
+# - Record-sourced locale:         apps/api/organizations/spec/logic/members/update_member_role_spec.rb
+#
+# Instances are `allocate`d with only the ivars the notify method reads, per
+# the precedent in spec/unit/onetime/logic/require_entitlement_spec.rb.
+#
+# Run: pnpm run test:rspec spec/unit/onetime/jobs/enqueue_email_locale_normalization_spec.rb
+
+require 'spec_helper'
+require 'organizations/logic'
+require 'auth/operations/disable_mfa'
+# Handlers self-register with ProcessWebhookEvent when their class body loads.
+require 'billing/operations/process_webhook_event'
+require 'billing/operations/webhook_handlers/subscription_updated'
+require 'v3/logic/feedback'
+
+RSpec.describe 'Email enqueue locale normalization (#3812)' do
+  def capture_enqueued_payloads
+    captured = []
+    allow(Onetime::Jobs::Publisher).to receive(:enqueue_email) do |_template, payload, **_kwargs|
+      captured << payload
+      nil
+    end
+    captured
+  end
+
+  describe 'OrganizationAPI::Logic::Organizations::DeleteOrganization#notify_members_deleted' do
+    # Recipient locales are captured from member records before deletion, so a
+    # blank stored locale arrives here as "" inside the recipients hash.
+    let(:logic) do
+      instance = OrganizationAPI::Logic::Organizations::DeleteOrganization.allocate
+      instance.instance_variable_set(:@cust, double('Customer', email: 'owner@example.com'))
+      instance
+    end
+
+    it 'normalizes blank recipient locales and preserves set ones' do
+      captured   = capture_enqueued_payloads
+      recipients = [
+        { email: 'blank@example.com', locale: '' },
+        { email: 'spaces@example.com', locale: '   ' },
+        { email: 'missing@example.com', locale: nil },
+        { email: 'set@example.com', locale: 'de' },
+      ]
+
+      logic.send(:notify_members_deleted, recipients, 'Doomed Org')
+
+      expect(captured.map { |payload| payload[:locale] })
+        .to eq([OT.default_locale, OT.default_locale, OT.default_locale, 'de'])
+    end
+  end
+
+  describe 'Auth::Operations::DisableMfa#notify_customer' do
+    def enqueued_mfa_disabled_locale(customer)
+      captured  = capture_enqueued_payloads
+      operation = Auth::Operations::DisableMfa.allocate
+      operation.instance_variable_set(:@email, 'user@example.com')
+      operation.instance_variable_set(:@customer, customer)
+
+      operation.send(:notify_customer)
+
+      expect(captured.size).to eq(1),
+        "Expected exactly one :mfa_disabled email, got #{captured.size}"
+      captured.first[:locale]
+    end
+
+    it 'falls back to the default locale when the customer locale is blank' do
+      customer = double('Customer', locale: '')
+      expect(enqueued_mfa_disabled_locale(customer)).to eq(OT.default_locale)
+    end
+
+    it 'falls back to the default locale when the customer locale is whitespace-only' do
+      customer = double('Customer', locale: '   ')
+      expect(enqueued_mfa_disabled_locale(customer)).to eq(OT.default_locale)
+    end
+
+    it 'falls back to the default locale when the customer has no locale method' do
+      customer = double('AuthAccount')
+      expect(enqueued_mfa_disabled_locale(customer)).to eq(OT.default_locale)
+    end
+
+    it 'carries a set customer locale through to the payload' do
+      customer = double('Customer', locale: 'fr')
+      expect(enqueued_mfa_disabled_locale(customer)).to eq('fr')
+    end
+  end
+
+  describe 'Billing::Operations::WebhookHandlers::SubscriptionUpdated#notify_subscription_changed' do
+    def enqueued_subscription_changed_locale(owner)
+      captured = capture_enqueued_payloads
+      handler  = Billing::Operations::WebhookHandlers::SubscriptionUpdated.allocate
+      org      = double('Organization', owner: owner)
+
+      handler.send(:notify_subscription_changed, org, 'basic', 'premium')
+
+      expect(captured.size).to eq(1),
+        "Expected exactly one :subscription_changed email, got #{captured.size}"
+      captured.first[:locale]
+    end
+
+    it 'falls back to the default locale when the owner locale is blank' do
+      owner = double('Customer', email: 'owner@example.com', locale: '')
+      expect(enqueued_subscription_changed_locale(owner)).to eq(OT.default_locale)
+    end
+
+    it 'carries a set owner locale through to the payload' do
+      owner = double('Customer', email: 'owner@example.com', locale: 'fr')
+      expect(enqueued_subscription_changed_locale(owner)).to eq('fr')
+    end
+  end
+
+  describe 'V3::Logic::ReceiveFeedback#send_feedback' do
+    # Here `locale` comes from Logic::Base (request context / params), so a
+    # blank request locale ("") is the failure mode rather than a record load.
+    def enqueued_feedback_locale(request_locale)
+      captured = capture_enqueued_payloads
+      customer = double('Customer', anonymous?: false, email: 'user@example.com', extid: 'ur_user_extid')
+
+      logic = V3::Logic::ReceiveFeedback.allocate
+      logic.instance_variable_set(:@cust, customer)
+      logic.instance_variable_set(:@tz, 'UTC')
+      logic.instance_variable_set(:@version, '1.0.0')
+      logic.instance_variable_set(:@display_domain, 'onetime.example')
+      logic.instance_variable_set(:@domain_strategy, :canonical)
+      logic.instance_variable_set(:@locale, request_locale)
+
+      logic.send(:send_feedback, 'admin@example.com', customer, 'hello world')
+
+      expect(captured.size).to eq(1),
+        "Expected exactly one :feedback_email, got #{captured.size}"
+      captured.first[:locale]
+    end
+
+    it 'falls back to the default locale when the request locale is blank' do
+      expect(enqueued_feedback_locale('')).to eq(OT.default_locale)
+    end
+
+    it 'falls back to the default locale when the request locale is whitespace-only' do
+      expect(enqueued_feedback_locale('   ')).to eq(OT.default_locale)
+    end
+
+    it 'carries a set request locale through to the payload' do
+      expect(enqueued_feedback_locale('fr')).to eq('fr')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes `new_login_alert` (and MFA) emails being queued with an empty-string locale. The queueing path relied on `||` to fall back to a default locale, but an empty string `""` is truthy in Ruby, so it slipped through and produced alerts with no usable locale.

The fix normalizes locale resolution with `.to_s.strip.empty?` checks (project convention) at the login/MFA hooks and email worker. While in these files, the remaining `blank?`/`present?` ActiveSupport calls were swept out in favor of plain Ruby to keep the codebase AS-free.

## Changes

- Login/MFA hooks and email worker: treat empty/blank locale as absent, fall back to default
- Replace 21 residual `.blank?`/`.present?` calls with plain-Ruby equivalents across models and logic (8 files)

Closes #3812