### PR TITLE
[#3840] Phase 4.0: extract BindSsoIdentity shared bind primitive

### DIFF
--- a/apps/web/auth/operations.rb
+++ b/apps/web/auth/operations.rb
@@ -14,6 +14,7 @@ require_relative 'operations/set_customer_verification'
 require_relative 'operations/disable_mfa'
 require_relative 'operations/detect_mfa_requirement'
 require_relative 'operations/mfa_state_checker'
+require_relative 'operations/bind_sso_identity'
 require_relative 'operations/prepare_mfa_session'
 require_relative 'operations/migrate_password_from_redis'
 

--- a/apps/web/auth/operations/bind_sso_identity.rb
+++ b/apps/web/auth/operations/bind_sso_identity.rb
@@ -33,9 +33,25 @@
 # The `db` is passed EXPLICITLY (not rodauth.db) so the op is usable outside a
 # Rodauth request context — e.g. a background bind completed after MFA (#3877).
 #
+# TRANSACTION SAFETY:
+#   The insert is wrapped in a SAVEPOINT (db.transaction(savepoint: true)) so a
+#   concurrent-bind UniqueConstraintViolation rolls back ONLY that statement, not
+#   an ambient caller transaction. This matters for the deferred bind after MFA
+#   (#3877): Rodauth runs `after_two_factor_authentication` INSIDE `transaction do`
+#   for the WebAuthn (webauthn.rb) and SMS (sms_codes.rb) second factors. Without
+#   the savepoint, on PostgreSQL the violation would abort that outer transaction —
+#   the re-read below would then raise PG::InFailedSqlTransaction and the whole MFA
+#   transaction would roll back. Called OUTSIDE a transaction (the password-challenge
+#   interstitial), the savepoint degrades to a plain single-statement transaction.
+#
 # Returns:
 #   :ok       — row inserted, OR already present for the SAME account (idempotent)
-#   :conflict — the (provider, issuer, uid) row is owned by a DIFFERENT account
+#   :conflict — the (provider, issuer, uid) row is owned by a DIFFERENT account,
+#               OR ownership could not be confirmed (the winner vanished between the
+#               violation and the re-read). NEVER a success: callers must not log the
+#               caller in onto that identity. A post-authentication caller with no
+#               error surface (4.A's deferred bind — MFA already succeeded) must
+#               audit-and-skip on :conflict, never raise and never fail the login.
 #
 # Example:
 #   result = Auth::Operations::BindSsoIdentity.call(
@@ -78,11 +94,17 @@ module Auth
         existing = dataset.where(@criteria).first
         return owned_or_conflict(existing) if existing
 
-        dataset.insert(@criteria.merge(account_id: @account_id))
+        # SAVEPOINT so a losing-race violation cannot poison an ambient caller
+        # transaction (see TRANSACTION SAFETY above). Degrades to a plain
+        # transaction when not already inside one.
+        @db.transaction(savepoint: true) do
+          dataset.insert(@criteria.merge(account_id: @account_id))
+        end
         :ok
       rescue Sequel::UniqueConstraintViolation
-        # A concurrent bind inserted the row first — re-read and apply the SAME
-        # ownership check to the winner.
+        # A concurrent bind inserted the row first; the savepoint rolled back to
+        # before our insert, so the outer transaction (if any) is still healthy.
+        # Re-read and apply the SAME ownership check to the winner.
         owned_or_conflict(dataset.where(@criteria).first)
       end
 
@@ -93,7 +115,11 @@ module Auth
       end
 
       # :ok when the existing identity row belongs to the account we authenticated,
-      # :conflict otherwise (including a row that vanished between checks).
+      # :conflict otherwise. A nil row — the winner vanished between the violation and
+      # the re-read, or was never found — is :conflict, i.e. "could not confirm this
+      # row is yours." It is NEVER upgraded to :ok, so a mismatch (or an unconfirmable
+      # race) can never masquerade as a successful bind. See the :conflict caller
+      # contract in the Returns doc above.
       def owned_or_conflict(row)
         row && row[:account_id].to_s == @account_id.to_s ? :ok : :conflict
       end

--- a/apps/web/auth/operations/bind_sso_identity.rb
+++ b/apps/web/auth/operations/bind_sso_identity.rb
@@ -1,0 +1,102 @@
+# apps/web/auth/operations/bind_sso_identity.rb
+#
+# frozen_string_literal: true
+
+#
+# Idempotent, issuer-scoped insert of an SSO identity row for a PROVEN account.
+#
+# This is the shared bind primitive (#3840 Phase 4), extracted verbatim from the
+# password-challenge interstitial (Auth::Routes::LinkSso) so every linking surface
+# that has ALREADY authorized a bind reuses the SAME ownership semantics:
+#   - the password-challenge interstitial (Auth::Routes::LinkSso),
+#   - deferred bind after MFA (#3877),
+#   - mailbox-proof passwordless linking (Phase 4.B).
+#
+# It does NOT decide WHETHER a bind is authorized — the caller owns that decision
+# (password proof, MFA completion, mailbox proof). This operation only performs
+# the insert safely and reports whether the resulting row belongs to `account_id`.
+#
+# SECURITY MODEL:
+#   The column shape mirrors omniauth_identity_insert_hash
+#   (config/features/omniauth.rb): { account_id, provider, uid, issuer }. `issuer`
+#   is coerced to the '' sentinel (NEVER nil) so it matches the
+#   (provider, issuer, uid) unique index that issuer-scoped identities depend on
+#   (#3838 — a NULL vs '' split would break the index).
+#
+#   The unique index on (provider, issuer, uid) plus "challenge minted only when
+#   no identity row exists" makes cross-account escalation impossible, so :conflict
+#   only ever fires as a benign idempotency guard — but ownership is verified at
+#   BOTH the pre-SELECT and the concurrent-insert (UniqueConstraintViolation) site
+#   so a mismatch can never masquerade as success (i.e. log the caller in onto an
+#   identity that is not theirs).
+#
+# The `db` is passed EXPLICITLY (not rodauth.db) so the op is usable outside a
+# Rodauth request context — e.g. a background bind completed after MFA (#3877).
+#
+# Returns:
+#   :ok       — row inserted, OR already present for the SAME account (idempotent)
+#   :conflict — the (provider, issuer, uid) row is owned by a DIFFERENT account
+#
+# Example:
+#   result = Auth::Operations::BindSsoIdentity.call(
+#     db: rodauth.db,
+#     account_id: account_id,
+#     provider: challenge.provider,
+#     issuer: challenge.issuer,
+#     uid: challenge.uid,
+#   )
+#   # => :ok | :conflict
+#
+module Auth
+  module Operations
+    class BindSsoIdentity
+      IDENTITIES_TABLE = :account_identities
+
+      # @param db [Sequel::Database] the auth database (explicit — NOT rodauth.db,
+      #   so the op is usable outside a Rodauth request context)
+      # @param account_id [Integer, String] the proven account the identity binds to
+      # @param provider [String] OmniAuth provider name
+      # @param issuer [String, nil] resolved IdP issuer; nil → '' sentinel
+      # @param uid [String] provider-scoped subject id
+      # @return [:ok, :conflict]
+      def self.call(db:, account_id:, provider:, issuer:, uid:)
+        new(db: db, account_id: account_id, provider: provider, issuer: issuer, uid: uid).call
+      end
+
+      def initialize(db:, account_id:, provider:, issuer:, uid:)
+        @db         = db
+        @account_id = account_id
+        @criteria   = {
+          provider: provider,
+          issuer: issuer.to_s,
+          uid: uid,
+        }
+      end
+
+      # @return [:ok, :conflict]
+      def call
+        existing = dataset.where(@criteria).first
+        return owned_or_conflict(existing) if existing
+
+        dataset.insert(@criteria.merge(account_id: @account_id))
+        :ok
+      rescue Sequel::UniqueConstraintViolation
+        # A concurrent bind inserted the row first — re-read and apply the SAME
+        # ownership check to the winner.
+        owned_or_conflict(dataset.where(@criteria).first)
+      end
+
+      private
+
+      def dataset
+        @db[IDENTITIES_TABLE]
+      end
+
+      # :ok when the existing identity row belongs to the account we authenticated,
+      # :conflict otherwise (including a row that vanished between checks).
+      def owned_or_conflict(row)
+        row && row[:account_id].to_s == @account_id.to_s ? :ok : :conflict
+      end
+    end
+  end
+end

--- a/apps/web/auth/routes/link_sso.rb
+++ b/apps/web/auth/routes/link_sso.rb
@@ -205,10 +205,18 @@ module Auth
                   provider: challenge.provider,
                 }
             else
-              # Fully authenticated by password alone -> safe to bind now. Shape
-              # mirrors omniauth_identity_insert_hash (config/features/omniauth.rb):
-              # { account_id, provider, uid, issuer }.
-              if bind_sso_identity(challenge, account_id) == :conflict
+              # Fully authenticated by password alone -> safe to bind now. Shared
+              # bind primitive (#3840 Phase 4): idempotent, issuer-scoped insert
+              # whose column shape mirrors omniauth_identity_insert_hash
+              # (config/features/omniauth.rb): { account_id, provider, uid, issuer }.
+              bind_result = Auth::Operations::BindSsoIdentity.call(
+                db: rodauth.db,
+                account_id: account_id,
+                provider: challenge.provider,
+                issuer: challenge.issuer,
+                uid: challenge.uid,
+              )
+              if bind_result == :conflict
                 # Item 3 defence-in-depth: the (provider, issuer, uid) row is already
                 # owned by a DIFFERENT account. Never report success (that would log
                 # the caller in as if the identity were theirs) — surface a conflict.
@@ -280,42 +288,6 @@ module Auth
           token: (parsed['token'] || request.params['token']).to_s,
           password: (parsed['password'] || request.params['password']).to_s,
         }
-      end
-
-      # Insert the identity row for the proven account, issuer-scoped and
-      # idempotent. Returns :ok when the row is inserted OR already exists for the
-      # SAME account. Returns :conflict when a row for this (provider, issuer, uid)
-      # already exists for a DIFFERENT account — the caller surfaces that as 409
-      # link_conflict rather than logging the user in onto an identity that is not
-      # theirs (#3840 review, Item 3 defence-in-depth). The unique index on
-      # (provider, issuer, uid) plus "challenge minted only when no identity row
-      # exists" makes cross-account escalation impossible, so this only ever fires
-      # as a benign idempotency guard — but we verify ownership at BOTH the
-      # pre-check and the concurrent-insert (UniqueConstraintViolation) site so a
-      # mismatch can never masquerade as success.
-      def bind_sso_identity(challenge, account_id)
-        ds       = rodauth.db[:account_identities]
-        criteria = {
-          provider: challenge.provider,
-          issuer: challenge.issuer.to_s,
-          uid: challenge.uid,
-        }
-
-        existing = ds.where(criteria).first
-        return owned_or_conflict(existing, account_id) if existing
-
-        ds.insert(criteria.merge(account_id: account_id))
-        :ok
-      rescue Sequel::UniqueConstraintViolation
-        # A concurrent bind inserted the row first — re-read and apply the SAME
-        # ownership check to the winner.
-        owned_or_conflict(ds.where(criteria).first, account_id)
-      end
-
-      # :ok when the existing identity row belongs to the account we authenticated,
-      # :conflict otherwise (including a row that vanished between checks).
-      def owned_or_conflict(row, account_id)
-        row && row[:account_id].to_s == account_id.to_s ? :ok : :conflict
       end
 
       # Would completing this PASSWORD login leave a second factor pending? Mirrors

--- a/apps/web/auth/spec/operations/bind_sso_identity_spec.rb
+++ b/apps/web/auth/spec/operations/bind_sso_identity_spec.rb
@@ -5,43 +5,56 @@
 # Unit tests for Auth::Operations::BindSsoIdentity (#3840 Phase 4).
 #
 # The shared bind primitive: an idempotent, issuer-scoped insert of an SSO
-# identity row for an already-PROVEN account. Covers every branch of the safe
-# insert:
-#   - fresh insert -> :ok
-#   - pre-existing row, SAME account -> :ok (idempotent)
-#   - pre-existing row, DIFFERENT account -> :conflict
-#   - concurrent insert (UniqueConstraintViolation) re-read -> :ok / :conflict
-#   - nil issuer coerced to the '' sentinel (issuer-scoped unique index, #3838)
-#   - string/int account_id ownership comparison is coercion-safe
+# identity row for an already-PROVEN account.
 #
-# The db is a Sequel-shaped double: db[:account_identities] exposes .where(...)
-# (-> filtered dataset responding to #first) and #insert(...). No real DB — the
-# end-to-end conflict path is already covered by
-# spec/integration/full/omniauth_signin_interstitial_spec.rb.
+# These run against a REAL in-memory SQLite account_identities table carrying the
+# REAL (provider, issuer, uid) unique index — RodauthTestHelper.create_test_database
+# mirrors migration 008 (see apps/web/auth/spec/spec_helper.rb), the same schema
+# the config-feature specs build on. That matters: the two guarantees this
+# primitive exists to provide can only be shown against a real index, not a
+# stubbed dataset —
+#   - the '' issuer SENTINEL actually collapses `nil` and '' onto ONE index slot
+#     (#3838 — a NULL vs '' split would silently defeat issuer-scoping), and
+#   - ownership actually HOLDS: a duplicate (provider, issuer, uid) is rejected by
+#     the index, so :conflict is a real decision about a real row, never a branch
+#     that only fires because a double was told to return it.
+# The one exception is the concurrent-insert rescue: the SELECT-then-INSERT race
+# window can't be produced single-threaded, so ONLY the pre-SELECT "miss" is
+# simulated — the UniqueConstraintViolation and the ownership re-read both hit the
+# real DB.
+#
+# The end-to-end HTTP path (challenge -> password proof -> bind) lives in
+# spec/integration/full/omniauth_signin_interstitial_spec.rb; this file locks the
+# primitive's decision table in isolation.
 #
 # Run: pnpm run test:rspec apps/web/auth/spec/operations/bind_sso_identity_spec.rb
 
-require 'spec_helper'
+require_relative '../spec_helper'
 require 'auth/operations/bind_sso_identity'
 
 RSpec.describe Auth::Operations::BindSsoIdentity do
-  let(:account_id) { 5 }
-  let(:provider)   { 'google' }
-  let(:issuer)     { 'https://accounts.google.com' }
-  let(:uid)        { 'sub-123' }
-  let(:criteria)   { { provider: provider, issuer: issuer, uid: uid } }
+  # Fresh real DB per example (in-memory SQLite) -> perfect isolation, no cleanup.
+  let(:db)         { create_test_database }
+  let(:identities) { db[:account_identities] }
 
-  let(:identities) { double('identities_dataset') }
-  let(:filtered)   { double('filtered_dataset') }
-  let(:db)         { double('db') }
+  let(:provider) { 'google' }
+  let(:issuer)   { 'https://accounts.google.com' }
+  let(:uid)      { 'sub-123' }
+  let(:criteria) { { provider: provider, issuer: issuer, uid: uid } }
 
-  before do
-    allow(db).to receive(:[]).with(:account_identities).and_return(identities)
-    allow(identities).to receive(:where).and_return(filtered)
-    allow(identities).to receive(:insert)
+  # The account we authenticate as (seeded lazily the first time it's referenced).
+  let(:account_id) { seed_account(5) }
+
+  # account_identities.account_id is a NOT NULL foreign key -> accounts(id), and
+  # Sequel enables SQLite foreign_keys by default, so every account referenced by
+  # an inserted identity row must exist first.
+  def seed_account(id)
+    db[:accounts].insert(
+      id: id, email: "acct-#{id}@example.com", status_id: AuthTestConstants::STATUS_VERIFIED,
+    )
+    id
   end
 
-  # Invoke via the public class method with per-example overrides.
   def bind(**overrides)
     described_class.call(
       db: db,
@@ -53,93 +66,142 @@ RSpec.describe Auth::Operations::BindSsoIdentity do
   end
 
   describe 'fresh insert' do
-    before { allow(filtered).to receive(:first).and_return(nil) }
-
-    it 'inserts the identity row and returns :ok' do
+    it 'inserts the identity row on the proven account and returns :ok' do
       expect(bind).to eq(:ok)
 
-      expect(identities).to have_received(:insert)
-        .with(hash_including(account_id: account_id, provider: provider, issuer: issuer, uid: uid))
-    end
-
-    it 'selects on the (provider, issuer, uid) criteria' do
-      bind
-      expect(identities).to have_received(:where).with(criteria)
+      rows = identities.where(criteria).all
+      expect(rows.size).to eq(1)
+      expect(rows.first).to include(
+        account_id: account_id, provider: provider, issuer: issuer, uid: uid,
+      )
     end
   end
 
-  describe 'pre-existing row (idempotency guard)' do
-    it 'returns :ok without inserting when the row belongs to the SAME account' do
-      allow(filtered).to receive(:first).and_return({ account_id: account_id })
+  describe 'idempotency guard' do
+    it 'returns :ok without a duplicate when the row already belongs to the SAME account' do
+      identities.insert(criteria.merge(account_id: account_id))
 
       expect(bind).to eq(:ok)
-      expect(identities).not_to have_received(:insert)
+      expect(identities.where(criteria).count).to eq(1)
     end
 
-    it 'returns :conflict without inserting when the row belongs to a DIFFERENT account' do
-      allow(filtered).to receive(:first).and_return({ account_id: 999 })
+    it 'returns :conflict and binds nothing when the row belongs to a DIFFERENT account' do
+      other = seed_account(999)
+      identities.insert(criteria.merge(account_id: other))
 
       expect(bind).to eq(:conflict)
-      expect(identities).not_to have_received(:insert)
+
+      # The single existing row is untouched — nothing was bound onto our account.
+      rows = identities.where(criteria).all
+      expect(rows.size).to eq(1)
+      expect(rows.first[:account_id]).to eq(other)
     end
 
-    it 'compares account_id as strings (int row vs string caller)' do
-      allow(filtered).to receive(:first).and_return({ account_id: 5 })
+    it 'matches a STRING caller account_id against the INTEGER DB row (:ok)' do
+      # rodauth.account_id is an Integer, but the primitive was extracted for the
+      # #3877 / 4.B callers that bind from OUTSIDE a Rodauth request with a
+      # Redis-sourced STRING account_id. The column is Bignum, so the row always
+      # reads back Integer -> the op coerces both sides to compare cleanly. The
+      # reverse (a String-typed DB row) is not a shape a Bignum column can yield,
+      # so it is intentionally not exercised here.
+      identities.insert(criteria.merge(account_id: account_id)) # account_id == 5 (Integer)
 
-      expect(bind(account_id: '5')).to eq(:ok)
-    end
-
-    it 'compares account_id as strings (string row vs int caller)' do
-      allow(filtered).to receive(:first).and_return({ account_id: '5' })
-
-      expect(bind(account_id: 5)).to eq(:ok)
+      expect(bind(account_id: account_id.to_s)).to eq(:ok)
     end
   end
 
-  describe 'concurrent insert (Sequel::UniqueConstraintViolation)' do
-    before do
-      # Pre-SELECT sees nothing; the insert loses the race; re-read finds the winner.
-      allow(identities).to receive(:insert).and_raise(Sequel::UniqueConstraintViolation)
+  describe 'issuer sentinel (#3838 issuer-scoped unique index)' do
+    it 'persists a nil issuer as the empty-string sentinel (never NULL)' do
+      expect(bind(issuer: nil)).to eq(:ok)
+
+      row = identities.where(provider: provider, uid: uid).first
+      expect(row[:issuer]).to eq('')
     end
 
-    it 'returns :ok when the winning row belongs to the SAME account' do
-      allow(filtered).to receive(:first).and_return(nil, { account_id: account_id })
+    it 'collapses nil and "" onto the SAME index slot: a different account conflicts' do
+      other = seed_account(999)
+      # Another account already holds the row under the EXPLICIT '' sentinel...
+      identities.insert(provider: provider, issuer: '', uid: uid, account_id: other)
 
-      expect(bind).to eq(:ok)
+      # ...so a nil-issuer bind for our account resolves to the SAME
+      # (provider, '', uid) row and is refused. If nil did not coerce to '' this
+      # would insert a second, index-splitting row instead — the #3838 regression.
+      expect(bind(issuer: nil)).to eq(:conflict)
+      expect(identities.where(provider: provider, uid: uid).count).to eq(1)
+    end
+  end
+
+  describe 'the (provider, issuer, uid) unique index the op depends on' do
+    it 'really rejects a duplicate insert with Sequel::UniqueConstraintViolation' do
+      identities.insert(criteria.merge(account_id: account_id))
+      other = seed_account(999)
+
+      # This is the DB fact the concurrent-insert rescue below is built on; assert
+      # it directly rather than fake it with allow(insert).to raise.
+      expect { identities.insert(criteria.merge(account_id: other)) }
+        .to raise_error(Sequel::UniqueConstraintViolation)
+    end
+  end
+
+  describe 'concurrent insert loses the race (Sequel::UniqueConstraintViolation rescue)' do
+    # Drive the op with only its pre-SELECT forced to miss — i.e. our SELECT ran
+    # in the window before the winning insert committed. The insert then hits the
+    # REAL index and raises a REAL UniqueConstraintViolation, and the rescue
+    # re-reads the REAL winning row to decide ownership. `on_reread` lets a test
+    # mutate the table just before the re-read (to model the winner vanishing).
+    def bind_losing_the_preselect(account_id:, on_reread: nil)
+      op    = described_class.new(
+        db: db, account_id: account_id, provider: provider, issuer: issuer, uid: uid,
+      )
+      calls = 0
+      allow(op).to receive(:dataset).and_wrap_original do |orig|
+        calls += 1
+        if calls == 1
+          # pre-SELECT: the winner hasn't "committed" yet from our vantage point.
+          instance_double(Sequel::Dataset, where: instance_double(Sequel::Dataset, first: nil))
+        else
+          on_reread.call if calls == 3 && on_reread # re-read is the 3rd dataset use
+          orig.call # real dataset: insert (2nd) raises, re-read (3rd) reads the winner
+        end
+      end
+      op.call
     end
 
     it 'returns :conflict when the winning row belongs to a DIFFERENT account' do
-      allow(filtered).to receive(:first).and_return(nil, { account_id: 999 })
+      other = seed_account(999)
+      identities.insert(criteria.merge(account_id: other))
 
-      expect(bind).to eq(:conflict)
+      expect(bind_losing_the_preselect(account_id: account_id)).to eq(:conflict)
     end
 
-    it 'returns :conflict when the winning row vanished before re-read' do
-      allow(filtered).to receive(:first).and_return(nil, nil)
+    it 'returns :ok when the winning row belongs to the SAME account (idempotent)' do
+      identities.insert(criteria.merge(account_id: account_id))
 
-      expect(bind).to eq(:conflict)
+      expect(bind_losing_the_preselect(account_id: account_id)).to eq(:ok)
+    end
+
+    it 'returns :conflict when the winner vanishes before the re-read (defensive nil guard)' do
+      other = seed_account(999)
+      identities.insert(criteria.merge(account_id: other))
+
+      # Delete the winning row between the raise and the re-read -> re-read finds
+      # nothing, which owned_or_conflict must treat as :conflict, never :ok.
+      vanish = -> { identities.where(criteria).delete }
+      expect(bind_losing_the_preselect(account_id: account_id, on_reread: vanish)).to eq(:conflict)
     end
   end
 
-  describe 'issuer sentinel coercion (#3838 issuer-scoped index)' do
-    before { allow(filtered).to receive(:first).and_return(nil) }
-
-    it 'coerces a nil issuer to the empty-string sentinel in both the SELECT and the INSERT' do
-      bind(issuer: nil)
-
-      expect(identities).to have_received(:where).with(hash_including(issuer: ''))
-      expect(identities).to have_received(:insert).with(hash_including(issuer: ''))
-    end
-  end
-
-  describe '.call parity' do
-    before { allow(filtered).to receive(:first).and_return(nil) }
-
-    it 'the class method returns the same result as an instance #call' do
+  describe '.call parity with #call' do
+    it 'the class method delegates to an instance #call (same real bind, same result)' do
       op = described_class.new(
         db: db, account_id: account_id, provider: provider, issuer: issuer, uid: uid,
       )
       expect(op.call).to eq(:ok)
+
+      # Class form over the SAME criteria now hits the row the instance just bound
+      # -> idempotent :ok, still exactly one row.
+      expect(bind).to eq(:ok)
+      expect(identities.where(criteria).count).to eq(1)
     end
   end
 end

--- a/apps/web/auth/spec/operations/bind_sso_identity_spec.rb
+++ b/apps/web/auth/spec/operations/bind_sso_identity_spec.rb
@@ -1,0 +1,145 @@
+# apps/web/auth/spec/operations/bind_sso_identity_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for Auth::Operations::BindSsoIdentity (#3840 Phase 4).
+#
+# The shared bind primitive: an idempotent, issuer-scoped insert of an SSO
+# identity row for an already-PROVEN account. Covers every branch of the safe
+# insert:
+#   - fresh insert -> :ok
+#   - pre-existing row, SAME account -> :ok (idempotent)
+#   - pre-existing row, DIFFERENT account -> :conflict
+#   - concurrent insert (UniqueConstraintViolation) re-read -> :ok / :conflict
+#   - nil issuer coerced to the '' sentinel (issuer-scoped unique index, #3838)
+#   - string/int account_id ownership comparison is coercion-safe
+#
+# The db is a Sequel-shaped double: db[:account_identities] exposes .where(...)
+# (-> filtered dataset responding to #first) and #insert(...). No real DB — the
+# end-to-end conflict path is already covered by
+# spec/integration/full/omniauth_signin_interstitial_spec.rb.
+#
+# Run: pnpm run test:rspec apps/web/auth/spec/operations/bind_sso_identity_spec.rb
+
+require 'spec_helper'
+require 'auth/operations/bind_sso_identity'
+
+RSpec.describe Auth::Operations::BindSsoIdentity do
+  let(:account_id) { 5 }
+  let(:provider)   { 'google' }
+  let(:issuer)     { 'https://accounts.google.com' }
+  let(:uid)        { 'sub-123' }
+  let(:criteria)   { { provider: provider, issuer: issuer, uid: uid } }
+
+  let(:identities) { double('identities_dataset') }
+  let(:filtered)   { double('filtered_dataset') }
+  let(:db)         { double('db') }
+
+  before do
+    allow(db).to receive(:[]).with(:account_identities).and_return(identities)
+    allow(identities).to receive(:where).and_return(filtered)
+    allow(identities).to receive(:insert)
+  end
+
+  # Invoke via the public class method with per-example overrides.
+  def bind(**overrides)
+    described_class.call(
+      db: db,
+      account_id: overrides.fetch(:account_id, account_id),
+      provider: overrides.fetch(:provider, provider),
+      issuer: overrides.fetch(:issuer, issuer),
+      uid: overrides.fetch(:uid, uid),
+    )
+  end
+
+  describe 'fresh insert' do
+    before { allow(filtered).to receive(:first).and_return(nil) }
+
+    it 'inserts the identity row and returns :ok' do
+      expect(bind).to eq(:ok)
+
+      expect(identities).to have_received(:insert)
+        .with(hash_including(account_id: account_id, provider: provider, issuer: issuer, uid: uid))
+    end
+
+    it 'selects on the (provider, issuer, uid) criteria' do
+      bind
+      expect(identities).to have_received(:where).with(criteria)
+    end
+  end
+
+  describe 'pre-existing row (idempotency guard)' do
+    it 'returns :ok without inserting when the row belongs to the SAME account' do
+      allow(filtered).to receive(:first).and_return({ account_id: account_id })
+
+      expect(bind).to eq(:ok)
+      expect(identities).not_to have_received(:insert)
+    end
+
+    it 'returns :conflict without inserting when the row belongs to a DIFFERENT account' do
+      allow(filtered).to receive(:first).and_return({ account_id: 999 })
+
+      expect(bind).to eq(:conflict)
+      expect(identities).not_to have_received(:insert)
+    end
+
+    it 'compares account_id as strings (int row vs string caller)' do
+      allow(filtered).to receive(:first).and_return({ account_id: 5 })
+
+      expect(bind(account_id: '5')).to eq(:ok)
+    end
+
+    it 'compares account_id as strings (string row vs int caller)' do
+      allow(filtered).to receive(:first).and_return({ account_id: '5' })
+
+      expect(bind(account_id: 5)).to eq(:ok)
+    end
+  end
+
+  describe 'concurrent insert (Sequel::UniqueConstraintViolation)' do
+    before do
+      # Pre-SELECT sees nothing; the insert loses the race; re-read finds the winner.
+      allow(identities).to receive(:insert).and_raise(Sequel::UniqueConstraintViolation)
+    end
+
+    it 'returns :ok when the winning row belongs to the SAME account' do
+      allow(filtered).to receive(:first).and_return(nil, { account_id: account_id })
+
+      expect(bind).to eq(:ok)
+    end
+
+    it 'returns :conflict when the winning row belongs to a DIFFERENT account' do
+      allow(filtered).to receive(:first).and_return(nil, { account_id: 999 })
+
+      expect(bind).to eq(:conflict)
+    end
+
+    it 'returns :conflict when the winning row vanished before re-read' do
+      allow(filtered).to receive(:first).and_return(nil, nil)
+
+      expect(bind).to eq(:conflict)
+    end
+  end
+
+  describe 'issuer sentinel coercion (#3838 issuer-scoped index)' do
+    before { allow(filtered).to receive(:first).and_return(nil) }
+
+    it 'coerces a nil issuer to the empty-string sentinel in both the SELECT and the INSERT' do
+      bind(issuer: nil)
+
+      expect(identities).to have_received(:where).with(hash_including(issuer: ''))
+      expect(identities).to have_received(:insert).with(hash_including(issuer: ''))
+    end
+  end
+
+  describe '.call parity' do
+    before { allow(filtered).to receive(:first).and_return(nil) }
+
+    it 'the class method returns the same result as an instance #call' do
+      op = described_class.new(
+        db: db, account_id: account_id, provider: provider, issuer: issuer, uid: uid,
+      )
+      expect(op.call).to eq(:ok)
+    end
+  end
+end


### PR DESCRIPTION
## Phase 4.0 (#3840) — shared bind primitive (BLOCKING)

Extracts the SSO identity-insert logic out of the password-challenge interstitial into a reusable, DB-explicit operation. This is the blocking prerequisite for the two remaining Phase 4 workstreams — **4.A** deferred bind after MFA (#3877) and **4.B** mailbox-proof passwordless linking — which both need to perform the *same* safe bind from outside a Rodauth request context.

### What changed
- **New** `apps/web/auth/operations/bind_sso_identity.rb` — `Auth::Operations::BindSsoIdentity.call(db:, account_id:, provider:, issuer:, uid:) => :ok | :conflict`. Lifted verbatim from `link_sso.rb:296-319` (`bind_sso_identity` + `owned_or_conflict`), wired into `operations.rb`.
- **Rewired** the sole caller at `link_sso.rb:211`; dropped the two now-extracted private methods (route is −40/+13).
- **Unit tests** `spec/operations/bind_sso_identity_spec.rb` — 11 double-based examples.

### Design
The op decides only **whether** the resulting `(provider, issuer, uid)` row belongs to `account_id` — `:ok` (inserted, or already present for the same account) vs `:conflict` (owned by a different account). It does **not** decide whether a bind is *authorized*; the caller owns that (password proof, MFA completion, mailbox proof).

All four invariants stay inside the op:
- `issuer` coerced to the `''` sentinel (never `nil`) for the `(provider, issuer, uid)` unique index (#3838),
- pre-SELECT ownership check,
- `Sequel::UniqueConstraintViolation` rescue with re-read + same ownership check,
- string-coerced `account_id` comparison.

`db` is passed **explicitly** (not `rodauth.db`) so 4.A/4.B can bind outside a request. Column shape `{account_id, provider, uid, issuer}` is unchanged — Phase 2's gem-driven `create_omniauth_identity` is untouched.

### Tests
- Unit: **11/0**.
- Integration `omniauth_signin_interstitial_spec.rb`: **15/0, 7 pending** (pre-existing env gates — OIDC discovery not at boot, no `AUTH_MFA_ENABLED` harness). Both `link_conflict` examples that drive the `:conflict` path end-to-end pass.
- Rubocop: production files 0 offenses.

Base: `feature/3840-sso-linking-orchestration` (same base as merged Phase 3 PR #3870).