### PR TITLE
Fix Current badge landing on wrong plan card (#3824)

### DIFF
--- a/src/apps/workspace/billing/PlanSelector.vue
+++ b/src/apps/workspace/billing/PlanSelector.vue
@@ -21,6 +21,7 @@ import {
   isPlanRecommended,
   resolvePlanSelectAction,
   resolveCompletePendingMigrationAction,
+  shouldShowCancelLink,
 } from './planSelectorLogic';
 import { useEntitlements } from '@/shared/composables/useEntitlements';
 import { classifyError } from '@/schemas/errors';
@@ -227,6 +228,17 @@ const isPlanButtonDisabled = (plan: BillingPlan): boolean =>
 
 const isPlanProcessing = (plan: BillingPlan): boolean =>
   (isCreatingCheckout.value && !isPlanCurrent(plan)) || (isReactivating.value && isPlanCurrent(plan));
+
+// Cancel-link visibility is pure state logic; share it with the spec so the
+// template condition can't drift out from under the tests (#3824).
+const showCancelLink = computed(() =>
+  shouldShowCancelLink({
+    hasActiveSubscription: hasActiveSubscription.value,
+    isLegacyCustomer: isLegacyCustomer.value,
+    currentTier: currentTier.value,
+    isCancelScheduled: isCancelScheduled.value,
+  })
+);
 
 const getButtonLabel = (plan: BillingPlan): string => {
   if (isPlanCurrent(plan)) {
@@ -730,7 +742,7 @@ aria-live="polite">
 
       <!-- Cancel Subscription (shown for active paid subscriptions OR legacy customers, NOT already scheduled for cancellation) -->
       <div
-        v-if="(hasActiveSubscription || isLegacyCustomer) && currentTier !== 'free' && !isCancelScheduled"
+        v-if="showCancelLink"
         class="text-center">
         <button
           type="button"

--- a/src/apps/workspace/billing/PlanSelector.vue
+++ b/src/apps/workspace/billing/PlanSelector.vue
@@ -601,10 +601,11 @@ onMounted(async () => {
       </div>
 
       <!-- Billing Interval Toggle -->
-      <div class="flex items-center justify-center gap-3"
-data-testid="billing-interval-toggle"
-role="group"
-aria-label="Billing interval">
+      <div
+        class="flex items-center justify-center gap-3"
+        data-testid="billing-interval-toggle"
+        role="group"
+        aria-label="Billing interval">
         <button
           @click="billingInterval = 'month'"
           data-testid="billing-interval-month"
@@ -673,7 +674,7 @@ aria-live="polite">
             </p>
           </div>
           <span
-            v-if="currentTier === 'free'"
+            v-if="freePlan && isPlanCurrent(freePlan)"
             class="shrink-0 rounded-md bg-green-100 px-4 py-2 text-sm font-semibold text-green-800 dark:bg-green-900/30 dark:text-green-300">
             {{ t('web.billing.plans.current') }}
           </span>

--- a/src/apps/workspace/billing/PlanSelector.vue
+++ b/src/apps/workspace/billing/PlanSelector.vue
@@ -12,6 +12,12 @@ import PlanChangeModal from './PlanChangeModal.vue';
 import CancelSubscriptionModal from './CancelSubscriptionModal.vue';
 import CurrencyMigrationModal from './CurrencyMigrationModal.vue';
 import PendingMigrationBanner from './PendingMigrationBanner.vue';
+import {
+  isPlanCurrent as isPlanCurrentLogic,
+  isPlanCurrencyMismatch as isPlanCurrencyMismatchLogic,
+  isCurrencyMigrationBlocked,
+  isPlanButtonDisabled as isPlanButtonDisabledLogic,
+} from './planSelectorLogic';
 import { useEntitlements } from '@/shared/composables/useEntitlements';
 import { classifyError } from '@/schemas/errors';
 import type { CurrencyConflictError } from '@/schemas/shapes/account/billing';
@@ -91,7 +97,7 @@ const pendingMigration = computed(() => subscriptionStatus.value?.pending_curren
 const currentCurrency = computed(() => subscriptionStatus.value?.current_currency ?? null);
 
 const isPlanCurrencyMismatch = (plan: BillingPlan): boolean =>
-  !!currentCurrency.value && !!plan.currency && currentCurrency.value !== plan.currency;
+  isPlanCurrencyMismatchLogic(currentCurrency.value, plan);
 
 // Current plan for the modal (find from plans list based on subscription)
 const currentPlanForModal = computed(() => {
@@ -201,7 +207,8 @@ const isPlanRecommended = (plan: BillingPlan): boolean => plan.is_popular ?? fal
  * STRICT id match: the "Current" badge belongs to the plan whose id equals the
  * org's planid. No tier comparison — tier is drift-prone metadata (#3824).
  */
-const isPlanCurrent = (plan: BillingPlan): boolean => plan.id === selectedOrg.value?.planid;
+const isPlanCurrent = (plan: BillingPlan): boolean =>
+  isPlanCurrentLogic(plan, selectedOrg.value?.planid);
 
 /**
  * Canonical tier ordering for upgrade/downgrade direction (#3824).
@@ -227,11 +234,14 @@ const canDowngrade = (plan: BillingPlan): boolean => {
 };
 
 const isPlanButtonDisabled = (plan: BillingPlan): boolean =>
-  (isPlanCurrent(plan) && !isCancelScheduled.value) ||
-  isCreatingCheckout.value ||
-  isReactivating.value ||
-  (plan.tier === 'free' && !hasActiveSubscription.value) ||
-  isPlanCurrencyMismatch(plan);
+  isPlanButtonDisabledLogic(plan, {
+    orgPlanId: selectedOrg.value?.planid,
+    currentCurrency: currentCurrency.value,
+    isCreatingCheckout: isCreatingCheckout.value,
+    isReactivating: isReactivating.value,
+    isCancelScheduled: isCancelScheduled.value,
+    hasActiveSubscription: hasActiveSubscription.value,
+  });
 
 const isPlanProcessing = (plan: BillingPlan): boolean =>
   (isCreatingCheckout.value && !isPlanCurrent(plan)) || (isReactivating.value && isPlanCurrent(plan));
@@ -419,11 +429,7 @@ const handleCompletePendingMigration = async () => {
   // Guard: if the old subscription hasn't been cancelled yet, its currency
   // still differs from the migration target — creating a checkout would
   // trigger a currency conflict from Stripe.
-  if (
-    currentCurrency.value &&
-    pendingMigration.value.target_currency &&
-    currentCurrency.value !== pendingMigration.value.target_currency
-  ) {
+  if (isCurrencyMigrationBlocked(currentCurrency.value, pendingMigration.value.target_currency)) {
     error.value = t('web.billing.plan_unavailable_region_mismatch');
     return;
   }

--- a/src/apps/workspace/billing/PlanSelector.vue
+++ b/src/apps/workspace/billing/PlanSelector.vue
@@ -15,8 +15,12 @@ import PendingMigrationBanner from './PendingMigrationBanner.vue';
 import {
   isPlanCurrent as isPlanCurrentLogic,
   isPlanCurrencyMismatch as isPlanCurrencyMismatchLogic,
-  isCurrencyMigrationBlocked,
   isPlanButtonDisabled as isPlanButtonDisabledLogic,
+  canUpgrade as canUpgradeLogic,
+  canDowngrade as canDowngradeLogic,
+  isPlanRecommended,
+  resolvePlanSelectAction,
+  resolveCompletePendingMigrationAction,
 } from './planSelectorLogic';
 import { useEntitlements } from '@/shared/composables/useEntitlements';
 import { classifyError } from '@/schemas/errors';
@@ -197,41 +201,19 @@ const freePlan = computed(() => plans.value.find((plan) => plan.tier === 'free')
 const isLoadingContent = computed(() => isLoadingPlans.value || isLoadingDefinitions.value || isLoadingOrg.value);
 
 /**
- * Check if plan should show "Most Popular" badge.
- * is_popular (API-provided) is the sole authority — no tier-based fallback,
- * so "Most Popular" is never defaulted onto a card (#3824).
- */
-const isPlanRecommended = (plan: BillingPlan): boolean => plan.is_popular ?? false;
-
-/**
  * STRICT id match: the "Current" badge belongs to the plan whose id equals the
  * org's planid. No tier comparison — tier is drift-prone metadata (#3824).
  */
 const isPlanCurrent = (plan: BillingPlan): boolean =>
   isPlanCurrentLogic(plan, selectedOrg.value?.planid);
 
-/**
- * Canonical tier ordering for upgrade/downgrade direction (#3824).
- * free < single_account < single_team < multi_team
- */
-const TIER_ORDER = ['free', 'single_account', 'single_team', 'multi_team'] as const;
-const tierRank = (tier: string | undefined | null): number =>
-  tier ? TIER_ORDER.indexOf(tier as (typeof TIER_ORDER)[number]) : -1;
+// Upgrade/downgrade direction is pure tier-rank logic (#3824). Bind the current
+// tier here so all call sites (getButtonLabel, etc.) stay single-arg.
+const canUpgrade = (plan: BillingPlan): boolean =>
+  canUpgradeLogic(currentPlan.value?.tier, plan);
 
-const canUpgrade = (plan: BillingPlan): boolean => {
-  const current = tierRank(currentPlan.value?.tier);
-  const target = tierRank(plan.tier);
-  // Unresolved/legacy current plan (rank -1) yields no direction.
-  if (current === -1 || target === -1) return false;
-  return target > current;
-};
-
-const canDowngrade = (plan: BillingPlan): boolean => {
-  const current = tierRank(currentPlan.value?.tier);
-  const target = tierRank(plan.tier);
-  if (current === -1 || target === -1) return false;
-  return target < current;
-};
+const canDowngrade = (plan: BillingPlan): boolean =>
+  canDowngradeLogic(currentPlan.value?.tier, plan);
 
 const isPlanButtonDisabled = (plan: BillingPlan): boolean =>
   isPlanButtonDisabledLogic(plan, {
@@ -280,35 +262,54 @@ const loadPlans = async () => {
 };
 
 const handlePlanSelect = async (plan: BillingPlan) => {
+  // Pure decision first (shared with the currency spec), then side effects.
+  const action = resolvePlanSelectAction(plan, {
+    orgExtid: selectedOrg.value?.extid,
+    orgPlanId: selectedOrg.value?.planid,
+    currentCurrency: currentCurrency.value,
+    isCancelScheduled: isCancelScheduled.value,
+    hasActiveSubscription: hasActiveSubscription.value,
+  });
+
+  switch (action) {
+    case 'noop':
+      return;
+
+    case 'reactivate':
+      // Current plan clicked while a cancellation is scheduled → reactivate.
+      await handleReactivateSubscription();
+      return;
+
+    case 'open-cancel-modal':
+      // Free plan for an active subscriber: cancel instead of checkout.
+      showCancelModal.value = true;
+      return;
+
+    case 'currency-blocked':
+      // Clear stale messages; the disabled button already explains the block.
+      error.value = '';
+      successMessage.value = '';
+      return;
+
+    case 'open-plan-change-modal':
+      error.value = '';
+      successMessage.value = '';
+      targetPlan.value = plan;
+      showPlanChangeModal.value = true;
+      return;
+
+    case 'checkout':
+      error.value = '';
+      successMessage.value = '';
+      await startCheckoutSession(plan);
+      return;
+  }
+};
+
+// New subscriber flow: redirect to Stripe Checkout for the selected plan.
+const startCheckoutSession = async (plan: BillingPlan) => {
   if (!selectedOrg.value?.extid) return;
 
-  if (isPlanCurrent(plan)) {
-    // When cancellation is scheduled, clicking the current plan reactivates
-    if (isCancelScheduled.value) await handleReactivateSubscription();
-    return;
-  }
-
-  // Free plan: open the cancel subscription modal instead of checkout
-  if (plan.tier === 'free') {
-    if (hasActiveSubscription.value) {
-      showCancelModal.value = true;
-    }
-    return;
-  }
-
-  // Clear any previous messages
-  error.value = '';
-  successMessage.value = '';
-
-  if (isPlanCurrencyMismatch(plan)) return;
-
-  if (hasActiveSubscription.value) {
-    targetPlan.value = plan;
-    showPlanChangeModal.value = true;
-    return;
-  }
-
-  // New subscriber or currency-mismatch flow: redirect to Stripe Checkout
   isCreatingCheckout.value = true;
 
   try {
@@ -424,15 +425,26 @@ const handleImmediateRedirect = (checkoutUrl: string) => {
 
 // Handle "Complete Migration" from the PendingMigrationBanner
 const handleCompletePendingMigration = async () => {
-  if (!selectedOrg.value?.extid || !pendingMigration.value) return;
+  // Pure decision first (shared with the currency spec), then side effects.
+  // 'currency-blocked' means the old subscription hasn't been cancelled yet, so
+  // its currency still differs from the migration target — creating a checkout
+  // would trigger a currency conflict from Stripe.
+  const action = resolveCompletePendingMigrationAction(pendingMigration.value, {
+    orgExtid: selectedOrg.value?.extid,
+    currentCurrency: currentCurrency.value,
+  });
 
-  // Guard: if the old subscription hasn't been cancelled yet, its currency
-  // still differs from the migration target — creating a checkout would
-  // trigger a currency conflict from Stripe.
-  if (isCurrencyMigrationBlocked(currentCurrency.value, pendingMigration.value.target_currency)) {
+  if (action === 'currency-blocked') {
     error.value = t('web.billing.plan_unavailable_region_mismatch');
     return;
   }
+  if (action !== 'checkout') return;
+
+  // action === 'checkout': both are guaranteed present; re-read as locals so
+  // TypeScript narrows for the checkout call below.
+  const extid = selectedOrg.value?.extid;
+  const migration = pendingMigration.value;
+  if (!extid || !migration) return;
 
   isCompletingPendingMigration.value = true;
   error.value = '';
@@ -441,10 +453,10 @@ const handleCompletePendingMigration = async () => {
     // Create a new checkout session for the pending migration target plan.
     // target_plan_id is a family ID (e.g. "identity_plus_v1").
     // target_interval provides the billing interval.
-    const planId = pendingMigration.value.target_plan_id;
-    const interval = pendingMigration.value.target_interval ?? 'month';
+    const planId = migration.target_plan_id;
+    const interval = migration.target_interval ?? 'month';
     const response = await BillingService.createCheckoutSession(
-      selectedOrg.value.extid,
+      extid,
       {
         id: planId,
         interval,

--- a/src/apps/workspace/billing/PlanSelector.vue
+++ b/src/apps/workspace/billing/PlanSelector.vue
@@ -22,7 +22,8 @@ import { isLegacyPlan, getPlanLabel } from '@/types/billing';
 import type { Organization } from '@/types/organization';
 import { formatDisplayDate } from '@/utils/format';
 import { isAllowedCheckoutUrl } from '@/utils/redirect';
-import { computed, onMounted, ref } from 'vue';
+import { captureMessage, isDiagnosticsEnabled } from '@/services/diagnostics.service';
+import { computed, onMounted, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 
 const props = withDefaults(
@@ -109,24 +110,55 @@ const {
 } = useEntitlements(selectedOrg);
 
 /**
- * Get the current organization's tier by finding the matching plan.
- * The org has planid (canonical family ID like 'identity_plus_v1') and we need
- * the tier (e.g., 'single_team') for comparison with available plans.
+ * Resolve the organization's current plan by STRICT id match against the
+ * loaded plans list. Returns null when the org's planid isn't present (legacy
+ * or unmatched) — we never invent a tier for an unresolved plan (#3824).
  */
-const currentTier = computed((): string => {
-  const planid = selectedOrg.value?.planid;
-  if (!planid) return 'free';
+const currentPlan = computed(
+  () => plans.value.find((p) => p.id === selectedOrg.value?.planid) ?? null
+);
 
-  // Find the plan that matches the org's planid to get its tier
-  const matchingPlan = plans.value.find(p => p.id === planid);
-  if (matchingPlan) return matchingPlan.tier;
+/**
+ * Current tier, derived strictly from the resolved plan. Null for
+ * unresolved/legacy plans so the free banner and upgrade/downgrade ordering
+ * never badge or mis-order the wrong card.
+ */
+const currentTier = computed((): string | null => currentPlan.value?.tier ?? null);
 
-  // Handle legacy plans that aren't in the active plans list
-  // Legacy 'identity' plan has team features equivalent to single_team tier
-  if (planid === 'identity') return 'single_team';
+/**
+ * Diagnostic: an org carrying a non-legacy planid that isn't present in the
+ * loaded plans list is a data/tier drift the team needs to see (this replaces
+ * the old silent 'free' fallback). Fire once per unmatched planid (deduped)
+ * through the shared diagnostics service.
+ */
+const reportedUnmatchedPlanids = new Set<string>();
+watch(
+  [currentPlan, selectedOrg, plans],
+  () => {
+    const planid = selectedOrg.value?.planid;
+    if (!planid) return;
+    // Plans not loaded yet — can't conclude the id is genuinely absent.
+    if (plans.value.length === 0) return;
+    if (currentPlan.value) return;
+    // Legacy plans (e.g. 'identity') are expected to be absent from the list.
+    if (isLegacyPlan(planid)) return;
+    if (reportedUnmatchedPlanids.has(planid)) return;
 
-  return 'free';
-});
+    if (isDiagnosticsEnabled()) {
+      // Mark as reported only when actually emitting, so dedup tracks
+      // "sent" rather than "seen" (a disabled emit must not suppress a
+      // later send once diagnostics are enabled).
+      reportedUnmatchedPlanids.add(planid);
+      captureMessage('current plan id not present in plans list', {
+        service: 'web',
+        errorType: 'technical',
+        planid,
+        orgExtid: selectedOrg.value?.extid,
+      });
+    }
+  },
+  { immediate: true }
+);
 
 // Legacy plan detection for grandfathered customers
 const isLegacyCustomer = computed(() =>
@@ -160,22 +192,38 @@ const isLoadingContent = computed(() => isLoadingPlans.value || isLoadingDefinit
 
 /**
  * Check if plan should show "Most Popular" badge.
- * Uses API-provided is_popular flag if available.
+ * is_popular (API-provided) is the sole authority — no tier-based fallback,
+ * so "Most Popular" is never defaulted onto a card (#3824).
  */
-const isPlanRecommended = (plan: BillingPlan): boolean => plan.is_popular ?? plan.tier === 'single_team';
+const isPlanRecommended = (plan: BillingPlan): boolean => plan.is_popular ?? false;
 
-const isPlanCurrent = (plan: BillingPlan): boolean => plan.tier === currentTier.value;
+/**
+ * STRICT id match: the "Current" badge belongs to the plan whose id equals the
+ * org's planid. No tier comparison — tier is drift-prone metadata (#3824).
+ */
+const isPlanCurrent = (plan: BillingPlan): boolean => plan.id === selectedOrg.value?.planid;
+
+/**
+ * Canonical tier ordering for upgrade/downgrade direction (#3824).
+ * free < single_account < single_team < multi_team
+ */
+const TIER_ORDER = ['free', 'single_account', 'single_team', 'multi_team'] as const;
+const tierRank = (tier: string | undefined | null): number =>
+  tier ? TIER_ORDER.indexOf(tier as (typeof TIER_ORDER)[number]) : -1;
 
 const canUpgrade = (plan: BillingPlan): boolean => {
-  if (currentTier.value === 'free') return plan.tier !== 'free';
-  if (currentTier.value === 'single_team') return plan.tier === 'multi_team';
-  return false;
+  const current = tierRank(currentPlan.value?.tier);
+  const target = tierRank(plan.tier);
+  // Unresolved/legacy current plan (rank -1) yields no direction.
+  if (current === -1 || target === -1) return false;
+  return target > current;
 };
 
 const canDowngrade = (plan: BillingPlan): boolean => {
-  if (currentTier.value === 'multi_team') return plan.tier !== 'multi_team';
-  if (currentTier.value === 'single_team') return plan.tier === 'free';
-  return false;
+  const current = tierRank(currentPlan.value?.tier);
+  const target = tierRank(plan.tier);
+  if (current === -1 || target === -1) return false;
+  return target < current;
 };
 
 const isPlanButtonDisabled = (plan: BillingPlan): boolean =>

--- a/src/apps/workspace/billing/planSelectorLogic.ts
+++ b/src/apps/workspace/billing/planSelectorLogic.ts
@@ -226,3 +226,24 @@ export function resolveCompletePendingMigrationAction(
   }
   return 'checkout';
 }
+
+export interface CancelLinkState {
+  hasActiveSubscription: boolean;
+  isLegacyCustomer: boolean;
+  currentTier: string | null | undefined;
+  isCancelScheduled: boolean;
+}
+
+/**
+ * Whether the "Cancel Subscription" link is shown. Mirrors the template guard
+ * exactly: an active subscriber OR a grandfathered legacy customer, on a paid
+ * tier, whose cancellation is not already scheduled. Free tier never shows it,
+ * and a customer already scheduled to cancel sees the reactivate banner instead.
+ */
+export function shouldShowCancelLink(state: CancelLinkState): boolean {
+  return (
+    (state.hasActiveSubscription || state.isLegacyCustomer) &&
+    state.currentTier !== 'free' &&
+    !state.isCancelScheduled
+  );
+}

--- a/src/apps/workspace/billing/planSelectorLogic.ts
+++ b/src/apps/workspace/billing/planSelectorLogic.ts
@@ -83,3 +83,146 @@ export function isPlanButtonDisabled(
     isPlanCurrencyMismatch(state.currentCurrency, plan)
   );
 }
+
+/**
+ * Canonical tier ordering for upgrade/downgrade direction (#3824).
+ * free < single_account < single_team < multi_team.
+ * Single source of truth — the component and its specs both consume this rather
+ * than re-declaring the order (drift is exactly the #3824 failure mode).
+ */
+export const TIER_ORDER = [
+  'free',
+  'single_account',
+  'single_team',
+  'multi_team',
+] as const;
+
+/**
+ * Rank of a tier in TIER_ORDER. Falsy (unresolved/legacy) and unknown tiers
+ * both yield -1, which callers treat as "no direction".
+ */
+export function tierRank(tier: string | null | undefined): number {
+  return tier ? TIER_ORDER.indexOf(tier as (typeof TIER_ORDER)[number]) : -1;
+}
+
+/**
+ * Whether moving from currentTier to targetPlan's tier is an upgrade. An
+ * unresolved current or target tier (rank -1) yields no direction, matching the
+ * component's "currentPlan null => no upgrade/downgrade" behavior.
+ */
+export function canUpgrade(
+  currentTier: string | null | undefined,
+  targetPlan: BillingPlan
+): boolean {
+  const current = tierRank(currentTier);
+  const target = tierRank(targetPlan.tier);
+  if (current === -1 || target === -1) return false;
+  return target > current;
+}
+
+/**
+ * Whether moving from currentTier to targetPlan's tier is a downgrade.
+ * Same unresolved-tier handling as canUpgrade.
+ */
+export function canDowngrade(
+  currentTier: string | null | undefined,
+  targetPlan: BillingPlan
+): boolean {
+  const current = tierRank(currentTier);
+  const target = tierRank(targetPlan.tier);
+  if (current === -1 || target === -1) return false;
+  return target < current;
+}
+
+/**
+ * Whether a plan shows the "Most Popular" badge. is_popular (API-provided) is
+ * the sole authority — no tier-based fallback, so the badge is never defaulted
+ * onto a card (#3824).
+ */
+export function isPlanRecommended(plan: BillingPlan): boolean {
+  return plan.is_popular ?? false;
+}
+
+/**
+ * The action handlePlanSelect resolves to before running side effects. Pure
+ * classification so the component and its spec share one control-flow contract:
+ *   - 'noop'                   no org, current-plan (not cancel-scheduled), or
+ *                             free-tier without an active subscription
+ *   - 'reactivate'             current plan while a cancellation is scheduled
+ *   - 'open-cancel-modal'      free tier with an active subscription
+ *   - 'currency-blocked'       target currency conflicts with the subscription
+ *   - 'open-plan-change-modal' existing subscriber switching paid plans
+ *   - 'checkout'               new subscriber starting a Stripe Checkout
+ */
+export type PlanSelectAction =
+  | 'reactivate'
+  | 'open-cancel-modal'
+  | 'currency-blocked'
+  | 'open-plan-change-modal'
+  | 'checkout'
+  | 'noop';
+
+export interface PlanSelectContext {
+  orgExtid: string | null | undefined;
+  orgPlanId: string | null | undefined;
+  currentCurrency: string | null | undefined;
+  isCancelScheduled: boolean;
+  hasActiveSubscription: boolean;
+}
+
+/**
+ * Classify what a plan-card click should do, matching handlePlanSelect's
+ * early-return cascade exactly. The component switches on the returned action to
+ * run the impure work (modals, checkout redirect, error strings); the spec
+ * asserts the action, so the ordering can't drift out from under the tests.
+ */
+export function resolvePlanSelectAction(
+  plan: BillingPlan,
+  ctx: PlanSelectContext
+): PlanSelectAction {
+  if (!ctx.orgExtid) return 'noop';
+
+  if (isPlanCurrent(plan, ctx.orgPlanId)) {
+    return ctx.isCancelScheduled ? 'reactivate' : 'noop';
+  }
+
+  if (plan.tier === 'free') {
+    return ctx.hasActiveSubscription ? 'open-cancel-modal' : 'noop';
+  }
+
+  if (isPlanCurrencyMismatch(ctx.currentCurrency, plan)) return 'currency-blocked';
+
+  if (ctx.hasActiveSubscription) return 'open-plan-change-modal';
+
+  return 'checkout';
+}
+
+/**
+ * The action handleCompletePendingMigration resolves to before side effects:
+ *   - 'noop'             no org or no pending migration
+ *   - 'currency-blocked' the still-active subscription's currency conflicts
+ *                        with the migration target (checkout would fail)
+ *   - 'checkout'         safe to create the migration checkout session
+ */
+export type CompletePendingMigrationAction = 'noop' | 'currency-blocked' | 'checkout';
+
+export interface CompletePendingMigrationContext {
+  orgExtid: string | null | undefined;
+  currentCurrency: string | null | undefined;
+}
+
+/**
+ * Classify the "Complete Migration" click, matching
+ * handleCompletePendingMigration's guard order. Reuses isCurrencyMigrationBlocked
+ * for the currency decision so production and spec share one implementation.
+ */
+export function resolveCompletePendingMigrationAction(
+  pendingMigration: { target_currency?: string | null } | null | undefined,
+  ctx: CompletePendingMigrationContext
+): CompletePendingMigrationAction {
+  if (!ctx.orgExtid || !pendingMigration) return 'noop';
+  if (isCurrencyMigrationBlocked(ctx.currentCurrency, pendingMigration.target_currency)) {
+    return 'currency-blocked';
+  }
+  return 'checkout';
+}

--- a/src/apps/workspace/billing/planSelectorLogic.ts
+++ b/src/apps/workspace/billing/planSelectorLogic.ts
@@ -1,0 +1,85 @@
+// src/apps/workspace/billing/planSelectorLogic.ts
+
+//
+// Pure decision logic for PlanSelector.vue.
+//
+// Extracted so the component and its unit tests share ONE implementation.
+// Previously the specs re-implemented these predicates inline, which let the
+// test copy drift from production (e.g. the pre-#3824 tier-based isPlanCurrent
+// lingering in tests after the component moved to strict id match).
+//
+
+import type { Plan as BillingPlan } from '@/services/billing.service';
+
+/**
+ * STRICT id match: the "Current" badge belongs to the plan whose id equals the
+ * org's planid. No tier comparison — tier is drift-prone metadata (#3824).
+ */
+export function isPlanCurrent(
+  plan: BillingPlan,
+  orgPlanId: string | null | undefined
+): boolean {
+  return plan.id === orgPlanId;
+}
+
+/**
+ * Two currencies conflict only when both are present and differ. A missing
+ * currency (new subscriber, or a plan without one) never conflicts.
+ */
+function currenciesConflict(
+  a: string | null | undefined,
+  b: string | null | undefined
+): boolean {
+  return !!a && !!b && a !== b;
+}
+
+/**
+ * True when the plan's currency differs from the current subscription's
+ * currency. New subscribers (no current currency) never mismatch.
+ */
+export function isPlanCurrencyMismatch(
+  currentCurrency: string | null | undefined,
+  plan: BillingPlan
+): boolean {
+  return currenciesConflict(currentCurrency, plan.currency);
+}
+
+/**
+ * True when completing a pending currency migration would create a checkout
+ * that conflicts with the still-active subscription's currency. Shared by
+ * handleCompletePendingMigration's guard.
+ */
+export function isCurrencyMigrationBlocked(
+  currentCurrency: string | null | undefined,
+  targetCurrency: string | null | undefined
+): boolean {
+  return currenciesConflict(currentCurrency, targetCurrency);
+}
+
+export interface PlanButtonState {
+  orgPlanId: string | null | undefined;
+  currentCurrency: string | null | undefined;
+  isCreatingCheckout: boolean;
+  isReactivating: boolean;
+  isCancelScheduled: boolean;
+  hasActiveSubscription: boolean;
+}
+
+/**
+ * Whether a plan card's action button is disabled. Mirrors the production
+ * cascade exactly: the current plan is actionable only while a cancellation is
+ * scheduled (to reactivate); free is actionable only for active subscribers
+ * (to downgrade); currency mismatches are never actionable.
+ */
+export function isPlanButtonDisabled(
+  plan: BillingPlan,
+  state: PlanButtonState
+): boolean {
+  return (
+    (isPlanCurrent(plan, state.orgPlanId) && !state.isCancelScheduled) ||
+    state.isCreatingCheckout ||
+    state.isReactivating ||
+    (plan.tier === 'free' && !state.hasActiveSubscription) ||
+    isPlanCurrencyMismatch(state.currentCurrency, plan)
+  );
+}

--- a/src/tests/apps/workspace/billing/PlanChangeModal.spec.ts
+++ b/src/tests/apps/workspace/billing/PlanChangeModal.spec.ts
@@ -62,7 +62,9 @@ const mockCurrentPlan = {
   id: 'identity_plus_v1',
   stripe_price_id: 'price_current_123',
   name: 'Identity Plus',
-  tier: 'single_team',
+  // Backend reality: identity_plus_v1 is single_account (#3824). Inert here —
+  // PlanChangeModal derives upgrade/downgrade from amount/display_order.
+  tier: 'single_account',
   interval: 'month',
   amount: 2900,
   currency: 'cad',
@@ -77,7 +79,9 @@ const mockTargetPlan = {
   id: 'team_plus_v1',
   stripe_price_id: 'price_target_456',
   name: 'Team Plus',
-  tier: 'multi_team',
+  // Backend reality: team_plus_v1 is single_team (#3824). Inert here —
+  // PlanChangeModal derives upgrade/downgrade from amount/display_order.
+  tier: 'single_team',
   interval: 'month',
   amount: 9900,
   currency: 'cad',

--- a/src/tests/apps/workspace/billing/PlanSelector.currency.spec.ts
+++ b/src/tests/apps/workspace/billing/PlanSelector.currency.spec.ts
@@ -9,54 +9,50 @@
 // - handleCompletePendingMigration currency guard
 // - Plan card button disabled state for mismatched currencies
 //
-// NOTE: These tests exercise extracted logic from PlanSelector.vue.
-// They do not mount the component to avoid complex Vue/Pinia/i18n setup.
+// These exercise the SHARED pure logic in planSelectorLogic.ts — the same
+// module PlanSelector.vue delegates to. The predicates are imported, never
+// re-implemented, so the test can't drift from the component (the pre-#3824
+// tier-based isPlanCurrent silently lingering in a test copy is exactly the
+// failure mode this avoids).
 
 import { describe, it, expect } from 'vitest';
 import type { Plan as BillingPlan, SubscriptionStatusResponse } from '@/services/billing.service';
+import {
+  isPlanCurrent,
+  isPlanCurrencyMismatch,
+  isCurrencyMigrationBlocked,
+  isPlanButtonDisabled,
+  type PlanButtonState,
+} from '@/apps/workspace/billing/planSelectorLogic';
 
-// --- Extracted logic from PlanSelector.vue ---
+// --- Thin composition of the handler flows under test ---
+//
+// These mirror the early-return ordering of PlanSelector.vue's async handlers
+// (which interleave side effects, so they can't be imported as-is). The
+// drift-prone predicates — isPlanCurrent, isPlanCurrencyMismatch — come from
+// the shared module, so only the trivial glue (extid/free-tier checks) is local.
 
 /**
- * isPlanCurrencyMismatch — line ~90 in PlanSelector.vue
- *
- * Returns true when the plan's currency differs from the
- * current subscription's currency.
- */
-function isPlanCurrencyMismatch(
-  currentCurrency: string | null,
-  plan: BillingPlan
-): boolean {
-  return !!currentCurrency && !!plan.currency && currentCurrency !== plan.currency;
-}
-
-/**
- * Simulates handlePlanSelect's early-return logic (lines ~213-220)
- *
- * Returns true if the handler would bail out before making an API call.
+ * handlePlanSelect (PlanSelector.vue) bails before any checkout/modal when the
+ * org is unset, the plan is already current, the plan is free, or the currency
+ * mismatches.
  */
 function wouldHandlePlanSelectEarlyReturn(
   plan: BillingPlan,
-  currentPlanId: string | undefined,
+  orgPlanId: string | undefined,
   orgExtid: string | undefined,
   currentCurrency: string | null
 ): boolean {
-  // isPlanCurrent check — STRICT id match, mirrors production (#3824)
-  if (plan.id === currentPlanId) return true;
-  // No org selected
   if (!orgExtid) return true;
-  // Free tier — no checkout
+  if (isPlanCurrent(plan, orgPlanId)) return true;
   if (plan.tier === 'free') return true;
-  // Currency mismatch
-  if (isPlanCurrencyMismatch(currentCurrency, plan)) return true;
-  return false;
+  return isPlanCurrencyMismatch(currentCurrency, plan);
 }
 
 /**
- * Simulates handleCompletePendingMigration's currency guard
- * (the fix added in this PR).
- *
- * Returns true if the handler would bail out before creating a checkout.
+ * handleCompletePendingMigration bails when the org is unset, there's no
+ * pending migration, or the still-active subscription's currency conflicts
+ * with the migration target.
  */
 function wouldCompleteMigrationBail(
   orgExtid: string | undefined,
@@ -64,35 +60,7 @@ function wouldCompleteMigrationBail(
   currentCurrency: string | null
 ): boolean {
   if (!orgExtid || !pendingMigration) return true;
-  if (
-    currentCurrency &&
-    pendingMigration.target_currency &&
-    currentCurrency !== pendingMigration.target_currency
-  ) {
-    return true;
-  }
-  return false;
-}
-
-/**
- * Simulates the button-disabled condition from PlanSelector template (line ~608):
- *   :button-disabled="isPlanCurrent(plan) || isCreatingCheckout
- *     || plan.tier === 'free' || isPlanCurrencyMismatch(plan)"
- */
-function isButtonDisabled(
-  plan: BillingPlan,
-  currentPlanId: string | undefined,
-  isCreatingCheckout: boolean,
-  currentCurrency: string | null
-): boolean {
-  // isPlanCurrent — STRICT id match, mirrors production (#3824)
-  const isPlanCurrent = plan.id === currentPlanId;
-  return (
-    isPlanCurrent ||
-    isCreatingCheckout ||
-    plan.tier === 'free' ||
-    isPlanCurrencyMismatch(currentCurrency, plan)
-  );
+  return isCurrencyMigrationBlocked(currentCurrency, pendingMigration.target_currency);
 }
 
 // --- Test fixtures ---
@@ -110,6 +78,16 @@ const createMockPlan = (overrides: Partial<BillingPlan> = {}): BillingPlan => ({
   features: ['Feature 1'],
   limits: { teams: 1 },
   entitlements: ['create_secrets', 'api_access'],
+  ...overrides,
+});
+
+const createButtonState = (overrides: Partial<PlanButtonState> = {}): PlanButtonState => ({
+  orgPlanId: 'free_v1',
+  currentCurrency: null,
+  isCreatingCheckout: false,
+  isReactivating: false,
+  isCancelScheduled: false,
+  hasActiveSubscription: false,
   ...overrides,
 });
 
@@ -216,6 +194,11 @@ describe('PlanSelector currency mismatch logic', () => {
       );
       expect(result).toBe(true);
     });
+
+    it('early-returns when no org selected', () => {
+      const cadPlan = createMockPlan({ currency: 'cad', tier: 'single_team' });
+      expect(wouldHandlePlanSelectEarlyReturn(cadPlan, 'free_v1', undefined, 'cad')).toBe(true);
+    });
   });
 
   describe('handleCompletePendingMigration currency guard', () => {
@@ -255,50 +238,92 @@ describe('PlanSelector currency mismatch logic', () => {
   describe('plan card button disabled state', () => {
     it('disables button when plan currency mismatches subscription', () => {
       const eurPlan = createMockPlan({ currency: 'eur', tier: 'single_team' });
-      expect(isButtonDisabled(eurPlan, 'free_v1', false, 'cad')).toBe(true);
+      const state = createButtonState({ currentCurrency: 'cad', hasActiveSubscription: true });
+      expect(isPlanButtonDisabled(eurPlan, state)).toBe(true);
     });
 
     it('enables button when currencies match', () => {
       const cadPlan = createMockPlan({ currency: 'cad', tier: 'single_team' });
-      expect(isButtonDisabled(cadPlan, 'free_v1', false, 'cad')).toBe(false);
+      const state = createButtonState({ currentCurrency: 'cad', hasActiveSubscription: true });
+      expect(isPlanButtonDisabled(cadPlan, state)).toBe(false);
     });
 
     it('enables button when no current currency (new subscriber)', () => {
       const eurPlan = createMockPlan({ currency: 'eur', tier: 'single_team' });
-      expect(isButtonDisabled(eurPlan, 'free_v1', false, null)).toBe(false);
+      const state = createButtonState({ currentCurrency: null });
+      expect(isPlanButtonDisabled(eurPlan, state)).toBe(false);
     });
 
     it('disables button for current plan even when currencies match', () => {
       const cadPlan = createMockPlan({ currency: 'cad', tier: 'single_team' });
       // Strict id match: org's planid equals this plan's id (#3824)
-      expect(isButtonDisabled(cadPlan, 'identity_plus_v1', false, 'cad')).toBe(true);
+      const state = createButtonState({
+        orgPlanId: 'identity_plus_v1',
+        currentCurrency: 'cad',
+        hasActiveSubscription: true,
+      });
+      expect(isPlanButtonDisabled(cadPlan, state)).toBe(true);
+    });
+
+    it('enables the current plan button while a cancellation is scheduled (to reactivate)', () => {
+      const cadPlan = createMockPlan({ currency: 'cad', tier: 'single_team' });
+      const state = createButtonState({
+        orgPlanId: 'identity_plus_v1',
+        currentCurrency: 'cad',
+        hasActiveSubscription: true,
+        isCancelScheduled: true,
+      });
+      expect(isPlanButtonDisabled(cadPlan, state)).toBe(false);
     });
 
     it('disables button during checkout creation', () => {
       const cadPlan = createMockPlan({ currency: 'cad', tier: 'single_team' });
-      expect(isButtonDisabled(cadPlan, 'free_v1', true, 'cad')).toBe(true);
+      const state = createButtonState({
+        currentCurrency: 'cad',
+        hasActiveSubscription: true,
+        isCreatingCheckout: true,
+      });
+      expect(isPlanButtonDisabled(cadPlan, state)).toBe(true);
     });
 
-    it('disables button for free tier plans', () => {
+    it('disables button while reactivating', () => {
+      const cadPlan = createMockPlan({ currency: 'cad', tier: 'single_team' });
+      const state = createButtonState({ currentCurrency: 'cad', isReactivating: true });
+      expect(isPlanButtonDisabled(cadPlan, state)).toBe(true);
+    });
+
+    it('disables the free tier button for a new subscriber (nothing to cancel to)', () => {
       const freePlan = createMockPlan({ currency: 'cad', tier: 'free', id: 'free_v1' });
-      expect(isButtonDisabled(freePlan, 'identity_plus_v1', false, null)).toBe(true);
+      const state = createButtonState({ orgPlanId: 'free_v1', hasActiveSubscription: false });
+      expect(isPlanButtonDisabled(freePlan, state)).toBe(true);
+    });
+
+    it('enables the free tier button for an active subscriber (cancel to downgrade)', () => {
+      const freePlan = createMockPlan({ currency: 'cad', tier: 'free', id: 'free_v1' });
+      const state = createButtonState({
+        orgPlanId: 'identity_plus_v1',
+        hasActiveSubscription: true,
+      });
+      expect(isPlanButtonDisabled(freePlan, state)).toBe(false);
     });
   });
 
   describe('cross-region scenarios', () => {
-    it('USD subscriber sees EUR plans as disabled', () => {
+    it('CAD subscriber sees EUR plans as disabled', () => {
       const eurPlan = createMockPlan({ currency: 'eur', region: 'EU' });
+      const state = createButtonState({ currentCurrency: 'cad', hasActiveSubscription: true });
       expect(isPlanCurrencyMismatch('cad', eurPlan)).toBe(true);
-      expect(isButtonDisabled(eurPlan, 'free_v1', false, 'cad')).toBe(true);
+      expect(isPlanButtonDisabled(eurPlan, state)).toBe(true);
     });
 
-    it('EUR subscriber sees USD plans as disabled', () => {
+    it('EUR subscriber sees CAD plans as disabled', () => {
       const cadPlan = createMockPlan({ currency: 'cad', region: 'US' });
+      const state = createButtonState({ currentCurrency: 'eur', hasActiveSubscription: true });
       expect(isPlanCurrencyMismatch('eur', cadPlan)).toBe(true);
-      expect(isButtonDisabled(cadPlan, 'free_v1', false, 'eur')).toBe(true);
+      expect(isPlanButtonDisabled(cadPlan, state)).toBe(true);
     });
 
-    it('new subscriber (no currency) sees all plans as enabled', () => {
+    it('new subscriber (no currency) sees paid plans as enabled', () => {
       const cadPlan = createMockPlan({ currency: 'cad', region: 'US' });
       const eurPlan = createMockPlan({ currency: 'eur', region: 'EU' });
 
@@ -306,12 +331,12 @@ describe('PlanSelector currency mismatch logic', () => {
       expect(isPlanCurrencyMismatch(null, eurPlan)).toBe(false);
     });
 
-    it('pending migration blocked when old USD sub still active for EUR target', () => {
+    it('pending migration blocked when old CAD sub still active for EUR target', () => {
       const pending = createPendingMigration({
         target_currency: 'eur',
         target_plan_name: 'Identity Plus (EU)',
       });
-      // Old subscription still active with USD
+      // Old subscription still active with CAD
       expect(wouldCompleteMigrationBail('on1abc123', pending, 'cad')).toBe(true);
     });
 

--- a/src/tests/apps/workspace/billing/PlanSelector.currency.spec.ts
+++ b/src/tests/apps/workspace/billing/PlanSelector.currency.spec.ts
@@ -18,50 +18,20 @@
 import { describe, it, expect } from 'vitest';
 import type { Plan as BillingPlan, SubscriptionStatusResponse } from '@/services/billing.service';
 import {
-  isPlanCurrent,
   isPlanCurrencyMismatch,
-  isCurrencyMigrationBlocked,
   isPlanButtonDisabled,
+  resolvePlanSelectAction,
+  resolveCompletePendingMigrationAction,
   type PlanButtonState,
+  type PlanSelectContext,
+  type CompletePendingMigrationContext,
 } from '@/apps/workspace/billing/planSelectorLogic';
 
-// --- Thin composition of the handler flows under test ---
-//
-// These mirror the early-return ordering of PlanSelector.vue's async handlers
-// (which interleave side effects, so they can't be imported as-is). The
-// drift-prone predicates — isPlanCurrent, isPlanCurrencyMismatch — come from
-// the shared module, so only the trivial glue (extid/free-tier checks) is local.
-
-/**
- * handlePlanSelect (PlanSelector.vue) bails before any checkout/modal when the
- * org is unset, the plan is already current, the plan is free, or the currency
- * mismatches.
- */
-function wouldHandlePlanSelectEarlyReturn(
-  plan: BillingPlan,
-  orgPlanId: string | undefined,
-  orgExtid: string | undefined,
-  currentCurrency: string | null
-): boolean {
-  if (!orgExtid) return true;
-  if (isPlanCurrent(plan, orgPlanId)) return true;
-  if (plan.tier === 'free') return true;
-  return isPlanCurrencyMismatch(currentCurrency, plan);
-}
-
-/**
- * handleCompletePendingMigration bails when the org is unset, there's no
- * pending migration, or the still-active subscription's currency conflicts
- * with the migration target.
- */
-function wouldCompleteMigrationBail(
-  orgExtid: string | undefined,
-  pendingMigration: SubscriptionStatusResponse['pending_currency_migration'],
-  currentCurrency: string | null
-): boolean {
-  if (!orgExtid || !pendingMigration) return true;
-  return isCurrencyMigrationBlocked(currentCurrency, pendingMigration.target_currency);
-}
+// The handler-flow tests below assert the ACTUAL decision functions
+// PlanSelector.vue calls (resolvePlanSelectAction /
+// resolveCompletePendingMigrationAction) rather than re-implementing the
+// early-return ordering. If the component reorders a guard, these break — the
+// drift the previous hand-copied helpers couldn't catch (#3824).
 
 // --- Test fixtures ---
 
@@ -91,6 +61,17 @@ const createButtonState = (overrides: Partial<PlanButtonState> = {}): PlanButton
   ...overrides,
 });
 
+// Default context: org present, on the free plan, no subscription — i.e. a new
+// subscriber. Override per-test to exercise the other handlePlanSelect branches.
+const createSelectContext = (overrides: Partial<PlanSelectContext> = {}): PlanSelectContext => ({
+  orgExtid: 'on1abc123',
+  orgPlanId: 'free_v1',
+  currentCurrency: null,
+  isCancelScheduled: false,
+  hasActiveSubscription: false,
+  ...overrides,
+});
+
 const createPendingMigration = (
   overrides: Partial<NonNullable<SubscriptionStatusResponse['pending_currency_migration']>> = {}
 ): NonNullable<SubscriptionStatusResponse['pending_currency_migration']> => ({
@@ -101,6 +82,12 @@ const createPendingMigration = (
   target_interval: 'month',
   effective_after: Math.floor(Date.now() / 1000) + 86400 * 30,
   ...overrides,
+});
+
+// Migration guard context — org always present; the no-org case is inlined.
+const migCtx = (currentCurrency: string | null): CompletePendingMigrationContext => ({
+  orgExtid: 'on1abc123',
+  currentCurrency,
 });
 
 // --- Tests ---
@@ -139,99 +126,129 @@ describe('PlanSelector currency mismatch logic', () => {
     });
   });
 
-  describe('handlePlanSelect early return on mismatch', () => {
-    it('early-returns when plan currency mismatches subscription currency', () => {
+  describe('resolvePlanSelectAction (handlePlanSelect decision)', () => {
+    it('is currency-blocked when plan currency mismatches subscription currency', () => {
       const eurPlan = createMockPlan({ currency: 'eur', tier: 'single_team' });
-      const result = wouldHandlePlanSelectEarlyReturn(
+      const action = resolvePlanSelectAction(
         eurPlan,
-        'free_v1', // org's current plan id (not this plan)
-        'on1abc123', // org extid
-        'cad' // current subscription currency
+        createSelectContext({ orgPlanId: 'free_v1', currentCurrency: 'cad' })
       );
-      expect(result).toBe(true);
+      expect(action).toBe('currency-blocked');
     });
 
-    it('does not early-return when currencies match', () => {
+    it('proceeds to checkout when currencies match and no active subscription', () => {
       const cadPlan = createMockPlan({ currency: 'cad', tier: 'single_team' });
-      const result = wouldHandlePlanSelectEarlyReturn(
+      const action = resolvePlanSelectAction(
         cadPlan,
-        'free_v1',
-        'on1abc123',
-        'cad'
+        createSelectContext({ orgPlanId: 'free_v1', currentCurrency: 'cad' })
       );
-      expect(result).toBe(false);
+      expect(action).toBe('checkout');
     });
 
-    it('does not early-return when no current currency (new subscriber)', () => {
+    it('proceeds to checkout when no current currency (new subscriber)', () => {
       const eurPlan = createMockPlan({ currency: 'eur', tier: 'single_team' });
-      const result = wouldHandlePlanSelectEarlyReturn(
+      const action = resolvePlanSelectAction(
         eurPlan,
-        'free_v1',
-        'on1abc123',
-        null
+        createSelectContext({ orgPlanId: 'free_v1', currentCurrency: null })
       );
-      expect(result).toBe(false);
+      expect(action).toBe('checkout');
     });
 
-    it('early-returns for current plan regardless of currency', () => {
-      const plan = createMockPlan({ currency: 'cad', tier: 'single_team' });
-      const result = wouldHandlePlanSelectEarlyReturn(
-        plan,
-        'identity_plus_v1', // same plan id (this is the current plan)
-        'on1abc123',
-        'cad'
-      );
-      expect(result).toBe(true);
-    });
-
-    it('early-returns for free tier plans regardless of currency', () => {
-      const freePlan = createMockPlan({ currency: 'cad', tier: 'free', id: 'free_v1' });
-      const result = wouldHandlePlanSelectEarlyReturn(
-        freePlan,
-        'identity_plus_v1', // org on a paid plan; free card early-returns via free-tier check
-        'on1abc123',
-        'cad'
-      );
-      expect(result).toBe(true);
-    });
-
-    it('early-returns when no org selected', () => {
+    it('opens the plan-change modal for an active subscriber switching paid plans', () => {
       const cadPlan = createMockPlan({ currency: 'cad', tier: 'single_team' });
-      expect(wouldHandlePlanSelectEarlyReturn(cadPlan, 'free_v1', undefined, 'cad')).toBe(true);
+      const action = resolvePlanSelectAction(
+        cadPlan,
+        createSelectContext({
+          orgPlanId: 'team_plus_v1', // different paid plan than this card
+          currentCurrency: 'cad',
+          hasActiveSubscription: true,
+        })
+      );
+      expect(action).toBe('open-plan-change-modal');
+    });
+
+    it('is a no-op for the current plan (not cancel-scheduled) regardless of currency', () => {
+      const plan = createMockPlan({ currency: 'cad', tier: 'single_team' }); // id identity_plus_v1
+      const action = resolvePlanSelectAction(
+        plan,
+        createSelectContext({ orgPlanId: 'identity_plus_v1', currentCurrency: 'cad' })
+      );
+      expect(action).toBe('noop');
+    });
+
+    it('reactivates when the current plan is clicked while a cancellation is scheduled', () => {
+      const plan = createMockPlan({ currency: 'cad', tier: 'single_team' }); // id identity_plus_v1
+      const action = resolvePlanSelectAction(
+        plan,
+        createSelectContext({
+          orgPlanId: 'identity_plus_v1',
+          currentCurrency: 'cad',
+          isCancelScheduled: true,
+        })
+      );
+      expect(action).toBe('reactivate');
+    });
+
+    it('opens the cancel modal for a free card when the subscriber is active', () => {
+      const freePlan = createMockPlan({ currency: 'cad', tier: 'free', id: 'free_v1' });
+      const action = resolvePlanSelectAction(
+        freePlan,
+        createSelectContext({ orgPlanId: 'identity_plus_v1', hasActiveSubscription: true })
+      );
+      expect(action).toBe('open-cancel-modal');
+    });
+
+    it('is a no-op for a free card when there is no active subscription', () => {
+      const freePlan = createMockPlan({ currency: 'cad', tier: 'free', id: 'free_v1' });
+      const action = resolvePlanSelectAction(
+        freePlan,
+        createSelectContext({ orgPlanId: 'free_v1', hasActiveSubscription: false })
+      );
+      expect(action).toBe('noop');
+    });
+
+    it('is a no-op when no org is selected', () => {
+      const cadPlan = createMockPlan({ currency: 'cad', tier: 'single_team' });
+      const action = resolvePlanSelectAction(
+        cadPlan,
+        createSelectContext({ orgExtid: undefined, currentCurrency: 'cad' })
+      );
+      expect(action).toBe('noop');
     });
   });
 
-  describe('handleCompletePendingMigration currency guard', () => {
-    it('bails when current currency differs from migration target currency', () => {
+  describe('resolveCompletePendingMigrationAction (migration guard)', () => {
+    it('is currency-blocked when current currency differs from migration target', () => {
       const pending = createPendingMigration({ target_currency: 'eur' });
-      expect(wouldCompleteMigrationBail('on1abc123', pending, 'cad')).toBe(true);
+      expect(resolveCompletePendingMigrationAction(pending, migCtx('cad'))).toBe('currency-blocked');
     });
 
-    it('proceeds when current currency matches migration target', () => {
+    it('proceeds to checkout when current currency matches migration target', () => {
       const pending = createPendingMigration({ target_currency: 'eur' });
-      expect(wouldCompleteMigrationBail('on1abc123', pending, 'eur')).toBe(false);
+      expect(resolveCompletePendingMigrationAction(pending, migCtx('eur'))).toBe('checkout');
     });
 
-    it('proceeds when current currency is null (subscription already cancelled)', () => {
+    it('proceeds to checkout when current currency is null (subscription already cancelled)', () => {
       const pending = createPendingMigration({ target_currency: 'eur' });
-      expect(wouldCompleteMigrationBail('on1abc123', pending, null)).toBe(false);
+      expect(resolveCompletePendingMigrationAction(pending, migCtx(null))).toBe('checkout');
     });
 
-    it('bails when no org extid', () => {
+    it('is a no-op when no org extid', () => {
       const pending = createPendingMigration();
-      expect(wouldCompleteMigrationBail(undefined, pending, 'cad')).toBe(true);
+      // Inline (not migCtx) because an explicit undefined still hits the default.
+      const ctx: CompletePendingMigrationContext = { orgExtid: undefined, currentCurrency: 'cad' };
+      expect(resolveCompletePendingMigrationAction(pending, ctx)).toBe('noop');
     });
 
-    it('bails when no pending migration', () => {
-      expect(wouldCompleteMigrationBail('on1abc123', null, 'cad')).toBe(true);
+    it('is a no-op when no pending migration', () => {
+      expect(resolveCompletePendingMigrationAction(null, migCtx('cad'))).toBe('noop');
     });
 
-    it('proceeds when pending migration target_currency is empty', () => {
+    it('proceeds to checkout when pending migration target_currency is empty', () => {
       // Empty target_currency means !!'' is false, so the guard won't trigger,
-      // but the checkout will proceed. This is the expected behavior since
-      // the API should always provide a target_currency.
+      // but the checkout will proceed. The API should always provide a currency.
       const pending = createPendingMigration({ target_currency: '' });
-      expect(wouldCompleteMigrationBail('on1abc123', pending, 'cad')).toBe(false);
+      expect(resolveCompletePendingMigrationAction(pending, migCtx('cad'))).toBe('checkout');
     });
   });
 
@@ -332,21 +349,15 @@ describe('PlanSelector currency mismatch logic', () => {
     });
 
     it('pending migration blocked when old CAD sub still active for EUR target', () => {
-      const pending = createPendingMigration({
-        target_currency: 'eur',
-        target_plan_name: 'Identity Plus (EU)',
-      });
+      const pending = createPendingMigration({ target_currency: 'eur' });
       // Old subscription still active with CAD
-      expect(wouldCompleteMigrationBail('on1abc123', pending, 'cad')).toBe(true);
+      expect(resolveCompletePendingMigrationAction(pending, migCtx('cad'))).toBe('currency-blocked');
     });
 
     it('pending migration allowed after old sub cancels (currency becomes null)', () => {
-      const pending = createPendingMigration({
-        target_currency: 'eur',
-        target_plan_name: 'Identity Plus (EU)',
-      });
+      const pending = createPendingMigration({ target_currency: 'eur' });
       // Old subscription cancelled — current_currency is null
-      expect(wouldCompleteMigrationBail('on1abc123', pending, null)).toBe(false);
+      expect(resolveCompletePendingMigrationAction(pending, migCtx(null))).toBe('checkout');
     });
   });
 });

--- a/src/tests/apps/workspace/billing/PlanSelector.currency.spec.ts
+++ b/src/tests/apps/workspace/billing/PlanSelector.currency.spec.ts
@@ -37,12 +37,12 @@ function isPlanCurrencyMismatch(
  */
 function wouldHandlePlanSelectEarlyReturn(
   plan: BillingPlan,
-  currentTier: string,
+  currentPlanId: string | undefined,
   orgExtid: string | undefined,
   currentCurrency: string | null
 ): boolean {
-  // isPlanCurrent check
-  if (plan.tier === currentTier) return true;
+  // isPlanCurrent check — STRICT id match, mirrors production (#3824)
+  if (plan.id === currentPlanId) return true;
   // No org selected
   if (!orgExtid) return true;
   // Free tier — no checkout
@@ -81,11 +81,12 @@ function wouldCompleteMigrationBail(
  */
 function isButtonDisabled(
   plan: BillingPlan,
-  currentTier: string,
+  currentPlanId: string | undefined,
   isCreatingCheckout: boolean,
   currentCurrency: string | null
 ): boolean {
-  const isPlanCurrent = plan.tier === currentTier;
+  // isPlanCurrent — STRICT id match, mirrors production (#3824)
+  const isPlanCurrent = plan.id === currentPlanId;
   return (
     isPlanCurrent ||
     isCreatingCheckout ||
@@ -165,7 +166,7 @@ describe('PlanSelector currency mismatch logic', () => {
       const eurPlan = createMockPlan({ currency: 'eur', tier: 'single_team' });
       const result = wouldHandlePlanSelectEarlyReturn(
         eurPlan,
-        'free', // current tier
+        'free_v1', // org's current plan id (not this plan)
         'on1abc123', // org extid
         'cad' // current subscription currency
       );
@@ -176,7 +177,7 @@ describe('PlanSelector currency mismatch logic', () => {
       const cadPlan = createMockPlan({ currency: 'cad', tier: 'single_team' });
       const result = wouldHandlePlanSelectEarlyReturn(
         cadPlan,
-        'free',
+        'free_v1',
         'on1abc123',
         'cad'
       );
@@ -187,7 +188,7 @@ describe('PlanSelector currency mismatch logic', () => {
       const eurPlan = createMockPlan({ currency: 'eur', tier: 'single_team' });
       const result = wouldHandlePlanSelectEarlyReturn(
         eurPlan,
-        'free',
+        'free_v1',
         'on1abc123',
         null
       );
@@ -198,7 +199,7 @@ describe('PlanSelector currency mismatch logic', () => {
       const plan = createMockPlan({ currency: 'cad', tier: 'single_team' });
       const result = wouldHandlePlanSelectEarlyReturn(
         plan,
-        'single_team', // same tier
+        'identity_plus_v1', // same plan id (this is the current plan)
         'on1abc123',
         'cad'
       );
@@ -206,10 +207,10 @@ describe('PlanSelector currency mismatch logic', () => {
     });
 
     it('early-returns for free tier plans regardless of currency', () => {
-      const freePlan = createMockPlan({ currency: 'cad', tier: 'free' });
+      const freePlan = createMockPlan({ currency: 'cad', tier: 'free', id: 'free_v1' });
       const result = wouldHandlePlanSelectEarlyReturn(
         freePlan,
-        'single_team',
+        'identity_plus_v1', // org on a paid plan; free card early-returns via free-tier check
         'on1abc123',
         'cad'
       );
@@ -254,32 +255,33 @@ describe('PlanSelector currency mismatch logic', () => {
   describe('plan card button disabled state', () => {
     it('disables button when plan currency mismatches subscription', () => {
       const eurPlan = createMockPlan({ currency: 'eur', tier: 'single_team' });
-      expect(isButtonDisabled(eurPlan, 'free', false, 'cad')).toBe(true);
+      expect(isButtonDisabled(eurPlan, 'free_v1', false, 'cad')).toBe(true);
     });
 
     it('enables button when currencies match', () => {
       const cadPlan = createMockPlan({ currency: 'cad', tier: 'single_team' });
-      expect(isButtonDisabled(cadPlan, 'free', false, 'cad')).toBe(false);
+      expect(isButtonDisabled(cadPlan, 'free_v1', false, 'cad')).toBe(false);
     });
 
     it('enables button when no current currency (new subscriber)', () => {
       const eurPlan = createMockPlan({ currency: 'eur', tier: 'single_team' });
-      expect(isButtonDisabled(eurPlan, 'free', false, null)).toBe(false);
+      expect(isButtonDisabled(eurPlan, 'free_v1', false, null)).toBe(false);
     });
 
     it('disables button for current plan even when currencies match', () => {
       const cadPlan = createMockPlan({ currency: 'cad', tier: 'single_team' });
-      expect(isButtonDisabled(cadPlan, 'single_team', false, 'cad')).toBe(true);
+      // Strict id match: org's planid equals this plan's id (#3824)
+      expect(isButtonDisabled(cadPlan, 'identity_plus_v1', false, 'cad')).toBe(true);
     });
 
     it('disables button during checkout creation', () => {
       const cadPlan = createMockPlan({ currency: 'cad', tier: 'single_team' });
-      expect(isButtonDisabled(cadPlan, 'free', true, 'cad')).toBe(true);
+      expect(isButtonDisabled(cadPlan, 'free_v1', true, 'cad')).toBe(true);
     });
 
     it('disables button for free tier plans', () => {
-      const freePlan = createMockPlan({ currency: 'cad', tier: 'free' });
-      expect(isButtonDisabled(freePlan, 'free', false, null)).toBe(true);
+      const freePlan = createMockPlan({ currency: 'cad', tier: 'free', id: 'free_v1' });
+      expect(isButtonDisabled(freePlan, 'identity_plus_v1', false, null)).toBe(true);
     });
   });
 
@@ -287,13 +289,13 @@ describe('PlanSelector currency mismatch logic', () => {
     it('USD subscriber sees EUR plans as disabled', () => {
       const eurPlan = createMockPlan({ currency: 'eur', region: 'EU' });
       expect(isPlanCurrencyMismatch('cad', eurPlan)).toBe(true);
-      expect(isButtonDisabled(eurPlan, 'free', false, 'cad')).toBe(true);
+      expect(isButtonDisabled(eurPlan, 'free_v1', false, 'cad')).toBe(true);
     });
 
     it('EUR subscriber sees USD plans as disabled', () => {
       const cadPlan = createMockPlan({ currency: 'cad', region: 'US' });
       expect(isPlanCurrencyMismatch('eur', cadPlan)).toBe(true);
-      expect(isButtonDisabled(cadPlan, 'free', false, 'eur')).toBe(true);
+      expect(isButtonDisabled(cadPlan, 'free_v1', false, 'eur')).toBe(true);
     });
 
     it('new subscriber (no currency) sees all plans as enabled', () => {

--- a/src/tests/apps/workspace/billing/PlanSelector.spec.ts
+++ b/src/tests/apps/workspace/billing/PlanSelector.spec.ts
@@ -14,50 +14,16 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import type { Plan as BillingPlan } from '@/services/billing.service';
-
-// Type for the tier hierarchy - matches PlanSelector.vue logic
-// #3824: single_account is a distinct tier below single_team (identity_plus_v1).
-type PlanTier = 'free' | 'single_account' | 'single_team' | 'multi_team';
-
-// Canonical tier order for upgrade/downgrade comparison (#3824)
-// free < single_account < single_team < multi_team
-const TIER_ORDER: PlanTier[] = ['free', 'single_account', 'single_team', 'multi_team'];
-
-/**
- * Helper: Get tier index for comparison
- * Used to determine upgrade/downgrade eligibility
- */
-function getTierIndex(tier: string): number {
-  const index = TIER_ORDER.indexOf(tier as PlanTier);
-  return index >= 0 ? index : -1;
-}
-
-/**
- * Logic extracted from PlanSelector.vue: canUpgrade
- *
- * Determines if user can upgrade from current tier to target plan.
- * Uses canonical rank ordering (#3824). Unresolved tiers (rank -1) yield no
- * direction, matching the component (currentPlan null => no upgrade/downgrade).
- */
-function canUpgrade(currentTier: string, targetPlan: BillingPlan): boolean {
-  const c = getTierIndex(currentTier);
-  const t = getTierIndex(targetPlan.tier);
-  if (c === -1 || t === -1) return false;
-  return t > c;
-}
-
-/**
- * Logic extracted from PlanSelector.vue: canDowngrade
- *
- * Determines if user can downgrade from current tier to target plan.
- * Uses canonical rank ordering (#3824).
- */
-function canDowngrade(currentTier: string, targetPlan: BillingPlan): boolean {
-  const c = getTierIndex(currentTier);
-  const t = getTierIndex(targetPlan.tier);
-  if (c === -1 || t === -1) return false;
-  return t < c;
-}
+// Drift-prone predicates come from the ONE shared module PlanSelector.vue
+// delegates to (#3824). tierRank is imported under its historical spec name
+// getTierIndex so the existing call sites read unchanged.
+import {
+  tierRank as getTierIndex,
+  canUpgrade,
+  canDowngrade,
+  isPlanRecommended,
+  isPlanCurrent,
+} from '@/apps/workspace/billing/planSelectorLogic';
 
 /**
  * Logic extracted from PlanSelector.vue: getBasePlan
@@ -83,18 +49,6 @@ function getNewFeatures(plan: BillingPlan, allPlans: BillingPlan[]): string[] {
 
   // Filter out features that exist in base plan
   return plan.entitlements.filter(ent => !basePlan.entitlements.includes(ent));
-}
-
-/**
- * Logic extracted from PlanSelector.vue: isPlanRecommended
- *
- * Determines if plan should show "Most Popular" badge.
- * #3824: is_popular (API-provided) is the SOLE authority. The old
- * tier === 'single_team' fallback was removed so "Most Popular" is never
- * defaulted onto a card.
- */
-function isPlanRecommended(plan: BillingPlan & { is_popular?: boolean }): boolean {
-  return plan.is_popular ?? false;
 }
 
 /**
@@ -244,11 +198,8 @@ describe('PlanSelector Logic', () => {
      *     triggers the original mis-badge — a drift guard on the fixture itself.
      */
 
-    // NEW (shipped) logic under guard.
-    const isPlanCurrent = (
-      plan: BillingPlan,
-      planid: string | null | undefined
-    ): boolean => plan.id === planid;
+    // NEW (shipped) logic under guard = the shared module's isPlanCurrent
+    // (imported at top of file), NOT a local re-implementation.
 
     // OLD (buggy) pre-#3824 logic, reproduced verbatim: resolve the org's tier
     // from the plans list, else hardcode legacy 'identity' -> single_team, else
@@ -720,13 +671,9 @@ describe('PlanSelector Logic', () => {
           tier: 'free',
         });
 
-        // #3824: isPlanCurrent is STRICT id match (plan.id === org.planid), not
-        // tier equality. A real free customer has planid === the free plan id.
-        const isPlanCurrent = (
-          plan: BillingPlan,
-          planid: string | null | undefined
-        ): boolean => plan.id === planid;
-
+        // #3824: isPlanCurrent (shared module, imported at top) is STRICT id
+        // match (plan.id === org.planid), not tier equality. A real free
+        // customer has planid === the free plan id.
         expect(isPlanCurrent(freePlan, 'free_v1')).toBe(true);
         // A tier string is NOT a plan id, so it must not badge the card.
         expect(isPlanCurrent(freePlan, 'free')).toBe(false);

--- a/src/tests/apps/workspace/billing/PlanSelector.spec.ts
+++ b/src/tests/apps/workspace/billing/PlanSelector.spec.ts
@@ -23,6 +23,12 @@ import {
   canDowngrade,
   isPlanRecommended,
   isPlanCurrent,
+  isPlanButtonDisabled,
+  resolvePlanSelectAction,
+  shouldShowCancelLink,
+  type PlanButtonState,
+  type PlanSelectContext,
+  type CancelLinkState,
 } from '@/apps/workspace/billing/planSelectorLogic';
 
 /**
@@ -713,32 +719,64 @@ describe('PlanSelector Logic', () => {
     });
 
     describe('free plan CTA link', () => {
-      it('free plan action is disabled in PlanSelector (no checkout for free)', () => {
-        // PlanSelector disables the button for free plans
-        // PlanSelector.vue disables button when isPlanCurrent || isCreatingCheckout || free
+      // Default PlanButtonState for a fresh, non-subscribing visitor. Overrides
+      // flip individual dimensions. The disable logic itself is imported from
+      // planSelectorLogic (isPlanButtonDisabled), so it can't drift.
+      const buttonState = (
+        overrides: Partial<PlanButtonState> = {}
+      ): PlanButtonState => ({
+        orgPlanId: 'single_team_v1',
+        currentCurrency: null,
+        isCreatingCheckout: false,
+        isReactivating: false,
+        isCancelScheduled: false,
+        hasActiveSubscription: false,
+        ...overrides,
+      });
+
+      it('free plan action is disabled for a visitor without a subscription', () => {
         const freePlan = createMockPlan({
           id: 'free',
           tier: 'free',
         });
 
-        // Simulate the disable condition from PlanSelector
-        const isButtonDisabled = (
-          plan: BillingPlan, isPlanCurrent: boolean, isCreatingCheckout: boolean
-        ): boolean => isPlanCurrent || isCreatingCheckout || plan.id === 'free';
-
-        expect(isButtonDisabled(freePlan, false, false)).toBe(true);
+        expect(
+          isPlanButtonDisabled(freePlan, buttonState({ hasActiveSubscription: false }))
+        ).toBe(true);
       });
 
-      it('free plan does not trigger checkout flow', () => {
-        // PlanSelector.vue skips checkout for free tier
+      it('free plan action is enabled for an active subscriber (to downgrade)', () => {
+        // #3824: free is disabled ONLY when there is no active subscription. An
+        // active subscriber can click free to cancel/downgrade.
+        const freePlan = createMockPlan({
+          id: 'free',
+          tier: 'free',
+        });
+
+        expect(
+          isPlanButtonDisabled(freePlan, buttonState({ hasActiveSubscription: true }))
+        ).toBe(false);
+      });
+
+      it('free plan never resolves to a checkout action', () => {
+        // handlePlanSelect routes free away from Stripe Checkout: it is a no-op
+        // for a non-subscriber and opens the cancel modal for a subscriber.
         const freePlan = createMockPlan({
           id: 'free_v1',
           tier: 'free',
         });
+        const ctx: PlanSelectContext = {
+          orgExtid: 'org-abc',
+          orgPlanId: 'single_team_v1',
+          currentCurrency: null,
+          isCancelScheduled: false,
+          hasActiveSubscription: false,
+        };
 
-        // handlePlanSelect early returns for free tier
-        const shouldSkipCheckout = (plan: BillingPlan): boolean => plan.tier === 'free';
-        expect(shouldSkipCheckout(freePlan)).toBe(true);
+        expect(resolvePlanSelectAction(freePlan, ctx)).toBe('noop');
+        expect(
+          resolvePlanSelectAction(freePlan, { ...ctx, hasActiveSubscription: true })
+        ).toBe('open-cancel-modal');
       });
     });
 
@@ -836,41 +874,54 @@ describe('PlanSelector Logic', () => {
     });
 
     describe('cancel subscription link visibility', () => {
-      /**
-       * Logic extracted from PlanSelector.vue:
-       * Cancel link is shown when:
-       * 1. hasActiveSubscription is true
-       * 2. currentTier is not 'free'
-       *
-       * Template: v-if="hasActiveSubscription && currentTier !== 'free'"
-       */
-      function shouldShowCancelLink(
-        hasActiveSubscription: boolean,
-        currentTier: string
-      ): boolean {
-        return hasActiveSubscription && currentTier !== 'free';
-      }
+      // Production template guard (PlanSelector.vue), imported so the test can't
+      // drift from it:
+      //   (hasActiveSubscription || isLegacyCustomer) && currentTier !== 'free' && !isCancelScheduled
+      const cancelLinkState = (
+        overrides: Partial<CancelLinkState> = {}
+      ): CancelLinkState => ({
+        hasActiveSubscription: false,
+        isLegacyCustomer: false,
+        currentTier: 'single_team',
+        isCancelScheduled: false,
+        ...overrides,
+      });
 
       it('shows cancel link for active paid subscriber on single_team tier', () => {
-        expect(shouldShowCancelLink(true, 'single_team')).toBe(true);
+        expect(
+          shouldShowCancelLink(cancelLinkState({ hasActiveSubscription: true, currentTier: 'single_team' }))
+        ).toBe(true);
       });
 
       it('shows cancel link for active paid subscriber on multi_team tier', () => {
-        expect(shouldShowCancelLink(true, 'multi_team')).toBe(true);
+        expect(
+          shouldShowCancelLink(cancelLinkState({ hasActiveSubscription: true, currentTier: 'multi_team' }))
+        ).toBe(true);
+      });
+
+      it('shows cancel link for a legacy customer without an active subscription', () => {
+        // Grandfathered customers can still cancel even without an active sub.
+        expect(
+          shouldShowCancelLink(cancelLinkState({ isLegacyCustomer: true, hasActiveSubscription: false }))
+        ).toBe(true);
       });
 
       it('hides cancel link for free tier users', () => {
-        expect(shouldShowCancelLink(true, 'free')).toBe(false);
+        expect(
+          shouldShowCancelLink(cancelLinkState({ hasActiveSubscription: true, currentTier: 'free' }))
+        ).toBe(false);
       });
 
-      it('hides cancel link when no active subscription', () => {
-        expect(shouldShowCancelLink(false, 'single_team')).toBe(false);
-        expect(shouldShowCancelLink(false, 'multi_team')).toBe(false);
+      it('hides cancel link when neither subscribed nor legacy', () => {
+        expect(shouldShowCancelLink(cancelLinkState({ currentTier: 'single_team' }))).toBe(false);
+        expect(shouldShowCancelLink(cancelLinkState({ currentTier: 'multi_team' }))).toBe(false);
       });
 
-      it('hides cancel link for free tier even with subscription flag', () => {
-        // Edge case: subscription data might be stale
-        expect(shouldShowCancelLink(true, 'free')).toBe(false);
+      it('hides cancel link once a cancellation is already scheduled', () => {
+        // The reactivate banner covers this state instead.
+        expect(
+          shouldShowCancelLink(cancelLinkState({ hasActiveSubscription: true, isCancelScheduled: true }))
+        ).toBe(false);
       });
     });
 

--- a/src/tests/apps/workspace/billing/PlanSelector.spec.ts
+++ b/src/tests/apps/workspace/billing/PlanSelector.spec.ts
@@ -16,10 +16,12 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import type { Plan as BillingPlan } from '@/services/billing.service';
 
 // Type for the tier hierarchy - matches PlanSelector.vue logic
-type PlanTier = 'free' | 'single_team' | 'multi_team';
+// #3824: single_account is a distinct tier below single_team (identity_plus_v1).
+type PlanTier = 'free' | 'single_account' | 'single_team' | 'multi_team';
 
-// Tier order for upgrade/downgrade comparison
-const TIER_ORDER: PlanTier[] = ['free', 'single_team', 'multi_team'];
+// Canonical tier order for upgrade/downgrade comparison (#3824)
+// free < single_account < single_team < multi_team
+const TIER_ORDER: PlanTier[] = ['free', 'single_account', 'single_team', 'multi_team'];
 
 /**
  * Helper: Get tier index for comparison
@@ -34,24 +36,27 @@ function getTierIndex(tier: string): number {
  * Logic extracted from PlanSelector.vue: canUpgrade
  *
  * Determines if user can upgrade from current tier to target plan.
- * FIXED: Uses tier comparison instead of planid.
+ * Uses canonical rank ordering (#3824). Unresolved tiers (rank -1) yield no
+ * direction, matching the component (currentPlan null => no upgrade/downgrade).
  */
 function canUpgrade(currentTier: string, targetPlan: BillingPlan): boolean {
-  if (currentTier === 'free') return targetPlan.tier !== 'free';
-  if (currentTier === 'single_team') return targetPlan.tier === 'multi_team';
-  return false;
+  const c = getTierIndex(currentTier);
+  const t = getTierIndex(targetPlan.tier);
+  if (c === -1 || t === -1) return false;
+  return t > c;
 }
 
 /**
  * Logic extracted from PlanSelector.vue: canDowngrade
  *
  * Determines if user can downgrade from current tier to target plan.
- * FIXED: Uses tier comparison instead of planid.
+ * Uses canonical rank ordering (#3824).
  */
 function canDowngrade(currentTier: string, targetPlan: BillingPlan): boolean {
-  if (currentTier === 'multi_team') return targetPlan.tier !== 'multi_team';
-  if (currentTier === 'single_team') return targetPlan.tier === 'free';
-  return false;
+  const c = getTierIndex(currentTier);
+  const t = getTierIndex(targetPlan.tier);
+  if (c === -1 || t === -1) return false;
+  return t < c;
 }
 
 /**
@@ -84,16 +89,12 @@ function getNewFeatures(plan: BillingPlan, allPlans: BillingPlan[]): string[] {
  * Logic extracted from PlanSelector.vue: isPlanRecommended
  *
  * Determines if plan should show "Most Popular" badge.
- * ISSUE: Currently hardcoded to tier === 'single_team'
- * FIX: Should use is_popular flag from API when available.
+ * #3824: is_popular (API-provided) is the SOLE authority. The old
+ * tier === 'single_team' fallback was removed so "Most Popular" is never
+ * defaulted onto a card.
  */
 function isPlanRecommended(plan: BillingPlan & { is_popular?: boolean }): boolean {
-  // Fixed implementation uses API flag when available
-  if (plan.is_popular !== undefined) {
-    return plan.is_popular;
-  }
-  // Fallback to tier-based logic (legacy behavior)
-  return plan.tier === 'single_team';
+  return plan.is_popular ?? false;
 }
 
 /**
@@ -219,6 +220,151 @@ describe('PlanSelector Logic', () => {
     it('returns false when multi_team targets multi_team', () => {
       const targetPlan = createMockPlan({ tier: 'multi_team' });
       expect(canDowngrade('multi_team', targetPlan)).toBe(false);
+    });
+  });
+
+  // ============================================================
+  // isPlanCurrent — STRICT id match (#3824)
+  // ============================================================
+  describe('isPlanCurrent (strict id match, #3824)', () => {
+    /**
+     * Regression coverage for the "Current" badge landing on the wrong card.
+     *
+     * Root cause: the old component derived a tier for the org and badged every
+     * card whose tier matched. A legacy 'identity' org resolved (via a hardcode)
+     * to tier `single_team`, and because `team_plus_v1` is ALSO `single_team`,
+     * the badge landed on the Team Plus card. The fix compares
+     * `plan.id === org.planid` — no tier, no fallback.
+     *
+     * These tests pin BOTH logics against the backend-correct fixture so the
+     * scenario provably reproduces the bug:
+     *   - NEW (shipped): strict id match. This is the contract under guard.
+     *   - OLD (buggy): tier match with the `identity -> single_team` hardcode
+     *     and a silent `free` fallback. Asserted only to prove the fixture still
+     *     triggers the original mis-badge — a drift guard on the fixture itself.
+     */
+
+    // NEW (shipped) logic under guard.
+    const isPlanCurrent = (
+      plan: BillingPlan,
+      planid: string | null | undefined
+    ): boolean => plan.id === planid;
+
+    // OLD (buggy) pre-#3824 logic, reproduced verbatim: resolve the org's tier
+    // from the plans list, else hardcode legacy 'identity' -> single_team, else
+    // fall back to 'free'; then badge by tier equality.
+    const oldResolveTier = (
+      plans: BillingPlan[],
+      planid: string | null | undefined
+    ): string =>
+      plans.find((p) => p.id === planid)?.tier ??
+      (planid === 'identity' ? 'single_team' : 'free');
+    const isPlanCurrentOld = (
+      plan: BillingPlan,
+      plans: BillingPlan[],
+      planid: string | null | undefined
+    ): boolean => plan.tier === oldResolveTier(plans, planid);
+
+    // Backend-correct plan grid (#3824), matching apps/web/billing/docs/
+    // plan-definitions.md and etc/examples/billing.example.yaml:
+    //   identity_plus_v1 = single_account, team_plus_v1 = single_team.
+    const buildPlans = (): BillingPlan[] => [
+      createMockPlan({ id: 'free_v1', tier: 'free' }),
+      createMockPlan({ id: 'identity_plus_v1', tier: 'single_account' }),
+      createMockPlan({ id: 'team_plus_v1', tier: 'single_team' }),
+    ];
+
+    it('(a) legacy "identity" org badges NO card — old tier logic wrongly badged Team Plus', () => {
+      const plans = buildPlans();
+
+      // NEW (shipped): strict id match → nothing is badged.
+      const badged = plans.filter((p) => isPlanCurrent(p, 'identity'));
+      expect(badged).toHaveLength(0);
+      expect(isPlanCurrent(plans[0], 'identity')).toBe(false); // Free
+      expect(isPlanCurrent(plans[1], 'identity')).toBe(false); // Identity Plus
+      expect(isPlanCurrent(plans[2], 'identity')).toBe(false); // Team Plus
+
+      // OLD (buggy): 'identity' -> single_team hardcode collides with
+      // team_plus_v1 (single_team) → Team Plus is mis-badged. This is the exact
+      // #3824 regression; asserting it proves the fixture reproduces the bug
+      // (if team_plus_v1 drifts back to multi_team, this assertion breaks).
+      const oldBadged = plans.filter((p) => isPlanCurrentOld(p, plans, 'identity'));
+      expect(oldBadged.map((p) => p.id)).toEqual(['team_plus_v1']);
+    });
+
+    it('(b) identity_plus_v1 subscriber badges ONLY the Identity Plus card', () => {
+      const plans = buildPlans();
+
+      // NEW (shipped): strict id match → only its own card.
+      const badged = plans.filter((p) => isPlanCurrent(p, 'identity_plus_v1'));
+      expect(badged).toHaveLength(1);
+      expect(badged[0].id).toBe('identity_plus_v1');
+      // Team Plus (single_team) must NOT be badged.
+      expect(isPlanCurrent(plans[2], 'identity_plus_v1')).toBe(false);
+
+      // single_account is a unique tier in the grid (no collision), so the old
+      // tier logic happens to agree here for this in-grid planid. Documents why
+      // this positive case is safe under both logics.
+      const oldBadged = plans.filter((p) =>
+        isPlanCurrentOld(p, plans, 'identity_plus_v1')
+      );
+      expect(oldBadged.map((p) => p.id)).toEqual(['identity_plus_v1']);
+    });
+
+    it('(c) a non-matching, non-legacy planid badges NO card — old logic wrongly badged Free', () => {
+      // The diagnostic path: planid absent from the plans list.
+      const plans = buildPlans();
+
+      // NEW (shipped): strict id match → nothing is badged.
+      const badged = plans.filter((p) => isPlanCurrent(p, 'some_unknown_v9'));
+      expect(badged).toHaveLength(0);
+      expect(isPlanCurrent(plans[0], 'some_unknown_v9')).toBe(false); // Free
+
+      // OLD (buggy): unknown planid → silent 'free' fallback collides with
+      // free_v1 → Free is mis-badged. Asserting it pins both the fixture and
+      // the fallback that #3824 removed.
+      const oldBadged = plans.filter((p) =>
+        isPlanCurrentOld(p, plans, 'some_unknown_v9')
+      );
+      expect(oldBadged.map((p) => p.id)).toEqual(['free_v1']);
+    });
+
+    it('genuine free subscriber (planid free_v1) badges only the free card', () => {
+      const plans = buildPlans();
+      const badged = plans.filter((p) => isPlanCurrent(p, 'free_v1'));
+      expect(badged).toHaveLength(1);
+      expect(badged[0].id).toBe('free_v1');
+    });
+  });
+
+  // ============================================================
+  // single_account tier ordering (#3824)
+  // ============================================================
+  describe('single_account tier ordering (#3824)', () => {
+    it('ranks free < single_account < single_team < multi_team', () => {
+      expect(getTierIndex('free')).toBeLessThan(getTierIndex('single_account'));
+      expect(getTierIndex('single_account')).toBeLessThan(getTierIndex('single_team'));
+      expect(getTierIndex('single_team')).toBeLessThan(getTierIndex('multi_team'));
+    });
+
+    it('single_account can upgrade to single_team and multi_team', () => {
+      expect(canUpgrade('single_account', createMockPlan({ tier: 'single_team' }))).toBe(true);
+      expect(canUpgrade('single_account', createMockPlan({ tier: 'multi_team' }))).toBe(true);
+    });
+
+    it('single_account can downgrade to free but not to single_team', () => {
+      expect(canDowngrade('single_account', createMockPlan({ tier: 'free' }))).toBe(true);
+      expect(canDowngrade('single_account', createMockPlan({ tier: 'single_team' }))).toBe(false);
+    });
+
+    it('free can upgrade to single_account', () => {
+      expect(canUpgrade('free', createMockPlan({ tier: 'single_account' }))).toBe(true);
+    });
+
+    it('unresolved tier yields no upgrade/downgrade direction (component: currentPlan null)', () => {
+      const target = createMockPlan({ tier: 'single_team' });
+      expect(canUpgrade('', target)).toBe(false);
+      expect(canDowngrade('', target)).toBe(false);
     });
   });
 
@@ -357,15 +503,19 @@ describe('PlanSelector Logic', () => {
       expect(isPlanRecommended(plan)).toBe(false);
     });
 
-    it('falls back to tier-based logic when is_popular not set', () => {
+    it('returns false when is_popular is not set (#3824: no tier fallback)', () => {
+      // No card is defaulted to "Most Popular" without an explicit API flag.
       const singleTeamPlan = createMockPlan({ tier: 'single_team' });
-      expect(isPlanRecommended(singleTeamPlan)).toBe(true);
+      expect(isPlanRecommended(singleTeamPlan)).toBe(false);
+
+      const singleAccountPlan = createMockPlan({ tier: 'single_account' });
+      expect(isPlanRecommended(singleAccountPlan)).toBe(false);
 
       const multiTeamPlan = createMockPlan({ tier: 'multi_team' });
       expect(isPlanRecommended(multiTeamPlan)).toBe(false);
     });
 
-    it('falls back to false for non-single_team tiers without API flag', () => {
+    it('returns false for any tier without the API flag', () => {
       const freePlan = createMockPlan({ tier: 'free' });
       expect(isPlanRecommended(freePlan)).toBe(false);
     });
@@ -564,18 +714,22 @@ describe('PlanSelector Logic', () => {
     });
 
     describe('free plan button state for current free users', () => {
-      it('free plan button is disabled when user is on free tier', () => {
+      it('free plan card is marked current for a genuine free subscriber (#3824 id match)', () => {
         const freePlan = createMockPlan({
           id: 'free_v1',
           tier: 'free',
         });
 
-        // User is on free tier (currentTier = 'free')
-        // isPlanCurrent should return true
-        const isPlanCurrent = (plan: BillingPlan, currentTier: string): boolean =>
-          plan.tier === currentTier;
+        // #3824: isPlanCurrent is STRICT id match (plan.id === org.planid), not
+        // tier equality. A real free customer has planid === the free plan id.
+        const isPlanCurrent = (
+          plan: BillingPlan,
+          planid: string | null | undefined
+        ): boolean => plan.id === planid;
 
-        expect(isPlanCurrent(freePlan, 'free')).toBe(true);
+        expect(isPlanCurrent(freePlan, 'free_v1')).toBe(true);
+        // A tier string is NOT a plan id, so it must not badge the card.
+        expect(isPlanCurrent(freePlan, 'free')).toBe(false);
       });
 
       it('free plan cannot be upgraded to when already on free', () => {
@@ -649,7 +803,7 @@ describe('PlanSelector Logic', () => {
           is_popular: undefined, // Not explicitly set
         });
 
-        // isPlanRecommended falls back to tier === 'single_team' when is_popular undefined
+        // #3824: is_popular is the sole authority; undefined => false (no fallback)
         expect(isPlanRecommended(freePlan)).toBe(false);
       });
 

--- a/src/tests/fixtures/billing.fixture.ts
+++ b/src/tests/fixtures/billing.fixture.ts
@@ -18,9 +18,10 @@ import {
 } from '@/tests/schemas/shapes/fixtures/organization.fixtures';
 
 /**
- * Plan tier type for billing fixtures
+ * Plan tier type for billing fixtures.
+ * Canonical order: free < single_account < single_team < multi_team.
  */
-export type PlanTier = 'free' | 'single_team' | 'multi_team';
+export type PlanTier = 'free' | 'single_account' | 'single_team' | 'multi_team';
 
 /**
  * Factory function to create mock billing plans
@@ -62,13 +63,13 @@ export const mockPlans: Record<string, Plan> = {
   /**
    * Legacy "identity" plan - grandfathered Early Supporter plan.
    * This plan is NOT available for new subscriptions but is honored for existing customers.
-   * Maps to single_team tier for feature parity with Identity Plus.
+   * Maps to single_account tier (same as identity_plus_v1 backend reality).
    */
   legacy_identity: createMockPlan({
     id: 'identity',
     stripe_price_id: null, // Legacy plans may not have Stripe price IDs
     name: 'Identity Plus (Early Supporter)',
-    tier: 'single_team', // Same tier as identity_plus for feature parity
+    tier: 'single_account', // Same tier as identity_plus_v1 (backend: single_account)
     interval: 'month', // Assumed monthly billing
     amount: 1900, // Original early supporter price
     display_order: -1, // Not shown in plan selector (legacy)
@@ -81,7 +82,8 @@ export const mockPlans: Record<string, Plan> = {
     id: 'identity_plus_v1',
     stripe_price_id: 'price_single_monthly',
     name: 'Identity Plus',
-    tier: 'single_team',
+    // Backend reality: identity_plus_v1 is single_account, not single_team (#3824).
+    tier: 'single_account',
     interval: 'month',
     amount: 2900,
     display_order: 10,
@@ -95,7 +97,9 @@ export const mockPlans: Record<string, Plan> = {
     id: 'team_plus_v1',
     stripe_price_id: 'price_multi_monthly',
     name: 'Team Plus',
-    tier: 'multi_team',
+    // Backend reality: team_plus_v1 is single_team, not multi_team (#3824).
+    // Object key kept as `multi_team` to avoid breaking imports.
+    tier: 'single_team',
     interval: 'month',
     amount: 9900,
     display_order: 20,
@@ -278,7 +282,7 @@ export const mockOrganizations = {
   multiTeam: createWireMultiTeamOrganization(),
   /**
    * Legacy "identity" plan - grandfathered Early Supporter plan
-   * These customers have single_team tier features but their planid is just 'identity'
+   * These customers have single_account tier features but their planid is just 'identity'
    * (not 'identity_plus_v1'). Display should show "Identity Plus (Early Supporter)".
    */
   legacyIdentity: createWireLegacyIdentityOrganization(),
@@ -381,7 +385,8 @@ export function createMockOverviewResponse(
     plan: {
       id: 'identity_plus_v1',
       name: 'Identity Plus',
-      tier: 'single_team',
+      // Backend reality: identity_plus_v1 is single_account, not single_team (#3824).
+      tier: 'single_account',
       interval: 'month',
       amount: 2900,
       currency: 'cad',
@@ -420,7 +425,8 @@ export const mockOverviewResponses = {
     plan: {
       id: 'identity',
       name: 'Identity Plus (Early Supporter)',
-      tier: 'single_team',
+      // Legacy identity maps to single_account, same as identity_plus_v1 (#3824).
+      tier: 'single_account',
       interval: 'month',
       amount: 1900,
       currency: 'cad',

--- a/src/tests/fixtures/billing.fixture.ts
+++ b/src/tests/fixtures/billing.fixture.ts
@@ -83,6 +83,7 @@ export const mockPlans: Record<string, Plan> = {
     stripe_price_id: 'price_single_monthly',
     name: 'Identity Plus',
     // Backend reality: identity_plus_v1 is single_account, not single_team (#3824).
+    // Object key kept as `single_team` to avoid breaking imports.
     tier: 'single_account',
     interval: 'month',
     amount: 2900,

--- a/src/tests/schemas/shapes/fixtures/organization.fixtures.ts
+++ b/src/tests/schemas/shapes/fixtures/organization.fixtures.ts
@@ -246,7 +246,9 @@ export function createWireFreeOrganization(
 }
 
 /**
- * Creates wire format for single team tier (Identity Plus).
+ * Creates wire format for the Identity Plus org (planid identity_plus_v1).
+ * Backend tier for this plan is single_account (#3824). The factory name is
+ * retained for backwards compatibility with existing test imports.
  */
 export function createWireSingleTeamOrganization(
   overrides?: Partial<OrganizationWire>
@@ -300,7 +302,8 @@ export function createWireMultiTeamOrganization(
 
 /**
  * Creates wire format for legacy identity plan (Early Supporter).
- * These customers have single_team tier features but planid is 'identity'.
+ * These customers have single_account tier features but planid is 'identity'
+ * (grandfathered; not present in the active plans list) (#3824).
  */
 export function createWireLegacyIdentityOrganization(
   overrides?: Partial<OrganizationWire>

--- a/src/tests/services/billing.service.spec.ts
+++ b/src/tests/services/billing.service.spec.ts
@@ -378,7 +378,7 @@ describe('BillingService', () => {
         data: {
           plans: [
             { id: 'free_v1', name: 'Free', tier: 'free' },
-            { id: 'identity_plus_v1', name: 'Identity Plus', tier: 'single_team' },
+            { id: 'identity_plus_v1', name: 'Identity Plus', tier: 'single_account' },
           ],
         },
       };

--- a/src/tests/types/billing-legacy.spec.ts
+++ b/src/tests/types/billing-legacy.spec.ts
@@ -217,12 +217,13 @@ describe('PlanSelector currentTier Logic', () => {
 
   // Mock plan data for testing
   // Plan IDs are now family-keyed without interval suffix.
-  // Backend reality (#3824): identity_plus_v1 is single_account, not single_team.
+  // Backend reality (#3824): identity_plus_v1 is single_account (not single_team)
+  // and team_plus_v1 is single_team (not multi_team). Mirrors billing.fixture.ts.
   type MockPlan = { id: string; tier: string };
   const mockPlans: MockPlan[] = [
     { id: 'free_v1', tier: 'free' },
     { id: 'identity_plus_v1', tier: 'single_account' },
-    { id: 'team_plus_v1', tier: 'multi_team' },
+    { id: 'team_plus_v1', tier: 'single_team' },
   ];
 
   /**
@@ -239,9 +240,11 @@ describe('PlanSelector currentTier Logic', () => {
     // Legacy "identity" shares identity_plus_v1's family tier: single_account.
     if (planid === 'identity') return 'single_account';
 
-    // Fallback: infer tier from planid naming convention
-    if (planid.includes('multi_team') || planid.includes('team_plus')) return 'multi_team';
-    if (planid.includes('single_team')) return 'single_team';
+    // Fallback: infer tier from planid naming convention.
+    // #3824: team_plus_* is single_team, not multi_team. Match multi_team first
+    // so a literal multi_team_* id still resolves to the top tier.
+    if (planid.includes('multi_team')) return 'multi_team';
+    if (planid.includes('team_plus') || planid.includes('single_team')) return 'single_team';
     if (planid.includes('single_account') || planid.includes('identity_plus')) return 'single_account';
 
     return 'free';
@@ -262,9 +265,10 @@ describe('PlanSelector currentTier Logic', () => {
 
     it('returns correct tier for plans in the list', () => {
       expect(getCurrentTier('free_v1', mockPlans)).toBe('free');
-      // #3824: identity_plus_v1 is single_account in the backend, not single_team.
+      // #3824: identity_plus_v1 is single_account and team_plus_v1 is single_team
+      // in the backend (not single_team / multi_team respectively).
       expect(getCurrentTier('identity_plus_v1', mockPlans)).toBe('single_account');
-      expect(getCurrentTier('team_plus_v1', mockPlans)).toBe('multi_team');
+      expect(getCurrentTier('team_plus_v1', mockPlans)).toBe('single_team');
     });
 
     it('returns "single_account" for legacy "identity" planid', () => {
@@ -275,7 +279,9 @@ describe('PlanSelector currentTier Logic', () => {
     it('infers tier from naming convention for unknown plans', () => {
       // Plans not in list but follow naming convention
       expect(getCurrentTier('identity_plus_v2', mockPlans)).toBe('single_account');
-      expect(getCurrentTier('team_plus_v2', mockPlans)).toBe('multi_team');
+      // #3824: team_plus_* infers to single_team; only a literal multi_team_* id
+      // resolves to the top multi_team tier.
+      expect(getCurrentTier('team_plus_v2', mockPlans)).toBe('single_team');
       expect(getCurrentTier('multi_team_v1', mockPlans)).toBe('multi_team');
       expect(getCurrentTier('single_team_v1', mockPlans)).toBe('single_team');
     });

--- a/src/tests/types/billing-legacy.spec.ts
+++ b/src/tests/types/billing-legacy.spec.ts
@@ -88,7 +88,7 @@ describe('Legacy Plan Utilities', () => {
         expect(info).toEqual({
           isLegacy: true,
           displayName: 'Identity Plus (Early Supporter)',
-          tier: 'single_team',
+          tier: 'single_account',
         });
       });
 
@@ -97,9 +97,9 @@ describe('Legacy Plan Utilities', () => {
         expect(info?.isLegacy).toBe(true);
       });
 
-      it('maps to single_team tier for feature parity', () => {
+      it('maps to single_account tier for feature parity (#3824 backend reality)', () => {
         const info = getLegacyPlanInfo('identity');
-        expect(info?.tier).toBe('single_team');
+        expect(info?.tier).toBe('single_account');
       });
 
       it('has correct display name with Early Supporter suffix', () => {
@@ -178,27 +178,27 @@ describe('Legacy Plan Utilities', () => {
   // ============================================================
   describe('Legacy Plan Tier Mapping', () => {
     /**
-     * This tests the logic that PlanSelector.vue uses to map legacy planid
-     * to currentTier. The component has this logic:
-     *
-     * if (planid === 'identity') return 'single_team';
-     *
-     * We verify that getLegacyPlanInfo provides the correct tier.
+     * getLegacyPlanInfo is the source of truth for a grandfathered plan's
+     * family tier. Post-#3824 the legacy "identity" plan shares the same tier
+     * as identity_plus_v1 in the backend, which is single_account (NOT
+     * single_team). Note: PlanSelector.vue no longer hardcodes a legacy tier —
+     * its currentTier is derived strictly from an id-matched plan (null for
+     * unresolved/legacy). This block verifies the family tier metadata only.
      */
-    it('legacy "identity" plan maps to "single_team" tier', () => {
+    it('legacy "identity" plan maps to "single_account" tier', () => {
       const info = getLegacyPlanInfo('identity');
-      expect(info?.tier).toBe('single_team');
+      expect(info?.tier).toBe('single_account');
     });
 
     it('tier mapping enables correct upgrade/downgrade behavior', () => {
       const legacyInfo = getLegacyPlanInfo('identity');
       const legacyTier = legacyInfo?.tier ?? 'free';
 
-      // Legacy identity users (single_team tier) can:
-      // - Upgrade to multi_team
+      // Legacy identity users (single_account tier) can:
+      // - Upgrade to single_team or multi_team
       // - Downgrade to free
-      // - NOT upgrade to single_team (same tier)
-      expect(legacyTier).toBe('single_team');
+      // (single_account is a distinct, lower tier than single_team)
+      expect(legacyTier).toBe('single_account');
     });
   });
 });
@@ -208,21 +208,25 @@ describe('Legacy Plan Utilities', () => {
 // ============================================================
 describe('PlanSelector currentTier Logic', () => {
   /**
-   * Extracted logic from PlanSelector.vue currentTier computed property.
-   * This tests the tier resolution for various planid values including legacy plans.
+   * Family-tier resolution for a given planid. Post-#3824 the component's own
+   * currentTier is id-derived (null for unresolved/legacy), so this helper is a
+   * standalone resolver of the FAMILY tier a planid belongs to (used for
+   * display/feature-parity reasoning), consistent with getLegacyPlanInfo and
+   * the corrected backend tiers: identity_plus_v1 => single_account.
    */
 
   // Mock plan data for testing
-  // Plan IDs are now family-keyed without interval suffix
+  // Plan IDs are now family-keyed without interval suffix.
+  // Backend reality (#3824): identity_plus_v1 is single_account, not single_team.
   type MockPlan = { id: string; tier: string };
   const mockPlans: MockPlan[] = [
     { id: 'free_v1', tier: 'free' },
-    { id: 'identity_plus_v1', tier: 'single_team' },
+    { id: 'identity_plus_v1', tier: 'single_account' },
     { id: 'team_plus_v1', tier: 'multi_team' },
   ];
 
   /**
-   * Replicates PlanSelector.vue currentTier logic
+   * Resolves the family tier for a planid (see block doc).
    */
   function getCurrentTier(planid: string | null | undefined, plans: MockPlan[]): string {
     if (!planid) return 'free';
@@ -231,12 +235,14 @@ describe('PlanSelector currentTier Logic', () => {
     const matchingPlan = plans.find(p => p.id === planid);
     if (matchingPlan) return matchingPlan.tier;
 
-    // Handle legacy plans that aren't in the active plans list
-    if (planid === 'identity') return 'single_team';
+    // Handle legacy plans that aren't in the active plans list.
+    // Legacy "identity" shares identity_plus_v1's family tier: single_account.
+    if (planid === 'identity') return 'single_account';
 
     // Fallback: infer tier from planid naming convention
     if (planid.includes('multi_team') || planid.includes('team_plus')) return 'multi_team';
-    if (planid.includes('single_team') || planid.includes('identity_plus')) return 'single_team';
+    if (planid.includes('single_team')) return 'single_team';
+    if (planid.includes('single_account') || planid.includes('identity_plus')) return 'single_account';
 
     return 'free';
   }
@@ -256,18 +262,19 @@ describe('PlanSelector currentTier Logic', () => {
 
     it('returns correct tier for plans in the list', () => {
       expect(getCurrentTier('free_v1', mockPlans)).toBe('free');
-      expect(getCurrentTier('identity_plus_v1', mockPlans)).toBe('single_team');
+      // #3824: identity_plus_v1 is single_account in the backend, not single_team.
+      expect(getCurrentTier('identity_plus_v1', mockPlans)).toBe('single_account');
       expect(getCurrentTier('team_plus_v1', mockPlans)).toBe('multi_team');
     });
 
-    it('returns "single_team" for legacy "identity" planid', () => {
+    it('returns "single_account" for legacy "identity" planid', () => {
       // Legacy plan not in active plans list but has special handling
-      expect(getCurrentTier('identity', mockPlans)).toBe('single_team');
+      expect(getCurrentTier('identity', mockPlans)).toBe('single_account');
     });
 
     it('infers tier from naming convention for unknown plans', () => {
       // Plans not in list but follow naming convention
-      expect(getCurrentTier('identity_plus_v2', mockPlans)).toBe('single_team');
+      expect(getCurrentTier('identity_plus_v2', mockPlans)).toBe('single_account');
       expect(getCurrentTier('team_plus_v2', mockPlans)).toBe('multi_team');
       expect(getCurrentTier('multi_team_v1', mockPlans)).toBe('multi_team');
       expect(getCurrentTier('single_team_v1', mockPlans)).toBe('single_team');
@@ -275,18 +282,22 @@ describe('PlanSelector currentTier Logic', () => {
   });
 
   describe('legacy plan upgrade/downgrade eligibility', () => {
-    // Tier order for reference: free < single_team < multi_team
+    // Canonical tier order (#3824): free < single_account < single_team < multi_team
+    const TIER_ORDER = ['free', 'single_account', 'single_team', 'multi_team'];
+    const rank = (tier: string): number => TIER_ORDER.indexOf(tier);
 
     function canUpgrade(currentTier: string, targetTier: string): boolean {
-      if (currentTier === 'free') return targetTier !== 'free';
-      if (currentTier === 'single_team') return targetTier === 'multi_team';
-      return false;
+      const c = rank(currentTier);
+      const t = rank(targetTier);
+      if (c === -1 || t === -1) return false;
+      return t > c;
     }
 
     function canDowngrade(currentTier: string, targetTier: string): boolean {
-      if (currentTier === 'multi_team') return targetTier !== 'multi_team';
-      if (currentTier === 'single_team') return targetTier === 'free';
-      return false;
+      const c = rank(currentTier);
+      const t = rank(targetTier);
+      if (c === -1 || t === -1) return false;
+      return t < c;
     }
 
     it('legacy "identity" users can upgrade to multi_team', () => {
@@ -299,12 +310,14 @@ describe('PlanSelector currentTier Logic', () => {
       expect(canDowngrade(legacyTier, 'free')).toBe(true);
     });
 
-    it('legacy "identity" users cannot upgrade to single_team (same tier)', () => {
+    it('legacy "identity" users can upgrade to single_team (a higher tier)', () => {
+      // #3824: single_account is a distinct, LOWER tier than single_team, so
+      // this is a genuine upgrade direction (the old "same tier" premise is gone).
       const legacyTier = getCurrentTier('identity', mockPlans);
-      expect(canUpgrade(legacyTier, 'single_team')).toBe(false);
+      expect(canUpgrade(legacyTier, 'single_team')).toBe(true);
     });
 
-    it('legacy "identity" users cannot downgrade to single_team (same tier)', () => {
+    it('legacy "identity" users cannot downgrade to single_team (a higher tier)', () => {
       const legacyTier = getCurrentTier('identity', mockPlans);
       expect(canDowngrade(legacyTier, 'single_team')).toBe(false);
     });

--- a/src/types/billing.ts
+++ b/src/types/billing.ts
@@ -66,7 +66,7 @@ export function getLegacyPlanInfo(
     return {
       isLegacy: true,
       displayName: 'Identity Plus (Early Supporter)',
-      tier: 'single_team', // Same tier as identity_plus for feature parity
+      tier: 'single_account', // Same tier as identity_plus_v1 (backend: single_account)
     };
   }
   return null;


### PR DESCRIPTION
## Summary

The "Current" badge on the plan-selector was landing on the wrong card because plans were matched by **tier** rather than by **id**. After the `identity_plus_v1` tier drifted (`single_team` → `single_account`), a customer on the legacy `identity` plan had their badge render on the Team Plus card.

This switches `isPlanCurrent` to match on `plan.id === planid`, removes the legacy tier remaps/fallbacks, and adds a diagnostic event when a current plan can't be resolved. Test fixtures are aligned to correct tiers and the regression suite now reproduces the original bug.

Closes #3824

## Changes

- `PlanSelector.vue`: id-based `isPlanCurrent`; drop tier-based remaps and fallbacks; emit diagnostic on unresolved current plan
- `src/types/billing.ts`: type alignment for id matching
- Fixtures corrected to accurate tiers (`billing.fixture.ts`, `organization.fixtures.ts`)
- Tests updated/added across `PlanSelector`, `PlanChangeModal`, currency, legacy, and billing.service specs

## Stacking

Stacked on **#3823** (`feature/3821-checkout-host-allowlist`). Base is set to that branch so this PR shows only the #3824 delta (1 commit, 9 files). Re-target to `main` once #3823 merges.
