### PR TITLE
chore(review): scope AI review bots to defects-only feedback

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,4 +21,14 @@ input or state leading to wrong output, data loss, or a security consequence.
 No scenario, no comment. Finding nothing that meets this bar is an acceptable
 review outcome.
 
-See AGENTS.md for repo invariants that must not be reported as defects.
+## Non-blocking observations
+
+Structural or architectural observations that lack a failure scenario may be
+raised as explicitly non-blocking follow-up suggestions — at most two per
+review, clearly marked non-blocking.
+
+## Invariants
+
+See AGENTS.md for repo invariants that must not be reported as defects. Those
+exemptions apply to the current mechanisms only: a PR that modifies the
+mechanism enforcing an invariant puts that invariant in scope for review.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,24 @@
+# Code review instructions
+
+## Do not comment on
+
+- Locale `content_hash` values (missing, stale, or mismatched). CI gates these
+  and `pnpm locales:hashes:apply` regenerates them.
+- Anything rubocop, eslint, or prettier enforces: layout, alignment, quoting,
+  whitespace, argument wrapping. These run in pre-commit and CI.
+- Missing stdlib `require` lines, unless you can name the exact command that
+  fails without them.
+- Typos in comments or docs, unless they invert the meaning.
+- Test file organization or helper placement.
+- Pre-existing code not changed in this PR.
+
+Do not summarize the PR, restate what the diff does, or add praise.
+
+## Threshold
+
+Skip any finding you cannot state as a concrete failure scenario: a specific
+input or state leading to wrong output, data loss, or a security consequence.
+No scenario, no comment. Finding nothing that meets this bar is an acceptable
+review outcome.
+
+See AGENTS.md for repo invariants that must not be reported as defects.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -90,14 +90,21 @@ jobs:
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
+            Review this PR for defects. Report only findings you can state
+            as a concrete failure scenario (specific input or state leading
+            to wrong output, data loss, or a security consequence), with
+            file and line.
 
-            Be constructive and helpful in your feedback.
+            Do not comment on: style or formatting (rubocop/eslint/prettier
+            gate these in CI), locale content_hash values (CI gates these),
+            missing stdlib requires, typos, test file organization, or
+            pre-existing code outside this PR's changes.
+
+            Do not summarize the PR, restate the diff, or praise the code.
+            If nothing meets the bar, say exactly that in one sentence.
+
+            Read AGENTS.md for repo invariants that must not be reported
+            as defects.
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           use_sticky_comment: true

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -104,7 +104,13 @@ jobs:
             If nothing meets the bar, say exactly that in one sentence.
 
             Read AGENTS.md for repo invariants that must not be reported
-            as defects.
+            as defects. Those exemptions cover the current mechanisms only:
+            if this PR modifies the mechanism enforcing an invariant, the
+            invariant is in scope and must be reviewed.
+
+            Structural or architectural observations without a failure
+            scenario may be raised as explicitly non-blocking follow-up
+            suggestions, at most two per review, clearly marked as such.
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           use_sticky_comment: true

--- a/.gitignore
+++ b/.gitignore
@@ -81,10 +81,10 @@ public/branding/*
 
 # Files
 .DS_Store
-AGENTS.md
 CLAUDE.md
 !.oci-build.json
 .github/*md
+!.github/copilot-instructions.md
 .eslintcache
 .rspec*
 .qodo

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,7 @@
+{
+  "strictness": 3,
+  "commentTypes": ["logic"],
+  "summarySection": { "included": false },
+  "issuesTableSection": { "included": false },
+  "confidenceScoreSection": { "included": false }
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,8 @@
+{
+  "files": [
+    {
+      "path": "AGENTS.md",
+      "description": "Repo invariants (transaction boundaries, session key lifecycles, OAuth state handling) that must not be reported as defects unless this PR modifies the mechanism enforcing them."
+    }
+  ]
+}

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,16 @@
+# Review Rules
+
+Skip findings you cannot state as a concrete failure scenario in the changed
+lines. Do not comment on style, naming, formatting, docs wording, test
+organization, or locale content hashes; linters and CI gates cover those. Do
+not flag pre-existing code as introduced by this PR.
+
+If a finding depends on an invariant outside the diff (transaction
+boundaries, session key lifecycles, OAuth state handling), ask a question
+rather than asserting a P1 — unless this PR modifies the mechanism that
+enforces the invariant, in which case the invariant is in scope and must be
+reviewed. See `AGENTS.md` for the invariant list.
+
+Structural or architectural observations that lack a failure scenario may be
+raised as explicitly non-blocking follow-up suggestions, at most two per
+review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+Guidance for coding agents and AI reviewers working in this repo.
+
+## Repo invariants (not defects; do not flag in review)
+
+- Session data is stored under string keys, never symbols. Reads and writes
+  agree on string keys by design.
+- Times are stored in UTC and converted only at the display edge.
+- OAuth connect-intent binding is enforced transitively via the single
+  `session['omniauth.state']` slot (omniauth-oauth2 >= 1.9 rejects mismatched
+  callbacks). Explicit per-intent transaction binding is not required.
+- SessionSidecar stores per-value Redis keys with individual TTLs. Single-use
+  semantics come from short-TTL delete-on-read keys; expiry is not data loss.
+- Issuerless SSO providers (GitHub, Google) are refused on tenant surfaces
+  (`refuse_issuerless_on_tenant?`); identity lookups never match across
+  surfaces on the `(provider, '', uid)` key.
+
+## Replying to review comments
+
+- Every P1 gets a binary disposition before merge: fixed (cite the commit),
+  refuted (one short reply citing the relevant invariant), or ticketed.
+- Refutations are one paragraph max.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,20 @@ Guidance for coding agents and AI reviewers working in this repo.
   (`refuse_issuerless_on_tenant?`); identity lookups never match across
   surfaces on the `(provider, '', uid)` key.
 
+These exemptions describe the *current* mechanisms. A PR that modifies the
+mechanism enforcing an invariant (e.g. the omniauth-oauth2 version or state
+slot handling, SessionSidecar TTL/delete-on-read behavior, the issuerless
+refusal path) puts that invariant in scope: review the change against the
+invariant rather than exempting it.
+
+## Non-blocking observations
+
+Findings without a concrete failure scenario are not defects, but structural
+or architectural observations (extraction candidates, complexity hotspots,
+missing abstractions) may be raised as explicitly non-blocking follow-up
+suggestions — at most two per review, clearly marked non-blocking. The author
+either opens an issue or declines; neither blocks merge.
+
 ## Replying to review comments
 
 - Every P1 gets a binary disposition before merge: fixed (cite the commit),

--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,17 @@
+{
+  "strictness": 3,
+  "commentTypes": ["logic"],
+  "instructions": "Skip findings you cannot state as a concrete failure scenario in the changed lines. Do not comment on style, naming, formatting, docs wording, test organization, or locale content hashes; linters and CI gates cover those. Do not flag pre-existing code as introduced by this PR. If a finding depends on an invariant outside the diff (transaction boundaries, session key lifecycles, OAuth state handling), ask a question rather than asserting a P1. See AGENTS.md for invariants that are not defects.",
+  "customContext": {
+    "rules": [
+      {
+        "id": "oauth-state-binding",
+        "rule": "Do not flag OAuth connect-intent flows as unbound or non-atomic. Binding is enforced transitively through the single session['omniauth.state'] slot; omniauth-oauth2 >= 1.9 rejects callbacks whose state does not match."
+      },
+      {
+        "id": "sidecar-ttl-semantics",
+        "rule": "Do not flag SessionSidecar per-key TTL expiry or delete-on-read as lost session state. Single-use, short-TTL keys are the intended mechanism."
+      }
+    ]
+  }
+}

--- a/greptile.json
+++ b/greptile.json
@@ -1,17 +1,8 @@
 {
   "strictness": 3,
   "commentTypes": ["logic"],
-  "instructions": "Skip findings you cannot state as a concrete failure scenario in the changed lines. Do not comment on style, naming, formatting, docs wording, test organization, or locale content hashes; linters and CI gates cover those. Do not flag pre-existing code as introduced by this PR. If a finding depends on an invariant outside the diff (transaction boundaries, session key lifecycles, OAuth state handling), ask a question rather than asserting a P1. See AGENTS.md for invariants that are not defects.",
-  "customContext": {
-    "rules": [
-      {
-        "id": "oauth-state-binding",
-        "rule": "Do not flag OAuth connect-intent flows as unbound or non-atomic. Binding is enforced transitively through the single session['omniauth.state'] slot; omniauth-oauth2 >= 1.9 rejects callbacks whose state does not match."
-      },
-      {
-        "id": "sidecar-ttl-semantics",
-        "rule": "Do not flag SessionSidecar per-key TTL expiry or delete-on-read as lost session state. Single-use, short-TTL keys are the intended mechanism."
-      }
-    ]
-  }
+  "instructions": "Skip findings you cannot state as a concrete failure scenario in the changed lines. Do not comment on style, naming, formatting, docs wording, test organization, or locale content hashes; linters and CI gates cover those. Do not flag pre-existing code as introduced by this PR. If a finding depends on an invariant outside the diff (transaction boundaries, session key lifecycles, OAuth state handling), ask a question rather than asserting a P1 — unless this PR modifies the mechanism that enforces the invariant, in which case the invariant is in scope and must be reviewed. See AGENTS.md for the invariant list. Structural or architectural observations that lack a failure scenario may be raised as explicitly non-blocking follow-up suggestions, at most two per review.",
+  "summarySection": { "included": false },
+  "issuesTableSection": { "included": false },
+  "confidenceScoreSection": { "included": false }
 }

--- a/greptile.json
+++ b/greptile.json
@@ -1,8 +1,0 @@
-{
-  "strictness": 3,
-  "commentTypes": ["logic"],
-  "instructions": "Skip findings you cannot state as a concrete failure scenario in the changed lines. Do not comment on style, naming, formatting, docs wording, test organization, or locale content hashes; linters and CI gates cover those. Do not flag pre-existing code as introduced by this PR. If a finding depends on an invariant outside the diff (transaction boundaries, session key lifecycles, OAuth state handling), ask a question rather than asserting a P1 — unless this PR modifies the mechanism that enforces the invariant, in which case the invariant is in scope and must be reviewed. See AGENTS.md for the invariant list. Structural or architectural observations that lack a failure scenario may be raised as explicitly non-blocking follow-up suggestions, at most two per review.",
-  "summarySection": { "included": false },
-  "issuesTableSection": { "included": false },
-  "confidenceScoreSection": { "included": false }
-}


### PR DESCRIPTION
Tightens Claude, Copilot, and Greptile bot behavior so they report only concrete failure scenarios rather than style, formatting, or doc nits that linters and CI already gate.

- Adds `AGENTS.md` with repo invariants reviewers must not flag as defects (session key semantics, OAuth state binding, SessionSidecar TTL, issuerless SSO guard)
- Adds `.github/copilot-instructions.md` with equivalent defects-only threshold for Copilot
- Rewrites the `claude-code-review.yml` direct prompt to match the same bar
- Adds `greptile.json` at strictness 3 with logic-only comment type and custom rules for OAuth/sidecar invariants
- Updates `.gitignore` to track `AGENTS.md` and `.github/copilot-instructions.md` (previously excluded)