### PR TITLE
[#3911] Enforce AUTH_ENABLED master switch in SSO config

### DIFF
--- a/apps/web/core/spec/views/serializers/config_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/config_serializer_spec.rb
@@ -351,8 +351,9 @@ RSpec.describe Core::Views::ConfigSerializer do
           allow(mock_auth_config).to receive(:sso_providers).and_return([
             { 'route_name' => 'oidc', 'display_name' => 'Corporate SSO' },
           ])
-          # Master switch off: build_platform_sso_config returns the disabled
-          # shape before consulting env-var provider config.
+          # Master switch off: build_sso_config early-returns the disabled
+          # shape before consulting env-var provider config
+          # (build_platform_sso_config re-checks as defense in depth).
           allow(OT).to receive(:conf).and_return(
             { 'site' => { 'authentication' => { 'enabled' => false } } }
           )
@@ -381,6 +382,7 @@ RSpec.describe Core::Views::ConfigSerializer do
         let(:domain_sso_config) do
           instance_double(
             Onetime::CustomDomain::SsoConfig,
+            domain_id: domain_id,
             enabled?: true,
             provider_type: 'entra_id',
             display_name: 'Contoso Azure AD',
@@ -411,12 +413,28 @@ RSpec.describe Core::Views::ConfigSerializer do
           expect(mock_auth_config).not_to receive(:sso_providers)
           described_class.build_sso_config(custom_domain_view_vars)
         end
+
+        # Single-read contract: the availability check and the returned
+        # record must come from ONE find_by_domain_id call, so a concurrent
+        # disable/delete cannot pass the check on one read and hand back a
+        # stale (or nil) record on a second.
+        it 'loads the SsoConfig once and returns the record the availability check saw' do
+          expect(Onetime::CustomDomain::SsoConfig).to receive(:find_by_domain_id)
+            .with(domain_id)
+            .once
+            .and_return(domain_sso_config)
+
+          result = described_class.resolve_tenant_sso_config(custom_domain_view_vars)
+
+          expect(result).to be(domain_sso_config)
+        end
       end
 
       context 'when SigninConfig blocks SSO (sso_permitted_for? returns false)' do
         let(:domain_sso_config) do
           instance_double(
             Onetime::CustomDomain::SsoConfig,
+            domain_id: domain_id,
             enabled?: true,
             provider_type: 'oidc',
             display_name: 'Corp SSO',
@@ -473,6 +491,7 @@ RSpec.describe Core::Views::ConfigSerializer do
         let(:domain_sso_config) do
           instance_double(
             Onetime::CustomDomain::SsoConfig,
+            domain_id: domain_id,
             enabled?: false,
             provider_type: 'entra_id',
             display_name: 'Contoso Azure AD'
@@ -596,6 +615,7 @@ RSpec.describe Core::Views::ConfigSerializer do
         let(:domain_sso_config) do
           instance_double(
             Onetime::CustomDomain::SsoConfig,
+            domain_id: domain_id,
             enabled?: true,
             provider_type: 'entra_id',
             display_name: 'Acme Corp Entra',

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -300,6 +300,7 @@ module Core
         # platform SSO configuration (from env vars).
         #
         # Resolution priority:
+        #   0. AUTH_ENABLED master switch off => disabled, unconditionally
         #   1. CustomDomain::SsoConfig for tenant (if custom domain with domain SSO config)
         #   2. Platform SSO providers (from env vars, if fallback allowed)
         #   3. Disabled (empty providers)
@@ -307,6 +308,17 @@ module Core
         # @param view_vars [Hash] View variables containing domain context
         # @return [Boolean, Hash] false if disabled, otherwise config hash
         def build_sso_config(view_vars)
+          # AUTH_ENABLED master switch: with authentication off there is no
+          # SSO surface at all — tenant or platform — so return the disabled
+          # shape before resolving anything. The tenant ladder
+          # (SsoConfig.tenant_sso_unavailable_reason, rung :auth_disabled)
+          # and build_platform_sso_config each enforce this too, but the
+          # branches below must not depend on those internal checks: the
+          # master switch is this method's own contract, guarded here.
+          unless Onetime::CustomDomain::SigninConfig.global_auth_enabled
+            return { 'enabled' => false, 'providers' => [] }
+          end
+
           # Try tenant-specific SSO config first
           tenant_config = resolve_tenant_sso_config(view_vars)
 
@@ -340,14 +352,26 @@ module Core
         # governs the TENANT's SSO only; build_sso_config's platform-fallback
         # policy is unchanged.
         #
+        # Single-read contract: the record is loaded exactly once and handed
+        # to the availability check via its sso_config: pass-through, so the
+        # verdict and the returned record are the same object. Checking first
+        # and re-loading after would leave a window where an operator
+        # disabling or deleting the SsoConfig between the two reads passes the
+        # check but returns nil — and build_sso_config would then silently
+        # fall through to platform fallback for a domain that had tenant SSO
+        # a moment earlier.
+        #
         # @param view_vars [Hash] View variables
         # @return [Onetime::CustomDomain::SsoConfig, nil] Config if found and enabled
         def resolve_tenant_sso_config(view_vars)
           domain_id = resolve_domain_id(view_vars)
           return nil unless domain_id
-          return nil unless Onetime::CustomDomain::SsoConfig.tenant_sso_available_for?(domain_id)
 
-          Onetime::CustomDomain::SsoConfig.find_by_domain_id(domain_id)
+          config = Onetime::CustomDomain::SsoConfig.find_by_domain_id(domain_id)
+          return nil unless config
+          return nil unless Onetime::CustomDomain::SsoConfig.tenant_sso_available_for?(domain_id, sso_config: config)
+
+          config
         end
 
         # Resolve domain identifier from view variables
@@ -436,10 +460,11 @@ module Core
         # This is the original behavior - reading SSO providers from
         # AuthConfig which derives them from environment variables.
         #
-        # Gated on the AUTH_ENABLED master switch (mirroring
-        # SsoConfig.tenant_sso_unavailable_reason) so platform SSO buttons
-        # go dark on the canonical host too, not just tenant fallback —
-        # hence the guard lives here rather than in allow_platform_fallback?.
+        # Also gated on the AUTH_ENABLED master switch as defense in depth:
+        # build_sso_config (the sole caller today) returns the disabled shape
+        # before reaching here, but this builder must never advertise platform
+        # providers on its own if it gains another caller — so it re-checks
+        # rather than relying on the caller's guard.
         #
         # @return [Boolean, Hash] false if disabled, otherwise config hash
         def build_platform_sso_config


### PR DESCRIPTION
Add a global authentication check to `build_sso_config` to ensure SSO is disabled when the master switch is off, and update `resolve_tenant_sso_config` to use a single-read pattern to prevent race conditions during record lookup and availability validation.
