### PR TITLE
[#3840] Tests: consolidate duplicated integration helpers into support modules

### DIFF
--- a/apps/web/auth/spec/integration/full/basicauth/basicauth_rejection_on_session_routes_spec.rb
+++ b/apps/web/auth/spec/integration/full/basicauth/basicauth_rejection_on_session_routes_spec.rb
@@ -61,10 +61,7 @@ RSpec.describe 'BasicAuth rejection on session-only routes', type: :integration,
     get path
   end
 
-  # Parse JSON response body.
-  def json_body
-    JSON.parse(last_response.body)
-  end
+  # json_body comes from support/auth_request_helper.rb.
 
   # =====================================================================
   # Positive control: BasicAuth strategy authenticates with valid creds

--- a/apps/web/auth/spec/integration/full/identities_routes_spec.rb
+++ b/apps/web/auth/spec/integration/full/identities_routes_spec.rb
@@ -37,10 +37,6 @@ RSpec.describe 'Linked identities management API (#3840 Phase 2)', type: :integr
   # Password is AuthTestConstants::TEST_PASSWORD (shared across spec files so a
   # top-level constant isn't redefined when both specs load in one process).
 
-  def app
-    Onetime::Application::Registry.generate_rack_url_map
-  end
-
   before(:all) do
     require 'onetime'
     require 'onetime/application/registry'
@@ -76,21 +72,6 @@ RSpec.describe 'Linked identities management API (#3840 Phase 2)', type: :integr
   end
 
   # clear_body_headers/json_body come from support/auth_request_helper.rb.
-
-  # Establish an authenticated session via password login.
-  def csrf_login(email, password: AuthTestConstants::TEST_PASSWORD)
-    clear_body_headers
-    header 'Accept', 'application/json'
-    get '/auth'
-    token = last_response.headers['X-CSRF-Token']
-
-    header 'Content-Type', 'application/json'
-    header 'Accept', 'application/json'
-    header 'X-CSRF-Token', token if token
-    post '/auth/login', JSON.generate(login: email, password: password, shrimp: token)
-    expect(last_response.status).to be_between(200, 302),
-      "Precondition failed: login for #{email} returned #{last_response.status}: #{last_response.body}"
-  end
 
   def get_identities
     clear_body_headers

--- a/apps/web/auth/spec/integration/full/identities_routes_spec.rb
+++ b/apps/web/auth/spec/integration/full/identities_routes_spec.rb
@@ -63,20 +63,7 @@ RSpec.describe 'Linked identities management API (#3840 Phase 2)', type: :integr
   # Helpers
   # ==========================================================================
 
-  def seed_account_with_password(email, password: AuthTestConstants::TEST_PASSWORD)
-    normalized = OT::Utils.normalize_email(email)
-    customer   = Onetime::Customer.new(email: normalized)
-    customer.save
-    account_id = auth_db[:accounts].insert(
-      email: normalized,
-      status_id: AuthTestConstants::STATUS_VERIFIED,
-      external_id: customer.extid,
-    )
-    require 'argon2'
-    hasher     = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
-    auth_db[:account_password_hashes].insert(id: account_id, password_hash: hasher.create(password))
-    account_id
-  end
+  # seed_account_with_password comes from support/account_seed_helper.rb.
 
   def remove_password(account_id)
     auth_db[:account_password_hashes].where(id: account_id).delete

--- a/apps/web/auth/spec/integration/full/identities_routes_spec.rb
+++ b/apps/web/auth/spec/integration/full/identities_routes_spec.rb
@@ -88,10 +88,7 @@ RSpec.describe 'Linked identities management API (#3840 Phase 2)', type: :integr
     { id: id, uid: uid }
   end
 
-  def clear_body_headers
-    header 'Content-Type', nil
-    header 'Content-Length', nil
-  end
+  # clear_body_headers/json_body come from support/auth_request_helper.rb.
 
   # Establish an authenticated session via password login.
   def csrf_login(email, password: AuthTestConstants::TEST_PASSWORD)
@@ -123,10 +120,6 @@ RSpec.describe 'Linked identities management API (#3840 Phase 2)', type: :integr
     token = last_response.headers['X-CSRF-Token']
     header 'X-CSRF-Token', token if token
     delete "/auth/identities/#{id}"
-  end
-
-  def json_body
-    JSON.parse(last_response.body)
   end
 
   # ==========================================================================

--- a/apps/web/auth/spec/integration/full/omniauth_account_creation_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_account_creation_spec.rb
@@ -59,12 +59,17 @@ RSpec.describe 'after_omniauth_create_account operations', type: :integration do
     end
   end
 
-  # Helper to create a test account in the database
+  # Helper to create a test account in the database.
+  #
+  # Status is UNVERIFIED, and that is correct for these examples even though
+  # nothing here reads it: CreateCustomer hard-codes `verified: false` (the
+  # account's own status never reaches it — after_verify_account flips the
+  # Customer later), so an account fresh out of signup is the honest subject.
   def create_test_account(email:)
     db = Auth::Database.connection
     account_id = db[:accounts].insert(
       email: email,
-      status_id: 1, # verified status
+      status_id: AuthTestConstants::STATUS_UNVERIFIED,
       created_at: Time.now,
       updated_at: Time.now
     )

--- a/apps/web/auth/spec/integration/full/omniauth_account_creation_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_account_creation_spec.rb
@@ -59,11 +59,6 @@ RSpec.describe 'after_omniauth_create_account operations', type: :integration do
     end
   end
 
-  # Helper to generate unique test emails
-  def unique_test_email(prefix = 'test')
-    "#{prefix}-#{SecureRandom.hex(8)}@integration-test.example.com"
-  end
-
   # Helper to create a test account in the database
   def create_test_account(email:)
     db = Auth::Database.connection

--- a/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
@@ -73,10 +73,6 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
   # Password is AuthTestConstants::TEST_PASSWORD (shared across spec files so a
   # top-level constant isn't redefined when both specs load in one process).
 
-  def app
-    Onetime::Application::Registry.generate_rack_url_map
-  end
-
   before(:all) do
     require 'onetime'
     require 'onetime/application/registry'
@@ -99,29 +95,9 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
   # Helpers
   # ==========================================================================
 
-  # Leaves session[:validated_omniauth_domain_id] nil == the PLATFORM path.
-  def enable_platform_fallback
-    allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
-  end
-
   # seed_existing_account (the SSO-only / victim account) and
   # seed_account_with_password (the subject csrf_login can authenticate as)
   # come from support/account_seed_helper.rb.
-
-  # Establish a session, fetch the CSRF token, then POST a JSON login. The full
-  # Rack app enforces CSRF, so the shrimp token is required.
-  def csrf_login(email, password: AuthTestConstants::TEST_PASSWORD)
-    clear_body_headers
-    header 'Accept', 'application/json'
-    get '/auth'
-    token = last_response.headers['X-CSRF-Token']
-
-    header 'Content-Type', 'application/json'
-    header 'Accept', 'application/json'
-    header 'X-CSRF-Token', token if token
-    post '/auth/login', JSON.generate(login: email, password: password, shrimp: token)
-    token
-  end
 
   # clear_body_headers (support/auth_request_helper.rb) and setup_mock_auth /
   # teardown_mock_auth (support/omniauth_test_helper.rb) are shared.

--- a/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
@@ -104,28 +104,9 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
     allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
   end
 
-  # Seed a VERIFIED account WITHOUT a password (SSO-only / victim account).
-  def seed_existing_account(email)
-    normalized = OT::Utils.normalize_email(email)
-    customer   = Onetime::Customer.new(email: normalized)
-    customer.save
-    auth_db[:accounts].insert(
-      email: normalized,
-      status_id: AuthTestConstants::STATUS_VERIFIED,
-      external_id: customer.extid,
-    )
-  end
-
-  # Seed a VERIFIED account WITH an Argon2 password hash so csrf_login can
-  # establish a real authenticated session for it. Cost params match the test
-  # config in config/features/argon2.rb.
-  def seed_account_with_password(email, password: AuthTestConstants::TEST_PASSWORD)
-    account_id = seed_existing_account(email)
-    require 'argon2'
-    hasher     = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
-    auth_db[:account_password_hashes].insert(id: account_id, password_hash: hasher.create(password))
-    account_id
-  end
+  # seed_existing_account (the SSO-only / victim account) and
+  # seed_account_with_password (the subject csrf_login can authenticate as)
+  # come from support/account_seed_helper.rb.
 
   # Establish a session, fetch the CSRF token, then POST a JSON login. The full
   # Rack app enforces CSRF, so the shrimp token is required.

--- a/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_connect_link_spec.rb
@@ -142,43 +142,15 @@ RSpec.describe 'OmniAuth authenticated identity connect (#3840 Phase 2)', type: 
     token
   end
 
-  # Content-Type/Content-Length leak from a prior JSON POST and make the next
-  # bodyless callback POST try to parse an empty JSON body. Clear them.
-  def clear_body_headers
-    header 'Content-Type', nil
-    header 'Content-Length', nil
-  end
-
-  # email: nil models an IdP that asserts NO email claim. The key is OMITTED
-  # from info/raw_info rather than set to nil — that is what a minimal-scope
-  # OIDC response actually looks like, and it makes omniauth_email nil via the
-  # gem's `omniauth_info[info_key] if omniauth_info` accessor
-  # (rodauth-omniauth 0.6.2 omniauth_base.rb:69).
-  def setup_mock_auth(email:, uid:, provider: :oidc)
-    info     = { name: 'Connect User' }
-    raw_info = { sub: uid, name: 'Connect User' }
-    if email
-      info     = info.merge(email: email, email_verified: true)
-      raw_info = raw_info.merge(email: email, email_verified: true)
-    end
-
-    OmniAuth.config.test_mode               = true
-    OmniAuth.config.allowed_request_methods = [:get, :post]
-    OmniAuth.config.mock_auth[provider]     = OmniAuth::AuthHash.new(
-      {
-        provider: provider.to_s,
-        uid: uid,
-        info: info,
-        credentials: { token: 'mock_access_token', expires_at: Time.now.to_i + 3600, expires: true },
-        extra: { raw_info: raw_info },
-      },
-    )
-  end
-
-  def teardown_mock_auth
-    OmniAuth.config.test_mode = false
-    OmniAuth.config.mock_auth.clear
-  end
+  # clear_body_headers (support/auth_request_helper.rb) and setup_mock_auth /
+  # teardown_mock_auth (support/omniauth_test_helper.rb) are shared.
+  #
+  # setup_mock_auth(email: nil, ...) below models an IdP that asserts NO email
+  # claim: the shared helper OMITS the key from info/raw_info rather than
+  # setting it to nil — that is what a minimal-scope OIDC response actually
+  # looks like, and it makes omniauth_email nil via the gem's
+  # `omniauth_info[info_key] if omniauth_info` accessor (rodauth-omniauth 0.6.2
+  # omniauth_base.rb:69).
 
   # Run the SSO REQUEST phase carrying the connect-intent signal (connect=1),
   # exactly as the Connected Identities panel does at initiation. In OmniAuth

--- a/apps/web/auth/spec/integration/full/omniauth_domain_restriction_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_domain_restriction_spec.rb
@@ -31,10 +31,6 @@ require_relative '../../spec_helper'
 RSpec.describe 'OmniAuth Domain Restriction', type: :integration do
   include Rack::Test::Methods
 
-  def app
-    Onetime::Application::Registry.generate_rack_url_map
-  end
-
   before(:all) do
     # Boot the full Onetime application for integration tests.
     # require 'onetime' unconditionally — the `Onetime` constant can be
@@ -83,38 +79,8 @@ RSpec.describe 'OmniAuth Domain Restriction', type: :integration do
   # Helper Methods
   # ==========================================================================
 
-  # Asserts the OmniAuth callback ended in a redirect to /signin with the given
-  # stable auth_error code. Matches the convention shared with email_auth and
-  # omniauth_on_failure (Login.vue dispatches the code to a localized message).
-  def expect_auth_error_redirect(code)
-    expect(last_response.status).to eq(302),
-      "Expected 302 redirect for #{code}, got #{last_response.status}: #{last_response.body}"
-    expect(last_response.location.to_s).to include("/signin?auth_error=#{code}"),
-      "Expected auth_error=#{code} in Location, got: #{last_response.location.inspect}"
-  end
-
   # setup_mock_auth/teardown_mock_auth come from support/omniauth_test_helper.rb.
   # This spec passes only email:, so every example gets a fresh random uid.
-
-  # Configures allowed_signup_domains in OT.conf
-  # Pass nil to remove restrictions
-  def configure_allowed_domains(domains)
-    # Deep clone to avoid mutating original
-    config = Marshal.load(Marshal.dump(OT.conf))
-
-    config['site'] ||= {}
-    config['site']['authentication'] ||= {}
-    config['site']['authentication']['allowed_signup_domains'] = domains
-
-    allow(OT).to receive(:conf).and_return(config)
-  end
-
-  # Enables platform credential fallback for non-tenant requests.
-  # Required because tests run on `example.org` which isn't the canonical
-  # domain, so without this the tenant hook blocks before domain validation.
-  def enable_platform_fallback
-    allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
-  end
 
   # ==========================================================================
   # Tests: Domain Restrictions Configured

--- a/apps/web/auth/spec/integration/full/omniauth_domain_restriction_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_domain_restriction_spec.rb
@@ -93,40 +93,8 @@ RSpec.describe 'OmniAuth Domain Restriction', type: :integration do
       "Expected auth_error=#{code} in Location, got: #{last_response.location.inspect}"
   end
 
-  # Sets up OmniAuth test mode with a mock auth hash for the given email
-  def setup_mock_auth(email:, provider: :oidc, uid: nil)
-    OmniAuth.config.test_mode = true
-    OmniAuth.config.allowed_request_methods = %i[get post]
-
-    OmniAuth.config.mock_auth[provider] = OmniAuth::AuthHash.new({
-      provider: provider.to_s,
-      uid: uid || "test-uid-#{SecureRandom.hex(8)}",
-      info: {
-        email: email,
-        name: 'Test User',
-        email_verified: true,
-      },
-      credentials: {
-        token: 'mock_access_token',
-        refresh_token: 'mock_refresh_token',
-        expires_at: Time.now.to_i + 3600,
-        expires: true,
-      },
-      extra: {
-        raw_info: {
-          sub: uid || "test-uid-#{SecureRandom.hex(8)}",
-          email: email,
-          name: 'Test User',
-          email_verified: true,
-        },
-      },
-    })
-  end
-
-  def teardown_mock_auth
-    OmniAuth.config.test_mode = false
-    OmniAuth.config.mock_auth.clear
-  end
+  # setup_mock_auth/teardown_mock_auth come from support/omniauth_test_helper.rb.
+  # This spec passes only email:, so every example gets a fresh random uid.
 
   # Configures allowed_signup_domains in OT.conf
   # Pass nil to remove restrictions

--- a/apps/web/auth/spec/integration/full/omniauth_issuer_scoped_identity_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_issuer_scoped_identity_spec.rb
@@ -60,8 +60,12 @@ RSpec.describe 'Issuer-scoped SSO identity lookup', type: :integration do
     created_account_ids.each { |id| db[:accounts].where(id: id).delete }
   end
 
+  # Status is irrelevant here — these examples exercise the account_identities
+  # schema and its (provider, issuer, uid) constraint, and the account row is
+  # only an FK target. Named rather than a bare 1 so it doesn't read as a
+  # meaningful choice.
   def create_account(email)
-    id = db[:accounts].insert(email: email, status_id: 1)
+    id = db[:accounts].insert(email: email, status_id: AuthTestConstants::STATUS_UNVERIFIED)
     created_account_ids << id
     id
   end

--- a/apps/web/auth/spec/integration/full/omniauth_missing_email_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_missing_email_spec.rb
@@ -144,10 +144,9 @@ RSpec.describe 'OmniAuth Missing Email (issue #3478)', type: :integration do
     })
   end
 
-  def teardown_mock_auth
-    OmniAuth.config.test_mode = false
-    OmniAuth.config.mock_auth.clear
-  end
+  # teardown_mock_auth comes from support/omniauth_test_helper.rb. The SETUP
+  # stays local: the shared setup_mock_auth omits an absent email claim, while
+  # #3478 needs info.email PRESENT and nil/blank.
 
   # Posts the SSO callback, self-skipping if the route isn't registered in this
   # boot (e.g. the :entra route when Entra credentials/orgs_sso aren't present).

--- a/apps/web/auth/spec/integration/full/omniauth_missing_email_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_missing_email_spec.rb
@@ -53,10 +53,6 @@ require_relative '../../spec_helper'
 RSpec.describe 'OmniAuth Missing Email (issue #3478)', type: :integration do
   include Rack::Test::Methods
 
-  def app
-    Onetime::Application::Registry.generate_rack_url_map
-  end
-
   before(:all) do
     # Boot the full Onetime application for integration tests. Mirrors the
     # sibling omniauth_domain_restriction_spec.rb boot — see its comments for
@@ -96,16 +92,6 @@ RSpec.describe 'OmniAuth Missing Email (issue #3478)', type: :integration do
   # ==========================================================================
   # Helpers
   # ==========================================================================
-
-  # Asserts the OmniAuth callback ended in a 302 redirect to /signin with the
-  # given stable auth_error code. The 302 (vs 500/timeout) is itself the
-  # regression guard against the "frozen loading screen" symptom.
-  def expect_auth_error_redirect(code)
-    expect(last_response.status).to eq(302),
-      "Expected 302 redirect for #{code}, got #{last_response.status}: #{last_response.body}"
-    expect(last_response.location.to_s).to include("/signin?auth_error=#{code}"),
-      "Expected auth_error=#{code} in Location, got: #{last_response.location.inspect}"
-  end
 
   # Builds an OmniAuth mock shaped like a Microsoft Entra ID v2.0 id_token.
   #
@@ -155,18 +141,6 @@ RSpec.describe 'OmniAuth Missing Email (issue #3478)', type: :integration do
     return unless last_response.status == 404
 
     skip "OmniAuth route /auth/sso/#{provider}/callback not registered in this boot"
-  end
-
-  def enable_platform_fallback
-    allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
-  end
-
-  def configure_allowed_domains(domains)
-    config = Marshal.load(Marshal.dump(OT.conf))
-    config['site'] ||= {}
-    config['site']['authentication'] ||= {}
-    config['site']['authentication']['allowed_signup_domains'] = domains
-    allow(OT).to receive(:conf).and_return(config)
   end
 
   # ==========================================================================

--- a/apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
@@ -111,31 +111,10 @@ RSpec.describe 'OmniAuth sign-in interstitial (#3840 Phase 3)', type: :integrati
     account_id
   end
 
-  def setup_mock_auth(email:, uid:, provider: :oidc)
-    OmniAuth.config.test_mode               = true
-    OmniAuth.config.allowed_request_methods = [:get, :post]
-    OmniAuth.config.mock_auth[provider]     = OmniAuth::AuthHash.new(
-      {
-        provider: provider.to_s,
-        uid: uid,
-        info: { email: email, name: 'Interstitial User', email_verified: true },
-        credentials: { token: 'mock_access_token', expires_at: Time.now.to_i + 3600, expires: true },
-        extra: { raw_info: { sub: uid, email: email, name: 'Interstitial User', email_verified: true } },
-      },
-    )
-  end
-
-  def teardown_mock_auth
-    OmniAuth.config.test_mode = false
-    OmniAuth.config.mock_auth.clear
-  end
-
-  # Content-Type/Content-Length leak from a prior JSON POST and make the next
-  # bodyless request try to parse an empty JSON body. Clear them.
-  def clear_body_headers
-    header 'Content-Type', nil
-    header 'Content-Length', nil
-  end
+  # setup_mock_auth/teardown_mock_auth (support/omniauth_test_helper.rb) and
+  # clear_body_headers/fetch_csrf_token (support/auth_request_helper.rb) are
+  # shared. fetch_csrf_token establishes a fresh session; the challenge lives in
+  # Redis, not the session, so that does not disturb it.
 
   # Drive the UNAUTHENTICATED SSO callback and return the response. No login and
   # no connect intent — this is the plain sign-in that resolves to an existing
@@ -150,16 +129,6 @@ RSpec.describe 'OmniAuth sign-in interstitial (#3840 Phase 3)', type: :integrati
   # Extract the challenge token from a /link-sso/:token redirect Location.
   def token_from_location(location)
     location.to_s.split('/link-sso/').last.to_s.split(/[?#]/).first
-  end
-
-  # Fetch a CSRF token from the app bootstrap (mirrors csrf_login). The challenge
-  # lives in Redis, not the session, so establishing a fresh session here does
-  # not disturb it.
-  def fetch_csrf_token
-    clear_body_headers
-    header 'Accept', 'application/json'
-    get '/auth'
-    last_response.headers['X-CSRF-Token']
   end
 
   def get_link_context(token)

--- a/apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
@@ -52,13 +52,11 @@
 
 require_relative '../../spec_helper'
 require_relative '../../support/oauth_flow_helper'
+require_relative '../../support/sso_link_flow_helper'
 
 RSpec.describe 'OmniAuth sign-in interstitial (#3840 Phase 3)', type: :integration do
   include Rack::Test::Methods
-
-  def app
-    Onetime::Application::Registry.generate_rack_url_map
-  end
+  include SsoLinkFlowHelper
 
   before(:all) do
     require 'onetime'
@@ -82,13 +80,6 @@ RSpec.describe 'OmniAuth sign-in interstitial (#3840 Phase 3)', type: :integrati
   # Helpers (mirrors omniauth_connect_link_spec.rb)
   # ==========================================================================
 
-  # Leaves session[:validated_omniauth_domain_id] nil == the PLATFORM path, and
-  # lets a non-tenant callback proceed on platform credentials instead of
-  # redirecting to sso_not_configured.
-  def enable_platform_fallback
-    allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
-  end
-
   # seed_existing_account (SSO-only, no password) and
   # seed_account_with_password (support/account_seed_helper.rb),
   # setup_mock_auth/teardown_mock_auth (support/omniauth_test_helper.rb) and
@@ -96,35 +87,10 @@ RSpec.describe 'OmniAuth sign-in interstitial (#3840 Phase 3)', type: :integrati
   # shared. fetch_csrf_token establishes a fresh session; the challenge lives in
   # Redis, not the session, so that does not disturb it.
 
-  # Drive the UNAUTHENTICATED SSO callback and return the response. No login and
-  # no connect intent — this is the plain sign-in that resolves to an existing
-  # account by email.
-  def sso_callback(email:, uid:, provider: :oidc)
-    setup_mock_auth(email: email, uid: uid, provider: provider)
-    clear_body_headers
-    post "/auth/sso/#{provider}/callback"
-    last_response
-  end
-
-  # Extract the challenge token from a /link-sso/:token redirect Location.
-  def token_from_location(location)
-    location.to_s.split('/link-sso/').last.to_s.split(/[?#]/).first
-  end
-
   def get_link_context(token)
     clear_body_headers
     header 'Accept', 'application/json'
     get "/auth/link-sso/#{token}"
-    last_response
-  end
-
-  def post_link_sso(token:, password:)
-    csrf = fetch_csrf_token
-    clear_body_headers
-    header 'Content-Type', 'application/json'
-    header 'Accept', 'application/json'
-    header 'X-CSRF-Token', csrf if csrf
-    post '/auth/link-sso', JSON.generate(token: token, password: password)
     last_response
   end
 

--- a/apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
@@ -89,28 +89,8 @@ RSpec.describe 'OmniAuth sign-in interstitial (#3840 Phase 3)', type: :integrati
     allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
   end
 
-  # Seed a VERIFIED account WITHOUT a password (SSO-only account).
-  def seed_existing_account(email)
-    normalized = OT::Utils.normalize_email(email)
-    customer   = Onetime::Customer.new(email: normalized)
-    customer.save
-    auth_db[:accounts].insert(
-      email: normalized,
-      status_id: AuthTestConstants::STATUS_VERIFIED,
-      external_id: customer.extid,
-    )
-  end
-
-  # Seed a VERIFIED account WITH an Argon2 password hash. Cost params match the
-  # test config in config/features/argon2.rb.
-  def seed_account_with_password(email, password: AuthTestConstants::TEST_PASSWORD)
-    account_id = seed_existing_account(email)
-    require 'argon2'
-    hasher     = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
-    auth_db[:account_password_hashes].insert(id: account_id, password_hash: hasher.create(password))
-    account_id
-  end
-
+  # seed_existing_account (SSO-only, no password) and
+  # seed_account_with_password (support/account_seed_helper.rb),
   # setup_mock_auth/teardown_mock_auth (support/omniauth_test_helper.rb) and
   # clear_body_headers/fetch_csrf_token (support/auth_request_helper.rb) are
   # shared. fetch_csrf_token establishes a fresh session; the challenge lives in

--- a/apps/web/auth/spec/integration/full/omniauth_trusted_link_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_trusted_link_spec.rb
@@ -135,29 +135,9 @@ RSpec.describe 'OmniAuth trusted-provider email linking (#3836 Phase 1)', type: 
     )
   end
 
-  # OmniAuth test-mode mock for a successful IdP assertion of `email`/`uid`.
-  def setup_mock_auth(email:, uid:, provider: :oidc)
-    OmniAuth.config.test_mode = true
-    OmniAuth.config.allowed_request_methods = %i[get post]
-    OmniAuth.config.mock_auth[provider] = OmniAuth::AuthHash.new({
-      provider: provider.to_s,
-      uid: uid,
-      info: { email: email, name: 'Trusted Link User', email_verified: true },
-      credentials: {
-        token: 'mock_access_token',
-        expires_at: Time.now.to_i + 3600,
-        expires: true,
-      },
-      extra: {
-        raw_info: { sub: uid, email: email, name: 'Trusted Link User', email_verified: true },
-      },
-    })
-  end
-
-  def teardown_mock_auth
-    OmniAuth.config.test_mode = false
-    OmniAuth.config.mock_auth.clear
-  end
+  # setup_mock_auth/teardown_mock_auth — the OmniAuth test-mode mock for a
+  # successful IdP assertion of `email`/`uid` — come from
+  # support/omniauth_test_helper.rb.
 
   # ==========================================================================
   # Scenario 1 — PLATFORM path + trust flag ON -> auto-link

--- a/apps/web/auth/spec/integration/full/omniauth_trusted_link_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_trusted_link_spec.rb
@@ -120,21 +120,10 @@ RSpec.describe 'OmniAuth trusted-provider email linking (#3836 Phase 1)', type: 
       .with(route).and_return(enabled)
   end
 
-  # Seed a pre-existing VERIFIED account (accounts row + linked Customer) that
-  # _account_from_login will locate by normalized email. status_id = 2 (Verified)
-  # both satisfies the lookup's status filter AND makes open_account? true so the
-  # gem skips its verify-account branch. Returns the account_id.
-  def seed_existing_account(email)
-    normalized = OT::Utils.normalize_email(email)
-    customer   = Onetime::Customer.new(email: normalized)
-    customer.save
-    auth_db[:accounts].insert(
-      email: normalized,
-      status_id: AuthTestConstants::STATUS_VERIFIED,
-      external_id: customer.extid,
-    )
-  end
-
+  # seed_existing_account — the pre-existing VERIFIED account (accounts row +
+  # linked Customer) that _account_from_login locates by normalized email —
+  # comes from support/account_seed_helper.rb.
+  #
   # setup_mock_auth/teardown_mock_auth — the OmniAuth test-mode mock for a
   # successful IdP assertion of `email`/`uid` — come from
   # support/omniauth_test_helper.rb.

--- a/apps/web/auth/spec/integration/full/omniauth_trusted_link_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_trusted_link_spec.rb
@@ -73,10 +73,6 @@ require_relative '../../support/oauth_flow_helper'
 RSpec.describe 'OmniAuth trusted-provider email linking (#3836 Phase 1)', type: :integration do
   include Rack::Test::Methods
 
-  def app
-    Onetime::Application::Registry.generate_rack_url_map
-  end
-
   before(:all) do
     # Mirror the proven boot in omniauth_domain_restriction_spec.rb: force a
     # clean reboot so provider registration runs against this suite's WebMock
@@ -102,14 +98,6 @@ RSpec.describe 'OmniAuth trusted-provider email linking (#3836 Phase 1)', type: 
   # ==========================================================================
   # Helpers
   # ==========================================================================
-
-  # Enables platform credential fallback for non-tenant requests. Tests run on
-  # example.org (Rack::Test default), which isn't the canonical domain, so
-  # without this the tenant hook blocks the callback before account lookup.
-  # Leaves session[:validated_omniauth_domain_id] nil == the PLATFORM path.
-  def enable_platform_fallback
-    allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
-  end
 
   # Force the trust flag decision for a given route without touching the
   # auth_config plumbing (owned by another agent / tested separately). Any other

--- a/apps/web/auth/spec/integration/full/pending_plan_intent_flow_spec.rb
+++ b/apps/web/auth/spec/integration/full/pending_plan_intent_flow_spec.rb
@@ -86,10 +86,6 @@ RSpec.describe 'Pending plan intent flow (issue #3126)', type: :integration do
     end
   end
 
-  def unique_test_email(prefix = 'plan-intent')
-    "#{prefix}-#{SecureRandom.hex(8)}@integration-test.example.com"
-  end
-
   def create_test_account(email:, extid: nil)
     db = Auth::Database.connection
     extid ||= SecureRandom.uuid
@@ -102,25 +98,6 @@ RSpec.describe 'Pending plan intent flow (issue #3126)', type: :integration do
     )
     created_account_ids << account_id
     { id: account_id, email: email, external_id: extid, extid: extid }
-  end
-
-  # Establish a session, fetch the CSRF token, then POST a JSON login to the
-  # rodauth endpoint (mounted at /auth). The full Rack app enforces CSRF, so a
-  # raw post without the shrimp token returns 403 Forbidden.
-  def csrf_login(email, password = TEST_PASSWORD)
-    # Clear headers that leaked from previous POST (Content-Type triggers body
-    # parsing in Rack::Parser; when applied to a GET with no body, rack.input
-    # is nil and .read fails)
-    header 'Content-Type', nil
-    header 'Content-Length', nil
-    header 'Accept', 'application/json'
-    get '/auth'
-    token = last_response.headers['X-CSRF-Token']
-
-    header 'Content-Type', 'application/json'
-    header 'Accept', 'application/json'
-    header 'X-CSRF-Token', token if token
-    post '/auth/login', JSON.generate(login: email, password: password, shrimp: token)
   end
 
   # ==========================================================================

--- a/apps/web/auth/spec/integration/full/reset_password_request_enumeration_spec.rb
+++ b/apps/web/auth/spec/integration/full/reset_password_request_enumeration_spec.rb
@@ -64,10 +64,6 @@ RSpec.describe 'Reset-password-request enumeration safety (issue #3857)', type: 
   # moment a new flow touches another table — which is exactly what a stricter
   # version of this block surfaced during review.
 
-  def unique_test_email(prefix = 'reset-enum')
-    "#{prefix}-#{SecureRandom.hex(8)}@integration-test.example.com"
-  end
-
   # Creates an account with a password hash. status_id defaults to verified.
   def create_account(email:, status_id: AuthTestConstants::STATUS_VERIFIED, password: 'TestPassword123!')
     db    = Auth::Database.connection

--- a/apps/web/auth/spec/integration/full/sso_link_confirm_mailbox_proof_spec.rb
+++ b/apps/web/auth/spec/integration/full/sso_link_confirm_mailbox_proof_spec.rb
@@ -70,13 +70,11 @@
 
 require_relative '../../spec_helper'
 require_relative '../../support/oauth_flow_helper'
+require_relative '../../support/sso_link_flow_helper'
 
 RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integration do
   include Rack::Test::Methods
-
-  def app
-    Onetime::Application::Registry.generate_rack_url_map
-  end
+  include SsoLinkFlowHelper
 
   before(:all) do
     require 'onetime'
@@ -102,13 +100,6 @@ RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integrat
   # ==========================================================================
   # Helpers (mirror omniauth_signin_interstitial_spec.rb / omniauth_connect_link_spec.rb)
   # ==========================================================================
-
-  # Leaves session[:validated_omniauth_domain_id] nil == the PLATFORM path, so a
-  # non-tenant callback proceeds on platform credentials rather than redirecting to
-  # sso_not_configured.
-  def enable_platform_fallback
-    allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
-  end
 
   # Seed a VERIFIED account WITHOUT a password (a PASSWORDLESS / SSO-only account —
   # the Phase 4 subject). Also seeds the paired Customer so the watermark probe
@@ -153,50 +144,6 @@ RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integrat
   # establishing a fresh session there does not disturb it — and (for the
   # cross-device example) it deliberately makes the POST's current_sid DIFFER
   # from the token's snapshotted sid.
-
-  # Drive the UNAUTHENTICATED SSO callback and return the response.
-  def sso_callback(email:, uid:, provider: :oidc)
-    setup_mock_auth(email: email, uid: uid, provider: provider)
-    clear_body_headers
-    post "/auth/sso/#{provider}/callback"
-    last_response
-  end
-
-  # GET /auth/sso-link-confirm/:token — the display-only consent context.
-  def get_confirm(token)
-    clear_body_headers
-    header 'Accept', 'application/json'
-    get "/auth/sso-link-confirm/#{token}"
-    last_response
-  end
-
-  # POST /auth/sso-link-confirm { token } — the atomic consume + bind + login.
-  def post_confirm(token:)
-    csrf = fetch_csrf_token
-    clear_body_headers
-    header 'Content-Type', 'application/json'
-    header 'Accept', 'application/json'
-    header 'X-CSRF-Token', csrf if csrf
-    post '/auth/sso-link-confirm', JSON.generate(token: token)
-    last_response
-  end
-
-  # Mint a verification directly — the POST endpoint can be exercised without a full
-  # SSO round-trip, since the token carries the snapshot the op reloads. account_id,
-  # sid, and password_watermark are caller-supplied so tests can drive the conflict,
-  # cross-device, and watermark branches deterministically.
-  def mint_verification(email:, uid:, account_id:, provider: 'oidc',
-                        issuer: 'https://issuer.example.com', sid: nil, password_watermark: 0)
-    Onetime::SsoLinkVerification.issue(
-      provider: provider,
-      issuer: issuer,
-      uid: uid,
-      email: OT::Utils.normalize_email(email),
-      account_id: account_id,
-      sid: sid,
-      password_watermark: password_watermark,
-    )
-  end
 
   # Stub the templated publisher and CAPTURE every enqueue_email call. Returns the
   # capture buffer. Returning true means the message was QUEUED — the only outcome

--- a/apps/web/auth/spec/integration/full/sso_link_confirm_mailbox_proof_spec.rb
+++ b/apps/web/auth/spec/integration/full/sso_link_confirm_mailbox_proof_spec.rb
@@ -145,31 +145,14 @@ RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integrat
     )
   end
 
-  def setup_mock_auth(email:, uid:, provider: :oidc)
-    OmniAuth.config.test_mode               = true
-    OmniAuth.config.allowed_request_methods = [:get, :post]
-    OmniAuth.config.mock_auth[provider]     = OmniAuth::AuthHash.new(
-      {
-        provider: provider.to_s,
-        uid: uid,
-        info: { email: email, name: 'Mailbox User', email_verified: true },
-        credentials: { token: 'mock_access_token', expires_at: Time.now.to_i + 3600, expires: true },
-        extra: { raw_info: { sub: uid, email: email, name: 'Mailbox User', email_verified: true } },
-      },
-    )
-  end
-
-  def teardown_mock_auth
-    OmniAuth.config.test_mode = false
-    OmniAuth.config.mock_auth.clear
-  end
-
-  # Content-Type/Content-Length leak from a prior JSON POST and make the next
-  # bodyless request try to parse an empty JSON body. Clear them.
-  def clear_body_headers
-    header 'Content-Type', nil
-    header 'Content-Length', nil
-  end
+  # setup_mock_auth/teardown_mock_auth (support/omniauth_test_helper.rb) and
+  # clear_body_headers/fetch_csrf_token (support/auth_request_helper.rb) are
+  # shared.
+  #
+  # On fetch_csrf_token: the verification lives in Redis, not the session, so
+  # establishing a fresh session there does not disturb it — and (for the
+  # cross-device example) it deliberately makes the POST's current_sid DIFFER
+  # from the token's snapshotted sid.
 
   # Drive the UNAUTHENTICATED SSO callback and return the response.
   def sso_callback(email:, uid:, provider: :oidc)
@@ -177,17 +160,6 @@ RSpec.describe 'SSO mailbox-proof link confirm (#3840 Phase 4)', type: :integrat
     clear_body_headers
     post "/auth/sso/#{provider}/callback"
     last_response
-  end
-
-  # Fetch a CSRF token from the app bootstrap. The verification lives in Redis, not
-  # the session, so establishing a fresh session here does not disturb it — and (for
-  # the cross-device example) it deliberately makes the POST's current_sid DIFFER
-  # from the token's snapshotted sid.
-  def fetch_csrf_token
-    clear_body_headers
-    header 'Accept', 'application/json'
-    get '/auth'
-    last_response.headers['X-CSRF-Token']
   end
 
   # GET /auth/sso-link-confirm/:token — the display-only consent context.

--- a/apps/web/auth/spec/integration/full_mfa/omniauth_signin_interstitial_mfa_spec.rb
+++ b/apps/web/auth/spec/integration/full_mfa/omniauth_signin_interstitial_mfa_spec.rb
@@ -74,24 +74,7 @@ RSpec.describe 'OmniAuth sign-in interstitial: deferred bind after MFA (#3877)',
     allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
   end
 
-  def setup_mock_auth(email:, uid:, provider: :oidc)
-    OmniAuth.config.test_mode               = true
-    OmniAuth.config.allowed_request_methods = [:get, :post]
-    OmniAuth.config.mock_auth[provider]     = OmniAuth::AuthHash.new(
-      {
-        provider: provider.to_s,
-        uid: uid,
-        info: { email: email, name: 'MFA Interstitial User', email_verified: true },
-        credentials: { token: 'mock_access_token', expires_at: Time.now.to_i + 3600, expires: true },
-        extra: { raw_info: { sub: uid, email: email, name: 'MFA Interstitial User', email_verified: true } },
-      },
-    )
-  end
-
-  def teardown_mock_auth
-    OmniAuth.config.test_mode = false
-    OmniAuth.config.mock_auth.clear
-  end
+  # setup_mock_auth/teardown_mock_auth come from support/omniauth_test_helper.rb.
 
   def sso_callback(email:, uid:, provider: :oidc)
     setup_mock_auth(email: email, uid: uid, provider: provider)
@@ -105,7 +88,7 @@ RSpec.describe 'OmniAuth sign-in interstitial: deferred bind after MFA (#3877)',
   end
 
   def post_link_sso(token:, password:)
-    json_post('/auth/link-sso', token: token, password: password)
+    csrf_json_post('/auth/link-sso', token: token, password: password)
   end
 
   # Drive the SSO callback for an OTP-enabled password account up to the point
@@ -167,7 +150,7 @@ RSpec.describe 'OmniAuth sign-in interstitial: deferred bind after MFA (#3877)',
 
       # Complete the second factor in the SAME session the hand-off prepared.
       allow_immediate_otp_reuse!(account_id)
-      json_post('/auth/otp-auth', otp_code: ROTP::TOTP.new(secret).now)
+      csrf_json_post('/auth/otp-auth', otp_code: ROTP::TOTP.new(secret).now)
       expect(last_response.status).to eq(200),
         "OTP verification should succeed, got #{last_response.status}: #{last_response.body}"
 
@@ -202,7 +185,7 @@ RSpec.describe 'OmniAuth sign-in interstitial: deferred bind after MFA (#3877)',
 
       # A wrong code must not complete the login — and must not bind.
       allow_immediate_otp_reuse!(account_id)
-      json_post('/auth/otp-auth', otp_code: wrong_otp_code(secret))
+      csrf_json_post('/auth/otp-auth', otp_code: wrong_otp_code(secret))
 
       # Pin the SPECIFIC rejection, not just "non-200": Rodauth's OTP failure
       # path is 401 (invalid_key_error_status) with a field-error on the OTP
@@ -233,7 +216,7 @@ RSpec.describe 'OmniAuth sign-in interstitial: deferred bind after MFA (#3877)',
       # The pending bind survives the failed attempt: the next successful
       # factor still completes it (the stash is consumed on SUCCESS, not on
       # the first attempt).
-      json_post('/auth/otp-auth', otp_code: ROTP::TOTP.new(secret).now)
+      csrf_json_post('/auth/otp-auth', otp_code: ROTP::TOTP.new(secret).now)
       expect(last_response.status).to eq(200),
         "OTP retry should succeed, got #{last_response.status}: #{last_response.body}"
 
@@ -269,7 +252,7 @@ RSpec.describe 'OmniAuth sign-in interstitial: deferred bind after MFA (#3877)',
       # after_two_factor_authentication fires for ANY accepted factor, so the
       # deferred bind must land via /auth/recovery-auth exactly as via OTP —
       # this locks in the hook's factor-agnostic placement (hooks/mfa.rb).
-      json_post('/auth/recovery-auth', 'recovery-code' => recovery_codes.first)
+      csrf_json_post('/auth/recovery-auth', 'recovery-code' => recovery_codes.first)
       expect(last_response.status).to eq(200),
         "Recovery-code auth should succeed, got #{last_response.status}: #{last_response.body}"
 

--- a/apps/web/auth/spec/integration/full_mfa/omniauth_signin_interstitial_mfa_spec.rb
+++ b/apps/web/auth/spec/integration/full_mfa/omniauth_signin_interstitial_mfa_spec.rb
@@ -59,10 +59,12 @@ require_relative '../../spec_helper'
 # Rack::Test, `app`, `identities`, the OTP-feature guard, and the OTP
 # provisioning machinery. See the helper's header.
 require_relative '../../support/mfa_flow_helper'
+require_relative '../../support/sso_link_flow_helper'
 
 RSpec.describe 'OmniAuth sign-in interstitial: deferred bind after MFA (#3877)',
   :full_auth_mode, type: :integration do
   include MfaFlowHelper
+  include SsoLinkFlowHelper
 
   # ==========================================================================
   # Route driving for THIS flow (mirrors
@@ -70,26 +72,7 @@ RSpec.describe 'OmniAuth sign-in interstitial: deferred bind after MFA (#3877)',
   # machinery lives in support/mfa_flow_helper.rb.
   # ==========================================================================
 
-  def enable_platform_fallback
-    allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
-  end
-
   # setup_mock_auth/teardown_mock_auth come from support/omniauth_test_helper.rb.
-
-  def sso_callback(email:, uid:, provider: :oidc)
-    setup_mock_auth(email: email, uid: uid, provider: provider)
-    clear_body_headers
-    post "/auth/sso/#{provider}/callback"
-    last_response
-  end
-
-  def token_from_location(location)
-    location.to_s.split('/link-sso/').last.to_s.split(/[?#]/).first
-  end
-
-  def post_link_sso(token:, password:)
-    csrf_json_post('/auth/link-sso', token: token, password: password)
-  end
 
   # Drive the SSO callback for an OTP-enabled password account up to the point
   # where the interstitial has verified the password and handed off to MFA.

--- a/apps/web/auth/spec/integration/full_mfa/sso_link_confirm_mailbox_proof_mfa_spec.rb
+++ b/apps/web/auth/spec/integration/full_mfa/sso_link_confirm_mailbox_proof_mfa_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'SSO mailbox-proof link confirm: deferred bind after MFA (#3840 P
   end
 
   # POST /auth/sso-link-confirm { token } — the atomic consume + (deferred) bind
-  # + login handoff. Carries shrimp in the body like json_post; the custom route
+  # + login handoff. Carries shrimp in the body like csrf_json_post; the custom route
   # accepts the header token too, but sending both matches the SPA.
   def post_confirm(token:)
     csrf = fetch_csrf_token
@@ -186,7 +186,7 @@ RSpec.describe 'SSO mailbox-proof link confirm: deferred bind after MFA (#3840 P
 
     # Complete the second factor in the SAME session the hand-off prepared.
     allow_immediate_otp_reuse!(account_id)
-    json_post('/auth/otp-auth', otp_code: ROTP::TOTP.new(secret).now)
+    csrf_json_post('/auth/otp-auth', otp_code: ROTP::TOTP.new(secret).now)
     expect(last_response.status).to eq(200),
       "OTP verification should succeed, got #{last_response.status}: #{last_response.body}"
 
@@ -220,7 +220,7 @@ RSpec.describe 'SSO mailbox-proof link confirm: deferred bind after MFA (#3840 P
     # The mailbox-written stash is consumed by whichever 2FA route runs: swap
     # otp-auth for recovery-auth and the bind still lands. See header note (c)
     # for why this is a readability guard rather than independent coverage.
-    json_post('/auth/recovery-auth', 'recovery-code' => recovery_codes.first)
+    csrf_json_post('/auth/recovery-auth', 'recovery-code' => recovery_codes.first)
     expect(last_response.status).to eq(200),
       "Recovery-code auth should succeed, got #{last_response.status}: #{last_response.body}"
 

--- a/apps/web/auth/spec/integration/full_mfa/sso_link_confirm_mailbox_proof_mfa_spec.rb
+++ b/apps/web/auth/spec/integration/full_mfa/sso_link_confirm_mailbox_proof_mfa_spec.rb
@@ -85,54 +85,18 @@ require_relative '../../spec_helper'
 # Rack::Test, `app`, `identities`, the OTP-feature guard, and the OTP
 # provisioning machinery. See the helper's header.
 require_relative '../../support/mfa_flow_helper'
+require_relative '../../support/sso_link_flow_helper'
 
 RSpec.describe 'SSO mailbox-proof link confirm: deferred bind after MFA (#3840 Phase 4 / #3877)',
   :full_auth_mode, type: :integration do
   include MfaFlowHelper
+  include SsoLinkFlowHelper
 
   # ==========================================================================
   # Route driving for THIS flow (mirrors
   # integration/full/sso_link_confirm_mailbox_proof_spec.rb). The shared OTP
   # machinery lives in support/mfa_flow_helper.rb.
   # ==========================================================================
-
-  # GET /auth/sso-link-confirm/:token — the display-only consent context.
-  def get_confirm(token)
-    clear_body_headers
-    header 'Accept', 'application/json'
-    get "/auth/sso-link-confirm/#{token}"
-    last_response
-  end
-
-  # POST /auth/sso-link-confirm { token } — the atomic consume + (deferred) bind
-  # + login handoff. Carries shrimp in the body like csrf_json_post; the custom route
-  # accepts the header token too, but sending both matches the SPA.
-  def post_confirm(token:)
-    csrf = fetch_csrf_token
-    clear_body_headers
-    header 'Content-Type', 'application/json'
-    header 'Accept', 'application/json'
-    header 'X-CSRF-Token', csrf if csrf
-    post '/auth/sso-link-confirm', JSON.generate(token: token, shrimp: csrf)
-    last_response
-  end
-
-  # Mint a verification directly — the POST endpoint carries the snapshot the op
-  # reloads, so it needs no SSO round-trip. Default watermark 0 matches a freshly
-  # seeded Customer (never had last_password_update stamped), so watermark_state
-  # resolves :unchanged.
-  def mint_verification(email:, uid:, account_id:, provider: 'oidc',
-                        issuer: 'https://issuer.example.com', sid: nil, password_watermark: 0)
-    Onetime::SsoLinkVerification.issue(
-      provider: provider,
-      issuer: issuer,
-      uid: uid,
-      email: OT::Utils.normalize_email(email),
-      account_id: account_id,
-      sid: sid,
-      password_watermark: password_watermark,
-    )
-  end
 
   # Drive the mailbox-proof confirm up to the MFA hand-off: mint a verification,
   # POST it, and assert the deferral contract — mfa_required, the token CONSUMED

--- a/apps/web/auth/spec/spec_helper.rb
+++ b/apps/web/auth/spec/spec_helper.rb
@@ -74,6 +74,7 @@ require 'rack/test'
 
 # Load OmniAuth test helper for additional helper methods
 require_relative 'support/omniauth_test_helper'
+require_relative 'support/auth_request_helper'
 require_relative 'support/auth_test_constants'
 require_relative 'support/mock_omniauth_strategy'
 require_relative 'support/config_recreator'
@@ -566,6 +567,11 @@ RSpec.configure do |config|
   # Integration test helpers (for tests requiring full app boot)
   config.include Rack::Test::Methods, type: :integration
   config.include ProductionConfigHelper, type: :integration
+
+  # CSRF-aware request plumbing (csrf_json_post, fetch_csrf_token, json_body,
+  # clear_body_headers). Distinct names from ProductionConfigHelper#json_post,
+  # which is CSRF-blind and stays for the non-Rodauth routes.
+  config.include AuthRequestHelper, type: :integration
 
   # Capture AUTH_* env vars before integration suite to prevent leakage
   # between spec files that set different feature flags.

--- a/apps/web/auth/spec/spec_helper.rb
+++ b/apps/web/auth/spec/spec_helper.rb
@@ -75,6 +75,7 @@ require 'rack/test'
 # Load OmniAuth test helper for additional helper methods
 require_relative 'support/omniauth_test_helper'
 require_relative 'support/auth_request_helper'
+require_relative 'support/account_seed_helper'
 require_relative 'support/auth_test_constants'
 require_relative 'support/mock_omniauth_strategy'
 require_relative 'support/config_recreator'
@@ -572,6 +573,9 @@ RSpec.configure do |config|
   # clear_body_headers). Distinct names from ProductionConfigHelper#json_post,
   # which is CSRF-blind and stays for the non-Rodauth routes.
   config.include AuthRequestHelper, type: :integration
+
+  # Subject seeding (seed_existing_account, seed_account_with_password).
+  config.include AccountSeedHelper, type: :integration
 
   # Capture AUTH_* env vars before integration suite to prevent leakage
   # between spec files that set different feature flags.

--- a/apps/web/auth/spec/support/account_seed_helper.rb
+++ b/apps/web/auth/spec/support/account_seed_helper.rb
@@ -1,0 +1,66 @@
+# apps/web/auth/spec/support/account_seed_helper.rb
+#
+# frozen_string_literal: true
+
+require_relative 'auth_test_constants'
+
+# =============================================================================
+# Account seeding (auto-included into `type: :integration`)
+# =============================================================================
+#
+# One place to build the SUBJECT of an auth integration spec: an accounts row
+# plus its paired Customer, optionally with an Argon2 password hash.
+#
+# Every field here is load-bearing for the gem's own lookups, which is why the
+# copies had drifted apart in wording but never in behaviour (the copy counts
+# before this file: seed_account_with_password 4, seed_existing_account 3):
+#
+#   status_id = Verified  — both satisfies _account_from_login's status filter
+#     AND makes open_account? true, so Rodauth skips its verify-account branch.
+#   external_id = customer.extid — the accounts row and the Customer are one
+#     subject. Flows that probe customer state resolve :unreadable without it
+#     (e.g. the SSO mailbox-proof watermark check reads
+#     Customer#last_password_update via load_by_extid_or_email).
+#   Argon2 cost params — mirror the test config in config/features/argon2.rb.
+#
+# Auto-included alongside AuthRequestHelper (spec_helper.rb) and included
+# explicitly by MfaFlowHelper, so the full_mfa lane does not depend on the
+# config-level include. `auth_db` comes from ProductionConfigHelper.
+#
+# A group that defines either method itself still wins — a `def` in the example
+# group body sits below config-included modules in the ancestor chain.
+#
+# =============================================================================
+
+module AccountSeedHelper
+  # Seed a VERIFIED account (accounts row + linked Customer) WITHOUT a
+  # password — an SSO-only subject. Returns the account_id.
+  def seed_existing_account(email)
+    normalized = OT::Utils.normalize_email(email)
+    customer   = Onetime::Customer.new(email: normalized)
+    customer.save
+    auth_db[:accounts].insert(
+      email: normalized,
+      status_id: AuthTestConstants::STATUS_VERIFIED,
+      external_id: customer.extid,
+    )
+  end
+
+  # Seed a VERIFIED account WITH an Argon2 password hash. Returns the
+  # account_id.
+  #
+  # Two distinct reasons a spec wants the password: to establish a real
+  # authenticated session through the login route, and — in the full_mfa lane —
+  # as the OTP-PROVISIONING VEHICLE, because this deploy sets
+  # two_factor_modifications_require_password? and Rodauth's real setup flow is
+  # the only way to get a production-shaped (HMAC'd) OTP key. Specs whose
+  # subject is passwordless in production still seed it for that second reason;
+  # see their headers.
+  def seed_account_with_password(email, password: AuthTestConstants::TEST_PASSWORD)
+    account_id = seed_existing_account(email)
+    require 'argon2'
+    hasher = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
+    auth_db[:account_password_hashes].insert(id: account_id, password_hash: hasher.create(password))
+    account_id
+  end
+end

--- a/apps/web/auth/spec/support/account_seed_helper.rb
+++ b/apps/web/auth/spec/support/account_seed_helper.rb
@@ -33,6 +33,13 @@ require_relative 'auth_test_constants'
 # =============================================================================
 
 module AccountSeedHelper
+  # A collision-free address on a domain that is not routable and not a
+  # configured signup domain. Every call site passes its own prefix — the
+  # default only keeps the signature usable from a console.
+  def unique_test_email(prefix = 'test')
+    "#{prefix}-#{SecureRandom.hex(8)}@integration-test.example.com"
+  end
+
   # Seed a VERIFIED account (accounts row + linked Customer) WITHOUT a
   # password — an SSO-only subject. Returns the account_id.
   def seed_existing_account(email)

--- a/apps/web/auth/spec/support/auth_request_helper.rb
+++ b/apps/web/auth/spec/support/auth_request_helper.rb
@@ -34,7 +34,20 @@ module AuthRequestHelper
   # carried this identical one-liner; a group that needs different construction
   # (e.g. basicauth_rejection_on_session_routes_spec.rb, which memoizes around
   # a Registry.reset!) still defines its own and wins on ancestor order.
+  #
+  # The empty-registry guard is what a per-spec copy used to buy implicitly: a
+  # group that never boots gets an EMPTY Rack::URLMap rather than an error, and
+  # every request in it 404s. Auto-inclusion means no author is forced to think
+  # about mounting any more, so the check has to be here — a named harness
+  # failure instead of a spec that reads as "the route is broken".
   def app
+    if Onetime::Application::Registry.mount_mappings.empty?
+      raise 'Application registry has no mounts, so `app` would be an empty ' \
+            'Rack::URLMap and every request in this group would 404. The group ' \
+            'needs a before(:all) that calls Onetime.boot! then ' \
+            'Onetime::Application::Registry.prepare_application_registry.'
+    end
+
     Onetime::Application::Registry.generate_rack_url_map
   end
 

--- a/apps/web/auth/spec/support/auth_request_helper.rb
+++ b/apps/web/auth/spec/support/auth_request_helper.rb
@@ -1,0 +1,70 @@
+# apps/web/auth/spec/support/auth_request_helper.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# CSRF-aware request plumbing (auto-included into `type: :integration`)
+# =============================================================================
+#
+# Every Rodauth POST in this app needs shrimp — the token in BOTH the
+# X-CSRF-Token header and the JSON body — and every request after a POST needs
+# the body headers cleared, because Rack::Test keeps `Content-Type` and
+# `Content-Length` sticky across calls and a GET carrying a stale
+# `Content-Length` is answered as a truncated/blank body.
+#
+# ProductionConfigHelper#json_post (spec_helper.rb) predates all of that and is
+# CSRF-blind: no shrimp, no header clearing. It stays as-is — a dozen specs
+# post to non-Rodauth routes through it. This module is the CSRF-aware path,
+# under DIFFERENT names, so the two never resolve against each other by
+# ancestor order.
+#
+# Auto-included, so a new integration spec gets the shared path for free
+# rather than growing an eighth copy (the copy counts before this file:
+# fetch_csrf_token 6, clear_body_headers 5, json_body 3).
+#
+# A group that defines any of these itself still wins — a `def` in the example
+# group body sits below config-included modules in the ancestor chain.
+#
+# =============================================================================
+
+module AuthRequestHelper
+  # Drop the sticky body headers Rack::Test carries over from a previous POST.
+  # Call before any GET, and before a POST whose body length differs.
+  def clear_body_headers
+    header 'Content-Type', nil
+    header 'Content-Length', nil
+  end
+
+  # GET /auth purely to read the CSRF token off the response headers.
+  def fetch_csrf_token
+    clear_body_headers
+    header 'Accept', 'application/json'
+    get '/auth'
+    last_response.headers['X-CSRF-Token']
+  end
+
+  # JSON POST with the CSRF token in both the header and the body (shrimp),
+  # matching what the SPA sends and what the Rodauth routes require.
+  def csrf_json_post(path, params = {})
+    csrf = fetch_csrf_token
+    clear_body_headers
+    header 'Content-Type', 'application/json'
+    header 'Accept', 'application/json'
+    header 'X-CSRF-Token', csrf if csrf
+    post path, JSON.generate(params.merge(shrimp: csrf))
+    last_response
+  end
+
+  # Parse the last response body as JSON.
+  #
+  # Raises (rather than returning {}) on a non-JSON body: every caller asserts
+  # the status first, so a parse failure here means the response was not the
+  # one the spec thinks it got, and an empty hash would surface that as a
+  # confusing nil three lines later.
+  def json_body
+    JSON.parse(last_response.body)
+  rescue JSON::ParserError => e
+    raise JSON::ParserError,
+      "Response body is not JSON (#{last_response.status}): #{last_response.body.to_s[0, 300].inspect} (#{e.message})"
+  end
+end

--- a/apps/web/auth/spec/support/auth_request_helper.rb
+++ b/apps/web/auth/spec/support/auth_request_helper.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require_relative 'auth_test_constants'
+
 # =============================================================================
 # CSRF-aware request plumbing (auto-included into `type: :integration`)
 # =============================================================================
@@ -28,6 +30,14 @@
 # =============================================================================
 
 module AuthRequestHelper
+  # The full mounted Rack stack, as Rack::Test::Methods requires. Eight specs
+  # carried this identical one-liner; a group that needs different construction
+  # (e.g. basicauth_rejection_on_session_routes_spec.rb, which memoizes around
+  # a Registry.reset!) still defines its own and wins on ancestor order.
+  def app
+    Onetime::Application::Registry.generate_rack_url_map
+  end
+
   # Drop the sticky body headers Rack::Test carries over from a previous POST.
   # Call before any GET, and before a POST whose body length differs.
   def clear_body_headers
@@ -52,6 +62,19 @@ module AuthRequestHelper
     header 'Accept', 'application/json'
     header 'X-CSRF-Token', csrf if csrf
     post path, JSON.generate(params.merge(shrimp: csrf))
+    last_response
+  end
+
+  # Establish an authenticated session through the real login route.
+  #
+  # The status assertion is a PRECONDITION, not the subject of any caller: a
+  # silently failed login here surfaces three lines later as a confusing 401 on
+  # the route actually under test. 200 (JSON) and 302 (HTML redirect) are both
+  # success — which one comes back depends on the Accept negotiation.
+  def csrf_login(email, password: AuthTestConstants::TEST_PASSWORD)
+    csrf_json_post('/auth/login', login: email, password: password)
+    expect(last_response.status).to be_between(200, 302),
+      "Precondition failed: login for #{email} returned #{last_response.status}: #{last_response.body}"
     last_response
   end
 

--- a/apps/web/auth/spec/support/mfa_flow_helper.rb
+++ b/apps/web/auth/spec/support/mfa_flow_helper.rb
@@ -18,9 +18,13 @@ require_relative 'account_seed_helper'
 # two_factor_modifications_require_password?, the otp_setup/otp_raw_secret/
 # recovery-code param names, the two-phase otp-setup contract). A Rodauth
 # upgrade or a config flip breaks every copy at once, so a mirrored copy is a
-# second place to forget. Route DRIVING stays in each spec — that is the part
-# that genuinely differs (link-sso vs sso-link-confirm) and the part a mirror
-# is for. Compare support/oauth_flow_helper.rb, included by four full/ specs.
+# second place to forget. Compare support/oauth_flow_helper.rb, included by
+# four full/ specs.
+#
+# Route DRIVING is NOT here — but it is not mirrored per spec either: the
+# link-sso and sso-link-confirm drivers live in support/sso_link_flow_helper.rb,
+# because the route is identical across the full/ and full_mfa/ lanes and only
+# the ASSERTIONS differ. What stays in each spec is the expectations.
 #
 # LOAD-TIME SIDE EFFECT — AUTH_MFA_ENABLED: requiring this file sets
 # AUTH_MFA_ENABLED=true. It must be set before the suite's FIRST boot
@@ -78,10 +82,6 @@ module MfaFlowHelper
     end
 
     base.let(:identities) { auth_db[:account_identities] }
-  end
-
-  def app
-    Onetime::Application::Registry.generate_rack_url_map
   end
 
   # ==========================================================================

--- a/apps/web/auth/spec/support/mfa_flow_helper.rb
+++ b/apps/web/auth/spec/support/mfa_flow_helper.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative 'auth_test_constants'
+require_relative 'auth_request_helper'
 
 # =============================================================================
 # MFA Lane Helper (integration/full_mfa/)
@@ -41,9 +42,14 @@ require_relative 'auth_test_constants'
 #       account_id     = seed_account_with_password(email)
 #       secret, codes  = provision_totp(email)
 #       allow_immediate_otp_reuse!(account_id)
-#       json_post('/auth/otp-auth', otp_code: ROTP::TOTP.new(secret).now)
+#       csrf_json_post('/auth/otp-auth', otp_code: ROTP::TOTP.new(secret).now)
 #     end
 #   end
+#
+# Request plumbing (csrf_json_post, fetch_csrf_token, json_body,
+# clear_body_headers) comes from support/auth_request_helper.rb — included
+# here explicitly so this helper stands on its own, not on the config-level
+# auto-include.
 #
 # =============================================================================
 
@@ -54,6 +60,7 @@ require 'rotp'
 module MfaFlowHelper
   def self.included(base)
     base.include Rack::Test::Methods
+    base.include AuthRequestHelper
 
     # Hard-fail (not skip): this lane EXISTS to cover the MFA path, so a boot
     # without the OTP feature is harness breakage, not an environment quirk.
@@ -72,41 +79,6 @@ module MfaFlowHelper
 
   def app
     Onetime::Application::Registry.generate_rack_url_map
-  end
-
-  # ==========================================================================
-  # Request plumbing
-  # ==========================================================================
-
-  def clear_body_headers
-    header 'Content-Type', nil
-    header 'Content-Length', nil
-  end
-
-  def fetch_csrf_token
-    clear_body_headers
-    header 'Accept', 'application/json'
-    get '/auth'
-    last_response.headers['X-CSRF-Token']
-  end
-
-  # JSON POST with the CSRF token in both header and body (shrimp), matching
-  # what the SPA sends and what the Rodauth routes (otp-setup, otp-auth,
-  # recovery-auth) require.
-  def json_post(path, params = {})
-    csrf = fetch_csrf_token
-    clear_body_headers
-    header 'Content-Type', 'application/json'
-    header 'Accept', 'application/json'
-    header 'X-CSRF-Token', csrf if csrf
-    post path, JSON.generate(params.merge(shrimp: csrf))
-    last_response
-  end
-
-  def json_body
-    JSON.parse(last_response.body)
-  rescue JSON::ParserError
-    {}
   end
 
   # ==========================================================================
@@ -156,11 +128,11 @@ module MfaFlowHelper
   # ==========================================================================
 
   def provision_totp(email, password: AuthTestConstants::TEST_PASSWORD)
-    json_post('/auth/login', login: email, password: password)
+    csrf_json_post('/auth/login', login: email, password: password)
     expect(last_response.status).to eq(200),
       "Precondition failed: password login for OTP setup (#{last_response.status}: #{last_response.body})"
 
-    json_post('/auth/otp-setup', {})
+    csrf_json_post('/auth/otp-setup', {})
     expect(last_response.status).to eq(422),
       "Phase-1 otp-setup should return the generated secret with a field error (#{last_response.status}: #{last_response.body})"
     setup_body = json_body
@@ -169,7 +141,7 @@ module MfaFlowHelper
     expect(secret).not_to be_nil
     expect(raw_secret).not_to be_nil
 
-    json_post(
+    csrf_json_post(
       '/auth/otp-setup',
       otp_setup: secret,
       otp_raw_secret: raw_secret,

--- a/apps/web/auth/spec/support/mfa_flow_helper.rb
+++ b/apps/web/auth/spec/support/mfa_flow_helper.rb
@@ -4,6 +4,7 @@
 
 require_relative 'auth_test_constants'
 require_relative 'auth_request_helper'
+require_relative 'account_seed_helper'
 
 # =============================================================================
 # MFA Lane Helper (integration/full_mfa/)
@@ -47,9 +48,10 @@ require_relative 'auth_request_helper'
 #   end
 #
 # Request plumbing (csrf_json_post, fetch_csrf_token, json_body,
-# clear_body_headers) comes from support/auth_request_helper.rb — included
-# here explicitly so this helper stands on its own, not on the config-level
-# auto-include.
+# clear_body_headers) comes from support/auth_request_helper.rb, and subject
+# seeding (seed_existing_account, seed_account_with_password) from
+# support/account_seed_helper.rb — both included here explicitly so this helper
+# stands on its own, not on the config-level auto-include.
 #
 # =============================================================================
 
@@ -61,6 +63,7 @@ module MfaFlowHelper
   def self.included(base)
     base.include Rack::Test::Methods
     base.include AuthRequestHelper
+    base.include AccountSeedHelper
 
     # Hard-fail (not skip): this lane EXISTS to cover the MFA path, so a boot
     # without the OTP feature is harness breakage, not an environment quirk.
@@ -79,37 +82,6 @@ module MfaFlowHelper
 
   def app
     Onetime::Application::Registry.generate_rack_url_map
-  end
-
-  # ==========================================================================
-  # Subject seeding
-  # ==========================================================================
-
-  # Seed a VERIFIED account WITH a password AND its paired Customer.
-  #
-  # The password is the OTP-PROVISIONING VEHICLE: this deploy sets
-  # two_factor_modifications_require_password?, so Rodauth's real setup flow —
-  # the only way to get a production-shaped (HMAC'd) OTP key — needs one. Specs
-  # for passwordless subjects still seed it for that reason alone; see their
-  # headers.
-  #
-  # The paired Customer matters to any flow that probes customer state (e.g.
-  # the SSO mailbox-proof watermark check reads Customer#last_password_update
-  # via load_by_extid_or_email, which resolves :unchanged rather than
-  # :unreadable only when the Customer exists).
-  def seed_account_with_password(email, password: AuthTestConstants::TEST_PASSWORD)
-    normalized = OT::Utils.normalize_email(email)
-    customer   = Onetime::Customer.new(email: normalized)
-    customer.save
-    account_id = auth_db[:accounts].insert(
-      email: normalized,
-      status_id: AuthTestConstants::STATUS_VERIFIED,
-      external_id: customer.extid,
-    )
-    require 'argon2'
-    hasher = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
-    auth_db[:account_password_hashes].insert(id: account_id, password_hash: hasher.create(password))
-    account_id
   end
 
   # ==========================================================================

--- a/apps/web/auth/spec/support/omniauth_test_helper.rb
+++ b/apps/web/auth/spec/support/omniauth_test_helper.rb
@@ -4,6 +4,7 @@
 
 require 'webmock/rspec'
 require 'omniauth'
+require 'securerandom'
 
 # =============================================================================
 # OmniAuth Test Helpers
@@ -100,15 +101,26 @@ module OmniAuthTestHelper
 
   # Mock a successful OIDC authentication hash
   # Use for testing callback handling
-  def mock_oidc_success(email: 'test@example.com', name: 'Test User', uid: 'test-uid-123')
-    OmniAuth.config.mock_auth[:oidc] = OmniAuth::AuthHash.new({
-      provider: 'oidc',
+  #
+  # provider: registers under a provider other than :oidc (the callback route
+  #   segment and the auth hash's provider value are the same string).
+  # email: nil models an IdP that returns NO email claim — the claim is OMITTED
+  #   from info and raw_info rather than sent as null, which is what a real
+  #   emailless response looks like and what the app's missing-email paths must
+  #   handle. Note '' is not nil: an empty-string claim is still a claim, and
+  #   the domain-restriction specs rely on it being passed through.
+  def mock_oidc_success(email: 'test@example.com', name: 'Test User', uid: 'test-uid-123', provider: :oidc)
+    info     = { name: name }
+    raw_info = { sub: uid, name: name }
+    unless email.nil?
+      info     = info.merge(email: email, email_verified: true)
+      raw_info = raw_info.merge(email: email, email_verified: true)
+    end
+
+    OmniAuth.config.mock_auth[provider.to_sym] = OmniAuth::AuthHash.new({
+      provider: provider.to_s,
       uid: uid,
-      info: {
-        email: email,
-        name: name,
-        email_verified: true,
-      },
+      info: info,
       credentials: {
         token: 'mock_access_token',
         refresh_token: 'mock_refresh_token',
@@ -116,14 +128,39 @@ module OmniAuthTestHelper
         expires: true,
       },
       extra: {
-        raw_info: {
-          sub: uid,
-          email: email,
-          name: name,
-          email_verified: true,
-        },
+        raw_info: raw_info,
       },
     })
+  end
+
+  # Put OmniAuth in test mode AND register a mock auth hash for `provider` —
+  # the pair every callback-driving spec needs, previously mirrored in seven of
+  # them. Callers that need a non-default hash shape can still reach for
+  # mock_oidc_success/mock_entra_success/etc. directly.
+  #
+  # uid defaults to a fresh random value, used for BOTH uid and raw_info.sub
+  # (the copies in omniauth_domain_restriction_spec.rb generated the fallback
+  # twice, so uid and sub disagreed for every example that omitted uid).
+  #
+  # Pair with teardown_mock_auth in an ensure block, or let the :omniauth_mock
+  # tag's after hook (reset_omniauth_config) handle it.
+  def setup_mock_auth(email:, uid: nil, provider: :oidc, name: 'Test User')
+    enable_omniauth_test_mode
+    mock_oidc_success(
+      email: email,
+      name: name,
+      uid: uid || "test-uid-#{SecureRandom.hex(8)}",
+      provider: provider,
+    )
+  end
+
+  # Leave OmniAuth out of test mode with no mocks registered. Narrower than
+  # reset_omniauth_config on purpose: it does not touch allowed_request_methods,
+  # so a spec that tears down mid-example can set up again without re-enabling
+  # GET callbacks.
+  def teardown_mock_auth
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth.clear
   end
 
   # Mock a failed OIDC authentication

--- a/apps/web/auth/spec/support/omniauth_test_helper.rb
+++ b/apps/web/auth/spec/support/omniauth_test_helper.rb
@@ -154,6 +154,44 @@ module OmniAuthTestHelper
     )
   end
 
+  # Drive the SSO callback for a mocked IdP assertion and return the response.
+  #
+  # Unauthenticated by default — the plain sign-in path. A caller that needs the
+  # AUTHENTICATED (connect-intent) variant logs in first; the mock and the POST
+  # are the same either way.
+  def sso_callback(email:, uid:, provider: :oidc)
+    setup_mock_auth(email: email, uid: uid, provider: provider)
+    clear_body_headers
+    post "/auth/sso/#{provider}/callback"
+    last_response
+  end
+
+  # Leaves session[:validated_omniauth_domain_id] nil == the PLATFORM path, and
+  # lets a non-tenant callback proceed on platform credentials instead of
+  # redirecting to sso_not_configured.
+  def enable_platform_fallback
+    allow(Onetime.auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
+  end
+
+  # Deep-clone OT.conf before mutating: the stub must not leak the domain list
+  # into the next example through the shared config object.
+  def configure_allowed_domains(domains)
+    config = Marshal.load(Marshal.dump(OT.conf))
+    config['site'] ||= {}
+    config['site']['authentication'] ||= {}
+    config['site']['authentication']['allowed_signup_domains'] = domains
+    allow(OT).to receive(:conf).and_return(config)
+  end
+
+  # Assert the callback bounced to the SPA sign-in page carrying `code`, which
+  # is how every refusal in the OmniAuth callback chain surfaces.
+  def expect_auth_error_redirect(code)
+    expect(last_response.status).to eq(302),
+      "Expected 302 redirect for #{code}, got #{last_response.status}: #{last_response.body}"
+    expect(last_response.location.to_s).to include("/signin?auth_error=#{code}"),
+      "Expected auth_error=#{code} in Location, got: #{last_response.location.inspect}"
+  end
+
   # Leave OmniAuth out of test mode with no mocks registered. Narrower than
   # reset_omniauth_config on purpose: it does not touch allowed_request_methods,
   # so a spec that tears down mid-example can set up again without re-enabling

--- a/apps/web/auth/spec/support/sso_link_flow_helper.rb
+++ b/apps/web/auth/spec/support/sso_link_flow_helper.rb
@@ -1,0 +1,79 @@
+# apps/web/auth/spec/support/sso_link_flow_helper.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# SSO account-linking route drivers (#3840)
+# =============================================================================
+#
+# The two post-callback linking flows, driven the way the SPA drives them:
+#
+#   /auth/link-sso        — Phase 3 signin interstitial: prove the mailbox with
+#                           the account password, then bind.
+#   /auth/sso-link-confirm — Phase 4 mailbox proof: prove it with an emailed
+#                           single-use token instead, for passwordless subjects.
+#
+# WHY SHARED RATHER THAN MIRRORED PER LANE: each of these had a full/ copy and
+# a full_mfa/ copy that were byte-identical, because the ROUTE does not change
+# between the lanes — only the assertions do (full_mfa/ expects the bind to be
+# DEFERRED behind the OTP step). Mirroring the driver bought nothing and meant
+# a route or param rename had to be found in two places. What legitimately
+# differs — the expectations, and the OTP machinery in support/mfa_flow_helper.rb
+# — stays where it is.
+#
+# Included explicitly (`include SsoLinkFlowHelper`) rather than auto-included:
+# these hit specific routes, so only the linking specs should carry them.
+# Request plumbing comes from AuthRequestHelper, which is already auto-included
+# into type: :integration and included by MfaFlowHelper.
+#
+# =============================================================================
+
+module SsoLinkFlowHelper
+  # ==========================================================================
+  # /auth/link-sso — password-proof interstitial
+  # ==========================================================================
+
+  # Pull the challenge token out of a /link-sso/:token redirect Location.
+  # Tolerates a trailing query or fragment.
+  def token_from_location(location)
+    location.to_s.split('/link-sso/').last.to_s.split(/[?#]/).first
+  end
+
+  def post_link_sso(token:, password:)
+    csrf_json_post('/auth/link-sso', token: token, password: password)
+  end
+
+  # ==========================================================================
+  # /auth/sso-link-confirm — mailbox-proof confirmation
+  # ==========================================================================
+
+  # Read the confirmation context the SPA renders before the user commits.
+  def get_confirm(token)
+    clear_body_headers
+    header 'Accept', 'application/json'
+    get "/auth/sso-link-confirm/#{token}"
+    last_response
+  end
+
+  def post_confirm(token:)
+    csrf_json_post('/auth/sso-link-confirm', token: token)
+  end
+
+  # Mint the single-use verification a confirm link carries, skipping the email
+  # round-trip. password_watermark: 0 is the "no password on file" case that the
+  # passwordless subjects in these specs are in; a non-zero value models a
+  # subject whose password changed after the link was issued, which must
+  # invalidate it.
+  def mint_verification(email:, uid:, account_id:, provider: 'oidc',
+                        issuer: 'https://issuer.example.com', sid: nil, password_watermark: 0)
+    Onetime::SsoLinkVerification.issue(
+      provider: provider,
+      issuer: issuer,
+      uid: uid,
+      email: OT::Utils.normalize_email(email),
+      account_id: account_id,
+      sid: sid,
+      password_watermark: password_watermark,
+    )
+  end
+end


### PR DESCRIPTION
Test-suite tidy stacked on Phase 4. No production code touched — every file is under `apps/web/auth/spec/`.

Helpers duplicated across 14 integration specs move into four support modules: `AuthRequestHelper` (CSRF request plumbing, `app`, `csrf_login`), `AccountSeedHelper` (account + Customer seeding), `OmniAuthTestHelper` (mock callback, config stubs, redirect assertion), and a new `SsoLinkFlowHelper` holding the `link-sso` / `sso-link-confirm` route drivers shared by the `full/` and `full_mfa/` lanes. Net −221 lines.

Two notes, both flagged because they are invisible in the diff:

- **A reversed decision, both sides mine.** `6c8b9a855` (four commits back in this stack) added a `MfaFlowHelper` header stating that route driving stays mirrored per spec. This PR deletes that arrangement: the two lane copies were byte-identical, and the routes are the same in both lanes — only the assertions differ — so the drivers now live in `SsoLinkFlowHelper` and the header says so. Recording it because a reader who finds the old header in the log deserves to know it was superseded on purpose.
- **Auto-inclusion needed a guard.** With `app` auto-included for `type: :integration`, an author is no longer forced to think about mounting. A group that never boots would get an empty `Rack::URLMap` and 404 every request, which reads as a broken route rather than a broken harness — so `app` now raises a named error when the registry has no mounts.

Also names two bare `status_id` numbers, one of which was commented "verified status" while inserting Unverified. No coverage was affected (`CreateCustomer` hard-codes `verified: false` and never reads account status) — the comment was simply wrong.

Verified: `spec:integration:full` green (1506 examples, 0 failures, 22 pending) as of the helper sweep; 42 examples / 0 failures across the four specs touched by the last two commits.

Related to #3840. Stacks on #3882.