### PR TITLE
Seed domain signin/signup settings from the default-off custom-domain resolver (#3814)

### DIFF
--- a/apps/api/domains/logic/signin_config/base.rb
+++ b/apps/api/domains/logic/signin_config/base.rb
@@ -49,13 +49,27 @@ module DomainsAPI
         # drift ADR-024 exists to kill. global_restrict_to lets the UI show the
         # inherited method restriction while the domain is unconfigured.
         #
+        # effective_enabled uses the CUSTOM-DOMAIN resolver (default OFF,
+        # opt-in) with the tenant-SSO carve-out — NOT resolve_signin_enabled.
+        # These settings describe a custom domain, so an unconfigured domain
+        # must read "disabled" even when the canonical site's sign-in is on
+        # (#3814), while an SSO-only tenant (enabled SsoConfig, no
+        # SigninConfig) reads "enabled" to match its working masthead link and
+        # /signin page (same shared authority as
+        # Core::Views::DomainSerializer#effective_signin_enabled?).
+        #
         # @param config [Onetime::CustomDomain::SigninConfig, nil] nil when unconfigured
+        # @param domain_id [String] CustomDomain identifier (objid) for the SSO carve-out
         # @return [Hash] global_enabled, effective_enabled, global_restrict_to
-        def signin_override_details(config)
+        def signin_override_details(config, domain_id)
           global = Onetime::CustomDomain::SigninConfig.global_signin_enabled
           {
             global_enabled: global,
-            effective_enabled: Onetime::CustomDomain::SigninConfig.resolve_signin_enabled(global, config),
+            effective_enabled: Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_custom_domain(
+              global,
+              config,
+              domain_id: domain_id,
+            ),
             global_restrict_to: Onetime.auth_config.restrict_to,
           }
         end

--- a/apps/api/domains/logic/signin_config/delete_signin_config.rb
+++ b/apps/api/domains/logic/signin_config/delete_signin_config.rb
@@ -15,8 +15,8 @@ module DomainsAPI
       #   Requires the requesting user to be an organization owner with
       #   custom_signin_config entitlement.
       #
-      # After deletion, sign-in on this domain falls back to the global
-      # authentication configuration in auth.defaults.yaml.
+      # After deletion, sign-in on this custom domain reverts to the
+      # default-OFF opt-in posture (open only when tenant SSO is available).
       #
       class DeleteSigninConfig < Base
         include AuditLogger
@@ -58,9 +58,10 @@ module DomainsAPI
           {
             success: true,
             message: "Signin configuration deleted for domain #{@custom_domain.display_domain}",
-            # Post-delete resolution truth: no record, so effective == global.
+            # Post-delete resolution truth: no record, so the custom domain
+            # reverts to default-OFF (unless tenant SSO keeps it open, #3814).
             # Serialized so the settings UI can re-render without a refetch (ADR-024).
-            details: signin_override_details(nil),
+            details: signin_override_details(nil, @custom_domain.identifier),
           }
         end
 

--- a/apps/api/domains/logic/signin_config/get_signin_config.rb
+++ b/apps/api/domains/logic/signin_config/get_signin_config.rb
@@ -47,7 +47,7 @@ module DomainsAPI
           {
             user_id: cust.extid,
             record: @signin_config.nil? ? nil : serialize_signin_config(@signin_config),
-            details: signin_override_details(@signin_config),
+            details: signin_override_details(@signin_config, @custom_domain.identifier),
           }
         end
 

--- a/apps/api/domains/logic/signin_config/put_signin_config.rb
+++ b/apps/api/domains/logic/signin_config/put_signin_config.rb
@@ -81,7 +81,7 @@ module DomainsAPI
           {
             user_id: cust.extid,
             record: serialize_signin_config(@signin_config),
-            details: signin_override_details(@signin_config),
+            details: signin_override_details(@signin_config, @custom_domain.identifier),
           }
         end
 

--- a/apps/api/domains/logic/signup_config/base.rb
+++ b/apps/api/domains/logic/signup_config/base.rb
@@ -49,13 +49,21 @@ module DomainsAPI
         # availability from the raw flag pair — client-side derivation is the
         # drift ADR-024 exists to kill.
         #
+        # effective_enabled uses the CUSTOM-DOMAIN resolver (default OFF,
+        # opt-in) — NOT resolve_signup_enabled. These settings describe a
+        # custom domain, so an unconfigured domain must read "disabled" even
+        # when the canonical site's signup is on (#3814). Same authority as
+        # the runtime gate (Core::Controllers::Base#signup_enabled?) and the
+        # masthead (DomainSerializer#effective_signup_enabled?). Signup has no
+        # SSO carve-out.
+        #
         # @param config [Onetime::CustomDomain::SignupConfig, nil] nil when unconfigured
         # @return [Hash] global_enabled, effective_enabled
         def signup_override_details(config)
           global = Onetime::CustomDomain::SignupConfig.global_signup_enabled
           {
             global_enabled: global,
-            effective_enabled: Onetime::CustomDomain::SignupConfig.resolve_signup_enabled(global, config),
+            effective_enabled: Onetime::CustomDomain::SignupConfig.resolve_signup_enabled_for_custom_domain(global, config),
           }
         end
 

--- a/apps/api/domains/spec/integration/domain_signin_config_spec.rb
+++ b/apps/api/domains/spec/integration/domain_signin_config_spec.rb
@@ -1,0 +1,211 @@
+# apps/api/domains/spec/integration/domain_signin_config_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration Tests for Domain Signin Config API Endpoints
+# =============================================================================
+#
+# Issue: #3814 - Sign-In settings seeded from the wrong resolver
+#
+# Focused HTTP-surface proof that every signin-config response carries the
+# resolution `details` (ADR-024) computed by the CUSTOM-DOMAIN resolver
+# (default OFF, opt-in — #3814), not the canonical follows-global resolver:
+#
+#   GET    /api/domains/:extid/signin-config   (unconfigured -> effective_enabled: false)
+#   PUT    /api/domains/:extid/signin-config   (enabled + signin_enabled -> true)
+#   DELETE /api/domains/:extid/signin-config   (revert -> false)
+#
+# Resolver branch coverage (SSO carve-out, explicit signin_enabled=false,
+# etc.) lives at the logic level in
+# try/integration/api/domains/put_signin_config_try.rb (section 11) — this
+# file only pins the HTTP wiring of the three handlers.
+#
+# REQUIREMENTS:
+# - Valkey running on port 2121: pnpm run test:database:start
+# - AUTHENTICATION_MODE=simple (login_as creates a Valkey-backed Customer
+#   with a passphrase; full mode routes /auth/login through Rodauth, which
+#   has no matching account row, so every login 401s)
+#
+# RUN:
+#   RACK_ENV=test AUTHENTICATION_MODE=simple bundle exec rspec apps/api/domains/spec/integration/domain_signin_config_spec.rb
+#
+# NOTE: like its siblings in this directory, this file has no mode
+# subdirectory, so the rake spec:integration:<mode> lanes do not pick it up.
+# It currently runs only when invoked directly.
+#
+# =============================================================================
+
+require_relative File.join(Onetime::HOME, 'spec', 'integration', 'integration_spec_helper')
+
+RSpec.describe 'Domain Signin Config API', type: :integration do
+  include Rack::Test::Methods
+  include CsrfTestHelpers
+
+  # Use the full Rack::URLMap so requests traverse the complete middleware
+  # stack (including CSRF bypass for /api/* paths) exactly as in production.
+  def app
+    @rack_app ||= begin
+      Onetime::Application::Registry.reset!
+      Onetime::Application::Registry.prepare_application_registry
+      Onetime::Application::Registry.generate_rack_url_map
+    end
+  end
+
+  before(:all) do
+    Onetime.boot! :test
+  end
+
+  let(:test_run_id) { SecureRandom.hex(8) }
+  let(:test_email) { "owner-#{test_run_id}@test.local" }
+  let(:test_password) { 'Test123!@#' }
+  let(:tenant_domain) { "signin-#{test_run_id}.acme-corp.example.com" }
+
+  let!(:test_owner) do
+    customer = Onetime::Customer.new(email: test_email)
+    customer.update_passphrase(test_password)
+    customer.verified = 'true'
+    customer.role = 'customer'
+    customer.save
+    customer
+  end
+
+  # Note: In standalone/test mode (billing disabled), all orgs get
+  # STANDALONE_ENTITLEMENTS which includes custom_signin_config automatically.
+  let!(:test_organization) do
+    Onetime::Organization.create!(
+      "Test Org #{test_run_id}",
+      test_owner,
+      "contact-#{test_run_id}@test.local",
+    )
+  end
+
+  let!(:test_custom_domain) do
+    domain = Onetime::CustomDomain.new(
+      display_domain: tenant_domain,
+      org_id: test_organization.org_id,
+    )
+    domain.save
+    Onetime::CustomDomain.display_domain_index.put(tenant_domain, domain.domainid)
+    domain
+  end
+
+  after do
+    Onetime::CustomDomain::SigninConfig.delete_for_domain!(test_custom_domain.identifier) rescue nil
+    Onetime::CustomDomain.display_domain_index.remove(tenant_domain) rescue nil
+    test_custom_domain&.destroy! rescue nil
+    test_organization&.destroy! rescue nil
+    test_owner&.destroy! rescue nil
+  end
+
+  def api_path(domain_extid)
+    "/api/domains/#{domain_extid}/signin-config"
+  end
+
+  def login_as(customer)
+    reset_csrf_token
+    csrf_post '/auth/login', {
+      login: customer.email,
+      password: test_password,
+    }
+    # Refresh CSRF token after login (session regeneration)
+    reset_csrf_token
+  end
+
+  def json_get(path)
+    header 'Accept', 'application/json'
+    header 'Content-Type', nil
+    get path
+  end
+
+  def json_body
+    JSON.parse(last_response.body)
+  end
+
+  describe 'GET /api/domains/:extid/signin-config' do
+    context 'when the domain is unconfigured' do
+      before do
+        login_as(test_owner)
+      end
+
+      # Unconfigured is a first-class state (ADR-024): 200 with record: null,
+      # not 404, so the settings UI can render the inherited global state.
+      it 'returns 200 with a null record' do
+        json_get api_path(test_custom_domain.extid)
+
+        expect(last_response.status).to eq(200)
+
+        body = json_body
+        expect(body).to have_key('record')
+        expect(body['record']).to be_nil
+      end
+
+      # #3814: custom domains are default-OFF opt-in for sign-in. With no
+      # SigninConfig and no tenant SSO, effective_enabled must be false even
+      # while the canonical site's sign-in is globally enabled (signin: true
+      # in spec/config.test.yaml). This is the seed the settings UI displays;
+      # before #3814 it leaked the follows-global resolver's true.
+      it 'reports effective_enabled false while global signin is enabled' do
+        json_get api_path(test_custom_domain.extid)
+
+        details = json_body['details']
+        expect(details).not_to be_nil
+        expect(details['global_enabled']).to be true
+        expect(details['effective_enabled']).to be false
+        expect(details).to have_key('global_restrict_to')
+      end
+    end
+  end
+
+  describe 'PUT /api/domains/:extid/signin-config' do
+    before do
+      login_as(test_owner)
+    end
+
+    context 'opting the domain in (enabled + signin_enabled)' do
+      it 'reports effective_enabled true in the PUT response and subsequent GET' do
+        csrf_put api_path(test_custom_domain.extid), {
+          enabled: true,
+          signin_enabled: true,
+        }
+
+        expect(last_response.status).to eq(200)
+
+        body = json_body
+        expect(body['record']['enabled']).to be true
+        expect(body['record']['signin_enabled']).to be true
+        expect(body['details']['effective_enabled']).to be true
+
+        json_get api_path(test_custom_domain.extid)
+
+        expect(last_response.status).to eq(200)
+        expect(json_body['details']['effective_enabled']).to be true
+      end
+    end
+  end
+
+  describe 'DELETE /api/domains/:extid/signin-config' do
+    before do
+      login_as(test_owner)
+      Onetime::CustomDomain::SigninConfig.create!(
+        domain_id: test_custom_domain.identifier,
+        enabled: true,
+        signin_enabled: true,
+      )
+    end
+
+    # Post-delete resolution truth (ADR-024): the response carries details so
+    # the settings UI can re-render without a refetch; the domain reverts to
+    # default-OFF (#3814).
+    it 'reports effective_enabled false after deleting the config' do
+      csrf_delete api_path(test_custom_domain.extid)
+
+      expect(last_response.status).to eq(200)
+
+      body = json_body
+      expect(body['success']).to be true
+      expect(body['details']['effective_enabled']).to be false
+      expect(body['details']['global_enabled']).to be true
+    end
+  end
+end

--- a/apps/api/domains/spec/integration/domain_signup_config_spec.rb
+++ b/apps/api/domains/spec/integration/domain_signup_config_spec.rb
@@ -20,11 +20,17 @@
 #
 # REQUIREMENTS:
 # - Valkey running on port 2121: pnpm run test:database:start
-# - AUTH_DATABASE_URL set (SQLite or PostgreSQL)
-# - AUTHENTICATION_MODE=full
+# - AUTHENTICATION_MODE=simple (login_as creates a Valkey-backed Customer
+#   with a passphrase; full mode routes /auth/login through Rodauth, which
+#   has no matching account row, so every login 401s)
 #
 # RUN:
-#   source .env.test && pnpm run test:rspec apps/api/domains/spec/integration/domain_signup_config_spec.rb
+#   RACK_ENV=test AUTHENTICATION_MODE=simple bundle exec rspec apps/api/domains/spec/integration/domain_signup_config_spec.rb
+#
+# NOTE: this file sits at spec/integration/ root (no mode subdirectory), so
+# the rake spec:integration:<mode> lanes — which glob
+# apps/*/*/spec/integration/<mode> — do not pick it up, and spec:apps:*
+# excludes integration/. It currently runs only when invoked directly.
 #
 # =============================================================================
 
@@ -695,12 +701,30 @@ RSpec.describe 'Domain Signup Config API', type: :integration do
         login_as(test_owner)
       end
 
-      it 'returns 404' do
+      # Unconfigured is a first-class state (ADR-024): 200 with record: null,
+      # not 404, so the settings UI can render the inherited global state.
+      it 'returns 200 with a null record' do
         json_get api_path(test_custom_domain.extid)
 
-        expect(last_response.status).to eq(404)
+        expect(last_response.status).to eq(200)
+
         body = json_body
-        expect(body['error']).to include('Signup configuration not found')
+        expect(body).to have_key('record')
+        expect(body['record']).to be_nil
+      end
+
+      # #3814: custom domains are default-OFF opt-in for signup. An
+      # unconfigured domain must read effective_enabled: false even while the
+      # canonical site's signup is globally enabled (signup: true in
+      # spec/config.test.yaml) — same authority as the runtime POST gate and
+      # the masthead serializer.
+      it 'reports effective_enabled false while global signup is enabled' do
+        json_get api_path(test_custom_domain.extid)
+
+        details = json_body['details']
+        expect(details).not_to be_nil
+        expect(details['global_enabled']).to be true
+        expect(details['effective_enabled']).to be false
       end
     end
 

--- a/apps/api/domains/spec/integration/simple/domain_sender_config_spec.rb
+++ b/apps/api/domains/spec/integration/simple/domain_sender_config_spec.rb
@@ -1,4 +1,4 @@
-# apps/api/domains/spec/integration/domain_sender_config_spec.rb
+# apps/api/domains/spec/integration/simple/domain_sender_config_spec.rb
 #
 # frozen_string_literal: true
 
@@ -22,11 +22,12 @@
 #
 # REQUIREMENTS:
 # - Valkey running on port 2121: pnpm run test:database:start
-# - AUTH_DATABASE_URL set (SQLite or PostgreSQL)
-# - AUTHENTICATION_MODE=full
+# - AUTHENTICATION_MODE=simple (login_as creates a Valkey-backed Customer
+#   with a passphrase; full mode routes /auth/login through Rodauth, which
+#   has no matching account row, so every login 401s)
 #
 # RUN:
-#   source .env.test && pnpm run test:rspec apps/api/domains/spec/integration/domain_sender_config_spec.rb
+#   RACK_ENV=test AUTHENTICATION_MODE=simple bundle exec rspec apps/api/domains/spec/integration/simple/domain_sender_config_spec.rb
 #
 # =============================================================================
 

--- a/apps/api/domains/spec/integration/simple/domain_signin_config_spec.rb
+++ b/apps/api/domains/spec/integration/simple/domain_signin_config_spec.rb
@@ -1,4 +1,4 @@
-# apps/api/domains/spec/integration/domain_signin_config_spec.rb
+# apps/api/domains/spec/integration/simple/domain_signin_config_spec.rb
 #
 # frozen_string_literal: true
 
@@ -28,11 +28,13 @@
 #   has no matching account row, so every login 401s)
 #
 # RUN:
-#   RACK_ENV=test AUTHENTICATION_MODE=simple bundle exec rspec apps/api/domains/spec/integration/domain_signin_config_spec.rb
+#   RACK_ENV=test AUTHENTICATION_MODE=simple bundle exec rspec apps/api/domains/spec/integration/simple/domain_signin_config_spec.rb
 #
-# NOTE: like its siblings in this directory, this file has no mode
-# subdirectory, so the rake spec:integration:<mode> lanes do not pick it up.
-# It currently runs only when invoked directly.
+# NOTE: living under integration/simple/ puts this file in the rake
+# spec:integration:simple lane (glob apps/*/*/spec/integration/simple), which
+# CI runs in the blocking ruby-integration-simple job. The path also derives
+# the :simple_auth_mode tag (spec/spec_helper.rb), pinning the simple-mode
+# mock auth config.
 #
 # =============================================================================
 

--- a/apps/api/domains/spec/integration/simple/domain_signup_config_spec.rb
+++ b/apps/api/domains/spec/integration/simple/domain_signup_config_spec.rb
@@ -1,4 +1,4 @@
-# apps/api/domains/spec/integration/domain_signup_config_spec.rb
+# apps/api/domains/spec/integration/simple/domain_signup_config_spec.rb
 #
 # frozen_string_literal: true
 
@@ -25,12 +25,13 @@
 #   has no matching account row, so every login 401s)
 #
 # RUN:
-#   RACK_ENV=test AUTHENTICATION_MODE=simple bundle exec rspec apps/api/domains/spec/integration/domain_signup_config_spec.rb
+#   RACK_ENV=test AUTHENTICATION_MODE=simple bundle exec rspec apps/api/domains/spec/integration/simple/domain_signup_config_spec.rb
 #
-# NOTE: this file sits at spec/integration/ root (no mode subdirectory), so
-# the rake spec:integration:<mode> lanes — which glob
-# apps/*/*/spec/integration/<mode> — do not pick it up, and spec:apps:*
-# excludes integration/. It currently runs only when invoked directly.
+# NOTE: living under integration/simple/ puts this file in the rake
+# spec:integration:simple lane (glob apps/*/*/spec/integration/simple), which
+# CI runs in the blocking ruby-integration-simple job. The path also derives
+# the :simple_auth_mode tag (spec/spec_helper.rb), pinning the simple-mode
+# mock auth config.
 #
 # =============================================================================
 

--- a/apps/api/domains/spec/integration/simple/domain_sso_config_spec.rb
+++ b/apps/api/domains/spec/integration/simple/domain_sso_config_spec.rb
@@ -1,4 +1,4 @@
-# apps/api/domains/spec/integration/domain_sso_config_spec.rb
+# apps/api/domains/spec/integration/simple/domain_sso_config_spec.rb
 #
 # frozen_string_literal: true
 
@@ -23,11 +23,12 @@
 #
 # REQUIREMENTS:
 # - Valkey running on port 2121: pnpm run test:database:start
-# - AUTH_DATABASE_URL set (SQLite or PostgreSQL)
-# - AUTHENTICATION_MODE=full
+# - AUTHENTICATION_MODE=simple (login_as creates a Valkey-backed Customer
+#   with a passphrase; full mode routes /auth/login through Rodauth, which
+#   has no matching account row, so every login 401s)
 #
 # RUN:
-#   source .env.test && pnpm run test:rspec apps/api/domains/spec/integration/domain_sso_config_spec.rb
+#   RACK_ENV=test AUTHENTICATION_MODE=simple bundle exec rspec apps/api/domains/spec/integration/simple/domain_sso_config_spec.rb
 #
 # =============================================================================
 

--- a/apps/api/v1/spec/integration/simple/v1_response_contract_spec.rb
+++ b/apps/api/v1/spec/integration/simple/v1_response_contract_spec.rb
@@ -32,8 +32,13 @@ RSpec.describe 'V1 API Response Contract', type: :integration do
     end
   end
 
+  # force: a partial boot (`OT.boot! :test, false`) from an earlier
+  # randomized-order spec marks boot complete while skipping configure_familia,
+  # and a plain boot! re-entry is a no-op — this spec needs the full
+  # initializer set (VERIFIABLE_ID_HMAC_SECRET, encryption keys) to mint
+  # secrets.
   before(:all) do
-    Onetime.boot! :test
+    Onetime.boot! :test, force: true
   end
 
   # The response=json wrapper adds top-level "success" and "data" keys;

--- a/apps/api/v1/spec/integration/simple/v1_response_contract_spec.rb
+++ b/apps/api/v1/spec/integration/simple/v1_response_contract_spec.rb
@@ -1,4 +1,4 @@
-# apps/api/v1/spec/integration/v1_response_contract_spec.rb
+# apps/api/v1/spec/integration/simple/v1_response_contract_spec.rb
 #
 # frozen_string_literal: true
 
@@ -15,7 +15,7 @@
 #
 # Run:
 #   pnpm run test:database:start
-#   pnpm run test:rspec apps/api/v1/spec/integration/v1_response_contract_spec.rb
+#   RACK_ENV=test AUTHENTICATION_MODE=simple bundle exec rspec apps/api/v1/spec/integration/simple/v1_response_contract_spec.rb
 
 require_relative File.join(Onetime::HOME, 'spec', 'integration', 'integration_spec_helper')
 

--- a/apps/web/billing/spec/integration/pending_federation_spec.rb
+++ b/apps/web/billing/spec/integration/pending_federation_spec.rb
@@ -10,6 +10,12 @@
 # 2. User creates account → pending matched → benefits applied
 #
 # Run: pnpm run test:rspec apps/web/billing/spec/integration/pending_federation_spec.rb
+#
+# NOTE: deliberately stays at the integration/ root (no mode subdirectory), so
+# no spec:integration:<mode> rake lane or CI job runs it. Moving it into
+# integration/simple/ would derive the :simple_auth_mode tag, which conflicts
+# with the manual rake vcr:billing:verify/rerecord lanes that run this tree
+# under AUTHENTICATION_MODE=full. Runs via those lanes or direct invocation.
 
 require_relative '../support/billing_spec_helper'
 require_relative '../operations/process_webhook_event/shared_examples'

--- a/apps/web/billing/spec/integration/stripe_client_spec.rb
+++ b/apps/web/billing/spec/integration/stripe_client_spec.rb
@@ -2,6 +2,12 @@
 #
 # frozen_string_literal: true
 
+# NOTE: deliberately stays at the integration/ root (no mode subdirectory), so
+# no spec:integration:<mode> rake lane or CI job runs it. Moving it into
+# integration/simple/ would derive the :simple_auth_mode tag, which conflicts
+# with the manual rake vcr:billing:verify/rerecord lanes that run this tree
+# under AUTHENTICATION_MODE=full. Runs via those lanes or direct invocation.
+
 require_relative '../support/billing_spec_helper'
 require_relative '../../lib/stripe_client'
 

--- a/apps/web/billing/spec/integration/webhook_validator_spec.rb
+++ b/apps/web/billing/spec/integration/webhook_validator_spec.rb
@@ -2,6 +2,12 @@
 #
 # frozen_string_literal: true
 
+# NOTE: deliberately stays at the integration/ root (no mode subdirectory), so
+# no spec:integration:<mode> rake lane or CI job runs it. Moving it into
+# integration/simple/ would derive the :simple_auth_mode tag, which conflicts
+# with the manual rake vcr:billing:verify/rerecord lanes that run this tree
+# under AUTHENTICATION_MODE=full. Runs via those lanes or direct invocation.
+
 require_relative '../support/billing_spec_helper'
 require_relative '../../lib/webhook_validator'
 require_relative '../../models/stripe_webhook_event'

--- a/apps/web/core/views/serializers/domain_serializer.rb
+++ b/apps/web/core/views/serializers/domain_serializer.rb
@@ -171,28 +171,28 @@ module Core
         # The masthead link navigates to the /signin PAGE, so its visibility
         # must mirror the PAGE display gate (ConfigSerializer#resolve_signin),
         # NOT the POST /signin runtime gate (Core::Controllers::Base#signin_enabled?).
-        # That is why this method reproduces resolve_signin's structure rather
-        # than the runtime resolver: a custom domain with no enabled SigninConfig
-        # defaults OFF for password/email but keeps the door open when tenant
-        # SSO is available (SsoConfig.tenant_sso_available_for?), so an SSO-only
-        # tenant (enabled SsoConfig, no SigninConfig) gets a working link to its
-        # working /signin page. An *enabled* SigninConfig falls through to the
-        # shared resolver, which honors an explicit signin_enabled=false and
-        # hides SSO along with it (#3415) — matching resolve_signin exactly. SSO
-        # itself signs in via the omniauth routes, never POST /signin, so the
-        # POST handler correctly stays OFF for SSO-only tenants; that asymmetry
-        # with this link gate is intentional. Platform-SSO fallback is out of
-        # scope here by design (see SsoConfig.tenant_sso_available_for?).
+        # Passing domain_id: activates the shared resolver's tenant-SSO
+        # carve-out: a custom domain with no enabled SigninConfig defaults OFF
+        # for password/email but keeps the door open when tenant SSO is
+        # available (SsoConfig.tenant_sso_available_for?), so an SSO-only
+        # tenant (enabled SsoConfig, no SigninConfig) gets a working link to
+        # its working /signin page. An *enabled* SigninConfig falls through to
+        # the shared resolver, which honors an explicit signin_enabled=false
+        # and hides SSO along with it (#3415) — matching resolve_signin
+        # exactly. SSO itself signs in via the omniauth routes, never POST
+        # /signin, so the POST handler correctly stays OFF for SSO-only
+        # tenants; that asymmetry with this link gate is intentional.
+        # Platform-SSO fallback is out of scope here by design (see
+        # SsoConfig.tenant_sso_available_for?). The settings API details
+        # (DomainsAPI signin_config) use the same domain_id: form, so the
+        # settings page and this link cannot disagree (#3814).
         def effective_signin_enabled?(domain_id)
           config = Onetime::CustomDomain::SigninConfig.find_by_domain_id(domain_id)
-
-          unless config&.enabled?
-            return Onetime::CustomDomain::SsoConfig.tenant_sso_available_for?(domain_id)
-          end
 
           Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_custom_domain(
             Onetime::CustomDomain::SigninConfig.global_signin_enabled,
             config,
+            domain_id: domain_id,
           )
         end
 

--- a/docs/architecture/decision-records/adr-024-custom-domain-auth-override-resolution.md
+++ b/docs/architecture/decision-records/adr-024-custom-domain-auth-override-resolution.md
@@ -130,5 +130,5 @@ Frontend:
 
 Tests:
 - `try/unit/models/custom_domain_auth_killswitch_try.rb` — resolver truth table (kill switch, narrowing, inherit)
-- `apps/api/domains/spec/integration/domain_signup_config_spec.rb` — settings API contract
+- `apps/api/domains/spec/integration/simple/domain_signup_config_spec.rb` — settings API contract
 - `src/tests/composables/useSigninConfig.spec.ts`, `src/tests/apps/workspace/components/domains/DomainSigninConfigForm.spec.ts` — seeding + materialization

--- a/lib/onetime/models/custom_domain/signin_config.rb
+++ b/lib/onetime/models/custom_domain/signin_config.rb
@@ -204,16 +204,36 @@ module Onetime
         # re-enable sign-in disabled globally.
         #
         # Single source of truth for the custom-domain default, shared by the
-        # runtime route gate (Core::Controllers::Base#signin_enabled?) and the
+        # runtime route gate (Core::Controllers::Base#signin_enabled?), the
         # branded-masthead display gate
-        # (Core::Views::DomainSerializer#effective_signin_enabled?), so the
-        # /signin POST handler and the masthead link cannot disagree.
+        # (Core::Views::DomainSerializer#effective_signin_enabled?), and the
+        # settings API (DomainsAPI signin_config details, #3814), so the
+        # /signin POST handler, the masthead link, and the settings page
+        # cannot disagree.
+        #
+        # SSO carve-out (domain_id:): when the caller passes domain_id, the
+        # "not explicitly allowed" branch falls back to
+        # SsoConfig.tenant_sso_available_for? instead of false. An SSO-only
+        # tenant (enabled SsoConfig, no SigninConfig) has a working /signin
+        # page via the omniauth routes, so DISPLAY surfaces — the masthead
+        # link and the settings page — must report sign-in as available.
+        # Callers gating the password/email POST /signin handler omit
+        # domain_id and keep the strict false: SSO never flows through POST
+        # /signin, so that asymmetry is intentional (#3415, #3783). An
+        # *enabled* config always falls through to the shared resolver, which
+        # honors an explicit signin_enabled=false and hides SSO along with it.
         #
         # @param global [Boolean] install-level availability (auth.enabled && auth.signin)
         # @param config [SigninConfig, nil] the per-domain config, if any
+        # @param domain_id [String, nil] CustomDomain identifier (objid); when
+        #   present, enables the tenant-SSO carve-out for display surfaces
         # @return [Boolean]
-        def resolve_signin_enabled_for_custom_domain(global, config)
-          return false unless config&.enabled?
+        def resolve_signin_enabled_for_custom_domain(global, config, domain_id: nil)
+          unless config&.enabled?
+            return false if domain_id.nil?
+
+            return Onetime::CustomDomain::SsoConfig.tenant_sso_available_for?(domain_id)
+          end
 
           resolve_signin_enabled(global, config)
         end

--- a/spec/integration/all/default_workspace_creation_spec.rb
+++ b/spec/integration/all/default_workspace_creation_spec.rb
@@ -16,7 +16,11 @@ RSpec.describe 'default_workspace_creation_try', type: :integration, order: :def
     # disabled. billing_isolation.rb disables billing before every example
     # group's context hooks (#3418), so no per-spec toggle is needed here.
     begin
-      OT.boot! :test, false unless OT.ready?
+      # Full boot, not partial (`:test, false`): a partial boot skips
+      # configure_familia (VERIFIABLE_ID_HMAC_SECRET, encryption keys) yet
+      # marks boot complete, so later files' plain `boot!` re-entries no-op
+      # and inherit the partial state (PR #3817 seed-60018 CI failure).
+      OT.boot! :test unless OT.ready?
     rescue Redis::CannotConnectError, Redis::ConnectionError => e
       puts "SKIP: Requires Redis connection (#{e.class})"
       exit 0

--- a/spec/integration/all/lazy_organization_creation_spec.rb
+++ b/spec/integration/all/lazy_organization_creation_spec.rb
@@ -23,7 +23,11 @@ RSpec.describe 'Lazy Organization Creation', type: :integration, order: :defined
     ENV.delete('REDIS_URL')
     ENV.delete('VALKEY_URL')
     begin
-      OT.boot! :test, false unless OT.ready?
+      # Full boot, not partial (`:test, false`): a partial boot skips
+      # configure_familia (VERIFIABLE_ID_HMAC_SECRET, encryption keys) yet
+      # marks boot complete, so later files' plain `boot!` re-entries no-op
+      # and inherit the partial state (PR #3817 seed-60018 CI failure).
+      OT.boot! :test unless OT.ready?
     rescue Redis::CannotConnectError, Redis::ConnectionError => e
       puts "SKIP: Requires Redis connection (#{e.class})"
       exit 0
@@ -136,7 +140,11 @@ RSpec.describe 'Federation Application on Workspace Creation', type: :integratio
     ENV.delete('REDIS_URL')
     ENV.delete('VALKEY_URL')
     begin
-      OT.boot! :test, false unless OT.ready?
+      # Full boot, not partial (`:test, false`): a partial boot skips
+      # configure_familia (VERIFIABLE_ID_HMAC_SECRET, encryption keys) yet
+      # marks boot complete, so later files' plain `boot!` re-entries no-op
+      # and inherit the partial state (PR #3817 seed-60018 CI failure).
+      OT.boot! :test unless OT.ready?
     rescue Redis::CannotConnectError, Redis::ConnectionError => e
       puts "SKIP: Requires Redis connection (#{e.class})"
       exit 0
@@ -201,7 +209,11 @@ RSpec.describe 'Billing Webhook Organization Creation Paths', type: :integration
     ENV.delete('REDIS_URL')
     ENV.delete('VALKEY_URL')
     begin
-      OT.boot! :test, false unless OT.ready?
+      # Full boot, not partial (`:test, false`): a partial boot skips
+      # configure_familia (VERIFIABLE_ID_HMAC_SECRET, encryption keys) yet
+      # marks boot complete, so later files' plain `boot!` re-entries no-op
+      # and inherit the partial state (PR #3817 seed-60018 CI failure).
+      OT.boot! :test unless OT.ready?
     rescue Redis::CannotConnectError, Redis::ConnectionError => e
       puts "SKIP: Requires Redis connection (#{e.class})"
       exit 0
@@ -302,7 +314,11 @@ RSpec.describe 'OrganizationContext in Logic Classes', type: :integration, order
     ENV.delete('REDIS_URL')
     ENV.delete('VALKEY_URL')
     begin
-      OT.boot! :test, false unless OT.ready?
+      # Full boot, not partial (`:test, false`): a partial boot skips
+      # configure_familia (VERIFIABLE_ID_HMAC_SECRET, encryption keys) yet
+      # marks boot complete, so later files' plain `boot!` re-entries no-op
+      # and inherit the partial state (PR #3817 seed-60018 CI failure).
+      OT.boot! :test unless OT.ready?
     rescue Redis::CannotConnectError, Redis::ConnectionError => e
       puts "SKIP: Requires Redis connection (#{e.class})"
       exit 0

--- a/spec/integration/all/organization_v1_migration_created_by_spec.rb
+++ b/spec/integration/all/organization_v1_migration_created_by_spec.rb
@@ -34,7 +34,11 @@ RSpec.describe 'Organization.create_from_v1_customer! created_by dual-write',
     # disabled. billing_isolation.rb disables billing before every example
     # group's context hooks (#3418), so no per-spec toggle is needed here.
     begin
-      OT.boot! :test, false unless OT.ready?
+      # Full boot, not partial (`:test, false`): a partial boot skips
+      # configure_familia (VERIFIABLE_ID_HMAC_SECRET, encryption keys) yet
+      # marks boot complete, so later files' plain `boot!` re-entries no-op
+      # and inherit the partial state (PR #3817 seed-60018 CI failure).
+      OT.boot! :test unless OT.ready?
     rescue Redis::CannotConnectError, Redis::ConnectionError => e
       puts "SKIP: Requires Redis connection (#{e.class})"
       exit 0

--- a/src/schemas/api/domains/responses/auth-override.ts
+++ b/src/schemas/api/domains/responses/auth-override.ts
@@ -15,8 +15,11 @@ import { z } from 'zod';
 /**
  * Resolution details common to signin-config and signup-config responses.
  *
- * Optional-tolerant: older backends omit `details` entirely (the envelope
- * marks it optional), but when present these two fields are guaranteed.
+ * REQUIRED on GET/PUT responses (PR #3817): the settings UI seeds
+ * unconfigured domains from these fields, so a details-less payload fails
+ * parse instead of seeding a guess. Older backends that omit `details`
+ * (or 404) surface as a failed load. DELETE responses still mark it
+ * optional — they only refresh already-held details.
  */
 export const authOverrideDetailsSchema = z.object({
   /** Whether the current user can manage this config. */

--- a/src/schemas/api/domains/responses/signin-config.ts
+++ b/src/schemas/api/domains/responses/signin-config.ts
@@ -46,21 +46,32 @@ export type SigninConfigDetails = z.infer<typeof signinConfigDetailsSchema>;
  * `record` is null when the domain has no signin config — unconfigured is a
  * first-class state (200, not 404) so `details` can carry the inherited
  * global state (ADR-024).
+ *
+ * `details` is REQUIRED (overriding the envelope's optional default): the
+ * settings UI seeds unconfigured domains from it and every save materializes
+ * that seed as an explicit override, so a details-less response must fail
+ * parse rather than let a guessed seed get persisted.
  */
 export const getSigninConfigResponseSchema = createApiResponseSchema(
   customDomainSigninConfigSchema.nullable(),
   signinConfigDetailsSchema
-);
+).extend({
+  details: signinConfigDetailsSchema,
+});
 
 export type GetSigninConfigResponse = z.infer<typeof getSigninConfigResponseSchema>;
 
 /**
  * Response schema for PUT /api/domains/:domain_extid/signin-config
+ *
+ * `details` is REQUIRED — same contract as the GET schema.
  */
 export const putSigninConfigResponseSchema = createApiResponseSchema(
   customDomainSigninConfigSchema,
   signinConfigDetailsSchema
-);
+).extend({
+  details: signinConfigDetailsSchema,
+});
 
 export type PutSigninConfigResponse = z.infer<typeof putSigninConfigResponseSchema>;
 

--- a/src/schemas/api/domains/responses/signup-config.ts
+++ b/src/schemas/api/domains/responses/signup-config.ts
@@ -36,21 +36,32 @@ export type SignupConfigDetails = z.infer<typeof signupConfigDetailsSchema>;
  * `record` is null when the domain has no signup config — unconfigured is a
  * first-class state (200, not 404) so `details` can carry the inherited
  * global state (ADR-024).
+ *
+ * `details` is REQUIRED (overriding the envelope's optional default): the
+ * settings UI seeds unconfigured domains from it and every save materializes
+ * that seed as an explicit override, so a details-less response must fail
+ * parse rather than let a guessed seed get persisted.
  */
 export const getSignupConfigResponseSchema = createApiResponseSchema(
   customDomainSignupConfigSchema.nullable(),
   signupConfigDetailsSchema
-);
+).extend({
+  details: signupConfigDetailsSchema,
+});
 
 export type GetSignupConfigResponse = z.infer<typeof getSignupConfigResponseSchema>;
 
 /**
  * Response schema for PUT /api/domains/:domain_extid/signup-config
+ *
+ * `details` is REQUIRED — same contract as the GET schema.
  */
 export const putSignupConfigResponseSchema = createApiResponseSchema(
   customDomainSignupConfigSchema,
   signupConfigDetailsSchema
-);
+).extend({
+  details: signupConfigDetailsSchema,
+});
 
 export type PutSignupConfigResponse = z.infer<typeof putSignupConfigResponseSchema>;
 

--- a/src/schemas/contracts/custom-domain/signin-config.ts
+++ b/src/schemas/contracts/custom-domain/signin-config.ts
@@ -19,7 +19,7 @@
  *    config. The domain_id field is the identifier.
  *
  * 2. Explicit Booleans: Boolean fields are non-nullable with conservative
- *    defaults (signin on, optional methods off until explicitly enabled).
+ *    defaults (signin and optional methods off until explicitly enabled).
  *
  * 3. restrict_to: Mirrors auth.defaults.yaml full.restrict_to. When set,
  *    only that single method is shown on the login page. The underlying
@@ -107,7 +107,7 @@ export const customDomainSigninConfigCanonical = z.object({
 
   /**
    * Whether sign-in is enabled on this custom domain.
-   * Defaults to true (conservative: don't lock users out).
+   * Defaults to false (conservative: off until explicitly enabled, #3814).
    */
   signin_enabled: z.boolean(),
 
@@ -162,7 +162,7 @@ export const putSigninConfigPayloadSchema = z.object({
   /** Whether the per-domain config is active. Defaults to false. */
   enabled: z.boolean().optional(),
 
-  /** Whether sign-in is enabled. Defaults to true. */
+  /** Whether sign-in is enabled. Defaults to false. */
   signin_enabled: z.boolean().optional(),
 
   /** Restrict login page to a single method. Null to show all enabled methods. */

--- a/src/services/signin-config.service.ts
+++ b/src/services/signin-config.service.ts
@@ -28,7 +28,10 @@ const $api = createApi();
  *
  * `record` is null when the domain is unconfigured — the API returns 200
  * with a null record and resolution `details` (ADR-024). A 404 fallback is
- * kept for older backends; in that case `details` is null too.
+ * kept for older backends; in that case `details` is null too, as it is
+ * when the payload fails schema validation (`details` is required by the
+ * response schema). Callers treat record+details both null as a failed
+ * load — never as a seedable state (PR #3817).
  */
 export interface SigninConfigResponse {
   record: CustomDomainSigninConfig | null;

--- a/src/services/signup-config.service.ts
+++ b/src/services/signup-config.service.ts
@@ -28,7 +28,10 @@ const $api = createApi();
  *
  * `record` is null when the domain is unconfigured — the API returns 200
  * with a null record and resolution `details` (ADR-024). A 404 fallback is
- * kept for older backends; in that case `details` is null too.
+ * kept for older backends; in that case `details` is null too, as it is
+ * when the payload fails schema validation (`details` is required by the
+ * response schema). Callers treat record+details both null as a failed
+ * load — never as a seedable state (PR #3817).
  */
 export interface SignupConfigResponse {
   record: CustomDomainSignupConfig | null;

--- a/src/shared/composables/useSigninConfig.ts
+++ b/src/shared/composables/useSigninConfig.ts
@@ -84,6 +84,10 @@ export function resolveGlobalMethodAvailability(): GlobalMethodAvailability {
  * actually runs, and the first explicit write materializes this snapshot
  * plus the user's change — never static defaults that could silently flip
  * unrelated behavior.
+ *
+ * When `details` is absent (older backend / missing payload), signin seeds
+ * OFF: custom domains are default-off opt-in (#3814), so false is the safe
+ * fallback — matching useSignupConfig.
  */
 function createSeededFormState(
   details: SigninConfigDetails | null,
@@ -91,7 +95,7 @@ function createSeededFormState(
 ): SigninConfigFormState {
   return {
     enabled: false,
-    signin_enabled: details?.effective_enabled ?? true,
+    signin_enabled: details?.effective_enabled ?? false,
     restrict_to: details?.global_restrict_to ?? null,
     email_auth_enabled: methods.email_auth,
     sso_enabled: methods.sso,

--- a/src/shared/composables/useSigninConfig.ts
+++ b/src/shared/composables/useSigninConfig.ts
@@ -112,7 +112,7 @@ function createSeededFormState(
 function configToFormState(config: CustomDomainSigninConfig): SigninConfigFormState {
   return {
     enabled: config.enabled,
-    signin_enabled: config.signin_enabled ?? true,
+    signin_enabled: config.signin_enabled ?? false,
     restrict_to: config.restrict_to ?? null,
     email_auth_enabled: config.email_auth_enabled ?? false,
     sso_enabled: config.sso_enabled ?? false,

--- a/src/shared/composables/useSigninConfig.ts
+++ b/src/shared/composables/useSigninConfig.ts
@@ -24,7 +24,7 @@
 
 import type { PutSigninConfigRequest } from '@/schemas/api/domains/requests/signin-config';
 import type { SigninConfigDetails } from '@/schemas/api/domains/responses/signin-config';
-import type { ApplicationError } from '@/schemas/errors';
+import { createError, type ApplicationError } from '@/schemas/errors';
 import type {
   CustomDomainSigninConfig,
   SigninRestrictTo,
@@ -85,9 +85,10 @@ export function resolveGlobalMethodAvailability(): GlobalMethodAvailability {
  * plus the user's change — never static defaults that could silently flip
  * unrelated behavior.
  *
- * When `details` is absent (older backend / missing payload), signin seeds
- * OFF: custom domains are default-off opt-in (#3814), so false is the safe
- * fallback — matching useSignupConfig.
+ * The null-details fallback seeds signin OFF (custom domains are default-off
+ * opt-in, #3814) and only backs the placeholder state before initialize
+ * resolves — initialize itself errors on a details-less response instead of
+ * seeding, so a guessed seed can never be materialized by an autosave.
  */
 function createSeededFormState(
   details: SigninConfigDetails | null,
@@ -218,10 +219,21 @@ export function useSigninConfig(domainExtId: string) {
    * Load the current signin config for this domain.
    * A null record means "unconfigured" — the form is seeded from the
    * inherited global state carried in details, not from static defaults.
+   *
+   * A response with neither record nor details (older backend 404 or a
+   * payload that failed schema validation) fails loudly instead of seeding:
+   * the seed is a guess about the inherited state, and any autosave would
+   * materialize that guess as an explicit override — on an SSO-only domain
+   * that would persist signin_enabled: false and disable sign-in (PR #3817).
    */
   const initialize = () =>
     wrap(async () => {
       const response = await SigninConfigService.getConfigForDomain(domainExtId);
+
+      if (!response.record && !response.details) {
+        throw createError(t('web.COMMON.unexpected_error'), 'technical', 'error');
+      }
+
       signinConfig.value = response.record;
       details.value = response.details;
 

--- a/src/shared/composables/useSignupConfig.ts
+++ b/src/shared/composables/useSignupConfig.ts
@@ -24,7 +24,7 @@
 
 import type { PutSignupConfigRequest } from '@/schemas/api/domains/requests/signup-config';
 import type { SignupConfigDetails } from '@/schemas/api/domains/responses/signup-config';
-import type { ApplicationError } from '@/schemas/errors';
+import { createError, type ApplicationError } from '@/schemas/errors';
 import type {
   CustomDomainSignupConfig,
   SignupValidationStrategy,
@@ -187,10 +187,21 @@ export function useSignupConfig(domainExtId: string) {
    * Load the current signup config for this domain.
    * A null record means "unconfigured" — the form is seeded from the
    * inherited global state carried in details, not from static defaults.
+   *
+   * A response with neither record nor details (older backend 404 or a
+   * payload that failed schema validation) fails loudly instead of seeding:
+   * the seed is a guess about the inherited state, and a save would
+   * materialize that guess as an explicit override (PR #3817, mirroring
+   * useSigninConfig).
    */
   const initialize = () =>
     wrap(async () => {
       const response = await SignupConfigService.getConfigForDomain(domainExtId);
+
+      if (!response.record && !response.details) {
+        throw createError(t('web.COMMON.unexpected_error'), 'technical', 'error');
+      }
+
       signupConfig.value = response.record;
       details.value = response.details;
 

--- a/src/tests/composables/useAuthOverrideState.spec.ts
+++ b/src/tests/composables/useAuthOverrideState.spec.ts
@@ -1,0 +1,130 @@
+// src/tests/composables/useAuthOverrideState.spec.ts
+//
+// Pins the badge-driver invariant for the shared auth-override display state
+// (ADR-024, used by both useSigninConfig and useSignupConfig):
+//
+//   isWorkspaceDefault is driven by record.enabled ONLY — never by
+//   details.effective_enabled.
+//
+// This independence is what kept the #3814 resolver change (unconfigured
+// custom domains now resolve effective_enabled: false) from breaking the
+// "Workspace default" badge. The full cross-product below makes any future
+// coupling of the badge to effective_enabled an immediate failure.
+
+import {
+  asExplicitOverride,
+  createAuthOverrideState,
+} from '@/shared/composables/useAuthOverrideState';
+import { describe, expect, it } from 'vitest';
+import { ref } from 'vue';
+
+import type { AuthOverrideDetails } from '@/shared/composables/useAuthOverrideState';
+
+type TestRecord = { enabled: boolean };
+
+function makeState(record: TestRecord | null, details: AuthOverrideDetails | null) {
+  return createAuthOverrideState(ref(record), ref(details));
+}
+
+describe('createAuthOverrideState', () => {
+  describe('isWorkspaceDefault is driven by record.enabled, not effective_enabled (#3814 invariant)', () => {
+    it('record.enabled true → NOT workspace default, even with effective_enabled false', () => {
+      // Pinned domain whose resolver output is off (e.g. explicit
+      // signin_enabled: false override): still explicitly configured.
+      const state = makeState(
+        { enabled: true },
+        { global_enabled: true, effective_enabled: false }
+      );
+
+      expect(state.isWorkspaceDefault.value).toBe(false);
+      expect(state.isExplicitlyConfigured.value).toBe(true);
+    });
+
+    it('record.enabled true → NOT workspace default with effective_enabled true', () => {
+      const state = makeState(
+        { enabled: true },
+        { global_enabled: true, effective_enabled: true }
+      );
+
+      expect(state.isWorkspaceDefault.value).toBe(false);
+      expect(state.isExplicitlyConfigured.value).toBe(true);
+    });
+
+    it('record null → workspace default, even with effective_enabled true (SSO-only tenant carve-out)', () => {
+      // #3814: an unconfigured SSO-only tenant resolves effective_enabled
+      // true, but it is still following workspace defaults — no pin exists.
+      const state = makeState(null, { global_enabled: true, effective_enabled: true });
+
+      expect(state.isWorkspaceDefault.value).toBe(true);
+      expect(state.isExplicitlyConfigured.value).toBe(false);
+    });
+
+    it('record null → workspace default with effective_enabled false', () => {
+      const state = makeState(null, { global_enabled: true, effective_enabled: false });
+
+      expect(state.isWorkspaceDefault.value).toBe(true);
+      expect(state.isExplicitlyConfigured.value).toBe(false);
+    });
+
+    it('legacy record with enabled false → workspace default, regardless of effective_enabled', () => {
+      // The resolver treats an enabled=false record like no record at all.
+      const offEffective = makeState(
+        { enabled: false },
+        { global_enabled: true, effective_enabled: false }
+      );
+      const onEffective = makeState(
+        { enabled: false },
+        { global_enabled: true, effective_enabled: true }
+      );
+
+      expect(offEffective.isWorkspaceDefault.value).toBe(true);
+      expect(onEffective.isWorkspaceDefault.value).toBe(true);
+    });
+
+    it('record null and details null (nothing loaded) → workspace default', () => {
+      const state = makeState(null, null);
+
+      expect(state.isWorkspaceDefault.value).toBe(true);
+      expect(state.isExplicitlyConfigured.value).toBe(false);
+    });
+  });
+
+  describe('globalEnabled / effectiveEnabled / isGloballyDisabled', () => {
+    it('surface the details verbatim; null until details load', () => {
+      const state = makeState(null, null);
+      expect(state.globalEnabled.value).toBeNull();
+      expect(state.effectiveEnabled.value).toBeNull();
+      // Null global is "unknown", not "disabled".
+      expect(state.isGloballyDisabled.value).toBe(false);
+
+      const loaded = makeState(null, { global_enabled: false, effective_enabled: false });
+      expect(loaded.globalEnabled.value).toBe(false);
+      expect(loaded.effectiveEnabled.value).toBe(false);
+      expect(loaded.isGloballyDisabled.value).toBe(true);
+    });
+
+    it('tracks record/details ref changes reactively', () => {
+      const record = ref<TestRecord | null>(null);
+      const details = ref<AuthOverrideDetails | null>(null);
+      const state = createAuthOverrideState(record, details);
+
+      expect(state.isWorkspaceDefault.value).toBe(true);
+
+      record.value = { enabled: true };
+      details.value = { global_enabled: true, effective_enabled: true };
+
+      expect(state.isWorkspaceDefault.value).toBe(false);
+      expect(state.effectiveEnabled.value).toBe(true);
+    });
+  });
+
+  describe('asExplicitOverride', () => {
+    it('forces enabled: true onto any payload (the writes-materialize chokepoint)', () => {
+      expect(asExplicitOverride({ signin_enabled: false, enabled: false })).toEqual({
+        signin_enabled: false,
+        enabled: true,
+      });
+      expect(asExplicitOverride({})).toEqual({ enabled: true });
+    });
+  });
+});

--- a/src/tests/composables/useSigninConfig.spec.ts
+++ b/src/tests/composables/useSigninConfig.spec.ts
@@ -162,11 +162,12 @@ describe('useSigninConfig', () => {
       expect(composable.isConfigured.value).toBe(true);
     });
 
-    it('seeds formState from inherited state when unconfigured (no details: optimistic signin, methods from bootstrap)', async () => {
+    it('seeds formState from inherited state when unconfigured (no details: default-off signin, methods from bootstrap)', async () => {
       // ADR-024 seeding, older-backend shape (details null): signin_enabled
-      // defaults optimistic, method flags mirror global availability (all
-      // available here) — NOT static false, which would flip methods off on
-      // the first unrelated save.
+      // falls back to false — custom domains are default-off opt-in (#3814),
+      // matching useSignupConfig. Method flags still mirror global
+      // availability (all available here) — NOT static false, which would
+      // flip methods off on the first unrelated save.
       mockGetConfigForDomain.mockResolvedValue({ record: null, details: null });
 
       const composable = useSigninConfig('dm-ext-123');
@@ -174,7 +175,7 @@ describe('useSigninConfig', () => {
 
       expect(composable.formState.value).toEqual({
         enabled: false,
-        signin_enabled: true,
+        signin_enabled: false,
         restrict_to: null,
         email_auth_enabled: true,
         sso_enabled: true,
@@ -705,10 +706,11 @@ describe('useSigninConfig', () => {
       await composable.deleteConfig();
 
       // No details on the DELETE response here, so the reseed uses the
-      // optimistic defaults + bootstrap method availability (all available).
+      // default-off signin fallback (#3814) + bootstrap method availability
+      // (all available).
       expect(composable.formState.value).toEqual({
         enabled: false,
-        signin_enabled: true,
+        signin_enabled: false,
         restrict_to: null,
         email_auth_enabled: true,
         sso_enabled: true,
@@ -949,11 +951,12 @@ describe('useSigninConfig', () => {
       // Should not throw
       composable.discardChanges();
 
-      // formState remains at the pre-init seed (no details yet: optimistic
-      // signin, method flags from bootstrap availability — all available).
+      // formState remains at the pre-init seed (no details yet: default-off
+      // signin (#3814), method flags from bootstrap availability — all
+      // available).
       expect(composable.formState.value).toEqual({
         enabled: false,
-        signin_enabled: true,
+        signin_enabled: false,
         restrict_to: null,
         email_auth_enabled: true,
         sso_enabled: true,
@@ -1041,9 +1044,11 @@ describe('useSigninConfig', () => {
     });
 
     it('seeds restrict_to from details.global_restrict_to (inherit: the workspace-wide restriction is pre-selected)', async () => {
+      // Unconfigured non-SSO-tenant domain: default-off, so the resolver
+      // reports effective_enabled false (#3814); restrict_to still seeds.
       mockGetConfigForDomain.mockResolvedValue({
         record: null,
-        details: { global_enabled: true, effective_enabled: true, global_restrict_to: 'sso' },
+        details: { global_enabled: true, effective_enabled: false, global_restrict_to: 'sso' },
       });
 
       const composable = useSigninConfig('dm-ext-123');
@@ -1054,9 +1059,11 @@ describe('useSigninConfig', () => {
 
     it('seeds method flags from global availability (AND semantics: a globally-off method seeds as off, not on)', async () => {
       mockFeatures.value = { email_auth: false, webauthn: true, sso: { enabled: false } };
+      // Unconfigured domain, SSO globally off → no carve-out: default-off
+      // resolver output (#3814).
       mockGetConfigForDomain.mockResolvedValue({
         record: null,
-        details: { global_enabled: true, effective_enabled: true, global_restrict_to: null },
+        details: { global_enabled: true, effective_enabled: false, global_restrict_to: null },
       });
 
       const composable = useSigninConfig('dm-ext-123');
@@ -1077,6 +1084,23 @@ describe('useSigninConfig', () => {
 
       expect(composable.formState.value.signin_enabled).toBe(false);
       expect(composable.formState.value.enabled).toBe(true);
+    });
+
+    it('SSO-only tenant carve-out: unconfigured domain with effective_enabled true seeds signin_enabled true (resolver output passes through)', async () => {
+      // #3814: unconfigured custom domains are default-off (effective_enabled
+      // false) EXCEPT when the tenant has SSO available and no SigninConfig —
+      // the masthead SSO carve-out. The backend resolver reports true in that
+      // case and the frontend does nothing special: it seeds whatever the
+      // resolver reports.
+      mockGetConfigForDomain.mockResolvedValue({
+        record: null,
+        details: { global_enabled: true, effective_enabled: true, global_restrict_to: null },
+      });
+
+      const composable = useSigninConfig('dm-ext-123');
+      await composable.initialize();
+
+      expect(composable.formState.value.signin_enabled).toBe(true);
     });
   });
 
@@ -1121,10 +1145,12 @@ describe('useSigninConfig', () => {
 
     it('an empty autoSaveFields patch still PUTs the full seeded snapshot with enabled: true (pin-without-value-change)', async () => {
       // The form emits an empty patch when a workspace-default domain's user
-      // clicks the mode that already matches the inherited state.
+      // clicks the mode that already matches the inherited state. Unconfigured
+      // domain: default-off resolver output (#3814), so the seeded snapshot
+      // carries signin_enabled false.
       mockGetConfigForDomain.mockResolvedValue({
         record: null,
-        details: { global_enabled: true, effective_enabled: true, global_restrict_to: null },
+        details: { global_enabled: true, effective_enabled: false, global_restrict_to: null },
       });
 
       const composable = useSigninConfig('dm-ext-123');
@@ -1134,7 +1160,7 @@ describe('useSigninConfig', () => {
 
       expect(mockPutConfigForDomain).toHaveBeenCalledWith(
         'dm-ext-123',
-        expect.objectContaining({ enabled: true, signin_enabled: true, restrict_to: null })
+        expect.objectContaining({ enabled: true, signin_enabled: false, restrict_to: null })
       );
     });
   });
@@ -1148,9 +1174,11 @@ describe('useSigninConfig', () => {
 
   describe('ADR-024: override display state', () => {
     it('no record → isWorkspaceDefault (inherit), not explicitly configured', async () => {
+      // Unconfigured domain: default-off resolver output (#3814). The badge
+      // is driven by record.enabled, not effective_enabled.
       mockGetConfigForDomain.mockResolvedValue({
         record: null,
-        details: { global_enabled: true, effective_enabled: true, global_restrict_to: null },
+        details: { global_enabled: true, effective_enabled: false, global_restrict_to: null },
       });
 
       const composable = useSigninConfig('dm-ext-123');
@@ -1161,9 +1189,11 @@ describe('useSigninConfig', () => {
     });
 
     it('a legacy record with enabled=false still counts as workspace default (the resolver ignores it)', async () => {
+      // The resolver treats an enabled=false record like no record at all,
+      // so the domain resolves default-off (#3814).
       mockGetConfigForDomain.mockResolvedValue({
         record: { ...mockSigninConfigData, enabled: false },
-        details: { global_enabled: true, effective_enabled: true, global_restrict_to: null },
+        details: { global_enabled: true, effective_enabled: false, global_restrict_to: null },
       });
 
       const composable = useSigninConfig('dm-ext-123');
@@ -1214,46 +1244,52 @@ describe('useSigninConfig', () => {
     });
 
     it('PUT response details refresh the display state (effective flips with the save, no refetch)', async () => {
+      // Unconfigured domain starts default-off (#3814); explicitly enabling
+      // signin flips the resolver output to true via the PUT response details.
       mockGetConfigForDomain.mockResolvedValue({
         record: null,
-        details: { global_enabled: true, effective_enabled: true, global_restrict_to: null },
+        details: { global_enabled: true, effective_enabled: false, global_restrict_to: null },
       });
       mockPutConfigForDomain.mockResolvedValue({
-        record: { ...mockSigninConfigData, signin_enabled: false },
-        details: { global_enabled: true, effective_enabled: false, global_restrict_to: null },
+        record: { ...mockSigninConfigData, signin_enabled: true },
+        details: { global_enabled: true, effective_enabled: true, global_restrict_to: null },
       });
 
       const composable = useSigninConfig('dm-ext-123');
       await composable.initialize();
-      expect(composable.effectiveEnabled.value).toBe(true);
-
-      await composable.autoSaveField('signin_enabled', false);
-
       expect(composable.effectiveEnabled.value).toBe(false);
+
+      await composable.autoSaveField('signin_enabled', true);
+
+      expect(composable.effectiveEnabled.value).toBe(true);
       expect(composable.isWorkspaceDefault.value).toBe(false);
     });
 
     it('deleteConfig unpins: DELETE response details reseed the form to the inherited state', async () => {
+      // Explicitly-enabled record → effective true; deleting it returns the
+      // domain to the unconfigured default-off state (#3814), and the reseed
+      // reflects that resolution without a refetch.
       mockGetConfigForDomain.mockResolvedValue({
-        record: { ...mockSigninConfigData, signin_enabled: false },
-        details: { global_enabled: true, effective_enabled: false, global_restrict_to: null },
+        record: { ...mockSigninConfigData, signin_enabled: true },
+        details: { global_enabled: true, effective_enabled: true, global_restrict_to: null },
       });
       mockDeleteConfigForDomain.mockResolvedValue({
         success: true,
-        details: { global_enabled: true, effective_enabled: true, global_restrict_to: null },
+        details: { global_enabled: true, effective_enabled: false, global_restrict_to: null },
       });
 
       const composable = useSigninConfig('dm-ext-123');
       await composable.initialize();
-      expect(composable.formState.value.signin_enabled).toBe(false);
+      expect(composable.formState.value.signin_enabled).toBe(true);
 
       await composable.deleteConfig();
 
-      // Back to workspace defaults: the form reflects the post-delete
-      // resolution (inherited signin available again).
+      // Back to workspace defaults: custom domains are default-off, so the
+      // post-delete resolution reports signin unavailable and the form
+      // reseeds to false.
       expect(composable.isWorkspaceDefault.value).toBe(true);
-      expect(composable.effectiveEnabled.value).toBe(true);
-      expect(composable.formState.value.signin_enabled).toBe(true);
+      expect(composable.effectiveEnabled.value).toBe(false);
+      expect(composable.formState.value.signin_enabled).toBe(false);
     });
   });
 });

--- a/src/tests/composables/useSigninConfig.spec.ts
+++ b/src/tests/composables/useSigninConfig.spec.ts
@@ -71,12 +71,16 @@ vi.mock('vue-i18n', () => ({
   }),
 }));
 
+// Mirrors the real wrap error-boundary: catches, forwards to onError (which
+// the composable uses to set error.value), returns undefined. Without the
+// onError forwarding, the fail-loud initialize contract would be untestable.
 vi.mock('@/shared/composables/useAsyncHandler', () => ({
-  useAsyncHandler: () => ({
+  useAsyncHandler: (options?: { onError?: (err: unknown) => void }) => ({
     wrap: vi.fn(async (fn: () => Promise<unknown>) => {
       try {
         return await fn();
-      } catch {
+      } catch (err) {
+        options?.onError?.(err);
         return undefined;
       }
     }),
@@ -112,6 +116,16 @@ const _mockDisabledConfig: CustomDomainSigninConfig = {
   email_auth_enabled: false,
 };
 
+// Resolution details for an unconfigured domain under an enabled global:
+// default-off resolver output (#3814). `details` is required on GET/PUT
+// responses — a response without it is a failed load, never a seedable
+// state (PR #3817).
+const mockUnconfiguredDetails = {
+  global_enabled: true,
+  effective_enabled: false,
+  global_restrict_to: null,
+};
+
 // -----------------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------------
@@ -122,9 +136,10 @@ describe('useSigninConfig', () => {
     vi.clearAllMocks();
     mockFeatures.value = undefined; // all methods globally available
 
-    // Default: no existing config (unconfigured), no resolution details
-    // (older-backend fallback shape)
-    mockGetConfigForDomain.mockResolvedValue({ record: null, details: null });
+    // Default: no existing config (unconfigured) with resolution details —
+    // the modern backend always sends details; a details-less response is a
+    // failed load (covered explicitly below).
+    mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
     mockPutConfigForDomain.mockResolvedValue({ record: mockSigninConfigData });
     mockDeleteConfigForDomain.mockResolvedValue({ success: true });
   });
@@ -134,8 +149,8 @@ describe('useSigninConfig', () => {
   // ---------------------------------------------------------------------------
 
   describe('initialize', () => {
-    it('sets signinConfig to null when domain is unconfigured (404)', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+    it('sets signinConfig to null when domain is unconfigured', async () => {
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
 
       const composable = useSigninConfig('dm-ext-123');
       await composable.initialize();
@@ -143,6 +158,20 @@ describe('useSigninConfig', () => {
       expect(composable.signinConfig.value).toBeNull();
       expect(composable.isConfigured.value).toBe(false);
       expect(composable.isInitialized.value).toBe(true);
+    });
+
+    it('fails initialization when the response has neither record nor details (older-backend 404 / failed parse)', async () => {
+      // The seed is a guess about the inherited state; an autosave would
+      // materialize it as an explicit override — on an SSO-only domain that
+      // would persist signin_enabled: false and disable sign-in (PR #3817).
+      // Fail loudly instead: error set, never initialized.
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: null });
+
+      const composable = useSigninConfig('dm-ext-123');
+      await composable.initialize();
+
+      expect(composable.error.value?.message).toBe('An unexpected error occurred');
+      expect(composable.isInitialized.value).toBe(false);
     });
 
     it('populates formState from existing config', async () => {
@@ -162,24 +191,19 @@ describe('useSigninConfig', () => {
       expect(composable.isConfigured.value).toBe(true);
     });
 
-    it('seeds formState from inherited state when unconfigured (no details: default-off signin, methods from bootstrap)', async () => {
-      // ADR-024 seeding, older-backend shape (details null): signin_enabled
-      // falls back to false — custom domains are default-off opt-in (#3814),
-      // matching useSignupConfig. Method flags still mirror global
-      // availability (all available here) — NOT static false, which would
-      // flip methods off on the first unrelated save.
+    it('does not seed or snapshot on a details-less response (nothing to materialize)', async () => {
+      // Companion to the fail-loud contract: the failed initialize must leave
+      // no saved snapshot behind — savedFormState stays null, so there is no
+      // materializable state for a later save to persist.
       mockGetConfigForDomain.mockResolvedValue({ record: null, details: null });
 
       const composable = useSigninConfig('dm-ext-123');
+      const placeholder = { ...composable.formState.value };
       await composable.initialize();
 
-      expect(composable.formState.value).toEqual({
-        enabled: false,
-        signin_enabled: false,
-        restrict_to: null,
-        email_auth_enabled: true,
-        sso_enabled: true,
-      });
+      expect(composable.formState.value).toEqual(placeholder);
+      expect(composable.hasUnsavedChanges.value).toBe(false);
+      expect(composable.details.value).toBeNull();
     });
 
     it('snapshots savedFormState on load', async () => {
@@ -229,6 +253,33 @@ describe('useSigninConfig', () => {
 
       expect(composable.formState.value.restrict_to).toBeNull();
     });
+
+    it('defaults a null or missing signin_enabled to false (conservative default, #3814)', async () => {
+      // The shape types signin_enabled as boolean, but the mocked service
+      // bypasses Zod parsing, so a legacy/unparsed record can reach
+      // configToFormState with signin_enabled null. The fallback must be OFF:
+      // custom domains are default-off opt-in, matching useSignupConfig.
+      const configWithNullSignin = {
+        ...mockSigninConfigData,
+        signin_enabled: null,
+      } as unknown as CustomDomainSigninConfig;
+      mockGetConfigForDomain.mockResolvedValue({ record: configWithNullSignin });
+
+      const composable = useSigninConfig('dm-ext-123');
+      await composable.initialize();
+
+      expect(composable.formState.value.signin_enabled).toBe(false);
+
+      const { signin_enabled: _omit, ...configWithoutSignin } = mockSigninConfigData;
+      mockGetConfigForDomain.mockResolvedValue({
+        record: configWithoutSignin as unknown as CustomDomainSigninConfig,
+      });
+
+      const fresh = useSigninConfig('dm-ext-123');
+      await fresh.initialize();
+
+      expect(fresh.formState.value.signin_enabled).toBe(false);
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -237,7 +288,7 @@ describe('useSigninConfig', () => {
 
   describe('saveConfig', () => {
     it('sends all form fields in PUT payload', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       const composable = useSigninConfig('dm-ext-123');
       await composable.initialize();
 
@@ -265,7 +316,7 @@ describe('useSigninConfig', () => {
         ...mockSigninConfigData,
         sso_enabled: true,
       };
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       mockPutConfigForDomain.mockResolvedValue({ record: updatedConfig });
 
       const composable = useSigninConfig('dm-ext-123');
@@ -285,7 +336,7 @@ describe('useSigninConfig', () => {
     });
 
     it('updates savedFormState snapshot after successful save', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       mockPutConfigForDomain.mockResolvedValue({ record: mockSigninConfigData });
 
       const composable = useSigninConfig('dm-ext-123');
@@ -307,7 +358,7 @@ describe('useSigninConfig', () => {
     });
 
     it('shows success notification after save', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       const composable = useSigninConfig('dm-ext-123');
       await composable.initialize();
 
@@ -329,7 +380,7 @@ describe('useSigninConfig', () => {
     });
 
     it('sets isSaving during operation', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       let resolveSave: (value: unknown) => void;
       mockPutConfigForDomain.mockImplementation(
         () =>
@@ -359,7 +410,7 @@ describe('useSigninConfig', () => {
     });
 
     it('resets isSaving even when save fails', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       mockPutConfigForDomain.mockRejectedValue(new Error('Network error'));
 
       const composable = useSigninConfig('dm-ext-123');
@@ -423,7 +474,7 @@ describe('useSigninConfig', () => {
 
   describe('autoSaveField', () => {
     it('updates the field then persists via PUT', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       mockPutConfigForDomain.mockResolvedValue({
         record: { ...mockSigninConfigData, sso_enabled: true },
       });
@@ -441,7 +492,7 @@ describe('useSigninConfig', () => {
     });
 
     it('commits other pending edits in the same full-replacement PUT', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       const composable = useSigninConfig('dm-ext-123');
       await composable.initialize();
 
@@ -461,7 +512,7 @@ describe('useSigninConfig', () => {
     });
 
     it('exposes savingField while the save is in flight, clears it after', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       let resolveSave: (value: unknown) => void;
       mockPutConfigForDomain.mockImplementation(
         () =>
@@ -483,7 +534,7 @@ describe('useSigninConfig', () => {
     });
 
     it('clears savingField even when the save fails', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       mockPutConfigForDomain.mockRejectedValue(new Error('Network error'));
 
       const composable = useSigninConfig('dm-ext-123');
@@ -495,7 +546,7 @@ describe('useSigninConfig', () => {
     });
 
     it('reverts formState to the saved snapshot when the PUT fails', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null, details: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       mockPutConfigForDomain.mockRejectedValue(new Error('Network error'));
 
       const composable = useSigninConfig('dm-ext-123');
@@ -512,7 +563,7 @@ describe('useSigninConfig', () => {
     });
 
     it('ignores concurrent calls while a save is already running', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       let resolveSave: (value: unknown) => void;
       mockPutConfigForDomain.mockImplementation(
         () =>
@@ -537,7 +588,7 @@ describe('useSigninConfig', () => {
     });
 
     it('leaves hasUnsavedChanges false after a clean auto-save', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       mockPutConfigForDomain.mockResolvedValue({
         record: { ...mockSigninConfigData, sso_enabled: true },
       });
@@ -563,7 +614,7 @@ describe('useSigninConfig', () => {
 
   describe('autoSaveFields', () => {
     it('merges a multi-key partial and sends all of it in one full-replacement PUT', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       mockPutConfigForDomain.mockResolvedValue({
         record: { ...mockSigninConfigData, restrict_to: 'sso', sso_enabled: true },
       });
@@ -585,7 +636,7 @@ describe('useSigninConfig', () => {
     });
 
     it('attributes savingField to the explicit hint when provided', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       let resolveSave: (value: unknown) => void;
       mockPutConfigForDomain.mockImplementation(
         () =>
@@ -611,7 +662,7 @@ describe('useSigninConfig', () => {
     });
 
     it('defaults savingField to the first partial key when no hint is given', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       let resolveSave: (value: unknown) => void;
       mockPutConfigForDomain.mockImplementation(
         () =>
@@ -656,7 +707,7 @@ describe('useSigninConfig', () => {
     });
 
     it('is a no-op while a save is already in flight (multi-key path)', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       let resolveSave: (value: unknown) => void;
       mockPutConfigForDomain.mockImplementation(
         () =>
@@ -1014,7 +1065,7 @@ describe('useSigninConfig', () => {
     });
 
     it('isConfigured returns false when signinConfig is null', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       const composable = useSigninConfig('dm-ext-123');
       await composable.initialize();
 
@@ -1115,7 +1166,7 @@ describe('useSigninConfig', () => {
 
   describe('ADR-024: writes materialize an explicit override (pinning)', () => {
     it('saveConfig forces enabled: true in the PUT even while formState.enabled is false (saving = pinning)', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null, details: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
 
       const composable = useSigninConfig('dm-ext-123');
       await composable.initialize();
@@ -1130,7 +1181,7 @@ describe('useSigninConfig', () => {
     });
 
     it('autoSave pins too: a single toggle flip on an unconfigured domain sends enabled: true (never an enabled=false record)', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null, details: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
 
       const composable = useSigninConfig('dm-ext-123');
       await composable.initialize();

--- a/src/tests/composables/useSignupConfig.spec.ts
+++ b/src/tests/composables/useSignupConfig.spec.ts
@@ -1,0 +1,624 @@
+// src/tests/composables/useSignupConfig.spec.ts
+//
+// Tests for useSignupConfig composable covering:
+// 1. initialize(): null record = unconfigured, populates formState from config
+// 2. saveConfig(): PUT full replacement with strategy-conditional allowlist
+// 3. deleteConfig(): unpins and reseeds from inherited state
+// 4. hasUnsavedChanges / discardChanges: form lifecycle
+// 5. ADR-024 / #3814: seeding signup_enabled from details.effective_enabled
+//    (custom domains are default-off opt-in; null details fall back to false)
+//    and the writes-materialize pinning (asExplicitOverride).
+//
+// Mirrors the structure of useSigninConfig.spec.ts for the paths the two
+// composables share. Signup has no autoSaveField/autoSaveFields and no
+// bootstrap-driven method flags, so those blocks have no equivalent here.
+
+import { useSignupConfig } from '@/shared/composables/useSignupConfig';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CustomDomainSignupConfig } from '@/schemas/shapes/domains/signup-config';
+
+// -----------------------------------------------------------------------------
+// Mock Setup
+// -----------------------------------------------------------------------------
+
+const mockGetConfigForDomain = vi.fn();
+const mockPutConfigForDomain = vi.fn();
+const mockDeleteConfigForDomain = vi.fn();
+const mockNotificationsShow = vi.fn();
+const mockRouterPush = vi.fn();
+
+vi.mock('@/services/signup-config.service', () => ({
+  SignupConfigService: {
+    getConfigForDomain: (...args: unknown[]) => mockGetConfigForDomain(...args),
+    putConfigForDomain: (...args: unknown[]) => mockPutConfigForDomain(...args),
+    deleteConfigForDomain: (...args: unknown[]) => mockDeleteConfigForDomain(...args),
+  },
+}));
+
+vi.mock('@/shared/stores', () => ({
+  useNotificationsStore: () => ({
+    show: mockNotificationsShow,
+  }),
+}));
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+  }),
+}));
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'web.domains.signup.update_success': 'Signup configuration updated',
+        'web.domains.signup.delete_success': 'Signup configuration deleted',
+        'web.COMMON.unexpected_error': 'An unexpected error occurred',
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('@/shared/composables/useAsyncHandler', () => ({
+  useAsyncHandler: () => ({
+    wrap: vi.fn(async (fn: () => Promise<unknown>) => {
+      try {
+        return await fn();
+      } catch {
+        return undefined;
+      }
+    }),
+  }),
+  createError: vi.fn(),
+}));
+
+// -----------------------------------------------------------------------------
+// Test Fixtures
+// -----------------------------------------------------------------------------
+
+const mockSignupConfigData: CustomDomainSignupConfig = {
+  domain_id: 'domain-123',
+  validation_strategy: 'domain_allowlist',
+  allowed_signup_domains: ['acme.com', 'partner.com'],
+  enabled: true,
+  signup_enabled: true,
+  autoverify: false,
+  requires_allowlist: true,
+  network_validation: false,
+  created_at: new Date('2025-01-01T00:00:00Z'),
+  updated_at: new Date('2025-01-15T10:00:00Z'),
+};
+
+const mockPassthroughConfig: CustomDomainSignupConfig = {
+  ...mockSignupConfigData,
+  validation_strategy: 'passthrough',
+  allowed_signup_domains: [],
+  requires_allowlist: false,
+};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+describe('useSignupConfig', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+
+    // Default: no existing config (unconfigured), no resolution details
+    // (older-backend fallback shape)
+    mockGetConfigForDomain.mockResolvedValue({ record: null, details: null });
+    mockPutConfigForDomain.mockResolvedValue({ record: mockSignupConfigData });
+    mockDeleteConfigForDomain.mockResolvedValue({ success: true });
+  });
+
+  // ---------------------------------------------------------------------------
+  // initialize
+  // ---------------------------------------------------------------------------
+
+  describe('initialize', () => {
+    it('sets signupConfig to null when domain is unconfigured', async () => {
+      mockGetConfigForDomain.mockResolvedValue({ record: null });
+
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      expect(composable.signupConfig.value).toBeNull();
+      expect(composable.isConfigured.value).toBe(false);
+      expect(composable.isInitialized.value).toBe(true);
+    });
+
+    it('populates formState from existing config', async () => {
+      mockGetConfigForDomain.mockResolvedValue({ record: mockSignupConfigData });
+
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      expect(composable.signupConfig.value).toEqual(mockSignupConfigData);
+      expect(composable.formState.value).toEqual({
+        validation_strategy: 'domain_allowlist',
+        allowed_signup_domains: ['acme.com', 'partner.com'],
+        enabled: true,
+        signup_enabled: true,
+        autoverify: false,
+      });
+      expect(composable.isConfigured.value).toBe(true);
+    });
+
+    it('seeds formState with static defaults when unconfigured and details are null (#3814 ?? false fallback)', async () => {
+      // Older-backend shape (details null): signup_enabled falls back to
+      // false — custom domains are default-off opt-in (#3814). Never seeded
+      // from the canonical follows-global resolver.
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: null });
+
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      expect(composable.formState.value).toEqual({
+        validation_strategy: 'passthrough',
+        allowed_signup_domains: [],
+        enabled: false,
+        signup_enabled: false,
+        autoverify: false,
+      });
+    });
+
+    it('snapshots savedFormState on load', async () => {
+      mockGetConfigForDomain.mockResolvedValue({ record: mockSignupConfigData });
+
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      expect(composable.hasUnsavedChanges.value).toBe(false);
+    });
+
+    it('calls SignupConfigService.getConfigForDomain with correct extid', async () => {
+      const composable = useSignupConfig('dm-ext-456');
+      await composable.initialize();
+
+      expect(mockGetConfigForDomain).toHaveBeenCalledWith('dm-ext-456');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // saveConfig
+  // ---------------------------------------------------------------------------
+
+  describe('saveConfig', () => {
+    it('sends strategy, signup_enabled, autoverify and allowlist in PUT payload (domain_allowlist)', async () => {
+      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      composable.formState.value = {
+        validation_strategy: 'domain_allowlist',
+        allowed_signup_domains: ['acme.com'],
+        enabled: true,
+        signup_enabled: true,
+        autoverify: true,
+      };
+
+      await composable.saveConfig();
+
+      expect(mockPutConfigForDomain).toHaveBeenCalledWith('dm-ext-123', {
+        validation_strategy: 'domain_allowlist',
+        allowed_signup_domains: ['acme.com'],
+        enabled: true,
+        signup_enabled: true,
+        autoverify: true,
+      });
+    });
+
+    it('omits allowed_signup_domains when strategy does not use it (PUT semantics clear it server-side)', async () => {
+      mockGetConfigForDomain.mockResolvedValue({ record: mockSignupConfigData });
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      composable.formState.value = {
+        ...composable.formState.value,
+        validation_strategy: 'passthrough',
+      };
+
+      await composable.saveConfig();
+
+      expect(mockPutConfigForDomain).toHaveBeenCalledWith(
+        'dm-ext-123',
+        expect.not.objectContaining({ allowed_signup_domains: expect.anything() })
+      );
+    });
+
+    it('updates signupConfig and snapshot after successful save', async () => {
+      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockPutConfigForDomain.mockResolvedValue({ record: mockPassthroughConfig });
+
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      composable.formState.value = {
+        ...composable.formState.value,
+        signup_enabled: true,
+      };
+      expect(composable.hasUnsavedChanges.value).toBe(true);
+
+      await composable.saveConfig();
+
+      expect(composable.signupConfig.value).toEqual(mockPassthroughConfig);
+      expect(composable.hasUnsavedChanges.value).toBe(false);
+    });
+
+    it('shows success notification after save', async () => {
+      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      await composable.saveConfig();
+
+      expect(mockNotificationsShow).toHaveBeenCalledWith(
+        'Signup configuration updated',
+        'success',
+        'top'
+      );
+    });
+
+    it('sets isSaving during operation and clears it after', async () => {
+      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      let resolveSave: (value: unknown) => void;
+      mockPutConfigForDomain.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveSave = resolve;
+          })
+      );
+
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      const savePromise = composable.saveConfig();
+      expect(composable.isSaving.value).toBe(true);
+
+      resolveSave!({ record: mockSignupConfigData });
+      await savePromise;
+
+      expect(composable.isSaving.value).toBe(false);
+    });
+
+    it('resets isSaving and preserves state when save fails', async () => {
+      mockGetConfigForDomain.mockResolvedValue({ record: mockSignupConfigData });
+      mockPutConfigForDomain.mockRejectedValue(new Error('Server error'));
+
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      const originalConfig = composable.signupConfig.value;
+      composable.formState.value = {
+        ...composable.formState.value,
+        autoverify: true,
+      };
+
+      await composable.saveConfig();
+
+      expect(composable.isSaving.value).toBe(false);
+      expect(composable.signupConfig.value).toEqual(originalConfig);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteConfig
+  // ---------------------------------------------------------------------------
+
+  describe('deleteConfig', () => {
+    it('resets signupConfig to null after deletion', async () => {
+      mockGetConfigForDomain.mockResolvedValue({ record: mockSignupConfigData });
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      expect(composable.isConfigured.value).toBe(true);
+
+      await composable.deleteConfig();
+
+      expect(composable.signupConfig.value).toBeNull();
+      expect(composable.isConfigured.value).toBe(false);
+    });
+
+    it('reseeds formState from inherited state after deletion (no details: default-off fallback)', async () => {
+      mockGetConfigForDomain.mockResolvedValue({ record: mockSignupConfigData });
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      await composable.deleteConfig();
+
+      expect(composable.formState.value).toEqual({
+        validation_strategy: 'passthrough',
+        allowed_signup_domains: [],
+        enabled: false,
+        signup_enabled: false,
+        autoverify: false,
+      });
+      expect(composable.hasUnsavedChanges.value).toBe(false);
+    });
+
+    it('calls SignupConfigService.deleteConfigForDomain with correct extid and notifies', async () => {
+      mockGetConfigForDomain.mockResolvedValue({ record: mockSignupConfigData });
+      const composable = useSignupConfig('dm-ext-456');
+      await composable.initialize();
+
+      await composable.deleteConfig();
+
+      expect(mockDeleteConfigForDomain).toHaveBeenCalledWith('dm-ext-456');
+      expect(mockNotificationsShow).toHaveBeenCalledWith(
+        'Signup configuration deleted',
+        'success',
+        'top'
+      );
+    });
+
+    it('sets isDeleting during operation and preserves state when delete throws', async () => {
+      mockGetConfigForDomain.mockResolvedValue({ record: mockSignupConfigData });
+      mockDeleteConfigForDomain.mockRejectedValue(new Error('Permission denied'));
+
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      const originalConfig = composable.signupConfig.value;
+
+      await composable.deleteConfig();
+
+      // The service call is the first statement in the wrapAction callback
+      // and throws, so the state reset after it never runs.
+      expect(composable.signupConfig.value).toEqual(originalConfig);
+      expect(composable.isDeleting.value).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // hasUnsavedChanges / discardChanges
+  // ---------------------------------------------------------------------------
+
+  describe('hasUnsavedChanges', () => {
+    it('returns true when signup_enabled is toggled', async () => {
+      mockGetConfigForDomain.mockResolvedValue({ record: mockSignupConfigData });
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      composable.formState.value = {
+        ...composable.formState.value,
+        signup_enabled: false,
+      };
+
+      expect(composable.hasUnsavedChanges.value).toBe(true);
+    });
+
+    it('treats allowlist reordering as unchanged (order-insensitive compare)', async () => {
+      mockGetConfigForDomain.mockResolvedValue({ record: mockSignupConfigData });
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      composable.formState.value = {
+        ...composable.formState.value,
+        allowed_signup_domains: ['partner.com', 'acme.com'],
+      };
+
+      expect(composable.hasUnsavedChanges.value).toBe(false);
+    });
+
+    it('returns true when allowlist membership changes', async () => {
+      mockGetConfigForDomain.mockResolvedValue({ record: mockSignupConfigData });
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      composable.formState.value = {
+        ...composable.formState.value,
+        allowed_signup_domains: ['acme.com', 'other.com'],
+      };
+
+      expect(composable.hasUnsavedChanges.value).toBe(true);
+    });
+
+    it('returns false before initialization (no savedFormState)', () => {
+      const composable = useSignupConfig('dm-ext-123');
+      expect(composable.hasUnsavedChanges.value).toBe(false);
+    });
+  });
+
+  describe('discardChanges', () => {
+    it('restores all fields from savedFormState', async () => {
+      mockGetConfigForDomain.mockResolvedValue({ record: mockSignupConfigData });
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      const originalFormData = {
+        ...composable.formState.value,
+        allowed_signup_domains: [...composable.formState.value.allowed_signup_domains],
+      };
+
+      composable.formState.value = {
+        validation_strategy: 'mx',
+        allowed_signup_domains: [],
+        enabled: false,
+        signup_enabled: false,
+        autoverify: true,
+      };
+      expect(composable.hasUnsavedChanges.value).toBe(true);
+
+      composable.discardChanges();
+
+      expect(composable.formState.value).toEqual(originalFormData);
+      expect(composable.hasUnsavedChanges.value).toBe(false);
+    });
+
+    it('is a no-op when savedFormState is null (before init)', () => {
+      const composable = useSignupConfig('dm-ext-123');
+
+      composable.discardChanges();
+
+      expect(composable.formState.value).toEqual({
+        validation_strategy: 'passthrough',
+        allowed_signup_domains: [],
+        enabled: false,
+        signup_enabled: false,
+        autoverify: false,
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // ADR-024 / #3814: seeding from inherited state
+  //
+  // An UNCONFIGURED domain's form is seeded from the resolution details the
+  // API returns (what actually runs), never from the canonical follows-global
+  // resolver. Custom domains are default-off opt-in for signup (#3814).
+  // ---------------------------------------------------------------------------
+
+  describe('ADR-024: seeding from inherited state (#3814)', () => {
+    it('seeds signup_enabled false from details.effective_enabled false (default-off custom domain, global on)', async () => {
+      // The #3814 shape: global signup is enabled but the unconfigured custom
+      // domain resolves OFF. Before the fix this seeded true.
+      mockGetConfigForDomain.mockResolvedValue({
+        record: null,
+        details: { global_enabled: true, effective_enabled: false },
+      });
+
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      expect(composable.formState.value.signup_enabled).toBe(false);
+    });
+
+    it('seeds signup_enabled true from details.effective_enabled true (resolver output passes through)', async () => {
+      mockGetConfigForDomain.mockResolvedValue({
+        record: null,
+        details: { global_enabled: true, effective_enabled: true },
+      });
+
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      expect(composable.formState.value.signup_enabled).toBe(true);
+    });
+
+    it('falls back to signup_enabled false when details are null (?? false, never the global flag)', async () => {
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: null });
+
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      expect(composable.formState.value.signup_enabled).toBe(false);
+    });
+
+    it('an explicit record wins over seeding', async () => {
+      mockGetConfigForDomain.mockResolvedValue({
+        record: { ...mockSignupConfigData, signup_enabled: false },
+        details: { global_enabled: true, effective_enabled: false },
+      });
+
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      expect(composable.formState.value.signup_enabled).toBe(false);
+      expect(composable.formState.value.enabled).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // ADR-024: writes materialize an explicit override (pinning)
+  // ---------------------------------------------------------------------------
+
+  describe('ADR-024: writes materialize an explicit override (pinning)', () => {
+    it('saveConfig forces enabled: true in the PUT even while formState.enabled is false (saving = pinning)', async () => {
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: null });
+
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+      expect(composable.formState.value.enabled).toBe(false);
+
+      await composable.saveConfig();
+
+      expect(mockPutConfigForDomain).toHaveBeenCalledWith(
+        'dm-ext-123',
+        expect.objectContaining({ enabled: true })
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // ADR-024: override display state
+  // ---------------------------------------------------------------------------
+
+  describe('ADR-024: override display state', () => {
+    it('no record → isWorkspaceDefault; badge driven by record.enabled, not effective_enabled', async () => {
+      mockGetConfigForDomain.mockResolvedValue({
+        record: null,
+        details: { global_enabled: true, effective_enabled: false },
+      });
+
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      expect(composable.isWorkspaceDefault.value).toBe(true);
+      expect(composable.isExplicitlyConfigured.value).toBe(false);
+      expect(composable.globalEnabled.value).toBe(true);
+      expect(composable.effectiveEnabled.value).toBe(false);
+    });
+
+    it('a record with enabled=true is explicitly configured (pinned)', async () => {
+      mockGetConfigForDomain.mockResolvedValue({
+        record: mockSignupConfigData,
+        details: { global_enabled: true, effective_enabled: true },
+      });
+
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+
+      expect(composable.isWorkspaceDefault.value).toBe(false);
+      expect(composable.isExplicitlyConfigured.value).toBe(true);
+    });
+
+    it('PUT response details refresh the display state (effective flips with the save, no refetch)', async () => {
+      mockGetConfigForDomain.mockResolvedValue({
+        record: null,
+        details: { global_enabled: true, effective_enabled: false },
+      });
+      mockPutConfigForDomain.mockResolvedValue({
+        record: mockPassthroughConfig,
+        details: { global_enabled: true, effective_enabled: true },
+      });
+
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+      expect(composable.effectiveEnabled.value).toBe(false);
+
+      composable.formState.value = {
+        ...composable.formState.value,
+        signup_enabled: true,
+      };
+      await composable.saveConfig();
+
+      expect(composable.effectiveEnabled.value).toBe(true);
+      expect(composable.isWorkspaceDefault.value).toBe(false);
+    });
+
+    it('deleteConfig unpins: DELETE response details reseed the form to the inherited default-off state', async () => {
+      mockGetConfigForDomain.mockResolvedValue({
+        record: mockSignupConfigData,
+        details: { global_enabled: true, effective_enabled: true },
+      });
+      mockDeleteConfigForDomain.mockResolvedValue({
+        success: true,
+        details: { global_enabled: true, effective_enabled: false },
+      });
+
+      const composable = useSignupConfig('dm-ext-123');
+      await composable.initialize();
+      expect(composable.formState.value.signup_enabled).toBe(true);
+
+      await composable.deleteConfig();
+
+      expect(composable.isWorkspaceDefault.value).toBe(true);
+      expect(composable.effectiveEnabled.value).toBe(false);
+      expect(composable.formState.value.signup_enabled).toBe(false);
+    });
+  });
+});

--- a/src/tests/composables/useSignupConfig.spec.ts
+++ b/src/tests/composables/useSignupConfig.spec.ts
@@ -62,12 +62,16 @@ vi.mock('vue-i18n', () => ({
   }),
 }));
 
+// Mirrors the real wrap error-boundary: catches, forwards to onError (which
+// the composable uses to set error.value), returns undefined. Without the
+// onError forwarding, the fail-loud initialize contract would be untestable.
 vi.mock('@/shared/composables/useAsyncHandler', () => ({
-  useAsyncHandler: () => ({
+  useAsyncHandler: (options?: { onError?: (err: unknown) => void }) => ({
     wrap: vi.fn(async (fn: () => Promise<unknown>) => {
       try {
         return await fn();
-      } catch {
+      } catch (err) {
+        options?.onError?.(err);
         return undefined;
       }
     }),
@@ -99,6 +103,15 @@ const mockPassthroughConfig: CustomDomainSignupConfig = {
   requires_allowlist: false,
 };
 
+// Resolution details for an unconfigured domain under an enabled global:
+// default-off resolver output (#3814). `details` is required on GET/PUT
+// responses — a response without it is a failed load, never a seedable
+// state (PR #3817).
+const mockUnconfiguredDetails = {
+  global_enabled: true,
+  effective_enabled: false,
+};
+
 // -----------------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------------
@@ -108,9 +121,10 @@ describe('useSignupConfig', () => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
 
-    // Default: no existing config (unconfigured), no resolution details
-    // (older-backend fallback shape)
-    mockGetConfigForDomain.mockResolvedValue({ record: null, details: null });
+    // Default: no existing config (unconfigured) with resolution details —
+    // the modern backend always sends details; a details-less response is a
+    // failed load (covered explicitly below).
+    mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
     mockPutConfigForDomain.mockResolvedValue({ record: mockSignupConfigData });
     mockDeleteConfigForDomain.mockResolvedValue({ success: true });
   });
@@ -121,7 +135,7 @@ describe('useSignupConfig', () => {
 
   describe('initialize', () => {
     it('sets signupConfig to null when domain is unconfigured', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
 
       const composable = useSignupConfig('dm-ext-123');
       await composable.initialize();
@@ -148,22 +162,19 @@ describe('useSignupConfig', () => {
       expect(composable.isConfigured.value).toBe(true);
     });
 
-    it('seeds formState with static defaults when unconfigured and details are null (#3814 ?? false fallback)', async () => {
-      // Older-backend shape (details null): signup_enabled falls back to
-      // false — custom domains are default-off opt-in (#3814). Never seeded
-      // from the canonical follows-global resolver.
+    it('fails initialization when the response has neither record nor details (older-backend 404 / failed parse)', async () => {
+      // The seed is a guess about the inherited state; a save would
+      // materialize it as an explicit override (PR #3817, mirroring
+      // useSigninConfig). Fail loudly instead: error set, never initialized,
+      // no saved snapshot to persist.
       mockGetConfigForDomain.mockResolvedValue({ record: null, details: null });
 
       const composable = useSignupConfig('dm-ext-123');
       await composable.initialize();
 
-      expect(composable.formState.value).toEqual({
-        validation_strategy: 'passthrough',
-        allowed_signup_domains: [],
-        enabled: false,
-        signup_enabled: false,
-        autoverify: false,
-      });
+      expect(composable.error.value?.message).toBe('An unexpected error occurred');
+      expect(composable.isInitialized.value).toBe(false);
+      expect(composable.hasUnsavedChanges.value).toBe(false);
     });
 
     it('snapshots savedFormState on load', async () => {
@@ -189,7 +200,7 @@ describe('useSignupConfig', () => {
 
   describe('saveConfig', () => {
     it('sends strategy, signup_enabled, autoverify and allowlist in PUT payload (domain_allowlist)', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       const composable = useSignupConfig('dm-ext-123');
       await composable.initialize();
 
@@ -231,7 +242,7 @@ describe('useSignupConfig', () => {
     });
 
     it('updates signupConfig and snapshot after successful save', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       mockPutConfigForDomain.mockResolvedValue({ record: mockPassthroughConfig });
 
       const composable = useSignupConfig('dm-ext-123');
@@ -250,7 +261,7 @@ describe('useSignupConfig', () => {
     });
 
     it('shows success notification after save', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       const composable = useSignupConfig('dm-ext-123');
       await composable.initialize();
 
@@ -264,7 +275,7 @@ describe('useSignupConfig', () => {
     });
 
     it('sets isSaving during operation and clears it after', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
       let resolveSave: (value: unknown) => void;
       mockPutConfigForDomain.mockImplementation(
         () =>
@@ -499,15 +510,6 @@ describe('useSignupConfig', () => {
       expect(composable.formState.value.signup_enabled).toBe(true);
     });
 
-    it('falls back to signup_enabled false when details are null (?? false, never the global flag)', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null, details: null });
-
-      const composable = useSignupConfig('dm-ext-123');
-      await composable.initialize();
-
-      expect(composable.formState.value.signup_enabled).toBe(false);
-    });
-
     it('an explicit record wins over seeding', async () => {
       mockGetConfigForDomain.mockResolvedValue({
         record: { ...mockSignupConfigData, signup_enabled: false },
@@ -528,7 +530,7 @@ describe('useSignupConfig', () => {
 
   describe('ADR-024: writes materialize an explicit override (pinning)', () => {
     it('saveConfig forces enabled: true in the PUT even while formState.enabled is false (saving = pinning)', async () => {
-      mockGetConfigForDomain.mockResolvedValue({ record: null, details: null });
+      mockGetConfigForDomain.mockResolvedValue({ record: null, details: mockUnconfiguredDetails });
 
       const composable = useSignupConfig('dm-ext-123');
       await composable.initialize();

--- a/src/tests/services/signin-config.service.spec.ts
+++ b/src/tests/services/signin-config.service.spec.ts
@@ -39,7 +39,9 @@ describe('SigninConfigService', () => {
   const domainExtId = 'dm_test_domain_456';
   const baseUrl = `/api/domains/${domainExtId}/signin-config`;
 
-  // Wire-format response (pre-transform: timestamps are numbers)
+  // Wire-format response (pre-transform: timestamps are numbers).
+  // `details` is required on GET/PUT responses (PR #3817): the settings UI
+  // seeds from it, so a details-less payload must fail validation.
   const mockSigninConfigResponse = {
     record: {
       domain_id: domainExtId,
@@ -50,6 +52,11 @@ describe('SigninConfigService', () => {
       sso_enabled: false,
       created_at: 1234567890,
       updated_at: 1234567890,
+    },
+    details: {
+      global_enabled: true,
+      effective_enabled: true,
+      global_restrict_to: null,
     },
   };
 
@@ -92,6 +99,19 @@ describe('SigninConfigService', () => {
       expect(result.record).toBeNull();
     });
 
+    it('fails parse when details is missing (record + details both null = failed load, PR #3817)', async () => {
+      // details is required by the response schema: without it the composable
+      // would seed a guess about the inherited state that an autosave then
+      // materializes as an explicit override.
+      const { details: _omit, ...withoutDetails } = mockSigninConfigResponse;
+      mockGet.mockResolvedValueOnce({ data: withoutDetails });
+
+      const result = await SigninConfigService.getConfigForDomain(domainExtId);
+
+      expect(result.record).toBeNull();
+      expect(result.details).toBeNull();
+    });
+
     it('rethrows non-404 errors', async () => {
       const serverError = new Error('Internal Server Error');
       mockGet.mockRejectedValueOnce(serverError);
@@ -112,6 +132,7 @@ describe('SigninConfigService', () => {
 
     it('preserves restrict_to value from response', async () => {
       const restricted = {
+        ...mockSigninConfigResponse,
         record: {
           ...mockSigninConfigResponse.record,
           restrict_to: 'sso',
@@ -174,6 +195,18 @@ describe('SigninConfigService', () => {
 
       await expect(
         SigninConfigService.putConfigForDomain(domainExtId, payload)
+      ).rejects.toThrow();
+    });
+
+    it('throws when the PUT response omits details (required, PR #3817)', async () => {
+      const { details: _omit, ...withoutDetails } = mockSigninConfigResponse;
+      mockPut.mockResolvedValueOnce({ data: withoutDetails });
+
+      await expect(
+        SigninConfigService.putConfigForDomain(domainExtId, {
+          enabled: true,
+          signin_enabled: true,
+        })
       ).rejects.toThrow();
     });
   });

--- a/try/integration/api/domains/put_signin_config_try.rb
+++ b/try/integration/api/domains/put_signin_config_try.rb
@@ -16,6 +16,9 @@
 #   6. Authentication guard — anonymous users rejected
 #   7. Missing domain_id — rejected
 #   8. Entitlement gating — org without custom_signin_config is rejected
+#  11. ADR-024 details resolution — details.effective_enabled uses the
+#      custom-domain resolver (default OFF, opt-in, SSO carve-out) so the
+#      settings page agrees with the masthead link and POST gate (#3814)
 #
 # Run:
 #   bundle exec try try/integration/api/domains/put_signin_config_try.rb --agent
@@ -33,6 +36,8 @@ require 'apps/api/domains/logic/signin_config/base'
 require 'apps/api/domains/logic/signin_config/put_signin_config'
 require 'apps/api/domains/logic/signin_config/get_signin_config'
 require 'apps/api/domains/logic/signin_config/delete_signin_config'
+require 'apps/api/domains/logic/signup_config/base'
+require 'apps/api/domains/logic/signup_config/get_signup_config'
 
 Familia.dbclient.flushdb
 OT.info "Cleaned Redis for PutSigninConfig test run"
@@ -358,6 +363,83 @@ rescue Onetime::FormError => ex
   ex.message.include?('restrict_to must be one of')
 end
 #=> true
+
+# ============================================================
+# 11. ADR-024 details resolution — custom-domain default OFF (#3814)
+#
+# details.effective_enabled must use the same custom-domain resolver
+# (default OFF, opt-in, tenant-SSO carve-out) as the runtime POST gate
+# and the branded masthead. Global signin is ON in the test config, so
+# these cases discriminate: the canonical-surface resolver
+# (resolve_signin_enabled) would report true for an unconfigured domain
+# — the exact bug where the settings page read "Enabled (Workspace
+# default)" while the domain's /signin was closed.
+# ============================================================
+
+## Sanity: global signin is ON in test config (makes the cases below discriminating)
+Onetime::CustomDomain::SigninConfig.global_signin_enabled
+#=> true
+
+## GET details: unconfigured domain, no SSO — effective_enabled false despite global true
+@domain_unconf = Onetime::CustomDomain.create!("psc-unconf-#{@ts}-#{SecureRandom.hex(2)}.example.com", @org.objid)
+@logic_get_unconf = build_get(extid: @domain_unconf.extid)
+@logic_get_unconf.raise_concerns
+@details_unconf = @logic_get_unconf.process[:details]
+[@details_unconf[:global_enabled], @details_unconf[:effective_enabled]]
+#=> [true, false]
+
+## GET details: SSO-only tenant (enabled SsoConfig, NO SigninConfig) — effective_enabled true (SSO carve-out)
+@domain_ssoonly = Onetime::CustomDomain.create!("psc-ssoonly-#{@ts}-#{SecureRandom.hex(2)}.example.com", @org.objid)
+Onetime::CustomDomain::SsoConfig.create!(
+  domain_id: @domain_ssoonly.identifier,
+  provider_type: 'oidc',
+  display_name: 'PSC SSO',
+  enabled: true,
+  issuer: 'https://idp-psc.example.com',
+  client_id: 'client-psc',
+)
+@logic_get_ssoonly = build_get(extid: @domain_ssoonly.extid)
+@logic_get_ssoonly.raise_concerns
+@logic_get_ssoonly.process[:details][:effective_enabled]
+#=> true
+
+## PUT details: enabled config with signin_enabled=true — effective_enabled true (explicit opt-in)
+@domain_opt = Onetime::CustomDomain.create!("psc-opt-#{@ts}-#{SecureRandom.hex(2)}.example.com", @org.objid)
+@logic_put_opt = build_put(
+  extid: @domain_opt.extid,
+  params: { 'enabled' => 'true', 'signin_enabled' => 'true' },
+)
+@logic_put_opt.raise_concerns
+@logic_put_opt.process[:details][:effective_enabled]
+#=> true
+
+## PUT details: enabled config with signin_enabled=false wins over tenant SSO (explicit opt-out, #3415 parity)
+@logic_put_ssooff = build_put(
+  extid: @domain_ssoonly.extid,
+  params: { 'enabled' => 'true', 'signin_enabled' => 'false', 'sso_enabled' => 'false' },
+)
+@logic_put_ssooff.raise_concerns
+@logic_put_ssooff.process[:details][:effective_enabled]
+#=> false
+
+## DELETE details: post-delete reverts to default OFF (nil config, no SSO)
+@logic_del_opt = build_delete(extid: @domain_opt.extid)
+@logic_del_opt.raise_concerns
+@logic_del_opt.process[:details][:effective_enabled]
+#=> false
+
+## DELETE details: post-delete with tenant SSO stays true (carve-out survives config removal)
+@logic_del_ssoonly = build_delete(extid: @domain_ssoonly.extid)
+@logic_del_ssoonly.raise_concerns
+@logic_del_ssoonly.process[:details][:effective_enabled]
+#=> true
+
+## GET signup details: unconfigured domain — effective_enabled false despite global signup true (no SSO carve-out for signup)
+@logic_get_signup = DomainsAPI::Logic::SignupConfig::GetSignupConfig.new(@strategy_result, { 'extid' => @domain_unconf.extid })
+@logic_get_signup.raise_concerns
+@signup_details = @logic_get_signup.process[:details]
+[@signup_details[:global_enabled], @signup_details[:effective_enabled]]
+#=> [true, false]
 
 # --- Cleanup ---
 


### PR DESCRIPTION
## Problem

On a fresh account with `AUTHENTICATION_MODE=full` (global sign-in ON), a custom domain's **Sign-In Configuration** settings showed *"Enabled (Workspace default)"* — while the domain's `/signin` page and branded masthead correctly treated sign-in as default-OFF, opt-in. The settings form was the only surface seeding from the canonical follows-global resolver (`resolve_signin_enabled`) instead of the custom-domain resolver (`resolve_signin_enabled_for_custom_domain`), misleading domain owners into thinking sign-in was already live.

Sign-up had the identical latent bug, masked only because the global signup default is off.

Closes #3814.

## Changes (one commit each)

1. **Hoist the tenant-SSO carve-out into the shared resolver** — `resolve_signin_enabled_for_custom_domain` gains an optional `domain_id:` kwarg: without it, strict default-off (POST `/signin` gate unchanged); with it, an unconfigured domain falls back to `SsoConfig.tenant_sso_available_for?` so an SSO-only tenant (enabled SsoConfig, no SigninConfig) reads enabled on display surfaces. `DomainSerializer#effective_signin_enabled?` now delegates to it — behavior byte-identical, inline carve-out removed.
2. **Signin settings fix (root cause)** — `signin_override_details` uses the custom-domain resolver with `domain_id:`; the masthead link, POST gate, and settings page now share one authority and cannot disagree.
3. **Signup settings fix** — `signup_override_details` swaps to `resolve_signup_enabled_for_custom_domain` (no SSO carve-out).
4. **Backend coverage for the gap that shipped this bug** — 8 new tryout cases asserting `details.effective_enabled` under global-on: unconfigured → `false`; SSO-only tenant → `true`; explicit enable → `true`; `signin_enabled=false` over tenant SSO → `false` (#3415 parity); DELETE reverts; signup unconfigured → `false`.
5. **Frontend** — `createSeededFormState` fallback flips `?? true` → `?? false` (matches `useSignupConfig`); stale fixtures assuming unconfigured→enabled realigned; new SSO-only pass-through case.

**Reviewer focus:** the SSO carve-out unification in commit 1 is the one design decision — display surfaces (masthead, settings) pass `domain_id:` and get the carve-out; the password/email POST gate omits it and stays strictly off (SSO signs in via omniauth routes, never POST `/signin`; asymmetry intentional per #3415/#3783).

Not changed: the "Workspace default" badge — it keys off `record.enabled` (`isWorkspaceDefault`), not `effective_enabled`, so only the Enabled/Disabled word and the seeded mode flip. The materialize-on-touch contract is *repaired*, not broken: the first explicit write now snapshots the actually-running (OFF) state.

## Test plan

- Backend: 40/40 `put_signin_config_try.rb` (32 existing + 8 new), 89/89 enforcement/killswitch tryouts (refactor-parity proof for the serializer), 16/16 authorization, 48 RSpec logic examples — all green; rubocop clean.
- Frontend: 167 vitest across signin composable + 2 component specs; eslint clean.
- Manual: fresh full-mode account + custom domain → settings now read **Disabled**; "Workspace default" badge still renders; `/signin` and masthead unchanged.
- Follow-up commits incoming on this branch: QA agent is adding HTTP-surface `details.effective_enabled` assertions, fixing a stale pre-ADR-024 404 expectation in `domain_signup_config_spec.rb`, and creating the missing `useSignupConfig.spec.ts`.