### PR TITLE
[#3840] Phase 3: SSO sign-in interstitial (LinkSso challenge flow)

### DIFF
--- a/apps/web/auth/config/hooks/omniauth.rb
+++ b/apps/web/auth/config/hooks/omniauth.rb
@@ -219,6 +219,83 @@ module Auth::Config::Hooks
           # reach create_omniauth_identity or omniauth_create_account. The
           # domain-validation hook below also runs only on the CREATE path, so
           # the email-link path would bypass it entirely.
+          existing_id = existing[account_id_column]
+
+          # ────────────────────────────────────────────────────────────────
+          # #3840 Phase 3: sign-in interstitial for PASSWORD-HOLDING accounts.
+          # ────────────────────────────────────────────────────────────────
+          #
+          # A password-holding account CAN prove ownership without a prior
+          # session: re-enter the existing password. Instead of dead-ending at
+          # the H-3 refusal, mint a single-use challenge snapshotting this
+          # callback's (provider, resolved_issuer, uid, email, account id) and
+          # redirect to the interstitial, where the password is collected and
+          # verified before the (provider, issuer, uid) row is bound
+          # (POST /auth/link-sso, apps/web/auth/routes/link_sso.rb). This still
+          # honours "email may LOCATE, only a credential may BIND" — the located
+          # account is NOT returned here (no auto-link); the credential is proven
+          # at the POST.
+          #
+          # We CANNOT use rodauth.has_password? here: it reads the SESSION
+          # account's hash (account ? account_id : session_value), and this branch
+          # is the UNAUTHENTICATED path (session_value nil) — it would always be
+          # false. Query the located account's hash directly instead, mirroring
+          # Rodauth's own password_hash_ds (base.rb) but scoped to existing_id.
+          #
+          # SURFACE ISOLATION (critical — this guard is NOT redundant): mint ONLY
+          # on the PLATFORM surface (session[:validated_omniauth_domain_id] nil). An
+          # UNAUTHENTICATED TENANT SSO callback ALSO reaches this email branch:
+          # before_omniauth_callback_route (omniauth_tenant.rb) stamps
+          # session[:validated_omniauth_domain_id] on EVERY tenant callback, and an
+          # unauthenticated caller is not logged in and has no connect intent — so
+          # the connect/refuse branches at the top of this hook are skipped and
+          # execution falls through to HERE with the tenant key SET. A tenant admin
+          # controls their own IdP and can assert ANY email, so WITHOUT this guard
+          # the tenant surface would become an unauthenticated, un-lockable
+          # password-guessing oracle against arbitrary PLATFORM accounts, and a
+          # successful guess would bind the tenant IdP identity onto the victim's
+          # platform account — the exact cross-surface takeover #3849 says must stay
+          # refused. So gate the mint on the platform surface, matching the trust
+          # branch's guard above (session[:validated_omniauth_domain_id].nil?) and
+          # the connect branch's tenant refusal. A tenant callback falls through to
+          # the H-3 refusal below (no challenge minted, no :omniauth_link_challenge_
+          # issued event). Authenticated tenant-surface linking is a deliberate
+          # follow-up (#3849).
+          # Mint only on the platform surface AND only when the located account has
+          # a password to challenge. account_has_challengeable_password? (below) also
+          # covers not-yet-migrated Redis-resident passwords so those accounts get
+          # the interstitial instead of the H-3 dead-end; see its doc for why that
+          # does not weaken anything. SQL-first short-circuit keeps the migrated
+          # common case cheap.
+          platform_surface = session[:validated_omniauth_domain_id].nil?
+          has_password     = platform_surface &&
+                             Auth::Config::Hooks::OmniAuth.account_has_challengeable_password?(
+                               db[password_hash_table].where(password_hash_id_column => existing_id),
+                               normalized_email,
+                               provider,
+                             )
+
+          if has_password
+            challenge = Onetime::SsoLinkChallenge.issue(
+              provider: provider,
+              issuer: resolved_issuer,
+              uid: omniauth_uid,
+              email: normalized_email,
+              account_id: existing_id,
+            )
+            Auth::Logging.log_auth_event(
+              :omniauth_link_challenge_issued,
+              level: :warn,
+              email: OT::Utils.obscure_email(normalized_email),
+              provider: provider,
+              issuer: resolved_issuer,
+            )
+            # Redirect to the SPA interstitial route (served by the Vue app),
+            # carrying the single-use token as a path segment.
+            redirect "/link-sso/#{challenge.token}"
+          end
+
+          # SSO-only account (no password to challenge) → UNCHANGED H-3 refusal.
           #
           # RECOVERY (Phase 2, shipped): a password-first user who hits this
           # refusal self-resolves by signing in with their password, then
@@ -555,6 +632,42 @@ module Auth::Config::Hooks
         # Query param allows frontend to display appropriate error message.
         '/signin?auth_error=sso_failed'
       end
+    end
+
+    # Does the located account have a password the Phase 3 interstitial can
+    # challenge? True when a Rodauth password hash exists, OR (coverage) when a
+    # password still resident in Redis under the simple->full migration
+    # (config/overrides/password_migration.rb) has not yet been written to
+    # account_password_hashes. Consulting the migration source keeps those
+    # (shrinking, self-healing) accounts on the interstitial instead of the H-3
+    # dead-end, and does NOT weaken anything: the bind is still gated on the POST
+    # /auth/link-sso password verify, which itself routes through password_match?
+    # -> migrate_password_from_redis (the SAME transparent path a normal login
+    # uses), and the account was already LOCATED by the caller, so no new
+    # existence / has-password oracle is introduced. Fail-safe: any lookup error
+    # returns false, so the caller falls through to the H-3 refusal — never a
+    # weaker bind. SQL-first short-circuit avoids the Redis read for the migrated
+    # common case. Extracted from account_from_omniauth to keep that hook's
+    # branching (and complexity) contained.
+    #
+    # @param hash_ds [Sequel::Dataset] account_password_hashes scoped to the id
+    # @param normalized_email [String] email that located the account
+    # @param provider [String] OmniAuth provider name (logging only)
+    # @return [Boolean]
+    def self.account_has_challengeable_password?(hash_ds, normalized_email, provider)
+      return true if hash_ds.any?
+
+      Onetime::Customer.email_exists?(normalized_email) &&
+        !!Onetime::Customer.find_by_email(normalized_email)&.has_passphrase?
+    rescue StandardError => ex
+      Auth::Logging.log_auth_event(
+        :omniauth_link_password_probe_error,
+        level: :warn,
+        email: OT::Utils.obscure_email(normalized_email),
+        provider: provider,
+        error: ex.message,
+      )
+      false
     end
   end
 end

--- a/apps/web/auth/router.rb
+++ b/apps/web/auth/router.rb
@@ -16,6 +16,7 @@ require_relative 'error_translator'
 require_relative 'routes/account'
 require_relative 'routes/active_sessions'
 require_relative 'routes/identities'
+require_relative 'routes/link_sso'
 require_relative 'routes/mfa'
 require_relative 'routes/admin'
 require_relative 'routes/health'
@@ -42,6 +43,7 @@ module Auth
     include Auth::Routes::MFA
     include Auth::Routes::ActiveSessions
     include Auth::Routes::Identities
+    include Auth::Routes::LinkSso
     include Auth::Routes::Admin
 
     plugin :json, parser: true  # Parse incoming JSON request bodies
@@ -154,6 +156,9 @@ module Auth
 
       # Linked SSO identities management routes (#3840 Phase 2)
       handle_identities_routes(r)
+
+      # SSO sign-in interstitial: password-challenge linking (#3840 Phase 3)
+      handle_link_sso_routes(r)
 
       handle_admin_routes(r)
 

--- a/apps/web/auth/routes/link_sso.rb
+++ b/apps/web/auth/routes/link_sso.rb
@@ -13,7 +13,7 @@ require 'onetime/security/login_rate_limiter'
 # (/link-sso/:token). These endpoints back that page:
 #
 #   GET  /auth/link-sso/:token  → { provider, email }         (display only)
-#   POST /auth/link-sso         → verify existing password, bind identity, log in
+#   POST /auth/link-sso         → verify existing password, log in, bind on full auth
 #
 # SECURITY MODEL (the invariant: email may LOCATE, only a credential may BIND):
 #   - The challenge token is NOT proof of ownership — it only proves someone
@@ -37,6 +37,14 @@ require 'onetime/security/login_rate_limiter'
 #     (rodauth.login('password')) — NOT hand-rolled — so after_login runs
 #     (Redis session blob via SyncSession, active_sessions registration, MFA
 #     detection). That blob, not the Rodauth SQL row, is the real app auth gate.
+#   - MFA-SAFE BIND (#3840 review, Item 1): the identity is bound ONLY when the
+#     password login FULLY authenticates. If the account has a pending second
+#     factor, the bind is DEFERRED — login still proceeds and returns mfa_required
+#     (the SAME body POST /auth/login emits), but no identity is linked this round.
+#     Binding before 2FA would attach an MFA-EXEMPT SSO login path (SSO logins
+#     bypass MFA) to an account whose owner never passed the second factor — a
+#     password-only attacker could then sign in via SSO and defeat MFA. Completing
+#     the bind after MFA is a documented follow-up.
 #   - PLATFORM-only: challenges are minted solely on the platform callback path,
 #     so the tenant surface is never offered this interstitial (#3849).
 #
@@ -59,7 +67,8 @@ module Auth
       #                      located account vanished between mint and POST
       #   invalid_password— the existing password did not verify (token consumed)
       #   link_conflict   — the email now resolves to a different account than the
-      #                      one snapshotted at mint (defence-in-depth)
+      #                      one snapshotted at mint, OR the (provider,issuer,uid)
+      #                      is already bound to a different account (defence-in-depth)
       #   link_rate_limited— too many password attempts for this account/IP (429);
       #                      carries retry_after seconds
       def handle_link_sso_routes(r)
@@ -119,9 +128,20 @@ module Auth
             # generic StandardError rescue that would otherwise mask it as a 500).
             check_login_rate_limit!(login, client_ip)
 
-            # SINGLE-USE: consume the token NOW, before verifying the password, so
-            # a token is worth exactly one guess (see the security note above).
-            challenge.delete!
+            # SINGLE-USE (atomic — #3840 review, Item 2): consume the token NOW,
+            # before verifying the password, so a token is worth exactly one guess.
+            # #delete! returns the Redis DEL count; because DEL is atomic, exactly
+            # ONE of two concurrent POSTs gets 1 (the winner) and the loser gets 0.
+            # A 0 means the token was already spent by a racing request (or expired
+            # between load and here) -> reject as spent, closing the load-then-delete
+            # TOCTOU that would otherwise let both racers reach the password check.
+            unless challenge.delete! == 1
+              response.status = 401
+              next {
+                error: 'This linking request has expired. Please sign in with SSO again.',
+                error_code: 'link_expired',
+              }
+            end
 
             # Verify the EXISTING password via Rodauth's internal request. This
             # routes through the password_match? override (Redis→Rodauth password
@@ -158,28 +178,67 @@ module Auth
               next { error: 'This linking request could not be completed.', error_code: 'link_conflict' }
             end
 
-            # Bind the (provider, issuer, uid) identity to the proven account.
-            # Shape mirrors omniauth_identity_insert_hash
-            # (config/features/omniauth.rb): { account_id, provider, uid, issuer }.
-            bind_sso_identity(challenge, account_id)
+            # LOGIN-FIRST, BIND-ON-FULL-AUTH (#3840 review, Item 1).
+            #
+            # Rodauth's login('password') THROWS its JSON response (Roda :halt) and
+            # never returns to this route, so we cannot inspect the login result
+            # after the fact and then bind. Instead we make the SAME MFA decision
+            # the after_login hook makes (hooks/login.rb — a pure function of the
+            # located account's stored factors, via_omniauth: false) HERE, and gate
+            # the bind on it. Security-equivalent to "login, then bind only when
+            # fully authenticated": we bind ONLY when no second factor is pending.
+            #
+            # WHY: SSO logins are MFA-EXEMPT (DetectMfaRequirement bypasses MFA for
+            # via_omniauth: true). Binding the (provider, issuer, uid) row before a
+            # second factor is satisfied would leave an MFA-bypassing SSO login path
+            # attached to the account — a password-only attacker who cannot pass the
+            # victim's OTP could bind their own IdP identity and then sign in via
+            # SSO, defeating MFA. So for an MFA account we DEFER the bind: the login
+            # below proceeds to the OTP step (emits mfa_required, unchanged) and the
+            # identity is left UNLINKED this round (a follow-up completes it after
+            # MFA). Moot for default installs (MFA off) but load-bearing for
+            # AUTH_MFA_ENABLED deployments.
+            if link_sso_second_factor_pending?(account_id)
+              auth_logger.warn 'SSO link deferred: second factor pending, identity NOT bound this round',
+                {
+                  account_id: account_id,
+                  provider: challenge.provider,
+                }
+            else
+              # Fully authenticated by password alone -> safe to bind now. Shape
+              # mirrors omniauth_identity_insert_hash (config/features/omniauth.rb):
+              # { account_id, provider, uid, issuer }.
+              if bind_sso_identity(challenge, account_id) == :conflict
+                # Item 3 defence-in-depth: the (provider, issuer, uid) row is already
+                # owned by a DIFFERENT account. Never report success (that would log
+                # the caller in as if the identity were theirs) — surface a conflict.
+                response.status = 409
+                next {
+                  error: 'This linking request could not be completed.',
+                  error_code: 'link_conflict',
+                }
+              end
 
-            # Verified credential -> clear the throttle so the just-linked user is
-            # not held under a stale per-IP lockout on their next password login
-            # (same keys as a normal successful login would clear).
+              auth_logger.warn 'SSO identity linked via password challenge',
+                {
+                  account_id: account_id,
+                  provider: challenge.provider,
+                }
+            end
+
+            # Verified credential -> clear the throttle so the user is not held under
+            # a stale per-IP lockout on their next password login (same keys a normal
+            # successful login clears). Cleared in BOTH branches: the password was
+            # correct regardless of the MFA outcome.
             clear_login_rate_limit!(login, client_ip)
-
-            auth_logger.warn 'SSO identity linked via password challenge',
-              {
-                account_id: account_id,
-                provider: challenge.provider,
-              }
 
             # Establish the session through Rodauth's proven login machinery.
             # login('password') runs before_login/login_session/after_login (Redis
-            # session blob via SyncSession, active_sessions, MFA detection) and
-            # then throws Rodauth's JSON login response (200 { success: ... },
-            # plus mfa_required / billing_redirect when applicable) — exactly the
-            # shape POST /auth/login returns, which the SPA already handles.
+            # session blob via SyncSession, active_sessions, MFA detection) and then
+            # THROWS Rodauth's JSON login response — 200 { success: ... } for a
+            # non-MFA account, or the SAME mfa_required body POST /auth/login returns
+            # for an MFA account (authSuccessWithMfaSchema). The response passes
+            # through unchanged; the SPA already handles both shapes.
             rodauth.login('password')
           rescue Onetime::LimitExceeded => ex
             # Must precede the generic StandardError rescue below (which would turn
@@ -224,25 +283,59 @@ module Auth
       end
 
       # Insert the identity row for the proven account, issuer-scoped and
-      # idempotent. A concurrent bind that already inserted the row (unique index
-      # on provider, issuer, uid) is treated as success.
+      # idempotent. Returns :ok when the row is inserted OR already exists for the
+      # SAME account. Returns :conflict when a row for this (provider, issuer, uid)
+      # already exists for a DIFFERENT account — the caller surfaces that as 409
+      # link_conflict rather than logging the user in onto an identity that is not
+      # theirs (#3840 review, Item 3 defence-in-depth). The unique index on
+      # (provider, issuer, uid) plus "challenge minted only when no identity row
+      # exists" makes cross-account escalation impossible, so this only ever fires
+      # as a benign idempotency guard — but we verify ownership at BOTH the
+      # pre-check and the concurrent-insert (UniqueConstraintViolation) site so a
+      # mismatch can never masquerade as success.
       def bind_sso_identity(challenge, account_id)
-        ds      = rodauth.db[:account_identities]
-        already = ds.where(
+        ds       = rodauth.db[:account_identities]
+        criteria = {
           provider: challenge.provider,
           issuer: challenge.issuer.to_s,
           uid: challenge.uid,
-        ).any?
-        return if already
+        }
 
-        ds.insert(
-          account_id: account_id,
-          provider: challenge.provider,
-          uid: challenge.uid,
-          issuer: challenge.issuer.to_s,
-        )
+        existing = ds.where(criteria).first
+        return owned_or_conflict(existing, account_id) if existing
+
+        ds.insert(criteria.merge(account_id: account_id))
+        :ok
       rescue Sequel::UniqueConstraintViolation
-        nil
+        # A concurrent bind inserted the row first — re-read and apply the SAME
+        # ownership check to the winner.
+        owned_or_conflict(ds.where(criteria).first, account_id)
+      end
+
+      # :ok when the existing identity row belongs to the account we authenticated,
+      # :conflict otherwise (including a row that vanished between checks).
+      def owned_or_conflict(row, account_id)
+        row && row[:account_id].to_s == account_id.to_s ? :ok : :conflict
+      end
+
+      # Would completing this PASSWORD login leave a second factor pending? Mirrors
+      # the after_login hook's MFA decision (hooks/login.rb) for via_omniauth: false
+      # — a pure function of the located account's stored factors — evaluated HERE so
+      # the identity bind can be gated on FULL authentication (Item 1). When the OTP
+      # feature is not loaded (MFA disabled — the default), no second factor can be
+      # pending, so this returns false and the bind proceeds. A read error propagates
+      # to the POST handler's rescue (uniform with the unguarded MfaStateChecker call
+      # in after_login) rather than binding without certainty of full auth.
+      def link_sso_second_factor_pending?(account_id)
+        return false unless rodauth.respond_to?(:otp_auth_route)
+
+        mfa_state = Auth::Operations::MfaStateChecker.new(rodauth.db).check(account_id)
+        Auth::Operations::DetectMfaRequirement.call(
+          account_id: account_id,
+          has_otp_secret: mfa_state.has_otp_secret,
+          has_recovery_codes: mfa_state.has_recovery_codes,
+          via_omniauth: false,
+        ).requires_mfa?
       end
     end
   end

--- a/apps/web/auth/routes/link_sso.rb
+++ b/apps/web/auth/routes/link_sso.rb
@@ -1,0 +1,249 @@
+# apps/web/auth/routes/link_sso.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/security/login_rate_limiter'
+
+#
+# JSON API for the SSO sign-in interstitial (#3840 Phase 3 / #3838 item 1b).
+#
+# When an UNAUTHENTICATED SSO sign-in resolves to an EXISTING account that has a
+# password, account_from_omniauth (config/hooks/omniauth.rb) mints a single-use
+# Onetime::SsoLinkChallenge and redirects the browser to the SPA interstitial
+# (/link-sso/:token). These endpoints back that page:
+#
+#   GET  /auth/link-sso/:token  → { provider, email }         (display only)
+#   POST /auth/link-sso         → verify existing password, bind identity, log in
+#
+# SECURITY MODEL (the invariant: email may LOCATE, only a credential may BIND):
+#   - The challenge token is NOT proof of ownership — it only proves someone
+#     completed an SSO round-trip for this email. The EXISTING PASSWORD is the
+#     credential that authorizes the bind.
+#   - The token is SINGLE-USE: POST deletes it up front (before verifying the
+#     password), so each token is good for exactly one attempt. This is
+#     load-bearing — Auth::Config.valid_login_and_password? is an internal
+#     request that bypasses Rodauth's lockout counters, so without one-shot
+#     consumption a minted token would be an unbounded (TTL-window) password
+#     oracle with no lockout. One guess per full IdP round-trip is the bound.
+#   - RATE LIMITED (#3840 Phase 3 review, Finding 2): single-use caps guesses
+#     per token, but NOT in aggregate across freshly minted tokens — wherever the
+#     IdP does not strongly bind email to a vetted subject (unverified-email OIDC
+#     / public providers) an attacker can mint token after token, one guess each,
+#     with no lockout (the internal-request password check does not increment
+#     Rodauth's counters). POST therefore runs the canonical
+#     Onetime::Security::LoginRateLimiter (email + client IP) BEFORE consuming the
+#     token, and records each wrong guess — closing the residual aggregate oracle.
+#   - On success the session is established by Rodauth's OWN login machinery
+#     (rodauth.login('password')) — NOT hand-rolled — so after_login runs
+#     (Redis session blob via SyncSession, active_sessions registration, MFA
+#     detection). That blob, not the Rodauth SQL row, is the real app auth gate.
+#   - PLATFORM-only: challenges are minted solely on the platform callback path,
+#     so the tenant surface is never offered this interstitial (#3849).
+#
+module Auth
+  module Routes
+    module LinkSso
+      # Reuse the canonical credential-submission throttle. It is designed for
+      # exactly this gap: an internal-request password verify with NO Rodauth
+      # lockout. Two-tier (per-email+IP tight lock at MAX_ATTEMPTS, per-email
+      # global backstop for IP-rotators), sharing the SAME Redis keys as normal
+      # password login so the throttle is unified across both surfaces. Included
+      # here so its check/record/clear methods are available in the route block
+      # (LinkSso is included into Auth::Router).
+      include Onetime::Security::LoginRateLimiter
+
+      # Error codes returned to the SPA (LinkSso.vue maps these to copy + the
+      # Phase 2 settings pointer /account/settings/security/connections):
+      #   invalid_request — token or password missing
+      #   link_expired    — token missing / already consumed / expired, or the
+      #                      located account vanished between mint and POST
+      #   invalid_password— the existing password did not verify (token consumed)
+      #   link_conflict   — the email now resolves to a different account than the
+      #                      one snapshotted at mint (defence-in-depth)
+      #   link_rate_limited— too many password attempts for this account/IP (429);
+      #                      carries retry_after seconds
+      def handle_link_sso_routes(r)
+        r.on 'link-sso' do
+          # GET /auth/link-sso/:token — display context for the interstitial.
+          # Returns ONLY the provider name and claimed email; never the account
+          # id, uid, or issuer. Missing/consumed/expired token → 404.
+          r.get String do |token|
+            challenge = Onetime::SsoLinkChallenge.load(token)
+            unless challenge
+              response.status = 404
+              next { error: 'This linking request is no longer valid.', error_code: 'link_expired' }
+            end
+
+            response.headers['Content-Type'] = 'application/json'
+            challenge.to_display
+          rescue StandardError => ex
+            auth_logger.error 'Error loading SSO link challenge', { exception: ex }
+            response.status = 500
+            { error: 'Failed to load linking request' }
+          end
+
+          # POST /auth/link-sso — verify the existing password, bind the identity,
+          # and establish the login session. Body: { token, password }.
+          r.post do
+            # Rodauth's JSON feature parses request bodies only for its OWN
+            # routes; this is a custom Roda route, so parse the JSON body here
+            # (falling back to form/query params).
+            params   = link_sso_params(request)
+            token    = params[:token]
+            password = params[:password]
+
+            if token.empty? || password.empty?
+              response.status = 400
+              next { error: 'Token and password are required.', error_code: 'invalid_request' }
+            end
+
+            challenge = Onetime::SsoLinkChallenge.load(token)
+            unless challenge
+              response.status = 401
+              next {
+                error: 'This linking request has expired. Please sign in with SSO again.',
+                error_code: 'link_expired',
+              }
+            end
+
+            login     = challenge.email
+            client_ip = request.ip
+
+            # RATE LIMIT (#3840 Phase 3 review, Finding 2) — gate BEFORE consuming
+            # the token or verifying the password. valid_login_and_password? is a
+            # Rodauth INTERNAL request and does NOT increment Rodauth's lockout
+            # counters, so single-use alone caps per-token but not in aggregate
+            # across freshly minted tokens. Keyed on the located account's email +
+            # client IP via the canonical LoginRateLimiter. Raises
+            # Onetime::LimitExceeded when locked -> 429 (rescued below, before the
+            # generic StandardError rescue that would otherwise mask it as a 500).
+            check_login_rate_limit!(login, client_ip)
+
+            # SINGLE-USE: consume the token NOW, before verifying the password, so
+            # a token is worth exactly one guess (see the security note above).
+            challenge.delete!
+
+            # Verify the EXISTING password via Rodauth's internal request. This
+            # routes through the password_match? override (Redis→Rodauth password
+            # migration is transparent). Raises Rodauth::InternalRequestError on a
+            # non-match (mirrors apps/api/account/logic/account/update_password.rb).
+            password_ok = begin
+              Auth::Config.valid_login_and_password?(login: login, password: password)
+            rescue Rodauth::InternalRequestError
+              false
+            end
+
+            unless password_ok
+              # Count the failed guess toward the lockout so repeated wrong
+              # passwords (across freshly minted tokens) eventually trip the limit.
+              record_failed_login_attempt!(login, client_ip)
+              response.status = 401
+              next { error: 'Incorrect password.', error_code: 'invalid_password' }
+            end
+
+            # Re-locate the account by the verified login and load it onto the
+            # rodauth instance so login('password') can establish the session.
+            unless rodauth.account_from_login(login)
+              response.status = 401
+              next { error: 'This linking request is no longer valid.', error_code: 'link_expired' }
+            end
+
+            account_id = rodauth.account_id
+
+            # Defence-in-depth: the account located by login now must match the one
+            # snapshotted at mint. A mismatch (email re-pointed between mint and
+            # POST) must never bind onto a different account.
+            if challenge.account_id.to_s != account_id.to_s
+              response.status = 409
+              next { error: 'This linking request could not be completed.', error_code: 'link_conflict' }
+            end
+
+            # Bind the (provider, issuer, uid) identity to the proven account.
+            # Shape mirrors omniauth_identity_insert_hash
+            # (config/features/omniauth.rb): { account_id, provider, uid, issuer }.
+            bind_sso_identity(challenge, account_id)
+
+            # Verified credential -> clear the throttle so the just-linked user is
+            # not held under a stale per-IP lockout on their next password login
+            # (same keys as a normal successful login would clear).
+            clear_login_rate_limit!(login, client_ip)
+
+            auth_logger.warn 'SSO identity linked via password challenge',
+              {
+                account_id: account_id,
+                provider: challenge.provider,
+              }
+
+            # Establish the session through Rodauth's proven login machinery.
+            # login('password') runs before_login/login_session/after_login (Redis
+            # session blob via SyncSession, active_sessions, MFA detection) and
+            # then throws Rodauth's JSON login response (200 { success: ... },
+            # plus mfa_required / billing_redirect when applicable) — exactly the
+            # shape POST /auth/login returns, which the SPA already handles.
+            rodauth.login('password')
+          rescue Onetime::LimitExceeded => ex
+            # Must precede the generic StandardError rescue below (which would turn
+            # this into a 500). Translate to the ADR-013-style 429 the SPA surfaces.
+            auth_logger.warn 'SSO link rate limited', { retry_after: ex.retry_after }
+            response.status                 = 429
+            response.headers['Retry-After'] = ex.retry_after.to_s if ex.retry_after
+            {
+              error: 'Too many attempts. Please try again later.',
+              error_code: 'link_rate_limited',
+              retry_after: ex.retry_after,
+            }
+          rescue StandardError => ex
+            auth_logger.error 'Error completing SSO link', { exception: ex }
+            response.status = 500
+            { error: 'Failed to complete linking' }
+          end
+        end
+      end
+
+      private
+
+      # Extract { token, password } from a JSON body (Content-Type
+      # application/json), falling back to form/query params. Returns string
+      # values ('' when absent). Rewinds the input so nothing downstream is
+      # surprised by a consumed body.
+      def link_sso_params(request)
+        raw = request.body&.read.to_s
+        request.body.rewind if request.body.respond_to?(:rewind)
+
+        parsed = begin
+          raw.empty? ? {} : JSON.parse(raw)
+        rescue JSON::ParserError
+          {}
+        end
+        parsed = {} unless parsed.is_a?(Hash)
+
+        {
+          token: (parsed['token'] || request.params['token']).to_s,
+          password: (parsed['password'] || request.params['password']).to_s,
+        }
+      end
+
+      # Insert the identity row for the proven account, issuer-scoped and
+      # idempotent. A concurrent bind that already inserted the row (unique index
+      # on provider, issuer, uid) is treated as success.
+      def bind_sso_identity(challenge, account_id)
+        ds      = rodauth.db[:account_identities]
+        already = ds.where(
+          provider: challenge.provider,
+          issuer: challenge.issuer.to_s,
+          uid: challenge.uid,
+        ).any?
+        return if already
+
+        ds.insert(
+          account_id: account_id,
+          provider: challenge.provider,
+          uid: challenge.uid,
+          issuer: challenge.issuer.to_s,
+        )
+      rescue Sequel::UniqueConstraintViolation
+        nil
+      end
+    end
+  end
+end

--- a/apps/web/auth/spec/config/hooks/omniauth_spec.rb
+++ b/apps/web/auth/spec/config/hooks/omniauth_spec.rb
@@ -215,25 +215,45 @@ RSpec.describe 'OmniAuth hooks' do
         accounts_store[normalized_email]
       end
 
-      # Simulates the full _account_from_omniauth method AFTER the H-3 fix.
+      # Simulates the full _account_from_omniauth method AFTER the H-3 fix and the
+      # #3840 Phase 3 sign-in interstitial.
       #
       # SECURITY (H-3): the production hook no longer returns an existing account
       # for auto-linking by email — that is the account-takeover vector. When an
-      # existing account matches the normalized IdP email, the hook logs, sets an
-      # error flash, and `redirect`s to account_exists_link_required, which HALTS
-      # the callback (Roda throw :halt) so create_omniauth_identity never links
-      # the caller's (provider, uid) and never logs them in. We can't redirect in
-      # this pure-logic harness, so we model the halt as a refusal marker carrying
-      # the redirect target. Only a genuinely new email returns nil (JIT create).
+      # existing account matches the normalized IdP email, the hook either:
+      #   - (Phase 3) mints a single-use challenge and `redirect`s to the sign-in
+      #     interstitial (/link-sso/:token) IFF the account HAS a password — the
+      #     user proves ownership by re-entering it before any bind; or
+      #   - (SSO-only, no password) logs, sets an error flash, and `redirect`s to
+      #     account_exists_link_required.
+      # Both HALT the callback (Roda throw :halt) so create_omniauth_identity never
+      # links the caller's (provider, uid) by email. We can't redirect in this
+      # pure-logic harness, so we model the halt as a marker carrying the redirect
+      # target. Only a genuinely new email returns nil (JIT create).
       #
       # HONESTY: this is a REIMPLEMENTATION of the decision boundary — it does NOT
-      # drive the production `_account_from_omniauth`. The real hook's redirect/halt
-      # path is NOT yet integration-covered end-to-end (follow-up filed); these unit
-      # assertions verify the intended logic only.
-      def account_from_omniauth(omniauth_email)
+      # drive the production `_account_from_omniauth`. End-to-end coverage of the
+      # interstitial + H-3 halt lives in
+      # apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb;
+      # these unit assertions verify the intended decision logic only.
+      #
+      # `has_password:` models "does the located account have a password hash",
+      # which the production hook derives from a direct password_hash_table lookup
+      # (has_password? is unusable on the unauthenticated path). `tenant_domain_id:`
+      # models session[:validated_omniauth_domain_id] — non-nil on a TENANT callback.
+      # The interstitial is PLATFORM-only: on the tenant surface the mint branch's
+      # platform-surface guard is skipped, so even a password account keeps the H-3
+      # refusal (Finding 1 — closes the tenant-surface password-guessing oracle).
+      def account_from_omniauth(omniauth_email, has_password: false, tenant_domain_id: nil)
         normalized_email = normalize_email(omniauth_email)
         existing         = find_account_by_email(normalized_email)
-        return { refused: true, redirect: '/signin?auth_error=account_exists_link_required' } if existing
+        platform_surface = tenant_domain_id.nil?
+
+        if existing
+          return { interstitial: true, redirect: '/link-sso/<token>' } if has_password && platform_surface
+
+          return { refused: true, redirect: '/signin?auth_error=account_exists_link_required' }
+        end
 
         nil
       end
@@ -301,6 +321,64 @@ RSpec.describe 'OmniAuth hooks' do
         it 'does not surface the victim account for linking' do
           result = account_from_omniauth('VICTIM@X.COM')
           expect(result).not_to include(id: 42)
+        end
+      end
+
+      # ======================================================================
+      # #3840 Phase 3 — password-holding account diverts to the interstitial
+      # ======================================================================
+      #
+      # The decision split H-3 gained: an existing account that HAS a password is
+      # not dead-ended. The hook mints a single-use challenge and redirects to the
+      # sign-in interstitial, where the EXISTING password is verified before any
+      # bind. An SSO-only account (no password) keeps the H-3 refusal. Either way
+      # the located account is NEVER returned for auto-link-by-email.
+      context 'existing account WITH a password (Phase 3 interstitial)' do
+        it 'redirects to the sign-in interstitial instead of the H-3 refusal' do
+          result = account_from_omniauth('user@example.com', has_password: true)
+          expect(result).to include(interstitial: true)
+          expect(result[:redirect]).to match(%r{^/link-sso/})
+          expect(result).not_to include(refused: true)
+        end
+
+        it 'diverts regardless of IdP email casing (same normalization)' do
+          result = account_from_omniauth('USER@EXAMPLE.COM', has_password: true)
+          expect(result).to include(interstitial: true)
+        end
+
+        it 'still never surfaces the located account record (no auto-link)' do
+          result = account_from_omniauth('user@example.com', has_password: true)
+          expect(result).not_to include(:id)
+          expect(result).not_to include(:email)
+        end
+      end
+
+      context 'existing account WITHOUT a password (SSO-only keeps H-3)' do
+        it 'refuses to the account_exists_link_required redirect' do
+          result = account_from_omniauth('user@example.com', has_password: false)
+          expect(result).to include(refused: true)
+          expect(result[:redirect]).to eq('/signin?auth_error=account_exists_link_required')
+          expect(result).not_to include(:interstitial)
+        end
+      end
+
+      # Finding 1 (adversarial review): an unauthenticated TENANT callback whose
+      # asserted email matches a PASSWORD-holding platform account must NOT get the
+      # interstitial — the mint branch is platform-only, so it falls through to the
+      # unchanged H-3 refusal. Without the guard this is a tenant-controlled,
+      # un-lockable password-guessing oracle against arbitrary platform accounts.
+      context 'existing password account on the TENANT surface (Finding 1: no interstitial)' do
+        it 'keeps the H-3 refusal — the interstitial is platform-only' do
+          result = account_from_omniauth('user@example.com', has_password: true, tenant_domain_id: 'domain-123')
+          expect(result).to include(refused: true)
+          expect(result[:redirect]).to eq('/signin?auth_error=account_exists_link_required')
+          expect(result).not_to include(:interstitial)
+        end
+
+        it 'still refuses an SSO-only account on the tenant surface' do
+          result = account_from_omniauth('user@example.com', has_password: false, tenant_domain_id: 'domain-123')
+          expect(result).to include(refused: true)
+          expect(result).not_to include(:interstitial)
         end
       end
 

--- a/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
@@ -528,16 +528,26 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
   end
 
   # ==========================================================================
-  # Scenario 3 — UNAUTHENTICATED -> unchanged H-3 refusal (regression)
+  # Scenario 3 — UNAUTHENTICATED, SSO-ONLY account -> unchanged H-3 refusal
   # ==========================================================================
+  #
+  # The connect branch is gated on logged_in? + intent, so an unauthenticated
+  # callback never binds. For an existing account WITHOUT a password there is no
+  # credential to challenge, so the H-3 refusal stands unchanged.
+  #
+  # NOTE (#3840 Phase 3): a password-HOLDING account on this same unauthenticated
+  # path now diverts to the sign-in interstitial (/link-sso/:token) instead of the
+  # H-3 refusal — that branch is covered end-to-end in
+  # omniauth_signin_interstitial_spec.rb. Here the account is seeded WITHOUT a
+  # password, so it stays on the H-3 refusal and no challenge is minted.
 
-  describe 'unauthenticated (regression: new branch is gated on logged_in?)' do
+  describe 'unauthenticated, SSO-only account (regression: connect branch gated + no interstitial)' do
     before { enable_platform_fallback }
 
-    it 'falls through to the existing H-3 refusal and never fires the connect event' do
+    it 'falls through to the H-3 refusal, mints no challenge, and fires no connect event' do
       email = "anon-#{SecureRandom.hex(6)}@company.example.com"
       uid   = "sub-#{SecureRandom.hex(8)}"
-      seed_existing_account(email)
+      seed_existing_account(email) # no password -> nothing to challenge
 
       # No login. trust flag defaults off -> H-3 refusal path.
       allow(Onetime.auth_config).to receive(:trust_email_for_linking?).and_return(false)
@@ -551,12 +561,16 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
 
         expect(last_response.status).to eq(302)
         expect(last_response.location.to_s).to include('/signin?auth_error=account_exists_link_required'),
-          "Unauthenticated flow must keep the H-3 refusal. Location: #{last_response.location.inspect}"
+          "SSO-only unauthenticated flow must keep the H-3 refusal. Location: #{last_response.location.inspect}"
+        # And it must NOT divert to the Phase 3 interstitial (no password = no challenge).
+        expect(last_response.location.to_s).not_to match(%r{/link-sso/})
 
         expect(identities.where(provider: 'oidc', uid: uid).count).to eq(0)
 
         expect(Auth::Logging).to have_received(:log_auth_event)
           .with(:omniauth_link_refused_existing_account, hash_including(provider: 'oidc'))
+        expect(Auth::Logging).not_to have_received(:log_auth_event)
+          .with(:omniauth_link_challenge_issued, anything)
         expect(Auth::Logging).not_to have_received(:log_auth_event)
           .with(:omniauth_identity_connected, anything)
         expect(Auth::Logging).not_to have_received(:log_auth_event)

--- a/apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
@@ -1,0 +1,522 @@
+# apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration (full mode)
+# =============================================================================
+#
+# Issue: #3840 Phase 3 (#3838 item 1b) — sign-in interstitial (password-challenge
+#        linking). An UNAUTHENTICATED SSO sign-in whose IdP email matches an
+#        EXISTING account that HAS a password no longer dead-ends at the H-3
+#        refusal. Instead account_from_omniauth mints a single-use
+#        Onetime::SsoLinkChallenge and redirects to the SPA interstitial
+#        (/link-sso/:token); the user re-enters their EXISTING password at
+#        POST /auth/link-sso, which verifies it, binds (provider, issuer, uid),
+#        and establishes the login session via Rodauth's own machinery.
+#
+#        INVARIANT: email may LOCATE an account; only a demonstrated credential
+#        (here, the existing password) may BIND. SSO-only accounts (no password)
+#        keep the H-3 refusal unchanged — there is nothing to challenge.
+#
+# WHAT IT LOCKS IN (production code: config/hooks/omniauth.rb H-3 branch +
+#   routes/link_sso.rb + models/sso_link_challenge.rb):
+#   a. password-holding existing account -> 302 to /link-sso/:token (NOT
+#      account_exists_link_required); a challenge is minted; :omniauth_link_
+#      challenge_issued fires.
+#   b. GET /auth/link-sso/:token -> { provider, email } (display only).
+#   c. POST /auth/link-sso with the CORRECT password -> identity row bound with
+#      the right (provider, issuer, uid) on the account, and the user is logged
+#      in (Rodauth login response).
+#   d. POST with the WRONG password -> refused (invalid_password), NO bind, and
+#      the token is CONSUMED (single-use closes the no-lockout password oracle).
+#   e. missing/expired/invalid token -> refused (link_expired), no bind.
+#   f. SSO-only account (no password) -> UNCHANGED H-3 refusal; no interstitial,
+#      no challenge minted.
+#
+# REQUIREMENTS:
+# - Valkey running on port 2121: pnpm run test:database:start
+# - AUTHENTICATION_MODE=full, AUTH_DATABASE_URL (SQLite in-memory; rake sets it)
+#
+# RUN:
+#   RACK_ENV=test AUTHENTICATION_MODE=full AUTH_DATABASE_URL=sqlite::memory: \
+#     ORGS_SSO_ENABLED=true LANG=en_US.UTF-8 \
+#     bundle exec rspec \
+#     apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb \
+#     --tag '~postgres_database'
+# =============================================================================
+
+require_relative '../../spec_helper'
+require_relative '../../support/oauth_flow_helper'
+
+RSpec.describe 'OmniAuth sign-in interstitial (#3840 Phase 3)', type: :integration do
+  include Rack::Test::Methods
+
+  def app
+    Onetime::Application::Registry.generate_rack_url_map
+  end
+
+  before(:all) do
+    require 'onetime'
+    require 'onetime/application/registry'
+    require 'onetime/auth_config'
+
+    Onetime.auth_config.reload! if Onetime.respond_to?(:auth_config) && Onetime.auth_config.respond_to?(:reload!)
+    Onetime::Application::Registry.reset! if Onetime::Application::Registry.respond_to?(:reset!)
+
+    Onetime.boot!(:test, force: true)
+
+    Onetime::Application::Registry.prepare_application_registry
+
+    mounts = Onetime::Application::Registry.mount_mappings.keys
+    raise "Auth app not mounted post-boot: #{mounts.inspect}" unless mounts.any? { |m| m.include?('/auth') }
+  end
+
+  let(:identities) { auth_db[:account_identities] }
+
+  # ==========================================================================
+  # Helpers (mirrors omniauth_connect_link_spec.rb)
+  # ==========================================================================
+
+  # Leaves session[:validated_omniauth_domain_id] nil == the PLATFORM path, and
+  # lets a non-tenant callback proceed on platform credentials instead of
+  # redirecting to sso_not_configured.
+  def enable_platform_fallback
+    allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
+  end
+
+  # Seed a VERIFIED account WITHOUT a password (SSO-only account).
+  def seed_existing_account(email)
+    normalized = OT::Utils.normalize_email(email)
+    customer   = Onetime::Customer.new(email: normalized)
+    customer.save
+    auth_db[:accounts].insert(
+      email: normalized,
+      status_id: AuthTestConstants::STATUS_VERIFIED,
+      external_id: customer.extid,
+    )
+  end
+
+  # Seed a VERIFIED account WITH an Argon2 password hash. Cost params match the
+  # test config in config/features/argon2.rb.
+  def seed_account_with_password(email, password: AuthTestConstants::TEST_PASSWORD)
+    account_id = seed_existing_account(email)
+    require 'argon2'
+    hasher     = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
+    auth_db[:account_password_hashes].insert(id: account_id, password_hash: hasher.create(password))
+    account_id
+  end
+
+  def setup_mock_auth(email:, uid:, provider: :oidc)
+    OmniAuth.config.test_mode               = true
+    OmniAuth.config.allowed_request_methods = [:get, :post]
+    OmniAuth.config.mock_auth[provider]     = OmniAuth::AuthHash.new(
+      {
+        provider: provider.to_s,
+        uid: uid,
+        info: { email: email, name: 'Interstitial User', email_verified: true },
+        credentials: { token: 'mock_access_token', expires_at: Time.now.to_i + 3600, expires: true },
+        extra: { raw_info: { sub: uid, email: email, name: 'Interstitial User', email_verified: true } },
+      },
+    )
+  end
+
+  def teardown_mock_auth
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth.clear
+  end
+
+  # Content-Type/Content-Length leak from a prior JSON POST and make the next
+  # bodyless request try to parse an empty JSON body. Clear them.
+  def clear_body_headers
+    header 'Content-Type', nil
+    header 'Content-Length', nil
+  end
+
+  # Drive the UNAUTHENTICATED SSO callback and return the response. No login and
+  # no connect intent — this is the plain sign-in that resolves to an existing
+  # account by email.
+  def sso_callback(email:, uid:, provider: :oidc)
+    setup_mock_auth(email: email, uid: uid, provider: provider)
+    clear_body_headers
+    post "/auth/sso/#{provider}/callback"
+    last_response
+  end
+
+  # Extract the challenge token from a /link-sso/:token redirect Location.
+  def token_from_location(location)
+    location.to_s.split('/link-sso/').last.to_s.split(/[?#]/).first
+  end
+
+  # Fetch a CSRF token from the app bootstrap (mirrors csrf_login). The challenge
+  # lives in Redis, not the session, so establishing a fresh session here does
+  # not disturb it.
+  def fetch_csrf_token
+    clear_body_headers
+    header 'Accept', 'application/json'
+    get '/auth'
+    last_response.headers['X-CSRF-Token']
+  end
+
+  def get_link_context(token)
+    clear_body_headers
+    header 'Accept', 'application/json'
+    get "/auth/link-sso/#{token}"
+    last_response
+  end
+
+  def post_link_sso(token:, password:)
+    csrf = fetch_csrf_token
+    clear_body_headers
+    header 'Content-Type', 'application/json'
+    header 'Accept', 'application/json'
+    header 'X-CSRF-Token', csrf if csrf
+    post '/auth/link-sso', JSON.generate(token: token, password: password)
+    last_response
+  end
+
+  # Trust off -> an existing account reaches the H-3/interstitial branch rather
+  # than being auto-linked by email.
+  before do
+    enable_platform_fallback
+    allow(Onetime.auth_config).to receive(:trust_email_for_linking?).and_return(false)
+  end
+
+  # ==========================================================================
+  # (a) password-holding account -> interstitial redirect + challenge minted
+  # ==========================================================================
+
+  describe 'password-holding existing account' do
+    it 'redirects to the interstitial (not the H-3 refusal) and mints a challenge' do
+      email = "pw-#{SecureRandom.hex(6)}@company.example.com"
+      uid   = "sub-#{SecureRandom.hex(8)}"
+      seed_account_with_password(email)
+
+      allow(Auth::Logging).to receive(:log_auth_event).and_call_original
+
+      begin
+        response = sso_callback(email: email, uid: uid)
+        skip 'OmniAuth route not registered (OIDC discovery not available at boot)' if response.status == 404
+
+        expect(response.status).to eq(302)
+        expect(response.location.to_s).not_to include('account_exists_link_required'),
+          "Password account must divert to the interstitial. Location: #{response.location.inspect}"
+        expect(response.location.to_s).to match(%r{/link-sso/}),
+          "Expected a /link-sso/:token redirect. Location: #{response.location.inspect}"
+
+        token = token_from_location(response.location)
+        expect(token).not_to be_empty
+
+        # The challenge exists in Redis and snapshots this callback.
+        challenge = Onetime::SsoLinkChallenge.load(token)
+        expect(challenge).not_to be_nil
+        expect(challenge.provider).to eq('oidc')
+        expect(challenge.uid).to eq(uid)
+        expect(challenge.email).to eq(OT::Utils.normalize_email(email))
+
+        expect(Auth::Logging).to have_received(:log_auth_event)
+          .with(:omniauth_link_challenge_issued, hash_including(provider: 'oidc'))
+        expect(Auth::Logging).not_to have_received(:log_auth_event)
+          .with(:omniauth_link_refused_existing_account, anything)
+      ensure
+        teardown_mock_auth
+      end
+    end
+  end
+
+  # ==========================================================================
+  # (b) GET /auth/link-sso/:token -> { provider, email }
+  # ==========================================================================
+
+  describe 'GET /auth/link-sso/:token' do
+    it 'returns the provider and email for display (no secrets)' do
+      email = "ctx-#{SecureRandom.hex(6)}@company.example.com"
+      uid   = "sub-#{SecureRandom.hex(8)}"
+      seed_account_with_password(email)
+
+      begin
+        response = sso_callback(email: email, uid: uid)
+        skip 'OmniAuth route not registered' if response.status == 404
+        token = token_from_location(response.location)
+
+        ctx = get_link_context(token)
+        expect(ctx.status).to eq(200)
+        body = JSON.parse(ctx.body)
+        expect(body['provider']).to eq('oidc')
+        expect(body['email']).to eq(OT::Utils.normalize_email(email))
+        # Never surface account id, uid, or issuer.
+        expect(body).not_to have_key('account_id')
+        expect(body).not_to have_key('uid')
+        expect(body).not_to have_key('issuer')
+      ensure
+        teardown_mock_auth
+      end
+    end
+  end
+
+  # ==========================================================================
+  # (c) correct password -> identity bound + logged in
+  # ==========================================================================
+
+  describe 'POST /auth/link-sso with the correct password' do
+    it 'binds (provider, issuer, uid) to the account and logs the user in' do
+      email      = "ok-#{SecureRandom.hex(6)}@company.example.com"
+      uid        = "sub-#{SecureRandom.hex(8)}"
+      account_id = seed_account_with_password(email)
+
+      begin
+        response = sso_callback(email: email, uid: uid)
+        skip 'OmniAuth route not registered' if response.status == 404
+        token = token_from_location(response.location)
+
+        result = post_link_sso(token: token, password: AuthTestConstants::TEST_PASSWORD)
+
+        expect(result.status).to eq(200),
+          "Expected a Rodauth login response, got #{result.status}: #{result.body}"
+        body = JSON.parse(result.body)
+        expect(body).to have_key('success')
+
+        # The bind: exactly one (provider, uid) row, on the proven account.
+        rows = identities.where(provider: 'oidc', uid: uid).all
+        expect(rows.size).to eq(1), "Expected one bound row, got #{rows.inspect}"
+        expect(rows.first[:account_id]).to eq(account_id)
+        expect(rows.first[:issuer]).not_to be_nil
+
+        # The single-use token is consumed on success.
+        expect(Onetime::SsoLinkChallenge.load(token)).to be_nil
+      ensure
+        teardown_mock_auth
+      end
+    end
+  end
+
+  # ==========================================================================
+  # (d) wrong password -> refuse, no bind, token consumed
+  # ==========================================================================
+
+  describe 'POST /auth/link-sso with the wrong password' do
+    it 'refuses, binds nothing, and consumes the single-use token' do
+      email      = "bad-#{SecureRandom.hex(6)}@company.example.com"
+      uid        = "sub-#{SecureRandom.hex(8)}"
+      account_id = seed_account_with_password(email)
+
+      begin
+        response = sso_callback(email: email, uid: uid)
+        skip 'OmniAuth route not registered' if response.status == 404
+        token = token_from_location(response.location)
+
+        result = post_link_sso(token: token, password: 'wrong-password-entirely')
+
+        expect(result.status).to eq(401)
+        body = JSON.parse(result.body)
+        expect(body['error_code']).to eq('invalid_password')
+
+        # No identity bound.
+        expect(identities.where(account_id: account_id).count).to eq(0)
+        expect(identities.where(provider: 'oidc', uid: uid).count).to eq(0)
+
+        # Single-use: the token was consumed up front, so it can't be retried
+        # (this is what closes the no-lockout password oracle).
+        expect(Onetime::SsoLinkChallenge.load(token)).to be_nil
+        expect(get_link_context(token).status).to eq(404)
+      ensure
+        teardown_mock_auth
+      end
+    end
+  end
+
+  # ==========================================================================
+  # (e) missing/expired/invalid token -> refuse
+  # ==========================================================================
+
+  describe 'invalid or expired token' do
+    it 'refuses GET for an unknown token' do
+      expect(get_link_context("nonexistent-#{SecureRandom.hex(8)}").status).to eq(404)
+    end
+
+    it 'refuses POST for an unknown token without binding anything' do
+      result = post_link_sso(token: "nonexistent-#{SecureRandom.hex(8)}", password: AuthTestConstants::TEST_PASSWORD)
+      expect(result.status).to eq(401)
+      expect(JSON.parse(result.body)['error_code']).to eq('link_expired')
+    end
+
+    it 'refuses POST when token or password is missing' do
+      result = post_link_sso(token: '', password: '')
+      expect(result.status).to eq(400)
+      expect(JSON.parse(result.body)['error_code']).to eq('invalid_request')
+    end
+  end
+
+  # ==========================================================================
+  # (f) SSO-only account -> UNCHANGED H-3 refusal (no interstitial, no token)
+  # ==========================================================================
+
+  describe 'SSO-only account (no password)' do
+    it 'keeps the H-3 refusal and does not mint a challenge' do
+      email = "ssoonly-#{SecureRandom.hex(6)}@company.example.com"
+      uid   = "sub-#{SecureRandom.hex(8)}"
+      seed_existing_account(email) # no password
+
+      allow(Auth::Logging).to receive(:log_auth_event).and_call_original
+
+      begin
+        response = sso_callback(email: email, uid: uid)
+        skip 'OmniAuth route not registered' if response.status == 404
+
+        expect(response.status).to eq(302)
+        expect(response.location.to_s).to include('/signin?auth_error=account_exists_link_required'),
+          "SSO-only account must keep the H-3 refusal. Location: #{response.location.inspect}"
+        expect(response.location.to_s).not_to match(%r{/link-sso/})
+
+        expect(Auth::Logging).to have_received(:log_auth_event)
+          .with(:omniauth_link_refused_existing_account, hash_including(provider: 'oidc'))
+        expect(Auth::Logging).not_to have_received(:log_auth_event)
+          .with(:omniauth_link_challenge_issued, anything)
+      ensure
+        teardown_mock_auth
+      end
+    end
+  end
+
+  # ==========================================================================
+  # (g) TENANT-surface callback for a password account -> REFUSE (Finding 1)
+  # ==========================================================================
+  #
+  # SECURITY REGRESSION (#3840 Phase 3 adversarial review, Finding 1): an
+  # UNAUTHENTICATED TENANT SSO callback whose asserted email matches an existing
+  # PASSWORD-HOLDING PLATFORM account must NOT be offered the interstitial. A
+  # tenant admin controls their own IdP and can assert ANY email, and
+  # before_omniauth_callback_route (omniauth_tenant.rb) stamps
+  # session[:validated_omniauth_domain_id] on EVERY tenant callback — so an
+  # unauthenticated tenant callback (no login, no connect intent) falls straight
+  # through the connect/refuse branches to the email branch with the tenant key
+  # SET. Without the platform-surface guard on the mint branch this would mint a
+  # challenge and turn the tenant surface into an un-lockable password-guessing
+  # oracle against arbitrary platform accounts (a successful guess binding the
+  # tenant IdP identity onto the victim). The guard makes it fall through to the
+  # UNCHANGED H-3 refusal instead: NO /link-sso redirect, NO challenge, NO
+  # :omniauth_link_challenge_issued event.
+
+  describe 'tenant-surface callback for a password account (surface isolation)', :oauth_flow do
+    include OAuthFlowHelper
+
+    it 'refuses (H-3) and mints NO challenge — no interstitial oracle on the tenant surface' do
+      run_id = "tenant-pw-#{SecureRandom.hex(4)}"
+      host   = "secrets-#{run_id}.tenant.example.com"
+      email  = "victim-#{run_id}@company.example.com"
+      uid    = "sub-#{SecureRandom.hex(8)}"
+
+      # A PLATFORM account that HAS a password (the takeover target the tenant IdP
+      # would try to bind onto by asserting this email).
+      seed_account_with_password(email)
+
+      # Registered tenant domain so the callback validates and the tenant hook
+      # stamps session[:validated_omniauth_domain_id].
+      setup_oauth_test_domain(host)
+
+      allow(Auth::Logging).to receive(:log_auth_event).and_call_original
+      setup_mock_auth(email: email, uid: uid)
+
+      begin
+        # UNAUTHENTICATED initiation from the tenant host (no login, no connect):
+        # the request phase stores the tenant domain id in the session so the
+        # callback below validates and re-stamps validated_omniauth_domain_id.
+        clear_body_headers
+        header 'Host', host
+        post '/auth/sso/oidc'
+        skip "OmniAuth route not registered for #{host}" if last_response.status == 404
+        expect(last_response.status).to eq(302)
+
+        # Callback from the SAME tenant host -> validated_omniauth_domain_id is set,
+        # so the mint branch's platform-surface guard refuses.
+        clear_body_headers
+        header 'Host', host
+        post '/auth/sso/oidc/callback'
+
+        expect(last_response.status).to eq(302)
+        expect(last_response.location.to_s).to include('/signin?auth_error=account_exists_link_required'),
+          "Tenant callback for a password account must keep the H-3 refusal, not mint an interstitial. Location: #{last_response.location.inspect}"
+        expect(last_response.location.to_s).not_to match(%r{/link-sso/}),
+          'The tenant surface must NEVER be offered the password interstitial'
+
+        # No challenge minted; the located account gets no identity row.
+        expect(Auth::Logging).not_to have_received(:log_auth_event)
+          .with(:omniauth_link_challenge_issued, anything)
+        expect(identities.where(provider: 'oidc', uid: uid).count).to eq(0)
+
+        # The UNCHANGED H-3 refusal fired instead.
+        expect(Auth::Logging).to have_received(:log_auth_event)
+          .with(:omniauth_link_refused_existing_account, hash_including(provider: 'oidc'))
+      ensure
+        teardown_mock_auth
+      end
+    end
+  end
+
+  # ==========================================================================
+  # (h) POST /auth/link-sso is rate limited (Finding 2)
+  # ==========================================================================
+  #
+  # SECURITY (#3840 Phase 3 adversarial review, Finding 2): valid_login_and_password?
+  # is a Rodauth INTERNAL request that does NOT increment lockout counters, so
+  # single-use tokens cap guesses per token but NOT in aggregate across freshly
+  # minted tokens (cheap wherever the IdP does not strongly bind email to a vetted
+  # subject). POST /auth/link-sso runs the canonical Onetime::Security::LoginRateLimiter
+  # (email + IP) BEFORE consuming the token, so once the located account is locked
+  # no further guesses land — while a lone first attempt is unaffected.
+
+  describe 'POST /auth/link-sso rate limiting' do
+    # Pre-lock the SAME Redis keys the endpoint checks, independent of whatever
+    # client IP the Rack stack resolves: lock the per-email GLOBAL backstop (keyed
+    # on email only), which the endpoint's check enforces for any IP. Uses the
+    # canonical limiter via #extend (no bespoke throttle, no new constant).
+    def lock_login_rate_limit(email)
+      limiter = Object.new.extend(Onetime::Security::LoginRateLimiter)
+      Onetime::Security::LoginRateLimiter::GLOBAL_MAX_ATTEMPTS.times do
+        limiter.record_failed_login_attempt!(email, nil)
+      end
+    end
+
+    # Mint a challenge directly — the POST throttle can be exercised without a full
+    # SSO round-trip, since the token only carries the snapshot the POST reloads.
+    def mint_challenge(email:, uid:, account_id:)
+      Onetime::SsoLinkChallenge.issue(
+        provider: 'oidc',
+        issuer: 'https://issuer.example.com',
+        uid: uid,
+        email: OT::Utils.normalize_email(email),
+        account_id: account_id,
+      )
+    end
+
+    it 'refuses with 429 link_rate_limited once locked; a single attempt is unaffected' do
+      email      = "rl-#{SecureRandom.hex(6)}@company.example.com"
+      uid        = "sub-#{SecureRandom.hex(8)}"
+      account_id = seed_account_with_password(email)
+      normalized = OT::Utils.normalize_email(email)
+
+      # A lone wrong-password POST is a normal 401 — the limiter does NOT trip on
+      # the first try.
+      first  = mint_challenge(email: email, uid: uid, account_id: account_id)
+      result = post_link_sso(token: first.token, password: 'wrong-password-entirely')
+      expect(result.status).to eq(401)
+      expect(JSON.parse(result.body)['error_code']).to eq('invalid_password')
+
+      # Lock the account, then a subsequent POST is refused BEFORE the token is
+      # consumed (the throttle precedes single-use deletion).
+      lock_login_rate_limit(normalized)
+      locked = mint_challenge(email: email, uid: uid, account_id: account_id)
+      result = post_link_sso(token: locked.token, password: AuthTestConstants::TEST_PASSWORD)
+
+      expect(result.status).to eq(429),
+        "A locked account must be throttled, got #{result.status}: #{result.body}"
+      body = JSON.parse(result.body)
+      expect(body['error_code']).to eq('link_rate_limited')
+      expect(body['retry_after']).to be_a(Integer)
+
+      # No bind happened, and the throttled attempt did NOT consume the token.
+      expect(identities.where(account_id: account_id).count).to eq(0)
+      expect(Onetime::SsoLinkChallenge.load(locked.token)).not_to be_nil
+    end
+  end
+end

--- a/apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
@@ -175,6 +175,20 @@ RSpec.describe 'OmniAuth sign-in interstitial (#3840 Phase 3)', type: :integrati
     last_response
   end
 
+  # Mint a challenge directly — the POST endpoint can be exercised without a full
+  # SSO round-trip, since the token only carries the snapshot the POST reloads.
+  # account_id is intentionally caller-supplied so tests can mint a challenge whose
+  # snapshotted account differs from the one the email re-locates (link_conflict).
+  def mint_challenge(email:, uid:, account_id:, provider: 'oidc', issuer: 'https://issuer.example.com')
+    Onetime::SsoLinkChallenge.issue(
+      provider: provider,
+      issuer: issuer,
+      uid: uid,
+      email: OT::Utils.normalize_email(email),
+      account_id: account_id,
+    )
+  end
+
   # Trust off -> an existing account reaches the H-3/interstitial branch rather
   # than being auto-linked by email.
   before do
@@ -477,18 +491,6 @@ RSpec.describe 'OmniAuth sign-in interstitial (#3840 Phase 3)', type: :integrati
       end
     end
 
-    # Mint a challenge directly — the POST throttle can be exercised without a full
-    # SSO round-trip, since the token only carries the snapshot the POST reloads.
-    def mint_challenge(email:, uid:, account_id:)
-      Onetime::SsoLinkChallenge.issue(
-        provider: 'oidc',
-        issuer: 'https://issuer.example.com',
-        uid: uid,
-        email: OT::Utils.normalize_email(email),
-        account_id: account_id,
-      )
-    end
-
     it 'refuses with 429 link_rate_limited once locked; a single attempt is unaffected' do
       email      = "rl-#{SecureRandom.hex(6)}@company.example.com"
       uid        = "sub-#{SecureRandom.hex(8)}"
@@ -518,5 +520,138 @@ RSpec.describe 'OmniAuth sign-in interstitial (#3840 Phase 3)', type: :integrati
       expect(identities.where(account_id: account_id).count).to eq(0)
       expect(Onetime::SsoLinkChallenge.load(locked.token)).not_to be_nil
     end
+  end
+
+  # ==========================================================================
+  # (i) snapshot account_id mismatch -> 409 link_conflict (review L3)
+  # ==========================================================================
+  #
+  # #3840 review, L3: the challenge snapshots account_id at mint. If the email now
+  # re-locates a DIFFERENT account than the snapshot (the address was re-pointed
+  # between mint and POST), the mismatch guard (~routes/link_sso.rb:176) must refuse
+  # with 409 link_conflict and bind nothing — never link onto the re-located account.
+  # This is the FIRST spec to exercise the link_conflict branch.
+
+  describe 'POST /auth/link-sso snapshot account mismatch (link_conflict)' do
+    it 'refuses with 409 link_conflict when the snapshot account_id differs from the re-located account' do
+      email      = "mismatch-#{SecureRandom.hex(6)}@company.example.com"
+      uid        = "sub-#{SecureRandom.hex(8)}"
+      account_id = seed_account_with_password(email)
+
+      # Snapshot a DIFFERENT account id than the one `email` re-locates. Correct
+      # password is required to reach the mismatch guard (it runs AFTER the verify).
+      challenge = mint_challenge(email: email, uid: uid, account_id: account_id + 100_000)
+      result    = post_link_sso(token: challenge.token, password: AuthTestConstants::TEST_PASSWORD)
+
+      expect(result.status).to eq(409),
+        "Expected link_conflict, got #{result.status}: #{result.body}"
+      expect(JSON.parse(result.body)['error_code']).to eq('link_conflict')
+
+      # Nothing bound onto the re-located account.
+      expect(identities.where(account_id: account_id).count).to eq(0)
+      expect(identities.where(provider: 'oidc', uid: uid).count).to eq(0)
+    end
+  end
+
+  # ==========================================================================
+  # (j) identity already owned by another account -> 409 link_conflict (review L1)
+  # ==========================================================================
+  #
+  # #3840 review, L1: bind_sso_identity must verify the pre-existing
+  # (provider, issuer, uid) row belongs to the SAME account we just authenticated.
+  # A row owned by a DIFFERENT account is a conflict (409 link_conflict), never a
+  # silent idempotent success that would log the caller in onto someone else's
+  # identity. Cannot occur on the happy path (the challenge is minted only when no
+  # identity row exists), so this is defence-in-depth against a row that appears
+  # between mint and POST.
+
+  describe 'POST /auth/link-sso identity already owned by another account (link_conflict)' do
+    it 'refuses with 409 link_conflict and inserts no new row when the identity belongs to another account' do
+      email_a   = "owner-a-#{SecureRandom.hex(6)}@company.example.com"
+      email_b   = "owner-b-#{SecureRandom.hex(6)}@company.example.com"
+      uid       = "sub-#{SecureRandom.hex(8)}"
+      issuer    = 'https://issuer.example.com'
+      account_a = seed_account_with_password(email_a)
+      account_b = seed_existing_account(email_b)
+
+      # Account B already owns this exact (provider, issuer, uid).
+      identities.insert(account_id: account_b, provider: 'oidc', issuer: issuer, uid: uid)
+
+      # Challenge snapshots account A (matches the account email_a re-locates, so the
+      # mint-mismatch guard passes and execution reaches bind_sso_identity).
+      challenge = mint_challenge(email: email_a, uid: uid, account_id: account_a, issuer: issuer)
+      result    = post_link_sso(token: challenge.token, password: AuthTestConstants::TEST_PASSWORD)
+
+      expect(result.status).to eq(409),
+        "Expected link_conflict from the bind ownership check, got #{result.status}: #{result.body}"
+      expect(JSON.parse(result.body)['error_code']).to eq('link_conflict')
+
+      # Still exactly one row — owned by B — and nothing bound onto A.
+      rows = identities.where(provider: 'oidc', uid: uid).all
+      expect(rows.size).to eq(1)
+      expect(rows.first[:account_id]).to eq(account_b)
+      expect(identities.where(account_id: account_a).count).to eq(0)
+    end
+  end
+
+  # ==========================================================================
+  # (k) single-use token consumption is atomic (review Item 2)
+  # ==========================================================================
+  #
+  # #3840 review, Item 2: #delete! returns the Redis DEL count. Redis DEL is atomic,
+  # so of two concurrent consumers exactly ONE gets 1 and the other gets 0 — which
+  # the POST handler now gates on to reject a racing consumer, closing the
+  # load-then-delete TOCTOU.
+
+  describe 'single-use token consumption (atomic)' do
+    it 'returns DEL count 1 for the winning consumer and 0 for a second handle to the same token' do
+      winner = mint_challenge(
+        email: "atomic-#{SecureRandom.hex(6)}@company.example.com",
+        uid: "sub-#{SecureRandom.hex(8)}",
+        account_id: 4242,
+      )
+      loser  = Onetime::SsoLinkChallenge.load(winner.token) # second handle, same Redis key
+      expect(loser).not_to be_nil
+
+      expect(winner.delete!).to eq(1)
+      expect(loser.delete!).to eq(0)
+    end
+
+    it 'rejects a second POST that reuses an already-consumed token' do
+      email      = "reuse-#{SecureRandom.hex(6)}@company.example.com"
+      uid        = "sub-#{SecureRandom.hex(8)}"
+      account_id = seed_account_with_password(email)
+
+      challenge = mint_challenge(email: email, uid: uid, account_id: account_id)
+
+      first = post_link_sso(token: challenge.token, password: AuthTestConstants::TEST_PASSWORD)
+      expect(first.status).to eq(200),
+        "First link should succeed, got #{first.status}: #{first.body}"
+
+      # Same token again -> the challenge is gone, so the load-nil guard refuses.
+      second = post_link_sso(token: challenge.token, password: AuthTestConstants::TEST_PASSWORD)
+      expect(second.status).to eq(401)
+      expect(JSON.parse(second.body)['error_code']).to eq('link_expired')
+    end
+  end
+
+  # ==========================================================================
+  # (l) MFA account defers the identity bind (review Item 1)
+  # ==========================================================================
+  #
+  # The interstitial must NOT bind the identity when the password login leaves a
+  # second factor pending: login returns mfa_required (the SAME body POST /auth/login
+  # emits) and the (provider, issuer, uid) row stays UNLINKED this round. Binding
+  # before 2FA would attach an MFA-EXEMPT SSO login path to the account.
+  #
+  # Exercising this end-to-end needs the OTP feature loaded (AUTH_MFA_ENABLED) so
+  # respond_to?(:otp_auth_route) is true and after_login emits mfa_required. The
+  # shared integration harness boots ONCE (before(:all)) with MFA disabled and cannot
+  # toggle the Rodauth feature set per-example, so this path is verified by code
+  # review + the link_sso_second_factor_pending? gate. Left as a pending example to
+  # keep the coverage gap VISIBLE (manual follow-up).
+
+  describe 'MFA account defers the identity bind (Item 1)' do
+    it 'returns mfa_required and binds no identity (needs an AUTH_MFA_ENABLED harness)'
   end
 end

--- a/docs/authentication/per-install-sso.md
+++ b/docs/authentication/per-install-sso.md
@@ -138,7 +138,10 @@ Account lookup by (provider, uid), then by email
     ├─ (provider, uid) already linked → sync session
     ├─ Email matches an account, but this identity is not linked
     │     ├─ Trusted-IdP flag ON  → auto-link identity, sync session
-    │     └─ Trusted-IdP flag OFF → refuse, redirect to /signin (default)
+    │     └─ Trusted-IdP flag OFF →
+    │            ├─ account HAS a password → sign-in interstitial
+    │            │      (prove existing password → link identity → sync session)
+    │            └─ account has NO password → refuse, redirect to /signin (default)
     └─ Email unknown → Create account + Customer + workspace, sync session
     │
     ▼
@@ -149,7 +152,7 @@ All hooks (`account_from_omniauth`, `before_omniauth_create_account`, etc.) are 
 
 ## Behavior
 
-**Account Matching:** By linked identity first — the `(provider, uid)` pair in `account_identities`. If that identity is already linked, the user is signed into its account. If the identity is *not* linked but the IdP email matches an existing account, the default is to **refuse** auto-linking (email may locate an account, but only a demonstrated credential may bind an identity to it). This refusal can be relaxed per provider with the trusted-IdP flag — see [Identity Linking and the Trusted-IdP Flag](#identity-linking-and-the-trusted-idp-flag).
+**Account Matching:** By linked identity first — the `(provider, uid)` pair in `account_identities`. If that identity is already linked, the user is signed into its account. If the identity is *not* linked but the IdP email matches an existing account, the default is to **refuse** auto-linking (email may locate an account, but only a demonstrated credential may bind an identity to it). Two paths relax that refusal without weakening the invariant: a password-holding account is offered a **sign-in interstitial** to prove its existing password (on by default — see [Sign-in interstitial](#sign-in-interstitial-password-challenge-linking)), and an operator can opt a trusted IdP into email auto-linking (see [Identity Linking and the Trusted-IdP Flag](#identity-linking-and-the-trusted-idp-flag)).
 
 **Account Creation:** Automatic for unrecognized emails. Creates Customer record and default workspace.
 
@@ -168,6 +171,40 @@ An email claim may **locate** an account; only a **demonstrated credential** may
 Concretely: an SSO login is identified by the `(provider, uid)` pair recorded in `account_identities`. When that pair is already linked, the user is signed into the linked account. When it is *not* linked, but the IdP-supplied email happens to match an existing account, the default behavior is to **refuse** — because anyone who controls the IdP can mint a token bearing any victim's email address. Auto-linking on email alone would let such a token take over the matching account. The refusal is logged as `omniauth_link_refused_existing_account` (level `warn`) and the user is redirected to `/signin?auth_error=account_exists_link_required` with a flash telling them to sign in with their existing method.
 
 This is the correct default for a multi-tenant platform. It is *not* what a self-hosted single-tenant operator wants when they control both the app and the IdP — for them, email is a trustworthy join key, and the refusal locks legitimate users out. The trusted-IdP flag is the sanctioned, opt-in exception.
+
+### Sign-in interstitial (password-challenge linking)
+
+The refusal is the *right* default, but for one common case it is unnecessarily blunt: a user who already has a **password** account and now signs in through SSO for the first time. That user *can* demonstrate a credential — their existing password — so instead of dead-ending them, the callback offers a **sign-in interstitial** that collects and verifies that password before binding the identity. This keeps the invariant intact: email still only *locates* the account; the existing password is the credential that *binds*.
+
+This path needs no operator configuration. It is on by default and is the platform-surface recovery for a password user's first SSO sign-in (the counterpart to the authenticated "Connect SSO" panel in account settings, which serves users who signed in with their password first).
+
+**What happens (unauthenticated callback, existing account, identity not linked, trust flag off):**
+
+1. `account_from_omniauth` looks up the located account's password hash directly (it cannot use `has_password?`, which reads the *session* account and there is no session yet on this path).
+2. **Account has a password →** it mints a single-use `Onetime::SsoLinkChallenge` in Redis — a short-lived (5 min) token snapshotting `(provider, resolved_issuer, uid, normalized email, account id)` — logs `omniauth_link_challenge_issued` (level `warn`), and redirects the browser to the SPA interstitial at `/link-sso/{token}`.
+3. **Account has no password (SSO-only) →** unchanged H-3 refusal (`omniauth_link_refused_existing_account`, redirect to `/signin?auth_error=account_exists_link_required`). There is no credential to challenge.
+
+**The interstitial endpoints** (`apps/web/auth/routes/link_sso.rb`):
+
+| Endpoint | Purpose | Response |
+|----------|---------|----------|
+| `GET /auth/link-sso/{token}` | Display context for the page | `{ provider, email }` — display only; never the account id, uid, or issuer. Missing/consumed/expired token → `404 { error, error_code: "link_expired" }`. |
+| `POST /auth/link-sso` | Verify password, bind identity, log in | Body `{ token, password }`. Success establishes the session and returns Rodauth's standard login JSON response (`200 { success, … }`, plus `mfa_required`/`billing_redirect` when applicable). Failures return `{ error, error_code }` (see below). |
+
+**POST error codes** (the SPA maps these to copy and, for `link_expired`/`link_conflict`, the account-settings connections pointer `/account/settings/security/connections`):
+
+| Status | `error_code` | Meaning |
+|--------|--------------|---------|
+| 400 | `invalid_request` | token or password missing |
+| 401 | `link_expired` | token missing / already consumed / expired, or the located account vanished |
+| 401 | `invalid_password` | the existing password did not verify |
+| 409 | `link_conflict` | the email now resolves to a different account than the one snapshotted at mint |
+
+**Why the token is single-use (security-load-bearing).** `POST /auth/link-sso` **deletes** the challenge up front — before it even checks the password — so a token is worth exactly **one** attempt. This is deliberate: password verification runs through `Auth::Config.valid_login_and_password?`, a Rodauth *internal request* that does **not** go through the login route and therefore does **not** increment lockout counters. Without one-shot consumption, a token minted by an attacker who completed an SSO round-trip asserting a victim's email would be an unbounded (TTL-window) password-guessing oracle with no lockout. One-shot consumption bounds it to a single guess per full IdP round-trip. The 5-minute TTL bounds abandoned challenges. On a wrong password the user must restart the SSO sign-in — a deliberate trade of a small amount of retry convenience for closing the oracle.
+
+**Session establishment reuses Rodauth's own machinery.** On a correct password the handler binds the `(provider, issuer, uid)` row (same shape as `omniauth_identity_insert_hash`) and then calls `rodauth.login('password')` rather than hand-rolling the session. That runs the normal `after_login` path — the Redis session blob via `SyncSession` (the real app auth gate), `active_sessions` registration, and MFA detection — so a password account that has OTP configured still gets the MFA gate, exactly as a direct `/auth/login` would.
+
+**Platform-only.** The interstitial is only ever offered on the platform callback path. The email branches in `account_from_omniauth` are reached solely when `session[:validated_omniauth_domain_id]` is `nil` (tenant callbacks bind by session or refuse earlier), so a tenant callback can never mint a challenge. Authenticated tenant-surface linking is a separate follow-up.
 
 ### The flag
 

--- a/lib/onetime/models.rb
+++ b/lib/onetime/models.rb
@@ -16,6 +16,7 @@ require_relative 'models/admin_audit_event'
 require_relative 'models/daily_metric'
 require_relative 'models/email_suppression'
 require_relative 'models/session_metadata'
+require_relative 'models/sso_link_challenge'
 
 # CustomDomain sibling configs — loaded after CustomDomain so the
 # nested-class reopens (`class CustomDomain; class ApiConfig; ...`)

--- a/lib/onetime/models/sso_link_challenge.rb
+++ b/lib/onetime/models/sso_link_challenge.rb
@@ -1,0 +1,101 @@
+# lib/onetime/models/sso_link_challenge.rb
+#
+# frozen_string_literal: true
+
+require 'securerandom'
+
+module Onetime
+  # SsoLinkChallenge — a single-use, short-lived capability token that carries an
+  # unauthenticated SSO sign-in across the password-challenge interstitial
+  # (#3840 Phase 3 / #3838 item 1b).
+  #
+  # ## Why this exists
+  #
+  # When an UNAUTHENTICATED SSO sign-in resolves to an EXISTING local account that
+  # already has a password, the H-3 refusal in account_from_omniauth
+  # (apps/web/auth/config/hooks/omniauth.rb) would otherwise dead-end the user at
+  # /signin?auth_error=account_exists_link_required. That refusal is correct for
+  # SSO-only accounts (nothing to prove), but a password-holding account CAN prove
+  # ownership: re-enter the existing password. Phase 3 offers an interstitial that
+  # collects that password, verifies it, and only then binds the (provider, issuer,
+  # uid) identity — honouring the invariant "email may LOCATE an account; only a
+  # demonstrated credential may BIND".
+  #
+  # The bind cannot happen inside the OmniAuth callback (the password has not been
+  # collected yet) and the callback-only auth-hash accessors (omniauth_uid,
+  # resolved_issuer, ...) are gone by the time the password POST arrives. So the
+  # callback SNAPSHOTS the decision into one of these records and redirects to the
+  # interstitial carrying the token; the POST /auth/link-sso handler loads it back.
+  #
+  # ## Single-use in time (delete-on-consume + short TTL)
+  #
+  # The token id is the Redis key. The record self-expires after
+  # DEFAULT_EXPIRATION seconds (one IdP round-trip), and POST /auth/link-sso
+  # DELETES it (#delete!) before it even verifies the password — so a token is
+  # good for exactly ONE attempt. This is deliberate and security-load-bearing:
+  # Auth::Config.valid_login_and_password? does NOT run through the login route, so
+  # it does NOT increment Rodauth's lockout counters. Consuming the token up front
+  # means an attacker who mints a challenge (by completing an SSO round-trip that
+  # asserts a victim's email) gets ONE password guess per full IdP round-trip, not
+  # an unbounded 5-minute oracle. Mirrors the shipped delete-on-consume patterns:
+  # Customer#pending_plan_intent (Auth::Config::Hooks::Billing.extract_pending_plan_intent)
+  # and OrganizationMembership#accept! (one-shot token_lookup consume).
+  #
+  # ## Not the security boundary
+  #
+  # Possession of a token proves only that SOMEONE completed an SSO round-trip for
+  # this email; it is NOT proof of account ownership. The password check in
+  # POST /auth/link-sso is the boundary. The token carries account_id purely as a
+  # defence-in-depth consistency check against the account re-located by email at
+  # POST time — never as the authorization to bind.
+  class SsoLinkChallenge < Familia::Horreum
+    feature :expiration
+
+    prefix :sso_link_challenge
+    identifier_field :token
+
+    # 5 minutes — comfortably covers one IdP round-trip plus entering a password,
+    # short enough to bound the abandoned-challenge / guessing window. Raw seconds
+    # (no TimeLiterals refinement needed), matching Onetime::SessionMetadata.
+    DEFAULT_EXPIRATION = 300
+    default_expiration DEFAULT_EXPIRATION
+
+    field :token       # opaque single-use id; also the identifier and Redis key
+    field :provider    # OmniAuth strategy name ('oidc', 'entra', ...) — display + bind
+    field :issuer      # resolved issuer for issuer-scoped binding ('' sentinel allowed)
+    field :uid         # IdP subject (sub) to bind
+    field :email       # normalized email that LOCATED the account — display + login
+    field :account_id  # snapshotted account PK — defence-in-depth consistency check
+
+    class << self
+      # Mint a new single-use challenge and persist it with its TTL.
+      #
+      # @param provider   [String, Symbol] OmniAuth strategy name
+      # @param issuer     [String, nil]    resolved issuer ('' sentinel permitted)
+      # @param uid        [String]         IdP subject identifier
+      # @param email      [String]         normalized email that located the account
+      # @param account_id [Integer, String] located account's primary key
+      # @return [SsoLinkChallenge] the persisted challenge (token available as #token)
+      def issue(provider:, uid:, email:, account_id:, issuer: nil)
+        challenge = new(
+          token: SecureRandom.urlsafe_base64(32),
+          provider: provider.to_s,
+          issuer: issuer.to_s,
+          uid: uid.to_s,
+          email: email.to_s,
+          account_id: account_id.to_s,
+        )
+        challenge.save
+        challenge
+      end
+    end
+
+    # Display-only projection for GET /auth/link-sso/:token. Intentionally omits
+    # uid, issuer, and account_id — the interstitial only needs to name the
+    # provider and echo the claimed email; nothing else is safe to surface to an
+    # unauthenticated caller who merely holds the token.
+    def to_display
+      { provider: provider, email: email }
+    end
+  end
+end

--- a/locales/content/en/session-auth-extended.json
+++ b/locales/content/en/session-auth-extended.json
@@ -431,6 +431,66 @@
     "context": "Fallback error for connected-identities fetch/remove failures",
     "content_hash": "a0d4edc0"
   },
+  "web.link_sso.title": {
+    "text": "Link your sign-in method",
+    "context": "Heading + page title for the #3840 Phase 3 sign-in interstitial: an unauthenticated SSO sign-in whose email matches an existing password account is asked to prove the password before the provider is linked.",
+    "content_hash": "46339bac"
+  },
+  "web.link_sso.prompt": {
+    "text": "You signed in with {provider}, which matches the existing account {email}. Enter that account's password to link {provider} and continue.",
+    "context": "Instruction on the sign-in interstitial. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/link-sso/:token.",
+    "content_hash": "59da1c08"
+  },
+  "web.link_sso.password_label": {
+    "text": "Password",
+    "context": "Label for the existing-account password field on the #3840 Phase 3 sign-in interstitial.",
+    "content_hash": "e7cf3ef4"
+  },
+  "web.link_sso.password_placeholder": {
+    "text": "Your existing password",
+    "context": "Placeholder for the existing-account password field on the #3840 Phase 3 sign-in interstitial.",
+    "content_hash": "ad4e56da"
+  },
+  "web.link_sso.submit": {
+    "text": "Link and continue",
+    "context": "Submit button on the #3840 Phase 3 sign-in interstitial: verifies the existing password, binds the SSO identity, and completes sign-in.",
+    "content_hash": "c969b759"
+  },
+  "web.link_sso.cancel": {
+    "text": "Cancel",
+    "context": "Cancel action on the #3840 Phase 3 sign-in interstitial; returns the user to sign in with their existing method.",
+    "content_hash": "19766ed6"
+  },
+  "web.link_sso.unavailable_title": {
+    "text": "This linking request has expired",
+    "context": "Heading of the dead-end panel on the #3840 Phase 3 sign-in interstitial, shown when the single-use challenge token is missing, expired, or already used.",
+    "content_hash": "b53c7e55"
+  },
+  "web.link_sso.unavailable_message": {
+    "text": "For your security, the request to link this sign-in method is no longer valid. Sign in with your existing password, then connect this provider under Security settings → Connected identities.",
+    "context": "Body of the dead-end panel on the #3840 Phase 3 sign-in interstitial (expired/spent challenge token). Points the user at the Phase 2 Connected Identities flow.",
+    "content_hash": "f7e349d1"
+  },
+  "web.link_sso.unavailable_action": {
+    "text": "Continue to sign in",
+    "context": "Primary action on the dead-end panel of the #3840 Phase 3 sign-in interstitial; routes to /signin carrying the Connected Identities panel as the post-login destination.",
+    "content_hash": "d398cd0a"
+  },
+  "web.link_sso.errors.invalid_password": {
+    "text": "That password doesn't match this account. Please try again.",
+    "context": "Inline error on the #3840 Phase 3 sign-in interstitial when the entered password fails to verify (retryable). Deliberately does not confirm the account exists beyond the already-displayed claimed email.",
+    "content_hash": "3259b4f5"
+  },
+  "web.link_sso.errors.invalid_token": {
+    "text": "This linking request has expired or was already used. Sign in with your existing password, then connect this provider from your account settings.",
+    "context": "Error on the #3840 Phase 3 sign-in interstitial when the single-use challenge token is expired, spent, or unknown (dead-end, not retryable).",
+    "content_hash": "541f9127"
+  },
+  "web.link_sso.errors.generic": {
+    "text": "We couldn't link your account. Please try again.",
+    "context": "Fallback error for #3840 Phase 3 sign-in interstitial challenge-context / verify failures that are neither a wrong password nor an expired token.",
+    "content_hash": "f727c174"
+  },
   "web.auth.lockout.attempts_remaining": {
     "text": "Warning: {count} login attempt(s) remaining",
     "content_hash": "151dcb5e"

--- a/locales/content/en/session-auth.json
+++ b/locales/content/en/session-auth.json
@@ -143,6 +143,11 @@
     "context": "Shown on signin page when tenant-domain SSO authenticated but the organization join produced no membership (orphaned account). Admins/ops must investigate; the user cannot self-resolve.",
     "content_hash": "155e71bb"
   },
+  "web.login.errors.link_sso_failed": {
+    "text": "We couldn't link that sign-in method. Sign in with your existing password, then connect this provider under Security settings → Connected identities.",
+    "context": "Shown on /signin after the #3840 Phase 3 sign-in interstitial is cancelled, its challenge token expires/is spent, or password linking otherwise dead-ends. Points the user at the Phase 2 Connected Identities flow; the interstitial routes here with ?redirect=/account/settings/security/connections so the panel opens after they sign in.",
+    "content_hash": "49954127"
+  },
   "web.login.signin_disabled_heading": {
     "text": "Sign-in is not available",
     "context": "Page heading on /signin when sign-in is disabled for the current domain (per-domain SigninConfig).",

--- a/src/apps/session/routes.ts
+++ b/src/apps/session/routes.ts
@@ -183,6 +183,35 @@ const routes: Array<RouteRecordRaw> = [
       sentryScrubParams: false,
     },
   },
+  // Sign-in interstitial (SSO password-challenge linking — #3840 Phase 3).
+  // Reached UNAUTHENTICATED via a backend redirect after an SSO sign-in whose
+  // IdP email matched an existing password-holding account. The single-use
+  // challenge token rides in the path (`:token`). Meta mirrors /mfa-verify
+  // (another post-credential, pre-fully-authenticated interstitial), EXCEPT the
+  // token is sensitive: sentryScrubParams: ['token'] redacts it from diagnostics
+  // (mfa-verify has no path param, so it opts out with `false`).
+  {
+    path: '/link-sso/:token',
+    name: 'Link SSO',
+    component: () => import('@/apps/session/views/LinkSso.vue'),
+    meta: {
+      title: 'web.link_sso.title',
+      requiresAuth: false,
+      isAuthRoute: true,
+      requiresFeature: 'signin',
+      excludeSsoOnly: true,
+      layout: AuthLayout,
+      layoutProps: {
+        displayMasthead: false,
+        displayNavigation: false,
+        displayFooterLinks: false,
+        displayFeedback: false,
+        displayVersion: true,
+        displayToggles: true,
+      },
+      sentryScrubParams: ['token'],
+    },
+  },
   {
     path: '/email-login',
     name: 'Email Login',

--- a/src/apps/session/views/LinkSso.vue
+++ b/src/apps/session/views/LinkSso.vue
@@ -1,0 +1,265 @@
+<!-- src/apps/session/views/LinkSso.vue -->
+
+<script setup lang="ts">
+  import AuthView from '@/apps/session/components/AuthView.vue';
+  import { loggingService } from '@/services/logging.service';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import { useLinkSso } from '@/shared/composables/useLinkSso';
+  import { useAuthStore } from '@/shared/stores/authStore';
+  import { isValidInternalPath } from '@/utils/redirect';
+  import { ref, onMounted, computed } from 'vue';
+  import { useI18n } from 'vue-i18n';
+  import { useRoute, useRouter } from 'vue-router';
+
+  const { t } = useI18n();
+  const route = useRoute();
+  const router = useRouter();
+  const authStore = useAuthStore();
+
+  const { challenge, verifyLink, fetchChallenge, isLoading, error, errorCode, clearError } =
+    useLinkSso();
+
+  // Phase 2 Connected Identities panel — where the H-3 refusal points on
+  // cancel / dead-end. An UNAUTHENTICATED user cannot open it directly, so we
+  // route through /signin carrying this as the post-login destination.
+  const CONNECT_REDIRECT = '/account/settings/security/connections';
+
+  // Friendly provider labels; unknown providers fall back to a capitalized name
+  // so a backend that adds a strategy still renders sensibly. Mirrors
+  // ConnectedIdentities.vue.
+  const PROVIDER_LABELS: Record<string, string> = {
+    oidc: 'OpenID Connect',
+    entra: 'Microsoft Entra',
+    github: 'GitHub',
+    google: 'Google',
+  };
+
+  const password = ref('');
+  const passwordInputRef = ref<HTMLInputElement | null>(null);
+  // Set when the challenge context cannot be loaded or the token is spent: there
+  // is nothing to prove against, so render the dead-end panel, not the form.
+  const challengeUnavailable = ref(false);
+
+  // Single-use challenge token from the interstitial URL (path param, scrubbed
+  // from diagnostics via the route's sentryScrubParams).
+  const token = computed(() => {
+    const raw = route.params.token;
+    return typeof raw === 'string' ? raw : '';
+  });
+
+  // Post-link destination from the query, if a safe internal path. Only used as
+  // a fallback when the verify response does not carry its own redirect target.
+  const redirectPath = computed(() => {
+    const redirect = route.query.redirect;
+    if (typeof redirect !== 'string') return null;
+    return isValidInternalPath(redirect) ? redirect : null;
+  });
+
+  const providerLabel = computed(() => {
+    const provider = challenge.value?.provider;
+    if (!provider) return '';
+    return PROVIDER_LABELS[provider] ?? provider.charAt(0).toUpperCase() + provider.slice(1);
+  });
+
+  onMounted(async () => {
+    // Already fully signed in (e.g. a stale interstitial link opened after a
+    // separate login): nothing to link, go home.
+    if (authStore.isFullyAuthenticated) {
+      loggingService.debug('[LinkSso] Already authenticated, redirecting to /');
+      router.push('/');
+      return;
+    }
+
+    if (!token.value) {
+      loggingService.debug('[LinkSso] Missing challenge token — dead-end');
+      challengeUnavailable.value = true;
+      return;
+    }
+
+    const context = await fetchChallenge(token.value);
+    if (!context) {
+      // Token spent / expired / unknown — keep the H-3 refusal, point at settings.
+      challengeUnavailable.value = true;
+    }
+  });
+
+  // Verify the account's EXISTING password. Success establishes the session
+  // server-side; sync client auth state and navigate. Wrong password → retry;
+  // spent/expired token → dead-end.
+  const handleVerify = async () => {
+    if (!password.value || isLoading.value) return;
+
+    clearError();
+    const result = await verifyLink(token.value, password.value);
+
+    if (result) {
+      loggingService.debug('[LinkSso] Link verified, completing sign-in');
+      await authStore.setAuthenticated(true);
+
+      // Prefer the backend's redirect target when it is a safe internal path;
+      // otherwise the ?redirect query param; otherwise the dashboard.
+      const fromResponse =
+        result.redirect && isValidInternalPath(result.redirect) ? result.redirect : null;
+      const destination = fromResponse ?? redirectPath.value ?? '/';
+      router.push(destination);
+      return;
+    }
+
+    if (errorCode.value === 'invalid_token') {
+      // Nothing left to prove against — fall through to the dead-end panel.
+      challengeUnavailable.value = true;
+      return;
+    }
+
+    // Wrong password: clear the field and let the user try again.
+    password.value = '';
+    passwordInputRef.value?.focus();
+  };
+
+  // Cancel / dead-end: an unauthenticated user is sent to sign in with their
+  // existing method, carrying the Connected Identities panel as the post-login
+  // destination plus an explanatory pointer (Login.vue renders link_sso_failed).
+  const goToSignInFallback = () => {
+    router.push({
+      path: '/signin',
+      query: { auth_error: 'link_sso_failed', redirect: CONNECT_REDIRECT },
+    });
+  };
+
+  const handleCancel = () => {
+    clearError();
+    goToSignInFallback();
+  };
+</script>
+
+<template>
+  <AuthView
+    :heading="t('web.link_sso.title')"
+    heading-id="link-sso-heading"
+    :with-subheading="false"
+    :show-return-home="false">
+    <template #form>
+      <div class="space-y-6">
+        <!-- Dead-end: token missing / expired / spent. Keep the H-3 refusal and
+             point the user at the Phase 2 settings flow. -->
+        <div
+          v-if="challengeUnavailable"
+          data-testid="link-sso-unavailable"
+          class="space-y-4 text-center">
+          <OIcon
+            collection="heroicons"
+            name="lock-closed"
+            class="mx-auto size-10 text-gray-400 dark:text-gray-500"
+            aria-hidden="true" />
+          <h2 class="text-lg font-medium text-gray-900 dark:text-white">
+            {{ t('web.link_sso.unavailable_title') }}
+          </h2>
+          <p class="text-sm text-gray-600 dark:text-gray-400">
+            {{ t('web.link_sso.unavailable_message') }}
+          </p>
+          <button
+            @click="goToSignInFallback"
+            type="button"
+            class="w-full rounded-md bg-brand-600 px-4 py-3 text-lg font-medium text-white hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2"
+            data-testid="link-sso-unavailable-action">
+            {{ t('web.link_sso.unavailable_action') }}
+          </button>
+        </div>
+
+        <!-- Loading the challenge context -->
+        <div
+          v-else-if="isLoading && !challenge"
+          aria-live="polite"
+          class="py-4 text-center text-sm text-gray-600 dark:text-gray-400"
+          data-testid="link-sso-loading">
+          {{ t('web.COMMON.form_processing') }}
+        </div>
+
+        <!-- Password challenge -->
+        <template v-else-if="challenge">
+          <p
+            id="link-sso-instructions"
+            class="text-center text-gray-600 dark:text-gray-400"
+            data-testid="link-sso-prompt">
+            {{ t('web.link_sso.prompt', { provider: providerLabel, email: challenge.email }) }}
+          </p>
+
+          <form
+            @submit.prevent="handleVerify"
+            class="space-y-4">
+            <div>
+              <label
+                for="link-sso-password"
+                class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                {{ t('web.link_sso.password_label') }}
+              </label>
+              <input
+                id="link-sso-password"
+                ref="passwordInputRef"
+                v-model="password"
+                type="password"
+                autocomplete="current-password"
+                :disabled="isLoading"
+                :aria-invalid="error ? 'true' : undefined"
+                :aria-describedby="error ? 'link-sso-error' : 'link-sso-instructions'"
+                :placeholder="t('web.link_sso.password_placeholder')"
+                class="block w-full appearance-none rounded-md border border-gray-300 px-3 py-2 placeholder:text-gray-400 focus:border-brand-500 focus:outline-none focus:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-500"
+                data-testid="link-sso-password-input" />
+            </div>
+
+            <!-- Error message (wrong password stays inline; token errors dead-end) -->
+            <div
+              v-if="error"
+              id="link-sso-error"
+              class="rounded-md bg-red-50 p-4 dark:bg-red-900/20"
+              role="alert"
+              aria-live="assertive"
+              aria-atomic="true"
+              data-testid="link-sso-error">
+              <p class="text-sm text-red-800 dark:text-red-200">
+                {{ error }}
+              </p>
+            </div>
+
+            <button
+              type="submit"
+              :disabled="!password || isLoading"
+              :aria-disabled="!password || isLoading ? 'true' : undefined"
+              class="w-full rounded-md bg-brand-600 px-4 py-3 text-lg font-medium text-white hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              data-testid="link-sso-submit">
+              <span v-if="isLoading">{{ t('web.COMMON.processing') || 'Processing...' }}</span>
+              <span v-else>{{ t('web.link_sso.submit') }}</span>
+            </button>
+
+            <!-- Loading state announcement (screen reader only) -->
+            <div
+              v-if="isLoading"
+              aria-live="polite"
+              aria-atomic="true"
+              class="sr-only">
+              {{ t('web.COMMON.form_processing') }}
+            </div>
+          </form>
+        </template>
+      </div>
+    </template>
+
+    <!-- Footer: cancel returns to the sign-in / settings flow -->
+    <template #footer>
+      <div
+        v-if="!challengeUnavailable"
+        class="border-t border-gray-200 pt-4 dark:border-gray-700">
+        <nav class="flex items-center justify-center gap-2 text-sm">
+          <button
+            @click="handleCancel"
+            type="button"
+            :disabled="isLoading"
+            class="text-gray-500 transition-colors duration-200 hover:text-gray-700 focus:outline-none focus:underline disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:text-gray-300"
+            data-testid="link-sso-cancel">
+            {{ t('web.link_sso.cancel') }}
+          </button>
+        </nav>
+      </div>
+    </template>
+  </AuthView>
+</template>

--- a/src/apps/session/views/LinkSso.vue
+++ b/src/apps/session/views/LinkSso.vue
@@ -2,10 +2,15 @@
 
 <script setup lang="ts">
   import AuthView from '@/apps/session/components/AuthView.vue';
+  import {
+    linkSsoRequiresMfa,
+    type LinkSsoVerifySuccess,
+  } from '@/schemas/api/auth/responses/auth';
   import { loggingService } from '@/services/logging.service';
   import OIcon from '@/shared/components/icons/OIcon.vue';
   import { useLinkSso } from '@/shared/composables/useLinkSso';
   import { useAuthStore } from '@/shared/stores/authStore';
+  import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import { isValidInternalPath } from '@/utils/redirect';
   import { ref, onMounted, computed } from 'vue';
   import { useI18n } from 'vue-i18n';
@@ -15,6 +20,7 @@
   const route = useRoute();
   const router = useRouter();
   const authStore = useAuthStore();
+  const bootstrapStore = useBootstrapStore();
 
   const { challenge, verifyLink, fetchChallenge, isLoading, error, errorCode, clearError } =
     useLinkSso();
@@ -83,6 +89,35 @@
     }
   });
 
+  // Handle a successful verify. The password proof succeeded server-side; for an
+  // MFA account only the FIRST factor is done. Mirror the normal Login flow
+  // (useAuth) EXACTLY: hand an MFA account off to the shared /mfa-verify challenge
+  // WITHOUT marking it fully authenticated; otherwise complete the sign-in and
+  // navigate to the safest available destination.
+  const handleVerifySuccess = async (result: LinkSsoVerifySuccess) => {
+    if (linkSsoRequiresMfa(result)) {
+      loggingService.debug('[LinkSso] MFA required, routing to /mfa-verify');
+      // Mark awaiting_mfa (NOT authenticated) so the MFA route guard permits
+      // /mfa-verify; preserve any ?redirect for the post-verify hop.
+      bootstrapStore.update({ awaiting_mfa: true, authenticated: false });
+      router.push({
+        path: '/mfa-verify',
+        query: redirectPath.value ? { redirect: redirectPath.value } : undefined,
+      });
+      return;
+    }
+
+    loggingService.debug('[LinkSso] Link verified, completing sign-in');
+    await authStore.setAuthenticated(true);
+
+    // Prefer the backend's redirect target when it is a safe internal path;
+    // otherwise the ?redirect query param; otherwise the dashboard.
+    const fromResponse =
+      result.redirect && isValidInternalPath(result.redirect) ? result.redirect : null;
+    const destination = fromResponse ?? redirectPath.value ?? '/';
+    router.push(destination);
+  };
+
   // Verify the account's EXISTING password. Success establishes the session
   // server-side; sync client auth state and navigate. Wrong password → retry;
   // spent/expired token → dead-end.
@@ -93,15 +128,7 @@
     const result = await verifyLink(token.value, password.value);
 
     if (result) {
-      loggingService.debug('[LinkSso] Link verified, completing sign-in');
-      await authStore.setAuthenticated(true);
-
-      // Prefer the backend's redirect target when it is a safe internal path;
-      // otherwise the ?redirect query param; otherwise the dashboard.
-      const fromResponse =
-        result.redirect && isValidInternalPath(result.redirect) ? result.redirect : null;
-      const destination = fromResponse ?? redirectPath.value ?? '/';
-      router.push(destination);
+      await handleVerifySuccess(result);
       return;
     }
 
@@ -227,7 +254,7 @@
               :aria-disabled="!password || isLoading ? 'true' : undefined"
               class="w-full rounded-md bg-brand-600 px-4 py-3 text-lg font-medium text-white hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
               data-testid="link-sso-submit">
-              <span v-if="isLoading">{{ t('web.COMMON.processing') || 'Processing...' }}</span>
+              <span v-if="isLoading">{{ t('web.COMMON.processing') }}</span>
               <span v-else>{{ t('web.link_sso.submit') }}</span>
             </button>
 

--- a/src/apps/session/views/Login.vue
+++ b/src/apps/session/views/Login.vue
@@ -76,6 +76,7 @@ const authErrorMessages: Record<string, string> = {
   domain_not_allowed: 'web.login.errors.domain_not_allowed',
   account_exists_link_required: 'web.login.errors.account_exists_link_required',
   identity_connect_conflict: 'web.login.errors.identity_connect_conflict',
+  link_sso_failed: 'web.login.errors.link_sso_failed',
   org_join_failed: 'web.login.errors.org_join_failed',
 };
 

--- a/src/schemas/api/auth/responses/auth.ts
+++ b/src/schemas/api/auth/responses/auth.ts
@@ -168,6 +168,8 @@ export function isAuthError(
     | ResendVerificationEmailResponse
     | IdentitiesResponse
     | RemoveIdentityResponse
+    | LinkSsoChallengeResponse
+    | LinkSsoVerifyResponse
 ): response is z.infer<typeof authErrorSchema> {
   return 'error' in response;
 }
@@ -307,6 +309,62 @@ export type IdentitiesResponse = z.infer<typeof identitiesResponseSchema>;
  */
 export const removeIdentityResponseSchema = z.union([authSuccessSchema, authErrorSchema]);
 export type RemoveIdentityResponse = z.infer<typeof removeIdentityResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sign-in interstitial (SSO password-challenge linking — #3840 Phase 3)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Challenge context for the sign-in interstitial.
+ *
+ * An UNAUTHENTICATED SSO sign-in whose IdP email matches an existing account
+ * that HAS a password is redirected by the backend to the interstitial carrying
+ * a single-use challenge token. GET /auth/link-sso/:token returns the display
+ * context: which provider was used and the email that was claimed. Both are
+ * DISPLAY-ONLY — no secrets, no account id, no uid. The token itself is the
+ * authorization; a missing / expired / consumed token is a 404 (or an error
+ * body) and never returns context.
+ *
+ * INVARIANT (#3840): email may LOCATE an account; only a demonstrated credential
+ * may BIND an identity. Here the credential is the account's EXISTING password,
+ * collected by the interstitial and verified by POST /auth/link-sso.
+ */
+export const linkSsoChallengeSchema = z.object({
+  provider: z.string(),
+  email: z.string(),
+});
+export type LinkSsoChallenge = z.infer<typeof linkSsoChallengeSchema>;
+
+/**
+ * GET /auth/link-sso/:token → { provider, email } on 200.
+ * A spent / expired / unknown token surfaces as an axios error (404/410) whose
+ * body is classified by useAsyncHandler; the union's error branch only covers
+ * the unusual 200-with-error body.
+ */
+export const linkSsoChallengeResponseSchema = z.union([linkSsoChallengeSchema, authErrorSchema]);
+export type LinkSsoChallengeResponse = z.infer<typeof linkSsoChallengeResponseSchema>;
+
+/**
+ * POST /auth/link-sso { token, password } success body.
+ *
+ * On success the backend verifies the password, binds (provider, issuer, uid)
+ * to the located account, and ESTABLISHES THE SESSION. It returns an optional
+ * internal redirect target; the SPA validates it with isValidInternalPath and
+ * falls back to the ?redirect query param, then '/'.
+ *
+ * Failure bodies (403 wrong password, 404/410 expired-or-spent token) are NOT
+ * modelled here — they arrive as axios errors and are distinguished by the
+ * composable via HTTP status + an optional { error_code } the backend may set
+ * ('invalid_password' vs 'invalid_token'/'expired_token').
+ */
+export const linkSsoVerifySuccessSchema = z.object({
+  success: z.string(),
+  redirect: z.string().optional(),
+});
+export type LinkSsoVerifySuccess = z.infer<typeof linkSsoVerifySuccessSchema>;
+
+export const linkSsoVerifyResponseSchema = z.union([linkSsoVerifySuccessSchema, authErrorSchema]);
+export type LinkSsoVerifyResponse = z.infer<typeof linkSsoVerifyResponseSchema>;
 
 // OTP setup response
 // When HMAC is enabled, Rodauth returns an error response with only secrets on first request

--- a/src/schemas/api/auth/responses/auth.ts
+++ b/src/schemas/api/auth/responses/auth.ts
@@ -345,23 +345,48 @@ export const linkSsoChallengeResponseSchema = z.union([linkSsoChallengeSchema, a
 export type LinkSsoChallengeResponse = z.infer<typeof linkSsoChallengeResponseSchema>;
 
 /**
- * POST /auth/link-sso { token, password } success body.
- *
- * On success the backend verifies the password, binds (provider, issuer, uid)
- * to the located account, and ESTABLISHES THE SESSION. It returns an optional
- * internal redirect target; the SPA validates it with isValidInternalPath and
- * falls back to the ?redirect query param, then '/'.
- *
- * Failure bodies (403 wrong password, 404/410 expired-or-spent token) are NOT
- * modelled here — they arrive as axios errors and are distinguished by the
- * composable via HTTP status + an optional { error_code } the backend may set
- * ('invalid_password' vs 'invalid_token'/'expired_token').
+ * POST /auth/link-sso non-MFA success body: the backend verified the password,
+ * bound (provider, issuer, uid) to the located account, and ESTABLISHED THE
+ * SESSION. It returns an optional internal redirect target; the SPA validates it
+ * with isValidInternalPath and falls back to the ?redirect query param, then '/'.
  */
-export const linkSsoVerifySuccessSchema = z.object({
+const linkSsoVerifyCompleteSchema = z.object({
   success: z.string(),
   redirect: z.string().optional(),
 });
+
+/**
+ * POST /auth/link-sso success body.
+ *
+ * Because the backend completes the password check via the SAME rodauth login
+ * path as POST /auth/login, it returns the STANDARD login success contract, in
+ * two variants:
+ * - MFA account: the same body login returns for MFA (authSuccessWithMfaSchema) —
+ *   password proven, but a second factor is still required. mfa_required MUST be
+ *   modelled here; a plain z.object would silently strip it and the interstitial
+ *   would mark the user fully authenticated, skipping the OTP challenge (#3840).
+ * - Non-MFA account: { success, redirect? } — session established.
+ *
+ * Union order matters (Zod matches the first valid schema): the MFA variant
+ * carries the required mfa_required key and MUST precede the plain success
+ * variant, which would otherwise match an MFA body and drop the flag.
+ *
+ * Failure bodies (401 invalid_password wrong password, 401 link_expired expired-
+ * or-spent token) are NOT modelled here — they arrive as axios errors and are
+ * distinguished by the composable via HTTP status + an optional { error_code }.
+ */
+export const linkSsoVerifySuccessSchema = z.union([
+  authSuccessWithMfaSchema, // MFA variant — must precede plain success
+  linkSsoVerifyCompleteSchema, // { success, redirect? }
+]);
 export type LinkSsoVerifySuccess = z.infer<typeof linkSsoVerifySuccessSchema>;
+
+/** Type guard: a link-sso verify success that still requires a second factor. */
+export function linkSsoRequiresMfa(
+  response: LinkSsoVerifySuccess
+): response is z.infer<typeof authSuccessWithMfaSchema> {
+  return 'mfa_required' in response && response.mfa_required === true;
+}
 
 export const linkSsoVerifyResponseSchema = z.union([linkSsoVerifySuccessSchema, authErrorSchema]);
 export type LinkSsoVerifyResponse = z.infer<typeof linkSsoVerifyResponseSchema>;

--- a/src/shared/composables/useLinkSso.ts
+++ b/src/shared/composables/useLinkSso.ts
@@ -1,0 +1,248 @@
+// src/shared/composables/useLinkSso.ts
+
+/**
+ * Sign-in interstitial composable (SSO password-challenge linking — #3840 Phase 3)
+ *
+ * Drives the interstitial an UNAUTHENTICATED SSO sign-in is redirected to when
+ * its IdP email matches an existing account that HAS a password (the H-3 case
+ * that Phase 2 could only refuse). Two calls:
+ * - fetchChallenge(token): GET /auth/link-sso/:token → { provider, email }
+ *     (display-only context: which provider, which claimed email)
+ * - verifyLink(token, password): POST /auth/link-sso { token, password }
+ *     → on success the backend verifies the EXISTING password, binds
+ *       (provider, issuer, uid) to the located account, and ESTABLISHES THE
+ *       SESSION, returning an optional internal redirect target.
+ *
+ * INVARIANT (#3840): email may LOCATE an account; only a demonstrated CREDENTIAL
+ * may BIND an identity. Here the credential is the account's existing password —
+ * the interstitial is the password-proof path, nothing more. The challenge token
+ * is single-use and short-lived (backend Familia TTL model); a spent, expired,
+ * or unknown token yields a distinct error the UI treats as a dead-end (point
+ * the user at the Phase 2 Connected Identities flow) rather than a retry.
+ *
+ * Backend contract (pinned; flag mismatches):
+ * - GET  /auth/link-sso/:token  200 => { provider, email }
+ *                               404/410 => token missing / expired / consumed
+ * - POST /auth/link-sso         200 => { success, redirect? } (session established)
+ *                               403 => wrong password (retryable)
+ *                               404/410 => token expired / consumed (dead-end)
+ *   The failure branch is distinguished by HTTP status and, when present, an
+ *   { error_code } field ('invalid_password' vs 'invalid_token'/'expired_token').
+ *
+ * Mirrors useMfa / useConnectedIdentities: happy paths validate through a zod
+ * schema; useAsyncHandler `wrap` manages the loading state and the unexpected
+ * (technical) fallback. Failures are classified INSIDE the operation by reading
+ * the axios error's `response` directly (the useMfa 422 pattern) — this is the
+ * portable signal in both prod and the mock test harness — and surfaced as a
+ * typed errorCode the view branches on.
+ */
+
+import {
+  linkSsoChallengeResponseSchema,
+  linkSsoVerifyResponseSchema,
+  isAuthError,
+  type LinkSsoChallenge,
+  type LinkSsoChallengeResponse,
+  type LinkSsoVerifyResponse,
+  type LinkSsoVerifySuccess,
+} from '@/schemas/api/auth/responses/auth';
+import { useApi } from '@/shared/composables/useApi';
+import { useAsyncHandler, createError } from '@/shared/composables/useAsyncHandler';
+import { useCsrfStore } from '@/shared/stores/csrfStore';
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+/**
+ * Distinguishes a retryable wrong-password failure from a dead-end token
+ * failure (expired / spent / unknown challenge). The view keeps the user on the
+ * password form for 'invalid_password' and points them at the settings flow for
+ * 'invalid_token'.
+ */
+export type LinkSsoErrorCode = 'invalid_password' | 'invalid_token' | null;
+
+/** Minimal shape of the axios error's carried response (status + parsed body). */
+interface ErrorResponseLike {
+  status?: number;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Maps an HTTP status and an optional backend { error_code } to the UI's typed
+ * failure. Prefers the explicit backend code; falls back to the status family
+ * (404/410 => spent token, 401/403/422 => wrong password). Returns null when the
+ * failure is neither (e.g. a 5xx) so the caller surfaces a generic message.
+ */
+function resolveLinkErrorCode(
+  status: number | undefined,
+  backendCode: unknown
+): LinkSsoErrorCode {
+  if (
+    backendCode === 'invalid_token' ||
+    backendCode === 'expired_token' ||
+    status === 404 ||
+    status === 410
+  ) {
+    return 'invalid_token';
+  }
+  if (
+    backendCode === 'invalid_password' ||
+    status === 401 ||
+    status === 403 ||
+    status === 422
+  ) {
+    return 'invalid_password';
+  }
+  return null;
+}
+
+/* eslint-disable max-lines-per-function */
+export function useLinkSso() {
+  const { t } = useI18n();
+  const $api = useApi();
+  const csrfStore = useCsrfStore();
+
+  const challenge = ref<LinkSsoChallenge | null>(null);
+  const isLoading = ref(false);
+  const error = ref<string | null>(null);
+  const errorCode = ref<LinkSsoErrorCode>(null);
+
+  const { wrap } = useAsyncHandler({
+    notify: false,
+    setLoading: (loading) => (isLoading.value = loading),
+    onError: () => {
+      // Failures are classified inside the operation (setLinkError). Only fill a
+      // generic message for an unexpected throw the operation did not classify
+      // (e.g. a zod parse failure) so the view never dead-ends silently.
+      if (error.value === null) {
+        errorCode.value = null;
+        error.value = t('web.link_sso.errors.generic');
+      }
+    },
+  });
+
+  function clearError() {
+    error.value = null;
+    errorCode.value = null;
+  }
+
+  function messageForCode(code: LinkSsoErrorCode): string {
+    if (code === 'invalid_token') return t('web.link_sso.errors.invalid_token');
+    if (code === 'invalid_password') return t('web.link_sso.errors.invalid_password');
+    return t('web.link_sso.errors.generic');
+  }
+
+  /**
+   * Classifies and stores a failure from the (status, backend error_code) pair.
+   * `fallback` lets a caller bias an unclassifiable failure — e.g. any GET of the
+   * challenge context that fails at all means there is no usable context, so the
+   * fetch biases to 'invalid_token' (dead-end) rather than a generic retry.
+   */
+  function setLinkError(
+    status: number | undefined,
+    backendCode: unknown,
+    fallback: LinkSsoErrorCode = null
+  ) {
+    const code = resolveLinkErrorCode(status, backendCode) ?? fallback;
+    errorCode.value = code;
+    error.value = messageForCode(code);
+  }
+
+  function readErrorResponse(err: unknown): ErrorResponseLike | undefined {
+    return (err as { response?: ErrorResponseLike }).response;
+  }
+
+  /**
+   * Loads the display context for the challenge token. Returns null on any
+   * failure (error/errorCode are set via setLinkError); the view then renders
+   * the dead-end state instead of the password form.
+   */
+  async function fetchChallenge(token: string): Promise<LinkSsoChallenge | null> {
+    clearError();
+
+    const result = await wrap(async () => {
+      let response;
+      try {
+        response = await $api.get<LinkSsoChallengeResponse>(
+          `/auth/link-sso/${encodeURIComponent(token)}`
+        );
+      } catch (err) {
+        // Any failure to load the context means the token is spent/expired/
+        // unknown — bias the dead-end classification to 'invalid_token'.
+        const resp = readErrorResponse(err);
+        setLinkError(resp?.status, resp?.data?.error_code, 'invalid_token');
+        throw err;
+      }
+
+      const validated = linkSsoChallengeResponseSchema.parse(response.data);
+
+      // A 200 that still carries an error body is unusual; treat it as a spent
+      // token so the view dead-ends rather than showing a broken password form.
+      if (isAuthError(validated)) {
+        const rawCode = (response.data as Record<string, unknown>)?.error_code;
+        setLinkError(response.status, rawCode, 'invalid_token');
+        throw createError(t('web.link_sso.errors.invalid_token'), 'human', 'error');
+      }
+
+      challenge.value = validated;
+      return validated;
+    });
+
+    if (!result) {
+      challenge.value = null;
+    }
+    return result ?? null;
+  }
+
+  /**
+   * Verifies the account's EXISTING password against the challenge token. On
+   * success the backend establishes the session and returns the validated
+   * response (optionally carrying an internal redirect target); the caller syncs
+   * client auth state and navigates. Returns null on failure; the caller reads
+   * errorCode to decide retry (invalid_password) vs dead-end (invalid_token).
+   */
+  async function verifyLink(
+    token: string,
+    password: string
+  ): Promise<LinkSsoVerifySuccess | null> {
+    clearError();
+
+    const result = await wrap(async () => {
+      let response;
+      try {
+        response = await $api.post<LinkSsoVerifyResponse>('/auth/link-sso', {
+          token,
+          password,
+          shrimp: csrfStore.shrimp,
+        });
+      } catch (err) {
+        const resp = readErrorResponse(err);
+        setLinkError(resp?.status, resp?.data?.error_code);
+        throw err;
+      }
+
+      const validated = linkSsoVerifyResponseSchema.parse(response.data);
+
+      // Defensive: a 200 carrying an error body. Classify it the same way so the
+      // view branches consistently on errorCode.
+      if (isAuthError(validated)) {
+        const rawCode = (response.data as Record<string, unknown>)?.error_code;
+        setLinkError(response.status, rawCode);
+        throw createError(error.value ?? t('web.link_sso.errors.generic'), 'human', 'error');
+      }
+
+      return validated;
+    });
+
+    return result ?? null;
+  }
+
+  return {
+    challenge,
+    isLoading,
+    error,
+    errorCode,
+    fetchChallenge,
+    verifyLink,
+    clearError,
+  };
+}

--- a/src/shared/composables/useLinkSso.ts
+++ b/src/shared/composables/useLinkSso.ts
@@ -24,10 +24,14 @@
  * - GET  /auth/link-sso/:token  200 => { provider, email }
  *                               404/410 => token missing / expired / consumed
  * - POST /auth/link-sso         200 => { success, redirect? } (session established)
- *                               403 => wrong password (retryable)
- *                               404/410 => token expired / consumed (dead-end)
+ *                                    or { success, mfa_required, ... } (MFA account —
+ *                                    same body POST /auth/login returns; hand off to
+ *                                    the shared /mfa-verify challenge, do NOT complete)
+ *                               401 invalid_password => wrong password (retryable)
+ *                               401 link_expired     => token expired / consumed (dead-end)
  *   The failure branch is distinguished by HTTP status and, when present, an
- *   { error_code } field ('invalid_password' vs 'invalid_token'/'expired_token').
+ *   { error_code } field ('invalid_password' vs 'invalid_token'/'expired_token'/
+ *   'link_expired'). Legacy 403/404/410 statuses are still classified defensively.
  *
  * Mirrors useMfa / useConnectedIdentities: happy paths validate through a zod
  * schema; useAsyncHandler `wrap` manages the loading state and the unexpected
@@ -79,6 +83,7 @@ function resolveLinkErrorCode(
   if (
     backendCode === 'invalid_token' ||
     backendCode === 'expired_token' ||
+    backendCode === 'link_expired' ||
     status === 404 ||
     status === 410
   ) {
@@ -141,10 +146,11 @@ export function useLinkSso() {
     status: number | undefined,
     backendCode: unknown,
     fallback: LinkSsoErrorCode = null
-  ) {
+  ): string {
     const code = resolveLinkErrorCode(status, backendCode) ?? fallback;
     errorCode.value = code;
     error.value = messageForCode(code);
+    return error.value;
   }
 
   function readErrorResponse(err: unknown): ErrorResponseLike | undefined {
@@ -226,8 +232,8 @@ export function useLinkSso() {
       // view branches consistently on errorCode.
       if (isAuthError(validated)) {
         const rawCode = (response.data as Record<string, unknown>)?.error_code;
-        setLinkError(response.status, rawCode);
-        throw createError(error.value ?? t('web.link_sso.errors.generic'), 'human', 'error');
+        const message = setLinkError(response.status, rawCode);
+        throw createError(message, 'human', 'error');
       }
 
       return validated;

--- a/src/tests/apps/session/views/LinkSso.spec.ts
+++ b/src/tests/apps/session/views/LinkSso.spec.ts
@@ -1,0 +1,323 @@
+// src/tests/apps/session/views/LinkSso.spec.ts
+
+import { mount, flushPromises, VueWrapper } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { defineComponent, ref } from 'vue';
+import { createI18n } from 'vue-i18n';
+import type { LinkSsoChallenge } from '@/schemas/api/auth/responses/auth';
+import type { LinkSsoErrorCode } from '@/shared/composables/useLinkSso';
+
+// Router: controllable route (params.token, query.redirect) + spyable push.
+const mockPush = vi.fn();
+const mockRoute: { params: Record<string, unknown>; query: Record<string, unknown> } = {
+  params: {},
+  query: {},
+};
+vi.mock('vue-router', () => ({
+  useRoute: () => mockRoute,
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// AuthView: render named slots inline so slot content is testable.
+vi.mock('@/apps/session/components/AuthView.vue', () => ({
+  default: defineComponent({
+    name: 'AuthView',
+    template: `<div data-testid="auth-view"><slot name="form" /><slot name="footer" /></div>`,
+    props: ['heading', 'headingId', 'withSubheading', 'showReturnHome', 'title', 'titleLogo'],
+  }),
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-icon="name" />',
+    props: ['collection', 'name', 'class'],
+  },
+}));
+
+// Auth store: controllable auth state + spyable setAuthenticated.
+const mockSetAuthenticated = vi.fn();
+const mockAuthStore = { isFullyAuthenticated: false, setAuthenticated: mockSetAuthenticated };
+vi.mock('@/shared/stores/authStore', () => ({
+  useAuthStore: () => mockAuthStore,
+}));
+
+// Composable: controllable reactive state + spies.
+const mockState = {
+  challenge: ref<LinkSsoChallenge | null>(null),
+  isLoading: ref(false),
+  error: ref<string | null>(null),
+  errorCode: ref<LinkSsoErrorCode>(null),
+  fetchChallenge: vi.fn(),
+  verifyLink: vi.fn(),
+  clearError: vi.fn(),
+};
+vi.mock('@/shared/composables/useLinkSso', () => ({
+  useLinkSso: () => mockState,
+}));
+
+import LinkSso from '@/apps/session/views/LinkSso.vue';
+
+// Pass-through i18n (keys render as-is), EXCEPT the prompt is given a real
+// interpolating message so the provider label + claimed email are observable in
+// the rendered text (the pass-through `missing` handler drops interpolation).
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  missingWarn: false,
+  fallbackWarn: false,
+  missing: (_: unknown, key: string) => key,
+  messages: {
+    en: {
+      web: {
+        link_sso: {
+          prompt: 'You signed in with {provider}, matching {email}.',
+        },
+      },
+    },
+  },
+});
+
+const makeChallenge = (overrides: Partial<LinkSsoChallenge> = {}): LinkSsoChallenge => ({
+  provider: 'entra',
+  email: 'user@example.com',
+  ...overrides,
+});
+
+/**
+ * LinkSso Component Tests (#3840 Phase 3 — sign-in interstitial)
+ *
+ * Verifies the password-proof interstitial an unauthenticated SSO sign-in is
+ * redirected to when its IdP email matches an existing password account:
+ * - fetches the challenge context on mount and names provider + claimed email
+ * - collects the EXISTING password and completes sign-in on success
+ * - keeps the user on the form for a wrong password (retry)
+ * - dead-ends (settings pointer) for a missing / expired / spent token
+ * - cancel routes to /signin carrying the Connected Identities destination
+ */
+describe('LinkSso', () => {
+  let wrapper: VueWrapper;
+
+  const mountComponent = () => mount(LinkSso, { global: { plugins: [i18n] } });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRoute.params = { token: 'challenge-token-123' };
+    mockRoute.query = {};
+    mockState.challenge.value = null;
+    mockState.isLoading.value = false;
+    mockState.error.value = null;
+    mockState.errorCode.value = null;
+    mockState.fetchChallenge.mockResolvedValue(makeChallenge());
+    mockState.verifyLink.mockResolvedValue({ success: 'ok' });
+    mockAuthStore.isFullyAuthenticated = false;
+  });
+
+  afterEach(() => {
+    if (wrapper) wrapper.unmount();
+  });
+
+  describe('Mount / challenge fetch', () => {
+    it('fetches the challenge with the token from the route path param', async () => {
+      wrapper = mountComponent();
+      await flushPromises();
+      expect(mockState.fetchChallenge).toHaveBeenCalledWith('challenge-token-123');
+    });
+
+    it('redirects a fully authenticated user home and does not fetch', async () => {
+      mockAuthStore.isFullyAuthenticated = true;
+      wrapper = mountComponent();
+      await flushPromises();
+      expect(mockPush).toHaveBeenCalledWith('/');
+      expect(mockState.fetchChallenge).not.toHaveBeenCalled();
+    });
+
+    it('dead-ends without fetching when the token is missing', async () => {
+      mockRoute.params = {};
+      wrapper = mountComponent();
+      await flushPromises();
+      expect(mockState.fetchChallenge).not.toHaveBeenCalled();
+      expect(wrapper.find('[data-testid="link-sso-unavailable"]').exists()).toBe(true);
+    });
+
+    it('dead-ends when the challenge fetch fails (expired / spent token)', async () => {
+      mockState.fetchChallenge.mockResolvedValue(null);
+      wrapper = mountComponent();
+      await flushPromises();
+      expect(wrapper.find('[data-testid="link-sso-unavailable"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="link-sso-password-input"]').exists()).toBe(false);
+    });
+  });
+
+  describe('Challenge display', () => {
+    beforeEach(() => {
+      mockState.challenge.value = makeChallenge();
+    });
+
+    it('names the provider (friendly label) and the claimed email', async () => {
+      wrapper = mountComponent();
+      await flushPromises();
+      const prompt = wrapper.find('[data-testid="link-sso-prompt"]');
+      expect(prompt.exists()).toBe(true);
+      // i18n is pass-through; interpolated params are substituted into the key text.
+      expect(prompt.text()).toContain('Microsoft Entra');
+      expect(prompt.text()).toContain('user@example.com');
+    });
+
+    it('renders the password form', async () => {
+      wrapper = mountComponent();
+      await flushPromises();
+      expect(wrapper.find('[data-testid="link-sso-password-input"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="link-sso-submit"]').exists()).toBe(true);
+    });
+
+    it('falls back to a capitalized provider name for unknown providers', async () => {
+      mockState.challenge.value = makeChallenge({ provider: 'okta' });
+      wrapper = mountComponent();
+      await flushPromises();
+      expect(wrapper.find('[data-testid="link-sso-prompt"]').text()).toContain('Okta');
+    });
+  });
+
+  describe('Verify success', () => {
+    beforeEach(() => {
+      mockState.challenge.value = makeChallenge();
+    });
+
+    it('completes sign-in and navigates to the dashboard by default', async () => {
+      wrapper = mountComponent();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="link-sso-password-input"]').setValue('correct horse');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockState.verifyLink).toHaveBeenCalledWith('challenge-token-123', 'correct horse');
+      expect(mockSetAuthenticated).toHaveBeenCalledWith(true);
+      expect(mockPush).toHaveBeenCalledWith('/');
+    });
+
+    it('prefers the redirect target returned by the backend when it is internal', async () => {
+      mockState.verifyLink.mockResolvedValue({ success: 'ok', redirect: '/dashboard' });
+      wrapper = mountComponent();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="link-sso-password-input"]').setValue('pw');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockPush).toHaveBeenCalledWith('/dashboard');
+    });
+
+    it('falls back to the ?redirect query param when the response carries none', async () => {
+      mockRoute.query = { redirect: '/account/settings' };
+      wrapper = mountComponent();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="link-sso-password-input"]').setValue('pw');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockPush).toHaveBeenCalledWith('/account/settings');
+    });
+
+    it('ignores an external redirect target from the backend', async () => {
+      mockState.verifyLink.mockResolvedValue({ success: 'ok', redirect: 'https://evil.example/' });
+      wrapper = mountComponent();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="link-sso-password-input"]').setValue('pw');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockPush).toHaveBeenCalledWith('/');
+    });
+
+    it('does not submit an empty password', async () => {
+      wrapper = mountComponent();
+      await flushPromises();
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+      expect(mockState.verifyLink).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Verify failure', () => {
+    beforeEach(() => {
+      mockState.challenge.value = makeChallenge();
+    });
+
+    it('keeps the user on the form and clears the password on a wrong password', async () => {
+      mockState.verifyLink.mockImplementation(async () => {
+        mockState.errorCode.value = 'invalid_password';
+        mockState.error.value = 'web.link_sso.errors.invalid_password';
+        return null;
+      });
+      wrapper = mountComponent();
+      await flushPromises();
+
+      const input = wrapper.find<HTMLInputElement>('[data-testid="link-sso-password-input"]');
+      await input.setValue('wrong');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      // No navigation, still on the form, error surfaced, password cleared.
+      expect(mockSetAuthenticated).not.toHaveBeenCalled();
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(wrapper.find('[data-testid="link-sso-error"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="link-sso-unavailable"]').exists()).toBe(false);
+      expect(input.element.value).toBe('');
+    });
+
+    it('dead-ends to the settings pointer when the token expired mid-flow', async () => {
+      mockState.verifyLink.mockImplementation(async () => {
+        mockState.errorCode.value = 'invalid_token';
+        mockState.error.value = 'web.link_sso.errors.invalid_token';
+        return null;
+      });
+      wrapper = mountComponent();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="link-sso-password-input"]').setValue('pw');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockSetAuthenticated).not.toHaveBeenCalled();
+      expect(wrapper.find('[data-testid="link-sso-unavailable"]').exists()).toBe(true);
+    });
+  });
+
+  describe('Cancel / dead-end navigation', () => {
+    it('cancel routes to /signin carrying the connections destination + pointer', async () => {
+      mockState.challenge.value = makeChallenge();
+      wrapper = mountComponent();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="link-sso-cancel"]').trigger('click');
+
+      expect(mockPush).toHaveBeenCalledWith({
+        path: '/signin',
+        query: {
+          auth_error: 'link_sso_failed',
+          redirect: '/account/settings/security/connections',
+        },
+      });
+    });
+
+    it('the dead-end panel action routes to /signin with the same pointer', async () => {
+      mockState.fetchChallenge.mockResolvedValue(null);
+      wrapper = mountComponent();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="link-sso-unavailable-action"]').trigger('click');
+
+      expect(mockPush).toHaveBeenCalledWith({
+        path: '/signin',
+        query: {
+          auth_error: 'link_sso_failed',
+          redirect: '/account/settings/security/connections',
+        },
+      });
+    });
+  });
+});

--- a/src/tests/apps/session/views/LinkSso.spec.ts
+++ b/src/tests/apps/session/views/LinkSso.spec.ts
@@ -42,6 +42,12 @@ vi.mock('@/shared/stores/authStore', () => ({
   useAuthStore: () => mockAuthStore,
 }));
 
+// Bootstrap store: MFA hand-off marks awaiting_mfa via update() (mirrors Login).
+const mockBootstrapUpdate = vi.fn();
+vi.mock('@/shared/stores/bootstrapStore', () => ({
+  useBootstrapStore: () => ({ update: mockBootstrapUpdate }),
+}));
+
 // Composable: controllable reactive state + spies.
 const mockState = {
   challenge: ref<LinkSsoChallenge | null>(null),
@@ -239,6 +245,48 @@ describe('LinkSso', () => {
       await wrapper.find('form').trigger('submit');
       await flushPromises();
       expect(mockState.verifyLink).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Verify success — MFA required', () => {
+    beforeEach(() => {
+      mockState.challenge.value = makeChallenge();
+    });
+
+    it('does NOT mark fully authenticated and hands off to /mfa-verify', async () => {
+      // MFA account: password proven but a second factor is still required.
+      mockState.verifyLink.mockResolvedValue({ success: 'ok', mfa_required: true });
+      wrapper = mountComponent();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="link-sso-password-input"]').setValue('correct pw');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      // Not fully authenticated — the OTP challenge is not skipped.
+      expect(mockSetAuthenticated).not.toHaveBeenCalled();
+      // Marked awaiting MFA so the route guard permits /mfa-verify (mirrors Login).
+      expect(mockBootstrapUpdate).toHaveBeenCalledWith({
+        awaiting_mfa: true,
+        authenticated: false,
+      });
+      expect(mockPush).toHaveBeenCalledWith({ path: '/mfa-verify', query: undefined });
+    });
+
+    it('preserves the ?redirect query when handing off to /mfa-verify', async () => {
+      mockRoute.query = { redirect: '/account/settings' };
+      mockState.verifyLink.mockResolvedValue({ success: 'ok', mfa_required: true });
+      wrapper = mountComponent();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="link-sso-password-input"]').setValue('pw');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockPush).toHaveBeenCalledWith({
+        path: '/mfa-verify',
+        query: { redirect: '/account/settings' },
+      });
     });
   });
 

--- a/src/tests/composables/useLinkSso.spec.ts
+++ b/src/tests/composables/useLinkSso.spec.ts
@@ -1,0 +1,213 @@
+// src/tests/composables/useLinkSso.spec.ts
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useLinkSso } from '@/shared/composables/useLinkSso';
+import { setupTestPinia } from '../setup';
+import type AxiosMockAdapter from 'axios-mock-adapter';
+
+// Pass-through i18n: keys render as-is so assertions can match on the key.
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+// CSRF store: verifyLink includes csrfStore.shrimp in the POST body.
+vi.mock('@/shared/stores/csrfStore', () => ({
+  useCsrfStore: () => ({ shrimp: 'test-shrimp' }),
+}));
+
+/**
+ * useLinkSso Composable Tests (#3840 Phase 3 — sign-in interstitial)
+ *
+ * Verifies the GET challenge-context fetch and POST password verify, plus the
+ * typed error classification the view branches on:
+ * - invalid_password (retryable) vs invalid_token (dead-end)
+ * - distinguished by HTTP status AND an optional backend { error_code }
+ */
+describe('useLinkSso', () => {
+  let axiosMock: AxiosMockAdapter;
+
+  beforeEach(async () => {
+    const setup = await setupTestPinia();
+    axiosMock = setup.axiosMock!;
+  });
+
+  afterEach(() => {
+    axiosMock.restore();
+    vi.clearAllMocks();
+  });
+
+  describe('fetchChallenge', () => {
+    it('returns the display context on success', async () => {
+      axiosMock
+        .onGet('/auth/link-sso/tok123')
+        .reply(200, { provider: 'entra', email: 'user@example.com' });
+
+      const { fetchChallenge, challenge, error, errorCode } = useLinkSso();
+      const result = await fetchChallenge('tok123');
+
+      expect(result).toEqual({ provider: 'entra', email: 'user@example.com' });
+      expect(challenge.value).toEqual({ provider: 'entra', email: 'user@example.com' });
+      expect(error.value).toBeNull();
+      expect(errorCode.value).toBeNull();
+    });
+
+    it('url-encodes the token in the path', async () => {
+      axiosMock.onGet('/auth/link-sso/a%2Fb').reply(200, { provider: 'oidc', email: 'a@b.com' });
+
+      const { fetchChallenge } = useLinkSso();
+      const result = await fetchChallenge('a/b');
+
+      expect(result).toEqual({ provider: 'oidc', email: 'a@b.com' });
+    });
+
+    it('dead-ends (invalid_token) when the token is not found (404)', async () => {
+      axiosMock.onGet('/auth/link-sso/gone').reply(404, { error: 'not found' });
+
+      const { fetchChallenge, challenge, error, errorCode } = useLinkSso();
+      const result = await fetchChallenge('gone');
+
+      expect(result).toBeNull();
+      expect(challenge.value).toBeNull();
+      expect(errorCode.value).toBe('invalid_token');
+      expect(error.value).toBe('web.link_sso.errors.invalid_token');
+    });
+
+    it('dead-ends (invalid_token) when the token is gone (410)', async () => {
+      axiosMock.onGet('/auth/link-sso/spent').reply(410, { error: 'gone' });
+
+      const { fetchChallenge, errorCode } = useLinkSso();
+      const result = await fetchChallenge('spent');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('invalid_token');
+    });
+
+    it('treats a 200 error body as a spent token', async () => {
+      axiosMock.onGet('/auth/link-sso/weird').reply(200, { error: 'expired' });
+
+      const { fetchChallenge, errorCode } = useLinkSso();
+      const result = await fetchChallenge('weird');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('invalid_token');
+    });
+  });
+
+  describe('verifyLink', () => {
+    it('returns the success body (with redirect) on 200', async () => {
+      axiosMock
+        .onPost('/auth/link-sso')
+        .reply(200, { success: 'linked', redirect: '/dashboard' });
+
+      const { verifyLink, error, errorCode } = useLinkSso();
+      const result = await verifyLink('tok123', 'correct-password');
+
+      expect(result).toEqual({ success: 'linked', redirect: '/dashboard' });
+      expect(error.value).toBeNull();
+      expect(errorCode.value).toBeNull();
+    });
+
+    it('accepts a success body without a redirect target', async () => {
+      axiosMock.onPost('/auth/link-sso').reply(200, { success: 'linked' });
+
+      const { verifyLink } = useLinkSso();
+      const result = await verifyLink('tok123', 'pw');
+
+      expect(result).toEqual({ success: 'linked' });
+    });
+
+    it('sends the token, password, and shrimp', async () => {
+      axiosMock.onPost('/auth/link-sso').reply(200, { success: 'linked' });
+
+      const { verifyLink } = useLinkSso();
+      await verifyLink('tok123', 'sekret');
+
+      const body = JSON.parse(axiosMock.history.post[0].data);
+      expect(body).toEqual({ token: 'tok123', password: 'sekret', shrimp: 'test-shrimp' });
+    });
+
+    it('classifies a wrong password (403) as invalid_password (retryable)', async () => {
+      axiosMock.onPost('/auth/link-sso').reply(403, { error: 'invalid credentials' });
+
+      const { verifyLink, error, errorCode } = useLinkSso();
+      const result = await verifyLink('tok123', 'wrong');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('invalid_password');
+      expect(error.value).toBe('web.link_sso.errors.invalid_password');
+    });
+
+    it('honors an explicit error_code (invalid_password) over the status', async () => {
+      axiosMock
+        .onPost('/auth/link-sso')
+        .reply(401, { error: 'nope', error_code: 'invalid_password' });
+
+      const { verifyLink, errorCode } = useLinkSso();
+      const result = await verifyLink('tok123', 'wrong');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('invalid_password');
+    });
+
+    it('classifies an expired token (410) as invalid_token (dead-end)', async () => {
+      axiosMock.onPost('/auth/link-sso').reply(410, { error: 'expired' });
+
+      const { verifyLink, error, errorCode } = useLinkSso();
+      const result = await verifyLink('tok123', 'pw');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('invalid_token');
+      expect(error.value).toBe('web.link_sso.errors.invalid_token');
+    });
+
+    it('honors an explicit error_code (invalid_token) on a 403', async () => {
+      axiosMock
+        .onPost('/auth/link-sso')
+        .reply(403, { error: 'stale', error_code: 'invalid_token' });
+
+      const { verifyLink, errorCode } = useLinkSso();
+      const result = await verifyLink('tok123', 'pw');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('invalid_token');
+    });
+
+    it('treats a 200 error body carrying invalid_token as a dead-end', async () => {
+      axiosMock
+        .onPost('/auth/link-sso')
+        .reply(200, { error: 'stale', error_code: 'invalid_token' });
+
+      const { verifyLink, errorCode } = useLinkSso();
+      const result = await verifyLink('tok123', 'pw');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('invalid_token');
+    });
+
+    it('falls back to a generic error for an unclassifiable failure (500)', async () => {
+      axiosMock.onPost('/auth/link-sso').reply(500);
+
+      const { verifyLink, error, errorCode } = useLinkSso();
+      const result = await verifyLink('tok123', 'pw');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBeNull();
+      expect(error.value).toBe('web.link_sso.errors.generic');
+    });
+  });
+
+  describe('clearError', () => {
+    it('resets both error and errorCode', async () => {
+      axiosMock.onPost('/auth/link-sso').reply(403, { error: 'nope' });
+
+      const { verifyLink, clearError, error, errorCode } = useLinkSso();
+      await verifyLink('tok123', 'wrong');
+      expect(error.value).not.toBeNull();
+      expect(errorCode.value).toBe('invalid_password');
+
+      clearError();
+      expect(error.value).toBeNull();
+      expect(errorCode.value).toBeNull();
+    });
+  });
+});

--- a/src/tests/composables/useLinkSso.spec.ts
+++ b/src/tests/composables/useLinkSso.spec.ts
@@ -160,6 +160,43 @@ describe('useLinkSso', () => {
       expect(error.value).toBe('web.link_sso.errors.invalid_token');
     });
 
+    // Backend returns 401 (not 404/410) with error_code 'link_expired' for a
+    // consumed/expired token. Without the explicit code mapping the 401 would
+    // fall through to invalid_password (retryable) — but the token is single-use,
+    // so a retry can never succeed. It MUST dead-end.
+    it('classifies a spent token (401 link_expired) as invalid_token (dead-end)', async () => {
+      axiosMock
+        .onPost('/auth/link-sso')
+        .reply(401, { error: 'expired', error_code: 'link_expired' });
+
+      const { verifyLink, error, errorCode } = useLinkSso();
+      const result = await verifyLink('tok123', 'pw');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('invalid_token');
+      expect(error.value).toBe('web.link_sso.errors.invalid_token');
+    });
+
+    // MFA account: the backend returns the SAME body POST /auth/login returns for
+    // MFA. The schema must NOT strip mfa_required (else the view would mark the
+    // user fully authenticated and skip the OTP challenge).
+    it('preserves mfa_required (does not strip it) on a 200 MFA response', async () => {
+      axiosMock
+        .onPost('/auth/link-sso')
+        .reply(200, { success: 'ok', mfa_required: true, mfa_methods: ['otp'] });
+
+      const { verifyLink, error, errorCode } = useLinkSso();
+      const result = await verifyLink('tok123', 'correct-password');
+
+      expect(result).toMatchObject({
+        success: 'ok',
+        mfa_required: true,
+        mfa_methods: ['otp'],
+      });
+      expect(error.value).toBeNull();
+      expect(errorCode.value).toBeNull();
+    });
+
     it('honors an explicit error_code (invalid_token) on a 403', async () => {
       axiosMock
         .onPost('/auth/link-sso')


### PR DESCRIPTION
## Summary

Phase 3 of #3840 (#3838 item 1b): the SSO **sign-in** interstitial. When an SSO callback matches an existing local account, the omniauth hook now branches to a single-use password-challenge flow instead of silently binding, closing the account-takeover gap Phase 2 left for password-backed accounts.

- New `SsoLinkChallenge` model — single-use, TTL'd password-challenge token.
- New `/auth/link-sso` Roda route + `useLinkSso` composable + `LinkSso.vue` interstitial.
- Omniauth hook branches to the interstitial on sign-in identity match; response schemas + i18n added.
- Security-reviewed and fixed: tenant-surface guard on the interstitial branch (HIGH) + regression, rate-limiting via `Onetime::Security::LoginRateLimiter` (MEDIUM), migration coverage (INFO).

## Tests

- Interstitial integration: 10/0
- P0/P1/P2 guardrails + hook unit: 133/0
- Frontend vitest (LinkSso + useLinkSso): 31/31

Resolves #3838 (item 1b). Related to #3840.

Base is the orchestration branch, not main — orchestration merges to main separately.