### PR TITLE
Config-drive the Stripe custom-domain checkout host allowlist (#3821) *

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -653,6 +653,14 @@ STRIPE_API_KEY=
 PUBLIC_STRIPE_API_KEY=
 STRIPE_WEBHOOK_SIGNING_SECRET=
 
+# Bare host of a Stripe custom Checkout domain (live-mode only), e.g.
+# pay.onetimesecret.com. When set, the frontend allowlists checkout URLs
+# served from this host in addition to checkout.stripe.com. Leave unset
+# unless a Stripe custom domain is configured. Wins over billing.yaml
+# `checkout_host`. Validated at boot (BillingConfig#validate_checkout_host!):
+# a malformed value (scheme/path/userinfo) fails startup, not a later checkout.
+#STRIPE_CHECKOUT_HOST=
+
 # Billing catalog currency as a lowercase ISO 4217 code (billing.yaml
 # `currency` key, via ERB in etc/billing.yaml copied from
 # etc/examples/billing.example.yaml). Wins over CURRENCY when both are

--- a/.env.reference
+++ b/.env.reference
@@ -657,8 +657,10 @@ STRIPE_WEBHOOK_SIGNING_SECRET=
 # pay.onetimesecret.com. When set, the frontend allowlists checkout URLs
 # served from this host in addition to checkout.stripe.com. Leave unset
 # unless a Stripe custom domain is configured. Wins over billing.yaml
-# `checkout_host`. Validated at boot (BillingConfig#validate_checkout_host!):
-# a malformed value (scheme/path/userinfo) fails startup, not a later checkout.
+# `checkout_host`. Validated at boot when billing is enabled — the check runs
+# in Billing::Initializers::StripeSetup (BillingConfig#validate_checkout_host!),
+# which is skipped when billing is disabled. A malformed value
+# (scheme/path/userinfo/out-of-range port) fails startup, not a later checkout.
 #STRIPE_CHECKOUT_HOST=
 
 # Billing catalog currency as a lowercase ISO 4217 code (billing.yaml

--- a/apps/web/billing/initializers/stripe_setup.rb
+++ b/apps/web/billing/initializers/stripe_setup.rb
@@ -17,6 +17,11 @@ module Billing
       end
 
       def execute(_context)
+        # Fail the deploy — not a future customer's checkout — on a malformed
+        # custom Checkout host. Runs before Stripe setup so the message is
+        # about config, not an obscure downstream navigation failure.
+        Onetime.billing_config.validate_checkout_host!
+
         # Don't bring Stripe into this unless billing is enabled
         require 'stripe'
 

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -62,6 +62,7 @@ module Core
 
         # Link to the pricing page can be seen regardless of authentication status
         output['billing_enabled'] = OT.billing_config.enabled?
+        output['checkout_host']   = OT.billing_config.checkout_host.to_s
 
         output['frontend_development'] = development['enabled'] || false
         output['frontend_host']        = development['frontend_host'] || ''
@@ -143,6 +144,7 @@ module Core
             'frontend_host' => nil,
             'homepage_mode' => nil,
             'billing_enabled' => nil,
+            'checkout_host' => nil,
             'regions' => nil,
             'regions_enabled' => nil,
             'secret_options' => nil,

--- a/docs/runbooks/recreating-email-notification-from-receipt.md
+++ b/docs/runbooks/recreating-email-notification-from-receipt.md
@@ -4,7 +4,9 @@ _Created: 2026-07-20_
 
 ## Follow-up improvements
 
-1 & 2 were related to the DLQ which is removed in RabbitMQ 2.3
+Items 1 & 2 concerned the dead-letter queue and have been dropped from this
+list — the DLQ recovery path is documented below under "First check the dead
+letter queue." (The DLQ is still in use; the stack runs RabbitMQ 4.2.)
 
 3. Fail fast and loud at boot, not at first send
 

--- a/docs/runbooks/recreating-email-notification-from-receipt.md
+++ b/docs/runbooks/recreating-email-notification-from-receipt.md
@@ -1,8 +1,6 @@
-# docs/runbooks/recreating-email-notification-from-receipt.md
+# Recreating an email notification from a receipt
 
-created: 2026-07-20
-
----
+_Created: 2026-07-20_
 
 ## Follow-up improvements
 
@@ -163,7 +161,7 @@ share_domain: s.share_domain,
 recipient: r.recipients,
 memo: r.memo,
 has_passphrase: r.has_passphrase?,
-locale: OT.default_locale, # originored on the receipt
+locale: OT.default_locale, # original locale not stored on the receipt
 },
 domain_id: r.domain_id,
 )
@@ -172,11 +170,11 @@ puts "re-enqueued #{r.shortid} -> #{OT::Utils.obscure_email(r.recipients)}"
 end
 puts "Re-enqueued #{sent} notifications"
 
-This pushes them onto email.message.send; the workeatch them drain:
+This pushes them onto email.message.send; the workers deliver them — watch them drain:
 
 podman exec <container> bin/ots queue status
 
 Notes
 
 - The payload mirrors create_incoming_secret.rb:292 exactly, with two substitutions: secret_key/share_domain come from the reloaded secret, and locale falls back to OT.default_locale because the original request locale isn't persisted on the receipt (recipients get the default-language email — cosmetic only).
-- If instances scoring turns out not to be created he dry-run's printed created= timestamps will lookwrong (outside your window) — that's your signal to tell me and I'll switch the enumerator to expiration_timeline ranged by created + ttl instead.
+- If instances scoring turns out not to be created, the dry-run's printed created= timestamps will look wrong (outside your window) — that's your signal to tell me and I'll switch the enumerator to expiration_timeline ranged by created + ttl instead.

--- a/docs/runbooks/recreating-email-notification-from-receipt.md
+++ b/docs/runbooks/recreating-email-notification-from-receipt.md
@@ -1,0 +1,182 @@
+# docs/runbooks/recreating-email-notification-from-receipt.md
+
+created: 2026-07-20
+
+---
+
+## Follow-up improvements
+
+1 & 2 were related to the DLQ which is removed in RabbitMQ 2.3
+
+3. Fail fast and loud at boot, not at first send
+
+The port block was invisible until an email actually tried to go out — potentially hours after deploy. You already have bin/ots email test and the delivery machinery; status_command does not probe SMTP.
+
+Implement: a startup/readiness SMTP connectivity probe — a TCP connect (or full openssl s_client STARTTLS+AUTH) to SMTP_HOST:SMTP_PORT at boot or in a healthcheck. If it can't reach the mail server, log it at ERROR and fail the readiness check. This matches your own "fail fast and loud" rule: a blocked port should break the deploy's health signal, not the first user's secret. Wire the existing Operations::Email::SendTest probe (dry-run mode) into status/healthcheck.
+
+4. Deployment docs: the DO port trap
+
+DigitalOcean blocks 25/587/465 by default; 2587/2465 are SES's escape hatches. This will bite the next person who spins up a droplet. The config generator (config_generator.rb:249) emits SMTP_HOST/USERNAME/PASSWORD — add a comment there and a docs note: "On DigitalOcean and similar hosts, 587 is often blocked — use 2587 (STARTTLS) or 2465 (implicit TLS)." Cheap, high-recall.
+
+5. SMTP_AUTH is a lie — honor it or delete it
+
+smtp.rb:144 hardcodes authentication: :plain and ignores the SMTP_AUTH=login env var entirely. It happens to work because SES accepts both, but a config var that silently does nothing is false confidence during exactly the kind of debugging you just did. Either read ENV['SMTP_AUTH'] or remove the var from docs/config generation.
+
+Lower priority
+
+- Incident log clarity: the async SemanticLogger lag made "18:36" look stuck when it was fine. On the success path the worker doesn't flush_logs (only on failure). A per-delivery flush, or a synchronous appender for delivery events, removes that red herring during the next incident.
+- Promote the receipt-resend to a real command: you needed an ad-hoc console script. bin/ots email resend-incoming --since --until (with the live-secret guard the script already had) would make that a supported, tested recovery tool instead of paste-in Ruby. Only worth it if DLQ replay isn't always sufficient — but the auto-consumer's discard behavior (#2) means it sometimes won't be.
+
+---
+
+## First check the dead letter queue.
+
+```bash
+bin/ots queue dlq list
+
+ ══════════════════════════════════════════════════════════════════════
+ Dead Letter Queue Summary
+ ══════════════════════════════════════════════════════════════════════
+
+ Queue                            Messages  Consumers
+ ----------------------------------------------------------------------
+ dlq.email.message                       9          0
+ dlq.notifications.alert                 0          0
+ dlq.webhooks.payload                    0          0
+ dlq.billing.event                       0          0
+ dlq.domain.validation                   0          0
+ dlq.migration.customer                  0          0
+ ----------------------------------------------------------------------
+ Total
+```
+
+bin/ots queue dlq list email.message
+
+This is the precise recovery path — use it instead of receipt reconstruction. Note the real short name is email.message (not email.message.send — I had the queue name wrong earlier).
+
+Act now, before any dlq_consumer tick can discard the non-auth (incoming) ones.
+
+Inspect, then replay
+
+# 1. Confirm these 9 are the incoming-secret notifications
+
+podman exec -it <container> bin/ots queue dlq list email.message
+
+# 2. (optional) Look at one in detail — check the template field
+
+podman exec -it <container> bin/ots queue dlq show email.message --id <ID>
+
+You're looking for template: incoming_secret (or raw Rodauth auth mails). If all 9 are the incoming notifications, replay them:
+
+# 3. Replay all back to the live queue — workers deliver via 2587 now
+
+podman exec -it <container> bin/ots queue dlq replay email.message
+
+# 4. Watch them drain
+
+podman exec <container> bin/ots queue status
+
+Why replay beats reconstruction here
+
+The DLQ messages are the original enqueued payloads — exact recipient, locale, memo, domain_id, everything as originally sent. Replay is a faithful re-delivery. Reconstruction from receipts was the fallback for a drained DLQ; you don't need it — keep it in your back pocket only if some messages fail again.
+
+Two things to watch
+
+1. Idempotency: replay re-delivers all 9. If any of those secrets were already viewed/burned since the outage, the email still goes out but the link is dead — low harm, but worth knowing. (Unlike the reconstruction script, replay does not skip consumed secrets, because it doesn't reload them — it just re-sends the stored payload.)
+2. If a replayed message fails again it lands back in the DLQ. After replay, re-run dlq list email.message — a count of 0 means all delivered; any remainder is a genuine per-message problem (bad recipient, etc.) worth a dlq show.
+
+Run step 1 and paste the output — confirm the 9 are incoming_secret before replaying.
+
+---
+
+## Recreate email jobs from receipts
+
+Confirmed everything. Publisher.enqueue_email(template, data, domain_id:) is the exact call, and Receipt.instances is a sorted set scored by created, so you can range it by your outage window.
+
+First, the config check you couldn't do (config get doesn't exist — only validate):
+
+# inside the container, in the console:
+
+podman exec -it <container> bin/ots console
+OT.conf.dig('jobs', 'dlq_consumer', 'enabled') # true = the auto-purger is running
+
+Reconstruction — run inside bin/ots console
+
+Why this is safe (and its one limitation)
+
+- Natural guard: receipt.load_secret returns nil if the secret was already viewed/burned or expired. So already-delivered-and-opened secrets are automatically skipped — you only re-notify secrets that are still live and unviewed.
+- Limitation: receipts have no "notified_at" field, so this cannot tell sent from failed. It re-notifies every live, unviewed incoming receipt in the window — including any whose original email actually got through but hasn't been opened yet. The duplicate is the identical one-time link, so harm is low, but know that it's a superset, not a precise replay. (DLQ replay is precise; this is the fallback for when the DLQ is already drained.)
+
+Step 1 — Dry run (lists, sends nothing)
+
+Edit the two timestamps to bracket your outage, then paste:
+
+# --- outage window (local paste: set these) ---
+
+outage_start = Time.parse('2026-07-20 14:00 UTC').to_i # when the port block began
+restart_at = Time.parse('2026-07-20 18:30 UTC').to_i # when you switched to 2587
+DRY_RUN = true
+
+# ----------------------------------------------
+
+ids = Onetime::Receipt.instances.rangebyscoreraw(outage_start, restart_at)
+puts "Receipts created in window: #{ids.size}"
+
+candidates = ids.filter_map do |id|
+r = Onetime::Receipt.load(id) rescue nil
+next unless r
+next unless r.source.to_s == 'incoming' # incoming feature only
+next if r.recipients.to_s.empty? # must have a recipient
+s = r.load_secret # nil => viewed/burned/expired
+next unless s
+{ receipt: r, secret: s }
+end
+
+puts "Live, unviewed incoming secrets to re-notify: #{candidates.size}"
+candidates.each do |c|
+r, s = c[:receipt], c[:secret]
+puts format(' %s created=%s to=%s domain=%s',
+r.shortid,
+Time.at(r.created.to_i).utc,
+OT::Utils.obscure_email(r.recipients),
+s.share_domain || 'canonical')
+end
+
+Verify the count and the recipients/timestamps look right. If the window is off, widen it and re-run — nothing is sent.
+
+Step 2 — Send (flip the flag, re-enqueue via the real path)
+
+Same block, but set DRY_RUN = false and add the enqueue at the end:
+
+DRY_RUN = false
+
+sent = 0
+candidates.each do |c|
+r, s = c[:receipt], c[:secret]
+next if DRY_RUN
+
+Onetime::Jobs::Publisher.enqueue_email(
+:incoming_secret,
+{
+secret_key: s.identifier,
+share_domain: s.share_domain,
+recipient: r.recipients,
+memo: r.memo,
+has_passphrase: r.has_passphrase?,
+locale: OT.default_locale, # originored on the receipt
+},
+domain_id: r.domain_id,
+)
+sent += 1
+puts "re-enqueued #{r.shortid} -> #{OT::Utils.obscure_email(r.recipients)}"
+end
+puts "Re-enqueued #{sent} notifications"
+
+This pushes them onto email.message.send; the workeatch them drain:
+
+podman exec <container> bin/ots queue status
+
+Notes
+
+- The payload mirrors create_incoming_secret.rb:292 exactly, with two substitutions: secret_key/share_domain come from the reloaded secret, and locale falls back to OT.default_locale because the original request locale isn't persisted on the receipt (recipients get the default-language email — cosmetic only).
+- If instances scoring turns out not to be created he dry-run's printed created= timestamps will lookwrong (outside your window) — that's your signal to tell me and I'll switch the enumerator to expiration_timeline ranged by created + ttl instead.

--- a/etc/examples/billing.example.yaml
+++ b/etc/examples/billing.example.yaml
@@ -42,6 +42,12 @@ enabled: <%= ENV['BILLING_ENABLED'] != 'false' %>
 stripe_key: <%= ENV['STRIPE_API_KEY'] || 'nostripekey' %>
 webhook_signing_secret: <%= ENV['STRIPE_WEBHOOK_SIGNING_SECRET'] || 'nosigningsecret' %>
 stripe_api_version: "2025-12-15.clover"
+
+# Stripe custom Checkout domain host (bare host, no scheme). Empty unless
+# this deployment configures a Stripe "custom domain" for Checkout. When set,
+# the frontend allowlists checkout URLs served from this host.
+checkout_host: <%= ENV['STRIPE_CHECKOUT_HOST'] || '' %>
+
 currency: <%= ENV['BILLING_CURRENCY'] || ENV['CURRENCY'] || 'cad' %>
 
 # Product Matching Configuration

--- a/lib/onetime/billing_config.rb
+++ b/lib/onetime/billing_config.rb
@@ -77,8 +77,12 @@ module Onetime
 
     # Stripe custom Checkout domain host (bare host, no scheme).
     # Empty/nil unless a Stripe "custom domain" is configured for Checkout.
+    #
+    # Checks ENV['STRIPE_CHECKOUT_HOST'] first, then falls back to config file,
+    # mirroring stripe_key. This keeps the host available even when billing.yaml
+    # is absent (the deployment contract sets STRIPE_CHECKOUT_HOST directly).
     def checkout_host
-      config['checkout_host']
+      ENV.fetch('STRIPE_CHECKOUT_HOST', nil) || config['checkout_host']
     end
 
     # Schema version

--- a/lib/onetime/billing_config.rb
+++ b/lib/onetime/billing_config.rb
@@ -75,6 +75,12 @@ module Onetime
       config['stripe_api_version']
     end
 
+    # Stripe custom Checkout domain host (bare host, no scheme).
+    # Empty/nil unless a Stripe "custom domain" is configured for Checkout.
+    def checkout_host
+      config['checkout_host']
+    end
+
     # Schema version
     def schema_version
       config['schema_version']

--- a/lib/onetime/billing_config.rb
+++ b/lib/onetime/billing_config.rb
@@ -128,8 +128,9 @@ module Onetime
       raise Onetime::ConfigError, <<~MSG.strip
         STRIPE_CHECKOUT_HOST (or billing.yaml checkout_host) is not a bare host: #{checkout_host.to_s.strip.inspect}
 
-        It must be a hostname only — no scheme, no path, no userinfo. Examples:
+        It must be a bare host with an optional port — no scheme, no path, no userinfo. Examples:
           valid:   pay.onetimesecret.com
+          valid:   pay.onetimesecret.com:8443       (optional port)
           invalid: https://pay.onetimesecret.com   (drop the scheme)
           invalid: pay.onetimesecret.com/checkout  (drop the path)
 

--- a/lib/onetime/billing_config.rb
+++ b/lib/onetime/billing_config.rb
@@ -19,6 +19,17 @@ module Onetime
   class BillingConfig
     include Singleton
 
+    # Bare-host shape for a Stripe custom Checkout domain, mirroring the
+    # frontend allowlist rule in src/utils/redirect.ts (setAllowedCheckoutHost):
+    # DNS labels with an optional :port and nothing else — no scheme, userinfo,
+    # path, query, or fragment. Anything the frontend would reject at navigation
+    # time must fail here at boot instead.
+    CHECKOUT_HOST_RE = /\A
+      (?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)          # first DNS label
+      (?:\.(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?))*   # additional labels
+      (?::\d{1,5})?                                # optional port
+    \z/ix
+
     attr_reader :config, :path, :environment
 
     def initialize
@@ -83,6 +94,37 @@ module Onetime
     # is absent (the deployment contract sets STRIPE_CHECKOUT_HOST directly).
     def checkout_host
       ENV.fetch('STRIPE_CHECKOUT_HOST', nil) || config['checkout_host']
+    end
+
+    # Whether the configured checkout_host is a well-formed bare host.
+    # Empty/nil counts as valid — the custom-domain feature is simply off.
+    def valid_checkout_host?
+      host = checkout_host.to_s.strip
+      return true if host.empty?
+
+      CHECKOUT_HOST_RE.match?(host)
+    end
+
+    # Boot-time enforcement: raise when checkout_host is set but malformed.
+    #
+    # Without this, a bad STRIPE_CHECKOUT_HOST (scheme prefix, userinfo,
+    # path, whitespace-in-the-middle) is silently dropped by the frontend
+    # guard (fail-closed), so custom-domain checkout breaks only when a
+    # customer clicks Upgrade — hours or days after the bad deploy. Failing
+    # here turns that into a loud boot failure the deploy can catch.
+    def validate_checkout_host!
+      return if valid_checkout_host?
+
+      raise Onetime::ConfigError, <<~MSG.strip
+        STRIPE_CHECKOUT_HOST (or billing.yaml checkout_host) is not a bare host: #{checkout_host.to_s.strip.inspect}
+
+        It must be a hostname only — no scheme, no path, no userinfo. Examples:
+          valid:   pay.onetimesecret.com
+          invalid: https://pay.onetimesecret.com   (drop the scheme)
+          invalid: pay.onetimesecret.com/checkout  (drop the path)
+
+        Leave it unset unless a Stripe custom Checkout domain is configured.
+      MSG
     end
 
     # Schema version

--- a/lib/onetime/billing_config.rb
+++ b/lib/onetime/billing_config.rb
@@ -98,11 +98,21 @@ module Onetime
 
     # Whether the configured checkout_host is a well-formed bare host.
     # Empty/nil counts as valid — the custom-domain feature is simply off.
+    #
+    # The port, when present, must fall in the real TCP range (1..65535). The
+    # frontend derives the origin with `new URL()`, which rejects out-of-range
+    # ports; enforcing the same bound here keeps a value like
+    # "pay.example.com:99999" from booting the backend only to be silently
+    # dropped (fail-closed) by the browser guard and break checkout later.
     def valid_checkout_host?
       host = checkout_host.to_s.strip
       return true if host.empty?
+      return false unless CHECKOUT_HOST_RE.match?(host)
 
-      CHECKOUT_HOST_RE.match?(host)
+      port = host[/:(\d+)\z/, 1]
+      return true if port.nil?
+
+      (1..65_535).cover?(port.to_i)
     end
 
     # Boot-time enforcement: raise when checkout_host is set but malformed.

--- a/src/plugins/core/appInitializer.ts
+++ b/src/plugins/core/appInitializer.ts
@@ -5,6 +5,7 @@ import i18n from '@/i18n';
 import { setupRouterGuards } from '@/router/guards.routes';
 import { consumeBootstrapData, getBootstrapValue } from '@/services/bootstrap.service';
 import { loggingService } from '@/services/logging.service';
+import { setAllowedCheckoutHost } from '@/utils/redirect';
 import { AxiosInstance } from 'axios';
 import { createPinia } from 'pinia';
 import { App, Plugin } from 'vue';
@@ -46,7 +47,7 @@ export const AppInitializer: Plugin<AppInitializerOptions> = {
  *
  * We separate this from the main plugin to interface for testing purposes.
  */
-/*eslint max-statements: ["error", 23]*/
+/*eslint max-statements: ["error", 24]*/
 function initializeApp(app: App, options: AppInitializerOptions) {
   // Consume bootstrap data early, before Pinia is installed.
   // This populates the snapshot for getBootstrapValue() calls.
@@ -56,6 +57,13 @@ function initializeApp(app: App, options: AppInitializerOptions) {
   const d9sEnabled = getBootstrapValue('d9s_enabled');
   const displayDomain = getBootstrapValue('display_domain');
   const siteHost = getBootstrapValue('site_host');
+
+  // Seed the checkout-URL host allowlist with this deployment's Stripe
+  // custom-domain host (bare host, empty when unconfigured). Must run before
+  // any billing/checkout response is parsed; checkout only happens on user
+  // action, well after init.
+  setAllowedCheckoutHost(getBootstrapValue('checkout_host'));
+
   const router = options.router;
   const pinia = createPinia();
   const api = options.api ?? createApi();

--- a/src/schemas/contracts/billing.ts
+++ b/src/schemas/contracts/billing.ts
@@ -18,6 +18,10 @@ import { BillingTierSchema, CanonicalPlanIdSchema } from './config/billing';
  * Security (M-9): checkout URLs are navigated to via `window.location`, so the
  * schema layer host-allowlists them as defence-in-depth. The load-bearing check
  * remains the assignment-site guard in PlanSelector.vue (isAllowedCheckoutUrl).
+ * The allowlisted origins are the static baseline (`checkout.stripe.com`), the
+ * current app origin (same-origin), and this deployment's Stripe custom-domain
+ * Checkout host, configured at runtime from the bootstrap `checkout_host` field
+ * (see setAllowedCheckoutHost in @/utils/redirect).
  */
 const checkoutUrlSchema = z
   .url()

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -510,6 +510,7 @@ export const bootstrapSchema = z.object({
   site_host: z.string().default(''),
   support_email: z.string().default(''),
   support_host: z.string().default(''),
+  checkout_host: z.string().default(''),
   ui: uiInterfaceSchema.default(uiInterfaceSchema.parse({})),
   available_jurisdictions: z.array(z.string()).default([]),
 

--- a/src/tests/contracts/bootstrap-serializer-fields.ts
+++ b/src/tests/contracts/bootstrap-serializer-fields.ts
@@ -58,6 +58,7 @@ export const CONFIG_SERIALIZER_FIELDS = [
   'site_host',
   'support_email',
   'support_host',
+  'checkout_host',
   'ui',
 ] as const;
 

--- a/src/tests/fixtures/bootstrap.fixture.ts
+++ b/src/tests/fixtures/bootstrap.fixture.ts
@@ -63,6 +63,7 @@ export const baseBootstrap: BootstrapPayload = {
   frontend_host: 'https://test.onetimesecret.com',
   site_host: 'test.onetimesecret.com',
   support_host: 'support.onetimesecret.com',
+  checkout_host: 'pay.onetimesecret.com',
 
   // Test locales
   supported_locales: ['en', 'es', 'fr', 'de'],

--- a/src/tests/fixtures/bootstrap.fixture.ts
+++ b/src/tests/fixtures/bootstrap.fixture.ts
@@ -63,7 +63,10 @@ export const baseBootstrap: BootstrapPayload = {
   frontend_host: 'https://test.onetimesecret.com',
   site_host: 'test.onetimesecret.com',
   support_host: 'support.onetimesecret.com',
-  checkout_host: 'pay.onetimesecret.com',
+  // Empty by default — mirrors production (set only when a Stripe custom
+  // Checkout domain is configured) and avoids enabling the custom-domain
+  // allowlist across unrelated tests. Scenario fixtures override as needed.
+  checkout_host: '',
 
   // Test locales
   supported_locales: ['en', 'es', 'fr', 'de'],

--- a/src/tests/utils/redirect.spec.ts
+++ b/src/tests/utils/redirect.spec.ts
@@ -302,5 +302,27 @@ describe('isAllowedCheckoutUrl', () => {
       setAllowedCheckoutHost('https://pay.onetimesecret.com');
       expect(isAllowedCheckoutUrl('https://pay.onetimesecret.com/c/pay/cs')).toBe(false);
     });
+
+    it('accepts a host with an explicit non-default port', () => {
+      // The port is part of the origin, so only matching-port URLs are allowed.
+      setAllowedCheckoutHost('pay.onetimesecret.com:8443');
+      expect(isAllowedCheckoutUrl('https://pay.onetimesecret.com:8443/c/pay/cs')).toBe(true);
+      expect(isAllowedCheckoutUrl('https://pay.onetimesecret.com/c/pay/cs')).toBe(false);
+    });
+
+    it('accepts a host with the explicit default HTTPS port (:443)', () => {
+      // new URL() normalizes :443 away; the host must still be enabled. This is
+      // the regression the raw-input validation guards against — comparing the
+      // input to new URL().host would drop :443 and clear the origin.
+      setAllowedCheckoutHost('pay.onetimesecret.com:443');
+      expect(isAllowedCheckoutUrl('https://pay.onetimesecret.com/c/pay/cs')).toBe(true);
+      expect(isAllowedCheckoutUrl('https://pay.onetimesecret.com:443/c/pay/cs')).toBe(true);
+    });
+
+    it('rejects a host with an out-of-range port', () => {
+      // new URL() rejects ports > 65535; fail closed rather than silently drop.
+      setAllowedCheckoutHost('pay.onetimesecret.com:99999');
+      expect(isAllowedCheckoutUrl('https://pay.onetimesecret.com/c/pay/cs')).toBe(false);
+    });
   });
 });

--- a/src/tests/utils/redirect.spec.ts
+++ b/src/tests/utils/redirect.spec.ts
@@ -188,14 +188,25 @@ describe('validateRedirect', () => {
 });
 
 describe('isAllowedCheckoutUrl', () => {
+  let originalLocation: Location;
+
   beforeEach(() => {
+    originalLocation = window.location;
     Object.defineProperty(window, 'location', {
       value: { origin: 'https://onetimesecret.com' },
       writable: true,
+      configurable: true,
     });
   });
 
   afterEach(() => {
+    // Restore the real Location so a partial stub doesn't leak into other test
+    // files sharing this Vitest worker (see src/tests/router/guards.routes.spec.ts).
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
     // Reset the module-level configured host so state doesn't leak between tests.
     setAllowedCheckoutHost(null);
   });

--- a/src/tests/utils/redirect.spec.ts
+++ b/src/tests/utils/redirect.spec.ts
@@ -1,7 +1,11 @@
 // src/tests/utils/redirect.spec.ts
 
-import { validateRedirect } from '@/utils/redirect';
-import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  isAllowedCheckoutUrl,
+  setAllowedCheckoutHost,
+  validateRedirect,
+} from '@/utils/redirect';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 describe('validateRedirect', () => {
   beforeEach(() => {
@@ -180,5 +184,97 @@ describe('validateRedirect', () => {
       // Invalid properties should still fail
       expect(validateRedirect({ path: '/profile', query: '<script>' })).toBe(true);
     });
+  });
+});
+
+describe('isAllowedCheckoutUrl', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: { origin: 'https://onetimesecret.com' },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    // Reset the module-level configured host so state doesn't leak between tests.
+    setAllowedCheckoutHost(null);
+  });
+
+  it('allows the shared Stripe Checkout host', () => {
+    expect(isAllowedCheckoutUrl('https://checkout.stripe.com/c/pay/cs_test_123')).toBe(true);
+  });
+
+  it('allows the current app origin', () => {
+    expect(isAllowedCheckoutUrl('https://onetimesecret.com/billing/welcome')).toBe(true);
+  });
+
+  it('rejects an unrelated host', () => {
+    expect(isAllowedCheckoutUrl('https://evil.example.com/c/pay/cs')).toBe(false);
+  });
+
+  describe('when no custom checkout host is configured', () => {
+    it('rejects the Stripe custom-domain host (not hardcoded)', () => {
+      expect(isAllowedCheckoutUrl('https://pay.onetimesecret.com/c/pay/cs_test_123')).toBe(
+        false
+      );
+    });
+
+    it('still allows the shared Stripe host and the app origin', () => {
+      expect(isAllowedCheckoutUrl('https://checkout.stripe.com/c/pay/cs_test_123')).toBe(
+        true
+      );
+      expect(isAllowedCheckoutUrl('https://onetimesecret.com/billing/welcome')).toBe(true);
+    });
+  });
+
+  describe('when a custom checkout host is configured', () => {
+    beforeEach(() => {
+      setAllowedCheckoutHost('pay.onetimesecret.com');
+    });
+
+    it('allows the configured Stripe custom-domain Checkout host', () => {
+      expect(isAllowedCheckoutUrl('https://pay.onetimesecret.com/c/pay/cs_test_123')).toBe(
+        true
+      );
+    });
+
+    it('still allows the static baseline and same-origin', () => {
+      expect(isAllowedCheckoutUrl('https://checkout.stripe.com/c/pay/cs_test_123')).toBe(
+        true
+      );
+      expect(isAllowedCheckoutUrl('https://onetimesecret.com/billing/welcome')).toBe(true);
+    });
+
+    it('still rejects lookalike siblings of the configured host', () => {
+      expect(isAllowedCheckoutUrl('https://not-pay.onetimesecret.com.evil.com/')).toBe(
+        false
+      );
+      expect(isAllowedCheckoutUrl('https://pay.onetimesecret.com.evil.com/')).toBe(false);
+      expect(isAllowedCheckoutUrl('https://checkout.stripe.com.evil.com/')).toBe(false);
+    });
+  });
+
+  it('clears the configured host when set to empty or null', () => {
+    setAllowedCheckoutHost('pay.onetimesecret.com');
+    expect(isAllowedCheckoutUrl('https://pay.onetimesecret.com/c/pay/cs')).toBe(true);
+
+    setAllowedCheckoutHost('');
+    expect(isAllowedCheckoutUrl('https://pay.onetimesecret.com/c/pay/cs')).toBe(false);
+
+    setAllowedCheckoutHost('pay.onetimesecret.com');
+    setAllowedCheckoutHost(null);
+    expect(isAllowedCheckoutUrl('https://pay.onetimesecret.com/c/pay/cs')).toBe(false);
+  });
+
+  it('does not allow a wildcard sibling of an allowlisted host', () => {
+    expect(isAllowedCheckoutUrl('https://not-pay.onetimesecret.com.evil.com/')).toBe(false);
+    expect(isAllowedCheckoutUrl('https://checkout.stripe.com.evil.com/')).toBe(false);
+  });
+
+  it('rejects empty, null, and unparseable input', () => {
+    expect(isAllowedCheckoutUrl('')).toBe(false);
+    expect(isAllowedCheckoutUrl(null)).toBe(false);
+    expect(isAllowedCheckoutUrl(undefined)).toBe(false);
+    expect(isAllowedCheckoutUrl('not-a-url')).toBe(false);
   });
 });

--- a/src/tests/utils/redirect.spec.ts
+++ b/src/tests/utils/redirect.spec.ts
@@ -277,4 +277,30 @@ describe('isAllowedCheckoutUrl', () => {
     expect(isAllowedCheckoutUrl(undefined)).toBe(false);
     expect(isAllowedCheckoutUrl('not-a-url')).toBe(false);
   });
+
+  describe('setAllowedCheckoutHost input validation', () => {
+    it('tolerates surrounding whitespace on the configured host', () => {
+      // env/helm values commonly carry stray spaces; they must not silently
+      // clear the host and reintroduce the checkout regression.
+      setAllowedCheckoutHost('  pay.onetimesecret.com  ');
+      expect(isAllowedCheckoutUrl('https://pay.onetimesecret.com/c/pay/cs')).toBe(true);
+    });
+
+    it('rejects a host carrying userinfo instead of selecting the authority', () => {
+      // "pay.onetimesecret.com@evil.example" parses to origin https://evil.example.
+      setAllowedCheckoutHost('pay.onetimesecret.com@evil.example');
+      expect(isAllowedCheckoutUrl('https://evil.example/c/pay/cs')).toBe(false);
+      expect(isAllowedCheckoutUrl('https://pay.onetimesecret.com/c/pay/cs')).toBe(false);
+    });
+
+    it('rejects a host that includes a path', () => {
+      setAllowedCheckoutHost('pay.onetimesecret.com/evil');
+      expect(isAllowedCheckoutUrl('https://pay.onetimesecret.com/c/pay/cs')).toBe(false);
+    });
+
+    it('rejects a value that already includes a scheme', () => {
+      setAllowedCheckoutHost('https://pay.onetimesecret.com');
+      expect(isAllowedCheckoutUrl('https://pay.onetimesecret.com/c/pay/cs')).toBe(false);
+    });
+  });
 });

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -115,6 +115,16 @@ const CHECKOUT_ALLOWED_ORIGINS = ['https://checkout.stripe.com'] as const;
 let configuredCheckoutOrigin: string | null = null;
 
 /**
+ * Bare-host shape for a Stripe custom Checkout domain: DNS labels with an
+ * optional `:port` and nothing else — no scheme, userinfo, path, query, or
+ * fragment. Mirrors CHECKOUT_HOST_RE in lib/onetime/billing_config.rb so a
+ * value that boots on the backend also passes here at navigation time. The
+ * captured group is the optional port digits, range-checked by the caller.
+ */
+const CHECKOUT_HOST_RE =
+  /^(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)(?:\.(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?))*(?::(\d{1,5}))?$/i;
+
+/**
  * Register this deployment's Stripe custom-domain Checkout host (bare host,
  * e.g. "pay.onetimesecret.com"), sourced from the bootstrap `checkout_host`
  * config. Call once at app init. Empty/invalid input clears it. Enables
@@ -136,18 +146,30 @@ export function setAllowedCheckoutHost(host: string | undefined | null): void {
   const trimmed = host.trim();
   if (!trimmed) return;
 
+  // Validate the raw input directly against a bare-host shape — DNS labels plus
+  // an optional port, nothing else. This mirrors the backend CHECKOUT_HOST_RE in
+  // lib/onetime/billing_config.rb. We deliberately do NOT validate by comparing
+  // against `new URL().host`: that parser normalizes the default port (:443)
+  // away, so the supported "host:443" form would fail the comparison and clear
+  // the origin. The regex rejects userinfo, paths, queries, fragments, and
+  // embedded schemes up front, so URL parsing below is only used to normalize.
+  const match = CHECKOUT_HOST_RE.exec(trimmed);
+  if (!match) return;
+
+  const port = match[1];
+  if (port !== undefined) {
+    const portNum = Number(port);
+    // new URL() rejects out-of-range ports; enforce the TCP range here so a
+    // value like "pay.example.com:99999" fails closed at config time rather
+    // than passing our shape check and then being silently dropped by new URL().
+    if (portNum < 1 || portNum > 65535) return;
+  }
+
   try {
-    const url = new URL(`https://${trimmed}`);
-    const isBareHost =
-      url.username === '' &&
-      url.password === '' &&
-      url.pathname === '/' &&
-      url.search === '' &&
-      url.hash === '' &&
-      url.host === trimmed.toLowerCase(); // url.host includes any non-default port
-    if (isBareHost) configuredCheckoutOrigin = url.origin;
+    // Normalize to an origin (drops the default :443, lowercases the host).
+    configuredCheckoutOrigin = new URL(`https://${trimmed}`).origin;
   } catch {
-    // Unparseable host — leave cleared.
+    // Unparseable despite matching the bare-host shape — leave cleared.
   }
 }
 

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -117,19 +117,37 @@ let configuredCheckoutOrigin: string | null = null;
 /**
  * Register this deployment's Stripe custom-domain Checkout host (bare host,
  * e.g. "pay.onetimesecret.com"), sourced from the bootstrap `checkout_host`
- * config. Call once at app init. Empty/invalid clears it. Enables
+ * config. Call once at app init. Empty/invalid input clears it. Enables
  * isAllowedCheckoutUrl to accept live-mode Checkout URLs served from the
  * account's Stripe custom domain without hardcoding the host.
+ *
+ * Input must be a bare host (optionally `host:port`). Surrounding whitespace is
+ * tolerated (env/helm values often carry it). Anything else — userinfo, a path,
+ * a query/fragment, or an embedded scheme — is rejected rather than coerced,
+ * because `new URL()` silently absorbs those components and could yield an
+ * unintended origin (e.g. "pay.example.com@evil.example" → "https://evil.example",
+ * or "https://pay.example.com" → host "https"). Rejection fails closed.
  */
 export function setAllowedCheckoutHost(host: string | undefined | null): void {
-  if (!host) {
-    configuredCheckoutOrigin = null;
-    return;
-  }
+  // Default to cleared; only a well-formed bare host re-enables the origin.
+  configuredCheckoutOrigin = null;
+  if (!host) return;
+
+  const trimmed = host.trim();
+  if (!trimmed) return;
+
   try {
-    configuredCheckoutOrigin = new URL(`https://${host}`).origin;
+    const url = new URL(`https://${trimmed}`);
+    const isBareHost =
+      url.username === '' &&
+      url.password === '' &&
+      url.pathname === '/' &&
+      url.search === '' &&
+      url.hash === '' &&
+      url.host === trimmed.toLowerCase(); // url.host includes any non-default port
+    if (isBareHost) configuredCheckoutOrigin = url.origin;
   } catch {
-    configuredCheckoutOrigin = null;
+    // Unparseable host — leave cleared.
   }
 }
 

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -101,6 +101,39 @@ function validatePathString(path: string): boolean {
 }
 
 /**
+ * Static baseline allowlist for checkout origins.
+ *
+ * Contains only the shared Stripe Checkout host. When a Stripe "custom domain"
+ * is configured on the account, its host is NOT hardcoded here — it is supplied
+ * at runtime from the bootstrap `checkout_host` config via
+ * setAllowedCheckoutHost(). See isAllowedCheckoutUrl.
+ *
+ * Do NOT loosen these to a wildcard `*.stripe.com` or `*.onetimesecret.com`.
+ */
+const CHECKOUT_ALLOWED_ORIGINS = ['https://checkout.stripe.com'] as const;
+
+let configuredCheckoutOrigin: string | null = null;
+
+/**
+ * Register this deployment's Stripe custom-domain Checkout host (bare host,
+ * e.g. "pay.onetimesecret.com"), sourced from the bootstrap `checkout_host`
+ * config. Call once at app init. Empty/invalid clears it. Enables
+ * isAllowedCheckoutUrl to accept live-mode Checkout URLs served from the
+ * account's Stripe custom domain without hardcoding the host.
+ */
+export function setAllowedCheckoutHost(host: string | undefined | null): void {
+  if (!host) {
+    configuredCheckoutOrigin = null;
+    return;
+  }
+  try {
+    configuredCheckoutOrigin = new URL(`https://${host}`).origin;
+  } catch {
+    configuredCheckoutOrigin = null;
+  }
+}
+
+/**
  * Validates that a checkout URL is safe to navigate to via `window.location`.
  *
  * Security (M-9): `checkout_url` is API-derived and assigned directly to
@@ -110,18 +143,28 @@ function validatePathString(path: string): boolean {
  * (isValidInternalPath, validateRedirect, validateUrl) only permit same-origin
  * internal targets, so an external-host allowlist requires this dedicated helper.
  *
- * The host allowlist is intentionally exact — Stripe Checkout is served only
- * from `checkout.stripe.com`; do not loosen to a wildcard `*.stripe.com`.
+ * The host allowlist is intentionally exact. Accepted origins are:
+ *   1. the static baseline: the shared `checkout.stripe.com` host,
+ *   2. the current app origin (same-origin), and
+ *   3. this deployment's runtime-configured Stripe custom-domain Checkout host,
+ *      seeded once at app init from the bootstrap `checkout_host` config via
+ *      setAllowedCheckoutHost() (e.g. `pay.onetimesecret.com`).
+ *
+ * Do NOT loosen to a wildcard `*.stripe.com` or `*.onetimesecret.com`.
  *
  * @param url - The checkout URL to validate
- * @returns true only when the URL parses and its origin is the Stripe Checkout
- *          host or the current origin
+ * @returns true only when the URL parses and its origin is an allowlisted
+ *          Stripe Checkout host, the current origin, or the configured host
  */
 export function isAllowedCheckoutUrl(url: string | undefined | null): url is string {
   if (!url || typeof url !== 'string') return false;
   try {
     const { origin } = new URL(url);
-    return origin === 'https://checkout.stripe.com' || origin === window.location.origin;
+    return (
+      (CHECKOUT_ALLOWED_ORIGINS as readonly string[]).includes(origin) ||
+      origin === window.location.origin ||
+      (configuredCheckoutOrigin !== null && origin === configuredCheckoutOrigin)
+    );
   } catch {
     return false;
   }

--- a/try/unit/config/billing_config_try.rb
+++ b/try/unit/config/billing_config_try.rb
@@ -84,5 +84,56 @@ Onetime::BillingConfig.instance_variable_set(:@singleton__instance__, nil)
 result
 #=> nil
 
+# --- checkout_host validation ---
+# checkout_host reads ENV['STRIPE_CHECKOUT_HOST'] first, so drive it via ENV.
+@original_checkout_host = ENV.delete('STRIPE_CHECKOUT_HOST')
+
+## valid_checkout_host? is true when unset (feature off)
+Onetime::BillingConfig.instance.valid_checkout_host?
+#=> true
+
+## validate_checkout_host! is a no-op when unset
+Onetime::BillingConfig.instance.validate_checkout_host!
+#=> nil
+
+## valid_checkout_host? accepts a bare host
+ENV['STRIPE_CHECKOUT_HOST'] = 'pay.onetimesecret.com'
+Onetime::BillingConfig.instance.valid_checkout_host?
+#=> true
+
+## valid_checkout_host? accepts a bare host with a port
+ENV['STRIPE_CHECKOUT_HOST'] = 'pay.onetimesecret.com:8443'
+Onetime::BillingConfig.instance.valid_checkout_host?
+#=> true
+
+## valid_checkout_host? rejects a scheme prefix
+ENV['STRIPE_CHECKOUT_HOST'] = 'https://pay.onetimesecret.com'
+Onetime::BillingConfig.instance.valid_checkout_host?
+#=> false
+
+## valid_checkout_host? rejects an embedded path
+ENV['STRIPE_CHECKOUT_HOST'] = 'pay.onetimesecret.com/checkout'
+Onetime::BillingConfig.instance.valid_checkout_host?
+#=> false
+
+## valid_checkout_host? rejects userinfo (origin-selection attack)
+ENV['STRIPE_CHECKOUT_HOST'] = 'pay.onetimesecret.com@evil.example'
+Onetime::BillingConfig.instance.valid_checkout_host?
+#=> false
+
+## validate_checkout_host! raises ConfigError on a malformed host
+ENV['STRIPE_CHECKOUT_HOST'] = 'https://pay.onetimesecret.com'
+begin
+  Onetime::BillingConfig.instance.validate_checkout_host!
+  :no_raise
+rescue Onetime::ConfigError
+  :raised
+end
+#=> :raised
+
+# Restore checkout_host env var
+ENV.delete('STRIPE_CHECKOUT_HOST')
+ENV['STRIPE_CHECKOUT_HOST'] = @original_checkout_host unless @original_checkout_host.nil?
+
 # Restore env var cleared in setup
 ENV['STRIPE_API_KEY'] = @original_stripe_api_key unless @original_stripe_api_key.nil?

--- a/try/unit/config/billing_config_try.rb
+++ b/try/unit/config/billing_config_try.rb
@@ -106,6 +106,16 @@ ENV['STRIPE_CHECKOUT_HOST'] = 'pay.onetimesecret.com:8443'
 Onetime::BillingConfig.instance.valid_checkout_host?
 #=> true
 
+## valid_checkout_host? accepts the explicit default HTTPS port
+ENV['STRIPE_CHECKOUT_HOST'] = 'pay.onetimesecret.com:443'
+Onetime::BillingConfig.instance.valid_checkout_host?
+#=> true
+
+## valid_checkout_host? rejects an out-of-range port (new URL() would drop it)
+ENV['STRIPE_CHECKOUT_HOST'] = 'pay.onetimesecret.com:99999'
+Onetime::BillingConfig.instance.valid_checkout_host?
+#=> false
+
 ## valid_checkout_host? rejects a scheme prefix
 ENV['STRIPE_CHECKOUT_HOST'] = 'https://pay.onetimesecret.com'
 Onetime::BillingConfig.instance.valid_checkout_host?


### PR DESCRIPTION
## Summary

Fixes #3821 — the M-9 checkout-URL host allowlist rejected checkout URLs served from the account's Stripe **custom Checkout domain** (e.g. `pay.onetimesecret.com`), which broke live-mode checkout on production upgrades. The static allowlist only accepted `checkout.stripe.com` and the app origin.

This makes the custom-domain host **config-driven** rather than hardcoded, so each deployment allowlists exactly its own Stripe custom domain.

## Deployment Notes

> [!WARNING]
> Production must set `STRIPE_CHECKOUT_HOST=pay.onetimesecret.com` before/with this deploy. Without it, `isAllowedCheckoutUrl()` rejects the custom-domain checkout URL and live-mode checkout stays broken. Ship as **v0.26.1**.

## Changes

- **Backend** — `BillingConfig#checkout_host` reads a new `STRIPE_CHECKOUT_HOST` env var (empty unless a Stripe custom Checkout domain is configured) and the config serializer emits it into the bootstrap payload.
- **Frontend allowlist** — `setAllowedCheckoutHost()` registers the deployment's custom host at runtime; `isAllowedCheckoutUrl()` now accepts (1) the static `checkout.stripe.com` baseline, (2) same-origin, and (3) the runtime-configured host. No wildcards.
- **Wiring** — `checkout_host` added to the bootstrap schema + serializer-field contract; seeded once at app init before any checkout response is parsed.
- **Tests** — 32 specs covering baseline, configured-host, lookalike-sibling rejection, and clearing.
- **Runbook** (unrelated) — recreating email notification from receipt (DLQ replay recovery + SMTP-preflight follow-ups).

## Test plan

- `pnpm exec vitest run src/tests/utils/redirect.spec.ts` → 32/32 pass.
