### PR TITLE
feat(branding): extract BrandMark and resolve install logo on disabled homepage

### DIFF
--- a/src/apps/secret/views/disabled/useDisabledConfig.ts
+++ b/src/apps/secret/views/disabled/useDisabledConfig.ts
@@ -82,8 +82,29 @@ export interface DisabledHomepageProps {
    * radii instead of identityStore's DEFAULT_CORNER_CLASS fallback.
    */
   cornerClass: string | null;
-  /** Tenant-uploaded logo URL; falls back to monogram when null. */
+  /**
+   * Logo URL: the tenant-uploaded logo, falling back to the operator's
+   * install-wide logo (brand.logo_url) on the canonical site. Deliberately
+   * NOT identityStore's logoSource — that ends in the DEFAULT_LOGO_COMPONENT
+   * sentinel, while variants want URL-or-null so their own monogram/keyhole
+   * fallbacks still apply. Null when neither is configured.
+   */
   logoUri: string | null;
+  /**
+   * Dark-theme variant of the install logo (brand.logo_dark_url). Non-null
+   * only while the install logo is the asset being rendered (the store nulls
+   * it when a tenant logo outranks it or no light install logo exists).
+   * Variants swap it in via class-based `dark:` utilities, mirroring
+   * MastHead.
+   */
+  logoDarkUri: string | null;
+  /**
+   * Operator alt text for the install logo (BRAND_LOGO_ALT). Non-null only
+   * while the install logo is the asset being rendered — labeling a tenant
+   * logo with the operator's alt text would leak the wrong accessible name.
+   * Variants fall back to their i18n workspace-derived alt when null.
+   */
+  logoAlt: string | null;
   /** Domain the visitor sees in the URL bar. */
   displayDomain: string;
   /** Whether to render the "Sign in" CTA (auth.signin must be enabled). */
@@ -208,8 +229,18 @@ function coerceDisabledVariant(candidate: unknown): DisabledHomepageVariant {
 // eslint-disable-next-line max-lines-per-function
 export function useDisabledConfig(): DisabledHomepageBindings {
   const identityStore = useProductIdentity();
-  const { isCustom, primaryColor, logoUri, displayName, displayDomain, brand, siteHost } =
-    storeToRefs(identityStore);
+  const {
+    isCustom,
+    primaryColor,
+    logoUri,
+    installLogoUri,
+    installLogoDarkUri,
+    installLogoAlt,
+    displayName,
+    displayDomain,
+    brand,
+    siteHost,
+  } = storeToRefs(identityStore);
 
   const bootstrapStore = useBootstrapStore();
   const {
@@ -229,9 +260,7 @@ export function useDisabledConfig(): DisabledHomepageBindings {
   // branding is set (free tier with a custom domain).
   const isBranded = computed(() => isCustom.value && !!brand.value?.description);
 
-  const workspaceName = computed(
-    () => brand.value?.description?.trim() || displayName.value
-  );
+  const workspaceName = computed(() => brand.value?.description?.trim() || displayName.value);
 
   const monogramInitial = computed(() =>
     (workspaceName.value || displayDomain.value || 'A').trim().charAt(0).toUpperCase()
@@ -275,8 +304,7 @@ export function useDisabledConfig(): DisabledHomepageBindings {
   );
   const showPromo = computed(
     () =>
-      hasSiteHost.value &&
-      applyOverride(disabled_homepage.value?.show_promo, showPromoAuto.value)
+      hasSiteHost.value && applyOverride(disabled_homepage.value?.show_promo, showPromoAuto.value)
   );
 
   const showSignin = computed(() => !!authentication.value?.signin);
@@ -328,22 +356,63 @@ export function useDisabledConfig(): DisabledHomepageBindings {
   // so each getter re-reads its source computed and reactivity is preserved
   // through the spread. Plain destructuring would freeze values at call time.
   const props = {
-    get isBranded() { return isBranded.value; },
-    get workspaceName() { return workspaceName.value; },
-    get monogramInitial() { return monogramInitial.value; },
-    get primaryColor() { return primaryColor.value; },
-    get fontFamilyClass() { return fontFamilyClass.value; },
-    get headingFontClass() { return headingFontClass.value; },
-    get cornerClass() { return cornerClass.value; },
-    get logoUri() { return logoUri.value; },
-    get displayDomain() { return displayDomain.value; },
-    get showSignin() { return showSignin.value; },
-    get showWhatIsThis() { return showWhatIsThis.value; },
-    get whatIsThisHref() { return whatIsThisHref.value; },
-    get showPromo() { return showPromo.value; },
-    get promoHref() { return promoHref.value; },
-    get ssoOneClick() { return ssoOneClick.value; },
-    get ssoProviderName() { return ssoProvider.value?.display_name ?? null; },
+    get isBranded() {
+      return isBranded.value;
+    },
+    get workspaceName() {
+      return workspaceName.value;
+    },
+    get monogramInitial() {
+      return monogramInitial.value;
+    },
+    get primaryColor() {
+      return primaryColor.value;
+    },
+    get fontFamilyClass() {
+      return fontFamilyClass.value;
+    },
+    get headingFontClass() {
+      return headingFontClass.value;
+    },
+    get cornerClass() {
+      return cornerClass.value;
+    },
+    // Tenant logo first, install-wide logo second (installLogoUri is already
+    // null on custom domains, so no operator-identity leak). See the
+    // DisabledHomepageProps docs for why this isn't logoSource.
+    get logoUri() {
+      return logoUri.value || installLogoUri.value;
+    },
+    get logoDarkUri() {
+      return installLogoDarkUri.value;
+    },
+    get logoAlt() {
+      return installLogoAlt.value;
+    },
+    get displayDomain() {
+      return displayDomain.value;
+    },
+    get showSignin() {
+      return showSignin.value;
+    },
+    get showWhatIsThis() {
+      return showWhatIsThis.value;
+    },
+    get whatIsThisHref() {
+      return whatIsThisHref.value;
+    },
+    get showPromo() {
+      return showPromo.value;
+    },
+    get promoHref() {
+      return promoHref.value;
+    },
+    get ssoOneClick() {
+      return ssoOneClick.value;
+    },
+    get ssoProviderName() {
+      return ssoProvider.value?.display_name ?? null;
+    },
     onSsoLogin,
   } satisfies DisabledHomepageProps;
 

--- a/src/apps/secret/views/disabled/variants/DisabledMinimal.vue
+++ b/src/apps/secret/views/disabled/variants/DisabledMinimal.vue
@@ -3,8 +3,9 @@
 <script setup lang="ts">
   import KeyholeIcon from '@/shared/components/icons/KeyholeIcon.vue';
   import OIcon from '@/shared/components/icons/OIcon.vue';
+  import BrandMark from '@/shared/components/logos/BrandMark.vue';
   import type { DisabledHomepageProps } from '../useDisabledConfig';
-  import { computed, ref, watch } from 'vue';
+  import { computed } from 'vue';
 
   /*
     Minimal — a quiet refresh of the closed two-tagline view.
@@ -18,18 +19,6 @@
 
   const props = defineProps<DisabledHomepageProps>();
 
-  const logoError = ref(false);
-  watch(
-    () => props.logoUri,
-    () => {
-      logoError.value = false;
-    }
-  );
-  const onLogoError = () => {
-    logoError.value = true;
-  };
-  const hasUsableLogo = computed(() => !!props.logoUri && !logoError.value);
-
   const monogramStyle = computed(() => ({ backgroundColor: props.primaryColor }));
 </script>
 
@@ -37,28 +26,30 @@
   <div class="mx-auto flex w-full max-w-xl flex-col items-center px-4 pb-12 pt-20 text-center sm:pt-28">
     <!-- Small mark — priority: configured custom-domain logo → branded monogram → neutral keyhole mark -->
     <div class="mb-6 flex items-center justify-center">
-      <img
-        v-if="hasUsableLogo"
-        :src="logoUri ?? ''"
-        :alt="$t('homepage_secrets.disabled.logo_alt', { name: workspaceName })"
-        class="h-12 w-auto max-w-[120px] object-contain"
-        @error="onLogoError" />
-      <div
-        v-else-if="isBranded"
-        :style="monogramStyle"
-        :class="[cornerClass ?? 'rounded-2xl', fontFamilyClass ?? 'font-brand']"
-        class="flex size-14 items-center justify-center text-2xl font-extrabold tracking-tight text-white"
-        aria-hidden="true">
-        {{ monogramInitial }}
-      </div>
-      <div
-        v-else
-        class="flex size-14 items-center justify-center rounded-2xl bg-brand-500 text-white dark:bg-brand-600"
-        aria-hidden="true">
-        <KeyholeIcon
-          :size="36"
-          class="text-white" />
-      </div>
+      <BrandMark
+        :logo-uri="logoUri"
+        :logo-dark-uri="logoDarkUri"
+        :alt="logoAlt ?? $t('homepage_secrets.disabled.logo_alt', { name: workspaceName })"
+        img-class="h-12 w-auto max-w-[120px] object-contain">
+        <template #fallback>
+          <div
+            v-if="isBranded"
+            :style="monogramStyle"
+            :class="[cornerClass ?? 'rounded-2xl', fontFamilyClass ?? 'font-brand']"
+            class="flex size-14 items-center justify-center text-2xl font-extrabold tracking-tight text-white"
+            aria-hidden="true">
+            {{ monogramInitial }}
+          </div>
+          <div
+            v-else
+            class="flex size-14 items-center justify-center rounded-2xl bg-brand-500 text-white dark:bg-brand-600"
+            aria-hidden="true">
+            <KeyholeIcon
+              :size="36"
+              class="text-white" />
+          </div>
+        </template>
+      </BrandMark>
     </div>
 
     <!-- Headline (smaller than V1, larger than closed) -->

--- a/src/apps/secret/views/disabled/variants/DisabledV1.vue
+++ b/src/apps/secret/views/disabled/variants/DisabledV1.vue
@@ -3,8 +3,9 @@
 <script setup lang="ts">
   import KeyholeIcon from '@/shared/components/icons/KeyholeIcon.vue';
   import OIcon from '@/shared/components/icons/OIcon.vue';
+  import BrandMark from '@/shared/components/logos/BrandMark.vue';
   import type { DisabledHomepageProps } from '../useDisabledConfig';
-  import { computed, ref, watch } from 'vue';
+  import { computed } from 'vue';
 
   /*
     V1 — "Composed refresh" of the disabled-homepage view.
@@ -18,20 +19,6 @@
   */
 
   const props = defineProps<DisabledHomepageProps>();
-
-  // Image error handling for branded logos that may 404. Reset whenever the
-  // logo URL changes so a subsequent valid URL gets a chance to load.
-  const logoError = ref(false);
-  watch(
-    () => props.logoUri,
-    () => {
-      logoError.value = false;
-    }
-  );
-  const onLogoError = () => {
-    logoError.value = true;
-  };
-  const hasUsableLogo = computed(() => !!props.logoUri && !logoError.value);
 
   const monogramStyle = computed(() => ({ backgroundColor: props.primaryColor }));
   // The dot's accent color always comes from primaryColor. In branded mode that
@@ -48,28 +35,30 @@
   <div class="relative mx-auto flex w-full max-w-2xl flex-col items-center px-4 pb-12 pt-16 text-center sm:pt-24">
     <!-- Mark — priority: configured custom-domain logo → branded monogram → neutral keyhole mark -->
     <div class="mb-8 flex items-center justify-center">
-      <img
-        v-if="hasUsableLogo"
-        :src="logoUri ?? ''"
-        :alt="$t('homepage_secrets.disabled.logo_alt', { name: workspaceName })"
-        class="h-24 w-auto max-w-[180px] object-contain"
-        @error="onLogoError" />
-      <div
-        v-else-if="isBranded"
-        :style="monogramStyle"
-        :class="[cornerClass ?? 'rounded-3xl', fontFamilyClass ?? 'font-brand']"
-        class="flex size-28 items-center justify-center text-6xl font-extrabold tracking-tight text-white shadow-sm"
-        aria-hidden="true">
-        {{ monogramInitial }}
-      </div>
-      <div
-        v-else
-        class="flex size-28 items-center justify-center rounded-3xl bg-brand-500 text-white shadow-sm dark:bg-brand-600"
-        aria-hidden="true">
-        <KeyholeIcon
-          :size="76"
-          class="text-white" />
-      </div>
+      <BrandMark
+        :logo-uri="logoUri"
+        :logo-dark-uri="logoDarkUri"
+        :alt="logoAlt ?? $t('homepage_secrets.disabled.logo_alt', { name: workspaceName })"
+        img-class="h-24 w-auto max-w-[180px] object-contain">
+        <template #fallback>
+          <div
+            v-if="isBranded"
+            :style="monogramStyle"
+            :class="[cornerClass ?? 'rounded-3xl', fontFamilyClass ?? 'font-brand']"
+            class="flex size-28 items-center justify-center text-6xl font-extrabold tracking-tight text-white shadow-sm"
+            aria-hidden="true">
+            {{ monogramInitial }}
+          </div>
+          <div
+            v-else
+            class="flex size-28 items-center justify-center rounded-3xl bg-brand-500 text-white shadow-sm dark:bg-brand-600"
+            aria-hidden="true">
+            <KeyholeIcon
+              :size="76"
+              class="text-white" />
+          </div>
+        </template>
+      </BrandMark>
     </div>
 
     <!-- Eyebrow badge -->

--- a/src/router/public.routes.ts
+++ b/src/router/public.routes.ts
@@ -85,9 +85,10 @@ function getLayoutPropsForMode(componentMode: string, domainStrategy: string): L
       // dispatcher in apps/secret/views/DisabledHomepage.vue). The
       // top-left masthead is suppressed for canonical and custom domain
       // alike, and we drop the entire header chrome (the padded band)
-      // so nothing else competes with the centred mark. The header slot
-      // is reserved for a future canonical brand logo configured at the
-      // deployment level.
+      // so nothing else competes with the centred mark. On the canonical
+      // site that centred mark now honours the deployment-level install
+      // logo (brand.logo_url) via useDisabledConfig, so no header slot is
+      // needed for it.
       layoutProps = {
         ...layoutProps,
         displayHeader: false,

--- a/src/shared/components/layout/MastHead.vue
+++ b/src/shared/components/layout/MastHead.vue
@@ -2,6 +2,7 @@
 
 <script setup lang="ts">
   import { useI18n } from 'vue-i18n';
+  import BrandMark from '@/shared/components/logos/BrandMark.vue';
   import DefaultLogo from '@/shared/components/logos/DefaultLogo.vue';
   import UserMenu from '@/shared/components/navigation/UserMenu.vue';
   import { useHeaderEnabled } from '@/shared/composables/useHeaderEnabled';
@@ -267,25 +268,18 @@
             data-testid="header-logo-link"
             class="flex items-center gap-3"
             :aria-label="logoConfig.alt">
-            <img
+            <!-- Light/dark img pair + dark-mode swap live in BrandMark; the
+                 fallback slot stays empty because logoConfig.url is always a
+                 real asset URL here (the sentinel takes the component branch
+                 above). A 404'd logo simply renders nothing. -->
+            <BrandMark
               id="logo"
-              :src="logoConfig.url"
-              class="w-auto object-contain transition-transform"
-              :class="[imgHeightClass, logoConfig.darkUrl ? 'dark:hidden' : null]"
-              :style="imgInlineStyle"
-              :height="logoConfig.size"
-              :alt="logoConfig.alt" />
-            <!-- Dark-theme logo variant (brand.logo_dark_url): swapped by the
-                 app's class-based dark mode so it tracks the theme toggle. -->
-            <img
-              v-if="logoConfig.darkUrl"
-              data-testid="logo-dark"
-              :src="logoConfig.darkUrl"
-              class="hidden w-auto object-contain transition-transform dark:block"
-              :class="imgHeightClass"
-              :style="imgInlineStyle"
-              :height="logoConfig.size"
-              :alt="logoConfig.alt" />
+              :logo-uri="logoConfig.url"
+              :logo-dark-uri="logoConfig.darkUrl"
+              :alt="logoConfig.alt"
+              :img-class="['w-auto object-contain transition-transform', imgHeightClass]"
+              :img-style="imgInlineStyle"
+              :height="logoConfig.size" />
             <span
               v-if="logoConfig.showSiteName"
               class="font-brand text-lg font-bold leading-tight">

--- a/src/shared/components/logos/BrandMark.vue
+++ b/src/shared/components/logos/BrandMark.vue
@@ -1,0 +1,89 @@
+<!-- src/shared/components/logos/BrandMark.vue -->
+
+<script setup lang="ts">
+  import { computed, ref, watch, type StyleValue } from 'vue';
+
+  /*
+    BrandMark — the shared light/dark logo pair with a graceful fallback.
+
+    Renders the light logo (hidden in dark mode when a dark variant exists)
+    plus the optional dark-theme variant, swapped via the app's class-based
+    `dark:` utilities so it tracks the theme toggle, not the OS scheme.
+
+    A logo that 404s is treated as absent: an internal @error flag (reset
+    whenever the URL changes so a subsequent valid URL gets a chance to
+    load) flips rendering to the `fallback` slot. Consumers put their own
+    monogram/keyhole/placeholder markup there — the slot boundary guarantees
+    the fallback only appears when no usable logo exists.
+
+    Sizing/styling is the consumer's job via `imgClass` (applied to both
+    imgs so the light/dark pair always match) and optional `imgStyle` /
+    `height` for pixel-accurate callers (MastHead). Extra attrs (e.g. `id`)
+    land on the light img only.
+  */
+
+  defineOptions({ inheritAttrs: false });
+
+  const props = withDefaults(
+    defineProps<{
+      /** Light-theme logo URL. Null/empty renders the fallback slot. */
+      logoUri: string | null;
+      /** Dark-theme logo URL; when set, the light img gets `dark:hidden`. */
+      logoDarkUri?: string | null;
+      /** Accessible name, shared by both imgs. */
+      alt: string;
+      /** Sizing/layout classes applied to both light and dark imgs. */
+      imgClass?: string | (string | null)[] | null;
+      /** Inline style for both imgs (explicit pixel sizing callers). */
+      imgStyle?: StyleValue;
+      /** `height` attribute for both imgs. */
+      height?: number;
+    }>(),
+    {
+      logoDarkUri: null,
+      imgClass: null,
+      imgStyle: undefined,
+      height: undefined,
+    }
+  );
+
+  // Image error handling for logos that may 404. Reset whenever the logo URL
+  // changes so a subsequent valid URL gets a chance to load.
+  const logoError = ref(false);
+  watch(
+    () => props.logoUri,
+    () => {
+      logoError.value = false;
+    }
+  );
+  const onLogoError = () => {
+    logoError.value = true;
+  };
+  const hasUsableLogo = computed(() => !!props.logoUri && !logoError.value);
+</script>
+
+<template>
+  <template v-if="hasUsableLogo">
+    <img
+      v-bind="$attrs"
+      :src="logoUri ?? ''"
+      :alt="alt"
+      :class="[imgClass, logoDarkUri ? 'dark:hidden' : null]"
+      :style="imgStyle"
+      :height="height"
+      @error="onLogoError" />
+    <!-- Dark-theme logo variant (brand.logo_dark_url): swapped by the
+         app's class-based dark mode so it tracks the theme toggle. -->
+    <img
+      v-if="logoDarkUri"
+      data-testid="logo-dark"
+      :src="logoDarkUri"
+      :alt="alt"
+      :class="['hidden dark:block', imgClass]"
+      :style="imgStyle"
+      :height="height" />
+  </template>
+  <slot
+    v-else
+    name="fallback"></slot>
+</template>

--- a/src/shared/components/logos/BrandMark.vue
+++ b/src/shared/components/logos/BrandMark.vue
@@ -16,6 +16,12 @@
     monogram/keyhole/placeholder markup there — the slot boundary guarantees
     the fallback only appears when no usable logo exists.
 
+    Light and dark each get their own error flag. A broken dark variant must
+    not blank the header in dark mode: when the dark asset errors we drop the
+    dark img AND drop `dark:hidden` from the light img, so the working light
+    logo degrades gracefully into dark mode. Only when the light asset is
+    also unusable do we fall through to the `fallback` slot.
+
     Sizing/styling is the consumer's job via `imgClass` (applied to both
     imgs so the light/dark pair always match) and optional `imgStyle` /
     `height` for pixel-accurate callers (MastHead). Extra attrs (e.g. `id`)
@@ -60,6 +66,20 @@
     logoError.value = true;
   };
   const hasUsableLogo = computed(() => !!props.logoUri && !logoError.value);
+
+  // Same treatment for the dark variant, tracked separately: a dark asset that
+  // 404s must not take the (working) light asset down with it.
+  const logoDarkError = ref(false);
+  watch(
+    () => props.logoDarkUri,
+    () => {
+      logoDarkError.value = false;
+    }
+  );
+  const onLogoDarkError = () => {
+    logoDarkError.value = true;
+  };
+  const hasUsableDarkLogo = computed(() => !!props.logoDarkUri && !logoDarkError.value);
 </script>
 
 <template>
@@ -68,20 +88,22 @@
       v-bind="$attrs"
       :src="logoUri ?? ''"
       :alt="alt"
-      :class="[imgClass, logoDarkUri ? 'dark:hidden' : null]"
+      :class="[imgClass, hasUsableDarkLogo ? 'dark:hidden' : null]"
       :style="imgStyle"
       :height="height"
       @error="onLogoError" />
     <!-- Dark-theme logo variant (brand.logo_dark_url): swapped by the
-         app's class-based dark mode so it tracks the theme toggle. -->
+         app's class-based dark mode so it tracks the theme toggle. Dropped
+         entirely if it errors, which also un-hides the light img above. -->
     <img
-      v-if="logoDarkUri"
+      v-if="hasUsableDarkLogo"
       data-testid="logo-dark"
-      :src="logoDarkUri"
+      :src="logoDarkUri ?? ''"
       :alt="alt"
       :class="['hidden dark:block', imgClass]"
       :style="imgStyle"
-      :height="height" />
+      :height="height"
+      @error="onLogoDarkError" />
   </template>
   <slot
     v-else

--- a/src/tests/apps/secret/views/disabled/DisabledVariantsLogo.spec.ts
+++ b/src/tests/apps/secret/views/disabled/DisabledVariantsLogo.spec.ts
@@ -26,6 +26,8 @@ const baseProps = {
   monogramInitial: 'A',
   primaryColor: '#3B82F6',
   logoUri: null as string | null,
+  logoDarkUri: null as string | null,
+  logoAlt: null as string | null,
   displayDomain: 'acme.example',
   showSignin: true,
   showWhatIsThis: false,
@@ -80,6 +82,83 @@ describe.each([
 
     expect(wrapper.text()).toContain('A');
     expect(wrapper.find('[data-testid="keyhole-mark"]').exists()).toBe(false);
+  });
+});
+
+describe.each([
+  ['DisabledMinimal', DisabledMinimal],
+  ['DisabledV1', DisabledV1],
+])('%s dark-logo variant + alt text (BrandMark)', (_name, Component) => {
+  it('renders the dark img (hidden dark:block) when logoDarkUri is set', () => {
+    const wrapper = mountVariant(Component, {
+      logoUri: '/imagine/cd123/logo.png',
+      logoDarkUri: '/imagine/cd123/logo-dark.png',
+    });
+
+    const dark = wrapper.find('[data-testid="logo-dark"]');
+    expect(dark.exists()).toBe(true);
+    expect(dark.attributes('src')).toBe('/imagine/cd123/logo-dark.png');
+    expect(dark.classes()).toContain('hidden');
+    expect(dark.classes()).toContain('dark:block');
+    // Light img is swapped out in dark mode.
+    expect(wrapper.findAll('img')[0].classes()).toContain('dark:hidden');
+  });
+
+  it('renders no dark img when logoDarkUri is null', () => {
+    const wrapper = mountVariant(Component, {
+      logoUri: '/imagine/cd123/logo.png',
+      logoDarkUri: null,
+    });
+
+    expect(wrapper.find('[data-testid="logo-dark"]').exists()).toBe(false);
+    expect(wrapper.findAll('img')).toHaveLength(1);
+  });
+
+  // Regression guard: an earlier v-if chain let the monogram/keyhole
+  // co-render with a configured logo. The BrandMark fallback-slot boundary
+  // must make that impossible.
+  it('never co-renders the keyhole with a logo', () => {
+    const wrapper = mountVariant(Component, {
+      isBranded: false,
+      logoUri: '/imagine/cd123/logo.png',
+      logoDarkUri: '/imagine/cd123/logo-dark.png',
+    });
+
+    expect(wrapper.find('img').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="keyhole-mark"]').exists()).toBe(false);
+  });
+
+  it('never co-renders the monogram with a logo', () => {
+    const wrapper = mountVariant(Component, {
+      isBranded: true,
+      monogramInitial: 'Z',
+      logoUri: '/imagine/cd123/logo.png',
+    });
+
+    expect(wrapper.find('img').exists()).toBe(true);
+    expect(wrapper.text()).not.toContain('Z');
+  });
+
+  it('uses logoAlt for both imgs when provided', () => {
+    const wrapper = mountVariant(Component, {
+      logoUri: '/imagine/cd123/logo.png',
+      logoDarkUri: '/imagine/cd123/logo-dark.png',
+      logoAlt: 'Acme Corp wordmark',
+    });
+
+    for (const img of wrapper.findAll('img')) {
+      expect(img.attributes('alt')).toBe('Acme Corp wordmark');
+    }
+  });
+
+  it('falls back to the i18n logo_alt key when logoAlt is null', () => {
+    const wrapper = mountVariant(Component, {
+      logoUri: '/imagine/cd123/logo.png',
+      logoAlt: null,
+    });
+
+    // Pass-through test i18n renders the key itself (ADR-014).
+    expect(wrapper.find('img').attributes('alt')).toBe('homepage_secrets.disabled.logo_alt');
   });
 });
 

--- a/src/tests/apps/secret/views/useDisabledConfig.spec.ts
+++ b/src/tests/apps/secret/views/useDisabledConfig.spec.ts
@@ -72,6 +72,16 @@ interface SetupOptions {
   ssoOnly?: boolean;
   /** Per-domain SSO enforcement (features.sso.enforce_sso_only). */
   enforceSsoOnly?: boolean;
+  // Logo sources
+  /** Tenant-uploaded logo URL (bootstrap.domain_logo — the backend-computed
+   *  /imagine URL identityStore surfaces as logoUri). */
+  tenantLogo?: string | null;
+  /** Install-wide light logo (brand.logo_url → bootstrap.brand_logo_url). */
+  installLogoUrl?: string | null;
+  /** Install-wide dark-theme logo (brand.logo_dark_url). */
+  installLogoDarkUrl?: string | null;
+  /** Operator alt text for the install logo (brand.logo_alt). */
+  installLogoAlt?: string | null;
 }
 
 /**
@@ -101,6 +111,10 @@ function setup(opts: SetupOptions = {}) {
   const bootstrap = useBootstrapStore();
   bootstrap.$patch({
     domain_branding: rawBranding,
+    domain_logo: opts.tenantLogo ?? null,
+    brand_logo_url: opts.installLogoUrl ?? undefined,
+    brand_logo_dark_url: opts.installLogoDarkUrl ?? undefined,
+    brand_logo_alt: opts.installLogoAlt ?? undefined,
     site_host: opts.siteHost ?? 'onetimesecret.com',
     billing_enabled: opts.billingEnabled ?? false,
     authentication: {
@@ -672,6 +686,82 @@ describe('useDisabledConfig', () => {
         displayDomain: 'zebra.example.com',
       });
       expect(config.props.monogramInitial).toBe('Z');
+    });
+  });
+
+  describe('logo resolution', () => {
+    const tenant = 'https://cdn.example.com/imagine/tenant.png';
+    const install = 'https://cdn.example.com/install-light.svg';
+    const installDark = 'https://cdn.example.com/install-dark.svg';
+
+    it('tenant logo wins over the install logo', () => {
+      const { config } = setup({
+        domainStrategy: 'custom',
+        tenantLogo: tenant,
+        installLogoUrl: install,
+        installLogoDarkUrl: installDark,
+        installLogoAlt: 'Acme Corp',
+      });
+      expect(config.props.logoUri).toBe(tenant);
+      // Install-only companions must not leak onto a tenant logo.
+      expect(config.props.logoDarkUri).toBeNull();
+      expect(config.props.logoAlt).toBeNull();
+    });
+
+    it('falls back to the install logo on canonical when no tenant logo', () => {
+      const { config } = setup({
+        domainStrategy: 'canonical',
+        tenantLogo: null,
+        installLogoUrl: install,
+      });
+      expect(config.props.logoUri).toBe(install);
+    });
+
+    it('is null when neither logo is configured (monogram/keyhole path)', () => {
+      const { config } = setup({ tenantLogo: null });
+      expect(config.props.logoUri).toBeNull();
+      expect(config.props.logoDarkUri).toBeNull();
+      expect(config.props.logoAlt).toBeNull();
+    });
+
+    it('does not surface the install logo on a custom domain (identity-leak guard)', () => {
+      const { config } = setup({
+        domainStrategy: 'custom',
+        tenantLogo: null,
+        installLogoUrl: install,
+        installLogoDarkUrl: installDark,
+        installLogoAlt: 'Acme Corp',
+      });
+      expect(config.props.logoUri).toBeNull();
+      expect(config.props.logoDarkUri).toBeNull();
+      expect(config.props.logoAlt).toBeNull();
+    });
+
+    it('exposes operator alt text while the install logo is active', () => {
+      const { config } = setup({
+        installLogoUrl: install,
+        installLogoAlt: 'Acme Corp',
+      });
+      expect(config.props.logoAlt).toBe('Acme Corp');
+    });
+
+    it('alt is null when the install logo has no configured alt text', () => {
+      const { config } = setup({ installLogoUrl: install });
+      expect(config.props.logoAlt).toBeNull();
+    });
+
+    it('exposes the dark install logo alongside the light one', () => {
+      const { config } = setup({
+        installLogoUrl: install,
+        installLogoDarkUrl: installDark,
+      });
+      expect(config.props.logoDarkUri).toBe(installDark);
+    });
+
+    it('dark logo is null without a light install logo to pair with', () => {
+      const { config } = setup({ installLogoDarkUrl: installDark });
+      expect(config.props.logoUri).toBeNull();
+      expect(config.props.logoDarkUri).toBeNull();
     });
   });
 

--- a/src/tests/shared/components/layout/MastHead.spec.ts
+++ b/src/tests/shared/components/layout/MastHead.spec.ts
@@ -1068,6 +1068,30 @@ describe('MastHead', () => {
       expect(light.classes()).not.toContain('dark:hidden');
       expect(wrapper.find('[data-testid="logo-dark"]').exists()).toBe(false);
     });
+
+    it('falls back to the light logo in dark mode when the dark asset 404s', async () => {
+      // Operator sets both URLs but the dark one is a bad path. The masthead
+      // must keep showing the working light logo instead of going blank under
+      // the dark theme.
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          brand_logo_url: '/img/brand.svg',
+          brand_logo_dark_url: '/img/missing-dark.svg',
+        }
+      );
+
+      await nextTick();
+      await wrapper.find('[data-testid="logo-dark"]').trigger('error');
+      await nextTick();
+
+      expect(wrapper.find('[data-testid="logo-dark"]').exists()).toBe(false);
+      const light = wrapper.find('img#logo');
+      expect(light.exists()).toBe(true);
+      expect(light.attributes('src')).toBe('/img/brand.svg');
+      expect(light.classes()).not.toContain('dark:hidden');
+    });
   });
 
   describe('Accessibility', () => {

--- a/src/tests/shared/components/logos/BrandMark.spec.ts
+++ b/src/tests/shared/components/logos/BrandMark.spec.ts
@@ -7,7 +7,9 @@
 //     `hidden dark:block`), with the light img gaining `dark:hidden`
 //   - the fallback slot renders when logoUri is null/empty AND after @error,
 //     and NEVER co-renders with a logo
-//   - the internal error flag resets when logoUri changes
+//   - the internal error flags reset when logoUri / logoDarkUri change
+//   - a broken dark logo degrades to the light logo (drops `dark:hidden`)
+//     instead of blanking the mark in dark mode
 
 import { mount } from '@vue/test-utils';
 import { describe, it, expect } from 'vitest';
@@ -86,6 +88,85 @@ describe('BrandMark', () => {
         expect(img.classes()).toContain('h-12');
         expect(img.classes()).toContain('w-auto');
       }
+    });
+  });
+
+  // Operator sets BRAND_LOGO_URL + BRAND_LOGO_DARK_URL and the dark asset 404s
+  // (wrong path, CDN misconfiguration). The mark must not go blank in dark
+  // mode: drop the dark img and un-hide the working light one.
+  describe('broken dark img', () => {
+    const darkPair = { logoDarkUri: '/imagine/cd123/logo-dark.png' };
+
+    it('removes the dark img after it fires @error', async () => {
+      const wrapper = mountMark(darkPair, fallbackSlot);
+
+      await wrapper.find('[data-testid="logo-dark"]').trigger('error');
+
+      expect(wrapper.find('[data-testid="logo-dark"]').exists()).toBe(false);
+    });
+
+    it('drops dark:hidden from the light img so it shows in dark mode', async () => {
+      const wrapper = mountMark(darkPair, fallbackSlot);
+      expect(wrapper.findAll('img')[0].classes()).toContain('dark:hidden');
+
+      await wrapper.find('[data-testid="logo-dark"]').trigger('error');
+
+      const imgs = wrapper.findAll('img');
+      expect(imgs).toHaveLength(1);
+      expect(imgs[0].attributes('src')).toBe('/imagine/cd123/logo.png');
+      expect(imgs[0].classes()).not.toContain('dark:hidden');
+    });
+
+    it('does not render the fallback slot while the light img still works', async () => {
+      const wrapper = mountMark(darkPair, fallbackSlot);
+
+      await wrapper.find('[data-testid="logo-dark"]').trigger('error');
+
+      expect(wrapper.find('[data-testid="fallback-mark"]').exists()).toBe(false);
+    });
+
+    it('renders the fallback slot only when BOTH imgs error', async () => {
+      const wrapper = mountMark(darkPair, fallbackSlot);
+
+      await wrapper.find('[data-testid="logo-dark"]').trigger('error');
+      await wrapper.find('img').trigger('error');
+
+      expect(wrapper.find('img').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="fallback-mark"]').exists()).toBe(true);
+    });
+
+    it('resets the dark error state when logoDarkUri changes', async () => {
+      const wrapper = mountMark(darkPair, fallbackSlot);
+
+      await wrapper.find('[data-testid="logo-dark"]').trigger('error');
+      expect(wrapper.find('[data-testid="logo-dark"]').exists()).toBe(false);
+
+      await wrapper.setProps({ logoDarkUri: '/imagine/cd123/logo-dark-v2.png' });
+
+      const dark = wrapper.find('[data-testid="logo-dark"]');
+      expect(dark.exists()).toBe(true);
+      expect(dark.attributes('src')).toBe('/imagine/cd123/logo-dark-v2.png');
+      expect(wrapper.findAll('img')[0].classes()).toContain('dark:hidden');
+    });
+
+    it('keeps the dark swap intact when neither img errors', () => {
+      const wrapper = mountMark(darkPair, fallbackSlot);
+
+      const imgs = wrapper.findAll('img');
+      expect(imgs).toHaveLength(2);
+      expect(imgs[0].classes()).toContain('dark:hidden');
+      expect(imgs[1].classes()).toContain('hidden');
+      expect(imgs[1].classes()).toContain('dark:block');
+      expect(wrapper.find('[data-testid="fallback-mark"]').exists()).toBe(false);
+    });
+
+    it('a light-img error still falls through to the fallback when the dark img is fine', async () => {
+      const wrapper = mountMark(darkPair, fallbackSlot);
+
+      await wrapper.find('img').trigger('error');
+
+      expect(wrapper.find('img').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="fallback-mark"]').exists()).toBe(true);
     });
   });
 

--- a/src/tests/shared/components/logos/BrandMark.spec.ts
+++ b/src/tests/shared/components/logos/BrandMark.spec.ts
@@ -1,0 +1,137 @@
+// src/tests/shared/components/logos/BrandMark.spec.ts
+//
+// BrandMark — the shared light/dark logo pair with fallback-slot behavior.
+// Guards the contract consumed by MastHead and the disabled-homepage variants:
+//   - light img always renders when logoUri is usable
+//   - dark img renders ONLY when logoDarkUri is set (data-testid="logo-dark",
+//     `hidden dark:block`), with the light img gaining `dark:hidden`
+//   - the fallback slot renders when logoUri is null/empty AND after @error,
+//     and NEVER co-renders with a logo
+//   - the internal error flag resets when logoUri changes
+
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import BrandMark from '@/shared/components/logos/BrandMark.vue';
+
+const mountMark = (props: Record<string, unknown> = {}, slots: Record<string, string> = {}) =>
+  mount(BrandMark, {
+    props: {
+      logoUri: '/imagine/cd123/logo.png',
+      alt: 'Acme logo',
+      ...props,
+    },
+    slots,
+  });
+
+const fallbackSlot = { fallback: '<div data-testid="fallback-mark" />' };
+
+describe('BrandMark', () => {
+  describe('light img', () => {
+    it('renders the light img with src and alt', () => {
+      const wrapper = mountMark();
+
+      const imgs = wrapper.findAll('img');
+      expect(imgs).toHaveLength(1);
+      expect(imgs[0].attributes('src')).toBe('/imagine/cd123/logo.png');
+      expect(imgs[0].attributes('alt')).toBe('Acme logo');
+    });
+
+    it('does not apply dark:hidden to the light img when no dark variant is set', () => {
+      const wrapper = mountMark();
+
+      expect(wrapper.find('img').classes()).not.toContain('dark:hidden');
+    });
+  });
+
+  describe('dark img', () => {
+    it('does not render the dark img when logoDarkUri is null', () => {
+      const wrapper = mountMark({ logoDarkUri: null });
+
+      expect(wrapper.find('[data-testid="logo-dark"]').exists()).toBe(false);
+    });
+
+    it('renders the dark img with hidden dark:block classes when logoDarkUri is set', () => {
+      const wrapper = mountMark({ logoDarkUri: '/imagine/cd123/logo-dark.png' });
+
+      const dark = wrapper.find('[data-testid="logo-dark"]');
+      expect(dark.exists()).toBe(true);
+      expect(dark.attributes('src')).toBe('/imagine/cd123/logo-dark.png');
+      expect(dark.classes()).toContain('hidden');
+      expect(dark.classes()).toContain('dark:block');
+    });
+
+    it('hides the light img in dark mode (dark:hidden) when a dark variant exists', () => {
+      const wrapper = mountMark({ logoDarkUri: '/imagine/cd123/logo-dark.png' });
+
+      const light = wrapper.findAll('img')[0];
+      expect(light.classes()).toContain('dark:hidden');
+    });
+
+    it('applies the same alt to both imgs', () => {
+      const wrapper = mountMark({ logoDarkUri: '/imagine/cd123/logo-dark.png' });
+
+      const imgs = wrapper.findAll('img');
+      expect(imgs).toHaveLength(2);
+      expect(imgs[0].attributes('alt')).toBe('Acme logo');
+      expect(imgs[1].attributes('alt')).toBe('Acme logo');
+    });
+
+    it('applies imgClass to both imgs so the pair matches', () => {
+      const wrapper = mountMark({
+        logoDarkUri: '/imagine/cd123/logo-dark.png',
+        imgClass: 'h-12 w-auto',
+      });
+
+      for (const img of wrapper.findAll('img')) {
+        expect(img.classes()).toContain('h-12');
+        expect(img.classes()).toContain('w-auto');
+      }
+    });
+  });
+
+  describe('fallback slot', () => {
+    it('renders the fallback slot when logoUri is null', () => {
+      const wrapper = mountMark({ logoUri: null }, fallbackSlot);
+
+      expect(wrapper.find('[data-testid="fallback-mark"]').exists()).toBe(true);
+      expect(wrapper.find('img').exists()).toBe(false);
+    });
+
+    it('renders the fallback slot when logoUri is an empty string', () => {
+      const wrapper = mountMark({ logoUri: '' }, fallbackSlot);
+
+      expect(wrapper.find('[data-testid="fallback-mark"]').exists()).toBe(true);
+      expect(wrapper.find('img').exists()).toBe(false);
+    });
+
+    it('does not render the fallback slot alongside a usable logo', () => {
+      const wrapper = mountMark({}, fallbackSlot);
+
+      expect(wrapper.find('img').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="fallback-mark"]').exists()).toBe(false);
+    });
+
+    it('renders the fallback slot after the img fires @error', async () => {
+      const wrapper = mountMark({}, fallbackSlot);
+
+      await wrapper.find('img').trigger('error');
+
+      expect(wrapper.find('img').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="fallback-mark"]').exists()).toBe(true);
+    });
+
+    it('resets the error state when logoUri changes, giving the new URL a chance', async () => {
+      const wrapper = mountMark({}, fallbackSlot);
+
+      await wrapper.find('img').trigger('error');
+      expect(wrapper.find('[data-testid="fallback-mark"]').exists()).toBe(true);
+
+      await wrapper.setProps({ logoUri: '/imagine/cd123/logo-v2.png' });
+
+      const img = wrapper.find('img');
+      expect(img.exists()).toBe(true);
+      expect(img.attributes('src')).toBe('/imagine/cd123/logo-v2.png');
+      expect(wrapper.find('[data-testid="fallback-mark"]').exists()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Stacked on #3953 (`feature/brand-logo-dark-url`) — review that one first. This PR
adds only the two commits above the fork point at `f0038a892`.

## What this does

Extends the operator install logo (`BRAND_LOGO_DARK_URL`, added in #3953) to the
disabled-homepage variants, and extracts the light/dark rendering into a shared
component instead of a third copy of the same `<img>` pair.

### `BrandMark.vue` (new)

MastHead and both disabled-homepage variants each needed the same logic: render
the light logo, swap to the dark one via class-based dark mode, fall back through
alt-text sources, recover on load error. That's now one component rather than
three near-identical template blocks.

### Logo resolution in `useDisabledConfig`

Resolves through tenant logo → install logo → branded monogram → neutral keyhole
mark, with one guard worth calling out: **the install logo is never surfaced on a
custom domain.** A tenant's branded page showing the operator's mark would leak
one customer's identity onto another's page. The install-only companions
(`logoDarkUri`, `logoAlt`) are likewise suppressed when a tenant logo is active,
so they can't attach themselves to the wrong image.

## Tests

145 passing across `useDisabledConfig`, `DisabledVariantsLogo`, `BrandMark`, and
`MastHead`. The 8 new `useDisabledConfig` cases cover tenant-over-install
precedence, the custom-domain identity-leak guard, operator alt text, and
dark-logo pairing (a dark logo with no light logo to pair with resolves to null
rather than rendering alone).

## Merge order

Depends on #3953. If that merges to `main` as a squash, the shared commits leave
`main`'s history and this branch needs a rebase onto `main` rather than a base
retarget.
