### PR TITLE
Gate domain sign-in SSO on tenant SSO, not platform SSO

### DIFF
--- a/changelog.d/20260729_121600_claude_domain_signin_sso_toggle_axis.rst
+++ b/changelog.d/20260729_121600_claude_domain_signin_sso_toggle_axis.rst
@@ -1,0 +1,37 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- The **Single Sign-On** controls on a domain's *Sign-in Settings* page
+  (``/org/:orgid/domains/:extid/signin``) were gated on the wrong switch. They
+  read the PLATFORM SSO flag (``AUTH_SSO_ENABLED``, resolved by the config
+  serializer against the *current request's* domain — the canonical workspace
+  host), while per-domain SSO is TENANT SSO, whose real authorities are
+  ``ORGS_SSO_ENABLED`` plus the ``manage_sso`` entitlement. On any install with
+  platform SSO off, the availability toggle and the "SSO" method radio rendered
+  permanently locked even for an organization fully entitled to configure tenant
+  SSO. This page was the only surface gating on that axis; the domains table and
+  the organization SSO tab already used ``ORGS_SSO_ENABLED`` + ``manage_sso``,
+  and it now matches them.
+
+- **Data loss:** on a domain with no sign-in configuration, the form seeded its
+  ``sso_enabled`` flag from that same platform SSO flag. Because the page
+  auto-saves every change as a full-replacement ``PUT``, the first edit to *any*
+  field — the mode switch, the email toggle — persisted ``sso_enabled: false``
+  on installs with platform SSO off. That flips
+  ``SigninConfig.sso_permitted_for?`` to false and takes the domain's working
+  tenant SSO sign-in buttons down. The flag is now seeded from the backend
+  authority for an unconfigured domain (``sso_permitted_for?``, which defers to
+  the domain's SSO credentials), so materializing the seed leaves tenant SSO
+  exactly as it was running. Structurally the same failure as the
+  ``signin_enabled`` bug fixed in #3817. Domains already carrying a stored
+  ``sso_enabled: false`` from this bug are not rewritten; the toggle is now
+  operable, so they can be switched back on from the same page.
+
+- The SSO availability toggle reported OFF whenever the org lacked ``manage_sso``
+  or tenant SSO was disabled install-wide, even when the stored value was true
+  and the domain's SSO was live. Those two are management gates — the runtime
+  ladder (``SsoConfig.tenant_sso_unavailable_reason``) never consults them — so
+  the toggle now reports the stored value and expresses the lock through its
+  disabled state alone.

--- a/changelog.d/20260729_121600_claude_domain_signin_sso_toggle_axis.rst
+++ b/changelog.d/20260729_121600_claude_domain_signin_sso_toggle_axis.rst
@@ -26,8 +26,11 @@ Fixed
   the domain's SSO credentials), so materializing the seed leaves tenant SSO
   exactly as it was running. Structurally the same failure as the
   ``signin_enabled`` bug fixed in #3817. Domains already carrying a stored
-  ``sso_enabled: false`` from this bug are not rewritten; the toggle is now
-  operable, so they can be switched back on from the same page.
+  ``sso_enabled: false`` from this bug are **not** rewritten by this release.
+  Recovering one in-app requires ``ORGS_SSO_ENABLED=true`` *and* the
+  ``manage_sso`` entitlement — the conditions under which the toggle is
+  operable; with tenant SSO disabled install-wide there is no in-app path, and
+  the flag must be turned on first.
 
 - The SSO availability toggle reported OFF whenever the org lacked ``manage_sso``
   or tenant SSO was disabled install-wide, even when the stored value was true
@@ -35,3 +38,14 @@ Fixed
   ladder (``SsoConfig.tenant_sso_unavailable_reason``) never consults them — so
   the toggle now reports the stored value and expresses the lock through its
   disabled state alone.
+
+- In "One specific method" mode, a domain restricted to SSO rendered a method
+  list with nothing selected whenever the SSO row was filtered out, hiding the
+  domain's actual configuration. The SSO row now stays visible — locked, and
+  still not re-selectable — when it is the current restriction.
+
+.. note::
+
+   Tenant SSO is off by default (``ORGS_SSO_ENABLED``, absent ⇒ ``false``).
+   These controls are *correctly* locked on an install that has not set it;
+   turning them on is an operator action, not a plan upgrade.

--- a/lib/onetime/models/custom_domain/signin_config.rb
+++ b/lib/onetime/models/custom_domain/signin_config.rb
@@ -65,7 +65,14 @@ module Onetime
       field :signin_enabled       # Override for AUTH_SIGNIN
       field :restrict_to          # Override for full.restrict_to (string or nil)
       field :email_auth_enabled   # Override for AUTH_EMAIL_AUTH_ENABLED
-      field :sso_enabled          # Override for AUTH_SSO_ENABLED
+      # TENANT-SSO activation gate — NOT an override for the platform
+      # AUTH_SSO_ENABLED, despite what this comment said until 2026-07.
+      # Authority for `sso_permitted_for?` below, which feeds
+      # SsoConfig.tenant_sso_available_for? and the omniauth_tenant hook, i.e.
+      # whether THIS domain's own SsoConfig credentials may be used to sign in.
+      # Reading it as the platform flag is what led the domain sign-in settings
+      # UI to gate on (and seed from) the wrong switch.
+      field :sso_enabled
 
       # Timestamps (Unix epoch integers)
       field :created

--- a/src/apps/workspace/components/domains/DomainSigninConfigForm.vue
+++ b/src/apps/workspace/components/domains/DomainSigninConfigForm.vue
@@ -224,12 +224,15 @@
   const webauthnAvailable = computed(() => props.globalAvailability.webauthn);
   const emailAuthAvailable = computed(() => props.globalAvailability.email_auth);
   /**
-   * SSO here means TENANT SSO (the domain's own SsoConfig credentials), whose
-   * authorities are ORGS_SSO_ENABLED + manage_sso — the same pair DomainsTable
-   * and OrganizationSettings gate on. It is NOT bootstrap `features.sso`
-   * (platform AUTH_SSO_ENABLED, resolved against the *current request's*
-   * domain): on the workspace host that reads the canonical site's SSO config,
-   * which has no bearing on whether this domain may run tenant SSO.
+   * SSO here means TENANT SSO (the domain's own SsoConfig credentials).
+   * ORGS_SSO_ENABLED — with manage_sso, the pair DomainsTable and
+   * OrganizationSettings gate on — governs who may CONFIGURE tenant SSO, not
+   * whether it runs: the runtime ladder (SsoConfig.tenant_sso_unavailable_reason)
+   * checks the SsoConfig record + sso_permitted_for?, never these management
+   * gates, so don't AND runtime state with them. It is also NOT bootstrap
+   * `features.sso` (platform AUTH_SSO_ENABLED, resolved against the *current
+   * request's* domain): on the workspace host that reads the canonical site's
+   * SSO config, which has no bearing on this domain's tenant SSO.
    */
   const ssoAvailable = computed(() => isOrgsSsoEnabled());
 
@@ -737,12 +740,16 @@
               </span>
             </span>
 
-            <!-- SSO Configure stays reachable in Mode B -->
+            <!-- SSO Configure stays reachable in Mode B — same gates as Mode A:
+                 the button needs BOTH write-endpoint gates (ssoConfigurable),
+                 and the upgrade lock names the ENTITLEMENT only. When the
+                 blocker is the install flag, neither renders — no plan unlocks
+                 an operator's ORGS_SSO_ENABLED. -->
             <span
               v-if="method.value === 'sso'"
               class="ml-3 flex-shrink-0">
               <button
-                v-if="canManageSso"
+                v-if="ssoConfigurable"
                 type="button"
                 @click.prevent="emit('configure-sso')"
                 class="inline-flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm ring-1 ring-gray-300 ring-inset hover:bg-gray-50 dark:bg-gray-700 dark:text-gray-200 dark:ring-gray-600 dark:hover:bg-gray-600">
@@ -758,7 +765,7 @@
                 }}
               </button>
               <span
-                v-else
+                v-else-if="!canManageSso"
                 class="inline-flex items-center gap-1.5 text-sm text-gray-400 dark:text-gray-500">
                 <OIcon
                   collection="heroicons"

--- a/src/apps/workspace/components/domains/DomainSigninConfigForm.vue
+++ b/src/apps/workspace/components/domains/DomainSigninConfigForm.vue
@@ -45,6 +45,7 @@
   import ToggleWithIcon from '@/shared/components/common/ToggleWithIcon.vue';
   import OIcon from '@/shared/components/icons/OIcon.vue';
   import type { SigninConfigFormState } from '@/shared/composables/useSigninConfig';
+  import { isOrgsSsoEnabled } from '@/utils/features';
   import { computed, ref, watch } from 'vue';
   import { useI18n } from 'vue-i18n';
 
@@ -74,8 +75,13 @@
      * selectable, or restrict_to/availability would produce a blank login page.
      * Password and WebAuthn have no per-domain field; only the global flag gates
      * them. undefined upstream is treated as available (codebase convention).
+     *
+     * SSO is deliberately NOT a member: per-domain SSO is *tenant* SSO
+     * (CustomDomain::SsoConfig credentials), gated on ORGS_SSO_ENABLED +
+     * manage_sso — not on the platform AUTH_SSO_ENABLED that bootstrap
+     * `features.sso` carries. See `ssoAvailable` below.
      */
-    globalAvailability: { email_auth: boolean; webauthn: boolean; sso: boolean };
+    globalAvailability: { email_auth: boolean; webauthn: boolean };
     /** Field currently auto-saving, for per-toggle loading feedback. */
     savingField: keyof SigninConfigFormState | null;
   }>();
@@ -217,7 +223,24 @@
   const passwordAvailable = true; // always available
   const webauthnAvailable = computed(() => props.globalAvailability.webauthn);
   const emailAuthAvailable = computed(() => props.globalAvailability.email_auth);
-  const ssoAvailable = computed(() => props.globalAvailability.sso);
+  /**
+   * SSO here means TENANT SSO (the domain's own SsoConfig credentials), whose
+   * authorities are ORGS_SSO_ENABLED + manage_sso — the same pair DomainsTable
+   * and OrganizationSettings gate on. It is NOT bootstrap `features.sso`
+   * (platform AUTH_SSO_ENABLED, resolved against the *current request's*
+   * domain): on the workspace host that reads the canonical site's SSO config,
+   * which has no bearing on whether this domain may run tenant SSO.
+   */
+  const ssoAvailable = computed(() => isOrgsSsoEnabled());
+
+  /**
+   * Both gates the backend enforces on every tenant-SSO write
+   * (DomainsAPI::Logic::SsoConfig::Base — `manage_sso` entitlement AND the
+   * `features.organizations.sso_enabled` flag). Offering "Configure" without
+   * both would open a modal whose save is rejected. Mode B gets this for free
+   * (the SSO row is omitted when unavailable); Mode A's static row needs it.
+   */
+  const ssoConfigurable = computed(() => ssoAvailable.value && props.canManageSso);
 
   interface MethodRow {
     value: SigninRestrictTo;
@@ -574,7 +597,7 @@
           </div>
           <div class="flex items-center gap-3">
             <button
-              v-if="canManageSso"
+              v-if="ssoConfigurable"
               type="button"
               @click="emit('configure-sso')"
               class="inline-flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm ring-1 ring-gray-300 ring-inset hover:bg-gray-50 dark:bg-gray-700 dark:text-gray-200 dark:ring-gray-600 dark:hover:bg-gray-600">
@@ -589,8 +612,13 @@
                   : t('web.domains.sso.configure_button')
               }}
             </button>
+            <!-- Upgrade lock is for the ENTITLEMENT only. When the blocker is
+                 the install flag instead, neither control renders here — the
+                 hint above already reads "Unavailable", and "Upgrade to
+                 configure" would name the wrong cause (no plan unlocks an
+                 operator's ORGS_SSO_ENABLED). -->
             <span
-              v-else
+              v-else-if="!canManageSso"
               class="inline-flex items-center gap-1.5 text-sm text-gray-400 dark:text-gray-500">
               <OIcon
                 collection="heroicons"
@@ -599,12 +627,17 @@
                 aria-hidden="true" />
               {{ t('web.domains.sso.upgrade_required') }}
             </span>
-            <!-- Locked without the manage-SSO entitlement: the org cannot
-                 configure SSO credentials, so the method can never activate —
-                 showing an operable "Enabled" next to the upgrade lock would
-                 contradict it. -->
+            <!-- Locked without the manage-SSO entitlement (or with tenant SSO
+                 off install-wide): the org cannot configure SSO credentials, so
+                 the method can never activate — showing an operable toggle next
+                 to the upgrade lock would contradict it. `:enabled` reports the
+                 STORED value alone: the runtime ladder
+                 (SsoConfig.tenant_sso_unavailable_reason) gates on the SsoConfig
+                 record and sso_permitted_for?, never on these two management
+                 gates, so ANDing them in here would render OFF for a domain
+                 whose tenant SSO is actually live. -->
             <ToggleWithIcon
-              :enabled="Boolean(formState.sso_enabled) && ssoAvailable && canManageSso"
+              :enabled="Boolean(formState.sso_enabled)"
               :disabled="isSaving || !ssoAvailable || !canManageSso"
               :loading="savingField === 'sso_enabled'"
               :on-label="t('web.COMMON.enabled')"

--- a/src/apps/workspace/components/domains/DomainSigninConfigForm.vue
+++ b/src/apps/workspace/components/domains/DomainSigninConfigForm.vue
@@ -273,7 +273,11 @@
         available: true,
       });
     }
-    if (ssoAvailable.value) {
+    // Also listed — locked — when SSO is the CURRENT restriction. Omitting the
+    // selected method would render a radiogroup with nothing checked, hiding
+    // the domain's actual configuration; showing it locked reports the truth
+    // and still refuses re-selection.
+    if (ssoAvailable.value || props.formState.restrict_to === 'sso') {
       rows.push({
         value: 'sso',
         label: t('web.domains.signin.method_sso'),
@@ -281,7 +285,7 @@
         // Kept visible when unentitled (the lock badge is the upgrade prompt)
         // but not selectable: without the entitlement the org cannot configure
         // SSO credentials, so restrict_to=sso would dead-end the login page.
-        available: props.canManageSso,
+        available: ssoAvailable.value && props.canManageSso,
       });
     }
     // WebAuthn / Passkeys listed last.
@@ -377,8 +381,10 @@
    */
   const selectMethod = (value: SigninRestrictTo) => {
     // Disabled radios fire no events, but guard anyway: restricting to SSO
-    // without the manage-SSO entitlement must be unexpressible.
-    if (value === 'sso' && !props.canManageSso) return;
+    // without BOTH tenant-SSO gates must be unexpressible — the SSO row is now
+    // also rendered (locked) when it is the current restriction, so this is
+    // the backstop for that row.
+    if (value === 'sso' && !ssoConfigurable.value) return;
     const patch: Partial<SigninConfigFormState> = { restrict_to: value };
     if (value === 'email_auth') patch.email_auth_enabled = true;
     if (value === 'sso') patch.sso_enabled = true;

--- a/src/apps/workspace/domains/DomainSignin.vue
+++ b/src/apps/workspace/domains/DomainSignin.vue
@@ -31,6 +31,7 @@ import {
 import { useSsoConfig } from '@/shared/composables/useSsoConfig';
 import { useOrganizationStore } from '@/shared/stores/organizationStore';
 import { ENTITLEMENTS } from '@/types/organization';
+import { isOrgsSsoEnabled } from '@/utils/features';
 import { storeToRefs } from 'pinia';
 import { computed, onMounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -67,7 +68,18 @@ const organization = computed(() =>
 );
 const { can } = useEntitlements(organization);
 const canCustomSignin = computed(() => can(ENTITLEMENTS.CUSTOM_SIGNIN_CONFIG));
+/**
+ * Entitlement only — the form distinguishes "upgrade to configure" (this) from
+ * "unavailable on this instance" (ORGS_SSO_ENABLED), so the two must not be
+ * fused into one prop the way DomainsTable fuses them.
+ */
 const canManageSso = computed(() => can(ENTITLEMENTS.MANAGE_SSO));
+/**
+ * Both gates the tenant-SSO endpoints enforce. Fetching credentials without
+ * the install flag returns "Organization SSO is not enabled on this instance"
+ * (DomainsAPI::Logic::SsoConfig::Base), so don't ask.
+ */
+const canFetchSsoConfig = computed(() => isOrgsSsoEnabled() && canManageSso.value);
 const billingRoute = computed(() => `/billing/${props.orgid}/plans`);
 
 // ---------------------------------------------------------------------------
@@ -178,7 +190,7 @@ onMounted(async () => {
     await initializeSigninConfig();
   }
 
-  if (canManageSso.value) {
+  if (canFetchSsoConfig.value) {
     await initializeSsoConfig();
     if (wantsSsoModal.value) showSsoModal.value = true;
   }
@@ -192,8 +204,8 @@ watch(canCustomSignin, async (entitled) => {
   }
 });
 
-watch(canManageSso, async (entitled) => {
-  if (entitled && !ssoInitialized.value) {
+watch(canFetchSsoConfig, async (allowed) => {
+  if (allowed && !ssoInitialized.value) {
     await initializeSsoConfig();
     if (wantsSsoModal.value) showSsoModal.value = true;
   }

--- a/src/shared/composables/useSigninConfig.ts
+++ b/src/shared/composables/useSigninConfig.ts
@@ -59,12 +59,15 @@ export interface SigninConfigFormState {
  * SSO is deliberately absent. Bootstrap `features.sso` is PLATFORM SSO
  * (AUTH_SSO_ENABLED + platform provider env), resolved by ConfigSerializer
  * against the *current request's* display_domain — on the workspace host that
- * is the canonical site. Per-domain SSO is TENANT SSO (the domain's own
- * SsoConfig credentials), whose authorities are ORGS_SSO_ENABLED + manage_sso.
- * Reading the platform flag here made the domain sign-in page the sole surface
- * gating tenant SSO on the wrong axis, and — worse — seeded `sso_enabled`
- * from it, so the first autosave on an install with platform SSO off persisted
- * `sso_enabled: false` and killed the domain's working tenant SSO.
+ * is the canonical site. Per-domain SSO is TENANT SSO: whether it RUNS is
+ * decided by the domain's SsoConfig credentials + sso_permitted_for? (the
+ * stored sso_enabled) — the runtime ladder never consults ORGS_SSO_ENABLED or
+ * manage_sso, which only gate who may CONFIGURE it (write endpoints + UI).
+ * Never AND runtime state with those management gates. Reading the platform
+ * flag here made the domain sign-in page the sole surface gating tenant SSO
+ * on the wrong axis, and — worse — seeded `sso_enabled` from it, so the first
+ * autosave on an install with platform SSO off persisted `sso_enabled: false`
+ * and killed the domain's working tenant SSO.
  *
  * Single definition consumed by both the page (method gating) and this
  * composable (seeding unconfigured domains).

--- a/src/shared/composables/useSigninConfig.ts
+++ b/src/shared/composables/useSigninConfig.ts
@@ -54,8 +54,17 @@ export interface SigninConfigFormState {
  * Globally-available auth methods (install-level config), read from the
  * bootstrap. The workspace app runs on the dashboard domain, so bootstrap
  * features reflect the install/global auth config. undefined is treated as
- * available (codebase convention). SSO is a union (boolean | config object);
- * an object's `enabled` flag is authoritative.
+ * available (codebase convention).
+ *
+ * SSO is deliberately absent. Bootstrap `features.sso` is PLATFORM SSO
+ * (AUTH_SSO_ENABLED + platform provider env), resolved by ConfigSerializer
+ * against the *current request's* display_domain — on the workspace host that
+ * is the canonical site. Per-domain SSO is TENANT SSO (the domain's own
+ * SsoConfig credentials), whose authorities are ORGS_SSO_ENABLED + manage_sso.
+ * Reading the platform flag here made the domain sign-in page the sole surface
+ * gating tenant SSO on the wrong axis, and — worse — seeded `sso_enabled`
+ * from it, so the first autosave on an install with platform SSO off persisted
+ * `sso_enabled: false` and killed the domain's working tenant SSO.
  *
  * Single definition consumed by both the page (method gating) and this
  * composable (seeding unconfigured domains).
@@ -63,18 +72,13 @@ export interface SigninConfigFormState {
 export interface GlobalMethodAvailability {
   email_auth: boolean;
   webauthn: boolean;
-  sso: boolean;
 }
 
 export function resolveGlobalMethodAvailability(): GlobalMethodAvailability {
   const features = useBootstrapStore().features;
-  const sso = features?.sso;
-  const ssoAvailable =
-    typeof sso === 'object' && sso !== null ? sso.enabled : sso !== false;
   return {
     email_auth: features?.email_auth !== false,
     webauthn: features?.webauthn !== false,
-    sso: ssoAvailable,
   };
 }
 
@@ -99,7 +103,13 @@ function createSeededFormState(
     signin_enabled: details?.effective_enabled ?? false,
     restrict_to: details?.global_restrict_to ?? null,
     email_auth_enabled: methods.email_auth,
-    sso_enabled: methods.sso,
+    // Both seed call sites run with no record (initialize's null branch,
+    // deleteConfig after clearing it), and for an unconfigured domain the
+    // backend authority — SigninConfig.sso_permitted_for? — returns true
+    // unconditionally ("master switch off => defer to SsoConfig credentials").
+    // So the inherited state is literally true; materializing this seed leaves
+    // tenant SSO exactly as it was running.
+    sso_enabled: true,
   };
 }
 

--- a/src/tests/apps/workspace/components/domains/DomainSigninConfigForm.spec.ts
+++ b/src/tests/apps/workspace/components/domains/DomainSigninConfigForm.spec.ts
@@ -27,12 +27,24 @@ import { mount, type VueWrapper } from '@vue/test-utils';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import { createI18n } from 'vue-i18n';
+import { ref } from 'vue';
 import DomainSigninConfigForm from '@/apps/workspace/components/domains/DomainSigninConfigForm.vue';
 import type { SigninConfigFormState } from '@/shared/composables/useSigninConfig';
 
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
+
+// Tenant-SSO availability is an install feature flag (ORGS_SSO_ENABLED), read
+// straight from the bootstrap — NOT a prop. It is deliberately not part of
+// globalAvailability: that triple carries PLATFORM auth methods, and gating
+// per-domain (tenant) SSO on the platform AUTH_SSO_ENABLED flag was the bug
+// this mock exists to pin. Same gate DomainsTable/OrganizationSettings use.
+const mockOrgsSsoEnabled = ref(true);
+vi.mock('@/utils/features', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils/features')>()),
+  isOrgsSsoEnabled: () => mockOrgsSsoEnabled.value,
+}));
 
 vi.mock('@/shared/components/icons/OIcon.vue', () => ({
   default: {
@@ -130,7 +142,7 @@ const defaultFormState: SigninConfigFormState = {
   sso_enabled: false,
 };
 
-const allAvailable = { email_auth: true, webauthn: true, sso: true };
+const allAvailable = { email_auth: true, webauthn: true };
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -145,11 +157,14 @@ interface MountOptions {
   workspaceDefault?: boolean;
   ssoConfigured?: boolean;
   canManageSso?: boolean;
-  globalAvailability?: { email_auth: boolean; webauthn: boolean; sso: boolean };
+  globalAvailability?: { email_auth: boolean; webauthn: boolean };
+  /** ORGS_SSO_ENABLED — tenant-SSO availability (bootstrap flag, not a prop). */
+  orgsSsoEnabled?: boolean;
   savingField?: keyof SigninConfigFormState | null;
 }
 
 function mountForm(opts: MountOptions = {}): VueWrapper {
+  mockOrgsSsoEnabled.value = opts.orgsSsoEnabled ?? true;
   return mount(DomainSigninConfigForm, {
     props: {
       domainExtId: 'dm-ext-test',
@@ -512,6 +527,23 @@ describe('DomainSigninConfigForm', () => {
       const configureBtn = wrapper.findAll('button').find((b) => b.text().includes(COPY.configure));
       expect(configureBtn).toBeUndefined();
     });
+
+    it('hides Configure when ORGS_SSO_ENABLED is off, even with the entitlement', () => {
+      // The tenant-SSO write endpoints enforce BOTH gates, so an entitled org
+      // on an install with tenant SSO off would open a modal whose save is
+      // rejected with "Organization SSO is not enabled on this instance".
+      wrapper = mountForm({ canManageSso: true, orgsSsoEnabled: false });
+      const configureBtn = wrapper.findAll('button').find((b) => b.text().includes(COPY.configure));
+      expect(configureBtn).toBeUndefined();
+    });
+
+    it('does not blame the plan when the blocker is the install flag', () => {
+      // "Upgrade to configure" would name the wrong cause — no plan unlocks an
+      // operator's ORGS_SSO_ENABLED. The row's hint carries the real reason.
+      wrapper = mountForm({ canManageSso: true, orgsSsoEnabled: false });
+      expect(wrapper.text()).not.toContain(COPY.upgradeRequired);
+      expect(wrapper.find('#signin-sso-hint').text()).toContain(COPY.availabilityUnavailable);
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -521,6 +553,11 @@ describe('DomainSigninConfigForm', () => {
   // credentials, so SSO can never activate on the domain. An operable
   // "Enabled" toggle next to the "Upgrade to configure" lock contradicted
   // that (and persisted a flag that could never take effect).
+  //
+  // The lock is expressed by :disabled ONLY. :enabled still reports the
+  // stored value — manage_sso governs who may configure tenant SSO, not
+  // whether it runs, so blanking the toggle would misreport a domain whose
+  // SSO is live.
   // -----------------------------------------------------------------------
 
   describe('entitlement gating: canManageSso=false locks SSO controls', () => {
@@ -529,12 +566,13 @@ describe('DomainSigninConfigForm', () => {
       expect(toggles(wrapper)[1].attributes('disabled')).toBeDefined();
     });
 
-    it('forces the sso toggle visually off even if formState says enabled', () => {
+    it('still reports the stored sso value while locked (disabled, not blanked)', () => {
       wrapper = mountForm({
         canManageSso: false,
         formState: { ...defaultFormState, sso_enabled: true },
       });
-      expect(toggles(wrapper)[1].attributes('aria-checked')).toBe('false');
+      expect(toggles(wrapper)[1].attributes('aria-checked')).toBe('true');
+      expect(toggles(wrapper)[1].attributes('disabled')).toBeDefined();
     });
 
     it('leaves the email toggle operable', () => {
@@ -703,7 +741,8 @@ describe('DomainSigninConfigForm', () => {
         // restrict_to value, which would render a blank login page.
         wrapper = mountForm({
           formState: { ...defaultFormState, restrict_to: 'password' },
-          globalAvailability: { email_auth: false, webauthn: false, sso: false },
+          globalAvailability: { email_auth: false, webauthn: false },
+          orgsSsoEnabled: false,
         });
         expect(wrapper.findAll('input[type="radio"][name="restrict_to"]')).toHaveLength(1);
       });
@@ -731,15 +770,24 @@ describe('DomainSigninConfigForm', () => {
         expect(wrapper.find('#signin-email-auth-hint').text()).toContain(COPY.allowOnDomain);
       });
 
-      it('disables the sso toggle and shows "Unavailable" reason when sso is off', () => {
-        wrapper = mountForm({ globalAvailability: { ...allAvailable, sso: false } });
+      it('disables the sso toggle and shows "Unavailable" reason when ORGS_SSO_ENABLED is off', () => {
+        wrapper = mountForm({ orgsSsoEnabled: false });
         expect(toggles(wrapper)[1].attributes('disabled')).toBeDefined();
         expect(wrapper.find('#signin-sso-hint').text()).toContain(COPY.availabilityUnavailable);
       });
 
       it('shows "Allow on this domain" reason for sso when available', () => {
-        wrapper = mountForm({ globalAvailability: allAvailable });
+        wrapper = mountForm({ orgsSsoEnabled: true });
         expect(wrapper.find('#signin-sso-hint').text()).toContain(COPY.allowOnDomain);
+      });
+
+      it('keeps the sso toggle operable when platform SSO is off but ORGS_SSO_ENABLED is on', () => {
+        // The axis fix: bootstrap `features.sso` (platform AUTH_SSO_ENABLED,
+        // resolved against the workspace host) must have NO bearing on the
+        // tenant-SSO toggle. It is no longer a prop at all, so an install with
+        // platform SSO off leaves this toggle live.
+        wrapper = mountForm({ orgsSsoEnabled: true, canManageSso: true });
+        expect(toggles(wrapper)[1].attributes('disabled')).toBeUndefined();
       });
 
       it('forces the email toggle visually off when globally unavailable, even if formState says enabled', () => {
@@ -752,12 +800,23 @@ describe('DomainSigninConfigForm', () => {
         expect(toggles(wrapper)[0].attributes('aria-checked')).toBe('false');
       });
 
-      it('forces the sso toggle visually off when globally unavailable, even if formState says enabled', () => {
+      it('reports the STORED sso value even when the management gates are off', () => {
+        // NOT the email AND-semantics case. email_auth_enabled is ANDed with a
+        // real install kill switch, so `stored && global` IS its effective
+        // state. Tenant SSO is different: the runtime ladder
+        // (SsoConfig.tenant_sso_unavailable_reason) gates on the SsoConfig
+        // record and sso_permitted_for? — never on ORGS_SSO_ENABLED or
+        // manage_sso, which only govern who may CONFIGURE it. A domain whose
+        // stored sso_enabled is true is running tenant SSO right now, so the
+        // toggle must not render OFF and misreport persisted state. It stays
+        // disabled (see :disabled), just truthful.
         wrapper = mountForm({
           formState: { ...defaultFormState, sso_enabled: true },
-          globalAvailability: { ...allAvailable, sso: false },
+          orgsSsoEnabled: false,
+          canManageSso: false,
         });
-        expect(toggles(wrapper)[1].attributes('aria-checked')).toBe('false');
+        expect(toggles(wrapper)[1].attributes('aria-checked')).toBe('true');
+        expect(toggles(wrapper)[1].attributes('disabled')).toBeDefined();
       });
     });
   });
@@ -958,10 +1017,10 @@ describe('DomainSigninConfigForm', () => {
   // -----------------------------------------------------------------------
 
   describe('global availability gating', () => {
-    it('omits the SSO radio in Mode B when SSO is globally off', () => {
+    it('omits the SSO radio in Mode B when ORGS_SSO_ENABLED is off', () => {
       wrapper = mountForm({
         formState: { ...defaultFormState, restrict_to: 'password' },
-        globalAvailability: { ...allAvailable, sso: false },
+        orgsSsoEnabled: false,
       });
       expect(wrapper.find('#signin-restrict-sso').exists()).toBe(false);
     });
@@ -977,7 +1036,8 @@ describe('DomainSigninConfigForm', () => {
     it('always offers Password in Mode B even if everything else is off', () => {
       wrapper = mountForm({
         formState: { ...defaultFormState, restrict_to: 'password' },
-        globalAvailability: { email_auth: false, webauthn: false, sso: false },
+        globalAvailability: { email_auth: false, webauthn: false },
+        orgsSsoEnabled: false,
       });
       expect(wrapper.find('#signin-restrict-password').exists()).toBe(true);
     });

--- a/src/tests/apps/workspace/components/domains/DomainSigninConfigForm.spec.ts
+++ b/src/tests/apps/workspace/components/domains/DomainSigninConfigForm.spec.ts
@@ -1025,6 +1025,28 @@ describe('DomainSigninConfigForm', () => {
       expect(wrapper.find('#signin-restrict-sso').exists()).toBe(false);
     });
 
+    it('keeps the SSO radio visible-but-locked when it is the CURRENT restriction', () => {
+      // Omitting the selected method would render a radiogroup with nothing
+      // checked, hiding the fact that the domain is restricted to SSO.
+      wrapper = mountForm({
+        formState: { ...defaultFormState, restrict_to: 'sso' },
+        orgsSsoEnabled: false,
+      });
+      const radio = wrapper.find('#signin-restrict-sso');
+      expect(radio.exists()).toBe(true);
+      expect((radio.element as HTMLInputElement).checked).toBe(true);
+      expect(radio.attributes('disabled')).toBeDefined();
+    });
+
+    it('cannot re-select SSO from the locked row', async () => {
+      wrapper = mountForm({
+        formState: { ...defaultFormState, restrict_to: 'sso' },
+        orgsSsoEnabled: false,
+      });
+      await wrapper.find('#signin-restrict-sso').trigger('change');
+      expect(wrapper.emitted('auto-save')).toBeFalsy();
+    });
+
     it('omits the WebAuthn radio in Mode B when WebAuthn is globally off', () => {
       wrapper = mountForm({
         formState: { ...defaultFormState, restrict_to: 'password' },

--- a/src/tests/apps/workspace/components/domains/DomainSigninConfigForm.spec.ts
+++ b/src/tests/apps/workspace/components/domains/DomainSigninConfigForm.spec.ts
@@ -1243,7 +1243,12 @@ describe('DomainSigninConfigForm', () => {
   //
   // Existing tests cover Mode A (button + emit, upgrade hint) and Mode B
   // (button reachable + emit). Gap: Mode B with canManageSso=false must show
-  // the upgrade hint and NO Configure button, same as Mode A.
+  // the upgrade hint and NO Configure button, same as Mode A. And like Mode A,
+  // Configure needs BOTH write-endpoint gates: restrict_to='sso' keeps the SSO
+  // row visible when ORGS_SSO_ENABLED is off (visible-but-locked invariant),
+  // so its Configure button must not survive on canManageSso alone — the modal
+  // save would be rejected ("Organization SSO is not enabled on this
+  // instance").
   // -----------------------------------------------------------------------
 
   describe('SSO configure across modes', () => {
@@ -1257,6 +1262,40 @@ describe('DomainSigninConfigForm', () => {
         .findAll('button')
         .find((b) => b.text().includes(COPY.configure) || b.text().includes(COPY.editCredentials));
       expect(configureBtn).toBeUndefined();
+    });
+
+    it('Mode B hides Configure when ORGS_SSO_ENABLED is off, even with the entitlement — and does not blame the plan', () => {
+      // Mirror of Mode A's wrong-blame guard: "Upgrade to configure" would
+      // name the wrong cause — no plan unlocks an operator's ORGS_SSO_ENABLED.
+      // With the entitlement present and only the install flag off, the locked
+      // SSO row renders neither the button nor the upgrade hint.
+      wrapper = mountForm({
+        formState: { ...defaultFormState, restrict_to: 'sso' },
+        canManageSso: true,
+        orgsSsoEnabled: false,
+      });
+      const configureBtn = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes(COPY.configure) || b.text().includes(COPY.editCredentials));
+      expect(configureBtn).toBeUndefined();
+      expect(wrapper.text()).not.toContain(COPY.upgradeRequired);
+    });
+
+    it('Mode B with both gates off hides Configure and keeps the upgrade hint', () => {
+      // Deliberate v-else-if="!canManageSso" semantics: the hint keys on the
+      // entitlement alone, so it still shows when the install flag is ALSO off
+      // — acceptable, because the entitlement is genuinely missing too and an
+      // upgrade is a real (if not sufficient) step toward configuring.
+      wrapper = mountForm({
+        formState: { ...defaultFormState, restrict_to: 'sso' },
+        canManageSso: false,
+        orgsSsoEnabled: false,
+      });
+      const configureBtn = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes(COPY.configure) || b.text().includes(COPY.editCredentials));
+      expect(configureBtn).toBeUndefined();
+      expect(wrapper.text()).toContain(COPY.upgradeRequired);
     });
 
     it('Configure label reflects ssoConfigured (Edit credentials when configured)', () => {

--- a/src/tests/composables/useSigninConfig.spec.ts
+++ b/src/tests/composables/useSigninConfig.spec.ts
@@ -1108,7 +1108,7 @@ describe('useSigninConfig', () => {
       expect(composable.formState.value.restrict_to).toBe('sso');
     });
 
-    it('seeds method flags from global availability (AND semantics: a globally-off method seeds as off, not on)', async () => {
+    it('seeds email_auth from global availability (AND semantics: a globally-off method seeds as off, not on)', async () => {
       mockFeatures.value = { email_auth: false, webauthn: true, sso: { enabled: false } };
       // Unconfigured domain, SSO globally off → no carve-out: default-off
       // resolver output (#3814).
@@ -1121,7 +1121,49 @@ describe('useSigninConfig', () => {
       await composable.initialize();
 
       expect(composable.formState.value.email_auth_enabled).toBe(false);
-      expect(composable.formState.value.sso_enabled).toBe(false);
+    });
+
+    it('seeds sso_enabled true regardless of the PLATFORM sso feature flag', async () => {
+      // sso_enabled is the TENANT-SSO activation gate consumed by
+      // SigninConfig.sso_permitted_for?, which returns true unconditionally
+      // while no config is enabled — so `true` is the inherited state for
+      // every unconfigured domain. Bootstrap `features.sso` is the unrelated
+      // PLATFORM switch (AUTH_SSO_ENABLED, resolved against the workspace
+      // host); seeding from it is what let an autosave persist
+      // sso_enabled: false and take a domain's live tenant SSO down.
+      mockFeatures.value = { email_auth: true, webauthn: true, sso: { enabled: false } };
+      mockGetConfigForDomain.mockResolvedValue({
+        record: null,
+        details: { global_enabled: true, effective_enabled: false, global_restrict_to: null },
+      });
+
+      const composable = useSigninConfig('dm-ext-123');
+      await composable.initialize();
+
+      expect(composable.formState.value.sso_enabled).toBe(true);
+    });
+
+    it('an unrelated autosave on an unconfigured domain never persists sso_enabled: false', async () => {
+      // The regression proof for the data bug. Platform SSO off, domain
+      // unconfigured; the user flips the email toggle — the first thing that
+      // materializes an explicit override. The PUT must not carry
+      // sso_enabled: false, which would flip sso_permitted_for? to false and
+      // dark the domain's tenant SSO buttons. Same failure class as the
+      // PR #3817 signin_enabled bug.
+      mockFeatures.value = { email_auth: true, webauthn: true, sso: { enabled: false } };
+      mockGetConfigForDomain.mockResolvedValue({
+        record: null,
+        details: { global_enabled: true, effective_enabled: true, global_restrict_to: null },
+      });
+
+      const composable = useSigninConfig('dm-ext-123');
+      await composable.initialize();
+      await composable.autoSaveField('email_auth_enabled', false);
+
+      expect(mockPutConfigForDomain).toHaveBeenCalledWith(
+        'dm-ext-123',
+        expect.objectContaining({ enabled: true, sso_enabled: true, email_auth_enabled: false })
+      );
     });
 
     it('an explicit record wins over seeding (explicit: formState comes from the stored override, not the inherited state)', async () => {


### PR DESCRIPTION
Per-domain sign-in SSO controls at /org/:orgid/domains/:extid/signin read the platform SSO flag (AUTH_SSO_ENABLED) instead of tenant SSO (ORGS_SSO_ENABLED + manage_sso), the only surface still on that axis. sso_enabled was also seeded from the platform flag, so the page's auto-save PUT could persist sso_enabled: false and disable a domain's working tenant SSO on the first edit to any field.

- Drop sso from GlobalMethodAvailability; gate on isOrgsSsoEnabled() instead
- Seed sso_enabled from the backend authority, not features.sso
- Report the stored sso_enabled on the toggle; express the configure-lock via :disabled alone
- Require both manage_sso and features.organizations.sso_enabled before offering "Configure"
- Keep the SSO row visible (locked) when it is the current restriction, so a stored restrict_to: 'sso' isn't rendered as an empty radiogroup

Existing domains with a stored sso_enabled: false from the seed bug are not rewritten; the toggle is now operable so they can be restored.