### PR TITLE
Fix has_password fail-open: degrade to unknown, not false, on DB errors

### DIFF
--- a/apps/web/core/views/serializers/authentication_serializer.rb
+++ b/apps/web/core/views/serializers/authentication_serializer.rb
@@ -87,18 +87,29 @@ module Core
         # Checks whether the authenticated account has a password hash set.
         # SSO-only accounts have no row in account_password_hashes.
         #
+        # Returns nil (unknown) when the lookup hits a transient database
+        # failure rather than a fabricated false — on the wire, false means
+        # "SSO-only account" and drives the frontend to hide password/MFA
+        # settings. The bootstrap store treats nil as "no information" so a
+        # blipped refresh never clobbers a known-good value. Only Sequel
+        # errors degrade; programming errors propagate.
+        #
         # @param sess [Hash, nil] Session hash containing account_id
-        # @return [Boolean] true if account has a password, false otherwise
+        # @return [Boolean, nil] true if account has a password, false if not
+        #   (or no session account / auth DB not in this mode), nil when the
+        #   lookup failed
         def account_has_password?(sess)
           account_id = sess&.[]('account_id')
           return false unless account_id
+          return false unless defined?(Auth::Database)
 
           db = Auth::Database.connection
           return false unless db
 
           db[:account_password_hashes].where(id: account_id).any?
-        rescue StandardError
-          false
+        rescue Sequel::DatabaseError, Sequel::PoolTimeout => ex
+          OT.le "[AuthenticationSerializer] account_has_password? query failed: #{ex.class} account_id=#{account_id}"
+          nil
         end
 
         # Resolve test plan name from Billing::Plan cache or config

--- a/spec/unit/core/views/serializers/authentication_serializer_spec.rb
+++ b/spec/unit/core/views/serializers/authentication_serializer_spec.rb
@@ -1,0 +1,109 @@
+# spec/unit/core/views/serializers/authentication_serializer_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sequel'
+
+# Unit tests for AuthenticationSerializer.account_has_password? (#3926).
+#
+# The lookup is tri-state: true/false are definitive answers, nil means the
+# query failed and the caller (frontend bootstrap store) should keep its last
+# known value. A transient database error must never serialize as a confident
+# has_password:false — that is the wire signal for an SSO-only account and
+# hides the password/MFA settings UI. Programming errors must propagate.
+RSpec.describe Core::Views::AuthenticationSerializer do
+  describe '.account_has_password?' do
+    subject(:result) { described_class.account_has_password?(sess) }
+
+    let(:sess) { { 'account_id' => 42 } }
+    let(:dataset) { instance_double(Sequel::Dataset) }
+    let(:db) { double('Sequel::Database') }
+
+    before do
+      stub_const('Auth::Database', class_double('Auth::Database', connection: db))
+      allow(db).to receive(:[]).with(:account_password_hashes).and_return(dataset)
+      allow(dataset).to receive(:where).with(id: 42).and_return(dataset)
+    end
+
+    context 'without a session account' do
+      let(:sess) { nil }
+
+      it 'returns false for a nil session' do
+        expect(result).to be(false)
+      end
+
+      it 'returns false when the session has no account_id' do
+        expect(described_class.account_has_password?({})).to be(false)
+      end
+    end
+
+    context 'when the auth app is not loaded' do
+      before { hide_const('Auth::Database') }
+
+      it 'returns false' do
+        expect(result).to be(false)
+      end
+    end
+
+    context 'without an auth database connection (simple mode)' do
+      let(:db) { nil }
+
+      it 'returns false' do
+        expect(result).to be(false)
+      end
+    end
+
+    context 'with a working database' do
+      it 'returns true when a password hash row exists' do
+        allow(dataset).to receive(:any?).and_return(true)
+
+        expect(result).to be(true)
+      end
+
+      it 'returns false for an SSO-only account (no row)' do
+        allow(dataset).to receive(:any?).and_return(false)
+
+        expect(result).to be(false)
+      end
+    end
+
+    context 'when the query raises a database error' do
+      before do
+        allow(dataset).to receive(:any?).and_raise(Sequel::DatabaseError, 'connection refused')
+      end
+
+      it 'returns nil (unknown), not false' do
+        expect(result).to be_nil
+      end
+
+      it 'logs the failure with class and account context' do
+        expect(OT).to receive(:le).with(
+          '[AuthenticationSerializer] account_has_password? query failed: Sequel::DatabaseError account_id=42'
+        )
+
+        result
+      end
+    end
+
+    context 'when the connection pool is exhausted' do
+      before do
+        allow(dataset).to receive(:any?).and_raise(Sequel::PoolTimeout, 'pool timeout')
+      end
+
+      it 'returns nil (unknown)' do
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when the lookup hits a programming error' do
+      before do
+        allow(dataset).to receive(:any?).and_raise(NoMethodError, "undefined method `oops'")
+      end
+
+      it 'propagates instead of masking it as a serialized value' do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+  end
+end

--- a/spec/unit/core/views/serializers/authentication_serializer_spec.rb
+++ b/spec/unit/core/views/serializers/authentication_serializer_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe Core::Views::AuthenticationSerializer do
     let(:db) { double('Sequel::Database') }
 
     before do
+      # Keep rescue-path examples from writing real log output; the explicit
+      # expect(OT).to receive(:le) in the logging example still verifies it.
+      allow(OT).to receive(:le)
       stub_const('Auth::Database', class_double('Auth::Database', connection: db))
       if db
         allow(db).to receive(:[]).with(:account_password_hashes).and_return(dataset)

--- a/spec/unit/core/views/serializers/authentication_serializer_spec.rb
+++ b/spec/unit/core/views/serializers/authentication_serializer_spec.rb
@@ -22,8 +22,10 @@ RSpec.describe Core::Views::AuthenticationSerializer do
 
     before do
       stub_const('Auth::Database', class_double('Auth::Database', connection: db))
-      allow(db).to receive(:[]).with(:account_password_hashes).and_return(dataset)
-      allow(dataset).to receive(:where).with(id: 42).and_return(dataset)
+      if db
+        allow(db).to receive(:[]).with(:account_password_hashes).and_return(dataset)
+        allow(dataset).to receive(:where).with(id: 42).and_return(dataset)
+      end
     end
 
     context 'without a session account' do

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -564,7 +564,10 @@ export const bootstrapSchema = z.object({
   authenticated: z.boolean().default(false),
   awaiting_mfa: z.boolean().optional().default(false),
   had_valid_session: z.boolean().default(false),
-  has_password: z.boolean().optional().default(false),
+  // Tri-state: true/false are definitive; null means the server could not
+  // determine it (transient auth-DB failure during serialization). The store
+  // treats null as "no information" and keeps the last known value.
+  has_password: z.boolean().nullable().optional().default(false),
   custid: z.string().default(''),
   cust: customerCanonical.nullable().default(null),
   email: z.string().default(''),

--- a/src/shared/stores/bootstrapStore.ts
+++ b/src/shared/stores/bootstrapStore.ts
@@ -246,7 +246,10 @@ export const useBootstrapStore = defineStore('bootstrap', {
     update(data: Partial<BootstrapPayload>): void {
       // has_password: null means the server couldn't determine it (transient
       // auth-DB failure during serialization). Treat it like an absent field
-      // so a blipped refresh never clobbers a known-good true/false.
+      // so a blipped refresh never clobbers a known-good true/false. init()
+      // intentionally skips this drop: on first load there is no prior value
+      // to preserve, and consumers (hasPasswordOf) gate on === true, so a
+      // null in state already reads conservatively as "no password known".
       if (data.has_password === null) {
         const { has_password: _unknown, ...known } = data;
         data = known;

--- a/src/shared/stores/bootstrapStore.ts
+++ b/src/shared/stores/bootstrapStore.ts
@@ -244,6 +244,14 @@ export const useBootstrapStore = defineStore('bootstrap', {
      * @param data - Partial BootstrapPayload data to merge
      */
     update(data: Partial<BootstrapPayload>): void {
+      // has_password: null means the server couldn't determine it (transient
+      // auth-DB failure during serialization). Treat it like an absent field
+      // so a blipped refresh never clobbers a known-good true/false.
+      if (data.has_password === null) {
+        const { has_password: _unknown, ...known } = data;
+        data = known;
+      }
+
       // Use functional $patch to avoid _DeepPartial type issues with complex Stripe types
       // Filter out undefined values to match previous updateIfDefined behavior
       this.$patch((state) => {

--- a/src/tests/stores/bootstrapStore.spec.ts
+++ b/src/tests/stores/bootstrapStore.spec.ts
@@ -1255,6 +1255,19 @@ describe('bootstrapStore', () => {
       expect(store.has_password).toBe(true);
     });
 
+    it('retains known has_password when a refresh reports null (unknown)', () => {
+      store.update({ has_password: true });
+
+      // null = server couldn't determine it (transient auth-DB failure);
+      // it must not clobber the known-good value in store or snapshot.
+      store.update({ has_password: null, email: 'fresh@example.com' });
+
+      expect(store.has_password).toBe(true);
+      expect(store.email).toBe('fresh@example.com');
+      const lastSnapshotUpdate = vi.mocked(bootstrapService.updateBootstrapSnapshot).mock.lastCall?.[0];
+      expect(lastSnapshotUpdate).toEqual({ email: 'fresh@example.com' });
+    });
+
     it('updates support_host field', () => {
       store.update({ support_host: 'help.example.com' });
 

--- a/src/tests/utils/features.spec.ts
+++ b/src/tests/utils/features.spec.ts
@@ -1071,6 +1071,10 @@ describe('features utility', () => {
     it('returns false when has_password is undefined', () => {
       expect(hasPasswordOf({})).toBe(false);
     });
+
+    it('returns false when has_password is null (server could not determine)', () => {
+      expect(hasPasswordOf({ has_password: null })).toBe(false);
+    });
   });
 
   // ── hasPassword (snapshot wrapper) ──────────────────────────────
@@ -1091,6 +1095,12 @@ describe('features utility', () => {
 
     it('returns false when bootstrap has_password is undefined', () => {
       getBootstrapValueMock.mockReturnValue(undefined);
+
+      expect(hasPassword()).toBe(false);
+    });
+
+    it('returns false when bootstrap has_password is null', () => {
+      getBootstrapValueMock.mockReturnValue(null);
 
       expect(hasPassword()).toBe(false);
     });

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -358,10 +358,11 @@ export function isFullAuthMode(): boolean {
  * Pure predicate: user has a password set in the given state.
  *
  * Accepts an optional `has_password` so the snapshot wrapper can pass through
- * `getBootstrapValue('has_password')` (which is typed as `boolean | undefined`)
- * without a coercion at every call site.
+ * `getBootstrapValue('has_password')` (typed `boolean | null | undefined`;
+ * null is the server's "unknown" signal) without a coercion at every call
+ * site. Anything other than a definitive true stays conservative.
  */
-export function hasPasswordOf(state: { has_password?: boolean }): boolean {
+export function hasPasswordOf(state: { has_password?: boolean | null }): boolean {
   return state.has_password === true;
 }
 


### PR DESCRIPTION
## Summary

[#3926](https://github.com/onetimesecret/onetimesecret/issues/3926)

`AuthenticationSerializer#account_has_password?` rescued `StandardError` and returned `false`, so a transient auth-DB failure during serialization emitted `has_password: false` — the wire signal for an SSO-only account — for users who do have a password. The frontend then hid the Change Email/Password/MFA/Recovery Codes routes and sidebar entries, showed the "SSO linked" badge, and a blipped `/bootstrap/me` refresh clobbered a known-good `true` in the bootstrap store. The broad rescue also permanently masked programming errors, and nothing was logged on either path.

This implements the issue's recommendation: degrade, but honestly and observably, with a tri-state contract.

**Backend** (`apps/web/core/views/serializers/authentication_serializer.rb`):
- Rescue narrowed to `Sequel::DatabaseError` and `Sequel::PoolTimeout` (the latter covers the pool-exhaustion scenario from the issue, which is not a `DatabaseError`); programming errors propagate again.
- Failures log via `OT.le` with exception class and `account_id`, matching the ConfigSerializer precedent.
- The rescue returns `nil` (unknown) instead of a fabricated `false`. The config-state guards (no session account, no auth DB connection) still return a definitive `false`, now including an explicit `defined?(Auth::Database)` guard for builds where the auth app isn't loaded — previously that `NameError` was silently absorbed by the broad rescue (the health controller uses the same guard).

**Frontend**:
- `src/schemas/contracts/bootstrap.ts`: `has_password` is now `z.boolean().nullable().optional().default(false)` — `null` passes through, absent still defaults to `false`.
- `src/shared/stores/bootstrapStore.ts`: `update()` drops a `null` `has_password` before both the store patch and the `updateBootstrapSnapshot()` sync, so a refresh during a DB blip retains the last known value instead of clobbering it. Done per-field rather than in `filterDefined()` because `null` is meaningful for other fields (e.g. `cust: null` on logout).
- `src/utils/features.ts`: `hasPasswordOf()` accepts `boolean | null`; it already gated on `=== true`, so anything but a definitive `true` stays conservative and first-load behavior is unchanged (password UI hidden until known).

## Related Issues

Fixes #3926

## Test Plan

- New `spec/unit/core/views/serializers/authentication_serializer_spec.rb`: definitive `false` for no session account / auth app not loaded / no connection; `true`/`false` from the query; `Sequel::DatabaseError` and `Sequel::PoolTimeout` return `nil` and log with class + account context; `NoMethodError` propagates.
- `src/tests/stores/bootstrapStore.spec.ts`: an update with `has_password: null` retains the known `true`, still applies sibling fields, and never forwards the `null` to the bootstrap.service snapshot.
- `src/tests/utils/features.spec.ts`: `hasPasswordOf`/`hasPassword` return `false` for `null`.
- `pnpm run type-check` passes; the three affected vitest suites pass (290 tests); ESLint on changed files reports only pre-existing warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZMNTGRjyAG7jSYRmAxsY9

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZMNTGRjyAG7jSYRmAxsY9)_