### PR TITLE
feat(branding): add BRAND_LOGO_DARK_URL dark-theme masthead logo

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -1283,6 +1283,13 @@ HELP_ENABLED=true
 # (https:// recommended).
 #BRAND_LOGO_URL=
 
+# Dark-theme variant of BRAND_LOGO_URL, swapped in by the web UI's masthead
+# when the site theme toggle is dark. Inert unless BRAND_LOGO_URL is also
+# set (it pairs with the light logo, never replaces it). Web UI only —
+# outbound emails always use BRAND_LOGO_URL. Same rules as BRAND_LOGO_URL:
+# never shown on tenant custom domains, .vue values ignored.
+#BRAND_LOGO_DARK_URL=
+
 # Alt text for the brand logo (accessibility / hover title). Default when
 # unset: an i18n string derived from the product name.
 #BRAND_LOGO_ALT=

--- a/apps/web/core/spec/views/serializers/config_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/config_serializer_spec.rb
@@ -351,6 +351,7 @@ RSpec.describe Core::Views::ConfigSerializer do
           brand_font_family
           brand_button_text_light
           brand_logo_url
+          brand_logo_dark_url
           brand_logo_alt
           brand_favicon_url
         ].each do |key|
@@ -369,6 +370,7 @@ RSpec.describe Core::Views::ConfigSerializer do
           brand_font_family
           brand_button_text_light
           brand_logo_url
+          brand_logo_dark_url
           brand_logo_alt
           brand_favicon_url
         ].each do |key|

--- a/apps/web/core/views/helpers/initialize_view_vars.rb
+++ b/apps/web/core/views/helpers/initialize_view_vars.rb
@@ -213,6 +213,7 @@ module Core
         brand_product_domain        = brand_config['product_domain']
         brand_support_email         = brand_config['support_email'] || brand_global_defaults[:support_email]
         brand_logo_url              = brand_config['logo_url'] || brand_global_defaults[:logo_url]
+        brand_logo_dark_url         = brand_config['logo_dark_url']
         brand_logo_alt              = brand_config['logo_alt'] || brand_global_defaults[:logo_alt]
         brand_favicon_url           = brand_config['favicon_url'] || brand_global_defaults[:favicon_url]
         # Mobile/social variety-pack URLs used by the HTML head. Unlike the
@@ -276,6 +277,7 @@ module Core
           'brand_product_domain' => brand_product_domain,
           'brand_support_email' => brand_support_email,
           'brand_logo_url' => brand_logo_url,
+          'brand_logo_dark_url' => brand_logo_dark_url,
           'brand_logo_alt' => brand_logo_alt,
           'brand_favicon_url' => brand_favicon_url,
           'brand_apple_touch_icon_url' => brand_apple_touch_icon_url,

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -78,6 +78,7 @@ module Core
         output['brand_font_family']           = view_vars['brand_font_family']
         output['brand_button_text_light']     = view_vars['brand_button_text_light']
         output['brand_logo_url']              = view_vars['brand_logo_url']
+        output['brand_logo_dark_url']         = view_vars['brand_logo_dark_url']
         output['brand_logo_alt']              = view_vars['brand_logo_alt']
         output['brand_favicon_url']           = view_vars['brand_favicon_url']
         output['support_email']               = view_vars['support_email']
@@ -193,6 +194,7 @@ module Core
             'brand_font_family' => nil,
             'brand_button_text_light' => nil,
             'brand_logo_url' => nil,
+            'brand_logo_dark_url' => nil,
             'brand_logo_alt' => nil,
             'brand_favicon_url' => nil,
             'd9s_enabled' => nil,

--- a/docs/architecture/branding.md
+++ b/docs/architecture/branding.md
@@ -77,6 +77,7 @@ field. No defaults shipped.
 | `BRAND_FONT_FAMILY`          | `sans` \| `serif` \| `mono`                        |
 | `BRAND_BUTTON_TEXT_LIGHT`    |                                                    |
 | `BRAND_LOGO_URL`             | masthead + email logo, per-domain default          |
+| `BRAND_LOGO_DARK_URL`        | dark-theme masthead logo (web UI only)             |
 | `BRAND_LOGO_ALT`             | logo alt text (falls back to product-name i18n)    |
 | `BRAND_FAVICON_URL`          | `/favicon.ico` 302 redirect                        |
 | `BRAND_APPLE_TOUCH_ICON_URL` | head `apple-touch-icon`                            |
@@ -97,6 +98,15 @@ never rendered *as the operator's* on tenant custom domains (they get their own
 upload or the neutral mark, same guard as the wordmark). Emails only emit
 absolute `http(s)` URLs; a masthead-oriented relative path degrades emails to a
 text-only header.
+
+`BRAND_LOGO_DARK_URL` is an optional dark-theme variant of the masthead logo,
+swapped in by the app's class-based dark mode (`dark:` variants), so it follows
+the site theme toggle rather than the OS scheme. It only applies while the
+install logo is the asset being rendered (same custom-domain suppression, and
+inert without a configured `logo_url`), and never reaches emails. A pack can
+carry it as `brand-logo-dark.svg` / `brand-logo-dark.png` (both served
+existence-filtered like the light logo) and reference it via `logo_dark_url`
+in `brand.yaml`.
 
 `brand.allow_public_homepage` / `brand.allow_public_api` are YAML-only keys
 (read by `initialize_view_vars.rb`, default `false`) — they have **no** env var

--- a/docs/architecture/decision-records/adr-032-decide-by-default.md
+++ b/docs/architecture/decision-records/adr-032-decide-by-default.md
@@ -1,0 +1,57 @@
+---
+id: '032'
+status: accepted
+title: 'ADR-032: Decide by Default'
+---
+
+## Status
+
+Accepted
+
+## Date
+
+2026-08-01
+
+## Context
+
+"Should we make it configurable?" is a reasonable question on its face. But
+turn it over and you realize it's often punting a problem down the road
+masquerading as flexibility. That has consequences.
+
+Every mechanic multiplies support, QA, docs, design, and a11y surface for
+its lifetime. It's also easier to add then it is to remove. Adding an option
+later is a feature release; removing one is a breaking and/or disruptive
+change.
+
+## Decision
+
+We expose a choice only when whoever proposes it can show all four:
+
+1. **The split is real.** Two identified users need opposite behaviour and no
+   single default works for both. "Someone might prefer" is not a user.
+2. **The deciding facts are theirs, not ours.** The answer depends on their
+   compliance regime, their brand, their threat model, or their recipients.
+   If we could work out the better answer ourselves, offering the choice is
+   just refusing to do the work.
+3. **The wrong default is a blocker.** They cannot reach an acceptable outcome
+   with what already exists, at tolerable cost.
+4. **Someone owns the cost.** Support answer, test case, doc paragraph, and
+   a11y check, for both branches, for its lifetime.
+
+Anything the recipient sees needs more: all four, plus real harm to the
+recipient under the default. A sender preferring something else is not harm.
+Operator branding is settled in [ADR-026](adr-026-brand-nil-means-unconfigured.md)
+and later, and this record does not reopen it.
+
+When the test fails, we pick what is best for the median recipient. That pick
+can be reopened with evidence: support volume, a lost deal, a named
+regulation. Wanting it is not evidence.
+
+The part worth remembering: "make it configurable" is not a compromise between
+two positions. It pays for both positions forever, and hands the unresolved
+argument to everyone who installs the product.
+
+## Related
+
+- [ADR-026](adr-026-brand-nil-means-unconfigured.md), absence as a load bearing signal
+- [ADR-027](adr-027-one-authority-per-value.md), one authority per value

--- a/docs/architecture/decision-records/adr-032-decide-by-default.md
+++ b/docs/architecture/decision-records/adr-032-decide-by-default.md
@@ -23,33 +23,40 @@ its lifetime. It's also easier to add then it is to remove. Adding an option
 later is a feature release; removing one is a breaking and/or disruptive
 change.
 
+The recipient side deserves its own mention. The reveal page is the surface
+most seen by people who never chose us, and it's the one our brand gets judged
+on. Every variation we allow there splits that experience into versions we
+can't all vouch for.
+
 ## Decision
 
 We expose a choice only when whoever proposes it can show all four:
 
-1. **The split is real.** Two identified users need opposite behaviour and no
-   single default works for both. "Someone might prefer" is not a user.
-2. **The deciding facts are theirs, not ours.** The answer depends on their
-   compliance regime, their brand, their threat model, or their recipients.
-   If we could work out the better answer ourselves, offering the choice is
-   just refusing to do the work.
-3. **The wrong default is a blocker.** They cannot reach an acceptable outcome
-   with what already exists, at tolerable cost.
-4. **Someone owns the cost.** Support answer, test case, doc paragraph, and
-   a11y check, for both branches, for its lifetime.
+1. **Two identified users need opposite behaviour, and no single default works
+   for both.** "Someone might prefer it" is not a user.
+2. **The answer depends on facts we don't have.** Their compliance regime,
+   their brand, their threat model, their recipients. If we could work out the
+   better answer ourselves, then offering the choice is just refusing to do the
+   work.
+3. **The wrong default actually blocks them.** They can't reach an acceptable
+   outcome with what already exists, at a cost they'd accept.
+4. **Someone owns the cost for the life of the option.** The support answer,
+   the test case, the doc paragraph, the a11y check, and all of it twice
+   because there are two branches now.
 
-Anything the recipient sees needs more: all four, plus real harm to the
-recipient under the default. A sender preferring something else is not harm.
-Operator branding is settled in [ADR-026](adr-026-brand-nil-means-unconfigured.md)
-and later, and this record does not reopen it.
+Anything the recipient sees has to clear a higher bar: all four, plus a real
+harm to the recipient under the default. A sender preferring something else is
+not a harm. Operator branding is settled in
+[ADR-026](adr-026-brand-nil-means-unconfigured.md) and later, and this record
+does not reopen it.
 
-When the test fails, we pick what is best for the median recipient. That pick
-can be reopened with evidence: support volume, a lost deal, a named
-regulation. Wanting it is not evidence.
+When a proposal doesn't clear the bar, we pick what's best for the median
+recipient and move on. That pick can be reopened later with evidence, such as
+support volume, a lost deal, or a named regulation. Wanting it is not evidence.
 
-The part worth remembering: "make it configurable" is not a compromise between
-two positions. It pays for both positions forever, and hands the unresolved
-argument to everyone who installs the product.
+The part worth remembering is that "make it configurable" is not a compromise
+between two positions. It pays for both positions forever, and it hands the
+unresolved argument to everyone who installs the product.
 
 ## Related
 

--- a/docs/runbooks/fork-rebrand-playbook.md
+++ b/docs/runbooks/fork-rebrand-playbook.md
@@ -1,0 +1,71 @@
+# Playbook: Converting a Customized Fork to Brand-Pack Configuration
+
+Migrate a fork with hardcoded branding (pre-v0.26 style) onto the official
+brand-pack system (v0.26.2+, #3739/#3774).
+
+## 1. Enumerate the fork's delta
+
+Find the last upstream merge point and diff against it:
+
+```bash
+git merge-base <fork-branch> upstream/main        # or inspect the merge commit's 2nd parent
+git tag --contains <merge-base>                   # confirm which upstream version it maps to
+git diff --name-only <merge-base>..<fork-branch>
+```
+
+Classify each changed file:
+
+- **Branding** — logos, favicons, colors, component edits (DefaultLogo.vue,
+  DisabledMinimal.vue, style.css palette, test hex literals).
+- **Deployment** — `.oci-build.json`, registry config. Keep as fork commits.
+- **Noise** — version bumps, prettier reformatting, notes docs. Drop.
+
+## 2. Extract brand facts
+
+From the fork branch (via `git show <branch>:<path>`, no checkout needed):
+
+- Primary color hex (check `.interface-design/system.md`, test literals, CSS).
+- Logo assets: wordmark SVG(s), light/dark variants, fills.
+- `favicon.ico` and any other replaced icons.
+- Product name / site title / TOTP issuer / support email — often set via
+  `BRAND_*` env in the deployment, not in the repo; check relevant
+  correspondence docs if present.
+
+## 3. Check coverage, note gaps
+
+Map each customization onto the v0.26.2+ config surface (`BRAND_*` env vars,
+pack `brand.yaml`, pack asset files — see upstream
+`docs/architecture/branding.md` and `docs/product/branding-favicon.md`).
+Known gaps to watch for (record as memory / follow-up, don't block):
+
+- **Dark-mode logo variant** — upstream has a single `logo_url`; forks with
+  separate light/dark logos need one dual-background SVG or an upstream patch.
+- **Suppressing the logo entirely** on specific views (e.g. disabled
+  homepage) — no config knob.
+
+## 4. Build the pack on a clean upstream base
+
+```bash
+git checkout -b integration/<version>-brandpack rel/<version>
+```
+
+- Author `scripts/branding/presets/<name>.mjs` (copy `maruhi.mjs`): colors via
+  `MARK_*` vars, output to `public/branding/<name>/` and
+  `src/assets/branding/<name>/`. Wordmarks rarely work as favicon glyphs —
+  keep a simple mark that reads at 16–32px.
+- Generate: `pnpm run gen:favicons -- --preset <name>`.
+- In `public/branding/<name>/`: `brand.yaml` (`primary_color`, `logo_url:
+"/brand-logo.svg"`, product name/support email if known), `brand-logo.svg`
+  (the wordmark), the fork's real `favicon.ico` if it should carry over.
+- Commit the pack (vendor packs are committed — `vshare`/`linkdepot`
+  precedent).
+- Port deployment config (`.oci-build.json`) as its own commit.
+
+## 5. Verify
+
+- `pnpm run gen:favicons:check` — neutral defaults untouched.
+- `git diff rel/<version>..HEAD --stat` — only the pack, preset, and
+  deployment commits.
+- `brand.yaml` keys ⊆ `BRAND_MANIFEST_KEYS` (`lib/onetime/config.rb`).
+- Deploy with `BRAND_PACK=<name>` (runtime) or `--build-arg BRAND_PACK=<name>`
+  (baked); confirm masthead logo, favicon, palette, page title, TOTP issuer.

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -568,6 +568,10 @@ brand:
   # served path (e.g. "/brand-logo.svg", #3774). A root-relative value renders in
   # the web UI but is omitted from emails (which need an absolute URL).
   logo_url: <%= ENV['BRAND_LOGO_URL']&.to_json %>
+  # Dark-theme variant of the masthead logo, shown when the app's dark mode is
+  # active. Web UI only (emails always use logo_url). A pack can carry it as
+  # brand-logo-dark.svg / brand-logo-dark.png and set this to the served path.
+  logo_dark_url: <%= ENV['BRAND_LOGO_DARK_URL']&.to_json %>
   # Accessible name for the brand logo. Unset falls back to an i18n string
   # derived from the product name.
   logo_alt: <%= ENV['BRAND_LOGO_ALT']&.to_json %>

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -625,6 +625,7 @@ module Onetime
       'corner_style' => 'BRAND_CORNER_STYLE',
       'font_family' => 'BRAND_FONT_FAMILY',
       'logo_url' => 'BRAND_LOGO_URL',
+      'logo_dark_url' => 'BRAND_LOGO_DARK_URL',
       'logo_alt' => 'BRAND_LOGO_ALT',
       'favicon_url' => 'BRAND_FAVICON_URL',
       'apple_touch_icon_url' => 'BRAND_APPLE_TOUCH_ICON_URL',
@@ -794,7 +795,9 @@ module Onetime
       # favicon handling, and per-domain defaults, so it never enters the
       # brand block — from any source, including an operator-set
       # BRAND_LOGO_URL (hazard 1 of #3612).
-      brand['logo_url'] = nil if brand['logo_url'].is_a?(String) && brand['logo_url'].end_with?('.vue')
+      %w[logo_url logo_dark_url].each do |logo_key|
+        brand[logo_key] = nil if brand[logo_key].is_a?(String) && brand[logo_key].end_with?('.vue')
+      end
 
       LEGACY_BRAND_FALLBACKS.each do |key, legacy|
         next unless brand[key].nil?
@@ -810,11 +813,13 @@ module Onetime
       # instead). Root-relativize it here so the one install logo resolves
       # identically on every surface. Absolute URLs (scheme: or protocol-
       # relative //) and already-root-relative paths pass through untouched.
-      logo_path = brand['logo_url']
-      if logo_path.is_a?(String) && !logo_path.empty? &&
-         !logo_path.start_with?('/') &&
-         !logo_path.match?(/\A[a-z][a-z0-9+.-]*:/i)
-        brand['logo_url'] = "/#{logo_path}"
+      %w[logo_url logo_dark_url].each do |logo_key|
+        logo_path = brand[logo_key]
+        next unless logo_path.is_a?(String) && !logo_path.empty? &&
+                    !logo_path.start_with?('/') &&
+                    !logo_path.match?(/\A[a-z][a-z0-9+.-]*:/i)
+
+        brand[logo_key] = "/#{logo_path}"
       end
 
       # brand.logo_url is now the one install logo for every surface, but the
@@ -824,9 +829,11 @@ module Onetime
       # letting them discover it in a delivered email. Deliberately always
       # logged: this is an operational notice about mail rendering, not a
       # deprecation, so compatibility.deprecated_config_mode does not apply.
-      logo_url = brand['logo_url']
-      if logo_url && !logo_url.match?(%r{\Ahttps?://}i)
-        OT.le "CONFIG NOTICE: brand.logo_url '#{logo_url}' is not an absolute http(s) URL; " \
+      %w[logo_url logo_dark_url].each do |logo_key|
+        logo_url = brand[logo_key]
+        next unless logo_url && !logo_url.match?(%r{\Ahttps?://}i)
+
+        OT.le "CONFIG NOTICE: brand.#{logo_key} '#{logo_url}' is not an absolute http(s) URL; " \
               'it will render in the web UI but is omitted from outbound emails.'
       end
 

--- a/lib/onetime/middleware/static_files.rb
+++ b/lib/onetime/middleware/static_files.rb
@@ -46,7 +46,7 @@ module Onetime
       # identically on every route. Note: a root-relative logo renders in the
       # web UI but is omitted from emails (which need an absolute URL) — the
       # same pre-existing caveat normalize_brand already warns about at boot.
-      BRAND_PACK_LOGO_URLS = %w[/brand-logo.svg /brand-logo.png].freeze
+      BRAND_PACK_LOGO_URLS = %w[/brand-logo.svg /brand-logo.png /brand-logo-dark.svg /brand-logo-dark.png].freeze
 
       # The wrapped Rack application
       # @return [#call] The Rack application instance passed to this middleware

--- a/public/branding/default/brand.yaml
+++ b/public/branding/default/brand.yaml
@@ -44,6 +44,7 @@
 # corner_style: "rounded"                      # rounded | square | pill
 # font_family: "sans"                          # sans | serif | mono
 # logo_url: "https://cdn.example.com/logo.svg" # masthead + email logo; absolute for email, or "/brand-logo.svg" for a pack-carried file
+# logo_dark_url: "https://cdn.example.com/logo-dark.svg" # dark-theme masthead logo; or "/brand-logo-dark.svg" for a pack-carried file
 # logo_alt: "Example logo"                     # logo alt text
 # favicon_url: "https://cdn.example.com/favicon.ico" # /favicon.ico 302 redirect
 # apple_touch_icon_url: "https://cdn.example.com/touch.png" # head apple-touch-icon

--- a/spec/unit/onetime/config/normalize_brand_spec.rb
+++ b/spec/unit/onetime/config/normalize_brand_spec.rb
@@ -203,6 +203,64 @@ RSpec.describe Onetime::Config do
         end
       end
 
+      context 'logo_dark_url' do
+        it 'prefers BRAND_LOGO_DARK_URL over a brand: YAML value' do
+          brand = normalized({ 'brand' => { 'logo_dark_url' => '/img/yaml-dark.svg' } },
+                             'BRAND_LOGO_DARK_URL' => 'https://cdn.example.com/dark.svg')
+          expect(brand['logo_dark_url']).to eq('https://cdn.example.com/dark.svg')
+        end
+
+        it 'adopts the brand: YAML value when the env var is unset' do
+          brand = normalized({ 'brand' => { 'logo_dark_url' => '/img/yaml-dark.svg' } }, {})
+          expect(brand['logo_dark_url']).to eq('/img/yaml-dark.svg')
+        end
+
+        it 'rejects a *.vue value from the env var' do
+          brand = normalized({ 'brand' => {} }, 'BRAND_LOGO_DARK_URL' => 'DefaultLogo.vue')
+          expect(brand['logo_dark_url']).to be_nil
+        end
+
+        it 'rejects a *.vue value supplied via brand: YAML' do
+          brand = normalized({ 'brand' => { 'logo_dark_url' => 'DarkLogo.vue' } }, {})
+          expect(brand['logo_dark_url']).to be_nil
+        end
+
+        it 'root-relativizes a bare relative path so it resolves on nested routes' do
+          brand = normalized({ 'brand' => {} }, 'BRAND_LOGO_DARK_URL' => 'img/dark.svg')
+          expect(brand['logo_dark_url']).to eq('/img/dark.svg')
+        end
+
+        it 'leaves an already-root-relative path untouched' do
+          brand = normalized({ 'brand' => {} }, 'BRAND_LOGO_DARK_URL' => '/img/dark.svg')
+          expect(brand['logo_dark_url']).to eq('/img/dark.svg')
+        end
+
+        it 'leaves an absolute and a protocol-relative URL untouched' do
+          expect(normalized({ 'brand' => {} }, 'BRAND_LOGO_DARK_URL' => 'https://cdn.example.com/d.svg')['logo_dark_url'])
+            .to eq('https://cdn.example.com/d.svg')
+          expect(normalized({ 'brand' => {} }, 'BRAND_LOGO_DARK_URL' => '//cdn.example.com/d.svg')['logo_dark_url'])
+            .to eq('//cdn.example.com/d.svg')
+        end
+
+        it 'logs the boot notice when the value is not absolute http(s)' do
+          expect(OT).to receive(:le).with(/CONFIG NOTICE: brand\.logo_dark_url/)
+          normalized({ 'brand' => {} }, 'BRAND_LOGO_DARK_URL' => 'img/dark.svg')
+        end
+
+        it 'logs no notice for an absolute https value' do
+          expect(OT).not_to receive(:le).with(/CONFIG NOTICE: brand\.logo_dark_url/)
+          normalized({ 'brand' => {} }, 'BRAND_LOGO_DARK_URL' => 'https://cdn.example.com/d.svg')
+        end
+
+        it 'has no legacy fallback: legacy LOGO_URL and YAML feed only logo_url' do
+          # LEGACY_BRAND_FALLBACKS deliberately omits logo_dark_url — the
+          # legacy single-logo sources have no dark variant to offer.
+          brand = normalized(legacy_conf('logo' => { 'url' => '/img/legacy.png' }),
+                             'LOGO_URL' => '/img/legacy-env.png')
+          expect(brand['logo_dark_url']).to be_nil
+        end
+      end
+
       context 'logo_alt' do
         it 'adopts LOGO_ALT when BRAND_LOGO_ALT is unset' do
           brand = normalized({ 'brand' => {} }, 'LOGO_ALT' => 'Legacy Alt')

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -572,6 +572,7 @@ export const bootstrapSchema = z.object({
   brand_font_family: z.enum(fontFamilyValues).nullish(),
   brand_button_text_light: z.boolean().nullish(),
   brand_logo_url: z.string().nullish(),
+  brand_logo_dark_url: z.string().nullish(),
   brand_logo_alt: z.string().nullish(),
   brand_favicon_url: z.string().nullish(),
 

--- a/src/shared/components/layout/MastHead.vue
+++ b/src/shared/components/layout/MastHead.vue
@@ -39,6 +39,7 @@
     displayName,
     showPlatformIdentity,
     installLogoUri,
+    installLogoDarkUri,
     installLogoAlt,
     logoSource,
   } = storeToRefs(identityStore);
@@ -76,6 +77,15 @@
   // holds an operator-logo rung of its own — config authority lives in the
   // brand: block and resolution in the identity resolver (#3612).
   const getLogoUrl = () => props.logo?.url || logoSource.value;
+  // Dark-theme variant (brand.logo_dark_url): only while the install logo is
+  // the asset actually being rendered. Tenant brands do declare a paired
+  // logo_dark_url (BrandSettings / brand-config schema) but it has no UI
+  // consumer yet, so this swap intentionally covers only the install logo
+  // for now; installLogoDarkUri already nulls itself when a tenant logo
+  // outranks the install logo. Swapped via the app's class-based `dark:`
+  // variants so it follows the site theme toggle, not the OS scheme.
+  const getLogoDarkUrl = () =>
+    props.logo?.url ? null : installLogoDarkUri.value;
   // Alt text: caller > operator BRAND_LOGO_ALT (only while the install logo
   // is the asset being shown) > i18n string derived from the product name.
   // When platform identity is suppressed (custom domain / tenant logo), the
@@ -141,6 +151,7 @@
   // Helper function to get logo configuration
   const getLogoConfig = () => ({
     url: getLogoUrl(),
+    darkUrl: getLogoDarkUrl(),
     alt: getLogoAlt(),
     href: getLogoHref(),
     size: getLogoSize(),
@@ -260,6 +271,17 @@
               id="logo"
               :src="logoConfig.url"
               class="w-auto object-contain transition-transform"
+              :class="[imgHeightClass, logoConfig.darkUrl ? 'dark:hidden' : null]"
+              :style="imgInlineStyle"
+              :height="logoConfig.size"
+              :alt="logoConfig.alt" />
+            <!-- Dark-theme logo variant (brand.logo_dark_url): swapped by the
+                 app's class-based dark mode so it tracks the theme toggle. -->
+            <img
+              v-if="logoConfig.darkUrl"
+              data-testid="logo-dark"
+              :src="logoConfig.darkUrl"
+              class="hidden w-auto object-contain transition-transform dark:block"
               :class="imgHeightClass"
               :style="imgInlineStyle"
               :height="logoConfig.size"

--- a/src/shared/stores/bootstrapStore.ts
+++ b/src/shared/stores/bootstrapStore.ts
@@ -55,6 +55,7 @@ const DEFAULTS: BootstrapPayload = {
   brand_font_family: undefined,
   brand_button_text_light: undefined,
   brand_logo_url: undefined,
+  brand_logo_dark_url: undefined,
   brand_logo_alt: undefined,
   brand_favicon_url: undefined,
 };

--- a/src/shared/stores/identityStore.ts
+++ b/src/shared/stores/identityStore.ts
@@ -78,6 +78,7 @@ export const useProductIdentity = defineStore('productIdentity', () => {
     domain_logo,
     brand_product_name,
     brand_logo_url,
+    brand_logo_dark_url,
     brand_logo_alt,
     homepage_config,
   } = storeToRefs(bootstrapStore);
@@ -252,6 +253,22 @@ export const useProductIdentity = defineStore('productIdentity', () => {
   );
 
   /**
+   * Dark-theme variant of the install logo (BRAND_LOGO_DARK_URL /
+   * brand.logo_dark_url). Only meaningful while installLogoUri is the asset
+   * being rendered — it is the same identity in a dark-legible treatment, so
+   * it inherits the same custom-domain suppression, and is additionally null
+   * when no light install logo is configured (a dark-only logo has no base
+   * asset to pair with) and when a tenant logo outranks the install logo in
+   * logoSource (same structural guard as installLogoAlt). Consumers swap it
+   * in via the app's class-based dark
+   * mode (`dark:` variants), NOT prefers-color-scheme, so it tracks the
+   * site's theme toggle. Web UI only; emails always use logo_url.
+   */
+  const installLogoDarkUri = computed(() =>
+    installLogoUri.value && !logoUri.value ? brand_logo_dark_url?.value || null : null
+  );
+
+  /**
    * Operator-supplied alt text for the install logo (BRAND_LOGO_ALT /
    * brand.logo_alt). Only meaningful while the install logo is the asset
    * actually being rendered — it describes that image — so it is null when
@@ -338,6 +355,7 @@ export const useProductIdentity = defineStore('productIdentity', () => {
     productName,
     showPlatformIdentity,
     installLogoUri,
+    installLogoDarkUri,
     installLogoAlt,
     logoSource,
     homepageSecretsMode,

--- a/src/tests/contracts/bootstrap-serializer-fields.ts
+++ b/src/tests/contracts/bootstrap-serializer-fields.ts
@@ -40,6 +40,7 @@ export const CONFIG_SERIALIZER_FIELDS = [
   'brand_font_family',
   'brand_button_text_light',
   'brand_logo_url',
+  'brand_logo_dark_url',
   'brand_logo_alt',
   'brand_favicon_url',
   'd9s_enabled',

--- a/src/tests/fixtures/bootstrap.fixture.ts
+++ b/src/tests/fixtures/bootstrap.fixture.ts
@@ -142,6 +142,7 @@ export const baseBootstrap: BootstrapPayload = {
   brand_font_family: null,
   brand_button_text_light: null,
   brand_logo_url: null,
+  brand_logo_dark_url: null,
   brand_logo_alt: null,
   brand_favicon_url: null,
 };

--- a/src/tests/shared/components/layout/MastHead.spec.ts
+++ b/src/tests/shared/components/layout/MastHead.spec.ts
@@ -97,6 +97,7 @@ describe('MastHead', () => {
       domain_strategy?: string;
       brand_product_name?: string | null;
       brand_logo_url?: string | null;
+      brand_logo_dark_url?: string | null;
       brand_logo_alt?: string | null;
       header_logo?: {
         href?: string | null;
@@ -118,6 +119,7 @@ describe('MastHead', () => {
           domain_strategy: storeState.domain_strategy ?? 'canonical',
           brand_product_name: storeState.brand_product_name ?? null,
           brand_logo_url: storeState.brand_logo_url ?? null,
+          brand_logo_dark_url: storeState.brand_logo_dark_url ?? null,
           brand_logo_alt: storeState.brand_logo_alt ?? null,
           ui: {
             header: {
@@ -989,6 +991,82 @@ describe('MastHead', () => {
 
       const siteName = wrapper.find('span.font-brand.text-lg');
       expect(siteName.exists()).toBe(false);
+    });
+  });
+
+  describe('Dark-theme logo variant (brand_logo_dark_url)', () => {
+    // Component-level rendering of the dark swap. Store gating
+    // (installLogoDarkUri nulling on custom domains / tenant logos / missing
+    // light logo) is covered in identityStore.spec.ts — not retested here.
+
+    it('renders both imgs with class-based dark swap when light+dark install logos are set', async () => {
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          brand_logo_url: '/img/brand.svg',
+          brand_logo_dark_url: '/img/brand-dark.svg',
+        }
+      );
+
+      await nextTick();
+      const light = wrapper.find('img#logo');
+      expect(light.exists()).toBe(true);
+      expect(light.attributes('src')).toBe('/img/brand.svg');
+      // Light img hides under the app's class-based dark theme
+      expect(light.classes()).toContain('dark:hidden');
+
+      const dark = wrapper.find('[data-testid="logo-dark"]');
+      expect(dark.exists()).toBe(true);
+      expect(dark.attributes('src')).toBe('/img/brand-dark.svg');
+      // Dark img is hidden by default, shown only under dark theme
+      expect(dark.classes()).toContain('hidden');
+      expect(dark.classes()).toContain('dark:block');
+      // Both share the same sizing/alt so the swap is visually seamless
+      expect(dark.classes()).toContain('w-auto');
+      expect(dark.classes()).toContain('object-contain');
+      expect(dark.attributes('height')).toBe(light.attributes('height'));
+      expect(dark.attributes('alt')).toBe(light.attributes('alt'));
+    });
+
+    it('renders only the light img (no dark:hidden) when brand_logo_dark_url is null', async () => {
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          brand_logo_url: '/img/brand.svg',
+          brand_logo_dark_url: null,
+        }
+      );
+
+      await nextTick();
+      const light = wrapper.find('img#logo');
+      expect(light.exists()).toBe(true);
+      // Without a dark variant the light logo must stay visible in dark theme
+      expect(light.classes()).not.toContain('dark:hidden');
+      expect(wrapper.find('[data-testid="logo-dark"]').exists()).toBe(false);
+    });
+
+    it('suppresses the dark variant when a caller supplies props.logo.url', async () => {
+      // getLogoDarkUrl: a caller-supplied logo replaces the install logo, so
+      // the install-level dark variant must not render behind it.
+      wrapper = mountComponent(
+        {
+          logo: { url: '/static/caller-logo.png' },
+        },
+        {
+          authenticated: false,
+          brand_logo_url: '/img/brand.svg',
+          brand_logo_dark_url: '/img/brand-dark.svg',
+        }
+      );
+
+      await nextTick();
+      const light = wrapper.find('img#logo');
+      expect(light.exists()).toBe(true);
+      expect(light.attributes('src')).toBe('/static/caller-logo.png');
+      expect(light.classes()).not.toContain('dark:hidden');
+      expect(wrapper.find('[data-testid="logo-dark"]').exists()).toBe(false);
     });
   });
 

--- a/src/tests/stores/identityStore.spec.ts
+++ b/src/tests/stores/identityStore.spec.ts
@@ -648,6 +648,61 @@ describe('identityStore installLogoAlt', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
+// installLogoDarkUri — dark-theme variant of the install logo
+// (BRAND_LOGO_DARK_URL). Same contract as installLogoAlt: only meaningful
+// while the install logo is the asset actually being rendered.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('identityStore installLogoDarkUri', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('returns brand_logo_dark_url when the install logo is present', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({
+      brand_logo_url: '/img/install-brand.svg',
+      brand_logo_dark_url: '/img/install-brand-dark.svg',
+      domain_strategy: 'canonical',
+    });
+
+    const identity = useProductIdentity();
+
+    expect(identity.installLogoDarkUri).toBe('/img/install-brand-dark.svg');
+  });
+
+  it('is null when set without a light install logo to pair with', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({
+      brand_logo_url: null,
+      brand_logo_dark_url: '/img/install-brand-dark.svg',
+      domain_strategy: 'canonical',
+    });
+
+    const identity = useProductIdentity();
+
+    expect(identity.installLogoDarkUri).toBeNull();
+  });
+
+  it('is null when a tenant logo outranks the install logo in logoSource', () => {
+    // Same guard as installLogoAlt: the dark variant is the operator's
+    // identity, so it must not swap in over a tenant's image.
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({
+      brand_logo_url: '/img/install-brand.svg',
+      brand_logo_dark_url: '/img/install-brand-dark.svg',
+      domain_logo: '/imagine/ext123/logo.png',
+      domain_strategy: 'canonical',
+    });
+
+    const identity = useProductIdentity();
+
+    expect(identity.logoSource).toBe('/imagine/ext123/logo.png');
+    expect(identity.installLogoDarkUri).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
 // logoSource — resolved logo image on the identity axis (#3612)
 //
 // Tenant's uploaded logo > operator's install-wide brand_logo_url (custom

--- a/try/unit/web/brand_asset_overlay_try.rb
+++ b/try/unit/web/brand_asset_overlay_try.rb
@@ -347,9 +347,9 @@ BRAND_PACK_URLS.all? { |u| File.exist?(File.join(DEFAULT_PACK, u)) }
 #    existence-filtered on BOTH layers so an absent logo falls through.
 # ============================================================================
 
-## the optional logo URL set is exactly brand-logo.svg + brand-logo.png
+## the optional logo URL set is the light + dark brand-logo svg/png variants
 BRAND_PACK_LOGO_URLS.sort
-#=> ['/brand-logo.png', '/brand-logo.svg']
+#=> ['/brand-logo-dark.png', '/brand-logo-dark.svg', '/brand-logo.png', '/brand-logo.svg']
 
 ## an overlay carrying brand-logo.svg lists it (and only it) among the logo URLs
 set_overlay(assets_dir: @overlay_logo, pack: nil)


### PR DESCRIPTION
## Summary

Adds an optional dark-theme variant of the masthead logo, configurable via `BRAND_LOGO_DARK_URL` / `brand.logo_dark_url`, swapped by the app's class-based dark mode (`dark:` variants) so it follows the site theme toggle rather than the OS scheme.

- **Config**: new `logo_dark_url` key in the brand block (env-wired via `BRAND_ENV`), with the same `.vue`-sentinel guard, bare-relative root-relativization, and boot CONFIG NOTICE as `logo_url`.
- **Serving**: brand packs can carry `brand-logo-dark.svg` / `brand-logo-dark.png` (existence-filtered like the light logo via `BRAND_PACK_LOGO_URLS`).
- **Bootstrap**: `brand_logo_dark_url` flows through view vars → config serializer → zod schema → bootstrap store, and is covered by all three contract lists (TS field list, fixture, serializer spec).
- **Identity**: new `installLogoDarkUri` computed in `identityStore` — null unless the install logo is the asset actually rendered (tenant logo outranks, custom-domain suppression inherited), mirroring `installLogoAlt`'s structural predicate.
- **MastHead**: dual-`<img>` CSS swap (`dark:hidden` / `hidden dark:block`) — no first-paint flash on theme toggle; dark img is addressable via `data-testid="logo-dark"`.

Scope notes: web UI only — emails always use `logo_url`. Tenant custom-domain `BrandSettings.logo_dark_url` already exists in the schema but remains unwired to UI (intentionally out of scope; MastHead comment documents this).

## Test plan

- `try --agent try/unit/web/brand_pack_default_try.rb` — 8/8 (manifest drift guard, includes new commented key in default brand.yaml)
- `rspec` normalize_brand + apply_brand_manifest — 60 examples, 0 failures
- vitest: identityStore (incl. new 3-test `installLogoDarkUri` block), MastHead, bootstrap contracts, branding resolver guard — 509 tests across 16 files, all green