### PR TITLE
[#3857] Make Rodauth reset-password-request path enumeration-safe

### DIFF
--- a/apps/web/auth/config.rb
+++ b/apps/web/auth/config.rb
@@ -89,6 +89,10 @@ module Auth
       # Method overrides (replace Rodauth methods, not before/after hooks)
       Overrides::PasswordMigration.configure(self)
       Overrides::ErrorHandling.configure(self)
+      # Enumeration safety for the reset-password-request path (issue #3857).
+      # Runs after AccountManagement enables :reset_password above, so the
+      # overridden methods exist.
+      Overrides::ResetPasswordEnumeration.configure(self)
       RodauthOverrides.configure(self)
 
       # Lockout: brute force protection

--- a/apps/web/auth/config/overrides.rb
+++ b/apps/web/auth/config/overrides.rb
@@ -18,4 +18,5 @@
 module Auth::Config::Overrides
   require_relative 'overrides/error_handling'
   require_relative 'overrides/password_migration'
+  require_relative 'overrides/reset_password_enumeration'
 end

--- a/apps/web/auth/config/overrides/reset_password_enumeration.rb
+++ b/apps/web/auth/config/overrides/reset_password_enumeration.rb
@@ -1,0 +1,121 @@
+# apps/web/auth/config/overrides/reset_password_enumeration.rb
+#
+# frozen_string_literal: true
+
+#
+# Reset-Password-Request Enumeration Safety (issue #3857)
+#
+# MECHANISM: method overrides via `auth_class_eval` — these REPLACE Rodauth
+# methods (overrides clobber like hooks do: last definition wins), which is why
+# this file lives in config/overrides/ rather than config/hooks/. `super` inside
+# each override invokes the stock Rodauth implementation (features are included
+# as modules, so the originals live in the class's ancestry).
+#
+# WHY THIS EXISTS
+# ---------------
+# The Rodauth `:reset_password` feature is enabled (config/features/
+# account_management.rb). In `full` auth mode the Rodauth app is mounted at
+# `/auth` and — because Rack::URLMap dispatches to the longest matching prefix —
+# handles EVERY `/auth/*` route, including `POST /auth/reset-password-request`.
+# That route is therefore the one actually exposed to unauthenticated callers;
+# it shadows the enumeration-safe custom endpoint in apps/web/core (mounted at
+# `/`).
+#
+# Stock Rodauth 2.44.0 (lib/rodauth/features/reset_password.rb, the
+# reset_password_request route) distinguishes "account exists" from "no account"
+# on that request path in THREE ways, each an account-existence oracle (CWE-204):
+#
+#   1. no matching login         -> throw_error_reason(:no_matching_login, ...)
+#   2. account not open/verified -> reset_password_request_for_unverified_account
+#                                   (throws :unverified_account)
+#   3. email recently sent       -> "reset_password_email_recently_sent" error
+#
+# A registered, verified account returns 200 { success: "An email has been
+# sent..." }, whereas a non-existent login returns an error tuple carrying a
+# `field-error`. Comparing the two lets an unauthenticated caller enumerate
+# accounts — exactly the posture the custom endpoint
+# (apps/api/account/logic/authentication/reset_password_request.rb) was written
+# to prevent.
+#
+# WHY OVERRIDE RATHER THAN DISABLE THE ROUTE
+# ------------------------------------------
+# We cannot simply disable the request route. In full mode the reset *consume*
+# path (`/auth/reset-password`) is Rodauth's and expects a Rodauth-generated
+# reset token, and the reset email links to Rodauth's reset URL
+# (config/email/reset_password.rb) — so the request path must remain Rodauth's to
+# mint that token. Instead we neutralise the three oracle branches so every POST
+# yields the SAME generic "email sent" response, regardless of whether the login
+# maps to an account, whether that account is open, and whether an email was
+# recently sent.
+#
+# Side effects (reset-key creation + email) still happen only for a valid, open,
+# non-throttled account, and Rodauth's resend throttle is PRESERVED: a
+# recently-emailed account returns the same generic success WITHOUT resending, so
+# closing the oracle does not open an email-bombing regression.
+#
+# See also: config/rodauth_overrides.rb (verify_account error-flash overrides)
+# and config/overrides/password_migration.rb (the `super` override idiom).
+#
+module Auth::Config::Overrides
+  module ResetPasswordEnumeration
+    def self.configure(auth)
+      auth_class = auth.instance_variable_get(:@auth)
+      # reset_password_email_sent_response and the two reset-request predicates
+      # only exist when the feature is enabled; nothing to harden otherwise.
+      return unless auth_class&.features&.include?(:reset_password)
+
+      # rubocop:disable Lint/NestedMethodDefinition -- Rodauth's auth_class_eval pattern
+      auth.auth_class_eval do
+        # ---- Oracle 1: no matching login ----------------------------------
+        # account_from_login is SHARED with the login route, so the
+        # enumeration-safe short-circuit is scoped to the reset-password-request
+        # route via current_route (set by Rodauth's route wrapper). On every
+        # other route — login above all — a missing account behaves exactly as
+        # before. Internal requests bypass the wrapper, leaving current_route
+        # nil, so they are unaffected too.
+        def account_from_login(login)
+          account = super
+
+          if account.nil? && current_route == :reset_password_request
+            Auth::Logging.log_auth_event(
+              :reset_password_request_no_account,
+              level: :info,
+              email: login, # obscured by log_auth_event
+            )
+            # Respond exactly as the success path would; halts the request, so
+            # the `unless account_from_login(...)` check in the route never sees
+            # the nil and never emits no_matching_login.
+            reset_password_email_sent_response
+          end
+
+          account
+        end
+
+        # ---- Oracle 2: account exists but is not open (unverified/closed) --
+        # Rodauth's default throws :unverified_account, revealing the account
+        # exists. Return the same generic success instead. No reset email is
+        # sent for a non-open account, mirroring the custom endpoint.
+        def reset_password_request_for_unverified_account
+          Auth::Logging.log_auth_event(
+            :reset_password_request_unopen_account,
+            level: :info,
+            account_id: account_id,
+          )
+          reset_password_email_sent_response
+        end
+
+        # ---- Oracle 3: email recently sent --------------------------------
+        # Rodauth's default renders the "reset_password_email_recently_sent"
+        # error, which only an existing account can trigger. Keep the throttle
+        # (do NOT resend), but return the same generic success so the throttled
+        # case is indistinguishable from a fresh send or a non-existent login.
+        def reset_password_email_recently_sent?
+          return false unless super
+
+          reset_password_email_sent_response
+        end
+      end
+      # rubocop:enable Lint/NestedMethodDefinition
+    end
+  end
+end

--- a/apps/web/auth/config/overrides/reset_password_enumeration.rb
+++ b/apps/web/auth/config/overrides/reset_password_enumeration.rb
@@ -53,6 +53,41 @@
 # recently-emailed account returns the same generic success WITHOUT resending, so
 # closing the oracle does not open an email-bombing regression.
 #
+# HALT CONTRACT (why these overrides are safe)
+# --------------------------------------------
+# Each override neutralises its oracle by calling reset_password_email_sent_response,
+# which builds the generic success and then HALTS the request (Rodauth's
+# return_response -> request.halt, i.e. throw :halt). The overrides DEPEND on that
+# halt: in account_from_login the halt is what stops the route from ever observing
+# the nil account and emitting no_matching_login. If a future Rodauth changed
+# reset_password_email_sent_response to return instead of halt, these overrides
+# would fail OPEN (re-expose the oracle) rather than crash — so the enumeration
+# regression spec
+# (apps/web/auth/spec/integration/full/reset_password_request_enumeration_spec.rb)
+# is the guard that must catch such a change. Pinned against Rodauth 2.44.0.
+#
+# RESIDUAL: TIMING SIDE-CHANNEL (accepted, not closed)
+# ----------------------------------------------------
+# Response content and status are now identical across all four cases (no account,
+# unopen account, throttled account, fresh send), so the single-request CWE-204
+# oracle is closed. A LATENCY residual remains: the miss path halts right after the
+# shared `accounts` SELECT, whereas a valid, open, non-throttled account
+# additionally runs ~4 single-row statements on account_password_reset_keys
+# (inside a transaction), generates a random key, and enqueues the reset email — an
+# async AMQP publish (~ms) in production with background jobs enabled. That
+# hit/miss delta is single-digit-millisecond indexed DB work, an order of magnitude
+# below the network / Puma / GC jitter an off-host attacker sees, so it degrades to
+# a statistical-only, many-sample attack rather than a deterministic distinguisher.
+#
+# We deliberately DO NOT pad the miss path. account_password_reset_keys is FK/PK-
+# bound to accounts, so a non-existent login has no legal row to mirror;
+# equalization would require junk accounts, insert-and-rollback theater, or dummy
+# queue traffic — all new side effects and an abuse surface on an unauthenticated
+# route — while a fixed sleep pad is defeated by variance analysis and taxes every
+# legitimate request (Ruby/Rack offers no constant-time guarantee across a DB +
+# AMQP chain anyway). Content-equalization above is the meaningful fix; the timing
+# residual is accepted and documented. (Reviewed: Greptile P1, issue #3857.)
+#
 # See also: config/rodauth_overrides.rb (verify_account error-flash overrides)
 # and config/overrides/password_migration.rb (the `super` override idiom).
 #
@@ -60,8 +95,11 @@ module Auth::Config::Overrides
   module ResetPasswordEnumeration
     def self.configure(auth)
       auth_class = auth.instance_variable_get(:@auth)
-      # reset_password_email_sent_response and the two reset-request predicates
-      # only exist when the feature is enabled; nothing to harden otherwise.
+      # Rodauth exposes the enabled feature symbols via the public `features`
+      # reader on the auth class (Rodauth 2.44.0). reset_password_email_sent_response
+      # and the two reset-request predicates only exist when :reset_password is
+      # enabled, so there is nothing to harden otherwise; the safe-navigation guards
+      # also make this a no-op if `features` is ever unavailable.
       return unless auth_class&.features&.include?(:reset_password)
 
       # rubocop:disable Lint/NestedMethodDefinition -- Rodauth's auth_class_eval pattern
@@ -82,9 +120,12 @@ module Auth::Config::Overrides
               level: :info,
               email: login, # obscured by log_auth_event
             )
-            # Respond exactly as the success path would; halts the request, so
-            # the `unless account_from_login(...)` check in the route never sees
-            # the nil and never emits no_matching_login.
+            # Respond exactly as the success path would; HALTS the request (see
+            # the HALT CONTRACT note in the header), so the
+            # `unless account_from_login(...)` check in the route never sees the
+            # nil and never emits no_matching_login. Halting here — before the
+            # reset-key writes + email enqueue a valid account performs — is the
+            # source of the accepted timing residual documented in the header.
             reset_password_email_sent_response
           end
 

--- a/apps/web/auth/config/overrides/reset_password_enumeration.rb
+++ b/apps/web/auth/config/overrides/reset_password_enumeration.rb
@@ -73,20 +73,24 @@
 # oracle is closed. A LATENCY residual remains: the miss path halts right after the
 # shared `accounts` SELECT, whereas a valid, open, non-throttled account
 # additionally runs ~4 single-row statements on account_password_reset_keys
-# (inside a transaction), generates a random key, and enqueues the reset email — an
-# async AMQP publish (~ms) in production with background jobs enabled. That
-# hit/miss delta is single-digit-millisecond indexed DB work, an order of magnitude
-# below the network / Puma / GC jitter an off-host attacker sees, so it degrades to
-# a statistical-only, many-sample attack rather than a deterministic distinguisher.
+# (inside a transaction), generates a random key, and dispatches the reset email.
+# Dispatch cost is deployment-dependent: an async AMQP publish (~ms) when background
+# jobs are enabled, or a synchronous inline SMTP send (delivery.rb uses
+# fallback: :sync, taken whenever RabbitMQ is absent — a common self-hosted config)
+# that can dominate the delta. With jobs enabled the hit/miss gap sits near the
+# network / Puma / GC jitter an off-host attacker sees (a noisy many-sample attack);
+# under synchronous delivery the gap is larger and that statistical attack is
+# easier. Either way it is not a single-request distinguisher — but not negligible.
 #
 # We deliberately DO NOT pad the miss path. account_password_reset_keys is FK/PK-
 # bound to accounts, so a non-existent login has no legal row to mirror;
 # equalization would require junk accounts, insert-and-rollback theater, or dummy
 # queue traffic — all new side effects and an abuse surface on an unauthenticated
-# route — while a fixed sleep pad is defeated by variance analysis and taxes every
-# legitimate request (Ruby/Rack offers no constant-time guarantee across a DB +
-# AMQP chain anyway). Content-equalization above is the meaningful fix; the timing
-# residual is accepted and documented. (Reviewed: Greptile P1, issue #3857.)
+# route — while a fixed sleep pad is defeated by variance analysis, taxes every
+# legitimate request, and lets an unauthenticated caller pin Puma threads (a DoS
+# amplifier); Ruby/Rack offers no constant-time guarantee across a DB + email chain
+# regardless. Content-equalization above is the meaningful fix; the timing residual
+# is accepted and documented. (Reviewed: Greptile P1 + 2nd review bot, issue #3857.)
 #
 # See also: config/rodauth_overrides.rb (verify_account error-flash overrides)
 # and config/overrides/password_migration.rb (the `super` override idiom).
@@ -129,6 +133,11 @@ module Auth::Config::Overrides
             reset_password_email_sent_response
           end
 
+          # Fail-open return: normally the halt above fires and we never reach
+          # here. If the halt contract ever breaks, this bare `account` (nil on a
+          # miss) makes the route re-expose the oracle rather than act on a
+          # non-account. A guard clause would return the response object instead;
+          # an explicit `return` trips Style/RedundantReturn.
           account
         end
 
@@ -153,6 +162,11 @@ module Auth::Config::Overrides
         def reset_password_email_recently_sent?
           return false unless super
 
+          # Truthy super = a real account is throttled. HALTS with the generic
+          # success (HALT CONTRACT). Intentionally no explicit boolean: on the
+          # fail-open (halt-removed) path this returns the response value, which
+          # the route treats as truthy and re-exposes the oracle. A defensive
+          # `true` would change that documented fall-through return — omit it.
           reset_password_email_sent_response
         end
       end

--- a/apps/web/auth/spec/integration/full/reset_password_request_enumeration_spec.rb
+++ b/apps/web/auth/spec/integration/full/reset_password_request_enumeration_spec.rb
@@ -1,0 +1,190 @@
+# apps/web/auth/spec/integration/full/reset_password_request_enumeration_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration — reset-password-request enumeration safety (issue #3857)
+# =============================================================================
+#
+# In `full` auth mode the Rodauth app is mounted at /auth and handles
+# POST /auth/reset-password-request. Stock Rodauth distinguishes "account
+# exists" from "no account" on that path (no_matching_login / unverified /
+# recently-sent), which is an account-existence oracle (CWE-204). The override
+# in config/overrides/reset_password_enumeration.rb collapses all three branches
+# to the same generic "email sent" response.
+#
+# These tests assert the exposed request path is enumeration-safe: an existing
+# login and a non-existent login yield an identical HTTP response.
+#
+# REQUIREMENTS:
+# - Valkey running on port 2121: pnpm run test:database:start
+# - AUTH_DATABASE_URL set (SQLite or PostgreSQL)
+# - AUTHENTICATION_MODE=full
+#
+# RUN:
+#   source .env.test && pnpm run test:rspec \
+#     apps/web/auth/spec/integration/full/reset_password_request_enumeration_spec.rb
+#
+# =============================================================================
+
+require_relative '../../spec_helper'
+require 'rack/test'
+
+RSpec.describe 'Reset-password-request enumeration safety (issue #3857)', type: :integration do
+  include Rack::Test::Methods
+
+  before(:all) do
+    # Boot the full app so the REAL Auth::Config (with the enumeration override
+    # wired in via config/overrides/reset_password_enumeration.rb) is loaded and
+    # mounted at /auth. See pending_plan_intent_flow_spec.rb for why we must not
+    # reopen Auth::Config as a plain module here.
+    boot_onetime_app
+  end
+
+  before do
+    unless defined?(Auth::Database) && Auth::Database.connection
+      skip 'Auth database not configured (run with AUTH_DATABASE_URL set)'
+    end
+
+    # Isolate from real email delivery. The enumeration property holds with or
+    # without a real send; stubbing keeps the happy path deterministic (the
+    # publisher would otherwise attempt a synchronous delivery). Kept as a spy so
+    # the throttle example can assert a resend did NOT happen.
+    allow(Onetime::Jobs::Publisher).to receive(:enqueue_email_raw).and_return(true)
+  end
+
+  let(:created_account_ids) { [] }
+
+  after do
+    created_account_ids.each do |account_id|
+      Auth::Database.connection[:accounts].where(id: account_id).delete
+    rescue StandardError
+      # Non-fatal cleanup error
+    end
+  end
+
+  def unique_test_email(prefix = 'reset-enum')
+    "#{prefix}-#{SecureRandom.hex(8)}@integration-test.example.com"
+  end
+
+  # Creates an account with a password hash. status_id defaults to verified.
+  def create_account(email:, status_id: AuthTestConstants::STATUS_VERIFIED, password: 'TestPassword123!')
+    db    = Auth::Database.connection
+    extid = SecureRandom.uuid
+    account_id = db[:accounts].insert(
+      email: email,
+      status_id: status_id,
+      external_id: extid,
+      created_at: Time.now,
+      updated_at: Time.now
+    )
+    created_account_ids << account_id
+
+    require 'argon2'
+    # Cost params match test config in config/features/argon2.rb
+    hasher = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
+    db[:account_password_hashes].insert(id: account_id, password_hash: hasher.create(password))
+
+    { id: account_id, email: email, external_id: extid }
+  end
+
+  # Establish a fresh session, fetch the CSRF token from GET /auth, then POST a
+  # JSON reset-password-request to the Rodauth endpoint (mounted at /auth). The
+  # full Rack app enforces CSRF, so the shrimp token is included (mirrors the
+  # csrf_login helper in pending_plan_intent_flow_spec.rb).
+  #
+  # @return [Rack::MockResponse] the last response
+  def request_password_reset(login)
+    clear_cookies
+
+    header 'Content-Type', nil
+    header 'Content-Length', nil
+    header 'Accept', 'application/json'
+    get '/auth'
+    token = last_response.headers['X-CSRF-Token']
+
+    header 'Content-Type', 'application/json'
+    header 'Accept', 'application/json'
+    header 'X-CSRF-Token', token if token
+    post '/auth/reset-password-request', JSON.generate(login: login, shrimp: token)
+    last_response
+  end
+
+  # Capture (status, parsed-body) for a probe so two probes can be compared.
+  def probe(login)
+    response = request_password_reset(login)
+    [response.status, JSON.parse(response.body)]
+  end
+
+  describe 'non-existent login' do
+    it 'returns a generic success rather than a no_matching_login field error' do
+      status, body = probe(unique_test_email('nobody'))
+
+      # Pre-fix, Rodauth answered a non-existent login with an error tuple:
+      #   { "field-error": ["login", "no matching login"], "error": "..." }
+      # The override must instead answer with the same success a real request
+      # gets, disclosing nothing about account existence.
+      expect(body).not_to have_key('field-error')
+      expect(body['error']).to be_nil
+      expect(body['success']).to be_a(String)
+      expect(body['success']).to match(/email has been sent/i)
+      expect(status).to eq(200)
+    end
+  end
+
+  describe 'existing (verified) vs non-existent login' do
+    it 'returns an identical response for both' do
+      existing = unique_test_email('exists')
+      create_account(email: existing)
+
+      existing_status, existing_body = probe(existing)
+      missing_status,  missing_body  = probe(unique_test_email('missing'))
+
+      expect(existing_status).to eq(missing_status)
+      expect(existing_body).to eq(missing_body)
+      # And it is the success shape, not a shared error shape.
+      expect(existing_body).not_to have_key('field-error')
+      expect(existing_body['success']).to match(/email has been sent/i)
+    end
+  end
+
+  describe 'existing but unverified vs non-existent login' do
+    it 'does not distinguish the unverified account (no unverified_account oracle)' do
+      unverified = unique_test_email('unverified')
+      create_account(email: unverified, status_id: AuthTestConstants::STATUS_UNVERIFIED)
+
+      unverified_status, unverified_body = probe(unverified)
+      missing_status,    missing_body    = probe(unique_test_email('missing-unverified'))
+
+      expect(unverified_status).to eq(missing_status)
+      expect(unverified_body).to eq(missing_body)
+      expect(unverified_body).not_to have_key('field-error')
+    end
+  end
+
+  describe 'recently-sent throttle' do
+    it 'stays enumeration-safe without resending (throttle preserved)' do
+      verified = unique_test_email('recent')
+      account  = create_account(email: verified)
+
+      # Simulate a reset email that was just sent: a live key row whose
+      # email_last_sent is within reset_password_skip_resend_email_within.
+      Auth::Database.connection[:account_password_reset_keys].insert(
+        id: account[:id],
+        key: SecureRandom.hex(16),
+        deadline: Time.now + (24 * 60 * 60),
+        email_last_sent: Time.now
+      )
+
+      throttled_status, throttled_body = probe(verified)
+      missing_status,   missing_body   = probe(unique_test_email('missing-recent'))
+
+      # Same generic success as a non-existent login...
+      expect(throttled_status).to eq(missing_status)
+      expect(throttled_body).to eq(missing_body)
+      expect(throttled_body).not_to have_key('field-error')
+      # ...and the throttle held: no additional reset email was dispatched.
+      expect(Onetime::Jobs::Publisher).not_to have_received(:enqueue_email_raw)
+    end
+  end
+end

--- a/apps/web/auth/spec/integration/full/reset_password_request_enumeration_spec.rb
+++ b/apps/web/auth/spec/integration/full/reset_password_request_enumeration_spec.rb
@@ -29,6 +29,7 @@
 
 require_relative '../../spec_helper'
 require 'rack/test'
+require 'argon2'
 
 RSpec.describe 'Reset-password-request enumeration safety (issue #3857)', type: :integration do
   include Rack::Test::Methods
@@ -56,8 +57,16 @@ RSpec.describe 'Reset-password-request enumeration safety (issue #3857)', type: 
   let(:created_account_ids) { [] }
 
   after do
+    db = Auth::Database.connection
     created_account_ids.each do |account_id|
-      Auth::Database.connection[:accounts].where(id: account_id).delete
+      # Delete child rows before the parent. On PostgreSQL the FK from
+      # account_password_reset_keys / account_password_hashes -> accounts makes a
+      # bare accounts delete raise; the rescue below would then swallow it and the
+      # rows would leak. (On SQLite FKs are off by default so order is moot, but we
+      # keep the correct order so cleanup is real on either backend.)
+      db[:account_password_reset_keys].where(id: account_id).delete
+      db[:account_password_hashes].where(id: account_id).delete
+      db[:accounts].where(id: account_id).delete
     rescue StandardError
       # Non-fatal cleanup error
     end
@@ -80,8 +89,8 @@ RSpec.describe 'Reset-password-request enumeration safety (issue #3857)', type: 
     )
     created_account_ids << account_id
 
-    require 'argon2'
-    # Cost params match test config in config/features/argon2.rb
+    # Cost params match test config in config/features/argon2.rb (argon2 is
+    # required at the top of the file).
     hasher = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
     db[:account_password_hashes].insert(id: account_id, password_hash: hasher.create(password))
 
@@ -91,7 +100,9 @@ RSpec.describe 'Reset-password-request enumeration safety (issue #3857)', type: 
   # Establish a fresh session, fetch the CSRF token from GET /auth, then POST a
   # JSON reset-password-request to the Rodauth endpoint (mounted at /auth). The
   # full Rack app enforces CSRF, so the shrimp token is included (mirrors the
-  # csrf_login helper in pending_plan_intent_flow_spec.rb).
+  # csrf_login helper in pending_plan_intent_flow_spec.rb). "shrimp" is this
+  # app's name for the CSRF authenticity token (the Rack authenticity_param is
+  # literally 'shrimp'; see lib/onetime/middleware/security.rb).
   #
   # @return [Rack::MockResponse] the last response
   def request_password_reset(login)
@@ -145,6 +156,26 @@ RSpec.describe 'Reset-password-request enumeration safety (issue #3857)', type: 
       # And it is the success shape, not a shared error shape.
       expect(existing_body).not_to have_key('field-error')
       expect(existing_body['success']).to match(/email has been sent/i)
+    end
+  end
+
+  describe 'happy path (existing verified account)' do
+    it 'still enqueues exactly one reset email for a valid, verified account' do
+      verified = unique_test_email('happy')
+      create_account(email: verified)
+
+      status, body = probe(verified)
+
+      # Closing the oracle must not suppress real functionality: a valid, open,
+      # non-throttled account still gets its reset email. probe() touches only
+      # this one account, so exactly one enqueue to this address is expected.
+      expect(status).to eq(200)
+      expect(body['success']).to match(/email has been sent/i)
+      # enqueue_email_raw is called with a message hash (to:/subject:/body:/from:)
+      # then delivery options; assert exactly one reset email addressed to the
+      # verified account.
+      expect(Onetime::Jobs::Publisher).to have_received(:enqueue_email_raw)
+        .with(hash_including(to: include(verified)), any_args).once
     end
   end
 

--- a/apps/web/auth/spec/integration/full/reset_password_request_enumeration_spec.rb
+++ b/apps/web/auth/spec/integration/full/reset_password_request_enumeration_spec.rb
@@ -54,23 +54,15 @@ RSpec.describe 'Reset-password-request enumeration safety (issue #3857)', type: 
     allow(Onetime::Jobs::Publisher).to receive(:enqueue_email_raw).and_return(true)
   end
 
-  let(:created_account_ids) { [] }
-
-  after do
-    db = Auth::Database.connection
-    created_account_ids.each do |account_id|
-      # Delete child rows before the parent. On PostgreSQL the FK from
-      # account_password_reset_keys / account_password_hashes -> accounts makes a
-      # bare accounts delete raise; the rescue below would then swallow it and the
-      # rows would leak. (On SQLite FKs are off by default so order is moot, but we
-      # keep the correct order so cleanup is real on either backend.)
-      db[:account_password_reset_keys].where(id: account_id).delete
-      db[:account_password_hashes].where(id: account_id).delete
-      db[:accounts].where(id: account_id).delete
-    rescue StandardError
-      # Non-fatal cleanup error
-    end
-  end
+  # No per-example DB cleanup block here on purpose. FullModeSuiteDatabase wipes
+  # every Rodauth table in an after(:each) hook for :full_auth_mode specs (see
+  # spec/support/full_mode_suite_database.rb — clean_tables! over the authoritative
+  # RODAUTH_TABLES list), so isolation is already guaranteed. A hand-rolled
+  # per-account delete would also be unsafe to maintain: an account is referenced by
+  # ~20 FK-bound tables (audit logs, reset/verify/remember keys, ...), several with
+  # ON DELETE RESTRICT, so a child-first delete list would silently leak rows the
+  # moment a new flow touches another table — which is exactly what a stricter
+  # version of this block surfaced during review.
 
   def unique_test_email(prefix = 'reset-enum')
     "#{prefix}-#{SecureRandom.hex(8)}@integration-test.example.com"
@@ -87,7 +79,6 @@ RSpec.describe 'Reset-password-request enumeration safety (issue #3857)', type: 
       created_at: Time.now,
       updated_at: Time.now
     )
-    created_account_ids << account_id
 
     # Cost params match test config in config/features/argon2.rb (argon2 is
     # required at the top of the file).
@@ -171,11 +162,14 @@ RSpec.describe 'Reset-password-request enumeration safety (issue #3857)', type: 
       # this one account, so exactly one enqueue to this address is expected.
       expect(status).to eq(200)
       expect(body['success']).to match(/email has been sent/i)
-      # enqueue_email_raw is called with a message hash (to:/subject:/body:/from:)
-      # then delivery options; assert exactly one reset email addressed to the
-      # verified account.
+      # enqueue_email_raw receives (message_hash, delivery_opts). Mail::Message#to
+      # ALWAYS returns a Mail::AddressContainer (< Array) of BARE addresses — even a
+      # "Name <addr>" input is parsed down to ["addr"] — and email_to here is
+      # account[login_column], so to: is exactly [verified]. contain_exactly pins
+      # that single recipient order-independently and, unlike include(), fails loudly
+      # if the shape ever regresses to a bare string (which would substring-match).
       expect(Onetime::Jobs::Publisher).to have_received(:enqueue_email_raw)
-        .with(hash_including(to: include(verified)), any_args).once
+        .with(hash_including(to: contain_exactly(verified)), any_args).once
     end
   end
 

--- a/changelog.d/20260723_050316_claude_3857_reset_password_enumeration.rst
+++ b/changelog.d/20260723_050316_claude_3857_reset_password_enumeration.rst
@@ -1,0 +1,15 @@
+.. A new scriv changelog fragment.
+
+Security
+--------
+
+- Closed an account-enumeration oracle on the password-reset request endpoint.
+  In full authentication mode the Rodauth-backed
+  ``POST /auth/reset-password-request`` answered a request for a registered
+  address differently from an unregistered one — and differently again for an
+  unverified account or one that was emailed moments earlier — letting an
+  unauthenticated caller probe which email addresses have accounts (CWE-204).
+  The endpoint now returns the same generic "an email has been sent" response in
+  every case, matching the enumeration-safe behavior the basic-mode endpoint
+  already enforced, while still sending a reset email only for a valid, verified
+  account and preserving Rodauth's resend throttle. (#3857)

--- a/changelog.d/20260723_050316_claude_3857_reset_password_enumeration.rst
+++ b/changelog.d/20260723_050316_claude_3857_reset_password_enumeration.rst
@@ -12,4 +12,10 @@ Security
   The endpoint now returns the same generic "an email has been sent" response in
   every case, matching the enumeration-safe behavior the basic-mode endpoint
   already enforced, while still sending a reset email only for a valid, verified
-  account and preserving Rodauth's resend throttle. (#3857)
+  account and preserving Rodauth's resend throttle. A residual response-timing
+  difference remains — a matching account performs additional database writes and
+  an email dispatch that a non-existent address does not — and is a known, accepted
+  limitation: it reduces the leak from a definitive single-request answer to a
+  timing-only signal, and closing it fully would require request padding or dummy
+  work that adds abuse surface on an unauthenticated route without robustly
+  removing it. (#3857)


### PR DESCRIPTION
## Summary

[#3857](https://github.com/onetimesecret/onetimesecret/issues/3857)

Closes an account-existence oracle (CWE-204) on the password-reset **request** path.

**Which route is actually exposed** (issue investigation step 1): in `full` auth mode the Rodauth app is mounted at `/auth`, and because `Rack::URLMap` dispatches to the longest matching prefix it handles *every* `/auth/*` route — including `POST /auth/reset-password-request`. That shadows the enumeration-safe custom endpoint in `apps/web/core` (mounted at `/`), so the **gem's** request route is the one unauthenticated callers reach. The custom endpoint's enumeration-safety is therefore not load-bearing here.

Stock Rodauth 2.44.0 distinguishes "account exists" from "no account" on that request path in three ways, each an existence oracle:

| Branch | Stock response |
| --- | --- |
| Unknown login | `no_matching_login` field-error |
| Existing but unverified/closed | `unverified_account` error |
| Existing, emailed moments ago | "reset password email recently sent" error |

A registered, verified account gets `200 { "success": "An email has been sent..." }`, so comparing responses reveals which addresses have accounts.

**Why override rather than disable the route:** in full mode the reset *consume* path (`/auth/reset-password`) is Rodauth's and expects a Rodauth-generated token, and the reset email links to it (`config/email/reset_password.rb`) — so the request path must stay Rodauth's to mint that token. Disabling it would 404 the flow (Rack::URLMap does not cascade to the core app). Instead, `config/overrides/reset_password_enumeration.rb` overrides the three oracle branches so every POST returns the same generic "email sent" response.

Key properties:
- Side effects (reset-key creation + email) still happen **only** for a valid, open, non-throttled account.
- Rodauth's resend **throttle is preserved** — a recently-emailed account returns the same generic success *without* resending, so closing the oracle does not open an email-bomb regression.
- The `no_matching_login` override is scoped to the reset-password-request route via `current_route`, leaving the shared `account_from_login` untouched on the login route and everywhere else.

## Related Issues

Fixes #3857

## Test Plan

Added `apps/web/auth/spec/integration/full/reset_password_request_enumeration_spec.rb` (full-stack Rack::Test through the mounted Rodauth app), asserting the exposed request path does not distinguish account existence:

- non-existent login returns a generic success (`200`, `success` key, **no** `field-error` / `no matching login`) rather than the stock error tuple;
- an existing **verified** login yields a response byte-identical to a non-existent login;
- an existing **unverified** account is likewise indistinguishable from a non-existent login;
- a **recently-emailed** account stays enumeration-safe *and* the throttle holds (no second email dispatched);
- **happy path:** a valid, verified account still enqueues exactly one reset email (the fix must not suppress real sends).

Delivery is stubbed for determinism; the enumeration property holds with or without a real send.

> **Verified** under Ruby 3.4.10 (rbenv): the enumeration spec passes **5/5** examples, and the full-auth integration directory `apps/web/auth/spec/integration/full/` runs **282 examples, 0 failures** (60 pending — OmniAuth/SSO specs that skip when OIDC routes aren't registered at boot). `rubocop` is clean on the override. Reproduce with `source .env.test && pnpm run test:rspec apps/web/auth/spec/integration/full/reset_password_request_enumeration_spec.rb` (requires Valkey/Redis on 2121 + `AUTH_DATABASE_URL`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtXwmqCnodmPStTFp2UEQu

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtXwmqCnodmPStTFp2UEQu)_