### PR TITLE
[#3856] Close account-enumeration oracle in invite signup

### DIFF
--- a/apps/api/invite/logic/invites/signup_and_accept.rb
+++ b/apps/api/invite/logic/invites/signup_and_accept.rb
@@ -24,8 +24,9 @@ module InviteAPI::Logic
     # Flow:
     # 1. Validates the invite token (pending, not expired)
     # 2. Derives email from token (NOT user-provided - security)
-    # 3. Checks if email exists in EITHER database -> error with signin hint
-    # 4. Validates password meets requirements
+    # 3. Validates password meets requirements
+    # 4. Checks if email exists in EITHER database -> generic error that does
+    #    not confirm account existence (see SIGNUP_UNAVAILABLE_MESSAGE)
     # 5. Creates account in authdb via Rodauth internal_request
     #    (the after_create_account hook creates the Customer, auto-verifies
     #    the SQL account, and skips default-workspace creation)
@@ -39,6 +40,14 @@ module InviteAPI::Logic
     #
     class SignupAndAccept < InviteAPI::Logic::Base
       include Onetime::LoggerMethods
+
+      # Anti-enumeration (#3856): this message is returned whenever signup
+      # cannot proceed for an email that already has an account, but it is
+      # phrased conditionally and carries a generic error_type so the response
+      # never *asserts* account existence. See raise_signup_unavailable.
+      SIGNUP_UNAVAILABLE_MESSAGE = 'Unable to complete signup for this ' \
+        'invitation. If you already have an account, sign in and then open ' \
+        'your invitation link again.'
 
       attr_reader :invitation, :customer
 
@@ -77,26 +86,26 @@ module InviteAPI::Logic
           raise_form_error('Invitation has expired', field: :token)
         end
 
-        # Check if email already exists in authdb (SQLite/PostgreSQL)
-        if email_exists_in_authdb?(@email)
-          raise_form_error(
-            'An account with this email already exists. Please sign in instead.',
-            field: :email,
-            error_type: 'account_exists',
-          )
-        end
-
-        # Check if email already exists in Redis (Customer)
-        if Onetime::Customer.email_exists?(@email)
-          raise_form_error(
-            'An account with this email already exists. Please sign in instead.',
-            field: :email,
-            error_type: 'account_exists',
-          )
-        end
-
-        # Validate password meets requirements
+        # Validate password BEFORE the account-existence checks (#3856).
+        # With this ordering, a request with an invalid password gets the
+        # identical password_too_short error whether or not the invited email
+        # already has an account — closing the cheap, non-destructive
+        # enumeration probe (junk password in, read the error_type out).
         validate_password_requirements!(@password)
+
+        # Check if email already exists in EITHER database (authdb + Redis).
+        #
+        # Anti-enumeration posture (#3856, aligns with the AZ7 hardening on
+        # ShowInvite): the error below is generic — same message and
+        # error_type regardless of which store matched — and never carries an
+        # account_exists signal. Residual: with a valid password, "exists"
+        # (this error) is still distinguishable from "does not exist" (signup
+        # succeeds); that is inherent to any signup endpoint and probing it is
+        # destructive and noisy — it creates the account and emails the
+        # invitee. Compensating control: InviteTokenRateLimiter above.
+        if email_exists_in_authdb?(@email) || Onetime::Customer.email_exists?(@email)
+          raise_signup_unavailable
+        end
       end
 
       def process
@@ -169,6 +178,20 @@ module InviteAPI::Logic
         OT::Utils.normalize_email(email)
       end
 
+      # Single chokepoint for the "email already has an account" outcome so
+      # every path (authdb pre-check, Redis pre-check, Rodauth create race)
+      # returns a byte-identical response. Deliberately: no field (the email
+      # is token-derived, not a submitted field), a conditional message, and
+      # a generic error_type — the frontend keys its sign-in fallback off
+      # error_type 'signup_unavailable' without the server confirming that an
+      # account exists (#3856).
+      def raise_signup_unavailable
+        raise_form_error(
+          SIGNUP_UNAVAILABLE_MESSAGE,
+          error_type: 'signup_unavailable',
+        )
+      end
+
       # Check if email exists in authdb (SQLite/PostgreSQL)
       def email_exists_in_authdb?(email)
         normalized = normalize_email(email)
@@ -233,6 +256,12 @@ module InviteAPI::Logic
         # Parse field errors from Rodauth
         if ex.field_errors&.any?
           field, message = ex.field_errors.first
+          # An account created between our pre-check and Rodauth's insert
+          # surfaces here as "already an account with this login". Map it to
+          # the same generic response as the pre-check so the race window
+          # doesn't reopen the account-existence oracle (#3856).
+          raise_signup_unavailable if message.to_s.match?(/already an account/i)
+
           raise_form_error(message, field: field.to_sym)
         else
           raise_form_error(ex.flash || 'Failed to create account', field: :email)

--- a/apps/api/invite/logic/invites/signup_and_accept.rb
+++ b/apps/api/invite/logic/invites/signup_and_accept.rb
@@ -262,9 +262,14 @@ module InviteAPI::Logic
           # doesn't reopen the account-existence oracle (#3856).
           raise_signup_unavailable if message.to_s.match?(/already an account/i)
 
-          raise_form_error(message, field: field.to_sym)
+          # Sentinel error_type so clients keying on it never see it absent
+          # from this endpoint. Rodauth doesn't supply machine-readable codes
+          # for its validation rules, so a generic sentinel is the best we
+          # can forward without message-sniffing.
+          raise_form_error(message, field: field.to_sym, error_type: 'validation_error')
         else
-          raise_form_error(ex.flash || 'Failed to create account', field: :email)
+          raise_form_error(ex.flash || 'Failed to create account',
+            field: :email, error_type: 'validation_error')
         end
       end
 

--- a/apps/api/invite/spec/logic/invites/signup_and_accept_spec.rb
+++ b/apps/api/invite/spec/logic/invites/signup_and_accept_spec.rb
@@ -9,7 +9,9 @@
 # This endpoint handles organization invite signups. It:
 # - Validates invite token (must be pending, not expired)
 # - Derives email from token (email not user-provided)
-# - Checks if account already exists in authdb or Redis
+# - Validates the password BEFORE any account-existence check (#3856)
+# - Checks if account already exists in authdb or Redis -> generic
+#   signup_unavailable error that does not confirm account existence
 # - Creates account + customer + default workspace
 # - Accepts the invitation (adds user to organization)
 # - Auto-logins the user
@@ -253,6 +255,10 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
       end
     end
 
+    # Anti-enumeration posture (#3856): when the invited email already has an
+    # account, the response must be generic — same message and error_type for
+    # both stores, no account_exists signal, no assertion that an account
+    # exists. See raise_signup_unavailable in the logic class.
     context 'when account already exists in authdb' do
       before do
         allow(Onetime::OrganizationMembership).to receive(:find_by_token)
@@ -268,8 +274,13 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
 
       subject(:logic) { described_class.new(strategy_result, valid_params) }
 
-      it 'raises form error indicating account exists' do
-        expect { logic.raise_concerns }.to raise_error(Onetime::FormError, /already exists/i)
+      it 'raises the generic signup_unavailable error without confirming account existence' do
+        expect { logic.raise_concerns }.to raise_error(Onetime::FormError) do |err|
+          expect(err.message).to eq(described_class::SIGNUP_UNAVAILABLE_MESSAGE)
+          expect(err.error_type).to eq('signup_unavailable')
+          expect(err.field).to be_nil
+          expect(err.message).not_to match(/already exists/i)
+        end
       end
     end
 
@@ -285,8 +296,82 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
 
       subject(:logic) { described_class.new(strategy_result, valid_params) }
 
-      it 'raises form error indicating account exists' do
-        expect { logic.raise_concerns }.to raise_error(Onetime::FormError, /already exists/i)
+      it 'raises the generic signup_unavailable error without confirming account existence' do
+        expect { logic.raise_concerns }.to raise_error(Onetime::FormError) do |err|
+          expect(err.message).to eq(described_class::SIGNUP_UNAVAILABLE_MESSAGE)
+          expect(err.error_type).to eq('signup_unavailable')
+          expect(err.field).to be_nil
+        end
+      end
+    end
+
+    # Regression for #3856: the two existence stores must be indistinguishable
+    # from each other, and an invalid-password probe must be indistinguishable
+    # across "account exists" and "no account".
+    context 'enumeration hardening (#3856)' do
+      subject(:logic) { described_class.new(strategy_result, valid_params) }
+
+      before do
+        allow(Onetime::OrganizationMembership).to receive(:find_by_token)
+          .with(invite_token)
+          .and_return(invitation)
+      end
+
+      def capture_form_error(logic_instance)
+        logic_instance.raise_concerns
+        nil
+      rescue Onetime::FormError => ex
+        ex
+      end
+
+      def stub_authdb_exists(exists)
+        accounts_ds = double('accounts_dataset')
+        allow(accounts_ds).to receive(:where).and_return(accounts_ds)
+        allow(accounts_ds).to receive(:any?).and_return(exists)
+        allow(mock_auth_db).to receive(:[]).with(:accounts).and_return(accounts_ds)
+      end
+
+      it 'returns an identical error payload whether the account lives in authdb or Redis' do
+        stub_authdb_exists(true)
+        authdb_error = capture_form_error(described_class.new(strategy_result, valid_params))
+
+        stub_authdb_exists(false)
+        allow(Onetime::Customer).to receive(:email_exists?)
+          .with(normalized_email)
+          .and_return(true)
+        redis_error = capture_form_error(described_class.new(strategy_result, valid_params))
+
+        expect(authdb_error).not_to be_nil
+        expect(redis_error).not_to be_nil
+        expect(authdb_error.to_h).to eq(redis_error.to_h)
+      end
+
+      it 'never uses the account_exists error_type' do
+        stub_authdb_exists(true)
+        err = capture_form_error(described_class.new(strategy_result, valid_params))
+
+        expect(err.error_type).not_to eq('account_exists')
+      end
+
+      it 'returns the identical password error whether or not the account exists' do
+        weak_params = valid_params.merge('password' => weak_password)
+
+        # Account exists: the password check must fire first, so the probe
+        # learns nothing from the existence branch.
+        stub_authdb_exists(true)
+        exists_error = capture_form_error(described_class.new(strategy_result, weak_params))
+
+        # No account anywhere:
+        stub_authdb_exists(false)
+        allow(Onetime::Customer).to receive(:email_exists?)
+          .with(normalized_email)
+          .and_return(false)
+        fresh_error = capture_form_error(described_class.new(strategy_result, weak_params))
+
+        expect(exists_error).not_to be_nil
+        expect(fresh_error).not_to be_nil
+        expect(exists_error.error_type).to eq('password_too_short')
+        expect(exists_error.to_h).to eq(fresh_error.to_h)
       end
     end
 
@@ -497,6 +582,27 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
       end
     end
 
+    context 'when Rodauth reports the login is already taken (create race, #3856)' do
+      # An account created between the raise_concerns pre-check and Rodauth's
+      # insert surfaces as an InternalRequestError with a "already an account
+      # with this login" field error. That path must return the same generic
+      # signup_unavailable error as the pre-check so the race window doesn't
+      # reopen the account-existence oracle.
+      before do
+        race_error              = Rodauth::InternalRequestError.new('There was an error creating your account')
+        race_error.field_errors = { 'login' => 'already an account with this login' }
+        allow(Auth::Config).to receive(:create_account).and_raise(race_error)
+        logic.raise_concerns
+      end
+
+      it 'raises the same generic signup_unavailable error as the pre-check' do
+        expect { logic.process }.to raise_error(Onetime::FormError) do |err|
+          expect(err.message).to eq(described_class::SIGNUP_UNAVAILABLE_MESSAGE)
+          expect(err.error_type).to eq('signup_unavailable')
+        end
+      end
+    end
+
     context 'when the account row is missing after create_account' do
       # Mirrors signup_and_accept.rb:228 — create_account succeeded with no
       # error, but the followup .where(email: ...).first lookup returns nil.
@@ -573,7 +679,7 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
     it 'POST /api/invite/:token/signup returns 200 with organization details'
     it 'POST /api/invite/:token/signup returns 404 for non-existent token'
     it 'POST /api/invite/:token/signup returns 422 for expired invitation'
-    it 'POST /api/invite/:token/signup returns 422 when account already exists'
+    it 'POST /api/invite/:token/signup returns 422 with the generic signup_unavailable error when the email already has an account'
     it 'POST /api/invite/:token/signup returns 429 when rate limited'
   end
 end

--- a/apps/api/invite/spec/logic/invites/signup_and_accept_spec.rb
+++ b/apps/api/invite/spec/logic/invites/signup_and_accept_spec.rb
@@ -603,6 +603,27 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
       end
     end
 
+    context 'when Rodauth rejects the signup for a non-race validation reason' do
+      # Any other Rodauth validation rule (a server-side password plugin, a
+      # login-format rejection) forwards the field error with the generic
+      # 'validation_error' sentinel, so clients keying on error_type never
+      # see it absent from this endpoint.
+      before do
+        validation_error              = Rodauth::InternalRequestError.new('There was an error creating your account')
+        validation_error.field_errors = { 'password' => 'invalid password, does not meet requirements' }
+        allow(Auth::Config).to receive(:create_account).and_raise(validation_error)
+        logic.raise_concerns
+      end
+
+      it 'forwards the field error with the validation_error sentinel' do
+        expect { logic.process }.to raise_error(Onetime::FormError) do |err|
+          expect(err.message).to eq('invalid password, does not meet requirements')
+          expect(err.field).to eq(:password)
+          expect(err.error_type).to eq('validation_error')
+        end
+      end
+    end
+
     context 'when the account row is missing after create_account' do
       # Mirrors signup_and_accept.rb:228 — create_account succeeded with no
       # error, but the followup .where(email: ...).first lookup returns nil.

--- a/changelog.d/20260729_120000_claude_3856_invite_signup_enumeration.rst
+++ b/changelog.d/20260729_120000_claude_3856_invite_signup_enumeration.rst
@@ -1,0 +1,23 @@
+.. A new scriv changelog fragment.
+
+Security
+--------
+
+- Closed the account-enumeration oracle in the invite signup endpoint
+  (``POST /api/invite/:token/signup``). It previously returned a distinct
+  ``account_exists`` error when the invited email already had an account,
+  re-opening the oracle the AZ7 hardening removed from the sibling
+  show-invite endpoint — exploitable by any registered user who invites a
+  target address and probes the token. The endpoint now validates the
+  password before any account-existence check (an invalid-password probe
+  gets a byte-identical error whether or not the account exists) and
+  collapses all existing-account outcomes — authdb pre-check, Redis
+  pre-check, and the Rodauth create race — into one generic
+  ``signup_unavailable`` error whose conditional message never confirms
+  account existence. The frontend keys its sign-in fallback off that
+  error_type instead of sniffing the message text, so the invitee UX is
+  unchanged. Residual: with a valid password, "exists" remains
+  distinguishable from a successful signup — inherent to any signup
+  endpoint, and probing it is destructive and noisy (creates the account,
+  emails the invitee); the per-IP ``InviteTokenRateLimiter`` bounds it.
+  (#3856)

--- a/docs/product/organization-invites.md
+++ b/docs/product/organization-invites.md
@@ -52,7 +52,7 @@ Acceptance is **always an explicit user click**. Signup/signin establishes auth;
 | POST | `/api/org/:extid/invitations/:token/resend` | sessionauth (admin) | `OrganizationAPI::Logic::Invitations::ResendInvitation` |
 | DELETE | `/api/org/:extid/invitations/:token` | sessionauth (admin) | `OrganizationAPI::Logic::Invitations::RevokeInvitation` |
 
-`ShowInvite` returns structured responses for *every* invitation state (pending/accepted/declined/expired). Only truly unknown tokens 404. The response carries computed flags `actionable` and `account_exists` so the frontend can branch without a second round-trip.
+`ShowInvite` returns structured responses for *every* invitation state (pending/accepted/declined/expired). Only truly unknown tokens 404. The response carries a computed `actionable` flag so the frontend can branch without a second round-trip. It deliberately carries **no** `account_exists` flag (AZ7 anti-enumeration hardening): unauthenticated visitors always start in the signup flow, and the frontend falls back to signin only when the signup endpoint returns its generic `signup_unavailable` error (#3856) — which likewise never confirms account existence.
 
 ## Dimensions we track
 
@@ -65,7 +65,7 @@ Reference: industry comparison across 10 SaaS products (Clerk, GitHub, Slack, No
 | Token lifecycle | New token on resend (old invalidated) | `ResendInvitation` calls `generate_token!`, max 3 resends |
 | Role at invite | Set at invite (`through_attrs[:role]`) | Majority pattern |
 | Account creation | Embedded in flow | Inline `InviteSignUpForm` / `InviteSignInForm` |
-| Account-exists branching | Returned in `ShowInvite` response (`account_exists`) | Same pattern as Clerk `__clerk_status`, WorkOS user-exists fork |
+| Account-exists branching | Not disclosed by the API (AZ7/#3856) | Signup is the default path; frontend falls back to signin on the generic `signup_unavailable` error. Differs from Clerk `__clerk_status` / WorkOS user-exists fork by design (anti-enumeration) |
 | Admin confirmation | Not required (`requires_admin_approval?` hardcoded `false`) | Branch exists in `accept!` for the future approval workflow |
 | Email match | Strict, case-insensitive | Enforced in `accept!` and at signup hook (`before_create_account`) — defense in depth |
 | Anti-enumeration | `InviteTokenRateLimiter` on GET (per-IP) | Mirrors GitHub verified-email matching, in spirit |

--- a/e2e/full/invite-flow-states.spec.ts
+++ b/e2e/full/invite-flow-states.spec.ts
@@ -187,10 +187,11 @@ test.describe('INV-001: New User Atomic Signup Flow', () => {
     await page.goto(`/invite/${token}`);
     await expect(page.locator('html[data-app-ready="true"]')).toBeAttached();
 
-    // Verify signup_required state is shown (account_exists: false)
+    // Verify signup_required state is shown (the unauthenticated default —
+    // the API never discloses whether an account exists, AZ7/#3856)
     const signupState = page.getByTestId('invite-signup-required');
-    // Note: If account_exists is true, we'll see signin-required instead
-    // This depends on whether the test email happens to exist
+    // Note: signin-required only appears after a signup attempt comes back
+    // with the generic signup_unavailable error
     const signinState = page.getByTestId('invite-signin-required');
 
     const isSignupRequired = await signupState.isVisible().catch(() => false);

--- a/src/apps/session/components/InviteSignUpForm.vue
+++ b/src/apps/session/components/InviteSignUpForm.vue
@@ -45,8 +45,11 @@ const emit = defineEmits<{
   (e: 'success'): void;
   (e: 'error', message: string): void;
   (e: 'decline'): void;
-  /** Emitted when signup fails because an account already exists for this email. */
-  (e: 'account-exists'): void;
+  /**
+   * Emitted when the backend reports signup is unavailable for this invitation
+   * (generic anti-enumeration error, #3856); parent should offer signin.
+   */
+  (e: 'signin-required'): void;
 }>();
 
 const { t } = useI18n();
@@ -181,9 +184,9 @@ const handleSubmit = async () => {
 
     if (result.success) {
       emit('success');
-    } else if (result.accountExists) {
-      // Account already exists - parent should switch to signin flow
-      emit('account-exists');
+    } else if (result.signinRequired) {
+      // Signup unavailable for this invitation - parent switches to signin flow
+      emit('signin-required');
     } else if (result.error) {
       emit('error', result.error);
     }

--- a/src/apps/session/composables/useInviteAuth.ts
+++ b/src/apps/session/composables/useInviteAuth.ts
@@ -28,10 +28,17 @@ export interface InviteAuthResult {
   signinRequired?: boolean;
 }
 
-/** Shape of API error responses */
+/**
+ * Shape of API error responses. Two producers share this composable:
+ * Rodauth (/auth/login) sends a `'field-error': [field, message]` tuple,
+ * while the InviteAPI's Onetime::FormError serializes as
+ * `{ error, error_type, field }` — a flat `field` naming the offending
+ * input, with `error` as the message.
+ */
 interface ApiErrorResponse {
   error?: string;
   error_type?: string;
+  field?: string;
   'field-error'?: [string, string];
 }
 
@@ -50,9 +57,15 @@ function extractErrorInfo(
 ): { message: string | null; fieldError?: [string, string] } {
   const errorData = data ?? err?.response?.data;
   if (errorData?.error) {
+    // Prefer the Rodauth tuple; fall back to FormError's flat `field`,
+    // pairing it with the top-level message. Errors without either (e.g.
+    // signup_unavailable, token errors shown globally) yield no fieldError.
+    const fieldError =
+      errorData['field-error'] ??
+      (errorData.field ? ([errorData.field, errorData.error] as [string, string]) : undefined);
     return {
       message: errorData.error,
-      fieldError: errorData['field-error'],
+      fieldError,
     };
   }
   return { message: err?.message ?? 'An error occurred' };

--- a/src/apps/session/composables/useInviteAuth.ts
+++ b/src/apps/session/composables/useInviteAuth.ts
@@ -19,13 +19,19 @@ export interface InviteAuthResult {
   error?: string | null;
   requiresMfa?: boolean;
   redirect?: string;
-  /** Set when signup fails because account already exists; caller should switch to signin. */
-  accountExists?: boolean;
+  /**
+   * Set when the backend reports signup is unavailable for this invitation
+   * (error_type 'signup_unavailable'); caller should offer the signin flow.
+   * Deliberately NOT named accountExists: the server does not confirm account
+   * existence (#3856 anti-enumeration posture), signin is simply the fallback.
+   */
+  signinRequired?: boolean;
 }
 
 /** Shape of API error responses */
 interface ApiErrorResponse {
   error?: string;
+  error_type?: string;
   'field-error'?: [string, string];
 }
 
@@ -102,8 +108,8 @@ export function useInviteAuth() {
    * pending state. The parent view transitions to the explicit Decline/Accept
    * screen and the user issues the /accept call themselves.
    *
-   * @returns InviteAuthResult with accountExists: true if the backend indicates
-   *          the account already exists (caller should switch to signin flow).
+   * @returns InviteAuthResult with signinRequired: true if the backend reports
+   *          signup is unavailable (caller should switch to signin flow).
    */
   async function signupForInvite(
     _email: string, // Kept for API compatibility; backend derives email from token
@@ -111,7 +117,7 @@ export function useInviteAuth() {
     termsAgreed: boolean,
     inviteToken: string,
     _skill: string = '' // Honeypot no longer sent to new endpoint
-  ): Promise<InviteAuthResult & { accountExists?: boolean }> {
+  ): Promise<InviteAuthResult> {
     isLoading.value = true;
     error.value = null;
     fieldErrors.value = {};
@@ -130,9 +136,11 @@ export function useInviteAuth() {
         const info = extractErrorInfo(response.data);
         setError(info);
 
-        // Check for "account exists" error to trigger signin flow
-        const accountExists = response.data.error?.toLowerCase().includes('already exists');
-        return { success: false, error: info.message, accountExists };
+        // Generic signup-unavailable error -> offer the signin flow. Keyed on
+        // error_type, not message text: the server no longer says whether an
+        // account exists (#3856).
+        const signinRequired = response.data.error_type === 'signup_unavailable';
+        return { success: false, error: info.message, signinRequired };
       }
 
       // Server set session cookie via create_account_autologin — sync frontend state.
@@ -149,10 +157,10 @@ export function useInviteAuth() {
       const info = extractErrorInfo(undefined, e as AxiosLikeError);
       setError(info);
 
-      // Check for "account exists" in error response
+      // Non-2xx path (FormError renders as 422): same error_type check.
       const axiosErr = e as AxiosLikeError;
-      const accountExists = axiosErr.response?.data?.error?.toLowerCase().includes('already exists');
-      return { success: false, error: info.message, accountExists };
+      const signinRequired = axiosErr.response?.data?.error_type === 'signup_unavailable';
+      return { success: false, error: info.message, signinRequired };
     } finally {
       isLoading.value = false;
     }

--- a/src/apps/session/views/AcceptInvite.vue
+++ b/src/apps/session/views/AcceptInvite.vue
@@ -56,8 +56,9 @@
    * - loading: Initial fetch in progress
    * - signup_required: Unauthenticated default (the API deliberately does not
    *   reveal whether an account exists — see show-invite schema note)
-   * - signin_required: Unauthenticated, account known to exist (discovered via
-   *   a failed signup attempt with an account-exists error)
+   * - signin_required: Unauthenticated, signup reported unavailable for this
+   *   invitation (generic signup_unavailable error, #3856) — signin is the
+   *   fallback path
    * - direct_accept: Authenticated with correct email, can accept immediately
    * - wrong_email: Authenticated but with different email than invitation
    * - already_accepted: Invitation was already accepted (status: active)
@@ -81,10 +82,11 @@
   // the action row from re-rendering during the redirect delay window.
   const actionResult = ref<'accepted' | 'declined' | null>(null);
 
-  // Whether we've learned (via a failed signup attempt) that an account
-  // already exists for the invited email. The show endpoint intentionally
-  // carries no account_exists signal, so signup is the default entry path.
-  const knownAccountExists = ref(false);
+  // Whether a signup attempt came back signup_unavailable, meaning signin is
+  // the remaining path. Neither the show endpoint nor the signup endpoint
+  // confirms account existence (AZ7 / #3856), so signup is the default entry
+  // path and this flag only flips on that generic backend signal.
+  const signinFallback = ref(false);
 
   const inviteState = computed<InviteState>(() => {
     if (isLoading.value) return 'loading';
@@ -101,7 +103,7 @@
 
     // Invitation is actionable (pending, not expired)
     if (!authStore.isAuthenticated) {
-      return knownAccountExists.value ? 'signin_required' : 'signup_required';
+      return signinFallback.value ? 'signin_required' : 'signup_required';
     }
 
     // User is authenticated
@@ -255,11 +257,11 @@
   }
 
   /**
-   * Handler for when signup fails because account already exists.
-   * Updates invitation state to trigger signin flow instead.
+   * Handler for when the backend reports signup is unavailable for this
+   * invitation. Updates invitation state to offer the signin flow instead.
    */
-  function onAccountExists() {
-    knownAccountExists.value = true;
+  function onSigninRequired() {
+    signinFallback.value = true;
   }
 </script>
 
@@ -456,7 +458,7 @@
         @success="onAuthSuccess"
         @error="onFormError"
         @decline="handleDecline"
-        @account-exists="onAccountExists" />
+        @signin-required="onSigninRequired" />
 
       <p v-if="invitation" class="mt-4 text-center text-sm text-gray-500 dark:text-gray-400">
         {{ t('web.organizations.invitations.expires_at') }}

--- a/src/tests/composables/useInviteAuth.spec.ts
+++ b/src/tests/composables/useInviteAuth.spec.ts
@@ -214,6 +214,39 @@ describe('useInviteAuth', () => {
       expect(fieldErrors.value).toEqual({ password: 'Password too weak' });
     });
 
+    it('populates fieldErrors from FormError-shaped responses (flat field key)', async () => {
+      // The InviteAPI serializes Onetime::FormError as { error, error_type,
+      // field } — no Rodauth 'field-error' tuple. The composable must map the
+      // flat field so InviteSignUpForm can mark the input invalid.
+      axiosMock.onPost('/api/invite/tok/signup').reply(422, {
+        error: 'Password must be at least 8 characters',
+        error_type: 'password_too_short',
+        field: 'password',
+      });
+
+      const { signupForInvite, error, fieldErrors } = useInviteAuth();
+      const result = await signupForInvite('u@e.com', 'short', true, 'tok');
+
+      expect(result.success).toBe(false);
+      expect(error.value).toBe('Password must be at least 8 characters');
+      expect(fieldErrors.value).toEqual({ password: 'Password must be at least 8 characters' });
+    });
+
+    it('leaves fieldErrors empty for FormError responses without a field (signup_unavailable)', async () => {
+      // signup_unavailable deliberately carries no field (#3856) — the error
+      // is global, not attached to an input.
+      axiosMock.onPost('/api/invite/tok/signup').reply(422, {
+        error: 'Unable to complete signup for this invitation. If you already have an account, sign in and then open your invitation link again.',
+        error_type: 'signup_unavailable',
+      });
+
+      const { signupForInvite, fieldErrors } = useInviteAuth();
+      const result = await signupForInvite('u@e.com', 'pw12345678', true, 'tok');
+
+      expect(result.success).toBe(false);
+      expect(fieldErrors.value).toEqual({});
+    });
+
     it('returns signinRequired: true on the generic signup_unavailable error_type', async () => {
       // #3856: the backend responds with a generic error that does not confirm
       // account existence; the signin fallback keys off error_type alone.

--- a/src/tests/composables/useInviteAuth.spec.ts
+++ b/src/tests/composables/useInviteAuth.spec.ts
@@ -208,13 +208,44 @@ describe('useInviteAuth', () => {
       const { signupForInvite, error, fieldErrors } = useInviteAuth();
       const result = await signupForInvite('dup@e.com', 'pw12345678', true, 'tok');
 
-      // accountExists is always returned (false unless error contains "already exists")
-      expect(result).toEqual({ success: false, error: 'Unable to create account', accountExists: false });
+      // signinRequired is always returned (false unless error_type is signup_unavailable)
+      expect(result).toEqual({ success: false, error: 'Unable to create account', signinRequired: false });
       expect(error.value).toBe('Unable to create account');
       expect(fieldErrors.value).toEqual({ password: 'Password too weak' });
     });
 
-    it('returns accountExists: true when server indicates account already exists', async () => {
+    it('returns signinRequired: true on the generic signup_unavailable error_type', async () => {
+      // #3856: the backend responds with a generic error that does not confirm
+      // account existence; the signin fallback keys off error_type alone.
+      axiosMock.onPost('/api/invite/tok/signup').reply(200, {
+        error: 'Unable to complete signup for this invitation. If you already have an account, sign in and then open your invitation link again.',
+        error_type: 'signup_unavailable',
+      });
+
+      const { signupForInvite } = useInviteAuth();
+      const result = await signupForInvite('existing@e.com', 'pw12345678', true, 'tok');
+
+      expect(result.success).toBe(false);
+      expect(result.signinRequired).toBe(true);
+    });
+
+    it('returns signinRequired: true when signup_unavailable arrives as a 422', async () => {
+      // FormError renders as HTTP 422, so axios rejects and the catch path
+      // must apply the same error_type check.
+      axiosMock.onPost('/api/invite/tok/signup').reply(422, {
+        error: 'Unable to complete signup for this invitation. If you already have an account, sign in and then open your invitation link again.',
+        error_type: 'signup_unavailable',
+      });
+
+      const { signupForInvite } = useInviteAuth();
+      const result = await signupForInvite('existing@e.com', 'pw12345678', true, 'tok');
+
+      expect(result.success).toBe(false);
+      expect(result.signinRequired).toBe(true);
+    });
+
+    it('does not flip signinRequired on message text mentioning existing accounts', async () => {
+      // Regression (#3856): detection must not sniff the message string.
       axiosMock.onPost('/api/invite/tok/signup').reply(200, {
         error: 'An account already exists with this email',
       });
@@ -223,7 +254,7 @@ describe('useInviteAuth', () => {
       const result = await signupForInvite('existing@e.com', 'pw12345678', true, 'tok');
 
       expect(result.success).toBe(false);
-      expect(result.accountExists).toBe(true);
+      expect(result.signinRequired).toBe(false);
     });
 
     it('does not call setAuthenticated on server error response', async () => {

--- a/src/tests/composables/useInviteAuth.spec.ts
+++ b/src/tests/composables/useInviteAuth.spec.ts
@@ -200,9 +200,12 @@ describe('useInviteAuth', () => {
     });
 
     it('returns error when server responds with error field', async () => {
+      // FormError shape (flat `field` key) — the InviteAPI never emits the
+      // Rodauth 'field-error' tuple; that shape belongs to /auth/login.
       axiosMock.onPost('/api/invite/tok/signup').reply(200, {
         error: 'Unable to create account',
-        'field-error': ['password', 'Password too weak'],
+        error_type: 'validation_error',
+        field: 'password',
       });
 
       const { signupForInvite, error, fieldErrors } = useInviteAuth();
@@ -211,7 +214,7 @@ describe('useInviteAuth', () => {
       // signinRequired is always returned (false unless error_type is signup_unavailable)
       expect(result).toEqual({ success: false, error: 'Unable to create account', signinRequired: false });
       expect(error.value).toBe('Unable to create account');
-      expect(fieldErrors.value).toEqual({ password: 'Password too weak' });
+      expect(fieldErrors.value).toEqual({ password: 'Unable to create account' });
     });
 
     it('populates fieldErrors from FormError-shaped responses (flat field key)', async () => {
@@ -522,17 +525,17 @@ describe('useInviteAuth', () => {
 
   describe('clearErrors', () => {
     it('clears error and fieldErrors state', async () => {
-      // Uses the new invite signup endpoint
+      // Uses the new invite signup endpoint (FormError shape: flat field key)
       axiosMock.onPost('/api/invite/tok/signup').reply(200, {
         error: 'Some error',
-        'field-error': ['password', 'Bad password'],
+        field: 'password',
       });
 
       const { signupForInvite, clearErrors, error, fieldErrors } = useInviteAuth();
       await signupForInvite('u@e.com', 'pw12345678', true, 'tok');
 
       expect(error.value).toBe('Some error');
-      expect(fieldErrors.value).toEqual({ password: 'Bad password' });
+      expect(fieldErrors.value).toEqual({ password: 'Some error' });
 
       clearErrors();
 

--- a/src/tests/views/session/AcceptInvite.spec.ts
+++ b/src/tests/views/session/AcceptInvite.spec.ts
@@ -226,7 +226,7 @@ describe('AcceptInvite', () => {
       expect(wrapper.find('[data-testid="invite-signup-required"]').exists()).toBe(true);
     });
 
-    it('switches to sign-in notice after signup reports an existing account', async () => {
+    it('switches to sign-in notice after signup reports signup unavailable', async () => {
       authStore.$patch({ cust: null });
       const axiosMock = getGlobalAxiosMock();
       axiosMock.onGet('/api/invite/test-token-123').reply(200, {
@@ -236,9 +236,10 @@ describe('AcceptInvite', () => {
       const wrapper = await mountComponent();
       expect(wrapper.find('[data-testid="invite-signup-required"]').exists()).toBe(true);
 
-      // The signup form discovers the existing account via the signup attempt
-      // and emits account-exists; the state machine flips to signin_required.
-      wrapper.findComponent(InviteSignUpForm).vm.$emit('account-exists');
+      // The signup attempt comes back with the generic signup_unavailable
+      // error (#3856) and the form emits signin-required; the state machine
+      // flips to signin_required.
+      wrapper.findComponent(InviteSignUpForm).vm.$emit('signin-required');
       await flushPromises();
 
       expect(wrapper.text()).toContain('web.organizations.invitations.must_sign_in');


### PR DESCRIPTION
## Summary

[#3856](https://github.com/onetimesecret/onetimesecret/issues/3856)

The invite signup endpoint (`POST /api/invite/:token/signup`) returned a distinct `error_type: 'account_exists'` when the invited email already had an account — the sweep S2 enumeration oracle. Because the account-existence checks ran **before** password validation, the probe was clean and non-destructive: any registered user could invite a target address (the create-invitation response includes the raw token via `safe_dump`), POST a junk password, and read account existence straight off the `error_type`.

This aligns the endpoint to the AZ7 generic posture (issue option 1), as far as a mutating endpoint can go:

- **Password validated before any existence check.** An invalid-password probe now gets a byte-identical `password_too_short` error whether or not the account exists.
- **One generic chokepoint for every existing-account outcome** — authdb pre-check, Redis pre-check, and the Rodauth create-race in the `InternalRequestError` rescue all raise the same `signup_unavailable` error with a conditional message ("If you already have an account, sign in…") that never asserts account existence, and no field (the email is token-derived, not submitted).
- **Frontend keys the sign-in fallback off `error_type`** instead of sniffing the message for "already exists" (on both the 200-with-error and 422 paths). The `accountExists` / `account-exists` plumbing is renamed `signinRequired` / `signin-required` since the client no longer learns that an account exists. Invitee UX is unchanged: signup remains the default entry path; the generic error still flips the view to the sign-in form.
- Docs (`docs/product/organization-invites.md`) updated — they still described the pre-AZ7 `account_exists` flag on ShowInvite — plus a scriv changelog fragment.

**Documented residual (ratified inline per the issue's option 2 clause):** with a *valid* password, "exists" (the generic error) remains distinguishable from "does not exist" (signup succeeds). That is inherent to any signup endpoint — success cannot be faked without a session — and probing it is destructive and noisy: it creates the account and emails the invitee. The existing per-IP `InviteTokenRateLimiter` bounds it. This rationale is captured in comments at the chokepoint in `signup_and_accept.rb`.

## Related Issues

Closes #3856

## Test Plan

- `bundle exec rspec apps/api/invite/spec` — 55 examples, 0 failures (7 pre-existing integration placeholders pending). New regression specs assert:
  - identical error payload (`FormError#to_h`) whether the existing account lives in authdb or Redis;
  - identical `password_too_short` payload for an invalid-password probe across exists / not-exists;
  - `error_type` is never `account_exists`;
  - the Rodauth create-race path returns the same generic `signup_unavailable` error as the pre-check.
- `vitest run src/tests/views/session src/tests/composables src/tests/apps/session` — 1203 passed. New specs cover `signinRequired` detection via `error_type` on 200-with-error and 422 responses, and that message text mentioning existing accounts no longer flips the fallback.
- `vue-tsc --noEmit` clean; `eslint` on touched files: 0 errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_012JjsnyccR9q2SLozHimWaS)_