### PR TITLE
Email-change follow-ups: landed-partial completion, index-claim release

### DIFF
--- a/apps/api/account/logic/account/confirm_email_change.rb
+++ b/apps/api/account/logic/account/confirm_email_change.rb
@@ -84,14 +84,21 @@ module AccountAPI::Logic
           notify: true,
         ).call
 
-        handle_result_status(@change_result)
-
         # ADAPTER-OWNED, by construction: the operation deletes every STORED
         # session blob, but the current request's in-memory Rack session is
         # written back by the session middleware after this call returns — which
         # would re-create the blob that was just revoked. The op has no request
         # context, so this cannot move into it.
-        sess.clear if sess
+        #
+        # Runs BEFORE the status mapping: a `:partial` whose swap LANDED
+        # (`:secondary_writes_incomplete` — both authoritative stores hold the new
+        # address) revokes sessions too, and the mapping below raises on
+        # `:partial`. Clearing only on the paths that return would leave the one
+        # session blob the revocation exists to kill alive on exactly the messy
+        # path.
+        clear_current_session(@change_result)
+
+        handle_result_status(@change_result)
 
         OT.info "[confirm-email-change] Email change confirmed cid/#{@owner.objid} " \
                 "status/#{@change_result.status} new/#{OT::Utils.obscure_email(new_email)} " \
@@ -105,6 +112,26 @@ module AccountAPI::Logic
       end
 
       private
+
+      # Drop the current request's session, but ONLY once the address has
+      # actually changed hands — on `:email_taken` and the system-error statuses
+      # nothing moved and signing the caller out would be gratuitous.
+      def clear_current_session(result)
+        return unless sess
+        return unless swap_landed?(result)
+
+        sess.clear
+      end
+
+      # `:no_change` counts: the account already holds the address, the
+      # redemption is idempotent, and this surface still sends the caller to
+      # /signin. `:partial` counts only in the sub-case where the Customer hash
+      # committed — the other sub-case rolled the accounts row back.
+      def swap_landed?(result)
+        return true if [:success, :no_change].include?(result.status)
+
+        result.status == :partial && result.warnings.include?(:secondary_writes_incomplete)
+      end
 
       # Map the operation's status vocabulary onto this surface's form errors.
       # Messages and error_types are preserved verbatim from the pre-extraction
@@ -128,6 +155,9 @@ module AccountAPI::Logic
         # :partial — SQL committed, the Redis side did not complete. The op has
         # already recorded the audit event and compensated where it safely
         # could; `customers doctor --check auth_email_drift` is the remediation.
+        # Where the swap LANDED the op also revoked sessions and mailed both
+        # addresses, and `clear_current_session` has already dropped this one —
+        # so the caller is signed out even though this reports an error.
         #
         # `:verification_not_reset` cannot reach this branch: it is only produced
         # when `require_verification: true`, and this adapter always passes false

--- a/apps/api/account/logic/account/confirm_email_change.rb
+++ b/apps/api/account/logic/account/confirm_email_change.rb
@@ -125,10 +125,15 @@ module AccountAPI::Logic
 
       # `:no_change` counts: the account already holds the address, the
       # redemption is idempotent, and this surface still sends the caller to
-      # /signin. `:partial` counts only in the sub-case where the Customer hash
-      # committed — the other sub-case rolled the accounts row back.
+      # /signin. `:verification_not_reset` counts: the op only computes it AFTER
+      # the swap landed and RevokeAllForCustomer ran — unreachable here today
+      # (this adapter passes `require_verification: false`), but if that
+      # parameter ever changes, skipping the clear would write this session back
+      # and resurrect the blob the op just deleted. `:partial` counts only in
+      # the sub-case where the Customer hash committed — the other sub-case
+      # rolled the accounts row back.
       def swap_landed?(result)
-        return true if [:success, :no_change].include?(result.status)
+        return true if [:success, :no_change, :verification_not_reset].include?(result.status)
 
         result.status == :partial && result.warnings.include?(:secondary_writes_incomplete)
       end
@@ -164,7 +169,8 @@ module AccountAPI::Logic
         # (D34 — the redeemed token is the proof of ownership). It falls into the
         # fail-closed `else` deliberately rather than being whitelisted above, so
         # if that parameter is ever changed the surface refuses instead of
-        # reporting a clean success.
+        # reporting a clean success — but it IS a swap-landed status, so
+        # `swap_landed?` counts it and the session clear has already fired.
         else
           auth_logger.error '[confirm-email-change] Email change did not fully land',
             extid: @owner.extid,

--- a/apps/api/account/spec/logic/account/confirm_email_change_spec.rb
+++ b/apps/api/account/spec/logic/account/confirm_email_change_spec.rb
@@ -1,0 +1,178 @@
+# apps/api/account/spec/logic/account/confirm_email_change_spec.rb
+#
+# frozen_string_literal: true
+
+# Run with:
+#   source .env.test && bundle exec rspec apps/api/account/spec/logic/account/confirm_email_change_spec.rb
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'account/logic'
+require 'auth/operations/customers/change_email'
+
+# Adapter-layer coverage for the one piece of the email-change swap this class
+# still owns after #3731 PR-C2: dropping the CURRENT request's Rack session
+# (`clear_current_session` / `swap_landed?`). The cross-store mutation is covered
+# by apps/web/auth/spec/operations/customers/change_email_spec.rb and the live
+# token path by try/unit/logic/account/email_change_try.rb — but every case there
+# drives `:success`, a status that cleared the session both before and after the
+# gate existed. These examples drive the OTHER statuses, pinning the gate in both
+# directions: widen it and an `:email_taken` redemption signs the caller out of an
+# account that never changed hands; narrow it and the `:partial` whose swap LANDED
+# skips `sess.clear`, so the middleware writes this session back and re-creates the
+# blob RevokeAllForCustomer just deleted.
+#
+# The operation itself is stubbed — this is the adapter's contract, not the op's.
+RSpec.describe AccountAPI::Logic::Account::ConfirmEmailChange do
+  let(:result_class) { Auth::Operations::Customers::ChangeEmail::Result }
+  let(:op) { instance_double(Auth::Operations::Customers::ChangeEmail) }
+  let(:token) { 'tok-confirm-email-change' }
+  let(:new_email) { 'new@example.com' }
+
+  let(:owner) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_owner',
+      extid: 'ur_owner',
+      email: 'old@example.com',
+      pending_email_change: token)
+  end
+
+  let(:secret) do
+    instance_double(Onetime::Secret,
+      identifier: token,
+      exists?: true,
+      custid: 'cust_owner',
+      verification?: true,
+      load_owner: owner,
+      decrypted_secret_value: new_email)
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+    # The fail-closed `else` arm logs through Onetime::LoggerMethods#auth_logger.
+    allow(Onetime).to receive(:get_logger).and_return(double('Logger').as_null_object)
+    allow(Onetime.auth_config).to receive(:sso_only_enabled?).and_return(false)
+    allow(Onetime::Secret).to receive(:find_by_identifier).with(token).and_return(secret)
+    allow(Auth::Operations::Customers::ChangeEmail).to receive(:new).and_return(op)
+  end
+
+  # Seeded rather than empty: an assertion against `{}` would pass whether or not
+  # anything cleared it.
+  def fresh_session
+    { 'sid' => 'sid-under-test', 'authenticated' => true }
+  end
+
+  def build_result(status, warnings)
+    result_class.new(
+      status: status,
+      extid: 'ur_owner',
+      from: 'old@example.com',
+      to: new_email,
+      dry_run: false,
+      auth_row_updated: %i[success partial].include?(status),
+      orgs_reindexed: 0,
+      sessions_revoked: status == :success,
+      verification_reset: false,
+      warnings: warnings,
+    )
+  end
+
+  # Keyword-only, deliberately: a positional params hash here would swallow a
+  # braceless trailing hash at the call site and silently build a default result.
+  #
+  # Drives the full controller sequence and hands back the session hash plus
+  # whatever `process` raised, so an example can assert BOTH — the clear has to be
+  # observable on the arms that then raise.
+  def confirm(status:, warnings: [], session: fresh_session)
+    allow(op).to receive(:call).and_return(build_result(status, warnings))
+    strategy_result = double('StrategyResult',
+      session: session, user: nil, auth_method: 'noauth', metadata: {})
+
+    logic = described_class.new(strategy_result, { 'token' => token })
+    logic.raise_concerns
+
+    error = nil
+    begin
+      logic.process
+    rescue OT::FormError => ex
+      error = ex
+    end
+
+    [session, error]
+  end
+
+  describe "the swap landed — this request's session must go" do
+    it 'clears the session on :success' do
+      session, error = confirm(status: :success)
+
+      expect(error).to be_nil
+      expect(session).to be_empty
+    end
+
+    # Idempotent redemption: the account already holds the address and this
+    # surface still sends the caller to /signin.
+    it 'clears the session on :no_change' do
+      session, error = confirm(status: :no_change)
+
+      expect(error).to be_nil
+      expect(session).to be_empty
+    end
+
+    # The load-bearing case. `:secondary_writes_incomplete` means the Customer
+    # hash committed, so both authoritative stores hold the new address and the op
+    # ran RevokeAllForCustomer — yet the status mapping raises. The clear has to
+    # happen BEFORE that raise or the middleware resurrects the revoked blob.
+    it 'clears the session on the :partial that carries :secondary_writes_incomplete, even though process raises' do
+      session, error = confirm(status: :partial, warnings: %i[secondary_writes_incomplete])
+
+      expect(error).to be_a(OT::FormError)
+      expect(error.message).to eq('Email change could not be completed')
+      expect(session).to be_empty
+    end
+  end
+
+  describe 'nothing changed hands — signing the caller out would be gratuitous' do
+    # Claimed by another account between the request and this redemption. The
+    # caller still owns the address they signed in with.
+    it 'leaves the session intact on :email_taken' do
+      session, error = confirm(status: :email_taken)
+
+      expect(error).to be_a(OT::FormError)
+      expect(error.message).to eq('This email is no longer available')
+      expect(session).to eq({ 'sid' => 'sid-under-test', 'authenticated' => true })
+    end
+
+    it 'leaves the session intact on :invalid_email' do
+      session, error = confirm(status: :invalid_email)
+
+      expect(error).to be_a(OT::FormError)
+      expect(session).not_to be_empty
+    end
+
+    it 'leaves the session intact on :not_found' do
+      session, error = confirm(status: :not_found)
+
+      expect(error).to be_a(OT::FormError)
+      expect(session).not_to be_empty
+    end
+
+    # The OTHER :partial sub-case: the Customer hash never took the new address,
+    # so the op wrote the old one back to `accounts` and revoked nothing. Status
+    # alone is not enough to decide — the warning is what separates the two.
+    it 'leaves the session intact on a :partial that rolled the auth row back' do
+      session, error = confirm(status: :partial, warnings: %i[auth_row_rolled_back])
+
+      expect(error).to be_a(OT::FormError)
+      expect(session).not_to be_empty
+    end
+  end
+
+  # `clear_current_session` now runs before the status mapping, so its nil guard
+  # is reached on the raising arms too.
+  it 'tolerates a request with no Rack session on an arm that raises' do
+    expect { confirm(status: :partial, warnings: %i[secondary_writes_incomplete], session: nil) }
+      .not_to raise_error
+  end
+end

--- a/apps/api/account/spec/logic/account/confirm_email_change_spec.rb
+++ b/apps/api/account/spec/logic/account/confirm_email_change_spec.rb
@@ -71,9 +71,9 @@ RSpec.describe AccountAPI::Logic::Account::ConfirmEmailChange do
       from: 'old@example.com',
       to: new_email,
       dry_run: false,
-      auth_row_updated: %i[success partial].include?(status),
+      auth_row_updated: %i[success partial verification_not_reset].include?(status),
       orgs_reindexed: 0,
-      sessions_revoked: status == :success,
+      sessions_revoked: %i[success verification_not_reset].include?(status),
       verification_reset: false,
       warnings: warnings,
     )
@@ -126,6 +126,23 @@ RSpec.describe AccountAPI::Logic::Account::ConfirmEmailChange do
     # happen BEFORE that raise or the middleware resurrects the revoked blob.
     it 'clears the session on the :partial that carries :secondary_writes_incomplete, even though process raises' do
       session, error = confirm(status: :partial, warnings: %i[secondary_writes_incomplete])
+
+      expect(error).to be_a(OT::FormError)
+      expect(error.message).to eq('Email change could not be completed')
+      expect(session).to be_empty
+    end
+
+    # Unreachable on this surface today — the adapter passes
+    # `require_verification: false`, so the op never produces this status here.
+    # But the op only computes it AFTER the swap landed and RevokeAllForCustomer
+    # ran, so if that parameter default ever changes, the clear must fire while
+    # the mapping still refuses via the fail-closed `else`. Clear-and-raise,
+    # same shape as the landed :partial. Both directions are load-bearing:
+    # dropping the status from `swap_landed?` resurrects the revoked blob, and
+    # whitelisting it in the status mapping reports a clean success for an
+    # account left verified on an unproven address.
+    it 'clears the session on :verification_not_reset, even though process raises' do
+      session, error = confirm(status: :verification_not_reset)
 
       expect(error).to be_a(OT::FormError)
       expect(error.message).to eq('Email change could not be completed')

--- a/apps/api/account/spec/logic/account/confirm_email_change_spec.rb
+++ b/apps/api/account/spec/logic/account/confirm_email_change_spec.rb
@@ -73,7 +73,10 @@ RSpec.describe AccountAPI::Logic::Account::ConfirmEmailChange do
       dry_run: false,
       auth_row_updated: %i[success partial verification_not_reset].include?(status),
       orgs_reindexed: 0,
-      sessions_revoked: %i[success verification_not_reset].include?(status),
+      # Mirrors the op: the landed :partial runs the same follow-ups as
+      # :success, so it reports the revocation too.
+      sessions_revoked: %i[success verification_not_reset].include?(status) ||
+        (status == :partial && warnings.include?(:secondary_writes_incomplete)),
       verification_reset: false,
       warnings: warnings,
     )
@@ -129,6 +132,7 @@ RSpec.describe AccountAPI::Logic::Account::ConfirmEmailChange do
 
       expect(error).to be_a(OT::FormError)
       expect(error.message).to eq('Email change could not be completed')
+      expect(error.error_type).to eq('system_error')
       expect(session).to be_empty
     end
 
@@ -146,6 +150,7 @@ RSpec.describe AccountAPI::Logic::Account::ConfirmEmailChange do
 
       expect(error).to be_a(OT::FormError)
       expect(error.message).to eq('Email change could not be completed')
+      expect(error.error_type).to eq('system_error')
       expect(session).to be_empty
     end
   end

--- a/apps/api/account/spec/logic/account/confirm_email_change_spec.rb
+++ b/apps/api/account/spec/logic/account/confirm_email_change_spec.rb
@@ -64,19 +64,24 @@ RSpec.describe AccountAPI::Logic::Account::ConfirmEmailChange do
     { 'sid' => 'sid-under-test', 'authenticated' => true }
   end
 
+  # Field values mirror the op's reporting: only the swap-landed statuses carry
+  # `auth_row_updated` (the rolled-back :partial wrote the old address back) and
+  # `sessions_revoked` (the landed :partial runs the same follow-ups as
+  # :success). `verification_reset` stays false because this adapter passes
+  # `require_verification: false`.
   def build_result(status, warnings)
+    landed = %i[success verification_not_reset].include?(status) ||
+      (status == :partial && warnings.include?(:secondary_writes_incomplete))
+
     result_class.new(
       status: status,
       extid: 'ur_owner',
       from: 'old@example.com',
       to: new_email,
       dry_run: false,
-      auth_row_updated: %i[success partial verification_not_reset].include?(status),
+      auth_row_updated: landed,
       orgs_reindexed: 0,
-      # Mirrors the op: the landed :partial runs the same follow-ups as
-      # :success, so it reports the revocation too.
-      sessions_revoked: %i[success verification_not_reset].include?(status) ||
-        (status == :partial && warnings.include?(:secondary_writes_incomplete)),
+      sessions_revoked: landed,
       verification_reset: false,
       warnings: warnings,
     )

--- a/apps/api/colonel/logic/colonel/change_user_email.rb
+++ b/apps/api/colonel/logic/colonel/change_user_email.rb
@@ -154,10 +154,17 @@ module ColonelAPI
           when :not_found
             raise_not_found('User has no usable email address')
           when :partial
+            # The warnings are load-bearing here, not decoration: a partial whose
+            # Customer hash already committed runs the full follow-up phase, so it
+            # can carry :verification_not_reset — same "do not retry, unverify now"
+            # obligation the dedicated status below spells out. Interpolating them
+            # (as that branch does) is the only way a colonel operator sees it; the
+            # CLI gets it for free through print_warnings.
             raise_form_error(
               'PARTIAL: the email change did not complete and the auth database ' \
               'and Redis may now disagree. Run `bin/ots customers doctor` ' \
-              '(check :auth_email_drift) before retrying.',
+              '(check :auth_email_drift) before retrying. ' \
+              "(#{result.warnings.join(', ')})",
               field: :new_email,
             )
           when :verification_not_reset

--- a/apps/api/colonel/logic/colonel/change_user_email.rb
+++ b/apps/api/colonel/logic/colonel/change_user_email.rb
@@ -154,28 +154,49 @@ module ColonelAPI
           when :not_found
             raise_not_found('User has no usable email address')
           when :partial
-            # The warnings are load-bearing here, not decoration: a partial whose
-            # Customer hash already committed runs the full follow-up phase, so it
-            # can carry :verification_not_reset — same "do not retry, unverify now"
-            # obligation the dedicated status below spells out. Interpolating them
-            # (as that branch does) is the only way a colonel operator sees it; the
-            # CLI gets it for free through print_warnings.
+            # A partial whose Customer hash already committed ran the full
+            # follow-up phase, so it can carry :verification_not_reset (or
+            # :verification_still_set): the swap LANDED and the account is still
+            # flagged verified on an unproven address. Telling that operator to
+            # doctor-then-retry sends them the wrong way — the change already
+            # stuck, and the obligation is the same "unverify now" the dedicated
+            # status below spells out. The remaining warnings stay interpolated
+            # either way: they are the only channel a colonel operator has,
+            # where the CLI gets print_warnings for free.
+            if result.warnings.intersect?([:verification_not_reset, :verification_still_set])
+              raise_form_error(
+                'PARTIAL: the email change LANDED but verification could not ' \
+                "be reset: #{result.extid} is still marked verified on an " \
+                'address nobody has proven they own. Do not retry the change — ' \
+                "run `bin/ots customers unverify #{result.extid}` now, then " \
+                '`bin/ots customers doctor` for the remaining drift.' \
+                "#{warnings_suffix}",
+                field: :new_email,
+              )
+            end
+
             raise_form_error(
               'PARTIAL: the email change did not complete and the auth database ' \
               'and Redis may now disagree. Run `bin/ots customers doctor` ' \
-              '(check :auth_email_drift) before retrying. ' \
-              "(#{result.warnings.join(', ')})",
+              "(check :auth_email_drift) before retrying.#{warnings_suffix}",
               field: :new_email,
             )
           when :verification_not_reset
             raise_form_error(
               "The email change APPLIED, but verification could not be reset: #{result.extid} " \
               'is still marked verified on an address nobody has proven they own. ' \
-              "Do not retry the change — run `bin/ots customers unverify #{result.extid}` now. " \
-              "(#{result.warnings.join(', ')})",
+              "Do not retry the change — run `bin/ots customers unverify #{result.extid}` now." \
+              "#{warnings_suffix}",
               field: :new_email,
             )
           end
+        end
+
+        # The op's partial() has one sub-case (no auth-row write, no Customer
+        # commit) that appends nothing, so a bare "()" is reachable and reads
+        # as a rendering bug rather than "no warnings".
+        def warnings_suffix
+          result.warnings.empty? ? '' : " (#{result.warnings.join(', ')})"
         end
 
         def status_message

--- a/apps/api/colonel/spec/logic/colonel/change_user_email_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/change_user_email_spec.rb
@@ -32,7 +32,18 @@ RSpec.describe ColonelAPI::Logic::Colonel::ChangeUserEmail do
       auth_method: 'sessionauth', metadata: {})
   end
 
+  # Defaults mirror the op's reporting under this adapter's flags
+  # (require_verification: true, revoke_sessions: true): the swap-landed
+  # statuses — :success, :verification_not_reset, and the :partial carrying
+  # :secondary_writes_incomplete — report the auth-row write and the follow-up
+  # revocation; everything else reports false. `verification_reset` is false
+  # exactly where the op says the reset did NOT land: the downgraded status and
+  # the warning of the same name.
   def build_result(status:, **overrides)
+    warnings = overrides.fetch(:warnings, [])
+    landed   = %i[success verification_not_reset].include?(status) ||
+      (status == :partial && warnings.include?(:secondary_writes_incomplete))
+
     result_class.new(
       **{
         status: status,
@@ -40,11 +51,12 @@ RSpec.describe ColonelAPI::Logic::Colonel::ChangeUserEmail do
         from: 'old@example.com',
         to: 'new@example.com',
         dry_run: status == :planned,
-        auth_row_updated: status == :success,
+        auth_row_updated: landed,
         orgs_reindexed: 0,
-        sessions_revoked: false,
-        verification_reset: status == :success,
-        warnings: [],
+        sessions_revoked: landed,
+        verification_reset: landed && status != :verification_not_reset &&
+          !warnings.include?(:verification_not_reset),
+        warnings: warnings,
       }.merge(overrides),
     )
   end
@@ -152,7 +164,7 @@ RSpec.describe ColonelAPI::Logic::Colonel::ChangeUserEmail do
     # this MUST NOT read as a 200.
     it 'raises a form error on :partial rather than returning success' do
       logic = logic_for({ 'dry_run' => 'false' }, status: :partial,
-        auth_row_updated: true, warnings: %i[secondary_writes_incomplete])
+        warnings: %i[secondary_writes_incomplete])
       logic.raise_concerns
 
       expect { logic.process }.to raise_error(Onetime::FormError, /PARTIAL/)
@@ -164,7 +176,7 @@ RSpec.describe ColonelAPI::Logic::Colonel::ChangeUserEmail do
     # tell the operator to retry the change.
     it 'raises a form error on :verification_not_reset with the remediation' do
       logic = logic_for({ 'dry_run' => 'false' }, status: :verification_not_reset,
-        auth_row_updated: true, warnings: %i[verification_still_set])
+        warnings: %i[verification_still_set])
       logic.raise_concerns
 
       expect { logic.process }.to raise_error(Onetime::FormError, /customers unverify ur_target/)

--- a/apps/api/colonel/spec/logic/colonel/change_user_email_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/change_user_email_spec.rb
@@ -171,6 +171,34 @@ RSpec.describe ColonelAPI::Logic::Colonel::ChangeUserEmail do
       expect { logic.process }.to raise_error(Onetime::FormError, /customers doctor/)
     end
 
+    # A landed partial: the Customer hash committed, the follow-up phase ran,
+    # and the verification reset failed. The swap already stuck, so the generic
+    # doctor-then-retry guidance is wrong here — the message must carry the
+    # unverify-now remediation instead.
+    it 'routes a landed :partial carrying :verification_not_reset to unverify, not retry' do
+      logic = logic_for({ 'dry_run' => 'false' }, status: :partial,
+        warnings: %i[secondary_writes_incomplete verification_not_reset])
+      logic.raise_concerns
+
+      expect { logic.process }.to raise_error(Onetime::FormError) do |err|
+        expect(err.message).to match(/customers unverify ur_target/)
+        expect(err.message).not_to match(/before retrying/)
+        expect(err.message).to include('verification_not_reset')
+      end
+    end
+
+    # The op's partial() has a sub-case that appends no warning, so the
+    # parenthetical must disappear rather than render as "()".
+    it 'omits the warnings parenthetical on a :partial with no warnings' do
+      logic = logic_for({ 'dry_run' => 'false' }, status: :partial, warnings: [])
+      logic.raise_concerns
+
+      expect { logic.process }.to raise_error(Onetime::FormError) do |err|
+        expect(err.message).to include('before retrying')
+        expect(err.message).not_to include('()')
+      end
+    end
+
     # The swap LANDED but the account is still flagged verified on an address
     # nobody has proven they own. Also must not read as a 200, and must not
     # tell the operator to retry the change.

--- a/apps/api/colonel/spec/logic/colonel/change_user_email_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/change_user_email_spec.rb
@@ -1,0 +1,174 @@
+# apps/api/colonel/spec/logic/colonel/change_user_email_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'colonel/logic'
+require 'auth/operations/customers/change_email'
+
+# Adapter-layer coverage only. The cross-store swap itself is covered by
+# apps/web/auth/spec/operations/customers/change_email_spec.rb, and the CLI
+# adapter by spec/cli/customers_change_email_command_spec.rb. These examples
+# assert what THIS adapter owns: preview-by-default, dry_run parsing, and the
+# two statuses that must never come back as a 200.
+RSpec.describe ColonelAPI::Logic::Colonel::ChangeUserEmail do
+  let(:result_class) { Auth::Operations::Customers::ChangeEmail::Result }
+  let(:op) { instance_double(Auth::Operations::Customers::ChangeEmail) }
+
+  let(:colonel) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_colonel', extid: 'ur_colonel',
+      role: 'colonel', verified?: true, anonymous?: false)
+  end
+
+  let(:target) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_target', extid: 'ur_target',
+      email: 'old@example.com', exists?: true, anonymous?: false)
+  end
+
+  let(:strategy_result) do
+    double('StrategyResult', session: {}, user: colonel,
+      auth_method: 'sessionauth', metadata: {})
+  end
+
+  def build_result(status:, **overrides)
+    result_class.new(
+      **{
+        status: status,
+        extid: 'ur_target',
+        from: 'old@example.com',
+        to: 'new@example.com',
+        dry_run: status == :planned,
+        auth_row_updated: status == :success,
+        orgs_reindexed: 0,
+        sessions_revoked: false,
+        verification_reset: status == :success,
+        warnings: [],
+      }.merge(overrides),
+    )
+  end
+
+  # Builds the logic with the two required params plus whatever the example is
+  # exercising, and pins the op's answer. Callers still drive raise_concerns
+  # (which resolves @user) before process, exactly as the controller does.
+  def logic_for(params = {}, status: :planned, **result_overrides)
+    allow(op).to receive(:call).and_return(build_result(status: status, **result_overrides))
+    described_class.new(
+      strategy_result,
+      { 'user_id' => 'ur_target', 'new_email' => 'new@example.com' }.merge(params),
+    )
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(target)
+    allow(Auth::Operations::Customers::ChangeEmail).to receive(:new).and_return(op)
+  end
+
+  describe 'dry_run defaults to preview' do
+    it 'is true when the param is absent, and reaches the op that way' do
+      logic = logic_for
+      expect(logic.dry_run).to be true
+
+      logic.raise_concerns
+      logic.process
+
+      expect(Auth::Operations::Customers::ChangeEmail).to have_received(:new)
+        .with(hash_including(dry_run: true))
+    end
+
+    # JSON bodies deliver native booleans; consoles and curl deliver strings.
+    %w[true 1 yes on TRUE On].each do |raw|
+      it "treats #{raw.inspect} as a preview" do
+        expect(logic_for({ 'dry_run' => raw }).dry_run).to be true
+      end
+    end
+
+    it 'treats a native JSON true as a preview' do
+      expect(logic_for({ 'dry_run' => true }).dry_run).to be true
+    end
+
+    ['false', '0', 'no', 'off', '', false].each do |raw|
+      it "treats #{raw.inspect} as an explicit opt-out" do
+        expect(logic_for({ 'dry_run' => raw }).dry_run).to be false
+      end
+    end
+
+    # Documents current behaviour, which fails OPEN: anything outside the
+    # truthy allowlist applies the change rather than previewing it.
+    it 'treats an unrecognized value as an opt-out' do
+      expect(logic_for({ 'dry_run' => 'maybe' }).dry_run).to be false
+    end
+  end
+
+  describe 'flag defaults threaded into the op' do
+    it 'notifies, revokes sessions, and requires re-verification' do
+      logic = logic_for
+      logic.raise_concerns
+      logic.process
+
+      expect(Auth::Operations::Customers::ChangeEmail).to have_received(:new)
+        .with(hash_including(notify: true, revoke_sessions: true, require_verification: true))
+    end
+
+    it 'maps keep_verified to require_verification: false' do
+      logic = logic_for({ 'keep_verified' => 'true' })
+      logic.raise_concerns
+      logic.process
+
+      expect(Auth::Operations::Customers::ChangeEmail).to have_received(:new)
+        .with(hash_including(require_verification: false))
+    end
+  end
+
+  describe 'status mapping' do
+    it 'returns the success shape on :success with obscured addresses' do
+      logic = logic_for({ 'dry_run' => 'false' }, status: :success)
+      logic.raise_concerns
+      data = logic.process
+
+      expect(data[:record][:status]).to eq('success')
+      expect(data[:record][:user_id]).to eq('cust_target')
+      expect(data[:details][:changed]).to be true
+      expect(data[:details][:message]).to eq('Email changed')
+      expect(data[:record][:from]).to eq(OT::Utils.obscure_email('old@example.com'))
+      expect(data[:record][:from]).not_to eq('old@example.com')
+    end
+
+    it 'returns the preview shape on :planned' do
+      logic = logic_for
+      logic.raise_concerns
+      data = logic.process
+
+      expect(data[:details][:changed]).to be false
+      expect(data[:details][:dry_run]).to be true
+      expect(data[:details][:message]).to eq('Preview only — no changes applied')
+    end
+
+    # SQL committed, Redis did not finish: the two stores may now disagree, so
+    # this MUST NOT read as a 200.
+    it 'raises a form error on :partial rather than returning success' do
+      logic = logic_for({ 'dry_run' => 'false' }, status: :partial,
+        auth_row_updated: true, warnings: %i[secondary_writes_incomplete])
+      logic.raise_concerns
+
+      expect { logic.process }.to raise_error(Onetime::FormError, /PARTIAL/)
+      expect { logic.process }.to raise_error(Onetime::FormError, /customers doctor/)
+    end
+
+    # The swap LANDED but the account is still flagged verified on an address
+    # nobody has proven they own. Also must not read as a 200, and must not
+    # tell the operator to retry the change.
+    it 'raises a form error on :verification_not_reset with the remediation' do
+      logic = logic_for({ 'dry_run' => 'false' }, status: :verification_not_reset,
+        auth_row_updated: true, warnings: %i[verification_still_set])
+      logic.raise_concerns
+
+      expect { logic.process }.to raise_error(Onetime::FormError, /customers unverify ur_target/)
+      expect { logic.process }.to raise_error(Onetime::FormError, /verification_still_set/)
+    end
+  end
+end

--- a/apps/web/auth/operations/customers/change_email.rb
+++ b/apps/web/auth/operations/customers/change_email.rb
@@ -73,8 +73,13 @@ module Auth
       # surfaces as `Sequel::UniqueConstraintViolation`, which is rescued and
       # mapped to `:email_taken`.
       #
+      # That guard depends on there BEING an accounts row. A customer without one
+      # (a provisioning gap `bin/ots customers sync-auth-accounts` owns) updates
+      # nothing in step 1, so no constraint ever fires — which is why the claim
+      # below keys on the accounts row, not on the connection.
+      #
       # SIMPLE MODE has no SQL and therefore no such serialization point. We claim
-      # the index entry with `HSETNX` (`simple_mode_race_lost?`), which IS atomic:
+      # the index entry with `HSETNX` (`index_claim_race_lost?`), which IS atomic:
       # a concurrent claimant can no longer slip between our check and our write
       # and have its entry silently stolen by us. What HSETNX cannot do is stop
       # the reverse — Familia auto-adds class `unique_index` entries on EVERY save
@@ -113,6 +118,12 @@ module Auth
       # (`force_clear_verification!`), and if even that cannot confirm the flag is
       # down the call returns `:verification_not_reset` — NOT `:success`.
       #
+      # The reset is owed on the landed-`:partial` sub-case too, on the same
+      # gate: the swap committed there as well, so "flagged verified on an
+      # unproven address" is the same unsafe state. That path cannot downgrade a
+      # status that is already `:partial`, so it carries the identical signal as
+      # the `:verification_not_reset` WARNING instead.
+      #
       # ## Deliberately NOT touched
       #
       # * `Organization#billing_email` / `#stripe_checkout_email` / `#email_hash`
@@ -139,6 +150,27 @@ module Auth
         STATUS_VERIFIED   = 2
         STATUS_CLOSED     = 3
         INDEXED_STATUSES  = [STATUS_UNVERIFIED, STATUS_VERIFIED].freeze
+
+        # Compare-and-delete on the global email index: drop the field ONLY while
+        # it still names us (`release_index_claim`). A read-then-HDEL is NOT good
+        # enough and the difference is a real unindexing bug: `@index_claim_created`
+        # proves we won the HSETNX, not that we still hold the field. Familia's
+        # auto-index on save is a blind HSET (indexing.rb:64-67), so a customer who
+        # completed signup on this address in between already owns the entry — and
+        # a bare HDEL would unindex a LIVE account, leaving it findable by neither
+        # `Customer.find_by_email` nor its owner. Same Lua-CAS shape ADR-019 uses
+        # for the one-way claim on `secret_value_shown_at` (access_timeline.rb).
+        #
+        # Comparing RAW stored bytes is sound only because a `unique_index`
+        # hashkey is declared `reference: true` (familia
+        # unique_index_generators.rb:88-95), so a String identifier is stored
+        # verbatim rather than JSON-encoded — the objid we pass IS what HSETNX
+        # wrote. A non-reference collection would need the encoded form.
+        # @return [Integer] 1 when the entry was ours and is now gone, else 0
+        RELEASE_INDEX_CLAIM_SCRIPT = <<~LUA
+          if redis.call('HGET', KEYS[1], ARGV[1]) ~= ARGV[2] then return 0 end
+          return redis.call('HDEL', KEYS[1], ARGV[1])
+        LUA
 
         # @!attribute status [r]
         #   @return [Symbol] one of:
@@ -240,10 +272,11 @@ module Auth
             raise
           end
 
-          # Simple mode has no SQL serialization point, so the index entry is
-          # CLAIMED (atomically) as late as possible — the last statement before
-          # the first Redis write. No-op in full mode (see class docs).
-          return terminal(:email_taken, old_email) if simple_mode_race_lost?
+          # With no SQL serialization point the index entry is CLAIMED
+          # (atomically) as late as possible — the last statement before the
+          # first Redis write. No-op once an accounts row carries the claim for
+          # us (see class docs).
+          return terminal(:email_taken, old_email) if index_claim_race_lost?
 
           # --- 2. REDIS (compensable). ---
           customer_committed = false
@@ -419,10 +452,16 @@ module Auth
           true
         end
 
-        # Simple mode only: ATOMICALLY claim the global email index entry.
-        # Returns false in full mode — there the unique index on accounts.email is
-        # the real guard, it is consulted before any Redis write, and its
+        # ATOMICALLY claim the global email index entry whenever no SQL
+        # constraint will serialize the claim for us. Skipped only when this
+        # customer HAS an accounts row — there the unique index on accounts.email
+        # is the real guard, it is consulted before any Redis write, and its
         # violation is rescued on the UPDATE.
+        #
+        # Keyed on the accounts row rather than on the connection: a full-mode
+        # customer with NO row (a provisioning gap `sync-auth-accounts` owns)
+        # updates nothing in `update_auth_row!`, so no constraint ever fires and
+        # this claim is the only guard left.
         #
         # `HSETNX` sets the field only if it does not already exist, so the check
         # and the claim are one operation and a concurrent claimant can no longer
@@ -440,18 +479,20 @@ module Auth
         # lands after our claim still overwrites it. That needs a claim-once
         # primitive inside Familia itself.
         #
-        # NOT rescued: in simple mode nothing has committed at this point, so a
-        # datastore error here is a clean abort with nothing to compensate.
+        # NOT rescued: with no accounts row nothing has committed at this point,
+        # so a datastore error here is a clean abort with nothing to compensate.
         # @return [Boolean] true when another account holds the address
-        def simple_mode_race_lost?
-          return false if connection
+        def index_claim_race_lost?
+          db = connection
+          return false if db && auth_account_id(db)
 
           index = Onetime::Customer.email_index
           if index_claimed?(index.hsetnx(@new_email, @customer.objid))
             # Remember that WE created this entry. Unlike the old pure-read
             # check, winning the claim is a mutation, so if the Redis phase then
-            # fails the entry is left pointing at a customer that never took the
-            # address. `partial` reports that rather than leaving it silent.
+            # fails the entry would point at a customer that never took the
+            # address. `partial` releases it (best effort, `release_index_claim`)
+            # and only warns when even that cannot be done.
             @index_claim_created = true
             return false
           end
@@ -860,7 +901,9 @@ module Auth
             extid: @customer.extid,
             exception: exception
 
-          rolled_back = false
+          rolled_back        = false
+          sessions_revoked   = false
+          verification_state = :skipped
           if auth_row_updated && !customer_committed
             rolled_back = compensate_auth_row!(old_email)
             @warnings << (rolled_back ? :auth_row_rolled_back : :auth_row_rollback_failed)
@@ -868,14 +911,38 @@ module Auth
             # Authoritative stores agree on the NEW address; only secondary
             # indexes are behind. `customers doctor` repairs those.
             @warnings << :secondary_writes_incomplete
+
+            # The swap LANDED in this sub-case, so the follow-up work is owed in
+            # FULL, exactly as it is on :success — same three calls, same order,
+            # same `require_verification` gate. Returning without it would drop
+            # the "an email change revokes every session" property on precisely
+            # the messy path, leave the account holder with no notice of a change
+            # that stuck, and — worst of the three — leave the account flagged
+            # VERIFIED on an address nobody has proven ownership of, which is the
+            # exact state `require_verification` exists to prevent. All three
+            # already swallow their own failures into warnings.
+            sessions_revoked   = revoke_sessions
+            verification_state = reset_verification
+            send_notifications(old_email)
+
+            # On :success a reset that could not be confirmed downgrades the
+            # STATUS to :verification_not_reset. Here the status is already
+            # :partial and there is nothing below it, so the WARNING carries the
+            # same signal under the same name — the operator reads the identical
+            # symbol and owes the identical remediation
+            # (`bin/ots customers unverify <extid>`), not just the doctor run
+            # :partial asks for on its own.
+            @warnings << :verification_not_reset if verification_state == :still_verified
           end
 
-          # Simple mode: the claim we took at :246 is a write, and nothing here
-          # rolls it back — the customer never took the address, so the index
-          # entry now points at a record that does not hold it.
-          # `customers doctor` check_email_index detects and repairs exactly
-          # this mismatch; the warning is what tells the operator to run it.
-          @warnings << :email_index_claim_orphaned if @index_claim_created && !customer_committed
+          # The claim taken in `index_claim_race_lost?` is a write, and nothing
+          # else rolls it back — the customer never took the address, so the
+          # entry points at a record that does not hold it. Released here by
+          # compare-and-delete; anything it cannot cleanly release raises
+          # `:email_index_claim_orphaned`, which tells the operator to run
+          # `customers doctor` (check_email_index detects and repairs exactly
+          # this mismatch).
+          release_index_claim if @index_claim_created && !customer_committed
 
           record_audit(:partial, old_email, auth_row_updated && !rolled_back)
 
@@ -887,10 +954,38 @@ module Auth
             dry_run: false,
             auth_row_updated: auth_row_updated && !rolled_back,
             orgs_reindexed: @orgs_reindexed.to_i,
-            sessions_revoked: false,
-            verification_reset: false,
+            sessions_revoked: sessions_revoked,
+            verification_reset: verification_state == :reset,
             warnings: @warnings.uniq,
           )
+        end
+
+        # Undo of our own HSETNX claim, by the compare-and-delete above. Only
+        # ever reached when WE created the entry AND the Customer hash never took
+        # the address, so the entry points at a record that does not hold it.
+        #
+        # ANY outcome other than "we deleted our own entry" warns: a superseded
+        # field means someone else's blind HSET landed on top of a claim we were
+        # about to abandon, which is exactly the state `customers doctor`
+        # check_email_index reconciles. Staying silent there is what leaves that
+        # account unindexed with nobody told to run it.
+        def release_index_claim
+          index    = Onetime::Customer.email_index
+          released = index.dbclient.eval(
+            RELEASE_INDEX_CLAIM_SCRIPT,
+            keys: [index.dbkey],
+            argv: [@new_email.to_s, @customer.objid.to_s],
+          )
+          return if released.to_i == 1
+
+          auth_logger.warn '[customer.change_email] index claim no longer ours; left in place',
+            extid: @customer.extid
+          @warnings << :email_index_claim_orphaned
+        rescue StandardError => ex
+          auth_logger.error '[customer.change_email] orphaned index claim release failed',
+            extid: @customer.extid,
+            exception: ex
+          @warnings << :email_index_claim_orphaned
         end
 
         # EXACTLY ONE event, from the op, obscured addresses only. `:partial` is

--- a/apps/web/auth/operations/customers/doctor.rb
+++ b/apps/web/auth/operations/customers/doctor.rb
@@ -327,6 +327,14 @@ module Auth
         # A key that points at a DIFFERENT customer is reported but NOT repaired:
         # overwriting it would steal that customer's index entry, and this doctor
         # has no way to tell which of the two is the rightful holder.
+        #
+        # COST: the stale-key sweep reads the org's ENTIRE email index once per
+        # (customer, org) pair, so a `--all` run is O(customers x org-index-size).
+        # Bounded in practice — a personal workspace holds one entry — but a large
+        # shared org is re-read once per member. HSCAN would not reduce that: the
+        # sweep matches on the index VALUE (objid) while MATCH filters on the field
+        # (email), so a cursor walk reads the same bytes in batches and still needs
+        # a full-size seen-map to absorb HSCAN's at-least-once yields.
         def check_org_email_index(issues, repaired)
           email = @customer.email.to_s
           return if email.empty?

--- a/apps/web/auth/spec/operations/customers/change_email_spec.rb
+++ b/apps/web/auth/spec/operations/customers/change_email_spec.rb
@@ -66,8 +66,17 @@ RSpec.describe Auth::Operations::Customers::ChangeEmail do
   end
 
   # --- Redis index doubles -------------------------------------------------
-  # hsetnx: 1 == "the claim was ours" (simple mode only; full mode never calls it)
-  let(:email_index)         { double('Customer.email_index', get: nil, hsetnx: 1) }
+  # hsetnx: 1 == "the claim was ours" (only claimed when no accounts row carries
+  # the claim for us; with a row present the op never calls it).
+  #
+  # The claim RELEASE is a Lua compare-and-delete rather than a method on the
+  # index, so it goes through the raw client — hence dbclient/dbkey. `eval: 1`
+  # is the default "the field was still ours and is now gone" answer.
+  let(:index_dbclient)      { double('index dbclient', eval: 1) }
+  let(:index_dbkey)         { 'customer:email_index' }
+  let(:email_index) do
+    double('Customer.email_index', get: nil, hsetnx: 1, dbclient: index_dbclient, dbkey: index_dbkey)
+  end
   let(:contact_email_index) { double('Organization.contact_email_index', get: nil) }
 
   # --- SQL doubles ---------------------------------------------------------
@@ -391,6 +400,141 @@ RSpec.describe Auth::Operations::Customers::ChangeEmail do
       expect(result.warnings).to include(:secondary_writes_incomplete)
       expect(result.auth_row_updated).to be true
       expect(trace.count { |entry| entry.first == :sql_update }).to eq(1)
+    end
+
+    # In this sub-case the swap LANDED: both authoritative stores hold the new
+    # address and only secondary indexes are behind. So the FULL follow-up phase
+    # is owed exactly as it is on :success. Returning without it would drop the
+    # "an email change revokes every session" property on precisely the messy
+    # path — every session, including the current one, would survive a change
+    # the user is told failed — and would leave the account flagged verified on
+    # an address nobody has proven ownership of.
+    context 'when the Customer hash already committed (the swap landed)' do
+      before { allow(customer).to receive(:pending_email_change).and_raise(StandardError, 'redis blip') }
+
+      it 'still revokes sessions, through the same op :success uses' do
+        result = op.call
+
+        expect(Onetime::Operations::Sessions::RevokeAllForCustomer).to have_received(:new).with(
+          custid: 'ur_c', actor: 'cli'
+        )
+        expect(revoker).to have_received(:call)
+        expect(result.sessions_revoked).to be true
+      end
+
+      it 'still mails BOTH addresses (D36)' do
+        op.call
+
+        expect(Onetime::Jobs::Publisher).to have_received(:enqueue_email).twice
+        expect(Onetime::Jobs::Publisher).to have_received(:enqueue_email).with(
+          :email_changed, hash_including(recipient: old_email), hash_including(fallback: :async_thread)
+        )
+        expect(Onetime::Jobs::Publisher).to have_received(:enqueue_email).with(
+          :email_changed, hash_including(recipient: new_email), hash_including(fallback: :async_thread)
+        )
+      end
+
+      it 'still honours revoke_sessions: false and notify: false' do
+        result = op(revoke_sessions: false, notify: false).call
+
+        expect(Onetime::Operations::Sessions::RevokeAllForCustomer).not_to have_received(:new)
+        expect(Onetime::Jobs::Publisher).not_to have_received(:enqueue_email)
+        expect(result.sessions_revoked).to be false
+      end
+
+      # The follow-up is NOT best-effort cover for every partial: it is owed only
+      # where the swap landed. It must not degrade into a warning either.
+      it 'reports a revocation that failed rather than claiming one' do
+        allow(revoker).to receive(:call).and_raise(StandardError, 'redis gone')
+
+        result = op.call
+
+        expect(result.sessions_revoked).to be false
+        expect(result.warnings).to include(:sessions_revoke_failed)
+      end
+
+      # The one that actually bites: an operator-initiated change that half-lands
+      # must not leave the account flagged Verified on an address nobody proved.
+      # Same delegate, same require_verification gate :success uses.
+      it 'still resets verification, through the same wrapper :success uses' do
+        result = op.call
+
+        expect(Auth::Operations::Customers::SetVerification).to have_received(:new).with(
+          customer: customer, verified: false, actor: 'cli', verified_by: nil, db: db
+        )
+        expect(verifier).to have_received(:call)
+        expect(result.verification_reset).to be true
+      end
+
+      it 'honours require_verification: false exactly as :success does' do
+        result = op(require_verification: false).call
+
+        expect(Auth::Operations::Customers::SetVerification).not_to have_received(:new)
+        expect(result.verification_reset).to be false
+      end
+
+      # The status is already :partial and there is nothing below it, so the
+      # signal the :success path carries as a STATUS is carried here as the
+      # identically named warning — the operator owes the same
+      # `bin/ots customers unverify` remediation either way.
+      context 'when the reset cannot be confirmed' do
+        before do
+          allow(verifier).to receive(:call).and_raise(StandardError, 'no auth db')
+          allow(by_id_verified).to receive(:update).and_raise(StandardError, 'db gone')
+        end
+
+        it 'warns :verification_not_reset without moving the status off :partial' do
+          result = op.call
+
+          expect(result.status).to eq(:partial)
+          expect(result.verification_reset).to be false
+          expect(result.warnings).to include(
+            :secondary_writes_incomplete, :verification_reset_failed,
+            :verification_still_set, :verification_not_reset
+          )
+        end
+
+        it 'carries those warnings into the single :partial audit event' do
+          op.call
+
+          expect(Onetime::AdminAuditEvent).to have_received(:record).with(
+            hash_including(
+              verb: 'customer.change_email',
+              result: :partial,
+              detail: hash_including(warnings: include(:verification_not_reset, :verification_still_set)),
+            )
+          )
+        end
+      end
+
+      # The fail-closed fallback is owed here too: the wrapper failing must not
+      # mean the flag simply stays up.
+      it 'force-clears row-scoped when the wrapper fails, and reports the clear' do
+        allow(verifier).to receive(:call).and_raise(StandardError, 'no auth db')
+
+        result = op.call
+
+        expect(result.status).to eq(:partial)
+        expect(result.verification_reset).to be true
+        expect(result.warnings).to include(:verification_reset_failed, :verification_force_cleared)
+        expect(result.warnings).not_to include(:verification_not_reset)
+        expect(trace).to include([:sql_status_update, 1], [:customer_verified_assigned, false])
+      end
+    end
+
+    # The mirror image: the swap did NOT land (the accounts row was rolled back
+    # to the old address), so revoking sessions, unverifying and mailing a change
+    # notice would all be reacting to something that never happened.
+    it 'runs NO follow-up when the Customer never committed' do
+      allow(customer).to receive(:save).and_raise(StandardError, 'redis down')
+
+      result = op.call
+
+      expect(Onetime::Operations::Sessions::RevokeAllForCustomer).not_to have_received(:new)
+      expect(Auth::Operations::Customers::SetVerification).not_to have_received(:new)
+      expect(Onetime::Jobs::Publisher).not_to have_received(:enqueue_email)
+      expect(result.sessions_revoked).to be false
+      expect(result.verification_reset).to be false
     end
   end
 
@@ -819,15 +963,56 @@ RSpec.describe Auth::Operations::Customers::ChangeEmail do
 
     # Winning the HSETNX claim is a MUTATION (the old pre-write check was a pure
     # read). If the Redis phase then fails, the index entry points at a customer
-    # that never took the address and nothing rolls it back.
-    it 'flags the orphaned index claim when the Redis phase fails after claiming' do
-      allow(email_index).to receive(:hsetnx).and_return(true)
-      allow(customer).to receive(:update_in_class_email_index).and_raise(StandardError, 'redis gone')
+    # that never took the address — so it is released rather than handed to the
+    # operator as a doctor round-trip.
+    context 'when the Redis phase fails after the claim was won' do
+      before do
+        allow(email_index).to receive(:hsetnx).and_return(true)
+        allow(customer).to receive(:update_in_class_email_index).and_raise(StandardError, 'redis gone')
+        # Allowed purely so the negative assertions below are well-formed — the
+        # release must never route through the non-atomic HDEL wrapper.
+        allow(email_index).to receive(:remove_field)
+      end
 
-      result = op(db: nil).call
+      # The release MUST be compare-and-delete, not read-then-HDEL: winning the
+      # HSETNX proves we took the field, not that we still hold it, and Familia's
+      # auto-index on save is a blind HSET. A bare HDEL would therefore be able to
+      # unindex a DIFFERENT, live account that claimed the address in between.
+      it 'releases the claim by compare-and-delete on our own objid' do
+        result = op(db: nil).call
 
-      expect(result.status).to eq(:partial)
-      expect(result.warnings).to include(:email_index_claim_orphaned)
+        expect(index_dbclient).to have_received(:eval).with(
+          described_class::RELEASE_INDEX_CLAIM_SCRIPT,
+          keys: [index_dbkey],
+          argv: [new_email, 'obj_c'],
+        )
+        expect(email_index).not_to have_received(:remove_field)
+        expect(result.status).to eq(:partial)
+        expect(result.warnings).not_to include(:email_index_claim_orphaned)
+      end
+
+      it 'falls back to :email_index_claim_orphaned when the release itself fails' do
+        allow(index_dbclient).to receive(:eval).and_raise(StandardError, 'redis gone')
+
+        result = op(db: nil).call
+
+        expect(result.status).to eq(:partial)
+        expect(result.warnings).to include(:email_index_claim_orphaned)
+      end
+
+      # 0 == the field no longer names us: someone else's blind HSET landed on
+      # top of our claim, so the CAS correctly declines to delete THEIR live
+      # entry. That is exactly the mismatch `customers doctor` reconciles, so it
+      # must still warn — staying silent leaves that account unindexed with
+      # nobody told to run it.
+      it 'warns rather than deleting an entry that no longer names us' do
+        allow(index_dbclient).to receive(:eval).and_return(0)
+
+        result = op(db: nil).call
+
+        expect(result.status).to eq(:partial)
+        expect(result.warnings).to include(:email_index_claim_orphaned)
+      end
     end
 
     it 'degrades to Redis-only and reports auth_row_updated: false, never a phantom success' do
@@ -890,11 +1075,37 @@ RSpec.describe Auth::Operations::Customers::ChangeEmail do
   # Full mode is serialized by the unique index on accounts.email, which every
   # writer passes through BEFORE its Redis write — no Redis-level claim needed,
   # and a lost race surfaces as the UniqueConstraintViolation covered above.
-  describe 'full mode does not need the Redis claim' do
-    it 'never touches the index claim when an auth database is present' do
+  # That guard is the ROW, though, not the connection.
+  describe 'full mode: the claim follows the accounts row, not the connection' do
+    it 'never touches the index claim when the customer has an accounts row' do
       op.call
 
       expect(email_index).not_to have_received(:hsetnx)
+    end
+
+    # A customer with no accounts row (a provisioning gap sync-auth-accounts
+    # owns) updates nothing in step 1, so the unique constraint never fires.
+    # Skipping the claim because a connection exists would leave that write with
+    # no guard at all.
+    it 'still claims the index entry when the accounts row is missing' do
+      allow(by_external_id).to receive(:first).and_return(nil)
+      expect(email_index).to receive(:hsetnx).with(new_email, 'obj_c').and_return(1)
+
+      result = op.call
+
+      expect(result.status).to eq(:success)
+      expect(result.auth_row_updated).to be false
+    end
+
+    it 'aborts with :email_taken when that claim is lost' do
+      allow(by_external_id).to receive(:first).and_return(nil)
+      allow(email_index).to receive(:hsetnx).and_return(0)
+      allow(email_index).to receive(:get).with(new_email).and_return(nil, 'obj_other')
+
+      result = op.call
+
+      expect(result.status).to eq(:email_taken)
+      expect(customer).not_to have_received(:save)
     end
   end
 end

--- a/spec/cli/customers_change_email_command_spec.rb
+++ b/spec/cli/customers_change_email_command_spec.rb
@@ -29,7 +29,18 @@ RSpec.describe 'customers change-email', type: :cli do
 
   let(:op) { instance_double(Auth::Operations::Customers::ChangeEmail) }
 
+  # Defaults mirror the op's reporting under this command's default flags
+  # (require_verification: true, revoke_sessions: true): the swap-landed
+  # statuses — :success, :verification_not_reset, and the :partial carrying
+  # :secondary_writes_incomplete — report the auth-row write and the follow-up
+  # revocation; everything else reports false. `verification_reset` is false
+  # exactly where the op says the reset did NOT land: the downgraded status and
+  # the warning of the same name.
   def build_result(status:, **overrides)
+    warnings = overrides.fetch(:warnings, [])
+    landed   = %i[success verification_not_reset].include?(status) ||
+      (status == :partial && warnings.include?(:secondary_writes_incomplete))
+
     result_class.new(
       **{
         status: status,
@@ -37,11 +48,12 @@ RSpec.describe 'customers change-email', type: :cli do
         from: 'old@example.com',
         to: 'new@example.com',
         dry_run: status == :planned,
-        auth_row_updated: status == :success,
+        auth_row_updated: landed,
         orgs_reindexed: 0,
-        sessions_revoked: false,
-        verification_reset: false,
-        warnings: [],
+        sessions_revoked: landed,
+        verification_reset: landed && status != :verification_not_reset &&
+          !warnings.include?(:verification_not_reset),
+        warnings: warnings,
       }.merge(overrides),
     )
   end
@@ -197,8 +209,7 @@ RSpec.describe 'customers change-email', type: :cli do
   describe 'non-success statuses' do
     it 'surfaces :partial distinctly and exits non-zero' do
       allow(op).to receive(:call).and_return(
-        build_result(status: :partial, auth_row_updated: true,
-          warnings: %i[secondary_writes_incomplete]),
+        build_result(status: :partial, warnings: %i[secondary_writes_incomplete]),
       )
 
       output = run_cli_command_quietly('customers', 'change-email',
@@ -216,7 +227,7 @@ RSpec.describe 'customers change-email', type: :cli do
     # success and must not tell the operator to retry the change.
     it 'surfaces :verification_not_reset with the remediation and exits non-zero' do
       allow(op).to receive(:call).and_return(
-        build_result(status: :verification_not_reset, auth_row_updated: true,
+        build_result(status: :verification_not_reset,
           warnings: %i[verification_reset_failed verification_still_set]),
       )
 
@@ -324,7 +335,11 @@ RSpec.describe 'customers change-email', type: :cli do
     end
 
     it 'exits 1 while still emitting the payload on :partial' do
-      allow(op).to receive(:call).and_return(build_result(status: :partial))
+      # The op never emits a warnings-less :partial; this is the rolled-back
+      # sub-case shape.
+      allow(op).to receive(:call).and_return(
+        build_result(status: :partial, warnings: %i[auth_row_rolled_back]),
+      )
 
       output  = run_cli_command_quietly('customers', 'change-email',
         'old@example.com', 'new@example.com', '--apply', '--yes', '--json')

--- a/spec/cli/manifest_load_order_spec.rb
+++ b/spec/cli/manifest_load_order_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe 'CLI command file self-sufficiency' do
   harness = <<~RUBY
     cli_rb = File.join(Dir.pwd, 'lib/onetime/cli.rb')
     head, manifest = File.read(cli_rb).split('# Load core CLI commands', 2)
+    abort 'marker comment not found in lib/onetime/cli.rb' if manifest.nil?
     eval(head, TOPLEVEL_BINDING, cli_rb, 1)
 
     paths = manifest.scan(/^require_relative '([^']+)'/).flatten

--- a/try/unit/logic/account/email_change_try.rb
+++ b/try/unit/logic/account/email_change_try.rb
@@ -422,10 +422,12 @@ obj.success_data
 # Onetime::Operations::Sessions::RevokeAllForCustomer — index-first and
 # cap-proof, where the deleted scan-first sweep could exhaust its cap before
 # reaching the target's blobs and still report success at ~200k accounts
-# (revoke_all_for_customer.rb:34-43). The ADAPTER still owns exactly one line,
-# `sess.clear if sess`, because the current request's in-memory Rack session is
-# written back by the session middleware after process returns and would
-# otherwise re-create the blob the op just revoked.
+# (revoke_all_for_customer.rb:34-43). The ADAPTER still owns dropping THIS
+# request's session (`clear_current_session`, nil-guarded), because the current
+# request's in-memory Rack session is written back by the session middleware
+# after process returns and would otherwise re-create the blob the op just
+# revoked. It runs on every status where the swap landed — including the
+# `:partial` that then raises, which also revokes.
 #
 # So these cases assert the same guarantees through the surviving public entry
 # point, ConfirmEmailChange#process, via build_confirm (see setup).


### PR DESCRIPTION
Follow-ups to the `Customers::ChangeEmail` operation shipped in #3908:

- On a `:partial` whose swap landed (`:secondary_writes_incomplete` — both authoritative stores hold the new address), run the full follow-up phase exactly as on `:success`: revoke sessions, reset verification (warning `:verification_not_reset` when it cannot be confirmed), and notify both addresses. Previously the messy path silently skipped all three.
- The account-API adapter (`ConfirmEmailChange`) now clears the current request's session before the status mapping, so the caller is signed out on every path where the address actually changed hands — including landed partials and idempotent `:no_change`.
- The HSETNX index claim is now taken whenever no accounts row exists to serialize it (renamed `simple_mode_race_lost?` → `index_claim_race_lost?`), covering full-mode customers with a provisioning gap. On a failed partial the claim is released by a Lua compare-and-delete instead of being left orphaned; only an unreleasable claim warns.
- Colonel `ChangeUserEmail` interpolates result warnings into its PARTIAL form error so operators see `:verification_not_reset` and friends.
- New specs for the account-API and colonel adapters plus expanded operation specs (748 insertions).

Related to #3731