### PR TITLE
[#3717] Honor disabled-homepage variant defaults on custom domains

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -1091,8 +1091,9 @@ UI_HOMEPAGE_MODE_HEADER=
 HOMEPAGE_PUBLIC_LINKS_RECIPIENT_INTRO=
 
 # Which landing page the homepage shows when secret creation is gated by auth
-# (auth.required, or UI_HOMEPAGE_MODE=external). Deployment-wide default;
-# per-domain config and the ?variant= URL override still take precedence.
+# (auth.required, or UI_HOMEPAGE_MODE=external). Deployment-wide default for
+# the CANONICAL site; per-domain config and the ?variant= URL override still
+# take precedence.
 # One of:
 #   closed  - quiet "members only" two-tagline page, no sign-in button (default)
 #   minimal - small mark + headline + sign-in CTA (one-click SSO when a single
@@ -1100,6 +1101,14 @@ HOMEPAGE_PUBLIC_LINKS_RECIPIENT_INTRO=
 #   v1      - full hero: mark, eyebrow, headline, CTA, trust strip, optional promo
 # Leave blank to use the default (closed).
 DEFAULT_DISABLED_HOMEPAGE_VARIANT=
+
+# Same as DEFAULT_DISABLED_HOMEPAGE_VARIANT, but the deployment-wide default
+# for CUSTOM DOMAINS whose homepage is private. Kept separate so the canonical
+# and custom-domain defaults stay decoupled: a custom domain does NOT inherit
+# DEFAULT_DISABLED_HOMEPAGE_VARIANT. Per-domain config and the ?variant= URL
+# override still take precedence. Same values (closed / minimal / v1); leave
+# blank to use the default (closed).
+DEFAULT_CUSTOM_DOMAIN_DISABLED_HOMEPAGE_VARIANT=
 
 # Show help modals on secret reveal/receipt pages. Set to 'false' to hide.
 HELP_ENABLED=true

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -67,12 +67,21 @@ site:
         mode: <%= ENV['UI_HOMEPAGE_MODE'] || nil %>
         matching_cidrs: <%= ENV['UI_HOMEPAGE_MATCHING_CIDRS']&.split(',')&.map(&:strip) || [] %>
         mode_header: <%= ENV['UI_HOMEPAGE_MODE_HEADER'] || 'O-Homepage-Mode' %>
-        # Deployment-wide default landing page when the homepage secret form
-        # is gated by auth (auth.required or mode=external). One of: closed
-        # (quiet two-tagline, no CTA), minimal, or v1. Per-domain config and
-        # the ?variant= URL override take precedence; blank uses the frontend
-        # default (closed).
+        # Deployment-wide default landing page for the CANONICAL site when the
+        # homepage secret form is gated by auth (auth.required or mode=external).
+        # One of: closed (quiet two-tagline, no CTA), minimal, or v1. Per-domain
+        # config and the ?variant= URL override take precedence; blank uses the
+        # frontend default (closed). Applies to the canonical site only —
+        # custom domains use custom_disabled_variant below.
         disabled_variant: <%= ENV['DEFAULT_DISABLED_HOMEPAGE_VARIANT'] || nil %>
+        # Deployment-wide default landing page for CUSTOM DOMAINS whose homepage
+        # is private (homepage disabled, or incoming mode degraded at runtime).
+        # Same values as disabled_variant (closed / minimal / v1). Kept separate
+        # so the canonical and custom-domain defaults stay decoupled: a custom
+        # domain does NOT inherit disabled_variant. Per-domain config
+        # (homepage_config.disabled_homepage_variant) and the ?variant= URL
+        # override take precedence; blank uses the frontend default (closed).
+        custom_disabled_variant: <%= ENV['DEFAULT_CUSTOM_DOMAIN_DISABLED_HOMEPAGE_VARIANT'] || nil %>
         # Links rendered when a public visitor lands on the homepage but
         # the secret form is gated by auth (e.g. mode=external). Recipients
         # arriving via a shared link use these to learn about the service.

--- a/lib/onetime/models/custom_domain/homepage_config.rb
+++ b/lib/onetime/models/custom_domain/homepage_config.rb
@@ -70,8 +70,11 @@ module Onetime
 
       # Which disabled-homepage variant this domain renders when the homepage
       # secret form is gated by auth. nil (unset) = fall back to the
-      # deployment-wide default (site.interface.ui.homepage.disabled_variant)
-      # and ultimately the frontend DEFAULT_DISABLED_HOMEPAGE_VARIANT constant.
+      # deployment-wide custom-domain default
+      # (site.interface.ui.homepage.custom_disabled_variant) and ultimately the
+      # frontend DEFAULT_DISABLED_HOMEPAGE_VARIANT constant. Custom domains do
+      # NOT inherit the canonical-site disabled_variant — the two tiers are
+      # kept decoupled.
       field :disabled_homepage_variant
 
       # Which interactive experience the homepage offers when enabled

--- a/src/apps/secret/conceal/BrandedHomepage.vue
+++ b/src/apps/secret/conceal/BrandedHomepage.vue
@@ -4,6 +4,7 @@
   import BrandedHero from '@/apps/secret/components/branded/BrandedHero.vue';
   import SecretForm from '@/apps/secret/components/form/SecretForm.vue';
   import IncomingSecretFormBody from '@/apps/secret/components/incoming/IncomingSecretFormBody.vue';
+  import DisabledHomepage from '@/apps/secret/views/DisabledHomepage.vue';
   import OIcon from '@/shared/components/icons/OIcon.vue';
   import { useProductIdentity } from '@/shared/stores/identityStore';
   import { useIncomingStore } from '@/shared/stores/incomingStore';
@@ -35,9 +36,9 @@
   // The bootstrap payload only says incoming mode is active when the
   // backend judged it servable, but the config still loads at runtime and
   // can fail (entitlement lapse, recipients emptied moments ago, network).
-  // Any such failure degrades to the same private trust card the disabled
-  // homepage shows — an anonymous visitor must never see upgrade/billing
-  // or misconfiguration copy on the branded front door.
+  // Any such failure degrades to the same private disabled-homepage view an
+  // anonymous visitor would otherwise see — they must never be shown
+  // upgrade/billing or misconfiguration copy on the branded front door.
   // ---------------------------------------------------------------------
 
   const incomingStore = useIncomingStore();
@@ -62,7 +63,7 @@
       try {
         await incomingStore.loadConfig();
       } catch {
-        // Degrade to the trust card; the store captures error state.
+        // Degrade to the disabled-homepage view; the store captures error state.
       } finally {
         incomingLoading.value = false;
       }
@@ -73,7 +74,11 @@
   const showIncomingForm = computed(
     () => incomingMode.value && !incomingLoading.value && incomingAvailable.value
   );
-  const showTrustCard = computed(
+  // The private front door: the homepage is not public, or incoming mode was
+  // active but degraded at runtime. Presentation is delegated to the
+  // disabled-homepage variant dispatcher (DisabledHomepage.vue), which is
+  // brand-aware and honours the per-domain / deployment-wide variant defaults.
+  const showDisabledHomepage = computed(
     () =>
       !allowPublicHomepage.value ||
       (incomingMode.value && !incomingLoading.value && !incomingAvailable.value)
@@ -81,8 +86,8 @@
 
   // Send-a-secret copy only while the incoming form is (or is about to be)
   // the content below it. Once the runtime check degrades incoming to the
-  // trust card, fall back to the neutral copy the private branch has always
-  // shown — a "Send a secret" headline over a members-only notice reads as
+  // disabled-homepage view, fall back to the neutral copy the create branch
+  // shows — a "Send a secret" headline over a members-only notice reads as
   // a broken page.
   const incomingCopy = computed(
     () => incomingMode.value && (incomingLoading.value || incomingAvailable.value)
@@ -100,111 +105,73 @@
 </script>
 
 <template>
-  <div
-    :class="fontFamilyClass"
-    class="relative mx-auto w-full max-w-xl px-4">
-    <BrandedHero
-      class="mb-8"
-      :title="headline"
-      :subtitle="subline" />
+  <!--
+    Custom Domain Homepage (branded landing for self-hosted workspaces)
 
+    Audiences:
+    - Recipients arriving via a shared link
+    - Team members who need to sign in (via TransactionalHeader)
+    - Admins verifying the branded landing page
+
+    BrandedHomepage owns the public-vs-private decision
+    (allowPublicHomepage + the runtime incoming-degradation guard) and
+    delegates presentation:
+    - Public create mode: branded hero + secret creation form
+    - Public incoming mode (secrets_mode=incoming): branded hero + incoming
+      secrets form; degrades to the disabled-homepage view below if incoming
+      becomes unavailable at runtime
+    - Private mode: hands off to the disabled-homepage variant dispatcher,
+      which renders the operator-selected variant (closed / minimal / v1)
+      with full brand awareness
+  -->
+  <div class="w-full">
     <!--
-      Custom Domain Homepage (branded landing for self-hosted workspaces)
-
-      Audiences:
-      - Recipients arriving via a shared link
-      - Team members who need to sign in (via TransactionalHeader)
-      - Admins verifying the branded landing page
-
-      Design notes:
-      - Minimal, trust-focused with brand color accents
-      - Sign In handled at layout level, not here
-      - Public create mode: shows the secret creation form
-      - Public incoming mode (secrets_mode=incoming): shows the incoming
-        secrets form; degrades to the private trust card if incoming
-        becomes unavailable at runtime
-      - Private mode: status card with trust signals, no form
+      Private (or incoming unavailable): delegate to the disabled-homepage
+      variant dispatcher. It is brand-aware via useDisabledConfig and honours
+      the per-domain homepage_config.disabled_homepage_variant plus the
+      deployment-wide DEFAULT_CUSTOM_DOMAIN_DISABLED_HOMEPAGE_VARIANT default.
+      The variant owns its own hero, so BrandedHero is suppressed here.
     -->
+    <DisabledHomepage v-if="showDisabledHomepage" />
 
-    <!-- Public create mode: secret form -->
-    <SecretForm
-      v-if="allowPublicHomepage && !incomingMode"
-      class="mb-8"
-      :primary-color="primaryColor"
-      :button-text-light="buttonTextLight"
-      :corner-class="cornerClass"
-      :with-recipient="false"
-      :with-asterisk="false"
-      :with-generate="false" />
-
-    <!-- Public incoming mode: send-a-secret form -->
-    <IncomingSecretFormBody
-      v-else-if="showIncomingForm"
-      class="mb-8"
-      data-testid="homepage-incoming-form"
-      :primary-color="primaryColor" />
-
-    <!-- Incoming config loading: quiet placeholder to avoid a content flash -->
+    <!-- Public create/incoming mode: branded hero over the active form -->
     <div
-      v-else-if="incomingMode && incomingLoading"
-      class="mb-8 flex justify-center py-12"
-      data-testid="homepage-incoming-loading">
-      <OIcon
-        collection="heroicons"
-        name="arrow-path"
-        class="size-6 animate-spin text-gray-400"
-        aria-hidden="true" />
-    </div>
+      v-else
+      :class="fontFamilyClass"
+      class="relative mx-auto w-full max-w-xl px-4">
+      <BrandedHero
+        class="mb-8"
+        :title="headline"
+        :subtitle="subline" />
 
-    <!-- Private (or incoming unavailable): trust signals only -->
-    <div
-      v-else-if="showTrustCard"
-      class="space-y-8">
-      <!-- Status Card -->
+      <!-- Public create mode: secret form -->
+      <SecretForm
+        v-if="allowPublicHomepage && !incomingMode"
+        class="mb-8"
+        :primary-color="primaryColor"
+        :button-text-light="buttonTextLight"
+        :corner-class="cornerClass"
+        :with-recipient="false"
+        :with-asterisk="false"
+        :with-generate="false" />
+
+      <!-- Public incoming mode: send-a-secret form -->
+      <IncomingSecretFormBody
+        v-else-if="showIncomingForm"
+        class="mb-8"
+        data-testid="homepage-incoming-form"
+        :primary-color="primaryColor" />
+
+      <!-- Incoming config loading: quiet placeholder to avoid a content flash -->
       <div
-        class="relative overflow-hidden rounded-2xl border border-gray-200 bg-white p-8 shadow-sm dark:border-gray-700 dark:bg-gray-800 dark:shadow-none">
-        <!-- Brand accent line -->
-        <div class="absolute inset-x-0 top-0 h-1 bg-brand-500"></div>
-
-        <!-- Status indicator -->
-        <div class="mb-6 flex items-center gap-3">
-          <div
-            class="flex size-10 items-center justify-center rounded-full bg-brand-500/10">
-            <OIcon
-              collection="heroicons"
-              name="shield-check"
-              class="size-5 text-brand-500" />
-          </div>
-          <div>
-            <p class="text-sm font-medium text-gray-900 dark:text-white/90">
-              {{ t('web.homepage.this_is_a_private_instance_only_authorized_team_') }}
-            </p>
-          </div>
-        </div>
-
-        <!-- Feature pills -->
-        <div class="flex flex-wrap gap-3">
-          <div
-            class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-gray-50 px-4 py-2 dark:border-white/10 dark:bg-white/5">
-            <OIcon
-              collection="heroicons"
-              name="lock-closed"
-              class="size-4 text-gray-500 dark:text-white/60" />
-            <span class="text-sm text-gray-600 dark:text-white/70">
-              {{ t('web.secrets.secure_encrypted_storage') }}
-            </span>
-          </div>
-          <div
-            class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-gray-50 px-4 py-2 dark:border-white/10 dark:bg-white/5">
-            <OIcon
-              collection="heroicons"
-              name="clock"
-              class="size-4 text-gray-500 dark:text-white/60" />
-            <span class="text-sm text-gray-600 dark:text-white/70">
-              {{ t('web.secrets.auto_expire_after_viewing') }}
-            </span>
-          </div>
-        </div>
+        v-else-if="incomingMode && incomingLoading"
+        class="mb-8 flex justify-center py-12"
+        data-testid="homepage-incoming-loading">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          class="size-6 animate-spin text-gray-400"
+          aria-hidden="true" />
       </div>
     </div>
   </div>

--- a/src/apps/secret/views/disabled/useDisabledConfig.ts
+++ b/src/apps/secret/views/disabled/useDisabledConfig.ts
@@ -297,8 +297,15 @@ export function useDisabledConfig(): DisabledHomepageBindings {
   // Variant resolution (highest precedence first):
   //   1. ?variant= URL override (dogfood/preview)
   //   2. per-domain homepage_config.disabled_homepage_variant
-  //   3. deployment-wide ui.homepage.disabled_variant
-  //      (DEFAULT_DISABLED_HOMEPAGE_VARIANT env var)
+  //   3. deployment-wide default — SPLIT by domain context so the canonical
+  //      site and custom domains stay decoupled (the canonical/custom split
+  //      from 4effa3e3f5):
+  //        - custom domains: ui.homepage.custom_disabled_variant
+  //          (DEFAULT_CUSTOM_DOMAIN_DISABLED_HOMEPAGE_VARIANT env var). Custom
+  //          domains do NOT fall back to the canonical disabled_variant — an
+  //          unset custom default goes straight to the frontend const.
+  //        - canonical site: ui.homepage.disabled_variant
+  //          (DEFAULT_DISABLED_HOMEPAGE_VARIANT env var)
   //   4. frontend DEFAULT_DISABLED_HOMEPAGE_VARIANT constant
   // URL is read once at composable-call time (page loads don't preserve query
   // params); the store-backed fallbacks stay reactive so a $patch on the
@@ -311,7 +318,9 @@ export function useDisabledConfig(): DisabledHomepageBindings {
     coerceDisabledVariant(
       urlOverride ??
         homepage_config.value?.disabled_homepage_variant ??
-        ui.value?.homepage?.disabled_variant
+        (isCustom.value
+          ? ui.value?.homepage?.custom_disabled_variant
+          : ui.value?.homepage?.disabled_variant)
     )
   );
 

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -170,8 +170,8 @@ export const homepagePublicLinksSchema = z.object({
 export const homepageUiConfigSchema = z.object({
   public_links: homepagePublicLinksSchema.optional(),
   /**
-   * Deployment-wide default disabled-homepage variant, from the
-   * `DEFAULT_DISABLED_HOMEPAGE_VARIANT` env var
+   * Deployment-wide default disabled-homepage variant for the CANONICAL site,
+   * from the `DEFAULT_DISABLED_HOMEPAGE_VARIANT` env var
    * (`site.interface.ui.homepage.disabled_variant`). Sits between the
    * per-domain `homepage_config.disabled_homepage_variant` and the frontend
    * `DEFAULT_DISABLED_HOMEPAGE_VARIANT` constant in the resolution chain.
@@ -180,6 +180,20 @@ export const homepageUiConfigSchema = z.object({
    * rather than failing the whole bootstrap parse.
    */
   disabled_variant: disabledHomepageVariantSchema.nullable().catch(null).optional(),
+  /**
+   * Deployment-wide default disabled-homepage variant for CUSTOM DOMAINS, from
+   * the `DEFAULT_CUSTOM_DOMAIN_DISABLED_HOMEPAGE_VARIANT` env var
+   * (`site.interface.ui.homepage.custom_disabled_variant`). Kept separate from
+   * `disabled_variant` so the canonical default and the custom-domain default
+   * stay decoupled (the canonical/custom split from `4effa3e3f5`). Sits between
+   * the per-domain `homepage_config.disabled_homepage_variant` and the frontend
+   * `DEFAULT_DISABLED_HOMEPAGE_VARIANT` constant — custom domains do NOT fall
+   * back to the canonical `disabled_variant`.
+   *
+   * `.catch(null)` so an unrecognised value degrades to the frontend default
+   * rather than failing the whole bootstrap parse.
+   */
+  custom_disabled_variant: disabledHomepageVariantSchema.nullable().catch(null).optional(),
 });
 
 export const uiInterfaceSchema = z.object({

--- a/src/tests/apps/secret/views/BrandedHomepage.spec.ts
+++ b/src/tests/apps/secret/views/BrandedHomepage.spec.ts
@@ -18,6 +18,7 @@ import { flushPromises, mount } from '@vue/test-utils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
 import { createTestI18n } from '@tests/setup';
+import BrandedHero from '@/apps/secret/components/branded/BrandedHero.vue';
 
 vi.mock('@/services/bootstrap.service', () => ({
   getBootstrapSnapshot: vi.fn(() => null),
@@ -125,6 +126,9 @@ describe('BrandedHomepage render switch', () => {
     expect(wrapper.find('[data-testid="stub-secret-form"]').exists()).toBe(false);
     expect(wrapper.find('[data-testid="homepage-incoming-form"]').exists()).toBe(false);
     expect(wrapper.find('[data-testid="stub-disabled-homepage"]').exists()).toBe(true);
+    // BrandedHero is suppressed in the private branch — the variant dispatcher
+    // owns its own hero, so the branded landing hero must not double up.
+    expect(wrapper.findComponent(BrandedHero).exists()).toBe(false);
     expect(loadConfigMock).not.toHaveBeenCalled();
   });
 
@@ -160,6 +164,7 @@ describe('BrandedHomepage render switch', () => {
     expect(wrapper.text()).not.toContain('incoming.upgrade_required_title');
     // BrandedHero (and its "Send a secret" headline) is suppressed once the
     // private branch takes over — no marketing copy over a members-only page.
+    expect(wrapper.findComponent(BrandedHero).exists()).toBe(false);
     expect(wrapper.text()).not.toContain('web.homepage.send_a_secret');
   });
 

--- a/src/tests/apps/secret/views/BrandedHomepage.spec.ts
+++ b/src/tests/apps/secret/views/BrandedHomepage.spec.ts
@@ -1,13 +1,18 @@
 // src/tests/apps/secret/views/BrandedHomepage.spec.ts
 //
 // Render-switch contract for the branded custom-domain homepage:
-//   - private (enabled: false)            -> trust card, no form
+//   - private (enabled: false)            -> disabled-homepage dispatcher, no form
 //   - create mode (enabled, create)       -> SecretForm
 //   - incoming mode (enabled, incoming)   -> IncomingSecretFormBody once the
 //                                            runtime config confirms it
-//   - incoming mode, runtime unavailable  -> trust card (NEVER upgrade/billing
-//                                            or misconfiguration copy on the
-//                                            branded front door)
+//   - incoming mode, runtime unavailable  -> disabled-homepage dispatcher (NEVER
+//                                            upgrade/billing or misconfiguration
+//                                            copy on the branded front door)
+//
+// The private/degraded branch delegates presentation to the disabled-homepage
+// variant dispatcher (DisabledHomepage.vue), stubbed here so these tests stay
+// focused on BrandedHomepage's public-vs-private switching. The variant chain
+// itself is covered in useDisabledConfig.spec.ts.
 
 import { flushPromises, mount } from '@vue/test-utils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -31,6 +36,13 @@ vi.mock('@/apps/secret/components/incoming/IncomingSecretFormBody.vue', () => ({
   default: {
     name: 'IncomingSecretFormBody',
     template: '<div data-testid="stub-incoming-form-body" />',
+  },
+}));
+
+vi.mock('@/apps/secret/views/DisabledHomepage.vue', () => ({
+  default: {
+    name: 'DisabledHomepage',
+    template: '<div data-testid="stub-disabled-homepage" />',
   },
 }));
 
@@ -97,8 +109,6 @@ async function mountHomepage(config: HomepageConfigCanonical | null) {
   return wrapper;
 }
 
-const TRUST_CARD_KEY = 'web.homepage.this_is_a_private_instance_only_authorized_team_';
-
 describe('BrandedHomepage render switch', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
@@ -109,12 +119,12 @@ describe('BrandedHomepage render switch', () => {
     incomingState.recipients = [{ digest: 'abc', display_name: 'Security' }];
   });
 
-  it('renders the trust card when the homepage is not public', async () => {
+  it('renders the disabled-homepage dispatcher when the homepage is not public', async () => {
     const wrapper = await mountHomepage(homepageConfig({ enabled: false }));
 
     expect(wrapper.find('[data-testid="stub-secret-form"]').exists()).toBe(false);
     expect(wrapper.find('[data-testid="homepage-incoming-form"]').exists()).toBe(false);
-    expect(wrapper.text()).toContain(TRUST_CARD_KEY);
+    expect(wrapper.find('[data-testid="stub-disabled-homepage"]').exists()).toBe(true);
     expect(loadConfigMock).not.toHaveBeenCalled();
   });
 
@@ -123,6 +133,7 @@ describe('BrandedHomepage render switch', () => {
 
     expect(wrapper.find('[data-testid="stub-secret-form"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="homepage-incoming-form"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="stub-disabled-homepage"]').exists()).toBe(false);
     expect(wrapper.text()).toContain('web.homepage.create_a_secure_link');
     expect(loadConfigMock).not.toHaveBeenCalled();
   });
@@ -136,7 +147,7 @@ describe('BrandedHomepage render switch', () => {
     expect(wrapper.text()).toContain('web.homepage.send_a_secret');
   });
 
-  it('degrades to the trust card when the runtime config is entitlement-blocked', async () => {
+  it('degrades to the disabled-homepage dispatcher when the runtime config is entitlement-blocked', async () => {
     incomingState.isEntitlementBlocked = true;
     incomingState.isFeatureEnabled = false;
 
@@ -144,24 +155,24 @@ describe('BrandedHomepage render switch', () => {
 
     expect(wrapper.find('[data-testid="homepage-incoming-form"]').exists()).toBe(false);
     expect(wrapper.find('[data-testid="stub-secret-form"]').exists()).toBe(false);
-    expect(wrapper.text()).toContain(TRUST_CARD_KEY);
+    expect(wrapper.find('[data-testid="stub-disabled-homepage"]').exists()).toBe(true);
     // No upgrade/billing copy for anonymous visitors.
     expect(wrapper.text()).not.toContain('incoming.upgrade_required_title');
-    // Headline falls back to the neutral copy — no "Send a secret" over a
-    // members-only trust card.
+    // BrandedHero (and its "Send a secret" headline) is suppressed once the
+    // private branch takes over — no marketing copy over a members-only page.
     expect(wrapper.text()).not.toContain('web.homepage.send_a_secret');
   });
 
-  it('degrades to the trust card when recipients drift to empty', async () => {
+  it('degrades to the disabled-homepage dispatcher when recipients drift to empty', async () => {
     incomingState.recipients = [];
 
     const wrapper = await mountHomepage(homepageConfig({ secrets_mode: 'incoming' }));
 
     expect(wrapper.find('[data-testid="homepage-incoming-form"]').exists()).toBe(false);
-    expect(wrapper.text()).toContain(TRUST_CARD_KEY);
+    expect(wrapper.find('[data-testid="stub-disabled-homepage"]').exists()).toBe(true);
   });
 
-  it('degrades to the trust card when the config load fails', async () => {
+  it('degrades to the disabled-homepage dispatcher when the config load fails', async () => {
     loadConfigMock.mockRejectedValue(new Error('network'));
     incomingState.configError = 'network';
     incomingState.isFeatureEnabled = false;
@@ -169,7 +180,7 @@ describe('BrandedHomepage render switch', () => {
     const wrapper = await mountHomepage(homepageConfig({ secrets_mode: 'incoming' }));
 
     expect(wrapper.find('[data-testid="homepage-incoming-form"]').exists()).toBe(false);
-    expect(wrapper.text()).toContain(TRUST_CARD_KEY);
+    expect(wrapper.find('[data-testid="stub-disabled-homepage"]').exists()).toBe(true);
   });
 
   it('never renders the create form in incoming mode', async () => {

--- a/src/tests/apps/secret/views/useDisabledConfig.spec.ts
+++ b/src/tests/apps/secret/views/useDisabledConfig.spec.ts
@@ -52,9 +52,14 @@ interface SetupOptions {
   /** Per-domain disabled-homepage variant. Null/omitted means
    *  "use the frontend DEFAULT_DISABLED_HOMEPAGE_VARIANT". */
   homepageVariant?: 'v1' | 'minimal' | 'closed' | null;
-  /** Deployment-wide default variant (ui.homepage.disabled_variant, from the
+  /** Deployment-wide default variant for the CANONICAL site
+   *  (ui.homepage.disabled_variant, from the
    *  DEFAULT_DISABLED_HOMEPAGE_VARIANT env var). */
   siteDefaultVariant?: 'v1' | 'minimal' | 'closed' | null;
+  /** Deployment-wide default variant for CUSTOM DOMAINS
+   *  (ui.homepage.custom_disabled_variant, from the
+   *  DEFAULT_CUSTOM_DOMAIN_DISABLED_HOMEPAGE_VARIANT env var). */
+  customSiteDefaultVariant?: 'v1' | 'minimal' | 'closed' | null;
   /** Tri-state operator overrides for the auto-detected affordances. */
   disabledHomepage?: {
     show_promo?: boolean | null;
@@ -107,6 +112,7 @@ function setup(opts: SetupOptions = {}) {
       homepage: {
         ...(bootstrap.ui.homepage ?? { matching_cidrs: [], mode_header: 'O-Homepage-Mode' }),
         disabled_variant: opts.siteDefaultVariant ?? null,
+        custom_disabled_variant: opts.customSiteDefaultVariant ?? null,
         public_links: {
           recipient_intro: opts.recipientIntroUrl ?? null,
         },
@@ -210,6 +216,67 @@ describe('useDisabledConfig', () => {
 
     it('per-domain homepage_config wins over the deployment-wide default', () => {
       const { config } = setup({ siteDefaultVariant: 'minimal', homepageVariant: 'v1' });
+      expect(config.variant.value).toBe('v1');
+    });
+
+    it('custom domains use ui.homepage.custom_disabled_variant, not the canonical default', () => {
+      const { config } = setup({
+        domainStrategy: 'custom',
+        siteDefaultVariant: 'minimal',
+        customSiteDefaultVariant: 'v1',
+      });
+      expect(config.variant.value).toBe('v1');
+    });
+
+    it('custom domains do NOT inherit the canonical disabled_variant (strict split)', () => {
+      // custom_disabled_variant is unset, so a custom domain goes straight to
+      // the frontend const — it must NOT fall back to the canonical 'minimal'.
+      const { config } = setup({
+        domainStrategy: 'custom',
+        siteDefaultVariant: 'minimal',
+        customSiteDefaultVariant: null,
+      });
+      expect(config.variant.value).toBe('closed');
+    });
+
+    it('the canonical site ignores custom_disabled_variant', () => {
+      const { config } = setup({
+        domainStrategy: 'canonical',
+        siteDefaultVariant: 'minimal',
+        customSiteDefaultVariant: 'v1',
+      });
+      expect(config.variant.value).toBe('minimal');
+    });
+
+    it('per-domain homepage_config wins over the custom-domain default', () => {
+      const { config } = setup({
+        domainStrategy: 'custom',
+        customSiteDefaultVariant: 'minimal',
+        homepageVariant: 'v1',
+      });
+      expect(config.variant.value).toBe('v1');
+    });
+
+    it('?variant override wins over the custom-domain default', () => {
+      window.history.replaceState({}, '', '/?variant=closed');
+      const { config } = setup({
+        domainStrategy: 'custom',
+        customSiteDefaultVariant: 'v1',
+      });
+      expect(config.variant.value).toBe('closed');
+    });
+
+    it('reacts when the domain strategy flips the deployment-wide tier', () => {
+      // Same site + custom defaults; flipping isCustom must swap which tier
+      // the resolution chain reads.
+      const { config, identity } = setup({
+        domainStrategy: 'canonical',
+        siteDefaultVariant: 'minimal',
+        customSiteDefaultVariant: 'v1',
+      });
+      expect(config.variant.value).toBe('minimal');
+
+      identity.$patch({ domainStrategy: 'custom' });
       expect(config.variant.value).toBe('v1');
     });
 


### PR DESCRIPTION
## Summary

[#3717](https://github.com/onetimesecret/onetimesecret/issues/3717)

Custom domains ignored the disabled-homepage variant system entirely. On a custom domain, `determineComponentMode()` returns `'normal'`, which routes to `BrandedHomepage.vue` — and its private/gated front door rendered a **hardcoded trust card** that never consulted the variant chain. As a result the per-domain `homepage_config.disabled_homepage_variant` (fully built in #3426), the deployment-wide default, and the frontend const were all inert on custom domains: the `DisabledHomepage` dispatcher was never reached. This was an unintended side effect of `4effa3e3f5`.

This PR reaches the dispatcher and gives custom domains their own default tier, kept decoupled from the canonical site.

- **`BrandedHomepage.vue`** — the private / incoming-degraded branch now delegates to the `DisabledHomepage` variant dispatcher (brand-aware via `useDisabledConfig`) instead of the inline trust card. `BrandedHomepage` still owns the public-vs-private decision (`allowPublicHomepage` + the runtime incoming-degradation guard); only the presentation moves to the variant system. `BrandedHero` is suppressed in the private branch because each variant renders its own hero.
- **`useDisabledConfig.ts`** — the deployment-wide tier now branches on `isCustom`: custom domains resolve `ui.homepage.custom_disabled_variant`, the canonical site keeps `ui.homepage.disabled_variant`. Custom domains do **not** fall back to the canonical default — an unset custom default goes straight to the frontend `'closed'` const (strict canonical/custom separation, matching the issue's recommended polarity).
- **`bootstrap.ts`** — adds `custom_disabled_variant` to `homepageUiConfigSchema`.
- **`config.defaults.yaml`** — adds the `DEFAULT_CUSTOM_DOMAIN_DISABLED_HOMEPAGE_VARIANT` env knob under `homepage:`.
- **`homepage_config.rb`** — doc comment updated to reflect the custom-domain fallback.

Resolution chain for custom domains:

```
?variant= URL override
  ?? homepage_config.disabled_homepage_variant   (domain-level, #3426)
  ?? ui.homepage.custom_disabled_variant          (custom-wide default, NEW)
  ?? 'closed'                                      (frontend const)
```

The canonical chain is unchanged (`… ?? ui.homepage.disabled_variant ?? 'closed'`). Custom domains remain `componentMode: 'normal'`, keeping their custom layout props (`displayPoweredBy`, minimal header Sign In) rather than the stripped disabled-homepage layout.

## Related Issues

Fixes #3717

## Test Plan

- `useDisabledConfig.spec.ts` — added cases: custom domains read `custom_disabled_variant` (not the canonical default); custom domains do not inherit `disabled_variant` (strict split → `closed`); the canonical site ignores `custom_disabled_variant`; per-domain config and `?variant` override still win; and reactivity when `isCustom` flips which tier is read.
- `BrandedHomepage.spec.ts` — the private and all incoming-degraded branches now assert the `DisabledHomepage` dispatcher renders (stubbed to keep the switch test focused); create/incoming/public branches unchanged.
- Passing locally: affected specs (68), `src/tests/apps/secret/views/` (77), bootstrap contract + store (187). Source `type-check` and lint clean. (`type-check:tests` has one pre-existing, unrelated error in the same `setup` helper, identical on the base branch.)
- Not yet exercised: a live custom domain with `DEFAULT_CUSTOM_DOMAIN_DISABLED_HOMEPAGE_VARIANT` set to each of `closed` / `minimal` / `v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPVyuNWTwiN8afefR8eyr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LtPVyuNWTwiN8afefR8eyr)_