### PR TITLE
Rate-limit the /auth/reset-password-request route (per-IP + per-target)

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -447,6 +447,35 @@ AUTH_VERIFY_ACCOUNT_ENABLED=true
 # (default): signups allowed from any domain.
 #ALLOWED_SIGNUP_DOMAIN=
 
+# Rate limiting for reset-password requests (#3872;
+# site.authentication.reset_request_rate_limit). In full auth mode,
+# throttles POST /auth/reset-password-request per client IP and per
+# submitted login BEFORE any account lookup, bounding the sampling
+# throughput of the accepted timing residual from #3857. Enabled by
+# default (protective); set to 'false' to opt out.
+# See lib/onetime/security/reset_request_rate_limiter.rb.
+#RESET_REQUEST_RATE_LIMIT_ENABLED=true
+
+# Requests permitted per window from a single client IP before the
+# per-IP tier locks out
+# (site.authentication.reset_request_rate_limit.max_per_ip). Default: 10.
+#RESET_REQUEST_RATE_LIMIT_MAX_PER_IP=10
+
+# Higher backstop cap per submitted login, catching IP-rotating callers
+# (site.authentication.reset_request_rate_limit.max_per_email).
+# Default: 30.
+#RESET_REQUEST_RATE_LIMIT_MAX_PER_EMAIL=30
+
+# Counting window in seconds for both rate-limit tiers
+# (site.authentication.reset_request_rate_limit.window).
+# Default: 3600 (1 hour).
+#RESET_REQUEST_RATE_LIMIT_WINDOW=3600
+
+# Lockout duration in seconds once a tier's cap is hit
+# (site.authentication.reset_request_rate_limit.lockout).
+# Default: 3600 (1 hour).
+#RESET_REQUEST_RATE_LIMIT_LOCKOUT=3600
+
 # Remember-me: persistent login across browser sessions via the
 # "Remember me" checkbox (auth: full.features.remember_me). Cookie
 # lifetime is Rodauth's default 14 days. Full auth mode only.

--- a/.env.reference
+++ b/.env.reference
@@ -452,7 +452,10 @@ AUTH_VERIFY_ACCOUNT_ENABLED=true
 # throttles POST /auth/reset-password-request per client IP and per
 # submitted login BEFORE any account lookup, bounding the sampling
 # throughput of the accepted timing residual from #3857. Enabled by
-# default (protective); set to 'false' to opt out.
+# default (protective); set to the exact string 'false' to opt out —
+# other falsey-looking values ('0', 'no', 'off') leave it ENABLED, the
+# same convention as the other *_ENABLED != 'false' knobs in
+# etc/defaults/config.defaults.yaml.
 # See lib/onetime/security/reset_request_rate_limiter.rb.
 #RESET_REQUEST_RATE_LIMIT_ENABLED=true
 

--- a/apps/web/auth/config.rb
+++ b/apps/web/auth/config.rb
@@ -85,6 +85,11 @@ module Auth
       Hooks::Login.configure(self)
       Hooks::Logout.configure(self)
       Hooks::Password.configure(self)
+      # Rate limiting for POST /auth/reset-password-request (issue #3872):
+      # bounds the timing-residual sampling the enumeration override (#3857)
+      # accepts. Requires :reset_password (enabled by AccountManagement above)
+      # so the before_reset_password_request_route hook exists.
+      Hooks::ResetPasswordRequest.configure(self)
 
       # Method overrides (replace Rodauth methods, not before/after hooks)
       Overrides::PasswordMigration.configure(self)

--- a/apps/web/auth/config/hooks.rb
+++ b/apps/web/auth/config/hooks.rb
@@ -34,6 +34,8 @@
 #                       before_recovery_auth, after_add_recovery_codes,
 #                       before_view_recovery_codes
 #   email_auth.rb       before_email_auth_route, after_email_auth_request
+#   reset_password_request.rb  before_reset_password_request_route (rate
+#                       limiting per client IP + per submitted login, #3872)
 #   webauthn.rb         after_webauthn_setup, before_webauthn_auth,
 #                       after_webauthn_auth_failure, before_webauthn_remove
 #   omniauth_tenant.rb  before_omniauth_callback_route (sole owner — logs
@@ -66,6 +68,7 @@ module Auth::Config::Hooks
   require_relative 'hooks/omniauth'
   require_relative 'hooks/omniauth_tenant'
   require_relative 'hooks/password'
+  require_relative 'hooks/reset_password_request'
   require_relative 'hooks/email_auth'
   require_relative 'hooks/webauthn'
 end

--- a/apps/web/auth/config/hooks/reset_password_request.rb
+++ b/apps/web/auth/config/hooks/reset_password_request.rb
@@ -1,0 +1,71 @@
+# apps/web/auth/config/hooks/reset_password_request.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/security/reset_request_rate_limiter'
+
+#
+# Reset-Password-Request Rate Limiting (issue #3872)
+#
+# SOLE OWNER of the before_reset_password_request_route hook (hooks do not
+# chain — see config/hooks.rb).
+#
+# The enumeration override (config/overrides/reset_password_enumeration.rb,
+# #3857) made every POST /auth/reset-password-request answer identically, which
+# closed the single-request content oracle but accepted a statistical TIMING
+# residual. Exploiting that residual needs many samples per target; this hook
+# caps that throughput by enforcing Onetime::Security::ResetRequestRateLimiter
+# (per-client-IP tight tier + per-submitted-login backstop) BEFORE the route
+# body runs — i.e. before Rodauth's account lookup, so a throttled probe never
+# executes the timing-sensitive path at all. It stacks with Rodauth's own
+# resend throttle, which caps emails per account but not request volume per
+# source (#3857 preserved it).
+#
+# CLIENT IP: the universal MiddlewareStack mounts Otto's IPPrivacyMiddleware
+# once, which resolves the canonical env['otto.client_ip'] via the
+# trusted-proxy resolver (Otto::Utils.resolve_client_ip) and rewrites
+# REMOTE_ADDR to the same masked value — so neither source is spoofable via
+# forwarded headers from an untrusted hop. We prefer the canonical env key and
+# fall back to request.ip (the rewritten REMOTE_ADDR) when it is absent (e.g. a
+# bare-Roda unit spec). An empty resolution skips the IP tier rather than
+# pooling unknown callers into one shared bucket an attacker could poison —
+# the per-login backstop still applies (same reasoning as the
+# sso_link_confirm throttle subject and LoginRateLimiter's RL-3 note).
+#
+# ENUMERATION SAFETY: the limiter keys only on request-observable inputs (IP,
+# submitted login string), never on account existence, so the 429 introduces
+# no new oracle. The raised Onetime::LimitExceeded propagates through
+# around_rodauth (which re-raises typed limiter exceptions without the
+# unhandled-exception error log — see overrides/error_handling.rb) to the
+# router's error_handler, which renders the ADR-013 429 body with retry_after.
+#
+# POST-only: Rodauth's route wrapper fires this hook for GET (form render)
+# and POST alike; only the POST performs the account lookup + email dispatch
+# that the timing channel rides on, so only the POST is counted.
+#
+module Auth::Config::Hooks
+  module ResetPasswordRequest
+    def self.configure(auth)
+      # The before_reset_password_request_route configuration method only
+      # exists when :reset_password is enabled (AccountManagement enables it
+      # unconditionally today); same defensive guard as the enumeration
+      # override so a future conditional enablement degrades to a no-op
+      # rather than a NoMethodError at configure time.
+      auth_class = auth.instance_variable_get(:@auth)
+      return unless auth_class&.features&.include?(:reset_password)
+
+      auth.auth_class_eval do
+        include Onetime::Security::ResetRequestRateLimiter
+      end
+
+      auth.before_reset_password_request_route do
+        if request.post?
+          client_ip = request.env['otto.client_ip']
+          client_ip = request.ip if client_ip.to_s.empty?
+
+          enforce_reset_request_rate_limit!(client_ip, param_or_nil(login_param))
+        end
+      end
+    end
+  end
+end

--- a/apps/web/auth/config/overrides/error_handling.rb
+++ b/apps/web/auth/config/overrides/error_handling.rb
@@ -27,6 +27,14 @@ module Auth::Config::Overrides
         end
         begin
           super(&blk)
+        rescue Onetime::LimitExceeded
+          # Expected control flow, not an unhandled exception: the
+          # reset-request rate limiter (hooks/reset_password_request.rb,
+          # #3872) raises this to reject a throttled request. Re-raise
+          # without the :unhandled_exception error log below — the router's
+          # error_handler translates it to the ADR-013 429 body and logs it
+          # at the ErrorTranslator's :warn level.
+          raise
         rescue Sequel::ForeignKeyConstraintViolation => ex
           # Handle FK violations that may indicate an orphaned session
           # (account deleted while session active). We detect this by checking

--- a/apps/web/auth/config/overrides/error_handling.rb
+++ b/apps/web/auth/config/overrides/error_handling.rb
@@ -28,9 +28,10 @@ module Auth::Config::Overrides
         begin
           super(&blk)
         rescue Onetime::LimitExceeded
-          # Expected control flow, not an unhandled exception: the
-          # reset-request rate limiter (hooks/reset_password_request.rb,
-          # #3872) raises this to reject a throttled request. Re-raise
+          # Expected control flow, not an unhandled exception: rate limiters
+          # on auth routes raise this to reject a throttled request (today
+          # the reset-request limiter — hooks/reset_password_request.rb,
+          # #3872 — and any future limiter wired the same way). Re-raise
           # without the :unhandled_exception error log below — the router's
           # error_handler translates it to the ADR-013 429 body and logs it
           # at the ErrorTranslator's :warn level.

--- a/apps/web/auth/config/overrides/reset_password_enumeration.rb
+++ b/apps/web/auth/config/overrides/reset_password_enumeration.rb
@@ -92,6 +92,12 @@
 # regardless. Content-equalization above is the meaningful fix; the timing residual
 # is accepted and documented. (Reviewed: Greptile P1 + 2nd review bot, issue #3857.)
 #
+# The residual is additionally BOUNDED by rate limiting (#3872): exploiting it
+# statistically needs many samples per target, and config/hooks/
+# reset_password_request.rb throttles POST volume per client IP and per
+# submitted login (Onetime::Security::ResetRequestRateLimiter) before the
+# route — and therefore before account_from_login — runs.
+#
 # See also: config/rodauth_overrides.rb (verify_account error-flash overrides)
 # and config/overrides/password_migration.rb (the `super` override idiom).
 #

--- a/apps/web/auth/spec/integration/full/reset_password_request_rate_limit_spec.rb
+++ b/apps/web/auth/spec/integration/full/reset_password_request_rate_limit_spec.rb
@@ -1,0 +1,226 @@
+# apps/web/auth/spec/integration/full/reset_password_request_rate_limit_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration — reset-password-request rate limiting (issue #3872)
+# =============================================================================
+#
+# In `full` auth mode the Rodauth app handles POST /auth/reset-password-request.
+# The enumeration override (#3857) made every response identical, accepting a
+# statistical timing residual; exploiting that residual needs many samples per
+# target. The before_reset_password_request_route hook (config/hooks/
+# reset_password_request.rb) enforces Onetime::Security::ResetRequestRateLimiter
+# BEFORE the route body runs: a tight per-client-IP tier plus a higher
+# per-submitted-login backstop, both keyed only on request-observable inputs.
+#
+# These tests assert: under-cap requests still get the generic success, an
+# over-cap source gets the ADR-013 429 regardless of which login it probes, an
+# IP-rotation-resistant per-login backstop exists (case-insensitively), and the
+# 429 itself is enumeration-safe (identical for existing vs non-existent
+# targets).
+#
+# The suite-wide test config ships the limiter DISABLED
+# (spec/config.test.yaml) so other full-mode specs are not throttled; each
+# example here enables it in-process with small caps and restores the config
+# after.
+#
+# REQUIREMENTS:
+# - Valkey running on port 2121: pnpm run test:database:start
+# - AUTH_DATABASE_URL set (SQLite or PostgreSQL)
+# - AUTHENTICATION_MODE=full
+#
+# RUN:
+#   source .env.test && pnpm run test:rspec \
+#     apps/web/auth/spec/integration/full/reset_password_request_rate_limit_spec.rb
+#
+# =============================================================================
+
+require_relative '../../spec_helper'
+require 'rack/test'
+require 'argon2'
+
+RSpec.describe 'Reset-password-request rate limiting (issue #3872)', type: :integration do
+  include Rack::Test::Methods
+
+  before(:all) do
+    # Boot the full app so the REAL Auth::Config (with the rate-limit hook wired
+    # in via config/hooks/reset_password_request.rb) is loaded and mounted at
+    # /auth.
+    boot_onetime_app
+  end
+
+  before do
+    unless defined?(Auth::Database) && Auth::Database.connection
+      skip 'Auth database not configured (run with AUTH_DATABASE_URL set)'
+    end
+
+    # Isolate from real email delivery (see the enumeration spec for rationale).
+    allow(Onetime::Jobs::Publisher).to receive(:enqueue_email_raw).and_return(true)
+
+    @saved_conf = YAML.load(YAML.dump(OT.conf))
+    clear_reset_request_keys
+  end
+
+  after do
+    OT.send(:conf=, @saved_conf) if @saved_conf
+    clear_reset_request_keys
+  end
+
+  let(:rl_redis) { Onetime::Customer.dbclient }
+
+  # Clear every limiter key so each example starts from a clean slate. The
+  # per-IP subject is the privacy-MASKED address Otto's IPPrivacyMiddleware
+  # resolves (NOT the Rack::Test REMOTE_ADDR), so keys are matched by prefix
+  # rather than assumed.
+  def clear_reset_request_keys
+    stale = rl_redis.keys('reset_request:attempts:*') +
+            rl_redis.keys('reset_request:locked:*')
+    rl_redis.del(*stale) unless stale.empty?
+  end
+
+  # Enable the limiter in-process with example-specific caps (the suite config
+  # ships it disabled). Restored from @saved_conf in the after hook.
+  def enable_limiter(max_per_ip:, max_per_email:)
+    new_conf = YAML.load(YAML.dump(OT.conf))
+    new_conf['site'] ||= {}
+    new_conf['site']['authentication'] ||= {}
+    new_conf['site']['authentication']['reset_request_rate_limit'] = {
+      'enabled' => true,
+      'max_per_ip' => max_per_ip,
+      'max_per_email' => max_per_email,
+      'window' => 900,
+      'lockout' => 900,
+    }
+    OT.send(:conf=, new_conf)
+  end
+
+  # CSRF-correct JSON POST to the Rodauth endpoint; mirrors the helper in
+  # reset_password_request_enumeration_spec.rb.
+  def request_password_reset(login)
+    clear_cookies
+
+    header 'Content-Type', nil
+    header 'Content-Length', nil
+    header 'Accept', 'application/json'
+    get '/auth'
+    token = last_response.headers['X-CSRF-Token']
+
+    header 'Content-Type', 'application/json'
+    header 'Accept', 'application/json'
+    header 'X-CSRF-Token', token if token
+    post '/auth/reset-password-request', JSON.generate(login: login, shrimp: token)
+    last_response
+  end
+
+  def create_account(email:, status_id: AuthTestConstants::STATUS_VERIFIED, password: 'TestPassword123!')
+    db    = Auth::Database.connection
+    extid = SecureRandom.uuid
+    account_id = db[:accounts].insert(
+      email: email,
+      status_id: status_id,
+      external_id: extid,
+      created_at: Time.now,
+      updated_at: Time.now
+    )
+
+    hasher = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
+    db[:account_password_hashes].insert(id: account_id, password_hash: hasher.create(password))
+
+    { id: account_id, email: email, external_id: extid }
+  end
+
+  describe 'per-IP tier' do
+    it 'caps request volume from one source across DIFFERENT logins (the enumeration sampling pattern)' do
+      enable_limiter(max_per_ip: 2, max_per_email: 100)
+
+      # Under the cap: each probe of a fresh target still gets the generic
+      # enumeration-safe success.
+      2.times do |i|
+        response = request_password_reset(unique_test_email("sample-#{i}"))
+        expect(response.status).to eq(200),
+          "Under-cap request #{i + 1} should pass, got #{response.status}: #{response.body}"
+        expect(JSON.parse(response.body)['success']).to match(/email has been sent/i)
+      end
+
+      # The cap-hitting request locked the per-IP tier (attempts key cleared,
+      # lockout flag set) — proving the IP tier, not the per-login backstop,
+      # is what engaged (every probe used a distinct login).
+      expect(rl_redis.keys('reset_request:locked:ip:*').size).to eq(1)
+
+      # Over the cap: a THIRD distinct login from the same source is refused
+      # with the ADR-013 429 before the route (and its account lookup) runs.
+      response = request_password_reset(unique_test_email('sample-2'))
+      expect(response.status).to eq(429),
+        "Over-cap request must be throttled, got #{response.status}: #{response.body}"
+      body = JSON.parse(response.body)
+      expect(body['error_type']).to eq('LimitExceeded')
+      expect(body['retry_after']).to be_a(Integer)
+      expect(body['max_attempts']).to eq(2)
+    end
+  end
+
+  describe 'per-login backstop' do
+    it 'caps repeated probes of ONE target case-insensitively, independent of the IP tier' do
+      enable_limiter(max_per_ip: 100, max_per_email: 2)
+      target = unique_test_email('backstop')
+
+      2.times do |i|
+        response = request_password_reset(target)
+        expect(response.status).to eq(200),
+          "Under-cap request #{i + 1} should pass, got #{response.status}: #{response.body}"
+      end
+
+      expect(rl_redis.keys('reset_request:locked:email:*').size).to eq(1)
+
+      # A case-variant of the same target shares the bucket (normalization),
+      # so the third probe is refused even though the per-IP cap is far away.
+      response = request_password_reset(target.upcase)
+      expect(response.status).to eq(429),
+        "Over-cap request must be throttled, got #{response.status}: #{response.body}"
+      expect(JSON.parse(response.body)['error_type']).to eq('LimitExceeded')
+    end
+  end
+
+  describe 'enumeration safety of the 429' do
+    it 'throttles an existing and a non-existent login identically' do
+      enable_limiter(max_per_ip: 100, max_per_email: 1)
+
+      existing = unique_test_email('exists')
+      missing  = unique_test_email('missing')
+      create_account(email: existing)
+
+      # First request per target is allowed (and locks each per-login bucket).
+      expect(request_password_reset(existing).status).to eq(200)
+      expect(request_password_reset(missing).status).to eq(200)
+
+      throttled_existing = request_password_reset(existing)
+      throttled_missing  = request_password_reset(missing)
+
+      expect(throttled_existing.status).to eq(429)
+      expect(throttled_missing.status).to eq(429)
+
+      # The throttle discloses nothing about account existence: same error
+      # content either way. (request_id varies per request, so compare the
+      # discriminating fields, not the whole body.)
+      existing_body = JSON.parse(throttled_existing.body)
+      missing_body  = JSON.parse(throttled_missing.body)
+      %w[error error_type max_attempts].each do |field|
+        expect(existing_body[field]).to eq(missing_body[field])
+      end
+    end
+  end
+
+  describe 'suite default (limiter disabled by test config)' do
+    it 'does not throttle when site.authentication.reset_request_rate_limit is disabled' do
+      # No enable_limiter call: this runs under spec/config.test.yaml, which
+      # ships enabled:false — repeated probes stay on the generic success and
+      # write no limiter keys.
+      3.times do
+        expect(request_password_reset(unique_test_email('off')).status).to eq(200)
+      end
+      expect(rl_redis.keys('reset_request:attempts:*')).to be_empty
+      expect(rl_redis.keys('reset_request:locked:*')).to be_empty
+    end
+  end
+end

--- a/changelog.d/20260728_000000_claude_3872_reset_request_rate_limit.rst
+++ b/changelog.d/20260728_000000_claude_3872_reset_request_rate_limit.rst
@@ -1,0 +1,20 @@
+.. A new scriv changelog fragment.
+
+Security
+--------
+
+- Added rate limiting to the password-reset request endpoint. In full
+  authentication mode ``POST /auth/reset-password-request`` was made
+  enumeration-safe earlier (#3857) but retained an accepted response-timing
+  residual; exploiting it statistically requires many requests per target
+  address. The route now enforces a two-tier limiter before any account lookup
+  runs: a tight per-client-IP cap (default 10 requests/hour, using the
+  trusted-proxy-resolved, privacy-masked client IP so forwarded headers cannot
+  spoof it) and a higher per-submitted-address backstop (default 30/hour,
+  case-normalized) that bounds IP-rotating callers probing a single target.
+  Both tiers key only on request-observable inputs — never on whether the
+  address maps to an account — so the 429 response discloses nothing about
+  account existence. This stacks with Rodauth's per-account resend throttle,
+  which caps emails but not request volume per source. Configurable via
+  ``site.authentication.reset_request_rate_limit`` /
+  ``RESET_REQUEST_RATE_LIMIT_*``; enabled by default. (#3872)

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -301,6 +301,23 @@ site:
     # If empty or not set, signups are allowed from any domain (default).
     # Environment variable: ALLOWED_SIGNUP_DOMAIN (comma-separated list)
     allowed_signup_domains: <%= ENV['ALLOWED_SIGNUP_DOMAIN']&.split(',')&.map(&:strip) || [] %>
+    # Rate limiting for reset-password requests (#3872). In full auth mode
+    # POST /auth/reset-password-request is enumeration-safe (#3857) but keeps
+    # an accepted timing residual; exploiting it needs many samples, so this
+    # throttles requests per client IP (tight tier) and per submitted login
+    # (higher backstop for IP-rotating callers) BEFORE any account lookup.
+    # Enabled by default (protective); set RESET_REQUEST_RATE_LIMIT_ENABLED=false
+    # to opt out. See lib/onetime/security/reset_request_rate_limiter.rb.
+    reset_request_rate_limit:
+      enabled: <%= ENV['RESET_REQUEST_RATE_LIMIT_ENABLED'] != 'false' %>
+      # Requests permitted per window from a single client IP.
+      max_per_ip: <%= ENV['RESET_REQUEST_RATE_LIMIT_MAX_PER_IP'] || 10 %>
+      # Higher backstop cap per submitted login (catches IP rotation).
+      max_per_email: <%= ENV['RESET_REQUEST_RATE_LIMIT_MAX_PER_EMAIL'] || 30 %>
+      # Counting window in seconds (1 hour).
+      window: <%= ENV['RESET_REQUEST_RATE_LIMIT_WINDOW'] || 3600 %>
+      # Lockout duration in seconds once a tier's cap is hit (1 hour).
+      lockout: <%= ENV['RESET_REQUEST_RATE_LIMIT_LOCKOUT'] || 3600 %>
   # Links to documentation. For onetimesecret.com, this is
   # docs.onetimesecret.com.
   support:

--- a/lib/onetime/security/reset_request_rate_limiter.rb
+++ b/lib/onetime/security/reset_request_rate_limiter.rb
@@ -129,8 +129,11 @@ module Onetime
       # Enforce the reset-request rate limit and record this request. Raises
       # LimitExceeded if either tier is locked; a locked tier is never
       # incremented (the Lua script denies before INCR). Tiers are evaluated
-      # IP-first, so a request denied by the per-email backstop still counts
-      # against its IP. No-op when the limiter is disabled by config.
+      # IP-first, which makes the counting asymmetric by design: a request
+      # denied by the IP tier never touches the email tier, while a request
+      # denied by the email backstop has already consumed one IP-tier slot —
+      # so every request an origin actually lands costs it IP budget. No-op
+      # when the limiter is disabled by config.
       #
       # @param client_ip [String, nil] The caller's edge-masked client IP.
       # @param login [String, nil] The submitted login (target email), taken
@@ -173,7 +176,9 @@ module Onetime
 
         count = detail.to_i
         if count >= max_attempts
-          OT.le "[ResetRequestRateLimiter] #{tier_label} #{obscured_reset_request_subject(tier_label, subject)} locked for #{reset_request_lockout}s after #{count} requests"
+          # This cap-reaching request was itself ALLOWED (the Lua script locks
+          # after incrementing); the lockout applies to subsequent requests.
+          OT.le "[ResetRequestRateLimiter] #{tier_label} #{obscured_reset_request_subject(tier_label, subject)} hit cap (#{count}/#{max_attempts}); locked for #{reset_request_lockout}s"
         elsif count >= max_attempts - 1
           OT.li "[ResetRequestRateLimiter] #{tier_label} #{obscured_reset_request_subject(tier_label, subject)} at #{count}/#{max_attempts} requests"
         end

--- a/lib/onetime/security/reset_request_rate_limiter.rb
+++ b/lib/onetime/security/reset_request_rate_limiter.rb
@@ -1,0 +1,263 @@
+# lib/onetime/security/reset_request_rate_limiter.rb
+#
+# frozen_string_literal: true
+
+module Onetime
+  module Security
+    # ResetRequestRateLimiter - Throttles reset-password-request submissions
+    #
+    # The enumeration-safe reset-password-request route (#3857) returns an
+    # identical response for every login, which closed the single-request
+    # content oracle but left a statistical TIMING residual: a hit performs
+    # reset-key writes and an email dispatch a miss does not. Beating network/
+    # Puma/GC jitter with that residual needs MANY samples per target (error
+    # shrinks ~1/sqrt(N)), so capping request volume is the direct way to bound
+    # the attack's throughput (#3872). Rodauth's own resend throttle
+    # (reset_password_email_recently_sent?) is per-account and caps EMAILS, not
+    # request volume — it does nothing against one source probing many different
+    # logins, which is exactly the enumeration sampling pattern.
+    #
+    # Two tiers, using the same atomic check-and-record shape as
+    # {IncomingRateLimiter} (every submission is an "attempt"; there is no
+    # failure branch — each tier's check and record is a single Lua call, so
+    # concurrent bursts cannot overshoot the cap):
+    #
+    #   1. Per-IP tier (the primary gate): keyed on the edge-masked client IP
+    #      and capped at MAX_PER_IP. Stops a given origin after a handful of
+    #      requests per window regardless of how many logins it cycles through.
+    #   2. Per-email tier (backstop): keyed on the NORMALIZED submitted login
+    #      and capped at the higher MAX_PER_EMAIL. Bounds an IP-rotating /
+    #      distributed attacker sampling one target, and also caps nil-IP
+    #      callers, who all share this bucket by login.
+    #
+    # The per-email cap is deliberately the LOOSER tier (mirroring
+    # LoginRateLimiter's global backstop, RL-3): a TIGHT per-email lockout
+    # would let an attacker deny a victim's reset flow from all IPs with a
+    # handful of requests. The higher cap keeps that targeted-DoS expensive
+    # while still bounding distributed timing samples per target per window —
+    # and the impact of a deliberate per-email lockout is itself bounded:
+    # Rodauth's resend throttle means the victim's reset email (once sent)
+    # is not resent within its window anyway, and the lockout expires.
+    #
+    # ENUMERATION SAFETY: both tiers key ONLY on request-observable inputs
+    # (client IP, submitted login string) — never on whether the login maps to
+    # an account — so a 429 discloses nothing about account existence. The
+    # login is normalized (strip/downcase) so case-variation cannot dodge the
+    # per-email bucket. The check runs BEFORE Rodauth touches the accounts
+    # table, so a throttled probe never reaches the timing-sensitive path.
+    #
+    # A missing client_ip skips the IP tier entirely (it never builds an "ip:"
+    # key with a blank suffix); the per-email backstop still applies. A missing
+    # login skips the email tier. If neither is available the limiter is a
+    # no-op — such a request fails Rodauth's own param validation anyway.
+    #
+    # Fail semantics mirror the other security limiters: Redis errors propagate
+    # (a surfaced error rejects the request rather than silently permitting an
+    # unthrottled probe).
+    #
+    # Redis keys (string keys at the Redis boundary):
+    #   - reset_request:attempts:ip:{ip}        - per-IP request counter
+    #   - reset_request:locked:ip:{ip}          - per-IP lockout flag
+    #   - reset_request:attempts:email:{email}  - per-login request counter
+    #   - reset_request:locked:email:{email}    - per-login lockout flag
+    #
+    # Config (site.authentication.reset_request_rate_limit): enabled,
+    # max_per_ip, max_per_email, window, lockout. Absent config -> enabled with
+    # the constant defaults below; set enabled:false to disable (the test
+    # config does, so full-mode suite POSTs are not throttled).
+    #
+    # Usage:
+    #   include Onetime::Security::ResetRequestRateLimiter
+    #   enforce_reset_request_rate_limit!(client_ip, login) # before any
+    #                                                        # account lookup
+    module ResetRequestRateLimiter
+      # Default requests permitted per window from a single client IP. The
+      # tight gate: far above any legitimate per-user need (Rodauth sends at
+      # most one email per account per resend window) while capping a single
+      # origin's timing samples per window.
+      DEFAULT_MAX_PER_IP = 10
+
+      # Default per-login backstop. Higher than the IP cap so several
+      # legitimate origins (user retrying from phone + laptop, a shared NAT)
+      # are not throttled, while an IP-rotating attacker is still bounded to
+      # this many samples per target per window.
+      DEFAULT_MAX_PER_EMAIL = 30
+
+      # Default window in seconds over which requests are counted (1 hour).
+      DEFAULT_WINDOW = 3600
+
+      # Default lockout duration in seconds once a tier's cap is hit (1 hour).
+      DEFAULT_LOCKOUT = 3600
+
+      # Longest login string a per-email key is built from. Anything longer is
+      # truncated (not skipped) so oversized garbage still lands in SOME
+      # bucket instead of minting unbounded-length Redis keys. 320 covers the
+      # maximal legal email (64 local + '@' + 255 domain).
+      MAX_EMAIL_KEY_LENGTH = 320
+
+      # Lua script that checks the lockout AND records the request in one
+      # atomic round trip (same contract as IncomingRateLimiter): Redis
+      # serializes script executions, the increment that reaches max_attempts
+      # sets the lockout flag and clears the counter, and every later
+      # execution sees the flag and is denied before incrementing.
+      # Returns {1, current_count} when allowed, {0, lockout_ttl} when denied.
+      CHECK_AND_RECORD_SCRIPT = <<~LUA
+        local attempts_key = KEYS[1]
+        local lockout_key = KEYS[2]
+        local attempt_window = tonumber(ARGV[1])
+        local max_attempts = tonumber(ARGV[2])
+        local lockout_duration = tonumber(ARGV[3])
+
+        if redis.call('EXISTS', lockout_key) == 1 then
+          return {0, redis.call('TTL', lockout_key)}
+        end
+
+        local current = redis.call('INCR', attempts_key)
+
+        if current == 1 then
+          redis.call('EXPIRE', attempts_key, attempt_window)
+        end
+
+        if current >= max_attempts then
+          redis.call('SETEX', lockout_key, lockout_duration, '1')
+          redis.call('DEL', attempts_key)
+        end
+
+        return {1, current}
+      LUA
+
+      # Enforce the reset-request rate limit and record this request. Raises
+      # LimitExceeded if either tier is locked; a locked tier is never
+      # incremented (the Lua script denies before INCR). Tiers are evaluated
+      # IP-first, so a request denied by the per-email backstop still counts
+      # against its IP. No-op when the limiter is disabled by config.
+      #
+      # @param client_ip [String, nil] The caller's edge-masked client IP.
+      # @param login [String, nil] The submitted login (target email), taken
+      #   verbatim from the request params — existence is never consulted.
+      # @raise [Onetime::LimitExceeded] If either tier's limit is exceeded.
+      # @return [void]
+      def enforce_reset_request_rate_limit!(client_ip, login = nil)
+        return unless reset_request_rate_limit_enabled?
+
+        # Per-IP first (the tighter gate): a locked IP is rejected before the
+        # email tier is touched, so it never inflates the per-target count.
+        if (ip_keys    = reset_request_ip_keys(client_ip))
+          enforce_reset_request_tier!(ip_keys, reset_request_max_per_ip, 'ip', client_ip)
+        end
+        if (email_keys = reset_request_email_keys(login))
+          enforce_reset_request_tier!(email_keys, reset_request_max_per_email, 'email', login)
+        end
+      end
+
+      private
+
+      # Atomically check-and-record one tier via CHECK_AND_RECORD_SCRIPT.
+      # Raises LimitExceeded when the tier is locked; otherwise logs as the
+      # count approaches/reaches the cap (the detection tie-in for #3872 —
+      # alert on these alongside the reset_password_request_no_account events).
+      def enforce_reset_request_tier!(keys, max_attempts, tier_label, subject)
+        allowed, detail = reset_request_redis.eval(
+          CHECK_AND_RECORD_SCRIPT,
+          keys: [keys[:attempts], keys[:lockout]],
+          argv: [reset_request_window, max_attempts, reset_request_lockout],
+        )
+
+        if allowed.to_i != 1
+          raise Onetime::LimitExceeded.new(
+            'Too many password reset requests. Please try again later.',
+            retry_after: detail.to_i.positive? ? detail.to_i : reset_request_lockout,
+            max_attempts: max_attempts,
+          )
+        end
+
+        count = detail.to_i
+        if count >= max_attempts
+          OT.le "[ResetRequestRateLimiter] #{tier_label} #{obscured_reset_request_subject(tier_label, subject)} locked for #{reset_request_lockout}s after #{count} requests"
+        elsif count >= max_attempts - 1
+          OT.li "[ResetRequestRateLimiter] #{tier_label} #{obscured_reset_request_subject(tier_label, subject)} at #{count}/#{max_attempts} requests"
+        end
+      end
+
+      # Composite per-IP keys, or nil when no IP is available (skips the IP
+      # tier rather than building a blank-suffixed key — same rationale as
+      # LoginRateLimiter#login_ip_keys).
+      def reset_request_ip_keys(client_ip)
+        return nil if client_ip.to_s.empty?
+
+        {
+          attempts: "reset_request:attempts:ip:#{client_ip}",
+          lockout: "reset_request:locked:ip:#{client_ip}",
+        }
+      end
+
+      # Composite per-login keys, or nil when no login was submitted. The
+      # login is normalized so trivial case/whitespace variation of one target
+      # cannot spread across buckets.
+      def reset_request_email_keys(login)
+        normalized = normalize_reset_request_login(login)
+        return nil if normalized.empty?
+
+        {
+          attempts: "reset_request:attempts:email:#{normalized}",
+          lockout: "reset_request:locked:email:#{normalized}",
+        }
+      end
+
+      # Strip + downcase + length-cap the submitted login for keying. Runs
+      # BEFORE Rodauth validates the param, so this must tolerate arbitrary
+      # strings.
+      def normalize_reset_request_login(login)
+        login.to_s.strip.downcase[0, MAX_EMAIL_KEY_LENGTH].to_s
+      end
+
+      def reset_request_rate_limit_config
+        OT.conf.dig('site', 'authentication', 'reset_request_rate_limit') || {}
+      end
+
+      # Enabled unless config explicitly sets enabled:false. Absent config
+      # keeps the protective default on; the test config disables it so
+      # full-mode specs are not throttled.
+      def reset_request_rate_limit_enabled?
+        reset_request_rate_limit_config.fetch('enabled', true) != false
+      end
+
+      def reset_request_max_per_ip
+        (reset_request_rate_limit_config['max_per_ip'] || DEFAULT_MAX_PER_IP).to_i
+      end
+
+      def reset_request_max_per_email
+        (reset_request_rate_limit_config['max_per_email'] || DEFAULT_MAX_PER_EMAIL).to_i
+      end
+
+      def reset_request_window
+        (reset_request_rate_limit_config['window'] || DEFAULT_WINDOW).to_i
+      end
+
+      def reset_request_lockout
+        (reset_request_rate_limit_config['lockout'] || DEFAULT_LOCKOUT).to_i
+      end
+
+      # Obscure the subject for logs. IPv4 keeps the /16; emails go through the
+      # shared obscure helper; IPv6 is truncated to a short prefix. Full values
+      # never reach logs.
+      def obscured_reset_request_subject(tier_label, subject)
+        value = subject.to_s
+        if tier_label == 'ip'
+          parts = value.split('.')
+          return "#{parts[0]}.#{parts[1]}.x.x" if parts.length == 4
+
+          return value[0..8]
+        end
+        OT::Utils.obscure_email(value)
+      end
+
+      # Redis connection via the Customer model's dbclient — the subject is an
+      # email on the auth surface, so the counters live on the same shard as
+      # the login/account rate-limit state (matches LoginRateLimiter).
+      def reset_request_redis
+        Onetime::Customer.dbclient
+      end
+    end
+  end
+end

--- a/lib/onetime/security/reset_request_rate_limiter.rb
+++ b/lib/onetime/security/reset_request_rate_limiter.rb
@@ -42,9 +42,13 @@ module Onetime
     # ENUMERATION SAFETY: both tiers key ONLY on request-observable inputs
     # (client IP, submitted login string) — never on whether the login maps to
     # an account — so a 429 discloses nothing about account existence. The
-    # login is normalized (strip/downcase) so case-variation cannot dodge the
-    # per-email bucket. The check runs BEFORE Rodauth touches the accounts
-    # table, so a throttled probe never reaches the timing-sensitive path.
+    # login is normalized with the SAME helper Rodauth's normalize_login uses
+    # (OT::Utils.normalize_email: strip + NFC + case-fold; see config/base.rb)
+    # so every variant Rodauth would resolve to one account lands in one
+    # per-target bucket — plain downcase would let Unicode case-fold/NFC
+    # variants dodge the backstop. The check runs BEFORE Rodauth touches the
+    # accounts table, so a throttled probe never reaches the timing-sensitive
+    # path.
     #
     # A missing client_ip skips the IP tier entirely (it never builds an "ip:"
     # key with a blank suffix); the per-email backstop still applies. A missing
@@ -94,6 +98,13 @@ module Onetime
       # bucket instead of minting unbounded-length Redis keys. 320 covers the
       # maximal legal email (64 local + '@' + 255 domain).
       MAX_EMAIL_KEY_LENGTH = 320
+
+      # ASCII control characters (C0 + DEL) removed from the normalized login
+      # before it is used as a Redis-key suffix or log subject. An email can
+      # never contain them, so distinct garbage strings merging into one
+      # bucket is harmless — while newlines/escapes in keys or log lines are
+      # not.
+      CONTROL_CHAR_PATTERN = /[\u0000-\u001F\u007F]/
 
       # Lua script that checks the lockout AND records the request in one
       # atomic round trip (same contract as IncomingRateLimiter): Redis
@@ -145,11 +156,16 @@ module Onetime
 
         # Per-IP first (the tighter gate): a locked IP is rejected before the
         # email tier is touched, so it never inflates the per-target count.
-        if (ip_keys    = reset_request_ip_keys(client_ip))
+        if (ip_keys = reset_request_ip_keys(client_ip))
           enforce_reset_request_tier!(ip_keys, reset_request_max_per_ip, 'ip', client_ip)
         end
-        if (email_keys = reset_request_email_keys(login))
-          enforce_reset_request_tier!(email_keys, reset_request_max_per_email, 'email', login)
+
+        # Normalize ONCE; the same value feeds the Redis key AND the
+        # (obscured) log subject, so a raw attacker-supplied string never
+        # reaches either.
+        normalized = normalize_reset_request_login(login)
+        if (email_keys = reset_request_email_keys(normalized))
+          enforce_reset_request_tier!(email_keys, reset_request_max_per_email, 'email', normalized)
         end
       end
 
@@ -196,24 +212,36 @@ module Onetime
         }
       end
 
-      # Composite per-login keys, or nil when no login was submitted. The
-      # login is normalized so trivial case/whitespace variation of one target
-      # cannot spread across buckets.
-      def reset_request_email_keys(login)
-        normalized = normalize_reset_request_login(login)
-        return nil if normalized.empty?
+      # Composite per-login keys from the ALREADY-NORMALIZED login, or nil
+      # when no login was submitted (skips the email tier rather than keying
+      # a blank suffix).
+      def reset_request_email_keys(normalized_login)
+        return nil if normalized_login.empty?
 
         {
-          attempts: "reset_request:attempts:email:#{normalized}",
-          lockout: "reset_request:locked:email:#{normalized}",
+          attempts: "reset_request:attempts:email:#{normalized_login}",
+          lockout: "reset_request:locked:email:#{normalized_login}",
         }
       end
 
-      # Strip + downcase + length-cap the submitted login for keying. Runs
-      # BEFORE Rodauth validates the param, so this must tolerate arbitrary
-      # strings.
+      # Normalize the submitted login for keying and logging. Runs BEFORE
+      # Rodauth validates the param, so this must tolerate arbitrary strings.
+      #
+      # Uses the SAME helper as Rodauth's normalize_login (config/base.rb →
+      # OT::Utils.normalize_email: strip + NFC + case-fold), so every variant
+      # Rodauth would resolve to one account shares one bucket, then removes
+      # control characters and length-caps. Invalid encodings (which
+      # normalize_email cannot process and which can never match an account —
+      # Rodauth's own normalize_login is the same helper and would fail
+      # identically later) are scrubbed rather than raised, so the probe still
+      # consumes limiter budget instead of erroring here.
       def normalize_reset_request_login(login)
-        login.to_s.strip.downcase[0, MAX_EMAIL_KEY_LENGTH].to_s
+        value = begin
+          OT::Utils.normalize_email(login)
+        rescue StandardError
+          login.to_s.scrub('').strip.downcase
+        end
+        value.gsub(CONTROL_CHAR_PATTERN, '')[0, MAX_EMAIL_KEY_LENGTH].to_s
       end
 
       def reset_request_rate_limit_config

--- a/lib/onetime/security/reset_request_rate_limiter.rb
+++ b/lib/onetime/security/reset_request_rate_limiter.rb
@@ -30,6 +30,21 @@ module Onetime
     #      distributed attacker sampling one target, and also caps nil-IP
     #      callers, who all share this bucket by login.
     #
+    # IP GRANULARITY: the "client IP" is the value the universal
+    # IPPrivacyMiddleware mount resolves and privacy-masks BEFORE the app sees
+    # it — /24 for IPv4, /48 for IPv6 (Otto::Privacy::IPPrivacy,
+    # octet_precision 1). The per-IP bucket is therefore shared by that masked
+    # network neighborhood, exactly like every other IP-keyed limiter in this
+    # codebase (IncomingRateLimiter, the sso-link-confirm throttle, the
+    # LoginRateLimiter email+IP tier): the raw address never survives the
+    # privacy middleware, so no finer key exists downstream. A hostile
+    # neighbor in the same masked network can thus consume the shared budget
+    # and 429 the reset-request route for the neighborhood for one lockout
+    # window — bounded, repeatable-only-with-effort, and the accepted cost of
+    # IP privacy. Operators with dense NAT populations can raise
+    # RESET_REQUEST_RATE_LIMIT_MAX_PER_IP; the per-email backstop is
+    # unaffected by IP granularity.
+    #
     # The per-email cap is deliberately the LOOSER tier (mirroring
     # LoginRateLimiter's global backstop, RL-3): a TIGHT per-email lockout
     # would let an attacker deny a victim's reset flow from all IPs with a
@@ -256,19 +271,30 @@ module Onetime
       end
 
       def reset_request_max_per_ip
-        (reset_request_rate_limit_config['max_per_ip'] || DEFAULT_MAX_PER_IP).to_i
+        positive_reset_request_setting('max_per_ip', DEFAULT_MAX_PER_IP)
       end
 
       def reset_request_max_per_email
-        (reset_request_rate_limit_config['max_per_email'] || DEFAULT_MAX_PER_EMAIL).to_i
+        positive_reset_request_setting('max_per_email', DEFAULT_MAX_PER_EMAIL)
       end
 
       def reset_request_window
-        (reset_request_rate_limit_config['window'] || DEFAULT_WINDOW).to_i
+        positive_reset_request_setting('window', DEFAULT_WINDOW)
       end
 
       def reset_request_lockout
-        (reset_request_rate_limit_config['lockout'] || DEFAULT_LOCKOUT).to_i
+        positive_reset_request_setting('lockout', DEFAULT_LOCKOUT)
+      end
+
+      # Read a numeric setting, falling back to its default unless the
+      # configured value coerces to a POSITIVE integer. A zero/garbage value
+      # (e.g. a typo'd env var: `to_i` turns "abc" into 0) would otherwise
+      # invert enforcement — a zero cap locks on the first request and a
+      # non-positive lockout makes the Lua SETEX fail, turning every reset
+      # request into a 500 instead of a throttle.
+      def positive_reset_request_setting(key, default)
+        value = reset_request_rate_limit_config[key].to_i
+        value.positive? ? value : default
       end
 
       # Obscure the subject for logs. IPv4 keeps the /16; emails go through the

--- a/spec/config.test.yaml
+++ b/spec/config.test.yaml
@@ -76,6 +76,11 @@ site:
     required: false
     colonels:
       - 'CHANGEME@EXAMPLE.com'
+    # Disabled under test so full-mode reset-password specs are not throttled;
+    # the #3872 limiter tests enable it in-process. See
+    # reset_request_rate_limiter.rb.
+    reset_request_rate_limit:
+      enabled: false
 
 features:
   regions:

--- a/try/unit/security/reset_request_rate_limiter_try.rb
+++ b/try/unit/security/reset_request_rate_limiter_try.rb
@@ -178,6 +178,22 @@ end
 @raises.call(@ip_b, @email_b)
 #=> true
 
+## -- Config validation ----------------------------------------------------
+
+## Non-positive / garbage numeric settings fall back to the defaults instead
+## of inverting enforcement (a zero cap would otherwise lock on the very
+## first request, and a non-positive lockout would make the Lua SETEX fail)
+set_reset_request_rate_limit(
+  'enabled' => true, 'max_per_ip' => 0, 'max_per_email' => 'abc',
+  'window' => -5, 'lockout' => 0,
+)
+@cfg_ip    = '198.51.100.77'
+@cfg_email = "target_cfg_#{@tag}@example.com"
+cleanup(@redis, ip: @cfg_ip, email: @cfg_email)
+result = @raises.call(@cfg_ip, @cfg_email)
+[result, @redis.exists?("reset_request:locked:ip:#{@cfg_ip}")]
+#=> [false, false]
+
 ## -- Configured off -------------------------------------------------------
 
 ## With enabled:false the limiter is a total no-op even past the caps
@@ -198,5 +214,6 @@ cleanup(@redis, ip: @ip_a, email: @email_a)
 cleanup(@redis, ip: @ip_b, email: @email_b)
 cleanup(@redis, email: @email_c)
 cleanup(@redis, email: @email_fold)
+cleanup(@redis, ip: @cfg_ip, email: @cfg_email)
 cleanup(@redis, ip: @off_ip, email: @off_email)
 OT.send(:conf=, @saved_conf)

--- a/try/unit/security/reset_request_rate_limiter_try.rb
+++ b/try/unit/security/reset_request_rate_limiter_try.rb
@@ -1,0 +1,186 @@
+# try/unit/security/reset_request_rate_limiter_try.rb
+#
+# frozen_string_literal: true
+
+# #3872: ResetRequestRateLimiter throttles reset-password-request submissions,
+# bounding the sampling throughput of the timing residual accepted by the
+# enumeration-safe route (#3857). Two tiers, mirroring IncomingRateLimiter:
+#   1. Per-IP tier    - the tight gate (max_per_ip per window).
+#   2. Per-email tier - a higher backstop keyed on the NORMALIZED submitted
+#                       login (catches IP-rotating callers).
+#
+# We test:
+# 1. Under-limit requests are allowed
+# 2. Key shape and TTL of the per-IP attempts counter
+# 3. Over-limit raises LimitExceeded with the configured cap + lockout state
+# 4. Login normalization (case/whitespace variants share one bucket)
+# 5. nil-IP falls back to the per-email tier only
+# 6. The per-email backstop caps IP-rotating callers
+# 7. Configured-off (enabled:false) is a total no-op
+
+require_relative '../../support/test_models'
+require 'onetime/security/reset_request_rate_limiter'
+
+OT.boot! :test, true
+
+# Tryout files share one process and OT.conf is global; snapshot the booted
+# config so the teardown can restore it for later files.
+@saved_conf = YAML.load(YAML.dump(OT.conf))
+
+# Enable the limiter with small, known caps (test config ships it disabled).
+def set_reset_request_rate_limit(cfg)
+  new_conf = YAML.load(YAML.dump(OT.conf))
+  new_conf['site'] ||= {}
+  new_conf['site']['authentication'] ||= {}
+  new_conf['site']['authentication']['reset_request_rate_limit'] = cfg
+  OT.send(:conf=, new_conf)
+end
+
+set_reset_request_rate_limit(
+  'enabled' => true,
+  'max_per_ip' => 3,
+  'max_per_email' => 5,
+  'window' => 900,
+  'lockout' => 900,
+)
+
+class ResetRequestRateLimiterTester
+  include Onetime::Security::ResetRequestRateLimiter
+end
+
+@tester = ResetRequestRateLimiterTester.new
+@redis  = Onetime::Customer.dbclient
+
+@ip_a    = '203.0.113.10'
+@ip_b    = '198.51.100.20'
+@email_a = "target_a_#{Familia.now.to_i}_#{rand(10_000)}@example.com"
+@email_b = "target_b_#{Familia.now.to_i}_#{rand(10_000)}@example.com"
+@email_c = "target_c_#{Familia.now.to_i}_#{rand(10_000)}@example.com"
+
+# true if a single enforce call raises LimitExceeded, false otherwise.
+@raises = lambda do |ip, login = nil|
+  @tester.enforce_reset_request_rate_limit!(ip, login)
+  false
+rescue Onetime::LimitExceeded
+  true
+end
+
+def cleanup(redis, ip: nil, email: nil)
+  keys = []
+  keys += ["reset_request:attempts:ip:#{ip}", "reset_request:locked:ip:#{ip}"] if ip
+  keys += ["reset_request:attempts:email:#{email}", "reset_request:locked:email:#{email}"] if email
+  redis.del(*keys) unless keys.empty?
+end
+
+cleanup(@redis, ip: @ip_a, email: @email_a)
+cleanup(@redis, ip: @ip_b, email: @email_b)
+cleanup(@redis, email: @email_c)
+
+## -- Under-limit ----------------------------------------------------------
+
+## A single request under the cap is allowed
+@raises.call(@ip_a, @email_a)
+#=> false
+
+## The per-IP attempts counter uses the documented key shape
+@redis.exists?("reset_request:attempts:ip:#{@ip_a}")
+#=> true
+
+## The per-IP counter carries a TTL within the configured window
+ttl = @redis.ttl("reset_request:attempts:ip:#{@ip_a}")
+ttl.positive? && ttl <= 900
+#=> true
+
+## The per-email counter is also written on the same request
+@redis.exists?("reset_request:attempts:email:#{@email_a}")
+#=> true
+
+## -- Login normalization --------------------------------------------------
+
+## Case/whitespace variants of one target land in the SAME per-email bucket
+@tester.enforce_reset_request_rate_limit!(@ip_b, "  #{@email_a.upcase}  ")
+@redis.get("reset_request:attempts:email:#{@email_a}").to_i
+#=> 2
+
+## -- Over-limit (per-IP tier trips first at max_per_ip=3) -----------------
+
+## Two more requests reach the per-IP cap (total 3) and lock the IP tier
+[@raises.call(@ip_a, @email_a), @raises.call(@ip_a, @email_a)]
+#=> [false, false]
+
+## The per-IP lockout key is now set
+@redis.exists?("reset_request:locked:ip:#{@ip_a}")
+#=> true
+
+## The per-IP attempts counter is cleared once the tier locks
+@redis.exists?("reset_request:attempts:ip:#{@ip_a}")
+#=> false
+
+## The next request from that IP raises LimitExceeded
+@raises.call(@ip_a, @email_a)
+#=> true
+
+## The raised error reports the per-IP cap and a positive retry_after
+begin
+  @tester.enforce_reset_request_rate_limit!(@ip_a, @email_a)
+  nil
+rescue Onetime::LimitExceeded => e
+  [e.max_attempts, e.retry_after.positive?]
+end
+#=> [3, true]
+
+## -- nil-IP falls back to the per-email tier only -------------------------
+
+## A nil-IP request does not build a blank "ip:" key
+@raises.call(nil, @email_c)
+[@redis.exists?("reset_request:attempts:ip:"), @redis.exists?("reset_request:attempts:email:#{@email_c}")]
+#=> [false, true]
+
+## With neither IP nor login the limiter is a complete no-op: no raise,
+## and neither tier writes a blank-suffixed key
+result = @raises.call(nil, nil)
+[result, @redis.exists?("reset_request:attempts:ip:"), @redis.exists?("reset_request:attempts:email:")]
+#=> [false, false, false]
+
+## -- Per-email backstop (max_per_email=5) ---------------------------------
+
+## Five nil-IP requests reach the per-email cap and lock the email tier
+cleanup(@redis, email: @email_b)
+5.times { @tester.enforce_reset_request_rate_limit!(nil, @email_b) }
+@redis.exists?("reset_request:locked:email:#{@email_b}")
+#=> true
+
+## The next request for that login raises, reporting the per-email cap
+begin
+  @tester.enforce_reset_request_rate_limit!(nil, @email_b)
+  nil
+rescue Onetime::LimitExceeded => e
+  e.max_attempts
+end
+#=> 5
+
+## An IP-rotating caller (fresh IP each time) is still capped by the email tier
+@raises.call(@ip_b, @email_b)
+#=> true
+
+## -- Configured off -------------------------------------------------------
+
+## With enabled:false the limiter is a total no-op even past the caps
+set_reset_request_rate_limit('enabled' => false, 'max_per_ip' => 3, 'max_per_email' => 5)
+@off_ip    = '192.0.2.55'
+@off_email = "target_off_#{Familia.now.to_i}_#{rand(10_000)}@example.com"
+cleanup(@redis, ip: @off_ip, email: @off_email)
+results = (1..6).map { @raises.call(@off_ip, @off_email) }
+results.none?
+#=> true
+
+## Disabled limiter writes no keys at all
+[@redis.exists?("reset_request:attempts:ip:#{@off_ip}"), @redis.exists?("reset_request:attempts:email:#{@off_email}")]
+#=> [false, false]
+
+# Clean up test keys and restore the shared config for later tryout files.
+cleanup(@redis, ip: @ip_a, email: @email_a)
+cleanup(@redis, ip: @ip_b, email: @email_b)
+cleanup(@redis, email: @email_c)
+cleanup(@redis, ip: @off_ip, email: @off_email)
+OT.send(:conf=, @saved_conf)

--- a/try/unit/security/reset_request_rate_limiter_try.rb
+++ b/try/unit/security/reset_request_rate_limiter_try.rb
@@ -13,7 +13,8 @@
 # 1. Under-limit requests are allowed
 # 2. Key shape and TTL of the per-IP attempts counter
 # 3. Over-limit raises LimitExceeded with the configured cap + lockout state
-# 4. Login normalization (case/whitespace variants share one bucket)
+# 4. Login normalization (Rodauth-parity: case/whitespace variants, Unicode
+#    case-folding, and control characters all land in one bucket)
 # 5. nil-IP falls back to the per-email tier only
 # 6. The per-email backstop caps IP-rotating callers
 # 7. Configured-off (enabled:false) is a total no-op
@@ -53,9 +54,13 @@ end
 
 @ip_a    = '203.0.113.10'
 @ip_b    = '198.51.100.20'
-@email_a = "target_a_#{Familia.now.to_i}_#{rand(10_000)}@example.com"
-@email_b = "target_b_#{Familia.now.to_i}_#{rand(10_000)}@example.com"
-@email_c = "target_c_#{Familia.now.to_i}_#{rand(10_000)}@example.com"
+@tag     = "#{Familia.now.to_i}_#{rand(10_000)}"
+@email_a = "target_a_#{@tag}@example.com"
+@email_b = "target_b_#{@tag}@example.com"
+@email_c = "target_c_#{@tag}@example.com"
+# The bucket an eszett-variant login must case-fold into (U+00DF folds to
+# "ss").
+@email_fold = "fold_ss_#{@tag}@example.com"
 
 # true if a single enforce call raises LimitExceeded, false otherwise.
 @raises = lambda do |ip, login = nil|
@@ -75,6 +80,7 @@ end
 cleanup(@redis, ip: @ip_a, email: @email_a)
 cleanup(@redis, ip: @ip_b, email: @email_b)
 cleanup(@redis, email: @email_c)
+cleanup(@redis, email: @email_fold)
 
 ## -- Under-limit ----------------------------------------------------------
 
@@ -101,6 +107,15 @@ ttl.positive? && ttl <= 900
 @tester.enforce_reset_request_rate_limit!(@ip_b, "  #{@email_a.upcase}  ")
 @redis.get("reset_request:attempts:email:#{@email_a}").to_i
 #=> 2
+
+## Unicode case-folding and control characters cannot dodge the bucket either:
+## normalization mirrors Rodauth's normalize_login (OT::Utils.normalize_email,
+## NFC + case-fold), so an eszett (U+00DF) variant with an embedded control
+## character folds into the plain-ss bucket Rodauth would resolve the account
+## from
+@tester.enforce_reset_request_rate_limit!(nil, "\u0000fold_\u00df_#{@tag}@EXAMPLE.com\r\n")
+@redis.get("reset_request:attempts:email:#{@email_fold}").to_i
+#=> 1
 
 ## -- Over-limit (per-IP tier trips first at max_per_ip=3) -----------------
 
@@ -182,5 +197,6 @@ results.none?
 cleanup(@redis, ip: @ip_a, email: @email_a)
 cleanup(@redis, ip: @ip_b, email: @email_b)
 cleanup(@redis, email: @email_c)
+cleanup(@redis, email: @email_fold)
 cleanup(@redis, ip: @off_ip, email: @off_email)
 OT.send(:conf=, @saved_conf)


### PR DESCRIPTION
## Summary

[#3872](https://github.com/onetimesecret/onetimesecret/issues/3872)

The enumeration-safe reset-password-request route (#3857/#3862) closed the single-request content oracle but left a statistical timing residual that needs many samples per target to exploit. This adds per-IP + per-target rate limiting to `POST /auth/reset-password-request`, enforced **before** Rodauth's account lookup runs, so large-scale enumeration probing becomes expensive.

- **New `Onetime::Security::ResetRequestRateLimiter`** (`lib/onetime/security/reset_request_rate_limiter.rb`): atomic Lua check-and-record (same shape as `IncomingRateLimiter`) with a tight per-client-IP tier (default 10/hour) and a higher per-submitted-login backstop (default 30/hour, case-normalized) that bounds IP-rotating callers probing one target. Both tiers key only on request-observable inputs (client IP, submitted login string) — never on account existence — so the 429 introduces no new oracle. The per-email tier is deliberately the *looser* one, mirroring `LoginRateLimiter`'s RL-3 reasoning: a tight email-only lockout would let an attacker deny a victim's reset flow from all IPs with a handful of requests.
- **New `before_reset_password_request_route` hook** (`apps/web/auth/config/hooks/reset_password_request.rb`, sole owner per the one-owner invariant): enforces the limiter on POST only, using the trusted-proxy-resolved, privacy-masked client IP (`env['otto.client_ip']`, `request.ip` fallback — both set by the universal `IPPrivacyMiddleware` mount, so forwarded headers cannot spoof the subject). A missing IP skips the IP tier rather than pooling unknown callers into a poisonable shared bucket; the per-login backstop still applies.
- **`around_rodauth`** re-raises `Onetime::LimitExceeded` without the `:unhandled_exception` error log; the router's `error_handler` translates it to the ADR-013 429 body with `retry_after` (logged at `:warn` per `ErrorTranslator`).
- **Config**: `site.authentication.reset_request_rate_limit` (`RESET_REQUEST_RATE_LIMIT_*` env vars), enabled by default; `spec/config.test.yaml` ships it disabled so other full-mode suites are not throttled (same pattern as the incoming limiter). `.env.reference` documents the new vars.
- The limiter stacks with Rodauth's per-account resend throttle (which caps emails, not request volume per source) and pairs with the existing `reset_password_request_no_account` / `reset_password_request_unopen_account` detection logging; the limiter's own near-cap/locked log lines add the volume signal.

Not included: a `bin/ots ratelimit` registry entry — the registry maps one subject per kind and this limiter has two subject types; the same-shaped incoming limiter is likewise not registered. Can follow up if operators want inspect/reset verbs here.

## Related Issues

Closes #3872

## Test Plan

Ran locally against Valkey on 2121 + SQLite in-memory auth DB (Ruby 3.4.9, closest available to the pinned 3.4.10):

- `try/unit/security/reset_request_rate_limiter_try.rb` — 17/17 passed: both tiers' caps and lockouts, key shapes/TTLs, login normalization (case/whitespace variants share a bucket), nil-IP fallback to the per-email tier, no blank-suffixed keys, `enabled:false` no-op.
- New `apps/web/auth/spec/integration/full/reset_password_request_rate_limit_spec.rb` — 4/4 passed: per-IP tier caps one source across *different* logins (the sampling pattern) with an ADR-013 429; per-login backstop trips case-insensitively while the IP cap is far away; the 429 is byte-identical (modulo `request_id`) for existing vs non-existent targets; suite-default (disabled) posture writes no keys.
- Existing `reset_password_request_enumeration_spec.rb` — 5/5 passed with the hook wired in.
- `apps/web/auth/spec/config/hook_ownership_spec.rb` (one-owner static guard) — 7/7 passed.
- Full `apps/web/auth/spec/integration/full` suite — 389 examples, 0 failures.
- Incoming limiter tryout (16/16) as a regression check on the shared pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wVQ3BorM5FZjpg4jm1ALU

---
_Generated by [Claude Code](https://claude.ai/code/session_011wVQ3BorM5FZjpg4jm1ALU)_