### PR TITLE
[#3840 Phase 2] Connected Identities: connect-provider panel + session-bound SSO linking

### DIFF
--- a/apps/web/auth/config/hooks/omniauth.rb
+++ b/apps/web/auth/config/hooks/omniauth.rb
@@ -83,10 +83,19 @@ module Auth::Config::Hooks
         # account. Authenticated tenant-surface linking needs org-membership
         # verification and is a deliberate follow-up (see docs / open questions).
 
-        # Consume the account-bound connect intent. DELETE unconditionally so it
-        # can never be replayed on a later callback (single-use nonce). Bind only
-        # when the SAME session account that initiated the connect is still the
-        # authenticated one.
+        # Consume the account-bound connect intent by DELETE-on-read, then bind
+        # only when the SAME session account that initiated the connect is still
+        # the authenticated one.
+        #
+        # KNOWN GAP (fast-follow #3859): this DELETE is the ONLY site that clears
+        # the nonce, so it is NOT yet truly single-use. An abandoned connect (user
+        # cancels at the IdP, the IdP errors, or the tab is closed) never reaches
+        # this callback, so the intent stays live in the session — and the NEXT SSO
+        # callback on that session, even a plain (connect=0) sign-in, consumes it
+        # and binds. That reopens the shared-browser bind this nonce defends
+        # against, gated behind "a dangling connect intent exists." The fix is to
+        # clear stale intent at the next request phase (see the connect-intent
+        # capture in omniauth_request_validation_phase below); tracked in #3859.
         intent_account_id  = session.delete(:sso_connect_intent)
         has_connect_intent = logged_in? &&
                              !intent_account_id.nil? &&
@@ -318,6 +327,12 @@ module Auth::Config::Hooks
         # identity to the session account. CSRF/state proves "this browser
         # initiated a request"; this nonce proves "this browser initiated a
         # CONNECT for THIS account".
+        #
+        # TODO(#3859): make the nonce truly single-use — this hook is the fix
+        # site. Every subsequent SSO callback passes through here first (it mints
+        # the state the callback validates), so an `else session.delete(...)` for
+        # non-connect flows deterministically kills a nonce left dangling by an
+        # abandoned connect, before a plain (connect=0) callback can bind on it.
         if logged_in? && request.params['connect'].to_s == '1'
           session[:sso_connect_intent] = session_value
         end

--- a/apps/web/auth/config/hooks/omniauth.rb
+++ b/apps/web/auth/config/hooks/omniauth.rb
@@ -30,6 +30,87 @@ module Auth::Config::Hooks
         provider         = omniauth_provider
 
         # ────────────────────────────────────────────────────────────────
+        # #3840 Phase 2: authenticated identity connect (session == credential)
+        # ────────────────────────────────────────────────────────────────
+        #
+        # INVARIANT: email may LOCATE an account; only a demonstrated
+        # CREDENTIAL may BIND an identity. Here the credential is an ACTIVE
+        # AUTHENTICATED SESSION whose account IS the located account — the
+        # strongest possible proof of ownership. When a logged-in user connects
+        # a NEW IdP to their OWN account, bind it.
+        #
+        # Evaluated FIRST (before the trusted-provider auto-link and the H-3
+        # refusal below) because a proven session credential outranks the
+        # email-only heuristics those branches rely on. It is reached only for a
+        # NEW identity: an existing (provider, issuer, uid) row routes the gem to
+        # account_from_omniauth_identity and never enters this hook.
+        #
+        # SECURITY TRAPS (all three are guarded here):
+        #   (a) NEVER return nil on the located==self path — nil falls through to
+        #       omniauth_create_account, which inserts the located email and 500s
+        #       on the unique accounts.email index. Return the located account so
+        #       the gem's create_omniauth_identity upserts the (provider, issuer,
+        #       uid) row onto THAT already-authenticated account (confirmed vs
+        #       rodauth-omniauth 0.6.2 _handle_omniauth_callback: a returned
+        #       account skips create-account, and create_omniauth_identity binds
+        #       the row to account_id, then login re-affirms the same session).
+        #   (b) TAKEOVER GUARD: bind ONLY when the located account IS the session
+        #       account. If logged in but the email locates a DIFFERENT account
+        #       (or no account at all), refuse — never silently take over another
+        #       account, never create a duplicate.
+        #   (c) SURFACE ISOLATION: bind ONLY on the PLATFORM surface
+        #       (session[:validated_omniauth_domain_id] nil). A tenant callback
+        #       must not bind a tenant-issuer identity via this flow: a tenant
+        #       admin controls their IdP's assertions, so a tenant identity bound
+        #       onto an account would hand them a login into it. Tenant-surface
+        #       authenticated linking needs org-membership verification and is a
+        #       deliberate follow-up (see docs / open questions).
+        if logged_in?
+          session_account_id = session_value
+          platform_path      = session[:validated_omniauth_domain_id].nil?
+          located_is_self    = existing &&
+                               existing[account_id_column].to_s == session_account_id.to_s
+
+          if platform_path && located_is_self
+            Auth::Logging.log_auth_event(
+              :omniauth_identity_connected,
+              level: :warn,
+              email: OT::Utils.obscure_email(normalized_email),
+              provider: provider,
+              issuer: resolved_issuer,
+              account_id: session_account_id,
+            )
+            next existing
+          end
+
+          # Logged in but NOT a clean self-bind on the platform surface:
+          #   - tenant callback            => wrong surface (isolation)
+          #   - located account != self    => cross-account conflict (takeover)
+          #   - no account for this email  => would spawn a duplicate on JIT create
+          # Refuse in all cases. NEVER fall through to the trusted-provider or
+          # H-3 branches (which reason about email only) or to JIT create.
+          refuse_reason =
+            if !platform_path
+              'tenant_surface'
+            elsif existing
+              'account_conflict'
+            else
+              'no_matching_account'
+            end
+          Auth::Logging.log_auth_event(
+            :omniauth_identity_connect_refused,
+            level: :warn,
+            email: OT::Utils.obscure_email(normalized_email),
+            provider: provider,
+            reason: refuse_reason,
+          )
+          set_redirect_error_flash 'This identity could not be connected to your account. ' \
+                                   'It may already belong to a different account, or the ' \
+                                   'connection was started on the wrong domain.'
+          redirect '/signin?auth_error=identity_connect_conflict'
+        end
+
+        # ────────────────────────────────────────────────────────────────
         # #3836: opt-in, per-provider, boot-guarded email-based linking
         # ────────────────────────────────────────────────────────────────
         #

--- a/apps/web/auth/config/hooks/omniauth.rb
+++ b/apps/web/auth/config/hooks/omniauth.rb
@@ -26,89 +26,95 @@ module Auth::Config::Hooks
       # Uses NFC normalization and :fold for international email addresses.
       auth.account_from_omniauth do
         normalized_email = OT::Utils.normalize_email(omniauth_email)
-        existing         = _account_from_login(normalized_email)
         provider         = omniauth_provider
 
         # ────────────────────────────────────────────────────────────────
         # #3840 Phase 2: authenticated identity connect (session == credential)
         # ────────────────────────────────────────────────────────────────
         #
-        # INVARIANT: email may LOCATE an account; only a demonstrated
-        # CREDENTIAL may BIND an identity. Here the credential is an ACTIVE
-        # AUTHENTICATED SESSION whose account IS the located account — the
-        # strongest possible proof of ownership. When a logged-in user connects
-        # a NEW IdP to their OWN account, bind it.
+        # CANONICAL PRACTICE: when the caller is ALREADY AUTHENTICATED, the
+        # active session IS the authorization to bind a new identity. Bind the
+        # new (provider, issuer, uid) to the LOGGED-IN account, whatever email
+        # the IdP asserted. The IdP email plays NO role in the decision —
+        # matching the connect to an email-LOCATED account is the
+        # pre-account-hijacking anti-pattern: an attacker who controls an IdP
+        # that emits a victim's email must never be routed to the victim's
+        # account. We route by session, so the victim is untouched even if the
+        # IdP lies about the email.
+        #
+        # "Already linked elsewhere" cannot occur here: an existing
+        # (provider, issuer, uid) row routes the gem to
+        # account_from_omniauth_identity (rodauth-omniauth 0.6.2
+        # _handle_omniauth_callback), so this hook is reached ONLY for a NEW
+        # identity. The real control on this path is the CSRF/state protection
+        # on the connect INITIATION — the omniauth request phase is POST-only,
+        # the session cookie is SameSite=Lax (lib/onetime/boot.rb), and OAuth
+        # state is validated on callback — NOT email matching.
         #
         # Evaluated FIRST (before the trusted-provider auto-link and the H-3
-        # refusal below) because a proven session credential outranks the
-        # email-only heuristics those branches rely on. It is reached only for a
-        # NEW identity: an existing (provider, issuer, uid) row routes the gem to
-        # account_from_omniauth_identity and never enters this hook.
+        # refusal below): a proven session credential outranks the email-only
+        # heuristics those branches rely on.
         #
-        # SECURITY TRAPS (all three are guarded here):
-        #   (a) NEVER return nil on the located==self path — nil falls through to
-        #       omniauth_create_account, which inserts the located email and 500s
-        #       on the unique accounts.email index. Return the located account so
-        #       the gem's create_omniauth_identity upserts the (provider, issuer,
-        #       uid) row onto THAT already-authenticated account (confirmed vs
-        #       rodauth-omniauth 0.6.2 _handle_omniauth_callback: a returned
-        #       account skips create-account, and create_omniauth_identity binds
-        #       the row to account_id, then login re-affirms the same session).
-        #   (b) TAKEOVER GUARD: bind ONLY when the located account IS the session
-        #       account. If logged in but the email locates a DIFFERENT account
-        #       (or no account at all), refuse — never silently take over another
-        #       account, never create a duplicate.
-        #   (c) SURFACE ISOLATION: bind ONLY on the PLATFORM surface
-        #       (session[:validated_omniauth_domain_id] nil). A tenant callback
-        #       must not bind a tenant-issuer identity via this flow: a tenant
-        #       admin controls their IdP's assertions, so a tenant identity bound
-        #       onto an account would hand them a login into it. Tenant-surface
-        #       authenticated linking needs org-membership verification and is a
-        #       deliberate follow-up (see docs / open questions).
+        # Return semantics: the gem sets @account to whatever this block
+        # returns, skips create-account (account is present), and
+        # create_omniauth_identity binds the (provider, issuer, uid) row to
+        # that account's id; login then re-affirms the same session. So we must
+        # return the SESSION account row (loaded by id), never nil (nil would
+        # fall through to omniauth_create_account and 500 on the unique
+        # accounts.email index).
+        #
+        # SURFACE ISOLATION (the one refusal retained on this path): bind ONLY
+        # on the PLATFORM surface (session[:validated_omniauth_domain_id] nil).
+        # A tenant callback must not bind a tenant-issuer identity onto a
+        # platform-session account — a tenant admin controls their IdP's
+        # assertions, so such a binding would hand them a login into the
+        # account. Authenticated tenant-surface linking needs org-membership
+        # verification and is a deliberate follow-up (see docs / open questions).
         if logged_in?
-          session_account_id = session_value
-          platform_path      = session[:validated_omniauth_domain_id].nil?
-          located_is_self    = existing &&
-                               existing[account_id_column].to_s == session_account_id.to_s
-
-          if platform_path && located_is_self
+          if session[:validated_omniauth_domain_id]
+            # Tenant callback on a platform session → refuse (surface isolation).
             Auth::Logging.log_auth_event(
-              :omniauth_identity_connected,
+              :omniauth_identity_connect_refused,
               level: :warn,
-              email: OT::Utils.obscure_email(normalized_email),
               provider: provider,
-              issuer: resolved_issuer,
-              account_id: session_account_id,
+              reason: 'tenant_surface',
             )
-            next existing
+            set_redirect_error_flash 'This identity could not be connected. The connection ' \
+                                     'was started on the wrong domain.'
+            redirect '/signin?auth_error=identity_connect_conflict'
           end
 
-          # Logged in but NOT a clean self-bind on the platform surface:
-          #   - tenant callback            => wrong surface (isolation)
-          #   - located account != self    => cross-account conflict (takeover)
-          #   - no account for this email  => would spawn a duplicate on JIT create
-          # Refuse in all cases. NEVER fall through to the trusted-provider or
-          # H-3 branches (which reason about email only) or to JIT create.
-          refuse_reason =
-            if !platform_path
-              'tenant_surface'
-            elsif existing
-              'account_conflict'
-            else
-              'no_matching_account'
-            end
+          # Load the authenticated account by SESSION id (never by email).
+          # _account_from_session applies the open-status filter and returns nil
+          # exactly when the session account is no longer usable (e.g. closed
+          # mid-session) — refuse rather than fall through to a JIT duplicate.
+          session_account = _account_from_session
+          unless session_account
+            Auth::Logging.log_auth_event(
+              :omniauth_identity_connect_refused,
+              level: :warn,
+              provider: provider,
+              reason: 'session_account_missing',
+            )
+            set_redirect_error_flash 'This identity could not be connected to your account.'
+            redirect '/signin?auth_error=identity_connect_conflict'
+          end
+
           Auth::Logging.log_auth_event(
-            :omniauth_identity_connect_refused,
+            :omniauth_identity_connected,
             level: :warn,
             email: OT::Utils.obscure_email(normalized_email),
             provider: provider,
-            reason: refuse_reason,
+            issuer: resolved_issuer,
+            account_id: session_account[account_id_column],
           )
-          set_redirect_error_flash 'This identity could not be connected to your account. ' \
-                                   'It may already belong to a different account, or the ' \
-                                   'connection was started on the wrong domain.'
-          redirect '/signin?auth_error=identity_connect_conflict'
+          next session_account
         end
+
+        # Not authenticated: email is the only signal available, so the
+        # email-based branches below apply. Locate an existing account by the
+        # SAME normalized email each of them uses.
+        existing = _account_from_login(normalized_email)
 
         # ────────────────────────────────────────────────────────────────
         # #3836: opt-in, per-provider, boot-guarded email-based linking
@@ -162,12 +168,11 @@ module Auth::Config::Hooks
           # domain-validation hook below also runs only on the CREATE path, so
           # the email-link path would bypass it entirely.
           #
-          # FOLLOW-UP (needs a tracked ticket): no authenticated "link SSO from
-          # account settings" flow exists yet, so a password-first user who then
-          # tries SSO can only self-resolve by signing in with their password (the
-          # flash below tells them so) — they cannot complete the link themselves.
-          # Ship a companion authenticated account-linking UI so this refusal
-          # becomes a recoverable step instead of a dead end.
+          # RECOVERY (Phase 2, shipped): a password-first user who hits this
+          # refusal self-resolves by signing in with their password, then
+          # connecting the IdP from account settings (Connected Identities) —
+          # the authenticated connect branch at the top of this hook binds it.
+          # The flash below points them at that path.
           Auth::Logging.log_auth_event(
             :omniauth_link_refused_existing_account,
             level: :warn,

--- a/apps/web/auth/config/hooks/omniauth.rb
+++ b/apps/web/auth/config/hooks/omniauth.rb
@@ -29,31 +29,43 @@ module Auth::Config::Hooks
         provider         = omniauth_provider
 
         # ────────────────────────────────────────────────────────────────
-        # #3840 Phase 2: authenticated identity connect (session == credential)
+        # #3840 Phase 2: authenticated identity connect (session BINDS, but only
+        # with an account-bound CONNECT INTENT established at initiation)
         # ────────────────────────────────────────────────────────────────
         #
-        # CANONICAL PRACTICE: when the caller is ALREADY AUTHENTICATED, the
-        # active session IS the authorization to bind a new identity. Bind the
-        # new (provider, issuer, uid) to the LOGGED-IN account, whatever email
-        # the IdP asserted. The IdP email plays NO role in the decision —
-        # matching the connect to an email-LOCATED account is the
-        # pre-account-hijacking anti-pattern: an attacker who controls an IdP
-        # that emits a victim's email must never be routed to the victim's
-        # account. We route by session, so the victim is untouched even if the
-        # IdP lies about the email.
+        # CANONICAL PRACTICE: an active session is the authorization to bind a
+        # new identity — BUT logged_in? alone is NOT proof of connect intent.
+        # Tabs share cookies, so a plain second-tab / shared-browser SSO sign-in
+        # arriving on an already-authenticated session must NOT be treated as a
+        # connect. We therefore require TWO signals to bind:
+        #   1. an authenticated session (session_value), and
+        #   2. an account-bound connect intent set during INITIATION — the
+        #      omniauth_request_validation_phase hook above stashes
+        #      session[:sso_connect_intent] = session_value only when the
+        #      logged-in caller POSTed connect=1 (the Connected Identities
+        #      panel). CSRF/state proves "this browser initiated a request"; the
+        #      intent nonce proves "this browser initiated a CONNECT for THIS
+        #      account".
+        # We consume (DELETE) the nonce here, and bind ONLY when it matches the
+        # CURRENT session account. Absent/mismatched intent → fall through to the
+        # email-based branches exactly as an unauthenticated caller would (never
+        # silently bind onto the session account — that was the #3840 P1 finding).
+        #
+        # The IdP email still plays NO role in the bind decision. Matching a
+        # connect to an email-LOCATED account is the pre-account-hijacking
+        # anti-pattern: an attacker who controls an IdP that emits a victim's
+        # email must never be routed to the victim's account. We route by
+        # session, so the victim is untouched even if the IdP lies about email.
         #
         # "Already linked elsewhere" cannot occur here: an existing
         # (provider, issuer, uid) row routes the gem to
         # account_from_omniauth_identity (rodauth-omniauth 0.6.2
         # _handle_omniauth_callback), so this hook is reached ONLY for a NEW
-        # identity. The real control on this path is the CSRF/state protection
-        # on the connect INITIATION — the omniauth request phase is POST-only,
-        # the session cookie is SameSite=Lax (lib/onetime/boot.rb), and OAuth
-        # state is validated on callback — NOT email matching.
+        # identity.
         #
         # Evaluated FIRST (before the trusted-provider auto-link and the H-3
-        # refusal below): a proven session credential outranks the email-only
-        # heuristics those branches rely on.
+        # refusal below): a proven session credential + connect intent outranks
+        # the email-only heuristics those branches rely on.
         #
         # Return semantics: the gem sets @account to whatever this block
         # returns, skips create-account (account is present), and
@@ -70,7 +82,17 @@ module Auth::Config::Hooks
         # assertions, so such a binding would hand them a login into the
         # account. Authenticated tenant-surface linking needs org-membership
         # verification and is a deliberate follow-up (see docs / open questions).
-        if logged_in?
+
+        # Consume the account-bound connect intent. DELETE unconditionally so it
+        # can never be replayed on a later callback (single-use nonce). Bind only
+        # when the SAME session account that initiated the connect is still the
+        # authenticated one.
+        intent_account_id  = session.delete(:sso_connect_intent)
+        has_connect_intent = logged_in? &&
+                             !intent_account_id.nil? &&
+                             intent_account_id.to_s == session_value.to_s
+
+        if has_connect_intent
           if session[:validated_omniauth_domain_id]
             # Tenant callback on a platform session → refuse (surface isolation).
             Auth::Logging.log_auth_event(
@@ -109,11 +131,26 @@ module Auth::Config::Hooks
             account_id: session_account[account_id_column],
           )
           next session_account
+        elsif logged_in?
+          # Logged in but NO valid connect intent: a plain SSO sign-in on an
+          # already-authenticated session (second tab, shared browser), or an
+          # intent that was set for a DIFFERENT account. Do NOT bind onto the
+          # session account — fall through to the email-based branches below and
+          # treat this exactly like an unauthenticated caller. Log it: a callback
+          # reaching an authenticated session without connect intent is the
+          # precise shape of the shared-browser/second-tab hazard the intent
+          # nonce defends against, so it is worth observing.
+          Auth::Logging.log_auth_event(
+            :omniauth_connect_intent_absent,
+            level: :info,
+            provider: provider,
+            had_intent: !intent_account_id.nil?,
+          )
         end
 
-        # Not authenticated: email is the only signal available, so the
-        # email-based branches below apply. Locate an existing account by the
-        # SAME normalized email each of them uses.
+        # Not authenticated (or logged-in without connect intent): email is the
+        # only signal available, so the email-based branches below apply. Locate
+        # an existing account by the SAME normalized email each of them uses.
         existing = _account_from_login(normalized_email)
 
         # ────────────────────────────────────────────────────────────────
@@ -248,11 +285,42 @@ module Auth::Config::Hooks
       # See: lib/onetime/middleware/security.rb (Rack::Protection config)
       #
       auth.omniauth_request_validation_phase do
-        # ⚠️  INTENTIONALLY EMPTY - DO NOT ADD CODE HERE
+        # ⚠️  DO NOT call check_csrf / check_csrf? here.
         #
-        # This empty block skips Roda's route_csrf validation.
-        # OAuth state parameter provides CSRF protection instead.
-        # Removing this block breaks SSO with "encoded token is not a string".
+        # The default body is `check_csrf if check_csrf?`. Re-introducing it
+        # breaks SSO with "encoded token is not a string" (Rack::Protection is
+        # skipped for /auth/sso/*, so session[:csrf] is absent and route_csrf
+        # decodes nil). OAuth's state parameter provides CSRF protection instead.
+        #
+        # ────────────────────────────────────────────────────────────────
+        # #3840 Phase 2: CAPTURE account-bound CONNECT INTENT (the ONE thing
+        # this block may do — it does NOT validate CSRF).
+        # ────────────────────────────────────────────────────────────────
+        #
+        # This hook runs during the SSO REQUEST phase (POST /auth/sso/:provider),
+        # BEFORE the redirect to the IdP — verified in rodauth-omniauth 0.6.2 /
+        # omniauth 2.1.4 (strategy.rb request_call:240 and mock_request_call:325
+        # both call request_validation_phase, and it runs inside omniauth_run's
+        # set_omniauth_session so `session` is the Rodauth session). It has access
+        # to request.params and session.
+        #
+        # The Connected Identities panel initiates the connect flow with the form
+        # field connect=1; a plain sign-in does NOT send it. When a LOGGED-IN
+        # caller initiates a connect, stash an ACCOUNT-BOUND intent nonce (the
+        # session account id, not a bare boolean) so the callback can verify the
+        # SAME account that initiated is the one being bound. The callback
+        # (account_from_omniauth) consumes and deletes it.
+        #
+        # WHY THIS EXISTS (security): logged_in? alone is NOT connect intent.
+        # Tabs share cookies, so without this an ordinary second-tab / shared-
+        # browser SSO sign-in arriving on an already-authenticated session would
+        # be routed through the bind path and permanently attach the arriving IdP
+        # identity to the session account. CSRF/state proves "this browser
+        # initiated a request"; this nonce proves "this browser initiated a
+        # CONNECT for THIS account".
+        if logged_in? && request.params['connect'].to_s == '1'
+          session[:sso_connect_intent] = session_value
+        end
       end
 
       # NOTE: before_omniauth_callback_route is OWNED by omniauth_tenant.rb

--- a/apps/web/auth/router.rb
+++ b/apps/web/auth/router.rb
@@ -15,6 +15,7 @@ require_relative 'config'
 require_relative 'error_translator'
 require_relative 'routes/account'
 require_relative 'routes/active_sessions'
+require_relative 'routes/identities'
 require_relative 'routes/mfa'
 require_relative 'routes/admin'
 require_relative 'routes/health'
@@ -40,6 +41,7 @@ module Auth
     include Auth::Routes::Account
     include Auth::Routes::MFA
     include Auth::Routes::ActiveSessions
+    include Auth::Routes::Identities
     include Auth::Routes::Admin
 
     plugin :json, parser: true  # Parse incoming JSON request bodies
@@ -149,6 +151,9 @@ module Auth
 
       # Active sessions routes
       handle_active_sessions_routes(r)
+
+      # Linked SSO identities management routes (#3840 Phase 2)
+      handle_identities_routes(r)
 
       handle_admin_routes(r)
 

--- a/apps/web/auth/routes/identities.rb
+++ b/apps/web/auth/routes/identities.rb
@@ -1,0 +1,145 @@
+# apps/web/auth/routes/identities.rb
+#
+# frozen_string_literal: true
+
+#
+# JSON API for managing an account's linked SSO identities (#3840 Phase 2).
+#
+# Mirrors routes/active_sessions.rb: list + delete-one of a per-account
+# resource, scoped strictly to the CURRENT account. Rows live in the
+# account_identities table keyed on (provider, issuer, uid) — see
+# migrations/006_omniauth_identities.rb + 008_issuer_scoped_identities.rb.
+#
+# SECURITY:
+#   - Every query is scoped by account_id = rodauth.session_value, so a caller
+#     can never see or delete another account's identities (no IDOR): a
+#     cross-account id filters to zero rows and yields 404, never a delete.
+#   - DELETE enforces last-credential safety: an SSO-only account (no usable
+#     password) may not remove its FINAL identity, which would lock it out.
+#     Accounts that have a password may remove identities freely.
+#
+# NOTE: account_identities has NO created_at column (not added by 006/008), so
+# the list does not return one. `uid` (the IdP `sub`) is masked for display —
+# the row `id` is the delete handle, so the full uid is never needed client-side.
+#
+module Auth
+  module Routes
+    module Identities
+      def handle_identities_routes(r)
+        r.on 'identities' do
+          # Require authentication for all identity management endpoints.
+          unless rodauth.logged_in?
+            response.status = 401
+            next { error: 'Authentication required' }
+          end
+
+          # Account id straight from the session — no account load required, and
+          # the scoping key for every query below.
+          account_id = rodauth.session_value
+          unless account_id
+            response.status = 401
+            next { error: 'Invalid session' }
+          end
+
+          # Scoped dataset — NEVER widened. All reads/writes below derive from it,
+          # so cross-account access is impossible by construction.
+          identities_ds = rodauth.db[:account_identities].where(account_id: account_id)
+
+          # GET /auth/identities
+          # List the current account's linked SSO identities.
+          r.get do
+            rows = identities_ds.order(:id).all
+
+            identities_data = rows.map { |row| serialize_identity(row) }
+
+            response.headers['Content-Type'] = 'application/json'
+            { identities: identities_data }
+          rescue StandardError => ex
+            auth_logger.error 'Error fetching identities',
+              {
+                exception: ex,
+                account_id: account_id,
+              }
+
+            response.status = 500
+            { error: 'Failed to fetch identities' }
+          end
+
+          # DELETE /auth/identities/:id
+          # Remove ONE identity, iff it belongs to the current account.
+          # Integer matcher: a non-numeric segment simply doesn't match here and
+          # falls through to the router's 404.
+          r.is Integer do |identity_id|
+            next unless r.delete?
+
+            # Scope by BOTH id AND account_id (the dataset already pins
+            # account_id). A cross-account id resolves to nil => 404, never a
+            # delete of someone else's identity.
+            target = identities_ds.where(id: identity_id).first
+            unless target
+              response.status = 404
+              next { error: 'Identity not found' }
+            end
+
+            # Last-credential safety: refuse to remove the FINAL sign-in method of
+            # an account that has no usable password (SSO-only) — that would lock
+            # the account out with no way back in. has_password? checks the
+            # session account's password hash. Accounts WITH a password may remove
+            # identities freely.
+            if identities_ds.count <= 1 && !rodauth.has_password?
+              response.status = 409
+              next {
+                error: 'Cannot remove your only sign-in method. ' \
+                       'Set a password first, then remove this identity.',
+                error_code: 'last_credential',
+              }
+            end
+
+            identities_ds.where(id: identity_id).delete
+
+            auth_logger.warn 'SSO identity disconnected',
+              {
+                account_id: account_id,
+                provider: target[:provider],
+              }
+
+            response.headers['Content-Type'] = 'application/json'
+            { success: 'Identity removed successfully' }
+          rescue StandardError => ex
+            auth_logger.error 'Error removing identity',
+              {
+                exception: ex,
+                account_id: account_id,
+                identity_id: identity_id,
+              }
+
+            response.status = 500
+            { error: 'Failed to remove identity' }
+          end
+        end
+      end
+
+      private
+
+      # Transform an account_identities row into the wire shape. `uid` is masked
+      # (display-only); the row `id` is the stable delete handle.
+      def serialize_identity(row)
+        {
+          id: row[:id],
+          provider: row[:provider],
+          issuer: row[:issuer].to_s,
+          uid: mask_uid(row[:uid]),
+        }
+      end
+
+      # Mask the IdP subject identifier for display. Keeps enough to disambiguate
+      # without echoing the full opaque `sub`. Short uids are fully masked.
+      def mask_uid(uid)
+        s = uid.to_s
+        return '***' if s.length <= 8
+
+        "#{s[0, 4]}…#{s[-4, 4]}"
+      end
+    end
+  end
+end

--- a/apps/web/auth/routes/identities.rb
+++ b/apps/web/auth/routes/identities.rb
@@ -74,19 +74,47 @@ module Auth
 
             # Scope by BOTH id AND account_id (the dataset already pins
             # account_id). A cross-account id resolves to nil => 404, never a
-            # delete of someone else's identity.
-            target = identities_ds.where(id: identity_id).first
-            unless target
-              response.status = 404
-              next { error: 'Identity not found' }
+            # delete of someone else's identity. Built once, reused for the delete.
+            scoped = identities_ds.where(id: identity_id)
+
+            # Existence check, last-credential guard, and delete run inside ONE
+            # transaction with an account-scoped row lock, closing a TOCTOU: two
+            # concurrent DELETEs for DIFFERENT ids of the same SSO-only account
+            # could each observe count==2 and both pass the last-credential check,
+            # stripping every sign-in method.
+            #
+            # for_update.all issues "SELECT ... FOR UPDATE": on PostgreSQL this
+            # row-locks the account's identity rows, so a concurrent DELETE for
+            # the same account blocks here until we commit; on SQLite the lock
+            # clause is dropped and SQLite serializes writers anyway, so neither
+            # backend raises. Count/existence are derived from this single locked
+            # fetch — no redundant per-id re-query.
+            #
+            # NOTE: do NOT use identities_ds.for_update.count — Sequel emits
+            # "SELECT count(*) ... FOR UPDATE", which PostgreSQL REJECTS (FOR
+            # UPDATE is not allowed with aggregates). Materialize, then count in Ruby.
+            #
+            # has_password? checks the session account's password hash. Accounts
+            # WITH a password may remove identities freely.
+            result = rodauth.db.transaction do
+              locked = identities_ds.for_update.all
+              target = locked.find { |row| row[:id] == identity_id }
+
+              if target.nil?
+                :not_found
+              elsif locked.size <= 1 && !rodauth.has_password?
+                :last_credential
+              else
+                scoped.delete
+                { provider: target[:provider] }
+              end
             end
 
-            # Last-credential safety: refuse to remove the FINAL sign-in method of
-            # an account that has no usable password (SSO-only) — that would lock
-            # the account out with no way back in. has_password? checks the
-            # session account's password hash. Accounts WITH a password may remove
-            # identities freely.
-            if identities_ds.count <= 1 && !rodauth.has_password?
+            case result
+            when :not_found
+              response.status = 404
+              next { error: 'Identity not found' }
+            when :last_credential
               response.status = 409
               next {
                 error: 'Cannot remove your only sign-in method. ' \
@@ -95,12 +123,10 @@ module Auth
               }
             end
 
-            identities_ds.where(id: identity_id).delete
-
             auth_logger.warn 'SSO identity disconnected',
               {
                 account_id: account_id,
-                provider: target[:provider],
+                provider: result[:provider],
               }
 
             response.headers['Content-Type'] = 'application/json'

--- a/apps/web/auth/spec/integration/full/identities_routes_spec.rb
+++ b/apps/web/auth/spec/integration/full/identities_routes_spec.rb
@@ -1,0 +1,260 @@
+# apps/web/auth/spec/integration/full/identities_routes_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration (full mode)
+# =============================================================================
+#
+# Issue: #3840 Phase 2 — JSON API to manage an account's linked SSO identities
+#        (apps/web/auth/routes/identities.rb).
+#
+# WHAT IT LOCKS IN:
+#   - GET  /auth/identities lists ONLY the current account's rows (no leak).
+#   - DELETE /auth/identities/:id removes a row iff it belongs to the caller;
+#     a cross-account id yields 404 and deletes nothing (no IDOR).
+#   - Unauthenticated requests are rejected (401).
+#   - Last-credential safety: an SSO-only account (no usable password) may not
+#     delete its final identity (409); an account WITH a password may.
+#   - `uid` is masked in the list response.
+#
+# REQUIREMENTS:
+# - Valkey running on port 2121: pnpm run test:database:start
+# - AUTHENTICATION_MODE=full, AUTH_DATABASE_URL (SQLite in-memory)
+#
+# RUN:
+#   RACK_ENV=test AUTHENTICATION_MODE=full AUTH_DATABASE_URL=sqlite::memory: \
+#     ORGS_SSO_ENABLED=true LANG=en_US.UTF-8 \
+#     bundle exec rspec apps/web/auth/spec/integration/full/identities_routes_spec.rb \
+#     --tag '~postgres_database'
+# =============================================================================
+
+require_relative '../../spec_helper'
+
+RSpec.describe 'Linked identities management API (#3840 Phase 2)', type: :integration do
+  include Rack::Test::Methods
+
+  TEST_PASSWORD = 'TestPassword123!'
+
+  def app
+    Onetime::Application::Registry.generate_rack_url_map
+  end
+
+  before(:all) do
+    require 'onetime'
+    require 'onetime/application/registry'
+    require 'onetime/auth_config'
+
+    Onetime.auth_config.reload! if Onetime.respond_to?(:auth_config) && Onetime.auth_config.respond_to?(:reload!)
+    Onetime::Application::Registry.reset! if Onetime::Application::Registry.respond_to?(:reset!)
+
+    Onetime.boot!(:test, force: true)
+
+    Onetime::Application::Registry.prepare_application_registry
+
+    mounts = Onetime::Application::Registry.mount_mappings.keys
+    raise "Auth app not mounted post-boot: #{mounts.inspect}" unless mounts.any? { |m| m.include?('/auth') }
+  end
+
+  let(:identities) { auth_db[:account_identities] }
+
+  # ==========================================================================
+  # Helpers
+  # ==========================================================================
+
+  def seed_account_with_password(email, password: TEST_PASSWORD)
+    normalized = OT::Utils.normalize_email(email)
+    customer   = Onetime::Customer.new(email: normalized)
+    customer.save
+    account_id = auth_db[:accounts].insert(
+      email: normalized,
+      status_id: AuthTestConstants::STATUS_VERIFIED,
+      external_id: customer.extid,
+    )
+    require 'argon2'
+    hasher     = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
+    auth_db[:account_password_hashes].insert(id: account_id, password_hash: hasher.create(password))
+    account_id
+  end
+
+  def remove_password(account_id)
+    auth_db[:account_password_hashes].where(id: account_id).delete
+  end
+
+  def seed_identity(account_id, provider: 'oidc', uid: nil, issuer: 'https://idp.example.com')
+    uid ||= "sub-#{SecureRandom.hex(10)}"
+    id    = identities.insert(account_id: account_id, provider: provider, uid: uid, issuer: issuer)
+    { id: id, uid: uid }
+  end
+
+  def clear_body_headers
+    header 'Content-Type', nil
+    header 'Content-Length', nil
+  end
+
+  # Establish an authenticated session via password login.
+  def csrf_login(email, password: TEST_PASSWORD)
+    clear_body_headers
+    header 'Accept', 'application/json'
+    get '/auth'
+    token = last_response.headers['X-CSRF-Token']
+
+    header 'Content-Type', 'application/json'
+    header 'Accept', 'application/json'
+    header 'X-CSRF-Token', token if token
+    post '/auth/login', JSON.generate(login: email, password: password, shrimp: token)
+    expect(last_response.status).to be_between(200, 302),
+      "Precondition failed: login for #{email} returned #{last_response.status}: #{last_response.body}"
+  end
+
+  def get_identities
+    clear_body_headers
+    header 'Accept', 'application/json'
+    get '/auth/identities'
+  end
+
+  # DELETE with a fresh CSRF token (the route is a non-SSO /auth path, so
+  # Rack::Protection requires the shrimp token on the unsafe verb).
+  def delete_identity(id)
+    clear_body_headers
+    header 'Accept', 'application/json'
+    get '/auth'
+    token = last_response.headers['X-CSRF-Token']
+    header 'X-CSRF-Token', token if token
+    delete "/auth/identities/#{id}"
+  end
+
+  def json_body
+    JSON.parse(last_response.body)
+  end
+
+  # ==========================================================================
+  # Authentication gate
+  # ==========================================================================
+
+  describe 'authentication required' do
+    it 'GET /auth/identities returns 401 when unauthenticated' do
+      get_identities
+      expect(last_response.status).to eq(401)
+      expect(json_body).to include('error')
+    end
+
+    it 'DELETE /auth/identities/:id returns 401 when unauthenticated' do
+      account_id = seed_account_with_password("solo-#{SecureRandom.hex(6)}@example.com")
+      row        = seed_identity(account_id)
+      delete_identity(row[:id])
+      expect(last_response.status).to eq(401)
+      # The row must be untouched.
+      expect(identities.where(id: row[:id]).count).to eq(1)
+    end
+  end
+
+  # ==========================================================================
+  # GET — own rows only
+  # ==========================================================================
+
+  describe 'GET /auth/identities' do
+    it 'returns only the current account rows with masked uid and no created_at' do
+      a_email = "a-#{SecureRandom.hex(6)}@example.com"
+      b_email = "b-#{SecureRandom.hex(6)}@example.com"
+      a_id    = seed_account_with_password(a_email)
+      b_id    = seed_account_with_password(b_email)
+
+      a_row1 = seed_identity(a_id, provider: 'oidc')
+      a_row2 = seed_identity(a_id, provider: 'entra')
+      b_row  = seed_identity(b_id, provider: 'oidc')
+
+      csrf_login(a_email)
+      get_identities
+
+      expect(last_response.status).to eq(200)
+      body = json_body
+      expect(body).to have_key('identities')
+
+      returned_ids = body['identities'].map { |h| h['id'] }
+      expect(returned_ids).to contain_exactly(a_row1[:id], a_row2[:id])
+      expect(returned_ids).not_to include(b_row[:id])
+
+      row = body['identities'].find { |h| h['id'] == a_row1[:id] }
+      expect(row.keys).to match_array(%w[id provider issuer uid])
+      expect(row).not_to have_key('created_at')
+      expect(row['provider']).to eq('oidc')
+      # uid is masked, not the raw subject.
+      expect(row['uid']).not_to eq(a_row1[:uid])
+      expect(row['uid']).to include('…')
+    end
+  end
+
+  # ==========================================================================
+  # DELETE — ownership scoping (no IDOR)
+  # ==========================================================================
+
+  describe 'DELETE /auth/identities/:id' do
+    it 'removes an identity that belongs to the caller' do
+      email      = "own-#{SecureRandom.hex(6)}@example.com"
+      account_id = seed_account_with_password(email)
+      keep       = seed_identity(account_id, provider: 'oidc')
+      drop       = seed_identity(account_id, provider: 'entra')
+
+      csrf_login(email)
+      delete_identity(drop[:id])
+
+      expect(last_response.status).to eq(200)
+      expect(json_body).to include('success')
+      expect(identities.where(id: drop[:id]).count).to eq(0)
+      expect(identities.where(id: keep[:id]).count).to eq(1)
+    end
+
+    it 'returns 404 and deletes nothing for a cross-account id (no IDOR)' do
+      a_email = "a-#{SecureRandom.hex(6)}@example.com"
+      b_email = "b-#{SecureRandom.hex(6)}@example.com"
+      a_id    = seed_account_with_password(a_email)
+      b_id    = seed_account_with_password(b_email)
+      seed_identity(a_id) # A needs an identity so the account is not identity-less
+      b_row   = seed_identity(b_id)
+
+      csrf_login(a_email)
+      delete_identity(b_row[:id])
+
+      expect(last_response.status).to eq(404)
+      # B's identity must be intact — A cannot delete it.
+      expect(identities.where(id: b_row[:id]).count).to eq(1)
+    end
+  end
+
+  # ==========================================================================
+  # Last-credential safety
+  # ==========================================================================
+
+  describe 'last-credential safety' do
+    it 'refuses (409) to remove the final identity of an SSO-only account' do
+      email      = "ssoonly-#{SecureRandom.hex(6)}@example.com"
+      account_id = seed_account_with_password(email)
+      row        = seed_identity(account_id)
+
+      csrf_login(email)
+      # Make the account SSO-only: drop the password AFTER login (the session
+      # cookie stays valid; has_password? re-queries at delete time).
+      remove_password(account_id)
+
+      delete_identity(row[:id])
+
+      expect(last_response.status).to eq(409)
+      expect(json_body['error_code']).to eq('last_credential')
+      expect(identities.where(id: row[:id]).count).to eq(1),
+        'The only sign-in method must not be removed'
+    end
+
+    it 'allows removing the final identity when the account has a password' do
+      email      = "haspw-#{SecureRandom.hex(6)}@example.com"
+      account_id = seed_account_with_password(email)
+      row        = seed_identity(account_id)
+
+      csrf_login(email)
+      delete_identity(row[:id])
+
+      expect(last_response.status).to eq(200)
+      expect(identities.where(id: row[:id]).count).to eq(0)
+    end
+  end
+end

--- a/apps/web/auth/spec/integration/full/identities_routes_spec.rb
+++ b/apps/web/auth/spec/integration/full/identities_routes_spec.rb
@@ -34,7 +34,8 @@ require_relative '../../spec_helper'
 RSpec.describe 'Linked identities management API (#3840 Phase 2)', type: :integration do
   include Rack::Test::Methods
 
-  TEST_PASSWORD = 'TestPassword123!'
+  # Password is AuthTestConstants::TEST_PASSWORD (shared across spec files so a
+  # top-level constant isn't redefined when both specs load in one process).
 
   def app
     Onetime::Application::Registry.generate_rack_url_map
@@ -62,7 +63,7 @@ RSpec.describe 'Linked identities management API (#3840 Phase 2)', type: :integr
   # Helpers
   # ==========================================================================
 
-  def seed_account_with_password(email, password: TEST_PASSWORD)
+  def seed_account_with_password(email, password: AuthTestConstants::TEST_PASSWORD)
     normalized = OT::Utils.normalize_email(email)
     customer   = Onetime::Customer.new(email: normalized)
     customer.save
@@ -93,7 +94,7 @@ RSpec.describe 'Linked identities management API (#3840 Phase 2)', type: :integr
   end
 
   # Establish an authenticated session via password login.
-  def csrf_login(email, password: TEST_PASSWORD)
+  def csrf_login(email, password: AuthTestConstants::TEST_PASSWORD)
     clear_body_headers
     header 'Accept', 'application/json'
     get '/auth'
@@ -255,6 +256,32 @@ RSpec.describe 'Linked identities management API (#3840 Phase 2)', type: :integr
 
       expect(last_response.status).to eq(200)
       expect(identities.where(id: row[:id]).count).to eq(0)
+    end
+  end
+
+  # ==========================================================================
+  # mask_uid — display masking boundary (unit)
+  # ==========================================================================
+  #
+  # mask_uid (routes/identities.rb) returns '***' for length <= 8 and
+  # "#{first4}…#{last4}" otherwise. Exercised directly via a tiny double that
+  # includes the route module — no HTTP/DB round-trip needed. Auth::Routes::
+  # Identities is loaded during boot (router.rb requires + includes it).
+
+  describe '#mask_uid (boundary)' do
+    let(:masker) { Class.new { include Auth::Routes::Identities }.new }
+
+    it 'fully masks a uid of exactly 8 chars (the <= 8 boundary)' do
+      expect(masker.send(:mask_uid, 'abcd1234')).to eq('***')
+    end
+
+    it 'masks a 9-char uid as first4 + … + last4 (just past the boundary)' do
+      expect(masker.send(:mask_uid, 'abcde1234')).to eq('abcd…1234')
+    end
+
+    it 'fully masks nil and empty' do
+      expect(masker.send(:mask_uid, nil)).to eq('***')
+      expect(masker.send(:mask_uid, '')).to eq('***')
     end
   end
 end

--- a/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
@@ -7,33 +7,36 @@
 # =============================================================================
 #
 # Issue: #3840 Phase 2 — authenticated identity connect ("connect SSO from
-#        account settings"). The credential that BINDS an identity here is an
-#        ACTIVE AUTHENTICATED SESSION whose account IS the located account.
+#        account settings"). The credential that BINDS an identity here is the
+#        ACTIVE AUTHENTICATED SESSION. The IdP email plays NO role: we bind to
+#        the LOGGED-IN account, never to an email-located one (email matching is
+#        the pre-account-hijacking anti-pattern).
 #
 # WHY THIS FILE EXISTS:
 #   The authenticated-bind branch added to account_from_omniauth
 #   (apps/web/auth/config/hooks/omniauth.rb) can only be validated end-to-end:
 #   it depends on rodauth.logged_in? being true DURING the omniauth callback and
 #   on the gem's create_omniauth_identity upserting the row onto the
-#   already-authenticated account. This file drives the REAL Rodauth callback
-#   through the Rack stack (a password login establishes the session first) and
-#   asserts the persisted side effects — the account_identities row, the
-#   redirect, the audit event — that only the production machinery produces.
+#   already-authenticated (session) account. This file drives the REAL Rodauth
+#   callback through the Rack stack (a password login establishes the session
+#   first) and asserts the persisted side effects — the account_identities row,
+#   the redirect, the audit event — that only the production machinery produces.
 #
 # WHAT IT LOCKS IN (production code: apps/web/auth/config/hooks/omniauth.rb):
-#   1. logged-in + located account == self (platform surface)
-#        -> account_from_omniauth returns the session account, the gem persists
+#   1. logged-in on the PLATFORM surface
+#        -> account_from_omniauth returns the SESSION account, the gem persists
 #           the (provider, issuer, uid) row bound to it, and the
 #           :omniauth_identity_connected warn event fires. No refusal.
-#   2. logged-in + located account != self (email locates a DIFFERENT account)
-#        -> REFUSED (takeover guard): no identity row, no duplicate account,
-#           :omniauth_identity_connect_refused (reason account_conflict) fires.
+#   2. logged-in, IdP asserts a DIFFERENT account's email (hijack attempt)
+#        -> binds to the SESSION account anyway; the other (victim) account gets
+#           NO row and is untouched; no duplicate account. :omniauth_identity_
+#           connected fires with the SESSION account_id. Proves email is ignored.
 #   3. UNAUTHENTICATED + existing account (trust off)
 #        -> unchanged H-3 refusal. Proves the new branch is gated on logged_in?
 #           (:omniauth_identity_connected never fires when not logged in).
 #   4. logged-in on the PLATFORM surface + TENANT callback
-#        -> REFUSED (surface isolation): even with located == self, a tenant
-#           callback must not bind a tenant-issuer identity. Reason tenant_surface.
+#        -> REFUSED (surface isolation): a tenant callback must not bind a
+#           tenant-issuer identity onto a platform session. Reason tenant_surface.
 #
 # REQUIREMENTS:
 # - Valkey running on port 2121: pnpm run test:database:start
@@ -150,10 +153,10 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
   end
 
   # ==========================================================================
-  # Scenario 1 — logged-in, located == self (platform) -> bind
+  # Scenario 1 — logged-in on the platform surface -> bind to session account
   # ==========================================================================
 
-  describe 'logged-in, located account == self (platform surface)' do
+  describe 'logged-in on the platform surface' do
     before { enable_platform_fallback }
 
     it 'binds the new IdP identity to the session account and fires the connect event' do
@@ -201,18 +204,24 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
   end
 
   # ==========================================================================
-  # Scenario 2 — logged-in, located account != self -> REFUSE (takeover guard)
+  # Scenario 2 — logged-in, IdP asserts a DIFFERENT account's email
+  #              -> bind to the SESSION account; the victim is untouched
   # ==========================================================================
+  #
+  # The security property: email plays NO role. The session is the
+  # authorization, so an IdP that lies about the email (emitting a victim's
+  # address to try to reach the victim's account) still only binds to the
+  # ACTOR's own session account. The victim gets no row and is never routed to.
 
-  describe 'logged-in, located account != self (takeover guard)' do
+  describe 'logged-in, IdP asserts a different account email (email is ignored)' do
     before { enable_platform_fallback }
 
-    it 'refuses to bind, creates no row and no duplicate account' do
+    it 'binds to the session account and leaves the other account untouched' do
       actor_email  = "actor-#{SecureRandom.hex(6)}@company.example.com"
       victim_email = "victim-#{SecureRandom.hex(6)}@company.example.com"
       uid          = "sub-#{SecureRandom.hex(8)}"
 
-      seed_account_with_password(actor_email)
+      actor_id        = seed_account_with_password(actor_email)
       victim_id       = seed_existing_account(victim_email)
       accounts_before = auth_db[:accounts].count
 
@@ -228,23 +237,30 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
 
         skip 'OmniAuth route not registered' if last_response.status == 404
 
-        expect(last_response.status).to eq(302)
-        expect(last_response.location.to_s).to include('/signin?auth_error=identity_connect_conflict'),
-          "Cross-account connect must refuse. Location: #{last_response.location.inspect}"
+        expect(last_response.location.to_s).not_to include('identity_connect_conflict'),
+          "Authenticated connect must NOT refuse. Location: #{last_response.location.inspect}"
+        expect(last_response.status).to eq(302),
+          "Expected a post-login redirect, got #{last_response.status}: #{last_response.body}"
 
-        # No takeover: no identity row bound to the victim (or anyone).
-        expect(identities.where(provider: 'oidc', uid: uid).count).to eq(0),
-          'Takeover guard must NOT create an account_identities row'
+        # The bind attaches to the ACTOR's session account, NOT the victim whose
+        # email the IdP asserted.
+        rows = identities.where(provider: 'oidc', uid: uid).all
+        expect(rows.size).to eq(1),
+          "Expected exactly one bound identity row, got #{rows.size}: #{rows.inspect}"
+        expect(rows.first[:account_id]).to eq(actor_id),
+          'Bound identity must attach to the authenticated (session) account'
+
+        # The victim account is untouched — no row, no hijack.
         expect(identities.where(account_id: victim_id).count).to eq(0),
-          'No identity may be bound to the victim account'
+          'No identity may be bound to the account whose email the IdP asserted'
         # No duplicate account created.
         expect(auth_db[:accounts].count).to eq(accounts_before),
-          'Refusal must NOT create a duplicate account'
+          'Connect must NOT create a duplicate account'
 
         expect(Auth::Logging).to have_received(:log_auth_event)
-          .with(:omniauth_identity_connect_refused, hash_including(provider: 'oidc', reason: 'account_conflict'))
+          .with(:omniauth_identity_connected, hash_including(provider: 'oidc', account_id: actor_id))
         expect(Auth::Logging).not_to have_received(:log_auth_event)
-          .with(:omniauth_identity_connected, anything)
+          .with(:omniauth_identity_connect_refused, anything)
       ensure
         teardown_mock_auth
       end
@@ -295,14 +311,15 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
   # Scenario 4 — logged-in on PLATFORM, TENANT callback -> REFUSE (isolation)
   # ==========================================================================
   #
-  # Even with located == self, a tenant callback must not bind a tenant-issuer
-  # identity via this flow. The session is a PLATFORM session; the callback is a
-  # TENANT callback (validated_omniauth_domain_id set by the tenant hook).
+  # Surface isolation is checked BEFORE the session-account bind and is
+  # independent of the IdP email: a tenant callback must never bind a
+  # tenant-issuer identity onto a PLATFORM session (validated_omniauth_domain_id
+  # is set by the tenant hook on tenant callbacks only).
 
   describe 'logged-in on platform, tenant callback (surface isolation)', :oauth_flow do
     include OAuthFlowHelper
 
-    it 'refuses to bind on the tenant surface despite located == self' do
+    it 'refuses to bind on the tenant surface' do
       run_id = "connect-tenant-#{SecureRandom.hex(4)}"
       host   = "secrets-#{run_id}.tenant.example.com"
       email  = "tenant-actor-#{run_id}@tenant.example.com"

--- a/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
@@ -7,34 +7,44 @@
 # =============================================================================
 #
 # Issue: #3840 Phase 2 — authenticated identity connect ("connect SSO from
-#        account settings"). The credential that BINDS an identity here is the
-#        ACTIVE AUTHENTICATED SESSION. The IdP email plays NO role: we bind to
-#        the LOGGED-IN account, never to an email-located one (email matching is
-#        the pre-account-hijacking anti-pattern).
+#        account settings"). Binding requires TWO signals: an ACTIVE
+#        AUTHENTICATED SESSION *and* an account-bound CONNECT INTENT set at
+#        initiation (the panel POSTs connect=1, captured by
+#        omniauth_request_validation_phase into session[:sso_connect_intent]).
+#        logged_in? alone is NOT enough — that would let a second-tab / shared-
+#        browser sign-in silently bind the arriving identity to the session
+#        account. The IdP email plays NO role: we bind to the LOGGED-IN account,
+#        never to an email-located one (email matching is the pre-account-
+#        hijacking anti-pattern).
 #
 # WHY THIS FILE EXISTS:
-#   The authenticated-bind branch added to account_from_omniauth
+#   The authenticated-bind branch in account_from_omniauth
 #   (apps/web/auth/config/hooks/omniauth.rb) can only be validated end-to-end:
-#   it depends on rodauth.logged_in? being true DURING the omniauth callback and
-#   on the gem's create_omniauth_identity upserting the row onto the
-#   already-authenticated (session) account. This file drives the REAL Rodauth
-#   callback through the Rack stack (a password login establishes the session
-#   first) and asserts the persisted side effects — the account_identities row,
-#   the redirect, the audit event — that only the production machinery produces.
+#   it depends on rodauth.logged_in? being true AND a matching connect-intent
+#   nonce being present DURING the omniauth callback, and on the gem's
+#   create_omniauth_identity upserting the row onto the already-authenticated
+#   (session) account. This file drives the REAL Rodauth request+callback
+#   through the Rack stack (a password login establishes the session, then a
+#   connect=1 request phase sets the intent) and asserts the persisted side
+#   effects — the account_identities row, the redirect, the audit event — that
+#   only the production machinery produces.
 #
 # WHAT IT LOCKS IN (production code: apps/web/auth/config/hooks/omniauth.rb):
-#   1. logged-in on the PLATFORM surface
+#   1. logged-in + connect intent on the PLATFORM surface
 #        -> account_from_omniauth returns the SESSION account, the gem persists
 #           the (provider, issuer, uid) row bound to it, and the
 #           :omniauth_identity_connected warn event fires. No refusal.
-#   2. logged-in, IdP asserts a DIFFERENT account's email (hijack attempt)
+#   2. logged-in + connect intent, IdP asserts a DIFFERENT account's email
 #        -> binds to the SESSION account anyway; the other (victim) account gets
 #           NO row and is untouched; no duplicate account. :omniauth_identity_
 #           connected fires with the SESSION account_id. Proves email is ignored.
+#   2b. logged-in but NO connect intent (second-tab / shared-browser sign-in)
+#        -> treated as unauthenticated: falls through to H-3, session account
+#           gets NO row, :omniauth_identity_connected never fires. The P1 fix.
 #   3. UNAUTHENTICATED + existing account (trust off)
-#        -> unchanged H-3 refusal. Proves the new branch is gated on logged_in?
+#        -> unchanged H-3 refusal. Proves the branch is gated on session+intent
 #           (:omniauth_identity_connected never fires when not logged in).
-#   4. logged-in on the PLATFORM surface + TENANT callback
+#   4. logged-in + connect intent on the PLATFORM surface + TENANT callback
 #        -> REFUSED (surface isolation): a tenant callback must not bind a
 #           tenant-issuer identity onto a platform session. Reason tenant_surface.
 #
@@ -55,7 +65,8 @@ require_relative '../../support/oauth_flow_helper'
 RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: :integration do
   include Rack::Test::Methods
 
-  TEST_PASSWORD = 'TestPassword123!'
+  # Password is AuthTestConstants::TEST_PASSWORD (shared across spec files so a
+  # top-level constant isn't redefined when both specs load in one process).
 
   def app
     Onetime::Application::Registry.generate_rack_url_map
@@ -103,7 +114,7 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
   # Seed a VERIFIED account WITH an Argon2 password hash so csrf_login can
   # establish a real authenticated session for it. Cost params match the test
   # config in config/features/argon2.rb.
-  def seed_account_with_password(email, password: TEST_PASSWORD)
+  def seed_account_with_password(email, password: AuthTestConstants::TEST_PASSWORD)
     account_id = seed_existing_account(email)
     require 'argon2'
     hasher     = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
@@ -113,7 +124,7 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
 
   # Establish a session, fetch the CSRF token, then POST a JSON login. The full
   # Rack app enforces CSRF, so the shrimp token is required.
-  def csrf_login(email, password: TEST_PASSWORD)
+  def csrf_login(email, password: AuthTestConstants::TEST_PASSWORD)
     clear_body_headers
     header 'Accept', 'application/json'
     get '/auth'
@@ -152,6 +163,22 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
     OmniAuth.config.mock_auth.clear
   end
 
+  # Run the SSO REQUEST phase carrying the connect-intent signal (connect=1),
+  # exactly as the Connected Identities panel does at initiation. In OmniAuth
+  # test mode this triggers omniauth_request_validation_phase, which — when the
+  # caller is logged in — stashes session[:sso_connect_intent] = <session
+  # account id> in the session cookie. The subsequent callback consumes it and,
+  # only then, takes the bind branch. Cookie sessions can't be poked directly
+  # (see oauth_flow_helper#inject_oauth_session), so this real initiation is how
+  # the intent is threaded. Returns the request-phase status so callers can skip
+  # when the provider route isn't registered (404).
+  def initiate_sso_connect(provider: :oidc, host: nil)
+    clear_body_headers
+    header 'Host', host if host
+    post "/auth/sso/#{provider}", { connect: '1' }
+    last_response.status
+  end
+
   # ==========================================================================
   # Scenario 1 — logged-in on the platform surface -> bind to session account
   # ==========================================================================
@@ -172,6 +199,11 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
       allow(Auth::Logging).to receive(:log_auth_event).and_call_original
       setup_mock_auth(email: email, uid: uid)
       begin
+        # Establish account-bound connect intent via the real initiation POST
+        # (connect=1). Without it the bind branch is not taken (see the no-intent
+        # scenario below) — the intent nonce is now REQUIRED to bind.
+        skip 'OmniAuth route not registered (OIDC discovery not available at boot)' if initiate_sso_connect == 404
+
         clear_body_headers
         post '/auth/sso/oidc/callback'
 
@@ -232,6 +264,11 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
       allow(Auth::Logging).to receive(:log_auth_event).and_call_original
       setup_mock_auth(email: victim_email, uid: uid)
       begin
+        # Intent is established by the ACTOR (its session) at initiation; the IdP
+        # later asserting the victim's email cannot change which account the
+        # intent is bound to.
+        skip 'OmniAuth route not registered' if initiate_sso_connect == 404
+
         clear_body_headers
         post '/auth/sso/oidc/callback'
 
@@ -261,6 +298,69 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
           .with(:omniauth_identity_connected, hash_including(provider: 'oidc', account_id: actor_id))
         expect(Auth::Logging).not_to have_received(:log_auth_event)
           .with(:omniauth_identity_connect_refused, anything)
+      ensure
+        teardown_mock_auth
+      end
+    end
+  end
+
+  # ==========================================================================
+  # Scenario 2b — logged-in but NO connect intent -> must NOT bind (the P1 fix)
+  # ==========================================================================
+  #
+  # The core security property added in this PR: logged_in? alone is NOT connect
+  # intent. A plain SSO sign-in arriving on an already-authenticated session
+  # (second tab, shared browser) must be treated exactly like an unauthenticated
+  # caller — it must NEVER silently bind the arriving IdP identity to the session
+  # account. Here the IdP asserts a DIFFERENT existing account's email (trust
+  # off), so the fall-through lands on the H-3 refusal; the session account is
+  # left with no row.
+
+  describe 'logged-in but WITHOUT connect intent (must not bind)' do
+    before { enable_platform_fallback }
+
+    it 'does not bind onto the session account and falls through to the H-3 refusal' do
+      actor_email = "actor-nointent-#{SecureRandom.hex(6)}@company.example.com"
+      other_email = "other-#{SecureRandom.hex(6)}@company.example.com"
+      uid         = "sub-#{SecureRandom.hex(8)}"
+
+      actor_id = seed_account_with_password(actor_email)
+      seed_existing_account(other_email) # a DIFFERENT existing account
+
+      csrf_login(actor_email)
+      expect(last_response.status).to be_between(200, 302)
+
+      # Trust off -> the email branch for an existing account is the H-3 refusal.
+      allow(Onetime.auth_config).to receive(:trust_email_for_linking?).and_return(false)
+      allow(Auth::Logging).to receive(:log_auth_event).and_call_original
+
+      setup_mock_auth(email: other_email, uid: uid)
+      begin
+        # DELIBERATELY skip initiate_sso_connect: this is the second-tab / shared
+        # browser case — a callback arrives on the authenticated session with NO
+        # account-bound connect intent. It must be handled as unauthenticated.
+        clear_body_headers
+        post '/auth/sso/oidc/callback'
+
+        skip 'OmniAuth route not registered' if last_response.status == 404
+
+        expect(last_response.status).to eq(302)
+        expect(last_response.location.to_s).to include('/signin?auth_error=account_exists_link_required'),
+          "No-intent callback must fall through to H-3, not bind. Location: #{last_response.location.inspect}"
+
+        # THE CRUX: the arriving identity did NOT attach to the session account.
+        expect(identities.where(account_id: actor_id).count).to eq(0),
+          'A plain sign-in without connect intent must NOT bind onto the session account'
+        # And no identity row exists at all (H-3 refuses to create one).
+        expect(identities.where(provider: 'oidc', uid: uid).count).to eq(0)
+
+        # The connect event never fires; the intent-absent + H-3 events do.
+        expect(Auth::Logging).not_to have_received(:log_auth_event)
+          .with(:omniauth_identity_connected, anything)
+        expect(Auth::Logging).to have_received(:log_auth_event)
+          .with(:omniauth_connect_intent_absent, hash_including(provider: 'oidc'))
+        expect(Auth::Logging).to have_received(:log_auth_event)
+          .with(:omniauth_link_refused_existing_account, hash_including(provider: 'oidc'))
       ensure
         teardown_mock_auth
       end
@@ -347,10 +447,14 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
       )
 
       begin
-        # Initiate from the tenant host so the tenant hook records the context.
+        # Initiate from the tenant host WITH connect intent so the tenant hook
+        # records the context AND the callback reaches the intent-gated bind
+        # branch — where surface isolation then refuses. (Without intent the
+        # callback would fall through to the email branches and never assert the
+        # tenant_surface refusal this scenario is about.)
         clear_body_headers
         header 'Host', host
-        post '/auth/sso/oidc'
+        post '/auth/sso/oidc', { connect: '1' }
 
         skip "OmniAuth route not registered for #{host}" if last_response.status == 404
         expect(last_response.status).to eq(302)

--- a/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
@@ -1,0 +1,363 @@
+# apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration (full mode)
+# =============================================================================
+#
+# Issue: #3840 Phase 2 — authenticated identity connect ("connect SSO from
+#        account settings"). The credential that BINDS an identity here is an
+#        ACTIVE AUTHENTICATED SESSION whose account IS the located account.
+#
+# WHY THIS FILE EXISTS:
+#   The authenticated-bind branch added to account_from_omniauth
+#   (apps/web/auth/config/hooks/omniauth.rb) can only be validated end-to-end:
+#   it depends on rodauth.logged_in? being true DURING the omniauth callback and
+#   on the gem's create_omniauth_identity upserting the row onto the
+#   already-authenticated account. This file drives the REAL Rodauth callback
+#   through the Rack stack (a password login establishes the session first) and
+#   asserts the persisted side effects — the account_identities row, the
+#   redirect, the audit event — that only the production machinery produces.
+#
+# WHAT IT LOCKS IN (production code: apps/web/auth/config/hooks/omniauth.rb):
+#   1. logged-in + located account == self (platform surface)
+#        -> account_from_omniauth returns the session account, the gem persists
+#           the (provider, issuer, uid) row bound to it, and the
+#           :omniauth_identity_connected warn event fires. No refusal.
+#   2. logged-in + located account != self (email locates a DIFFERENT account)
+#        -> REFUSED (takeover guard): no identity row, no duplicate account,
+#           :omniauth_identity_connect_refused (reason account_conflict) fires.
+#   3. UNAUTHENTICATED + existing account (trust off)
+#        -> unchanged H-3 refusal. Proves the new branch is gated on logged_in?
+#           (:omniauth_identity_connected never fires when not logged in).
+#   4. logged-in on the PLATFORM surface + TENANT callback
+#        -> REFUSED (surface isolation): even with located == self, a tenant
+#           callback must not bind a tenant-issuer identity. Reason tenant_surface.
+#
+# REQUIREMENTS:
+# - Valkey running on port 2121: pnpm run test:database:start
+# - AUTHENTICATION_MODE=full, AUTH_DATABASE_URL (SQLite in-memory; rake sets it)
+#
+# RUN:
+#   RACK_ENV=test AUTHENTICATION_MODE=full AUTH_DATABASE_URL=sqlite::memory: \
+#     ORGS_SSO_ENABLED=true LANG=en_US.UTF-8 \
+#     bundle exec rspec apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb \
+#     --tag '~postgres_database'
+# =============================================================================
+
+require_relative '../../spec_helper'
+require_relative '../../support/oauth_flow_helper'
+
+RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: :integration do
+  include Rack::Test::Methods
+
+  TEST_PASSWORD = 'TestPassword123!'
+
+  def app
+    Onetime::Application::Registry.generate_rack_url_map
+  end
+
+  before(:all) do
+    require 'onetime'
+    require 'onetime/application/registry'
+    require 'onetime/auth_config'
+
+    Onetime.auth_config.reload! if Onetime.respond_to?(:auth_config) && Onetime.auth_config.respond_to?(:reload!)
+    Onetime::Application::Registry.reset! if Onetime::Application::Registry.respond_to?(:reset!)
+
+    Onetime.boot!(:test, force: true)
+
+    Onetime::Application::Registry.prepare_application_registry
+
+    mounts = Onetime::Application::Registry.mount_mappings.keys
+    raise "Auth app not mounted post-boot: #{mounts.inspect}" unless mounts.any? { |m| m.include?('/auth') }
+  end
+
+  let(:identities) { auth_db[:account_identities] }
+
+  # ==========================================================================
+  # Helpers
+  # ==========================================================================
+
+  # Leaves session[:validated_omniauth_domain_id] nil == the PLATFORM path.
+  def enable_platform_fallback
+    allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
+  end
+
+  # Seed a VERIFIED account WITHOUT a password (SSO-only / victim account).
+  def seed_existing_account(email)
+    normalized = OT::Utils.normalize_email(email)
+    customer   = Onetime::Customer.new(email: normalized)
+    customer.save
+    auth_db[:accounts].insert(
+      email: normalized,
+      status_id: AuthTestConstants::STATUS_VERIFIED,
+      external_id: customer.extid,
+    )
+  end
+
+  # Seed a VERIFIED account WITH an Argon2 password hash so csrf_login can
+  # establish a real authenticated session for it. Cost params match the test
+  # config in config/features/argon2.rb.
+  def seed_account_with_password(email, password: TEST_PASSWORD)
+    account_id = seed_existing_account(email)
+    require 'argon2'
+    hasher     = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
+    auth_db[:account_password_hashes].insert(id: account_id, password_hash: hasher.create(password))
+    account_id
+  end
+
+  # Establish a session, fetch the CSRF token, then POST a JSON login. The full
+  # Rack app enforces CSRF, so the shrimp token is required.
+  def csrf_login(email, password: TEST_PASSWORD)
+    clear_body_headers
+    header 'Accept', 'application/json'
+    get '/auth'
+    token = last_response.headers['X-CSRF-Token']
+
+    header 'Content-Type', 'application/json'
+    header 'Accept', 'application/json'
+    header 'X-CSRF-Token', token if token
+    post '/auth/login', JSON.generate(login: email, password: password, shrimp: token)
+    token
+  end
+
+  # Content-Type/Content-Length leak from a prior JSON POST and make the next
+  # bodyless callback POST try to parse an empty JSON body. Clear them.
+  def clear_body_headers
+    header 'Content-Type', nil
+    header 'Content-Length', nil
+  end
+
+  def setup_mock_auth(email:, uid:, provider: :oidc)
+    OmniAuth.config.test_mode               = true
+    OmniAuth.config.allowed_request_methods = [:get, :post]
+    OmniAuth.config.mock_auth[provider]     = OmniAuth::AuthHash.new(
+      {
+        provider: provider.to_s,
+        uid: uid,
+        info: { email: email, name: 'Connect User', email_verified: true },
+        credentials: { token: 'mock_access_token', expires_at: Time.now.to_i + 3600, expires: true },
+        extra: { raw_info: { sub: uid, email: email, name: 'Connect User', email_verified: true } },
+      },
+    )
+  end
+
+  def teardown_mock_auth
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth.clear
+  end
+
+  # ==========================================================================
+  # Scenario 1 — logged-in, located == self (platform) -> bind
+  # ==========================================================================
+
+  describe 'logged-in, located account == self (platform surface)' do
+    before { enable_platform_fallback }
+
+    it 'binds the new IdP identity to the session account and fires the connect event' do
+      email      = "connect-#{SecureRandom.hex(6)}@company.example.com"
+      uid        = "sub-#{SecureRandom.hex(8)}"
+      account_id = seed_account_with_password(email)
+
+      # Establish the credential: an authenticated session for THIS account.
+      csrf_login(email)
+      expect(last_response.status).to be_between(200, 302),
+        "Precondition failed: password login did not succeed (#{last_response.status}: #{last_response.body})"
+
+      allow(Auth::Logging).to receive(:log_auth_event).and_call_original
+      setup_mock_auth(email: email, uid: uid)
+      begin
+        clear_body_headers
+        post '/auth/sso/oidc/callback'
+
+        skip 'OmniAuth route not registered (OIDC discovery not available at boot)' if last_response.status == 404
+
+        expect(last_response.location.to_s).not_to include('identity_connect_conflict'),
+          "Self-bind must NOT refuse. Location: #{last_response.location.inspect}"
+        expect(last_response.location.to_s).not_to include('account_exists_link_required'),
+          "Self-bind must NOT hit the H-3 refusal. Location: #{last_response.location.inspect}"
+        expect(last_response.status).to eq(302),
+          "Expected a post-login redirect, got #{last_response.status}: #{last_response.body}"
+
+        # The bind: exactly one (provider, uid) row, bound to the session account.
+        rows = identities.where(provider: 'oidc', uid: uid).all
+        expect(rows.size).to eq(1),
+          "Expected exactly one bound identity row, got #{rows.size}: #{rows.inspect}"
+        expect(rows.first[:account_id]).to eq(account_id),
+          'Bound identity must attach to the already-authenticated account'
+        # Issuer was resolved and persisted (Phase 0 column, never NULL).
+        expect(rows.first[:issuer]).not_to be_nil
+
+        expect(Auth::Logging).to have_received(:log_auth_event)
+          .with(:omniauth_identity_connected, hash_including(provider: 'oidc', account_id: account_id))
+        expect(Auth::Logging).not_to have_received(:log_auth_event)
+          .with(:omniauth_identity_connect_refused, anything)
+      ensure
+        teardown_mock_auth
+      end
+    end
+  end
+
+  # ==========================================================================
+  # Scenario 2 — logged-in, located account != self -> REFUSE (takeover guard)
+  # ==========================================================================
+
+  describe 'logged-in, located account != self (takeover guard)' do
+    before { enable_platform_fallback }
+
+    it 'refuses to bind, creates no row and no duplicate account' do
+      actor_email  = "actor-#{SecureRandom.hex(6)}@company.example.com"
+      victim_email = "victim-#{SecureRandom.hex(6)}@company.example.com"
+      uid          = "sub-#{SecureRandom.hex(8)}"
+
+      seed_account_with_password(actor_email)
+      victim_id       = seed_existing_account(victim_email)
+      accounts_before = auth_db[:accounts].count
+
+      # Logged in as the ACTOR, but the IdP asserts the VICTIM's email.
+      csrf_login(actor_email)
+      expect(last_response.status).to be_between(200, 302)
+
+      allow(Auth::Logging).to receive(:log_auth_event).and_call_original
+      setup_mock_auth(email: victim_email, uid: uid)
+      begin
+        clear_body_headers
+        post '/auth/sso/oidc/callback'
+
+        skip 'OmniAuth route not registered' if last_response.status == 404
+
+        expect(last_response.status).to eq(302)
+        expect(last_response.location.to_s).to include('/signin?auth_error=identity_connect_conflict'),
+          "Cross-account connect must refuse. Location: #{last_response.location.inspect}"
+
+        # No takeover: no identity row bound to the victim (or anyone).
+        expect(identities.where(provider: 'oidc', uid: uid).count).to eq(0),
+          'Takeover guard must NOT create an account_identities row'
+        expect(identities.where(account_id: victim_id).count).to eq(0),
+          'No identity may be bound to the victim account'
+        # No duplicate account created.
+        expect(auth_db[:accounts].count).to eq(accounts_before),
+          'Refusal must NOT create a duplicate account'
+
+        expect(Auth::Logging).to have_received(:log_auth_event)
+          .with(:omniauth_identity_connect_refused, hash_including(provider: 'oidc', reason: 'account_conflict'))
+        expect(Auth::Logging).not_to have_received(:log_auth_event)
+          .with(:omniauth_identity_connected, anything)
+      ensure
+        teardown_mock_auth
+      end
+    end
+  end
+
+  # ==========================================================================
+  # Scenario 3 — UNAUTHENTICATED -> unchanged H-3 refusal (regression)
+  # ==========================================================================
+
+  describe 'unauthenticated (regression: new branch is gated on logged_in?)' do
+    before { enable_platform_fallback }
+
+    it 'falls through to the existing H-3 refusal and never fires the connect event' do
+      email = "anon-#{SecureRandom.hex(6)}@company.example.com"
+      uid   = "sub-#{SecureRandom.hex(8)}"
+      seed_existing_account(email)
+
+      # No login. trust flag defaults off -> H-3 refusal path.
+      allow(Onetime.auth_config).to receive(:trust_email_for_linking?).and_return(false)
+      allow(Auth::Logging).to receive(:log_auth_event).and_call_original
+
+      setup_mock_auth(email: email, uid: uid)
+      begin
+        post '/auth/sso/oidc/callback'
+
+        skip 'OmniAuth route not registered' if last_response.status == 404
+
+        expect(last_response.status).to eq(302)
+        expect(last_response.location.to_s).to include('/signin?auth_error=account_exists_link_required'),
+          "Unauthenticated flow must keep the H-3 refusal. Location: #{last_response.location.inspect}"
+
+        expect(identities.where(provider: 'oidc', uid: uid).count).to eq(0)
+
+        expect(Auth::Logging).to have_received(:log_auth_event)
+          .with(:omniauth_link_refused_existing_account, hash_including(provider: 'oidc'))
+        expect(Auth::Logging).not_to have_received(:log_auth_event)
+          .with(:omniauth_identity_connected, anything)
+        expect(Auth::Logging).not_to have_received(:log_auth_event)
+          .with(:omniauth_identity_connect_refused, anything)
+      ensure
+        teardown_mock_auth
+      end
+    end
+  end
+
+  # ==========================================================================
+  # Scenario 4 — logged-in on PLATFORM, TENANT callback -> REFUSE (isolation)
+  # ==========================================================================
+  #
+  # Even with located == self, a tenant callback must not bind a tenant-issuer
+  # identity via this flow. The session is a PLATFORM session; the callback is a
+  # TENANT callback (validated_omniauth_domain_id set by the tenant hook).
+
+  describe 'logged-in on platform, tenant callback (surface isolation)', :oauth_flow do
+    include OAuthFlowHelper
+
+    it 'refuses to bind on the tenant surface despite located == self' do
+      run_id = "connect-tenant-#{SecureRandom.hex(4)}"
+      host   = "secrets-#{run_id}.tenant.example.com"
+      email  = "tenant-actor-#{run_id}@tenant.example.com"
+      uid    = "sub-#{SecureRandom.hex(8)}"
+
+      seed_account_with_password(email)
+
+      # Establish a PLATFORM session for this account.
+      csrf_login(email)
+      expect(last_response.status).to be_between(200, 302)
+
+      # Registered tenant domain so the tenant callback validates.
+      setup_oauth_test_domain(host)
+
+      allow(Auth::Logging).to receive(:log_auth_event).and_call_original
+      OmniAuth.config.test_mode               = true
+      OmniAuth.config.allowed_request_methods = [:get, :post]
+      OmniAuth.config.mock_auth[:oidc]        = OmniAuth::AuthHash.new(
+        {
+          provider: 'oidc',
+          uid: uid,
+          info: { email: email, name: 'Tenant Actor', email_verified: true },
+          extra: { raw_info: { sub: uid, email: email, email_verified: true } },
+        },
+      )
+
+      begin
+        # Initiate from the tenant host so the tenant hook records the context.
+        clear_body_headers
+        header 'Host', host
+        post '/auth/sso/oidc'
+
+        skip "OmniAuth route not registered for #{host}" if last_response.status == 404
+        expect(last_response.status).to eq(302)
+
+        # Callback from the SAME host -> validated_omniauth_domain_id gets set,
+        # so the connect branch sees a NON-platform surface and refuses.
+        clear_body_headers
+        header 'Host', host
+        post '/auth/sso/oidc/callback'
+
+        expect(last_response.status).to eq(302)
+        expect(last_response.location.to_s).to include('/signin?auth_error=identity_connect_conflict'),
+          "Tenant callback must refuse the bind. Location: #{last_response.location.inspect}"
+
+        expect(identities.where(provider: 'oidc', uid: uid).count).to eq(0),
+          'Surface isolation must NOT create a tenant identity row'
+
+        expect(Auth::Logging).to have_received(:log_auth_event)
+          .with(:omniauth_identity_connect_refused, hash_including(provider: 'oidc', reason: 'tenant_surface'))
+        expect(Auth::Logging).not_to have_received(:log_auth_event)
+          .with(:omniauth_identity_connected, anything)
+      ensure
+        teardown_mock_auth
+      end
+    end
+  end
+end

--- a/apps/web/auth/spec/support/auth_test_constants.rb
+++ b/apps/web/auth/spec/support/auth_test_constants.rb
@@ -25,6 +25,11 @@ module AuthTestConstants
   STATUS_VERIFIED = 2
   STATUS_CLOSED = 3
 
+  # Shared password for integration specs that seed an Argon2 hash and then log
+  # in through the real Rack stack. Defined here (not per-file) so two specs
+  # loaded in one RSpec process don't warn on constant redefinition.
+  TEST_PASSWORD = 'TestPassword123!'
+
   # Tables whose rows must survive per-example cleanup (clear_auth_database):
   #   - schema_info / schema_migrations: Sequel's migration bookkeeping
   #   - account_statuses: seed-once reference table backing accounts.status_id;

--- a/locales/content/en/00-common.json
+++ b/locales/content/en/00-common.json
@@ -1320,7 +1320,8 @@
   },
   "web.TITLES.connected_identities": {
     "text": "Connected Identities",
-    "context": "Page title for the SSO connected-identities management panel (#3840 Phase 2)"
+    "context": "Page title for the SSO connected-identities management panel (#3840 Phase 2)",
+    "content_hash": "e132c4d9"
   },
   "web.TITLES.api_settings": {
     "text": "API Settings",

--- a/locales/content/en/00-common.json
+++ b/locales/content/en/00-common.json
@@ -1318,6 +1318,10 @@
     "context": "Page title for passkey management",
     "content_hash": "c87ccdb4"
   },
+  "web.TITLES.connected_identities": {
+    "text": "Connected Identities",
+    "context": "Page title for the SSO connected-identities management panel (#3840 Phase 2)"
+  },
   "web.TITLES.api_settings": {
     "text": "API Settings",
     "content_hash": "6c2a9675"

--- a/locales/content/en/session-auth-extended.json
+++ b/locales/content/en/session-auth-extended.json
@@ -347,6 +347,18 @@
     "text": "Identity providers you can use to sign in to this account",
     "context": "Card subheader for the list of linked SSO identities"
   },
+  "web.auth.connections.connect_title": {
+    "text": "Connect a provider",
+    "context": "Header for the section that lets a logged-in user link a new SSO identity provider (#3840 Phase 2)"
+  },
+  "web.auth.connections.connect_description": {
+    "text": "Link another single sign-on provider you can use to sign in to this account.",
+    "context": "Subtext under the Connect-a-provider header"
+  },
+  "web.auth.connections.connect_action": {
+    "text": "Connect {provider}",
+    "context": "Button label to start linking a specific SSO provider; {provider} is the provider display name"
+  },
   "web.auth.connections.issuer": {
     "text": "Issuer",
     "context": "Label preceding the identity provider issuer URL in a connected-identity row"

--- a/locales/content/en/session-auth-extended.json
+++ b/locales/content/en/session-auth-extended.json
@@ -333,83 +333,103 @@
   },
   "web.auth.connections.title": {
     "text": "Connected Identities",
-    "context": "Title / nav label for the SSO account-linking panel (#3840 Phase 2)"
+    "context": "Title / nav label for the SSO account-linking panel (#3840 Phase 2)",
+    "content_hash": "e132c4d9"
   },
   "web.auth.connections.description": {
     "text": "Manage the single sign-on providers linked to your account.",
-    "context": "Subheading under the Connected Identities page title"
+    "context": "Subheading under the Connected Identities page title",
+    "content_hash": "42c6d148"
   },
   "web.auth.connections.section_title": {
     "text": "Single sign-on",
-    "context": "Card header for the list of linked SSO identities"
+    "context": "Card header for the list of linked SSO identities",
+    "content_hash": "3bc44ac2"
   },
   "web.auth.connections.section_subtitle": {
     "text": "Identity providers you can use to sign in to this account",
-    "context": "Card subheader for the list of linked SSO identities"
+    "context": "Card subheader for the list of linked SSO identities",
+    "content_hash": "507254cd"
   },
   "web.auth.connections.connect_title": {
     "text": "Connect a provider",
-    "context": "Header for the section that lets a logged-in user link a new SSO identity provider (#3840 Phase 2)"
+    "context": "Header for the section that lets a logged-in user link a new SSO identity provider (#3840 Phase 2)",
+    "content_hash": "a002b3f3"
   },
   "web.auth.connections.connect_description": {
     "text": "Link another single sign-on provider you can use to sign in to this account.",
-    "context": "Subtext under the Connect-a-provider header"
+    "context": "Subtext under the Connect-a-provider header",
+    "content_hash": "32895a5a"
   },
   "web.auth.connections.connect_action": {
     "text": "Connect {provider}",
-    "context": "Button label to start linking a specific SSO provider; {provider} is the provider display name"
+    "context": "Button label to start linking a specific SSO provider; {provider} is the provider display name",
+    "content_hash": "c77540af"
   },
   "web.auth.connections.issuer": {
     "text": "Issuer",
-    "context": "Label preceding the identity provider issuer URL in a connected-identity row"
+    "context": "Label preceding the identity provider issuer URL in a connected-identity row",
+    "content_hash": "39e02c46"
   },
   "web.auth.connections.identifier": {
     "text": "Identifier",
-    "context": "Label preceding the masked subject/identifier in a connected-identity row"
+    "context": "Label preceding the masked subject/identifier in a connected-identity row",
+    "content_hash": "9b10587f"
   },
   "web.auth.connections.remove": {
     "text": "Remove",
-    "context": "Button to unlink a single connected identity"
+    "context": "Button to unlink a single connected identity",
+    "content_hash": "c3812fc4"
   },
   "web.auth.connections.remove_confirm_title": {
     "text": "Remove connected identity",
-    "context": "Title of the confirmation dialog shown before unlinking an identity"
+    "context": "Title of the confirmation dialog shown before unlinking an identity",
+    "content_hash": "4e8ffe4c"
   },
   "web.auth.connections.remove_confirm_message": {
     "text": "Are you sure you want to remove this connected identity? You will no longer be able to sign in with it.",
-    "context": "Body of the confirmation dialog shown before unlinking an identity"
+    "context": "Body of the confirmation dialog shown before unlinking an identity",
+    "content_hash": "64939c89"
   },
   "web.auth.connections.removed_success": {
     "text": "Connected identity removed",
-    "context": "Toast shown after an identity is successfully unlinked"
+    "context": "Toast shown after an identity is successfully unlinked",
+    "content_hash": "cf87daf3"
   },
   "web.auth.connections.no_identities": {
     "text": "No connected identities",
-    "context": "Empty-state title when the account has no linked SSO identities"
+    "context": "Empty-state title when the account has no linked SSO identities",
+    "content_hash": "5254048e"
   },
   "web.auth.connections.no_identities_description": {
     "text": "You haven't linked any single sign-on providers to this account yet.",
-    "context": "Empty-state description when the account has no linked SSO identities"
+    "context": "Empty-state description when the account has no linked SSO identities",
+    "content_hash": "0f58d5d0"
   },
   "web.auth.connections.overview_status": {
     "text": "Single sign-on",
-    "context": "Status badge text on the Security Overview card for connected identities"
+    "context": "Status badge text on the Security Overview card for connected identities",
+    "content_hash": "3bc44ac2"
   },
   "web.auth.connections.errors.last_credential": {
     "text": "This is your only way to sign in. Add a password or link another provider before removing it, so you don't get locked out.",
-    "context": "Error shown when removing the final identity of an SSO-only account is refused (backend 409 error_code last_credential)"
+    "context": "Error shown when removing the final identity of an SSO-only account is refused (backend 409 error_code last_credential)",
+    "content_hash": "edfbc970"
   },
   "web.auth.connections.errors.not_found": {
     "text": "That connected identity could not be found. It may have already been removed.",
-    "context": "Error shown when unlinking an identity returns 404 (not owned by the caller or already gone)"
+    "context": "Error shown when unlinking an identity returns 404 (not owned by the caller or already gone)",
+    "content_hash": "cf2c7673"
   },
   "web.auth.connections.errors.unauthorized": {
     "text": "Your session has expired. Please sign in again.",
-    "context": "Error shown when a connected-identities request returns 401"
+    "context": "Error shown when a connected-identities request returns 401",
+    "content_hash": "b529fce2"
   },
   "web.auth.connections.errors.generic": {
     "text": "We couldn't complete that action. Please try again.",
-    "context": "Fallback error for connected-identities fetch/remove failures"
+    "context": "Fallback error for connected-identities fetch/remove failures",
+    "content_hash": "a0d4edc0"
   },
   "web.auth.lockout.attempts_remaining": {
     "text": "Warning: {count} login attempt(s) remaining",

--- a/locales/content/en/session-auth-extended.json
+++ b/locales/content/en/session-auth-extended.json
@@ -331,6 +331,74 @@
     "context": "Navigation link title",
     "content_hash": "c87ccdb4"
   },
+  "web.auth.connections.title": {
+    "text": "Connected Identities",
+    "context": "Title / nav label for the SSO account-linking panel (#3840 Phase 2)"
+  },
+  "web.auth.connections.description": {
+    "text": "Manage the single sign-on providers linked to your account.",
+    "context": "Subheading under the Connected Identities page title"
+  },
+  "web.auth.connections.section_title": {
+    "text": "Single sign-on",
+    "context": "Card header for the list of linked SSO identities"
+  },
+  "web.auth.connections.section_subtitle": {
+    "text": "Identity providers you can use to sign in to this account",
+    "context": "Card subheader for the list of linked SSO identities"
+  },
+  "web.auth.connections.issuer": {
+    "text": "Issuer",
+    "context": "Label preceding the identity provider issuer URL in a connected-identity row"
+  },
+  "web.auth.connections.identifier": {
+    "text": "Identifier",
+    "context": "Label preceding the masked subject/identifier in a connected-identity row"
+  },
+  "web.auth.connections.remove": {
+    "text": "Remove",
+    "context": "Button to unlink a single connected identity"
+  },
+  "web.auth.connections.remove_confirm_title": {
+    "text": "Remove connected identity",
+    "context": "Title of the confirmation dialog shown before unlinking an identity"
+  },
+  "web.auth.connections.remove_confirm_message": {
+    "text": "Are you sure you want to remove this connected identity? You will no longer be able to sign in with it.",
+    "context": "Body of the confirmation dialog shown before unlinking an identity"
+  },
+  "web.auth.connections.removed_success": {
+    "text": "Connected identity removed",
+    "context": "Toast shown after an identity is successfully unlinked"
+  },
+  "web.auth.connections.no_identities": {
+    "text": "No connected identities",
+    "context": "Empty-state title when the account has no linked SSO identities"
+  },
+  "web.auth.connections.no_identities_description": {
+    "text": "You haven't linked any single sign-on providers to this account yet.",
+    "context": "Empty-state description when the account has no linked SSO identities"
+  },
+  "web.auth.connections.overview_status": {
+    "text": "Single sign-on",
+    "context": "Status badge text on the Security Overview card for connected identities"
+  },
+  "web.auth.connections.errors.last_credential": {
+    "text": "This is your only way to sign in. Add a password or link another provider before removing it, so you don't get locked out.",
+    "context": "Error shown when removing the final identity of an SSO-only account is refused (backend 409 error_code last_credential)"
+  },
+  "web.auth.connections.errors.not_found": {
+    "text": "That connected identity could not be found. It may have already been removed.",
+    "context": "Error shown when unlinking an identity returns 404 (not owned by the caller or already gone)"
+  },
+  "web.auth.connections.errors.unauthorized": {
+    "text": "Your session has expired. Please sign in again.",
+    "context": "Error shown when a connected-identities request returns 401"
+  },
+  "web.auth.connections.errors.generic": {
+    "text": "We couldn't complete that action. Please try again.",
+    "context": "Fallback error for connected-identities fetch/remove failures"
+  },
   "web.auth.lockout.attempts_remaining": {
     "text": "Warning: {count} login attempt(s) remaining",
     "content_hash": "151dcb5e"

--- a/locales/content/en/session-auth.json
+++ b/locales/content/en/session-auth.json
@@ -129,9 +129,8 @@
     "content_hash": "87603782"
   },
   "web.login.errors.account_exists_link_required": {
-    "text": "An account with this email address already exists but isn't linked to this sign-in method. Please sign in with your existing method to continue.",
-    "context": "Shown on signin page when SSO refuses to auto-link: an account with the callback email exists but is not linked to this provider. Message-only in Phase 1 (#3840) — do not reference an account-settings link or an email-confirmation flow (those arrive in #3840 Phase 2, the authenticated account-linking panel).",
-    "content_hash": "e4261e30"
+    "text": "An account with this email address already exists but isn't linked to this sign-in method. Sign in with your existing method, then link this provider under Security settings → Connected identities.",
+    "context": "Shown on signin page when SSO refuses to auto-link: an account with the callback email exists but is not linked to this provider. Phase 2 (#3840) is live — the authenticated Connected Identities panel (/account/settings/security/connections) now lets a signed-in user link the provider, so the copy points there. Content edited; content_hash intentionally omitted so locales:hashes regenerates it."
   },
   "web.login.errors.org_join_failed": {
     "text": "We couldn't finish adding you to your organization. Please contact your administrator.",

--- a/locales/content/en/session-auth.json
+++ b/locales/content/en/session-auth.json
@@ -132,6 +132,10 @@
     "text": "An account with this email address already exists but isn't linked to this sign-in method. Sign in with your existing method, then link this provider under Security settings → Connected identities.",
     "context": "Shown on signin page when SSO refuses to auto-link: an account with the callback email exists but is not linked to this provider. Phase 2 (#3840) is live — the authenticated Connected Identities panel (/account/settings/security/connections) now lets a signed-in user link the provider, so the copy points there. Content edited; content_hash intentionally omitted so locales:hashes regenerates it."
   },
+  "web.login.errors.identity_connect_conflict": {
+    "text": "This identity couldn't be connected. The connection may have been started on the wrong domain, or your session expired. Please sign in again, then connect it from your account settings.",
+    "context": "Shown on /signin when an authenticated SSO connect is refused for surface isolation (tenant callback on a platform session) or an expired session (#3840 Phase 2)"
+  },
   "web.login.errors.org_join_failed": {
     "text": "We couldn't finish adding you to your organization. Please contact your administrator.",
     "context": "Shown on signin page when tenant-domain SSO authenticated but the organization join produced no membership (orphaned account). Admins/ops must investigate; the user cannot self-resolve.",

--- a/locales/content/en/session-auth.json
+++ b/locales/content/en/session-auth.json
@@ -130,11 +130,13 @@
   },
   "web.login.errors.account_exists_link_required": {
     "text": "An account with this email address already exists but isn't linked to this sign-in method. Sign in with your existing method, then link this provider under Security settings → Connected identities.",
-    "context": "Shown on signin page when SSO refuses to auto-link: an account with the callback email exists but is not linked to this provider. Phase 2 (#3840) is live — the authenticated Connected Identities panel (/account/settings/security/connections) now lets a signed-in user link the provider, so the copy points there. Content edited; content_hash intentionally omitted so locales:hashes regenerates it."
+    "context": "Shown on signin page when SSO refuses to auto-link: an account with the callback email exists but is not linked to this provider. Phase 2 (#3840) is live — the authenticated Connected Identities panel (/account/settings/security/connections) now lets a signed-in user link the provider, so the copy points there. Content edited; content_hash intentionally omitted so locales:hashes regenerates it.",
+    "content_hash": "7fbbb7e7"
   },
   "web.login.errors.identity_connect_conflict": {
     "text": "This identity couldn't be connected. The connection may have been started on the wrong domain, or your session expired. Please sign in again, then connect it from your account settings.",
-    "context": "Shown on /signin when an authenticated SSO connect is refused for surface isolation (tenant callback on a platform session) or an expired session (#3840 Phase 2)"
+    "context": "Shown on /signin when an authenticated SSO connect is refused for surface isolation (tenant callback on a platform session) or an expired session (#3840 Phase 2)",
+    "content_hash": "4238bbf2"
   },
   "web.login.errors.org_join_failed": {
     "text": "We couldn't finish adding you to your organization. Please contact your administrator.",

--- a/src/apps/session/views/Login.vue
+++ b/src/apps/session/views/Login.vue
@@ -75,6 +75,7 @@ const authErrorMessages: Record<string, string> = {
   invalid_email: 'web.login.errors.invalid_email',
   domain_not_allowed: 'web.login.errors.domain_not_allowed',
   account_exists_link_required: 'web.login.errors.account_exists_link_required',
+  identity_connect_conflict: 'web.login.errors.identity_connect_conflict',
   org_join_failed: 'web.login.errors.org_join_failed',
 };
 

--- a/src/apps/session/views/Login.vue
+++ b/src/apps/session/views/Login.vue
@@ -1,7 +1,6 @@
 <!-- src/apps/session/views/Login.vue -->
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n';
 import AuthMethodSelector from '@/apps/session/components/AuthMethodSelector.vue';
 import AuthView from '@/apps/session/components/AuthView.vue';
 import OIcon from '@/shared/components/icons/OIcon.vue';
@@ -12,6 +11,7 @@ import { useLanguageStore } from '@/shared/stores/languageStore';
 import { hasPasswordlessMethods } from '@/utils/features';
 import { storeToRefs } from 'pinia';
 import { ref, computed, onMounted, type ComponentPublicInstance } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 
 const { t } = useI18n();
@@ -153,10 +153,13 @@ const handleModeChange = (_mode: AuthMode) => {
       <template v-else>
         <!-- Post-verification success: persistent confirmation that the email
              was verified, shown until the user leaves the page. -->
+        <!-- prettier-ignore-attribute class -->
         <div
           v-if="verifiedNotice"
           role="status"
-          class="mb-4 flex items-center gap-2 rounded-md border border-green-200 bg-green-50 p-3 text-sm text-green-800 dark:border-green-800 dark:bg-green-900/20 dark:text-green-300"
+          class="
+            mb-4 flex items-center gap-2 rounded-md border border-green-200 bg-green-50 p-3
+            text-sm text-green-800 dark:border-green-800 dark:bg-green-900/20 dark:text-green-300"
           data-testid="signin-verified-notice">
           <OIcon
             collection="heroicons"
@@ -167,10 +170,13 @@ const handleModeChange = (_mode: AuthMode) => {
         </div>
 
         <!-- Auth error from redirects (SSO failure, invalid magic link, etc.) -->
+        <!-- prettier-ignore-attribute class -->
         <div
           v-if="authError"
           role="alert"
-          class="mb-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+          class="
+            mb-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700
+            dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
           {{ authError }}
         </div>
 
@@ -188,16 +194,22 @@ const handleModeChange = (_mode: AuthMode) => {
         class="flex items-center justify-center gap-2 text-sm">
         <!-- Consistent footer for all modes when passwordless methods enabled -->
         <template v-if="passwordlessEnabled">
+          <!-- prettier-ignore-attribute class -->
           <router-link
             to="/help"
-            class="text-gray-500 transition-colors duration-200 hover:text-gray-700 hover:underline dark:text-gray-400 dark:hover:text-gray-300">
+            class="
+              text-gray-500 transition-colors duration-200 hover:text-gray-700 hover:underline
+              dark:text-gray-400 dark:hover:text-gray-300">
             {{ t('web.login.need_help') }}
           </router-link>
           <template v-if="signupEnabled">
             <span class="text-gray-300 dark:text-gray-600" aria-hidden="true">&#8226;</span>
+            <!-- prettier-ignore-attribute class -->
             <router-link
               :to="signupLink"
-              class="text-gray-500 transition-colors duration-200 hover:text-gray-700 hover:underline dark:text-gray-400 dark:hover:text-gray-300">
+              class="
+                text-gray-500 transition-colors duration-200 hover:text-gray-700 hover:underline
+                dark:text-gray-400 dark:hover:text-gray-300">
               {{ t('web.login.create_account') }}
             </router-link>
           </template>
@@ -208,9 +220,12 @@ const handleModeChange = (_mode: AuthMode) => {
             {{ t('web.login.alternate_prefix') }}
           </span>
           {{ ' ' }}
+          <!-- prettier-ignore-attribute class -->
           <router-link
             :to="signupLink"
-            class="font-medium text-brand-600 underline transition-colors duration-200 hover:text-brand-500 dark:text-brand-400 dark:hover:text-brand-300">
+            class="
+              font-medium text-brand-600 underline transition-colors duration-200
+              hover:text-brand-500 dark:text-brand-400 dark:hover:text-brand-300">
             {{ t('web.login.need_an_account') }}
           </router-link>
         </template>

--- a/src/apps/workspace/account/ConnectedIdentities.vue
+++ b/src/apps/workspace/account/ConnectedIdentities.vue
@@ -8,9 +8,13 @@
   import ConfirmDialog from '@/shared/components/modals/ConfirmDialog.vue';
   import SettingsLayout from '@/apps/workspace/layouts/SettingsLayout.vue';
   import { useConnectedIdentities } from '@/shared/composables/useConnectedIdentities';
-  import { onMounted, ref } from 'vue';
+  import { useCsrfStore } from '@/shared/stores/csrfStore';
+  import { submitSsoLogin } from '@/shared/utils/sso';
+  import { getSsoProviders, type SsoProvider } from '@/utils/features';
+  import { computed, onMounted, ref } from 'vue';
 
   const { t } = useI18n();
+  const csrfStore = useCsrfStore();
   const { identities, isLoading, error, errorCode, fetchIdentities, removeIdentity, clearError } =
     useConnectedIdentities();
 
@@ -24,6 +28,33 @@
   };
   const providerLabel = (provider: string): string =>
     PROVIDER_LABELS[provider] ?? provider.charAt(0).toUpperCase() + provider.slice(1);
+
+  // Providers the account can still link. A provider is "already linked" when
+  // its route_name matches the `provider` of any existing identity row (both are
+  // the omniauth route name, e.g. 'oidc'). Exclude-by-route is correct here: on
+  // the platform / self-host surface a route maps to a single issuer.
+  const CONNECT_REDIRECT = '/account/settings/security/connections';
+
+  const connectableProviders = computed<SsoProvider[]>(() => {
+    const linked = new Set(identities.value.map((identity) => identity.provider));
+    return getSsoProviders().filter((provider) => !linked.has(provider.route_name));
+  });
+
+  // Prefer the backend display_name; fall back to the friendly PROVIDER_LABELS
+  // map so a blank display_name still renders a sensible button label.
+  const connectLabel = (provider: SsoProvider): string =>
+    provider.display_name?.trim() ? provider.display_name : providerLabel(provider.route_name);
+
+  // Connecting reuses the sign-in form POST (see submitSsoLogin): the backend
+  // hook binds the returned identity to the logged-in account. `redirect` brings
+  // the user back to this panel after the IdP round-trip.
+  const handleConnect = (provider: SsoProvider) => {
+    submitSsoLogin({
+      routeName: provider.route_name,
+      shrimp: csrfStore.shrimp,
+      redirect: CONNECT_REDIRECT,
+    });
+  };
 
   // Confirmation dialog for individual identity removal (mirrors ActiveSessions).
   const {
@@ -199,6 +230,36 @@
               </button>
             </li>
           </ul>
+
+          <!-- Connect a provider: shown in both empty and populated states as
+               long as there is at least one provider not yet linked. -->
+          <div
+            v-if="connectableProviders.length > 0"
+            class="mt-6 border-t border-gray-200 pt-6 dark:border-gray-700"
+            data-testid="connections-connect">
+            <h3 class="text-sm font-medium text-gray-900 dark:text-white">
+              {{ t('web.auth.connections.connect_title') }}
+            </h3>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              {{ t('web.auth.connections.connect_description') }}
+            </p>
+            <div class="mt-4 flex flex-wrap gap-3">
+              <button
+                v-for="provider in connectableProviders"
+                :key="provider.route_name"
+                @click="handleConnect(provider)"
+                type="button"
+                :data-testid="`connections-connect-${provider.route_name}`"
+                class="inline-flex items-center gap-2 rounded-lg border border-brand-200 bg-brand-50 px-4 py-2 text-sm font-medium text-brand-700 transition-colors hover:bg-brand-100 dark:border-brand-800 dark:bg-brand-900/20 dark:text-brand-300 dark:hover:bg-brand-900/40">
+                <OIcon
+                  collection="heroicons"
+                  name="link-solid"
+                  class="size-5 shrink-0"
+                  aria-hidden="true" />
+                {{ t('web.auth.connections.connect_action', { provider: connectLabel(provider) }) }}
+              </button>
+            </div>
+          </div>
         </div>
 
         <!-- Related settings -->

--- a/src/apps/workspace/account/ConnectedIdentities.vue
+++ b/src/apps/workspace/account/ConnectedIdentities.vue
@@ -45,14 +45,16 @@
   const connectLabel = (provider: SsoProvider): string =>
     provider.display_name?.trim() ? provider.display_name : providerLabel(provider.route_name);
 
-  // Connecting reuses the sign-in form POST (see submitSsoLogin): the backend
-  // hook binds the returned identity to the logged-in account. `redirect` brings
-  // the user back to this panel after the IdP round-trip.
+  // Connecting reuses the sign-in form POST (see submitSsoLogin) but marks it
+  // with connect: true so the backend hook binds the returned identity to the
+  // logged-in account (a plain sign-in stays unmarked and never binds).
+  // `redirect` brings the user back to this panel after the IdP round-trip.
   const handleConnect = (provider: SsoProvider) => {
     submitSsoLogin({
       routeName: provider.route_name,
       shrimp: csrfStore.shrimp,
       redirect: CONNECT_REDIRECT,
+      connect: true,
     });
   };
 

--- a/src/apps/workspace/account/ConnectedIdentities.vue
+++ b/src/apps/workspace/account/ConnectedIdentities.vue
@@ -1,17 +1,17 @@
 <!-- src/apps/workspace/account/ConnectedIdentities.vue -->
 
 <script setup lang="ts">
-  import { useI18n } from 'vue-i18n';
-  import { useConfirmDialog } from '@vueuse/core';
-  import OIcon from '@/shared/components/icons/OIcon.vue';
-  import ListSkeleton from '@/shared/components/closet/ListSkeleton.vue';
-  import ConfirmDialog from '@/shared/components/modals/ConfirmDialog.vue';
   import SettingsLayout from '@/apps/workspace/layouts/SettingsLayout.vue';
+  import ListSkeleton from '@/shared/components/closet/ListSkeleton.vue';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import ConfirmDialog from '@/shared/components/modals/ConfirmDialog.vue';
   import { useConnectedIdentities } from '@/shared/composables/useConnectedIdentities';
   import { useCsrfStore } from '@/shared/stores/csrfStore';
   import { submitSsoLogin } from '@/shared/utils/sso';
   import { getSsoProviders, type SsoProvider } from '@/utils/features';
+  import { useConfirmDialog } from '@vueuse/core';
   import { computed, onMounted, ref } from 'vue';
+  import { useI18n } from 'vue-i18n';
 
   const { t } = useI18n();
   const csrfStore = useCsrfStore();
@@ -137,10 +137,13 @@
               ]">
               {{ error }}
             </p>
+            <!-- prettier-ignore-attribute class -->
             <button
               @click="clearError"
               type="button"
-              class="ml-auto shrink-0 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              class="
+                ml-auto shrink-0 text-gray-500 hover:text-gray-700
+                dark:text-gray-400 dark:hover:text-gray-200"
               aria-label="Dismiss">
               <OIcon
                 collection="heroicons"
@@ -154,8 +157,11 @@
         <!-- Identities card -->
         <div class="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
           <div class="flex items-center gap-3">
+            <!-- prettier-ignore-attribute class -->
             <div
-              class="flex size-12 items-center justify-center rounded-lg bg-brand-100 dark:bg-brand-900/30">
+              class="
+                flex size-12 items-center justify-center rounded-lg
+                bg-brand-100 dark:bg-brand-900/30">
               <OIcon
                 collection="heroicons"
                 name="globe-alt-solid"
@@ -212,7 +218,7 @@
                   <!-- Issuer is hidden for the '' sentinel (legacy / OAuth2-only rows) -->
                   <p
                     v-if="identity.issuer"
-                    class="break-all text-sm text-gray-500 dark:text-gray-400">
+                    class="text-sm break-all text-gray-500 dark:text-gray-400">
                     {{ t('web.auth.connections.issuer') }}: {{ identity.issuer }}
                   </p>
                   <p class="text-sm text-gray-500 dark:text-gray-400">
@@ -220,12 +226,16 @@
                   </p>
                 </div>
               </div>
+              <!-- prettier-ignore-attribute class -->
               <button
                 @click="handleRemove(identity.id)"
                 type="button"
                 :disabled="isLoading"
                 :data-testid="`connections-remove-${identity.id}`"
-                class="shrink-0 text-sm font-medium text-red-600 hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-red-400 dark:hover:text-red-300">
+                class="
+                  shrink-0 text-sm font-medium text-red-600 hover:text-red-500
+                  disabled:cursor-not-allowed disabled:opacity-50
+                  dark:text-red-400 dark:hover:text-red-300">
                 {{ t('web.auth.connections.remove') }}
               </button>
             </li>
@@ -244,13 +254,18 @@
               {{ t('web.auth.connections.connect_description') }}
             </p>
             <div class="mt-4 flex flex-wrap gap-3">
+              <!-- prettier-ignore-attribute class -->
               <button
                 v-for="provider in connectableProviders"
                 :key="provider.route_name"
                 @click="handleConnect(provider)"
                 type="button"
                 :data-testid="`connections-connect-${provider.route_name}`"
-                class="inline-flex items-center gap-2 rounded-lg border border-brand-200 bg-brand-50 px-4 py-2 text-sm font-medium text-brand-700 transition-colors hover:bg-brand-100 dark:border-brand-800 dark:bg-brand-900/20 dark:text-brand-300 dark:hover:bg-brand-900/40">
+                class="
+                  inline-flex items-center gap-2 rounded-lg border border-brand-200
+                  bg-brand-50 px-4 py-2 text-sm font-medium text-brand-700 transition-colors
+                  hover:bg-brand-100 dark:border-brand-800 dark:bg-brand-900/20
+                  dark:text-brand-300 dark:hover:bg-brand-900/40">
                 <OIcon
                   collection="heroicons"
                   name="link-solid"
@@ -264,14 +279,20 @@
 
         <!-- Related settings -->
         <div class="mt-6 rounded-lg bg-gray-50 p-4 dark:bg-gray-800">
+          <!-- prettier-ignore-attribute class -->
           <h3
-            class="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            class="
+              mb-3 text-sm font-semibold tracking-wide text-gray-500 uppercase
+              dark:text-gray-400">
             {{ t('web.LABELS.related_settings') }}
           </h3>
           <div class="space-y-2">
+            <!-- prettier-ignore-attribute class -->
             <router-link
               to="/account/settings/security/sessions"
-              class="flex items-center gap-3 text-sm text-gray-700 hover:text-brand-600 dark:text-gray-300 dark:hover:text-brand-400">
+              class="
+                flex items-center gap-3 text-sm text-gray-700 hover:text-brand-600
+                dark:text-gray-300 dark:hover:text-brand-400">
               <OIcon
                 collection="heroicons"
                 name="computer-desktop-solid"
@@ -279,9 +300,12 @@
                 aria-hidden="true" />
               <span>{{ t('web.auth.sessions.link_title') }}</span>
             </router-link>
+            <!-- prettier-ignore-attribute class -->
             <router-link
               to="/account/settings/security/passkeys"
-              class="flex items-center gap-3 text-sm text-gray-700 hover:text-brand-600 dark:text-gray-300 dark:hover:text-brand-400">
+              class="
+                flex items-center gap-3 text-sm text-gray-700 hover:text-brand-600
+                dark:text-gray-300 dark:hover:text-brand-400">
               <OIcon
                 collection="heroicons"
                 name="finger-print-solid"

--- a/src/apps/workspace/account/ConnectedIdentities.vue
+++ b/src/apps/workspace/account/ConnectedIdentities.vue
@@ -1,0 +1,245 @@
+<!-- src/apps/workspace/account/ConnectedIdentities.vue -->
+
+<script setup lang="ts">
+  import { useI18n } from 'vue-i18n';
+  import { useConfirmDialog } from '@vueuse/core';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import ListSkeleton from '@/shared/components/closet/ListSkeleton.vue';
+  import ConfirmDialog from '@/shared/components/modals/ConfirmDialog.vue';
+  import SettingsLayout from '@/apps/workspace/layouts/SettingsLayout.vue';
+  import { useConnectedIdentities } from '@/shared/composables/useConnectedIdentities';
+  import { onMounted, ref } from 'vue';
+
+  const { t } = useI18n();
+  const { identities, isLoading, error, errorCode, fetchIdentities, removeIdentity, clearError } =
+    useConnectedIdentities();
+
+  // Friendly provider labels; unknown providers fall back to a capitalized name
+  // so a backend that adds a strategy still renders sensibly.
+  const PROVIDER_LABELS: Record<string, string> = {
+    oidc: 'OpenID Connect',
+    entra: 'Microsoft Entra',
+    github: 'GitHub',
+    google: 'Google',
+  };
+  const providerLabel = (provider: string): string =>
+    PROVIDER_LABELS[provider] ?? provider.charAt(0).toUpperCase() + provider.slice(1);
+
+  // Confirmation dialog for individual identity removal (mirrors ActiveSessions).
+  const {
+    isRevealed: isRemoveRevealed,
+    reveal: revealRemove,
+    confirm: confirmRemove,
+    cancel: cancelRemove,
+  } = useConfirmDialog();
+
+  const pendingRemoveId = ref<number | null>(null);
+
+  const handleRemove = async (id: number) => {
+    clearError();
+    pendingRemoveId.value = id;
+    const { isCanceled } = await revealRemove();
+    if (isCanceled) {
+      pendingRemoveId.value = null;
+      return;
+    }
+    await removeIdentity(id);
+    pendingRemoveId.value = null;
+  };
+
+  onMounted(async () => {
+    await fetchIdentities();
+  });
+</script>
+
+<template>
+  <SettingsLayout>
+    <div>
+      <div class="mb-6">
+        <h1 class="text-3xl font-bold dark:text-white">
+          {{ t('web.auth.connections.title') }}
+        </h1>
+        <p class="mt-2 text-gray-600 dark:text-gray-400">
+          {{ t('web.auth.connections.description') }}
+        </p>
+      </div>
+
+      <!-- Loading state -->
+      <ListSkeleton
+        v-if="isLoading && identities.length === 0"
+        icon
+        icon-size="w-5" />
+
+      <template v-else>
+        <!-- Error / lockout-guard message -->
+        <div
+          v-if="error"
+          :class="[
+            'mb-6 rounded-lg p-4',
+            errorCode === 'last_credential'
+              ? 'bg-yellow-50 dark:bg-yellow-900/20'
+              : 'bg-red-50 dark:bg-red-900/20',
+          ]"
+          role="alert"
+          data-testid="connections-error">
+          <div class="flex items-center gap-3">
+            <OIcon
+              collection="heroicons"
+              :name="
+                errorCode === 'last_credential'
+                  ? 'exclamation-triangle-solid'
+                  : 'exclamation-circle-solid'
+              "
+              :class="[
+                'size-5 shrink-0',
+                errorCode === 'last_credential'
+                  ? 'text-yellow-600 dark:text-yellow-400'
+                  : 'text-red-600 dark:text-red-400',
+              ]"
+              aria-hidden="true" />
+            <p
+              :class="[
+                'text-sm font-medium',
+                errorCode === 'last_credential'
+                  ? 'text-yellow-800 dark:text-yellow-200'
+                  : 'text-red-800 dark:text-red-200',
+              ]">
+              {{ error }}
+            </p>
+            <button
+              @click="clearError"
+              type="button"
+              class="ml-auto shrink-0 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              aria-label="Dismiss">
+              <OIcon
+                collection="heroicons"
+                name="x-mark"
+                class="size-5"
+                aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+
+        <!-- Identities card -->
+        <div class="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
+          <div class="flex items-center gap-3">
+            <div
+              class="flex size-12 items-center justify-center rounded-lg bg-brand-100 dark:bg-brand-900/30">
+              <OIcon
+                collection="heroicons"
+                name="globe-alt-solid"
+                class="size-6 text-brand-600 dark:text-brand-400"
+                aria-hidden="true" />
+            </div>
+            <div>
+              <h2 class="text-xl font-semibold dark:text-white">
+                {{ t('web.auth.connections.section_title') }}
+              </h2>
+              <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                {{ t('web.auth.connections.section_subtitle') }}
+              </p>
+            </div>
+          </div>
+
+          <!-- Empty state -->
+          <div
+            v-if="identities.length === 0"
+            class="mt-8 text-center"
+            data-testid="connections-empty">
+            <OIcon
+              collection="heroicons"
+              name="globe-alt"
+              class="mx-auto size-12 text-gray-300 dark:text-gray-600"
+              aria-hidden="true" />
+            <h3 class="mt-4 text-lg font-medium text-gray-900 dark:text-white">
+              {{ t('web.auth.connections.no_identities') }}
+            </h3>
+            <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+              {{ t('web.auth.connections.no_identities_description') }}
+            </p>
+          </div>
+
+          <!-- Identities list -->
+          <ul
+            v-else
+            class="mt-6 divide-y divide-gray-200 dark:divide-gray-700"
+            data-testid="connections-list">
+            <li
+              v-for="identity in identities"
+              :key="identity.id"
+              class="flex items-center justify-between py-4">
+              <div class="flex items-center gap-4">
+                <OIcon
+                  collection="heroicons"
+                  name="key-solid"
+                  class="size-5 shrink-0 text-gray-400"
+                  aria-hidden="true" />
+                <div>
+                  <p class="font-medium text-gray-900 dark:text-white">
+                    {{ providerLabel(identity.provider) }}
+                  </p>
+                  <!-- Issuer is hidden for the '' sentinel (legacy / OAuth2-only rows) -->
+                  <p
+                    v-if="identity.issuer"
+                    class="break-all text-sm text-gray-500 dark:text-gray-400">
+                    {{ t('web.auth.connections.issuer') }}: {{ identity.issuer }}
+                  </p>
+                  <p class="text-sm text-gray-500 dark:text-gray-400">
+                    {{ t('web.auth.connections.identifier') }}: {{ identity.uid }}
+                  </p>
+                </div>
+              </div>
+              <button
+                @click="handleRemove(identity.id)"
+                type="button"
+                :disabled="isLoading"
+                :data-testid="`connections-remove-${identity.id}`"
+                class="shrink-0 text-sm font-medium text-red-600 hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-red-400 dark:hover:text-red-300">
+                {{ t('web.auth.connections.remove') }}
+              </button>
+            </li>
+          </ul>
+        </div>
+
+        <!-- Related settings -->
+        <div class="mt-6 rounded-lg bg-gray-50 p-4 dark:bg-gray-800">
+          <h3
+            class="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            {{ t('web.LABELS.related_settings') }}
+          </h3>
+          <div class="space-y-2">
+            <router-link
+              to="/account/settings/security/sessions"
+              class="flex items-center gap-3 text-sm text-gray-700 hover:text-brand-600 dark:text-gray-300 dark:hover:text-brand-400">
+              <OIcon
+                collection="heroicons"
+                name="computer-desktop-solid"
+                class="size-4"
+                aria-hidden="true" />
+              <span>{{ t('web.auth.sessions.link_title') }}</span>
+            </router-link>
+            <router-link
+              to="/account/settings/security/passkeys"
+              class="flex items-center gap-3 text-sm text-gray-700 hover:text-brand-600 dark:text-gray-300 dark:hover:text-brand-400">
+              <OIcon
+                collection="heroicons"
+                name="finger-print-solid"
+                class="size-4"
+                aria-hidden="true" />
+              <span>{{ t('web.auth.passkeys.link_title') }}</span>
+            </router-link>
+          </div>
+        </div>
+      </template>
+
+      <!-- Confirmation dialog for individual identity removal -->
+      <ConfirmDialog
+        v-if="isRemoveRevealed"
+        @confirm="confirmRemove"
+        @cancel="cancelRemove"
+        :title="t('web.auth.connections.remove_confirm_title')"
+        :message="t('web.auth.connections.remove_confirm_message')"
+        type="danger" />
+    </div>
+  </SettingsLayout>
+</template>

--- a/src/apps/workspace/account/settings/SecurityOverview.vue
+++ b/src/apps/workspace/account/settings/SecurityOverview.vue
@@ -5,7 +5,7 @@
   import OIcon from '@/shared/components/icons/OIcon.vue';
   import SettingsLayout from '@/apps/workspace/layouts/SettingsLayout.vue';
   import { useAccount } from '@/shared/composables/useAccount';
-  import { hasPasswordOf, isMfaEnabledOf, isWebAuthnEnabledOf } from '@/utils/features';
+  import { hasPasswordOf, isMfaEnabledOf, isSsoEnabledOf, isWebAuthnEnabledOf } from '@/utils/features';
   import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import type { AccountInfo } from '@/types/auth';
   import { computed, onMounted, ref } from 'vue';
@@ -18,6 +18,7 @@
   const showSessionsCard = ref(false);
   const mfaFeatureEnabled = computed(() => isMfaEnabledOf(bootstrapStore));
   const webAuthnEnabled = computed(() => isWebAuthnEnabledOf(bootstrapStore));
+  const ssoEnabled = computed(() => isSsoEnabledOf(bootstrapStore));
   const hasPw = computed(() => hasPasswordOf(bootstrapStore));
   const { accountInfo, fetchAccountInfo } = useAccount();
 
@@ -124,6 +125,23 @@
     };
   }
 
+  // Helper to build connected-identities card (SSO account-linking, #3840).
+  // NOT password-dependent — SSO-only accounts are the primary audience.
+  function buildConnectionsCard(): SecurityCard {
+    return {
+      id: 'connections',
+      icon: { collection: 'heroicons', name: 'globe-alt-solid' },
+      title: t('web.auth.connections.title'),
+      description: t('web.auth.connections.description'),
+      status: 'active',
+      statusText: t('web.auth.connections.overview_status'),
+      action: {
+        label: t('web.settings.security.manage'),
+        to: '/account/settings/security/connections',
+      },
+    };
+  }
+
   // Helper to build sessions card
   function buildSessionsCard(info: AccountInfo): SecurityCard {
     return {
@@ -158,6 +176,12 @@
 
     if (webAuthnEnabled.value) {
       cards.push(buildPasskeyCard(accountInfo.value));
+    }
+
+    // Connected identities card — not password-dependent, so it is added after
+    // the SSO-only card filter above and shown whenever SSO is enabled.
+    if (ssoEnabled.value) {
+      cards.push(buildConnectionsCard());
     }
 
     if (showSessionsCard.value) {

--- a/src/apps/workspace/account/settings/SecurityOverview.vue
+++ b/src/apps/workspace/account/settings/SecurityOverview.vue
@@ -1,14 +1,14 @@
 <!-- src/apps/workspace/account/settings/SecurityOverview.vue -->
 
 <script setup lang="ts">
-  import { useI18n } from 'vue-i18n';
-  import OIcon from '@/shared/components/icons/OIcon.vue';
   import SettingsLayout from '@/apps/workspace/layouts/SettingsLayout.vue';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
   import { useAccount } from '@/shared/composables/useAccount';
-  import { hasPasswordOf, isMfaEnabledOf, isSsoEnabledOf, isWebAuthnEnabledOf } from '@/utils/features';
   import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import type { AccountInfo } from '@/types/auth';
+  import { hasPasswordOf, isMfaEnabledOf, isSsoEnabledOf, isWebAuthnEnabledOf } from '@/utils/features';
   import { computed, onMounted, ref } from 'vue';
+  import { useI18n } from 'vue-i18n';
 
   const { t } = useI18n();
   const bootstrapStore = useBootstrapStore();
@@ -221,9 +221,12 @@
   <SettingsLayout>
     <div class="space-y-8">
       <!-- Security Score Card -->
+      <!-- prettier-ignore-attribute class -->
       <div
         v-if="false"
-        class="rounded-lg border border-gray-200/60 bg-white/60 p-6 shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/60">
+        class="
+          rounded-lg border border-gray-200/60 bg-white/60 p-6 shadow-sm backdrop-blur-sm
+          dark:border-gray-700/60 dark:bg-gray-800/60">
         <div class="flex items-start justify-between">
           <div>
             <h2 class="text-lg font-medium text-gray-600 dark:text-gray-300">
@@ -285,12 +288,18 @@
       </div>
 
       <!-- SSO empty state — shown when all cards are filtered out -->
+      <!-- prettier-ignore-attribute class -->
       <div
         v-if="!hasPw && securityCards.length === 0"
-        class="rounded-lg border border-gray-200/60 bg-white/60 p-6 shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/60">
+        class="
+          rounded-lg border border-gray-200/60 bg-white/60 p-6 shadow-sm backdrop-blur-sm
+          dark:border-gray-700/60 dark:bg-gray-800/60">
         <div class="flex items-start gap-4">
+          <!-- prettier-ignore-attribute class -->
           <div
-            class="flex size-12 shrink-0 items-center justify-center rounded-lg bg-brand-50 dark:bg-brand-900/20">
+            class="
+              flex size-12 shrink-0 items-center justify-center rounded-lg
+              bg-brand-50 dark:bg-brand-900/20">
             <OIcon
               collection="heroicons"
               name="shield-check-solid"
@@ -312,13 +321,19 @@
       <div
         v-if="securityCards.length > 0"
         class="grid gap-6 sm:grid-cols-2">
+        <!-- prettier-ignore-attribute class -->
         <div
           v-for="card in securityCards"
           :key="card.id"
-          class="rounded-lg border border-gray-200/60 bg-white/60 p-6 shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/60">
+          class="
+            rounded-lg border border-gray-200/60 bg-white/60 p-6 shadow-sm backdrop-blur-sm
+            dark:border-gray-700/60 dark:bg-gray-800/60">
           <div class="flex items-start gap-4">
+            <!-- prettier-ignore-attribute class -->
             <div
-              class="flex size-12 shrink-0 items-center justify-center rounded-lg bg-gray-100 dark:bg-gray-700">
+              class="
+                flex size-12 shrink-0 items-center justify-center rounded-lg
+                bg-gray-100 dark:bg-gray-700">
               <OIcon
                 :collection="card.icon.collection"
                 :name="card.icon.name"
@@ -346,9 +361,12 @@
 
               <!-- Action Button -->
               <div class="mt-4">
+                <!-- prettier-ignore-attribute class -->
                 <router-link
                   :to="card.action.to"
-                  class="inline-flex items-center gap-2 text-sm font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300">
+                  class="
+                    inline-flex items-center gap-2 text-sm font-medium text-brand-600
+                    hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300">
                   {{ card.action.label }}
                   <OIcon
                     collection="heroicons"

--- a/src/apps/workspace/account/settings/SecurityOverview.vue
+++ b/src/apps/workspace/account/settings/SecurityOverview.vue
@@ -35,29 +35,6 @@
     };
   }
 
-  const securityScore = computed(() => {
-    if (!accountInfo.value) return 0;
-
-    if (mfaFeatureEnabled.value) {
-      let score = 0;
-      if (accountInfo.value.email_verified) score += 25;
-      if (accountInfo.value.mfa_enabled) score += 50;
-      if (accountInfo.value.recovery_codes_count > 0) score += 25;
-      return score;
-    }
-
-    // When MFA is disabled, score based on available factors only
-    return accountInfo.value.email_verified ? 100 : 0;
-  });
-
-  const securityLevel = computed(() => {
-    const score = securityScore.value;
-    if (score >= 90) return { label: t('web.settings.security.excellent'), color: 'green' };
-    if (score >= 70) return { label: t('web.settings.security.good'), color: 'blue' };
-    if (score >= 25) return { label: t('web.settings.security.fair'), color: 'yellow' };
-    return { label: t('web.settings.security.weak'), color: 'red' };
-  });
-
   // Helper to build core security cards
   function buildCoreCards(info: AccountInfo): SecurityCard[] {
     return [
@@ -198,20 +175,6 @@
       'bg-yellow-50 text-yellow-800 ring-yellow-600/20 dark:bg-yellow-900/20 dark:text-yellow-400',
   };
 
-  const scoreColorClasses: Record<string, string> = {
-    green: 'text-green-600 dark:text-green-400',
-    blue: 'text-blue-600 dark:text-blue-400',
-    yellow: 'text-yellow-600 dark:text-yellow-400',
-    red: 'text-red-600 dark:text-red-400',
-  };
-
-  const progressBarColorClasses: Record<string, string> = {
-    green: 'bg-green-600',
-    blue: 'bg-blue-600',
-    yellow: 'bg-yellow-600',
-    red: 'bg-red-600',
-  };
-
   onMounted(async () => {
     await fetchAccountInfo();
   });
@@ -220,73 +183,6 @@
 <template>
   <SettingsLayout>
     <div class="space-y-8">
-      <!-- Security Score Card -->
-      <!-- prettier-ignore-attribute class -->
-      <div
-        v-if="false"
-        class="
-          rounded-lg border border-gray-200/60 bg-white/60 p-6 shadow-sm backdrop-blur-sm
-          dark:border-gray-700/60 dark:bg-gray-800/60">
-        <div class="flex items-start justify-between">
-          <div>
-            <h2 class="text-lg font-medium text-gray-600 dark:text-gray-300">
-              {{ t('web.settings.security.security_score') }}
-            </h2>
-            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-              {{ t('web.settings.security.score_description') }}
-            </p>
-          </div>
-          <div class="text-right">
-            <div :class="['text-4xl font-bold', scoreColorClasses[securityLevel.color]]">
-              {{ securityScore }}
-            </div>
-            <div
-              class="mt-1 text-sm font-medium"
-              :class="scoreColorClasses[securityLevel.color]">
-              {{ securityLevel.label }}
-            </div>
-          </div>
-        </div>
-
-        <!-- Progress Bar -->
-        <div class="mt-4">
-          <div class="h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
-            <div
-              :class="[
-                'h-full transition-all duration-500',
-                progressBarColorClasses[securityLevel.color],
-              ]"
-              :style="{ width: `${securityScore}%` }"></div>
-          </div>
-        </div>
-
-        <!-- Recommendations -->
-        <div
-          v-if="securityScore < 100"
-          class="mt-4 rounded-lg bg-blue-50 p-4 dark:bg-blue-900/20">
-          <div class="flex gap-3">
-            <OIcon
-              collection="heroicons"
-              name="information-circle-solid"
-              class="size-5 shrink-0 text-blue-600 dark:text-blue-400"
-              aria-hidden="true" />
-            <div class="text-sm text-blue-700 dark:text-blue-300">
-              <p class="font-medium">
-                {{ t('web.settings.security.improve_security') }}
-              </p>
-              <ul class="mt-2 list-inside list-disc space-y-1">
-                <li v-if="!accountInfo?.mfa_enabled">
-                  {{ t('web.settings.security.enable_mfa_recommendation') }}
-                </li>
-                <li v-if="!accountInfo?.recovery_codes_count">
-                  {{ t('web.settings.security.generate_recovery_codes_recommendation') }}
-                </li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </div>
-
       <!-- SSO empty state — shown when all cards are filtered out -->
       <!-- prettier-ignore-attribute class -->
       <div

--- a/src/apps/workspace/config/settings-navigation.ts
+++ b/src/apps/workspace/config/settings-navigation.ts
@@ -16,15 +16,17 @@
 // │  ├ MFA           │ hasPassword        │ ✓      │ —      │ ✓      │ —      │ ✓      │ —      │
 // │  ├ Sessions      │ —                  │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │
 // │  ├ Recovery      │ hasPassword        │ ✓      │ —      │ ✓      │ —      │ ✓      │ —      │
-// │  └ Passkeys      │ isWebAuthnEnabled  │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │
+// │  ├ Passkeys      │ isWebAuthnEnabled  │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │
+// │  └ Connections   │ isSsoEnabled       │ ✓†     │ ✓†     │ ✓†     │ ✓†     │ ✓†     │ ✓†     │
 // │ API              │ —                  │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │
 // │ Region           │ isOwnerOrAdmin     │ ✓*     │ ✓*     │ ✓*     │ ✓*     │ —      │ —      │
 // │ Caution          │ isOwnerOrAdmin     │ ✓*     │ ✓*     │ ✓*     │ ✓*     │ —      │ —      │
 // │                  │                    │        │        │        │        │        │        │
 // │ * also requires isFullAuthMode        │        │        │        │        │        │        │
+// │ † only when SSO is enabled (isSsoEnabled)                                    │        │
 // └──────────────────┴────────────────────┴────────┴────────┴────────┴────────┴────────┴────────┘
 
-import { hasPassword, isFullAuthMode, isSsoOnlyMode, isOwnerOrAdmin, isWebAuthnEnabled } from '@/utils/features';
+import { hasPassword, isFullAuthMode, isSsoEnabled, isSsoOnlyMode, isOwnerOrAdmin, isWebAuthnEnabled } from '@/utils/features';
 import type { ComposerTranslation } from 'vue-i18n';
 
 /**
@@ -41,6 +43,7 @@ export interface NavigationFeatures {
   isSsoOnlyMode: boolean;
   isOwnerOrAdmin: boolean;
   isWebAuthnEnabled: boolean;
+  isSsoEnabled: boolean;
 }
 
 function resolveFeatures(features?: NavigationFeatures): NavigationFeatures {
@@ -51,6 +54,7 @@ function resolveFeatures(features?: NavigationFeatures): NavigationFeatures {
       isSsoOnlyMode: isSsoOnlyMode(),
       isOwnerOrAdmin: isOwnerOrAdmin(),
       isWebAuthnEnabled: isWebAuthnEnabled(),
+      isSsoEnabled: isSsoEnabled(),
     }
   );
 }
@@ -179,6 +183,17 @@ function getSecuritySection(
         icon: { collection: 'heroicons', name: 'finger-print-solid' },
         label: t('web.auth.passkeys.title'),
         visible: () => f.isWebAuthnEnabled,
+      },
+      {
+        // Connected SSO identities (#3840). Gated on isSsoEnabled — like
+        // passkeys are gated on isWebAuthnEnabled — NOT on hasPassword: an SSO
+        // identity is an alternative credential, and SSO-only accounts are the
+        // primary audience for managing their linked identities.
+        id: 'connections',
+        to: '/account/settings/security/connections',
+        icon: { collection: 'heroicons', name: 'globe-alt-solid' },
+        label: t('web.auth.connections.title'),
+        visible: () => f.isSsoEnabled,
       },
     ],
   };

--- a/src/apps/workspace/layouts/SettingsLayout.vue
+++ b/src/apps/workspace/layouts/SettingsLayout.vue
@@ -18,6 +18,7 @@ import {
   hasPasswordOf,
   isFullAuthModeOf,
   isOwnerOrAdminOf,
+  isSsoEnabledOf,
   isSsoOnlyModeOf,
   isWebAuthnEnabledOf,
 } from '@/utils/features';
@@ -40,6 +41,7 @@ const tabItems = computed(() => {
     isSsoOnlyMode: isSsoOnlyModeOf(bootstrapStore),
     isOwnerOrAdmin: isOwnerOrAdminOf(bootstrapStore),
     isWebAuthnEnabled: isWebAuthnEnabledOf(bootstrapStore),
+    isSsoEnabled: isSsoEnabledOf(bootstrapStore),
   };
   const sections = getSettingsNavigationSections(t, features);
   const allItems = sections.flatMap((section) => section.items);

--- a/src/apps/workspace/layouts/SettingsLayout.vue
+++ b/src/apps/workspace/layouts/SettingsLayout.vue
@@ -8,12 +8,10 @@
 -->
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n';
-import OIcon from '@/shared/components/icons/OIcon.vue';
 import { getSettingsNavigationSections } from '@/apps/workspace/config/settings-navigation';
-import { computed } from 'vue';
-import { useRoute } from 'vue-router';
+import OIcon from '@/shared/components/icons/OIcon.vue';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
+import { debugLog } from '@/utils/debug';
 import {
   hasPasswordOf,
   isFullAuthModeOf,
@@ -22,7 +20,9 @@ import {
   isSsoOnlyModeOf,
   isWebAuthnEnabledOf,
 } from '@/utils/features';
-import { debugLog } from '@/utils/debug';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRoute } from 'vue-router';
 
 const { t } = useI18n();
 const route = useRoute();
@@ -69,9 +69,12 @@ const isActiveRoute = (item: (typeof tabItems.value)[0]): boolean => {
 <template>
   <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
     <!-- Back to Dashboard -->
+    <!-- prettier-ignore-attribute class -->
     <router-link
       to="/"
-      class="group mb-6 inline-flex items-center gap-2 text-sm text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200">
+      class="
+        group mb-6 inline-flex items-center gap-2 text-sm text-gray-600 transition-colors
+        hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200">
       <OIcon
         collection="heroicons"
         name="arrow-left"
@@ -99,7 +102,7 @@ const isActiveRoute = (item: (typeof tabItems.value)[0]): boolean => {
         :key="item.id"
         :to="item.to"
         :class="[
-          'flex items-center gap-2 whitespace-nowrap border-b-2 px-4 py-3 text-sm font-medium transition-colors',
+          'flex items-center gap-2 border-b-2 px-4 py-3 text-sm font-medium whitespace-nowrap transition-colors',
           isActiveRoute(item)
             ? 'border-brand-500 text-brand-600 dark:border-brand-400 dark:text-brand-400'
             : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-400 dark:hover:border-gray-600 dark:hover:text-gray-300',

--- a/src/apps/workspace/routes/account.ts
+++ b/src/apps/workspace/routes/account.ts
@@ -309,6 +309,24 @@ const routes: Array<RouteRecordRaw> = [
     },
   },
   {
+    // Connected SSO identities (#3840 Phase 2). Guarded like passkeys with
+    // checkSecurityAccess (full-auth mode only) — an SSO identity is an
+    // alternative credential, NOT password-dependent, so it must NOT use a
+    // hasPassword-gated guard (SSO-only accounts are the primary users here).
+    path: '/account/settings/security/connections',
+    name: 'Connected Identities',
+    beforeEnter: checkSecurityAccess,
+    component: () => import('@/apps/workspace/account/ConnectedIdentities.vue'),
+    meta: {
+      title: 'web.TITLES.connected_identities',
+      requiresAuth: true,
+      layout: WorkspaceLayout,
+      layoutProps: standardLayoutProps,
+      scopesAvailable: SCOPE_PRESETS.hideBoth,
+      sentryScrubParams: false,
+    },
+  },
+  {
     path: '/account/settings/api',
     name: 'API Settings',
     component: () => import('@/apps/workspace/account/settings/ApiSettings.vue'),

--- a/src/apps/workspace/routes/account.ts
+++ b/src/apps/workspace/routes/account.ts
@@ -1,9 +1,9 @@
 // src/apps/workspace/routes/account.ts
 
 import WorkspaceLayout from '@/apps/workspace/layouts/WorkspaceLayout.vue';
-import type { RouteRecordRaw } from 'vue-router';
 import { SCOPE_PRESETS } from '@/types/router';
 import { hasPassword, isFullAuthMode, isOwnerOrAdmin } from '@/utils/features';
+import type { RouteRecordRaw } from 'vue-router';
 
 /**
  * Route guard for org-management account routes (password, MFA,

--- a/src/schemas/api/auth/responses/auth.ts
+++ b/src/schemas/api/auth/responses/auth.ts
@@ -256,6 +256,52 @@ export type ActiveSessionsResponse = z.infer<typeof activeSessionsResponseSchema
 export const removeSessionResponseSchema = authResponseSchema;
 export type RemoveSessionResponse = z.infer<typeof removeSessionResponseSchema>;
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Connected Identities (SSO account-linking — #3840 Phase 2)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A single SSO identity linked to the authenticated account.
+ *
+ * Shape mirrors GET /auth/identities EXACTLY (account-scoped rows, ordered by
+ * id ascending):
+ * - id:       account_identities row PK — the stable DELETE handle.
+ * - provider: strategy name stored on the row (oidc, entra, github, google).
+ * - issuer:   resolved IdP issuer (Phase 0 column). '' sentinel for legacy rows
+ *             and OAuth2-only providers (GitHub/Google); a URL otherwise. NOT
+ *             NULL, so an empty string — never null — signals "no issuer".
+ * - uid:      MASKED IdP subject (first4 + U+2026 + last4, or '***' when
+ *             length <= 8). Display-only; the raw sub is never returned. The
+ *             delete handle is `id`, not `uid`.
+ *
+ * NOTE: created_at is deliberately ABSENT — no such column exists on
+ * account_identities in migration 006/008 or the spec schema. Adding a
+ * timestamp would require a schema migration first.
+ */
+export const connectedIdentitySchema = z.object({
+  id: z.number().int(),
+  provider: z.string(),
+  issuer: z.string(),
+  uid: z.string(),
+});
+export type ConnectedIdentity = z.infer<typeof connectedIdentitySchema>;
+
+/** GET /auth/identities → { identities: [...] }. Empty account => { identities: [] }. */
+export const identitiesResponseSchema = z.object({
+  identities: z.array(connectedIdentitySchema),
+});
+export type IdentitiesResponse = z.infer<typeof identitiesResponseSchema>;
+
+/**
+ * DELETE /auth/identities/:id → { success: string } on 200.
+ * Error bodies (401/404/409/500) surface as the axios error's response.data and
+ * are classified by useAsyncHandler; the 409 last-credential guard carries an
+ * additional { error_code: 'last_credential' } the composable reads from
+ * details.
+ */
+export const removeIdentityResponseSchema = z.union([authSuccessSchema, authErrorSchema]);
+export type RemoveIdentityResponse = z.infer<typeof removeIdentityResponseSchema>;
+
 // OTP setup response
 // When HMAC is enabled, Rodauth returns an error response with only secrets on first request
 export const otpSetupResponseSchema = z.object({

--- a/src/schemas/api/auth/responses/auth.ts
+++ b/src/schemas/api/auth/responses/auth.ts
@@ -166,6 +166,8 @@ export function isAuthError(
     | EmailChangeConfirmResponse
     | EmailChangeResendResponse
     | ResendVerificationEmailResponse
+    | IdentitiesResponse
+    | RemoveIdentityResponse
 ): response is z.infer<typeof authErrorSchema> {
   return 'error' in response;
 }
@@ -193,6 +195,10 @@ export function isAuthSuccess(
     | VerifyAccountResponse
     | ChangePasswordResponse
     | CloseAccountResponse
+    // RemoveIdentityResponse is a { success } | { error } union, so the success
+    // guard sensibly applies. IdentitiesResponse is deliberately NOT included:
+    // it is a { identities: [...] } list container with neither field.
+    | RemoveIdentityResponse
 ): response is z.infer<typeof authSuccessSchema> {
   return 'success' in response;
 }

--- a/src/shared/composables/useConnectedIdentities.ts
+++ b/src/shared/composables/useConnectedIdentities.ts
@@ -1,0 +1,163 @@
+// src/shared/composables/useConnectedIdentities.ts
+
+/**
+ * Connected Identities composable (SSO account-linking — #3840 Phase 2)
+ *
+ * Manages the SSO identities linked to the authenticated account:
+ * - fetchIdentities(): GET /auth/identities (account-scoped list)
+ * - removeIdentity(id): DELETE /auth/identities/:id (CSRF-protected)
+ *
+ * INVARIANT: email may LOCATE an account; only a demonstrated CREDENTIAL may
+ * BIND an identity. Here the credential is the active authenticated session, so
+ * both endpoints only ever read/mutate the caller's own rows (the backend
+ * scopes every query by session_value — a cross-account id filters to 0 rows,
+ * so there is no IDOR to defend against on the client).
+ *
+ * Backend contract:
+ * - GET    200 => { identities: [{ id, provider, issuer, uid }] }
+ * - DELETE 200 => { success: string }
+ *     - 401 => not logged in / invalid session
+ *     - 404 => identity not owned by the caller OR does not exist
+ *     - 409 => { error, error_code: 'last_credential' } — removing the FINAL
+ *              identity of an SSO-only account (no usable password) is refused
+ *              because it would lock the user out.
+ *     - 500 => unexpected failure
+ *
+ * Mirrors useMfa: happy paths validate the response through a zod schema; the
+ * useAsyncHandler `wrap` drives reactive loading/error and maps failures via
+ * onError. Success emits a notification; the caller renders `error`/`errorCode`.
+ */
+
+import {
+  identitiesResponseSchema,
+  removeIdentityResponseSchema,
+  isAuthError,
+  type ConnectedIdentity,
+  type IdentitiesResponse,
+  type RemoveIdentityResponse,
+} from '@/schemas/api/auth/responses/auth';
+import type { ApplicationError } from '@/schemas/errors';
+import { useApi } from '@/shared/composables/useApi';
+import { useAsyncHandler, createError } from '@/shared/composables/useAsyncHandler';
+import { useCsrfStore } from '@/shared/stores/csrfStore';
+import { useNotificationsStore } from '@/shared/stores/notificationsStore';
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+/**
+ * Distinguishes the SSO-only lockout guard (409 last_credential) from generic
+ * failures so the UI can surface "keep at least one sign-in method" guidance
+ * instead of a bare error.
+ */
+export type IdentityErrorCode = 'last_credential' | null;
+
+/* eslint-disable max-lines-per-function */
+export function useConnectedIdentities() {
+  const { t } = useI18n();
+  const $api = useApi();
+  const csrfStore = useCsrfStore();
+  const notificationsStore = useNotificationsStore();
+
+  const identities = ref<ConnectedIdentity[]>([]);
+  const isLoading = ref(false);
+  const error = ref<string | null>(null);
+  const errorCode = ref<IdentityErrorCode>(null);
+
+  const { wrap } = useAsyncHandler({
+    notify: false,
+    setLoading: (loading) => (isLoading.value = loading),
+    onError: (err: ApplicationError) => {
+      const status = typeof err.code === 'number' ? err.code : null;
+      const backendCode =
+        err.details && typeof err.details === 'object'
+          ? (err.details as Record<string, unknown>).error_code
+          : undefined;
+
+      if (status === 409 && backendCode === 'last_credential') {
+        errorCode.value = 'last_credential';
+        error.value = t('web.auth.connections.errors.last_credential');
+        return;
+      }
+      if (status === 404) {
+        error.value = t('web.auth.connections.errors.not_found');
+        return;
+      }
+      if (status === 401) {
+        error.value = t('web.auth.connections.errors.unauthorized');
+        return;
+      }
+      error.value = t('web.auth.connections.errors.generic');
+    },
+  });
+
+  function clearError() {
+    error.value = null;
+    errorCode.value = null;
+  }
+
+  /**
+   * Fetches the SSO identities linked to the current account.
+   * Returns [] on error (error state is set via onError).
+   */
+  async function fetchIdentities(): Promise<ConnectedIdentity[]> {
+    clearError();
+
+    const result = await wrap(async () => {
+      const response = await $api.get<IdentitiesResponse>('/auth/identities');
+      const validated = identitiesResponseSchema.parse(response.data);
+      identities.value = validated.identities;
+      return validated.identities;
+    });
+
+    if (!result) {
+      identities.value = [];
+    }
+    return result ?? [];
+  }
+
+  /**
+   * Removes a single linked identity by its account_identities row id.
+   *
+   * @param id - numeric account_identities PK (the delete handle)
+   * @returns true when the row was removed
+   *
+   * The DELETE is CSRF-protected like /auth/active-sessions and all non-SSO
+   * /auth routes. On success the row is dropped from local state and a
+   * notification is shown. A 409 last_credential surfaces via errorCode.
+   */
+  async function removeIdentity(id: number): Promise<boolean> {
+    clearError();
+
+    const result = await wrap(async () => {
+      const response = await $api.delete<RemoveIdentityResponse>(`/auth/identities/${id}`, {
+        // Mirror /auth/active-sessions: send shrimp in the body in addition to
+        // the axios interceptor's X-CSRF-Token header (either satisfies the
+        // guard; both is belt-and-suspenders).
+        data: { shrimp: csrfStore.shrimp },
+      });
+      const validated = removeIdentityResponseSchema.parse(response.data);
+
+      // A 200 that still carries an error body would be unusual, but guard so a
+      // malformed success never silently drops a row.
+      if (isAuthError(validated)) {
+        throw createError(t('web.auth.connections.errors.generic'), 'human', 'error');
+      }
+
+      identities.value = identities.value.filter((identity) => identity.id !== id);
+      notificationsStore.show(t('web.auth.connections.removed_success'), 'success', 'top');
+      return true;
+    });
+
+    return result ?? false;
+  }
+
+  return {
+    identities,
+    isLoading,
+    error,
+    errorCode,
+    fetchIdentities,
+    removeIdentity,
+    clearError,
+  };
+}

--- a/src/shared/utils/sso.ts
+++ b/src/shared/utils/sso.ts
@@ -30,6 +30,25 @@ export interface SubmitSsoLoginOptions {
    * When provided, the backend stores it and redirects there post-login.
    */
   redirect?: string;
+
+  /**
+   * Marks this as an authenticated account-linking initiation (Connected
+   * Identities connect flow) rather than a plain sign-in. When true, a hidden
+   * `connect=1` field is submitted; the backend `omniauth.rb` hook reads it to
+   * authorize binding the returned identity to the CURRENT session account.
+   * Omit (or false) for normal sign-in — an unmarked initiation must not bind.
+   */
+  connect?: boolean;
+}
+
+/** Append a hidden input to the form (skipped when the value is empty). */
+function appendHiddenField(form: HTMLFormElement, name: string, value: string): void {
+  if (!value) return;
+  const input = document.createElement('input');
+  input.type = 'hidden';
+  input.name = name;
+  input.value = value;
+  form.appendChild(input);
 }
 
 /**
@@ -37,26 +56,21 @@ export interface SubmitSsoLoginOptions {
  * provider. Navigates the browser away to the IdP, so nothing runs after
  * `form.submit()` returns.
  */
-export function submitSsoLogin({ routeName, shrimp, redirect }: SubmitSsoLoginOptions): void {
+export function submitSsoLogin({
+  routeName,
+  shrimp,
+  redirect,
+  connect,
+}: SubmitSsoLoginOptions): void {
   const form = document.createElement('form');
   form.method = 'POST';
   form.action = `/auth/sso/${routeName}`;
 
-  if (shrimp) {
-    const csrfInput = document.createElement('input');
-    csrfInput.type = 'hidden';
-    csrfInput.name = 'shrimp';
-    csrfInput.value = shrimp;
-    form.appendChild(csrfInput);
-  }
-
-  if (redirect) {
-    const redirectInput = document.createElement('input');
-    redirectInput.type = 'hidden';
-    redirectInput.name = 'redirect';
-    redirectInput.value = redirect;
-    form.appendChild(redirectInput);
-  }
+  appendHiddenField(form, 'shrimp', shrimp ?? '');
+  appendHiddenField(form, 'redirect', redirect ?? '');
+  // Connect-intent: only the authenticated account-linking flow marks the
+  // initiation. A plain sign-in leaves it unset so the backend never binds.
+  appendHiddenField(form, 'connect', connect ? '1' : '');
 
   document.body.appendChild(form);
   form.submit();

--- a/src/tests/apps/session/views/Login.spec.ts
+++ b/src/tests/apps/session/views/Login.spec.ts
@@ -183,6 +183,15 @@ describe('Login.vue auth_error handling', () => {
       expect(alert.text()).toContain('web.login.errors.account_exists_link_required');
     });
 
+    it('displays identity_connect_conflict error from SSO connect (#3840)', async () => {
+      wrapper = await createWrapper({ auth_error: 'identity_connect_conflict' });
+      await flushPromises();
+
+      const alert = wrapper.find('[role="alert"]');
+      expect(alert.exists()).toBe(true);
+      expect(alert.text()).toContain('web.login.errors.identity_connect_conflict');
+    });
+
     it('displays org_join_failed error from tenant SSO', async () => {
       wrapper = await createWrapper({ auth_error: 'org_join_failed' });
       await flushPromises();

--- a/src/tests/apps/workspace/account/ConnectedIdentities.spec.ts
+++ b/src/tests/apps/workspace/account/ConnectedIdentities.spec.ts
@@ -1,0 +1,278 @@
+// src/tests/apps/workspace/account/ConnectedIdentities.spec.ts
+
+import { mount, flushPromises, VueWrapper } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import { ref } from 'vue';
+import { createTestI18n } from '@tests/setup';
+import type { ConnectedIdentity } from '@/schemas/api/auth/responses/auth';
+import type { IdentityErrorCode } from '@/shared/composables/useConnectedIdentities';
+
+// Mock vue-router
+vi.mock('vue-router', () => ({
+  useRoute: vi.fn(() => ({ path: '/account/settings/security/connections' })),
+  useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn() })),
+  RouterLink: {
+    name: 'RouterLink',
+    template: '<a :href="to"><slot /></a>',
+    props: ['to'],
+  },
+}));
+
+// Mock OIcon
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-icon="name" :data-collection="collection" />',
+    props: ['collection', 'name', 'class'],
+  },
+}));
+
+// Mock SettingsLayout
+vi.mock('@/apps/workspace/layouts/SettingsLayout.vue', () => ({
+  default: {
+    name: 'SettingsLayout',
+    template: '<div class="mock-settings-layout"><slot /></div>',
+  },
+}));
+
+// Mock ListSkeleton
+vi.mock('@/shared/components/closet/ListSkeleton.vue', () => ({
+  default: {
+    name: 'ListSkeleton',
+    template: '<div class="mock-list-skeleton" />',
+    props: ['icon', 'iconSize'],
+  },
+}));
+
+// Mock ConfirmDialog — expose confirm/cancel buttons that emit the events the
+// component wires to useConfirmDialog's confirm()/cancel().
+vi.mock('@/shared/components/modals/ConfirmDialog.vue', () => ({
+  default: {
+    name: 'ConfirmDialog',
+    template: `<div class="mock-confirm-dialog">
+      <button class="confirm-btn" @click="$emit('confirm')">confirm</button>
+      <button class="cancel-btn" @click="$emit('cancel')">cancel</button>
+    </div>`,
+    props: ['title', 'message', 'type'],
+    emits: ['confirm', 'cancel'],
+  },
+}));
+
+// Mock the composable — controllable reactive state + spies.
+const mockState = {
+  identities: ref<ConnectedIdentity[]>([]),
+  isLoading: ref(false),
+  error: ref<string | null>(null),
+  errorCode: ref<IdentityErrorCode>(null),
+  fetchIdentities: vi.fn(),
+  removeIdentity: vi.fn(),
+  clearError: vi.fn(),
+};
+
+vi.mock('@/shared/composables/useConnectedIdentities', () => ({
+  useConnectedIdentities: () => mockState,
+}));
+
+import ConnectedIdentities from '@/apps/workspace/account/ConnectedIdentities.vue';
+
+const i18n = createTestI18n();
+
+const makeIdentity = (overrides: Partial<ConnectedIdentity> = {}): ConnectedIdentity => ({
+  id: 1,
+  provider: 'entra',
+  issuer: 'https://login.microsoftonline.com/tenant/v2.0',
+  uid: 'abcd…wxyz',
+  ...overrides,
+});
+
+/**
+ * ConnectedIdentities Component Tests (#3840 Phase 2)
+ *
+ * Verifies the SSO account-linking panel:
+ * - fetches the identity list on mount
+ * - renders loading / empty / list states
+ * - masks nothing itself (backend supplies a masked uid) and hides the '' issuer
+ * - drives per-row removal through a confirmation dialog
+ * - surfaces generic and last-credential (409) errors distinctly
+ */
+describe('ConnectedIdentities', () => {
+  let wrapper: VueWrapper;
+
+  const mountComponent = () =>
+    mount(ConnectedIdentities, {
+      global: {
+        plugins: [i18n, createTestingPinia({ createSpy: vi.fn })],
+      },
+    });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.identities.value = [];
+    mockState.isLoading.value = false;
+    mockState.error.value = null;
+    mockState.errorCode.value = null;
+    mockState.fetchIdentities.mockResolvedValue([]);
+    mockState.removeIdentity.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    if (wrapper) wrapper.unmount();
+  });
+
+  describe('Basic Rendering', () => {
+    it('renders within SettingsLayout', () => {
+      wrapper = mountComponent();
+      expect(wrapper.find('.mock-settings-layout').exists()).toBe(true);
+    });
+
+    it('renders page title', () => {
+      wrapper = mountComponent();
+      const title = wrapper.find('h1');
+      expect(title.exists()).toBe(true);
+      expect(title.text()).toBe('web.auth.connections.title');
+    });
+
+    it('fetches identities on mount', () => {
+      wrapper = mountComponent();
+      expect(mockState.fetchIdentities).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Loading State', () => {
+    it('shows the list skeleton while loading with no identities yet', () => {
+      mockState.isLoading.value = true;
+      wrapper = mountComponent();
+      expect(wrapper.find('.mock-list-skeleton').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="connections-empty"]').exists()).toBe(false);
+    });
+  });
+
+  describe('Empty State', () => {
+    it('shows empty state when there are no identities', () => {
+      wrapper = mountComponent();
+      const empty = wrapper.find('[data-testid="connections-empty"]');
+      expect(empty.exists()).toBe(true);
+      expect(empty.text()).toContain('web.auth.connections.no_identities');
+    });
+
+    it('does not render the list when empty', () => {
+      wrapper = mountComponent();
+      expect(wrapper.find('[data-testid="connections-list"]').exists()).toBe(false);
+    });
+  });
+
+  describe('List Rendering', () => {
+    it('renders one row per identity', () => {
+      mockState.identities.value = [
+        makeIdentity({ id: 1 }),
+        makeIdentity({ id: 2, provider: 'github', issuer: '', uid: '***' }),
+      ];
+      wrapper = mountComponent();
+
+      const rows = wrapper.findAll('[data-testid="connections-list"] > li');
+      expect(rows).toHaveLength(2);
+    });
+
+    it('shows a friendly provider label', () => {
+      mockState.identities.value = [makeIdentity({ provider: 'entra' })];
+      wrapper = mountComponent();
+      expect(wrapper.text()).toContain('Microsoft Entra');
+    });
+
+    it('falls back to a capitalized provider name for unknown providers', () => {
+      mockState.identities.value = [makeIdentity({ provider: 'okta' })];
+      wrapper = mountComponent();
+      expect(wrapper.text()).toContain('Okta');
+    });
+
+    it('shows the backend-masked uid verbatim', () => {
+      mockState.identities.value = [makeIdentity({ uid: 'abcd…wxyz' })];
+      wrapper = mountComponent();
+      expect(wrapper.text()).toContain('abcd…wxyz');
+    });
+
+    it('shows the issuer when present', () => {
+      mockState.identities.value = [
+        makeIdentity({ issuer: 'https://login.microsoftonline.com/tenant/v2.0' }),
+      ];
+      wrapper = mountComponent();
+      expect(wrapper.text()).toContain('https://login.microsoftonline.com/tenant/v2.0');
+    });
+
+    it('hides the issuer for the empty-string sentinel (legacy / OAuth2-only rows)', () => {
+      mockState.identities.value = [makeIdentity({ provider: 'github', issuer: '', uid: '***' })];
+      wrapper = mountComponent();
+      expect(wrapper.text()).not.toContain('web.auth.connections.issuer');
+    });
+  });
+
+  describe('Remove Flow', () => {
+    it('reveals the confirmation dialog when Remove is clicked', async () => {
+      mockState.identities.value = [makeIdentity({ id: 7 })];
+      wrapper = mountComponent();
+
+      expect(wrapper.find('.mock-confirm-dialog').exists()).toBe(false);
+
+      await wrapper.find('[data-testid="connections-remove-7"]').trigger('click');
+      await flushPromises();
+
+      expect(wrapper.find('.mock-confirm-dialog').exists()).toBe(true);
+    });
+
+    it('calls removeIdentity with the row id when confirmed', async () => {
+      mockState.identities.value = [makeIdentity({ id: 7 })];
+      wrapper = mountComponent();
+
+      await wrapper.find('[data-testid="connections-remove-7"]').trigger('click');
+      await flushPromises();
+      await wrapper.find('.confirm-btn').trigger('click');
+      await flushPromises();
+
+      expect(mockState.removeIdentity).toHaveBeenCalledWith(7);
+    });
+
+    it('does not call removeIdentity when the dialog is canceled', async () => {
+      mockState.identities.value = [makeIdentity({ id: 7 })];
+      wrapper = mountComponent();
+
+      await wrapper.find('[data-testid="connections-remove-7"]').trigger('click');
+      await flushPromises();
+      await wrapper.find('.cancel-btn').trigger('click');
+      await flushPromises();
+
+      expect(mockState.removeIdentity).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Error Display', () => {
+    it('shows a generic error with alert role', () => {
+      mockState.error.value = 'web.auth.connections.errors.generic';
+      wrapper = mountComponent();
+
+      const err = wrapper.find('[data-testid="connections-error"]');
+      expect(err.exists()).toBe(true);
+      expect(err.attributes('role')).toBe('alert');
+      expect(err.classes()).toContain('bg-red-50');
+    });
+
+    it('styles the last-credential guard as a warning, not an error', () => {
+      mockState.error.value = 'web.auth.connections.errors.last_credential';
+      mockState.errorCode.value = 'last_credential';
+      wrapper = mountComponent();
+
+      const err = wrapper.find('[data-testid="connections-error"]');
+      expect(err.exists()).toBe(true);
+      expect(err.classes()).toContain('bg-yellow-50');
+      expect(err.classes()).not.toContain('bg-red-50');
+    });
+
+    it('calls clearError when the dismiss button is clicked', async () => {
+      mockState.error.value = 'web.auth.connections.errors.generic';
+      wrapper = mountComponent();
+
+      await wrapper.find('[data-testid="connections-error"] button[aria-label="Dismiss"]').trigger('click');
+      expect(mockState.clearError).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/tests/apps/workspace/account/ConnectedIdentities.spec.ts
+++ b/src/tests/apps/workspace/account/ConnectedIdentities.spec.ts
@@ -305,16 +305,19 @@ describe('ConnectedIdentities', () => {
       expect(wrapper.find('[data-testid="connections-connect"]').exists()).toBe(false);
     });
 
-    it('initiates SSO connect with the provider route, shrimp, and return redirect', async () => {
+    it('initiates SSO connect with the provider route, shrimp, return redirect, and connect intent', async () => {
       mockGetSsoProviders.mockReturnValue([{ route_name: 'oidc', display_name: 'OpenID Connect' }]);
       wrapper = mountComponent();
 
       await wrapper.find('[data-testid="connections-connect-oidc"]').trigger('click');
 
+      // connect: true is load-bearing — the backend only binds the returned
+      // identity to the session account when the initiation is marked.
       expect(mockSubmitSsoLogin).toHaveBeenCalledWith({
         routeName: 'oidc',
         shrimp: 'test-shrimp',
         redirect: '/account/settings/security/connections',
+        connect: true,
       });
     });
   });

--- a/src/tests/apps/workspace/account/ConnectedIdentities.spec.ts
+++ b/src/tests/apps/workspace/account/ConnectedIdentities.spec.ts
@@ -74,6 +74,24 @@ vi.mock('@/shared/composables/useConnectedIdentities', () => ({
   useConnectedIdentities: () => mockState,
 }));
 
+// Configured SSO providers (bootstrap-backed in prod) — controllable per test.
+import type { SsoProvider } from '@/utils/features';
+const mockGetSsoProviders = vi.fn<() => SsoProvider[]>(() => []);
+vi.mock('@/utils/features', () => ({
+  getSsoProviders: () => mockGetSsoProviders(),
+}));
+
+// SSO connect initiates a form POST (navigates away); assert the call, not nav.
+const mockSubmitSsoLogin = vi.fn();
+vi.mock('@/shared/utils/sso', () => ({
+  submitSsoLogin: (opts: unknown) => mockSubmitSsoLogin(opts),
+}));
+
+// CSRF store: the component reads csrfStore.shrimp to include in the connect POST.
+vi.mock('@/shared/stores/csrfStore', () => ({
+  useCsrfStore: () => ({ shrimp: 'test-shrimp' }),
+}));
+
 import ConnectedIdentities from '@/apps/workspace/account/ConnectedIdentities.vue';
 
 const i18n = createTestI18n();
@@ -114,6 +132,8 @@ describe('ConnectedIdentities', () => {
     mockState.errorCode.value = null;
     mockState.fetchIdentities.mockResolvedValue([]);
     mockState.removeIdentity.mockResolvedValue(true);
+    // clearAllMocks keeps implementations, so reset the provider list explicitly.
+    mockGetSsoProviders.mockReturnValue([]);
   });
 
   afterEach(() => {
@@ -242,6 +262,60 @@ describe('ConnectedIdentities', () => {
       await flushPromises();
 
       expect(mockState.removeIdentity).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Connect a provider', () => {
+    const providers: SsoProvider[] = [
+      { route_name: 'oidc', display_name: 'OpenID Connect' },
+      { route_name: 'entra', display_name: 'Microsoft Entra' },
+    ];
+
+    it('renders a Connect button for each connectable provider', () => {
+      mockGetSsoProviders.mockReturnValue(providers);
+      wrapper = mountComponent();
+
+      expect(wrapper.find('[data-testid="connections-connect"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="connections-connect-oidc"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="connections-connect-entra"]').exists()).toBe(true);
+    });
+
+    it('offers connect buttons in the empty state', () => {
+      mockGetSsoProviders.mockReturnValue([{ route_name: 'oidc', display_name: 'OpenID Connect' }]);
+      wrapper = mountComponent();
+
+      expect(wrapper.find('[data-testid="connections-empty"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="connections-connect-oidc"]').exists()).toBe(true);
+    });
+
+    it('excludes a provider already present in identities (same route_name)', () => {
+      mockState.identities.value = [makeIdentity({ provider: 'entra' })];
+      mockGetSsoProviders.mockReturnValue(providers);
+      wrapper = mountComponent();
+
+      expect(wrapper.find('[data-testid="connections-connect-oidc"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="connections-connect-entra"]').exists()).toBe(false);
+    });
+
+    it('renders no connect region when every provider is already linked', () => {
+      mockState.identities.value = [makeIdentity({ provider: 'entra' })];
+      mockGetSsoProviders.mockReturnValue([{ route_name: 'entra', display_name: 'Microsoft Entra' }]);
+      wrapper = mountComponent();
+
+      expect(wrapper.find('[data-testid="connections-connect"]').exists()).toBe(false);
+    });
+
+    it('initiates SSO connect with the provider route, shrimp, and return redirect', async () => {
+      mockGetSsoProviders.mockReturnValue([{ route_name: 'oidc', display_name: 'OpenID Connect' }]);
+      wrapper = mountComponent();
+
+      await wrapper.find('[data-testid="connections-connect-oidc"]').trigger('click');
+
+      expect(mockSubmitSsoLogin).toHaveBeenCalledWith({
+        routeName: 'oidc',
+        shrimp: 'test-shrimp',
+        redirect: '/account/settings/security/connections',
+      });
     });
   });
 

--- a/src/tests/apps/workspace/account/settings/SecurityOverview.spec.ts
+++ b/src/tests/apps/workspace/account/settings/SecurityOverview.spec.ts
@@ -39,6 +39,7 @@ vi.mock('@/apps/workspace/layouts/SettingsLayout.vue', () => ({
 const mockMfaEnabled = ref(true);
 const mockWebAuthnEnabled = ref(true);
 const mockHasPassword = ref(true);
+const mockSsoEnabled = ref(false);
 vi.mock('@/utils/features', () => ({
   isMfaEnabled: () => mockMfaEnabled.value,
   isWebAuthnEnabled: () => mockWebAuthnEnabled.value,
@@ -49,6 +50,10 @@ vi.mock('@/utils/features', () => ({
   isMfaEnabledOf: () => mockMfaEnabled.value,
   isWebAuthnEnabledOf: () => mockWebAuthnEnabled.value,
   hasPasswordOf: () => mockHasPassword.value,
+  // Connected identities (#3840) card is gated on SSO enablement. Default OFF
+  // so the pre-existing card matrix is unchanged; the dedicated block below
+  // flips it on.
+  isSsoEnabledOf: () => mockSsoEnabled.value,
 }));
 
 // Mock useAccount composable
@@ -99,6 +104,7 @@ describe('SecurityOverview', () => {
     mockMfaEnabled.value = true;
     mockWebAuthnEnabled.value = true;
     mockHasPassword.value = true;
+    mockSsoEnabled.value = false;
     mockAccountInfo.value = {
       email_verified: true,
       mfa_enabled: false,
@@ -191,6 +197,39 @@ describe('SecurityOverview', () => {
 
       const passkeyCard = findCardByIcon('finger-print-solid');
       expect(passkeyCard?.find('[data-icon="finger-print-solid"]').exists()).toBe(true);
+    });
+  });
+
+  describe('Connected Identities Card (SSO Feature Flag)', () => {
+    it('shows connections card when SSO is enabled', () => {
+      mockSsoEnabled.value = true;
+      wrapper = mountComponent();
+
+      expect(findCardByIcon('globe-alt-solid')).toBeDefined();
+    });
+
+    it('hides connections card when SSO is disabled', () => {
+      mockSsoEnabled.value = false;
+      wrapper = mountComponent();
+
+      expect(findCardByIcon('globe-alt-solid')).toBeUndefined();
+    });
+
+    it('displays connections card title and description', () => {
+      mockSsoEnabled.value = true;
+      wrapper = mountComponent();
+
+      const card = findCardByIcon('globe-alt-solid');
+      expect(card?.text()).toContain('web.auth.connections.title');
+      expect(card?.text()).toContain('web.auth.connections.description');
+    });
+
+    it('is not password-dependent: shows for SSO-only accounts (no password)', () => {
+      mockSsoEnabled.value = true;
+      mockHasPassword.value = false;
+      wrapper = mountComponent();
+
+      expect(findCardByIcon('globe-alt-solid')).toBeDefined();
     });
   });
 

--- a/src/tests/apps/workspace/config/settings-navigation.spec.ts
+++ b/src/tests/apps/workspace/config/settings-navigation.spec.ts
@@ -9,6 +9,7 @@ vi.mock('@/utils/features', () => ({
   isFullAuthMode: vi.fn(() => false),
   isSsoOnlyMode: vi.fn(() => false),
   isWebAuthnEnabled: vi.fn(() => false),
+  isSsoEnabled: vi.fn(() => false),
   hasPassword: vi.fn(() => false),
   isOwnerOrAdmin: vi.fn(() => false),
 }));
@@ -17,11 +18,12 @@ import {
   getSettingsNavigation,
   getSettingsNavigationSections,
 } from '@/apps/workspace/config/settings-navigation';
-import { isFullAuthMode, isSsoOnlyMode, isWebAuthnEnabled, hasPassword, isOwnerOrAdmin } from '@/utils/features';
+import { isFullAuthMode, isSsoOnlyMode, isWebAuthnEnabled, isSsoEnabled, hasPassword, isOwnerOrAdmin } from '@/utils/features';
 
 const mockedIsFullAuthMode = vi.mocked(isFullAuthMode);
 const mockedIsSsoOnlyMode = vi.mocked(isSsoOnlyMode);
 const mockedIsWebAuthnEnabled = vi.mocked(isWebAuthnEnabled);
+const mockedIsSsoEnabled = vi.mocked(isSsoEnabled);
 const mockedHasPassword = vi.mocked(hasPassword);
 const mockedIsOwnerOrAdmin = vi.mocked(isOwnerOrAdmin);
 
@@ -36,6 +38,7 @@ function makeFeatures(overrides: Partial<NavigationFeatures> = {}): NavigationFe
     isSsoOnlyMode: false,
     isOwnerOrAdmin: false,
     isWebAuthnEnabled: false,
+    isSsoEnabled: false,
     ...overrides,
   };
 }
@@ -64,6 +67,7 @@ describe('settings-navigation config', () => {
     mockedIsFullAuthMode.mockReturnValue(false);
     mockedIsSsoOnlyMode.mockReturnValue(false);
     mockedIsWebAuthnEnabled.mockReturnValue(false);
+    mockedIsSsoEnabled.mockReturnValue(false);
     mockedHasPassword.mockReturnValue(false);
     mockedIsOwnerOrAdmin.mockReturnValue(false);
   });
@@ -180,6 +184,26 @@ describe('settings-navigation config', () => {
       expect(
         getVisibleChildIds(makeFeatures({ isWebAuthnEnabled: true }), 'security')
       ).toContain('passkeys');
+    });
+
+    it('connections child visible only when SSO is enabled', () => {
+      expect(
+        getVisibleChildIds(makeFeatures({ isSsoEnabled: false }), 'security')
+      ).not.toContain('connections');
+
+      expect(
+        getVisibleChildIds(makeFeatures({ isSsoEnabled: true }), 'security')
+      ).toContain('connections');
+    });
+
+    it('connections child is not password-dependent (visible for SSO-only accounts)', () => {
+      // SSO-only account: no password, SSO enabled — connections must still show.
+      expect(
+        getVisibleChildIds(
+          makeFeatures({ hasPassword: false, isSsoEnabled: true }),
+          'security'
+        )
+      ).toContain('connections');
     });
   });
 

--- a/src/tests/apps/workspace/routes/account.guards.spec.ts
+++ b/src/tests/apps/workspace/routes/account.guards.spec.ts
@@ -97,11 +97,12 @@ describe('Account route guards', () => {
       expect(route?.beforeEnter).toBeDefined();
     });
 
-    it('security overview, sessions, and passkeys routes have beforeEnter guards', () => {
+    it('security overview, sessions, passkeys, and connections routes have beforeEnter guards', () => {
       const securityPaths = [
         '/account/settings/security',
         '/account/settings/security/sessions',
         '/account/settings/security/passkeys',
+        '/account/settings/security/connections',
       ];
       for (const path of securityPaths) {
         const route = accountRoutes.find((r: RouteRecordRaw) => r.path === path);
@@ -273,6 +274,9 @@ describe('Account route guards', () => {
       '/account/settings/security',
       '/account/settings/security/sessions',
       '/account/settings/security/passkeys',
+      // Connected identities is guarded like passkeys — full-auth mode only,
+      // NOT password-dependent (SSO-only accounts must be able to reach it).
+      '/account/settings/security/connections',
     ];
 
     for (const path of guardedPaths) {
@@ -327,6 +331,8 @@ describe('Account route guards', () => {
       expect(invokeGuard('/account/settings/caution')).toBe(true);
       expect(invokeGuard('/account/settings/security')).toBe(true);
       expect(invokeGuard('/account/settings/security/sessions')).toBe(true);
+      // Connected identities is not password-dependent — SSO-only owner reaches it.
+      expect(invokeGuard('/account/settings/security/connections')).toBe(true);
 
       // Should redirect
       expect(invokeGuard('/account/settings/security/password')).toEqual({ name: 'Account' });
@@ -350,7 +356,7 @@ describe('Account route guards', () => {
       expect(invokeGuard('/account/settings/caution')).toEqual({ name: 'Account' });
     });
 
-    it('member SSO (no password) can only access security overview and sessions', () => {
+    it('member SSO (no password) can access security overview, sessions, and connections', () => {
       mockedIsFullAuthMode.mockReturnValue(true);
       mockedHasPassword.mockReturnValue(false);
       mockedIsOwnerOrAdmin.mockReturnValue(false);
@@ -358,6 +364,8 @@ describe('Account route guards', () => {
       // Should allow
       expect(invokeGuard('/account/settings/security')).toBe(true);
       expect(invokeGuard('/account/settings/security/sessions')).toBe(true);
+      // Connected identities is not password-dependent — SSO-only member reaches it.
+      expect(invokeGuard('/account/settings/security/connections')).toBe(true);
 
       // Should redirect
       expect(invokeGuard('/account/settings/security/password')).toEqual({ name: 'Account' });

--- a/src/tests/shared/utils/sso.spec.ts
+++ b/src/tests/shared/utils/sso.spec.ts
@@ -1,0 +1,83 @@
+// src/tests/shared/utils/sso.spec.ts
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { submitSsoLogin } from '@/shared/utils/sso';
+
+/**
+ * submitSsoLogin builds and POSTs a form to /auth/sso/:routeName. It is SHARED
+ * between plain sign-in (SsoButton, disabled-homepage CTA) and the authenticated
+ * Connected Identities connect flow (#3840 Phase 2).
+ *
+ * SECURITY-CRITICAL: only the connect flow may pass `connect: true`, which emits
+ * a hidden `connect=1` field. The backend omniauth.rb hook reads that field to
+ * authorize binding the returned identity to the current session account; an
+ * unmarked (plain sign-in) initiation must NOT bind.
+ */
+describe('submitSsoLogin', () => {
+  beforeEach(() => {
+    // Prevent real navigation; jsdom would otherwise warn/throw on submit().
+    HTMLFormElement.prototype.submit = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.querySelectorAll('form[action^="/auth/sso/"]').forEach((form) => form.remove());
+  });
+
+  const lastForm = (): HTMLFormElement | null =>
+    document.querySelector<HTMLFormElement>('form[action^="/auth/sso/"]');
+
+  it('builds a POST form targeting /auth/sso/:routeName', () => {
+    submitSsoLogin({ routeName: 'oidc' });
+
+    const form = lastForm();
+    expect(form).not.toBeNull();
+    expect(form?.getAttribute('action')).toBe('/auth/sso/oidc');
+    expect(form?.method.toUpperCase()).toBe('POST');
+  });
+
+  it('includes the shrimp field when provided', () => {
+    submitSsoLogin({ routeName: 'oidc', shrimp: 'my-shrimp' });
+
+    const input = lastForm()?.querySelector<HTMLInputElement>('input[name="shrimp"]');
+    expect(input).not.toBeNull();
+    expect(input?.value).toBe('my-shrimp');
+  });
+
+  it('includes the redirect field when provided', () => {
+    submitSsoLogin({ routeName: 'oidc', redirect: '/account/settings/security/connections' });
+
+    const input = lastForm()?.querySelector<HTMLInputElement>('input[name="redirect"]');
+    expect(input).not.toBeNull();
+    expect(input?.value).toBe('/account/settings/security/connections');
+  });
+
+  it('emits a hidden connect=1 field when connect is true (account-linking flow)', () => {
+    submitSsoLogin({ routeName: 'oidc', shrimp: 's', connect: true });
+
+    const input = lastForm()?.querySelector<HTMLInputElement>('input[name="connect"]');
+    expect(input).not.toBeNull();
+    expect(input?.type).toBe('hidden');
+    expect(input?.value).toBe('1');
+  });
+
+  it('omits the connect field when connect is false (plain sign-in must not bind)', () => {
+    submitSsoLogin({ routeName: 'oidc', shrimp: 's', connect: false });
+
+    expect(lastForm()?.querySelector('input[name="connect"]')).toBeNull();
+  });
+
+  it('omits the connect field when connect is not passed at all', () => {
+    submitSsoLogin({ routeName: 'oidc', shrimp: 's' });
+
+    expect(lastForm()?.querySelector('input[name="connect"]')).toBeNull();
+  });
+
+  it('submits the form after building it', () => {
+    const submitSpy = vi.spyOn(HTMLFormElement.prototype, 'submit');
+
+    submitSsoLogin({ routeName: 'oidc', connect: true });
+
+    expect(submitSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -1,11 +1,11 @@
 // src/utils/features.ts
 
-import { getBootstrapValue } from '@/services/bootstrap.service';
 import {
   featuresSchema,
   type AuthenticationSettings,
   type Features,
 } from '@/schemas/contracts/bootstrap';
+import { getBootstrapValue } from '@/services/bootstrap.service';
 import { debugLog } from '@/utils/debug';
 
 /**

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -134,16 +134,23 @@ export function isPasswordRequirementsEnabled(): boolean {
 }
 
 /**
+ * Pure predicate: SSO authentication enabled in the given state.
+ *
+ * `sso` can be a boolean (false) or an object with an `enabled` property.
+ */
+export function isSsoEnabledOf(state: { features?: Features }): boolean {
+  const sso = state.features?.sso;
+  if (typeof sso === 'boolean') return sso;
+  return sso?.enabled === true;
+}
+
+/**
  * Checks if SSO authentication is enabled
  */
 export function isSsoEnabled(): boolean {
   if (typeof window === 'undefined') return false;
 
-  const features = getBootstrapValue('features');
-  // sso can be boolean (false) or object with enabled property
-  const sso = features?.sso;
-  if (typeof sso === 'boolean') return sso;
-  return sso?.enabled === true;
+  return isSsoEnabledOf({ features: getBootstrapValue('features') });
 }
 
 /**


### PR DESCRIPTION
## #3840 Phase 2 — Connected Identities

Third phase of the SSO account-linking remediation (#3840, sequencing for #3838). Adds the authenticated **connect-a-provider** flow and the account-settings UI to manage linked SSO identities. Targets the orchestration branch; Phase 0 (#3845) and Phase 1 (#3844) are already merged there.

### What this does

- **Session-bound connect, not email-located.** `account_from_omniauth` now binds an authenticated SSO connect to the **session account** (`_account_from_session`) — the callback email plays **no role** in resolution. This closes the email-match anti-pattern where a tenant callback could be steered to another account by its asserted email. Tenant-surface isolation is preserved: a tenant callback on a platform session is refused.
- **Identities management API** — `GET`/`DELETE` routes under `apps/web/auth/routes/identities.rb`, wired in `router.rb`, with typed responses in `src/schemas/api/auth/responses/auth.ts`.
- **Connected Identities settings page** — `ConnectedIdentities.vue` + `useConnectedIdentities.ts` composable, reachable from Security settings; lists linked providers and offers a **Connect {provider}** action.
- **Refusal surfacing** — `Login.vue` maps `identity_connect_conflict` to a generic re-auth message (surface isolation or expired session).

### Why session-is-authorization

The authenticated session *is* the authorization to link. Using the callback's asserted email to locate the target account would let a hostile IdP assertion pick the victim. Settled per prior security-design guidance (canonical practice, not a preference poll). Verified in `rodauth-omniauth` 0.6.2: already-linked identities route to `account_from_omniauth_identity` **before** this hook, so "linked elsewhere" cannot occur here.

### Tests

- BE: `omniauth_connect_link_spec.rb` (Scenario 2 proves the email is ignored), `identities_routes_spec.rb` — all green.
- FE: `ConnectedIdentities.spec.ts`, `SecurityOverview.spec.ts`, `Login.spec.ts`, nav/route guards — all green, 0 lint errors.

### Diff

22 files, ~2000 insertions. Backend hook + routes, Vue panel + composable, integration + unit specs, 4 new en locale keys.

### Follow-ups (not in this PR)

- Tenant-surface authenticated-linking hardening tracked in #3849 (org-membership verification + surface-scoped login).
- `locales:hashes` for the 4 new bare keys — deferred to avoid tree-wide hash drift in a feature PR.
