### PR TITLE
Close canonical-domain guard gaps in CustomDomain (#3841)

### DIFF
--- a/lib/onetime/models/custom_domain.rb
+++ b/lib/onetime/models/custom_domain.rb
@@ -1052,6 +1052,10 @@ module Onetime
         PublicSuffix.valid?(input, default_rule: nil)
       end
 
+      # Whether the input is exactly the configured site host. Narrower
+      # than overlaps_canonical_domain? by design: callers (e.g.
+      # share_domain filtering) ask "is this THE site host?", not "does
+      # this collide with any canonical host or subdomain thereof?".
       def default_domain?(input)
         display_domain = Onetime::CustomDomain.display_domain(input)
         site_host      = OT.conf.dig('site', 'host')
@@ -1088,6 +1092,11 @@ module Onetime
         # Control characters are invalid in domain names (RFC 952/1123).
         # Treat as overlap to block registration -- a domain that cannot
         # be valid should never bypass the canonical-domain guard.
+        #
+        # Ordering matters: this check must stay ahead of the
+        # display_domain call below, which raises Onetime::Problem for
+        # the same input (caught by the fail-closed rescue, but the
+        # explicit path is the one under test).
         return true if contains_control_chars?(input)
 
         input_display = display_domain(input)

--- a/lib/onetime/models/custom_domain.rb
+++ b/lib/onetime/models/custom_domain.rb
@@ -187,6 +187,12 @@ module Onetime
 
       return if new_domain == old_domain
 
+      # Same system-integrity invariant as create!: a rename must not be
+      # able to move an existing record onto the canonical domain (#3841).
+      if self.class.overlaps_canonical_domain?(new_domain)
+        raise Onetime::Problem, 'This domain overlaps with the default site domain'
+      end
+
       # Verify the new domain is not already taken in either index
       existing = self.class.display_domain_index.get(new_domain)
       if existing && existing != identifier
@@ -757,6 +763,15 @@ module Onetime
         obj               = parse(input, org_id)
         normalized_domain = obj.display_domain.to_s.downcase
 
+        # System-integrity backstop: the logic layer already rejects
+        # canonical overlaps, but create! is also reachable from the
+        # console, CLI tooling, and future endpoints. Enforce the
+        # invariant at the write gate so no caller can register the
+        # canonical domain or a subdomain of it (#3841).
+        if overlaps_canonical_domain?(normalized_domain)
+          raise Onetime::Problem, 'This domain overlaps with the default site domain'
+        end
+
         # Check for existing domain BEFORE attempting creation
         existing = load_by_display_domain(normalized_domain)
 
@@ -1047,40 +1062,53 @@ module Onetime
         false
       end
 
-      # Whether the input domain overlaps with the canonical site domain.
+      # Whether the input domain overlaps with a canonical site domain.
       # Checks both exact match and base-domain match so that subdomains
-      # of the canonical host are also blocked (e.g. secrets.example.com
+      # of a canonical host are also blocked (e.g. secrets.example.com
       # when the site host is eu.example.com — both resolve to example.com).
+      #
+      # Covers both site.host and features.domains.default: the
+      # DomainStrategy middleware treats `domains.default || site.host`
+      # as canonical, so a distinct default link domain needs the same
+      # protection as the site host (#3841).
       #
       # Uses PublicSuffix for normalization, so leading/trailing whitespace,
       # casing differences, and trailing dots cannot circumvent the check.
+      # Fails closed: input that cannot be parsed is treated as overlap.
       #
       # Placed before entitlement checks in AddDomain so it is absolute
       # (no colonel bypass) — this is a system-integrity invariant.
       def overlaps_canonical_domain?(input)
-        site_host = OT.conf.dig('site', 'host').to_s
-        return false if site_host.empty?
+        canonical_hosts = [
+          OT.conf&.dig('site', 'host'),
+          OT.conf&.dig('features', 'domains', 'default'),
+        ].map(&:to_s).reject(&:empty?)
+        return false if canonical_hosts.empty?
 
         # Control characters are invalid in domain names (RFC 952/1123).
         # Treat as overlap to block registration -- a domain that cannot
         # be valid should never bypass the canonical-domain guard.
         return true if contains_control_chars?(input)
 
-        return true if default_domain?(input)
+        input_display = display_domain(input)
+        input_base    = base_domain(input)
 
-        # Strip port for PublicSuffix compatibility (e.g. localhost:3000)
-        canonical_host = site_host.split(':').first
-        input_base     = base_domain(input)
-        canonical_base = base_domain(canonical_host)
+        canonical_hosts.any? do |host|
+          # Strip port for PublicSuffix compatibility (e.g. localhost:3000)
+          bare_host = host.split(':').first.to_s.downcase
+          next true if input_display.eql?(bare_host)
 
-        # Skip base-domain comparison when canonical can't be resolved
-        # (e.g. localhost in development)
-        return false if canonical_base.nil? || input_base.nil?
+          canonical_base = base_domain(bare_host)
 
-        input_base == canonical_base
-      rescue PublicSuffix::Error => ex
+          # Skip base-domain comparison when this canonical host can't be
+          # resolved (e.g. localhost in development)
+          next false if canonical_base.nil? || input_base.nil?
+
+          input_base == canonical_base
+        end
+      rescue PublicSuffix::Error, Onetime::Problem => ex
         OT.le "[CustomDomain.overlaps_canonical_domain?] #{ex.message} for `#{input}`"
-        false
+        true
       end
 
       # ASCII control characters (0x00-0x1F, 0x7F) are invalid in domain

--- a/spec/unit/onetime/models/custom_domain/input_sanitization_spec.rb
+++ b/spec/unit/onetime/models/custom_domain/input_sanitization_spec.rb
@@ -2,14 +2,15 @@
 #
 # frozen_string_literal: true
 
-# TDD red-phase tests for two security findings in the domain input
-# validation pipeline. These test desired behavior that is NOT YET
-# implemented -- most tests are expected to FAIL until the fixes land.
+# Security regression tests for the domain input validation pipeline.
 #
-# Finding 1: Null bytes and control characters pass PublicSuffix.valid?
-#            and flow through unchecked.
-# Finding 2: Trailing dots -- PublicSuffix already normalizes these, so
-#            those tests serve as regression guards (expected GREEN).
+# Finding 1: Null bytes and control characters are rejected before they
+#            reach storage or DNS record instructions.
+# Finding 2: Trailing dots -- PublicSuffix normalizes these; regression
+#            guards.
+# Finding 3 (#3841): the canonical-domain overlap guard covers both
+#            site.host and features.domains.default, fails closed on
+#            unparseable input, and is enforced at the create! write gate.
 
 require 'spec_helper'
 
@@ -164,6 +165,75 @@ RSpec.describe Onetime::CustomDomain, 'input sanitization' do
       it 'returns false for a completely different domain' do
         expect(described_class.overlaps_canonical_domain?('other-site.org')).to be false
       end
+    end
+
+    context 'with unparseable input (fail closed)' do
+      it 'treats a bare unknown label as overlap' do
+        expect(described_class.overlaps_canonical_domain?('not_a_domain')).to be true
+      end
+    end
+
+    # The DomainStrategy middleware treats features.domains.default as
+    # canonical when set, so the guard must cover it too (#3841).
+    context 'when features.domains.default differs from site.host' do
+      before do
+        allow(OT).to receive(:conf).and_return({
+          'site' => { 'host' => 'example.com' },
+          'features' => { 'domains' => { 'default' => 'branded-links.net' } },
+        })
+      end
+
+      it 'detects the default link domain verbatim' do
+        expect(described_class.overlaps_canonical_domain?('branded-links.net')).to be true
+      end
+
+      it 'detects a subdomain of the default link domain' do
+        expect(described_class.overlaps_canonical_domain?('secrets.branded-links.net')).to be true
+      end
+
+      it 'still detects the site host' do
+        expect(described_class.overlaps_canonical_domain?('sub.example.com')).to be true
+      end
+
+      it 'returns false for an unrelated domain' do
+        expect(described_class.overlaps_canonical_domain?('other-site.org')).to be false
+      end
+    end
+
+    context 'when no canonical hosts are configured' do
+      before do
+        allow(OT).to receive(:conf).and_return({})
+      end
+
+      it 'returns false' do
+        expect(described_class.overlaps_canonical_domain?('example.com')).to be false
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # create! backstop — the write gate enforces the canonical invariant
+  # itself, so console/CLI callers can't bypass the endpoint guard (#3841).
+  # The guard raises before any Redis access.
+  # ------------------------------------------------------------------ #
+
+  describe '.create! canonical backstop' do
+    before do
+      allow(OT).to receive(:conf).and_return({
+        'site' => { 'host' => 'example.com' },
+      })
+    end
+
+    it 'rejects the canonical domain verbatim' do
+      expect {
+        described_class.create!('example.com', 'org-test-001')
+      }.to raise_error(Onetime::Problem, /overlaps with the default site domain/)
+    end
+
+    it 'rejects a subdomain of the canonical domain' do
+      expect {
+        described_class.create!('secrets.example.com', 'org-test-001')
+      }.to raise_error(Onetime::Problem, /overlaps with the default site domain/)
     end
   end
 end

--- a/spec/unit/onetime/models/custom_domain/input_sanitization_spec.rb
+++ b/spec/unit/onetime/models/custom_domain/input_sanitization_spec.rb
@@ -222,6 +222,13 @@ RSpec.describe Onetime::CustomDomain, 'input sanitization' do
       allow(OT).to receive(:conf).and_return({
         'site' => { 'host' => 'example.com' },
       })
+
+      # Spy on the Redis-touching collaborators so we can prove the
+      # guard raises before any of them run (mirrors the index spies in
+      # update_display_domain_spec).
+      index_double = instance_double('Familia::UniqueIndex', hsetnx: 1)
+      allow(described_class).to receive(:display_domain_index).and_return(index_double)
+      allow(described_class).to receive(:load_by_display_domain)
     end
 
     it 'rejects the canonical domain verbatim' do
@@ -234,6 +241,15 @@ RSpec.describe Onetime::CustomDomain, 'input sanitization' do
       expect {
         described_class.create!('secrets.example.com', 'org-test-001')
       }.to raise_error(Onetime::Problem, /overlaps with the default site domain/)
+    end
+
+    it 'raises before any Redis access' do
+      expect {
+        described_class.create!('example.com', 'org-test-001')
+      }.to raise_error(Onetime::Problem)
+
+      expect(described_class).not_to have_received(:load_by_display_domain)
+      expect(described_class.display_domain_index).not_to have_received(:hsetnx)
     end
   end
 end

--- a/spec/unit/onetime/models/custom_domain/update_display_domain_spec.rb
+++ b/spec/unit/onetime/models/custom_domain/update_display_domain_spec.rb
@@ -2,13 +2,9 @@
 #
 # frozen_string_literal: true
 
-# Coverage gap: the instance method `update_display_domain` re-parses via
-# PublicSuffix.parse directly (line 196) and does NOT go through the
-# class-level methods that call `contains_control_chars?`.
-#
-# The control-character tests are expected to FAIL (red-phase) until a
-# guard is added to `update_display_domain`. The sanity / trailing-dot
-# tests are expected to PASS, proving the harness itself is sound.
+# `update_display_domain` normalizes through the class-level
+# display_domain method (which rejects control characters) and enforces
+# the canonical-domain overlap guard before touching any index (#3841).
 
 require 'spec_helper'
 
@@ -75,11 +71,41 @@ RSpec.describe Onetime::CustomDomain, '#update_display_domain' do
   end
 
   # ------------------------------------------------------------------ #
-  # Control characters — expected RED (the coverage gap)
-  #
-  # update_display_domain passes input directly to PublicSuffix.parse
-  # without calling contains_control_chars?. These tests document the
-  # gap: they should raise Onetime::Problem but currently do not.
+  # Canonical-domain overlap — a rename must not be able to move an
+  # existing record onto the canonical domain or a subdomain of it.
+  # ------------------------------------------------------------------ #
+
+  context 'when the new domain overlaps the canonical site domain' do
+    before do
+      allow(OT).to receive(:conf).and_return({
+        'site' => { 'host' => 'canonical-site.com' },
+      })
+    end
+
+    it 'rejects the canonical domain verbatim' do
+      expect {
+        domain.update_display_domain('canonical-site.com')
+      }.to raise_error(Onetime::Problem, /overlaps with the default site domain/)
+    end
+
+    it 'rejects a subdomain of the canonical domain' do
+      expect {
+        domain.update_display_domain('secrets.canonical-site.com')
+      }.to raise_error(Onetime::Problem, /overlaps with the default site domain/)
+    end
+
+    it 'does not touch the display_domain index before raising' do
+      expect {
+        domain.update_display_domain('canonical-site.com')
+      }.to raise_error(Onetime::Problem)
+      expect(described_class.display_domain_index).not_to have_received(:remove)
+      expect(described_class.display_domain_index).not_to have_received(:put)
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Control characters — rejected during normalization via the
+  # class-level display_domain guard (contains_control_chars?).
   # ------------------------------------------------------------------ #
 
   context 'with a null byte' do


### PR DESCRIPTION
## Summary

[#3841](https://github.com/onetimesecret/onetimesecret/issues/3841)

Hardens the canonical-domain overlap guard so it can no longer be bypassed outside the two logic-layer endpoints:

- `overlaps_canonical_domain?` now covers **both** `site.host` and `features.domains.default` (the DomainStrategy middleware treats `domains.default || site.host` as canonical), and **fails closed** on unparseable input instead of allowing it.
- `CustomDomain.create!` enforces the invariant at the write gate, so console/CLI/future callers can't register the canonical domain or a subdomain of it.
- `CustomDomain#update_display_domain` gets the same guard, so a rename can't move an existing record onto the canonical domain; the raise happens before any index mutation.

## Related Issues

Fixes #3841

## Test Plan

- Flipped the red-phase expectations in `spec/unit/onetime/models/custom_domain/update_display_domain_spec.rb` (control-char rejection now enforced via `display_domain` normalization) and added canonical-overlap rename cases, including an assertion that no index writes occur before the raise.
- Extended `spec/unit/onetime/models/custom_domain/input_sanitization_spec.rb`: `features.domains.default` overlap (exact + subdomain), unrelated domains still allowed, fail-closed on unparseable input, nothing-configured returns false, and `create!` backstop raises before any Redis access.
- Test config uses `site.host: localhost:3000`, whose base domain is unresolvable, so existing `*.example.com` fixtures are unaffected by the new `create!` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RL3zrSySCco4DxGX8cVNeR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RL3zrSySCco4DxGX8cVNeR)_