### PR TITLE
fix(admin): hide customer checkout-link button when billing is disabled

### DIFF
--- a/src/apps/admin/views/AdminCustomerDetail.vue
+++ b/src/apps/admin/views/AdminCustomerDetail.vue
@@ -952,8 +952,11 @@
             data-testid="billing-disabled">
             {{ t('web.admin.customers.detail.billing.notConfigured') }}
           </p>
-          <!-- Colonel-built Stripe Checkout session for this customer. -->
+          <!-- Colonel-built Stripe Checkout session for this customer.
+               Hidden when billing is disabled: the colonel endpoint's
+               configuration_guard fails every request in that state. -->
           <button
+            v-if="billing.enabled"
             type="button"
             data-testid="checkout-link-button"
             class="inline-flex shrink-0 items-center gap-1 rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-brand-500 focus:outline-none dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
@@ -973,7 +976,9 @@
         <div class="border-b border-gray-200 px-6 py-4 dark:border-gray-800">
           <h3 class="text-lg font-medium text-gray-900 dark:text-white">
             {{ t('web.admin.customers.detail.sections.secrets') }}
-            <span class="ml-1 text-sm font-normal text-gray-500 dark:text-gray-400">({{ details.secrets.count }})</span>
+            <span class="ml-1 text-sm font-normal text-gray-500 dark:text-gray-400"
+              >({{ details.secrets.count }})</span
+            >
           </h3>
           <!-- The server told us this list is PARTIAL. Say so plainly — the
                count beside the heading is what is on screen, not the total. -->
@@ -1016,7 +1021,9 @@
         <div class="border-b border-gray-200 px-6 py-4 dark:border-gray-800">
           <h3 class="text-lg font-medium text-gray-900 dark:text-white">
             {{ t('web.admin.customers.detail.sections.receipts') }}
-            <span class="ml-1 text-sm font-normal text-gray-500 dark:text-gray-400">({{ details.receipts.count }})</span>
+            <span class="ml-1 text-sm font-normal text-gray-500 dark:text-gray-400"
+              >({{ details.receipts.count }})</span
+            >
           </h3>
           <p
             v-if="details.receipts.truncated"
@@ -1050,7 +1057,9 @@
         <div class="border-b border-gray-200 px-6 py-4 dark:border-gray-800">
           <h3 class="text-lg font-medium text-gray-900 dark:text-white">
             {{ t('web.admin.customers.detail.sections.organizations') }}
-            <span class="ml-1 text-sm font-normal text-gray-500 dark:text-gray-400">({{ details.organizations.length }})</span>
+            <span class="ml-1 text-sm font-normal text-gray-500 dark:text-gray-400"
+              >({{ details.organizations.length }})</span
+            >
           </h3>
         </div>
         <ul

--- a/src/tests/apps/admin/AdminCustomerDetail.spec.ts
+++ b/src/tests/apps/admin/AdminCustomerDetail.spec.ts
@@ -432,6 +432,30 @@ describe('AdminCustomerDetail (ticket #22)', () => {
       expect(link.attributes('href')).toBe('https://dashboard.stripe.com/customers/cus_123');
       expect(link.attributes('target')).toBe('_blank');
     });
+
+    it('hides the checkout-link button when billing is disabled (endpoint guard rejects it anyway)', async () => {
+      mockApi.get.mockResolvedValue({ data: detailPayload({ billing: { enabled: false } }) });
+      wrapper = mountView();
+      await flushPromises();
+
+      const section = wrapper.find('[data-testid="billing-section"]');
+      expect(section.exists()).toBe(true);
+      expect(section.find('[data-testid="checkout-link-button"]').exists()).toBe(false);
+    });
+
+    it('shows the checkout-link button when billing is enabled', async () => {
+      mockApi.get.mockResolvedValue({
+        data: detailPayload({ billing: { enabled: true, stripeAvailable: true } }),
+      });
+      wrapper = mountView();
+      await flushPromises();
+
+      expect(
+        wrapper
+          .find('[data-testid="billing-section"] [data-testid="checkout-link-button"]')
+          .exists()
+      ).toBe(true);
+    });
   });
 
   // ---- Suspend / unsuspend ----------------------------------------------------


### PR DESCRIPTION
Recovers a commit that missed its ride. `af3688684` was written on `feature/billing-checkout-link` at 23:41:50, three minutes *after* PR #3959 merged at 23:38:52, so it never reached `main` and the closed PR will not pick it up. Cherry-picked here onto current `main`, unmodified.

### The defect

`AdminCustomerDetail.vue` renders the Colonel checkout-link button unconditionally. The endpoint behind it is wrapped in a `configuration_guard` that fails **every** request when billing is disabled, so in that configuration the button is present, clickable, and guaranteed to error.

Fix is a `v-if="billing.enabled"` on the button, with a comment naming the guard as the reason.

### Also in the diff

Four eslint autofix hunks reflowing `<span>` closing brackets on the secrets / receipts / organizations count headings. Cosmetic, carried along rather than split out to keep the cherry-pick byte-identical to the original commit.

### Verification

`pnpm vitest run src/tests/apps/admin/AdminCustomerDetail.spec.ts` — 24 passed. The commit adds 24 lines of spec asserting button visibility tracks billing enablement in both states.