### PR TITLE
[#3948] Fix dead verification-resend branch in CreateAccount (boolean_field truthiness)

### DIFF
--- a/apps/api/account/logic/account/create_account.rb
+++ b/apps/api/account/logic/account/create_account.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'onetime/logic/signup_config_resolution'
+require 'onetime/security/verification_resend_cooldown'
 
 module AccountAPI::Logic
   module Account
@@ -14,6 +15,7 @@ module AccountAPI::Logic
     #   new and unverified accounts.
     class CreateAccount < AccountAPI::Logic::Base
       include Onetime::Logic::SignupConfigResolution
+      include Onetime::Security::VerificationResendCooldown
 
       SCHEMAS = { response: 'createAccount' }.freeze
 
@@ -81,7 +83,14 @@ module AccountAPI::Logic
           # If verified, we do nothing but still return success
           if @cust.verified?
             OT.info "[account-exists-verified] Silent success for #{@cust.obscure_email}"
-          else
+          elsif claim_verification_resend_slot?(@cust)
+            # Cooldown claimed: this is the first duplicate signup in the
+            # window, so the resend proceeds. The cooldown bounds mailbox
+            # spam AND reset_secret rotation from unauthenticated repeat
+            # signups (each resend invalidates the previous verification
+            # link). When the claim fails the resend is skipped SILENTLY —
+            # the response below stays byte-identical either way, because
+            # any observable difference would be an enumeration oracle.
             OT.info "[account-exists-unverified] Resending verification for #{@cust.obscure_email}"
             send_verification_email
           end

--- a/apps/api/account/logic/account/create_account.rb
+++ b/apps/api/account/logic/account/create_account.rb
@@ -79,7 +79,7 @@ module AccountAPI::Logic
 
           # If the account is not verified, resend the verification email
           # If verified, we do nothing but still return success
-          if @cust.verified
+          if @cust.verified?
             OT.info "[account-exists-verified] Silent success for #{@cust.obscure_email}"
           else
             OT.info "[account-exists-unverified] Resending verification for #{@cust.obscure_email}"

--- a/apps/api/account/spec/logic/account/create_account_spec.rb
+++ b/apps/api/account/spec/logic/account/create_account_spec.rb
@@ -149,7 +149,10 @@ RSpec.describe AccountAPI::Logic::Account::CreateAccount do
         email: email,
         obscure_email: 'n***r@example.com',
         role: 'customer',
-        verified: false,
+        # BooleanFieldType canonicalizes to the STRING 'false', never a
+        # real Ruby boolean — mirror the real model contract here.
+        verified: 'false',
+        verified?: false,
         'verified=': nil,
         'verified_by=': nil,
         'role=': nil,
@@ -226,7 +229,10 @@ RSpec.describe AccountAPI::Logic::Account::CreateAccount do
           extid: 'existing-cust-123',
           obscure_email: 'e***g@example.com',
           role: 'customer',
-          verified: true
+          # Stored form is the canonical STRING 'true' (BooleanFieldType);
+          # the predicate verified? is the correct read.
+          verified: 'true',
+          verified?: true
         )
       end
 
@@ -240,6 +246,42 @@ RSpec.describe AccountAPI::Logic::Account::CreateAccount do
 
         logic.raise_concerns
         logic.process
+      end
+
+      it 'takes the silent-success branch with no email for a verified account' do
+        allow(Onetime::Customer).to receive(:find_by_email).and_return(existing_customer)
+
+        expect(logic).not_to receive(:send_verification_email)
+
+        logic.raise_concerns
+        logic.process
+      end
+
+      context 'when the existing account is unverified' do
+        # Regression: verified is stored as the STRING 'false', which is
+        # truthy in Ruby. `if @cust.verified` silently skipped the resend
+        # branch; `verified?` must be used. See registration.rb behavior
+        # table: "No-autoverify + existing unverified → Yes (resent)".
+        let(:existing_customer) do
+          instance_double(
+            Onetime::Customer,
+            objid: 'existing-cust-123',
+            extid: 'existing-cust-123',
+            obscure_email: 'e***g@example.com',
+            role: 'customer',
+            verified: 'false',
+            verified?: false
+          )
+        end
+
+        it 'resends the verification email' do
+          allow(Onetime::Customer).to receive(:find_by_email).and_return(existing_customer)
+
+          expect(logic).to receive(:send_verification_email)
+
+          logic.raise_concerns
+          logic.process
+        end
       end
     end
   end

--- a/lib/onetime/security/verification_resend_cooldown.rb
+++ b/lib/onetime/security/verification_resend_cooldown.rb
@@ -1,0 +1,84 @@
+# lib/onetime/security/verification_resend_cooldown.rb
+#
+# frozen_string_literal: true
+
+module Onetime
+  module Security
+    # VerificationResendCooldown - per-customer cooldown on duplicate-signup
+    # verification resends
+    #
+    # The signup endpoint (AccountAPI::Logic::Account::CreateAccount) is
+    # reachable unauthenticated and deliberately returns the SAME generic
+    # success response whether the submitted email is new, an existing
+    # verified account, or an existing unverified account (enumeration
+    # safety). The existing-unverified branch resends the verification email
+    # and — because send_verification_email spawns a fresh receipt pair —
+    # ROTATES the customer's reset_secret on every request. Without a
+    # cooldown, repeated anonymous POSTs to signup with a known unverified
+    # email are (a) a mailbox-spam primitive and (b) a denial primitive:
+    # each request invalidates the verification link the victim was just
+    # sent, so they can never complete verification while the attacker keeps
+    # posting.
+    #
+    # This module bounds both with a single atomic Redis gate:
+    #
+    #   SET verification_resend:cooldown:{objid} '1' NX EX <cooldown>
+    #
+    # The first duplicate signup in a window claims the key and resends;
+    # every subsequent one inside the window sees NX fail and SILENTLY skips
+    # the resend (info log with obscured email only). The caller still
+    # returns the identical generic success response — a throttled request
+    # is indistinguishable from an unthrottled one to the client, which is
+    # required: any observable difference (status, body, error) would be an
+    # account-existence oracle.
+    #
+    # Keyed on the customer objid, not the submitted string: the branch only
+    # runs after find_by_email resolved a real customer, and objid keying
+    # means email-case/unicode variants of one account share one bucket.
+    #
+    # Fail semantics match the other lib/onetime/security/ limiters: Redis
+    # errors propagate (fail closed). Here "closed" means the resend is
+    # skipped — the surrounding request may 500, but a datastore outage
+    # never turns into an unthrottled send path.
+    #
+    # Redis key (string keys at the Redis boundary):
+    #   - verification_resend:cooldown:{objid}  - cooldown flag, EX-expired
+    #
+    # Usage:
+    #   include Onetime::Security::VerificationResendCooldown
+    #   send_verification_email if claim_verification_resend_slot?(cust)
+    module VerificationResendCooldown
+      # Seconds between verification resends per customer. Five minutes
+      # bounds an attacker to ~12 emails/hour per target and guarantees a
+      # verification link stays valid at least this long, while a legitimate
+      # user who lost the first email waits at most one coffee-length pause.
+      VERIFICATION_RESEND_COOLDOWN = 300
+
+      # Atomically claim this customer's resend slot for the cooldown
+      # window. Returns true exactly once per window (SET NX EX); false
+      # means a resend already happened recently and the caller must skip
+      # sending — silently, preserving the generic success response.
+      #
+      # @param customer [Onetime::Customer] the resolved existing customer
+      # @return [Boolean] true when the resend may proceed
+      def claim_verification_resend_slot?(customer)
+        key     = "verification_resend:cooldown:#{customer.objid}"
+        claimed = verification_resend_redis.set(
+          key, '1', nx: true, ex: VERIFICATION_RESEND_COOLDOWN
+        )
+        unless claimed
+          OT.info "[verification-resend-cooldown] Skipping resend for #{customer.obscure_email} (within #{VERIFICATION_RESEND_COOLDOWN}s window)"
+        end
+        !!claimed
+      end
+
+      private
+
+      # Same shard as the customer/auth rate-limit state (matches
+      # ResetRequestRateLimiter / LoginRateLimiter).
+      def verification_resend_redis
+        Onetime::Customer.dbclient
+      end
+    end
+  end
+end

--- a/spec/integration/simple/create_account_verification_resend_spec.rb
+++ b/spec/integration/simple/create_account_verification_resend_spec.rb
@@ -1,0 +1,194 @@
+# spec/integration/simple/create_account_verification_resend_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration — verification resend on duplicate signup in SIMPLE
+#            mode (security audit 2026-07-31, dead-branch finding)
+# =============================================================================
+#
+# `verified` is a boolean_field, and Onetime::FieldTypes::BooleanFieldType
+# canonicalizes every stored value to the STRING 'true'/'false'
+# (lib/onetime/field_types/boolean_field_type.rb). "false" is truthy in Ruby,
+# so `if @cust.verified` in CreateAccount#process took the silent-success
+# branch for EVERY persisted customer and the resend at
+# apps/api/account/logic/account/create_account.rb:86 was unreachable — a user
+# whose first verification email was lost could never get it resent, despite
+# the behavior table at apps/web/core/controllers/registration.rb:21
+# ("No-autoverify + existing unverified → Yes (resent)"). The fix reads the
+# predicate: `if @cust.verified?`.
+#
+# The unit spec masked the bug by stubbing `verified:` with real Ruby booleans,
+# values the model never returns. These examples drive the REAL simple-mode
+# rack stack with REAL persisted customers — no model stubs — so the canonical
+# string form is what the branch actually sees. The resend example fails
+# against the raw-read code; that is the point of this file.
+#
+# This file MUST live in spec/integration/simple/: in full mode /auth/* is
+# Rodauth's (apps/web/auth/application.rb mounts longest-prefix-first) and
+# POST /auth/create-account never reaches this logic class.
+#
+# The suite config has autoverify: false (spec/config.test.yaml:74), which
+# these examples require: with autoverify on, the first signup would persist
+# verified='true' and the resend branch would be legitimately unreachable.
+#
+# REQUIREMENTS:
+# - Valkey running on port 2121: pnpm run test:database:start
+# - AUTHENTICATION_MODE=simple (the default)
+#
+# RUN:
+#   RACK_ENV=test AUTHENTICATION_MODE=simple bundle exec rspec \
+#     spec/integration/simple/create_account_verification_resend_spec.rb
+#
+# =============================================================================
+
+require_relative '../integration_spec_helper'
+
+RSpec.describe 'Duplicate-signup verification resend in simple mode (audit dead-branch finding)', type: :integration do
+  include Rack::Test::Methods
+
+  def app
+    # Memoize: repeated generate_rack_url_map calls corrupt middleware state.
+    @app ||= begin
+      Onetime::Application::Registry.reset!
+      Onetime::Application::Registry.prepare_application_registry
+      Onetime::Application::Registry.generate_rack_url_map
+    end
+  end
+
+  before(:all) do
+    require 'onetime'
+    require 'onetime/config'
+    Onetime.boot! :test
+    require 'onetime/application/registry'
+
+    app
+  end
+
+  before do
+    # Full mode would route /auth/create-account to Rodauth — these assertions
+    # would then be testing the wrong code path.
+    skip 'requires simple auth mode' if Onetime.auth_config.full_enabled?
+
+    # These examples depend on the first signup persisting verified='false'.
+    autoverify = OT.conf.dig('site', 'authentication', 'autoverify')
+    raise "Test precondition broken: autoverify must be false in spec/config.test.yaml, got #{autoverify.inspect}" if autoverify
+
+    # Intercept delivery at the Mailer seam: send_verification_email delivers
+    # SYNCHRONOUSLY via Onetime::Mail::Mailer.deliver (lib/onetime/logic/
+    # base.rb), so without this stub every example would attempt real SMTP.
+    # Everything upstream of the seam — Receipt.spawn_pair, secret persistence,
+    # reset_secret write — still runs for real.
+    @deliveries = []
+    allow(Onetime::Mail::Mailer).to receive(:deliver) do |template, data, **|
+      @deliveries << { template: template, email: data[:email_address] }
+      true
+    end
+
+    @created_emails = []
+  end
+
+  after do
+    Array(@created_emails).each do |email|
+      cust = Onetime::Customer.find_by_email(email)
+      cust&.destroy!
+    rescue StandardError => e
+      warn "[create-account resend spec] customer cleanup failed: #{e.message}"
+    end
+  end
+
+  def unique_email(prefix)
+    "#{prefix}-#{SecureRandom.hex(8)}@integration-test.example.com"
+  end
+
+  # CSRF-correct JSON POST to the Core signup route (apps/web/core/
+  # routes.txt:32). Setup failure must be LOUD: a silently-nil shrimp draws a
+  # 403 from the CSRF middleware and surfaces as a misleading status-assertion
+  # failure three lines later.
+  def post_signup(login)
+    clear_cookies
+
+    header 'Content-Type', nil
+    header 'Content-Length', nil
+    header 'Accept', 'application/json'
+    get '/'
+    token = last_response.headers['X-CSRF-Token']
+
+    if token.to_s.empty?
+      raise "CSRF setup failed: GET / returned #{last_response.status} with no X-CSRF-Token header " \
+            "(headers: #{last_response.headers.keys.sort.join(', ')})."
+    end
+
+    header 'Content-Type', 'application/json'
+    header 'Accept', 'application/json'
+    header 'X-CSRF-Token', token
+    post '/auth/create-account',
+         JSON.generate(login: login, password: 'integration-test-pw', skill: '', shrimp: token)
+
+    if last_response.status == 403
+      raise "CSRF rejected by the stack (403): #{last_response.body}. " \
+            'This is a session/middleware problem, not a signup result.'
+    end
+
+    last_response
+  end
+
+  # Both signup outcomes must be the enumeration-safe generic success — a
+  # bare 200 check would also pass if the route stopped reaching this logic.
+  def expect_signup_success(response, context)
+    expect(response.status).to eq(200),
+      "#{context} should succeed, got #{response.status}: #{response.body}"
+  end
+
+  it 'resends the verification email when an unverified account re-submits signup' do
+    email = unique_email('resend')
+    @created_emails << email
+
+    expect_signup_success(post_signup(email), 'Initial signup')
+
+    cust = Onetime::Customer.find_by_email(email)
+    expect(cust).not_to be_nil
+    # The model stores the CANONICAL STRING — the exact value that made the
+    # raw `if @cust.verified` read always-truthy.
+    expect(cust.verified).to eq('false')
+    expect(cust.verified?).to be(false)
+    # reset_secret is a Familia related `string` object (customer.rb:129) —
+    # compare its VALUE; the wrapper object is equal to itself by key.
+    first_secret = cust.reset_secret.value
+    expect(first_secret).not_to be_nil, 'initial signup must bind a verification secret'
+    expect(@deliveries).to eq([{ template: :welcome, email: email }])
+
+    expect_signup_success(post_signup(email), 'Duplicate signup for the unverified account')
+
+    # The resend is observable two independent ways: a second :welcome
+    # delivery, and a FRESH verification secret bound to the customer. Under
+    # the raw-read bug, both assertions fail — the silent-success branch sends
+    # nothing and leaves reset_secret untouched.
+    expect(@deliveries.size).to eq(2),
+      "duplicate signup for an unverified account must resend verification, deliveries: #{@deliveries.inspect}"
+    expect(@deliveries.last).to eq({ template: :welcome, email: email })
+    cust.refresh!
+    expect(cust.reset_secret.value).not_to eq(first_secret),
+      'resend must bind a fresh verification secret'
+  end
+
+  it 'takes the silent-success branch for a verified account: 200, no email, secret untouched' do
+    email = unique_email('verified')
+    @created_emails << email
+
+    expect_signup_success(post_signup(email), 'Initial signup')
+    cust = Onetime::Customer.find_by_email(email)
+    cust.verified = true
+    cust.save
+    expect(cust.verified).to eq('true')
+    secret_before   = cust.reset_secret.value
+    delivery_before = @deliveries.size
+
+    expect_signup_success(post_signup(email), 'Duplicate signup for the verified account')
+
+    expect(@deliveries.size).to eq(delivery_before),
+      "verified account must NOT receive email on duplicate signup, deliveries: #{@deliveries.inspect}"
+    cust.refresh!
+    expect(cust.reset_secret.value).to eq(secret_before)
+  end
+end

--- a/spec/integration/simple/create_account_verification_resend_spec.rb
+++ b/spec/integration/simple/create_account_verification_resend_spec.rb
@@ -72,7 +72,9 @@ RSpec.describe 'Duplicate-signup verification resend in simple mode (audit dead-
 
     # These examples depend on the first signup persisting verified='false'.
     autoverify = OT.conf.dig('site', 'authentication', 'autoverify')
-    raise "Test precondition broken: autoverify must be false in spec/config.test.yaml, got #{autoverify.inspect}" if autoverify
+    # Match production semantics (resolve_autoverify): only the string/boolean
+    # 'true' counts as on — a YAML string "false" must not abort the suite.
+    raise "Test precondition broken: autoverify must be false in spec/config.test.yaml, got #{autoverify.inspect}" if autoverify.to_s == 'true'
 
     # Intercept delivery at the Mailer seam: send_verification_email delivers
     # SYNCHRONOUSLY via Onetime::Mail::Mailer.deliver (lib/onetime/logic/
@@ -91,7 +93,10 @@ RSpec.describe 'Duplicate-signup verification resend in simple mode (audit dead-
   after do
     Array(@created_emails).each do |email|
       cust = Onetime::Customer.find_by_email(email)
-      cust&.destroy!
+      next unless cust
+
+      Onetime::Customer.dbclient.del("verification_resend:cooldown:#{cust.objid}")
+      cust.destroy!
     rescue StandardError => e
       warn "[create-account resend spec] customer cleanup failed: #{e.message}"
     end
@@ -190,5 +195,59 @@ RSpec.describe 'Duplicate-signup verification resend in simple mode (audit dead-
       "verified account must NOT receive email on duplicate signup, deliveries: #{@deliveries.inspect}"
     cust.refresh!
     expect(cust.reset_secret.value).to eq(secret_before)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Resend cooldown (PR #3955 review, Greptile P1): the resend branch is
+  # unauthenticated, so without a throttle repeated duplicate signups spam the
+  # mailbox AND rotate reset_secret on every request, invalidating the link the
+  # victim was just sent. Onetime::Security::VerificationResendCooldown gates
+  # the branch with SET NX EX on verification_resend:cooldown:{objid}. The
+  # skip must be SILENT — response identical to the resend case — because any
+  # observable difference is an account-existence oracle.
+  # ---------------------------------------------------------------------------
+  it 'silently skips the resend inside the cooldown window, with an identical response, and resends after expiry' do
+    email = unique_email('cooldown')
+    @created_emails << email
+
+    expect_signup_success(post_signup(email), 'Initial signup')
+    cust = Onetime::Customer.find_by_email(email)
+    expect(cust).not_to be_nil
+    cooldown_key = "verification_resend:cooldown:#{cust.objid}"
+
+    # First duplicate: claims the cooldown slot and resends.
+    first_dup = post_signup(email)
+    expect_signup_success(first_dup, 'First duplicate signup')
+    expect(@deliveries.size).to eq(2),
+      "first duplicate must resend, deliveries: #{@deliveries.inspect}"
+    expect(Onetime::Customer.dbclient.exists(cooldown_key)).to eq(1),
+      'first resend must set the cooldown key'
+    ttl = Onetime::Customer.dbclient.ttl(cooldown_key)
+    expect(ttl).to be_between(1, Onetime::Security::VerificationResendCooldown::VERIFICATION_RESEND_COOLDOWN)
+    cust.refresh!
+    secret_after_first_dup = cust.reset_secret.value
+
+    # Second duplicate inside the window: NO delivery, NO secret rotation —
+    # and a response byte-identical to the resend case (enumeration safety).
+    second_dup = post_signup(email)
+    expect_signup_success(second_dup, 'Second duplicate signup (throttled)')
+    expect(second_dup.status).to eq(first_dup.status)
+    expect(second_dup.body).to eq(first_dup.body),
+      'throttled and unthrottled duplicate signups must return identical bodies'
+    expect(@deliveries.size).to eq(2),
+      "duplicate signup inside the cooldown must NOT deliver again, deliveries: #{@deliveries.inspect}"
+    cust.refresh!
+    expect(cust.reset_secret.value).to eq(secret_after_first_dup),
+      'throttled duplicate must not rotate the verification secret'
+
+    # Simulate cooldown expiry by deleting the key: the next duplicate
+    # resends again.
+    Onetime::Customer.dbclient.del(cooldown_key)
+    expect_signup_success(post_signup(email), 'Duplicate signup after cooldown expiry')
+    expect(@deliveries.size).to eq(3),
+      "post-expiry duplicate must resend, deliveries: #{@deliveries.inspect}"
+    cust.refresh!
+    expect(cust.reset_secret.value).not_to eq(secret_after_first_dup),
+      'post-expiry resend must bind a fresh verification secret'
   end
 end

--- a/spec/unit/onetime/models/boolean_field_raw_read_guard_spec.rb
+++ b/spec/unit/onetime/models/boolean_field_raw_read_guard_spec.rb
@@ -1,0 +1,87 @@
+# spec/unit/onetime/models/boolean_field_raw_read_guard_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Static guard — no bare truthiness reads of boolean_field readers
+#            (security audit 2026-07-31, dead-branch finding)
+# =============================================================================
+#
+# `boolean_field` readers return the canonical STRINGS 'true'/'false'
+# (Onetime::FieldTypes::BooleanFieldType), so `if cust.verified` type-checks,
+# reads naturally, and is ALWAYS truthy — "false" is truthy in Ruby. That
+# exact bug made the verification-resend branch in
+# apps/api/account/logic/account/create_account.rb unreachable for every
+# persisted customer until 2026-07-31. The correct read is the predicate:
+# `cust.verified?`.
+#
+# This spec is the lint the BooleanFieldType docs cannot be: it discovers
+# every declared boolean_field in the tree, then fails on any conditional
+# read of those attribute names that lacks the `?`. Discovery is dynamic so a
+# newly declared field is guarded the moment it exists, with no list to
+# maintain here.
+#
+# Scope and known limits: the scan is name-based, so an unrelated method that
+# happens to share a declared field's name would false-positive — acceptable
+# for the current field names (verified, suspended), and the failure message
+# says how to resolve one. Comments are skipped; multi-line conditions are
+# matched per-line.
+#
+# =============================================================================
+
+require 'spec_helper'
+
+RSpec.describe 'boolean_field raw-read guard' do
+  ROOT         = File.expand_path('../../../..', __dir__)
+  SOURCE_GLOBS = %w[apps/**/*.rb lib/**/*.rb].freeze
+  EXCLUDED     = %r{/(spec|try)/}
+
+  def source_files
+    SOURCE_GLOBS.flat_map { |glob| Dir.glob(File.join(ROOT, glob)) }
+                .reject { |path| path.match?(EXCLUDED) }
+  end
+
+  def declared_boolean_fields
+    fields = source_files.flat_map do |path|
+      File.read(path).scan(/^\s*(?:base\.)?boolean_field\s+:(\w+)/).flatten
+    end.uniq.sort
+    raise 'Guard is broken: found no boolean_field declarations in the tree' if fields.empty?
+
+    fields
+  end
+
+  it 'has no bare conditional reads of declared boolean_field attributes' do
+    fields  = declared_boolean_fields
+    # A read is "bare" when the field name follows a receiver inside a
+    # conditional context (if/unless/leading or trailing, &&, ||, !) without
+    # the predicate `?`. `= `-writes, `.to_s` comparisons, and symbol/string
+    # literals do not match because the pattern requires `.field` preceded by
+    # a conditional keyword or boolean operator on the same line. Chained
+    # calls (`.verified.to_s`) and explicit `==`/`!=` comparisons are
+    # excluded — those handle the string form deliberately.
+    pattern = /
+      (?: \b(?:if|unless|until|while)\s+ | && \s* | \|\| \s* | ! )
+      [\w@.\[\]']* \. (?:#{fields.join('|')})
+      (?! [?\w.] | \s*[=!]= )
+    /x
+
+    offenses = source_files.flat_map do |path|
+      File.read(path).each_line.with_index(1).filter_map do |line, lineno|
+        next if line.strip.start_with?('#')
+        next unless line.match?(pattern)
+
+        "#{path.delete_prefix("#{ROOT}/")}:#{lineno}: #{line.strip}"
+      end
+    end
+
+    expect(offenses).to be_empty, <<~MSG
+      Bare truthiness read of a boolean_field. These readers return the STRINGS
+      'true'/'false' (BooleanFieldType), so the condition is always truthy —
+      "false" is truthy in Ruby. Use the predicate (e.g. `verified?`) instead.
+      If a hit is an unrelated method that merely shares a declared field name
+      (#{fields.join(', ')}), rename one of them or adjust this guard.
+
+      #{offenses.join("\n")}
+    MSG
+  end
+end

--- a/spec/unit/onetime/models/boolean_field_raw_read_guard_spec.rb
+++ b/spec/unit/onetime/models/boolean_field_raw_read_guard_spec.rb
@@ -50,20 +50,40 @@ RSpec.describe 'boolean_field raw-read guard' do
     fields
   end
 
+  # A read is "bare" when the field name is used as a truthiness test without
+  # the predicate `?`. Two alternates cover the forms seen in review:
+  #
+  #   1. `.field` preceded on the same line by a conditional keyword
+  #      (if/elsif/unless/until/while — leading OR trailing statement-modifier) or a
+  #      boolean operator (&&, ||, !), with optional opening paren(s) between
+  #      them: `if cust.verified`, `return if cust.verified`,
+  #      `if (cust.verified)`, `x && cust.verified`, `!cust.verified`.
+  #   2. Ternary: `.field` followed by whitespace then `?` —
+  #      `cust.verified ? a : b`. The space is what separates the ternary
+  #      operator from the predicate: `verified?` has no space before `?` and
+  #      stays excluded.
+  #
+  # Still excluded: predicate reads (`verified?`), chained calls
+  # (`.verified.to_s`), explicit `==`/`!=` comparisons, assignments
+  # (`.verified = true` — no conditional context and no ternary `?`), and
+  # symbol/string literals (no receiver dot).
+  def bare_read_pattern(fields)
+    names = fields.join('|')
+    /
+      (?:
+        (?: \b(?:if|elsif|unless|until|while)\s+ | && \s* | \|\| \s* | ! ) [(\s]*
+        [\w@.\[\]']* \. (?:#{names})
+        (?! [?\w.] | \s*[=!]= )
+      |
+        [\w@.\[\]']* \. (?:#{names})
+        [ \t]+ \? (?![?\w])
+      )
+    /x
+  end
+
   it 'has no bare conditional reads of declared boolean_field attributes' do
     fields  = declared_boolean_fields
-    # A read is "bare" when the field name follows a receiver inside a
-    # conditional context (if/unless/leading or trailing, &&, ||, !) without
-    # the predicate `?`. `= `-writes, `.to_s` comparisons, and symbol/string
-    # literals do not match because the pattern requires `.field` preceded by
-    # a conditional keyword or boolean operator on the same line. Chained
-    # calls (`.verified.to_s`) and explicit `==`/`!=` comparisons are
-    # excluded — those handle the string form deliberately.
-    pattern = /
-      (?: \b(?:if|unless|until|while)\s+ | && \s* | \|\| \s* | ! )
-      [\w@.\[\]']* \. (?:#{fields.join('|')})
-      (?! [?\w.] | \s*[=!]= )
-    /x
+    pattern = bare_read_pattern(fields)
 
     offenses = source_files.flat_map do |path|
       File.read(path).each_line.with_index(1).filter_map do |line, lineno|
@@ -83,5 +103,39 @@ RSpec.describe 'boolean_field raw-read guard' do
 
       #{offenses.join("\n")}
     MSG
+  end
+
+  it 'matches the known bare-read forms and excludes safe reads (pattern self-test)' do
+    pattern = bare_read_pattern(%w[verified suspended])
+
+    flagged = [
+      'if cust.verified',                 # leading keyword
+      'elsif cust.verified',              # elsif branch
+      'return if cust.verified',          # trailing statement-modifier
+      'if (cust.verified)',               # parenthesized receiver
+      'unless (@cust.verified)',          # ivar + paren
+      'do_thing unless cust.verified',    # trailing unless
+      'cust.verified ? a : b',            # ternary, no keyword at all
+      'x = @cust.verified ? "y" : "n"',   # ternary in assignment RHS
+      'ok && cust.verified',              # boolean operator
+      '!cust.suspended',                  # negation
+      '!(cust.suspended)',                # negated paren
+    ]
+    not_flagged = [
+      'if cust.verified?',                # predicate
+      'return if cust.verified?',         # trailing predicate
+      "cust.verified.to_s == 'true'",     # chained call
+      "if cust.verified == 'true'",       # explicit comparison
+      "raise if cust.verified != 'true'", # explicit negated comparison
+      'cust.verified = true',             # assignment
+      'cust.verified? ? a : b',           # predicate + ternary
+      'field == :verified',               # symbol literal
+    ]
+
+    misses = flagged.reject { |line| line.match?(pattern) }
+    expect(misses).to be_empty, "pattern failed to flag: #{misses.inspect}"
+
+    false_positives = not_flagged.select { |line| line.match?(pattern) }
+    expect(false_positives).to be_empty, "pattern wrongly flagged: #{false_positives.inspect}"
   end
 end


### PR DESCRIPTION
## Summary

Recast after PR #3950 merged the simple-mode reset-request rate limiter to main: this PR now carries only the work orthogonal to #3950.

- **Fix**: `CreateAccount#process` read `@cust.verified` (a declared `boolean_field`, which persists as the string `"null"`/truthy raw value) instead of `@cust.verified?`, making the duplicate-signup verification-resend branch dead code. See `apps/api/account/logic/account/create_account.rb`.
- **Regression spec**: unverified duplicate-signup now re-sends the verification email (unit + simple-mode integration coverage).
- **Guard**: static raw-read guard spec that fails when any declared `boolean_field` is read without its `?` predicate, preventing recurrence of this bug class.

Part of the #3948 security-audit remainders. The reset-throttle portion previously on this branch was superseded by #3950 (merged) and the middleware/audit-event portion lives in #3956.

## Test plan
- `bundle exec rspec apps/api/account/spec/logic/account/create_account_spec.rb spec/unit/onetime/models/boolean_field_raw_read_guard_spec.rb` — 14 examples, 0 failures
- `bundle exec rspec spec/integration/simple/create_account_verification_resend_spec.rb` — 2 examples, 0 failures