### PR TITLE
Fix CloseAccount session sweep skipping all encrypted sessions

### DIFF
--- a/apps/api/account/logic/account/confirm_email_change.rb
+++ b/apps/api/account/logic/account/confirm_email_change.rb
@@ -193,13 +193,13 @@ module AccountAPI::Logic
         auth_logger.error '[confirm-email-change] Redis session cleanup error', exception: ex
       end
 
-      # Resolve the session secret using the same fallback chain as
-      # Onetime::Session#initialize: ENV['SESSION_SECRET'] then site secret.
+      # Resolve the session secret with the SAME chain the middleware writer
+      # is mounted with: Onetime.session_config['secret'] — site.session.secret
+      # falling back to site.secret (middleware_stack.rb / boot.rb). The
+      # middleware never consults ENV['SESSION_SECRET'], so reading ENV here
+      # could derive keys from a different secret and silently match nothing.
       def resolve_session_secret
-        secret = ENV.fetch('SESSION_SECRET', nil)
-        return secret if secret.is_a?(String) && !secret.empty?
-
-        OT.conf.dig('site', 'secret')
+        Onetime.session_config['secret']
       end
 
       # Extract the external_id from a stored session value after verifying

--- a/apps/api/account/logic/account/confirm_email_change.rb
+++ b/apps/api/account/logic/account/confirm_email_change.rb
@@ -180,7 +180,11 @@ module AccountAPI::Logic
         hmac_key           = Onetime::KeyDerivation.derive_session_subkey(session_secret, 'hmac')
         encryption_key_raw = [Onetime::KeyDerivation.derive_session_subkey(session_secret, 'encryption')].pack('H*')
 
-        dbclient.scan_each(match: 'session:*') do |key|
+        # STRING-typed like Store.scan_keys: the loose match also catches
+        # non-string session:* keys (the entitlement-preview SETs), each of
+        # which would cost a GET round trip that dies as a silently-rescued
+        # WRONGTYPE inside extract_session_extid.
+        dbclient.scan_each(match: 'session:*', type: 'string') do |key|
           session_extid = extract_session_extid(dbclient, key, hmac_key, encryption_key_raw)
           next unless session_extid == extid
 

--- a/apps/web/auth/operations/close_account.rb
+++ b/apps/web/auth/operations/close_account.rb
@@ -54,6 +54,9 @@
 #   end
 #
 
+require 'onetime/operations/sessions/store'
+require 'onetime/session/codec'
+
 module Auth
   module Operations
     class CloseAccount
@@ -174,8 +177,16 @@ module Auth
       end
 
       # Deletes all Redis sessions associated with the given external_id.
-      # Sessions are stored in Redis with keys like "session:<session_id>"
-      # and contain external_id in their JSON data.
+      # Sessions are stored in Redis with keys like "session:<session_id>".
+      #
+      # Session values are AES-256-GCM encrypted + HMAC-signed
+      # ("base64(iv+tag+ciphertext)--hmac"), so they MUST be decoded through
+      # the same SessionCodec the middleware writes with. The previous
+      # `JSON.parse(Base64.decode64(...))` treated the value as base64(json):
+      # for authenticated sessions the base64 decodes to binary ciphertext, the
+      # parse raised, and every authenticated session was silently skipped —
+      # closing an account left its live sessions untouched. {Store.load_data}
+      # decodes first and falls back to legacy plaintext JSON.
       #
       # @param extid [String] The customer's external ID
       # @return [Integer] Number of sessions deleted
@@ -184,36 +195,44 @@ module Auth
 
         dbclient      = Familia.dbclient
         deleted_count = 0
+        codec         = session_codec
 
         # Scan for all session keys
         dbclient.scan_each(match: 'session:*') do |key|
-            raw_value = dbclient.get(key)
-            next unless raw_value
-
-            # Session data format: "base64(json)--hmac"
-            # We need to decode the base64 part to check external_id
-            data_part = raw_value.split('--').first
-            next unless data_part
-
-            json_data    = Base64.decode64(data_part)
-            session_data = JSON.parse(json_data)
+            session_data = Onetime::Operations::Sessions::Store.load_data(dbclient, key, codec: codec)
+            next unless session_data.is_a?(Hash)
 
             # Check if this session belongs to the user being deleted
             session_extid = session_data['external_id'] || session_data['account_external_id']
-            if session_extid == extid
-              dbclient.del(key)
-              deleted_count += 1
-              OT.ld "[close-account] Deleted Redis session: #{key[0..30]}..."
-            end
-        rescue JSON::ParserError, ArgumentError => ex
-            # Skip malformed sessions
-            OT.ld "[close-account] Skipping malformed session #{key}: #{ex.message}"
+            next unless session_extid == extid
+
+            dbclient.del(key)
+            deleted_count += 1
+            OT.ld "[close-account] Deleted Redis session: #{key[0..30]}..."
+        rescue StandardError => ex
+            # One malformed/undecodable key must never abort the whole sweep.
+            OT.ld "[close-account] Skipping session #{key}: #{ex.message}"
         end
 
         deleted_count
       rescue StandardError => ex
         OT.le "[close-account] Error deleting Redis sessions: #{ex.message}"
         0
+      end
+
+      # SessionCodec built from the same secret the session middleware writes
+      # with — ENV['SESSION_SECRET'], then the site secret (the fallback chain
+      # in Onetime::Session#initialize). Returns nil when no secret is
+      # configured, in which case {Store.load_data} degrades to the legacy
+      # plaintext-JSON path rather than raising.
+      def session_codec
+        secret = ENV.fetch('SESSION_SECRET', nil)
+        secret = OT.conf.dig('site', 'secret') if secret.to_s.empty?
+        return nil if secret.to_s.empty?
+
+        Onetime::SessionCodec.new(secret)
+      rescue StandardError
+        nil
       end
 
       # Builds an error result hash

--- a/apps/web/auth/operations/close_account.rb
+++ b/apps/web/auth/operations/close_account.rb
@@ -195,10 +195,17 @@ module Auth
 
         dbclient      = Familia.dbclient
         deleted_count = 0
-        codec         = session_codec
+        # from_config resolves the SAME secret chain the middleware writer is
+        # mounted with (session_config['secret'] → site.secret). Any other
+        # chain — e.g. ENV['SESSION_SECRET'], which the middleware never
+        # reads — can build a codec with the wrong key, and every encrypted
+        # session silently fails to decode and survives the sweep.
+        codec         = Onetime::SessionCodec.from_config
 
-        # Scan for all session keys
-        dbclient.scan_each(match: 'session:*') do |key|
+        # Scan for all session keys. STRING-typed like Store.scan_keys: the
+        # loose match also catches non-string keys (the entitlement-preview
+        # SETs) that would WRONGTYPE on GET.
+        dbclient.scan_each(match: 'session:*', type: 'string') do |key|
             session_data = Onetime::Operations::Sessions::Store.load_data(dbclient, key, codec: codec)
             next unless session_data.is_a?(Hash)
 
@@ -218,21 +225,6 @@ module Auth
       rescue StandardError => ex
         OT.le "[close-account] Error deleting Redis sessions: #{ex.message}"
         0
-      end
-
-      # SessionCodec built from the same secret the session middleware writes
-      # with — ENV['SESSION_SECRET'], then the site secret (the fallback chain
-      # in Onetime::Session#initialize). Returns nil when no secret is
-      # configured, in which case {Store.load_data} degrades to the legacy
-      # plaintext-JSON path rather than raising.
-      def session_codec
-        secret = ENV.fetch('SESSION_SECRET', nil)
-        secret = OT.conf.dig('site', 'secret') if secret.to_s.empty?
-        return nil if secret.to_s.empty?
-
-        Onetime::SessionCodec.new(secret)
-      rescue StandardError
-        nil
       end
 
       # Builds an error result hash

--- a/apps/web/auth/try/operations/close_account_try.rb
+++ b/apps/web/auth/try/operations/close_account_try.rb
@@ -139,6 +139,45 @@ skip_without_db(false) do
 end
 #=> false
 
+# --- delete_redis_sessions: AES-GCM session decode ---
+#
+# delete_redis_sessions SCANs session:* for blobs whose codec-DECODED
+# external_id matches the closing account and deletes each match. Sessions are
+# AES-256-GCM encrypted, so the sweep MUST decode through the codec -- the old
+# JSON.parse(base64) path raised on every authenticated blob and silently
+# skipped it, leaving live sessions behind on account closure. These cases
+# assert the real Redis effects (the method swallows all errors, so nothing
+# else could catch a regression). Redis-only: no auth DB required, so they run
+# even when the accounts DB is absent (db: passed non-nil to skip the connect).
+require 'onetime/session/codec'
+
+## an authenticated, AES-GCM-encrypted session blob for the closing account is
+## deleted, while a DIFFERENT account's blob survives -- proving the encrypted
+## blob actually decodes (a plain JSON.parse skipped every authenticated
+## session)
+@ca_secret = ENV.fetch('SESSION_SECRET', nil)
+@ca_secret = OT.conf.dig('site', 'secret') if @ca_secret.to_s.empty?
+@ca_codec  = Onetime::SessionCodec.new(@ca_secret)
+@ca_db     = Familia.dbclient
+@ca_extid  = "extid_close_#{SecureRandom.hex(6)}"
+@ca_sid    = SecureRandom.hex(32)
+@ca_blob   = "session:#{@ca_sid}"
+@ca_other_sid  = SecureRandom.hex(32)
+@ca_other_blob = "session:#{@ca_other_sid}"
+@ca_op = Auth::Operations::CloseAccount.new(extid: @ca_extid, db: :redis_only)
+@ca_db.set(@ca_blob, @ca_codec.encode({ 'external_id' => @ca_extid, 'authenticated' => true }), ex: 3600)
+@ca_db.set(@ca_other_blob, @ca_codec.encode({ 'external_id' => 'someone_else', 'authenticated' => true }), ex: 3600)
+@ca_op.send(:delete_redis_sessions, @ca_extid)
+[@ca_db.exists(@ca_blob), @ca_db.exists(@ca_other_blob)]
+#=> [0, 1]
+
+## the sweep reports the count of blobs it deleted (one matching account)
+@ca_db.set(@ca_blob, @ca_codec.encode({ 'external_id' => @ca_extid }), ex: 3600)
+@ca_result = @ca_op.send(:delete_redis_sessions, @ca_extid)
+@ca_db.del(@ca_blob, @ca_other_blob)
+@ca_result
+#=> 1
+
 # Teardown
 if @db
   begin

--- a/apps/web/auth/try/operations/close_account_try.rb
+++ b/apps/web/auth/try/operations/close_account_try.rb
@@ -155,8 +155,11 @@ require 'onetime/session/codec'
 ## deleted, while a DIFFERENT account's blob survives -- proving the encrypted
 ## blob actually decodes (a plain JSON.parse skipped every authenticated
 ## session)
-@ca_secret = ENV.fetch('SESSION_SECRET', nil)
-@ca_secret = OT.conf.dig('site', 'secret') if @ca_secret.to_s.empty?
+# Plant blobs with the middleware writer's own secret resolution
+# (session_config['secret'], the chain middleware_stack mounts the session
+# with) — the sweep's SessionCodec.from_config must resolve the SAME secret
+# for the encrypted blob to decode and match.
+@ca_secret = Onetime.session_config['secret']
 @ca_codec  = Onetime::SessionCodec.new(@ca_secret)
 @ca_db     = Familia.dbclient
 @ca_extid  = "extid_close_#{SecureRandom.hex(6)}"

--- a/try/unit/logic/account/email_change_try.rb
+++ b/try/unit/logic/account/email_change_try.rb
@@ -443,6 +443,40 @@ confirm.process
 @inv_session.empty?
 #=> true
 
+# --- ConfirmEmailChange: Redis session sweep (AES-GCM decode) ---
+#
+# delete_redis_sessions SCANs session:* and deletes blobs whose decrypted
+# external_id matches the customer. Sessions are AES-256-GCM encrypted, so
+# the sweep's key derivation MUST start from the SAME secret the middleware
+# writer is mounted with (session_config['secret']); any other chain builds
+# wrong keys and every encrypted session silently survives. These cases
+# assert the real Redis effects (the method swallows all errors, so nothing
+# else could catch a regression).
+require 'onetime/session/codec'
+
+## delete_redis_sessions deletes the matching customer's session blob while a
+## different customer's blob survives (the identity match is exact) — proving
+## the sweep derives its keys from the writer's own secret resolution
+@sweep_secret = Onetime.session_config['secret']
+@sweep_codec  = Onetime::SessionCodec.new(@sweep_secret)
+@sweep_db     = Familia.dbclient
+@sweep_cust   = Onetime::Customer.new email: generate_unique_test_email('sweep')
+@sweep_cust.save
+@sweep_blob = "session:#{SecureRandom.hex(32)}"
+@other_blob = "session:#{SecureRandom.hex(32)}"
+@sweep_db.set(@sweep_blob,
+              @sweep_codec.encode({ 'external_id' => @sweep_cust.extid, 'authenticated' => true }),
+              ex: 3600)
+@sweep_db.set(@other_blob,
+              @sweep_codec.encode({ 'external_id' => 'extid_of_someone_else', 'authenticated' => true }),
+              ex: 3600)
+@sweep_obj = AccountAPI::Logic::Account::ConfirmEmailChange.new(
+  MockStrategyResult.new(session: {}, user: @sweep_cust), { 'token' => '' }
+)
+@sweep_obj.send(:delete_redis_sessions, @sweep_cust)
+[@sweep_db.exists(@sweep_blob), @sweep_db.exists(@other_blob)]
+#=> [0, 1]
+
 # --- ConfirmEmailChange: Rodauth full-mode (SQLite accounts.email update) ---
 #
 # These tests exercise the update_auth_database and invalidate_sessions
@@ -593,6 +627,8 @@ noacct_result[:confirmed]
 #=> true
 
 # Cleanup
+@sweep_db.del(@other_blob) if defined?(@other_blob) && @other_blob
+@sweep_cust.delete! if defined?(@sweep_cust) && @sweep_cust
 @bare_cust.delete! if defined?(@bare_cust) && @bare_cust
 @inv_cust.delete! if defined?(@inv_cust) && @inv_cust
 @rod_cust.delete! if defined?(@rod_cust) && @rod_cust


### PR DESCRIPTION
## Summary

`CloseAccount#delete_redis_sessions` decoded session values as `base64(json)--hmac`, but the session middleware writes AES-256-GCM encrypted blobs (`base64(iv+tag+ciphertext)--hmac`). The base64 part decoded to binary ciphertext, `JSON.parse` raised, and the per-key rescue skipped the blob — **so closing an account silently left every authenticated session alive**.

The fix decodes through `Store.load_data` with a `SessionCodec` built by `SessionCodec.from_config`, which resolves the **same secret chain the middleware writer is mounted with**: `session_config['secret']` (`site.session.secret` → `site.secret`, see `middleware_stack.rb` / `boot.rb`). An earlier revision resolved `ENV['SESSION_SECRET']` → `site.secret`; review (Copilot/Greptile) correctly flagged that the middleware never reads ENV, so a deployment with a distinct `site.session.secret` would have derived the wrong key and reintroduced the skip-everything failure mode. The same divergence existed in `ConfirmEmailChange#resolve_session_secret` (the email-change session sweep), so that now returns `session_config['secret']` too.

`load_data` falls back to legacy plaintext JSON, preserving the old behavior for pre-encryption blobs; the per-key rescue widens to `StandardError` so one undecodable key can never abort the whole sweep; and the close-account SCAN is now STRING-typed like `Store.scan_keys`, so non-string `session:*` keys (the entitlement-preview SETs) no longer cost a WRONGTYPE round-trip each.

This is a standalone extraction of the fix that first landed inside #3861, pulled out so a security-relevant correctness fix can be reviewed and merged on its own timeline rather than the feature's. #3861 additionally purges that PR's per-value sidecar keys in these sweeps; the extraction carries none of that coupling, and #3861 will absorb this cleanly on a rebase/merge of `main` (identical hunks land on both branches).

## Related Issues

Extracted from #3861 (issue #3858's review pass, where the bug was found).

## Test Plan

- Cases in `apps/web/auth/try/operations/close_account_try.rb` (real Valkey/Redis on :2121, no auth DB required): plant an AES-GCM-encrypted blob for the closing account and one for a different account — encoded via the **writer's own secret resolution** (`session_config['secret']`) — then assert the real Redis effects: the matching blob is deleted, the non-matching blob survives, the deleted count is returned. The Redis-effect assertions matter because the method deliberately swallows all errors; nothing else could catch a regression here.
- New case in `try/unit/logic/account/email_change_try.rb` pinning the same decode-and-match behavior for the email-change sweep (it had no Redis-effect coverage).
- `close_account_try.rb`: 12 testcases passed, 0 failed. `email_change_try.rb`: 32 passed vs 31 at the branch baseline (+1 = the new case); the 2 failures/10 errors in both runs are a pre-existing `VERIFIABLE_ID_HMAC_SECRET` container gap, verified by running the suite with the changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018auXPigG1Y77p6jSeLpUsC

---
_Generated by [Claude Code](https://claude.ai/code/session_018auXPigG1Y77p6jSeLpUsC)_