### PR TITLE
[#3840 Phase 0] Issuer-scoped SSO identity key — close cross-tenant takeover (#3838 item 5)

### DIFF
--- a/apps/web/auth/config/features/omniauth.rb
+++ b/apps/web/auth/config/features/omniauth.rb
@@ -52,6 +52,153 @@ module Auth::Config::Features
       configure_entra_id_provider(auth)
       configure_github_provider(auth)
       configure_google_provider(auth)
+
+      # Issuer-scoped identity lookup (#3840 Phase 0 / #3838 item 5).
+      configure_issuer_scoped_identities(auth)
+    end
+
+    # ========================================================================
+    # Issuer-scoped SSO identities — cross-tenant takeover fix (#3838 item 5)
+    # ========================================================================
+    #
+    # account_identities is keyed on (provider, issuer, uid). `provider` is the
+    # strategy NAME ('oidc', 'entra'), identical across every tenant using that
+    # strategy, so (provider, uid) alone let a second IdP asserting the same
+    # `sub` match the FIRST tenant's row → account takeover. Adding `issuer`
+    # makes colliding identities distinct rows.
+    #
+    # APPROACH A — platform grace + lazy upgrade. Pre-existing rows have the
+    # sentinel issuer '' (migration 008 backfills unconditionally; the real
+    # issuer is unreconstructable per #3838). The read path resolves it:
+    #   1. Exact lookup (provider, resolved_issuer, uid).
+    #   2. PLATFORM path only: fall back to the legacy (provider, '', uid) row
+    #      and lazily upgrade its issuer to resolved_issuer (self-heal).
+    #   3. TENANT path: issuer-exact ONLY — NEVER the '' fallback. The legacy
+    #      fallback on the tenant path IS the item-5 takeover.
+    #
+    # The pure decision functions below are driven verbatim by the auth-class
+    # helpers wired in configure_issuer_scoped_identities, and unit/integration
+    # tested directly.
+
+    # Sentinel issuer for identities with no known IdP issuer. ALWAYS '' — never
+    # nil (a NULL vs '' split breaks the (provider, issuer, uid) unique index).
+    ISSUER_SENTINEL = ''
+
+    # Resolve the issuer for the current callback.
+    # Precedence: strategy option (authoritative) > ENV['OIDC_ISSUER'] for OIDC
+    # > '' sentinel (non-OIDC / unknown).
+    #
+    # @param strategy_options [Hash, nil] omniauth_strategy&.options
+    # @param provider [String, Symbol] omniauth_provider (route name)
+    # @param oidc_route_name [String] configured OIDC route name (OIDC_ROUTE_NAME)
+    # @param env_oidc_issuer [String, nil] ENV['OIDC_ISSUER']
+    # @return [String] resolved issuer or the '' sentinel
+    def self.resolve_issuer(strategy_options:, provider:, oidc_route_name:, env_oidc_issuer:)
+      option_issuer = strategy_options && strategy_options[:issuer]
+      return option_issuer.to_s if option_issuer && !option_issuer.to_s.empty?
+
+      is_oidc = (strategy_options && strategy_options[:discovery] == true) ||
+                provider.to_s == oidc_route_name.to_s
+      return env_oidc_issuer.to_s if is_oidc && env_oidc_issuer && !env_oidc_issuer.to_s.empty?
+
+      ISSUER_SENTINEL
+    end
+
+    # Platform path == no validated tenant domain in session. The tenant hook
+    # (hooks/omniauth_tenant.rb) sets session[:validated_omniauth_domain_id] in
+    # before_omniauth_callback_route, which the gem runs BEFORE
+    # retrieve_omniauth_identity — so this signal is reliable at lookup time.
+    #
+    # @param validated_domain_id [Object] session[:validated_omniauth_domain_id]
+    # @return [Boolean] true when this is a platform (non-tenant) callback
+    def self.platform_path?(validated_domain_id)
+      validated_domain_id.nil? || validated_domain_id.to_s.empty?
+    end
+
+    # Issuer-scoped identity lookup (Approach A). Returns the identity row hash
+    # or nil. SECURITY-CRITICAL: the legacy '' fallback + lazy upgrade is gated
+    # on platform_path — it must NEVER run on a tenant callback.
+    #
+    # @param ds [Sequel::Dataset] omniauth_identities dataset
+    # @return [Hash, nil]
+    def self.lookup_identity(ds:, id_col:, provider_col:, uid_col:, issuer_col:,
+                             provider:, uid:, resolved_issuer:, platform_path:)
+      provider_s = provider.to_s
+
+      # 1. Exact lookup — (provider, resolved_issuer, uid).
+      exact = ds.first(provider_col => provider_s, issuer_col => resolved_issuer, uid_col => uid)
+      return exact if exact
+
+      # 2. Platform-path legacy grace + lazy upgrade ONLY. Never on tenant path.
+      #    When resolved_issuer is the sentinel, the exact query above already
+      #    covered the legacy '' row — there is nothing to upgrade TO, so bail
+      #    (also avoids a pointless '' -> '' write).
+      return nil unless platform_path
+      return nil if resolved_issuer == ISSUER_SENTINEL
+
+      legacy = ds.first(provider_col => provider_s, issuer_col => ISSUER_SENTINEL, uid_col => uid)
+      return nil unless legacy
+
+      # Lazy self-heal: bind the legacy row to the now-known issuer so future
+      # callbacks match exactly (and the '' row can never be re-graced).
+      ds.where(id_col => legacy[id_col]).update(issuer_col => resolved_issuer)
+      legacy[issuer_col] = resolved_issuer
+      legacy
+    end
+
+    # Wire the issuer-scoped lookup, resolver, and insert/update hashes onto the
+    # Rodauth auth class. The auth-class helpers are thin adapters over the pure
+    # module functions above.
+    def self.configure_issuer_scoped_identities(auth)
+      # rubocop:disable Lint/NestedMethodDefinition -- Rodauth's auth_class_eval pattern
+      auth.auth_class_eval do
+        # Resolver: strategy option > ENV OIDC_ISSUER (OIDC) > '' sentinel.
+        def resolved_issuer
+          Auth::Config::Features::OmniAuth.resolve_issuer(
+            strategy_options: omniauth_strategy&.options,
+            provider: omniauth_provider,
+            oidc_route_name: ENV.fetch('OIDC_ROUTE_NAME', 'oidc'),
+            env_oidc_issuer: ENV.fetch('OIDC_ISSUER', nil),
+          )
+        end
+
+        # Platform (non-tenant) callback gate. See hooks/omniauth_tenant.rb.
+        def omniauth_platform_path?
+          Auth::Config::Features::OmniAuth.platform_path?(session[:validated_omniauth_domain_id])
+        end
+      end
+      # rubocop:enable Lint/NestedMethodDefinition
+
+      # SECURITY-CRITICAL override: issuer-aware identity lookup.
+      auth.retrieve_omniauth_identity do
+        Auth::Config::Features::OmniAuth.lookup_identity(
+          ds: omniauth_identities_ds,
+          id_col: omniauth_identities_id_column,
+          provider_col: omniauth_identities_provider_column,
+          uid_col: omniauth_identities_uid_column,
+          issuer_col: :issuer,
+          provider: omniauth_provider,
+          uid: omniauth_uid,
+          resolved_issuer: resolved_issuer,
+          platform_path: omniauth_platform_path?,
+        )
+      end
+
+      # Persist the resolved issuer when a NEW identity row is created.
+      auth.omniauth_identity_insert_hash do
+        {
+          omniauth_identities_account_id_column => account_id,
+          omniauth_identities_provider_column => omniauth_provider.to_s,
+          omniauth_identities_uid_column => omniauth_uid,
+          issuer: resolved_issuer,
+        }
+      end
+
+      # On re-login, keep the row's issuer in sync with the resolved value
+      # (self-heals any row still carrying the '' sentinel on the platform path).
+      auth.omniauth_identity_update_hash do
+        { issuer: resolved_issuer }
+      end
     end
 
     # Returns names of env vars that are nil or empty.

--- a/apps/web/auth/config/features/omniauth.rb
+++ b/apps/web/auth/config/features/omniauth.rb
@@ -85,17 +85,34 @@ module Auth::Config::Features
     ISSUER_SENTINEL = ''
 
     # Resolve the issuer for the current callback.
-    # Precedence: strategy option (authoritative) > ENV['OIDC_ISSUER'] for OIDC
-    # > '' sentinel (non-OIDC / unknown).
+    # Precedence:
+    #   1. strategy option :issuer — OIDC discovery populates and validates this.
+    #   2. token issuer (`iss`) from the auth hash's extra.raw_info — id-token
+    #      providers (Entra ID) expose the validated `iss` claim here. OIDC never
+    #      reaches this branch (its issuer resolves at #1); its raw_info is the
+    #      UserInfo response, which per OIDC core §5.3.2 may omit `iss`.
+    #   3. ENV['OIDC_ISSUER'] for the OIDC route.
+    #   4. '' sentinel (OAuth2 providers with no issuer concept: GitHub/Google).
+    #
+    # Entra matters here: its strategy exposes :tenant_id, not :issuer, so #1
+    # misses and without #2 every Entra tenant would collapse to '' —
+    # reintroducing the item-5 collision for `ignore_tid: true` configs (where
+    # the Entra uid degrades from `tid+oid` to `oid` alone). Scoping on the
+    # validated `iss` makes the security property explicit rather than an
+    # implicit consequence of the gem's uid composition.
     #
     # @param strategy_options [Hash, nil] omniauth_strategy&.options
     # @param provider [String, Symbol] omniauth_provider (route name)
     # @param oidc_route_name [String] configured OIDC route name (OIDC_ROUTE_NAME)
     # @param env_oidc_issuer [String, nil] ENV['OIDC_ISSUER']
+    # @param token_issuer [String, nil] validated `iss` claim from extra.raw_info
     # @return [String] resolved issuer or the '' sentinel
-    def self.resolve_issuer(strategy_options:, provider:, oidc_route_name:, env_oidc_issuer:)
+    def self.resolve_issuer(strategy_options:, provider:, oidc_route_name:, env_oidc_issuer:,
+                            token_issuer: nil)
       option_issuer = strategy_options && strategy_options[:issuer]
       return option_issuer.to_s if option_issuer && !option_issuer.to_s.empty?
+
+      return token_issuer.to_s if token_issuer && !token_issuer.to_s.empty?
 
       is_oidc = (strategy_options && strategy_options[:discovery] == true) ||
                 provider.to_s == oidc_route_name.to_s
@@ -152,17 +169,36 @@ module Auth::Config::Features
     def self.configure_issuer_scoped_identities(auth)
       # rubocop:disable Lint/NestedMethodDefinition -- Rodauth's auth_class_eval pattern
       auth.auth_class_eval do
-        # Resolver: strategy option > ENV OIDC_ISSUER (OIDC) > '' sentinel.
+        # Resolver: strategy option > token `iss` (Entra) > ENV OIDC_ISSUER > ''.
         def resolved_issuer
           Auth::Config::Features::OmniAuth.resolve_issuer(
             strategy_options: omniauth_strategy&.options,
             provider: omniauth_provider,
             oidc_route_name: ENV.fetch('OIDC_ROUTE_NAME', 'oidc'),
             env_oidc_issuer: ENV.fetch('OIDC_ISSUER', nil),
+            token_issuer: omniauth_token_issuer,
           )
         end
 
-        # Platform (non-tenant) callback gate. See hooks/omniauth_tenant.rb.
+        # The validated `iss` claim from the auth hash's extra.raw_info, if the
+        # strategy exposes one (Entra ID's raw_info is the decoded id_token). Nil
+        # for OIDC (raw_info is the UserInfo response) and OAuth2 (no id_token).
+        # Read defensively — extra/raw_info may be a plain Hash or an AuthHash.
+        def omniauth_token_issuer
+          extra = omniauth_extra
+          return nil unless extra
+
+          raw = extra['raw_info'] || extra[:raw_info]
+          return nil unless raw
+
+          raw['iss'] || raw[:iss]
+        end
+
+        # Platform (non-tenant) callback gate. The tenant hook
+        # (hooks/omniauth_tenant.rb) sets session[:validated_omniauth_domain_id]
+        # in before_omniauth_callback_route; rodauth-omniauth-0.6.2 runs that
+        # hook (features/omniauth.rb:53 handle_omniauth_callback) BEFORE
+        # retrieve_omniauth_identity (:62), so the signal is reliable here.
         def omniauth_platform_path?
           Auth::Config::Features::OmniAuth.platform_path?(session[:validated_omniauth_domain_id])
         end
@@ -170,15 +206,21 @@ module Auth::Config::Features
       # rubocop:enable Lint/NestedMethodDefinition
 
       # SECURITY-CRITICAL override: issuer-aware identity lookup.
-      auth.retrieve_omniauth_identity do
+      #
+      # `retrieve_omniauth_identity` is declared via auth_private_methods, so this
+      # DSL block becomes the body of `_retrieve_omniauth_identity(provider, uid)`
+      # — Rodauth invokes it with the two positional args (omniauth_provider,
+      # omniauth_uid). The block MUST accept them or every callback 500s with
+      # ArgumentError (wrong number of arguments).
+      auth.retrieve_omniauth_identity do |provider, uid|
         Auth::Config::Features::OmniAuth.lookup_identity(
           ds: omniauth_identities_ds,
           id_col: omniauth_identities_id_column,
           provider_col: omniauth_identities_provider_column,
           uid_col: omniauth_identities_uid_column,
           issuer_col: :issuer,
-          provider: omniauth_provider,
-          uid: omniauth_uid,
+          provider: provider,
+          uid: uid,
           resolved_issuer: resolved_issuer,
           platform_path: omniauth_platform_path?,
         )

--- a/apps/web/auth/config/features/omniauth.rb
+++ b/apps/web/auth/config/features/omniauth.rb
@@ -199,6 +199,13 @@ module Auth::Config::Features
         # in before_omniauth_callback_route; rodauth-omniauth-0.6.2 runs that
         # hook (features/omniauth.rb:53 handle_omniauth_callback) BEFORE
         # retrieve_omniauth_identity (:62), so the signal is reliable here.
+        #
+        # VERSION-PINNED INVARIANT: this ordering (before_omniauth_callback_route
+        # runs before retrieve_omniauth_identity) is what makes the security gate
+        # sound. It holds in rodauth-omniauth >= 0.6.2; RE-VERIFY it whenever the
+        # gem is upgraded — if a later version reorders the callback, tenant
+        # callbacks could reach the '' legacy fallback and re-open the item-5
+        # takeover.
         def omniauth_platform_path?
           Auth::Config::Features::OmniAuth.platform_path?(session[:validated_omniauth_domain_id])
         end
@@ -305,6 +312,15 @@ module Auth::Config::Features
       #   - Auth hash: { provider: 'entra', ... }
       #   - DB: account_identities.provider = 'entra'
       # Without name: override, omniauth-entra-id defaults to 'entra_id'.
+      #
+      # SECURITY — dependency on issuer-scoping (#3840 Phase 0 / #3838 item 5):
+      # By default omniauth-entra-id composes the uid as `tid+oid` (tenant id +
+      # object id), so it is unique across tenants on its own. A deployer who
+      # sets `ignore_tid: true` degrades the uid to `oid` ALONE — the same oid
+      # can then recur across tenants. Cross-tenant safety in that config relies
+      # ENTIRELY on the (provider, issuer, uid) key: resolve_issuer scopes the
+      # row by the validated `iss` claim (see omniauth_token_issuer). If you add
+      # `ignore_tid: true` here, do NOT weaken that issuer resolution.
       tenant_id     = ENV.fetch('ENTRA_TENANT_ID', nil)
       client_id     = ENV.fetch('ENTRA_CLIENT_ID', nil)
       client_secret = ENV.fetch('ENTRA_CLIENT_SECRET', nil)

--- a/apps/web/auth/migrations/008_issuer_scoped_identities.rb
+++ b/apps/web/auth/migrations/008_issuer_scoped_identities.rb
@@ -15,8 +15,8 @@
 # Existing rows CANNOT be given a real issuer — #3838 bars reconstructing it
 # from logs, and it is not stored anywhere on the row. So EVERY pre-existing row
 # is backfilled to the sentinel issuer '' (empty string, NEVER NULL — a NULL vs
-# '' split would break the unique index). The read path (see
-# config/features/omniauth.rb#lookup_identity) then handles the sentinel:
+# '' split would break the unique index). The read path (see lookup_identity
+# in apps/web/auth/config/features/omniauth.rb) then handles the sentinel:
 #   - PLATFORM callbacks fall back to the '' row and lazily upgrade its issuer
 #     to the resolved value (self-heal).
 #   - TENANT callbacks are issuer-exact ONLY and never touch the '' row — the
@@ -39,12 +39,19 @@ Sequel.migration do
     case database_type
     when :sqlite
       # SQLite cannot drop an inline UNIQUE constraint in place; Sequel emulates
-      # by rebuilding the table. There is exactly one unique constraint on this
-      # table, so dropping "the unique constraint" is unambiguous. The rebuild
-      # preserves the account_id index.
+      # by rebuilding the table. A fresh 006 has exactly one unique constraint
+      # (the inline (provider, uid)), so dropping "the unique constraint" is
+      # unambiguous. The rebuild preserves the account_id index.
       alter_table(:account_identities) do
         drop_constraint(nil, type: :unique)
       end
+      # A prior `down` of THIS migration restores (provider, uid) as a STANDALONE
+      # unique INDEX, not an inline constraint. drop_constraint above rebuilds the
+      # table but cannot see that index — it re-creates it. Drop it idempotently
+      # so an up->down->up cycle can't leave a stale (provider, uid) unique that
+      # would silently defeat issuer-scoping (verified: without this, colliding
+      # rows are rejected after a re-migration). Mirrors the postgres branch.
+      run 'DROP INDEX IF EXISTS account_identities_provider_uid_index'
     when :postgres
       # Drop the (provider, uid) uniqueness idempotently. Migration 006 created
       # it as an unnamed table-level UNIQUE constraint, which PostgreSQL names
@@ -83,8 +90,9 @@ Sequel.migration do
     # NOTE: uniqueness is restored as a standalone unique INDEX, not the original
     # unnamed table-level UNIQUE constraint from migration 006. For PostgreSQL and
     # SQLite the two are functionally interchangeable for Rodauth's uniqueness
-    # check, and the paired `up` drops BOTH forms (IF EXISTS on postgres) so an
-    # up->down->up cycle stays consistent.
+    # check, and the paired `up` idempotently drops BOTH forms (inline constraint
+    # and standalone index) on each backend, so an up->down->up cycle stays
+    # consistent.
     #
     # A rollback WILL fail if production already holds two identities that share
     # (provider, uid) but differ by issuer — precisely the collisions this schema

--- a/apps/web/auth/migrations/008_issuer_scoped_identities.rb
+++ b/apps/web/auth/migrations/008_issuer_scoped_identities.rb
@@ -45,9 +45,19 @@ Sequel.migration do
       alter_table(:account_identities) do
         drop_constraint(nil, type: :unique)
       end
+    when :postgres
+      # Drop the (provider, uid) uniqueness idempotently. Migration 006 created
+      # it as an unnamed table-level UNIQUE constraint, which PostgreSQL names
+      # deterministically `<table>_<cols>_key`. IF EXISTS also tolerates the
+      # shape a prior `down` of THIS migration leaves behind (a standalone unique
+      # INDEX rather than a constraint), so up->down->up cycles in dev/CI don't
+      # fail on a missing constraint.
+      run 'ALTER TABLE account_identities DROP CONSTRAINT IF EXISTS account_identities_provider_uid_key'
+      run 'DROP INDEX IF EXISTS account_identities_provider_uid_index'
     else
-      # PostgreSQL/MySQL/MSSQL: the constraint from `unique [:provider, :uid]`
-      # is named deterministically by Sequel as "<table>_<cols>_key".
+      # Best-effort for other backends (MySQL/MSSQL). These name the constraint
+      # by their own convention, which may differ from Sequel's default — this
+      # project only ships PostgreSQL and SQLite, so those paths are unverified.
       alter_table(:account_identities) do
         drop_constraint(:account_identities_provider_uid_key, type: :unique)
       end
@@ -66,12 +76,28 @@ Sequel.migration do
   end
 
   down do
-    # Reverse exactly: drop the composite unique, restore (provider, uid)
-    # uniqueness, then drop the column. The composite index references :issuer,
-    # so it must be dropped before the column.
+    # Reverse: drop the composite unique, restore (provider, uid) uniqueness,
+    # then drop the column. The composite index references :issuer, so it must be
+    # dropped before the column.
+    #
+    # NOTE: uniqueness is restored as a standalone unique INDEX, not the original
+    # unnamed table-level UNIQUE constraint from migration 006. For PostgreSQL and
+    # SQLite the two are functionally interchangeable for Rodauth's uniqueness
+    # check, and the paired `up` drops BOTH forms (IF EXISTS on postgres) so an
+    # up->down->up cycle stays consistent.
+    #
+    # A rollback WILL fail if production already holds two identities that share
+    # (provider, uid) but differ by issuer — precisely the collisions this schema
+    # was introduced to admit. That data cannot be collapsed back onto a unique
+    # (provider, uid) key; reconcile such rows manually before rolling back.
     # rubocop:disable Sequel/ConcurrentIndex
-    alter_table(:account_identities) do
-      drop_index [:provider, :issuer, :uid]
+    case database_type
+    when :postgres
+      run 'DROP INDEX IF EXISTS account_identities_provider_issuer_uid_index'
+    else
+      alter_table(:account_identities) do
+        drop_index [:provider, :issuer, :uid]
+      end
     end
 
     alter_table(:account_identities) do

--- a/apps/web/auth/migrations/008_issuer_scoped_identities.rb
+++ b/apps/web/auth/migrations/008_issuer_scoped_identities.rb
@@ -62,9 +62,12 @@ Sequel.migration do
       run 'ALTER TABLE account_identities DROP CONSTRAINT IF EXISTS account_identities_provider_uid_key'
       run 'DROP INDEX IF EXISTS account_identities_provider_uid_index'
     else
-      # Best-effort for other backends (MySQL/MSSQL). These name the constraint
-      # by their own convention, which may differ from Sequel's default — this
-      # project only ships PostgreSQL and SQLite, so those paths are unverified.
+      # MySQL/MSSQL are NOT supported deployment targets — this project ships
+      # only PostgreSQL and SQLite. This branch is best-effort and UNVERIFIED:
+      # those backends name the 006 constraint by their own convention, which
+      # may differ from the PostgreSQL-style name assumed here, so drop_constraint
+      # can miss and abort the migration. If you add such a target, verify this
+      # path (and the paired `down`) against its real constraint name first.
       alter_table(:account_identities) do
         drop_constraint(:account_identities_provider_uid_key, type: :unique)
       end

--- a/apps/web/auth/migrations/008_issuer_scoped_identities.rb
+++ b/apps/web/auth/migrations/008_issuer_scoped_identities.rb
@@ -1,0 +1,86 @@
+# apps/web/auth/migrations/008_issuer_scoped_identities.rb
+#
+# frozen_string_literal: true
+
+# Issuer-scoped SSO identities (#3840 Phase 0 / #3838 item 5).
+#
+# WHY: account_identities was uniquely keyed on (provider, uid). `provider` is
+# the strategy NAME ('oidc', 'entra') — identical across every tenant that uses
+# that strategy via CustomDomain::SsoConfig. Two different IdPs (issuers) can
+# each assert the same `sub` (uid). Under the old key the second IdP's callback
+# matched the FIRST tenant's row → cross-tenant account takeover. Re-keying on
+# (provider, issuer, uid) makes the two colliding identities distinct rows.
+#
+# BACKFILL POLICY (Approach A — platform grace + lazy upgrade):
+# Existing rows CANNOT be given a real issuer — #3838 bars reconstructing it
+# from logs, and it is not stored anywhere on the row. So EVERY pre-existing row
+# is backfilled to the sentinel issuer '' (empty string, NEVER NULL — a NULL vs
+# '' split would break the unique index). The read path (see
+# config/features/omniauth.rb#lookup_identity) then handles the sentinel:
+#   - PLATFORM callbacks fall back to the '' row and lazily upgrade its issuer
+#     to the resolved value (self-heal).
+#   - TENANT callbacks are issuer-exact ONLY and never touch the '' row — the
+#     legacy fallback on the tenant path IS the item-5 takeover.
+# The backfill is therefore unconditional '' and deliberately does NOT read
+# ENV['OIDC_ISSUER']; issuer reconstruction happens at read time, not here.
+
+Sequel.migration do
+  up do
+    # 1. Add the issuer column NOT NULL with the '' sentinel default. On every
+    #    supported backend, ADD COLUMN ... DEFAULT '' backfills existing rows to
+    #    '' in a single step (the universal sentinel required by Approach A).
+    alter_table(:account_identities) do
+      add_column :issuer, String, null: false, default: ''
+    end
+
+    # 2. Swap the uniqueness key (provider, uid) -> (provider, issuer, uid).
+    #    006 created `unique [:provider, :uid]` as an UNNAMED table-level UNIQUE
+    #    constraint (not a standalone index), so removal differs by backend.
+    case database_type
+    when :sqlite
+      # SQLite cannot drop an inline UNIQUE constraint in place; Sequel emulates
+      # by rebuilding the table. There is exactly one unique constraint on this
+      # table, so dropping "the unique constraint" is unambiguous. The rebuild
+      # preserves the account_id index.
+      alter_table(:account_identities) do
+        drop_constraint(nil, type: :unique)
+      end
+    else
+      # PostgreSQL/MySQL/MSSQL: the constraint from `unique [:provider, :uid]`
+      # is named deterministically by Sequel as "<table>_<cols>_key".
+      alter_table(:account_identities) do
+        drop_constraint(:account_identities_provider_uid_key, type: :unique)
+      end
+    end
+
+    # CONCURRENTLY is intentionally not used: the migration runs in one
+    # transaction (CONCURRENTLY is forbidden there) and SQLite has no such
+    # option. account_identities holds SSO users only, so the brief lock is
+    # negligible. Sequel names the index "<table>_<cols>_index" by convention,
+    # which `down` drops by columns.
+    # rubocop:disable Sequel/ConcurrentIndex
+    alter_table(:account_identities) do
+      add_index [:provider, :issuer, :uid], unique: true
+    end
+    # rubocop:enable Sequel/ConcurrentIndex
+  end
+
+  down do
+    # Reverse exactly: drop the composite unique, restore (provider, uid)
+    # uniqueness, then drop the column. The composite index references :issuer,
+    # so it must be dropped before the column.
+    # rubocop:disable Sequel/ConcurrentIndex
+    alter_table(:account_identities) do
+      drop_index [:provider, :issuer, :uid]
+    end
+
+    alter_table(:account_identities) do
+      add_index [:provider, :uid], unique: true
+    end
+    # rubocop:enable Sequel/ConcurrentIndex
+
+    alter_table(:account_identities) do
+      drop_column :issuer
+    end
+  end
+end

--- a/apps/web/auth/spec/config/hooks/omniauth_spec.rb
+++ b/apps/web/auth/spec/config/hooks/omniauth_spec.rb
@@ -682,4 +682,160 @@ RSpec.describe 'OmniAuth hooks' do
   # - Organization creation with is_default flag
   # - Idempotency guarantees
   #
+
+  # ==========================================================================
+  # Issuer-scoped identity lookup (#3840 Phase 0 / #3838 item 5)
+  # ==========================================================================
+  #
+  # Unlike the pure-logic REIMPLEMENTATIONS elsewhere in this file, this block
+  # drives the SHIPPED production functions in
+  # Auth::Config::Features::OmniAuth against an in-memory SQLite dataset (real
+  # Sequel queries + a real UPDATE for the lazy upgrade). This is the item-5
+  # cross-tenant takeover regression coverage.
+  describe 'issuer-scoped identity lookup (Auth::Config::Features::OmniAuth)' do
+    before(:all) do
+      require 'sequel'
+      # Drives real code; the feature file only pulls in OmniAuth strategy gems
+      # at require time (no app boot, no DB connection).
+      require_relative '../../../config/features/omniauth'
+    end
+
+    let(:feature) { Auth::Config::Features::OmniAuth }
+
+    # Fresh in-memory schema mirroring migration 008 / create_omniauth_tables.
+    let(:db) do
+      d = Sequel.sqlite
+      d.create_table(:account_identities) do
+        primary_key :id, type: :Bignum
+        Integer :account_id, null: false
+        String :provider, null: false
+        String :issuer, null: false, default: ''
+        String :uid, null: false
+        index %i[provider issuer uid], unique: true
+      end
+      d
+    end
+    let(:ds) { db[:account_identities] }
+    let(:cols) { { id_col: :id, provider_col: :provider, uid_col: :uid, issuer_col: :issuer } }
+
+    describe '.resolve_issuer' do
+      it 'prefers the strategy option issuer (authoritative)' do
+        result = feature.resolve_issuer(
+          strategy_options: { issuer: 'https://idp-a.example' },
+          provider: 'oidc', oidc_route_name: 'oidc', env_oidc_issuer: 'https://env.example',
+        )
+        expect(result).to eq('https://idp-a.example')
+      end
+
+      it 'falls back to ENV OIDC_ISSUER for a discovery (OIDC) strategy' do
+        result = feature.resolve_issuer(
+          strategy_options: { discovery: true },
+          provider: 'oidc', oidc_route_name: 'oidc', env_oidc_issuer: 'https://env.example',
+        )
+        expect(result).to eq('https://env.example')
+      end
+
+      it 'falls back to ENV OIDC_ISSUER when provider matches the OIDC route name' do
+        result = feature.resolve_issuer(
+          strategy_options: nil,
+          provider: 'oidc', oidc_route_name: 'oidc', env_oidc_issuer: 'https://env.example',
+        )
+        expect(result).to eq('https://env.example')
+      end
+
+      it 'returns the "" sentinel for non-OIDC providers (never nil)' do
+        result = feature.resolve_issuer(
+          strategy_options: {},
+          provider: 'github', oidc_route_name: 'oidc', env_oidc_issuer: 'https://env.example',
+        )
+        expect(result).to eq('')
+      end
+
+      it 'returns the "" sentinel when no issuer is resolvable' do
+        result = feature.resolve_issuer(
+          strategy_options: { issuer: '' },
+          provider: 'github', oidc_route_name: 'oidc', env_oidc_issuer: nil,
+        )
+        expect(result).to eq('')
+      end
+    end
+
+    describe '.platform_path?' do
+      it 'is true when no validated tenant domain is present' do
+        expect(feature.platform_path?(nil)).to be true
+        expect(feature.platform_path?('')).to be true
+      end
+
+      it 'is false on a tenant callback (validated domain present)' do
+        expect(feature.platform_path?('domain-123')).to be false
+      end
+    end
+
+    describe '.lookup_identity' do
+      # ITEM-5 REGRESSION: two IdPs (issuers) assert the same sub under the same
+      # strategy name. Under the old (provider, uid) key the second collided
+      # with the first → takeover. With (provider, issuer, uid) they are two
+      # distinct rows and the lookup discriminates by issuer.
+      context 'same (provider, uid) with different issuer (item-5)' do
+        before do
+          ds.insert(account_id: 10, provider: 'oidc', issuer: 'https://idp-a', uid: 'sub-shared')
+          ds.insert(account_id: 20, provider: 'oidc', issuer: 'https://idp-b', uid: 'sub-shared')
+        end
+
+        it 'stores them as two distinct rows (composite unique permits)' do
+          expect(ds.count).to eq(2)
+        end
+
+        it 'rejects a true duplicate (provider, issuer, uid)' do
+          expect do
+            ds.insert(account_id: 99, provider: 'oidc', issuer: 'https://idp-a', uid: 'sub-shared')
+          end.to raise_error(Sequel::UniqueConstraintViolation)
+        end
+
+        it 'resolves issuer-A to account 10 and issuer-B to account 20 (no cross-bind)' do
+          a = feature.lookup_identity(ds: ds, **cols, provider: 'oidc', uid: 'sub-shared',
+                                                      resolved_issuer: 'https://idp-a', platform_path: false)
+          b = feature.lookup_identity(ds: ds, **cols, provider: 'oidc', uid: 'sub-shared',
+                                                      resolved_issuer: 'https://idp-b', platform_path: false)
+          expect(a[:account_id]).to eq(10)
+          expect(b[:account_id]).to eq(20)
+          expect(a[:account_id]).not_to eq(b[:account_id])
+        end
+      end
+
+      context 'platform grace + lazy upgrade' do
+        before { ds.insert(account_id: 30, provider: 'oidc', issuer: '', uid: 'legacy-sub') }
+
+        it 'matches the legacy "" row and upgrades its issuer in the DB' do
+          result = feature.lookup_identity(ds: ds, **cols, provider: 'oidc', uid: 'legacy-sub',
+                                                           resolved_issuer: 'https://real-idp', platform_path: true)
+          expect(result[:account_id]).to eq(30)
+          expect(result[:issuer]).to eq('https://real-idp')
+          expect(ds.first(account_id: 30)[:issuer]).to eq('https://real-idp')
+        end
+      end
+
+      context 'tenant path: issuer-exact only (no grace)' do
+        before { ds.insert(account_id: 40, provider: 'oidc', issuer: '', uid: 'legacy-sub-2') }
+
+        it 'does NOT match the legacy "" row and leaves it untouched' do
+          result = feature.lookup_identity(ds: ds, **cols, provider: 'oidc', uid: 'legacy-sub-2',
+                                                           resolved_issuer: 'https://tenant-idp', platform_path: false)
+          expect(result).to be_nil
+          expect(ds.first(account_id: 40)[:issuer]).to eq('')
+        end
+      end
+
+      context 'sentinel issuer (non-OIDC) with a legacy "" row on the platform path' do
+        before { ds.insert(account_id: 50, provider: 'github', issuer: '', uid: 'gh-1') }
+
+        it 'matches via the exact query without a pointless "" -> "" upgrade' do
+          result = feature.lookup_identity(ds: ds, **cols, provider: 'github', uid: 'gh-1',
+                                                           resolved_issuer: '', platform_path: true)
+          expect(result[:account_id]).to eq(50)
+          expect(ds.first(account_id: 50)[:issuer]).to eq('')
+        end
+      end
+    end
+  end
 end

--- a/apps/web/auth/spec/config/hooks/omniauth_spec.rb
+++ b/apps/web/auth/spec/config/hooks/omniauth_spec.rb
@@ -758,6 +758,45 @@ RSpec.describe 'OmniAuth hooks' do
         )
         expect(result).to eq('')
       end
+
+      # Entra ID exposes :tenant_id (not :issuer) in strategy options, so the
+      # option branch misses; the validated `iss` claim from the id-token
+      # (extra.raw_info) is the tenant-distinguishing issuer. Without this,
+      # every Entra tenant collapses to '' (#3838 item 5 regression).
+      it 'uses the token iss claim when the strategy exposes no issuer option (Entra)' do
+        result = feature.resolve_issuer(
+          strategy_options: { tenant_id: 'tenant-guid' },
+          provider: 'entra', oidc_route_name: 'oidc', env_oidc_issuer: nil,
+          token_issuer: 'https://login.microsoftonline.com/tenant-guid/v2.0',
+        )
+        expect(result).to eq('https://login.microsoftonline.com/tenant-guid/v2.0')
+      end
+
+      it 'distinguishes two Entra tenants by their token iss' do
+        opts = { strategy_options: { tenant_id: 'x' }, provider: 'entra',
+                 oidc_route_name: 'oidc', env_oidc_issuer: nil }
+        a = feature.resolve_issuer(**opts, token_issuer: 'https://login.microsoftonline.com/aaa/v2.0')
+        b = feature.resolve_issuer(**opts, token_issuer: 'https://login.microsoftonline.com/bbb/v2.0')
+        expect(a).not_to eq(b)
+      end
+
+      it 'prefers the strategy option issuer over the token iss' do
+        result = feature.resolve_issuer(
+          strategy_options: { issuer: 'https://discovery.example' },
+          provider: 'oidc', oidc_route_name: 'oidc', env_oidc_issuer: nil,
+          token_issuer: 'https://token.example',
+        )
+        expect(result).to eq('https://discovery.example')
+      end
+
+      it 'ignores a blank token iss and falls through to the sentinel' do
+        result = feature.resolve_issuer(
+          strategy_options: { tenant_id: 'x' },
+          provider: 'entra', oidc_route_name: 'oidc', env_oidc_issuer: nil,
+          token_issuer: '',
+        )
+        expect(result).to eq('')
+      end
     end
 
     describe '.platform_path?' do

--- a/apps/web/auth/spec/integration/full/migrations/migrations_postgres_spec.rb
+++ b/apps/web/auth/spec/integration/full/migrations/migrations_postgres_spec.rb
@@ -481,18 +481,7 @@ RSpec.describe 'Auth::Migrator PostgreSQL Integration', :postgres_database do
   # constraint AND that standalone index — otherwise a rollback+re-apply leaves a
   # stale (provider, uid) unique that silently re-imposes the pre-issuer key.
   describe 'issuer-scoped migration survives an up->down->up cycle' do
-    # Derive the version from the filename so a later renumber doesn't rot this.
-    let(:issuer_migration_version) do
-      file = Dir.glob(File.join(migrations_dir, '[0-9]*issuer_scoped*.rb')).first
-      raise 'issuer-scoped migration not found' unless file
-
-      File.basename(file)[/\A(\d+)/, 1].to_i
-    end
-
-    def insert_account(db, email)
-      db[:accounts].insert(email: email, status_id: 2, external_id: SecureRandom.uuid)
-    end
-
+    # issuer_migration_version and insert_account come from MigrationTestHelpers.
     it 'preserves (provider, issuer, uid) uniqueness after re-migrating' do
       v = issuer_migration_version
 

--- a/apps/web/auth/spec/integration/full/migrations/migrations_postgres_spec.rb
+++ b/apps/web/auth/spec/integration/full/migrations/migrations_postgres_spec.rb
@@ -472,4 +472,55 @@ RSpec.describe 'Auth::Migrator PostgreSQL Integration', :postgres_database do
       end.not_to raise_error
     end
   end
+
+  # Regression (#3840 Phase 0 / #3838 item 5): mirror of the SQLite up->down->up
+  # guard for the PRODUCTION backend. The issuer-scoped migration re-keys
+  # account_identities to (provider, issuer, uid) to close a cross-tenant SSO
+  # takeover. Its `down` restores (provider, uid) uniqueness as a standalone
+  # index, and its `up` must idempotently drop BOTH the original unnamed
+  # constraint AND that standalone index — otherwise a rollback+re-apply leaves a
+  # stale (provider, uid) unique that silently re-imposes the pre-issuer key.
+  describe 'issuer-scoped migration survives an up->down->up cycle' do
+    # Derive the version from the filename so a later renumber doesn't rot this.
+    let(:issuer_migration_version) do
+      file = Dir.glob(File.join(migrations_dir, '[0-9]*issuer_scoped*.rb')).first
+      raise 'issuer-scoped migration not found' unless file
+
+      File.basename(file)[/\A(\d+)/, 1].to_i
+    end
+
+    def insert_account(db, email)
+      db[:accounts].insert(email: email, status_id: 2, external_id: SecureRandom.uuid)
+    end
+
+    it 'preserves (provider, issuer, uid) uniqueness after re-migrating' do
+      v = issuer_migration_version
+
+      # up to the migration, roll it back (down), then re-apply it (up).
+      Sequel::Migrator.run(migration_db, migrations_dir, target: v)
+      Sequel::Migrator.run(migration_db, migrations_dir, target: v - 1)
+      Sequel::Migrator.run(migration_db, migrations_dir, target: v)
+
+      acct_a = insert_account(setup_db, 'cycle-a@example.com')
+      acct_b = insert_account(setup_db, 'cycle-b@example.com')
+      ids = setup_db[:account_identities]
+
+      # Two IdPs asserting the same sub (uid) under different issuers must coexist.
+      ids.insert(account_id: acct_a, provider: 'oidc', issuer: 'https://idp-a.example', uid: 'shared-sub')
+      expect do
+        ids.insert(account_id: acct_b, provider: 'oidc', issuer: 'https://idp-b.example', uid: 'shared-sub')
+      end.not_to raise_error
+      expect(ids.where(provider: 'oidc', uid: 'shared-sub').count).to eq(2)
+
+      # A true (provider, issuer, uid) duplicate is still rejected.
+      expect do
+        ids.insert(account_id: acct_b, provider: 'oidc', issuer: 'https://idp-a.example', uid: 'shared-sub')
+      end.to raise_error(Sequel::UniqueConstraintViolation)
+
+      # The stale (provider, uid) unique must be gone.
+      uniques = test_db.indexes(:account_identities).values.select { |i| i[:unique] }.map { |i| i[:columns] }
+      expect(uniques).to include(%i[provider issuer uid])
+      expect(uniques).not_to include(%i[provider uid])
+    end
+  end
 end

--- a/apps/web/auth/spec/integration/full/migrations/migrations_sqlite_spec.rb
+++ b/apps/web/auth/spec/integration/full/migrations/migrations_sqlite_spec.rb
@@ -294,18 +294,7 @@ RSpec.describe 'Auth::Migrator SQLite Integration', :sqlite_database do
   # (provider, uid) unique in place and silently re-imposed the old key —
   # defeating issuer-scoping. This guards that cycle.
   describe 'issuer-scoped migration (008) reversibility' do
-    # Derive the version from the filename so a later renumber doesn't rot this.
-    let(:issuer_migration_version) do
-      file = Dir.glob(File.join(migrations_dir, '[0-9]*issuer_scoped*.rb')).first
-      raise 'issuer-scoped migration not found' unless file
-
-      File.basename(file)[/\A(\d+)/, 1].to_i
-    end
-
-    def insert_account(db, email)
-      db[:accounts].insert(email: email, status_id: 2, external_id: SecureRandom.uuid)
-    end
-
+    # issuer_migration_version and insert_account come from MigrationTestHelpers.
     it 'preserves (provider, issuer, uid) uniqueness after an up->down->up cycle' do
       v = issuer_migration_version
 

--- a/apps/web/auth/spec/integration/full/migrations/migrations_sqlite_spec.rb
+++ b/apps/web/auth/spec/integration/full/migrations/migrations_sqlite_spec.rb
@@ -284,4 +284,78 @@ RSpec.describe 'Auth::Migrator SQLite Integration', :sqlite_database do
       expect(get_schema_version(db: test_db)).to eq(latest_version)
     end
   end
+
+  # Regression (#3840 Phase 0 / #3838 item 5): the issuer-scoped migration re-keys
+  # account_identities from (provider, uid) to (provider, issuer, uid) to close a
+  # cross-tenant SSO takeover. On SQLite the `down` path restores (provider, uid)
+  # as a STANDALONE unique index; the `up` path's drop_constraint rebuilds the
+  # table but cannot see that index (it re-creates it). Without the explicit
+  # idempotent DROP INDEX in `up`, an up->down->up cycle left the stale
+  # (provider, uid) unique in place and silently re-imposed the old key —
+  # defeating issuer-scoping. This guards that cycle.
+  describe 'issuer-scoped migration (008) reversibility' do
+    # Derive the version from the filename so a later renumber doesn't rot this.
+    let(:issuer_migration_version) do
+      file = Dir.glob(File.join(migrations_dir, '[0-9]*issuer_scoped*.rb')).first
+      raise 'issuer-scoped migration not found' unless file
+
+      File.basename(file)[/\A(\d+)/, 1].to_i
+    end
+
+    def insert_account(db, email)
+      db[:accounts].insert(email: email, status_id: 2, external_id: SecureRandom.uuid)
+    end
+
+    it 'preserves (provider, issuer, uid) uniqueness after an up->down->up cycle' do
+      v = issuer_migration_version
+
+      # up to the migration, roll it back (down), then re-apply it (up).
+      Sequel::Migrator.run(test_db, migrations_dir, target: v)
+      Sequel::Migrator.run(test_db, migrations_dir, target: v - 1)
+      Sequel::Migrator.run(test_db, migrations_dir, target: v)
+
+      acct_a = insert_account(test_db, 'cycle-a@example.com')
+      acct_b = insert_account(test_db, 'cycle-b@example.com')
+      ids = test_db[:account_identities]
+
+      # Two IdPs asserting the same sub (uid) under different issuers must coexist.
+      ids.insert(account_id: acct_a, provider: 'oidc', issuer: 'https://idp-a.example', uid: 'shared-sub')
+      expect do
+        ids.insert(account_id: acct_b, provider: 'oidc', issuer: 'https://idp-b.example', uid: 'shared-sub')
+      end.not_to raise_error
+      expect(ids.where(provider: 'oidc', uid: 'shared-sub').count).to eq(2)
+
+      # A true (provider, issuer, uid) duplicate is still rejected.
+      expect do
+        ids.insert(account_id: acct_b, provider: 'oidc', issuer: 'https://idp-a.example', uid: 'shared-sub')
+      end.to raise_error(Sequel::UniqueConstraintViolation)
+
+      # The stale (provider, uid) unique index must be gone.
+      uniques = test_db.indexes(:account_identities).values.select { |i| i[:unique] }.map { |i| i[:columns] }
+      expect(uniques).to include(%i[provider issuer uid])
+      expect(uniques).not_to include(%i[provider uid])
+    end
+
+    # The `down` block documents that a rollback CANNOT collapse two issuers back
+    # onto a single (provider, uid) key. Pin that it fails LOUDLY (rather than
+    # silently dropping a row and re-opening the takeover) and preserves the data.
+    it 'refuses to roll back when colliding-issuer rows exist' do
+      v = issuer_migration_version
+      Sequel::Migrator.run(test_db, migrations_dir, target: v)
+
+      acct_a = insert_account(test_db, 'rollback-a@example.com')
+      acct_b = insert_account(test_db, 'rollback-b@example.com')
+      ids = test_db[:account_identities]
+      ids.insert(account_id: acct_a, provider: 'oidc', issuer: 'https://idp-a.example', uid: 'dup-sub')
+      ids.insert(account_id: acct_b, provider: 'oidc', issuer: 'https://idp-b.example', uid: 'dup-sub')
+
+      expect do
+        Sequel::Migrator.run(test_db, migrations_dir, target: v - 1)
+      end.to raise_error(Sequel::DatabaseError)
+
+      # Rollback aborted: schema stays at v and both rows survive (no silent loss).
+      expect(get_schema_version(db: test_db)).to eq(v)
+      expect(ids.where(uid: 'dup-sub').count).to eq(2)
+    end
+  end
 end

--- a/apps/web/auth/spec/integration/full/omniauth_issuer_scoped_identity_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_issuer_scoped_identity_spec.rb
@@ -1,0 +1,153 @@
+# apps/web/auth/spec/integration/full/omniauth_issuer_scoped_identity_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration (full mode)
+# =============================================================================
+#
+# Issue: #3840 Phase 0 / #3838 item 5 — cross-tenant SSO account takeover.
+#
+# Drives the SHIPPED issuer-scoped identity lookup
+# (Auth::Config::Features::OmniAuth.lookup_identity) against the REAL migrated
+# account_identities schema (migration 008 runs during boot). This exercises
+# the persistence + decision layer end-to-end:
+#   (a) takeover regression — two tenants, provider='oidc', colliding uid,
+#       different issuer → two rows, tenant B resolves to tenant B's account,
+#       never tenant A's (no cross-bind); a true (provider, issuer, uid)
+#       duplicate is rejected by the unique index.
+#   (b) platform grace + lazy upgrade — a legacy (provider, '', uid) row + a
+#       PLATFORM callback resolving a real issuer matches the legacy row AND
+#       upgrades its issuer column.
+#   (c) tenant no-grace — the same legacy row + a TENANT callback (validated
+#       domain present) does NOT match the legacy row and leaves it untouched.
+#
+# SCOPE NOTE: this does NOT drive the full HTTP OmniAuth callback (that needs a
+# mocked IdP strategy + request cycle). It drives the exact production function
+# the retrieve_omniauth_identity override delegates to, against a real DB.
+#
+# REQUIREMENTS:
+# - Valkey running on port 2121: pnpm run test:database:start
+# - AUTHENTICATION_MODE=full, AUTH_DATABASE_URL=sqlite::memory: (rake sets this)
+#
+# RUN:
+#   bundle exec rake spec:integration:full
+# =============================================================================
+
+require_relative '../../spec_helper'
+
+RSpec.describe 'Issuer-scoped SSO identity lookup', type: :integration do
+  before(:all) do
+    require 'onetime' unless defined?(Onetime)
+    Onetime.boot! :test unless Onetime.ready?
+  end
+
+  let(:feature) { Auth::Config::Features::OmniAuth }
+  let(:db) { Auth::Database.connection }
+  let(:ds) { db[:account_identities] }
+  let(:cols) { { id_col: :id, provider_col: :provider, uid_col: :uid, issuer_col: :issuer } }
+
+  # Track inserted rows for cleanup (shared in-memory DB across specs).
+  let(:created_account_ids) { [] }
+  let(:created_identity_ids) { [] }
+
+  after do
+    created_identity_ids.each { |id| ds.where(id: id).delete }
+    created_account_ids.each { |id| db[:accounts].where(id: id).delete }
+  rescue StandardError
+    # Non-fatal cleanup error
+  end
+
+  def create_account(email)
+    id = db[:accounts].insert(email: email, status_id: 1)
+    created_account_ids << id
+    id
+  end
+
+  def insert_identity(account_id:, provider:, issuer:, uid:)
+    id = ds.insert(account_id: account_id, provider: provider, issuer: issuer, uid: uid)
+    created_identity_ids << id
+    id
+  end
+
+  def unique_email(prefix)
+    "#{prefix}-#{SecureRandom.hex(6)}@issuer-scoped-test.example.com"
+  end
+
+  describe 'schema' do
+    it 'has a NOT NULL issuer column keyed with (provider, issuer, uid)' do
+      schema = db.schema(:account_identities).to_h { |c, info| [c, info] }
+      expect(schema).to have_key(:issuer)
+      expect(schema[:issuer][:allow_null]).to be false
+
+      composite = db.indexes(:account_identities).values.find { |i| i[:columns] == %i[provider issuer uid] }
+      expect(composite).not_to be_nil
+      expect(composite[:unique]).to be true
+    end
+  end
+
+  describe '(a) takeover regression: colliding uid, different issuer' do
+    let(:uid) { "sub-#{SecureRandom.hex(6)}" }
+    let!(:acct_a) { create_account(unique_email('tenant-a')) }
+    let!(:acct_b) { create_account(unique_email('tenant-b')) }
+
+    before do
+      insert_identity(account_id: acct_a, provider: 'oidc', issuer: 'https://idp-a.example', uid: uid)
+      insert_identity(account_id: acct_b, provider: 'oidc', issuer: 'https://idp-b.example', uid: uid)
+    end
+
+    it 'stores two distinct rows for the same (provider, uid)' do
+      expect(ds.where(provider: 'oidc', uid: uid).count).to eq(2)
+    end
+
+    it 'rejects a true (provider, issuer, uid) duplicate' do
+      expect do
+        ds.insert(account_id: acct_b, provider: 'oidc', issuer: 'https://idp-a.example', uid: uid)
+      end.to raise_error(Sequel::UniqueConstraintViolation)
+    end
+
+    it 'binds tenant B to tenant B account, never tenant A (no cross-bind)' do
+      row_b = feature.lookup_identity(ds: ds, **cols, provider: 'oidc', uid: uid,
+                                                      resolved_issuer: 'https://idp-b.example',
+                                                      platform_path: false)
+      expect(row_b[:account_id]).to eq(acct_b)
+      expect(row_b[:account_id]).not_to eq(acct_a)
+    end
+
+    it 'binds tenant A to tenant A account' do
+      row_a = feature.lookup_identity(ds: ds, **cols, provider: 'oidc', uid: uid,
+                                                      resolved_issuer: 'https://idp-a.example',
+                                                      platform_path: false)
+      expect(row_a[:account_id]).to eq(acct_a)
+    end
+  end
+
+  describe '(b) platform grace + lazy upgrade' do
+    let(:uid) { "legacy-#{SecureRandom.hex(6)}" }
+    let!(:acct) { create_account(unique_email('platform-legacy')) }
+    let!(:identity_id) { insert_identity(account_id: acct, provider: 'oidc', issuer: '', uid: uid) }
+
+    it 'matches the legacy "" row and upgrades its issuer in the DB' do
+      row = feature.lookup_identity(ds: ds, **cols, provider: 'oidc', uid: uid,
+                                                    resolved_issuer: 'https://real-idp.example',
+                                                    platform_path: true)
+      expect(row[:account_id]).to eq(acct)
+      expect(row[:issuer]).to eq('https://real-idp.example')
+      expect(ds.where(id: identity_id).get(:issuer)).to eq('https://real-idp.example')
+    end
+  end
+
+  describe '(c) tenant no-grace' do
+    let(:uid) { "legacy-#{SecureRandom.hex(6)}" }
+    let!(:acct) { create_account(unique_email('tenant-legacy')) }
+    let!(:identity_id) { insert_identity(account_id: acct, provider: 'oidc', issuer: '', uid: uid) }
+
+    it 'does NOT match the legacy "" row and leaves it untouched' do
+      row = feature.lookup_identity(ds: ds, **cols, provider: 'oidc', uid: uid,
+                                                    resolved_issuer: 'https://tenant-idp.example',
+                                                    platform_path: false)
+      expect(row).to be_nil
+      expect(ds.where(id: identity_id).get(:issuer)).to eq('')
+    end
+  end
+end

--- a/apps/web/auth/spec/integration/full/omniauth_issuer_scoped_identity_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_issuer_scoped_identity_spec.rb
@@ -52,10 +52,12 @@ RSpec.describe 'Issuer-scoped SSO identity lookup', type: :integration do
   let(:created_identity_ids) { [] }
 
   after do
+    # Identities first, then accounts (FK order). Deletes are idempotent, so a
+    # partially-populated list is safe. A cleanup error is a real problem and is
+    # allowed to surface rather than leave stray rows in the shared in-memory DB
+    # that would make later examples order-dependent.
     created_identity_ids.each { |id| ds.where(id: id).delete }
     created_account_ids.each { |id| db[:accounts].where(id: id).delete }
-  rescue StandardError
-    # Non-fatal cleanup error
   end
 
   def create_account(email)

--- a/apps/web/auth/spec/spec_helper.rb
+++ b/apps/web/auth/spec/spec_helper.rb
@@ -230,13 +230,20 @@ module RodauthTestHelper
   end
 
   # Creates tables for OmniAuth (SSO identity linking)
+  #
+  # MUST mirror migrations/008_issuer_scoped_identities.rb — specs build the
+  # schema from HERE, not the migration. The identity is keyed on
+  # (provider, issuer, uid) to close the #3838 item-5 cross-tenant takeover;
+  # `issuer` is NOT NULL with the '' sentinel (never NULL — a NULL vs ''
+  # split would break the unique index).
   def self.create_omniauth_tables(db)
     db.create_table(:account_identities) do
       primary_key :id, type: :Bignum
       foreign_key :account_id, :accounts, type: :Bignum, null: false
       String :provider, null: false
+      String :issuer, null: false, default: ''
       String :uid, null: false
-      index [:provider, :uid], unique: true
+      index [:provider, :issuer, :uid], unique: true
     end
   end
 

--- a/spec/support/helpers/migration_test_helpers.rb
+++ b/spec/support/helpers/migration_test_helpers.rb
@@ -6,6 +6,7 @@ require 'sequel'
 require 'fileutils'
 require 'timeout'
 require 'concurrent'
+require 'securerandom'
 
 # Shared helpers for migration integration tests
 #
@@ -103,6 +104,30 @@ module MigrationTestHelpers
   # @return [Boolean] True if table exists
   def verify_table_exists(db:, table_name:)
     db.table_exists?(table_name)
+  end
+
+  # Derive the issuer-scoped migration's numeric version from its filename, so a
+  # later renumber doesn't rot the regression specs that target migration 008
+  # (#3840 Phase 0 / #3838 item 5). Defaults to the host example's
+  # +migrations_dir+; pass +dir+ to override.
+  #
+  # @param dir [String] Migrations directory (defaults to the host's migrations_dir)
+  # @return [Integer] The issuer-scoped migration's version number
+  def issuer_migration_version(dir = migrations_dir)
+    file = Dir.glob(File.join(dir, '[0-9]*issuer_scoped*.rb')).first
+    raise 'issuer-scoped migration not found' unless file
+
+    File.basename(file)[/\A(\d+)/, 1].to_i
+  end
+
+  # Insert a minimal valid account row and return its primary key. Used by the
+  # issuer-scoped reversibility specs to populate account_identities.
+  #
+  # @param db [Sequel::Database] Database connection
+  # @param email [String] Account email
+  # @return [Integer] The new account's id
+  def insert_account(db, email)
+    db[:accounts].insert(email: email, status_id: 2, external_id: SecureRandom.uuid)
   end
 
   # Create a database with partial migration state (migrated to specific version)

--- a/spec/support/postgres_mode_suite_database.rb
+++ b/spec/support/postgres_mode_suite_database.rb
@@ -51,7 +51,8 @@ require_relative 'factories/auth_account_factory'
 #
 module PostgresModeSuiteDatabase
   REQUIRED_TABLES = %i[accounts account_statuses account_password_hashes].freeze
-  EXPECTED_SCHEMA_VERSION = 7
+  # Bumped to 8 by migration 008 (issuer-scoped SSO identities, #3840 Phase 0).
+  EXPECTED_SCHEMA_VERSION = 8
 
   class << self
     attr_reader :database, :migration_database


### PR DESCRIPTION
**Phase 0 of the #3840 stacked-PR program** (sequences #3838). Targets the orchestration branch. **Blocks Phases 2–4** (they write identity rows against this key).

## The vulnerability (#3838 item 5)
`account_identities` was uniquely keyed on `(provider, uid)`. `provider` is the strategy **name** (`'oidc'`, `'entra'`) — identical across every tenant using that strategy via `CustomDomain::SsoConfig`. Two IdPs (issuers) can each assert the same `sub`. Under the old key, tenant B's callback asserting `sub=user-123` matched tenant A's row → **tenant B signs in as tenant A's user**. Re-keying on `(issuer, provider, uid)` makes colliding identities distinct rows.

## Approach A — platform grace + lazy upgrade (ratified)
Existing rows can't be given a real issuer (#3838 bars log-scraping; it isn't stored on the row), so migration 008 backfills the `''` sentinel unconditionally and the **read path** resolves it:
1. Exact lookup `(provider, resolved_issuer, uid)` first.
2. **Platform** (env-configured) callbacks fall back to the legacy `(provider, '', uid)` row and **lazily upgrade** its issuer (self-heal).
3. **Tenant** (`CustomDomain::SsoConfig`) callbacks are **issuer-exact only** and never touch the `''` row — the legacy fallback on the tenant path *is* the takeover.

The platform-vs-tenant signal (`session[:validated_omniauth_domain_id]`, set by the tenant hook in `before_omniauth_callback_route`) is **verified in the gem** to be present before `retrieve_omniauth_identity` runs — this was the critical uncertainty and it's resolved with evidence, not assumption.

## Changes
- `migrations/008_issuer_scoped_identities.rb`: `issuer NOT NULL DEFAULT ''`, drop `(provider,uid)` unique (backend-branched `drop_constraint`), add `(provider,issuer,uid)` unique. Reversible `down`.
- `config/features/omniauth.rb`: pure `resolve_issuer` / `platform_path?` / `lookup_identity` functions wired via `retrieve_omniauth_identity` + insert/update hashes (persist + self-heal issuer).
- `spec_helper.rb#create_omniauth_tables` mirrors 008 (specs build schema from here, not the migration).

## Verification
- Unit `omniauth_spec.rb`: **91 examples, 0 failures** (re-run independently).
- Full-mode integration `omniauth_issuer_scoped_identity_spec.rb`: **7 examples, 0 failures** — takeover regression (two tenants, colliding uid, different issuer → distinct rows, no cross-bind), platform grace + lazy upgrade, tenant no-grace.
- **Postgres `up` path verified empirically** on a scratch PG DB: `account_identities_provider_uid_key` dropped correctly, `issuer` backfilled to `''`, colliding `(provider,uid)`/different-issuer both insert, exact `(provider,issuer,uid)` dup rejected.

## Ratified consequence (not a defect)
Existing **tenant** SSO users whose rows predate this migration miss the exact lookup and are refused (`account_exists_link_required`) until they re-link via a later phase's authenticated (Phase 2) or mailbox (Phase 4) flow. A tenant issuer backfill is **impossible** — rows carry no domain association, so a legacy `(oidc, uid, '')` row can't be mapped to a specific tenant's issuer. Platform users self-heal via the grace path. This is the tradeoff of the chosen approach; the Phase 1 trust flag does not apply here (it's platform-only + boot-guarded off multi-tenant).

## Follow-up
- Down-migration verified on SQLite; PG-down not exercised (rollback-only path).