### PR TITLE
[#3837] Fix silently-dropped Secure session cookie behind TLS-terminating proxies (unify scheme detection + fail-loud diagnostics)

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -962,6 +962,18 @@ TRUSTED_PROXY_HEADER=X-Forwarded-For
 # rather than depth: 0.
 TRUSTED_PROXY_DEPTH=1
 
+# Assume HTTPS at the origin (config site.network.assume_https). Opt-in and
+# INDEPENDENT of TRUSTED_PROXY_*. Upgrade-only: when true, requests that do not
+# already look like HTTPS are marked as HTTPS before any downstream consumer
+# reads the scheme (Secure session cookie, HttpOrigin, CSRF, HSTS, scheme
+# redirects). Only enable when a real TLS-terminating proxy fronts the origin
+# AND it does not forward X-Forwarded-Proto: https (e.g. Cloudflare Tunnel).
+# Standard nginx/Caddy/ALB setups forward the scheme and do not need this.
+# Never enable on a directly-reachable origin. Keep SSL=true (site.ssl) when
+# this is on: pairing ASSUME_HTTPS=true with site.ssl:false makes generated
+# share/email/redirect links emit http:// while clients use https. Default: false.
+ASSUME_HTTPS=false
+
 # Admin (Colonel) network isolation (config site.admin.allowed_cidrs).
 # Optional CIDR allowlist for the Colonel admin surfaces (/colonel shell and
 # /api/colonel API). Comma-separated. When set, a request whose

--- a/apps/api/v1/controllers/helpers.rb
+++ b/apps/api/v1/controllers/helpers.rb
@@ -239,11 +239,10 @@ module V1
     end
 
     def secure?
-      # It's crucial to only accept header values set by known, trusted
-      # sources. See Caddy config docs re: trusted_proxies.
-      # X-Scheme is set by e.g. nginx, caddy etc
-      # X-FORWARDED-PROTO is set by load balancer e.g. ELB
-      (req.env['HTTP_X_FORWARDED_PROTO'] == 'https' || req.env['HTTP_X_SCHEME'] == 'https')
+      # Uses Rack's unified scheme detection (Rack::Request#ssl?), so this
+      # honors HTTPS, X-Forwarded-Proto/X-Forwarded-Ssl, and the AssumeHttps
+      # middleware's upgrade behind a TLS-terminating proxy (#3837).
+      req.ssl?
     end
 
     def deny_agents! *_agents

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -440,6 +440,22 @@ site:
       # than depth: 0; the master switch falls back to REMOTE_ADDR.
       depth: <%= ENV['TRUSTED_PROXY_DEPTH']&.to_i || 1 %>
 
+    # Assume HTTPS at the origin (opt-in, INDEPENDENT of trusted_proxy).
+    #
+    # Upgrade-only: when true, requests that do not already look like HTTPS
+    # are marked as HTTPS before any downstream consumer reads the scheme
+    # (Secure session cookie, HttpOrigin, CSRF, HSTS, scheme redirects).
+    #
+    # Only enable when a real TLS-terminating proxy fronts the origin AND it
+    # does NOT forward X-Forwarded-Proto: https (e.g. Cloudflare Tunnel).
+    # Standard nginx/Caddy/ALB setups forward the scheme and do NOT need
+    # this. Never enable on a directly-reachable origin: it would let a
+    # plain-HTTP client be treated as HTTPS. Also keep site.ssl at its https
+    # default when this is on: pairing assume_https with site.ssl:false makes
+    # config-driven share/email/redirect links emit http:// while clients use
+    # https (mixed-content downgrade of generated URLs).
+    assume_https: <%= ENV['ASSUME_HTTPS'] == 'true' %>
+
   # Admin (Colonel) Configuration
   # Network-level posture for the Colonel admin surfaces.
   admin:

--- a/lib/onetime/application/middleware_stack.rb
+++ b/lib/onetime/application/middleware_stack.rb
@@ -9,6 +9,7 @@ require 'rack/protection'
 require 'rack/utf8_sanitizer'
 
 require_relative '../session'
+require_relative '../middleware/assume_https'
 require_relative '../middleware/ip_ban'
 require_relative '../middleware/health_access_control'
 require_relative '../middleware/admin_network_isolation'
@@ -266,7 +267,17 @@ module Onetime
               application: application_context&.[](:name),
             }
 
-          # IP Privacy FIRST - masks public IPs before logging/monitoring
+          # Assume-HTTPS FIRST - normalizes the request scheme before any
+          # downstream consumer reads it. Behind a TLS-terminating proxy that
+          # does not forward X-Forwarded-Proto (e.g. Cloudflare Tunnel), this
+          # marks the request as HTTPS so the Secure session cookie, the
+          # mounted auth app's HttpOrigin check, CSRF, HSTS, and scheme
+          # redirects all see a consistent scheme. Opt-in via
+          # site.network.assume_https; strict no-op (and upgrade-only) when
+          # off, so native Rack X-Forwarded-Proto handling is unaffected.
+          builder.use Onetime::Middleware::AssumeHttps
+
+          # IP Privacy - masks public IPs before logging/monitoring
           # Private/localhost IPs are automatically exempted for development
           # Uses Otto's privacy middleware as a standalone Rack component.
           #

--- a/lib/onetime/middleware/assume_https.rb
+++ b/lib/onetime/middleware/assume_https.rb
@@ -1,0 +1,64 @@
+# lib/onetime/middleware/assume_https.rb
+#
+# frozen_string_literal: true
+
+module Onetime
+  module Middleware
+    # AssumeHttps - Normalizes the request scheme to HTTPS behind a
+    # TLS-terminating proxy that does NOT forward X-Forwarded-Proto.
+    #
+    # ## Why this exists
+    #
+    # Most reverse proxies (nginx, Caddy, AWS ALB) forward the original
+    # client scheme via `X-Forwarded-Proto: https`, which Rack honors
+    # natively, so `request.ssl?` is already true and this middleware is
+    # never needed. Some tunneling proxies do NOT set that header: notably
+    # Cloudflare Tunnel (cloudflared), which terminates TLS at Cloudflare's
+    # edge and connects to the origin over plain HTTP without forwarding the
+    # scheme. The origin then treats every request as HTTP, which suppresses
+    # the Secure session cookie and breaks scheme-aware redirects/HSTS
+    # (issue #3837, root cause of #3831).
+    #
+    # When `site.network.assume_https` is enabled, this middleware marks the
+    # request as HTTPS so every downstream consumer (session cookie Secure
+    # flag, the mounted auth app's HttpOrigin check, CSRF, HSTS, and scheme
+    # redirects) sees one consistent scheme.
+    #
+    # ## UPGRADE-ONLY invariant
+    #
+    # This middleware ONLY upgrades http -> https. It never downgrades the
+    # scheme and never strips or rewrites forwarded headers. If the request
+    # is already HTTPS (via env['HTTPS'], rack.url_scheme, or an
+    # X-Forwarded-Proto that Rack already honors), it is a strict no-op.
+    # When the flag is off it is a strict no-op for every request, so native
+    # Rack X-Forwarded-Proto handling for existing nginx/Caddy/ALB
+    # deployments is completely unaffected.
+    #
+    # Mount FIRST in the stack so the normalized scheme is visible to every
+    # downstream middleware and the mounted auth app.
+    #
+    # @note Only enable when a real TLS-terminating proxy fronts the origin.
+    #   Enabling it on a directly-reachable origin would let a plain-HTTP
+    #   client be treated as HTTPS.
+    class AssumeHttps
+      def initialize(app)
+        @app     = app
+        @enabled = OT.conf.dig('site', 'network', 'assume_https') == true
+      end
+
+      def call(env)
+        return @app.call(env) unless @enabled
+
+        # Upgrade-only: leave already-HTTPS requests (including those Rack
+        # resolved from X-Forwarded-Proto) untouched.
+        req = Rack::Request.new(env)
+        unless req.ssl?
+          env['HTTPS']           = 'on'
+          env['rack.url_scheme'] = 'https'
+        end
+
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/lib/onetime/middleware/csrf_response_header.rb
+++ b/lib/onetime/middleware/csrf_response_header.rb
@@ -27,6 +27,15 @@ module Onetime
       # State-changing methods that Rack::Protection::AuthenticityToken
       # validates. Safe methods (GET/HEAD/OPTIONS) are never CSRF-checked, so
       # they must not pay the session-load cost below nor emit rejection logs.
+      #
+      # NOTE (observability-only): this is a hardcoded allowlist, not the exact
+      # complement of rack-protection's `safe?` (GET/HEAD/OPTIONS/TRACE). A
+      # non-standard unsafe method that rack-protection WOULD CSRF-check (e.g.
+      # WebDAV PROPFIND/MKCOL) is absent here, so its 403 would skip this
+      # diagnostic. That only costs a log line — never security — and OTS
+      # exposes no such methods, so the explicit, readable allowlist is
+      # preferred over deriving the complement of a private rack-protection
+      # predicate.
       UNSAFE_METHODS = %w[POST PUT PATCH DELETE].freeze
 
       # Session key holding the raw CSRF token. This is AuthenticityToken's

--- a/lib/onetime/middleware/csrf_response_header.rb
+++ b/lib/onetime/middleware/csrf_response_header.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require_relative 'instrumented_authenticity_token'
+
 module Onetime
   module Middleware
     ##
@@ -34,15 +36,13 @@ module Onetime
       # (set_token only runs inside AuthenticityToken during @app.call).
       CSRF_SESSION_KEY = :csrf
 
-      # Rack::Protection stamps env['rack.protection.attack'] with the rejecting
-      # middleware's lowercased class name — but ONLY when an :instrumenter is
-      # configured (security.rb wires CSRF_ATTACK_INSTRUMENTER onto
-      # AuthenticityToken for exactly this). A 403 raised by the app itself
+      # InstrumentedAuthenticityToken stamps this env key true on its deny path
+      # (a genuine CSRF rejection). A 403 raised by the app itself
       # (Onetime::Forbidden, EntitlementRequired, GuestRoutesDisabled) never sets
       # it, so gating the diagnostic on this marker keeps non-CSRF 403s out of the
       # CSRF log. Scoped to AuthenticityToken specifically: HttpOrigin is a
       # different CSRF class whose 403s the token/continuity split does not model.
-      CSRF_ATTACK_MARKER = 'authenticitytoken'
+      CSRF_REJECTION_KEY = Onetime::Middleware::InstrumentedAuthenticityToken::REJECTION_ENV_KEY
 
       def initialize(app)
         @app = app
@@ -67,19 +67,21 @@ module Onetime
           headers['X-CSRF-Token'] = csrf_token if csrf_token
         end
 
-        log_csrf_rejection(env, had_csrf) if unsafe && csrf_rejection?(env)
+        log_csrf_rejection(env, had_csrf) if unsafe && status == 403 && csrf_rejection?(env)
 
         [status, headers, body]
       end
 
       private
 
-      # True only for a 403 produced by AuthenticityToken (a genuine CSRF
-      # rejection), as opposed to any other 403 this middleware happens to wrap.
-      # The marker's presence already implies the deny (403) reaction ran, so we
-      # do not also test `status`.
+      # True only for a request InstrumentedAuthenticityToken denied (a genuine
+      # CSRF rejection), as opposed to any other 403 this middleware happens to
+      # wrap. The marker is set only on the deny path, so it is already 403-only
+      # by construction; the caller still ANDs `status == 403` as free insurance
+      # against a future config change (e.g. reaction: :report) that could set a
+      # marker without denying.
       def csrf_rejection?(env)
-        env['rack.protection.attack'] == CSRF_ATTACK_MARKER
+        env[CSRF_REJECTION_KEY] == true
       end
 
       # True when the session already carries a non-empty raw CSRF token.

--- a/lib/onetime/middleware/csrf_response_header.rb
+++ b/lib/onetime/middleware/csrf_response_header.rb
@@ -22,11 +22,33 @@ module Onetime
     #   use Onetime::Middleware::CsrfResponseHeader  # exposes masked token
     #
     class CsrfResponseHeader
+      # State-changing methods that Rack::Protection::AuthenticityToken
+      # validates. Safe methods (GET/HEAD/OPTIONS) are never CSRF-checked, so
+      # they must not pay the session-load cost below nor emit rejection logs.
+      UNSAFE_METHODS = %w[POST PUT PATCH DELETE].freeze
+
+      # Session key holding the raw CSRF token. This is AuthenticityToken's
+      # default `key: :csrf` (security.rb does not override it). SessionHash
+      # normalizes the symbol to its stored string key, so reading session[:csrf]
+      # mirrors exactly what AuthenticityToken reads — and the read is pure
+      # (set_token only runs inside AuthenticityToken during @app.call).
+      CSRF_SESSION_KEY = :csrf
+
       def initialize(app)
         @app = app
       end
 
       def call(env)
+        # #3837 (root cause of #3831): a CSRF 403 has two very different causes.
+        # AuthenticityToken#accepts? calls set_token (session[:csrf] ||= random)
+        # BEFORE validating, so after @app.call the token is ALWAYS present and
+        # the two cases are indistinguishable. The only moment we can tell them
+        # apart is here, before @app.call. Unsafe methods only — reading the
+        # session lazy-loads it, a cost safe requests must not incur.
+        request_method = env['REQUEST_METHOD']
+        unsafe         = UNSAFE_METHODS.include?(request_method)
+        had_csrf       = unsafe && csrf_token_present?(env['rack.session'])
+
         status, headers, body = @app.call(env)
 
         session = env['rack.session']
@@ -35,7 +57,39 @@ module Onetime
           headers['X-CSRF-Token'] = csrf_token if csrf_token
         end
 
+        log_csrf_rejection(env, had_csrf) if unsafe && status == 403
+
         [status, headers, body]
+      end
+
+      private
+
+      # True when the session already carries a non-empty raw CSRF token.
+      # Reads with AuthenticityToken's own key; the read forces a lazy session
+      # load, which is why the caller gates this on unsafe methods.
+      def csrf_token_present?(session)
+        return false unless session
+
+        token = session[CSRF_SESSION_KEY]
+        !token.nil? && !token.to_s.empty?
+      end
+
+      # Observability only (#3837): classify a CSRF 403. Never logs token
+      # values or secrets — only method + path context. This logs the CSRF
+      # REJECTION and is distinct from the Part 2 cookie-drop warning.
+      def log_csrf_rejection(env, had_csrf)
+        context = { method: env['REQUEST_METHOD'], path: env['PATH_INFO'] }
+
+        if had_csrf
+          # The session held a token but the submitted one did not match: a
+          # genuine forged/stale request — real CSRF rejection.
+          OT.lw '[CsrfResponseHeader] CSRF 403 token-mismatch: session had a CSRF token; submitted token invalid or absent', **context
+        else
+          # No token in the session when the request arrived: the session was
+          # lost or never persisted between issuing the token and this request.
+          # This is the session-continuity break behind #3837/#3831, not forgery.
+          OT.lw '[CsrfResponseHeader] CSRF 403 session-continuity break: no CSRF token in session at request start; session lost or not persisted', **context
+        end
       end
     end
   end

--- a/lib/onetime/middleware/csrf_response_header.rb
+++ b/lib/onetime/middleware/csrf_response_header.rb
@@ -34,6 +34,16 @@ module Onetime
       # (set_token only runs inside AuthenticityToken during @app.call).
       CSRF_SESSION_KEY = :csrf
 
+      # Rack::Protection stamps env['rack.protection.attack'] with the rejecting
+      # middleware's lowercased class name — but ONLY when an :instrumenter is
+      # configured (security.rb wires CSRF_ATTACK_INSTRUMENTER onto
+      # AuthenticityToken for exactly this). A 403 raised by the app itself
+      # (Onetime::Forbidden, EntitlementRequired, GuestRoutesDisabled) never sets
+      # it, so gating the diagnostic on this marker keeps non-CSRF 403s out of the
+      # CSRF log. Scoped to AuthenticityToken specifically: HttpOrigin is a
+      # different CSRF class whose 403s the token/continuity split does not model.
+      CSRF_ATTACK_MARKER = 'authenticitytoken'
+
       def initialize(app)
         @app = app
       end
@@ -57,12 +67,20 @@ module Onetime
           headers['X-CSRF-Token'] = csrf_token if csrf_token
         end
 
-        log_csrf_rejection(env, had_csrf) if unsafe && status == 403
+        log_csrf_rejection(env, had_csrf) if unsafe && csrf_rejection?(env)
 
         [status, headers, body]
       end
 
       private
+
+      # True only for a 403 produced by AuthenticityToken (a genuine CSRF
+      # rejection), as opposed to any other 403 this middleware happens to wrap.
+      # The marker's presence already implies the deny (403) reaction ran, so we
+      # do not also test `status`.
+      def csrf_rejection?(env)
+        env['rack.protection.attack'] == CSRF_ATTACK_MARKER
+      end
 
       # True when the session already carries a non-empty raw CSRF token.
       # Reads with AuthenticityToken's own key; the read forces a lazy session
@@ -78,7 +96,13 @@ module Onetime
       # values or secrets — only method + path context. This logs the CSRF
       # REJECTION and is distinct from the Part 2 cookie-drop warning.
       def log_csrf_rejection(env, had_csrf)
-        context = { method: env['REQUEST_METHOD'], path: env['PATH_INFO'] }
+        # SCRIPT_NAME carries the URLMap mount prefix (e.g. "/api"); PATH_INFO is
+        # only the remainder. Join them so the logged path is the full request path
+        # rather than a prefix-stripped fragment.
+        context = {
+          method: env['REQUEST_METHOD'],
+          path: "#{env['SCRIPT_NAME']}#{env['PATH_INFO']}",
+        }
 
         if had_csrf
           # The session held a token but the submitted one did not match: a

--- a/lib/onetime/middleware/instrumented_authenticity_token.rb
+++ b/lib/onetime/middleware/instrumented_authenticity_token.rb
@@ -1,0 +1,57 @@
+# lib/onetime/middleware/instrumented_authenticity_token.rb
+#
+# frozen_string_literal: true
+
+require 'rack/protection'
+
+module Onetime
+  module Middleware
+    ##
+    # InstrumentedAuthenticityToken
+    #
+    # Rack::Protection::AuthenticityToken that stamps a private env marker on the
+    # exact rejection path, so CsrfResponseHeader can tell a genuine CSRF 403
+    # apart from an app-level 403 (Onetime::Forbidden, EntitlementRequired,
+    # GuestRoutesDisabled) it merely wraps. See #3837 (root cause of #3831).
+    #
+    # Why a subclass and not rack-protection's :instrumenter hook:
+    #   The instrumenter fires from Base#call for ANY reaction (including
+    #   :report) BEFORE the reaction runs, so its env['rack.protection.attack']
+    #   marker means "attack detected", not "request denied". Wiring up a no-op
+    #   instrumenter purely to trigger that side effect also couples us to an
+    #   internal detail (the marker string derived from self.class.name...downcase).
+    #   Overriding #deny instead gives us our OWN key/value on the one path that
+    #   actually returns a 403 — the marker now means "denied", and we own it.
+    #
+    # Why `default_reaction :deny` is REQUIRED, not decorative:
+    #   base.rb runs `alias default_reaction deny` at class-definition time, which
+    #   snapshots Base#deny's method body. Rejection dispatches via
+    #   `send(options[:reaction], env)` where the default reaction is
+    #   :default_reaction — i.e. that frozen alias, NOT the name #deny. A plain
+    #   override of #deny would therefore be dead code: dispatch would still reach
+    #   Base#deny's snapshot and our marker would never be set. The class macro
+    #   `self.default_reaction` (base.rb) re-aliases :default_reaction to our
+    #   override, so both the default dispatch and an explicit `reaction: :deny`
+    #   route through the method below. A live-stack integration test
+    #   (spec/integration/all/csrf_enforcement_spec.rb) guards this invariant: if
+    #   rack-protection ever changes the dispatch, that test goes red rather than
+    #   silently mislabeling 403s.
+    class InstrumentedAuthenticityToken < Rack::Protection::AuthenticityToken
+      # Rack env key stamped true when this middleware denies a request. The env
+      # hash is the same object all the way up the middleware chain, so
+      # CsrfResponseHeader reads this after @app.call returns. Namespaced under
+      # `onetime.` per the app's custom-env-key convention (onetime.nonce, etc.).
+      REJECTION_ENV_KEY = 'onetime.csrf.rejected'
+
+      # Runs ONLY on rejection (the deny reaction). Stamps our marker, then
+      # delegates to Base#deny for the standard 403 response tuple.
+      def deny(env)
+        env[REJECTION_ENV_KEY] = true
+        super
+      end
+
+      # Rebind Base's stale `default_reaction` alias to the override above.
+      default_reaction :deny
+    end
+  end
+end

--- a/lib/onetime/middleware/security.rb
+++ b/lib/onetime/middleware/security.rb
@@ -44,6 +44,20 @@ module Onetime
         utf8_sanitizer
       ].freeze
 
+      # Configuring an :instrumenter is the ONLY thing that makes Rack::Protection
+      # stamp env['rack.protection.attack'] with the rejecting middleware's name
+      # before it denies (rack-protection base.rb#instrument). CsrfResponseHeader
+      # reads that marker to tell a genuine AuthenticityToken 403 apart from an
+      # app-level 403 (Onetime::Forbidden, EntitlementRequired, GuestRoutesDisabled)
+      # it merely wraps. We only need the env marker, not the notification, so
+      # #instrument is a deliberate no-op -- no ActiveSupport::Notifications
+      # dependency and no event emission. See #3837 (root cause of #3831).
+      CSRF_ATTACK_INSTRUMENTER = Object.new.tap do |instrumenter|
+        # rack-protection invokes instrumenter.instrument('rack.protection', env)
+        # AFTER it has set the env marker we care about.
+        def instrumenter.instrument(_name, _env); end
+      end
+
       # The wrapped Rack application
       # @return [#call] The Rack application instance passed to this middleware
       attr_reader :app
@@ -149,6 +163,10 @@ Onetime::Middleware::Security.middleware_components = {
     klass: Rack::Protection::AuthenticityToken,
     options: {
       authenticity_param: 'shrimp',
+      # Marks env['rack.protection.attack'] on rejection so CsrfResponseHeader
+      # can distinguish a real CSRF 403 from an unrelated 403 (see the
+      # CSRF_ATTACK_INSTRUMENTER definition above).
+      instrumenter: Onetime::Middleware::Security::CSRF_ATTACK_INSTRUMENTER,
       allow_if: ->(env) {
         req = Rack::Request.new(env)
 

--- a/lib/onetime/middleware/security.rb
+++ b/lib/onetime/middleware/security.rb
@@ -11,6 +11,8 @@ require 'rack'
 require 'rack/protection'
 require 'rack/utf8_sanitizer'
 
+require_relative 'instrumented_authenticity_token'
+
 module Onetime
   module Middleware
     # Security middleware collection for Onetime Secret
@@ -43,20 +45,6 @@ module Onetime
         authenticity_token
         utf8_sanitizer
       ].freeze
-
-      # Configuring an :instrumenter is the ONLY thing that makes Rack::Protection
-      # stamp env['rack.protection.attack'] with the rejecting middleware's name
-      # before it denies (rack-protection base.rb#instrument). CsrfResponseHeader
-      # reads that marker to tell a genuine AuthenticityToken 403 apart from an
-      # app-level 403 (Onetime::Forbidden, EntitlementRequired, GuestRoutesDisabled)
-      # it merely wraps. We only need the env marker, not the notification, so
-      # #instrument is a deliberate no-op -- no ActiveSupport::Notifications
-      # dependency and no event emission. See #3837 (root cause of #3831).
-      CSRF_ATTACK_INSTRUMENTER = Object.new.tap do |instrumenter|
-        # rack-protection invokes instrumenter.instrument('rack.protection', env)
-        # AFTER it has set the env marker we care about.
-        def instrumenter.instrument(_name, _env); end
-      end
 
       # The wrapped Rack application
       # @return [#call] The Rack application instance passed to this middleware
@@ -160,13 +148,13 @@ Onetime::Middleware::Security.middleware_components = {
   # See also: apps/web/auth/config/hooks/omniauth.rb for Rodauth-side bypass
   'AuthenticityToken' => {
     key: :authenticity_token,
-    klass: Rack::Protection::AuthenticityToken,
+    # Subclass of Rack::Protection::AuthenticityToken that stamps
+    # env['onetime.csrf.rejected'] on rejection so CsrfResponseHeader can
+    # distinguish a real CSRF 403 from an unrelated 403. See
+    # InstrumentedAuthenticityToken for why the subclass (not an :instrumenter).
+    klass: Onetime::Middleware::InstrumentedAuthenticityToken,
     options: {
       authenticity_param: 'shrimp',
-      # Marks env['rack.protection.attack'] on rejection so CsrfResponseHeader
-      # can distinguish a real CSRF 403 from an unrelated 403 (see the
-      # CSRF_ATTACK_INSTRUMENTER definition above).
-      instrumenter: Onetime::Middleware::Security::CSRF_ATTACK_INSTRUMENTER,
       allow_if: ->(env) {
         req = Rack::Request.new(env)
 

--- a/lib/onetime/session.rb
+++ b/lib/onetime/session.rb
@@ -229,20 +229,22 @@ module Onetime
     # Snapshot of the scheme-detection signals Rack consults in Request#scheme.
     # We reach this method only when req.ssl? is already false, so any signal
     # present here definitionally did NOT carry an https value -- its value (or
-    # absence) is the diagnostic. rack.url_scheme and X-Forwarded-Proto are bare
-    # scheme tokens ("http", "https", or a proto list) with no client PII, so we
-    # log them verbatim: the value distinguishes "proxy forwarded http" from
-    # "proxy forwarded nothing", which a boolean would erase. HTTP_FORWARDED
-    # (RFC 7239) can carry the forwarded client IP in its `for=` parameter, and
-    # X-Forwarded-Ssl/HTTPS are boolean by nature, so those stay presence-only.
+    # absence) is the diagnostic. rack.url_scheme, X-Forwarded-Proto, X-Forwarded-Ssl
+    # and HTTPS are all bare tokens with no client PII, so we log them verbatim:
+    # the raw value distinguishes "proxy forwarded http"/"HTTPS=off" from "proxy
+    # forwarded nothing" (nil), which a presence boolean would erase -- and it
+    # avoids the trap where env.key?('HTTPS') reports true for an explicit
+    # HTTPS=off (Rack only treats 'on' as ssl, so `https: "off"` is the honest
+    # evidence). HTTP_FORWARDED (RFC 7239) can carry the forwarded client IP in
+    # its `for=` parameter, so it stays presence-only to keep PII out of the log.
     def scheme_evidence(request)
       env = request.env
       {
         rack_url_scheme: env['rack.url_scheme'],
         x_forwarded_proto: env['HTTP_X_FORWARDED_PROTO'],
         forwarded: env.key?('HTTP_FORWARDED'),
-        x_forwarded_ssl: env.key?('HTTP_X_FORWARDED_SSL'),
-        https: env.key?('HTTPS'),
+        x_forwarded_ssl: env['HTTP_X_FORWARDED_SSL'],
+        https: env['HTTPS'],
       }
     end
 

--- a/lib/onetime/session.rb
+++ b/lib/onetime/session.rb
@@ -227,16 +227,19 @@ module Onetime
     end
 
     # Snapshot of the scheme-detection signals Rack consults in Request#scheme.
-    # We reach this method only when req.ssl? is already false, so any header
-    # present here definitionally did NOT carry an https signal -- presence vs
-    # absence is the diagnostic. We record booleans rather than raw values so we
-    # never log the forwarded client IP that HTTP_FORWARDED (RFC 7239 `for=`)
-    # can carry; rack.url_scheme is a bare scheme token and safe to log verbatim.
+    # We reach this method only when req.ssl? is already false, so any signal
+    # present here definitionally did NOT carry an https value -- its value (or
+    # absence) is the diagnostic. rack.url_scheme and X-Forwarded-Proto are bare
+    # scheme tokens ("http", "https", or a proto list) with no client PII, so we
+    # log them verbatim: the value distinguishes "proxy forwarded http" from
+    # "proxy forwarded nothing", which a boolean would erase. HTTP_FORWARDED
+    # (RFC 7239) can carry the forwarded client IP in its `for=` parameter, and
+    # X-Forwarded-Ssl/HTTPS are boolean by nature, so those stay presence-only.
     def scheme_evidence(request)
       env = request.env
       {
         rack_url_scheme: env['rack.url_scheme'],
-        x_forwarded_proto: env.key?('HTTP_X_FORWARDED_PROTO'),
+        x_forwarded_proto: env['HTTP_X_FORWARDED_PROTO'],
         forwarded: env.key?('HTTP_FORWARDED'),
         x_forwarded_ssl: env.key?('HTTP_X_FORWARDED_SSL'),
         https: env.key?('HTTPS'),

--- a/lib/onetime/session.rb
+++ b/lib/onetime/session.rb
@@ -71,6 +71,25 @@ module Onetime
 
     attr_reader :dbclient
 
+    # Throttle interval (seconds) between "secure cookie silently dropped"
+    # warnings. Every request over a mis-forwarded TLS-terminating proxy trips
+    # the same condition, so we rate-limit to avoid flooding the log. See #3837.
+    unless defined?(SECURE_COOKIE_WARN_INTERVAL)
+      SECURE_COOKIE_WARN_INTERVAL = 300 # ~5 minutes
+    end
+
+    # Class-level, process-wide guard for the throttled warning below. Holds the
+    # monotonic timestamp (Process::CLOCK_MONOTONIC) of the last emission, nil
+    # until the first. The Mutex keeps concurrent Puma threads from racing on it.
+    # `||=` keeps this idempotent across code reloads.
+    @secure_cookie_warn_mutex ||= Mutex.new
+    @secure_cookie_warned_at  ||= nil
+
+    class << self
+      attr_accessor :secure_cookie_warned_at
+      attr_reader :secure_cookie_warn_mutex
+    end
+
     def initialize(app, options = {})
       # Require a secret for security - fall back to site secret if not set
       is_valid_string = options[:secret].is_a?(String) && !options[:secret].empty?
@@ -165,6 +184,63 @@ module Onetime
         }
 
       new_sid
+    end
+
+    # Rack calls this from commit_session to decide whether a cookie flagged
+    # :secure may be written. The parent (PersistedSecure) returns false when
+    # options[:secure] is set but the request is seen as non-SSL and @assume_ssl
+    # is not enabled — commit_session then returns EARLY and the cookie is
+    # SILENTLY never written. That silent drop is the root cause of #3837 (and
+    # the reported symptom in #3831).
+    #
+    # This override is observability-only: we deliberately do NOT change the
+    # decision or touch @assume_ssl semantics (both stay entirely in the parent).
+    # We just turn the silent drop into a throttled, actionable warning and then
+    # return the parent's verdict unchanged.
+    def security_matches?(request, options)
+      matched = super
+      warn_dropped_secure_cookie(request) if !matched && options[:secure] && !request.ssl?
+      matched
+    end
+
+    # Emit the dropped-secure-cookie warning at most once per
+    # SECURE_COOKIE_WARN_INTERVAL per process, using the class-level monotonic
+    # guard declared above. The constant is referenced explicitly (rather than
+    # via self.class) so subclasses can't miss the shared state.
+    #
+    # The warning carries its own proof: a snapshot of the scheme-detection
+    # signals Rack saw at the moment the cookie was dropped (see
+    # #scheme_evidence). The next field report then contains the observation
+    # directly instead of us reconstructing which hop stripped the scheme.
+    def warn_dropped_secure_cookie(request)
+      now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      Onetime::Session.secure_cookie_warn_mutex.synchronize do
+        last = Onetime::Session.secure_cookie_warned_at
+        return if last && (now - last) < SECURE_COOKIE_WARN_INTERVAL
+
+        Onetime::Session.secure_cookie_warned_at = now
+      end
+
+      OT.lw '[Session] cookie NOT written: secure cookie over a request the app sees as non-SSL. Behind a TLS-terminating proxy, forward X-Forwarded-Proto: https or set ASSUME_HTTPS=true.',
+        **scheme_evidence(request)
+    end
+
+    # Snapshot of the scheme-detection signals Rack consults in Request#scheme.
+    # We reach this method only when req.ssl? is already false, so any header
+    # present here definitionally did NOT carry an https signal -- presence vs
+    # absence is the diagnostic. We record booleans rather than raw values so we
+    # never log the forwarded client IP that HTTP_FORWARDED (RFC 7239 `for=`)
+    # can carry; rack.url_scheme is a bare scheme token and safe to log verbatim.
+    def scheme_evidence(request)
+      env = request.env
+      {
+        rack_url_scheme: env['rack.url_scheme'],
+        x_forwarded_proto: env.key?('HTTP_X_FORWARDED_PROTO'),
+        forwarded: env.key?('HTTP_FORWARDED'),
+        x_forwarded_ssl: env.key?('HTTP_X_FORWARDED_SSL'),
+        https: env.key?('HTTPS'),
+      }
     end
 
     # Validates session ID format

--- a/spec/integration/all/authentication_security_spec.rb
+++ b/spec/integration/all/authentication_security_spec.rb
@@ -251,7 +251,10 @@ RSpec.describe 'Authentication Security Attack Vectors', type: :integration do
       middleware_config = Onetime::Middleware::Security.middleware_components['AuthenticityToken']
 
       expect(middleware_config).not_to be_nil
-      expect(middleware_config[:klass]).to eq(Rack::Protection::AuthenticityToken)
+      # InstrumentedAuthenticityToken is our subclass of the standard middleware
+      # (it stamps a rejection marker on deny); it inherits the shrimp handling.
+      expect(middleware_config[:klass]).to eq(Onetime::Middleware::InstrumentedAuthenticityToken)
+      expect(middleware_config[:klass]).to be < Rack::Protection::AuthenticityToken
       expect(middleware_config[:options]).to include(authenticity_param: 'shrimp')
     end
 

--- a/spec/integration/all/csrf_enforcement_spec.rb
+++ b/spec/integration/all/csrf_enforcement_spec.rb
@@ -479,6 +479,74 @@ RSpec.describe 'CSRF Enforcement', type: :integration do
     end
   end
 
+  describe 'CsrfResponseHeader 403 discrimination (#3837, root cause of #3831)' do
+    # A CSRF 403 has two very different root causes that are indistinguishable
+    # AFTER @app.call (AuthenticityToken#accepts? sets session[:csrf] before it
+    # validates). CsrfResponseHeader captures presence BEFORE @app.call and logs
+    # a discriminated warning. We drive the middleware directly with a stub app
+    # so the branch is deterministic and does not depend on the full CSRF flow.
+    let(:stub_403_app) { ->(_env) { [403, {}, []] } }
+    let(:middleware) { Onetime::Middleware::CsrfResponseHeader.new(stub_403_app) }
+    # A realistic raw session token: the downstream X-CSRF-Token masking block
+    # base64-decodes session[:csrf], so it must be a valid urlsafe token (an
+    # arbitrary string can trip Base64.urlsafe_decode64 on length).
+    let(:valid_token) { Rack::Protection::AuthenticityToken.random_token }
+
+    def env_for(method:, path:, session: nil)
+      env = { 'REQUEST_METHOD' => method, 'PATH_INFO' => path }
+      env['rack.session'] = session unless session.nil?
+      env
+    end
+
+    it 'logs a session-continuity break when a POST 403s with NO token in session' do
+      # No csrf token present at request start => the session was lost or never
+      # persisted between issuing the token and this request. This is the #3837
+      # bug class, NOT forgery.
+      allow(OT).to receive(:lw).and_call_original
+      middleware.call(env_for(method: 'POST', path: '/account/update', session: {}))
+
+      expect(OT).to have_received(:lw).with(
+        a_string_matching(/session-continuity break/),
+        hash_including(method: 'POST', path: '/account/update')
+      )
+      # ...and it is NOT mis-classified as a genuine token-mismatch.
+      expect(OT).not_to have_received(:lw).with(a_string_matching(/token-mismatch/), anything)
+    end
+
+    it 'logs a token-mismatch when a POST 403s WITH a token already in session' do
+      # A raw token was present at request start but the submitted one did not
+      # match => a genuine forged/stale request. CSRF_SESSION_KEY is :csrf, read
+      # exactly as AuthenticityToken reads it.
+      allow(OT).to receive(:lw).and_call_original
+      middleware.call(env_for(method: 'POST', path: '/account/update', session: { csrf: valid_token }))
+
+      expect(OT).to have_received(:lw).with(
+        a_string_matching(/token-mismatch/),
+        hash_including(method: 'POST', path: '/account/update')
+      )
+      # ...and it is NOT mis-classified as a session-continuity break.
+      expect(OT).not_to have_received(:lw).with(a_string_matching(/session-continuity break/), anything)
+    end
+
+    it 'does NOT log for a SAFE method (GET) even when the response is 403' do
+      # Safe methods are never CSRF-checked, so they must not pay the session
+      # load cost nor emit a rejection log.
+      allow(OT).to receive(:lw).and_call_original
+      middleware.call(env_for(method: 'GET', path: '/account/update', session: {}))
+
+      expect(OT).not_to have_received(:lw).with(a_string_matching(/CSRF 403/), anything)
+    end
+
+    it 'does NOT log when an unsafe POST is NOT rejected (status != 403)' do
+      ok_app = ->(_env) { [200, {}, []] }
+      ok_middleware = Onetime::Middleware::CsrfResponseHeader.new(ok_app)
+      allow(OT).to receive(:lw).and_call_original
+      ok_middleware.call(env_for(method: 'POST', path: '/account/update', session: {}))
+
+      expect(OT).not_to have_received(:lw).with(a_string_matching(/CSRF 403/), anything)
+    end
+  end
+
   describe 'CSRF round-trip: page-rendered token accepted on POST' do
     # Validates the invariant that tokens generated from rack.session
     # during page render are accepted by Rack::Protection on subsequent

--- a/spec/integration/all/csrf_enforcement_spec.rb
+++ b/spec/integration/all/csrf_enforcement_spec.rb
@@ -485,7 +485,16 @@ RSpec.describe 'CSRF Enforcement', type: :integration do
     # validates). CsrfResponseHeader captures presence BEFORE @app.call and logs
     # a discriminated warning. We drive the middleware directly with a stub app
     # so the branch is deterministic and does not depend on the full CSRF flow.
-    let(:stub_403_app) { ->(_env) { [403, {}, []] } }
+    # Simulates AuthenticityToken rejecting the request: rack-protection sets the
+    # env attack marker (via the configured instrumenter) BEFORE it denies with a
+    # 403. CsrfResponseHeader keys its diagnostic on that marker, so the stub must
+    # set it to exercise the real code path.
+    let(:stub_403_app) do
+      ->(env) {
+        env['rack.protection.attack'] = 'authenticitytoken'
+        [403, {}, []]
+      }
+    end
     let(:middleware) { Onetime::Middleware::CsrfResponseHeader.new(stub_403_app) }
     # A realistic raw session token: the downstream X-CSRF-Token masking block
     # base64-decodes session[:csrf], so it must be a valid urlsafe token (an
@@ -534,7 +543,7 @@ RSpec.describe 'CSRF Enforcement', type: :integration do
       allow(OT).to receive(:lw).and_call_original
       middleware.call(env_for(method: 'GET', path: '/account/update', session: {}))
 
-      expect(OT).not_to have_received(:lw).with(a_string_matching(/CSRF 403/), anything)
+      expect(OT).not_to have_received(:lw)
     end
 
     it 'does NOT log when an unsafe POST is NOT rejected (status != 403)' do
@@ -543,7 +552,35 @@ RSpec.describe 'CSRF Enforcement', type: :integration do
       allow(OT).to receive(:lw).and_call_original
       ok_middleware.call(env_for(method: 'POST', path: '/account/update', session: {}))
 
-      expect(OT).not_to have_received(:lw).with(a_string_matching(/CSRF 403/), anything)
+      expect(OT).not_to have_received(:lw)
+    end
+
+    it 'does NOT log when a non-CSRF 403 is returned (no attack marker)' do
+      # An app-level 403 (Onetime::Forbidden, EntitlementRequired,
+      # GuestRoutesDisabled) never sets env['rack.protection.attack']. Before the
+      # marker gate these were mis-logged as CSRF failures; now they are correctly
+      # ignored so the CSRF diagnostic only fires on genuine CSRF rejections.
+      plain_403_app   = ->(_env) { [403, {}, []] }
+      plain_middleware = Onetime::Middleware::CsrfResponseHeader.new(plain_403_app)
+      allow(OT).to receive(:lw).and_call_original
+      plain_middleware.call(env_for(method: 'POST', path: '/account/update', session: {}))
+
+      expect(OT).not_to have_received(:lw)
+    end
+
+    it 'logs the full request path including the URLMap SCRIPT_NAME prefix' do
+      # CsrfResponseHeader runs above the URLMap mount, so a rejected POST to a
+      # mounted app must log SCRIPT_NAME + PATH_INFO, not the prefix-stripped
+      # PATH_INFO alone.
+      allow(OT).to receive(:lw).and_call_original
+      env = env_for(method: 'POST', path: '/v2/account/update', session: {})
+      env['SCRIPT_NAME'] = '/api'
+      middleware.call(env)
+
+      expect(OT).to have_received(:lw).with(
+        a_string_matching(/CSRF 403/),
+        hash_including(path: '/api/v2/account/update')
+      )
     end
   end
 

--- a/spec/integration/all/csrf_enforcement_spec.rb
+++ b/spec/integration/all/csrf_enforcement_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe 'CSRF Enforcement', type: :integration do
         middleware_config = Onetime::Middleware::Security.middleware_components['AuthenticityToken']
 
         expect(middleware_config).not_to be_nil
-        expect(middleware_config[:klass]).to eq(Rack::Protection::AuthenticityToken)
+        expect(middleware_config[:klass]).to eq(Onetime::Middleware::InstrumentedAuthenticityToken)
+        expect(middleware_config[:klass]).to be < Rack::Protection::AuthenticityToken
         expect(middleware_config[:options][:authenticity_param]).to eq('shrimp')
       end
 
@@ -420,9 +421,10 @@ RSpec.describe 'CSRF Enforcement', type: :integration do
         # The header name is hardcoded in the gem as X-CSRF-Token
         # This is used by Axios interceptor in the frontend
 
-        # We verify by checking the middleware is the standard one
+        # We verify by checking the middleware is our subclass of the standard
+        # one (InstrumentedAuthenticityToken inherits the header handling).
         config = Onetime::Middleware::Security.middleware_components['AuthenticityToken']
-        expect(config[:klass]).to eq(Rack::Protection::AuthenticityToken)
+        expect(config[:klass]).to be < Rack::Protection::AuthenticityToken
       end
     end
   end
@@ -485,13 +487,14 @@ RSpec.describe 'CSRF Enforcement', type: :integration do
     # validates). CsrfResponseHeader captures presence BEFORE @app.call and logs
     # a discriminated warning. We drive the middleware directly with a stub app
     # so the branch is deterministic and does not depend on the full CSRF flow.
-    # Simulates AuthenticityToken rejecting the request: rack-protection sets the
-    # env attack marker (via the configured instrumenter) BEFORE it denies with a
-    # 403. CsrfResponseHeader keys its diagnostic on that marker, so the stub must
-    # set it to exercise the real code path.
+    # Simulates InstrumentedAuthenticityToken rejecting the request: its #deny
+    # stamps the rejection marker BEFORE returning a 403. CsrfResponseHeader keys
+    # its diagnostic on that marker, so the stub sets the SAME key to exercise the
+    # real code path. (The live-stack tripwire below proves the real middleware
+    # actually sets it.)
     let(:stub_403_app) do
       ->(env) {
-        env['rack.protection.attack'] = 'authenticitytoken'
+        env[Onetime::Middleware::InstrumentedAuthenticityToken::REJECTION_ENV_KEY] = true
         [403, {}, []]
       }
     end
@@ -557,8 +560,8 @@ RSpec.describe 'CSRF Enforcement', type: :integration do
 
     it 'does NOT log when a non-CSRF 403 is returned (no attack marker)' do
       # An app-level 403 (Onetime::Forbidden, EntitlementRequired,
-      # GuestRoutesDisabled) never sets env['rack.protection.attack']. Before the
-      # marker gate these were mis-logged as CSRF failures; now they are correctly
+      # GuestRoutesDisabled) never sets the rejection marker. Before the marker
+      # gate these were mis-logged as CSRF failures; now they are correctly
       # ignored so the CSRF diagnostic only fires on genuine CSRF rejections.
       plain_403_app   = ->(_env) { [403, {}, []] }
       plain_middleware = Onetime::Middleware::CsrfResponseHeader.new(plain_403_app)
@@ -580,6 +583,28 @@ RSpec.describe 'CSRF Enforcement', type: :integration do
       expect(OT).to have_received(:lw).with(
         a_string_matching(/CSRF 403/),
         hash_including(path: '/api/v2/account/update')
+      )
+    end
+
+    # TRIPWIRE: the tests above stub the marker. This one drives the FULL live
+    # stack (CsrfResponseHeader wrapping the real InstrumentedAuthenticityToken),
+    # so it fails loudly if the subclass's #deny stops setting the marker — e.g.
+    # if rack-protection changes its reaction dispatch and `default_reaction
+    # :deny` no longer rebinds, or if the subclass is dropped. Without this, a
+    # marker that silently stopped firing would leave every other test green.
+    it 'stamps the rejection marker through the REAL middleware stack on a genuine CSRF 403' do
+      allow(OT).to receive(:lw).and_call_original
+
+      # POST to a web route with no session and no shrimp -> the real
+      # AuthenticityToken denies with 403 via its (rebound) deny path.
+      response = @mock_request.post('/signin', {
+        params: { login: 'test@example.com', pass: 'password123' }
+      })
+
+      expect(response.status).to eq(403)
+      expect(OT).to have_received(:lw).with(
+        a_string_matching(/CSRF 403/),
+        hash_including(method: 'POST', path: '/signin')
       )
     end
   end

--- a/try/unit/session_scheme_try.rb
+++ b/try/unit/session_scheme_try.rb
@@ -43,9 +43,12 @@ end
 
 # Capture OT.lw so we can assert the Part 2 dropped-cookie warning fires.
 # OT.lw is a class method on Onetime; override it to append to a constant
-# array (closure-captured). Single-file tryout process, so no cross-file leak.
+# array (closure-captured). Tryouts runs every try/unit file in ONE process, so
+# this singleton override WOULD leak into later files; ORIGINAL_OT_LW below
+# preserves the real method and the final teardown restores it.
 CAPTURED_WARNINGS = []
 CAPTURED_PAYLOADS = []
+ORIGINAL_OT_LW = OT.method(:lw)
 OT.define_singleton_method(:lw) do |*msgs, **payload|
   CAPTURED_WARNINGS << msgs.join(' ')
   CAPTURED_PAYLOADS << payload
@@ -92,20 +95,22 @@ CAPTURED_WARNINGS.first.include?('ASSUME_HTTPS=true') &&
 #=> true
 
 ## (a4) ...and the warning carries the scheme-evidence snapshot as its own proof:
-## for a plain HTTP request every scheme signal is absent and the scheme is nil.
+## for a plain HTTP request every scheme signal is absent (X-Forwarded-Proto is
+## logged by value, so absent => nil) and the resolved scheme is nil.
 reset_warn_guard!
 @session.send(:security_matches?, request_for({}), { secure: true })
 CAPTURED_PAYLOADS.first
-#=> { rack_url_scheme: nil, x_forwarded_proto: false, forwarded: false, x_forwarded_ssl: false, https: false }
+#=> { rack_url_scheme: nil, x_forwarded_proto: nil, forwarded: false, x_forwarded_ssl: false, https: false }
 
-## (a5) ...and a present-but-non-https X-Forwarded-Proto is recorded as PRESENT
-## in the evidence (it reached Rack but did not carry https) => pinpoints the hop
-## without us reconstructing it. Rack still resolves scheme http, so ssl? false.
+## (a5) ...and a present-but-non-https X-Forwarded-Proto is recorded by VALUE in
+## the evidence ('http' reached Rack but did not carry https) => pinpoints the hop
+## AND the scheme it claimed, without us reconstructing it. Rack still resolves
+## scheme http, so ssl? false.
 reset_warn_guard!
 partial = request_for({ 'HTTP_X_FORWARDED_PROTO' => 'http' })
 @session.send(:security_matches?, partial, { secure: true })
 [partial.ssl?, CAPTURED_PAYLOADS.first[:x_forwarded_proto], CAPTURED_PAYLOADS.first[:https]]
-#=> [false, true, false]
+#=> [false, 'http', false]
 
 ## (b) assume_https ON upgrades the scheme (Part 1): plain HTTP env is marked HTTPS
 @env = {}
@@ -150,5 +155,19 @@ assume_https_middleware(true).call(env)
 request_for(env).ssl?
 #=> true
 
+## (e) THROTTLE: within SECURE_COOKIE_WARN_INTERVAL the dropped-cookie warning
+## fires at most once per process. Two back-to-back drops => exactly one captured
+## warning (the monotonic guard suppresses the second). Deterministic: no sleep,
+## the interval is 300s and the clock is monotonic, so both calls fall inside it.
+reset_warn_guard!
+2.times { @session.send(:security_matches?, request_for({}), { secure: true }) }
+CAPTURED_WARNINGS.length
+#=> 1
+
 # Restore the flag to its default OFF state for hygiene.
 (OT.conf['site']['network'] ||= {})['assume_https'] = false
+
+# Restore the real OT.lw. Tryouts shares one process across try/unit files, so
+# leaving the capturing override in place would silently swallow warnings emitted
+# by every later file.
+OT.define_singleton_method(:lw, &ORIGINAL_OT_LW)

--- a/try/unit/session_scheme_try.rb
+++ b/try/unit/session_scheme_try.rb
@@ -41,19 +41,6 @@ class MockApp
   end
 end
 
-# Capture OT.lw so we can assert the Part 2 dropped-cookie warning fires.
-# OT.lw is a class method on Onetime; override it to append to a constant
-# array (closure-captured). Tryouts runs every try/unit file in ONE process, so
-# this singleton override WOULD leak into later files; ORIGINAL_OT_LW below
-# preserves the real method and the final teardown restores it.
-CAPTURED_WARNINGS = []
-CAPTURED_PAYLOADS = []
-ORIGINAL_OT_LW = OT.method(:lw)
-OT.define_singleton_method(:lw) do |*msgs, **payload|
-  CAPTURED_WARNINGS << msgs.join(' ')
-  CAPTURED_PAYLOADS << payload
-end
-
 @app     = MockApp.new
 @secret  = SecureRandom.hex(64)
 @session = Session.new(@app, { secret: @secret, key: 'test.session', expire_after: 3600 })
@@ -75,6 +62,24 @@ end
 def assume_https_middleware(enabled)
   (OT.conf['site']['network'] ||= {})['assume_https'] = enabled
   Onetime::Middleware::AssumeHttps.new(MockApp.new)
+end
+
+# Install the OT.lw capture LAST in setup — after every fallible setup step
+# (notably Session.new above) has run — so no setup statement can raise while
+# this process-wide singleton override is in place. The ordering matters: a
+# failure during SETUP early-returns before the teardown block runs
+# (tryouts test_batch.rb), whereas a failure inside a *test* does NOT skip
+# teardown (tryouts wraps each test in a rescue and still runs the teardown
+# afterward). Installing here means the teardown below restores OT.lw on every
+# reachable path, so the capture cannot leak into later files in the shared
+# tryouts process. OT.lw is a class method; we append to closure-captured
+# constant arrays and keep ORIGINAL_OT_LW to restore the real method.
+CAPTURED_WARNINGS = []
+CAPTURED_PAYLOADS = []
+ORIGINAL_OT_LW = OT.method(:lw)
+OT.define_singleton_method(:lw) do |*msgs, **payload|
+  CAPTURED_WARNINGS << msgs.join(' ')
+  CAPTURED_PAYLOADS << payload
 end
 
 
@@ -180,5 +185,10 @@ CAPTURED_WARNINGS.length
 
 # Restore the real OT.lw. Tryouts shares one process across try/unit files, so
 # leaving the capturing override in place would silently swallow warnings emitted
-# by every later file.
+# by every later file. tryouts runs this teardown block even when a test above
+# raises (each test is wrapped in a rescue; the teardown runs unconditionally
+# after the test loop), so this restore is the framework-guaranteed "ensure" —
+# and the override is installed as the last setup step so setup cannot fail with
+# it in place. at_exit would be the wrong tool here: it fires at process exit,
+# AFTER later files have already run, so it could not prevent a cross-file leak.
 OT.define_singleton_method(:lw, &ORIGINAL_OT_LW)

--- a/try/unit/session_scheme_try.rb
+++ b/try/unit/session_scheme_try.rb
@@ -1,0 +1,154 @@
+# try/unit/session_scheme_try.rb
+#
+# frozen_string_literal: true
+
+#
+# Session Scheme / Secure-Cookie Test Suite (#3837, root cause of #3831)
+#
+# Covers the three-part fix for the silently-dropped Secure session cookie
+# behind a TLS-terminating proxy that does NOT forward X-Forwarded-Proto
+# (e.g. Cloudflare Tunnel):
+#
+#   Part 1: Onetime::Middleware::AssumeHttps upgrades the request scheme to
+#           HTTPS when site.network.assume_https is enabled (upgrade-only).
+#   Part 2: Onetime::Session#security_matches? emits a throttled warning when
+#           a Secure cookie is dropped because the request is seen as non-SSL.
+#
+# The unit under test for cookie persistence is Rack's own decision method
+# security_matches?: when it returns false, commit_session returns EARLY and
+# NO Set-Cookie is written. Asserting its boolean is the precise, deterministic
+# proxy for "session persisted / not persisted".
+
+# Force simple mode before boot (matches try/unit/session_try.rb).
+ENV['AUTHENTICATION_MODE'] = 'simple'
+
+require 'rack'
+
+require_relative '../support/test_helpers'
+
+require 'onetime'
+require 'onetime/session'
+require 'onetime/middleware/assume_https'
+
+OT.boot! :test, false
+
+Session = Onetime::Session
+
+# Minimal downstream app for driving the middleware.
+class MockApp
+  def call(_env)
+    [200, {}, ['OK']]
+  end
+end
+
+# Capture OT.lw so we can assert the Part 2 dropped-cookie warning fires.
+# OT.lw is a class method on Onetime; override it to append to a constant
+# array (closure-captured). Single-file tryout process, so no cross-file leak.
+CAPTURED_WARNINGS = []
+CAPTURED_PAYLOADS = []
+OT.define_singleton_method(:lw) do |*msgs, **payload|
+  CAPTURED_WARNINGS << msgs.join(' ')
+  CAPTURED_PAYLOADS << payload
+end
+
+@app     = MockApp.new
+@secret  = SecureRandom.hex(64)
+@session = Session.new(@app, { secret: @secret, key: 'test.session', expire_after: 3600 })
+
+# Build a Rack::Request from a raw env hash.
+def request_for(env = {})
+  Rack::Request.new(env)
+end
+
+# Reset the process-wide throttle guard so each warn-expecting case can fire.
+def reset_warn_guard!
+  Onetime::Session.secure_cookie_warned_at = nil
+  CAPTURED_WARNINGS.clear
+  CAPTURED_PAYLOADS.clear
+end
+
+# Set the AssumeHttps flag in the live config, then build a fresh middleware
+# (the flag is cached at #initialize). String keys: OT.conf is string-keyed.
+def assume_https_middleware(enabled)
+  (OT.conf['site']['network'] ||= {})['assume_https'] = enabled
+  Onetime::Middleware::AssumeHttps.new(MockApp.new)
+end
+
+
+## (a) HTTP request + secure:true + assume_https OFF => cookie NOT persisted
+## security_matches? returns false, so commit_session bails before Set-Cookie.
+reset_warn_guard!
+req = request_for({}) # plain HTTP: no HTTPS env, no XFP => ssl? false
+@session.send(:security_matches?, req, { secure: true })
+#=> false
+
+## (a2) ...and the Part 2 dropped-secure-cookie warning fired exactly once
+CAPTURED_WARNINGS.length
+#=> 1
+
+## (a3) ...and the warning message names the actionable remediation
+CAPTURED_WARNINGS.first.include?('ASSUME_HTTPS=true') &&
+  CAPTURED_WARNINGS.first.include?('secure cookie')
+#=> true
+
+## (a4) ...and the warning carries the scheme-evidence snapshot as its own proof:
+## for a plain HTTP request every scheme signal is absent and the scheme is nil.
+reset_warn_guard!
+@session.send(:security_matches?, request_for({}), { secure: true })
+CAPTURED_PAYLOADS.first
+#=> { rack_url_scheme: nil, x_forwarded_proto: false, forwarded: false, x_forwarded_ssl: false, https: false }
+
+## (a5) ...and a present-but-non-https X-Forwarded-Proto is recorded as PRESENT
+## in the evidence (it reached Rack but did not carry https) => pinpoints the hop
+## without us reconstructing it. Rack still resolves scheme http, so ssl? false.
+reset_warn_guard!
+partial = request_for({ 'HTTP_X_FORWARDED_PROTO' => 'http' })
+@session.send(:security_matches?, partial, { secure: true })
+[partial.ssl?, CAPTURED_PAYLOADS.first[:x_forwarded_proto], CAPTURED_PAYLOADS.first[:https]]
+#=> [false, true, false]
+
+## (b) assume_https ON upgrades the scheme (Part 1): plain HTTP env is marked HTTPS
+@env = {}
+assume_https_middleware(true).call(@env)
+[@env['HTTPS'], @env['rack.url_scheme']]
+#=> ['on', 'https']
+
+## (b2) ...so the upgraded request is now seen as SSL
+request_for(@env).ssl?
+#=> true
+
+## (b3) ...and security_matches? now returns true => session PERSISTS (Set-Cookie)
+reset_warn_guard!
+result = @session.send(:security_matches?, request_for(@env), { secure: true })
+[result, CAPTURED_WARNINGS.length]
+#=> [true, 0]
+
+## (c) REGRESSION PIN: X-Forwarded-Proto: https ALONE (no assume_https, no
+## trusted_proxy config) is honored natively by Rack => request seen as SSL.
+## Zero-config nginx/Caddy/ALB reverse-proxy behavior must not regress.
+request_for({ 'HTTP_X_FORWARDED_PROTO' => 'https' }).ssl?
+#=> true
+
+## (c2) ...and that cookie persists (security_matches? true, no warn)
+reset_warn_guard!
+xfp_req = request_for({ 'HTTP_X_FORWARDED_PROTO' => 'https' })
+result  = @session.send(:security_matches?, xfp_req, { secure: true })
+[result, CAPTURED_WARNINGS.length]
+#=> [true, 0]
+
+## (d) UPGRADE-ONLY: assume_https OFF => AssumeHttps is a strict no-op; a plain
+## HTTP request env is left completely untouched (no scheme mutation).
+env = {}
+assume_https_middleware(false).call(env)
+[env.key?('HTTPS'), env.key?('rack.url_scheme')]
+#=> [false, false]
+
+## (d2) UPGRADE-ONLY: assume_https ON never DOWNGRADES an already-HTTPS request
+## (X-Forwarded-Proto: https stays https; no rewrite/strip of forwarded scheme).
+env = { 'HTTP_X_FORWARDED_PROTO' => 'https' }
+assume_https_middleware(true).call(env)
+request_for(env).ssl?
+#=> true
+
+# Restore the flag to its default OFF state for hygiene.
+(OT.conf['site']['network'] ||= {})['assume_https'] = false

--- a/try/unit/session_scheme_try.rb
+++ b/try/unit/session_scheme_try.rb
@@ -95,12 +95,13 @@ CAPTURED_WARNINGS.first.include?('ASSUME_HTTPS=true') &&
 #=> true
 
 ## (a4) ...and the warning carries the scheme-evidence snapshot as its own proof:
-## for a plain HTTP request every scheme signal is absent (X-Forwarded-Proto is
-## logged by value, so absent => nil) and the resolved scheme is nil.
+## for a plain HTTP request every scheme signal is absent. The scheme tokens
+## (X-Forwarded-Proto, X-Forwarded-Ssl, HTTPS) are logged by value, so absent =>
+## nil; HTTP_FORWARDED stays presence-only (false) to keep client PII out.
 reset_warn_guard!
 @session.send(:security_matches?, request_for({}), { secure: true })
 CAPTURED_PAYLOADS.first
-#=> { rack_url_scheme: nil, x_forwarded_proto: nil, forwarded: false, x_forwarded_ssl: false, https: false }
+#=> { rack_url_scheme: nil, x_forwarded_proto: nil, forwarded: false, x_forwarded_ssl: nil, https: nil }
 
 ## (a5) ...and a present-but-non-https X-Forwarded-Proto is recorded by VALUE in
 ## the evidence ('http' reached Rack but did not carry https) => pinpoints the hop
@@ -110,7 +111,17 @@ reset_warn_guard!
 partial = request_for({ 'HTTP_X_FORWARDED_PROTO' => 'http' })
 @session.send(:security_matches?, partial, { secure: true })
 [partial.ssl?, CAPTURED_PAYLOADS.first[:x_forwarded_proto], CAPTURED_PAYLOADS.first[:https]]
-#=> [false, 'http', false]
+#=> [false, 'http', nil]
+
+## (a6) ...and an explicit HTTPS=off is recorded by VALUE, not erased to a
+## misleading presence boolean. Rack treats only HTTPS=='on' as ssl, so 'off'
+## still resolves ssl? false and we log `https: "off"` -- the honest evidence
+## that a proxy set the header to a non-https value (vs. nil = header absent).
+reset_warn_guard!
+off_req = request_for({ 'HTTPS' => 'off' })
+@session.send(:security_matches?, off_req, { secure: true })
+[off_req.ssl?, CAPTURED_PAYLOADS.first[:https]]
+#=> [false, 'off']
 
 ## (b) assume_https ON upgrades the scheme (Part 1): plain HTTP env is marked HTTPS
 @env = {}


### PR DESCRIPTION
## Summary

[#3837](https://github.com/onetimesecret/onetimesecret/issues/3837)

Behind a TLS-terminating proxy that presents the request to the origin as plain HTTP (notably Cloudflare Tunnel, which forwards no `X-Forwarded-Proto`), the production-forced `Secure` session cookie is **silently never written** — every request gets a fresh empty session, so the CSRF (`shrimp`) token minted on `GET` can never match on the follow-up `POST`, surfacing as a misleading `403 "attack prevented"`. That is the root cause of #3831.

The fix is scoped past the single trigger, because the same dead-end (session lost → confusing CSRF 403) has several causes and is currently undiagnosable from logs. Three parts, four commits:

**Part 1 — Unify scheme detection** (`4d4166f`, `15cc4d1`)
- New `Onetime::Middleware::AssumeHttps`, mounted **first** so the normalized scheme reaches every downstream middleware *and* the mounted Roda auth app. When `site.network.assume_https` / `ASSUME_HTTPS=true` is set and the request is not already SSL, it marks the request HTTPS (`env['HTTPS']='on'` **and** `env['rack.url_scheme']='https'`).
- **Upgrade-only, opt-in, off by default.** Never downgrades, never strips/rewrites forwarded headers, strict no-op when off — native Rack `X-Forwarded-Proto` handling for existing nginx/Caddy/ALB deployments is untouched (regression-pinned in the spec). Does not weaken the M-7 `secure` default.
- One source of truth: the normalized scheme corrects the secure-cookie gate, the auth app's `HttpOrigin` base_url (the *second*, independent scheme-dependent 403 on this flow), HSTS, redirects, and Rodauth email links in one shot.
- Rewires API v1's ad-hoc `secure?` (`apps/api/v1/controllers/helpers.rb`) from raw header-sniffing to `req.ssl?`, so it flows from the same source.

**Part 2 — Fail loud on a dropped session cookie** (`3f5358a`)
- Overrides `security_matches?` in `Onetime::Session` to emit a throttled, actionable warn when a `Secure` cookie is suppressed because the app sees the request as non-SSL — the path `rack-session` leaves completely silent. Turns a multi-request mystery into a five-minute diagnosis, and also catches the other triggers of the same symptom (Redis write failure, `SessionHijacking` resets).

**Part 3 — Distinguish continuity-loss from a real attack on CSRF 403** (`bfe81c8`)
- In `CsrfResponseHeader`, on unsafe methods only, captures whether `session['csrf']` existed **before** delegating down the stack (it must be captured pre-call — `AuthenticityToken#accepts?` mints the token when missing, erasing the evidence). On a 403, logs `session-continuity-break` (token absent/freshly minted → this class of bug) vs `token-mismatch` (token present, submitted value wrong → a genuine forged request). The identical logging of these two is exactly what misdirected both #2501 and #3831.

Full root-cause analysis, gem line-references (rack 3.2.6 / rack-session 2.1.2 / rack-protection 4.2.1), and acceptance criteria are in the issue.

## Related Issues

Fixes #3837
Root cause of #3831

Follow-up (non-blocking, does **not** gate this PR): [delano/otto#214](https://github.com/delano/otto/issues/214) — `Otto::Request#secure?` carries a divergent scheme opinion (ignores `rack.url_scheme`). This PR's normalizer deliberately sets **both** `env['HTTPS']='on'` and `env['rack.url_scheme']='https'`, and Otto's `secure?` honors `HTTPS=='on'`, so Otto agrees today. See the issue comment for recommended sequencing.

## Test Plan

- `try/unit/session_scheme_try.rb` (new) — 12 testcases: upgrade-only invariant, no-downgrade, off-by-default no-op, both scheme keys set, XFP-already-SSL no-op. ✅
- `spec/integration/all/csrf_enforcement_spec.rb` (extended) — 44 examples: `CsrfResponseHeader` positioning, `session-continuity-break` vs `token-mismatch` discrimination, CSRF round-trip guarantee preserved, existing zero-config XFP behavior regression-pinned. ✅
- Both suites green locally (0 failures).
