### PR TITLE
Restore the Free plan on the pricing page and in the config-only catalog

### DIFF
--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,16 +1,5 @@
 # Review Rules
 
-Skip findings you cannot state as a concrete failure scenario in the changed
-lines. Do not comment on style, naming, formatting, docs wording, test
+Do not comment on style, naming, formatting, docs wording, test
 organization, or locale content hashes; linters and CI gates cover those. Do
 not flag pre-existing code as introduced by this PR.
-
-If a finding depends on an invariant outside the diff (transaction
-boundaries, session key lifecycles, OAuth state handling), ask a question
-rather than asserting a P1 — unless this PR modifies the mechanism that
-enforces the invariant, in which case the invariant is in scope and must be
-reviewed. See `AGENTS.md` for the invariant list.
-
-Structural or architectural observations that lack a failure scenario may be
-raised as explicitly non-blocking follow-up suggestions, at most two per
-review.

--- a/apps/web/billing/controllers/billing.rb
+++ b/apps/web/billing/controllers/billing.rb
@@ -372,34 +372,7 @@ module Billing
         # Frontend expects flat records with top-level interval, amount, stripe_price_id
         plan_data = plans
           .select { |plan| plan.show_on_plans_page.to_s == 'true' }
-          .flat_map do |plan|
-            # Skip plans with no prices (free plans filtered by show_on_plans_page anyway)
-            next [] if plan.prices_hash.empty?
-
-            # prices_hash uses STRING keys from JSON parse
-            plan.prices_hash.map do |interval, price_data|
-              {
-                id: plan.plan_id,
-                name: plan.name,
-                tier: plan.tier,
-                interval: interval,
-                stripe_price_id: price_data['stripe_price_id'],
-                amount: price_data['amount'].to_i,
-                currency: price_data['currency'] || plan.currency,
-                region: plan.region,
-                features: plan.features.to_a,
-                limits: plan.limits_hash.transform_values { |v| v == Float::INFINITY ? -1 : v },
-                entitlements: plan.entitlements.to_a,
-                display_order: plan.display_order.to_i,
-                plan_code: plan.plan_code,
-                is_popular: plan.popular?,
-                plan_name_label: plan.plan_name_label,
-                includes_plan: plan.includes_plan,
-                includes_plan_name: plan_names_by_id[plan.includes_plan],
-                monthly_equivalent_amount: (interval == 'year' ? (price_data['amount'].to_i / 12.0).round : nil),
-              }
-            end
-          end
+          .flat_map { |plan| plan_page_records(plan, plan_names_by_id) }
           .sort_by { |p| [p[:display_order], p[:interval] == 'month' ? 0 : 1] }
 
         json_response({ plans: plan_data })
@@ -1068,6 +1041,62 @@ module Billing
 
       module PrivateMethods
         private
+
+        # Build the plans-page wire records for one plan
+        #
+        # Priced plans emit one record per interval. A price-less plan that is
+        # still marked show_on_plans_page (the free tier, which ConfigLoader
+        # upserts into the catalog with `prices: []`) emits exactly ONE record:
+        # the frontend ignores `interval` for free plans, so a second record
+        # would render a duplicate card.
+        #
+        # @param plan [Billing::Plan] Plan to serialize
+        # @param plan_names_by_id [Hash] plan_id => name, for includes_plan_name
+        # @return [Array<Hash>] One or more flat plan records
+        def plan_page_records(plan, plan_names_by_id)
+          # prices_hash uses STRING keys from JSON parse
+          prices = plan.prices_hash
+
+          return [plan_page_record(plan, plan_names_by_id, 'month', nil)] if prices.empty?
+
+          prices.map do |interval, price_data|
+            plan_page_record(plan, plan_names_by_id, interval, price_data)
+          end
+        end
+
+        # Build a single flat plan record for the plans page
+        #
+        # @param plan [Billing::Plan] Plan to serialize
+        # @param plan_names_by_id [Hash] plan_id => name, for includes_plan_name
+        # @param interval [String] 'month' or 'year'
+        # @param price_data [Hash, nil] Parsed price row, or nil for a price-less plan
+        # @return [Hash] Flat plan record
+        def plan_page_record(plan, plan_names_by_id, interval, price_data)
+          amount          = price_data ? price_data['amount'].to_i : 0
+          stripe_price_id = price_data ? price_data['stripe_price_id'] : nil
+          currency        = (price_data ? price_data['currency'] : nil) || plan.currency
+
+          {
+            id: plan.plan_id,
+            name: plan.name,
+            tier: plan.tier,
+            interval: interval,
+            stripe_price_id: stripe_price_id,
+            amount: amount,
+            currency: currency,
+            region: plan.region,
+            features: plan.features.to_a,
+            limits: plan.limits_hash.transform_values { |v| v == Float::INFINITY ? -1 : v },
+            entitlements: plan.entitlements.to_a,
+            display_order: plan.display_order.to_i,
+            plan_code: plan.plan_code,
+            is_popular: plan.popular?,
+            plan_name_label: plan.plan_name_label,
+            includes_plan: plan.includes_plan,
+            includes_plan_name: plan_names_by_id[plan.includes_plan],
+            monthly_equivalent_amount: (interval == 'year' ? (amount / 12.0).round : nil),
+          }
+        end
 
         # Validate org has an active Stripe subscription and API key is present.
         # Returns [org, nil] on success or [nil, error_response] on failure.

--- a/apps/web/billing/operations/catalog/config_loader.rb
+++ b/apps/web/billing/operations/catalog/config_loader.rb
@@ -25,10 +25,11 @@ module Billing
 
         # Upsert config-only plans (free tier, etc.) that have no Stripe prices
         #
-        # Called AFTER Stripe sync to add plans with `prices: []` in billing.yaml.
-        # These plans are not synced from Stripe since they have no prices, but should
-        # still appear in the plan catalog for entitlement materialization and display
-        # on pricing pages.
+        # Called AFTER Stripe sync to add plans with `prices: []` in billing.yaml,
+        # and from #load_all_from_config so the Stripe-less fallback path builds
+        # the same catalog. These plans are not synced from Stripe since they have
+        # no prices, but should still appear in the plan catalog for entitlement
+        # materialization and display on pricing pages.
         #
         # Since this runs after prune_stale_plans, config-only plans are upserted fresh
         # each sync cycle with active=true, ensuring they persist in the catalog.
@@ -81,10 +82,16 @@ module Billing
         # Creates one Plan instance per family (e.g., "identity_plus_v1") with
         # interval variants stored in the nested `prices` hashkey.
         #
+        # Price-less plans (free tier) are delegated to #upsert_config_only_plans
+        # so both the Stripe-sync path (Pull) and this fallback path produce the
+        # same catalog. See that method for the show_on_plans_page gate and the
+        # region-inheritance rule that priced plans don't get.
+        #
         # Uses ConfigResolver to load from spec/billing.test.yaml in test environment.
         #
         # @param clear_first [Boolean] Whether to clear existing cache before loading (default: true)
-        # @return [Integer] Number of plans loaded into Redis
+        # @return [Integer] Number of plans loaded into Redis, priced plans plus
+        #   config-only plans
         def load_all_from_config(clear_first: true)
           plans_hash = OT.billing_config.plans
           return 0 if plans_hash.empty?
@@ -95,19 +102,18 @@ module Billing
           plans_count = 0
 
           plans_hash.each do |plan_key, plan_def|
+            prices_list = plan_def['prices'] || []
+
+            # Price-less plans are handled by upsert_config_only_plans below.
+            # Checked before the region filter so a config-only plan that omits
+            # `region` isn't logged as a region skip here and then loaded there.
+            next if prices_list.empty?
+
             # Skip plans not matching the configured region
             configured_region = OT.billing_config.region
             plan_region       = Billing::RegionNormalizer.normalize(plan_def['region'])
             unless Billing::RegionNormalizer.match?(plan_region, configured_region)
               OT.ld "[ConfigLoader] Skipping plan for region #{plan_region}: #{plan_key}"
-              next
-            end
-
-            prices_list = plan_def['prices'] || []
-
-            # Skip plans without prices (e.g., free tier - handled by upsert_config_only_plans)
-            if prices_list.empty?
-              OT.ld "[ConfigLoader] Skipping plan without prices: #{plan_key}"
               next
             end
 
@@ -123,6 +129,13 @@ module Billing
 
             plans_count += 1
           end
+
+          # Config-only plans belong in the catalog too: entitlement
+          # materialization and the plans page both read from it. Without this
+          # the free tier would exist after a Stripe sync (Pull calls
+          # upsert_config_only_plans) but vanish whenever Stripe is unreachable
+          # and boot falls back to this method.
+          plans_count += upsert_config_only_plans
 
           # Rebuild price ID cache after loading
           PlanPersister.rebuild_stripe_price_id_cache
@@ -216,7 +229,18 @@ module Billing
           plan.limits.clear
           limits_hash.each { |key, val| plan.limits[key] = val }
 
-          # Populate prices hashkey with JSON per interval
+          # Populate prices hashkey with JSON per interval.
+          #
+          # The guard is deliberate: Pull calls upsert_config_only_plans AFTER
+          # sync_from_stripe, so a config-only upsert must not touch prices that
+          # Stripe just wrote for the same plan_id. Clearing unconditionally
+          # would wipe live price data on every catalog pull whenever a Stripe
+          # product's plan_id metadata matches a plan declared `prices: []`.
+          #
+          # Trade-off: a plan that keeps an orphaned prices hash (e.g. its Stripe
+          # product was pruned) is then served as a priced plan by the plans
+          # page. That's cosmetic and recoverable with
+          # `bin/ots billing catalog sync --clear`; a wiped price is not.
           if prices_data.any?
             plan.prices.clear
             prices_data.each do |interval, price_data|

--- a/apps/web/billing/spec/cli/orgs_validate_command_integration_spec.rb
+++ b/apps/web/billing/spec/cli/orgs_validate_command_integration_spec.rb
@@ -133,22 +133,26 @@ RSpec.describe 'Billing Orgs Validate CLI (integration)', :integration do
 
   describe 'cache miss with config fallback' do
     it 'counts an org whose planid only exists in billing.yaml as Valid (billing.yaml)' do
-      # free_v1 is in spec/billing.test.yaml but is skipped by
-      # ConfigLoader (no prices), so it is NOT persisted to Redis.
-      # load_with_fallback should therefore miss the cache and hit
+      # `identity` is in spec/billing.test.yaml with no prices AND
+      # show_on_plans_page: false, so ConfigLoader leaves it out of Redis
+      # entirely (price-less plans are only upserted when they're shown on the
+      # plans page). load_with_fallback should therefore miss the cache and hit
       # load_from_config, returning source: 'local_config'.
-      config_plan = Billing::Plan.load_from_config('free_v1')
+      #
+      # NOTE: free_v1 used to be the vehicle here, back when ConfigLoader
+      # dropped every price-less plan. It is now cached, so it no longer
+      # exercises the fallback.
+      config_plan = Billing::Plan.load_from_config('identity')
 
       if config_plan.nil?
-        skip 'free_v1 not available via Billing::Config.load_plans in this environment'
+        skip 'identity not available via Billing::Config.load_plans in this environment'
       end
 
-      # Sanity check: free_v1 must not be in the Redis cache for this
-      # test to mean anything. ConfigLoader skips priceless plans so
-      # this should hold, but guard against silent regressions.
-      expect(Billing::Plan.load('free_v1')).to be_nil
+      # Sanity check: the plan must not be in the Redis cache for this
+      # test to mean anything.
+      expect(Billing::Plan.load('identity')).to be_nil
 
-      create_org(planid: 'free_v1', display_name: 'Config Fallback Org')
+      create_org(planid: 'identity', display_name: 'Config Fallback Org')
 
       output, status = run_command
 

--- a/apps/web/billing/spec/controllers/entitlements_controller_spec.rb
+++ b/apps/web/billing/spec/controllers/entitlements_controller_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe 'Billing::Controllers::Entitlements', :integration, :stripe_sandb
       expect(data['entitlements']).to have_key('infrastructure')
 
       # Verify plans summary structure
-      # Note: free_v1 has no prices so it's skipped by load_all_from_config
-      # identity_plus_v1 is now family-keyed (no interval suffix)
+      # Note: free_v1 has no prices but is still loaded by load_all_from_config
+      # (config-only plan); identity_plus_v1 is family-keyed (no interval suffix)
       expect(data['plans']).to be_a(Hash)
       expect(data['plans']).not_to be_empty
       first_plan = data['plans'].values.first

--- a/apps/web/billing/spec/controllers/plans_api_spec.rb
+++ b/apps/web/billing/spec/controllers/plans_api_spec.rb
@@ -96,7 +96,9 @@ RSpec.describe 'Plans API Response', type: :integration do
       it 'includes stripe_price_id as top-level field' do
         skip 'No plans in cache' if response_plans.empty?
 
-        # Find a paid plan (free plans may not have stripe_price_id)
+        # Narrowed to paid plans on purpose: this asserts the Stripe price is
+        # carried through, and price-less plans have none. The free tier's own
+        # contract is covered in the 'price-less plans' context below.
         paid_plan = response_plans.find { |p| p['tier'] != 'free' }
         skip 'No paid plans in cache' if paid_plan.nil?
 
@@ -143,6 +145,57 @@ RSpec.describe 'Plans API Response', type: :integration do
 
         plan = response_plans.first
         expect(plan['limits']).to be_a(Hash)
+      end
+    end
+
+    # Regression coverage: the endpoint used to drop every plan with an empty
+    # prices hash, which silently removed the free tier from /pricing even
+    # though ConfigLoader puts it in the catalog for exactly this purpose.
+    context 'price-less plans (free tier)' do
+      let(:response_plans) do
+        get '/billing/api/plans'
+        JSON.parse(last_response.body)['plans']
+      end
+
+      let(:free_records) { response_plans.select { |p| p['id'] == 'free_v1' } }
+      let(:free_record) { free_records.first }
+
+      it 'includes the price-less free plan in the response' do
+        expect(free_record).not_to be_nil
+      end
+
+      it 'emits exactly one record for it (not one per interval)' do
+        expect(free_records.size).to eq(1)
+      end
+
+      it 'reports a zero amount and no Stripe price' do
+        expect(free_record['amount']).to eq(0)
+        expect(free_record['stripe_price_id']).to be_nil
+      end
+
+      it 'uses the month interval with no monthly equivalent' do
+        expect(free_record['interval']).to eq('month')
+        expect(free_record['monthly_equivalent_amount']).to be_nil
+      end
+
+      it 'carries the free tier and the plan currency' do
+        expect(free_record['tier']).to eq('free')
+        expect(free_record['currency']).to be_a(String)
+      end
+
+      it 'carries entitlements, limits and features' do
+        expect(free_record['entitlements']).to include('create_secrets')
+        expect(free_record['limits']).not_to be_empty
+        # features is a distinct collection from entitlements and the test
+        # catalog's free_v1 declares none, so only the shape is asserted.
+        expect(free_record['features']).to be_an(Array)
+      end
+
+      it 'sorts ahead of paid plans by display_order' do
+        paid = response_plans.find { |p| p['tier'] != 'free' }
+        skip 'No paid plans in cache' if paid.nil?
+
+        expect(response_plans.index(free_record)).to be < response_plans.index(paid)
       end
     end
 
@@ -356,7 +409,8 @@ RSpec.describe 'Plans API Response', type: :integration do
       skip 'No plans in cache' if response_plans.empty?
 
       response_plans.each do |plan|
-        # Skip free plans
+        # Free plans are legitimately zero — see the 'price-less plans'
+        # context for their assertions.
         next if plan['tier'] == 'free'
 
         amount = plan['amount'].to_i

--- a/apps/web/billing/spec/controllers/stripe_integration_blockers_spec.rb
+++ b/apps/web/billing/spec/controllers/stripe_integration_blockers_spec.rb
@@ -131,8 +131,11 @@ RSpec.describe 'Stripe Integration Blockers', :integration, :stripe_sandbox_api,
         get '/billing/api/plans'
 
         data = JSON.parse(last_response.body)
-        monthly_plans = data['plans'].select { |p| p['interval'] == 'month' }
-        skip 'No monthly plans' if monthly_plans.empty?
+        # Only records backed by a Stripe price: price-less plans (the free
+        # tier) are served with amount 0 by design, so a zero there is not the
+        # blocker this asserts against.
+        monthly_plans = data['plans'].select { |p| p['interval'] == 'month' && p['stripe_price_id'] }
+        skip 'No priced monthly plans' if monthly_plans.empty?
 
         monthly_plans.each do |plan|
           expect(plan['amount'].to_i).to be > 0,

--- a/apps/web/billing/try/models/plan_load_all_from_config_try.rb
+++ b/apps/web/billing/try/models/plan_load_all_from_config_try.rb
@@ -31,17 +31,20 @@ Billing::Plan.instances.size
 #=> Integer
 
 ## Should load plans keyed by family ID (not suffixed)
+## Priced plans (identity_plus_v1) plus config-only plans shown on the plans
+## page (free_v1). The legacy `identity` plan is price-less AND
+## show_on_plans_page: false, so it stays out of the catalog.
 @count
-#=> 1
+#=> 2
 
 ## Verify plan was saved to Redis
 Billing::Plan.instances.size
-#=> 1
+#=> 2
 
 ## List all loaded plans
 @plans = Billing::Plan.list_plans
 @plans.size
-#=> 1
+#=> 2
 
 ## Verify plan exists by canonical family ID
 @plan = Billing::Plan.load('identity_plus_v1')
@@ -132,21 +135,34 @@ Billing::Plan.instances.size
 @plan_via_get.plan_id == @plan_via_yearly.plan_id
 #=> true
 
+## Config-only plan (free_v1) is persisted, with no prices
+@free = Billing::Plan.load('free_v1')
+[@free.nil?, @free&.prices_hash, @free&.show_on_plans_page.to_s]
+#=> [false, {}, 'true']
+
+## Config-only plan keeps its entitlements and limits
+[@free.entitlements.member?('create_secrets'), @free.limits_hash['organizations.max']]
+#=> [true, 5]
+
+## Price-less plan hidden from the plans page stays out of the catalog
+Billing::Plan.load('identity').nil?
+#=> true
+
 ## Test clearing and reloading (clear_first: false)
 @before_count = Billing::Plan.instances.size
 @reload_count = Billing::Operations::Catalog::ConfigLoader.load_all_from_config(clear_first: false)
 @after_count  = Billing::Plan.instances.size
 [@before_count, @reload_count, @after_count]
-#=> [1, 1, 1]
+#=> [2, 2, 2]
 
 ## Test clearing and reloading (clear_first: true, default)
 @reload_count = Billing::Operations::Catalog::ConfigLoader.load_all_from_config
 @reload_count
-#=> 1
+#=> 2
 
 ## Verify instances were updated after reload
 Billing::Plan.instances.size
-#=> 1
+#=> 2
 
 ## Cleanup
 Billing::Plan.clear_cache

--- a/changelog.d/20260729_115100_claude_free_plan_missing_from_pricing.rst
+++ b/changelog.d/20260729_115100_claude_free_plan_missing_from_pricing.rst
@@ -1,0 +1,25 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- Restored the Free plan on the pricing page. ``GET /billing/api/plans``
+  dropped every plan that had no prices, and the free tier is defined with
+  ``prices: []`` — so it passed the ``show_on_plans_page`` gate and was then
+  filtered out one line later, leaving the pricing page with only paid plans
+  and no way to see what the free tier includes. This regressed when the
+  endpoint was refactored to flat per-interval records (#3153) and contradicted
+  the catalog loader, which persists price-less plans specifically so they can
+  be displayed. The endpoint now emits a single record for a price-less visible
+  plan (``amount: 0``, no Stripe price, ``month`` interval). Signed-in
+  customers also see the Free tier in the workspace plan grid, where it acts as
+  the downgrade path for an active subscription.
+
+- Fixed the billing catalog losing the free tier whenever plans are loaded from
+  ``billing.yaml`` rather than Stripe. The loader skipped price-less plans
+  outright, so a deployment that started while Stripe was unreachable had no
+  free tier in its catalog at all — affecting entitlement materialization as
+  well as the pricing page. The same loader backs the billing test fixtures, so
+  the entire billing test suite ran against a catalog with no free tier, which
+  is why this went unnoticed. The loader now handles config-only plans through
+  the same path the Stripe sync uses.

--- a/e2e/full-billing/pricing-flow.spec.ts
+++ b/e2e/full-billing/pricing-flow.spec.ts
@@ -250,23 +250,24 @@ test.describe('CTA Navigation', () => {
     await expect(page).toHaveURL(/interval=yearly/);
   });
 
-  test('free tier CTA goes to signup without query params', async ({ page }) => {
+  test('free tier CTA goes to signup without billing params', async ({ page }) => {
     await page.goto('/pricing');
     await waitForPricingPageLoad(page);
 
     // Find free plan CTA - it has different text like "Get started free"
-    // The free tier uses getCtaLabel which returns 'get_started_free' for free tier
+    // The free tier uses getCtaLabel which returns 'get_started_free' for free tier.
+    // No conditional skip: /billing/api/plans emits the price-less free plan, so a
+    // missing CTA is the regression this test exists to catch (the skip is what let
+    // the plans endpoint drop free_v1 unnoticed).
     const freePlanCta = page.getByRole('link', { name: /get started free/i }).first();
-    const isVisible = await freePlanCta.isVisible().catch(() => false);
-
-    test.skip(!isVisible, 'No free tier plan found');
+    await expect(freePlanCta).toBeVisible();
 
     await freePlanCta.click();
 
-    // Should navigate to plain /signup without query params
-    await expect(page).toHaveURL('/signup');
+    // Should navigate to /signup carrying only the return-path redirect
+    await expect(page).toHaveURL(/\/signup\?redirect=/);
 
-    // Ensure no product or interval params
+    // Ensure no product or interval params - free tier skips the checkout flow
     const url = page.url();
     expect(url).not.toContain('product=');
     expect(url).not.toContain('interval=');
@@ -597,7 +598,8 @@ test.describe('Navigation Integration', () => {
  *
  * ## CTA Buttons
  * - [ ] Paid plan CTA goes to /signup?product=X&interval=Y
- * - [ ] Free plan CTA goes to /signup (no params)
+ * - [ ] Free plan banner renders above the paid grid
+ * - [ ] Free plan CTA goes to /signup?redirect=... (no product/interval params)
  * - [ ] Yearly plans include interval=yearly in URL
  *
  * ## Plan Cards

--- a/src/apps/workspace/billing/planSelectorLogic.ts
+++ b/src/apps/workspace/billing/planSelectorLogic.ts
@@ -36,11 +36,22 @@ function currenciesConflict(
 /**
  * True when the plan's currency differs from the current subscription's
  * currency. New subscribers (no current currency) never mismatch.
+ *
+ * The free plan is EXEMPT. It has no price, so its `currency` is not a billable
+ * currency at all — the API stamps it with the deployment default
+ * (`OT.billing_config.currency`) purely to satisfy the record shape. Comparing
+ * that against a subscriber whose subscription currency differs (a real state:
+ * see the pending-currency-migration flow) would permanently disable the free
+ * card with a misleading "region mismatch" reason and make downgrade-to-free
+ * unreachable from the grid. Exempting here — the single shared predicate —
+ * means isPlanButtonDisabled, resolvePlanSelectAction and the component's
+ * disabledReason all inherit it.
  */
 export function isPlanCurrencyMismatch(
   currentCurrency: string | null | undefined,
   plan: BillingPlan
 ): boolean {
+  if (plan.tier === 'free') return false;
   return currenciesConflict(currentCurrency, plan.currency);
 }
 

--- a/src/tests/apps/secret/support/Pricing.spec.ts
+++ b/src/tests/apps/secret/support/Pricing.spec.ts
@@ -799,4 +799,74 @@ describe('Pricing.vue', () => {
       expect(bannerSection.exists()).toBe(false);
     });
   });
+
+  // ============================================================
+  // 9. Free record on the wire (previously dropped by the API)
+  // ============================================================
+  //
+  // GET /billing/api/plans used to drop every price-less plan, so free_v1
+  // (defined with `prices: []`) never reached the frontend. `freePlan` at
+  // Pricing.vue:100 was therefore always undefined and the standalone banner at
+  // :236 never rendered — a dead branch that these tests keep alive. The spec
+  // mocked a free plan the wire never sent, and nothing compared the two; that
+  // is the exact drift `mockPlans.free` is now pinned against.
+  describe('free record from the API (standalone banner)', () => {
+    it('renders the standalone banner when the API returns the free record', async () => {
+      // defaultPlans includes mockPlans.free — the synthetic wire record.
+      await mountComponent();
+
+      const banner = wrapper.find('.mb-10.rounded-lg');
+      expect(banner.exists()).toBe(true);
+      expect(banner.text()).toContain('Free');
+      expect(banner.text()).toContain('web.pricing.free_tier_description');
+      expect(banner.text()).toContain('web.pricing.get_started_free');
+    });
+
+    it('does not duplicate the free plan into the grid in banner mode', async () => {
+      await mountComponent();
+
+      // Banner mode (default): free is excluded from filteredPlans entirely.
+      expect(wrapper.findAll('[data-testid="plan-card-free_v1"]')).toHaveLength(0);
+      // Paid cards still render, so the absence above isn't an empty grid.
+      expect(
+        wrapper.find('[data-testid="plan-card-identity_plus_v1"]').exists()
+      ).toBe(true);
+    });
+
+    it('renders no banner when the API omits the free record', async () => {
+      // Pre-fix wire behavior: price-less plans dropped. Pins the banner to the
+      // presence of the record rather than to a hardcoded free tier.
+      mockListPlans.mockResolvedValueOnce({
+        plans: defaultPlans.filter((p) => p.tier !== 'free'),
+      });
+      await mountComponent();
+
+      expect(wrapper.find('.mb-10.rounded-lg').exists()).toBe(false);
+      expect(wrapper.text()).not.toContain('web.pricing.free_tier_description');
+    });
+
+    it('renders exactly ONE free card in the grid when freePlanStandalone is false', async () => {
+      // The API emits a single free record (interval: 'month'). filteredPlans
+      // ignores interval for tier === 'free', so a second record would render a
+      // duplicate card — this pins the count, not just the presence.
+      await mountComponent({ freePlanStandalone: false });
+
+      expect(wrapper.findAll('[data-testid="plan-card-free_v1"]')).toHaveLength(1);
+      expect(wrapper.find('.mb-10.rounded-lg').exists()).toBe(false);
+    });
+
+    it('renders exactly ONE free card in the yearly view too', async () => {
+      // interval is ignored for free, so switching to yearly must not drop it
+      // (the record is stamped 'month') nor render it twice.
+      mockRouteParamsValue = { interval: 'yearly' };
+      await mountComponent({ freePlanStandalone: false });
+
+      expect(wrapper.findAll('[data-testid="plan-card-free_v1"]')).toHaveLength(1);
+      // Monthly paid cards are filtered out; yearly ones remain. Asserted via
+      // the yearly-only price ($24.17 from monthly_equivalent_amount: 2417) —
+      // both interval variants share id 'identity_plus_v1', so the card testid
+      // resolves in either view and cannot distinguish them.
+      expect(wrapper.text()).toContain('$24.17');
+    });
+  });
 });

--- a/src/tests/apps/workspace/billing/PlanSelector.currency.spec.ts
+++ b/src/tests/apps/workspace/billing/PlanSelector.currency.spec.ts
@@ -124,6 +124,24 @@ describe('PlanSelector currency mismatch logic', () => {
       const plan = createMockPlan({ currency: 'USD' });
       expect(isPlanCurrencyMismatch('cad', plan)).toBe(true);
     });
+
+    it('exempts the free tier — a price-less plan has no billable currency', () => {
+      // The API stamps the synthetic free record with the deployment default
+      // currency (OT.billing_config.currency) to satisfy the record shape. It is
+      // NOT a billable currency, so it must never conflict with a subscription
+      // whose currency differs.
+      const freePlan = createMockPlan({ id: 'free_v1', tier: 'free', currency: 'cad', amount: 0 });
+      expect(isPlanCurrencyMismatch('eur', freePlan)).toBe(false);
+      expect(isPlanCurrencyMismatch('usd', freePlan)).toBe(false);
+      // Same currency is trivially not a mismatch either.
+      expect(isPlanCurrencyMismatch('cad', freePlan)).toBe(false);
+    });
+
+    it('still flags a paid plan with the same currency pairing (exemption is tier-scoped)', () => {
+      // Control for the test above: identical currencies, only tier differs.
+      const paidPlan = createMockPlan({ tier: 'single_team', currency: 'cad' });
+      expect(isPlanCurrencyMismatch('eur', paidPlan)).toBe(true);
+    });
   });
 
   describe('resolvePlanSelectAction (handlePlanSelect decision)', () => {
@@ -322,6 +340,50 @@ describe('PlanSelector currency mismatch logic', () => {
         hasActiveSubscription: true,
       });
       expect(isPlanButtonDisabled(freePlan, state)).toBe(false);
+    });
+
+    it('enables the free tier button for an active subscriber on a DIFFERENT currency', () => {
+      // Regression: isPlanButtonDisabled ORs the currency predicate in at :83
+      // with no free-tier ordering protection (unlike resolvePlanSelectAction,
+      // where the free branch at :189 precedes the currency check at :193). A
+      // subscriber whose currency differs from the deployment default would see
+      // the free card permanently disabled with a "region mismatch" reason, and
+      // the downgrade-to-free path would be unreachable from the grid.
+      const freePlan = createMockPlan({ currency: 'cad', tier: 'free', id: 'free_v1', amount: 0 });
+      const state = createButtonState({
+        orgPlanId: 'identity_plus_v1',
+        currentCurrency: 'eur',
+        hasActiveSubscription: true,
+      });
+      expect(isPlanButtonDisabled(freePlan, state)).toBe(false);
+    });
+
+    it('still disables the free tier button for a non-subscriber on a different currency', () => {
+      // The currency exemption must not leak into the "nothing to cancel to"
+      // guard — that disable reason is independent and still applies.
+      const freePlan = createMockPlan({ currency: 'cad', tier: 'free', id: 'free_v1', amount: 0 });
+      const state = createButtonState({
+        orgPlanId: 'free_v1',
+        currentCurrency: 'eur',
+        hasActiveSubscription: false,
+      });
+      expect(isPlanButtonDisabled(freePlan, state)).toBe(true);
+    });
+
+    it('opens the cancel modal for a free card even when the subscription currency differs', () => {
+      // resolvePlanSelectAction's free branch (:189) already precedes the
+      // currency check (:193), so this passed before the exemption too. Pinned
+      // so the guard order can't be reshuffled without a failure.
+      const freePlan = createMockPlan({ currency: 'cad', tier: 'free', id: 'free_v1', amount: 0 });
+      const action = resolvePlanSelectAction(
+        freePlan,
+        createSelectContext({
+          orgPlanId: 'identity_plus_v1',
+          currentCurrency: 'eur',
+          hasActiveSubscription: true,
+        })
+      );
+      expect(action).toBe('open-cancel-modal');
     });
   });
 

--- a/src/tests/apps/workspace/billing/PlanSelector.freetier.spec.ts
+++ b/src/tests/apps/workspace/billing/PlanSelector.freetier.spec.ts
@@ -1,0 +1,350 @@
+// src/tests/apps/workspace/billing/PlanSelector.freetier.spec.ts
+
+//
+// MOUNTED tests for the Free card in the authenticated plan-change grid.
+//
+// Why a separate file from PlanSelector.spec.ts / PlanSelector.currency.spec.ts:
+// both of those are pure-logic specs that deliberately never mount the
+// component ("to avoid complex Vue/Pinia/i18n setup"). The module mocks needed
+// to mount are file-scoped and would apply to every pure-logic test in those
+// files. Predicate-level coverage stays there; this file covers only what
+// requires a real render.
+//
+// Context: GET /billing/api/plans used to drop every price-less plan, so
+// free_v1 (defined with `prices: []`) never reached the frontend. Now that the
+// endpoint emits a synthetic free record, PlanSelector's default
+// `freePlanStandalone: false` puts a Free card in the authenticated grid for
+// the first time. That is intended — planSelectorLogic has purpose-built
+// free-tier branches and PlanSelector.vue:728 has free-specific card ordering —
+// so these tests pin the rendered behavior of a surface that was dead code.
+//
+
+import { mount, VueWrapper, flushPromises } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { nextTick, ref } from 'vue';
+import PlanSelector from '@/apps/workspace/billing/PlanSelector.vue';
+import { createTestI18n } from '@tests/setup';
+import { mockPlans } from '@/tests/fixtures/billing.fixture';
+import type { Plan as BillingPlan, SubscriptionStatusResponse } from '@/services/billing.service';
+
+// --- Route: extid is required or onMounted skips the org + subscription load
+// entirely, leaving selectedOrg null and every assertion below vacuous.
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    path: '/billing/on1abc123/plans',
+    params: { extid: 'on1abc123' },
+    query: {},
+  }),
+}));
+
+// --- Presentational stubs. PlanCard is deliberately NOT stubbed: its
+// data-testid, Current badge and disabled button are what we assert on.
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: { name: 'OIcon', template: '<span class="o-icon" />', props: ['collection', 'name', 'class'] },
+}));
+vi.mock('@/shared/components/layout/BillingLayout.vue', () => ({
+  default: { name: 'BillingLayout', template: '<div class="billing-layout"><slot /></div>' },
+}));
+vi.mock('@/shared/components/billing/PlanCardSkeleton.vue', () => ({
+  default: { name: 'PlanCardSkeleton', template: '<div class="plan-card-skeleton" />' },
+}));
+vi.mock('@/shared/components/forms/BasicFormAlerts.vue', () => ({
+  default: { name: 'BasicFormAlerts', template: '<div class="form-alerts">{{ error }}</div>', props: ['error'] },
+}));
+vi.mock('@/shared/components/ui/FeedbackToggle.vue', () => ({
+  default: { name: 'FeedbackToggle', template: '<button class="feedback-toggle" />' },
+}));
+
+// --- Modals: stubbed so `open` is inspectable as a prop.
+vi.mock('@/apps/workspace/billing/PlanChangeModal.vue', () => ({
+  default: {
+    name: 'PlanChangeModal',
+    template: '<div class="plan-change-modal" />',
+    props: ['open', 'orgExtId', 'currentPlan', 'targetPlan'],
+  },
+}));
+vi.mock('@/apps/workspace/billing/CancelSubscriptionModal.vue', () => ({
+  default: {
+    name: 'CancelSubscriptionModal',
+    template: '<div class="cancel-subscription-modal" />',
+    props: ['open', 'orgExtId', 'planName', 'periodEnd'],
+  },
+}));
+vi.mock('@/apps/workspace/billing/CurrencyMigrationModal.vue', () => ({
+  default: {
+    name: 'CurrencyMigrationModal',
+    template: '<div class="currency-migration-modal" />',
+    props: ['open', 'orgExtId', 'conflict'],
+  },
+}));
+vi.mock('@/apps/workspace/billing/PendingMigrationBanner.vue', () => ({
+  default: {
+    name: 'PendingMigrationBanner',
+    template: '<div class="pending-migration-banner" />',
+    props: ['targetPlanName', 'targetCurrency', 'effectiveDate', 'isCompletingMigration'],
+  },
+}));
+
+// --- Services. extractCurrencyConflict is a NAMED import in PlanSelector.vue,
+// and formatCurrency is called unconditionally by PlanCard.
+const mockListPlans = vi.fn();
+const mockGetSubscriptionStatus = vi.fn();
+const mockCreateCheckoutSession = vi.fn();
+const mockReactivateSubscription = vi.fn();
+vi.mock('@/services/billing.service', () => ({
+  BillingService: {
+    listPlans: (...args: unknown[]) => mockListPlans(...args),
+    getSubscriptionStatus: (...args: unknown[]) => mockGetSubscriptionStatus(...args),
+    createCheckoutSession: (...args: unknown[]) => mockCreateCheckoutSession(...args),
+    reactivateSubscription: (...args: unknown[]) => mockReactivateSubscription(...args),
+  },
+  extractCurrencyConflict: () => null,
+}));
+
+vi.mock('@/types/billing', () => ({
+  formatCurrency: (amount: number, currency = 'cad') => `${currency.toUpperCase()} ${(amount / 100).toFixed(2)}`,
+  isLegacyPlan: (planId: string) => planId === 'identity',
+  getPlanLabel: (planId: string) => planId,
+}));
+
+vi.mock('@/schemas/errors', () => ({
+  classifyError: (err: unknown) => ({ message: err instanceof Error ? err.message : 'Unknown error' }),
+}));
+
+vi.mock('@/services/diagnostics.service', () => ({
+  captureMessage: vi.fn(),
+  isDiagnosticsEnabled: () => false,
+}));
+
+// --- Org store
+const mockFetchOrganization = vi.fn();
+vi.mock('@/shared/stores/organizationStore', () => ({
+  useOrganizationStore: () => ({
+    fetchOrganization: mockFetchOrganization,
+  }),
+}));
+
+// --- Entitlements. isLoadingDefinitions gates isLoadingContent, which gates the
+// ENTIRE render behind PlanCardSkeleton — it must be a resolved ref(false).
+const mockInitDefinitions = vi.fn();
+const mockIsLoadingDefinitions = ref(false);
+const mockDefinitionsError = ref('');
+vi.mock('@/shared/composables/useEntitlements', () => ({
+  useEntitlements: () => ({
+    initDefinitions: mockInitDefinitions,
+    isLoadingDefinitions: mockIsLoadingDefinitions,
+    definitionsError: mockDefinitionsError,
+  }),
+}));
+
+// --- Fixtures ---
+
+// The grid as the wire now delivers it: the synthetic free record plus two paid
+// monthly plans. mockPlans.free is the fixture pinned to the API contract.
+const gridPlans: BillingPlan[] = [
+  mockPlans.free,
+  mockPlans.single_team, // identity_plus_v1, tier single_account, cad
+  mockPlans.multi_team, // team_plus_v1, tier single_team, cad
+];
+
+interface MockOrg {
+  objid: string;
+  extid: string;
+  display_name: string;
+  planid: string;
+  entitlements: string[];
+  limits: Record<string, number>;
+}
+
+const makeOrg = (planid: string): MockOrg => ({
+  objid: 'org_123',
+  extid: 'on1abc123',
+  display_name: 'Test Organization',
+  planid,
+  entitlements: [],
+  limits: {},
+});
+
+const makeSubscription = (
+  overrides: Partial<SubscriptionStatusResponse> = {}
+): SubscriptionStatusResponse => ({
+  has_active_subscription: true,
+  current_plan: 'identity_plus_v1',
+  current_price_id: 'price_single_monthly',
+  subscription_status: 'active',
+  current_currency: 'cad',
+  cancel_at_period_end: false,
+  ...overrides,
+});
+
+const FREE_CARD = '[data-testid="plan-card-free_v1"]';
+const FREE_BUTTON = '[data-testid="plan-select-free_v1"]';
+const PAID_CARD = '[data-testid="plan-card-identity_plus_v1"]';
+const PAID_BUTTON = '[data-testid="plan-select-identity_plus_v1"]';
+
+describe('PlanSelector — free card in the authenticated grid', () => {
+  let wrapper: VueWrapper;
+  let pinia: ReturnType<typeof createPinia>;
+  const i18n = createTestI18n();
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+    mockIsLoadingDefinitions.value = false;
+    mockDefinitionsError.value = '';
+    mockInitDefinitions.mockResolvedValue(undefined);
+    mockListPlans.mockResolvedValue({ plans: gridPlans });
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  const mountComponent = async (options: {
+    planid?: string;
+    subscription?: SubscriptionStatusResponse | null;
+  } = {}) => {
+    mockFetchOrganization.mockResolvedValue(makeOrg(options.planid ?? 'identity_plus_v1'));
+    if (options.subscription === null) {
+      mockGetSubscriptionStatus.mockRejectedValue(new Error('no subscription'));
+    } else {
+      mockGetSubscriptionStatus.mockResolvedValue(options.subscription ?? makeSubscription());
+    }
+
+    wrapper = mount(PlanSelector, {
+      global: { plugins: [i18n, pinia] },
+    });
+    await flushPromises();
+    await nextTick();
+    return wrapper;
+  };
+
+  // ============================================================
+  // Rendering
+  // ============================================================
+  describe('rendering', () => {
+    it('renders exactly one Free card in the grid (default freePlanStandalone: false)', async () => {
+      await mountComponent();
+
+      expect(wrapper.findAll(FREE_CARD)).toHaveLength(1);
+      // The standalone banner branch must NOT be taken. Note it is a v-else-if
+      // in the same chain as the grid, so if it ever fired the grid would
+      // vanish — asserting the paid cards are present covers both.
+      expect(wrapper.find(PAID_CARD).exists()).toBe(true);
+      expect(wrapper.text()).not.toContain('web.pricing.free_tier_description');
+    });
+
+    it('keeps the Free card out of the interval filter (renders in the yearly view too)', async () => {
+      await mountComponent();
+
+      await wrapper.find('[data-testid="billing-interval-year"]').trigger('click');
+      await nextTick();
+
+      // Paid monthly cards drop out; the single free record stays, once.
+      expect(wrapper.findAll(FREE_CARD)).toHaveLength(1);
+      expect(wrapper.find(PAID_CARD).exists()).toBe(false);
+    });
+  });
+
+  // ============================================================
+  // Button state
+  // ============================================================
+  describe('button state', () => {
+    it('disables the Free card for a customer with no active subscription', async () => {
+      await mountComponent({ planid: 'free_v1', subscription: null });
+
+      const button = wrapper.find(FREE_BUTTON);
+      expect(button.exists()).toBe(true);
+      expect(button.attributes('disabled')).toBeDefined();
+    });
+
+    it('enables the Free card and labels it "cancel to downgrade" for an active subscriber', async () => {
+      await mountComponent({ planid: 'identity_plus_v1', subscription: makeSubscription() });
+
+      const button = wrapper.find(FREE_BUTTON);
+      expect(button.attributes('disabled')).toBeUndefined();
+      // canDowngrade resolves only because the org's planid is present in the
+      // plans list (identity_plus_v1 → single_account, rank 1 > free rank 0).
+      expect(button.text()).toBe('web.billing.plans.cancel_to_downgrade');
+    });
+
+    it('opens the cancel modal when an active subscriber clicks the Free card', async () => {
+      await mountComponent({ planid: 'identity_plus_v1', subscription: makeSubscription() });
+
+      const modal = wrapper.findComponent({ name: 'CancelSubscriptionModal' });
+      expect(modal.props('open')).toBe(false);
+
+      await wrapper.find(FREE_BUTTON).trigger('click');
+      await nextTick();
+
+      expect(modal.props('open')).toBe(true);
+    });
+  });
+
+  // ============================================================
+  // Current badge
+  // ============================================================
+  describe('current badge', () => {
+    it('lands the Current badge on the Free card when org.planid is free_v1', async () => {
+      await mountComponent({ planid: 'free_v1', subscription: null });
+
+      expect(wrapper.find(FREE_CARD).text()).toContain('web.billing.plans.current_badge');
+      expect(wrapper.find(PAID_CARD).text()).not.toContain('web.billing.plans.current_badge');
+    });
+
+    it('does not badge the Free card for a paid subscriber', async () => {
+      await mountComponent({ planid: 'identity_plus_v1', subscription: makeSubscription() });
+
+      expect(wrapper.find(FREE_CARD).text()).not.toContain('web.billing.plans.current_badge');
+      expect(wrapper.find(PAID_CARD).text()).toContain('web.billing.plans.current_badge');
+    });
+  });
+
+  // ============================================================
+  // Currency regression
+  // ============================================================
+  describe('subscriber on a non-default currency', () => {
+    // The synthetic free record carries the deployment default currency ('cad'
+    // in these fixtures). A subscriber whose subscription currency differs is a
+    // real state — see the pending-currency-migration flow. Before the free-tier
+    // exemption in isPlanCurrencyMismatch, isPlanButtonDisabled (which ORs the
+    // currency predicate in with no free-tier ordering protection) rendered the
+    // Free card permanently disabled with a misleading "region mismatch"
+    // reason, making downgrade-to-free unreachable from the grid.
+    const eurSubscriber = () => makeSubscription({ current_currency: 'eur' });
+
+    it('leaves the Free card actionable and free of a region-mismatch reason', async () => {
+      await mountComponent({ planid: 'identity_plus_v1', subscription: eurSubscriber() });
+
+      const card = wrapper.find(FREE_CARD);
+      expect(wrapper.find(FREE_BUTTON).attributes('disabled')).toBeUndefined();
+      expect(card.text()).not.toContain('web.billing.plan_unavailable_region_mismatch');
+      expect(wrapper.find(FREE_BUTTON).text()).toBe('web.billing.plans.cancel_to_downgrade');
+    });
+
+    it('still opens the cancel modal on click', async () => {
+      await mountComponent({ planid: 'identity_plus_v1', subscription: eurSubscriber() });
+
+      await wrapper.find(FREE_BUTTON).trigger('click');
+      await nextTick();
+
+      expect(wrapper.findComponent({ name: 'CancelSubscriptionModal' }).props('open')).toBe(true);
+    });
+
+    it('still blocks PAID cards with the region-mismatch reason (exemption is tier-scoped)', async () => {
+      // Control: the exemption must not disarm the currency guard generally.
+      // team_plus_v1 is a different plan than the org's, priced in cad.
+      await mountComponent({ planid: 'identity_plus_v1', subscription: eurSubscriber() });
+
+      const paidButton = wrapper.find('[data-testid="plan-select-team_plus_v1"]');
+      expect(paidButton.attributes('disabled')).toBeDefined();
+      expect(wrapper.find('[data-testid="plan-card-team_plus_v1"]').text()).toContain(
+        'web.billing.plan_unavailable_region_mismatch'
+      );
+      // The org's own card is disabled for being current, not for currency.
+      expect(wrapper.find(PAID_BUTTON).attributes('disabled')).toBeDefined();
+    });
+  });
+});

--- a/src/tests/fixtures/billing.fixture.ts
+++ b/src/tests/fixtures/billing.fixture.ts
@@ -48,14 +48,41 @@ export function createMockPlan(overrides: Partial<Plan> = {}): Plan {
  * Pre-configured mock plans for common test scenarios
  */
 export const mockPlans: Record<string, Plan> = {
+  /**
+   * API CONTRACT — pinned to `list_plans` in
+   * apps/web/billing/controllers/billing.rb.
+   *
+   * free_v1 is defined with `prices: []`, so the endpoint emits exactly ONE
+   * synthetic record for it: `interval: 'month'`, `amount: 0`,
+   * `stripe_price_id: null`, `display_order: 0`, `is_popular: false`, and a
+   * real `currency` (the deployment default, `OT.billing_config.currency`).
+   *
+   * Exactly one record, and `interval: 'month'` specifically: both PlanSelector
+   * and Pricing ignore `interval` for `tier === 'free'` in `filteredPlans`, so
+   * a second record would render a duplicate Free card.
+   *
+   * The wire also sends `plan_code`, `monthly_equivalent_amount`,
+   * `includes_plan` and `includes_plan_name` as null. They are OMITTED here
+   * rather than set to null because `Plan` types them as optional non-null and
+   * every consumer reads them via `??` or truthiness (PlanCard.vue:47,
+   * PlanChangeModal.vue:42-43, PlanCard.vue:168), so null and absent are
+   * indistinguishable in behavior. `plan_name_label` is the one exception —
+   * `Plan` already types it `string | null`, so the wire's null is spelled out.
+   *
+   * The endpoint used to DROP every price-less plan, so this fixture described
+   * a record the wire never sent and nothing compared the two. Keep them in
+   * lockstep.
+   */
   free: createMockPlan({
     id: 'free_v1',
     stripe_price_id: null, // Free plans have no Stripe price
     name: 'Free',
     tier: 'free',
-    interval: '', // Free plans have no interval
+    interval: 'month', // Synthetic record is stamped 'month' (never '' or 'year')
     amount: 0,
     display_order: 0,
+    is_popular: false,
+    plan_name_label: null, // Wire sends null; `Plan` already types this nullable
     features: ['Basic secret sharing'],
     limits: { teams: 0, total_members_per_org: 0 },
     entitlements: [],


### PR DESCRIPTION
`GET /billing/api/plans` dropped every plan with no prices, and the free tier is defined with `prices: []` — it passed the `show_on_plans_page` gate and was filtered out one line later, so /pricing showed only paid plans. The endpoint now emits a single synthetic record for a price-less visible plan (`amount: 0`, no Stripe price, `month` interval).

The catalog config loader had the same blind spot: it skipped price-less plans entirely, so any deployment booting from `billing.yaml` (Stripe unreachable) had no free tier in its catalog at all — which also affected entitlement materialization. Since that loader backs the billing test fixtures, the whole billing suite ran against a free-tier-less catalog, which is why this went unnoticed.

Frontend: the free tier is exempted from the currency-mismatch filter (a $0 plan has no currency to mismatch) so signed-in customers see it in the workspace plan grid as the downgrade path off an active subscription.

Regression dates back to the flat per-interval refactor in #3153.