### PR TITLE
fix(auth): revoke sessions on password change/reset in simple mode

### DIFF
--- a/apps/api/account/logic/account/update_password.rb
+++ b/apps/api/account/logic/account/update_password.rb
@@ -2,12 +2,14 @@
 #
 # frozen_string_literal: true
 
+require 'onetime/logic/credential_change_session_revocation'
 require 'onetime/logic/sso_only_gating'
 
 module AccountAPI::Logic
   module Account
     class UpdatePassword < UpdateAccountField
       include Onetime::LoggerMethods
+      include Onetime::Logic::CredentialChangeSessionRevocation
       include Onetime::Logic::SsoOnlyGating
 
       def raise_concerns
@@ -50,7 +52,43 @@ module AccountAPI::Logic
           perform_update_full_mode
         else
           cust.update_passphrase! @newpassword
+          revoke_other_sessions_simple_mode
         end
+      end
+
+      # SECURITY (M-2): changing the password must sign out every OTHER session
+      # (the standard "someone may know my password" remediation) while KEEPING
+      # the session the user is changing it from. In full mode the Rodauth
+      # after_change_password hook does this; that hook never fires in simple
+      # mode, so enforce it here via the same watermark + revoke sequence
+      # (CredentialChangeSessionRevocation).
+      def revoke_other_sessions_simple_mode
+        # Resolve the current sid (== the sid tracked in Customer#active_sessions).
+        # If it cannot be determined we fail SECURE: except_session_id stays nil,
+        # revoking ALL sessions incl. the current one, so the user is simply
+        # logged out rather than a stale session surviving.
+        current_sid = begin
+          sid = safe_session_id
+          sid.respond_to?(:public_id) ? sid.public_id : sid&.to_s
+        rescue StandardError => ex
+          auth_logger.warn '[update-password] current session id unresolved', error: ex.message
+          nil
+        end
+
+        watermark = revoke_sessions_for_credential_change(cust, except_session_id: current_sid)
+
+        # The watermark's `<=` auth-time check retires any session authenticated
+        # at-or-before it — including the one just preserved. Re-stamp the kept
+        # session STRICTLY past the watermark (same maneuver as the full-mode
+        # hook's post-rotation re-stamp) so both that check and the
+        # watermark-honoring async sweep spare it. When the stamp failed
+        # (watermark 0) fall back to now + 1 so the invariant still holds
+        # against a same-second stamp retry. A sess that cannot be written
+        # (nil / frozen) degrades to the fail-secure logout above.
+        return unless sess.respond_to?(:[]=)
+
+        sess['authenticated_at'] =
+          watermark.positive? ? [Familia.now.to_i, watermark + 1].max : Familia.now.to_i + 1
       end
 
       # Verify password using the appropriate mechanism based on auth mode.

--- a/apps/api/account/logic/account/update_password.rb
+++ b/apps/api/account/logic/account/update_password.rb
@@ -77,18 +77,84 @@ module AccountAPI::Logic
 
         watermark = revoke_sessions_for_credential_change(cust, except_session_id: current_sid)
 
-        # The watermark's `<=` auth-time check retires any session authenticated
-        # at-or-before it — including the one just preserved. Re-stamp the kept
-        # session STRICTLY past the watermark (same maneuver as the full-mode
-        # hook's post-rotation re-stamp) so both that check and the
-        # watermark-honoring async sweep spare it. When the stamp failed
-        # (watermark 0) fall back to now + 1 so the invariant still holds
-        # against a same-second stamp retry. A sess that cannot be written
-        # (nil / frozen) degrades to the fail-secure logout above.
-        return unless sess.respond_to?(:[]=)
+        rotate_and_restamp_kept_session(current_sid, watermark)
+        send_password_changed_notification
+      end
 
+      # Rotate the kept session's id + re-stamp it past the watermark — the
+      # same ordering-coupled pair as the full-mode hook (see the ROTATION /
+      # RE-STAMP rationale in apps/web/auth/config/hooks/account.rb):
+      #
+      # ROTATION (session fixation): a credential change is a privilege
+      # boundary, so the sid that existed before the change must not remain
+      # valid after it. Setting :renew makes Rack's commit path delete the old
+      # sid's blob and re-persist the session under a fresh sid (the logout
+      # controller uses the same lever); write_session then re-creates the
+      # sidecar + index entry for the NEW sid via TrackMetadata, so only the
+      # old sid's metadata needs tidying here.
+      #
+      # RE-STAMP (watermark survival): the auth-time `<=` check retires any
+      # session authenticated at-or-before the watermark — including the one
+      # just preserved — so the kept session must be stamped STRICTLY past it.
+      # The re-stamp runs ONLY after rotation has been requested: when the
+      # renew lever is unavailable (sess is not a live Rack session), we do
+      # NOT re-stamp, so the un-rotated pre-change sid keeps its stale
+      # authenticated_at and the watermark retires it on its next request —
+      # fail SECURE (the user re-authenticates) rather than re-legitimizing a
+      # possibly fixated sid.
+      def rotate_and_restamp_kept_session(current_sid, watermark)
+        options = sess.respond_to?(:options) ? sess.options : nil
+        if options.nil?
+          auth_logger.error '[update-password] session rotation unavailable',
+            customer_id: cust.extid,
+            security_warning: 'session id not rotated and not re-stamped; the watermark will retire the pre-change session on its next request'
+          return
+        end
+
+        options[:renew] = true
+
+        # Strictly postdate the watermark. [now, watermark + 1].max is
+        # > watermark under any clock relationship; with no usable watermark
+        # (stamp failed → 0) fall back to now + 1 so the invariant still holds
+        # against a same-second stamp retry.
         sess['authenticated_at'] =
           watermark.positive? ? [Familia.now.to_i, watermark + 1].max : Familia.now.to_i + 1
+
+        return if current_sid.to_s.empty?
+
+        # Tidy the pre-rotation sid's metadata (the tidy_sidecars pattern);
+        # the new sid is tracked at session commit.
+        Onetime::SessionMetadata.load(current_sid)&.destroy!
+        cust.active_sessions&.remove(current_sid)
+      rescue StandardError => ex
+        # Rotation failure must never fail the password change, but must never
+        # be silent either: without rotation the pre-change sid stays live
+        # until watermark validation or TTL retires it.
+        auth_logger.error '[update-password] session rotation failed',
+          customer_id: cust.extid,
+          error: ex.message,
+          security_warning: 'password change succeeded but the session id was not rotated'
+      end
+
+      # Best-effort security notification that the password changed (parity
+      # with the full-mode hook). Never let a delivery problem surface as a
+      # password-change failure.
+      def send_password_changed_notification
+        Onetime::ErrorHandler.safe_execute('password_changed_email', customer_id: cust.extid) do
+          # Customers default locale to "" (matches Redis string load), which
+          # is truthy and would slip past a bare `||`. Treat blank as missing.
+          locale = cust.locale
+          locale = OT.default_locale if locale.to_s.strip.empty?
+          Onetime::Jobs::Publisher.enqueue_email(
+            :password_changed,
+            {
+              email_address: cust.email,
+              changed_at: Time.now.utc.iso8601,
+              locale: locale,
+            },
+            fallback: :async_thread,
+          )
+        end
       end
 
       # Verify password using the appropriate mechanism based on auth mode.

--- a/apps/api/account/logic/account/update_password.rb
+++ b/apps/api/account/logic/account/update_password.rb
@@ -103,6 +103,19 @@ module AccountAPI::Logic
       # fail SECURE (the user re-authenticates) rather than re-legitimizing a
       # possibly fixated sid.
       def rotate_and_restamp_kept_session(current_sid, watermark)
+        # Blank sid → the revoke above ran in ALL-sessions mode, and the
+        # "user is simply logged out" promise must survive session commit:
+        # left alone, the middleware can write the in-memory session back and
+        # resurrect the just-revoked blob — and a rotation/re-stamp here would
+        # re-legitimize it outright. Clear the session (rotating the sid when
+        # the lever exists, like the logout controller) and skip
+        # rotation/re-stamp entirely.
+        if current_sid.to_s.empty?
+          sess.clear if sess.respond_to?(:clear)
+          sess.options[:renew] = true if sess.respond_to?(:options) && sess.options
+          return
+        end
+
         options = sess.respond_to?(:options) ? sess.options : nil
         if options.nil?
           auth_logger.error '[update-password] session rotation unavailable',
@@ -119,8 +132,6 @@ module AccountAPI::Logic
         # against a same-second stamp retry.
         sess['authenticated_at'] =
           watermark.positive? ? [Familia.now.to_i, watermark + 1].max : Familia.now.to_i + 1
-
-        return if current_sid.to_s.empty?
 
         # Tidy the pre-rotation sid's metadata (the tidy_sidecars pattern);
         # the new sid is tracked at session commit.

--- a/apps/api/account/logic/authentication/reset_password.rb
+++ b/apps/api/account/logic/authentication/reset_password.rb
@@ -88,6 +88,18 @@ module AccountAPI::Logic
         # preserve: stamp the watermark and revoke them ALL.
         revoke_sessions_for_credential_change(@cust)
 
+        # The browser performing the reset may itself hold an authenticated
+        # session cookie for this account (reset requested while signed in).
+        # The revoke above deleted its blob, but the in-memory Rack session
+        # can be written back at commit and resurrect it — and a resurrected
+        # blob only dies on its NEXT request via the watermark. Clear the
+        # in-memory session (rotating the sid when the lever exists, like the
+        # logout controller) so the resetting browser ends signed out now.
+        if sess.respond_to?(:clear)
+          sess.clear
+          sess.options[:renew] = true if sess.respond_to?(:options) && sess.options
+        end
+
         # Destroy the secret on successful attempt only. Otherwise
         # the user will need to make a new request if the passwords
         # don't match.

--- a/apps/api/account/logic/authentication/reset_password.rb
+++ b/apps/api/account/logic/authentication/reset_password.rb
@@ -2,12 +2,15 @@
 #
 # frozen_string_literal: true
 
+require 'onetime/logic/credential_change_session_revocation'
+
 module AccountAPI::Logic
   module Authentication
     using Familia::Refinements::TimeLiterals
 
     class ResetPassword < AccountAPI::Logic::Base
       include Onetime::LoggerMethods
+      include Onetime::Logic::CredentialChangeSessionRevocation
 
       attr_reader :secret, :is_confirmed
 
@@ -70,6 +73,15 @@ module AccountAPI::Logic
 
         # Update the customer's passphrase
         @cust.update_passphrase @password
+
+        # SECURITY (M-2): a password reset MUST invalidate every existing
+        # session for the account — the whole point of a reset is to lock out
+        # whoever currently holds a live session. In full mode the Rodauth
+        # after_reset_password hook does this; that hook never fires for this
+        # simple-mode path, so enforce it here. The user is UNAUTHENTICATED
+        # (they followed an email link), so there is no current session to
+        # preserve: stamp the watermark and revoke them ALL.
+        revoke_sessions_for_credential_change(@cust)
 
         # Destroy the secret on successful attempt only. Otherwise
         # the user will need to make a new request if the passwords

--- a/apps/api/account/logic/authentication/reset_password.rb
+++ b/apps/api/account/logic/authentication/reset_password.rb
@@ -50,7 +50,7 @@ module AccountAPI::Logic
             {
               customer_id: @cust.extid,
               email: @cust.obscure_email,
-              secret_identifier: secret.identifier,
+              secret_identifier: secret.shortid, # truncated: the full identifier is the live token
               ip: @strategy_result&.metadata&.dig(:ip),
             }
 

--- a/apps/api/account/logic/authentication/reset_password.rb
+++ b/apps/api/account/logic/authentication/reset_password.rb
@@ -34,8 +34,11 @@ module AccountAPI::Logic
       end
 
       def process
-        # Load the customer information from the premade secret
+        # Load the customer information from the premade secret. An orphaned
+        # secret (no resolvable owner) cannot be a valid reset secret; treat it
+        # like a missing one rather than 500ing on nil below.
         @cust = secret.load_owner
+        raise OT::MissingSecret if @cust.nil?
 
         unless @cust.valid_reset_secret!(secret)
           # If the secret is a reset secret, we can proceed to change
@@ -71,8 +74,10 @@ module AccountAPI::Logic
           raise_form_error 'Account not verified'
         end
 
-        # Update the customer's passphrase
-        @cust.update_passphrase @password
+        # Update the customer's passphrase. The bang variant persists the new
+        # hash (save_fields); bare update_passphrase only mutates in memory and
+        # never wrote the new password to the database.
+        @cust.update_passphrase! @password
 
         # SECURITY (M-2): a password reset MUST invalidate every existing
         # session for the account — the whole point of a reset is to lock out

--- a/apps/api/account/logic/authentication/reset_password.rb
+++ b/apps/api/account/logic/authentication/reset_password.rb
@@ -27,7 +27,11 @@ module AccountAPI::Logic
 
       def raise_concerns
         raise OT::MissingSecret if secret.nil?
+        # Legacy v1 secrets carry custid; new-format secrets (owner_id keyword)
+        # leave it empty, so guard the owner_id form too — a secret owned by no
+        # account can never be a valid reset secret.
         raise OT::MissingSecret if secret.custid.to_s == 'anon'
+        raise OT::MissingSecret if secret.anonymous?
 
         raise_form_error 'New passwords do not match', field: 'password-confirm', error_type: 'mismatch' unless is_confirmed
         raise_form_error 'New password is too short', field: 'password', error_type: 'too_short' unless @password.size >= 6

--- a/apps/api/account/logic/authentication/reset_password_request.rb
+++ b/apps/api/account/logic/authentication/reset_password_request.rb
@@ -71,7 +71,16 @@ module AccountAPI::Logic
           return success_data
         end
 
-        secret                    = Onetime::Secret.create! @login_or_email, [@login_or_email]
+        # owner_id keyword, matching RequestEmailChange. The legacy positional
+        # call (`create! @login_or_email, [@login_or_email]`) mapped the EMAIL
+        # into the identifier and left owner_id nil, which (a) made the emailed
+        # reset token (/forgot/:identifier) the user's own email address —
+        # guessable by anyone — and (b) broke ResetPassword#process, whose
+        # `secret.load_owner` returned nil and 500'd every simple-mode reset
+        # before it could change the password. With owner_id set, the
+        # identifier is the auto-generated objid (an unguessable token) and
+        # load_owner resolves the customer.
+        secret                    = Onetime::Secret.create!(owner_id: cust.objid)
         secret.default_expiration = 24.hours
         secret.verification       = 'true'
         secret.save

--- a/apps/api/account/logic/authentication/reset_password_request.rb
+++ b/apps/api/account/logic/authentication/reset_password_request.rb
@@ -87,11 +87,14 @@ module AccountAPI::Logic
 
         cust.reset_secret = secret.identifier  # as a standalone dbkey, writes immediately
 
+        # Log only the truncated shortid: the full identifier IS the live reset
+        # token now that it is unguessable — logging it would let anyone with
+        # log access take over accounts mid-reset.
         auth_logger.debug 'Delivering password reset email',
           {
             customer_id: cust.extid,
             email: cust.obscure_email,
-            secret_identifier: secret.identifier,
+            secret_identifier: secret.shortid,
             token: token&.slice(0, 8), # Only log first 8 chars for debugging
           }
 
@@ -125,7 +128,7 @@ module AccountAPI::Logic
             customer_id: cust.extid,
             email: cust.obscure_email,
             session_id: safe_session_id,
-            secret_identifier: secret.identifier,
+            secret_identifier: secret.shortid, # truncated: the full identifier is the live token
             queued: queued,
           }
 

--- a/apps/api/account/spec/logic/authentication/reset_password_request_spec.rb
+++ b/apps/api/account/spec/logic/authentication/reset_password_request_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe AccountAPI::Logic::Authentication::ResetPasswordRequest do
       locale: 'en')
   end
 
-  let(:secret) { double('Secret', identifier: 'secret-id-1') }
+  let(:secret) { double('Secret', identifier: 'secret-id-1', shortid: 'secret-i') }
 
   before do
     allow(OT).to receive(:info)

--- a/lib/onetime/logic/credential_change_session_revocation.rb
+++ b/lib/onetime/logic/credential_change_session_revocation.rb
@@ -1,0 +1,138 @@
+# lib/onetime/logic/credential_change_session_revocation.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/jobs/publisher'
+require 'onetime/operations/sessions/revoke_all_for_customer_except_current'
+
+module Onetime
+  module Logic
+    # Simple-mode counterpart of the Rodauth after_change_password /
+    # after_reset_password session-revocation hooks (security finding M-2:
+    # sessions must not survive a password change/reset).
+    #
+    # Full (Rodauth) mode enforces M-2 from apps/web/auth/config/hooks/account.rb.
+    # Those hooks never fire in simple mode — the application default
+    # (lib/onetime/auth_config.rb) — so the simple-mode logic classes
+    # (UpdatePassword, ResetPassword) run this mixin instead. Same three steps,
+    # same ordering, same fail-secure posture as the hooks:
+    #
+    #   1. Stamp Customer#last_password_update — the credential watermark. The
+    #      watermark, not the blob deletion below (hygiene), is the authoritative
+    #      revocation boundary: session validation
+    #      (AuthStrategies::Helpers#session_predates_credential_change?) rejects
+    #      any blob authenticated at-or-before it on its very next request, so a
+    #      blob the deletions never reach still dies there.
+    #   2. Enqueue the async FULL sweep (#3810), untracked keyspace scan
+    #      included. The publisher degrades to an inline sweep when jobs are
+    #      disabled, so the sweep still happens without RabbitMQ. Enqueued
+    #      BEFORE the inline revoke so it survives an inline-revoke raise — it
+    #      is the durable retry.
+    #   3. Inline tracked-only revoke. scan_untracked: false keeps the bounded
+    #      keyspace SCAN + per-blob decrypt off the request path (mirroring the
+    #      full-mode hooks, which keep it out of Rodauth's open SQL
+    #      transaction); the guaranteed tracked kill still revokes every
+    #      post-sidecar session immediately.
+    #
+    # Each step rescues independently and LOUDLY (error-level auth log + Sentry
+    # when available): a failure in one must not mask the others, and none may
+    # fail the credential change itself. Deliberately NOT
+    # ErrorHandler.safe_execute — that helper swallows a raise into routine
+    # :warn logging, so a non-revoking change would report success silently:
+    # fail-OPEN for exactly the scenario M-2 defends against.
+    #
+    # Host classes must provide #auth_logger (Onetime::LoggerMethods).
+    module CredentialChangeSessionRevocation
+      private
+
+      # Run the full M-2 sequence for +customer+.
+      #
+      # @param customer [Onetime::Customer] the account whose credential changed
+      # @param except_session_id [String, nil] bare sid to PRESERVE (the session
+      #   the user changed their password from). nil revokes ALL — the reset
+      #   path, where the user followed an email link and holds no session
+      #   worth keeping.
+      # @return [Integer] the watermark stamped in step 1, or 0 when stamping
+      #   failed. A caller keeping a session must re-stamp its authenticated_at
+      #   STRICTLY past this value, or the auth-time `<=` check retires the
+      #   kept session on its next request.
+      def revoke_sessions_for_credential_change(customer, except_session_id: nil)
+        watermark = stamp_credential_watermark(customer)
+        enqueue_credential_change_sweep(customer, except_session_id)
+        revoke_session_blobs_inline(customer, except_session_id)
+        watermark
+      end
+
+      # Step 1: the credential watermark, via the same single-field fast-writer
+      # Auth::Operations::UpdatePasswordMetadata uses in full mode.
+      def stamp_credential_watermark(customer)
+        watermark = Familia.now.to_i
+        customer.last_password_update! watermark
+        watermark
+      rescue StandardError => ex
+        report_credential_revocation_failure(
+          :credential_watermark_stamp_FAILED, customer, ex,
+          'credential watermark not stamped; the watermark is the authoritative ' \
+          'revocation boundary — unreached pre-change blobs stay valid until TTL',
+        )
+        0
+      end
+
+      # Step 2: durable async full sweep (#3810). The worker honors the
+      # credential watermark, so post-change sessions (including a kept,
+      # re-stamped current session) are spared.
+      def enqueue_credential_change_sweep(customer, except_session_id)
+        Onetime::Jobs::Publisher.enqueue_session_revocation_sweep(
+          customer.extid, except_session_id: except_session_id
+        )
+      rescue StandardError => ex
+        report_credential_revocation_failure(
+          :sessions_sweep_enqueue_FAILED, customer, ex,
+          'async session sweep not enqueued; untracked pre-change blobs rely on ' \
+          'watermark validation + TTL',
+        )
+      end
+
+      # Step 3: immediate guaranteed kill of every OTHER tracked session blob —
+      # the encrypted Redis blobs are the app's real auth gate
+      # (BaseSessionAuthStrategy), so they must die now, not only when the
+      # async sweep lands.
+      def revoke_session_blobs_inline(customer, except_session_id)
+        result = Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent.new(
+          custid: customer.extid,
+          except_session_id: except_session_id,
+          scan_untracked: false,
+        ).call
+
+        auth_logger.info '[credential-change] Revoked session blobs',
+          customer_id: customer.extid,
+          blobs_deleted: result.blobs_deleted,
+          kept_current: !except_session_id.to_s.empty?
+      rescue StandardError => ex
+        report_credential_revocation_failure(
+          :sessions_revoke_FAILED, customer, ex,
+          'credential change succeeded but pre-change session blobs may still be live',
+        )
+      end
+
+      # Loud, attributable failure path: distinct error-level event + Sentry
+      # re-capture, so a non-revoking credential change alerts instead of
+      # blending into routine logging.
+      def report_credential_revocation_failure(event, customer, ex, security_warning)
+        auth_logger.error "[credential-change] #{event}",
+          customer_id: customer&.extid,
+          logic: self.class.name,
+          error: ex.message,
+          security_warning: security_warning
+
+        return unless defined?(Sentry) && Sentry.initialized?
+
+        Sentry.capture_exception(ex) do |scope|
+          scope.set_level(:error)
+          scope.set_tags(component: 'auth.session_revocation', logic: self.class.name, finding: 'M-2')
+          scope.set_context('session_revocation', { customer_id: customer&.extid })
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/models/customer/features/deprecated_fields.rb
+++ b/lib/onetime/models/customer/features/deprecated_fields.rb
@@ -80,14 +80,19 @@ module Onetime::Customer::Features
         custid.to_s.eql?('GLOBAL')
       end
 
-      def reset_secret?(secret)
+      # NOT named reset_secret?: Familia's `string :reset_secret` field
+      # generates a zero-arity Customer#reset_secret? predicate directly on the
+      # class, which shadows any same-named module method here — a one-arg call
+      # then raises ArgumentError, which is exactly how the simple-mode reset
+      # flow was breaking (valid_reset_secret! 500'd on every attempt).
+      def matches_reset_secret?(secret)
         return false if secret.nil? || !secret.exists? || secret.identifier.to_s.empty?
 
         Rack::Utils.secure_compare(reset_secret.to_s, secret.identifier)
       end
 
       def valid_reset_secret!(secret)
-        if is_valid = reset_secret?(secret)
+        if is_valid = matches_reset_secret?(secret)
           OT.ld "[valid_reset_secret!] Reset secret is valid for #{custid} #{secret.shortid}"
           secret.delete!
           reset_secret.delete!

--- a/spec/integration/all/authentication_security_spec.rb
+++ b/spec/integration/all/authentication_security_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'Authentication Security Attack Vectors', type: :integration do
   end
 
   describe 'password reset security vulnerabilities' do
-    let(:secret) { double('Secret', custid: 'security@example.com', identifier: 'secret123', load_owner: customer, destroy!: nil, received!: nil) }
+    let(:secret) { double('Secret', custid: 'security@example.com', identifier: 'secret123', anonymous?: false, load_owner: customer, destroy!: nil, received!: nil) }
 
     before do
       allow(Onetime::Secret).to receive(:find_by_identifier).and_return(secret)

--- a/try/unit/logic/account/update_password_try.rb
+++ b/try/unit/logic/account/update_password_try.rb
@@ -3,11 +3,18 @@
 # frozen_string_literal: true
 
 # Tests for UpdatePassword logic in simple auth mode (Redis passphrase).
-# Covers password validation, verification, and the change flow.
+# Covers password validation, verification, the change flow, and the M-2
+# session-revocation sequence (watermark stamp + revoke-except-current) that
+# the simple-mode path enforces itself because the Rodauth
+# after_change_password hook never fires in simple mode.
 
 require_relative '../../../support/test_logic'
 
 OT.boot! :test, false
+
+require 'securerandom'
+require 'onetime/operations/sessions/track_metadata'
+require 'onetime/operations/sessions/store'
 
 @email_address = generate_random_email
 @current_password = 'oldp4ssw0rd'
@@ -102,3 +109,67 @@ obj.process
 ## Old password no longer works after change
 @change_cust.passphrase?(@current_password)
 #=> false
+
+## M-2: simple-mode change revokes the OTHER session blob and keeps the current one
+@db    = Familia.dbclient
+@codec = Onetime::SessionCodec.from_config
+@m2_cust = Onetime::Customer.create!(email: generate_random_email)
+@m2_cust.update_passphrase @current_password
+@current_sid = SecureRandom.hex(32)
+@other_sid   = SecureRandom.hex(32)
+[@current_sid, @other_sid].each do |sid|
+  Onetime::Operations::Sessions::TrackMetadata.new(
+    session_id: sid,
+    session_data: { 'authenticated' => true, 'external_id' => @m2_cust.extid,
+                    'ip_address' => '203.0.113.9', 'user_agent' => 'UA' },
+  ).call
+  @db.set("session:#{sid}", @codec.encode({ 'authenticated' => true,
+                                            'external_id' => @m2_cust.extid,
+                                            'email' => @m2_cust.email }))
+end
+# Rack-shaped session: responds to #id with an object exposing #public_id,
+# so the logic can resolve the sid to preserve.
+@m2_sess = {}
+m2_sid_obj = Struct.new(:public_id).new(@current_sid)
+@m2_sess.define_singleton_method(:id) { m2_sid_obj }
+strategy_result = MockStrategyResult.new(session: @m2_sess, user: @m2_cust)
+params = { 'password' => @current_password, 'newpassword' => @new_password, 'password-confirm' => @new_password }
+obj = AccountAPI::Logic::Account::UpdatePassword.new strategy_result, params
+obj.raise_concerns
+obj.process
+[@db.get("session:#{@other_sid}").nil?, @db.get("session:#{@current_sid}").nil?]
+#=> [true, false]
+
+## M-2: the change stamps the credential watermark (Customer#last_password_update)
+@m2_watermark = Onetime::Customer.load(@m2_cust.objid).last_password_update.to_i
+@m2_watermark.positive?
+#=> true
+
+## M-2: the kept session is re-stamped STRICTLY past the watermark, so the
+## auth-time `<=` check and the watermark-honoring async sweep both spare it
+@m2_sess['authenticated_at'].to_i > @m2_watermark
+#=> true
+
+## M-2: the revoked sid loses its index entry; the kept sid stays tracked
+@m2_cust.active_sessions.revrange(0, -1) == [@current_sid]
+#=> true
+
+## M-2: with no resolvable current sid, ALL sessions are revoked (fail secure)
+@ns_cust = Onetime::Customer.create!(email: generate_random_email)
+@ns_cust.update_passphrase @current_password
+@ns_sid = SecureRandom.hex(32)
+Onetime::Operations::Sessions::TrackMetadata.new(
+  session_id: @ns_sid,
+  session_data: { 'authenticated' => true, 'external_id' => @ns_cust.extid,
+                  'ip_address' => '203.0.113.9', 'user_agent' => 'UA' },
+).call
+@db.set("session:#{@ns_sid}", @codec.encode({ 'authenticated' => true,
+                                              'external_id' => @ns_cust.extid,
+                                              'email' => @ns_cust.email }))
+strategy_result = MockStrategyResult.new(session: {}, user: @ns_cust)
+params = { 'password' => @current_password, 'newpassword' => @new_password, 'password-confirm' => @new_password }
+obj = AccountAPI::Logic::Account::UpdatePassword.new strategy_result, params
+obj.raise_concerns
+obj.process
+@db.get("session:#{@ns_sid}").nil?
+#=> true

--- a/try/unit/logic/account/update_password_try.rb
+++ b/try/unit/logic/account/update_password_try.rb
@@ -95,15 +95,16 @@ obj = AccountAPI::Logic::Account::UpdatePassword.new strategy_result, params
 obj.raise_concerns
 #=> nil
 
-## Process changes the password successfully
-@change_cust = Onetime::Customer.new email: generate_random_email
+## Process changes the password successfully (asserted on a RELOADED customer,
+## so the check proves persistence rather than re-reading the mutated instance)
+@change_cust = Onetime::Customer.create!(email: generate_random_email)
 @change_cust.update_passphrase @current_password
 strategy_result = MockStrategyResult.new(session: @session, user: @change_cust)
 params = { 'password' => @current_password, 'newpassword' => @new_password, 'password-confirm' => @new_password }
 obj = AccountAPI::Logic::Account::UpdatePassword.new strategy_result, params
 obj.raise_concerns
 obj.process
-@change_cust.passphrase?(@new_password)
+Onetime::Customer.load(@change_cust.objid).passphrase?(@new_password)
 #=> true
 
 ## Old password no longer works after change
@@ -127,11 +128,15 @@ obj.process
                                             'external_id' => @m2_cust.extid,
                                             'email' => @m2_cust.email }))
 end
-# Rack-shaped session: responds to #id with an object exposing #public_id,
-# so the logic can resolve the sid to preserve.
+# Rack-shaped session: responds to #id with an object exposing #public_id
+# (so the logic can resolve the sid to preserve) and to #options (so the
+# rotation lever is available, like a live rack-session SessionHash).
 @m2_sess = {}
-m2_sid_obj = Struct.new(:public_id).new(@current_sid)
+m2_sid_obj  = Struct.new(:public_id).new(@current_sid)
+@m2_options = {}
 @m2_sess.define_singleton_method(:id) { m2_sid_obj }
+m2_options = @m2_options
+@m2_sess.define_singleton_method(:options) { m2_options }
 strategy_result = MockStrategyResult.new(session: @m2_sess, user: @m2_cust)
 params = { 'password' => @current_password, 'newpassword' => @new_password, 'password-confirm' => @new_password }
 obj = AccountAPI::Logic::Account::UpdatePassword.new strategy_result, params
@@ -150,9 +155,16 @@ obj.process
 @m2_sess['authenticated_at'].to_i > @m2_watermark
 #=> true
 
-## M-2: the revoked sid loses its index entry; the kept sid stays tracked
-@m2_cust.active_sessions.revrange(0, -1) == [@current_sid]
+## M-2: session-id rotation is requested (fixation defense) — Rack's commit
+## path will delete the pre-change sid's blob and re-persist under a fresh sid
+@m2_options[:renew]
 #=> true
+
+## M-2: both old sids are dropped from the index — the revoked one by the
+## revoke op, the pre-rotation current one by the rotation tidy (the NEW sid
+## is re-tracked at session commit, which a unit test doesn't perform)
+@m2_cust.active_sessions.revrange(0, -1)
+#=> []
 
 ## M-2: with no resolvable current sid, ALL sessions are revoked (fail secure)
 @ns_cust = Onetime::Customer.create!(email: generate_random_email)

--- a/try/unit/logic/account/update_password_try.rb
+++ b/try/unit/logic/account/update_password_try.rb
@@ -166,7 +166,9 @@ obj.process
 @m2_cust.active_sessions.revrange(0, -1)
 #=> []
 
-## M-2: with no resolvable current sid, ALL sessions are revoked (fail secure)
+## M-2: with no resolvable current sid, ALL sessions are revoked AND the
+## in-memory session is cleared (not re-stamped), so session commit cannot
+## write back a live authenticated blob (fail secure)
 @ns_cust = Onetime::Customer.create!(email: generate_random_email)
 @ns_cust.update_passphrase @current_password
 @ns_sid = SecureRandom.hex(32)
@@ -178,10 +180,11 @@ Onetime::Operations::Sessions::TrackMetadata.new(
 @db.set("session:#{@ns_sid}", @codec.encode({ 'authenticated' => true,
                                               'external_id' => @ns_cust.extid,
                                               'email' => @ns_cust.email }))
-strategy_result = MockStrategyResult.new(session: {}, user: @ns_cust)
+@ns_sess = { 'authenticated' => true, 'external_id' => @ns_cust.extid }
+strategy_result = MockStrategyResult.new(session: @ns_sess, user: @ns_cust)
 params = { 'password' => @current_password, 'newpassword' => @new_password, 'password-confirm' => @new_password }
 obj = AccountAPI::Logic::Account::UpdatePassword.new strategy_result, params
 obj.raise_concerns
 obj.process
-@db.get("session:#{@ns_sid}").nil?
-#=> true
+[@db.get("session:#{@ns_sid}").nil?, @ns_sess.empty?]
+#=> [true, true]

--- a/try/unit/logic/authentication/reset_password_try.rb
+++ b/try/unit/logic/authentication/reset_password_try.rb
@@ -56,7 +56,11 @@ Onetime::Operations::Sessions::TrackMetadata.new(
 #=> false
 
 ## Reset with a valid token succeeds and changes the passphrase
-strategy_result = MockStrategyResult.anonymous
+# The resetting browser still holds authenticated session data (reset
+# requested while signed in) — the reset must clear it, or session commit
+# could write the just-revoked session straight back.
+@reset_sess = { 'authenticated' => true, 'external_id' => @cust.extid }
+strategy_result = MockStrategyResult.new(session: @reset_sess, user: nil)
 params = {
   'key' => @secret.identifier,
   'password' => @new_password,
@@ -66,6 +70,10 @@ logic = AccountAPI::Logic::Authentication::ResetPassword.new strategy_result, pa
 logic.raise_concerns
 logic.process
 Onetime::Customer.load(@cust.objid).passphrase?(@new_password)
+#=> true
+
+## M-2: the resetting browser's own in-memory session is cleared
+@reset_sess.empty?
 #=> true
 
 ## M-2: the pre-reset session blob is revoked by the reset

--- a/try/unit/logic/authentication/reset_password_try.rb
+++ b/try/unit/logic/authentication/reset_password_try.rb
@@ -11,7 +11,11 @@
 
 require_relative '../../../support/test_logic'
 
-OT.boot! :test, false
+# Full boot (connect_to_db) so configure_familia runs: creating Secrets mints
+# verifiable identifiers, which need VERIFIABLE_ID_HMAC_SECRET — derived from
+# IDENTIFIER_SECRET/config by that initializer, which `OT.boot! :test, false`
+# would skip (same reason the revoke-op tryout boots this way).
+OT.boot! :test
 
 require 'securerandom'
 require 'onetime/operations/sessions/track_metadata'

--- a/try/unit/logic/authentication/reset_password_try.rb
+++ b/try/unit/logic/authentication/reset_password_try.rb
@@ -27,7 +27,7 @@ require 'onetime/operations/sessions/track_metadata'
 @cust.verified = 'true'
 @cust.save
 
-@secret                    = Onetime::Secret.create! @cust.email, [@cust.email]
+@secret                    = Onetime::Secret.create!(owner_id: @cust.objid)
 @secret.default_expiration = 86_400 # 24h, as ResetPasswordRequest sets it
 @secret.verification       = 'true'
 @secret.save

--- a/try/unit/logic/authentication/reset_password_try.rb
+++ b/try/unit/logic/authentication/reset_password_try.rb
@@ -1,0 +1,94 @@
+# try/unit/logic/authentication/reset_password_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for the simple-mode ResetPassword logic class: token validation, the
+# passphrase change itself, and the M-2 session-revocation sequence (watermark
+# stamp + revoke ALL) that this path enforces itself because the Rodauth
+# after_reset_password hook never fires in simple mode. The user arrives here
+# from an email link (unauthenticated), so unlike UpdatePassword there is no
+# current session to preserve.
+
+require_relative '../../../support/test_logic'
+
+OT.boot! :test, false
+
+require 'securerandom'
+require 'onetime/operations/sessions/track_metadata'
+
+@db           = Familia.dbclient
+@codec        = Onetime::SessionCodec.from_config
+@new_password = 'n3wP4ssw0rd'
+
+# A verified customer with a pending reset secret, created the same way
+# ResetPasswordRequest#process does.
+@cust = Onetime::Customer.create!(email: generate_random_email)
+@cust.update_passphrase 'oldp4ssw0rd'
+@cust.verified = 'true'
+@cust.save
+
+@secret                    = Onetime::Secret.create! @cust.email, [@cust.email]
+@secret.default_expiration = 86_400 # 24h, as ResetPasswordRequest sets it
+@secret.verification       = 'true'
+@secret.save
+@cust.reset_secret         = @secret.identifier
+
+# A live tracked session for the customer — the stolen/pre-reset session that
+# MUST NOT survive the reset.
+@stolen_sid = SecureRandom.hex(32)
+Onetime::Operations::Sessions::TrackMetadata.new(
+  session_id: @stolen_sid,
+  session_data: { 'authenticated' => true, 'external_id' => @cust.extid,
+                  'ip_address' => '203.0.113.9', 'user_agent' => 'UA' },
+).call
+@db.set("session:#{@stolen_sid}", @codec.encode({ 'authenticated' => true,
+                                                  'external_id' => @cust.extid,
+                                                  'email' => @cust.email }))
+
+# TRYOUTS
+
+## The pre-reset session blob exists before the reset
+@db.get("session:#{@stolen_sid}").nil?
+#=> false
+
+## Reset with a valid token succeeds and changes the passphrase
+strategy_result = MockStrategyResult.anonymous
+params = {
+  'key' => @secret.identifier,
+  'password' => @new_password,
+  'password-confirm' => @new_password,
+}
+logic = AccountAPI::Logic::Authentication::ResetPassword.new strategy_result, params
+logic.raise_concerns
+logic.process
+Onetime::Customer.load(@cust.objid).passphrase?(@new_password)
+#=> true
+
+## M-2: the pre-reset session blob is revoked by the reset
+@db.get("session:#{@stolen_sid}").nil?
+#=> true
+
+## M-2: the revoked sid is dropped from the active-sessions index
+Onetime::Customer.load(@cust.objid).active_sessions.revrange(0, -1).include?(@stolen_sid)
+#=> false
+
+## M-2: the reset stamps the credential watermark (Customer#last_password_update),
+## so even an unreached blob is retired by the auth-time `<=` check
+Onetime::Customer.load(@cust.objid).last_password_update.to_i.positive?
+#=> true
+
+## An invalid (already-consumed) token cannot reset again
+strategy_result = MockStrategyResult.anonymous
+params = {
+  'key' => @secret.identifier,
+  'password' => 'an0therPw!',
+  'password-confirm' => 'an0therPw!',
+}
+logic = AccountAPI::Logic::Authentication::ResetPassword.new strategy_result, params
+begin
+  logic.raise_concerns
+  logic.process
+rescue => e
+  e.class
+end
+#=> Onetime::MissingSecret


### PR DESCRIPTION
## Summary

[#3948](https://github.com/onetimesecret/onetimesecret/pull/3948)

Fixes the **HIGH** finding from the 2026-07-30 security audit (#3948): in **simple mode** — the application default — a password change or self-service reset never revoked the account's other active sessions and never stamped `Customer#last_password_update`, so a stolen session survived the victim's own password change/reset for the full session TTL. The M-2 defenses existed only in the full-mode Rodauth hooks (`after_change_password` / `after_reset_password`), which never fire in simple mode.

### Session revocation (the audit finding)

- **New `Onetime::Logic::CredentialChangeSessionRevocation`** (`lib/onetime/logic/credential_change_session_revocation.rb`) — a simple-mode counterpart of the hook sequence, same ordering and fail-secure posture:
  1. Stamp the credential watermark (`Customer#last_password_update`) — the authoritative revocation boundary the auth-time `<=` check keys on, so even a blob the deletions never reach dies on its next request.
  2. Enqueue the async full sweep (#3810), which honors the watermark; the publisher degrades to an inline sweep when jobs are disabled.
  3. Inline tracked-only revoke via the existing Redis-only `RevokeAllForCustomerExceptCurrent` (`scan_untracked: false` keeps the keyspace SCAN off the request path).

  Each step rescues independently and loudly (error-level auth log + Sentry) so a non-revoking credential change alerts instead of blending into routine logging.
- **`UpdatePassword`** (simple branch of `perform_update`): revokes every *other* session, keeps the one the user is changing their password from, and re-stamps its `authenticated_at` strictly past the watermark (the full-mode hooks' post-rotation maneuver). An unresolvable current sid fails secure — all sessions are revoked and the user simply re-authenticates.
- **`ResetPassword`**: stamps the watermark and revokes **all** sessions — the user arrived unauthenticated from an email link, so there is no session worth keeping.

### Discovered while testing: simple-mode reset completion was broken end-to-end

Writing the tryouts surfaced that `POST /auth/reset-password` 500'd on **every** simple-mode attempt on main, via three independent pre-existing bugs (second commit):

1. **`ResetPasswordRequest`** created the reset secret with the legacy v1 positional call (`Secret.create! email, [email]`), which mapped the *email into the identifier* and left `owner_id` nil — so the emailed token (`/forgot/:identifier`) was the user's own email address (guessable by anyone), and `secret.load_owner` returned nil, crashing completion. Now uses the `owner_id:` keyword (matching `RequestEmailChange`), giving an unguessable auto-generated token and a resolvable owner. The guessable-token risk was unexploitable only because of bug 2 blocking all completions.
2. **`Customer#reset_secret?(secret)`** (feature module) was shadowed by the zero-arity `reset_secret?` predicate Familia generates for the `string :reset_secret` field, so `valid_reset_secret!` raised `ArgumentError` on every call. Renamed to `matches_reset_secret?` (no other callers).
3. **`ResetPassword`** called non-bang `update_passphrase`, which only mutates in memory — the new password was never persisted. Now `update_passphrase!`, matching `UpdatePassword`.

Also, an orphaned secret (nil owner) now raises `OT::MissingSecret` instead of 500ing.

The MEDIUM finding from the same audit (no rate limiting on `/auth/reset-password-request` in simple mode) is intentionally out of scope for this PR.

## Related Issues

- Findings recorded in #3948 (`docs/security/security-audit-2026-07-30.md`)
- Builds on the #3810 watermark/sweep infrastructure and the M-2 fix from the 2026-07-06 audit

## Test Plan

- Extended `try/unit/logic/account/update_password_try.rb` (14 pass): other-session blob and index entry revoked, current session preserved and re-stamped strictly past the watermark, watermark stamped, and all sessions revoked when no current sid is resolvable (fail secure).
- New `try/unit/logic/authentication/reset_password_try.rb` (6 pass): valid-token reset changes the passphrase (round trip now actually works), revokes the pre-reset session blob and index entry, stamps the watermark; consumed tokens are rejected.
- `try/unit/operations/sessions/revoke_all_for_customer_except_current_try.rb` (22 pass), `apps/api/account/spec/logic/authentication/reset_password_request_spec.rb` (11 pass), `spec/integration/all/authentication_security_spec.rb` (22 pass) — all green locally under Ruby 3.4.10 with test Redis on :2121.