### PR TITLE
fix(docker): bump compose app-image pins to v0.26.1 + drift guards (#3892)

### DIFF
--- a/.github/workflows/build-and-publish-oci-images.yml
+++ b/.github/workflows/build-and-publish-oci-images.yml
@@ -102,6 +102,14 @@ jobs:
           ref: ${{ inputs.source_branch || github.ref }}
           fetch-depth: 0
 
+      # Release gate: the compose ${OTS_IMAGE_TAG:-vX.Y.Z} defaults must match
+      # the README quick-start pin. Compares two in-repo values (never the build
+      # version), so it's invariant across tag/nightly/dispatch builds and only
+      # fails on genuine README<->compose drift — the class of bug that shipped
+      # v0.25.11 in the compose files after v0.26.x released (#3892).
+      - name: Assert compose image pins match README (drift gate)
+        run: bash scripts/check-version-pins.sh
+
       - name: Generate commit hash
         id: commit
         run: |

--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -16,6 +16,16 @@
 #                      Caddy. Source-built so it guards the repo's Dockerfile
 #                      and compose wiring together (and the /app/data named-
 #                      volume ownership contract), not last release's image.
+#   full-stack-pinned  (weekly cron + manual): bring up the full stack with NO
+#                      OTS_IMAGE_TAG override, so it pulls the PUBLISHED pinned
+#                      image the compose default names and boots it against the
+#                      current compose file. full-stack-smoke builds from source
+#                      and so can't see when a pinned release predates the
+#                      compose file's runtime contract (#3892 — v0.25.11 + the
+#                      /app/data named volume = root-owned mount, sqlite boot
+#                      migration can't write). Cron/manual, not PR: a release PR
+#                      may bump the pin to a tag that isn't published yet (the
+#                      static check-version-pins.sh guard covers PR-time drift).
 #   docker-run-readme  (weekly cron + manual): the README `docker run` quick
 #                      start, verbatim, against the exact published tag the
 #                      README shows — the only thing that catches "the docs
@@ -252,6 +262,71 @@ jobs:
             exit 1
           fi
           echo "Caddy ingress OK (200)"
+
+      - name: Dump logs on failure
+        if: failure()
+        run: docker compose -f docker/compose/docker-compose.full.yml logs --no-color
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker/compose/docker-compose.full.yml down -v
+
+  full-stack-pinned:
+    name: docker compose up (full, pinned image)
+    # Pulls the PUBLISHED image the compose default names; on a release PR that
+    # bumps the pin, that tag may not exist yet — so cron/manual only, like
+    # docker-run-readme. check-version-pins.sh is the PR-time drift guard.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # Same interpolation + fail-fast story as full-stack-smoke: SECRET into
+      # the job env for `${SECRET:?}`, repo-root .env for `env_file:`, plus the
+      # full-mode secrets (AUTH_SECRET / ACCOUNT_ID_SECRET fail closed in
+      # production) and the ${VAR:?} Valkey/RabbitMQ credentials.
+      - name: Seed SECRET (interpolation) and .env (env_file target)
+        run: |
+          secret="$(openssl rand -hex 32)"
+          auth_secret="$(openssl rand -hex 32)"
+          account_id_secret="$(openssl rand -hex 32)"
+          echo "SECRET=$secret" >> "$GITHUB_ENV"
+          echo "AUTH_SECRET=$auth_secret" >> "$GITHUB_ENV"
+          echo "ACCOUNT_ID_SECRET=$account_id_secret" >> "$GITHUB_ENV"
+          echo "SECRET=$secret" > .env
+          valkey_password="$(openssl rand -hex 32)"
+          rabbitmq_pass="$(openssl rand -hex 16)"
+          echo "VALKEY_PASSWORD=$valkey_password" >> "$GITHUB_ENV"
+          echo "RABBITMQ_USER=ots" >> "$GITHUB_ENV"
+          echo "RABBITMQ_PASS=$rabbitmq_pass" >> "$GITHUB_ENV"
+          echo "VALKEY_PASSWORD=$valkey_password" >> .env
+          echo "RABBITMQ_USER=ots" >> .env
+          echo "RABBITMQ_PASS=$rabbitmq_pass" >> .env
+
+      # No OTS_IMAGE_TAG override and no bake: compose resolves the pinned
+      # default and pulls it from the registry (--quiet-pull). Bring up `app`
+      # (+ its maindb dep), NOT the proxy — the proxy needs a source build and
+      # is unrelated to the boot-migration/volume contract this lane guards.
+      # AUTHENTICATION_MODE defaults to full, so the app runs its sqlite auth.db
+      # migrations at boot inside the app-data named volume; --wait on the app
+      # healthcheck fails here if the volume mount is root-owned (#3892). The
+      # shared-volume contract is identical for worker-email/scheduler.
+      - name: Bring up the app against the pinned published image (--wait)
+        run: |
+          docker compose -f docker/compose/docker-compose.full.yml \
+            up -d --wait --wait-timeout 300 --quiet-pull app
+
+      # POL_CREATE_ACCOUNT stays off (unlike full-stack-smoke): a published
+      # release may predate the bin/ots CLI contract the account step depends
+      # on. Steps 1-3 are HTTP/API-only and stable across releases; a 200 from
+      # /api/v2/status already proves the boot migration wrote to the volume.
+      - name: Proof of life (inside the app container)
+        run: |
+          docker compose -f docker/compose/docker-compose.full.yml \
+            exec -T app bash -s -- http://127.0.0.1:3000 \
+            < scripts/test-install/proof-of-life.sh
 
       - name: Dump logs on failure
         if: failure()

--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -41,7 +41,10 @@ on:
     paths:
       - 'docker-compose.yml'
       - 'docker/compose/**'
+      # Named individually, not globbed: scripts/test-install/ also holds
+      # helpers for five other workflows, and this lane is a ~15min build+up.
       - 'scripts/test-install/proof-of-life.sh'
+      - 'scripts/test-install/seed-compose-env.sh'
       - '.github/workflows/compose-smoke.yml'
       # full-stack-smoke builds from source, so image-definition changes
       # must exercise it too.

--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -16,16 +16,16 @@
 #                      Caddy. Source-built so it guards the repo's Dockerfile
 #                      and compose wiring together (and the /app/data named-
 #                      volume ownership contract), not last release's image.
-#   full-stack-pinned  (weekly cron + manual): bring up the full stack with NO
-#                      OTS_IMAGE_TAG override, so it pulls the PUBLISHED pinned
-#                      image the compose default names and boots it against the
-#                      current compose file. full-stack-smoke builds from source
-#                      and so can't see when a pinned release predates the
-#                      compose file's runtime contract (#3892 — v0.25.11 + the
-#                      /app/data named volume = root-owned mount, sqlite boot
-#                      migration can't write). Cron/manual, not PR: a release PR
-#                      may bump the pin to a tag that isn't published yet (the
-#                      static check-version-pins.sh guard covers PR-time drift).
+#   app-boot-pinned    (weekly cron + manual): boot the app from the full
+#                      compose config with NO OTS_IMAGE_TAG override, so it
+#                      pulls the PUBLISHED pinned image the default names and
+#                      boots it against the current compose file. full-stack-
+#                      smoke builds from source and so can't see when a pinned
+#                      release predates the compose file's runtime contract
+#                      (#3892 — v0.25.11 + the /app/data named volume = root-
+#                      owned mount, sqlite boot migration can't write). Cron/
+#                      manual, not PR: a release PR may bump the pin to a tag
+#                      not published yet (check-version-pins.sh covers PR drift).
 #   docker-run-readme  (weekly cron + manual): the README `docker run` quick
 #                      start, verbatim, against the exact published tag the
 #                      README shows — the only thing that catches "the docs
@@ -141,35 +141,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      # Same interpolation story as compose-smoke above: SECRET into the job
-      # env for `${SECRET:?}` interpolation, repo-root .env for `env_file:`.
-      # This job also runs AUTHENTICATION_MODE=full (Rodauth), which enables
-      # rodauth-tools' hmac_secret_guard and account_id_obfuscation — both
-      # fail-closed in production (unset RACK_ENV counts as production) when
-      # AUTH_SECRET / ACCOUNT_ID_SECRET are blank, so seed those into the job
-      # env too (docker-compose.full.yml interpolates them the same way as
-      # SECRET, via `${AUTH_SECRET:-}` / `${ACCOUNT_ID_SECRET:-}`).
-      - name: Seed SECRET (interpolation) and .env (env_file target)
-        run: |
-          secret="$(openssl rand -hex 32)"
-          auth_secret="$(openssl rand -hex 32)"
-          account_id_secret="$(openssl rand -hex 32)"
-          echo "SECRET=$secret" >> "$GITHUB_ENV"
-          echo "AUTH_SECRET=$auth_secret" >> "$GITHUB_ENV"
-          echo "ACCOUNT_ID_SECRET=$account_id_secret" >> "$GITHUB_ENV"
-          echo "SECRET=$secret" > .env
-          # H-2: VALKEY_URL / maindb requirepass and RabbitMQ user/pass are now
-          # ${VAR:?...} fail-fast required. Supply throwaways so `config`/`build`/
-          # `up` interpolate (both $GITHUB_ENV for interpolation and .env for
-          # env_file: at container runtime).
-          valkey_password="$(openssl rand -hex 32)"
-          rabbitmq_pass="$(openssl rand -hex 16)"
-          echo "VALKEY_PASSWORD=$valkey_password" >> "$GITHUB_ENV"
-          echo "RABBITMQ_USER=ots" >> "$GITHUB_ENV"
-          echo "RABBITMQ_PASS=$rabbitmq_pass" >> "$GITHUB_ENV"
-          echo "VALKEY_PASSWORD=$valkey_password" >> .env
-          echo "RABBITMQ_USER=ots" >> .env
-          echo "RABBITMQ_PASS=$rabbitmq_pass" >> .env
+      # Seed throwaway secrets into $GITHUB_ENV (compose interpolation) and
+      # repo-root .env (the `env_file:` target). Shared with app-boot-pinned;
+      # see the script header for what each target covers and why full auth
+      # mode needs AUTH_SECRET / ACCOUNT_ID_SECRET.
+      - name: Seed throwaway secrets (compose interpolation + .env)
+        run: bash scripts/test-install/seed-compose-env.sh
 
       # Build the app image FROM SOURCE via the same bake config releases
       # use, tagged so the compose default `onetimesecret/onetimesecret:
@@ -271,8 +248,8 @@ jobs:
         if: always()
         run: docker compose -f docker/compose/docker-compose.full.yml down -v
 
-  full-stack-pinned:
-    name: docker compose up (full, pinned image)
+  app-boot-pinned:
+    name: docker compose up (app boot, pinned image)
     # Pulls the PUBLISHED image the compose default names; on a release PR that
     # bumps the pin, that tag may not exist yet — so cron/manual only, like
     # docker-run-readme. check-version-pins.sh is the PR-time drift guard.
@@ -283,27 +260,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      # Same interpolation + fail-fast story as full-stack-smoke: SECRET into
-      # the job env for `${SECRET:?}`, repo-root .env for `env_file:`, plus the
-      # full-mode secrets (AUTH_SECRET / ACCOUNT_ID_SECRET fail closed in
-      # production) and the ${VAR:?} Valkey/RabbitMQ credentials.
-      - name: Seed SECRET (interpolation) and .env (env_file target)
-        run: |
-          secret="$(openssl rand -hex 32)"
-          auth_secret="$(openssl rand -hex 32)"
-          account_id_secret="$(openssl rand -hex 32)"
-          echo "SECRET=$secret" >> "$GITHUB_ENV"
-          echo "AUTH_SECRET=$auth_secret" >> "$GITHUB_ENV"
-          echo "ACCOUNT_ID_SECRET=$account_id_secret" >> "$GITHUB_ENV"
-          echo "SECRET=$secret" > .env
-          valkey_password="$(openssl rand -hex 32)"
-          rabbitmq_pass="$(openssl rand -hex 16)"
-          echo "VALKEY_PASSWORD=$valkey_password" >> "$GITHUB_ENV"
-          echo "RABBITMQ_USER=ots" >> "$GITHUB_ENV"
-          echo "RABBITMQ_PASS=$rabbitmq_pass" >> "$GITHUB_ENV"
-          echo "VALKEY_PASSWORD=$valkey_password" >> .env
-          echo "RABBITMQ_USER=ots" >> .env
-          echo "RABBITMQ_PASS=$rabbitmq_pass" >> .env
+      # Shared with full-stack-smoke — same $GITHUB_ENV + .env seeding, incl.
+      # the full-mode AUTH_SECRET / ACCOUNT_ID_SECRET. See the script header.
+      - name: Seed throwaway secrets (compose interpolation + .env)
+        run: bash scripts/test-install/seed-compose-env.sh
 
       # No OTS_IMAGE_TAG override and no bake: compose resolves the pinned
       # default and pulls it from the registry (--quiet-pull). Bring up `app`

--- a/docker/README.md
+++ b/docker/README.md
@@ -94,10 +94,10 @@ anything to do.
 
 The compose files default `OTS_IMAGE_TAG` to a pinned release — the same
 version the root README's `docker run` quick start uses — so a fresh
-`docker compose up` is reproducible. Because pre-1.0 minor releases can
-carry breaking changes, we recommend pinning a specific `vX.Y.Z` tag
-rather than a moving tag like `latest`. Override it in `.env` or inline
-to run a different release:
+`docker compose up` is reproducible. Because releases before 1.0 can
+introduce breaking changes between minor versions, we recommend pinning a
+specific `vX.Y.Z` tag rather than a moving tag like `latest`. Override it
+in `.env` or inline to run a different release:
 
 ```bash
 OTS_IMAGE_TAG=v0.26.0 docker compose up

--- a/docker/README.md
+++ b/docker/README.md
@@ -94,15 +94,18 @@ anything to do.
 
 The compose files default `OTS_IMAGE_TAG` to a pinned release — the same
 version the root README's `docker run` quick start uses — rather than
-`latest`, so a fresh `docker compose up` is reproducible. Override it in
-`.env` or inline:
+`latest`, so a fresh `docker compose up` is reproducible. Pre-1.0 minor
+releases can carry breaking changes, so always pin an explicit `vX.Y.Z`
+tag — never `latest`. Override it in `.env` or inline to run a different
+release:
 
 ```bash
-OTS_IMAGE_TAG=latest docker compose up
+OTS_IMAGE_TAG=v0.26.0 docker compose up
 ```
 
 At release time, bump the pinned tag in the root README and in the
-`docker/compose/*.yml` defaults together (grep for the old version).
+`docker/compose/*.yml` defaults together.
+`scripts/check-version-pins.sh` fails CI if they drift (see #3892).
 
 ## Data Persistence
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -100,7 +100,7 @@ specific `vX.Y.Z` tag rather than a moving tag like `latest`. Override it
 in `.env` or inline to run a different release:
 
 ```bash
-OTS_IMAGE_TAG=v0.26.0 docker compose up
+OTS_IMAGE_TAG=vX.Y.Z docker compose up
 ```
 
 At release time, bump the pinned tag in the root README and in the

--- a/docker/README.md
+++ b/docker/README.md
@@ -93,11 +93,11 @@ anything to do.
 ## Image Version (OTS_IMAGE_TAG)
 
 The compose files default `OTS_IMAGE_TAG` to a pinned release — the same
-version the root README's `docker run` quick start uses — rather than
-`latest`, so a fresh `docker compose up` is reproducible. Pre-1.0 minor
-releases can carry breaking changes, so always pin an explicit `vX.Y.Z`
-tag — never `latest`. Override it in `.env` or inline to run a different
-release:
+version the root README's `docker run` quick start uses — so a fresh
+`docker compose up` is reproducible. Because pre-1.0 minor releases can
+carry breaking changes, we recommend pinning a specific `vX.Y.Z` tag
+rather than a moving tag like `latest`. Override it in `.env` or inline
+to run a different release:
 
 ```bash
 OTS_IMAGE_TAG=v0.26.0 docker compose up

--- a/docker/compose/docker-compose.full.yml
+++ b/docker/compose/docker-compose.full.yml
@@ -5,8 +5,8 @@
 # background workers, and scheduler.
 #
 # App uses pre-built images from Docker Hub, pinned by default to the same
-# release the root README documents. Override to run a different pinned
-# release (never `latest` — pre-1.0 minor releases can carry breaking changes):
+# release the root README documents. We recommend a specific release over a
+# moving tag (pre-1.0 minors can carry breaking changes); override with:
 #   OTS_IMAGE_TAG=v0.26.0 docker compose up
 #
 # Caddy proxy requires building (plugins: ratelimit, security, transform-encoder):

--- a/docker/compose/docker-compose.full.yml
+++ b/docker/compose/docker-compose.full.yml
@@ -6,7 +6,8 @@
 #
 # App uses pre-built images from Docker Hub, pinned by default to the same
 # release the root README documents. We recommend a specific release over a
-# moving tag (pre-1.0 minors can carry breaking changes); override with:
+# moving tag, since releases before 1.0 can introduce breaking changes between
+# minor versions; override with:
 #   OTS_IMAGE_TAG=v0.26.0 docker compose up
 #
 # Caddy proxy requires building (plugins: ratelimit, security, transform-encoder):

--- a/docker/compose/docker-compose.full.yml
+++ b/docker/compose/docker-compose.full.yml
@@ -54,7 +54,7 @@ services:
   app:
     # Default tag is kept in lockstep with the README quick-start pin.
     # Bump both together at release time (see docker/README.md).
-    image: onetimesecret/onetimesecret:${OTS_IMAGE_TAG:-v0.25.11}
+    image: onetimesecret/onetimesecret:${OTS_IMAGE_TAG:-v0.26.1}
     container_name: onetime-app
     depends_on:
       maindb:
@@ -189,7 +189,7 @@ services:
       start_period: 30s
 
   worker-email:
-    image: onetimesecret/onetimesecret:${OTS_IMAGE_TAG:-v0.25.11}
+    image: onetimesecret/onetimesecret:${OTS_IMAGE_TAG:-v0.26.1}
     container_name: onetime-worker-email
     depends_on:
       maindb:
@@ -232,7 +232,7 @@ services:
       - app-data:/app/data
 
   scheduler:
-    image: onetimesecret/onetimesecret:${OTS_IMAGE_TAG:-v0.25.11}
+    image: onetimesecret/onetimesecret:${OTS_IMAGE_TAG:-v0.26.1}
     container_name: onetime-scheduler
     depends_on:
       maindb:

--- a/docker/compose/docker-compose.full.yml
+++ b/docker/compose/docker-compose.full.yml
@@ -7,8 +7,8 @@
 # App uses pre-built images from Docker Hub, pinned by default to the same
 # release the root README documents. We recommend a specific release over a
 # moving tag, since releases before 1.0 can introduce breaking changes between
-# minor versions; override with:
-#   OTS_IMAGE_TAG=v0.26.0 docker compose up
+# minor versions; override with the release you want:
+#   OTS_IMAGE_TAG=vX.Y.Z docker compose up
 #
 # Caddy proxy requires building (plugins: ratelimit, security, transform-encoder):
 #   docker compose build proxy

--- a/docker/compose/docker-compose.full.yml
+++ b/docker/compose/docker-compose.full.yml
@@ -5,8 +5,9 @@
 # background workers, and scheduler.
 #
 # App uses pre-built images from Docker Hub, pinned by default to the same
-# release the root README documents. Override with:
-#   OTS_IMAGE_TAG=latest docker compose up
+# release the root README documents. Override to run a different pinned
+# release (never `latest` — pre-1.0 minor releases can carry breaking changes):
+#   OTS_IMAGE_TAG=v0.26.0 docker compose up
 #
 # Caddy proxy requires building (plugins: ratelimit, security, transform-encoder):
 #   docker compose build proxy

--- a/docker/compose/docker-compose.simple.yml
+++ b/docker/compose/docker-compose.simple.yml
@@ -7,8 +7,8 @@
 # Uses pre-built images from Docker Hub, pinned by default to the same
 # release the root README documents. We recommend a specific release over a
 # moving tag, since releases before 1.0 can introduce breaking changes between
-# minor versions; override with:
-#   OTS_IMAGE_TAG=v0.26.0 docker compose up
+# minor versions; override with the release you want:
+#   OTS_IMAGE_TAG=vX.Y.Z docker compose up
 #
 # To build from source instead, use Docker Bake:
 #   docker buildx bake -f docker/bake.hcl main

--- a/docker/compose/docker-compose.simple.yml
+++ b/docker/compose/docker-compose.simple.yml
@@ -6,7 +6,8 @@
 #
 # Uses pre-built images from Docker Hub, pinned by default to the same
 # release the root README documents. We recommend a specific release over a
-# moving tag (pre-1.0 minors can carry breaking changes); override with:
+# moving tag, since releases before 1.0 can introduce breaking changes between
+# minor versions; override with:
 #   OTS_IMAGE_TAG=v0.26.0 docker compose up
 #
 # To build from source instead, use Docker Bake:

--- a/docker/compose/docker-compose.simple.yml
+++ b/docker/compose/docker-compose.simple.yml
@@ -5,8 +5,9 @@
 # No reverse proxy, no message queue, no workers.
 #
 # Uses pre-built images from Docker Hub, pinned by default to the same
-# release the root README documents. Override with:
-#   OTS_IMAGE_TAG=latest docker compose up
+# release the root README documents. Override to run a different pinned
+# release (never `latest` — pre-1.0 minor releases can carry breaking changes):
+#   OTS_IMAGE_TAG=v0.26.0 docker compose up
 #
 # To build from source instead, use Docker Bake:
 #   docker buildx bake -f docker/bake.hcl main

--- a/docker/compose/docker-compose.simple.yml
+++ b/docker/compose/docker-compose.simple.yml
@@ -17,7 +17,7 @@ services:
   app:
     # Default tag is kept in lockstep with the README quick-start pin.
     # Bump both together at release time (see docker/README.md).
-    image: onetimesecret/onetimesecret:${OTS_IMAGE_TAG:-v0.25.11}
+    image: onetimesecret/onetimesecret:${OTS_IMAGE_TAG:-v0.26.1}
     container_name: onetime-app
     depends_on:
       maindb:

--- a/docker/compose/docker-compose.simple.yml
+++ b/docker/compose/docker-compose.simple.yml
@@ -5,8 +5,8 @@
 # No reverse proxy, no message queue, no workers.
 #
 # Uses pre-built images from Docker Hub, pinned by default to the same
-# release the root README documents. Override to run a different pinned
-# release (never `latest` — pre-1.0 minor releases can carry breaking changes):
+# release the root README documents. We recommend a specific release over a
+# moving tag (pre-1.0 minors can carry breaking changes); override with:
 #   OTS_IMAGE_TAG=v0.26.0 docker compose up
 #
 # To build from source instead, use Docker Bake:

--- a/scripts/check-version-pins.sh
+++ b/scripts/check-version-pins.sh
@@ -14,6 +14,14 @@
 #   - .devcontainer/devcontainer.json node feature version == .node-version major
 #     (devcontainer features can't read pin files, so those are duplicated by
 #     necessity — this guard keeps the duplication in lockstep; C8 → C9)
+#   - docker/compose/*.yml  ${OTS_IMAGE_TAG:-vX.Y.Z} app-image default ==
+#     README quick-start pin (the source of truth the compose headers cite).
+#     Drift here ships a `docker compose up` that pulls an image predating the
+#     compose file's own runtime contract — e.g. the /app/data volume-ownership
+#     fix that only landed in v0.26.0 (issue #3892). A non-vX.Y.Z *default* (a
+#     moving tag like `latest`) also fails the guard — the shipped quick-start
+#     must name an immutable release (a runtime OTS_IMAGE_TAG override is the
+#     caller's choice and out of scope).
 #
 set -euo pipefail
 
@@ -93,6 +101,39 @@ if [[ -f "$dc_json" ]]; then
 else
   fail "$dc_json not found"
 fi
+
+# --- Compose app-image pin matches the README quick-start pin ---------
+# The compose files pin onetimesecret/onetimesecret via ${OTS_IMAGE_TAG:-vX.Y.Z}.
+# That default must match the tag the root README quick-start documents (the
+# single source of truth the compose headers cite as "lockstep"), or a fresh
+# `docker compose up` pulls an image that predates the compose file's own
+# runtime contract (#3892). README is authoritative — it is also the tag the
+# docker-run-readme smoke lane runs verbatim.
+readme_pin="$(grep -oE 'onetimesecret/onetimesecret:v[0-9]+\.[0-9]+\.[0-9]+' README.md | head -n1 | cut -d: -f2)"
+[[ -n "$readme_pin" ]] || fail "no pinned onetimesecret/onetimesecret:vX.Y.Z tag found in README.md"
+
+for cf in docker/compose/docker-compose.full.yml docker/compose/docker-compose.simple.yml; do
+  [[ -f "$cf" ]] || fail "$cf not found"
+
+  # Total app-image references vs. those with a parseable vX.Y.Z default. A
+  # mismatch means a reference the pin pattern can't see (e.g. a `latest`
+  # default, or a reshaped interpolation) — fail rather than skip it silently.
+  refs="$(grep -cE 'onetimesecret/onetimesecret:\$\{OTS_IMAGE_TAG' "$cf" || true)"
+  [[ "$refs" -gt 0 ]] || fail "$cf pins no onetimesecret app image via \${OTS_IMAGE_TAG:-...} — pattern moved?"
+
+  pinned=0
+  while IFS= read -r tag; do
+    pinned=$((pinned + 1))
+    if [[ "$tag" == "$readme_pin" ]]; then
+      echo "PASS: $cf OTS_IMAGE_TAG default ($tag) matches README pin ($readme_pin)"
+    else
+      fail "$cf OTS_IMAGE_TAG default ($tag) != README quick-start pin ($readme_pin) — bump both together (#3892)"
+    fi
+  done < <(grep -oE 'onetimesecret/onetimesecret:\$\{OTS_IMAGE_TAG:-v[0-9]+\.[0-9]+\.[0-9]+\}' "$cf" \
+             | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
+
+  [[ "$pinned" -eq "$refs" ]] || fail "$cf has $refs app-image reference(s) but only $pinned parseable vX.Y.Z default(s) — a non-vX.Y.Z default (e.g. 'latest') escapes the pin guard"
+done
 
 echo "PASS: all version pins are in sync"
 exit 0

--- a/scripts/check-version-pins.sh
+++ b/scripts/check-version-pins.sh
@@ -16,6 +16,9 @@
 #     necessity — this guard keeps the duplication in lockstep; C8 → C9)
 #   - docker/compose/*.yml  ${OTS_IMAGE_TAG:-vX.Y.Z} app-image default ==
 #     README quick-start pin (the source of truth the compose headers cite).
+#     Every compose file is scanned; overlays that ship no app image (the
+#     mailpit sidecar) are skipped, but the two stacks that must pin one
+#     (full, simple) fail the guard if the pattern stops matching there.
 #     Drift here ships a `docker compose up` that pulls an image predating the
 #     compose file's own runtime contract — e.g. the /app/data volume-ownership
 #     fix that only landed in v0.26.0 (issue #3892). A non-vX.Y.Z *default* (a
@@ -109,17 +112,35 @@ fi
 # `docker compose up` pulls an image that predates the compose file's own
 # runtime contract (#3892). README is authoritative — it is also the tag the
 # docker-run-readme smoke lane runs verbatim.
-readme_pin="$(grep -oE 'onetimesecret/onetimesecret:v[0-9]+\.[0-9]+\.[0-9]+' README.md | head -n1 | cut -d: -f2)"
+# `|| true` keeps a no-match grep from tripping `set -o pipefail` and killing
+# the script before the explicit check below can name what went wrong.
+readme_pin="$(grep -oE 'onetimesecret/onetimesecret:v[0-9]+\.[0-9]+\.[0-9]+' README.md | head -n1 | cut -d: -f2 || true)"
 [[ -n "$readme_pin" ]] || fail "no pinned onetimesecret/onetimesecret:vX.Y.Z tag found in README.md"
 
-for cf in docker/compose/docker-compose.full.yml docker/compose/docker-compose.simple.yml; do
-  [[ -f "$cf" ]] || fail "$cf not found"
+# The stacks that must always pin an app image. Other compose files are still
+# scanned, but a zero-match in one of these means the pattern moved (a silent
+# skip is the failure mode this guard exists to prevent).
+must_pin=(
+  "docker/compose/docker-compose.full.yml"
+  "docker/compose/docker-compose.simple.yml"
+)
+for required in "${must_pin[@]}"; do
+  [[ -f "$required" ]] || fail "$required not found"
+done
 
+for cf in docker/compose/*.yml; do
   # Total app-image references vs. those with a parseable vX.Y.Z default. A
   # mismatch means a reference the pin pattern can't see (e.g. a `latest`
   # default, or a reshaped interpolation) — fail rather than skip it silently.
   refs="$(grep -cE 'onetimesecret/onetimesecret:\$\{OTS_IMAGE_TAG' "$cf" || true)"
-  [[ "$refs" -gt 0 ]] || fail "$cf pins no onetimesecret app image via \${OTS_IMAGE_TAG:-...} — pattern moved?"
+  if [[ "$refs" -eq 0 ]]; then
+    for required in "${must_pin[@]}"; do
+      if [[ "$cf" == "$required" ]]; then
+        fail "$cf pins no onetimesecret app image via \${OTS_IMAGE_TAG:-...} — pattern moved?"
+      fi
+    done
+    continue  # overlay with no app image of its own (e.g. the mailpit sidecar)
+  fi
 
   pinned=0
   while IFS= read -r tag; do

--- a/scripts/test-install/seed-compose-env.sh
+++ b/scripts/test-install/seed-compose-env.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# scripts/test-install/seed-compose-env.sh
+#
+# Seeds throwaway secrets for the full-stack compose smoke lanes and writes
+# both targets compose needs:
+#
+#   $GITHUB_ENV  — satisfies ${SECRET:?} / ${VALKEY_PASSWORD:?} /
+#                  ${RABBITMQ_USER:?} / ${RABBITMQ_PASS:?} interpolation for
+#                  every `config`/`build`/`up`, plus AUTH_SECRET /
+#                  ACCOUNT_ID_SECRET, which rodauth-tools' hmac_secret_guard
+#                  and account_id_obfuscation fail closed on in production
+#                  (an unset RACK_ENV counts as production).
+#   .env         — the `env_file: ../../.env` target, which must exist at
+#                  container runtime.
+#
+# Shared by the full-stack-smoke and app-boot-pinned lanes so the two can't
+# drift. The stack is torn down after each run, so throwaway values are fine.
+#
+set -euo pipefail
+
+: "${GITHUB_ENV:?GITHUB_ENV must be set — this helper runs inside GitHub Actions}"
+
+secret="$(openssl rand -hex 32)"
+auth_secret="$(openssl rand -hex 32)"
+account_id_secret="$(openssl rand -hex 32)"
+valkey_password="$(openssl rand -hex 32)"
+rabbitmq_pass="$(openssl rand -hex 16)"
+
+# Interpolation env for every compose invocation in later steps.
+{
+  echo "SECRET=$secret"
+  echo "AUTH_SECRET=$auth_secret"
+  echo "ACCOUNT_ID_SECRET=$account_id_secret"
+  echo "VALKEY_PASSWORD=$valkey_password"
+  echo "RABBITMQ_USER=ots"
+  echo "RABBITMQ_PASS=$rabbitmq_pass"
+} >> "$GITHUB_ENV"
+
+# env_file: target consumed by the containers at runtime.
+{
+  echo "SECRET=$secret"
+  echo "VALKEY_PASSWORD=$valkey_password"
+  echo "RABBITMQ_USER=ots"
+  echo "RABBITMQ_PASS=$rabbitmq_pass"
+} > .env

--- a/scripts/test-install/seed-compose-env.sh
+++ b/scripts/test-install/seed-compose-env.sh
@@ -12,7 +12,10 @@
 #                  and account_id_obfuscation fail closed on in production
 #                  (an unset RACK_ENV counts as production).
 #   .env         — the `env_file: ../../.env` target, which must exist at
-#                  container runtime.
+#                  container runtime. That path resolves to the repo root, so
+#                  this script writes there by script location rather than by
+#                  cwd (a workflow-level `working-directory:` would otherwise
+#                  strand the file where compose can't see it).
 #
 # Shared by the full-stack-smoke and app-boot-pinned lanes so the two can't
 # drift. The stack is torn down after each run, so throwaway values are fine.
@@ -20,6 +23,10 @@
 set -euo pipefail
 
 : "${GITHUB_ENV:?GITHUB_ENV must be set — this helper runs inside GitHub Actions}"
+
+# Repo root regardless of how the script is invoked (matches check-version-pins.sh).
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
 
 secret="$(openssl rand -hex 32)"
 auth_secret="$(openssl rand -hex 32)"


### PR DESCRIPTION
Fixes #3892.

## Root cause

A fresh `docker compose up` on the full stack dies at boot:

```
SQLite3::CantOpenException: unable to open database file
database_url: "sqlite://data/auth.db"
```

Not "file missing" — **directory not writable**:

- The compose files mount a **named volume** for the sqlite authdb (`app-data:/app/data`) and point SQLite at the relative `data/auth.db` (→ `/app/data/auth.db`, WORKDIR is `/app`).
- Docker only seeds a fresh named volume's ownership from the image if `/app/data` **exists in the image**. If not, it creates the mount point **root-owned**; the app runs as uid 1001 and can't create `auth.db`.
- The Dockerfile fix that ships `/app/data` pre-owned by appuser (`install -d -o appuser -g appuser data`, `85a2cc3e85`) first shipped in **v0.26.0**.
- But the compose files defaulted `OTS_IMAGE_TAG` to **v0.25.11** (pre-fix) in all 4 app services → old image + named volume = root-owned mount = crash.

The README already pins **v0.26.1**; the compose default had drifted behind it.

**Why CI didn't catch it:** `full-stack-smoke` builds the image *from source* (current Dockerfile, has the fix) and overrides `OTS_IMAGE_TAG=ci-fullstack`, so the published default-tag path was never exercised.

## Changes

1. **Bug fix** — bump the 4 `OTS_IMAGE_TAG` defaults (full ×3, simple ×1) `v0.25.11` → `v0.26.1`.
2. **Static drift guard** — extend `scripts/check-version-pins.sh` to assert every compose `${OTS_IMAGE_TAG:-vX.Y.Z}` default equals the README quick-start pin (and reject a non-`vX.Y.Z` default). Already wired into `drift-guards.yml` (every PR) and `validate-config.yml`; also added as a `build-and-publish` release gate. This alone would have caught this bug at the PR that released v0.26.x.
3. **Dynamic guard** — new `app-boot-pinned` lane in `compose-smoke.yml`: boots the `app` service (plus its `maindb` dep) from the full-stack compose file with **no** `OTS_IMAGE_TAG` override, so the **published pinned image** runs against the current compose wiring. Not the proxy — that needs a source build and is unrelated to the boot-migration/volume contract this lane guards. Cron/manual only (a release PR may bump the pin to a not-yet-published tag; the static guard covers PR-time drift).

## Verification

- `scripts/check-version-pins.sh` → PASS; reintroducing the `v0.25.11` drift → exits 1 with an actionable `(#3892)` message.
- YAML parses clean for both workflows and both compose files; no new `actionlint` findings beyond a pre-existing style nit mirrored from the adjacent `full-stack-smoke` seed step.

Immediate workaround for the reporter: `OTS_IMAGE_TAG=v0.26.1 docker compose up`.
