### PR TITLE
[#3951] Tolerant boolean encoding for CustomDomain config models

### DIFF
--- a/lib/onetime/models/custom_domain/api_config.rb
+++ b/lib/onetime/models/custom_domain/api_config.rb
@@ -46,7 +46,7 @@ module Onetime
       # stores a legacy 'true'/'false' STRING; the boolean_encoding feature
       # (below) normalizes writes to that encoding and keeps #enabled?
       # tolerant of both (#3951).
-      COLONEL_FIELD_SPECS = {
+      FIELD_SPECS = {
         'enabled' => { type: :boolean, storage: :string },
       }.freeze
 

--- a/lib/onetime/models/custom_domain/api_config.rb
+++ b/lib/onetime/models/custom_domain/api_config.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require_relative '../features/boolean_encoding'
+
 #
 # CustomDomain::ApiConfig - Per-domain API access configuration
 #
@@ -41,21 +43,20 @@ module Onetime
       # Colonel-writable fields, aggregated into
       # {Onetime::CustomDomain::ConfigRegistry::FIELD_SPECS} (the registry
       # validates at load time that every key has a setter here). `enabled`
-      # stores a legacy 'true'/'false' STRING (#enabled? tolerates both
-      # encodings).
+      # stores a legacy 'true'/'false' STRING; the boolean_encoding feature
+      # (below) normalizes writes to that encoding and keeps #enabled?
+      # tolerant of both (#3951).
       COLONEL_FIELD_SPECS = {
         'enabled' => { type: :boolean, storage: :string },
       }.freeze
 
+      # Tolerant predicate + normalizing setter for `enabled` per the spec
+      # above (#3951). Must come after both the field declaration and the
+      # constant.
+      feature :boolean_encoding
+
       def init
         self.enabled ||= 'false'
-      end
-
-      # Check if public API access is enabled for this domain.
-      #
-      # @return [Boolean] true if public API access is active
-      def enabled?
-        enabled.to_s == 'true'
       end
 
       # Enable public API access for this domain.

--- a/lib/onetime/models/custom_domain/api_config.rb
+++ b/lib/onetime/models/custom_domain/api_config.rb
@@ -152,7 +152,7 @@ module Onetime
 
           if config
             config.created ||= now  # repair missing created from legacy records
-            config.enabled   = enabled.to_s
+            config.enabled   = enabled
             config.updated   = now
           else
             config = new(domain_id: domain_id, enabled: enabled.to_s, created: now, updated: now)

--- a/lib/onetime/models/custom_domain/chores/normalize_boolean_encoding.rb
+++ b/lib/onetime/models/custom_domain/chores/normalize_boolean_encoding.rb
@@ -1,0 +1,132 @@
+# lib/onetime/models/custom_domain/chores/normalize_boolean_encoding.rb
+#
+# frozen_string_literal: true
+
+# Housekeeping chore: Rewrite drifted boolean encodings on the seven
+# CustomDomain config models (#3951) to each field's DECLARED storage
+# encoding.
+#
+# Background:
+#   The config models historically disagreed on boolean persistence — some
+#   fields store REAL booleans (storage :native), others 'true'/'false'
+#   STRINGS (storage :string). Writers that bypassed ConfigRegistry
+#   (console sessions, create!/upsert) could persist the "wrong" encoding.
+#   The boolean_encoding feature makes reads tolerant and new writes
+#   normalizing; this chore cleans up the bytes already stored so the raw
+#   hashes converge on each model's FIELD_SPECS declaration.
+#
+# Raw byte shapes (Familia v2 JSON-wraps every scalar via serialize_value):
+#   :native storage, canonical  ->  'true' / 'false'      (JSON booleans)
+#   :string storage, canonical  ->  '"true"' / '"false"'  (JSON-quoted strings)
+#
+# Three branches per field, per standardize_planid:
+#
+#   1. raw bytes already canonical for the declared storage → silent skip
+#   2. recognized divergent encoding (the other encoding's bytes, or
+#      1/'1'/0/'0' variants)  → rewrite via the fast writer with the
+#      canonically-typed value (field! serializes: true → 'true',
+#      'true' → '"true"'), log :info with from/to
+#   3. unrecognized garbage → log :info, leave alone (tolerant reads treat
+#      it as false; preserve forensic evidence)
+#
+# nil/absent fields are skipped — nil means unset, never coerced.
+# Idempotent: a second run finds only canonical bytes and does nothing.
+#
+# The models do not enable feature :housekeeping themselves; this file
+# enables it at registration so removing the chore later (once telemetry
+# confirms clean data) is a one-file deletion.
+#
+# Run via HousekeepingJob (one model at a time — the config models are not
+# in MaintenanceJob::INSTANCE_MODELS, so the nightly all-models sweep only
+# picks them up if listed under jobs.maintenance.housekeeping.models):
+#   HousekeepingJob.perform('Onetime::CustomDomain::SigninConfig', :normalize_boolean_encoding)
+#   bin/ots housekeeping run Onetime::CustomDomain::SigninConfig normalize_boolean_encoding
+
+module Onetime
+  module Chores
+    # Constants and the shared chore body are namespaced here (rather than
+    # inlined per model) because ONE implementation serves all seven config
+    # models, driven by each model's FIELD_SPECS constant.
+    module NormalizeBooleanEncoding
+      # Raw stored bytes recognized as boolean-intent, by truth value.
+      # Covers both encodings plus the numeric variants the tolerant
+      # readers accept (TRUTHY_VALUES in features/boolean_encoding.rb).
+      RAW_TRUTHY = ['true', '"true"', '1', '"1"'].freeze
+      RAW_FALSY  = ['false', '"false"', '0', '"0"'].freeze
+
+      # Enable feature :housekeeping (if needed) and register the chore on
+      # a config model, closing over its boolean FIELD_SPECS entries.
+      #
+      # @param model [Class] a CustomDomain config model with FIELD_SPECS
+      def self.register(model)
+        boolean_specs = model.const_get(:FIELD_SPECS).select do |_field, spec|
+          spec[:type] == :boolean
+        end
+        return if boolean_specs.empty?
+
+        model.feature :housekeeping unless model.respond_to?(:chore)
+
+        model.chore :normalize_boolean_encoding do |record|
+          Onetime::Chores::NormalizeBooleanEncoding.run(record, boolean_specs)
+        end
+      end
+
+      # Chore body: compare each spec'd boolean field's raw stored bytes
+      # against the declared encoding and rewrite recognized drift.
+      #
+      # @param record [Familia::Horreum] the config record
+      # @param boolean_specs [Hash{String => Hash}] field => spec, boolean only
+      # @return [Boolean] true if any field was rewritten
+      def self.run(record, boolean_specs)
+        logger   = Onetime.get_logger('Chores')
+        raw_hash = record.hgetall
+        modified = false
+
+        boolean_specs.each do |field, spec|
+          raw = raw_hash[field]
+          next if raw.nil? || raw.empty? # absent/unset — never coerce
+
+          string_storage = spec[:storage] == :string
+          canonical      = string_storage ? ['"true"', '"false"'] : %w[true false]
+          next if canonical.include?(raw) # already canonical — silent skip
+
+          truthy = RAW_TRUTHY.include?(raw)
+          unless truthy || RAW_FALSY.include?(raw)
+            logger.info 'Skipping unrecognized boolean bytes',
+              chore: :normalize_boolean_encoding,
+              model: record.class.name,
+              identifier: record.identifier,
+              field: field,
+              raw: raw
+            next
+          end
+
+          # Fast writer serializes the typed value into canonical bytes:
+          #   :string -> field!('true')  stores '"true"'
+          #   :native -> field!(true)    stores 'true'
+          typed    = if string_storage
+                    truthy ? 'true' : 'false'
+                  else
+                    truthy
+                  end
+          record.send(:"#{field}!", typed)
+          modified = true
+
+          logger.info 'Normalizing boolean encoding',
+            chore: :normalize_boolean_encoding,
+            model: record.class.name,
+            identifier: record.identifier,
+            field: field,
+            from: raw,
+            to: truthy ? canonical[0] : canonical[1]
+        end
+
+        modified
+      end
+    end
+  end
+end
+
+Onetime::CustomDomain::ConfigRegistry::KINDS.each_value do |entry|
+  Onetime::Chores::NormalizeBooleanEncoding.register(entry[:model])
+end

--- a/lib/onetime/models/custom_domain/config_registry.rb
+++ b/lib/onetime/models/custom_domain/config_registry.rb
@@ -38,9 +38,14 @@ module Onetime
     # signup_enabled/autoverify fields on SignupConfig) store REAL booleans,
     # while the other models store 'true'/'false' STRINGS. Each model declares
     # its own encoding (storage :native | :string) in its COLONEL_FIELD_SPECS,
-    # next to its field declarations. Serialization always goes through the
-    # model predicates so the frontend sees real JSON booleans; writes go
-    # through apply_field, which storage-encodes per the field spec.
+    # next to its field declarations, and enables the boolean_encoding
+    # feature, which builds tolerant predicates and normalizing setters from
+    # those specs (#3951) — so writers that bypass apply_field (console,
+    # create!/upsert) can no longer persist a mixed encoding that silently
+    # reads as disabled. Serialization always goes through the model
+    # predicates so the frontend sees real JSON booleans; writes go through
+    # apply_field, which storage-encodes per the field spec (a no-op under
+    # the normalizing setters, kept as the explicit encoding boundary).
     #
     # REDACTION INVARIANT: encrypted credentials (SsoConfig client_id /
     # client_secret, MailerConfig api_key) are NEVER serialized — presence
@@ -80,19 +85,30 @@ module Onetime
       #                    and raises Onetime::Problem).
       #
       # Load-time transcription check: every spec'd field must have a public
-      # setter on its model (apply_field writes via public_send), so a typo'd
-      # or renamed field fails at require time, not at PUT time.
-      FIELD_SPECS = KINDS.each_with_object({}) do |(slug, entry), acc|
-        next unless entry[:editable]
-
+      # setter on its model (apply_field writes via public_send, and the
+      # boolean_encoding feature builds its accessors from the same specs),
+      # so a typo'd or renamed field fails at require time, not at PUT time.
+      # Runs for EVERY kind that declares COLONEL_FIELD_SPECS — including the
+      # non-editable sso/mailer, whose specs exist for the boolean_encoding
+      # feature rather than for colonel PUTs.
+      KINDS.each do |slug, entry|
         model = entry[:model]
+        next unless model.const_defined?(:COLONEL_FIELD_SPECS)
+
         model::COLONEL_FIELD_SPECS.each_key do |field|
           next if model.method_defined?("#{field}=")
 
-          raise "ConfigRegistry: #{model}##{field}= missing for colonel-writable field '#{field}' (kind=#{slug})"
+          raise "ConfigRegistry: #{model}##{field}= missing for spec'd field '#{field}' (kind=#{slug})"
         end
+      end
 
-        acc[slug] = model::COLONEL_FIELD_SPECS
+      # Colonel-WRITABLE specs only: composition stays editable-kind-only, so
+      # sso/mailer declaring COLONEL_FIELD_SPECS does not make them PUTable
+      # (field_specs returns {} for them and the routes reject via editable?).
+      FIELD_SPECS = KINDS.each_with_object({}) do |(slug, entry), acc|
+        next unless entry[:editable]
+
+        acc[slug] = entry[:model]::COLONEL_FIELD_SPECS
       end.freeze
 
       class << self

--- a/lib/onetime/models/custom_domain/config_registry.rb
+++ b/lib/onetime/models/custom_domain/config_registry.rb
@@ -96,7 +96,7 @@ module Onetime
         next unless model.const_defined?(:FIELD_SPECS)
 
         model::FIELD_SPECS.each_key do |field|
-          next if model.method_defined?("#{field}=")
+          next if model.public_method_defined?("#{field}=")
 
           raise "ConfigRegistry: #{model}##{field}= missing for spec'd field '#{field}' (kind=#{slug})"
         end

--- a/lib/onetime/models/custom_domain/config_registry.rb
+++ b/lib/onetime/models/custom_domain/config_registry.rb
@@ -30,14 +30,14 @@ module Onetime
     #     (absent and present-but-disabled are behavior-equivalent for the five
     #     resolver-gated kinds, so creating disabled records is behavior-neutral)
     #   - the writable-field COERCIONS for PUT upserts; the specs themselves
-    #     are COMPOSED from each model's COLONEL_FIELD_SPECS constant (see
+    #     are COMPOSED from each model's FIELD_SPECS constant (see
     #     FIELD_SPECS below) — the model file is the single source of truth
     #   - the redacting serializer used by ALL colonel responses
     #
     # Boolean encodings differ across the models: SigninConfig (and the
     # signup_enabled/autoverify fields on SignupConfig) store REAL booleans,
     # while the other models store 'true'/'false' STRINGS. Each model declares
-    # its own encoding (storage :native | :string) in its COLONEL_FIELD_SPECS,
+    # its own encoding (storage :native | :string) in its FIELD_SPECS,
     # next to its field declarations, and enables the boolean_encoding
     # feature, which builds tolerant predicates and normalizing setters from
     # those specs (#3951) — so writers that bypass apply_field (console,
@@ -68,10 +68,10 @@ module Onetime
       }.freeze
 
       # Colonel-writable field specs per editable kind, COMPOSED from each
-      # model's own COLONEL_FIELD_SPECS constant. The model file — next to its
+      # model's own FIELD_SPECS constant. The model file — next to its
       # field declarations — is the ONLY place that names its writable fields
       # and their storage encoding, so adding a colonel-writable field is a
-      # one-file change (edit the model's COLONEL_FIELD_SPECS).
+      # one-file change (edit the model's FIELD_SPECS).
       #
       # Spec semantics (interpreted by coerce_field! / apply_field below):
       #   type :boolean  — accepts JSON true/false plus 'true'/'false'/'1'/'0';
@@ -88,14 +88,14 @@ module Onetime
       # setter on its model (apply_field writes via public_send, and the
       # boolean_encoding feature builds its accessors from the same specs),
       # so a typo'd or renamed field fails at require time, not at PUT time.
-      # Runs for EVERY kind that declares COLONEL_FIELD_SPECS — including the
+      # Runs for EVERY kind that declares FIELD_SPECS — including the
       # non-editable sso/mailer, whose specs exist for the boolean_encoding
       # feature rather than for colonel PUTs.
       KINDS.each do |slug, entry|
         model = entry[:model]
-        next unless model.const_defined?(:COLONEL_FIELD_SPECS)
+        next unless model.const_defined?(:FIELD_SPECS)
 
-        model::COLONEL_FIELD_SPECS.each_key do |field|
+        model::FIELD_SPECS.each_key do |field|
           next if model.method_defined?("#{field}=")
 
           raise "ConfigRegistry: #{model}##{field}= missing for spec'd field '#{field}' (kind=#{slug})"
@@ -103,12 +103,12 @@ module Onetime
       end
 
       # Colonel-WRITABLE specs only: composition stays editable-kind-only, so
-      # sso/mailer declaring COLONEL_FIELD_SPECS does not make them PUTable
+      # sso/mailer declaring FIELD_SPECS does not make them PUTable
       # (field_specs returns {} for them and the routes reject via editable?).
       FIELD_SPECS = KINDS.each_with_object({}) do |(slug, entry), acc|
         next unless entry[:editable]
 
-        acc[slug] = entry[:model]::COLONEL_FIELD_SPECS
+        acc[slug] = entry[:model]::FIELD_SPECS
       end.freeze
 
       class << self

--- a/lib/onetime/models/custom_domain/homepage_config.rb
+++ b/lib/onetime/models/custom_domain/homepage_config.rb
@@ -103,14 +103,14 @@ module Onetime
       # secrets_mode (incoming_secrets entitlement + a ready IncomingConfig)
       # as admin-repair power; read paths still fail closed via
       # #effectively_enabled?.
-      COLONEL_FIELD_SPECS = {
+      FIELD_SPECS = {
         'enabled' => { type: :boolean, storage: :string },
         'secrets_mode' => { type: :enum, values: VALID_SECRETS_MODES, nullable: false },
         'disabled_homepage_variant' => { type: :enum, values: VALID_DISABLED_HOMEPAGE_VARIANTS, nullable: true },
       }.freeze
 
       # Tolerant predicates + normalizing setters for the boolean fields in
-      # COLONEL_FIELD_SPECS above (#3951). Must come after both the field
+      # FIELD_SPECS above (#3951). Must come after both the field
       # declarations and the constant. Provides #enabled? / #enabled=;
       # deliberately does NOT cover the deprecated signup_enabled /
       # signin_enabled read-echo fields (not in the specs).

--- a/lib/onetime/models/custom_domain/homepage_config.rb
+++ b/lib/onetime/models/custom_domain/homepage_config.rb
@@ -360,7 +360,7 @@ module Onetime
 
           if config
             config.created                 ||= now  # repair missing created from legacy records
-            config.enabled                   = enabled.to_s
+            config.enabled                   = enabled
             config.signup_enabled            = signup_enabled unless signup_enabled.nil?
             config.signin_enabled            = signin_enabled unless signin_enabled.nil?
             config.disabled_homepage_variant = coerce_disabled_homepage_variant(disabled_homepage_variant) unless disabled_homepage_variant.nil?

--- a/lib/onetime/models/custom_domain/homepage_config.rb
+++ b/lib/onetime/models/custom_domain/homepage_config.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require_relative '../features/boolean_encoding'
+
 #
 # CustomDomain::HomepageConfig - Per-domain homepage secrets configuration
 #
@@ -90,9 +92,12 @@ module Onetime
       # Colonel-writable fields, aggregated into
       # {Onetime::CustomDomain::ConfigRegistry::FIELD_SPECS} (the registry
       # validates at load time that every key has a setter here). `enabled`
-      # stores a legacy 'true'/'false' STRING (#enabled? tolerates both
-      # encodings). The deprecated signup_enabled/signin_enabled read-echo
-      # fields are deliberately NOT writable (ADR-030: no display authority).
+      # stores a legacy 'true'/'false' STRING; the boolean_encoding feature
+      # (below) normalizes writes to that encoding and keeps #enabled?
+      # tolerant of both (#3951). The deprecated signup_enabled/signin_enabled
+      # read-echo fields are deliberately NOT writable (ADR-030: no display
+      # authority) and NOT covered by the feature — they keep their strict
+      # `== true` predicates.
       #
       # Colonel PUT deliberately BYPASSES the workspace write gate on
       # secrets_mode (incoming_secrets entitlement + a ready IncomingConfig)
@@ -104,6 +109,13 @@ module Onetime
         'disabled_homepage_variant' => { type: :enum, values: VALID_DISABLED_HOMEPAGE_VARIANTS, nullable: true },
       }.freeze
 
+      # Tolerant predicates + normalizing setters for the boolean fields in
+      # COLONEL_FIELD_SPECS above (#3951). Must come after both the field
+      # declarations and the constant. Provides #enabled? / #enabled=;
+      # deliberately does NOT cover the deprecated signup_enabled /
+      # signin_enabled read-echo fields (not in the specs).
+      feature :boolean_encoding
+
       def init
         self.enabled      ||= 'false'
         self.signup_enabled = false if signup_enabled.nil?
@@ -112,13 +124,6 @@ module Onetime
         # makes freshly created records self-describing without masking legacy
         # records' nil field — those still read as 'create' via secrets_mode_value.
         self.secrets_mode ||= DEFAULT_SECRETS_MODE
-      end
-
-      # Check if homepage secrets is enabled for this domain.
-      #
-      # @return [Boolean] true if homepage secrets is active
-      def enabled?
-        enabled.to_s == 'true'
       end
 
       # Whether the Sign Up link should render on this domain's homepage.
@@ -328,9 +333,10 @@ module Onetime
         #
         # @param domain_id [String] CustomDomain identifier
         # @param enabled [Boolean, String] Whether to enable homepage secrets.
-        #   Required by every call site; passing nil coerces to the string
-        #   "nil", which #enabled? reads as false — the safe default, but
-        #   not a validated one, so don't rely on this to reject bad input.
+        #   Required by every call site; any non-truthy value (including nil)
+        #   is normalized to the stored 'false' by the boolean_encoding
+        #   setter — the safe default, but not a validated one, so don't rely
+        #   on this to reject bad input.
         # @param signup_enabled [Boolean, nil] DEPRECATED (#3672, ADR-030):
         #   the field carries no display authority (see the field declaration).
         #   The API no longer passes it; kept so the disable_homepage_auth_links

--- a/lib/onetime/models/custom_domain/incoming_config.rb
+++ b/lib/onetime/models/custom_domain/incoming_config.rb
@@ -67,7 +67,7 @@ module Onetime
       # (below) normalizes writes to that encoding and keeps #enabled?
       # tolerant of both (#3951). Recipients stay workspace-managed in v1 —
       # enabled only.
-      COLONEL_FIELD_SPECS = {
+      FIELD_SPECS = {
         'enabled' => { type: :boolean, storage: :string },
       }.freeze
 

--- a/lib/onetime/models/custom_domain/incoming_config.rb
+++ b/lib/onetime/models/custom_domain/incoming_config.rb
@@ -4,6 +4,7 @@
 
 require 'digest/sha2'
 require_relative '../../security/input_sanitizers'
+require_relative '../features/boolean_encoding'
 
 #
 # CustomDomain::IncomingConfig - Per-domain incoming secrets recipient storage
@@ -62,22 +63,22 @@ module Onetime
       # Colonel-writable fields, aggregated into
       # {Onetime::CustomDomain::ConfigRegistry::FIELD_SPECS} (the registry
       # validates at load time that every key has a setter here). `enabled`
-      # stores a legacy 'true'/'false' STRING (#enabled? tolerates both
-      # encodings). Recipients stay workspace-managed in v1 — enabled only.
+      # stores a legacy 'true'/'false' STRING; the boolean_encoding feature
+      # (below) normalizes writes to that encoding and keeps #enabled?
+      # tolerant of both (#3951). Recipients stay workspace-managed in v1 —
+      # enabled only.
       COLONEL_FIELD_SPECS = {
         'enabled' => { type: :boolean, storage: :string },
       }.freeze
 
+      # Tolerant predicate + normalizing setter for `enabled` per the spec
+      # above (#3951). Must come after both the field declaration and the
+      # constant.
+      feature :boolean_encoding
+
       def init
         self.enabled         ||= 'false'
         self.recipients_json ||= '[]'
-      end
-
-      # Check if incoming secrets is enabled for this domain.
-      #
-      # @return [Boolean] true if incoming secrets is active
-      def enabled?
-        enabled.to_s == 'true'
       end
 
       # Whether this config can actually receive secrets: enabled AND at

--- a/lib/onetime/models/custom_domain/mailer_config.rb
+++ b/lib/onetime/models/custom_domain/mailer_config.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require_relative '../features/boolean_encoding'
+
 #
 # CustomDomain::MailerConfig - Per-domain mail sender configuration
 #
@@ -118,19 +120,30 @@ module Onetime
       field :created
       field :updated
 
+      # Boolean field encoding spec consumed by the boolean_encoding feature
+      # (below) and the registry's load-time setter check. Mailer is NOT
+      # colonel-editable (ConfigRegistry KINDS `editable: false` — create
+      # paths enforce credential/from_address validation), so this does NOT
+      # enter the registry's FIELD_SPECS composition; it exists so `enabled`
+      # shares the one normalizing writer/predicate idiom (#3951). The
+      # TRI-STATE worker-written outcome fields (dns_verified /
+      # provider_verified: nil = unknown) are deliberately excluded — they
+      # keep parse_boolean_field's nil-preserving semantics.
+      COLONEL_FIELD_SPECS = {
+        'enabled' => { type: :boolean, storage: :string },
+      }.freeze
+
+      # Tolerant predicate + normalizing setter for `enabled` per the spec
+      # above (#3951). Must come after both the field declaration and the
+      # constant.
+      feature :boolean_encoding
+
       def init
         self.enabled             ||= 'false'
         self.verification_status ||= 'pending'
         self.sending_mode        ||= 'platform'
         # Job lifecycle fields default to nil (no job enqueued yet)
         # Outcome fields default to nil (unknown/pending)
-      end
-
-      # Check if this mailer config is enabled.
-      #
-      # @return [Boolean] true if mailer config is active
-      def enabled?
-        enabled.to_s == 'true'
       end
 
       # Check if the sender address has been verified via DNS.

--- a/lib/onetime/models/custom_domain/mailer_config.rb
+++ b/lib/onetime/models/custom_domain/mailer_config.rb
@@ -120,16 +120,14 @@ module Onetime
       field :created
       field :updated
 
-      # Boolean field encoding spec consumed by the boolean_encoding feature
-      # (below) and the registry's load-time setter check. Mailer is NOT
-      # colonel-editable (ConfigRegistry KINDS `editable: false` — create
-      # paths enforce credential/from_address validation), so this does NOT
-      # enter the registry's FIELD_SPECS composition; it exists so `enabled`
-      # shares the one normalizing writer/predicate idiom (#3951). The
+      # Field encoding spec consumed by the boolean_encoding feature (below)
+      # and the registry's load-time setter check. Mailer is not
+      # colonel-editable (ConfigRegistry KINDS `editable: false`), so this
+      # does not enter the registry's composed FIELD_SPECS (#3951). The
       # TRI-STATE worker-written outcome fields (dns_verified /
       # provider_verified: nil = unknown) are deliberately excluded — they
       # keep parse_boolean_field's nil-preserving semantics.
-      COLONEL_FIELD_SPECS = {
+      FIELD_SPECS = {
         'enabled' => { type: :boolean, storage: :string },
       }.freeze
 

--- a/lib/onetime/models/custom_domain/signin_config.rb
+++ b/lib/onetime/models/custom_domain/signin_config.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require_relative '../features/boolean_encoding'
+
 #
 # CustomDomain::SigninConfig - Per-domain sign-in method configuration
 #
@@ -94,27 +96,16 @@ module Onetime
         'restrict_to' => { type: :enum, values: RESTRICT_TO_VALUES, nullable: true },
       }.freeze
 
+      # Tolerant predicates + normalizing setters for the boolean fields in
+      # COLONEL_FIELD_SPECS above (#3951). Must come after both the field
+      # declarations and the constant.
+      feature :boolean_encoding
+
       def init
         self.enabled            = false if enabled.nil?
         self.signin_enabled     = false if signin_enabled.nil?
         self.email_auth_enabled = false if email_auth_enabled.nil?
         self.sso_enabled        = false if sso_enabled.nil?
-      end
-
-      def enabled?
-        enabled == true
-      end
-
-      def signin_enabled?
-        signin_enabled == true
-      end
-
-      def email_auth_enabled?
-        email_auth_enabled == true
-      end
-
-      def sso_enabled?
-        sso_enabled == true
       end
 
       # Validate that all required fields are present.

--- a/lib/onetime/models/custom_domain/signin_config.rb
+++ b/lib/onetime/models/custom_domain/signin_config.rb
@@ -88,7 +88,7 @@ module Onetime
       # change. All boolean fields on this model store REAL booleans
       # (storage :native); the enum references the model constant so values
       # cannot drift.
-      COLONEL_FIELD_SPECS = {
+      FIELD_SPECS = {
         'enabled' => { type: :boolean, storage: :native },
         'signin_enabled' => { type: :boolean, storage: :native },
         'email_auth_enabled' => { type: :boolean, storage: :native },
@@ -97,7 +97,7 @@ module Onetime
       }.freeze
 
       # Tolerant predicates + normalizing setters for the boolean fields in
-      # COLONEL_FIELD_SPECS above (#3951). Must come after both the field
+      # FIELD_SPECS above (#3951). Must come after both the field
       # declarations and the constant.
       feature :boolean_encoding
 

--- a/lib/onetime/models/custom_domain/signup_config.rb
+++ b/lib/onetime/models/custom_domain/signup_config.rb
@@ -96,7 +96,7 @@ module Onetime
       # are normalized to the declared storage on assignment (#3951).
       # allowed_signup_domains routes through the model setter
       # (PublicSuffix validation, raises Onetime::Problem).
-      COLONEL_FIELD_SPECS = {
+      FIELD_SPECS = {
         'enabled' => { type: :boolean, storage: :string },
         'signup_enabled' => { type: :boolean, storage: :native },
         'autoverify' => { type: :boolean, storage: :native },
@@ -105,7 +105,7 @@ module Onetime
       }.freeze
 
       # Tolerant predicates + normalizing setters for the boolean fields in
-      # COLONEL_FIELD_SPECS above (#3951). Must come after both the field
+      # FIELD_SPECS above (#3951). Must come after both the field
       # declarations and the constant.
       feature :boolean_encoding
 

--- a/lib/onetime/models/custom_domain/signup_config.rb
+++ b/lib/onetime/models/custom_domain/signup_config.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require_relative '../features/boolean_encoding'
+
 #
 # CustomDomain::SignupConfig - Per-domain signup email validation strategy
 #
@@ -86,10 +88,13 @@ module Onetime
       # {Onetime::CustomDomain::ConfigRegistry::FIELD_SPECS} (the registry
       # validates at load time that every key has a setter here). This model's
       # MIXED boolean encoding is declared HERE so the registry carries no
-      # second copy: `enabled` stores a legacy 'true'/'false' STRING
-      # (workspace writers in apps/api/domains assign `.to_s`; #enabled?
-      # tolerates both encodings), while signup_enabled/autoverify store REAL
-      # booleans. allowed_signup_domains routes through the model setter
+      # second copy: `enabled` stores a legacy 'true'/'false' STRING while
+      # signup_enabled/autoverify store REAL booleans. The boolean_encoding
+      # feature (below) reads these specs to build tolerant predicates and
+      # normalizing setters, so writers that assign the "wrong" encoding
+      # (console, create!, the `.to_s` workspace writers in apps/api/domains)
+      # are normalized to the declared storage on assignment (#3951).
+      # allowed_signup_domains routes through the model setter
       # (PublicSuffix validation, raises Onetime::Problem).
       COLONEL_FIELD_SPECS = {
         'enabled' => { type: :boolean, storage: :string },
@@ -99,34 +104,16 @@ module Onetime
         'allowed_signup_domains' => { type: :string_array },
       }.freeze
 
+      # Tolerant predicates + normalizing setters for the boolean fields in
+      # COLONEL_FIELD_SPECS above (#3951). Must come after both the field
+      # declarations and the constant.
+      feature :boolean_encoding
+
       def init
         self.enabled             ||= 'false'
         self.validation_strategy ||= 'passthrough'
         self.signup_enabled        = false if signup_enabled.nil?
         self.autoverify            = false if autoverify.nil?
-      end
-
-      # Check if this config is enabled.
-      #
-      # @return [Boolean] true if per-domain validation is active
-      def enabled?
-        enabled.to_s == 'true'
-      end
-
-      # Whether signup is enabled on this domain.
-      # Treats legacy nil as false (conservative: off until explicitly enabled).
-      #
-      # @return [Boolean]
-      def signup_enabled?
-        signup_enabled == true
-      end
-
-      # Whether new accounts skip email verification on this domain.
-      # Treats legacy nil as false (conservative: require verification).
-      #
-      # @return [Boolean]
-      def autoverify?
-        autoverify == true
       end
 
       # Returns metadata for the current validation strategy.

--- a/lib/onetime/models/custom_domain/sso_config.rb
+++ b/lib/onetime/models/custom_domain/sso_config.rb
@@ -123,20 +123,18 @@ module Onetime
       field :enforce_sso_only  # Boolean string ('true'/'false')
       field :grant_org_scope   # Boolean string ('true'/'false')
 
-      # Boolean field encoding specs consumed by the boolean_encoding feature
-      # (below) and the registry's load-time setter check. SSO is NOT
-      # colonel-editable (ConfigRegistry KINDS `editable: false` — create
-      # paths enforce credential validation), so these do NOT enter the
-      # registry's FIELD_SPECS composition; they exist so this model's
-      # boolean writers/predicates share the one normalizing idiom (#3951).
-      COLONEL_FIELD_SPECS = {
+      # Field encoding specs consumed by the boolean_encoding feature (below)
+      # and the registry's load-time setter check. SSO is not colonel-editable
+      # (ConfigRegistry KINDS `editable: false`), so these do not enter the
+      # registry's composed FIELD_SPECS (#3951).
+      FIELD_SPECS = {
         'enabled' => { type: :boolean, storage: :string },
         'enforce_sso_only' => { type: :boolean, storage: :string },
         'grant_org_scope' => { type: :boolean, storage: :string },
       }.freeze
 
       # Tolerant predicates + normalizing setters for the boolean fields in
-      # COLONEL_FIELD_SPECS above (#3951). Must come after both the field
+      # FIELD_SPECS above (#3951). Must come after both the field
       # declarations and the constant.
       feature :boolean_encoding
 

--- a/lib/onetime/models/custom_domain/sso_config.rb
+++ b/lib/onetime/models/custom_domain/sso_config.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require_relative '../features/boolean_encoding'
+
 #
 # CustomDomain::SsoConfig - Per-domain SSO credential storage
 #
@@ -121,29 +123,28 @@ module Onetime
       field :enforce_sso_only  # Boolean string ('true'/'false')
       field :grant_org_scope   # Boolean string ('true'/'false')
 
+      # Boolean field encoding specs consumed by the boolean_encoding feature
+      # (below) and the registry's load-time setter check. SSO is NOT
+      # colonel-editable (ConfigRegistry KINDS `editable: false` — create
+      # paths enforce credential validation), so these do NOT enter the
+      # registry's FIELD_SPECS composition; they exist so this model's
+      # boolean writers/predicates share the one normalizing idiom (#3951).
+      COLONEL_FIELD_SPECS = {
+        'enabled' => { type: :boolean, storage: :string },
+        'enforce_sso_only' => { type: :boolean, storage: :string },
+        'grant_org_scope' => { type: :boolean, storage: :string },
+      }.freeze
+
+      # Tolerant predicates + normalizing setters for the boolean fields in
+      # COLONEL_FIELD_SPECS above (#3951). Must come after both the field
+      # declarations and the constant.
+      feature :boolean_encoding
+
       def init
         self.enabled          ||= 'false'
         self.provider_type    ||= 'oidc'
         self.enforce_sso_only ||= 'false'
         self.grant_org_scope  ||= 'false'
-      end
-
-      # Check if SSO is enabled for this domain.
-      #
-      # @return [Boolean] true if SSO is active
-      def enabled?
-        enabled.to_s == 'true'
-      end
-
-      # Check if SSO-only login is enforced (blocking password/other auth).
-      #
-      # @return [Boolean] true if SSO is the only allowed auth method
-      def enforce_sso_only?
-        enforce_sso_only.to_s == 'true'
-      end
-
-      def grant_org_scope?
-        grant_org_scope.to_s == 'true'
       end
 
       # Returns metadata for the current provider type.

--- a/lib/onetime/models/features/boolean_encoding.rb
+++ b/lib/onetime/models/features/boolean_encoding.rb
@@ -22,7 +22,7 @@ module Onetime
       # rewrite of existing rows.
       #
       # Enable with +feature :boolean_encoding+ AFTER both the field
-      # declarations and the COLONEL_FIELD_SPECS constant. For each spec entry
+      # declarations and the FIELD_SPECS constant. For each spec entry
       # with +type: :boolean+ the feature prepends, per field:
       #
       #   - +#{field}?+  — true iff the stored value is one of
@@ -43,7 +43,7 @@ module Onetime
       # bytes written via e.g. +enabled!(true)+ may be un-normalized. Read
       # tolerance covers such records; prefer +enabled=+ then +save+.
       #
-      # The model's COLONEL_FIELD_SPECS constant is the single source of truth
+      # The model's FIELD_SPECS constant is the single source of truth
       # for which fields are boolean and how each is stored; the registry's
       # load-time transcription check validates every spec'd field has a
       # setter (see ConfigRegistry).
@@ -58,12 +58,12 @@ module Onetime
         def self.included(base)
           OT.ld "[features] #{base}: #{name}"
 
-          unless base.const_defined?(:COLONEL_FIELD_SPECS)
+          unless base.const_defined?(:FIELD_SPECS)
             raise Familia::Problem,
-              "#{base}: COLONEL_FIELD_SPECS must be defined before `feature :boolean_encoding`"
+              "#{base}: FIELD_SPECS must be defined before `feature :boolean_encoding`"
           end
 
-          boolean_specs = base.const_get(:COLONEL_FIELD_SPECS).select do |_field, spec|
+          boolean_specs = base.const_get(:FIELD_SPECS).select do |_field, spec|
             spec[:type] == :boolean
           end
 
@@ -75,7 +75,7 @@ module Onetime
             next if base.fields.include?(field.to_sym)
 
             raise Familia::Problem,
-              "#{base}: COLONEL_FIELD_SPECS declares boolean field '#{field}' " \
+              "#{base}: FIELD_SPECS declares boolean field '#{field}' " \
               'but no matching Familia field is declared'
           end
 

--- a/lib/onetime/models/features/boolean_encoding.rb
+++ b/lib/onetime/models/features/boolean_encoding.rb
@@ -1,0 +1,124 @@
+# lib/onetime/models/features/boolean_encoding.rb
+#
+# frozen_string_literal: true
+
+require 'familia'
+
+module Onetime
+  module Models
+    module Features
+      # Tolerant boolean predicates + normalizing setters for the per-domain
+      # config models (#3951).
+      #
+      # The seven CustomDomain config models historically disagreed on boolean
+      # persistence: some fields store REAL booleans (storage :native), others
+      # store 'true'/'false' STRINGS (storage :string). Writers that bypass
+      # ConfigRegistry.apply_field (console sessions, create!/upsert class
+      # methods) could persist the "wrong" encoding for a field, and the old
+      # strict predicates (`== true`) then silently read the record as
+      # disabled. This feature makes every declared boolean field tolerant on
+      # READ and normalizing on WRITE, so a mixed-encoding write can no longer
+      # produce a silently-disabled record — with NO data migration and no
+      # rewrite of existing rows.
+      #
+      # Enable with +feature :boolean_encoding+ AFTER both the field
+      # declarations and the COLONEL_FIELD_SPECS constant. For each spec entry
+      # with +type: :boolean+ the feature prepends, per field:
+      #
+      #   - +#{field}?+  — true iff the stored value is one of
+      #     true/'true'/1/'1'. Everything else — nil, '', garbage strings —
+      #     reads as false (conservative default).
+      #   - +#{field}=+  — nil passes through unchanged (nil means unset);
+      #     any other value is normalized to the field's declared storage
+      #     encoding ('true'/'false' for :string, real booleans for :native)
+      #     before calling +super+ into Familia's generated writer.
+      #
+      # The writer is idempotent under ConfigRegistry.apply_field's
+      # pre-encoding: a 'true' string arriving at a :string field stays 'true'
+      # byte-for-byte, and a real boolean arriving at a :native field stays a
+      # boolean, so colonel PUT stored bytes do not change.
+      #
+      # Familia fast writers (+field!+) bypass the prepended writer for the
+      # persisted value — they hset the serialized raw input directly — so
+      # bytes written via e.g. +enabled!(true)+ may be un-normalized. Read
+      # tolerance covers such records; prefer +enabled=+ then +save+.
+      #
+      # The model's COLONEL_FIELD_SPECS constant is the single source of truth
+      # for which fields are boolean and how each is stored; the registry's
+      # load-time transcription check validates every spec'd field has a
+      # setter (see ConfigRegistry).
+      module BooleanEncoding
+        Familia::Base.add_feature self, :boolean_encoding
+
+        # Inputs that read and write as "set". Everything else — including
+        # nil, '', and garbage strings — reads as false; on write, non-nil
+        # non-truthy values normalize to the encoded false.
+        TRUTHY_VALUES = [true, 'true', 1, '1'].freeze
+
+        def self.included(base)
+          OT.ld "[features] #{base}: #{name}"
+
+          unless base.const_defined?(:COLONEL_FIELD_SPECS)
+            raise Familia::Problem,
+              "#{base}: COLONEL_FIELD_SPECS must be defined before `feature :boolean_encoding`"
+          end
+
+          boolean_specs = base.const_get(:COLONEL_FIELD_SPECS).select do |_field, spec|
+            spec[:type] == :boolean
+          end
+
+          # Fail at load for a typo'd/renamed spec field. Without this, the
+          # accessors below would satisfy ConfigRegistry's method_defined?
+          # transcription check for ANY spec'd boolean name, deferring the
+          # failure to a runtime NoMethodError on super.
+          boolean_specs.each_key do |field|
+            next if base.fields.include?(field.to_sym)
+
+            raise Familia::Problem,
+              "#{base}: COLONEL_FIELD_SPECS declares boolean field '#{field}' " \
+              'but no matching Familia field is declared'
+          end
+
+          accessors = build_accessor_module(boolean_specs)
+          # Name the anonymous module so ancestors/Method#owner are readable
+          # in debugging output (parens keep it an invalid constant path).
+          accessors.set_temporary_name("#{base.name}::BooleanEncoding(accessors)") if base.name
+          base.prepend(accessors)
+        end
+
+        # Build an anonymous module defining the tolerant predicate and
+        # normalizing writer for each boolean field. The module is PREPENDED
+        # (not included) so the writer can call +super+ into Familia's
+        # generated setter, which owns ivar assignment and dirty tracking.
+        #
+        # @param boolean_specs [Hash{String => Hash}] field => spec, boolean only
+        # @return [Module]
+        def self.build_accessor_module(boolean_specs)
+          Module.new do
+            boolean_specs.each do |field, spec|
+              string_storage = spec[:storage] == :string
+
+              define_method(:"#{field}?") do
+                TRUTHY_VALUES.include?(send(field))
+              end
+
+              define_method(:"#{field}=") do |value|
+                if value.nil?
+                  super(nil) # nil means unset — pass through, never coerce
+                else
+                  truthy  = TRUTHY_VALUES.include?(value)
+                  encoded = if string_storage
+                              truthy ? 'true' : 'false'
+                            else
+                              truthy
+                            end
+                  super(encoded)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/try/integration/api/colonel/config_registry_drift_try.rb
+++ b/try/integration/api/colonel/config_registry_drift_try.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 # Drift guard for Onetime::CustomDomain::ConfigRegistry and the per-model
-# COLONEL_FIELD_SPECS constants it composes (signin/signup/homepage/api/
+# FIELD_SPECS constants it composes (signin/signup/homepage/api/
 # incoming own their writable-field specs; sso/mailer contribute none).
 #
 # Every case WALKS the registry programmatically — no hand-copied field

--- a/try/unit/models/custom_domain_config_boolean_encoding_try.rb
+++ b/try/unit/models/custom_domain_config_boolean_encoding_try.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 # Matrix tests for the boolean_encoding feature (#3951) across ALL SEVEN
-# CustomDomain config models and every COLONEL_FIELD_SPECS boolean field.
+# CustomDomain config models and every FIELD_SPECS boolean field.
 #
 # Background: the seven config models historically disagreed on boolean
 # persistence — some fields store REAL booleans (storage :native), others
@@ -25,12 +25,12 @@
 #   - LEGACY/opposite-encoding persisted records (raw hset of 'true' and
 #     '"true"') read as enabled after reload, on one :native model
 #     (SigninConfig) and one :string model (SsoConfig)
-#   - A typo'd/renamed boolean field in COLONEL_FIELD_SPECS raises at
+#   - A typo'd/renamed boolean field in FIELD_SPECS raises at
 #     feature-enable (load) time, since the generated accessors would
 #     otherwise satisfy ConfigRegistry's method_defined? transcription check
 #
 # Field/storage map under test (single source of truth is each model's
-# COLONEL_FIELD_SPECS):
+# FIELD_SPECS):
 #   SigninConfig   enabled, signin_enabled, email_auth_enabled, sso_enabled  :native
 #   SignupConfig   enabled :string; signup_enabled, autoverify :native (MIXED)
 #   HomepageConfig enabled :string
@@ -48,7 +48,7 @@ require_relative '../../support/test_models'
 OT.boot! :test
 
 Familia.dbclient.flushdb
-OT.info "Cleaned Redis for config boolean encoding matrix test run"
+OT.info 'Cleaned Redis for config boolean encoding matrix test run'
 
 TRUTHY_INPUTS = [true, 'true', 1, '1'].freeze
 FALSY_INPUTS  = [false, 'false', 0, '0'].freeze
@@ -78,15 +78,15 @@ def nil_passthrough(obj, fields)
   end.uniq
 end
 
-@ts = Familia.now.to_i
+@ts      = Familia.now.to_i
 @entropy = SecureRandom.hex(4)
-@owner = Onetime::Customer.create!(email: "be_owner_#{@ts}_#{@entropy}@test.com")
-@org = Onetime::Organization.create!("BE Test Org #{@ts}", @owner, "be_#{@ts}@test.com")
+@owner   = Onetime::Customer.create!(email: "be_owner_#{@ts}_#{@entropy}@test.com")
+@org     = Onetime::Organization.create!("BE Test Org #{@ts}", @owner, "be_#{@ts}@test.com")
 
 # CustomDomain.create! bootstraps HomepageConfig + ApiConfig (disabled); the
 # other five kinds are created explicitly against the same domain.
 @domain = Onetime::CustomDomain.create!("be-matrix-#{@ts}-#{@entropy}.example.com", @org.objid)
-@did = @domain.identifier
+@did    = @domain.identifier
 
 @signin   = Onetime::CustomDomain::SigninConfig.create!(domain_id: @did)
 @signup   = Onetime::CustomDomain::SignupConfig.create!(domain_id: @did, validation_strategy: 'passthrough')
@@ -100,7 +100,7 @@ end
 )
 # SsoConfig.create! validates credentials (encrypted fields); the boolean
 # machinery needs neither, so build via new + save.
-@sso = Onetime::CustomDomain::SsoConfig.new(domain_id: @did)
+@sso      = Onetime::CustomDomain::SsoConfig.new(domain_id: @did)
 @sso.save
 
 # --- SigninConfig: four :native boolean fields ---
@@ -223,7 +223,7 @@ nil_passthrough(@mailer, %w[enabled])
 ## Legacy on :native model (SigninConfig): raw unquoted 'true' loads as a
 ## boolean and reads enabled
 @legacy_dom_n = Onetime::CustomDomain.create!("be-legacy-n-#{@ts}-#{@entropy}.example.com", @org.objid)
-@legacy_si = Onetime::CustomDomain::SigninConfig.create!(domain_id: @legacy_dom_n.identifier)
+@legacy_si    = Onetime::CustomDomain::SigninConfig.create!(domain_id: @legacy_dom_n.identifier)
 Familia.dbclient.hset(@legacy_si.dbkey, 'enabled', 'true')
 Onetime::CustomDomain::SigninConfig.find_by_domain_id(@legacy_dom_n.identifier).enabled?
 #=> true
@@ -245,7 +245,7 @@ Familia.dbclient.hset(@legacy_si.dbkey, 'signin_enabled', '"true"')
 ## Legacy on :string model (SsoConfig): raw unquoted 'true' — the OPPOSITE
 ## (boolean) encoding for a string field — loads as a boolean and reads enabled
 @legacy_dom_s = Onetime::CustomDomain.create!("be-legacy-s-#{@ts}-#{@entropy}.example.com", @org.objid)
-@legacy_sso = Onetime::CustomDomain::SsoConfig.new(domain_id: @legacy_dom_s.identifier)
+@legacy_sso   = Onetime::CustomDomain::SsoConfig.new(domain_id: @legacy_dom_s.identifier)
 @legacy_sso.save
 Familia.dbclient.hset(@legacy_sso.dbkey, 'enabled', 'true')
 Onetime::CustomDomain::SsoConfig.find_by_domain_id(@legacy_dom_s.identifier).enabled?
@@ -259,7 +259,7 @@ Onetime::CustomDomain::SsoConfig.find_by_domain_id(@legacy_dom_s.identifier).enf
 
 # --- Load-time guard: typo'd spec field fails fast (#3951 AC6) ---
 
-## A typo'd/renamed boolean field in COLONEL_FIELD_SPECS raises
+## A typo'd/renamed boolean field in FIELD_SPECS raises
 ## Familia::Problem at feature-enable time. Without this guard the feature
 ## would define accessors for the bogus name (satisfying ConfigRegistry's
 ## method_defined? check) and the failure would surface only as a runtime
@@ -270,19 +270,22 @@ begin
     identifier_field :domain_id
     field :domain_id
     field :enabled
-    const_set(:COLONEL_FIELD_SPECS, {
-      'enabled' => { type: :boolean, storage: :string },
-      'tpyoed_field' => { type: :boolean, storage: :string },
-    }.freeze)
+    const_set(
+      :FIELD_SPECS,
+      {
+        'enabled' => { type: :boolean, storage: :string },
+        'tpyoed_field' => { type: :boolean, storage: :string },
+      }.freeze,
+    )
     feature :boolean_encoding
   end
   :no_raise
-rescue Familia::Problem => e
-  e.message.include?("declares boolean field 'tpyoed_field'")
+rescue Familia::Problem => ex
+  ex.message.include?("declares boolean field 'tpyoed_field'")
 end
 #=> true
 
 # --- Cleanup ---
 
 Familia.dbclient.flushdb
-OT.info "Cleaned Redis after config boolean encoding matrix test run"
+OT.info 'Cleaned Redis after config boolean encoding matrix test run'

--- a/try/unit/models/custom_domain_config_boolean_encoding_try.rb
+++ b/try/unit/models/custom_domain_config_boolean_encoding_try.rb
@@ -1,0 +1,288 @@
+# try/unit/models/custom_domain_config_boolean_encoding_try.rb
+#
+# frozen_string_literal: true
+
+# Matrix tests for the boolean_encoding feature (#3951) across ALL SEVEN
+# CustomDomain config models and every COLONEL_FIELD_SPECS boolean field.
+#
+# Background: the seven config models historically disagreed on boolean
+# persistence — some fields store REAL booleans (storage :native), others
+# store 'true'/'false' STRINGS (storage :string). Writers that bypass
+# ConfigRegistry.apply_field (console, create!/upsert) could persist the
+# "wrong" encoding, and the old strict `== true` predicates then silently
+# read the record as disabled. The boolean_encoding feature makes every
+# declared boolean field tolerant on READ and normalizing on WRITE.
+#
+# Covers, for each spec'd boolean field:
+#   - Assigning each of true, 'true', 1, '1' reads true through the predicate
+#     AND persists in the model's DECLARED storage encoding. Raw hash bytes
+#     verified via Familia.dbclient.hget(obj.dbkey, field):
+#       :native  -> unquoted 'true'  (Familia JSON round-trip of boolean)
+#       :string  -> '"true"'         (JSON-quoted string)
+#   - Assigning each of false, 'false', 0, '0' reads false and persists the
+#     encoded false the same way
+#   - nil passes through the setter unchanged (nil means unset, never coerced)
+#   - LEGACY/opposite-encoding persisted records (raw hset of 'true' and
+#     '"true"') read as enabled after reload, on one :native model
+#     (SigninConfig) and one :string model (SsoConfig)
+#   - A typo'd/renamed boolean field in COLONEL_FIELD_SPECS raises at
+#     feature-enable (load) time, since the generated accessors would
+#     otherwise satisfy ConfigRegistry's method_defined? transcription check
+#
+# Field/storage map under test (single source of truth is each model's
+# COLONEL_FIELD_SPECS):
+#   SigninConfig   enabled, signin_enabled, email_auth_enabled, sso_enabled  :native
+#   SignupConfig   enabled :string; signup_enabled, autoverify :native (MIXED)
+#   HomepageConfig enabled :string
+#   ApiConfig      enabled :string
+#   IncomingConfig enabled :string
+#   SsoConfig      enabled, enforce_sso_only, grant_org_scope :string
+#   MailerConfig   enabled :string (tri-state dns_verified/provider_verified
+#                  are deliberately NOT spec'd and NOT covered here)
+#
+# Run:
+#   try try/unit/models/custom_domain_config_boolean_encoding_try.rb --agent
+
+require_relative '../../support/test_models'
+
+OT.boot! :test
+
+Familia.dbclient.flushdb
+OT.info "Cleaned Redis for config boolean encoding matrix test run"
+
+TRUTHY_INPUTS = [true, 'true', 1, '1'].freeze
+FALSY_INPUTS  = [false, 'false', 0, '0'].freeze
+
+# Assign each input to each field, save, then read back the predicate AND the
+# raw stored hash bytes. Returns the uniq [predicate, raw] pairs — a
+# single-element result proves every input converged on ONE read result and
+# ONE stored encoding.
+def boolean_matrix(obj, fields, inputs)
+  Array(fields).flat_map do |field|
+    inputs.map do |input|
+      obj.send(:"#{field}=", input)
+      obj.save
+      [obj.send(:"#{field}?"), Familia.dbclient.hget(obj.dbkey, field.to_s)]
+    end
+  end.uniq
+end
+
+# nil must pass through the setter unchanged (nil means unset — the feature
+# never coerces it to an encoded false). Returns uniq
+# [value_is_nil, predicate] pairs; expect [[true, false]].
+def nil_passthrough(obj, fields)
+  Array(fields).map do |field|
+    obj.send(:"#{field}=", true) # prove nil actually overwrites a set value
+    obj.send(:"#{field}=", nil)
+    [obj.send(field).nil?, obj.send(:"#{field}?")]
+  end.uniq
+end
+
+@ts = Familia.now.to_i
+@entropy = SecureRandom.hex(4)
+@owner = Onetime::Customer.create!(email: "be_owner_#{@ts}_#{@entropy}@test.com")
+@org = Onetime::Organization.create!("BE Test Org #{@ts}", @owner, "be_#{@ts}@test.com")
+
+# CustomDomain.create! bootstraps HomepageConfig + ApiConfig (disabled); the
+# other five kinds are created explicitly against the same domain.
+@domain = Onetime::CustomDomain.create!("be-matrix-#{@ts}-#{@entropy}.example.com", @org.objid)
+@did = @domain.identifier
+
+@signin   = Onetime::CustomDomain::SigninConfig.create!(domain_id: @did)
+@signup   = Onetime::CustomDomain::SignupConfig.create!(domain_id: @did, validation_strategy: 'passthrough')
+@homepage = Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@did)
+@api      = Onetime::CustomDomain::ApiConfig.find_by_domain_id(@did)
+@incoming = Onetime::CustomDomain::IncomingConfig.create!(domain_id: @did)
+@mailer   = Onetime::CustomDomain::MailerConfig.create!(
+  domain_id: @did,
+  provider: 'ses',
+  from_address: "noreply@be-matrix-#{@ts}.example.com",
+)
+# SsoConfig.create! validates credentials (encrypted fields); the boolean
+# machinery needs neither, so build via new + save.
+@sso = Onetime::CustomDomain::SsoConfig.new(domain_id: @did)
+@sso.save
+
+# --- SigninConfig: four :native boolean fields ---
+
+## SigninConfig truthy matrix: true/'true'/1/'1' all read true and store the
+## native (unquoted) boolean encoding on every spec'd field
+boolean_matrix(@signin, %w[enabled signin_enabled email_auth_enabled sso_enabled], TRUTHY_INPUTS)
+#=> [[true, 'true']]
+
+## SigninConfig falsy matrix: false/'false'/0/'0' all read false, stored native
+boolean_matrix(@signin, %w[enabled signin_enabled email_auth_enabled sso_enabled], FALSY_INPUTS)
+#=> [[false, 'false']]
+
+## SigninConfig nil passthrough: setter never coerces nil; predicate reads false
+nil_passthrough(@signin, %w[enabled signin_enabled email_auth_enabled sso_enabled])
+#=> [[true, false]]
+
+# --- SignupConfig: MIXED encoding (enabled :string; the rest :native) ---
+
+## SignupConfig enabled (:string) truthy matrix: stores JSON-quoted '"true"'
+boolean_matrix(@signup, %w[enabled], TRUTHY_INPUTS)
+#=> [[true, '"true"']]
+
+## SignupConfig enabled (:string) falsy matrix: stores JSON-quoted '"false"'
+boolean_matrix(@signup, %w[enabled], FALSY_INPUTS)
+#=> [[false, '"false"']]
+
+## SignupConfig signup_enabled/autoverify (:native) truthy matrix: store
+## unquoted booleans even when assigned strings — normalized on write
+boolean_matrix(@signup, %w[signup_enabled autoverify], TRUTHY_INPUTS)
+#=> [[true, 'true']]
+
+## SignupConfig signup_enabled/autoverify (:native) falsy matrix
+boolean_matrix(@signup, %w[signup_enabled autoverify], FALSY_INPUTS)
+#=> [[false, 'false']]
+
+## SignupConfig nil passthrough across all three boolean fields
+nil_passthrough(@signup, %w[enabled signup_enabled autoverify])
+#=> [[true, false]]
+
+# --- HomepageConfig: enabled :string ---
+
+## HomepageConfig enabled truthy matrix: stores '"true"'
+boolean_matrix(@homepage, %w[enabled], TRUTHY_INPUTS)
+#=> [[true, '"true"']]
+
+## HomepageConfig enabled falsy matrix: stores '"false"'
+boolean_matrix(@homepage, %w[enabled], FALSY_INPUTS)
+#=> [[false, '"false"']]
+
+## HomepageConfig nil passthrough
+nil_passthrough(@homepage, %w[enabled])
+#=> [[true, false]]
+
+# --- ApiConfig: enabled :string ---
+
+## ApiConfig enabled truthy matrix: stores '"true"'
+boolean_matrix(@api, %w[enabled], TRUTHY_INPUTS)
+#=> [[true, '"true"']]
+
+## ApiConfig enabled falsy matrix: stores '"false"'
+boolean_matrix(@api, %w[enabled], FALSY_INPUTS)
+#=> [[false, '"false"']]
+
+## ApiConfig nil passthrough
+nil_passthrough(@api, %w[enabled])
+#=> [[true, false]]
+
+# --- IncomingConfig: enabled :string ---
+
+## IncomingConfig enabled truthy matrix: stores '"true"'
+boolean_matrix(@incoming, %w[enabled], TRUTHY_INPUTS)
+#=> [[true, '"true"']]
+
+## IncomingConfig enabled falsy matrix: stores '"false"'
+boolean_matrix(@incoming, %w[enabled], FALSY_INPUTS)
+#=> [[false, '"false"']]
+
+## IncomingConfig nil passthrough
+nil_passthrough(@incoming, %w[enabled])
+#=> [[true, false]]
+
+# --- SsoConfig: three :string boolean fields ---
+
+## SsoConfig truthy matrix: real boolean or 1/'1' assignments normalize to the
+## string encoding — 'cfg.enabled = true' persists '"true"', not raw 'true'
+boolean_matrix(@sso, %w[enabled enforce_sso_only grant_org_scope], TRUTHY_INPUTS)
+#=> [[true, '"true"']]
+
+## SsoConfig falsy matrix: stores '"false"'
+boolean_matrix(@sso, %w[enabled enforce_sso_only grant_org_scope], FALSY_INPUTS)
+#=> [[false, '"false"']]
+
+## SsoConfig nil passthrough
+nil_passthrough(@sso, %w[enabled enforce_sso_only grant_org_scope])
+#=> [[true, false]]
+
+# --- MailerConfig: enabled :string (tri-state fields NOT covered — see header) ---
+
+## MailerConfig enabled truthy matrix: stores '"true"'
+boolean_matrix(@mailer, %w[enabled], TRUTHY_INPUTS)
+#=> [[true, '"true"']]
+
+## MailerConfig enabled falsy matrix: stores '"false"'
+boolean_matrix(@mailer, %w[enabled], FALSY_INPUTS)
+#=> [[false, '"false"']]
+
+## MailerConfig nil passthrough
+nil_passthrough(@mailer, %w[enabled])
+#=> [[true, false]]
+
+# --- Legacy / opposite-encoding persisted records (READ tolerance) ---
+# Simulate rows written by pre-#3951 code or by writers that bypass the
+# setters entirely (fast writers, direct Redis writes) by hset-ing raw bytes:
+#   raw 'true'   -> Familia JSON round-trip loads a real BOOLEAN
+#   raw '"true"' -> loads the STRING 'true'
+# Both must read enabled through the predicate after a reload, regardless of
+# the field's declared storage.
+
+## Legacy on :native model (SigninConfig): raw unquoted 'true' loads as a
+## boolean and reads enabled
+@legacy_dom_n = Onetime::CustomDomain.create!("be-legacy-n-#{@ts}-#{@entropy}.example.com", @org.objid)
+@legacy_si = Onetime::CustomDomain::SigninConfig.create!(domain_id: @legacy_dom_n.identifier)
+Familia.dbclient.hset(@legacy_si.dbkey, 'enabled', 'true')
+Onetime::CustomDomain::SigninConfig.find_by_domain_id(@legacy_dom_n.identifier).enabled?
+#=> true
+
+## Legacy on :native model (SigninConfig): quoted '"true"' — the OPPOSITE
+## (string) encoding for a native field — still reads enabled. Pre-#3951 the
+## strict `== true` predicate read this record as silently disabled.
+Familia.dbclient.hset(@legacy_si.dbkey, 'signin_enabled', '"true"')
+@legacy_si_loaded = Onetime::CustomDomain::SigninConfig.find_by_domain_id(@legacy_dom_n.identifier)
+@legacy_si_loaded.signin_enabled?
+#=> true
+
+## Loading routes through the normalizing setter, so the IN-MEMORY value for
+## the quoted-string row is already a real boolean (stored bytes untouched
+## until something saves the record)
+[@legacy_si_loaded.signin_enabled, Familia.dbclient.hget(@legacy_si.dbkey, 'signin_enabled')]
+#=> [true, '"true"']
+
+## Legacy on :string model (SsoConfig): raw unquoted 'true' — the OPPOSITE
+## (boolean) encoding for a string field — loads as a boolean and reads enabled
+@legacy_dom_s = Onetime::CustomDomain.create!("be-legacy-s-#{@ts}-#{@entropy}.example.com", @org.objid)
+@legacy_sso = Onetime::CustomDomain::SsoConfig.new(domain_id: @legacy_dom_s.identifier)
+@legacy_sso.save
+Familia.dbclient.hset(@legacy_sso.dbkey, 'enabled', 'true')
+Onetime::CustomDomain::SsoConfig.find_by_domain_id(@legacy_dom_s.identifier).enabled?
+#=> true
+
+## Legacy on :string model (SsoConfig): quoted '"true"' (correct string
+## encoding) loads as the string 'true' and reads enabled
+Familia.dbclient.hset(@legacy_sso.dbkey, 'enforce_sso_only', '"true"')
+Onetime::CustomDomain::SsoConfig.find_by_domain_id(@legacy_dom_s.identifier).enforce_sso_only?
+#=> true
+
+# --- Load-time guard: typo'd spec field fails fast (#3951 AC6) ---
+
+## A typo'd/renamed boolean field in COLONEL_FIELD_SPECS raises
+## Familia::Problem at feature-enable time. Without this guard the feature
+## would define accessors for the bogus name (satisfying ConfigRegistry's
+## method_defined? check) and the failure would surface only as a runtime
+## NoMethodError on super.
+begin
+  Class.new(Familia::Horreum) do
+    def self.name = 'BooleanEncodingProbeConfig'
+    identifier_field :domain_id
+    field :domain_id
+    field :enabled
+    const_set(:COLONEL_FIELD_SPECS, {
+      'enabled' => { type: :boolean, storage: :string },
+      'tpyoed_field' => { type: :boolean, storage: :string },
+    }.freeze)
+    feature :boolean_encoding
+  end
+  :no_raise
+rescue Familia::Problem => e
+  e.message.include?("declares boolean field 'tpyoed_field'")
+end
+#=> true
+
+# --- Cleanup ---
+
+Familia.dbclient.flushdb
+OT.info "Cleaned Redis after config boolean encoding matrix test run"

--- a/try/unit/models/custom_domain_config_normalize_boolean_encoding_chore_try.rb
+++ b/try/unit/models/custom_domain_config_normalize_boolean_encoding_chore_try.rb
@@ -1,0 +1,136 @@
+# try/unit/models/custom_domain_config_normalize_boolean_encoding_chore_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for the :normalize_boolean_encoding housekeeping chore (#3951),
+# registered on all seven CustomDomain config models by
+# lib/onetime/models/custom_domain/chores/normalize_boolean_encoding.rb.
+#
+# The chore compares each spec'd boolean field's RAW stored bytes against
+# the model's declared storage encoding (FIELD_SPECS) and rewrites
+# recognized drift via the fast writer:
+#
+#   :native canonical -> 'true'/'false'       (JSON booleans)
+#   :string canonical -> '"true"'/'"false"'   (JSON-quoted strings)
+#
+# Covered here:
+#   - canonical bytes            -> silent skip, chore returns false
+#   - string-encoded on :native  -> rewritten to native bytes, returns true
+#   - native-encoded on :string  -> rewritten to quoted bytes, returns true
+#   - 1/'1' numeric variants     -> rewritten to encoded true
+#   - unrecognized garbage       -> left byte-for-byte, returns false
+#   - absent field               -> skipped, never materialized
+#   - idempotence                -> second run is a no-op
+#   - registration               -> all seven models expose the chore
+#
+# Run:
+#   try try/unit/models/custom_domain_config_normalize_boolean_encoding_chore_try.rb --agent
+
+require_relative '../../support/test_models'
+
+OT.boot! :test
+
+Familia.dbclient.flushdb
+OT.info 'Cleaned Redis for normalize_boolean_encoding chore test run'
+
+CHORE = :normalize_boolean_encoding
+
+# Raw hash bytes for a field, straight from Redis.
+def raw(obj, field)
+  Familia.dbclient.hget(obj.dbkey, field)
+end
+
+# Force specific raw bytes into the stored hash, bypassing all setters.
+def force_raw(obj, field, bytes)
+  Familia.dbclient.hset(obj.dbkey, field, bytes)
+end
+
+@ts      = Familia.now.to_i
+@entropy = SecureRandom.hex(4)
+@owner   = Onetime::Customer.create!(email: "chore_owner_#{@ts}_#{@entropy}@test.com")
+@org     = Onetime::Organization.create!("Chore Test Org #{@ts}", @owner, "chore_#{@ts}@test.com")
+
+# CustomDomain.create! bootstraps HomepageConfig + ApiConfig (disabled).
+@domain = Onetime::CustomDomain.create!("chore-#{@ts}-#{@entropy}.example.com", @org.objid)
+@did    = @domain.identifier
+
+@signin = Onetime::CustomDomain::SigninConfig.create!(domain_id: @did) # :native booleans
+@api    = Onetime::CustomDomain::ApiConfig.find_by_domain_id(@did)    # enabled :string
+
+## All seven config models register the chore
+Onetime::CustomDomain::ConfigRegistry::KINDS.values.map do |entry|
+  entry[:model].chores.key?(CHORE)
+end.uniq
+#=> [true]
+
+# --- Branch (a): canonical bytes -> silent skip ---
+
+## SigninConfig create! saved native booleans; canonical bytes untouched,
+## chore reports no modification
+@signin.enabled = true
+@signin.save
+[@signin.do_chore!(CHORE), raw(@signin, 'enabled')]
+#=> [false, 'true']
+
+## ApiConfig enabled (:string) canonical quoted bytes -> skip
+@api.enabled = true
+@api.save
+[@api.do_chore!(CHORE), raw(@api, 'enabled')]
+#=> [false, '"true"']
+
+# --- Branch (b): recognized divergent encoding -> rewrite ---
+
+## String-encoded bytes on a :native field are rewritten to native bytes
+## and the tolerant predicate still reads true after reload
+force_raw(@signin, 'signin_enabled', '"true"')
+@result = @signin.do_chore!(CHORE)
+@signin.refresh!
+[@result, raw(@signin, 'signin_enabled'), @signin.signin_enabled?]
+#=> [true, 'true', true]
+
+## Native-encoded bytes on a :string field are rewritten to quoted bytes
+force_raw(@api, 'enabled', 'false')
+[@api.do_chore!(CHORE), raw(@api, 'enabled')]
+#=> [true, '"false"']
+
+## Numeric truthy variant '1' on a :native field normalizes to native true
+force_raw(@signin, 'sso_enabled', '1')
+[@signin.do_chore!(CHORE), raw(@signin, 'sso_enabled')]
+#=> [true, 'true']
+
+## Quoted numeric variant '"1"' on a :string field normalizes to quoted true
+force_raw(@api, 'enabled', '"1"')
+[@api.do_chore!(CHORE), raw(@api, 'enabled')]
+#=> [true, '"true"']
+
+# --- Branch (c): unrecognized garbage -> log + leave alone ---
+
+## Garbage bytes are preserved byte-for-byte (forensic evidence); the
+## tolerant predicate reads them as false; chore reports no modification
+force_raw(@signin, 'email_auth_enabled', '"banana"')
+@garbage_result = @signin.do_chore!(CHORE)
+@signin.refresh!
+[@garbage_result, raw(@signin, 'email_auth_enabled'), @signin.email_auth_enabled?]
+#=> [false, '"banana"', false]
+
+# --- nil/absent fields: skipped, never materialized ---
+
+## Deleting a field from the raw hash leaves it absent after the chore
+Familia.dbclient.hdel(@signin.dbkey, 'sso_enabled')
+[@signin.do_chore!(CHORE), raw(@signin, 'sso_enabled')]
+#=> [false, nil]
+
+# --- Idempotence: second run after a fix is a no-op ---
+
+## Re-running after a rewrite finds only canonical bytes (garbage aside)
+force_raw(@api, 'enabled', 'true')
+@first  = @api.do_chore!(CHORE)
+@second = @api.do_chore!(CHORE)
+[@first, @second, raw(@api, 'enabled')]
+#=> [true, false, '"true"']
+
+# Teardown
+@signin.destroy!
+@domain.destroy!
+@org.destroy!
+@owner.destroy!

--- a/try/unit/models/custom_domain_signin_config_non_nullable_try.rb
+++ b/try/unit/models/custom_domain_signin_config_non_nullable_try.rb
@@ -9,6 +9,9 @@
 #   - init defaults: all boolean fields default to false (conservative)
 #   - Predicate methods: signin_enabled?, email_auth_enabled?, sso_enabled? return correct booleans
 #   - Legacy nil coercion: predicates treat nil as false (conservative)
+#   - Encoding tolerance (#3951): predicates accept legacy string 'true' as
+#     enabled — the pre-#3951 strict `== true` reads silently disabled records
+#     whose fields held the string encoding
 #   - create! defaults: all omitted boolean fields default to false
 #   - create! with explicit true values
 #   - restrict_to remains nullable (string, not boolean)
@@ -118,23 +121,28 @@ OT.info "Cleaned Redis for SigninConfig non-nullable boolean test run"
 @legacy3.sso_enabled?
 #=> false
 
-## signin_enabled? returns false for string 'false' (not == true)
+## signin_enabled? returns false for string 'false' (tolerant predicate, #3951)
 @legacy4 = Onetime::CustomDomain::SigninConfig.new(domain_id: 'legacy_test_4')
 @legacy4.instance_variable_set(:@signin_enabled, 'false')
 @legacy4.signin_enabled?
 #=> false
 
-## email_auth_enabled? returns false for string 'true' (not == true)
+## email_auth_enabled? returns TRUE for string 'true' (#3951 encoding tolerance)
+## Pre-#3951 the strict `== true` predicate silently read a persisted string
+## 'true' as disabled. The boolean_encoding feature accepts both encodings
+## (true/'true'/1/'1') so a legacy string-encoded record cannot flip a
+## domain's auth surface off.
 @legacy5 = Onetime::CustomDomain::SigninConfig.new(domain_id: 'legacy_test_5')
 @legacy5.instance_variable_set(:@email_auth_enabled, 'true')
 @legacy5.email_auth_enabled?
-#=> false
+#=> true
 
-## sso_enabled? returns false for string 'true' (not == true)
+## sso_enabled? returns TRUE for string 'true' (#3951 encoding tolerance)
+## Same rationale as email_auth_enabled? above: string 'true' means enabled.
 @legacy6 = Onetime::CustomDomain::SigninConfig.new(domain_id: 'legacy_test_6')
 @legacy6.instance_variable_set(:@sso_enabled, 'true')
 @legacy6.sso_enabled?
-#=> false
+#=> true
 
 # --- create! defaults ---
 

--- a/try/unit/models/custom_domain_signup_config_non_nullable_try.rb
+++ b/try/unit/models/custom_domain_signup_config_non_nullable_try.rb
@@ -8,6 +8,9 @@
 #   - init defaults: both fields default to false (not nil)
 #   - Predicate methods: signup_enabled? and autoverify? return correct booleans
 #   - Legacy nil coercion: predicates treat nil as false (conservative)
+#   - Encoding tolerance (#3951): predicates accept legacy string 'true' as
+#     enabled — the pre-#3951 strict `== true` reads silently disabled records
+#     whose fields held the string encoding
 #   - create! defaults: omitted fields default to false
 #   - create! with explicit true values
 #   - Round-trip through save/load
@@ -89,17 +92,20 @@ OT.info "Cleaned Redis for SignupConfig non-nullable boolean test run"
 @legacy2.autoverify?
 #=> false
 
-## signup_enabled? returns false for string 'false' (not == true)
+## signup_enabled? returns false for string 'false' (tolerant predicate, #3951)
 @legacy3 = Onetime::CustomDomain::SignupConfig.new(domain_id: 'legacy_test_3')
 @legacy3.instance_variable_set(:@signup_enabled, 'false')
 @legacy3.signup_enabled?
 #=> false
 
-## autoverify? returns false for string 'true' (not == true)
+## autoverify? returns TRUE for string 'true' (#3951 encoding tolerance)
+## Pre-#3951 the strict `== true` predicate silently read a persisted string
+## 'true' as disabled. The boolean_encoding feature accepts both encodings
+## (true/'true'/1/'1'), so a legacy string-encoded record keeps its intent.
 @legacy4 = Onetime::CustomDomain::SignupConfig.new(domain_id: 'legacy_test_4')
 @legacy4.instance_variable_set(:@autoverify, 'true')
 @legacy4.autoverify?
-#=> false
+#=> true
 
 # --- create! defaults ---
 

--- a/try/unit/models/custom_domain_sso_config_try.rb
+++ b/try/unit/models/custom_domain_sso_config_try.rb
@@ -1,0 +1,244 @@
+# try/unit/models/custom_domain_sso_config_try.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for CustomDomain::SsoConfig boolean handling (#3951).
+#
+# SsoConfig declares three boolean fields, all storage :string
+# ('true'/'false'): enabled, enforce_sso_only, grant_org_scope. The
+# boolean_encoding feature gives each a tolerant predicate (accepts
+# true/'true'/1/'1') and a normalizing setter (any truthy input persists the
+# STRING 'true'; any non-nil falsy input persists 'false'; nil passes
+# through). Pre-#3951 these fields had strict to_s == 'true' predicates and
+# raw setters, so `cfg.enabled = true` persisted a real boolean that other
+# strict readers could misread.
+#
+# Covers:
+#   - init defaults: all three fields default to string 'false'
+#   - The three predicates under BOTH encodings (string and boolean input)
+#   - Normalizing setter: `cfg.enabled = true` now persists the string 'true'
+#     (raw hash bytes are the JSON-quoted '"true"')
+#   - Read tolerance for values planted around the setter (legacy in-memory)
+#   - create! path still works (encrypted credentials + enabled: true)
+#   - enable!/disable! helpers and round-trip through save/load
+#
+# Run:
+#   try try/unit/models/custom_domain_sso_config_try.rb --agent
+
+require_relative '../../support/test_models'
+
+OT.boot! :test
+
+Familia.dbclient.flushdb
+OT.info "Cleaned Redis for SsoConfig test run"
+
+# Familia encryption config required by SsoConfig encrypted fields
+@key_v1 = 'test_encryption_key_32bytes_ok!!'
+@key_v2 = 'another_test_key_for_testing_!!'
+
+# Tryouts share a single process, so global Familia config set here leaks
+# into every file that runs after this one. Capture originals for teardown.
+@original_encryption_keys = Familia.config.encryption_keys
+@original_key_version = Familia.config.current_key_version
+@original_personalization = Familia.config.encryption_personalization
+
+Familia.configure do |config|
+  config.encryption_keys = {
+    v1: Base64.strict_encode64(@key_v1),
+    v2: Base64.strict_encode64(@key_v2),
+  }
+  config.current_key_version = :v1
+  config.encryption_personalization = 'SsoConfigTest'
+end
+
+@ts = Familia.now.to_i
+@entropy = SecureRandom.hex(4)
+
+@owner = Onetime::Customer.create!(email: "sso_owner_#{@ts}_#{@entropy}@test.com")
+@org = Onetime::Organization.create!("SSO Test Org #{@ts}", @owner, "sso_#{@ts}@test.com")
+@domain = Onetime::CustomDomain.create!("sso-test-#{@ts}-#{@entropy}.example.com", @org.objid)
+
+# --- init defaults ---
+
+## New SsoConfig defaults enabled to string 'false'
+@fresh = Onetime::CustomDomain::SsoConfig.new(domain_id: 'init_test_1')
+@fresh.enabled
+#=> 'false'
+
+## New SsoConfig defaults enforce_sso_only to string 'false'
+@fresh.enforce_sso_only
+#=> 'false'
+
+## New SsoConfig defaults grant_org_scope to string 'false'
+@fresh.grant_org_scope
+#=> 'false'
+
+## All three predicates read false on a fresh config
+[@fresh.enabled?, @fresh.enforce_sso_only?, @fresh.grant_org_scope?]
+#=> [false, false, false]
+
+# --- Predicates under the STRING encoding (declared storage) ---
+
+## enabled? reads true for string 'true'
+@str = Onetime::CustomDomain::SsoConfig.new(domain_id: 'pred_str_1')
+@str.enabled = 'true'
+@str.enabled?
+#=> true
+
+## enabled? reads false for string 'false'
+@str.enabled = 'false'
+@str.enabled?
+#=> false
+
+## enforce_sso_only? reads true for string 'true'
+@str.enforce_sso_only = 'true'
+@str.enforce_sso_only?
+#=> true
+
+## enforce_sso_only? reads false for string 'false'
+@str.enforce_sso_only = 'false'
+@str.enforce_sso_only?
+#=> false
+
+## grant_org_scope? reads true for string 'true'
+@str.grant_org_scope = 'true'
+@str.grant_org_scope?
+#=> true
+
+## grant_org_scope? reads false for string 'false'
+@str.grant_org_scope = 'false'
+@str.grant_org_scope?
+#=> false
+
+# --- Predicates under the BOOLEAN encoding (#3951 tolerance) ---
+# Real booleans arrive from console assignments and pre-#3951 callers.
+# The normalizing setter encodes them to strings, so the predicate reads
+# them correctly no matter which encoding the caller used.
+
+## enabled? reads true when assigned boolean true
+@bool = Onetime::CustomDomain::SsoConfig.new(domain_id: 'pred_bool_1')
+@bool.enabled = true
+@bool.enabled?
+#=> true
+
+## enabled = true normalizes the in-memory value to the string 'true'
+@bool.enabled
+#=> 'true'
+
+## enabled? reads false when assigned boolean false
+@bool.enabled = false
+@bool.enabled?
+#=> false
+
+## enforce_sso_only? reads true when assigned boolean true
+@bool.enforce_sso_only = true
+[@bool.enforce_sso_only?, @bool.enforce_sso_only]
+#=> [true, 'true']
+
+## grant_org_scope? reads true when assigned boolean true
+@bool.grant_org_scope = true
+[@bool.grant_org_scope?, @bool.grant_org_scope]
+#=> [true, 'true']
+
+## Read tolerance without the setter: a boolean planted directly in the ivar
+## (legacy record loaded before #3951, or a writer bypassing the accessor)
+## still reads enabled
+@planted = Onetime::CustomDomain::SsoConfig.new(domain_id: 'pred_planted_1')
+@planted.instance_variable_set(:@enabled, true)
+@planted.enabled?
+#=> true
+
+## nil passes through the setter unchanged and reads false (conservative)
+@bool.enabled = nil
+[@bool.enabled.nil?, @bool.enabled?]
+#=> [true, false]
+
+# --- Normalizing setter persists the STRING encoding ---
+
+## 'cfg.enabled = true' now persists the string 'true': the raw hash value is
+## the JSON-quoted string '"true"', NOT the unquoted boolean bytes 'true'
+@persist = Onetime::CustomDomain::SsoConfig.new(domain_id: @domain.identifier)
+@persist.enabled = true
+@persist.save
+Familia.dbclient.hget(@persist.dbkey, 'enabled')
+#=> '"true"'
+
+## Reloading the persisted record reads enabled? true
+Onetime::CustomDomain::SsoConfig.find_by_domain_id(@domain.identifier).enabled?
+#=> true
+
+## Boolean assignments to the other two fields persist strings the same way
+@persist.enforce_sso_only = true
+@persist.grant_org_scope = true
+@persist.save
+[
+  Familia.dbclient.hget(@persist.dbkey, 'enforce_sso_only'),
+  Familia.dbclient.hget(@persist.dbkey, 'grant_org_scope'),
+]
+#=> ['"true"', '"true"']
+
+## Round-trip: reloaded record reads all three predicates true
+@reloaded = Onetime::CustomDomain::SsoConfig.find_by_domain_id(@domain.identifier)
+[@reloaded.enabled?, @reloaded.enforce_sso_only?, @reloaded.grant_org_scope?]
+#=> [true, true, true]
+
+# --- create! path ---
+
+## create! with encrypted credentials and enabled: true still works
+## (destroy the ad-hoc record first so create! can claim the domain, 1:1 keying)
+@persist.destroy!
+@created = Onetime::CustomDomain::SsoConfig.create!(
+  domain_id: @domain.identifier,
+  provider_type: 'oidc',
+  client_id: "client-#{@entropy}",
+  client_secret: "secret-#{@entropy}",
+  issuer: 'https://auth.example.com',
+  display_name: 'SSO Boolean Test',
+  enabled: true,
+)
+@created.class
+#=> Onetime::CustomDomain::SsoConfig
+
+## create! enabled: true reads enabled? (create! does .to_s, the normalizing
+## setter keeps it the string 'true')
+@created.enabled?
+#=> true
+
+## create! persisted the string encoding for enabled
+Familia.dbclient.hget(@created.dbkey, 'enabled')
+#=> '"true"'
+
+## create! defaults the enforcement fields to 'false' / predicates false
+[@created.enforce_sso_only?, @created.grant_org_scope?]
+#=> [false, false]
+
+## create! round-trips through the finder with predicates intact
+@found = Onetime::CustomDomain::SsoConfig.find_by_domain_id(@domain.identifier)
+[@found.enabled?, @found.provider_type]
+#=> [true, 'oidc']
+
+## Encrypted credential survives (create! path unaffected by the feature)
+@found.client_id.reveal { it }
+#=> "client-#{@entropy}"
+
+# --- enable!/disable! helpers ---
+
+## disable! persists string 'false' and reads disabled
+@found.disable!
+[@found.enabled?, Familia.dbclient.hget(@found.dbkey, 'enabled')]
+#=> [false, '"false"']
+
+## enable! persists string 'true' and reads enabled
+@found.enable!
+[@found.enabled?, Familia.dbclient.hget(@found.dbkey, 'enabled')]
+#=> [true, '"true"']
+
+# Teardown
+Familia.dbclient.flushdb
+
+# Restore original Familia encryption config to avoid polluting other test files
+Familia.configure do |config|
+  config.encryption_keys = @original_encryption_keys if @original_encryption_keys
+  config.current_key_version = @original_key_version if @original_key_version
+  config.encryption_personalization = @original_personalization if @original_personalization
+end


### PR DESCRIPTION
Introduces a `BooleanEncoding` Familia feature that reads both native (`true`/`false`) and string (`"true"`/`"false"`) boolean encodings tolerantly while writing a single canonical form, and enables it across all seven CustomDomain config models (signin, sso, signup, homepage, mailer, api, incoming). ConfigRegistry validation is widened to accept both encodings so mixed-encoding records persisted by older code paths no longer fail to load.

Adds tryouts covering round-trip encoding for each config model plus SsoConfig-specific coverage.

Resolves #3951