### PR TITLE
Add custom mail sender provider docs

### DIFF
--- a/docs/specs/custom-mail-sender/custom-mail-sender-apex-plan.md
+++ b/docs/specs/custom-mail-sender/custom-mail-sender-apex-plan.md
@@ -1,0 +1,147 @@
+---
+title: Apex-Domain Sender Records - Integration Plan
+type: plan
+status: draft
+updated: 2026-07-18
+summary: Changes needed for sender-domain records that live on the customer's root/apex domain (MailChannels SPF include, Domain Lockdown TXT), including merge-aware SPF matching parity between the two DNS-checking layers.
+---
+
+Context: SES and Lettermint confine every customer-published record to dedicated
+subdomains (`<token>._domainkey`, `mail.`, `lm-bounces.`), so exact-match DNS
+checking works. MailChannels (see
+[`custom-mail-sender-mailchannels.md`](./custom-mail-sender-mailchannels.md))
+breaks that assumption: its SPF include lands **in the customer's root-domain
+SPF TXT record**, which customers must merge into any existing record, and its
+Domain Lockdown TXT sits at `_mailchannels.<domain>`. This plan covers what the
+onetimesecret integration points need to support records on the apex.
+
+## Current state (verified in code)
+
+The codebase has **two independent DNS-checking layers**, and they have already
+drifted on exactly the semantics apex SPF needs:
+
+1. **Validation layer** — `DomainValidation::SenderStrategies::BaseStrategy`
+   (`ValidateSenderDomain` → `DomainValidationWorker`). Already merge-aware:
+   `txt_record_matches?` routes `v=spf1` expectations to `spf_record_matches?`,
+   which extracts the `include:` directive and passes if any live `v=spf1` TXT
+   contains it, regardless of other mechanisms. Non-SPF TXT uses substring
+   match. **No change needed here for apex SPF.**
+2. **Fact-finding layer** — `Mail::SenderStrategies::BaseSenderStrategy#`
+   `check_single_dns_record` (`DnsRecordCheckWorker`, drives per-record
+   `dns_exists` / `value_matches` and ultimately `dns_verified`). Exact match
+   only: normalized string equality or SHA-256 digest equality. A customer with
+   `v=spf1 include:example.com include:relay.mailchannels.net ~all` would
+   **pass validation but fail the record check worker**.
+
+So "support apex domain" is mostly "make layer 2 agree with layer 1, and teach
+the UI about merge semantics" — plus registering the MailChannels strategy
+itself.
+
+## Work items
+
+### 1. Shared DNS record matcher (the core fix)
+
+Extract the matching logic from `BaseStrategy`
+(`record_matches?` / `txt_record_matches?` / `spf_record_matches?`) into a
+single module, e.g. `lib/onetime/utils/dns_record_matcher.rb`, and use it from
+both layers:
+
+- `BaseStrategy#record_matches?` delegates to the module (behavior unchanged).
+- `BaseSenderStrategy#check_single_dns_record` computes `value_matches` via the
+  module instead of digest/equality. Keep the digests in the result hash for
+  debugging — they are informational, not the match criterion.
+
+This removes the drift permanently instead of patching SPF awareness into a
+second copy. Regression risk is low: for subdomain records (CNAME/MX and DKIM
+TXT) the module's behavior is equality/substring, which is a strict superset of
+today's equality check (substring TXT matching also fixes quoted/split TXT
+edge cases).
+
+### 2. Explicit merge semantics on the record hash
+
+Today a stored record is `{type, name, value}` (+ `optional`, `status`). Add a
+`match` hint set at provisioning time:
+
+```ruby
+{ type: 'TXT', name: 'example.com',
+  value: 'v=spf1 include:relay.mailchannels.net ~all',
+  match: 'spf-include' }   # default absent = exact/substring per matcher rules
+```
+
+Rationale: the matcher currently *sniffs* `v=spf1` to decide semantics. That
+works, but an explicit flag (a) survives value-shape changes, (b) lets the UI
+distinguish "create this record" from "merge into your existing record", and
+(c) gives future apex records (e.g. a provider wanting `TXT @` verification
+tokens) a place to declare semantics. The matcher treats the flag as
+authoritative and falls back to sniffing when absent (backward compatible with
+already-provisioned configs, which never re-provision).
+
+Follows the `optional: true` precedent from the SES advisory DMARC record:
+workers and models already tolerate extra keys on record hashes, and
+`MailerConfig` stores them verbatim.
+
+### 3. UI: merge-record presentation
+
+`DomainEmailConfigForm.vue` (and the DNS-records display components) render
+records as copy-paste rows. Apex SPF needs different copy: "add
+`include:relay.mailchannels.net` to your existing SPF record; if you have none,
+create this record." Drive it off `match: 'spf-include'` the same way the
+dashed-border "Recommended" treatment is driven off `optional`. Also surface
+the *actual* current SPF record when the check fails (the verification result
+already carries `actual` values) so the customer sees what to edit rather than
+a bare mismatch.
+
+Secondary: apex TXT lookups return unrelated records (site-verification tokens
+etc.), so `actual` arrays get noisy — filter display to `v=spf1`-prefixed
+values for SPF-purpose records.
+
+### 4. MailChannels strategy registration (per the research doc)
+
+- `MailchannelsSenderStrategy` emitting the four records with the new flags:
+  lockdown TXT + DKIM TXT exact-match; apex SPF with `match: 'spf-include'`;
+  advisory DMARC with `optional: true`.
+- `MailchannelsValidation#classify_record_purpose`: `_mailchannels` →
+  `'Domain Lockdown'`, `_domainkey` → `'DKIM'`, `v=spf1` → `'SPF'`.
+- Registries: `PROVIDER_STRATEGIES`, `PROVISIONING_PROVIDERS`, validation
+  `Strategy` registry, `provider_credentials('mailchannels')`
+  (`api_key` + `account_id` + `base_url`), `email_providers.mailchannels` in
+  `config.defaults.yaml`, env plumbing (`MAILCHANNELS_API_KEY`,
+  `MAILCHANNELS_ACCOUNT_ID`, `CUSTOM_MAIL_PROVIDER=mailchannels`).
+- `Delivery::Mailchannels` backend gated on `EMAILER_MODE=mailchannels`
+  (clone of the Lettermint backend against the new gem).
+
+### 5. Non-issues (checked, no change needed)
+
+- **DNS cache**: keyed `dns:cache:<host>:<type>`; the apex TXT entry is shared
+  by any record on the apex — one lookup serves all, no collision.
+- **`resolve_domain` / `extract_domain`**: derive the domain from
+  `from_address`; apex records use that domain directly as `name`/`host`, no
+  subdomain assumption exists in the resolution path.
+- **Optional-record filtering**: `check_dns_records` / `computed_verification_status`
+  already exclude `optional: true` records; the advisory DMARC record behaves
+  exactly as it does for SES.
+
+## Sequencing
+
+1. Extract shared matcher + parity specs (pure refactor, ships alone; fixes
+   the existing SES-SPF drift for customers who merged provider includes —
+   worth doing even if MailChannels never ships).
+2. `match` flag support in matcher + strategies + model passthrough.
+3. UI merge-record treatment.
+4. MailChannels strategy/validation/delivery + registries + config (depends on
+   the `mailchannels` gem reaching a usable 0.1.0).
+5. Sandbox pass: answer the research doc's open questions (DKIM create
+   idempotency, `envelope_from` subdomain viability — if that pans out, the
+   apex SPF record could become a subdomain record and item 3's UI work shrinks
+   to nothing for MailChannels, but items 1-2 remain correct regardless).
+
+## Test surface
+
+- Matcher module: table-driven specs covering exact CNAME/MX, DKIM TXT,
+  SPF-include-within-merged-record, SPF-missing-include, multiple TXT at apex,
+  quoted/split TXT strings; parity assertion that both layers produce the same
+  verdict for identical inputs (the drift regression test).
+- Strategy: provision composes the four records with correct flags;
+  check_provider_verification_status maps partial `check-domain` verdicts;
+  teardown revoke is idempotent on 404.
+- Existing tryouts under `try/unit/` for sender strategies extend naturally.

--- a/docs/specs/custom-mail-sender/custom-mail-sender-cakemail.md
+++ b/docs/specs/custom-mail-sender/custom-mail-sender-cakemail.md
@@ -1,0 +1,232 @@
+---
+title: Cakemail Sender Domain Provider (Research)
+type: research
+status: draft
+updated: 2026-07-18
+summary: Implementation research for Cakemail (Montreal) as a custom sender domain provider — API surface, OAuth2 auth model, per-address sender confirmation, DKIM/bounce-domain provisioning, Ruby library plan, and the multi-tenancy question that decides feasibility.
+---
+
+Cakemail (Montreal, QC) evaluated as a sender-domain provider alongside SES,
+Lettermint, and MailChannels. Same lens as
+[`custom-mail-sender-mailchannels.md`](./custom-mail-sender-mailchannels.md):
+API surface, Ruby options, and fit against the sender strategy interface in
+[`custom-mail-sender.md`](./custom-mail-sender.md).
+
+**Bottom line:** the strongest Canadian-residency story of the providers
+reviewed (Canadian-owned, data on Canadian servers, CASL-native, EU adequacy),
+and the DKIM/DNS lifecycle maps well onto our strategy interface. But two
+structural mismatches make it a harder integration than MailChannels: **OAuth2
+password-grant auth** (expiring tokens, no static API keys) and **per-address
+sender confirmation by emailed token** (a human at the customer's from-address
+must click a link — DNS alone cannot complete provisioning). A third question —
+whether bounce-domain SPF alignment is account-scoped rather than
+domain-scoped — likely pushes a serious integration toward their Partner API
+with one sub-account per customer. No Ruby SDK exists; we'd build our own.
+
+## 1. Platform and API overview
+
+| | Value |
+|---|---|
+| Base URL | `https://api.cakemail.dev` |
+| Auth | OAuth2 password grant: `POST /token` (`grant_type=password&username&password`) → `access_token` (expires_in 432000 = 5 days) + `refresh_token`; then `Authorization: Bearer` |
+| Spec | OpenAPI at `https://api.cakemail.dev/openapi.json` (indexed on Context7) |
+| Scopes | `senders:read/write`, `dkim:read/write/delete`, `domains:read/write`, `emailapi:send`, `suppressions:*`, ... |
+| Official SDKs | TypeScript (`cakemail-sdk`), CLI, MCP servers (`exec.mcp.cakemail.com`); PHP client archived; **no Ruby** |
+| Multi-tenant | `account_id` query param on every endpoint (Partner API delegation); sub-accounts via Partner API |
+| SMTP alternative | `smtp.cakemail.dev:465` (SMTPS, username/password), `x-email-api-enabled: true` header routing |
+| Send docs | dev.cakemail.com — Email API guides (REST + SMTP) |
+
+Two product generations coexist: the "Cakemail API" (campaigns/lists/contacts)
+and the "Email API" (`/v2/emails`) for individual transactional/marketing
+sends. We would use the Email API for delivery and the brand-level
+`senders` / `dkim` / `domains` resources for identity provisioning.
+
+### Sending model (`POST /v2/emails`)
+
+```json
+{
+  "sender": { "id": "<sender_id>", "name": "Optional Override" },
+  "email": "recipient@example.net",
+  "content": {
+    "type": "transactional",
+    "subject": "…",
+    "html": "…", "text": "…",
+    "encoding": "utf-8"
+  },
+  "additional_headers": [{ "name": "X-...", "value": "..." }],
+  "tracking": { "opens": false, "clicks_html": false }
+}
+```
+
+Notable constraints, all different from SES/Lettermint/MailChannels:
+
+- **`sender.id`, not a from-address.** The from identity is a reference to a
+  pre-registered, confirmed sender object. The delivery backend needs a
+  from_address → sender_id lookup (provision-time storage or list-and-match).
+- **One recipient per call** (transactional). No personalizations/batch. CC/BCC
+  are disallowed as custom headers; no cc/bcc fields on transactional sends.
+- **Attachment types are whitelisted** (csv, doc(x), calendar, jpeg, pdf, png,
+  xls(x)) — not arbitrary MIME types.
+- Transactional + raw `email` needs no list; `marketing` type always requires
+  `list_id`. Reply-to: per-template only in what the spec surfaced — confirm
+  whether `/v2/emails` accepts reply_to (open question; `additional_headers`
+  forbids cc/bcc but Reply-To may be allowed there).
+- Response: `201` with `data.id` (UUID) + `status` (`queued|rejected|error`);
+  lifecycle tracked via `GET /v2/emails/:id`, logs at `/v2/logs/emails`,
+  reports at `/v2/reports/emails`. Statuses include delivered/open/click/
+  bounce/spam/unsubscribe — polling-based feedback (webhooks exist in the
+  platform; whether they cover `/v2/emails` events is an open question).
+- Errors are FastAPI-shaped: `{"detail": [{"loc": [...], "msg": "...",
+  "type": "..."}]}` on 400/422/500 — a third error-parsing dialect for the gem.
+
+## 2. Sender identity and DNS model
+
+Three separate mechanisms, each with its own lifecycle:
+
+### 2.1 Sender confirmation (per address — the mismatch)
+
+`POST /brands/default/senders` `{name, email, language}` registers a sender
+identity and **sends a confirmation email to that address**. The sender is
+unusable until someone clicks the link (or we call
+`POST /brands/default/senders/confirm-email` with the `confirmation_id` from
+that email). `GET /brands/default/senders` lists senders with `confirmed`
+status; `resend-confirmation-email` re-triggers.
+
+This is the structural conflict with our flow: our customer decision surface is
+"flip on custom sender, add DNS records." Cakemail additionally requires the
+customer's from-address inbox to receive and act on a confirmation email at
+provision time. DNS checks cannot substitute. Integration would need a new
+UI/state: "confirmation email sent to noreply@customer.com — click the link,
+then re-verify" — including the failure mode where `noreply@` doesn't receive
+mail at all (common for send-only addresses). `MailerConfig` would need a
+provider-verification substate (`sender_pending_confirmation`) distinct from
+DNS-pending.
+
+### 2.2 DKIM keys (per domain — clean fit)
+
+- `POST /brands/default/dkim` `{domain, selector}` → key `id`, `selector`,
+  `public_key` (customer publishes `<selector>._domainkey.<domain>` TXT; we
+  compose the `v=DKIM1; k=rsa; p=<public_key>` value — confirm exact expected
+  value shape in sandbox).
+- `POST /brands/default/dkim/{id}/activate` — **server-side live DNS check**;
+  refuses if the TXT is missing or mismatched. This doubles as the provider
+  verification call: attempt activate, interpret refusal as "pending."
+- `GET /brands/default/dkim` lists keys (`status: active|inactive`,
+  `account_default`, `domain_default`); `DELETE /brands/default/dkim/{id}` for
+  teardown (a real DELETE — unlike MailChannels' status-patch).
+
+### 2.3 Bounce/tracking domains (SPF alignment — the scoping question)
+
+`GET/PATCH /brands/default/domains/default` shows/sets the account's `auth`,
+`bounce`, `dkim`, `tracking` domains; `GET /brands/default/domains/default/validate`
+returns the exact DNS entries with per-entry `valid` booleans — i.e. the
+provider tells us the records and checks them, which slots directly into our
+"store provisioned records verbatim, validate later" pattern.
+
+A custom bounce domain (e.g. `bounce.customer.com`) is Cakemail's SPF-alignment
+mechanism — the analogue of SES custom MAIL FROM and Lettermint's `lm-bounces`
+CNAME. But the resource path is `brands/default/domains/default`: it looks
+**account/brand-scoped, one bounce domain per account**, not per sending
+domain. If so, a single platform account cannot give each customer domain its
+own aligned envelope — SPF alignment would only work for one domain, and
+everyone else rides Cakemail's shared envelope (DKIM-only DMARC, like SES
+without MAIL FROM). Third-party SPF guides are contradictory (some show a
+root-domain include, some show `bounce.<domain>` records against `md02.com`)
+— treat the `validate` endpoint's output as the only source of truth.
+
+**Consequence:** a multi-customer deployment probably requires the **Partner
+API** — one sub-account per customer org (`account_id` param threads through
+every endpoint), each with its own senders, DKIM keys, and bounce domain. That
+is a bigger architectural step than any other provider needed:
+`provider_credentials` would gain per-customer account context, and
+provisioning would begin with ensure-sub-account. Cakemail is explicitly
+partner/agency-oriented, so this is their intended shape — but it must be
+priced/confirmed with them before committing.
+
+## 3. Ruby library: build our own (again)
+
+RubyGems has nothing for Cakemail's next-gen API. Official SDKs are
+TypeScript/CLI/MCP; the PHP client is archived. A `cakemail` gem following the
+lettermint/mailchannels structure works, with two deviations:
+
+1. **TokenManager instead of a static header.** `POST /token` password grant,
+   cache `access_token` with expiry, refresh via `refresh_token` (fall back to
+   re-auth on refresh failure), thread-safe (mutex around refresh), and retry
+   401s once after refresh. Credentials are the account's email + password (or
+   a dedicated API user) — flag: store like any secret, but note there is no
+   scoped/static key to rotate independently (an operational downside vs every
+   other provider we run).
+2. **FastAPI error mapping.** `{"detail": [{loc, msg, type}]}` → message
+   joining `loc.join('.')`+`msg`; 422 ValidationError (Cakemail uses 422 like
+   Lettermint, unlike MailChannels), 400 ClientError, 401 AuthenticationError
+   (trigger token refresh path), 403 scope error, 5xx ServerError.
+
+Resources for v1: `token` (internal), `senders` (create/list/confirm/resend/
+delete), `dkim` (create/list/activate/delete), `domains` (show/patch/validate),
+`emails` (`POST /v2/emails`, `GET /v2/emails/:id`) with an EmailMessage-style
+builder constrained to single recipient; `account_id:` kwarg on every resource
+call for Partner mode. Same gemspec/tooling/CI as mailchannels-ruby.
+
+## 4. Strategy mapping (if pursued)
+
+| Interface method | Cakemail calls |
+|---|---|
+| `provision_dns_records` | ensure sub-account (Partner mode) → `senders.create(from_address)` (triggers confirmation email) → `dkim.create(domain, selector)` → optionally `domains.patch(bounce: "bounce.<domain>")` → compose records: DKIM TXT + bounce/tracking entries from `domains.validate` (+ advisory DMARC). Store sender_id and dkim key id as `identity_id`/`provider_data`. |
+| `check_provider_verification_status` | `senders.list` → confirmed? + `dkim.activate(id)` attempt (or key status) + `domains.validate` per-entry `valid`. Verified = sender confirmed AND dkim active AND bounce entries valid. New substate: `sender_pending_confirmation`. |
+| `delete_sender_identity` | `dkim.delete(id)` + sender deletion (+ sub-account teardown in Partner mode). Idempotent on 404s. |
+| Delivery backend | `POST /v2/emails` with cached sender_id; classify errors (422/400 fatal, 401 → token refresh once, 429/5xx transient); single-recipient loop for multi-recipient templates. |
+
+DNS-validation strategy: all records come back from the provider
+(`public_key`, `validate` entries) — store verbatim, standard `Array<Hash>`
+normalization, no apex-SPF merge semantics needed *unless* the validate
+entries turn out to be root-domain SPF includes (see open questions; if so,
+the [apex plan](./custom-mail-sender-apex-plan.md) machinery covers it).
+
+## 5. Provider comparison (Canada lens)
+
+| | MailChannels | Cakemail |
+|---|---|---|
+| HQ | Vancouver, BC | Montreal, QC |
+| Residency claim | Canadian-owned; **no published regional processing guarantee** | Canadian servers, CASL-native, EU adequacy documented in privacy policy — strongest claim of the set |
+| Auth | static `X-Api-Key` | OAuth2 password grant, 5-day tokens + refresh |
+| Sender identity | DNS-only (Domain Lockdown TXT) | **per-address email confirmation** + DNS |
+| DKIM | managed keys, TXT, rotate API | managed keys, TXT, activate-with-DNS-check, DELETE |
+| SPF alignment | apex include (merge) or envelope_from subdomain | custom bounce domain — possibly **account-scoped** (Partner API per customer) |
+| Provider verify | `POST /check-domain` (one call, all verdicts) | assemble from senders.list + dkim activate + domains.validate |
+| Send API | personalizations, batch, 30 MB | single recipient, attachment-type whitelist |
+| Feedback | webhooks (signed) | status polling on `/v2/emails/:id` + logs; webhook coverage TBD |
+| Fit with current architecture | drop-in after apex work | needs confirmation-substate + likely Partner API |
+
+## 6. Open questions before committing
+
+1. **Bounce-domain scoping** — is `brands/default/domains/default` truly one
+   bounce domain per (sub-)account? If yes, Partner API sub-accounts are a
+   prerequisite for per-customer SPF alignment. Ask Cakemail directly; get
+   Partner terms and pricing.
+2. **Sender confirmation bypass** — for Partner accounts, can sender
+   confirmation be waived or completed programmatically (we control the
+   `confirmation_id` email only if we can receive at the customer's address —
+   we can't)? If not, the confirmation-click step is a permanent part of the
+   customer UX.
+3. **SPF record shape** — exact entries from `domains.validate` for a custom
+   bounce domain (CNAME vs MX+TXT vs root include). Third-party guides
+   disagree; sandbox it.
+4. **`/v2/emails` reply_to** and whether Reply-To is settable via
+   `additional_headers`.
+5. **Webhooks for Email API events** (delivered/bounce/spam) vs polling only.
+6. **DKIM TXT value shape** — raw `public_key` vs full `v=DKIM1; k=rsa; p=…`
+   string; and idempotency of `dkim.create` for an existing domain+selector.
+7. **Rate limits** and token-endpoint limits (password grant per worker
+   process could hit them; TokenManager should share tokens via Redis).
+8. **API user hygiene** — password-grant credentials are login credentials;
+   confirm a service-user with restricted scopes is possible.
+
+## References
+
+- Developer portal: https://dev.cakemail.com/en
+- Getting started (OAuth2): https://dev.cakemail.com/en/guides/getting-started
+- Email API reference (endpoints, SMTP): https://dev.cakemail.com/en/guides/email-api-reference
+- OpenAPI spec: https://api.cakemail.dev/openapi.json (Context7: `/openapi/api_cakemail_dev_openapi_json`)
+- GitHub org (SDK inventory): https://github.com/cakemail
+- Canadian residency claims: https://www.cakemail.com/solutions/email-marketing-for-canadian-businesses, https://www.cakemail.com/legal/privacy-policy
+- Domain auth support article: https://support.cakemail.com/hc/en-us/articles/360056294574

--- a/docs/specs/custom-mail-sender/custom-mail-sender-mailchannels.md
+++ b/docs/specs/custom-mail-sender/custom-mail-sender-mailchannels.md
@@ -1,0 +1,361 @@
+---
+title: MailChannels Sender Domain Provider (Research)
+type: research
+status: draft
+updated: 2026-07-18
+summary: Implementation research for adding MailChannels as a custom sender domain provider — API surface, Ruby library plan (self-maintained, modeled on our Lettermint gem), and integration into the sender strategy / DNS validation pipeline.
+---
+
+MailChannels (Vancouver, BC — the "Canada mail" provider) as a third sender-domain
+provider alongside AWS SES and Lettermint. This doc collates everything needed to
+(a) build a Ruby client library and (b) wire it into the custom sender domain
+provisioning/validation flow described in
+[`custom-mail-sender.md`](./custom-mail-sender.md).
+
+**Bottom line:** there is no usable Ruby library — we build our own, modeled on
+our Lettermint gem. The API maps cleanly onto the `BaseSenderStrategy` interface,
+with one structural difference that affects DNS validation: MailChannels has **no
+domain resource to provision**. Provisioning is "create a managed DKIM key +
+compose two TXT records ourselves," and the SPF record lands on the customer's
+**root domain**, which forces merge-aware SPF validation instead of exact-match.
+
+## 1. MailChannels Email API overview
+
+Single REST API, single auth scheme — no Lettermint-style Sending/Team API split.
+
+| | Value |
+|---|---|
+| Base URL | `https://api.mailchannels.net/tx/v1` |
+| Auth | `X-Api-Key: <key>` header on every request (created in Console → Settings → API Keys, `api` scope) |
+| Spec | OpenAPI 3.0, v1.4.0: `https://docs.mailchannels.com/email-api/api-reference/openapi.yaml` |
+| Docs index | `https://docs.mailchannels.com/llms.txt` (LLM-friendly, every page available as `.md`) |
+| Official SDKs | Node (`mailchannels-sdk`), Python (`mailchannels`), PHP — **no Ruby** |
+| Max message size | 30 MB including attachments |
+
+Endpoints relevant to us:
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /send` (and `?dry-run=true`) | Send email; dry-run returns rendered message without sending |
+| `POST /send-async` | Queue send, returns request ID immediately |
+| `POST /domains/{domain}/dkim-keys` | Create MailChannels-managed DKIM key pair; returns public key + DNS TXT record |
+| `GET /domains/{domain}/dkim-keys` | Retrieve keys by domain, optional `selector` filter |
+| `PATCH /domains/{domain}/dkim-keys/{selector}` | Update key status: `revoked` / `retired` / `rotated` |
+| `POST /domains/{domain}/dkim-keys/{selector}/rotate` | Rotate: old key `rotated` (3-day signing grace, auto-`retired` at 2 weeks), new key created |
+| `POST /check-domain` | Provider-side verification: DKIM + SPF + Domain Lockdown + sender-domain MX/A verdicts |
+| Webhooks (`/webhook` group) | Enroll endpoint, event types (delivered, hard/soft-bounced, complained, unsubscribed), signing-key retrieval, batch resend |
+| Sub-accounts, suppressions, metrics, usage | Not needed for v1; sub-accounts noteworthy for future tenant isolation (100K+ plans only) |
+
+### Sending model
+
+`POST /send` body (SendGrid-style):
+
+```json
+{
+  "personalizations": [{ "to": [{ "email": "r@example.net" }] }],
+  "from": { "email": "noreply@customer.com", "name": "Customer" },
+  "reply_to": { "email": "support@customer.com" },
+  "subject": "…",
+  "content": [
+    { "type": "text/plain", "value": "…" },
+    { "type": "text/html", "value": "…" }
+  ]
+}
+```
+
+Returns `202` with `request_id` and per-personalization `results[]` (`message_id`,
+`status: sent|failed`, `reason`). `400/403/413/500/502` carry `{ "errors": [...] }`.
+Optional fields we care about: `dkim_selector` (choose which managed key signs;
+if only one active key exists, signing is automatic), `envelope_from` (override
+envelope sender — see §3.3), `headers`, `campaign_id`, `transactional` (default
+true — keep it true; non-transactional adds List-Unsubscribe handling).
+Mustache templates via `content[].template_type: "mustache"` +
+`personalizations[].dynamic_template_data`.
+
+### Sender identity model (replaces "domain provisioning")
+
+Three DNS-visible mechanisms, per sending domain:
+
+1. **Domain Lockdown** (MailChannels-proprietary, required): TXT at
+   `_mailchannels.<domain>` binding the domain to our account:
+   `v=mc1 auth=<our_account_handle>`. Multiple `auth=`/`senderid=`/`sidw=`
+   fields allowed; message passes if any field matches. `senderid=` pins an exact
+   sender identity (`<account>|x-authsender|<email>`, visible in the
+   `X-MailChannels-SenderId` header); `sidw=` is the same with one `*` wildcard
+   in the sender part. Since we are the platform account and the customer's
+   domain should only send via us, plain `auth=<our_handle>` is correct and
+   simplest. Account handle is shown in the MailChannels dashboard footer.
+2. **DKIM**: bring-your-own keys (pass `dkim_domain`/`dkim_selector`/
+   `dkim_private_key` per send) **or MailChannels-managed keys** via the
+   dkim-keys API. Managed is the right choice — no private key custody on our
+   side. `POST /domains/{domain}/dkim-keys` with
+   `{ "selector": "mc1", "algorithm": "rsa", "key_length": 2048 }` returns:
+
+   ```json
+   {
+     "domain": "customer.com", "selector": "mc1", "status": "active",
+     "public_key": "MIIBIjANBg…",
+     "dkim_dns_records": [
+       { "name": "mc1._domainkey.customer.com", "type": "TXT",
+         "value": "v=DKIM1; k=rsa; p=MIIBIjANBg…" }
+     ]
+   }
+   ```
+
+   Note: **TXT record with inline public key**, not a CNAME delegation like
+   SES/Lettermint. Rotation therefore requires the customer to update DNS
+   (managed-rotation flow exists; see endpoint table).
+3. **SPF**: add `include:relay.mailchannels.net` to the sending domain's SPF
+   TXT. New record: `v=spf1 include:relay.mailchannels.net ~all`; existing
+   record: append the include. MailChannels does not pre-check SPF/DKIM/DMARC at
+   send time — mail is accepted regardless, deliverability is on us.
+
+Additionally, the sender domain must have **an MX or A record** (their SDNF —
+"Sender Domain Not Found" — block). Nearly always already true for a real
+customer domain; `check-domain` reports it.
+
+### Provider-side verification: `POST /check-domain`
+
+Request `{ "domain": "customer.com" }` (optional `dkim_settings[]` for BYO keys —
+omit and it uses all stored managed keys; optional `sender_id` only if using
+`senderid=` lockdown). Response:
+
+```json
+{
+  "check_results": {
+    "dkim": [{ "dkim_domain": "…", "dkim_selector": "mc1",
+                "dkim_key_status": "active", "verdict": "passed", "reason": "…" }],
+    "spf": { "verdict": "passed", "spfRecord": "v=spf1 …", "reason": "…" },
+    "domain_lockdown": { "verdict": "passed", "reason": "…" },
+    "sender_domain": { "verdict": "passed", "a": {…}, "mx": {…} }
+  },
+  "references": ["…docs links when something failed…"]
+}
+```
+
+DKIM/lockdown/sender-domain verdicts are `passed|failed`; SPF has the full SPF
+result range (`passed`, `failed`, `soft failed`, `neutral`, `none`, `temporary
+error`, `permanent error`, `unknown`). This endpoint is the direct analogue of
+Lettermint's `GET /domains/:id` + `verify` trigger and SES `GetEmailIdentity`,
+with the bonus that it re-evaluates live DNS on each call (no separate "trigger
+re-check" step needed).
+
+## 2. Ruby library: build our own
+
+RubyGems has exactly one hit for "mailchannels": `mailchannels-worker-rails`
+0.1.3 (~2.5K downloads, ActionMailer adapter for the **discontinued** Cloudflare
+Workers integration — lockdown-by-`cfid` died Aug 2024). Nothing targets the
+current Email API. MailChannels ships official Node/Python/PHP SDKs only. So we
+go the Lettermint route: a small Faraday-based gem we maintain.
+
+### Proposed gem: `mailchannels-ruby` (require `mailchannels`)
+
+Mirror the lettermint gem's architecture one-for-one, minus the dual-client
+split (MailChannels has one API and one auth header, so a single
+`MailChannels::Client` plays both roles that `Lettermint::Client` +
+`Lettermint::TeamAPI` play):
+
+```ruby
+client = MailChannels::Client.new(
+  api_key: 'key',                                   # → X-Api-Key header
+  base_url: 'https://api.mailchannels.net/tx/v1',   # default
+  timeout: 30,                                      # default
+)
+```
+
+Resources (v1 scope — what the integration actually calls):
+
+```ruby
+# Sending — keep the builder DSL so Delivery::MailChannels reads like
+# Delivery::Lettermint:
+client.email
+  .from('noreply@customer.com', name: 'Customer')
+  .to('r@example.net')
+  .reply_to('support@customer.com')
+  .subject('…')
+  .text('…')
+  .html('…')
+  .deliver                     # POST /send → SendResults
+# also: .deliver_async (POST /send-async), .dry_run (POST /send?dry-run=true),
+# .dkim_selector('mc1'), .envelope_from('bounces@…'), .header(k, v)
+
+# DKIM keys (the "provisioning" surface):
+client.dkim_keys.create('customer.com', selector: 'mc1', algorithm: 'rsa', key_length: 2048)
+client.dkim_keys.list('customer.com', selector: 'mc1')   # GET, optional filter
+client.dkim_keys.update_status('customer.com', 'mc1', status: 'revoked')
+client.dkim_keys.rotate('customer.com', 'mc1', new_selector: 'mc2')
+
+# Verification:
+client.check_domain('customer.com')                       # POST /check-domain
+
+# v1.1 (feedback loop parity with lib/onetime/mail/feedback/):
+client.webhooks.enroll(url)/list/delete/signing_key/batches
+```
+
+Error hierarchy — identical names to the lettermint gem so both
+`Delivery#classify_error` and the sender strategy rescue blocks translate
+mechanically:
+
+```
+MailChannels::Error
+├── MailChannels::TimeoutError                  # Faraday timeout
+├── MailChannels::ClientError                   # bad input, pre-request
+└── MailChannels::HttpRequestError              # status_code, response_body, error_type
+    ├── MailChannels::ValidationError           # 400  ({"errors": [...]} parsed into message)
+    ├── MailChannels::AuthenticationError       # 401/403 (403 doubles as "feature not on plan")
+    ├── MailChannels::RateLimitError            # 429
+    └── MailChannels::ServerError               # 5xx (500/502 documented)
+```
+
+Retry/idempotency notes: 429 semantics and DKIM-create-on-existing-selector
+behavior (409? 400? success-with-existing?) are **not documented** — pin both
+down with a sandbox key during gem development and encode the answer in the gem
+(the same way the lettermint gem documents its "Domain has already been added"
+ValidationError quirk). Error payload shape is uniform (`{"errors": ["…"]}`),
+simpler than Lettermint's three shapes.
+
+Gemspec skeleton: `faraday ~> 2.0` as sole runtime dep, same dev tooling as the
+lettermint gem, MFA required, Ruby ≥ 3.0.
+
+## 3. Integration into the custom sender domain flow
+
+App-side, this is a fourth entry in the existing strategy registries. Consumed
+config: `email_providers.mailchannels.{api_key, account_id, base_url}` via
+`Mailer.provider_credentials('mailchannels')`; env
+`CUSTOM_MAIL_PROVIDER=mailchannels`, `MAILCHANNELS_API_KEY`,
+`MAILCHANNELS_ACCOUNT_ID`. **`account_id` (the account handle) is required
+platform config** — unlike SES/Lettermint, the provider API does not hand us the
+lockdown record; we compose it from the handle.
+
+### 3.1 Files
+
+| File | Contents |
+|---|---|
+| `Gemfile` | `gem 'mailchannels', require: false` (lazy-loaded like lettermint) |
+| `lib/onetime/mail/sender_strategies/mailchannels_sender_strategy.rb` | provision / provider-verify / teardown (below) |
+| `lib/onetime/mail/sender_strategies.rb` | add to `PROVIDER_STRATEGIES` and `PROVISIONING_PROVIDERS` |
+| `lib/onetime/domain_validation/sender_strategies/mailchannels_validation.rb` | DNS-level validation; reads `mailer_config.dns_records` like `LettermintValidation` |
+| `lib/onetime/domain_validation/sender_strategies/strategy.rb` | register validation strategy |
+| `lib/onetime/mail/delivery/mailchannels.rb` | delivery backend (only when `EMAILER_MODE=mailchannels`) |
+| `lib/onetime/domain_validation/sender_strategies/provider_config.rb` | `email_providers.mailchannels` config |
+| `etc/defaults/config.defaults.yaml`, `.env.reference` | config + env plumbing |
+
+### 3.2 Strategy mapping
+
+**`provision_dns_records(mailer_config, credentials:)`**
+
+1. Extract domain from `from_address` (inherited helper).
+2. `client.dkim_keys.create(domain, selector: 'mc1')` — idempotent wrapper: on
+   "already exists," fall back to `client.dkim_keys.list(domain, selector:
+   'mc1')` (mirrors `create_or_get_domain` in the Lettermint strategy).
+3. Compose and normalize the record set (standard `Array<Hash>` shape,
+   `type`/`name`/`value`):
+
+```
+_mailchannels.<domain>       TXT  v=mc1 auth=<account_id>            (required — Domain Lockdown)
+mc1._domainkey.<domain>      TXT  v=DKIM1; k=rsa; p=<public_key>     (required — from dkim_dns_records)
+<domain>                     TXT  v=spf1 include:relay.mailchannels.net ~all   (required — see §3.3)
+_dmarc.<domain>              TXT  v=DMARC1; p=none;                  (optional: true — advisory, same as SES)
+```
+
+`identity_id` → selector (or `<domain>/mc1`); `provider_data` → key status,
+algorithm, created_at, account_id used.
+
+**`check_provider_verification_status(mailer_config, credentials:)`**
+
+One call: `client.check_domain(domain)`. `verified = dkim.all?(passed) &&
+spf.verdict == 'passed' && domain_lockdown.verdict == 'passed' &&
+sender_domain.verdict == 'passed'`. Map partial passes to
+`'pending'`-style statuses with the per-check `reason` strings in `:details`
+(they're human-readable and good enough to surface directly). No pre-trigger
+call needed — unlike Lettermint, `check-domain` evaluates live DNS.
+
+**`delete_sender_identity(mailer_config, credentials:)`**
+
+`client.dkim_keys.update_status(domain, selector, status: 'revoked')` — there is
+no domain object and no lockdown-record API to delete; the customer removes the
+TXT records themselves (the UI already shows required records; removal guidance
+belongs in the teardown message). 404 → already-deleted (idempotent, same as SES
+/ Lettermint).
+
+**`Delivery::MailChannels`** — clone of `Delivery::Lettermint` with the same
+builder chain, `classify_error` (TimeoutError/429/5xx transient;
+ValidationError/ClientError/4xx fatal), Sentry context tagged
+`provider: 'mailchannels'`.
+
+### 3.3 The one real integration wrinkle: SPF on the root domain
+
+SES and Lettermint both confine SPF alignment to a dedicated subdomain
+(`mail.<domain>` MX+TXT, `lm-bounces.<domain>` CNAME). MailChannels' documented
+setup puts `include:relay.mailchannels.net` **in the customer's root-domain SPF
+record**, because the envelope sender defaults to the from address itself.
+Consequences:
+
+1. Customers with an existing SPF record must **merge**, not add — two SPF
+   records on one name is an SPF permerror. The UI copy for this record needs
+   "add this include to your existing record" treatment, unlike every other
+   record we show.
+2. `ValidateSenderDomain` DNS checking cannot exact-match this TXT. The
+   MailChannels validation strategy needs a per-record match mode: for the SPF
+   record, pass if the domain's TXT set contains an SPF record whose mechanisms
+   include `include:relay.mailchannels.net` (the `check-domain` endpoint's
+   `spf.verdict` can serve as the authoritative tiebreaker). `classify_record_purpose`:
+   `_mailchannels` → `'Domain Lockdown'`, `_domainkey` → `'DKIM'`, `v=spf1` → `'SPF'`.
+3. DMARC posture: DKIM passes and aligns strictly (key is on the customer's
+   domain), so DMARC passes via DKIM regardless. SPF passes via the include and
+   aligns when the envelope stays on the from domain. That is equivalent to the
+   SES-with-MAIL-FROM column of the alignment table in
+   [`custom-mail-sender-ses.md`](./custom-mail-sender-ses.md) — but with the
+   include on the root record.
+
+**Possible subdomain alternative** (unverified): the send API accepts
+`envelope_from`. Setting it to e.g. `bounces.<domain>` and publishing the SPF
+TXT there instead would replicate the SES `mail.<domain>` pattern and leave the
+customer's root SPF untouched — relaxed alignment still holds. Unknowns: whether
+MailChannels applies SDNF (MX/A required) to that envelope subdomain, and where
+bounces then land. Worth a support ticket / sandbox test before choosing;
+default plan is the documented root-domain include.
+
+### 3.4 Provider comparison (extends the table in custom-mail-sender.md)
+
+| | AWS SES | Lettermint | MailChannels |
+|---|---|---|---|
+| Provision API | `CreateEmailIdentity` + MAIL FROM attrs | Team API `POST /domains` | `POST /domains/{d}/dkim-keys` + self-composed lockdown/SPF TXT |
+| Domain resource at provider | identity | domain object | **none** (keys only) |
+| DKIM records | 3 CNAMEs | CNAME selectors | **1 TXT** (inline public key, managed keypair) |
+| SPF / envelope | MX + SPF TXT on `mail.<domain>` | Return-Path CNAME `lm-bounces.<domain>` | `include:relay.mailchannels.net` in **root** SPF (merge!) |
+| Anti-spoofing | — (implicit in identity) | — | Domain Lockdown TXT `_mailchannels.<domain>` |
+| Verification | `GetEmailIdentity` | `GET /domains/:id` + verify trigger | `POST /check-domain` (live, no trigger) |
+| Teardown | `DeleteEmailIdentity` | `DELETE /domains/:id` | `PATCH dkim-keys status=revoked` |
+| Auth | AWS SigV4 (SDK) | dual token (Bearer team / x-lettermint-token send) | single `X-Api-Key` |
+| Ruby SDK | official `aws-sdk-sesv2` | ours (`lettermint`) | **ours (to build)** |
+
+### 3.5 Open questions before implementation
+
+1. **DKIM create idempotency** — response for an existing domain+selector
+   (informs `create_or_get` in both gem and strategy). Sandbox test.
+2. **`envelope_from` subdomain viability** (§3.3) — SDNF applicability, bounce
+   routing. Support ticket.
+3. **Rate limits** — undocumented; confirm 429 shape for `RateLimitError`.
+4. **Data residency** — MailChannels is Canadian-owned (Vancouver), but no
+   published regional processing guarantee equivalent to SES `ca-central-1`. If
+   the Canada angle is a compliance claim rather than a vendor-locality
+   preference, get it in writing from them before advertising it.
+5. **Plan gating** — `check-domain` documents a 403 "no access to this feature";
+   confirm our plan tier includes it (and webhooks + open/click tracking if
+   wanted later).
+6. **Webhook ingestion** (v1.1) — event types map well onto
+   `lib/onetime/mail/feedback/`; signing-key verification endpoint exists.
+   Scope into the feedback-sync work, not the sender-domain work.
+
+## References
+
+- Email API overview: https://docs.mailchannels.com/email-api/overview
+- Authentication: https://docs.mailchannels.com/email-api/authentication
+- Domain Lockdown: https://docs.mailchannels.com/email-api/domain-lockdown
+- DKIM management: https://docs.mailchannels.com/email-api/configuring-dkim
+- SPF/DKIM/DMARC: https://docs.mailchannels.com/email-api/spf-dkim-dmarc
+- check-domain reference: https://docs.mailchannels.com/api-reference/dkim/dkim-spf-&-domain-lockdown-check
+- Send reference: https://docs.mailchannels.com/api-reference/send/send-an-email
+- OpenAPI spec: https://docs.mailchannels.com/email-api/api-reference/openapi.yaml
+- Docs index (all pages as .md): https://docs.mailchannels.com/llms.txt

--- a/docs/specs/custom-mail-sender/custom-mail-sender-sendgrid.md
+++ b/docs/specs/custom-mail-sender/custom-mail-sender-sendgrid.md
@@ -1,0 +1,230 @@
+---
+title: SendGrid Sender Domain Provider
+type: reference
+status: supported
+updated: 2026-07-18
+summary: Configuring Twilio SendGrid as the provider for the domain-level custom sender flow (Domain Authentication with automatic_security CNAMEs, provider-side validation, teardown), including credential resolution and current limitations.
+---
+
+Twilio SendGrid is a supported provider for the **domain-level custom sender
+flow**: when an organization enables a custom sender identity on one of its
+custom domains, the platform calls SendGrid's Domain Authentication API
+(historically "whitelabel") on the organization's behalf, returns the CNAME
+records the customer must add at their registrar, verifies those records, and
+tears the domain authentication down when the sender config is removed.
+
+This document covers the SendGrid-specific configuration. For the
+provider-agnostic design (the three layers, who picks the provider, how
+credentials flow), see [`custom-mail-sender.md`](./custom-mail-sender.md).
+Siblings: [AWS SES](./custom-mail-sender-ses.md) (supported),
+[MailChannels](./custom-mail-sender-mailchannels.md) (research).
+
+## Scope
+
+SendGrid here is the **sender-domain provisioning provider**, selected once per
+installation. It is not a per-customer choice — the operator configures the
+provider, and the customer's only decision is "do I want emails from my domain
+to use my from-address/reply-to?" (see *Customer Decision Surface* in the
+architecture overview).
+
+The work this provider enables is the **domain-level lifecycle**:
+
+```
+enable custom sender → create domain authentication → show 3 CNAMEs
+                     → customer adds DNS → validate → (later) delete
+```
+
+## Selecting SendGrid
+
+```bash
+CUSTOM_MAIL_PROVIDER=sendgrid
+```
+
+As with SES, `CUSTOM_MAIL_PROVIDER` (config: `emailer.sender_provider`)
+decouples *domain provisioning* from the *sending transport* (`EMAILER_MODE`).
+You can run SMTP for outbound delivery while provisioning sender domains
+through SendGrid. If `CUSTOM_MAIL_PROVIDER` is unset, the provisioning provider
+falls back to `EMAILER_MODE`.
+
+## Credentials
+
+Everything — provision, validate, delete, and (when SendGrid is also the
+transport) delivery — authenticates with a single SendGrid API key sent as
+`Authorization: Bearer <key>`. `Mailer.provider_credentials('sendgrid')`
+resolves it in this order (first non-empty wins):
+
+| Priority | Source | Notes |
+|---|---|---|
+| 1 | `emailer.sendgrid_api_key` (config) | Not present in `config.defaults.yaml` — only set if your own config defines it |
+| 2 | `emailer.pass` (`SMTP_PASSWORD`) | Intended for `EMAILER_MODE=sendgrid` installs that put the key in the password slot |
+| 3 | `SENDGRID_API_KEY` env var | Fallback |
+
+> **Caution — SMTP collision:** unlike SES, SendGrid has **no dedicated
+> `CUSTOM_MAIL_SENDGRID_API_KEY` override** and no credential entry under
+> `email_providers.sendgrid`. If you run authenticated SMTP for delivery
+> (`EMAILER_MODE=smtp` with `SMTP_PASSWORD` set), `emailer.pass` outranks the
+> `SENDGRID_API_KEY` env var and your **SMTP password is used as the SendGrid
+> API key**, producing opaque HTTP 401s from the SendGrid API. Work around it
+> by setting `sendgrid_api_key` in your emailer config (e.g.
+> `sendgrid_api_key: <%= ENV['SENDGRID_API_KEY'] %>`). This is the same class
+> of collision the SES provider fixed with its `CUSTOM_MAIL_SES_*` vars.
+
+The API key must be a Full Access key, or a restricted key with the **Domain
+Authentication (`whitelabel`) scopes** — create, read, and delete at minimum
+(read covers the list + validate calls). Add the Mail Send scope only if
+SendGrid is also the delivery transport (`EMAILER_MODE=sendgrid`).
+
+Both the sender strategy and the delivery backend call the API with plain
+`Net::HTTP` — the `sendgrid-ruby` gem in the Gemfile (`require: false`) is
+**not used** by either path. That is deliberate (simpler dependencies and error
+handling per the note in `delivery/sendgrid.rb`) and prudent: the gem's last
+release is 6.7.0 (December 2023) and it has been effectively dormant since.
+
+## DMARC alignment (automatic security)
+
+The strategy always creates the domain with `automatic_security: true`, so
+SendGrid manages SPF, DKIM keys, and DKIM rotation behind **three CNAMEs** —
+the CNAME-delegated model, same family as Lettermint, in contrast to SES's
+publish-it-yourself MX + TXT:
+
+| | SendGrid (`automatic_security`) | Lettermint | SES (custom MAIL FROM) | MailChannels (research) |
+|---|---|---|---|---|
+| DKIM | 2 CNAMEs (`s1`/`s2._domainkey`) | CNAME selectors | 3 CNAMEs (tokens) | TXT (managed key) |
+| SPF / envelope sender | 1 mail CNAME (`em####.<domain>`) | 1 CNAME (`lm-bounces.<domain>`) | MX + SPF TXT on `mail.<domain>` | SPF TXT on **root** domain |
+| Who maintains SPF | SendGrid | Lettermint | customer publishes it | customer publishes it |
+
+The mail CNAME is the return-path host: SendGrid sets the envelope sender
+(Return-Path) to `em####.<domain>`, so SPF authenticates against a subdomain of
+the sender domain and aligns under DMARC's relaxed rules — the direct
+equivalent of Lettermint's `lm-bounces` CNAME and SES's custom MAIL FROM. With
+DKIM aligning too, DMARC passes via both paths. Domain authentication is also
+what removes the "via sendgrid.net" annotation recipients otherwise see.
+
+With `automatic_security: false` SendGrid instead returns 2 TXT + 1 MX for
+manual key management; the strategy never requests this mode.
+
+Unlike the SES strategy, the SendGrid strategy does **not** emit an advisory
+`_dmarc` TXT record — `build_dns_records` maps exactly what SendGrid returns.
+(The validation layer would classify a DMARC record correctly if one ever
+appeared in the provisioned set.)
+
+## Domain-level lifecycle
+
+### 1. Provision
+
+`ProvisionSenderDomain` → `SendGridSenderStrategy#provision_dns_records`:
+
+1. Extracts the domain from `mailer_config.from_address`.
+2. `POST /v3/whitelabel/domains` with body
+   `{ "domain": "<domain>", "automatic_security": true }`. No `subdomain`,
+   `custom_dkim_selector`, or `region` is passed — SendGrid assigns the
+   branding subdomain (`em####`) and default selectors (`s1`/`s2`) itself.
+3. `build_dns_records` normalizes the response's `dns` object (`mail_cname`,
+   `dkim1`, `dkim2`) to the standard `Array<Hash>` shape with `type` / `name` /
+   `value` plus a `purpose` key carrying the SendGrid record label.
+
+For `example.com` (SendGrid user id 1446226) the three required records look
+like:
+
+```
+em1234.example.com         CNAME  u1446226.wl123.sendgrid.net             (mail_cname — return-path/SPF)
+s1._domainkey.example.com  CNAME  s1.domainkey.u1446226.wl123.sendgrid.net (dkim1)
+s2._domainkey.example.com  CNAME  s2.domainkey.u1446226.wl123.sendgrid.net (dkim2)
+```
+
+The result also stores `provider_data` (`domain_id`, `subdomain`, the raw
+`dns` hash, `valid`) alongside the normalized `dns_records` on the
+`MailerConfig`; the records are read back verbatim at verification. A missing
+or empty API key fails fast (`missing_api_key`) before any HTTP call.
+
+### 2. Verify
+
+Two independent checks, as with every provider:
+
+- **DNS propagation** — `ValidateSenderDomain` → `SendgridValidation` reads the
+  provisioned records from `mailer_config.dns_records` (never hardcoded
+  selectors; returns an empty set with an error log if nothing was
+  provisioned) and runs live DNS lookups.
+- **Provider-side validation** —
+  `SendGridSenderStrategy#check_provider_verification_status` looks up the
+  domain id (from `credentials['domain_id']` if present, else by paginating
+  `GET /v3/whitelabel/domains?limit=50&offset=...` and matching on the domain
+  name), then `POST /v3/whitelabel/domains/{id}/validate`. SendGrid checks all
+  records on its side; the strategy reports `verified` when the domain's
+  `valid` flag is true or every entry in `validation_results` is valid, else
+  `pending`. Per-record results are surfaced in `:details`. Other statuses:
+  `not_found` (no matching domain authentication), `invalid` (bad
+  from_address), `error`.
+
+### 3. Delete
+
+Removing the sender config dispatches to
+`SendGridSenderStrategy#delete_sender_identity`: resolve the domain id (same
+lookup as verify), then `DELETE /v3/whitelabel/domains/{id}`. Note this is
+**not idempotent the way SES teardown is**: if the domain authentication no
+longer exists, the result is `deleted: false` with "Domain authentication not
+found" rather than treating it as already-deleted.
+
+## Configuration surface
+
+`email_providers.sendgrid` in `config.defaults.yaml` defines `subdomain`
+(default `em`, env `CUSTOM_MAIL_SENDGRID_SUBDOMAIN`), `dkim_selectors`
+(`s1`/`s2`), and `spf_include` (`sendgrid.net`), with matching defaults in
+`ProviderConfig`. **These are currently inert for this flow**: the strategy
+does not pass a subdomain or selectors to the API (SendGrid assigns its own),
+and validation reads provisioned records rather than composing them from
+config. Treat them as documentation of SendGrid's defaults, not as knobs.
+
+Minimal working example (SMTP transport, SendGrid provisioning):
+
+```bash
+EMAILER_MODE=smtp
+CUSTOM_MAIL_PROVIDER=sendgrid
+SENDGRID_API_KEY=SG.xxxxxxxx        # see SMTP-collision caution above if SMTP_PASSWORD is set
+ORGS_CUSTOM_MAIL_ENABLED=true
+```
+
+## Limitations and considerations
+
+- **EU regional subusers are unsupported.** The strategy hardcodes
+  `https://api.sendgrid.com/v3`; EU regional subusers require
+  `api.eu.sendgrid.com` and the `region: eu` request field, neither of which
+  the strategy sends.
+- **Subusers / `on-behalf-of`** are not used; domains are authenticated
+  directly on the account the API key belongs to. SendGrid allows up to 3,000
+  authenticated domains per user, so a single platform account scales fine.
+- **Link branding is separate.** Domain authentication covers sending identity
+  (DKIM/SPF, removing "via sendgrid.net"); click/open-tracking links are a
+  different SendGrid feature (`/v3/whitelabel/links`) that the platform does
+  not provision.
+- **Domain matching is exact-string.** `find_domain_id` matches
+  `d['domain'] == domain`, so a domain authenticated for `mail.example.com`
+  will not be found for `example.com` or vice versa.
+
+## Troubleshooting
+
+- DNS verification failures (propagation, value mismatches, registrars
+  appending the zone to CNAME hosts): see
+  [`docs/runbooks/dns-validation-failures.md`](../runbooks/dns-validation-failures.md).
+- HTTP 401/403 from provisioning: wrong or under-scoped API key — check the
+  Domain Authentication (whitelabel) scopes, and rule out the SMTP-collision
+  case where `SMTP_PASSWORD` is being used as the key.
+- `check_provider_verification_status` returns `not_found`: the domain
+  authentication was deleted, was created under a different account/subuser,
+  or the from-address domain doesn't exactly match — re-run provisioning.
+- Validate returns `pending` with some records valid: inspect `:details`
+  (SendGrid's per-record `validation_results`) to see which CNAME is wrong.
+- Delete reports "Domain authentication not found": already removed on the
+  SendGrid side; safe to treat as done, but the strategy reports it as a
+  failure (see lifecycle note above).
+
+## Key files
+
+| File | Role |
+|---|---|
+| `lib/onetime/mail/sender_strategies/sendgrid_sender_strategy.rb` | Provision / validate / delete via raw `Net::HTTP` against `api.sendgrid.com/v3` |
+| `lib/onetime/domain_validation/sender_strategies/sendgrid_validation.rb` | DNS validation from provisioned records (no hardcoded fallback) |
+| `lib/onetime/mail/delivery/sendgrid.rb` | Delivery backend via `/v3/mail/send` (only when `EMAILER_MODE=sendgrid`) |
+| `lib/onetime/domain_validation/sender_strategies/provider_config.rb` | `email_providers.sendgrid` defaults (currently inert for this flow) |
+| `lib/onetime/mail/mailer.rb` | `provider_credentials('sendgrid')` — api_key resolution (see SMTP-collision caution) |
+| `etc/defaults/config.defaults.yaml` | `emailer.sender_provider`, `email_providers.sendgrid.*` |


### PR DESCRIPTION
Adds research/planning docs for supporting custom sender domains via third-party mail providers. All docs-only, no code changes.

- **apex-plan** — plan for apex-domain SPF support
- **cakemail** — Cakemail integration research
- **mailchannels** — MailChannels custom sender integration research
- **sendgrid** — SendGrid sender domain provider documentation