### PR TITLE
Remove unused mustache gem; pin unpinned deps; amend ADR-001

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ support/schemas/
 Procfile.*
 !Procfile*.example
 !Procfile.production
+onetimesecret_*
 
 # Auto-generated files
 src/auto-imports.d.ts

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'rack-contrib', '~> 2.5.0'
 gem 'rack-protection', '~> 4.1'
 gem 'rack-proxy', '~> 0.7'
 gem 'rack-session', '~> 2.1.2'
-gem 'rack-utf8_sanitizer'
+gem 'rack-utf8_sanitizer', '~> 1.11'
 
 # ====================================
 # Data Processing & Utilities
@@ -59,14 +59,13 @@ gem 'dry-cli', '~> 1.2'
 gem 'fastimage', '~> 2.4'
 gem 'i18n', '~> 1.14'
 gem 'mail'
-gem 'mustache'
-gem 'public_suffix'
-gem 'sanitize'
+gem 'public_suffix', '~> 7.0'
+gem 'sanitize', '~> 7.0'
 gem 'semantic_logger', '~> 4.17'
 gem 'tilt'
 
 # Email validation
-gem 'truemail'
+gem 'truemail', '~> 3.3'
 
 # ====================================
 # Database & DB Tools

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,6 @@ GEM
     minitest (5.27.0)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
-    mustache (1.1.2)
     net-http (0.9.1)
       uri (>= 0.11.1)
     net-imap (0.6.4.1)
@@ -629,7 +628,6 @@ DEPENDENCIES
   lettermint (~> 0.2.0)
   logger
   mail
-  mustache
   omniauth-entra-id (~> 3.1)
   omniauth-github (~> 2.0)
   omniauth-google-oauth2 (~> 1.2)
@@ -638,7 +636,7 @@ DEPENDENCIES
   passforge (~> 1.1)
   pg (~> 1.6)
   psych (~> 5.2.3)
-  public_suffix
+  public_suffix (~> 7.0)
   puma (>= 6.0, < 8.0)
   rack (>= 3.2.6, < 4.0)
   rack-contrib (~> 2.5.0)
@@ -646,7 +644,7 @@ DEPENDENCIES
   rack-proxy (~> 0.7)
   rack-session (~> 2.1.2)
   rack-test
-  rack-utf8_sanitizer
+  rack-utf8_sanitizer (~> 1.11)
   rackup
   rbnacl (~> 7.1, >= 7.1.1)
   rdoc
@@ -672,7 +670,7 @@ DEPENDENCIES
   rubocop-thread_safety
   ruby-lsp (~> 0.26.9)
   rufus-scheduler (~> 3.9)
-  sanitize
+  sanitize (~> 7.0)
   semantic_logger (~> 4.17)
   sendgrid-ruby
   sentry-ruby
@@ -687,7 +685,7 @@ DEPENDENCIES
   syntax_tree
   tilt
   timecop (~> 0.9)
-  truemail
+  truemail (~> 3.3)
   tryouts (~> 3.7.1)
   uri-valkey (~> 1.4.0)
   vcr (~> 6.0)

--- a/docs/architecture/decision-records/adr-001-rack-app-naming.md
+++ b/docs/architecture/decision-records/adr-001-rack-app-naming.md
@@ -1,11 +1,16 @@
 ---
 id: 001
-status: accepted
+status: deprecated
 title: ADR-001: Naming and Separation of Rack Applications
 ---
 
 ## Status
-Accepted
+Deprecated
+
+Deprecated 2026-07-19 — no longer relevant; kept for history. Its `lib/`
+dependency-rules example referenced `lib/chimera.rb` for mustache
+compatibility; both that file and the `mustache` gem dependency have since
+been removed.
 
 ## Date
 2025-10-08

--- a/docs/architecture/decision-records/adr-001-rack-app-naming.md
+++ b/docs/architecture/decision-records/adr-001-rack-app-naming.md
@@ -1,16 +1,11 @@
 ---
 id: 001
-status: deprecated
+status: accepted
 title: ADR-001: Naming and Separation of Rack Applications
 ---
 
 ## Status
-Deprecated
-
-Deprecated 2026-07-19 — no longer relevant; kept for history. Its `lib/`
-dependency-rules example referenced `lib/chimera.rb` for mustache
-compatibility; both that file and the `mustache` gem dependency have since
-been removed.
+Accepted
 
 ## Date
 2025-10-08
@@ -91,6 +86,16 @@ This ADR is accepted for implementation targeting release 0.23. As of 2025-10-10
 ### lib/ Dependency Rules
 Code organization follows a strict dependency hierarchy:
 - `lib/onetime/` contains project-specific code and may reference anything in `lib/`
-- `lib/` contains potentially extractable code (e.g., `lib/chimera.rb` for mustache compatibility) and must not reference `lib/onetime/`
+- `lib/` contains potentially extractable code (e.g., `lib/middleware/`) and must not reference `lib/onetime/`
 
 This ensures clean extraction paths if/when `lib/` code graduates to separate repositories.
+
+## Amendments
+
+- 2026-07-19 — Names evolved during implementation: the `apps/public`
+  (anonymous) surface shipped as `apps/internal`; authenticated and core
+  surfaces consolidated under `apps/web` (`core`, `auth`, `billing`);
+  `apps/api` (v1/v2) is intact. The separation decision stands — only the
+  directory vocabulary changed. The former `lib/chimera.rb` mustache-compat
+  example was removed along with the unused `mustache` gem; `lib/middleware/`
+  now illustrates the extractable-`lib/` rule.


### PR DESCRIPTION
Follow-up on three verified low-severity dependency-hygiene findings from the 2026-07-19 audit. Atomic and complete.

## Changes
- **Remove `mustache`** (`Gemfile`) — unused production dependency. No `require`/`Mustache` usage, no `.mustache` templates, no transitive dependents; templating is rhales + tilt. Install-time supply-chain surface only. Dropped from `Gemfile.lock` (was 1.1.2).
- **Pin four unconstrained gems** to their tested lines:
  - `rack-utf8_sanitizer ~> 1.11` — mounted pre-routing on every request (`middleware_stack.rb`), listed in `SECURITY_CRITICAL_KEYS`.
  - `public_suffix ~> 7.0` — parses the request Host header (the #3225 cross-org ownership boundary).
  - `sanitize ~> 7.0` — the XSS sanitization chokepoint.
  - `truemail ~> 3.3` — signup / incoming email validation.

  All four sit on attacker-input boundaries and were the only unpinned gems in their blocks. Pins match the current lock, so **no transitive versions move**.
- **Amend ADR-001 (keep `Accepted`)** — the mustache removal only invalidated an incidental `lib/` example (`lib/chimera.rb`), not the decision. ADR-001's actual decision — functional app naming and anonymous/authenticated separation — shipped and stands; the directory vocabulary evolved (`apps/public` → `apps/internal`; core/auth/billing consolidated under `apps/web`). Reverted the earlier `Deprecated` status, replaced the stale example with `lib/middleware/`, and added an Amendments section mapping decision-era names to shipped names (preserving the immutable decision body).

## Verification
- `bundle lock` + `bundle check`: dependencies satisfied; lock diff is only the mustache removal and the four pin declarations.
- mustache references elsewhere are all inert (docs, billing VCR cassettes, audit-results file).
