### PR TITLE
[#3840] Phase 4: mailbox-proof SSO linking for passwordless accounts

### DIFF
--- a/apps/web/auth/config/hooks/omniauth.rb
+++ b/apps/web/auth/config/hooks/omniauth.rb
@@ -326,87 +326,157 @@ module Auth::Config::Hooks
             # to arbitrary platform addresses, so tenant callbacks fall through to the
             # H-3 refusal below (authenticated tenant-surface linking is a follow-up,
             # #3849).
+            #
+            # TWO email identities here, deliberately NOT interchangeable — DO NOT
+            # UNIFY THEM. Both halves are security-load-bearing:
+            #   on_file_email (existing[:email], the RAW address of record) is the
+            #     DELIVERY target. The mailbox-proof credential must go to the
+            #     address WE hold, never to the IdP-asserted string, or the proof
+            #     proves nothing.
+            #   normalized_email (the token's :email, below) is what the confirm-time
+            #     OWNERSHIP RE-CHECK compares against — the check in
+            #     operations/confirm_sso_link.rb normalizes the reloaded account email
+            #     before the ==. Storing the raw address here would make every legacy
+            #     mixed-case row (the rows migrations/007_normalize_customer_emails.rb
+            #     exists for) fail that check as a spurious :link_conflict.
             on_file_email = existing[:email]
 
-            # Snapshot the account's credential watermark so ANY later credential
-            # change (password set/reset/change stamps Customer#last_password_update
-            # via UpdatePasswordMetadata) invalidates this token at consume time.
-            watermark = begin
+            # ONE customer load serves BOTH the watermark snapshot and the locale.
+            # external_id-first (load_by_extid_or_email), NOT find_by_email: confirm
+            # time re-derives the watermark with the SAME external_id-first identifier
+            # logic (ConfirmSsoLink#watermark_advanced?), and resolving to a different
+            # record than confirm time surfaces as a spurious :link_invalidated with no
+            # way forward for the user.
+            customer = begin
               custid = existing[:external_id].to_s.empty? ? on_file_email : existing[:external_id]
-              Onetime::Customer.load_by_extid_or_email(custid)&.last_password_update.to_i
+              Onetime::Customer.load_by_extid_or_email(custid)
             rescue StandardError
-              0
+              nil
             end
 
-            verification = Onetime::SsoLinkVerification.issue(
-              provider: provider,
-              issuer: resolved_issuer,
-              uid: omniauth_uid,
-              email: normalized_email,
-              account_id: existing_id,
-              sid: session.id&.public_id,
-              password_watermark: watermark,
-            )
-
-            locale = begin
-              cust = Onetime::Customer.find_by_email(on_file_email)
-              loc  = cust&.locale
-              loc.to_s.strip.empty? ? OT.default_locale : loc
-            rescue StandardError
-              OT.default_locale
-            end
-
-            # Deliver to the ON-FILE address. Auth-critical → :sync. Fail CLOSED: a
-            # RETURN (true or false) both mean "sent" — false only means "delivered
-            # via the sync fallback rather than queued" — while a RAISE means the
-            # send failed. On failure, consume the just-issued token and fall through
-            # to the H-3 refusal rather than telling the user to check an inbox that
-            # got no mail.
-            sent = begin
-              Onetime::Jobs::Publisher.enqueue_email(
-                :sso_link_verification,
-                {
-                  email_address: on_file_email,
-                  confirm_url: "#{request.base_url}/sso-link-confirm/#{verification.token}",
-                  provider: provider,
-                  baseuri: request.base_url,
-                  product_name: OT.conf.dig('site', 'product_name'),
-                  display_domain: request.host,
-                  locale: locale,
-                },
-                fallback: :sync,
+            # ISSUANCE GATE — symmetric with the confirm-time watermark probe.
+            #
+            # ConfirmSsoLink#watermark_state fails SECURE on an unresolvable Customer:
+            # nil → :unreadable → :link_error (409). Confirm re-derives the identifier
+            # with the SAME external_id-first logic used above, so a Customer that does
+            # not resolve HERE will not resolve THERE either — minting anyway would mail
+            # a link that is guaranteed to 409 on every click, forever, with no other way
+            # in (this branch is reached only for PASSWORDLESS accounts, so the H-3
+            # "sign in with your existing method" recovery does not exist for them).
+            #
+            # This is not hypothetical: `accounts.email` is citext (case-insensitive
+            # compare, case-PRESERVING storage) and migrations/007_normalize_customer_
+            # emails.rb is a MANUAL migration that bails on duplicates, so mixed-case
+            # rows survive in the field. An external_id-less row stored as
+            # 'User@Example.com' probes the Customer email index — whose Redis hash keys
+            # ARE case-sensitive (customer.rb:282) and hold only the normalized
+            # 'user@example.com' — and misses.
+            #
+            # Do NOT "fix" this by normalizing the identifier on this side alone: the
+            # issue-time and confirm-time identifiers must stay derived identically, or
+            # the two sides resolve different records and the drift reappears as a
+            # spurious :link_invalidated. Refuse instead — the user gets the actionable
+            # H-3 message immediately rather than an unredeemable email — and audit it,
+            # because an account row whose Customer cannot be resolved also cannot
+            # authenticate app-side (BaseSessionAuthStrategy → CUSTOMER_NOT_FOUND) and
+            # needs an operator to reconcile it.
+            if customer.nil?
+              Auth::Logging.log_auth_event(
+                :sso_link_verification_customer_unresolved,
+                level: :error,
+                email: OT::Utils.obscure_email(on_file_email),
+                provider: provider,
+                account_id: existing_id,
               )
-              true
-            rescue StandardError => ex
+            else
+              # Snapshot the account's credential watermark so ANY later credential
+              # change (password set/reset/change stamps Customer#last_password_update
+              # via UpdatePasswordMetadata) invalidates this token at consume time.
+              # Independent fallback (0) — a failure to read the watermark must not
+              # silently default the locale, or vice versa.
+              watermark = begin
+                customer.last_password_update.to_i
+              rescue StandardError
+                0
+              end
+
+              verification = Onetime::SsoLinkVerification.issue(
+                provider: provider,
+                issuer: resolved_issuer,
+                uid: omniauth_uid,
+                # NORMALIZED, not on_file_email — see the do-not-unify note above (the
+                # confirm-time ownership re-check compares the normalized form).
+                email: normalized_email,
+                account_id: existing_id,
+                sid: session.id&.public_id,
+                password_watermark: watermark,
+              )
+
+              locale = begin
+                loc = customer.locale
+                loc.to_s.strip.empty? ? OT.default_locale : loc
+              rescue StandardError
+                OT.default_locale
+              end
+
+              # Deliver to the ON-FILE address. Auth-critical → fail CLOSED, where
+              # "sent" must mean SENT: deliver_sso_link_verification (below) performs
+              # the send in a way whose outcome this call site can actually observe,
+              # and documents why Publisher's return value cannot answer that. Both
+              # shapes of failure — a raise AND a "returned without dispatching
+              # anything" — consume the just-issued token and fall through to the H-3
+              # refusal, rather than telling the user to check an inbox that got no
+              # mail while the token lives out its TTL orphaned.
+              link_email = {
+                email_address: on_file_email,
+                confirm_url: "#{request.base_url}/sso-link-confirm/#{verification.token}",
+                provider: provider,
+                baseuri: request.base_url,
+                product_name: OT.conf.dig('site', 'product_name'),
+                display_domain: request.host,
+                locale: locale,
+              }
+
+              delivery_error = nil
+              sent           = begin
+                Auth::Config::Hooks::OmniAuth.deliver_sso_link_verification(link_email)
+              rescue StandardError => ex
+                delivery_error = ex.message
+                false
+              end
+
+              if sent
+                Auth::Logging.log_auth_event(
+                  :sso_link_verification_issued,
+                  level: :warn,
+                  email: OT::Utils.obscure_email(on_file_email),
+                  provider: provider,
+                  issuer: resolved_issuer,
+                  account_id: existing_id,
+                )
+                # TOKEN-LESS informational redirect — the token is only in the email.
+                # Halts, so everything below is the NOT-sent path.
+                redirect '/signin?auth_notice=link_verification_sent'
+              end
+
+              # Not sent — either a raise or a "returned without dispatching
+              # anything". One audit event for both shapes.
               Auth::Logging.log_auth_event(
                 :sso_link_verification_send_FAILED,
                 level: :error,
                 email: OT::Utils.obscure_email(on_file_email),
                 provider: provider,
-                error: ex.message,
+                error: delivery_error || 'not dispatched (suppressed, delivery disabled, or nothing sent)',
               )
-              false
-            end
 
-            if sent
-              Auth::Logging.log_auth_event(
-                :sso_link_verification_issued,
-                level: :warn,
-                email: OT::Utils.obscure_email(on_file_email),
-                provider: provider,
-                issuer: resolved_issuer,
-                account_id: existing_id,
-              )
-              # TOKEN-LESS informational redirect — the token is only in the email.
-              redirect '/signin?auth_notice=link_verification_sent'
+              # Delivery failed → do not leave an un-notified token live; fall through.
+              verification.delete!
             end
-
-            # Delivery failed → do not leave an un-notified token live; fall through.
-            verification.delete!
           end
 
-          # SSO-only account, tenant surface (or platform mailbox delivery failed)
-          # → UNCHANGED H-3 refusal.
+          # SSO-only account, tenant surface (or platform mailbox delivery failed,
+          # or the account's Customer did not resolve so no redeemable link could
+          # be minted) → UNCHANGED H-3 refusal.
           #
           # RECOVERY (Phase 2, shipped): a password-first user who hits this
           # refusal self-resolves by signing in with their password, then
@@ -780,6 +850,79 @@ module Auth::Config::Hooks
         error: ex.message,
       )
       false
+    end
+
+    # Send the Phase 4 mailbox-proof link and report whether it was ACTUALLY
+    # dispatched.
+    #
+    # The obvious call — Publisher.enqueue_email(..., fallback: :sync) — CANNOT
+    # answer that question, and this is the one send in the app where a wrong
+    # answer strands the user: the callback redirects them to "check your inbox"
+    # while the only credential that completes the link never arrives, and the
+    # token lives out its TTL orphaned. Publisher returns true when QUEUED and
+    # false when the fallback ran, and execute_fallback DISCARDS
+    # send_synchronously's boolean (lib/onetime/jobs/publisher.rb:551-553), which
+    # itself swallows Onetime::Mail::DeliveryError by contract (publisher.rb:595-600,
+    # 621-623) — so a REJECTED send is indistinguishable from a queued one. Two
+    # further paths are silent successes at the MAIL layer, on the QUEUED route
+    # too: a suppressed recipient (Delivery::Base#deliver returns nil,
+    # mail/delivery/base.rb:55-58) and EMAILER_MODE=disabled (Delivery::Disabled,
+    # mail/delivery/disabled.rb:21-23).
+    #
+    # So this auth-critical call site does the send itself:
+    #   1. probe the two silent-drop conditions BEFORE claiming anything;
+    #   2. hand the message to RabbitMQ with fallback: :none, so a true return
+    #      means genuinely QUEUED and never "fell back to something I cannot
+    #      see" — the queued happy path stays non-blocking for the callback;
+    #   3. when nothing was queued (jobs disabled, RabbitMQ down), deliver INLINE
+    #      through the same mail path the worker uses, where a nil return (nothing
+    #      dispatched) and a raised DeliveryError are both visible to us.
+    #
+    # NOT fallback: :raise — that refuses to deliver at all when RabbitMQ is down,
+    # turning a degraded-but-working install into a broken one. Publisher's own
+    # semantics are deliberately left ALONE: every other mailer in the app shares
+    # them and none of them are auth-critical in this way.
+    #
+    # @param data [Hash] :sso_link_verification template data (email_address,
+    #   confirm_url, provider, locale, ...)
+    # @return [Boolean] true only when queued or observably dispatched
+    # @raise [StandardError] transport/delivery errors from the inline path; the
+    #   caller audits them and fails closed
+    def self.deliver_sso_link_verification(data)
+      require 'onetime/mail'
+
+      recipient = data[:email_address].to_s
+
+      # Silent-drop probe 1: the install has no delivery at all (EMAILER_MODE=
+      # disabled/none). Config-only query, no backend instantiated.
+      return false if %w[disabled none].include?(Onetime::Mail::Mailer.determine_provider.to_s)
+
+      # Silent-drop probe 2: the recipient is suppressed, so every send to it is
+      # skipped — including the queued one, which could never report back here.
+      # FAIL-OPEN on a probe error, matching the mail layer's own guard contract
+      # (mail/delivery/base.rb:133-141): a suppression-check failure must never
+      # block a send. The real send re-runs the same guard.
+      suppressed = begin
+        defined?(Onetime::EmailSuppression) && Onetime::EmailSuppression.suppressed?(recipient)
+      rescue StandardError => ex
+        OT.le "[sso-link] suppression probe failed (failing open): #{ex.message}"
+        false
+      end
+      return false if suppressed
+
+      # Queued delivery is the happy path: non-blocking for the callback, and the
+      # worker owns retry/DLQ from there.
+      return true if Onetime::Jobs::Publisher.enqueue_email(:sso_link_verification, data, fallback: :none)
+
+      # Nothing queued → deliver here and READ the outcome. nil means the mail
+      # layer dispatched nothing; a transport failure raises DeliveryError, which
+      # the caller treats as not-sent. Locale is passed the way EmailWorker passes
+      # it (jobs/workers/email_worker.rb:156-165) — Publisher's in-process fallback
+      # drops it and always renders 'en'.
+      locale = data[:locale].to_s.strip
+      locale = OT.default_locale if locale.empty?
+
+      !Onetime::Mail.deliver(:sso_link_verification, data, locale: locale).nil?
     end
   end
 end

--- a/apps/web/auth/config/hooks/omniauth.rb
+++ b/apps/web/auth/config/hooks/omniauth.rb
@@ -17,6 +17,11 @@
 
 module Auth::Config::Hooks
   module OmniAuth
+    # rubocop:disable Metrics/PerceivedComplexity
+    # A long, linear chain of Rodauth hook registrations (mirrors the same
+    # inline disable on Hooks::Account.configure). Splitting it would scatter the
+    # callback flow across methods and obscure the account_from_omniauth branch
+    # order the security model depends on.
     def self.configure(auth)
       # Normalize email for case-insensitive account lookup.
       # Required because:
@@ -293,9 +298,115 @@ module Auth::Config::Hooks
             # Redirect to the SPA interstitial route (served by the Vue app),
             # carrying the single-use token as a path segment.
             redirect "/link-sso/#{challenge.token}"
+          elsif platform_surface
+            # ────────────────────────────────────────────────────────────────
+            # #3840 Phase 4: mailbox-proof linking for PASSWORDLESS accounts.
+            # ────────────────────────────────────────────────────────────────
+            #
+            # The located account has NO challengeable password, so Phase 3's
+            # password interstitial cannot help — but a passwordless account CAN
+            # still prove ownership: control of its on-file mailbox (the SAME proof
+            # magic-link/email_auth uses to authenticate). Email a single-use token
+            # to the ON-FILE address and bind (provider, issuer, uid) only when the
+            # user clicks it (POST /auth/sso-link-confirm, routes/sso_link_confirm.rb).
+            #
+            # SECURITY: the token proves MAILBOX control, so it travels ONLY via the
+            # emailed link — NEVER in this callback redirect. We redirect the browser
+            # to a TOKEN-LESS notice; the token reaches only the on-file inbox. A
+            # caller who merely completed an SSO round-trip asserting the victim's
+            # email therefore cannot self-consume it. Still honours "email may
+            # LOCATE, only a demonstrated credential may BIND" — mailbox control is
+            # the credential.
+            #
+            # PLATFORM-ONLY (the elsif guard, NOT redundant): an unauthenticated
+            # TENANT callback also reaches this email branch with
+            # session[:validated_omniauth_domain_id] SET (has_password is already
+            # gated on the platform surface, so it is false here for tenants). A
+            # tenant admin controls their IdP and could otherwise trigger link emails
+            # to arbitrary platform addresses, so tenant callbacks fall through to the
+            # H-3 refusal below (authenticated tenant-surface linking is a follow-up,
+            # #3849).
+            on_file_email = existing[:email]
+
+            # Snapshot the account's credential watermark so ANY later credential
+            # change (password set/reset/change stamps Customer#last_password_update
+            # via UpdatePasswordMetadata) invalidates this token at consume time.
+            watermark = begin
+              custid = existing[:external_id].to_s.empty? ? on_file_email : existing[:external_id]
+              Onetime::Customer.load_by_extid_or_email(custid)&.last_password_update.to_i
+            rescue StandardError
+              0
+            end
+
+            verification = Onetime::SsoLinkVerification.issue(
+              provider: provider,
+              issuer: resolved_issuer,
+              uid: omniauth_uid,
+              email: normalized_email,
+              account_id: existing_id,
+              sid: session.id&.public_id,
+              password_watermark: watermark,
+            )
+
+            locale = begin
+              cust = Onetime::Customer.find_by_email(on_file_email)
+              loc  = cust&.locale
+              loc.to_s.strip.empty? ? OT.default_locale : loc
+            rescue StandardError
+              OT.default_locale
+            end
+
+            # Deliver to the ON-FILE address. Auth-critical → :sync. Fail CLOSED: a
+            # RETURN (true or false) both mean "sent" — false only means "delivered
+            # via the sync fallback rather than queued" — while a RAISE means the
+            # send failed. On failure, consume the just-issued token and fall through
+            # to the H-3 refusal rather than telling the user to check an inbox that
+            # got no mail.
+            sent = begin
+              Onetime::Jobs::Publisher.enqueue_email(
+                :sso_link_verification,
+                {
+                  email_address: on_file_email,
+                  confirm_url: "#{request.base_url}/sso-link-confirm/#{verification.token}",
+                  provider: provider,
+                  baseuri: request.base_url,
+                  product_name: OT.conf.dig('site', 'product_name'),
+                  display_domain: request.host,
+                  locale: locale,
+                },
+                fallback: :sync,
+              )
+              true
+            rescue StandardError => ex
+              Auth::Logging.log_auth_event(
+                :sso_link_verification_send_FAILED,
+                level: :error,
+                email: OT::Utils.obscure_email(on_file_email),
+                provider: provider,
+                error: ex.message,
+              )
+              false
+            end
+
+            if sent
+              Auth::Logging.log_auth_event(
+                :sso_link_verification_issued,
+                level: :warn,
+                email: OT::Utils.obscure_email(on_file_email),
+                provider: provider,
+                issuer: resolved_issuer,
+                account_id: existing_id,
+              )
+              # TOKEN-LESS informational redirect — the token is only in the email.
+              redirect '/signin?auth_notice=link_verification_sent'
+            end
+
+            # Delivery failed → do not leave an un-notified token live; fall through.
+            verification.delete!
           end
 
-          # SSO-only account (no password to challenge) → UNCHANGED H-3 refusal.
+          # SSO-only account, tenant surface (or platform mailbox delivery failed)
+          # → UNCHANGED H-3 refusal.
           #
           # RECOVERY (Phase 2, shipped): a password-first user who hits this
           # refusal self-resolves by signing in with their password, then
@@ -633,6 +744,7 @@ module Auth::Config::Hooks
         '/signin?auth_error=sso_failed'
       end
     end
+    # rubocop:enable Metrics/PerceivedComplexity
 
     # Does the located account have a password the Phase 3 interstitial can
     # challenge? True when a Rodauth password hash exists, OR (coverage) when a

--- a/apps/web/auth/operations.rb
+++ b/apps/web/auth/operations.rb
@@ -15,6 +15,7 @@ require_relative 'operations/disable_mfa'
 require_relative 'operations/detect_mfa_requirement'
 require_relative 'operations/mfa_state_checker'
 require_relative 'operations/bind_sso_identity'
+require_relative 'operations/confirm_sso_link'
 require_relative 'operations/prepare_mfa_session'
 require_relative 'operations/migrate_password_from_redis'
 

--- a/apps/web/auth/operations/confirm_sso_link.rb
+++ b/apps/web/auth/operations/confirm_sso_link.rb
@@ -65,6 +65,11 @@ module Auth
       # @!attribute account_id [String, nil] the bound/target account id (for the route's login)
       # @!attribute email [String, nil] the normalized login the route logs in as
       # @!attribute provider [String, nil] provider name (logging + response context)
+      # @!attribute issuer [String, nil] resolved IdP issuer. Carried on a DEFERRED
+      #   MFA bind (:ok + second_factor_pending) so the route can stash the pending
+      #   bind tuple for after_two_factor_authentication to complete (#3877); nil on
+      #   the failure statuses, which never bind.
+      # @!attribute uid [String, nil] provider-scoped subject id (same deferred-bind use)
       # @!attribute bound [Boolean] whether the identity row was actually bound this call
       # @!attribute second_factor_pending [Boolean] whether the bind was deferred for MFA
       Result = Struct.new(
@@ -72,6 +77,8 @@ module Auth
         :account_id,
         :email,
         :provider,
+        :issuer,
+        :uid,
         :bound,
         :second_factor_pending,
         keyword_init: true,
@@ -136,13 +143,22 @@ module Auth
             level: :warn,
             email: OT::Utils.obscure_email(verification.email),
             provider: verification.provider,
+            issuer: verification.issuer,
             account_id: account_id,
           )
+          # DEFERRED BIND (#3877): the bind is authorized (mailbox proof consumed
+          # above) but must NOT land before the second factor — an MFA-exempt SSO
+          # row bound pre-2FA is an MFA-bypass. Surface issuer/uid so the route can
+          # stash the pending bind inside its rodauth.login block (the only place
+          # the login's FINAL re-keyed sid exists); after_two_factor_authentication
+          # then completes it via DeferredSsoBind, exactly like the interstitial.
           return Result.new(
             status: :ok,
             account_id: account_id,
             email: verification.email,
             provider: verification.provider,
+            issuer: verification.issuer,
+            uid: verification.uid,
             bound: false,
             second_factor_pending: true,
           )
@@ -171,6 +187,8 @@ module Auth
           account_id: account_id,
           email: verification.email,
           provider: verification.provider,
+          issuer: verification.issuer,
+          uid: verification.uid,
           bound: true,
           second_factor_pending: false,
         )

--- a/apps/web/auth/operations/confirm_sso_link.rb
+++ b/apps/web/auth/operations/confirm_sso_link.rb
@@ -1,0 +1,260 @@
+# apps/web/auth/operations/confirm_sso_link.rb
+#
+# frozen_string_literal: true
+
+require 'auth/lib/logging'
+require 'auth/operations/bind_sso_identity'
+require 'auth/operations/mfa_state_checker'
+require 'auth/operations/detect_mfa_requirement'
+
+#
+# Consume a mailbox-proof SsoLinkVerification token and bind the SSO identity
+# (#3840 Phase 4). This is the orchestration step for the passwordless linking
+# flow: load -> atomic single-use consume -> re-verify ownership + credential
+# watermark -> (MFA gate) -> bind via the shared primitive -> audit.
+#
+# It does NOT decide whether mailbox proof was valid — the fact that the token was
+# delivered ONLY to the on-file inbox (never in the callback redirect) IS the
+# proof, and holding the token is holding that proof. This op re-checks that the
+# snapshot still holds (account unchanged, email unchanged, no credential change)
+# and performs the bind through Auth::Operations::BindSsoIdentity.
+#
+# rodauth-INDEPENDENT by construction: it takes `db` explicitly and re-locates the
+# account by its snapshotted primary key in `db[:accounts]`. Session establishment
+# (login) is NOT its job — that requires a live Rodauth request and is done by the
+# calling route (Auth::Routes::SsoLinkConfirm) after this op returns :ok. The op is
+# handed `current_sid` (for the soft cross-device check) and `mfa_feature_loaded`
+# (whether the OTP feature is present) so it stays free of Rodauth internals.
+#
+# SECURITY MODEL (mirrors SsoLinkChallenge/LinkSso, mailbox proof replacing the
+# password proof):
+#   - SINGLE-USE: #delete! is the atomic consume gate. Exactly one of two
+#     concurrent consumers gets the delete count 1; the loser gets 0 -> :link_expired.
+#     Consumed up front, before the bind, so the token is worth one attempt.
+#   - OWNERSHIP RE-CHECK: the account is re-located by the snapshotted account_id and
+#     its email must STILL normalize to the token's email. A drift (account re-emailed,
+#     or the row gone) fails closed (:link_conflict / :link_expired) rather than
+#     binding onto an account the mailbox proof no longer matches.
+#   - CREDENTIAL-CHANGE INVALIDATION (criterion 3): the token snapshots
+#     Customer#last_password_update at issuance; if it advanced (any password
+#     set/reset/change stamps it via UpdatePasswordMetadata) the token is rejected
+#     (:link_invalidated). A watermark comparison, not a token-enumeration sweep.
+#   - MFA-SAFE BIND: SSO logins are MFA-exempt, so binding an SSO path before a
+#     pending second factor is satisfied would attach an MFA-bypassing login to the
+#     account. When the account has a pending second factor the bind is DEFERRED
+#     (bound: false); the route still logs the user in, which routes them to the OTP
+#     step. Moot for default installs (MFA off) but load-bearing for AUTH_MFA_ENABLED.
+#
+# Returns a Result (see below). The route maps status -> HTTP:
+#   :ok             -> establish session (or MFA hand-off); 200
+#   :link_expired   -> 401 (token missing / consumed / expired, or account vanished)
+#   :link_conflict  -> 409 (account/email drift, or the identity is owned elsewhere)
+#   :link_invalidated -> 409 (a credential change advanced the watermark since issuance)
+#
+module Auth
+  module Operations
+    class ConfirmSsoLink
+      # @!attribute status [Symbol] :ok | :link_expired | :link_conflict | :link_invalidated
+      # @!attribute account_id [String, nil] the bound/target account id (for the route's login)
+      # @!attribute email [String, nil] the normalized login the route logs in as
+      # @!attribute provider [String, nil] provider name (logging + response context)
+      # @!attribute bound [Boolean] whether the identity row was actually bound this call
+      # @!attribute second_factor_pending [Boolean] whether the bind was deferred for MFA
+      Result = Struct.new(
+        :status,
+        :account_id,
+        :email,
+        :provider,
+        :bound,
+        :second_factor_pending,
+        keyword_init: true,
+      ) do
+        def ok?
+          status == :ok
+        end
+      end
+
+      # @param db [Sequel::Database] the auth database (explicit — NOT rodauth.db, so
+      #   the op is usable outside a Rodauth request context)
+      # @param token [String] the raw single-use verification token from the email link
+      # @param current_sid [String, nil] the current request's session id (soft-bound)
+      # @param mfa_feature_loaded [Boolean] whether the OTP feature is enabled for this deploy
+      # @return [Result]
+      def self.call(db:, token:, current_sid: nil, mfa_feature_loaded: false)
+        new(
+          db: db, token: token, current_sid: current_sid, mfa_feature_loaded: mfa_feature_loaded,
+        ).call
+      end
+
+      def initialize(db:, token:, current_sid: nil, mfa_feature_loaded: false)
+        @db                 = db
+        @token              = token.to_s
+        @current_sid        = current_sid.to_s
+        @mfa_feature_loaded = mfa_feature_loaded
+      end
+
+      # @return [Result]
+      def call
+        verification = Onetime::SsoLinkVerification.load(@token)
+        return expired unless verification
+
+        # SINGLE-USE (atomic): consume NOW, before any bind. #delete! returns the
+        # Redis DEL count; exactly one of two racing consumers gets 1.
+        return expired unless verification.delete! == 1
+
+        warn_on_cross_device(verification)
+
+        account = @db[:accounts].where(id: verification.account_id.to_i).first
+        return expired unless account
+
+        # OWNERSHIP RE-CHECK: the account's email must still normalize to the token's
+        # email. A drift means the account was re-emailed since issuance and the
+        # mailbox proof no longer matches — never bind.
+        if OT::Utils.normalize_email(account[:email]) != verification.email.to_s
+          return conflict(verification)
+        end
+
+        # CREDENTIAL-CHANGE INVALIDATION (criterion 3).
+        return invalidated(verification) if watermark_advanced?(account, verification)
+
+        account_id = verification.account_id
+
+        if second_factor_pending?(account_id)
+          Auth::Logging.log_auth_event(
+            :sso_link_verification_deferred_mfa,
+            level: :warn,
+            email: OT::Utils.obscure_email(verification.email),
+            provider: verification.provider,
+            account_id: account_id,
+          )
+          return Result.new(
+            status: :ok,
+            account_id: account_id,
+            email: verification.email,
+            provider: verification.provider,
+            bound: false,
+            second_factor_pending: true,
+          )
+        end
+
+        bind_result = Auth::Operations::BindSsoIdentity.call(
+          db: @db,
+          account_id: account_id,
+          provider: verification.provider,
+          issuer: verification.issuer,
+          uid: verification.uid,
+        )
+        return conflict(verification) if bind_result == :conflict
+
+        Auth::Logging.log_auth_event(
+          :sso_link_verification_confirmed,
+          level: :warn,
+          email: OT::Utils.obscure_email(verification.email),
+          provider: verification.provider,
+          issuer: verification.issuer,
+          account_id: account_id,
+        )
+
+        Result.new(
+          status: :ok,
+          account_id: account_id,
+          email: verification.email,
+          provider: verification.provider,
+          bound: true,
+          second_factor_pending: false,
+        )
+      end
+
+      private
+
+      # SOFT session binding: the initiating sid is recorded for observability, but
+      # mailbox proof is inherently cross-device (the user may click on their phone),
+      # so a mismatch is logged and TOLERATED — never rejected.
+      def warn_on_cross_device(verification)
+        token_sid = verification.sid.to_s
+        return if token_sid.empty? || @current_sid.empty? || token_sid == @current_sid
+
+        Auth::Logging.log_auth_event(
+          :sso_link_verification_cross_device,
+          level: :info,
+          provider: verification.provider,
+          account_id: verification.account_id,
+        )
+      end
+
+      # Has a credential change advanced the account's watermark since issuance?
+      # Resolves the Customer the same way the password hooks do (external_id first,
+      # email fallback). A resolution error fails SECURE: treat as advanced so the
+      # token is rejected rather than binding without certainty the credential is
+      # unchanged.
+      def watermark_advanced?(account, verification)
+        identifier = account[:external_id].to_s.empty? ? account[:email] : account[:external_id]
+        current    = Onetime::Customer.load_by_extid_or_email(identifier)&.last_password_update.to_i
+        current > verification.password_watermark.to_i
+      rescue StandardError => ex
+        Auth::Logging.log_auth_event(
+          :sso_link_verification_watermark_probe_error,
+          level: :warn,
+          provider: verification.provider,
+          account_id: verification.account_id,
+          error: ex.message,
+        )
+        true
+      end
+
+      # Mirror the after_login MFA decision (a pure function of the account's stored
+      # factors, via_omniauth: false) so the bind is gated on FULL authentication.
+      # When the OTP feature is not loaded (MFA off — the default) no second factor
+      # can be pending, so this is false and the bind proceeds.
+      def second_factor_pending?(account_id)
+        return false unless @mfa_feature_loaded
+
+        mfa_state = Auth::Operations::MfaStateChecker.new(@db).check(account_id)
+        Auth::Operations::DetectMfaRequirement.call(
+          account_id: account_id,
+          has_otp_secret: mfa_state.has_otp_secret,
+          has_recovery_codes: mfa_state.has_recovery_codes,
+          via_omniauth: false,
+        ).requires_mfa?
+      end
+
+      def expired
+        Result.new(status: :link_expired, bound: false, second_factor_pending: false)
+      end
+
+      def conflict(verification)
+        Auth::Logging.log_auth_event(
+          :sso_link_verification_conflict,
+          level: :warn,
+          email: OT::Utils.obscure_email(verification.email),
+          provider: verification.provider,
+          account_id: verification.account_id,
+        )
+        Result.new(
+          status: :link_conflict,
+          account_id: verification.account_id,
+          provider: verification.provider,
+          bound: false,
+          second_factor_pending: false,
+        )
+      end
+
+      def invalidated(verification)
+        Auth::Logging.log_auth_event(
+          :sso_link_verification_invalidated,
+          level: :warn,
+          email: OT::Utils.obscure_email(verification.email),
+          provider: verification.provider,
+          account_id: verification.account_id,
+        )
+        Result.new(
+          status: :link_invalidated,
+          account_id: verification.account_id,
+          provider: verification.provider,
+          bound: false,
+          second_factor_pending: false,
+        )
+      end
+    end
+  end
+end

--- a/apps/web/auth/operations/confirm_sso_link.rb
+++ b/apps/web/auth/operations/confirm_sso_link.rb
@@ -39,6 +39,10 @@ require 'auth/operations/detect_mfa_requirement'
 #     Customer#last_password_update at issuance; if it advanced (any password
 #     set/reset/change stamps it via UpdatePasswordMetadata) the token is rejected
 #     (:link_invalidated). A watermark comparison, not a token-enumeration sweep.
+#     An UNREADABLE watermark (probe raises, or the Customer does not resolve) is
+#     rejected just as hard — the guard fails secure, never open — but under its
+#     OWN status (:link_error), because an outage on our side is not a credential
+#     change the user made and must not be reported to them as one.
 #   - MFA-SAFE BIND: SSO logins are MFA-exempt, so binding an SSO path before a
 #     pending second factor is satisfied would attach an MFA-bypassing login to the
 #     account. When the account has a pending second factor the bind is DEFERRED
@@ -50,11 +54,14 @@ require 'auth/operations/detect_mfa_requirement'
 #   :link_expired   -> 401 (token missing / consumed / expired, or account vanished)
 #   :link_conflict  -> 409 (account/email drift, or the identity is owned elsewhere)
 #   :link_invalidated -> 409 (a credential change advanced the watermark since issuance)
+#   :link_error     -> 409 (the watermark could not be READ — our outage, not their
+#                      credential change; terminal all the same, the token is spent)
 #
 module Auth
   module Operations
     class ConfirmSsoLink
-      # @!attribute status [Symbol] :ok | :link_expired | :link_conflict | :link_invalidated
+      # @!attribute status [Symbol] :ok | :link_expired | :link_conflict |
+      #   :link_invalidated | :link_error
       # @!attribute account_id [String, nil] the bound/target account id (for the route's login)
       # @!attribute email [String, nil] the normalized login the route logs in as
       # @!attribute provider [String, nil] provider name (logging + response context)
@@ -114,8 +121,12 @@ module Auth
           return conflict(verification)
         end
 
-        # CREDENTIAL-CHANGE INVALIDATION (criterion 3).
-        return invalidated(verification) if watermark_advanced?(account, verification)
+        # CREDENTIAL-CHANGE INVALIDATION (criterion 3). Tri-state on purpose: an
+        # unreadable watermark rejects like an advance but carries its own status.
+        case watermark_state(account, verification)
+        when :advanced   then return invalidated(verification)
+        when :unreadable then return probe_failed(verification)
+        end
 
         account_id = verification.account_id
 
@@ -183,14 +194,51 @@ module Auth
       end
 
       # Has a credential change advanced the account's watermark since issuance?
+      # Tri-state: :unchanged (bind may proceed) | :advanced (a real credential
+      # change) | :unreadable (the watermark could not be read at all).
+      #
       # Resolves the Customer the same way the password hooks do (external_id first,
-      # email fallback). A resolution error fails SECURE: treat as advanced so the
-      # token is rejected rather than binding without certainty the credential is
-      # unchanged.
-      def watermark_advanced?(account, verification)
+      # email fallback). An UNRESOLVABLE Customer fails SECURE: :unreadable rejects
+      # the token rather than binding without certainty the credential is unchanged.
+      #
+      # :unreadable is kept DISTINCT from :advanced even though both reject, because
+      # they mean opposite things to the person holding the link: :advanced is a
+      # credential change THEY made, :unreadable is a datastore outage on OUR side.
+      # Collapsing them tells an outage victim their credentials changed and sends
+      # them hunting for a change that never happened. Both are equally terminal —
+      # the token was consumed above — so the distinction is in the copy, not in
+      # whether a retry is offered.
+      #
+      # BOTH unresolvable shapes count — a raise AND a nil return. The nil is the
+      # subtle one: `load_by_extid_or_email` returns nil (it does not raise) for an
+      # absent record or an index miss, so a `&.last_password_update.to_i` would
+      # yield 0, compare as "not advanced", and let the bind PROCEED — fail-OPEN in
+      # exactly the case where the credential state cannot be read. A nil is not a
+      # legitimate state here: the account row was already located above, and the
+      # issuance side resolved the SAME Customer by the SAME identifier to snapshot
+      # the watermark. An account whose Customer cannot be resolved cannot
+      # authenticate app-side either (BaseSessionAuthStrategy fails CUSTOMER_NOT_FOUND),
+      # so rejecting costs nothing legitimate. Logged under its own event so an
+      # unreadable record is never mistaken for a real credential change.
+      def watermark_state(account, verification)
         identifier = account[:external_id].to_s.empty? ? account[:email] : account[:external_id]
-        current    = Onetime::Customer.load_by_extid_or_email(identifier)&.last_password_update.to_i
-        current > verification.password_watermark.to_i
+        customer   = Onetime::Customer.load_by_extid_or_email(identifier)
+
+        unless customer
+          Auth::Logging.log_auth_event(
+            :sso_link_verification_watermark_probe_missing,
+            level: :warn,
+            provider: verification.provider,
+            account_id: verification.account_id,
+          )
+          return :unreadable
+        end
+
+        if customer.last_password_update.to_i > verification.password_watermark.to_i
+          :advanced
+        else
+          :unchanged
+        end
       rescue StandardError => ex
         Auth::Logging.log_auth_event(
           :sso_link_verification_watermark_probe_error,
@@ -199,7 +247,7 @@ module Auth
           account_id: verification.account_id,
           error: ex.message,
         )
-        true
+        :unreadable
       end
 
       # Mirror the after_login MFA decision (a pure function of the account's stored
@@ -249,6 +297,26 @@ module Auth
         )
         Result.new(
           status: :link_invalidated,
+          account_id: verification.account_id,
+          provider: verification.provider,
+          bound: false,
+          second_factor_pending: false,
+        )
+      end
+
+      # The watermark could not be READ (see watermark_state) — an infrastructure
+      # failure, not a credential change. Rejected exactly like an advance (the
+      # token is already spent, so this is terminal either way); only the status
+      # differs, so the route can send copy that does not accuse the user of a
+      # credential change they never made.
+      #
+      # No audit event here: watermark_state already logged the SPECIFIC shape
+      # (:sso_link_verification_watermark_probe_missing / _probe_error) at :warn
+      # with the reason attached. A second terminal event would double-count the
+      # same failure with strictly less detail.
+      def probe_failed(verification)
+        Result.new(
+          status: :link_error,
           account_id: verification.account_id,
           provider: verification.provider,
           bound: false,

--- a/apps/web/auth/operations/deferred_sso_bind.rb
+++ b/apps/web/auth/operations/deferred_sso_bind.rb
@@ -2,6 +2,7 @@
 #
 # frozen_string_literal: true
 
+require 'auth/lib/logging'
 require 'onetime/session/sidecar'
 
 require_relative 'bind_sso_identity'
@@ -117,10 +118,12 @@ module Auth
       class << self
         # Stash a pending bind for the (already re-keyed) login session.
         #
-        # BEST-EFFORT: a storage failure is logged and swallowed — the login
-        # (whose password already verified) must proceed; the user just stays
-        # unlinked this round (fail-closed) and re-hits the interstitial on
-        # their next SSO sign-in.
+        # BEST-EFFORT: a storage failure is swallowed — the login (whose password
+        # already verified) must proceed; the user just stays unlinked this round
+        # (fail-closed) and re-hits the interstitial on their next SSO sign-in.
+        # Both failure shapes emit :sso_deferred_bind_stash_failed to the auth
+        # audit stream (see #stash_failed), so "silent for the user" never means
+        # "silent for the operator".
         #
         # @param sid [String] the session id — read it AFTER login_session has
         #   run (inside the rodauth.login block), or the login-time re-key
@@ -130,9 +133,8 @@ module Auth
         # @param issuer [String, nil] resolved IdP issuer; nil → '' sentinel
         # @param uid [String] provider-scoped subject id
         # @return [Boolean] whether the stash was written
-        def defer(sid:, account_id:, provider:, issuer:, uid:, logger: nil, dbclient: nil, codec: nil)
-          logger ||= default_logger
-          payload  = {
+        def defer(sid:, account_id:, provider:, issuer:, uid:, dbclient: nil, codec: nil)
+          payload = {
             'account_id' => account_id.to_s,
             'provider' => provider.to_s,
             'issuer' => issuer.to_s,
@@ -144,18 +146,10 @@ module Auth
           written = !Onetime::SessionSidecar.write(
             sid, FIELD, payload, dbclient: dbclient, codec: codec
           ).nil?
-          unless written
-            logger.warn 'Deferred SSO bind not stashed: session id unavailable',
-              account_id: account_id,
-              provider: provider
-          end
+          stash_failed(:sid_unavailable, account_id, provider) unless written
           written
         rescue StandardError => ex
-          logger.warn 'Deferred SSO bind not stashed: sidecar write failed',
-            account_id: account_id,
-            provider: provider,
-            error: ex.message,
-            error_class: ex.class.name
+          stash_failed(:write_error, account_id, provider, error: ex.message, error_class: ex.class.name)
           false
         end
 
@@ -181,6 +175,35 @@ module Auth
 
         def default_logger
           Onetime.get_logger('Auth::DeferredSsoBind')
+        end
+
+        private
+
+        # A stash that was never written is a SILENT degradation: the login
+        # proceeds (best-effort by contract) and the user simply stays unlinked,
+        # so nothing downstream ever reports the miss — `.complete` cannot, since
+        # :none is its normal outcome. It therefore goes to the AUTH AUDIT STREAM
+        # (Auth::Logging), not this class's own category logger: the completion
+        # side is already audited there as :sso_deferred_bind_completed by both
+        # callers (hooks/mfa.rb, hooks/login.rb), and a write side visible only
+        # under Auth::DeferredSsoBind means a SYSTEMIC sidecar failure degrades
+        # linking for every MFA user without ever appearing in the stream this
+        # flow is queried through.
+        #
+        # ONE event name carrying a `reason`, not two: the alertable signal is
+        # the stash-failure RATE (paired with the completion metric — hence
+        # log_metric), and both shapes degrade linking identically. The reason
+        # separates a nil/malformed sid from a datastore outage for triage.
+        def stash_failed(reason, account_id, provider, **extra)
+          Auth::Logging.log_auth_event(
+            :sso_deferred_bind_stash_failed,
+            level: :warn,
+            log_metric: true,
+            reason: reason,
+            account_id: account_id,
+            provider: provider,
+            **extra,
+          )
         end
       end
 

--- a/apps/web/auth/router.rb
+++ b/apps/web/auth/router.rb
@@ -17,6 +17,7 @@ require_relative 'routes/account'
 require_relative 'routes/active_sessions'
 require_relative 'routes/identities'
 require_relative 'routes/link_sso'
+require_relative 'routes/sso_link_confirm'
 require_relative 'routes/mfa'
 require_relative 'routes/admin'
 require_relative 'routes/health'
@@ -44,6 +45,7 @@ module Auth
     include Auth::Routes::ActiveSessions
     include Auth::Routes::Identities
     include Auth::Routes::LinkSso
+    include Auth::Routes::SsoLinkConfirm
     include Auth::Routes::Admin
 
     plugin :json, parser: true  # Parse incoming JSON request bodies
@@ -159,6 +161,9 @@ module Auth
 
       # SSO sign-in interstitial: password-challenge linking (#3840 Phase 3)
       handle_link_sso_routes(r)
+
+      # SSO mailbox-proof linking for passwordless accounts (#3840 Phase 4)
+      handle_sso_link_confirm_routes(r)
 
       handle_admin_routes(r)
 

--- a/apps/web/auth/routes/json_body.rb
+++ b/apps/web/auth/routes/json_body.rb
@@ -1,0 +1,40 @@
+# apps/web/auth/routes/json_body.rb
+#
+# frozen_string_literal: true
+
+module Auth
+  module Routes
+    # JSON body parsing for the HAND-ROLLED Roda routes in this directory.
+    #
+    # Rodauth's json feature parses request bodies only for its OWN routes, so the
+    # custom routes here (link_sso, sso_link_confirm) have to parse the body
+    # themselves. Shared so the two SSO-linking endpoints cannot drift apart in how
+    # they read a request.
+    #
+    # Included INTO the route modules (not into Auth::Router directly), so anything
+    # that includes a route module — the router, or a route spec's minimal Roda app
+    # — picks the helper up with it.
+    module JsonBody
+      private
+
+      # Extract the named keys from a JSON body (Content-Type application/json),
+      # falling back to form/query params. Returns a Hash keyed by the given SYMBOLS
+      # with string values ('' when absent), so callers can treat a missing field
+      # and an empty one identically. Rewinds the input so nothing downstream is
+      # surprised by a consumed body.
+      def json_body_params(request, *keys)
+        raw = request.body&.read.to_s
+        request.body.rewind if request.body.respond_to?(:rewind)
+
+        parsed = begin
+          raw.empty? ? {} : JSON.parse(raw)
+        rescue JSON::ParserError
+          {}
+        end
+        parsed = {} unless parsed.is_a?(Hash)
+
+        keys.to_h { |key| [key.to_sym, (parsed[key.to_s] || request.params[key.to_s]).to_s] }
+      end
+    end
+  end
+end

--- a/apps/web/auth/routes/link_sso.rb
+++ b/apps/web/auth/routes/link_sso.rb
@@ -4,6 +4,8 @@
 
 require 'onetime/security/login_rate_limiter'
 
+require_relative 'json_body'
+
 #
 # JSON API for the SSO sign-in interstitial (#3840 Phase 3 / #3838 item 1b).
 #
@@ -60,6 +62,9 @@ module Auth
       # (LinkSso is included into Auth::Router).
       include Onetime::Security::LoginRateLimiter
 
+      # Shared body parser for the custom (non-Rodauth) routes; see json_body.rb.
+      include Auth::Routes::JsonBody
+
       # Error codes returned to the SPA (LinkSso.vue maps these to copy + the
       # Phase 2 settings pointer /account/settings/security/connections):
       #   invalid_request — token or password missing
@@ -97,7 +102,7 @@ module Auth
             # Rodauth's JSON feature parses request bodies only for its OWN
             # routes; this is a custom Roda route, so parse the JSON body here
             # (falling back to form/query params).
-            params   = link_sso_params(request)
+            params   = json_body_params(request, :token, :password)
             token    = params[:token]
             password = params[:password]
 
@@ -268,27 +273,6 @@ module Auth
       end
 
       private
-
-      # Extract { token, password } from a JSON body (Content-Type
-      # application/json), falling back to form/query params. Returns string
-      # values ('' when absent). Rewinds the input so nothing downstream is
-      # surprised by a consumed body.
-      def link_sso_params(request)
-        raw = request.body&.read.to_s
-        request.body.rewind if request.body.respond_to?(:rewind)
-
-        parsed = begin
-          raw.empty? ? {} : JSON.parse(raw)
-        rescue JSON::ParserError
-          {}
-        end
-        parsed = {} unless parsed.is_a?(Hash)
-
-        {
-          token: (parsed['token'] || request.params['token']).to_s,
-          password: (parsed['password'] || request.params['password']).to_s,
-        }
-      end
 
       # Would completing this PASSWORD login leave a second factor pending? Mirrors
       # the after_login hook's MFA decision (hooks/login.rb) for via_omniauth: false

--- a/apps/web/auth/routes/sso_link_confirm.rb
+++ b/apps/web/auth/routes/sso_link_confirm.rb
@@ -4,6 +4,7 @@
 
 require 'auth/lib/logging'
 require 'auth/operations/confirm_sso_link'
+require 'auth/operations/deferred_sso_bind'
 
 require_relative 'json_body'
 
@@ -162,7 +163,27 @@ module Auth
             # The auth_type string is only the authenticated_by label; login does not
             # re-verify a credential (there is none — mailbox proof already authorized
             # this), matching how magic-link establishes a passwordless session.
-            rodauth.login('sso_link_confirm')
+            #
+            # DEFERRED BIND (#3877): when the op deferred the bind for a pending
+            # second factor (bound: false), stash the authorized bind tuple so
+            # after_two_factor_authentication completes it once the OTP succeeds —
+            # otherwise an MFA passwordless account would re-hit this flow forever,
+            # never linked. Mirrors the interstitial (Auth::Routes::LinkSso): the
+            # login block is the ONLY point that sees the login's FINAL sid
+            # (login_session re-keys the session; a stash keyed to the old sid would
+            # never be found) and precedes after_login. Best-effort by contract — a
+            # failed stash is logged inside `.defer` and the login proceeds unlinked.
+            rodauth.login('sso_link_confirm') do
+              if result.second_factor_pending
+                Auth::Operations::DeferredSsoBind.defer(
+                  sid: session.id&.public_id,
+                  account_id: result.account_id,
+                  provider: result.provider,
+                  issuer: result.issuer,
+                  uid: result.uid,
+                )
+              end
+            end
           rescue StandardError => ex
             auth_logger.error 'Error completing SSO link confirmation', { exception: ex }
             response.status = 500

--- a/apps/web/auth/routes/sso_link_confirm.rb
+++ b/apps/web/auth/routes/sso_link_confirm.rb
@@ -1,0 +1,182 @@
+# apps/web/auth/routes/sso_link_confirm.rb
+#
+# frozen_string_literal: true
+
+require 'auth/operations/confirm_sso_link'
+
+#
+# JSON API for the MAILBOX-PROOF SSO linking flow (#3840 Phase 4).
+#
+# When an UNAUTHENTICATED SSO sign-in resolves to an EXISTING PASSWORDLESS account,
+# account_from_omniauth (config/hooks/omniauth.rb) issues a single-use
+# Onetime::SsoLinkVerification, EMAILS the token to the account's on-file address,
+# and redirects the browser to a TOKEN-LESS notice (/signin?auth_notice=
+# link_verification_sent). The token never rides the callback redirect — it reaches
+# the user only through the emailed link, so possessing it proves mailbox control.
+# These endpoints back the confirm page the emailed link points at:
+#
+#   GET  /auth/sso-link-confirm/:token  → { provider, email }   (consent display)
+#   POST /auth/sso-link-confirm         → consume token, bind identity, log in
+#
+# WHY GET IS DISPLAY-ONLY AND POST DOES THE MUTATION: the emailed link opens the
+# SPA consent screen, which GETs the display context (provider + claimed email —
+# criterion 2's consent copy) and only mutates on an explicit user action (the
+# POST). A GET must stay side-effect-free: mail clients and link-preview bots
+# prefetch GET URLs, and a mutating GET would let such a prefetch silently consume
+# the single-use token before the user consents. The GET therefore NEVER consumes;
+# the POST is the atomic single-use consume + bind.
+#
+# SECURITY MODEL (the invariant: email may LOCATE, only a demonstrated credential
+# may BIND — here the credential is MAILBOX CONTROL):
+#   - The token is delivered ONLY to the on-file inbox, so holding it is the proof.
+#   - SINGLE-USE: the POST consumes the token atomically (#delete!) before binding,
+#     so it is good for exactly one confirmation (Auth::Operations::ConfirmSsoLink).
+#   - CREDENTIAL-CHANGE INVALIDATION: the token snapshots the account's password
+#     watermark; a change since issuance rejects it (:link_invalidated).
+#   - MFA-SAFE BIND: when a second factor is pending the bind is DEFERRED (SSO paths
+#     are MFA-exempt), but the login still proceeds to the OTP step.
+#   - CONFIRM LOGS THE USER IN: the account is passwordless, and clicking the emailed
+#     link proves mailbox control == the SAME proof magic-link (email_auth) uses to
+#     authenticate. On success the session is established through Rodauth's OWN login
+#     machinery (rodauth.login) — NOT hand-rolled — so after_login runs (Redis
+#     session blob via SyncSession, active_sessions, MFA detection). The user lands
+#     signed in and their newly linked SSO works next time.
+#   - PLATFORM-only: verifications are issued solely on the platform callback path
+#     (the tenant surface keeps the H-3 refusal), so this is never offered to tenants.
+#
+module Auth
+  module Routes
+    module SsoLinkConfirm
+      # Error codes returned to the SPA (SsoLinkConfirm.vue maps these to copy):
+      #   invalid_request  — token missing from the POST body
+      #   link_expired     — token missing / already consumed / expired, or the
+      #                      snapshotted account vanished (or is no longer loginable)
+      #   link_conflict    — the account was re-emailed since issuance, OR the
+      #                      (provider,issuer,uid) is already bound to a different
+      #                      account (defence-in-depth)
+      #   link_invalidated — a credential change advanced the account's password
+      #                      watermark since the token was issued (criterion 3)
+      def handle_sso_link_confirm_routes(r)
+        r.on 'sso-link-confirm' do
+          # GET /auth/sso-link-confirm/:token — consent display context.
+          # Returns ONLY the provider name and claimed email; never the account id,
+          # uid, issuer, sid, or watermark. NEVER consumes the token (see the
+          # module comment). Missing/consumed/expired token → 404.
+          r.get String do |token|
+            verification = Onetime::SsoLinkVerification.load(token)
+            unless verification
+              response.status = 404
+              next { error: 'This linking request is no longer valid.', error_code: 'link_expired' }
+            end
+
+            response.headers['Content-Type'] = 'application/json'
+            verification.to_display
+          rescue StandardError => ex
+            auth_logger.error 'Error loading SSO link verification', { exception: ex }
+            response.status = 500
+            { error: 'Failed to load linking request' }
+          end
+
+          # POST /auth/sso-link-confirm — consume the token, bind the identity, and
+          # establish the login session. Body: { token }.
+          r.post do
+            # Rodauth's JSON feature parses request bodies only for its OWN routes;
+            # this is a custom Roda route, so parse the JSON body here (falling back
+            # to form/query params).
+            token = sso_link_confirm_params(request)[:token]
+
+            if token.empty?
+              response.status = 400
+              next { error: 'A linking token is required.', error_code: 'invalid_request' }
+            end
+
+            result = Auth::Operations::ConfirmSsoLink.call(
+              db: rodauth.db,
+              token: token,
+              current_sid: sso_link_confirm_current_sid,
+              mfa_feature_loaded: rodauth.respond_to?(:otp_auth_route),
+            )
+
+            case result.status
+            when :link_expired
+              response.status = 401
+              next {
+                error: 'This linking request has expired. Please sign in with SSO again.',
+                error_code: 'link_expired',
+              }
+            when :link_conflict
+              response.status = 409
+              next { error: 'This linking request could not be completed.', error_code: 'link_conflict' }
+            when :link_invalidated
+              response.status = 409
+              next {
+                error: 'Your account credentials changed after this link was sent. Please sign in with SSO again.',
+                error_code: 'link_invalidated',
+              }
+            end
+
+            # result.status == :ok — the identity is bound (or deferred for MFA).
+            # Establish the session through Rodauth's OWN login machinery so
+            # after_login runs (Redis session blob via SyncSession — the real app
+            # auth gate — plus active_sessions and MFA detection). account_from_login
+            # applies the open-status filter, so a closed/absent account yields nil
+            # here → link_expired (the op's bind onto such an account is inert).
+            unless rodauth.account_from_login(result.email)
+              response.status = 401
+              next { error: 'This linking request is no longer valid.', error_code: 'link_expired' }
+            end
+
+            auth_logger.warn 'SSO identity linked via mailbox proof',
+              {
+                account_id: result.account_id,
+                provider: result.provider,
+                bound: result.bound,
+                mfa_pending: result.second_factor_pending,
+              }
+
+            # login('sso_link_confirm') runs before_login/login_session/after_login
+            # and THROWS Rodauth's JSON login response — 200 { success, … } for a
+            # non-MFA account, or the SAME mfa_required body POST /auth/login emits
+            # when a second factor is pending. The SPA already handles both shapes.
+            # The auth_type string is only the authenticated_by label; login does not
+            # re-verify a credential (there is none — mailbox proof already authorized
+            # this), matching how magic-link establishes a passwordless session.
+            rodauth.login('sso_link_confirm')
+          rescue StandardError => ex
+            auth_logger.error 'Error completing SSO link confirmation', { exception: ex }
+            response.status = 500
+            { error: 'Failed to complete linking' }
+          end
+        end
+      end
+
+      private
+
+      # Extract { token } from a JSON body (Content-Type application/json), falling
+      # back to form/query params. Returns a string value ('' when absent). Rewinds
+      # the input so nothing downstream is surprised by a consumed body.
+      def sso_link_confirm_params(request)
+        raw = request.body&.read.to_s
+        request.body.rewind if request.body.respond_to?(:rewind)
+
+        parsed = begin
+          raw.empty? ? {} : JSON.parse(raw)
+        rescue JSON::ParserError
+          {}
+        end
+        parsed = {} unless parsed.is_a?(Hash)
+
+        { token: (parsed['token'] || request.params['token']).to_s }
+      end
+
+      # Current request's session id, for the op's SOFT cross-device check. Best
+      # effort: mailbox proof is inherently cross-device, so a nil here just means
+      # the soft check is skipped — never a failure.
+      def sso_link_confirm_current_sid
+        rodauth.session.id&.public_id
+      rescue StandardError
+        nil
+      end
+    end
+  end
+end

--- a/apps/web/auth/routes/sso_link_confirm.rb
+++ b/apps/web/auth/routes/sso_link_confirm.rb
@@ -2,7 +2,10 @@
 #
 # frozen_string_literal: true
 
+require 'auth/lib/logging'
 require 'auth/operations/confirm_sso_link'
+
+require_relative 'json_body'
 
 #
 # JSON API for the MAILBOX-PROOF SSO linking flow (#3840 Phase 4).
@@ -47,6 +50,9 @@ require 'auth/operations/confirm_sso_link'
 module Auth
   module Routes
     module SsoLinkConfirm
+      # Shared body parser for the custom (non-Rodauth) routes; see json_body.rb.
+      include Auth::Routes::JsonBody
+
       # Error codes returned to the SPA (SsoLinkConfirm.vue maps these to copy):
       #   invalid_request  — token missing from the POST body
       #   link_expired     — token missing / already consumed / expired, or the
@@ -56,6 +62,10 @@ module Auth
       #                      account (defence-in-depth)
       #   link_invalidated — a credential change advanced the account's password
       #                      watermark since the token was issued (criterion 3)
+      #   link_error       — the watermark could NOT be read (datastore outage /
+      #                      unresolvable Customer). Same 409 and same dead-end as
+      #                      link_invalidated, separate code so the copy does not
+      #                      tell the user their credentials changed when they did not
       def handle_sso_link_confirm_routes(r)
         r.on 'sso-link-confirm' do
           # GET /auth/sso-link-confirm/:token — consent display context.
@@ -83,7 +93,7 @@ module Auth
             # Rodauth's JSON feature parses request bodies only for its OWN routes;
             # this is a custom Roda route, so parse the JSON body here (falling back
             # to form/query params).
-            token = sso_link_confirm_params(request)[:token]
+            token = json_body_params(request, :token)[:token]
 
             if token.empty?
               response.status = 400
@@ -112,6 +122,17 @@ module Auth
               next {
                 error: 'Your account credentials changed after this link was sent. Please sign in with SSO again.',
                 error_code: 'link_invalidated',
+              }
+            when :link_error
+              # The op could not READ the credential watermark (datastore outage),
+              # so it fails secure — but nothing about this account changed. 409,
+              # NOT a 5xx: the token was already consumed before the probe ran, so
+              # this link can never succeed and a status that invites a retry of the
+              # SAME link would be a lie. Terminal, like every other failure here.
+              response.status = 409
+              next {
+                error: "We couldn't verify this linking request. Please sign in with SSO again.",
+                error_code: 'link_error',
               }
             end
 
@@ -152,29 +173,27 @@ module Auth
 
       private
 
-      # Extract { token } from a JSON body (Content-Type application/json), falling
-      # back to form/query params. Returns a string value ('' when absent). Rewinds
-      # the input so nothing downstream is surprised by a consumed body.
-      def sso_link_confirm_params(request)
-        raw = request.body&.read.to_s
-        request.body.rewind if request.body.respond_to?(:rewind)
-
-        parsed = begin
-          raw.empty? ? {} : JSON.parse(raw)
-        rescue JSON::ParserError
-          {}
-        end
-        parsed = {} unless parsed.is_a?(Hash)
-
-        { token: (parsed['token'] || request.params['token']).to_s }
-      end
-
       # Current request's session id, for the op's SOFT cross-device check. Best
       # effort: mailbox proof is inherently cross-device, so a nil here just means
       # the soft check is skipped — never a failure.
       def sso_link_confirm_current_sid
         rodauth.session.id&.public_id
-      rescue StandardError
+      rescue StandardError => ex
+        # Surface the swallowed error rather than resolving to nil in silence. We
+        # still fall through to nil (fail SOFT: the cross-device check is advisory
+        # and is simply skipped), but the sid feeds ONLY that check — and
+        # ConfirmSsoLink#warn_on_cross_device early-returns on an empty sid — so a
+        # SYSTEMIC session.id failure would stop the cross-device audit event
+        # emitting permanently and undetectably.
+        #
+        # SAME event name as the identical resolver in config/hooks/account.rb
+        # (after_change_password) so one audit query covers both sites.
+        Auth::Logging.log_auth_event(
+          :current_session_id_unresolved,
+          level: :warn,
+          route: :sso_link_confirm,
+          error: ex.message,
+        )
         nil
       end
     end

--- a/apps/web/auth/spec/integration/full/basicauth/basicauth_rejection_on_session_routes_spec.rb
+++ b/apps/web/auth/spec/integration/full/basicauth/basicauth_rejection_on_session_routes_spec.rb
@@ -61,10 +61,7 @@ RSpec.describe 'BasicAuth rejection on session-only routes', type: :integration,
     get path
   end
 
-  # Parse JSON response body.
-  def json_body
-    JSON.parse(last_response.body)
-  end
+  # json_body comes from support/auth_request_helper.rb.
 
   # =====================================================================
   # Positive control: BasicAuth strategy authenticates with valid creds

--- a/apps/web/auth/spec/integration/full/identities_routes_spec.rb
+++ b/apps/web/auth/spec/integration/full/identities_routes_spec.rb
@@ -37,10 +37,6 @@ RSpec.describe 'Linked identities management API (#3840 Phase 2)', type: :integr
   # Password is AuthTestConstants::TEST_PASSWORD (shared across spec files so a
   # top-level constant isn't redefined when both specs load in one process).
 
-  def app
-    Onetime::Application::Registry.generate_rack_url_map
-  end
-
   before(:all) do
     require 'onetime'
     require 'onetime/application/registry'
@@ -76,21 +72,6 @@ RSpec.describe 'Linked identities management API (#3840 Phase 2)', type: :integr
   end
 
   # clear_body_headers/json_body come from support/auth_request_helper.rb.
-
-  # Establish an authenticated session via password login.
-  def csrf_login(email, password: AuthTestConstants::TEST_PASSWORD)
-    clear_body_headers
-    header 'Accept', 'application/json'
-    get '/auth'
-    token = last_response.headers['X-CSRF-Token']
-
-    header 'Content-Type', 'application/json'
-    header 'Accept', 'application/json'
-    header 'X-CSRF-Token', token if token
-    post '/auth/login', JSON.generate(login: email, password: password, shrimp: token)
-    expect(last_response.status).to be_between(200, 302),
-      "Precondition failed: login for #{email} returned #{last_response.status}: #{last_response.body}"
-  end
 
   def get_identities
     clear_body_headers

--- a/apps/web/auth/spec/integration/full/identities_routes_spec.rb
+++ b/apps/web/auth/spec/integration/full/identities_routes_spec.rb
@@ -63,20 +63,7 @@ RSpec.describe 'Linked identities management API (#3840 Phase 2)', type: :integr
   # Helpers
   # ==========================================================================
 
-  def seed_account_with_password(email, password: AuthTestConstants::TEST_PASSWORD)
-    normalized = OT::Utils.normalize_email(email)
-    customer   = Onetime::Customer.new(email: normalized)
-    customer.save
-    account_id = auth_db[:accounts].insert(
-      email: normalized,
-      status_id: AuthTestConstants::STATUS_VERIFIED,
-      external_id: customer.extid,
-    )
-    require 'argon2'
-    hasher     = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
-    auth_db[:account_password_hashes].insert(id: account_id, password_hash: hasher.create(password))
-    account_id
-  end
+  # seed_account_with_password comes from support/account_seed_helper.rb.
 
   def remove_password(account_id)
     auth_db[:account_password_hashes].where(id: account_id).delete

--- a/apps/web/auth/spec/integration/full/identities_routes_spec.rb
+++ b/apps/web/auth/spec/integration/full/identities_routes_spec.rb
@@ -88,10 +88,7 @@ RSpec.describe 'Linked identities management API (#3840 Phase 2)', type: :integr
     { id: id, uid: uid }
   end
 
-  def clear_body_headers
-    header 'Content-Type', nil
-    header 'Content-Length', nil
-  end
+  # clear_body_headers/json_body come from support/auth_request_helper.rb.
 
   # Establish an authenticated session via password login.
   def csrf_login(email, password: AuthTestConstants::TEST_PASSWORD)
@@ -123,10 +120,6 @@ RSpec.describe 'Linked identities management API (#3840 Phase 2)', type: :integr
     token = last_response.headers['X-CSRF-Token']
     header 'X-CSRF-Token', token if token
     delete "/auth/identities/#{id}"
-  end
-
-  def json_body
-    JSON.parse(last_response.body)
   end
 
   # ==========================================================================

--- a/apps/web/auth/spec/integration/full/omniauth_account_creation_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_account_creation_spec.rb
@@ -59,12 +59,17 @@ RSpec.describe 'after_omniauth_create_account operations', type: :integration do
     end
   end
 
-  # Helper to create a test account in the database
+  # Helper to create a test account in the database.
+  #
+  # Status is UNVERIFIED, and that is correct for these examples even though
+  # nothing here reads it: CreateCustomer hard-codes `verified: false` (the
+  # account's own status never reaches it — after_verify_account flips the
+  # Customer later), so an account fresh out of signup is the honest subject.
   def create_test_account(email:)
     db = Auth::Database.connection
     account_id = db[:accounts].insert(
       email: email,
-      status_id: 1, # verified status
+      status_id: AuthTestConstants::STATUS_UNVERIFIED,
       created_at: Time.now,
       updated_at: Time.now
     )

--- a/apps/web/auth/spec/integration/full/omniauth_account_creation_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_account_creation_spec.rb
@@ -59,11 +59,6 @@ RSpec.describe 'after_omniauth_create_account operations', type: :integration do
     end
   end
 
-  # Helper to generate unique test emails
-  def unique_test_email(prefix = 'test')
-    "#{prefix}-#{SecureRandom.hex(8)}@integration-test.example.com"
-  end
-
   # Helper to create a test account in the database
   def create_test_account(email:)
     db = Auth::Database.connection

--- a/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
@@ -339,7 +339,7 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
   describe 'logged-in but WITHOUT connect intent (must not bind)' do
     before { enable_platform_fallback }
 
-    it 'does not bind onto the session account and falls through to the H-3 refusal' do
+    it 'does not bind onto the session account (a no-intent callback is treated as unauthenticated)' do
       actor_email = "actor-nointent-#{SecureRandom.hex(6)}@company.example.com"
       other_email = "other-#{SecureRandom.hex(6)}@company.example.com"
       uid         = "sub-#{SecureRandom.hex(8)}"
@@ -365,22 +365,22 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
         skip 'OmniAuth route not registered' if last_response.status == 404
 
         expect(last_response.status).to eq(302)
-        expect(last_response.location.to_s).to include('/signin?auth_error=account_exists_link_required'),
-          "No-intent callback must fall through to H-3, not bind. Location: #{last_response.location.inspect}"
+        # The redirect target is incidental to this test's property (no intent =>
+        # no bind). The located account is passwordless, so it now takes the Phase 4
+        # mailbox path (asserted in sso_link_confirm_mailbox_proof_spec.rb); we do
+        # NOT pin the location here.
 
         # THE CRUX: the arriving identity did NOT attach to the session account.
         expect(identities.where(account_id: actor_id).count).to eq(0),
           'A plain sign-in without connect intent must NOT bind onto the session account'
-        # And no identity row exists at all (H-3 refuses to create one).
+        # And no identity row is bound at all (no direct-bind, no issuance-time bind).
         expect(identities.where(provider: 'oidc', uid: uid).count).to eq(0)
 
-        # The connect event never fires; the intent-absent + H-3 events do.
+        # The connect event never fires; the intent-absent event does.
         expect(Auth::Logging).not_to have_received(:log_auth_event)
           .with(:omniauth_identity_connected, anything)
         expect(Auth::Logging).to have_received(:log_auth_event)
           .with(:omniauth_connect_intent_absent, hash_including(provider: 'oidc'))
-        expect(Auth::Logging).to have_received(:log_auth_event)
-          .with(:omniauth_link_refused_existing_account, hash_including(provider: 'oidc'))
       ensure
         teardown_mock_auth
       end
@@ -439,8 +439,9 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
         post '/auth/sso/oidc/callback'
 
         expect(last_response.status).to eq(302)
-        expect(last_response.location.to_s).to include('/signin?auth_error=account_exists_link_required'),
-          "Expired-intent callback must fall through to H-3, not bind. Location: #{last_response.location.inspect}"
+        # Redirect target is incidental here (expired intent => no bind); the
+        # passwordless located account now takes the Phase 4 mailbox path, so the
+        # location is not pinned (see sso_link_confirm_mailbox_proof_spec.rb).
 
         # THE CRUX: the abandoned intent granted nothing to the later callback.
         expect(identities.where(account_id: actor_id).count).to eq(0),
@@ -510,8 +511,9 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
         post '/auth/sso/oidc/callback'
 
         expect(last_response.status).to eq(302)
-        expect(last_response.location.to_s).to include('/signin?auth_error=account_exists_link_required'),
-          "Plain sign-in after an abandoned connect must not bind. Location: #{last_response.location.inspect}"
+        # Redirect target is incidental (dangling intent cleared => no bind); the
+        # passwordless located account now takes the Phase 4 mailbox path, so the
+        # location is not pinned (see sso_link_confirm_mailbox_proof_spec.rb).
 
         expect(identities.where(account_id: actor_id).count).to eq(0),
           'A dangling connect intent must NOT let a plain sign-in bind onto the session account'
@@ -528,29 +530,36 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
   end
 
   # ==========================================================================
-  # Scenario 3 — UNAUTHENTICATED, SSO-ONLY account -> unchanged H-3 refusal
+  # Scenario 3 — UNAUTHENTICATED, PASSWORDLESS account -> Phase 4 mailbox link
   # ==========================================================================
   #
   # The connect branch is gated on logged_in? + intent, so an unauthenticated
-  # callback never binds. For an existing account WITHOUT a password there is no
-  # credential to challenge, so the H-3 refusal stands unchanged.
-  #
-  # NOTE (#3840 Phase 3): a password-HOLDING account on this same unauthenticated
-  # path now diverts to the sign-in interstitial (/link-sso/:token) instead of the
-  # H-3 refusal — that branch is covered end-to-end in
-  # omniauth_signin_interstitial_spec.rb. Here the account is seeded WITHOUT a
-  # password, so it stays on the H-3 refusal and no challenge is minted.
+  # callback never binds. For an existing PASSWORDLESS account there is no password
+  # to challenge, so Phase 4 emails a single-use mailbox-proof link (superseding the
+  # old H-3 refusal); a password-HOLDING account instead diverts to the Phase 3
+  # sign-in interstitial (/link-sso/:token). Both linking flows are covered
+  # end-to-end in omniauth_signin_interstitial_spec.rb and
+  # sso_link_confirm_mailbox_proof_spec.rb — here we only assert this callback never
+  # direct-binds and, being passwordless, takes the mailbox path (not the challenge).
 
-  describe 'unauthenticated, SSO-only account (regression: connect branch gated + no interstitial)' do
+  describe 'unauthenticated, passwordless account (connect branch gated; Phase 4 mailbox link)' do
     before { enable_platform_fallback }
 
-    it 'falls through to the H-3 refusal, mints no challenge, and fires no connect event' do
+    it 'diverts to the Phase 4 mailbox link email, mints no challenge, and fires no connect event' do
       email = "anon-#{SecureRandom.hex(6)}@company.example.com"
       uid   = "sub-#{SecureRandom.hex(8)}"
-      seed_existing_account(email) # no password -> nothing to challenge
+      seed_existing_account(email) # passwordless -> nothing to challenge
 
-      # No login. trust flag defaults off -> H-3 refusal path.
+      # No login, trust off. A passwordless PLATFORM account no longer dead-ends at
+      # the H-3 refusal — Phase 4 emails a single-use mailbox-proof link instead.
       allow(Onetime.auth_config).to receive(:trust_email_for_linking?).and_return(false)
+      # Stub the templated publisher to CAPTURE the enqueue and keep the :sync send
+      # deterministic (true == delivered, so the hook takes the notice redirect).
+      link_emails = []
+      allow(Onetime::Jobs::Publisher).to receive(:enqueue_email) do |template, data, **_opts|
+        link_emails << { template: template, data: data }
+        true
+      end
       allow(Auth::Logging).to receive(:log_auth_event).and_call_original
 
       setup_mock_auth(email: email, uid: uid)
@@ -560,15 +569,21 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
         skip 'OmniAuth route not registered' if last_response.status == 404
 
         expect(last_response.status).to eq(302)
-        expect(last_response.location.to_s).to include('/signin?auth_error=account_exists_link_required'),
-          "SSO-only unauthenticated flow must keep the H-3 refusal. Location: #{last_response.location.inspect}"
-        # And it must NOT divert to the Phase 3 interstitial (no password = no challenge).
+        expect(last_response.location.to_s).to include('/signin?auth_notice=link_verification_sent'),
+          "Passwordless account must divert to the mailbox notice. Location: #{last_response.location.inspect}"
+        # NOT the Phase 3 password interstitial (no password = no challenge).
         expect(last_response.location.to_s).not_to match(%r{/link-sso/})
 
+        # A single-use verification email went to the on-file address; NO identity
+        # row is bound at issuance (mailbox proof binds only on confirm).
+        expect(link_emails.size).to eq(1), "Expected one link email, got: #{link_emails.inspect}"
+        expect(link_emails.first[:template]).to eq(:sso_link_verification)
+        expect(link_emails.first[:data][:email_address]).to eq(OT::Utils.normalize_email(email))
         expect(identities.where(provider: 'oidc', uid: uid).count).to eq(0)
 
         expect(Auth::Logging).to have_received(:log_auth_event)
-          .with(:omniauth_link_refused_existing_account, hash_including(provider: 'oidc'))
+          .with(:sso_link_verification_issued, hash_including(provider: 'oidc'))
+        # No password challenge, and the connect branch stays gated (unauthenticated).
         expect(Auth::Logging).not_to have_received(:log_auth_event)
           .with(:omniauth_link_challenge_issued, anything)
         expect(Auth::Logging).not_to have_received(:log_auth_event)

--- a/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
@@ -73,10 +73,6 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
   # Password is AuthTestConstants::TEST_PASSWORD (shared across spec files so a
   # top-level constant isn't redefined when both specs load in one process).
 
-  def app
-    Onetime::Application::Registry.generate_rack_url_map
-  end
-
   before(:all) do
     require 'onetime'
     require 'onetime/application/registry'
@@ -99,29 +95,9 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
   # Helpers
   # ==========================================================================
 
-  # Leaves session[:validated_omniauth_domain_id] nil == the PLATFORM path.
-  def enable_platform_fallback
-    allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
-  end
-
   # seed_existing_account (the SSO-only / victim account) and
   # seed_account_with_password (the subject csrf_login can authenticate as)
   # come from support/account_seed_helper.rb.
-
-  # Establish a session, fetch the CSRF token, then POST a JSON login. The full
-  # Rack app enforces CSRF, so the shrimp token is required.
-  def csrf_login(email, password: AuthTestConstants::TEST_PASSWORD)
-    clear_body_headers
-    header 'Accept', 'application/json'
-    get '/auth'
-    token = last_response.headers['X-CSRF-Token']
-
-    header 'Content-Type', 'application/json'
-    header 'Accept', 'application/json'
-    header 'X-CSRF-Token', token if token
-    post '/auth/login', JSON.generate(login: email, password: password, shrimp: token)
-    token
-  end
 
   # clear_body_headers (support/auth_request_helper.rb) and setup_mock_auth /
   # teardown_mock_auth (support/omniauth_test_helper.rb) are shared.

--- a/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
@@ -35,6 +35,10 @@
 #        -> account_from_omniauth returns the SESSION account, the gem persists
 #           the (provider, issuer, uid) row bound to it, and the
 #           :omniauth_identity_connected warn event fires. No refusal.
+#   1b. logged-in + connect intent, IdP asserts NO email claim at all
+#        -> still binds on (provider, issuer, uid). The absence of an email
+#           cannot block a bind that never consults one; the invalid_email
+#           refusal is create-path-only and must not be reachable here.
 #   2. logged-in + connect intent, IdP asserts a DIFFERENT account's email
 #        -> binds to the SESSION account anyway; the other (victim) account gets
 #           NO row and is untouched; no duplicate account. :omniauth_identity_
@@ -145,16 +149,28 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
     header 'Content-Length', nil
   end
 
+  # email: nil models an IdP that asserts NO email claim. The key is OMITTED
+  # from info/raw_info rather than set to nil — that is what a minimal-scope
+  # OIDC response actually looks like, and it makes omniauth_email nil via the
+  # gem's `omniauth_info[info_key] if omniauth_info` accessor
+  # (rodauth-omniauth 0.6.2 omniauth_base.rb:69).
   def setup_mock_auth(email:, uid:, provider: :oidc)
+    info     = { name: 'Connect User' }
+    raw_info = { sub: uid, name: 'Connect User' }
+    if email
+      info     = info.merge(email: email, email_verified: true)
+      raw_info = raw_info.merge(email: email, email_verified: true)
+    end
+
     OmniAuth.config.test_mode               = true
     OmniAuth.config.allowed_request_methods = [:get, :post]
     OmniAuth.config.mock_auth[provider]     = OmniAuth::AuthHash.new(
       {
         provider: provider.to_s,
         uid: uid,
-        info: { email: email, name: 'Connect User', email_verified: true },
+        info: info,
         credentials: { token: 'mock_access_token', expires_at: Time.now.to_i + 3600, expires: true },
-        extra: { raw_info: { sub: uid, email: email, name: 'Connect User', email_verified: true } },
+        extra: { raw_info: raw_info },
       },
     )
   end
@@ -247,6 +263,94 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
 
         # Single-use (#3859): the successful bind CONSUMED the nonce (atomic
         # GETDEL) — nothing is left for a later callback to replay.
+        expect(intent_live?(sid)).to be(false),
+          'The consumed intent must not survive the bind'
+      ensure
+        teardown_mock_auth
+      end
+    end
+  end
+
+  # ==========================================================================
+  # Scenario 1b — logged-in connect, IdP asserts NO email claim -> still binds
+  # ==========================================================================
+  #
+  # The corollary of "the IdP email plays NO role": if email is not an input to
+  # the bind decision, its ABSENCE cannot block the bind. An IdP scoped to
+  # openid-only (no email/profile) emits an auth hash with no email claim, and
+  # connecting such a provider from account settings must still work — the
+  # session is the authorization, the uid is the identifier.
+  #
+  # This is a REGRESSION GUARD, not a happy-path duplicate. The connect branch
+  # currently survives a nil email only incidentally:
+  #   - normalize_email(nil) -> '' (Utils::Strings, .to_s.strip) rather than a
+  #     raise, and the '' is used ONLY for the obscured audit-log field;
+  #   - the invalid_email refusal lives in before_omniauth_create_account, which
+  #     the gem runs on the CREATE path only — the connect branch returns an
+  #     account, so omniauth_create_account (and that hook) never runs.
+  # Both are one refactor away from breaking: hoisting the email-shape check out
+  # of before_omniauth_create_account, or making normalized_email load-bearing
+  # above the connect branch, would turn every no-email-claim connect into a
+  # /signin?auth_error=invalid_email dead-end with no way to attach the provider.
+  # Nothing else in the suite exercises a nil omniauth_email, so pin it here.
+
+  describe 'logged-in connect, IdP asserts no email claim' do
+    before { enable_platform_fallback }
+
+    it 'binds on the uid alone and never hits the invalid_email refusal' do
+      email      = "connect-noemail-#{SecureRandom.hex(6)}@company.example.com"
+      uid        = "sub-#{SecureRandom.hex(8)}"
+      account_id = seed_account_with_password(email)
+
+      csrf_login(email)
+      expect(last_response.status).to be_between(200, 302),
+        "Precondition failed: password login did not succeed (#{last_response.status}: #{last_response.body})"
+
+      accounts_before = auth_db[:accounts].count
+
+      allow(Auth::Logging).to receive(:log_auth_event).and_call_original
+      # THE VARIABLE UNDER TEST: no email claim anywhere in the auth hash.
+      setup_mock_auth(email: nil, uid: uid)
+      begin
+        skip 'OmniAuth route not registered (OIDC discovery not available at boot)' if initiate_sso_connect == 404
+
+        sid = current_sid
+        expect(intent_live?(sid)).to be(true),
+          'Connect initiation must set the intent sidecar key'
+
+        clear_body_headers
+        post '/auth/sso/oidc/callback'
+
+        skip 'OmniAuth route not registered (OIDC discovery not available at boot)' if last_response.status == 404
+
+        # The crux: a missing email claim must not be read as an INVALID one.
+        expect(last_response.location.to_s).not_to include('auth_error=invalid_email'),
+          "A connect needs no email claim. Location: #{last_response.location.inspect}"
+        expect(last_response.location.to_s).not_to include('identity_connect_conflict'),
+          "Connect must NOT refuse. Location: #{last_response.location.inspect}"
+        expect(last_response.status).to eq(302),
+          "Expected a post-login redirect, got #{last_response.status}: #{last_response.body}"
+
+        # The bind happened on (provider, issuer, uid) — no email involved.
+        rows = identities.where(provider: 'oidc', uid: uid).all
+        expect(rows.size).to eq(1),
+          "Expected exactly one bound identity row, got #{rows.size}: #{rows.inspect}"
+        expect(rows.first[:account_id]).to eq(account_id),
+          'Bound identity must attach to the already-authenticated account'
+        expect(rows.first[:issuer]).not_to be_nil
+
+        # An emailless callback must never reach the JIT-create path (a nil login
+        # would violate the accounts.email NOT NULL/unique index).
+        expect(auth_db[:accounts].count).to eq(accounts_before),
+          'Connect must NOT create an account'
+
+        expect(Auth::Logging).to have_received(:log_auth_event)
+          .with(:omniauth_identity_connected, hash_including(provider: 'oidc', account_id: account_id))
+        expect(Auth::Logging).not_to have_received(:log_auth_event)
+          .with(:omniauth_invalid_email, anything)
+        expect(Auth::Logging).not_to have_received(:log_auth_event)
+          .with(:omniauth_identity_connect_refused, anything)
+
         expect(intent_live?(sid)).to be(false),
           'The consumed intent must not survive the bind'
       ensure

--- a/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
@@ -104,28 +104,9 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
     allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
   end
 
-  # Seed a VERIFIED account WITHOUT a password (SSO-only / victim account).
-  def seed_existing_account(email)
-    normalized = OT::Utils.normalize_email(email)
-    customer   = Onetime::Customer.new(email: normalized)
-    customer.save
-    auth_db[:accounts].insert(
-      email: normalized,
-      status_id: AuthTestConstants::STATUS_VERIFIED,
-      external_id: customer.extid,
-    )
-  end
-
-  # Seed a VERIFIED account WITH an Argon2 password hash so csrf_login can
-  # establish a real authenticated session for it. Cost params match the test
-  # config in config/features/argon2.rb.
-  def seed_account_with_password(email, password: AuthTestConstants::TEST_PASSWORD)
-    account_id = seed_existing_account(email)
-    require 'argon2'
-    hasher     = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
-    auth_db[:account_password_hashes].insert(id: account_id, password_hash: hasher.create(password))
-    account_id
-  end
+  # seed_existing_account (the SSO-only / victim account) and
+  # seed_account_with_password (the subject csrf_login can authenticate as)
+  # come from support/account_seed_helper.rb.
 
   # Establish a session, fetch the CSRF token, then POST a JSON login. The full
   # Rack app enforces CSRF, so the shrimp token is required.

--- a/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
@@ -142,43 +142,15 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
     token
   end
 
-  # Content-Type/Content-Length leak from a prior JSON POST and make the next
-  # bodyless callback POST try to parse an empty JSON body. Clear them.
-  def clear_body_headers
-    header 'Content-Type', nil
-    header 'Content-Length', nil
-  end
-
-  # email: nil models an IdP that asserts NO email claim. The key is OMITTED
-  # from info/raw_info rather than set to nil — that is what a minimal-scope
-  # OIDC response actually looks like, and it makes omniauth_email nil via the
-  # gem's `omniauth_info[info_key] if omniauth_info` accessor
-  # (rodauth-omniauth 0.6.2 omniauth_base.rb:69).
-  def setup_mock_auth(email:, uid:, provider: :oidc)
-    info     = { name: 'Connect User' }
-    raw_info = { sub: uid, name: 'Connect User' }
-    if email
-      info     = info.merge(email: email, email_verified: true)
-      raw_info = raw_info.merge(email: email, email_verified: true)
-    end
-
-    OmniAuth.config.test_mode               = true
-    OmniAuth.config.allowed_request_methods = [:get, :post]
-    OmniAuth.config.mock_auth[provider]     = OmniAuth::AuthHash.new(
-      {
-        provider: provider.to_s,
-        uid: uid,
-        info: info,
-        credentials: { token: 'mock_access_token', expires_at: Time.now.to_i + 3600, expires: true },
-        extra: { raw_info: raw_info },
-      },
-    )
-  end
-
-  def teardown_mock_auth
-    OmniAuth.config.test_mode = false
-    OmniAuth.config.mock_auth.clear
-  end
+  # clear_body_headers (support/auth_request_helper.rb) and setup_mock_auth /
+  # teardown_mock_auth (support/omniauth_test_helper.rb) are shared.
+  #
+  # setup_mock_auth(email: nil, ...) below models an IdP that asserts NO email
+  # claim: the shared helper OMITS the key from info/raw_info rather than
+  # setting it to nil — that is what a minimal-scope OIDC response actually
+  # looks like, and it makes omniauth_email nil via the gem's
+  # `omniauth_info[info_key] if omniauth_info` accessor (rodauth-omniauth 0.6.2
+  # omniauth_base.rb:69).
 
   # Run the SSO REQUEST phase carrying the connect-intent signal (connect=1),
   # exactly as the Connected Identities panel does at initiation. In OmniAuth

--- a/apps/web/auth/spec/integration/full/omniauth_domain_restriction_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_domain_restriction_spec.rb
@@ -31,10 +31,6 @@ require_relative '../../spec_helper'
 RSpec.describe 'OmniAuth Domain Restriction', type: :integration do
   include Rack::Test::Methods
 
-  def app
-    Onetime::Application::Registry.generate_rack_url_map
-  end
-
   before(:all) do
     # Boot the full Onetime application for integration tests.
     # require 'onetime' unconditionally — the `Onetime` constant can be
@@ -83,38 +79,8 @@ RSpec.describe 'OmniAuth Domain Restriction', type: :integration do
   # Helper Methods
   # ==========================================================================
 
-  # Asserts the OmniAuth callback ended in a redirect to /signin with the given
-  # stable auth_error code. Matches the convention shared with email_auth and
-  # omniauth_on_failure (Login.vue dispatches the code to a localized message).
-  def expect_auth_error_redirect(code)
-    expect(last_response.status).to eq(302),
-      "Expected 302 redirect for #{code}, got #{last_response.status}: #{last_response.body}"
-    expect(last_response.location.to_s).to include("/signin?auth_error=#{code}"),
-      "Expected auth_error=#{code} in Location, got: #{last_response.location.inspect}"
-  end
-
   # setup_mock_auth/teardown_mock_auth come from support/omniauth_test_helper.rb.
   # This spec passes only email:, so every example gets a fresh random uid.
-
-  # Configures allowed_signup_domains in OT.conf
-  # Pass nil to remove restrictions
-  def configure_allowed_domains(domains)
-    # Deep clone to avoid mutating original
-    config = Marshal.load(Marshal.dump(OT.conf))
-
-    config['site'] ||= {}
-    config['site']['authentication'] ||= {}
-    config['site']['authentication']['allowed_signup_domains'] = domains
-
-    allow(OT).to receive(:conf).and_return(config)
-  end
-
-  # Enables platform credential fallback for non-tenant requests.
-  # Required because tests run on `example.org` which isn't the canonical
-  # domain, so without this the tenant hook blocks before domain validation.
-  def enable_platform_fallback
-    allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
-  end
 
   # ==========================================================================
   # Tests: Domain Restrictions Configured

--- a/apps/web/auth/spec/integration/full/omniauth_domain_restriction_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_domain_restriction_spec.rb
@@ -93,40 +93,8 @@ RSpec.describe 'OmniAuth Domain Restriction', type: :integration do
       "Expected auth_error=#{code} in Location, got: #{last_response.location.inspect}"
   end
 
-  # Sets up OmniAuth test mode with a mock auth hash for the given email
-  def setup_mock_auth(email:, provider: :oidc, uid: nil)
-    OmniAuth.config.test_mode = true
-    OmniAuth.config.allowed_request_methods = %i[get post]
-
-    OmniAuth.config.mock_auth[provider] = OmniAuth::AuthHash.new({
-      provider: provider.to_s,
-      uid: uid || "test-uid-#{SecureRandom.hex(8)}",
-      info: {
-        email: email,
-        name: 'Test User',
-        email_verified: true,
-      },
-      credentials: {
-        token: 'mock_access_token',
-        refresh_token: 'mock_refresh_token',
-        expires_at: Time.now.to_i + 3600,
-        expires: true,
-      },
-      extra: {
-        raw_info: {
-          sub: uid || "test-uid-#{SecureRandom.hex(8)}",
-          email: email,
-          name: 'Test User',
-          email_verified: true,
-        },
-      },
-    })
-  end
-
-  def teardown_mock_auth
-    OmniAuth.config.test_mode = false
-    OmniAuth.config.mock_auth.clear
-  end
+  # setup_mock_auth/teardown_mock_auth come from support/omniauth_test_helper.rb.
+  # This spec passes only email:, so every example gets a fresh random uid.
 
   # Configures allowed_signup_domains in OT.conf
   # Pass nil to remove restrictions

--- a/apps/web/auth/spec/integration/full/omniauth_issuer_scoped_identity_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_issuer_scoped_identity_spec.rb
@@ -60,8 +60,12 @@ RSpec.describe 'Issuer-scoped SSO identity lookup', type: :integration do
     created_account_ids.each { |id| db[:accounts].where(id: id).delete }
   end
 
+  # Status is irrelevant here — these examples exercise the account_identities
+  # schema and its (provider, issuer, uid) constraint, and the account row is
+  # only an FK target. Named rather than a bare 1 so it doesn't read as a
+  # meaningful choice.
   def create_account(email)
-    id = db[:accounts].insert(email: email, status_id: 1)
+    id = db[:accounts].insert(email: email, status_id: AuthTestConstants::STATUS_UNVERIFIED)
     created_account_ids << id
     id
   end

--- a/apps/web/auth/spec/integration/full/omniauth_missing_email_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_missing_email_spec.rb
@@ -144,10 +144,9 @@ RSpec.describe 'OmniAuth Missing Email (issue #3478)', type: :integration do
     })
   end
 
-  def teardown_mock_auth
-    OmniAuth.config.test_mode = false
-    OmniAuth.config.mock_auth.clear
-  end
+  # teardown_mock_auth comes from support/omniauth_test_helper.rb. The SETUP
+  # stays local: the shared setup_mock_auth omits an absent email claim, while
+  # #3478 needs info.email PRESENT and nil/blank.
 
   # Posts the SSO callback, self-skipping if the route isn't registered in this
   # boot (e.g. the :entra route when Entra credentials/orgs_sso aren't present).

--- a/apps/web/auth/spec/integration/full/omniauth_missing_email_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_missing_email_spec.rb
@@ -53,10 +53,6 @@ require_relative '../../spec_helper'
 RSpec.describe 'OmniAuth Missing Email (issue #3478)', type: :integration do
   include Rack::Test::Methods
 
-  def app
-    Onetime::Application::Registry.generate_rack_url_map
-  end
-
   before(:all) do
     # Boot the full Onetime application for integration tests. Mirrors the
     # sibling omniauth_domain_restriction_spec.rb boot — see its comments for
@@ -96,16 +92,6 @@ RSpec.describe 'OmniAuth Missing Email (issue #3478)', type: :integration do
   # ==========================================================================
   # Helpers
   # ==========================================================================
-
-  # Asserts the OmniAuth callback ended in a 302 redirect to /signin with the
-  # given stable auth_error code. The 302 (vs 500/timeout) is itself the
-  # regression guard against the "frozen loading screen" symptom.
-  def expect_auth_error_redirect(code)
-    expect(last_response.status).to eq(302),
-      "Expected 302 redirect for #{code}, got #{last_response.status}: #{last_response.body}"
-    expect(last_response.location.to_s).to include("/signin?auth_error=#{code}"),
-      "Expected auth_error=#{code} in Location, got: #{last_response.location.inspect}"
-  end
 
   # Builds an OmniAuth mock shaped like a Microsoft Entra ID v2.0 id_token.
   #
@@ -155,18 +141,6 @@ RSpec.describe 'OmniAuth Missing Email (issue #3478)', type: :integration do
     return unless last_response.status == 404
 
     skip "OmniAuth route /auth/sso/#{provider}/callback not registered in this boot"
-  end
-
-  def enable_platform_fallback
-    allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
-  end
-
-  def configure_allowed_domains(domains)
-    config = Marshal.load(Marshal.dump(OT.conf))
-    config['site'] ||= {}
-    config['site']['authentication'] ||= {}
-    config['site']['authentication']['allowed_signup_domains'] = domains
-    allow(OT).to receive(:conf).and_return(config)
   end
 
   # ==========================================================================

--- a/apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
@@ -31,8 +31,12 @@
 #   d. POST with the WRONG password -> refused (invalid_password), NO bind, and
 #      the token is CONSUMED (single-use closes the no-lockout password oracle).
 #   e. missing/expired/invalid token -> refused (link_expired), no bind.
-#   f. SSO-only account (no password) -> UNCHANGED H-3 refusal; no interstitial,
-#      no challenge minted.
+#   f. SSO-only / PASSWORDLESS account -> Phase 4 mailbox-proof link EMAIL: a
+#      single-use SsoLinkVerification is issued to the on-file address and the
+#      browser gets the TOKEN-LESS /signin?auth_notice=link_verification_sent
+#      notice. NO password interstitial (nothing to challenge) and NO password
+#      challenge minted. (This SUPERSEDES the old H-3 refusal for passwordless
+#      accounts on the platform surface — see #3840 Phase 4.)
 #
 # REQUIREMENTS:
 # - Valkey running on port 2121: pnpm run test:database:start
@@ -362,28 +366,55 @@ RSpec.describe 'OmniAuth sign-in interstitial (#3840 Phase 3)', type: :integrati
   end
 
   # ==========================================================================
-  # (f) SSO-only account -> UNCHANGED H-3 refusal (no interstitial, no token)
+  # (f) SSO-only / PASSWORDLESS account -> Phase 4 mailbox-proof link EMAIL
   # ==========================================================================
+  #
+  # SUPERSEDES the old H-3 refusal for passwordless accounts (#3840 Phase 4). A
+  # passwordless account has no password to challenge, so the password interstitial
+  # cannot help — but mailbox control CAN prove ownership. On the platform surface
+  # the callback now issues a single-use SsoLinkVerification, EMAILS the token to the
+  # on-file address, and redirects the browser TOKEN-LESSLY to the
+  # auth_notice=link_verification_sent notice (the token rides ONLY the email). The
+  # full end-to-end confirm flow is locked in by
+  # sso_link_confirm_mailbox_proof_spec.rb; here we just assert the callback diverts
+  # to the mailbox EMAIL rather than the refusal or the password interstitial.
 
-  describe 'SSO-only account (no password)' do
-    it 'keeps the H-3 refusal and does not mint a challenge' do
+  describe 'SSO-only / passwordless account (no password)' do
+    it 'sends a mailbox-proof link email (Phase 4) and mints no password challenge' do
       email = "ssoonly-#{SecureRandom.hex(6)}@company.example.com"
       uid   = "sub-#{SecureRandom.hex(8)}"
-      seed_existing_account(email) # no password
+      seed_existing_account(email) # passwordless
 
+      # The full-boot :sync fallback would actually render + deliver; stub the
+      # templated publisher to CAPTURE the enqueue and keep the send deterministic
+      # (returning true == "delivered", so the hook takes the notice redirect).
+      link_emails = []
+      allow(Onetime::Jobs::Publisher).to receive(:enqueue_email) do |template, data, **_opts|
+        link_emails << { template: template, data: data }
+        true
+      end
       allow(Auth::Logging).to receive(:log_auth_event).and_call_original
 
       begin
         response = sso_callback(email: email, uid: uid)
         skip 'OmniAuth route not registered' if response.status == 404
 
+        # Phase 4: TOKEN-LESS mailbox notice — NOT the old H-3 refusal and NOT the
+        # password interstitial (there is no password to challenge).
         expect(response.status).to eq(302)
-        expect(response.location.to_s).to include('/signin?auth_error=account_exists_link_required'),
-          "SSO-only account must keep the H-3 refusal. Location: #{response.location.inspect}"
+        expect(response.location.to_s).to include('/signin?auth_notice=link_verification_sent'),
+          "Passwordless account must divert to the mailbox notice. Location: #{response.location.inspect}"
+        expect(response.location.to_s).not_to include('account_exists_link_required')
         expect(response.location.to_s).not_to match(%r{/link-sso/})
 
+        # A single-use verification email went to the on-file address.
+        expect(link_emails.size).to eq(1), "Expected one link email, got: #{link_emails.inspect}"
+        expect(link_emails.first[:template]).to eq(:sso_link_verification)
+        expect(link_emails.first[:data][:email_address]).to eq(OT::Utils.normalize_email(email))
+
         expect(Auth::Logging).to have_received(:log_auth_event)
-          .with(:omniauth_link_refused_existing_account, hash_including(provider: 'oidc'))
+          .with(:sso_link_verification_issued, hash_including(provider: 'oidc'))
+        # Still NO password challenge — there is no password to challenge.
         expect(Auth::Logging).not_to have_received(:log_auth_event)
           .with(:omniauth_link_challenge_issued, anything)
       ensure

--- a/apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
@@ -111,31 +111,10 @@ RSpec.describe 'OmniAuth sign-in interstitial (#3840 Phase 3)', type: :integrati
     account_id
   end
 
-  def setup_mock_auth(email:, uid:, provider: :oidc)
-    OmniAuth.config.test_mode               = true
-    OmniAuth.config.allowed_request_methods = [:get, :post]
-    OmniAuth.config.mock_auth[provider]     = OmniAuth::AuthHash.new(
-      {
-        provider: provider.to_s,
-        uid: uid,
-        info: { email: email, name: 'Interstitial User', email_verified: true },
-        credentials: { token: 'mock_access_token', expires_at: Time.now.to_i + 3600, expires: true },
-        extra: { raw_info: { sub: uid, email: email, name: 'Interstitial User', email_verified: true } },
-      },
-    )
-  end
-
-  def teardown_mock_auth
-    OmniAuth.config.test_mode = false
-    OmniAuth.config.mock_auth.clear
-  end
-
-  # Content-Type/Content-Length leak from a prior JSON POST and make the next
-  # bodyless request try to parse an empty JSON body. Clear them.
-  def clear_body_headers
-    header 'Content-Type', nil
-    header 'Content-Length', nil
-  end
+  # setup_mock_auth/teardown_mock_auth (support/omniauth_test_helper.rb) and
+  # clear_body_headers/fetch_csrf_token (support/auth_request_helper.rb) are
+  # shared. fetch_csrf_token establishes a fresh session; the challenge lives in
+  # Redis, not the session, so that does not disturb it.
 
   # Drive the UNAUTHENTICATED SSO callback and return the response. No login and
   # no connect intent — this is the plain sign-in that resolves to an existing
@@ -150,16 +129,6 @@ RSpec.describe 'OmniAuth sign-in interstitial (#3840 Phase 3)', type: :integrati
   # Extract the challenge token from a /link-sso/:token redirect Location.
   def token_from_location(location)
     location.to_s.split('/link-sso/').last.to_s.split(/[?#]/).first
-  end
-
-  # Fetch a CSRF token from the app bootstrap (mirrors csrf_login). The challenge
-  # lives in Redis, not the session, so establishing a fresh session here does
-  # not disturb it.
-  def fetch_csrf_token
-    clear_body_headers
-    header 'Accept', 'application/json'
-    get '/auth'
-    last_response.headers['X-CSRF-Token']
   end
 
   def get_link_context(token)

--- a/apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
@@ -52,13 +52,11 @@
 
 require_relative '../../spec_helper'
 require_relative '../../support/oauth_flow_helper'
+require_relative '../../support/sso_link_flow_helper'
 
 RSpec.describe 'OmniAuth sign-in interstitial (#3840 Phase 3)', type: :integration do
   include Rack::Test::Methods
-
-  def app
-    Onetime::Application::Registry.generate_rack_url_map
-  end
+  include SsoLinkFlowHelper
 
   before(:all) do
     require 'onetime'
@@ -82,13 +80,6 @@ RSpec.describe 'OmniAuth sign-in interstitial (#3840 Phase 3)', type: :integrati
   # Helpers (mirrors omniauth_connect_link_spec.rb)
   # ==========================================================================
 
-  # Leaves session[:validated_omniauth_domain_id] nil == the PLATFORM path, and
-  # lets a non-tenant callback proceed on platform credentials instead of
-  # redirecting to sso_not_configured.
-  def enable_platform_fallback
-    allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
-  end
-
   # seed_existing_account (SSO-only, no password) and
   # seed_account_with_password (support/account_seed_helper.rb),
   # setup_mock_auth/teardown_mock_auth (support/omniauth_test_helper.rb) and
@@ -96,35 +87,10 @@ RSpec.describe 'OmniAuth sign-in interstitial (#3840 Phase 3)', type: :integrati
   # shared. fetch_csrf_token establishes a fresh session; the challenge lives in
   # Redis, not the session, so that does not disturb it.
 
-  # Drive the UNAUTHENTICATED SSO callback and return the response. No login and
-  # no connect intent — this is the plain sign-in that resolves to an existing
-  # account by email.
-  def sso_callback(email:, uid:, provider: :oidc)
-    setup_mock_auth(email: email, uid: uid, provider: provider)
-    clear_body_headers
-    post "/auth/sso/#{provider}/callback"
-    last_response
-  end
-
-  # Extract the challenge token from a /link-sso/:token redirect Location.
-  def token_from_location(location)
-    location.to_s.split('/link-sso/').last.to_s.split(/[?#]/).first
-  end
-
   def get_link_context(token)
     clear_body_headers
     header 'Accept', 'application/json'
     get "/auth/link-sso/#{token}"
-    last_response
-  end
-
-  def post_link_sso(token:, password:)
-    csrf = fetch_csrf_token
-    clear_body_headers
-    header 'Content-Type', 'application/json'
-    header 'Accept', 'application/json'
-    header 'X-CSRF-Token', csrf if csrf
-    post '/auth/link-sso', JSON.generate(token: token, password: password)
     last_response
   end
 

--- a/apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
@@ -89,28 +89,8 @@ RSpec.describe 'OmniAuth sign-in interstitial (#3840 Phase 3)', type: :integrati
     allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
   end
 
-  # Seed a VERIFIED account WITHOUT a password (SSO-only account).
-  def seed_existing_account(email)
-    normalized = OT::Utils.normalize_email(email)
-    customer   = Onetime::Customer.new(email: normalized)
-    customer.save
-    auth_db[:accounts].insert(
-      email: normalized,
-      status_id: AuthTestConstants::STATUS_VERIFIED,
-      external_id: customer.extid,
-    )
-  end
-
-  # Seed a VERIFIED account WITH an Argon2 password hash. Cost params match the
-  # test config in config/features/argon2.rb.
-  def seed_account_with_password(email, password: AuthTestConstants::TEST_PASSWORD)
-    account_id = seed_existing_account(email)
-    require 'argon2'
-    hasher     = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
-    auth_db[:account_password_hashes].insert(id: account_id, password_hash: hasher.create(password))
-    account_id
-  end
-
+  # seed_existing_account (SSO-only, no password) and
+  # seed_account_with_password (support/account_seed_helper.rb),
   # setup_mock_auth/teardown_mock_auth (support/omniauth_test_helper.rb) and
   # clear_body_headers/fetch_csrf_token (support/auth_request_helper.rb) are
   # shared. fetch_csrf_token establishes a fresh session; the challenge lives in

--- a/apps/web/auth/spec/integration/full/omniauth_trusted_link_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_trusted_link_spec.rb
@@ -211,13 +211,19 @@ RSpec.describe 'OmniAuth trusted-provider email linking (#3836 Phase 1)', type: 
   end
 
   # ==========================================================================
-  # Scenario 2 — PLATFORM path + trust flag OFF -> H-3 refusal (unchanged)
+  # Scenario 2 — PLATFORM path + trust flag OFF -> no trusted-provider auto-link
   # ==========================================================================
+  #
+  # This test's property is the TRUST gate: with trust off, the trusted-provider
+  # auto-link branch is skipped and no identity row is created. The post-skip
+  # redirect is incidental — a passwordless account now takes the Phase 4 mailbox
+  # path (link_verification_sent, asserted in sso_link_confirm_mailbox_proof_spec.rb)
+  # rather than the old H-3 refusal — so it is not pinned here.
 
   describe 'platform path, trust flag OFF' do
     before { enable_platform_fallback }
 
-    it 'refuses to auto-link, creates no identity row, and fires the refusal event' do
+    it 'refuses to auto-link and creates no identity row when trust is off' do
       email = "refuse-#{SecureRandom.hex(6)}@company.example.com"
       uid   = "sub-#{SecureRandom.hex(8)}"
       seed_existing_account(email)
@@ -233,20 +239,19 @@ RSpec.describe 'OmniAuth trusted-provider email linking (#3836 Phase 1)', type: 
           skip 'OmniAuth route not registered (OIDC discovery not available at boot)'
         end
 
-        # H-3 refusal: redirect (halt) to the stable auth_error code.
+        # A 302 redirect is issued; its target is incidental to the TRUST property
+        # (a passwordless account now takes the Phase 4 mailbox path, asserted in
+        # sso_link_confirm_mailbox_proof_spec.rb), so it is not pinned here.
         expect(last_response.status).to eq(302),
-          "Expected a 302 refusal redirect, got #{last_response.status}: #{last_response.body}"
-        expect(last_response.location.to_s).to include('/signin?auth_error=account_exists_link_required'),
-          "Expected the H-3 refusal redirect, got: #{last_response.location.inspect}"
+          "Expected a 302 redirect, got #{last_response.status}: #{last_response.body}"
 
-        # No auto-link: the (provider, uid) row must not exist. The halt happens
-        # before create_omniauth_identity, so the caller's IdP identity is never
-        # bound to the victim account.
+        # No auto-link: the (provider, uid) row must not exist. The trusted-link
+        # branch is skipped when trust is off, so the caller's IdP identity is never
+        # auto-bound to the pre-existing account.
         expect(identities.where(provider: 'oidc', uid: uid).count).to eq(0),
-          'H-3 refusal must NOT create an account_identities row'
+          'Trust OFF must NOT create an account_identities row'
 
-        expect(Auth::Logging).to have_received(:log_auth_event)
-          .with(:omniauth_link_refused_existing_account, hash_including(provider: 'oidc'))
+        # And the trusted-provider auto-link event never fires.
         expect(Auth::Logging).not_to have_received(:log_auth_event)
           .with(:omniauth_email_linked_trusted_provider, anything)
       ensure

--- a/apps/web/auth/spec/integration/full/omniauth_trusted_link_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_trusted_link_spec.rb
@@ -135,29 +135,9 @@ RSpec.describe 'OmniAuth trusted-provider email linking (#3836 Phase 1)', type: 
     )
   end
 
-  # OmniAuth test-mode mock for a successful IdP assertion of `email`/`uid`.
-  def setup_mock_auth(email:, uid:, provider: :oidc)
-    OmniAuth.config.test_mode = true
-    OmniAuth.config.allowed_request_methods = %i[get post]
-    OmniAuth.config.mock_auth[provider] = OmniAuth::AuthHash.new({
-      provider: provider.to_s,
-      uid: uid,
-      info: { email: email, name: 'Trusted Link User', email_verified: true },
-      credentials: {
-        token: 'mock_access_token',
-        expires_at: Time.now.to_i + 3600,
-        expires: true,
-      },
-      extra: {
-        raw_info: { sub: uid, email: email, name: 'Trusted Link User', email_verified: true },
-      },
-    })
-  end
-
-  def teardown_mock_auth
-    OmniAuth.config.test_mode = false
-    OmniAuth.config.mock_auth.clear
-  end
+  # setup_mock_auth/teardown_mock_auth — the OmniAuth test-mode mock for a
+  # successful IdP assertion of `email`/`uid` — come from
+  # support/omniauth_test_helper.rb.
 
   # ==========================================================================
   # Scenario 1 — PLATFORM path + trust flag ON -> auto-link

--- a/apps/web/auth/spec/integration/full/omniauth_trusted_link_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_trusted_link_spec.rb
@@ -120,21 +120,10 @@ RSpec.describe 'OmniAuth trusted-provider email linking (#3836 Phase 1)', type: 
       .with(route).and_return(enabled)
   end
 
-  # Seed a pre-existing VERIFIED account (accounts row + linked Customer) that
-  # _account_from_login will locate by normalized email. status_id = 2 (Verified)
-  # both satisfies the lookup's status filter AND makes open_account? true so the
-  # gem skips its verify-account branch. Returns the account_id.
-  def seed_existing_account(email)
-    normalized = OT::Utils.normalize_email(email)
-    customer   = Onetime::Customer.new(email: normalized)
-    customer.save
-    auth_db[:accounts].insert(
-      email: normalized,
-      status_id: AuthTestConstants::STATUS_VERIFIED,
-      external_id: customer.extid,
-    )
-  end
-
+  # seed_existing_account — the pre-existing VERIFIED account (accounts row +
+  # linked Customer) that _account_from_login locates by normalized email —
+  # comes from support/account_seed_helper.rb.
+  #
   # setup_mock_auth/teardown_mock_auth — the OmniAuth test-mode mock for a
   # successful IdP assertion of `email`/`uid` — come from
   # support/omniauth_test_helper.rb.

--- a/apps/web/auth/spec/integration/full/omniauth_trusted_link_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_trusted_link_spec.rb
@@ -73,10 +73,6 @@ require_relative '../../support/oauth_flow_helper'
 RSpec.describe 'OmniAuth trusted-provider email linking (#3836 Phase 1)', type: :integration do
   include Rack::Test::Methods
 
-  def app
-    Onetime::Application::Registry.generate_rack_url_map
-  end
-
   before(:all) do
     # Mirror the proven boot in omniauth_domain_restriction_spec.rb: force a
     # clean reboot so provider registration runs against this suite's WebMock
@@ -102,14 +98,6 @@ RSpec.describe 'OmniAuth trusted-provider email linking (#3836 Phase 1)', type: 
   # ==========================================================================
   # Helpers
   # ==========================================================================
-
-  # Enables platform credential fallback for non-tenant requests. Tests run on
-  # example.org (Rack::Test default), which isn't the canonical domain, so
-  # without this the tenant hook blocks the callback before account lookup.
-  # Leaves session[:validated_omniauth_domain_id] nil == the PLATFORM path.
-  def enable_platform_fallback
-    allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
-  end
 
   # Force the trust flag decision for a given route without touching the
   # auth_config plumbing (owned by another agent / tested separately). Any other

--- a/apps/web/auth/spec/integration/full/pending_plan_intent_flow_spec.rb
+++ b/apps/web/auth/spec/integration/full/pending_plan_intent_flow_spec.rb
@@ -86,10 +86,6 @@ RSpec.describe 'Pending plan intent flow (issue #3126)', type: :integration do
     end
   end
 
-  def unique_test_email(prefix = 'plan-intent')
-    "#{prefix}-#{SecureRandom.hex(8)}@integration-test.example.com"
-  end
-
   def create_test_account(email:, extid: nil)
     db = Auth::Database.connection
     extid ||= SecureRandom.uuid
@@ -102,25 +98,6 @@ RSpec.describe 'Pending plan intent flow (issue #3126)', type: :integration do
     )
     created_account_ids << account_id
     { id: account_id, email: email, external_id: extid, extid: extid }
-  end
-
-  # Establish a session, fetch the CSRF token, then POST a JSON login to the
-  # rodauth endpoint (mounted at /auth). The full Rack app enforces CSRF, so a
-  # raw post without the shrimp token returns 403 Forbidden.
-  def csrf_login(email, password = TEST_PASSWORD)
-    # Clear headers that leaked from previous POST (Content-Type triggers body
-    # parsing in Rack::Parser; when applied to a GET with no body, rack.input
-    # is nil and .read fails)
-    header 'Content-Type', nil
-    header 'Content-Length', nil
-    header 'Accept', 'application/json'
-    get '/auth'
-    token = last_response.headers['X-CSRF-Token']
-
-    header 'Content-Type', 'application/json'
-    header 'Accept', 'application/json'
-    header 'X-CSRF-Token', token if token
-    post '/auth/login', JSON.generate(login: email, password: password, shrimp: token)
   end
 
   # ==========================================================================

--- a/apps/web/auth/spec/integration/full/reset_password_request_enumeration_spec.rb
+++ b/apps/web/auth/spec/integration/full/reset_password_request_enumeration_spec.rb
@@ -64,10 +64,6 @@ RSpec.describe 'Reset-password-request enumeration safety (issue #3857)', type: 
   # moment a new flow touches another table — which is exactly what a stricter
   # version of this block surfaced during review.
 
-  def unique_test_email(prefix = 'reset-enum')
-    "#{prefix}-#{SecureRandom.hex(8)}@integration-test.example.com"
-  end
-
   # Creates an account with a password hash. status_id defaults to verified.
   def create_account(email:, status_id: AuthTestConstants::STATUS_VERIFIED, password: 'TestPassword123!')
     db    = Auth::Database.connection

--- a/apps/web/auth/spec/integration/full/sso_link_confirm_mailbox_proof_spec.rb
+++ b/apps/web/auth/spec/integration/full/sso_link_confirm_mailbox_proof_spec.rb
@@ -1,0 +1,619 @@
+# apps/web/auth/spec/integration/full/sso_link_confirm_mailbox_proof_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration (full mode)
+# =============================================================================
+#
+# Issue: #3840 Phase 4 — MAILBOX-PROOF linking for PASSWORDLESS SSO accounts.
+#        An UNAUTHENTICATED SSO sign-in whose IdP email matches an EXISTING
+#        PASSWORDLESS account on the PLATFORM surface can no longer be helped by
+#        Phase 3's password interstitial (there is no password to challenge).
+#        Phase 4 instead mints a single-use Onetime::SsoLinkVerification, EMAILS
+#        the token to the account's ON-FILE address, and redirects the browser
+#        TOKEN-LESSLY to /signin?auth_notice=link_verification_sent. Clicking the
+#        emailed link opens the SPA confirm page, which:
+#          GET  /auth/sso-link-confirm/:token -> { provider, email } (display only,
+#               NEVER consumes)
+#          POST /auth/sso-link-confirm { token } -> atomic single-use consume ->
+#               re-verify ownership + watermark -> MFA gate ->
+#               Auth::Operations::BindSsoIdentity -> rodauth.login('sso_link_confirm')
+#
+#        INVARIANT: email may LOCATE an account; only a demonstrated credential may
+#        BIND. Here the credential is MAILBOX CONTROL — the token travels ONLY via
+#        the emailed link, NEVER in the callback redirect, so completing an SSO
+#        round-trip that merely asserts the victim's email discloses nothing that
+#        lets a caller self-consume the token.
+#
+# WHAT IT LOCKS IN (production code, ALL uncommitted working-tree at time of
+#   writing — see the concurrent-writer note in the run report):
+#     config/hooks/omniauth.rb (the `elsif platform_surface` mailbox branch),
+#     routes/sso_link_confirm.rb, operations/confirm_sso_link.rb,
+#     operations/bind_sso_identity.rb, models/sso_link_verification.rb.
+#
+#   1. passwordless PLATFORM callback -> TOKEN-LESS link_verification_sent redirect
+#      AND an email enqueued to the on-file address; GET display is non-consuming;
+#      POST binds (provider,issuer,uid), logs in (after_login), fires
+#      :sso_link_verification_confirmed.
+#   2. GET is non-consuming: GET twice, POST still succeeds.
+#   3. single-use: second POST -> 401 link_expired.
+#   4. TTL/expiry: gone token -> GET 404 / POST 401 link_expired.
+#   5. soft cross-device bind: POST from a DIFFERENT sid still SUCCEEDS and fires
+#      :sso_link_verification_cross_device (info) — never a hard reject.
+#   6. conflict: (provider,issuer,uid) owned by ANOTHER account -> 409 link_conflict,
+#      no rebind.
+#   7. watermark invalidation: a credential change after issuance -> 409
+#      link_invalidated.
+#   8. refusal fail-closed: tenant surface OR a delivery failure ->
+#      account_exists_link_required and NO usable token remains.
+#   9. MFA-deferred: pending second factor -> mfa_required, identity NOT bound
+#      (PENDING — needs an AUTH_MFA_ENABLED boot; see the example).
+#
+# REQUIREMENTS:
+# - Valkey running on port 2121: pnpm run test:database:start
+# - AUTHENTICATION_MODE=full, AUTH_DATABASE_URL (SQLite in-memory; rake sets it)
+#
+# RUN:
+#   RACK_ENV=test AUTHENTICATION_MODE=full AUTH_DATABASE_URL=sqlite::memory: \
+#     ORGS_SSO_ENABLED=true LANG=en_US.UTF-8 \
+#     bundle exec rspec \
+#     apps/web/auth/spec/integration/full/sso_link_confirm_mailbox_proof_spec.rb \
+#     --tag '~postgres_database'
+# =============================================================================
+
+require_relative '../../spec_helper'
+require_relative '../../support/oauth_flow_helper'
+
+RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integration do
+  include Rack::Test::Methods
+
+  def app
+    Onetime::Application::Registry.generate_rack_url_map
+  end
+
+  before(:all) do
+    require 'onetime'
+    require 'onetime/application/registry'
+    require 'onetime/auth_config'
+
+    Onetime.auth_config.reload! if Onetime.respond_to?(:auth_config) && Onetime.auth_config.respond_to?(:reload!)
+    Onetime::Application::Registry.reset! if Onetime::Application::Registry.respond_to?(:reset!)
+
+    Onetime.boot!(:test, force: true)
+
+    Onetime::Application::Registry.prepare_application_registry
+
+    mounts = Onetime::Application::Registry.mount_mappings.keys
+    raise "Auth app not mounted post-boot: #{mounts.inspect}" unless mounts.any? { |m| m.include?('/auth') }
+  end
+
+  let(:identities) { auth_db[:account_identities] }
+
+  # ==========================================================================
+  # Helpers (mirror omniauth_signin_interstitial_spec.rb / omniauth_connect_link_spec.rb)
+  # ==========================================================================
+
+  # Leaves session[:validated_omniauth_domain_id] nil == the PLATFORM path, so a
+  # non-tenant callback proceeds on platform credentials rather than redirecting to
+  # sso_not_configured.
+  def enable_platform_fallback
+    allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
+  end
+
+  # Seed a VERIFIED account WITHOUT a password (a PASSWORDLESS / SSO-only account —
+  # the Phase 4 subject). Also seeds the paired Customer so the watermark probe
+  # (Customer#last_password_update, via load_by_extid_or_email) resolves.
+  def seed_passwordless_account(email)
+    normalized = OT::Utils.normalize_email(email)
+    customer   = Onetime::Customer.new(email: normalized)
+    customer.save
+    auth_db[:accounts].insert(
+      email: normalized,
+      status_id: AuthTestConstants::STATUS_VERIFIED,
+      external_id: customer.extid,
+    )
+  end
+
+  def setup_mock_auth(email:, uid:, provider: :oidc)
+    OmniAuth.config.test_mode               = true
+    OmniAuth.config.allowed_request_methods = [:get, :post]
+    OmniAuth.config.mock_auth[provider]     = OmniAuth::AuthHash.new(
+      {
+        provider: provider.to_s,
+        uid: uid,
+        info: { email: email, name: 'Mailbox User', email_verified: true },
+        credentials: { token: 'mock_access_token', expires_at: Time.now.to_i + 3600, expires: true },
+        extra: { raw_info: { sub: uid, email: email, name: 'Mailbox User', email_verified: true } },
+      },
+    )
+  end
+
+  def teardown_mock_auth
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth.clear
+  end
+
+  # Content-Type/Content-Length leak from a prior JSON POST and make the next
+  # bodyless request try to parse an empty JSON body. Clear them.
+  def clear_body_headers
+    header 'Content-Type', nil
+    header 'Content-Length', nil
+  end
+
+  # Drive the UNAUTHENTICATED SSO callback and return the response.
+  def sso_callback(email:, uid:, provider: :oidc)
+    setup_mock_auth(email: email, uid: uid, provider: provider)
+    clear_body_headers
+    post "/auth/sso/#{provider}/callback"
+    last_response
+  end
+
+  # Fetch a CSRF token from the app bootstrap. The verification lives in Redis, not
+  # the session, so establishing a fresh session here does not disturb it — and (for
+  # the cross-device example) it deliberately makes the POST's current_sid DIFFER
+  # from the token's snapshotted sid.
+  def fetch_csrf_token
+    clear_body_headers
+    header 'Accept', 'application/json'
+    get '/auth'
+    last_response.headers['X-CSRF-Token']
+  end
+
+  # GET /auth/sso-link-confirm/:token — the display-only consent context.
+  def get_confirm(token)
+    clear_body_headers
+    header 'Accept', 'application/json'
+    get "/auth/sso-link-confirm/#{token}"
+    last_response
+  end
+
+  # POST /auth/sso-link-confirm { token } — the atomic consume + bind + login.
+  def post_confirm(token:)
+    csrf = fetch_csrf_token
+    clear_body_headers
+    header 'Content-Type', 'application/json'
+    header 'Accept', 'application/json'
+    header 'X-CSRF-Token', csrf if csrf
+    post '/auth/sso-link-confirm', JSON.generate(token: token)
+    last_response
+  end
+
+  # Mint a verification directly — the POST endpoint can be exercised without a full
+  # SSO round-trip, since the token carries the snapshot the op reloads. account_id,
+  # sid, and password_watermark are caller-supplied so tests can drive the conflict,
+  # cross-device, and watermark branches deterministically.
+  def mint_verification(email:, uid:, account_id:, provider: 'oidc',
+                        issuer: 'https://issuer.example.com', sid: nil, password_watermark: 0)
+    Onetime::SsoLinkVerification.issue(
+      provider: provider,
+      issuer: issuer,
+      uid: uid,
+      email: OT::Utils.normalize_email(email),
+      account_id: account_id,
+      sid: sid,
+      password_watermark: password_watermark,
+    )
+  end
+
+  # Stub the templated publisher and CAPTURE every enqueue_email call. Returns the
+  # capture buffer. Returning true means the hook treats the send as "delivered" and
+  # takes the link_verification_sent redirect. (Unstubbed, the sync fallback renders
+  # + delivers a real email in this harness — deterministic capture is cleaner and
+  # is how reset_password_request_enumeration_spec.rb isolates delivery.)
+  def capture_link_emails
+    captured = []
+    allow(Onetime::Jobs::Publisher).to receive(:enqueue_email) do |template, data, **opts|
+      captured << { template: template, data: data, opts: opts }
+      true
+    end
+    captured
+  end
+
+  # The token is delivered ONLY through the emailed confirm_url (never the redirect),
+  # so extract it from the captured email payload — mirroring what the user's inbox
+  # would receive.
+  def token_from_confirm_url(url)
+    url.to_s.split('/sso-link-confirm/').last.to_s.split(/[?#]/).first
+  end
+
+  # Advance the account's credential watermark the way a password set/reset/change
+  # would (UpdatePasswordMetadata stamps Customer#last_password_update). The op's
+  # watermark_advanced? re-reads exactly this value.
+  def advance_password_watermark(email, to: Time.now.to_i)
+    cust = Onetime::Customer.find_by_email(OT::Utils.normalize_email(email))
+    cust.last_password_update = to
+    cust.save
+    cust
+  end
+
+  # Trust off -> an existing account reaches the H-3 / mint branch rather than being
+  # auto-linked by email. Platform fallback on -> a non-tenant callback stays on the
+  # platform surface.
+  before do
+    enable_platform_fallback
+    allow(Onetime.auth_config).to receive(:trust_email_for_linking?).and_return(false)
+  end
+
+  # ==========================================================================
+  # (1) HAPPY PATH — full round trip through the REAL callback + REAL DB.
+  # ==========================================================================
+
+  describe 'happy path (passwordless platform account)' do
+    it 'emails a token-less redirect, GET displays without consuming, POST binds and logs in' do
+      email      = "mp-ok-#{SecureRandom.hex(6)}@company.example.com"
+      uid        = "sub-#{SecureRandom.hex(8)}"
+      account_id = seed_passwordless_account(email)
+      normalized = OT::Utils.normalize_email(email)
+
+      captured = capture_link_emails
+      allow(Auth::Logging).to receive(:log_auth_event).and_call_original
+
+      begin
+        # -- Issuance ---------------------------------------------------------
+        response = sso_callback(email: email, uid: uid)
+        skip 'OmniAuth route not registered (OIDC discovery not available at boot)' if response.status == 404
+
+        expect(response.status).to eq(302)
+        # TOKEN-LESS informational redirect (the mailbox-proof property).
+        expect(response.location.to_s).to include('/signin?auth_notice=link_verification_sent'),
+          "Passwordless platform account must divert to the mailbox notice. Location: #{response.location.inspect}"
+        expect(response.location.to_s).not_to include('account_exists_link_required')
+
+        # Exactly one link email, to the ON-FILE address, carrying the token in the
+        # confirm_url (and NOWHERE in the redirect).
+        expect(captured.size).to eq(1), "Expected one link email, got: #{captured.inspect}"
+        mail = captured.first
+        expect(mail[:template]).to eq(:sso_link_verification)
+        expect(mail[:opts][:fallback]).to eq(:sync)
+        expect(mail[:data][:email_address]).to eq(normalized)
+        expect(mail[:data][:provider].to_s).to eq('oidc')
+
+        token = token_from_confirm_url(mail[:data][:confirm_url])
+        expect(token).not_to be_empty
+        expect(response.location.to_s).not_to include(token),
+          'The token must NEVER ride the callback redirect — only the email.'
+
+        expect(Auth::Logging).to have_received(:log_auth_event)
+          .with(:sso_link_verification_issued, hash_including(provider: 'oidc', account_id: account_id))
+
+        # -- GET display (non-consuming) -------------------------------------
+        ctx = get_confirm(token)
+        expect(ctx.status).to eq(200)
+        body = JSON.parse(ctx.body)
+        expect(body['provider']).to eq('oidc')
+        expect(body['email']).to eq(normalized)
+        # Never surface the account id, uid, issuer, sid, or watermark.
+        %w[account_id uid issuer sid password_watermark].each do |leak|
+          expect(body).not_to have_key(leak)
+        end
+
+        # -- POST confirm -> bind + login ------------------------------------
+        result = post_confirm(token: token)
+        expect(result.status).to eq(200),
+          "Expected a Rodauth login response, got #{result.status}: #{result.body}"
+        expect(JSON.parse(result.body)).to have_key('success')
+
+        # The bind: exactly one (provider, uid) row, on the located account.
+        rows = identities.where(provider: 'oidc', uid: uid).all
+        expect(rows.size).to eq(1), "Expected one bound row, got #{rows.inspect}"
+        expect(rows.first[:account_id]).to eq(account_id)
+        expect(rows.first[:issuer]).not_to be_nil
+
+        # after_login ran: a 200 { success } is only THROWN by rodauth.login, which
+        # runs login_session + after_login (Redis session blob via SyncSession,
+        # active_sessions) before emitting login_response. Corroborate with the
+        # confirmed audit and the consumed single-use token. (The op logs the token's
+        # STRING account_id here, vs the hook's Integer one on :issued — an incidental
+        # type difference, so match on provider only.)
+        expect(Auth::Logging).to have_received(:log_auth_event)
+          .with(:sso_link_verification_confirmed, hash_including(provider: 'oidc'))
+        expect(Onetime::SsoLinkVerification.load(token)).to be_nil
+      ensure
+        teardown_mock_auth
+      end
+    end
+  end
+
+  # ==========================================================================
+  # (2) GET IS NON-CONSUMING — GET twice, POST still succeeds.
+  # ==========================================================================
+
+  describe 'GET /auth/sso-link-confirm/:token is non-consuming' do
+    it 'returns the display context on repeated GETs and leaves the token usable for POST' do
+      email      = "mp-get-#{SecureRandom.hex(6)}@company.example.com"
+      uid        = "sub-#{SecureRandom.hex(8)}"
+      account_id = seed_passwordless_account(email)
+
+      verification = mint_verification(email: email, uid: uid, account_id: account_id)
+
+      2.times do
+        ctx = get_confirm(verification.token)
+        expect(ctx.status).to eq(200)
+        expect(JSON.parse(ctx.body)['email']).to eq(OT::Utils.normalize_email(email))
+      end
+
+      # The token survived both GETs — the POST still consumes + binds.
+      result = post_confirm(token: verification.token)
+      expect(result.status).to eq(200), "Expected success after non-consuming GETs, got #{result.status}: #{result.body}"
+      expect(identities.where(provider: 'oidc', uid: uid).count).to eq(1)
+    end
+  end
+
+  # ==========================================================================
+  # (3) SINGLE-USE — second POST is refused.
+  # ==========================================================================
+
+  describe 'single-use token consumption' do
+    it 'refuses a second POST reusing an already-consumed token (401 link_expired)' do
+      email      = "mp-once-#{SecureRandom.hex(6)}@company.example.com"
+      uid        = "sub-#{SecureRandom.hex(8)}"
+      account_id = seed_passwordless_account(email)
+
+      verification = mint_verification(email: email, uid: uid, account_id: account_id)
+
+      first = post_confirm(token: verification.token)
+      expect(first.status).to eq(200), "First confirm should succeed, got #{first.status}: #{first.body}"
+
+      second = post_confirm(token: verification.token)
+      expect(second.status).to eq(401)
+      expect(JSON.parse(second.body)['error_code']).to eq('link_expired')
+
+      # And no duplicate bind resulted from the retry.
+      expect(identities.where(provider: 'oidc', uid: uid).count).to eq(1)
+    end
+  end
+
+  # ==========================================================================
+  # (4) TTL / EXPIRY — a gone token refuses on both verbs.
+  # ==========================================================================
+  #
+  # Familia expiration deletes the Redis key when the TTL lapses, so simulating
+  # expiry by deleting the key exercises the SAME load-nil path the real timeout
+  # produces (matches how the Phase 3 spec drives "unknown token").
+
+  describe 'expired / missing token' do
+    it 'GET returns 404 link_expired and POST returns 401 link_expired' do
+      email      = "mp-ttl-#{SecureRandom.hex(6)}@company.example.com"
+      uid        = "sub-#{SecureRandom.hex(8)}"
+      account_id = seed_passwordless_account(email)
+
+      verification = mint_verification(email: email, uid: uid, account_id: account_id)
+      verification.delete! # simulate the TTL lapse (key gone)
+
+      ctx = get_confirm(verification.token)
+      expect(ctx.status).to eq(404)
+      expect(JSON.parse(ctx.body)['error_code']).to eq('link_expired')
+
+      result = post_confirm(token: verification.token)
+      expect(result.status).to eq(401)
+      expect(JSON.parse(result.body)['error_code']).to eq('link_expired')
+
+      expect(identities.where(provider: 'oidc', uid: uid).count).to eq(0)
+    end
+  end
+
+  # ==========================================================================
+  # (5) SOFT CROSS-DEVICE BIND — a sid mismatch is logged, never rejected.
+  # ==========================================================================
+  #
+  # Mailbox proof is inherently cross-device (the user may click on their phone), so
+  # a POST whose current_sid differs from the token's snapshotted sid must still
+  # SUCCEED. The op fires :sso_link_verification_cross_device (info) for observability.
+  # The token is minted with a KNOWN sid; the POST's current_sid is the harness
+  # session cookie (a fresh 64-hex from fetch_csrf_token) -> guaranteed different.
+
+  describe 'soft cross-device binding' do
+    it 'binds successfully from a different sid and fires the cross-device info audit' do
+      email      = "mp-xd-#{SecureRandom.hex(6)}@company.example.com"
+      uid        = "sub-#{SecureRandom.hex(8)}"
+      account_id = seed_passwordless_account(email)
+
+      allow(Auth::Logging).to receive(:log_auth_event).and_call_original
+
+      verification = mint_verification(
+        email: email, uid: uid, account_id: account_id, sid: "device-a-#{SecureRandom.hex(8)}",
+      )
+
+      result = post_confirm(token: verification.token)
+
+      # Soft binding: SUCCEEDS despite the sid mismatch.
+      expect(result.status).to eq(200), "Cross-device confirm must succeed, got #{result.status}: #{result.body}"
+      expect(identities.where(provider: 'oidc', uid: uid).count).to eq(1)
+
+      expect(Auth::Logging).to have_received(:log_auth_event)
+        .with(:sso_link_verification_cross_device, hash_including(provider: 'oidc'))
+    end
+  end
+
+  # ==========================================================================
+  # (6) CONFLICT — the identity is already owned by a DIFFERENT account.
+  # ==========================================================================
+  #
+  # The bind primitive verifies the pre-existing (provider, issuer, uid) row belongs
+  # to the account we are confirming. A row owned by ANOTHER account is a conflict
+  # (409 link_conflict), never a silent idempotent success onto someone else's
+  # identity. Defence-in-depth: the mint only happens when no row exists, so this
+  # models a row appearing between issuance and confirm.
+
+  describe 'identity already owned by another account (link_conflict)' do
+    it 'refuses with 409 link_conflict and binds nothing onto the confirming account' do
+      email_a   = "mp-owner-a-#{SecureRandom.hex(6)}@company.example.com"
+      email_b   = "mp-owner-b-#{SecureRandom.hex(6)}@company.example.com"
+      uid       = "sub-#{SecureRandom.hex(8)}"
+      issuer    = 'https://issuer.example.com'
+      account_a = seed_passwordless_account(email_a)
+      account_b = seed_passwordless_account(email_b)
+
+      # Account B already owns this exact (provider, issuer, uid).
+      identities.insert(account_id: account_b, provider: 'oidc', issuer: issuer, uid: uid)
+
+      # The verification snapshots account A (which email_a re-locates, so the
+      # ownership re-check passes and execution reaches BindSsoIdentity).
+      verification = mint_verification(email: email_a, uid: uid, account_id: account_a, issuer: issuer)
+      result       = post_confirm(token: verification.token)
+
+      expect(result.status).to eq(409), "Expected link_conflict, got #{result.status}: #{result.body}"
+      expect(JSON.parse(result.body)['error_code']).to eq('link_conflict')
+
+      # Still exactly one row — owned by B — and nothing bound onto A.
+      rows = identities.where(provider: 'oidc', uid: uid).all
+      expect(rows.size).to eq(1)
+      expect(rows.first[:account_id]).to eq(account_b)
+      expect(identities.where(account_id: account_a).count).to eq(0)
+    end
+  end
+
+  # ==========================================================================
+  # (7) WATERMARK INVALIDATION — a credential change voids the token.
+  # ==========================================================================
+  #
+  # The token snapshots Customer#last_password_update at issuance. Any credential
+  # change (password set/reset/change stamps the watermark via UpdatePasswordMetadata)
+  # between issuance and confirm must invalidate it (409 link_invalidated).
+
+  describe 'credential-change invalidation (link_invalidated)' do
+    it 'refuses with 409 link_invalidated when the password watermark advanced after issuance' do
+      email      = "mp-wm-#{SecureRandom.hex(6)}@company.example.com"
+      uid        = "sub-#{SecureRandom.hex(8)}"
+      account_id = seed_passwordless_account(email)
+
+      # Snapshot watermark == 0 (freshly seeded passwordless customer), then advance
+      # it AFTER issuance — modelling a credential change during the email round-trip.
+      verification = mint_verification(email: email, uid: uid, account_id: account_id, password_watermark: 0)
+      advance_password_watermark(email, to: Time.now.to_i)
+
+      result = post_confirm(token: verification.token)
+
+      expect(result.status).to eq(409), "Expected link_invalidated, got #{result.status}: #{result.body}"
+      expect(JSON.parse(result.body)['error_code']).to eq('link_invalidated')
+
+      # Nothing bound; and the single-use token was consumed up front (no oracle).
+      expect(identities.where(provider: 'oidc', uid: uid).count).to eq(0)
+      expect(Onetime::SsoLinkVerification.load(verification.token)).to be_nil
+    end
+  end
+
+  # ==========================================================================
+  # (8) REFUSAL FAIL-CLOSED — no usable token when linking cannot proceed.
+  # ==========================================================================
+
+  describe 'refusal is fail-closed' do
+    # -- (8a) delivery failure ------------------------------------------------
+    #
+    # If the link email cannot be delivered, the just-issued token is consumed and
+    # the callback falls through to the UNCHANGED H-3 refusal — never leaving a live
+    # token whose recipient inbox got no mail.
+    it 'consumes the token and keeps the H-3 refusal when email delivery raises' do
+      email = "mp-fail-#{SecureRandom.hex(6)}@company.example.com"
+      uid   = "sub-#{SecureRandom.hex(8)}"
+      seed_passwordless_account(email)
+
+      allow(Onetime::Jobs::Publisher).to receive(:enqueue_email).and_raise(StandardError.new('smtp unreachable'))
+      allow(Auth::Logging).to receive(:log_auth_event).and_call_original
+
+      # Capture the exact token that was minted so we can prove it no longer resolves.
+      minted = nil
+      allow(Onetime::SsoLinkVerification).to receive(:issue).and_wrap_original do |orig, **kw|
+        minted = orig.call(**kw)
+        minted
+      end
+
+      begin
+        response = sso_callback(email: email, uid: uid)
+        skip 'OmniAuth route not registered' if response.status == 404
+
+        expect(response.status).to eq(302)
+        expect(response.location.to_s).to include('/signin?auth_error=account_exists_link_required'),
+          "Delivery failure must fall through to the H-3 refusal. Location: #{response.location.inspect}"
+        expect(response.location.to_s).not_to include('link_verification_sent')
+
+        # The send failure was audited AND the just-minted token was deleted.
+        expect(Auth::Logging).to have_received(:log_auth_event)
+          .with(:sso_link_verification_send_FAILED, hash_including(provider: 'oidc'))
+        expect(minted).not_to be_nil
+        expect(Onetime::SsoLinkVerification.load(minted.token)).to be_nil,
+          'A failed delivery must not leave a live, un-notified token behind.'
+      ensure
+        teardown_mock_auth
+      end
+    end
+
+    # -- (8b) tenant surface --------------------------------------------------
+    #
+    # A passwordless account reached via a TENANT callback must NEVER be offered
+    # mailbox linking: a tenant admin controls their IdP and could otherwise trigger
+    # link emails to arbitrary platform addresses. The `elsif platform_surface` guard
+    # makes tenant callbacks fall through to the H-3 refusal — no verification minted,
+    # no email, no :sso_link_verification_issued.
+    describe 'tenant-surface callback (surface isolation)', :oauth_flow do
+      include OAuthFlowHelper
+
+      it 'refuses (H-3) and mints NO verification on the tenant surface' do
+        run_id = "mp-tenant-#{SecureRandom.hex(4)}"
+        host   = "secrets-#{run_id}.tenant.example.com"
+        email  = "victim-#{run_id}@company.example.com"
+        uid    = "sub-#{SecureRandom.hex(8)}"
+
+        seed_passwordless_account(email)
+        setup_oauth_test_domain(host)
+
+        allow(Auth::Logging).to receive(:log_auth_event).and_call_original
+        allow(Onetime::SsoLinkVerification).to receive(:issue).and_call_original
+        allow(Onetime::Jobs::Publisher).to receive(:enqueue_email).and_call_original
+        setup_mock_auth(email: email, uid: uid)
+
+        begin
+          clear_body_headers
+          header 'Host', host
+          post '/auth/sso/oidc'
+          skip "OmniAuth route not registered for #{host}" if last_response.status == 404
+          expect(last_response.status).to eq(302)
+
+          clear_body_headers
+          header 'Host', host
+          post '/auth/sso/oidc/callback'
+
+          expect(last_response.status).to eq(302)
+          expect(last_response.location.to_s).to include('/signin?auth_error=account_exists_link_required'),
+            "Tenant callback for a passwordless account must keep the H-3 refusal. Location: #{last_response.location.inspect}"
+          expect(last_response.location.to_s).not_to include('link_verification_sent')
+
+          # No mailbox verification path was taken on the tenant surface.
+          expect(Onetime::SsoLinkVerification).not_to have_received(:issue)
+          expect(Onetime::Jobs::Publisher).not_to have_received(:enqueue_email)
+          expect(Auth::Logging).not_to have_received(:log_auth_event)
+            .with(:sso_link_verification_issued, anything)
+          expect(Auth::Logging).to have_received(:log_auth_event)
+            .with(:omniauth_link_refused_existing_account, hash_including(provider: 'oidc'))
+          expect(identities.where(provider: 'oidc', uid: uid).count).to eq(0)
+        ensure
+          teardown_mock_auth
+        end
+      end
+    end
+  end
+
+  # ==========================================================================
+  # (9) MFA-DEFERRED bind (needs an AUTH_MFA_ENABLED harness).
+  # ==========================================================================
+  #
+  # When the located account has a pending second factor the identity bind must be
+  # DEFERRED (binding an MFA-exempt SSO path before 2FA would attach an MFA-bypassing
+  # login): the op returns second_factor_pending, the route logs the user in via
+  # rodauth.login('sso_link_confirm') which THROWS the SAME mfa_required body
+  # POST /auth/login emits, and the (provider,issuer,uid) row stays UNLINKED this
+  # round.
+  #
+  # Exercising this end-to-end needs the OTP feature loaded (AUTH_MFA_ENABLED) so
+  # rodauth.respond_to?(:otp_auth_route) is true and after_login emits mfa_required.
+  # This shared integration harness boots ONCE (before(:all)) with MFA disabled and
+  # cannot toggle the Rodauth feature set per-example (the same boot-time-feature
+  # constraint that pends the Phase 3 interstitial MFA example). Left PENDING so the
+  # gap stays visible; verified in isolation by the ConfirmSsoLink#second_factor_pending?
+  # unit coverage. Manual follow-up: #3877 (deferred bind after MFA) needs an
+  # AUTH_MFA_ENABLED full-boot lane.
+  describe 'MFA account defers the identity bind (#3877)' do
+    it 'returns mfa_required and binds no identity (needs an AUTH_MFA_ENABLED harness)'
+  end
+end

--- a/apps/web/auth/spec/integration/full/sso_link_confirm_mailbox_proof_spec.rb
+++ b/apps/web/auth/spec/integration/full/sso_link_confirm_mailbox_proof_spec.rb
@@ -749,17 +749,21 @@ RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integrat
   # login): the op returns second_factor_pending, the route logs the user in via
   # rodauth.login('sso_link_confirm') which THROWS the SAME mfa_required body
   # POST /auth/login emits, and the (provider,issuer,uid) row stays UNLINKED this
-  # round.
+  # round — but the authorized bind tuple is STASHED inside the login block
+  # (DeferredSsoBind.defer, #3858) and COMPLETED by after_two_factor_authentication
+  # once the OTP succeeds (#3877), exactly like the password interstitial. Without
+  # that stash an MFA passwordless account would re-hit this flow on every SSO
+  # sign-in and never link.
   #
   # Exercising this end-to-end needs the OTP feature loaded (AUTH_MFA_ENABLED) so
   # rodauth.respond_to?(:otp_auth_route) is true and after_login emits mfa_required.
   # This shared integration harness boots ONCE (before(:all)) with MFA disabled and
   # cannot toggle the Rodauth feature set per-example (the same boot-time-feature
   # constraint that pends the Phase 3 interstitial MFA example). Left PENDING so the
-  # gap stays visible; verified in isolation by the ConfirmSsoLink#second_factor_pending?
-  # unit coverage. Manual follow-up: #3877 (deferred bind after MFA) needs an
-  # AUTH_MFA_ENABLED full-boot lane.
-  describe 'MFA account defers the identity bind (#3877)' do
-    it 'returns mfa_required and binds no identity (needs an AUTH_MFA_ENABLED harness)'
+  # gap stays visible; the defer→complete wiring is covered in isolation by
+  # deferred_sso_bind_spec.rb. A full end-to-end assertion needs an AUTH_MFA_ENABLED
+  # full-boot lane.
+  describe 'MFA account defers the identity bind, completing it after 2FA (#3877)' do
+    it 'returns mfa_required, stashes the bind, and links after OTP (needs an AUTH_MFA_ENABLED harness)'
   end
 end

--- a/apps/web/auth/spec/integration/full/sso_link_confirm_mailbox_proof_spec.rb
+++ b/apps/web/auth/spec/integration/full/sso_link_confirm_mailbox_proof_spec.rb
@@ -45,8 +45,14 @@
 #      no rebind.
 #   7. watermark invalidation: a credential change after issuance -> 409
 #      link_invalidated.
-#   8. refusal fail-closed: tenant surface OR a delivery failure ->
-#      account_exists_link_required and NO usable token remains.
+#   8. refusal fail-closed: tenant surface, a delivery failure, OR an unresolvable
+#      Customer -> account_exists_link_required and NO usable token remains.
+#      "Delivery failure" covers the NON-RAISING shapes too — the mail layer
+#      dispatching nothing, a suppressed recipient, EMAILER_MODE=disabled — because
+#      each of those returns normally and would otherwise be reported as "sent".
+#      "Unresolvable Customer" is the issuance/confirm SYMMETRY case: confirm rejects
+#      that state (:unreadable -> 409), so issuing would mail a permanently
+#      unredeemable link.
 #   9. MFA-deferred: pending second factor -> mfa_required, identity NOT bound
 #      (PENDING — needs an AUTH_MFA_ENABLED boot; see the example).
 #
@@ -76,6 +82,9 @@ RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integrat
     require 'onetime'
     require 'onetime/application/registry'
     require 'onetime/auth_config'
+    # The delivery examples stub Onetime::Mail / Mailer directly; the hook only
+    # requires the mail stack lazily, so make sure the constants exist first.
+    require 'onetime/mail'
 
     Onetime.auth_config.reload! if Onetime.respond_to?(:auth_config) && Onetime.auth_config.respond_to?(:reload!)
     Onetime::Application::Registry.reset! if Onetime::Application::Registry.respond_to?(:reset!)
@@ -112,6 +121,27 @@ RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integrat
       email: normalized,
       status_id: AuthTestConstants::STATUS_VERIFIED,
       external_id: customer.extid,
+    )
+  end
+
+  # Seed a VERIFIED PASSWORDLESS account whose paired Customer CANNOT be resolved:
+  # the row carries an external_id no Customer holds, and no Customer exists at the
+  # address either — so Customer.load_by_extid_or_email (the identifier logic BOTH
+  # the issuance hook and ConfirmSsoLink#watermark_state use) returns nil.
+  #
+  # This is the terminal state of the field case the issuance gate exists for: in
+  # production `accounts.email` is citext (case-insensitive compare, case-PRESERVING
+  # storage) while the Customer email index is a case-SENSITIVE Redis hash, so a
+  # legacy mixed-case row that migrations/007_normalize_customer_emails.rb skipped
+  # probes the index and misses. That exact shape cannot be staged in this harness
+  # (SQLite compares TEXT case-sensitively, so the account itself would not be
+  # located), and a dangling external_id reaches the same nil through the same call —
+  # which is all the gate keys on.
+  def seed_account_without_customer(email)
+    auth_db[:accounts].insert(
+      email: OT::Utils.normalize_email(email),
+      status_id: AuthTestConstants::STATUS_VERIFIED,
+      external_id: "cust-missing-#{SecureRandom.hex(8)}",
     )
   end
 
@@ -197,10 +227,11 @@ RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integrat
   end
 
   # Stub the templated publisher and CAPTURE every enqueue_email call. Returns the
-  # capture buffer. Returning true means the hook treats the send as "delivered" and
-  # takes the link_verification_sent redirect. (Unstubbed, the sync fallback renders
-  # + delivers a real email in this harness — deterministic capture is cleaner and
-  # is how reset_password_request_enumeration_spec.rb isolates delivery.)
+  # capture buffer. Returning true means the message was QUEUED — the only outcome
+  # the hook accepts as "delivered" without delivering inline itself — so the flow
+  # takes the link_verification_sent redirect. (Unstubbed, the hook would render +
+  # deliver a real email in this harness; deterministic capture is cleaner and is
+  # how reset_password_request_enumeration_spec.rb isolates delivery.)
   def capture_link_emails
     captured = []
     allow(Onetime::Jobs::Publisher).to receive(:enqueue_email) do |template, data, **opts|
@@ -265,7 +296,10 @@ RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integrat
         expect(captured.size).to eq(1), "Expected one link email, got: #{captured.inspect}"
         mail = captured.first
         expect(mail[:template]).to eq(:sso_link_verification)
-        expect(mail[:opts][:fallback]).to eq(:sync)
+        # :none, NOT :sync — the hook refuses a fallback whose outcome it cannot
+        # read (Publisher discards the sync delivery's boolean), so a `true` here
+        # can only mean genuinely QUEUED. It delivers inline itself otherwise.
+        expect(mail[:opts][:fallback]).to eq(:none)
         expect(mail[:data][:email_address]).to eq(normalized)
         expect(mail[:data][:provider].to_s).to eq('oidc')
 
@@ -499,17 +533,18 @@ RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integrat
   # ==========================================================================
 
   describe 'refusal is fail-closed' do
-    # -- (8a) delivery failure ------------------------------------------------
-    #
-    # If the link email cannot be delivered, the just-issued token is consumed and
-    # the callback falls through to the UNCHANGED H-3 refusal — never leaving a live
-    # token whose recipient inbox got no mail.
-    it 'consumes the token and keeps the H-3 refusal when email delivery raises' do
-      email = "mp-fail-#{SecureRandom.hex(6)}@company.example.com"
-      uid   = "sub-#{SecureRandom.hex(8)}"
+    # Drive the passwordless platform callback under a delivery condition that must
+    # NOT be reported as "sent", and assert the whole fail-closed contract: the H-3
+    # refusal, NO link_verification_sent notice, no :issued audit, an audited send
+    # failure, and NO live token left behind. The block installs the condition (the
+    # normalized on-file address is yielded for per-address stubs) AFTER the account
+    # is seeded but BEFORE the callback runs.
+    def expect_fail_closed_delivery(label)
+      email      = "mp-#{label}-#{SecureRandom.hex(6)}@company.example.com"
+      uid        = "sub-#{SecureRandom.hex(8)}"
+      normalized = OT::Utils.normalize_email(email)
       seed_passwordless_account(email)
 
-      allow(Onetime::Jobs::Publisher).to receive(:enqueue_email).and_raise(StandardError.new('smtp unreachable'))
       allow(Auth::Logging).to receive(:log_auth_event).and_call_original
 
       # Capture the exact token that was minted so we can prove it no longer resolves.
@@ -519,27 +554,89 @@ RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integrat
         minted
       end
 
+      yield normalized
+
       begin
         response = sso_callback(email: email, uid: uid)
         skip 'OmniAuth route not registered' if response.status == 404
 
         expect(response.status).to eq(302)
         expect(response.location.to_s).to include('/signin?auth_error=account_exists_link_required'),
-          "Delivery failure must fall through to the H-3 refusal. Location: #{response.location.inspect}"
+          "Undelivered mail must fall through to the H-3 refusal. Location: #{response.location.inspect}"
         expect(response.location.to_s).not_to include('link_verification_sent')
 
-        # The send failure was audited AND the just-minted token was deleted.
+        # The send failure was audited, the "check your inbox" audit was NOT, and the
+        # just-minted token was deleted.
         expect(Auth::Logging).to have_received(:log_auth_event)
           .with(:sso_link_verification_send_FAILED, hash_including(provider: 'oidc'))
+        expect(Auth::Logging).not_to have_received(:log_auth_event)
+          .with(:sso_link_verification_issued, anything)
         expect(minted).not_to be_nil
         expect(Onetime::SsoLinkVerification.load(minted.token)).to be_nil,
-          'A failed delivery must not leave a live, un-notified token behind.'
+          'An undelivered link must not leave a live, un-notified token behind.'
       ensure
         teardown_mock_auth
       end
     end
 
-    # -- (8b) tenant surface --------------------------------------------------
+    # -- (8a) delivery RAISES --------------------------------------------------
+    #
+    # If the link email cannot be delivered, the just-issued token is consumed and
+    # the callback falls through to the UNCHANGED H-3 refusal — never leaving a live
+    # token whose recipient inbox got no mail.
+    it 'consumes the token and keeps the H-3 refusal when email delivery raises' do
+      expect_fail_closed_delivery('fail') do
+        allow(Onetime::Jobs::Publisher).to receive(:enqueue_email).and_raise(StandardError.new('smtp unreachable'))
+      end
+    end
+
+    # -- (8b) delivery RETURNS without sending ---------------------------------
+    #
+    # The dangerous shape: nothing raises. Publisher reports "not queued" (jobs
+    # disabled / RabbitMQ down) and the inline delivery returns nil because the mail
+    # layer dispatched nothing (Delivery::Base#deliver returns nil for a suppressed
+    # recipient, Delivery::Disabled always does). A returned nil is NOT a send, so it
+    # must fail closed exactly like the raise — this is what the pre-fix code got
+    # wrong, unconditionally claiming success from a normal return.
+    it 'consumes the token and refuses when the mail layer returns without dispatching anything' do
+      expect_fail_closed_delivery('nodispatch') do
+        allow(Onetime::Jobs::Publisher).to receive(:enqueue_email).and_return(false)
+        allow(Onetime::Mail).to receive(:deliver).and_return(nil)
+      end
+    end
+
+    # -- (8c) suppressed recipient ---------------------------------------------
+    #
+    # A suppressed address is skipped silently by every send — including the QUEUED
+    # one, which could never report back to the callback. Probed up front, so nothing
+    # is queued and the user is never told to check an inbox that gets nothing.
+    it 'refuses without queuing anything when the on-file address is suppressed' do
+      expect_fail_closed_delivery('suppressed') do |normalized|
+        allow(Onetime::EmailSuppression).to receive(:suppressed?).and_call_original
+        allow(Onetime::EmailSuppression).to receive(:suppressed?).with(normalized).and_return(true)
+        # Would have claimed success had the hook queued it anyway.
+        allow(Onetime::Jobs::Publisher).to receive(:enqueue_email).and_return(true)
+      end
+
+      expect(Onetime::Jobs::Publisher).not_to have_received(:enqueue_email)
+    end
+
+    # -- (8d) delivery disabled install-wide -----------------------------------
+    #
+    # EMAILER_MODE=disabled/none makes every delivery a silent no-op
+    # (Delivery::Disabled), on the queued path too. Mailbox proof is impossible on
+    # such an install, so the branch must refuse rather than mint a token nobody can
+    # ever receive.
+    it 'refuses without queuing anything when email delivery is disabled install-wide' do
+      expect_fail_closed_delivery('disabled') do
+        allow(Onetime::Mail::Mailer).to receive(:determine_provider).and_return('disabled')
+        allow(Onetime::Jobs::Publisher).to receive(:enqueue_email).and_return(true)
+      end
+
+      expect(Onetime::Jobs::Publisher).not_to have_received(:enqueue_email)
+    end
+
+    # -- (8e) tenant surface --------------------------------------------------
     #
     # A passwordless account reached via a TENANT callback must NEVER be offered
     # mailbox linking: a tenant admin controls their IdP and could otherwise trigger
@@ -590,6 +687,55 @@ RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integrat
         ensure
           teardown_mock_auth
         end
+      end
+    end
+
+    # -- (8f) unresolvable Customer -------------------------------------------
+    #
+    # ISSUANCE/CONFIRM SYMMETRY. ConfirmSsoLink#watermark_state fails SECURE on an
+    # unresolvable Customer (nil -> :unreadable -> 409 link_error), and it re-derives
+    # the identifier with the SAME external_id-first logic the hook used at issuance —
+    # so a Customer that does not resolve at issuance will not resolve at confirm
+    # either. Minting anyway would mail a link guaranteed to 409 on EVERY click,
+    # permanently: this branch is passwordless-only, so the H-3 "sign in with your
+    # existing method" recovery does not exist for these accounts. The hook therefore
+    # gates issuance on the same resolution and falls through to the H-3 refusal — an
+    # actionable message now, rather than an unredeemable email later.
+    it 'refuses (H-3) and mints NO verification when the account Customer does not resolve' do
+      email = "mp-nocust-#{SecureRandom.hex(6)}@company.example.com"
+      uid   = "sub-#{SecureRandom.hex(8)}"
+      seed_account_without_customer(email)
+
+      allow(Auth::Logging).to receive(:log_auth_event).and_call_original
+      allow(Onetime::SsoLinkVerification).to receive(:issue).and_call_original
+      allow(Onetime::Jobs::Publisher).to receive(:enqueue_email).and_call_original
+      allow(Onetime::Mail).to receive(:deliver).and_call_original
+
+      begin
+        response = sso_callback(email: email, uid: uid)
+        skip 'OmniAuth route not registered' if response.status == 404
+
+        expect(response.status).to eq(302)
+        expect(response.location.to_s).to include('/signin?auth_error=account_exists_link_required'),
+          "An unresolvable Customer must refuse at issuance. Location: #{response.location.inspect}"
+        expect(response.location.to_s).not_to include('link_verification_sent')
+
+        # Nothing minted, nothing mailed — on either delivery path.
+        expect(Onetime::SsoLinkVerification).not_to have_received(:issue)
+        expect(Onetime::Jobs::Publisher).not_to have_received(:enqueue_email)
+        expect(Onetime::Mail).not_to have_received(:deliver)
+
+        # Audited as the operator-actionable data problem it is, NOT as "sent".
+        expect(Auth::Logging).to have_received(:log_auth_event)
+          .with(:sso_link_verification_customer_unresolved, hash_including(provider: 'oidc'))
+        expect(Auth::Logging).not_to have_received(:log_auth_event)
+          .with(:sso_link_verification_issued, anything)
+        expect(Auth::Logging).to have_received(:log_auth_event)
+          .with(:omniauth_link_refused_existing_account, hash_including(provider: 'oidc'))
+
+        expect(identities.where(provider: 'oidc', uid: uid).count).to eq(0)
+      ensure
+        teardown_mock_auth
       end
     end
   end

--- a/apps/web/auth/spec/integration/full/sso_link_confirm_mailbox_proof_spec.rb
+++ b/apps/web/auth/spec/integration/full/sso_link_confirm_mailbox_proof_spec.rb
@@ -741,7 +741,7 @@ RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integrat
   end
 
   # ==========================================================================
-  # (9) MFA-DEFERRED bind (needs an AUTH_MFA_ENABLED harness).
+  # (9) MFA-DEFERRED bind (covered in the AUTH_MFA_ENABLED lane).
   # ==========================================================================
   #
   # When the located account has a pending second factor the identity bind must be
@@ -757,13 +757,16 @@ RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integrat
   #
   # Exercising this end-to-end needs the OTP feature loaded (AUTH_MFA_ENABLED) so
   # rodauth.respond_to?(:otp_auth_route) is true and after_login emits mfa_required.
-  # This shared integration harness boots ONCE (before(:all)) with MFA disabled and
-  # cannot toggle the Rodauth feature set per-example (the same boot-time-feature
-  # constraint that pends the Phase 3 interstitial MFA example). Left PENDING so the
-  # gap stays visible; the defer→complete wiring is covered in isolation by
-  # deferred_sso_bind_spec.rb. A full end-to-end assertion needs an AUTH_MFA_ENABLED
-  # full-boot lane.
-  describe 'MFA account defers the identity bind, completing it after 2FA (#3877)' do
-    it 'returns mfa_required, stashes the bind, and links after OTP (needs an AUTH_MFA_ENABLED harness)'
-  end
+  # THIS shared harness boots ONCE (before(:all)) with MFA disabled and cannot
+  # toggle the Rodauth feature set per-example (Auth::Config is one-shot —
+  # auth-config-one-shot.md), so the coverage lives elsewhere:
+  #   - END-TO-END: integration/full_mfa/sso_link_confirm_mailbox_proof_mfa_spec.rb
+  #     runs in its OWN process with AUTH_MFA_ENABLED=true (rake
+  #     spec:integration:full:mfa, chained from spec:integration:full) and locks
+  #     in the full sequence — mfa_required + token consumed + NO row at the
+  #     confirm step, then the bound row after the second factor (OTP AND recovery
+  #     code) succeeds.
+  #   - MECHANICS: spec/operations/deferred_sso_bind_spec.rb (session contract,
+  #     single-use, account-bound, conflict passthrough).
+  # No pending example here: the gap this placeholder kept visible is closed.
 end

--- a/apps/web/auth/spec/integration/full/sso_link_confirm_mailbox_proof_spec.rb
+++ b/apps/web/auth/spec/integration/full/sso_link_confirm_mailbox_proof_spec.rb
@@ -70,13 +70,11 @@
 
 require_relative '../../spec_helper'
 require_relative '../../support/oauth_flow_helper'
+require_relative '../../support/sso_link_flow_helper'
 
 RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integration do
   include Rack::Test::Methods
-
-  def app
-    Onetime::Application::Registry.generate_rack_url_map
-  end
+  include SsoLinkFlowHelper
 
   before(:all) do
     require 'onetime'
@@ -102,13 +100,6 @@ RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integrat
   # ==========================================================================
   # Helpers (mirror omniauth_signin_interstitial_spec.rb / omniauth_connect_link_spec.rb)
   # ==========================================================================
-
-  # Leaves session[:validated_omniauth_domain_id] nil == the PLATFORM path, so a
-  # non-tenant callback proceeds on platform credentials rather than redirecting to
-  # sso_not_configured.
-  def enable_platform_fallback
-    allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
-  end
 
   # Seed a VERIFIED account WITHOUT a password (a PASSWORDLESS / SSO-only account —
   # the Phase 4 subject). Also seeds the paired Customer so the watermark probe
@@ -153,50 +144,6 @@ RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integrat
   # establishing a fresh session there does not disturb it — and (for the
   # cross-device example) it deliberately makes the POST's current_sid DIFFER
   # from the token's snapshotted sid.
-
-  # Drive the UNAUTHENTICATED SSO callback and return the response.
-  def sso_callback(email:, uid:, provider: :oidc)
-    setup_mock_auth(email: email, uid: uid, provider: provider)
-    clear_body_headers
-    post "/auth/sso/#{provider}/callback"
-    last_response
-  end
-
-  # GET /auth/sso-link-confirm/:token — the display-only consent context.
-  def get_confirm(token)
-    clear_body_headers
-    header 'Accept', 'application/json'
-    get "/auth/sso-link-confirm/#{token}"
-    last_response
-  end
-
-  # POST /auth/sso-link-confirm { token } — the atomic consume + bind + login.
-  def post_confirm(token:)
-    csrf = fetch_csrf_token
-    clear_body_headers
-    header 'Content-Type', 'application/json'
-    header 'Accept', 'application/json'
-    header 'X-CSRF-Token', csrf if csrf
-    post '/auth/sso-link-confirm', JSON.generate(token: token)
-    last_response
-  end
-
-  # Mint a verification directly — the POST endpoint can be exercised without a full
-  # SSO round-trip, since the token carries the snapshot the op reloads. account_id,
-  # sid, and password_watermark are caller-supplied so tests can drive the conflict,
-  # cross-device, and watermark branches deterministically.
-  def mint_verification(email:, uid:, account_id:, provider: 'oidc',
-                        issuer: 'https://issuer.example.com', sid: nil, password_watermark: 0)
-    Onetime::SsoLinkVerification.issue(
-      provider: provider,
-      issuer: issuer,
-      uid: uid,
-      email: OT::Utils.normalize_email(email),
-      account_id: account_id,
-      sid: sid,
-      password_watermark: password_watermark,
-    )
-  end
 
   # Stub the templated publisher and CAPTURE every enqueue_email call. Returns the
   # capture buffer. Returning true means the message was QUEUED — the only outcome

--- a/apps/web/auth/spec/integration/full/sso_link_confirm_mailbox_proof_spec.rb
+++ b/apps/web/auth/spec/integration/full/sso_link_confirm_mailbox_proof_spec.rb
@@ -145,31 +145,14 @@ RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integrat
     )
   end
 
-  def setup_mock_auth(email:, uid:, provider: :oidc)
-    OmniAuth.config.test_mode               = true
-    OmniAuth.config.allowed_request_methods = [:get, :post]
-    OmniAuth.config.mock_auth[provider]     = OmniAuth::AuthHash.new(
-      {
-        provider: provider.to_s,
-        uid: uid,
-        info: { email: email, name: 'Mailbox User', email_verified: true },
-        credentials: { token: 'mock_access_token', expires_at: Time.now.to_i + 3600, expires: true },
-        extra: { raw_info: { sub: uid, email: email, name: 'Mailbox User', email_verified: true } },
-      },
-    )
-  end
-
-  def teardown_mock_auth
-    OmniAuth.config.test_mode = false
-    OmniAuth.config.mock_auth.clear
-  end
-
-  # Content-Type/Content-Length leak from a prior JSON POST and make the next
-  # bodyless request try to parse an empty JSON body. Clear them.
-  def clear_body_headers
-    header 'Content-Type', nil
-    header 'Content-Length', nil
-  end
+  # setup_mock_auth/teardown_mock_auth (support/omniauth_test_helper.rb) and
+  # clear_body_headers/fetch_csrf_token (support/auth_request_helper.rb) are
+  # shared.
+  #
+  # On fetch_csrf_token: the verification lives in Redis, not the session, so
+  # establishing a fresh session there does not disturb it — and (for the
+  # cross-device example) it deliberately makes the POST's current_sid DIFFER
+  # from the token's snapshotted sid.
 
   # Drive the UNAUTHENTICATED SSO callback and return the response.
   def sso_callback(email:, uid:, provider: :oidc)
@@ -177,17 +160,6 @@ RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integrat
     clear_body_headers
     post "/auth/sso/#{provider}/callback"
     last_response
-  end
-
-  # Fetch a CSRF token from the app bootstrap. The verification lives in Redis, not
-  # the session, so establishing a fresh session here does not disturb it — and (for
-  # the cross-device example) it deliberately makes the POST's current_sid DIFFER
-  # from the token's snapshotted sid.
-  def fetch_csrf_token
-    clear_body_headers
-    header 'Accept', 'application/json'
-    get '/auth'
-    last_response.headers['X-CSRF-Token']
   end
 
   # GET /auth/sso-link-confirm/:token — the display-only consent context.

--- a/apps/web/auth/spec/integration/full_mfa/omniauth_signin_interstitial_mfa_spec.rb
+++ b/apps/web/auth/spec/integration/full_mfa/omniauth_signin_interstitial_mfa_spec.rb
@@ -74,24 +74,7 @@ RSpec.describe 'OmniAuth sign-in interstitial: deferred bind after MFA (#3877)',
     allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
   end
 
-  def setup_mock_auth(email:, uid:, provider: :oidc)
-    OmniAuth.config.test_mode               = true
-    OmniAuth.config.allowed_request_methods = [:get, :post]
-    OmniAuth.config.mock_auth[provider]     = OmniAuth::AuthHash.new(
-      {
-        provider: provider.to_s,
-        uid: uid,
-        info: { email: email, name: 'MFA Interstitial User', email_verified: true },
-        credentials: { token: 'mock_access_token', expires_at: Time.now.to_i + 3600, expires: true },
-        extra: { raw_info: { sub: uid, email: email, name: 'MFA Interstitial User', email_verified: true } },
-      },
-    )
-  end
-
-  def teardown_mock_auth
-    OmniAuth.config.test_mode = false
-    OmniAuth.config.mock_auth.clear
-  end
+  # setup_mock_auth/teardown_mock_auth come from support/omniauth_test_helper.rb.
 
   def sso_callback(email:, uid:, provider: :oidc)
     setup_mock_auth(email: email, uid: uid, provider: provider)
@@ -105,7 +88,7 @@ RSpec.describe 'OmniAuth sign-in interstitial: deferred bind after MFA (#3877)',
   end
 
   def post_link_sso(token:, password:)
-    json_post('/auth/link-sso', token: token, password: password)
+    csrf_json_post('/auth/link-sso', token: token, password: password)
   end
 
   # Drive the SSO callback for an OTP-enabled password account up to the point
@@ -167,7 +150,7 @@ RSpec.describe 'OmniAuth sign-in interstitial: deferred bind after MFA (#3877)',
 
       # Complete the second factor in the SAME session the hand-off prepared.
       allow_immediate_otp_reuse!(account_id)
-      json_post('/auth/otp-auth', otp_code: ROTP::TOTP.new(secret).now)
+      csrf_json_post('/auth/otp-auth', otp_code: ROTP::TOTP.new(secret).now)
       expect(last_response.status).to eq(200),
         "OTP verification should succeed, got #{last_response.status}: #{last_response.body}"
 
@@ -202,7 +185,7 @@ RSpec.describe 'OmniAuth sign-in interstitial: deferred bind after MFA (#3877)',
 
       # A wrong code must not complete the login — and must not bind.
       allow_immediate_otp_reuse!(account_id)
-      json_post('/auth/otp-auth', otp_code: wrong_otp_code(secret))
+      csrf_json_post('/auth/otp-auth', otp_code: wrong_otp_code(secret))
 
       # Pin the SPECIFIC rejection, not just "non-200": Rodauth's OTP failure
       # path is 401 (invalid_key_error_status) with a field-error on the OTP
@@ -233,7 +216,7 @@ RSpec.describe 'OmniAuth sign-in interstitial: deferred bind after MFA (#3877)',
       # The pending bind survives the failed attempt: the next successful
       # factor still completes it (the stash is consumed on SUCCESS, not on
       # the first attempt).
-      json_post('/auth/otp-auth', otp_code: ROTP::TOTP.new(secret).now)
+      csrf_json_post('/auth/otp-auth', otp_code: ROTP::TOTP.new(secret).now)
       expect(last_response.status).to eq(200),
         "OTP retry should succeed, got #{last_response.status}: #{last_response.body}"
 
@@ -269,7 +252,7 @@ RSpec.describe 'OmniAuth sign-in interstitial: deferred bind after MFA (#3877)',
       # after_two_factor_authentication fires for ANY accepted factor, so the
       # deferred bind must land via /auth/recovery-auth exactly as via OTP —
       # this locks in the hook's factor-agnostic placement (hooks/mfa.rb).
-      json_post('/auth/recovery-auth', 'recovery-code' => recovery_codes.first)
+      csrf_json_post('/auth/recovery-auth', 'recovery-code' => recovery_codes.first)
       expect(last_response.status).to eq(200),
         "Recovery-code auth should succeed, got #{last_response.status}: #{last_response.body}"
 

--- a/apps/web/auth/spec/integration/full_mfa/omniauth_signin_interstitial_mfa_spec.rb
+++ b/apps/web/auth/spec/integration/full_mfa/omniauth_signin_interstitial_mfa_spec.rb
@@ -55,57 +55,23 @@
 
 require_relative '../../spec_helper'
 
-# Must be set before the suite's FIRST boot (FullModeSuiteDatabase.setup! runs
-# from a config-level before(:context) hook, ahead of any group-level hook) so
-# config.rb loads the Rodauth OTP feature set. The rake lane already exports it;
-# this load-time set makes a direct `rspec <this file>` invocation work too.
-ENV['AUTH_MFA_ENABLED'] = 'true'
-
-require 'rotp'
+# Sets AUTH_MFA_ENABLED at load time (before the suite's first boot) and brings
+# Rack::Test, `app`, `identities`, the OTP-feature guard, and the OTP
+# provisioning machinery. See the helper's header.
+require_relative '../../support/mfa_flow_helper'
 
 RSpec.describe 'OmniAuth sign-in interstitial: deferred bind after MFA (#3877)',
   :full_auth_mode, type: :integration do
-  include Rack::Test::Methods
-
-  def app
-    Onetime::Application::Registry.generate_rack_url_map
-  end
-
-  before(:all) do
-    # Hard-fail (not skip): this lane EXISTS to cover the MFA path, so a boot
-    # without the OTP feature is harness breakage, not an environment quirk.
-    otp_loaded = Auth::Config.method_defined?(:otp_auth_route) ||
-                 Auth::Config.private_method_defined?(:otp_auth_route)
-    unless otp_loaded
-      raise 'Rodauth OTP feature not loaded — this suite must boot with ' \
-            'AUTH_MFA_ENABLED=true in a fresh process (run via ' \
-            '`bundle exec rake spec:integration:full:mfa`; Auth::Config is one-shot)'
-    end
-  end
-
-  let(:identities) { auth_db[:account_identities] }
+  include MfaFlowHelper
 
   # ==========================================================================
-  # Helpers (mirror integration/full/omniauth_signin_interstitial_spec.rb)
+  # Route driving for THIS flow (mirrors
+  # integration/full/omniauth_signin_interstitial_spec.rb). The shared OTP
+  # machinery lives in support/mfa_flow_helper.rb.
   # ==========================================================================
 
   def enable_platform_fallback
     allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
-  end
-
-  def seed_account_with_password(email, password: AuthTestConstants::TEST_PASSWORD)
-    normalized = OT::Utils.normalize_email(email)
-    customer   = Onetime::Customer.new(email: normalized)
-    customer.save
-    account_id = auth_db[:accounts].insert(
-      email: normalized,
-      status_id: AuthTestConstants::STATUS_VERIFIED,
-      external_id: customer.extid,
-    )
-    require 'argon2'
-    hasher = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
-    auth_db[:account_password_hashes].insert(id: account_id, password_hash: hasher.create(password))
-    account_id
   end
 
   def setup_mock_auth(email:, uid:, provider: :oidc)
@@ -127,11 +93,6 @@ RSpec.describe 'OmniAuth sign-in interstitial: deferred bind after MFA (#3877)',
     OmniAuth.config.mock_auth.clear
   end
 
-  def clear_body_headers
-    header 'Content-Type', nil
-    header 'Content-Length', nil
-  end
-
   def sso_callback(email:, uid:, provider: :oidc)
     setup_mock_auth(email: email, uid: uid, provider: provider)
     clear_body_headers
@@ -143,104 +104,8 @@ RSpec.describe 'OmniAuth sign-in interstitial: deferred bind after MFA (#3877)',
     location.to_s.split('/link-sso/').last.to_s.split(/[?#]/).first
   end
 
-  def fetch_csrf_token
-    clear_body_headers
-    header 'Accept', 'application/json'
-    get '/auth'
-    last_response.headers['X-CSRF-Token']
-  end
-
-  # JSON POST with the CSRF token in both header and body (shrimp), matching
-  # what the SPA sends and what the other integration specs do.
-  def json_post(path, params = {})
-    csrf = fetch_csrf_token
-    clear_body_headers
-    header 'Content-Type', 'application/json'
-    header 'Accept', 'application/json'
-    header 'X-CSRF-Token', csrf if csrf
-    post path, JSON.generate(params.merge(shrimp: csrf))
-    last_response
-  end
-
   def post_link_sso(token:, password:)
     json_post('/auth/link-sso', token: token, password: password)
-  end
-
-  def json_body
-    JSON.parse(last_response.body)
-  rescue JSON::ParserError
-    {}
-  end
-
-  # ==========================================================================
-  # OTP provisioning — through Rodauth's OWN JSON setup flow, exactly as the
-  # SPA does it, so the stored key shape (HMAC) matches production:
-  #   phase 1: POST /auth/otp-setup {}            -> 422 + { otp_setup (the
-  #            HMAC'd key the authenticator uses), otp_raw_secret }
-  #   phase 2: POST /auth/otp-setup {otp_setup, otp_raw_secret, otp_code,
-  #            password}                          -> 200, recovery codes added
-  # Returns [authenticator secret (the otp_setup value), recovery codes] —
-  # auto_add_recovery_codes? is on, and the app's after hook surfaces the
-  # generated codes in the phase-2 JSON response (hooks/mfa.rb).
-  # ==========================================================================
-
-  def provision_totp(email, password: AuthTestConstants::TEST_PASSWORD)
-    json_post('/auth/login', login: email, password: password)
-    expect(last_response.status).to eq(200),
-      "Precondition failed: password login for OTP setup (#{last_response.status}: #{last_response.body})"
-
-    json_post('/auth/otp-setup', {})
-    expect(last_response.status).to eq(422),
-      "Phase-1 otp-setup should return the generated secret with a field error (#{last_response.status}: #{last_response.body})"
-    setup_body = json_body
-    secret     = setup_body['otp_setup']
-    raw_secret = setup_body['otp_raw_secret']
-    expect(secret).not_to be_nil
-    expect(raw_secret).not_to be_nil
-
-    json_post(
-      '/auth/otp-setup',
-      otp_setup: secret,
-      otp_raw_secret: raw_secret,
-      otp_code: ROTP::TOTP.new(secret).now,
-      password: password,
-    )
-    expect(last_response.status).to eq(200),
-      "Phase-2 otp-setup should confirm the secret (#{last_response.status}: #{last_response.body})"
-    recovery_codes = Array(json_body['recovery_codes'])
-
-    # Drop the setup session entirely: the interstitial flow below must start
-    # from an UNAUTHENTICATED browser, like a user on a fresh device.
-    clear_cookies
-    [secret, recovery_codes]
-  end
-
-  # Rodauth's OTP reuse guard (otp_update_last_use) rejects any code within one
-  # interval (30s) of last_use — and setup just stamped last_use=now. Rewind it
-  # so the auth step can accept a fresh code immediately instead of sleeping
-  # out the window in the test.
-  #
-  # One rewind covers a failed-then-retry sequence: Rodauth stamps last_use
-  # only on SUCCESSFUL validation (`otp_valid_code? && otp_update_last_use`
-  # short-circuits), so a rejected code leaves the rewound value in place and
-  # the subsequent good code is still accepted without a second rewind.
-  def allow_immediate_otp_reuse!(account_id)
-    auth_db[:account_otp_keys].where(id: account_id).update(last_use: Time.now - 300)
-  end
-
-  # A code guaranteed to be rejected RIGHT NOW: Rodauth validates with
-  # otp_drift (30s), so the previous and next interval's codes are accepted
-  # too — a candidate must differ from all three, not just the current code.
-  # Counter-based so every candidate stays six digits by construction (at most
-  # four iterations: the valid set has exactly three elements).
-  def wrong_otp_code(secret)
-    totp  = ROTP::TOTP.new(secret)
-    now   = Time.now.to_i
-    valid = [totp.at(now - 30), totp.at(now), totp.at(now + 30)]
-    (0..valid.size).each do |i|
-      candidate = i.to_s.rjust(6, '0')
-      return candidate unless valid.include?(candidate)
-    end
   end
 
   # Drive the SSO callback for an OTP-enabled password account up to the point

--- a/apps/web/auth/spec/integration/full_mfa/omniauth_signin_interstitial_mfa_spec.rb
+++ b/apps/web/auth/spec/integration/full_mfa/omniauth_signin_interstitial_mfa_spec.rb
@@ -59,10 +59,12 @@ require_relative '../../spec_helper'
 # Rack::Test, `app`, `identities`, the OTP-feature guard, and the OTP
 # provisioning machinery. See the helper's header.
 require_relative '../../support/mfa_flow_helper'
+require_relative '../../support/sso_link_flow_helper'
 
 RSpec.describe 'OmniAuth sign-in interstitial: deferred bind after MFA (#3877)',
   :full_auth_mode, type: :integration do
   include MfaFlowHelper
+  include SsoLinkFlowHelper
 
   # ==========================================================================
   # Route driving for THIS flow (mirrors
@@ -70,26 +72,7 @@ RSpec.describe 'OmniAuth sign-in interstitial: deferred bind after MFA (#3877)',
   # machinery lives in support/mfa_flow_helper.rb.
   # ==========================================================================
 
-  def enable_platform_fallback
-    allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
-  end
-
   # setup_mock_auth/teardown_mock_auth come from support/omniauth_test_helper.rb.
-
-  def sso_callback(email:, uid:, provider: :oidc)
-    setup_mock_auth(email: email, uid: uid, provider: provider)
-    clear_body_headers
-    post "/auth/sso/#{provider}/callback"
-    last_response
-  end
-
-  def token_from_location(location)
-    location.to_s.split('/link-sso/').last.to_s.split(/[?#]/).first
-  end
-
-  def post_link_sso(token:, password:)
-    csrf_json_post('/auth/link-sso', token: token, password: password)
-  end
 
   # Drive the SSO callback for an OTP-enabled password account up to the point
   # where the interstitial has verified the password and handed off to MFA.

--- a/apps/web/auth/spec/integration/full_mfa/sso_link_confirm_mailbox_proof_mfa_spec.rb
+++ b/apps/web/auth/spec/integration/full_mfa/sso_link_confirm_mailbox_proof_mfa_spec.rb
@@ -1,0 +1,341 @@
+# apps/web/auth/spec/integration/full_mfa/sso_link_confirm_mailbox_proof_mfa_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration (full mode + AUTH_MFA_ENABLED=true — DEDICATED LANE)
+# =============================================================================
+#
+# Issue: #3840 Phase 4 (#3877 Phase 4.A) — the MAILBOX-PROOF deferred SSO bind,
+#        end to end, when the located account has a pending second factor.
+#
+# The confirm endpoint must NOT bind the (provider, issuer, uid) identity when
+# the login it establishes leaves a second factor pending: SSO logins are
+# MFA-EXEMPT, so a pre-2FA bind would attach an MFA-bypassing login path to the
+# account. Auth::Operations::ConfirmSsoLink instead returns second_factor_pending
+# (still consuming the single-use token), routes/sso_link_confirm.rb logs the
+# user in via rodauth.login('sso_link_confirm') — which THROWS the SAME
+# mfa_required body POST /auth/login emits — and STASHES the authorized bind
+# tuple inside the login block (Auth::Operations::DeferredSsoBind.defer). The
+# bind is completed by after_two_factor_authentication (config/hooks/mfa.rb) once
+# the second factor succeeds. Without that stash an MFA-enabled account would
+# re-hit the mailbox flow on every SSO sign-in and NEVER link (the exact failure
+# greptile flagged as P1 against the pre-#3877 snapshot, which returned the
+# deferred result WITHOUT issuer/uid).
+#
+# WHAT IT LOCKS IN (the sequence the shared full/ harness cannot reach —
+#   full/sso_link_confirm_mailbox_proof_spec.rb left it PENDING):
+#   a. POST /auth/sso-link-confirm for an OTP-enabled account -> the SAME
+#      mfa_required body POST /auth/login emits, the single-use token is
+#      CONSUMED, and NO identity row exists yet (the MFA-bypass guard).
+#   b. POST /auth/otp-auth with a valid TOTP code -> the deferred bind lands:
+#      exactly one identity row, on the proven account, with the token's
+#      (provider, issuer, uid), and :sso_deferred_bind_completed fires with
+#      outcome :ok.
+#   c. The RECOVERY-CODE second factor completes the bind too:
+#      after_two_factor_authentication is factor-agnostic, so the mailbox-proof
+#      deferral must complete for any factor Rodauth accepts, not just TOTP.
+#
+# WHY SEED A PASSWORD FOR A "PASSWORDLESS" SUBJECT: the mailbox-proof flow is
+# ISSUED only for passwordless accounts (config/hooks/omniauth.rb), but the
+# CONFIRM route/op never inspect password presence — the deferral is identical
+# for password and passwordless accounts. Provisioning a PRODUCTION-SHAPED OTP
+# key is only possible through Rodauth's real setup flow: this deploy sets
+# otp_keys_use_hmac? true (the stored key is HMAC'd, so a hand-inserted raw
+# secret would not validate) and two_factor_modifications_require_password? true
+# (setup requires the account password). So the subject is seeded WITH a password
+# purely as the OTP-provisioning vehicle, then the verification is MINTED
+# DIRECTLY and confirmed via mailbox proof — which is exactly the realistic
+# "legacy password+MFA account now using SSO" state config/hooks/login.rb calls
+# out. The bind path under test (confirm -> defer -> otp-auth -> complete) is the
+# code greptile flagged, and it is unaffected by whether a password hash exists.
+#
+# WHY A DEDICATED LANE: Auth::Config is one-shot per process
+# (apps/web/auth/docs/auth-config-one-shot.md) — the shared full-mode
+# integration process boots with MFA off and can never load the Rodauth OTP
+# feature set afterwards. This directory (integration/full_mfa/) is excluded from
+# the shared spec:integration:full glob and runs in its OWN process with
+# AUTH_MFA_ENABLED=true via `rake spec:integration:full:mfa` (chained from
+# spec:integration:full). The :full_auth_mode tag is set EXPLICITLY below because
+# the path-derived tag only matches /integration/full/.
+#
+# REQUIREMENTS:
+# - Valkey running on port 2121: pnpm run test:database:start
+#
+# RUN:
+#   bundle exec rake spec:integration:full:mfa
+# or directly (fresh process required):
+#   RACK_ENV=test AUTHENTICATION_MODE=full AUTH_DATABASE_URL=sqlite::memory: \
+#     ORGS_SSO_ENABLED=true AUTH_MFA_ENABLED=true LANG=en_US.UTF-8 \
+#     bundle exec rspec \
+#     apps/web/auth/spec/integration/full_mfa/sso_link_confirm_mailbox_proof_mfa_spec.rb
+# =============================================================================
+
+require_relative '../../spec_helper'
+
+# Must be set before the suite's FIRST boot (FullModeSuiteDatabase.setup! runs
+# from a config-level before(:context) hook, ahead of any group-level hook) so
+# config.rb loads the Rodauth OTP feature set. The rake lane already exports it;
+# this load-time set makes a direct `rspec <this file>` invocation work too.
+ENV['AUTH_MFA_ENABLED'] = 'true'
+
+require 'rotp'
+
+RSpec.describe 'SSO mailbox-proof link confirm: deferred bind after MFA (#3840 Phase 4 / #3877)',
+  :full_auth_mode, type: :integration do
+  include Rack::Test::Methods
+
+  def app
+    Onetime::Application::Registry.generate_rack_url_map
+  end
+
+  before(:all) do
+    # Hard-fail (not skip): this lane EXISTS to cover the MFA path, so a boot
+    # without the OTP feature is harness breakage, not an environment quirk.
+    otp_loaded = Auth::Config.method_defined?(:otp_auth_route) ||
+                 Auth::Config.private_method_defined?(:otp_auth_route)
+    unless otp_loaded
+      raise 'Rodauth OTP feature not loaded — this suite must boot with ' \
+            'AUTH_MFA_ENABLED=true in a fresh process (run via ' \
+            '`bundle exec rake spec:integration:full:mfa`; Auth::Config is one-shot)'
+    end
+  end
+
+  let(:identities) { auth_db[:account_identities] }
+
+  # ==========================================================================
+  # Helpers (mirror integration/full/sso_link_confirm_mailbox_proof_spec.rb and
+  # integration/full_mfa/omniauth_signin_interstitial_mfa_spec.rb)
+  # ==========================================================================
+
+  # Seed a VERIFIED account WITH a password AND its paired Customer. The password
+  # is the OTP-provisioning vehicle only (see the header); the Customer makes the
+  # confirm-time watermark probe (Customer#last_password_update via
+  # load_by_extid_or_email) resolve to :unchanged rather than :unreadable.
+  def seed_account_with_password(email, password: AuthTestConstants::TEST_PASSWORD)
+    normalized = OT::Utils.normalize_email(email)
+    customer   = Onetime::Customer.new(email: normalized)
+    customer.save
+    account_id = auth_db[:accounts].insert(
+      email: normalized,
+      status_id: AuthTestConstants::STATUS_VERIFIED,
+      external_id: customer.extid,
+    )
+    require 'argon2'
+    hasher = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
+    auth_db[:account_password_hashes].insert(id: account_id, password_hash: hasher.create(password))
+    account_id
+  end
+
+  def clear_body_headers
+    header 'Content-Type', nil
+    header 'Content-Length', nil
+  end
+
+  def fetch_csrf_token
+    clear_body_headers
+    header 'Accept', 'application/json'
+    get '/auth'
+    last_response.headers['X-CSRF-Token']
+  end
+
+  # JSON POST with the CSRF token in both header and body (shrimp), matching what
+  # the SPA sends and what the Rodauth routes (otp-setup, otp-auth, recovery-auth)
+  # require.
+  def json_post(path, params = {})
+    csrf = fetch_csrf_token
+    clear_body_headers
+    header 'Content-Type', 'application/json'
+    header 'Accept', 'application/json'
+    header 'X-CSRF-Token', csrf if csrf
+    post path, JSON.generate(params.merge(shrimp: csrf))
+    last_response
+  end
+
+  def json_body
+    JSON.parse(last_response.body)
+  rescue JSON::ParserError
+    {}
+  end
+
+  # GET /auth/sso-link-confirm/:token — the display-only consent context.
+  def get_confirm(token)
+    clear_body_headers
+    header 'Accept', 'application/json'
+    get "/auth/sso-link-confirm/#{token}"
+    last_response
+  end
+
+  # POST /auth/sso-link-confirm { token } — the atomic consume + (deferred) bind
+  # + login handoff. Carries shrimp in the body like json_post; the custom route
+  # accepts the header token too, but sending both matches the SPA.
+  def post_confirm(token:)
+    csrf = fetch_csrf_token
+    clear_body_headers
+    header 'Content-Type', 'application/json'
+    header 'Accept', 'application/json'
+    header 'X-CSRF-Token', csrf if csrf
+    post '/auth/sso-link-confirm', JSON.generate(token: token, shrimp: csrf)
+    last_response
+  end
+
+  # Mint a verification directly — the POST endpoint carries the snapshot the op
+  # reloads, so it needs no SSO round-trip. Default watermark 0 matches a freshly
+  # seeded Customer (never had last_password_update stamped), so watermark_state
+  # resolves :unchanged.
+  def mint_verification(email:, uid:, account_id:, provider: 'oidc',
+                        issuer: 'https://issuer.example.com', sid: nil, password_watermark: 0)
+    Onetime::SsoLinkVerification.issue(
+      provider: provider,
+      issuer: issuer,
+      uid: uid,
+      email: OT::Utils.normalize_email(email),
+      account_id: account_id,
+      sid: sid,
+      password_watermark: password_watermark,
+    )
+  end
+
+  # OTP provisioning through Rodauth's OWN JSON setup flow (matches production key
+  # shape, HMAC'd). Requires a password login (two_factor_modifications_require_
+  # password?), which is why the subject is seeded with a password. Returns
+  # [authenticator secret, recovery codes]. Clears cookies so the confirm flow
+  # below starts from an UNAUTHENTICATED browser, like a user clicking the emailed
+  # link on a fresh device.
+  def provision_totp(email, password: AuthTestConstants::TEST_PASSWORD)
+    json_post('/auth/login', login: email, password: password)
+    expect(last_response.status).to eq(200),
+      "Precondition failed: password login for OTP setup (#{last_response.status}: #{last_response.body})"
+
+    json_post('/auth/otp-setup', {})
+    expect(last_response.status).to eq(422),
+      "Phase-1 otp-setup should return the generated secret with a field error (#{last_response.status}: #{last_response.body})"
+    setup_body = json_body
+    secret     = setup_body['otp_setup']
+    raw_secret = setup_body['otp_raw_secret']
+    expect(secret).not_to be_nil
+    expect(raw_secret).not_to be_nil
+
+    json_post(
+      '/auth/otp-setup',
+      otp_setup: secret,
+      otp_raw_secret: raw_secret,
+      otp_code: ROTP::TOTP.new(secret).now,
+      password: password,
+    )
+    expect(last_response.status).to eq(200),
+      "Phase-2 otp-setup should confirm the secret (#{last_response.status}: #{last_response.body})"
+    recovery_codes = Array(json_body['recovery_codes'])
+
+    clear_cookies
+    [secret, recovery_codes]
+  end
+
+  # Rodauth's OTP reuse guard (otp_update_last_use) rejects any code within one
+  # interval (30s) of last_use — and setup just stamped last_use=now. Rewind it so
+  # the auth step can accept a fresh code immediately instead of sleeping out the
+  # window in the test.
+  def allow_immediate_otp_reuse!(account_id)
+    auth_db[:account_otp_keys].where(id: account_id).update(last_use: Time.now - 300)
+  end
+
+  # Drive the mailbox-proof confirm up to the MFA hand-off: mint a verification,
+  # POST it, and assert the deferral contract — mfa_required, the token CONSUMED
+  # (single-use), and NOTHING bound while the second factor is pending. Returns
+  # the token's issuer for the post-2FA assertion.
+  def confirm_step_expecting_mfa(email:, uid:, account_id:)
+    verification = mint_verification(email: email, uid: uid, account_id: account_id)
+    issuer       = verification.issuer
+
+    result = post_confirm(token: verification.token)
+    expect(result.status).to eq(200),
+      "Expected the login response with the MFA hand-off, got #{result.status}: #{result.body}"
+    body = json_body
+    expect(body['mfa_required']).to eq(true),
+      "An OTP-enabled account must be handed off to MFA, got: #{body.inspect}"
+
+    # THE GUARD: nothing is bound while the second factor is pending — a bound row
+    # here would be an MFA-bypassing SSO path.
+    expect(identities.where(account_id: account_id).count).to eq(0),
+      'No identity may be bound before the second factor completes'
+    expect(identities.where(provider: 'oidc', uid: uid).count).to eq(0)
+
+    # Single-use: the token is CONSUMED at the confirm step, not re-armed by the
+    # deferral — the stash in the partial MFA session carries the bind.
+    expect(Onetime::SsoLinkVerification.load(verification.token)).to be_nil
+
+    issuer
+  end
+
+  # Trust off keeps an existing account on the mint branch; platform fallback on
+  # keeps a non-tenant callback on the platform surface. Neither is strictly
+  # needed here (we mint directly) but mirrors the sibling specs' baseline.
+  before do
+    allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
+    allow(Onetime.auth_config).to receive(:trust_email_for_linking?).and_return(false)
+  end
+
+  # ==========================================================================
+  # (a)+(b) the deferred bind completes after the second factor succeeds
+  # ==========================================================================
+
+  it 'defers the bind at confirm and completes it after OTP verifies' do
+    email      = "mp-mfa-ok-#{SecureRandom.hex(6)}@company.example.com"
+    uid        = "sub-#{SecureRandom.hex(8)}"
+    account_id = seed_account_with_password(email)
+    secret, _codes = provision_totp(email)
+
+    allow(Auth::Logging).to receive(:log_auth_event).and_call_original
+
+    issuer = confirm_step_expecting_mfa(email: email, uid: uid, account_id: account_id)
+
+    # Complete the second factor in the SAME session the hand-off prepared.
+    allow_immediate_otp_reuse!(account_id)
+    json_post('/auth/otp-auth', otp_code: ROTP::TOTP.new(secret).now)
+    expect(last_response.status).to eq(200),
+      "OTP verification should succeed, got #{last_response.status}: #{last_response.body}"
+
+    # The deferred bind landed: exactly one row, on the proven account, with the
+    # token's (provider, issuer, uid).
+    rows = identities.where(provider: 'oidc', uid: uid).all
+    expect(rows.size).to eq(1), "Expected exactly one bound row, got #{rows.inspect}"
+    expect(rows.first[:account_id]).to eq(account_id)
+    expect(rows.first[:issuer]).to eq(issuer)
+
+    expect(Auth::Logging).to have_received(:log_auth_event)
+      .with(:sso_deferred_bind_completed, hash_including(outcome: :ok, account_id: account_id))
+  end
+
+  # ==========================================================================
+  # (c) the recovery-code factor completes the mailbox-proof deferral too
+  # ==========================================================================
+
+  it 'completes the deferred bind when the second factor is a recovery code' do
+    email      = "mp-mfa-recovery-#{SecureRandom.hex(6)}@company.example.com"
+    uid        = "sub-#{SecureRandom.hex(8)}"
+    account_id = seed_account_with_password(email)
+    _secret, recovery_codes = provision_totp(email)
+    expect(recovery_codes).not_to be_empty,
+      'Precondition failed: phase-2 otp-setup should surface auto-generated recovery codes'
+
+    allow(Auth::Logging).to receive(:log_auth_event).and_call_original
+
+    issuer = confirm_step_expecting_mfa(email: email, uid: uid, account_id: account_id)
+
+    # after_two_factor_authentication fires for ANY accepted factor, so the
+    # mailbox-proof deferral must land via /auth/recovery-auth exactly as via OTP
+    # — locking in the hook's factor-agnostic placement from the mailbox entry.
+    json_post('/auth/recovery-auth', 'recovery-code' => recovery_codes.first)
+    expect(last_response.status).to eq(200),
+      "Recovery-code auth should succeed, got #{last_response.status}: #{last_response.body}"
+
+    rows = identities.where(provider: 'oidc', uid: uid).all
+    expect(rows.size).to eq(1), "Expected exactly one bound row, got #{rows.inspect}"
+    expect(rows.first[:account_id]).to eq(account_id)
+    expect(rows.first[:issuer]).to eq(issuer)
+
+    expect(Auth::Logging).to have_received(:log_auth_event)
+      .with(:sso_deferred_bind_completed, hash_including(outcome: :ok, account_id: account_id))
+      .once
+  end
+end

--- a/apps/web/auth/spec/integration/full_mfa/sso_link_confirm_mailbox_proof_mfa_spec.rb
+++ b/apps/web/auth/spec/integration/full_mfa/sso_link_confirm_mailbox_proof_mfa_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'SSO mailbox-proof link confirm: deferred bind after MFA (#3840 P
   end
 
   # POST /auth/sso-link-confirm { token } — the atomic consume + (deferred) bind
-  # + login handoff. Carries shrimp in the body like json_post; the custom route
+  # + login handoff. Carries shrimp in the body like csrf_json_post; the custom route
   # accepts the header token too, but sending both matches the SPA.
   def post_confirm(token:)
     csrf = fetch_csrf_token
@@ -186,7 +186,7 @@ RSpec.describe 'SSO mailbox-proof link confirm: deferred bind after MFA (#3840 P
 
     # Complete the second factor in the SAME session the hand-off prepared.
     allow_immediate_otp_reuse!(account_id)
-    json_post('/auth/otp-auth', otp_code: ROTP::TOTP.new(secret).now)
+    csrf_json_post('/auth/otp-auth', otp_code: ROTP::TOTP.new(secret).now)
     expect(last_response.status).to eq(200),
       "OTP verification should succeed, got #{last_response.status}: #{last_response.body}"
 
@@ -220,7 +220,7 @@ RSpec.describe 'SSO mailbox-proof link confirm: deferred bind after MFA (#3840 P
     # The mailbox-written stash is consumed by whichever 2FA route runs: swap
     # otp-auth for recovery-auth and the bind still lands. See header note (c)
     # for why this is a readability guard rather than independent coverage.
-    json_post('/auth/recovery-auth', 'recovery-code' => recovery_codes.first)
+    csrf_json_post('/auth/recovery-auth', 'recovery-code' => recovery_codes.first)
     expect(last_response.status).to eq(200),
       "Recovery-code auth should succeed, got #{last_response.status}: #{last_response.body}"
 

--- a/apps/web/auth/spec/integration/full_mfa/sso_link_confirm_mailbox_proof_mfa_spec.rb
+++ b/apps/web/auth/spec/integration/full_mfa/sso_link_confirm_mailbox_proof_mfa_spec.rb
@@ -32,9 +32,17 @@
 #      exactly one identity row, on the proven account, with the token's
 #      (provider, issuer, uid), and :sso_deferred_bind_completed fires with
 #      outcome :ok.
-#   c. The RECOVERY-CODE second factor completes the bind too:
-#      after_two_factor_authentication is factor-agnostic, so the mailbox-proof
-#      deferral must complete for any factor Rodauth accepts, not just TOTP.
+#   c. The RECOVERY-CODE second factor completes the bind too. NOTE the modest
+#      scope: the hook's factor-agnosticism itself is already pinned by
+#      full_mfa/omniauth_signin_interstitial_mfa_spec.rb (d), and the completion
+#      path is shared and route-agnostic once the stash is written — so this
+#      example cannot fail unless (b) also fails. What it does pin is that
+#      nothing in the MAILBOX-written stash (routes/sso_link_confirm.rb, keyed
+#      off the verification token rather than an interstitial challenge) is
+#      specific to the otp-auth route that happens to consume it. Kept because
+#      it is nearly free next to this lane's fixed cost (own process, full-mode
+#      migration) and makes the mailbox contract readable without reading the
+#      interstitial spec — not because it adds independent failure detection.
 #
 # WHY SEED A PASSWORD FOR A "PASSWORDLESS" SUBJECT: the mailbox-proof flow is
 # ISSUED only for passwordless accounts (config/hooks/omniauth.rb), but the
@@ -73,90 +81,20 @@
 
 require_relative '../../spec_helper'
 
-# Must be set before the suite's FIRST boot (FullModeSuiteDatabase.setup! runs
-# from a config-level before(:context) hook, ahead of any group-level hook) so
-# config.rb loads the Rodauth OTP feature set. The rake lane already exports it;
-# this load-time set makes a direct `rspec <this file>` invocation work too.
-ENV['AUTH_MFA_ENABLED'] = 'true'
-
-require 'rotp'
+# Sets AUTH_MFA_ENABLED at load time (before the suite's first boot) and brings
+# Rack::Test, `app`, `identities`, the OTP-feature guard, and the OTP
+# provisioning machinery. See the helper's header.
+require_relative '../../support/mfa_flow_helper'
 
 RSpec.describe 'SSO mailbox-proof link confirm: deferred bind after MFA (#3840 Phase 4 / #3877)',
   :full_auth_mode, type: :integration do
-  include Rack::Test::Methods
-
-  def app
-    Onetime::Application::Registry.generate_rack_url_map
-  end
-
-  before(:all) do
-    # Hard-fail (not skip): this lane EXISTS to cover the MFA path, so a boot
-    # without the OTP feature is harness breakage, not an environment quirk.
-    otp_loaded = Auth::Config.method_defined?(:otp_auth_route) ||
-                 Auth::Config.private_method_defined?(:otp_auth_route)
-    unless otp_loaded
-      raise 'Rodauth OTP feature not loaded — this suite must boot with ' \
-            'AUTH_MFA_ENABLED=true in a fresh process (run via ' \
-            '`bundle exec rake spec:integration:full:mfa`; Auth::Config is one-shot)'
-    end
-  end
-
-  let(:identities) { auth_db[:account_identities] }
+  include MfaFlowHelper
 
   # ==========================================================================
-  # Helpers (mirror integration/full/sso_link_confirm_mailbox_proof_spec.rb and
-  # integration/full_mfa/omniauth_signin_interstitial_mfa_spec.rb)
+  # Route driving for THIS flow (mirrors
+  # integration/full/sso_link_confirm_mailbox_proof_spec.rb). The shared OTP
+  # machinery lives in support/mfa_flow_helper.rb.
   # ==========================================================================
-
-  # Seed a VERIFIED account WITH a password AND its paired Customer. The password
-  # is the OTP-provisioning vehicle only (see the header); the Customer makes the
-  # confirm-time watermark probe (Customer#last_password_update via
-  # load_by_extid_or_email) resolve to :unchanged rather than :unreadable.
-  def seed_account_with_password(email, password: AuthTestConstants::TEST_PASSWORD)
-    normalized = OT::Utils.normalize_email(email)
-    customer   = Onetime::Customer.new(email: normalized)
-    customer.save
-    account_id = auth_db[:accounts].insert(
-      email: normalized,
-      status_id: AuthTestConstants::STATUS_VERIFIED,
-      external_id: customer.extid,
-    )
-    require 'argon2'
-    hasher = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
-    auth_db[:account_password_hashes].insert(id: account_id, password_hash: hasher.create(password))
-    account_id
-  end
-
-  def clear_body_headers
-    header 'Content-Type', nil
-    header 'Content-Length', nil
-  end
-
-  def fetch_csrf_token
-    clear_body_headers
-    header 'Accept', 'application/json'
-    get '/auth'
-    last_response.headers['X-CSRF-Token']
-  end
-
-  # JSON POST with the CSRF token in both header and body (shrimp), matching what
-  # the SPA sends and what the Rodauth routes (otp-setup, otp-auth, recovery-auth)
-  # require.
-  def json_post(path, params = {})
-    csrf = fetch_csrf_token
-    clear_body_headers
-    header 'Content-Type', 'application/json'
-    header 'Accept', 'application/json'
-    header 'X-CSRF-Token', csrf if csrf
-    post path, JSON.generate(params.merge(shrimp: csrf))
-    last_response
-  end
-
-  def json_body
-    JSON.parse(last_response.body)
-  rescue JSON::ParserError
-    {}
-  end
 
   # GET /auth/sso-link-confirm/:token — the display-only consent context.
   def get_confirm(token)
@@ -194,49 +132,6 @@ RSpec.describe 'SSO mailbox-proof link confirm: deferred bind after MFA (#3840 P
       sid: sid,
       password_watermark: password_watermark,
     )
-  end
-
-  # OTP provisioning through Rodauth's OWN JSON setup flow (matches production key
-  # shape, HMAC'd). Requires a password login (two_factor_modifications_require_
-  # password?), which is why the subject is seeded with a password. Returns
-  # [authenticator secret, recovery codes]. Clears cookies so the confirm flow
-  # below starts from an UNAUTHENTICATED browser, like a user clicking the emailed
-  # link on a fresh device.
-  def provision_totp(email, password: AuthTestConstants::TEST_PASSWORD)
-    json_post('/auth/login', login: email, password: password)
-    expect(last_response.status).to eq(200),
-      "Precondition failed: password login for OTP setup (#{last_response.status}: #{last_response.body})"
-
-    json_post('/auth/otp-setup', {})
-    expect(last_response.status).to eq(422),
-      "Phase-1 otp-setup should return the generated secret with a field error (#{last_response.status}: #{last_response.body})"
-    setup_body = json_body
-    secret     = setup_body['otp_setup']
-    raw_secret = setup_body['otp_raw_secret']
-    expect(secret).not_to be_nil
-    expect(raw_secret).not_to be_nil
-
-    json_post(
-      '/auth/otp-setup',
-      otp_setup: secret,
-      otp_raw_secret: raw_secret,
-      otp_code: ROTP::TOTP.new(secret).now,
-      password: password,
-    )
-    expect(last_response.status).to eq(200),
-      "Phase-2 otp-setup should confirm the secret (#{last_response.status}: #{last_response.body})"
-    recovery_codes = Array(json_body['recovery_codes'])
-
-    clear_cookies
-    [secret, recovery_codes]
-  end
-
-  # Rodauth's OTP reuse guard (otp_update_last_use) rejects any code within one
-  # interval (30s) of last_use — and setup just stamped last_use=now. Rewind it so
-  # the auth step can accept a fresh code immediately instead of sleeping out the
-  # window in the test.
-  def allow_immediate_otp_reuse!(account_id)
-    auth_db[:account_otp_keys].where(id: account_id).update(last_use: Time.now - 300)
   end
 
   # Drive the mailbox-proof confirm up to the MFA hand-off: mint a verification,
@@ -322,9 +217,9 @@ RSpec.describe 'SSO mailbox-proof link confirm: deferred bind after MFA (#3840 P
 
     issuer = confirm_step_expecting_mfa(email: email, uid: uid, account_id: account_id)
 
-    # after_two_factor_authentication fires for ANY accepted factor, so the
-    # mailbox-proof deferral must land via /auth/recovery-auth exactly as via OTP
-    # — locking in the hook's factor-agnostic placement from the mailbox entry.
+    # The mailbox-written stash is consumed by whichever 2FA route runs: swap
+    # otp-auth for recovery-auth and the bind still lands. See header note (c)
+    # for why this is a readability guard rather than independent coverage.
     json_post('/auth/recovery-auth', 'recovery-code' => recovery_codes.first)
     expect(last_response.status).to eq(200),
       "Recovery-code auth should succeed, got #{last_response.status}: #{last_response.body}"

--- a/apps/web/auth/spec/integration/full_mfa/sso_link_confirm_mailbox_proof_mfa_spec.rb
+++ b/apps/web/auth/spec/integration/full_mfa/sso_link_confirm_mailbox_proof_mfa_spec.rb
@@ -85,54 +85,18 @@ require_relative '../../spec_helper'
 # Rack::Test, `app`, `identities`, the OTP-feature guard, and the OTP
 # provisioning machinery. See the helper's header.
 require_relative '../../support/mfa_flow_helper'
+require_relative '../../support/sso_link_flow_helper'
 
 RSpec.describe 'SSO mailbox-proof link confirm: deferred bind after MFA (#3840 Phase 4 / #3877)',
   :full_auth_mode, type: :integration do
   include MfaFlowHelper
+  include SsoLinkFlowHelper
 
   # ==========================================================================
   # Route driving for THIS flow (mirrors
   # integration/full/sso_link_confirm_mailbox_proof_spec.rb). The shared OTP
   # machinery lives in support/mfa_flow_helper.rb.
   # ==========================================================================
-
-  # GET /auth/sso-link-confirm/:token — the display-only consent context.
-  def get_confirm(token)
-    clear_body_headers
-    header 'Accept', 'application/json'
-    get "/auth/sso-link-confirm/#{token}"
-    last_response
-  end
-
-  # POST /auth/sso-link-confirm { token } — the atomic consume + (deferred) bind
-  # + login handoff. Carries shrimp in the body like csrf_json_post; the custom route
-  # accepts the header token too, but sending both matches the SPA.
-  def post_confirm(token:)
-    csrf = fetch_csrf_token
-    clear_body_headers
-    header 'Content-Type', 'application/json'
-    header 'Accept', 'application/json'
-    header 'X-CSRF-Token', csrf if csrf
-    post '/auth/sso-link-confirm', JSON.generate(token: token, shrimp: csrf)
-    last_response
-  end
-
-  # Mint a verification directly — the POST endpoint carries the snapshot the op
-  # reloads, so it needs no SSO round-trip. Default watermark 0 matches a freshly
-  # seeded Customer (never had last_password_update stamped), so watermark_state
-  # resolves :unchanged.
-  def mint_verification(email:, uid:, account_id:, provider: 'oidc',
-                        issuer: 'https://issuer.example.com', sid: nil, password_watermark: 0)
-    Onetime::SsoLinkVerification.issue(
-      provider: provider,
-      issuer: issuer,
-      uid: uid,
-      email: OT::Utils.normalize_email(email),
-      account_id: account_id,
-      sid: sid,
-      password_watermark: password_watermark,
-    )
-  end
 
   # Drive the mailbox-proof confirm up to the MFA hand-off: mint a verification,
   # POST it, and assert the deferral contract — mfa_required, the token CONSUMED

--- a/apps/web/auth/spec/operations/deferred_sso_bind_spec.rb
+++ b/apps/web/auth/spec/operations/deferred_sso_bind_spec.rb
@@ -116,8 +116,17 @@ RSpec.describe Auth::Operations::DeferredSsoBind do
   let(:criteria) { { provider: provider, issuer: issuer, uid: uid } }
 
   # Quiet logger accepting the (message, **fields) call shape of Onetime loggers
-  # (stdlib Logger would reject the keyword fields).
+  # (stdlib Logger would reject the keyword fields). `.complete` only — `.defer`
+  # reports its failures as auth EVENTS (see the Auth::Logging stub below).
   let(:logger) { double('logger', info: nil, warn: nil) }
+
+  # `.defer`'s failure branches are audit events, not category logging: a stash
+  # that never lands degrades linking for every MFA user with no other signal
+  # (`.complete` cannot report it — :none is its normal outcome), so it has to
+  # reach the same stream as :sso_deferred_bind_completed. Stubbed rather than
+  # called through: these examples assert the CONTRACT (event name, reason),
+  # not the formatting.
+  before { allow(Auth::Logging).to receive(:log_auth_event) }
 
   let(:account_id) { seed_account(5) }
 
@@ -139,7 +148,7 @@ RSpec.describe Auth::Operations::DeferredSsoBind do
   def defer(for_account: account_id, for_sid: sid, issuer_value: issuer)
     described_class.defer(
       sid: for_sid, account_id: for_account, provider: provider, issuer: issuer_value, uid: uid,
-      dbclient: redis, codec: codec, logger: logger,
+      dbclient: redis, codec: codec,
     )
   end
 
@@ -193,7 +202,8 @@ RSpec.describe Auth::Operations::DeferredSsoBind do
 
     it 'returns false (and writes nothing) when no usable sid is available' do
       expect(defer(for_sid: nil)).to be(false)
-      expect(logger).to have_received(:warn)
+      expect(Auth::Logging).to have_received(:log_auth_event)
+        .with(:sso_deferred_bind_stash_failed, hash_including(reason: :sid_unavailable))
     end
 
     it 'is BEST-EFFORT: a storage failure returns false instead of raising' do
@@ -203,7 +213,29 @@ RSpec.describe Auth::Operations::DeferredSsoBind do
       allow(redis).to receive(:set).and_raise(StandardError, 'redis connection refused')
 
       expect(defer).to be(false)
-      expect(logger).to have_received(:warn)
+      expect(Auth::Logging).to have_received(:log_auth_event)
+        .with(:sso_deferred_bind_stash_failed, hash_including(reason: :write_error))
+    end
+
+    it 'reports a stash failure to the AUTH AUDIT STREAM, with the metric the alert reads' do
+      # The regression this guards: a systemic sidecar outage degrades linking
+      # for every MFA account, and the only witness is this event. Downgrading it
+      # to category logging (or dropping log_metric) makes that outage invisible
+      # next to the :sso_deferred_bind_completed rate it must be compared against.
+      allow(redis).to receive(:set).and_raise(StandardError, 'redis connection refused')
+
+      defer
+
+      expect(Auth::Logging).to have_received(:log_auth_event).with(
+        :sso_deferred_bind_stash_failed,
+        hash_including(
+          level: :warn,
+          log_metric: true,
+          account_id: account_id,
+          provider: provider,
+          error: 'redis connection refused',
+        ),
+      )
     end
   end
 

--- a/apps/web/auth/spec/spec_helper.rb
+++ b/apps/web/auth/spec/spec_helper.rb
@@ -74,6 +74,7 @@ require 'rack/test'
 
 # Load OmniAuth test helper for additional helper methods
 require_relative 'support/omniauth_test_helper'
+require_relative 'support/auth_request_helper'
 require_relative 'support/auth_test_constants'
 require_relative 'support/mock_omniauth_strategy'
 require_relative 'support/config_recreator'
@@ -566,6 +567,11 @@ RSpec.configure do |config|
   # Integration test helpers (for tests requiring full app boot)
   config.include Rack::Test::Methods, type: :integration
   config.include ProductionConfigHelper, type: :integration
+
+  # CSRF-aware request plumbing (csrf_json_post, fetch_csrf_token, json_body,
+  # clear_body_headers). Distinct names from ProductionConfigHelper#json_post,
+  # which is CSRF-blind and stays for the non-Rodauth routes.
+  config.include AuthRequestHelper, type: :integration
 
   # Capture AUTH_* env vars before integration suite to prevent leakage
   # between spec files that set different feature flags.

--- a/apps/web/auth/spec/spec_helper.rb
+++ b/apps/web/auth/spec/spec_helper.rb
@@ -75,6 +75,7 @@ require 'rack/test'
 # Load OmniAuth test helper for additional helper methods
 require_relative 'support/omniauth_test_helper'
 require_relative 'support/auth_request_helper'
+require_relative 'support/account_seed_helper'
 require_relative 'support/auth_test_constants'
 require_relative 'support/mock_omniauth_strategy'
 require_relative 'support/config_recreator'
@@ -572,6 +573,9 @@ RSpec.configure do |config|
   # clear_body_headers). Distinct names from ProductionConfigHelper#json_post,
   # which is CSRF-blind and stays for the non-Rodauth routes.
   config.include AuthRequestHelper, type: :integration
+
+  # Subject seeding (seed_existing_account, seed_account_with_password).
+  config.include AccountSeedHelper, type: :integration
 
   # Capture AUTH_* env vars before integration suite to prevent leakage
   # between spec files that set different feature flags.

--- a/apps/web/auth/spec/support/account_seed_helper.rb
+++ b/apps/web/auth/spec/support/account_seed_helper.rb
@@ -1,0 +1,66 @@
+# apps/web/auth/spec/support/account_seed_helper.rb
+#
+# frozen_string_literal: true
+
+require_relative 'auth_test_constants'
+
+# =============================================================================
+# Account seeding (auto-included into `type: :integration`)
+# =============================================================================
+#
+# One place to build the SUBJECT of an auth integration spec: an accounts row
+# plus its paired Customer, optionally with an Argon2 password hash.
+#
+# Every field here is load-bearing for the gem's own lookups, which is why the
+# copies had drifted apart in wording but never in behaviour (the copy counts
+# before this file: seed_account_with_password 4, seed_existing_account 3):
+#
+#   status_id = Verified  — both satisfies _account_from_login's status filter
+#     AND makes open_account? true, so Rodauth skips its verify-account branch.
+#   external_id = customer.extid — the accounts row and the Customer are one
+#     subject. Flows that probe customer state resolve :unreadable without it
+#     (e.g. the SSO mailbox-proof watermark check reads
+#     Customer#last_password_update via load_by_extid_or_email).
+#   Argon2 cost params — mirror the test config in config/features/argon2.rb.
+#
+# Auto-included alongside AuthRequestHelper (spec_helper.rb) and included
+# explicitly by MfaFlowHelper, so the full_mfa lane does not depend on the
+# config-level include. `auth_db` comes from ProductionConfigHelper.
+#
+# A group that defines either method itself still wins — a `def` in the example
+# group body sits below config-included modules in the ancestor chain.
+#
+# =============================================================================
+
+module AccountSeedHelper
+  # Seed a VERIFIED account (accounts row + linked Customer) WITHOUT a
+  # password — an SSO-only subject. Returns the account_id.
+  def seed_existing_account(email)
+    normalized = OT::Utils.normalize_email(email)
+    customer   = Onetime::Customer.new(email: normalized)
+    customer.save
+    auth_db[:accounts].insert(
+      email: normalized,
+      status_id: AuthTestConstants::STATUS_VERIFIED,
+      external_id: customer.extid,
+    )
+  end
+
+  # Seed a VERIFIED account WITH an Argon2 password hash. Returns the
+  # account_id.
+  #
+  # Two distinct reasons a spec wants the password: to establish a real
+  # authenticated session through the login route, and — in the full_mfa lane —
+  # as the OTP-PROVISIONING VEHICLE, because this deploy sets
+  # two_factor_modifications_require_password? and Rodauth's real setup flow is
+  # the only way to get a production-shaped (HMAC'd) OTP key. Specs whose
+  # subject is passwordless in production still seed it for that second reason;
+  # see their headers.
+  def seed_account_with_password(email, password: AuthTestConstants::TEST_PASSWORD)
+    account_id = seed_existing_account(email)
+    require 'argon2'
+    hasher = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
+    auth_db[:account_password_hashes].insert(id: account_id, password_hash: hasher.create(password))
+    account_id
+  end
+end

--- a/apps/web/auth/spec/support/account_seed_helper.rb
+++ b/apps/web/auth/spec/support/account_seed_helper.rb
@@ -33,6 +33,13 @@ require_relative 'auth_test_constants'
 # =============================================================================
 
 module AccountSeedHelper
+  # A collision-free address on a domain that is not routable and not a
+  # configured signup domain. Every call site passes its own prefix — the
+  # default only keeps the signature usable from a console.
+  def unique_test_email(prefix = 'test')
+    "#{prefix}-#{SecureRandom.hex(8)}@integration-test.example.com"
+  end
+
   # Seed a VERIFIED account (accounts row + linked Customer) WITHOUT a
   # password — an SSO-only subject. Returns the account_id.
   def seed_existing_account(email)

--- a/apps/web/auth/spec/support/auth_request_helper.rb
+++ b/apps/web/auth/spec/support/auth_request_helper.rb
@@ -34,7 +34,20 @@ module AuthRequestHelper
   # carried this identical one-liner; a group that needs different construction
   # (e.g. basicauth_rejection_on_session_routes_spec.rb, which memoizes around
   # a Registry.reset!) still defines its own and wins on ancestor order.
+  #
+  # The empty-registry guard is what a per-spec copy used to buy implicitly: a
+  # group that never boots gets an EMPTY Rack::URLMap rather than an error, and
+  # every request in it 404s. Auto-inclusion means no author is forced to think
+  # about mounting any more, so the check has to be here — a named harness
+  # failure instead of a spec that reads as "the route is broken".
   def app
+    if Onetime::Application::Registry.mount_mappings.empty?
+      raise 'Application registry has no mounts, so `app` would be an empty ' \
+            'Rack::URLMap and every request in this group would 404. The group ' \
+            'needs a before(:all) that calls Onetime.boot! then ' \
+            'Onetime::Application::Registry.prepare_application_registry.'
+    end
+
     Onetime::Application::Registry.generate_rack_url_map
   end
 

--- a/apps/web/auth/spec/support/auth_request_helper.rb
+++ b/apps/web/auth/spec/support/auth_request_helper.rb
@@ -1,0 +1,70 @@
+# apps/web/auth/spec/support/auth_request_helper.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# CSRF-aware request plumbing (auto-included into `type: :integration`)
+# =============================================================================
+#
+# Every Rodauth POST in this app needs shrimp — the token in BOTH the
+# X-CSRF-Token header and the JSON body — and every request after a POST needs
+# the body headers cleared, because Rack::Test keeps `Content-Type` and
+# `Content-Length` sticky across calls and a GET carrying a stale
+# `Content-Length` is answered as a truncated/blank body.
+#
+# ProductionConfigHelper#json_post (spec_helper.rb) predates all of that and is
+# CSRF-blind: no shrimp, no header clearing. It stays as-is — a dozen specs
+# post to non-Rodauth routes through it. This module is the CSRF-aware path,
+# under DIFFERENT names, so the two never resolve against each other by
+# ancestor order.
+#
+# Auto-included, so a new integration spec gets the shared path for free
+# rather than growing an eighth copy (the copy counts before this file:
+# fetch_csrf_token 6, clear_body_headers 5, json_body 3).
+#
+# A group that defines any of these itself still wins — a `def` in the example
+# group body sits below config-included modules in the ancestor chain.
+#
+# =============================================================================
+
+module AuthRequestHelper
+  # Drop the sticky body headers Rack::Test carries over from a previous POST.
+  # Call before any GET, and before a POST whose body length differs.
+  def clear_body_headers
+    header 'Content-Type', nil
+    header 'Content-Length', nil
+  end
+
+  # GET /auth purely to read the CSRF token off the response headers.
+  def fetch_csrf_token
+    clear_body_headers
+    header 'Accept', 'application/json'
+    get '/auth'
+    last_response.headers['X-CSRF-Token']
+  end
+
+  # JSON POST with the CSRF token in both the header and the body (shrimp),
+  # matching what the SPA sends and what the Rodauth routes require.
+  def csrf_json_post(path, params = {})
+    csrf = fetch_csrf_token
+    clear_body_headers
+    header 'Content-Type', 'application/json'
+    header 'Accept', 'application/json'
+    header 'X-CSRF-Token', csrf if csrf
+    post path, JSON.generate(params.merge(shrimp: csrf))
+    last_response
+  end
+
+  # Parse the last response body as JSON.
+  #
+  # Raises (rather than returning {}) on a non-JSON body: every caller asserts
+  # the status first, so a parse failure here means the response was not the
+  # one the spec thinks it got, and an empty hash would surface that as a
+  # confusing nil three lines later.
+  def json_body
+    JSON.parse(last_response.body)
+  rescue JSON::ParserError => e
+    raise JSON::ParserError,
+      "Response body is not JSON (#{last_response.status}): #{last_response.body.to_s[0, 300].inspect} (#{e.message})"
+  end
+end

--- a/apps/web/auth/spec/support/auth_request_helper.rb
+++ b/apps/web/auth/spec/support/auth_request_helper.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require_relative 'auth_test_constants'
+
 # =============================================================================
 # CSRF-aware request plumbing (auto-included into `type: :integration`)
 # =============================================================================
@@ -28,6 +30,14 @@
 # =============================================================================
 
 module AuthRequestHelper
+  # The full mounted Rack stack, as Rack::Test::Methods requires. Eight specs
+  # carried this identical one-liner; a group that needs different construction
+  # (e.g. basicauth_rejection_on_session_routes_spec.rb, which memoizes around
+  # a Registry.reset!) still defines its own and wins on ancestor order.
+  def app
+    Onetime::Application::Registry.generate_rack_url_map
+  end
+
   # Drop the sticky body headers Rack::Test carries over from a previous POST.
   # Call before any GET, and before a POST whose body length differs.
   def clear_body_headers
@@ -52,6 +62,19 @@ module AuthRequestHelper
     header 'Accept', 'application/json'
     header 'X-CSRF-Token', csrf if csrf
     post path, JSON.generate(params.merge(shrimp: csrf))
+    last_response
+  end
+
+  # Establish an authenticated session through the real login route.
+  #
+  # The status assertion is a PRECONDITION, not the subject of any caller: a
+  # silently failed login here surfaces three lines later as a confusing 401 on
+  # the route actually under test. 200 (JSON) and 302 (HTML redirect) are both
+  # success — which one comes back depends on the Accept negotiation.
+  def csrf_login(email, password: AuthTestConstants::TEST_PASSWORD)
+    csrf_json_post('/auth/login', login: email, password: password)
+    expect(last_response.status).to be_between(200, 302),
+      "Precondition failed: login for #{email} returned #{last_response.status}: #{last_response.body}"
     last_response
   end
 

--- a/apps/web/auth/spec/support/mfa_flow_helper.rb
+++ b/apps/web/auth/spec/support/mfa_flow_helper.rb
@@ -18,9 +18,13 @@ require_relative 'account_seed_helper'
 # two_factor_modifications_require_password?, the otp_setup/otp_raw_secret/
 # recovery-code param names, the two-phase otp-setup contract). A Rodauth
 # upgrade or a config flip breaks every copy at once, so a mirrored copy is a
-# second place to forget. Route DRIVING stays in each spec — that is the part
-# that genuinely differs (link-sso vs sso-link-confirm) and the part a mirror
-# is for. Compare support/oauth_flow_helper.rb, included by four full/ specs.
+# second place to forget. Compare support/oauth_flow_helper.rb, included by
+# four full/ specs.
+#
+# Route DRIVING is NOT here — but it is not mirrored per spec either: the
+# link-sso and sso-link-confirm drivers live in support/sso_link_flow_helper.rb,
+# because the route is identical across the full/ and full_mfa/ lanes and only
+# the ASSERTIONS differ. What stays in each spec is the expectations.
 #
 # LOAD-TIME SIDE EFFECT — AUTH_MFA_ENABLED: requiring this file sets
 # AUTH_MFA_ENABLED=true. It must be set before the suite's FIRST boot
@@ -78,10 +82,6 @@ module MfaFlowHelper
     end
 
     base.let(:identities) { auth_db[:account_identities] }
-  end
-
-  def app
-    Onetime::Application::Registry.generate_rack_url_map
   end
 
   # ==========================================================================

--- a/apps/web/auth/spec/support/mfa_flow_helper.rb
+++ b/apps/web/auth/spec/support/mfa_flow_helper.rb
@@ -1,0 +1,214 @@
+# apps/web/auth/spec/support/mfa_flow_helper.rb
+#
+# frozen_string_literal: true
+
+require_relative 'auth_test_constants'
+
+# =============================================================================
+# MFA Lane Helper (integration/full_mfa/)
+# =============================================================================
+#
+# The shared machinery for specs in apps/*/*/spec/integration/full_mfa/: the
+# lane bootstrap plus OTP provisioning through Rodauth's OWN JSON setup flow.
+#
+# WHY A SHARED HELPER RATHER THAN A PER-SPEC MIRROR: everything here is coupled
+# to Rodauth's OTP CONFIGURATION (otp_keys_use_hmac?,
+# two_factor_modifications_require_password?, the otp_setup/otp_raw_secret/
+# recovery-code param names, the two-phase otp-setup contract). A Rodauth
+# upgrade or a config flip breaks every copy at once, so a mirrored copy is a
+# second place to forget. Route DRIVING stays in each spec — that is the part
+# that genuinely differs (link-sso vs sso-link-confirm) and the part a mirror
+# is for. Compare support/oauth_flow_helper.rb, included by four full/ specs.
+#
+# LOAD-TIME SIDE EFFECT — AUTH_MFA_ENABLED: requiring this file sets
+# AUTH_MFA_ENABLED=true. It must be set before the suite's FIRST boot
+# (FullModeSuiteDatabase.setup! runs from a config-level before(:context) hook,
+# ahead of any group-level hook) so config.rb loads the Rodauth OTP feature
+# set. The rake lane already exports it; doing it here makes a direct
+# `rspec <one file>` invocation work too, and means a NEW spec in this
+# directory cannot forget it. Requiring this file outside the full_mfa lane
+# would leak MFA into that process's one-shot Auth::Config boot — don't.
+#
+# Usage (after `require_relative '../../spec_helper'`):
+#
+#   require_relative '../../support/mfa_flow_helper'
+#
+#   RSpec.describe '...', :full_auth_mode, type: :integration do
+#     include MfaFlowHelper          # brings Rack::Test, `app`, `identities`,
+#                                    # the OTP-feature guard, and the helpers
+#
+#     it '...' do
+#       account_id     = seed_account_with_password(email)
+#       secret, codes  = provision_totp(email)
+#       allow_immediate_otp_reuse!(account_id)
+#       json_post('/auth/otp-auth', otp_code: ROTP::TOTP.new(secret).now)
+#     end
+#   end
+#
+# =============================================================================
+
+ENV['AUTH_MFA_ENABLED'] = 'true'
+
+require 'rotp'
+
+module MfaFlowHelper
+  def self.included(base)
+    base.include Rack::Test::Methods
+
+    # Hard-fail (not skip): this lane EXISTS to cover the MFA path, so a boot
+    # without the OTP feature is harness breakage, not an environment quirk.
+    base.before(:all) do
+      otp_loaded = Auth::Config.method_defined?(:otp_auth_route) ||
+                   Auth::Config.private_method_defined?(:otp_auth_route)
+      unless otp_loaded
+        raise 'Rodauth OTP feature not loaded — this suite must boot with ' \
+              'AUTH_MFA_ENABLED=true in a fresh process (run via ' \
+              '`bundle exec rake spec:integration:full:mfa`; Auth::Config is one-shot)'
+      end
+    end
+
+    base.let(:identities) { auth_db[:account_identities] }
+  end
+
+  def app
+    Onetime::Application::Registry.generate_rack_url_map
+  end
+
+  # ==========================================================================
+  # Request plumbing
+  # ==========================================================================
+
+  def clear_body_headers
+    header 'Content-Type', nil
+    header 'Content-Length', nil
+  end
+
+  def fetch_csrf_token
+    clear_body_headers
+    header 'Accept', 'application/json'
+    get '/auth'
+    last_response.headers['X-CSRF-Token']
+  end
+
+  # JSON POST with the CSRF token in both header and body (shrimp), matching
+  # what the SPA sends and what the Rodauth routes (otp-setup, otp-auth,
+  # recovery-auth) require.
+  def json_post(path, params = {})
+    csrf = fetch_csrf_token
+    clear_body_headers
+    header 'Content-Type', 'application/json'
+    header 'Accept', 'application/json'
+    header 'X-CSRF-Token', csrf if csrf
+    post path, JSON.generate(params.merge(shrimp: csrf))
+    last_response
+  end
+
+  def json_body
+    JSON.parse(last_response.body)
+  rescue JSON::ParserError
+    {}
+  end
+
+  # ==========================================================================
+  # Subject seeding
+  # ==========================================================================
+
+  # Seed a VERIFIED account WITH a password AND its paired Customer.
+  #
+  # The password is the OTP-PROVISIONING VEHICLE: this deploy sets
+  # two_factor_modifications_require_password?, so Rodauth's real setup flow —
+  # the only way to get a production-shaped (HMAC'd) OTP key — needs one. Specs
+  # for passwordless subjects still seed it for that reason alone; see their
+  # headers.
+  #
+  # The paired Customer matters to any flow that probes customer state (e.g.
+  # the SSO mailbox-proof watermark check reads Customer#last_password_update
+  # via load_by_extid_or_email, which resolves :unchanged rather than
+  # :unreadable only when the Customer exists).
+  def seed_account_with_password(email, password: AuthTestConstants::TEST_PASSWORD)
+    normalized = OT::Utils.normalize_email(email)
+    customer   = Onetime::Customer.new(email: normalized)
+    customer.save
+    account_id = auth_db[:accounts].insert(
+      email: normalized,
+      status_id: AuthTestConstants::STATUS_VERIFIED,
+      external_id: customer.extid,
+    )
+    require 'argon2'
+    hasher = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
+    auth_db[:account_password_hashes].insert(id: account_id, password_hash: hasher.create(password))
+    account_id
+  end
+
+  # ==========================================================================
+  # OTP provisioning — through Rodauth's OWN JSON setup flow, exactly as the
+  # SPA does it, so the stored key shape (HMAC) matches production:
+  #   phase 1: POST /auth/otp-setup {}            -> 422 + { otp_setup (the
+  #            HMAC'd key the authenticator uses), otp_raw_secret }
+  #   phase 2: POST /auth/otp-setup {otp_setup, otp_raw_secret, otp_code,
+  #            password}                          -> 200, recovery codes added
+  # Returns [authenticator secret (the otp_setup value), recovery codes] —
+  # auto_add_recovery_codes? is on, and the app's after hook surfaces the
+  # generated codes in the phase-2 JSON response (hooks/mfa.rb).
+  #
+  # Clears cookies on the way out: the flow under test must start from an
+  # UNAUTHENTICATED browser, like a user on a fresh device.
+  # ==========================================================================
+
+  def provision_totp(email, password: AuthTestConstants::TEST_PASSWORD)
+    json_post('/auth/login', login: email, password: password)
+    expect(last_response.status).to eq(200),
+      "Precondition failed: password login for OTP setup (#{last_response.status}: #{last_response.body})"
+
+    json_post('/auth/otp-setup', {})
+    expect(last_response.status).to eq(422),
+      "Phase-1 otp-setup should return the generated secret with a field error (#{last_response.status}: #{last_response.body})"
+    setup_body = json_body
+    secret     = setup_body['otp_setup']
+    raw_secret = setup_body['otp_raw_secret']
+    expect(secret).not_to be_nil
+    expect(raw_secret).not_to be_nil
+
+    json_post(
+      '/auth/otp-setup',
+      otp_setup: secret,
+      otp_raw_secret: raw_secret,
+      otp_code: ROTP::TOTP.new(secret).now,
+      password: password,
+    )
+    expect(last_response.status).to eq(200),
+      "Phase-2 otp-setup should confirm the secret (#{last_response.status}: #{last_response.body})"
+    recovery_codes = Array(json_body['recovery_codes'])
+
+    clear_cookies
+    [secret, recovery_codes]
+  end
+
+  # Rodauth's OTP reuse guard (otp_update_last_use) rejects any code within one
+  # interval (30s) of last_use — and setup just stamped last_use=now. Rewind it
+  # so the auth step can accept a fresh code immediately instead of sleeping
+  # out the window in the test.
+  #
+  # One rewind covers a failed-then-retry sequence: Rodauth stamps last_use
+  # only on SUCCESSFUL validation (`otp_valid_code? && otp_update_last_use`
+  # short-circuits), so a rejected code leaves the rewound value in place and
+  # the subsequent good code is still accepted without a second rewind.
+  def allow_immediate_otp_reuse!(account_id)
+    auth_db[:account_otp_keys].where(id: account_id).update(last_use: Time.now - 300)
+  end
+
+  # A code guaranteed to be rejected RIGHT NOW: Rodauth validates with
+  # otp_drift (30s), so the previous and next interval's codes are accepted
+  # too — a candidate must differ from all three, not just the current code.
+  # Counter-based so every candidate stays six digits by construction (at most
+  # four iterations: the valid set has exactly three elements).
+  def wrong_otp_code(secret)
+    totp  = ROTP::TOTP.new(secret)
+    now   = Time.now.to_i
+    valid = [totp.at(now - 30), totp.at(now), totp.at(now + 30)]
+    (0..valid.size).each do |i|
+      candidate = i.to_s.rjust(6, '0')
+      return candidate unless valid.include?(candidate)
+    end
+  end
+end

--- a/apps/web/auth/spec/support/mfa_flow_helper.rb
+++ b/apps/web/auth/spec/support/mfa_flow_helper.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative 'auth_test_constants'
+require_relative 'auth_request_helper'
 
 # =============================================================================
 # MFA Lane Helper (integration/full_mfa/)
@@ -41,9 +42,14 @@ require_relative 'auth_test_constants'
 #       account_id     = seed_account_with_password(email)
 #       secret, codes  = provision_totp(email)
 #       allow_immediate_otp_reuse!(account_id)
-#       json_post('/auth/otp-auth', otp_code: ROTP::TOTP.new(secret).now)
+#       csrf_json_post('/auth/otp-auth', otp_code: ROTP::TOTP.new(secret).now)
 #     end
 #   end
+#
+# Request plumbing (csrf_json_post, fetch_csrf_token, json_body,
+# clear_body_headers) comes from support/auth_request_helper.rb — included
+# here explicitly so this helper stands on its own, not on the config-level
+# auto-include.
 #
 # =============================================================================
 
@@ -54,6 +60,7 @@ require 'rotp'
 module MfaFlowHelper
   def self.included(base)
     base.include Rack::Test::Methods
+    base.include AuthRequestHelper
 
     # Hard-fail (not skip): this lane EXISTS to cover the MFA path, so a boot
     # without the OTP feature is harness breakage, not an environment quirk.
@@ -72,41 +79,6 @@ module MfaFlowHelper
 
   def app
     Onetime::Application::Registry.generate_rack_url_map
-  end
-
-  # ==========================================================================
-  # Request plumbing
-  # ==========================================================================
-
-  def clear_body_headers
-    header 'Content-Type', nil
-    header 'Content-Length', nil
-  end
-
-  def fetch_csrf_token
-    clear_body_headers
-    header 'Accept', 'application/json'
-    get '/auth'
-    last_response.headers['X-CSRF-Token']
-  end
-
-  # JSON POST with the CSRF token in both header and body (shrimp), matching
-  # what the SPA sends and what the Rodauth routes (otp-setup, otp-auth,
-  # recovery-auth) require.
-  def json_post(path, params = {})
-    csrf = fetch_csrf_token
-    clear_body_headers
-    header 'Content-Type', 'application/json'
-    header 'Accept', 'application/json'
-    header 'X-CSRF-Token', csrf if csrf
-    post path, JSON.generate(params.merge(shrimp: csrf))
-    last_response
-  end
-
-  def json_body
-    JSON.parse(last_response.body)
-  rescue JSON::ParserError
-    {}
   end
 
   # ==========================================================================
@@ -156,11 +128,11 @@ module MfaFlowHelper
   # ==========================================================================
 
   def provision_totp(email, password: AuthTestConstants::TEST_PASSWORD)
-    json_post('/auth/login', login: email, password: password)
+    csrf_json_post('/auth/login', login: email, password: password)
     expect(last_response.status).to eq(200),
       "Precondition failed: password login for OTP setup (#{last_response.status}: #{last_response.body})"
 
-    json_post('/auth/otp-setup', {})
+    csrf_json_post('/auth/otp-setup', {})
     expect(last_response.status).to eq(422),
       "Phase-1 otp-setup should return the generated secret with a field error (#{last_response.status}: #{last_response.body})"
     setup_body = json_body
@@ -169,7 +141,7 @@ module MfaFlowHelper
     expect(secret).not_to be_nil
     expect(raw_secret).not_to be_nil
 
-    json_post(
+    csrf_json_post(
       '/auth/otp-setup',
       otp_setup: secret,
       otp_raw_secret: raw_secret,

--- a/apps/web/auth/spec/support/mfa_flow_helper.rb
+++ b/apps/web/auth/spec/support/mfa_flow_helper.rb
@@ -4,6 +4,7 @@
 
 require_relative 'auth_test_constants'
 require_relative 'auth_request_helper'
+require_relative 'account_seed_helper'
 
 # =============================================================================
 # MFA Lane Helper (integration/full_mfa/)
@@ -47,9 +48,10 @@ require_relative 'auth_request_helper'
 #   end
 #
 # Request plumbing (csrf_json_post, fetch_csrf_token, json_body,
-# clear_body_headers) comes from support/auth_request_helper.rb — included
-# here explicitly so this helper stands on its own, not on the config-level
-# auto-include.
+# clear_body_headers) comes from support/auth_request_helper.rb, and subject
+# seeding (seed_existing_account, seed_account_with_password) from
+# support/account_seed_helper.rb — both included here explicitly so this helper
+# stands on its own, not on the config-level auto-include.
 #
 # =============================================================================
 
@@ -61,6 +63,7 @@ module MfaFlowHelper
   def self.included(base)
     base.include Rack::Test::Methods
     base.include AuthRequestHelper
+    base.include AccountSeedHelper
 
     # Hard-fail (not skip): this lane EXISTS to cover the MFA path, so a boot
     # without the OTP feature is harness breakage, not an environment quirk.
@@ -79,37 +82,6 @@ module MfaFlowHelper
 
   def app
     Onetime::Application::Registry.generate_rack_url_map
-  end
-
-  # ==========================================================================
-  # Subject seeding
-  # ==========================================================================
-
-  # Seed a VERIFIED account WITH a password AND its paired Customer.
-  #
-  # The password is the OTP-PROVISIONING VEHICLE: this deploy sets
-  # two_factor_modifications_require_password?, so Rodauth's real setup flow —
-  # the only way to get a production-shaped (HMAC'd) OTP key — needs one. Specs
-  # for passwordless subjects still seed it for that reason alone; see their
-  # headers.
-  #
-  # The paired Customer matters to any flow that probes customer state (e.g.
-  # the SSO mailbox-proof watermark check reads Customer#last_password_update
-  # via load_by_extid_or_email, which resolves :unchanged rather than
-  # :unreadable only when the Customer exists).
-  def seed_account_with_password(email, password: AuthTestConstants::TEST_PASSWORD)
-    normalized = OT::Utils.normalize_email(email)
-    customer   = Onetime::Customer.new(email: normalized)
-    customer.save
-    account_id = auth_db[:accounts].insert(
-      email: normalized,
-      status_id: AuthTestConstants::STATUS_VERIFIED,
-      external_id: customer.extid,
-    )
-    require 'argon2'
-    hasher = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
-    auth_db[:account_password_hashes].insert(id: account_id, password_hash: hasher.create(password))
-    account_id
   end
 
   # ==========================================================================

--- a/apps/web/auth/spec/support/omniauth_test_helper.rb
+++ b/apps/web/auth/spec/support/omniauth_test_helper.rb
@@ -4,6 +4,7 @@
 
 require 'webmock/rspec'
 require 'omniauth'
+require 'securerandom'
 
 # =============================================================================
 # OmniAuth Test Helpers
@@ -100,15 +101,26 @@ module OmniAuthTestHelper
 
   # Mock a successful OIDC authentication hash
   # Use for testing callback handling
-  def mock_oidc_success(email: 'test@example.com', name: 'Test User', uid: 'test-uid-123')
-    OmniAuth.config.mock_auth[:oidc] = OmniAuth::AuthHash.new({
-      provider: 'oidc',
+  #
+  # provider: registers under a provider other than :oidc (the callback route
+  #   segment and the auth hash's provider value are the same string).
+  # email: nil models an IdP that returns NO email claim — the claim is OMITTED
+  #   from info and raw_info rather than sent as null, which is what a real
+  #   emailless response looks like and what the app's missing-email paths must
+  #   handle. Note '' is not nil: an empty-string claim is still a claim, and
+  #   the domain-restriction specs rely on it being passed through.
+  def mock_oidc_success(email: 'test@example.com', name: 'Test User', uid: 'test-uid-123', provider: :oidc)
+    info     = { name: name }
+    raw_info = { sub: uid, name: name }
+    unless email.nil?
+      info     = info.merge(email: email, email_verified: true)
+      raw_info = raw_info.merge(email: email, email_verified: true)
+    end
+
+    OmniAuth.config.mock_auth[provider.to_sym] = OmniAuth::AuthHash.new({
+      provider: provider.to_s,
       uid: uid,
-      info: {
-        email: email,
-        name: name,
-        email_verified: true,
-      },
+      info: info,
       credentials: {
         token: 'mock_access_token',
         refresh_token: 'mock_refresh_token',
@@ -116,14 +128,39 @@ module OmniAuthTestHelper
         expires: true,
       },
       extra: {
-        raw_info: {
-          sub: uid,
-          email: email,
-          name: name,
-          email_verified: true,
-        },
+        raw_info: raw_info,
       },
     })
+  end
+
+  # Put OmniAuth in test mode AND register a mock auth hash for `provider` —
+  # the pair every callback-driving spec needs, previously mirrored in seven of
+  # them. Callers that need a non-default hash shape can still reach for
+  # mock_oidc_success/mock_entra_success/etc. directly.
+  #
+  # uid defaults to a fresh random value, used for BOTH uid and raw_info.sub
+  # (the copies in omniauth_domain_restriction_spec.rb generated the fallback
+  # twice, so uid and sub disagreed for every example that omitted uid).
+  #
+  # Pair with teardown_mock_auth in an ensure block, or let the :omniauth_mock
+  # tag's after hook (reset_omniauth_config) handle it.
+  def setup_mock_auth(email:, uid: nil, provider: :oidc, name: 'Test User')
+    enable_omniauth_test_mode
+    mock_oidc_success(
+      email: email,
+      name: name,
+      uid: uid || "test-uid-#{SecureRandom.hex(8)}",
+      provider: provider,
+    )
+  end
+
+  # Leave OmniAuth out of test mode with no mocks registered. Narrower than
+  # reset_omniauth_config on purpose: it does not touch allowed_request_methods,
+  # so a spec that tears down mid-example can set up again without re-enabling
+  # GET callbacks.
+  def teardown_mock_auth
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth.clear
   end
 
   # Mock a failed OIDC authentication

--- a/apps/web/auth/spec/support/omniauth_test_helper.rb
+++ b/apps/web/auth/spec/support/omniauth_test_helper.rb
@@ -154,6 +154,44 @@ module OmniAuthTestHelper
     )
   end
 
+  # Drive the SSO callback for a mocked IdP assertion and return the response.
+  #
+  # Unauthenticated by default — the plain sign-in path. A caller that needs the
+  # AUTHENTICATED (connect-intent) variant logs in first; the mock and the POST
+  # are the same either way.
+  def sso_callback(email:, uid:, provider: :oidc)
+    setup_mock_auth(email: email, uid: uid, provider: provider)
+    clear_body_headers
+    post "/auth/sso/#{provider}/callback"
+    last_response
+  end
+
+  # Leaves session[:validated_omniauth_domain_id] nil == the PLATFORM path, and
+  # lets a non-tenant callback proceed on platform credentials instead of
+  # redirecting to sso_not_configured.
+  def enable_platform_fallback
+    allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
+  end
+
+  # Deep-clone OT.conf before mutating: the stub must not leak the domain list
+  # into the next example through the shared config object.
+  def configure_allowed_domains(domains)
+    config = Marshal.load(Marshal.dump(OT.conf))
+    config['site'] ||= {}
+    config['site']['authentication'] ||= {}
+    config['site']['authentication']['allowed_signup_domains'] = domains
+    allow(OT).to receive(:conf).and_return(config)
+  end
+
+  # Assert the callback bounced to the SPA sign-in page carrying `code`, which
+  # is how every refusal in the OmniAuth callback chain surfaces.
+  def expect_auth_error_redirect(code)
+    expect(last_response.status).to eq(302),
+      "Expected 302 redirect for #{code}, got #{last_response.status}: #{last_response.body}"
+    expect(last_response.location.to_s).to include("/signin?auth_error=#{code}"),
+      "Expected auth_error=#{code} in Location, got: #{last_response.location.inspect}"
+  end
+
   # Leave OmniAuth out of test mode with no mocks registered. Narrower than
   # reset_omniauth_config on purpose: it does not touch allowed_request_methods,
   # so a spec that tears down mid-example can set up again without re-enabling

--- a/apps/web/auth/spec/support/sso_link_flow_helper.rb
+++ b/apps/web/auth/spec/support/sso_link_flow_helper.rb
@@ -1,0 +1,79 @@
+# apps/web/auth/spec/support/sso_link_flow_helper.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# SSO account-linking route drivers (#3840)
+# =============================================================================
+#
+# The two post-callback linking flows, driven the way the SPA drives them:
+#
+#   /auth/link-sso        — Phase 3 signin interstitial: prove the mailbox with
+#                           the account password, then bind.
+#   /auth/sso-link-confirm — Phase 4 mailbox proof: prove it with an emailed
+#                           single-use token instead, for passwordless subjects.
+#
+# WHY SHARED RATHER THAN MIRRORED PER LANE: each of these had a full/ copy and
+# a full_mfa/ copy that were byte-identical, because the ROUTE does not change
+# between the lanes — only the assertions do (full_mfa/ expects the bind to be
+# DEFERRED behind the OTP step). Mirroring the driver bought nothing and meant
+# a route or param rename had to be found in two places. What legitimately
+# differs — the expectations, and the OTP machinery in support/mfa_flow_helper.rb
+# — stays where it is.
+#
+# Included explicitly (`include SsoLinkFlowHelper`) rather than auto-included:
+# these hit specific routes, so only the linking specs should carry them.
+# Request plumbing comes from AuthRequestHelper, which is already auto-included
+# into type: :integration and included by MfaFlowHelper.
+#
+# =============================================================================
+
+module SsoLinkFlowHelper
+  # ==========================================================================
+  # /auth/link-sso — password-proof interstitial
+  # ==========================================================================
+
+  # Pull the challenge token out of a /link-sso/:token redirect Location.
+  # Tolerates a trailing query or fragment.
+  def token_from_location(location)
+    location.to_s.split('/link-sso/').last.to_s.split(/[?#]/).first
+  end
+
+  def post_link_sso(token:, password:)
+    csrf_json_post('/auth/link-sso', token: token, password: password)
+  end
+
+  # ==========================================================================
+  # /auth/sso-link-confirm — mailbox-proof confirmation
+  # ==========================================================================
+
+  # Read the confirmation context the SPA renders before the user commits.
+  def get_confirm(token)
+    clear_body_headers
+    header 'Accept', 'application/json'
+    get "/auth/sso-link-confirm/#{token}"
+    last_response
+  end
+
+  def post_confirm(token:)
+    csrf_json_post('/auth/sso-link-confirm', token: token)
+  end
+
+  # Mint the single-use verification a confirm link carries, skipping the email
+  # round-trip. password_watermark: 0 is the "no password on file" case that the
+  # passwordless subjects in these specs are in; a non-zero value models a
+  # subject whose password changed after the link was issued, which must
+  # invalidate it.
+  def mint_verification(email:, uid:, account_id:, provider: 'oidc',
+                        issuer: 'https://issuer.example.com', sid: nil, password_watermark: 0)
+    Onetime::SsoLinkVerification.issue(
+      provider: provider,
+      issuer: issuer,
+      uid: uid,
+      email: OT::Utils.normalize_email(email),
+      account_id: account_id,
+      sid: sid,
+      password_watermark: password_watermark,
+    )
+  end
+end

--- a/docs/authentication/per-domain-sso.md
+++ b/docs/authentication/per-domain-sso.md
@@ -141,6 +141,8 @@ Resolution chain (`apps/web/auth/config/hooks/omniauth_tenant.rb`):
 
 **Security:** Tenant context (domain_id) stored in session during request phase, validated on callback to prevent cross-tenant redirect attacks.
 
+**Identity linking is platform-only.** The three linking paths documented for platform SSO — the authenticated [Connected Identities panel](per-install-sso.md#connected-identities-authenticated-linking-from-account-settings), the [sign-in interstitial](per-install-sso.md#sign-in-interstitial-password-challenge-linking), and [mailbox-proof linking](per-install-sso.md#mailbox-proof-linking-passwordless-accounts) — are **not** offered on a tenant callback, and the trusted-IdP email-linking flag has no effect here. Each of those paths is gated on `session[:validated_omniauth_domain_id]` being `nil`, which a tenant callback always sets. A tenant admin controls their own IdP's assertions, so a tenant-issuer identity must not be bound to an account located by email (or to whatever account happens to hold the current platform session). Tenant SSO keeps the refusal: an unlinked identity whose email matches an existing account is refused with `account_exists_link_required`. Authenticated tenant-surface linking requires org-membership verification first and is tracked in #3849.
+
 ## Troubleshooting
 
 ### SSO Tab Not Appearing

--- a/docs/authentication/per-install-sso.md
+++ b/docs/authentication/per-install-sso.md
@@ -141,7 +141,9 @@ Account lookup by (provider, uid), then by email
     │     └─ Trusted-IdP flag OFF →
     │            ├─ account HAS a password → sign-in interstitial
     │            │      (prove existing password → link identity → sync session)
-    │            └─ account has NO password → refuse, redirect to /signin (default)
+    │            └─ account has NO password (passwordless) → mailbox-proof link
+    │                   (email single-use token to on-file address → user clicks →
+    │                    confirm → link identity → sign in), tenant surface → refuse
     └─ Email unknown → Create account + Customer + workspace, sync session
     │
     ▼
@@ -152,7 +154,7 @@ All hooks (`account_from_omniauth`, `before_omniauth_create_account`, etc.) are 
 
 ## Behavior
 
-**Account Matching:** By linked identity first — the `(provider, uid)` pair in `account_identities`. If that identity is already linked, the user is signed into its account. If the identity is *not* linked but the IdP email matches an existing account, the default is to **refuse** auto-linking (email may locate an account, but only a demonstrated credential may bind an identity to it). Two paths relax that refusal without weakening the invariant: a password-holding account is offered a **sign-in interstitial** to prove its existing password (on by default — see [Sign-in interstitial](#sign-in-interstitial-password-challenge-linking)), and an operator can opt a trusted IdP into email auto-linking (see [Identity Linking and the Trusted-IdP Flag](#identity-linking-and-the-trusted-idp-flag)).
+**Account Matching:** By linked identity first — the `(provider, uid)` pair in `account_identities`. If that identity is already linked, the user is signed into its account. If the identity is *not* linked but the IdP email matches an existing account, the default is to **refuse** auto-linking (email may locate an account, but only a demonstrated credential may bind an identity to it). Three paths relax that refusal without weakening the invariant: a password-holding account is offered a **sign-in interstitial** to prove its existing password (on by default — see [Sign-in interstitial](#sign-in-interstitial-password-challenge-linking)); a **passwordless** account is offered **mailbox-proof linking** — a single-use link emailed to its on-file address (on by default, platform surface — see [Mailbox-proof linking](#mailbox-proof-linking-passwordless-accounts)); and an operator can opt a trusted IdP into email auto-linking (see [Identity Linking and the Trusted-IdP Flag](#identity-linking-and-the-trusted-idp-flag)).
 
 **Account Creation:** Automatic for unrecognized emails. Creates Customer record and default workspace.
 
@@ -205,6 +207,50 @@ This path needs no operator configuration. It is on by default and is the platfo
 **Session establishment reuses Rodauth's own machinery.** On a correct password the handler binds the `(provider, issuer, uid)` row (same shape as `omniauth_identity_insert_hash`) and then calls `rodauth.login('password')` rather than hand-rolling the session. That runs the normal `after_login` path — the Redis session blob via `SyncSession` (the real app auth gate), `active_sessions` registration, and MFA detection — so a password account that has OTP configured still gets the MFA gate, exactly as a direct `/auth/login` would.
 
 **Platform-only.** The interstitial is only ever offered on the platform callback path. The email branches in `account_from_omniauth` are reached solely when `session[:validated_omniauth_domain_id]` is `nil` (tenant callbacks bind by session or refuse earlier), so a tenant callback can never mint a challenge. Authenticated tenant-surface linking is a separate follow-up.
+
+### Mailbox-proof linking (passwordless accounts)
+
+The sign-in interstitial above proves ownership with the account's **existing password**. That leaves one case: a **passwordless** account (SSO-only, or migrated without a local password) whose owner now signs in through a *new* SSO identity. There is no password to challenge — but that account can still prove ownership the same way magic-link (email_auth) does: **control of its on-file mailbox.** So instead of dead-ending at the H-3 refusal, the callback **emails a single-use link to the account's on-file address**, and binding the `(provider, issuer, uid)` identity happens only when the user clicks it and confirms. Mailbox control is the demonstrated credential; the invariant holds.
+
+**The token travels only through the email — never the callback redirect.** The proof is mailbox control, so the callback redirects the browser to a **token-less** notice (`/signin?auth_notice=link_verification_sent`) and delivers the token *solely* to the on-file inbox. A caller who merely completed an SSO round-trip asserting the victim's email therefore never learns the token and cannot self-consume it.
+
+**What happens (unauthenticated callback, existing passwordless account, identity not linked, trust flag off, platform surface):**
+
+1. `account_from_omniauth` finds no challengeable password for the located account (Phase 3's SQL + Redis-migration probe both come up empty).
+2. It mints a single-use `Onetime::SsoLinkVerification` in Redis — a short-lived (15 min) token snapshotting `(provider, resolved_issuer, uid, normalized email, account id, initiating session id, password watermark)`.
+3. It emails the token to the account's **on-file address** (`fallback: :sync`, auth-critical), logs `sso_link_verification_issued` (level `warn`), and redirects to the token-less notice. If mail delivery *raises*, the token is consumed and the flow falls through to the H-3 refusal — the user is never told to check an inbox that got no mail (fail closed).
+
+**Consent screen + confirm endpoints** (`apps/web/auth/routes/sso_link_confirm.rb`):
+
+| Endpoint | Purpose | Response |
+|----------|---------|----------|
+| `GET /auth/sso-link-confirm/{token}` | Consent display context | `{ provider, email }` — names the requesting provider and echoes the claimed email; never the account id, uid, issuer, sid, or watermark. **Never consumes the token.** Missing/consumed/expired token → `404 { error, error_code: "link_expired" }`. |
+| `POST /auth/sso-link-confirm` | Consume token, bind identity, log in | Body `{ token }`. Success establishes the session and returns Rodauth's standard login JSON response (`200 { success, … }`, or `mfa_required` when a second factor is pending). Failures return `{ error, error_code }` (see below). |
+
+**Why GET is display-only and POST does the mutation.** The emailed link opens the SPA consent screen, which `GET`s the display context (the consent copy names the provider *and* the claimed email) and only mutates on an explicit user action — the `POST`. A GET must stay side-effect-free: mail clients and link-preview bots prefetch GET URLs, and a mutating GET would let such a prefetch silently consume the single-use token before the user ever consents.
+
+**POST error codes:**
+
+| Status | `error_code` | Meaning |
+|--------|--------------|---------|
+| 400 | `invalid_request` | token missing from the POST body |
+| 401 | `link_expired` | token missing / already consumed / expired, or the snapshotted account vanished or is no longer loginable |
+| 409 | `link_conflict` | the account was re-emailed since issuance, or the `(provider, issuer, uid)` is already bound to a different account |
+| 409 | `link_invalidated` | a credential change advanced the account's password watermark since the token was issued |
+
+**Single-use, atomically consumed.** `POST /auth/sso-link-confirm` deletes the token up front (`#delete!` — the atomic single-use gate) before binding, so it is worth exactly one confirmation. Two concurrent confirmations race on the delete count; only the winner proceeds. The 15-minute TTL bounds abandoned tokens.
+
+**Invalidated on any credential change (watermark, not a sweep).** The token snapshots the account's `Customer#last_password_update` at issuance. Every password set/reset/change stamps that watermark (via `Auth::Operations::UpdatePasswordMetadata` in the `after_*_password` hooks). At confirm time the op re-reads the current watermark and rejects (`link_invalidated`) if it advanced. This is a comparison, not a token-enumeration sweep — no need to find and delete outstanding tokens on every credential change. (This is why the credential-change hooks needed no modification.)
+
+**Soft, cross-device session binding.** The token records the id of the session that *initiated* the SSO round-trip, but the check is **compare-and-warn, not a hard gate**: mailbox proof is inherently cross-device (the user may open the link on their phone). A sid mismatch is logged (`sso_link_verification_cross_device`, level `info`) and tolerated.
+
+**Confirm logs the user in.** The account is passwordless and clicking the emailed link proves mailbox control — the *same* proof magic-link uses to authenticate — so on success the confirm route establishes the session through Rodauth's own `login` machinery (`rodauth.login('sso_link_confirm')`), not a hand-rolled session. That runs the normal `after_login` path (Redis session blob via `SyncSession` — the real app auth gate — plus `active_sessions` registration and MFA detection). The user lands signed in and their newly linked SSO works next time.
+
+**MFA-safe bind.** SSO logins are MFA-exempt, so if the passwordless account has a pending second factor the identity bind is **deferred** (the login still proceeds to the OTP step, emitting `mfa_required`); completing the bind after MFA is the same follow-up as the password interstitial (#3877). Moot for default installs (MFA off), load-bearing for `AUTH_MFA_ENABLED` deployments.
+
+**Platform-only.** Like the password interstitial, mailbox-proof linking is only offered on the platform callback path. A tenant admin controls their own IdP and could otherwise trigger link emails to arbitrary platform addresses, so tenant callbacks keep the unchanged H-3 refusal.
+
+**Audit events.** `sso_link_verification_issued` (issuance), `sso_link_verification_confirmed` (successful bind), plus `sso_link_verification_deferred_mfa`, `sso_link_verification_invalidated`, `sso_link_verification_conflict`, `sso_link_verification_cross_device`, and `sso_link_verification_send_FAILED` for the branch outcomes.
 
 ### The flag
 

--- a/docs/authentication/per-install-sso.md
+++ b/docs/authentication/per-install-sso.md
@@ -154,7 +154,7 @@ All hooks (`account_from_omniauth`, `before_omniauth_create_account`, etc.) are 
 
 ## Behavior
 
-**Account Matching:** By linked identity first — the `(provider, uid)` pair in `account_identities`. If that identity is already linked, the user is signed into its account. If the identity is *not* linked but the IdP email matches an existing account, the default is to **refuse** auto-linking (email may locate an account, but only a demonstrated credential may bind an identity to it). Three paths relax that refusal without weakening the invariant: a password-holding account is offered a **sign-in interstitial** to prove its existing password (on by default — see [Sign-in interstitial](#sign-in-interstitial-password-challenge-linking)); a **passwordless** account is offered **mailbox-proof linking** — a single-use link emailed to its on-file address (on by default, platform surface — see [Mailbox-proof linking](#mailbox-proof-linking-passwordless-accounts)); and an operator can opt a trusted IdP into email auto-linking (see [Identity Linking and the Trusted-IdP Flag](#identity-linking-and-the-trusted-idp-flag)).
+**Account Matching:** By linked identity first — the `(provider, uid)` pair in `account_identities`. If that identity is already linked, the user is signed into its account. If the identity is *not* linked but the IdP email matches an existing account, the default is to **refuse** auto-linking (email may locate an account, but only a demonstrated credential may bind an identity to it). Three paths relax that refusal without weakening the invariant: a password-holding account is offered a **sign-in interstitial** to prove its existing password (on by default — see [Sign-in interstitial](#sign-in-interstitial-password-challenge-linking)); a **passwordless** account is offered **mailbox-proof linking** — a single-use link emailed to its on-file address (on by default, platform surface — see [Mailbox-proof linking](#mailbox-proof-linking-passwordless-accounts)); and an operator can opt a trusted IdP into email auto-linking (see [Identity Linking and the Trusted-IdP Flag](#identity-linking-and-the-trusted-idp-flag)). A signed-in user can also link an identity deliberately, without any email involvement, from [Connected Identities](#connected-identities-authenticated-linking-from-account-settings) in account settings.
 
 **Account Creation:** Automatic for unrecognized emails. Creates Customer record and default workspace.
 
@@ -174,11 +174,102 @@ Concretely: an SSO login is identified by the `(provider, uid)` pair recorded in
 
 This is the correct default for a multi-tenant platform. It is *not* what a self-hosted single-tenant operator wants when they control both the app and the IdP — for them, email is a trustworthy join key, and the refusal locks legitimate users out. The trusted-IdP flag is the sanctioned, opt-in exception.
 
+### Connected Identities: authenticated linking from account settings
+
+The invariant says a *demonstrated credential* is what binds an identity. The cleanest such credential is one the user has **already** demonstrated: an active, authenticated session. So the primary way to attach an SSO identity to an existing account is not a callback heuristic at all — it is a deliberate action the signed-in user takes from **Security settings → Connected identities** (`/account/settings/security/connections`, `src/apps/workspace/account/ConnectedIdentities.vue`).
+
+This is the surface the other paths point at: the H-3 refusal flash names it, and the interstitial and mailbox-proof flows send `link_expired` / `link_conflict` here rather than re-minting a token.
+
+**The panel** lists the account's linked identities — canonical provider label, the `issuer` (hidden for the `''` sentinel on legacy / OAuth2-only rows), and a **masked** `uid` — with a Remove action behind a confirmation dialog, plus a Connect button for each configured provider **not** already linked. "Already linked" is decided by route name (`provider.route_name` vs the row's `provider`), which is correct on the platform surface where one route maps to one issuer.
+
+```
+Signed-in user clicks "Connect {provider}"
+    │
+    ▼
+Form POST /auth/sso/{provider} with connect=1  (submitSsoLogin, src/shared/utils/sso.ts)
+    │
+    ▼
+omniauth_request_validation_phase → write sidecar:<sid>:sso_connect_intent = <account id>
+    │
+    ▼
+IdP round-trip → callback → account_from_omniauth
+    │
+    ▼
+Consume the intent (atomic GETDEL)
+    ├─ matches the current session account → bind (provider, issuer, uid) to it, re-affirm session
+    ├─ tenant callback on a platform session → refuse (identity_connect_conflict)
+    ├─ session account no longer open       → refuse (identity_connect_conflict)
+    └─ absent / expired / other account     → fall through to the email branches (never bind)
+    │
+    ▼
+Back to /account/settings/security/connections
+```
+
+#### Two signals are required to bind, not one
+
+`logged_in?` alone is **not** connect intent. Tabs share cookies, so an ordinary second-tab or shared-browser SSO *sign-in* arriving on an already-authenticated session would otherwise be routed through the bind path and permanently attach the arriving IdP identity to whoever happens to be signed in. Binding therefore requires **both**:
+
+1. an authenticated session (`session_value`), and
+2. an **account-bound connect intent** established at initiation.
+
+The division of labour: OAuth `state`/CSRF proves *"this browser initiated a request"*; the intent nonce proves *"this browser initiated a **connect** for **this account**"*.
+
+#### The connect-intent nonce (#3859)
+
+| Property | Behavior |
+|----------|----------|
+| Written | `omniauth_request_validation_phase` (`config/hooks/omniauth.rb`), during `POST /auth/sso/:provider`, only when a logged-in caller submits `connect=1` |
+| Stored as | `sidecar:<sid>:sso_connect_intent` = the **session account id** (not a bare boolean), short TTL (~5 min — one IdP round-trip) |
+| Consumed | Atomic GETDEL in `account_from_omniauth`, before any email-based branch |
+| Binds when | The consumed value equals the *current* session account id |
+| Abandoned connect | Needs no cleanup — the key expires. Additionally, any **non**-connect SSO initiation deletes a dangling intent, so a later plain `connect=0` callback can never consume one that is still in TTL |
+| Failure mode | Fail-closed — a failed write or a miss means no intent, and no intent means no bind |
+
+It is a sidecar key rather than a field in the session blob on purpose. A blob-resident nonce was only ever cleared at the callback, so an abandoned connect (user cancels at the IdP, the IdP errors, the tab closes) left it live for the *next* callback on that session — even a plain sign-in — to consume and bind on, which is exactly the shared-browser bind the nonce exists to prevent. Blob copies written by pre-#3859 code are discarded unconsumed.
+
+#### Email plays no part in the decision
+
+The connect branch is evaluated **first** — ahead of the trusted-provider auto-link and the H-3 refusal — because a proven session credential outranks the email-only heuristics those branches rely on. Within it, the account is loaded **by session id** (`_account_from_session`, which also applies the open-status filter), never by email. The IdP-supplied email appears only in the audit event, obscured.
+
+That ordering is the point: matching a connect to an email-*located* account would be the pre-account-hijacking anti-pattern — an attacker who controls an IdP that emits a victim's email would be routed to the victim's account. Routing by session leaves the victim untouched no matter what the IdP claims.
+
+"Already linked elsewhere" cannot arise on this path: an existing `(provider, issuer, uid)` row routes the gem to `account_from_omniauth_identity` instead, so this hook is only ever reached for a **new** identity.
+
+#### Refusals
+
+| Condition | Outcome | Audit event |
+|-----------|---------|-------------|
+| Tenant callback (`validated_omniauth_domain_id` set) on a platform session | Redirect `/signin?auth_error=identity_connect_conflict` | `omniauth_identity_connect_refused`, reason `tenant_surface` |
+| Session account gone or no longer open (e.g. closed mid-session) | Redirect `/signin?auth_error=identity_connect_conflict` | `omniauth_identity_connect_refused`, reason `session_account_missing` |
+| Logged in, but no valid intent (second tab, shared browser, intent for a different account) | **No bind** — falls through to the email branches exactly as an unauthenticated caller would | `omniauth_connect_intent_absent` (level `info`) |
+| Bind succeeds | `(provider, issuer, uid)` row written for the session account; session re-affirmed | `omniauth_identity_connected` (level `warn`) |
+
+Refusing rather than falling back matters in the first row: a tenant admin controls their own IdP's assertions, so binding a tenant-issuer identity onto a platform-session account would hand them a login into that account.
+
+#### Managing linked identities (`GET` / `DELETE /auth/identities`)
+
+`apps/web/auth/routes/identities.rb`, mirroring `routes/active_sessions.rb`:
+
+| Endpoint | Purpose | Response |
+|----------|---------|----------|
+| `GET /auth/identities` | List the current account's identities | `{ identities: [{ id, provider, issuer, uid }] }` — `uid` is masked (`abcd…wxyz`, or `***` when ≤ 8 chars); the row `id` is the delete handle, so the full `sub` is never sent to the client. No `created_at`: migrations 006/008 do not add one. |
+| `DELETE /auth/identities/:id` | Remove one identity | `200 { success }`; `404` unknown/not-yours; `409 { error_code: "last_credential" }`; `401` unauthenticated |
+
+**No IDOR by construction.** Every query derives from one dataset pinned to `account_id = rodauth.session_value`, and the dataset is never widened. A cross-account id filters to zero rows and yields `404` — never a delete of someone else's identity. The `:id` segment is an integer matcher, so a non-numeric segment falls through to the router's 404.
+
+**Last-credential guard.** An SSO-only account (no usable password) may not remove its **final** identity — that would lock it out. Accounts that have a password may remove identities freely. The existence check, the guard, and the delete run in **one transaction** with an account-scoped row lock (`for_update.all`), closing a TOCTOU where two concurrent DELETEs for *different* ids of the same SSO-only account could each observe two rows, both pass the guard, and strip every sign-in method. Note the shape: materialize the locked rows and count in Ruby — `identities_ds.for_update.count` emits `SELECT count(*) … FOR UPDATE`, which PostgreSQL rejects. Removals are logged (`SSO identity disconnected`, level `warn`).
+
+**Issuer column.** Binds on this path go through the same `(provider, issuer, uid)` shape as the callback, with `issuer` coerced to the `''` sentinel rather than `NULL` so it matches the issuer-scoped unique index (see migration `008_issuer_scoped_identities.rb`).
+
+#### Platform-only
+
+The panel connects identities on the **platform** surface only. Authenticated linking on a tenant (custom-domain) surface needs org-membership verification before a tenant-issuer identity may be bound to an account, and is a deliberate follow-up (#3849).
+
 ### Sign-in interstitial (password-challenge linking)
 
 The refusal is the *right* default, but for one common case it is unnecessarily blunt: a user who already has a **password** account and now signs in through SSO for the first time. That user *can* demonstrate a credential — their existing password — so instead of dead-ending them, the callback offers a **sign-in interstitial** that collects and verifies that password before binding the identity. This keeps the invariant intact: email still only *locates* the account; the existing password is the credential that *binds*.
 
-This path needs no operator configuration. It is on by default and is the platform-surface recovery for a password user's first SSO sign-in (the counterpart to the authenticated "Connect SSO" panel in account settings, which serves users who signed in with their password first).
+This path needs no operator configuration. It is on by default and is the platform-surface recovery for a password user's first SSO sign-in (the counterpart to the authenticated [Connected Identities panel](#connected-identities-authenticated-linking-from-account-settings), which serves users who signed in with their password first).
 
 **What happens (unauthenticated callback, existing account, identity not linked, trust flag off):**
 
@@ -246,7 +337,7 @@ The sign-in interstitial above proves ownership with the account's **existing pa
 
 **Confirm logs the user in.** The account is passwordless and clicking the emailed link proves mailbox control — the *same* proof magic-link uses to authenticate — so on success the confirm route establishes the session through Rodauth's own `login` machinery (`rodauth.login('sso_link_confirm')`), not a hand-rolled session. That runs the normal `after_login` path (Redis session blob via `SyncSession` — the real app auth gate — plus `active_sessions` registration and MFA detection). The user lands signed in and their newly linked SSO works next time.
 
-**MFA-safe bind.** SSO logins are MFA-exempt, so if the passwordless account has a pending second factor the identity bind is **deferred** (the login still proceeds to the OTP step, emitting `mfa_required`); completing the bind after MFA is the same follow-up as the password interstitial (#3877). Moot for default installs (MFA off), load-bearing for `AUTH_MFA_ENABLED` deployments.
+**MFA-safe bind, completed after the second factor.** SSO logins are MFA-exempt, so if the passwordless account has a pending second factor the identity bind is **deferred** rather than performed at confirm time — a pre-2FA bind would be an MFA-bypassing login path. The authorized bind is stashed by `Auth::Operations::DeferredSsoBind` in a short-TTL `SessionSidecar` key bound to the partial-MFA session's sid (#3858), the login proceeds to the OTP step (emitting `mfa_required`, logged as `sso_link_verification_deferred_mfa`), and `after_two_factor_authentication` (`config/hooks/mfa.rb`) completes the bind once the second factor succeeds — OTP *or* recovery code. Completion is single-use (atomic GETDEL at the store), account-bound, and audit-and-skip on conflict/mismatch (`sso_deferred_bind_completed`): MFA has already succeeded, so nothing on that path may fail the login. For a login that never went through a deferred branch the check is one Redis GETDEL and no DB access. Moot for default installs (MFA off), load-bearing for `AUTH_MFA_ENABLED` deployments. The password interstitial uses the same machinery (#3877/#3879).
 
 **Platform-only.** Like the password interstitial, mailbox-proof linking is only offered on the platform callback path. A tenant admin controls their own IdP and could otherwise trigger link emails to arbitrary platform addresses, so tenant callbacks keep the unchanged H-3 refusal.
 

--- a/lib/onetime/mail/mailer.rb
+++ b/lib/onetime/mail/mailer.rb
@@ -19,6 +19,7 @@ require_relative 'views/secret_revealed'
 require_relative 'views/expiration_warning'
 require_relative 'views/organization_invitation'
 require_relative 'views/magic_link'
+require_relative 'views/sso_link_verification'
 require_relative 'views/email_change_confirmation'
 require_relative 'views/email_change_requested'
 require_relative 'views/email_changed'
@@ -257,6 +258,8 @@ module Onetime
             Templates::ExpirationWarning
           when :organization_invitation
             Templates::OrganizationInvitation
+          when :sso_link_verification
+            Templates::SsoLinkVerification
           when :email_change_confirmation
             Templates::EmailChangeConfirmation
           when :email_change_requested

--- a/lib/onetime/mail/templates/sso_link_verification.html.erb
+++ b/lib/onetime/mail/templates/sso_link_verification.html.erb
@@ -1,0 +1,39 @@
+<%# Body content only. Shared shell, header, and footer come from layout.html.erb. -%>
+<!-- Title -->
+<div style="font-family: Helvetica, Arial, sans-serif; font-size: 24px; color: #374550; margin-bottom: 16px;">
+  <p style="margin: 0;"><%= t('email.sso_link_verification.title') %></p>
+</div>
+
+<!-- Body -->
+<div style="font-family: Helvetica, Arial, sans-serif; font-size: 14px; line-height: 20px; color: #333333;">
+  <p><%= h(t('email.sso_link_verification.request_notice', provider: provider, email_address: email_address, product_name: product_name)) %></p>
+
+  <div style="margin: 24px 0;">
+    <a href="<%= confirm_url %>" style="display: inline-block; padding: 12px 24px; background-color: <%= brand_color %>; color: #ffffff; text-decoration: none; border-radius: 4px; font-weight: bold;" rel="noopener noreferrer">
+      <%= h(t('email.sso_link_verification.confirm_button', provider: provider)) %>
+    </a>
+  </div>
+
+  <p style="color: #666666; font-size: 12px;">
+    <%= t('email.sso_link_verification.copy_link_prompt') %><br />
+    <a href="<%= confirm_url %>" style="color: <%= brand_color %>; word-break: break-all;"><%= confirm_url %></a>
+  </p>
+
+  <p style="color: #666666; background-color: #f5f5f5; padding: 12px; border-radius: 4px; margin-top: 24px;">
+    <%= t('email.sso_link_verification.expiration_notice') %>
+  </p>
+
+  <p style="color: #666666; background-color: #f5f5f5; padding: 12px; border-radius: 4px; margin-top: 12px;">
+    <%= h(t('email.sso_link_verification.ignore_notice', provider: provider)) %>
+  </p>
+</div>
+
+<!-- Signature -->
+<div style="font-family: Helvetica, Arial, sans-serif; font-size: 14px; color: #333333; margin-top: 32px; border-top: 1px solid #eeeeee; padding-top: 16px;">
+  <p style="margin: 0;"><%= h(signature_name || t('email.sso_link_verification.signature')) %></p>
+</div>
+
+<!-- Postscript -->
+<p style="font-family: Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; margin-top: 24px;">
+  <%= h(t('email.sso_link_verification.postscript', email_address: email_address)) %>
+</p>

--- a/lib/onetime/mail/templates/sso_link_verification.txt.erb
+++ b/lib/onetime/mail/templates/sso_link_verification.txt.erb
@@ -1,0 +1,11 @@
+<%= t('email.sso_link_verification.request_notice', provider: provider, email_address: email_address, product_name: product_name) %>
+
+<%= confirm_url %>
+
+<%= t('email.sso_link_verification.expiration_notice') %>
+
+<%= t('email.sso_link_verification.ignore_notice', provider: provider) %>
+
+<%= signature_name || t('email.sso_link_verification.signature') %>
+
+<%= t('email.sso_link_verification.postscript', email_address: email_address) %>

--- a/lib/onetime/mail/views/sso_link_verification.rb
+++ b/lib/onetime/mail/views/sso_link_verification.rb
@@ -1,0 +1,84 @@
+# lib/onetime/mail/views/sso_link_verification.rb
+#
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Onetime
+  module Mail
+    module Templates
+      # SSO link verification (mailbox-proof linking) email template (#3840 Phase 4).
+      #
+      # Sent when an UNAUTHENTICATED SSO sign-in matches an EXISTING PASSWORDLESS
+      # account. Delivered to the account's ON-FILE address; clicking the link proves
+      # mailbox control and binds the SSO identity. The consent copy NAMES the
+      # requesting provider AND the claimed email (criterion 2) so the recipient can
+      # tell exactly what they are authorizing.
+      #
+      # Required data:
+      #   email_address: On-file account email (recipient + claimed-email echo)
+      #   confirm_url:   Full URL of the SPA confirm page (carries the single-use token)
+      #   provider:      OmniAuth provider name that initiated the sign-in
+      #
+      # Optional data:
+      #   baseuri:        Override site base URI
+      #   product_name:   Override product name
+      #   display_domain: Override display domain
+      #
+      class SsoLinkVerification < Base
+        protected
+
+        def validate_data!
+          raise ArgumentError, 'Email address required' unless data[:email_address]
+          raise ArgumentError, 'Confirm URL required' unless data[:confirm_url]
+          raise ArgumentError, 'Provider required' unless data[:provider]
+        end
+
+        public
+
+        def subject
+          EmailTranslations.translate(
+            'email.sso_link_verification.subject',
+            locale: locale,
+            provider: provider,
+            product_name: product_name,
+          )
+        end
+
+        def recipient_email
+          data[:email_address]
+        end
+
+        def confirm_url
+          data[:confirm_url]
+        end
+
+        def provider
+          data[:provider]
+        end
+
+        def email_address
+          data[:email_address]
+        end
+
+        def baseuri
+          data[:baseuri] || site_baseuri
+        end
+
+        private
+
+        def template_binding
+          computed_data = data.merge(
+            confirm_url: confirm_url,
+            provider: provider,
+            email_address: email_address,
+            baseuri: baseuri,
+            product_name: product_name,
+            display_domain: display_domain,
+          )
+          TemplateContext.new(computed_data, locale).get_binding
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/models.rb
+++ b/lib/onetime/models.rb
@@ -17,6 +17,7 @@ require_relative 'models/daily_metric'
 require_relative 'models/email_suppression'
 require_relative 'models/session_metadata'
 require_relative 'models/sso_link_challenge'
+require_relative 'models/sso_link_verification'
 
 # CustomDomain sibling configs — loaded after CustomDomain so the
 # nested-class reopens (`class CustomDomain; class ApiConfig; ...`)

--- a/lib/onetime/models/sso_link_verification.rb
+++ b/lib/onetime/models/sso_link_verification.rb
@@ -1,0 +1,124 @@
+# lib/onetime/models/sso_link_verification.rb
+#
+# frozen_string_literal: true
+
+require 'securerandom'
+
+module Onetime
+  # SsoLinkVerification — a single-use, short-lived capability token that carries a
+  # MAILBOX-PROOF SSO link across the email round-trip (#3840 Phase 4).
+  #
+  # ## Why this exists (sibling of SsoLinkChallenge, different proof)
+  #
+  # When an UNAUTHENTICATED SSO sign-in resolves to an EXISTING local account that
+  # is PASSWORDLESS (no challengeable password), the H-3 refusal in
+  # account_from_omniauth (apps/web/auth/config/hooks/omniauth.rb) would otherwise
+  # dead-end the user at /signin?auth_error=account_exists_link_required. Phase 3's
+  # SsoLinkChallenge cannot help here: it proves ownership by re-entering the
+  # EXISTING PASSWORD, and this account has none.
+  #
+  # A passwordless account CAN still prove ownership: control of the on-file
+  # mailbox — the same proof magic-link (email_auth) uses to authenticate. Phase 4
+  # emails a single-use token to the ACCOUNT's on-file address; clicking it proves
+  # mailbox control and authorizes binding the (provider, issuer, uid) identity.
+  # This honours the invariant "email may LOCATE an account; only a demonstrated
+  # credential may BIND" — mailbox control is the demonstrated credential.
+  #
+  # ## The token travels ONLY via email (security-load-bearing)
+  #
+  # The proof is MAILBOX control, so the token MUST reach the user only through the
+  # emailed link — NEVER through the callback redirect URL. The OmniAuth callback
+  # redirects the browser to a TOKEN-LESS informational state
+  # (/signin?auth_notice=link_verification_sent); the token is delivered solely to
+  # the on-file inbox. A caller who merely completed an SSO round-trip asserting the
+  # victim's email therefore learns nothing that lets them consume the token.
+  #
+  # ## Single-use in time (delete-on-consume + short TTL)
+  #
+  # The token id is the Redis key. The record self-expires after DEFAULT_EXPIRATION
+  # seconds (== 15 min, criterion 3), and POST /auth/sso-link-confirm DELETES it
+  # (#delete!) as the atomic single-use gate BEFORE it binds. Mirrors the shipped
+  # delete-on-consume patterns: SsoLinkChallenge, Customer#pending_plan_intent,
+  # OrganizationMembership#accept!.
+  #
+  # ## Deltas vs SsoLinkChallenge (Phase 3)
+  #
+  #   - TTL is 900s (15 min), not 300s — a human must switch to their inbox, open
+  #     the message, and click, which is slower than entering a password inline.
+  #   - Adds `sid` — the id of the session that INITIATED the SSO round-trip. This
+  #     is a SOFT (compare-and-warn) binding, NOT a hard gate: mailbox proof is
+  #     inherently cross-device (the user may open the link on their phone), so a
+  #     sid mismatch is logged for observability but never rejected.
+  #   - Adds `password_watermark` — a snapshot of the account's
+  #     Customer#last_password_update at issuance. Consume-time re-checks it and
+  #     rejects if it advanced, so ANY credential change (password set/reset/change,
+  #     which all stamp the watermark via Auth::Operations::UpdatePasswordMetadata)
+  #     between issuance and click invalidates the token (criterion 3). This is a
+  #     watermark comparison, not a token-enumeration sweep — no need to find and
+  #     delete outstanding tokens on every credential change.
+  #
+  # ## Not the security boundary
+  #
+  # Possession of a token proves only that SOMEONE completed an SSO round-trip for
+  # this email AND received the email at the on-file inbox. The mailbox delivery is
+  # the boundary; account_id/email/watermark carried here are defence-in-depth
+  # consistency checks re-verified at consume time (Auth::Operations::ConfirmSsoLink),
+  # never the authorization to bind.
+  class SsoLinkVerification < Familia::Horreum
+    feature :expiration
+
+    prefix :sso_link_verification
+    identifier_field :token
+
+    # 15 minutes — criterion 3's TTL ceiling. Covers the human email round-trip
+    # (switch to inbox, open, click) while bounding the abandoned/guessing window.
+    # Raw seconds (no TimeLiterals refinement needed), matching SsoLinkChallenge.
+    DEFAULT_EXPIRATION = 900
+    default_expiration DEFAULT_EXPIRATION
+
+    field :token              # opaque single-use id; also the identifier and Redis key
+    field :provider           # OmniAuth strategy name ('oidc', 'entra', ...) — display + bind
+    field :issuer             # resolved issuer for issuer-scoped binding ('' sentinel allowed)
+    field :uid                # IdP subject (sub) to bind
+    field :email              # normalized on-file email that LOCATED the account — display + login
+    field :account_id         # snapshotted account PK — defence-in-depth consistency check
+    field :sid                # initiating session id — SOFT (compare-and-warn) binding
+    field :password_watermark # Customer#last_password_update snapshot — credential-change guard
+
+    class << self
+      # Mint a new single-use verification token and persist it with its TTL.
+      #
+      # @param provider           [String, Symbol]  OmniAuth strategy name
+      # @param uid                [String]          IdP subject identifier
+      # @param email              [String]          normalized on-file email that located the account
+      # @param account_id         [Integer, String] located account's primary key
+      # @param sid                [String, nil]     initiating session id (soft-bound)
+      # @param password_watermark [Integer, String] Customer#last_password_update at issuance
+      # @param issuer             [String, nil]     resolved issuer ('' sentinel permitted)
+      # @return [SsoLinkVerification] the persisted token (available as #token)
+      def issue(provider:, uid:, email:, account_id:, sid: nil, password_watermark: 0, issuer: nil)
+        verification = new(
+          token: SecureRandom.urlsafe_base64(32),
+          provider: provider.to_s,
+          issuer: issuer.to_s,
+          uid: uid.to_s,
+          email: email.to_s,
+          account_id: account_id.to_s,
+          sid: sid.to_s,
+          password_watermark: password_watermark.to_i.to_s,
+        )
+        verification.save
+        verification
+      end
+    end
+
+    # Display-only projection for GET /auth/sso-link-confirm/:token. Intentionally
+    # omits uid, issuer, account_id, sid, and the watermark — the consent screen
+    # only needs to NAME the requesting provider and echo the claimed email
+    # (criterion 2); nothing else is safe to surface to a caller who merely holds
+    # the token.
+    def to_display
+      { provider: provider, email: email }
+    end
+  end
+end

--- a/locales/content/en/email.json
+++ b/locales/content/en/email.json
@@ -171,39 +171,48 @@
   },
   "email.sso_link_verification.subject": {
     "text": "Confirm linking %{provider} to your %{product_name} account",
-    "renderer": "erb"
+    "renderer": "erb",
+    "content_hash": "65e70296"
   },
   "email.sso_link_verification.title": {
     "text": "Confirm your SSO sign-in",
-    "renderer": "erb"
+    "renderer": "erb",
+    "content_hash": "35bce6cc"
   },
   "email.sso_link_verification.request_notice": {
     "text": "Someone signed in with %{provider} using the email %{email_address}. To finish connecting %{provider} to your %{product_name} account, confirm below.",
-    "renderer": "erb"
+    "renderer": "erb",
+    "content_hash": "baeb18c0"
   },
   "email.sso_link_verification.confirm_button": {
     "text": "Confirm and link %{provider}",
-    "renderer": "erb"
+    "renderer": "erb",
+    "content_hash": "9809e210"
   },
   "email.sso_link_verification.copy_link_prompt": {
     "text": "Or copy and paste this link:",
-    "renderer": "erb"
+    "renderer": "erb",
+    "content_hash": "88c72144"
   },
   "email.sso_link_verification.expiration_notice": {
     "text": "This link expires in 15 minutes and can be used only once.",
-    "renderer": "erb"
+    "renderer": "erb",
+    "content_hash": "1a437f42"
   },
   "email.sso_link_verification.ignore_notice": {
     "text": "If you did not try to sign in with %{provider}, you can safely ignore this email — nothing will be connected to your account.",
-    "renderer": "erb"
+    "renderer": "erb",
+    "content_hash": "d7317d30"
   },
   "email.sso_link_verification.signature": {
     "text": "Support Team",
-    "renderer": "erb"
+    "renderer": "erb",
+    "content_hash": "dc75bf9f"
   },
   "email.sso_link_verification.postscript": {
     "text": "P.S. This email was sent to %{email_address}.",
-    "renderer": "erb"
+    "renderer": "erb",
+    "content_hash": "8ab1dbea"
   },
   "email.incoming_secret.subject": {
     "text": "You've received a secret message",

--- a/locales/content/en/email.json
+++ b/locales/content/en/email.json
@@ -169,6 +169,42 @@
     "renderer": "erb",
     "content_hash": "8ab1dbea"
   },
+  "email.sso_link_verification.subject": {
+    "text": "Confirm linking %{provider} to your %{product_name} account",
+    "renderer": "erb"
+  },
+  "email.sso_link_verification.title": {
+    "text": "Confirm your SSO sign-in",
+    "renderer": "erb"
+  },
+  "email.sso_link_verification.request_notice": {
+    "text": "Someone signed in with %{provider} using the email %{email_address}. To finish connecting %{provider} to your %{product_name} account, confirm below.",
+    "renderer": "erb"
+  },
+  "email.sso_link_verification.confirm_button": {
+    "text": "Confirm and link %{provider}",
+    "renderer": "erb"
+  },
+  "email.sso_link_verification.copy_link_prompt": {
+    "text": "Or copy and paste this link:",
+    "renderer": "erb"
+  },
+  "email.sso_link_verification.expiration_notice": {
+    "text": "This link expires in 15 minutes and can be used only once.",
+    "renderer": "erb"
+  },
+  "email.sso_link_verification.ignore_notice": {
+    "text": "If you did not try to sign in with %{provider}, you can safely ignore this email — nothing will be connected to your account.",
+    "renderer": "erb"
+  },
+  "email.sso_link_verification.signature": {
+    "text": "Support Team",
+    "renderer": "erb"
+  },
+  "email.sso_link_verification.postscript": {
+    "text": "P.S. This email was sent to %{email_address}.",
+    "renderer": "erb"
+  },
   "email.incoming_secret.subject": {
     "text": "You've received a secret message",
     "renderer": "erb",

--- a/locales/content/en/session-auth-extended.json
+++ b/locales/content/en/session-auth-extended.json
@@ -493,47 +493,58 @@
   },
   "web.sso_link_confirm.title": {
     "text": "Confirm connecting your account",
-    "context": "Heading + page title for the #3840 Phase 4 mailbox-proof SSO linking consent page. Reached via a link emailed to a PASSWORDLESS account whose email matched an SSO sign-in; opening the link proves mailbox control."
+    "context": "Heading + page title for the #3840 Phase 4 mailbox-proof SSO linking consent page. Reached via a link emailed to a PASSWORDLESS account whose email matched an SSO sign-in; opening the link proves mailbox control.",
+    "content_hash": "ad80bfe7"
   },
   "web.sso_link_confirm.prompt": {
     "text": "You signed in with {provider}, which matches your account {email}. Confirm to connect {provider} to this account and finish signing in.",
-    "context": "Consent instruction on the #3840 Phase 4 mailbox-proof SSO linking page. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/sso-link-confirm/:token. No password is asked — clicking the emailed link is the proof."
+    "context": "Consent instruction on the #3840 Phase 4 mailbox-proof SSO linking page. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/sso-link-confirm/:token. No password is asked — clicking the emailed link is the proof.",
+    "content_hash": "6ff0d6cc"
   },
   "web.sso_link_confirm.submit": {
     "text": "Confirm and connect",
-    "context": "Primary CTA on the #3840 Phase 4 mailbox-proof SSO linking page. Triggers POST /auth/sso-link-confirm: binds the SSO identity and signs the user in. There is no password field — mailbox possession is the proof."
+    "context": "Primary CTA on the #3840 Phase 4 mailbox-proof SSO linking page. Triggers POST /auth/sso-link-confirm: binds the SSO identity and signs the user in. There is no password field — mailbox possession is the proof.",
+    "content_hash": "5cf663e6"
   },
   "web.sso_link_confirm.cancel": {
     "text": "Cancel",
-    "context": "Cancel action on the #3840 Phase 4 mailbox-proof SSO linking page; abandons linking and returns the user to the sign-in page."
+    "context": "Cancel action on the #3840 Phase 4 mailbox-proof SSO linking page; abandons linking and returns the user to the sign-in page.",
+    "content_hash": "19766ed6"
   },
   "web.sso_link_confirm.unavailable_title": {
     "text": "This linking request can't be completed",
-    "context": "Heading of the terminal panel on the #3840 Phase 4 mailbox-proof SSO linking page, shown when the single-use token is missing/expired/used or the confirm fails (conflict / credentials changed)."
+    "context": "Heading of the terminal panel on the #3840 Phase 4 mailbox-proof SSO linking page, shown when the single-use token is missing/expired/used or the confirm fails (conflict / credentials changed).",
+    "content_hash": "47abb784"
   },
   "web.sso_link_confirm.unavailable_message": {
     "text": "For your security, this request to connect your sign-in method is no longer valid. Sign in with your provider again and we'll email you a fresh link.",
-    "context": "Default body of the terminal panel on the #3840 Phase 4 mailbox-proof SSO linking page (e.g. the token was missing from the URL). A specific error message replaces this when the failure was classified."
+    "context": "Default body of the terminal panel on the #3840 Phase 4 mailbox-proof SSO linking page (e.g. the token was missing from the URL). A specific error message replaces this when the failure was classified.",
+    "content_hash": "080e6f9f"
   },
   "web.sso_link_confirm.unavailable_action": {
     "text": "Return to sign in",
-    "context": "Primary action on the terminal panel of the #3840 Phase 4 mailbox-proof SSO linking page; routes to /signin so a passwordless user can start SSO again (which re-issues the email)."
+    "context": "Primary action on the terminal panel of the #3840 Phase 4 mailbox-proof SSO linking page; routes to /signin so a passwordless user can start SSO again (which re-issues the email).",
+    "content_hash": "8504054f"
   },
   "web.sso_link_confirm.errors.link_expired": {
     "text": "This linking request has expired or was already used. Sign in with your provider again and we'll email you a fresh link.",
-    "context": "Terminal error on the #3840 Phase 4 mailbox-proof SSO linking page when the single-use token is missing, expired, or already consumed (backend error_code link_expired; also the GET dead-end)."
+    "context": "Terminal error on the #3840 Phase 4 mailbox-proof SSO linking page when the single-use token is missing, expired, or already consumed (backend error_code link_expired; also the GET dead-end).",
+    "content_hash": "a50538df"
   },
   "web.sso_link_confirm.errors.link_conflict": {
     "text": "We couldn't connect this sign-in method. Your account may have changed, or this provider is already linked to another account. Sign in with your provider again to continue.",
-    "context": "Terminal error on the #3840 Phase 4 mailbox-proof SSO linking page when the account was re-emailed since the link was issued, or the identity is already bound to a different account (backend error_code link_conflict, HTTP 409)."
+    "context": "Terminal error on the #3840 Phase 4 mailbox-proof SSO linking page when the account was re-emailed since the link was issued, or the identity is already bound to a different account (backend error_code link_conflict, HTTP 409).",
+    "content_hash": "c954854b"
   },
   "web.sso_link_confirm.errors.link_invalidated": {
     "text": "Your account credentials changed after this link was sent, so it's no longer valid. Sign in with your provider again and we'll email you a fresh link.",
-    "context": "Terminal error on the #3840 Phase 4 mailbox-proof SSO linking page when a credential change advanced the account's password watermark after the token was issued (backend error_code link_invalidated, HTTP 409)."
+    "context": "Terminal error on the #3840 Phase 4 mailbox-proof SSO linking page when a credential change advanced the account's password watermark after the token was issued (backend error_code link_invalidated, HTTP 409).",
+    "content_hash": "db88cb1d"
   },
   "web.sso_link_confirm.errors.generic": {
     "text": "We couldn't confirm this connection. Please sign in with your provider again.",
-    "context": "Fallback error for #3840 Phase 4 mailbox-proof SSO linking page failures that are neither expired, a conflict, nor a credential change (e.g. an unexpected server error or a missing token)."
+    "context": "Fallback error for #3840 Phase 4 mailbox-proof SSO linking page failures that are neither expired, a conflict, nor a credential change (e.g. an unexpected server error or a missing token).",
+    "content_hash": "076fa25a"
   },
   "web.auth.lockout.attempts_remaining": {
     "text": "Warning: {count} login attempt(s) remaining",

--- a/locales/content/en/session-auth-extended.json
+++ b/locales/content/en/session-auth-extended.json
@@ -541,6 +541,11 @@
     "context": "Terminal error on the #3840 Phase 4 mailbox-proof SSO linking page when a credential change advanced the account's password watermark after the token was issued (backend error_code link_invalidated, HTTP 409).",
     "content_hash": "db88cb1d"
   },
+  "web.sso_link_confirm.errors.link_error": {
+    "text": "Something went wrong on our side and we couldn't verify this link. Sign in with your provider again and we'll email you a fresh one.",
+    "context": "Terminal error on the #3840 Phase 4 mailbox-proof SSO linking page when the backend could not READ the account's password watermark (datastore outage / unresolvable customer record) — an infrastructure failure, NOT a credential change (backend error_code link_error, HTTP 409). Deliberately distinct from errors.link_invalidated so a transient outage is never reported as 'your credentials changed'.",
+    "content_hash": "ec24e0a1"
+  },
   "web.sso_link_confirm.errors.generic": {
     "text": "We couldn't confirm this connection. Please sign in with your provider again.",
     "context": "Fallback error for #3840 Phase 4 mailbox-proof SSO linking page failures that are neither expired, a conflict, nor a credential change (e.g. an unexpected server error or a missing token).",

--- a/locales/content/en/session-auth-extended.json
+++ b/locales/content/en/session-auth-extended.json
@@ -491,6 +491,50 @@
     "context": "Fallback error for #3840 Phase 3 sign-in interstitial challenge-context / verify failures that are neither a wrong password nor an expired token.",
     "content_hash": "f727c174"
   },
+  "web.sso_link_confirm.title": {
+    "text": "Confirm connecting your account",
+    "context": "Heading + page title for the #3840 Phase 4 mailbox-proof SSO linking consent page. Reached via a link emailed to a PASSWORDLESS account whose email matched an SSO sign-in; opening the link proves mailbox control."
+  },
+  "web.sso_link_confirm.prompt": {
+    "text": "You signed in with {provider}, which matches your account {email}. Confirm to connect {provider} to this account and finish signing in.",
+    "context": "Consent instruction on the #3840 Phase 4 mailbox-proof SSO linking page. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/sso-link-confirm/:token. No password is asked — clicking the emailed link is the proof."
+  },
+  "web.sso_link_confirm.submit": {
+    "text": "Confirm and connect",
+    "context": "Primary CTA on the #3840 Phase 4 mailbox-proof SSO linking page. Triggers POST /auth/sso-link-confirm: binds the SSO identity and signs the user in. There is no password field — mailbox possession is the proof."
+  },
+  "web.sso_link_confirm.cancel": {
+    "text": "Cancel",
+    "context": "Cancel action on the #3840 Phase 4 mailbox-proof SSO linking page; abandons linking and returns the user to the sign-in page."
+  },
+  "web.sso_link_confirm.unavailable_title": {
+    "text": "This linking request can't be completed",
+    "context": "Heading of the terminal panel on the #3840 Phase 4 mailbox-proof SSO linking page, shown when the single-use token is missing/expired/used or the confirm fails (conflict / credentials changed)."
+  },
+  "web.sso_link_confirm.unavailable_message": {
+    "text": "For your security, this request to connect your sign-in method is no longer valid. Sign in with your provider again and we'll email you a fresh link.",
+    "context": "Default body of the terminal panel on the #3840 Phase 4 mailbox-proof SSO linking page (e.g. the token was missing from the URL). A specific error message replaces this when the failure was classified."
+  },
+  "web.sso_link_confirm.unavailable_action": {
+    "text": "Return to sign in",
+    "context": "Primary action on the terminal panel of the #3840 Phase 4 mailbox-proof SSO linking page; routes to /signin so a passwordless user can start SSO again (which re-issues the email)."
+  },
+  "web.sso_link_confirm.errors.link_expired": {
+    "text": "This linking request has expired or was already used. Sign in with your provider again and we'll email you a fresh link.",
+    "context": "Terminal error on the #3840 Phase 4 mailbox-proof SSO linking page when the single-use token is missing, expired, or already consumed (backend error_code link_expired; also the GET dead-end)."
+  },
+  "web.sso_link_confirm.errors.link_conflict": {
+    "text": "We couldn't connect this sign-in method. Your account may have changed, or this provider is already linked to another account. Sign in with your provider again to continue.",
+    "context": "Terminal error on the #3840 Phase 4 mailbox-proof SSO linking page when the account was re-emailed since the link was issued, or the identity is already bound to a different account (backend error_code link_conflict, HTTP 409)."
+  },
+  "web.sso_link_confirm.errors.link_invalidated": {
+    "text": "Your account credentials changed after this link was sent, so it's no longer valid. Sign in with your provider again and we'll email you a fresh link.",
+    "context": "Terminal error on the #3840 Phase 4 mailbox-proof SSO linking page when a credential change advanced the account's password watermark after the token was issued (backend error_code link_invalidated, HTTP 409)."
+  },
+  "web.sso_link_confirm.errors.generic": {
+    "text": "We couldn't confirm this connection. Please sign in with your provider again.",
+    "context": "Fallback error for #3840 Phase 4 mailbox-proof SSO linking page failures that are neither expired, a conflict, nor a credential change (e.g. an unexpected server error or a missing token)."
+  },
   "web.auth.lockout.attempts_remaining": {
     "text": "Warning: {count} login attempt(s) remaining",
     "content_hash": "151dcb5e"

--- a/locales/content/en/session-auth.json
+++ b/locales/content/en/session-auth.json
@@ -148,6 +148,10 @@
     "context": "Shown on /signin after the #3840 Phase 3 sign-in interstitial is cancelled, its challenge token expires/is spent, or password linking otherwise dead-ends. Points the user at the Phase 2 Connected Identities flow; the interstitial routes here with ?redirect=/account/settings/security/connections so the panel opens after they sign in.",
     "content_hash": "49954127"
   },
+  "web.login.notices.link_verification_sent": {
+    "text": "Check your inbox — we emailed you a link to confirm connecting your account. Open it to finish signing in.",
+    "context": "Informational (non-error) notice shown on /signin via ?auth_notice=link_verification_sent after a passwordless account's SSO sign-in triggers a mailbox-proof linking email (#3840 Phase 4). The emailed link opens the /sso-link-confirm/:token consent page."
+  },
   "web.login.signin_disabled_heading": {
     "text": "Sign-in is not available",
     "context": "Page heading on /signin when sign-in is disabled for the current domain (per-domain SigninConfig).",

--- a/locales/content/en/session-auth.json
+++ b/locales/content/en/session-auth.json
@@ -150,7 +150,8 @@
   },
   "web.login.notices.link_verification_sent": {
     "text": "Check your inbox — we emailed you a link to confirm connecting your account. Open it to finish signing in.",
-    "context": "Informational (non-error) notice shown on /signin via ?auth_notice=link_verification_sent after a passwordless account's SSO sign-in triggers a mailbox-proof linking email (#3840 Phase 4). The emailed link opens the /sso-link-confirm/:token consent page."
+    "context": "Informational (non-error) notice shown on /signin via ?auth_notice=link_verification_sent after a passwordless account's SSO sign-in triggers a mailbox-proof linking email (#3840 Phase 4). The emailed link opens the /sso-link-confirm/:token consent page.",
+    "content_hash": "b251c8f3"
   },
   "web.login.signin_disabled_heading": {
     "text": "Sign-in is not available",

--- a/spec/unit/auth/confirm_sso_link_spec.rb
+++ b/spec/unit/auth/confirm_sso_link_spec.rb
@@ -1,0 +1,256 @@
+# spec/unit/auth/confirm_sso_link_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sequel'
+require 'auth/operations/confirm_sso_link'
+
+# Unit tests for Auth::Operations::ConfirmSsoLink — the orchestration step of the
+# #3840 Phase 4 mailbox-proof passwordless linking flow: load -> atomic single-use
+# consume -> re-verify ownership + credential watermark -> (MFA gate) -> bind.
+#
+# Mirrors the real-DB approach of the Phase 4.0 bind_sso_identity spec: the accounts
+# / account_identities / OTP tables are a REAL in-memory SQLite carrying the REAL
+# (provider, issuer, uid) unique index, while the token is a REAL Familia record on
+# the test database (port 2121) and the watermark reads a REAL Onetime::Customer.
+# The end-to-end HTTP path (issue -> email -> confirm -> login) is Wave 2.
+RSpec.describe Auth::Operations::ConfirmSsoLink do
+  let(:db)         { build_auth_db }
+  let(:identities) { db[:account_identities] }
+
+  let(:account_id) { 42 }
+  let(:email)      { 'user@example.com' }
+  let(:provider)   { 'google' }
+  let(:issuer)     { 'https://accounts.google.com' }
+  let(:uid)        { 'sub-123' }
+  let(:sid)        { 'a' * 64 }
+
+  let(:tokens)    { [] }
+  let(:customers) { [] }
+
+  # Minimal real SQLite mirroring the columns the op + BindSsoIdentity + MfaStateChecker
+  # touch. Kept local (not RodauthTestHelper) so this stays in the top-level unit lane
+  # where Familia is connected to Valkey.
+  def build_auth_db
+    db = Sequel.sqlite
+    db.create_table(:accounts) do
+      primary_key :id, type: :Bignum
+      String :email, null: false
+      String :external_id
+      Integer :status_id, null: false, default: 2
+    end
+    db.create_table(:account_identities) do
+      primary_key :id, type: :Bignum
+      foreign_key :account_id, :accounts, type: :Bignum, null: false
+      String :provider, null: false
+      String :issuer, null: false, default: ''
+      String :uid, null: false
+      index %i[provider issuer uid], unique: true
+    end
+    db.create_table(:account_otp_keys) do
+      foreign_key :id, :accounts, primary_key: true, type: :Bignum
+      String :key, null: false
+      Integer :num_failures, null: false, default: 0
+      Time :last_use, null: false, default: Sequel::CURRENT_TIMESTAMP
+    end
+    db.create_table(:account_recovery_codes) do
+      foreign_key :id, :accounts, type: :Bignum
+      String :code
+      primary_key %i[id code]
+    end
+    db
+  end
+
+  def seed_account(id: account_id, account_email: email, external_id: nil, status_id: 2)
+    db[:accounts].insert(id: id, email: account_email, external_id: external_id, status_id: status_id)
+    id
+  end
+
+  def issue_token(**overrides)
+    record = Onetime::SsoLinkVerification.issue(
+      provider: provider,
+      uid: uid,
+      email: overrides.fetch(:email, email),
+      account_id: overrides.fetch(:account_id, account_id),
+      sid: overrides.fetch(:sid, sid),
+      password_watermark: overrides.fetch(:password_watermark, 0),
+      issuer: issuer,
+    )
+    tokens << record
+    record.token
+  end
+
+  def confirm(token, current_sid: sid, mfa_feature_loaded: false)
+    described_class.call(
+      db: db, token: token, current_sid: current_sid, mfa_feature_loaded: mfa_feature_loaded,
+    )
+  end
+
+  # Unique email per example so Customer's unique email-index (which delete! does
+  # not fully clear on the test DB) never collides across runs.
+  def unique_email(prefix)
+    "#{prefix}-#{SecureRandom.hex(4)}@example.com"
+  end
+
+  def customer_with_watermark(customer_email, watermark)
+    customer = Onetime::Customer.create!(customer_email)
+    customers << customer
+    customer.last_password_update! watermark
+    customer
+  end
+
+  # Capture every audit event name emitted during the block's op call.
+  def with_captured_events
+    events = []
+    allow(Auth::Logging).to receive(:log_auth_event).and_wrap_original do |orig, event, **kw|
+      events << event
+      orig.call(event, **kw)
+    end
+    events
+  end
+
+  after do
+    tokens.each { |t| Onetime::SsoLinkVerification.load(t)&.delete! rescue nil }
+    customers.each { |c| c.delete! rescue nil }
+  end
+
+  describe 'fresh confirmation (happy path)' do
+    it 'binds the identity, returns :ok bound with account context, and audits the consume' do
+      seed_account
+      events = with_captured_events
+      token  = issue_token
+
+      result = confirm(token)
+
+      expect(result).to have_attributes(
+        status: :ok, bound: true, second_factor_pending: false,
+        account_id: account_id.to_s, email: email, provider: provider,
+      )
+      expect(result.ok?).to be(true)
+
+      rows = identities.where(provider: provider, issuer: issuer, uid: uid).all
+      expect(rows.size).to eq(1)
+      expect(rows.first[:account_id]).to eq(account_id)
+
+      expect(events).to include(:sso_link_verification_confirmed)
+    end
+  end
+
+  describe 'single-use consume' do
+    it 'succeeds once then reports :link_expired on a second confirmation of the same token' do
+      seed_account
+      token = issue_token
+
+      expect(confirm(token).status).to eq(:ok)
+      expect(confirm(token).status).to eq(:link_expired)
+
+      # The winning bind is the only row — the second call bound nothing.
+      expect(identities.where(provider: provider, issuer: issuer, uid: uid).count).to eq(1)
+    end
+  end
+
+  describe 'missing / vanished' do
+    it 'returns :link_expired for an unknown token' do
+      seed_account
+      expect(confirm('does-not-exist').status).to eq(:link_expired)
+    end
+
+    it 'returns :link_expired when the snapshotted account no longer exists' do
+      token = issue_token # no account seeded
+      expect(confirm(token).status).to eq(:link_expired)
+    end
+  end
+
+  describe 'soft, cross-device session binding' do
+    it 'confirms with NO cross-device warning when the current sid matches the initiating sid' do
+      seed_account
+      events = with_captured_events
+      token  = issue_token(sid: sid)
+
+      expect(confirm(token, current_sid: sid).status).to eq(:ok)
+      expect(events).not_to include(:sso_link_verification_cross_device)
+    end
+
+    it 'still confirms (soft path) but warns when the current sid differs from the initiating sid' do
+      seed_account
+      events = with_captured_events
+      token  = issue_token(sid: sid)
+
+      result = confirm(token, current_sid: 'f' * 64)
+      expect(result.status).to eq(:ok)
+      expect(result.bound).to be(true)
+      expect(events).to include(:sso_link_verification_cross_device)
+    end
+  end
+
+  describe 'conflict handling' do
+    it 'returns :link_conflict without binding when the identity is owned by a DIFFERENT account' do
+      seed_account
+      other = seed_account(id: 999, account_email: 'other@example.com')
+      identities.insert(provider: provider, issuer: issuer, uid: uid, account_id: other)
+
+      expect(confirm(issue_token).status).to eq(:link_conflict)
+
+      # The existing row still belongs to the other account — nothing rebound.
+      row = identities.where(provider: provider, issuer: issuer, uid: uid).first
+      expect(row[:account_id]).to eq(other)
+    end
+
+    it 'returns :link_conflict when the account was re-emailed since issuance (no bind)' do
+      seed_account(account_email: 'changed@example.com')
+      token = issue_token(email: email) # token still carries the OLD email
+
+      expect(confirm(token).status).to eq(:link_conflict)
+      expect(identities.where(provider: provider, issuer: issuer, uid: uid).count).to eq(0)
+    end
+  end
+
+  describe 'credential-change invalidation (watermark)' do
+    it 'returns :link_invalidated when the account watermark advanced after issuance' do
+      wm_email = unique_email('wm-adv')
+      customer = customer_with_watermark(wm_email, 200)
+
+      seed_account(account_email: wm_email, external_id: customer.extid)
+      token = issue_token(email: wm_email, password_watermark: 100)
+
+      expect(confirm(token).status).to eq(:link_invalidated)
+      expect(identities.where(provider: provider, issuer: issuer, uid: uid).count).to eq(0)
+    end
+
+    it 'confirms when the watermark is unchanged since issuance' do
+      wm_email = unique_email('wm-eq')
+      customer = customer_with_watermark(wm_email, 150)
+
+      seed_account(account_email: wm_email, external_id: customer.extid)
+      token = issue_token(email: wm_email, password_watermark: 150)
+
+      expect(confirm(token).status).to eq(:ok)
+    end
+  end
+
+  describe 'MFA-safe bind' do
+    it 'DEFERS the bind (bound: false) when a second factor is pending' do
+      seed_account
+      db[:account_otp_keys].insert(id: account_id, key: 'otpsecret', num_failures: 0)
+      events = with_captured_events
+      token  = issue_token
+
+      result = confirm(token, mfa_feature_loaded: true)
+
+      expect(result).to have_attributes(status: :ok, bound: false, second_factor_pending: true)
+      # No identity bound this round — the deferred-MFA follow-up completes it.
+      expect(identities.where(provider: provider, issuer: issuer, uid: uid).count).to eq(0)
+      expect(events).to include(:sso_link_verification_deferred_mfa)
+    end
+
+    it 'binds normally when the OTP feature is not loaded even if an OTP row exists' do
+      seed_account
+      db[:account_otp_keys].insert(id: account_id, key: 'otpsecret', num_failures: 0)
+
+      result = confirm(issue_token, mfa_feature_loaded: false)
+      expect(result).to have_attributes(status: :ok, bound: true)
+      expect(identities.where(provider: provider, issuer: issuer, uid: uid).count).to eq(1)
+    end
+  end
+end

--- a/spec/unit/auth/confirm_sso_link_spec.rb
+++ b/spec/unit/auth/confirm_sso_link_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe Auth::Operations::ConfirmSsoLink do
   let(:identities) { db[:account_identities] }
 
   let(:account_id) { 42 }
-  let(:email)      { 'user@example.com' }
+  # Unique per example: seed_account pairs a REAL Customer with this address, and
+  # the test Customer email-index outlives delete! (see unique_email below).
+  let(:email)      { unique_email('confirm') }
   let(:provider)   { 'google' }
   let(:issuer)     { 'https://accounts.google.com' }
   let(:uid)        { 'sub-123' }
@@ -62,7 +64,13 @@ RSpec.describe Auth::Operations::ConfirmSsoLink do
     db
   end
 
-  def seed_account(id: account_id, account_email: email, external_id: nil, status_id: 2)
+  # Pairs a REAL Customer with the account by default. Any account that reaches the
+  # watermark probe NEEDS one: watermark_state fails SECURE on an unresolvable
+  # Customer (:link_error), the same pairing the mailbox-proof integration spec
+  # seeds. Callers whose account never reaches the probe — or that are proving the
+  # unresolvable case itself — pass with_customer: false.
+  def seed_account(id: account_id, account_email: email, external_id: nil, status_id: 2, with_customer: true)
+    external_id ||= customer_with_watermark(account_email, 0).extid if with_customer
     db[:accounts].insert(id: id, email: account_email, external_id: external_id, status_id: status_id)
     id
   end
@@ -187,7 +195,9 @@ RSpec.describe Auth::Operations::ConfirmSsoLink do
   describe 'conflict handling' do
     it 'returns :link_conflict without binding when the identity is owned by a DIFFERENT account' do
       seed_account
-      other = seed_account(id: 999, account_email: 'other@example.com')
+      # The rival owner is never probed (the confirm targets account_id), so no
+      # paired Customer — and none minted under a fixed, colliding address.
+      other = seed_account(id: 999, account_email: 'other@example.com', with_customer: false)
       identities.insert(provider: provider, issuer: issuer, uid: uid, account_id: other)
 
       expect(confirm(issue_token).status).to eq(:link_conflict)
@@ -198,7 +208,8 @@ RSpec.describe Auth::Operations::ConfirmSsoLink do
     end
 
     it 'returns :link_conflict when the account was re-emailed since issuance (no bind)' do
-      seed_account(account_email: 'changed@example.com')
+      # Email drift is caught BEFORE the watermark probe, so no paired Customer.
+      seed_account(account_email: 'changed@example.com', with_customer: false)
       token = issue_token(email: email) # token still carries the OLD email
 
       expect(confirm(token).status).to eq(:link_conflict)
@@ -226,6 +237,60 @@ RSpec.describe Auth::Operations::ConfirmSsoLink do
       token = issue_token(email: wm_email, password_watermark: 150)
 
       expect(confirm(token).status).to eq(:ok)
+    end
+  end
+
+  # An UNREADABLE watermark is not a pass — the guard exists precisely to be certain
+  # the credential did not change, and both unreadable shapes (a raising probe and
+  # an unresolvable Customer) must reject. Load-bearing: without these the probe
+  # could regress to fail-OPEN and every other example would stay green.
+  #
+  # They reject as :link_error, NOT :link_invalidated: a datastore outage is our
+  # failure, and reporting it as "your credentials changed" sends the user hunting
+  # for a change that never happened. The rejection is identical either way — what
+  # differs is only the blame the copy assigns.
+  describe 'unreadable watermark (probe failure, distinct from a credential change)' do
+    it 'REJECTS as :link_error when the watermark probe RAISES (fail-secure)' do
+      seed_account(with_customer: false)
+      events = with_captured_events
+      token  = issue_token
+
+      # Stub scoped to this example only — the suite runs against a REAL datastore.
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email)
+        .and_raise(StandardError.new('datastore unreachable'))
+
+      expect(confirm(token).status).to eq(:link_error)
+      expect(identities.where(provider: provider, issuer: issuer, uid: uid).count).to eq(0)
+      expect(events).to include(:sso_link_verification_watermark_probe_error)
+      # The probe's own event carries the reason, so the terminal path adds none —
+      # an outage must never be audited as a credential-change invalidation.
+      expect(events).not_to include(:sso_link_verification_invalidated)
+
+      # Consume-before-probe: the token was already spent by the atomic #delete!,
+      # so the rejection costs the attempt rather than leaving a retryable token.
+      # This is why :link_error is terminal (409) and not a retryable 5xx.
+      expect(confirm(token).status).to eq(:link_expired)
+    end
+
+    it 'REJECTS as :link_error when the Customer does not resolve (fail-secure)' do
+      # No stub: the account is seeded WITHOUT its paired Customer, so the real
+      # lookup returns nil — the production shape (record absent / index miss),
+      # which a `&.last_password_update.to_i` would have read as watermark 0.
+      seed_account(with_customer: false)
+      events = with_captured_events
+      token  = issue_token
+
+      result = confirm(token)
+      expect(result.status).to eq(:link_error)
+      # Context still travels with the rejection (the route logs it).
+      expect(result).to have_attributes(
+        account_id: account_id.to_s, provider: provider, bound: false,
+      )
+      expect(identities.where(provider: provider, issuer: issuer, uid: uid).count).to eq(0)
+      expect(events).to include(:sso_link_verification_watermark_probe_missing)
+      expect(events).not_to include(:sso_link_verification_invalidated)
+
+      expect(confirm(token).status).to eq(:link_expired)
     end
   end
 

--- a/spec/unit/auth/sso_link_confirm_route_spec.rb
+++ b/spec/unit/auth/sso_link_confirm_route_spec.rb
@@ -1,0 +1,227 @@
+# spec/unit/auth/sso_link_confirm_route_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sequel'
+require 'json'
+require 'roda'
+require 'rack/test'
+require 'auth/routes/sso_link_confirm'
+
+# Route-level tests for Auth::Routes::SsoLinkConfirm (#3840 Phase 4).
+#
+# A minimal Roda app includes the route module and drives it with Rack::Test,
+# against a REAL in-memory SQLite (accounts / account_identities) and a REAL
+# Familia token — the same real-DB posture as the bind_sso_identity spec. Rodauth
+# is a small fake exposing only the surface the route uses (db, account_from_login,
+# login, session, respond_to?). This locks the request parsing and the
+# op-result -> HTTP/JSON mapping. The success path's session-establishing
+# rodauth.login is stubbed to return a login body (the real Rodauth THROWS it); the
+# genuine throw + after_login wiring is exercised by the Wave 2 full-boot spec.
+RSpec.describe Auth::Routes::SsoLinkConfirm, type: :rack do
+  include Rack::Test::Methods
+
+  let(:db)         { build_auth_db }
+  let(:identities) { db[:account_identities] }
+
+  let(:account_id) { 42 }
+  let(:email)      { 'user@example.com' }
+  let(:provider)   { 'google' }
+  let(:issuer)     { 'https://accounts.google.com' }
+  let(:uid)        { 'sub-123' }
+  let(:sid)        { 'a' * 64 }
+
+  let(:tokens)   { [] }
+  let(:otp)      { false }
+  let(:account_found) { true }
+  let(:rodauth)  { FakeRodauth.new(db: db, otp: otp, account_found: account_found) }
+
+  # ── minimal Rodauth stand-in ──────────────────────────────────────────────
+  class FakeRodauth
+    attr_reader :db, :login_calls, :account_from_login_calls
+
+    def initialize(db:, otp: false, account_found: true)
+      @db                       = db
+      @otp                      = otp
+      @account_found            = account_found
+      @login_calls              = []
+      @account_from_login_calls = []
+    end
+
+    def respond_to?(name, include_all = false)
+      return @otp if name == :otp_auth_route
+
+      super
+    end
+
+    def session
+      nil # -> route's current-sid resolver rescues to nil (soft check skipped)
+    end
+
+    def account_from_login(login)
+      @account_from_login_calls << login
+      @account_found
+    end
+
+    def login(auth_type)
+      @login_calls << auth_type
+      { success: true } # real Rodauth THROWS this; returning it is fine for the mapping test
+    end
+  end
+
+  def null_logger
+    @null_logger ||= Class.new do
+      def method_missing(*); nil; end
+      def respond_to_missing?(*); true; end
+    end.new
+  end
+
+  def app
+    rd  = rodauth
+    log = null_logger
+    Class.new(Roda) do
+      plugin :json
+      plugin :halt
+      include Auth::Routes::SsoLinkConfirm
+      define_method(:rodauth) { rd }
+      define_method(:auth_logger) { log }
+      route do |r|
+        handle_sso_link_confirm_routes(r)
+      end
+    end
+  end
+
+  def build_auth_db
+    db = Sequel.sqlite
+    db.create_table(:accounts) do
+      primary_key :id, type: :Bignum
+      String :email, null: false
+      String :external_id
+      Integer :status_id, null: false, default: 2
+    end
+    db.create_table(:account_identities) do
+      primary_key :id, type: :Bignum
+      foreign_key :account_id, :accounts, type: :Bignum, null: false
+      String :provider, null: false
+      String :issuer, null: false, default: ''
+      String :uid, null: false
+      index %i[provider issuer uid], unique: true
+    end
+    db
+  end
+
+  def seed_account(id: account_id, account_email: email, external_id: nil)
+    db[:accounts].insert(id: id, email: account_email, external_id: external_id, status_id: 2)
+    id
+  end
+
+  def issue_token(**overrides)
+    record = Onetime::SsoLinkVerification.issue(
+      provider: provider,
+      uid: uid,
+      email: overrides.fetch(:email, email),
+      account_id: overrides.fetch(:account_id, account_id),
+      sid: sid,
+      password_watermark: overrides.fetch(:password_watermark, 0),
+      issuer: issuer,
+    )
+    tokens << record.token
+    record.token
+  end
+
+  def json_post(token)
+    post '/sso-link-confirm', JSON.generate({ token: token }), { 'CONTENT_TYPE' => 'application/json' }
+  end
+
+  def body
+    JSON.parse(last_response.body)
+  end
+
+  after do
+    tokens.each { |t| Onetime::SsoLinkVerification.load(t)&.delete! rescue nil }
+  end
+
+  describe 'GET /sso-link-confirm/:token (consent display)' do
+    it 'returns ONLY provider + claimed email and does NOT consume the token' do
+      token = issue_token
+
+      get "/sso-link-confirm/#{token}"
+
+      expect(last_response.status).to eq(200)
+      expect(body).to eq('provider' => provider, 'email' => email)
+      # Display must never consume — the token is still loadable.
+      expect(Onetime::SsoLinkVerification.load(token)).not_to be_nil
+    end
+
+    it 'returns 404 link_expired for an unknown token' do
+      get '/sso-link-confirm/nope'
+      expect(last_response.status).to eq(404)
+      expect(body['error_code']).to eq('link_expired')
+    end
+  end
+
+  describe 'POST /sso-link-confirm (confirm)' do
+    it 'rejects a missing token with 400 invalid_request' do
+      post '/sso-link-confirm', JSON.generate({}), { 'CONTENT_TYPE' => 'application/json' }
+      expect(last_response.status).to eq(400)
+      expect(body['error_code']).to eq('invalid_request')
+    end
+
+    it 'rejects an already-consumed / unknown token with 401 link_expired' do
+      json_post('does-not-exist')
+      expect(last_response.status).to eq(401)
+      expect(body['error_code']).to eq('link_expired')
+    end
+
+    it 'maps an identity owned by a different account to 409 link_conflict' do
+      seed_account
+      other = seed_account(id: 999, account_email: 'other@example.com')
+      identities.insert(provider: provider, issuer: issuer, uid: uid, account_id: other)
+
+      json_post(issue_token)
+      expect(last_response.status).to eq(409)
+      expect(body['error_code']).to eq('link_conflict')
+    end
+
+    it 'maps a credential-change watermark advance to 409 link_invalidated' do
+      wm_email = "route-wm-#{SecureRandom.hex(4)}@example.com"
+      customer = Onetime::Customer.create!(wm_email)
+      customer.last_password_update! 200
+      seed_account(account_email: wm_email, external_id: customer.extid)
+
+      json_post(issue_token(email: wm_email, password_watermark: 100))
+      expect(last_response.status).to eq(409)
+      expect(body['error_code']).to eq('link_invalidated')
+    ensure
+      customer&.delete!
+    end
+
+    it 'on success binds, logs in via Rodauth, and returns the login response' do
+      seed_account
+      token = issue_token
+
+      json_post(token)
+
+      expect(last_response.status).to eq(200)
+      expect(body).to eq('success' => true)
+      # Session established through Rodauth's own machinery, as the passwordless account.
+      expect(rodauth.account_from_login_calls).to eq([email])
+      expect(rodauth.login_calls).to eq(['sso_link_confirm'])
+      # The identity was actually bound.
+      expect(identities.where(provider: provider, issuer: issuer, uid: uid).count).to eq(1)
+    end
+
+    context 'when the account is no longer loginable at login time' do
+      let(:account_found) { false } # rodauth.account_from_login returns nil/false
+
+      it 'returns 401 link_expired (the op bound, but login cannot proceed)' do
+        seed_account
+
+        json_post(issue_token)
+        expect(last_response.status).to eq(401)
+        expect(body['error_code']).to eq('link_expired')
+      end
+    end
+  end
+end

--- a/spec/unit/auth/sso_link_confirm_route_spec.rb
+++ b/spec/unit/auth/sso_link_confirm_route_spec.rb
@@ -26,13 +26,16 @@ RSpec.describe Auth::Routes::SsoLinkConfirm, type: :rack do
   let(:identities) { db[:account_identities] }
 
   let(:account_id) { 42 }
-  let(:email)      { 'user@example.com' }
+  # Unique per example: seed_account pairs a REAL Customer with this address, and the
+  # test Customer email-index outlives delete! (same reason as confirm_sso_link_spec).
+  let(:email)      { unique_email('route') }
   let(:provider)   { 'google' }
   let(:issuer)     { 'https://accounts.google.com' }
   let(:uid)        { 'sub-123' }
   let(:sid)        { 'a' * 64 }
 
-  let(:tokens)   { [] }
+  let(:tokens)    { [] }
+  let(:customers) { [] }
   let(:otp)      { false }
   let(:account_found) { true }
   let(:rodauth)  { FakeRodauth.new(db: db, otp: otp, account_found: account_found) }
@@ -56,7 +59,7 @@ RSpec.describe Auth::Routes::SsoLinkConfirm, type: :rack do
     end
 
     def session
-      nil # -> route's current-sid resolver rescues to nil (soft check skipped)
+      nil # -> nil.id raises; the route's current-sid resolver warns and returns nil
     end
 
     def account_from_login(login)
@@ -111,9 +114,28 @@ RSpec.describe Auth::Routes::SsoLinkConfirm, type: :rack do
     db
   end
 
-  def seed_account(id: account_id, account_email: email, external_id: nil)
+  # Pairs a REAL Customer with the account by default. Any account that reaches the
+  # watermark probe NEEDS one: the probe fails SECURE on an unresolvable Customer
+  # (:link_error), so an unpaired account would map to 409 link_error instead of
+  # whatever the example is actually asserting. Accounts that never reach the probe
+  # (the rival owner in the conflict case) pass with_customer: false.
+  def seed_account(id: account_id, account_email: email, external_id: nil, with_customer: true)
+    external_id ||= customer_with_watermark(account_email, 0).extid if with_customer
     db[:accounts].insert(id: id, email: account_email, external_id: external_id, status_id: 2)
     id
+  end
+
+  # Unique email per example so Customer's unique email-index (which delete! does not
+  # fully clear on the test DB) never collides across runs.
+  def unique_email(prefix)
+    "#{prefix}-#{SecureRandom.hex(4)}@example.com"
+  end
+
+  def customer_with_watermark(customer_email, watermark)
+    customer = Onetime::Customer.create!(customer_email)
+    customers << customer
+    customer.last_password_update! watermark
+    customer
   end
 
   def issue_token(**overrides)
@@ -130,6 +152,16 @@ RSpec.describe Auth::Routes::SsoLinkConfirm, type: :rack do
     record.token
   end
 
+  # Capture every audit event (name + payload) emitted during the block's request.
+  def with_captured_events
+    events = []
+    allow(Auth::Logging).to receive(:log_auth_event).and_wrap_original do |orig, event, **kw|
+      events << [event, kw]
+      orig.call(event, **kw)
+    end
+    events
+  end
+
   def json_post(token)
     post '/sso-link-confirm', JSON.generate({ token: token }), { 'CONTENT_TYPE' => 'application/json' }
   end
@@ -140,6 +172,7 @@ RSpec.describe Auth::Routes::SsoLinkConfirm, type: :rack do
 
   after do
     tokens.each { |t| Onetime::SsoLinkVerification.load(t)&.delete! rescue nil }
+    customers.each { |c| c.delete! rescue nil }
   end
 
   describe 'GET /sso-link-confirm/:token (consent display)' do
@@ -176,7 +209,9 @@ RSpec.describe Auth::Routes::SsoLinkConfirm, type: :rack do
 
     it 'maps an identity owned by a different account to 409 link_conflict' do
       seed_account
-      other = seed_account(id: 999, account_email: 'other@example.com')
+      # The rival owner is never probed (the confirm targets account_id), so no
+      # paired Customer — and none minted under a fixed, colliding address.
+      other = seed_account(id: 999, account_email: 'other@example.com', with_customer: false)
       identities.insert(provider: provider, issuer: issuer, uid: uid, account_id: other)
 
       json_post(issue_token)
@@ -197,6 +232,34 @@ RSpec.describe Auth::Routes::SsoLinkConfirm, type: :rack do
       customer&.delete!
     end
 
+    # An UNREADABLE watermark shares the 409 with a real credential change, so the
+    # error_code is the ONLY thing that separates them — and it has to, because
+    # link_invalidated's copy tells the user their credentials changed. Here they
+    # did not: the probe simply could not read them.
+    it 'maps an unreadable watermark to 409 link_error (NOT link_invalidated)' do
+      seed_account
+
+      # Stub scoped to this example only — the suite runs against a REAL datastore.
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email)
+        .and_raise(StandardError.new('datastore unreachable'))
+
+      token = issue_token
+      json_post(token)
+
+      expect(last_response.status).to eq(409)
+      expect(body['error_code']).to eq('link_error')
+      expect(body['error']).not_to include('credentials changed')
+      # Nothing bound, and no session established.
+      expect(identities.where(provider: provider, issuer: issuer, uid: uid).count).to eq(0)
+      expect(rodauth.login_calls).to be_empty
+
+      # 409 rather than a retryable 5xx is load-bearing: the op consumed the token
+      # BEFORE probing, so replaying the same link can only ever be link_expired.
+      json_post(token)
+      expect(last_response.status).to eq(401)
+      expect(body['error_code']).to eq('link_expired')
+    end
+
     it 'on success binds, logs in via Rodauth, and returns the login response' do
       seed_account
       token = issue_token
@@ -210,6 +273,30 @@ RSpec.describe Auth::Routes::SsoLinkConfirm, type: :rack do
       expect(rodauth.login_calls).to eq(['sso_link_confirm'])
       # The identity was actually bound.
       expect(identities.where(provider: provider, issuer: issuer, uid: uid).count).to eq(1)
+    end
+
+    # The sid feeds ONLY the op's SOFT cross-device check, which early-returns on an
+    # empty sid — so a SYSTEMIC session.id failure would silently stop the
+    # cross-device audit event emitting. The swallow must therefore be observable.
+    # FakeRodauth#session returns nil (so nil.id raises) and EVERY POST example above
+    # drives this branch incidentally; this one names and asserts it.
+    it 'warns :current_session_id_unresolved when the sid cannot be resolved, and still confirms' do
+      seed_account
+      events = with_captured_events
+
+      json_post(issue_token)
+
+      # Fails SOFT: the confirmation completes despite the unresolved sid.
+      expect(last_response.status).to eq(200)
+      expect(rodauth.login_calls).to eq(['sso_link_confirm'])
+
+      entry = events.find { |(event, _)| event == :current_session_id_unresolved }
+      expect(entry).not_to be_nil
+      # Same event name the after_change_password resolver uses (hooks/account.rb),
+      # discriminated by route, so one audit query covers both sites.
+      expect(entry.last).to include(level: :warn, route: :sso_link_confirm)
+      expect(entry.last[:error]).to be_a(String)
+      expect(entry.last[:error]).not_to be_empty
     end
 
     context 'when the account is no longer loginable at login time' do

--- a/spec/unit/onetime/models/sso_link_verification_spec.rb
+++ b/spec/unit/onetime/models/sso_link_verification_spec.rb
@@ -1,0 +1,106 @@
+# spec/unit/onetime/models/sso_link_verification_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Unit tests for Onetime::SsoLinkVerification — the single-use, mailbox-proof token
+# behind the #3840 Phase 4 passwordless SSO linking flow.
+#
+# These exercise the real Familia-backed record on the test database (port 2121):
+# persistence, the 15-minute TTL (criterion 3), string round-tripping of the
+# snapshot fields, the display projection, and single-use consume semantics.
+RSpec.describe Onetime::SsoLinkVerification do
+  let(:issued) { [] }
+
+  def issue(**overrides)
+    record = described_class.issue(
+      provider: overrides.fetch(:provider, 'google'),
+      uid: overrides.fetch(:uid, 'sub-123'),
+      email: overrides.fetch(:email, 'user@example.com'),
+      account_id: overrides.fetch(:account_id, 42),
+      sid: overrides.fetch(:sid, 'a' * 64),
+      password_watermark: overrides.fetch(:password_watermark, 100),
+      issuer: overrides.fetch(:issuer, 'https://accounts.google.com'),
+    )
+    issued << record
+    record
+  end
+
+  after do
+    issued.each { |r| r.delete! rescue nil }
+  end
+
+  describe 'TTL contract (criterion 3: <= 15 min)' do
+    it 'sets DEFAULT_EXPIRATION to 900 seconds' do
+      expect(described_class::DEFAULT_EXPIRATION).to eq(900)
+    end
+
+    it 'persists the record with a positive TTL no greater than 900s' do
+      record = issue
+      ttl    = Familia.dbclient.ttl(record.dbkey)
+      expect(ttl).to be > 0
+      expect(ttl).to be <= 900
+    end
+  end
+
+  describe '.issue' do
+    it 'mints a urlsafe token and persists a loadable record' do
+      record = issue
+      expect(record.token).to be_a(String)
+      expect(record.token.length).to be >= 40
+
+      loaded = described_class.load(record.token)
+      expect(loaded).not_to be_nil
+      expect(loaded.provider).to eq('google')
+      expect(loaded.uid).to eq('sub-123')
+      expect(loaded.email).to eq('user@example.com')
+      expect(loaded.issuer).to eq('https://accounts.google.com')
+    end
+
+    it 'coerces the account id, watermark, and sid to strings (Familia string round-trip)' do
+      loaded = described_class.load(issue(account_id: 42, password_watermark: 100, sid: 'b' * 64).token)
+      expect(loaded.account_id).to eq('42')
+      expect(loaded.password_watermark).to eq('100')
+      expect(loaded.sid).to eq('b' * 64)
+    end
+
+    it 'stores a nil issuer as the empty-string sentinel (never nil)' do
+      loaded = described_class.load(issue(issuer: nil).token)
+      expect(loaded.issuer).to eq('')
+    end
+
+    it 'defaults an omitted watermark to "0"' do
+      record = described_class.issue(
+        provider: 'oidc', uid: 'u', email: 'x@y.com', account_id: 1,
+      )
+      issued << record
+      expect(described_class.load(record.token).password_watermark).to eq('0')
+    end
+  end
+
+  describe '#to_display' do
+    it 'exposes ONLY the provider and claimed email (consent copy — criterion 2)' do
+      expect(issue.to_display).to eq(provider: 'google', email: 'user@example.com')
+    end
+
+    it 'never leaks the account id, uid, issuer, sid, or watermark' do
+      keys = issue.to_display.keys
+      expect(keys).not_to include(:account_id, :uid, :issuer, :sid, :password_watermark)
+    end
+  end
+
+  describe 'single-use consume (#delete!)' do
+    it 'returns 1 on the first consume and removes the record' do
+      record = issue
+      expect(record.delete!).to eq(1)
+      expect(described_class.load(record.token)).to be_nil
+    end
+
+    it 'returns 0 on a second consume of the same token (already spent)' do
+      record = issue
+      record.delete!
+      expect(record.delete!).to eq(0)
+    end
+  end
+end

--- a/src/apps/session/routes.ts
+++ b/src/apps/session/routes.ts
@@ -212,6 +212,36 @@ const routes: Array<RouteRecordRaw> = [
       sentryScrubParams: ['token'],
     },
   },
+  // Mailbox-proof SSO linking consent page (#3840 Phase 4). Reached
+  // UNAUTHENTICATED via an emailed link after an SSO sign-in whose IdP email
+  // matched an existing PASSWORDLESS account: the backend emails a single-use
+  // token to the on-file address, so opening this link proves mailbox control.
+  // The token rides the path (`:token`) and is EMAIL-DELIVERED — sentryScrubParams:
+  // ['token'] redacts it from diagnostics. Meta mirrors /link-sso (another
+  // post-issuance, pre-fully-authenticated interstitial); the GET is display-only
+  // and the mutating confirm is an explicit user action (never auto-POST on load).
+  {
+    path: '/sso-link-confirm/:token',
+    name: 'SSO Link Confirm',
+    component: () => import('@/apps/session/views/SsoLinkConfirm.vue'),
+    meta: {
+      title: 'web.sso_link_confirm.title',
+      requiresAuth: false,
+      isAuthRoute: true,
+      requiresFeature: 'signin',
+      excludeSsoOnly: true,
+      layout: AuthLayout,
+      layoutProps: {
+        displayMasthead: false,
+        displayNavigation: false,
+        displayFooterLinks: false,
+        displayFeedback: false,
+        displayVersion: true,
+        displayToggles: true,
+      },
+      sentryScrubParams: ['token'],
+    },
+  },
   {
     path: '/email-login',
     name: 'Email Login',

--- a/src/apps/session/views/LinkSso.vue
+++ b/src/apps/session/views/LinkSso.vue
@@ -12,7 +12,7 @@
   import { useAuthStore } from '@/shared/stores/authStore';
   import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import { isValidInternalPath } from '@/utils/redirect';
-  import { ref, onMounted, computed } from 'vue';
+  import { ref, onMounted, computed, nextTick, watch } from 'vue';
   import { useI18n } from 'vue-i18n';
   import { useRoute, useRouter } from 'vue-router';
 
@@ -65,6 +65,25 @@
     const provider = challenge.value?.provider;
     if (!provider) return '';
     return PROVIDER_LABELS[provider] ?? provider.charAt(0).toUpperCase() + provider.slice(1);
+  });
+
+  // Single polite live region, rendered unconditionally. A live region has to be
+  // in the DOM BEFORE its content changes for assistive tech to announce it, so
+  // inserting an already-populated region (v-if) is unreliable — only the text
+  // swaps here.
+  const statusMessage = computed(() => (isLoading.value ? t('web.COMMON.form_processing') : ''));
+
+  // Heading of the dead-end panel. The panel replaces the password form in place,
+  // so whatever had focus (the Submit button, or the password input) is unmounted
+  // and focus falls back to <body>: keyboard users lose their place and the
+  // refusal is never announced. Move focus to the heading instead
+  // (WCAG 2.4.3 / 3.2.2).
+  const unavailableHeadingRef = ref<HTMLElement | null>(null);
+
+  watch(challengeUnavailable, async (unavailable) => {
+    if (!unavailable) return;
+    await nextTick();
+    unavailableHeadingRef.value?.focus();
   });
 
   onMounted(async () => {
@@ -166,11 +185,24 @@
     :with-subheading="false"
     :show-return-home="false">
     <template #form>
+      <!-- Always-present polite live region (see statusMessage). Kept OUTSIDE
+           the space-y-6 stack so it never participates in sibling spacing. -->
+      <div
+        aria-live="polite"
+        aria-atomic="true"
+        class="sr-only"
+        data-testid="link-sso-status">
+        {{ statusMessage }}
+      </div>
+
       <div class="space-y-6">
         <!-- Dead-end: token missing / expired / spent. Keep the H-3 refusal and
-             point the user at the Phase 2 settings flow. -->
+             point the user at the Phase 2 settings flow. Labelled + described so
+             focusing the heading announces the refusal. -->
         <div
           v-if="challengeUnavailable"
+          role="group"
+          aria-labelledby="link-sso-unavailable-title"
           data-testid="link-sso-unavailable"
           class="space-y-4 text-center">
           <OIcon
@@ -178,25 +210,31 @@
             name="lock-closed"
             class="mx-auto size-10 text-gray-400 dark:text-gray-500"
             aria-hidden="true" />
-          <h2 class="text-lg font-medium text-gray-900 dark:text-white">
+          <h2
+            id="link-sso-unavailable-title"
+            ref="unavailableHeadingRef"
+            tabindex="-1"
+            aria-describedby="link-sso-unavailable-message"
+            class="text-lg font-medium text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:text-white">
             {{ t('web.link_sso.unavailable_title') }}
           </h2>
-          <p class="text-sm text-gray-600 dark:text-gray-400">
+          <p
+            id="link-sso-unavailable-message"
+            class="text-sm text-gray-600 dark:text-gray-400">
             {{ t('web.link_sso.unavailable_message') }}
           </p>
           <button
             @click="goToSignInFallback"
             type="button"
-            class="w-full rounded-md bg-brand-600 px-4 py-3 text-lg font-medium text-white hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2"
+            class="w-full cursor-pointer rounded-md bg-brand-600 px-4 py-3 text-lg font-medium text-white hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2"
             data-testid="link-sso-unavailable-action">
             {{ t('web.link_sso.unavailable_action') }}
           </button>
         </div>
 
-        <!-- Loading the challenge context -->
+        <!-- Loading the challenge context (visual only; announced by the region above) -->
         <div
           v-else-if="isLoading && !challenge"
-          aria-live="polite"
           class="py-4 text-center text-sm text-gray-600 dark:text-gray-400"
           data-testid="link-sso-loading">
           {{ t('web.COMMON.form_processing') }}
@@ -251,21 +289,12 @@
             <button
               type="submit"
               :disabled="!password || isLoading"
-              :aria-disabled="!password || isLoading ? 'true' : undefined"
-              class="w-full rounded-md bg-brand-600 px-4 py-3 text-lg font-medium text-white hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              :aria-busy="isLoading ? 'true' : undefined"
+              class="w-full cursor-pointer rounded-md bg-brand-600 px-4 py-3 text-lg font-medium text-white hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
               data-testid="link-sso-submit">
               <span v-if="isLoading">{{ t('web.COMMON.processing') }}</span>
               <span v-else>{{ t('web.link_sso.submit') }}</span>
             </button>
-
-            <!-- Loading state announcement (screen reader only) -->
-            <div
-              v-if="isLoading"
-              aria-live="polite"
-              aria-atomic="true"
-              class="sr-only">
-              {{ t('web.COMMON.form_processing') }}
-            </div>
           </form>
         </template>
       </div>
@@ -281,7 +310,7 @@
             @click="handleCancel"
             type="button"
             :disabled="isLoading"
-            class="text-gray-500 transition-colors duration-200 hover:text-gray-700 focus:outline-none focus:underline disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:text-gray-300"
+            class="cursor-pointer rounded-sm px-1 text-gray-500 underline-offset-2 transition-colors duration-200 hover:text-gray-700 focus:underline focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:text-gray-300"
             data-testid="link-sso-cancel">
             {{ t('web.link_sso.cancel') }}
           </button>

--- a/src/apps/session/views/LinkSso.vue
+++ b/src/apps/session/views/LinkSso.vue
@@ -11,6 +11,7 @@
   import { useLinkSso } from '@/shared/composables/useLinkSso';
   import { useAuthStore } from '@/shared/stores/authStore';
   import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
+  import { providerLabel } from '@/utils/features';
   import { isValidInternalPath } from '@/utils/redirect';
   import { ref, onMounted, computed, nextTick, watch } from 'vue';
   import { useI18n } from 'vue-i18n';
@@ -29,16 +30,6 @@
   // cancel / dead-end. An UNAUTHENTICATED user cannot open it directly, so we
   // route through /signin carrying this as the post-login destination.
   const CONNECT_REDIRECT = '/account/settings/security/connections';
-
-  // Friendly provider labels; unknown providers fall back to a capitalized name
-  // so a backend that adds a strategy still renders sensibly. Mirrors
-  // ConnectedIdentities.vue.
-  const PROVIDER_LABELS: Record<string, string> = {
-    oidc: 'OpenID Connect',
-    entra: 'Microsoft Entra',
-    github: 'GitHub',
-    google: 'Google',
-  };
 
   const password = ref('');
   const passwordInputRef = ref<HTMLInputElement | null>(null);
@@ -61,11 +52,11 @@
     return isValidInternalPath(redirect) ? redirect : null;
   });
 
-  const providerLabel = computed(() => {
-    const provider = challenge.value?.provider;
-    if (!provider) return '';
-    return PROVIDER_LABELS[provider] ?? provider.charAt(0).toUpperCase() + provider.slice(1);
-  });
+  // Shared label resolution (features.providerLabel): the built-in canonical
+  // label, else a capitalized route name. NOT the bootstrap display_name — the
+  // backend defaults that to 'SSO'/'Microsoft', which would read wrong in the
+  // prose below ("You signed in with SSO"). See utils/features.ts.
+  const providerDisplayName = computed(() => providerLabel(challenge.value?.provider ?? ''));
 
   // Single polite live region, rendered unconditionally. A live region has to be
   // in the DOM BEFORE its content changes for assistive tech to announce it, so
@@ -246,7 +237,12 @@
             id="link-sso-instructions"
             class="text-center text-gray-600 dark:text-gray-400"
             data-testid="link-sso-prompt">
-            {{ t('web.link_sso.prompt', { provider: providerLabel, email: challenge.email }) }}
+            {{
+              t('web.link_sso.prompt', {
+                provider: providerDisplayName,
+                email: challenge.email,
+              })
+            }}
           </p>
 
           <form

--- a/src/apps/session/views/Login.vue
+++ b/src/apps/session/views/Login.vue
@@ -40,6 +40,12 @@ const signupEnabled = computed(
 // Handle auth errors passed via query params (from SSO/magic link failures)
 const authError = ref<string | null>(null);
 
+// Handle informational notices passed via query params. Distinct from auth_error:
+// these are non-failure prompts a backend redirect drops the user here with — e.g.
+// after issuing a mailbox-proof SSO link (#3840 Phase 4), the callback redirects to
+// /signin?auth_notice=link_verification_sent (token-less; the token is emailed).
+const authNotice = ref<string | null>(null);
+
 // Post-verification return: useAuth.verifyAccount() sends the user here after
 // they click the link in their welcome email. The "just verified" signal
 // arrives via router history state (SIGNIN_VERIFIED_STATE_KEY), not the URL:
@@ -80,6 +86,12 @@ const authErrorMessages: Record<string, string> = {
   org_join_failed: 'web.login.errors.org_join_failed',
 };
 
+// Informational notices (not failures). Only known codes render — an unknown
+// notice is silently ignored rather than shown as a generic banner.
+const authNoticeMessages: Record<string, string> = {
+  link_verification_sent: 'web.login.notices.link_verification_sent',
+};
+
 onMounted(() => {
   const errorCode = route.query.auth_error;
   if (typeof errorCode === 'string' && errorCode.length > 0) {
@@ -92,6 +104,18 @@ onMounted(() => {
     authError.value = t(messageKey);
     // Clear the query param to prevent showing error on refresh
     router.replace({ query: { ...route.query, auth_error: undefined } });
+  }
+
+  const noticeCode = route.query.auth_notice;
+  if (typeof noticeCode === 'string' && noticeCode.length > 0) {
+    // Unlike auth_error there is no generic fallback: an unrecognized notice is
+    // not a failure to surface, so ignore it rather than guess a message.
+    const messageKey = authNoticeMessages[noticeCode];
+    if (messageKey) {
+      authNotice.value = t(messageKey);
+    }
+    // Clear the query param either way so a refresh does not re-show it.
+    router.replace({ query: { ...route.query, auth_notice: undefined } });
   }
 });
 
@@ -168,6 +192,25 @@ const handleModeChange = (_mode: AuthMode) => {
             class="size-5 shrink-0 text-green-500 dark:text-green-400"
             aria-hidden="true" />
           <span>{{ t('web.login.verified_notice') }}</span>
+        </div>
+
+        <!-- Informational notice from redirects (e.g. mailbox-proof SSO link sent —
+             #3840 Phase 4). Non-failure "check your inbox" prompt, styled distinctly
+             from the red error banner. -->
+        <!-- prettier-ignore-attribute class -->
+        <div
+          v-if="authNotice"
+          role="status"
+          class="
+            mb-4 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 p-3
+            text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-300"
+          data-testid="signin-auth-notice">
+          <OIcon
+            collection="heroicons"
+            name="envelope"
+            class="size-5 shrink-0 text-blue-500 dark:text-blue-400"
+            aria-hidden="true" />
+          <span>{{ authNotice }}</span>
         </div>
 
         <!-- Auth error from redirects (SSO failure, invalid magic link, etc.) -->

--- a/src/apps/session/views/Login.vue
+++ b/src/apps/session/views/Login.vue
@@ -12,11 +12,10 @@ import { hasPasswordlessMethods } from '@/utils/features';
 import { storeToRefs } from 'pinia';
 import { ref, computed, onMounted, type ComponentPublicInstance } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useRoute, useRouter } from 'vue-router';
+import { useRoute } from 'vue-router';
 
 const { t } = useI18n();
 const route = useRoute();
-const router = useRouter();
 
 const languageStore = useLanguageStore();
 const bootstrapStore = useBootstrapStore();
@@ -92,6 +91,23 @@ const authNoticeMessages: Record<string, string> = {
   link_verification_sent: 'web.login.notices.link_verification_sent',
 };
 
+// Strip a consumed one-shot query param (auth_error / auth_notice) from the
+// address bar so a manual refresh does not re-show the banner. Uses
+// window.history.replaceState — NOT router.replace — deliberately: App.vue keys
+// <router-view> by $route.fullPath and forces a fresh component instance on any
+// route change (query-only changes included), so a router.replace() dropping the
+// param would REMOUNT this view and discard the banner we just set — the same
+// fullPath-remount trap the verifiedNotice handling above sidesteps. replaceState
+// updates only the URL bar, leaving Vue Router's route (and this instance)
+// intact, so the banner survives while a refresh no longer re-shows it.
+const stripConsumedQueryParam = (name: string) => {
+  if (typeof window === 'undefined') return;
+  const url = new URL(window.location.href);
+  if (!url.searchParams.has(name)) return;
+  url.searchParams.delete(name);
+  window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`);
+};
+
 onMounted(() => {
   const errorCode = route.query.auth_error;
   if (typeof errorCode === 'string' && errorCode.length > 0) {
@@ -102,8 +118,9 @@ onMounted(() => {
     // fall back to the generic SSO failure copy instead of rendering nothing.
     const messageKey = authErrorMessages[errorCode] ?? 'web.login.errors.sso_failed';
     authError.value = t(messageKey);
-    // Clear the query param to prevent showing error on refresh
-    router.replace({ query: { ...route.query, auth_error: undefined } });
+    // Clear the query param to prevent showing error on refresh (URL-bar only;
+    // see stripConsumedQueryParam — a router nav here would remount and wipe it).
+    stripConsumedQueryParam('auth_error');
   }
 
   const noticeCode = route.query.auth_notice;
@@ -114,8 +131,9 @@ onMounted(() => {
     if (messageKey) {
       authNotice.value = t(messageKey);
     }
-    // Clear the query param either way so a refresh does not re-show it.
-    router.replace({ query: { ...route.query, auth_notice: undefined } });
+    // Clear the query param either way so a refresh does not re-show it
+    // (URL-bar only — see stripConsumedQueryParam).
+    stripConsumedQueryParam('auth_notice');
   }
 });
 

--- a/src/apps/session/views/SsoLinkConfirm.vue
+++ b/src/apps/session/views/SsoLinkConfirm.vue
@@ -1,0 +1,252 @@
+<!-- src/apps/session/views/SsoLinkConfirm.vue -->
+
+<script setup lang="ts">
+  import AuthView from '@/apps/session/components/AuthView.vue';
+  import {
+    ssoLinkConfirmRequiresMfa,
+    type SsoLinkConfirmSuccess,
+  } from '@/schemas/api/auth/responses/auth';
+  import { loggingService } from '@/services/logging.service';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import { useSsoLinkConfirm } from '@/shared/composables/useSsoLinkConfirm';
+  import { useAuthStore } from '@/shared/stores/authStore';
+  import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
+  import { isValidInternalPath } from '@/utils/redirect';
+  import { ref, onMounted, computed } from 'vue';
+  import { useI18n } from 'vue-i18n';
+  import { useRoute, useRouter } from 'vue-router';
+
+  const { t } = useI18n();
+  const route = useRoute();
+  const router = useRouter();
+  const authStore = useAuthStore();
+  const bootstrapStore = useBootstrapStore();
+
+  const { pendingLink, confirmLink, fetchPendingLink, isLoading, error, clearError } =
+    useSsoLinkConfirm();
+
+  // Friendly provider labels; unknown providers fall back to a capitalized name
+  // so a backend that adds a strategy still renders sensibly. Mirrors
+  // ConnectedIdentities.vue / LinkSso.vue.
+  const PROVIDER_LABELS: Record<string, string> = {
+    oidc: 'OpenID Connect',
+    entra: 'Microsoft Entra',
+    github: 'GitHub',
+    google: 'Google',
+  };
+
+  // Set when the display context cannot be loaded (GET failed) OR any confirm
+  // (POST) fails: the single-use token is spent or the account moved, so there is
+  // nothing to retry — render the terminal panel, not the consent CTA. The
+  // specific reason lives in `error`.
+  const linkUnavailable = ref(false);
+
+  // Single-use token from the emailed link's path (scrubbed from diagnostics via
+  // the route's sentryScrubParams).
+  const token = computed(() => {
+    const raw = route.params.token;
+    return typeof raw === 'string' ? raw : '';
+  });
+
+  // Post-link destination from the query, if a safe internal path. Only used as a
+  // fallback when the confirm response does not carry its own redirect target.
+  const redirectPath = computed(() => {
+    const redirect = route.query.redirect;
+    if (typeof redirect !== 'string') return null;
+    return isValidInternalPath(redirect) ? redirect : null;
+  });
+
+  const providerLabel = computed(() => {
+    const provider = pendingLink.value?.provider;
+    if (!provider) return '';
+    return PROVIDER_LABELS[provider] ?? provider.charAt(0).toUpperCase() + provider.slice(1);
+  });
+
+  // Terminal-panel body: the specific dead-end reason when one was classified
+  // (expired / conflict / invalidated), else the generic expired copy (e.g. the
+  // token was missing from the URL entirely, so no fetch ran).
+  const unavailableMessage = computed(
+    () => error.value ?? t('web.sso_link_confirm.unavailable_message')
+  );
+
+  onMounted(async () => {
+    // Already fully signed in (e.g. a stale link opened after a separate login):
+    // nothing to link, go home.
+    if (authStore.isFullyAuthenticated) {
+      loggingService.debug('[SsoLinkConfirm] Already authenticated, redirecting to /');
+      router.push('/');
+      return;
+    }
+
+    if (!token.value) {
+      loggingService.debug('[SsoLinkConfirm] Missing token — dead-end');
+      linkUnavailable.value = true;
+      return;
+    }
+
+    // DISPLAY-ONLY fetch: never mutates. The confirm (POST) only fires on the
+    // user's explicit consent below — never auto-POST on load.
+    const context = await fetchPendingLink(token.value);
+    if (!context) {
+      // Token spent / expired / unknown — render the terminal panel.
+      linkUnavailable.value = true;
+    }
+  });
+
+  // Handle a successful confirm. Mailbox proof succeeded server-side and the
+  // identity is bound; for an MFA account only the FIRST factor is done. Mirror
+  // the normal Login flow EXACTLY: hand an MFA account off to the shared
+  // /mfa-verify challenge WITHOUT marking it fully authenticated; otherwise
+  // complete the sign-in and navigate to the safest available destination.
+  const handleConfirmSuccess = async (result: SsoLinkConfirmSuccess) => {
+    if (ssoLinkConfirmRequiresMfa(result)) {
+      loggingService.debug('[SsoLinkConfirm] MFA required, routing to /mfa-verify');
+      // Mark awaiting_mfa (NOT authenticated) so the MFA route guard permits
+      // /mfa-verify; preserve any ?redirect for the post-verify hop.
+      bootstrapStore.update({ awaiting_mfa: true, authenticated: false });
+      router.push({
+        path: '/mfa-verify',
+        query: redirectPath.value ? { redirect: redirectPath.value } : undefined,
+      });
+      return;
+    }
+
+    loggingService.debug('[SsoLinkConfirm] Link confirmed, completing sign-in');
+    await authStore.setAuthenticated(true);
+
+    // Prefer the backend's redirect target when it is a safe internal path;
+    // otherwise the ?redirect query param; otherwise the dashboard.
+    const fromResponse =
+      result.redirect && isValidInternalPath(result.redirect) ? result.redirect : null;
+    const destination = fromResponse ?? redirectPath.value ?? '/';
+    router.push(destination);
+  };
+
+  // Confirm the link. Mailbox possession (the emailed token) is the proof — no
+  // password. Success binds the identity and establishes the session; any failure
+  // is terminal (single-use token consumed / account moved), so flip to the
+  // dead-end panel carrying the specific reason.
+  const handleConfirm = async () => {
+    if (isLoading.value) return;
+
+    clearError();
+    const result = await confirmLink(token.value);
+
+    if (result) {
+      await handleConfirmSuccess(result);
+      return;
+    }
+
+    linkUnavailable.value = true;
+  };
+
+  // Cancel / dead-end: the account is PASSWORDLESS, so there is no existing
+  // password to sign in with — send the user back to /signin to start SSO again
+  // (which re-issues a fresh verification email). Not the Connected Identities
+  // pointer Phase 3 uses (that flow needs a password to reach).
+  const goToSignIn = () => {
+    router.push('/signin');
+  };
+
+  const handleCancel = () => {
+    clearError();
+    goToSignIn();
+  };
+</script>
+
+<template>
+  <AuthView
+    :heading="t('web.sso_link_confirm.title')"
+    heading-id="sso-link-confirm-heading"
+    :with-subheading="false"
+    :show-return-home="false">
+    <template #form>
+      <div class="space-y-6">
+        <!-- Dead-end: token missing / expired / spent, or the confirm failed
+             (conflict / invalidated). Terminal — the single-use token is gone. -->
+        <div
+          v-if="linkUnavailable"
+          data-testid="sso-link-confirm-unavailable"
+          class="space-y-4 text-center">
+          <OIcon
+            collection="heroicons"
+            name="lock-closed"
+            class="mx-auto size-10 text-gray-400 dark:text-gray-500"
+            aria-hidden="true" />
+          <h2 class="text-lg font-medium text-gray-900 dark:text-white">
+            {{ t('web.sso_link_confirm.unavailable_title') }}
+          </h2>
+          <p class="text-sm text-gray-600 dark:text-gray-400">
+            {{ unavailableMessage }}
+          </p>
+          <button
+            @click="goToSignIn"
+            type="button"
+            class="w-full rounded-md bg-brand-600 px-4 py-3 text-lg font-medium text-white hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2"
+            data-testid="sso-link-confirm-unavailable-action">
+            {{ t('web.sso_link_confirm.unavailable_action') }}
+          </button>
+        </div>
+
+        <!-- Loading the display context -->
+        <div
+          v-else-if="isLoading && !pendingLink"
+          aria-live="polite"
+          class="py-4 text-center text-sm text-gray-600 dark:text-gray-400"
+          data-testid="sso-link-confirm-loading">
+          {{ t('web.COMMON.form_processing') }}
+        </div>
+
+        <!-- Consent: name the provider + claimed email, then a single Confirm CTA.
+             Mailbox possession is the proof — there is NO password field. -->
+        <template v-else-if="pendingLink">
+          <p
+            id="sso-link-confirm-instructions"
+            class="text-center text-gray-600 dark:text-gray-400"
+            data-testid="sso-link-confirm-prompt">
+            {{ t('web.sso_link_confirm.prompt', { provider: providerLabel, email: pendingLink.email }) }}
+          </p>
+
+          <button
+            @click="handleConfirm"
+            type="button"
+            :disabled="isLoading"
+            :aria-disabled="isLoading ? 'true' : undefined"
+            aria-describedby="sso-link-confirm-instructions"
+            class="w-full rounded-md bg-brand-600 px-4 py-3 text-lg font-medium text-white hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            data-testid="sso-link-confirm-submit">
+            <span v-if="isLoading">{{ t('web.COMMON.processing') }}</span>
+            <span v-else>{{ t('web.sso_link_confirm.submit') }}</span>
+          </button>
+
+          <!-- Loading state announcement (screen reader only) -->
+          <div
+            v-if="isLoading"
+            aria-live="polite"
+            aria-atomic="true"
+            class="sr-only">
+            {{ t('web.COMMON.form_processing') }}
+          </div>
+        </template>
+      </div>
+    </template>
+
+    <!-- Footer: cancel abandons linking and returns to sign in -->
+    <template #footer>
+      <div
+        v-if="!linkUnavailable"
+        class="border-t border-gray-200 pt-4 dark:border-gray-700">
+        <nav class="flex items-center justify-center gap-2 text-sm">
+          <button
+            @click="handleCancel"
+            type="button"
+            :disabled="isLoading"
+            class="text-gray-500 transition-colors duration-200 hover:text-gray-700 focus:outline-none focus:underline disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:text-gray-300"
+            data-testid="sso-link-confirm-cancel">
+            {{ t('web.sso_link_confirm.cancel') }}
+          </button>
+        </nav>
+      </div>
+    </template>
+  </AuthView>
+</template>

--- a/src/apps/session/views/SsoLinkConfirm.vue
+++ b/src/apps/session/views/SsoLinkConfirm.vue
@@ -11,6 +11,7 @@
   import { useSsoLinkConfirm } from '@/shared/composables/useSsoLinkConfirm';
   import { useAuthStore } from '@/shared/stores/authStore';
   import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
+  import { providerLabel } from '@/utils/features';
   import { isValidInternalPath } from '@/utils/redirect';
   import { ref, onMounted, computed, nextTick, watch } from 'vue';
   import { useI18n } from 'vue-i18n';
@@ -24,16 +25,6 @@
 
   const { pendingLink, confirmLink, fetchPendingLink, isLoading, error, clearError } =
     useSsoLinkConfirm();
-
-  // Friendly provider labels; unknown providers fall back to a capitalized name
-  // so a backend that adds a strategy still renders sensibly. Mirrors
-  // ConnectedIdentities.vue / LinkSso.vue.
-  const PROVIDER_LABELS: Record<string, string> = {
-    oidc: 'OpenID Connect',
-    entra: 'Microsoft Entra',
-    github: 'GitHub',
-    google: 'Google',
-  };
 
   // Set when the display context cannot be loaded (GET failed) OR any confirm
   // (POST) fails: the single-use token is spent or the account moved, so there is
@@ -56,11 +47,11 @@
     return isValidInternalPath(redirect) ? redirect : null;
   });
 
-  const providerLabel = computed(() => {
-    const provider = pendingLink.value?.provider;
-    if (!provider) return '';
-    return PROVIDER_LABELS[provider] ?? provider.charAt(0).toUpperCase() + provider.slice(1);
-  });
+  // Shared label resolution (features.providerLabel): the built-in canonical
+  // label, else a capitalized route name. NOT the bootstrap display_name — the
+  // backend defaults that to 'SSO'/'Microsoft', which would read wrong in the
+  // prose below ("You signed in with SSO"). See utils/features.ts.
+  const providerDisplayName = computed(() => providerLabel(pendingLink.value?.provider ?? ''));
 
   // Terminal-panel body: the specific dead-end reason when one was classified
   // (expired / conflict / invalidated), else the generic expired copy (e.g. the
@@ -243,7 +234,12 @@
             id="sso-link-confirm-instructions"
             class="text-center text-gray-600 dark:text-gray-400"
             data-testid="sso-link-confirm-prompt">
-            {{ t('web.sso_link_confirm.prompt', { provider: providerLabel, email: pendingLink.email }) }}
+            {{
+              t('web.sso_link_confirm.prompt', {
+                provider: providerDisplayName,
+                email: pendingLink.email,
+              })
+            }}
           </p>
 
           <button

--- a/src/apps/session/views/SsoLinkConfirm.vue
+++ b/src/apps/session/views/SsoLinkConfirm.vue
@@ -12,7 +12,7 @@
   import { useAuthStore } from '@/shared/stores/authStore';
   import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import { isValidInternalPath } from '@/utils/redirect';
-  import { ref, onMounted, computed } from 'vue';
+  import { ref, onMounted, computed, nextTick, watch } from 'vue';
   import { useI18n } from 'vue-i18n';
   import { useRoute, useRouter } from 'vue-router';
 
@@ -68,6 +68,26 @@
   const unavailableMessage = computed(
     () => error.value ?? t('web.sso_link_confirm.unavailable_message')
   );
+
+  // Single polite live region, rendered unconditionally. A live region has to be
+  // in the DOM BEFORE its content changes for assistive tech to announce it, so
+  // inserting an already-populated region (v-if) is unreliable — only the text
+  // swaps here.
+  const statusMessage = computed(() =>
+    isLoading.value ? t('web.COMMON.form_processing') : ''
+  );
+
+  // Heading of the terminal panel. The panel replaces the consent CTA in place,
+  // so whatever had focus (the Confirm button) is unmounted and focus falls back
+  // to <body>: keyboard users lose their place and the reason is never announced.
+  // Move focus to the heading instead (WCAG 2.4.3 / 3.2.2).
+  const unavailableHeadingRef = ref<HTMLElement | null>(null);
+
+  watch(linkUnavailable, async (unavailable) => {
+    if (!unavailable) return;
+    await nextTick();
+    unavailableHeadingRef.value?.focus();
+  });
 
   onMounted(async () => {
     // Already fully signed in (e.g. a stale link opened after a separate login):
@@ -161,11 +181,24 @@
     :with-subheading="false"
     :show-return-home="false">
     <template #form>
+      <!-- Always-present polite live region (see statusMessage). Kept OUTSIDE
+           the space-y-6 stack so it never participates in sibling spacing. -->
+      <div
+        aria-live="polite"
+        aria-atomic="true"
+        class="sr-only"
+        data-testid="sso-link-confirm-status">
+        {{ statusMessage }}
+      </div>
+
       <div class="space-y-6">
         <!-- Dead-end: token missing / expired / spent, or the confirm failed
-             (conflict / invalidated). Terminal — the single-use token is gone. -->
+             (conflict / invalidated). Terminal — the single-use token is gone.
+             Labelled + described so focusing the heading announces the reason. -->
         <div
           v-if="linkUnavailable"
+          role="group"
+          aria-labelledby="sso-link-confirm-unavailable-title"
           data-testid="sso-link-confirm-unavailable"
           class="space-y-4 text-center">
           <OIcon
@@ -173,25 +206,31 @@
             name="lock-closed"
             class="mx-auto size-10 text-gray-400 dark:text-gray-500"
             aria-hidden="true" />
-          <h2 class="text-lg font-medium text-gray-900 dark:text-white">
+          <h2
+            id="sso-link-confirm-unavailable-title"
+            ref="unavailableHeadingRef"
+            tabindex="-1"
+            aria-describedby="sso-link-confirm-unavailable-message"
+            class="text-lg font-medium text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:text-white">
             {{ t('web.sso_link_confirm.unavailable_title') }}
           </h2>
-          <p class="text-sm text-gray-600 dark:text-gray-400">
+          <p
+            id="sso-link-confirm-unavailable-message"
+            class="text-sm text-gray-600 dark:text-gray-400">
             {{ unavailableMessage }}
           </p>
           <button
             @click="goToSignIn"
             type="button"
-            class="w-full rounded-md bg-brand-600 px-4 py-3 text-lg font-medium text-white hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2"
+            class="w-full cursor-pointer rounded-md bg-brand-600 px-4 py-3 text-lg font-medium text-white hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2"
             data-testid="sso-link-confirm-unavailable-action">
             {{ t('web.sso_link_confirm.unavailable_action') }}
           </button>
         </div>
 
-        <!-- Loading the display context -->
+        <!-- Loading the display context (visual only; announced by the region above) -->
         <div
           v-else-if="isLoading && !pendingLink"
-          aria-live="polite"
           class="py-4 text-center text-sm text-gray-600 dark:text-gray-400"
           data-testid="sso-link-confirm-loading">
           {{ t('web.COMMON.form_processing') }}
@@ -211,22 +250,13 @@
             @click="handleConfirm"
             type="button"
             :disabled="isLoading"
-            :aria-disabled="isLoading ? 'true' : undefined"
+            :aria-busy="isLoading ? 'true' : undefined"
             aria-describedby="sso-link-confirm-instructions"
-            class="w-full rounded-md bg-brand-600 px-4 py-3 text-lg font-medium text-white hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            class="w-full cursor-pointer rounded-md bg-brand-600 px-4 py-3 text-lg font-medium text-white hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
             data-testid="sso-link-confirm-submit">
             <span v-if="isLoading">{{ t('web.COMMON.processing') }}</span>
             <span v-else>{{ t('web.sso_link_confirm.submit') }}</span>
           </button>
-
-          <!-- Loading state announcement (screen reader only) -->
-          <div
-            v-if="isLoading"
-            aria-live="polite"
-            aria-atomic="true"
-            class="sr-only">
-            {{ t('web.COMMON.form_processing') }}
-          </div>
         </template>
       </div>
     </template>
@@ -241,7 +271,7 @@
             @click="handleCancel"
             type="button"
             :disabled="isLoading"
-            class="text-gray-500 transition-colors duration-200 hover:text-gray-700 focus:outline-none focus:underline disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:text-gray-300"
+            class="cursor-pointer rounded-sm px-1 text-gray-500 underline-offset-2 transition-colors duration-200 hover:text-gray-700 focus:underline focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:text-gray-300"
             data-testid="sso-link-confirm-cancel">
             {{ t('web.sso_link_confirm.cancel') }}
           </button>

--- a/src/apps/workspace/account/ConnectedIdentities.vue
+++ b/src/apps/workspace/account/ConnectedIdentities.vue
@@ -8,7 +8,15 @@
   import { useConnectedIdentities } from '@/shared/composables/useConnectedIdentities';
   import { useCsrfStore } from '@/shared/stores/csrfStore';
   import { submitSsoLogin } from '@/shared/utils/sso';
-  import { getSsoProviders, type SsoProvider } from '@/utils/features';
+  // Two label helpers on purpose: linked rows name the provider canonically
+  // (providerLabel), connect buttons prefer the operator's display_name
+  // (configuredProviderLabel). See the docblocks in utils/features.ts.
+  import {
+    configuredProviderLabel,
+    getSsoProviders,
+    providerLabel,
+    type SsoProvider,
+  } from '@/utils/features';
   import { useConfirmDialog } from '@vueuse/core';
   import { computed, onMounted, ref } from 'vue';
   import { useI18n } from 'vue-i18n';
@@ -17,17 +25,6 @@
   const csrfStore = useCsrfStore();
   const { identities, isLoading, error, errorCode, fetchIdentities, removeIdentity, clearError } =
     useConnectedIdentities();
-
-  // Friendly provider labels; unknown providers fall back to a capitalized name
-  // so a backend that adds a strategy still renders sensibly.
-  const PROVIDER_LABELS: Record<string, string> = {
-    oidc: 'OpenID Connect',
-    entra: 'Microsoft Entra',
-    github: 'GitHub',
-    google: 'Google',
-  };
-  const providerLabel = (provider: string): string =>
-    PROVIDER_LABELS[provider] ?? provider.charAt(0).toUpperCase() + provider.slice(1);
 
   // Providers the account can still link. A provider is "already linked" when
   // its route_name matches the `provider` of any existing identity row (both are
@@ -39,11 +36,6 @@
     const linked = new Set(identities.value.map((identity) => identity.provider));
     return getSsoProviders().filter((provider) => !linked.has(provider.route_name));
   });
-
-  // Prefer the backend display_name; fall back to the friendly PROVIDER_LABELS
-  // map so a blank display_name still renders a sensible button label.
-  const connectLabel = (provider: SsoProvider): string =>
-    provider.display_name?.trim() ? provider.display_name : providerLabel(provider.route_name);
 
   // Connecting reuses the sign-in form POST (see submitSsoLogin) but marks it
   // with connect: true so the backend hook binds the returned identity to the
@@ -273,7 +265,11 @@
                   name="link-solid"
                   class="size-5 shrink-0"
                   aria-hidden="true" />
-                {{ t('web.auth.connections.connect_action', { provider: connectLabel(provider) }) }}
+                {{
+                  t('web.auth.connections.connect_action', {
+                    provider: configuredProviderLabel(provider),
+                  })
+                }}
               </button>
             </div>
           </div>

--- a/src/schemas/api/auth/responses/auth.ts
+++ b/src/schemas/api/auth/responses/auth.ts
@@ -170,6 +170,8 @@ export function isAuthError(
     | RemoveIdentityResponse
     | LinkSsoChallengeResponse
     | LinkSsoVerifyResponse
+    | SsoLinkConfirmDisplayResponse
+    | SsoLinkConfirmResponse
 ): response is z.infer<typeof authErrorSchema> {
   return 'error' in response;
 }
@@ -390,6 +392,72 @@ export function linkSsoRequiresMfa(
 
 export const linkSsoVerifyResponseSchema = z.union([linkSsoVerifySuccessSchema, authErrorSchema]);
 export type LinkSsoVerifyResponse = z.infer<typeof linkSsoVerifyResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SSO link-confirm (#3840 Phase 4 — MAILBOX-PROOF linking, passwordless accounts)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * GET /auth/sso-link-confirm/:token → { provider, email } on 200.
+ *
+ * The Phase 4 counterpart to linkSsoChallengeSchema, but the account is
+ * PASSWORDLESS: the proof is not a password but MAILBOX CONTROL — the token
+ * reached the user only via an emailed link to <base_url>/sso-link-confirm/:token.
+ * The GET is DISPLAY-ONLY (it never consumes the token, so a mail/link prefetch
+ * cannot burn it); it returns solely the requesting provider name and the claimed
+ * email for the consent screen. A missing / consumed / expired token surfaces as
+ * an axios error (404 { error, error_code: 'link_expired' }); the union's error
+ * branch only covers the unusual 200-with-error body.
+ */
+export const ssoLinkConfirmDisplaySchema = z.object({
+  provider: z.string(),
+  email: z.string(),
+});
+export type SsoLinkConfirmDisplay = z.infer<typeof ssoLinkConfirmDisplaySchema>;
+
+export const ssoLinkConfirmDisplayResponseSchema = z.union([
+  ssoLinkConfirmDisplaySchema,
+  authErrorSchema,
+]);
+export type SsoLinkConfirmDisplayResponse = z.infer<typeof ssoLinkConfirmDisplayResponseSchema>;
+
+/**
+ * POST /auth/sso-link-confirm success body.
+ *
+ * The backend consumes the single-use token, binds (provider, issuer, uid) to the
+ * located account, and ESTABLISHES THE SESSION through Rodauth's OWN login path —
+ * the SAME machinery POST /auth/login uses. It therefore returns the STANDARD
+ * login success contract, in two variants (identical shapes to Phase 3's
+ * linkSsoVerifySuccessSchema — reuse authSuccessWithMfaSchema / the complete
+ * variant):
+ * - MFA account: the same mfa_required body login returns — a second factor is
+ *   still pending. mfa_required MUST be modelled first (union order matters: a
+ *   plain success schema would match an MFA body and silently strip the flag,
+ *   marking the user fully authenticated and skipping the OTP challenge).
+ * - Non-MFA account: { success, redirect? } — session established.
+ *
+ * Failure bodies (400 invalid_request / 401 link_expired / 409 link_conflict /
+ * 409 link_invalidated) are NOT modelled here — they arrive as axios errors and
+ * are classified by the composable via HTTP status + { error_code }.
+ */
+export const ssoLinkConfirmSuccessSchema = z.union([
+  authSuccessWithMfaSchema, // MFA variant — must precede plain success
+  linkSsoVerifyCompleteSchema, // { success, redirect? }
+]);
+export type SsoLinkConfirmSuccess = z.infer<typeof ssoLinkConfirmSuccessSchema>;
+
+/** Type guard: an sso-link-confirm success that still requires a second factor. */
+export function ssoLinkConfirmRequiresMfa(
+  response: SsoLinkConfirmSuccess
+): response is z.infer<typeof authSuccessWithMfaSchema> {
+  return 'mfa_required' in response && response.mfa_required === true;
+}
+
+export const ssoLinkConfirmResponseSchema = z.union([
+  ssoLinkConfirmSuccessSchema,
+  authErrorSchema,
+]);
+export type SsoLinkConfirmResponse = z.infer<typeof ssoLinkConfirmResponseSchema>;
 
 // OTP setup response
 // When HMAC is enabled, Rodauth returns an error response with only secrets on first request

--- a/src/shared/composables/useSsoLinkConfirm.ts
+++ b/src/shared/composables/useSsoLinkConfirm.ts
@@ -1,0 +1,264 @@
+// src/shared/composables/useSsoLinkConfirm.ts
+
+/**
+ * Mailbox-proof SSO linking composable (#3840 Phase 4)
+ *
+ * Drives the consent page an emailed link points at when an UNAUTHENTICATED SSO
+ * sign-in resolves to an existing PASSWORDLESS account (the H-3 case Phase 3's
+ * password-proof path cannot serve — there is no password to prove). The token
+ * reached the user ONLY via a link mailed to the on-file address, so possessing
+ * it proves mailbox control. Two calls:
+ * - fetchPendingLink(token): GET /auth/sso-link-confirm/:token → { provider, email }
+ *     display-only context (which provider, which claimed email). NEVER consumes
+ *     the token — a mail/link prefetch of the GET must not burn the single-use
+ *     token before the user consents.
+ * - confirmLink(token): POST /auth/sso-link-confirm { token }
+ *     → the backend atomically consumes the token, binds (provider, issuer, uid)
+ *       to the located account, and ESTABLISHES THE SESSION via Rodauth's own
+ *       login path (the same one POST /auth/login uses). No password: mailbox
+ *       possession is the credential, exactly as magic-link authenticates a
+ *       passwordless account.
+ *
+ * INVARIANT (#3840): email may LOCATE an account; only a demonstrated credential
+ * may BIND an identity. Here the credential is MAILBOX CONTROL. The token is
+ * single-use and short-lived; every failure is a DEAD-END (the token is spent or
+ * the account moved) — there is no retryable input on this page, so the view
+ * surfaces the specific reason and points the user back to sign in with SSO,
+ * which re-issues the email.
+ *
+ * Backend contract (pinned; flag mismatches):
+ * - GET  /auth/sso-link-confirm/:token  200 => { provider, email }
+ *                                       404 { error, error_code: 'link_expired' }
+ *                                             => missing / consumed / expired
+ *                                       500 { error } => unexpected
+ * - POST /auth/sso-link-confirm  200 => { success, redirect? } (session established)
+ *                                    or { success, mfa_required, ... } (MFA account —
+ *                                    identical body POST /auth/login returns; hand off
+ *                                    to the shared /mfa-verify challenge, do NOT complete)
+ *                                400 invalid_request  => token missing from the body
+ *                                401 link_expired     => token spent/expired, or the
+ *                                                        account vanished / not loginable
+ *                                409 link_conflict    => account re-emailed since issuance,
+ *                                                        or (provider,issuer,uid) bound elsewhere
+ *                                409 link_invalidated => a credential change advanced the
+ *                                                        account's password watermark
+ *   The failure branch is distinguished by an { error_code } field and, defensively,
+ *   the HTTP status.
+ *
+ * Mirrors useLinkSso: happy paths validate through a zod schema; useAsyncHandler
+ * `wrap` manages the loading state and the unexpected (technical) fallback.
+ * Failures are classified INSIDE the operation by reading the axios error's
+ * `response` directly (the useMfa 422 pattern) — the portable signal in both prod
+ * and the mock test harness — and surfaced as a typed errorCode the view branches on.
+ */
+
+import {
+  ssoLinkConfirmDisplayResponseSchema,
+  ssoLinkConfirmResponseSchema,
+  isAuthError,
+  type SsoLinkConfirmDisplay,
+  type SsoLinkConfirmDisplayResponse,
+  type SsoLinkConfirmResponse,
+  type SsoLinkConfirmSuccess,
+} from '@/schemas/api/auth/responses/auth';
+import { useApi } from '@/shared/composables/useApi';
+import { useAsyncHandler, createError } from '@/shared/composables/useAsyncHandler';
+import { useCsrfStore } from '@/shared/stores/csrfStore';
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+/**
+ * Typed failure the view maps to copy. Every code is terminal (no retryable
+ * input on this page); they differ only in WHY the link can't be completed and
+ * therefore in the message shown before sending the user back to sign in.
+ */
+export type SsoLinkConfirmErrorCode =
+  | 'link_expired'
+  | 'link_conflict'
+  | 'link_invalidated'
+  | 'invalid_request'
+  | null;
+
+/** Minimal shape of the axios error's carried response (status + parsed body). */
+interface ErrorResponseLike {
+  status?: number;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Maps an HTTP status and an optional backend { error_code } to the UI's typed
+ * failure. Prefers the explicit backend code (the backend always sends one);
+ * falls back to the status family only defensively. Returns null when the failure
+ * is neither (e.g. an unclassifiable 5xx) so the caller surfaces a generic message.
+ */
+function resolveConfirmErrorCode(
+  status: number | undefined,
+  backendCode: unknown
+): SsoLinkConfirmErrorCode {
+  if (backendCode === 'link_invalidated') return 'link_invalidated';
+  if (backendCode === 'link_conflict') return 'link_conflict';
+  if (backendCode === 'invalid_request') return 'invalid_request';
+  if (
+    backendCode === 'link_expired' ||
+    backendCode === 'expired_token' ||
+    backendCode === 'invalid_token'
+  ) {
+    return 'link_expired';
+  }
+  // Status-family fallback (backend always sends a code; this is defence only).
+  if (status === 401 || status === 404 || status === 410) return 'link_expired';
+  if (status === 409) return 'link_conflict';
+  if (status === 400) return 'invalid_request';
+  return null;
+}
+
+/* eslint-disable max-lines-per-function */
+export function useSsoLinkConfirm() {
+  const { t } = useI18n();
+  const $api = useApi();
+  const csrfStore = useCsrfStore();
+
+  const pendingLink = ref<SsoLinkConfirmDisplay | null>(null);
+  const isLoading = ref(false);
+  const error = ref<string | null>(null);
+  const errorCode = ref<SsoLinkConfirmErrorCode>(null);
+
+  const { wrap } = useAsyncHandler({
+    notify: false,
+    setLoading: (loading) => (isLoading.value = loading),
+    onError: () => {
+      // Failures are classified inside the operation (setConfirmError). Only fill
+      // a generic message for an unexpected throw the operation did not classify
+      // (e.g. a zod parse failure) so the view never dead-ends silently.
+      if (error.value === null) {
+        errorCode.value = null;
+        error.value = t('web.sso_link_confirm.errors.generic');
+      }
+    },
+  });
+
+  function clearError() {
+    error.value = null;
+    errorCode.value = null;
+  }
+
+  function messageForCode(code: SsoLinkConfirmErrorCode): string {
+    if (code === 'link_expired') return t('web.sso_link_confirm.errors.link_expired');
+    if (code === 'link_conflict') return t('web.sso_link_confirm.errors.link_conflict');
+    if (code === 'link_invalidated') return t('web.sso_link_confirm.errors.link_invalidated');
+    return t('web.sso_link_confirm.errors.generic');
+  }
+
+  /**
+   * Classifies and stores a failure from the (status, backend error_code) pair.
+   * `fallback` biases an unclassifiable failure — any GET of the display context
+   * that fails at all means there is no usable context, so the fetch biases to
+   * 'link_expired' (dead-end) rather than a generic message.
+   */
+  function setConfirmError(
+    status: number | undefined,
+    backendCode: unknown,
+    fallback: SsoLinkConfirmErrorCode = null
+  ): string {
+    const code = resolveConfirmErrorCode(status, backendCode) ?? fallback;
+    errorCode.value = code;
+    error.value = messageForCode(code);
+    return error.value;
+  }
+
+  function readErrorResponse(err: unknown): ErrorResponseLike | undefined {
+    return (err as { response?: ErrorResponseLike }).response;
+  }
+
+  /**
+   * Loads the display context for the pending link. Returns null on any failure
+   * (error/errorCode are set via setConfirmError); the view then renders the
+   * dead-end state instead of the consent CTA. DISPLAY-ONLY — never consumes the
+   * token.
+   */
+  async function fetchPendingLink(token: string): Promise<SsoLinkConfirmDisplay | null> {
+    clearError();
+
+    const result = await wrap(async () => {
+      let response;
+      try {
+        response = await $api.get<SsoLinkConfirmDisplayResponse>(
+          `/auth/sso-link-confirm/${encodeURIComponent(token)}`
+        );
+      } catch (err) {
+        // Any failure to load the context means the token is spent/expired/
+        // unknown — bias the dead-end classification to 'link_expired'.
+        const resp = readErrorResponse(err);
+        setConfirmError(resp?.status, resp?.data?.error_code, 'link_expired');
+        throw err;
+      }
+
+      const validated = ssoLinkConfirmDisplayResponseSchema.parse(response.data);
+
+      // A 200 that still carries an error body is unusual; treat it as a spent
+      // token so the view dead-ends rather than showing a broken consent CTA.
+      if (isAuthError(validated)) {
+        const rawCode = (response.data as Record<string, unknown>)?.error_code;
+        setConfirmError(response.status, rawCode, 'link_expired');
+        throw createError(t('web.sso_link_confirm.errors.link_expired'), 'human', 'error');
+      }
+
+      pendingLink.value = validated;
+      return validated;
+    });
+
+    if (!result) {
+      pendingLink.value = null;
+    }
+    return result ?? null;
+  }
+
+  /**
+   * Confirms the link: POSTs the token (mailbox possession is the proof — no
+   * password). On success the backend binds the identity and establishes the
+   * session, returning the standard login body (optionally MFA-pending); the
+   * caller syncs client auth state and navigates. Returns null on failure; the
+   * caller reads errorCode for the specific dead-end message.
+   */
+  async function confirmLink(token: string): Promise<SsoLinkConfirmSuccess | null> {
+    clearError();
+
+    const result = await wrap(async () => {
+      let response;
+      try {
+        response = await $api.post<SsoLinkConfirmResponse>('/auth/sso-link-confirm', {
+          token,
+          shrimp: csrfStore.shrimp,
+        });
+      } catch (err) {
+        const resp = readErrorResponse(err);
+        setConfirmError(resp?.status, resp?.data?.error_code);
+        throw err;
+      }
+
+      const validated = ssoLinkConfirmResponseSchema.parse(response.data);
+
+      // Defensive: a 200 carrying an error body. Classify it the same way so the
+      // view branches consistently on errorCode.
+      if (isAuthError(validated)) {
+        const rawCode = (response.data as Record<string, unknown>)?.error_code;
+        const message = setConfirmError(response.status, rawCode);
+        throw createError(message, 'human', 'error');
+      }
+
+      return validated;
+    });
+
+    return result ?? null;
+  }
+
+  return {
+    pendingLink,
+    isLoading,
+    error,
+    errorCode,
+    fetchPendingLink,
+    confirmLink,
+    clearError,
+  };
+}

--- a/src/shared/composables/useSsoLinkConfirm.ts
+++ b/src/shared/composables/useSsoLinkConfirm.ts
@@ -30,7 +30,11 @@
  * - GET  /auth/sso-link-confirm/:token  200 => { provider, email }
  *                                       404 { error, error_code: 'link_expired' }
  *                                             => missing / consumed / expired
- *                                       500 { error } => unexpected
+ *                                       500 { error } => code-less; the STORE read
+ *                                             failed, so the token is untouched and
+ *                                             still live. Classified 'link_error',
+ *                                             NOT 'link_expired' (see
+ *                                             fetchFallbackForStatus).
  * - POST /auth/sso-link-confirm  200 => { success, redirect? } (session established)
  *                                    or { success, mfa_required, ... } (MFA account —
  *                                    identical body POST /auth/login returns; hand off
@@ -42,6 +46,10 @@
  *                                                        or (provider,issuer,uid) bound elsewhere
  *                                409 link_invalidated => a credential change advanced the
  *                                                        account's password watermark
+ *                                409 link_error       => the backend could not READ the
+ *                                                        watermark (its outage, not a
+ *                                                        credential change); still terminal —
+ *                                                        the token was consumed first
  *   The failure branch is distinguished by an { error_code } field and, defensively,
  *   the HTTP status.
  *
@@ -68,14 +76,19 @@ import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 /**
- * Typed failure the view maps to copy. Every code is terminal (no retryable
- * input on this page); they differ only in WHY the link can't be completed and
- * therefore in the message shown before sending the user back to sign in.
+ * Typed failure the view maps to copy. They differ in WHY the link can't be
+ * completed and therefore in the message shown before sending the user back to
+ * sign in. All are terminal for the current attempt — there is no retryable
+ * input on this page. The one code whose UNDERLYING token may still be live is
+ * 'link_error' raised by the GET path (our outage, nothing consumed), so its
+ * copy must never claim the link expired; returning to sign in re-issues a fresh
+ * email and works regardless.
  */
 export type SsoLinkConfirmErrorCode =
   | 'link_expired'
   | 'link_conflict'
   | 'link_invalidated'
+  | 'link_error'
   | 'invalid_request'
   | null;
 
@@ -90,26 +103,47 @@ interface ErrorResponseLike {
  * failure. Prefers the explicit backend code (the backend always sends one);
  * falls back to the status family only defensively. Returns null when the failure
  * is neither (e.g. an unclassifiable 5xx) so the caller surfaces a generic message.
+ *
+ * The five codes below are exactly the set apps/web/auth/routes/sso_link_confirm.rb
+ * emits — keep them in lockstep with that route.
+ *
+ * link_invalidated and link_error share HTTP 409, so ONLY the explicit backend code
+ * separates them (the status-family fallback collapses both to link_conflict). They
+ * differ in blame, not in outcome: a real credential change vs. a backend that could
+ * not read the credential state. Both stay terminal.
  */
 function resolveConfirmErrorCode(
   status: number | undefined,
   backendCode: unknown
 ): SsoLinkConfirmErrorCode {
   if (backendCode === 'link_invalidated') return 'link_invalidated';
+  if (backendCode === 'link_error') return 'link_error';
   if (backendCode === 'link_conflict') return 'link_conflict';
   if (backendCode === 'invalid_request') return 'invalid_request';
-  if (
-    backendCode === 'link_expired' ||
-    backendCode === 'expired_token' ||
-    backendCode === 'invalid_token'
-  ) {
-    return 'link_expired';
-  }
+  if (backendCode === 'link_expired') return 'link_expired';
   // Status-family fallback (backend always sends a code; this is defence only).
   if (status === 401 || status === 404 || status === 410) return 'link_expired';
   if (status === 409) return 'link_conflict';
   if (status === 400) return 'invalid_request';
   return null;
+}
+
+/**
+ * Dead-end bias for a GET (display-context) failure the backend did NOT classify
+ * with an { error_code }.
+ *
+ * apps/web/auth/routes/sso_link_confirm.rb returns a bare 500 { error: 'Failed to
+ * load linking request' } — no error_code — when the SsoLinkVerification load
+ * raises (datastore outage). The token is UNTOUCHED and still live for its full
+ * TTL, so biasing that to 'link_expired' would tell the user their link is dead
+ * and push them back through SSO to re-issue when a reload would have worked.
+ * 'link_error' names the real cause ("something went wrong on our side") without
+ * asserting the link is spent. Same for a transport failure with no response at
+ * all. Anything else (4xx) genuinely does mean missing / consumed / expired.
+ */
+function fetchFallbackForStatus(status: number | undefined): SsoLinkConfirmErrorCode {
+  if (status === undefined || status >= 500) return 'link_error';
+  return 'link_expired';
 }
 
 /* eslint-disable max-lines-per-function */
@@ -146,14 +180,15 @@ export function useSsoLinkConfirm() {
     if (code === 'link_expired') return t('web.sso_link_confirm.errors.link_expired');
     if (code === 'link_conflict') return t('web.sso_link_confirm.errors.link_conflict');
     if (code === 'link_invalidated') return t('web.sso_link_confirm.errors.link_invalidated');
+    if (code === 'link_error') return t('web.sso_link_confirm.errors.link_error');
     return t('web.sso_link_confirm.errors.generic');
   }
 
   /**
    * Classifies and stores a failure from the (status, backend error_code) pair.
-   * `fallback` biases an unclassifiable failure — any GET of the display context
-   * that fails at all means there is no usable context, so the fetch biases to
-   * 'link_expired' (dead-end) rather than a generic message.
+   * `fallback` biases an unclassifiable failure. The POST passes none (generic
+   * message); the GET passes fetchFallbackForStatus, because any failed load of
+   * the display context leaves nothing to show and deserves a specific reason.
    */
   function setConfirmError(
     status: number | undefined,
@@ -186,10 +221,11 @@ export function useSsoLinkConfirm() {
           `/auth/sso-link-confirm/${encodeURIComponent(token)}`
         );
       } catch (err) {
-        // Any failure to load the context means the token is spent/expired/
-        // unknown — bias the dead-end classification to 'link_expired'.
+        // No usable context either way, but WHY matters: a code-less 5xx (or no
+        // response at all) is our outage with the token still live, not a spent
+        // link. See fetchFallbackForStatus.
         const resp = readErrorResponse(err);
-        setConfirmError(resp?.status, resp?.data?.error_code, 'link_expired');
+        setConfirmError(resp?.status, resp?.data?.error_code, fetchFallbackForStatus(resp?.status));
         throw err;
       }
 

--- a/src/tests/apps/session/views/LinkSso.spec.ts
+++ b/src/tests/apps/session/views/LinkSso.spec.ts
@@ -368,4 +368,71 @@ describe('LinkSso', () => {
       });
     });
   });
+
+  describe('Accessibility', () => {
+    // Focus assertions need a real document connection.
+    const mountAttached = () =>
+      mount(LinkSso, { global: { plugins: [i18n] }, attachTo: document.body });
+
+    it('moves focus to the dead-end panel heading when the token expires mid-flow', async () => {
+      mockState.challenge.value = makeChallenge();
+      mockState.verifyLink.mockImplementation(async () => {
+        mockState.errorCode.value = 'invalid_token';
+        mockState.error.value = 'web.link_sso.errors.invalid_token';
+        return null;
+      });
+      wrapper = mountAttached();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="link-sso-password-input"]').setValue('pw');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      // The form that held focus is unmounted; without this, focus falls to
+      // <body> and the refusal is never announced.
+      const heading = wrapper.find('#link-sso-unavailable-title');
+      expect(heading.exists()).toBe(true);
+      expect(document.activeElement).toBe(heading.element);
+    });
+
+    it('keeps a single live region mounted so status changes are announced', async () => {
+      mockState.challenge.value = makeChallenge();
+      wrapper = mountComponent();
+      await flushPromises();
+
+      // Present (and empty) BEFORE the status changes — a region inserted with
+      // its text already in place is not reliably announced.
+      const region = wrapper.find('[data-testid="link-sso-status"]');
+      expect(region.exists()).toBe(true);
+      expect(region.attributes('aria-live')).toBe('polite');
+      expect(region.text()).toBe('');
+
+      mockState.isLoading.value = true;
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-testid="link-sso-status"]').text()).toBe(
+        'web.COMMON.form_processing'
+      );
+    });
+
+    it('gives every action a pointer cursor (Tailwind v4 drops the button default)', async () => {
+      mockState.challenge.value = makeChallenge();
+      wrapper = mountComponent();
+      await flushPromises();
+
+      for (const testid of ['link-sso-submit', 'link-sso-cancel']) {
+        expect(wrapper.find(`[data-testid="${testid}"]`).classes()).toContain('cursor-pointer');
+      }
+
+      wrapper.unmount();
+      mockState.challenge.value = null;
+      mockState.fetchChallenge.mockResolvedValue(null);
+      wrapper = mountComponent();
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="link-sso-unavailable-action"]').classes()).toContain(
+        'cursor-pointer'
+      );
+    });
+  });
 });

--- a/src/tests/apps/session/views/LinkSso.spec.ts
+++ b/src/tests/apps/session/views/LinkSso.spec.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { defineComponent, ref } from 'vue';
 import { createI18n } from 'vue-i18n';
 import type { LinkSsoChallenge } from '@/schemas/api/auth/responses/auth';
+import { _resetForTesting, updateBootstrapSnapshot } from '@/services/bootstrap.service';
 import type { LinkSsoErrorCode } from '@/shared/composables/useLinkSso';
 
 // Router: controllable route (params.token, query.redirect) + spyable push.
@@ -121,6 +122,9 @@ describe('LinkSso', () => {
 
   afterEach(() => {
     if (wrapper) wrapper.unmount();
+    // Drop any bootstrap seeded by the provider-label regression test so it
+    // cannot leak into sibling specs.
+    _resetForTesting();
   });
 
   describe('Mount / challenge fetch', () => {
@@ -182,6 +186,36 @@ describe('LinkSso', () => {
       wrapper = mountComponent();
       await flushPromises();
       expect(wrapper.find('[data-testid="link-sso-prompt"]').text()).toContain('Okta');
+    });
+
+    /**
+     * Regression guard: the prompt must stay canonical even when bootstrap DOES
+     * carry providers. Every stock deployment ships a generic display_name
+     * ('SSO' for oidc, 'Microsoft' for entra — lib/onetime/auth_config.rb's
+     * `sso_display_name || 'SSO'` default), so a display_name-first label helper
+     * renders "You signed in with SSO" in production while the default empty
+     * bootstrap keeps the other assertions green.
+     */
+    it('ignores the generic bootstrap display_name and names the provider canonically', async () => {
+      updateBootstrapSnapshot({
+        features: {
+          sso: {
+            enabled: true,
+            providers: [
+              { route_name: 'entra', display_name: 'Microsoft' },
+              { route_name: 'oidc', display_name: 'SSO' },
+            ],
+          },
+        },
+      } as unknown as Parameters<typeof updateBootstrapSnapshot>[0]);
+
+      mockState.challenge.value = makeChallenge({ provider: 'entra' });
+      wrapper = mountComponent();
+      await flushPromises();
+
+      const prompt = wrapper.find('[data-testid="link-sso-prompt"]').text();
+      expect(prompt).toContain('Microsoft Entra');
+      expect(prompt).not.toContain('with Microsoft,');
     });
   });
 

--- a/src/tests/apps/session/views/Login.spec.ts
+++ b/src/tests/apps/session/views/Login.spec.ts
@@ -124,8 +124,9 @@ describe('Login.vue auth_error handling', () => {
   afterEach(() => {
     wrapper?.unmount();
     // window.history is shared across tests in the jsdom environment; reset the
-    // handed-over verified flag so it never bleeds into the next case.
-    window.history.replaceState(null, '');
+    // handed-over verified flag AND the address bar (the query-param cleanup
+    // cases seed it) so neither bleeds into the next case.
+    window.history.replaceState(null, '', '/');
   });
 
   describe('error code handling', () => {
@@ -222,19 +223,30 @@ describe('Login.vue auth_error handling', () => {
     });
   });
 
+  // Cleanup happens on the ADDRESS BAR only (window.history.replaceState), not
+  // through the router: App.vue keys <router-view> by $route.fullPath, so a
+  // router.replace() dropping the param would remount this view and discard the
+  // banner it just set. Assert both halves of that contract — the param is gone
+  // from window.location, its siblings survive, and the banner is still on
+  // screen. The specs use memory history, so seed the address bar explicitly.
   describe('query param cleanup', () => {
-    it('removes auth_error from URL after displaying', async () => {
+    const seedAddressBar = (search: string) =>
+      window.history.replaceState(window.history.state, '', `/signin${search}`);
+
+    it('removes auth_error from the address bar after displaying', async () => {
+      seedAddressBar('?auth_error=sso_failed');
       wrapper = await createWrapper({ auth_error: 'sso_failed' });
       await flushPromises();
       await nextTick();
 
-      // Give router time to update
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      expect(router.currentRoute.value.query.auth_error).toBeUndefined();
+      expect(new URLSearchParams(window.location.search).has('auth_error')).toBe(false);
+      // The banner must survive the strip — this is the regression the
+      // replaceState switch fixes.
+      expect(wrapper.find('[role="alert"]').exists()).toBe(true);
     });
 
     it('preserves other query params when clearing auth_error', async () => {
+      seedAddressBar('?auth_error=sso_failed&redirect=%2Fdashboard');
       wrapper = await createWrapper({
         auth_error: 'sso_failed',
         redirect: '/dashboard',
@@ -242,14 +254,14 @@ describe('Login.vue auth_error handling', () => {
       await flushPromises();
       await nextTick();
 
-      // Give router time to update
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      expect(router.currentRoute.value.query.auth_error).toBeUndefined();
-      expect(router.currentRoute.value.query.redirect).toBe('/dashboard');
+      const params = new URLSearchParams(window.location.search);
+      expect(params.has('auth_error')).toBe(false);
+      expect(params.get('redirect')).toBe('/dashboard');
+      expect(wrapper.find('[role="alert"]').exists()).toBe(true);
     });
 
     it('preserves email param when clearing auth_error', async () => {
+      seedAddressBar('?auth_error=token_expired&email=user%40example.com');
       wrapper = await createWrapper({
         auth_error: 'token_expired',
         email: 'user@example.com',
@@ -257,10 +269,21 @@ describe('Login.vue auth_error handling', () => {
       await flushPromises();
       await nextTick();
 
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      const params = new URLSearchParams(window.location.search);
+      expect(params.has('auth_error')).toBe(false);
+      expect(params.get('email')).toBe('user@example.com');
+      expect(wrapper.find('[role="alert"]').exists()).toBe(true);
+    });
 
-      expect(router.currentRoute.value.query.auth_error).toBeUndefined();
-      expect(router.currentRoute.value.query.email).toBe('user@example.com');
+    it('leaves the router route untouched so the view is not remounted', async () => {
+      seedAddressBar('?auth_error=sso_failed');
+      wrapper = await createWrapper({ auth_error: 'sso_failed' });
+      await flushPromises();
+      await nextTick();
+
+      // A router navigation here would change fullPath and, via App.vue's
+      // keyed <router-view>, throw away the instance holding the banner.
+      expect(router.currentRoute.value.query.auth_error).toBe('sso_failed');
     });
   });
 

--- a/src/tests/apps/session/views/SsoLinkConfirm.spec.ts
+++ b/src/tests/apps/session/views/SsoLinkConfirm.spec.ts
@@ -1,0 +1,346 @@
+// src/tests/apps/session/views/SsoLinkConfirm.spec.ts
+
+import { mount, flushPromises, VueWrapper } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { defineComponent, ref } from 'vue';
+import { createI18n } from 'vue-i18n';
+import type { SsoLinkConfirmDisplay } from '@/schemas/api/auth/responses/auth';
+import type { SsoLinkConfirmErrorCode } from '@/shared/composables/useSsoLinkConfirm';
+
+// Router: controllable route (params.token, query.redirect) + spyable push.
+const mockPush = vi.fn();
+const mockRoute: { params: Record<string, unknown>; query: Record<string, unknown> } = {
+  params: {},
+  query: {},
+};
+vi.mock('vue-router', () => ({
+  useRoute: () => mockRoute,
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// AuthView: render named slots inline so slot content is testable.
+vi.mock('@/apps/session/components/AuthView.vue', () => ({
+  default: defineComponent({
+    name: 'AuthView',
+    template: `<div data-testid="auth-view"><slot name="form" /><slot name="footer" /></div>`,
+    props: ['heading', 'headingId', 'withSubheading', 'showReturnHome', 'title', 'titleLogo'],
+  }),
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-icon="name" />',
+    props: ['collection', 'name', 'class'],
+  },
+}));
+
+// Auth store: controllable auth state + spyable setAuthenticated.
+const mockSetAuthenticated = vi.fn();
+const mockAuthStore = { isFullyAuthenticated: false, setAuthenticated: mockSetAuthenticated };
+vi.mock('@/shared/stores/authStore', () => ({
+  useAuthStore: () => mockAuthStore,
+}));
+
+// Bootstrap store: MFA hand-off marks awaiting_mfa via update() (mirrors Login).
+const mockBootstrapUpdate = vi.fn();
+vi.mock('@/shared/stores/bootstrapStore', () => ({
+  useBootstrapStore: () => ({ update: mockBootstrapUpdate }),
+}));
+
+// Composable: controllable reactive state + spies.
+const mockState = {
+  pendingLink: ref<SsoLinkConfirmDisplay | null>(null),
+  isLoading: ref(false),
+  error: ref<string | null>(null),
+  errorCode: ref<SsoLinkConfirmErrorCode>(null),
+  fetchPendingLink: vi.fn(),
+  confirmLink: vi.fn(),
+  clearError: vi.fn(),
+};
+vi.mock('@/shared/composables/useSsoLinkConfirm', () => ({
+  useSsoLinkConfirm: () => mockState,
+}));
+
+import SsoLinkConfirm from '@/apps/session/views/SsoLinkConfirm.vue';
+
+// Pass-through i18n (keys render as-is), EXCEPT the prompt is given a real
+// interpolating message so the provider label + claimed email are observable in
+// the rendered text (the pass-through `missing` handler drops interpolation).
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  missingWarn: false,
+  fallbackWarn: false,
+  missing: (_: unknown, key: string) => key,
+  messages: {
+    en: {
+      web: {
+        sso_link_confirm: {
+          prompt: 'You signed in with {provider}, matching {email}.',
+        },
+      },
+    },
+  },
+});
+
+const makeLink = (overrides: Partial<SsoLinkConfirmDisplay> = {}): SsoLinkConfirmDisplay => ({
+  provider: 'entra',
+  email: 'user@example.com',
+  ...overrides,
+});
+
+/**
+ * SsoLinkConfirm Component Tests (#3840 Phase 4 — mailbox-proof linking)
+ *
+ * Verifies the consent page an emailed link opens for a PASSWORDLESS account:
+ * - fetches the display context on mount and names provider + claimed email
+ * - confirms via a single CTA (NO password — mailbox possession is the proof)
+ *   and completes sign-in on success
+ * - hands an MFA account off to /mfa-verify without completing sign-in
+ * - dead-ends (terminal panel) for a missing / expired / spent token OR any
+ *   confirm failure (conflict / invalidated) — a single-use token has no retry
+ * - cancel / dead-end action route to /signin (passwordless: re-do SSO)
+ */
+describe('SsoLinkConfirm', () => {
+  let wrapper: VueWrapper;
+
+  const mountComponent = () => mount(SsoLinkConfirm, { global: { plugins: [i18n] } });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRoute.params = { token: 'confirm-token-123' };
+    mockRoute.query = {};
+    mockState.pendingLink.value = null;
+    mockState.isLoading.value = false;
+    mockState.error.value = null;
+    mockState.errorCode.value = null;
+    mockState.fetchPendingLink.mockResolvedValue(makeLink());
+    mockState.confirmLink.mockResolvedValue({ success: 'ok' });
+    mockAuthStore.isFullyAuthenticated = false;
+  });
+
+  afterEach(() => {
+    if (wrapper) wrapper.unmount();
+  });
+
+  describe('Mount / display fetch', () => {
+    it('fetches the display context with the token from the route path param', async () => {
+      wrapper = mountComponent();
+      await flushPromises();
+      expect(mockState.fetchPendingLink).toHaveBeenCalledWith('confirm-token-123');
+    });
+
+    it('does NOT confirm (POST) on load — only on explicit consent', async () => {
+      wrapper = mountComponent();
+      await flushPromises();
+      // Never auto-POST: a mail/link prefetch of the page must not burn the token.
+      expect(mockState.confirmLink).not.toHaveBeenCalled();
+    });
+
+    it('redirects a fully authenticated user home and does not fetch', async () => {
+      mockAuthStore.isFullyAuthenticated = true;
+      wrapper = mountComponent();
+      await flushPromises();
+      expect(mockPush).toHaveBeenCalledWith('/');
+      expect(mockState.fetchPendingLink).not.toHaveBeenCalled();
+    });
+
+    it('dead-ends without fetching when the token is missing', async () => {
+      mockRoute.params = {};
+      wrapper = mountComponent();
+      await flushPromises();
+      expect(mockState.fetchPendingLink).not.toHaveBeenCalled();
+      expect(wrapper.find('[data-testid="sso-link-confirm-unavailable"]').exists()).toBe(true);
+    });
+
+    it('dead-ends when the display fetch fails (expired / spent token)', async () => {
+      mockState.fetchPendingLink.mockResolvedValue(null);
+      wrapper = mountComponent();
+      await flushPromises();
+      expect(wrapper.find('[data-testid="sso-link-confirm-unavailable"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="sso-link-confirm-submit"]').exists()).toBe(false);
+    });
+  });
+
+  describe('Consent display', () => {
+    beforeEach(() => {
+      mockState.pendingLink.value = makeLink();
+    });
+
+    it('names the provider (friendly label) and the claimed email', async () => {
+      wrapper = mountComponent();
+      await flushPromises();
+      const prompt = wrapper.find('[data-testid="sso-link-confirm-prompt"]');
+      expect(prompt.exists()).toBe(true);
+      expect(prompt.text()).toContain('Microsoft Entra');
+      expect(prompt.text()).toContain('user@example.com');
+    });
+
+    it('renders the confirm CTA and NO password field', async () => {
+      wrapper = mountComponent();
+      await flushPromises();
+      expect(wrapper.find('[data-testid="sso-link-confirm-submit"]').exists()).toBe(true);
+      expect(wrapper.find('input[type="password"]').exists()).toBe(false);
+    });
+
+    it('falls back to a capitalized provider name for unknown providers', async () => {
+      mockState.pendingLink.value = makeLink({ provider: 'okta' });
+      wrapper = mountComponent();
+      await flushPromises();
+      expect(wrapper.find('[data-testid="sso-link-confirm-prompt"]').text()).toContain('Okta');
+    });
+  });
+
+  describe('Confirm success', () => {
+    beforeEach(() => {
+      mockState.pendingLink.value = makeLink();
+    });
+
+    it('confirms with the token, completes sign-in, and navigates home by default', async () => {
+      wrapper = mountComponent();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="sso-link-confirm-submit"]').trigger('click');
+      await flushPromises();
+
+      expect(mockState.confirmLink).toHaveBeenCalledWith('confirm-token-123');
+      expect(mockSetAuthenticated).toHaveBeenCalledWith(true);
+      expect(mockPush).toHaveBeenCalledWith('/');
+    });
+
+    it('prefers the redirect target returned by the backend when it is internal', async () => {
+      mockState.confirmLink.mockResolvedValue({ success: 'ok', redirect: '/dashboard' });
+      wrapper = mountComponent();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="sso-link-confirm-submit"]').trigger('click');
+      await flushPromises();
+
+      expect(mockPush).toHaveBeenCalledWith('/dashboard');
+    });
+
+    it('falls back to the ?redirect query param when the response carries none', async () => {
+      mockRoute.query = { redirect: '/account/settings' };
+      wrapper = mountComponent();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="sso-link-confirm-submit"]').trigger('click');
+      await flushPromises();
+
+      expect(mockPush).toHaveBeenCalledWith('/account/settings');
+    });
+
+    it('ignores an external redirect target from the backend', async () => {
+      mockState.confirmLink.mockResolvedValue({ success: 'ok', redirect: 'https://evil.example/' });
+      wrapper = mountComponent();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="sso-link-confirm-submit"]').trigger('click');
+      await flushPromises();
+
+      expect(mockPush).toHaveBeenCalledWith('/');
+    });
+  });
+
+  describe('Confirm success — MFA required', () => {
+    beforeEach(() => {
+      mockState.pendingLink.value = makeLink();
+    });
+
+    it('does NOT mark fully authenticated and hands off to /mfa-verify', async () => {
+      mockState.confirmLink.mockResolvedValue({ success: 'ok', mfa_required: true });
+      wrapper = mountComponent();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="sso-link-confirm-submit"]').trigger('click');
+      await flushPromises();
+
+      expect(mockSetAuthenticated).not.toHaveBeenCalled();
+      expect(mockBootstrapUpdate).toHaveBeenCalledWith({
+        awaiting_mfa: true,
+        authenticated: false,
+      });
+      expect(mockPush).toHaveBeenCalledWith({ path: '/mfa-verify', query: undefined });
+    });
+
+    it('preserves the ?redirect query when handing off to /mfa-verify', async () => {
+      mockRoute.query = { redirect: '/account/settings' };
+      mockState.confirmLink.mockResolvedValue({ success: 'ok', mfa_required: true });
+      wrapper = mountComponent();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="sso-link-confirm-submit"]').trigger('click');
+      await flushPromises();
+
+      expect(mockPush).toHaveBeenCalledWith({
+        path: '/mfa-verify',
+        query: { redirect: '/account/settings' },
+      });
+    });
+  });
+
+  describe('Confirm failure', () => {
+    beforeEach(() => {
+      mockState.pendingLink.value = makeLink();
+    });
+
+    it('flips to the terminal panel (no retry) and does not authenticate on a conflict', async () => {
+      mockState.confirmLink.mockImplementation(async () => {
+        mockState.errorCode.value = 'link_conflict';
+        mockState.error.value = 'web.sso_link_confirm.errors.link_conflict';
+        return null;
+      });
+      wrapper = mountComponent();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="sso-link-confirm-submit"]').trigger('click');
+      await flushPromises();
+
+      expect(mockSetAuthenticated).not.toHaveBeenCalled();
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(wrapper.find('[data-testid="sso-link-confirm-unavailable"]').exists()).toBe(true);
+      // The consent CTA is gone — a single-use token has no retry path.
+      expect(wrapper.find('[data-testid="sso-link-confirm-submit"]').exists()).toBe(false);
+    });
+
+    it('shows the classified reason in the terminal panel body', async () => {
+      mockState.confirmLink.mockImplementation(async () => {
+        mockState.errorCode.value = 'link_invalidated';
+        mockState.error.value = 'web.sso_link_confirm.errors.link_invalidated';
+        return null;
+      });
+      wrapper = mountComponent();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="sso-link-confirm-submit"]').trigger('click');
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="sso-link-confirm-unavailable"]').text()).toContain(
+        'web.sso_link_confirm.errors.link_invalidated'
+      );
+    });
+  });
+
+  describe('Cancel / dead-end navigation', () => {
+    it('cancel routes to /signin (passwordless: re-do SSO)', async () => {
+      mockState.pendingLink.value = makeLink();
+      wrapper = mountComponent();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="sso-link-confirm-cancel"]').trigger('click');
+
+      expect(mockPush).toHaveBeenCalledWith('/signin');
+    });
+
+    it('the dead-end panel action routes to /signin', async () => {
+      mockState.fetchPendingLink.mockResolvedValue(null);
+      wrapper = mountComponent();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="sso-link-confirm-unavailable-action"]').trigger('click');
+
+      expect(mockPush).toHaveBeenCalledWith('/signin');
+    });
+  });
+});

--- a/src/tests/apps/session/views/SsoLinkConfirm.spec.ts
+++ b/src/tests/apps/session/views/SsoLinkConfirm.spec.ts
@@ -343,4 +343,70 @@ describe('SsoLinkConfirm', () => {
       expect(mockPush).toHaveBeenCalledWith('/signin');
     });
   });
+
+  describe('Accessibility', () => {
+    // Focus assertions need a real document connection.
+    const mountAttached = () =>
+      mount(SsoLinkConfirm, { global: { plugins: [i18n] }, attachTo: document.body });
+
+    it('moves focus to the terminal-panel heading when the confirm dead-ends', async () => {
+      mockState.pendingLink.value = makeLink();
+      mockState.confirmLink.mockImplementation(async () => {
+        mockState.errorCode.value = 'link_conflict';
+        mockState.error.value = 'web.sso_link_confirm.errors.link_conflict';
+        return null;
+      });
+      wrapper = mountAttached();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="sso-link-confirm-submit"]').trigger('click');
+      await flushPromises();
+
+      // The CTA that had focus is unmounted; without this, focus falls to <body>
+      // and the reason is never announced.
+      const heading = wrapper.find('#sso-link-confirm-unavailable-title');
+      expect(heading.exists()).toBe(true);
+      expect(document.activeElement).toBe(heading.element);
+    });
+
+    it('keeps a single live region mounted so status changes are announced', async () => {
+      mockState.pendingLink.value = makeLink();
+      wrapper = mountComponent();
+      await flushPromises();
+
+      // Present (and empty) BEFORE the status changes — a region inserted with
+      // its text already in place is not reliably announced.
+      const region = wrapper.find('[data-testid="sso-link-confirm-status"]');
+      expect(region.exists()).toBe(true);
+      expect(region.attributes('aria-live')).toBe('polite');
+      expect(region.text()).toBe('');
+
+      mockState.isLoading.value = true;
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-testid="sso-link-confirm-status"]').text()).toBe(
+        'web.COMMON.form_processing'
+      );
+    });
+
+    it('gives every action a pointer cursor (Tailwind v4 drops the button default)', async () => {
+      mockState.pendingLink.value = makeLink();
+      wrapper = mountComponent();
+      await flushPromises();
+
+      for (const testid of ['sso-link-confirm-submit', 'sso-link-confirm-cancel']) {
+        expect(wrapper.find(`[data-testid="${testid}"]`).classes()).toContain('cursor-pointer');
+      }
+
+      wrapper.unmount();
+      mockState.pendingLink.value = null;
+      mockState.fetchPendingLink.mockResolvedValue(null);
+      wrapper = mountComponent();
+      await flushPromises();
+
+      expect(
+        wrapper.find('[data-testid="sso-link-confirm-unavailable-action"]').classes()
+      ).toContain('cursor-pointer');
+    });
+  });
 });

--- a/src/tests/apps/session/views/SsoLinkConfirm.spec.ts
+++ b/src/tests/apps/session/views/SsoLinkConfirm.spec.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { defineComponent, ref } from 'vue';
 import { createI18n } from 'vue-i18n';
 import type { SsoLinkConfirmDisplay } from '@/schemas/api/auth/responses/auth';
+import { _resetForTesting, updateBootstrapSnapshot } from '@/services/bootstrap.service';
 import type { SsoLinkConfirmErrorCode } from '@/shared/composables/useSsoLinkConfirm';
 
 // Router: controllable route (params.token, query.redirect) + spyable push.
@@ -122,6 +123,9 @@ describe('SsoLinkConfirm', () => {
 
   afterEach(() => {
     if (wrapper) wrapper.unmount();
+    // Drop any bootstrap seeded by the provider-label regression test so it
+    // cannot leak into sibling specs.
+    _resetForTesting();
   });
 
   describe('Mount / display fetch', () => {
@@ -189,6 +193,36 @@ describe('SsoLinkConfirm', () => {
       wrapper = mountComponent();
       await flushPromises();
       expect(wrapper.find('[data-testid="sso-link-confirm-prompt"]').text()).toContain('Okta');
+    });
+
+    /**
+     * Regression guard: the prompt must stay canonical even when bootstrap DOES
+     * carry providers. Every stock deployment ships a generic display_name
+     * ('SSO' for oidc, 'Microsoft' for entra — lib/onetime/auth_config.rb's
+     * `sso_display_name || 'SSO'` default), so a display_name-first label helper
+     * renders "You signed in with SSO" in production while the default empty
+     * bootstrap keeps the other assertions green.
+     */
+    it('ignores the generic bootstrap display_name and names the provider canonically', async () => {
+      updateBootstrapSnapshot({
+        features: {
+          sso: {
+            enabled: true,
+            providers: [
+              { route_name: 'entra', display_name: 'Microsoft' },
+              { route_name: 'oidc', display_name: 'SSO' },
+            ],
+          },
+        },
+      } as unknown as Parameters<typeof updateBootstrapSnapshot>[0]);
+
+      mockState.pendingLink.value = makeLink({ provider: 'entra' });
+      wrapper = mountComponent();
+      await flushPromises();
+
+      const prompt = wrapper.find('[data-testid="sso-link-confirm-prompt"]').text();
+      expect(prompt).toContain('Microsoft Entra');
+      expect(prompt).not.toContain('with Microsoft,');
     });
   });
 

--- a/src/tests/apps/workspace/account/ConnectedIdentities.spec.ts
+++ b/src/tests/apps/workspace/account/ConnectedIdentities.spec.ts
@@ -4,6 +4,7 @@ import { mount, flushPromises, VueWrapper } from '@vue/test-utils';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import { ref } from 'vue';
+import { createI18n } from 'vue-i18n';
 import { createTestI18n } from '@tests/setup';
 import type { ConnectedIdentity } from '@/schemas/api/auth/responses/auth';
 import type { IdentityErrorCode } from '@/shared/composables/useConnectedIdentities';
@@ -75,9 +76,13 @@ vi.mock('@/shared/composables/useConnectedIdentities', () => ({
 }));
 
 // Configured SSO providers (bootstrap-backed in prod) — controllable per test.
+// Partial mock: only getSsoProviders is stubbed. providerLabel and
+// configuredProviderLabel stay real so the deliberate precedence split between
+// them (built-in map vs. operator display_name) is exercised, not stubbed away.
 import type { SsoProvider } from '@/utils/features';
 const mockGetSsoProviders = vi.fn<() => SsoProvider[]>(() => []);
-vi.mock('@/utils/features', () => ({
+vi.mock('@/utils/features', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils/features')>()),
   getSsoProviders: () => mockGetSsoProviders(),
 }));
 
@@ -319,6 +324,76 @@ describe('ConnectedIdentities', () => {
         redirect: '/account/settings/security/connections',
         connect: true,
       });
+    });
+  });
+
+  /**
+   * Label precedence with PRODUCTION display_name values.
+   *
+   * The fixtures above use display_name: 'OpenID Connect', which happens to match
+   * the built-in map and therefore cannot tell the two precedences apart. A stock
+   * deployment (OIDC_ISSUER + OIDC_CLIENT_ID, no OIDC_DISPLAY_NAME) ships the
+   * generic default 'SSO' / 'Microsoft' instead — the values that expose the
+   * split. Linked rows must stay canonical; connect buttons must honour the
+   * operator's name. Needs an i18n with a real interpolating message, since the
+   * shared pass-through i18n renders the bare key.
+   */
+  describe('Provider label precedence (stock backend display_name defaults)', () => {
+    const stockProviders: SsoProvider[] = [
+      { route_name: 'oidc', display_name: 'SSO' },
+      { route_name: 'entra', display_name: 'Microsoft' },
+    ];
+
+    const interpolatingI18n = createI18n({
+      legacy: false,
+      locale: 'en',
+      missingWarn: false,
+      fallbackWarn: false,
+      missing: (_: unknown, key: string) => key,
+      messages: {
+        en: { web: { auth: { connections: { connect_action: 'Connect {provider}' } } } },
+      },
+    });
+
+    const mountWithI18n = () =>
+      mount(ConnectedIdentities, {
+        global: {
+          plugins: [interpolatingI18n, createTestingPinia({ createSpy: vi.fn })],
+        },
+      });
+
+    it('labels a linked row canonically, ignoring the generic display_name', () => {
+      mockState.identities.value = [
+        makeIdentity({ id: 1, provider: 'oidc' }),
+        makeIdentity({ id: 2, provider: 'entra' }),
+      ];
+      mockGetSsoProviders.mockReturnValue(stockProviders);
+      wrapper = mountWithI18n();
+
+      const list = wrapper.find('[data-testid="connections-list"]').text();
+      expect(list).toContain('OpenID Connect');
+      expect(list).toContain('Microsoft Entra');
+    });
+
+    it('labels the connect button with the operator display_name', () => {
+      mockGetSsoProviders.mockReturnValue(stockProviders);
+      wrapper = mountWithI18n();
+
+      expect(wrapper.find('[data-testid="connections-connect-oidc"]').text()).toContain(
+        'Connect SSO'
+      );
+      expect(wrapper.find('[data-testid="connections-connect-entra"]').text()).toContain(
+        'Connect Microsoft'
+      );
+    });
+
+    it('falls back to the canonical label when display_name is blank', () => {
+      mockGetSsoProviders.mockReturnValue([{ route_name: 'oidc', display_name: '' }]);
+      wrapper = mountWithI18n();
+
+      expect(wrapper.find('[data-testid="connections-connect-oidc"]').text()).toContain(
+        'Connect OpenID Connect'
+      );
     });
   });
 

--- a/src/tests/composables/useSsoLinkConfirm.spec.ts
+++ b/src/tests/composables/useSsoLinkConfirm.spec.ts
@@ -21,8 +21,8 @@ vi.mock('@/shared/stores/csrfStore', () => ({
  * Verifies the GET display-context fetch and the POST confirm (NO password —
  * mailbox possession is the proof), plus the typed error classification the view
  * branches on. Every failure is terminal; they differ only in the reason:
- * link_expired / link_conflict / link_invalidated / invalid_request — distinguished
- * by the backend { error_code } and, defensively, the HTTP status.
+ * link_expired / link_conflict / link_invalidated / link_error / invalid_request —
+ * distinguished by the backend { error_code } and, defensively, the HTTP status.
  */
 describe('useSsoLinkConfirm', () => {
   let axiosMock: AxiosMockAdapter;
@@ -87,14 +87,52 @@ describe('useSsoLinkConfirm', () => {
       expect(errorCode.value).toBe('link_expired');
     });
 
-    it('dead-ends (link_expired) on an unexpected server error (500)', async () => {
+    // The route returns a bare 500 { error } (NO error_code) when the token-store
+    // read raises. The token is untouched and live for its full TTL, so blaming
+    // an expired link would push an outage victim back through SSO needlessly.
+    it('blames the outage, not the link, on a code-less 500 (link_error)', async () => {
       axiosMock.onGet('/auth/sso-link-confirm/boom').reply(500, { error: 'failed to load' });
 
-      const { fetchPendingLink, errorCode } = useSsoLinkConfirm();
+      const { fetchPendingLink, error, errorCode } = useSsoLinkConfirm();
       const result = await fetchPendingLink('boom');
 
-      // Any GET failure means no usable context; the fetch biases to link_expired.
       expect(result).toBeNull();
+      expect(errorCode.value).toBe('link_error');
+      expect(error.value).toBe('web.sso_link_confirm.errors.link_error');
+      expect(error.value).not.toBe('web.sso_link_confirm.errors.link_expired');
+    });
+
+    // Same reasoning for a transport failure: nothing reached the backend, so
+    // nothing was consumed.
+    it('blames the outage on a network failure with no response (link_error)', async () => {
+      axiosMock.onGet('/auth/sso-link-confirm/offline').networkError();
+
+      const { fetchPendingLink, errorCode } = useSsoLinkConfirm();
+      const result = await fetchPendingLink('offline');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('link_error');
+    });
+
+    // An explicit backend code still wins over the 5xx bias.
+    it('honours an explicit error_code on a 5xx over the outage bias', async () => {
+      axiosMock
+        .onGet('/auth/sso-link-confirm/coded')
+        .reply(503, { error: 'gone', error_code: 'link_expired' });
+
+      const { fetchPendingLink, errorCode } = useSsoLinkConfirm();
+      await fetchPendingLink('coded');
+
+      expect(errorCode.value).toBe('link_expired');
+    });
+
+    // 4xx without a code really does mean missing / consumed / expired.
+    it('still dead-ends (link_expired) on a code-less 404', async () => {
+      axiosMock.onGet('/auth/sso-link-confirm/nope').reply(404, { error: 'not found' });
+
+      const { fetchPendingLink, errorCode } = useSsoLinkConfirm();
+      await fetchPendingLink('nope');
+
       expect(errorCode.value).toBe('link_expired');
     });
   });
@@ -184,6 +222,25 @@ describe('useSsoLinkConfirm', () => {
       expect(result).toBeNull();
       expect(errorCode.value).toBe('link_invalidated');
       expect(error.value).toBe('web.sso_link_confirm.errors.link_invalidated');
+    });
+
+    // A backend that could not READ the watermark shares the 409 with a real
+    // credential change; only the error_code separates them. Mis-mapping this to
+    // link_invalidated would tell an outage victim their credentials changed.
+    it('classifies an unreadable-watermark backend failure (409 link_error)', async () => {
+      axiosMock
+        .onPost('/auth/sso-link-confirm')
+        .reply(409, { error: "couldn't verify", error_code: 'link_error' });
+
+      const { confirmLink, error, errorCode } = useSsoLinkConfirm();
+      const result = await confirmLink('tok123');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('link_error');
+      expect(error.value).toBe('web.sso_link_confirm.errors.link_error');
+      // Terminal, exactly like link_invalidated: the token was consumed before the
+      // probe ran, so the view must dead-end rather than offer a retry.
+      expect(error.value).not.toBe('web.sso_link_confirm.errors.link_invalidated');
     });
 
     // MFA account: the backend returns the SAME body POST /auth/login returns for

--- a/src/tests/composables/useSsoLinkConfirm.spec.ts
+++ b/src/tests/composables/useSsoLinkConfirm.spec.ts
@@ -1,0 +1,249 @@
+// src/tests/composables/useSsoLinkConfirm.spec.ts
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSsoLinkConfirm } from '@/shared/composables/useSsoLinkConfirm';
+import { setupTestPinia } from '../setup';
+import type AxiosMockAdapter from 'axios-mock-adapter';
+
+// Pass-through i18n: keys render as-is so assertions can match on the key.
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+// CSRF store: confirmLink includes csrfStore.shrimp in the POST body.
+vi.mock('@/shared/stores/csrfStore', () => ({
+  useCsrfStore: () => ({ shrimp: 'test-shrimp' }),
+}));
+
+/**
+ * useSsoLinkConfirm Composable Tests (#3840 Phase 4 — mailbox-proof linking)
+ *
+ * Verifies the GET display-context fetch and the POST confirm (NO password —
+ * mailbox possession is the proof), plus the typed error classification the view
+ * branches on. Every failure is terminal; they differ only in the reason:
+ * link_expired / link_conflict / link_invalidated / invalid_request — distinguished
+ * by the backend { error_code } and, defensively, the HTTP status.
+ */
+describe('useSsoLinkConfirm', () => {
+  let axiosMock: AxiosMockAdapter;
+
+  beforeEach(async () => {
+    const setup = await setupTestPinia();
+    axiosMock = setup.axiosMock!;
+  });
+
+  afterEach(() => {
+    axiosMock.restore();
+    vi.clearAllMocks();
+  });
+
+  describe('fetchPendingLink', () => {
+    it('returns the display context on success', async () => {
+      axiosMock
+        .onGet('/auth/sso-link-confirm/tok123')
+        .reply(200, { provider: 'entra', email: 'user@example.com' });
+
+      const { fetchPendingLink, pendingLink, error, errorCode } = useSsoLinkConfirm();
+      const result = await fetchPendingLink('tok123');
+
+      expect(result).toEqual({ provider: 'entra', email: 'user@example.com' });
+      expect(pendingLink.value).toEqual({ provider: 'entra', email: 'user@example.com' });
+      expect(error.value).toBeNull();
+      expect(errorCode.value).toBeNull();
+    });
+
+    it('url-encodes the token in the path', async () => {
+      axiosMock
+        .onGet('/auth/sso-link-confirm/a%2Fb')
+        .reply(200, { provider: 'oidc', email: 'a@b.com' });
+
+      const { fetchPendingLink } = useSsoLinkConfirm();
+      const result = await fetchPendingLink('a/b');
+
+      expect(result).toEqual({ provider: 'oidc', email: 'a@b.com' });
+    });
+
+    it('dead-ends (link_expired) when the token is not found (404)', async () => {
+      axiosMock
+        .onGet('/auth/sso-link-confirm/gone')
+        .reply(404, { error: 'no longer valid', error_code: 'link_expired' });
+
+      const { fetchPendingLink, pendingLink, error, errorCode } = useSsoLinkConfirm();
+      const result = await fetchPendingLink('gone');
+
+      expect(result).toBeNull();
+      expect(pendingLink.value).toBeNull();
+      expect(errorCode.value).toBe('link_expired');
+      expect(error.value).toBe('web.sso_link_confirm.errors.link_expired');
+    });
+
+    it('treats a 200 error body as a spent token (link_expired)', async () => {
+      axiosMock.onGet('/auth/sso-link-confirm/weird').reply(200, { error: 'expired' });
+
+      const { fetchPendingLink, errorCode } = useSsoLinkConfirm();
+      const result = await fetchPendingLink('weird');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('link_expired');
+    });
+
+    it('dead-ends (link_expired) on an unexpected server error (500)', async () => {
+      axiosMock.onGet('/auth/sso-link-confirm/boom').reply(500, { error: 'failed to load' });
+
+      const { fetchPendingLink, errorCode } = useSsoLinkConfirm();
+      const result = await fetchPendingLink('boom');
+
+      // Any GET failure means no usable context; the fetch biases to link_expired.
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('link_expired');
+    });
+  });
+
+  describe('confirmLink', () => {
+    it('returns the success body (with redirect) on 200', async () => {
+      axiosMock
+        .onPost('/auth/sso-link-confirm')
+        .reply(200, { success: 'linked', redirect: '/dashboard' });
+
+      const { confirmLink, error, errorCode } = useSsoLinkConfirm();
+      const result = await confirmLink('tok123');
+
+      expect(result).toEqual({ success: 'linked', redirect: '/dashboard' });
+      expect(error.value).toBeNull();
+      expect(errorCode.value).toBeNull();
+    });
+
+    it('accepts a success body without a redirect target', async () => {
+      axiosMock.onPost('/auth/sso-link-confirm').reply(200, { success: 'linked' });
+
+      const { confirmLink } = useSsoLinkConfirm();
+      const result = await confirmLink('tok123');
+
+      expect(result).toEqual({ success: 'linked' });
+    });
+
+    it('sends the token and shrimp — and NO password', async () => {
+      axiosMock.onPost('/auth/sso-link-confirm').reply(200, { success: 'linked' });
+
+      const { confirmLink } = useSsoLinkConfirm();
+      await confirmLink('tok123');
+
+      const body = JSON.parse(axiosMock.history.post[0].data);
+      expect(body).toEqual({ token: 'tok123', shrimp: 'test-shrimp' });
+      expect(body).not.toHaveProperty('password');
+    });
+
+    it('classifies a missing token (400 invalid_request)', async () => {
+      axiosMock
+        .onPost('/auth/sso-link-confirm')
+        .reply(400, { error: 'token required', error_code: 'invalid_request' });
+
+      const { confirmLink, errorCode } = useSsoLinkConfirm();
+      const result = await confirmLink('');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('invalid_request');
+    });
+
+    it('classifies a spent/expired token (401 link_expired)', async () => {
+      axiosMock
+        .onPost('/auth/sso-link-confirm')
+        .reply(401, { error: 'expired', error_code: 'link_expired' });
+
+      const { confirmLink, error, errorCode } = useSsoLinkConfirm();
+      const result = await confirmLink('tok123');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('link_expired');
+      expect(error.value).toBe('web.sso_link_confirm.errors.link_expired');
+    });
+
+    it('classifies an account/identity conflict (409 link_conflict)', async () => {
+      axiosMock
+        .onPost('/auth/sso-link-confirm')
+        .reply(409, { error: 'could not complete', error_code: 'link_conflict' });
+
+      const { confirmLink, error, errorCode } = useSsoLinkConfirm();
+      const result = await confirmLink('tok123');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('link_conflict');
+      expect(error.value).toBe('web.sso_link_confirm.errors.link_conflict');
+    });
+
+    // A watermark-advancing credential change and a plain conflict are both 409;
+    // the explicit error_code is what disambiguates them (status alone can't).
+    it('classifies a credential change (409 link_invalidated) via error_code', async () => {
+      axiosMock
+        .onPost('/auth/sso-link-confirm')
+        .reply(409, { error: 'credentials changed', error_code: 'link_invalidated' });
+
+      const { confirmLink, error, errorCode } = useSsoLinkConfirm();
+      const result = await confirmLink('tok123');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('link_invalidated');
+      expect(error.value).toBe('web.sso_link_confirm.errors.link_invalidated');
+    });
+
+    // MFA account: the backend returns the SAME body POST /auth/login returns for
+    // MFA. The schema must NOT strip mfa_required (else the view would mark the
+    // user fully authenticated and skip the OTP challenge).
+    it('preserves mfa_required (does not strip it) on a 200 MFA response', async () => {
+      axiosMock
+        .onPost('/auth/sso-link-confirm')
+        .reply(200, { success: 'ok', mfa_required: true, mfa_methods: ['otp'] });
+
+      const { confirmLink, error, errorCode } = useSsoLinkConfirm();
+      const result = await confirmLink('tok123');
+
+      expect(result).toMatchObject({
+        success: 'ok',
+        mfa_required: true,
+        mfa_methods: ['otp'],
+      });
+      expect(error.value).toBeNull();
+      expect(errorCode.value).toBeNull();
+    });
+
+    it('treats a 200 error body carrying link_conflict as classified', async () => {
+      axiosMock
+        .onPost('/auth/sso-link-confirm')
+        .reply(200, { error: 'stale', error_code: 'link_conflict' });
+
+      const { confirmLink, errorCode } = useSsoLinkConfirm();
+      const result = await confirmLink('tok123');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('link_conflict');
+    });
+
+    it('falls back to a generic error for an unclassifiable failure (500)', async () => {
+      axiosMock.onPost('/auth/sso-link-confirm').reply(500);
+
+      const { confirmLink, error, errorCode } = useSsoLinkConfirm();
+      const result = await confirmLink('tok123');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBeNull();
+      expect(error.value).toBe('web.sso_link_confirm.errors.generic');
+    });
+  });
+
+  describe('clearError', () => {
+    it('resets both error and errorCode', async () => {
+      axiosMock
+        .onPost('/auth/sso-link-confirm')
+        .reply(409, { error: 'nope', error_code: 'link_conflict' });
+
+      const { confirmLink, clearError, error, errorCode } = useSsoLinkConfirm();
+      await confirmLink('tok123');
+      expect(error.value).not.toBeNull();
+      expect(errorCode.value).toBe('link_conflict');
+
+      clearError();
+      expect(error.value).toBeNull();
+      expect(errorCode.value).toBeNull();
+    });
+  });
+});

--- a/src/tests/utils/features.spec.ts
+++ b/src/tests/utils/features.spec.ts
@@ -26,6 +26,9 @@ import {
   isFullAuthMode,
   isApproximatedDomainValidationOf,
   isApproximatedDomainValidation,
+  providerLabel,
+  configuredProviderLabel,
+  getSsoProviders,
 } from '@/utils/features';
 import { _resetForTesting } from '@/services/bootstrap.service';
 
@@ -1178,6 +1181,92 @@ describe('features utility', () => {
   });
 
   // ── SSR safety (window undefined) ─────────────────────────────────
+
+  /**
+   * Provider label precedence.
+   *
+   * The backend ALWAYS populates features.sso.providers[].display_name — a stock
+   * install that sets only OIDC_ISSUER + OIDC_CLIENT_ID gets the generic default
+   * ('SSO' for oidc, 'Microsoft' for entra; see lib/onetime/auth_config.rb).
+   * These tests seed exactly that shape, because a bootstrap with no `features`
+   * key (the default under test) makes the precedence unobservable — which is how
+   * a display_name-first providerLabel once shipped unnoticed.
+   */
+  describe('provider labels (bootstrap populated with backend defaults)', () => {
+    const STOCK_SSO_FEATURES = {
+      sso: {
+        enabled: true,
+        providers: [
+          // Exactly what the backend ships with no *_DISPLAY_NAME env var set.
+          { route_name: 'oidc', display_name: 'SSO' },
+          { route_name: 'entra', display_name: 'Microsoft' },
+        ],
+      },
+    };
+
+    beforeEach(() => {
+      getBootstrapValueMock.mockImplementation((key: string) =>
+        key === 'features' ? STOCK_SSO_FEATURES : undefined
+      );
+    });
+
+    it('exposes the generic backend defaults (guards the fixture)', () => {
+      expect(getSsoProviders()).toEqual([
+        { route_name: 'oidc', display_name: 'SSO' },
+        { route_name: 'entra', display_name: 'Microsoft' },
+      ]);
+    });
+
+    describe('providerLabel — canonical, built-in map wins', () => {
+      // The regression: a display_name-first providerLabel returns 'SSO' here and
+      // renders "You signed in with SSO" on the linking pages.
+      it('returns the built-in label even though display_name is set', () => {
+        expect(providerLabel('oidc')).toBe('OpenID Connect');
+        expect(providerLabel('entra')).toBe('Microsoft Entra');
+      });
+
+      it('covers the remaining built-in strategies', () => {
+        expect(providerLabel('github')).toBe('GitHub');
+        expect(providerLabel('google')).toBe('Google');
+      });
+
+      it('capitalizes an unknown route name', () => {
+        expect(providerLabel('okta')).toBe('Okta');
+      });
+
+      it('returns an empty string for a missing route name', () => {
+        expect(providerLabel('')).toBe('');
+      });
+    });
+
+    describe('configuredProviderLabel — operator display_name wins', () => {
+      it('prefers the configured display_name (connect buttons)', () => {
+        expect(configuredProviderLabel({ route_name: 'oidc', display_name: 'SSO' })).toBe('SSO');
+        expect(configuredProviderLabel({ route_name: 'entra', display_name: 'Microsoft' })).toBe(
+          'Microsoft'
+        );
+      });
+
+      it('honours an operator-chosen name', () => {
+        expect(configuredProviderLabel({ route_name: 'oidc', display_name: 'Acme SSO' })).toBe(
+          'Acme SSO'
+        );
+      });
+
+      it('falls back to the built-in label when display_name is blank', () => {
+        expect(configuredProviderLabel({ route_name: 'oidc', display_name: '   ' })).toBe(
+          'OpenID Connect'
+        );
+        expect(
+          configuredProviderLabel({ route_name: 'entra' } as unknown as { route_name: string; display_name: string })
+        ).toBe('Microsoft Entra');
+      });
+
+      it('falls back to a capitalized route name for an unknown blank provider', () => {
+        expect(configuredProviderLabel({ route_name: 'okta', display_name: '' })).toBe('Okta');
+      });
+    });
+  });
 
   describe('SSR safety (window undefined)', () => {
     // Store original window reference

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -188,6 +188,64 @@ export function getSsoProviders(): SsoProvider[] {
 }
 
 /**
+ * Built-in friendly labels for the omniauth strategies shipped with the app.
+ *
+ * Keyed on the omniauth ROUTE NAME ('entra'), NOT the domain-SSO strategy id
+ * ('entra_id') — that is a separate surface with its own label list (see
+ * DomainSsoConfigForm.vue).
+ */
+const PROVIDER_LABELS: Record<string, string> = {
+  oidc: 'OpenID Connect',
+  entra: 'Microsoft Entra',
+  github: 'GitHub',
+  google: 'Google',
+};
+
+/**
+ * Canonical display label for an omniauth route name ('entra' → 'Microsoft Entra').
+ *
+ * Resolution order:
+ * 1. The built-in label above.
+ * 2. The capitalized route name, so a backend that adds a strategy still renders
+ *    sensibly.
+ *
+ * DELIBERATELY does NOT consult the bootstrap `display_name`. The backend always
+ * populates that field with a generic default — lib/onetime/auth_config.rb
+ * resolves it to `sso_display_name || 'SSO'`, so a stock OIDC install (no
+ * OIDC_DISPLAY_NAME set) ships display_name: 'SSO' and entra ships 'Microsoft'.
+ * Preferring it here would make this map unreachable in production and silently
+ * downgrade prose like "You signed in with OpenID Connect" to "…with SSO".
+ *
+ * Use this wherever the provider is named in prose or in a linked-identity row:
+ * ConnectedIdentities linked rows, LinkSso, SsoLinkConfirm.
+ * Use configuredProviderLabel() — NOT this — for the Connect buttons, where the
+ * operator's chosen name is what should win. Do not collapse the two into one
+ * helper: the precedence difference is intentional and user-visible.
+ */
+export function providerLabel(routeName: string): string {
+  if (!routeName) return '';
+
+  return PROVIDER_LABELS[routeName] ?? routeName.charAt(0).toUpperCase() + routeName.slice(1);
+}
+
+/**
+ * Display label for a CONFIGURED provider, operator `display_name` first.
+ *
+ * The inverse precedence of providerLabel(): an operator who sets
+ * OIDC_DISPLAY_NAME='Acme SSO' expects the Connect button to read
+ * "Connect Acme SSO" with no frontend change. Falls back to providerLabel()
+ * (built-in map, then capitalized route name) when display_name is blank.
+ *
+ * Only the ConnectedIdentities connect buttons use this — see providerLabel()
+ * for why the other label sites must not.
+ */
+export function configuredProviderLabel(provider: SsoProvider): string {
+  return provider.display_name?.trim()
+    ? provider.display_name
+    : providerLabel(provider.route_name);
+}
+
+/**
  * Checks if SSO-only authentication is enforced for this domain.
  * When true, password-based authentication is disabled and users
  * must sign in via the configured SSO provider.

--- a/try/unit/mail/templates_brand_color_try.rb
+++ b/try/unit/mail/templates_brand_color_try.rb
@@ -456,9 +456,9 @@ offenders = files.select { |path| File.read(path).include?('onetime-logo-v3-xl.s
 offenders.map { |p| File.basename(p) }.sort
 #=> []
 
-## All 22 shipped HTML templates are present (count baseline)
+## All 23 shipped HTML templates are present (count baseline)
 Dir.glob(File.join(ENV.fetch('ONETIME_HOME'), 'lib/onetime/mail/templates/*.html.erb')).size
-#=> 22
+#=> 23
 
 ## [regression guard] no shipped email template hardcodes the 'Delano' sign-off
 files = Dir.glob(File.join(ENV.fetch('ONETIME_HOME'), 'lib/onetime/mail/templates/*.erb'))


### PR DESCRIPTION
## #3840 Phase 4 — Mailbox-proof SSO linking for passwordless accounts

> **Stacked PR.** Base is `feature/3840-sso-linking-orchestration` (the #3840 integration branch), not `main`. Sibling Phase 4.A (deferred-MFA bind, #3877) is #3879 against the same base; file-disjoint except `router.rb`.

### Problem

Phases 1–3 relaxed the SSO email-link **refusal** for accounts that can *prove ownership*: a trusted-IdP flag (Phase 1), authenticated session linking (Phase 2), and a password-challenge interstitial (Phase 3). One case still dead-ended at the H-3 refusal (`/signin?auth_error=account_exists_link_required`): a **passwordless** account (SSO-only, or migrated without a local password) signing in through a *new* SSO identity. There is no password to challenge.

### Approach

A passwordless account can still prove ownership the way magic-link (`email_auth`) does: **control of its on-file mailbox.** Instead of refusing, the callback emails a single-use link to the account's on-file address; binding `(provider, issuer, uid)` happens only when the user clicks it and confirms. This keeps the #3840 invariant intact — *email may **locate** an account; only a demonstrated credential may **bind** an identity* — with mailbox control as the credential.

**The token travels only through the email, never the callback redirect.** The callback redirects the browser to a **token-less** notice (`/signin?auth_notice=link_verification_sent`) and delivers the token *solely* to the on-file inbox. A caller who merely completed an SSO round-trip asserting the victim's email never learns the token and cannot self-consume it.

### Flow

1. `account_from_omniauth` finds an existing account matched by email, with no challengeable password, on the **platform** surface, trust flag off.
2. Mints a single-use `Onetime::SsoLinkVerification` (Redis, 15-min TTL) snapshotting `(provider, resolved_issuer, uid, normalized email, account id, initiating sid, password watermark)`.
3. Emails the token to the on-file address (`fallback: :sync`, auth-critical). Mail delivery **raises** ⇒ token consumed, fall through to the unchanged H-3 refusal (fail closed — never tell the user to check an inbox that got no mail).
4. Redirects to the token-less notice; `Login.vue` renders a "check your inbox" banner.
5. The emailed link opens `SsoLinkConfirm.vue`. `GET /auth/sso-link-confirm/:token` loads display context (**never consumes** — mail/link prefetch must not burn the single-use token). On explicit consent, `POST /auth/sso-link-confirm` atomically consumes, binds, and establishes the session via `rodauth.login` (so `after_login` runs — Redis session blob, active-sessions, MFA detection).

### Security properties

| Property | Mechanism |
|---|---|
| Token = mailbox proof | Delivered only to the on-file inbox; never in the callback redirect |
| Single-use | `#delete!` is the atomic consume gate *before* bind; concurrent confirms race on the DEL count |
| GET is side-effect-free | Display-only; prefetch/preview bots can't consume the token |
| Credential-change invalidation | Token snapshots `Customer#last_password_update`; a watermark advance ⇒ `link_invalidated` (comparison, not a token sweep — no change to credential hooks) |
| Ownership re-check | Account re-located by snapshotted id; email must still normalize to the token's email |
| MFA-safe bind | Pending second factor ⇒ bind **deferred**, login proceeds to OTP (`mfa_required`); completion is #3877 |
| Cross-device tolerant | Initiating sid is compare-and-warn, never a hard gate (user may click on their phone) |
| Platform-only | Tenant callbacks keep the H-3 refusal (a tenant admin controls their IdP) |

### POST error codes

`400 invalid_request` (no token) · `401 link_expired` (spent/expired/account gone) · `409 link_conflict` (account re-emailed, or identity bound elsewhere) · `409 link_invalidated` (watermark advanced).

### Changes
- **Backend:** `SsoLinkVerification` model; `account_from_omniauth` passwordless branch; `ConfirmSsoLink` op (reuses the merged `BindSsoIdentity` primitive); `GET/POST /auth/sso-link-confirm`; mailer view + html/txt templates.
- **Frontend:** `SsoLinkConfirm.vue` + `useSsoLinkConfirm` composable + zod schemas; `/sso-link-confirm/:token` route (`sentryScrubParams: ['token']`); `Login.vue` inbox notice.
- **Docs/i18n:** `per-install-sso.md` "Mailbox-proof linking" section; EN strings (email + consent page + notice).

### Tests
- Backend: `40 examples, 0 failures, 4 pending` across the new model/op/route/integration specs. Pending = full OIDC-callback E2E (needs a live discovery endpoint at boot) + the MFA-deferred case (#3877 harness); the GET/POST confirm endpoints and error codes are directly covered by the passing examples.
- Frontend: `58 passed` (`SsoLinkConfirm.vue`, `useSsoLinkConfirm`, `Login`).
- Rubocop + ESLint (staged) + tsc: green.

### Follow-ups
- #3877 — complete the deferred SSO identity bind after MFA (shared with Phase 4.A / #3879).
- No per-address issuance throttle yet (same shape as `email_auth`; never binds without a victim click). Worth a rate-limit follow-up.
