### PR TITLE
Restore pointer cursor on buttons after Tailwind v4 upgrade (merge after v0.26.2)

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -236,6 +236,23 @@
     font-family: 'Zilla Slab', ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
   }
 
+  /*
+   * Restores the pointer cursor on buttons. Tailwind v3's Preflight shipped
+   * `button, [role="button"] { cursor: pointer }`; v4 dropped it to match the
+   * browser default (`cursor: default`), so every button that does not set
+   * `cursor-pointer` itself lost its affordance on upgrade.
+   *
+   * Scoped with `:not(:disabled)` so a disabled button falls through to the
+   * browser default rather than misleadingly showing a pointer. Utilities
+   * still win over this rule: `disabled:cursor-not-allowed` (and any explicit
+   * `cursor-*`) emit into the `utilities` layer, which the cascade orders
+   * after `base` regardless of selector specificity.
+   */
+  button:not(:disabled),
+  [role='button']:not(:disabled) {
+    cursor: pointer;
+  }
+
   h1 {
     @apply mb-3 text-4xl font-bold text-gray-900;
   }

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -243,10 +243,13 @@
    * `cursor-pointer` itself lost its affordance on upgrade.
    *
    * Scoped with `:not(:disabled)` so a disabled button falls through to the
-   * browser default rather than misleadingly showing a pointer. Utilities
-   * still win over this rule: `disabled:cursor-not-allowed` (and any explicit
-   * `cursor-*`) emit into the `utilities` layer, which the cascade orders
-   * after `base` regardless of selector specificity.
+   * browser default rather than misleadingly showing a pointer. Note that
+   * `:disabled` only matches native form controls, so on `[role='button']`
+   * elements the `:not(:disabled)` clause is inert — `aria-disabled="true"`
+   * is not excluded here, by design. Utilities still win over this rule:
+   * `disabled:cursor-not-allowed` (and any explicit `cursor-*`) emit into the
+   * `utilities` layer, which the cascade orders after `base` regardless of
+   * selector specificity.
    */
   button:not(:disabled),
   [role='button']:not(:disabled) {


### PR DESCRIPTION
## Problem

Tailwind v3's Preflight shipped `button, [role="button"] { cursor: pointer }`. **v4 removed it** to match the browser default (`cursor: default`). Nothing in this repo's markup changed — every button that does not set `cursor-pointer` itself silently lost its pointer affordance when we upgraded to v4.

Scope of the regression:

- **170** `.vue` components contain a `<button>`
- **34** of them set `cursor-pointer` explicitly
- → **~136 components** currently render buttons with `cursor: default`

Verified against the installed `tailwindcss@^4.2.1`: `node_modules/tailwindcss/preflight.css` contains no button cursor rule (its only `cursor` mention is the Safari increment/decrement spinner fix).

## Fix

One base-layer rule in `src/assets/style.css`, the v4 CSS-first design-system entry — added alongside the existing `button, a.block` base rule rather than patching ~136 call sites.

```css
button:not(:disabled),
[role='button']:not(:disabled) {
  cursor: pointer;
}
```

`:not(:disabled)` is deliberate: a disabled button falls through to the browser default rather than showing a misleading pointer.

## Why this does not break `disabled:cursor-not-allowed`

Explicit cursor utilities still win — by **cascade layer order**, not specificity. Verified in the compiled bundle (`public/web/dist/assets/style.*.css`):

| Symbol | Byte offset |
| --- | --- |
| `@layer base` opens | 13164 |
| new `button:not(:disabled)` rule | 17742 |
| `@layer utilities` opens | 25000 |
| `cursor-not-allowed` occurrences | 64452, 158203 |

The base rule sits inside the `base` layer; every `cursor-not-allowed` emission lands in `utilities`, which the cascade orders after `base` regardless of selector weight. Any explicit `cursor-*` utility on a button therefore overrides this rule.

## Verification

- `pnpm build` — clean, no CSS errors
- Compiled-output layer ordering confirmed as above

## Notes for reviewers

- **Supersedes per-page cursor patches.** Any `cursor-pointer` added by hand to individual buttons becomes a redundant no-op once this lands. `src/apps/session/views/LinkSso.vue` was one of the affected pages.
- **`aria-disabled` is not covered.** `:not(:disabled)` matches only the real form-control `disabled` attribute, so a `[role='button'][aria-disabled='true']` still gets a pointer. Left out deliberately as scope creep — flagging, not recommending.
- The `[#V4]` prefix on the commit is a pre-commit hook artifact (it parsed "v4" out of the branch name). There is no issue #V4.
