### PR TITLE
[#3948] Verification-resend cooldown follow-ups: residual note + spec stub

### DIFF
--- a/apps/api/account/spec/logic/account/create_account_spec.rb
+++ b/apps/api/account/spec/logic/account/create_account_spec.rb
@@ -276,6 +276,11 @@ RSpec.describe AccountAPI::Logic::Account::CreateAccount do
 
         it 'resends the verification email' do
           allow(Onetime::Customer).to receive(:find_by_email).and_return(existing_customer)
+          # Stub the cooldown claim: the real implementation writes a 300s
+          # NX key to Redis keyed on the fixed objid above, which would make
+          # this example fail on any re-run inside the window. The cooldown
+          # itself is covered by the integration specs.
+          allow(logic).to receive(:claim_verification_resend_slot?).and_return(true)
 
           expect(logic).to receive(:send_verification_email)
 

--- a/lib/onetime/security/verification_resend_cooldown.rb
+++ b/lib/onetime/security/verification_resend_cooldown.rb
@@ -41,6 +41,15 @@ module Onetime
     # skipped — the surrounding request may 500, but a datastore outage
     # never turns into an unthrottled send path.
     #
+    # Accepted residual: the cooldown carries no IP dimension, so an
+    # attacker who knows an unverified account exists can keep the denial
+    # primitive alive at a slower rate — one resend every cooldown window
+    # keeps rotating reset_secret, so the victim's most recent link is
+    # still the only valid one and older ones stay dead. The cooldown
+    # bounds spam volume and guarantees each link a minimum lifetime; it
+    # does not eliminate slow-drip denial. Adding an IP tier is a product
+    # decision deferred until it proves necessary.
+    #
     # Redis key (string keys at the Redis boundary):
     #   - verification_resend:cooldown:{objid}  - cooldown flag, EX-expired
     #


### PR DESCRIPTION
Two follow-ups to the verification-resend cooldown that landed in #3955. They were sitting uncommitted in the `fix/3948-remainders` worktree when that PR merged, so they missed it.

### 1. Record the no-IP-dimension residual

`VerificationResendCooldown` keys solely on `objid`. An attacker who already knows an unverified account exists can therefore keep the denial primitive alive at one resend per window: each resend rotates `reset_secret`, so the victim's most recent link stays the only valid one and older links stay dead.

That is a bounded, accepted residual — the cooldown caps spam volume and guarantees every link a minimum lifetime — but it was not written down anywhere, and the module's existing comment reads as though the cooldown closes the denial vector outright. This adds the residual to that comment block, including why an IP tier was deferred rather than shipped.

Documentation only, no behaviour change.

### 2. Stub the cooldown claim in the resend example

`create_account_spec.rb`'s "resends the verification email" example pins a fixed `objid`. The real `claim_verification_resend_slot?` writes a 300s NX key against it, so the first local run passed and every run inside the following five minutes took the cooldown branch and failed. CI never saw it — fresh datastore per run — which is exactly why it is worth fixing rather than tolerating.

Stubs the claim in that one example. The cooldown's own behaviour is covered by the integration specs added in #3955, so nothing loses coverage.

### Verification

`bundle exec rspec apps/api/account/spec/logic/account/create_account_spec.rb` — 13 examples, 0 failures, re-run against this branch's post-#3955/#3956 base.