### PR TITLE
[#3948] Retry-After header middleware + queryable lockout audit events

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -1025,12 +1025,26 @@ FOOTER_VERSION_ENABLED=true
 TRUSTED_PROXY_ENABLED=false
 
 # How to resolve client IP behind proxies. Default: filter.
-# - filter: walk the header right-to-left, skipping RFC1918 private IPs
-#   (10.x, 172.16-31.x, 192.168.x); return the first non-private IP. Works
-#   for most k8s/cloud deployments where proxies have internal IPs.
+# - filter: CIDR-walk. Walk the forwarded chain LEFT-TO-RIGHT and return the
+#   first entry that is not a trusted proxy — i.e. the LEFTMOST non-proxy
+#   entry becomes the client IP. Trusted = RFC1918/loopback/link-local
+#   (10.x, 127.x, 169.254.x, 172.16-31.x, 192.168.x, ::1, fc00::/7,
+#   fe80::/10) plus every range in TRUSTED_PROXY_CIDRS. Works for most
+#   k8s/cloud deployments where proxies have internal IPs.
+#
+#   SECURITY: because the leftmost entry wins, the edge proxy MUST OVERWRITE
+#   X-Forwarded-For with the real peer address, otherwise a client-supplied
+#   entry is returned as the client IP and IP rate limits/bans are spoofable:
+#     nginx:  proxy_set_header X-Forwarded-For $remote_addr;
+#     Caddy:  header_up X-Forwarded-For {remote_host}
+#   Use depth mode when you cannot make the edge overwrite.
+#
+#   Note: filter mode ignores TRUSTED_PROXY_HEADER and reads the
+#   X-Forwarded-For family (X-Forwarded-For, X-Real-IP, X-Client-IP).
 # - depth:  position-based; skip exactly TRUSTED_PROXY_DEPTH rightmost hops.
-#   Use for CDNs with public IPs, variable proxy depth, or when you need
-#   deterministic hop selection regardless of IP class.
+#   Counts positions from the RIGHT of the chain, so a forged leftmost entry
+#   is never reached. Use for CDNs with public IPs, variable proxy depth, or
+#   when you need deterministic hop selection regardless of IP class.
 TRUSTED_PROXY_MODE=filter
 
 # Which header to read the forwarding chain from. Default: X-Forwarded-For.

--- a/apps/api/colonel/logic/colonel/list_audit_events.rb
+++ b/apps/api/colonel/logic/colonel/list_audit_events.rb
@@ -14,7 +14,9 @@ module ColonelAPI
       #   substring over the acting colonel's extid/email — the sessions-search
       #   idiom) and `verb` (an exact action like `customer.set_role`, or a
       #   category prefix like `customer` that matches `customer.*`). Requires
-      #   colonel role.
+      #   colonel role. Covers BOTH of the model's trails — operator activity
+      #   and unauthenticated security telemetry — merged chronologically; they
+      #   are stored apart only so the latter cannot evict the former.
       #
       # This is the read side of the flight recorder: every mutating admin op
       # writes an AdminAuditEvent; this endpoint plays it back. READ-ONLY —
@@ -23,8 +25,19 @@ module ColonelAPI
       class ListAuditEvents < ColonelAPI::Logic::Base
         SCHEMAS = { response: 'colonelAuditEvents' }.freeze
 
-        attr_reader :events, :total_count, :page, :per_page, :total_pages,
-          :actor_filter, :verb_filter
+        # Ceiling on how many events a single read may load into Ruby: the two
+        # trails' caps summed, i.e. the entire store. Both are trimmed on every
+        # write, so this is a fixed bound, not a function of traffic.
+        MAX_COMBINED = Onetime::AdminAuditEvent::MAX_EVENTS +
+                       Onetime::AdminAuditEvent::MAX_SECURITY_EVENTS
+
+        attr_reader :events,
+          :total_count,
+          :page,
+          :per_page,
+          :total_pages,
+          :actor_filter,
+          :verb_filter
 
         def process_params
           @page         = (params['page'] || 1).to_i
@@ -44,19 +57,16 @@ module ColonelAPI
           offset = (page - 1) * per_page
 
           if filters_active?
-            # Filtered read: the events are opaque JSON members of one sorted
-            # set, so filtering means loading and matching in Ruby. Bounded by
-            # design — the set is hard-capped at MAX_EVENTS (10k) on every
-            # write, so this can never become an unbounded enumeration.
-            matching     = Onetime::AdminAuditEvent
-              .recent(Onetime::AdminAuditEvent::MAX_EVENTS)
-              .select { |event| matches_filters?(event) }
+            # Filtered read: the events are opaque JSON members of the backing
+            # sorted sets, so filtering means loading and matching in Ruby.
+            # Bounded by design — both sets are hard-capped on every write, so
+            # this can never become an unbounded enumeration.
+            matching     = merged_events(MAX_COMBINED).select { |event| matches_filters?(event) }
             @total_count = matching.size
             @events      = matching.slice(offset, per_page) || []
           else
-            # Unfiltered read: a single ZREVRANGE slice of the requested page.
-            @total_count = Onetime::AdminAuditEvent.count
-            @events      = Onetime::AdminAuditEvent.recent(per_page, offset)
+            @total_count = Onetime::AdminAuditEvent.count + Onetime::AdminAuditEvent.security_count
+            @events      = merged_events(offset + per_page).slice(offset, per_page) || []
           end
 
           @total_pages = (total_count.to_f / per_page).ceil
@@ -67,13 +77,35 @@ module ColonelAPI
 
         private
 
+        # Newest-first view over BOTH audit trails.
+        #
+        # AdminAuditEvent stores operator activity and unauthenticated security
+        # telemetry in two separately-capped sorted sets, so that a flood of
+        # anonymous events (e.g. reset-request throttle cap-hits) cannot evict
+        # privileged records — see the WRITE-FREQUENCY INVARIANT on the model.
+        # That split is a storage concern; the operator wants one chronological
+        # feed, so the merge happens here on read.
+        #
+        # Both trails are already newest-first, so this is a merge by `created`
+        # (descending) truncated to `limit`. Bounded by MAX_COMBINED: an
+        # arbitrarily deep page can never read more than the whole store, which
+        # is the same ceiling the filtered path has always had.
+        def merged_events(limit)
+          limit = [limit.to_i, MAX_COMBINED].min
+          return [] if limit <= 0
+
+          (Onetime::AdminAuditEvent.recent(limit) + Onetime::AdminAuditEvent.recent_security(limit))
+            .sort_by { |event| -event['created'].to_f }
+            .first(limit)
+        end
+
         def filters_active?
           !actor_filter.to_s.empty? || !verb_filter.to_s.empty?
         end
 
         def matches_filters?(event)
-          unless actor_filter.to_s.empty?
-            return false unless event['actor'].to_s.downcase.include?(actor_filter.downcase)
+          if !actor_filter.to_s.empty? && !event['actor'].to_s.downcase.include?(actor_filter.downcase)
+            return false
           end
 
           unless verb_filter.to_s.empty?

--- a/apps/web/auth/spec/integration/full/reset_password_request_rate_limit_spec.rb
+++ b/apps/web/auth/spec/integration/full/reset_password_request_rate_limit_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe 'Reset-password-request rate limiting (issue #3872)', type: :inte
       expect(body['retry_after']).to be_a(Integer)
       expect(body['max_attempts']).to eq(2)
 
-      # Security audit 2026-07-30, finding #2, residual 2: the delay must also
+      # The delay must also
       # reach the HTTP header proxies and clients actually read (RFC 9110
       # §10.2.3). Set by Onetime::Middleware::RetryAfterHeader from the value
       # the Roda error handler stashes via ErrorCorrelation — the same

--- a/apps/web/auth/spec/integration/full/reset_password_request_rate_limit_spec.rb
+++ b/apps/web/auth/spec/integration/full/reset_password_request_rate_limit_spec.rb
@@ -157,6 +157,14 @@ RSpec.describe 'Reset-password-request rate limiting (issue #3872)', type: :inte
       expect(body['error_type']).to eq('LimitExceeded')
       expect(body['retry_after']).to be_a(Integer)
       expect(body['max_attempts']).to eq(2)
+
+      # Security audit 2026-07-30, finding #2, residual 2: the delay must also
+      # reach the HTTP header proxies and clients actually read (RFC 9110
+      # §10.2.3). Set by Onetime::Middleware::RetryAfterHeader from the value
+      # the Roda error handler stashes via ErrorCorrelation — the same
+      # mechanism the simple-mode Otto stack uses, so the two modes cannot
+      # drift (spec/integration/simple/reset_password_request_rate_limit_spec.rb).
+      expect(response.headers['retry-after']).to eq(body['retry_after'].to_s)
     end
   end
 

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -315,21 +315,13 @@ site:
     # If empty or not set, signups are allowed from any domain (default).
     # Environment variable: ALLOWED_SIGNUP_DOMAIN (comma-separated list)
     allowed_signup_domains: <%= ENV['ALLOWED_SIGNUP_DOMAIN']&.split(',')&.map(&:strip) || [] %>
-    # Rate limiting for reset-password requests (#3872). POST
-    # /auth/reset-password-request is enumeration-safe by response content
-    # (#3857 in full mode, CWE-204 handling in the simple-mode logic) but keeps
+    # Rate limiting for reset-password requests (#3872, #3948). Applies in EVERY
+    # auth mode — full mode enforces it in the Rodauth route hook, simple mode
+    # in AccountAPI::Logic::Authentication::ResetPasswordRequest#process_params.
+    # POST /auth/reset-password-request is enumeration-safe (#3857) but keeps
     # an accepted timing residual; exploiting it needs many samples, so this
     # throttles requests per client IP (tight tier) and per submitted login
     # (higher backstop for IP-rotating callers) BEFORE any account lookup.
-    # Applies in BOTH auth modes: full mode enforces it from the Rodauth
-    # before_reset_password_request_route hook, simple mode (the default) from
-    # ResetPasswordRequest#raise_concerns.
-    # NOTE: the per-IP tier keys on the resolved, privacy-masked client IP. If
-    # you run behind a reverse proxy WITHOUT site.network.trusted_proxy enabled,
-    # that resolves to the proxy's own address for every request, collapsing the
-    # tier into a single deployment-wide bucket (max_per_ip requests/window for
-    # all users combined). Configure trusted_proxy, or raise max_per_ip and lean
-    # on the per-email backstop, which is unaffected.
     # Enabled by default (protective); set RESET_REQUEST_RATE_LIMIT_ENABLED=false
     # to opt out. See lib/onetime/security/reset_request_rate_limiter.rb.
     reset_request_rate_limit:
@@ -453,21 +445,32 @@ site:
 
       # How to resolve client IP behind proxies:
       #
-      # 'filter' (default): Rack walks X-Forwarded-For right-to-left,
-      #   automatically skipping RFC1918 private IPs (10.x, 172.16-31.x,
-      #   192.168.x). Returns first non-private IP. Works for most k8s/cloud
-      #   deployments where proxies have internal IPs.
+      # 'filter' (default): CIDR-walk. Otto::Utils.resolve_client_ip walks the
+      #   forwarded chain LEFT-TO-RIGHT and returns the first entry that is not
+      #   in the trusted-proxy set below (`cidrs`, plus the private ranges when
+      #   trust_private_networks is on). Works for most k8s/cloud deployments
+      #   where the proxy tier has enumerable internal addresses.
+      #
+      #   SECURITY — read before enabling: the edge proxy MUST OVERWRITE
+      #   X-Forwarded-For with the real peer address so the resolved client IP
+      #   is always proxy-attested:
+      #     nginx:  proxy_set_header X-Forwarded-For $remote_addr;
+      #     Caddy:  header_up X-Forwarded-For {remote_host}
+      #   Use 'depth' instead when you cannot make the edge overwrite: it counts
+      #   positions from the right, so a forged leftmost entry is never reached.
       #
       # 'depth': Position-based counting. Skip exactly N rightmost hops.
       #   Use when:
       #   - CDN has a public IP (not RFC1918)
       #   - Variable proxy depth that filter can't handle
       #   - You need deterministic hop selection regardless of IP class
+      #   - Your edge appends to X-Forwarded-For and you cannot change it
       #
       # When filter and depth differ:
       #   - CDN with public IP: filter returns CDN IP (add to cidrs or use depth)
       #   - Variable hop count: filter handles automatically; depth fails if wrong
-      #   - Spoofed private IP in header: filter skips it; depth trusts if in range
+      #   - Forged leftmost entry: filter returns it (see SECURITY above); depth
+      #     ignores it, since only the position N-from-the-right is read
       #
       mode: <%= ENV['TRUSTED_PROXY_MODE'] || 'filter' %>
 

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -447,9 +447,13 @@ site:
       #
       # 'filter' (default): CIDR-walk. Otto::Utils.resolve_client_ip walks the
       #   forwarded chain LEFT-TO-RIGHT and returns the first entry that is not
-      #   in the trusted-proxy set below (`cidrs`, plus the private ranges when
-      #   trust_private_networks is on). Works for most k8s/cloud deployments
-      #   where the proxy tier has enumerable internal addresses.
+      #   in the trusted-proxy set — i.e. the LEFTMOST non-proxy entry becomes
+      #   the client IP. The trusted set is the RFC1918/loopback/link-local
+      #   private ranges (always trusted in this mode) plus every range in
+      #   `cidrs` below. Works for most k8s/cloud deployments where the proxy
+      #   tier has enumerable internal addresses. Note: filter mode ignores
+      #   `header` below and reads the X-Forwarded-For family (X-Forwarded-For,
+      #   X-Real-IP, X-Client-IP).
       #
       #   SECURITY — read before enabling: the edge proxy MUST OVERWRITE
       #   X-Forwarded-For with the real peer address so the resolved client IP

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -317,7 +317,7 @@ site:
     allowed_signup_domains: <%= ENV['ALLOWED_SIGNUP_DOMAIN']&.split(',')&.map(&:strip) || [] %>
     # Rate limiting for reset-password requests (#3872, #3948). Applies in EVERY
     # auth mode — full mode enforces it in the Rodauth route hook, simple mode
-    # in AccountAPI::Logic::Authentication::ResetPasswordRequest#process_params.
+    # in AccountAPI::Logic::Authentication::ResetPasswordRequest#raise_concerns.
     # POST /auth/reset-password-request is enumeration-safe (#3857) but keeps
     # an accepted timing residual; exploiting it needs many samples, so this
     # throttles requests per client IP (tight tier) and per submitted login

--- a/lib/onetime/application/error_correlation.rb
+++ b/lib/onetime/application/error_correlation.rb
@@ -99,12 +99,24 @@ module Onetime
       # 9110 §10.2.3, so a nil, negative, or non-numeric value must produce no
       # header rather than a malformed one.
       #
+      # Rounds UP (`ceil`), never toward zero. Every current LimitExceeded
+      # producer passes an Integer (a Redis TTL or a constant), so today header
+      # and body are identical — but the coercion accepts Floats by design, and
+      # truncating 30.5 to 30 would advertise a SHORTER back-off than the body
+      # states. A client that honours the header would then retry before the
+      # lockout key expires and be throttled again, i.e. the header would
+      # misdirect the very back-off it exists to communicate. Over-waiting by
+      # under a second is the harmless direction.
+      #
       # @param value [Object]
       # @return [Integer, nil]
       def retry_after_seconds(value)
         return nil unless value.is_a?(Numeric)
+        # NaN/Infinity would raise FloatDomainError from #ceil, and neither is a
+        # delay a header could express. Numeric#finite? covers every subclass.
+        return nil if value.respond_to?(:finite?) && !value.finite?
 
-        seconds = value.to_i
+        seconds = value.ceil
         seconds.negative? ? nil : seconds
       end
 

--- a/lib/onetime/application/error_correlation.rb
+++ b/lib/onetime/application/error_correlation.rb
@@ -47,9 +47,25 @@ module Onetime
       # (MiddlewareStack) and mirrored in the x-request-id response header.
       ENV_REQUEST_ID = 'HTTP_X_REQUEST_ID'
 
+      # Rack env key under which a throttle's retry-after delay (seconds) is
+      # stashed for {Onetime::Middleware::RetryAfterHeader} to turn into the
+      # `Retry-After` response header. Same cross-frame pattern as
+      # ENV_ERROR_TYPE: neither routing stack can set a response header from
+      # where it builds the error body (Otto's registered error handlers return
+      # a body Hash and nothing else — Otto::Core::ErrorHandler owns the header
+      # hash), so the value is handed to the middleware frame above instead.
+      #
+      # Read from the body rather than from the exception so ONE assignment
+      # covers every limiter: `Onetime::LimitExceeded#to_h` already carries
+      # `retry_after`, and every security limiter
+      # (Reset/Login/Incoming/InviteToken/Passphrase/Feedback/Dns) raises that
+      # one class. Bodies without the key stash nothing.
+      ENV_RETRY_AFTER = 'otto.retry_after'
+
       module_function
 
-      # Echo the request_id into the error body and stash the error_type into env.
+      # Echo the request_id into the error body and stash the error_type (and,
+      # for throttles, the retry-after delay) into env.
       #
       # Nil-safe on env: the Otto error-handler unit specs invoke the handler
       # blocks with no request, and any pre-middleware caller has no env — with
@@ -71,8 +87,25 @@ module Onetime
         error_type        ||= short_class_name(exception) if exception
         env[ENV_ERROR_TYPE] = error_type if error_type
 
+        retry_after           = retry_after_seconds(body[:retry_after])
+        env[ENV_RETRY_AFTER]  = retry_after if retry_after
+
         request_id = env[ENV_REQUEST_ID]
         request_id ? body.merge(request_id: request_id) : body
+      end
+
+      # Coerce a body's retry_after into a non-negative Integer of seconds, or
+      # nil when it is absent/unusable. `Retry-After` is delay-seconds per RFC
+      # 9110 §10.2.3, so a nil, negative, or non-numeric value must produce no
+      # header rather than a malformed one.
+      #
+      # @param value [Object]
+      # @return [Integer, nil]
+      def retry_after_seconds(value)
+        return nil unless value.is_a?(Numeric)
+
+        seconds = value.to_i
+        seconds.negative? ? nil : seconds
       end
 
       # @param exception [Exception]

--- a/lib/onetime/application/middleware_stack.rb
+++ b/lib/onetime/application/middleware_stack.rb
@@ -15,6 +15,7 @@ require_relative '../middleware/health_access_control'
 require_relative '../middleware/admin_network_isolation'
 require_relative '../middleware/csrf_response_header'
 require_relative '../middleware/normalize_content_type'
+require_relative '../middleware/retry_after_header'
 require_relative '../middleware/entitlement_preview_context'
 require 'otto'
 
@@ -397,6 +398,13 @@ module Onetime
             # Position Sentry middleware early to capture exceptions throughout the stack
             builder.use Sentry::Rack::CaptureExceptions
           end
+
+          # Retry-After header for throttled (429) responses. Both routing
+          # stacks stash the delay in env via ErrorCorrelation; neither can set
+          # a response header from where it builds the error body. Mounted here
+          # so Otto apps and the Roda /auth app get identical back-off headers.
+          logger.debug 'Setting up Retry-After header middleware'
+          builder.use Onetime::Middleware::RetryAfterHeader
 
           # CSRF Response Header - MUST be before Security middleware so that
           # 403 responses from AuthenticityToken also get a fresh masked token.

--- a/lib/onetime/audited_failure.rb
+++ b/lib/onetime/audited_failure.rb
@@ -99,6 +99,16 @@ module Onetime
       # Resolved lazily by `defined?` so this file carries no load-order
       # dependency on the error classes or on Otto being loaded.
       #
+      # Onetime::Forbidden covers Onetime::LimitExceeded by inheritance, so no
+      # throttle rejection is auto-audited through this path either — which is
+      # the point: AdminAuditEvent is count-capped with no TTL, so anything an
+      # unauthorized caller can trigger per-request is a log-eviction primitive.
+      # This predicate is the automatic half of that invariant. A call site may
+      # still write an AdminAuditEvent DIRECTLY for an unauthenticated event if
+      # it bounds its own write rate per window — see the MAX_EVENTS rationale
+      # on {Onetime::AdminAuditEvent} for the one such writer and the bar it
+      # has to clear.
+      #
       # @param error [Exception]
       # @return [Boolean]
       def authorization_rejection?(error)

--- a/lib/onetime/audited_failure.rb
+++ b/lib/onetime/audited_failure.rb
@@ -101,13 +101,19 @@ module Onetime
       #
       # Onetime::Forbidden covers Onetime::LimitExceeded by inheritance, so no
       # throttle rejection is auto-audited through this path either — which is
-      # the point: AdminAuditEvent is count-capped with no TTL, so anything an
-      # unauthorized caller can trigger per-request is a log-eviction primitive.
-      # This predicate is the automatic half of that invariant. A call site may
-      # still write an AdminAuditEvent DIRECTLY for an unauthenticated event if
-      # it bounds its own write rate per window — see the MAX_EVENTS rationale
-      # on {Onetime::AdminAuditEvent} for the one such writer and the bar it
-      # has to clear.
+      # the point: the OPERATOR trail (`events`) is count-capped with no TTL, so
+      # anything an unauthorized caller can trigger a write into it with is a
+      # log-eviction primitive. This predicate is the automatic half of that
+      # invariant.
+      #
+      # A call site that genuinely needs to record an event an UNAUTHENTICATED
+      # caller can cause must write it through
+      # {Onetime::AdminAuditEvent.record_security}, which lands in the separate
+      # `security_events` collection with its own count cap and age bound — NOT
+      # through `.record`. Bounding the write RATE is not an accepted substitute
+      # (see the WRITE-FREQUENCY INVARIANT on {Onetime::AdminAuditEvent}): the
+      # one such writer today, the reset-request throttle, still rate-limits
+      # itself, but for signal quality only.
       #
       # @param error [Exception]
       # @return [Boolean]

--- a/lib/onetime/middleware/retry_after_header.rb
+++ b/lib/onetime/middleware/retry_after_header.rb
@@ -1,0 +1,95 @@
+# lib/onetime/middleware/retry_after_header.rb
+#
+# frozen_string_literal: true
+
+require_relative '../application/error_correlation'
+
+module Onetime
+  module Middleware
+    ##
+    # RetryAfterHeader
+    #
+    # Emits the `Retry-After` response header for throttled (429) responses.
+    #
+    # Every security limiter raises {Onetime::LimitExceeded} carrying
+    # `retry_after` seconds, and both routing stacks already put that value in
+    # the JSON body — but a body field is invisible to the clients and
+    # intermediaries that actually back off: proxies, SDK retry policies,
+    # `fetch` wrappers, and monitoring all read the HTTP header (RFC 9110
+    # §10.2.3). Without it a throttled caller has no machine-readable cue and
+    # typically retries immediately, which is the opposite of what a rate limit
+    # is for. (Security audit 2026-07-30, finding #2, residual 2.)
+    #
+    # ## Why a middleware rather than the error handlers
+    #
+    # Neither error edge can set a response header where it builds the body:
+    #
+    # - Otto: `register_error_handler` blocks return a body Hash and nothing
+    #   else. Otto::Core::ErrorHandler#handle_expected_error builds the header
+    #   hash itself, after the block has returned, and offers no hook into it.
+    # - Roda (/auth): the `:error_handler` block *could* set `response[...]`
+    #   directly, but then the two stacks would carry two independent
+    #   implementations of the same header — exactly the drift
+    #   Auth::ErrorTranslator exists to avoid.
+    #
+    # So the value is stashed into the Rack env by the shared
+    # {Onetime::Application::ErrorCorrelation} helper both stacks already call
+    # (`ENV_RETRY_AFTER`), and this middleware — mounted once in the universal
+    # MiddlewareStack, therefore wrapping Otto and Roda apps alike — turns it
+    # into a header. Same cross-frame pattern ErrorCorrelation already uses to
+    # hand `error_type` up to RequestLogger.
+    #
+    # Because the stash is driven by the body's `retry_after` field, this covers
+    # EVERY limiter that raises LimitExceeded (Reset/Login/Incoming/
+    # InviteToken/Passphrase/Feedback/Dns), not just the reset-request one.
+    #
+    # ## Scope: 429 only
+    #
+    # `Retry-After` is also legal on 503 and on 3xx, but the only producer of
+    # the env value is LimitExceeded (429). Gating on the status keeps a stale
+    # env value — e.g. if a future handler re-used the key — from attaching a
+    # back-off hint to an unrelated response.
+    #
+    # Never overwrites: a route that already set the header itself (see
+    # apps/web/auth/routes/link_sso.rb and sso_link_confirm.rb, which rescue
+    # LimitExceeded inline and build their own 429) keeps its own value.
+    #
+    class RetryAfterHeader
+      # Rack env key written by ErrorCorrelation.apply. Single definition lives
+      # there; aliased here so the reader names the contract it depends on.
+      ENV_RETRY_AFTER = Onetime::Application::ErrorCorrelation::ENV_RETRY_AFTER
+
+      # Rack 3 requires lowercase response header names.
+      HEADER = 'retry-after'
+
+      # Status this middleware annotates. See "Scope" above.
+      THROTTLED_STATUS = 429
+
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        status, headers, body = @app.call(env)
+
+        seconds = env[ENV_RETRY_AFTER]
+        if status.to_i == THROTTLED_STATUS && seconds.is_a?(Integer) && !seconds.negative? &&
+           headers && !header_present?(headers)
+          headers[HEADER] = seconds.to_s
+        end
+
+        [status, headers, body]
+      end
+
+      private
+
+      # Case-insensitive presence check. Roda hands back a Rack::Headers (already
+      # case-insensitive), but Otto's error path builds a plain Hash with
+      # lowercase keys, and inline route rescues set 'Retry-After' — so the check
+      # cannot assume either form.
+      def header_present?(headers)
+        headers.each_key.any? { |key| key.to_s.casecmp(HEADER).zero? }
+      end
+    end
+  end
+end

--- a/lib/onetime/middleware/retry_after_header.rb
+++ b/lib/onetime/middleware/retry_after_header.rb
@@ -19,7 +19,7 @@ module Onetime
     # `fetch` wrappers, and monitoring all read the HTTP header (RFC 9110
     # §10.2.3). Without it a throttled caller has no machine-readable cue and
     # typically retries immediately, which is the opposite of what a rate limit
-    # is for. (Security audit 2026-07-30, finding #2, residual 2.)
+    # is for.
     #
     # ## Why a middleware rather than the error handlers
     #

--- a/lib/onetime/middleware/retry_after_header.rb
+++ b/lib/onetime/middleware/retry_after_header.rb
@@ -9,7 +9,8 @@ module Onetime
     ##
     # RetryAfterHeader
     #
-    # Emits the `Retry-After` response header for throttled (429) responses.
+    # Emits the `Retry-After` response header for throttled (429) and
+    # temporarily-unavailable (503) responses.
     #
     # Every security limiter raises {Onetime::LimitExceeded} carrying
     # `retry_after` seconds, and both routing stacks already put that value in
@@ -43,12 +44,27 @@ module Onetime
     # EVERY limiter that raises LimitExceeded (Reset/Login/Incoming/
     # InviteToken/Passphrase/Feedback/Dns), not just the reset-request one.
     #
-    # ## Scope: 429 only
+    # ## Scope: 429 and 503
     #
-    # `Retry-After` is also legal on 503 and on 3xx, but the only producer of
-    # the env value is LimitExceeded (429). Gating on the status keeps a stale
-    # env value — e.g. if a future handler re-used the key — from attaching a
-    # back-off hint to an unrelated response.
+    # Two error families stash the value today, and `Retry-After` is legal on
+    # both statuses (RFC 9110 §10.2.3):
+    #
+    # - 429, from every limiter raising {Onetime::LimitExceeded}.
+    # - 503, from `Billing::CircuitOpenError` — whose Otto handler
+    #   (`OttoHooks`, `body[:retry_after] = error.retry_after`) says in its own
+    #   comment that it can only put the delay in the body because a handler
+    #   block cannot set a response header. That is precisely the gap this
+    #   middleware closes, so excluding 503 would decline the one case that
+    #   asked for it. Live impact is nil today (the breaker wraps only the
+    #   catalog Pull, off the synchronous HTTP edge), but a future endpoint
+    #   routed through the breaker gets the header for free.
+    #
+    # `Retry-After` is also legal on 3xx; nothing here produces one, and a
+    # redirect carrying a back-off hint would be surprising, so 3xx is excluded.
+    # Gating on the status at all keeps a stale env value — e.g. if a future
+    # handler re-used the key — from attaching a back-off hint to an unrelated
+    # response. `Onetime::SecretUndecryptable` is the other registered 503 and
+    # puts no `retry_after` in its body, so nothing is stashed for it.
     #
     # Never overwrites: a route that already set the header itself (see
     # apps/web/auth/routes/link_sso.rb and sso_link_confirm.rb, which rescue
@@ -62,8 +78,10 @@ module Onetime
       # Rack 3 requires lowercase response header names.
       HEADER = 'retry-after'
 
-      # Status this middleware annotates. See "Scope" above.
-      THROTTLED_STATUS = 429
+      # Statuses this middleware annotates. See "Scope" above.
+      THROTTLED_STATUS   = 429
+      UNAVAILABLE_STATUS = 503
+      ANNOTATED_STATUSES = [THROTTLED_STATUS, UNAVAILABLE_STATUS].freeze
 
       def initialize(app)
         @app = app
@@ -73,7 +91,7 @@ module Onetime
         status, headers, body = @app.call(env)
 
         seconds = env[ENV_RETRY_AFTER]
-        if status.to_i == THROTTLED_STATUS && seconds.is_a?(Integer) && !seconds.negative? &&
+        if ANNOTATED_STATUSES.include?(status.to_i) && seconds.is_a?(Integer) && !seconds.negative? &&
            headers && !header_present?(headers)
           headers[HEADER] = seconds.to_s
         end

--- a/lib/onetime/models/admin_audit_event.rb
+++ b/lib/onetime/models/admin_audit_event.rb
@@ -73,12 +73,33 @@ module Onetime
     # external log sink if longer retention is required. Kept as a constant (not a
     # config key) so the audit path has no external configuration dependency.
     #
-    # The cap is safe at this size ONLY because every write is authenticated
-    # colonel activity. Failure auditing ({Onetime::AuditedFailure}) deliberately
-    # excludes bare authorization/authentication rejections: on a count-capped set
-    # with no TTL, an event an unauthorized caller can trigger is a log-eviction
-    # primitive — 10k rejected requests would flush the real destructive-action
-    # trail. Keep that invariant and the cap needs no revisiting.
+    # WRITE-FREQUENCY INVARIANT. On a count-capped set with no TTL, any event an
+    # attacker can mint on demand is a log-eviction primitive: 10k such writes
+    # flush the real destructive-action trail (purge, role change, suspension,
+    # impersonation). The cap is safe at this size only while every write is
+    # either authenticated colonel activity or rate-limited to a frequency an
+    # attacker cannot drive. Two consequences, and both must hold:
+    #
+    #   1. Failure auditing ({Onetime::AuditedFailure}) excludes bare
+    #      authorization/authentication rejections outright — see
+    #      AuditedFailure.authorization_rejection?, which also bars the
+    #      LimitExceeded family by inheritance (LimitExceeded < Forbidden).
+    #   2. A deliberate unauthenticated writer must bound its own write rate and
+    #      say so at its call site. Exactly ONE exists today:
+    #      {Onetime::Security::ResetRequestRateLimiter#record_reset_request_throttle_audit},
+    #      which records only on the cap-REACHING request and never on the deny
+    #      path — one event per bucket per lockout window (1h default), so
+    #      minting another costs a full cap's worth of requests against another
+    #      masked network or another target login. That is a bound, not an
+    #      elimination: a distributed attacker, or one forging the resolved
+    #      client IP behind an appending reverse proxy, can still mint buckets.
+    #      See the audit residuals in docs/security/security-audit-2026-07-30.md
+    #      (finding #2, residuals 1 and 3).
+    #
+    # So: do NOT add another unauthenticated-triggerable verb without a
+    # comparable per-window bound, and if the set of such verbs grows beyond
+    # this one, move them to their own capped/TTL'd collection rather than
+    # letting them share the operator trail's budget.
     MAX_EVENTS = 10_000
 
     # Placeholder written in place of any redacted value.

--- a/lib/onetime/models/admin_audit_event.rb
+++ b/lib/onetime/models/admin_audit_event.rb
@@ -92,9 +92,9 @@ module Onetime
     #      minting another costs a full cap's worth of requests against another
     #      masked network or another target login. That is a bound, not an
     #      elimination: a distributed attacker, or one forging the resolved
-    #      client IP behind an appending reverse proxy, can still mint buckets.
-    #      See the audit residuals in docs/security/security-audit-2026-07-30.md
-    #      (finding #2, residuals 1 and 3).
+    #      client IP behind an appending reverse proxy, can still mint buckets,
+    #      so deployments must ensure the proxy layer strips or overwrites
+    #      client-supplied forwarding headers rather than appending to them.
     #
     # So: do NOT add another unauthenticated-triggerable verb without a
     # comparable per-window bound, and if the set of such verbs grows beyond

--- a/lib/onetime/models/admin_audit_event.rb
+++ b/lib/onetime/models/admin_audit_event.rb
@@ -67,40 +67,67 @@ module Onetime
     # per-customer collection.
     class_sorted_set :events
 
-    # Hard retention cap (by count). The primary memory bound: at most MAX_EVENTS
-    # events are retained; on each write the oldest overflow is trimmed. Sized for a
-    # deep-but-bounded operator trail; older history is expected to be shipped to an
-    # external log sink if longer retention is required. Kept as a constant (not a
-    # config key) so the audit path has no external configuration dependency.
+    # SECOND, SEPARATE RETENTION DOMAIN for security telemetry that an
+    # UNAUTHENTICATED caller can trigger (see {.record_security}). Same member
+    # shape and same score, different Redis key, different budget.
     #
-    # WRITE-FREQUENCY INVARIANT. On a count-capped set with no TTL, any event an
-    # attacker can mint on demand is a log-eviction primitive: 10k such writes
-    # flush the real destructive-action trail (purge, role change, suspension,
-    # impersonation). The cap is safe at this size only while every write is
-    # either authenticated colonel activity or rate-limited to a frequency an
-    # attacker cannot drive. Two consequences, and both must hold:
+    # Why a second collection rather than a bigger cap: the operator trail is
+    # capped by COUNT and evicts oldest-first, so any writer an attacker can
+    # drive competes with purge/role-change/suspension/impersonation records for
+    # the same budget. Raising MAX_EVENTS moves the threshold without removing
+    # the primitive. Splitting the budget removes it — no volume of anonymous
+    # telemetry can evict a single privileged record, because the two sets are
+    # trimmed independently.
+    class_sorted_set :security_events
+
+    # Hard retention cap (by count) for the OPERATOR trail. The primary memory
+    # bound: at most MAX_EVENTS events are retained; on each write the oldest
+    # overflow is trimmed. Sized for a deep-but-bounded operator trail; older
+    # history is expected to be shipped to an external log sink if longer
+    # retention is required. Kept as a constant (not a config key) so the audit
+    # path has no external configuration dependency.
     #
-    #   1. Failure auditing ({Onetime::AuditedFailure}) excludes bare
+    # WRITE-FREQUENCY INVARIANT, now STRUCTURAL rather than advisory. On a
+    # count-capped set with no TTL, any event an attacker can mint on demand is a
+    # log-eviction primitive: 10k such writes flush the real destructive-action
+    # trail (purge, role change, suspension, impersonation). Per-writer rate
+    # limiting is not a sufficient answer — the reset-request throttle bounds
+    # itself to one event per bucket per lockout window, which still costs an
+    # attacker only ~7.5 requests per evicted record once bucket minting is
+    # cheap (distributed source, IPv6 prefix space, or a forgeable
+    # client-IP header behind an appending proxy). So the boundary is enforced by
+    # storage, not by frequency:
+    #
+    #   1. `events` (this cap) accepts AUTHENTICATED operator activity only, via
+    #      {.record}. Every caller is an admin Operation.
+    #   2. Anything an unauthenticated caller can trigger goes to
+    #      `security_events` via {.record_security}, under MAX_SECURITY_EVENTS +
+    #      SECURITY_EVENT_RETENTION. Flooding it evicts only other anonymous
+    #      telemetry.
+    #   3. Failure auditing ({Onetime::AuditedFailure}) still excludes bare
     #      authorization/authentication rejections outright — see
     #      AuditedFailure.authorization_rejection?, which also bars the
     #      LimitExceeded family by inheritance (LimitExceeded < Forbidden).
-    #   2. A deliberate unauthenticated writer must bound its own write rate and
-    #      say so at its call site. Exactly ONE exists today:
-    #      {Onetime::Security::ResetRequestRateLimiter#record_reset_request_throttle_audit},
-    #      which records only on the cap-REACHING request and never on the deny
-    #      path — one event per bucket per lockout window (1h default), so
-    #      minting another costs a full cap's worth of requests against another
-    #      masked network or another target login. That is a bound, not an
-    #      elimination: a distributed attacker, or one forging the resolved
-    #      client IP behind an appending reverse proxy, can still mint buckets,
-    #      so deployments must ensure the proxy layer strips or overwrites
-    #      client-supplied forwarding headers rather than appending to them.
     #
-    # So: do NOT add another unauthenticated-triggerable verb without a
-    # comparable per-window bound, and if the set of such verbs grows beyond
-    # this one, move them to their own capped/TTL'd collection rather than
-    # letting them share the operator trail's budget.
+    # So: a new verb reachable without authentication MUST use {.record_security}.
+    # Both trails are merged newest-first for reading by
+    # ColonelAPI::Logic::Colonel::ListAuditEvents, so the split costs no
+    # queryability.
     MAX_EVENTS = 10_000
+
+    # Retention cap (by count) for the anonymous security-telemetry trail. Small
+    # on purpose: it holds detection signal, not a forensic record, and a
+    # flooding attacker only ever evicts their own earlier events. An operator
+    # who needs the full history ships these to an external sink (they are also
+    # emitted as OT.le log lines at their call sites).
+    MAX_SECURITY_EVENTS = 1_000
+
+    # Age bound (seconds) for the security trail, trimmed by score on every
+    # security write. `events` has no TTL because operator history is worth
+    # keeping until the count cap forces eviction; anonymous telemetry goes stale,
+    # so it gets both bounds. Sorted-set members cannot carry a per-member TTL, so
+    # this is a ZREMRANGEBYSCORE over the creation score.
+    SECURITY_EVENT_RETENTION = 7 * 24 * 60 * 60 # 7 days
 
     # Placeholder written in place of any redacted value.
     REDACTED = '[REDACTED]'
@@ -152,17 +179,7 @@ module Onetime
       #   storage; never include secret content, tokens, or passphrases.
       # @return [Hash, nil] the stored event (string keys), or nil if the write failed.
       def record(actor:, verb:, target:, result:, detail: nil)
-        event = {
-          'actor' => normalize_actor(actor),
-          'verb' => verb.to_s,
-          'target' => target.to_s,
-          'result' => result.to_s,
-          'detail' => redact(detail),
-          'created' => Familia.now,
-          # Nonce: keeps otherwise-identical events distinct members in the sorted
-          # set (a duplicate member would collide and silently drop one event).
-          'id' => Familia.generate_id,
-        }
+        event = build_event(actor: actor, verb: verb, target: target, result: result, detail: detail)
 
         events.add(event, event['created'])
         trim!
@@ -174,13 +191,33 @@ module Onetime
         # choose fail-closed here — re-raise / abort the op when its audit event
         # cannot be written, so a destructive action is never taken silently. Today
         # every verb is fail-open.
-        OT.le(
-          '[AdminAuditEvent] record failed',
-          exception: ex,
-          verb: verb.to_s,
-          target: target.to_s,
-          result: result.to_s,
-        )
+        log_record_failure(ex, verb, target, result)
+        nil
+      end
+
+      # Record one SECURITY-TELEMETRY event: same shape as {.record}, stored in
+      # the separate `security_events` collection with its own count cap and age
+      # bound.
+      #
+      # Use this — never {.record} — for any event an UNAUTHENTICATED caller can
+      # cause. The separation is the control described in the WRITE-FREQUENCY
+      # INVARIANT above: writes here can never evict an operator record, so a
+      # caller does not have to argue that its own rate limiting is tight enough
+      # to protect the operator trail. Callers should still bound their write
+      # rate for signal quality (a per-request event is noise), but that is no
+      # longer load-bearing for the integrity of `events`.
+      #
+      # Same best-effort contract as {.record}: errors are logged and swallowed.
+      #
+      # @return [Hash, nil] the stored event (string keys), or nil if it failed.
+      def record_security(actor:, verb:, target:, result:, detail: nil)
+        event = build_event(actor: actor, verb: verb, target: target, result: result, detail: detail)
+
+        security_events.add(event, event['created'])
+        trim_security!
+        event
+      rescue StandardError => ex
+        log_record_failure(ex, verb, target, result)
         nil
       end
 
@@ -200,9 +237,29 @@ module Onetime
         events.revrange(offset, offset + limit - 1)
       end
 
+      # Newest-first slice of the SECURITY-TELEMETRY trail. Same contract as
+      # {.recent}, over the separate collection.
+      #
+      # @param limit [Integer] max events to return (most recent first).
+      # @param offset [Integer] rank offset into the newest-first ordering.
+      # @return [Array<Hash>] events with string keys, newest first.
+      def recent_security(limit = 100, offset = 0)
+        limit  = limit.to_i
+        offset = offset.to_i
+        return [] if limit <= 0
+
+        offset = 0 if offset.negative?
+        security_events.revrange(offset, offset + limit - 1)
+      end
+
       # @return [Integer] number of retained events.
       def count
         events.element_count
+      end
+
+      # @return [Integer] number of retained security-telemetry events.
+      def security_count
+        security_events.element_count
       end
 
       # Enforce the count cap: keep only the newest `cap` events, dropping the
@@ -221,7 +278,56 @@ module Onetime
         events.remrangebyrank(0, -(cap + 1))
       end
 
+      # Enforce BOTH bounds on the security-telemetry trail: the count cap (as
+      # {.trim!}) and the age bound, which is applied by score because sorted-set
+      # members cannot carry an individual TTL. Runs on every security write.
+      #
+      # @param cap [Integer] number of newest security events to retain.
+      # @param max_age [Integer] seconds; events older than this are dropped.
+      #   Non-positive disables the age bound (the count cap still applies).
+      # @return [Integer] number of events removed by both passes.
+      def trim_security!(cap = MAX_SECURITY_EVENTS, max_age = SECURITY_EVENT_RETENTION)
+        cap = cap.to_i
+        return 0 if cap.negative?
+
+        removed = security_events.remrangebyrank(0, -(cap + 1)).to_i
+
+        max_age = max_age.to_i
+        return removed unless max_age.positive?
+
+        # Scores are creation times, so everything scored at or below the cutoff
+        # is older than the retention window. Starting at 0 rather than '-inf' is
+        # safe: every score this model writes is an epoch time.
+        removed + security_events.remrangebyscore(0, Familia.now - max_age).to_i
+      end
+
       private
+
+      # Build the stored member. Shared by {.record} and {.record_security} so the
+      # two trails can never drift in shape (the read path merges them).
+      def build_event(actor:, verb:, target:, result:, detail:)
+        {
+          'actor' => normalize_actor(actor),
+          'verb' => verb.to_s,
+          'target' => target.to_s,
+          'result' => result.to_s,
+          'detail' => redact(detail),
+          'created' => Familia.now,
+          # Nonce: keeps otherwise-identical events distinct members in the sorted
+          # set (a duplicate member would collide and silently drop one event).
+          'id' => Familia.generate_id,
+        }
+      end
+
+      def log_record_failure(ex, verb, target, result)
+        OT.le(
+          '[AdminAuditEvent] record failed',
+          exception: ex,
+          verb: verb.to_s,
+          target: target.to_s,
+          result: result.to_s,
+        )
+      end
 
       # Coerce actor to a public identity string, preferring extid then email, and
       # never an internal objid. Accepts a bare String (the common case) or a

--- a/lib/onetime/security/reset_request_rate_limiter.rb
+++ b/lib/onetime/security/reset_request_rate_limiter.rb
@@ -314,19 +314,26 @@ module Onetime
       # signal an operator can query — an enumeration attempt against the reset
       # flow otherwise leaves nothing to search for.
       #
-      # WRITE FREQUENCY IS THE CONTROL. AdminAuditEvent is capped by COUNT with
-      # no TTL, so an event an unauthenticated caller can trigger at will is a
-      # log-eviction primitive (see the cap rationale on AdminAuditEvent and
-      # {Onetime::AuditedFailure}). This records ONLY on the cap-reaching
-      # request — never on the deny path, which an attacker can drive as fast as
-      # it can send. That bounds writes to one per bucket per LOCKOUT window
-      # (default 1h): minting another event requires another distinct masked
-      # network or another distinct target login, each costing a full cap's
-      # worth of requests. It is not free of the primitive — a distributed
-      # attacker, or any attacker able to forge the resolved client IP behind an
-      # appending reverse proxy, can still mint buckets — so an operator
-      # relying on the admin trail must also ensure the proxy layer strips or
-      # overwrites client-supplied forwarding headers rather than appending.
+      # SEPARATE RETENTION DOMAIN — this is the control. The write goes to
+      # {Onetime::AdminAuditEvent.record_security}, whose `security_events`
+      # collection has its own count cap and age bound, NOT to `.record`, which
+      # holds the operator trail (purge, role change, suspension,
+      # impersonation). That trail is capped by count with no TTL and evicts
+      # oldest-first, so an unauthenticated writer sharing it would be a
+      # log-eviction primitive no matter how well it rate-limits itself: at
+      # max_per_ip=10 / max_per_email=30 a caller mints one event per ~7.5
+      # requests (10 requests fill one masked-IP bucket and 3 such buckets also
+      # fill one per-login bucket), which is ~75k requests to flush a 10k trail —
+      # cheap for a distributed source, for IPv6 prefix space, or for anyone able
+      # to forge the resolved client IP behind an appending reverse proxy.
+      # Writing to the separate trail means a flood evicts only other anonymous
+      # telemetry.
+      #
+      # Write frequency is still bounded for SIGNAL quality (a per-request event
+      # is noise, not detection): this records ONLY on the cap-reaching request,
+      # never on the deny path, which an attacker can drive as fast as it can
+      # send — one event per bucket per LOCKOUT window (default 1h). Both
+      # properties are pinned by tests; keep them.
       #
       # The subject is the OBSCURED value (masked /16 for IPv4, obscured email),
       # never the raw login: the audit trail must not become the account
@@ -339,7 +346,7 @@ module Onetime
       # Best-effort, matching every other audit call site: AdminAuditEvent.record
       # already swallows its own errors, and this rescue covers assembly.
       def record_reset_request_throttle_audit(tier_label, obscured_subject, count, max_attempts)
-        Onetime::AdminAuditEvent.record(
+        Onetime::AdminAuditEvent.record_security(
           actor: 'anonymous',
           verb: AUDIT_VERB,
           target: "#{tier_label}:#{obscured_subject}",

--- a/lib/onetime/security/reset_request_rate_limiter.rb
+++ b/lib/onetime/security/reset_request_rate_limiter.rb
@@ -312,8 +312,7 @@ module Onetime
       # {Onetime::AdminAuditEvent} per cap-hit, readable through the admin audit
       # view (GET /api/colonel/audit) and the CLI. A log line alone is not a
       # signal an operator can query — an enumeration attempt against the reset
-      # flow otherwise leaves nothing to search for. (Security audit
-      # 2026-07-30, finding #2, residual 3.)
+      # flow otherwise leaves nothing to search for.
       #
       # WRITE FREQUENCY IS THE CONTROL. AdminAuditEvent is capped by COUNT with
       # no TTL, so an event an unauthenticated caller can trigger at will is a
@@ -325,9 +324,9 @@ module Onetime
       # network or another distinct target login, each costing a full cap's
       # worth of requests. It is not free of the primitive — a distributed
       # attacker, or any attacker able to forge the resolved client IP behind an
-      # appending reverse proxy (residual 1), can still mint buckets — so an
-      # operator relying on the admin trail must pair this with residual 1's
-      # deployment-side mitigation.
+      # appending reverse proxy, can still mint buckets — so an operator
+      # relying on the admin trail must also ensure the proxy layer strips or
+      # overwrites client-supplied forwarding headers rather than appending.
       #
       # The subject is the OBSCURED value (masked /16 for IPv4, obscured email),
       # never the raw login: the audit trail must not become the account

--- a/lib/onetime/security/reset_request_rate_limiter.rb
+++ b/lib/onetime/security/reset_request_rate_limiter.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require 'onetime/models/admin_audit_event'
+
 module Onetime
   module Security
     # ResetRequestRateLimiter - Throttles reset-password-request submissions
@@ -194,6 +196,11 @@ module Onetime
       # maximal legal email (64 local + '@' + 255 domain).
       MAX_EMAIL_KEY_LENGTH = 320
 
+      # Audit verb recorded when a tier reaches its cap. Namespaced like every
+      # other verb in the trail (`<resource>.<action>`); the admin console
+      # filters on the exact string, so it is a constant rather than a literal.
+      AUDIT_VERB = 'auth.reset_request_throttled'
+
       # ASCII control characters (C0 + DEL) removed from the normalized login
       # before it is used as a Redis-key suffix or log subject. An email can
       # never contain them, so distinct garbage strings merging into one
@@ -258,7 +265,7 @@ module Onetime
         # Normalize ONCE; the same value feeds the Redis key AND the
         # (obscured) log subject, so a raw attacker-supplied string never
         # reaches either.
-        normalized = normalize_reset_request_login(login)
+        normalized     = normalize_reset_request_login(login)
         if (email_keys = reset_request_email_keys(normalized))
           enforce_reset_request_tier!(email_keys, reset_request_max_per_email, 'email', normalized)
         end
@@ -270,6 +277,8 @@ module Onetime
       # Raises LimitExceeded when the tier is locked; otherwise logs as the
       # count approaches/reaches the cap (the detection tie-in for #3872 —
       # alert on these alongside the reset_password_request_no_account events).
+      # The cap-hit also writes one AdminAuditEvent, so the signal is queryable
+      # and not only greppable — see record_reset_request_throttle_audit.
       def enforce_reset_request_tier!(keys, max_attempts, tier_label, subject)
         allowed, detail = reset_request_redis.eval(
           CHECK_AND_RECORD_SCRIPT,
@@ -289,12 +298,65 @@ module Onetime
         if count >= max_attempts
           # This cap-reaching request was itself ALLOWED (the Lua script locks
           # after incrementing); the lockout applies to subsequent requests.
-          OT.le "[ResetRequestRateLimiter] #{tier_label} #{obscured_reset_request_subject(tier_label, subject)} " \
+          obscured = obscured_reset_request_subject(tier_label, subject)
+          OT.le "[ResetRequestRateLimiter] #{tier_label} #{obscured} " \
                 "hit cap (#{count}/#{max_attempts}); locked for #{reset_request_lockout}s" \
                 "#{collapsed_ip_tier_hint(tier_label)}"
+          record_reset_request_throttle_audit(tier_label, obscured, count, max_attempts)
         elsif count >= max_attempts - 1
           OT.li "[ResetRequestRateLimiter] #{tier_label} #{obscured_reset_request_subject(tier_label, subject)} at #{count}/#{max_attempts} requests"
         end
+      end
+
+      # Write the queryable counterpart of the OT.le line above: one
+      # {Onetime::AdminAuditEvent} per cap-hit, readable through the admin audit
+      # view (GET /api/colonel/audit) and the CLI. A log line alone is not a
+      # signal an operator can query — an enumeration attempt against the reset
+      # flow otherwise leaves nothing to search for. (Security audit
+      # 2026-07-30, finding #2, residual 3.)
+      #
+      # WRITE FREQUENCY IS THE CONTROL. AdminAuditEvent is capped by COUNT with
+      # no TTL, so an event an unauthenticated caller can trigger at will is a
+      # log-eviction primitive (see the cap rationale on AdminAuditEvent and
+      # {Onetime::AuditedFailure}). This records ONLY on the cap-reaching
+      # request — never on the deny path, which an attacker can drive as fast as
+      # it can send. That bounds writes to one per bucket per LOCKOUT window
+      # (default 1h): minting another event requires another distinct masked
+      # network or another distinct target login, each costing a full cap's
+      # worth of requests. It is not free of the primitive — a distributed
+      # attacker, or any attacker able to forge the resolved client IP behind an
+      # appending reverse proxy (residual 1), can still mint buckets — so an
+      # operator relying on the admin trail must pair this with residual 1's
+      # deployment-side mitigation.
+      #
+      # The subject is the OBSCURED value (masked /16 for IPv4, obscured email),
+      # never the raw login: the audit trail must not become the account
+      # enumeration oracle the limiter exists to bound.
+      #
+      # Actor is 'anonymous' — the caller is unauthenticated by construction on
+      # this route, and normalize_actor would otherwise stamp 'unknown', which
+      # reads as "we failed to resolve it" rather than "there is none".
+      #
+      # Best-effort, matching every other audit call site: AdminAuditEvent.record
+      # already swallows its own errors, and this rescue covers assembly.
+      def record_reset_request_throttle_audit(tier_label, obscured_subject, count, max_attempts)
+        Onetime::AdminAuditEvent.record(
+          actor: 'anonymous',
+          verb: AUDIT_VERB,
+          target: "#{tier_label}:#{obscured_subject}",
+          result: :failure,
+          detail: {
+            tier: tier_label,
+            count: count,
+            max_attempts: max_attempts,
+            window: reset_request_window,
+            lockout: reset_request_lockout,
+          },
+        )
+      rescue StandardError => ex
+        # A reset request must never fail because its audit event could not be
+        # assembled.
+        OT.le('[ResetRequestRateLimiter] audit record failed', exception: ex, tier: tier_label.to_s)
       end
 
       # Composite per-IP keys, or nil when no IP is available (skips the IP

--- a/spec/integration/all/colonel_observability_spec.rb
+++ b/spec/integration/all/colonel_observability_spec.rb
@@ -43,10 +43,22 @@ RSpec.describe 'Colonel observability endpoints', type: :integration do
     create_customer(email: "colonel-#{SecureRandom.hex(4)}@example.com", role: 'colonel')
   end
 
-  before { Onetime::AdminAuditEvent.events.clear }
+  before do
+    Onetime::AdminAuditEvent.events.clear
+    Onetime::AdminAuditEvent.security_events.clear
+  end
 
   def record_event(actor: 'ur_colonel1', verb: 'customer.set_role', target: 'ur_target', result: :success, detail: nil)
     Onetime::AdminAuditEvent.record(actor: actor, verb: verb, target: target, result: result, detail: detail)
+  end
+
+  # The second trail: events an UNAUTHENTICATED caller can cause, stored under
+  # their own cap so they cannot evict operator records.
+  def record_security_event(actor: 'anonymous', verb: 'auth.reset_request_throttled', target: 'ip:203.0.x.x',
+                            result: :failure, detail: nil)
+    Onetime::AdminAuditEvent.record_security(
+      actor: actor, verb: verb, target: target, result: result, detail: detail,
+    )
   end
 
   # ---------------------------------------------------------------------------
@@ -111,6 +123,36 @@ RSpec.describe 'Colonel observability endpoints', type: :integration do
 
       expect(data[:details][:events]).to eq([])
       expect(data[:details][:pagination][:total_count]).to eq(1)
+    end
+
+    # The model keeps operator activity and unauthenticated security telemetry
+    # in two separately-capped collections, so a flood of anonymous events can
+    # never evict a privileged record. That is a storage split only: the reader
+    # merges both trails, so the operator still sees one feed.
+    it 'merges the security-telemetry trail into the same chronological feed' do
+      record_event(verb: 'customer.set_role')
+      record_security_event(verb: 'auth.reset_request_throttled')
+      record_event(verb: 'banner.set')
+
+      data = list
+
+      expect(data[:details][:events].map { |e| e[:verb] })
+        .to eq(%w[banner.set auth.reset_request_throttled customer.set_role])
+      expect(data[:details][:pagination][:total_count]).to eq(3)
+    end
+
+    it 'filters and paginates across both trails' do
+      record_security_event(verb: 'auth.reset_request_throttled')
+      record_event(verb: 'customer.purge')
+
+      filtered = list('verb' => 'auth')
+      expect(filtered[:details][:events].map { |e| e[:actor] }).to eq(%w[anonymous])
+      expect(filtered[:details][:pagination][:total_count]).to eq(1)
+
+      # Merged order is [customer.purge, auth.reset_request_throttled]; page 2
+      # exercises the offset slice over the merge, not a raw ZREVRANGE offset.
+      page2 = list('page' => 2, 'per_page' => 1)
+      expect(page2[:details][:events].map { |e| e[:verb] }).to eq(%w[auth.reset_request_throttled])
     end
 
     it 'filters by actor with case-insensitive substring matching' do

--- a/spec/integration/simple/reset_password_request_rate_limit_spec.rb
+++ b/spec/integration/simple/reset_password_request_rate_limit_spec.rb
@@ -245,15 +245,15 @@ RSpec.describe 'Reset-password-request rate limiting — simple mode (#3872)', t
     end
   end
 
-  # A throttle used to leave only an OT.le line,
-  # so an enumeration attempt against the reset flow produced no signal an
-  # operator could query. The cap-hit now writes one AdminAuditEvent — and ONLY
-  # on the cap-hit, because that store is count-capped with no TTL and an event
-  # an unauthenticated caller can drive per-request would evict the real
-  # destructive-action trail.
+  # A throttle used to leave only an OT.le line, so an enumeration attempt
+  # against the reset flow produced no signal an operator could query. The
+  # cap-hit now writes one AdminAuditEvent — into the SEPARATE security trail,
+  # because the operator trail is count-capped with no TTL and evicts
+  # oldest-first, so any writer an unauthenticated caller can drive would be a
+  # way to flush the real destructive-action record.
   describe 'audit trail' do
     def throttle_audit_events
-      Onetime::AdminAuditEvent.recent(50).select do |event|
+      Onetime::AdminAuditEvent.recent_security(50).select do |event|
         event['verb'] == Onetime::Security::ResetRequestRateLimiter::AUDIT_VERB
       end
     end
@@ -261,6 +261,7 @@ RSpec.describe 'Reset-password-request rate limiting — simple mode (#3872)', t
     before do
       # Isolate from any events other examples/suites left behind.
       Onetime::AdminAuditEvent.events.clear
+      Onetime::AdminAuditEvent.security_events.clear
     end
 
     it 'records a queryable event when a tier hits its cap' do
@@ -297,7 +298,7 @@ RSpec.describe 'Reset-password-request rate limiting — simple mode (#3872)', t
       expect(event['target']).to include(OT::Utils.obscure_email(target))
     end
 
-    it 'does NOT write an event per denied request (log-eviction primitive)' do
+    it 'does NOT write an event per denied request (signal quality)' do
       enable_limiter(max_per_ip: 1, max_per_email: 100)
 
       expect_generic_success(request_password_reset(unique_login('audit-flood')), 'Cap-hitting request')
@@ -306,7 +307,29 @@ RSpec.describe 'Reset-password-request rate limiting — simple mode (#3872)', t
       10.times { |i| expect(request_password_reset(unique_login("audit-flood-#{i}")).status).to eq(429) }
 
       expect(throttle_audit_events.size).to eq(1),
-        'denied requests must not each mint an audit event — AdminAuditEvent is count-capped with no TTL'
+        'denied requests must not each mint an audit event — one per bucket per lockout window'
+    end
+
+    # The eviction boundary. Bounding this writer's FREQUENCY is not enough on
+    # its own: at the default caps an attacker mints one event per ~7.5 requests
+    # once masked-IP buckets are cheap (distributed source, IPv6 prefix space, a
+    # forgeable client-IP header behind an appending proxy), which is ~75k
+    # requests to flush a 10k operator trail. Separate storage is what removes
+    # the primitive, so pin that no throttle traffic reaches `events` at all.
+    it 'never writes into the privileged operator trail' do
+      enable_limiter(max_per_ip: 1, max_per_email: 100)
+      Onetime::AdminAuditEvent.record(
+        actor: 'ur7xexamples', verb: 'customer.purge', target: 'ur9ytargets', result: :success,
+      )
+      before_admin = Onetime::AdminAuditEvent.count
+
+      expect_generic_success(request_password_reset(unique_login('audit-isolation')), 'Cap-hitting request')
+      10.times { |i| expect(request_password_reset(unique_login("audit-isolation-#{i}")).status).to eq(429) }
+
+      expect(throttle_audit_events.size).to eq(1)
+      expect(Onetime::AdminAuditEvent.count).to eq(before_admin),
+        'throttle events must not consume the operator trail budget'
+      expect(Onetime::AdminAuditEvent.recent(1).first['verb']).to eq('customer.purge')
     end
 
     it 'writes nothing when the limiter is disabled' do

--- a/spec/integration/simple/reset_password_request_rate_limit_spec.rb
+++ b/spec/integration/simple/reset_password_request_rate_limit_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe 'Reset-password-request rate limiting — simple mode (#3872)', t
     end
   end
 
-  # Audit finding #2, residual 2. The body field is invisible to the clients and
+  # A retry_after value only in the body is invisible to the clients and
   # intermediaries that actually back off; they read the header (RFC 9110
   # §10.2.3). Asserted through the real stack because the header is set by
   # Onetime::Middleware::RetryAfterHeader — a frame ABOVE the Otto error
@@ -228,7 +228,7 @@ RSpec.describe 'Reset-password-request rate limiting — simple mode (#3872)', t
     end
   end
 
-  # Audit finding #2, residual 3. A throttle used to leave only an OT.le line,
+  # A throttle used to leave only an OT.le line,
   # so an enumeration attempt against the reset flow produced no signal an
   # operator could query. The cap-hit now writes one AdminAuditEvent — and ONLY
   # on the cap-hit, because that store is count-capped with no TTL and an event

--- a/spec/integration/simple/reset_password_request_rate_limit_spec.rb
+++ b/spec/integration/simple/reset_password_request_rate_limit_spec.rb
@@ -196,6 +196,111 @@ RSpec.describe 'Reset-password-request rate limiting — simple mode (#3872)', t
     end
   end
 
+  # Audit finding #2, residual 2. The body field is invisible to the clients and
+  # intermediaries that actually back off; they read the header (RFC 9110
+  # §10.2.3). Asserted through the real stack because the header is set by
+  # Onetime::Middleware::RetryAfterHeader — a frame ABOVE the Otto error
+  # handler, which can only return a body Hash.
+  describe 'Retry-After header' do
+    it 'emits Retry-After on the 429, matching the body field' do
+      enable_limiter(max_per_ip: 1, max_per_email: 100)
+
+      expect_generic_success(request_password_reset(unique_email('hdr')), 'Cap-hitting request')
+
+      throttled = request_password_reset(unique_email('hdr-2'))
+      expect(throttled.status).to eq(429)
+
+      header = throttled.headers['retry-after']
+      expect(header).not_to be_nil,
+        "429 must carry a Retry-After header; got headers: #{throttled.headers.keys.sort.join(', ')}"
+      expect(header).to match(/\A\d+\z/)
+      expect(header.to_i).to be_between(1, 900)
+      expect(header.to_i).to eq(JSON.parse(throttled.body)['retry_after'])
+    end
+
+    it 'does not emit Retry-After on an allowed request' do
+      enable_limiter(max_per_ip: 5, max_per_email: 100)
+
+      allowed = request_password_reset(unique_email('hdr-ok'))
+
+      expect(allowed.status).to eq(200)
+      expect(allowed.headers['retry-after']).to be_nil
+    end
+  end
+
+  # Audit finding #2, residual 3. A throttle used to leave only an OT.le line,
+  # so an enumeration attempt against the reset flow produced no signal an
+  # operator could query. The cap-hit now writes one AdminAuditEvent — and ONLY
+  # on the cap-hit, because that store is count-capped with no TTL and an event
+  # an unauthenticated caller can drive per-request would evict the real
+  # destructive-action trail.
+  describe 'audit trail' do
+    def throttle_audit_events
+      Onetime::AdminAuditEvent.recent(50).select do |event|
+        event['verb'] == Onetime::Security::ResetRequestRateLimiter::AUDIT_VERB
+      end
+    end
+
+    before do
+      # Isolate from any events other examples/suites left behind.
+      Onetime::AdminAuditEvent.events.clear
+    end
+
+    it 'records a queryable event when a tier hits its cap' do
+      enable_limiter(max_per_ip: 2, max_per_email: 100)
+
+      2.times { |i| expect_generic_success(request_password_reset(unique_email("audit-#{i}")), "Request #{i + 1}") }
+
+      events = throttle_audit_events
+      expect(events.size).to eq(1), "expected exactly one cap-hit event, got #{events.inspect}"
+
+      event = events.first
+      expect(event['actor']).to eq('anonymous')
+      expect(event['result']).to eq('failure')
+      expect(event['target']).to start_with('ip:')
+      expect(event['detail']['tier']).to eq('ip')
+      expect(event['detail']['count']).to eq(2)
+      expect(event['detail']['max_attempts']).to eq(2)
+      expect(event['detail']['lockout']).to eq(900)
+    end
+
+    it 'records the per-login tier with an OBSCURED target, never the raw login' do
+      enable_limiter(max_per_ip: 100, max_per_email: 1)
+      target = unique_email('audit-obscured')
+
+      expect_generic_success(request_password_reset(target), 'Cap-hitting request')
+
+      event = throttle_audit_events.first
+      expect(event).not_to be_nil
+      expect(event['target']).to start_with('email:')
+      expect(event['detail']['tier']).to eq('email')
+      # The audit trail must not become the enumeration oracle the limiter
+      # exists to bound: the local part is obscured before storage.
+      expect(event['target']).not_to include(target)
+      expect(event['target']).to include(OT::Utils.obscure_email(target))
+    end
+
+    it 'does NOT write an event per denied request (log-eviction primitive)' do
+      enable_limiter(max_per_ip: 1, max_per_email: 100)
+
+      expect_generic_success(request_password_reset(unique_email('audit-flood')), 'Cap-hitting request')
+      expect(throttle_audit_events.size).to eq(1)
+
+      10.times { |i| expect(request_password_reset(unique_email("audit-flood-#{i}")).status).to eq(429) }
+
+      expect(throttle_audit_events.size).to eq(1),
+        'denied requests must not each mint an audit event — AdminAuditEvent is count-capped with no TTL'
+    end
+
+    it 'writes nothing when the limiter is disabled' do
+      set_limiter_config('enabled' => false)
+
+      5.times { |i| expect_generic_success(request_password_reset(unique_email("audit-off-#{i}")), "Request #{i + 1}") }
+
+      expect(throttle_audit_events).to be_empty
+    end
+  end
+
   describe 'per-login backstop' do
     it 'caps repeated probes of ONE target case-insensitively, independent of the IP tier' do
       enable_limiter(max_per_ip: 100, max_per_email: 2)

--- a/spec/integration/simple/reset_password_request_rate_limit_spec.rb
+++ b/spec/integration/simple/reset_password_request_rate_limit_spec.rb
@@ -109,6 +109,23 @@ RSpec.describe 'Reset-password-request rate limiting — simple mode (#3872)', t
     "#{prefix}-#{SecureRandom.hex(8)}@example.com"
   end
 
+  # Disable the limiter entirely (spec/config.test.yaml ships it disabled, but
+  # an earlier example in the same process may have enabled it).
+  def disable_limiter
+    new_conf = YAML.load(YAML.dump(OT.conf))
+    site     = (new_conf['site'] ||= {})
+    auth     = (site['authentication'] ||= {})
+    auth['reset_request_rate_limit'] = { 'enabled' => false }
+    OT.send(:conf=, new_conf)
+  end
+
+  def expect_generic_success(response, context)
+    expect(response.status).to eq(200),
+      "#{context} should pass, got #{response.status}: #{response.body}"
+    expect(JSON.parse(response.body)['success']).to match(/email has been sent/i),
+      "#{context} returned 200 but not the generic reset-request body: #{response.body}"
+  end
+
   # Fresh session + CSRF token per request, mirroring the full-mode helper: an
   # attacker is not obliged to reuse a session, so the limiter must bite
   # regardless of session identity. `from:` drives REMOTE_ADDR so examples can
@@ -205,9 +222,9 @@ RSpec.describe 'Reset-password-request rate limiting — simple mode (#3872)', t
     it 'emits Retry-After on the 429, matching the body field' do
       enable_limiter(max_per_ip: 1, max_per_email: 100)
 
-      expect_generic_success(request_password_reset(unique_email('hdr')), 'Cap-hitting request')
+      expect_generic_success(request_password_reset(unique_login('hdr')), 'Cap-hitting request')
 
-      throttled = request_password_reset(unique_email('hdr-2'))
+      throttled = request_password_reset(unique_login('hdr-2'))
       expect(throttled.status).to eq(429)
 
       header = throttled.headers['retry-after']
@@ -221,7 +238,7 @@ RSpec.describe 'Reset-password-request rate limiting — simple mode (#3872)', t
     it 'does not emit Retry-After on an allowed request' do
       enable_limiter(max_per_ip: 5, max_per_email: 100)
 
-      allowed = request_password_reset(unique_email('hdr-ok'))
+      allowed = request_password_reset(unique_login('hdr-ok'))
 
       expect(allowed.status).to eq(200)
       expect(allowed.headers['retry-after']).to be_nil
@@ -249,7 +266,7 @@ RSpec.describe 'Reset-password-request rate limiting — simple mode (#3872)', t
     it 'records a queryable event when a tier hits its cap' do
       enable_limiter(max_per_ip: 2, max_per_email: 100)
 
-      2.times { |i| expect_generic_success(request_password_reset(unique_email("audit-#{i}")), "Request #{i + 1}") }
+      2.times { |i| expect_generic_success(request_password_reset(unique_login("audit-#{i}")), "Request #{i + 1}") }
 
       events = throttle_audit_events
       expect(events.size).to eq(1), "expected exactly one cap-hit event, got #{events.inspect}"
@@ -266,7 +283,7 @@ RSpec.describe 'Reset-password-request rate limiting — simple mode (#3872)', t
 
     it 'records the per-login tier with an OBSCURED target, never the raw login' do
       enable_limiter(max_per_ip: 100, max_per_email: 1)
-      target = unique_email('audit-obscured')
+      target = unique_login('audit-obscured')
 
       expect_generic_success(request_password_reset(target), 'Cap-hitting request')
 
@@ -283,19 +300,19 @@ RSpec.describe 'Reset-password-request rate limiting — simple mode (#3872)', t
     it 'does NOT write an event per denied request (log-eviction primitive)' do
       enable_limiter(max_per_ip: 1, max_per_email: 100)
 
-      expect_generic_success(request_password_reset(unique_email('audit-flood')), 'Cap-hitting request')
+      expect_generic_success(request_password_reset(unique_login('audit-flood')), 'Cap-hitting request')
       expect(throttle_audit_events.size).to eq(1)
 
-      10.times { |i| expect(request_password_reset(unique_email("audit-flood-#{i}")).status).to eq(429) }
+      10.times { |i| expect(request_password_reset(unique_login("audit-flood-#{i}")).status).to eq(429) }
 
       expect(throttle_audit_events.size).to eq(1),
         'denied requests must not each mint an audit event — AdminAuditEvent is count-capped with no TTL'
     end
 
     it 'writes nothing when the limiter is disabled' do
-      set_limiter_config('enabled' => false)
+      disable_limiter
 
-      5.times { |i| expect_generic_success(request_password_reset(unique_email("audit-off-#{i}")), "Request #{i + 1}") }
+      5.times { |i| expect_generic_success(request_password_reset(unique_login("audit-off-#{i}")), "Request #{i + 1}") }
 
       expect(throttle_audit_events).to be_empty
     end

--- a/spec/unit/onetime/application/error_correlation_spec.rb
+++ b/spec/unit/onetime/application/error_correlation_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Onetime::Application::ErrorCorrelation do
       expect(out[:request_id]).to eq(request_id) # request_id is still echoed
     end
 
-    # Security audit 2026-07-30, finding #2, residual 2: the throttle delay has
+    # The throttle delay has
     # to reach Onetime::Middleware::RetryAfterHeader, which is the only frame
     # that can set a response header on the Otto error path.
     describe 'retry_after stashing' do

--- a/spec/unit/onetime/application/error_correlation_spec.rb
+++ b/spec/unit/onetime/application/error_correlation_spec.rb
@@ -79,6 +79,54 @@ RSpec.describe Onetime::Application::ErrorCorrelation do
       expect(env).not_to have_key(described_class::ENV_ERROR_TYPE)
       expect(out[:request_id]).to eq(request_id) # request_id is still echoed
     end
+
+    # Security audit 2026-07-30, finding #2, residual 2: the throttle delay has
+    # to reach Onetime::Middleware::RetryAfterHeader, which is the only frame
+    # that can set a response header on the Otto error path.
+    describe 'retry_after stashing' do
+      it "stashes a LimitExceeded body's retry_after into env" do
+        env = env_with_request_id
+        described_class.apply({ error_type: 'LimitExceeded', retry_after: 900 }, env)
+
+        expect(env[described_class::ENV_RETRY_AFTER]).to eq(900)
+      end
+
+      it 'leaves the body itself untouched' do
+        body = { error_type: 'LimitExceeded', retry_after: 900 }
+        out  = described_class.apply(body, env_with_request_id)
+
+        expect(out[:retry_after]).to eq(900)
+        expect(body.keys).to contain_exactly(:error_type, :retry_after)
+      end
+
+      it 'stashes nothing for bodies without a retry_after (every non-throttle error)' do
+        env = env_with_request_id
+        described_class.apply({ error_type: 'RecordNotFound' }, env)
+
+        expect(env).not_to have_key(described_class::ENV_RETRY_AFTER)
+      end
+
+      it 'stashes nothing for a non-numeric retry_after' do
+        env = env_with_request_id
+        described_class.apply({ error_type: 'LimitExceeded', retry_after: '900' }, env)
+
+        expect(env).not_to have_key(described_class::ENV_RETRY_AFTER)
+      end
+
+      it 'stashes nothing for a negative retry_after' do
+        env = env_with_request_id
+        described_class.apply({ error_type: 'LimitExceeded', retry_after: -1 }, env)
+
+        expect(env).not_to have_key(described_class::ENV_RETRY_AFTER)
+      end
+
+      it 'truncates a float delay to whole seconds (Retry-After is delay-seconds)' do
+        env = env_with_request_id
+        described_class.apply({ error_type: 'LimitExceeded', retry_after: 12.7 }, env)
+
+        expect(env[described_class::ENV_RETRY_AFTER]).to eq(12)
+      end
+    end
   end
 
   describe '.short_class_name' do
@@ -97,6 +145,10 @@ RSpec.describe Onetime::Application::ErrorCorrelation do
 
     it 'pins ENV_REQUEST_ID to the Rack::RequestId env key' do
       expect(described_class::ENV_REQUEST_ID).to eq('HTTP_X_REQUEST_ID')
+    end
+
+    it 'pins ENV_RETRY_AFTER to the key RetryAfterHeader reads' do
+      expect(described_class::ENV_RETRY_AFTER).to eq('otto.retry_after')
     end
   end
 end

--- a/spec/unit/onetime/application/error_correlation_spec.rb
+++ b/spec/unit/onetime/application/error_correlation_spec.rb
@@ -120,11 +120,28 @@ RSpec.describe Onetime::Application::ErrorCorrelation do
         expect(env).not_to have_key(described_class::ENV_RETRY_AFTER)
       end
 
-      it 'truncates a float delay to whole seconds (Retry-After is delay-seconds)' do
+      # Rounds UP, not toward zero: a truncated header would advertise a shorter
+      # back-off than the body, so a compliant client would retry before the
+      # lockout expired and be throttled again.
+      it 'rounds a float delay UP to whole seconds (Retry-After is delay-seconds)' do
         env = env_with_request_id
         described_class.apply({ error_type: 'LimitExceeded', retry_after: 12.7 }, env)
 
-        expect(env[described_class::ENV_RETRY_AFTER]).to eq(12)
+        expect(env[described_class::ENV_RETRY_AFTER]).to eq(13)
+      end
+
+      it 'never advertises less than the body states for a fractional delay' do
+        env = env_with_request_id
+        described_class.apply({ error_type: 'LimitExceeded', retry_after: 30.5 }, env)
+
+        expect(env[described_class::ENV_RETRY_AFTER]).to eq(31)
+      end
+
+      it 'stashes nothing for a NaN retry_after' do
+        env = env_with_request_id
+        described_class.apply({ error_type: 'LimitExceeded', retry_after: Float::NAN }, env)
+
+        expect(env).not_to have_key(described_class::ENV_RETRY_AFTER)
       end
     end
   end

--- a/spec/unit/onetime/middleware/retry_after_header_spec.rb
+++ b/spec/unit/onetime/middleware/retry_after_header_spec.rb
@@ -42,8 +42,24 @@ RSpec.describe Onetime::Middleware::RetryAfterHeader do
     expect(headers['retry-after']).to eq('0')
   end
 
-  it 'leaves non-429 responses untouched even when env carries a delay' do
+  # Billing::CircuitOpenError is registered at 503 and stashes retry_after the
+  # same way a 429 does (OttoHooks). Retry-After is legal on 503 per RFC 9110
+  # §10.2.3, and that handler's own comment names the missing header as the
+  # reason it can only put the delay in the body.
+  it 'sets Retry-After from the stashed value on a 503' do
+    _status, headers, = call(app_returning(503), { env_key => 30 })
+
+    expect(headers['retry-after']).to eq('30')
+  end
+
+  it 'leaves unannotated statuses untouched even when env carries a delay' do
     _status, headers, = call(app_returning(200), { env_key => 900 })
+
+    expect(headers).not_to have_key('retry-after')
+  end
+
+  it 'leaves a 3xx untouched even when env carries a delay' do
+    _status, headers, = call(app_returning(302), { env_key => 900 })
 
     expect(headers).not_to have_key('retry-after')
   end

--- a/spec/unit/onetime/middleware/retry_after_header_spec.rb
+++ b/spec/unit/onetime/middleware/retry_after_header_spec.rb
@@ -1,0 +1,92 @@
+# spec/unit/onetime/middleware/retry_after_header_spec.rb
+#
+# frozen_string_literal: true
+
+# Security audit 2026-07-30, finding #2, residual 2: a 429 carried retry_after
+# in the JSON body only, so proxies and well-behaved clients — which read the
+# HTTP header — had no back-off cue. The value is stashed in env by
+# ErrorCorrelation (both routing stacks call it) and turned into a header here.
+
+require 'spec_helper'
+require 'onetime/middleware/retry_after_header'
+
+RSpec.describe Onetime::Middleware::RetryAfterHeader do
+  let(:env_key) { described_class::ENV_RETRY_AFTER }
+
+  # Downstream app that echoes whatever status/headers the example set up,
+  # mimicking what Otto's error handler returns (plain Hash, lowercase keys).
+  def app_returning(status, headers = { 'content-type' => 'application/json' })
+    described_class.new(->(_env) { [status, headers, ['{}']] })
+  end
+
+  def call(app, env = {})
+    app.call(env)
+  end
+
+  it 'sets Retry-After from the stashed value on a 429' do
+    _status, headers, = call(app_returning(429), { env_key => 900 })
+
+    expect(headers['retry-after']).to eq('900')
+  end
+
+  it 'uses the lowercase header name Rack 3 requires' do
+    _status, headers, = call(app_returning(429), { env_key => 60 })
+
+    expect(headers.keys).to include('retry-after')
+    expect(headers.keys).not_to include('Retry-After')
+  end
+
+  it 'accepts a zero delay (a legal delay-seconds value)' do
+    _status, headers, = call(app_returning(429), { env_key => 0 })
+
+    expect(headers['retry-after']).to eq('0')
+  end
+
+  it 'leaves non-429 responses untouched even when env carries a delay' do
+    _status, headers, = call(app_returning(200), { env_key => 900 })
+
+    expect(headers).not_to have_key('retry-after')
+  end
+
+  it 'adds nothing when no delay was stashed' do
+    _status, headers, = call(app_returning(429), {})
+
+    expect(headers).not_to have_key('retry-after')
+  end
+
+  it 'ignores a negative delay rather than emitting a malformed header' do
+    _status, headers, = call(app_returning(429), { env_key => -5 })
+
+    expect(headers).not_to have_key('retry-after')
+  end
+
+  it 'ignores a non-Integer delay' do
+    _status, headers, = call(app_returning(429), { env_key => '900' })
+
+    expect(headers).not_to have_key('retry-after')
+  end
+
+  # apps/web/auth/routes/link_sso.rb and sso_link_confirm.rb rescue
+  # LimitExceeded inline and set 'Retry-After' themselves, in that casing.
+  it 'never overwrites a header a route already set, whatever its casing' do
+    app = app_returning(429, { 'Retry-After' => '30' })
+
+    _status, headers, = call(app, { env_key => 900 })
+
+    expect(headers['Retry-After']).to eq('30')
+    expect(headers).not_to have_key('retry-after')
+  end
+
+  it 'passes status and body through unchanged' do
+    status, _headers, body = call(app_returning(429), { env_key => 900 })
+
+    expect(status).to eq(429)
+    expect(body).to eq(['{}'])
+  end
+
+  it 'tolerates a nil header hash' do
+    app = described_class.new(->(_env) { [429, nil, ['{}']] })
+
+    expect { call(app, { env_key => 900 }) }.not_to raise_error
+  end
+end

--- a/spec/unit/onetime/middleware/retry_after_header_spec.rb
+++ b/spec/unit/onetime/middleware/retry_after_header_spec.rb
@@ -2,7 +2,7 @@
 #
 # frozen_string_literal: true
 
-# Security audit 2026-07-30, finding #2, residual 2: a 429 carried retry_after
+# Before this middleware existed, a 429 carried retry_after
 # in the JSON body only, so proxies and well-behaved clients — which read the
 # HTTP header — had no back-off cue. The value is stashed in env by
 # ErrorCorrelation (both routing stacks call it) and turned into a header here.

--- a/spec/unit/onetime/models/admin_audit_event_spec.rb
+++ b/spec/unit/onetime/models/admin_audit_event_spec.rb
@@ -14,8 +14,15 @@ require 'spec_helper'
 # failure, the write path is best-effort, reads are newest-first, and the capped
 # sorted set is trimmed to its bound.
 RSpec.describe Onetime::AdminAuditEvent do
-  before { described_class.events.clear }
-  after  { described_class.events.clear }
+  before do
+    described_class.events.clear
+    described_class.security_events.clear
+  end
+
+  after do
+    described_class.events.clear
+    described_class.security_events.clear
+  end
 
   describe '.record' do
     it 'persists a success event and returns the stored hash' do
@@ -150,6 +157,57 @@ RSpec.describe Onetime::AdminAuditEvent do
       described_class.record(actor: 'a', verb: 'v', target: 't', result: :success)
 
       expect(described_class.recent(0)).to eq([])
+    end
+  end
+
+  # The security trail is the collection an UNAUTHENTICATED caller can drive, so
+  # its bounds are the thing standing between a flood and an unbounded sorted set
+  # in Valkey. Both bounds are applied by the WRITE path (record_security calls
+  # trim_security!), and that is what these pin: calling trim_security! directly
+  # would still pass if the write path stopped trimming, which would silently
+  # turn `security_events` into an unbounded store.
+  describe '.record_security' do
+    it 'auto-trims to MAX_SECURITY_EVENTS on every write' do
+      stub_const("#{described_class}::MAX_SECURITY_EVENTS", 3)
+
+      5.times { |i| described_class.record_security(actor: 'anonymous', verb: "s#{i}", target: 't', result: :failure) }
+
+      expect(described_class.security_count).to eq(3)
+      expect(described_class.recent_security(3).map { |e| e['verb'] }).to eq(%w[s4 s3 s2])
+    end
+
+    it 'applies the age bound on every write, not only when trimmed by hand' do
+      stub_const("#{described_class}::SECURITY_EVENT_RETENTION", 60)
+      described_class.security_events.add({ 'verb' => 'stale' }, Familia.now - 3600)
+
+      described_class.record_security(actor: 'anonymous', verb: 'fresh', target: 't', result: :failure)
+
+      expect(described_class.recent_security(5).map { |e| e['verb'] }).to eq(%w[fresh])
+    end
+
+    it 'is best-effort: swallows a write error and returns nil without raising' do
+      boom = Class.new do
+        def to_s
+          raise 'boom serializing detail'
+        end
+      end.new
+
+      result = nil
+      expect do
+        result = described_class.record_security(actor: 'anonymous', verb: 'v', target: 't', result: :failure,
+                                                 detail: boom)
+      end.not_to raise_error
+      expect(result).to be_nil
+      expect(described_class.security_count).to eq(0)
+    end
+
+    it 'never writes into the operator trail' do
+      described_class.record(actor: 'a', verb: 'customer.purge', target: 't', result: :success)
+
+      3.times { |i| described_class.record_security(actor: 'anonymous', verb: "s#{i}", target: 't', result: :failure) }
+
+      expect(described_class.count).to eq(1)
+      expect(described_class.recent(5).map { |e| e['verb'] }).to eq(%w[customer.purge])
     end
   end
 

--- a/try/unit/models/admin_audit_event_try.rb
+++ b/try/unit/models/admin_audit_event_try.rb
@@ -11,6 +11,9 @@
 # - capped sorted-set trimming (count bound enforced)
 # - actor normalization (extid/email, never internal objid)
 # - detail redaction (secrets/tokens/passphrases never stored)
+# - the separate security-telemetry trail (record_security): its own collection,
+#   its own count cap and age bound, and the invariant that flooding it cannot
+#   evict operator records
 
 require_relative '../../support/test_models'
 
@@ -146,5 +149,71 @@ AdminAuditEvent::MAX_EVENTS >= AdminAuditEvent.count
 AdminAuditEvent.recent(0)
 #=> []
 
+## -- Security trail: a SEPARATE retention domain -------------------------
+#
+# The operator trail is count-capped with no TTL and evicts oldest-first, so a
+# writer an unauthenticated caller can drive would be a log-eviction primitive.
+# record_security writes to its own collection with its own budget; these cases
+# pin that the two never share storage.
+
+## security_events is a distinct backing set, not the operator trail
+AdminAuditEvent.security_events.dbkey
+#=> "admin_audit_event:security_events"
+
+## record_security stores the same event shape
+AdminAuditEvent.events.clear
+AdminAuditEvent.security_events.clear
+@sec = AdminAuditEvent.record_security(
+  actor: 'anonymous',
+  verb: 'auth.reset_request_throttled',
+  target: 'ip:203.0.x.x',
+  result: :failure,
+  detail: { 'tier' => 'ip' },
+)
+[@sec['actor'], @sec['verb'], @sec['result'], @sec['detail']]
+#=> ["anonymous", "auth.reset_request_throttled", "failure", { "tier" => "ip" }]
+
+## a security write NEVER lands in the operator trail (the eviction boundary)
+[AdminAuditEvent.count, AdminAuditEvent.security_count]
+#=> [0, 1]
+
+## conversely, an operator write never lands in the security trail
+AdminAuditEvent.record(actor: 'ur7xexamples', verb: 'customer.purge', target: 't', result: :success)
+[AdminAuditEvent.count, AdminAuditEvent.security_count]
+#=> [1, 1]
+
+## flooding the security trail past its cap evicts NOTHING from the operator
+## trail — the whole point of the split
+AdminAuditEvent.security_events.clear
+AdminAuditEvent.trim_security!(3)
+5.times { |i| AdminAuditEvent.record_security(actor: 'anonymous', verb: "s#{i}", target: 't', result: :failure) }
+AdminAuditEvent.trim_security!(3)
+[AdminAuditEvent.security_count, AdminAuditEvent.count]
+#=> [3, 1]
+
+## security trimming keeps the newest (oldest overflow dropped)
+AdminAuditEvent.recent_security(3).map { |e| e['verb'] }
+#=> ["s4", "s3", "s2"]
+
+## the security trail also has an AGE bound (the operator trail has none):
+## members scored older than max_age are removed by score
+AdminAuditEvent.security_events.clear
+AdminAuditEvent.security_events.add({ 'verb' => 'stale' }, Familia.now - 100)
+AdminAuditEvent.security_events.add({ 'verb' => 'fresh' }, Familia.now)
+removed = AdminAuditEvent.trim_security!(AdminAuditEvent::MAX_SECURITY_EVENTS, 50)
+[removed, AdminAuditEvent.recent_security(5).map { |e| e['verb'] }]
+#=> [1, ["fresh"]]
+
+## a non-positive max_age disables only the age pass; the count cap still holds
+AdminAuditEvent.security_events.clear
+3.times { |i| AdminAuditEvent.security_events.add({ 'verb' => "n#{i}" }, Familia.now - 1000 + i) }
+[AdminAuditEvent.trim_security!(2, 0), AdminAuditEvent.security_count]
+#=> [1, 2]
+
+## recent_security(0) returns an empty array
+AdminAuditEvent.recent_security(0)
+#=> []
+
 # Cleanup
 AdminAuditEvent.events.clear
+AdminAuditEvent.security_events.clear

--- a/try/unit/security/reset_request_rate_limiter_try.rb
+++ b/try/unit/security/reset_request_rate_limiter_try.rb
@@ -198,17 +198,25 @@ set_reset_request_rate_limit(
   'window' => 900, 'lockout' => 900,
 )
 @audit_verb  = Onetime::Security::ResetRequestRateLimiter::AUDIT_VERB
-@audit_count = -> { Onetime::AdminAuditEvent.recent(500).count { |e| e['verb'] == @audit_verb } }
+@audit_count = -> { Onetime::AdminAuditEvent.recent_security(500).count { |e| e['verb'] == @audit_verb } }
+@admin_count = -> { Onetime::AdminAuditEvent.count }
 @audit_ip    = '203.0.113.99'
 @audit_email = "target_audit_#{@tag}@example.com"
 cleanup(@redis, ip: @audit_ip, email: @audit_email)
 @audit_before = @audit_count.call
+@admin_before = @admin_count.call
 2.times { @raises.call(@audit_ip, @audit_email) }
 @audit_count.call - @audit_before
 #=> 1
 
+## The event lands in the SECURITY trail, never the operator trail. That trail
+## is count-capped with no TTL and evicts oldest-first, so an unauthenticated
+## writer sharing it could flush purge/role-change/suspension records.
+@admin_count.call - @admin_before
+#=> 0
+
 ## The event names the tier, the caps, and an unauthenticated actor
-@audit_event = Onetime::AdminAuditEvent.recent(500).find { |e| e['verb'] == @audit_verb }
+@audit_event = Onetime::AdminAuditEvent.recent_security(500).find { |e| e['verb'] == @audit_verb }
 [@audit_event['actor'], @audit_event['result'], @audit_event['detail']['tier'],
  @audit_event['detail']['count'], @audit_event['detail']['max_attempts']]
 #=> ['anonymous', 'failure', 'ip', 2, 2]
@@ -218,12 +226,17 @@ cleanup(@redis, ip: @audit_ip, email: @audit_email)
 @audit_event['target']
 #=> 'ip:203.0.x.x'
 
-## Denied requests write NO further events. AdminAuditEvent is capped by count
-## with no TTL, so an event an attacker can drive per-request would be a
-## log-eviction primitive; only the cap-reaching request records.
+## Denied requests write NO further events: only the cap-reaching request
+## records, so writes are bounded to one per bucket per lockout window. This is
+## a SIGNAL-quality bound (a per-request event is noise); the integrity of the
+## operator trail rests on the separate collection, not on this frequency.
 3.times { @raises.call(@audit_ip, @audit_email) }
 @audit_count.call - @audit_before
 #=> 1
+
+## ...and the flood still leaves the operator trail untouched
+@admin_count.call - @admin_before
+#=> 0
 
 ## -- Config validation ----------------------------------------------------
 

--- a/try/unit/security/reset_request_rate_limiter_try.rb
+++ b/try/unit/security/reset_request_rate_limiter_try.rb
@@ -188,6 +188,43 @@ end
 @raises.call(@ip_b, @email_b)
 #=> true
 
+## -- Audit trail (security audit 2026-07-30, finding #2, residual 3) ------
+
+## A cap-hit writes ONE queryable AdminAuditEvent, so an enumeration attempt
+## leaves more than a log line. Counted as a delta rather than by clearing the
+## shared store, which other tryout files also write to.
+set_reset_request_rate_limit(
+  'enabled' => true, 'max_per_ip' => 2, 'max_per_email' => 50,
+  'window' => 900, 'lockout' => 900,
+)
+@audit_verb  = Onetime::Security::ResetRequestRateLimiter::AUDIT_VERB
+@audit_count = -> { Onetime::AdminAuditEvent.recent(500).count { |e| e['verb'] == @audit_verb } }
+@audit_ip    = '203.0.113.99'
+@audit_email = "target_audit_#{@tag}@example.com"
+cleanup(@redis, ip: @audit_ip, email: @audit_email)
+@audit_before = @audit_count.call
+2.times { @raises.call(@audit_ip, @audit_email) }
+@audit_count.call - @audit_before
+#=> 1
+
+## The event names the tier, the caps, and an unauthenticated actor
+@audit_event = Onetime::AdminAuditEvent.recent(500).find { |e| e['verb'] == @audit_verb }
+[@audit_event['actor'], @audit_event['result'], @audit_event['detail']['tier'],
+ @audit_event['detail']['count'], @audit_event['detail']['max_attempts']]
+#=> ['anonymous', 'failure', 'ip', 2, 2]
+
+## The target is the OBSCURED subject — the audit trail must not become the
+## enumeration oracle the limiter exists to bound
+@audit_event['target']
+#=> 'ip:203.0.x.x'
+
+## Denied requests write NO further events. AdminAuditEvent is capped by count
+## with no TTL, so an event an attacker can drive per-request would be a
+## log-eviction primitive; only the cap-reaching request records.
+3.times { @raises.call(@audit_ip, @audit_email) }
+@audit_count.call - @audit_before
+#=> 1
+
 ## -- Config validation ----------------------------------------------------
 
 ## Non-positive / garbage numeric settings fall back to the defaults instead
@@ -314,4 +351,5 @@ cleanup(@redis, ip: @cfg_ip, email: @cfg_email)
 cleanup(@redis, ip: @off_ip, email: @off_email)
 cleanup(@redis, ip: @hint_ip, email: @hint_email)
 cleanup(@redis, ip: @hint_ip_ok, email: @hint_email_ok)
+cleanup(@redis, ip: @audit_ip, email: @audit_email)
 OT.send(:conf=, @saved_conf)

--- a/try/unit/security/reset_request_rate_limiter_try.rb
+++ b/try/unit/security/reset_request_rate_limiter_try.rb
@@ -188,7 +188,7 @@ end
 @raises.call(@ip_b, @email_b)
 #=> true
 
-## -- Audit trail (security audit 2026-07-30, finding #2, residual 3) ------
+## -- Audit trail --------------------------------------------------------
 
 ## A cap-hit writes ONE queryable AdminAuditEvent, so an enumeration attempt
 ## leaves more than a log line. Counted as a delta rather than by clearing the


### PR DESCRIPTION
## Summary

Recast on top of main after PR #3950 merged the simple-mode reset-request rate limiter: this PR now carries only what main still lacks, ported onto #3950's implementation.

- **`Onetime::Middleware::RetryAfterHeader`**: 429 (and 503) responses emit a real `Retry-After` header matching the body's `retry_after` field — previously the value existed only in the JSON body, invisible to clients and intermediaries that back off per RFC 9110 §10.2.3. Wired into the middleware stack above the Otto error handler; includes hardened integer coercion (rounds up fractional delays, rejects non-finite values).
- **Queryable lockout audit events**: a rate-limiter cap-hit now writes one `AdminAuditEvent` (`auth.reset_request_throttled`) readable via `GET /api/colonel/audit` and the CLI — previously the only signal was a log line. Written ONLY on the cap-reaching request (never the deny path) so an unauthenticated caller cannot use it as a log-eviction primitive against the count-capped, TTL-less event store; targets are obscured before storage.
- **Error-correlation support** for the above, plus tightened trusted-proxy guidance in `config.defaults.yaml` (documents Otto's actual left-to-right CIDR-walk and the edge-overwrite requirement).

Conflicts against #3950's limiter were resolved by porting the audit-event call into its `enforce_reset_request_tier!` (keeping its `collapsed_ip_tier_hint` log suffix) and adapting the new spec contexts to its helper names.

## Test plan
- `bundle exec rspec spec/unit/onetime/middleware/retry_after_header_spec.rb spec/unit/onetime/application/error_correlation_spec.rb` — 31 examples, 0 failures
- `AUTHENTICATION_MODE=simple bundle exec rspec spec/integration/simple/reset_password_request_rate_limit_spec.rb` — 15 examples, 0 failures
- `AUTHENTICATION_MODE=full bundle exec rspec apps/web/auth/spec/integration/full/reset_password_request_rate_limit_spec.rb` — 4 examples, 0 failures
- `bundle exec try try/unit/security/reset_request_rate_limiter_try.rb` — 29 testcases, 0 failed