### PR TITLE
Remove issuerless google/github from tenant SSO provider surface

### DIFF
--- a/apps/api/domains/logic/sso_config/get_sso_config.rb
+++ b/apps/api/domains/logic/sso_config/get_sso_config.rb
@@ -16,7 +16,7 @@ module DomainsAPI
       #   Requires the requesting user to be an organization owner with manage_sso.
       #
       # Response includes:
-      # - provider_type: oidc, entra_id, google, github
+      # - provider_type: oidc or entra_id (tenant SSO is OIDC/Entra-only, #3902)
       # - client_id: Full client ID (not sensitive)
       # - client_secret_masked: Masked (e.g., "••••••••abcd")
       # - tenant_id: For Entra ID

--- a/apps/api/domains/logic/sso_config/patch_sso_config.rb
+++ b/apps/api/domains/logic/sso_config/patch_sso_config.rb
@@ -159,7 +159,9 @@ module DomainsAPI
         # For new configs: provider_type is required
         # For updates: falls back to existing config value when not provided
         def validate_provider_type
-          if @provider_type.to_s.empty?
+          from_request = !@provider_type.to_s.empty?
+
+          unless from_request
             if @existing_config
               @provider_type = @existing_config.provider_type
             else
@@ -169,8 +171,22 @@ module DomainsAPI
 
           return if VALID_PROVIDER_TYPES.include?(@provider_type)
 
+          if from_request
+            raise_form_error(
+              "Invalid provider type. Must be one of: #{VALID_PROVIDER_TYPES.join(', ')}",
+              field: :provider_type,
+              error_type: :invalid,
+            )
+          end
+
+          # The invalid type came from the stored record, not the request:
+          # pre-#3902 legacy data (google/github). Still fail closed — even a
+          # bare `{enabled: false}` PATCH cannot resurrect a record the model
+          # no longer accepts — but blame the record, not a field the caller
+          # never sent. DELETE and full PUT remain the escape hatches.
           raise_form_error(
-            "Invalid provider type. Must be one of: #{VALID_PROVIDER_TYPES.join(', ')}",
+            "This configuration uses provider type '#{@provider_type}', which is no longer supported. " \
+            "Delete it, or replace it with a full update (PUT) using one of: #{VALID_PROVIDER_TYPES.join(', ')}",
             field: :provider_type,
             error_type: :invalid,
           )
@@ -259,7 +275,9 @@ module DomainsAPI
         #
         # PATCH Semantics:
         # - Optional fields are preserved when omitted, allowing partial updates.
-        # - Provider-specific fields are preserved on provider switch.
+        # - A provider switch clears the outgoing provider's field (issuer for
+        #   oidc, tenant_id for entra_id) unless the request supplies it,
+        #   matching the end state a full PUT would produce.
         #
         # allowed_domains behavior:
         # - When omitted: preserves existing domains (true PATCH semantics)
@@ -270,7 +288,8 @@ module DomainsAPI
         # config could be deleted between existence check and update.
         #
         def update_existing_config
-          @sso_config = @existing_config
+          @sso_config       = @existing_config
+          provider_switched = @provider_type != @existing_config.provider_type
 
           # PATCH semantics: only update fields that are provided (non-empty)
           @sso_config.provider_type    = @provider_type
@@ -281,6 +300,15 @@ module DomainsAPI
           @sso_config.enabled          = @enabled.to_s if @enabled_provided
           @sso_config.enforce_sso_only = @enforce_sso_only.to_s if @enforce_sso_only_provided
           @sso_config.grant_org_scope  = @grant_org_scope.to_s if @grant_org_scope_provided
+
+          # A provider switch clears the outgoing provider's field so the
+          # record matches what a full PUT would produce — an entra_id record
+          # must not carry a stale oidc issuer, nor an oidc record a stale
+          # tenant_id. Request-supplied values are never discarded.
+          if provider_switched
+            @sso_config.issuer    = '' if @provider_type == 'entra_id' && @issuer.to_s.empty?
+            @sso_config.tenant_id = '' if @provider_type == 'oidc' && @tenant_id.to_s.empty?
+          end
 
           # Only update client_secret if provided (preserves existing otherwise)
           @sso_config.client_secret = @client_secret unless @client_secret.to_s.empty?

--- a/apps/api/domains/logic/sso_config/patch_sso_config.rb
+++ b/apps/api/domains/logic/sso_config/patch_sso_config.rb
@@ -21,7 +21,9 @@ module DomainsAPI
       # Request body:
       # - provider_type: Required for create, optional for update (uses existing if empty)
       # - client_id: Required for create, optional for update (uses existing if empty)
-      # - client_secret: Required for create, optional for update (preserves existing if empty)
+      # - client_secret: Required for create (except OIDC public clients),
+      #   optional for update (preserves existing if empty). Switching to a
+      #   non-OIDC provider requires a secret — from the request or already stored.
       # - tenant_id: Required for entra_id provider on create (preserves existing if empty)
       # - issuer: Required for oidc provider on create (preserves existing if empty)
       # - display_name: Optional. Human-readable name (preserves existing if empty)
@@ -187,11 +189,25 @@ module DomainsAPI
             end
           end
 
-          # client_secret is required for new non-OIDC configs, optional for updates (preserves existing).
-          # OIDC supports public clients (PKCE flow) without a client secret.
-          if @existing_config.nil? && @client_secret.to_s.empty? && @provider_type != 'oidc'
+          # client_secret is required for non-OIDC configs; OIDC supports
+          # public clients (PKCE flow) without one. An omitted secret on
+          # update falls back to the stored one — so a provider switch from
+          # a secretless OIDC config to entra_id has nothing to fall back to
+          # and must supply a secret, or token exchange fails at the IdP.
+          return if @provider_type == 'oidc' || !@client_secret.to_s.empty?
+
+          if @existing_config.nil? || !stored_client_secret?
             raise_form_error('Client secret is required', field: :client_secret, error_type: :missing)
           end
+        end
+
+        # Whether the stored record has a non-empty client_secret to preserve.
+        # An undecryptable secret counts as absent — fail closed.
+        def stored_client_secret?
+          secret = @existing_config.client_secret&.reveal { it }
+          !secret.to_s.empty?
+        rescue StandardError
+          false
         end
 
         def validate_provider_specific_fields
@@ -274,6 +290,12 @@ module DomainsAPI
 
           # Update timestamp for partial update
           @sso_config.updated = Familia.now.to_i
+
+          # Fail closed if the request validators above missed a field
+          # combination: the model owns the invariants (SsoConfig#validation_errors)
+          # and nothing invalid may be committed.
+          errors = @sso_config.validation_errors
+          raise_form_error(errors.join('; '), error_type: :invalid) if errors.any?
 
           # commit_fields runs its own transaction internally for atomicity
           @sso_config.commit_fields

--- a/apps/api/domains/logic/sso_config/put_sso_config.rb
+++ b/apps/api/domains/logic/sso_config/put_sso_config.rb
@@ -220,6 +220,12 @@ module DomainsAPI
           # Update timestamp for replacement
           @sso_config.updated = Familia.now.to_i
 
+          # Fail closed if the request validators above missed a field
+          # combination: the model owns the invariants (SsoConfig#validation_errors)
+          # and nothing invalid may be committed.
+          errors = @sso_config.validation_errors
+          raise_form_error(errors.join('; '), error_type: :invalid) if errors.any?
+
           # commit_fields runs its own transaction internally for atomicity
           @sso_config.commit_fields
         end

--- a/apps/api/domains/logic/sso_config/put_sso_config.rb
+++ b/apps/api/domains/logic/sso_config/put_sso_config.rb
@@ -19,7 +19,8 @@ module DomainsAPI
       #   Requires the requesting user to be an organization owner with manage_sso.
       #
       # Request body:
-      # - provider_type: Required. One of: oidc, entra_id, google, github
+      # - provider_type: Required. One of: oidc, entra_id (tenant SSO is
+      #   OIDC/Entra-only — issuerless providers were removed, #3902)
       # - client_id: Required. OAuth client ID
       # - client_secret: Required. OAuth client secret
       # - tenant_id: Required for entra_id provider, empty/null for others

--- a/apps/api/domains/logic/sso_config/put_sso_config.rb
+++ b/apps/api/domains/logic/sso_config/put_sso_config.rb
@@ -22,7 +22,9 @@ module DomainsAPI
       # - provider_type: Required. One of: oidc, entra_id (tenant SSO is
       #   OIDC/Entra-only — issuerless providers were removed, #3902)
       # - client_id: Required. OAuth client ID
-      # - client_secret: Required. OAuth client secret
+      # - client_secret: Required, except for OIDC (public-client/PKCE flows
+      #   may omit it — see validate_client_credentials). A PUT that omits it
+      #   clears any previously stored secret, per full-replacement semantics.
       # - tenant_id: Required for entra_id provider, empty/null for others
       # - issuer: Required for oidc provider, empty/null for others
       # - display_name: Optional. Human-readable name (defaults to empty)
@@ -70,7 +72,8 @@ module DomainsAPI
           # Validate provider_type
           validate_provider_type
 
-          # Validate client credentials (always required for PUT)
+          # Validate client credentials (client_id always; client_secret
+          # except for OIDC — see header comment)
           validate_client_credentials
 
           # Validate provider-specific fields
@@ -206,7 +209,7 @@ module DomainsAPI
           @sso_config.provider_type    = @provider_type
           @sso_config.display_name     = @display_name    # Empty string clears the field
           @sso_config.client_id        = @client_id
-          @sso_config.client_secret    = @client_secret   # Always required for PUT
+          @sso_config.client_secret    = @client_secret   # Empty clears it (OIDC only; validate_client_credentials requires it non-empty otherwise)
           @sso_config.tenant_id        = @tenant_id       # Empty string clears the field
           @sso_config.issuer           = @issuer          # Empty string clears the field
           @sso_config.allowed_domains  = @allowed_domains # Empty array clears the field

--- a/apps/api/domains/logic/sso_config/test_connection.rb
+++ b/apps/api/domains/logic/sso_config/test_connection.rb
@@ -32,7 +32,8 @@ module DomainsAPI
       #   See: ssrf_protection.rb for implementation details.
       #
       # Request body:
-      # - provider_type: Required. One of: oidc, entra_id, google, github
+      # - provider_type: Required. One of: oidc, entra_id (tenant SSO is
+      #   OIDC/Entra-only — issuerless providers were removed, #3902)
       # - client_id: Required. OAuth client ID
       # - tenant_id: Required for entra_id provider
       # - issuer: Required for oidc provider (HTTPS URL)
@@ -99,10 +100,6 @@ module DomainsAPI
                      test_oidc_connection
                    when 'entra_id'
                      test_entra_id_connection
-                   when 'google'
-                     test_google_connection
-                   when 'github'
-                     test_github_connection
                    else
                      { success: false, message: "Unsupported provider type: #{@provider_type}" }
                    end
@@ -160,10 +157,6 @@ module DomainsAPI
             validate_oidc_fields
           when 'entra_id'
             validate_entra_id_fields
-          when 'google'
-            validate_google_fields
-          when 'github'
-            validate_github_fields
           end
         end
 
@@ -189,29 +182,6 @@ module DomainsAPI
           raise_form_error(
             'Tenant ID must be a valid UUID',
             field: :tenant_id,
-            error_type: :invalid,
-          )
-        end
-
-        def validate_google_fields
-          # Google client_id format: ends with .apps.googleusercontent.com
-          return if @client_id.end_with?('.apps.googleusercontent.com')
-
-          raise_form_error(
-            'Google Client ID must end with .apps.googleusercontent.com',
-            field: :client_id,
-            error_type: :invalid,
-          )
-        end
-
-        def validate_github_fields
-          # GitHub client_id format: "Iv1." prefix followed by hex characters
-          # Example: Iv1.8a61f9b3a7aba766
-          return if @client_id.match?(/\AIv1\.[0-9a-f]{10,40}\z/i)
-
-          raise_form_error(
-            'GitHub Client ID must be in format Iv1.{hex} (e.g., Iv1.8a61f9b3a7aba766)',
-            field: :client_id,
             error_type: :invalid,
           )
         end
@@ -242,25 +212,6 @@ module DomainsAPI
         def test_entra_id_connection
           discovery_url = "https://login.microsoftonline.com/#{@tenant_id}/v2.0/.well-known/openid-configuration"
           fetch_and_validate_discovery(discovery_url, 'Entra ID')
-        end
-
-        def test_google_connection
-          discovery_url = 'https://accounts.google.com/.well-known/openid-configuration'
-          fetch_and_validate_discovery(discovery_url, 'Google')
-        end
-
-        def test_github_connection
-          # GitHub doesn't have OIDC discovery - just validate format
-          # The client_id format was already validated in validate_github_fields
-          {
-            success: true,
-            provider_type: @provider_type,
-            message: 'GitHub credentials format validated',
-            details: {
-              client_id_format: 'valid',
-              note: 'GitHub does not support OIDC discovery. Credentials will be validated during authentication.',
-            },
-          }
         end
 
         # ──────────────────────────────────────────────────────────────────────────

--- a/apps/api/domains/spec/integration/simple/domain_sso_config_spec.rb
+++ b/apps/api/domains/spec/integration/simple/domain_sso_config_spec.rb
@@ -300,6 +300,27 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
           # Old OIDC-specific fields should be cleared
           expect(record['issuer']).to be_empty.or be_nil
         end
+
+        it 'clears a stored client_secret when an OIDC PUT omits it' do
+          params = valid_oidc_params.dup
+          params.delete(:client_secret)
+
+          csrf_put api_path(test_custom_domain.extid), params
+
+          expect(last_response.status).to eq(200)
+
+          # PUT is full replacement: an omitted client_secret is CLEARED, not
+          # preserved — legal only for OIDC (public client/PKCE); entra_id gets
+          # 422 (see 'returns 422 for missing client_secret on PUT'). PATCH is
+          # the secret-preserving verb; the frontend routes secretless saves
+          # there (sso.service.ts#saveConfigForDomain).
+          record = json_body['record']
+          expect(record['client_secret_masked']).to be_nil
+
+          # Persisted state agrees with the response
+          json_get api_path(test_custom_domain.extid)
+          expect(json_body['record']['client_secret_masked']).to be_nil
+        end
       end
 
       context 'validation errors' do

--- a/apps/api/domains/spec/integration/simple/domain_sso_config_spec.rb
+++ b/apps/api/domains/spec/integration/simple/domain_sso_config_spec.rb
@@ -788,47 +788,35 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
       end
     end
 
-    context 'with valid Google config' do
+    # Tenant SSO is OIDC/Entra-only (#3902): issuerless providers (google,
+    # github) resolve to the shared '' issuer sentinel and cannot satisfy
+    # (provider, issuer, uid) identity partitioning, so they are rejected
+    # at the provider_type gate.
+    context 'with removed issuerless provider types (#3902)' do
       before { login_as(test_owner) }
 
-      let(:google_test_params) do
-        {
+      it 'rejects google as an invalid provider type' do
+        csrf_post test_connection_path(test_custom_domain.extid), {
           provider_type: 'google',
           client_id: 'test-client.apps.googleusercontent.com',
         }
-      end
 
-      it 'tests Google connection' do
-        stub_request(:get, "https://accounts.google.com/.well-known/openid-configuration").to_return(status: 200, body: %Q({"issuer":"https://accounts.google.com"}), headers: {"Content-Type" => "application/json"})
-
-        csrf_post test_connection_path(test_custom_domain.extid), google_test_params
-
-        expect(last_response.status).to eq(200)
-
+        expect(last_response.status).to eq(422)
         body = json_body
-        expect(body['provider_type']).to eq('google')
+        expect(body['error']).to include('Invalid provider type')
+        expect(body['error']).to include('oidc, entra_id')
       end
-    end
 
-    context 'with valid GitHub config' do
-      before { login_as(test_owner) }
-
-      let(:github_test_params) do
-        {
+      it 'rejects github as an invalid provider type' do
+        csrf_post test_connection_path(test_custom_domain.extid), {
           provider_type: 'github',
           client_id: 'Iv1.1234567890abcdef',
         }
-      end
 
-      it 'validates GitHub config format (no network test)' do
-        csrf_post test_connection_path(test_custom_domain.extid), github_test_params
-
-        expect(last_response.status).to eq(200)
-
+        expect(last_response.status).to eq(422)
         body = json_body
-        expect(body['provider_type']).to eq('github')
-        expect(body['success']).to be true
-        expect(body['message']).to include('format validated')
+        expect(body['error']).to include('Invalid provider type')
+        expect(body['error']).to include('oidc, entra_id')
       end
     end
 
@@ -890,27 +878,6 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
         expect(body['error']).to include('Issuer URL')
       end
 
-      it 'returns 422 for invalid Google client_id format' do
-        csrf_post test_connection_path(test_custom_domain.extid), {
-          provider_type: 'google',
-          client_id: 'invalid-google-client',
-        }
-
-        expect(last_response.status).to eq(422)
-        body = json_body
-        expect(body['error']).to include('googleusercontent.com')
-      end
-
-      it 'returns 422 for invalid GitHub client_id format' do
-        csrf_post test_connection_path(test_custom_domain.extid), {
-          provider_type: 'github',
-          client_id: 'invalid-github-client',
-        }
-
-        expect(last_response.status).to eq(422)
-        body = json_body
-        expect(body['error']).to include('Iv1')
-      end
     end
 
     context 'authorization checks' do

--- a/apps/api/domains/spec/integration/simple/domain_sso_config_spec.rb
+++ b/apps/api/domains/spec/integration/simple/domain_sso_config_spec.rb
@@ -671,6 +671,66 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
       end
     end
 
+    context 'switching provider from a secretless OIDC config' do
+      before do
+        # Replace the entra_id fixture with an OIDC public-client config
+        # (PKCE) that has no stored client_secret to fall back to.
+        Onetime::CustomDomain::SsoConfig.delete_for_domain!(test_custom_domain.identifier)
+        Onetime::CustomDomain::SsoConfig.create!(
+          domain_id: test_custom_domain.identifier,
+          provider_type: 'oidc',
+          client_id: 'pkce-client-id',
+          issuer: 'https://pkce-issuer.example.com',
+          enabled: false,
+        )
+        login_as(test_owner)
+      end
+
+      it 'returns 422 when switching to entra_id without a client_secret' do
+        # Neither the request nor the stored record has a secret — allowing
+        # this through would produce an entra_id config whose token exchange
+        # fails at the IdP.
+        csrf_patch api_path(test_custom_domain.extid), {
+          provider_type: 'entra_id',
+          tenant_id: '12345678-1234-1234-1234-123456789abc',
+        }
+
+        expect(last_response.status).to eq(422)
+        expect(json_body['error']).to include('Client secret')
+
+        # Stored config is untouched
+        config = Onetime::CustomDomain::SsoConfig.find_by_domain_id(test_custom_domain.identifier)
+        expect(config.provider_type).to eq('oidc')
+      end
+
+      it 'switches to entra_id when a client_secret is provided' do
+        csrf_patch api_path(test_custom_domain.extid), {
+          provider_type: 'entra_id',
+          tenant_id: '12345678-1234-1234-1234-123456789abc',
+          client_secret: 'switch-secret-value',
+        }
+
+        expect(last_response.status).to eq(200)
+        record = json_body['record']
+        expect(record['provider_type']).to eq('entra_id')
+        expect(record['client_secret_masked']).to eq('••••••••alue')
+      end
+
+      it 'switches to entra_id without a request secret when one is stored' do
+        config = Onetime::CustomDomain::SsoConfig.find_by_domain_id(test_custom_domain.identifier)
+        config.client_secret = 'stored-oidc-secret'
+        config.commit_fields
+
+        csrf_patch api_path(test_custom_domain.extid), {
+          provider_type: 'entra_id',
+          tenant_id: '12345678-1234-1234-1234-123456789abc',
+        }
+
+        expect(last_response.status).to eq(200)
+        expect(json_body['record']['provider_type']).to eq('entra_id')
+      end
+    end
+
     context 'when no existing config' do
       before do
         # Remove the existing config
@@ -1120,6 +1180,42 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
       json_get api_path(test_custom_domain.extid)
 
       expect(last_response.content_type).to include('application/json')
+    end
+  end
+
+  # ==========================================================================
+  # Model-level Validation (SsoConfig.create!)
+  # ==========================================================================
+
+  describe 'SsoConfig.create! validation' do
+    it 'raises Onetime::Problem when required provider fields are missing' do
+      expect do
+        Onetime::CustomDomain::SsoConfig.create!(
+          domain_id: test_custom_domain.identifier,
+          enabled: true,
+        )
+      end.to raise_error(Onetime::Problem, /client_id is required.*issuer is required/)
+    end
+
+    it 'raises Onetime::Problem for entra_id without a client_secret' do
+      expect do
+        Onetime::CustomDomain::SsoConfig.create!(
+          domain_id: test_custom_domain.identifier,
+          provider_type: 'entra_id',
+          client_id: 'entra-client-id',
+          tenant_id: 'entra-tenant-id',
+        )
+      end.to raise_error(Onetime::Problem, /client_secret is required/)
+    end
+
+    it 'allows OIDC public clients without a client_secret' do
+      config = Onetime::CustomDomain::SsoConfig.create!(
+        domain_id: test_custom_domain.identifier,
+        provider_type: 'oidc',
+        client_id: 'pkce-client-id',
+        issuer: 'https://pkce-issuer.example.com',
+      )
+      expect(config.valid?).to be true
     end
   end
 end

--- a/apps/api/domains/spec/integration/simple/domain_sso_config_spec.rb
+++ b/apps/api/domains/spec/integration/simple/domain_sso_config_spec.rb
@@ -669,6 +669,22 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
         record = body['record']
         expect(record['allowed_domains']).to eq(['original.com'])
       end
+
+      it 'clears tenant_id when switching to oidc' do
+        csrf_patch api_path(test_custom_domain.extid), {
+          provider_type: 'oidc',
+          issuer: 'https://auth.example.com',
+        }
+
+        expect(last_response.status).to eq(200)
+        record = json_body['record']
+        expect(record['provider_type']).to eq('oidc')
+        expect(record['issuer']).to eq('https://auth.example.com')
+
+        # Provider switch clears the outgoing provider's field — an oidc
+        # record must not carry the entra fixture's stale tenant_id.
+        expect(record['tenant_id'].to_s).to eq('')
+      end
     end
 
     context 'switching provider from a secretless OIDC config' do
@@ -714,6 +730,10 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
         record = json_body['record']
         expect(record['provider_type']).to eq('entra_id')
         expect(record['client_secret_masked']).to eq('••••••••alue')
+
+        # Provider switch clears the outgoing provider's field — an entra_id
+        # record must not carry the oidc fixture's stale issuer.
+        expect(record['issuer'].to_s).to eq('')
       end
 
       it 'switches to entra_id without a request secret when one is stored' do
@@ -724,6 +744,52 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
         csrf_patch api_path(test_custom_domain.extid), {
           provider_type: 'entra_id',
           tenant_id: '12345678-1234-1234-1234-123456789abc',
+        }
+
+        expect(last_response.status).to eq(200)
+        expect(json_body['record']['provider_type']).to eq('entra_id')
+      end
+    end
+
+    context 'with a legacy stored provider type (pre-#3902)' do
+      before do
+        # Pre-#3902 records (google/github) predate model validation and
+        # cannot be created through any current API path — seed one by
+        # writing the field directly.
+        existing_config.provider_type = 'google'
+        existing_config.commit_fields
+        login_as(test_owner)
+      end
+
+      it 'returns 422 naming the stored legacy type, even for a bare disable' do
+        # The request never sent provider_type — the error must blame the
+        # stored record and point at the escape hatches, not claim the
+        # caller supplied an invalid field.
+        csrf_patch api_path(test_custom_domain.extid), { enabled: false }
+
+        expect(last_response.status).to eq(422)
+        expect(json_body['error']).to include("'google'")
+        expect(json_body['error']).to include('no longer supported')
+
+        # Fail closed: the stored record is untouched
+        config = Onetime::CustomDomain::SsoConfig.find_by_domain_id(test_custom_domain.identifier)
+        expect(config.provider_type).to eq('google')
+      end
+
+      it 'can still be deleted (the escape hatch)' do
+        csrf_delete api_path(test_custom_domain.extid)
+
+        expect(last_response.status).to eq(200)
+        expect(Onetime::CustomDomain::SsoConfig.find_by_domain_id(test_custom_domain.identifier)).to be_nil
+      end
+
+      it 'can be replaced with a full PUT' do
+        csrf_put api_path(test_custom_domain.extid), {
+          provider_type: 'entra_id',
+          client_id: 'replacement-client-id',
+          client_secret: 'replacement-secret',
+          tenant_id: '12345678-1234-1234-1234-123456789abc',
+          enabled: false,
         }
 
         expect(last_response.status).to eq(200)

--- a/apps/web/auth/operations/backfill_tenant_issuer.rb
+++ b/apps/web/auth/operations/backfill_tenant_issuer.rb
@@ -64,9 +64,12 @@ module Auth
     #      account_id in the dry-run.
     #
     # Only providers whose resolved issuer is non-'' (oidc, entra_id) can lock a
-    # user out. google/github resolve to the '' sentinel, so their legacy '' row
-    # still matches the exact lookup — those users are NOT locked out and this
-    # operation refuses to run for them.
+    # user out. Issuerless providers (google/github) resolved to the '' sentinel,
+    # so a legacy '' row still matched the exact lookup — those users were never
+    # locked out and this operation refuses to run for them. As of #3902 those
+    # provider types are no longer configurable on the tenant surface at all
+    # (SsoConfig::PROVIDER_TYPES is oidc/entra_id only), so the eligibility
+    # guard below is a defense-in-depth check against pre-#3902 stored records.
     #
     # Idempotent, dry-run by default. Mirrors BulkSsoMigration's conventions.
     #
@@ -80,8 +83,13 @@ module Auth
       IDENTITIES_TABLE = :account_identities
 
       # provider_type values whose live callback resolves a REAL (non-sentinel)
-      # issuer, and can therefore lock a pre-008 tenant user out. OAuth2 providers
-      # (google, github) resolve to '' — their legacy row already matches.
+      # issuer, and can therefore lock a pre-008 tenant user out. Issuerless
+      # OAuth2 providers (google, github) resolved to '' — their legacy rows
+      # already matched — and since #3902 they are no longer configurable
+      # tenant provider types, so this list now equals
+      # SsoConfig::PROVIDER_TYPES. Kept as an explicit local constant: the
+      # guard exists to refuse pre-#3902 stored records, independent of what
+      # the model currently accepts.
       ISSUER_BEARING_PROVIDER_TYPES = %w[oidc entra_id].freeze
 
       Result = Struct.new(
@@ -295,8 +303,10 @@ module Auth
       #                           #2 via omniauth_token_issuer). DERIVED — verify
       #                           against IdP metadata before --confirm, or pass
       #                           --issuer.
-      #   - google/github      -> resolves to '' at callback, so no lockout;
-      #                           refuse (nothing to backfill).
+      #   - anything else      -> a pre-#3902 issuerless record (google/github,
+      #                           since removed from PROVIDER_TYPES) resolved to
+      #                           '' at callback, so no lockout; refuse (nothing
+      #                           to backfill).
       def resolve_issuer(sso_config, override)
         return override.to_s.strip unless override.to_s.strip.empty?
 

--- a/apps/web/auth/spec/integration/full/backfill_tenant_issuer_spec.rb
+++ b/apps/web/auth/spec/integration/full/backfill_tenant_issuer_spec.rb
@@ -115,18 +115,22 @@ RSpec.describe 'Tenant issuer backfill operation (#3840 Phase 1)', type: :integr
     domain.save
     Onetime::CustomDomain.display_domain_index.put(display, domain.domainid)
 
-    attrs = {
-      domain_id: domain.identifier,
-      provider_type: provider_type,
-      display_name: "Backfill SSO #{run}",
-      client_id: "client-#{run}",
-      client_secret: "secret-#{run}",
-      enabled: enabled,
-      grant_org_scope: grant_org_scope,
-    }
-    attrs[:issuer]    = issuer    unless issuer.nil?
-    attrs[:tenant_id] = tenant_id unless tenant_id.nil?
-    sso = Onetime::CustomDomain::SsoConfig.create!(**attrs)
+    # These fixtures simulate pre-#3902 rows (issuerless providers, missing
+    # issuer/tenant_id) that predate model validation and cannot pass
+    # SsoConfig.create! — write them the way they were originally written:
+    # direct field assignment + save.
+    sso                 = Onetime::CustomDomain::SsoConfig.new(domain_id: domain.identifier)
+    sso.provider_type   = provider_type
+    sso.display_name    = "Backfill SSO #{run}"
+    sso.client_id       = "client-#{run}"
+    sso.client_secret   = "secret-#{run}"
+    sso.enabled         = enabled.to_s
+    sso.grant_org_scope = grant_org_scope.to_s
+    sso.issuer          = issuer unless issuer.nil?
+    sso.tenant_id       = tenant_id unless tenant_id.nil?
+    sso.created         = Familia.now.to_i
+    sso.updated         = sso.created
+    sso.save
 
     Tenant.new(domain: domain, org: org, sso: sso, provider: sso.platform_route_name, issuer: issuer)
   end

--- a/apps/web/auth/spec/support/domain_sso_test_fixtures.rb
+++ b/apps/web/auth/spec/support/domain_sso_test_fixtures.rb
@@ -22,8 +22,11 @@ module DomainSsoTestFixtures
   # Constants
   # ==========================================================================
 
-  # Supported SSO provider types (matches PROVIDER_TYPES constant in model)
-  PROVIDER_TYPES = %i[oidc entra_id google github].freeze
+  # Supported SSO provider types (matches PROVIDER_TYPES constant in model).
+  # Tenant SSO is OIDC/Entra-only (#3902): issuerless providers (google,
+  # github) resolve to the shared '' issuer sentinel and cannot satisfy the
+  # (provider, issuer, uid) identity partitioning, so they were removed.
+  PROVIDER_TYPES = %i[oidc entra_id].freeze
 
   # Mock encryption key for testing (32 bytes for AES-256)
   TEST_ENCRYPTION_KEY = 'test_encryption_key_32_bytes_ok!'.freeze
@@ -72,20 +75,6 @@ module DomainSsoTestFixtures
       client_secret: 'entra_domain_test_client_secret_value',
       allowed_domains: ['contoso.onmicrosoft.com', 'contoso.com'],
     },
-    google: {
-      provider_type: 'google',
-      display_name: 'Google Workspace',
-      client_id: 'google_domain_test_client_id.apps.googleusercontent.com',
-      client_secret: 'google_domain_test_client_secret',
-      allowed_domains: ['company.com'],
-    },
-    github: {
-      provider_type: 'github',
-      display_name: 'GitHub Enterprise',
-      client_id: 'github_domain_test_client_id',
-      client_secret: 'github_domain_test_client_secret',
-      allowed_domains: [], # GitHub typically doesn't restrict by email domain
-    },
   }.freeze
 
   # ==========================================================================
@@ -94,7 +83,7 @@ module DomainSsoTestFixtures
 
   # Build CustomDomain::SsoConfig attributes hash for a given provider type
   #
-  # @param provider [Symbol] one of :oidc, :entra_id, :google, :github
+  # @param provider [Symbol] one of :oidc, :entra_id
   # @param overrides [Hash] attributes to override defaults
   # @return [Hash] complete attributes hash
   def build_domain_sso_config_attributes(provider = :oidc, overrides = {})
@@ -116,7 +105,7 @@ module DomainSsoTestFixtures
   # This creates an instance with stubbed persistence methods,
   # suitable for testing model behavior without Redis.
   #
-  # @param provider [Symbol] one of :oidc, :entra_id, :google, :github
+  # @param provider [Symbol] one of :oidc, :entra_id
   # @param overrides [Hash] attributes to override defaults
   # @return [Onetime::CustomDomain::SsoConfig] stubbed instance
   #
@@ -235,23 +224,6 @@ module DomainSsoTestFixtures
         tenant_id: 'contoso-tenant-uuid-1234',
         scope: 'openid profile email',
       }
-    when :google
-      {
-        strategy: :google_oauth2,
-        name: extid,
-        client_id: anything,
-        client_secret: anything,
-        scope: 'openid,email,profile',
-        prompt: 'select_account',
-      }
-    when :github
-      {
-        strategy: :github,
-        name: extid,
-        client_id: anything,
-        client_secret: anything,
-        scope: 'user:email',
-      }
     end
   end
 
@@ -273,8 +245,6 @@ module DomainSsoTestFixtures
     {
       oidc: ['user@example.com', 'admin@subsidiary.example.com'],
       entra_id: ['user@contoso.onmicrosoft.com', 'admin@contoso.com'],
-      google: ['employee@company.com'],
-      github: [], # No domain restriction
     }
   end
 
@@ -283,7 +253,6 @@ module DomainSsoTestFixtures
     {
       oidc: ['user@attacker.com', 'admin@not-example.com'],
       entra_id: ['user@external.com', 'admin@fabrikam.com'],
-      google: ['personal@gmail.com', 'work@other-company.com'],
     }
   end
 

--- a/apps/web/auth/spec/unit/domain_sso_config_spec.rb
+++ b/apps/web/auth/spec/unit/domain_sso_config_spec.rb
@@ -245,19 +245,20 @@ RSpec.describe Onetime::CustomDomain::SsoConfig do
       end
     end
 
-    describe 'for Google provider' do
-      let(:config) { build_domain_sso_config(:google) }
-
-      it 'specifies :google_oauth2 strategy' do
-        expect(config.to_omniauth_options[:strategy]).to eq(:google_oauth2)
+    # Tenant SSO is OIDC/Entra-only (#3902): issuerless providers resolve to
+    # the '' issuer sentinel and cannot satisfy (provider, issuer, uid)
+    # partitioning, so they are no longer dispatchable provider types.
+    describe 'for removed issuerless providers' do
+      it 'raises Onetime::Problem for google' do
+        config = build_minimal_domain_sso_config(domain_id: 'dom_removed', provider_type: 'google')
+        expect { config.to_omniauth_options }
+          .to raise_error(Onetime::Problem, /Unsupported SSO provider type: google/)
       end
-    end
 
-    describe 'for GitHub provider' do
-      let(:config) { build_domain_sso_config(:github) }
-
-      it 'specifies :github strategy' do
-        expect(config.to_omniauth_options[:strategy]).to eq(:github)
+      it 'raises Onetime::Problem for github' do
+        config = build_minimal_domain_sso_config(domain_id: 'dom_removed', provider_type: 'github')
+        expect { config.to_omniauth_options }
+          .to raise_error(Onetime::Problem, /Unsupported SSO provider type: github/)
       end
     end
   end
@@ -312,7 +313,7 @@ RSpec.describe Onetime::CustomDomain::SsoConfig do
     end
 
     describe 'without domain restrictions' do
-      let(:config) { build_domain_sso_config(:github) }
+      let(:config) { build_domain_sso_config(:oidc, allowed_domains: []) }
 
       it 'allows any email domain' do
         expect(config.valid_email_domain?('user@anydomain.com')).to be true
@@ -377,7 +378,11 @@ RSpec.describe Onetime::CustomDomain::SsoConfig do
   describe 'PROVIDER_METADATA constant' do
     it 'defines metadata for all provider types' do
       expect(described_class::PROVIDER_METADATA).to be_a(Hash)
-      expect(described_class::PROVIDER_METADATA.keys).to include('oidc', 'entra_id', 'google', 'github')
+      expect(described_class::PROVIDER_METADATA.keys).to include('oidc', 'entra_id')
+    end
+
+    it 'excludes removed issuerless providers (#3902)' do
+      expect(described_class::PROVIDER_METADATA.keys).not_to include('google', 'github')
     end
   end
 
@@ -425,8 +430,8 @@ RSpec.describe Onetime::CustomDomain::SsoConfig do
   end
 
   describe '#requires_domain_filter?' do
-    it 'returns true for GitHub' do
-      config = build_domain_sso_config(:github)
+    it 'returns true for OIDC' do
+      config = build_domain_sso_config(:oidc)
       expect(config.requires_domain_filter?).to be true
     end
 
@@ -644,22 +649,6 @@ RSpec.describe Onetime::CustomDomain::SsoConfig do
       end
     end
 
-    context 'with a fully valid Google config' do
-      let(:config) { build_domain_sso_config(:google) }
-
-      it 'returns an empty errors array' do
-        expect(config.validation_errors).to eq([])
-      end
-    end
-
-    context 'with a fully valid GitHub config' do
-      let(:config) { build_domain_sso_config(:github) }
-
-      it 'returns an empty errors array' do
-        expect(config.validation_errors).to eq([])
-      end
-    end
-
     context 'when provider_type is missing' do
       it 'returns an error about provider_type' do
         config = build_domain_sso_config(:oidc)
@@ -714,7 +703,7 @@ RSpec.describe Onetime::CustomDomain::SsoConfig do
 
     context 'when client_secret is missing' do
       it 'returns an error about client_secret' do
-        config = build_domain_sso_config(:google)
+        config = build_domain_sso_config(:entra_id)
         config.client_secret = nil
 
         errors = config.validation_errors
@@ -724,7 +713,7 @@ RSpec.describe Onetime::CustomDomain::SsoConfig do
 
     context 'when client_secret is empty string' do
       it 'returns an error about client_secret' do
-        config = build_domain_sso_config(:google)
+        config = build_domain_sso_config(:entra_id)
         config.client_secret = ''
 
         errors = config.validation_errors
@@ -780,26 +769,6 @@ RSpec.describe Onetime::CustomDomain::SsoConfig do
 
         errors = config.validation_errors
         expect(errors).to include('issuer is required for OIDC provider')
-      end
-    end
-
-    # Google and GitHub should NOT require tenant_id or issuer
-
-    context 'when Google config has no tenant_id or issuer' do
-      it 'does not return provider-specific field errors' do
-        config = build_domain_sso_config(:google)
-        errors = config.validation_errors
-        expect(errors).not_to include(a_string_matching(/tenant_id/))
-        expect(errors).not_to include(a_string_matching(/issuer/))
-      end
-    end
-
-    context 'when GitHub config has no tenant_id or issuer' do
-      it 'does not return provider-specific field errors' do
-        config = build_domain_sso_config(:github)
-        errors = config.validation_errors
-        expect(errors).not_to include(a_string_matching(/tenant_id/))
-        expect(errors).not_to include(a_string_matching(/issuer/))
       end
     end
 

--- a/apps/web/auth/spec/unit/domain_sso_config_spec.rb
+++ b/apps/web/auth/spec/unit/domain_sso_config_spec.rb
@@ -23,6 +23,7 @@
 
 require_relative '../spec_helper'
 require_relative '../support/domain_sso_test_fixtures'
+require_relative '../../operations/backfill_tenant_issuer'
 
 RSpec.describe Onetime::CustomDomain::SsoConfig do
   include DomainSsoTestFixtures
@@ -346,6 +347,44 @@ RSpec.describe Onetime::CustomDomain::SsoConfig do
     end
   end
 
+  describe '.tenant_sso_unavailable_reason' do
+    let(:domain_id) { 'dom_ladder_test' }
+
+    before do
+      allow(Onetime::CustomDomain::SigninConfig).to receive_messages(
+        global_auth_enabled: true,
+        sso_permitted_for?: true,
+      )
+    end
+
+    it 'returns :unsupported_provider_type for a pre-#3902 legacy provider_type' do
+      config = build_minimal_domain_sso_config(domain_id: domain_id, provider_type: 'google')
+      expect(described_class.tenant_sso_unavailable_reason(domain_id, sso_config: config))
+        .to eq(:unsupported_provider_type)
+    end
+
+    it 'returns :sso_config_disabled before reaching the provider_type check' do
+      config = build_minimal_domain_sso_config(domain_id: domain_id, provider_type: 'google')
+
+      config.enabled = 'false'
+      expect(described_class.tenant_sso_unavailable_reason(domain_id, sso_config: config))
+        .to eq(:sso_config_disabled)
+    end
+
+    it 'returns :unsupported_provider_type before reaching the sso_permitted_for? check' do
+      allow(Onetime::CustomDomain::SigninConfig).to receive(:sso_permitted_for?).and_return(false)
+
+      config = build_minimal_domain_sso_config(domain_id: domain_id, provider_type: 'github')
+      expect(described_class.tenant_sso_unavailable_reason(domain_id, sso_config: config))
+        .to eq(:unsupported_provider_type)
+    end
+
+    it 'returns nil for a supported, enabled provider_type' do
+      config = build_minimal_domain_sso_config(domain_id: domain_id, provider_type: 'oidc')
+      expect(described_class.tenant_sso_unavailable_reason(domain_id, sso_config: config)).to be_nil
+    end
+  end
+
   # ==========================================================================
   # Create and Delete Tests
   # ==========================================================================
@@ -426,6 +465,18 @@ RSpec.describe Onetime::CustomDomain::SsoConfig do
     it 'test fixtures enumerate the same providers as the model' do
       expect(DomainSsoTestFixtures::PROVIDER_TYPES.map(&:to_s).sort)
         .to eq(described_class::PROVIDER_TYPES.sort)
+    end
+
+    # BackfillTenantIssuer::ISSUER_BEARING_PROVIDER_TYPES is an intentionally
+    # decoupled local constant (it must keep refusing pre-#3902 stored
+    # google/github rows even if PROVIDER_TYPES changes later), so this only
+    # guards the direction that would silently break the backfill: a new
+    # provider added to PROVIDER_TYPES without a matching update there. It
+    # deliberately does NOT assert equality — ISSUER_BEARING_PROVIDER_TYPES
+    # retaining historical entries beyond PROVIDER_TYPES is expected.
+    it 'BackfillTenantIssuer::ISSUER_BEARING_PROVIDER_TYPES covers every current PROVIDER_TYPES value' do
+      expect(described_class::PROVIDER_TYPES - Auth::Operations::BackfillTenantIssuer::ISSUER_BEARING_PROVIDER_TYPES)
+        .to eq([]), "PROVIDER_TYPES gained a value BackfillTenantIssuer::ISSUER_BEARING_PROVIDER_TYPES doesn't know about"
     end
   end
 

--- a/apps/web/core/spec/views/serializers/config_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/config_serializer_spec.rb
@@ -1184,7 +1184,7 @@ RSpec.describe Core::Views::ConfigSerializer do
     end
 
     it 'handles nil display_name gracefully' do
-      config = build_domain_sso_config(:github)
+      config = build_domain_sso_config(:oidc)
       allow(config).to receive(:display_name).and_return(nil)
 
       result = described_class.build_tenant_sso_response(config)

--- a/e2e/full/domain-sso-config.spec.ts
+++ b/e2e/full/domain-sso-config.spec.ts
@@ -430,7 +430,9 @@ test.describe('Domain SSO Configuration - Form', () => {
     await expect(clientIdInput).toHaveValue('');
   });
 
-  test('TC-DSSO-009: provider type selector shows all 4 options', async ({ page }) => {
+  test('TC-DSSO-009: provider type selector shows only the two supported providers', async ({
+    page,
+  }) => {
     const org = await getFirstOrganization(page);
     test.skip(!org, 'Test requires at least 1 organization');
 
@@ -441,13 +443,32 @@ test.describe('Domain SSO Configuration - Form', () => {
     const domains = await getDomainsFromSsoTab(page);
     test.skip(domains.length === 0, 'Test requires at least 1 domain');
 
+    // Force new-config mode so the selectable radio group renders (provider
+    // type is locked while editing an existing config).
+    await page.route(`**/api/domains/${domains[0].extid}/sso`, async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ record: null }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
     const modal = await openDomainSsoModal(page, org!.extid, domains[0].extid);
 
-    // Check for all 4 provider options inside the modal
+    // #3902: tenant SSO is OIDC/Entra-only. Issuerless providers
+    // (Google/GitHub) live on the platform surface only and must not be
+    // offered per-domain.
     await expect(modal.getByText('Microsoft Entra ID')).toBeVisible();
-    await expect(modal.getByText('Google Workspace')).toBeVisible();
-    await expect(modal.getByText('GitHub')).toBeVisible();
     await expect(modal.getByText('Generic OIDC')).toBeVisible();
+    await expect(
+      modal.locator('input[type="radio"][name="provider_type"]')
+    ).toHaveCount(2);
+    await expect(modal.getByText('Google Workspace')).toHaveCount(0);
+    await expect(modal.getByText('GitHub', { exact: true })).toHaveCount(0);
   });
 
   test('TC-DSSO-010: selecting Entra ID shows tenant_id field', async ({ page }) => {
@@ -880,9 +901,10 @@ test.describe('Domain SSO Configuration - Multi-Domain', () => {
           body: JSON.stringify({
             record: {
               extid: 'sso-config-domain-b',
-              provider_type: 'google',
-              display_name: 'Domain B Google',
+              provider_type: 'oidc',
+              display_name: 'Domain B OIDC',
               client_id: 'client-b',
+              issuer: 'https://idp.domain-b.example.com',
               enabled: true,
             },
           }),
@@ -921,13 +943,15 @@ test.describe('Domain SSO Configuration - Multi-Domain', () => {
     // Step 4: Open SSO modal for domain B (navigates to domain B's signin page)
     const modalB = await openDomainSsoModal(page, org!.extid, domainB.extid);
 
-    // Step 5: Configure Google for domain B
-    const googleOption = modalB.locator('label').filter({ hasText: 'Google Workspace' });
-    await googleOption.click();
+    // Step 5: Configure Generic OIDC for domain B (#3902: tenant SSO is
+    // OIDC/Entra-only, so the second provider is OIDC rather than Google)
+    const oidcOption = modalB.locator('label').filter({ hasText: 'Generic OIDC' });
+    await oidcOption.click();
 
-    await page.locator('#domain-sso-display-name').fill('Domain B Google');
+    await page.locator('#domain-sso-display-name').fill('Domain B OIDC');
     await page.locator('#domain-sso-client-id').fill('client-b');
     await page.locator('#domain-sso-client-secret').fill('secret-b');
+    await page.locator('#domain-sso-issuer').fill('https://idp.domain-b.example.com');
 
     // Step 6: Save domain B config (anchor on the mocked save round-trip)
     const saveButtonB = modalB.locator('button[type="submit"]');
@@ -1036,7 +1060,7 @@ test.describe('Domain SSO Configuration - Access Control', () => {
  * | TC-DSSO-006  | configure link is visible in SSO hub domain list                | Critical | Automated  |
  * | TC-DSSO-007  | empty domains state shows add domain prompt                     | Medium   | Automated  |
  * | TC-DSSO-008  | shows empty form for domain without SSO config                  | High     | Automated  |
- * | TC-DSSO-009  | provider type selector shows all 4 options                      | High     | Automated  |
+ * | TC-DSSO-009  | provider type selector shows only the two supported providers   | High     | Automated  |
  * | TC-DSSO-010  | selecting Entra ID shows tenant_id field                        | High     | Automated  |
  * | TC-DSSO-011  | selecting OIDC shows issuer field                               | High     | Automated  |
  * | TC-DSSO-012  | form validation prevents save without required fields           | Critical | Automated  |

--- a/e2e/full/domain-sso-multi-provider.spec.ts
+++ b/e2e/full/domain-sso-multi-provider.spec.ts
@@ -10,10 +10,15 @@
  * - Organization has multiple custom domains (e.g., corp.example.com, partner.example.com)
  * - User navigates to each domain's signin page and opens the SSO credentials modal
  * - Domain A uses Microsoft Entra ID
- * - Domain B uses Google Workspace
+ * - Domain B uses a Generic OIDC provider
  * - Both configurations coexist within the same organization
  *
  * This validates the architecture that SSO config is scoped to domain, not org.
+ *
+ * Tenant SSO is OIDC/Entra-only (#3902): issuerless providers (Google/GitHub)
+ * resolve to the shared '' issuer sentinel and cannot satisfy per-tenant
+ * identity partitioning keyed (provider, issuer, uid). They remain available
+ * only on the PLATFORM/install-level SSO surface, never per-domain.
  *
  * Prerequisites:
  * - Authenticated via the project storageState (e2e/global.setup.ts consumes TEST_USER_*)
@@ -64,7 +69,8 @@ interface DomainInfo {
   providerType?: string;
 }
 
-type ProviderType = 'entra_id' | 'google' | 'github' | 'oidc';
+// Tenant surface supports OIDC-capable providers only (#3902).
+type ProviderType = 'entra_id' | 'oidc';
 
 interface SsoConfigData {
   providerType: ProviderType;
@@ -210,8 +216,6 @@ async function openDomainSsoModal(
 async function selectProvider(container: Locator, providerType: ProviderType): Promise<void> {
   const providerLabels: Record<ProviderType, string> = {
     entra_id: 'Microsoft Entra ID',
-    google: 'Google Workspace',
-    github: 'GitHub',
     oidc: 'Generic OIDC',
   };
 
@@ -315,6 +319,7 @@ async function setupDomainSsoMock(
             client_id: saveConfig?.clientId || 'saved-client-id',
             client_secret_masked: '****',
             tenant_id: saveConfig?.tenantId,
+            issuer: saveConfig?.issuer,
             enabled: true,
           },
         }),
@@ -334,7 +339,7 @@ test.describe('Multi-Domain SSO - Different Providers per Domain', () => {
     page.setDefaultTimeout(15000);
   });
 
-  test('TC-MPROV-001: configure Entra ID for first domain and Google for second domain', async ({
+  test('TC-MPROV-001: configure Entra ID for first domain and Generic OIDC for second domain', async ({
     page,
   }) => {
     const org = await getFirstOrganization(page);
@@ -358,16 +363,17 @@ test.describe('Multi-Domain SSO - Different Providers per Domain', () => {
       tenantId: 'tenant-id-domain-a',
     };
 
-    const googleConfig: SsoConfigData = {
-      providerType: 'google',
-      displayName: `${domainB.displayDomain} Google`,
-      clientId: 'google-client-id-domain-b',
-      clientSecret: 'google-secret-domain-b',
+    const oidcConfig: SsoConfigData = {
+      providerType: 'oidc',
+      displayName: `${domainB.displayDomain} OIDC`,
+      clientId: 'oidc-client-id-domain-b',
+      clientSecret: 'oidc-secret-domain-b',
+      issuer: 'https://idp.domain-b.example.com',
     };
 
     // Setup mocks for both domains
     await setupDomainSsoMock(page, domainA.extid, { onSave: entraConfig, existingConfig: null });
-    await setupDomainSsoMock(page, domainB.extid, { onSave: googleConfig, existingConfig: null });
+    await setupDomainSsoMock(page, domainB.extid, { onSave: oidcConfig, existingConfig: null });
 
     // Step 1: Open SSO modal for domain A and configure Entra ID
     const modalA = await openDomainSsoModal(page, org!.extid, domainA.extid);
@@ -375,10 +381,10 @@ test.describe('Multi-Domain SSO - Different Providers per Domain', () => {
     await fillSsoConfigForm(page, modalA, entraConfig);
     await submitSsoForm(modalA);
 
-    // Step 2: Open SSO modal for domain B and configure Google
+    // Step 2: Open SSO modal for domain B and configure Generic OIDC
     const modalB = await openDomainSsoModal(page, org!.extid, domainB.extid);
 
-    await fillSsoConfigForm(page, modalB, googleConfig);
+    await fillSsoConfigForm(page, modalB, oidcConfig);
     await submitSsoForm(modalB);
 
     // Step 3: Verify both domains appear in org SSO hub
@@ -461,9 +467,10 @@ test.describe('Multi-Domain SSO - Different Providers per Domain', () => {
 
     await setupDomainSsoMock(page, domainB.extid, {
       existingConfig: {
-        providerType: 'google',
-        displayName: 'Domain B Google',
+        providerType: 'oidc',
+        displayName: 'Domain B OIDC',
         clientId: 'client-b',
+        issuer: 'https://idp.domain-b.example.com',
       },
     });
 
@@ -478,22 +485,30 @@ test.describe('Multi-Domain SSO - Different Providers per Domain', () => {
       (await entraRadio.isChecked().catch(() => false)) ||
       (await entraLabel.locator('input').isChecked().catch(() => false));
 
-    // Open SSO modal for domain B and verify Google is selected
+    // Open SSO modal for domain B and verify Generic OIDC is selected
     const modalB = await openDomainSsoModal(page, org!.extid, domainB.extid);
 
-    const googleRadio = page.locator('input[type="radio"][value="google"]');
-    const googleLabel = modalB.locator('label').filter({ hasText: 'Google Workspace' });
+    const oidcRadio = page.locator('input[type="radio"][value="oidc"]');
+    const oidcLabel = modalB.locator('label').filter({ hasText: 'Generic OIDC' });
 
-    const isGoogleSelected =
-      (await googleRadio.isChecked().catch(() => false)) ||
-      (await googleLabel.locator('input').isChecked().catch(() => false));
+    const isOidcSelected =
+      (await oidcRadio.isChecked().catch(() => false)) ||
+      (await oidcLabel.locator('input').isChecked().catch(() => false));
+
+    // #3902: issuerless providers must not exist anywhere on the tenant
+    // surface — neither as a selectable radio nor as the locked provider
+    // display for an existing config.
+    await expect(modalB.locator('input[type="radio"][value="google"]')).toHaveCount(0);
+    await expect(modalB.locator('input[type="radio"][value="github"]')).toHaveCount(0);
+    await expect(modalB.getByText('Google Workspace')).toHaveCount(0);
+    await expect(modalB.getByText('GitHub', { exact: true })).toHaveCount(0);
 
     // At least one verification should pass (mocked data may not fully load)
     // In production with real data, both would be true
-    expect(isEntraSelected || isGoogleSelected || true).toBe(true);
+    expect(isEntraSelected || isOidcSelected || true).toBe(true);
   });
 
-  test('TC-MPROV-004: changing provider on one domain does not affect other domain', async ({
+  test('TC-MPROV-004: updating credentials on one domain does not affect other domain', async ({
     page,
   }) => {
     const org = await getFirstOrganization(page);
@@ -536,9 +551,10 @@ test.describe('Multi-Domain SSO - Different Providers per Domain', () => {
           body: JSON.stringify({
             record: {
               extid: 'sso-a',
-              provider_type: 'github',
-              display_name: 'Domain A GitHub',
+              provider_type: 'entra_id',
+              display_name: 'Domain A Entra Updated',
               client_id: 'new-client-a',
+              tenant_id: 'tenant-a',
               enabled: true,
             },
           }),
@@ -556,23 +572,23 @@ test.describe('Multi-Domain SSO - Different Providers per Domain', () => {
         body: JSON.stringify({
           record: {
             extid: 'sso-b',
-            provider_type: 'google',
-            display_name: 'Domain B Google',
+            provider_type: 'oidc',
+            display_name: 'Domain B OIDC',
             client_id: 'client-b',
+            issuer: 'https://idp.domain-b.example.com',
             enabled: true,
           },
         }),
       });
     });
 
-    // Open SSO modal for domain A and change provider from Entra ID to GitHub
+    // Open SSO modal for domain A and update its credentials in place.
+    // (Provider type is locked while editing an existing config, and the
+    // issuerless providers that the old provider-swap flow relied on are
+    // gone from the tenant surface — #3902.)
     const modal = await openDomainSsoModal(page, org!.extid, domainA.extid);
 
-    // Change to GitHub provider
-    const githubOption = modal.locator('label').filter({ hasText: 'GitHub' });
-    await githubOption.click();
-
-    await page.locator('#domain-sso-display-name').fill('Domain A GitHub');
+    await page.locator('#domain-sso-display-name').fill('Domain A Entra Updated');
     await page.locator('#domain-sso-client-id').fill('new-client-a');
     await page.locator('#domain-sso-client-secret').fill('new-secret-a');
 
@@ -718,7 +734,7 @@ test.describe('Multi-Domain SSO - Provider-Specific Fields', () => {
     await expect(issuerInput).not.toBeVisible();
   });
 
-  test('TC-MPROV-009: Google Workspace does not require tenant_id', async ({ page }) => {
+  test('TC-MPROV-009: switching provider swaps tenant_id for issuer field', async ({ page }) => {
     const org = await getFirstOrganization(page);
     test.skip(!org, 'Test requires at least 1 organization');
 
@@ -731,16 +747,15 @@ test.describe('Multi-Domain SSO - Provider-Specific Fields', () => {
 
     const modal = await openDomainSsoModal(page, org!.extid, domains[0].extid);
 
-    // Select Google Workspace
-    await selectProvider(modal, 'google');
+    // Start on Entra ID: tenant_id visible, issuer hidden
+    await selectProvider(modal, 'entra_id');
+    await expect(page.locator('#domain-sso-tenant-id')).toBeVisible();
+    await expect(page.locator('#domain-sso-issuer')).not.toBeVisible();
 
-    // Tenant ID field should NOT be visible for Google
-    const tenantIdInput = page.locator('#domain-sso-tenant-id');
-    await expect(tenantIdInput).not.toBeVisible();
-
-    // Issuer field should NOT be visible
-    const issuerInput = page.locator('#domain-sso-issuer');
-    await expect(issuerInput).not.toBeVisible();
+    // Switch to Generic OIDC: issuer visible, tenant_id hidden
+    await selectProvider(modal, 'oidc');
+    await expect(page.locator('#domain-sso-issuer')).toBeVisible();
+    await expect(page.locator('#domain-sso-tenant-id')).not.toBeVisible();
   });
 
   test('TC-MPROV-010: Generic OIDC requires issuer field', async ({ page }) => {
@@ -768,7 +783,9 @@ test.describe('Multi-Domain SSO - Provider-Specific Fields', () => {
     await expect(tenantIdInput).not.toBeVisible();
   });
 
-  test('TC-MPROV-011: GitHub uses minimal configuration', async ({ page }) => {
+  test('TC-MPROV-011: provider picker offers exactly Entra ID and Generic OIDC', async ({
+    page,
+  }) => {
     const org = await getFirstOrganization(page);
     test.skip(!org, 'Test requires at least 1 organization');
 
@@ -779,21 +796,23 @@ test.describe('Multi-Domain SSO - Provider-Specific Fields', () => {
     const domains = await getDomainsFromSsoTab(page);
     test.skip(domains.length === 0, 'Test requires at least 1 domain');
 
+    // Force new-config mode so the selectable radio group renders (provider
+    // type is locked while editing an existing config).
+    await setupDomainSsoMock(page, domains[0].extid, { existingConfig: null });
+
     const modal = await openDomainSsoModal(page, org!.extid, domains[0].extid);
 
-    // Select GitHub
-    await selectProvider(modal, 'github');
+    // #3902: tenant SSO is OIDC/Entra-only — exactly two provider radios.
+    const providerRadios = modal.locator('input[type="radio"][name="provider_type"]');
+    await expect(providerRadios).toHaveCount(2);
+    await expect(modal.locator('input[type="radio"][value="entra_id"]')).toHaveCount(1);
+    await expect(modal.locator('input[type="radio"][value="oidc"]')).toHaveCount(1);
 
-    // GitHub should only need client_id and client_secret (no tenant_id, no issuer)
-    const tenantIdInput = page.locator('#domain-sso-tenant-id');
-    const issuerInput = page.locator('#domain-sso-issuer');
-
-    await expect(tenantIdInput).not.toBeVisible();
-    await expect(issuerInput).not.toBeVisible();
-
-    // Client ID and secret should be visible
-    await expect(page.locator('#domain-sso-client-id')).toBeVisible();
-    await expect(page.locator('#domain-sso-client-secret')).toBeVisible();
+    // Issuerless providers must not be offered on the tenant surface.
+    await expect(modal.locator('input[type="radio"][value="google"]')).toHaveCount(0);
+    await expect(modal.locator('input[type="radio"][value="github"]')).toHaveCount(0);
+    await expect(modal.getByText('Google Workspace')).toHaveCount(0);
+    await expect(modal.getByText('GitHub', { exact: true })).toHaveCount(0);
   });
 });
 
@@ -833,9 +852,10 @@ test.describe('Multi-Domain SSO - Configuration Isolation', () => {
     // Setup mock for domain B with different config
     await setupDomainSsoMock(page, domainB.extid, {
       existingConfig: {
-        providerType: 'google',
+        providerType: 'oidc',
         displayName: 'UNIQUE_DOMAIN_B_NAME_67890',
         clientId: 'unique-client-b-abc',
+        issuer: 'https://idp.unique-b.example.com',
       },
     });
 

--- a/e2e/full/domain-sso-multi-provider.spec.ts
+++ b/e2e/full/domain-sso-multi-provider.spec.ts
@@ -474,38 +474,21 @@ test.describe('Multi-Domain SSO - Different Providers per Domain', () => {
       },
     });
 
-    // Open SSO modal for domain A and verify Entra ID is selected
-    const modalA = await openDomainSsoModal(page, org!.extid, domainA.extid);
-
-    // The Entra ID option should be selected (checked state)
-    const entraRadio = page.locator('input[type="radio"][value="entra_id"]');
-    const entraLabel = modalA.locator('label').filter({ hasText: 'Microsoft Entra ID' });
-
-    const isEntraSelected =
-      (await entraRadio.isChecked().catch(() => false)) ||
-      (await entraLabel.locator('input').isChecked().catch(() => false));
-
-    // Open SSO modal for domain B and verify Generic OIDC is selected
-    const modalB = await openDomainSsoModal(page, org!.extid, domainB.extid);
-
-    const oidcRadio = page.locator('input[type="radio"][value="oidc"]');
-    const oidcLabel = modalB.locator('label').filter({ hasText: 'Generic OIDC' });
-
-    const isOidcSelected =
-      (await oidcRadio.isChecked().catch(() => false)) ||
-      (await oidcLabel.locator('input').isChecked().catch(() => false));
-
     // #3902: issuerless providers must not exist anywhere on the tenant
     // surface — neither as a selectable radio nor as the locked provider
-    // display for an existing config.
+    // display for an existing config. Assert on each domain's modal while
+    // it is the open one.
+    const modalA = await openDomainSsoModal(page, org!.extid, domainA.extid);
+    await expect(modalA.locator('input[type="radio"][value="google"]')).toHaveCount(0);
+    await expect(modalA.locator('input[type="radio"][value="github"]')).toHaveCount(0);
+    await expect(modalA.getByText('Google Workspace')).toHaveCount(0);
+    await expect(modalA.getByText('GitHub', { exact: true })).toHaveCount(0);
+
+    const modalB = await openDomainSsoModal(page, org!.extid, domainB.extid);
     await expect(modalB.locator('input[type="radio"][value="google"]')).toHaveCount(0);
     await expect(modalB.locator('input[type="radio"][value="github"]')).toHaveCount(0);
     await expect(modalB.getByText('Google Workspace')).toHaveCount(0);
     await expect(modalB.getByText('GitHub', { exact: true })).toHaveCount(0);
-
-    // At least one verification should pass (mocked data may not fully load)
-    // In production with real data, both would be true
-    expect(isEntraSelected || isOidcSelected || true).toBe(true);
   });
 
   test('TC-MPROV-004: updating credentials on one domain does not affect other domain', async ({

--- a/lib/onetime/cli/sso/backfill_issuer_command.rb
+++ b/lib/onetime/cli/sso/backfill_issuer_command.rb
@@ -248,8 +248,10 @@ module Onetime
             issuer onto legacy rows whose account belongs to the domain organization,
             so the exact tenant lookup matches again.
 
-            Only oidc and entra_id domains are eligible: google/github resolve to the
-            '' sentinel at callback time, so their legacy rows already match.
+            Only oidc and entra_id domains are eligible — the only configurable
+            tenant provider types since #3902. Pre-#3902 issuerless records
+            (google/github) resolved to the '' sentinel at callback time, so
+            their legacy rows already match and are refused.
 
             Scoping is per-row and fail-closed: a row is stamped ONLY when it passes
             BOTH gates —

--- a/lib/onetime/models/custom_domain/mailer_config.rb
+++ b/lib/onetime/models/custom_domain/mailer_config.rb
@@ -243,19 +243,6 @@ module Onetime
         save
       end
 
-      # Rotate the API key without affecting verification state.
-      #
-      # Credential rotation is independent of DNS verification -- the
-      # DKIM/SPF records don't change when the API key changes.
-      #
-      # @param new_api_key [String] The new provider API key
-      # @return [void]
-      def rotate_credentials(new_api_key)
-        self.api_key = new_api_key
-        self.updated = Familia.now.to_i
-        save
-      end
-
       # Load the associated CustomDomain record.
       #
       # @return [CustomDomain, nil] The domain or nil if not found

--- a/lib/onetime/models/custom_domain/sso_config.rb
+++ b/lib/onetime/models/custom_domain/sso_config.rb
@@ -462,7 +462,7 @@ module Onetime
         # @param domain_id [String] CustomDomain identifier
         # @param attrs [Hash] Configuration attributes
         # @return [CustomDomain::SsoConfig] The created config
-        # @raise [Onetime::Problem] if config already exists
+        # @raise [Onetime::Problem] if config already exists or validation fails
         def create!(domain_id:, **attrs)
           raise Onetime::Problem, 'domain_id is required' if domain_id.to_s.empty?
           raise Onetime::Problem, 'SSO config already exists for this domain' if exists_for_domain?(domain_id)
@@ -489,6 +489,10 @@ module Onetime
           now            = Familia.now.to_i
           config.created = now
           config.updated = now
+
+          unless config.valid?
+            raise Onetime::Problem, config.validation_errors.join('; ')
+          end
 
           # Save using Horreum's built-in method
           config.save

--- a/lib/onetime/models/custom_domain/sso_config.rb
+++ b/lib/onetime/models/custom_domain/sso_config.rb
@@ -97,7 +97,9 @@ module Onetime
       # (#3902, see PROVIDER_TYPES).
       #
       # Universal required fields (all providers):
-      #   - client_id, client_secret, display_name, provider_type
+      #   - client_id, provider_type
+      # client_secret is required for entra_id only — OIDC public clients
+      # (PKCE) may omit it. display_name is optional.
       #
       # See: validation_errors method for enforcement
       #
@@ -395,10 +397,13 @@ module Onetime
         # password/email path (see SigninConfig.global_signin_enabled).
         #
         # Reasons (rung order matches the checks below):
-        #   :auth_disabled       - AUTH_ENABLED master switch is off
-        #   :no_sso_config       - no SsoConfig record for the domain
-        #   :sso_config_disabled - record present, its enabled switch is off
-        #   :sso_not_permitted   - SigninConfig withholds SSO for the domain
+        #   :auth_disabled             - AUTH_ENABLED master switch is off
+        #   :no_sso_config             - no SsoConfig record for the domain
+        #   :sso_config_disabled       - record present, its enabled switch is off
+        #   :unsupported_provider_type - record's provider_type is not in
+        #                                PROVIDER_TYPES (pre-#3902 legacy data;
+        #                                see BackfillTenantIssuer)
+        #   :sso_not_permitted         - SigninConfig withholds SSO for the domain
         #
         # @param domain_id [String] CustomDomain identifier (objid)
         # @param auth [Hash, nil] site.authentication settings (injectable for tests)
@@ -415,6 +420,13 @@ module Onetime
           config = sso_config&.domain_id == domain_id ? sso_config : find_by_domain_id(domain_id)
           return :no_sso_config if config.nil?
           return :sso_config_disabled unless config.enabled?
+          # Defense-in-depth against pre-#3902 stored records: google/github
+          # configs predate the OIDC/Entra-only surface and would otherwise
+          # reach to_omniauth_options, which raises Onetime::Problem — this
+          # rung fails the SAME record closed here instead, so the masthead
+          # link and /signin page (both reading this ladder) never advertise
+          # a route that would 500.
+          return :unsupported_provider_type unless PROVIDER_TYPES.include?(config.provider_type)
           return :sso_not_permitted unless Onetime::CustomDomain::SigninConfig.sso_permitted_for?(domain_id)
 
           nil

--- a/lib/onetime/models/custom_domain/sso_config.rb
+++ b/lib/onetime/models/custom_domain/sso_config.rb
@@ -10,7 +10,7 @@
 # by the same organization can use different identity providers.
 #
 # Use Cases:
-#   - Regional compliance: secrets.acme.eu uses Google Workspace, secrets.acme.com uses Entra ID
+#   - Regional compliance: secrets.acme.eu uses a regional OIDC IdP, secrets.acme.com uses Entra ID
 #   - Gradual rollout: enable SSO on one domain before expanding to others
 #   - Subsidiary isolation: different business units use different IdPs
 #
@@ -27,8 +27,18 @@ module Onetime
 
       SCHEMA = 'models/domain-sso-config'
 
-      # Supported SSO provider types
-      PROVIDER_TYPES = %w[oidc entra_id google github].freeze
+      # Supported SSO provider types.
+      #
+      # Tenant SSO is OIDC/Entra-only by design (#3902). Identity partitioning
+      # is keyed (provider, issuer, uid), so a tenant provider must resolve a
+      # tenant-distinguishing issuer. GitHub (plain OAuth2, no issuer) and
+      # Google (single GLOBAL issuer accounts.google.com) both resolve to the
+      # shared '' sentinel, which cannot partition identities per tenant —
+      # their callbacks are refused on tenant surfaces (PR #3900,
+      # refuse_issuerless_on_tenant?), so they are not configurable here.
+      # PLATFORM/install-level SSO still supports them (separate surface,
+      # registered from ENV in apps/web/auth/config/features/omniauth.rb).
+      PROVIDER_TYPES = %w[oidc entra_id].freeze
 
       # Provider metadata for UI filtering logic
       #
@@ -51,16 +61,6 @@ module Onetime
           idp_controls_access: true,
           description: 'Microsoft Entra ID - access controlled via Azure app assignment',
         },
-        'google' => {
-          requires_domain_filter: true,
-          idp_controls_access: false,
-          description: 'Google Workspace - domain filtering recommended for enterprise',
-        },
-        'github' => {
-          requires_domain_filter: true,
-          idp_controls_access: false,
-          description: 'GitHub OAuth - domain filtering recommended',
-        },
       }.freeze
 
       # Map provider_type to platform route name ENV var and default.
@@ -70,8 +70,6 @@ module Onetime
       PROVIDER_ROUTE_MAP = {
         'oidc' => { env_var: 'OIDC_ROUTE_NAME', default: 'oidc' },
         'entra_id' => { env_var: 'ENTRA_ROUTE_NAME', default: 'entra' },
-        'google' => { env_var: 'GOOGLE_ROUTE_NAME', default: 'google' },
-        'github' => { env_var: 'GITHUB_ROUTE_NAME', default: 'github' },
       }.freeze
 
       prefix :custom_domain__sso_config
@@ -93,8 +91,10 @@ module Onetime
       # Required fields vary by provider_type:
       #   - entra_id: requires tenant_id
       #   - oidc:     requires issuer
-      #   - google:   neither (uses well-known Google endpoints)
-      #   - github:   neither (uses well-known GitHub endpoints)
+      #
+      # Both remaining providers carry a tenant-distinguishing issuer — the
+      # reason issuerless OAuth2 providers were removed from this surface
+      # (#3902, see PROVIDER_TYPES).
       #
       # Universal required fields (all providers):
       #   - client_id, client_secret, display_name, provider_type
@@ -252,10 +252,6 @@ module Onetime
           build_oidc_options
         when 'entra_id'
           build_entra_id_options
-        when 'google'
-          build_google_options
-        when 'github'
-          build_github_options
         else
           raise Onetime::Problem, "Unsupported SSO provider type: #{provider_type}"
         end
@@ -311,12 +307,10 @@ module Onetime
         #   |---------------|-----------|--------|---------------|
         #   | entra_id      | required  | -      | required      |
         #   | oidc          | -         | required | optional    |
-        #   | google        | -         | -      | required      |
-        #   | github        | -         | -      | required      |
         #
         # OIDC supports public clients (PKCE flow) without a client secret.
-        # Google and GitHub use well-known OAuth endpoints, so neither
-        # tenant_id nor issuer is needed.
+        # Every tenant provider requires an issuer-bearing field (issuer or
+        # tenant_id) — issuerless providers are not configurable (#3902).
         #
         case provider_type
         when 'oidc'
@@ -558,27 +552,6 @@ module Onetime
           client_secret: client_secret&.reveal { it },
           tenant_id: tenant_id,
           scope: 'openid profile email',
-        }
-      end
-
-      def build_google_options
-        {
-          strategy: :google_oauth2,
-          name: strategy_name,
-          client_id: client_id&.reveal { it },
-          client_secret: client_secret&.reveal { it },
-          scope: 'openid,email,profile',
-          prompt: 'select_account',
-        }
-      end
-
-      def build_github_options
-        {
-          strategy: :github,
-          name: strategy_name,
-          client_id: client_id&.reveal { it },
-          client_secret: client_secret&.reveal { it },
-          scope: 'user:email',
         }
       end
     end

--- a/lib/onetime/operations/validate_sender_domain.rb
+++ b/lib/onetime/operations/validate_sender_domain.rb
@@ -301,7 +301,7 @@ module Onetime
         @mailer_config.updated             = Familia.now.to_i
         # Partial save: only write verification fields, not the full record.
         # A full save would overwrite api_key with stale in-memory ciphertext
-        # if a concurrent rotate_credentials call updated it since we loaded.
+        # if a concurrent write updated it since we loaded.
         @mailer_config.save_fields(:verification_status, :verified_at, :updated)
 
         true

--- a/src/apps/workspace/components/domains/DomainSsoConfigForm.vue
+++ b/src/apps/workspace/components/domains/DomainSsoConfigForm.vue
@@ -61,21 +61,14 @@ const { t } = useI18n();
 // Provider options
 // ---------------------------------------------------------------------------
 
+// Tenant SSO is OIDC/Entra-only: issuerless providers (GitHub, Google) cannot
+// satisfy per-tenant identity partitioning keyed (provider, issuer, uid) and
+// are refused on tenant surfaces (#3902, PR #3900).
 const providerOptions: { value: SsoProviderType; label: string; description: string }[] = [
   {
     value: 'entra_id',
     label: 'Microsoft Entra ID',
     description: 'Azure Active Directory / Microsoft 365',
-  },
-  {
-    value: 'google',
-    label: 'Google Workspace',
-    description: 'Google OAuth for Workspace domains',
-  },
-  {
-    value: 'github',
-    label: 'GitHub',
-    description: 'GitHub OAuth for organizations',
   },
   {
     value: 'oidc',
@@ -122,8 +115,6 @@ const requiresClientSecret = computed(() => props.formState.provider_type !== 'o
 const PROVIDER_ROUTE_NAMES: Record<SsoProviderType, string> = {
   oidc: 'oidc',
   entra_id: 'entra',
-  google: 'google',
-  github: 'github',
 };
 
 const callbackUrl = computed(() => {

--- a/src/apps/workspace/components/domains/DomainSsoConfigForm.vue
+++ b/src/apps/workspace/components/domains/DomainSsoConfigForm.vue
@@ -112,6 +112,13 @@ const requiresIssuer = computed(() => props.formState.provider_type === 'oidc');
 
 const requiresClientSecret = computed(() => props.formState.provider_type !== 'oidc');
 
+// Mirrors the defaults in CustomDomain::SsoConfig::PROVIDER_ROUTE_MAP
+// (lib/onetime/models/custom_domain/sso_config.rb). That map lets an operator
+// override the registered route per provider via OIDC_ROUTE_NAME/
+// ENTRA_ROUTE_NAME; this static preview has no way to see that override, so
+// it drifts from the real callback path in a deployment that sets either.
+// Not plumbed through the API yet — tracked in #3932 (bootstrap-config
+// carrier, since the preview must work before any record exists).
 const PROVIDER_ROUTE_NAMES: Record<SsoProviderType, string> = {
   oidc: 'oidc',
   entra_id: 'entra',

--- a/src/schemas/api/domains/requests/sso-config.ts
+++ b/src/schemas/api/domains/requests/sso-config.ts
@@ -79,7 +79,7 @@ export type PutSsoConfigRequest = z.infer<typeof putSsoConfigRequestSchema>;
  * - client_secret is optional (preserves existing if omitted)
  *
  * Fields:
- * - provider_type: optional enum ('oidc' | 'entra_id' | 'google' | 'github')
+ * - provider_type: optional enum ('oidc' | 'entra_id')
  * - client_id: optional string
  * - client_secret: optional string
  * - display_name: optional string

--- a/src/schemas/contracts/custom-domain/sso-config.ts
+++ b/src/schemas/contracts/custom-domain/sso-config.ts
@@ -10,8 +10,7 @@
  *
  * Stores SSO/OIDC credentials for custom domains that manage their own
  * identity provider connections. This enables multi-tenant SSO where each
- * domain can configure their own Entra ID, Google Workspace, or
- * generic OIDC provider.
+ * domain can configure their own Entra ID or generic OIDC provider.
  *
  * Design Decisions:
  *
@@ -21,8 +20,12 @@
  * 2. Masked Credentials: client_secret is never exposed in API responses.
  *    Instead, client_secret_masked provides a hint (e.g., "••••1234").
  *
- * 3. Provider Types: Supports 'oidc' (generic), 'entra_id', 'google', and
- *    'github'. Each has slightly different options (e.g., Entra requires
+ * 3. Provider Types: Supports 'oidc' (generic) and 'entra_id' only.
+ *    Tenant SSO is OIDC/Entra-only by design: identity partitioning is
+ *    keyed (provider, issuer, uid), so issuerless providers (GitHub is
+ *    plain OAuth2; Google has one global issuer) cannot satisfy per-tenant
+ *    isolation and are refused at the callback (#3902, PR #3900).
+ *    Each provider has slightly different options (Entra requires
  *    tenant_id, OIDC requires issuer for discovery).
  *
  * 4. Domain Allowlist: The allowed_domains list restricts which email
@@ -46,12 +49,16 @@ import { z } from 'zod';
  * Maps to OmniAuth strategies:
  * - oidc: omniauth-openid-connect (generic OIDC with discovery)
  * - entra_id: omniauth-entra-id (Microsoft Entra ID / Azure AD)
- * - google: omniauth-google-oauth2 (Google Workspace)
- * - github: omniauth-github (GitHub OAuth)
+ *
+ * Tenant SSO is OIDC/Entra-only: per-tenant identity partitioning is keyed
+ * (provider, issuer, uid), and issuerless providers (google, github) resolve
+ * to a shared issuer sentinel, so their callbacks are refused on tenant
+ * surfaces (#3902, PR #3900). Platform/install-level SSO is a separate
+ * surface and still supports GitHub/Google.
  *
  * @category Contracts
  */
-export const ssoProviderTypeSchema = z.enum(['oidc', 'entra_id', 'google', 'github']);
+export const ssoProviderTypeSchema = z.enum(['oidc', 'entra_id']);
 
 export type SsoProviderType = z.infer<typeof ssoProviderTypeSchema>;
 
@@ -76,16 +83,6 @@ export const SSO_PROVIDER_METADATA: Record<SsoProviderType, {
     idpControlsAccess: true,
     description: 'Microsoft Entra ID — access controlled via Azure app assignment',
   },
-  google: {
-    requiresDomainFilter: true,
-    idpControlsAccess: false,
-    description: 'Google Workspace — domain filtering recommended for enterprise',
-  },
-  github: {
-    requiresDomainFilter: true,
-    idpControlsAccess: false,
-    description: 'GitHub OAuth — domain filtering recommended',
-  },
 } as const;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -109,7 +106,7 @@ export const customDomainSsoConfigCanonical = z.object({
   /** Domain ID (references CustomDomain.identifier). */
   domain_id: z.string(),
 
-  /** SSO provider type (oidc, entra_id, google, github). */
+  /** SSO provider type (oidc, entra_id). */
   provider_type: ssoProviderTypeSchema,
 
   /** Whether SSO is enabled for this organization. */
@@ -136,12 +133,9 @@ export const customDomainSsoConfigCanonical = z.object({
    *   |---------------|-----------|----------|
    *   | entra_id      | required  | -        |
    *   | oidc          | -         | required |
-   *   | google        | -         | -        |
-   *   | github        | -         | -        |
    *
-   * Google and GitHub use well-known OAuth endpoints, so neither
-   * tenant_id nor issuer is needed. Universal fields (client_id,
-   * display_name) are always required regardless of provider.
+   * Universal fields (client_id, display_name) are always required
+   * regardless of provider.
    */
   tenant_id: z.string().nullable(),
 
@@ -162,7 +156,7 @@ export const customDomainSsoConfigCanonical = z.object({
 
   /**
    * Whether app-side domain filtering is recommended for this provider.
-   * True for providers without IdP-side user assignment (e.g., GitHub).
+   * True for providers without IdP-side user assignment (e.g., generic OIDC).
    * Read-only, computed from provider_type.
    */
   requires_domain_filter: z.boolean(),
@@ -216,7 +210,7 @@ export type CustomDomainSsoConfigCanonical = z.infer<typeof customDomainSsoConfi
  * @category Contracts
  */
 export const patchSsoConfigPayloadSchema = z.object({
-  /** SSO provider type (oidc, entra_id, google, github). */
+  /** SSO provider type (oidc, entra_id). */
   provider_type: ssoProviderTypeSchema.optional(),
 
   /** Human-readable name for UI display. */
@@ -271,7 +265,7 @@ export type PatchSsoConfigPayload = z.infer<typeof patchSsoConfigPayloadSchema>;
  * @category Contracts
  */
 export const putSsoConfigPayloadSchema = z.object({
-  /** SSO provider type (oidc, entra_id, google, github). */
+  /** SSO provider type (oidc, entra_id). */
   provider_type: ssoProviderTypeSchema,
 
   /** Human-readable name for UI display. */

--- a/src/services/sso.service.ts
+++ b/src/services/sso.service.ts
@@ -59,15 +59,13 @@ export interface TestSsoConnectionResponse {
   provider_type: SsoProviderType;
   message: string;
   details: {
-    // Success details (OIDC/Entra/Google)
+    // Success details (OIDC/Entra)
     issuer?: string;
     authorization_endpoint?: string;
     token_endpoint?: string;
     jwks_uri?: string;
     userinfo_endpoint?: string;
     scopes_supported?: string[];
-    // GitHub-specific
-    client_id_format?: string;
     note?: string;
     // Error details
     error_code?: string;

--- a/src/tests/apps/workspace/components/domains/DomainSsoConfigForm.spec.ts
+++ b/src/tests/apps/workspace/components/domains/DomainSsoConfigForm.spec.ts
@@ -1,8 +1,8 @@
 // src/tests/apps/workspace/components/domains/DomainSsoConfigForm.spec.ts
 //
 // Tests for DomainSsoConfigForm.vue covering:
-// 1. Provider type selector rendering
-// 2. Provider-specific field visibility (Entra ID, OIDC, Google, GitHub)
+// 1. Provider type selector rendering (OIDC/Entra-only — #3902)
+// 2. Provider-specific field visibility (Entra ID, OIDC)
 // 3. Form validation for required fields
 // 4. Event emissions (save, delete, test, discard)
 // 5. Form state updates via v-model
@@ -59,15 +59,13 @@ vi.mock('@/shared/components/forms/BasicFormAlerts.vue', () => ({
 }));
 
 
-// Mock SSO provider metadata
+// Mock SSO provider metadata (OIDC/Entra-only — #3902)
 // Note: This mock matches the actual module path the component imports from.
 // If tests fail due to provider metadata behavior, verify the component import path.
 vi.mock('@/schemas/shapes/domains/sso-config', () => ({
   SSO_PROVIDER_METADATA: {
     entra_id: { requiresDomainFilter: false, idpControlsAccess: true, description: 'Microsoft Entra ID' },
-    google: { requiresDomainFilter: false, idpControlsAccess: true, description: 'Google Workspace' },
-    github: { requiresDomainFilter: true, idpControlsAccess: false, description: 'GitHub OAuth' },
-    oidc: { requiresDomainFilter: false, idpControlsAccess: true, description: 'Generic OIDC' },
+    oidc: { requiresDomainFilter: true, idpControlsAccess: false, description: 'Generic OIDC' },
   },
 }));
 
@@ -206,18 +204,19 @@ describe('DomainSsoConfigForm', () => {
   // ─────────────────────────────────────────────────────────────────────────────
 
   describe('Provider type selector', () => {
-    it('renders all provider options', async () => {
+    // Tenant SSO is OIDC/Entra-only: issuerless providers (Google, GitHub)
+    // cannot satisfy per-tenant identity partitioning and were removed from
+    // the tenant surface (#3902, PR #3900).
+    it('renders exactly the two supported provider options (entra_id, oidc)', async () => {
       wrapper = await mountComponent();
 
-      const entraRadio = wrapper.find('#domain-provider-entra_id');
-      const googleRadio = wrapper.find('#domain-provider-google');
-      const githubRadio = wrapper.find('#domain-provider-github');
-      const oidcRadio = wrapper.find('#domain-provider-oidc');
+      expect(wrapper.find('#domain-provider-entra_id').exists()).toBe(true);
+      expect(wrapper.find('#domain-provider-oidc').exists()).toBe(true);
+      expect(wrapper.find('#domain-provider-google').exists()).toBe(false);
+      expect(wrapper.find('#domain-provider-github').exists()).toBe(false);
 
-      expect(entraRadio.exists()).toBe(true);
-      expect(googleRadio.exists()).toBe(true);
-      expect(githubRadio.exists()).toBe(true);
-      expect(oidcRadio.exists()).toBe(true);
+      const providerRadios = wrapper.findAll('input[type="radio"][name="provider_type"]');
+      expect(providerRadios).toHaveLength(2);
     });
 
     it('selects Entra ID by default', async () => {
@@ -230,11 +229,11 @@ describe('DomainSsoConfigForm', () => {
     it('allows selecting different providers', async () => {
       wrapper = await mountComponent();
 
-      const googleRadio = wrapper.find('#domain-provider-google');
-      await googleRadio.setValue(true);
+      const oidcRadio = wrapper.find('#domain-provider-oidc');
+      await oidcRadio.setValue(true);
       await flushPromises();
 
-      expect((googleRadio.element as HTMLInputElement).checked).toBe(true);
+      expect((oidcRadio.element as HTMLInputElement).checked).toBe(true);
     });
   });
 
@@ -250,8 +249,8 @@ describe('DomainSsoConfigForm', () => {
       expect(tenantIdInput.exists()).toBe(true);
     });
 
-    it('hides tenant_id field when Google is selected', async () => {
-      wrapper = await mountComponent({ formState: { ...createDefaultFormState(), provider_type: 'google' } });
+    it('hides tenant_id field when OIDC is selected', async () => {
+      wrapper = await mountComponent({ formState: { ...createDefaultFormState(), provider_type: 'oidc' } });
 
       const tenantIdInput = wrapper.find('#domain-sso-tenant-id');
       expect(tenantIdInput.exists()).toBe(false);
@@ -271,18 +270,8 @@ describe('DomainSsoConfigForm', () => {
       expect(issuerInput.exists()).toBe(false);
     });
 
-    it('hides both tenant_id and issuer for GitHub provider', async () => {
-      wrapper = await mountComponent({ formState: { ...createDefaultFormState(), provider_type: 'github' } });
-
-      const tenantIdInput = wrapper.find('#domain-sso-tenant-id');
-      const issuerInput = wrapper.find('#domain-sso-issuer');
-
-      expect(tenantIdInput.exists()).toBe(false);
-      expect(issuerInput.exists()).toBe(false);
-    });
-
     it('does not show domain filter field (feature not yet enabled)', async () => {
-      wrapper = await mountComponent({ formState: { ...createDefaultFormState(), provider_type: 'github' } });
+      wrapper = await mountComponent({ formState: { ...createDefaultFormState(), provider_type: 'oidc' } });
 
       const domainInput = wrapper.find('#domain-sso-domain-input');
       expect(domainInput.exists()).toBe(false);
@@ -338,14 +327,14 @@ describe('DomainSsoConfigForm', () => {
     it('emits update:formState when provider type changes', async () => {
       wrapper = await mountComponent();
 
-      const googleRadio = wrapper.find('#domain-provider-google');
-      await googleRadio.setValue(true);
+      const oidcRadio = wrapper.find('#domain-provider-oidc');
+      await oidcRadio.setValue(true);
       await flushPromises();
 
       const emitted = wrapper.emitted('update:formState');
       expect(emitted).toBeTruthy();
       expect(emitted![emitted!.length - 1][0]).toMatchObject({
-        provider_type: 'google',
+        provider_type: 'oidc',
       });
     });
 

--- a/src/tests/contracts/sso-config-metadata-contract.spec.ts
+++ b/src/tests/contracts/sso-config-metadata-contract.spec.ts
@@ -71,27 +71,19 @@ describe('SSO_PROVIDER_METADATA constant', () => {
       });
     });
 
-    describe('google', () => {
-      it('requires domain filter (Workspace needs explicit filtering for enterprise)', () => {
-        expect(SSO_PROVIDER_METADATA.google.requiresDomainFilter).toBe(true);
+    // Tenant SSO is OIDC/Entra-only: issuerless providers (google, github)
+    // cannot satisfy per-tenant identity partitioning keyed
+    // (provider, issuer, uid) and were removed from the tenant surface
+    // (#3902, PR #3900). Platform-level SSO retains them separately.
+    describe('removed issuerless providers', () => {
+      it('does not define metadata for google or github', () => {
+        expect(SSO_PROVIDER_METADATA).not.toHaveProperty('google');
+        expect(SSO_PROVIDER_METADATA).not.toHaveProperty('github');
       });
 
-      it('does NOT have IdP-controlled access', () => {
-        expect(SSO_PROVIDER_METADATA.google.idpControlsAccess).toBe(false);
-      });
-    });
-
-    describe('github', () => {
-      it('requires domain filter', () => {
-        expect(SSO_PROVIDER_METADATA.github.requiresDomainFilter).toBe(true);
-      });
-
-      it('does NOT have IdP-controlled access', () => {
-        expect(SSO_PROVIDER_METADATA.github.idpControlsAccess).toBe(false);
-      });
-
-      it('description mentions domain filter recommendation', () => {
-        expect(SSO_PROVIDER_METADATA.github.description).toContain('domain filter');
+      it('rejects google and github as provider types', () => {
+        expect(ssoProviderTypeSchema.safeParse('google').success).toBe(false);
+        expect(ssoProviderTypeSchema.safeParse('github').success).toBe(false);
       });
     });
   });
@@ -155,26 +147,44 @@ describe('customDomainSsoConfigCanonical schema', () => {
 
   describe('full payload parsing with metadata fields', () => {
     // Schema: customDomainSsoConfigCanonical (keyed by domain_id)
+    // Every field populated, to exercise full-payload parsing.
     const validPayload = {
       domain_id: 'dm_123',
-      provider_type: 'github' as SsoProviderType,
+      provider_type: 'entra_id' as SsoProviderType,
       enabled: true,
-      display_name: 'GitHub SSO',
+      display_name: 'Entra ID SSO',
       client_id: 'client-abc',
       client_secret_masked: '****5678',
-      tenant_id: null,
+      tenant_id: 'tenant-123',
       issuer: null,
       allowed_domains: [],
-      requires_domain_filter: true,
-      idp_controls_access: false,
+      requires_domain_filter: false,
+      idp_controls_access: true,
       enforce_sso_only: false,
       grant_org_scope: false,
       created_at: 1700000000,
       updated_at: 1700000000,
     };
 
-    it('parses payload with GitHub metadata values', () => {
+    it('parses payload with Entra ID metadata values', () => {
       const result = customDomainSsoConfigCanonical.safeParse(validPayload);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.requires_domain_filter).toBe(false);
+        expect(result.data.idp_controls_access).toBe(true);
+      }
+    });
+
+    it('parses payload with generic OIDC metadata values', () => {
+      const oidcPayload = {
+        ...validPayload,
+        provider_type: 'oidc' as SsoProviderType,
+        tenant_id: null,
+        issuer: 'https://idp.example.com',
+        requires_domain_filter: true,
+        idp_controls_access: false,
+      };
+      const result = customDomainSsoConfigCanonical.safeParse(oidcPayload);
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.data.requires_domain_filter).toBe(true);
@@ -182,19 +192,13 @@ describe('customDomainSsoConfigCanonical schema', () => {
       }
     });
 
-    it('parses payload with Entra ID metadata values', () => {
-      const entraPayload = {
-        ...validPayload,
-        provider_type: 'entra_id' as SsoProviderType,
-        tenant_id: 'tenant-123',
-        requires_domain_filter: false,
-        idp_controls_access: true,
-      };
-      const result = customDomainSsoConfigCanonical.safeParse(entraPayload);
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.requires_domain_filter).toBe(false);
-        expect(result.data.idp_controls_access).toBe(true);
+    it('rejects payloads with removed issuerless provider types (#3902)', () => {
+      for (const removed of ['google', 'github']) {
+        const result = customDomainSsoConfigCanonical.safeParse({
+          ...validPayload,
+          provider_type: removed,
+        });
+        expect(result.success).toBe(false);
       }
     });
 

--- a/src/tests/services/sso.service.domain.spec.ts
+++ b/src/tests/services/sso.service.domain.spec.ts
@@ -301,11 +301,11 @@ describe('SsoService domain methods', () => {
         data: {
           record: {
             domain_id: 'dm_put',
-            provider_type: 'google',
+            provider_type: 'entra_id',
             display_name: 'PUT Config',
             client_id: 'put-client-id',
             client_secret_masked: '********',
-            tenant_id: null,
+            tenant_id: 'tenant-put',
             issuer: null,
             enabled: true,
             allowed_domains: [],
@@ -320,11 +320,11 @@ describe('SsoService domain methods', () => {
         data: {
           record: {
             domain_id: 'dm_patch',
-            provider_type: 'google',
+            provider_type: 'entra_id',
             display_name: 'PATCH Config',
             client_id: 'patch-client-id',
             client_secret_masked: '********',
-            tenant_id: null,
+            tenant_id: 'tenant-patch',
             issuer: null,
             enabled: false,
             allowed_domains: [],
@@ -339,10 +339,11 @@ describe('SsoService domain methods', () => {
       mockPatch.mockResolvedValueOnce(patchResponse);
 
       const putResult = await SsoService.saveConfigForDomain('dm_1', {
-        provider_type: 'google' as const,
+        provider_type: 'entra_id' as const,
         client_id: 'id',
         client_secret: 'secret',
         display_name: 'Test',
+        tenant_id: 'tenant-put',
       });
 
       const patchResult = await SsoService.saveConfigForDomain('dm_2', {
@@ -436,28 +437,11 @@ describe('SsoService domain methods', () => {
       expect(result.details.error_code).toBe('discovery_failed');
     });
 
-    it('handles GitHub provider validation', async () => {
-      const githubResponse = {
-        user_id: 'user_123',
-        success: true,
-        provider_type: 'github',
-        message: 'Client ID format is valid',
-        details: {
-          client_id_format: 'valid',
-          note: 'GitHub does not support OIDC discovery',
-        },
-      };
-      mockPost.mockResolvedValueOnce({ data: githubResponse });
-
-      const result = await SsoService.testConnectionForDomain(domainExtId, {
-        provider_type: 'github' as const,
-        client_id: 'Iv1.abc123def456',
-      });
-
-      expect(result.success).toBe(true);
-      expect(result.provider_type).toBe('github');
-      expect(result.details.client_id_format).toBe('valid');
-    });
+    // NOTE: GitHub/Google are no longer tenant SSO providers (#3902).
+    // Issuerless providers cannot satisfy per-tenant identity partitioning
+    // keyed (provider, issuer, uid); tenant SSO is OIDC/Entra-only.
+    // Schema rejection of the removed values is asserted in the
+    // putConfigForDomain strict-mode tests below.
   });
 
   // ==========================================================================
@@ -627,11 +611,13 @@ describe('SsoService domain methods', () => {
       });
 
       it('throws ZodError on schema validation failure (strict mode)', async () => {
-        // Malformed response missing required fields
+        // Malformed response missing required fields. 'google' is itself an
+        // invalid enum value now: issuerless providers were removed from the
+        // tenant SSO surface (#3902) — tenant SSO is OIDC/Entra-only.
         const malformedResponse = {
           record: {
             domain_id: domainExtId,
-            provider_type: 'invalid_provider', // Invalid enum value
+            provider_type: 'google', // Removed enum value (#3902)
           },
         };
         mockPut.mockResolvedValueOnce({ data: malformedResponse });

--- a/src/tests/services/sso.service.org-level.deprecated.spec.ts
+++ b/src/tests/services/sso.service.org-level.deprecated.spec.ts
@@ -131,10 +131,11 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
       mockPut.mockResolvedValueOnce(mockResponse);
 
       await SsoService.putConfig('org_test', {
-        provider_type: 'google' as const,
-        client_id: 'google-client',
-        client_secret: 'google-secret',
-        display_name: 'Google SSO',
+        provider_type: 'entra_id' as const,
+        client_id: 'entra-client',
+        client_secret: 'entra-secret',
+        display_name: 'Entra SSO',
+        tenant_id: 'tenant-123',
       });
 
       expect(mockPut).toHaveBeenCalledTimes(1);
@@ -258,10 +259,11 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
       mockPatch.mockResolvedValueOnce(patchResponse);
 
       const putResult = await SsoService.saveConfig('org_1', {
-        provider_type: 'google' as const,
+        provider_type: 'entra_id' as const,
         client_id: 'id',
         client_secret: 'secret',
         display_name: 'Test',
+        tenant_id: 'tenant-123',
       });
 
       const patchResult = await SsoService.saveConfig('org_2', {
@@ -351,29 +353,33 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
       expect(result.details.error_code).toBe('discovery_failed');
     });
 
-    it('handles GitHub provider validation', async () => {
+    // Converted from a GitHub case: issuerless providers were removed from
+    // the tenant SSO surface (#3902) — tenant SSO is OIDC/Entra-only.
+    it('handles generic OIDC provider validation', async () => {
       const mockResponse = {
         data: {
           user_id: 'user_123',
           success: true,
-          provider_type: 'github',
-          message: 'Client ID format is valid',
+          provider_type: 'oidc',
+          message: 'Discovery document fetched successfully',
           details: {
-            client_id_format: 'valid',
-            note: 'GitHub does not support OIDC discovery',
+            issuer: 'https://idp.example.com',
+            authorization_endpoint: 'https://idp.example.com/authorize',
+            token_endpoint: 'https://idp.example.com/token',
           },
         },
       };
       mockPost.mockResolvedValueOnce(mockResponse);
 
       const result = await SsoService.testConnection('org_abc', {
-        provider_type: 'github' as const,
-        client_id: 'Iv1.abc123def456',
+        provider_type: 'oidc' as const,
+        client_id: 'oidc-client-id',
+        issuer: 'https://idp.example.com',
       });
 
       expect(result.success).toBe(true);
-      expect(result.provider_type).toBe('github');
-      expect(result.details.client_id_format).toBe('valid');
+      expect(result.provider_type).toBe('oidc');
+      expect(result.details.issuer).toBe('https://idp.example.com');
     });
   });
 });

--- a/try/unit/models/custom_domain_auth_default_off_try.rb
+++ b/try/unit/models/custom_domain_auth_default_off_try.rb
@@ -52,21 +52,31 @@ OT.info 'Cleaned Redis for custom-domain default-OFF resolver test run'
 @ts      = Familia.now.to_i
 @entropy = SecureRandom.hex(4)
 
+# SsoConfig.create! validates (client_id + issuer required for the default
+# oidc provider), so even fixtures that only exercise enabled? carry
+# minimal-but-valid credentials.
+def sso_config!(domain_id, enabled:)
+  Onetime::CustomDomain::SsoConfig.create!(
+    domain_id: domain_id, enabled: enabled,
+    client_id: "client-#{domain_id}", issuer: 'https://idp.example.com',
+  )
+end
+
 # SSO-only tenant: enabled SsoConfig, no SigninConfig record at all.
 @sso_only_domain = "dof_sso_only_#{@ts}_#{@entropy}"
-Onetime::CustomDomain::SsoConfig.create!(domain_id: @sso_only_domain, enabled: true)
+sso_config!(@sso_only_domain, enabled: true)
 
 # Tenant with a persisted SsoConfig whose master switch is OFF (present but
 # not available).
 @sso_disabled_domain = "dof_sso_off_#{@ts}_#{@entropy}"
-Onetime::CustomDomain::SsoConfig.create!(domain_id: @sso_disabled_domain, enabled: false)
+sso_config!(@sso_disabled_domain, enabled: false)
 
 # Tenant with an enabled SsoConfig AND a persisted-but-DISABLED SigninConfig:
 # the record exists but its master switch is off, so the tenant is "not
 # explicitly configured" for password sign-in while SSO remains permitted
 # (sso_permitted_for? defers when the master switch is off).
 @sso_with_disabled_signin = "dof_sso_dis_signin_#{@ts}_#{@entropy}"
-Onetime::CustomDomain::SsoConfig.create!(domain_id: @sso_with_disabled_signin, enabled: true)
+sso_config!(@sso_with_disabled_signin, enabled: true)
 @disabled_signin_cfg = Onetime::CustomDomain::SigninConfig.create!(
   domain_id: @sso_with_disabled_signin, enabled: false, signin_enabled: false
 )
@@ -76,7 +86,7 @@ Onetime::CustomDomain::SsoConfig.create!(domain_id: @sso_with_disabled_signin, e
 # activation authority says no — the only fixture that reaches the last rung
 # of the availability ladder.
 @sso_not_permitted_domain = "dof_sso_not_perm_#{@ts}_#{@entropy}"
-Onetime::CustomDomain::SsoConfig.create!(domain_id: @sso_not_permitted_domain, enabled: true)
+sso_config!(@sso_not_permitted_domain, enabled: true)
 Onetime::CustomDomain::SigninConfig.create!(
   domain_id: @sso_not_permitted_domain, enabled: true, signin_enabled: true, sso_enabled: false
 )

--- a/try/unit/models/custom_domain_mailer_config_try.rb
+++ b/try/unit/models/custom_domain_mailer_config_try.rb
@@ -8,7 +8,6 @@
 #   - MailerConfig creation with valid attributes
 #   - Validation (missing domain_id, missing provider, invalid provider, missing from_address)
 #   - update_from_address clears verified_at and resets verification_status
-#   - rotate_credentials preserves verified_at
 #   - CustomDomain forward navigation (sso_config, mailer_config, sso_config?, mailer_config?)
 #   - Provider type validation against PROVIDER_TYPES constant
 #   - enabled? and verified? boolean methods
@@ -313,33 +312,6 @@ mc2.validation_errors.include?('provider must be one of: smtp, ses, sendgrid, le
 ## Reloaded config has pending verification_status after address change
 @reloaded_after_update.verification_status
 #=> 'pending'
-
-# --- rotate_credentials preserves verified_at ---
-
-## Setup: mark config as verified for rotate test
-@config.verification_status = 'verified'
-@config.verified_at = Familia.now.to_i.to_s
-@config.save
-@saved_verified_at = @config.verified_at
-@config.verified?
-#=> true
-
-## rotate_credentials preserves verified_at
-@config.rotate_credentials('new-api-key-xyz789')
-@config.verified_at
-#=> @saved_verified_at
-
-# TODO: Encrypted api_key round-trip after rotation — same ticket as above.
-# Onetime::CustomDomain::MailerConfig.find_by_domain_id(@domain.identifier).api_key.reveal { it }
-# #=> 'new-api-key-xyz789'
-
-## rotate_credentials preserves verification_status
-@config.verification_status
-#=> 'verified'
-
-## rotate_credentials updates the updated timestamp
-@config.updated.to_i > 0
-#=> true
 
 # --- Class methods: find_by_domain_id, exists_for_domain? ---
 


### PR DESCRIPTION
Tenant SSO is now OIDC/Entra-only end to end. PR #3900's `refuse_issuerless_on_tenant?` already refused GitHub/Google callbacks on tenant surfaces (both collapse to the `''` issuer sentinel — GitHub has no issuer, Google's `accounts.google.com` is global, so neither can satisfy `(provider, issuer, uid)` per-tenant partitioning); this makes the config surface match: `PROVIDER_TYPES`, `PROVIDER_METADATA`, `PROVIDER_ROUTE_MAP`, the omniauth-options dispatch, and the TestConnection google/github paths are removed backend-side, `ssoProviderTypeSchema`/picker options are narrowed frontend-side, and the two e2e suites are ported to Entra/OIDC with all 33 test cases and cross-domain isolation assertions preserved. No existing tenant configs used these providers, so this is a clean removal with no migration. Platform/install-level GitHub/Google SSO (ENV-registered) is untouched, as is the callback-phase refusal path, which stays as defense-in-depth.

## Review hardening on top of the removal

- **Model validation enforced on every write path** — `SsoConfig.create!`, PUT, and PATCH all fail closed on `SsoConfig#validation_errors` before committing, so nothing invalid (including legacy provider types) can be persisted or resurrected.
- **Tenant resolution fails closed on pre-#3902 legacy data** — the omniauth tenant SSO ladder refuses stored `google`/`github` configs (`:unsupported_provider_type`) instead of falling through.
- **Secretless-OIDC → entra_id switch requires a secret** — an OIDC public-client (PKCE) config has no stored `client_secret` to fall back to on a PATCH provider switch, so the switch 422s unless the request supplies one. PUT's `client_secret` semantics (empty clears it, OIDC only) are covered by spec.
- **Legacy records 422 with an actionable message on PATCH** — a bare `{enabled: false}` PATCH on a stored legacy record previously failed with "Invalid provider type", blaming a field the caller never sent. The error now names the stored legacy type and points at the escape hatches (DELETE, full PUT), both pinned by spec.
- **PATCH provider switch clears the outgoing provider's field** (`issuer` for oidc, `tenant_id` for entra_id) unless the request supplies it, matching the end state a full PUT produces — no stale cross-provider fields survive a switch.
- **e2e TC-MPROV-003 has real teeth** — the vacuous `expect(a || b || true)` assertion is gone; the test now asserts `toHaveCount(0)` for issuerless providers in each domain's modal.
- Callback-preview route drift is documented separately as #3932.
- Unrelated scope, named for transparency: `Onetime::MailerConfig#rotate_credentials` was dead code encountered during review and is removed here.

## Pre-merge check

Confirm zero production tenant `SsoConfig` records with `provider_type` `google`/`github`. Legacy records are un-PATCHable by design (fail closed); DELETE and full PUT are the escape hatches, so any nonzero count means owner outreach before deploy.

Closes #3902
