### PR TITLE
Degrade bootstrap to free tier on plan catalog miss instead of 503

### DIFF
--- a/apps/web/core/spec/views/serializers/organization_serializer_degrade_spec.rb
+++ b/apps/web/core/spec/views/serializers/organization_serializer_degrade_spec.rb
@@ -1,0 +1,222 @@
+# apps/web/core/spec/views/serializers/organization_serializer_degrade_spec.rb
+#
+# frozen_string_literal: true
+
+# Degrade-path coverage for OrganizationSerializer (issue #3813).
+#
+# Billing::PlanCacheMissError is raised by the model's fail-closed
+# entitlements/limits ladders when billing is enabled and a non-empty planid
+# resolves in neither the plan cache nor billing.yaml. Before #3813 that raise
+# propagated out of the bootstrap serializer and 503'd GET /bootstrap/me,
+# blocking login entirely.
+#
+# Contract under test: the 503 path REMAINS for enforcement callers
+# (require_entitlement! and friends stay fail-closed at the model layer —
+# see spec/unit/onetime/models/features/with_entitlements_cache_miss_spec.rb
+# and spec/api/v2/plan_cache_miss_handling_spec.rb). Only the bootstrap READ
+# degrades, at the serializer edge: plan_derived_fields rescues
+# PlanCacheMissError and substitutes free-tier entitlements + limits so the
+# payload stays schema-valid (string arrays + integers) and login proceeds.
+#
+# Run with:
+#   bundle exec rspec apps/web/core/spec/views/serializers/organization_serializer_degrade_spec.rb
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require_relative '../../../views/serializers'
+require_relative '../../../../billing/errors'
+
+RSpec.describe Core::Views::OrganizationSerializer do
+  before(:all) do
+    # Idempotently load Billing::Plan so .load_from_config can be stubbed
+    # (verify_partial_doubles requires the real method to exist).
+    BillingTestHelpers.ensure_billing_loaded!
+  end
+
+  let(:free_tier_entitlements) do
+    Onetime::Models::Features::WithPlanEntitlements::FREE_TIER_ENTITLEMENTS
+  end
+
+  let(:org) do
+    instance_double(
+      Onetime::Organization,
+      objid: 'org_obj_123',
+      extid: 'onabc123',
+      display_name: 'Acme Workspace',
+      is_default: false,
+      planid: 'identity_plus_v1',
+    )
+  end
+
+  # cust: nil keeps determine_user_role out of scope (returns nil early);
+  # this spec targets plan_derived_fields only.
+  let(:view_vars) do
+    {
+      'authenticated' => true,
+      'organization' => org,
+      'cust' => nil,
+    }
+  end
+
+  def serialized_org
+    described_class.serialize(view_vars)['organization']
+  end
+
+  describe 'happy path (plan resolves)' do
+    before do
+      allow(org).to receive(:entitlements).and_return(%w[create_secrets api_access custom_domains])
+      allow(org).to receive(:limit_for).with(:teams).and_return(3)
+      allow(org).to receive(:limit_for).with(:total_members_per_org).and_return(Float::INFINITY)
+      allow(org).to receive(:limit_for).with(:custom_domains).and_return(5)
+    end
+
+    it 'serializes live entitlements and limits without degrading' do
+      payload = serialized_org
+
+      expect(payload['entitlements']).to eq(%w[create_secrets api_access custom_domains])
+      expect(payload['limits']).to eq(
+        'teams' => 3,
+        'total_members_per_org' => -1, # Float::INFINITY normalizes to -1
+        'custom_domains' => 5,
+      )
+      expect(payload['planid']).to eq('identity_plus_v1')
+    end
+
+    it 'does not emit the degrade ops log' do
+      expect(OT).not_to receive(:le)
+      serialized_org
+    end
+  end
+
+  describe 'degrade path: entitlements raises PlanCacheMissError' do
+    before do
+      allow(org).to receive(:entitlements).and_raise(
+        Billing::PlanCacheMissError.new(
+          plan_id: 'identity_plus_v1',
+          organization_id: 'onabc123',
+          context: 'WithPlanEntitlements#entitlements',
+        )
+      )
+      allow(OT).to receive(:le)
+    end
+
+    context 'when free_v1 resolves from billing config' do
+      before do
+        # load_from_config returns flattened string keys/values
+        # ('teams.max' absent for free tier; 'unlimited' -> -1).
+        allow(::Billing::Plan).to receive(:load_from_config).with('free_v1').and_return(
+          {
+            planid: 'free_v1',
+            limits: {
+              'total_members_per_org.max' => '1',
+              'custom_domains.max' => 'unlimited',
+            },
+          }
+        )
+      end
+
+      it 'serializes free-tier entitlements as an array of strings instead of raising' do
+        payload = serialized_org
+
+        expect(payload['entitlements']).to eq(free_tier_entitlements)
+        expect(payload['entitlements']).to all(be_a(String))
+      end
+
+      it 'returns a dup, not the frozen FREE_TIER_ENTITLEMENTS constant' do
+        expect(serialized_org['entitlements']).not_to be(free_tier_entitlements)
+        expect(serialized_org['entitlements']).not_to be_frozen
+      end
+
+      it 'normalizes config limits: missing key -> fallback literal, unlimited -> -1' do
+        expect(serialized_org['limits']).to eq(
+          'teams' => 0, # absent from config -> FALLBACK_FREE_TIER_LIMITS
+          'total_members_per_org' => 1, # '1' -> 1
+          'custom_domains' => -1, # 'unlimited' -> -1
+        )
+      end
+
+      it 'emits exactly the three limit keys, all Integers' do
+        limits = serialized_org['limits']
+
+        expect(limits.keys).to contain_exactly('teams', 'total_members_per_org', 'custom_domains')
+        expect(limits.values).to all(be_a(Integer))
+      end
+
+      it 'logs a single error-level ops line identifying plan and org' do
+        serialized_org
+
+        expect(OT).to have_received(:le).once.with(
+          a_string_matching(
+            /\[OrganizationSerializer\] Plan catalog unavailable.*plan=identity_plus_v1 org=onabc123/
+          )
+        )
+      end
+    end
+
+    context 'when free_v1 is also unresolvable from config' do
+      before do
+        allow(::Billing::Plan).to receive(:load_from_config).with('free_v1').and_return(nil)
+      end
+
+      it 'falls back to FALLBACK_FREE_TIER_LIMITS literals' do
+        expect(serialized_org['limits']).to eq(
+          'teams' => 0,
+          'total_members_per_org' => 1,
+          'custom_domains' => 1,
+        )
+      end
+
+      it 'still serializes free-tier entitlements' do
+        expect(serialized_org['entitlements']).to eq(free_tier_entitlements)
+      end
+    end
+  end
+
+  describe 'degrade path: limit_for raises PlanCacheMissError' do
+    before do
+      # entitlements succeeds; the limits reader is what hits the cache miss.
+      allow(org).to receive(:entitlements).and_return(%w[create_secrets api_access])
+      allow(org).to receive(:limit_for).and_raise(
+        Billing::PlanCacheMissError.new(
+          plan_id: 'identity_plus_v1',
+          organization_id: 'onabc123',
+          resource: 'teams.max',
+          context: 'WithMaterializedLimits#limit_for',
+        )
+      )
+      allow(::Billing::Plan).to receive(:load_from_config).with('free_v1').and_return(nil)
+      allow(OT).to receive(:le)
+    end
+
+    it 'degrades BOTH fields together: one rescue wraps both readers' do
+      payload = serialized_org
+
+      # The live entitlements read succeeded, but the payload still carries
+      # free-tier values: plan_derived_fields degrades atomically so
+      # entitlements and limits never disagree about which plan they reflect.
+      expect(payload['entitlements']).to eq(free_tier_entitlements)
+      expect(payload['limits']).to eq(
+        'teams' => 0,
+        'total_members_per_org' => 1,
+        'custom_domains' => 1,
+      )
+    end
+
+    it 'logs the degrade once' do
+      serialized_org
+
+      expect(OT).to have_received(:le).once.with(a_string_matching(/Plan catalog unavailable/))
+    end
+  end
+
+  describe 'non-billing errors propagate untouched' do
+    before do
+      allow(org).to receive(:entitlements).and_raise(ArgumentError, 'not a plan problem')
+    end
+
+    it 're-raises instead of swallowing into the degrade path' do
+      expect(OT).not_to receive(:le)
+      expect { described_class.serialize(view_vars) }
+        .to raise_error(ArgumentError, 'not a plan problem')
+    end
+  end
+end

--- a/apps/web/core/views/serializers/organization_serializer.rb
+++ b/apps/web/core/views/serializers/organization_serializer.rb
@@ -14,6 +14,15 @@ module Core
     module OrganizationSerializer
       extend Onetime::LoggerMethods
 
+      # Free-tier limit literals used only when the free_v1 plan itself
+      # cannot be resolved from billing config. Values mirror free_v1 in
+      # billing.yaml (teams is absent there: free tier has none).
+      FALLBACK_FREE_TIER_LIMITS = {
+        'teams' => 0,
+        'total_members_per_org' => 1,
+        'custom_domains' => 1,
+      }.freeze
+
       # Serializes organization data from view variables
       #
       # @param view_vars [Hash] The view variables containing organization info
@@ -61,6 +70,7 @@ module Core
         # @param cust [Onetime::Customer] Current user for role calculation
         # @return [Hash] Serialized organization data
         def serialize_organization(org, cust)
+          entitlements, limits = plan_derived_fields(org)
           {
             'objid' => org.objid,
             'extid' => org.extid,
@@ -68,9 +78,63 @@ module Core
             'is_default' => org.is_default || false,
             'planid' => org.planid,
             'current_user_role' => determine_user_role(org, cust),
-            'entitlements' => org.entitlements,
-            'limits' => serialize_limits(org),
+            'entitlements' => entitlements,
+            'limits' => limits,
           }
+        end
+
+        # Resolve entitlements and limits for the bootstrap payload
+        #
+        # Both readers fail closed (Billing::PlanCacheMissError) when the
+        # org's planid resolves from neither the plan cache nor billing.yaml.
+        # Degrade to free tier at this read edge only — the model raise must
+        # stay so enforcement paths (require_entitlement!) remain fail-closed,
+        # but a bootstrap read raising takes login down with a 503.
+        #
+        # @param org [Onetime::Organization] Organization
+        # @return [Array(Array<String>, Hash)] Entitlements and limits
+        def plan_derived_fields(org)
+          [org.entitlements, serialize_limits(org)]
+        rescue StandardError => ex
+          # Match by name: builds without the billing app never define (or
+          # raise) the error class, and a bare rescue would NameError here.
+          raise unless defined?(::Billing::PlanCacheMissError) && ex.is_a?(::Billing::PlanCacheMissError)
+
+          OT.le "[OrganizationSerializer] Plan catalog unavailable, degrading to free tier: plan=#{org.planid} org=#{org.extid}"
+          [
+            Onetime::Models::Features::WithPlanEntitlements::FREE_TIER_ENTITLEMENTS.dup,
+            free_tier_fallback_limits,
+          ]
+        end
+
+        # Free-tier limits for the degraded bootstrap payload
+        #
+        # Resolves free_v1 from billing config when possible (config loading
+        # rescues internally, so this returns nil rather than raising), with
+        # FALLBACK_FREE_TIER_LIMITS literals per missing key. Same shape as
+        # serialize_limits: integers, -1 for unlimited.
+        #
+        # @return [Hash] Normalized limits
+        def free_tier_fallback_limits
+          config_limits =
+            if defined?(::Billing::Plan)
+              (::Billing::Plan.load_from_config('free_v1') || {})[:limits] || {}
+            else
+              {}
+            end
+
+          FALLBACK_FREE_TIER_LIMITS.to_h do |key, default|
+            val        = config_limits["#{key}.max"]
+            normalized =
+              if val.nil?
+                default
+              elsif val == 'unlimited'
+                -1
+              else
+                val.to_i
+              end
+            [key, normalized]
+          end
         end
 
         # Limits for the bootstrap payload, matching the safe_dump shape


### PR DESCRIPTION
Closes #3813

When billing is enabled and an org's `planid` resolves in neither the Plan cache nor billing config, the model's fail-closed `PlanCacheMissError` was propagating to a 503 on `GET /bootstrap/me` (and the `VuePoint`/`AdminPoint` page renders), taking down login for affected accounts.

Fix is at the serializer read edge only: `OrganizationSerializer` now rescues the error and degrades entitlements to `FREE_TIER_ENTITLEMENTS` and limits to free_v1 values (config lookup with hardcoded fallback), emitting a single error-level ops log as the incident signal. The model resolution ladders are untouched, so enforcement paths (`require_entitlement!`, `EntitlementCheck` middleware) remain fail-closed. Free tier is a subset of every paid set, so no over-grant is possible; the bootstrap schema contract stays valid (86 contract tests pass).

New serializer degrade spec (12 examples); existing model-level cache-miss specs and the entitlements tryout pass unchanged.

**Stacked on** `fix/3812-login-alert-empty-locale` — merge that first.