### PR TITLE
Add colonel transfer-ownership endpoint over the shipped org op

### DIFF
--- a/apps/api/colonel/logic/colonel.rb
+++ b/apps/api/colonel/logic/colonel.rb
@@ -60,6 +60,7 @@ require_relative 'colonel/list_organizations'
 require_relative 'colonel/get_organization_detail'
 require_relative 'colonel/investigate_organization'
 require_relative 'colonel/reconcile_organization'
+require_relative 'colonel/transfer_organization_ownership'
 require_relative 'colonel/manage_entitlement_override'
 
 # Memberships (#3731: add/remove/set-role — op-backed)

--- a/apps/api/colonel/logic/colonel/transfer_organization_ownership.rb
+++ b/apps/api/colonel/logic/colonel/transfer_organization_ownership.rb
@@ -21,10 +21,14 @@ module ColonelAPI
       # only HTTP concerns: params, authorization, org/customer resolution and
       # the response shape.
       #
-      # The OP records the single `organization.transfer_ownership`
-      # AdminAuditEvent (plus the two composed `membership.set_role` events —
-      # three per transfer, by design, D26). DO NOT audit here; a second event
-      # would double-record the trail.
+      # Audit (D26): the op records exactly ONE `organization.transfer_ownership`
+      # AdminAuditEvent per applied transfer — none on :no_change, a guardrail
+      # status, or a rolled-back failure. The composed SetRole calls each record
+      # their own `membership.set_role` event: nominally two (promote + demote),
+      # but 0..n in practice — promotion is skipped when the new owner already
+      # holds the owner role, stale owner memberships with no backing customer
+      # are skipped, and every extra owner membership (D29) demotes with its own
+      # event. DO NOT audit here; a second event would double-record the trail.
       #
       # The new owner MUST already be an active member (D28: one confirmation
       # must not both create a membership and hand it ownership) — :not_member
@@ -84,7 +88,9 @@ module ColonelAPI
 
         # PUBLIC extids only, matching the membership adapters (the op's Result
         # never carries an objid). Key names mirror the CLI's --json payload so
-        # the two adapters cannot drift.
+        # the two adapters cannot drift. `from_owner_id` is nil when
+        # `orphaned_owner` is true (org.owner_id was blank or pointed at a
+        # deleted customer) — the Zod schema marks it nullable to match.
         def success_data
           {
             record: {
@@ -102,8 +108,11 @@ module ColonelAPI
         private
 
         # Non-OK statuses mutate nothing and surface as 4xx form errors;
-        # :no_change is an idempotent 200 (already the sole owner). :planned
-        # cannot occur here — dry_run is pinned false above.
+        # :no_change is an idempotent 200 (already the sole owner). Anything
+        # else fails loudly: the op's status vocabulary is closed, and the Zod
+        # schema promises the FE only 'success' | 'no_change' ever ride a 200.
+        # :planned lands in the else on purpose — dry_run is pinned false
+        # above, so seeing it means the pin broke, not that a preview happened.
         def handle_result_status
           case result.status
           when :not_member
@@ -117,6 +126,10 @@ module ColonelAPI
               "#{Onetime::Operations::Org::TransferOwnership::DEMOTABLE_ROLES.join(', ')}",
               field: :demote_to,
             )
+          when :success, :no_change
+            # Fall through to success_data.
+          else
+            raise Onetime::Problem, "Unexpected transfer status: #{result.status}"
           end
         end
       end

--- a/apps/api/colonel/logic/colonel/transfer_organization_ownership.rb
+++ b/apps/api/colonel/logic/colonel/transfer_organization_ownership.rb
@@ -1,0 +1,125 @@
+# apps/api/colonel/logic/colonel/transfer_organization_ownership.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require_relative 'membership_resolvers'
+require 'onetime/operations/org/transfer_ownership'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Transfer an organization's ownership (Colonel) — the console peer of
+      # `bin/ots org transfer-ownership` (#3731 D33, filed as #3907).
+      #
+      # POST /api/colonel/organizations/:org_id/transfer-ownership
+      # Body: { "new_owner": "user@example.com", "demote_to": "admin" }
+      #
+      # Thin adapter over {Onetime::Operations::Org::TransferOwnership} — the
+      # single implementation of the transfer verb (promote-then-demote
+      # ordering, legacy owner_id pivot, best-effort rollback). This class owns
+      # only HTTP concerns: params, authorization, org/customer resolution and
+      # the response shape.
+      #
+      # The OP records the single `organization.transfer_ownership`
+      # AdminAuditEvent (plus the two composed `membership.set_role` events —
+      # three per transfer, by design, D26). DO NOT audit here; a second event
+      # would double-record the trail.
+      #
+      # The new owner MUST already be an active member (D28: one confirmation
+      # must not both create a membership and hand it ownership) — :not_member
+      # below tells the operator to add them first. This endpoint never
+      # fabricates a Customer (ADR-023).
+      #
+      # No `?dry_run=1` preview (decision D12 precedent, reconcile_organization):
+      # the op defaults to a dry run, but the admin UI has no preview flow
+      # today, so this adapter pins `dry_run: false`.
+      #
+      # Security invariant: BOTH the router (role=colonel) AND this logic
+      # (verify_one_of_roles!) enforce the colonel role.
+      class TransferOrganizationOwnership < ColonelAPI::Logic::Base
+        include MembershipResolvers
+
+        attr_reader :org, :new_owner, :demote_to, :result
+
+        def process_params
+          @org_id       = sanitize_identifier(params['org_id'])
+          # Email-tolerant (see AccountIdentifier) — sanitize_identifier strips
+          # '@' and '.', which would make the resolver's email arm unreachable.
+          @new_owner_id = sanitize_account_identifier(params['new_owner'])
+          @demote_to    = sanitize_plain_text(params['demote_to']).to_s.downcase
+          @demote_to    = 'admin' if @demote_to.empty?
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+
+          raise_form_error('Organization ID is required', field: :org_id) if @org_id.to_s.empty?
+          raise_form_error('New owner is required', field: :new_owner) if @new_owner_id.to_s.empty?
+
+          @org = resolve_org(@org_id)
+          raise_not_found('Organization not found') unless @org&.exists?
+
+          @new_owner = resolve_customer(@new_owner_id)
+          raise_not_found('Customer not found') unless @new_owner
+        end
+
+        def process
+          @result = Onetime::Operations::Org::TransferOwnership.new(
+            org: org,
+            new_owner: new_owner,
+            actor: cust.extid, # acting colonel's PUBLIC id (never an objid)
+            demote_to: demote_to,
+            # Pinned: no preview flow in the admin UI today (D12).
+            dry_run: false,
+          ).call
+
+          handle_result_status
+
+          OT.info "[TransferOrganizationOwnership] org=#{org.extid} to=#{new_owner.extid} " \
+                  "status=#{result.status} demoted=#{result.demoted.size}"
+
+          success_data
+        end
+
+        # PUBLIC extids only, matching the membership adapters (the op's Result
+        # never carries an objid). Key names mirror the CLI's --json payload so
+        # the two adapters cannot drift.
+        def success_data
+          {
+            record: {
+              org_id: org.extid,
+              status: result.status.to_s,
+              from_owner_id: result.from_owner_id,
+              to_owner_id: result.to_owner_id,
+              demoted: result.demoted,
+              demoted_to: result.from_owner_role_after,
+              orphaned_owner: result.orphaned_owner,
+            },
+          }
+        end
+
+        private
+
+        # Non-OK statuses mutate nothing and surface as 4xx form errors;
+        # :no_change is an idempotent 200 (already the sole owner). :planned
+        # cannot occur here — dry_run is pinned false above.
+        def handle_result_status
+          case result.status
+          when :not_member
+            raise_form_error(
+              'Customer is not an active member of the organization. Add them as a member first.',
+              field: :new_owner,
+            )
+          when :invalid_role
+            raise_form_error(
+              "Invalid demote_to role '#{demote_to}'. Must be one of: " \
+              "#{Onetime::Operations::Org::TransferOwnership::DEMOTABLE_ROLES.join(', ')}",
+              field: :demote_to,
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/routes.txt
+++ b/apps/api/colonel/routes.txt
@@ -63,6 +63,8 @@ GET    /organizations                     ColonelAPI::Logic::Colonel::ListOrgani
 GET    /organizations/:org_id             ColonelAPI::Logic::Colonel::GetOrganizationDetail response=json auth=sessionauth role=colonel scope=internal
 POST   /organizations/:org_id/investigate ColonelAPI::Logic::Colonel::InvestigateOrganization response=json auth=sessionauth role=colonel scope=internal
 POST   /organizations/:org_id/reconcile   ColonelAPI::Logic::Colonel::ReconcileOrganization response=json auth=sessionauth role=colonel scope=internal
+# Ownership transfer (#3907: op-backed, shared with `bin/ots org transfer-ownership`). Applies immediately — dry_run pinned false (D12: no preview flow in the console).
+POST   /organizations/:org_id/transfer-ownership ColonelAPI::Logic::Colonel::TransferOrganizationOwnership response=json auth=sessionauth role=colonel scope=internal
 
 # Entitlement Overrides (Phase 2: grant/revoke per-org entitlements)
 POST   /organizations/:org_id/entitlements/:action  ColonelAPI::Logic::Colonel::ManageEntitlementOverride response=json auth=sessionauth role=colonel scope=internal

--- a/apps/api/colonel/spec/logic/colonel/transfer_organization_ownership_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/transfer_organization_ownership_spec.rb
@@ -1,0 +1,194 @@
+# apps/api/colonel/spec/logic/colonel/transfer_organization_ownership_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'colonel/logic'
+require 'onetime/operations/org/transfer_ownership'
+
+# Adapter-layer coverage only. The transfer itself (promote-then-demote
+# ordering, the owner_id pivot, rollback, and the single audit event) lives in
+# Onetime::Operations::Org::TransferOwnership; the CLI adapter is covered by
+# its own spec. These examples assert what THIS adapter owns: param handling
+# and resolution, the pinned dry_run, status→HTTP mapping, and that it records
+# NO audit event of its own (CONTRACT 4 — the op owns the trail).
+RSpec.describe ColonelAPI::Logic::Colonel::TransferOrganizationOwnership do
+  let(:result_class) { Onetime::Operations::Org::TransferOwnership::Result }
+  let(:op) { instance_double(Onetime::Operations::Org::TransferOwnership) }
+
+  let(:colonel) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_colonel', extid: 'ur_colonel',
+      role: 'colonel', verified?: true, anonymous?: false)
+  end
+
+  let(:org) do
+    instance_double(Onetime::Organization,
+      objid: 'org_internal', extid: 'or_target', exists?: true)
+  end
+
+  let(:new_owner) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_new', extid: 'ur_newowner', anonymous?: false)
+  end
+
+  let(:strategy_result) do
+    double('StrategyResult', session: {}, user: colonel,
+      auth_method: 'sessionauth', metadata: {})
+  end
+
+  def build_result(status:, **overrides)
+    result_class.new(
+      **{
+        status: status,
+        org_id: 'or_target',
+        from_owner_id: 'ur_oldowner',
+        from_owner_role_after: 'admin',
+        to_owner_id: 'ur_newowner',
+        demoted: status == :success ? ['ur_oldowner'] : [],
+        orphaned_owner: false,
+        dry_run: false,
+      }.merge(overrides),
+    )
+  end
+
+  # Builds the logic with the two required params plus whatever the example is
+  # exercising, and pins the op's answer. Callers still drive raise_concerns
+  # (which resolves @org and @new_owner) before process, as the controller does.
+  def logic_for(params = {}, status: :success, **result_overrides)
+    allow(op).to receive(:call).and_return(build_result(status: status, **result_overrides))
+    described_class.new(
+      strategy_result,
+      { 'org_id' => 'or_target', 'new_owner' => 'ur_newowner' }.merge(params),
+    )
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(Onetime::Organization).to receive(:find_by_extid).and_return(org)
+    allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(new_owner)
+    allow(Onetime::Operations::Org::TransferOwnership).to receive(:new).and_return(op)
+    allow(Onetime::AdminAuditEvent).to receive(:record)
+  end
+
+  describe 'success path' do
+    it 'returns the ack record with PUBLIC extids only' do
+      logic = logic_for
+      logic.raise_concerns
+      data = logic.process
+
+      expect(data[:record][:org_id]).to eq('or_target')
+      expect(data[:record][:status]).to eq('success')
+      expect(data[:record][:from_owner_id]).to eq('ur_oldowner')
+      expect(data[:record][:to_owner_id]).to eq('ur_newowner')
+      expect(data[:record][:demoted]).to eq(['ur_oldowner'])
+      expect(data[:record][:demoted_to]).to eq('admin')
+      expect(data[:record][:orphaned_owner]).to be false
+    end
+
+    it 'hands the op the colonel extid as actor, never a synthesized identity' do
+      logic = logic_for
+      logic.raise_concerns
+      logic.process
+
+      expect(Onetime::Operations::Org::TransferOwnership).to have_received(:new)
+        .with(hash_including(org: org, new_owner: new_owner, actor: 'ur_colonel'))
+    end
+
+    it 'defaults demote_to to admin and threads an explicit value through downcased' do
+      logic = logic_for
+      logic.raise_concerns
+      logic.process
+      expect(Onetime::Operations::Org::TransferOwnership).to have_received(:new)
+        .with(hash_including(demote_to: 'admin'))
+
+      logic = logic_for({ 'demote_to' => 'Member' })
+      logic.raise_concerns
+      logic.process
+      expect(Onetime::Operations::Org::TransferOwnership).to have_received(:new)
+        .with(hash_including(demote_to: 'member'))
+    end
+
+    it 'records no audit event of its own (the op owns the trail)' do
+      logic = logic_for
+      logic.raise_concerns
+      logic.process
+
+      expect(Onetime::AdminAuditEvent).not_to have_received(:record)
+    end
+  end
+
+  describe 'dry_run pinned false (D12 — no preview flow in the console)' do
+    it 'passes dry_run: false to the op' do
+      logic = logic_for
+      logic.raise_concerns
+      logic.process
+
+      expect(Onetime::Operations::Org::TransferOwnership).to have_received(:new)
+        .with(hash_including(dry_run: false))
+    end
+
+    it 'ignores a dry_run param — there is no preview contract to honor' do
+      logic = logic_for({ 'dry_run' => 'true' })
+      logic.raise_concerns
+      logic.process
+
+      expect(Onetime::Operations::Org::TransferOwnership).to have_received(:new)
+        .with(hash_including(dry_run: false))
+    end
+  end
+
+  describe 'status mapping' do
+    it 'treats :no_change as an idempotent 200' do
+      logic = logic_for(status: :no_change)
+      logic.raise_concerns
+      data = logic.process
+
+      expect(data[:record][:status]).to eq('no_change')
+      expect(data[:record][:demoted]).to eq([])
+    end
+
+    it 'raises a form error on :not_member with the add-first remediation' do
+      logic = logic_for(status: :not_member)
+      logic.raise_concerns
+
+      expect { logic.process }.to raise_error(Onetime::FormError, /not an active member/)
+    end
+
+    it 'raises a form error on :invalid_role naming the demotable roles' do
+      logic = logic_for({ 'demote_to' => 'bogus' }, status: :invalid_role)
+      logic.raise_concerns
+
+      expect { logic.process }.to raise_error(Onetime::FormError) do |err|
+        expect(err.message).to include('bogus')
+        expect(err.message).to include(
+          Onetime::Operations::Org::TransferOwnership::DEMOTABLE_ROLES.join(', '),
+        )
+      end
+    end
+  end
+
+  describe 'resolution' do
+    it 'raises not-found when the org does not resolve' do
+      allow(Onetime::Organization).to receive(:find_by_extid).and_return(nil)
+      allow(Onetime::Organization).to receive(:load).and_return(nil)
+
+      expect { logic_for.raise_concerns }.to raise_error(Onetime::RecordNotFound)
+    end
+
+    it 'raises not-found when the new owner does not resolve' do
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(nil)
+      allow(Onetime::Customer).to receive(:load).and_return(nil)
+
+      expect { logic_for.raise_concerns }.to raise_error(Onetime::RecordNotFound)
+    end
+
+    it 'requires a new_owner param' do
+      logic = logic_for({ 'new_owner' => '' })
+
+      expect { logic.raise_concerns }.to raise_error(Onetime::FormError, /New owner is required/)
+    end
+  end
+end

--- a/apps/api/colonel/spec/logic/colonel/transfer_organization_ownership_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/transfer_organization_ownership_spec.rb
@@ -168,6 +168,22 @@ RSpec.describe ColonelAPI::Logic::Colonel::TransferOrganizationOwnership do
         )
       end
     end
+
+    it 'fails loudly on a status outside the adapter contract, never a 200' do
+      logic = logic_for(status: :landed_partial)
+      logic.raise_concerns
+
+      expect { logic.process }
+        .to raise_error(Onetime::Problem, /Unexpected transfer status: landed_partial/)
+    end
+
+    it 'treats a leaked :planned as a broken dry_run pin, not a preview 200' do
+      logic = logic_for(status: :planned, dry_run: true)
+      logic.raise_concerns
+
+      expect { logic.process }
+        .to raise_error(Onetime::Problem, /Unexpected transfer status: planned/)
+    end
   end
 
   describe 'resolution' do

--- a/src/schemas/api/internal/responses/colonel-organizations.ts
+++ b/src/schemas/api/internal/responses/colonel-organizations.ts
@@ -235,3 +235,35 @@ export type ColonelReconcileOrganizationRecord = z.infer<
 export type ColonelReconcileOrganizationResponse = z.infer<
   typeof colonelReconcileOrganizationResponseSchema
 >;
+
+/**
+ * `POST /api/colonel/organizations/:org_id/transfer-ownership` → `{ record }`
+ * ack (#3907 — console peer of `bin/ots org transfer-ownership`). MUTATING:
+ * promotes the new owner, pivots the legacy `owner_id` mirror, and demotes
+ * every other owner membership. All ids are PUBLIC extids (mirroring
+ * `TransferOrganizationOwnership#success_data`, which mirrors the CLI's --json
+ * payload). `from_owner_id` is null when the previous `owner_id` pointed at no
+ * live customer (`orphaned_owner: true` — the transfer repairs it). `status`
+ * is the op's vocabulary verbatim (`success` | `no_change` — failure statuses
+ * surface as 4xx form errors, never as a 200).
+ */
+export const colonelTransferOrganizationOwnershipRecordSchema = z.object({
+  org_id: z.string(),
+  status: z.string(),
+  from_owner_id: z.string().nullable(),
+  to_owner_id: z.string(),
+  demoted: z.array(z.string()),
+  demoted_to: z.string(),
+  orphaned_owner: z.boolean(),
+});
+
+export const colonelTransferOrganizationOwnershipResponseSchema = createApiResponseSchema(
+  colonelTransferOrganizationOwnershipRecordSchema
+);
+
+export type ColonelTransferOrganizationOwnershipRecord = z.infer<
+  typeof colonelTransferOrganizationOwnershipRecordSchema
+>;
+export type ColonelTransferOrganizationOwnershipResponse = z.infer<
+  typeof colonelTransferOrganizationOwnershipResponseSchema
+>;

--- a/src/schemas/api/internal/responses/registry.ts
+++ b/src/schemas/api/internal/responses/registry.ts
@@ -38,6 +38,7 @@ import {
   colonelEntitlementOverrideResponseSchema,
   colonelOrganizationDetailResponseSchema,
   colonelReconcileOrganizationResponseSchema,
+  colonelTransferOrganizationOwnershipResponseSchema,
 } from './colonel-organizations';
 import { colonelBanIpResponseSchema, colonelUnbanIpResponseSchema } from './colonel-bannedips';
 
@@ -165,6 +166,7 @@ export const responseSchemas = {
   colonelOrganizationDetail: colonelOrganizationDetailResponseSchema,
   investigateOrganization: investigateOrganizationResponseSchema,
   colonelReconcileOrganization: colonelReconcileOrganizationResponseSchema,
+  colonelTransferOrganizationOwnership: colonelTransferOrganizationOwnershipResponseSchema,
   colonelEntitlementOverride: colonelEntitlementOverrideResponseSchema,
   databaseMetrics: databaseMetricsResponseSchema,
   brandDiagnostics: brandDiagnosticsResponseSchema,


### PR DESCRIPTION
Item 1 from #3907.

## Changes

Adds `POST /organizations/:org_id/transfer-ownership` to the colonel API as a thin adapter over the already-shipped transfer-ownership operation:

- Email-tolerant owner resolution (accepts an email or an identifier for the new owner)
- Real colonel extid used as the actor
- `dry_run` pinned to `false`, following the D12 reconcile precedent
- No self-audit — asserted by spec
- Zod response schemas registered

**Convention note:** this endpoint deliberately uses `org_id:` extid, not reconcile's legacy-objid convention.

## Testing

- 12 new examples + 35 directory examples green
- `vue-tsc` clean

Refs #3907
