### PR TITLE
[#3840] fix(sso): map link_conflict/link_rate_limited in the sign-in interstitial

### DIFF
--- a/locales/content/en/session-auth-extended.json
+++ b/locales/content/en/session-auth-extended.json
@@ -486,6 +486,16 @@
     "context": "Error on the #3840 Phase 3 sign-in interstitial when the single-use challenge token is expired, spent, or unknown (dead-end, not retryable).",
     "content_hash": "541f9127"
   },
+  "web.link_sso.errors.link_conflict": {
+    "text": "We couldn't link this sign-in method. Your account may have changed, or this provider is already linked to another account. Sign in with your existing password, then manage connections under Security settings → Connected identities.",
+    "context": "Terminal error on the #3840 Phase 3 sign-in interstitial when the account was re-emailed between challenge mint and submit, or the (provider, issuer, uid) identity is already bound to a different account (backend error_code link_conflict, HTTP 409). Dead-end — a retry against this challenge can never succeed; points the user at the Phase 2 Connected Identities flow.",
+    "content_hash": "7b0e0d0e"
+  },
+  "web.link_sso.errors.link_rate_limited": {
+    "text": "Too many password attempts. Please wait a few minutes, then try again.",
+    "context": "Inline error on the #3840 Phase 3 sign-in interstitial when the per-account/IP login throttle trips (backend error_code link_rate_limited, HTTP 429). The throttle fires BEFORE the single-use token is consumed, so waiting and retrying can succeed — the copy must say 'wait', never that the request is dead.",
+    "content_hash": "a95e78cd"
+  },
   "web.link_sso.errors.generic": {
     "text": "We couldn't link your account. Please try again.",
     "context": "Fallback error for #3840 Phase 3 sign-in interstitial challenge-context / verify failures that are neither a wrong password nor an expired token.",

--- a/locales/content/en/session-auth-extended.json
+++ b/locales/content/en/session-auth-extended.json
@@ -496,6 +496,11 @@
     "context": "Inline error on the #3840 Phase 3 sign-in interstitial when the per-account/IP login throttle trips (backend error_code link_rate_limited, HTTP 429). The throttle fires BEFORE the single-use token is consumed, so waiting and retrying can succeed — the copy must say 'wait', never that the request is dead.",
     "content_hash": "a95e78cd"
   },
+  "web.link_sso.errors.invalid_request": {
+    "text": "We couldn't process this linking request. Please sign in with your SSO provider again.",
+    "context": "Inline error on the #3840 Phase 3 sign-in interstitial when the submit was malformed — token or password missing from the body (backend error_code invalid_request, HTTP 400). Unreachable through the view's own guards; shown so a crafted or buggy submit is never presented as a wrong password.",
+    "content_hash": "053b9fc6"
+  },
   "web.link_sso.errors.generic": {
     "text": "We couldn't link your account. Please try again.",
     "context": "Fallback error for #3840 Phase 3 sign-in interstitial challenge-context / verify failures that are neither a wrong password nor an expired token.",

--- a/src/apps/session/views/LinkSso.vue
+++ b/src/apps/session/views/LinkSso.vue
@@ -33,8 +33,10 @@
 
   const password = ref('');
   const passwordInputRef = ref<HTMLInputElement | null>(null);
-  // Set when the challenge context cannot be loaded or the token is spent: there
-  // is nothing to prove against, so render the dead-end panel, not the form.
+  // Set when the challenge context cannot be loaded, the token is spent, or the
+  // verify failed terminally (link_conflict — the account moved or the identity
+  // is bound elsewhere): there is nothing left to prove against, so render the
+  // dead-end panel, not the form. The specific reason lives in `error`.
   const challengeUnavailable = ref(false);
 
   // Single-use challenge token from the interstitial URL (path param, scrubbed
@@ -57,6 +59,14 @@
   // backend defaults that to 'SSO'/'Microsoft', which would read wrong in the
   // prose below ("You signed in with SSO"). See utils/features.ts.
   const providerDisplayName = computed(() => providerLabel(challenge.value?.provider ?? ''));
+
+  // Dead-end-panel body: the specific classified reason when one was set
+  // (spent token / conflict), else the generic expired copy (e.g. the token was
+  // missing from the URL entirely, so no request ever ran). Mirrors
+  // SsoLinkConfirm.vue's unavailableMessage.
+  const unavailableMessage = computed(
+    () => error.value ?? t('web.link_sso.unavailable_message')
+  );
 
   // Single polite live region, rendered unconditionally. A live region has to be
   // in the DOM BEFORE its content changes for assistive tech to announce it, so
@@ -142,9 +152,20 @@
       return;
     }
 
-    if (errorCode.value === 'invalid_token') {
-      // Nothing left to prove against — fall through to the dead-end panel.
+    if (errorCode.value === 'invalid_token' || errorCode.value === 'link_conflict') {
+      // Terminal: nothing left to prove against (spent token), or the account
+      // moved / the identity is bound elsewhere (conflict). A retry against this
+      // challenge can never succeed — fall through to the dead-end panel, which
+      // carries the specific reason (see unavailableMessage).
       challengeUnavailable.value = true;
+      return;
+    }
+
+    if (errorCode.value === 'link_rate_limited') {
+      // Throttled BEFORE the token was consumed: the challenge is still live and
+      // a retry after the lockout can succeed. Leave the form as-is — clearing
+      // and refocusing the password would invite an immediate retype that
+      // re-trips the throttle. The inline error says "wait".
       return;
     }
 
@@ -187,9 +208,11 @@
       </div>
 
       <div class="space-y-6">
-        <!-- Dead-end: token missing / expired / spent. Keep the H-3 refusal and
-             point the user at the Phase 2 settings flow. Labelled + described so
-             focusing the heading announces the refusal. -->
+        <!-- Dead-end: token missing / expired / spent, or the verify hit a
+             terminal conflict (account moved / identity bound elsewhere). Keep
+             the H-3 refusal and point the user at the Phase 2 settings flow.
+             Labelled + described so focusing the heading announces the
+             refusal. -->
         <div
           v-if="challengeUnavailable"
           role="group"
@@ -212,7 +235,7 @@
           <p
             id="link-sso-unavailable-message"
             class="text-sm text-gray-600 dark:text-gray-400">
-            {{ t('web.link_sso.unavailable_message') }}
+            {{ unavailableMessage }}
           </p>
           <button
             @click="goToSignInFallback"

--- a/src/apps/session/views/LinkSso.vue
+++ b/src/apps/session/views/LinkSso.vue
@@ -161,11 +161,14 @@
       return;
     }
 
-    if (errorCode.value === 'link_rate_limited') {
-      // Throttled BEFORE the token was consumed: the challenge is still live and
-      // a retry after the lockout can succeed. Leave the form as-is — clearing
-      // and refocusing the password would invite an immediate retype that
-      // re-trips the throttle. The inline error says "wait".
+    if (errorCode.value === 'link_rate_limited' || errorCode.value === 'invalid_request') {
+      // Not a password verdict — leave the form as-is; clearing and refocusing
+      // the field would misrepresent either failure as a wrong password.
+      // - link_rate_limited: throttled BEFORE the token was consumed, so the
+      //   challenge is still live and a retry after the lockout can succeed;
+      //   the inline error says "wait". An immediate retype would re-trip it.
+      // - invalid_request: malformed submit (missing token/password) that the
+      //   guards above should make impossible; surface its copy inline.
       return;
     }
 

--- a/src/shared/composables/useLinkSso.ts
+++ b/src/shared/composables/useLinkSso.ts
@@ -27,11 +27,24 @@
  *                                    or { success, mfa_required, ... } (MFA account —
  *                                    same body POST /auth/login returns; hand off to
  *                                    the shared /mfa-verify challenge, do NOT complete)
- *                               401 invalid_password => wrong password (retryable)
- *                               401 link_expired     => token expired / consumed (dead-end)
- *   The failure branch is distinguished by HTTP status and, when present, an
- *   { error_code } field ('invalid_password' vs 'invalid_token'/'expired_token'/
- *   'link_expired'). Legacy 403/404/410 statuses are still classified defensively.
+ *                               401 invalid_password  => wrong password (retryable)
+ *                               401 link_expired      => token expired / consumed (dead-end)
+ *                               409 link_conflict     => the email re-resolved to a different
+ *                                                       account since mint, or the
+ *                                                       (provider,issuer,uid) is already bound
+ *                                                       elsewhere (dead-end — retry can never
+ *                                                       succeed)
+ *                               429 link_rate_limited => too many password attempts for this
+ *                                                       account/IP; refused BEFORE consuming
+ *                                                       the token, so waiting and retrying can
+ *                                                       succeed — but the view must NOT invite
+ *                                                       an immediate retry
+ *   The failure branch is distinguished by an { error_code } field
+ *   ('invalid_request' / 'link_expired' / 'invalid_password' / 'link_conflict' /
+ *   'link_rate_limited' — the exact set apps/web/auth/routes/link_sso.rb emits;
+ *   keep in lockstep with that route) and, defensively, the HTTP status family.
+ *   'invalid_token' / 'expired_token' are frontend-side legacy aliases (no Ruby
+ *   route emits them) kept in the resolver as defence.
  *
  * Mirrors useMfa / useConnectedIdentities: happy paths validate through a zod
  * schema; useAsyncHandler `wrap` manages the loading state and the unexpected
@@ -57,12 +70,27 @@ import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 /**
- * Distinguishes a retryable wrong-password failure from a dead-end token
- * failure (expired / spent / unknown challenge). The view keeps the user on the
- * password form for 'invalid_password' and points them at the settings flow for
- * 'invalid_token'.
+ * Typed failure the view branches on:
+ * - 'invalid_password'  — wrong password; the view keeps the user on the form
+ *                         for another try.
+ * - 'invalid_token'     — dead-end token failure (expired / spent / unknown
+ *                         challenge); the view points at the settings flow.
+ * - 'link_conflict'     — dead-end: the account moved or the identity is bound
+ *                         to a different account. Terminal — a retry against
+ *                         this challenge can never succeed, so the view must
+ *                         NOT re-offer the password form.
+ * - 'link_rate_limited' — too many attempts; the backend refused BEFORE
+ *                         consuming the token, so waiting and retrying can
+ *                         succeed. The copy says "wait" — the view must not
+ *                         clear/refocus the password field, which would invite
+ *                         an immediate retry that re-trips the throttle.
  */
-export type LinkSsoErrorCode = 'invalid_password' | 'invalid_token' | null;
+export type LinkSsoErrorCode =
+  | 'invalid_password'
+  | 'invalid_token'
+  | 'link_conflict'
+  | 'link_rate_limited'
+  | null;
 
 /** Minimal shape of the axios error's carried response (status + parsed body). */
 interface ErrorResponseLike {
@@ -70,32 +98,45 @@ interface ErrorResponseLike {
   data?: Record<string, unknown>;
 }
 
+const BACKEND_CODE_MAP: Record<string, NonNullable<LinkSsoErrorCode>> = {
+  invalid_password: 'invalid_password',
+  link_conflict: 'link_conflict',
+  link_rate_limited: 'link_rate_limited',
+  link_expired: 'invalid_token',
+  // Frontend-side legacy aliases — no backend route emits these; defence only.
+  invalid_token: 'invalid_token',
+  expired_token: 'invalid_token',
+};
+
+const STATUS_FAMILY_MAP: Record<number, NonNullable<LinkSsoErrorCode>> = {
+  404: 'invalid_token',
+  410: 'invalid_token',
+  409: 'link_conflict',
+  429: 'link_rate_limited',
+  401: 'invalid_password',
+  403: 'invalid_password',
+  422: 'invalid_password',
+};
+
 /**
  * Maps an HTTP status and an optional backend { error_code } to the UI's typed
- * failure. Prefers the explicit backend code; falls back to the status family
- * (404/410 => spent token, 401/403/422 => wrong password). Returns null when the
- * failure is neither (e.g. a 5xx) so the caller surfaces a generic message.
+ * failure. The explicit backend code is checked FIRST — before any status-family
+ * fallback — so a specific code arriving on a shared status can never be
+ * shadowed (mirrors useSsoLinkConfirm's resolver after #3882). The status
+ * families (404/410 => spent token, 409 => conflict, 429 => rate limited,
+ * 401/403/422 => wrong password) are defence for a code-less response. Returns
+ * null when the failure is neither (e.g. a 5xx) so the caller surfaces a
+ * generic message.
  */
 function resolveLinkErrorCode(
   status: number | undefined,
   backendCode: unknown
 ): LinkSsoErrorCode {
-  if (
-    backendCode === 'invalid_token' ||
-    backendCode === 'expired_token' ||
-    backendCode === 'link_expired' ||
-    status === 404 ||
-    status === 410
-  ) {
-    return 'invalid_token';
+  if (typeof backendCode === 'string' && backendCode in BACKEND_CODE_MAP) {
+    return BACKEND_CODE_MAP[backendCode];
   }
-  if (
-    backendCode === 'invalid_password' ||
-    status === 401 ||
-    status === 403 ||
-    status === 422
-  ) {
-    return 'invalid_password';
+  if (status !== undefined && status in STATUS_FAMILY_MAP) {
+    return STATUS_FAMILY_MAP[status];
   }
   return null;
 }
@@ -133,6 +174,8 @@ export function useLinkSso() {
   function messageForCode(code: LinkSsoErrorCode): string {
     if (code === 'invalid_token') return t('web.link_sso.errors.invalid_token');
     if (code === 'invalid_password') return t('web.link_sso.errors.invalid_password');
+    if (code === 'link_conflict') return t('web.link_sso.errors.link_conflict');
+    if (code === 'link_rate_limited') return t('web.link_sso.errors.link_rate_limited');
     return t('web.link_sso.errors.generic');
   }
 

--- a/src/shared/composables/useLinkSso.ts
+++ b/src/shared/composables/useLinkSso.ts
@@ -27,6 +27,12 @@
  *                                    or { success, mfa_required, ... } (MFA account —
  *                                    same body POST /auth/login returns; hand off to
  *                                    the shared /mfa-verify challenge, do NOT complete)
+ *                               400 invalid_request   => token or password missing from the
+ *                                                       body. The view's guards prevent this
+ *                                                       (empty token dead-ends on mount, empty
+ *                                                       password blocks submit); classified so
+ *                                                       a crafted or buggy submit never reads
+ *                                                       as a wrong password
  *                               401 invalid_password  => wrong password (retryable)
  *                               401 link_expired      => token expired / consumed (dead-end)
  *                               409 link_conflict     => the email re-resolved to a different
@@ -84,12 +90,17 @@ import { useI18n } from 'vue-i18n';
  *                         succeed. The copy says "wait" — the view must not
  *                         clear/refocus the password field, which would invite
  *                         an immediate retry that re-trips the throttle.
+ * - 'invalid_request'   — malformed submit (token or password missing from the
+ *                         body). Unreachable via the view's guards; classified
+ *                         so a crafted or buggy request is never presented as
+ *                         a wrong password (no field clear/refocus).
  */
 export type LinkSsoErrorCode =
   | 'invalid_password'
   | 'invalid_token'
   | 'link_conflict'
   | 'link_rate_limited'
+  | 'invalid_request'
   | null;
 
 /** Minimal shape of the axios error's carried response (status + parsed body). */
@@ -102,6 +113,7 @@ const BACKEND_CODE_MAP: Record<string, NonNullable<LinkSsoErrorCode>> = {
   invalid_password: 'invalid_password',
   link_conflict: 'link_conflict',
   link_rate_limited: 'link_rate_limited',
+  invalid_request: 'invalid_request',
   link_expired: 'invalid_token',
   // Frontend-side legacy aliases — no backend route emits these; defence only.
   invalid_token: 'invalid_token',
@@ -109,6 +121,7 @@ const BACKEND_CODE_MAP: Record<string, NonNullable<LinkSsoErrorCode>> = {
 };
 
 const STATUS_FAMILY_MAP: Record<number, NonNullable<LinkSsoErrorCode>> = {
+  400: 'invalid_request',
   404: 'invalid_token',
   410: 'invalid_token',
   409: 'link_conflict',
@@ -123,10 +136,10 @@ const STATUS_FAMILY_MAP: Record<number, NonNullable<LinkSsoErrorCode>> = {
  * failure. The explicit backend code is checked FIRST — before any status-family
  * fallback — so a specific code arriving on a shared status can never be
  * shadowed (mirrors useSsoLinkConfirm's resolver after #3882). The status
- * families (404/410 => spent token, 409 => conflict, 429 => rate limited,
- * 401/403/422 => wrong password) are defence for a code-less response. Returns
- * null when the failure is neither (e.g. a 5xx) so the caller surfaces a
- * generic message.
+ * families (400 => malformed request, 404/410 => spent token, 409 => conflict,
+ * 429 => rate limited, 401/403/422 => wrong password) are defence for a
+ * code-less response. Returns null when the failure is neither (e.g. a 5xx)
+ * so the caller surfaces a generic message.
  */
 function resolveLinkErrorCode(
   status: number | undefined,
@@ -176,6 +189,7 @@ export function useLinkSso() {
     if (code === 'invalid_password') return t('web.link_sso.errors.invalid_password');
     if (code === 'link_conflict') return t('web.link_sso.errors.link_conflict');
     if (code === 'link_rate_limited') return t('web.link_sso.errors.link_rate_limited');
+    if (code === 'invalid_request') return t('web.link_sso.errors.invalid_request');
     return t('web.link_sso.errors.generic');
   }
 

--- a/src/tests/apps/session/views/LinkSso.spec.ts
+++ b/src/tests/apps/session/views/LinkSso.spec.ts
@@ -423,6 +423,31 @@ describe('LinkSso', () => {
       );
       expect(input.element.value).toBe('correct horse');
     });
+
+    // invalid_request (400) means the submit was malformed — not a password
+    // verdict. The view's guards should make it unreachable, but if the backend
+    // disagrees the form must not clear/refocus as if the password were wrong.
+    it('keeps the form without clearing the password on invalid_request', async () => {
+      mockState.verifyLink.mockImplementation(async () => {
+        mockState.errorCode.value = 'invalid_request';
+        mockState.error.value = 'web.link_sso.errors.invalid_request';
+        return null;
+      });
+      wrapper = mountComponent();
+      await flushPromises();
+
+      const input = wrapper.find<HTMLInputElement>('[data-testid="link-sso-password-input"]');
+      await input.setValue('typed pw');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockSetAuthenticated).not.toHaveBeenCalled();
+      expect(wrapper.find('[data-testid="link-sso-unavailable"]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="link-sso-error"]').text()).toBe(
+        'web.link_sso.errors.invalid_request'
+      );
+      expect(input.element.value).toBe('typed pw');
+    });
   });
 
   describe('Cancel / dead-end navigation', () => {

--- a/src/tests/apps/session/views/LinkSso.spec.ts
+++ b/src/tests/apps/session/views/LinkSso.spec.ts
@@ -99,7 +99,10 @@ const makeChallenge = (overrides: Partial<LinkSsoChallenge> = {}): LinkSsoChalle
  * - fetches the challenge context on mount and names provider + claimed email
  * - collects the EXISTING password and completes sign-in on success
  * - keeps the user on the form for a wrong password (retry)
- * - dead-ends (settings pointer) for a missing / expired / spent token
+ * - dead-ends (settings pointer) for a missing / expired / spent token and for
+ *   a terminal conflict (link_conflict — retry can never succeed)
+ * - keeps the form untouched (no clear/refocus) when rate limited — the token
+ *   is still live; inviting an immediate retype would re-trip the throttle
  * - cancel routes to /signin carrying the Connected Identities destination
  */
 describe('LinkSso', () => {
@@ -366,6 +369,59 @@ describe('LinkSso', () => {
 
       expect(mockSetAuthenticated).not.toHaveBeenCalled();
       expect(wrapper.find('[data-testid="link-sso-unavailable"]').exists()).toBe(true);
+    });
+
+    // #3889: link_conflict (account re-emailed since mint, or identity bound to
+    // another account) is unrecoverable by retry. It must dead-end like a spent
+    // token — never re-offer the password form as if the password were wrong.
+    it('dead-ends with the specific reason on a terminal conflict (link_conflict)', async () => {
+      mockState.verifyLink.mockImplementation(async () => {
+        mockState.errorCode.value = 'link_conflict';
+        mockState.error.value = 'web.link_sso.errors.link_conflict';
+        return null;
+      });
+      wrapper = mountComponent();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="link-sso-password-input"]').setValue('pw');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockSetAuthenticated).not.toHaveBeenCalled();
+      expect(wrapper.find('[data-testid="link-sso-unavailable"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="link-sso-password-input"]').exists()).toBe(false);
+      // The panel names the actual reason, not the generic expired copy.
+      expect(wrapper.find('#link-sso-unavailable-message').text()).toBe(
+        'web.link_sso.errors.link_conflict'
+      );
+    });
+
+    // #3889: link_rate_limited fires BEFORE the token is consumed, so the
+    // challenge is still live — but clearing + refocusing the password invites
+    // an immediate retype that re-trips the throttle. Keep the form (with the
+    // typed password) and surface the "wait" copy inline.
+    it('keeps the form without clearing the password when rate limited', async () => {
+      mockState.verifyLink.mockImplementation(async () => {
+        mockState.errorCode.value = 'link_rate_limited';
+        mockState.error.value = 'web.link_sso.errors.link_rate_limited';
+        return null;
+      });
+      wrapper = mountComponent();
+      await flushPromises();
+
+      const input = wrapper.find<HTMLInputElement>('[data-testid="link-sso-password-input"]');
+      await input.setValue('correct horse');
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+
+      expect(mockSetAuthenticated).not.toHaveBeenCalled();
+      expect(mockPush).not.toHaveBeenCalled();
+      // Not a dead-end: still on the form, error inline, password preserved.
+      expect(wrapper.find('[data-testid="link-sso-unavailable"]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="link-sso-error"]').text()).toBe(
+        'web.link_sso.errors.link_rate_limited'
+      );
+      expect(input.element.value).toBe('correct horse');
     });
   });
 

--- a/src/tests/composables/useLinkSso.spec.ts
+++ b/src/tests/composables/useLinkSso.spec.ts
@@ -20,8 +20,11 @@ vi.mock('@/shared/stores/csrfStore', () => ({
  *
  * Verifies the GET challenge-context fetch and POST password verify, plus the
  * typed error classification the view branches on:
- * - invalid_password (retryable) vs invalid_token (dead-end)
- * - distinguished by HTTP status AND an optional backend { error_code }
+ * - invalid_password (retryable) vs invalid_token / link_conflict (dead-end)
+ *   vs link_rate_limited (throttled; token still live — wait and retry)
+ * - distinguished by an explicit backend { error_code } first, then the HTTP
+ *   status family as defence (so a specific code on a shared status is never
+ *   shadowed)
  */
 describe('useLinkSso', () => {
   let axiosMock: AxiosMockAdapter;
@@ -213,6 +216,78 @@ describe('useLinkSso', () => {
       axiosMock
         .onPost('/auth/link-sso')
         .reply(200, { error: 'stale', error_code: 'invalid_token' });
+
+      const { verifyLink, errorCode } = useLinkSso();
+      const result = await verifyLink('tok123', 'pw');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('invalid_token');
+    });
+
+    // Backend emits 409 link_conflict when the account was re-emailed between
+    // challenge mint and POST, or the (provider,issuer,uid) is already bound to
+    // a different account. Terminal — without the mapping it fell through to
+    // null and the view treated it as a retryable password error (#3889).
+    it('classifies a conflict (409 link_conflict) as link_conflict (dead-end)', async () => {
+      axiosMock
+        .onPost('/auth/link-sso')
+        .reply(409, { error: 'conflict', error_code: 'link_conflict' });
+
+      const { verifyLink, error, errorCode } = useLinkSso();
+      const result = await verifyLink('tok123', 'pw');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('link_conflict');
+      expect(error.value).toBe('web.link_sso.errors.link_conflict');
+    });
+
+    it('falls back to link_conflict for a code-less 409', async () => {
+      axiosMock.onPost('/auth/link-sso').reply(409, { error: 'conflict' });
+
+      const { verifyLink, errorCode } = useLinkSso();
+      const result = await verifyLink('tok123', 'pw');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('link_conflict');
+    });
+
+    // Backend emits 429 link_rate_limited when the per-account/IP throttle
+    // trips — BEFORE consuming the token, so the challenge is still live.
+    // Without the mapping it fell through to null (generic copy) and the view
+    // handed back a focused password field, immediately re-tripping the
+    // throttle (#3889).
+    it('classifies a throttle (429 link_rate_limited) as link_rate_limited', async () => {
+      axiosMock.onPost('/auth/link-sso').reply(429, {
+        error: 'Too many attempts. Please try again later.',
+        error_code: 'link_rate_limited',
+        retry_after: 60,
+      });
+
+      const { verifyLink, error, errorCode } = useLinkSso();
+      const result = await verifyLink('tok123', 'pw');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('link_rate_limited');
+      expect(error.value).toBe('web.link_sso.errors.link_rate_limited');
+    });
+
+    it('falls back to link_rate_limited for a code-less 429', async () => {
+      axiosMock.onPost('/auth/link-sso').reply(429, { error: 'slow down' });
+
+      const { verifyLink, errorCode } = useLinkSso();
+      const result = await verifyLink('tok123', 'pw');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('link_rate_limited');
+    });
+
+    // Ordering guard: the explicit code must be checked BEFORE the status-family
+    // fallback, so a specific code arriving on a shared status is never
+    // shadowed (mirrors the useSsoLinkConfirm resolver after #3882).
+    it('honors an explicit error_code (link_expired) over a 409 status', async () => {
+      axiosMock
+        .onPost('/auth/link-sso')
+        .reply(409, { error: 'expired', error_code: 'link_expired' });
 
       const { verifyLink, errorCode } = useLinkSso();
       const result = await verifyLink('tok123', 'pw');

--- a/src/tests/composables/useLinkSso.spec.ts
+++ b/src/tests/composables/useLinkSso.spec.ts
@@ -281,6 +281,33 @@ describe('useLinkSso', () => {
       expect(errorCode.value).toBe('link_rate_limited');
     });
 
+    // Backend emits 400 invalid_request when token/password are missing from
+    // the body. The view's guards make that unreachable, but a crafted or
+    // buggy submit must never be classified as a wrong password and invited
+    // to retry (PR #3936 review).
+    it('classifies a malformed submit (400 invalid_request) as invalid_request', async () => {
+      axiosMock
+        .onPost('/auth/link-sso')
+        .reply(400, { error: 'Token and password are required.', error_code: 'invalid_request' });
+
+      const { verifyLink, error, errorCode } = useLinkSso();
+      const result = await verifyLink('tok123', 'pw');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('invalid_request');
+      expect(error.value).toBe('web.link_sso.errors.invalid_request');
+    });
+
+    it('falls back to invalid_request for a code-less 400', async () => {
+      axiosMock.onPost('/auth/link-sso').reply(400, { error: 'bad request' });
+
+      const { verifyLink, errorCode } = useLinkSso();
+      const result = await verifyLink('tok123', 'pw');
+
+      expect(result).toBeNull();
+      expect(errorCode.value).toBe('invalid_request');
+    });
+
     // Ordering guard: the explicit code must be checked BEFORE the status-family
     // fallback, so a specific code arriving on a shared status is never
     // shadowed (mirrors the useSsoLinkConfirm resolver after #3882).


### PR DESCRIPTION
## Summary

[#3889](https://github.com/onetimesecret/onetimesecret/issues/3889)

`resolveLinkErrorCode` in `useLinkSso.ts` had no mapping for two error codes `apps/web/auth/routes/link_sso.rb` actually emits — `link_conflict` (HTTP 409) and `link_rate_limited` (HTTP 429). Both fell through to `null`, so `LinkSso.vue` took the wrong-password path: clear the password field, refocus it, and invite the user to retry against a challenge that can never succeed (conflict) or immediately re-trip the throttle (rate limit).

**Composable (`useLinkSso.ts`)**
- Adds `link_conflict` and `link_rate_limited` to `LinkSsoErrorCode`, each with distinct copy.
- Reworks the resolver as a backend-code map checked **before** a status-family fallback map, so a specific code arriving on a shared status can never be shadowed — mirroring `useSsoLinkConfirm`'s resolver after #3882. Code-less 409/429 responses still classify correctly via the status fallback.
- Per review: also maps `invalid_request` (400), completing coverage of the route's full emitted code set (`invalid_request` / `link_expired` / `invalid_password` / `link_conflict` / `link_rate_limited`). A malformed submit — unreachable through the view's own guards — is no longer presented as a wrong password.
- Refreshes the stale docstring; `invalid_token` / `expired_token` are frontend-side legacy aliases kept as defence only.

**View (`LinkSso.vue`)**
- `link_conflict` is terminal: it now dead-ends to the unavailable panel like a spent token, and the panel shows the specific classified reason (new `unavailableMessage` computed, mirroring `SsoLinkConfirm.vue`) instead of always the generic expired copy.
- `link_rate_limited` and `invalid_request` leave the form untouched — no password clear, no refocus. The throttle fires **before** the single-use token is consumed, so the challenge is still live and a retry after waiting can succeed (the inline copy says "wait"); a malformed submit is not a password verdict.

**Locale**
- Adds `web.link_sso.errors.link_conflict`, `.link_rate_limited`, and `.invalid_request` to the en source (`session-auth-extended.json`) with populated content hashes. The rate-limit copy deliberately says "wait", never that the request is dead.

**Review follow-up**
- The pre-existing middleware 403/422 → `invalid_password` fallback concern raised in review (not introduced here) is tracked separately in #3940.

## Related Issues

Fixes #3889

## Test Plan

- `pnpm test:base run src/tests/composables/useLinkSso.spec.ts src/tests/apps/session/views/LinkSso.spec.ts` — 49 tests pass (10 new):
  - composable: 409 `link_conflict`, 429 `link_rate_limited`, and 400 `invalid_request` classify correctly (with and without explicit `error_code`), and an explicit `link_expired` on a 409 wins over the status (ordering guard).
  - view: `link_conflict` dead-ends to the panel showing the specific reason with the password form unmounted; `link_rate_limited` and `invalid_request` stay on the form with the typed password preserved and their copy inline.
- `pnpm run type-check` — clean.
- `pnpm run lint:base` / `lint:tests` on touched files — clean.
- `python3 locales/scripts/i18n content hashes` (dry run) — all hashes fresh; `content compile --all` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bzrEqcrACaUzbKxez6qT6

---
_Generated by [Claude Code](https://claude.ai/code/session_014bzrEqcrACaUzbKxez6qT6)_