### PR TITLE
Move the deferred SSO bind stash onto SessionSidecar

### DIFF
--- a/apps/web/auth/config/hooks/login.rb
+++ b/apps/web/auth/config/hooks/login.rb
@@ -215,7 +215,6 @@ module Auth::Config::Hooks
             outcome = Auth::Operations::DeferredSsoBind.complete(
               db: db,
               sid: session.id&.public_id,
-              session: session,
               account_id: account_id,
             )
             unless outcome == :none

--- a/apps/web/auth/config/hooks/login.rb
+++ b/apps/web/auth/config/hooks/login.rb
@@ -200,19 +200,21 @@ module Auth::Config::Hooks
           session['awaiting_mfa'] = false
 
           # Self-heal a DEFERRED SSO bind whose MFA prediction went stale
-          # (#3877). The link-sso interstitial stashes a deferred bind (via the
-          # rodauth.login block, i.e. BEFORE this hook) only when its pre-login
-          # MFA check said a second factor was pending. If the decision just
-          # made HERE disagrees (the account's factors changed in the window
-          # between the two checks), no second factor will ever fire to
-          # complete the stash — so complete it now: the password verified
-          # moments ago and no factor is pending, which is exactly the
-          # authorization the interstitial's direct-bind branch requires. For
-          # every other login the stash cannot exist (login_session destroyed
-          # the previous session before this hook) and this is a no-op (:none).
+          # (#3877). The link-sso interstitial stashes a deferred bind (a
+          # sid-bound SessionSidecar key written in the rodauth.login block,
+          # i.e. BEFORE this hook — #3858) only when its pre-login MFA check
+          # said a second factor was pending. If the decision just made HERE
+          # disagrees (the account's factors changed in the window between the
+          # two checks), no second factor will ever fire to complete the stash
+          # — so complete it now: the password verified moments ago and no
+          # factor is pending, which is exactly the authorization the
+          # interstitial's direct-bind branch requires. For every other login
+          # the stash cannot exist (login_session re-keyed the sid before this
+          # hook, and sidecar keys are sid-bound) and this is a no-op (:none).
           Onetime::ErrorHandler.safe_execute('complete_deferred_sso_bind', account_id: account_id) do
             outcome = Auth::Operations::DeferredSsoBind.complete(
               db: db,
+              sid: session.id&.public_id,
               session: session,
               account_id: account_id,
             )

--- a/apps/web/auth/config/hooks/mfa.rb
+++ b/apps/web/auth/config/hooks/mfa.rb
@@ -181,16 +181,18 @@ module Auth::Config::Hooks
         # link-sso interstitial verifies the existing password but must NOT bind
         # the (provider, issuer, uid) identity while a second factor is pending
         # (SSO logins are MFA-exempt — a pre-2FA bind would be an MFA-bypassing
-        # login path), so it stashes the authorized bind in the partial MFA
-        # session instead. The second factor has now succeeded — finish it.
-        # Single-use (the stash is consumed up front), account-bound, and
-        # audit-and-skip on conflict/mismatch: MFA already succeeded, so nothing
-        # here may fail the login — hence the best-effort wrapper. :none for
-        # every login that didn't come through the interstitial's deferred
-        # branch (the common case: one session-hash lookup, no DB access).
+        # login path), so it stashes the authorized bind in a short-TTL
+        # SessionSidecar key bound to the partial MFA session's sid (#3858).
+        # The second factor has now succeeded — finish it. Single-use (atomic
+        # GETDEL at the store), account-bound, and audit-and-skip on
+        # conflict/mismatch: MFA already succeeded, so nothing here may fail
+        # the login — hence the best-effort wrapper. :none for every login
+        # that didn't come through the interstitial's deferred branch (the
+        # common case: one Redis GETDEL, no DB access).
         Onetime::ErrorHandler.safe_execute('complete_deferred_sso_bind', account_id: account_id) do
           outcome = Auth::Operations::DeferredSsoBind.complete(
             db: db,
+            sid: session.id&.public_id,
             session: session,
             account_id: account_id,
           )

--- a/apps/web/auth/config/hooks/mfa.rb
+++ b/apps/web/auth/config/hooks/mfa.rb
@@ -239,8 +239,20 @@ module Auth::Config::Hooks
           correlation_id: correlation_id,
         )
 
-        # Clear awaiting_mfa flag
-        session[:awaiting_mfa] = false
+        # Write the healing FALSE over the hand-off flag (STRING key — the one
+        # PrepareMfaSession wrote and the M-11 guard reads; SyncSession already
+        # deleted both key forms above). Not parked state: the sidecar commit
+        # treats a falsy awaiting_mfa as a DELETE (absent_when_falsy), so on
+        # success this request converges the field to absent everywhere. The
+        # write is load-bearing for exactly one failure case: if this request's
+        # sidecar commit FAILS, the DEL of the stale sidecar awaiting_mfa=true
+        # is lost with it — but write_session's rescue keeps this false in the
+        # BLOB, where blob-wins outranks the stale true on the next read and
+        # the next healthy commit heals it. A deletion here could not win that
+        # conflict: the blob would carry nothing, and the stale true would
+        # re-merge (and re-commit with a fresh TTL) on every request — an
+        # authenticated session locked out of every gated route indefinitely.
+        session['awaiting_mfa'] = false
 
         # Clean up correlation ID after successful completion
         session.delete(:auth_correlation_id)

--- a/apps/web/auth/config/hooks/mfa.rb
+++ b/apps/web/auth/config/hooks/mfa.rb
@@ -193,7 +193,6 @@ module Auth::Config::Hooks
           outcome = Auth::Operations::DeferredSsoBind.complete(
             db: db,
             sid: session.id&.public_id,
-            session: session,
             account_id: account_id,
           )
           unless outcome == :none

--- a/apps/web/auth/operations/deferred_sso_bind.rb
+++ b/apps/web/auth/operations/deferred_sso_bind.rb
@@ -135,17 +135,20 @@ module Auth
           # write returns the effective TTL, or nil when no key was written
           # (a sid that fails the sidecar's format guard).
           written = !Onetime::SessionSidecar.write(
-            sid, FIELD, payload, dbclient: dbclient, codec: codec,
+            sid, FIELD, payload, dbclient: dbclient, codec: codec
           ).nil?
           unless written
             logger.warn 'Deferred SSO bind not stashed: session id unavailable',
-              account_id: account_id, provider: provider
+              account_id: account_id,
+              provider: provider
           end
           written
         rescue StandardError => ex
           logger.warn 'Deferred SSO bind not stashed: sidecar write failed',
-            account_id: account_id, provider: provider,
-            error: ex.message, error_class: ex.class.name
+            account_id: account_id,
+            provider: provider,
+            error: ex.message,
+            error_class: ex.class.name
           false
         end
 
@@ -163,8 +166,13 @@ module Auth
         # @return [:none, :ok, :conflict, :mismatch]
         def complete(db:, sid:, account_id:, session: nil, logger: nil, dbclient: nil, codec: nil)
           new(
-            db: db, sid: sid, account_id: account_id, session: session,
-            logger: logger, dbclient: dbclient, codec: codec,
+            db: db,
+            sid: sid,
+            account_id: account_id,
+            session: session,
+            logger: logger,
+            dbclient: dbclient,
+            codec: codec,
           ).complete
         end
 

--- a/apps/web/auth/operations/deferred_sso_bind.rb
+++ b/apps/web/auth/operations/deferred_sso_bind.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require 'onetime/session/sidecar'
+
 require_relative 'bind_sso_identity'
 
 #
@@ -22,7 +24,7 @@ require_relative 'bind_sso_identity'
 # so an MFA account that authenticates through the interstitial ends up linked
 # exactly like a non-MFA account:
 #
-#   1. `.defer`    — the interstitial stashes the pending bind into the partial
+#   1. `.defer`    — the interstitial stashes the pending bind for the partial
 #                    MFA session (alongside PrepareMfaSession's awaiting_mfa
 #                    state). The password has ALREADY been verified and the
 #                    single-use challenge token ALREADY consumed by this point;
@@ -32,39 +34,60 @@ require_relative 'bind_sso_identity'
 #                    consumes the stash and performs the bind via the shared
 #                    BindSsoIdentity primitive.
 #
-# ## Session contract
+# ## Storage contract (#3858)
 #
-# The payload lives under SESSION_KEY as a STRING-KEYED hash — the session blob
-# is JSON-serialized into Redis between the login request and the MFA-verify
-# request (lib/onetime/session.rb), so symbol keys would not round-trip:
+# The stash is a SessionSidecar explicit-use field — the sso_connect_intent
+# pattern — NOT a field in the session blob:
+#
+#   sidecar:<sid>:link_sso_pending_bind   (encrypted, sid/field-bound, TTL 900s)
+#
+# holding the string-keyed bind tuple:
 #
 #   { 'account_id' => '42', 'provider' => 'oidc',
 #     'issuer' => 'https://...', 'uid' => 'sub-123' }
 #
-# TIMING (load-bearing): Rodauth's login_session CLEARS the session (the app's
-# clear_session override destroys it) before after_login runs, so the stash must
-# be written AFTER login_session — the interstitial writes it inside the block
-# it passes to rodauth.login('password'), which Rodauth yields between
-# login_session and after_login. From there it survives the MFA hand-off:
-# two_factor_authenticate does not clear the session (it only appends to
-# authenticated_by), the same mechanism awaiting_mfa relies on.
+# Living there instead of in the blob buys the two properties the blob could
+# not provide (and closes the distributed session-key hand-off this class used
+# to coordinate across the route and two hooks):
+#
+#   - BOUNDED IN TIME: the key's 900s TTL matches awaiting_mfa's MFA
+#     completion window (SessionSidecar::FIELDS), so an ABANDONED half-done
+#     MFA login expires the pending bind with the window instead of leaving
+#     it live for the session blob's full 24h.
+#   - ATOMIC SINGLE-USE: `.complete` consumes the key via SessionSidecar's
+#     GETDEL, so exactly one caller can ever observe the stash — single-use
+#     is enforced at the store, not by a Ruby delete-then-act sequence.
+#
+# TIMING (load-bearing): `.defer` must run with the FINAL sid of the login —
+# Rodauth's login_session RE-KEYS the session (the app's clear_session
+# override destroys it, minting a new sid), so a stash written before it
+# would key to the destroyed sid and never be found. The interstitial defers
+# inside the block it passes to rodauth.login('password'), which Rodauth
+# yields between login_session (sid now final) and after_login (whose stale-
+# prediction self-heal in hooks/login.rb is the earliest reader). The sid is
+# then stable through the MFA hand-off — two_factor_authenticate never
+# re-keys the session — so the MFA-verify request presents the same sid.
 #
 # ## Security model
 #
 #   - The stash is NOT an authorization: it can only be written by the
 #     interstitial AFTER the existing password verified (and any prior session
-#     content was destroyed by login_session moments earlier). It lives in the
-#     server-side encrypted+HMAC'd session blob, out of the client's reach.
-#   - SINGLE-USE: `.complete` deletes the stash BEFORE attempting the bind, so
-#     an error can never leave a retryable pending bind behind.
+#     content was destroyed by login_session moments earlier). It lives in an
+#     encrypted, sid/field-bound sidecar envelope, out of the client's reach;
+#     a value replayed under another sid decodes as absent.
+#   - SINGLE-USE: `.complete` consumes the stash atomically BEFORE attempting
+#     the bind, so an error can never leave a retryable pending bind behind.
 #   - ACCOUNT-BOUND: the stash snapshots the account the password proved; if the
 #     account completing the second factor differs, the bind is refused
 #     (:mismatch) — defence-in-depth against a re-keyed session.
-#   - NEVER fails the login: MFA has already succeeded when `.complete` runs and
-#     there is no error surface to return to the user, so :conflict / :mismatch
-#     are audit-and-skip outcomes (the BindSsoIdentity contract for
-#     post-authentication callers). The user simply remains unlinked and can
-#     link later via Connected Identities.
+#   - FAIL-CLOSED, NEVER fails the login: the bind is best-effort by contract
+#     (audit-and-skip). A lost or expired stash means no bind — the user
+#     simply remains unlinked and can link later via Connected Identities —
+#     so `.defer` swallows storage failures rather than aborting a login whose
+#     password already verified. MFA has already succeeded when `.complete`
+#     runs and there is no error surface to return to the user, so :conflict /
+#     :mismatch are audit-and-skip outcomes (the BindSsoIdentity contract for
+#     post-authentication callers).
 #
 # Returns from `.complete`:
 #   :none     — no stash present (every login that didn't come through the
@@ -78,56 +101,101 @@ require_relative 'bind_sso_identity'
 module Auth
   module Operations
     class DeferredSsoBind
-      # Session key for the pending-bind payload. Written only by `.defer`
-      # (from the interstitial's login block) and consumed only by `.complete`
-      # (from the MFA-success hook).
-      SESSION_KEY = 'link_sso_pending_bind'
+      # The SessionSidecar registry field (and, historically, the session-blob
+      # key) for the pending-bind payload. Written only by `.defer` (from the
+      # interstitial's login block) and consumed only by `.complete` (from the
+      # MFA-success hook / the after_login self-heal).
+      FIELD = 'link_sso_pending_bind'
 
       class << self
-        # Stash a pending bind into the (already re-keyed) login session.
+        # Stash a pending bind for the (already re-keyed) login session.
         #
-        # @param session [Hash] the Rack session — call AFTER login_session has
-        #   run (inside the rodauth.login block), or the login-time
-        #   clear_session wipes the stash
+        # BEST-EFFORT: a storage failure is logged and swallowed — the login
+        # (whose password already verified) must proceed; the user just stays
+        # unlinked this round (fail-closed) and re-hits the interstitial on
+        # their next SSO sign-in.
+        #
+        # @param sid [String] the session id — read it AFTER login_session has
+        #   run (inside the rodauth.login block), or the login-time re-key
+        #   strands the stash under the destroyed sid
         # @param account_id [Integer, String] the account the password proved
         # @param provider [String] OmniAuth provider name
         # @param issuer [String, nil] resolved IdP issuer; nil → '' sentinel
         # @param uid [String] provider-scoped subject id
-        def defer(session:, account_id:, provider:, issuer:, uid:)
-          session[SESSION_KEY] = {
+        # @return [Boolean] whether the stash was written
+        def defer(sid:, account_id:, provider:, issuer:, uid:, logger: nil, dbclient: nil, codec: nil)
+          logger ||= default_logger
+          payload  = {
             'account_id' => account_id.to_s,
             'provider' => provider.to_s,
             'issuer' => issuer.to_s,
             'uid' => uid.to_s,
           }
+
+          # write returns the effective TTL, or nil when no key was written
+          # (a sid that fails the sidecar's format guard).
+          written = !Onetime::SessionSidecar.write(
+            sid, FIELD, payload, dbclient: dbclient, codec: codec,
+          ).nil?
+          unless written
+            logger.warn 'Deferred SSO bind not stashed: session id unavailable',
+              account_id: account_id, provider: provider
+          end
+          written
+        rescue StandardError => ex
+          logger.warn 'Deferred SSO bind not stashed: sidecar write failed',
+            account_id: account_id, provider: provider,
+            error: ex.message, error_class: ex.class.name
+          false
         end
 
-        # Consume the stash (single-use) and complete the bind for the account
-        # that just fully authenticated.
+        # Consume the stash (atomic single-use) and complete the bind for the
+        # account that just fully authenticated.
         #
         # @param db [Sequel::Database] the auth database
-        # @param session [Hash] the Rack session carrying the stash
+        # @param sid [String] the session id carrying the sidecar stash
         # @param account_id [Integer, String] the account that completed the
         #   second factor (rodauth.account_id in the hook)
+        # @param session [Hash, nil] the Rack session, when the caller has one —
+        #   any blob-resident stash left by a pre-sidecar writer (rolling
+        #   deploy) is discarded UNCONSUMED, mirroring sso_connect_intent
         # @param logger [Logger, nil]
         # @return [:none, :ok, :conflict, :mismatch]
-        def complete(db:, session:, account_id:, logger: nil)
-          new(db: db, session: session, account_id: account_id, logger: logger).complete
+        def complete(db:, sid:, account_id:, session: nil, logger: nil, dbclient: nil, codec: nil)
+          new(
+            db: db, sid: sid, account_id: account_id, session: session,
+            logger: logger, dbclient: dbclient, codec: codec,
+          ).complete
+        end
+
+        def default_logger
+          Onetime.get_logger('Auth::DeferredSsoBind')
         end
       end
 
-      def initialize(db:, session:, account_id:, logger: nil)
+      def initialize(db:, sid:, account_id:, session: nil, logger: nil, dbclient: nil, codec: nil)
         @db         = db
-        @session    = session
+        @sid        = sid
         @account_id = account_id
-        @logger     = logger || Onetime.get_logger('Auth::DeferredSsoBind')
+        @session    = session
+        @logger     = logger || self.class.default_logger
+        @dbclient   = dbclient
+        @codec      = codec
       end
 
       # @return [:none, :ok, :conflict, :mismatch]
       def complete
-        # SINGLE-USE: remove the stash up front so no outcome — including an
-        # exception from the insert — leaves a retryable pending bind behind.
-        pending = @session.delete(SESSION_KEY)
+        # Rolling-deploy hygiene: a stash written into the session BLOB by a
+        # pre-sidecar writer is discarded unconsumed (never completed) — the
+        # same posture the sso_connect_intent migration took. Fail-closed: the
+        # user stays unlinked and re-hits the interstitial next sign-in.
+        @session&.delete(FIELD)
+
+        # SINGLE-USE, ATOMIC: GETDEL at the store, so no outcome — including
+        # an exception from the insert below — leaves a retryable pending bind
+        # behind, and two concurrent completions can never both see the stash.
+        # nil covers absent, expired, tampered, and sid-binding-mismatch alike.
+        pending = Onetime::SessionSidecar.consume(@sid, FIELD, dbclient: @dbclient, codec: @codec)
         return :none unless well_formed?(pending)
 
         # ACCOUNT-BOUND: bind only onto the account the password proved. The
@@ -171,7 +239,7 @@ module Auth
 
       # A usable stash is a hash carrying the full bind tuple. Anything else
       # (nil, legacy junk, partial writes) is discarded silently — the key has
-      # already been deleted above, so malformed data cannot linger.
+      # already been consumed above, so malformed data cannot linger.
       def well_formed?(pending)
         pending.is_a?(Hash) &&
           !pending['provider'].to_s.empty? &&

--- a/apps/web/auth/operations/deferred_sso_bind.rb
+++ b/apps/web/auth/operations/deferred_sso_bind.rb
@@ -68,6 +68,13 @@ require_relative 'bind_sso_identity'
 # then stable through the MFA hand-off — two_factor_authenticate never
 # re-keys the session — so the MFA-verify request presents the same sid.
 #
+# TRIPWIRE for that stability assumption: `.complete` cannot log a missing
+# stash (:none is its overwhelmingly common, legitimate outcome), so a future
+# refactor that re-keys sessions MID-flow would strand the hand-off silently
+# — except that the field is registered destroy_warn: true, and the session
+# middleware's delete_session warns whenever it destroys a session still
+# holding a live pending bind (Onetime::SessionSidecar#inflight_fields).
+#
 # ## Security model
 #
 #   - The stash is NOT an authorization: it can only be written by the
@@ -101,10 +108,10 @@ require_relative 'bind_sso_identity'
 module Auth
   module Operations
     class DeferredSsoBind
-      # The SessionSidecar registry field (and, historically, the session-blob
-      # key) for the pending-bind payload. Written only by `.defer` (from the
-      # interstitial's login block) and consumed only by `.complete` (from the
-      # MFA-success hook / the after_login self-heal).
+      # The SessionSidecar registry field for the pending-bind payload.
+      # Written only by `.defer` (from the interstitial's login block) and
+      # consumed only by `.complete` (from the MFA-success hook / the
+      # after_login self-heal).
       FIELD = 'link_sso_pending_bind'
 
       class << self
@@ -159,17 +166,13 @@ module Auth
         # @param sid [String] the session id carrying the sidecar stash
         # @param account_id [Integer, String] the account that completed the
         #   second factor (rodauth.account_id in the hook)
-        # @param session [Hash, nil] the Rack session, when the caller has one —
-        #   any blob-resident stash left by a pre-sidecar writer (rolling
-        #   deploy) is discarded UNCONSUMED, mirroring sso_connect_intent
         # @param logger [Logger, nil]
         # @return [:none, :ok, :conflict, :mismatch]
-        def complete(db:, sid:, account_id:, session: nil, logger: nil, dbclient: nil, codec: nil)
+        def complete(db:, sid:, account_id:, logger: nil, dbclient: nil, codec: nil)
           new(
             db: db,
             sid: sid,
             account_id: account_id,
-            session: session,
             logger: logger,
             dbclient: dbclient,
             codec: codec,
@@ -181,11 +184,10 @@ module Auth
         end
       end
 
-      def initialize(db:, sid:, account_id:, session: nil, logger: nil, dbclient: nil, codec: nil)
+      def initialize(db:, sid:, account_id:, logger: nil, dbclient: nil, codec: nil)
         @db         = db
         @sid        = sid
         @account_id = account_id
-        @session    = session
         @logger     = logger || self.class.default_logger
         @dbclient   = dbclient
         @codec      = codec
@@ -193,12 +195,6 @@ module Auth
 
       # @return [:none, :ok, :conflict, :mismatch]
       def complete
-        # Rolling-deploy hygiene: a stash written into the session BLOB by a
-        # pre-sidecar writer is discarded unconsumed (never completed) — the
-        # same posture the sso_connect_intent migration took. Fail-closed: the
-        # user stays unlinked and re-hits the interstitial next sign-in.
-        @session&.delete(FIELD)
-
         # SINGLE-USE, ATOMIC: GETDEL at the store, so no outcome — including
         # an exception from the insert below — leaves a retryable pending bind
         # behind, and two concurrent completions can never both see the stash.

--- a/apps/web/auth/routes/link_sso.rb
+++ b/apps/web/auth/routes/link_sso.rb
@@ -44,10 +44,11 @@ require 'onetime/security/login_rate_limiter'
 #     Binding before 2FA would attach an MFA-EXEMPT SSO login path (SSO logins
 #     bypass MFA) to an account whose owner never passed the second factor — a
 #     password-only attacker could then sign in via SSO and defeat MFA. The
-#     deferred bind is stashed in the partial MFA session (DeferredSsoBind.defer)
-#     and completed by after_two_factor_authentication once the second factor
-#     succeeds (#3877 / Phase 4.A), so MFA accounts end up linked exactly like
-#     non-MFA accounts — just one factor later.
+#     deferred bind is stashed in a short-TTL SessionSidecar key bound to the
+#     partial MFA session's sid (DeferredSsoBind.defer, #3858) and completed by
+#     after_two_factor_authentication once the second factor succeeds (#3877 /
+#     Phase 4.A), so MFA accounts end up linked exactly like non-MFA accounts —
+#     just one factor later.
 #   - PLATFORM-only: challenges are minted solely on the platform callback path,
 #     so the tenant surface is never offered this interstitial (#3849).
 #
@@ -207,9 +208,9 @@ module Auth
               # DEFERRED BIND (#3877 / Phase 4.A): the password HAS verified, so
               # the bind is authorized — only its timing moves. Snapshot the
               # challenge tuple here (the single-use token is already consumed;
-              # this local is the last place it exists) and stash it into the
-              # session INSIDE the login block below, where it survives the
-              # login-time clear_session and rides the partial MFA session to
+              # this local is the last place it exists) and stash it INSIDE the
+              # login block below as a short-TTL SessionSidecar key bound to
+              # the partial MFA session's sid (#3858), to be consumed by
               # after_two_factor_authentication (hooks/mfa.rb), which completes
               # the bind once the second factor succeeds.
               deferred_bind = {
@@ -268,13 +269,19 @@ module Auth
             # through unchanged; the SPA already handles both shapes.
             #
             # The block Rodauth yields runs between login_session and after_login —
-            # the ONLY point where a session write both survives the login-time
-            # clear_session (login_session destroys the previous session) and
-            # precedes after_login's MFA hand-off (PrepareMfaSession). Stash the
-            # deferred bind there so after_two_factor_authentication can complete it.
+            # the ONLY point that both sees the login's FINAL sid (login_session
+            # destroys the previous session, minting a new sid; a stash keyed to
+            # the old sid would never be found) and precedes after_login (whose
+            # stale-prediction self-heal in hooks/login.rb is the earliest
+            # reader). Stash the deferred bind there — a sid-bound SessionSidecar
+            # key (#3858) — so after_two_factor_authentication can consume it.
+            # Best-effort by contract: a failed stash write is logged inside
+            # `.defer` and the login proceeds unlinked (fail-closed).
             rodauth.login('password') do
               if deferred_bind
-                Auth::Operations::DeferredSsoBind.defer(session: session, **deferred_bind)
+                Auth::Operations::DeferredSsoBind.defer(
+                  sid: session.id&.public_id, **deferred_bind,
+                )
               end
             end
           rescue Onetime::LimitExceeded => ex

--- a/apps/web/auth/spec/operations/deferred_sso_bind_spec.rb
+++ b/apps/web/auth/spec/operations/deferred_sso_bind_spec.rb
@@ -2,45 +2,103 @@
 #
 # frozen_string_literal: true
 
-# Unit tests for Auth::Operations::DeferredSsoBind (#3877 / #3840 Phase 4.A).
+# Unit tests for Auth::Operations::DeferredSsoBind (#3877 / #3840 Phase 4.A,
+# storage moved to SessionSidecar in #3858).
 #
 # The MFA hand-off for the interstitial's identity bind: `.defer` stashes an
-# ALREADY-AUTHORIZED (password-proven) bind into the partial MFA session, and
-# `.complete` — called from after_two_factor_authentication — consumes it and
-# performs the bind via the shared BindSsoIdentity primitive.
+# ALREADY-AUTHORIZED (password-proven) bind as a short-TTL, sid-bound
+# SessionSidecar key, and `.complete` — called from
+# after_two_factor_authentication — consumes it (atomic GETDEL at the store)
+# and performs the bind via the shared BindSsoIdentity primitive.
 #
 # Like bind_sso_identity_spec.rb, these run against a REAL in-memory SQLite
 # account_identities table carrying the REAL (provider, issuer, uid) unique
 # index (RodauthTestHelper.create_test_database), because the decisions under
-# test — did a row land, on WHOSE account, exactly once — are DB facts.
+# test — did a row land, on WHOSE account, exactly once — are DB facts. The
+# Redis side is a minimal in-memory stand-in implementing exactly the commands
+# SessionSidecar issues (SET+EX / GET / GETDEL / DEL / TTL), paired with a
+# REAL SessionCodec so the encrypted, sid/field-bound envelope is genuine —
+# the GETDEL-vs-concurrency guarantee itself is locked in by the sidecar's
+# own tryouts against real Valkey (try/unit/session/sidecar_try.rb).
 #
 # What this file locks in:
-#   - the session contract: the stash round-trips the JSON serialization the
-#     Redis session blob applies between the login request and the MFA-verify
-#     request (lib/onetime/session.rb) — symbol keys would NOT survive that,
-#     so the payload must be string-keyed;
+#   - the storage contract: the stash is an ENCRYPTED sidecar envelope under
+#     sidecar:<sid>:link_sso_pending_bind, sid/field-bound, string-keyed
+#     payload, TTL clamped to the registered 900s MFA window;
 #   - SINGLE-USE: the stash is consumed up front, on EVERY outcome — including
 #     when the underlying insert raises — so no path leaves a retryable
 #     pending bind behind;
 #   - ACCOUNT-BOUND: a stash snapshotted for one account never binds onto a
 #     different authenticated account (:mismatch, audit-and-skip);
+#   - SID-BOUND: a stash value replayed under another sid decodes as absent
+#     (:none) — one session's pending bind can never complete under another;
+#   - BEST-EFFORT defer: a storage failure returns false instead of raising,
+#     so it can never abort a login whose password already verified;
 #   - :conflict passthrough: a (provider, issuer, uid) row owned by another
-#     account is never bound over and never reported as success.
+#     account is never bound over and never reported as success;
+#   - rolling-deploy hygiene: a legacy BLOB-resident stash is discarded
+#     unconsumed, never completed.
 #
 # The end-to-end MFA path (interstitial -> mfa_required -> OTP -> bound row)
-# needs an AUTH_MFA_ENABLED integration harness — tracked in #3877 alongside
-# the pending example in integration/full/omniauth_signin_interstitial_spec.rb.
+# is covered by integration/full_mfa/omniauth_signin_interstitial_mfa_spec.rb.
 #
 # Run: pnpm run test:rspec apps/web/auth/spec/operations/deferred_sso_bind_spec.rb
 
 require 'json'
+require 'securerandom'
 require_relative '../spec_helper'
+require 'onetime/session/sidecar'
 require 'auth/operations/deferred_sso_bind'
 
 RSpec.describe Auth::Operations::DeferredSsoBind do
+  # Minimal in-memory stand-in for the sidecar's Redis surface. Implements
+  # only what SessionSidecar issues: SET+EX, GET, GETDEL (the atomic consume),
+  # DEL, TTL. TTLs are recorded, not enforced — expiry semantics live in the
+  # sidecar tryouts against real Valkey.
+  class FakeSidecarRedis
+    def initialize
+      @data = {}
+      @ttls = {}
+    end
+
+    def set(key, value, ex: nil)
+      @data[key] = value
+      @ttls[key] = ex
+      'OK'
+    end
+
+    def get(key)
+      @data[key]
+    end
+
+    def getdel(key)
+      @ttls.delete(key)
+      @data.delete(key)
+    end
+
+    def del(*keys)
+      keys.count { |key| !@data.delete(key).nil? }
+    end
+
+    def ttl(key)
+      return -2 unless @data.key?(key)
+
+      @ttls[key] || -1
+    end
+
+    def exists(*keys)
+      keys.count { |key| @data.key?(key) }
+    end
+  end
+
   # Fresh real DB per example (in-memory SQLite) -> perfect isolation, no cleanup.
   let(:db)         { create_test_database }
   let(:identities) { db[:account_identities] }
+
+  let(:redis) { FakeSidecarRedis.new }
+  let(:codec) { Onetime::SessionCodec.new('deferred-sso-bind-spec-secret') }
+  let(:sid)   { SecureRandom.hex(32) } # 64 hex chars, matches the sidecar SID_FORMAT
+  let(:key)   { Onetime::SessionSidecar.key_for(sid, described_class::FIELD) }
 
   let(:provider) { 'oidc' }
   let(:issuer)   { 'https://issuer.example.com' }
@@ -61,99 +119,121 @@ RSpec.describe Auth::Operations::DeferredSsoBind do
     id
   end
 
-  # A session as the interstitial leaves it: `.defer` writes the stash the same
-  # way the rodauth.login block does.
-  def deferred_session(for_account: account_id)
-    session = {}
-    described_class.defer(
-      session: session, account_id: for_account, provider: provider, issuer: issuer, uid: uid,
-    )
-    session
+  before do
+    # A live session blob for the sid: the sidecar clamps every write against
+    # the blob's remaining TTL so a stash can never outlive the session.
+    redis.set("session:#{sid}", 'blob', ex: 86_400)
   end
 
-  def complete(session, as_account: account_id)
-    described_class.complete(db: db, session: session, account_id: as_account, logger: logger)
+  # Stash a pending bind the same way the interstitial's rodauth.login block does.
+  def defer(for_account: account_id, for_sid: sid, issuer_value: issuer)
+    described_class.defer(
+      sid: for_sid, account_id: for_account, provider: provider, issuer: issuer_value, uid: uid,
+      dbclient: redis, codec: codec, logger: logger,
+    )
+  end
+
+  def complete(as_account: account_id, for_sid: sid, session: nil)
+    described_class.complete(
+      db: db, sid: for_sid, account_id: as_account, session: session,
+      dbclient: redis, codec: codec, logger: logger,
+    )
   end
 
   describe '.defer' do
-    it 'stashes a fully STRING-keyed, string-valued payload under SESSION_KEY' do
-      session = deferred_session
+    it 'stores an encrypted, sid/field-bound envelope around the STRING-keyed bind tuple' do
+      expect(defer).to be(true)
 
-      expect(session).to eq(
-        described_class::SESSION_KEY => {
-          'account_id' => account_id.to_s,
-          'provider'   => provider,
-          'issuer'     => issuer,
-          'uid'        => uid,
-        },
+      raw = redis.get(key)
+      expect(raw).not_to be_nil
+
+      envelope = codec.decode(raw)
+      expect(envelope['sid']).to eq(sid)
+      expect(envelope['f']).to eq(described_class::FIELD)
+      expect(envelope['v']).to eq(
+        'account_id' => account_id.to_s,
+        'provider'   => provider,
+        'issuer'     => issuer,
+        'uid'        => uid,
       )
     end
 
+    it 'clamps the key TTL to the registered 900s MFA completion window' do
+      defer
+
+      expect(redis.ttl(key)).to be_between(1, 900)
+    end
+
     it 'coerces a nil issuer to the empty-string sentinel expected by the unique index' do
-      session = {}
-      described_class.defer(
-        session: session, account_id: account_id, provider: provider, issuer: nil, uid: uid,
-      )
-      expect(session[described_class::SESSION_KEY]['issuer']).to eq('')
+      defer(issuer_value: nil)
+
+      expect(codec.decode(redis.get(key))['v']['issuer']).to eq('')
+    end
+
+    it 'returns false (and writes nothing) when no usable sid is available' do
+      expect(defer(for_sid: nil)).to be(false)
+      expect(logger).to have_received(:warn)
+    end
+
+    it 'is BEST-EFFORT: a storage failure returns false instead of raising' do
+      # The defer runs inside the rodauth.login block of a login whose password
+      # already verified — a Redis outage must not abort that login. Fail-closed:
+      # no stash simply means no bind.
+      allow(redis).to receive(:set).and_raise(StandardError, 'redis connection refused')
+
+      expect(defer).to be(false)
+      expect(logger).to have_received(:warn)
     end
   end
 
   describe '.complete on the happy path' do
     it 'binds the identity onto the stashed account, consumes the stash, and returns :ok' do
-      session = deferred_session
+      defer
 
-      expect(complete(session)).to eq(:ok)
+      expect(complete).to eq(:ok)
 
       rows = identities.where(criteria).all
       expect(rows.size).to eq(1)
       expect(rows.first[:account_id]).to eq(account_id)
 
-      # SINGLE-USE: the stash is gone — a second completion is a no-op.
-      expect(session).not_to have_key(described_class::SESSION_KEY)
-      expect(complete(session)).to eq(:none)
+      # SINGLE-USE: the sidecar key is gone — a second completion is a no-op.
+      expect(redis.get(key)).to be_nil
+      expect(complete).to eq(:none)
       expect(identities.where(criteria).count).to eq(1)
-    end
-
-    it 'survives the JSON round-trip the Redis session blob applies between requests' do
-      # The stash is written during the login request but read during the LATER
-      # MFA-verify request, after lib/onetime/session.rb has JSON-serialized the
-      # session into Redis and parsed it back. Symbol keys would come back as
-      # strings, so the contract is string keys throughout — locked in here.
-      session = JSON.parse(JSON.generate(deferred_session))
-
-      expect(complete(session)).to eq(:ok)
-      expect(identities.where(criteria).first[:account_id]).to eq(account_id)
     end
 
     it 'returns :ok idempotently when the row already belongs to the same account' do
       identities.insert(criteria.merge(account_id: account_id))
+      defer
 
-      expect(complete(deferred_session)).to eq(:ok)
+      expect(complete).to eq(:ok)
       expect(identities.where(criteria).count).to eq(1)
     end
   end
 
   describe '.complete with no stash (every non-interstitial login)' do
-    it 'returns :none and touches neither the session nor the database' do
-      session = { 'awaiting_mfa' => false, 'account_id' => account_id }
+    it 'returns :none and touches the database not at all' do
+      expect(complete).to eq(:none)
+      expect(identities.count).to eq(0)
+    end
 
-      expect(complete(session)).to eq(:none)
-      expect(session).to eq('awaiting_mfa' => false, 'account_id' => account_id)
+    it 'returns :none when no usable sid is available' do
+      expect(complete(for_sid: nil)).to eq(:none)
       expect(identities.count).to eq(0)
     end
   end
 
   describe '.complete with a mismatched account (:mismatch, audit-and-skip)' do
     it 'refuses to bind when the authenticated account differs from the stash snapshot' do
-      other   = seed_account(999)
-      session = deferred_session # stash snapshots account_id (5)
+      other = seed_account(999)
+      defer # stash snapshots account_id (5)
 
-      expect(complete(session, as_account: other)).to eq(:mismatch)
+      expect(complete(as_account: other)).to eq(:mismatch)
 
       # Nothing bound onto EITHER account, and the stash is still consumed —
       # a mismatch must not leave a retryable pending bind behind.
       expect(identities.count).to eq(0)
-      expect(session).not_to have_key(described_class::SESSION_KEY)
+      expect(redis.get(key)).to be_nil
     end
   end
 
@@ -161,45 +241,82 @@ RSpec.describe Auth::Operations::DeferredSsoBind do
     it 'binds nothing over the existing owner and consumes the stash' do
       other = seed_account(999)
       identities.insert(criteria.merge(account_id: other))
-      session = deferred_session
+      defer
 
-      expect(complete(session)).to eq(:conflict)
+      expect(complete).to eq(:conflict)
 
       rows = identities.where(criteria).all
       expect(rows.size).to eq(1)
       expect(rows.first[:account_id]).to eq(other)
-      expect(session).not_to have_key(described_class::SESSION_KEY)
+      expect(redis.get(key)).to be_nil
+    end
+  end
+
+  describe '.complete is SID-BOUND (the envelope binding, not just the key name)' do
+    it 'refuses a stash value replayed under another sid, and still spends the planted key' do
+      other_sid = SecureRandom.hex(32)
+      redis.set("session:#{other_sid}", 'blob', ex: 86_400)
+      defer
+
+      # A Redis-writing attacker copies one session's pending bind under
+      # another sid. The envelope's sid binding makes it decode as absent.
+      planted = Onetime::SessionSidecar.key_for(other_sid, described_class::FIELD)
+      redis.set(planted, redis.get(key), ex: 900)
+
+      expect(complete(for_sid: other_sid)).to eq(:none)
+      expect(identities.count).to eq(0)
+      expect(redis.get(planted)).to be_nil # spent either way
     end
   end
 
   describe '.complete with a malformed stash' do
     it 'discards a non-hash payload (:none) and still consumes the key' do
-      session = { described_class::SESSION_KEY => 'not-a-hash' }
+      Onetime::SessionSidecar.write(
+        sid, described_class::FIELD, 'not-a-hash', dbclient: redis, codec: codec,
+      )
 
-      expect(complete(session)).to eq(:none)
-      expect(session).not_to have_key(described_class::SESSION_KEY)
+      expect(complete).to eq(:none)
+      expect(redis.get(key)).to be_nil
       expect(identities.count).to eq(0)
     end
 
     it 'discards a payload missing part of the bind tuple (:none)' do
-      session = deferred_session
-      session[described_class::SESSION_KEY].delete('uid')
+      Onetime::SessionSidecar.write(
+        sid, described_class::FIELD,
+        { 'account_id' => account_id.to_s, 'provider' => provider, 'issuer' => issuer },
+        dbclient: redis, codec: codec,
+      )
 
-      expect(complete(session)).to eq(:none)
+      expect(complete).to eq(:none)
+      expect(identities.count).to eq(0)
+    end
+  end
+
+  describe '.complete with a legacy BLOB-resident stash (rolling deploy)' do
+    it 'discards the blob copy unconsumed — never completes from it' do
+      legacy_session = {
+        described_class::FIELD => {
+          'account_id' => account_id.to_s, 'provider' => provider,
+          'issuer' => issuer, 'uid' => uid,
+        },
+      }
+
+      expect(complete(session: legacy_session)).to eq(:none)
+      expect(legacy_session).not_to have_key(described_class::FIELD)
       expect(identities.count).to eq(0)
     end
   end
 
   describe 'single-use holds even when the bind raises' do
     it 'consumes the stash BEFORE attempting the insert, so an error cannot leave a retry behind' do
-      session = deferred_session
+      defer
       allow(Auth::Operations::BindSsoIdentity).to receive(:call)
         .and_raise(Sequel::DatabaseError, 'boom')
 
       # The error propagates (the hook wraps completion in ErrorHandler.safe_execute),
-      # but the stash is already gone.
-      expect { complete(session) }.to raise_error(Sequel::DatabaseError)
-      expect(session).not_to have_key(described_class::SESSION_KEY)
+      # but the stash is already gone — GETDEL consumed it at the store.
+      expect { complete }.to raise_error(Sequel::DatabaseError)
+      expect(redis.get(key)).to be_nil
     end
   end
 end

--- a/apps/web/auth/spec/operations/deferred_sso_bind_spec.rb
+++ b/apps/web/auth/spec/operations/deferred_sso_bind_spec.rb
@@ -35,9 +35,7 @@
 #   - BEST-EFFORT defer: a storage failure returns false instead of raising,
 #     so it can never abort a login whose password already verified;
 #   - :conflict passthrough: a (provider, issuer, uid) row owned by another
-#     account is never bound over and never reported as success;
-#   - rolling-deploy hygiene: a legacy BLOB-resident stash is discarded
-#     unconsumed, never completed.
+#     account is never bound over and never reported as success.
 #
 # The end-to-end MFA path (interstitial -> mfa_required -> OTP -> bound row)
 # is covered by integration/full_mfa/omniauth_signin_interstitial_mfa_spec.rb.
@@ -133,9 +131,9 @@ RSpec.describe Auth::Operations::DeferredSsoBind do
     )
   end
 
-  def complete(as_account: account_id, for_sid: sid, session: nil)
+  def complete(as_account: account_id, for_sid: sid)
     described_class.complete(
-      db: db, sid: for_sid, account_id: as_account, session: session,
+      db: db, sid: for_sid, account_id: as_account,
       dbclient: redis, codec: codec, logger: logger,
     )
   end
@@ -288,21 +286,6 @@ RSpec.describe Auth::Operations::DeferredSsoBind do
       )
 
       expect(complete).to eq(:none)
-      expect(identities.count).to eq(0)
-    end
-  end
-
-  describe '.complete with a legacy BLOB-resident stash (rolling deploy)' do
-    it 'discards the blob copy unconsumed — never completes from it' do
-      legacy_session = {
-        described_class::FIELD => {
-          'account_id' => account_id.to_s, 'provider' => provider,
-          'issuer' => issuer, 'uid' => uid,
-        },
-      }
-
-      expect(complete(session: legacy_session)).to eq(:none)
-      expect(legacy_session).not_to have_key(described_class::FIELD)
       expect(identities.count).to eq(0)
     end
   end

--- a/lib/onetime/session.rb
+++ b/lib/onetime/session.rb
@@ -174,7 +174,35 @@ module Onetime
         # TTL-bounded by the sidecar clamp (they can never outlive the blob's
         # would-have-been lifetime).
         begin
+          # Tripwire for the sid-stability assumption the short-TTL hand-off
+          # fields ride on (awaiting_mfa, the SSO connect/bind stashes): a
+          # session destroyed while one of them still holds a live truthy
+          # value takes an uncompleted hand-off with it. Today that means the
+          # user abandoned the flow and re-keyed (restarted login, logged out
+          # mid-MFA) — expected, rare, and worth a line. If a future auth
+          # refactor re-keys sessions MID-flow, this warning is what surfaces
+          # the silently-stranded hand-off: the consume sides cannot log a
+          # miss (absence is their overwhelmingly common case). This is a
+          # request-path (middleware) tripwire only — the admin/colonel revoke
+          # operations destroy sessions deliberately, where killing in-flight
+          # state is the point, not a signal. Probe failure degrades to "no
+          # warning" and must never block the purge.
+          doomed = begin
+            Onetime::SessionSidecar.inflight_fields(sid_string, dbclient: @dbclient, codec: @codec)
+          rescue StandardError
+            []
+          end
+
           Onetime::SessionSidecar.purge(sid_string, dbclient: @dbclient)
+
+          unless doomed.empty?
+            session_logger.warn 'Session destroyed with in-flight sidecar state',
+              {
+                session_id: sid_string,
+                fields: doomed,
+                operation: 'delete',
+              }
+          end
         rescue StandardError => ex
           session_logger.error 'Sidecar purge failed (orphans are TTL-bounded)',
             {

--- a/lib/onetime/session/sidecar.rb
+++ b/lib/onetime/session/sidecar.rb
@@ -73,6 +73,16 @@ module Onetime
     #   externalize   — write_session strips it from the blob and owns the
     #                   sidecar key (false = declared/policy-reviewed but still
     #                   blob-resident, or explicit-use only)
+    #   destroy_warn  — in-flight hand-off state: destroying a session while
+    #                   this field holds a live TRUTHY value takes an
+    #                   uncompleted hand-off with it, and the middleware's
+    #                   delete_session logs a warning naming the field (via
+    #                   #inflight_fields). This is the tripwire for the
+    #                   sid-stability assumption the short-TTL hand-off fields
+    #                   ride on: their consume sides cannot log a miss (absence
+    #                   is their common case), so a future refactor that
+    #                   re-keys sessions mid-flow would strand them SILENTLY —
+    #                   except for this warning at the destroy site.
     #
     # ADMISSION RULE (the security contract): a field may set externalize: true
     # ONLY if its absence is the safe state. awaiting_mfa qualifies: with it
@@ -106,11 +116,16 @@ module Onetime
     FIELDS = {
       # 15-minute MFA completion window instead of riding the 24h blob — the
       # point of #3858 for this field. Expiry strands a half-done MFA login as
-      # unauthenticated (user restarts login): fail-closed.
-      'awaiting_mfa'   => { ttl: 900,   encrypted: true,  merge_on_read: true, externalize: true  },
+      # unauthenticated (user restarts login): fail-closed. destroy_warn: true
+      # only fires on a TRUTHY value (an MFA login actually pending) — every
+      # authenticated login PARKS awaiting_mfa=false, which is healthy state,
+      # not an in-flight hand-off.
+      'awaiting_mfa'   => { ttl: 900,   encrypted: true,  merge_on_read: true, externalize: true, destroy_warn: true },
       # Post-AddDomain UI context; cosmetic on expiry. Same value is plaintext
       # in CustomDomain records, so a plaintext envelope leaks nothing new.
-      'domain_context' => { ttl: 3_600, encrypted: false, merge_on_read: true, externalize: true  },
+      # No destroy_warn: routinely live on healthy sessions, and losing it
+      # costs a UI hint, not a hand-off.
+      'domain_context' => { ttl: 3_600, encrypted: false, merge_on_read: true, externalize: true, destroy_warn: false },
       # One-shot Roda flash messages (may embed email addresses — mild PII,
       # hence encrypted). Declared but NOT externalized: the Roda flash plugin
       # writes it mid-request via its own delete-then-rewrite cycle, which must
@@ -121,7 +136,7 @@ module Onetime
       # externalize:false->true flip with no risk of leaving the two flags out
       # of step. (This is why it is neither an externalized field nor an
       # explicit-use field — a third, declared-pending-audit state.)
-      '_flash'         => { ttl: 600,   encrypted: true,  merge_on_read: true, externalize: false },
+      '_flash'         => { ttl: 600,   encrypted: true,  merge_on_read: true, externalize: false, destroy_warn: false },
       # #3859: the SSO account-bound connect-intent nonce (value = the session
       # account id). EXPLICIT-USE: written by omniauth_request_validation_phase
       # when a logged-in caller POSTs connect=1, consumed (atomic GETDEL) by
@@ -135,7 +150,7 @@ module Onetime
       # the value is an account id bound to the session — capability-adjacent —
       # and the codec's sid/field binding stops a Redis-writing attacker from
       # replaying one session's intent under another sid.
-      'sso_connect_intent' => { ttl: 300, encrypted: true, merge_on_read: false, externalize: false },
+      'sso_connect_intent' => { ttl: 300, encrypted: true, merge_on_read: false, externalize: false, destroy_warn: true },
       # #3877 (#3840 Phase 4.A): the interstitial's deferred SSO identity bind
       # — the password-proven (account_id, provider, issuer, uid) tuple carried
       # across the MFA hand-off. EXPLICIT-USE: written by the link-sso route
@@ -151,7 +166,7 @@ module Onetime
       # to an account id, and the codec's sid/field binding stops a
       # Redis-writing attacker from replaying one session's pending bind under
       # another sid.
-      'link_sso_pending_bind' => { ttl: 900, encrypted: true, merge_on_read: false, externalize: false },
+      'link_sso_pending_bind' => { ttl: 900, encrypted: true, merge_on_read: false, externalize: false, destroy_warn: true },
     }.freeze
 
     # Deterministic key derivation — no stored key names needed, which is what
@@ -258,6 +273,33 @@ module Onetime
 
       db = dbclient || Familia.dbclient
       db.exists(key_for(sid, field)).to_i.positive?
+    end
+
+    # Report which destroy_warn fields currently hold a live TRUTHY value for
+    # this sid — the probe behind the middleware's destroyed-with-in-flight-
+    # state warning (Session#delete_session), the tripwire for the
+    # sid-stability assumption the hand-off fields ride on.
+    #
+    # TRUTHY, not merely present, is the line: several fields PARK a falsy
+    # value on healthy sessions (every authenticated login leaves
+    # awaiting_mfa=false behind, refreshed each commit), so key existence
+    # would flag every logout and drown the signal. One pipelined GET over
+    # the destroy_warn subset; tampered/unauthentic values read as absent,
+    # exactly like #read.
+    #
+    # @return [Array<String>] destroy_warn field names holding a truthy value.
+    def inflight_fields(sid, dbclient: nil, codec: nil)
+      fields = FIELDS.select { |_f, policy| policy[:destroy_warn] }.keys
+      return [] if fields.empty? || !valid_sid?(sid)
+
+      db   = dbclient || Familia.dbclient
+      raws = db.pipelined do |pipe|
+        fields.each { |field| pipe.get(key_for(sid, field)) }
+      end
+
+      fields.zip(raws).select do |field, raw|
+        decode_envelope(sid, field, raw, FIELDS[field], codec)
+      end.map(&:first)
     end
 
     # Delete one field's key.

--- a/lib/onetime/session/sidecar.rb
+++ b/lib/onetime/session/sidecar.rb
@@ -73,6 +73,18 @@ module Onetime
     #   externalize   — write_session strips it from the blob and owns the
     #                   sidecar key (false = declared/policy-reviewed but still
     #                   blob-resident, or explicit-use only)
+    #   absent_when_falsy — commit treats a present FALSY value exactly like an
+    #                   app-side deletion: DEL the sidecar key and strip the
+    #                   field from the blob, instead of parking the falsy value
+    #                   as a sidecar key refreshed on every commit. Only for
+    #                   fields whose readers already treat absence as false
+    #                   (awaiting_mfa's guard checks `== true`). The falsy
+    #                   WRITE stays load-bearing for one request: on commit
+    #                   failure the middleware's rescue keeps it in the BLOB,
+    #                   where blob-wins lets it outrank a stale truthy sidecar
+    #                   copy (see #merge) — a deletion could not win that
+    #                   conflict. The next healthy commit then converges the
+    #                   field to absent everywhere.
     #   destroy_warn  — in-flight hand-off state: destroying a session while
     #                   this field holds a live TRUTHY value takes an
     #                   uncompleted hand-off with it, and the middleware's
@@ -116,11 +128,21 @@ module Onetime
     FIELDS = {
       # 15-minute MFA completion window instead of riding the 24h blob — the
       # point of #3858 for this field. Expiry strands a half-done MFA login as
-      # unauthenticated (user restarts login): fail-closed. destroy_warn: true
-      # only fires on a TRUTHY value (an MFA login actually pending) — every
-      # authenticated login PARKS awaiting_mfa=false, which is healthy state,
-      # not an in-flight hand-off.
-      'awaiting_mfa'   => { ttl: 900,   encrypted: true,  merge_on_read: true, externalize: true, destroy_warn: true },
+      # unauthenticated (user restarts login): fail-closed. absent_when_falsy:
+      # every reader treats absence as false (the M-11 guard checks `== true`),
+      # so the healing false the MFA-success hook writes (hooks/mfa.rb) is
+      # converged to absent by the next healthy commit instead of parked as a
+      # sidecar key refreshed forever. destroy_warn: true only fires on a
+      # TRUTHY value (an MFA login actually pending) — a lingering stored
+      # false is healthy residue, not an in-flight hand-off.
+      'awaiting_mfa' => {
+        ttl: 900,
+        encrypted: true,
+        merge_on_read: true,
+        externalize: true,
+        absent_when_falsy: true,
+        destroy_warn: true,
+      },
       # Post-AddDomain UI context; cosmetic on expiry. Same value is plaintext
       # in CustomDomain records, so a plaintext envelope leaks nothing new.
       # No destroy_warn: routinely live on healthy sessions, and losing it
@@ -280,12 +302,12 @@ module Onetime
     # state warning (Session#delete_session), the tripwire for the
     # sid-stability assumption the hand-off fields ride on.
     #
-    # TRUTHY, not merely present, is the line: several fields PARK a falsy
-    # value on healthy sessions (every authenticated login leaves
-    # awaiting_mfa=false behind, refreshed each commit), so key existence
-    # would flag every logout and drown the signal. One pipelined GET over
-    # the destroy_warn subset; tampered/unauthentic values read as absent,
-    # exactly like #read.
+    # TRUTHY, not merely present, is the line: a stored FALSY value is healthy
+    # residue, not an uncompleted hand-off — e.g. an awaiting_mfa=false parked
+    # by a pre-absent_when_falsy worker (rolling deploy) that hasn't been
+    # converged to a DEL by a newer commit yet. Key existence would flag those
+    # logouts and drown the signal. One pipelined GET over the destroy_warn
+    # subset; tampered/unauthentic values read as absent, exactly like #read.
     #
     # @return [Array<String>] destroy_warn field names holding a truthy value.
     def inflight_fields(sid, dbclient: nil, codec: nil)
@@ -347,7 +369,9 @@ module Onetime
     # `false` each request, be re-committed with a fresh TTL, and lock the
     # authenticated session out of every gated route indefinitely. Blob-wins
     # keeps that degradation to the documented single cycle: the next
-    # successful commit re-externalizes the blob copy and heals the sidecar.
+    # successful commit heals the sidecar from the blob copy — re-externalizing
+    # it, or (absent_when_falsy; exactly the awaiting_mfa=false case above)
+    # DELing the stale key so the field converges to absent everywhere.
     #
     # NOT called on the blob-miss or tamper/new-sid paths: a revoked/expired
     # session must present as {}; its sidecar keys are inert until purged or
@@ -399,6 +423,9 @@ module Onetime
     #                             commit, tracking the blob's per-request TTL
     #                             refresh); field removed from the hash copy
     #   present, nil           -> DEL; field removed from the hash copy
+    #   present, falsy, and the field is absent_when_falsy
+    #                          -> DEL; field removed from the hash copy (falsy
+    #                             means absent for these fields — see FIELDS)
     #   absent, but in merged: -> DEL (the app deleted a field the read-side
     #                             overlaid this request — e.g. SyncSession
     #                             clearing awaiting_mfa)
@@ -436,7 +463,7 @@ module Onetime
 
         if data.key?(field)
           value = data[field]
-          if value.nil?
+          if value.nil? || (policy[:absent_when_falsy] && !value)
             deletes << field
           else
             # Envelopes are encoded before the pipeline opens so a codec

--- a/lib/onetime/session/sidecar.rb
+++ b/lib/onetime/session/sidecar.rb
@@ -136,6 +136,22 @@ module Onetime
       # and the codec's sid/field binding stops a Redis-writing attacker from
       # replaying one session's intent under another sid.
       'sso_connect_intent' => { ttl: 300, encrypted: true, merge_on_read: false, externalize: false },
+      # #3877 (#3840 Phase 4.A): the interstitial's deferred SSO identity bind
+      # — the password-proven (account_id, provider, issuer, uid) tuple carried
+      # across the MFA hand-off. EXPLICIT-USE: written by the link-sso route
+      # inside its rodauth.login block (AFTER login_session has re-keyed the
+      # sid), consumed (atomic GETDEL) when the second factor succeeds — see
+      # Auth::Operations::DeferredSsoBind, the single owner of this field. TTL
+      # matches awaiting_mfa's 900s MFA completion window (the two ride the
+      # same hand-off), so an abandoned half-done MFA login can no longer
+      # leave the pending bind live for the blob's full 24h. Absence is the
+      # safe state (admission rule): a miss means no bind — the login simply
+      # completes unlinked, which is the flow's documented audit-and-skip
+      # posture. Encrypted: the payload carries a forward authorization bound
+      # to an account id, and the codec's sid/field binding stops a
+      # Redis-writing attacker from replaying one session's pending bind under
+      # another sid.
+      'link_sso_pending_bind' => { ttl: 900, encrypted: true, merge_on_read: false, externalize: false },
     }.freeze
 
     # Deterministic key derivation — no stored key names needed, which is what

--- a/try/unit/session/sidecar_try.rb
+++ b/try/unit/session/sidecar_try.rb
@@ -271,9 +271,11 @@ SC.write(@sid, 'link_sso_pending_bind', @bind, codec: @codec)
 SC.inflight_fields(@sid, codec: @codec).sort
 #=> ['awaiting_mfa', 'link_sso_pending_bind']
 
-## TRUTHY is the line, not key existence: every authenticated login PARKS
-## awaiting_mfa=false (healthy state, refreshed each commit), so a parked
-## false must NOT read as in-flight — else every logout would fire the warning
+## TRUTHY is the line, not key existence: a stored FALSY value is healthy
+## residue, not an uncompleted hand-off — e.g. an awaiting_mfa=false parked
+## by a pre-absent_when_falsy worker (rolling deploy) that no newer commit
+## has converged to a DEL yet — and must NOT read as in-flight, else those
+## logouts would fire the warning and drown the signal
 SC.write(@sid, 'awaiting_mfa', false, codec: @codec)
 SC.inflight_fields(@sid, codec: @codec)
 #=> ['link_sso_pending_bind']
@@ -319,11 +321,13 @@ SC.inflight_fields(@sid, codec: @codec)
 #=> [false, true]
 
 ## ...and the next healthy commit HEALS the stale sidecar from the blob copy —
-## the documented one-cycle degradation, not a permanent lockout: the sidecar
-## now reads back false, not the stale true
-SC.commit(@sid, @conflict[:data], merged: @conflict[:fields], codec: @codec)
-SC.read(@sid, 'awaiting_mfa', codec: @codec)
-#=> false
+## the documented one-cycle degradation, not a permanent lockout. awaiting_mfa
+## is absent_when_falsy (every reader treats absence as false), so the heal is
+## a DEL, not a re-SET: the stale true is gone and the field has converged to
+## absent everywhere instead of a parked false refreshed on every commit
+@healed = SC.commit(@sid, @conflict[:data], merged: @conflict[:fields], codec: @codec)
+[SC.read(@sid, 'awaiting_mfa', codec: @codec), DB.exists(@key_mfa), @healed.key?('awaiting_mfa')]
+#=> [nil, 0, false]
 
 ## commit with the merged stash translates an app-side deletion into a sidecar
 ## DEL: awaiting_mfa was merged in, then deleted before write-back
@@ -336,6 +340,27 @@ DB.exists(@key_mfa)
 SC.commit(@sid, { 'domain_context' => nil }, codec: @codec)
 DB.exists(@key_dc)
 #=> 0
+
+## awaiting_mfa is registered absent_when_falsy: falsy-is-absent is a REGISTRY
+## policy, safe only because every reader treats absence as false (the M-11
+## guard checks `== true`) — it is NOT the default for externalized fields
+[SC::FIELDS['awaiting_mfa'][:absent_when_falsy], SC::FIELDS['domain_context'][:absent_when_falsy]]
+#=> [true, nil]
+
+## for an absent_when_falsy field, committing a present FALSE is also a
+## DELETE, not a parked sidecar key: the healing false the MFA-success hook
+## writes converges to absent-everywhere on the next healthy commit instead
+## of being re-SET with a fresh TTL on every request for the session's life
+SC.write(@sid, 'awaiting_mfa', true, codec: @codec)
+@false_out = SC.commit(@sid, { 'account_id' => 7, 'awaiting_mfa' => false }, codec: @codec)
+[@false_out, DB.exists(@key_mfa)]
+#=> [{ 'account_id' => 7 }, 0]
+
+## a falsy commit for a field WITHOUT the policy still SETs: domain_context
+## has no falsy-is-absent contract, so an explicit false round-trips intact
+SC.commit(@sid, { 'domain_context' => false }, codec: @codec)
+SC.read(@sid, 'domain_context', codec: @codec)
+#=> false
 
 ## a declared-but-not-externalized field (_flash) stays in the blob hash —
 ## commit never touches it

--- a/try/unit/session/sidecar_try.rb
+++ b/try/unit/session/sidecar_try.rb
@@ -246,6 +246,21 @@ SC.write(@sid, 'sso_connect_intent', 42, codec: @codec)
  SC.consume(@sid, 'sso_connect_intent', codec: @codec)]
 #=> [42, nil]
 
+## link_sso_pending_bind (#3877/#3858) is registered EXPLICIT-USE the same
+## way: encrypted, never merged or externalized, TTL matching awaiting_mfa's
+## 900s MFA completion window — the deferred SSO bind hand-off
+## (Auth::Operations::DeferredSsoBind) depends on this policy
+SC::FIELDS['link_sso_pending_bind']
+#=> { ttl: 900, encrypted: true, merge_on_read: false, externalize: false }
+
+## the pending-bind tuple round-trips through write + single-use consume with
+## its hash shape and string keys intact (the envelope is JSON both ways)
+@bind = { 'account_id' => '5', 'provider' => 'oidc', 'issuer' => 'https://idp', 'uid' => 'sub-1' }
+SC.write(@sid, 'link_sso_pending_bind', @bind, codec: @codec)
+[SC.consume(@sid, 'link_sso_pending_bind', codec: @codec),
+ SC.consume(@sid, 'link_sso_pending_bind', codec: @codec)]
+#=> [@bind, nil]
+
 # ---- middleware hooks: commit / merge -----------------------------------
 
 ## commit externalizes registered fields: strips them from the returned hash

--- a/try/unit/session/sidecar_try.rb
+++ b/try/unit/session/sidecar_try.rb
@@ -237,7 +237,7 @@ DB.set("sidecar:#{@sid2}:awaiting_mfa", DB.get(@key_mfa))
 ## merged or externalized (merge/commit ignore it), TTL bounded to one IdP
 ## round-trip — the policy the omniauth connect-intent nonce depends on
 SC::FIELDS['sso_connect_intent']
-#=> { ttl: 300, encrypted: true, merge_on_read: false, externalize: false }
+#=> { ttl: 300, encrypted: true, merge_on_read: false, externalize: false, destroy_warn: true }
 
 ## the intent nonce round-trips through write + single-use consume: first
 ## consume yields the bound account id and spends the key, second is nil
@@ -251,7 +251,7 @@ SC.write(@sid, 'sso_connect_intent', 42, codec: @codec)
 ## 900s MFA completion window — the deferred SSO bind hand-off
 ## (Auth::Operations::DeferredSsoBind) depends on this policy
 SC::FIELDS['link_sso_pending_bind']
-#=> { ttl: 900, encrypted: true, merge_on_read: false, externalize: false }
+#=> { ttl: 900, encrypted: true, merge_on_read: false, externalize: false, destroy_warn: true }
 
 ## the pending-bind tuple round-trips through write + single-use consume with
 ## its hash shape and string keys intact (the envelope is JSON both ways)
@@ -260,6 +260,34 @@ SC.write(@sid, 'link_sso_pending_bind', @bind, codec: @codec)
 [SC.consume(@sid, 'link_sso_pending_bind', codec: @codec),
  SC.consume(@sid, 'link_sso_pending_bind', codec: @codec)]
 #=> [@bind, nil]
+
+# ---- inflight_fields: the destroyed-with-in-flight-state probe ------------
+
+## inflight_fields reports destroy_warn fields holding a live TRUTHY value —
+## the probe behind delete_session's destroyed-with-in-flight-state warning
+## (the tripwire for the sid-stability assumption the hand-off fields ride on)
+SC.write(@sid, 'awaiting_mfa', true, codec: @codec)
+SC.write(@sid, 'link_sso_pending_bind', @bind, codec: @codec)
+SC.inflight_fields(@sid, codec: @codec).sort
+#=> ['awaiting_mfa', 'link_sso_pending_bind']
+
+## TRUTHY is the line, not key existence: every authenticated login PARKS
+## awaiting_mfa=false (healthy state, refreshed each commit), so a parked
+## false must NOT read as in-flight — else every logout would fire the warning
+SC.write(@sid, 'awaiting_mfa', false, codec: @codec)
+SC.inflight_fields(@sid, codec: @codec)
+#=> ['link_sso_pending_bind']
+
+## non-destroy_warn fields never appear, however live: domain_context is
+## routinely live on healthy sessions and losing it costs a UI hint, not a
+## hand-off
+SC.write(@sid, 'domain_context', 'example.com', codec: @codec)
+SC.inflight_fields(@sid, codec: @codec)
+#=> ['link_sso_pending_bind']
+
+## a malformed sid reads as nothing in flight, and purge clears the probe
+[SC.inflight_fields('nothex', codec: @codec), SC.purge(@sid) > 0, SC.inflight_fields(@sid, codec: @codec)]
+#=> [[], true, []]
 
 # ---- middleware hooks: commit / merge -----------------------------------
 

--- a/try/unit/session_try.rb
+++ b/try/unit/session_try.rb
@@ -350,12 +350,14 @@ _sw_sid, @sw_data = call_private_method(@sidecar_session, :find_session, @sw_req
 #=> false
 
 ## [#3858] ...and the next write_session HEALS the stale sidecar from the blob
-## copy — the documented one-cycle degradation: the sidecar now stores false
-## and the blob is stripped of the field again
+## copy — the documented one-cycle degradation. awaiting_mfa is
+## absent_when_falsy, so the heal is a DEL, not a re-SET of the false: the
+## stale key is gone, the blob is stripped, and the field has converged to
+## absent everywhere (every reader treats absence as false)
 call_private_method(@sidecar_session, :write_session, @sw_req, @sw_sid, @sw_data, {})
-[Onetime::SessionSidecar.read(@sw_sid, 'awaiting_mfa', codec: @try_codec),
+[DB.exists("sidecar:#{@sw_sid}:awaiting_mfa"),
  @try_codec.decode(DB.get("session:#{@sw_sid}")).key?('awaiting_mfa')]
-#=> [false, false]
+#=> [0, false]
 
 ## [#3858] the blob-miss path does NOT merge: a revoked/expired session
 ## presents as {} even while sidecar keys still exist — they are inert until


### PR DESCRIPTION
## Summary

[#3877](https://github.com/onetimesecret/onetimesecret/issues/3877)

Replaces the deferred SSO bind's session-blob stash with a registered explicit-use `SessionSidecar` field (#3858), following the `sso_connect_intent` pattern:

```
sidecar:<sid>:link_sso_pending_bind
{ ttl: 900, encrypted: true, merge_on_read: false, externalize: false, destroy_warn: true }
```

The old stash was a distributed hand-off — the route wrote a blob field, two hooks read it, coordinated only by a string key and a timing assumption about when sessions get cleared. The sidecar move fixes the two weaknesses flagged in the Phase 4.A review and removes the fragile parts of the contract:

- **Bounded in time** — the 900s per-field TTL matches `awaiting_mfa`'s MFA completion window, so an abandoned half-done MFA login expires the pending bind with the window instead of leaving it live for the session blob's full 24h.
- **Atomic single-use** — `.complete` consumes the stash via GETDEL at the store, replacing the Ruby delete-then-act sequence; two concurrent completions can never both observe it.
- **Sid/field-bound envelope** — the encrypted envelope makes a stash value replayed under another sid decode as absent, a property the blob-resident hash didn't have.
- **Registry-driven cleanup** — logout/`delete_session` purge covers the field with no new code.

The admission rule holds by construction: absence of the stash means no bind, which is precisely the flow's documented fail-closed state, and the bind is already best-effort by contract (audit-and-skip) — so `.defer` swallows storage failures rather than aborting a login whose password already verified. The sid is read inside the `rodauth.login` block (`session.id&.public_id`), the only point that both sees the login's final sid (login_session re-keys it) and precedes `after_login`'s self-heal reader; the sid is then stable through the MFA hand-off.

`DeferredSsoBind` remains the single owner of the field: the route and both hooks only pass the sid through.

**Tripwire for the sid-stability assumption** (`destroy_warn`): the hand-off fields' consume sides cannot log a miss — absence is their overwhelmingly common case — so a future auth refactor that re-keys sessions mid-flow would strand them silently. The registry gains a `destroy_warn` policy flag (`awaiting_mfa`, `sso_connect_intent`, `link_sso_pending_bind`), and the middleware's `delete_session` now warns when it destroys a session whose flagged fields still hold a live **truthy** value (`SessionSidecar#inflight_fields`, one pipelined GET before the purge). Truthy, not present, is the line: a stored falsy value is healthy residue (e.g. a parked `awaiting_mfa=false` from a pre-`absent_when_falsy` worker during a rolling deploy), so key existence would drown the signal. Scoped to the request-path middleware — the admin/colonel revoke operations kill in-flight state deliberately.

**`absent_when_falsy` (follow-up to review feedback)**: every reader of `awaiting_mfa` treats absence as false (the M-11 guard checks `== true`), yet every completed MFA login used to park a sidecar key storing `false`, re-SET with a fresh TTL on every commit for the session's remaining life. The `false` is load-bearing for exactly one failure case — if the MFA-completion request's sidecar commit fails, `write_session`'s rescue keeps it in the **blob**, where blob-wins outranks the stale sidecar `true` whose DEL was lost (a deletion cannot win that conflict; without the tombstone the stale `true` would re-merge and re-commit indefinitely, locking the authenticated session out of every gated route). The perpetual re-SET afterwards was incidental residue of that one-request role. The registry now carries an `absent_when_falsy` axis (set only on `awaiting_mfa`) under which `commit` treats a present falsy value exactly like an app-side deletion — DEL the key, strip the field from the blob. The heal is preserved (the tombstone still lands in the blob via the rescue precisely when it's needed) and the authenticated steady state converges to absent-everywhere: no parked key, no per-commit SET. The MFA-success hook now also writes the healing `false` under the string key (the one the registry, `PrepareMfaSession`, and the guard all use) instead of the symbol, so convergence happens on the completion request itself rather than one request later via the blob's JSON round-trip.

An earlier revision carried a `session:` parameter on `.complete` to discard blob-resident stashes from a pre-sidecar writer; it was removed on merits — it coupled the operation back to the session hash, and the blob entry it deleted is unreachable (nothing reads that session key anymore), so it defended against already-inert data.

## Related Issues

Relates to #3877, #3858, #3840 (Phase 4.A follow-up chore; branched off the Phase 4 branch)

## Test Plan

- `apps/web/auth/spec/operations/deferred_sso_bind_spec.rb` rewritten against the sidecar storage contract: real `SessionCodec` envelope (sid/field binding, replay-under-another-sid refused), real SQLite `account_identities` table, minimal in-memory Redis stand-in for the exact commands the sidecar issues (SET+EX/GET/GETDEL/DEL/TTL). Locks in single-use-on-every-outcome, account-bound `:mismatch`, `:conflict` passthrough, best-effort defer, and both directions of the account_id `.to_s` coercion (ported from the base branch's review feedback onto the sidecar API).
- `try/unit/session/sidecar_try.rb` extended with the registry-policy assertions, a write→consume round-trip for the new field, `inflight_fields` coverage (truthy-vs-stored-false, non-`destroy_warn` fields excluded, malformed sid), and the `absent_when_falsy` semantics: heal-by-DEL (stale `true` gone, blob stripped, converged absent), falsy-commit-DELs for `awaiting_mfa`, falsy-commit-still-SETs for fields without the policy — runs against real Valkey.
- `try/unit/session_try.rb`'s middleware-level heal case updated to assert the DEL convergence instead of a re-SET `false`.
- End-to-end path covered by the `AUTH_MFA_ENABLED` integration lane (`apps/web/auth/spec/integration/full_mfa/omniauth_signin_interstitial_mfa_spec.rb`), which after the base-branch merge also exercises the recovery-code second factor and the pinned 401 OTP rejection — all green against the sidecar path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsNVJZ1xzanpRbvwRyabhs