### PR TITLE
Re-key SetCustomerVerification off bare email onto external_id

### DIFF
--- a/apps/api/colonel/logic/colonel/set_user_verification.rb
+++ b/apps/api/colonel/logic/colonel/set_user_verification.rb
@@ -68,7 +68,7 @@ module ColonelAPI
         rescue Auth::Operations::SetCustomerVerification::AccountNotFound => ex
           raise_not_found("#{ex.message}. Run auth-account reconciliation.")
         rescue Auth::Operations::SetCustomerVerification::AccountClosed => ex
-          raise_form_error("#{ex.message}. Verification cannot be changed on a closed account.")
+          raise_form_error(ex.message)
         end
 
         def success_data

--- a/apps/api/colonel/logic/colonel/set_user_verification.rb
+++ b/apps/api/colonel/logic/colonel/set_user_verification.rb
@@ -67,6 +67,8 @@ module ColonelAPI
           raise_form_error("#{ex.message}. Check AUTH_DATABASE_URL.")
         rescue Auth::Operations::SetCustomerVerification::AccountNotFound => ex
           raise_not_found("#{ex.message}. Run auth-account reconciliation.")
+        rescue Auth::Operations::SetCustomerVerification::AccountClosed => ex
+          raise_form_error("#{ex.message}. Verification cannot be changed on a closed account.")
         end
 
         def success_data

--- a/apps/web/auth/account_statuses.rb
+++ b/apps/web/auth/account_statuses.rb
@@ -1,0 +1,21 @@
+# apps/web/auth/account_statuses.rb
+#
+# frozen_string_literal: true
+
+module Auth
+  # Rodauth account status ids — the single code-side mirror of the
+  # account_statuses reference table seeded in migrations/001_initial.rb.
+  #
+  # LIVE matters beyond readability: the unique index on accounts.email is
+  # PARTIAL (`where status_id in (1, 2)`), so only LIVE rows are covered by
+  # email uniqueness. A Closed row can share a live row's address, which is
+  # why email-keyed queries must constrain on these ids (#3916).
+  module AccountStatuses
+    UNVERIFIED = 1
+    VERIFIED   = 2
+    CLOSED     = 3
+
+    # Statuses covered by the partial unique index on accounts.email.
+    LIVE = [UNVERIFIED, VERIFIED].freeze
+  end
+end

--- a/apps/web/auth/operations/customers/change_email.rb
+++ b/apps/web/auth/operations/customers/change_email.rb
@@ -326,8 +326,9 @@ module Auth
           return :email_taken if others.any? { |row| AccountStatuses::LIVE.include?(row[:status_id]) }
 
           # Only CLOSED holders remain: invisible to the unique index AND to
-          # Customer.email_exists?, so the write WOULD succeed and leave two rows
-          # sharing an address that `where(email:)` callers update in bulk.
+          # Customer.email_exists?, so the write WOULD succeed and leave two
+          # rows sharing an address — the contested state that made email-keyed
+          # verification writes unsafe (#3916).
           return :email_taken unless @allow_closed_account_reuse
 
           @warnings << :new_address_held_by_closed_account
@@ -591,12 +592,17 @@ module Auth
         def reset_verification
           return :skipped unless @require_verification
 
-          # The wrapper's SQL write keys on `where(email:)`
-          # (set_customer_verification.rb:102-106). When a sibling row may share
-          # this address that update moves THAT row too — including a CLOSED (3)
-          # account back to Unverified (1), which resurrects it. Both paths that
-          # knowingly proceed without a clean single-holder answer therefore use
-          # the row-scoped clear instead.
+          # Since #3916 the wrapper's SQL write keys on external_id and only
+          # updates live rows (set_customer_verification.rb,
+          # update_rodauth_account!), so it can no longer move a sibling row
+          # sharing this address — the old resurrection hazard is gone. The
+          # guard remains as a shortcut: one warning confirmed a closed holder,
+          # the other left the SQL state unverified, and either way the wrapper
+          # may raise (AccountNotFound, AccountClosed) where this reset must
+          # still succeed. The rescue below would force-clear after such a
+          # raise anyway; going straight to the row-scoped clear — conditional,
+          # only ever able to REMOVE access from this customer's own row —
+          # skips the failed attempt.
           return force_clear_verification! if sibling_row_possible?
 
           begin
@@ -628,8 +634,10 @@ module Auth
           force_clear_verification!
         end
 
-        # True when a second `accounts` row could share the new address — the only
-        # case where the wrapper's `where(email:)` update is unsafe.
+        # True when a second `accounts` row could share the new address. The
+        # wrapper's external_id-keyed write can no longer touch such a row
+        # (#3916); this predicate now routes those paths straight to the
+        # row-scoped clear — see reset_verification for the rationale.
         def sibling_row_possible?
           @warnings.include?(:new_address_held_by_closed_account) ||
             @warnings.include?(:sql_collision_probe_failed)

--- a/apps/web/auth/operations/customers/change_email.rb
+++ b/apps/web/auth/operations/customers/change_email.rb
@@ -56,9 +56,10 @@ module Auth
       # `where status_id in (1, 2)` (migrations/001_initial.rb:26,32). A CLOSED
       # account (status_id 3) therefore holds an address that is invisible to
       # BOTH the Redis index and the unique constraint. Reusing such an address
-      # is a real hazard, because `SetCustomerVerification#update_rodauth_account!`
-      # keys on `where(email:)` and would then update TWO rows. So a closed-account
-      # holder is treated as `:email_taken` unless the caller explicitly passes
+      # is still ambiguous for any email-keyed lookup (#3916 re-keyed
+      # `SetCustomerVerification#update_rodauth_account!` on external_id for
+      # exactly this reason), so a closed-account holder is treated as
+      # `:email_taken` unless the caller explicitly passes
       # `allow_closed_account_reuse: true`.
       #
       # ## Uniqueness under concurrency: guarded in full mode, one-sided in simple

--- a/apps/web/auth/operations/customers/change_email.rb
+++ b/apps/web/auth/operations/customers/change_email.rb
@@ -7,6 +7,7 @@
 require 'onetime/models/admin_audit_event'
 require 'onetime/jobs/publisher'
 require 'onetime/operations/sessions/revoke_all_for_customer'
+require 'auth/account_statuses'
 require 'auth/operations/customers/set_verification'
 
 module Auth
@@ -133,13 +134,6 @@ module Auth
         include Onetime::LoggerMethods
 
         AUDIT_VERB = 'customer.change_email'
-
-        # Rodauth account statuses (migrations/001_initial.rb:15-19). Only 1 and 2
-        # are covered by the partial unique index on accounts.email.
-        STATUS_UNVERIFIED = 1
-        STATUS_VERIFIED   = 2
-        STATUS_CLOSED     = 3
-        INDEXED_STATUSES  = [STATUS_UNVERIFIED, STATUS_VERIFIED].freeze
 
         # @!attribute status [r]
         #   @return [Symbol] one of:
@@ -329,7 +323,7 @@ module Auth
 
           # A live holder is a hard collision (the partial unique index would
           # reject the UPDATE anyway).
-          return :email_taken if others.any? { |row| INDEXED_STATUSES.include?(row[:status_id]) }
+          return :email_taken if others.any? { |row| AccountStatuses::LIVE.include?(row[:status_id]) }
 
           # Only CLOSED holders remain: invisible to the unique index AND to
           # Customer.email_exists?, so the write WOULD succeed and leave two rows
@@ -681,8 +675,8 @@ module Auth
 
           rows = db.transaction do
             db[:accounts]
-              .where(id: account_id, status_id: STATUS_VERIFIED)
-              .update(status_id: STATUS_UNVERIFIED, updated_at: Sequel::CURRENT_TIMESTAMP)
+              .where(id: account_id, status_id: AccountStatuses::VERIFIED)
+              .update(status_id: AccountStatuses::UNVERIFIED, updated_at: Sequel::CURRENT_TIMESTAMP)
           end
           rows.to_i.positive? ? :cleared : :unchanged
         rescue StandardError => ex
@@ -740,7 +734,7 @@ module Auth
           return false unless account_id
 
           row = db[:accounts].where(id: account_id).select(:status_id).first
-          !row.nil? && row[:status_id] == STATUS_VERIFIED
+          !row.nil? && row[:status_id] == AccountStatuses::VERIFIED
         rescue StandardError => ex
           auth_logger.error '[customer.change_email] verification status probe failed',
             extid: @customer.extid,

--- a/apps/web/auth/operations/customers/set_verification.rb
+++ b/apps/web/auth/operations/customers/set_verification.rb
@@ -30,7 +30,7 @@ module Auth
       # Return value and error classes are passed through unchanged so existing
       # adapters keep their exact control flow:
       #   :success | :no_change  (symbols, same as the underlying op)
-      #   raises SetCustomerVerification::{NoAuthDatabase, AccountNotFound}
+      #   raises SetCustomerVerification::{NoAuthDatabase, AccountNotFound, AccountClosed}
       class SetVerification
         # @param customer [Onetime::Customer] target (caller ensures non-nil,
         #   non-anonymous)
@@ -49,7 +49,8 @@ module Auth
         end
 
         # @return [Symbol] :success or :no_change (passthrough from the inner op)
-        # @raise [SetCustomerVerification::NoAuthDatabase, SetCustomerVerification::AccountNotFound]
+        # @raise [SetCustomerVerification::NoAuthDatabase, SetCustomerVerification::AccountNotFound,
+        #   SetCustomerVerification::AccountClosed]
         def call
           result = Auth::Operations::SetCustomerVerification.new(
             customer: @customer,

--- a/apps/web/auth/operations/set_customer_verification.rb
+++ b/apps/web/auth/operations/set_customer_verification.rb
@@ -40,6 +40,8 @@
 #       Detectable and fixable via `bin/ots customers sync-auth-accounts`.
 #
 
+require 'auth/account_statuses'
+
 module Auth
   module Operations
     class SetCustomerVerification
@@ -48,12 +50,6 @@ module Auth
       class NoAuthDatabase < StandardError; end
       class AccountNotFound < StandardError; end
       class AccountClosed < StandardError; end
-
-      # Rodauth account statuses (mirrors change_email.rb and the
-      # account_statuses reference table in migrations/001_initial.rb).
-      STATUS_UNVERIFIED = 1
-      STATUS_VERIFIED   = 2
-      LIVE_STATUS_IDS   = [STATUS_UNVERIFIED, STATUS_VERIFIED].freeze
 
       # @param customer    [Onetime::Customer] target (caller ensures non-nil,
       #                    non-anonymous)
@@ -116,8 +112,8 @@ module Auth
           raise AccountNotFound, "No Rodauth account for customer #{@customer.extid}" unless scope
 
           scope
-            .where(status_id: LIVE_STATUS_IDS)
-            .update(status_id: @verified ? STATUS_VERIFIED : STATUS_UNVERIFIED,
+            .where(status_id: AccountStatuses::LIVE)
+            .update(status_id: @verified ? AccountStatuses::VERIFIED : AccountStatuses::UNVERIFIED,
               updated_at: Sequel::CURRENT_TIMESTAMP,
             )
         end
@@ -126,7 +122,8 @@ module Auth
         # A row exists but none of it is live: the account is Closed. Refuse —
         # verification only ever moves between Unverified and Verified;
         # resurrecting a Closed account is a different, deliberate operation.
-        raise AccountClosed, "Rodauth account for customer #{@customer.extid} is closed"
+        raise AccountClosed,
+          "Cannot change verification for customer #{@customer.extid}: Rodauth account is closed"
       end
 
       # Locate this customer's accounts row, keyed on external_id — never bare
@@ -138,7 +135,10 @@ module Auth
       #
       # Rows predating the external_id backfill fall back to email, restricted
       # to unlinked rows (external_id IS NULL) — a linked row holding this
-      # address belongs to a different customer.
+      # address belongs to a different customer. The fallback deliberately does
+      # NOT backfill external_id on the row it claims: linking rows to
+      # customers is reconciliation's job (`bin/ots customers
+      # sync-auth-accounts`), not a side effect of a verification toggle.
       #
       # @return [Sequel::Dataset, nil] scope over the customer's row(s), or
       #   nil when no row exists at all

--- a/apps/web/auth/operations/set_customer_verification.rb
+++ b/apps/web/auth/operations/set_customer_verification.rb
@@ -133,12 +133,17 @@ module Auth
       # resurrect the Closed account (one-row case) or trip the partial index
       # mid-statement (two-row case). See #3916.
       #
-      # Rows predating the external_id backfill fall back to email, restricted
-      # to unlinked rows (external_id IS NULL) — a linked row holding this
-      # address belongs to a different customer. The fallback deliberately does
-      # NOT backfill external_id on the row it claims: linking rows to
-      # customers is reconciliation's job (`bin/ots customers
-      # sync-auth-accounts`), not a side effect of a verification toggle.
+      # Unlinked rows (external_id IS NULL) fall back to email. These are not
+      # a mode-migration relic — linking is best-effort: Rodauth commits the
+      # accounts row in its own transaction, then after_create_account links
+      # external_id via a separate UPDATE under safe_execute
+      # (hooks/account.rb), so a failure there leaves a live, unlinked row.
+      # SyncSession heals such rows on next login (link-on-login,
+      # sync_session.rb). The fallback is restricted to unlinked rows because
+      # a LINKED row holding this address belongs to a different customer, and
+      # it deliberately does NOT backfill external_id itself: link-on-login is
+      # the sanctioned healer, and claiming a row by email from a verification
+      # toggle is the same email-keyed guesswork #3916 removed.
       #
       # @return [Sequel::Dataset, nil] scope over the customer's row(s), or
       #   nil when no row exists at all

--- a/apps/web/auth/operations/set_customer_verification.rb
+++ b/apps/web/auth/operations/set_customer_verification.rb
@@ -33,6 +33,7 @@
 #   Failure modes:
 #     - SQL raises  → Redis untouched (clean rollback)
 #     - No SQL row  → AccountNotFound, Redis untouched
+#     - Closed row  → AccountClosed, Redis untouched (see #3916)
 #     - SQL ok, Redis raises → Rodauth fresh, Customer stale.
 #       Auth state (the important one) is correct; display of
 #       Customer#verified? will be wrong until next save.
@@ -46,6 +47,13 @@ module Auth
 
       class NoAuthDatabase < StandardError; end
       class AccountNotFound < StandardError; end
+      class AccountClosed < StandardError; end
+
+      # Rodauth account statuses (mirrors change_email.rb and the
+      # account_statuses reference table in migrations/001_initial.rb).
+      STATUS_UNVERIFIED = 1
+      STATUS_VERIFIED   = 2
+      LIVE_STATUS_IDS   = [STATUS_UNVERIFIED, STATUS_VERIFIED].freeze
 
       # @param customer    [Onetime::Customer] target (caller ensures non-nil,
       #                    non-anonymous)
@@ -70,7 +78,10 @@ module Auth
       # @return [Symbol] :success or :no_change
       # @raise [NoAuthDatabase] full auth mode + DB unreachable
       #   (not raised when rodauth_already_synced: true)
-      # @raise [AccountNotFound] full auth mode + no accounts row for email
+      # @raise [AccountNotFound] full auth mode + no accounts row for the
+      #   customer (not raised when rodauth_already_synced: true)
+      # @raise [AccountClosed] full auth mode + the customer's accounts row
+      #   is Closed; verification only moves between Unverified and Verified
       #   (not raised when rodauth_already_synced: true)
       def call
         return :no_change if @customer.verified? == @verified
@@ -95,18 +106,51 @@ module Auth
         db = @db || Auth::Database.connection
         raise NoAuthDatabase, 'Auth database unreachable' unless db
 
-        # status_id: 1=Unverified, 2=Verified (per Rodauth convention,
-        # mirrors lib/onetime/cli/customers/create_command.rb).
         # Sequel::CURRENT_TIMESTAMP lets the DB own updated_at — matches
         # sync_auth_accounts_command.rb and avoids any client-side TZ drift.
+        # The status_id predicate makes the UPDATE a no-op on a Closed row,
+        # atomically: no read-then-write window in which a concurrent close
+        # could slip through.
         rows = db.transaction do
-          db[:accounts]
-            .where(email: @customer.email)
-            .update(status_id: @verified ? 2 : 1, updated_at: Sequel::CURRENT_TIMESTAMP)
-        end
-        return unless rows.zero?
+          scope = account_scope(db)
+          raise AccountNotFound, "No Rodauth account for customer #{@customer.extid}" unless scope
 
-        raise AccountNotFound, "No Rodauth account for #{@customer.email}"
+          scope
+            .where(status_id: LIVE_STATUS_IDS)
+            .update(status_id: @verified ? STATUS_VERIFIED : STATUS_UNVERIFIED,
+              updated_at: Sequel::CURRENT_TIMESTAMP,
+            )
+        end
+        return if rows.positive?
+
+        # A row exists but none of it is live: the account is Closed. Refuse —
+        # verification only ever moves between Unverified and Verified;
+        # resurrecting a Closed account is a different, deliberate operation.
+        raise AccountClosed, "Rodauth account for customer #{@customer.extid} is closed"
+      end
+
+      # Locate this customer's accounts row, keyed on external_id — never bare
+      # email. The unique index on accounts.email is PARTIAL
+      # (`where status_id in (1, 2)`, migrations/001_initial.rb), so a Closed
+      # row may share a live row's address: a bare-email UPDATE would either
+      # resurrect the Closed account (one-row case) or trip the partial index
+      # mid-statement (two-row case). See #3916.
+      #
+      # Rows predating the external_id backfill fall back to email, restricted
+      # to unlinked rows (external_id IS NULL) — a linked row holding this
+      # address belongs to a different customer.
+      #
+      # @return [Sequel::Dataset, nil] scope over the customer's row(s), or
+      #   nil when no row exists at all
+      def account_scope(db)
+        extid = @customer.extid.to_s
+        unless extid.empty?
+          account_id = db[:accounts].where(external_id: extid).get(:id)
+          return db[:accounts].where(id: account_id) if account_id
+        end
+
+        legacy = db[:accounts].where(email: @customer.email, external_id: nil)
+        legacy.empty? ? nil : legacy
       end
 
       def update_customer!

--- a/apps/web/auth/spec/operations/set_customer_verification_spec.rb
+++ b/apps/web/auth/spec/operations/set_customer_verification_spec.rb
@@ -8,12 +8,16 @@
 # - Idempotency when already in target state
 # - Simple-mode verify/unverify (Redis only)
 # - Full-mode verify/unverify (SQL update + Redis save)
-# - Failure modes: no auth DB, no account row, SQL exception
-# - SQL update always keys off customer.email (not the caller's identifier)
+# - Failure modes: no auth DB, no account row, closed account, SQL exception
+# - SQL update keys on external_id, constrained to live statuses; legacy
+#   NULL-external_id rows fall back to email + live statuses — never bare
+#   email (#3916). Partial-index semantics are exercised for real in
+#   set_customer_verification_sql_spec.rb.
 #
 # Run: pnpm run test:rspec apps/web/auth/spec/operations/set_customer_verification_spec.rb
 
 require 'spec_helper'
+require 'auth/database'
 require 'auth/operations/set_customer_verification'
 
 RSpec.describe Auth::Operations::SetCustomerVerification do
@@ -30,14 +34,26 @@ RSpec.describe Auth::Operations::SetCustomerVerification do
     )
   end
 
-  # Sequel-shaped double: db.transaction yields and returns the block
-  # value; db[:accounts].where(...).update(...) returns the affected
-  # row count.
-  let(:accounts_dataset) { double('accounts_dataset', where: filtered_dataset) }
-  let(:filtered_dataset) { double('filtered_dataset', update: 1) }
+  # Sequel-shaped doubles, one per WHERE filter: the op resolves the row by
+  # external_id, then updates by id constrained to live statuses (1, 2);
+  # legacy rows (NULL external_id) go through the email fallback scope.
+  let(:by_external_id) { double('by_external_id', get: 42) }
+  let(:live_scope)     { double('live_scope', update: 1) }
+  let(:by_id)          { double('by_id', where: live_scope) }
+  let(:legacy_scope)   { double('legacy_scope', empty?: false, where: live_scope) }
+  let(:accounts_dataset) do
+    ds = double('accounts_dataset')
+    allow(ds).to receive(:where) do |cond|
+      if cond.key?(:id)       then by_id
+      elsif cond.key?(:email) then legacy_scope
+      else                         by_external_id
+      end
+    end
+    ds
+  end
   let(:db) do
     db_dbl = double('db', :[] => accounts_dataset)
-    allow(db_dbl).to receive(:transaction).and_yield.and_return(1)
+    allow(db_dbl).to receive(:transaction) { |&blk| blk.call }
     db_dbl
   end
 
@@ -136,8 +152,9 @@ RSpec.describe Auth::Operations::SetCustomerVerification do
 
       expect(op.call).to eq(:success)
       expect(db).to have_received(:transaction)
-      expect(accounts_dataset).to have_received(:where).with(email: 'user@example.com')
-      expect(filtered_dataset).to have_received(:update)
+      expect(accounts_dataset).to have_received(:where).with(external_id: 'ur_test_123')
+      expect(accounts_dataset).to have_received(:where).with(id: 42)
+      expect(live_scope).to have_received(:update)
         .with(hash_including(status_id: 2))
       expect(customer).to have_received(:save)
     end
@@ -153,8 +170,21 @@ RSpec.describe Auth::Operations::SetCustomerVerification do
       )
 
       expect(op.call).to eq(:success)
-      expect(filtered_dataset).to have_received(:update)
+      expect(live_scope).to have_received(:update)
         .with(hash_including(status_id: 1))
+    end
+
+    it 'constrains the UPDATE to live statuses so a Closed row is never touched' do
+      op = described_class.new(
+        customer: customer,
+        verified: true,
+        verified_by: 'cli_provision',
+        db: db,
+      )
+
+      op.call
+      expect(by_id).to have_received(:where)
+        .with(status_id: described_class::LIVE_STATUS_IDS)
     end
 
     it 'falls back to Auth::Database.connection when db: not injected' do
@@ -186,9 +216,9 @@ RSpec.describe Auth::Operations::SetCustomerVerification do
       expect(customer).not_to have_received(:save)
     end
 
-    it 'raises AccountNotFound when SQL update affects 0 rows; Redis untouched' do
-      allow(filtered_dataset).to receive(:update).and_return(0)
-      allow(db).to receive(:transaction).and_yield.and_return(0)
+    it 'raises AccountNotFound when no row matches by external_id or legacy email; Redis untouched' do
+      allow(by_external_id).to receive(:get).and_return(nil)
+      allow(legacy_scope).to receive(:empty?).and_return(true)
 
       op = described_class.new(
         customer: customer,
@@ -199,7 +229,24 @@ RSpec.describe Auth::Operations::SetCustomerVerification do
 
       expect { op.call }.to raise_error(
         described_class::AccountNotFound,
-        /user@example\.com/,
+        /ur_test_123/,
+      )
+      expect(customer).not_to have_received(:save)
+    end
+
+    it 'raises AccountClosed when the row exists but the live-status UPDATE hits 0 rows; Redis untouched' do
+      allow(live_scope).to receive(:update).and_return(0)
+
+      op = described_class.new(
+        customer: customer,
+        verified: true,
+        verified_by: 'cli_provision',
+        db: db,
+      )
+
+      expect { op.call }.to raise_error(
+        described_class::AccountClosed,
+        /ur_test_123/,
       )
       expect(customer).not_to have_received(:save)
     end
@@ -218,12 +265,10 @@ RSpec.describe Auth::Operations::SetCustomerVerification do
       expect(customer).not_to have_received(:save)
     end
 
-    it 'always uses customer.email for SQL WHERE, ignoring how the caller looked the customer up' do
-      # Simulate: caller looked up the customer by extid; the canonical
-      # email lives on the customer record and is the only correct key
-      # for the Rodauth accounts join.
-      allow(customer).to receive(:email).and_return('canonical@example.com')
-
+    it 'keys the SQL WHERE on external_id, never bare email (#3916)' do
+      # A bare-email WHERE would sweep Closed rows sharing the address:
+      # resurrection in the one-row case, a partial-unique-index violation
+      # in the two-row case.
       op = described_class.new(
         customer: customer,
         verified: true,
@@ -232,8 +277,25 @@ RSpec.describe Auth::Operations::SetCustomerVerification do
       )
 
       op.call
+      expect(accounts_dataset).to have_received(:where).with(external_id: 'ur_test_123')
+      expect(accounts_dataset).not_to have_received(:where).with(hash_including(:email))
+    end
+
+    it 'falls back to email + NULL external_id for legacy rows, never bare email' do
+      allow(by_external_id).to receive(:get).and_return(nil)
+
+      op = described_class.new(
+        customer: customer,
+        verified: true,
+        verified_by: 'cli_provision',
+        db: db,
+      )
+
+      expect(op.call).to eq(:success)
       expect(accounts_dataset).to have_received(:where)
-        .with(email: 'canonical@example.com')
+        .with(email: 'user@example.com', external_id: nil)
+      expect(legacy_scope).to have_received(:where)
+        .with(status_id: described_class::LIVE_STATUS_IDS)
     end
   end
 

--- a/apps/web/auth/spec/operations/set_customer_verification_spec.rb
+++ b/apps/web/auth/spec/operations/set_customer_verification_spec.rb
@@ -2,17 +2,21 @@
 #
 # frozen_string_literal: true
 
-# Unit tests for Auth::Operations::SetCustomerVerification.
+# Unit tests for Auth::Operations::SetCustomerVerification CONTROL FLOW:
 #
-# Covers:
 # - Idempotency when already in target state
-# - Simple-mode verify/unverify (Redis only)
-# - Full-mode verify/unverify (SQL update + Redis save)
-# - Failure modes: no auth DB, no account row, closed account, SQL exception
-# - SQL update keys on external_id, constrained to live statuses; legacy
-#   NULL-external_id rows fall back to email + live statuses — never bare
-#   email (#3916). Partial-index semantics are exercised for real in
-#   set_customer_verification_sql_spec.rb.
+# - Simple-mode verify/unverify (Redis only, SQL never touched)
+# - rodauth_already_synced: caller owns the SQL side, op only mirrors Redis
+# - NoAuthDatabase when full mode has no connection
+# - SQL exceptions propagate with Redis untouched
+#
+# Everything that actually touches the accounts table — external_id keying,
+# the live-status constraint, AccountNotFound/AccountClosed, the legacy email
+# fallback, partial-index semantics (#3916) — is covered against a migrated
+# schema in set_customer_verification_sql_spec.rb. Deliberately NO
+# Sequel-shaped dataset doubles here: mocking the query chain only re-states
+# the implementation, so the db double below answers exactly one question —
+# "was a transaction opened?"
 #
 # Run: pnpm run test:rspec apps/web/auth/spec/operations/set_customer_verification_spec.rb
 
@@ -21,8 +25,8 @@ require 'auth/database'
 require 'auth/operations/set_customer_verification'
 
 RSpec.describe Auth::Operations::SetCustomerVerification do
-  # The op only touches scalar fields and the SQL accounts table; the
-  # double exposes just those plus the predicates the op consults.
+  # The op only touches scalar fields; the double exposes just those plus
+  # the predicates the op consults.
   let(:customer) do
     double(
       'Customer',
@@ -35,31 +39,7 @@ RSpec.describe Auth::Operations::SetCustomerVerification do
     )
   end
 
-  # Sequel-shaped doubles, one per WHERE filter: the op resolves the row by
-  # external_id, then updates by id constrained to live statuses (1, 2);
-  # legacy rows (NULL external_id) go through the email fallback scope.
-  let(:by_external_id) { double('by_external_id', get: 42) }
-  let(:live_scope)     { double('live_scope', update: 1) }
-  let(:by_id)          { double('by_id', where: live_scope) }
-  let(:legacy_scope)   { double('legacy_scope', empty?: false, where: live_scope) }
-  let(:accounts_dataset) do
-    ds = double('accounts_dataset')
-    allow(ds).to receive(:where) do |cond|
-      if cond.key?(:id)       then by_id
-      elsif cond.key?(:email) then legacy_scope
-      else                         by_external_id
-      end
-    end
-    ds
-  end
-  let(:db) do
-    db_dbl = double('db', :[] => accounts_dataset)
-    # Explicit block implementation: yields AND returns the block's value,
-    # matching Sequel's transaction semantics (the op reads the returned
-    # rowcount) without leaning on and_yield's return-value behavior.
-    allow(db_dbl).to receive(:transaction) { |&blk| blk.call }
-    db_dbl
-  end
+  let(:db) { double('db', transaction: nil) }
 
   let(:auth_config) { double('AuthConfig', mode: 'simple') }
 
@@ -146,64 +126,6 @@ RSpec.describe Auth::Operations::SetCustomerVerification do
   describe 'full auth mode' do
     before { allow(auth_config).to receive(:mode).and_return('full') }
 
-    it 'verifies: updates SQL status_id=2 then saves Redis' do
-      op = described_class.new(
-        customer: customer,
-        verified: true,
-        verified_by: 'cli_provision',
-        db: db,
-      )
-
-      expect(op.call).to eq(:success)
-      expect(db).to have_received(:transaction)
-      expect(accounts_dataset).to have_received(:where).with(external_id: 'ur_test_123')
-      expect(accounts_dataset).to have_received(:where).with(id: 42)
-      expect(live_scope).to have_received(:update)
-        .with(hash_including(status_id: 2))
-      expect(customer).to have_received(:save)
-    end
-
-    it 'unverifies: updates SQL status_id=1 then saves Redis' do
-      allow(customer).to receive(:verified?).and_return(true)
-
-      op = described_class.new(
-        customer: customer,
-        verified: false,
-        verified_by: nil,
-        db: db,
-      )
-
-      expect(op.call).to eq(:success)
-      expect(live_scope).to have_received(:update)
-        .with(hash_including(status_id: 1))
-    end
-
-    it 'constrains the UPDATE to live statuses so a Closed row is never touched' do
-      op = described_class.new(
-        customer: customer,
-        verified: true,
-        verified_by: 'cli_provision',
-        db: db,
-      )
-
-      op.call
-      expect(by_id).to have_received(:where)
-        .with(status_id: described_class::LIVE_STATUS_IDS)
-    end
-
-    it 'falls back to Auth::Database.connection when db: not injected' do
-      allow(Auth::Database).to receive(:connection).and_return(db)
-
-      op = described_class.new(
-        customer: customer,
-        verified: true,
-        verified_by: 'cli_provision',
-      )
-
-      expect(op.call).to eq(:success)
-      expect(Auth::Database).to have_received(:connection)
-    end
-
     it 'raises NoAuthDatabase when connection is nil; Redis untouched' do
       allow(Auth::Database).to receive(:connection).and_return(nil)
 
@@ -220,41 +142,6 @@ RSpec.describe Auth::Operations::SetCustomerVerification do
       expect(customer).not_to have_received(:save)
     end
 
-    it 'raises AccountNotFound when no row matches by external_id or legacy email; Redis untouched' do
-      allow(by_external_id).to receive(:get).and_return(nil)
-      allow(legacy_scope).to receive(:empty?).and_return(true)
-
-      op = described_class.new(
-        customer: customer,
-        verified: true,
-        verified_by: 'cli_provision',
-        db: db,
-      )
-
-      expect { op.call }.to raise_error(
-        described_class::AccountNotFound,
-        /ur_test_123/,
-      )
-      expect(customer).not_to have_received(:save)
-    end
-
-    it 'raises AccountClosed when the row exists but the live-status UPDATE hits 0 rows; Redis untouched' do
-      allow(live_scope).to receive(:update).and_return(0)
-
-      op = described_class.new(
-        customer: customer,
-        verified: true,
-        verified_by: 'cli_provision',
-        db: db,
-      )
-
-      expect { op.call }.to raise_error(
-        described_class::AccountClosed,
-        /ur_test_123/,
-      )
-      expect(customer).not_to have_received(:save)
-    end
-
     it 'propagates SQL exceptions without touching Redis' do
       allow(db).to receive(:transaction).and_raise(Sequel::DatabaseError, 'boom')
 
@@ -267,39 +154,6 @@ RSpec.describe Auth::Operations::SetCustomerVerification do
 
       expect { op.call }.to raise_error(Sequel::DatabaseError, 'boom')
       expect(customer).not_to have_received(:save)
-    end
-
-    it 'keys the SQL WHERE on external_id, never bare email (#3916)' do
-      # A bare-email WHERE would sweep Closed rows sharing the address:
-      # resurrection in the one-row case, a partial-unique-index violation
-      # in the two-row case.
-      op = described_class.new(
-        customer: customer,
-        verified: true,
-        verified_by: 'cli_provision',
-        db: db,
-      )
-
-      op.call
-      expect(accounts_dataset).to have_received(:where).with(external_id: 'ur_test_123')
-      expect(accounts_dataset).not_to have_received(:where).with(hash_including(:email))
-    end
-
-    it 'falls back to email + NULL external_id for legacy rows, never bare email' do
-      allow(by_external_id).to receive(:get).and_return(nil)
-
-      op = described_class.new(
-        customer: customer,
-        verified: true,
-        verified_by: 'cli_provision',
-        db: db,
-      )
-
-      expect(op.call).to eq(:success)
-      expect(accounts_dataset).to have_received(:where)
-        .with(email: 'user@example.com', external_id: nil)
-      expect(legacy_scope).to have_received(:where)
-        .with(status_id: described_class::LIVE_STATUS_IDS)
     end
   end
 

--- a/apps/web/auth/spec/operations/set_customer_verification_spec.rb
+++ b/apps/web/auth/spec/operations/set_customer_verification_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe Auth::Operations::SetCustomerVerification do
   # The op only touches scalar fields and the SQL accounts table; the
   # double exposes just those plus the predicates the op consults.
   let(:customer) do
-    double('Customer',
+    double(
+      'Customer',
       extid: 'ur_test_123',
       email: 'user@example.com',
       verified?: false,
@@ -53,7 +54,7 @@ RSpec.describe Auth::Operations::SetCustomerVerification do
   end
   let(:db) do
     db_dbl = double('db', :[] => accounts_dataset)
-    allow(db_dbl).to receive(:transaction) { |&blk| blk.call }
+    allow(db_dbl).to receive(:transaction).and_yield
     db_dbl
   end
 

--- a/apps/web/auth/spec/operations/set_customer_verification_spec.rb
+++ b/apps/web/auth/spec/operations/set_customer_verification_spec.rb
@@ -54,7 +54,10 @@ RSpec.describe Auth::Operations::SetCustomerVerification do
   end
   let(:db) do
     db_dbl = double('db', :[] => accounts_dataset)
-    allow(db_dbl).to receive(:transaction).and_yield
+    # Explicit block implementation: yields AND returns the block's value,
+    # matching Sequel's transaction semantics (the op reads the returned
+    # rowcount) without leaning on and_yield's return-value behavior.
+    allow(db_dbl).to receive(:transaction) { |&blk| blk.call }
     db_dbl
   end
 

--- a/apps/web/auth/spec/operations/set_customer_verification_spec.rb
+++ b/apps/web/auth/spec/operations/set_customer_verification_spec.rb
@@ -11,8 +11,8 @@
 # - SQL exceptions propagate with Redis untouched
 #
 # Everything that actually touches the accounts table — external_id keying,
-# the live-status constraint, AccountNotFound/AccountClosed, the legacy email
-# fallback, partial-index semantics (#3916) — is covered against a migrated
+# the live-status constraint, AccountNotFound/AccountClosed, the unlinked-row
+# email fallback, partial-index semantics (#3916) — is covered against a migrated
 # schema in set_customer_verification_sql_spec.rb. Deliberately NO
 # Sequel-shaped dataset doubles here: mocking the query chain only re-states
 # the implementation, so the db double below answers exactly one question —

--- a/apps/web/auth/spec/operations/set_customer_verification_sql_spec.rb
+++ b/apps/web/auth/spec/operations/set_customer_verification_sql_spec.rb
@@ -28,18 +28,18 @@ RSpec.describe Auth::Operations::SetCustomerVerification, 'with a real (migrated
     Sequel::Migrator.run(connection, migrations_dir, use_transactions: true)
     connection
   end
+  let(:auth_config) { double('AuthConfig', mode: 'full') }
 
   after do
     db.disconnect
-    File.delete(test_db_file) if File.exist?(test_db_file)
+    FileUtils.rm_f(test_db_file)
   end
-
-  let(:auth_config) { double('AuthConfig', mode: 'full') }
 
   before { allow(Onetime).to receive(:auth_config).and_return(auth_config) }
 
   def build_customer(extid:, email:)
-    double('Customer',
+    double(
+      'Customer',
       extid: extid,
       email: email,
       verified?: false,

--- a/apps/web/auth/spec/operations/set_customer_verification_sql_spec.rb
+++ b/apps/web/auth/spec/operations/set_customer_verification_sql_spec.rb
@@ -2,17 +2,29 @@
 #
 # frozen_string_literal: true
 
-# Regression coverage for #3916 against a REAL schema. The mock-based spec
-# (set_customer_verification_spec.rb) pins the keying contract; these examples
-# exercise the part mocks cannot: the PARTIAL unique index on accounts.email
-# (`where status_id in (1, 2)`, migrations/001_initial.rb), which lets a
-# Closed row share a live row's address. Before the fix, the op keyed its
-# UPDATE on bare email:
+# Regression coverage for #3916 against a REAL schema, and the home of the
+# op's whole SQL contract: external_id keying, the live-status constraint,
+# the AccountNotFound/AccountClosed taxonomy and the legacy email fallback.
+# (The mock-based sibling spec covers only mode/flag control flow.) The
+# load-bearing piece mocks cannot express is the PARTIAL unique index on
+# accounts.email (`where status_id in (1, 2)`, migrations/001_initial.rb),
+# which lets a Closed row share a live row's address. Before the fix, the op
+# keyed its UPDATE on bare email:
 #   - one row, Closed       -> silent resurrection (3 -> 2)
 #   - Closed + live sibling -> Sequel::UniqueConstraintViolation mid-statement
 #
 # SQLite supports partial indexes, so the migrated schema reproduces both
 # cases without needing the Postgres suite.
+#
+# Schema setup: migrated ONCE per run (before :context), and only through the
+# STRUCTURAL migrations — deliberately stopping before the first data
+# migration. 007_normalize_customer_emails reaches for the live Familia/Redis
+# connection, which a spec process must never touch (shared-state hazard in
+# CI), and no migration after 001 reshapes accounts. Same structural/data
+# split as MigrationTestHelpers#create_partial_migration_state; the target is
+# derived from the data migration's filename so a renumber doesn't rot it
+# (the issuer_migration_version precedent). If a future structural migration
+# lands AFTER the data migrations and alters accounts, revisit the target.
 #
 # Run: pnpm run test:rspec apps/web/auth/spec/operations/set_customer_verification_sql_spec.rb
 
@@ -22,32 +34,44 @@ require 'fileutils'
 require 'securerandom'
 require 'tmpdir'
 
+require 'auth/account_statuses'
+require 'auth/database'
 require 'auth/operations/set_customer_verification'
 
 RSpec.describe Auth::Operations::SetCustomerVerification, 'with a real (migrated) schema' do
-  let(:migrations_dir) { File.join(Onetime::HOME, 'apps', 'web', 'auth', 'migrations') }
-  let(:test_db_file)   { File.join(Dir.tmpdir, "test_auth_#{SecureRandom.hex(4)}.db") }
-  let(:db) do
+  before(:context) do
     Sequel.extension :migration
-    connection = Sequel.connect("sqlite://#{test_db_file}")
-    Sequel::Migrator.run(connection, migrations_dir, use_transactions: true)
-    connection
+
+    migrations_dir = File.join(Onetime::HOME, 'apps', 'web', 'auth', 'migrations')
+    data_migration = Dir.glob(File.join(migrations_dir, '[0-9]*_normalize_customer_emails.rb')).first
+    raise 'normalize_customer_emails data migration not found — update this spec' unless data_migration
+
+    structural_target = File.basename(data_migration)[/\A\d+/].to_i - 1
+
+    @db_file = File.join(Dir.tmpdir, "test_auth_#{SecureRandom.hex(4)}.db")
+    @db      = Sequel.connect("sqlite://#{@db_file}")
+    Sequel::Migrator.run(@db, migrations_dir, target: structural_target, use_transactions: true)
   end
+
+  after(:context) do
+    @db.disconnect
+    FileUtils.rm_f(@db_file)
+  end
+
+  let(:db)          { @db }
   let(:auth_config) { double('AuthConfig', mode: 'full') }
 
-  after do
-    db.disconnect
-    FileUtils.rm_f(test_db_file)
+  before do
+    allow(Onetime).to receive(:auth_config).and_return(auth_config)
+    db[:accounts].delete
   end
 
-  before { allow(Onetime).to receive(:auth_config).and_return(auth_config) }
-
-  def build_customer(extid:, email:)
+  def build_customer(extid:, email:, verified: false)
     double(
       'Customer',
       extid: extid,
       email: email,
-      verified?: false,
+      verified?: verified,
       :verified= => nil,
       :verified_by= => nil,
       save: true,
@@ -58,86 +82,130 @@ RSpec.describe Auth::Operations::SetCustomerVerification, 'with a real (migrated
     db[:accounts].insert(email: email, status_id: status_id, external_id: external_id)
   end
 
-  def verify!(customer)
+  def set_verification!(customer, verified:)
     described_class.new(
       customer: customer,
-      verified: true,
-      verified_by: 'cli_provision',
+      verified: verified,
+      verified_by: verified ? 'cli_provision' : nil,
       db: db,
     ).call
   end
 
+  def verify!(customer)
+    set_verification!(customer, verified: true)
+  end
+
+  describe 'happy path on an external_id-linked row' do
+    it 'verify moves Unverified -> Verified and saves the Customer mirror' do
+      id       = insert_account(email: 'up@example.com', status_id: Auth::AccountStatuses::UNVERIFIED, external_id: 'ur_up')
+      customer = build_customer(extid: 'ur_up', email: 'up@example.com')
+
+      expect(verify!(customer)).to eq(:success)
+      expect(db[:accounts].where(id: id).get(:status_id)).to eq(Auth::AccountStatuses::VERIFIED)
+      expect(customer).to have_received(:save)
+    end
+
+    it 'unverify moves Verified -> Unverified' do
+      id       = insert_account(email: 'down@example.com', status_id: Auth::AccountStatuses::VERIFIED, external_id: 'ur_down')
+      customer = build_customer(extid: 'ur_down', email: 'down@example.com', verified: true)
+
+      expect(set_verification!(customer, verified: false)).to eq(:success)
+      expect(db[:accounts].where(id: id).get(:status_id)).to eq(Auth::AccountStatuses::UNVERIFIED)
+    end
+
+    it 'falls back to Auth::Database.connection when db: is not injected' do
+      allow(Auth::Database).to receive(:connection).and_return(db)
+      id       = insert_account(email: 'conn@example.com', status_id: Auth::AccountStatuses::UNVERIFIED, external_id: 'ur_conn')
+      customer = build_customer(extid: 'ur_conn', email: 'conn@example.com')
+
+      result = described_class.new(
+        customer: customer,
+        verified: true,
+        verified_by: 'cli_provision',
+      ).call
+
+      expect(result).to eq(:success)
+      expect(db[:accounts].where(id: id).get(:status_id)).to eq(Auth::AccountStatuses::VERIFIED)
+    end
+  end
+
   describe 'one-row case: Closed account, no live sibling' do
     it 'refuses to resurrect: raises AccountClosed and leaves status_id=3' do
-      id       = insert_account(email: 'gone@example.com', status_id: 3, external_id: 'ur_gone')
+      id       = insert_account(email: 'gone@example.com', status_id: Auth::AccountStatuses::CLOSED, external_id: 'ur_gone')
       customer = build_customer(extid: 'ur_gone', email: 'gone@example.com')
 
-      expect { verify!(customer) }.to raise_error(described_class::AccountClosed)
-      expect(db[:accounts].where(id: id).get(:status_id)).to eq(3)
+      expect { verify!(customer) }.to raise_error(described_class::AccountClosed, /ur_gone/)
+      expect(db[:accounts].where(id: id).get(:status_id)).to eq(Auth::AccountStatuses::CLOSED)
       expect(customer).not_to have_received(:save)
     end
   end
 
   describe "two-row case: Closed row shares a live row's address" do
-    let!(:live_id)   { insert_account(email: 'shared@example.com', status_id: 1, external_id: 'ur_live') }
-    let!(:closed_id) { insert_account(email: 'shared@example.com', status_id: 3, external_id: 'ur_gone') }
+    let!(:live_id) do
+      insert_account(email: 'shared@example.com', status_id: Auth::AccountStatuses::UNVERIFIED, external_id: 'ur_live')
+    end
+    let!(:closed_id) do
+      insert_account(email: 'shared@example.com', status_id: Auth::AccountStatuses::CLOSED, external_id: 'ur_gone')
+    end
 
     it 'verifying the live customer touches only the live row' do
       customer = build_customer(extid: 'ur_live', email: 'shared@example.com')
 
       expect(verify!(customer)).to eq(:success)
-      expect(db[:accounts].where(id: live_id).get(:status_id)).to eq(2)
-      expect(db[:accounts].where(id: closed_id).get(:status_id)).to eq(3)
+      expect(db[:accounts].where(id: live_id).get(:status_id)).to eq(Auth::AccountStatuses::VERIFIED)
+      expect(db[:accounts].where(id: closed_id).get(:status_id)).to eq(Auth::AccountStatuses::CLOSED)
     end
 
     it 'verifying the closed customer raises AccountClosed, not UniqueConstraintViolation' do
       customer = build_customer(extid: 'ur_gone', email: 'shared@example.com')
 
       expect { verify!(customer) }.to raise_error(described_class::AccountClosed)
-      expect(db[:accounts].where(id: live_id).get(:status_id)).to eq(1)
-      expect(db[:accounts].where(id: closed_id).get(:status_id)).to eq(3)
+      expect(db[:accounts].where(id: live_id).get(:status_id)).to eq(Auth::AccountStatuses::UNVERIFIED)
+      expect(db[:accounts].where(id: closed_id).get(:status_id)).to eq(Auth::AccountStatuses::CLOSED)
     end
   end
 
   describe 'legacy rows (NULL external_id)' do
     it 'verifies via the email fallback' do
-      id       = insert_account(email: 'legacy@example.com', status_id: 1)
+      id       = insert_account(email: 'legacy@example.com', status_id: Auth::AccountStatuses::UNVERIFIED)
       customer = build_customer(extid: 'ur_legacy', email: 'legacy@example.com')
 
       expect(verify!(customer)).to eq(:success)
-      expect(db[:accounts].where(id: id).get(:status_id)).to eq(2)
+      expect(db[:accounts].where(id: id).get(:status_id)).to eq(Auth::AccountStatuses::VERIFIED)
     end
 
     it 'updates only the live row, never a Closed sibling' do
-      closed_id = insert_account(email: 'legacy2@example.com', status_id: 3)
-      live_id   = insert_account(email: 'legacy2@example.com', status_id: 1)
+      closed_id = insert_account(email: 'legacy2@example.com', status_id: Auth::AccountStatuses::CLOSED)
+      live_id   = insert_account(email: 'legacy2@example.com', status_id: Auth::AccountStatuses::UNVERIFIED)
       customer  = build_customer(extid: 'ur_legacy2', email: 'legacy2@example.com')
 
       expect(verify!(customer)).to eq(:success)
-      expect(db[:accounts].where(id: live_id).get(:status_id)).to eq(2)
-      expect(db[:accounts].where(id: closed_id).get(:status_id)).to eq(3)
+      expect(db[:accounts].where(id: live_id).get(:status_id)).to eq(Auth::AccountStatuses::VERIFIED)
+      expect(db[:accounts].where(id: closed_id).get(:status_id)).to eq(Auth::AccountStatuses::CLOSED)
     end
 
     it 'never claims a row linked to a different customer' do
-      other_id = insert_account(email: 'taken@example.com', status_id: 1, external_id: 'ur_other')
+      other_id = insert_account(email: 'taken@example.com', status_id: Auth::AccountStatuses::UNVERIFIED, external_id: 'ur_other')
       customer = build_customer(extid: 'ur_me', email: 'taken@example.com')
 
-      expect { verify!(customer) }.to raise_error(described_class::AccountNotFound)
-      expect(db[:accounts].where(id: other_id).get(:status_id)).to eq(1)
+      expect { verify!(customer) }.to raise_error(described_class::AccountNotFound, /ur_me/)
+      expect(db[:accounts].where(id: other_id).get(:status_id)).to eq(Auth::AccountStatuses::UNVERIFIED)
+      expect(customer).not_to have_received(:save)
     end
 
     it 'raises AccountClosed when only a Closed legacy row holds the address' do
-      id       = insert_account(email: 'legacy3@example.com', status_id: 3)
+      id       = insert_account(email: 'legacy3@example.com', status_id: Auth::AccountStatuses::CLOSED)
       customer = build_customer(extid: 'ur_legacy3', email: 'legacy3@example.com')
 
       expect { verify!(customer) }.to raise_error(described_class::AccountClosed)
-      expect(db[:accounts].where(id: id).get(:status_id)).to eq(3)
+      expect(db[:accounts].where(id: id).get(:status_id)).to eq(Auth::AccountStatuses::CLOSED)
     end
   end
 
   it 'raises AccountNotFound when no row exists at all' do
     customer = build_customer(extid: 'ur_none', email: 'none@example.com')
 
-    expect { verify!(customer) }.to raise_error(described_class::AccountNotFound)
+    expect { verify!(customer) }.to raise_error(described_class::AccountNotFound, /ur_none/)
+    expect(customer).not_to have_received(:save)
   end
 end

--- a/apps/web/auth/spec/operations/set_customer_verification_sql_spec.rb
+++ b/apps/web/auth/spec/operations/set_customer_verification_sql_spec.rb
@@ -17,6 +17,11 @@
 # Run: pnpm run test:rspec apps/web/auth/spec/operations/set_customer_verification_sql_spec.rb
 
 require 'spec_helper'
+
+require 'fileutils'
+require 'securerandom'
+require 'tmpdir'
+
 require 'auth/operations/set_customer_verification'
 
 RSpec.describe Auth::Operations::SetCustomerVerification, 'with a real (migrated) schema' do

--- a/apps/web/auth/spec/operations/set_customer_verification_sql_spec.rb
+++ b/apps/web/auth/spec/operations/set_customer_verification_sql_spec.rb
@@ -1,0 +1,138 @@
+# apps/web/auth/spec/operations/set_customer_verification_sql_spec.rb
+#
+# frozen_string_literal: true
+
+# Regression coverage for #3916 against a REAL schema. The mock-based spec
+# (set_customer_verification_spec.rb) pins the keying contract; these examples
+# exercise the part mocks cannot: the PARTIAL unique index on accounts.email
+# (`where status_id in (1, 2)`, migrations/001_initial.rb), which lets a
+# Closed row share a live row's address. Before the fix, the op keyed its
+# UPDATE on bare email:
+#   - one row, Closed       -> silent resurrection (3 -> 2)
+#   - Closed + live sibling -> Sequel::UniqueConstraintViolation mid-statement
+#
+# SQLite supports partial indexes, so the migrated schema reproduces both
+# cases without needing the Postgres suite.
+#
+# Run: pnpm run test:rspec apps/web/auth/spec/operations/set_customer_verification_sql_spec.rb
+
+require 'spec_helper'
+require 'auth/operations/set_customer_verification'
+
+RSpec.describe Auth::Operations::SetCustomerVerification, 'with a real (migrated) schema' do
+  let(:migrations_dir) { File.join(Onetime::HOME, 'apps', 'web', 'auth', 'migrations') }
+  let(:test_db_file)   { File.join(Dir.tmpdir, "test_auth_#{SecureRandom.hex(4)}.db") }
+  let(:db) do
+    Sequel.extension :migration
+    connection = Sequel.connect("sqlite://#{test_db_file}")
+    Sequel::Migrator.run(connection, migrations_dir, use_transactions: true)
+    connection
+  end
+
+  after do
+    db.disconnect
+    File.delete(test_db_file) if File.exist?(test_db_file)
+  end
+
+  let(:auth_config) { double('AuthConfig', mode: 'full') }
+
+  before { allow(Onetime).to receive(:auth_config).and_return(auth_config) }
+
+  def build_customer(extid:, email:)
+    double('Customer',
+      extid: extid,
+      email: email,
+      verified?: false,
+      :verified= => nil,
+      :verified_by= => nil,
+      save: true,
+    )
+  end
+
+  def insert_account(email:, status_id:, external_id: nil)
+    db[:accounts].insert(email: email, status_id: status_id, external_id: external_id)
+  end
+
+  def verify!(customer)
+    described_class.new(
+      customer: customer,
+      verified: true,
+      verified_by: 'cli_provision',
+      db: db,
+    ).call
+  end
+
+  describe 'one-row case: Closed account, no live sibling' do
+    it 'refuses to resurrect: raises AccountClosed and leaves status_id=3' do
+      id       = insert_account(email: 'gone@example.com', status_id: 3, external_id: 'ur_gone')
+      customer = build_customer(extid: 'ur_gone', email: 'gone@example.com')
+
+      expect { verify!(customer) }.to raise_error(described_class::AccountClosed)
+      expect(db[:accounts].where(id: id).get(:status_id)).to eq(3)
+      expect(customer).not_to have_received(:save)
+    end
+  end
+
+  describe "two-row case: Closed row shares a live row's address" do
+    let!(:live_id)   { insert_account(email: 'shared@example.com', status_id: 1, external_id: 'ur_live') }
+    let!(:closed_id) { insert_account(email: 'shared@example.com', status_id: 3, external_id: 'ur_gone') }
+
+    it 'verifying the live customer touches only the live row' do
+      customer = build_customer(extid: 'ur_live', email: 'shared@example.com')
+
+      expect(verify!(customer)).to eq(:success)
+      expect(db[:accounts].where(id: live_id).get(:status_id)).to eq(2)
+      expect(db[:accounts].where(id: closed_id).get(:status_id)).to eq(3)
+    end
+
+    it 'verifying the closed customer raises AccountClosed, not UniqueConstraintViolation' do
+      customer = build_customer(extid: 'ur_gone', email: 'shared@example.com')
+
+      expect { verify!(customer) }.to raise_error(described_class::AccountClosed)
+      expect(db[:accounts].where(id: live_id).get(:status_id)).to eq(1)
+      expect(db[:accounts].where(id: closed_id).get(:status_id)).to eq(3)
+    end
+  end
+
+  describe 'legacy rows (NULL external_id)' do
+    it 'verifies via the email fallback' do
+      id       = insert_account(email: 'legacy@example.com', status_id: 1)
+      customer = build_customer(extid: 'ur_legacy', email: 'legacy@example.com')
+
+      expect(verify!(customer)).to eq(:success)
+      expect(db[:accounts].where(id: id).get(:status_id)).to eq(2)
+    end
+
+    it 'updates only the live row, never a Closed sibling' do
+      closed_id = insert_account(email: 'legacy2@example.com', status_id: 3)
+      live_id   = insert_account(email: 'legacy2@example.com', status_id: 1)
+      customer  = build_customer(extid: 'ur_legacy2', email: 'legacy2@example.com')
+
+      expect(verify!(customer)).to eq(:success)
+      expect(db[:accounts].where(id: live_id).get(:status_id)).to eq(2)
+      expect(db[:accounts].where(id: closed_id).get(:status_id)).to eq(3)
+    end
+
+    it 'never claims a row linked to a different customer' do
+      other_id = insert_account(email: 'taken@example.com', status_id: 1, external_id: 'ur_other')
+      customer = build_customer(extid: 'ur_me', email: 'taken@example.com')
+
+      expect { verify!(customer) }.to raise_error(described_class::AccountNotFound)
+      expect(db[:accounts].where(id: other_id).get(:status_id)).to eq(1)
+    end
+
+    it 'raises AccountClosed when only a Closed legacy row holds the address' do
+      id       = insert_account(email: 'legacy3@example.com', status_id: 3)
+      customer = build_customer(extid: 'ur_legacy3', email: 'legacy3@example.com')
+
+      expect { verify!(customer) }.to raise_error(described_class::AccountClosed)
+      expect(db[:accounts].where(id: id).get(:status_id)).to eq(3)
+    end
+  end
+
+  it 'raises AccountNotFound when no row exists at all' do
+    customer = build_customer(extid: 'ur_none', email: 'none@example.com')
+
+    expect { verify!(customer) }.to raise_error(described_class::AccountNotFound)
+  end
+end

--- a/apps/web/auth/spec/operations/set_customer_verification_sql_spec.rb
+++ b/apps/web/auth/spec/operations/set_customer_verification_sql_spec.rb
@@ -4,7 +4,7 @@
 
 # Regression coverage for #3916 against a REAL schema, and the home of the
 # op's whole SQL contract: external_id keying, the live-status constraint,
-# the AccountNotFound/AccountClosed taxonomy and the legacy email fallback.
+# the AccountNotFound/AccountClosed taxonomy and the unlinked-row email fallback.
 # (The mock-based sibling spec covers only mode/flag control flow.) The
 # load-bearing piece mocks cannot express is the PARTIAL unique index on
 # accounts.email (`where status_id in (1, 2)`, migrations/001_initial.rb),
@@ -165,19 +165,19 @@ RSpec.describe Auth::Operations::SetCustomerVerification, 'with a real (migrated
     end
   end
 
-  describe 'legacy rows (NULL external_id)' do
+  describe 'unlinked rows (NULL external_id)' do
     it 'verifies via the email fallback' do
-      id       = insert_account(email: 'legacy@example.com', status_id: Auth::AccountStatuses::UNVERIFIED)
-      customer = build_customer(extid: 'ur_legacy', email: 'legacy@example.com')
+      id       = insert_account(email: 'unlinked@example.com', status_id: Auth::AccountStatuses::UNVERIFIED)
+      customer = build_customer(extid: 'ur_unlinked', email: 'unlinked@example.com')
 
       expect(verify!(customer)).to eq(:success)
       expect(db[:accounts].where(id: id).get(:status_id)).to eq(Auth::AccountStatuses::VERIFIED)
     end
 
     it 'updates only the live row, never a Closed sibling' do
-      closed_id = insert_account(email: 'legacy2@example.com', status_id: Auth::AccountStatuses::CLOSED)
-      live_id   = insert_account(email: 'legacy2@example.com', status_id: Auth::AccountStatuses::UNVERIFIED)
-      customer  = build_customer(extid: 'ur_legacy2', email: 'legacy2@example.com')
+      closed_id = insert_account(email: 'unlinked2@example.com', status_id: Auth::AccountStatuses::CLOSED)
+      live_id   = insert_account(email: 'unlinked2@example.com', status_id: Auth::AccountStatuses::UNVERIFIED)
+      customer  = build_customer(extid: 'ur_unlinked2', email: 'unlinked2@example.com')
 
       expect(verify!(customer)).to eq(:success)
       expect(db[:accounts].where(id: live_id).get(:status_id)).to eq(Auth::AccountStatuses::VERIFIED)
@@ -193,9 +193,9 @@ RSpec.describe Auth::Operations::SetCustomerVerification, 'with a real (migrated
       expect(customer).not_to have_received(:save)
     end
 
-    it 'raises AccountClosed when only a Closed legacy row holds the address' do
-      id       = insert_account(email: 'legacy3@example.com', status_id: Auth::AccountStatuses::CLOSED)
-      customer = build_customer(extid: 'ur_legacy3', email: 'legacy3@example.com')
+    it 'raises AccountClosed when only a Closed unlinked row holds the address' do
+      id       = insert_account(email: 'unlinked3@example.com', status_id: Auth::AccountStatuses::CLOSED)
+      customer = build_customer(extid: 'ur_unlinked3', email: 'unlinked3@example.com')
 
       expect { verify!(customer) }.to raise_error(described_class::AccountClosed)
       expect(db[:accounts].where(id: id).get(:status_id)).to eq(Auth::AccountStatuses::CLOSED)

--- a/changelog.d/20260726_061407_claude_3916_verification_email_keying.rst
+++ b/changelog.d/20260726_061407_claude_3916_verification_email_keying.rst
@@ -11,9 +11,9 @@ Security
   then silently resurrect a Closed account (status 3 → 2) when no live sibling
   existed, or die with an unhandled ``Sequel::UniqueConstraintViolation`` when
   one did — leaving that customer permanently un-verifiable through every admin
-  surface. The update is now keyed on the ``external_id``-linked row (legacy
-  rows without an ``external_id`` fall back to email restricted to live,
-  unlinked rows), constrained to live statuses so a Closed row is never
+  surface. The update is now keyed on the ``external_id``-linked row (rows
+  left unlinked by a failed signup-time link fall back to email restricted to
+  live, unlinked rows), constrained to live statuses so a Closed row is never
   touched, and a new ``AccountClosed`` error is reported cleanly by the CLI and
   colonel surfaces instead of a stack trace. The self-service Rodauth
   ``after_verify_account`` path was never affected. (#3916)

--- a/changelog.d/20260726_061407_claude_3916_verification_email_keying.rst
+++ b/changelog.d/20260726_061407_claude_3916_verification_email_keying.rst
@@ -1,0 +1,19 @@
+.. A new scriv changelog fragment.
+
+Security
+--------
+
+- Re-keyed admin verification updates off bare email. In full authentication
+  mode, ``SetCustomerVerification`` updated the Rodauth ``accounts`` row with
+  ``WHERE email = ?``, but the unique index on ``accounts.email`` is partial
+  (``status_id IN (1, 2)``), so a Closed account can share a live row's
+  address. A plain ``bin/ots customers verify`` (or the colonel endpoint) would
+  then silently resurrect a Closed account (status 3 → 2) when no live sibling
+  existed, or die with an unhandled ``Sequel::UniqueConstraintViolation`` when
+  one did — leaving that customer permanently un-verifiable through every admin
+  surface. The update is now keyed on the ``external_id``-linked row (legacy
+  rows without an ``external_id`` fall back to email restricted to live,
+  unlinked rows), constrained to live statuses so a Closed row is never
+  touched, and a new ``AccountClosed`` error is reported cleanly by the CLI and
+  colonel surfaces instead of a stack trace. The self-service Rodauth
+  ``after_verify_account`` path was never affected. (#3916)

--- a/lib/onetime/cli/customers/unverify_command.rb
+++ b/lib/onetime/cli/customers/unverify_command.rb
@@ -84,7 +84,7 @@ module Onetime
              'Run `bin/ots customers sync-auth-accounts` to reconcile.'
         exit 1
       rescue Auth::Operations::SetCustomerVerification::AccountClosed => ex
-        puts "Error: #{ex.message}. Verification cannot be changed on a closed account."
+        puts "Error: #{ex.message}"
         exit 1
       end
     end

--- a/lib/onetime/cli/customers/unverify_command.rb
+++ b/lib/onetime/cli/customers/unverify_command.rb
@@ -83,6 +83,9 @@ module Onetime
         puts "Error: #{ex.message}. " \
              'Run `bin/ots customers sync-auth-accounts` to reconcile.'
         exit 1
+      rescue Auth::Operations::SetCustomerVerification::AccountClosed => ex
+        puts "Error: #{ex.message}. Verification cannot be changed on a closed account."
+        exit 1
       end
     end
 

--- a/lib/onetime/cli/customers/verify_command.rb
+++ b/lib/onetime/cli/customers/verify_command.rb
@@ -88,7 +88,7 @@ module Onetime
              'Run `bin/ots customers sync-auth-accounts` to reconcile.'
         exit 1
       rescue Auth::Operations::SetCustomerVerification::AccountClosed => ex
-        puts "Error: #{ex.message}. Verification cannot be changed on a closed account."
+        puts "Error: #{ex.message}"
         exit 1
       end
     end

--- a/lib/onetime/cli/customers/verify_command.rb
+++ b/lib/onetime/cli/customers/verify_command.rb
@@ -87,6 +87,9 @@ module Onetime
         puts "Error: #{ex.message}. " \
              'Run `bin/ots customers sync-auth-accounts` to reconcile.'
         exit 1
+      rescue Auth::Operations::SetCustomerVerification::AccountClosed => ex
+        puts "Error: #{ex.message}. Verification cannot be changed on a closed account."
+        exit 1
       end
     end
 

--- a/spec/cli/customers_command_spec.rb
+++ b/spec/cli/customers_command_spec.rb
@@ -164,6 +164,22 @@ RSpec.describe 'Customers Command', type: :cli do
       expect(output[:stdout]).to include('sync-auth-accounts')
       expect(last_exit_code).to eq(1)
     end
+
+    it 'translates AccountClosed to a plain error and exits 1' do
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email)
+        .and_return(target_customer)
+      allow(Auth::Operations::SetCustomerVerification).to receive(:new)
+        .and_return(verification_op)
+      allow(verification_op).to receive(:call).and_raise(
+        Auth::Operations::SetCustomerVerification::AccountClosed,
+        'Cannot change verification for customer cust_ext_target: Rodauth account is closed',
+      )
+
+      output = run_cli_command_quietly('customers', 'verify', 'target@example.com')
+      expect(output[:stdout]).to include('Rodauth account is closed')
+      expect(output[:stdout]).not_to include('sync-auth-accounts')
+      expect(last_exit_code).to eq(1)
+    end
   end
 
   describe 'unverify subcommand' do
@@ -197,6 +213,22 @@ RSpec.describe 'Customers Command', type: :cli do
 
       output = run_cli_command_quietly('customers', 'unverify', 'missing@example.com')
       expect(output[:stdout]).to include('Customer not found')
+      expect(last_exit_code).to eq(1)
+    end
+
+    it 'translates AccountClosed to a plain error and exits 1' do
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email)
+        .and_return(target_customer)
+      allow(Auth::Operations::SetCustomerVerification).to receive(:new)
+        .and_return(verification_op)
+      allow(verification_op).to receive(:call).and_raise(
+        Auth::Operations::SetCustomerVerification::AccountClosed,
+        'Cannot change verification for customer cust_ext_target: Rodauth account is closed',
+      )
+
+      output = run_cli_command_quietly('customers', 'unverify', 'target@example.com')
+      expect(output[:stdout]).to include('Rodauth account is closed')
+      expect(output[:stdout]).not_to include('sync-auth-accounts')
       expect(last_exit_code).to eq(1)
     end
   end


### PR DESCRIPTION
Keys the verification UPDATE on `external_id` (falling back to email for
unlinked legacy rows) instead of bare email. The accounts.email index is
partial (`status_id in (1,2)`), so a Closed row can share a live row's
address — a bare-email UPDATE could silently resurrect a Closed account or
raise `Sequel::UniqueConstraintViolation` mid-statement when both rows
exist.

Adds `AccountClosed` when no live row is found for the customer, and makes
the status transition atomic (predicate in the UPDATE, no read-then-write
window). Includes a new SQL-backed spec exercising the partial index against
a real SQLite schema, alongside the existing mock-based spec.

Closes #3916
