### PR TITLE
[#3854] Add direct test coverage for MFA enforcement DB read and awaiting-MFA session flag

### DIFF
--- a/apps/web/auth/config/hooks/email_auth.rb
+++ b/apps/web/auth/config/hooks/email_auth.rb
@@ -52,7 +52,7 @@
 # 5. USER COMPLETES MFA
 #    - User enters TOTP code or uses WebAuthn device
 #    - POST /auth/otp-auth or POST /auth/webauthn-auth
-#    - If valid: session[:awaiting_mfa] = false
+#    - If valid: session['awaiting_mfa'] = false
 #    - User now fully authenticated
 #
 # 6. FULLY AUTHENTICATED SESSION

--- a/apps/web/auth/config/hooks/mfa.rb
+++ b/apps/web/auth/config/hooks/mfa.rb
@@ -209,8 +209,14 @@ module Auth::Config::Hooks
           correlation_id: correlation_id,
         )
 
-        # Clear awaiting_mfa flag
-        session[:awaiting_mfa] = false
+        # Clear awaiting_mfa flag.
+        # String key deliberately: BaseSessionAuthStrategy enforces MFA by reading
+        # session['awaiting_mfa'] (a symbol :awaiting_mfa would silently never
+        # match). SyncSession above already deletes both key forms, but it runs
+        # inside safe_execute and swallows errors — so on a sync failure this line
+        # is the only remaining clear, and it must target the string key or the
+        # user stays locked in the awaiting-MFA state after completing MFA.
+        session['awaiting_mfa'] = false
 
         # Clean up correlation ID after successful completion
         session.delete(:auth_correlation_id)

--- a/apps/web/auth/operations/mfa_state_checker.rb
+++ b/apps/web/auth/operations/mfa_state_checker.rb
@@ -15,7 +15,7 @@
 #
 # Example:
 #   checker = Auth::Operations::MfaStateChecker.new(DB)
-#   state = checker.check(account_id: 123)
+#   state = checker.check(123) # account_id is a positional argument
 #   if state.has_otp_secret
 #     # Account has OTP configured
 #   end

--- a/apps/web/auth/operations/prepare_mfa_session.rb
+++ b/apps/web/auth/operations/prepare_mfa_session.rb
@@ -97,9 +97,12 @@ module Auth
           @session['external_id'] = @external_id
         end
 
-        # Store correlation ID for flow tracking
+        # Store correlation ID for flow tracking.
+        # String key deliberately: every session key this operation writes is a
+        # String so the data round-trips consistently through Rack session
+        # serialization (a symbol key can come back stringified from the store).
         if @correlation_id
-          @session[:mfa_correlation_id] = @correlation_id
+          @session['mfa_correlation_id'] = @correlation_id
         end
 
         # Log successful preparation
@@ -115,11 +118,11 @@ module Auth
       private
 
       # Get list of session keys that were set (for logging)
-      # @return [Array<String, Symbol>]
+      # @return [Array<String>]
       def session_keys_set
         keys = %w[awaiting_mfa account_id email]
         keys << 'external_id' if @external_id
-        keys << :mfa_correlation_id if @correlation_id
+        keys << 'mfa_correlation_id' if @correlation_id
         keys
       end
     end

--- a/apps/web/auth/spec/integration/full/mfa_awaiting_flag_clear_spec.rb
+++ b/apps/web/auth/spec/integration/full/mfa_awaiting_flag_clear_spec.rb
@@ -1,0 +1,292 @@
+# apps/web/auth/spec/integration/full/mfa_awaiting_flag_clear_spec.rb
+#
+# frozen_string_literal: true
+
+# Regression coverage for issue #3884 — "awaiting_mfa clear on MFA completion
+# has no test".
+#
+# What is under test
+# ------------------
+# apps/web/auth/config/hooks/mfa.rb, after_two_factor_authentication:
+#
+#     session['awaiting_mfa'] = false
+#
+# The flag is the MFA gate: PrepareMfaSession sets session['awaiting_mfa'] =
+# true when the password step defers to a second factor, and
+# BaseSessionAuthStrategy refuses every request while it reads true. If the
+# clear regresses, a user who completes MFA stays locked out of the app.
+#
+# Two things make that line easy to break silently:
+#
+#   1. The STRING key is load-bearing. BaseSessionAuthStrategy checks
+#      `session['awaiting_mfa'] == true`; a symbol :awaiting_mfa never matches
+#      the writer's string key, so the gate would fail OPEN — which is exactly
+#      the bug fixed in commit 01352555 (issue #3854), reasoned from code with
+#      no test to prove it.
+#   2. The line looks redundant. SyncSession#populate_session already deletes
+#      both key forms — but it runs inside ErrorHandler.safe_execute, which
+#      swallows StandardError. When the sync fails, this line is the ONLY
+#      remaining clear. That is its reason to exist, so it is tested here with
+#      SyncSession forced to raise.
+#
+# Why an inline Roda app rather than the mounted /auth app
+# --------------------------------------------------------
+# MFA is boot-time conditional (config.rb gates Features::MFA + Hooks::MFA on
+# Onetime.auth_config.mfa_enabled?) and spec/auth.test.yaml pins `mfa: false`,
+# so the booted app has no otp routes at all — which is why
+# spec/integration/full/env_toggles/mfa_spec.rb can only assert "route exists"
+# and never completes a real OTP auth. This spec boots the full application
+# (Valkey, Familia, Auth::Operations) and then mounts a Rodauth app configured
+# with the REAL production modules — Auth::Config::Features::MFA and
+# Auth::Config::Hooks::MFA/Login — so the hook body executing here is the
+# production hook body, not a copy of it.
+#
+# REQUIREMENTS: Valkey on port 2121 (pnpm run test:database:start).
+#
+# RUN:
+#   AUTHENTICATION_MODE=full AUTH_DATABASE_URL=sqlite::memory: \
+#     pnpm run test:rspec apps/web/auth/spec/integration/full/mfa_awaiting_flag_clear_spec.rb
+
+require_relative '../../spec_helper'
+require 'rack/test'
+require 'rotp'
+require 'bcrypt'
+
+require_relative '../../support/auth_test_constants'
+
+RSpec.describe 'MFA completion clears awaiting_mfa (issue #3884)', type: :integration do
+  include Rack::Test::Methods
+
+  before(:all) do
+    # Loads the real Auth::Config (a Rodauth::Auth subclass) along with
+    # Auth::Config::Features::*, Auth::Config::Hooks::* and Auth::Operations::*,
+    # and connects Familia to the test datastore. See the note in
+    # pending_plan_intent_flow_spec.rb: never fabricate the Auth::Config
+    # constant here — doing so poisons boot for every spec in the process.
+    boot_onetime_app
+  end
+
+  let(:db) { create_test_database }
+  let(:password) { 'correct horse battery staple' }
+  let(:email) { "mfa-clear-#{SecureRandom.hex(6)}@integration-test.example.com" }
+
+  let(:account_id) do
+    id = db[:accounts].insert(email: email, status_id: AuthTestConstants::STATUS_VERIFIED)
+    db[:account_password_hashes].insert(id: id, password_hash: BCrypt::Password.create(password))
+    id
+  end
+
+  # Rodauth app wired with the production MFA feature config and the production
+  # login/MFA hooks. Feature-enable order mirrors config.rb: :json before :otp,
+  # so Hooks::MFA's before_otp_setup_route runs after the json feature has
+  # populated the setup secrets.
+  let(:app) do
+    app_db = db
+
+    Class.new(Roda) do
+      plugin :sessions, secret: SecureRandom.hex(64)
+      plugin :json
+      plugin :json_parser
+      plugin :halt
+
+      plugin :rodauth do
+        db app_db
+        enable :base, :json, :login, :logout
+        only_json? true
+        login_column :email
+        hmac_secret SecureRandom.hex(32)
+
+        # Production MFA wiring: enables two_factor_base/otp/recovery_codes and
+        # sets otp params, HMAC keys, failure limits (config/features/mfa.rb).
+        Auth::Config::Features::MFA.configure(self)
+
+        # Production hooks. Login.configure owns after_login, whose MFA branch
+        # calls PrepareMfaSession (the writer of awaiting_mfa); MFA.configure
+        # owns after_two_factor_authentication (the clear under test).
+        Auth::Config::Hooks::Login.configure(self)
+        Auth::Config::Hooks::MFA.configure(self)
+      end
+
+      route do |r|
+        r.rodauth
+
+        # Reads the session as the NEXT request sees it, after the cookie
+        # round-trip — the state BaseSessionAuthStrategy would act on.
+        r.get 'session-probe' do
+          {
+            'awaiting_mfa' => session['awaiting_mfa'],
+            'authenticated' => session['authenticated'],
+          }
+        end
+      end
+    end
+  end
+
+  # Enrolls OTP through Rodauth's real two-step JSON otp-setup flow and returns
+  # the shared secret the authenticator would hold, leaving the account logged
+  # out and ready for a fresh MFA login.
+  let(:otp_secret) do
+    account_id
+    status, = login!
+    raise "otp enrollment: login failed (#{status})" unless status == 200
+
+    # Step 1 returns the secrets with a 422 (JSON HMAC flow).
+    _, setup = post_json('/otp-setup', {})
+    secret   = setup['otp_setup']
+    raise "otp enrollment: no otp_setup in #{setup.inspect}" if secret.to_s.empty?
+
+    # Step 2 verifies a real TOTP code and stores the key.
+    status, body = post_json(
+      '/otp-setup',
+      otp_setup: secret,
+      otp_raw_secret: setup['otp_raw_secret'],
+      otp_code: ROTP::TOTP.new(secret).now,
+      password: password,
+    )
+    raise "otp enrollment: setup failed (#{status}) #{body.inspect}" unless status == 200
+
+    # Rodauth stamps last_use at enrollment and otp_update_last_use refuses a
+    # second use inside the same 30s interval, so a code generated now would be
+    # rejected as a replay. Backdate the stamp instead of sleeping. Plain
+    # Time.now, not Time.now.utc: the comparison is against the database's
+    # CURRENT_TIMESTAMP as Sequel renders it (local by default), and a UTC
+    # wall-clock lands in the future on a machine behind UTC.
+    db[:account_otp_keys].where(id: account_id).update(last_use: Time.now - 300)
+
+    post_json('/logout', {})
+    clear_cookies
+
+    secret
+  end
+
+  # The in-request session hash. Symbol and string keys are still distinct here
+  # (Roda's JSON session serializer stringifies both on the way out), so this is
+  # the only place a symbol-key regression on the clear is observable.
+  def rack_session
+    last_request.env['rack.session']
+  end
+
+  def parsed_body
+    JSON.parse(last_response.body)
+  rescue JSON::ParserError
+    {}
+  end
+
+  def post_json(path, body)
+    post(path, body.to_json, 'CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json')
+    [last_response.status, parsed_body]
+  end
+
+  def login!
+    post_json('/login', login: email, password: password)
+  end
+
+  def session_probe
+    get('/session-probe', {}, 'HTTP_ACCEPT' => 'application/json')
+    parsed_body
+  end
+
+  def current_otp_code(secret)
+    ROTP::TOTP.new(secret).now
+  end
+
+  before do
+    # Delivery is best-effort in production (safe_execute) and not under test;
+    # stubbing keeps the example off RabbitMQ and its async-thread fallback.
+    allow(Onetime::Jobs::Publisher).to receive(:enqueue_email).and_return(true)
+  end
+
+  describe 'a login that requires MFA' do
+    it 'sets awaiting_mfa true under the string key and defers the session sync' do
+      otp_secret
+
+      status, body = login!
+
+      expect(status).to eq(200)
+      expect(body['mfa_required']).to be(true)
+      expect(rack_session.fetch('awaiting_mfa')).to be(true)
+      # SyncSession is deferred until the second factor, so the app-session
+      # authenticated marker must not be set yet.
+      expect(rack_session['authenticated']).to be_nil
+    end
+  end
+
+  describe 'completing MFA with a valid TOTP code' do
+    it 'clears awaiting_mfa under the string key and finishes the session sync' do
+      secret = otp_secret
+      login!
+      expect(rack_session.fetch('awaiting_mfa')).to be(true)
+
+      status, = post_json('/otp-auth', otp_code: current_otp_code(secret))
+
+      expect(status).to eq(200)
+      expect(rack_session.fetch('awaiting_mfa')).to be(false)
+      # A symbol key would leave BaseSessionAuthStrategy's string read unmatched.
+      expect(rack_session.keys.grep(Symbol)).not_to include(:awaiting_mfa)
+      # Second factor recorded, and the deferred SyncSession has now run.
+      expect(rack_session['authenticated_by']).to include('totp')
+      expect(rack_session['authenticated']).to be(true)
+    end
+
+    it 'leaves the gate cleared on the next request, after the cookie round-trip' do
+      secret = otp_secret
+      login!
+      post_json('/otp-auth', otp_code: current_otp_code(secret))
+
+      expect(session_probe).to include('awaiting_mfa' => false, 'authenticated' => true)
+    end
+  end
+
+  # The reason line 219 of hooks/mfa.rb is kept rather than deleted as
+  # redundant: SyncSession's own clear runs inside safe_execute, so a raising
+  # sync leaves the hook's assignment as the only thing between the user and a
+  # permanent awaiting-MFA lockout.
+  describe 'completing MFA when SyncSession raises' do
+    it 'still clears awaiting_mfa under the string key' do
+      secret = otp_secret # enroll before stubbing: enrollment's login syncs
+
+      allow(Auth::Operations::SyncSession).to receive(:call)
+        .and_raise(Sequel::DatabaseConnectionError, 'simulated datastore failure')
+
+      login!
+      expect(rack_session.fetch('awaiting_mfa')).to be(true)
+
+      status, = post_json('/otp-auth', otp_code: current_otp_code(secret))
+
+      # safe_execute swallows the failure, so MFA itself still succeeds.
+      expect(status).to eq(200)
+      expect(rack_session.fetch('awaiting_mfa')).to be(false)
+      expect(rack_session.keys.grep(Symbol)).not_to include(:awaiting_mfa)
+      # Proof the clear came from the hook and not from SyncSession: the sync's
+      # other writes are absent.
+      expect(rack_session['authenticated']).to be_nil
+    end
+
+    it 'leaves the gate cleared on the next request' do
+      secret = otp_secret
+
+      allow(Auth::Operations::SyncSession).to receive(:call)
+        .and_raise(Sequel::DatabaseConnectionError, 'simulated datastore failure')
+
+      login!
+      post_json('/otp-auth', otp_code: current_otp_code(secret))
+
+      expect(session_probe).to include('awaiting_mfa' => false, 'authenticated' => nil)
+    end
+  end
+
+  # Counterweight: proves the assertions above have teeth — the flag is not
+  # simply always false by the end of an otp-auth request.
+  describe 'a failed TOTP attempt' do
+    it 'leaves awaiting_mfa true' do
+      otp_secret
+      login!
+
+      status, = post_json('/otp-auth', otp_code: '000000')
+
+      expect(status).not_to eq(200)
+      expect(rack_session.fetch('awaiting_mfa')).to be(true)
+      expect(session_probe['awaiting_mfa']).to be(true)
+    end
+  end
+end

--- a/apps/web/auth/spec/unit/mfa_state_checker_spec.rb
+++ b/apps/web/auth/spec/unit/mfa_state_checker_spec.rb
@@ -1,0 +1,219 @@
+# apps/web/auth/spec/unit/mfa_state_checker_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for Auth::Operations::MfaStateChecker
+#
+# Closes Gap 1 from issue #3854 (flagged in the 2026-07-19 security audit,
+# "Two real test-coverage gaps on MFA enforcement").
+#
+# MfaStateChecker#check is the DB-backed half of MFA enforcement: it reads
+# account_otp_keys and counts account_recovery_codes to derive the
+# has_otp_secret / has_recovery_codes booleans that DetectMfaRequirement then
+# turns into a requires-MFA decision (see apps/web/auth/config/hooks/login.rb).
+#
+# detect_mfa_requirement_spec.rb already covers the pure decision logic, but it
+# passes those booleans as hard-coded values — the real table/count logic in
+# #query_mfa_state never ran under test. A silent regression there (wrong table,
+# wrong id column, a JOIN that drops rows) would weaken MFA enforcement with
+# nothing to catch it. These tests seed real rows in an in-memory SQLite DB and
+# assert the state object #check returns.
+
+require_relative '../spec_helper'
+require_relative '../../operations/mfa_state_checker'
+
+RSpec.describe Auth::Operations::MfaStateChecker do
+  # In-memory SQLite with the full Rodauth schema (account_otp_keys,
+  # account_recovery_codes, accounts, ...). See RodauthTestHelper.
+  let(:db) { create_test_database }
+
+  # A logger that swallows every structured call. Injecting it keeps the test
+  # hermetic (no dependency on Onetime.get_logger / global boot state) and
+  # quiet, while still exercising the real DB query path.
+  let(:null_logger) do
+    Object.new.tap do |logger|
+      def logger.method_missing(_name, *_args, **_kwargs); nil; end
+      def logger.respond_to_missing?(_name, _include_private = false); true; end
+    end
+  end
+
+  subject(:checker) { described_class.new(db, logger: null_logger) }
+
+  # --- seed helpers --------------------------------------------------------
+
+  # Insert a real account row; status_id defaults, email must be unique.
+  # @return [Integer] the generated account_id
+  def create_account(email)
+    db[:accounts].insert(email: email)
+  end
+
+  # account_otp_keys.id IS the account_id (FK + PK). `key` is NOT NULL.
+  def add_otp_key(account_id, last_use: Time.now)
+    db[:account_otp_keys].insert(
+      id: account_id,
+      key: SecureRandom.hex(20),
+      last_use: last_use,
+    )
+  end
+
+  # account_recovery_codes has composite PK [id, code]; id is the account_id.
+  # Codes are deleted when used, so row count == unused-code count.
+  def add_recovery_codes(account_id, count)
+    count.times do |i|
+      db[:account_recovery_codes].insert(id: account_id, code: "code-#{account_id}-#{i}")
+    end
+  end
+
+  describe '#check' do
+    context 'when the account has neither OTP nor recovery codes' do
+      let(:account_id) { create_account('none@example.com') }
+
+      it 'reports no MFA configured' do
+        state = checker.check(account_id)
+
+        expect(state.account_id).to eq(account_id)
+        expect(state.has_otp_secret).to be(false)
+        expect(state.has_recovery_codes).to be(false)
+        expect(state.unused_recovery_code_count).to eq(0)
+        expect(state.otp_last_use).to be_nil
+        expect(state.mfa_enabled?).to be(false)
+        expect(state.available_methods).to eq([])
+        expect(state.reason).to eq('no_mfa_configured')
+      end
+    end
+
+    context 'when the account has an OTP secret only' do
+      let(:account_id) { create_account('otp@example.com') }
+
+      before { add_otp_key(account_id) }
+
+      it 'reads has_otp_secret=true from account_otp_keys' do
+        state = checker.check(account_id)
+
+        expect(state.has_otp_secret).to be(true)
+        expect(state.has_recovery_codes).to be(false)
+        expect(state.unused_recovery_code_count).to eq(0)
+        expect(state.otp_last_use).not_to be_nil
+        expect(state.mfa_enabled?).to be(true)
+        expect(state.available_methods).to eq([:otp])
+        expect(state.reason).to eq('otp_configured')
+      end
+    end
+
+    context 'when the account has recovery codes only' do
+      let(:account_id) { create_account('recovery@example.com') }
+
+      before { add_recovery_codes(account_id, 3) }
+
+      it 'reads has_recovery_codes=true and the exact unused count' do
+        state = checker.check(account_id)
+
+        expect(state.has_otp_secret).to be(false)
+        expect(state.has_recovery_codes).to be(true)
+        expect(state.unused_recovery_code_count).to eq(3)
+        expect(state.otp_last_use).to be_nil
+        expect(state.mfa_enabled?).to be(true)
+        expect(state.available_methods).to eq([:recovery_codes])
+        expect(state.reason).to eq('recovery_codes_only')
+      end
+    end
+
+    context 'when the account has both OTP and recovery codes' do
+      let(:account_id) { create_account('both@example.com') }
+
+      before do
+        add_otp_key(account_id)
+        add_recovery_codes(account_id, 5)
+      end
+
+      it 'reports both methods and the recovery-code count' do
+        state = checker.check(account_id)
+
+        expect(state.has_otp_secret).to be(true)
+        expect(state.has_recovery_codes).to be(true)
+        expect(state.unused_recovery_code_count).to eq(5)
+        expect(state.mfa_enabled?).to be(true)
+        expect(state.available_methods).to eq([:otp, :recovery_codes])
+        expect(state.reason).to eq('otp_and_recovery_configured')
+      end
+    end
+
+    context 'when account_id is passed as a String' do
+      let(:account_id) { create_account('string-id@example.com') }
+
+      before { add_otp_key(account_id) }
+
+      it 'coerces to Integer and still reads the right row' do
+        state = checker.check(account_id.to_s)
+
+        expect(state.account_id).to eq(account_id)
+        expect(state.account_id).to be_a(Integer)
+        expect(state.has_otp_secret).to be(true)
+      end
+    end
+
+    context 'when the account_id does not exist' do
+      it 'returns an all-false state rather than raising' do
+        state = checker.check(999_999)
+
+        expect(state.has_otp_secret).to be(false)
+        expect(state.has_recovery_codes).to be(false)
+        expect(state.unused_recovery_code_count).to eq(0)
+        expect(state.otp_last_use).to be_nil
+        expect(state.mfa_enabled?).to be(false)
+      end
+    end
+
+    context 'data isolation between accounts' do
+      it 'counts only the rows belonging to the queried account' do
+        account_a = create_account('a@example.com')
+        account_b = create_account('b@example.com')
+
+        add_otp_key(account_a)
+        add_recovery_codes(account_a, 2)
+        # account_b intentionally left with no MFA rows.
+
+        state_b = checker.check(account_b)
+        expect(state_b.has_otp_secret).to be(false)
+        expect(state_b.has_recovery_codes).to be(false)
+        expect(state_b.unused_recovery_code_count).to eq(0)
+
+        state_a = checker.check(account_a)
+        expect(state_a.has_otp_secret).to be(true)
+        expect(state_a.unused_recovery_code_count).to eq(2)
+      end
+    end
+  end
+
+  # The caching path is part of #check's public contract: when cache_ttl is set,
+  # a State is served from an in-process cache until clear_cache invalidates it.
+  # Covering it guards the "did we accidentally re-query / never cache" regressions.
+  describe 'caching (cache_ttl set)' do
+    subject(:checker) { described_class.new(db, logger: null_logger, cache_ttl: 60) }
+
+    it 'serves the cached State on a subsequent check within the TTL' do
+      account_id = create_account('cache@example.com')
+
+      first = checker.check(account_id)
+      expect(first.has_otp_secret).to be(false)
+
+      # Mutate the DB *after* the first read was cached.
+      add_otp_key(account_id)
+
+      second = checker.check(account_id)
+      expect(second).to equal(first), 'expected the cached State object to be returned'
+      expect(second.has_otp_secret).to be(false)
+    end
+
+    it 're-reads the DB after clear_cache' do
+      account_id = create_account('cache-clear@example.com')
+
+      checker.check(account_id)
+      add_otp_key(account_id)
+      checker.clear_cache(account_id)
+
+      refreshed = checker.check(account_id)
+      expect(refreshed.has_otp_secret).to be(true)
+    end
+  end
+end

--- a/apps/web/auth/spec/unit/mfa_state_checker_spec.rb
+++ b/apps/web/auth/spec/unit/mfa_state_checker_spec.rb
@@ -191,18 +191,17 @@ RSpec.describe Auth::Operations::MfaStateChecker do
   describe 'caching (cache_ttl set)' do
     subject(:checker) { described_class.new(db, logger: null_logger, cache_ttl: 60) }
 
-    it 'serves the cached State on a subsequent check within the TTL' do
+    it 'serves the cached result on a subsequent check within the TTL' do
       account_id = create_account('cache@example.com')
 
-      first = checker.check(account_id)
-      expect(first.has_otp_secret).to be(false)
+      expect(checker.check(account_id).has_otp_secret).to be(false)
 
       # Mutate the DB *after* the first read was cached.
       add_otp_key(account_id)
 
-      second = checker.check(account_id)
-      expect(second).to equal(first), 'expected the cached State object to be returned'
-      expect(second.has_otp_secret).to be(false)
+      # The cached result is returned, so this read is intentionally stale — it
+      # does not reflect the OTP row we just inserted (that's the caching contract).
+      expect(checker.check(account_id).has_otp_secret).to be(false)
     end
 
     it 're-reads the DB after clear_cache' do

--- a/apps/web/auth/spec/unit/mfa_state_checker_spec.rb
+++ b/apps/web/auth/spec/unit/mfa_state_checker_spec.rb
@@ -85,7 +85,11 @@ RSpec.describe Auth::Operations::MfaStateChecker do
     context 'when the account has an OTP secret only' do
       let(:account_id) { create_account('otp@example.com') }
 
-      before { add_otp_key(account_id) }
+      # A fixed, whole-second UTC time so we can assert the exact value the DB
+      # read returns, not merely that it is present.
+      let(:otp_last_use) { Time.utc(2026, 1, 15, 10, 30, 45) }
+
+      before { add_otp_key(account_id, last_use: otp_last_use) }
 
       it 'reads has_otp_secret=true from account_otp_keys' do
         state = checker.check(account_id)
@@ -93,10 +97,19 @@ RSpec.describe Auth::Operations::MfaStateChecker do
         expect(state.has_otp_secret).to be(true)
         expect(state.has_recovery_codes).to be(false)
         expect(state.unused_recovery_code_count).to eq(0)
-        expect(state.otp_last_use).not_to be_nil
         expect(state.mfa_enabled?).to be(true)
         expect(state.available_methods).to eq([:otp])
         expect(state.reason).to eq('otp_configured')
+      end
+
+      # #query_mfa_state selects last_use and passes it through untouched; this
+      # asserts the value actually round-trips (guards a wrong column / dropped
+      # select), not just that something non-nil came back.
+      it 'round-trips the stored otp_last_use timestamp from the DB' do
+        state = checker.check(account_id)
+
+        expect(state.otp_last_use).to be_a(Time)
+        expect(state.otp_last_use.getutc.to_i).to eq(otp_last_use.to_i)
       end
     end
 

--- a/apps/web/auth/spec/unit/prepare_mfa_session_spec.rb
+++ b/apps/web/auth/spec/unit/prepare_mfa_session_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe Auth::Operations::PrepareMfaSession do
         )
       end
 
+      # The STRING key is load-bearing, not incidental: BaseSessionAuthStrategy
+      # reads `session['awaiting_mfa'] == true` and its own comment warns that a
+      # symbol :awaiting_mfa "would silently never match" — i.e. writing the
+      # wrong key form here fails OPEN (MFA skipped). This assertion guards that.
+      # See lib/onetime/application/auth_strategies/base_session_auth_strategy.rb.
       it 'sets the awaiting_mfa flag under the STRING key' do
         expect(session['awaiting_mfa']).to be(true)
       end
@@ -48,7 +53,7 @@ RSpec.describe Auth::Operations::PrepareMfaSession do
 
       it 'does not set external_id or the correlation id when they are absent' do
         expect(session).not_to have_key('external_id')
-        expect(session).not_to have_key(:mfa_correlation_id)
+        expect(session).not_to have_key('mfa_correlation_id')
       end
 
       it 'never marks the session authenticated (fail-closed contract)' do
@@ -81,8 +86,12 @@ RSpec.describe Auth::Operations::PrepareMfaSession do
         expect(session['external_id']).to eq('cust_abc123')
       end
 
-      it 'stores the correlation id under the SYMBOL key :mfa_correlation_id' do
-        expect(session[:mfa_correlation_id]).to eq('auth_xyz789')
+      # Every key this operation writes is a String so the session round-trips
+      # consistently through Rack serialization. (This assertion also guards the
+      # previously-symbol :mfa_correlation_id write, corrected alongside this spec.)
+      it "stores the correlation id under the STRING key 'mfa_correlation_id'" do
+        expect(session['mfa_correlation_id']).to eq('auth_xyz789')
+        expect(session).not_to have_key(:mfa_correlation_id)
       end
     end
 

--- a/apps/web/auth/spec/unit/prepare_mfa_session_spec.rb
+++ b/apps/web/auth/spec/unit/prepare_mfa_session_spec.rb
@@ -1,0 +1,171 @@
+# apps/web/auth/spec/unit/prepare_mfa_session_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for Auth::Operations::PrepareMfaSession
+#
+# Closes Gap 2 from issue #3854 (flagged in the 2026-07-19 security audit,
+# "Two real test-coverage gaps on MFA enforcement").
+#
+# PrepareMfaSession#call is the writer for the awaiting_mfa session flag: when
+# the login hook decides MFA is required, it sets session['awaiting_mfa'] = true
+# (plus minimal account data) WITHOUT granting authenticated access. The
+# SessionAuthStrategy then fails closed on that flag until the second factor
+# completes (see session_auth_strategy_spec.rb, M-11).
+#
+# Before this spec nothing instantiated PrepareMfaSession — session_auth_strategy_spec
+# only hard-coded 'awaiting_mfa' => true in a fake session hash. A regression in
+# which key is written (string vs symbol), or an accidental 'authenticated' =>
+# true leaking in here, would silently break the fail-closed contract. These
+# tests call PrepareMfaSession.call against a real session hash and assert
+# exactly which keys it sets.
+
+require_relative '../spec_helper'
+require_relative '../../operations/prepare_mfa_session'
+
+RSpec.describe Auth::Operations::PrepareMfaSession do
+  # A plain Hash stands in for the Rack session (the operation only uses []=).
+  let(:session) { {} }
+
+  describe '.call' do
+    context 'with the minimal required inputs' do
+      before do
+        described_class.call(
+          session: session,
+          account_id: 123,
+          email: 'user@example.com',
+        )
+      end
+
+      it 'sets the awaiting_mfa flag under the STRING key' do
+        expect(session['awaiting_mfa']).to be(true)
+      end
+
+      it 'stores account_id and email for the MFA UI' do
+        expect(session['account_id']).to eq(123)
+        expect(session['email']).to eq('user@example.com')
+      end
+
+      it 'does not set external_id or the correlation id when they are absent' do
+        expect(session).not_to have_key('external_id')
+        expect(session).not_to have_key(:mfa_correlation_id)
+      end
+
+      it 'never marks the session authenticated (fail-closed contract)' do
+        expect(session).not_to have_key('authenticated')
+        expect(session['authenticated']).to be_nil
+      end
+    end
+
+    it 'returns true on success' do
+      result = described_class.call(
+        session: session,
+        account_id: 123,
+        email: 'user@example.com',
+      )
+      expect(result).to be(true)
+    end
+
+    context 'with an external_id and correlation_id' do
+      before do
+        described_class.call(
+          session: session,
+          account_id: 123,
+          email: 'user@example.com',
+          external_id: 'cust_abc123',
+          correlation_id: 'auth_xyz789',
+        )
+      end
+
+      it 'stores external_id under the STRING key' do
+        expect(session['external_id']).to eq('cust_abc123')
+      end
+
+      it 'stores the correlation id under the SYMBOL key :mfa_correlation_id' do
+        expect(session[:mfa_correlation_id]).to eq('auth_xyz789')
+      end
+    end
+
+    context 'input coercion' do
+      it 'coerces a String account_id to Integer' do
+        described_class.call(session: session, account_id: '456', email: 'u@example.com')
+        expect(session['account_id']).to eql(456)
+      end
+
+      it 'coerces a non-String external_id to String' do
+        described_class.call(
+          session: session,
+          account_id: 1,
+          email: 'u@example.com',
+          external_id: 789,
+        )
+        expect(session['external_id']).to eq('789')
+      end
+    end
+
+    context 'idempotency' do
+      it 'is safe to call multiple times and leaves the flag set' do
+        described_class.call(session: session, account_id: 1, email: 'u@example.com')
+
+        expect {
+          described_class.call(session: session, account_id: 1, email: 'u@example.com')
+        }.not_to raise_error
+
+        expect(session['awaiting_mfa']).to be(true)
+        expect(session['account_id']).to eq(1)
+      end
+    end
+
+    context 'when the session already holds unrelated data' do
+      let(:session) { { 'shrimp' => 'csrf-token', 'return_to' => '/dashboard' } }
+
+      it 'preserves the pre-existing keys' do
+        described_class.call(session: session, account_id: 1, email: 'u@example.com')
+
+        expect(session['shrimp']).to eq('csrf-token')
+        expect(session['return_to']).to eq('/dashboard')
+        expect(session['awaiting_mfa']).to be(true)
+      end
+    end
+  end
+
+  describe 'input validation' do
+    it 'raises InvalidInput when the session is nil' do
+      expect {
+        described_class.call(session: nil, account_id: 1, email: 'u@example.com')
+      }.to raise_error(described_class::InvalidInput, /session/)
+    end
+
+    it 'raises InvalidInput when account_id is nil' do
+      expect {
+        described_class.call(session: {}, account_id: nil, email: 'u@example.com')
+      }.to raise_error(described_class::InvalidInput, /account_id/)
+    end
+
+    it 'raises InvalidInput when account_id is an empty string' do
+      expect {
+        described_class.call(session: {}, account_id: '', email: 'u@example.com')
+      }.to raise_error(described_class::InvalidInput, /account_id/)
+    end
+
+    it 'raises InvalidInput when email is nil' do
+      expect {
+        described_class.call(session: {}, account_id: 1, email: nil)
+      }.to raise_error(described_class::InvalidInput, /email/)
+    end
+
+    it 'raises InvalidInput when email is empty' do
+      expect {
+        described_class.call(session: {}, account_id: 1, email: '')
+      }.to raise_error(described_class::InvalidInput, /email/)
+    end
+
+    it 'does not mutate the session when validation fails' do
+      expect {
+        described_class.call(session: session, account_id: nil, email: 'u@example.com')
+      }.to raise_error(described_class::InvalidInput)
+
+      expect(session).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Summary

[#3854](https://github.com/onetimesecret/onetimesecret/issues/3854)

Adds the two direct unit specs called for by the 2026-07-19 security audit ("Two real test-coverage gaps on MFA enforcement"). Both are **coverage gaps, not live bugs** — defense-in-depth means neither path is currently exploitable — but a silent regression in either would weaken MFA enforcement with nothing to catch it.

Writing the coverage also surfaced a session-key inconsistency in the MFA flow, corrected here (see "Production fixes" below).

**Gap 1 — MFA-state DB read** (`apps/web/auth/spec/unit/mfa_state_checker_spec.rb`)
`Auth::Operations::MfaStateChecker#query_mfa_state` reads `account_otp_keys` and counts `account_recovery_codes` to derive `has_otp_secret`/`has_recovery_codes`, which feed `DetectMfaRequirement`. Previously only the pure decision logic was covered (`detect_mfa_requirement_spec.rb`, with hard-coded booleans) — the real table/count query never ran under test. The new spec seeds rows in the in-memory SQLite schema and asserts `check(account_id)` returns the correct booleans, counts, `available_methods`, and `reason` across: no MFA, OTP-only, recovery-only, both, string `account_id` coercion, a nonexistent account, per-account isolation, and the `cache_ttl` caching / `clear_cache` path. `otp_last_use` is asserted to **round-trip** a seeded whole-second UTC timestamp (not merely non-nil), so a wrong-column / dropped-select regression fails.

**Gap 2 — awaiting-MFA session flag writer** (`apps/web/auth/spec/unit/prepare_mfa_session_spec.rb`)
`Auth::Operations::PrepareMfaSession#call` sets `session['awaiting_mfa'] = true` (the fail-closed flag `SessionAuthStrategy` enforces until the second factor completes). Nothing instantiated the operation before — `session_auth_strategy_spec.rb` only hard-coded the flag in a fake session. The new spec calls `PrepareMfaSession.call` against a real session hash and asserts exactly which keys it writes, that it **never** sets `'authenticated'`, that unrelated session keys are preserved, plus input coercion, idempotency, and input validation. The `'awaiting_mfa'` assertion is deliberately pinned to the **string** key form — `BaseSessionAuthStrategy` reads `session['awaiting_mfa']` and its own comment warns that a symbol key "would silently never match" (i.e. the wrong key form here fails **open**).

## Production fixes (surfaced by the new coverage)

The `awaiting_mfa` enforcement flag is keyed by a **string** everywhere it's read (`BaseSessionAuthStrategy`, `SyncSession`, `login.rb`, view/serializer, `session.rb`). The new coverage surfaced the two places that used a **symbol** instead:

1. **`prepare_mfa_session.rb`** — wrote the correlation id under `session[:mfa_correlation_id]` (symbol) while every other key it writes is a string. Nothing reads that key, so it was latent, but a symbol round-trips inconsistently through Rack session serialization. Now `'mfa_correlation_id'` (and `session_keys_set`, used only for logging, to match). Also corrected a misleading `MfaStateChecker` docstring example (`check(account_id:)` → `check(123)`; the keyword form would raise on `Hash#to_i`).
2. **`mfa.rb`** (`after_two_factor_authentication`) — cleared the flag with `session[:awaiting_mfa] = false` (symbol), the lone symbol write of `awaiting_mfa` in the codebase. It was masked because `SyncSession` (called just above) deletes both key forms — but `SyncSession` runs inside `safe_execute`, which swallows errors, so on a sync failure this line is the only remaining clear. Writing the symbol key would leave `session['awaiting_mfa'] == true`, stranding the user in the awaiting-MFA state after they completed MFA. Now writes the string key. (The adjacent `auth_correlation_id` delete is intentionally left as a symbol: it's written and read as a symbol everywhere and never crosses into the string-keyed strategy layer.) A stale-doc comment in `email_auth.rb` describing the symbol form was corrected to match.

## Related Issues

Part of #3854. Follow-up integration coverage for the `mfa.rb` clear tracked in #3884.

## Test Plan

The two new unit specs, plus the existing MFA config-feature specs as a regression check, run green locally against the in-memory SQLite auth schema (`RodauthTestHelper.create_test_database`), no Valkey required:

```
bundle exec rspec apps/web/auth/spec/unit/mfa_state_checker_spec.rb \
                  apps/web/auth/spec/unit/prepare_mfa_session_spec.rb \
                  apps/web/auth/spec/config/features/mfa_spec.rb \
                  apps/web/auth/spec/config/features/mfa_provisioning_uri_spec.rb
# 51 examples, 0 failures
```

The MFA-state spec injects a null logger to stay hermetic; the prepare-session spec exercises the real `.call` path (structured logging + `OT::Utils.obscure_email`).

**Coverage note:** the `mfa.rb` clear runs inside the `after_two_factor_authentication` Rodauth hook, which isn't unit-testable without a full OTP-completion integration flow. The string-key *contract* it now honors is unit-tested on both sides — the write (`PrepareMfaSession`) and the enforcement read (`SessionAuthStrategy`, M-11). A dedicated integration test that drives a valid OTP completion and asserts the hook clears the flag — including the `SyncSession`-failure branch where that line is the sole clear — is tracked in **#3884**.