### PR TITLE
Admin ops expansion + fix colonel customer-detail timeout and row-click bugs

### DIFF
--- a/apps/api/colonel/logic/colonel.rb
+++ b/apps/api/colonel/logic/colonel.rb
@@ -25,6 +25,9 @@ require_relative 'colonel/list_secrets'
 require_relative 'colonel/get_secret_receipt'
 require_relative 'colonel/delete_secret'
 
+# Shared identifier handling (email-tolerant account lookup)
+require_relative 'colonel/account_identifier'
+
 # User management
 require_relative 'colonel/list_users'
 require_relative 'colonel/get_user_details'
@@ -117,8 +120,9 @@ require_relative 'colonel/get_email_provider_status'
 require_relative 'colonel/lookup_email_recipient'
 require_relative 'colonel/list_email_messages'
 
-# Billing catalog (ticket #45)
+# Billing catalog (ticket #45) + the Stripe-linked organization roster
 require_relative 'colonel/get_billing_catalog'
+require_relative 'colonel/list_stripe_organizations'
 
 # Observability: audit trail reader + daily activity trends
 require_relative 'colonel/list_audit_events'

--- a/apps/api/colonel/logic/colonel/account_identifier.rb
+++ b/apps/api/colonel/logic/colonel/account_identifier.rb
@@ -1,0 +1,70 @@
+# apps/api/colonel/logic/colonel/account_identifier.rb
+#
+# frozen_string_literal: true
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Sanitizer for identifiers that may be an EMAIL ADDRESS.
+      #
+      # ## Why this exists
+      #
+      # `Onetime::Security::InputSanitizers#sanitize_identifier` strips every
+      # character outside `[a-zA-Z0-9_-]`, so `user@example.com` arrives at the
+      # resolver as `userexamplecom`. Every colonel surface that documents an
+      # "email or extid" identifier (verify/unverify, purge, user detail, the
+      # three membership verbs) was therefore email-blind: the email arm of
+      # `Customer.load_by_extid_or_email` could never match and the request 404'd
+      # with "not found".
+      #
+      # `sanitize_account_identifier` keeps the same strict allowlist posture —
+      # a character allowlist, no HTML parsing — but widens it by exactly the
+      # characters an email address needs (`@ . + %`). It is NOT a validator:
+      # callers still resolve the result through
+      # `Customer.load_by_extid_or_email` (or the membership resolver), which is
+      # what decides whether the identifier names anything.
+      #
+      # ## Threat model
+      #
+      # The allowlist excludes whitespace, quotes, angle brackets, backslashes,
+      # colons, slashes and every Redis/glob metacharacter, so the output is
+      # still safe to interpolate into a key lookup or a log line. Length is
+      # bounded at {MAX_LENGTH} (RFC 5321's 254-octet path limit, rounded) so a
+      # pathological identifier can't be used to inflate a log or an index probe.
+      #
+      # Use `sanitize_identifier` (unchanged) for identifiers that can only ever
+      # be an extid/objid — org ids, domain extids, session ids.
+      module AccountIdentifier
+        # Any character NOT valid in an extid/objid OR an email local/domain part.
+        # Mirrors IDENTIFIER_STRIP_PATTERN plus `@ . + %`.
+        ACCOUNT_IDENTIFIER_STRIP_PATTERN = /[^a-zA-Z0-9_\-.@+%]/
+
+        # RFC 5321 caps a forward-path at 254 octets; extids are far shorter.
+        MAX_LENGTH = 255
+
+        # @param value [String, nil] raw identifier (email, extid, or objid)
+        # @return [String] sanitized identifier, never nil
+        def sanitize_account_identifier(value)
+          value.to_s.strip.gsub(ACCOUNT_IDENTIFIER_STRIP_PATTERN, '').slice(0, MAX_LENGTH).to_s
+        end
+
+        # Resolve a sanitized identifier to a Customer, trying extid, then
+        # email, then the internal objid — the resolution order every colonel
+        # user surface uses (the users list exposes only extid, so that arm has
+        # to win, but operators paste emails).
+        #
+        # `normalize_email` is a safe pass-through for an extid (extids are
+        # already lowercase ASCII); it only matters when the value is an email
+        # typed with capitals.
+        #
+        # @param identifier [String]
+        # @return [Onetime::Customer, nil]
+        def resolve_account(identifier)
+          normalized = OT::Utils.normalize_email(identifier)
+          Onetime::Customer.load_by_extid_or_email(normalized) ||
+            Onetime::Customer.load(identifier)
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/add_membership.rb
+++ b/apps/api/colonel/logic/colonel/add_membership.rb
@@ -30,7 +30,10 @@ module ColonelAPI
 
         def process_params
           @org_id      = sanitize_identifier(params['org_id'])
-          @customer_id = sanitize_identifier(params['customer'])
+          # Email-tolerant: the docstring above advertises
+          # {"customer": "user@example.com"} and sanitize_identifier would strip
+          # the '@' and '.' out of it. See AccountIdentifier.
+          @customer_id = sanitize_account_identifier(params['customer'])
           @role        = sanitize_plain_text(params['role']).to_s.downcase
           @role        = 'member' if @role.empty?
         end

--- a/apps/api/colonel/logic/colonel/create_custom_domain.rb
+++ b/apps/api/colonel/logic/colonel/create_custom_domain.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 require 'onetime/domain_validation/features'
-require 'onetime/domain_validation/strategy'
+require 'onetime/operations/domains/create'
 require_relative '../base'
 
 module ColonelAPI
@@ -26,15 +26,17 @@ module ColonelAPI
       # Security invariant (epic #20): BOTH the router (role=colonel) AND this
       # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
       #
-      # Audit: one AdminAuditEvent per successful create (CONTRACT 4). No Operation
-      # has been extracted for the create verb yet, so the audit backstop lives in
-      # this logic layer — matching ReconcileOrganization / ManageEntitlementOverride.
+      # Audit: one AdminAuditEvent per successful create (CONTRACT 4), emitted by
+      # {Onetime::Operations::Domains::Create} — this adapter MUST NOT audit.
       # verb is 'domain.create' (the domain.* family: verify/repair/transfer),
       # target is the domain extid, and the org's extid is carried in detail.
+      #
+      # This class used to own the validate + create + cert + audit sequence
+      # inline (create was the last domain verb with no extracted op, so there
+      # was no CLI peer). That sequence now lives in the op; the HTTP contract —
+      # every error message, field and response key — is unchanged.
       class CreateCustomDomain < ColonelAPI::Logic::Base
-        AUDIT_VERB = 'domain.create'
-
-        attr_reader :org, :domain_input, :display_domain, :custom_domain
+        attr_reader :org, :domain_input, :display_domain, :custom_domain, :result
 
         def process_params
           # Sanitize plain text to strip HTML tags before PublicSuffix normalizes.
@@ -50,65 +52,28 @@ module ColonelAPI
           @org = load_organization
           raise_not_found('Organization not found') unless @org&.exists?
 
-          # Domain validation — identical to AddDomain#raise_concerns, minus the
-          # membership/entitlement gate. Reuse the model regex; don't reinvent it.
-          raise_form_error('Please enter a domain', field: :domain) if @domain_input.to_s.empty?
-          raise_form_error('Not a valid public domain', field: :domain) unless Onetime::CustomDomain.valid?(@domain_input)
-          raise_form_error('This domain overlaps with the default site domain', field: :domain) if Onetime::CustomDomain.overlaps_canonical_domain?(@domain_input)
+          # Refuse a bad request BEFORE #process. The rules (and their exact
+          # operator-facing messages) live in the op so the CLI cannot drift.
+          check = operation.validate
+          raise_form_error(check.message, field: :domain) unless check.status == :ok
 
-          # Normalise to the parsed display_domain (mirrors AddDomain).
-          parsed          = Onetime::CustomDomain.parse(@domain_input, @org.objid)
-          @display_domain = parsed.display_domain
+          @display_domain = check.display_domain
+          return unless check.claims_orphan
 
-          # Pre-check duplicates for precise errors (create! re-checks atomically).
-          existing = Onetime::CustomDomain.load_by_display_domain(@display_domain)
-          return unless existing
-
-          if existing.org_id.to_s == @org.objid.to_s
-            raise_form_error('Domain already registered in this organization', field: :domain)
-          end
-
-          unless existing.org_id.to_s.empty?
-            raise_form_error('Domain is registered to another organization', field: :domain)
-          end
-
-          # Orphaned domain (no org_id): create! claims it in #process.
           OT.info "[CreateCustomDomain] Found orphaned domain, will claim: #{@display_domain}"
         end
 
         def process
-          @custom_domain = Onetime::CustomDomain.create!(@display_domain, @org.objid)
+          @result = operation.call
 
-          begin
-            request_certificate
-          rescue HTTParty::ResponseError => ex
-            OT.le "[CreateCustomDomain.request_certificate error] org=#{org.extid} display_domain=#{@display_domain} exception=#{ex}"
-            # Continue: the domain exists; cert provisioning can be retried.
-          rescue StandardError => ex
-            OT.le "[CreateCustomDomain] Unexpected error during certificate request: #{ex}"
-            # Continue: the domain exists; cert provisioning can be retried.
-          end
+          # raise_concerns already validated; a rejection here means the state
+          # changed underneath us (a concurrent create claimed the name).
+          raise_form_error(result.message, field: :domain) unless result.status == :created
 
-          record_audit_event
-
-          OT.info "[CreateCustomDomain] #{@display_domain} -> org=#{org.extid} extid=#{custom_domain.extid}"
+          @custom_domain  = result.domain
+          @display_domain = result.display_domain
 
           success_data
-        end
-
-        def request_certificate
-          strategy = Onetime::DomainValidation::Strategy.for_config(OT.conf)
-          result   = strategy.request_certificate(@custom_domain)
-
-          OT.info "[CreateCustomDomain.request_certificate] #{@display_domain} -> #{result[:status]}"
-
-          if result[:data]
-            @custom_domain.vhost   = result[:data].to_json
-            @custom_domain.updated = OT.now.to_i
-            @custom_domain.save
-          end
-
-          result
         end
 
         def success_data
@@ -116,6 +81,16 @@ module ColonelAPI
         end
 
         private
+
+        # Memoized so raise_concerns and process share one instance (and one
+        # set of resolved inputs).
+        def operation
+          @operation ||= Onetime::Operations::Domains::Create.new(
+            domain: @domain_input,
+            org: @org,
+            actor: cust.extid, # acting colonel's PUBLIC id (never an objid)
+          )
+        end
 
         # Resolve by PUBLIC id (extid) first — every admin surface routes by extid —
         # then fall back to objid. Mirrors GetOrganizationDetail#load_organization.
@@ -145,19 +120,6 @@ module ColonelAPI
 
         def domain_details
           { cluster: Onetime::DomainValidation::Features.safe_dump }
-        end
-
-        def record_audit_event
-          Onetime::AdminAuditEvent.record(
-            actor: cust.extid, # acting colonel's PUBLIC id (never an objid)
-            verb: AUDIT_VERB,
-            target: custom_domain.extid,
-            result: :success,
-            detail: {
-              org_id: org.extid,
-              display_domain: custom_domain.display_domain,
-            },
-          )
         end
       end
     end

--- a/apps/api/colonel/logic/colonel/get_billing_catalog.rb
+++ b/apps/api/colonel/logic/colonel/get_billing_catalog.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative '../base'
+require 'onetime/operations/billing/catalog_drift'
 
 module ColonelAPI
   module Logic
@@ -22,12 +23,16 @@ module ColonelAPI
       #     on only one side, and planids present on both whose entitlements or
       #     limits diverge)
       #
-      # Recipe note (epic #45): unlike the other Phase-3 items this needs NO op
-      # extraction and NO mutating route — the read ops already exist. This is a
-      # thin HTTP adapter that REUSES the incumbent Billing::Plan source
-      # (CONTRACT 5). It NEVER writes, so it emits NO AdminAuditEvent
-      # (CONTRACT 4 — audit is for mutations only). Catalog sync stays CLI-only
-      # until this view is trusted (spec: read-only drift first).
+      # Thin HTTP adapter over {Onetime::Operations::Billing::CatalogDrift}, the
+      # single implementation (shared with `bin/ots billing catalog drift`),
+      # which REUSES the incumbent Billing::Plan source (CONTRACT 5). It NEVER
+      # writes, so it emits NO AdminAuditEvent (CONTRACT 4 — audit is for
+      # mutations only). Catalog sync stays CLI-only until this view is trusted
+      # (spec: read-only drift first).
+      #
+      # The wire shape below is FROZEN by the frontend Zod contract
+      # (src/schemas/api/internal/responses/colonel-billing.ts) — in particular
+      # `source` is an enum of exactly 'stripe' | 'local_config'.
       #
       # ## Request
       #
@@ -72,17 +77,14 @@ module ColonelAPI
       class GetBillingCatalog < ColonelAPI::Logic::Base
         SCHEMAS = { response: 'colonelBillingCatalog' }.freeze
 
-        attr_reader :config_plans, :live_plans, :drift, :source
+        attr_reader :result
 
         def raise_concerns
           verify_one_of_roles!(colonel: true)
         end
 
         def process
-          @config_plans = load_plans_from_config
-          @live_plans   = load_plans_from_stripe_cache
-          @source       = @live_plans.any? ? 'stripe' : 'local_config'
-          @drift        = compute_drift(@config_plans, @live_plans)
+          @result = Onetime::Operations::Billing::CatalogDrift.new.call
 
           success_data
         end
@@ -91,118 +93,13 @@ module ColonelAPI
           {
             record: {},
             details: {
-              source: source,
-              stripe_configured: live_plans.any?,
-              config_plans: config_plans,
-              live_plans: live_plans,
-              drift: drift,
+              source: result.source,
+              stripe_configured: result.stripe_configured,
+              config_plans: result.config_plans,
+              live_plans: result.live_plans,
+              drift: result.drift,
             },
           }
-        end
-
-        private
-
-        # Configured catalog (billing.yaml). REUSES the incumbent source.
-        #
-        # @return [Array<Hash>] Normalized PlanEntry hashes
-        def load_plans_from_config
-          ::Billing::Plan.list_plans_from_config.map { |plan| normalize_config_plan(plan) }
-        rescue StandardError => ex
-          OT.le '[GetBillingCatalog] Error loading plans from config',
-            { exception: ex, message: ex.message }
-          []
-        end
-
-        # Live plans (Stripe-synced Redis cache). Mirrors GetAvailablePlans'
-        # normalization so both sides share the exact same PlanEntry shape and
-        # drift compares like-for-like. Uses the bounded instances lookup, not a
-        # blocking KEYS scan (CONTRACT 6).
-        #
-        # @return [Array<Hash>] Normalized PlanEntry hashes
-        def load_plans_from_stripe_cache
-          ::Billing::Plan.list_plans.map do |plan|
-            {
-              planid: plan.plan_id,
-              name: plan.name,
-              tier: plan.tier,
-              tenancy: plan.tenancy,
-              region: plan.region,
-              display_order: plan.display_order.to_i,
-              show_on_plans_page: plan.show_on_plans_page.to_s == 'true',
-              description: plan.respond_to?(:description) ? plan.description : nil,
-              entitlements: plan.entitlements.to_a.sort,
-              limits: normalize_limits(plan.limits.hgetall || {}),
-            }
-          end
-        rescue StandardError => ex
-          OT.le '[GetBillingCatalog] Error loading plans from Stripe cache',
-            { exception: ex, message: ex.message }
-          []
-        end
-
-        # Select the shared PlanEntry fields from a config plan hash and
-        # normalize entitlements/limits so both sides are comparable.
-        def normalize_config_plan(plan)
-          {
-            planid: plan[:planid],
-            name: plan[:name],
-            tier: plan[:tier],
-            tenancy: plan[:tenancy],
-            region: plan[:region],
-            display_order: plan[:display_order].to_i,
-            show_on_plans_page: plan[:show_on_plans_page] == true,
-            description: plan[:description],
-            entitlements: Array(plan[:entitlements]).map(&:to_s).sort,
-            limits: normalize_limits(plan[:limits] || {}),
-          }
-        end
-
-        # Stringify limit values so a config "0" and a cached "0" compare equal.
-        def normalize_limits(limits)
-          limits.each_with_object({}) do |(key, value), acc|
-            acc[key.to_s] = value.to_s
-          end
-        end
-
-        # Compute the config-vs-live difference, keyed by planid.
-        #
-        # @return [Hash] drift summary
-        def compute_drift(config_plans, live_plans)
-          config_by_id = config_plans.each_with_object({}) { |p, h| h[p[:planid]] = p }
-          live_by_id   = live_plans.each_with_object({}) { |p, h| h[p[:planid]] = p }
-
-          only_in_config = (config_by_id.keys - live_by_id.keys).sort
-          only_in_live   = (live_by_id.keys - config_by_id.keys).sort
-
-          changed = (config_by_id.keys & live_by_id.keys).sort.filter_map do |planid|
-            fields = drifted_fields(config_by_id[planid], live_by_id[planid])
-            next if fields.empty?
-
-            {
-              planid: planid,
-              name: config_by_id[planid][:name] || live_by_id[planid][:name],
-              fields: fields,
-            }
-          end
-
-          {
-            in_sync: only_in_config.empty? && only_in_live.empty? && changed.empty?,
-            only_in_config: only_in_config,
-            only_in_live: only_in_live,
-            changed: changed,
-          }
-        end
-
-        # Which comparable fields diverge between the two sides of a plan.
-        # Entitlements + limits are the operationally meaningful drift; tier and
-        # display metadata are reported too so a rename doesn't hide silently.
-        def drifted_fields(config_plan, live_plan)
-          fields = []
-          fields << 'entitlements' if config_plan[:entitlements] != live_plan[:entitlements]
-          fields << 'limits'       if config_plan[:limits] != live_plan[:limits]
-          fields << 'tier'         if config_plan[:tier] != live_plan[:tier]
-          fields << 'name'         if config_plan[:name] != live_plan[:name]
-          fields
         end
       end
     end

--- a/apps/api/colonel/logic/colonel/get_user_details.rb
+++ b/apps/api/colonel/logic/colonel/get_user_details.rb
@@ -13,6 +13,20 @@ module ColonelAPI
 
         attr_reader :user_id, :user, :user_secrets, :user_receipts, :organizations, :billing
 
+        # Newest-first page size for the per-owner index reads. The page is what
+        # the detail view renders; anything beyond it is reported as truncated
+        # rather than silently dropped.
+        INDEX_PAGE_SIZE = 100
+
+        # Bounds for the legacy-data fallback SCAN (secrets created before the
+        # per-owner index existed). Deliberately bounded by SCAN ROUNDS and
+        # WALL CLOCK — never by match count, which is the bug this replaces: a
+        # match-count cap on an owner-filtered scan never trips for a normal
+        # user, so the loop ran to cursor == '0' over the whole keyspace.
+        FALLBACK_SCAN_ROUNDS  = 40
+        FALLBACK_SCAN_COUNT   = 500
+        FALLBACK_DEADLINE_SEC = 2.0
+
         def process_params
           # sanitize_account_identifier (NOT sanitize_identifier) — the latter
           # strips '@' and '.', which silently destroyed the documented email
@@ -34,11 +48,13 @@ module ColonelAPI
         end
 
         def process
-          # Get all secrets owned by this user using non-blocking SCAN
-          @user_secrets = scan_user_secrets
-
-          # Get all receipts owned by this user using non-blocking SCAN
-          @user_receipts = scan_user_receipts
+          # Secrets and receipts are INDEPENDENTLY degradable sections: each is
+          # read behind its own rescue so a slow or failing datastore read of
+          # one can never stop the identity / plan / role / org / billing
+          # read-out from rendering. A support agent needs the record even when
+          # the activity lists come back empty.
+          @user_secrets  = degrade_on_error('secrets') { collect_secrets }
+          @user_receipts = degrade_on_error('receipts') { collect_receipts }
 
           # Get user's organizations (if they participate in any). The loaded
           # org objects are kept for the billing read-out below (Stripe ids
@@ -76,84 +92,183 @@ module ColonelAPI
 
         private
 
-        # Scan secrets owned by user using non-blocking Redis SCAN.
-        # O(all secrets) but filters by owner_id. The user.receipts sorted
-        # set would be more efficient but isn't populated by spawn_pair yet.
+        # Run one activity section, degrading to an honest empty-but-truncated
+        # result instead of failing the whole page. The rest of the record
+        # (identity, plan, role, org, billing) must always render.
         #
-        # SCOPE (#60): this detail view intentionally keeps its own bounded
-        # cursor SCAN and does NOT source `details.secrets.count` from the
-        # maintained `secrets_active` counter. #60's "count correct beyond 10k"
-        # criterion applies to the colonel USERS LIST column (ListUsers), which
-        # shows only a count. Here we render the actual secret ITEMS, so the
-        # count must equal the items shown (`details.secrets.count == items.size`).
-        # Sourcing it from `secrets_active` would surface a visible count/items
-        # mismatch because that counter drifts UP between nightly reconciliations
-        # (no TTL-expiry decrement — see Customer::Features::CounterFields). This
-        # is a bounded, non-blocking cursor SCAN (COUNT=100, 10k cap), so it is
-        # CONTRACT-8 compliant — not the blocking KEYS/SMEMBERS the #2211 incident
-        # forbids. list_secrets.rb / export_usage.rb keep similar bounded SCANs
-        # for the same reason (separate features). Removing the full-keyspace scan
-        # via a per-owner secret index is a separate follow-up.
-        def scan_user_secrets
-          secrets  = []
-          cursor   = '0'
-          dbclient = Onetime::Secret.dbclient
-          pattern  = 'secret:*:object'
-
-          loop do
-            cursor, keys = dbclient.scan(cursor, match: pattern, count: 100)
-
-            keys.each do |key|
-              objid  = key.split(':')[1]
-              secret = Onetime::Secret.load(objid)
-              next unless secret&.exists?
-              next unless secret.owner_id == user.objid
-
-              secrets << {
-                secret_id: secret.objid,
-                shortid: secret.shortid,
-                state: secret.state,
-                created: secret.created,
-                expiration: secret.expiration,
-              }
-            end
-
-            break if secrets.size >= 10_000
-            break if cursor == '0'
-          end
-
-          secrets
+        # @return [Hash] `{ items: Array, truncated: Boolean }`
+        def degrade_on_error(label)
+          yield
+        rescue StandardError => ex
+          OT.le "[GetUserDetails] #{label} lookup failed: #{ex.class}: #{ex.message}"
+          # truncated: true — we know we are NOT showing everything. A silently
+          # wrong (empty) list is worse than an honest partial one.
+          { items: [], truncated: true }
         end
 
-        # Scan receipts owned by user using non-blocking Redis SCAN.
-        def scan_user_receipts
-          receipt_list = []
-          cursor       = '0'
-          dbclient     = Onetime::Receipt.dbclient
-          pattern      = 'receipt:*:object'
+        # Secrets owned by this user, newest first.
+        #
+        # PRIMARY PATH: the per-owner index (`customer:<objid>:secrets`), written
+        # at the same chokepoint as the `secrets_active` counter
+        # (Receipt.spawn_pair → Customer.increment_secrets_active,
+        # Secret#destroy! → decrement_secrets_active). One ZREVRANGE plus one
+        # pipelined HGETALL batch — O(page), not O(all secrets in the system).
+        # This replaces the full-keyspace `secret:*:object` cursor SCAN that
+        # loaded every secret one at a time to filter by owner: it was
+        # non-blocking for the datastore but unbounded in wall clock for the
+        # caller, which is what made this page time out.
+        #
+        # FALLBACK: secrets created before the index existed are not in it. When
+        # the index is empty but the maintained counter says the user owns
+        # secrets, fall back to a bounded scan (see #scan_secrets_bounded).
+        #
+        # COUNT CONTRACT (#60, unchanged): `details.secrets.count` equals
+        # `items.size` — the detail view renders ITEMS, so the count must match
+        # what is on screen and must not be sourced from the up-drifting
+        # `secrets_active` counter. `truncated` is how "there may be more" is
+        # communicated now, instead of a short list that reads as complete.
+        #
+        # NOTE for whoever touches the sibling colonel scans: export_usage.rb
+        # still has the bug removed here — its `break if secrets.size >= 10_000`
+        # counts DATE-RANGE MATCHES, so a narrow range never trips it and the
+        # loop walks the whole keyspace one Secret.load at a time. list_secrets.rb
+        # uses the same shape but filters nothing, so there every scanned key is a
+        # match and the cap does bound it (still 10k un-pipelined loads per page).
+        def collect_secrets
+          index_size = user.secrets.element_count
 
-          loop do
-            cursor, keys = dbclient.scan(cursor, match: pattern, count: 100)
-
-            keys.each do |key|
-              objid   = key.split(':')[1]
-              receipt = Onetime::Receipt.load(objid)
-              next unless receipt&.exists?
-              next unless receipt.owner_id == user.objid
-
-              receipt_list << {
-                receipt_id: receipt.objid,
-                shortid: receipt.shortid,
-                state: receipt.state,
-                created: receipt.created,
-              }
-            end
-
-            break if receipt_list.size >= 10_000
-            break if cursor == '0'
+          if index_size.zero? && user.secrets_active.to_i.positive?
+            # Nothing indexed but the counter says the user owns secrets: this is
+            # the pre-index (historical) account. Pay for the bounded scan only
+            # here — a user with a live index, or with genuinely zero secrets,
+            # never triggers it.
+            return scan_secrets_bounded
           end
 
-          receipt_list
+          indexed               = read_secret_index
+          indexed[:truncated] ||= index_incomplete?(index_size)
+          indexed
+        end
+
+        # Does the index provably NOT hold every secret this user owns?
+        #
+        # Compares the index size against the `secrets_active` counter — NOT
+        # against the number of items rendered. Both the index and the counter
+        # are written at the same two chokepoints and neither is decremented on
+        # TTL expiry, so they over-count IDENTICALLY; the difference between them
+        # is therefore real missing coverage (secrets created before the index
+        # existed, or trimmed off by SECRET_INDEX_LIMIT), never expiry drift.
+        #
+        # Comparing against the rendered item count instead would flag "partial"
+        # for every account with an expired secret — a flag that fires constantly
+        # is a flag operators learn to ignore.
+        def index_incomplete?(index_size)
+          user.secrets_active.to_i > index_size
+        end
+
+        # Bounded, newest-first read of the per-owner secret index.
+        # Members whose object no longer loads (TTL expiry drops the key with no
+        # application code running) are simply skipped — the index carries
+        # candidates, the object store is the truth.
+        def read_secret_index
+          # One extra member tells us whether a further page exists.
+          objids    = user.secrets.revrange(0, INDEX_PAGE_SIZE)
+          truncated = objids.size > INDEX_PAGE_SIZE
+          objids    = objids.first(INDEX_PAGE_SIZE)
+
+          items = load_secrets(objids).map { |secret| secret_row(secret) }
+          { items: items, truncated: truncated }
+        end
+
+        # Legacy-data fallback: cursor SCAN of `secret:*:object`, bounded by SCAN
+        # ROUNDS **and** a wall-clock deadline. NOT by match count — an
+        # owner-filtered match cap never trips for a normal user, so it bounds
+        # nothing. Stopping early sets `truncated`, so the UI can say the list is
+        # partial rather than imply it is complete.
+        def scan_secrets_bounded
+          rows      = []
+          cursor    = '0'
+          rounds    = 0
+          truncated = false
+          deadline  = monotonic_now + FALLBACK_DEADLINE_SEC
+          dbclient  = Onetime::Secret.dbclient
+
+          loop do
+            cursor, keys = dbclient.scan(cursor, match: 'secret:*:object', count: FALLBACK_SCAN_COUNT)
+            rounds      += 1
+
+            # Pipeline the object loads: one round trip per SCAN batch instead of
+            # one per key (the old code issued a Secret.load per key).
+            load_secrets(keys.map { |key| key.split(':')[1] }).each do |secret|
+              next unless secret.owner_id.to_s == user.objid.to_s
+
+              rows << secret_row(secret)
+            end
+
+            break if cursor == '0'
+
+            if rounds >= FALLBACK_SCAN_ROUNDS || monotonic_now >= deadline
+              truncated = true
+              break
+            end
+          end
+
+          rows.sort_by! { |row| -(row[:created] || 0) }
+          { items: rows.first(INDEX_PAGE_SIZE), truncated: truncated || rows.size > INDEX_PAGE_SIZE }
+        end
+
+        # Receipts owned by this user, newest first, off the per-customer
+        # `receipts` sorted set. That index IS populated at every authenticated
+        # creation path (`cust.add_receipt` in the v1/v2 secret actions and in
+        # create_incoming_secret) and was backfilled for pre-v0.24.5 data by
+        # scripts/upgrades/v0.24.5/copy_customer_receipts_zset.rb, so there is no
+        # scan fallback here — the whole-keyspace `receipt:*:object` walk this
+        # replaces is gone, not merely bounded.
+        #
+        # Receipts minted through Receipt.spawn_pair WITHOUT going through those
+        # logic classes (e.g. password-reset / billing-welcome secrets) are not
+        # indexed; they are operational artifacts, not customer activity, and
+        # were never worth an O(all receipts) walk to surface.
+        def collect_receipts
+          objids    = user.receipts.revrange(0, INDEX_PAGE_SIZE)
+          truncated = objids.size > INDEX_PAGE_SIZE
+          objids    = objids.first(INDEX_PAGE_SIZE)
+
+          items = Onetime::Receipt.load_multi(objids.map(&:to_s)).compact.map do |receipt|
+            {
+              receipt_id: receipt.objid,
+              shortid: receipt.shortid,
+              state: receipt.state,
+              created: receipt.created,
+            }
+          end
+
+          { items: items, truncated: truncated }
+        end
+
+        # Pipelined bulk load (one MULTI/pipeline round trip for the whole
+        # batch), dropping ids whose object is gone. load_multi already returns
+        # nil for a missing key, so this needs no per-key EXISTS.
+        def load_secrets(objids)
+          ids = objids.map(&:to_s).reject(&:empty?)
+          return [] if ids.empty?
+
+          Onetime::Secret.load_multi(ids).compact
+        end
+
+        def secret_row(secret)
+          {
+            secret_id: secret.objid,
+            shortid: secret.shortid,
+            state: secret.state,
+            created: secret.created,
+            expiration: secret.expiration,
+          }
+        end
+
+        # Monotonic clock: a wall-clock deadline must not be moved by NTP steps.
+        def monotonic_now
+          Process.clock_gettime(Process::CLOCK_MONOTONIC)
         end
 
         # Billing summary combining local model state with a live (but
@@ -293,13 +408,20 @@ module ColonelAPI
               locale: user.locale,
             },
             details: {
+              # count == items.size (the #60 contract: the view renders items,
+              # so the number beside the heading must be the number on screen).
+              # `truncated` is the honest signal that more may exist beyond this
+              # page — a short list that reads as complete is the failure mode
+              # this flag exists to prevent.
               secrets: {
-                count: user_secrets.size,
-                items: user_secrets,
+                count: user_secrets[:items].size,
+                items: user_secrets[:items],
+                truncated: user_secrets[:truncated],
               },
               receipts: {
-                count: user_receipts.size,
-                items: user_receipts,
+                count: user_receipts[:items].size,
+                items: user_receipts[:items],
+                truncated: user_receipts[:truncated],
               },
               organizations: organizations,
               billing: billing,

--- a/apps/api/colonel/logic/colonel/get_user_details.rb
+++ b/apps/api/colonel/logic/colonel/get_user_details.rb
@@ -3,15 +3,21 @@
 # frozen_string_literal: true
 
 require_relative '../base'
+require_relative 'account_identifier'
 
 module ColonelAPI
   module Logic
     module Colonel
       class GetUserDetails < ColonelAPI::Logic::Base
+        include AccountIdentifier
+
         attr_reader :user_id, :user, :user_secrets, :user_receipts, :organizations, :billing
 
         def process_params
-          @user_id = sanitize_identifier(params['user_id'])
+          # sanitize_account_identifier (NOT sanitize_identifier) — the latter
+          # strips '@' and '.', which silently destroyed the documented email
+          # arm below. See AccountIdentifier.
+          @user_id = sanitize_account_identifier(params['user_id'])
           raise_form_error('User ID is required', field: :user_id) if user_id.to_s.empty?
         end
 
@@ -23,8 +29,7 @@ module ColonelAPI
           # then objid. Mirrors Auth::Operations::Customers::Show#resolve
           # (show.rb): a plain Customer.load only resolves the internal objid
           # (identifier_field :objid), so an extid would 404.
-          @user = Onetime::Customer.load_by_extid_or_email(user_id) ||
-                  Onetime::Customer.load(user_id)
+          @user = resolve_account(user_id)
           raise_not_found('User not found') unless user&.exists?
         end
 

--- a/apps/api/colonel/logic/colonel/list_custom_domains.rb
+++ b/apps/api/colonel/logic/colonel/list_custom_domains.rb
@@ -13,16 +13,41 @@ module ColonelAPI
       #   organizations, including verification state, brand settings,
       #   logo/icon presence, and the owning organization. Requires
       #   colonel role.
+      #
+      # Optional server-side filters (all additive; omitting them reproduces the
+      # previous unfiltered behaviour byte-for-byte):
+      #
+      #   search  — case-insensitive substring over display_domain / base_domain,
+      #             or an exact extid / domain_id match.
+      #   status  — exact verification_state ('verified', 'pending', ...).
+      #   org_id  — exact owning-org match; accepts the org extid or objid.
+      #
+      # Scaling note: this endpoint loads every CustomDomain before slicing (the
+      # incumbent behaviour). Filtering happens in the same in-memory pass, so it
+      # does not make the read heavier — but a genuinely index-backed page read
+      # is still the right fix if the domain population grows. Filters are
+      # applied BEFORE pagination, so total_count reflects the filtered set.
       class ListCustomDomains < ColonelAPI::Logic::Base
         SCHEMAS = { response: 'customDomains' }.freeze
 
-        attr_reader :domains, :total_count, :page, :per_page, :total_pages
+        attr_reader :domains,
+          :total_count,
+          :page,
+          :per_page,
+          :total_pages,
+          :search_term,
+          :status_filter,
+          :org_filter
 
         def process_params
           @page     = (params['page'] || 1).to_i
           @per_page = (params['per_page'] || 50).to_i
           @per_page = 100 if @per_page > 100 # Max 100 per page
           @page     = 1 if @page < 1
+
+          @search_term   = sanitize_plain_text(params['search'], max_length: 255).to_s.strip
+          @status_filter = sanitize_identifier(params['status']).to_s
+          @org_filter    = sanitize_identifier(params['org_id']).to_s
         end
 
         def raise_concerns
@@ -33,6 +58,7 @@ module ColonelAPI
           # Get all custom domains using efficient loading
           all_domain_ids = Onetime::CustomDomain.instances.to_a
           all_domains    = Onetime::CustomDomain.load_multi(all_domain_ids).compact
+          all_domains    = apply_filters(all_domains)
 
           @total_count = all_domains.size
           @total_pages = (@total_count.to_f / @per_page).ceil
@@ -138,8 +164,46 @@ module ColonelAPI
                 total_count: total_count,
                 total_pages: total_pages,
               },
+              # Server echo of the applied filters (additive key; mirrors
+              # ListOrganizations). Never read for state by the frontend.
+              filters: {
+                search: search_term,
+                status: status_filter,
+                org_id: org_filter,
+              },
             },
           }
+        end
+
+        private
+
+        # All three filters are AND-ed. Empty/absent filters are no-ops, so an
+        # unfiltered request returns exactly the previous result set.
+        def apply_filters(all_domains)
+          result = all_domains
+
+          unless status_filter.empty?
+            result = result.select { |d| d.verification_state.to_s == status_filter }
+          end
+
+          unless org_filter.empty?
+            # Accept the org extid (what every admin surface routes by) or the
+            # internal objid, which is what CustomDomain#org_id actually stores.
+            org     = Onetime::Organization.find_by_extid(org_filter)
+            org_ids = [org_filter, org&.objid].compact.map(&:to_s)
+            result  = result.select { |d| org_ids.include?(d.org_id.to_s) }
+          end
+
+          return result if search_term.empty?
+
+          needle = search_term.downcase
+          result.select do |d|
+            next true if d.extid.to_s == search_term
+            next true if d.domainid.to_s == search_term
+
+            d.display_domain.to_s.downcase.include?(needle) ||
+              d.base_domain.to_s.downcase.include?(needle)
+          end
         end
       end
     end

--- a/apps/api/colonel/logic/colonel/list_stripe_organizations.rb
+++ b/apps/api/colonel/logic/colonel/list_stripe_organizations.rb
@@ -1,0 +1,113 @@
+# apps/api/colonel/logic/colonel/list_stripe_organizations.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/operations/billing/stripe_organizations'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # List organizations that carry a Stripe customer id (Colonel).
+      #
+      # Thin adapter over {Onetime::Operations::Billing::StripeOrganizations},
+      # the single implementation (shared with `bin/ots billing orgs stripe`).
+      #
+      # ## Why a sibling endpoint and not a field on /billing/catalog
+      #
+      # {GetBillingCatalog} answers "does the declared catalog match Stripe?" —
+      # an unpaginated, parameterless config-vs-live snapshot whose wire shape is
+      # already frozen by a frontend Zod contract. This answers "which tenants are
+      # actually billed?" — a paginated, searchable, index-backed roster with a
+      # completely different refresh cadence and failure mode (a Stripe outage
+      # degrades the catalog view; it does not touch this one). Folding a
+      # paginated list into the catalog response would have forced every catalog
+      # read to pay for an org scan and would have broken the pinned enum on
+      # `details.source`. Two endpoints, two schemas, two caches.
+      #
+      # ## Request
+      #
+      # GET /api/colonel/billing/stripe-organizations
+      #   ?page=1&per_page=50&search=cus_ABC
+      #
+      # `search` filters on the Stripe customer id ONLY (it is the index field,
+      # so the filter runs server-side inside HSCAN MATCH). A bare term is
+      # treated as a substring; a term containing `*` / `?` is used verbatim as a
+      # glob. There is deliberately no name/email search — that would require
+      # hydrating the whole population, which is the scan this endpoint replaces.
+      #
+      # ## Response
+      #
+      # {
+      #   record: {},
+      #   details: {
+      #     organizations: [ {
+      #       org_id:, extid:, display_name:, owner_email:, billing_email:,
+      #       planid:, stripe_customer_id:, stripe_subscription_id:,
+      #       subscription_status:, subscription_period_end:, sync_status:,
+      #       created:, updated:
+      #     } ],
+      #     pagination: { page:, per_page:, total_count:, total_pages: },
+      #     filters: { search: },
+      #     capped: false,          # true => total_count understates the population
+      #     stale_count: 0,         # index entries on THIS page whose org is gone
+      #     indexed_total: 1234     # HLEN of the index, ignoring `search`
+      #   }
+      # }
+      #
+      # READ-ONLY: emits NO AdminAuditEvent (CONTRACT 4).
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class ListStripeOrganizations < ColonelAPI::Logic::Base
+        SCHEMAS = { response: 'colonelStripeOrganizations' }.freeze
+
+        attr_reader :page, :per_page, :search_term, :result
+
+        def process_params
+          @page        = (params['page'] || 1).to_i
+          @per_page    = (params['per_page'] || 50).to_i
+          # Stripe customer ids are `cus_…` plus the operator's optional glob;
+          # sanitize_identifier would strip `*`/`?`, so use the plain-text
+          # sanitizer and let the op decide how to build the MATCH pattern.
+          @search_term = sanitize_plain_text(params['search'], max_length: 128).to_s.strip
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+        end
+
+        def process
+          @result = Onetime::Operations::Billing::StripeOrganizations.new(
+            page: page,
+            per_page: per_page,
+            search: search_term,
+          ).call
+
+          success_data
+        end
+
+        def success_data
+          {
+            record: {},
+            details: {
+              organizations: result.organizations,
+              pagination: {
+                page: result.page,
+                per_page: result.per_page,
+                total_count: result.total_count,
+                total_pages: result.total_pages,
+              },
+              filters: {
+                search: result.search,
+              },
+              capped: result.capped,
+              stale_count: result.stale_count,
+              indexed_total: result.indexed_total,
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/membership_resolvers.rb
+++ b/apps/api/colonel/logic/colonel/membership_resolvers.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require_relative 'account_identifier'
+
 module ColonelAPI
   module Logic
     module Colonel
@@ -14,6 +16,8 @@ module ColonelAPI
       # lookup order is membership-specific — other colonel logic resolves orgs
       # with a different precedence (see transfer_domain.rb).
       module MembershipResolvers
+        include AccountIdentifier
+
         private
 
         # extid first, then objid — user-facing colonel input is an extid.
@@ -25,8 +29,14 @@ module ColonelAPI
         # normalize_email is a safe pass-through for an extid (extids are
         # already lowercase ASCII); it only matters when the identifier is an
         # email. load_by_extid_or_email tries extid before email.
+        #
+        # NOTE: the caller MUST sanitize the raw param with
+        # {AccountIdentifier#sanitize_account_identifier}, not
+        # `sanitize_identifier` — the latter strips '@' and '.', turning
+        # `user@example.com` into `userexamplecom` and making this email arm
+        # permanently unreachable.
         def resolve_customer(identifier)
-          Onetime::Customer.load_by_extid_or_email(OT::Utils.normalize_email(identifier))
+          resolve_account(identifier)
         end
       end
     end

--- a/apps/api/colonel/logic/colonel/purge_user.rb
+++ b/apps/api/colonel/logic/colonel/purge_user.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative '../base'
+require_relative 'account_identifier'
 require 'auth/operations/customers/purge'
 
 module ColonelAPI
@@ -17,10 +18,15 @@ module ColonelAPI
       # Security invariant (epic #20): BOTH the router (role=colonel) AND this
       # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
       class PurgeUser < ColonelAPI::Logic::Base
+        include AccountIdentifier
+
         attr_reader :user_id, :user, :purged_extid, :purged_objid
 
         def process_params
-          @user_id = sanitize_identifier(params['user_id'])
+          # sanitize_account_identifier (NOT sanitize_identifier) — the latter
+          # strips '@' and '.', which silently destroyed the documented email
+          # arm below. See AccountIdentifier.
+          @user_id = sanitize_account_identifier(params['user_id'])
           raise_form_error('User ID is required', field: :user_id) if user_id.to_s.empty?
         end
 
@@ -31,8 +37,7 @@ module ColonelAPI
           # extid, so every admin surface routes by it — then email, then objid.
           # Mirrors Auth::Operations::Customers::Show#resolve (show.rb): a plain
           # Customer.load only resolves the internal objid, so an extid would 404.
-          @user = Onetime::Customer.load_by_extid_or_email(user_id) ||
-                  Onetime::Customer.load(user_id)
+          @user = resolve_account(user_id)
           raise_not_found('User not found') unless user&.exists?
 
           raise_form_error('Cannot purge anonymous user', field: :user_id) if user.anonymous?

--- a/apps/api/colonel/logic/colonel/remove_membership.rb
+++ b/apps/api/colonel/logic/colonel/remove_membership.rb
@@ -30,7 +30,9 @@ module ColonelAPI
 
         def process_params
           @org_id    = sanitize_identifier(params['org_id'])
-          @member_id = sanitize_identifier(params['member_id'])
+          # Email-tolerant (see AccountIdentifier) — sanitize_identifier strips
+          # '@' and '.', which made the resolver's email arm unreachable.
+          @member_id = sanitize_account_identifier(params['member_id'])
         end
 
         def raise_concerns

--- a/apps/api/colonel/logic/colonel/set_membership_role.rb
+++ b/apps/api/colonel/logic/colonel/set_membership_role.rb
@@ -28,7 +28,9 @@ module ColonelAPI
 
         def process_params
           @org_id    = sanitize_identifier(params['org_id'])
-          @member_id = sanitize_identifier(params['member_id'])
+          # Email-tolerant (see AccountIdentifier) — sanitize_identifier strips
+          # '@' and '.', which made the resolver's email arm unreachable.
+          @member_id = sanitize_account_identifier(params['member_id'])
           @new_role  = sanitize_plain_text(params['role']).to_s.downcase
         end
 

--- a/apps/api/colonel/logic/colonel/set_user_verification.rb
+++ b/apps/api/colonel/logic/colonel/set_user_verification.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative '../base'
+require_relative 'account_identifier'
 require 'auth/operations/customers/set_verification'
 
 module ColonelAPI
@@ -18,6 +19,8 @@ module ColonelAPI
       # Security invariant (epic #20): BOTH the router (role=colonel) AND this
       # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
       class SetUserVerificationBase < ColonelAPI::Logic::Base
+        include AccountIdentifier
+
         attr_reader :user_id, :user, :change_result
 
         # @return [Boolean] target verification state (subclass overrides)
@@ -31,7 +34,10 @@ module ColonelAPI
         end
 
         def process_params
-          @user_id = sanitize_identifier(params['user_id'])
+          # sanitize_account_identifier (NOT sanitize_identifier) — the latter
+          # strips '@' and '.', which silently destroyed the documented email
+          # arm below. See AccountIdentifier.
+          @user_id = sanitize_account_identifier(params['user_id'])
           raise_form_error('User ID is required', field: :user_id) if user_id.to_s.empty?
         end
 
@@ -42,8 +48,7 @@ module ColonelAPI
           # extid, so every admin surface routes by it — then email, then objid.
           # Mirrors Auth::Operations::Customers::Show#resolve (show.rb): a plain
           # Customer.load only resolves the internal objid, so an extid would 404.
-          @user = Onetime::Customer.load_by_extid_or_email(user_id) ||
-                  Onetime::Customer.load(user_id)
+          @user = resolve_account(user_id)
           raise_not_found('User not found') unless user&.exists?
 
           raise_form_error('Cannot modify anonymous user', field: :user_id) if user.anonymous?

--- a/apps/api/colonel/routes.txt
+++ b/apps/api/colonel/routes.txt
@@ -118,6 +118,9 @@ GET    /email/deliverability/messages                  ColonelAPI::Logic::Colone
 
 # Billing Catalog (ticket #45, read-only plan drift)
 GET    /billing/catalog                   ColonelAPI::Logic::Colonel::GetBillingCatalog response=json auth=sessionauth role=colonel scope=internal
+# Stripe-linked organization roster. Index-backed (organization:stripe_customer_id_index),
+# paginated + bounded — never a full Organization.instances scan. Read-only.
+GET    /billing/stripe-organizations      ColonelAPI::Logic::Colonel::ListStripeOrganizations response=json auth=sessionauth role=colonel scope=internal
 
 # Observability: audit trail reader + daily activity trends (both read-only)
 GET    /audit                             ColonelAPI::Logic::Colonel::ListAuditEvents response=json auth=sessionauth role=colonel scope=internal

--- a/changelog.d/20260724_124300_claude_admin_ops_expansion.rst
+++ b/changelog.d/20260724_124300_claude_admin_ops_expansion.rst
@@ -1,0 +1,40 @@
+.. A new scriv changelog fragment.
+
+Added
+-----
+
+- Admin console can now list every organization that carries a Stripe customer
+  id, via the new ``GET /api/colonel/billing/stripe-organizations`` endpoint and
+  its CLI peer ``bin/ots billing orgs stripe``. The listing reads the existing
+  ``organization:stripe_customer_id_index`` (HLEN for the count, HSCAN for the
+  entries) and hydrates only the requested page, so it never scans every
+  organization. Searching filters on the Stripe customer id server-side, and
+  index entries whose organization no longer loads are reported as a per-page
+  ``stale_count`` instead of rendering as broken rows.
+
+- ``bin/ots domains create DOMAIN --org EXTID`` registers a custom domain
+  against an organization from the shell. Create was the only colonel domain
+  verb with no CLI peer; it now shares one implementation (and one audit event)
+  with ``POST /api/colonel/domains``.
+
+- ``bin/ots customers purge-one IDENTIFIER`` permanently deletes a single
+  customer account and records it in the admin audit trail, matching
+  ``DELETE /api/colonel/users/:user_id``. This is distinct from
+  ``bin/ots customers purge``, which remains a bulk inactivity sweep.
+
+- ``bin/ots billing catalog drift`` shows the same config-vs-live plan
+  comparison as the admin console's billing catalog view, and exits non-zero
+  when the two sides disagree so it can gate a deploy step.
+
+- The colonel custom-domain listing accepts optional ``search``, ``status`` and
+  ``org_id`` filters, applied before pagination.
+
+Fixed
+-----
+
+- Colonel admin endpoints that document an "email or extid" identifier now
+  actually accept an email address. The shared identifier sanitizer stripped
+  ``@`` and ``.``, so ``user@example.com`` arrived at the lookup as
+  ``userexamplecom`` and the request failed with "not found". This affected
+  adding a member to an organization, changing or removing a membership, and
+  the verify / unverify / purge / detail user endpoints.

--- a/changelog.d/20260724_133000_claude_admin_customer_detail_fixes.rst
+++ b/changelog.d/20260724_133000_claude_admin_customer_detail_fixes.rst
@@ -1,0 +1,30 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- The colonel customer detail page no longer times out. Its secrets and receipts
+  read-outs walked the entire ``secret:*`` / ``receipt:*`` keyspace, loading every
+  object one at a time to filter by owner; the 10,000-item guard counted MATCHES
+  rather than keys scanned, so it never tripped for a normal account and the walk
+  ran to completion on every page load. Both sections now read a bounded,
+  newest-first page from a per-owner index — receipts from the existing
+  ``customer:<id>:receipts`` set, secrets from a new ``customer:<id>:secrets``
+  index written at the same two chokepoints as the ``secrets_active`` counter, so
+  the two can only drift together. Accounts whose secrets predate the index fall
+  back to a scan that is bounded by scan rounds *and* a wall-clock deadline, and
+  any partial result is reported to the UI as such rather than rendered as if it
+  were the whole record. A slow or failing activity lookup now degrades that
+  section alone — identity, plan, role, organization and billing still render.
+
+- Revealing an email address in an admin table no longer also opens the row's
+  detail drawer. The reveal toggle and its copy button now contain their own
+  clicks, which fixes the same interaction across every console table that
+  renders an obscured address inside a clickable row.
+
+Added
+-----
+
+- Each row of the admin customers table links directly to the customer's full
+  detail page, so an operator can escalate without opening the drawer first. It
+  is a real link, so middle-click and open-in-new-tab work.

--- a/lib/onetime/cli.rb
+++ b/lib/onetime/cli.rb
@@ -79,6 +79,7 @@ require_relative 'cli/customers/shared'
 require_relative 'cli/customers/sync_auth_accounts_command'
 require_relative 'cli/customers/dates_command'
 require_relative 'cli/customers/purge_command'
+require_relative 'cli/customers/purge_one_command'
 require_relative 'cli/customers/show_command'
 require_relative 'cli/customers/list_command'
 require_relative 'cli/customers/create_command'
@@ -97,6 +98,7 @@ require_relative 'cli/memberships/remove_command'
 require_relative 'cli/memberships_command'
 require_relative 'cli/domains/doctor_command'
 require_relative 'cli/domains/migrate_sso_command'
+require_relative 'cli/domains/create_command'
 require_relative 'cli/domains_command'
 require_relative 'cli/org/doctor_command'
 require_relative 'cli/org_command'
@@ -150,6 +152,14 @@ require_relative 'cli/diagnostics/sentry/check_dsn_command'
 
 # Load install CLI commands
 require_relative 'cli/install_command'
+
+# Billing read-only views shared with the colonel API. The `billing` and
+# `billing catalog` / `billing orgs` parents are registered by the billing app
+# (auto-discovered below); Dry::CLI's registry is a tree, so registration order
+# does not matter — but the parents MUST exist or `bin/ots billing --help`
+# walks a nil node.
+require_relative 'cli/billing/catalog_drift_command'
+require_relative 'cli/billing/orgs_stripe_command'
 
 # Load queue CLI commands
 require_relative 'cli/queue/init_command'

--- a/lib/onetime/cli/billing/catalog_drift_command.rb
+++ b/lib/onetime/cli/billing/catalog_drift_command.rb
@@ -1,0 +1,135 @@
+# lib/onetime/cli/billing/catalog_drift_command.rb
+#
+# frozen_string_literal: true
+
+# Show config-vs-live billing catalog drift.
+#
+# This is the CLI peer of `GET /api/colonel/billing/catalog`. Both adapters call
+# the same read op (Onetime::Operations::Billing::CatalogDrift), so the console
+# and the shell can never disagree about what "in sync" means.
+#
+# Distinct from the neighbouring catalog commands:
+#   validate — JSON-schema checks on billing.yaml (structure only)
+#   push / pull / sync — MOVE data between billing.yaml, Stripe and Redis
+#   drift  — READ-ONLY comparison; changes nothing
+#
+# Usage:
+#   bin/ots billing catalog drift
+#   bin/ots billing catalog drift --json
+#   bin/ots billing catalog drift --verbose    # list every plan on both sides
+#
+# Exit status is 0 when the two sides agree, 1 when they drift — so it can gate
+# a deploy step.
+
+require 'json'
+require 'onetime/operations/billing/catalog_drift'
+
+module Onetime
+  module CLI
+    class BillingCatalogDriftCommand < Command
+      desc 'Compare the configured plan catalog against the live Stripe cache'
+
+      option :json,
+        type: :boolean,
+        default: false,
+        desc: 'Output as JSON'
+      option :verbose,
+        type: :boolean,
+        default: false,
+        desc: 'List every plan on both sides, not just the differences'
+
+      def call(json: false, verbose: false, **)
+        boot_application!
+
+        result = Onetime::Operations::Billing::CatalogDrift.new.call
+
+        json ? output_json(result) : output_text(result, verbose: verbose)
+
+        exit 1 unless result.drift[:in_sync]
+      end
+
+      private
+
+      def output_json(result)
+        puts JSON.pretty_generate(
+          source: result.source,
+          stripe_configured: result.stripe_configured,
+          billing_enabled: result.billing_enabled,
+          config_plans: result.config_plans,
+          live_plans: result.live_plans,
+          drift: result.drift,
+        )
+      end
+
+      def output_text(result, verbose:)
+        unless result.billing_enabled
+          puts 'Billing is not enabled in this deployment — nothing to compare.'
+          return
+        end
+
+        puts "Source:     #{result.source}"
+        puts "Config:     #{result.config_plans.size} plans (billing.yaml)"
+        puts "Live:       #{result.live_plans.size} plans (Stripe-synced cache)"
+
+        if result.source == 'local_config'
+          puts
+          puts 'WARNING: the live cache is empty, so drift cannot be evaluated.'
+          puts '         Run `bin/ots billing catalog pull` first.'
+        end
+
+        drift = result.drift
+        puts
+        if drift[:in_sync]
+          puts 'In sync: config and live catalogs match.'
+        else
+          print_drift(drift)
+        end
+
+        return unless verbose
+
+        puts
+        print_plan_table('Config plans', result.config_plans)
+        puts
+        print_plan_table('Live plans', result.live_plans)
+      end
+
+      def print_drift(drift)
+        puts 'DRIFT DETECTED'
+        puts '-' * 60
+
+        if drift[:only_in_config].any?
+          puts "  Only in config (#{drift[:only_in_config].size}):"
+          drift[:only_in_config].each { |planid| puts "    #{planid}" }
+        end
+
+        if drift[:only_in_live].any?
+          puts "  Only in live (#{drift[:only_in_live].size}):"
+          drift[:only_in_live].each { |planid| puts "    #{planid}" }
+        end
+
+        return unless drift[:changed].any?
+
+        puts "  Changed (#{drift[:changed].size}):"
+        drift[:changed].each do |change|
+          puts format('    %-32s %s', change[:planid], change[:fields].join(', '))
+        end
+      end
+
+      def print_plan_table(title, plans)
+        puts "#{title} (#{plans.size})"
+        puts format('  %-32s %-20s %-10s %s', 'PLANID', 'NAME', 'TIER', 'ENTITLEMENTS')
+        plans.each do |plan|
+          puts format(
+            '  %-32s %-20s %-10s %s',
+            plan[:planid].to_s[0, 31],
+            plan[:name].to_s[0, 19],
+            plan[:tier].to_s[0, 9],
+            plan[:entitlements].size,
+          )
+        end
+      end
+    end
+
+    register 'billing catalog drift', BillingCatalogDriftCommand
+  end
+end

--- a/lib/onetime/cli/billing/orgs_stripe_command.rb
+++ b/lib/onetime/cli/billing/orgs_stripe_command.rb
@@ -1,0 +1,129 @@
+# lib/onetime/cli/billing/orgs_stripe_command.rb
+#
+# frozen_string_literal: true
+
+# List organizations that carry a Stripe customer id.
+#
+# This is the CLI peer of `GET /api/colonel/billing/stripe-organizations`. Both
+# adapters call the same read op
+# (Onetime::Operations::Billing::StripeOrganizations), which reads the EXISTING
+# `organization:stripe_customer_id_index` — HLEN for the count, HSCAN for the
+# entries — and hydrates only the requested page. It never enumerates
+# Organization.instances.
+#
+# Distinct from `bin/ots billing orgs validate`, which scans for unresolvable
+# plan ids. This one answers "which tenants are actually billed?".
+#
+# Usage:
+#   bin/ots billing orgs stripe
+#   bin/ots billing orgs stripe --search cus_ABC        # substring on the Stripe id
+#   bin/ots billing orgs stripe --page 2 --per-page 100
+#   bin/ots billing orgs stripe --json
+
+require 'json'
+require 'onetime/operations/billing/stripe_organizations'
+
+module Onetime
+  module CLI
+    class BillingOrgsStripeCommand < Command
+      desc 'List organizations that have a Stripe customer id (index-backed)'
+
+      option :page,
+        type: :integer,
+        default: 1,
+        desc: 'Page number (1-based)'
+      option :per_page,
+        type: :integer,
+        default: 50,
+        desc: 'Rows per page (max 100)'
+      option :search,
+        type: :string,
+        default: nil,
+        desc: 'Filter on the Stripe customer id (substring, or a * / ? glob)'
+      option :json,
+        type: :boolean,
+        default: false,
+        desc: 'Output as JSON'
+
+      def call(page: 1, per_page: 50, search: nil, json: false, **)
+        boot_application!
+
+        result = Onetime::Operations::Billing::StripeOrganizations.new(
+          page: page,
+          per_page: per_page,
+          search: search,
+        ).call
+
+        json ? output_json(result) : output_text(result)
+      end
+
+      private
+
+      def output_json(result)
+        puts JSON.pretty_generate(
+          organizations: result.organizations,
+          pagination: {
+            page: result.page,
+            per_page: result.per_page,
+            total_count: result.total_count,
+            total_pages: result.total_pages,
+          },
+          filters: { search: result.search },
+          capped: result.capped,
+          stale_count: result.stale_count,
+          indexed_total: result.indexed_total,
+        )
+      end
+
+      def output_text(result)
+        puts "Indexed organizations with a Stripe customer: #{result.indexed_total}"
+        puts "Filter: #{result.search}" unless result.search.to_s.empty?
+        if result.capped
+          puts "WARNING: scan stopped at #{Onetime::Operations::Billing::StripeOrganizations::MAX_INDEX_ENTRIES} " \
+               'entries — the counts below understate the population.'
+        end
+        puts
+
+        if result.organizations.empty?
+          puts 'No matching organizations.'
+          return
+        end
+
+        puts format(
+          '%-24s %-28s %-22s %-14s %s',
+          'ORG EXTID',
+          'NAME',
+          'STRIPE CUSTOMER',
+          'PLAN',
+          'STATUS',
+        )
+        puts '-' * 100
+
+        result.organizations.each do |row|
+          puts format(
+            '%-24s %-28s %-22s %-14s %s',
+            row[:extid].to_s[0, 23],
+            row[:display_name].to_s[0, 27],
+            row[:stripe_customer_id].to_s[0, 21],
+            row[:planid].to_s[0, 13],
+            row[:subscription_status].to_s,
+          )
+        end
+
+        puts
+        puts format(
+          'Page %d/%d (%d matching entries, %d rows shown)',
+          result.page,
+          [result.total_pages, 1].max,
+          result.total_count,
+          result.organizations.size,
+        )
+        return unless result.stale_count.positive?
+
+        puts "Stale index entries on this page (org no longer loads): #{result.stale_count}"
+      end
+    end
+
+    register 'billing orgs stripe', BillingOrgsStripeCommand
+  end
+end

--- a/lib/onetime/cli/customers/purge_one_command.rb
+++ b/lib/onetime/cli/customers/purge_one_command.rb
@@ -1,0 +1,116 @@
+# lib/onetime/cli/customers/purge_one_command.rb
+#
+# frozen_string_literal: true
+
+# Purge (permanently delete) ONE customer account.
+#
+# This is the CLI peer of `DELETE /api/colonel/users/:user_id`. Both adapters
+# call the same audited op (Auth::Operations::Customers::Purge), so a
+# CLI-initiated deletion lands in the admin audit trail exactly like an
+# operator-initiated one — the difference is only the actor
+# (Customers::Shared::CLI_ACTOR).
+#
+# NOT the same command as `bin/ots customers purge`: that one is a BULK
+# inactivity sweep (`--older-than 3y`) which deliberately uses the bare
+# DeleteCustomer primitive and writes NO audit events, because a sweep would
+# flood the 10k-capped audit set. Use this command for single, deliberate,
+# accountable deletions.
+#
+# Guards (kept in lockstep with the colonel endpoint):
+#   - refuses an anonymous customer
+#   - requires an explicit confirmation (interactive y/N, or --yes)
+#
+# Usage:
+#   bin/ots customers purge-one user@example.com          # confirm, then purge
+#   bin/ots customers purge-one ur1234567890abcdef --yes
+#   bin/ots customers purge-one 123 --yes --json          # Rodauth account ID
+
+require 'json'
+require 'auth/operations/customers/purge'
+
+module Onetime
+  module CLI
+    class CustomersPurgeOneCommand < Command
+      include Customers::Shared
+
+      desc 'Purge (permanently delete) a single customer account'
+
+      argument :identifier,
+        type: :string,
+        required: true,
+        desc: 'Email, extid, or Rodauth account ID of the customer'
+
+      option :yes,
+        type: :boolean,
+        default: false,
+        aliases: ['-y', '-f'],
+        desc: 'Skip confirmation prompt'
+      option :json,
+        type: :boolean,
+        default: false,
+        desc: 'Output as JSON'
+
+      def call(identifier:, yes: false, json: false, **)
+        boot_application!
+
+        if identifier.to_s.strip.empty?
+          error_exit('Identifier is required', json: json)
+        end
+
+        customer = resolve_customer(identifier)
+        error_exit("Customer not found: #{identifier}", json: json) unless customer
+        error_exit('Cannot purge anonymous customer', json: json) if customer.anonymous?
+
+        obscured = customer.obscure_email
+        extid    = customer.extid
+
+        unless yes
+          # Never auto-confirm in --json mode: a machine-driven caller must be
+          # explicit about an irreversible delete.
+          error_exit('Refusing to purge without --yes in --json mode', json: true) if json
+
+          puts 'This permanently destroys the customer record, its indexes and'
+          puts 'its metadata. It is NOT reversible without a Redis backup.'
+          puts
+          print "Purge #{obscured} (#{extid})? [y/N] "
+          response = $stdin.gets&.strip&.downcase
+          unless response == 'y'
+            puts 'Aborted.'
+            return
+          end
+        end
+
+        result = Auth::Operations::Customers::Purge.new(
+          customer: customer,
+          actor: Customers::Shared::CLI_ACTOR,
+        ).call
+
+        OT.info "[cli-customers-purge-one] extid=#{extid} status=#{result.status}"
+
+        if json
+          puts JSON.pretty_generate(
+            status: result.status,
+            extid: result.extid,
+            email: obscured,
+          )
+        else
+          case result.status
+          when :success   then puts "Purged #{obscured} (#{extid})"
+          when :not_found then puts "Nothing to delete for #{obscured} (#{extid})"
+          end
+        end
+
+        exit 1 if result.status == :not_found
+      end
+
+      private
+
+      def error_exit(message, json:)
+        puts(json ? JSON.generate({ error: message }) : "Error: #{message}")
+        exit 1
+      end
+    end
+
+    register 'customers purge-one', CustomersPurgeOneCommand
+  end
+end

--- a/lib/onetime/cli/customers/unverify_command.rb
+++ b/lib/onetime/cli/customers/unverify_command.rb
@@ -18,6 +18,11 @@
 # don't go through that path. Load the op explicitly so the call site
 # resolves at runtime. The admin wrapper reuses SetCustomerVerification
 # and adds the AdminAuditEvent for this operator-initiated change.
+#
+# Auth::Database is required alongside it because SetCustomerVerification
+# reaches for `Auth::Database.connection` at call time without requiring it
+# (set_customer_verification.rb:95) — see the note in verify_command.rb.
+require 'auth/database'
 require 'auth/operations/customers/set_verification'
 
 module Onetime

--- a/lib/onetime/cli/customers/verify_command.rb
+++ b/lib/onetime/cli/customers/verify_command.rb
@@ -19,6 +19,14 @@
 # don't go through that path. Load the op explicitly so the call site
 # resolves at runtime. The admin wrapper reuses SetCustomerVerification
 # and adds the AdminAuditEvent for this operator-initiated change.
+#
+# Auth::Database has to be required alongside it: SetCustomerVerification
+# reaches for `Auth::Database.connection` at call time WITHOUT requiring it
+# (set_customer_verification.rb:95). Under the autoloader that resolves; from
+# the CLI it raised `uninitialized constant Auth::Database` and this command
+# could never verify anyone. The unverify path only hit it when there was an
+# actual state change, which is why it looked like it worked.
+require 'auth/database'
 require 'auth/operations/customers/set_verification'
 
 module Onetime

--- a/lib/onetime/cli/customers_command.rb
+++ b/lib/onetime/cli/customers_command.rb
@@ -40,8 +40,9 @@ module Onetime
         puts '  bin/ots customers dates                    # Count by creation year'
         puts '  bin/ots customers dates --by-age           # Count by age bucket'
         puts '  bin/ots customers dates --refresh          # Force cache rebuild'
-        puts '  bin/ots customers purge --older-than 3y    # Dry-run purge preview'
-        puts '  bin/ots customers purge --older-than 3y --purge  # Execute purge'
+        puts '  bin/ots customers purge --older-than 3y    # Dry-run BULK purge preview'
+        puts '  bin/ots customers purge --older-than 3y --purge  # Execute bulk purge'
+        puts '  bin/ots customers purge-one ID             # Purge ONE account (audited)'
         puts '  bin/ots customers sync-auth-accounts       # Sync to auth DB'
         puts
         puts 'Remote source (pre-migration):'

--- a/lib/onetime/cli/domains/create_command.rb
+++ b/lib/onetime/cli/domains/create_command.rb
@@ -1,0 +1,141 @@
+# lib/onetime/cli/domains/create_command.rb
+#
+# frozen_string_literal: true
+
+# Register a custom domain against an organization.
+#
+# This is the CLI peer of `POST /api/colonel/domains`. Both adapters call the
+# same op (Onetime::Operations::Domains::Create), which owns validation,
+# creation, certificate provisioning and the single `domain.create`
+# AdminAuditEvent. Every other colonel domain verb (verify / probe / repair /
+# transfer / remove) already had a CLI peer; create was the gap.
+#
+# Usage:
+#   bin/ots domains create example.com --org on123abc            # confirm, then create
+#   bin/ots domains create example.com --org on123abc --yes
+#   bin/ots domains create example.com --org on123abc --yes --json
+#   bin/ots domains create example.com --org on123abc --yes --no-cert
+#
+# ORG accepts the organization extid (preferred — what every admin surface
+# routes by) or the internal objid.
+#
+# Lives under lib/onetime/cli (not apps/api/domains/cli) so the require of the
+# op is unambiguous at load time; registration is identical either way.
+
+require 'json'
+require 'onetime/operations/domains/create'
+
+module Onetime
+  module CLI
+    class DomainsCreateCommand < Command
+      # Audit actor for CLI-initiated mutations. Matches the other domain
+      # commands' sentinel — never an operator objid (the shell has no identity).
+      CLI_ACTOR = 'cli'
+
+      desc 'Register a custom domain against an organization'
+
+      argument :domain,
+        type: :string,
+        required: true,
+        desc: 'Domain name to register (e.g. secrets.example.com)'
+
+      option :org,
+        type: :string,
+        default: nil,
+        desc: 'Organization extid (or objid) that will own the domain'
+      option :yes,
+        type: :boolean,
+        default: false,
+        aliases: ['-y', '-f'],
+        desc: 'Skip confirmation prompt'
+      option :cert,
+        type: :boolean,
+        default: true,
+        desc: 'Request an SSL certificate after creating (--no-cert to skip)'
+      option :json,
+        type: :boolean,
+        default: false,
+        desc: 'Output as JSON'
+
+      def call(domain:, org: nil, yes: false, cert: true, json: false, **)
+        boot_application!
+
+        error_exit('--org is required', json: json) if org.to_s.strip.empty?
+
+        organization = resolve_org(org)
+        error_exit("Organization not found: #{org}", json: json) unless organization
+
+        operation = Onetime::Operations::Domains::Create.new(
+          domain: domain,
+          org: organization,
+          actor: CLI_ACTOR,
+          request_certificate: cert,
+        )
+
+        # Validate BEFORE prompting so an obviously bad input fails fast, and so
+        # the operator sees the normalised FQDN they are about to register.
+        check = operation.validate
+        error_exit(check.message, json: json) unless check.status == :ok
+
+        unless yes
+          error_exit('Refusing to create without --yes in --json mode', json: true) if json
+
+          puts "Domain:       #{check.display_domain}"
+          puts "Organization: #{organization.display_name || organization.extid} (#{organization.extid})"
+          puts '  (claims an existing ORPHANED record)' if check.claims_orphan
+          puts "Certificate:  #{cert ? 'request after create' : 'skipped (--no-cert)'}"
+          puts
+          print 'Create this domain? [y/N] '
+          response = $stdin.gets&.strip&.downcase
+          unless response == 'y'
+            puts 'Aborted.'
+            return
+          end
+        end
+
+        result = operation.call
+        error_exit(result.message, json: json) unless result.status == :created
+
+        OT.info "[cli-domains-create] domain=#{result.display_domain} org=#{organization.extid} extid=#{result.extid}"
+
+        if json
+          puts JSON.pretty_generate(
+            status: result.status,
+            domain_id: result.domain_id,
+            extid: result.extid,
+            display_domain: result.display_domain,
+            org_id: organization.extid,
+            claimed_orphan: result.claims_orphan,
+            cert_status: result.cert_status,
+          )
+        else
+          puts "Created #{result.display_domain} (#{result.extid}) for #{organization.extid}"
+          puts '  Claimed a previously orphaned record' if result.claims_orphan
+          puts "  Certificate request: #{result.cert_status}" if result.cert_status
+          puts
+          puts "Next: bin/ots domains verify #{result.display_domain}"
+        end
+      end
+
+      private
+
+      # extid first (the documented input), objid as a fallback — the same
+      # precedence CreateCustomDomain uses on the HTTP side.
+      def resolve_org(identifier)
+        value = identifier.to_s.strip
+        Onetime::Organization.find_by_extid(value) || Onetime::Organization.load(value)
+      end
+
+      def error_exit(message, json:)
+        puts(json ? JSON.generate({ error: message }) : "Error: #{message}")
+        exit 1
+      end
+    end
+
+    # Registered twice (not via `aliases:`) — nested Dry::CLI names are
+    # registry paths, so an alias has to be its own registration. Mirrors
+    # `domains info` / `domains show`.
+    register 'domains create', DomainsCreateCommand
+    register 'domains add', DomainsCreateCommand
+  end
+end

--- a/lib/onetime/cli/domains_command.rb
+++ b/lib/onetime/cli/domains_command.rb
@@ -26,6 +26,13 @@ module Onetime
         puts format('%d custom domains (%d in display_domain_index index)', domain_count, index_count)
         puts
         puts 'Usage:'
+        puts '  bin/ots domains list                       # List domains (filters available)'
+        puts '  bin/ots domains info DOMAIN                # Show domain details'
+        puts '  bin/ots domains create DOMAIN --org EXTID  # Register a domain for an org'
+        puts '  bin/ots domains verify DOMAIN              # Run DNS/TLS verification'
+        puts '  bin/ots domains transfer DOMAIN --to-org X # Move a domain between orgs'
+        puts '  bin/ots domains remove DOMAIN              # Permanently delete a domain'
+        puts '  bin/ots domains orphaned                   # Domains with no organization'
         puts '  bin/ots domains doctor --all               # Check all domains'
         puts '  bin/ots domains migrate-sso FQDN           # Bulk-migrate SSO users (dry run)'
         puts '  bin/ots domains migrate-sso FQDN --run     # Bulk-migrate SSO users (execute)'

--- a/lib/onetime/models/customer.rb
+++ b/lib/onetime/models/customer.rb
@@ -96,6 +96,27 @@ module Onetime
     feature :customer_migration_fields
 
     sorted_set :receipts
+
+    # Per-customer LIVE-secret index. member = secret objid, score = created
+    # epoch. The read-side companion to the `secrets_active` counter: the
+    # counter answers "how many", this answers "which ones", so the colonel
+    # customer-detail view can list a customer's secrets without a
+    # full-keyspace `secret:*:object` SCAN (the O(all secrets) walk that made
+    # the page time out).
+    #
+    # Written at the SAME two chokepoints as the counter, so index and counter
+    # can only drift together — Customer.increment_secrets_active
+    # (Receipt.spawn_pair) adds, Customer.decrement_secrets_active
+    # (Secret#destroy!) removes. See customer/features/counter_fields.rb.
+    #
+    # Bounded by construction: the increment side trims to the newest
+    # SECRET_INDEX_LIMIT members, so a heavy owner's index can never grow
+    # without limit. TTL expiry still leaves dead members behind (no
+    # application code runs), exactly like the counter's up-drift; readers
+    # must treat a member as a candidate and drop the ones that no longer
+    # load.
+    sorted_set :secrets
+
     # Per-customer session index for the colonel's per-customer session view.
     # member = plain sid (== live blob key name `session:<sid>`), score =
     # last_activity epoch. Makes "this customer's sessions" O(sessions-for-user)

--- a/lib/onetime/models/customer/features/counter_fields.rb
+++ b/lib/onetime/models/customer/features/counter_fields.rb
@@ -55,6 +55,14 @@ module Onetime::Customer::Features
       base.class_counter :emails_sent
     end
 
+    # Newest-first cap on the per-owner `secrets` index (Customer#secrets).
+    # The index exists to answer "which secrets does this customer own" for the
+    # colonel detail view, which renders one bounded page — it is not an
+    # archive. Trimming on write means the key size is bounded by construction
+    # rather than by hoping expiry keeps up, and readers stay honest by
+    # reporting truncation instead of a silently short list.
+    SECRET_INDEX_LIMIT = 1_000
+
     module ClassMethods
       # Increment a customer's per-customer live-secret counter (secrets_active)
       # by object id, without loading the full Customer record.
@@ -69,13 +77,32 @@ module Onetime::Customer::Features
       # counter issues a single INCR on `customer:<objid>:secrets_active` — the
       # same key the reconciliation resets and the colonel list reads. See #60.
       #
+      # When `secret_id` is supplied the owner's `secrets` sorted-set index is
+      # maintained in the SAME call, so the "how many" counter and the "which
+      # ones" index are written at one chokepoint and can only drift together.
+      # The index backs the colonel customer-detail view, which previously had
+      # to walk the entire `secret:*:object` keyspace to answer the same
+      # question. Callers that pass no secret_id (tests, the nightly
+      # reconciliation's callers) keep the pre-index behaviour exactly.
+      #
       # @param owner_id [String, nil] the secret owner's Customer objid
+      # @param secret_id [String, nil] the created secret's objid; when present,
+      #   added to the owner's `secrets` index
+      # @param score [Numeric, nil] index score (defaults to now); pass the
+      #   secret's `created` so the index orders by creation time
       # @return [void]
-      def increment_secrets_active(owner_id)
+      def increment_secrets_active(owner_id, secret_id: nil, score: nil)
         oid = owner_id.to_s
         return if oid.empty? || oid == 'anon'
 
-        new(objid: oid).secrets_active.increment
+        cust = new(objid: oid)
+        # A bare Customer.new(objid:) is "dirty" (the initializer runs the objid
+        # setter), and SortedSet writes warn/raise on a dirty parent. Nothing
+        # here is a deferred scalar write, so clear the flag rather than trip a
+        # false unsaved-parent diagnostic.
+        cust.clear_dirty!
+        cust.secrets_active.increment
+        index_secret(cust, secret_id, score)
       rescue StandardError => ex
         # A counter bump must never break secret creation. Log and move on; the
         # nightly reconciliation will correct any missed increment.
@@ -101,17 +128,47 @@ module Onetime::Customer::Features
       # loses live-secret information; reconciliation still SETs the truth daily.
       #
       # @param owner_id [String, nil] the secret owner's Customer objid
+      # @param secret_id [String, nil] the destroyed secret's objid; when
+      #   present, removed from the owner's `secrets` index so index and
+      #   counter move together
       # @return [void]
-      def decrement_secrets_active(owner_id)
+      def decrement_secrets_active(owner_id, secret_id: nil)
         oid = owner_id.to_s
         return if oid.empty? || oid == 'anon'
 
-        counter = new(objid: oid).secrets_active
+        cust    = new(objid: oid)
+        cust.clear_dirty! # see increment_secrets_active
+        counter = cust.secrets_active
         counter.increment if counter.decrement.negative?
+        unindex_secret(cust, secret_id)
       rescue StandardError => ex
         # A counter bump must never break secret destruction. Log and move on;
         # the nightly reconciliation will correct any missed decrement.
         OT.le "[decrement_secrets_active] #{ex.class}: #{ex.message} (owner_id=#{oid})"
+      end
+
+      private
+
+      # Add a secret to its owner's newest-first index and trim to
+      # SECRET_INDEX_LIMIT. ZADD + ZREMRANGEBYRANK are both O(log n); the trim
+      # is what keeps the key bounded without a sweeper job.
+      def index_secret(cust, secret_id, score)
+        sid = secret_id.to_s
+        return if sid.empty?
+
+        cust.secrets.add(sid, (score || Familia.now).to_f)
+        # Drop everything outside the newest SECRET_INDEX_LIMIT (lowest scores
+        # rank first, so the excess sits at the head).
+        limit = Onetime::Customer::Features::CounterFields::SECRET_INDEX_LIMIT
+        cust.secrets.remrangebyrank(0, -(limit + 1))
+      end
+
+      # Mirror of {index_secret} — drop the member on early destruction.
+      def unindex_secret(cust, secret_id)
+        sid = secret_id.to_s
+        return if sid.empty?
+
+        cust.secrets.remove_element(sid)
       end
     end
 

--- a/lib/onetime/models/receipt.rb
+++ b/lib/onetime/models/receipt.rb
@@ -317,7 +317,15 @@ module Onetime
         # is missed. Anonymous/ownerless creates are skipped inside the helper.
         # This counter drifts UP (no expire/reveal decrement) and is corrected by
         # the nightly SecretCountReconcileJob — see counter_fields.rb.
-        Onetime::Customer.increment_secrets_active(owner_id)
+        #
+        # The same call maintains the owner's per-secret index
+        # (customer:<objid>:secrets, member = secret objid, score = created), so
+        # the colonel customer-detail view can list a customer's secrets without
+        # walking the whole `secret:*:object` keyspace. Index and counter are
+        # written together here so they can only drift together.
+        Onetime::Customer.increment_secrets_active(
+          owner_id, secret_id: secret.objid, score: secret.created
+        )
 
         # Count the creation in today's daily-trend bucket (admin dashboard).
         # Same chokepoint rationale as the counter above; fire-and-forget —

--- a/lib/onetime/models/secret.rb
+++ b/lib/onetime/models/secret.rb
@@ -58,8 +58,12 @@ module Onetime
     # SecretCountReconcileJob remains the correctness mechanism for that path.
     # The helper is fail-open and clamps at zero; see counter_fields.rb (#60).
     def destroy!
+      # Capture the identity BEFORE super — destroy! clears the record, and the
+      # owner index needs the member name to remove.
+      oid    = objid
+      owner  = owner_id
       result = super
-      Onetime::Customer.decrement_secrets_active(owner_id)
+      Onetime::Customer.decrement_secrets_active(owner, secret_id: oid)
       result
     end
 

--- a/lib/onetime/operations/billing/catalog_drift.rb
+++ b/lib/onetime/operations/billing/catalog_drift.rb
@@ -1,0 +1,187 @@
+# lib/onetime/operations/billing/catalog_drift.rb
+#
+# frozen_string_literal: true
+
+module Onetime
+  module Operations
+    module Billing
+      # Config-vs-live billing catalog drift — the SINGLE implementation.
+      #
+      # Adapters:
+      #   - `GET /api/colonel/billing/catalog` (ColonelAPI::Logic::Colonel::GetBillingCatalog)
+      #   - `bin/ots billing catalog drift`
+      #
+      # Where `Billing::Plan.list_plans` returns ONE source (the Stripe-synced
+      # Redis cache) and `list_plans_from_config` returns the other (billing.yaml),
+      # this op returns BOTH plus a computed difference, so an operator can see at
+      # a glance which plans exist on only one side and which diverge in
+      # entitlements or limits.
+      #
+      # READ-ONLY: it never writes and therefore emits NO AdminAuditEvent
+      # (CONTRACT 4 — audit is for mutations only).
+      #
+      # ## Why an op for a read
+      #
+      # The drift computation was previously private to the colonel logic class,
+      # so `bin/ots billing catalog …` (validate / push / pull / sync) had no way
+      # to show the same view without a second implementation. Sharing it here
+      # keeps one normalisation — a config "0" and a cached "0" must compare
+      # equal, or every plan reports as drifted.
+      #
+      # ## Billing-disabled deployments
+      #
+      # `Billing::Plan` is only defined when billing is enabled. When it is
+      # absent both sides come back empty and `billing_enabled` is false, so the
+      # CLI can print "billing not configured" instead of a spurious full drift.
+      # `source` deliberately keeps its original two-value domain
+      # ('stripe' | 'local_config') — the frontend Zod contract pins it to that
+      # enum, so a third value would break the admin catalog view.
+      class CatalogDrift
+        # @!attribute source [r] String —
+        #   'stripe' (live cache populated; drift is meaningful) or
+        #   'local_config' (cache empty — every configured plan reads as
+        #   only_in_config; drift cannot be evaluated).
+        # @!attribute billing_enabled [r] Boolean — false when this deployment
+        #   has no billing app loaded (CLI-only signal; not part of the HTTP
+        #   response).
+        Result = Data.define(
+          :source,
+          :stripe_configured,
+          :billing_enabled,
+          :config_plans,
+          :live_plans,
+          :drift,
+        )
+
+        # @return [Result]
+        def call
+          config_plans = load_plans_from_config
+          live_plans   = load_plans_from_stripe_cache
+
+          Result.new(
+            source: live_plans.any? ? 'stripe' : 'local_config',
+            stripe_configured: live_plans.any?,
+            billing_enabled: billing_available?,
+            config_plans: config_plans,
+            live_plans: live_plans,
+            drift: compute_drift(config_plans, live_plans),
+          )
+        end
+
+        # @return [Boolean] false when this deployment has no billing app loaded.
+        def billing_available?
+          defined?(::Billing::Plan) ? true : false
+        end
+
+        private
+
+        # Configured catalog (billing.yaml). REUSES the incumbent source.
+        #
+        # @return [Array<Hash>] Normalized PlanEntry hashes
+        def load_plans_from_config
+          return [] unless billing_available?
+
+          ::Billing::Plan.list_plans_from_config.map { |plan| normalize_config_plan(plan) }
+        rescue StandardError => ex
+          OT.le '[Billing::CatalogDrift] Error loading plans from config',
+            { exception: ex, message: ex.message }
+          []
+        end
+
+        # Live plans (Stripe-synced Redis cache). Mirrors GetAvailablePlans'
+        # normalization so both sides share the exact same PlanEntry shape and
+        # drift compares like-for-like. Uses the bounded instances lookup, not a
+        # blocking KEYS scan (CONTRACT 6).
+        #
+        # @return [Array<Hash>] Normalized PlanEntry hashes
+        def load_plans_from_stripe_cache
+          return [] unless billing_available?
+
+          ::Billing::Plan.list_plans.map do |plan|
+            {
+              planid: plan.plan_id,
+              name: plan.name,
+              tier: plan.tier,
+              tenancy: plan.tenancy,
+              region: plan.region,
+              display_order: plan.display_order.to_i,
+              show_on_plans_page: plan.show_on_plans_page.to_s == 'true',
+              description: plan.respond_to?(:description) ? plan.description : nil,
+              entitlements: plan.entitlements.to_a.sort,
+              limits: normalize_limits(plan.limits.hgetall || {}),
+            }
+          end
+        rescue StandardError => ex
+          OT.le '[Billing::CatalogDrift] Error loading plans from Stripe cache',
+            { exception: ex, message: ex.message }
+          []
+        end
+
+        # Select the shared PlanEntry fields from a config plan hash and
+        # normalize entitlements/limits so both sides are comparable.
+        def normalize_config_plan(plan)
+          {
+            planid: plan[:planid],
+            name: plan[:name],
+            tier: plan[:tier],
+            tenancy: plan[:tenancy],
+            region: plan[:region],
+            display_order: plan[:display_order].to_i,
+            show_on_plans_page: plan[:show_on_plans_page] == true,
+            description: plan[:description],
+            entitlements: Array(plan[:entitlements]).map(&:to_s).sort,
+            limits: normalize_limits(plan[:limits] || {}),
+          }
+        end
+
+        # Stringify limit values so a config "0" and a cached "0" compare equal.
+        def normalize_limits(limits)
+          limits.each_with_object({}) do |(key, value), acc|
+            acc[key.to_s] = value.to_s
+          end
+        end
+
+        # Compute the config-vs-live difference, keyed by planid.
+        #
+        # @return [Hash] drift summary
+        def compute_drift(config_plans, live_plans)
+          config_by_id = config_plans.each_with_object({}) { |p, h| h[p[:planid]] = p }
+          live_by_id   = live_plans.each_with_object({}) { |p, h| h[p[:planid]] = p }
+
+          only_in_config = (config_by_id.keys - live_by_id.keys).sort
+          only_in_live   = (live_by_id.keys - config_by_id.keys).sort
+
+          changed = (config_by_id.keys & live_by_id.keys).sort.filter_map do |planid|
+            fields = drifted_fields(config_by_id[planid], live_by_id[planid])
+            next if fields.empty?
+
+            {
+              planid: planid,
+              name: config_by_id[planid][:name] || live_by_id[planid][:name],
+              fields: fields,
+            }
+          end
+
+          {
+            in_sync: only_in_config.empty? && only_in_live.empty? && changed.empty?,
+            only_in_config: only_in_config,
+            only_in_live: only_in_live,
+            changed: changed,
+          }
+        end
+
+        # Which comparable fields diverge between the two sides of a plan.
+        # Entitlements + limits are the operationally meaningful drift; tier and
+        # display metadata are reported too so a rename doesn't hide silently.
+        def drifted_fields(config_plan, live_plan)
+          fields = []
+          fields << 'entitlements' if config_plan[:entitlements] != live_plan[:entitlements]
+          fields << 'limits'       if config_plan[:limits] != live_plan[:limits]
+          fields << 'tier'         if config_plan[:tier] != live_plan[:tier]
+          fields << 'name'         if config_plan[:name] != live_plan[:name]
+          fields
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/billing/stripe_organizations.rb
+++ b/lib/onetime/operations/billing/stripe_organizations.rb
@@ -1,0 +1,235 @@
+# lib/onetime/operations/billing/stripe_organizations.rb
+#
+# frozen_string_literal: true
+
+module Onetime
+  module Operations
+    module Billing
+      # Bounded, index-backed listing of every organization that carries a
+      # Stripe customer id — the SINGLE implementation.
+      #
+      # Adapters:
+      #   - `GET /api/colonel/billing/stripe-organizations`
+      #     (ColonelAPI::Logic::Colonel::ListStripeOrganizations)
+      #   - `bin/ots billing orgs stripe`
+      #
+      # ## Why the index, not a scan (CONTRACT 6)
+      #
+      # `Onetime::Organization` already declares
+      # `unique_index :stripe_customer_id, :stripe_customer_id_index`, which
+      # Familia materialises as the class-level HashKey
+      # `Organization.stripe_customer_id_index` (Redis key
+      # `organization:stripe_customer_id_index`, field = `cus_…`, value = the org
+      # objid). This op reads THAT — HLEN for the population count, HSCAN for the
+      # entries — and hydrates ONLY the requested page through
+      # `Organization.load_multi`. It never enumerates `Organization.instances`
+      # (the slow path `ListOrganizations` still uses) and it never adds a second
+      # index.
+      #
+      # Stripe customer ids live on Organization, NOT on Customer:
+      # `Customer#stripe_customer_id` is a deprecated v1 field with no index. A
+      # "customers with billing" view must therefore be derived from org
+      # membership, not queried directly — hence organizations here.
+      #
+      # ## Ordering and bounding
+      #
+      # HSCAN has no defined order, so the entries are sorted by
+      # `stripe_customer_id` (ascending) to give pagination a STABLE key.
+      # Created-desc ordering would require hydrating the whole population on
+      # every request, which is exactly what this op exists to avoid.
+      #
+      # The scan stops at {MAX_INDEX_ENTRIES}; when it does, `capped` is true and
+      # `total_count` UNDERSTATES the population. Surface that — do not render
+      # "showing X of Y" as if Y were exact.
+      #
+      # ## Stale entries
+      #
+      # An index entry whose org no longer loads is a real (and interesting)
+      # integrity signal, but it has no extid/display_name to render. Such rows
+      # are dropped from `organizations` and counted in `stale_count` for the
+      # page, so a page can contain fewer rows than `per_page`.
+      #
+      # READ-ONLY: emits NO AdminAuditEvent (CONTRACT 4).
+      class StripeOrganizations
+        # Hard bound on how many index entries a single request will read.
+        MAX_INDEX_ENTRIES = 5_000
+
+        # HSCAN batch size — round-trips vs. per-call blocking.
+        SCAN_BATCH = 500
+
+        DEFAULT_PER_PAGE = 50
+        MAX_PER_PAGE     = 100
+
+        # @!attribute organizations [r] Array<Hash> — one row per hydrated org.
+        # @!attribute total_count [r] Integer — matching index entries (bounded).
+        # @!attribute capped [r] Boolean — true when the scan hit the bound.
+        # @!attribute stale_count [r] Integer — index entries on THIS page whose
+        #   organization no longer loads.
+        # @!attribute indexed_total [r] Integer — HLEN of the whole index,
+        #   independent of any search filter.
+        Result = Data.define(
+          :organizations,
+          :total_count,
+          :page,
+          :per_page,
+          :total_pages,
+          :capped,
+          :stale_count,
+          :indexed_total,
+          :search,
+        )
+
+        # @param page [Integer] 1-based page number.
+        # @param per_page [Integer] page size, clamped to 1..{MAX_PER_PAGE}.
+        # @param search [String, nil] filter on the Stripe customer id. A bare
+        #   term is treated as a substring (wrapped in `*`); a term already
+        #   containing a glob metacharacter (`*` or `?`) is passed through
+        #   verbatim to HSCAN MATCH.
+        def initialize(page: 1, per_page: DEFAULT_PER_PAGE, search: nil)
+          @page     = page.to_i
+          @page     = 1 if @page < 1
+          @per_page = per_page.to_i
+          @per_page = DEFAULT_PER_PAGE if @per_page < 1
+          @per_page = MAX_PER_PAGE if @per_page > MAX_PER_PAGE
+          @search   = search.to_s.strip
+        end
+
+        # @return [Result]
+        def call
+          index         = Onetime::Organization.stripe_customer_id_index
+          indexed_total = safe_field_count(index)
+
+          entries, capped = scan_entries(index)
+          entries.sort_by! { |stripe_id, _objid| stripe_id.to_s }
+
+          total_count = entries.size
+          total_pages = (total_count.to_f / @per_page).ceil
+
+          start_idx  = (@page - 1) * @per_page
+          page_slice = entries[start_idx, @per_page] || []
+
+          orgs_by_objid = hydrate(page_slice.map(&:last))
+
+          stale_count = 0
+          rows        = page_slice.filter_map do |stripe_id, objid|
+            org = orgs_by_objid[objid.to_s]
+            if org.nil?
+              stale_count += 1
+              OT.lw "[Billing::StripeOrganizations] stale index entry #{stripe_id} -> #{objid}"
+              next
+            end
+
+            build_row(org, stripe_id)
+          end
+
+          Result.new(
+            organizations: rows,
+            total_count: total_count,
+            page: @page,
+            per_page: @per_page,
+            total_pages: total_pages,
+            capped: capped,
+            stale_count: stale_count,
+            indexed_total: indexed_total,
+            search: @search,
+          )
+        end
+
+        private
+
+        # @return [Array(Array<Array(String, String)>, Boolean)] entries + capped
+        def scan_entries(index)
+          entries = []
+          capped  = false
+
+          index.each(matching: match_pattern, batch_size: SCAN_BATCH) do |stripe_id, objid|
+            entries << [stripe_id.to_s, objid.to_s]
+            if entries.size >= MAX_INDEX_ENTRIES
+              capped = true
+              break
+            end
+          end
+
+          [entries, capped]
+        rescue StandardError => ex
+          OT.le '[Billing::StripeOrganizations] index scan failed',
+            { exception: ex, message: ex.message }
+          [[], false]
+        end
+
+        # nil means "no MATCH" (HSCAN returns everything).
+        def match_pattern
+          return nil if @search.empty?
+          return @search if @search.match?(/[*?\[\]]/)
+
+          "*#{@search}*"
+        end
+
+        def safe_field_count(index)
+          index.field_count.to_i
+        rescue StandardError
+          0
+        end
+
+        # One pipelined load_multi for the page's objids.
+        def hydrate(objids)
+          return {} if objids.empty?
+
+          Onetime::Organization.load_multi(objids).compact
+            .each_with_object({}) { |org, acc| acc[org.objid.to_s] = org }
+        rescue StandardError => ex
+          OT.le '[Billing::StripeOrganizations] page hydration failed',
+            { exception: ex, message: ex.message }
+          {}
+        end
+
+        # Row shape mirrors the billing subset of ListOrganizations' rows so the
+        # admin console can reuse its cell renderers. Emails are FULL addresses
+        # (colonel-only, scope=internal) and are masked client-side by
+        # RevealEmail.vue, matching ListOrganizations.
+        def build_row(org, stripe_id)
+          {
+            org_id: org.objid,
+            extid: org.extid,
+            display_name: org.display_name,
+            owner_email: safe_owner_email(org),
+            billing_email: org.billing_email,
+            planid: org.planid,
+            stripe_customer_id: stripe_id,
+            stripe_subscription_id: org.stripe_subscription_id,
+            subscription_status: org.subscription_status,
+            subscription_period_end: blank_to_nil(org.subscription_period_end),
+            sync_status: compute_sync_status(org),
+            created: org.created&.to_i,
+            updated: org.updated&.to_i,
+          }
+        end
+
+        # Owner resolution is one extra load per ROW (bounded by per_page, max
+        # 100) — never per population.
+        def safe_owner_email(org)
+          org.owner&.email
+        rescue StandardError
+          nil
+        end
+
+        # Emitted as a String (or nil) so the field types match the rest of the
+        # billing row; the underlying field is a Unix timestamp.
+        def blank_to_nil(value)
+          str = value.to_s
+          str.empty? ? nil : str
+        end
+
+        # Reuses the incumbent computation when the billing app is loaded; a
+        # billing-disabled deployment reports nil rather than guessing.
+        def compute_sync_status(org)
+          return nil unless defined?(::Billing::BillingService)
+
+          ::Billing::BillingService.compute_sync_status(org)
+        rescue StandardError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/domains/create.rb
+++ b/lib/onetime/operations/domains/create.rb
@@ -1,0 +1,210 @@
+# lib/onetime/operations/domains/create.rb
+#
+# frozen_string_literal: true
+
+# Domain-owned (app-scoped) operation — see decision D3 in
+# lib/onetime/operations/README.md. Loaded at the call site (colonel logic +
+# CLI), which run outside the app autoloaders, so require the audit model and
+# the validation strategy explicitly (mirrors Repair / Transfer / Remove).
+require 'onetime/models/admin_audit_event'
+require 'onetime/domain_validation/strategy'
+
+module Onetime
+  module Operations
+    module Domains
+      # Register a custom domain against an organization — the SINGLE
+      # implementation of the admin create verb.
+      #
+      # Adapters:
+      #   - `POST /api/colonel/domains` (ColonelAPI::Logic::Colonel::CreateCustomDomain)
+      #   - `bin/ots domains create DOMAIN --org ORG`
+      #
+      # Before this op existed, create was the ONE domain verb with no extracted
+      # operation: the colonel logic class validated, created, requested the
+      # certificate and wrote its own AdminAuditEvent inline, and there was no
+      # CLI peer at all. A CLI-only reimplementation would have forked the audit
+      # path, so the logic is centralised here and both adapters stay thin.
+      #
+      # ## Two entry points, one validation
+      #
+      # {#validate} is the pure, side-effect-free half (normalise + reject). The
+      # HTTP adapter calls it from `raise_concerns` so a bad request is refused
+      # before `process` runs; {#call} re-runs it (cheap: string + index reads)
+      # so the CLI and any future caller cannot skip it. There is exactly one
+      # copy of the rules.
+      #
+      # ## Audit (CONTRACT 4)
+      #
+      # Exactly ONE {Onetime::AdminAuditEvent} per successful create, emitted
+      # here. Adapters MUST NOT audit. A rejected create (invalid / duplicate)
+      # mutates nothing and audits nothing. Certificate provisioning failures are
+      # logged but do NOT roll back or suppress the audit event — the domain
+      # record exists and cert issuance is retryable via
+      # `POST /api/colonel/domains/:extid/verify`.
+      #
+      # ## Deliberate omission
+      #
+      # There is NO membership / entitlement gate. A colonel attaches a domain to
+      # an org they are not a member of; that is the whole point of the verb. The
+      # role gate lives at the adapter (router `role=colonel` +
+      # `verify_one_of_roles!`), and the CLI is already a root-shell surface.
+      class Create
+        AUDIT_VERB = 'domain.create'
+
+        # Rejection reasons, mapped to the operator-facing message the incumbent
+        # colonel endpoint has always returned. Adapters render these verbatim so
+        # the HTTP contract does not shift under the frontend.
+        REJECTIONS = {
+          blank: 'Please enter a domain',
+          invalid: 'Not a valid public domain',
+          overlaps_canonical: 'This domain overlaps with the default site domain',
+          duplicate_in_org: 'Domain already registered in this organization',
+          duplicate_other_org: 'Domain is registered to another organization',
+        }.freeze
+
+        # Outcome of {#validate}.
+        #
+        # @!attribute status [r] Symbol — :ok, or one of {REJECTIONS}' keys.
+        # @!attribute display_domain [r] String, nil — normalised FQDN when :ok.
+        # @!attribute message [r] String, nil — operator-facing rejection text.
+        # @!attribute claims_orphan [r] Boolean — true when an existing orphaned
+        #   record (no org_id) will be claimed rather than a new one created.
+        Check = Data.define(:status, :display_domain, :message, :claims_orphan)
+
+        # Outcome of {#call}.
+        #
+        # @!attribute status [r] Symbol — :created, or a rejection key.
+        # @!attribute domain [r] Onetime::CustomDomain, nil
+        # @!attribute cert_status [r] String, nil — strategy result, 'error', or
+        #   nil when no certificate request was attempted.
+        Result = Data.define(
+          :status,
+          :domain,
+          :domain_id,
+          :extid,
+          :display_domain,
+          :message,
+          :claims_orphan,
+          :cert_status,
+        )
+
+        # @param domain [String] raw operator input (adapter pre-sanitises HTML).
+        # @param org [Onetime::Organization] target org (adapter resolves; required).
+        # @param actor [String, #extid, #email] acting admin's PUBLIC identity
+        #   (colonel extid, or the CLI sentinel). Never an internal objid.
+        # @param request_certificate [Boolean] kick off SSL provisioning through
+        #   the configured strategy after a successful create (default true).
+        def initialize(domain:, org:, actor:, request_certificate: true)
+          @domain_input        = domain.to_s.strip
+          @org                 = org
+          @actor               = actor
+          @request_certificate = request_certificate
+        end
+
+        # Pure validation + normalisation. No writes, no audit.
+        #
+        # @return [Check]
+        def validate
+          return reject(:blank) if @domain_input.empty?
+          return reject(:invalid) unless Onetime::CustomDomain.valid?(@domain_input)
+          return reject(:overlaps_canonical) if Onetime::CustomDomain.overlaps_canonical_domain?(@domain_input)
+
+          display_domain = Onetime::CustomDomain.parse(@domain_input, @org.objid).display_domain
+
+          existing = Onetime::CustomDomain.load_by_display_domain(display_domain)
+          return Check.new(status: :ok, display_domain: display_domain, message: nil, claims_orphan: false) unless existing
+
+          # Pre-check duplicates for a precise message; create! re-checks the
+          # same three cases atomically at the write gate.
+          return reject(:duplicate_in_org, display_domain) if existing.org_id.to_s == @org.objid.to_s
+          return reject(:duplicate_other_org, display_domain) unless existing.org_id.to_s.empty?
+
+          # Orphaned record (no org_id): create! claims it atomically.
+          Check.new(status: :ok, display_domain: display_domain, message: nil, claims_orphan: true)
+        end
+
+        # @return [Result]
+        def call
+          check = validate
+          return rejected_result(check) unless check.status == :ok
+
+          domain = Onetime::CustomDomain.create!(check.display_domain, @org.objid)
+          cert   = @request_certificate ? provision_certificate(domain) : nil
+
+          # Exactly one audit event per successful create. Public ids only.
+          Onetime::AdminAuditEvent.record(
+            actor: @actor,
+            verb: AUDIT_VERB,
+            target: domain.extid,
+            result: :success,
+            detail: {
+              org_id: @org.extid,
+              display_domain: domain.display_domain,
+            },
+          )
+
+          OT.info "[Domains::Create] #{domain.display_domain} -> org=#{@org.extid} extid=#{domain.extid}"
+
+          Result.new(
+            status: :created,
+            domain: domain,
+            domain_id: domain.domainid,
+            extid: domain.extid,
+            display_domain: domain.display_domain,
+            message: nil,
+            claims_orphan: check.claims_orphan,
+            cert_status: cert,
+          )
+        end
+
+        private
+
+        # Certificate provisioning is best-effort: the domain record already
+        # exists and issuance is retryable, so a failure is logged and reported
+        # in the Result rather than raised (unchanged from the incumbent colonel
+        # behaviour).
+        #
+        # @return [String, nil] strategy status, or 'error' when it blew up.
+        def provision_certificate(domain)
+          strategy = Onetime::DomainValidation::Strategy.for_config(OT.conf)
+          result   = strategy.request_certificate(domain)
+
+          OT.info "[Domains::Create.request_certificate] #{domain.display_domain} -> #{result[:status]}"
+
+          if result[:data]
+            domain.vhost   = result[:data].to_json
+            domain.updated = OT.now.to_i
+            domain.save
+          end
+
+          result[:status].to_s
+        rescue StandardError => ex
+          OT.le "[Domains::Create] certificate request failed for #{domain.display_domain}: #{ex.message}"
+          'error'
+        end
+
+        def reject(status, display_domain = nil)
+          Check.new(
+            status: status,
+            display_domain: display_domain,
+            message: REJECTIONS.fetch(status),
+            claims_orphan: false,
+          )
+        end
+
+        def rejected_result(check)
+          Result.new(
+            status: check.status,
+            domain: nil,
+            domain_id: nil,
+            extid: nil,
+            display_domain: check.display_domain,
+            message: check.message,
+            claims_orphan: false,
+            cert_status: nil,
+          )
+        end
+      end
+    end
+  end
+end

--- a/locales/content/ar/admin-colonel.json
+++ b/locales/content/ar/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "إدارة المستخدمين",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "إدارة الأسرار",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "النطاقات المخصصة",
     "source_hash": "6170ab94"

--- a/locales/content/bg/admin-colonel.json
+++ b/locales/content/bg/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Управление на потребители",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Управление на тайни",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Персонализирани домейни",
     "source_hash": "6170ab94"

--- a/locales/content/ca_ES/admin-colonel.json
+++ b/locales/content/ca_ES/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Gestió d'usuaris",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Gestió de secrets",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Dominis personalitzats",
     "source_hash": "6170ab94"

--- a/locales/content/cs/admin-colonel.json
+++ b/locales/content/cs/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Správa uživatelů",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Správa tajemství",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Vlastní domény",
     "source_hash": "6170ab94"

--- a/locales/content/da_DK/admin-colonel.json
+++ b/locales/content/da_DK/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Brugeradministration",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Beskedadministration",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Brugerdefinerede domæner",
     "source_hash": "6170ab94"

--- a/locales/content/de/admin-colonel.json
+++ b/locales/content/de/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Benutzerverwaltung",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Nachrichtenverwaltung",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Benutzerdefinierte Domains",
     "source_hash": "6170ab94"

--- a/locales/content/de_AT/admin-colonel.json
+++ b/locales/content/de_AT/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Benutzerverwaltung",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Geheimnisverwaltung",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Eigene Domains",
     "source_hash": "6170ab94"

--- a/locales/content/el_GR/admin-colonel.json
+++ b/locales/content/el_GR/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Διαχείριση χρηστών",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Διαχείριση μυστικών",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Προσαρμοσμένοι τομείς",
     "source_hash": "6170ab94"

--- a/locales/content/en/admin-audit.json
+++ b/locales/content/en/admin-audit.json
@@ -36,16 +36,20 @@
     "content_hash": "966aa580"
   },
   "web.admin.audit.filters.actorLabel": {
-    "text": "Actor"
+    "text": "Actor",
+    "content_hash": "449995c4"
   },
   "web.admin.audit.filters.searchButton": {
-    "text": "Search"
+    "text": "Search",
+    "content_hash": "49c266ba"
   },
   "web.admin.audit.filters.searchHint": {
-    "text": "Type an actor, then press Enter or choose Search to run it. The list does not update while you type."
+    "text": "Type an actor, then press Enter or choose Search to run it. The list does not update while you type.",
+    "content_hash": "45eceb12"
   },
   "web.admin.audit.filters.pendingSearch": {
-    "text": "Not searched yet — press Enter or choose Search to apply this actor."
+    "text": "Not searched yet — press Enter or choose Search to apply this actor.",
+    "content_hash": "f76095c2"
   },
   "web.admin.audit.filters.actionLabel": {
     "text": "Action",

--- a/locales/content/en/admin-audit.json
+++ b/locales/content/en/admin-audit.json
@@ -35,6 +35,18 @@
     "text": "Filter by actor (extid or email)",
     "content_hash": "966aa580"
   },
+  "web.admin.audit.filters.actorLabel": {
+    "text": "Actor"
+  },
+  "web.admin.audit.filters.searchButton": {
+    "text": "Search"
+  },
+  "web.admin.audit.filters.searchHint": {
+    "text": "Type an actor, then press Enter or choose Search to run it. The list does not update while you type."
+  },
+  "web.admin.audit.filters.pendingSearch": {
+    "text": "Not searched yet — press Enter or choose Search to apply this actor."
+  },
   "web.admin.audit.filters.actionLabel": {
     "text": "Action",
     "content_hash": "64cff131"

--- a/locales/content/en/admin-billing.json
+++ b/locales/content/en/admin-billing.json
@@ -124,63 +124,83 @@
     "content_hash": "c53f31c3"
   },
   "web.admin.billing.diff.backToCatalog": {
-    "text": "Back to billing catalog"
+    "text": "Back to billing catalog",
+    "content_hash": "8532b373"
   },
   "web.admin.billing.diff.driftedFields": {
-    "text": "Fields that differ:"
+    "text": "Fields that differ:",
+    "content_hash": "9890c95b"
   },
   "web.admin.billing.diff.notFound": {
-    "text": "Plan not in the catalog"
+    "text": "Plan not in the catalog",
+    "content_hash": "0253898b"
   },
   "web.admin.billing.diff.notFoundDescription": {
-    "text": "No plan with the id {planid} was found in the configured catalog or the live Stripe-synced cache."
+    "text": "No plan with the id {planid} was found in the configured catalog or the live Stripe-synced cache.",
+    "content_hash": "2e69551c"
   },
   "web.admin.billing.stripeOrgs.title": {
-    "text": "Stripe customers"
+    "text": "Stripe customers",
+    "content_hash": "0463ae27"
   },
   "web.admin.billing.stripeOrgs.description": {
-    "text": "Organizations linked to a Stripe customer record."
+    "text": "Organizations linked to a Stripe customer record.",
+    "content_hash": "2ab09aec"
   },
   "web.admin.billing.stripeOrgs.searchPlaceholder": {
-    "text": "Search by Stripe customer ID"
+    "text": "Search by Stripe customer ID",
+    "content_hash": "d5acf08f"
   },
   "web.admin.billing.stripeOrgs.empty": {
-    "text": "No organizations have a Stripe customer ID."
+    "text": "No organizations have a Stripe customer ID.",
+    "content_hash": "2e373537"
   },
   "web.admin.billing.stripeOrgs.emptySearch": {
-    "text": "No Stripe customer ID matches that search."
+    "text": "No Stripe customer ID matches that search.",
+    "content_hash": "75011174"
   },
   "web.admin.billing.stripeOrgs.loadError": {
-    "text": "Could not load the Stripe customers list."
+    "text": "Could not load the Stripe customers list.",
+    "content_hash": "15e2d9a7"
   },
   "web.admin.billing.stripeOrgs.unavailable": {
-    "text": "The Stripe customers list is not available on this server yet."
+    "text": "The Stripe customers list is not available on this server yet.",
+    "content_hash": "aab6451a"
   },
   "web.admin.billing.stripeOrgs.none": {
-    "text": "None"
+    "text": "None",
+    "content_hash": "dc937b59"
   },
   "web.admin.billing.stripeOrgs.capped": {
-    "text": "The index scan hit its limit, so the total is a lower bound — narrow the search to see the rest."
+    "text": "The index scan hit its limit, so the total is a lower bound — narrow the search to see the rest.",
+    "content_hash": "20bcaa38"
   },
   "web.admin.billing.stripeOrgs.stale": {
-    "text": "{count} index entry/entries on this page point at an organization that no longer loads and were skipped."
+    "text": "{count} index entry/entries on this page point at an organization that no longer loads and were skipped.",
+    "content_hash": "51980f83"
   },
   "web.admin.billing.stripeOrgs.copyStripeId": {
-    "text": "Copy Stripe customer ID"
+    "text": "Copy Stripe customer ID",
+    "content_hash": "a77d18b1"
   },
   "web.admin.billing.stripeOrgs.columns.organization": {
-    "text": "Organization"
+    "text": "Organization",
+    "content_hash": "d764d425"
   },
   "web.admin.billing.stripeOrgs.columns.owner": {
-    "text": "Owner"
+    "text": "Owner",
+    "content_hash": "4b1b8aa3"
   },
   "web.admin.billing.stripeOrgs.columns.plan": {
-    "text": "Plan"
+    "text": "Plan",
+    "content_hash": "fa8ed0bd"
   },
   "web.admin.billing.stripeOrgs.columns.subscription": {
-    "text": "Subscription"
+    "text": "Subscription",
+    "content_hash": "4999c6c6"
   },
   "web.admin.billing.stripeOrgs.columns.stripeCustomer": {
-    "text": "Stripe customer ID"
+    "text": "Stripe customer ID",
+    "content_hash": "7e1d8bbb"
   }
 }

--- a/locales/content/en/admin-billing.json
+++ b/locales/content/en/admin-billing.json
@@ -122,5 +122,65 @@
   "web.admin.billing.diff.absentLive": {
     "text": "This plan is not present in the live Stripe-synced cache.",
     "content_hash": "c53f31c3"
+  },
+  "web.admin.billing.diff.backToCatalog": {
+    "text": "Back to billing catalog"
+  },
+  "web.admin.billing.diff.driftedFields": {
+    "text": "Fields that differ:"
+  },
+  "web.admin.billing.diff.notFound": {
+    "text": "Plan not in the catalog"
+  },
+  "web.admin.billing.diff.notFoundDescription": {
+    "text": "No plan with the id {planid} was found in the configured catalog or the live Stripe-synced cache."
+  },
+  "web.admin.billing.stripeOrgs.title": {
+    "text": "Stripe customers"
+  },
+  "web.admin.billing.stripeOrgs.description": {
+    "text": "Organizations linked to a Stripe customer record."
+  },
+  "web.admin.billing.stripeOrgs.searchPlaceholder": {
+    "text": "Search by Stripe customer ID"
+  },
+  "web.admin.billing.stripeOrgs.empty": {
+    "text": "No organizations have a Stripe customer ID."
+  },
+  "web.admin.billing.stripeOrgs.emptySearch": {
+    "text": "No Stripe customer ID matches that search."
+  },
+  "web.admin.billing.stripeOrgs.loadError": {
+    "text": "Could not load the Stripe customers list."
+  },
+  "web.admin.billing.stripeOrgs.unavailable": {
+    "text": "The Stripe customers list is not available on this server yet."
+  },
+  "web.admin.billing.stripeOrgs.none": {
+    "text": "None"
+  },
+  "web.admin.billing.stripeOrgs.capped": {
+    "text": "The index scan hit its limit, so the total is a lower bound — narrow the search to see the rest."
+  },
+  "web.admin.billing.stripeOrgs.stale": {
+    "text": "{count} index entry/entries on this page point at an organization that no longer loads and were skipped."
+  },
+  "web.admin.billing.stripeOrgs.copyStripeId": {
+    "text": "Copy Stripe customer ID"
+  },
+  "web.admin.billing.stripeOrgs.columns.organization": {
+    "text": "Organization"
+  },
+  "web.admin.billing.stripeOrgs.columns.owner": {
+    "text": "Owner"
+  },
+  "web.admin.billing.stripeOrgs.columns.plan": {
+    "text": "Plan"
+  },
+  "web.admin.billing.stripeOrgs.columns.subscription": {
+    "text": "Subscription"
+  },
+  "web.admin.billing.stripeOrgs.columns.stripeCustomer": {
+    "text": "Stripe customer ID"
   }
 }

--- a/locales/content/en/admin-colonel.json
+++ b/locales/content/en/admin-colonel.json
@@ -760,7 +760,7 @@
     "content_hash": "fe45f3a1"
   },
   "web.colonel.titles.secrets": {
-    "text": "Secret Management",
+    "text": "Secret Records",
     "content_hash": "af69773b"
   },
   "web.colonel.titles.domains": {

--- a/locales/content/en/admin-colonel.json
+++ b/locales/content/en/admin-colonel.json
@@ -759,10 +759,6 @@
     "text": "User Management",
     "content_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Secret Records",
-    "content_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Custom Domains",
     "content_hash": "6170ab94"

--- a/locales/content/en/admin-customers.json
+++ b/locales/content/en/admin-customers.json
@@ -47,6 +47,12 @@
     "text": "Suspended",
     "content_hash": "e392a389"
   },
+  "web.admin.customers.verification.verified": {
+    "text": "Verified"
+  },
+  "web.admin.customers.verification.unverified": {
+    "text": "Not verified"
+  },
   "web.admin.customers.columns.email": {
     "text": "Email",
     "content_hash": "969ccbd3"
@@ -410,6 +416,9 @@
   "web.admin.customers.actions.purge.success": {
     "text": "Customer purged.",
     "content_hash": "6145e5c8"
+  },
+  "web.admin.customers.actions.purge.typePrompt": {
+    "text": "To confirm, type the account email address {token} below"
   },
   "web.admin.customers.detail.sessions.title": {
     "text": "Active Sessions",

--- a/locales/content/en/admin-customers.json
+++ b/locales/content/en/admin-customers.json
@@ -81,6 +81,10 @@
     "text": "Last login",
     "content_hash": "0d39602d"
   },
+  "web.admin.customers.columns.actions": {
+    "text": "Actions",
+    "content_hash": "ff8059dc"
+  },
   "web.admin.customers.detail.backToList": {
     "text": "Back to customers",
     "content_hash": "077807fb"
@@ -273,9 +277,17 @@
     "text": "No secrets",
     "content_hash": "c37ab3f7"
   },
+  "web.admin.customers.detail.secrets.partial": {
+    "text": "Partial list — showing the {count} most recent. This customer owns more secrets than are shown here.",
+    "content_hash": "a537c8f3"
+  },
   "web.admin.customers.detail.receipts.empty": {
     "text": "No receipts",
     "content_hash": "fb425a68"
+  },
+  "web.admin.customers.detail.receipts.partial": {
+    "text": "Partial list — showing the {count} most recent. This customer has more receipts than are shown here.",
+    "content_hash": "127fd4db"
   },
   "web.admin.customers.detail.organizations.empty": {
     "text": "No organizations",

--- a/locales/content/en/admin-customers.json
+++ b/locales/content/en/admin-customers.json
@@ -48,10 +48,12 @@
     "content_hash": "e392a389"
   },
   "web.admin.customers.verification.verified": {
-    "text": "Verified"
+    "text": "Verified",
+    "content_hash": "4f783840"
   },
   "web.admin.customers.verification.unverified": {
-    "text": "Not verified"
+    "text": "Not verified",
+    "content_hash": "15133907"
   },
   "web.admin.customers.columns.email": {
     "text": "Email",
@@ -430,7 +432,8 @@
     "content_hash": "6145e5c8"
   },
   "web.admin.customers.actions.purge.typePrompt": {
-    "text": "To confirm, type the account email address {token} below"
+    "text": "To confirm, type the account email address {token} below",
+    "content_hash": "8b2a1819"
   },
   "web.admin.customers.detail.sessions.title": {
     "text": "Active Sessions",

--- a/locales/content/en/admin-customers.json
+++ b/locales/content/en/admin-customers.json
@@ -5,7 +5,7 @@
   },
   "web.admin.customers.description": {
     "text": "Find a customer and resolve support issues.",
-    "content_hash": "c8487e68"
+    "content_hash": "00961ea3"
   },
   "web.admin.customers.list.roleFilter": {
     "text": "Role",

--- a/locales/content/en/admin-customers.json
+++ b/locales/content/en/admin-customers.json
@@ -4,7 +4,7 @@
     "content_hash": "aabe76f1"
   },
   "web.admin.customers.description": {
-    "text": "Find a customer and resolve support issues without SSH.",
+    "text": "Find a customer and resolve support issues.",
     "content_hash": "c8487e68"
   },
   "web.admin.customers.list.roleFilter": {

--- a/locales/content/en/admin-domains.json
+++ b/locales/content/en/admin-domains.json
@@ -190,5 +190,260 @@
   "web.admin.domains.orgPicker.select": {
     "text": "Select",
     "content_hash": "2a78025d"
+  },
+  "web.admin.domains.list.searchPlaceholder": {
+    "text": "Search by domain name or ID"
+  },
+  "web.admin.domains.list.stateFilter": {
+    "text": "State"
+  },
+  "web.admin.domains.list.emptyFilter": {
+    "text": "No domains match the current filters."
+  },
+  "web.admin.domains.columns.domain": {
+    "text": "Domain"
+  },
+  "web.admin.domains.columns.organization": {
+    "text": "Organization"
+  },
+  "web.admin.domains.columns.state": {
+    "text": "Verification"
+  },
+  "web.admin.domains.columns.tls": {
+    "text": "TLS"
+  },
+  "web.admin.domains.columns.created": {
+    "text": "Created"
+  },
+  "web.admin.domains.columns.actions": {
+    "text": "Actions"
+  },
+  "web.admin.domains.tls.serving": {
+    "text": "Serving"
+  },
+  "web.admin.domains.tls.resolving": {
+    "text": "Resolving"
+  },
+  "web.admin.domains.tls.none": {
+    "text": "Not serving"
+  },
+  "web.admin.domains.fields.publicId": {
+    "text": "Public ID"
+  },
+  "web.admin.domains.fields.domainId": {
+    "text": "Internal ID"
+  },
+  "web.admin.domains.fields.organization": {
+    "text": "Organization"
+  },
+  "web.admin.domains.fields.baseDomain": {
+    "text": "Base domain"
+  },
+  "web.admin.domains.fields.subdomain": {
+    "text": "Subdomain"
+  },
+  "web.admin.domains.fields.apex": {
+    "text": "Apex domain"
+  },
+  "web.admin.domains.fields.status": {
+    "text": "Status"
+  },
+  "web.admin.domains.fields.created": {
+    "text": "Created"
+  },
+  "web.admin.domains.fields.updated": {
+    "text": "Updated"
+  },
+  "web.admin.domains.fields.verified": {
+    "text": "Verified"
+  },
+  "web.admin.domains.fields.resolving": {
+    "text": "Resolving"
+  },
+  "web.admin.domains.fields.ready": {
+    "text": "Ready"
+  },
+  "web.admin.domains.detail.openFullPage": {
+    "text": "Open full page"
+  },
+  "web.admin.domains.detail.backToList": {
+    "text": "Back to domains"
+  },
+  "web.admin.domains.detail.notFound": {
+    "text": "Domain not found"
+  },
+  "web.admin.domains.detail.notFoundDescription": {
+    "text": "This domain does not exist, or it has already been removed."
+  },
+  "web.admin.domains.detail.loadError": {
+    "text": "Could not load this domain."
+  },
+  "web.admin.domains.detail.retry": {
+    "text": "Retry"
+  },
+  "web.admin.domains.detail.never": {
+    "text": "Never"
+  },
+  "web.admin.domains.detail.none": {
+    "text": "None"
+  },
+  "web.admin.domains.detail.yes": {
+    "text": "Yes"
+  },
+  "web.admin.domains.detail.no": {
+    "text": "No"
+  },
+  "web.admin.domains.detail.sections.overview": {
+    "text": "Overview"
+  },
+  "web.admin.domains.detail.sections.actions": {
+    "text": "Actions"
+  },
+  "web.admin.domains.detail.sections.organization": {
+    "text": "Owning organization"
+  },
+  "web.admin.domains.detail.sections.dns": {
+    "text": "DNS"
+  },
+  "web.admin.domains.detail.sections.diagnostics": {
+    "text": "Diagnostics"
+  },
+  "web.admin.domains.detail.sections.operations": {
+    "text": "Ownership operations"
+  },
+  "web.admin.domains.detail.sections.operationsHint": {
+    "text": "Each operation previews first. Nothing is written until you confirm the apply step."
+  },
+  "web.admin.domains.detail.organization.open": {
+    "text": "Open organization"
+  },
+  "web.admin.domains.detail.organization.unknown": {
+    "text": "The owning organization is not included in this response. Open this domain from the domains list to see it."
+  },
+  "web.admin.domains.actions.preview": {
+    "text": "Preview"
+  },
+  "web.admin.domains.actions.probe.button": {
+    "text": "Probe"
+  },
+  "web.admin.domains.probe.healthLabel": {
+    "text": "Health"
+  },
+  "web.admin.domains.probe.certInvalid": {
+    "text": "Certificate not usable"
+  },
+  "web.admin.domains.probe.noCertificate": {
+    "text": "No certificate was returned — the connection failed before TLS."
+  },
+  "web.admin.domains.probe.fields.httpStatus": {
+    "text": "HTTP status"
+  },
+  "web.admin.domains.probe.fields.httpError": {
+    "text": "HTTP error"
+  },
+  "web.admin.domains.probe.fields.sslError": {
+    "text": "TLS error"
+  },
+  "web.admin.domains.probe.fields.issuer": {
+    "text": "Certificate issuer"
+  },
+  "web.admin.domains.probe.fields.subject": {
+    "text": "Certificate subject"
+  },
+  "web.admin.domains.probe.fields.notAfter": {
+    "text": "Certificate expires"
+  },
+  "web.admin.domains.probe.fields.expiresIn": {
+    "text": "{date} ({days} days)"
+  },
+  "web.admin.domains.actions.repair.title": {
+    "text": "Repair organization link"
+  },
+  "web.admin.domains.actions.repair.description": {
+    "text": "Find and fix broken links between this domain and its organization. Preview first to see what would change."
+  },
+  "web.admin.domains.actions.repair.orgIdLabel": {
+    "text": "Organization ID (orphaned domains only)"
+  },
+  "web.admin.domains.actions.repair.orgIdPlaceholder": {
+    "text": "Leave blank unless the domain has no owner"
+  },
+  "web.admin.domains.actions.repair.statusLabel": {
+    "text": "Status:"
+  },
+  "web.admin.domains.actions.repair.noIssues": {
+    "text": "No problems found — nothing to repair."
+  },
+  "web.admin.domains.actions.repair.button": {
+    "text": "Apply repair"
+  },
+  "web.admin.domains.actions.repair.confirmTitle": {
+    "text": "Apply repair?"
+  },
+  "web.admin.domains.actions.repair.confirmDescription": {
+    "text": "This rewrites the organization link for {domain}. Retype the domain's public ID to continue."
+  },
+  "web.admin.domains.actions.repair.success": {
+    "text": "Repair applied."
+  },
+  "web.admin.domains.actions.transfer.title": {
+    "text": "Transfer to another organization"
+  },
+  "web.admin.domains.actions.transfer.description": {
+    "text": "Move this domain to a different organization. Preview first to confirm both sides of the move."
+  },
+  "web.admin.domains.actions.transfer.toOrgLabel": {
+    "text": "Destination organization ID"
+  },
+  "web.admin.domains.actions.transfer.fromOrgLabel": {
+    "text": "Expected current organization ID (optional)"
+  },
+  "web.admin.domains.actions.transfer.fromOrgPlaceholder": {
+    "text": "Assert the current owner before moving"
+  },
+  "web.admin.domains.actions.transfer.from": {
+    "text": "From"
+  },
+  "web.admin.domains.actions.transfer.to": {
+    "text": "To"
+  },
+  "web.admin.domains.actions.transfer.orphaned": {
+    "text": "No organization (orphaned)"
+  },
+  "web.admin.domains.actions.transfer.button": {
+    "text": "Apply transfer"
+  },
+  "web.admin.domains.actions.transfer.confirmTitle": {
+    "text": "Transfer domain?"
+  },
+  "web.admin.domains.actions.transfer.confirmDescription": {
+    "text": "This moves {domain} to organization {org}. Retype the domain's public ID to continue."
+  },
+  "web.admin.domains.actions.transfer.success": {
+    "text": "Domain transferred."
+  },
+  "web.admin.domains.actions.remove.button": {
+    "text": "Remove domain"
+  },
+  "web.admin.domains.actions.remove.previewButton": {
+    "text": "Preview removal"
+  },
+  "web.admin.domains.actions.remove.previewStatus": {
+    "text": "Status:"
+  },
+  "web.admin.domains.actions.remove.previewOrg": {
+    "text": "Organization:"
+  },
+  "web.admin.domains.actions.remove.reassertsSurvivor": {
+    "text": "Another record claims the same domain name and will take over the lookup index."
+  },
+  "web.admin.domains.actions.remove.confirmTitle": {
+    "text": "Remove domain?"
+  },
+  "web.admin.domains.actions.remove.confirmDescription": {
+    "text": "This permanently deletes {domain} and its branding, DNS and configuration records. It cannot be undone. Retype the domain's public ID to continue."
+  },
+  "web.admin.domains.actions.remove.success": {
+    "text": "Domain removed."
   }
 }

--- a/locales/content/en/admin-domains.json
+++ b/locales/content/en/admin-domains.json
@@ -192,258 +192,343 @@
     "content_hash": "2a78025d"
   },
   "web.admin.domains.list.searchPlaceholder": {
-    "text": "Search by domain name or ID"
+    "text": "Search by domain name or ID",
+    "content_hash": "aecdd873"
   },
   "web.admin.domains.list.stateFilter": {
-    "text": "State"
+    "text": "State",
+    "content_hash": "a3b50c47"
   },
   "web.admin.domains.list.emptyFilter": {
-    "text": "No domains match the current filters."
+    "text": "No domains match the current filters.",
+    "content_hash": "be4d64ec"
   },
   "web.admin.domains.columns.domain": {
-    "text": "Domain"
+    "text": "Domain",
+    "content_hash": "79fa3361"
   },
   "web.admin.domains.columns.organization": {
-    "text": "Organization"
+    "text": "Organization",
+    "content_hash": "d764d425"
   },
   "web.admin.domains.columns.state": {
-    "text": "Verification"
+    "text": "Verification",
+    "content_hash": "7140f4f1"
   },
   "web.admin.domains.columns.tls": {
-    "text": "TLS"
+    "text": "TLS",
+    "content_hash": "d1c18ec0"
   },
   "web.admin.domains.columns.created": {
-    "text": "Created"
+    "text": "Created",
+    "content_hash": "d70b9e24"
   },
   "web.admin.domains.columns.actions": {
-    "text": "Actions"
+    "text": "Actions",
+    "content_hash": "ff8059dc"
   },
   "web.admin.domains.tls.serving": {
-    "text": "Serving"
+    "text": "Serving",
+    "content_hash": "f55e53f9"
   },
   "web.admin.domains.tls.resolving": {
-    "text": "Resolving"
+    "text": "Resolving",
+    "content_hash": "3287a034"
   },
   "web.admin.domains.tls.none": {
-    "text": "Not serving"
+    "text": "Not serving",
+    "content_hash": "da8a5ab9"
   },
   "web.admin.domains.fields.publicId": {
-    "text": "Public ID"
+    "text": "Public ID",
+    "content_hash": "3705b64f"
   },
   "web.admin.domains.fields.domainId": {
-    "text": "Internal ID"
+    "text": "Internal ID",
+    "content_hash": "e468bb47"
   },
   "web.admin.domains.fields.organization": {
-    "text": "Organization"
+    "text": "Organization",
+    "content_hash": "d764d425"
   },
   "web.admin.domains.fields.baseDomain": {
-    "text": "Base domain"
+    "text": "Base domain",
+    "content_hash": "33295d5b"
   },
   "web.admin.domains.fields.subdomain": {
-    "text": "Subdomain"
+    "text": "Subdomain",
+    "content_hash": "ba4520ab"
   },
   "web.admin.domains.fields.apex": {
-    "text": "Apex domain"
+    "text": "Apex domain",
+    "content_hash": "0a8a42fa"
   },
   "web.admin.domains.fields.status": {
-    "text": "Status"
+    "text": "Status",
+    "content_hash": "920e413c"
   },
   "web.admin.domains.fields.created": {
-    "text": "Created"
+    "text": "Created",
+    "content_hash": "d70b9e24"
   },
   "web.admin.domains.fields.updated": {
-    "text": "Updated"
+    "text": "Updated",
+    "content_hash": "3a5ecca1"
   },
   "web.admin.domains.fields.verified": {
-    "text": "Verified"
+    "text": "Verified",
+    "content_hash": "4f783840"
   },
   "web.admin.domains.fields.resolving": {
-    "text": "Resolving"
+    "text": "Resolving",
+    "content_hash": "3287a034"
   },
   "web.admin.domains.fields.ready": {
-    "text": "Ready"
+    "text": "Ready",
+    "content_hash": "5fa7aac5"
   },
   "web.admin.domains.detail.openFullPage": {
-    "text": "Open full page"
+    "text": "Open full page",
+    "content_hash": "a467911c"
   },
   "web.admin.domains.detail.backToList": {
-    "text": "Back to domains"
+    "text": "Back to domains",
+    "content_hash": "22fd50fe"
   },
   "web.admin.domains.detail.notFound": {
-    "text": "Domain not found"
+    "text": "Domain not found",
+    "content_hash": "7b8fc0e6"
   },
   "web.admin.domains.detail.notFoundDescription": {
-    "text": "This domain does not exist, or it has already been removed."
+    "text": "This domain does not exist, or it has already been removed.",
+    "content_hash": "e0f0b987"
   },
   "web.admin.domains.detail.loadError": {
-    "text": "Could not load this domain."
+    "text": "Could not load this domain.",
+    "content_hash": "39e9c657"
   },
   "web.admin.domains.detail.retry": {
-    "text": "Retry"
+    "text": "Retry",
+    "content_hash": "942087cc"
   },
   "web.admin.domains.detail.never": {
-    "text": "Never"
+    "text": "Never",
+    "content_hash": "6300ef80"
   },
   "web.admin.domains.detail.none": {
-    "text": "None"
+    "text": "None",
+    "content_hash": "dc937b59"
   },
   "web.admin.domains.detail.yes": {
-    "text": "Yes"
+    "text": "Yes",
+    "content_hash": "85a39ab3"
   },
   "web.admin.domains.detail.no": {
-    "text": "No"
+    "text": "No",
+    "content_hash": "1ea442a1"
   },
   "web.admin.domains.detail.sections.overview": {
-    "text": "Overview"
+    "text": "Overview",
+    "content_hash": "d4b1ea57"
   },
   "web.admin.domains.detail.sections.actions": {
-    "text": "Actions"
+    "text": "Actions",
+    "content_hash": "ff8059dc"
   },
   "web.admin.domains.detail.sections.organization": {
-    "text": "Owning organization"
+    "text": "Owning organization",
+    "content_hash": "39ad6d9c"
   },
   "web.admin.domains.detail.sections.dns": {
-    "text": "DNS"
+    "text": "DNS",
+    "content_hash": "020965a2"
   },
   "web.admin.domains.detail.sections.diagnostics": {
-    "text": "Diagnostics"
+    "text": "Diagnostics",
+    "content_hash": "268f14bb"
   },
   "web.admin.domains.detail.sections.operations": {
-    "text": "Ownership operations"
+    "text": "Ownership operations",
+    "content_hash": "eb9a8cbc"
   },
   "web.admin.domains.detail.sections.operationsHint": {
-    "text": "Each operation previews first. Nothing is written until you confirm the apply step."
+    "text": "Each operation previews first. Nothing is written until you confirm the apply step.",
+    "content_hash": "f09bf7bd"
   },
   "web.admin.domains.detail.organization.open": {
-    "text": "Open organization"
+    "text": "Open organization",
+    "content_hash": "54a43621"
   },
   "web.admin.domains.detail.organization.unknown": {
-    "text": "The owning organization is not included in this response. Open this domain from the domains list to see it."
+    "text": "The owning organization is not included in this response. Open this domain from the domains list to see it.",
+    "content_hash": "bb5bdc9c"
   },
   "web.admin.domains.actions.preview": {
-    "text": "Preview"
+    "text": "Preview",
+    "content_hash": "324b134f"
   },
   "web.admin.domains.actions.probe.button": {
-    "text": "Probe"
+    "text": "Probe",
+    "content_hash": "3bd51ab9"
   },
   "web.admin.domains.probe.healthLabel": {
-    "text": "Health"
+    "text": "Health",
+    "content_hash": "55898449"
   },
   "web.admin.domains.probe.certInvalid": {
-    "text": "Certificate not usable"
+    "text": "Certificate not usable",
+    "content_hash": "5535f4d4"
   },
   "web.admin.domains.probe.noCertificate": {
-    "text": "No certificate was returned — the connection failed before TLS."
+    "text": "No certificate was returned — the connection failed before TLS.",
+    "content_hash": "8ffd63be"
   },
   "web.admin.domains.probe.fields.httpStatus": {
-    "text": "HTTP status"
+    "text": "HTTP status",
+    "content_hash": "0f7cf91f"
   },
   "web.admin.domains.probe.fields.httpError": {
-    "text": "HTTP error"
+    "text": "HTTP error",
+    "content_hash": "5c6896d4"
   },
   "web.admin.domains.probe.fields.sslError": {
-    "text": "TLS error"
+    "text": "TLS error",
+    "content_hash": "7b827515"
   },
   "web.admin.domains.probe.fields.issuer": {
-    "text": "Certificate issuer"
+    "text": "Certificate issuer",
+    "content_hash": "2912559a"
   },
   "web.admin.domains.probe.fields.subject": {
-    "text": "Certificate subject"
+    "text": "Certificate subject",
+    "content_hash": "d7816b16"
   },
   "web.admin.domains.probe.fields.notAfter": {
-    "text": "Certificate expires"
+    "text": "Certificate expires",
+    "content_hash": "1e73119d"
   },
   "web.admin.domains.probe.fields.expiresIn": {
-    "text": "{date} ({days} days)"
+    "text": "{date} ({days} days)",
+    "content_hash": "a71a6e81"
   },
   "web.admin.domains.actions.repair.title": {
-    "text": "Repair organization link"
+    "text": "Repair organization link",
+    "content_hash": "82b40352"
   },
   "web.admin.domains.actions.repair.description": {
-    "text": "Find and fix broken links between this domain and its organization. Preview first to see what would change."
+    "text": "Find and fix broken links between this domain and its organization. Preview first to see what would change.",
+    "content_hash": "531ed287"
   },
   "web.admin.domains.actions.repair.orgIdLabel": {
-    "text": "Organization ID (orphaned domains only)"
+    "text": "Organization ID (orphaned domains only)",
+    "content_hash": "0d3010eb"
   },
   "web.admin.domains.actions.repair.orgIdPlaceholder": {
-    "text": "Leave blank unless the domain has no owner"
+    "text": "Leave blank unless the domain has no owner",
+    "content_hash": "118b7132"
   },
   "web.admin.domains.actions.repair.statusLabel": {
-    "text": "Status:"
+    "text": "Status:",
+    "content_hash": "755c8b2a"
   },
   "web.admin.domains.actions.repair.noIssues": {
-    "text": "No problems found — nothing to repair."
+    "text": "No problems found — nothing to repair.",
+    "content_hash": "17735887"
   },
   "web.admin.domains.actions.repair.button": {
-    "text": "Apply repair"
+    "text": "Apply repair",
+    "content_hash": "4d0ab2d4"
   },
   "web.admin.domains.actions.repair.confirmTitle": {
-    "text": "Apply repair?"
+    "text": "Apply repair?",
+    "content_hash": "ef0ffae5"
   },
   "web.admin.domains.actions.repair.confirmDescription": {
-    "text": "This rewrites the organization link for {domain}. Retype the domain's public ID to continue."
+    "text": "This rewrites the organization link for {domain}. Retype the domain's public ID to continue.",
+    "content_hash": "a9f2702f"
   },
   "web.admin.domains.actions.repair.success": {
-    "text": "Repair applied."
+    "text": "Repair applied.",
+    "content_hash": "850bd784"
   },
   "web.admin.domains.actions.transfer.title": {
-    "text": "Transfer to another organization"
+    "text": "Transfer to another organization",
+    "content_hash": "1b0b0655"
   },
   "web.admin.domains.actions.transfer.description": {
-    "text": "Move this domain to a different organization. Preview first to confirm both sides of the move."
+    "text": "Move this domain to a different organization. Preview first to confirm both sides of the move.",
+    "content_hash": "457e852d"
   },
   "web.admin.domains.actions.transfer.toOrgLabel": {
-    "text": "Destination organization ID"
+    "text": "Destination organization ID",
+    "content_hash": "1a3f05c4"
   },
   "web.admin.domains.actions.transfer.fromOrgLabel": {
-    "text": "Expected current organization ID (optional)"
+    "text": "Expected current organization ID (optional)",
+    "content_hash": "f6e75729"
   },
   "web.admin.domains.actions.transfer.fromOrgPlaceholder": {
-    "text": "Assert the current owner before moving"
+    "text": "Assert the current owner before moving",
+    "content_hash": "1ac6c59b"
   },
   "web.admin.domains.actions.transfer.from": {
-    "text": "From"
+    "text": "From",
+    "content_hash": "21819769"
   },
   "web.admin.domains.actions.transfer.to": {
-    "text": "To"
+    "text": "To",
+    "content_hash": "f4b06ef6"
   },
   "web.admin.domains.actions.transfer.orphaned": {
-    "text": "No organization (orphaned)"
+    "text": "No organization (orphaned)",
+    "content_hash": "6f4c745c"
   },
   "web.admin.domains.actions.transfer.button": {
-    "text": "Apply transfer"
+    "text": "Apply transfer",
+    "content_hash": "fb546c5c"
   },
   "web.admin.domains.actions.transfer.confirmTitle": {
-    "text": "Transfer domain?"
+    "text": "Transfer domain?",
+    "content_hash": "801eb986"
   },
   "web.admin.domains.actions.transfer.confirmDescription": {
-    "text": "This moves {domain} to organization {org}. Retype the domain's public ID to continue."
+    "text": "This moves {domain} to organization {org}. Retype the domain's public ID to continue.",
+    "content_hash": "52c8808d"
   },
   "web.admin.domains.actions.transfer.success": {
-    "text": "Domain transferred."
+    "text": "Domain transferred.",
+    "content_hash": "91e681ae"
   },
   "web.admin.domains.actions.remove.button": {
-    "text": "Remove domain"
+    "text": "Remove domain",
+    "content_hash": "5ce43507"
   },
   "web.admin.domains.actions.remove.previewButton": {
-    "text": "Preview removal"
+    "text": "Preview removal",
+    "content_hash": "6b81bd92"
   },
   "web.admin.domains.actions.remove.previewStatus": {
-    "text": "Status:"
+    "text": "Status:",
+    "content_hash": "755c8b2a"
   },
   "web.admin.domains.actions.remove.previewOrg": {
-    "text": "Organization:"
+    "text": "Organization:",
+    "content_hash": "5300e286"
   },
   "web.admin.domains.actions.remove.reassertsSurvivor": {
-    "text": "Another record claims the same domain name and will take over the lookup index."
+    "text": "Another record claims the same domain name and will take over the lookup index.",
+    "content_hash": "902838f4"
   },
   "web.admin.domains.actions.remove.confirmTitle": {
-    "text": "Remove domain?"
+    "text": "Remove domain?",
+    "content_hash": "716dfac9"
   },
   "web.admin.domains.actions.remove.confirmDescription": {
-    "text": "This permanently deletes {domain} and its branding, DNS and configuration records. It cannot be undone. Retype the domain's public ID to continue."
+    "text": "This permanently deletes {domain} and its branding, DNS and configuration records. It cannot be undone. Retype the domain's public ID to continue.",
+    "content_hash": "d0b67b47"
   },
   "web.admin.domains.actions.remove.success": {
-    "text": "Domain removed."
+    "text": "Domain removed.",
+    "content_hash": "2ccaa6d3"
   }
 }

--- a/locales/content/en/admin-organizations.json
+++ b/locales/content/en/admin-organizations.json
@@ -310,5 +310,122 @@
   "web.admin.organizations.detail.reconcile.mode.entitlements_only": {
     "text": "Entitlements only",
     "content_hash": "8cf49a5d"
+  },
+  "web.admin.organizations.addMember.button": {
+    "text": "Add existing account"
+  },
+  "web.admin.organizations.addMember.title": {
+    "text": "Add an existing account"
+  },
+  "web.admin.organizations.addMember.description": {
+    "text": "Add someone who already has an account to {org}. Use this when a person signed up on their own and cannot be invited because the account already exists."
+  },
+  "web.admin.organizations.addMember.searchLabel": {
+    "text": "Email address or account id"
+  },
+  "web.admin.organizations.addMember.searchPlaceholder": {
+    "text": "Search by email address"
+  },
+  "web.admin.organizations.addMember.searchHint": {
+    "text": "Matches part of an email address, or an exact account id."
+  },
+  "web.admin.organizations.addMember.searchError": {
+    "text": "Could not search accounts. Check the connection and try again."
+  },
+  "web.admin.organizations.addMember.searchParseError": {
+    "text": "The account search returned an unexpected response. Results may be incomplete."
+  },
+  "web.admin.organizations.addMember.idle": {
+    "text": "Enter an email address to find the account."
+  },
+  "web.admin.organizations.addMember.noResults": {
+    "text": "No account matches “{term}”."
+  },
+  "web.admin.organizations.addMember.noResultsHint": {
+    "text": "Only existing accounts can be added here. If the person has never signed up, invite them instead."
+  },
+  "web.admin.organizations.addMember.select": {
+    "text": "Select"
+  },
+  "web.admin.organizations.addMember.selectedEyebrow": {
+    "text": "Selected account"
+  },
+  "web.admin.organizations.addMember.change": {
+    "text": "Choose a different account"
+  },
+  "web.admin.organizations.addMember.createdOn": {
+    "text": "Signed up {date}"
+  },
+  "web.admin.organizations.addMember.badges.verified": {
+    "text": "Verified"
+  },
+  "web.admin.organizations.addMember.badges.unverified": {
+    "text": "Not verified"
+  },
+  "web.admin.organizations.addMember.badges.suspended": {
+    "text": "Suspended"
+  },
+  "web.admin.organizations.addMember.badges.alreadyMember": {
+    "text": "Already a member"
+  },
+  "web.admin.organizations.addMember.fields.created": {
+    "text": "Signed up"
+  },
+  "web.admin.organizations.addMember.fields.verified": {
+    "text": "Verification"
+  },
+  "web.admin.organizations.addMember.fields.lastLogin": {
+    "text": "Last sign-in"
+  },
+  "web.admin.organizations.addMember.fields.organizations": {
+    "text": "Current organizations"
+  },
+  "web.admin.organizations.addMember.organizationsUnavailable": {
+    "text": "Could not load this account's current organizations."
+  },
+  "web.admin.organizations.addMember.defaultOrg": {
+    "text": "default"
+  },
+  "web.admin.organizations.addMember.roleLabel": {
+    "text": "Role in this organization"
+  },
+  "web.admin.organizations.addMember.roles.member": {
+    "text": "Member"
+  },
+  "web.admin.organizations.addMember.roles.admin": {
+    "text": "Admin"
+  },
+  "web.admin.organizations.addMember.roles.owner": {
+    "text": "Owner"
+  },
+  "web.admin.organizations.addMember.roleHints.member": {
+    "text": "Everyday access to the organization's secrets and domains."
+  },
+  "web.admin.organizations.addMember.roleHints.admin": {
+    "text": "Can manage members, domains, and organization settings."
+  },
+  "web.admin.organizations.addMember.roleHints.owner": {
+    "text": "Full control, including billing. Grant this only when asked to."
+  },
+  "web.admin.organizations.addMember.submit": {
+    "text": "Add to organization"
+  },
+  "web.admin.organizations.addMember.success": {
+    "text": "Added {account} as {role}."
+  },
+  "web.admin.organizations.addMember.errors.alreadyMember": {
+    "text": "This account is already a member of this organization, with the role {role}. Adding does not change an existing role — use the set-role action for that."
+  },
+  "web.admin.organizations.addMember.errors.alreadyMemberUnknownRole": {
+    "text": "This account is already a member of this organization. Adding does not change an existing role."
+  },
+  "web.admin.organizations.addMember.errors.notFound": {
+    "text": "That account or organization no longer exists. Search again to confirm the account."
+  },
+  "web.admin.organizations.addMember.errors.invalidRole": {
+    "text": "That role was rejected. Choose one of the listed roles and try again."
+  },
+  "web.admin.organizations.addMember.errors.noSelection": {
+    "text": "No account selected."
   }
 }

--- a/locales/content/en/admin-organizations.json
+++ b/locales/content/en/admin-organizations.json
@@ -312,120 +312,159 @@
     "content_hash": "8cf49a5d"
   },
   "web.admin.organizations.addMember.button": {
-    "text": "Add existing account"
+    "text": "Add existing account",
+    "content_hash": "45a3b757"
   },
   "web.admin.organizations.addMember.title": {
-    "text": "Add an existing account"
+    "text": "Add an existing account",
+    "content_hash": "2f676a94"
   },
   "web.admin.organizations.addMember.description": {
-    "text": "Add someone who already has an account to {org}. Use this when a person signed up on their own and cannot be invited because the account already exists."
+    "text": "Add someone who already has an account to {org}. Use this when a person signed up on their own and cannot be invited because the account already exists.",
+    "content_hash": "bb41faa6"
   },
   "web.admin.organizations.addMember.searchLabel": {
-    "text": "Email address or account id"
+    "text": "Email address or account id",
+    "content_hash": "82b3040b"
   },
   "web.admin.organizations.addMember.searchPlaceholder": {
-    "text": "Search by email address"
+    "text": "Search by email address",
+    "content_hash": "b75cc66c"
   },
   "web.admin.organizations.addMember.searchHint": {
-    "text": "Matches part of an email address, or an exact account id."
+    "text": "Matches part of an email address, or an exact account id.",
+    "content_hash": "84547a60"
   },
   "web.admin.organizations.addMember.searchError": {
-    "text": "Could not search accounts. Check the connection and try again."
+    "text": "Could not search accounts. Check the connection and try again.",
+    "content_hash": "4b6caa41"
   },
   "web.admin.organizations.addMember.searchParseError": {
-    "text": "The account search returned an unexpected response. Results may be incomplete."
+    "text": "The account search returned an unexpected response. Results may be incomplete.",
+    "content_hash": "0c814231"
   },
   "web.admin.organizations.addMember.idle": {
-    "text": "Enter an email address to find the account."
+    "text": "Enter an email address to find the account.",
+    "content_hash": "f6340d35"
   },
   "web.admin.organizations.addMember.noResults": {
-    "text": "No account matches “{term}”."
+    "text": "No account matches “{term}”.",
+    "content_hash": "199b662a"
   },
   "web.admin.organizations.addMember.noResultsHint": {
-    "text": "Only existing accounts can be added here. If the person has never signed up, invite them instead."
+    "text": "Only existing accounts can be added here. If the person has never signed up, invite them instead.",
+    "content_hash": "ee90aeeb"
   },
   "web.admin.organizations.addMember.select": {
-    "text": "Select"
+    "text": "Select",
+    "content_hash": "2a78025d"
   },
   "web.admin.organizations.addMember.selectedEyebrow": {
-    "text": "Selected account"
+    "text": "Selected account",
+    "content_hash": "8b63d947"
   },
   "web.admin.organizations.addMember.change": {
-    "text": "Choose a different account"
+    "text": "Choose a different account",
+    "content_hash": "d4fe39ab"
   },
   "web.admin.organizations.addMember.createdOn": {
-    "text": "Signed up {date}"
+    "text": "Signed up {date}",
+    "content_hash": "cfc0e19f"
   },
   "web.admin.organizations.addMember.badges.verified": {
-    "text": "Verified"
+    "text": "Verified",
+    "content_hash": "4f783840"
   },
   "web.admin.organizations.addMember.badges.unverified": {
-    "text": "Not verified"
+    "text": "Not verified",
+    "content_hash": "15133907"
   },
   "web.admin.organizations.addMember.badges.suspended": {
-    "text": "Suspended"
+    "text": "Suspended",
+    "content_hash": "e392a389"
   },
   "web.admin.organizations.addMember.badges.alreadyMember": {
-    "text": "Already a member"
+    "text": "Already a member",
+    "content_hash": "1739ed7c"
   },
   "web.admin.organizations.addMember.fields.created": {
-    "text": "Signed up"
+    "text": "Signed up",
+    "content_hash": "486b3fe0"
   },
   "web.admin.organizations.addMember.fields.verified": {
-    "text": "Verification"
+    "text": "Verification",
+    "content_hash": "7140f4f1"
   },
   "web.admin.organizations.addMember.fields.lastLogin": {
-    "text": "Last sign-in"
+    "text": "Last sign-in",
+    "content_hash": "0b70af7a"
   },
   "web.admin.organizations.addMember.fields.organizations": {
-    "text": "Current organizations"
+    "text": "Current organizations",
+    "content_hash": "cbb5b92f"
   },
   "web.admin.organizations.addMember.organizationsUnavailable": {
-    "text": "Could not load this account's current organizations."
+    "text": "Could not load this account's current organizations.",
+    "content_hash": "a35b6bfc"
   },
   "web.admin.organizations.addMember.defaultOrg": {
-    "text": "default"
+    "text": "default",
+    "content_hash": "37a8eec1"
   },
   "web.admin.organizations.addMember.roleLabel": {
-    "text": "Role in this organization"
+    "text": "Role in this organization",
+    "content_hash": "817475fa"
   },
   "web.admin.organizations.addMember.roles.member": {
-    "text": "Member"
+    "text": "Member",
+    "content_hash": "7c968fb7"
   },
   "web.admin.organizations.addMember.roles.admin": {
-    "text": "Admin"
+    "text": "Admin",
+    "content_hash": "c1c224b0"
   },
   "web.admin.organizations.addMember.roles.owner": {
-    "text": "Owner"
+    "text": "Owner",
+    "content_hash": "4b1b8aa3"
   },
   "web.admin.organizations.addMember.roleHints.member": {
-    "text": "Everyday access to the organization's secrets and domains."
+    "text": "Everyday access to the organization's secrets and domains.",
+    "content_hash": "d0c7439e"
   },
   "web.admin.organizations.addMember.roleHints.admin": {
-    "text": "Can manage members, domains, and organization settings."
+    "text": "Can manage members, domains, and organization settings.",
+    "content_hash": "beaa50d7"
   },
   "web.admin.organizations.addMember.roleHints.owner": {
-    "text": "Full control, including billing. Grant this only when asked to."
+    "text": "Full control, including billing. Grant this only when asked to.",
+    "content_hash": "614ace63"
   },
   "web.admin.organizations.addMember.submit": {
-    "text": "Add to organization"
+    "text": "Add to organization",
+    "content_hash": "0e0cb636"
   },
   "web.admin.organizations.addMember.success": {
-    "text": "Added {account} as {role}."
+    "text": "Added {account} as {role}.",
+    "content_hash": "533be0dc"
   },
   "web.admin.organizations.addMember.errors.alreadyMember": {
-    "text": "This account is already a member of this organization, with the role {role}. Adding does not change an existing role — use the set-role action for that."
+    "text": "This account is already a member of this organization, with the role {role}. Adding does not change an existing role — use the set-role action for that.",
+    "content_hash": "cb6a4774"
   },
   "web.admin.organizations.addMember.errors.alreadyMemberUnknownRole": {
-    "text": "This account is already a member of this organization. Adding does not change an existing role."
+    "text": "This account is already a member of this organization. Adding does not change an existing role.",
+    "content_hash": "035641ec"
   },
   "web.admin.organizations.addMember.errors.notFound": {
-    "text": "That account or organization no longer exists. Search again to confirm the account."
+    "text": "That account or organization no longer exists. Search again to confirm the account.",
+    "content_hash": "bd88db18"
   },
   "web.admin.organizations.addMember.errors.invalidRole": {
-    "text": "That role was rejected. Choose one of the listed roles and try again."
+    "text": "That role was rejected. Choose one of the listed roles and try again.",
+    "content_hash": "eb696a8f"
   },
   "web.admin.organizations.addMember.errors.noSelection": {
-    "text": "No account selected."
+    "text": "No account selected.",
+    "content_hash": "dd15bb5b"
   }
 }

--- a/locales/content/en/admin-secrets.json
+++ b/locales/content/en/admin-secrets.json
@@ -1,15 +1,30 @@
 {
   "web.admin.secrets.title": {
-    "text": "Secrets",
+    "text": "Secret Records",
     "content_hash": "d8707d41"
   },
   "web.admin.secrets.description": {
-    "text": "Inspect a secret's receipt and delete it without SSH — look it up by its key.",
+    "text": "Look up the record kept about a secret — its state, timestamps, receipt, and owner.",
     "content_hash": "07775a11"
+  },
+  "web.admin.secrets.capability.title": {
+    "text": "Metadata only"
+  },
+  "web.admin.secrets.capability.canRead": {
+    "text": "Reads a secret's metadata and its receipt: state, timestamps, owner, and the size of the stored ciphertext."
+  },
+  "web.admin.secrets.capability.cannotRead": {
+    "text": "Cannot decrypt or display secret content. The endpoint behind this screen never returns it."
+  },
+  "web.admin.secrets.capability.canDelete": {
+    "text": "Can permanently delete a secret and its receipt, which destroys the content without ever revealing it."
   },
   "web.admin.secrets.lookup.label": {
     "text": "Secret key",
     "content_hash": "f47a99eb"
+  },
+  "web.admin.secrets.lookup.hint": {
+    "text": "The identifier from the secret's link — not the secret content."
   },
   "web.admin.secrets.lookup.placeholder": {
     "text": "Secret identifier",
@@ -20,11 +35,11 @@
     "content_hash": "504101bc"
   },
   "web.admin.secrets.lookup.resultTitle": {
-    "text": "Secret {shortid}",
+    "text": "Secret record {shortid}",
     "content_hash": "8b311d32"
   },
   "web.admin.secrets.lookup.notFound": {
-    "text": "Secret not found",
+    "text": "No record found",
     "content_hash": "70a9532c"
   },
   "web.admin.secrets.lookup.notFoundDescription": {
@@ -32,7 +47,7 @@
     "content_hash": "9f068a81"
   },
   "web.admin.secrets.lookup.loadError": {
-    "text": "Could not load this secret.",
+    "text": "Could not load this record.",
     "content_hash": "c96672e4"
   },
   "web.admin.secrets.lookup.retry": {
@@ -64,7 +79,7 @@
     "content_hash": "1b28d178"
   },
   "web.admin.secrets.sections.secret": {
-    "text": "Secret",
+    "text": "Secret record",
     "content_hash": "7e32a729"
   },
   "web.admin.secrets.sections.receipt": {

--- a/locales/content/en/admin-secrets.json
+++ b/locales/content/en/admin-secrets.json
@@ -4,7 +4,7 @@
     "content_hash": "a8a2d0e4"
   },
   "web.admin.secrets.description": {
-    "text": "Look up the record kept about a secret — its state, timestamps, receipt, and owner.",
+    "text": "Look up state, timestamps, receipt, etc.",
     "content_hash": "faca2418"
   },
   "web.admin.secrets.capability.title": {

--- a/locales/content/en/admin-secrets.json
+++ b/locales/content/en/admin-secrets.json
@@ -1,30 +1,35 @@
 {
   "web.admin.secrets.title": {
-    "text": "Secret Records",
-    "content_hash": "d8707d41"
+    "text": "Secret Receipts",
+    "content_hash": "a8a2d0e4"
   },
   "web.admin.secrets.description": {
     "text": "Look up the record kept about a secret — its state, timestamps, receipt, and owner.",
-    "content_hash": "07775a11"
+    "content_hash": "faca2418"
   },
   "web.admin.secrets.capability.title": {
-    "text": "Metadata only"
+    "text": "Metadata only",
+    "content_hash": "df0453d1"
   },
   "web.admin.secrets.capability.canRead": {
-    "text": "Reads a secret's metadata and its receipt: state, timestamps, owner, and the size of the stored ciphertext."
+    "text": "Reads a secret's metadata and its receipt: state, timestamps, owner, and the size of the stored ciphertext.",
+    "content_hash": "d438ecc7"
   },
   "web.admin.secrets.capability.cannotRead": {
-    "text": "Cannot decrypt or display secret content. The endpoint behind this screen never returns it."
+    "text": "Cannot decrypt or display secret content. The endpoint behind this screen never returns it.",
+    "content_hash": "7f69f222"
   },
   "web.admin.secrets.capability.canDelete": {
-    "text": "Can permanently delete a secret and its receipt, which destroys the content without ever revealing it."
+    "text": "Can permanently delete a secret and its receipt, which destroys the content without ever revealing it.",
+    "content_hash": "77f2bc7e"
   },
   "web.admin.secrets.lookup.label": {
     "text": "Secret key",
     "content_hash": "f47a99eb"
   },
   "web.admin.secrets.lookup.hint": {
-    "text": "The identifier from the secret's link — not the secret content."
+    "text": "The identifier from the secret's link — not the secret content.",
+    "content_hash": "acfbc352"
   },
   "web.admin.secrets.lookup.placeholder": {
     "text": "Secret identifier",
@@ -36,11 +41,11 @@
   },
   "web.admin.secrets.lookup.resultTitle": {
     "text": "Secret record {shortid}",
-    "content_hash": "8b311d32"
+    "content_hash": "ee06d765"
   },
   "web.admin.secrets.lookup.notFound": {
     "text": "No record found",
-    "content_hash": "70a9532c"
+    "content_hash": "40f4d9e9"
   },
   "web.admin.secrets.lookup.notFoundDescription": {
     "text": "No secret exists with this key. It may have expired or been deleted.",
@@ -48,7 +53,7 @@
   },
   "web.admin.secrets.lookup.loadError": {
     "text": "Could not load this record.",
-    "content_hash": "c96672e4"
+    "content_hash": "de77cc72"
   },
   "web.admin.secrets.lookup.retry": {
     "text": "Retry",
@@ -80,7 +85,7 @@
   },
   "web.admin.secrets.sections.secret": {
     "text": "Secret record",
-    "content_hash": "7e32a729"
+    "content_hash": "263813c6"
   },
   "web.admin.secrets.sections.receipt": {
     "text": "Receipt",

--- a/locales/content/en/admin-secrets.json
+++ b/locales/content/en/admin-secrets.json
@@ -5,7 +5,7 @@
   },
   "web.admin.secrets.description": {
     "text": "Look up state, timestamps, receipt, etc.",
-    "content_hash": "faca2418"
+    "content_hash": "91fba2a1"
   },
   "web.admin.secrets.capability.title": {
     "text": "Metadata only",

--- a/locales/content/eo/admin-colonel.json
+++ b/locales/content/eo/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Uzanta administrado",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Administrado de sekretoj",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Propraj domajnoj",
     "source_hash": "6170ab94"

--- a/locales/content/es/admin-colonel.json
+++ b/locales/content/es/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Gestión de Usuarios",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Gestión de Secretos",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Dominios Personalizados",
     "source_hash": "6170ab94"

--- a/locales/content/fr_CA/admin-colonel.json
+++ b/locales/content/fr_CA/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Gestion des utilisateurs",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Gestion des secrets",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Domaines personnalisés",
     "source_hash": "6170ab94"

--- a/locales/content/fr_FR/admin-colonel.json
+++ b/locales/content/fr_FR/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Gestion des utilisateurs",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Gestion des secrets",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Domaines personnalisés",
     "source_hash": "6170ab94"

--- a/locales/content/he/admin-colonel.json
+++ b/locales/content/he/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "ניהול משתמשים",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "ניהול סודות",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "דומיינים מותאמים אישית",
     "source_hash": "6170ab94"

--- a/locales/content/hu/admin-colonel.json
+++ b/locales/content/hu/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Felhasználók kezelése",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Titkok kezelése",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Egyéni domainek",
     "source_hash": "6170ab94"

--- a/locales/content/it_IT/admin-colonel.json
+++ b/locales/content/it_IT/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Gestione utenti",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Gestione segreti",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Domini personalizzati",
     "source_hash": "6170ab94"

--- a/locales/content/ja/admin-colonel.json
+++ b/locales/content/ja/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "ユーザー管理",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "シークレット管理",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "カスタムドメイン",
     "source_hash": "6170ab94"

--- a/locales/content/ko/admin-colonel.json
+++ b/locales/content/ko/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "사용자 관리",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "비밀 메시지 관리",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "사용자 지정 도메인",
     "source_hash": "6170ab94"

--- a/locales/content/mi_NZ/admin-colonel.json
+++ b/locales/content/mi_NZ/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Whakahaere Kaiwhakamahi",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Whakahaere Karere Huna",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Rohe Ritenga",
     "source_hash": "6170ab94"

--- a/locales/content/nl/admin-colonel.json
+++ b/locales/content/nl/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Gebruikersbeheer",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Berichtenbeheer",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Aangepaste domeinen",
     "source_hash": "6170ab94"

--- a/locales/content/pl/admin-colonel.json
+++ b/locales/content/pl/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Zarządzanie użytkownikami",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Zarządzanie sekretami",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Domeny niestandardowe",
     "source_hash": "6170ab94"

--- a/locales/content/pt_BR/admin-colonel.json
+++ b/locales/content/pt_BR/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Gerenciamento de Usuários",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Gerenciamento de Mensagens Confidenciais",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Domínios Personalizados",
     "source_hash": "6170ab94"

--- a/locales/content/pt_PT/admin-colonel.json
+++ b/locales/content/pt_PT/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Gestão de utilizadores",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Gestão de mensagens confidenciais",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Domínios personalizados",
     "source_hash": "6170ab94"

--- a/locales/content/ru/admin-colonel.json
+++ b/locales/content/ru/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Управление пользователями",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Управление секретами",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Пользовательские домены",
     "source_hash": "6170ab94"

--- a/locales/content/sl_SI/admin-colonel.json
+++ b/locales/content/sl_SI/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Upravljanje uporabnikov",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Upravljanje skrivnosti",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Lastne domene",
     "source_hash": "6170ab94"

--- a/locales/content/sv_SE/admin-colonel.json
+++ b/locales/content/sv_SE/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Användarhantering",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Hemlighetshantering",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Anpassade domäner",
     "source_hash": "6170ab94"

--- a/locales/content/tr/admin-colonel.json
+++ b/locales/content/tr/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Kullanıcı Yönetimi",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Gizli Mesaj Yönetimi",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Özel Alan Adları",
     "source_hash": "6170ab94"

--- a/locales/content/uk/admin-colonel.json
+++ b/locales/content/uk/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Керування користувачами",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Керування таємницями",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Власні домени",
     "source_hash": "6170ab94"

--- a/locales/content/vi/admin-colonel.json
+++ b/locales/content/vi/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "Quản lý người dùng",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "Quản lý bí mật",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "Tên miền tùy chỉnh",
     "source_hash": "6170ab94"

--- a/locales/content/zh/admin-colonel.json
+++ b/locales/content/zh/admin-colonel.json
@@ -563,10 +563,6 @@
     "text": "用户管理",
     "source_hash": "fe45f3a1"
   },
-  "web.colonel.titles.secrets": {
-    "text": "内容管理",
-    "source_hash": "af69773b"
-  },
   "web.colonel.titles.domains": {
     "text": "自定义域名",
     "source_hash": "6170ab94"

--- a/spec/integration/all/colonel_customer_support_spec.rb
+++ b/spec/integration/all/colonel_customer_support_spec.rb
@@ -232,6 +232,102 @@ RSpec.describe 'Colonel customer support features', type: :integration do
   end
 
   # ---------------------------------------------------------------------------
+  # 2b. Activity read-out (GetUserDetails details.secrets / details.receipts)
+  #
+  # These sections used to walk the entire `secret:*:object` and
+  # `receipt:*:object` keyspaces, loading every object one at a time to filter
+  # by owner — the 10k guard counted MATCHES, so it never tripped for a normal
+  # user and the page timed out. They now read the per-owner indexes
+  # (customer:<objid>:secrets / :receipts). What is asserted here is the
+  # CONTRACT: the right items, count == items.size, an honest `truncated` flag,
+  # and independent degradation.
+  # ---------------------------------------------------------------------------
+  describe 'GetUserDetails activity read-out' do
+    def user_details(target)
+      logic = ColonelAPI::Logic::Colonel::GetUserDetails.new(
+        strategy_result_for(colonel), { 'user_id' => target.extid },
+      )
+      logic.raise_concerns
+      logic.process
+    end
+
+    let(:owner) { create_customer(email: "activity-#{SecureRandom.hex(4)}@example.com") }
+
+    it 'lists only the owner\'s secrets, newest first, with count == items.size' do
+      other = create_customer(email: "other-#{SecureRandom.hex(4)}@example.com")
+      _r1, first  = Onetime::Receipt.spawn_pair(owner.objid, 3600, 'mine one')
+      _r2, second = Onetime::Receipt.spawn_pair(owner.objid, 3600, 'mine two')
+      Onetime::Receipt.spawn_pair(other.objid, 3600, 'not mine')
+
+      secrets = user_details(owner)[:details][:secrets]
+
+      expect(secrets[:items].map { |s| s[:secret_id] }).to eq([second.objid, first.objid])
+      expect(secrets[:count]).to eq(secrets[:items].size)
+      expect(secrets[:truncated]).to be(false)
+    end
+
+    it 'drops a destroyed secret from the list (index and counter move together)' do
+      _r1, keep    = Onetime::Receipt.spawn_pair(owner.objid, 3600, 'keep')
+      _r2, destroy = Onetime::Receipt.spawn_pair(owner.objid, 3600, 'destroy')
+      destroy.destroy!
+
+      secrets = user_details(owner)[:details][:secrets]
+
+      expect(secrets[:items].map { |s| s[:secret_id] }).to eq([keep.objid])
+      expect(secrets[:count]).to eq(1)
+    end
+
+    it 'reports an empty, non-truncated read-out for a customer with no activity' do
+      details = user_details(owner)[:details]
+
+      expect(details[:secrets]).to eq(count: 0, items: [], truncated: false)
+      expect(details[:receipts]).to eq(count: 0, items: [], truncated: false)
+    end
+
+    it 'lists receipts off the per-customer index' do
+      receipt, _secret = Onetime::Receipt.spawn_pair(owner.objid, 3600, 'with receipt')
+      owner.add_receipt(receipt)
+
+      receipts = user_details(owner)[:details][:receipts]
+
+      expect(receipts[:items].map { |r| r[:receipt_id] }).to eq([receipt.objid])
+      expect(receipts[:count]).to eq(1)
+      expect(receipts[:truncated]).to be(false)
+    end
+
+    it 'flags truncation instead of implying the short list is complete' do
+      # Counter says there are more secrets than the index can show (the
+      # pre-index / straddling-rollout case).
+      Onetime::Receipt.spawn_pair(owner.objid, 3600, 'only indexed one')
+      owner.secrets_active.reset(5)
+
+      secrets = user_details(owner)[:details][:secrets]
+
+      expect(secrets[:items].size).to eq(1)
+      expect(secrets[:count]).to eq(1)
+      expect(secrets[:truncated]).to be(true)
+    end
+
+    it 'still renders identity, plan and billing when the secrets read blows up' do
+      logic = ColonelAPI::Logic::Colonel::GetUserDetails.new(
+        strategy_result_for(colonel), { 'user_id' => owner.extid },
+      )
+      logic.raise_concerns
+      allow(logic).to receive(:collect_secrets).and_raise(StandardError, 'datastore down')
+
+      data = logic.process
+
+      # The failing section degrades to empty-but-honest...
+      expect(data[:details][:secrets]).to eq(count: 0, items: [], truncated: true)
+      # ...and the rest of the record renders.
+      expect(data[:record][:extid]).to eq(owner.extid)
+      expect(data[:record][:email]).to eq(owner.email)
+      expect(data[:details][:receipts][:truncated]).to be(false)
+      expect(data[:details][:billing]).to include(:enabled, :plan_id)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # 3. Account suspend
   # ---------------------------------------------------------------------------
   describe 'SuspendUser / UnsuspendUser' do

--- a/src/apps/admin/components/RevealEmail.vue
+++ b/src/apps/admin/components/RevealEmail.vue
@@ -17,6 +17,13 @@
    * boundary. Toggling reveal exposes the address plus a copy affordance.
    *
    * Null/empty → an em dash (matches the rest of the admin read-outs).
+   *
+   * CLICK CONTAINMENT: this component is rendered inside CLICKABLE TABLE ROWS
+   * across the console (customers, sessions, organizations), where the row's
+   * `@click` opens a detail drawer. Its interactive controls therefore stop
+   * propagation — revealing or copying an address must not also open the
+   * drawer. The address TEXT deliberately does NOT stop propagation, so
+   * clicking the cell still activates the row like every other cell.
    */
   const props = defineProps<{
     /** The address to display, or null/empty for the em-dash placeholder. */
@@ -90,16 +97,23 @@
       :aria-pressed="revealed"
       data-testid="reveal-email-toggle"
       class="shrink-0 rounded text-gray-400 hover:text-gray-700 focus:ring-2 focus:ring-brand-500 focus:outline-none dark:text-gray-500 dark:hover:text-gray-200"
-      @click="toggle">
+      @click.stop="toggle">
       <OIcon
         collection="heroicons"
         :name="revealed ? 'eye-slash' : 'eye'"
         size="4" />
     </button>
-    <CopyButton
+    <!-- CopyButton is a shared, app-wide primitive, so containment is applied
+         here (at this component's boundary) rather than changing copy
+         behaviour for every other consumer in the app. -->
+    <span
       v-if="revealed && email"
-      :text="email"
-      :tooltip="t('web.admin.kit.revealEmail.copy')"
-      testid="reveal-email-copy" />
+      class="inline-flex shrink-0"
+      @click.stop>
+      <CopyButton
+        :text="email"
+        :tooltip="t('web.admin.kit.revealEmail.copy')"
+        testid="reveal-email-copy" />
+    </span>
   </span>
 </template>

--- a/src/apps/admin/components/billing/StripeOrganizationsSection.vue
+++ b/src/apps/admin/components/billing/StripeOrganizationsSection.vue
@@ -1,0 +1,269 @@
+<!-- src/apps/admin/components/billing/StripeOrganizationsSection.vue -->
+
+<script setup lang="ts">
+  import RevealEmail from '@/apps/admin/components/RevealEmail.vue';
+  import { DataTable, FilterBar, KitPagination } from '@/apps/admin/components/kit';
+  import type { DataTableColumn } from '@/apps/admin/components/kit';
+  import { useAdminBilling } from '@/apps/admin/stores/useAdminBilling';
+  import type { ColonelStripeOrganization } from '@/apps/admin/stores/useAdminBilling';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import CopyButton from '@/shared/components/ui/CopyButton.vue';
+  import { storeToRefs } from 'pinia';
+  import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  /**
+   * Stripe customers roster — the "who is actually billed" half of the billing
+   * screen, next to the config-vs-live catalog drift.
+   *
+   * Backed by the index the Organization model already declares
+   * (`organization:stripe_customer_id_index`), so this is a bounded, paged read
+   * rather than a scan of every organization: one server page per request via
+   * {@link useAdminBilling}, with a debounced server-side `search` over the
+   * Stripe customer id.
+   *
+   * Stripe ids live ONLY on Organization (Customer#stripe_customer_id is a
+   * deprecated, unindexed field), so a "customer with a Stripe id" is reached
+   * through its org — every row links to /colonel/organizations/:id, which is
+   * where the member roster and the investigate/reconcile actions live.
+   *
+   * Read-only: nothing here mutates, so nothing is audited (CONTRACT 4).
+   */
+  const { t } = useI18n();
+
+  const store = useAdminBilling();
+  const { stripeOrganizations, pagination, loading, error, unavailable, capped, staleCount } =
+    storeToRefs(store);
+
+  const searchTerm = ref('');
+  const activeSearch = ref('');
+
+  const hasActiveFilters = computed(() => searchTerm.value !== '');
+
+  const columns = computed<DataTableColumn<ColonelStripeOrganization>[]>(() => [
+    { key: 'organization', label: t('web.admin.billing.stripeOrgs.columns.organization') },
+    { key: 'owner', label: t('web.admin.billing.stripeOrgs.columns.owner') },
+    { key: 'plan', label: t('web.admin.billing.stripeOrgs.columns.plan') },
+    { key: 'subscription', label: t('web.admin.billing.stripeOrgs.columns.subscription') },
+    { key: 'stripeCustomer', label: t('web.admin.billing.stripeOrgs.columns.stripeCustomer') },
+  ]);
+
+  /** Fetch one server page with the committed search. Errors land in the store. */
+  async function fetchPage(targetPage = 1): Promise<void> {
+    try {
+      await store.fetchStripeOrganizations(targetPage, {
+        search: activeSearch.value || undefined,
+      });
+    } catch {
+      // Network/HTTP failure is captured in `store.error`; the banner + retry
+      // button below handle it. Swallow so it never becomes unhandled.
+    }
+  }
+
+  // Debounce so we issue one request per pause, not per keystroke. The no-op
+  // guard keeps the programmatic reset in onClear() from double-fetching
+  // (the AdminCustomers form of this watcher — the fixed one).
+  let searchTimer: ReturnType<typeof setTimeout> | null = null;
+  watch(searchTerm, (value) => {
+    if (searchTimer) clearTimeout(searchTimer);
+    if (value.trim() === activeSearch.value) return;
+    searchTimer = setTimeout(() => {
+      activeSearch.value = value.trim();
+      fetchPage(1);
+    }, 300);
+  });
+  onBeforeUnmount(() => {
+    if (searchTimer) clearTimeout(searchTimer);
+  });
+
+  function onClear(): void {
+    // Cancel any in-flight debounce so the reset below doesn't fire a second,
+    // late request on top of this one.
+    if (searchTimer) clearTimeout(searchTimer);
+    searchTerm.value = '';
+    activeSearch.value = '';
+    fetchPage(1);
+  }
+
+  function onPageChange(targetPage: number): void {
+    fetchPage(targetPage);
+  }
+
+  function onPerPageChange(perPage: number): void {
+    // The composable owns perPage (reconciled from the server echo); set it
+    // then re-fetch the first page at the new size.
+    store.perPage = perPage;
+    fetchPage(1);
+  }
+
+  /** Display label for a row: name, then billing/owner email, then the extid. */
+  function orgLabel(row: ColonelStripeOrganization): string {
+    return row.display_name || row.billing_email || row.extid;
+  }
+
+  onMounted(() => fetchPage(1));
+</script>
+
+<template>
+  <section data-testid="billing-stripe-orgs">
+    <div class="mb-3 flex flex-wrap items-baseline justify-between gap-2">
+      <h3 class="text-lg font-medium text-gray-900 dark:text-white">
+        {{ t('web.admin.billing.stripeOrgs.title') }}
+        <span
+          v-if="pagination"
+          class="ml-1 text-sm font-normal text-gray-500 tabular-nums dark:text-gray-400"
+          data-testid="billing-stripe-orgs-count">
+          ({{ pagination.total_count }})
+        </span>
+      </h3>
+      <p class="text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.billing.stripeOrgs.description') }}
+      </p>
+    </div>
+
+    <!-- The roster endpoint is not served by this backend build. Informational,
+         not an error: there is nothing for the operator to retry. -->
+    <div
+      v-if="unavailable"
+      class="flex items-start gap-2 rounded-md border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-800 dark:bg-gray-800/40"
+      role="status"
+      data-testid="billing-stripe-orgs-unavailable">
+      <OIcon
+        collection="heroicons"
+        name="information-circle"
+        size="5"
+        class="mt-0.5 shrink-0 text-gray-500 dark:text-gray-400" />
+      <span class="text-sm text-gray-700 dark:text-gray-300">
+        {{ t('web.admin.billing.stripeOrgs.unavailable') }}
+      </span>
+    </div>
+
+    <template v-else>
+      <!-- Network/HTTP error banner (validation mismatches degrade to empty). -->
+      <div
+        v-if="error"
+        class="mb-4 flex items-center justify-between gap-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-900/20"
+        role="alert"
+        data-testid="billing-stripe-orgs-error">
+        <span class="text-sm text-red-800 dark:text-red-200">
+          {{ t('web.admin.billing.stripeOrgs.loadError') }}
+        </span>
+        <button
+          type="button"
+          class="inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-800 hover:bg-red-100 focus:ring-2 focus:ring-red-500 focus:outline-none dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/40"
+          data-testid="billing-stripe-orgs-retry"
+          @click="fetchPage(pagination?.page ?? 1)">
+          <OIcon
+            collection="heroicons"
+            name="arrow-path"
+            size="4" />
+          {{ t('web.admin.billing.retry') }}
+        </button>
+      </div>
+
+      <!-- The server's index scan is bounded: when it caps, total_count is a
+           FLOOR. Say so rather than letting "(N)" read as the population. -->
+      <div
+        v-if="capped || staleCount > 0"
+        class="mb-4 flex flex-col gap-1 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-900/50 dark:bg-amber-900/20 dark:text-amber-200"
+        role="status"
+        data-testid="billing-stripe-orgs-caveat">
+        <span v-if="capped">{{ t('web.admin.billing.stripeOrgs.capped') }}</span>
+        <span v-if="staleCount > 0">
+          {{ t('web.admin.billing.stripeOrgs.stale', { count: staleCount }) }}
+        </span>
+      </div>
+
+      <div class="mb-4">
+        <FilterBar
+          v-model:search="searchTerm"
+          :search-placeholder="t('web.admin.billing.stripeOrgs.searchPlaceholder')"
+          :has-active-filters="hasActiveFilters"
+          testid="billing-stripe-orgs-filterbar"
+          @clear="onClear" />
+      </div>
+
+      <div
+        class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
+        <DataTable
+          :columns="columns"
+          :rows="stripeOrganizations"
+          row-key="extid"
+          :loading="loading"
+          :empty-text="
+            activeSearch
+              ? t('web.admin.billing.stripeOrgs.emptySearch')
+              : t('web.admin.billing.stripeOrgs.empty')
+          "
+          testid="billing-stripe-orgs-table">
+          <!-- The org is the route to everything else (members, investigate,
+               reconcile), so the name cell is the link — keyboard reachable,
+               unlike a clickable row. -->
+          <template #cell-organization="{ row }">
+            <router-link
+              :to="{ name: 'AdminOrganizationDetail', params: { id: row.extid } }"
+              :data-testid="`stripe-org-link-${row.extid}`"
+              class="inline-flex items-center gap-1 font-medium text-brand-600 hover:text-brand-800 hover:underline focus:ring-2 focus:ring-brand-500 focus:outline-none dark:text-brand-400 dark:hover:text-brand-300">
+              {{ orgLabel(row) }}
+              <OIcon
+                collection="heroicons"
+                name="arrow-top-right-on-square"
+                size="3"
+                class="shrink-0" />
+            </router-link>
+            <div class="mt-0.5 font-mono text-xs text-gray-400 tabular-nums dark:text-gray-500">
+              {{ row.extid }}
+            </div>
+          </template>
+
+          <template #cell-owner="{ row }">
+            <RevealEmail :email="row.owner_email ?? row.billing_email ?? null" />
+          </template>
+
+          <template #cell-plan="{ row }">
+            {{ row.planid || t('web.admin.billing.stripeOrgs.none') }}
+          </template>
+
+          <template #cell-subscription="{ row }">
+            <span
+              v-if="row.subscription_status"
+              class="inline-flex items-center rounded px-2 py-0.5 text-xs font-medium"
+              :class="
+                row.subscription_status === 'active' || row.subscription_status === 'trialing'
+                  ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200'
+                  : 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200'
+              ">
+              {{ row.subscription_status }}
+            </span>
+            <span
+              v-else
+              class="text-gray-400 dark:text-gray-600">
+              —
+            </span>
+          </template>
+
+          <template #cell-stripeCustomer="{ row }">
+            <span class="inline-flex items-center gap-1.5">
+              <span
+                class="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs break-all text-gray-700 tabular-nums dark:bg-gray-800 dark:text-gray-300">
+                {{ row.stripe_customer_id }}
+              </span>
+              <CopyButton
+                :text="row.stripe_customer_id"
+                :tooltip="t('web.admin.billing.stripeOrgs.copyStripeId')"
+                :testid="`stripe-org-copy-${row.extid}`" />
+            </span>
+          </template>
+        </DataTable>
+      </div>
+
+      <KitPagination
+        v-if="pagination"
+        :pagination="pagination"
+        :loading="loading"
+        class="mt-4"
+        @update:page="onPageChange"
+        @update:per-page="onPerPageChange" />
+    </template>
+  </section>
+</template>

--- a/src/apps/admin/components/domains/DomainProbeResult.vue
+++ b/src/apps/admin/components/domains/DomainProbeResult.vue
@@ -1,0 +1,187 @@
+<!-- src/apps/admin/components/domains/DomainProbeResult.vue -->
+
+<script setup lang="ts">
+  import { JsonViewer } from '@/apps/admin/components/kit';
+  import type { ColonelDomainProbeDetails } from '@/schemas/api/internal/responses/colonel-domaintoolbox';
+  import { computed } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  /**
+   * Read-out for one `GET /api/colonel/domains/:extid/probe` result.
+   *
+   * Presentational only — the caller owns the request (see
+   * `useAdminDomains.probe`). Surfaces the op's honest health classification,
+   * the HTTP arm and the TLS-certificate arm, then the raw payload via
+   * {@link JsonViewer} for anything the summary doesn't name.
+   *
+   * A probe reaches the network but mutates nothing, so nothing here is guarded
+   * and no audit is written.
+   */
+  const props = defineProps<{
+    /** The probe payload (`details` of the wrapped response). */
+    details: ColonelDomainProbeDetails;
+    /** The probed hostname, echoed next to the health pill. */
+    domain?: string;
+  }>();
+
+  const { t } = useI18n();
+
+  /** Health pill colour keyed by the op's classification. */
+  const healthClass = computed(() => {
+    switch (props.details.health) {
+      case 'healthy':
+        return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
+      case 'ssl_expiring_soon':
+      case 'http_error':
+        return 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200';
+      default:
+        return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200';
+    }
+  });
+
+  const http = computed(() => props.details.http);
+  const ssl = computed(() => props.details.ssl ?? null);
+
+  type ProbeField = { key: string; label: string; value: string; mono?: boolean };
+
+  /** HTTP arm: either a status line, or the transport error that replaced it. */
+  const httpFields = computed<ProbeField[]>(() => {
+    const h = http.value;
+    const rows: ProbeField[] = [];
+    if (h.status_code !== undefined) {
+      rows.push({
+        key: 'status',
+        label: t('web.admin.domains.probe.fields.httpStatus'),
+        value: [h.status_code, h.status_message].filter(Boolean).join(' '),
+        mono: true,
+      });
+    }
+    if (h.error) {
+      rows.push({
+        key: 'httpError',
+        label: t('web.admin.domains.probe.fields.httpError'),
+        value: h.message ? `${h.error}: ${h.message}` : h.error,
+      });
+    }
+    return rows;
+  });
+
+  /**
+   * TLS arm. Absent entirely on failure branches that never reached a
+   * certificate (connection refused, timeout) — the caller sees the notice
+   * below instead of empty rows.
+   */
+  const sslFields = computed<ProbeField[]>(() => {
+    const s = ssl.value;
+    if (!s) return [];
+
+    const rows: ProbeField[] = [];
+    if (s.error) {
+      rows.push({
+        key: 'sslError',
+        label: t('web.admin.domains.probe.fields.sslError'),
+        value: s.error,
+      });
+      return rows;
+    }
+    if (s.issuer) {
+      rows.push({
+        key: 'issuer',
+        label: t('web.admin.domains.probe.fields.issuer'),
+        value: s.issuer,
+      });
+    }
+    if (s.subject) {
+      rows.push({
+        key: 'subject',
+        label: t('web.admin.domains.probe.fields.subject'),
+        value: s.subject,
+        mono: true,
+      });
+    }
+    if (s.not_after) {
+      rows.push({
+        key: 'notAfter',
+        label: t('web.admin.domains.probe.fields.notAfter'),
+        value:
+          s.days_until_expiry === undefined
+            ? s.not_after
+            : t('web.admin.domains.probe.fields.expiresIn', {
+                date: s.not_after,
+                days: s.days_until_expiry,
+              }),
+      });
+    }
+    return rows;
+  });
+
+  /** True once we know a certificate arm was returned but is unusable. */
+  const certUnusable = computed(
+    () => ssl.value !== null && (ssl.value?.expired === true || ssl.value?.not_yet_valid === true)
+  );
+</script>
+
+<template>
+  <div
+    class="space-y-4"
+    data-testid="probe-result">
+    <!-- Health headline -->
+    <div class="flex flex-wrap items-center gap-3">
+      <span class="text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.domains.probe.healthLabel') }}
+      </span>
+      <span
+        :class="['inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium', healthClass]"
+        data-testid="probe-health">
+        {{ details.health }}
+      </span>
+      <span
+        v-if="domain"
+        class="font-mono text-xs text-gray-500 dark:text-gray-400">
+        {{ domain }}
+      </span>
+      <span
+        v-if="certUnusable"
+        class="inline-flex items-center rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-800 dark:bg-red-900 dark:text-red-200"
+        data-testid="probe-cert-invalid">
+        {{ t('web.admin.domains.probe.certInvalid') }}
+      </span>
+    </div>
+
+    <!-- Summary rows -->
+    <dl
+      v-if="httpFields.length || sslFields.length"
+      class="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2">
+      <div
+        v-for="field in [...httpFields, ...sslFields]"
+        :key="field.key"
+        :data-testid="`probe-${field.key}`">
+        <dt
+          class="font-brand text-[11px] font-semibold tracking-[0.1em] text-gray-500 uppercase dark:text-gray-400">
+          {{ field.label }}
+        </dt>
+        <dd
+          :class="[
+            'mt-1 text-sm break-words text-gray-900 dark:text-gray-100',
+            field.mono ? 'font-mono tabular-nums' : '',
+          ]">
+          {{ field.value }}
+        </dd>
+      </div>
+    </dl>
+
+    <p
+      v-if="!ssl"
+      class="text-xs text-gray-500 dark:text-gray-400"
+      data-testid="probe-no-cert">
+      {{ t('web.admin.domains.probe.noCertificate') }}
+    </p>
+
+    <!-- Full payload. Probe results carry no secrets (hostname, status, cert
+         metadata), so passing them through is safe. -->
+    <JsonViewer
+      :data="details"
+      :expand-depth="2"
+      testid="probe-json" />
+  </div>
+</template>

--- a/src/apps/admin/components/domains/DomainStateBadge.vue
+++ b/src/apps/admin/components/domains/DomainStateBadge.vue
@@ -1,0 +1,60 @@
+<!-- src/apps/admin/components/domains/DomainStateBadge.vue -->
+
+<script setup lang="ts">
+  import { computed } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  /**
+   * Verification-state pill for a custom domain.
+   *
+   * Presentational only. Extracted so the domains LIST, its detail drawer and
+   * the full detail page render the operator-facing state with one set of
+   * colours and one label map — the previous copies drifted apart.
+   *
+   * The state string comes straight from the backend
+   * (`CustomDomain#verification_state`): verified / resolving / pending, with
+   * anything unknown rendered verbatim rather than swallowed.
+   */
+  const props = withDefaults(
+    defineProps<{
+      /** Backend verification state (verified | resolving | pending | …). */
+      state: string;
+      /** Optional test id for the pill. */
+      testid?: string;
+    }>(),
+    { testid: undefined }
+  );
+
+  const { t } = useI18n();
+
+  const badgeClass = computed(() => {
+    switch (props.state) {
+      case 'verified':
+        return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
+      case 'pending':
+        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200';
+      case 'resolving':
+        return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200';
+      default:
+        return 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200';
+    }
+  });
+
+  /**
+   * Reuses the existing colonel status labels. Unknown states fall back to the
+   * raw value (vue-i18n returns the key when missing, so we guard explicitly).
+   */
+  const label = computed(() => {
+    const key = `web.colonel.customDomains.status.${props.state}`;
+    const translated = t(key);
+    return translated === key ? props.state : translated;
+  });
+</script>
+
+<template>
+  <span
+    :class="['inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium', badgeClass]"
+    :data-testid="testid">
+    {{ label }}
+  </span>
+</template>

--- a/src/apps/admin/components/organizations/AddMemberModal.vue
+++ b/src/apps/admin/components/organizations/AddMemberModal.vue
@@ -1,0 +1,641 @@
+<!-- src/apps/admin/components/organizations/AddMemberModal.vue -->
+
+<script setup lang="ts">
+  import RevealEmail from '@/apps/admin/components/RevealEmail.vue';
+  import { AdminModal } from '@/apps/admin/components/kit';
+  import {
+    MEMBERSHIP_ROLES,
+    type AddMembershipRequest,
+    type MembershipRole,
+  } from '@/apps/admin/components/organizations/membershipSchemas';
+  import { usePaginatedFetch } from '@/apps/admin/composables/usePaginatedFetch';
+  import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
+  import type {
+    ColonelUser,
+    ColonelUserDetailResponse,
+    ColonelUsersResponse,
+  } from '@/schemas/api/internal/responses/colonel';
+  import {
+    colonelUserDetailResponseSchema,
+    colonelUsersResponseSchema,
+  } from '@/schemas/api/internal/responses/colonel';
+  import type { ColonelOrganizationDetailMember } from '@/schemas/api/internal/responses/colonel-organizations';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import { formatDisplayDateTime } from '@/utils/format';
+  import { computed, onBeforeUnmount, ref, watch } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  /**
+   * "Add an existing account to this organization" — the support-desk flow for
+   * the case an invitation cannot cover: a person signed up on their own, so
+   * they already have an account and the invite path refuses them, but they
+   * belong in an existing organization.
+   *
+   * Deliberately NOT a membership CRUD surface. It does exactly one verb (add)
+   * against `POST /api/colonel/organizations/:org_id/members`; removing a member
+   * and changing an existing member's role are different endpoints and are out
+   * of scope here.
+   *
+   * Two steps in one modal:
+   *  1. FIND — `GET /api/colonel/users?search=` (the same bounded email-index
+   *     scan the customers list uses). An operator working from a support ticket
+   *     has an email address, so that is the primary key; the endpoint also
+   *     matches an exact extid or objid, which is what a paste from another
+   *     console tab gives you.
+   *  2. CONFIRM — the picked account is pinned with enough identity to be sure
+   *     it is the right person (obscured-by-default address, public id, created
+   *     date, verification/suspension state) plus the organizations it is
+   *     ALREADY in, fetched from `GET /api/colonel/users/:extid`. That second
+   *     fetch is best-effort: if it fails the flow degrades to the roster-based
+   *     guard below and never blocks the add.
+   *
+   * The parent owns the mutation (loading/error are passed back in) — this only
+   * collects the account + role and emits `submit`, mirroring
+   * {@link AddDomainForOrgModal}.
+   */
+  const props = withDefaults(
+    defineProps<{
+      /** Whether the modal is shown (use with `v-model:open`). */
+      open: boolean;
+      /** The target organization's PUBLIC id (extid). */
+      orgExtid: string;
+      /** Display label for the target organization (header + copy). */
+      orgName: string;
+      /**
+       * The organization's CURRENT roster. Used purely as a client-side guard so
+       * an operator is told "already a member" before spending a request; the
+       * server's idempotent `no_change` is still the authority.
+       */
+      members: ColonelOrganizationDetailMember[];
+      /** True while the parent's add request is in flight. */
+      loading?: boolean;
+      /** Server/action error from the parent's mutation, or null. */
+      error?: string | null;
+    }>(),
+    {
+      loading: false,
+      error: null,
+    }
+  );
+
+  const emit = defineEmits<{
+    'update:open': [value: boolean];
+    submit: [payload: AddMembershipRequest];
+  }>();
+
+  const { t } = useI18n();
+
+  // ---- Step 1: find the account -------------------------------------------
+
+  const term = ref('');
+  /** The term the current `results` were fetched for — guards no-op refetches. */
+  const activeTerm = ref('');
+  const results = ref<ColonelUser[]>([]);
+  /** True once a search has run — separates "no matches" from "idle". */
+  const searched = ref(false);
+
+  const pager = usePaginatedFetch<ColonelUsersResponse, ColonelUser>({
+    url: '/api/colonel/users',
+    schema: colonelUsersResponseSchema,
+    context: 'ColonelUsersResponse',
+    perPage: 25,
+    select: (data) => ({
+      items: data.details?.users ?? [],
+      pagination: data.details?.pagination ?? null,
+    }),
+  });
+  const {
+    loading: searchLoading,
+    error: searchError,
+    validationError: searchValidationError,
+  } = pager;
+
+  async function runSearch(): Promise<void> {
+    const q = term.value.trim();
+    activeTerm.value = q;
+    if (q === '') {
+      results.value = [];
+      searched.value = false;
+      return;
+    }
+    searched.value = true;
+    try {
+      const page = await pager.fetchPage(1, { search: q });
+      results.value = page?.items ?? [];
+    } catch {
+      // Network/HTTP failure is captured in `error`; the banner renders it.
+      results.value = [];
+    }
+  }
+
+  // One request per pause, not per keystroke. The no-op guard keeps the
+  // programmatic reset below from firing a second, pointless search.
+  let debounceId: ReturnType<typeof setTimeout> | null = null;
+  watch(term, (value) => {
+    if (debounceId) clearTimeout(debounceId);
+    if (value.trim() === activeTerm.value) return;
+    debounceId = setTimeout(runSearch, 300);
+  });
+  onBeforeUnmount(() => {
+    if (debounceId) clearTimeout(debounceId);
+  });
+
+  function onSearchSubmit(): void {
+    if (debounceId) clearTimeout(debounceId);
+    runSearch();
+  }
+
+  // ---- Step 2: confirm the account + pick a role ---------------------------
+
+  const selected = ref<ColonelUser | null>(null);
+  const role = ref<MembershipRole>('member');
+
+  const {
+    data: accountData,
+    loading: accountLoading,
+    error: accountError,
+    validationError: accountValidationError,
+    load: loadAccount,
+    reset: resetAccount,
+  } = useResourceFetch<ColonelUserDetailResponse>({
+    // Getter form: the id is read lazily, at load() time.
+    url: () => `/api/colonel/users/${encodeURIComponent(selected.value?.extid ?? '')}`,
+    schema: colonelUserDetailResponseSchema,
+    context: 'ColonelUserDetailResponse',
+  });
+
+  /** The organizations the picked account already belongs to (best-effort). */
+  const accountOrganizations = computed(() => accountData.value?.details?.organizations ?? []);
+
+  /** True when the memberships read-out could not be loaded — shown, not fatal. */
+  const accountLookupFailed = computed(
+    () => accountError.value !== null || accountValidationError.value !== null
+  );
+
+  /** Roster lookup by customer extid (org detail `members[].extid` is the customer's). */
+  const rosterByExtid = computed(
+    () => new Map(props.members.map((member) => [member.extid, member]))
+  );
+
+  function rosterEntry(extid: string): ColonelOrganizationDetailMember | undefined {
+    return rosterByExtid.value.get(extid);
+  }
+
+  /** The picked account's existing membership in THIS org, from the roster. */
+  const existingMembership = computed(() =>
+    selected.value ? (rosterEntry(selected.value.extid) ?? null) : null
+  );
+
+  /**
+   * Already a member per either source: the roster we were handed, or the
+   * account's own organization list (which covers a roster that has gone stale
+   * since the page loaded).
+   */
+  const alreadyMember = computed(() => {
+    if (existingMembership.value) return true;
+    return accountOrganizations.value.some((org) => org.extid === props.orgExtid);
+  });
+
+  /** The role we can name in the "already a member" warning, when we know it. */
+  const existingRole = computed(() => existingMembership.value?.role ?? null);
+
+  const canSubmit = computed(
+    () => selected.value !== null && !alreadyMember.value && !props.loading
+  );
+
+  function roleLabel(value: string): string {
+    return t(`web.admin.organizations.addMember.roles.${value}`, value);
+  }
+
+  function choose(user: ColonelUser): void {
+    selected.value = user;
+    role.value = 'member';
+    resetAccount();
+    // Best-effort: this is the only call that exposes the account's current org
+    // memberships. A failure degrades to the roster guard, it never blocks.
+    loadAccount().catch(() => {});
+  }
+
+  function clearSelection(): void {
+    selected.value = null;
+    resetAccount();
+  }
+
+  function onSubmit(): void {
+    if (!canSubmit.value || !selected.value) return;
+    emit('submit', { customer: selected.value.extid, role: role.value });
+  }
+
+  // Reset every time the modal opens so it never shows a stale account/result set.
+  watch(
+    () => props.open,
+    (isOpen) => {
+      if (!isOpen) return;
+      if (debounceId) clearTimeout(debounceId);
+      term.value = '';
+      activeTerm.value = '';
+      results.value = [];
+      searched.value = false;
+      selected.value = null;
+      role.value = 'member';
+      resetAccount();
+    }
+  );
+</script>
+
+<template>
+  <AdminModal
+    :open="open"
+    :title="t('web.admin.organizations.addMember.title')"
+    :subtitle="orgExtid"
+    :dismissable="!loading"
+    width-class="max-w-2xl"
+    testid="add-member-modal"
+    @update:open="emit('update:open', $event)">
+    <p class="text-sm text-gray-600 dark:text-gray-400">
+      {{ t('web.admin.organizations.addMember.description', { org: orgName }) }}
+    </p>
+
+    <!-- Step 1: find the account ------------------------------------------- -->
+    <form
+      v-if="!selected"
+      class="mt-4"
+      @submit.prevent="onSearchSubmit">
+      <label
+        for="add-member-search"
+        class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.organizations.addMember.searchLabel') }}
+      </label>
+      <div class="relative">
+        <span
+          class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-gray-400">
+          <OIcon
+            collection="heroicons"
+            name="magnifying-glass"
+            size="5" />
+        </span>
+        <input
+          id="add-member-search"
+          v-model="term"
+          type="search"
+          autocomplete="off"
+          autocapitalize="off"
+          autocorrect="off"
+          spellcheck="false"
+          data-testid="add-member-search"
+          :placeholder="t('web.admin.organizations.addMember.searchPlaceholder')"
+          class="w-full rounded-md border border-gray-300 py-2 pr-3 pl-10 text-sm text-gray-900 placeholder:text-gray-400 focus:border-brand-500 focus:ring-brand-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+      </div>
+      <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+        {{ t('web.admin.organizations.addMember.searchHint') }}
+      </p>
+    </form>
+
+    <!-- Results region -->
+    <div
+      v-if="!selected"
+      class="mt-4 min-h-[8rem]"
+      aria-live="polite">
+      <!-- Network / HTTP failure -->
+      <div
+        v-if="searchError"
+        class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800 dark:border-red-900/50 dark:bg-red-900/20 dark:text-red-200"
+        role="alert"
+        data-testid="add-member-search-error">
+        {{ t('web.admin.organizations.addMember.searchError') }}
+      </div>
+      <!-- Contract mismatch (degraded, not fatal) -->
+      <div
+        v-else-if="searchValidationError"
+        class="rounded-md border border-yellow-200 bg-yellow-50 px-3 py-2 text-sm text-yellow-800 dark:border-yellow-900/50 dark:bg-yellow-900/20 dark:text-yellow-200"
+        role="alert"
+        data-testid="add-member-search-parse-error">
+        {{ t('web.admin.organizations.addMember.searchParseError') }}
+      </div>
+
+      <!-- Loading -->
+      <div
+        v-else-if="searchLoading"
+        class="flex items-center justify-center gap-2 py-8 text-sm text-gray-500 dark:text-gray-400">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          size="5"
+          class="animate-spin motion-reduce:animate-none" />
+        {{ t('web.COMMON.processing') }}
+      </div>
+
+      <!-- Idle -->
+      <p
+        v-else-if="!searched"
+        class="py-8 text-center text-sm text-gray-400 dark:text-gray-500"
+        data-testid="add-member-idle">
+        {{ t('web.admin.organizations.addMember.idle') }}
+      </p>
+
+      <!-- No matches: the account genuinely does not exist -->
+      <div
+        v-else-if="results.length === 0"
+        class="py-8 text-center"
+        data-testid="add-member-no-results">
+        <OIcon
+          collection="heroicons"
+          name="user-circle"
+          size="8"
+          class="mx-auto text-gray-300 dark:text-gray-600" />
+        <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+          {{ t('web.admin.organizations.addMember.noResults', { term: activeTerm }) }}
+        </p>
+        <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+          {{ t('web.admin.organizations.addMember.noResultsHint') }}
+        </p>
+      </div>
+
+      <!-- Matches -->
+      <ul
+        v-else
+        class="divide-y divide-gray-100 dark:divide-gray-800"
+        data-testid="add-member-results">
+        <li
+          v-for="user in results"
+          :key="user.extid"
+          class="flex items-start justify-between gap-3 py-3">
+          <div class="min-w-0">
+            <div class="text-sm font-semibold text-gray-900 dark:text-white">
+              <RevealEmail :email="user.email" />
+            </div>
+            <p
+              class="mt-0.5 truncate font-mono text-xs text-gray-500 tabular-nums dark:text-gray-400">
+              {{ user.extid }}
+            </p>
+            <div class="mt-1 flex flex-wrap items-center gap-1.5">
+              <span
+                v-if="user.verified"
+                class="inline-flex items-center gap-1 rounded bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/40 dark:text-green-200">
+                <OIcon
+                  collection="heroicons"
+                  name="check-badge"
+                  size="3" />
+                {{ t('web.admin.organizations.addMember.badges.verified') }}
+              </span>
+              <span
+                v-else
+                class="inline-flex items-center gap-1 rounded bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
+                <OIcon
+                  collection="heroicons"
+                  name="exclamation-triangle"
+                  size="3" />
+                {{ t('web.admin.organizations.addMember.badges.unverified') }}
+              </span>
+              <span
+                v-if="user.suspended"
+                class="inline-flex items-center gap-1 rounded bg-red-100 px-1.5 py-0.5 text-xs font-medium text-red-800 dark:bg-red-900/40 dark:text-red-200">
+                <OIcon
+                  collection="heroicons"
+                  name="no-symbol"
+                  size="3" />
+                {{ t('web.admin.organizations.addMember.badges.suspended') }}
+              </span>
+              <span
+                v-if="user.role && user.role !== 'customer'"
+                class="inline-flex items-center rounded bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
+                {{ user.role }}
+              </span>
+              <span
+                v-if="rosterEntry(user.extid)"
+                class="inline-flex items-center rounded bg-gray-200 px-1.5 py-0.5 text-xs font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+                :data-testid="`add-member-existing-${user.extid}`">
+                {{ t('web.admin.organizations.addMember.badges.alreadyMember') }}
+              </span>
+              <span class="text-xs text-gray-400 tabular-nums dark:text-gray-500">
+                {{
+                  t('web.admin.organizations.addMember.createdOn', {
+                    date: formatDisplayDateTime(user.created),
+                  })
+                }}
+              </span>
+            </div>
+          </div>
+          <button
+            type="button"
+            :data-testid="`add-member-select-${user.extid}`"
+            class="mt-0.5 inline-flex shrink-0 items-center rounded-md bg-brand-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-700 focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 focus:outline-none dark:bg-brand-500 dark:hover:bg-brand-600"
+            @click="choose(user)">
+            {{ t('web.admin.organizations.addMember.select') }}
+          </button>
+        </li>
+      </ul>
+    </div>
+
+    <!-- Step 2: confirm the account + pick a role ---------------------------- -->
+    <div
+      v-else
+      class="mt-4"
+      data-testid="add-member-selected">
+      <div
+        class="overflow-hidden rounded-lg border border-l-4 border-gray-200 border-l-brand-600 bg-white dark:border-gray-700 dark:border-l-brand-500 dark:bg-gray-900">
+        <!-- Identity -->
+        <div
+          class="flex items-start justify-between gap-4 border-b border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800/50">
+          <div class="min-w-0">
+            <p
+              class="mb-1 text-xs font-semibold tracking-wide text-brand-600 uppercase dark:text-brand-400">
+              {{ t('web.admin.organizations.addMember.selectedEyebrow') }}
+            </p>
+            <div class="text-sm font-semibold text-gray-900 dark:text-white">
+              <RevealEmail :email="selected.email" />
+            </div>
+            <p
+              class="mt-0.5 truncate font-mono text-xs text-gray-500 tabular-nums dark:text-gray-400">
+              {{ selected.extid }}
+            </p>
+          </div>
+          <button
+            type="button"
+            data-testid="add-member-change"
+            :disabled="loading"
+            class="shrink-0 rounded-md px-2 py-1 text-xs font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus:ring-2 focus:ring-brand-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+            @click="clearSelection">
+            {{ t('web.admin.organizations.addMember.change') }}
+          </button>
+        </div>
+
+        <div class="space-y-4 px-4 py-4">
+          <!-- Identifying detail -->
+          <dl class="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-3">
+            <div data-testid="add-member-field-created">
+              <dt
+                class="text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                {{ t('web.admin.organizations.addMember.fields.created') }}
+              </dt>
+              <dd class="mt-0.5 text-sm text-gray-900 tabular-nums dark:text-gray-100">
+                {{ formatDisplayDateTime(selected.created) }}
+              </dd>
+            </div>
+            <div data-testid="add-member-field-verified">
+              <dt
+                class="text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                {{ t('web.admin.organizations.addMember.fields.verified') }}
+              </dt>
+              <dd class="mt-0.5 text-sm text-gray-900 dark:text-gray-100">
+                {{
+                  selected.verified
+                    ? t('web.admin.organizations.addMember.badges.verified')
+                    : t('web.admin.organizations.addMember.badges.unverified')
+                }}
+              </dd>
+            </div>
+            <div data-testid="add-member-field-lastLogin">
+              <dt
+                class="text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                {{ t('web.admin.organizations.addMember.fields.lastLogin') }}
+              </dt>
+              <dd class="mt-0.5 text-sm text-gray-900 tabular-nums dark:text-gray-100">
+                {{
+                  selected.last_login
+                    ? formatDisplayDateTime(selected.last_login)
+                    : t('web.admin.organizations.detail.none')
+                }}
+              </dd>
+            </div>
+          </dl>
+
+          <!-- Current organizations (best-effort read) -->
+          <div data-testid="add-member-organizations">
+            <p
+              class="text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+              {{ t('web.admin.organizations.addMember.fields.organizations') }}
+            </p>
+            <div
+              v-if="accountLoading"
+              class="mt-1 flex items-center gap-2 text-xs text-gray-400 dark:text-gray-500">
+              <OIcon
+                collection="heroicons"
+                name="arrow-path"
+                size="4"
+                class="animate-spin motion-reduce:animate-none" />
+              {{ t('web.COMMON.loading') }}
+            </div>
+            <p
+              v-else-if="accountLookupFailed"
+              class="mt-1 text-xs text-gray-500 dark:text-gray-400"
+              data-testid="add-member-organizations-error">
+              {{ t('web.admin.organizations.addMember.organizationsUnavailable') }}
+            </p>
+            <div
+              v-else-if="accountOrganizations.length > 0"
+              class="mt-1 flex flex-wrap gap-1.5">
+              <span
+                v-for="org in accountOrganizations"
+                :key="org.extid"
+                class="inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium"
+                :class="
+                  org.extid === orgExtid
+                    ? 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200'
+                    : 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300'
+                ">
+                {{ org.display_name || org.extid }}
+                <span
+                  v-if="org.is_default"
+                  class="text-[10px] tracking-wide uppercase opacity-70">
+                  {{ t('web.admin.organizations.addMember.defaultOrg') }}
+                </span>
+              </span>
+            </div>
+            <p
+              v-else
+              class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+              {{ t('web.admin.organizations.detail.none') }}
+            </p>
+          </div>
+
+          <!-- Role selector: exactly the roles the backend accepts. -->
+          <div>
+            <label
+              for="add-member-role"
+              class="mb-1 block text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+              {{ t('web.admin.organizations.addMember.roleLabel') }}
+            </label>
+            <select
+              id="add-member-role"
+              v-model="role"
+              data-testid="add-member-role"
+              :disabled="loading || alreadyMember"
+              class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-brand-500 focus:ring-brand-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 sm:w-64 dark:border-gray-600 dark:bg-gray-800 dark:text-white">
+              <option
+                v-for="value in MEMBERSHIP_ROLES"
+                :key="value"
+                :value="value">
+                {{ roleLabel(value) }}
+              </option>
+            </select>
+            <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+              {{ t(`web.admin.organizations.addMember.roleHints.${role}`) }}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Already a member: the add would be a no-op; point at set-role. -->
+      <div
+        v-if="alreadyMember"
+        class="mt-4 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 dark:border-amber-900/50 dark:bg-amber-900/20"
+        role="alert"
+        data-testid="add-member-already-member">
+        <OIcon
+          collection="heroicons"
+          name="information-circle"
+          size="5"
+          class="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
+        <p class="text-sm text-amber-800 dark:text-amber-200">
+          {{
+            existingRole
+              ? t('web.admin.organizations.addMember.errors.alreadyMember', {
+                  role: roleLabel(existingRole),
+                })
+              : t('web.admin.organizations.addMember.errors.alreadyMemberUnknownRole')
+          }}
+        </p>
+      </div>
+
+      <!-- Parent mutation failure (stays put so the operator can retry/cancel). -->
+      <div
+        v-if="error"
+        class="mt-4 rounded-md bg-red-50 p-3 dark:bg-red-900/20"
+        role="alert"
+        aria-live="assertive"
+        data-testid="add-member-error">
+        <p class="text-sm text-red-800 dark:text-red-200">
+          {{ error }}
+        </p>
+      </div>
+    </div>
+
+    <template #footer>
+      <div class="flex justify-end gap-3">
+        <button
+          type="button"
+          data-testid="add-member-cancel"
+          :disabled="loading"
+          class="inline-flex justify-center rounded-md bg-white px-4 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-gray-300 ring-inset hover:bg-gray-50 focus:ring-2 focus:ring-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-700 dark:text-gray-300 dark:ring-gray-600 dark:hover:bg-gray-600"
+          @click="emit('update:open', false)">
+          {{ t('web.COMMON.word_cancel') }}
+        </button>
+        <button
+          type="button"
+          data-testid="add-member-submit"
+          :disabled="!canSubmit"
+          class="inline-flex items-center justify-center gap-2 rounded-md bg-brand-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-700 focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-brand-500 dark:hover:bg-brand-600"
+          @click="onSubmit">
+          <OIcon
+            v-if="loading"
+            collection="heroicons"
+            name="arrow-path"
+            size="4"
+            class="animate-spin motion-reduce:animate-none" />
+          {{ loading ? t('web.COMMON.processing') : t('web.admin.organizations.addMember.submit') }}
+        </button>
+      </div>
+    </template>
+  </AdminModal>
+</template>

--- a/src/apps/admin/components/organizations/membershipSchemas.ts
+++ b/src/apps/admin/components/organizations/membershipSchemas.ts
@@ -1,0 +1,77 @@
+// src/apps/admin/components/organizations/membershipSchemas.ts
+
+/**
+ * Contract for the colonel organization-membership ADD verb.
+ *
+ *   POST /api/colonel/organizations/:org_id/members
+ *
+ * Colocated with the organizations components rather than sitting in
+ * `src/schemas/api/internal/responses/colonel-organizations.ts` (where the
+ * sibling organization contracts live) purely because this change set could not
+ * edit that file. It is a straight lift-and-shift when it moves — see the
+ * handoff note in the PR description.
+ *
+ * Two things live here:
+ *  - {@link MEMBERSHIP_ROLES}, mirrored from the backend's single source of
+ *    truth for assignable roles.
+ *  - {@link colonelAddMembershipResponseSchema}, the ack shape. Used as a
+ *    TRIPWIRE (`gracefulParse`, never a gate) with ONE exception: `status` is
+ *    load-bearing, because an idempotent `no_change` is a 200 that must NOT be
+ *    reported to the operator as "added".
+ */
+
+import { createApiResponseSchema } from '@/schemas/api/base';
+import { z } from 'zod';
+
+/**
+ * The membership roles `POST /organizations/:org_id/members` accepts.
+ *
+ * Mirrors `Onetime::Operations::Memberships::Add::VALID_ROLES`, which is itself
+ * `Onetime::OrganizationMembership::ROLE_ENTITLEMENTS.keys`
+ * (lib/onetime/models/organization_membership.rb). Anything outside this list
+ * comes back as a 4xx form error on the `role` field, so do NOT extend it here
+ * without changing that constant first.
+ *
+ * Ordered least- to most-privileged so the select defaults to the safe choice.
+ */
+export const MEMBERSHIP_ROLES = ['member', 'admin', 'owner'] as const;
+
+export type MembershipRole = (typeof MEMBERSHIP_ROLES)[number];
+
+/** Payload the add-member modal hands back to its parent on submit. */
+export interface AddMembershipRequest {
+  /**
+   * The customer's PUBLIC id (extid) — never an email address. The picker has
+   * already resolved the operator's address to exactly one account, and an
+   * extid survives the adapter's identifier sanitizing unambiguously where an
+   * address does not.
+   */
+  customer: string;
+  role: MembershipRole;
+}
+
+/**
+ * `AddMembership#success_data`. The three membership adapters return `record`
+ * ONLY (no `details` key) — `createApiResponseSchema` already makes `details`
+ * optional, so nothing extra is needed here.
+ *
+ * `status` is `success` (a real add, audited server-side as `membership.add`)
+ * or `no_change` (the customer was already a member; the op deliberately left
+ * their role untouched and audited nothing). Kept as a plain string rather than
+ * an enum so a future status does not turn a successful mutation into a parse
+ * failure. `role` echoes the member's role AFTER the call — for `no_change`
+ * that is their CURRENT role, not the requested one.
+ */
+export const colonelAddMembershipRecordSchema = z.object({
+  org_id: z.string(),
+  member_id: z.string(),
+  status: z.string(),
+  role: z.string().nullable(),
+});
+
+export const colonelAddMembershipResponseSchema = createApiResponseSchema(
+  colonelAddMembershipRecordSchema
+);
+
+export type ColonelAddMembershipRecord = z.infer<typeof colonelAddMembershipRecordSchema>;
+export type ColonelAddMembershipResponse = z.infer<typeof colonelAddMembershipResponseSchema>;

--- a/src/apps/admin/routes.ts
+++ b/src/apps/admin/routes.ts
@@ -88,6 +88,26 @@ const routes: Array<RouteRecordRaw> = [
     },
   },
   {
+    // Domain detail. `:id` is the domain's PUBLIC id (extid) — the colonel
+    // domain endpoints resolve by extid ONLY (an objid or display_domain 404s).
+    // `sentryScrubParams` is OMITTED so the default (scrub all params) redacts
+    // the id from breadcrumbs, mirroring `/colonel/customers/:id`.
+    //
+    // Declared after the list route, and any future literal sibling (the
+    // backend's `/domains/orphaned` vs `/domains/:extid` split) must be declared
+    // ABOVE this record — vue-router ranks static segments over dynamic ones, so
+    // declaration order is only the tie-break, but keeping literals first keeps
+    // the file readable against the backend's routes.txt ordering.
+    path: '/colonel/domains/:id',
+    name: 'AdminDomainDetail',
+    component: () => import('@/apps/admin/views/AdminDomainDetail.vue'),
+    meta: {
+      ...adminDefaultMeta,
+      title: 'web.colonel.titles.domains',
+    },
+    props: true,
+  },
+  {
     // Organizations list + billing-investigate + entitlement overrides (ticket #32).
     path: '/colonel/organizations',
     name: 'AdminOrganizations',
@@ -213,6 +233,24 @@ const routes: Array<RouteRecordRaw> = [
       title: 'web.admin.billing.title',
       sentryScrubParams: false,
     },
+  },
+  {
+    // Plan diff (billing): the config-vs-live comparison for ONE plan, promoted
+    // out of the billing screen's slide-over because it renders two JSON
+    // documents side by side and a drawer cannot show them without cramping.
+    // `:planid` is a catalog id (e.g. `identity_plus_v1`) — not key material and
+    // not customer-identifying — so `sentryScrubParams: false` matches the other
+    // non-sensitive routes in this file rather than the customer/org/domain
+    // detail routes, which OMIT the key to get the scrub-all default.
+    path: '/colonel/billing/plans/:planid',
+    name: 'AdminPlanDiff',
+    component: () => import('@/apps/admin/views/AdminPlanDiff.vue'),
+    meta: {
+      ...adminDefaultMeta,
+      title: 'web.admin.billing.title',
+      sentryScrubParams: false,
+    },
+    props: true,
   },
 ];
 

--- a/src/apps/admin/sections.ts
+++ b/src/apps/admin/sections.ts
@@ -93,7 +93,10 @@ export const CONSOLE_SECTIONS: ConsoleSection[] = [
   },
   {
     key: 'secrets',
-    labelKey: 'web.colonel.titles.secrets',
+    // Single source for this label: the nav item, the route title and the page
+    // heading all read web.admin.secrets.title. The old web.colonel.titles.secrets
+    // duplicate was removed so a future rename cannot miss one of them.
+    labelKey: 'web.admin.secrets.title',
     icon: 'key',
     group: 'platform',
     hide: false,

--- a/src/apps/admin/stores/useAdminBilling.ts
+++ b/src/apps/admin/stores/useAdminBilling.ts
@@ -1,0 +1,233 @@
+// src/apps/admin/stores/useAdminBilling.ts
+
+import {
+  usePaginatedFetch,
+  type PageMeta,
+} from '@/apps/admin/composables/usePaginatedFetch';
+import { createApiResponseSchema } from '@/schemas/api/base';
+import { defineStore } from 'pinia';
+import { computed, ref } from 'vue';
+import { z } from 'zod';
+
+/**
+ * Per-resource admin store for the billing screen's Stripe-customer roster.
+ *
+ * Scope is deliberately narrow: the catalog/drift read-out stays on
+ * {@link useResourceFetch} inside the views (CONTRACT 1 — one-shot reads do not
+ * get a store); this store owns ONLY the paginated, searchable list of
+ * organizations that carry a `stripe_customer_id`, which is index-backed
+ * server-side (`organization:stripe_customer_id_index`) and therefore pages like
+ * every other admin list.
+ *
+ * Sibling of {@link useAdminOrganizations} / {@link useAdminCustomers} — same
+ * `usePaginatedFetch` wiring, same two-failure-mode split (Zod mismatch degrades
+ * to empty via `validationError`; network/HTTP sets `error` and throws).
+ */
+
+// ============================================================================
+// Response contract
+// ============================================================================
+//
+// TEMPORARY HOME. These schemas belong beside the rest of the billing contracts
+// in `src/schemas/api/internal/responses/colonel-billing.ts`; they live here
+// only because that file is owned by a concurrent change. See the handoff note
+// in the PR — move them (re-exporting the types) once the endpoint lands.
+//
+// GET /api/colonel/billing/stripe-organizations → ListStripeOrganizations
+//
+// Every field except the two identity keys is `.nullish()` on purpose: the
+// endpoint is landing concurrently, and a lenient row shape means a partial or
+// still-evolving payload renders a degraded row rather than blanking the whole
+// table through a `gracefulParse` failure.
+
+/** One organization that has a Stripe customer id. */
+export const colonelStripeOrganizationSchema = z.object({
+  /** The organization's PUBLIC id — routes to /colonel/organizations/:id. */
+  extid: z.string(),
+  /** The Stripe customer id (`cus_…`) — the index field this list is keyed by. */
+  stripe_customer_id: z.string(),
+  org_id: z.string().nullish(),
+  display_name: z.string().nullish(),
+  owner_email: z.string().nullish(),
+  billing_email: z.string().nullish(),
+  planid: z.string().nullish(),
+  stripe_subscription_id: z.string().nullish(),
+  subscription_status: z.string().nullish(),
+  subscription_period_end: z.string().nullish(),
+  sync_status: z.string().nullish(),
+});
+
+/**
+ * The canonical four-field pagination envelope ({@link PageMeta}) plus the two
+ * bound signals this index-backed read carries:
+ *
+ * - `capped`      the HSCAN hit its entry bound, so `total_count` UNDERSTATES
+ *                 the real population. Never render "showing X of Y" as exact.
+ * - `stale_count` index entries on THIS page whose organization no longer
+ *                 loads; they are dropped, so a page can be short.
+ *
+ * Both are optional: they are read wherever the adapter puts them (pagination
+ * envelope or the details root — see {@link colonelStripeOrganizationsDetailsSchema}).
+ */
+const stripeOrganizationsPaginationSchema = z.object({
+  page: z.number(),
+  per_page: z.number(),
+  total_count: z.number(),
+  total_pages: z.number(),
+  capped: z.boolean().optional(),
+  stale_count: z.number().optional(),
+});
+
+export const colonelStripeOrganizationsDetailsSchema = z.object({
+  organizations: z.array(colonelStripeOrganizationSchema),
+  pagination: stripeOrganizationsPaginationSchema,
+  /** Server echo of the applied filters. Optional — never read for state. */
+  filters: z.object({ search: z.string().nullish() }).optional(),
+  // Accepted at the details root too, since the HTTP adapter for this op is
+  // landing concurrently and may hang the bound signals here instead.
+  capped: z.boolean().optional(),
+  stale_count: z.number().optional(),
+});
+
+export type StripeOrganizationsPageMeta = z.infer<typeof stripeOrganizationsPaginationSchema>;
+
+export const colonelStripeOrganizationsResponseSchema = createApiResponseSchema(
+  z.object({}),
+  colonelStripeOrganizationsDetailsSchema
+);
+
+export type ColonelStripeOrganization = z.infer<typeof colonelStripeOrganizationSchema>;
+export type ColonelStripeOrganizationsResponse = z.infer<
+  typeof colonelStripeOrganizationsResponseSchema
+>;
+
+/** Server-side filters the endpoint honours. */
+export interface StripeOrganizationFilters {
+  /** Glob/substring over the Stripe customer id (HSCAN `matching:` server-side). */
+  search?: string;
+}
+
+export const STRIPE_ORGANIZATIONS_URL = '/api/colonel/billing/stripe-organizations';
+
+/** Narrow an unknown error to its HTTP status without importing axios types. */
+function httpStatusOf(err: unknown): number | undefined {
+  return (err as { response?: { status?: number } } | null)?.response?.status;
+}
+
+/**
+ * Map the validated envelope onto the shared `{ items, pagination }` shape,
+ * normalizing the bound signals (`capped` / `stale_count`) onto the pagination
+ * object so the view reads them from ONE place regardless of where the HTTP
+ * adapter chose to emit them.
+ */
+function selectPage(
+  data: ColonelStripeOrganizationsResponse
+): { items: ColonelStripeOrganization[]; pagination: StripeOrganizationsPageMeta | null } {
+  const meta = data.details?.pagination ?? null;
+  return {
+    items: data.details?.organizations ?? [],
+    pagination: meta
+      ? {
+          ...meta,
+          capped: meta.capped ?? data.details?.capped,
+          stale_count: meta.stale_count ?? data.details?.stale_count,
+        }
+      : null,
+  };
+}
+
+export const useAdminBilling = defineStore('adminBilling', () => {
+  /** Rows for the current page only (one server page — never accumulated). */
+  const stripeOrganizations = ref<ColonelStripeOrganization[]>([]);
+  const pagination = ref<StripeOrganizationsPageMeta | null>(null);
+
+  /**
+   * True when the server's bounded index scan hit its limit — `total_count` is
+   * then a floor, not the population. Read from wherever the adapter puts it.
+   */
+  const capped = ref(false);
+  /** Index entries on the current page whose organization no longer loads. */
+  const staleCount = ref(0);
+
+  /**
+   * True when the endpoint answered 404 — i.e. this build of the frontend is
+   * running against a backend that does not serve the roster yet. Held apart
+   * from `error` so the section renders an informational "not available" notice
+   * instead of a red failure banner an operator would try to retry forever.
+   */
+  const unavailable = ref(false);
+
+  const pager = usePaginatedFetch<ColonelStripeOrganizationsResponse, ColonelStripeOrganization>({
+    url: STRIPE_ORGANIZATIONS_URL,
+    schema: colonelStripeOrganizationsResponseSchema,
+    context: 'ColonelStripeOrganizationsResponse',
+    select: selectPage,
+  });
+
+  /** Adopt (or clear) one page of rows plus its bound signals. */
+  function adopt(
+    result: { items: ColonelStripeOrganization[]; pagination: PageMeta | null } | null
+  ): void {
+    stripeOrganizations.value = result?.items ?? [];
+    pagination.value = result?.pagination ?? null;
+    capped.value = pagination.value?.capped === true;
+    staleCount.value = pagination.value?.stale_count ?? 0;
+  }
+
+  /** Suppress the failure banner for the "endpoint not deployed yet" case. */
+  const error = computed(() => (unavailable.value ? null : pager.error.value));
+
+  /**
+   * Fetch one page of Stripe-linked organizations.
+   *
+   * @param targetPage 1-based page (defaults to the current page).
+   * @param filters optional `search` over the Stripe customer id.
+   * @returns the page result, or null on a schema mismatch / missing endpoint.
+   * @throws the underlying network/HTTP error, EXCEPT a 404 (see `unavailable`).
+   */
+  async function fetchStripeOrganizations(
+    targetPage: number = pager.page.value,
+    filters: StripeOrganizationFilters = {}
+  ): Promise<{ items: ColonelStripeOrganization[]; pagination: PageMeta | null } | null> {
+    unavailable.value = false;
+    try {
+      // A null result is a schema mismatch: degrade to empty, and
+      // pager.validationError names the contract that drifted.
+      const result = await pager.fetchPage(targetPage, { search: filters.search });
+      adopt(result);
+      return result;
+    } catch (err) {
+      adopt(null);
+      if (httpStatusOf(err) === 404) {
+        unavailable.value = true;
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  /** Explicit manual reset — setup stores have no built-in $reset. */
+  function $reset(): void {
+    adopt(null);
+    unavailable.value = false;
+    pager.reset();
+  }
+
+  return {
+    // State
+    stripeOrganizations,
+    pagination,
+    unavailable,
+    capped,
+    staleCount,
+    // Fetch state (owned by the shared composable)
+    loading: pager.loading,
+    error,
+    validationError: pager.validationError,
+    page: pager.page,
+    perPage: pager.perPage,
+    // Actions
+    fetchStripeOrganizations,
+    $reset,
+  };
+});

--- a/src/apps/admin/stores/useAdminBilling.ts
+++ b/src/apps/admin/stores/useAdminBilling.ts
@@ -4,10 +4,16 @@ import {
   usePaginatedFetch,
   type PageMeta,
 } from '@/apps/admin/composables/usePaginatedFetch';
-import { createApiResponseSchema } from '@/schemas/api/base';
+import {
+  colonelStripeOrganizationSchema,
+  colonelStripeOrganizationsDetailsSchema,
+  colonelStripeOrganizationsResponseSchema,
+  type ColonelStripeOrganization,
+  type ColonelStripeOrganizationsResponse,
+  type StripeOrganizationsPageMeta,
+} from '@/schemas/api/internal/responses/colonel-billing';
 import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
-import { z } from 'zod';
 
 /**
  * Per-resource admin store for the billing screen's Stripe-customer roster.
@@ -28,78 +34,24 @@ import { z } from 'zod';
 // Response contract
 // ============================================================================
 //
-// TEMPORARY HOME. These schemas belong beside the rest of the billing contracts
-// in `src/schemas/api/internal/responses/colonel-billing.ts`; they live here
-// only because that file is owned by a concurrent change. See the handoff note
-// in the PR — move them (re-exporting the types) once the endpoint lands.
-//
-// GET /api/colonel/billing/stripe-organizations → ListStripeOrganizations
-//
-// Every field except the two identity keys is `.nullish()` on purpose: the
-// endpoint is landing concurrently, and a lenient row shape means a partial or
-// still-evolving payload renders a degraded row rather than blanking the whole
-// table through a `gracefulParse` failure.
+// GET /api/colonel/billing/stripe-organizations → ListStripeOrganizations,
+// whose `SCHEMAS = { response: 'colonelStripeOrganizations' }` resolves through
+// the registry to the schema imported below. The contract itself lives beside
+// the other billing contracts in the schemas tree (the OpenAPI scanner asserts
+// every declared SCHEMA constant resolves); it is re-exported here so existing
+// consumers keep importing from the store.
 
-/** One organization that has a Stripe customer id. */
-export const colonelStripeOrganizationSchema = z.object({
-  /** The organization's PUBLIC id — routes to /colonel/organizations/:id. */
-  extid: z.string(),
-  /** The Stripe customer id (`cus_…`) — the index field this list is keyed by. */
-  stripe_customer_id: z.string(),
-  org_id: z.string().nullish(),
-  display_name: z.string().nullish(),
-  owner_email: z.string().nullish(),
-  billing_email: z.string().nullish(),
-  planid: z.string().nullish(),
-  stripe_subscription_id: z.string().nullish(),
-  subscription_status: z.string().nullish(),
-  subscription_period_end: z.string().nullish(),
-  sync_status: z.string().nullish(),
-});
+export {
+  colonelStripeOrganizationSchema,
+  colonelStripeOrganizationsDetailsSchema,
+  colonelStripeOrganizationsResponseSchema,
+};
 
-/**
- * The canonical four-field pagination envelope ({@link PageMeta}) plus the two
- * bound signals this index-backed read carries:
- *
- * - `capped`      the HSCAN hit its entry bound, so `total_count` UNDERSTATES
- *                 the real population. Never render "showing X of Y" as exact.
- * - `stale_count` index entries on THIS page whose organization no longer
- *                 loads; they are dropped, so a page can be short.
- *
- * Both are optional: they are read wherever the adapter puts them (pagination
- * envelope or the details root — see {@link colonelStripeOrganizationsDetailsSchema}).
- */
-const stripeOrganizationsPaginationSchema = z.object({
-  page: z.number(),
-  per_page: z.number(),
-  total_count: z.number(),
-  total_pages: z.number(),
-  capped: z.boolean().optional(),
-  stale_count: z.number().optional(),
-});
-
-export const colonelStripeOrganizationsDetailsSchema = z.object({
-  organizations: z.array(colonelStripeOrganizationSchema),
-  pagination: stripeOrganizationsPaginationSchema,
-  /** Server echo of the applied filters. Optional — never read for state. */
-  filters: z.object({ search: z.string().nullish() }).optional(),
-  // Accepted at the details root too, since the HTTP adapter for this op is
-  // landing concurrently and may hang the bound signals here instead.
-  capped: z.boolean().optional(),
-  stale_count: z.number().optional(),
-});
-
-export type StripeOrganizationsPageMeta = z.infer<typeof stripeOrganizationsPaginationSchema>;
-
-export const colonelStripeOrganizationsResponseSchema = createApiResponseSchema(
-  z.object({}),
-  colonelStripeOrganizationsDetailsSchema
-);
-
-export type ColonelStripeOrganization = z.infer<typeof colonelStripeOrganizationSchema>;
-export type ColonelStripeOrganizationsResponse = z.infer<
-  typeof colonelStripeOrganizationsResponseSchema
->;
+export type {
+  ColonelStripeOrganization,
+  ColonelStripeOrganizationsResponse,
+  StripeOrganizationsPageMeta,
+};
 
 /** Server-side filters the endpoint honours. */
 export interface StripeOrganizationFilters {

--- a/src/apps/admin/stores/useAdminCustomers.ts
+++ b/src/apps/admin/stores/useAdminCustomers.ts
@@ -8,10 +8,46 @@ import {
   usePaginatedFetch,
   type PageMeta,
 } from '@/apps/admin/composables/usePaginatedFetch';
-import { colonelUsersResponseSchema } from '@/schemas/api/internal/responses/colonel';
+import {
+  colonelUserMutationResponseSchema,
+  colonelUsersResponseSchema,
+} from '@/schemas/api/internal/responses/colonel';
 import type { ColonelUser } from '@/schemas/api/internal/responses/colonel';
+import { useApi } from '@/shared/composables/useApi';
+import { gracefulParse } from '@/utils/schemaValidation';
 
 type ColonelUsersResponse = z.infer<typeof colonelUsersResponseSchema>;
+
+/** Single-customer colonel URL, keyed by the row's public id (extid, 'ur…'). */
+function userUrl(userId: string): string {
+  return `/api/colonel/users/${encodeURIComponent(userId)}`;
+}
+
+/**
+ * Ack tripwire for the mutation endpoints: reports contract drift without ever
+ * failing the action (a 2xx means it already happened server-side).
+ */
+function parseMutationAck(data: unknown): void {
+  gracefulParse(colonelUserMutationResponseSchema, data, 'ColonelUserMutationResponse');
+}
+
+/**
+ * Replace one row (matched by public id) with a patched copy, so the table cell
+ * and any open drawer re-render off the ack instead of waiting for a re-read.
+ *
+ * @returns the new array plus the patched row, or the array unchanged and a
+ *   null row when that customer is not on the current page.
+ */
+function replaceRow(
+  rows: ColonelUser[],
+  userId: string,
+  patch: Partial<ColonelUser>
+): { rows: ColonelUser[]; updated: ColonelUser | null } {
+  const index = rows.findIndex((row) => row.user_id === userId);
+  if (index === -1) return { rows, updated: null };
+  const updated: ColonelUser = { ...rows[index], ...patch };
+  return { rows: [...rows.slice(0, index), updated, ...rows.slice(index + 1)], updated };
+}
 
 /**
  * Per-resource admin store for customers/users (CONTRACT 3).
@@ -24,6 +60,13 @@ type ColonelUsersResponse = z.infer<typeof colonelUsersResponseSchema>;
  * composable, so adding the next resource is a copy of this ~40-line file, not
  * an edit to a shared god-store.
  *
+ * Also owns the two row-scoped operator mutations the list drawer offers
+ * ({@link setVerification} and {@link purge}) so the drawer never has to reach
+ * for a raw HTTP client: both go through the injected Axios instance, ack-parse
+ * as a tripwire, and patch local state so the open drawer reflects the new
+ * server state without a page reload. Audit is written SERVER-SIDE by the
+ * operation — nothing here logs it.
+ *
  * Isolation: this module has ZERO import edge into `src/apps/colonel/*` or
  * `src/shared/stores/colonelInfoStore.ts` (enforced by an architecture test),
  * so it never drags the retiring legacy tree into the admin bundle.
@@ -32,6 +75,8 @@ export const useAdminCustomers = defineStore('adminCustomers', () => {
   /** Rows for the current page only (one server page — never accumulated). */
   const customers = ref<ColonelUser[]>([]);
   const pagination = ref<PageMeta | null>(null);
+
+  const $api = useApi();
 
   const pager = usePaginatedFetch<ColonelUsersResponse, ColonelUser>({
     url: '/api/colonel/users',
@@ -58,13 +103,9 @@ export const useAdminCustomers = defineStore('adminCustomers', () => {
     search?: string
   ): Promise<{ items: ColonelUser[]; pagination: PageMeta | null } | null> {
     try {
-      const params: Record<string, string> = {};
-      if (roleFilter) params.role = roleFilter;
-      if (search) params.search = search;
-      const result = await pager.fetchPage(
-        targetPage,
-        Object.keys(params).length > 0 ? params : undefined
-      );
+      // Empty/undefined params are dropped by the pager, so both filters can be
+      // passed unconditionally.
+      const result = await pager.fetchPage(targetPage, { role: roleFilter, search });
       if (result) {
         customers.value = result.items;
         pagination.value = result.pagination;
@@ -80,6 +121,49 @@ export const useAdminCustomers = defineStore('adminCustomers', () => {
       pagination.value = null;
       throw err;
     }
+  }
+
+  /**
+   * Manually verify / unverify one account
+   * (POST /api/colonel/users/:user_id/verify | /unverify).
+   *
+   * On a 2xx the row is replaced in place with `verified` flipped, so the open
+   * drawer and the table cell both show the new state immediately — no refetch,
+   * no page reload. The ack is schema-checked as a live tripwire but never fails
+   * the action (a 2xx means it happened server-side).
+   *
+   * @param userId the customer's public id (extid, 'ur…' — `row.user_id`).
+   * @param verified the target state.
+   * @returns the patched row, or null when it is not on the current page.
+   * @throws the network/HTTP error, for `useAdminMutation` to classify.
+   */
+  async function setVerification(
+    userId: string,
+    verified: boolean
+  ): Promise<ColonelUser | null> {
+    const verb = verified ? 'verify' : 'unverify';
+    const response = await $api.post(`${userUrl(userId)}/${verb}`, {});
+    parseMutationAck(response.data);
+    const patched = replaceRow(customers.value, userId, { verified });
+    customers.value = patched.rows;
+    return patched.updated;
+  }
+
+  /**
+   * Purge one account (DELETE /api/colonel/users/:user_id) — irreversible, so
+   * the view gates it behind the typed-confirmation dialog.
+   *
+   * Drops the row ONLY after a 2xx: the drop is sequenced after the awaited
+   * DELETE, so a failure throws before it and the row stays. Callers still
+   * refetch the page afterwards (totals/pagination move server-side).
+   *
+   * @param userId the customer's public id (extid, 'ur…').
+   * @throws the network/HTTP error, for `useAdminMutation` to classify.
+   */
+  async function purge(userId: string): Promise<void> {
+    const response = await $api.delete(userUrl(userId));
+    parseMutationAck(response.data);
+    customers.value = customers.value.filter((row) => row.user_id !== userId);
   }
 
   /** Explicit manual reset — setup stores have no built-in $reset. */
@@ -101,6 +185,8 @@ export const useAdminCustomers = defineStore('adminCustomers', () => {
     perPage: pager.perPage,
     // Actions
     fetchPage,
+    setVerification,
+    purge,
     $reset,
   };
 });

--- a/src/apps/admin/stores/useAdminDomains.ts
+++ b/src/apps/admin/stores/useAdminDomains.ts
@@ -4,32 +4,295 @@ import {
   usePaginatedFetch,
   type PageMeta,
 } from '@/apps/admin/composables/usePaginatedFetch';
+import { createApiResponseSchema } from '@/schemas/api/base';
 import type { ColonelCustomDomain } from '@/schemas/api/internal/responses/colonel';
 import { colonelCustomDomainsResponseSchema } from '@/schemas/api/internal/responses/colonel';
+import {
+  colonelDomainDetailResponseSchema,
+  colonelDomainVerifyResponseSchema,
+  type ColonelDomainCluster,
+  type ColonelDomainDetailRecord,
+  type ColonelDomainVerifyDetails,
+} from '@/schemas/api/internal/responses/colonel-domains';
+import {
+  colonelDomainProbeResponseSchema,
+  colonelDomainRepairResponseSchema,
+  colonelDomainTransferResponseSchema,
+  type ColonelDomainProbeDetails,
+  type ColonelDomainRepairDetails,
+  type ColonelDomainTransferDetails,
+} from '@/schemas/api/internal/responses/colonel-domaintoolbox';
+import { useApi } from '@/shared/composables/useApi';
+import { gracefulParse } from '@/utils/schemaValidation';
+import type { AxiosInstance } from 'axios';
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
-import type { z } from 'zod';
-
+import { z } from 'zod';
 
 type ColonelCustomDomainsResponse = z.infer<typeof colonelCustomDomainsResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Remove ack (DELETE /api/colonel/domains/:extid)
+//
+// TEMPORARY HOME. Every other colonel domain schema lives in
+// `src/schemas/api/internal/responses/colonel-domains.ts`; this one is declared
+// here because that file is owned by another workstream in the current split.
+// Move it there verbatim (and re-export from this module) when the contract
+// files are next touched — nothing else needs to change.
+//
+// Shape verified against ColonelAPI::Logic::Colonel::RemoveCustomDomain
+// #success_data. `display_domain` is nullable because the applied path snapshots
+// it from the op result AFTER destroy! has nil'd the in-memory attribute.
+// ---------------------------------------------------------------------------
+
+export const colonelDomainRemoveRecordSchema = z.object({
+  deleted: z.boolean(),
+  domain_id: z.string(),
+  extid: z.string(),
+  display_domain: z.string().nullable(),
+});
+
+/**
+ * Remove outcome. `status` is the op's symbol as a string (planned / removed /
+ * not_found); `dry_run` echoes whether this was a PREVIEW — the endpoint
+ * defaults it to TRUE, so a plain DELETE never destroys anything.
+ * `reasserts_survivor` is true when tearing this record down hands the
+ * display_domain index back to another CustomDomain row.
+ */
+export const colonelDomainRemoveDetailsSchema = z.object({
+  status: z.string(),
+  dry_run: z.boolean(),
+  org_id: z.string(),
+  org_name: z.string().nullable(),
+  reasserts_survivor: z.boolean(),
+});
+
+export const colonelDomainRemoveResponseSchema = createApiResponseSchema(
+  colonelDomainRemoveRecordSchema,
+  colonelDomainRemoveDetailsSchema
+);
+
+export type ColonelDomainRemoveDetails = z.infer<typeof colonelDomainRemoveDetailsSchema>;
+
+/**
+ * Server-side filters `GET /api/colonel/domains` accepts. All are AND-ed and
+ * applied BEFORE pagination, so `total_count` reflects the filtered set.
+ * `search` is a case-insensitive substring over display_domain / base_domain
+ * plus an exact extid / domain_id match — it does NOT match the org name.
+ */
+export interface DomainListFilters {
+  search?: string;
+  /** Exact verification_state ('verified' | 'resolving' | 'pending'). */
+  status?: string;
+  /** Owning organization, by extid or objid. */
+  orgId?: string;
+}
+
+/** The `{ record, cluster }` pair every domain detail read resolves to. */
+export interface ColonelDomainDetail {
+  record: ColonelDomainDetailRecord;
+  cluster: ColonelDomainCluster;
+}
+
+/** Options for the repair verb. `dryRun` is explicit — never defaulted here. */
+export interface DomainRepairOptions {
+  /** Target org for the ORPHANED case (objid or extid). Omitted when blank. */
+  orgId?: string;
+  dryRun: boolean;
+}
+
+/** Options for the transfer verb. `dryRun` is explicit — never defaulted here. */
+export interface DomainTransferOptions {
+  /** REQUIRED destination org (objid or extid). */
+  toOrg: string;
+  /** Optional ownership assertion; a mismatch is a 4xx on field `from_org`. */
+  fromOrg?: string;
+  dryRun: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Per-domain operations.
+//
+// Module-level so each verb stays small and independently readable; the store
+// binds them to the injected Axios instance below. Every one THROWS on a
+// network/HTTP failure (so the caller's useAdminMutation can classify it into
+// the confirm dialog) and resolves `null` when a 2xx ack fails its Zod contract
+// — the mutation still happened server-side, acks are tripwires, not gates.
+// Audit is written SERVER-SIDE by each operation (CONTRACT 4).
+// ---------------------------------------------------------------------------
+
+/** Path for a single domain, resolved by PUBLIC id (extid) only. */
+function domainPath(extid: string): string {
+  return `/api/colonel/domains/${encodeURIComponent(extid)}`;
+}
+
+/** Read one domain's full record + the deployment's proxy cluster. READ-ONLY. */
+async function fetchDomainDetail(
+  $api: AxiosInstance,
+  extid: string
+): Promise<ColonelDomainDetail | null> {
+  const response = await $api.get(domainPath(extid));
+  const parsed = gracefulParse(
+    colonelDomainDetailResponseSchema,
+    response.data,
+    'ColonelDomainDetailResponse'
+  );
+  if (!parsed.ok) return null;
+  return { record: parsed.data.record, cluster: parsed.data.details?.cluster ?? null };
+}
+
+/**
+ * Run DNS + SSL verification. The op reports the REAL post-check state, so the
+ * caller must surface `current_state` honestly rather than assuming success.
+ */
+async function verifyDomain(
+  $api: AxiosInstance,
+  extid: string
+): Promise<ColonelDomainVerifyDetails | null> {
+  const response = await $api.post(`${domainPath(extid)}/verify`);
+  const parsed = gracefulParse(
+    colonelDomainVerifyResponseSchema,
+    response.data,
+    'ColonelDomainVerifyResponse'
+  );
+  return parsed.ok ? parsed.data.details ?? null : null;
+}
+
+/**
+ * HTTPS + TLS diagnostics for a domain. READ-ONLY (no audit); the server clamps
+ * `timeout` to 1..30s.
+ */
+async function probeDomain(
+  $api: AxiosInstance,
+  extid: string,
+  timeout?: number
+): Promise<ColonelDomainProbeDetails | null> {
+  const response = await $api.get(
+    `${domainPath(extid)}/probe`,
+    timeout ? { params: { timeout } } : undefined
+  );
+  const parsed = gracefulParse(
+    colonelDomainProbeResponseSchema,
+    response.data,
+    'ColonelDomainProbeResponse'
+  );
+  return parsed.ok ? parsed.data.details ?? null : null;
+}
+
+/**
+ * Repair a domain's organization relationship. `dryRun: true` PREVIEWS
+ * (`repairs_applied` stays empty); `dryRun: false` applies and audits.
+ */
+async function repairDomain(
+  $api: AxiosInstance,
+  extid: string,
+  options: DomainRepairOptions
+): Promise<ColonelDomainRepairDetails | null> {
+  const body: Record<string, unknown> = { dry_run: options.dryRun };
+  if (options.orgId) body.org_id = options.orgId;
+
+  const response = await $api.post(`${domainPath(extid)}/repair`, body);
+  const parsed = gracefulParse(
+    colonelDomainRepairResponseSchema,
+    response.data,
+    'ColonelDomainRepairResponse'
+  );
+  return parsed.ok ? parsed.data.details ?? null : null;
+}
+
+/**
+ * Move a domain to another organization. `dryRun: true` PREVIEWS the move;
+ * `dryRun: false` applies and audits. A `fromOrg` mismatch is a 4xx.
+ */
+async function transferDomain(
+  $api: AxiosInstance,
+  extid: string,
+  options: DomainTransferOptions
+): Promise<ColonelDomainTransferDetails | null> {
+  const body: Record<string, unknown> = {
+    dry_run: options.dryRun,
+    to_org: options.toOrg,
+  };
+  if (options.fromOrg) body.from_org = options.fromOrg;
+
+  const response = await $api.post(`${domainPath(extid)}/transfer`, body);
+  const parsed = gracefulParse(
+    colonelDomainTransferResponseSchema,
+    response.data,
+    'ColonelDomainTransferResponse'
+  );
+  return parsed.ok ? parsed.data.details ?? null : null;
+}
+
+/**
+ * Permanently delete a domain.
+ *
+ * `dry_run` rides the QUERY STRING (not a request body): DELETE bodies are not
+ * reliably parsed across the stack, and the endpoint defaults `dry_run` to TRUE
+ * — so an apply MUST send `dry_run=false` explicitly. Always check
+ * `details.dry_run` on the response before reporting a removal.
+ */
+async function removeDomain(
+  $api: AxiosInstance,
+  extid: string,
+  dryRun: boolean
+): Promise<ColonelDomainRemoveDetails | null> {
+  const response = await $api.delete(`${domainPath(extid)}?dry_run=${dryRun}`);
+  const parsed = gracefulParse(
+    colonelDomainRemoveResponseSchema,
+    response.data,
+    'ColonelDomainRemoveResponse'
+  );
+  return parsed.ok ? parsed.data.details ?? null : null;
+}
+
+/** Bind every per-domain verb to one Axios instance for the store's surface. */
+function bindOperations($api: AxiosInstance) {
+  return {
+    fetchDetail: (extid: string) => fetchDomainDetail($api, extid),
+    verify: (extid: string) => verifyDomain($api, extid),
+    probe: (extid: string, timeout?: number) => probeDomain($api, extid, timeout),
+    repair: (extid: string, options: DomainRepairOptions) =>
+      repairDomain($api, extid, options),
+    transfer: (extid: string, options: DomainTransferOptions) =>
+      transferDomain($api, extid, options),
+    remove: (extid: string, dryRun: boolean) => removeDomain($api, extid, dryRun),
+  };
+}
 
 /**
  * Per-resource admin store for custom domains (CONTRACT 1 / #31).
  *
- * Sibling of {@link useAdminCustomers} — the shared paginated-fetch
- * composable makes a new resource a few lines pointing at its endpoint +
- * schema + selector. Backed by the existing `GET /api/colonel/domains`
- * and the existing `colonelCustomDomainsResponseSchema` (REUSED, no schema
- * changes — CONTRACT 3). Owns ONLY this resource's page state.
+ * Two responsibilities:
+ *
+ * 1. LIST paging over `GET /api/colonel/domains` via the shared
+ *    {@link usePaginatedFetch} composable — one server page per request, never
+ *    load-all-then-slice — with the endpoint's server-side filters.
+ * 2. The per-domain OPERATIONS both domain screens share (verify, probe,
+ *    repair, transfer, remove, detail read). They live here, not in a view, so
+ *    the list, the detail page and the Domain Toolbox drive the SAME endpoints
+ *    with the same ack parsing instead of three divergent copies.
  *
  * Isolation: ZERO import edge into `src/apps/colonel/*` or
  * `src/shared/stores/colonelInfoStore.ts` (enforced by the architecture test),
  * so the legacy tree never enters the isolated admin bundle.
  */
 export const useAdminDomains = defineStore('adminDomains', () => {
+  const operations = bindOperations(useApi());
+
   /** Rows for the current page only (one server page — never accumulated). */
   const domains = ref<ColonelCustomDomain[]>([]);
   const pagination = ref<PageMeta | null>(null);
+
+  /**
+   * Every list row seen this session, keyed by extid.
+   *
+   * The detail endpoint (`GET /api/colonel/domains/:extid`) returns the domain's
+   * safe_dump, which does NOT carry `org_id` / `org_name` — so the detail page
+   * recovers the owning organization from the row it was opened from. Bounded by
+   * the pages an operator actually visits and cleared by `$reset()`.
+   */
+  const rowIndex = ref<Record<string, ColonelCustomDomain>>({});
 
   const pager = usePaginatedFetch<ColonelCustomDomainsResponse, ColonelCustomDomain>({
     url: '/api/colonel/domains',
@@ -41,21 +304,33 @@ export const useAdminDomains = defineStore('adminDomains', () => {
     }),
   });
 
+  /** The cached list row for `extid`, or null when it was never listed here. */
+  function rowFor(extid: string): ColonelCustomDomain | null {
+    return rowIndex.value[extid] ?? null;
+  }
+
   /**
    * Fetch one page of domains.
    *
    * @param targetPage 1-based page (defaults to the current page).
+   * @param filters server-side filters; empty values are dropped by the pager.
    * @returns the page result, or null on a schema mismatch (see validationError).
    * @throws the underlying network/HTTP error (state is cleared first).
    */
   async function fetchPage(
-    targetPage: number = pager.page.value
+    targetPage: number = pager.page.value,
+    filters?: DomainListFilters
   ): Promise<{ items: ColonelCustomDomain[]; pagination: PageMeta | null } | null> {
     try {
-      const result = await pager.fetchPage(targetPage);
+      const result = await pager.fetchPage(targetPage, {
+        search: filters?.search,
+        status: filters?.status,
+        org_id: filters?.orgId,
+      });
       if (result) {
         domains.value = result.items;
         pagination.value = result.pagination;
+        for (const row of result.items) rowIndex.value[row.extid] = row;
       } else {
         domains.value = [];
         pagination.value = null;
@@ -68,10 +343,16 @@ export const useAdminDomains = defineStore('adminDomains', () => {
     }
   }
 
+  /** Drop a domain from the row cache (e.g. after it was removed). */
+  function forget(extid: string): void {
+    delete rowIndex.value[extid];
+  }
+
   /** Explicit manual reset — setup stores have no built-in $reset. */
   function $reset(): void {
     domains.value = [];
     pagination.value = null;
+    rowIndex.value = {};
     pager.reset();
   }
 
@@ -79,6 +360,7 @@ export const useAdminDomains = defineStore('adminDomains', () => {
     // State
     domains,
     pagination,
+    rowIndex,
     // Fetch state (owned by the shared composable)
     loading: pager.loading,
     error: pager.error,
@@ -87,6 +369,9 @@ export const useAdminDomains = defineStore('adminDomains', () => {
     perPage: pager.perPage,
     // Actions
     fetchPage,
+    rowFor,
+    forget,
     $reset,
+    ...operations,
   };
 });

--- a/src/apps/admin/views/AdminAuditLog.vue
+++ b/src/apps/admin/views/AdminAuditLog.vue
@@ -9,7 +9,7 @@
   import OIcon from '@/shared/components/icons/OIcon.vue';
   import { formatDisplayDateTime } from '@/utils/format';
   import { storeToRefs } from 'pinia';
-  import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+  import { computed, onMounted, ref } from 'vue';
   import { useI18n } from 'vue-i18n';
 
   /**
@@ -19,9 +19,14 @@
    * {@link useAdminAuditLog} store (no `src/apps/colonel/*` / `colonelInfoStore`).
    *
    * - LIST: DataTable + KitPagination, timestamp/actor/action/target/result/detail.
-   * - FILTERS: the FilterBar search box drives the server-side `actor` filter
-   *   (case-insensitive substring, debounced like the sessions search) and a
-   *   category `<select>` drives the `verb` filter (prefix match server-side).
+   * - ACTOR SEARCH: MANUAL, never as-you-type. The operator submits with Enter
+   *   or the Search button; typing alone changes nothing. This is deliberate —
+   *   any `actor` filter puts the endpoint on its slow path (it loads up to
+   *   MAX_EVENTS = 10k events into Ruby and matches there), so a debounced
+   *   as-you-type box turned every pause into a full-set scan.
+   * - ACTION CATEGORY: applies immediately on change. A `<select>` commits one
+   *   deliberate value per interaction, so there is nothing to debounce and no
+   *   half-typed intermediate state to fire on.
    * - READ-ONLY: viewing the log never writes an audit event (CONTRACT 4), so
    *   there are no mutations — and deliberately no way to edit or delete
    *   entries from the UI.
@@ -33,10 +38,22 @@
 
   // ---- Filters ---------------------------------------------------------------
 
+  /** The raw input value. Editing this NEVER issues a request. */
   const actorTerm = ref('');
+  /** The actor term actually applied to the last fetch — the request reads this. */
   const activeActor = ref('');
   const verbCategory = ref('');
-  const hasActiveFilters = computed(() => actorTerm.value !== '' || verbCategory.value !== '');
+
+  const hasActiveFilters = computed(
+    () => actorTerm.value !== '' || activeActor.value !== '' || verbCategory.value !== ''
+  );
+
+  /**
+   * True when the box holds a term that has not been submitted yet. Manual
+   * search means the table can legitimately disagree with the input, so we say
+   * so rather than letting the operator read stale rows as a result set.
+   */
+  const searchPending = computed(() => actorTerm.value.trim() !== activeActor.value);
 
   /**
    * Action categories = the dotted-verb prefixes the ops layer writes today
@@ -93,25 +110,30 @@
     }
   }
 
-  // Debounce actor input so we issue one request per pause, not per keystroke.
-  let actorTimer: ReturnType<typeof setTimeout> | null = null;
-  watch(actorTerm, (value) => {
-    if (actorTimer) clearTimeout(actorTimer);
-    actorTimer = setTimeout(() => {
-      activeActor.value = value.trim();
-      fetchPage(1);
-    }, 300);
-  });
-  onBeforeUnmount(() => {
-    if (actorTimer) clearTimeout(actorTimer);
-  });
+  /**
+   * Commit the typed actor term and fetch page 1. The ONLY path from the actor
+   * box to a request — bound to Enter (keydown) and to the Search button
+   * (submit), so keyboard and mouse have parity. No timers, nothing to clean up
+   * on unmount.
+   *
+   * The term is normalised in place so a stray trailing space cannot leave the
+   * "not applied yet" hint stuck on after a successful search.
+   */
+  function runSearch(): void {
+    const term = actorTerm.value.trim();
+    actorTerm.value = term;
+    activeActor.value = term;
+    fetchPage(1);
+  }
 
+  /** The action category is a discrete choice — apply it immediately. */
   function onFilterChange(key: string, value: string): void {
     if (key !== 'verb') return;
     verbCategory.value = value;
     fetchPage(1);
   }
 
+  /** Reset every filter (typed and applied) and return to the unfiltered list. */
   function onClear(): void {
     actorTerm.value = '';
     activeActor.value = '';
@@ -185,16 +207,69 @@
       </button>
     </div>
 
-    <!-- Filters: actor substring (search box) + action category (select) -->
+    <!--
+      Filters: MANUAL actor search (Enter or the Search button) + an action
+      category select that applies immediately. `show-search` is off because the
+      kit search box is an as-you-type control; the bespoke form below is the
+      submit-driven replacement and `order-first` keeps it in the usual
+      search-leftmost position.
+    -->
     <div class="mb-4">
       <FilterBar
-        v-model:search="actorTerm"
-        :search-placeholder="t('web.admin.audit.filters.actorPlaceholder')"
+        :show-search="false"
         :filters="filters"
         :has-active-filters="hasActiveFilters"
         testid="audit-filterbar"
         @filter-change="onFilterChange"
-        @clear="onClear" />
+        @clear="onClear">
+        <form
+          class="order-first flex min-w-[18rem] flex-1 flex-wrap items-end gap-2"
+          data-testid="audit-actor-form"
+          @submit.prevent="runSearch">
+          <div class="min-w-0 flex-1">
+            <label
+              for="audit-actor-input"
+              class="font-brand text-[11px] font-semibold tracking-[0.1em] text-gray-500 uppercase dark:text-gray-400">
+              {{ t('web.admin.audit.filters.actorLabel') }}
+            </label>
+            <input
+              id="audit-actor-input"
+              v-model="actorTerm"
+              type="text"
+              autocomplete="off"
+              spellcheck="false"
+              data-testid="audit-actor-input"
+              :placeholder="t('web.admin.audit.filters.actorPlaceholder')"
+              aria-describedby="audit-actor-hint"
+              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm placeholder:text-gray-400 focus:border-brand-500 focus:ring-1 focus:ring-brand-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+              @keydown.enter.prevent="runSearch" />
+          </div>
+          <button
+            type="submit"
+            data-testid="audit-actor-search"
+            :disabled="loading"
+            class="inline-flex items-center gap-1 rounded-md bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700 focus:ring-2 focus:ring-brand-500 focus:ring-offset-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-brand-500 dark:hover:bg-brand-600">
+            <OIcon
+              collection="heroicons"
+              name="magnifying-glass"
+              size="4" />
+            {{ t('web.admin.audit.filters.searchButton') }}
+          </button>
+        </form>
+      </FilterBar>
+
+      <!-- Announced to screen readers; the visible cue is the pending line. -->
+      <p
+        id="audit-actor-hint"
+        class="sr-only">
+        {{ t('web.admin.audit.filters.searchHint') }}
+      </p>
+      <p
+        v-if="searchPending"
+        class="mt-2 text-xs text-amber-700 dark:text-amber-300"
+        data-testid="audit-search-pending">
+        {{ t('web.admin.audit.filters.pendingSearch') }}
+      </p>
     </div>
 
     <!-- Table -->

--- a/src/apps/admin/views/AdminBilling.vue
+++ b/src/apps/admin/views/AdminBilling.vue
@@ -2,7 +2,8 @@
 
 <script setup lang="ts">
 
-  import { DataTable, DetailDrawer, JsonViewer, StatCard } from '@/apps/admin/components/kit';
+  import StripeOrganizationsSection from '@/apps/admin/components/billing/StripeOrganizationsSection.vue';
+  import { DataTable, StatCard } from '@/apps/admin/components/kit';
   import type { DataTableColumn } from '@/apps/admin/components/kit';
   import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
   import type {
@@ -11,7 +12,7 @@
   } from '@/schemas/api/internal/responses/colonel-billing';
   import { colonelBillingCatalogResponseSchema } from '@/schemas/api/internal/responses/colonel-billing';
   import OIcon from '@/shared/components/icons/OIcon.vue';
-  import { computed, onMounted, ref } from 'vue';
+  import { computed, onMounted } from 'vue';
   import { useI18n } from 'vue-i18n';
 
   /**
@@ -28,6 +29,15 @@
    * The endpoint returns BOTH the configured catalog (billing.yaml) and the live
    * plans (Stripe-synced cache) plus a computed drift summary, so the operator
    * can see "config says X, live says Y" at a glance — that is the whole value.
+   *
+   * Alongside the catalog sits the Stripe-customer roster
+   * ({@link StripeOrganizationsSection}) — the organizations that are actually
+   * billed, read from the existing `stripe_customer_id` index. "What we sell"
+   * and "who is paying" belong on one screen.
+   *
+   * The per-plan config-vs-live comparison is a full PAGE (`AdminPlanDiff`), not
+   * a drawer: it renders two JSON documents side by side and a slide-over cannot
+   * show them without cramping.
    *
    * Read-only: nothing here mutates, so nothing is audited (CONTRACT 4). Catalog
    * sync stays CLI-only until this view is trusted (spec).
@@ -126,23 +136,6 @@
       default:
         return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300';
     }
-  }
-
-  // ---- Side-by-side diff drawer --------------------------------------------
-
-  const selectedPlanid = ref<string | null>(null);
-  const drawerOpen = ref(false);
-
-  const selectedConfig = computed(() =>
-    selectedPlanid.value ? (configById.value[selectedPlanid.value] ?? null) : null
-  );
-  const selectedLive = computed(() =>
-    selectedPlanid.value ? (liveById.value[selectedPlanid.value] ?? null) : null
-  );
-
-  function openDiff(planid: string): void {
-    selectedPlanid.value = planid;
-    drawerOpen.value = true;
   }
 
   onMounted(() => {
@@ -292,69 +285,26 @@
               </span>
             </template>
             <template #cell-actions="{ row }">
-              <button
-                type="button"
+              <!-- Full page, not a drawer: the diff is two JSON blobs wide. -->
+              <router-link
+                :to="{ name: 'AdminPlanDiff', params: { planid: row.planid } }"
                 class="inline-flex items-center gap-1 rounded-md border border-gray-300 px-2.5 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-brand-500 focus:outline-none dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
-                :data-testid="`billing-diff-${row.planid}`"
-                @click="openDiff(row.planid)">
+                :data-testid="`billing-diff-${row.planid}`">
                 <OIcon
                   collection="heroicons"
                   name="rectangle-group"
                   size="3" />
                 {{ t('web.admin.billing.plans.viewDiff') }}
-              </button>
+              </router-link>
             </template>
           </DataTable>
         </div>
       </section>
     </div>
 
-    <!-- Side-by-side config vs live diff -->
-    <DetailDrawer
-      v-model:open="drawerOpen"
-      :title="t('web.admin.billing.diff.title', { planid: selectedPlanid ?? '' })"
-      :subtitle="t('web.admin.billing.diff.subtitle')"
-      testid="billing-diff-drawer">
-      <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <div>
-          <h4 class="mb-2 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-            {{ t('web.admin.billing.diff.config') }}
-          </h4>
-          <div
-            v-if="selectedConfig"
-            class="rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-800 dark:bg-gray-900">
-            <JsonViewer
-              :data="selectedConfig"
-              :expand-depth="2"
-              testid="billing-diff-config-json" />
-          </div>
-          <p
-            v-else
-            class="rounded-lg border border-dashed border-gray-300 px-3 py-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400"
-            data-testid="billing-diff-config-absent">
-            {{ t('web.admin.billing.diff.absentConfig') }}
-          </p>
-        </div>
-        <div>
-          <h4 class="mb-2 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-            {{ t('web.admin.billing.diff.live') }}
-          </h4>
-          <div
-            v-if="selectedLive"
-            class="rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-800 dark:bg-gray-900">
-            <JsonViewer
-              :data="selectedLive"
-              :expand-depth="2"
-              testid="billing-diff-live-json" />
-          </div>
-          <p
-            v-else
-            class="rounded-lg border border-dashed border-gray-300 px-3 py-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400"
-            data-testid="billing-diff-live-absent">
-            {{ t('web.admin.billing.diff.absentLive') }}
-          </p>
-        </div>
-      </div>
-    </DetailDrawer>
+    <!-- Stripe customers roster. Deliberately OUTSIDE the catalog's
+         loading/error chain: it is an independent read, so a failing catalog
+         must not hide the billed-organizations list (and vice versa). -->
+    <StripeOrganizationsSection class="mt-8" />
   </div>
 </template>

--- a/src/apps/admin/views/AdminCustomerDetail.vue
+++ b/src/apps/admin/views/AdminCustomerDetail.vue
@@ -919,6 +919,21 @@
             {{ t('web.admin.customers.detail.sections.secrets') }}
             <span class="ml-1 text-sm font-normal text-gray-500 dark:text-gray-400">({{ details.secrets.count }})</span>
           </h3>
+          <!-- The server told us this list is PARTIAL. Say so plainly — the
+               count beside the heading is what is on screen, not the total. -->
+          <p
+            v-if="details.secrets.truncated"
+            class="mt-1.5 flex items-start gap-1.5 text-xs text-amber-700 dark:text-amber-400"
+            data-testid="secrets-truncated">
+            <OIcon
+              collection="heroicons"
+              name="exclamation-triangle"
+              size="4"
+              class="mt-px shrink-0" />
+            <span>{{
+              t('web.admin.customers.detail.secrets.partial', { count: details.secrets.count })
+            }}</span>
+          </p>
         </div>
         <DataTable
           :columns="secretColumns"
@@ -943,6 +958,19 @@
             {{ t('web.admin.customers.detail.sections.receipts') }}
             <span class="ml-1 text-sm font-normal text-gray-500 dark:text-gray-400">({{ details.receipts.count }})</span>
           </h3>
+          <p
+            v-if="details.receipts.truncated"
+            class="mt-1.5 flex items-start gap-1.5 text-xs text-amber-700 dark:text-amber-400"
+            data-testid="receipts-truncated">
+            <OIcon
+              collection="heroicons"
+              name="exclamation-triangle"
+              size="4"
+              class="mt-px shrink-0" />
+            <span>{{
+              t('web.admin.customers.detail.receipts.partial', { count: details.receipts.count })
+            }}</span>
+          </p>
         </div>
         <DataTable
           :columns="receiptColumns"

--- a/src/apps/admin/views/AdminCustomerDetail.vue
+++ b/src/apps/admin/views/AdminCustomerDetail.vue
@@ -205,8 +205,20 @@
     purge: 'purge',
   };
 
-  /** Destructive actions gate confirm behind retyping the public id. */
+  /** Destructive actions gate confirm behind a typed-confirmation token. */
   const DANGER_ACTIONS: readonly ActionKey[] = ['purge', 'suspend'];
+
+  /**
+   * The exact string the operator must retype, or undefined for a one-click
+   * confirm. PURGE is irreversible, so it asks for the account's EMAIL — the
+   * identifier the operator can check against the ticket they are working,
+   * rather than an id they just copied off this page. Suspend is reversible and
+   * keeps the public id.
+   */
+  function confirmTokenFor(action: ActionKey): string | undefined {
+    if (!DANGER_ACTIONS.includes(action)) return undefined;
+    return action === 'purge' ? record.value?.email : publicId.value;
+  }
 
   const dialogConfig = computed(() => {
     const action = activeAction.value;
@@ -231,12 +243,22 @@
     return {
       title: t(`web.admin.customers.actions.${key}.confirmTitle`),
       description: t(`web.admin.customers.actions.${key}.confirmDescription`, args),
-      // Typed-confirmation gate: retype the public id to enable confirm.
-      confirmToken: isDanger ? publicId.value : undefined,
+      confirmToken: confirmTokenFor(action),
       variant: isDanger ? ('danger' as const) : ('default' as const),
       confirmText: isDanger ? t(`web.admin.customers.actions.${key}.button`) : undefined,
     };
   });
+
+  /**
+   * Prompt copy above the typed-confirmation input. Purge names the email
+   * explicitly; everything else falls back to the kit's generic prompt.
+   */
+  function promptFor(token: string | undefined): string {
+    const args = { token: token ?? '' };
+    return activeAction.value === 'purge'
+      ? t('web.admin.customers.actions.purge.typePrompt', args)
+      : t('web.admin.kit.confirmDialog.typePrompt', args);
+  }
 
   const successMessageKey: Record<ActionKey, string> = {
     setRole: 'web.admin.customers.actions.role.success',
@@ -570,14 +592,28 @@
           ">
           {{ t(`web.admin.customers.roles.${record.role}`, record.role) }}
         </span>
+        <!-- Verification state, both ways: the action panel only offers the verb
+             that matches this, so it must never be ambiguous. Amber (attention),
+             not red — red stays reserved for destructive/suspended. -->
         <span
           v-if="record.verified"
-          class="inline-flex items-center gap-1 rounded bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/40 dark:text-green-200">
+          class="inline-flex items-center gap-1 rounded bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/40 dark:text-green-200"
+          data-testid="verified-badge">
           <OIcon
             collection="heroicons"
             name="check-circle"
             size="3" />
-          {{ t('web.admin.customers.detail.fields.verified') }}
+          {{ t('web.admin.customers.verification.verified') }}
+        </span>
+        <span
+          v-else
+          class="inline-flex items-center gap-1 rounded bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-200"
+          data-testid="unverified-badge">
+          <OIcon
+            collection="heroicons"
+            name="exclamation-triangle"
+            size="3" />
+          {{ t('web.admin.customers.verification.unverified') }}
         </span>
         <span
           v-if="record.suspended"
@@ -964,7 +1000,7 @@
       <AdminCustomerSessionsSection :user-id="publicId" />
     </div>
 
-    <!-- Shared guarded-action dialog (typed-confirm for purge). -->
+    <!-- Shared guarded-action dialog (typed-confirm for purge + suspend). -->
     <AdminConfirmDialog
       v-model:open="dialogOpen"
       :title="dialogConfig.title"
@@ -975,6 +1011,10 @@
       :loading="mutationLoading"
       :error="mutationError"
       @confirm="onConfirm"
-      @cancel="onCancel" />
+      @cancel="onCancel">
+      <template #prompt="{ token }">
+        {{ promptFor(token) }}
+      </template>
+    </AdminConfirmDialog>
   </div>
 </template>

--- a/src/apps/admin/views/AdminCustomers.vue
+++ b/src/apps/admin/views/AdminCustomers.vue
@@ -4,6 +4,7 @@
 
   import RevealEmail from '@/apps/admin/components/RevealEmail.vue';
   import {
+    AdminConfirmDialog,
     DataTable,
     DetailDrawer,
     FilterBar,
@@ -11,9 +12,11 @@
     StatCard,
   } from '@/apps/admin/components/kit';
   import type { DataTableColumn, FilterConfig } from '@/apps/admin/components/kit';
+  import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
   import { useAdminCustomers } from '@/apps/admin/stores/useAdminCustomers';
   import type { ColonelUser } from '@/schemas/api/internal/responses/colonel';
   import OIcon from '@/shared/components/icons/OIcon.vue';
+  import { useNotificationsStore } from '@/shared/stores/notificationsStore';
   import { formatDisplayDateTime } from '@/utils/format';
   import { storeToRefs } from 'pinia';
   import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
@@ -32,11 +35,17 @@
    * address or an id). Columns are non-sortable on purpose: the endpoint returns a
    * FIXED most-recently-modified ordering (epic #20 CONTRACT 6), so there is no
    * server `sort` param to drive a controlled re-fetch.
+   *
+   * The drawer also carries the two row-scoped operator actions (ticket #22
+   * follow-up): manual VERIFY/UNVERIFY (simple confirm — reversible) and PURGE
+   * (danger, typed-confirmation on the account's email). Both run through the
+   * store + `useAdminMutation` + notifications idiom; audit is server-side.
    */
   const { t } = useI18n();
 
   const store = useAdminCustomers();
   const { customers, pagination, loading, error } = storeToRefs(store);
+  const notifications = useNotificationsStore();
 
   /** Assignable roles, mirrored from the backend SetRole::VALID_ROLES. */
   const ROLE_OPTIONS = ['colonel', 'admin', 'staff', 'customer'] as const;
@@ -131,8 +140,9 @@
   // Detail is a slide-over drawer (the console's standard inspect pattern, same
   // as organizations / sessions) rather than a full-page route, so a row click
   // never yanks you out of the list you're scanning. The drawer renders from the
-  // row data already in hand — no second fetch — and offers "Open full page" for
-  // the deep, mutating actions that live on AdminCustomerDetail.
+  // row data already in hand — no second fetch — carries the two row-scoped
+  // actions (verify/unverify, purge) in its footer, and offers "Open full page"
+  // for the rest (role, plan, suspend, billing) on AdminCustomerDetail.
   const drawerOpen = ref(false);
   const selectedCustomer = ref<ColonelUser | null>(null);
 
@@ -167,6 +177,108 @@
   function openDetail(row: ColonelUser): void {
     selectedCustomer.value = row;
     drawerOpen.value = true;
+  }
+
+  // ---- Drawer actions (CONTRACT 3 / D4) -------------------------------------
+  // ONE confirm dialog per page (the kit hard-codes its element ids), driven by
+  // an activeAction state machine — the console's standard multi-action shape.
+
+  type ActionKey = 'verify' | 'unverify' | 'purge';
+
+  const dialogOpen = ref(false);
+  const activeAction = ref<ActionKey | null>(null);
+  /** The row the confirm dialog is gating (request target + typed token source). */
+  const actionTarget = ref<ColonelUser | null>(null);
+
+  const {
+    loading: mutationLoading,
+    error: mutationError,
+    run: runMutation,
+    reset: resetMutation,
+  } = useAdminMutation(async () => {
+    const target = actionTarget.value;
+    const action = activeAction.value;
+    if (!target || !action) throw new Error('No customer selected');
+
+    if (action === 'purge') {
+      await store.purge(target.user_id);
+      return;
+    }
+    // The store patches the row in place on a 2xx; re-point the drawer at the
+    // new object so the verification state flips with no page reload.
+    const updated = await store.setVerification(target.user_id, action === 'verify');
+    if (!updated) return;
+    actionTarget.value = updated;
+    if (selectedCustomer.value?.user_id === updated.user_id) {
+      selectedCustomer.value = updated;
+    }
+  });
+
+  const SUCCESS_MESSAGE_KEY: Record<ActionKey, string> = {
+    verify: 'web.admin.customers.actions.verify.success',
+    unverify: 'web.admin.customers.actions.unverify.success',
+    purge: 'web.admin.customers.actions.purge.success',
+  };
+
+  const dialogConfig = computed(() => {
+    const action = activeAction.value;
+    const email = actionTarget.value?.email ?? '';
+    if (!action) {
+      return {
+        title: '',
+        description: undefined,
+        confirmToken: undefined,
+        variant: 'default' as const,
+        confirmText: undefined,
+      };
+    }
+    return {
+      title: t(`web.admin.customers.actions.${action}.confirmTitle`),
+      description: t(`web.admin.customers.actions.${action}.confirmDescription`, { email }),
+      // Purge is irreversible: gate confirm behind retyping the account's email.
+      // Verify/unverify are reversible, so they degrade to a one-click confirm.
+      confirmToken: action === 'purge' ? email : undefined,
+      variant: action === 'purge' ? ('danger' as const) : ('default' as const),
+      confirmText: t(`web.admin.customers.actions.${action}.button`),
+    };
+  });
+
+  function requestAction(key: ActionKey, row: ColonelUser): void {
+    activeAction.value = key;
+    actionTarget.value = row;
+    resetMutation(); // clear any error left from a previous attempt
+    dialogOpen.value = true;
+  }
+
+  async function onConfirm(): Promise<void> {
+    const action = activeAction.value;
+    if (!action) return;
+
+    const ok = await runMutation();
+    if (!ok) return; // Failure message stays in the dialog for retry/cancel.
+
+    dialogOpen.value = false;
+    notifications.show(t(SUCCESS_MESSAGE_KEY[action]), 'success');
+    activeAction.value = null;
+    actionTarget.value = null;
+
+    if (action === 'purge') {
+      // The record is gone: close the drawer, then re-read the page under it
+      // (the store already dropped the row; totals/pagination move server-side).
+      drawerOpen.value = false;
+      selectedCustomer.value = null;
+      await fetchPage(pagination.value?.page ?? 1);
+    }
+    // Verify/unverify deliberately do NOT refetch: the ack already told us the
+    // new state and the store patched the row, so a re-read would only risk
+    // flickering back to a stale list read.
+  }
+
+  function onCancel(): void {
+    dialogOpen.value = false;
+    activeAction.value = null;
+    actionTarget.value = null;
+    resetMutation();
   }
 
   onMounted(() => fetchPage(1));
@@ -328,6 +440,31 @@
           {{ t('web.admin.customers.suspended.badge') }}
         </div>
 
+        <!-- Verification state, stated plainly: the operator decides between
+             verify and unverify from this, so it is a pill (amber = attention,
+             never red — red is reserved for destructive/suspended). -->
+        <div class="flex flex-wrap items-center gap-2">
+          <span
+            class="inline-flex items-center gap-1 rounded px-2 py-0.5 font-brand text-[11px] font-semibold tracking-wide uppercase"
+            :class="
+              selectedCustomer.verified
+                ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200'
+                : 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200'
+            "
+            data-testid="customer-drawer-verification">
+            <OIcon
+              collection="heroicons"
+              :name="selectedCustomer.verified ? 'check-circle' : 'exclamation-triangle'"
+              size="3"
+              class="shrink-0" />
+            {{
+              selectedCustomer.verified
+                ? t('web.admin.customers.verification.verified')
+                : t('web.admin.customers.verification.unverified')
+            }}
+          </span>
+        </div>
+
         <section>
           <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
             <StatCard
@@ -378,7 +515,8 @@
           </dl>
         </section>
 
-        <!-- Escalation: the deep, mutating actions live on the full page. -->
+        <!-- Escalation: verify/unverify + purge are in the footer below; role,
+             plan, suspend and the full read-out live on the detail page. -->
         <section class="border-t border-gray-200 pt-6 dark:border-gray-800">
           <router-link
             :to="{ name: 'AdminCustomerDetail', params: { id: selectedCustomer.user_id } }"
@@ -392,6 +530,70 @@
           </router-link>
         </section>
       </div>
+
+      <!-- Operator actions. Same guarded flow as the full page, so a support
+           agent never has to leave the list they are scanning. -->
+      <template #footer>
+        <div
+          v-if="selectedCustomer"
+          class="flex flex-wrap items-center gap-2">
+          <button
+            v-if="!selectedCustomer.verified"
+            type="button"
+            data-testid="drawer-verify-button"
+            class="inline-flex items-center justify-center gap-1 rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-brand-500 focus:outline-none dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+            @click="requestAction('verify', selectedCustomer)">
+            <OIcon
+              collection="heroicons"
+              name="check-circle"
+              size="4" />
+            {{ t('web.admin.customers.actions.verify.button') }}
+          </button>
+          <button
+            v-else
+            type="button"
+            data-testid="drawer-unverify-button"
+            class="inline-flex items-center justify-center gap-1 rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-brand-500 focus:outline-none dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+            @click="requestAction('unverify', selectedCustomer)">
+            <OIcon
+              collection="heroicons"
+              name="x-circle"
+              size="4" />
+            {{ t('web.admin.customers.actions.unverify.button') }}
+          </button>
+
+          <button
+            type="button"
+            data-testid="drawer-purge-button"
+            class="ml-auto inline-flex items-center justify-center gap-1 rounded-md border border-red-300 px-3 py-2 text-sm font-semibold text-red-700 hover:bg-red-50 focus:ring-2 focus:ring-red-500 focus:outline-none dark:border-red-800 dark:text-red-300 dark:hover:bg-red-900/30"
+            @click="requestAction('purge', selectedCustomer)">
+            <OIcon
+              collection="heroicons"
+              name="trash"
+              size="4" />
+            {{ t('web.admin.customers.actions.purge.button') }}
+          </button>
+        </div>
+      </template>
     </DetailDrawer>
+
+    <!-- Single guarded-action dialog (typed-confirm on the email for purge). -->
+    <AdminConfirmDialog
+      v-model:open="dialogOpen"
+      :title="dialogConfig.title"
+      :description="dialogConfig.description"
+      :confirm-token="dialogConfig.confirmToken"
+      :variant="dialogConfig.variant"
+      :confirm-text="dialogConfig.confirmText"
+      :loading="mutationLoading"
+      :error="mutationError"
+      @confirm="onConfirm"
+      @cancel="onCancel">
+      <!-- Only purge is in typed mode here, so the prompt can name the email
+           outright — the operator must see exactly what to type, and why. -->
+      <template #prompt="{ token }">
+        {{ t('web.admin.customers.actions.purge.typePrompt', { token: token ?? '' }) }}
+      </template>
+    </AdminConfirmDialog>
   </div>
 </template>

--- a/src/apps/admin/views/AdminCustomers.vue
+++ b/src/apps/admin/views/AdminCustomers.vue
@@ -76,6 +76,7 @@
     { key: 'secrets', label: t('web.admin.customers.columns.secrets'), align: 'right' },
     { key: 'created', label: t('web.admin.customers.columns.created') },
     { key: 'lastLogin', label: t('web.admin.customers.columns.lastLogin') },
+    { key: 'actions', label: t('web.admin.customers.columns.actions'), align: 'right' },
   ]);
 
   /** Fetch one server page with the active filters. Errors surface via the store. */
@@ -143,6 +144,11 @@
   // row data already in hand — no second fetch — carries the two row-scoped
   // actions (verify/unverify, purge) in its footer, and offers "Open full page"
   // for the rest (role, plan, suspend, billing) on AdminCustomerDetail.
+  //
+  // The row's `actions` cell ALSO links straight to AdminCustomerDetail for the
+  // operator who already knows they want the full record — see the cell-actions
+  // template. It is a real router-link (middle-click / new-tab must work), not a
+  // second path through this handler.
   const drawerOpen = ref(false);
   const selectedCustomer = ref<ColonelUser | null>(null);
 
@@ -409,6 +415,27 @@
           <span class="text-gray-500 tabular-nums dark:text-gray-400">{{
             row.last_login ? formatDisplayDateTime(row.last_login) : t('web.admin.customers.detail.never')
           }}</span>
+        </template>
+
+        <!-- Row escalation: straight to the full page, skipping the drawer.
+             A real <router-link> (not a JS handler) so middle-click and
+             open-in-new-tab work; @click.stop so it doesn't ALSO open the
+             drawer behind it. Mirrors the domains table's row action. -->
+        <template #cell-actions="{ row }">
+          <div class="flex items-center justify-end">
+            <router-link
+              :to="{ name: 'AdminCustomerDetail', params: { id: row.user_id } }"
+              :data-testid="`customer-detail-${row.user_id}`"
+              :aria-label="t('web.admin.customers.detail.openFullPage')"
+              :title="t('web.admin.customers.detail.openFullPage')"
+              class="rounded p-1.5 text-gray-400 hover:text-brand-600 focus:ring-2 focus:ring-brand-500 focus:outline-none dark:hover:text-brand-400"
+              @click.stop>
+              <OIcon
+                collection="heroicons"
+                name="arrow-right"
+                size="4" />
+            </router-link>
+          </div>
         </template>
       </DataTable>
     </div>

--- a/src/apps/admin/views/AdminDomainDetail.vue
+++ b/src/apps/admin/views/AdminDomainDetail.vue
@@ -1,0 +1,976 @@
+<!-- src/apps/admin/views/AdminDomainDetail.vue -->
+
+<script setup lang="ts">
+
+  import AdminDomainDnsDetails from '@/apps/admin/components/AdminDomainDnsDetails.vue';
+  import DomainProbeResult from '@/apps/admin/components/domains/DomainProbeResult.vue';
+  import DomainStateBadge from '@/apps/admin/components/domains/DomainStateBadge.vue';
+  import { AdminConfirmDialog, StatCard } from '@/apps/admin/components/kit';
+  import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
+  import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
+  import { useAdminDomains } from '@/apps/admin/stores/useAdminDomains';
+  import type { ColonelDomainRemoveDetails } from '@/apps/admin/stores/useAdminDomains';
+  import { colonelDomainDetailResponseSchema } from '@/schemas/api/internal/responses/colonel-domains';
+  import type { ColonelDomainVerifyDetails } from '@/schemas/api/internal/responses/colonel-domains';
+  import type {
+    ColonelDomainProbeDetails,
+    ColonelDomainRepairDetails,
+    ColonelDomainTransferDetails,
+  } from '@/schemas/api/internal/responses/colonel-domaintoolbox';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import { useNotificationsStore } from '@/shared/stores/notificationsStore';
+  import { formatDisplayDateTime } from '@/utils/format';
+  import { computed, onMounted, ref } from 'vue';
+  import { useI18n } from 'vue-i18n';
+  import { useRouter } from 'vue-router';
+
+  /**
+   * Domain detail — the custom-domains peer of AdminCustomerDetail.vue: one
+   * record, a full read-out, and every per-domain operation the colonel API
+   * exposes, each behind the console's standard guard.
+   *
+   * - Single-resource fetch via {@link useResourceFetch} against
+   *   `GET /api/colonel/domains/:extid`, keyed by the domain's PUBLIC id.
+   * - Read-out: identity + timestamps, verification/serving state, the owning
+   *   organization (linked to its own detail page) and the DNS records the
+   *   operator must publish ({@link AdminDomainDnsDetails}, reused verbatim from
+   *   the list's attach panel).
+   * - Operations, ALL driven through {@link useAdminDomains} so this page, the
+   *   list and the Domain Toolbox share one implementation per verb:
+   *     verify   — one-click confirm; the honest post-check state is reported.
+   *     probe    — read-only HTTPS/TLS diagnostics, no confirmation.
+   *     repair   — dry-run PREVIEW first, apply behind typed confirmation.
+   *     transfer — dry-run PREVIEW first, apply behind typed confirmation.
+   *     remove   — dry-run PREVIEW first, apply behind typed confirmation.
+   *   `dry_run` defaults to TRUE server-side on repair/transfer/remove, so the
+   *   preview is free and the apply must say `dry_run: false` explicitly.
+   * - Audit is emitted SERVER-SIDE by each operation; nothing here logs it.
+   */
+  const props = defineProps<{
+    /** The domain's public id (route param), forwarded from the router. */
+    id: string;
+  }>();
+
+  const { t } = useI18n();
+  const router = useRouter();
+  const notifications = useNotificationsStore();
+  const store = useAdminDomains();
+
+  const publicId = computed(() => props.id);
+  const domainUrl = (): string => `/api/colonel/domains/${encodeURIComponent(publicId.value)}`;
+
+  const {
+    data: domainData,
+    loading: domainLoading,
+    error: domainError,
+    validationError: domainValidationError,
+    notFound: domainNotFound,
+    load: loadDomain,
+    refresh: refreshDomain,
+  } = useResourceFetch({
+    url: domainUrl,
+    schema: colonelDomainDetailResponseSchema,
+    context: 'ColonelDomainDetailResponse',
+  });
+
+  const record = computed(() => domainData.value?.record ?? null);
+  const cluster = computed(() => domainData.value?.details?.cluster ?? null);
+
+  /** A non-404 network/HTTP failure, or a Zod contract mismatch. */
+  const loadFailed = computed(
+    () =>
+      (domainError.value !== null && !domainNotFound.value) ||
+      domainValidationError.value !== null
+  );
+
+  /** External URL so an operator can open the live domain in a new tab. */
+  const externalUrl = computed(() =>
+    record.value ? `https://${record.value.display_domain}` : ''
+  );
+
+  function yesNo(value: boolean | null | undefined): string {
+    return value ? t('web.admin.domains.detail.yes') : t('web.admin.domains.detail.no');
+  }
+
+  // ---- Owning organization ---------------------------------------------------
+  //
+  // The detail endpoint returns the domain's safe_dump, which does NOT carry
+  // org_id / org_name (they are not safe_dump fields on CustomDomain). The store
+  // caches every list row it has seen, so arriving from the list gives us the
+  // owner; a cold deep-link degrades to an explicit "unknown" note instead of a
+  // wrong or empty value. The record fields are read first so this page picks
+  // the owner up automatically if the endpoint ever starts sending it.
+
+  const listRow = computed(() => store.rowFor(publicId.value));
+  const orgId = computed(() => record.value?.org_id || listRow.value?.org_id || '');
+  const orgName = computed(() => record.value?.org_name || listRow.value?.org_name || '');
+
+  // ---- Read-out fields -------------------------------------------------------
+
+  const overviewFields = computed(() => {
+    const r = record.value;
+    if (!r) return [];
+    return [
+      {
+        key: 'publicId',
+        label: t('web.admin.domains.fields.publicId'),
+        value: r.extid,
+        mono: true,
+      },
+      {
+        key: 'domainId',
+        label: t('web.admin.domains.fields.domainId'),
+        value: r.domain_id,
+        mono: true,
+      },
+      {
+        key: 'baseDomain',
+        label: t('web.admin.domains.fields.baseDomain'),
+        value: r.base_domain || t('web.admin.domains.detail.none'),
+        mono: true,
+      },
+      {
+        key: 'subdomain',
+        label: t('web.admin.domains.fields.subdomain'),
+        value: r.subdomain || r.trd || t('web.admin.domains.detail.none'),
+        mono: true,
+      },
+      {
+        key: 'apex',
+        label: t('web.admin.domains.fields.apex'),
+        value: yesNo(r.is_apex),
+        mono: false,
+      },
+      {
+        key: 'status',
+        label: t('web.admin.domains.fields.status'),
+        value: r.status || t('web.admin.domains.detail.none'),
+        mono: false,
+      },
+      {
+        key: 'created',
+        label: t('web.admin.domains.fields.created'),
+        value: r.created
+          ? formatDisplayDateTime(r.created)
+          : t('web.admin.domains.detail.none'),
+        mono: false,
+      },
+      {
+        key: 'updated',
+        label: t('web.admin.domains.fields.updated'),
+        value: r.updated
+          ? formatDisplayDateTime(r.updated)
+          : t('web.admin.domains.detail.never'),
+        mono: false,
+      },
+    ];
+  });
+
+  // ---- Probe (read-only, no confirmation) ------------------------------------
+
+  const probeDetails = ref<ColonelDomainProbeDetails | null>(null);
+
+  const {
+    loading: probeLoading,
+    error: probeError,
+    run: runProbe,
+    reset: resetProbe,
+  } = useAdminMutation(async () => {
+    probeDetails.value = await store.probe(publicId.value);
+  });
+
+  async function onProbe(): Promise<void> {
+    resetProbe();
+    probeDetails.value = null;
+    await runProbe();
+  }
+
+  // ---- Repair (dry-run preview → typed-confirm apply) ------------------------
+
+  const repairOrgId = ref('');
+  const repairPlan = ref<ColonelDomainRepairDetails | null>(null);
+
+  const {
+    loading: repairPreviewLoading,
+    error: repairPreviewError,
+    run: runRepairPreview,
+    reset: resetRepairPreview,
+  } = useAdminMutation(async () => {
+    repairPlan.value = await store.repair(publicId.value, {
+      orgId: repairOrgId.value.trim() || undefined,
+      dryRun: true,
+    });
+  });
+
+  async function onRepairPreview(): Promise<void> {
+    resetRepairPreview();
+    repairPlan.value = null;
+    await runRepairPreview();
+  }
+
+  /** Only offer the apply when the preview actually planned repairs. */
+  const repairApplicable = computed(
+    () => repairPlan.value?.status === 'planned' && (repairPlan.value?.issues.length ?? 0) > 0
+  );
+
+  // ---- Transfer (dry-run preview → typed-confirm apply) ----------------------
+
+  const transferToOrg = ref('');
+  const transferFromOrg = ref('');
+  const transferPlan = ref<ColonelDomainTransferDetails | null>(null);
+
+  const transferReady = computed(() => transferToOrg.value.trim() !== '');
+
+  const {
+    loading: transferPreviewLoading,
+    error: transferPreviewError,
+    run: runTransferPreview,
+    reset: resetTransferPreview,
+  } = useAdminMutation(async () => {
+    transferPlan.value = await store.transfer(publicId.value, {
+      toOrg: transferToOrg.value.trim(),
+      fromOrg: transferFromOrg.value.trim() || undefined,
+      dryRun: true,
+    });
+  });
+
+  async function onTransferPreview(): Promise<void> {
+    if (!transferReady.value) return;
+    resetTransferPreview();
+    transferPlan.value = null;
+    await runTransferPreview();
+  }
+
+  const transferApplicable = computed(() => transferPlan.value?.status === 'planned');
+
+  // ---- Remove (dry-run preview → typed-confirm apply) ------------------------
+
+  const removePlan = ref<ColonelDomainRemoveDetails | null>(null);
+
+  const {
+    loading: removePreviewLoading,
+    error: removePreviewError,
+    run: runRemovePreview,
+    reset: resetRemovePreview,
+  } = useAdminMutation(async () => {
+    removePlan.value = await store.remove(publicId.value, true);
+  });
+
+  async function onRemovePreview(): Promise<void> {
+    resetRemovePreview();
+    removePlan.value = null;
+    await runRemovePreview();
+  }
+
+  // ---- The single guarded-action dialog --------------------------------------
+
+  type ActionKey = 'verify' | 'repair' | 'transfer' | 'remove';
+
+  const dialogOpen = ref(false);
+  const activeAction = ref<ActionKey | null>(null);
+  /** The last verify outcome, read in onConfirm to pick an honest message. */
+  const verifyResult = ref<ColonelDomainVerifyDetails | null>(null);
+
+  const {
+    loading: mutationLoading,
+    error: mutationError,
+    run: runMutation,
+    reset: resetMutation,
+  } = useAdminMutation(async () => {
+    switch (activeAction.value) {
+      case 'verify':
+        verifyResult.value = await store.verify(publicId.value);
+        return;
+      case 'repair':
+        await store.repair(publicId.value, {
+          orgId: repairOrgId.value.trim() || undefined,
+          dryRun: false,
+        });
+        return;
+      case 'transfer':
+        await store.transfer(publicId.value, {
+          toOrg: transferToOrg.value.trim(),
+          fromOrg: transferFromOrg.value.trim() || undefined,
+          dryRun: false,
+        });
+        return;
+      case 'remove':
+        await store.remove(publicId.value, false);
+        return;
+      default:
+        throw new Error('No active action');
+    }
+  });
+
+  /** Repair, transfer and remove all rewrite or destroy ownership state. */
+  const DANGER_ACTIONS: readonly ActionKey[] = ['repair', 'transfer', 'remove'];
+
+  /**
+   * i18n root per action. Verify points at the SHARED `verify.*` subtree the
+   * list screen already uses, so the two surfaces never drift into two wordings
+   * of the same confirmation.
+   */
+  const ACTION_I18N_ROOT: Record<ActionKey, string> = {
+    verify: 'web.admin.domains.verify',
+    repair: 'web.admin.domains.actions.repair',
+    transfer: 'web.admin.domains.actions.transfer',
+    remove: 'web.admin.domains.actions.remove',
+  };
+
+  const dialogConfig = computed(() => {
+    const action = activeAction.value;
+    if (!action) {
+      return {
+        title: '',
+        description: undefined as string | undefined,
+        confirmToken: undefined as string | undefined,
+        variant: 'default' as const,
+        confirmText: undefined as string | undefined,
+      };
+    }
+
+    const root = ACTION_I18N_ROOT[action];
+    const isDanger = DANGER_ACTIONS.includes(action);
+    const args: Record<string, string> = {
+      domain: record.value?.display_domain ?? publicId.value,
+      org: transferToOrg.value.trim(),
+    };
+    return {
+      title: t(`${root}.confirmTitle`),
+      description: t(`${root}.confirmDescription`, args),
+      // Typed-confirmation gate: retype the domain's public id, matching the
+      // console convention (AdminCustomerDetail, Domain Toolbox).
+      confirmToken: isDanger ? publicId.value : undefined,
+      variant: isDanger ? ('danger' as const) : ('default' as const),
+      confirmText: t(`${root}.button`),
+    };
+  });
+
+  function requestAction(key: ActionKey): void {
+    activeAction.value = key;
+    resetMutation();
+    dialogOpen.value = true;
+  }
+
+  /** Per-state operator notification for verify. Unknown states fall back. */
+  const VERIFY_MESSAGE_KEYS: Record<string, string> = {
+    verified: 'web.admin.domains.verify.success.verified',
+    resolving: 'web.admin.domains.verify.success.resolving',
+    pending: 'web.admin.domains.verify.success.pending',
+    unverified: 'web.admin.domains.verify.success.unverified',
+  };
+
+  function notifyVerifyOutcome(): void {
+    const state = verifyResult.value?.current_state ?? '';
+    const messageKey = VERIFY_MESSAGE_KEYS[state] ?? 'web.admin.domains.verify.success.done';
+    notifications.show(
+      t(messageKey, { domain: record.value?.display_domain ?? publicId.value }),
+      state === 'verified' ? 'success' : 'info'
+    );
+  }
+
+  async function onConfirm(): Promise<void> {
+    const action = activeAction.value;
+    if (!action) return;
+
+    const ok = await runMutation();
+    if (!ok) return; // Failure message stays in the dialog for retry/cancel.
+
+    dialogOpen.value = false;
+
+    if (action === 'verify') {
+      notifyVerifyOutcome();
+      verifyResult.value = null;
+    } else {
+      notifications.show(t(`${ACTION_I18N_ROOT[action]}.success`), 'success');
+    }
+
+    if (action === 'remove') {
+      // The record no longer exists — drop the cached row and return to the list.
+      store.forget(publicId.value);
+      activeAction.value = null;
+      router.push({ name: 'AdminDomains' });
+      return;
+    }
+
+    // The plans described the pre-mutation world; clear them before refreshing.
+    repairPlan.value = null;
+    transferPlan.value = null;
+    removePlan.value = null;
+    await refreshDomain().catch(() => {});
+    activeAction.value = null;
+  }
+
+  function onCancel(): void {
+    dialogOpen.value = false;
+    activeAction.value = null;
+    resetMutation();
+  }
+
+  function goBack(): void {
+    router.push({ name: 'AdminDomains' });
+  }
+
+  onMounted(() => {
+    loadDomain().catch(() => {});
+  });
+</script>
+
+<template>
+  <div class="mx-auto max-w-5xl">
+    <!-- Back link -->
+    <button
+      type="button"
+      class="mb-4 inline-flex items-center gap-1 text-sm font-medium text-gray-500 hover:text-gray-700 focus:ring-2 focus:ring-brand-500 focus:outline-none dark:text-gray-400 dark:hover:text-gray-200"
+      data-testid="detail-back"
+      @click="goBack">
+      <OIcon
+        collection="heroicons"
+        name="arrow-left"
+        size="4" />
+      {{ t('web.admin.domains.detail.backToList') }}
+    </button>
+
+    <!-- Loading -->
+    <div
+      v-if="domainLoading && !record"
+      class="flex items-center justify-center py-24 text-gray-500 dark:text-gray-400"
+      data-testid="detail-loading">
+      <OIcon
+        collection="heroicons"
+        name="arrow-path"
+        size="6"
+        class="animate-spin motion-reduce:animate-none" />
+      <span class="ml-3 text-sm">{{ t('web.COMMON.loading') }}</span>
+    </div>
+
+    <!-- Not found -->
+    <div
+      v-else-if="domainNotFound"
+      class="rounded-lg border border-gray-200 bg-white px-6 py-16 text-center dark:border-gray-800 dark:bg-gray-900"
+      data-testid="detail-not-found">
+      <OIcon
+        collection="heroicons"
+        name="globe-alt"
+        size="8"
+        class="mx-auto text-gray-400 dark:text-gray-600" />
+      <h3 class="mt-3 text-lg font-medium text-gray-900 dark:text-white">
+        {{ t('web.admin.domains.detail.notFound') }}
+      </h3>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.domains.detail.notFoundDescription') }}
+      </p>
+      <button
+        type="button"
+        class="mt-4 inline-flex items-center gap-1 rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-brand-500 focus:outline-none dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+        @click="goBack">
+        {{ t('web.admin.domains.detail.backToList') }}
+      </button>
+    </div>
+
+    <!-- Load error (network/HTTP non-404, or contract mismatch) -->
+    <div
+      v-else-if="loadFailed"
+      class="rounded-lg border border-red-200 bg-red-50 px-6 py-16 text-center dark:border-red-900/50 dark:bg-red-900/20"
+      role="alert"
+      data-testid="detail-error">
+      <OIcon
+        collection="heroicons"
+        name="exclamation-triangle"
+        size="8"
+        class="mx-auto text-red-500 dark:text-red-400" />
+      <p class="mt-3 text-sm text-red-800 dark:text-red-200">
+        {{ t('web.admin.domains.detail.loadError') }}
+      </p>
+      <button
+        type="button"
+        class="mt-4 inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-2 text-sm font-medium text-red-800 hover:bg-red-100 focus:ring-2 focus:ring-red-500 focus:outline-none dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/40"
+        @click="loadDomain().catch(() => {})">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          size="4" />
+        {{ t('web.admin.domains.detail.retry') }}
+      </button>
+    </div>
+
+    <!-- Loaded -->
+    <div
+      v-else-if="record"
+      class="space-y-6"
+      data-testid="detail-content">
+      <!-- Header -->
+      <div class="flex flex-wrap items-center gap-3 border-b-2 border-gray-900 pb-4 dark:border-gray-100">
+        <h2 class="font-brand text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
+          {{ record.display_domain }}
+        </h2>
+        <DomainStateBadge
+          :state="record.verification_state"
+          testid="detail-state-badge" />
+        <span
+          v-if="record.ready"
+          class="inline-flex items-center gap-1 rounded bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/40 dark:text-green-200"
+          data-testid="detail-ready-badge">
+          <OIcon
+            collection="heroicons"
+            name="check-badge"
+            size="3" />
+          {{ t('web.admin.domains.tls.serving') }}
+        </span>
+        <a
+          :href="externalUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          data-testid="detail-open-external"
+          :aria-label="t('web.admin.domains.attach.openExternal', { domain: record.display_domain })"
+          :title="t('web.admin.domains.attach.openExternal', { domain: record.display_domain })"
+          class="rounded text-gray-400 hover:text-brand-600 focus:ring-2 focus:ring-brand-500 focus:outline-none dark:hover:text-brand-400">
+          <OIcon
+            collection="heroicons"
+            name="arrow-top-right-on-square"
+            size="4" />
+        </a>
+        <span class="font-mono text-xs text-gray-400 dark:text-gray-500">{{ record.extid }}</span>
+      </div>
+
+      <!-- Stat tiles -->
+      <div class="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <StatCard
+          :label="t('web.admin.domains.columns.state')"
+          :value="t(`web.colonel.customDomains.status.${record.verification_state}`, record.verification_state)"
+          icon="shield-check"
+          testid="stat-state" />
+        <StatCard
+          :label="t('web.admin.domains.fields.verified')"
+          :value="yesNo(record.verified)"
+          icon="check-circle"
+          testid="stat-verified" />
+        <StatCard
+          :label="t('web.admin.domains.fields.resolving')"
+          :value="yesNo(record.resolving)"
+          icon="signal"
+          testid="stat-resolving" />
+        <StatCard
+          :label="t('web.admin.domains.fields.ready')"
+          :value="yesNo(record.ready)"
+          icon="check-badge"
+          testid="stat-ready" />
+      </div>
+
+      <!-- Overview + Actions -->
+      <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <!-- Overview -->
+        <section
+          class="rounded-lg border border-gray-200 bg-white shadow-sm lg:col-span-2 dark:border-gray-800 dark:bg-gray-900">
+          <div class="border-b border-gray-200 px-6 py-4 dark:border-gray-800">
+            <h3 class="text-lg font-medium text-gray-900 dark:text-white">
+              {{ t('web.admin.domains.detail.sections.overview') }}
+            </h3>
+          </div>
+          <dl class="grid grid-cols-1 gap-x-6 gap-y-4 px-6 py-5 sm:grid-cols-2">
+            <div
+              v-for="field in overviewFields"
+              :key="field.key"
+              :data-testid="`profile-${field.key}`">
+              <dt class="text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                {{ field.label }}
+              </dt>
+              <dd
+                :class="[
+                  'mt-1 text-sm break-words text-gray-900 dark:text-gray-100',
+                  field.mono ? 'font-mono tabular-nums' : '',
+                ]">
+                {{ field.value }}
+              </dd>
+            </div>
+          </dl>
+        </section>
+
+        <!-- Action panel -->
+        <section
+          class="rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900"
+          data-testid="action-panel">
+          <div class="border-b border-gray-200 px-6 py-4 dark:border-gray-800">
+            <h3 class="text-lg font-medium text-gray-900 dark:text-white">
+              {{ t('web.admin.domains.detail.sections.actions') }}
+            </h3>
+          </div>
+          <div class="space-y-4 px-6 py-5">
+            <!-- Verify (reversible, one-click confirm) -->
+            <button
+              type="button"
+              data-testid="verify-button"
+              class="inline-flex w-full items-center justify-center gap-1 rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-brand-500 focus:outline-none dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+              @click="requestAction('verify')">
+              <OIcon
+                collection="heroicons"
+                name="shield-check"
+                size="4" />
+              {{ t('web.admin.domains.verify.button') }}
+            </button>
+
+            <!-- Probe (read-only: reaches the network, changes nothing) -->
+            <button
+              type="button"
+              data-testid="probe-button"
+              :disabled="probeLoading"
+              class="inline-flex w-full items-center justify-center gap-1 rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-brand-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+              @click="onProbe">
+              <OIcon
+                collection="heroicons"
+                :name="probeLoading ? 'arrow-path' : 'signal'"
+                size="4"
+                :class="probeLoading ? 'animate-spin motion-reduce:animate-none' : ''" />
+              {{ t('web.admin.domains.actions.probe.button') }}
+            </button>
+            <p
+              v-if="probeError"
+              class="text-sm text-red-700 dark:text-red-300"
+              role="alert"
+              data-testid="probe-error">
+              {{ probeError }}
+            </p>
+
+            <!-- Remove (destructive, typed-confirm). Preview first: the endpoint
+                 dry-runs by default, so this costs nothing and names the org
+                 that is about to lose the domain. -->
+            <div class="space-y-3 border-t border-gray-200 pt-4 dark:border-gray-800">
+              <button
+                type="button"
+                data-testid="remove-preview"
+                :disabled="removePreviewLoading"
+                class="inline-flex w-full items-center justify-center gap-1 rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-brand-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+                @click="onRemovePreview">
+                {{ t('web.admin.domains.actions.remove.previewButton') }}
+              </button>
+              <p
+                v-if="removePreviewError"
+                class="text-sm text-red-700 dark:text-red-300"
+                role="alert"
+                data-testid="remove-preview-error">
+                {{ removePreviewError }}
+              </p>
+              <div
+                v-if="removePlan"
+                class="rounded-md bg-gray-50 px-3 py-2 text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+                data-testid="remove-plan">
+                <p>
+                  {{ t('web.admin.domains.actions.remove.previewStatus') }}
+                  <span class="font-mono font-medium">{{ removePlan.status }}</span>
+                </p>
+                <p class="mt-1">
+                  {{ t('web.admin.domains.actions.remove.previewOrg') }}
+                  <span class="font-medium">{{
+                    removePlan.org_name || removePlan.org_id || t('web.admin.domains.detail.none')
+                  }}</span>
+                </p>
+                <p
+                  v-if="removePlan.reasserts_survivor"
+                  class="mt-1 text-amber-700 dark:text-amber-400"
+                  data-testid="remove-reasserts">
+                  {{ t('web.admin.domains.actions.remove.reassertsSurvivor') }}
+                </p>
+              </div>
+              <button
+                type="button"
+                data-testid="remove-button"
+                class="inline-flex w-full items-center justify-center gap-1 rounded-md border border-red-300 px-3 py-2 text-sm font-semibold text-red-700 hover:bg-red-50 focus:ring-2 focus:ring-red-500 focus:outline-none dark:border-red-800 dark:text-red-300 dark:hover:bg-red-900/30"
+                @click="requestAction('remove')">
+                <OIcon
+                  collection="heroicons"
+                  name="trash"
+                  size="4" />
+                {{ t('web.admin.domains.actions.remove.button') }}
+              </button>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <!-- Owning organization -->
+      <section
+        class="rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900"
+        data-testid="organization-section">
+        <div class="border-b border-gray-200 px-6 py-4 dark:border-gray-800">
+          <h3 class="text-lg font-medium text-gray-900 dark:text-white">
+            {{ t('web.admin.domains.detail.sections.organization') }}
+          </h3>
+        </div>
+        <div class="px-6 py-5">
+          <div
+            v-if="orgId"
+            class="flex flex-wrap items-center justify-between gap-3">
+            <div class="min-w-0">
+              <p class="truncate text-sm font-medium text-gray-900 dark:text-gray-100">
+                {{ orgName || t('web.admin.domains.detail.none') }}
+              </p>
+              <p class="truncate font-mono text-xs text-gray-400 dark:text-gray-500">
+                {{ orgId }}
+              </p>
+            </div>
+            <router-link
+              :to="{ name: 'AdminOrganizationDetail', params: { id: orgId } }"
+              data-testid="organization-link"
+              class="inline-flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-brand-500 focus:outline-none dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800">
+              {{ t('web.admin.domains.detail.organization.open') }}
+              <OIcon
+                collection="heroicons"
+                name="arrow-right"
+                size="4" />
+            </router-link>
+          </div>
+          <p
+            v-else
+            class="text-sm text-gray-500 dark:text-gray-400"
+            data-testid="organization-unknown">
+            {{ t('web.admin.domains.detail.organization.unknown') }}
+          </p>
+        </div>
+      </section>
+
+      <!-- DNS records to publish (same component the attach panel uses) -->
+      <section
+        class="rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900"
+        data-testid="dns-section">
+        <div class="border-b border-gray-200 px-6 py-4 dark:border-gray-800">
+          <h3 class="text-lg font-medium text-gray-900 dark:text-white">
+            {{ t('web.admin.domains.detail.sections.dns') }}
+          </h3>
+        </div>
+        <div class="px-6 py-5">
+          <AdminDomainDnsDetails
+            :record="record"
+            :cluster="cluster" />
+        </div>
+      </section>
+
+      <!-- Diagnostics (probe result) -->
+      <section
+        v-if="probeDetails"
+        class="rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900"
+        data-testid="probe-section">
+        <div class="border-b border-gray-200 px-6 py-4 dark:border-gray-800">
+          <h3 class="text-lg font-medium text-gray-900 dark:text-white">
+            {{ t('web.admin.domains.detail.sections.diagnostics') }}
+          </h3>
+        </div>
+        <div class="px-6 py-5">
+          <DomainProbeResult
+            :details="probeDetails"
+            :domain="record.display_domain" />
+        </div>
+      </section>
+
+      <!-- Ownership operations: repair + transfer. Both preview first. -->
+      <section
+        class="rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900"
+        data-testid="operations-section">
+        <div class="border-b border-gray-200 px-6 py-4 dark:border-gray-800">
+          <h3 class="text-lg font-medium text-gray-900 dark:text-white">
+            {{ t('web.admin.domains.detail.sections.operations') }}
+          </h3>
+          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.domains.detail.sections.operationsHint') }}
+          </p>
+        </div>
+
+        <!-- Repair -->
+        <div
+          class="border-b border-gray-200 px-6 py-5 dark:border-gray-800"
+          data-testid="repair-block">
+          <h4 class="text-sm font-semibold text-gray-900 dark:text-white">
+            {{ t('web.admin.domains.actions.repair.title') }}
+          </h4>
+          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.domains.actions.repair.description') }}
+          </p>
+
+          <div class="mt-3 flex flex-wrap items-end gap-3">
+            <div class="min-w-[16rem] flex-1">
+              <label
+                for="domain-repair-orgid"
+                class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+                {{ t('web.admin.domains.actions.repair.orgIdLabel') }}
+              </label>
+              <input
+                id="domain-repair-orgid"
+                v-model="repairOrgId"
+                type="text"
+                data-testid="repair-orgid-input"
+                :placeholder="t('web.admin.domains.actions.repair.orgIdPlaceholder')"
+                class="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm text-gray-900 focus:border-brand-500 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+            </div>
+            <button
+              type="button"
+              data-testid="repair-preview"
+              :disabled="repairPreviewLoading"
+              class="inline-flex items-center gap-1 rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-brand-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+              @click="onRepairPreview">
+              {{ t('web.admin.domains.actions.preview') }}
+            </button>
+          </div>
+
+          <p
+            v-if="repairPreviewError"
+            class="mt-3 text-sm text-red-700 dark:text-red-300"
+            role="alert"
+            data-testid="repair-preview-error">
+            {{ repairPreviewError }}
+          </p>
+
+          <div
+            v-if="repairPlan"
+            class="mt-4"
+            data-testid="repair-plan">
+            <p class="mb-2 text-sm text-gray-700 dark:text-gray-300">
+              {{ t('web.admin.domains.actions.repair.statusLabel') }}
+              <span
+                class="font-mono font-medium"
+                data-testid="repair-status">{{ repairPlan.status }}</span>
+            </p>
+            <ul
+              v-if="repairPlan.issues.length"
+              class="ml-4 list-disc space-y-1 text-sm text-gray-700 dark:text-gray-300">
+              <li
+                v-for="(issue, index) in repairPlan.issues"
+                :key="index">
+                {{ issue }}
+              </li>
+            </ul>
+            <p
+              v-else
+              class="text-sm text-gray-500 dark:text-gray-400">
+              {{ t('web.admin.domains.actions.repair.noIssues') }}
+            </p>
+
+            <button
+              v-if="repairApplicable"
+              type="button"
+              data-testid="repair-apply"
+              class="mt-4 inline-flex items-center gap-1 rounded-md bg-amber-600 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-700 focus:ring-2 focus:ring-amber-500 focus:outline-none"
+              @click="requestAction('repair')">
+              <OIcon
+                collection="heroicons"
+                name="cog-6-tooth"
+                size="4" />
+              {{ t('web.admin.domains.actions.repair.button') }}
+            </button>
+          </div>
+        </div>
+
+        <!-- Transfer -->
+        <div
+          class="px-6 py-5"
+          data-testid="transfer-block">
+          <h4 class="text-sm font-semibold text-gray-900 dark:text-white">
+            {{ t('web.admin.domains.actions.transfer.title') }}
+          </h4>
+          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.domains.actions.transfer.description') }}
+          </p>
+
+          <div class="mt-3 grid gap-3 sm:grid-cols-2">
+            <div>
+              <label
+                for="domain-transfer-to"
+                class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+                {{ t('web.admin.domains.actions.transfer.toOrgLabel') }}
+              </label>
+              <input
+                id="domain-transfer-to"
+                v-model="transferToOrg"
+                type="text"
+                data-testid="transfer-toorg-input"
+                class="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm text-gray-900 focus:border-brand-500 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+            </div>
+            <div>
+              <label
+                for="domain-transfer-from"
+                class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+                {{ t('web.admin.domains.actions.transfer.fromOrgLabel') }}
+              </label>
+              <input
+                id="domain-transfer-from"
+                v-model="transferFromOrg"
+                type="text"
+                data-testid="transfer-fromorg-input"
+                :placeholder="t('web.admin.domains.actions.transfer.fromOrgPlaceholder')"
+                class="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm text-gray-900 focus:border-brand-500 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+            </div>
+          </div>
+
+          <button
+            type="button"
+            data-testid="transfer-preview"
+            :disabled="!transferReady || transferPreviewLoading"
+            class="mt-3 inline-flex items-center gap-1 rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-brand-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+            @click="onTransferPreview">
+            {{ t('web.admin.domains.actions.preview') }}
+          </button>
+
+          <p
+            v-if="transferPreviewError"
+            class="mt-3 text-sm text-red-700 dark:text-red-300"
+            role="alert"
+            data-testid="transfer-preview-error">
+            {{ transferPreviewError }}
+          </p>
+
+          <div
+            v-if="transferPlan"
+            class="mt-4 text-sm"
+            data-testid="transfer-plan">
+            <dl class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <div>
+                <dt class="text-xs text-gray-500 dark:text-gray-400">
+                  {{ t('web.admin.domains.actions.transfer.from') }}
+                </dt>
+                <dd class="font-mono text-gray-900 dark:text-white">
+                  {{
+                    transferPlan.from_org_id
+                      ? `${transferPlan.from_org_name || '—'} (${transferPlan.from_org_id})`
+                      : t('web.admin.domains.actions.transfer.orphaned')
+                  }}
+                </dd>
+              </div>
+              <div>
+                <dt class="text-xs text-gray-500 dark:text-gray-400">
+                  {{ t('web.admin.domains.actions.transfer.to') }}
+                </dt>
+                <dd class="font-mono text-gray-900 dark:text-white">
+                  {{ transferPlan.to_org_name || '—' }} ({{ transferPlan.to_org_id }})
+                </dd>
+              </div>
+            </dl>
+
+            <button
+              v-if="transferApplicable"
+              type="button"
+              data-testid="transfer-apply"
+              class="mt-4 inline-flex items-center gap-1 rounded-md bg-amber-600 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-700 focus:ring-2 focus:ring-amber-500 focus:outline-none"
+              @click="requestAction('transfer')">
+              <OIcon
+                collection="heroicons"
+                name="arrow-right"
+                size="4" />
+              {{ t('web.admin.domains.actions.transfer.button') }}
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <!-- Shared guarded-action dialog (typed-confirm for repair/transfer/remove). -->
+    <AdminConfirmDialog
+      v-model:open="dialogOpen"
+      :title="dialogConfig.title"
+      :description="dialogConfig.description"
+      :confirm-token="dialogConfig.confirmToken"
+      :variant="dialogConfig.variant"
+      :confirm-text="dialogConfig.confirmText"
+      :loading="mutationLoading"
+      :error="mutationError"
+      @confirm="onConfirm"
+      @cancel="onCancel" />
+  </div>
+</template>

--- a/src/apps/admin/views/AdminDomains.vue
+++ b/src/apps/admin/views/AdminDomains.vue
@@ -5,48 +5,64 @@
   import AddDomainForOrgModal from '@/apps/admin/components/AddDomainForOrgModal.vue';
   import AdminDomainDnsDetails from '@/apps/admin/components/AdminDomainDnsDetails.vue';
   import AdminOrgSelectorModal from '@/apps/admin/components/AdminOrgSelectorModal.vue';
-  import { AdminConfirmDialog, AdminRecordPanel, KitPagination } from '@/apps/admin/components/kit';
+  import DomainStateBadge from '@/apps/admin/components/domains/DomainStateBadge.vue';
+  import {
+    AdminConfirmDialog,
+    AdminRecordPanel,
+    DataTable,
+    DetailDrawer,
+    FilterBar,
+    KitPagination,
+    StatCard,
+  } from '@/apps/admin/components/kit';
+  import type { DataTableColumn, FilterConfig } from '@/apps/admin/components/kit';
   import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
   import { useAdminDomains } from '@/apps/admin/stores/useAdminDomains';
   import type { ColonelCustomDomain, ColonelOrganization } from '@/schemas/api/internal/responses/colonel';
-  import {
-    colonelDomainDetailResponseSchema,
-    colonelDomainVerifyResponseSchema,
-    type ColonelDomainCluster,
-    type ColonelDomainDetailRecord,
+  import type {
+    ColonelDomainCluster,
+    ColonelDomainDetailRecord,
+    ColonelDomainVerifyDetails,
   } from '@/schemas/api/internal/responses/colonel-domains';
-  import type { ColonelDomainVerifyResponse } from '@/schemas/api/internal/responses/colonel-domains';
+  import { colonelDomainDetailResponseSchema } from '@/schemas/api/internal/responses/colonel-domains';
   import {
     colonelOrganizationDetailResponseSchema,
     type ColonelOrganizationDetailDomain,
   } from '@/schemas/api/internal/responses/colonel-organizations';
-  import CardGridSkeleton from '@/shared/components/closet/CardGridSkeleton.vue';
   import OIcon from '@/shared/components/icons/OIcon.vue';
   import { useApi } from '@/shared/composables/useApi';
   import { useNotificationsStore } from '@/shared/stores/notificationsStore';
   import { formatDisplayDateTime } from '@/utils/format';
   import { gracefulParse } from '@/utils/schemaValidation';
   import { storeToRefs } from 'pinia';
-  import { computed, onMounted, ref } from 'vue';
+  import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
   import { useI18n } from 'vue-i18n';
 
   /**
-   * Domains screen — dense domain table + per-domain verify (ticket #31,
-   * Phase-2 parity port), plus the admin "attach a domain to a specific
-   * organization" flow.
+   * Domains list — the User-Management-grade console surface for custom domains.
    *
-   * - LIST via {@link useAdminDomains} (a per-resource paginated store over the
-   *   existing `GET /api/colonel/domains`) + {@link KitPagination}.
-   * - The VERIFY action POSTs to `/api/colonel/domains/:extid/verify` and
-   *   surfaces the op's real DNS/SSL outcome HONESTLY (never faked).
-   * - The ATTACH flow: a CTA opens {@link AdminOrgSelectorModal} to pick an org
-   *   by objid/extid/email; the chosen org is pinned into an
-   *   {@link AdminRecordPanel} between the header rule and the list. From there
-   *   the operator adds a domain ({@link AddDomainForOrgModal} →
-   *   `POST /api/colonel/domains`) and inspects each domain's DNS-validation
-   *   records, status, and re-verify ({@link AdminDomainDnsDetails} +
-   *   `GET /api/colonel/domains/:extid`). The panel + picker are reusable kit /
-   *   components so other console screens can adopt the single-record pattern.
+   * Structure mirrors AdminCustomers.vue so a row behaves the same everywhere in
+   * the console: FilterBar + {@link DataTable} + {@link KitPagination} over the
+   * {@link useAdminDomains} store, a row click opens a read-only
+   * {@link DetailDrawer} rendered from data already in hand (no second fetch),
+   * and the drawer escalates to the full page (AdminDomainDetail) for the deep,
+   * mutating verbs (probe / repair / transfer / remove).
+   *
+   * Filters are SERVER-SIDE (`search` + `status` on GET /api/colonel/domains,
+   * applied before pagination) with the same 300 ms debounce and no-op guard
+   * AdminCustomers uses. `search` matches display_domain / base_domain plus an
+   * exact extid / domain_id — NOT the organization name.
+   *
+   * One deliberate difference from the customers list: VERIFY stays on the row.
+   * It is the one high-frequency, low-risk domain verb, so keeping it inline
+   * preserves the capability the previous card grid had and saves a round trip
+   * through the detail page.
+   *
+   * The admin "attach a domain to a specific organization" flow is unchanged: a
+   * CTA opens {@link AdminOrgSelectorModal}, the chosen org is pinned into an
+   * {@link AdminRecordPanel}, and from there the operator adds a domain
+   * ({@link AddDomainForOrgModal}) and inspects each domain's DNS records
+   * ({@link AdminDomainDnsDetails}).
    */
   const { t } = useI18n();
   const $api = useApi();
@@ -55,46 +71,85 @@
   const store = useAdminDomains();
   const { domains, pagination, loading, error } = storeToRefs(store);
 
-  // ---- Status badges (parity with the legacy screen) ------------------------
-
-  /** Verification-state badge colours, keyed by the op's state symbol. */
-  function stateBadgeClass(state: string): string {
-    switch (state) {
-      case 'verified':
-        return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
-      case 'pending':
-        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200';
-      case 'resolving':
-        return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200';
-      default:
-        return 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200';
-    }
-  }
-
-  const stateLabels = computed<Record<string, string>>(() => ({
-    verified: t('web.colonel.customDomains.status.verified'),
-    resolving: t('web.colonel.customDomains.status.resolving'),
-    pending: t('web.colonel.customDomains.status.pending'),
-  }));
-
-  function stateLabel(state: string): string {
-    return stateLabels.value[state] ?? state;
-  }
-
   /** External URL for an operator to open/test a domain in a new tab. */
   function domainUrl(displayDomain: string): string {
     return `https://${displayDomain}`;
   }
 
-  // ---- List fetching --------------------------------------------------------
+  // ---- Filters + list fetching ----------------------------------------------
+  //
+  // Both filters are SERVER-SIDE (`search` / `status` on
+  // GET /api/colonel/domains) and are applied before pagination, so the pager's
+  // total_count always describes the filtered population.
 
+  const searchTerm = ref('');
+  const activeSearch = ref('');
+  const stateFilter = ref('');
+
+  /** States the backend emits (CustomDomain#verification_state). */
+  const STATE_OPTIONS = ['verified', 'resolving', 'pending'] as const;
+
+  const filters = computed<FilterConfig[]>(() => [
+    {
+      key: 'state',
+      label: t('web.admin.domains.list.stateFilter'),
+      value: stateFilter.value,
+      options: STATE_OPTIONS.map((state) => ({
+        value: state,
+        label: t(`web.colonel.customDomains.status.${state}`, state),
+      })),
+    },
+  ]);
+
+  const hasActiveFilters = computed(
+    () => searchTerm.value !== '' || stateFilter.value !== ''
+  );
+
+  /** Fetch one server page with the active filters. Errors surface via the store. */
   async function fetchPage(targetPage = 1): Promise<void> {
     try {
-      await store.fetchPage(targetPage);
+      await store.fetchPage(targetPage, {
+        search: activeSearch.value || undefined,
+        status: stateFilter.value || undefined,
+      });
     } catch {
       // Network/HTTP failure is captured in `store.error`; the banner + retry
       // below handle it. Swallow so it doesn't become an unhandled rejection.
     }
+  }
+
+  // Debounce search input so we issue one request per pause, not per keystroke
+  // (the fixed AdminCustomers wiring, including the no-op guard).
+  let searchTimer: ReturnType<typeof setTimeout> | null = null;
+  watch(searchTerm, (value) => {
+    if (searchTimer) clearTimeout(searchTimer);
+    // Skip no-op changes (e.g. the programmatic reset in onClear(), which
+    // already issues its own fetch) so clearing doesn't double-fetch.
+    if (value.trim() === activeSearch.value) return;
+    searchTimer = setTimeout(() => {
+      activeSearch.value = value.trim();
+      fetchPage(1);
+    }, 300);
+  });
+  onBeforeUnmount(() => {
+    if (searchTimer) clearTimeout(searchTimer);
+  });
+
+  function onFilterChange(key: string, value: string): void {
+    if (key === 'state') {
+      stateFilter.value = value;
+      fetchPage(1);
+    }
+  }
+
+  function onClear(): void {
+    // Cancel any in-flight debounce so the reset below doesn't fire a second,
+    // late request on top of this one.
+    if (searchTimer) clearTimeout(searchTimer);
+    searchTerm.value = '';
+    activeSearch.value = '';
+    stateFilter.value = '';
+    fetchPage(1);
   }
 
   function onPageChange(targetPage: number): void {
@@ -102,19 +157,35 @@
   }
 
   function onPerPageChange(perPage: number): void {
+    // The composable owns perPage (reconciled from the server echo); set it then
+    // re-fetch the first page at the new size.
     store.perPage = perPage;
     fetchPage(1);
   }
 
-  // ---- Guarded verify action (list rows) ------------------------------------
+  // ---- Columns --------------------------------------------------------------
+  //
+  // Non-sortable on purpose: the endpoint returns a FIXED ordering and takes no
+  // `sort` param, so a sortable header would promise a re-fetch we cannot make.
+
+  const columns = computed<DataTableColumn<ColonelCustomDomain>[]>(() => [
+    { key: 'domain', label: t('web.admin.domains.columns.domain') },
+    { key: 'organization', label: t('web.admin.domains.columns.organization') },
+    { key: 'state', label: t('web.admin.domains.columns.state') },
+    { key: 'tls', label: t('web.admin.domains.columns.tls') },
+    { key: 'created', label: t('web.admin.domains.columns.created') },
+    { key: 'actions', label: t('web.admin.domains.columns.actions'), align: 'right' },
+  ]);
+
+  // ---- Guarded verify action (row + drawer) ---------------------------------
 
   const dialogOpen = ref(false);
   /** The domain awaiting confirmation, or currently being verified. */
   const activeDomain = ref<ColonelCustomDomain | null>(null);
-  /** extid of the domain whose verify request is in flight (per-card spinner). */
+  /** extid of the domain whose verify request is in flight (per-row spinner). */
   const verifyingExtid = ref<string | null>(null);
-  /** The last parsed verify ack, read in onConfirm to pick an honest message. */
-  const verifyResult = ref<ColonelDomainVerifyResponse | null>(null);
+  /** The last verify outcome, read in onConfirm to pick an honest message. */
+  const verifyResult = ref<ColonelDomainVerifyDetails | null>(null);
 
   const {
     loading: verifyLoading,
@@ -122,20 +193,11 @@
     run: runVerify,
     reset: resetVerify,
   } = useAdminMutation(async (extid: string) => {
-    verifyResult.value = null;
-    const response = await $api.post(
-      `/api/colonel/domains/${encodeURIComponent(extid)}/verify`
-    );
-    // Parse the ack so it stays a live tripwire. A 2xx means the verify ran
-    // server-side regardless of ack shape; a mismatch is reported by
-    // gracefulParse but does not fail the action (we fall back to a generic
-    // success message and refresh the list).
-    const parsed = gracefulParse(
-      colonelDomainVerifyResponseSchema,
-      response.data,
-      'ColonelDomainVerifyResponse'
-    );
-    verifyResult.value = parsed.ok ? parsed.data : null;
+    // The store owns the request + ack parsing so the list, the drawer and the
+    // detail page all drive the same endpoint. A 2xx means the verify ran
+    // server-side regardless of ack shape; a mismatch resolves null and we fall
+    // back to the generic success message.
+    verifyResult.value = await store.verify(extid);
   });
 
   const dialogDescription = computed(() =>
@@ -162,7 +224,7 @@
 
   /** Map the honest post-verify state to its operator notification. */
   function notifyOutcome(): void {
-    const state = verifyResult.value?.details?.current_state ?? '';
+    const state = verifyResult.value?.current_state ?? '';
     const domainName = activeDomain.value?.display_domain ?? '';
     const messageKey = VERIFY_MESSAGE_KEYS[state] ?? 'web.admin.domains.verify.success.done';
 
@@ -184,17 +246,88 @@
 
     dialogOpen.value = false;
     notifyOutcome();
-    // Re-fetch the current page so every card's badge reflects real persisted
-    // state (the verify may have flipped verified/resolving).
+    // The drawer renders a row SNAPSHOT, so remember which one before the page
+    // is replaced and re-point it at the refreshed row afterwards.
+    const openExtid = selectedDomain.value?.extid ?? null;
+
+    // Re-fetch the current page so every badge reflects real persisted state
+    // (the verify may have flipped verified/resolving).
     await fetchPage(pagination.value?.page ?? 1);
     activeDomain.value = null;
     verifyResult.value = null;
+
+    if (openExtid) {
+      const refreshed = domains.value.find((row) => row.extid === openExtid) ?? null;
+      selectedDomain.value = refreshed;
+      if (!refreshed) drawerOpen.value = false;
+    }
   }
 
   function onCancel(): void {
     dialogOpen.value = false;
     activeDomain.value = null;
     resetVerify();
+  }
+
+  // ---- Detail drawer (read-only summary + escalation) -----------------------
+
+  const drawerOpen = ref(false);
+  const selectedDomain = ref<ColonelCustomDomain | null>(null);
+
+  /** Read-only summary rows for the drawer's field grid. */
+  const drawerFields = computed(() => {
+    const d = selectedDomain.value;
+    if (!d) return [];
+    return [
+      {
+        key: 'publicId',
+        label: t('web.admin.domains.fields.publicId'),
+        value: d.extid,
+        mono: true,
+      },
+      {
+        key: 'organization',
+        label: t('web.admin.domains.fields.organization'),
+        value: d.org_name || t('web.admin.domains.detail.none'),
+        mono: false,
+      },
+      {
+        key: 'baseDomain',
+        label: t('web.admin.domains.fields.baseDomain'),
+        value: d.base_domain || t('web.admin.domains.detail.none'),
+        mono: true,
+      },
+      {
+        key: 'subdomain',
+        label: t('web.admin.domains.fields.subdomain'),
+        value: d.subdomain || t('web.admin.domains.detail.none'),
+        mono: true,
+      },
+      {
+        key: 'created',
+        label: t('web.admin.domains.fields.created'),
+        value: formatDisplayDateTime(d.created),
+        mono: false,
+      },
+      {
+        key: 'updated',
+        label: t('web.admin.domains.fields.updated'),
+        value: d.updated
+          ? formatDisplayDateTime(d.updated)
+          : t('web.admin.domains.detail.never'),
+        mono: false,
+      },
+    ];
+  });
+
+  function openDetail(row: ColonelCustomDomain): void {
+    selectedDomain.value = row;
+    drawerOpen.value = true;
+  }
+
+  /** Yes/no label for the drawer's boolean stat tiles. */
+  function yesNo(value: boolean): string {
+    return value ? t('web.admin.domains.detail.yes') : t('web.admin.domains.detail.no');
   }
 
   // ---- Attach-domain-to-organization flow -----------------------------------
@@ -264,15 +397,10 @@
     domainDetail.value = null;
     domainCluster.value = null;
     try {
-      const res = await $api.get(`/api/colonel/domains/${encodeURIComponent(extid)}`);
-      const parsed = gracefulParse(
-        colonelDomainDetailResponseSchema,
-        res.data,
-        'ColonelDomainDetailResponse'
-      );
-      if (parsed.ok) {
-        domainDetail.value = parsed.data.record;
-        domainCluster.value = parsed.data.details?.cluster ?? null;
+      const detail = await store.fetchDetail(extid);
+      if (detail) {
+        domainDetail.value = detail.record;
+        domainCluster.value = detail.cluster;
       } else {
         detailError.value = true;
       }
@@ -344,15 +472,8 @@
   async function reverifyPanelDomain(domain: ColonelOrganizationDetailDomain): Promise<void> {
     panelVerifyingExtid.value = domain.extid;
     try {
-      const res = await $api.post(
-        `/api/colonel/domains/${encodeURIComponent(domain.extid)}/verify`
-      );
-      const parsed = gracefulParse(
-        colonelDomainVerifyResponseSchema,
-        res.data,
-        'ColonelDomainVerifyResponse'
-      );
-      const state = parsed.ok ? parsed.data.details?.current_state ?? '' : '';
+      const outcome = await store.verify(domain.extid);
+      const state = outcome?.current_state ?? '';
       const messageKey = VERIFY_MESSAGE_KEYS[state] ?? 'web.admin.domains.verify.success.done';
       notifications.show(
         t(messageKey, { domain: domain.display_domain }),
@@ -477,16 +598,22 @@
                   name="arrow-top-right-on-square"
                   size="4" />
               </a>
-              <span
-                :class="[
-                  'inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium',
-                  stateBadgeClass(domain.verification_state),
-                ]"
-                :data-testid="`panel-domain-state-${domain.extid}`">
-                {{ stateLabel(domain.verification_state) }}
-              </span>
+              <DomainStateBadge
+                :state="domain.verification_state"
+                :testid="`panel-domain-state-${domain.extid}`"
+                class="shrink-0" />
             </div>
             <div class="flex shrink-0 items-center gap-2">
+              <router-link
+                :to="{ name: 'AdminDomainDetail', params: { id: domain.extid } }"
+                :data-testid="`panel-domain-detail-${domain.extid}`"
+                class="inline-flex items-center gap-1 rounded-md border border-gray-300 px-2.5 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-brand-500 focus:outline-none dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700">
+                <OIcon
+                  collection="heroicons"
+                  name="arrow-right"
+                  size="4" />
+                {{ t('web.admin.domains.detail.openFullPage') }}
+              </router-link>
               <button
                 type="button"
                 :data-testid="`panel-domain-dns-${domain.extid}`"
@@ -565,185 +692,291 @@
       </button>
     </div>
 
-    <!-- Loading (first load) -->
-    <CardGridSkeleton
-      v-if="loading && domains.length === 0"
-      :count="4"
-      data-testid="domains-loading" />
-
-    <!-- Empty -->
-    <div
-      v-else-if="domains.length === 0"
-      class="rounded-lg border border-gray-200 bg-white p-12 text-center dark:border-gray-700 dark:bg-gray-900"
-      data-testid="domains-empty">
-      <p class="text-gray-500 dark:text-gray-400">
-        {{ t('web.colonel.customDomains.empty') }}
-      </p>
+    <!-- Filters (server-side: `search` + `status`, applied before pagination). -->
+    <div class="mb-4">
+      <FilterBar
+        v-model:search="searchTerm"
+        :filters="filters"
+        :search-placeholder="t('web.admin.domains.list.searchPlaceholder')"
+        :has-active-filters="hasActiveFilters"
+        testid="domains-filterbar"
+        @filter-change="onFilterChange"
+        @clear="onClear" />
     </div>
 
-    <!-- Domain table — dense, column-aligned so all 50 rows on a page are
-         scannable at once (the card grid was too tall for a 1000-domain
-         install). Low-value fields (brand tagline/homepage, favicon, updated)
-         are dropped from the row; the state badge already conveys
-         verified/resolving so those redundant flags are gone. -->
-    <template v-else>
-      <div
-        data-testid="domains-grid"
-        class="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
-        <table class="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-700">
-          <thead class="bg-gray-50 dark:bg-gray-800/60">
-            <tr>
-              <th
-                scope="col"
-                class="px-4 py-2.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400">
-                {{ t('web.colonel.customDomains.labels.domain') }}
-              </th>
-              <th
-                scope="col"
-                class="px-4 py-2.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400">
-                {{ t('web.colonel.customDomains.labels.organization') }}
-              </th>
-              <th
-                scope="col"
-                class="px-4 py-2.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400">
-                {{ t('web.colonel.customDomains.labels.status') }}
-              </th>
-              <th
-                scope="col"
-                class="px-4 py-2.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400">
-                {{ t('web.colonel.customDomains.labels.created') }}
-              </th>
-              <th
-                scope="col"
-                class="px-4 py-2.5 text-right text-xs font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400">
-                {{ t('web.colonel.customDomains.labels.actions') }}
-              </th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
-            <tr
-              v-for="domain in domains"
-              :key="domain.domain_id"
-              :data-testid="`domain-row-${domain.extid}`"
-              class="bg-white hover:bg-gray-50 dark:bg-gray-900 dark:hover:bg-gray-800/50">
-              <!-- Domain: logo + name + extid -->
-              <td class="px-4 py-2.5">
-                <div class="flex items-center gap-3">
-                  <div
-                    v-if="domain.has_logo"
-                    class="size-8 shrink-0 overflow-hidden rounded border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900">
-                    <img
-                      :src="domain.logo_url ?? undefined"
-                      :alt="`${domain.display_domain} logo`"
-                      class="size-full object-contain"
-                      loading="lazy" />
-                  </div>
-                  <div
-                    v-else
-                    class="flex size-8 shrink-0 items-center justify-center rounded border border-gray-200 bg-gray-100 dark:border-gray-700 dark:bg-gray-700">
-                    <OIcon
-                      collection="heroicons"
-                      name="globe-alt"
-                      size="4"
-                      class="text-gray-400" />
-                  </div>
-                  <div class="min-w-0">
-                    <div class="truncate font-medium text-gray-900 dark:text-white">
-                      {{ domain.display_domain }}
-                    </div>
-                    <div class="truncate font-mono text-xs text-gray-400 dark:text-gray-500">
-                      {{ domain.extid }}
-                    </div>
-                  </div>
-                </div>
-              </td>
-              <!-- Organization -->
-              <td class="px-4 py-2.5 text-gray-700 dark:text-gray-300">
-                <span class="block max-w-[16rem] truncate">{{ domain.org_name }}</span>
-              </td>
-              <!-- Status: state badge + non-redundant capability flags -->
-              <td class="px-4 py-2.5">
-                <div class="flex items-center gap-1.5">
-                  <span
-                    :class="[
-                      'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
-                      stateBadgeClass(domain.verification_state),
-                    ]"
-                    :data-testid="`domain-state-${domain.extid}`">
-                    {{ stateLabel(domain.verification_state) }}
-                  </span>
-                  <OIcon
-                    v-if="domain.ready"
-                    collection="heroicons"
-                    name="check-badge"
-                    size="4"
-                    class="text-green-600 dark:text-green-400"
-                    :title="t('web.colonel.customDomains.status.ready')" />
-                  <OIcon
-                    v-if="domain.homepage_config?.enabled"
-                    collection="heroicons"
-                    name="home"
-                    size="4"
-                    class="text-purple-600 dark:text-purple-400"
-                    :title="t('web.colonel.customDomains.status.publicHomepage')" />
-                  <OIcon
-                    v-if="domain.api_config?.enabled"
-                    collection="heroicons"
-                    name="code-bracket"
-                    size="4"
-                    class="text-purple-600 dark:text-purple-400"
-                    :title="t('web.colonel.customDomains.status.publicApi')" />
-                </div>
-              </td>
-              <!-- Created -->
-              <td class="px-4 py-2.5 whitespace-nowrap text-gray-600 dark:text-gray-400">
-                {{ formatDisplayDateTime(domain.created) }}
-              </td>
-              <!-- Actions: open external + verify -->
-              <td class="px-4 py-2.5">
-                <div class="flex items-center justify-end gap-1">
-                  <a
-                    :href="domainUrl(domain.display_domain)"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    :data-testid="`domain-open-${domain.extid}`"
-                    :aria-label="t('web.admin.domains.attach.openExternal', { domain: domain.display_domain })"
-                    :title="t('web.admin.domains.attach.openExternal', { domain: domain.display_domain })"
-                    class="rounded p-1.5 text-gray-400 hover:text-brand-600 focus:ring-2 focus:ring-brand-500 focus:outline-none dark:hover:text-brand-400">
-                    <OIcon
-                      collection="heroicons"
-                      name="arrow-top-right-on-square"
-                      size="4" />
-                  </a>
-                  <button
-                    type="button"
-                    :data-testid="`domain-verify-${domain.extid}`"
-                    :disabled="verifyingExtid === domain.extid"
-                    class="inline-flex items-center gap-1 rounded-md border border-gray-300 px-2.5 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-brand-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
-                    @click="requestVerify(domain)">
-                    <OIcon
-                      collection="heroicons"
-                      :name="verifyingExtid === domain.extid ? 'arrow-path' : 'shield-check'"
-                      size="4"
-                      :class="verifyingExtid === domain.extid ? 'animate-spin motion-reduce:animate-none' : ''" />
-                    {{ t('web.admin.domains.verify.button') }}
-                  </button>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <!-- Pagination -->
-      <KitPagination
-        v-if="pagination"
-        :pagination="pagination"
+    <!-- Table. `domains-grid` is the list container (kept stable for tooling);
+         the DataTable inside owns loading + empty rendering. -->
+    <div
+      data-testid="domains-grid"
+      class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
+      <DataTable
+        :columns="columns"
+        :rows="domains"
+        row-key="domain_id"
         :loading="loading"
-        class="mt-6"
-        @update:page="onPageChange"
-        @update:per-page="onPerPageChange" />
-    </template>
+        clickable-rows
+        testid="domains-table"
+        @row-click="openDetail">
+        <template #empty>
+          <div
+            class="px-6 py-12 text-center"
+            data-testid="domains-empty">
+            <OIcon
+              collection="heroicons"
+              name="globe-alt"
+              size="8"
+              class="mx-auto text-gray-300 dark:text-gray-600" />
+            <p class="mt-3 text-sm text-gray-500 dark:text-gray-400">
+              {{
+                hasActiveFilters
+                  ? t('web.admin.domains.list.emptyFilter')
+                  : t('web.colonel.customDomains.empty')
+              }}
+            </p>
+          </div>
+        </template>
+
+        <!-- Identity: logo + name + extid. The testid is the row handle. -->
+        <template #cell-domain="{ row }">
+          <div
+            class="flex items-center gap-3"
+            :data-testid="`domain-row-${row.extid}`">
+            <div
+              v-if="row.has_logo"
+              class="size-8 shrink-0 overflow-hidden rounded border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900">
+              <img
+                :src="row.logo_url ?? undefined"
+                :alt="`${row.display_domain} logo`"
+                class="size-full object-contain"
+                loading="lazy" />
+            </div>
+            <div
+              v-else
+              class="flex size-8 shrink-0 items-center justify-center rounded border border-gray-200 bg-gray-100 dark:border-gray-700 dark:bg-gray-700">
+              <OIcon
+                collection="heroicons"
+                name="globe-alt"
+                size="4"
+                class="text-gray-400" />
+            </div>
+            <div class="min-w-0">
+              <div class="truncate font-medium text-gray-900 dark:text-white">
+                {{ row.display_domain }}
+              </div>
+              <div class="truncate font-mono text-xs text-gray-400 dark:text-gray-500">
+                {{ row.extid }}
+              </div>
+            </div>
+          </div>
+        </template>
+
+        <template #cell-organization="{ row }">
+          <span class="block max-w-[16rem] truncate">
+            {{ row.org_name || t('web.admin.domains.detail.none') }}
+          </span>
+        </template>
+
+        <!-- Verification state + the non-redundant capability flags. -->
+        <template #cell-state="{ row }">
+          <div class="flex items-center gap-1.5">
+            <DomainStateBadge
+              :state="row.verification_state"
+              :testid="`domain-state-${row.extid}`" />
+            <OIcon
+              v-if="row.homepage_config?.enabled"
+              collection="heroicons"
+              name="home"
+              size="4"
+              class="text-purple-600 dark:text-purple-400"
+              :title="t('web.colonel.customDomains.status.publicHomepage')" />
+            <OIcon
+              v-if="row.api_config?.enabled"
+              collection="heroicons"
+              name="code-bracket"
+              size="4"
+              class="text-purple-600 dark:text-purple-400"
+              :title="t('web.colonel.customDomains.status.publicApi')" />
+          </div>
+        </template>
+
+        <!-- Serving / TLS readiness. `ready` is the server's own answer to "is
+             this domain resolving AND certificate-ready"; we never re-derive it. -->
+        <template #cell-tls="{ row }">
+          <span
+            v-if="row.ready"
+            class="inline-flex items-center gap-1 text-xs font-medium text-green-700 dark:text-green-400"
+            :data-testid="`domain-tls-${row.extid}`">
+            <OIcon
+              collection="heroicons"
+              name="check-badge"
+              size="4" />
+            {{ t('web.admin.domains.tls.serving') }}
+          </span>
+          <span
+            v-else-if="row.resolving"
+            class="inline-flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-400"
+            :data-testid="`domain-tls-${row.extid}`">
+            <OIcon
+              collection="heroicons"
+              name="clock"
+              size="4" />
+            {{ t('web.admin.domains.tls.resolving') }}
+          </span>
+          <span
+            v-else
+            class="text-xs text-gray-400 dark:text-gray-600"
+            :data-testid="`domain-tls-${row.extid}`">
+            {{ t('web.admin.domains.tls.none') }}
+          </span>
+        </template>
+
+        <template #cell-created="{ row }">
+          <span class="text-gray-500 tabular-nums dark:text-gray-400">
+            {{ formatDisplayDateTime(row.created) }}
+          </span>
+        </template>
+
+        <!-- Row actions. Every one stops propagation so it never also opens the
+             drawer behind the click. -->
+        <template #cell-actions="{ row }">
+          <div class="flex items-center justify-end gap-1">
+            <a
+              :href="domainUrl(row.display_domain)"
+              target="_blank"
+              rel="noopener noreferrer"
+              :data-testid="`domain-open-${row.extid}`"
+              :aria-label="t('web.admin.domains.attach.openExternal', { domain: row.display_domain })"
+              :title="t('web.admin.domains.attach.openExternal', { domain: row.display_domain })"
+              class="rounded p-1.5 text-gray-400 hover:text-brand-600 focus:ring-2 focus:ring-brand-500 focus:outline-none dark:hover:text-brand-400"
+              @click.stop>
+              <OIcon
+                collection="heroicons"
+                name="arrow-top-right-on-square"
+                size="4" />
+            </a>
+            <button
+              type="button"
+              :data-testid="`domain-verify-${row.extid}`"
+              :disabled="verifyingExtid === row.extid"
+              class="inline-flex items-center gap-1 rounded-md border border-gray-300 px-2.5 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-brand-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+              @click.stop="requestVerify(row)">
+              <OIcon
+                collection="heroicons"
+                :name="verifyingExtid === row.extid ? 'arrow-path' : 'shield-check'"
+                size="4"
+                :class="verifyingExtid === row.extid ? 'animate-spin motion-reduce:animate-none' : ''" />
+              {{ t('web.admin.domains.verify.button') }}
+            </button>
+            <router-link
+              :to="{ name: 'AdminDomainDetail', params: { id: row.extid } }"
+              :data-testid="`domain-detail-${row.extid}`"
+              :aria-label="t('web.admin.domains.detail.openFullPage')"
+              :title="t('web.admin.domains.detail.openFullPage')"
+              class="rounded p-1.5 text-gray-400 hover:text-brand-600 focus:ring-2 focus:ring-brand-500 focus:outline-none dark:hover:text-brand-400"
+              @click.stop>
+              <OIcon
+                collection="heroicons"
+                name="arrow-right"
+                size="4" />
+            </router-link>
+          </div>
+        </template>
+      </DataTable>
+    </div>
+
+    <!-- Pagination -->
+    <KitPagination
+      v-if="pagination"
+      :pagination="pagination"
+      :loading="loading"
+      class="mt-4"
+      @update:page="onPageChange"
+      @update:per-page="onPerPageChange" />
+
+    <!-- Detail drawer: read-only summary + escalation to the full page. Mirrors
+         the customers / organizations drawers so every row click behaves alike. -->
+    <DetailDrawer
+      v-model:open="drawerOpen"
+      width-class="max-w-2xl"
+      :title="selectedDomain?.display_domain"
+      :subtitle="selectedDomain?.extid"
+      testid="domains-drawer">
+      <div
+        v-if="selectedDomain"
+        class="space-y-8">
+        <section>
+          <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <StatCard
+              :label="t('web.admin.domains.columns.state')"
+              :value="t(`web.colonel.customDomains.status.${selectedDomain.verification_state}`, selectedDomain.verification_state)"
+              icon="shield-check"
+              testid="domain-stat-state" />
+            <StatCard
+              :label="t('web.admin.domains.fields.verified')"
+              :value="yesNo(selectedDomain.verified)"
+              icon="check-circle"
+              testid="domain-stat-verified" />
+            <StatCard
+              :label="t('web.admin.domains.fields.resolving')"
+              :value="yesNo(selectedDomain.resolving)"
+              icon="signal"
+              testid="domain-stat-resolving" />
+            <StatCard
+              :label="t('web.admin.domains.fields.ready')"
+              :value="yesNo(selectedDomain.ready)"
+              icon="check-badge"
+              testid="domain-stat-ready" />
+          </div>
+
+          <dl class="mt-5 grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2">
+            <div
+              v-for="field in drawerFields"
+              :key="field.key"
+              :data-testid="`domain-field-${field.key}`">
+              <dt
+                class="font-brand text-[11px] font-semibold tracking-[0.1em] text-gray-500 uppercase dark:text-gray-400">
+                {{ field.label }}
+              </dt>
+              <dd
+                v-if="field.mono"
+                class="mt-1 inline-block rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs break-all text-gray-700 tabular-nums dark:bg-gray-800 dark:text-gray-300">
+                {{ field.value }}
+              </dd>
+              <dd
+                v-else
+                class="mt-1 text-sm break-words text-gray-900 tabular-nums dark:text-gray-100">
+                {{ field.value }}
+              </dd>
+            </div>
+          </dl>
+        </section>
+
+        <!-- Escalation: probe / repair / transfer / remove live on the full page. -->
+        <section class="flex flex-wrap gap-3 border-t border-gray-200 pt-6 dark:border-gray-800">
+          <router-link
+            :to="{ name: 'AdminDomainDetail', params: { id: selectedDomain.extid } }"
+            class="inline-flex items-center gap-1.5 rounded-md bg-brand-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-700 focus:ring-2 focus:ring-brand-500 focus:ring-offset-1 focus:outline-none dark:bg-brand-500 dark:hover:bg-brand-600"
+            data-testid="domain-open-full-page">
+            {{ t('web.admin.domains.detail.openFullPage') }}
+            <OIcon
+              collection="heroicons"
+              name="arrow-top-right-on-square"
+              size="4" />
+          </router-link>
+          <button
+            type="button"
+            data-testid="domain-drawer-verify"
+            class="inline-flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-brand-500 focus:outline-none dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+            @click="selectedDomain && requestVerify(selectedDomain)">
+            <OIcon
+              collection="heroicons"
+              name="shield-check"
+              size="4" />
+            {{ t('web.admin.domains.verify.button') }}
+          </button>
+        </section>
+      </div>
+    </DetailDrawer>
 
     <!-- Shared guarded-action dialog (one-click confirm for the low-risk verb). -->
     <AdminConfirmDialog

--- a/src/apps/admin/views/AdminOrganizationDetail.vue
+++ b/src/apps/admin/views/AdminOrganizationDetail.vue
@@ -4,6 +4,9 @@
   import RevealEmail from '@/apps/admin/components/RevealEmail.vue';
   import { AdminConfirmDialog, DataTable, JsonViewer, StatCard } from '@/apps/admin/components/kit';
   import type { DataTableColumn } from '@/apps/admin/components/kit';
+  import AddMemberModal from '@/apps/admin/components/organizations/AddMemberModal.vue';
+  import type { AddMembershipRequest } from '@/apps/admin/components/organizations/membershipSchemas';
+  import { colonelAddMembershipResponseSchema } from '@/apps/admin/components/organizations/membershipSchemas';
   import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
   import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
   import type { InvestigateOrganizationResult } from '@/schemas/api/internal/responses/colonel';
@@ -18,6 +21,7 @@
     colonelOrganizationDetailResponseSchema,
     colonelReconcileOrganizationResponseSchema,
   } from '@/schemas/api/internal/responses/colonel-organizations';
+  import { classifyError } from '@/schemas/errors';
   import OIcon from '@/shared/components/icons/OIcon.vue';
   import { useApi } from '@/shared/composables/useApi';
   import { useNotificationsStore } from '@/shared/stores/notificationsStore';
@@ -416,6 +420,119 @@
       },
     ];
   });
+
+  // ---- Add an EXISTING account to this org (MUTATING — audited server-side) --
+  //
+  // Scoped deliberately to the one verb support actually needs: a person signed
+  // up on their own, so they already have an account and the invite flow refuses
+  // them, but they belong in this org. Removing a member and changing an
+  // existing member's role are different endpoints and are NOT surfaced here.
+
+  const addMemberOpen = ref(false);
+  /** The account + role captured from the modal, held for the in-flight POST. */
+  const pendingMember = ref<AddMembershipRequest | null>(null);
+
+  /**
+   * Turn a failed add into an operator-actionable message.
+   *
+   * The HTTP status is read straight off `err.response`: wrapped/mocked axios
+   * errors are not reliably `instanceof AxiosError`, so the response envelope is
+   * the dependable probe. The backend's own `error` string wins when present —
+   * it is the only thing that separates "Organization not found" from "Customer
+   * not found" on a 404, and it carries the accepted role list on a bad role.
+   */
+  function addMemberFailureMessage(err: unknown): string {
+    const response = (err as { response?: { status?: number; data?: unknown } } | null)?.response;
+    const data = response?.data;
+    const serverMessage =
+      typeof data === 'object' &&
+      data !== null &&
+      typeof (data as { error?: unknown }).error === 'string'
+        ? (data as { error: string }).error
+        : null;
+
+    if (serverMessage) return serverMessage;
+    if (response?.status === 404) {
+      return t('web.admin.organizations.addMember.errors.notFound');
+    }
+    if (response?.status === 400 || response?.status === 422) {
+      return t('web.admin.organizations.addMember.errors.invalidRole');
+    }
+    return classifyError(err).message;
+  }
+
+  const {
+    loading: addMemberLoading,
+    error: addMemberError,
+    run: runAddMember,
+    reset: resetAddMember,
+  } = useAdminMutation(async () => {
+    const target = pendingMember.value;
+    if (!target) throw new Error(t('web.admin.organizations.addMember.errors.noSelection'));
+
+    let response;
+    try {
+      response = await $api.post(`${orgUrl()}/members`, {
+        // Always the EXTID, never an email address: the colonel adapter runs
+        // `customer` through an identifier sanitizer, and the account picker
+        // already resolved the address to a public id.
+        customer: target.customer,
+        role: target.role,
+      });
+    } catch (err) {
+      throw new Error(addMemberFailureMessage(err));
+    }
+
+    const parsed = gracefulParse(
+      colonelAddMembershipResponseSchema,
+      response.data,
+      'ColonelAddMembershipResponse'
+    );
+    // `no_change` is an idempotent 200: the account was ALREADY a member and the
+    // op deliberately left their role untouched (add is strictly additive).
+    // Surface it as an actionable failure instead of a false "added" toast. Ack
+    // drift stays non-fatal — an unparseable 2xx is still treated as a success.
+    if (parsed.ok && parsed.data.record.status === 'no_change') {
+      throw new Error(
+        t('web.admin.organizations.addMember.errors.alreadyMember', {
+          role: parsed.data.record.role || target.role,
+        })
+      );
+    }
+  });
+
+  function openAddMember(): void {
+    resetAddMember();
+    pendingMember.value = null;
+    addMemberOpen.value = true;
+  }
+
+  async function onAddMemberSubmit(payload: AddMembershipRequest): Promise<void> {
+    pendingMember.value = payload;
+    const ok = await runAddMember();
+    if (!ok) return; // Failure message stays in the modal for retry/cancel.
+
+    addMemberOpen.value = false;
+    notifications.show(
+      t('web.admin.organizations.addMember.success', {
+        account: payload.customer,
+        role: t(`web.admin.organizations.addMember.roles.${payload.role}`, payload.role),
+      }),
+      'success'
+    );
+    pendingMember.value = null;
+    // The roster is driven by a refreshed detail GET, never the ack — the new
+    // member appears without a page reload.
+    await refreshOrg().catch(() => {});
+  }
+
+  /** Dismissal (cancel / backdrop / Escape) — drop the captured target + error. */
+  function onAddMemberOpenChange(value: boolean): void {
+    addMemberOpen.value = value;
+    if (value) return;
+    pendingMember.value = null;
+    resetAddMember();
+  }
 
   // ---- Members + Domains tables ---------------------------------------------
 
@@ -858,13 +975,26 @@
       <!-- Members -->
       <section
         class="rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
-        <div class="border-b border-gray-200 px-6 py-4 dark:border-gray-800">
+        <div
+          class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 px-6 py-4 dark:border-gray-800">
           <h3 class="text-lg font-medium text-gray-900 dark:text-white">
             {{ t('web.admin.organizations.detail.sections.members') }}
             <span class="ml-1 text-sm font-normal text-gray-500 dark:text-gray-400"
               >({{ details.members.length }})</span
             >
           </h3>
+          <!-- Add an EXISTING account (the invite flow cannot cover this case). -->
+          <button
+            type="button"
+            data-testid="org-add-member-button"
+            class="inline-flex items-center gap-1.5 rounded-md bg-brand-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-700 focus:ring-2 focus:ring-brand-500 focus:ring-offset-1 focus:outline-none dark:bg-brand-500 dark:hover:bg-brand-600"
+            @click="openAddMember">
+            <OIcon
+              collection="heroicons"
+              name="user-plus"
+              size="4" />
+            {{ t('web.admin.organizations.addMember.button') }}
+          </button>
         </div>
         <DataTable
           :columns="memberColumns"
@@ -1175,6 +1305,20 @@
         </div>
       </section>
     </div>
+
+    <!--
+      Add an existing account to this org. Kept at the root (not inside the
+      loaded block) so opening/closing it never remounts the detail sections.
+    -->
+    <AddMemberModal
+      :open="addMemberOpen"
+      :org-extid="record?.extid ?? ''"
+      :org-name="heading"
+      :members="details?.members ?? []"
+      :loading="addMemberLoading"
+      :error="addMemberError"
+      @update:open="onAddMemberOpenChange"
+      @submit="onAddMemberSubmit" />
 
     <!-- Guarded entitlement mutation (typed-confirmation — retype the extid). -->
     <AdminConfirmDialog

--- a/src/apps/admin/views/AdminPlanDiff.vue
+++ b/src/apps/admin/views/AdminPlanDiff.vue
@@ -1,0 +1,297 @@
+<!-- src/apps/admin/views/AdminPlanDiff.vue -->
+
+<script setup lang="ts">
+  import { JsonViewer } from '@/apps/admin/components/kit';
+  import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
+  import type { ColonelBillingPlan } from '@/schemas/api/internal/responses/colonel-billing';
+  import { colonelBillingCatalogResponseSchema } from '@/schemas/api/internal/responses/colonel-billing';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import { computed, onMounted } from 'vue';
+  import { useI18n } from 'vue-i18n';
+  import { useRouter } from 'vue-router';
+
+  /**
+   * Plan diff — the config-vs-live comparison for ONE plan, as a full page.
+   *
+   * Promoted out of the billing screen's slide-over: the payload is two JSON
+   * documents side by side, which a `max-w-md` drawer cannot show without
+   * horizontal cramping. Full page width means both blobs expand at once.
+   *
+   * Deep-linkable by design: the page fetches the catalog itself rather than
+   * reading anything handed over by the navigation, so a refresh, a bookmark or
+   * a pasted link renders identically. That is one extra GET of an endpoint the
+   * billing screen already reads — acceptable for an operator tool, and the only
+   * shape that survives a reload.
+   *
+   * Read-only: nothing here mutates, so nothing is audited (CONTRACT 4).
+   */
+  const props = defineProps<{
+    /**
+     * The plan id being diffed (route param). Not key material and not
+     * customer-identifying — it is a catalog id like `identity_plus_v1`.
+     */
+    planid: string;
+  }>();
+
+  const { t } = useI18n();
+  const router = useRouter();
+
+  const { data, loading, error, validationError, notFound, load } = useResourceFetch({
+    url: '/api/colonel/billing/catalog',
+    schema: colonelBillingCatalogResponseSchema,
+    context: 'ColonelBillingCatalogResponse',
+  });
+
+  const details = computed(() => data.value?.details ?? null);
+
+  /** A non-404 network/HTTP failure, or a Zod contract mismatch. */
+  const loadFailed = computed(
+    () => (error.value !== null && !notFound.value) || validationError.value !== null
+  );
+
+  function findPlan(plans: ColonelBillingPlan[] | undefined): ColonelBillingPlan | null {
+    return plans?.find((plan) => plan.planid === props.planid) ?? null;
+  }
+
+  const configPlan = computed(() => findPlan(details.value?.config_plans));
+  const livePlan = computed(() => findPlan(details.value?.live_plans));
+
+  /** The catalog loaded, but this planid exists on neither side. */
+  const planMissing = computed(
+    () => details.value !== null && configPlan.value === null && livePlan.value === null
+  );
+
+  const isLocalConfig = computed(() => details.value?.source === 'local_config');
+
+  /** Which comparable fields drift, per the server's computed drift summary. */
+  const changedFields = computed<string[]>(
+    () => details.value?.drift.changed.find((c) => c.planid === props.planid)?.fields ?? []
+  );
+
+  /** Same badge vocabulary as the catalog table, so the two screens agree. */
+  type PlanStatus = 'in_sync' | 'only_config' | 'only_live' | 'changed';
+
+  const status = computed<PlanStatus | null>(() => {
+    if (!details.value) return null;
+    if (configPlan.value && !livePlan.value) return 'only_config';
+    if (!configPlan.value && livePlan.value) return 'only_live';
+    if (changedFields.value.length > 0) return 'changed';
+    return 'in_sync';
+  });
+
+  function statusBadgeClass(value: PlanStatus): string {
+    switch (value) {
+      case 'in_sync':
+        return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200';
+      case 'changed':
+        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200';
+      case 'only_config':
+        return 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200';
+      case 'only_live':
+        return 'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-200';
+      default:
+        return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300';
+    }
+  }
+
+  /** The plan's display name from whichever side carries it. */
+  const planName = computed(() => configPlan.value?.name ?? livePlan.value?.name ?? null);
+
+  function goBack(): void {
+    router.push({ name: 'AdminBilling' });
+  }
+
+  onMounted(() => {
+    load().catch(() => {});
+  });
+</script>
+
+<template>
+  <!-- Wider than the standard detail page (max-w-5xl): two JSON documents side
+       by side is the whole point of promoting this out of the drawer. -->
+  <div class="mx-auto max-w-7xl">
+    <button
+      type="button"
+      class="mb-4 inline-flex items-center gap-1 text-sm font-medium text-gray-600 hover:text-gray-900 focus:ring-2 focus:ring-brand-500 focus:outline-none dark:text-gray-400 dark:hover:text-gray-100"
+      data-testid="detail-back"
+      @click="goBack">
+      <OIcon
+        collection="heroicons"
+        name="arrow-left"
+        size="4" />
+      {{ t('web.admin.billing.diff.backToCatalog') }}
+    </button>
+
+    <!-- Loading -->
+    <div
+      v-if="loading && !details"
+      class="flex items-center justify-center py-24 text-gray-500 dark:text-gray-400"
+      data-testid="detail-loading">
+      <OIcon
+        collection="heroicons"
+        name="arrow-path"
+        size="6"
+        class="animate-spin motion-reduce:animate-none" />
+      <span class="ml-3 text-sm">{{ t('web.COMMON.loading') }}</span>
+    </div>
+
+    <!-- The catalog loaded but carries no such plan (stale link / renamed plan). -->
+    <div
+      v-else-if="planMissing"
+      class="rounded-lg border border-gray-200 bg-white px-6 py-16 text-center dark:border-gray-800 dark:bg-gray-900"
+      data-testid="detail-not-found">
+      <OIcon
+        collection="heroicons"
+        name="rectangle-group"
+        size="8"
+        class="mx-auto text-gray-400 dark:text-gray-600" />
+      <h3 class="mt-3 text-lg font-medium text-gray-900 dark:text-white">
+        {{ t('web.admin.billing.diff.notFound') }}
+      </h3>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.billing.diff.notFoundDescription', { planid: props.planid }) }}
+      </p>
+      <button
+        type="button"
+        class="mt-4 inline-flex items-center gap-1 rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-brand-500 focus:outline-none dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+        @click="goBack">
+        {{ t('web.admin.billing.diff.backToCatalog') }}
+      </button>
+    </div>
+
+    <!-- Load error (network/HTTP, or contract mismatch) -->
+    <div
+      v-else-if="loadFailed || notFound"
+      class="rounded-lg border border-red-200 bg-red-50 px-6 py-16 text-center dark:border-red-900/50 dark:bg-red-900/20"
+      role="alert"
+      data-testid="detail-error">
+      <OIcon
+        collection="heroicons"
+        name="exclamation-triangle"
+        size="8"
+        class="mx-auto text-red-500 dark:text-red-400" />
+      <p class="mt-3 text-sm text-red-800 dark:text-red-200">
+        {{ t('web.admin.billing.loadError') }}
+      </p>
+      <button
+        type="button"
+        class="mt-4 inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-2 text-sm font-medium text-red-800 hover:bg-red-100 focus:ring-2 focus:ring-red-500 focus:outline-none dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/40"
+        @click="load().catch(() => {})">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          size="4" />
+        {{ t('web.admin.billing.retry') }}
+      </button>
+    </div>
+
+    <!-- Loaded -->
+    <div
+      v-else-if="details"
+      class="space-y-6"
+      data-testid="detail-content">
+      <!-- Header -->
+      <header class="border-b-2 border-gray-900 pb-4 dark:border-gray-100">
+        <div class="flex flex-wrap items-center gap-3">
+          <h2 class="font-brand text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
+            {{ planName ?? props.planid }}
+          </h2>
+          <span
+            v-if="status"
+            class="inline-flex items-center rounded px-2 py-0.5 text-xs font-medium"
+            :class="statusBadgeClass(status)"
+            data-testid="plan-diff-status">
+            {{ t(`web.admin.billing.status.${status}`) }}
+          </span>
+          <span
+            class="font-mono text-xs text-gray-400 tabular-nums dark:text-gray-500"
+            data-testid="plan-diff-planid">
+            {{ props.planid }}
+          </span>
+        </div>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          {{ t('web.admin.billing.diff.subtitle') }}
+        </p>
+      </header>
+
+      <!-- local_config warning: drift cannot be evaluated without Stripe. -->
+      <div
+        v-if="isLocalConfig"
+        class="flex items-start gap-2 rounded-md border border-yellow-200 bg-yellow-50 px-4 py-3 dark:border-yellow-900/50 dark:bg-yellow-900/20"
+        role="status"
+        data-testid="plan-diff-local-config-warning">
+        <OIcon
+          collection="heroicons"
+          name="exclamation-triangle"
+          size="5"
+          class="mt-0.5 shrink-0 text-yellow-600 dark:text-yellow-400" />
+        <span class="text-sm text-yellow-800 dark:text-yellow-200">
+          {{ t('web.admin.billing.localConfigWarning') }}
+        </span>
+      </div>
+
+      <!-- Which fields drift, per the server's drift summary. -->
+      <div
+        v-if="changedFields.length"
+        class="flex flex-wrap items-center gap-2 rounded-md border border-yellow-200 bg-yellow-50 px-4 py-3 dark:border-yellow-900/50 dark:bg-yellow-900/20"
+        data-testid="plan-diff-fields">
+        <span class="text-sm font-medium text-yellow-800 dark:text-yellow-200">
+          {{ t('web.admin.billing.diff.driftedFields') }}
+        </span>
+        <span
+          v-for="field in changedFields"
+          :key="field"
+          class="rounded bg-yellow-100 px-2 py-0.5 font-mono text-xs text-yellow-900 dark:bg-yellow-900/40 dark:text-yellow-100">
+          {{ field }}
+        </span>
+      </div>
+
+      <!-- Side-by-side config vs live, full page width. -->
+      <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <section
+          class="rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <div class="border-b border-gray-200 px-6 py-4 dark:border-gray-800">
+            <h3 class="text-lg font-medium text-gray-900 dark:text-white">
+              {{ t('web.admin.billing.diff.config') }}
+            </h3>
+          </div>
+          <div class="p-4">
+            <JsonViewer
+              v-if="configPlan"
+              :data="configPlan"
+              :expand-depth="2"
+              testid="billing-diff-config-json" />
+            <p
+              v-else
+              class="rounded-lg border border-dashed border-gray-300 px-3 py-8 text-center text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400"
+              data-testid="billing-diff-config-absent">
+              {{ t('web.admin.billing.diff.absentConfig') }}
+            </p>
+          </div>
+        </section>
+
+        <section
+          class="rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <div class="border-b border-gray-200 px-6 py-4 dark:border-gray-800">
+            <h3 class="text-lg font-medium text-gray-900 dark:text-white">
+              {{ t('web.admin.billing.diff.live') }}
+            </h3>
+          </div>
+          <div class="p-4">
+            <JsonViewer
+              v-if="livePlan"
+              :data="livePlan"
+              :expand-depth="2"
+              testid="billing-diff-live-json" />
+            <p
+              v-else
+              class="rounded-lg border border-dashed border-gray-300 px-3 py-8 text-center text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400"
+              data-testid="billing-diff-live-absent">
+              {{ t('web.admin.billing.diff.absentLive') }}
+            </p>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/apps/admin/views/AdminSecrets.vue
+++ b/src/apps/admin/views/AdminSecrets.vue
@@ -19,7 +19,7 @@
   import { useI18n } from 'vue-i18n';
 
   /**
-   * Secret Records screen (ticket #30) — LOOKUP-FIRST by design review: on a
+   * Secret Receipts screen (ticket #30) — LOOKUP-FIRST by design review: on a
    * zero-knowledge platform there is nothing to gain from browsing every
    * secret, so the paginated browse-all table was removed (the list endpoint
    * still exists server-side; this screen never calls it).

--- a/src/apps/admin/views/AdminSecrets.vue
+++ b/src/apps/admin/views/AdminSecrets.vue
@@ -19,10 +19,17 @@
   import { useI18n } from 'vue-i18n';
 
   /**
-   * Secrets screen (ticket #30) — LOOKUP-FIRST by design review: on a
+   * Secret Records screen (ticket #30) — LOOKUP-FIRST by design review: on a
    * zero-knowledge platform there is nothing to gain from browsing every
    * secret, so the paginated browse-all table was removed (the list endpoint
    * still exists server-side; this screen never calls it).
+   *
+   * NAMING: operator-facing copy says "record", never "secret content". The
+   * screen reads the RECORD kept about a secret (state, timestamps, receipt,
+   * owner, ciphertext length) — `GET /api/colonel/secrets/:secret_id` returns
+   * `has_ciphertext` and `ciphertext_length`, never the ciphertext or the
+   * plaintext. The capability note in the header states that in the UI so the
+   * screen's title can never be read as "operators can see secrets".
    *
    * - LOOKUP: the operator pastes a secret's key (identifier); the screen loads
    *   GET /api/colonel/secrets/:secret_id via {@link useResourceFetch} and
@@ -296,6 +303,48 @@
       </p>
     </header>
 
+    <!--
+      Capability note: states what this screen can and cannot reach, so the
+      section title is never read as "operators can see secret content".
+    -->
+    <section
+      class="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-800 dark:bg-gray-800/40"
+      data-testid="secret-capability-note">
+      <h3
+        class="font-brand text-[11px] font-semibold tracking-[0.1em] text-gray-500 uppercase dark:text-gray-400">
+        {{ t('web.admin.secrets.capability.title') }}
+      </h3>
+      <ul class="mt-2 space-y-1.5 text-sm text-gray-600 dark:text-gray-300">
+        <li class="flex items-start gap-2">
+          <OIcon
+            collection="heroicons"
+            name="eye"
+            size="4"
+            class="mt-0.5 shrink-0 text-gray-400 dark:text-gray-500"
+            aria-hidden="true" />
+          <span>{{ t('web.admin.secrets.capability.canRead') }}</span>
+        </li>
+        <li class="flex items-start gap-2">
+          <OIcon
+            collection="heroicons"
+            name="lock-closed"
+            size="4"
+            class="mt-0.5 shrink-0 text-gray-400 dark:text-gray-500"
+            aria-hidden="true" />
+          <span>{{ t('web.admin.secrets.capability.cannotRead') }}</span>
+        </li>
+        <li class="flex items-start gap-2">
+          <OIcon
+            collection="heroicons"
+            name="trash"
+            size="4"
+            class="mt-0.5 shrink-0 text-gray-400 dark:text-gray-500"
+            aria-hidden="true" />
+          <span>{{ t('web.admin.secrets.capability.canDelete') }}</span>
+        </li>
+      </ul>
+    </section>
+
     <!-- Lookup -->
     <section
       class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
@@ -317,6 +366,7 @@
             spellcheck="false"
             data-testid="secret-lookup-input"
             :placeholder="t('web.admin.secrets.lookup.placeholder')"
+            aria-describedby="secret-key-hint"
             class="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm text-gray-900 focus:border-brand-500 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
         </div>
         <button
@@ -332,6 +382,11 @@
           {{ t('web.admin.secrets.lookup.button') }}
         </button>
       </form>
+      <p
+        id="secret-key-hint"
+        class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.secrets.lookup.hint') }}
+      </p>
     </section>
 
     <!-- Loading -->

--- a/src/schemas/api/internal/responses/colonel-billing.ts
+++ b/src/schemas/api/internal/responses/colonel-billing.ts
@@ -111,3 +111,86 @@ export const colonelBillingCatalogResponseSchema = createApiResponseSchema(
 );
 
 export type ColonelBillingCatalogResponse = z.infer<typeof colonelBillingCatalogResponseSchema>;
+
+// ============================================================================
+// Stripe-customer roster — GET /billing/stripe-organizations
+// ============================================================================
+//
+// Sibling endpoint to the catalog above, NOT an extension of it: the catalog is
+// an unpaginated config-vs-live snapshot, this is a paginated, index-backed
+// roster of the tenants that are actually billed. Different cadence, different
+// failure mode, different pagination — so a separate schema.
+//
+// Backed by ColonelAPI::Logic::Colonel::ListStripeOrganizations
+// (SCHEMAS = { response: 'colonelStripeOrganizations' }) over
+// Onetime::Operations::Billing::StripeOrganizations.
+//
+// Every field except the two identity keys is `.nullish()` on purpose: a
+// partial or evolving payload should degrade ONE row rather than blank the
+// whole table through a gracefulParse failure.
+
+/** One organization that carries a Stripe customer id. */
+export const colonelStripeOrganizationSchema = z.object({
+  /** The organization's PUBLIC id — routes to /colonel/organizations/:id. */
+  extid: z.string(),
+  /** The Stripe customer id (`cus_…`) — the index field this list is keyed by. */
+  stripe_customer_id: z.string(),
+  org_id: z.string().nullish(),
+  display_name: z.string().nullish(),
+  owner_email: z.string().nullish(),
+  billing_email: z.string().nullish(),
+  planid: z.string().nullish(),
+  stripe_subscription_id: z.string().nullish(),
+  /** NOTE: a STRING (or null) on the wire, not a unix number. */
+  subscription_period_end: z.string().nullish(),
+  subscription_status: z.string().nullish(),
+  sync_status: z.string().nullish(),
+});
+
+/**
+ * The canonical four-field pagination envelope plus the two bound signals this
+ * index-backed read carries:
+ *
+ * - `capped`      the HSCAN hit its entry bound (5,000), so `total_count`
+ *                 UNDERSTATES the real population. Never render "showing X of
+ *                 Y" as exact.
+ * - `stale_count` index entries on THIS page whose organization no longer
+ *                 loads; they are dropped, so a page can be SHORT. Do not
+ *                 derive counts from rendered row length.
+ *
+ * The server emits both at the details root; they are accepted here as well so
+ * the store can normalize from one place.
+ */
+export const colonelStripeOrganizationsPaginationSchema = z.object({
+  page: z.number(),
+  per_page: z.number(),
+  total_count: z.number(),
+  total_pages: z.number(),
+  capped: z.boolean().optional(),
+  stale_count: z.number().optional(),
+});
+
+export const colonelStripeOrganizationsDetailsSchema = z.object({
+  organizations: z.array(colonelStripeOrganizationSchema),
+  pagination: colonelStripeOrganizationsPaginationSchema,
+  /** Server echo of the applied filters. Optional — never read for state. */
+  filters: z.object({ search: z.string().nullish() }).optional(),
+  capped: z.boolean().optional(),
+  stale_count: z.number().optional(),
+  /** HLEN of the index, ignoring `search`. Informational only. */
+  indexed_total: z.number().optional(),
+});
+
+/** The record is empty ({}); everything lives under `details`. */
+export const colonelStripeOrganizationsResponseSchema = createApiResponseSchema(
+  z.object({}),
+  colonelStripeOrganizationsDetailsSchema
+);
+
+export type ColonelStripeOrganization = z.infer<typeof colonelStripeOrganizationSchema>;
+export type StripeOrganizationsPageMeta = z.infer<
+  typeof colonelStripeOrganizationsPaginationSchema
+>;
+export type ColonelStripeOrganizationsResponse = z.infer<
+  typeof colonelStripeOrganizationsResponseSchema
+>;

--- a/src/schemas/api/internal/responses/colonel.ts
+++ b/src/schemas/api/internal/responses/colonel.ts
@@ -657,17 +657,27 @@ export const colonelUserBillingSchema = z.object({
  * The `details` payload of GetUserDetails: everything a support agent needs to
  * read out a customer without SSH — secrets (count + items), receipts, orgs,
  * billing and lifetime stats. `count` is authoritative and equals
- * `items.length` (the endpoint sources it from the same bounded SCAN, not the
- * drifting counter). `billing` is optional so pre-billing payloads keep parsing.
+ * `items.length` (the endpoint sources it from the per-owner index page it just
+ * rendered, not from the drifting counter). `billing` is optional so
+ * pre-billing payloads keep parsing.
+ *
+ * `truncated` says the list is a PARTIAL view — more exist than are shown
+ * (another index page, pre-index historical data, a bounded fallback scan that
+ * hit its deadline, or a section that failed to load). The UI must surface it:
+ * a short list that reads as complete is worse than an honest partial one. It
+ * is optional + defaulted so payloads from a server predating the flag parse as
+ * "not truncated" rather than failing validation.
  */
 export const colonelUserDetailsSchema = z.object({
   secrets: z.object({
     count: z.number(),
     items: z.array(colonelUserDetailSecretSchema),
+    truncated: z.boolean().optional().default(false),
   }),
   receipts: z.object({
     count: z.number(),
     items: z.array(colonelUserDetailReceiptSchema),
+    truncated: z.boolean().optional().default(false),
   }),
   organizations: z.array(colonelUserDetailOrganizationSchema),
   billing: colonelUserBillingSchema.optional(),

--- a/src/schemas/api/internal/responses/registry.ts
+++ b/src/schemas/api/internal/responses/registry.ts
@@ -93,7 +93,10 @@ import {
   colonelEmailRecipientLookupResponseSchema,
   colonelEmailMessagesResponseSchema,
 } from './colonel-deliverability';
-import { colonelBillingCatalogResponseSchema } from './colonel-billing';
+import {
+  colonelBillingCatalogResponseSchema,
+  colonelStripeOrganizationsResponseSchema,
+} from './colonel-billing';
 
 // Colonel (admin) observability — audit trail reader + overview trends
 import { colonelAuditEventsResponseSchema } from './colonel-audit';
@@ -209,6 +212,7 @@ export const responseSchemas = {
   colonelEmailRecipientLookup: colonelEmailRecipientLookupResponseSchema,
   colonelEmailMessages: colonelEmailMessagesResponseSchema,
   colonelBillingCatalog: colonelBillingCatalogResponseSchema,
+  colonelStripeOrganizations: colonelStripeOrganizationsResponseSchema,
 
   // Colonel / admin — observability (audit reader + trends)
   colonelAuditEvents: colonelAuditEventsResponseSchema,

--- a/src/shared/components/icons/sprites/HeroiconsSprites.vue
+++ b/src/shared/components/icons/sprites/HeroiconsSprites.vue
@@ -712,6 +712,17 @@ clip-rule="evenodd" /></symbol>
       </symbol>
       <symbol
         viewBox="0 0 24 24"
+        id="heroicons-eye-slash">
+        <path
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.5"
+          d="M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88" />
+      </symbol>
+      <symbol
+        viewBox="0 0 24 24"
         id="heroicons-magnifying-glass">
         <path
           fill="none"

--- a/src/tests/apps/admin/AdminAuditLog.spec.ts
+++ b/src/tests/apps/admin/AdminAuditLog.spec.ts
@@ -116,17 +116,23 @@ describe('AdminAuditLog (flight-recorder playback — observability lane)', () =
     expect(wrapper.find('[data-testid="audit-table"]').text()).toContain('—');
   });
 
-  it('debounces the actor box into a single filtered fetch', async () => {
+  // The actor box is MANUAL search (the debounce was removed deliberately):
+  // typing issues nothing, submitting the form issues exactly one fetch.
+  // Full coverage lives in AdminAuditLogSearch.spec.ts.
+  it('searches the actor box on submit, not while typing', async () => {
     mockApi.get.mockResolvedValue({ data: auditPayload() });
     wrapper = mountView(pinia);
     await flushPromises();
     const before = listGetCount();
 
-    await wrapper.find('[data-testid="audit-filterbar"] input').setValue('ur_colonel1');
-    // Debounced — no request yet.
+    await wrapper.find('[data-testid="audit-actor-input"]').setValue('ur_colonel1');
+    // Manual search — nothing fires on input, and no timer is pending either.
+    expect(listGetCount()).toBe(before);
+    vi.advanceTimersByTime(1000);
+    await flushPromises();
     expect(listGetCount()).toBe(before);
 
-    vi.advanceTimersByTime(300);
+    await wrapper.find('[data-testid="audit-actor-form"]').trigger('submit');
     await flushPromises();
 
     expect(listGetCount()).toBe(before + 1);

--- a/src/tests/apps/admin/AdminAuditLogSearch.spec.ts
+++ b/src/tests/apps/admin/AdminAuditLogSearch.spec.ts
@@ -1,0 +1,277 @@
+// src/tests/apps/admin/AdminAuditLogSearch.spec.ts
+
+import { createPinia, setActivePinia } from 'pinia';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+vi.mock('@/utils/format', () => ({
+  formatDisplayDateTime: (d: Date) => `DT:${d.toISOString()}`,
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+import AdminAuditLog from '@/apps/admin/views/AdminAuditLog.vue';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+const LIST_URL = '/api/colonel/audit';
+
+function auditRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'evt_1',
+    actor: 'ur_colonel1',
+    verb: 'customer.set_role',
+    target: 'ur_target1',
+    result: 'success',
+    detail: { from: 'customer', to: 'admin' },
+    created: 1700000000,
+    ...overrides,
+  };
+}
+
+function auditPayload(rows = [auditRow()]) {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      events: rows,
+      pagination: {
+        page: 1,
+        per_page: 50,
+        total_count: rows.length,
+        total_pages: 1,
+        actor: null,
+        verb: null,
+      },
+    },
+  };
+}
+
+const mountView = (pinia: ReturnType<typeof createPinia>) =>
+  mount(AdminAuditLog, { global: { plugins: [pinia, i18n] } });
+
+const listGetCount = () => mockApi.get.mock.calls.filter((c) => c[0] === LIST_URL).length;
+
+const actorInput = (w: VueWrapper) => w.find('[data-testid="audit-actor-input"]');
+const actorForm = (w: VueWrapper) => w.find('[data-testid="audit-actor-form"]');
+const searchButton = (w: VueWrapper) => w.find('[data-testid="audit-actor-search"]');
+
+/**
+ * The audit `actor` filter is MANUAL by operator request: the endpoint's
+ * filtered path loads up to 10k events into Ruby per request, so the old
+ * debounced as-you-type box turned every typing pause into a full-set scan.
+ * These specs pin the "typing is inert, submitting searches" contract.
+ */
+describe('AdminAuditLog actor search (manual submit, no debounce)', () => {
+  let wrapper: VueWrapper;
+  let pinia: ReturnType<typeof createPinia>;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockApi.get.mockResolvedValue({ data: auditPayload() });
+  });
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    wrapper?.unmount();
+  });
+
+  it('does not fetch while the operator types — not even after any debounce window', async () => {
+    wrapper = mountView(pinia);
+    await flushPromises();
+    const before = listGetCount();
+
+    await actorInput(wrapper).setValue('ur_col');
+    await actorInput(wrapper).setValue('ur_colonel1');
+    expect(listGetCount()).toBe(before);
+
+    // Nothing is scheduled: advancing well past the old 300ms debounce is inert.
+    vi.advanceTimersByTime(5000);
+    await flushPromises();
+    expect(listGetCount()).toBe(before);
+  });
+
+  it('flags the typed-but-unsubmitted state so stale rows are not read as results', async () => {
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="audit-search-pending"]').exists()).toBe(false);
+
+    await actorInput(wrapper).setValue('ur_colonel1');
+    expect(wrapper.find('[data-testid="audit-search-pending"]').exists()).toBe(true);
+
+    await actorForm(wrapper).trigger('submit');
+    await flushPromises();
+    expect(wrapper.find('[data-testid="audit-search-pending"]').exists()).toBe(false);
+  });
+
+  it('runs the search on Enter in the actor box', async () => {
+    wrapper = mountView(pinia);
+    await flushPromises();
+    const before = listGetCount();
+
+    await actorInput(wrapper).setValue('ur_colonel1');
+    await actorInput(wrapper).trigger('keydown.enter');
+    await flushPromises();
+
+    expect(listGetCount()).toBe(before + 1);
+    expect(mockApi.get).toHaveBeenLastCalledWith(LIST_URL, {
+      params: { page: 1, per_page: 50, actor: 'ur_colonel1' },
+    });
+  });
+
+  it('runs the same search from the Search button (mouse/keyboard parity)', async () => {
+    wrapper = mountView(pinia);
+    await flushPromises();
+    const before = listGetCount();
+
+    await actorInput(wrapper).setValue('ur_colonel1');
+    expect(searchButton(wrapper).exists()).toBe(true);
+    await actorForm(wrapper).trigger('submit');
+    await flushPromises();
+
+    expect(listGetCount()).toBe(before + 1);
+    expect(mockApi.get).toHaveBeenLastCalledWith(LIST_URL, {
+      params: { page: 1, per_page: 50, actor: 'ur_colonel1' },
+    });
+  });
+
+  it('submits exactly once per Enter press (no debounce echo behind it)', async () => {
+    wrapper = mountView(pinia);
+    await flushPromises();
+    const before = listGetCount();
+
+    await actorInput(wrapper).setValue('ur_colonel1');
+    await actorInput(wrapper).trigger('keydown.enter');
+    await flushPromises();
+    vi.advanceTimersByTime(5000);
+    await flushPromises();
+
+    expect(listGetCount()).toBe(before + 1);
+  });
+
+  it('trims the submitted term and keeps the box in sync with what was applied', async () => {
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    await actorInput(wrapper).setValue('  ur_colonel1  ');
+    await actorForm(wrapper).trigger('submit');
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenLastCalledWith(LIST_URL, {
+      params: { page: 1, per_page: 50, actor: 'ur_colonel1' },
+    });
+    expect((actorInput(wrapper).element as HTMLInputElement).value).toBe('ur_colonel1');
+    expect(wrapper.find('[data-testid="audit-search-pending"]').exists()).toBe(false);
+  });
+
+  it('submitting an emptied box returns to the unfiltered list', async () => {
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    await actorInput(wrapper).setValue('ur_colonel1');
+    await actorForm(wrapper).trigger('submit');
+    await flushPromises();
+
+    await actorInput(wrapper).setValue('');
+    await actorForm(wrapper).trigger('submit');
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenLastCalledWith(LIST_URL, {
+      params: { page: 1, per_page: 50 },
+    });
+  });
+
+  it('clear resets the applied actor search and refetches unfiltered', async () => {
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    await actorInput(wrapper).setValue('ur_colonel1');
+    await actorForm(wrapper).trigger('submit');
+    await flushPromises();
+    expect(mockApi.get).toHaveBeenLastCalledWith(LIST_URL, {
+      params: { page: 1, per_page: 50, actor: 'ur_colonel1' },
+    });
+
+    const before = listGetCount();
+    await wrapper
+      .find('[data-testid="audit-filterbar"]')
+      .findAll('button')
+      .at(-1)!
+      .trigger('click');
+    await flushPromises();
+
+    expect(listGetCount()).toBe(before + 1);
+    expect(mockApi.get).toHaveBeenLastCalledWith(LIST_URL, {
+      params: { page: 1, per_page: 50 },
+    });
+    expect((actorInput(wrapper).element as HTMLInputElement).value).toBe('');
+
+    // And no deferred work fires behind the clear.
+    vi.advanceTimersByTime(5000);
+    await flushPromises();
+    expect(listGetCount()).toBe(before + 1);
+  });
+
+  it('keeps the action category select immediate, and carries the applied actor with it', async () => {
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    await wrapper.find('#kit-filter-verb').setValue('customer');
+    await flushPromises();
+    expect(mockApi.get).toHaveBeenLastCalledWith(LIST_URL, {
+      params: { page: 1, per_page: 50, verb: 'customer' },
+    });
+
+    await actorInput(wrapper).setValue('ur_colonel1');
+    await actorForm(wrapper).trigger('submit');
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenLastCalledWith(LIST_URL, {
+      params: { page: 1, per_page: 50, actor: 'ur_colonel1', verb: 'customer' },
+    });
+  });
+
+  it('does not carry an unsubmitted actor term into a category change', async () => {
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    await actorInput(wrapper).setValue('ur_colonel1');
+    await wrapper.find('#kit-filter-verb').setValue('domain');
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenLastCalledWith(LIST_URL, {
+      params: { page: 1, per_page: 50, verb: 'domain' },
+    });
+  });
+
+  it('leaves no pending timer behind on unmount', async () => {
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    await actorInput(wrapper).setValue('ur_colonel1');
+    wrapper.unmount();
+
+    const after = listGetCount();
+    vi.advanceTimersByTime(5000);
+    await flushPromises();
+    expect(listGetCount()).toBe(after);
+  });
+});

--- a/src/tests/apps/admin/AdminBilling.spec.ts
+++ b/src/tests/apps/admin/AdminBilling.spec.ts
@@ -1,7 +1,7 @@
 // src/tests/apps/admin/AdminBilling.spec.ts
 
 import { createPinia, setActivePinia } from 'pinia';
-import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { flushPromises, mount, RouterLinkStub, VueWrapper } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockApi = {
@@ -92,24 +92,20 @@ function localConfigPayload() {
   };
 }
 
-// Stub JsonViewer (avoid clipboard machinery) and DetailDrawer (always render
-// its slot so the diff content is assertable without headlessui teleport).
+// Stub JsonViewer (avoid clipboard machinery). The side-by-side diff is no
+// longer a drawer on this page — it is the AdminPlanDiff route, so the row
+// action is a router-link and RouterLinkStub is what we assert against.
 const jsonViewerStub = {
   name: 'JsonViewer',
   props: ['data', 'expandDepth', 'testid'],
   template: '<div :data-testid="testid" />',
-};
-const detailDrawerStub = {
-  name: 'DetailDrawer',
-  props: ['open', 'title', 'subtitle', 'testid'],
-  template: '<div :data-testid="testid"><slot /></div>',
 };
 
 const mountView = (pinia: ReturnType<typeof createPinia>) =>
   mount(AdminBilling, {
     global: {
       plugins: [pinia, i18n],
-      stubs: { JsonViewer: jsonViewerStub, DetailDrawer: detailDrawerStub },
+      stubs: { JsonViewer: jsonViewerStub, RouterLink: RouterLinkStub },
     },
   });
 
@@ -150,29 +146,32 @@ describe('AdminBilling (read-only billing catalog drift — ticket #45)', () => 
     expect(wrapper.find('[data-testid="billing-in-sync"]').exists()).toBe(false);
   });
 
-  it('opens the side-by-side diff drawer for a plan present on both sides', async () => {
+  // The drawer was replaced by the deep-linkable /colonel/billing/plans/:planid
+  // page. Panel/placeholder rendering is asserted in AdminPlanDiff.spec.ts;
+  // here we only pin that every row links to the right route + params.
+  it('links each plan row to the full-page diff (no drawer)', async () => {
     mockApi.get.mockResolvedValue({ data: catalogPayload() });
     wrapper = mountView(pinia);
     await flushPromises();
 
-    await wrapper.find('[data-testid="billing-diff-identity_plus_v1"]').trigger('click');
-    await flushPromises();
+    const bothSides = wrapper.findComponent<typeof RouterLinkStub>(
+      '[data-testid="billing-diff-identity_plus_v1"]'
+    );
+    expect(bothSides.exists()).toBe(true);
+    expect(bothSides.props('to')).toEqual({
+      name: 'AdminPlanDiff',
+      params: { planid: 'identity_plus_v1' },
+    });
 
-    // Both config and live JSON panels render for a plan on both sides.
-    expect(wrapper.find('[data-testid="billing-diff-config-json"]').exists()).toBe(true);
-    expect(wrapper.find('[data-testid="billing-diff-live-json"]').exists()).toBe(true);
-  });
-
-  it('shows a config-absent placeholder in the diff for a live-only plan', async () => {
-    mockApi.get.mockResolvedValue({ data: catalogPayload() });
-    wrapper = mountView(pinia);
-    await flushPromises();
-
-    await wrapper.find('[data-testid="billing-diff-new_v2"]').trigger('click');
-    await flushPromises();
-
-    expect(wrapper.find('[data-testid="billing-diff-config-absent"]').exists()).toBe(true);
-    expect(wrapper.find('[data-testid="billing-diff-live-json"]').exists()).toBe(true);
+    // …including a plan that exists only on the live side.
+    const liveOnly = wrapper.findComponent<typeof RouterLinkStub>(
+      '[data-testid="billing-diff-new_v2"]'
+    );
+    expect(liveOnly.exists()).toBe(true);
+    expect(liveOnly.props('to')).toEqual({
+      name: 'AdminPlanDiff',
+      params: { planid: 'new_v2' },
+    });
   });
 
   it('warns when the source is local_config (drift cannot be evaluated)', async () => {

--- a/src/tests/apps/admin/AdminCustomerDetail.spec.ts
+++ b/src/tests/apps/admin/AdminCustomerDetail.spec.ts
@@ -69,6 +69,8 @@ import { createTestI18n } from '@tests/setup';
 const i18n = createTestI18n();
 
 const PUBLIC_ID = 'ur_alice';
+/** Purge is gated on the account EMAIL (suspend still uses the public id). */
+const PURGE_TOKEN = 'alice@example.com';
 
 type BillingOverride = {
   enabled?: boolean;
@@ -238,7 +240,7 @@ describe('AdminCustomerDetail (ticket #22)', () => {
       await flushPromises();
     });
 
-    it('opens a danger dialog whose confirm stays disabled until the public id is retyped', async () => {
+    it('opens a danger dialog whose confirm stays disabled until the account email is retyped', async () => {
       await wrapper.find('[data-testid="purge-button"]').trigger('click');
       await flushPromises();
 
@@ -250,8 +252,12 @@ describe('AdminCustomerDetail (ticket #22)', () => {
       await dialogInput(wrapper).setValue('not-the-id');
       expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
 
-      // …exact public id enables it.
+      // …the public id is NOT the purge token any more; only the email is.
       await dialogInput(wrapper).setValue(PUBLIC_ID);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+      // …exact account email enables it.
+      await dialogInput(wrapper).setValue(PURGE_TOKEN);
       expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
     });
 
@@ -259,7 +265,7 @@ describe('AdminCustomerDetail (ticket #22)', () => {
       mockApi.delete.mockResolvedValue({ data: mutationAck() });
 
       await wrapper.find('[data-testid="purge-button"]').trigger('click');
-      await dialogInput(wrapper).setValue(PUBLIC_ID);
+      await dialogInput(wrapper).setValue(PURGE_TOKEN);
       await wrapper.find('form').trigger('submit');
       await flushPromises();
 
@@ -285,7 +291,7 @@ describe('AdminCustomerDetail (ticket #22)', () => {
       );
 
       await wrapper.find('[data-testid="purge-button"]').trigger('click');
-      await dialogInput(wrapper).setValue(PUBLIC_ID);
+      await dialogInput(wrapper).setValue(PURGE_TOKEN);
       await wrapper.find('form').trigger('submit');
       await flushPromises();
 

--- a/src/tests/apps/admin/AdminCustomerDetail.spec.ts
+++ b/src/tests/apps/admin/AdminCustomerDetail.spec.ts
@@ -205,6 +205,34 @@ describe('AdminCustomerDetail (ticket #22)', () => {
       expect(wrapper.find('[data-testid="organizations-list"]').text()).toContain('Acme');
     });
 
+    // The endpoint reads a bounded page off the per-owner index, so a short
+    // list is not proof of a short history. `truncated` is how the server says
+    // "this is partial" — the view must never render a partial list as if it
+    // were the whole record.
+    it('says nothing about truncation when the payload is complete', async () => {
+      mockApi.get.mockResolvedValue({ data: detailPayload() });
+      wrapper = mountView();
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="secrets-truncated"]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="receipts-truncated"]').exists()).toBe(false);
+    });
+
+    it('flags a partial secrets/receipts list when the server truncated it', async () => {
+      const payload = detailPayload();
+      payload.details.secrets.truncated = true;
+      payload.details.receipts.truncated = true;
+      mockApi.get.mockResolvedValue({ data: payload });
+      wrapper = mountView();
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="secrets-truncated"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="receipts-truncated"]').exists()).toBe(true);
+      // The rest of the record still renders — truncation is not an error state.
+      expect(wrapper.find('[data-testid="detail-content"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="secrets-table"]').text()).toContain('sh1');
+    });
+
     it('renders the not-found panel on a 404', async () => {
       mockApi.get.mockRejectedValue(Object.assign(new Error('nf'), { response: { status: 404 } }));
       wrapper = mountView();

--- a/src/tests/apps/admin/AdminCustomerDetailPurge.spec.ts
+++ b/src/tests/apps/admin/AdminCustomerDetailPurge.spec.ts
@@ -1,0 +1,245 @@
+// src/tests/apps/admin/AdminCustomerDetailPurge.spec.ts
+
+import { AxiosError } from 'axios';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Detail-page purge gate: the typed-confirmation token is the account's EMAIL.
+ *
+ * Split out of AdminCustomerDetail.spec.ts (which still asserts the previous
+ * public-id token in its `purge — typed-confirmation gate` block; those three
+ * assertions need the email instead). Suspend is covered here too, as the
+ * regression guard that ONLY purge moved to the email token.
+ */
+
+/** Build a real AxiosError so the shared classifier extracts `data.error`. */
+function axiosError(status: number, data: unknown, message = 'Request failed'): AxiosError {
+  const err = new AxiosError(message);
+  err.response = { status, data, statusText: '', headers: {}, config: {} as never };
+  return err;
+}
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+const pushMock = vi.fn();
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: pushMock }),
+  useRoute: () => ({ params: { id: 'ur_alice' } }),
+}));
+
+const showMock = vi.fn();
+vi.mock('@/shared/stores/notificationsStore', () => ({
+  useNotificationsStore: () => ({ show: showMock }),
+}));
+
+vi.mock('@/utils/format', () => ({
+  formatDisplayDateTime: (d: Date) => `DT:${d.toISOString()}`,
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+vi.mock('@headlessui/vue', () => ({
+  Dialog: {
+    name: 'Dialog',
+    template: '<div role="dialog" @close="$emit(\'close\')"><slot /></div>',
+    props: ['class'],
+    emits: ['close'],
+  },
+  DialogPanel: {
+    name: 'DialogPanel',
+    template: '<div class="dialog-panel" :data-testid="$attrs[\'data-testid\']"><slot /></div>',
+    props: ['class'],
+  },
+  DialogTitle: { name: 'DialogTitle', template: '<h3><slot /></h3>', props: ['as', 'class'] },
+  TransitionRoot: {
+    name: 'TransitionRoot',
+    template: '<div v-if="show"><slot /></div>',
+    props: ['as', 'show'],
+  },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>', props: ['as'] },
+}));
+
+import AdminCustomerDetail from '@/apps/admin/views/AdminCustomerDetail.vue';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+const PUBLIC_ID = 'ur_alice';
+const EMAIL = 'alice@example.com';
+
+function detailPayload(overrides: { verified?: boolean } = {}) {
+  return {
+    shrimp: '',
+    record: {
+      extid: PUBLIC_ID,
+      email: EMAIL,
+      role: 'customer',
+      verified: overrides.verified ?? false,
+      suspended: false,
+      suspended_at: null,
+      suspended_by: null,
+      suspended_reason: null,
+      created: 1700000000,
+      updated: 1700000100,
+      last_login: 1700000200,
+      planid: 'basic',
+      locale: 'en',
+    },
+    details: {
+      secrets: { count: 0, items: [] },
+      receipts: { count: 0, items: [] },
+      organizations: [],
+      billing: {
+        enabled: false,
+        plan_id: 'basic',
+        organization: null,
+        stripe: {
+          available: false,
+          reason: 'Billing is not configured',
+          customer_id: null,
+          dashboard_url: null,
+          subscription: null,
+          latest_invoice: null,
+        },
+      },
+      stats: { secrets_created: 0, secrets_shared: 0, emails_sent: 0 },
+    },
+  };
+}
+
+function mutationAck() {
+  return { shrimp: '', record: { user_id: 'objid', extid: PUBLIC_ID }, details: { message: 'ok' } };
+}
+
+const mountView = () =>
+  mount(AdminCustomerDetail, {
+    props: { id: PUBLIC_ID },
+    global: { plugins: [i18n], stubs: { AdminCustomerSessionsSection: true } },
+  });
+
+const dialogInput = (w: VueWrapper) => w.find('#admin-confirm-input');
+const dialogSubmit = (w: VueWrapper) => w.find('[data-testid="admin-confirm-submit"]');
+
+describe('AdminCustomerDetail — purge gate (typed email) + verification state', () => {
+  let wrapper: VueWrapper;
+
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => wrapper?.unmount());
+
+  async function mountLoaded(overrides: { verified?: boolean } = {}): Promise<void> {
+    mockApi.get.mockResolvedValue({ data: detailPayload(overrides) });
+    wrapper = mountView();
+    await flushPromises();
+  }
+
+  it('gates purge behind the EXACT email — the public id does not unlock it', async () => {
+    await mountLoaded();
+
+    await wrapper.find('[data-testid="purge-button"]').trigger('click');
+    await flushPromises();
+
+    expect(dialogInput(wrapper).exists()).toBe(true);
+    expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+    await dialogInput(wrapper).setValue(PUBLIC_ID);
+    expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+    await dialogInput(wrapper).setValue(EMAIL.toUpperCase());
+    expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+    await dialogInput(wrapper).setValue(EMAIL);
+    expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+  });
+
+  it('DELETEs, toasts and routes back to the list on confirm', async () => {
+    await mountLoaded();
+    mockApi.delete.mockResolvedValue({ data: mutationAck() });
+
+    await wrapper.find('[data-testid="purge-button"]').trigger('click');
+    await dialogInput(wrapper).setValue(EMAIL);
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(mockApi.delete).toHaveBeenCalledWith(`/api/colonel/users/${PUBLIC_ID}`);
+    expect(showMock).toHaveBeenCalledWith('web.admin.customers.actions.purge.success', 'success');
+    expect(pushMock).toHaveBeenCalledWith({ name: 'AdminCustomers' });
+  });
+
+  it('keeps a failed purge in the dialog: no navigation, no toast', async () => {
+    await mountLoaded();
+    mockApi.delete.mockRejectedValue(axiosError(422, { error: 'Cannot purge anonymous user' }));
+
+    await wrapper.find('[data-testid="purge-button"]').trigger('click');
+    await dialogInput(wrapper).setValue(EMAIL);
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="admin-confirm-dialog"]').text()).toContain(
+      'Cannot purge anonymous user'
+    );
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(showMock).not.toHaveBeenCalled();
+  });
+
+  it('leaves SUSPEND on the public-id token (only purge moved to the email)', async () => {
+    await mountLoaded();
+    mockApi.post.mockResolvedValue({ data: mutationAck() });
+
+    await wrapper.find('[data-testid="suspend-button"]').trigger('click');
+    await flushPromises();
+
+    await dialogInput(wrapper).setValue(EMAIL);
+    expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+    await dialogInput(wrapper).setValue(PUBLIC_ID);
+    expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+  });
+
+  it('states the verification badge both ways and offers only the matching verb', async () => {
+    await mountLoaded({ verified: false });
+    expect(wrapper.find('[data-testid="unverified-badge"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="verified-badge"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="verify-button"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="unverify-button"]').exists()).toBe(false);
+
+    wrapper.unmount();
+
+    await mountLoaded({ verified: true });
+    expect(wrapper.find('[data-testid="verified-badge"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="unverified-badge"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="unverify-button"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="verify-button"]').exists()).toBe(false);
+  });
+
+  it('refreshes the record after verify instead of navigating away', async () => {
+    await mountLoaded({ verified: false });
+    mockApi.post.mockResolvedValue({ data: mutationAck() });
+    // The refreshed read reports the new state — the badge must follow it.
+    mockApi.get.mockResolvedValue({ data: detailPayload({ verified: true }) });
+
+    await wrapper.find('[data-testid="verify-button"]').trigger('click');
+    await flushPromises();
+    // Reversible action: one-click confirm, no typed gate.
+    expect(dialogInput(wrapper).exists()).toBe(false);
+
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(mockApi.post).toHaveBeenCalledWith(`/api/colonel/users/${PUBLIC_ID}/verify`, {});
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(wrapper.find('[data-testid="verified-badge"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="unverify-button"]').exists()).toBe(true);
+  });
+});

--- a/src/tests/apps/admin/AdminCustomers.spec.ts
+++ b/src/tests/apps/admin/AdminCustomers.spec.ts
@@ -255,12 +255,67 @@ describe('AdminCustomers (list view — ticket #22)', () => {
     expect(pushMock).not.toHaveBeenCalled();
 
     // The deep, mutating actions stay one click away on the full page (by public id).
-    const fullPage = wrapper.findComponent(RouterLinkStub);
-    expect(fullPage.exists()).toBe(true);
-    expect(fullPage.props('to')).toEqual({
+    const fullPage = wrapper
+      .findAllComponents(RouterLinkStub)
+      .find((link) => link.attributes('data-testid') === 'customer-open-full-page');
+    expect(fullPage).toBeDefined();
+    expect(fullPage!.props('to')).toEqual({
       name: 'AdminCustomerDetail',
       params: { id: 'ur_alice' },
     });
+  });
+
+  // --- Row-scoped affordances inside a CLICKABLE row ------------------------
+  // The row's @click opens the drawer, so anything interactive rendered inside
+  // a cell must contain its own click. Both of these were operator-reported.
+
+  it('reveals an email without also opening the drawer', async () => {
+    mockApi.get.mockResolvedValue({ data: usersPayload() });
+    wrapper = mountView();
+    await flushPromises();
+
+    const row = wrapper.find('[data-testid="customers-table"] tbody tr');
+    // Obscured by default.
+    expect(row.find('[data-testid="reveal-email-value"]').text()).not.toBe('alice@example.com');
+
+    await row.find('[data-testid="reveal-email-toggle"]').trigger('click');
+    await flushPromises();
+
+    // Revealed...
+    expect(row.find('[data-testid="reveal-email-value"]').text()).toBe('alice@example.com');
+    // ...and the row handler never fired.
+    expect(wrapper.find('[data-testid="customers-drawer"]').exists()).toBe(false);
+
+    // The copy affordance that appears on reveal is contained too.
+    Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
+    await row.find('[data-testid="reveal-email-copy"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-testid="customers-drawer"]').exists()).toBe(false);
+  });
+
+  it('links each row straight to the full page without opening the drawer', async () => {
+    mockApi.get.mockResolvedValue({ data: usersPayload() });
+    wrapper = mountView();
+    await flushPromises();
+
+    const rowLink = wrapper
+      .findAllComponents(RouterLinkStub)
+      .find((link) => link.attributes('data-testid') === 'customer-detail-ur_alice');
+
+    // A REAL router-link — middle-click / open-in-new-tab must work, so this
+    // must never become a JS click handler.
+    expect(rowLink).toBeDefined();
+    expect(rowLink!.props('to')).toEqual({
+      name: 'AdminCustomerDetail',
+      params: { id: 'ur_alice' },
+    });
+    // Icon-only control, so it carries its own accessible name.
+    expect(rowLink!.attributes('aria-label')).toBeTruthy();
+
+    // Activating it must not also open the drawer behind it.
+    await rowLink!.trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-testid="customers-drawer"]').exists()).toBe(false);
   });
 
   it('renders the pagination control when the server returns pagination', async () => {

--- a/src/tests/apps/admin/AdminCustomersActions.spec.ts
+++ b/src/tests/apps/admin/AdminCustomersActions.spec.ts
@@ -1,0 +1,384 @@
+// src/tests/apps/admin/AdminCustomersActions.spec.ts
+
+import { AxiosError } from 'axios';
+import { createPinia, setActivePinia } from 'pinia';
+import { flushPromises, mount, RouterLinkStub, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/** Build a real AxiosError so the shared classifier extracts `data.error`. */
+function axiosError(status: number, data: unknown, message = 'Request failed'): AxiosError {
+  const err = new AxiosError(message);
+  err.response = { status, data, statusText: '', headers: {}, config: {} as never };
+  return err;
+}
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+const pushMock = vi.fn();
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: pushMock }),
+  useRoute: () => ({ params: {} }),
+}));
+
+const showMock = vi.fn();
+vi.mock('@/shared/stores/notificationsStore', () => ({
+  useNotificationsStore: () => ({ show: showMock }),
+}));
+
+// Deterministic, bootstrap-free date rendering.
+vi.mock('@/utils/format', () => ({
+  formatDisplayDateTime: (d: Date) => `DT:${d.toISOString()}`,
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+// Render the drawer + confirm dialog markup synchronously and IN-PLACE (the real
+// headlessui Dialog teleports to <body>, escaping the mounted wrapper).
+vi.mock('@headlessui/vue', () => ({
+  Dialog: {
+    name: 'Dialog',
+    template: '<div role="dialog" @close="$emit(\'close\')"><slot /></div>',
+    props: ['class'],
+    emits: ['close'],
+  },
+  DialogPanel: {
+    name: 'DialogPanel',
+    template: '<div class="dialog-panel" :data-testid="$attrs[\'data-testid\']"><slot /></div>',
+    props: ['class'],
+  },
+  DialogTitle: { name: 'DialogTitle', template: '<h3><slot /></h3>', props: ['as', 'class'] },
+  TransitionRoot: {
+    name: 'TransitionRoot',
+    template: '<div v-if="show"><slot /></div>',
+    props: ['as', 'show'],
+  },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>', props: ['as'] },
+}));
+
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
+
+import AdminCustomers from '@/apps/admin/views/AdminCustomers.vue';
+import { useAdminCustomers } from '@/apps/admin/stores/useAdminCustomers';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+const PUBLIC_ID = 'ur_alice';
+const EMAIL = 'alice@example.com';
+
+/** Wire-shape users page (numbers for dates) so the REAL schema runs unchanged. */
+function usersPayload(overrides: { verified?: boolean } = {}) {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      users: [
+        {
+          user_id: PUBLIC_ID,
+          extid: PUBLIC_ID,
+          email: EMAIL,
+          role: 'customer',
+          verified: overrides.verified ?? false,
+          suspended: false,
+          created: 1700000000,
+          last_login: 1700000100,
+          planid: 'basic',
+          secrets_count: 3,
+          secrets_created: 5,
+          secrets_shared: 2,
+        },
+      ],
+      pagination: { page: 1, per_page: 50, total_count: 1, total_pages: 1, role_filter: null },
+    },
+  };
+}
+
+/** Empty page — what the list returns after the only row is purged. */
+function emptyPayload() {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      users: [],
+      pagination: { page: 1, per_page: 50, total_count: 0, total_pages: 0, role_filter: null },
+    },
+  };
+}
+
+function mutationAck() {
+  return {
+    shrimp: '',
+    record: { user_id: 'objid', extid: PUBLIC_ID },
+    details: { message: 'ok' },
+  };
+}
+
+const dialogInput = (w: VueWrapper) => w.find('#admin-confirm-input');
+const dialogSubmit = (w: VueWrapper) => w.find('[data-testid="admin-confirm-submit"]');
+const drawer = (w: VueWrapper) => w.find('[data-testid="customers-drawer"]');
+
+describe('AdminCustomers — drawer operator actions', () => {
+  let wrapper: VueWrapper;
+  let pinia: ReturnType<typeof createPinia>;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+  });
+  afterEach(() => wrapper?.unmount());
+
+  const mountView = () =>
+    mount(AdminCustomers, {
+      global: { plugins: [pinia, i18n], stubs: { RouterLink: RouterLinkStub } },
+    });
+
+  /** Mount, load one row, and open its drawer. */
+  async function openDrawer(overrides: { verified?: boolean } = {}): Promise<void> {
+    mockApi.get.mockResolvedValue({ data: usersPayload(overrides) });
+    wrapper = mountView();
+    await flushPromises();
+    await wrapper.find('[data-testid="customers-table"] tbody tr').trigger('click');
+    await flushPromises();
+  }
+
+  describe('verification state + verb selection', () => {
+    it('shows the unverified pill and offers ONLY verify', async () => {
+      await openDrawer({ verified: false });
+
+      expect(drawer(wrapper).find('[data-testid="customer-drawer-verification"]').text()).toContain(
+        'web.admin.customers.verification.unverified'
+      );
+      expect(wrapper.find('[data-testid="drawer-verify-button"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="drawer-unverify-button"]').exists()).toBe(false);
+    });
+
+    it('shows the verified pill and offers ONLY unverify', async () => {
+      await openDrawer({ verified: true });
+
+      expect(drawer(wrapper).find('[data-testid="customer-drawer-verification"]').text()).toContain(
+        'web.admin.customers.verification.verified'
+      );
+      expect(wrapper.find('[data-testid="drawer-unverify-button"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="drawer-verify-button"]').exists()).toBe(false);
+    });
+  });
+
+  describe('verify / unverify — simple confirm', () => {
+    it('POSTs verify, toasts, and flips the drawer + row without re-reading the list', async () => {
+      await openDrawer({ verified: false });
+      mockApi.post.mockResolvedValue({ data: mutationAck() });
+      const getCallsBefore = mockApi.get.mock.calls.length;
+
+      // Reversible action: one-click confirm, no typed-confirmation input.
+      await wrapper.find('[data-testid="drawer-verify-button"]').trigger('click');
+      await flushPromises();
+      expect(dialogInput(wrapper).exists()).toBe(false);
+
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockApi.post).toHaveBeenCalledWith(`/api/colonel/users/${PUBLIC_ID}/verify`, {});
+      expect(showMock).toHaveBeenCalledWith(
+        'web.admin.customers.actions.verify.success',
+        'success'
+      );
+
+      // Displayed state updates from the ack — no reload, no extra GET.
+      expect(mockApi.get.mock.calls.length).toBe(getCallsBefore);
+      expect(drawer(wrapper).find('[data-testid="customer-drawer-verification"]').text()).toContain(
+        'web.admin.customers.verification.verified'
+      );
+      // …and the action offered flips to the opposite verb.
+      expect(wrapper.find('[data-testid="drawer-unverify-button"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="drawer-verify-button"]').exists()).toBe(false);
+      // The underlying row is patched too, so the table cell agrees.
+      expect(useAdminCustomers().customers[0].verified).toBe(true);
+    });
+
+    it('POSTs unverify for a verified account and flips the pill back', async () => {
+      await openDrawer({ verified: true });
+      mockApi.post.mockResolvedValue({ data: mutationAck() });
+
+      await wrapper.find('[data-testid="drawer-unverify-button"]').trigger('click');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockApi.post).toHaveBeenCalledWith(`/api/colonel/users/${PUBLIC_ID}/unverify`, {});
+      expect(drawer(wrapper).find('[data-testid="customer-drawer-verification"]').text()).toContain(
+        'web.admin.customers.verification.unverified'
+      );
+    });
+
+    it('keeps the failure in the dialog and does not toast or change state', async () => {
+      await openDrawer({ verified: false });
+      mockApi.post.mockRejectedValue(axiosError(422, { error: 'Account has no auth record' }));
+
+      await wrapper.find('[data-testid="drawer-verify-button"]').trigger('click');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="admin-confirm-dialog"]').text()).toContain(
+        'Account has no auth record'
+      );
+      expect(showMock).not.toHaveBeenCalled();
+      expect(drawer(wrapper).find('[data-testid="customer-drawer-verification"]').text()).toContain(
+        'web.admin.customers.verification.unverified'
+      );
+    });
+  });
+
+  describe('purge — typed-confirmation on the email', () => {
+    it('stays disabled until the EXACT email is retyped (the public id does not unlock it)', async () => {
+      await openDrawer();
+
+      await wrapper.find('[data-testid="drawer-purge-button"]').trigger('click');
+      await flushPromises();
+
+      expect(dialogInput(wrapper).exists()).toBe(true);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+      // The public id is NOT the token for a purge.
+      await dialogInput(wrapper).setValue(PUBLIC_ID);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+      // Case matters — the gate is an exact, untrimmed match.
+      await dialogInput(wrapper).setValue(EMAIL.toUpperCase());
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+      await dialogInput(wrapper).setValue(EMAIL);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+    });
+
+    it('DELETEs, toasts, closes the drawer and refreshes the list', async () => {
+      await openDrawer();
+      mockApi.delete.mockResolvedValue({ data: mutationAck() });
+      mockApi.get.mockResolvedValue({ data: emptyPayload() });
+      const getCallsBefore = mockApi.get.mock.calls.length;
+
+      await wrapper.find('[data-testid="drawer-purge-button"]').trigger('click');
+      await dialogInput(wrapper).setValue(EMAIL);
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockApi.delete).toHaveBeenCalledWith(`/api/colonel/users/${PUBLIC_ID}`);
+      expect(showMock).toHaveBeenCalledWith('web.admin.customers.actions.purge.success', 'success');
+      expect(drawer(wrapper).exists()).toBe(false);
+      // The list is re-read (totals/pagination move server-side).
+      expect(mockApi.get.mock.calls.length).toBe(getCallsBefore + 1);
+      expect(mockApi.get).toHaveBeenLastCalledWith('/api/colonel/users', {
+        params: { page: 1, per_page: 50 },
+      });
+      // Stays on the list — the drawer never navigated anywhere.
+      expect(pushMock).not.toHaveBeenCalled();
+    });
+
+    it('does NOT delete when submitted without a matching token', async () => {
+      await openDrawer();
+      mockApi.delete.mockResolvedValue({ data: mutationAck() });
+
+      await wrapper.find('[data-testid="drawer-purge-button"]').trigger('click');
+      await dialogInput(wrapper).setValue('wrong');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockApi.delete).not.toHaveBeenCalled();
+      expect(drawer(wrapper).exists()).toBe(true);
+    });
+
+    it('surfaces the backend error in the dialog and keeps the row', async () => {
+      await openDrawer();
+      mockApi.delete.mockRejectedValue(axiosError(422, { error: 'Cannot purge yourself' }));
+
+      await wrapper.find('[data-testid="drawer-purge-button"]').trigger('click');
+      await dialogInput(wrapper).setValue(EMAIL);
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="admin-confirm-dialog"]').text()).toContain(
+        'Cannot purge yourself'
+      );
+      expect(showMock).not.toHaveBeenCalled();
+      expect(drawer(wrapper).exists()).toBe(true);
+      expect(useAdminCustomers().customers).toHaveLength(1);
+    });
+  });
+});
+
+describe('useAdminCustomers — operator mutations', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  async function seeded(overrides: { verified?: boolean } = {}) {
+    mockApi.get.mockResolvedValue({ data: usersPayload(overrides) });
+    const store = useAdminCustomers();
+    await store.fetchPage(1);
+    return store;
+  }
+
+  it('setVerification posts the matching verb and returns the patched row', async () => {
+    const store = await seeded({ verified: false });
+    mockApi.post.mockResolvedValue({ data: mutationAck() });
+
+    const updated = await store.setVerification(PUBLIC_ID, true);
+
+    expect(mockApi.post).toHaveBeenCalledWith(`/api/colonel/users/${PUBLIC_ID}/verify`, {});
+    expect(updated?.verified).toBe(true);
+    expect(store.customers[0].verified).toBe(true);
+  });
+
+  it('setVerification leaves the row untouched when the request fails', async () => {
+    const store = await seeded({ verified: false });
+    mockApi.post.mockRejectedValue(axiosError(500, {}));
+
+    await expect(store.setVerification(PUBLIC_ID, true)).rejects.toBeTruthy();
+    expect(store.customers[0].verified).toBe(false);
+  });
+
+  it('purge drops the row only after a 2xx', async () => {
+    const store = await seeded();
+    mockApi.delete.mockResolvedValue({ data: mutationAck() });
+
+    await store.purge(PUBLIC_ID);
+
+    expect(mockApi.delete).toHaveBeenCalledWith(`/api/colonel/users/${PUBLIC_ID}`);
+    expect(store.customers).toHaveLength(0);
+  });
+
+  it('purge keeps the row when the request fails', async () => {
+    const store = await seeded();
+    mockApi.delete.mockRejectedValue(axiosError(422, { error: 'nope' }));
+
+    await expect(store.purge(PUBLIC_ID)).rejects.toBeTruthy();
+    expect(store.customers).toHaveLength(1);
+  });
+
+  it('encodes the id in the mutation paths', async () => {
+    const store = await seeded();
+    mockApi.delete.mockResolvedValue({ data: mutationAck() });
+
+    await store.purge('ur alice/../colonel');
+
+    expect(mockApi.delete).toHaveBeenCalledWith(
+      '/api/colonel/users/ur%20alice%2F..%2Fcolonel'
+    );
+  });
+});

--- a/src/tests/apps/admin/AdminDomainDetail.spec.ts
+++ b/src/tests/apps/admin/AdminDomainDetail.spec.ts
@@ -1,0 +1,450 @@
+// src/tests/apps/admin/AdminDomainDetail.spec.ts
+
+import { AxiosError } from 'axios';
+import { createPinia, setActivePinia } from 'pinia';
+import { flushPromises, mount, RouterLinkStub, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/** Build a real AxiosError so the shared classifier extracts `data.error`. */
+function axiosError(status: number, data: unknown, message = 'Request failed'): AxiosError {
+  const err = new AxiosError(message);
+  err.response = { status, data, statusText: '', headers: {}, config: {} as never };
+  return err;
+}
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+const pushMock = vi.fn();
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: pushMock }),
+  useRoute: () => ({ params: { id: 'cd_abc123' } }),
+}));
+
+const showMock = vi.fn();
+vi.mock('@/shared/stores/notificationsStore', () => ({
+  useNotificationsStore: () => ({ show: showMock }),
+}));
+
+vi.mock('@/utils/format', () => ({
+  formatDisplayDateTime: (d: Date) => `DT:${d.toISOString()}`,
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+// Render the HeadlessUI confirm dialog synchronously and in place.
+vi.mock('@headlessui/vue', () => ({
+  Dialog: {
+    name: 'Dialog',
+    template: '<div role="dialog" @close="$emit(\'close\')"><slot /></div>',
+    props: ['class'],
+    emits: ['close'],
+  },
+  DialogPanel: {
+    name: 'DialogPanel',
+    template: '<div class="dialog-panel" :data-testid="$attrs[\'data-testid\']"><slot /></div>',
+    props: ['class'],
+  },
+  DialogTitle: { name: 'DialogTitle', template: '<h3><slot /></h3>', props: ['as', 'class'] },
+  TransitionRoot: {
+    name: 'TransitionRoot',
+    template: '<div v-if="show"><slot /></div>',
+    props: ['as', 'show'],
+  },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>', props: ['as'] },
+}));
+
+import AdminDomainDetail from '@/apps/admin/views/AdminDomainDetail.vue';
+import { useAdminDomains } from '@/apps/admin/stores/useAdminDomains';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+const EXTID = 'cd_abc123';
+const DETAIL_URL = `/api/colonel/domains/${EXTID}`;
+
+function detailPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    shrimp: '',
+    record: {
+      domain_id: 'cd1',
+      extid: EXTID,
+      display_domain: 'secrets.example.com',
+      base_domain: 'example.com',
+      subdomain: 'secrets',
+      trd: 'secrets',
+      tld: 'com',
+      status: null,
+      verification_state: 'pending',
+      verified: false,
+      resolving: false,
+      ready: false,
+      is_apex: false,
+      txt_validation_host: '_ots.secrets',
+      txt_validation_value: 'ots=abc123',
+      created: 1700000000,
+      updated: 1700003600,
+      ...overrides,
+    },
+    details: { cluster: { proxy_ip: '203.0.113.5', proxy_host: 'proxy.example' } },
+  };
+}
+
+function verifyAck(current_state = 'pending') {
+  return {
+    shrimp: '',
+    record: {
+      domain_id: 'cd1',
+      extid: EXTID,
+      display_domain: 'secrets.example.com',
+      verification_state: current_state,
+      verified: current_state === 'verified',
+      resolving: current_state !== 'pending',
+      ready: current_state === 'verified',
+      updated: 1700009999,
+    },
+    details: {
+      previous_state: 'pending',
+      current_state,
+      changed: true,
+      dns_validated: current_state === 'verified',
+      ssl_ready: current_state === 'verified',
+      is_resolving: current_state !== 'pending',
+      error: null,
+      message: 'Domain verification completed',
+    },
+  };
+}
+
+function probeAck() {
+  return {
+    shrimp: '',
+    record: { extid: EXTID, display_domain: 'secrets.example.com' },
+    details: {
+      timestamp: '2026-07-24T00:00:00Z',
+      domain: 'secrets.example.com',
+      url: 'https://secrets.example.com',
+      http: { status_code: 200, status_message: 'OK', success: true },
+      ssl: { valid: true, issuer: "Let's Encrypt", not_after: '2026-10-01', days_until_expiry: 68 },
+      health: 'healthy',
+    },
+  };
+}
+
+function removeAck(dry_run: boolean) {
+  return {
+    shrimp: '',
+    record: {
+      deleted: !dry_run,
+      domain_id: 'cd1',
+      extid: EXTID,
+      display_domain: 'secrets.example.com',
+    },
+    details: {
+      status: dry_run ? 'planned' : 'removed',
+      dry_run,
+      org_id: 'org1',
+      org_name: 'Acme',
+      reasserts_survivor: false,
+    },
+  };
+}
+
+function transferAck(dry_run: boolean) {
+  return {
+    shrimp: '',
+    record: { domain_id: 'cd1', extid: EXTID, display_domain: 'secrets.example.com' },
+    details: {
+      status: dry_run ? 'planned' : 'transferred',
+      dry_run,
+      from_org_id: 'org1',
+      from_org_name: 'Acme',
+      to_org_id: 'org_new',
+      to_org_name: 'Globex',
+    },
+  };
+}
+
+function repairAck(dry_run: boolean) {
+  return {
+    shrimp: '',
+    record: { domain_id: 'cd1', extid: EXTID, display_domain: 'secrets.example.com' },
+    details: {
+      status: 'planned',
+      dry_run,
+      issues: ['organization is missing the domain in its relation set'],
+      repairs_applied: dry_run ? [] : ['reattached domain to organization'],
+    },
+  };
+}
+
+const dialogInput = (w: VueWrapper) => w.find('#admin-confirm-input');
+const dialogSubmit = (w: VueWrapper) => w.find('[data-testid="admin-confirm-submit"]');
+
+describe('AdminDomainDetail', () => {
+  let wrapper: VueWrapper;
+  let pinia: ReturnType<typeof createPinia>;
+
+  const mountView = () =>
+    mount(AdminDomainDetail, {
+      props: { id: EXTID },
+      global: {
+        plugins: [pinia, i18n],
+        stubs: { RouterLink: RouterLinkStub },
+      },
+    });
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+    mockApi.get.mockResolvedValue({ data: detailPayload() });
+  });
+  afterEach(() => wrapper?.unmount());
+
+  describe('load states', () => {
+    it('fetches the domain by public id and renders the read-out', async () => {
+      wrapper = mountView();
+      await flushPromises();
+
+      expect(mockApi.get).toHaveBeenCalledWith(DETAIL_URL, undefined);
+      const content = wrapper.find('[data-testid="detail-content"]');
+      expect(content.exists()).toBe(true);
+      expect(content.text()).toContain('secrets.example.com');
+      // Identity fields + the reused DNS panel both render.
+      expect(wrapper.find('[data-testid="profile-publicId"]').text()).toContain(EXTID);
+      expect(wrapper.find('[data-testid="dns-details"]').exists()).toBe(true);
+    });
+
+    it('renders the not-found state for a 404', async () => {
+      mockApi.get.mockRejectedValue(axiosError(404, { error: 'Domain not found' }));
+      wrapper = mountView();
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="detail-not-found"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="detail-content"]').exists()).toBe(false);
+    });
+
+    it('renders the error state and retries on a network failure', async () => {
+      mockApi.get.mockRejectedValue(new Error('Network Error'));
+      wrapper = mountView();
+      await flushPromises();
+
+      const banner = wrapper.find('[data-testid="detail-error"]');
+      expect(banner.exists()).toBe(true);
+
+      mockApi.get.mockResolvedValue({ data: detailPayload() });
+      await banner.find('button').trigger('click');
+      await flushPromises();
+      expect(wrapper.find('[data-testid="detail-content"]').exists()).toBe(true);
+    });
+  });
+
+  describe('owning organization', () => {
+    it('links to the organization when the list row is cached', async () => {
+      const store = useAdminDomains();
+      // The detail endpoint omits org_id/org_name; the store's row cache carries
+      // it over from the list the operator navigated from.
+      store.rowIndex[EXTID] = { extid: EXTID, org_id: 'org1', org_name: 'Acme' } as never;
+
+      wrapper = mountView();
+      await flushPromises();
+
+      const link = wrapper.find('[data-testid="organization-link"]');
+      expect(link.exists()).toBe(true);
+      expect(wrapper.find('[data-testid="organization-section"]').text()).toContain('Acme');
+      expect(wrapper.find('[data-testid="organization-unknown"]').exists()).toBe(false);
+    });
+
+    it('says so honestly when the owner is unknown', async () => {
+      wrapper = mountView();
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="organization-unknown"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="organization-link"]').exists()).toBe(false);
+    });
+  });
+
+  describe('verify', () => {
+    it('confirms in one click, reports the honest state, and refreshes', async () => {
+      mockApi.post.mockResolvedValue({ data: verifyAck('pending') });
+      wrapper = mountView();
+      await flushPromises();
+      expect(mockApi.get).toHaveBeenCalledTimes(1);
+
+      await wrapper.find('[data-testid="verify-button"]').trigger('click');
+      await flushPromises();
+
+      // Reversible verb: no typed token, so confirm is enabled immediately.
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockApi.post).toHaveBeenCalledWith(`${DETAIL_URL}/verify`);
+      // A pending result is surfaced as info, never faked as success.
+      expect(showMock).toHaveBeenCalledTimes(1);
+      expect(showMock.mock.calls[0][1]).toBe('info');
+      expect(mockApi.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps a 4xx failure inside the dialog and does not toast', async () => {
+      mockApi.post.mockRejectedValue(axiosError(422, { error: 'DNS lookup failed' }));
+      wrapper = mountView();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="verify-button"]').trigger('click');
+      await flushPromises();
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="admin-confirm-dialog"]').text()).toContain(
+        'DNS lookup failed'
+      );
+      expect(showMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('probe', () => {
+    it('runs a read-only probe and renders the health classification', async () => {
+      mockApi.get.mockImplementation((url: string) =>
+        Promise.resolve({
+          data: url.endsWith('/probe') ? probeAck() : detailPayload(),
+        })
+      );
+      wrapper = mountView();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="probe-button"]').trigger('click');
+      await flushPromises();
+
+      expect(mockApi.get).toHaveBeenCalledWith(`${DETAIL_URL}/probe`, undefined);
+      expect(wrapper.find('[data-testid="probe-health"]').text()).toBe('healthy');
+      // No confirmation and no toast: a probe mutates nothing.
+      expect(showMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('remove (typed-confirm)', () => {
+    it('previews with dry_run=true before anything destructive is offered', async () => {
+      mockApi.delete.mockResolvedValue({ data: removeAck(true) });
+      wrapper = mountView();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="remove-preview"]').trigger('click');
+      await flushPromises();
+
+      expect(mockApi.delete).toHaveBeenCalledWith(`${DETAIL_URL}?dry_run=true`);
+      const plan = wrapper.find('[data-testid="remove-plan"]');
+      expect(plan.exists()).toBe(true);
+      expect(plan.text()).toContain('Acme');
+    });
+
+    it('gates the apply on the retyped public id, then deletes and returns to the list', async () => {
+      mockApi.delete.mockResolvedValue({ data: removeAck(false) });
+      wrapper = mountView();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="remove-button"]').trigger('click');
+      await flushPromises();
+
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+      await dialogInput(wrapper).setValue(EXTID);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      // The apply MUST say dry_run=false — the endpoint defaults it to true.
+      expect(mockApi.delete).toHaveBeenCalledWith(`${DETAIL_URL}?dry_run=false`);
+      expect(showMock).toHaveBeenCalledWith('web.admin.domains.actions.remove.success', 'success');
+      expect(pushMock).toHaveBeenCalledWith({ name: 'AdminDomains' });
+    });
+  });
+
+  describe('transfer (preview then typed-confirm)', () => {
+    it('previews with dry_run=true and applies with dry_run=false', async () => {
+      mockApi.post.mockImplementation((_url: string, body: { dry_run: boolean }) =>
+        Promise.resolve({ data: transferAck(body.dry_run) })
+      );
+      wrapper = mountView();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="transfer-toorg-input"]').setValue('org_new');
+      await wrapper.find('[data-testid="transfer-preview"]').trigger('click');
+      await flushPromises();
+
+      expect(mockApi.post).toHaveBeenCalledWith(`${DETAIL_URL}/transfer`, {
+        dry_run: true,
+        to_org: 'org_new',
+      });
+      expect(wrapper.find('[data-testid="transfer-plan"]').text()).toContain('Globex');
+
+      await wrapper.find('[data-testid="transfer-apply"]').trigger('click');
+      await flushPromises();
+      await dialogInput(wrapper).setValue(EXTID);
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockApi.post).toHaveBeenCalledWith(`${DETAIL_URL}/transfer`, {
+        dry_run: false,
+        to_org: 'org_new',
+      });
+      expect(showMock).toHaveBeenCalledWith(
+        'web.admin.domains.actions.transfer.success',
+        'success'
+      );
+    });
+  });
+
+  describe('repair (preview then typed-confirm)', () => {
+    it('previews the plan and only offers the apply when repairs are planned', async () => {
+      mockApi.post.mockImplementation((_url: string, body: { dry_run: boolean }) =>
+        Promise.resolve({ data: repairAck(body.dry_run) })
+      );
+      wrapper = mountView();
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="repair-apply"]').exists()).toBe(false);
+
+      await wrapper.find('[data-testid="repair-preview"]').trigger('click');
+      await flushPromises();
+
+      expect(mockApi.post).toHaveBeenCalledWith(`${DETAIL_URL}/repair`, { dry_run: true });
+      expect(wrapper.find('[data-testid="repair-status"]').text()).toBe('planned');
+
+      await wrapper.find('[data-testid="repair-apply"]').trigger('click');
+      await flushPromises();
+      await dialogInput(wrapper).setValue(EXTID);
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockApi.post).toHaveBeenCalledWith(`${DETAIL_URL}/repair`, { dry_run: false });
+      expect(showMock).toHaveBeenCalledWith('web.admin.domains.actions.repair.success', 'success');
+    });
+
+    it('passes the org id only when the operator supplied one', async () => {
+      mockApi.post.mockResolvedValue({ data: repairAck(true) });
+      wrapper = mountView();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="repair-orgid-input"]').setValue('org_rescue');
+      await wrapper.find('[data-testid="repair-preview"]').trigger('click');
+      await flushPromises();
+
+      expect(mockApi.post).toHaveBeenCalledWith(`${DETAIL_URL}/repair`, {
+        dry_run: true,
+        org_id: 'org_rescue',
+      });
+    });
+  });
+});

--- a/src/tests/apps/admin/AdminDomainsTable.spec.ts
+++ b/src/tests/apps/admin/AdminDomainsTable.spec.ts
@@ -1,0 +1,270 @@
+// src/tests/apps/admin/AdminDomainsTable.spec.ts
+//
+// Covers the DataTable rebuild of the domains list: the server-side search /
+// status filters, the TLS/serving column, the row-click detail drawer and its
+// escalation link. The verify flow and the attach-to-organization flow are
+// covered by AdminDomains.spec.ts and are not repeated here.
+//
+// The filter assertions pin the REQUEST CONTRACT (`search` / `status` query
+// params on GET /api/colonel/domains, applied server-side before pagination).
+
+import { createPinia, setActivePinia } from 'pinia';
+import { flushPromises, mount, RouterLinkStub, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+const pushMock = vi.fn();
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: pushMock }),
+  useRoute: () => ({ params: {} }),
+}));
+
+const showMock = vi.fn();
+vi.mock('@/shared/stores/notificationsStore', () => ({
+  useNotificationsStore: () => ({ show: showMock }),
+}));
+
+vi.mock('@/utils/format', () => ({
+  formatDisplayDateTime: (d: Date) => `DT:${d.toISOString()}`,
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+// Render the drawer's HeadlessUI dialog synchronously and IN-PLACE (the real
+// Dialog teleports its panel to <body>, escaping the mounted wrapper).
+vi.mock('@headlessui/vue', () => ({
+  Dialog: {
+    name: 'Dialog',
+    template: '<div role="dialog" @close="$emit(\'close\')"><slot /></div>',
+    props: ['class'],
+    emits: ['close'],
+  },
+  DialogPanel: {
+    name: 'DialogPanel',
+    template: '<div class="dialog-panel" :data-testid="$attrs[\'data-testid\']"><slot /></div>',
+    props: ['class'],
+  },
+  DialogTitle: { name: 'DialogTitle', template: '<h3><slot /></h3>', props: ['as', 'class'] },
+  TransitionRoot: {
+    name: 'TransitionRoot',
+    template: '<div v-if="show"><slot /></div>',
+    props: ['as', 'show'],
+  },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>', props: ['as'] },
+}));
+
+import AdminDomains from '@/apps/admin/views/AdminDomains.vue';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+function domainRow(overrides: Record<string, unknown> = {}) {
+  return {
+    domain_id: 'cd1',
+    extid: 'cd_abc123',
+    display_domain: 'secrets.example.com',
+    base_domain: 'example.com',
+    subdomain: 'secrets',
+    status: null,
+    verified: false,
+    resolving: false,
+    verification_state: 'pending',
+    ready: false,
+    created: 1700000000,
+    updated: 1700003600,
+    org_id: 'org1',
+    org_name: 'Acme',
+    brand: { name: 'Acme', tagline: null, homepage_url: null },
+    homepage_config: null,
+    api_config: null,
+    has_logo: false,
+    has_icon: false,
+    logo_url: null,
+    icon_url: null,
+    ...overrides,
+  };
+}
+
+/** Two rows that differ in every filterable dimension. */
+function twoRowPayload() {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      domains: [
+        domainRow(),
+        domainRow({
+          domain_id: 'cd2',
+          extid: 'cd_def456',
+          display_domain: 'links.globex.com',
+          base_domain: 'globex.com',
+          subdomain: 'links',
+          verified: true,
+          resolving: true,
+          verification_state: 'verified',
+          ready: true,
+          org_id: 'org2',
+          org_name: 'Globex',
+        }),
+      ],
+      pagination: { page: 1, per_page: 50, total_count: 2, total_pages: 1 },
+    },
+  };
+}
+
+const searchInput = (w: VueWrapper) => w.find('#kit-filter-search');
+const stateSelect = (w: VueWrapper) => w.find('#kit-filter-state');
+const rowCount = (w: VueWrapper) => w.findAll('tbody tr').length;
+
+describe('AdminDomains — table, filters and drawer', () => {
+  let wrapper: VueWrapper;
+  let pinia: ReturnType<typeof createPinia>;
+
+  const mountView = () =>
+    mount(AdminDomains, {
+      global: {
+        plugins: [pinia, i18n],
+        stubs: { RouterLink: RouterLinkStub },
+      },
+    });
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+    mockApi.get.mockResolvedValue({ data: twoRowPayload() });
+  });
+  afterEach(() => wrapper?.unmount());
+
+  it('renders one table row per domain with the serving/TLS state', async () => {
+    wrapper = mountView();
+    await flushPromises();
+
+    expect(rowCount(wrapper)).toBe(2);
+    // `ready` is the server's own answer; we render it, never re-derive it.
+    expect(wrapper.find('[data-testid="domain-tls-cd_def456"]').text()).toBe(
+      'web.admin.domains.tls.serving'
+    );
+    expect(wrapper.find('[data-testid="domain-tls-cd_abc123"]').text()).toBe(
+      'web.admin.domains.tls.none'
+    );
+  });
+
+  it('debounces the search box into a single filtered request', async () => {
+    vi.useFakeTimers();
+    try {
+      wrapper = mountView();
+      await flushPromises();
+      expect(mockApi.get).toHaveBeenCalledTimes(1);
+
+      await searchInput(wrapper).setValue('glo');
+      await searchInput(wrapper).setValue('globex');
+      vi.advanceTimersByTime(300);
+      await flushPromises();
+
+      // One request for the pause, not one per keystroke, and page 1.
+      expect(mockApi.get).toHaveBeenCalledTimes(2);
+      expect(mockApi.get).toHaveBeenLastCalledWith('/api/colonel/domains', {
+        params: { page: 1, per_page: 50, search: 'globex' },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('sends the state filter as the server `status` param', async () => {
+    wrapper = mountView();
+    await flushPromises();
+
+    await stateSelect(wrapper).setValue('verified');
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenLastCalledWith('/api/colonel/domains', {
+      params: { page: 1, per_page: 50, status: 'verified' },
+    });
+  });
+
+  it('clearing drops every filter param in one request', async () => {
+    wrapper = mountView();
+    await flushPromises();
+
+    await stateSelect(wrapper).setValue('verified');
+    await flushPromises();
+
+    await wrapper.find('[data-testid="domains-filterbar"] button').trigger('click');
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenLastCalledWith('/api/colonel/domains', {
+      params: { page: 1, per_page: 50 },
+    });
+  });
+
+  it('shows the filtered-empty message when the filtered page comes back empty', async () => {
+    wrapper = mountView();
+    await flushPromises();
+
+    mockApi.get.mockResolvedValue({
+      data: {
+        shrimp: '',
+        record: {},
+        details: {
+          domains: [],
+          pagination: { page: 1, per_page: 50, total_count: 0, total_pages: 0 },
+        },
+      },
+    });
+    await stateSelect(wrapper).setValue('verified');
+    await flushPromises();
+
+    const empty = wrapper.find('[data-testid="domains-empty"]');
+    expect(empty.exists()).toBe(true);
+    expect(empty.text()).toContain('web.admin.domains.list.emptyFilter');
+  });
+
+  it('opens the read-only drawer on row click and escalates to the detail page', async () => {
+    wrapper = mountView();
+    await flushPromises();
+
+    await wrapper.find('[data-testid="domain-row-cd_abc123"]').trigger('click');
+    await flushPromises();
+
+    const drawer = wrapper.find('[data-testid="domains-drawer"]');
+    expect(drawer.exists()).toBe(true);
+    expect(drawer.text()).toContain('Acme');
+    expect(wrapper.find('[data-testid="domain-field-publicId"]').text()).toContain('cd_abc123');
+
+    // The drawer renders from the row already in hand — no second fetch.
+    expect(mockApi.get).toHaveBeenCalledTimes(1);
+
+    const fullPage = wrapper.findComponent('[data-testid="domain-open-full-page"]');
+    expect(fullPage.exists()).toBe(true);
+    expect(fullPage.props('to')).toEqual({
+      name: 'AdminDomainDetail',
+      params: { id: 'cd_abc123' },
+    });
+  });
+
+  it('does not open the drawer when a row action is clicked', async () => {
+    wrapper = mountView();
+    await flushPromises();
+
+    await wrapper.find('[data-testid="domain-verify-cd_abc123"]').trigger('click');
+    await flushPromises();
+
+    // The verify confirm dialog opened; the drawer stayed closed.
+    expect(wrapper.find('[data-testid="admin-confirm-dialog"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="domains-drawer"]').exists()).toBe(false);
+  });
+});

--- a/src/tests/apps/admin/AdminOrganizationAddMember.spec.ts
+++ b/src/tests/apps/admin/AdminOrganizationAddMember.spec.ts
@@ -1,0 +1,547 @@
+// src/tests/apps/admin/AdminOrganizationAddMember.spec.ts
+
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+const showMock = vi.fn();
+vi.mock('@/shared/stores/notificationsStore', () => ({
+  useNotificationsStore: () => ({ show: showMock }),
+}));
+
+const pushMock = vi.fn();
+// `isNavigationFailure` is reached by the shared error classifier on every
+// failed mutation — the mock must provide it or the classifier throws.
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: pushMock }),
+  isNavigationFailure: () => false,
+  NavigationFailureType: { aborted: 4, cancelled: 8, duplicated: 16 },
+}));
+
+vi.mock('@/utils/format', () => ({
+  formatDisplayDateTime: (d: Date) => `DT:${d.toISOString()}`,
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+// CopyButton (used by RevealEmail) touches navigator.clipboard; stub it.
+vi.mock('@/shared/components/ui/CopyButton.vue', () => ({
+  default: {
+    name: 'CopyButton',
+    template: '<button class="copy-button" />',
+    props: ['text', 'tooltip', 'testid'],
+  },
+}));
+
+// Render the headlessui modal synchronously and IN-PLACE (the real Dialog
+// teleports its panel to <body>, escaping the mounted wrapper).
+vi.mock('@headlessui/vue', () => ({
+  Dialog: {
+    name: 'Dialog',
+    template: '<div role="dialog" @close="$emit(\'close\')"><slot /></div>',
+    props: ['class'],
+    emits: ['close'],
+  },
+  DialogPanel: {
+    name: 'DialogPanel',
+    template: '<div class="dialog-panel" :data-testid="$attrs[\'data-testid\']"><slot /></div>',
+    props: ['class'],
+  },
+  DialogTitle: { name: 'DialogTitle', template: '<h3><slot /></h3>', props: ['as', 'class'] },
+  TransitionRoot: {
+    name: 'TransitionRoot',
+    template: '<div v-if="show"><slot /></div>',
+    props: ['as', 'show'],
+  },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>', props: ['as'] },
+}));
+
+import AdminOrganizationDetail from '@/apps/admin/views/AdminOrganizationDetail.vue';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+const ORG_EXTID = 'on_abc123';
+const ORG_URL = `/api/colonel/organizations/${ORG_EXTID}`;
+const MEMBERS_URL = `${ORG_URL}/members`;
+const USERS_URL = '/api/colonel/users';
+
+/** Existing owner already on the roster. */
+const OWNER_EXTID = 'ur_owner1';
+/** The account the operator is trying to add. */
+const CANDIDATE_EXTID = 'ur_cand99';
+
+function detailPayload() {
+  return {
+    shrimp: '',
+    record: {
+      org_id: 'org1',
+      extid: ORG_EXTID,
+      display_name: 'Acme',
+      description: 'Acme workspace',
+      is_default: false,
+      archived: false,
+      archived_at: null,
+      archived_comment: null,
+      contact_email: 'owner@acme.test',
+      owner_id: 'cust1',
+      owner_email: 'owner@acme.test',
+      billing_email: null,
+      member_count: 1,
+      domain_count: 0,
+      created: 1700000000,
+      updated: null,
+      planid: 'identity_plus_v1',
+      stripe_customer_id: null,
+      stripe_subscription_id: null,
+      subscription_status: null,
+      subscription_period_end: null,
+      billing_email_present: false,
+      sync_status: 'synced',
+      sync_status_reason: null,
+    },
+    details: {
+      entitlements: {
+        plan: ['create_secrets'],
+        grants: [],
+        revokes: [],
+        materialized: ['create_secrets'],
+        expected: ['create_secrets'],
+        materialized_flag: true,
+        materialized_at: 1700000000,
+        plan_stale: false,
+        drift: { extra: [], missing: [], in_sync: true },
+      },
+      members: [
+        {
+          extid: OWNER_EXTID,
+          email: 'owner@acme.test',
+          role: 'owner',
+          status: 'active',
+          is_owner: true,
+          joined_at: 1700000000,
+          created: 1700000000,
+        },
+      ],
+      domains: [],
+    },
+  };
+}
+
+function usersPayload(users: Array<Record<string, unknown>>) {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      users,
+      pagination: { page: 1, per_page: 25, total_count: users.length, total_pages: 1 },
+    },
+  };
+}
+
+function userRow(overrides: Record<string, unknown> = {}) {
+  return {
+    user_id: CANDIDATE_EXTID,
+    extid: CANDIDATE_EXTID,
+    email: 'newperson@acme.test',
+    role: 'customer',
+    verified: true,
+    suspended: false,
+    created: 1700000000,
+    last_login: 1700003600,
+    planid: 'identity_plus_v1',
+    secrets_count: 0,
+    secrets_created: 0,
+    secrets_shared: 0,
+    ...overrides,
+  };
+}
+
+function userDetailPayload(organizations: Array<Record<string, unknown>> = []) {
+  return {
+    shrimp: '',
+    record: {
+      extid: CANDIDATE_EXTID,
+      email: 'newperson@acme.test',
+      role: 'customer',
+      verified: true,
+      suspended: false,
+      created: 1700000000,
+      updated: null,
+      last_login: 1700003600,
+      planid: 'identity_plus_v1',
+      locale: 'en',
+    },
+    details: {
+      secrets: { count: 0, items: [] },
+      receipts: { count: 0, items: [] },
+      organizations,
+      billing: {
+        enabled: false,
+        plan_id: null,
+        organization: null,
+        stripe: {
+          available: false,
+          reason: 'billing disabled',
+          customer_id: null,
+          dashboard_url: null,
+          subscription: null,
+          latest_invoice: null,
+        },
+      },
+      stats: { secrets_created: 0, secrets_shared: 0, emails_sent: 0 },
+    },
+  };
+}
+
+function addAck(status: 'success' | 'no_change', role = 'member') {
+  return {
+    shrimp: '',
+    record: { org_id: ORG_EXTID, member_id: CANDIDATE_EXTID, status, role },
+  };
+}
+
+/** Build an error whose shape matches what the classifier probes (`response`). */
+function httpError(status: number, data: unknown): Error & { response: unknown } {
+  const err = new Error('Request failed') as Error & { response: unknown };
+  err.response = { status, data, statusText: '', headers: {}, config: {} };
+  return err;
+}
+
+/**
+ * Route GETs by url so the org detail and the account lookups can be mocked
+ * independently (the view issues both against the same axios stub).
+ */
+function routeGets(
+  options: {
+    users?: unknown;
+    userDetail?: unknown;
+    usersRejects?: Error;
+  } = {}
+) {
+  mockApi.get.mockImplementation((url: string) => {
+    if (url === ORG_URL) return Promise.resolve({ data: detailPayload() });
+    if (url === USERS_URL) {
+      if (options.usersRejects) return Promise.reject(options.usersRejects);
+      return Promise.resolve({ data: options.users ?? usersPayload([userRow()]) });
+    }
+    if (url === `${USERS_URL}/${CANDIDATE_EXTID}`) {
+      return Promise.resolve({ data: options.userDetail ?? userDetailPayload() });
+    }
+    return Promise.reject(new Error(`unexpected GET ${url}`));
+  });
+}
+
+describe('AdminOrganizationDetail — add an existing account to the organization', () => {
+  let wrapper: VueWrapper;
+  let pinia: ReturnType<typeof createPinia>;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    wrapper?.unmount();
+  });
+
+  const mountView = () =>
+    mount(AdminOrganizationDetail, {
+      props: { id: ORG_EXTID },
+      global: { plugins: [pinia, i18n] },
+    });
+
+  /** Open the modal, search for `term`, and let the debounce + request settle. */
+  async function search(w: VueWrapper, term: string): Promise<void> {
+    await w.find('[data-testid="org-add-member-button"]').trigger('click');
+    await w.find('[data-testid="add-member-search"]').setValue(term);
+    vi.advanceTimersByTime(300);
+    await flushPromises();
+  }
+
+  it('searches existing accounts by email through the customers search endpoint', async () => {
+    routeGets();
+    wrapper = mountView();
+    await flushPromises();
+
+    // The modal is inert until opened: only the org detail GET has fired.
+    expect(mockApi.get).toHaveBeenCalledTimes(1);
+
+    await search(wrapper, 'newperson@acme.test');
+
+    expect(mockApi.get).toHaveBeenCalledWith(USERS_URL, {
+      params: { page: 1, per_page: 25, search: 'newperson@acme.test' },
+    });
+
+    const results = wrapper.find('[data-testid="add-member-results"]');
+    expect(results.exists()).toBe(true);
+    // Address is obscured by default (RevealEmail), extid shown as key material.
+    expect(results.text()).not.toContain('newperson@acme.test');
+    expect(results.text()).toContain('n•••@a•••.test');
+    expect(results.text()).toContain(CANDIDATE_EXTID);
+  });
+
+  it('debounces the search so it issues one request per pause, not per keystroke', async () => {
+    routeGets();
+    wrapper = mountView();
+    await flushPromises();
+
+    await wrapper.find('[data-testid="org-add-member-button"]').trigger('click');
+    const input = wrapper.find('[data-testid="add-member-search"]');
+    await input.setValue('new');
+    await input.setValue('newper');
+    await input.setValue('newperson@acme.test');
+    vi.advanceTimersByTime(300);
+    await flushPromises();
+
+    const userSearches = mockApi.get.mock.calls.filter(([url]) => url === USERS_URL);
+    expect(userSearches).toHaveLength(1);
+  });
+
+  it('shows an explicit not-found state when no account matches', async () => {
+    routeGets({ users: usersPayload([]) });
+    wrapper = mountView();
+    await flushPromises();
+
+    await search(wrapper, 'ghost@acme.test');
+
+    expect(wrapper.find('[data-testid="add-member-no-results"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="add-member-results"]').exists()).toBe(false);
+    // Submit stays disabled with nothing selected.
+    expect(wrapper.find('[data-testid="add-member-submit"]').attributes('disabled')).toBeDefined();
+  });
+
+  it('pins the selected account with identifying detail and its current organizations', async () => {
+    routeGets({
+      userDetail: userDetailPayload([
+        { organization_id: 'org9', extid: 'on_other', display_name: 'Other Co', is_default: true },
+      ]),
+    });
+    wrapper = mountView();
+    await flushPromises();
+
+    await search(wrapper, 'newperson@acme.test');
+    await wrapper.find(`[data-testid="add-member-select-${CANDIDATE_EXTID}"]`).trigger('click');
+    await flushPromises();
+
+    // The account detail GET is what exposes current memberships.
+    expect(mockApi.get).toHaveBeenCalledWith(`${USERS_URL}/${CANDIDATE_EXTID}`, undefined);
+
+    const panel = wrapper.find('[data-testid="add-member-selected"]');
+    expect(panel.exists()).toBe(true);
+    expect(panel.text()).toContain(CANDIDATE_EXTID);
+    expect(wrapper.find('[data-testid="add-member-field-created"]').text()).toContain('DT:');
+    expect(wrapper.find('[data-testid="add-member-organizations"]').text()).toContain('Other Co');
+    // Not already in THIS org, so the add is allowed.
+    expect(wrapper.find('[data-testid="add-member-already-member"]').exists()).toBe(false);
+    expect(
+      wrapper.find('[data-testid="add-member-submit"]').attributes('disabled')
+    ).toBeUndefined();
+  });
+
+  it('posts the extid plus the chosen role, toasts, closes, and refreshes the roster', async () => {
+    routeGets();
+    mockApi.post.mockResolvedValue({ data: addAck('success', 'admin') });
+    wrapper = mountView();
+    await flushPromises();
+
+    await search(wrapper, 'newperson@acme.test');
+    await wrapper.find(`[data-testid="add-member-select-${CANDIDATE_EXTID}"]`).trigger('click');
+    await flushPromises();
+
+    await wrapper.find('[data-testid="add-member-role"]').setValue('admin');
+    await wrapper.find('[data-testid="add-member-submit"]').trigger('click');
+    await flushPromises();
+
+    // Never an email address: the colonel adapter resolves the public id.
+    expect(mockApi.post).toHaveBeenCalledWith(MEMBERS_URL, {
+      customer: CANDIDATE_EXTID,
+      role: 'admin',
+    });
+    expect(showMock).toHaveBeenCalledTimes(1);
+    expect(showMock.mock.calls[0][0]).toBe('web.admin.organizations.addMember.success');
+    expect(showMock.mock.calls[0][1]).toBe('success');
+
+    // Modal closed and the roster re-read from the server (2 org detail GETs).
+    expect(wrapper.find('[data-testid="add-member-selected"]').exists()).toBe(false);
+    const orgGets = mockApi.get.mock.calls.filter(([url]) => url === ORG_URL);
+    expect(orgGets).toHaveLength(2);
+  });
+
+  it('offers only the roles the backend accepts', async () => {
+    routeGets();
+    wrapper = mountView();
+    await flushPromises();
+
+    await search(wrapper, 'newperson@acme.test');
+    await wrapper.find(`[data-testid="add-member-select-${CANDIDATE_EXTID}"]`).trigger('click');
+    await flushPromises();
+
+    const values = wrapper
+      .find('[data-testid="add-member-role"]')
+      .findAll('option')
+      .map((option) => option.attributes('value'));
+    expect(values).toEqual(['member', 'admin', 'owner']);
+  });
+
+  it('blocks the add and explains when the account is already on the roster', async () => {
+    routeGets({ users: usersPayload([userRow({ extid: OWNER_EXTID, user_id: OWNER_EXTID })]) });
+    mockApi.get.mockImplementation((url: string) => {
+      if (url === ORG_URL) return Promise.resolve({ data: detailPayload() });
+      if (url === USERS_URL) {
+        return Promise.resolve({
+          data: usersPayload([userRow({ extid: OWNER_EXTID, user_id: OWNER_EXTID })]),
+        });
+      }
+      return Promise.resolve({ data: userDetailPayload() });
+    });
+    wrapper = mountView();
+    await flushPromises();
+
+    await search(wrapper, 'owner@acme.test');
+
+    // Flagged in the result list before the operator even picks.
+    expect(wrapper.find(`[data-testid="add-member-existing-${OWNER_EXTID}"]`).exists()).toBe(true);
+
+    await wrapper.find(`[data-testid="add-member-select-${OWNER_EXTID}"]`).trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="add-member-already-member"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="add-member-submit"]').attributes('disabled')).toBeDefined();
+    expect(mockApi.post).not.toHaveBeenCalled();
+  });
+
+  it('treats an idempotent no_change 200 as a failure, not a false success', async () => {
+    routeGets();
+    mockApi.post.mockResolvedValue({ data: addAck('no_change', 'admin') });
+    wrapper = mountView();
+    await flushPromises();
+
+    await search(wrapper, 'newperson@acme.test');
+    await wrapper.find(`[data-testid="add-member-select-${CANDIDATE_EXTID}"]`).trigger('click');
+    await flushPromises();
+
+    await wrapper.find('[data-testid="add-member-submit"]').trigger('click');
+    await flushPromises();
+
+    // No toast, modal stays open, message names the already-member case.
+    expect(showMock).not.toHaveBeenCalled();
+    expect(wrapper.find('[data-testid="add-member-selected"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="add-member-error"]').text()).toContain(
+      'web.admin.organizations.addMember.errors.alreadyMember'
+    );
+    // The roster was NOT refreshed — nothing changed server-side.
+    const orgGets = mockApi.get.mock.calls.filter(([url]) => url === ORG_URL);
+    expect(orgGets).toHaveLength(1);
+  });
+
+  it('keeps a 404 inside the modal with the backend message', async () => {
+    routeGets();
+    mockApi.post.mockRejectedValue(httpError(404, { error: 'Customer not found' }));
+    wrapper = mountView();
+    await flushPromises();
+
+    await search(wrapper, 'newperson@acme.test');
+    await wrapper.find(`[data-testid="add-member-select-${CANDIDATE_EXTID}"]`).trigger('click');
+    await flushPromises();
+
+    await wrapper.find('[data-testid="add-member-submit"]').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="add-member-error"]').text()).toContain('Customer not found');
+    expect(showMock).not.toHaveBeenCalled();
+    expect(wrapper.find('[data-testid="add-member-selected"]').exists()).toBe(true);
+  });
+
+  it('falls back to a localized message when a 404 carries no backend error text', async () => {
+    routeGets();
+    mockApi.post.mockRejectedValue(httpError(404, {}));
+    wrapper = mountView();
+    await flushPromises();
+
+    await search(wrapper, 'newperson@acme.test');
+    await wrapper.find(`[data-testid="add-member-select-${CANDIDATE_EXTID}"]`).trigger('click');
+    await flushPromises();
+
+    await wrapper.find('[data-testid="add-member-submit"]').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="add-member-error"]').text()).toContain(
+      'web.admin.organizations.addMember.errors.notFound'
+    );
+  });
+
+  it('surfaces a rejected role from the form error the backend returns', async () => {
+    routeGets();
+    mockApi.post.mockRejectedValue(
+      httpError(422, { error: "Invalid role 'auditor'. Must be one of: owner, admin, member" })
+    );
+    wrapper = mountView();
+    await flushPromises();
+
+    await search(wrapper, 'newperson@acme.test');
+    await wrapper.find(`[data-testid="add-member-select-${CANDIDATE_EXTID}"]`).trigger('click');
+    await flushPromises();
+
+    await wrapper.find('[data-testid="add-member-submit"]').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="add-member-error"]').text()).toContain(
+      'Must be one of: owner, admin, member'
+    );
+  });
+
+  it('degrades to the roster guard when the account lookup fails', async () => {
+    mockApi.get.mockImplementation((url: string) => {
+      if (url === ORG_URL) return Promise.resolve({ data: detailPayload() });
+      if (url === USERS_URL) return Promise.resolve({ data: usersPayload([userRow()]) });
+      return Promise.reject(httpError(500, {}));
+    });
+    mockApi.post.mockResolvedValue({ data: addAck('success') });
+    wrapper = mountView();
+    await flushPromises();
+
+    await search(wrapper, 'newperson@acme.test');
+    await wrapper.find(`[data-testid="add-member-select-${CANDIDATE_EXTID}"]`).trigger('click');
+    await flushPromises();
+
+    // The memberships read-out says so, but the add is still allowed.
+    expect(wrapper.find('[data-testid="add-member-organizations-error"]').exists()).toBe(true);
+    expect(
+      wrapper.find('[data-testid="add-member-submit"]').attributes('disabled')
+    ).toBeUndefined();
+
+    await wrapper.find('[data-testid="add-member-submit"]').trigger('click');
+    await flushPromises();
+    expect(mockApi.post).toHaveBeenCalledWith(MEMBERS_URL, {
+      customer: CANDIDATE_EXTID,
+      role: 'member',
+    });
+  });
+
+  it('renders a retryable banner when the account search itself fails', async () => {
+    routeGets({ usersRejects: httpError(500, {}) });
+    wrapper = mountView();
+    await flushPromises();
+
+    await search(wrapper, 'newperson@acme.test');
+
+    expect(wrapper.find('[data-testid="add-member-search-error"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="add-member-results"]').exists()).toBe(false);
+  });
+});

--- a/src/tests/apps/admin/AdminPlanDiff.spec.ts
+++ b/src/tests/apps/admin/AdminPlanDiff.spec.ts
@@ -1,0 +1,226 @@
+// src/tests/apps/admin/AdminPlanDiff.spec.ts
+
+import { AxiosError } from 'axios';
+import { createPinia, setActivePinia } from 'pinia';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/** Build a real AxiosError so the 404 branch of useResourceFetch is exercised. */
+function axiosError(status: number, data: unknown, message = 'Request failed'): AxiosError {
+  const err = new AxiosError(message);
+  err.response = { status, data, statusText: '', headers: {}, config: {} as never };
+  return err;
+}
+
+const mockApi = { get: vi.fn(), post: vi.fn(), delete: vi.fn() };
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+const pushMock = vi.fn();
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: pushMock }),
+  useRoute: () => ({ params: { planid: 'identity_plus_v1' } }),
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+import AdminPlanDiff from '@/apps/admin/views/AdminPlanDiff.vue';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+const CATALOG_URL = '/api/colonel/billing/catalog';
+
+function plan(overrides: Record<string, unknown> = {}) {
+  return {
+    planid: 'plan_x',
+    name: 'Plan X',
+    tier: 'single_team',
+    tenancy: 'shared',
+    region: 'US',
+    display_order: 1,
+    show_on_plans_page: true,
+    description: null,
+    entitlements: ['create_secrets'],
+    limits: { 'teams.max': '1' },
+    ...overrides,
+  };
+}
+
+/** One plan on both sides (drifting), one config-only, one live-only. */
+function catalogPayload() {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      source: 'stripe',
+      stripe_configured: true,
+      config_plans: [
+        plan({
+          planid: 'identity_plus_v1',
+          name: 'Identity+',
+          entitlements: ['create_secrets', 'custom_domains'],
+        }),
+        plan({ planid: 'legacy_v1', name: 'Legacy' }),
+      ],
+      live_plans: [
+        plan({ planid: 'identity_plus_v1', name: 'Identity+', entitlements: ['create_secrets'] }),
+        plan({ planid: 'new_v2', name: 'New' }),
+      ],
+      drift: {
+        in_sync: false,
+        only_in_config: ['legacy_v1'],
+        only_in_live: ['new_v2'],
+        changed: [{ planid: 'identity_plus_v1', name: 'Identity+', fields: ['entitlements'] }],
+      },
+    },
+  };
+}
+
+// Stub JsonViewer: its clipboard machinery is not under test here.
+const jsonViewerStub = {
+  name: 'JsonViewer',
+  props: ['data', 'expandDepth', 'testid'],
+  template: '<div :data-testid="testid" />',
+};
+
+const mountView = (planid: string) =>
+  mount(AdminPlanDiff, {
+    props: { planid },
+    global: { plugins: [i18n], stubs: { JsonViewer: jsonViewerStub } },
+  });
+
+describe('AdminPlanDiff (full-page config-vs-live plan comparison)', () => {
+  let wrapper: VueWrapper;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+  afterEach(() => wrapper?.unmount());
+
+  it('fetches the catalog itself so a deep link / refresh works', async () => {
+    mockApi.get.mockResolvedValue({ data: catalogPayload() });
+    wrapper = mountView('identity_plus_v1');
+    await flushPromises();
+
+    // No reliance on navigation state: the page issues its own GET on mount.
+    expect(mockApi.get).toHaveBeenCalledWith(CATALOG_URL, undefined);
+  });
+
+  it('renders both JSON panels for a plan present on both sides', async () => {
+    mockApi.get.mockResolvedValue({ data: catalogPayload() });
+    wrapper = mountView('identity_plus_v1');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="detail-content"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="billing-diff-config-json"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="billing-diff-live-json"]').exists()).toBe(true);
+    // The drifted field names are surfaced from the server's drift summary.
+    expect(wrapper.find('[data-testid="plan-diff-fields"]').text()).toContain('entitlements');
+    expect(wrapper.find('[data-testid="plan-diff-planid"]').text()).toBe('identity_plus_v1');
+  });
+
+  it('hands the selected plan (not the whole catalog) to each JSON panel', async () => {
+    mockApi.get.mockResolvedValue({ data: catalogPayload() });
+    wrapper = mountView('identity_plus_v1');
+    await flushPromises();
+
+    const viewers = wrapper.findAllComponents(jsonViewerStub);
+    expect(viewers).toHaveLength(2);
+    expect((viewers[0].props('data') as { planid: string }).planid).toBe('identity_plus_v1');
+    expect((viewers[0].props('data') as { entitlements: string[] }).entitlements).toEqual([
+      'create_secrets',
+      'custom_domains',
+    ]);
+    expect((viewers[1].props('data') as { entitlements: string[] }).entitlements).toEqual([
+      'create_secrets',
+    ]);
+  });
+
+  it('shows a config-absent placeholder for a live-only plan', async () => {
+    mockApi.get.mockResolvedValue({ data: catalogPayload() });
+    wrapper = mountView('new_v2');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="billing-diff-config-absent"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="billing-diff-live-json"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="plan-diff-status"]').text()).toContain('only_live');
+  });
+
+  it('shows a live-absent placeholder for a config-only plan', async () => {
+    mockApi.get.mockResolvedValue({ data: catalogPayload() });
+    wrapper = mountView('legacy_v1');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="billing-diff-live-absent"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="billing-diff-config-json"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="plan-diff-status"]').text()).toContain('only_config');
+  });
+
+  it('renders a not-found state for a planid absent from the catalog', async () => {
+    mockApi.get.mockResolvedValue({ data: catalogPayload() });
+    wrapper = mountView('does_not_exist_v9');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="detail-not-found"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="detail-content"]').exists()).toBe(false);
+  });
+
+  it('navigates back to the billing catalog', async () => {
+    mockApi.get.mockResolvedValue({ data: catalogPayload() });
+    wrapper = mountView('identity_plus_v1');
+    await flushPromises();
+
+    await wrapper.find('[data-testid="detail-back"]').trigger('click');
+    expect(pushMock).toHaveBeenCalledWith({ name: 'AdminBilling' });
+  });
+
+  it('shows an error state with retry when the catalog GET fails', async () => {
+    mockApi.get.mockRejectedValue(new Error('Network Error'));
+    wrapper = mountView('identity_plus_v1');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="detail-error"]').exists()).toBe(true);
+
+    mockApi.get.mockResolvedValue({ data: catalogPayload() });
+    await wrapper.find('[data-testid="detail-error"] button').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="detail-content"]').exists()).toBe(true);
+  });
+
+  it('treats a 404 on the catalog endpoint as a load failure, not a missing plan', async () => {
+    mockApi.get.mockRejectedValue(axiosError(404, { error: 'Not Found' }));
+    wrapper = mountView('identity_plus_v1');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="detail-error"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="detail-not-found"]').exists()).toBe(false);
+  });
+
+  it('shows the loading state while the request is in flight', async () => {
+    mockApi.get.mockReturnValue(new Promise(() => {}));
+    wrapper = mountView('identity_plus_v1');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="detail-loading"]').exists()).toBe(true);
+  });
+
+  it('warns when the catalog source is local_config', async () => {
+    const payload = catalogPayload();
+    payload.details.source = 'local_config';
+    payload.details.stripe_configured = false;
+    payload.details.live_plans = [];
+    mockApi.get.mockResolvedValue({ data: payload });
+    wrapper = mountView('identity_plus_v1');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="plan-diff-local-config-warning"]').exists()).toBe(true);
+  });
+});

--- a/src/tests/apps/admin/StripeOrganizationsSection.spec.ts
+++ b/src/tests/apps/admin/StripeOrganizationsSection.spec.ts
@@ -1,0 +1,286 @@
+// src/tests/apps/admin/StripeOrganizationsSection.spec.ts
+
+import { AxiosError } from 'axios';
+import { createPinia, setActivePinia } from 'pinia';
+import { flushPromises, mount, RouterLinkStub, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/** Build a real AxiosError so the store can read `response.status`. */
+function axiosError(status: number, data: unknown, message = 'Request failed'): AxiosError {
+  const err = new AxiosError(message);
+  err.response = { status, data, statusText: '', headers: {}, config: {} as never };
+  return err;
+}
+
+const mockApi = { get: vi.fn(), post: vi.fn(), delete: vi.fn() };
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+import { FilterBar } from '@/apps/admin/components/kit';
+import StripeOrganizationsSection from '@/apps/admin/components/billing/StripeOrganizationsSection.vue';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+const LIST_URL = '/api/colonel/billing/stripe-organizations';
+
+function org(overrides: Record<string, unknown> = {}) {
+  return {
+    org_id: 'org_internal_1',
+    extid: 'og_acme',
+    display_name: 'Acme Inc',
+    owner_email: 'owner@acme.example',
+    billing_email: 'billing@acme.example',
+    planid: 'identity_plus_v1',
+    stripe_customer_id: 'cus_ACME001',
+    stripe_subscription_id: 'sub_ACME001',
+    subscription_status: 'active',
+    subscription_period_end: '2026-08-01',
+    sync_status: 'synced',
+    ...overrides,
+  };
+}
+
+function listPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      organizations: [
+        org(),
+        org({
+          extid: 'og_globex',
+          display_name: 'Globex',
+          owner_email: 'ops@globex.example',
+          stripe_customer_id: 'cus_GLOBEX9',
+          subscription_status: 'past_due',
+          planid: null,
+        }),
+      ],
+      pagination: { page: 1, per_page: 50, total_count: 2, total_pages: 1 },
+      filters: { search: null },
+      ...overrides,
+    },
+  };
+}
+
+// CopyButton drives the real clipboard API; stub it and assert on the payload.
+const copyButtonStub = {
+  name: 'CopyButton',
+  props: ['text', 'tooltip', 'testid', 'interval'],
+  template: '<button :data-testid="testid" :data-text="text" type="button" />',
+};
+
+const mountSection = () =>
+  mount(StripeOrganizationsSection, {
+    global: {
+      plugins: [i18n],
+      stubs: { RouterLink: RouterLinkStub, CopyButton: copyButtonStub },
+    },
+  });
+
+describe('StripeOrganizationsSection (billing → Stripe customers roster)', () => {
+  let wrapper: VueWrapper;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+  afterEach(() => wrapper?.unmount());
+
+  it('fetches the first page on mount', async () => {
+    mockApi.get.mockResolvedValue({ data: listPayload() });
+    wrapper = mountSection();
+    await flushPromises();
+
+    expect(mockApi.get).toHaveBeenCalledWith(LIST_URL, {
+      params: { page: 1, per_page: 50 },
+    });
+  });
+
+  it('renders one row per Stripe-linked organization', async () => {
+    mockApi.get.mockResolvedValue({ data: listPayload() });
+    wrapper = mountSection();
+    await flushPromises();
+
+    const table = wrapper.find('[data-testid="billing-stripe-orgs-table"]');
+    expect(table.exists()).toBe(true);
+    expect(table.text()).toContain('Acme Inc');
+    expect(table.text()).toContain('cus_ACME001');
+    expect(table.text()).toContain('Globex');
+    expect(table.text()).toContain('cus_GLOBEX9');
+    expect(wrapper.find('[data-testid="billing-stripe-orgs-count"]').text()).toContain('2');
+  });
+
+  it('links each row to the owning organization detail page', async () => {
+    mockApi.get.mockResolvedValue({ data: listPayload() });
+    wrapper = mountSection();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="stripe-org-link-og_acme"]').exists()).toBe(true);
+
+    const targets = wrapper.findAllComponents(RouterLinkStub).map((l) => l.props('to'));
+    expect(targets).toContainEqual({
+      name: 'AdminOrganizationDetail',
+      params: { id: 'og_acme' },
+    });
+    expect(targets).toContainEqual({
+      name: 'AdminOrganizationDetail',
+      params: { id: 'og_globex' },
+    });
+  });
+
+  it('offers the Stripe customer id in a copyable form', async () => {
+    mockApi.get.mockResolvedValue({ data: listPayload() });
+    wrapper = mountSection();
+    await flushPromises();
+
+    const copy = wrapper.find('[data-testid="stripe-org-copy-og_acme"]');
+    expect(copy.exists()).toBe(true);
+    expect(copy.attributes('data-text')).toBe('cus_ACME001');
+  });
+
+  it('debounces the search box into a single filtered fetch', async () => {
+    vi.useFakeTimers();
+    try {
+      mockApi.get.mockResolvedValue({ data: listPayload() });
+      wrapper = mountSection();
+      await flushPromises();
+      const before = mockApi.get.mock.calls.length;
+
+      await wrapper
+        .find('[data-testid="billing-stripe-orgs-filterbar"] input[type="search"]')
+        .setValue('cus_ACME');
+      expect(mockApi.get.mock.calls.length).toBe(before);
+
+      vi.advanceTimersByTime(300);
+      await flushPromises();
+
+      expect(mockApi.get.mock.calls.length).toBe(before + 1);
+      expect(mockApi.get).toHaveBeenLastCalledWith(LIST_URL, {
+        params: { page: 1, per_page: 50, search: 'cus_ACME' },
+      });
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it('issues exactly one fetch when clearing the search (no debounce double-fetch)', async () => {
+    vi.useFakeTimers();
+    try {
+      mockApi.get.mockResolvedValue({ data: listPayload() });
+      wrapper = mountSection();
+      await flushPromises();
+
+      await wrapper
+        .find('[data-testid="billing-stripe-orgs-filterbar"] input[type="search"]')
+        .setValue('cus_ACME');
+      vi.advanceTimersByTime(300);
+      await flushPromises();
+
+      const before = mockApi.get.mock.calls.length;
+
+      wrapper.findComponent(FilterBar).vm.$emit('clear');
+      vi.advanceTimersByTime(300);
+      await flushPromises();
+
+      expect(mockApi.get.mock.calls.length).toBe(before + 1);
+      expect(mockApi.get).toHaveBeenLastCalledWith(LIST_URL, {
+        params: { page: 1, per_page: 50 },
+      });
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it('surfaces the bounded-scan caveat so the count is not read as exact', async () => {
+    const payload = listPayload();
+    payload.details.pagination = {
+      page: 1,
+      per_page: 50,
+      total_count: 5000,
+      total_pages: 100,
+      capped: true,
+      stale_count: 2,
+    } as never;
+    mockApi.get.mockResolvedValue({ data: payload });
+    wrapper = mountSection();
+    await flushPromises();
+
+    const caveat = wrapper.find('[data-testid="billing-stripe-orgs-caveat"]');
+    expect(caveat.exists()).toBe(true);
+    expect(caveat.text()).toContain('web.admin.billing.stripeOrgs.capped');
+    expect(caveat.text()).toContain('web.admin.billing.stripeOrgs.stale');
+  });
+
+  it('omits the caveat on an unbounded page', async () => {
+    mockApi.get.mockResolvedValue({ data: listPayload() });
+    wrapper = mountSection();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="billing-stripe-orgs-caveat"]').exists()).toBe(false);
+  });
+
+  it('shows an informational notice (not an error) when the endpoint 404s', async () => {
+    mockApi.get.mockRejectedValue(axiosError(404, { error: 'Not Found' }));
+    wrapper = mountSection();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="billing-stripe-orgs-unavailable"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="billing-stripe-orgs-error"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="billing-stripe-orgs-table"]').exists()).toBe(false);
+  });
+
+  it('shows an error banner with retry on a network failure', async () => {
+    mockApi.get.mockRejectedValue(new Error('Network Error'));
+    wrapper = mountSection();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="billing-stripe-orgs-error"]').exists()).toBe(true);
+
+    mockApi.get.mockResolvedValue({ data: listPayload() });
+    await wrapper.find('[data-testid="billing-stripe-orgs-retry"]').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="billing-stripe-orgs-error"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="billing-stripe-orgs-table"]').text()).toContain('Acme Inc');
+  });
+
+  it('degrades to an empty table (no throw) when the payload fails the contract', async () => {
+    mockApi.get.mockResolvedValue({ data: { shrimp: '', record: {}, details: { nope: true } } });
+    wrapper = mountSection();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="billing-stripe-orgs-error"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="billing-stripe-orgs-table-empty"]').exists()).toBe(true);
+  });
+
+  it('tolerates a sparse row shape (fields the backend has not filled in yet)', async () => {
+    mockApi.get.mockResolvedValue({
+      data: {
+        shrimp: '',
+        record: {},
+        details: {
+          organizations: [{ extid: 'og_minimal', stripe_customer_id: 'cus_MIN' }],
+          pagination: { page: 1, per_page: 50, total_count: 1, total_pages: 1 },
+        },
+      },
+    });
+    wrapper = mountSection();
+    await flushPromises();
+
+    const table = wrapper.find('[data-testid="billing-stripe-orgs-table"]');
+    expect(table.text()).toContain('cus_MIN');
+    // No display_name/billing_email: the row falls back to the extid.
+    expect(table.text()).toContain('og_minimal');
+  });
+});

--- a/src/tests/apps/admin/useAdminBilling.spec.ts
+++ b/src/tests/apps/admin/useAdminBilling.spec.ts
@@ -1,0 +1,197 @@
+// src/tests/apps/admin/useAdminBilling.spec.ts
+
+import { AxiosError } from 'axios';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock('@/shared/composables/useApi', () => ({
+  useApi: () => mockApi,
+}));
+
+import { STRIPE_ORGANIZATIONS_URL, useAdminBilling } from '@/apps/admin/stores/useAdminBilling';
+
+/** Build a real AxiosError so the store can read `response.status`. */
+function axiosError(status: number, data: unknown, message = 'Request failed'): AxiosError {
+  const err = new AxiosError(message);
+  err.response = { status, data, statusText: '', headers: {}, config: {} as never };
+  return err;
+}
+
+function orgRow(overrides: Record<string, unknown> = {}) {
+  return {
+    org_id: 'org1',
+    extid: 'og_abc123',
+    display_name: 'Acme',
+    owner_email: 'owner@acme.test',
+    billing_email: 'billing@acme.test',
+    planid: 'identity_plus_v1',
+    stripe_customer_id: 'cus_123',
+    stripe_subscription_id: 'sub_123',
+    subscription_status: 'active',
+    subscription_period_end: '2026-01-01',
+    sync_status: 'synced',
+    ...overrides,
+  };
+}
+
+function payload(rows = [orgRow()]) {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      organizations: rows,
+      pagination: { page: 1, per_page: 50, total_count: rows.length, total_pages: 1 },
+      filters: { search: null },
+    },
+  };
+}
+
+describe('useAdminBilling (Stripe customers roster)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses a unique store id', () => {
+    expect(useAdminBilling().$id).toBe('adminBilling');
+  });
+
+  it('fetches the index-backed roster endpoint and maps the page', async () => {
+    mockApi.get.mockResolvedValue({ data: payload() });
+    const store = useAdminBilling();
+
+    await store.fetchStripeOrganizations(1);
+
+    expect(mockApi.get).toHaveBeenCalledWith(STRIPE_ORGANIZATIONS_URL, {
+      params: { page: 1, per_page: 50 },
+    });
+    expect(store.stripeOrganizations).toHaveLength(1);
+    expect(store.stripeOrganizations[0].stripe_customer_id).toBe('cus_123');
+    expect(store.pagination).toEqual({
+      page: 1,
+      per_page: 50,
+      total_count: 1,
+      total_pages: 1,
+    });
+  });
+
+  it('threads the search filter through and drops it when empty', async () => {
+    mockApi.get.mockResolvedValue({ data: payload() });
+    const store = useAdminBilling();
+
+    await store.fetchStripeOrganizations(2, { search: 'cus_1' });
+    expect(mockApi.get).toHaveBeenLastCalledWith(STRIPE_ORGANIZATIONS_URL, {
+      params: { page: 2, per_page: 50, search: 'cus_1' },
+    });
+
+    await store.fetchStripeOrganizations(1, { search: '' });
+    expect(mockApi.get).toHaveBeenLastCalledWith(STRIPE_ORGANIZATIONS_URL, {
+      params: { page: 1, per_page: 50 },
+    });
+  });
+
+  it('degrades to empty (no throw) on a contract mismatch', async () => {
+    mockApi.get.mockResolvedValue({ data: { shrimp: '', record: {}, details: { nope: true } } });
+    const store = useAdminBilling();
+
+    await expect(store.fetchStripeOrganizations(1)).resolves.toBeNull();
+    expect(store.stripeOrganizations).toEqual([]);
+    expect(store.validationError).toBe('ColonelStripeOrganizationsResponse');
+    expect(store.error).toBeNull();
+  });
+
+  it('flags a 404 as unavailable and suppresses the failure banner', async () => {
+    mockApi.get.mockRejectedValue(axiosError(404, { error: 'Not Found' }));
+    const store = useAdminBilling();
+
+    // A backend without the endpoint is a known deployment state, not a failure
+    // the operator can retry away — so it resolves instead of throwing.
+    await expect(store.fetchStripeOrganizations(1)).resolves.toBeNull();
+    expect(store.unavailable).toBe(true);
+    expect(store.error).toBeNull();
+    expect(store.stripeOrganizations).toEqual([]);
+  });
+
+  it('clears rows and rethrows a real network failure', async () => {
+    mockApi.get.mockResolvedValue({ data: payload() });
+    const store = useAdminBilling();
+    await store.fetchStripeOrganizations(1);
+    expect(store.stripeOrganizations).toHaveLength(1);
+
+    mockApi.get.mockRejectedValue(new Error('Network Error'));
+    await expect(store.fetchStripeOrganizations(1)).rejects.toThrow('Network Error');
+    expect(store.stripeOrganizations).toEqual([]);
+    expect(store.pagination).toBeNull();
+    expect(store.unavailable).toBe(false);
+    expect(store.error).toBeInstanceOf(Error);
+  });
+
+  it('clears the unavailable flag once the endpoint answers', async () => {
+    mockApi.get.mockRejectedValue(axiosError(404, {}));
+    const store = useAdminBilling();
+    await store.fetchStripeOrganizations(1);
+    expect(store.unavailable).toBe(true);
+
+    mockApi.get.mockResolvedValue({ data: payload() });
+    await store.fetchStripeOrganizations(1);
+    expect(store.unavailable).toBe(false);
+    expect(store.stripeOrganizations).toHaveLength(1);
+  });
+
+  it('reads the bound signals from the pagination envelope', async () => {
+    const body = payload();
+    Object.assign(body.details.pagination, { capped: true, stale_count: 3 });
+    mockApi.get.mockResolvedValue({ data: body });
+    const store = useAdminBilling();
+
+    await store.fetchStripeOrganizations(1);
+    expect(store.capped).toBe(true);
+    expect(store.staleCount).toBe(3);
+  });
+
+  it('falls back to the details root for the bound signals', async () => {
+    // The HTTP adapter is landing concurrently; accept either placement rather
+    // than silently under-reporting a capped scan.
+    const body = payload();
+    Object.assign(body.details, { capped: true, stale_count: 1 });
+    mockApi.get.mockResolvedValue({ data: body });
+    const store = useAdminBilling();
+
+    await store.fetchStripeOrganizations(1);
+    expect(store.capped).toBe(true);
+    expect(store.staleCount).toBe(1);
+  });
+
+  it('accepts a sparse row (only the two identity fields)', async () => {
+    mockApi.get.mockResolvedValue({
+      data: payload([{ extid: 'og_minimal', stripe_customer_id: 'cus_MIN' }]),
+    });
+    const store = useAdminBilling();
+
+    await store.fetchStripeOrganizations(1);
+    expect(store.validationError).toBeNull();
+    expect(store.stripeOrganizations[0].display_name).toBeUndefined();
+  });
+
+  it('$reset clears rows, pagination, page state and the unavailable flag', async () => {
+    mockApi.get.mockResolvedValue({ data: payload() });
+    const store = useAdminBilling();
+    await store.fetchStripeOrganizations(1);
+
+    store.$reset();
+    expect(store.stripeOrganizations).toEqual([]);
+    expect(store.pagination).toBeNull();
+    expect(store.unavailable).toBe(false);
+    expect(store.page).toBe(1);
+    expect(store.perPage).toBe(50);
+  });
+});

--- a/try/integration/api/colonel/admin_ops_expansion_try.rb
+++ b/try/integration/api/colonel/admin_ops_expansion_try.rb
@@ -1,0 +1,278 @@
+# try/integration/api/colonel/admin_ops_expansion_try.rb
+#
+# frozen_string_literal: true
+
+# Integration tests for the colonel admin-ops expansion:
+#
+#   POST /api/colonel/organizations/:org_id/members  (AddMembership by EMAIL)
+#   GET  /api/colonel/users/:user_id                 (GetUserDetails by EMAIL)
+#   GET  /api/colonel/domains?search=&status=&org_id= (ListCustomDomains filters)
+#   GET  /api/colonel/billing/stripe-organizations   (ListStripeOrganizations)
+#
+# Covers:
+# - The email-identifier bug: sanitize_identifier stripped '@' and '.', so every
+#   documented "email or extid" colonel identifier resolved to nothing. The
+#   membership + user surfaces now accept an email.
+# - AddMembership stays additive (:no_change on a repeat) and still audits
+#   exactly one membership.add event for a real add.
+# - ListCustomDomains' new server-side filters narrow total_count BEFORE
+#   pagination, and an unfiltered call is unchanged.
+# - The Stripe roster is index-backed: it finds an org by its Stripe customer
+#   id, honours the server-side search glob, counts (but does not render) stale
+#   index entries, and writes NO audit event (it is a read).
+# - 401 anonymous / 403 non-colonel on the new route.
+#
+# Run: try --agent try/integration/api/colonel/admin_ops_expansion_try.rb
+
+require 'rack/test'
+require_relative '../../../support/test_helpers'
+
+OT.boot! :test
+
+require 'onetime/application/registry'
+Onetime::Application::Registry.prepare_application_registry
+
+@test = Object.new
+@test.extend Rack::Test::Methods
+
+def @test.app
+  Onetime::Application::Registry.generate_rack_url_map
+end
+
+def post(*args);   @test.post(*with_csrf(args));   end
+def get(*args);    @test.get(*args);    end
+def last_response; @test.last_response; end
+
+# ----------------------------------------------------------------
+# Test data setup
+# ----------------------------------------------------------------
+
+@timestamp = Familia.now.to_i
+
+@colonel = Onetime::Customer.create!(email: "colonel_aox_#{@timestamp}@example.com")
+@colonel.role = 'colonel'
+@colonel.verified = 'true'
+@colonel.save
+
+@regular = Onetime::Customer.create!(email: "regular_aox_#{@timestamp}@example.com")
+@regular.verified = 'true'
+@regular.save
+
+@org_owner = Onetime::Customer.create!(email: "owner_aox_#{@timestamp}@example.com")
+@org_owner.verified = 'true'
+@org_owner.save
+
+# The account we will add to the org BY EMAIL (the bug this exercises).
+@joiner       = Onetime::Customer.create!(email: "joiner_aox_#{@timestamp}@example.com")
+@joiner.verified = 'true'
+@joiner.save
+@joiner_email = @joiner.email
+@joiner_extid = @joiner.extid
+
+@org = Onetime::Organization.create!("AOX Org #{@timestamp}", @org_owner, "billing_aox_#{@timestamp}@example.com")
+
+# A second org carrying a Stripe customer id, for the billing roster.
+@billed_org = Onetime::Organization.create!("AOX Billed #{@timestamp}", @org_owner)
+@stripe_customer_id = "cus_AOX#{@timestamp}"
+@billed_org.stripe_customer_id = @stripe_customer_id
+@billed_org.planid = 'identity_v1'
+@billed_org.subscription_status = 'active'
+@billed_org.billing_email = "stripe_aox_#{@timestamp}@example.com"
+@billed_org.save
+
+# A deliberately stale index entry: field present, org gone.
+@stale_stripe_id = "cus_AOXSTALE#{@timestamp}"
+Onetime::Organization.stripe_customer_id_index[@stale_stripe_id] = "gone_#{@timestamp}"
+
+@colonel_session = {
+  'authenticated' => true,
+  'external_id'   => @colonel.extid,
+  'email'         => @colonel.email,
+}
+@regular_session = {
+  'authenticated' => true,
+  'external_id'   => @regular.extid,
+  'email'         => @regular.email,
+}
+
+def colonel_headers
+  { 'rack.session' => @colonel_session, 'HTTP_ACCEPT' => 'application/json' }
+end
+
+def colonel_get_headers
+  { 'rack.session' => @colonel_session, 'HTTP_ACCEPT' => 'application/json' }
+end
+
+# ----------------------------------------------------------------
+# AddMembership by EMAIL (the sanitize_identifier bug)
+# ----------------------------------------------------------------
+
+## An email survives sanitization and resolves to the account (200, not 404)
+@before_audit = Onetime::AdminAuditEvent.count
+post "/api/colonel/organizations/#{@org.extid}/members",
+  { 'customer' => @joiner_email, 'role' => 'admin' }, colonel_headers
+@add_resp = JSON.parse(last_response.body)
+[last_response.status, @add_resp['record']['status'], @add_resp['record']['role']]
+#=> [200, "success", "admin"]
+
+## The member_id echoed back is the account's PUBLIC id, never an email
+@add_resp['record']['member_id'] == @joiner_extid
+#=> true
+
+## The membership really exists on the org
+Onetime::Organization.find_by_extid(@org.extid).member?(Onetime::Customer.find_by_extid(@joiner_extid))
+#=> true
+
+## Exactly one membership.add audit event was recorded (by the op, not the adapter)
+@after_audit = Onetime::AdminAuditEvent.count
+@latest = Onetime::AdminAuditEvent.recent(1, 0).first
+[@after_audit - @before_audit, @latest['verb'], @latest['actor']]
+#=> [1, "membership.add", @colonel.extid]
+
+## Add is strictly additive: a repeat by email is :no_change and audits nothing
+@before_audit2 = Onetime::AdminAuditEvent.count
+post "/api/colonel/organizations/#{@org.extid}/members",
+  { 'customer' => @joiner_email, 'role' => 'member' }, colonel_headers
+@again = JSON.parse(last_response.body)
+[last_response.status, @again['record']['status'], @again['record']['role'],
+ Onetime::AdminAuditEvent.count - @before_audit2]
+#=> [200, "no_change", "admin", 0]
+
+## An unknown email is a clean 404, not a 500
+post "/api/colonel/organizations/#{@org.extid}/members",
+  { 'customer' => "nobody_#{@timestamp}@example.com" }, colonel_headers
+last_response.status
+#=> 404
+
+## An email with HTML/control junk is stripped, not executed (still a 404)
+post "/api/colonel/organizations/#{@org.extid}/members",
+  { 'customer' => "<script>x</script>nobody_#{@timestamp}@example.com" }, colonel_headers
+last_response.status < 500
+#=> true
+
+# ----------------------------------------------------------------
+# GetUserDetails by EMAIL
+# ----------------------------------------------------------------
+
+## The user detail read resolves an email identifier too
+get "/api/colonel/users/#{CGI.escape(@joiner_email)}", {}, colonel_get_headers
+@detail = JSON.parse(last_response.body)
+[last_response.status, @detail['record']['extid']]
+#=> [200, @joiner_extid]
+
+## ...and still resolves the extid (the path every admin surface routes by)
+get "/api/colonel/users/#{@joiner_extid}", {}, colonel_get_headers
+[last_response.status, JSON.parse(last_response.body)['record']['extid']]
+#=> [200, @joiner_extid]
+
+# ----------------------------------------------------------------
+# ListCustomDomains filters
+# ----------------------------------------------------------------
+
+## Create a domain to filter on
+@aox_domain = "aox-#{@timestamp}.example.com"
+post '/api/colonel/domains', { 'org_id' => @org.extid, 'domain' => @aox_domain }, colonel_headers
+@created_domain = JSON.parse(last_response.body)['record']
+[last_response.status, @created_domain['display_domain']]
+#=> [200, @aox_domain]
+
+## Unfiltered list still answers with the incumbent envelope
+get '/api/colonel/domains', {}, colonel_get_headers
+@list = JSON.parse(last_response.body)
+[last_response.status, @list['details'].key?('domains'), @list['details'].key?('pagination')]
+#=> [200, true, true]
+
+## search narrows total_count BEFORE pagination
+get '/api/colonel/domains', { 'search' => "aox-#{@timestamp}" }, colonel_get_headers
+@filtered = JSON.parse(last_response.body)
+[last_response.status,
+ @filtered['details']['pagination']['total_count'],
+ @filtered['details']['domains'].first['display_domain']]
+#=> [200, 1, @aox_domain]
+
+## The applied filters are echoed back under details.filters
+@filtered['details']['filters']['search']
+#=> "aox-#{@timestamp}"
+
+## org_id accepts the org EXTID (not just the internal objid it stores)
+get '/api/colonel/domains', { 'org_id' => @org.extid }, colonel_get_headers
+@by_org = JSON.parse(last_response.body)
+@by_org['details']['domains'].all? { |d| d['display_domain'].include?("aox-#{@timestamp}") }
+#=> true
+
+## A non-matching search yields an empty page, not an error
+get '/api/colonel/domains', { 'search' => "nothing-matches-#{@timestamp}" }, colonel_get_headers
+@empty = JSON.parse(last_response.body)
+[last_response.status, @empty['details']['pagination']['total_count'], @empty['details']['domains']]
+#=> [200, 0, []]
+
+# ----------------------------------------------------------------
+# ListStripeOrganizations — authorization
+# ----------------------------------------------------------------
+
+## Anonymous gets 401 on the Stripe roster
+@test.clear_cookies
+get '/api/colonel/billing/stripe-organizations', {}, { 'HTTP_ACCEPT' => 'application/json' }
+last_response.status
+#=> 401
+
+## Non-colonel gets 403
+get '/api/colonel/billing/stripe-organizations', {},
+  { 'rack.session' => @regular_session, 'HTTP_ACCEPT' => 'application/json' }
+last_response.status
+#=> 403
+
+# ----------------------------------------------------------------
+# ListStripeOrganizations — payload
+# ----------------------------------------------------------------
+
+## 200 with the record/details envelope and the documented detail keys
+get '/api/colonel/billing/stripe-organizations', {}, colonel_get_headers
+@roster = JSON.parse(last_response.body)
+[last_response.status,
+ %w[organizations pagination filters capped stale_count indexed_total]
+   .all? { |k| @roster['details'].key?(k) }]
+#=> [200, true]
+
+## The server-side glob finds the seeded org by its Stripe customer id
+get '/api/colonel/billing/stripe-organizations', { 'search' => "AOX#{@timestamp}" }, colonel_get_headers
+@hit = JSON.parse(last_response.body)['details']['organizations']
+[@hit.size, @hit.first['extid'], @hit.first['stripe_customer_id']]
+#=> [1, @billed_org.extid, @stripe_customer_id]
+
+## Rows carry the billing fields the admin table renders
+@row = @hit.first
+%w[org_id extid display_name owner_email billing_email planid stripe_customer_id
+   stripe_subscription_id subscription_status subscription_period_end sync_status]
+  .all? { |k| @row.key?(k) }
+#=> true
+
+## A stale index entry is counted, never rendered as a row with a blank extid
+get '/api/colonel/billing/stripe-organizations', { 'search' => "AOXSTALE#{@timestamp}" }, colonel_get_headers
+@stale = JSON.parse(last_response.body)['details']
+[@stale['organizations'], @stale['stale_count'], @stale['pagination']['total_count']]
+#=> [[], 1, 1]
+
+## The roster is READ-ONLY: it writes no AdminAuditEvent
+@before_read = Onetime::AdminAuditEvent.count
+get '/api/colonel/billing/stripe-organizations', {}, colonel_get_headers
+Onetime::AdminAuditEvent.count - @before_read
+#=> 0
+
+## per_page is clamped to 100 even when the caller asks for more
+get '/api/colonel/billing/stripe-organizations', { 'per_page' => '5000' }, colonel_get_headers
+JSON.parse(last_response.body)['details']['pagination']['per_page']
+#=> 100
+
+# ----------------------------------------------------------------
+# Teardown
+# ----------------------------------------------------------------
+
+Onetime::Organization.stripe_customer_id_index.remove(@stale_stripe_id)
+Onetime::CustomDomain.load_by_display_domain(@aox_domain)&.destroy!
+@billed_org.destroy!
+@org.destroy!
+@joiner.destroy!
+@org_owner.destroy!
+@regular.destroy!
+@colonel.destroy!

--- a/try/unit/models/secret_active_counter_try.rb
+++ b/try/unit/models/secret_active_counter_try.rb
@@ -14,6 +14,10 @@
 # - Customer.increment_secrets_active guards anon/nil/blank owner ids
 # - Customer.decrement_secrets_active clamps at zero
 # - a fresh Customer.new(objid:) reads the same counter key (no full load)
+# - the per-owner `secrets` INDEX is written at the same two chokepoints as the
+#   counter, so "how many" and "which ones" can only drift together. The index
+#   is what lets the colonel customer-detail view list a customer's secrets
+#   without a full `secret:*:object` keyspace walk.
 #
 # Run: try --agent try/unit/models/secret_active_counter_try.rb
 
@@ -95,6 +99,47 @@ Onetime::Customer.increment_secrets_active(@direct.objid)
 @direct.secrets_active.to_i
 #=> 1
 
+## the per-owner secrets INDEX is written at the create chokepoint
+@indexed = Onetime::Customer.create!(email: "indexed_#{@stamp}@ctr.example")
+_receipt, @first = Onetime::Receipt.spawn_pair(@indexed.objid, 3600, 'indexed one')
+@indexed.secrets.member?(@first.objid)
+#=> true
+
+## the index score is the secret's created time (so revrange is newest-first)
+@indexed.secrets.score(@first.objid).to_i == @first.created.to_i
+#=> true
+
+## index and counter stay in step across a second create
+_receipt, @second = Onetime::Receipt.spawn_pair(@indexed.objid, 3600, 'indexed two')
+[@indexed.secrets.element_count, @indexed.secrets_active.to_i]
+#=> [2, 2]
+
+## a newest-first read returns the most recent secret first
+@indexed.secrets.revrange(0, 0)
+#=> [@second.objid]
+
+## destroy! removes the member — the mirror of the create-side add
+@second.destroy!
+[@indexed.secrets.member?(@second.objid), @indexed.secrets.element_count]
+#=> [false, 1]
+
+## a reveal (same destroy! chokepoint) also unindexes
+_receipt, @revealed = Onetime::Receipt.spawn_pair(@indexed.objid, 3600, 'to reveal')
+@revealed.revealed!
+[@indexed.secrets.member?(@revealed.objid), @indexed.secrets.element_count]
+#=> [false, 1]
+
+## anonymous creates touch no per-owner index
+Onetime::Receipt.spawn_pair('anon', 3600, 'anon indexed')
+Onetime::Customer.new(objid: 'anon').secrets.element_count
+#=> 0
+
+## increment_secrets_active without a secret_id bumps the counter but not the index
+@countonly = Onetime::Customer.create!(email: "countonly_#{@stamp}@ctr.example")
+Onetime::Customer.increment_secrets_active(@countonly.objid)
+[@countonly.secrets_active.to_i, @countonly.secrets.element_count]
+#=> [1, 0]
+
 # TEARDOWN
 
-[@cust, @direct, @zeroed].each { |c| c.destroy! rescue nil }
+[@cust, @direct, @zeroed, @indexed, @countonly].each { |c| c.destroy! rescue nil }


### PR DESCRIPTION
Admin console ("Operations Ledger") expansion, plus three operator-reported bug fixes on the User Management surface.

The branch is two layers. Commits `324b6946..6d6a260d` are the feature expansion (new colonel ops, CLI peers, admin views). Commit `2a4c34f1` is the bug-fix pass described below, and is the part covered in detail here.

---

## Bug fixes (2a4c34f1)

### 1. The customer detail page timed out — backend

`scan_user_secrets` and `scan_user_receipts` each walked the **entire** `secret:*:object` / `receipt:*:object` keyspace, issuing one object load per key and filtering by owner *after* loading. The 10,000 guard counted **matches, not keys scanned**, so for a normal account (a handful of secrets) it never tripped and the loop always ran to `cursor == '0'`. Non-blocking for the datastore, unbounded in wall clock for the caller.

**Receipts** — `Customer` already declares `sorted_set :receipts`. Verified it is genuinely written (not assumed): `cust.add_receipt receipt` fires at every authenticated creation path (`apps/api/v2/logic/secrets/base_secret_action.rb#update_stats`, the v1 equivalent, and `create_incoming_secret.rb`), and pre-v0.24.5 data was backfilled by `scripts/upgrades/v0.24.5/copy_customer_receipts_zset.rb`. So `scan_user_receipts` is **deleted**, not bounded — replaced by a newest-first `ZREVRANGE` + one pipelined load.

**Secrets** — no per-owner index existed, so this adds `sorted_set :secrets` on `Customer`, written at the **same two chokepoints as the existing `secrets_active` counter**: `Receipt.spawn_pair → increment_secrets_active` adds, `Secret#destroy! → decrement_secrets_active` removes. Index and counter are written in one call, so they can only drift together. The index is trimmed to `SECRET_INDEX_LIMIT` (1000) on write, so it is bounded by construction rather than relying on expiry to keep up.

**Backfill safety net** — historical secrets are not in a fresh index, so a bounded fallback scan remains for the case "index empty **and** the counter says the account owns secrets". It is bounded by **SCAN rounds and a monotonic wall-clock deadline**, never by match count (that is the bug being removed). Stopping early sets `truncated`.

**Honest truncation** — the response now carries `details.{secrets,receipts}.truncated`, surfaced in the UI as an amber "partial list" notice. The `count == items.size` contract from #60 is preserved: the view renders items, so the number beside the heading is the number on screen.

The truncation signal compares the **index size** against `secrets_active`, not the rendered item count. Both are written at the same chokepoints and neither is decremented on TTL expiry, so they over-count identically — the difference between them is real missing coverage, never expiry drift. Comparing against rendered items would have flagged "partial" on every account with an expired secret, and a flag that fires constantly is one operators learn to ignore.

**Degradation** — each section runs behind its own rescue. A slow or failing secrets/receipts read degrades that section alone (empty + `truncated: true`); identity, plan, role, organization and billing still render.

**Pipelining** — per-key `Secret.load` calls are replaced with `load_multi` (one pipelined round trip per batch).

### 2. Reveal-email icon opened the drawer — frontend

`RevealEmail`'s toggle and its embedded `CopyButton` bubbled into the row's `@click`, so revealing an address also opened the slide-over. Fixed at the component, so every consumer inherits it. The address **text** deliberately still bubbles, so clicking the cell activates the row like any other cell.

Audited all 9 consumers before changing it — none depend on the bubbling (`AddMemberModal`'s `<li>` and the members/secrets tables have no row handler). Also audited the other four `clickable-rows` tables: `AdminSessions` (revoke) and `AdminDomains` (open/verify/detail) already use `@click.stop`; `AdminOrganizations` has no interactive cell content.

`CopyButton` is an app-wide shared primitive, so containment is applied at `RevealEmail`'s boundary rather than changing copy behaviour everywhere.

### 3. No direct row link to the full page — frontend

Added an `actions` column to the customers table with a **real `<router-link>`** (middle-click and open-in-new-tab must work — not a JS handler), `@click.stop` so it does not also open the drawer, plus `aria-label`/`title` for the icon-only control. Matches the existing precedent in `AdminDomains.vue`, which already has exactly this row escalation.

---

## Also reported (NOT fixed — separate features, out of scope)

The removed comment claimed `list_secrets.rb` and `export_usage.rb` "keep similar bounded SCANs". Checked both:

- **`export_usage.rb` has the same bug.** Its `break if secrets.size >= 10_000` counts **date-range matches**, so a narrow range never trips the cap and it walks the whole keyspace one `Secret.load` at a time.
- **`list_secrets.rb` does not.** Same shape, but it filters nothing, so every scanned key is a match and the cap genuinely bounds the scan. Still 10k un-pipelined object loads plus an in-memory sort per page request — expensive, but bounded.

A corrected note replaces the old claim in `get_user_details.rb`.

---

## Verification

| Check | Result |
|---|---|
| `rubocop` (5 changed .rb files) | no offenses |
| `pnpm exec eslint` (4 .vue/.ts + 2 spec files) | 0 errors; warnings all pre-existing (1 `max-len` on a class string copied verbatim from the `AdminDomains` precedent) |
| `vue-tsc --noEmit` | clean |
| `try/unit/models/` + reconcile job (89 files) | 2164 pass, 0 fail |
| `spec/integration/all/` | 790 pass, 0 fail |
| `vitest src/tests/apps/admin/` (56 files) | 597 pass, 0 fail |

New coverage: 8 tryout cases for the secrets index (write, score, newest-first read, destroy/reveal unindex, anon skip, no-secret_id back-compat), 6 integration examples for the activity read-out (ownership scoping, ordering, destroy, truncation, independent degradation), 4 frontend tests (reveal containment, copy containment, row link, truncation notice).

**RED-checked**: reverting `@click.stop` in `RevealEmail.vue` makes the reveal test fail, so it is not vacuous.

### Known-failing, pre-existing

`try/integration/api/colonel/customer_admin_try.rb` and `customer_admin_extid_try.rb` each have one failure on the verify endpoint. Confirmed **pre-existing** by running both files in a detached worktree at the parent commit — identical failures there. Untouched by this change.

### Not verified

- No browser run — the fixes were verified through unit/integration tests and jsdom mounts only.
- The fallback scan's wall-clock deadline was not exercised against a large real keyspace; the bound is by construction (rounds + monotonic deadline), not measured.
- The tree already carries 156 locale keys pending `content_hash` from earlier commits on this branch. I did **not** run `locales:hashes --apply` (it rewrites hashes tree-wide). The 3 keys added here carry correct hashes, computed with the script's own algorithm and verified against existing entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
