### PR TITLE
[#3948] Rate-limit unauthenticated account creation (audit finding #4)

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -509,6 +509,51 @@ AUTH_VERIFY_ACCOUNT_ENABLED=true
 # Default: 3600 (1 hour).
 #RESET_REQUEST_RATE_LIMIT_LOCKOUT=3600
 
+# Rate limiting for unauthenticated account creation
+# (site.authentication.create_account_rate_limit). POST /auth/create-account
+# previously had no limiter, leaving unthrottled account creation: one
+# customer record (which carries no TTL) plus one welcome email per distinct
+# address, with subaddressing folding many addresses onto one mailbox.
+# Enabled by default (protective); set to the exact string 'false' to opt out
+# — other falsey-looking values ('0', 'no', 'off') leave it ENABLED, the same
+# convention as the other *_ENABLED != 'false' knobs.
+# See lib/onetime/security/create_account_rate_limiter.rb.
+#CREATE_ACCOUNT_RATE_LIMIT_ENABLED=true
+
+# Signups permitted per window from a single client IP before the limiter
+# locks out (site.authentication.create_account_rate_limit.max_per_ip).
+# Default: 10.
+#CREATE_ACCOUNT_RATE_LIMIT_MAX_PER_IP=10
+# Single tier, keyed on IP alone — there is no per-address backstop and there
+# cannot be one: every request in the abuse pattern carries a fresh address,
+# so an address-keyed tier would mint one bucket per request and cap nothing.
+# NOTE: the same collapse condition as the reset-request tier applies, and it
+# bites harder here. With TRUSTED_PROXY_ENABLED unset/false (the default) the
+# resolved IP is REMOTE_ADDR, which behind a reverse proxy is the proxy's own
+# address for every request — so the cap becomes this many signups/window for
+# the WHOLE deployment, and a lockout blocks SIGNUP for every new visitor
+# (not just a recovery flow for existing users). Set TRUSTED_PROXY_ENABLED=true,
+# or raise this cap; there is no second tier to fall back on.
+# To clear a stuck lockout: `bin/ots ratelimit keys` only PRINTS valkey-cli
+# command text (it never touches the datastore itself), so pipe it —
+#   valkey-cli --scan --pattern 'create_account:locked:ip:*'
+#   bin/ots ratelimit keys create_account_ip <masked-ip> | grep -v '^#' | valkey-cli
+# <masked-ip> is the STORED subject: the privacy-masked address (/24 IPv4,
+# /48 IPv6), not the raw address and not the /16-obscured form the lockout
+# log line prints. A colonel can instead POST /api/colonel/ratelimit/reset
+# with kind=create_account_ip and subject=<masked-ip>, which deletes the same
+# keys and records an admin audit event.
+
+# Counting window in seconds
+# (site.authentication.create_account_rate_limit.window).
+# Default: 3600 (1 hour).
+#CREATE_ACCOUNT_RATE_LIMIT_WINDOW=3600
+
+# Lockout duration in seconds once the cap is hit
+# (site.authentication.create_account_rate_limit.lockout).
+# Default: 3600 (1 hour).
+#CREATE_ACCOUNT_RATE_LIMIT_LOCKOUT=3600
+
 # Remember-me: persistent login across browser sessions via the
 # "Remember me" checkbox (auth: full.features.remember_me). Cookie
 # lifetime is Rodauth's default 14 days. Full auth mode only.

--- a/.env.reference
+++ b/.env.reference
@@ -511,9 +511,13 @@ AUTH_VERIFY_ACCOUNT_ENABLED=true
 
 # Rate limiting for unauthenticated account creation
 # (site.authentication.create_account_rate_limit). POST /auth/create-account
-# previously had no limiter, leaving unthrottled account creation: one
-# customer record (which carries no TTL) plus one welcome email per distinct
-# address, with subaddressing folding many addresses onto one mailbox.
+# previously had no limiter in EITHER auth mode, leaving unthrottled account
+# creation: one customer record (which carries no TTL) plus one welcome email
+# per distinct address, with subaddressing folding many addresses onto one
+# mailbox. This setting applies to both modes — full mode enforces it from the
+# Rodauth before_create_account_route hook, simple mode from the shared
+# CreateAccount logic class — so the knob means the same thing whichever mode
+# a deployment runs.
 # Enabled by default (protective); set to the exact string 'false' to opt out
 # — other falsey-looking values ('0', 'no', 'off') leave it ENABLED, the same
 # convention as the other *_ENABLED != 'false' knobs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ When context gets large: write current state to tasks/mission.md. Include: what'
 
 ### Responses
 
-Use short responses.
+Use short responses. Write in plain language.
 
 ## Pull Request Reviews
 

--- a/apps/api/account/logic/account/create_account.rb
+++ b/apps/api/account/logic/account/create_account.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'onetime/logic/signup_config_resolution'
+require 'onetime/security/create_account_rate_limiter'
 require 'onetime/security/verification_resend_cooldown'
 
 module AccountAPI::Logic
@@ -15,6 +16,7 @@ module AccountAPI::Logic
     #   new and unverified accounts.
     class CreateAccount < AccountAPI::Logic::Base
       include Onetime::Logic::SignupConfigResolution
+      include Onetime::Security::CreateAccountRateLimiter
       include Onetime::Security::VerificationResendCooldown
 
       SCHEMAS = { response: 'createAccount' }.freeze
@@ -41,6 +43,22 @@ module AccountAPI::Logic
 
       def raise_concerns
         raise OT::FormError, "You're already signed up" if @strategy_result.authenticated?
+
+        # Throughput cap (audit 2026-07-30 finding #4). Placed AFTER the
+        # already-authenticated guard above — a signed-in caller here is a UI
+        # mistake, not the abuse this bounds, and charging them would let one
+        # user's stray posts drain a shared masked-IP bucket — but ahead of every
+        # check below, so a throttled caller reaches neither the format/domain
+        # validation nor the Customer.find_by_email lookup and Customer.create!
+        # in #process. Malformed and disallowed-domain submissions DO cost
+        # budget: they are free to generate and equally good for flooding.
+        #
+        # Single tier, keyed on the client IP alone — never on the submitted
+        # address. Every request in the abuse pattern carries a FRESH address, so
+        # a per-email tier would mint one bucket per request and cap nothing; and
+        # keying on anything account-derived would punch a hole through this
+        # class's byte-identical-response contract. See the module for both.
+        enforce_create_account_rate_limit!(create_account_client_ip)
 
         # Security: Email enumeration prevention - don't check if email_exists? in the
         # validation layer. Do it in the  process() method where we can handle both new
@@ -129,7 +147,7 @@ module AccountAPI::Logic
           cust.save
 
           session_id = @strategy_result.session['id']
-          ip_address = @strategy_result.metadata['ip']
+          ip_address = create_account_client_ip
           OT.info "[new-customer] #{cust.objid} #{cust.role} #{ip_address} #{session_id}"
 
           # Send verification email for new accounts (unless autoverify is enabled)
@@ -166,6 +184,21 @@ module AccountAPI::Logic
 
       def form_fields
         { email: email }
+      end
+
+      # The limiter subject, and the IP in the [new-customer] log line.
+      #
+      # SYMBOL key. build_metadata (auth_strategies/helpers.rb) builds this hash
+      # with symbol keys, and every other reader in the codebase uses :ip; this
+      # class was the sole site indexing it with the string 'ip', which returned
+      # nil, so [new-customer] had been logging a blank IP. Reading it once here
+      # keeps the limiter key and the log line on the same value.
+      #
+      # AuthStrategies::Helpers#client_ip sources it from env['otto.client_ip'],
+      # so it is trusted-proxy-resolved and privacy-masked, not header-spoofable
+      # — subject to the collapse condition documented on the limiter module.
+      def create_account_client_ip
+        @strategy_result&.metadata&.[](:ip)
       end
 
       # Validates if the email domain is allowed for account creation.

--- a/apps/web/auth/config.rb
+++ b/apps/web/auth/config.rb
@@ -90,6 +90,15 @@ module Auth
       # accepts. Requires :reset_password (enabled by AccountManagement above)
       # so the before_reset_password_request_route hook exists.
       Hooks::ResetPasswordRequest.configure(self)
+      # Rate limiting for POST /auth/create-account (issue #3948, audit
+      # 2026-07-30 finding #4): bounds unauthenticated, unthrottled account
+      # creation — one Customer record (no TTL) plus one welcome email per
+      # distinct address. Simple mode enforces the SAME limiter from
+      # AccountAPI::Logic::Account::CreateAccount#raise_concerns; this is the
+      # full-mode half, and full mode is what production runs. Requires
+      # :create_account (enabled by AccountManagement above) so the
+      # before_create_account_route hook exists.
+      Hooks::CreateAccount.configure(self)
 
       # Method overrides (replace Rodauth methods, not before/after hooks)
       Overrides::PasswordMigration.configure(self)

--- a/apps/web/auth/config/hooks.rb
+++ b/apps/web/auth/config/hooks.rb
@@ -36,6 +36,9 @@
 #   email_auth.rb       before_email_auth_route, after_email_auth_request
 #   reset_password_request.rb  before_reset_password_request_route (rate
 #                       limiting per client IP + per submitted login, #3872)
+#   create_account.rb   before_create_account_route (rate limiting per client
+#                       IP, #3948; NOT before_create_account, which account.rb
+#                       owns and which fires later in the submission)
 #   webauthn.rb         after_webauthn_setup, before_webauthn_auth,
 #                       after_webauthn_auth_failure, before_webauthn_remove
 #   omniauth_tenant.rb  before_omniauth_callback_route (sole owner — logs
@@ -62,6 +65,7 @@
 module Auth::Config::Hooks
   require_relative 'hooks/account'
   require_relative 'hooks/billing'
+  require_relative 'hooks/create_account'
   require_relative 'hooks/login'
   require_relative 'hooks/logout'
   require_relative 'hooks/mfa'

--- a/apps/web/auth/config/hooks/create_account.rb
+++ b/apps/web/auth/config/hooks/create_account.rb
@@ -1,0 +1,124 @@
+# apps/web/auth/config/hooks/create_account.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/security/create_account_rate_limiter'
+
+#
+# Account-Creation Rate Limiting (issue #3948, audit 2026-07-30 finding #4)
+#
+# SOLE OWNER of the before_create_account_route hook (hooks do not chain —
+# see config/hooks.rb).
+#
+# FULL MODE ONLY: this file lives under apps/web/auth/, which the registry
+# skips entirely unless auth_config.full_enabled? (lib/onetime/application/
+# registry.rb#find_application_files). In simple mode — the application
+# default — POST /auth/create-account is served by the Core app
+# (apps/web/core/routes.txt → Core::Controllers::Registration#create_account)
+# and the SAME limiter is enforced from
+# AccountAPI::Logic::Account::CreateAccount#raise_concerns, with the same
+# client-IP subject and the same before-any-account-lookup ordering. The two
+# modes share one Redis keyspace shape and one config block, so a deployment
+# gets identical protection either way. Keep the two call sites in lockstep on
+# ORDERING and on the subject passed: a change here belongs there too.
+#
+# Production runs AUTHENTICATION_MODE=full, so THIS is the call site that
+# matters for the hosted deployment; the logic-class one covers self-hosted
+# simple-mode installs. Neither is redundant — only one of the two is reachable
+# in a given process, because the Auth app owns /auth/* whenever it is mounted
+# (Rack::URLMap dispatches longest-prefix-first, registry.rb).
+#
+# WHY ITS OWN FILE rather than an addition to hooks/account.rb: that file owns
+# before_create_account, which is a different hook AND fires too late for this
+# purpose — it runs inside the create-account POST body, after Rodauth has
+# begun processing the submission. before_create_account_route fires at the top
+# of the route (rodauth-2.44.0/lib/rodauth/features/create_account.rb:35),
+# ahead of the db[:accounts] lookup at hooks/account.rb:67 and the
+# Onetime::Customer.email_exists? call at :92, which is the
+# "before any account lookup or write" ordering the limiter's header asserts.
+#
+# ORDERING relative to the already-logged-in guard is inherited from Rodauth
+# and is the one we want: the route runs check_already_logged_in BEFORE
+# before_create_account_route, so an authenticated caller is turned away
+# without consuming budget. That matches the deliberate placement of the simple
+# mode call site after CreateAccount#raise_concerns' authenticated check —
+# a signed-in caller hitting this route is a UI mistake, not the abuse this
+# bounds, and charging them would let one user's stray form posts drain a
+# shared masked-IP bucket.
+#
+# CLIENT IP: the universal MiddlewareStack mounts Otto's IPPrivacyMiddleware
+# once, which resolves the canonical env['otto.client_ip'] via the
+# trusted-proxy resolver (Otto::Utils.resolve_client_ip) and rewrites
+# REMOTE_ADDR to the same masked value — so neither source is spoofable via
+# forwarded headers from an untrusted hop. We prefer the canonical env key and
+# fall back to request.ip (the rewritten REMOTE_ADDR) when it is absent (e.g. a
+# bare-Roda unit spec). An empty resolution skips the tier rather than pooling
+# unknown callers into one shared bucket an attacker could poison; unlike the
+# reset limiter there is no second tier to fall back on, so that is a genuine
+# (small) hole — see CreateAccountRateLimiter#create_account_ip_keys.
+#
+# INTERNAL REQUESTS ARE EXCLUDED, EXPLICITLY. :internal_request is enabled
+# (config/base.rb), and handle_internal_request runs this same route block with
+# a SYNTHESIZED env whose REQUEST_METHOD is 'POST'
+# (rodauth-2.44.0/lib/rodauth/features/internal_request.rb:325) — so a bare
+# `request.post?` guard does NOT exclude it. The affected caller is the
+# invite-signup path (Auth::Config.create_account in
+# apps/api/invite/logic/invites/signup_and_accept.rb), which is already
+# throttled by Onetime::Security::InviteTokenRateLimiter and is not the
+# unauthenticated-flood primitive this finding targets, so it must not consume
+# signup budget. We skip on internal_request? rather than leaning on the fact
+# that the synthesized env carries neither otto.client_ip nor REMOTE_ADDR (the
+# limiter would no-op via create_account_ip_keys returning nil): that no-op is
+# an accident of the synthesized env, not a contract, and it would degrade
+# SILENTLY — a future change that seeds an IP into internal requests would
+# start charging invite signups against a random bucket with nothing to catch
+# it.
+#
+# respond_to? takes the include_all argument because internal_request? is a
+# PRIVATE method on the Rodauth instance (defined in features/base.rb:965 and
+# overridden in the internal-request subclass); the one-argument form returns
+# false for it and the guard would never fire.
+#
+# ENUMERATION SAFETY: the limiter keys only on the client IP — never on the
+# submitted login, and never on whether it resolves to an account — so the 429
+# introduces no oracle on a route whose entire response contract is that new
+# and existing accounts answer identically. The raised Onetime::LimitExceeded
+# propagates through around_rodauth (which re-raises typed limiter exceptions
+# without the unhandled-exception error log — see overrides/error_handling.rb)
+# to the router's error_handler, which renders the ADR-013 429 body with
+# retry_after; Onetime::Middleware::RetryAfterHeader turns that into the RFC
+# 9110 Retry-After response header.
+#
+# POST-only: Rodauth's route wrapper fires this hook for GET (form render) and
+# POST alike; only the POST creates an account, so only the POST is counted.
+#
+module Auth::Config::Hooks
+  module CreateAccount
+    def self.configure(auth)
+      # The before_create_account_route configuration method only exists when
+      # :create_account is enabled (AccountManagement enables it
+      # unconditionally today); same defensive guard as
+      # hooks/reset_password_request.rb so a future conditional enablement
+      # degrades to a no-op rather than a NoMethodError at configure time.
+      auth_class = auth.instance_variable_get(:@auth)
+      return unless auth_class&.features&.include?(:create_account)
+
+      auth.auth_class_eval do
+        include Onetime::Security::CreateAccountRateLimiter
+      end
+
+      auth.before_create_account_route do
+        # See the INTERNAL REQUESTS note above: this must come before the
+        # request.post? check, which internal requests satisfy.
+        next if respond_to?(:internal_request?, true) && internal_request?
+
+        if request.post?
+          client_ip = request.env['otto.client_ip']
+          client_ip = request.ip if client_ip.to_s.empty?
+
+          enforce_create_account_rate_limit!(client_ip)
+        end
+      end
+    end
+  end
+end

--- a/apps/web/auth/spec/integration/full/create_account_rate_limit_spec.rb
+++ b/apps/web/auth/spec/integration/full/create_account_rate_limit_spec.rb
@@ -1,0 +1,424 @@
+# apps/web/auth/spec/integration/full/create_account_rate_limit_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration — account-creation rate limiting in FULL mode (#3948)
+# =============================================================================
+#
+# Covers the FULL-mode half of finding #4 of the 2026-07-30 audit. In full mode
+# the Auth app is mounted at /auth (apps/web/auth/application.rb) and
+# Rack::URLMap dispatches longest-prefix-first, so POST /auth/create-account is
+# served by Rodauth's create_account route — the simple-mode logic class
+# (AccountAPI::Logic::Account::CreateAccount, where the sibling spec's limiter
+# call lives) is never instantiated. Full mode is what production runs, so this
+# is the path that has to be throttled for the finding to be closed at all.
+#
+# The before_create_account_route hook (config/hooks/create_account.rb) enforces
+# Onetime::Security::CreateAccountRateLimiter at the top of the route: ahead of
+# the POST body, ahead of the db[:accounts] lookup and
+# Onetime::Customer.email_exists? check in before_create_account, and ahead of
+# the account INSERT.
+#
+# These tests assert the four properties that distinguish a correct
+# implementation from one that merely returns 429 somewhere:
+#
+#   1. the cap bites across DISTINCT submitted addresses (only an IP-keyed tier
+#      can do that — every request in the abuse pattern carries a fresh
+#      address);
+#   2. the key written is exactly create_account:locked:ip:<masked-ip> — the
+#      privacy-masked address IPPrivacyMiddleware resolved, never a raw
+#      REMOTE_ADDR and never a global bucket that one caller could use to shut
+#      off signup deployment-wide;
+#   3. a throttled request creates NO accounts row and NO Customer, which is
+#      the datastore-growth half of the finding;
+#   4. the invite-signup path — Auth::Config.create_account via
+#      :internal_request — is NOT charged budget, even when an IP is present in
+#      the synthesized env. It is already throttled by InviteTokenRateLimiter
+#      and is not the unauthenticated-flood primitive this bounds.
+#
+# Sibling coverage: spec/integration/simple/create_account_rate_limit_spec.rb
+# (same limiter, simple-mode call site) and
+# try/unit/security/create_account_rate_limiter_try.rb (unit, including the
+# audit-write bound and the collapsed-IP operator hint).
+#
+# The suite-wide test config ships the limiter DISABLED (spec/config.test.yaml)
+# so other full-mode specs are not throttled; each example here enables it
+# in-process with small caps and restores the config after.
+#
+# REQUIREMENTS:
+# - Valkey running on port 2121: pnpm run test:database:start
+# - AUTH_DATABASE_URL set (SQLite or PostgreSQL)
+# - AUTHENTICATION_MODE=full
+#
+# RUN:
+#   RACK_ENV=test AUTHENTICATION_MODE=full AUTH_DATABASE_URL='sqlite::memory:' \
+#     ORGS_SSO_ENABLED=true bundle exec rspec \
+#     apps/web/auth/spec/integration/full/create_account_rate_limit_spec.rb
+#
+# =============================================================================
+
+require_relative '../../spec_helper'
+require 'rack/test'
+
+RSpec.describe 'Account-creation rate limiting — full mode (#3948 finding #4)', type: :integration do
+  include Rack::Test::Methods
+
+  before(:all) do
+    # Boot the full app so the REAL Auth::Config — with the rate-limit hook
+    # wired in via config/hooks/create_account.rb — is loaded and mounted at
+    # /auth.
+    boot_onetime_app
+  end
+
+  before do
+    unless defined?(Auth::Database) && Auth::Database.connection
+      skip 'Auth database not configured (run with AUTH_DATABASE_URL set)'
+    end
+
+    # Isolate from real delivery: an allowed signup dispatches a welcome /
+    # verification email. Everything upstream still runs for real.
+    allow(Onetime::Jobs::Publisher).to receive(:enqueue_email_raw).and_return(true)
+
+    @saved_conf     = YAML.load(YAML.dump(OT.conf))
+    @created_emails = []
+    clear_limiter_keys
+  end
+
+  after do
+    OT.send(:conf=, @saved_conf) if @saved_conf
+    clear_limiter_keys
+
+    Array(@created_emails).each do |email|
+      purge_account(email)
+      Onetime::Customer.find_by_email(email)&.destroy!
+    rescue StandardError => e
+      warn "[create-account limiter spec] cleanup failed for #{email}: #{e.message}"
+    end
+  end
+
+  # Delete an accounts row and everything that references it. The allowed
+  # signups here are REAL account creations, so the row has children (password
+  # hash, verification key, audit log, ...) and a bare delete trips the FK
+  # constraint. The child set differs between the SQLite and PostgreSQL
+  # migration lanes, so it is discovered from the schema rather than hardcoded.
+  def purge_account(email)
+    db  = Auth::Database.connection
+    row = db[:accounts].where(email: email).first
+    return unless row
+
+    db.tables.each do |table|
+      next if table == :accounts
+
+      db.foreign_key_list(table).each do |fk|
+        next unless fk[:table].to_s == 'accounts'
+
+        db[table].where(fk[:columns].first => row[:id]).delete
+      end
+    rescue Sequel::Error
+      next
+    end
+
+    db[:accounts].where(id: row[:id]).delete
+  end
+
+  # The counters live on the Customer shard (see
+  # CreateAccountRateLimiter#create_account_redis), which is not necessarily the
+  # logical DB the suite helpers flush.
+  let(:rl_redis) { Onetime::Customer.dbclient }
+
+  def clear_limiter_keys
+    stale = rl_redis.keys('create_account:attempts:*') +
+            rl_redis.keys('create_account:locked:*')
+    rl_redis.del(*stale) unless stale.empty?
+  end
+
+  # Enable the limiter in-process with an example-specific cap
+  # (spec/config.test.yaml ships it disabled). Restored from @saved_conf above.
+  def enable_limiter(max_per_ip:)
+    new_conf = YAML.load(YAML.dump(OT.conf))
+    site     = (new_conf['site'] ||= {})
+    auth     = (site['authentication'] ||= {})
+
+    auth['create_account_rate_limit'] = {
+      'enabled' => true,
+      'max_per_ip' => max_per_ip,
+      'window' => 900,
+      'lockout' => 900,
+    }
+
+    OT.send(:conf=, new_conf)
+  end
+
+  # Fresh session + CSRF token per request: an attacker is not obliged to reuse
+  # a session, so the limiter must bite regardless of session identity. `from:`
+  # drives REMOTE_ADDR; IPPrivacyMiddleware resolves and masks it into
+  # env['otto.client_ip'], which is what the limiter keys on.
+  #
+  # login-confirm and password-confirm are both required by this deploy's
+  # Rodauth config; omitting either turns every under-cap signup into a 422 that
+  # writes no account row, which would make the "nothing is written for a
+  # throttled request" assertions below pass vacuously. Sending them keeps the
+  # allowed path a REAL account creation.
+  def post_signup(login, from:, password: 'TestPassword123!')
+    clear_cookies
+    rack_env = { 'REMOTE_ADDR' => from }
+
+    header 'Content-Type', nil
+    header 'Content-Length', nil
+    header 'Accept', 'application/json'
+    get '/auth', {}, rack_env
+    token = last_response.headers['X-CSRF-Token']
+
+    header 'Content-Type', 'application/json'
+    header 'Accept', 'application/json'
+    header 'X-CSRF-Token', token if token
+    post '/auth/create-account',
+      JSON.generate(
+        login: login,
+        'login-confirm' => login,
+        password: password,
+        'password-confirm' => password,
+        shrimp: token,
+      ),
+      rack_env
+    last_response
+  end
+
+  # The /24 (IPv4) mask IPPrivacyMiddleware applies before the app sees the
+  # address — the bucket is that masked network, never the raw source.
+  def masked(ip)
+    "#{ip.split('.').first(3).join('.')}.0"
+  end
+
+  it 'runs the full-mode path (the Auth app owns /auth/create-account)' do
+    expect(Onetime.auth_config.full_enabled?).to be true
+    expect(Onetime::Application::Registry.mount_mappings.key?('/auth')).to be true
+    # The hook, not the logic class, is what can possibly be enforcing here:
+    # the limiter module is mixed into the Rodauth class, and OUR block is what
+    # `_before_create_account_route` compiles to.
+    #
+    # Assert the source_location, not merely that the method is defined:
+    # Rodauth's `before` definer class_evals a `def _before_create_account_route;
+    # nil end` stub for every class carrying the :create_account feature
+    # (rodauth-2.44.0/lib/rodauth.rb:257), so `private_method_defined?` is true
+    # whether or not we registered anything. The file the method actually came
+    # from is the part that discriminates.
+    expect(Auth::Config.ancestors).to include(Onetime::Security::CreateAccountRateLimiter)
+    hook_source = Auth::Config.instance_method(:_before_create_account_route).source_location&.first
+    expect(hook_source).to end_with('apps/web/auth/config/hooks/create_account.rb')
+  end
+
+  describe 'per-IP cap' do
+    let(:source_a) { '203.0.113.10' }
+    let(:source_b) { '198.51.100.20' }
+
+    it 'caps signup volume from one source across DIFFERENT addresses (the abuse pattern)' do
+      enable_limiter(max_per_ip: 2)
+
+      2.times do |i|
+        email    = unique_test_email("burst-#{i}")
+        @created_emails << email
+        response = post_signup(email, from: source_a)
+        expect(response.status).to eq(200),
+          "Under-cap signup #{i + 1} should pass, got #{response.status}: #{response.body}"
+      end
+
+      # Assert the EXACT key, not merely that something locked. A constant or
+      # global bucket and a raw-REMOTE_ADDR key would both satisfy a glob count;
+      # this pins the subject to the privacy-masked address the middleware
+      # resolved. Every signup above used a distinct address, so only an
+      # IP-keyed tier can be what engaged.
+      expect(rl_redis.keys('create_account:locked:ip:*'))
+        .to eq(["create_account:locked:ip:#{masked(source_a)}"])
+
+      response = post_signup(unique_test_email('burst-over'), from: source_a)
+      expect(response.status).to eq(429),
+        "Over-cap signup must be throttled, got #{response.status}: #{response.body}"
+      body = JSON.parse(response.body)
+      expect(body['error_type']).to eq('LimitExceeded')
+      expect(body['retry_after']).to be_a(Integer)
+      expect(body['max_attempts']).to eq(2)
+
+      # The delay must also reach the HTTP header proxies and clients actually
+      # read (RFC 9110 §10.2.3). Set by Onetime::Middleware::RetryAfterHeader
+      # from the value the Roda error handler stashes via ErrorCorrelation — the
+      # same mechanism the simple-mode Otto stack uses, so the two modes cannot
+      # drift.
+      expect(response.headers['retry-after']).to eq(body['retry_after'].to_s)
+    end
+
+    it 'isolates sources: one locked-out network does not throttle another' do
+      enable_limiter(max_per_ip: 1)
+
+      first = unique_test_email('iso-a')
+      @created_emails << first
+      post_signup(first, from: source_a)
+
+      expect(post_signup(unique_test_email('iso-a-over'), from: source_a).status).to eq(429)
+
+      second   = unique_test_email('iso-b')
+      @created_emails << second
+      response = post_signup(second, from: source_b)
+      expect(response.status).to eq(200),
+        "A different source must be unaffected, got #{response.status}: #{response.body}"
+    end
+  end
+
+  describe 'ordering: nothing is written for a throttled request' do
+    let(:source) { '192.0.2.30' }
+
+    it 'creates NO accounts row and NO Customer for a throttled signup' do
+      enable_limiter(max_per_ip: 1)
+
+      first = unique_test_email('order')
+      @created_emails << first
+      # The allowed sibling proves the route really does write on this path, so
+      # the absences asserted below are the limiter's doing and not a signup
+      # that would have failed anyway.
+      expect(post_signup(first, from: source).status).to eq(200)
+      expect(Auth::Database.connection[:accounts].where(email: first).first).not_to be_nil
+
+      blocked = unique_test_email('order-blocked')
+      @created_emails << blocked
+      response = post_signup(blocked, from: source)
+      expect(response.status).to eq(429)
+
+      # The datastore-growth half of the finding: a limiter wired after the
+      # INSERT would leave the row behind despite the 429.
+      #
+      # This does NOT discriminate route-hook placement from before_create_account
+      # placement — that hook also runs before save_account, so a limiter there
+      # would likewise leave no row. What the route hook additionally buys is
+      # running ahead of the ACCOUNT LOOKUP (hooks/account.rb's db[:accounts]
+      # query and Customer.email_exists?), which is asserted separately below.
+      expect(Auth::Database.connection[:accounts].where(email: blocked).first).to be_nil
+      expect(Onetime::Customer.find_by_email(blocked)).to be_nil
+    end
+
+    it 'never reaches the account lookup for a throttled signup' do
+      enable_limiter(max_per_ip: 1)
+
+      # This is what route-hook placement buys over before_create_account, which
+      # would also leave no row behind: a throttled probe never executes the
+      # existence check at all (hooks/account.rb queries db[:accounts] and then
+      # Onetime::Customer.email_exists?). On a route whose response contract is
+      # that new and existing addresses answer identically, not running the
+      # lookup is the strongest form of that guarantee.
+      # Counted rather than asserted with have_received(:once): an allowed
+      # signup calls email_exists? several times (the hook check, then customer
+      # provisioning downstream), so the meaningful assertion is that a
+      # throttled request adds ZERO calls, not that the total is any one number.
+      lookups = 0
+      allow(Onetime::Customer).to receive(:email_exists?).and_wrap_original do |orig, *args, &blk|
+        lookups += 1
+        orig.call(*args, &blk)
+      end
+
+      first = unique_test_email('lookup')
+      @created_emails << first
+      expect(post_signup(first, from: source).status).to eq(200)
+
+      # The allowed sibling pins the spy to a call site that really is on this
+      # path — without it, the assertion below would hold for a typo'd method
+      # name just as well.
+      baseline = lookups
+      expect(baseline).to be_positive
+
+      expect(post_signup(unique_test_email('lookup-blocked'), from: source).status).to eq(429)
+      expect(lookups).to eq(baseline)
+    end
+
+    it 'never writes a key derived from the submitted address' do
+      enable_limiter(max_per_ip: 3)
+
+      email = unique_test_email('nokey')
+      @created_emails << email
+      post_signup(email, from: source)
+
+      # An address-keyed bucket would be an enumeration oracle on a route whose
+      # contract is that existing and new accounts respond identically.
+      local_part = email.split('@').first
+      expect(rl_redis.keys('create_account:*').grep(/#{Regexp.escape(local_part)}|@/)).to be_empty
+    end
+  end
+
+  describe 'internal requests (the invite-signup path)' do
+    let(:test_suffix) { "#{Familia.now.to_i}_#{SecureRandom.hex(4)}" }
+    let(:owner_email) { "invite_owner_#{test_suffix}@onetimesecret.com" }
+    let(:invited_email) { "invitee_#{test_suffix}@onetimesecret.com" }
+
+    let(:owner) { Onetime::Customer.create!(email: owner_email, role: 'customer') }
+    let(:organization) do
+      Onetime::Organization.create!(
+        "Create-Account Limiter Org #{test_suffix}",
+        owner,
+        owner_email,
+        is_default: true,
+      )
+    end
+    let(:invitation) do
+      Onetime::OrganizationMembership.create_invitation!(
+        organization: organization,
+        email: invited_email,
+        inviter: owner,
+        role: 'member',
+      )
+    end
+
+    after do
+      Auth::Database.connection[:accounts].where(email: invited_email).delete
+      invitation&.destroy_with_index_cleanup!
+      organization&.destroy!
+      owner&.destroy!
+      Onetime::Customer.find_by_email(invited_email)&.destroy!
+    rescue StandardError
+      # Non-fatal cleanup error
+    end
+
+    # handle_internal_request runs the SAME route block with a synthesized env
+    # whose REQUEST_METHOD is 'POST', so a bare request.post? guard would charge
+    # invite signups against a signup bucket. The env here deliberately carries
+    # a resolvable client IP: without one the limiter would no-op via
+    # create_account_ip_keys returning nil, and this example would pass on an
+    # accident of the synthesized env rather than on the internal_request? guard
+    # actually being there.
+    it 'does not charge budget for Auth::Config.create_account, even with a client IP in env' do
+      enable_limiter(max_per_ip: 1)
+      expect(invitation.pending?).to be(true)
+
+      Auth::Config.create_account(
+        login: invited_email,
+        password: 'TestPassword123!',
+        params: { 'invite_token' => invitation.token },
+        env: { 'otto.client_ip' => '203.0.113.77', 'REMOTE_ADDR' => '203.0.113.77' },
+      )
+
+      # The invite signup still works (the guard skips the limiter, it does not
+      # abort the route)...
+      expect(Auth::Database.connection[:accounts].where(email: invited_email).first).not_to be_nil
+
+      # ...and consumed no budget at all: neither an attempts counter nor a
+      # lockout flag exists for that IP, so the very first HTTP signup from it
+      # is still allowed.
+      expect(rl_redis.keys('create_account:*')).to be_empty
+    end
+  end
+
+  describe 'suite default (limiter disabled by test config)' do
+    it 'does not throttle when site.authentication.create_account_rate_limit is disabled' do
+      # No enable_limiter call: this runs under spec/config.test.yaml, which
+      # ships enabled:false — repeated signups write no limiter keys.
+      3.times do |i|
+        email    = unique_test_email("off-#{i}")
+        @created_emails << email
+        response = post_signup(email, from: '198.51.100.77')
+        expect(response.status).to eq(200),
+          "Signup #{i + 1} should pass with the limiter off, got #{response.status}: #{response.body}"
+      end
+
+      expect(rl_redis.keys('create_account:attempts:*')).to be_empty
+      expect(rl_redis.keys('create_account:locked:*')).to be_empty
+    end
+  end
+end

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -336,12 +336,16 @@ site:
       lockout: <%= ENV['RESET_REQUEST_RATE_LIMIT_LOCKOUT'] || 3600 %>
     # Rate limiting for unauthenticated account creation (#3948, audit
     # 2026-07-30 finding #4). POST /auth/create-account previously had no
-    # limiter, leaving unthrottled account creation: one Customer record (no
-    # TTL) plus one welcome email per distinct address, with subaddressing
-    # folding many addresses onto one mailbox. Throttles per client IP BEFORE
-    # any account lookup or write. Single tier by necessity, not choice — every
-    # request in the abuse pattern carries a fresh address, so a per-email tier
-    # would cap nothing. Enabled by default (protective); set
+    # limiter in EITHER auth mode, leaving unthrottled account creation: one
+    # Customer record (no TTL) plus one welcome email per distinct address,
+    # with subaddressing folding many addresses onto one mailbox. Throttles per
+    # client IP BEFORE any account lookup or write, in both modes: full mode
+    # via the Rodauth before_create_account_route hook (apps/web/auth/config/
+    # hooks/create_account.rb), simple mode via
+    # AccountAPI::Logic::Account::CreateAccount#raise_concerns. Single tier by
+    # necessity, not choice — every request in the abuse pattern carries a
+    # fresh address, so a per-email tier would cap nothing.
+    # Enabled by default (protective); set
     # CREATE_ACCOUNT_RATE_LIMIT_ENABLED=false to opt out.
     # See lib/onetime/security/create_account_rate_limiter.rb.
     create_account_rate_limit:

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -334,6 +334,28 @@ site:
       window: <%= ENV['RESET_REQUEST_RATE_LIMIT_WINDOW'] || 3600 %>
       # Lockout duration in seconds once a tier's cap is hit (1 hour).
       lockout: <%= ENV['RESET_REQUEST_RATE_LIMIT_LOCKOUT'] || 3600 %>
+    # Rate limiting for unauthenticated account creation (#3948, audit
+    # 2026-07-30 finding #4). POST /auth/create-account previously had no
+    # limiter, leaving unthrottled account creation: one Customer record (no
+    # TTL) plus one welcome email per distinct address, with subaddressing
+    # folding many addresses onto one mailbox. Throttles per client IP BEFORE
+    # any account lookup or write. Single tier by necessity, not choice — every
+    # request in the abuse pattern carries a fresh address, so a per-email tier
+    # would cap nothing. Enabled by default (protective); set
+    # CREATE_ACCOUNT_RATE_LIMIT_ENABLED=false to opt out.
+    # See lib/onetime/security/create_account_rate_limiter.rb.
+    create_account_rate_limit:
+      enabled: <%= ENV['CREATE_ACCOUNT_RATE_LIMIT_ENABLED'] != 'false' %>
+      # Signups permitted per window from a single masked client IP. The bucket
+      # is a whole /24 (office, campus NAT), and behind an unconfigured reverse
+      # proxy it is the entire deployment — so this is deliberately loose
+      # relative to the one signup a person needs. Raise it for dense-NAT
+      # populations; a too-tight value here is a signup-funnel outage.
+      max_per_ip: <%= ENV['CREATE_ACCOUNT_RATE_LIMIT_MAX_PER_IP'] || 10 %>
+      # Counting window in seconds (1 hour).
+      window: <%= ENV['CREATE_ACCOUNT_RATE_LIMIT_WINDOW'] || 3600 %>
+      # Lockout duration in seconds once the cap is hit (1 hour).
+      lockout: <%= ENV['CREATE_ACCOUNT_RATE_LIMIT_LOCKOUT'] || 3600 %>
   # Links to documentation. For onetimesecret.com, this is
   # docs.onetimesecret.com.
   support:

--- a/lib/onetime/operations/ratelimit/registry.rb
+++ b/lib/onetime/operations/ratelimit/registry.rb
@@ -76,6 +76,15 @@ module Onetime
             keys: ['reset_request:attempts:email:%s', 'reset_request:locked:email:%s'],
             dbclient: -> { Onetime::Customer.dbclient },
           },
+          # Single-tier IP limiter on unauthenticated account creation. SUBJECT
+          # IS THE STORED FORM: the privacy-masked IP (/24 IPv4, /48 IPv6), not
+          # the raw address and not the /16-obscured form the lockout log line
+          # prints. A raw address reads back `not_set`.
+          'create_account_ip' => {
+            subject: 'masked client IP (/24 IPv4, /48 IPv6)',
+            keys: ['create_account:attempts:ip:%s', 'create_account:locked:ip:%s'],
+            dbclient: -> { Onetime::Customer.dbclient },
+          },
           'dns' => {
             subject: 'domain identifier (sanitized)',
             keys: ['dns:ratelimit:%s'],

--- a/lib/onetime/security/create_account_rate_limiter.rb
+++ b/lib/onetime/security/create_account_rate_limiter.rb
@@ -1,0 +1,335 @@
+# lib/onetime/security/create_account_rate_limiter.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/models/admin_audit_event'
+
+module Onetime
+  module Security
+    # CreateAccountRateLimiter - Throttles unauthenticated account creation
+    #
+    # Closes finding #4 of the 2026-07-30 audit: POST /auth/create-account
+    # (routes.txt, auth=noauth) reached AccountAPI::Logic::Account::CreateAccount
+    # with no limiter of any kind. The reachable primitive is unauthenticated,
+    # unthrottled account creation — one Customer record plus one welcome email
+    # per DISTINCT address, with subaddressing (victim+1@, victim+2@, ...)
+    # collapsing arbitrarily many addresses onto one mailbox. Impact is datastore
+    # growth (the Customer hash carries no TTL) and unsolicited mail.
+    #
+    # SINGLE TIER, IP ONLY — and unlike {ResetRequestRateLimiter} that is not a
+    # tradeoff, it is the only tier that can work here. That limiter's per-email
+    # backstop bounds an IP-rotating attacker sampling ONE target, because there
+    # the target address is the thing held fixed. Account-creation abuse holds
+    # nothing fixed: every request carries a fresh address, which is the point of
+    # the attack. A per-email tier would mint one bucket per request and cap
+    # nothing. Capping volume per origin is the whole of the available defense.
+    #
+    # NOT a per-mailbox tier either. Subaddress folding (strip +tag, and for the
+    # major providers strip dots) would key victim+1@ and victim+2@ to one
+    # bucket, which is the shape the mail-bombing case wants. It is deliberately
+    # NOT done: the fold is provider-specific (gmail strips dots, others do not),
+    # so a wrong guess silently merges DISTINCT people's addresses into one
+    # bucket and one stranger's signups lock out another's. That is a worse
+    # failure than the spam it prevents, for a LOW finding. The per-IP cap
+    # already bounds total mail volume per origin, which is the same ceiling by a
+    # safer key.
+    #
+    # ENUMERATION SAFETY: the tier keys ONLY on the client IP — never on the
+    # submitted address, and never on whether it resolves to an account — so a
+    # 429 discloses nothing. This matters more here than on the reset route:
+    # CreateAccount's entire response contract is that existing and new accounts
+    # are byte-identical (see #process), and a limiter keyed on anything
+    # account-derived would have punched a hole straight through it.
+    #
+    # ORDERING: enforced from #raise_concerns, ahead of the format and
+    # signup-domain checks and therefore ahead of the Customer.find_by_email
+    # lookup and Customer.create! in #process. Deliberately AFTER the
+    # already-authenticated guard on the first line of that method: a signed-in
+    # caller hitting this route is a UI mistake, not the abuse this bounds, and
+    # charging them budget would let one authenticated user's stray form posts
+    # consume a shared masked-IP bucket. Malformed and disallowed-domain
+    # submissions DO cost budget — they are free to generate and equally good
+    # for flooding.
+    #
+    # IP GRANULARITY, and the COLLAPSE CONDITION, are identical to
+    # {ResetRequestRateLimiter}: the subject is the privacy-masked network (/24
+    # IPv4, /48 IPv6) the universal IPPrivacyMiddleware resolved, so the bucket
+    # is shared by that neighborhood; and with site.network.trusted_proxy
+    # disabled behind a reverse proxy the resolved IP is the PROXY's address for
+    # every request, collapsing the whole deployment into one bucket. Read that
+    # module's COLLAPSE CONDITION section — the diagnosis and both remedies are
+    # the same, and this limiter appends the same self-contained hint to its
+    # lockout log line.
+    #
+    # The collapse matters MORE here than for reset requests. A reset-request
+    # lockout denies a recovery flow to an already-registered user, who can wait
+    # out the window; a create-account lockout denies SIGNUP to every new visitor
+    # behind that address. Hence the deliberately loose default cap below.
+    #
+    # CLEARING A STUCK LOCKOUT — same two paths as every other limiter, over
+    # kind `create_account_ip`:
+    #
+    #   1. `bin/ots ratelimit keys create_account_ip <masked-ip>` piped to
+    #      valkey-cli (the CLI only PRINTS commands; see ratelimit_command.rb).
+    #      <masked-ip> is the STORED subject — the privacy-masked address, not
+    #      the raw one and not the /16-obscured form in the log line.
+    #   2. `POST /api/colonel/ratelimit/reset` with kind=create_account_ip,
+    #      which performs the delete AND records an AdminAuditEvent.
+    #
+    # Fail semantics mirror the other security limiters: Redis errors propagate
+    # rather than silently permitting an unthrottled signup flood.
+    #
+    # Redis keys (string keys at the Redis boundary):
+    #   - create_account:attempts:ip:{ip}  - per-IP request counter
+    #   - create_account:locked:ip:{ip}    - per-IP lockout flag
+    #
+    # Config (site.authentication.create_account_rate_limit): enabled, max_per_ip,
+    # window, lockout. Absent config -> enabled with the constant defaults below;
+    # set enabled:false to disable (the test config does, so suite signups are not
+    # throttled).
+    #
+    # Usage:
+    #   include Onetime::Security::CreateAccountRateLimiter
+    #   enforce_create_account_rate_limit!(client_ip) # before any account write
+    module CreateAccountRateLimiter
+      # Default signups permitted per window from a single masked client IP.
+      #
+      # Deliberately loose relative to what one PERSON needs (one signup, ever).
+      # The bucket is a whole masked /24 — an office, a campus NAT, a coworking
+      # space — and under the collapse condition above it can be the entire
+      # deployment. A tight cap there would be an outage of the signup funnel,
+      # i.e. worse than the LOW-severity spam it bounds. 10/hour still turns
+      # unbounded account creation into a bounded, loggable, auditable trickle,
+      # which is the whole ask of the finding.
+      DEFAULT_MAX_PER_IP = 10
+
+      # Default window in seconds over which signups are counted (1 hour).
+      DEFAULT_WINDOW = 3600
+
+      # Default lockout duration in seconds once the cap is hit (1 hour).
+      DEFAULT_LOCKOUT = 3600
+
+      # Audit verb recorded when the tier reaches its cap. Namespaced
+      # `<resource>.<action>` like every other verb in the trail; the admin
+      # console filters on the exact string, so it is a constant.
+      AUDIT_VERB = 'auth.create_account_throttled'
+
+      # Lua script that checks the lockout AND records the request in one atomic
+      # round trip — same contract as {ResetRequestRateLimiter} and
+      # {IncomingRateLimiter}: Redis serializes script executions, the increment
+      # that reaches max_attempts sets the lockout flag and clears the counter,
+      # and every later execution sees the flag and is denied before
+      # incrementing, so concurrent bursts cannot overshoot the cap.
+      # Returns {1, current_count} when allowed, {0, lockout_ttl} when denied.
+      CHECK_AND_RECORD_SCRIPT = <<~LUA
+        local attempts_key = KEYS[1]
+        local lockout_key = KEYS[2]
+        local attempt_window = tonumber(ARGV[1])
+        local max_attempts = tonumber(ARGV[2])
+        local lockout_duration = tonumber(ARGV[3])
+
+        if redis.call('EXISTS', lockout_key) == 1 then
+          return {0, redis.call('TTL', lockout_key)}
+        end
+
+        local current = redis.call('INCR', attempts_key)
+
+        if current == 1 then
+          redis.call('EXPIRE', attempts_key, attempt_window)
+        end
+
+        if current >= max_attempts then
+          redis.call('SETEX', lockout_key, lockout_duration, '1')
+          redis.call('DEL', attempts_key)
+        end
+
+        return {1, current}
+      LUA
+
+      # Enforce the account-creation rate limit and record this request. Raises
+      # LimitExceeded when the IP is locked; a locked tier is never incremented
+      # (the Lua script denies before INCR). No-op when the limiter is disabled
+      # by config, and no-op when no client IP is available — see
+      # create_account_ip_keys for why that skips rather than shares a bucket.
+      #
+      # @param client_ip [String, nil] The caller's edge-masked client IP.
+      # @raise [Onetime::LimitExceeded] If the limit is exceeded.
+      # @return [void]
+      def enforce_create_account_rate_limit!(client_ip)
+        return unless create_account_rate_limit_enabled?
+        return unless (keys = create_account_ip_keys(client_ip))
+
+        allowed, detail = create_account_redis.eval(
+          CHECK_AND_RECORD_SCRIPT,
+          keys: [keys[:attempts], keys[:lockout]],
+          argv: [create_account_window, create_account_max_per_ip, create_account_lockout],
+        )
+
+        if allowed.to_i != 1
+          raise Onetime::LimitExceeded.new(
+            'Too many signup attempts. Please try again later.',
+            retry_after: detail.to_i.positive? ? detail.to_i : create_account_lockout,
+            max_attempts: create_account_max_per_ip,
+          )
+        end
+
+        count = detail.to_i
+        if count >= create_account_max_per_ip
+          # This cap-reaching request was itself ALLOWED (the Lua script locks
+          # after incrementing); the lockout applies to subsequent requests.
+          obscured = obscured_create_account_ip(client_ip)
+          OT.le "[CreateAccountRateLimiter] ip #{obscured} " \
+                "hit cap (#{count}/#{create_account_max_per_ip}); " \
+                "locked for #{create_account_lockout}s" \
+                "#{collapsed_create_account_ip_hint}"
+          record_create_account_throttle_audit(obscured, count)
+        elsif count >= create_account_max_per_ip - 1
+          OT.li "[CreateAccountRateLimiter] ip #{obscured_create_account_ip(client_ip)} " \
+                "at #{count}/#{create_account_max_per_ip} signups"
+        end
+      end
+
+      private
+
+      # Write the queryable counterpart of the OT.le line above.
+      #
+      # SEPARATE RETENTION DOMAIN, and a BOUNDED WRITE FREQUENCY — both are
+      # required, not stylistic. This is the SECOND unauthenticated writer into
+      # the audit store, and the MAX_EVENTS rationale on
+      # {Onetime::AdminAuditEvent} (rewritten when ResetRequestRateLimiter became
+      # the first) requires any further unauthenticated-triggerable verb to carry
+      # a comparable per-window bound or move to its own collection. This does
+      # both:
+      #
+      #   - it writes to .record_security, whose security_events collection has
+      #     its own count cap and age bound, NOT to .record, which holds the
+      #     count-capped-with-no-TTL operator trail (purge, role change,
+      #     suspension, impersonation) and would evict oldest-first under a
+      #     flood;
+      #   - it records ONLY on the cap-reaching request, never on the deny path,
+      #     which an attacker can drive as fast as it can send. That bounds
+      #     writes to one event per masked network per LOCKOUT window (default
+      #     1h), so minting another costs a full cap's worth of requests from
+      #     another masked network.
+      #
+      # Both properties are pinned by tests; keep them.
+      #
+      # The subject is the OBSCURED IP (/16), never the resolved one. Actor is
+      # 'anonymous' — the caller is unauthenticated by construction on this
+      # route, and normalize_actor would otherwise stamp 'unknown', which reads
+      # as "we failed to resolve it" rather than "there is none".
+      #
+      # Best-effort, matching every other audit call site.
+      def record_create_account_throttle_audit(obscured_ip, count)
+        Onetime::AdminAuditEvent.record_security(
+          actor: 'anonymous',
+          verb: AUDIT_VERB,
+          target: "ip:#{obscured_ip}",
+          result: :failure,
+          detail: {
+            tier: 'ip',
+            count: count,
+            max_attempts: create_account_max_per_ip,
+            window: create_account_window,
+            lockout: create_account_lockout,
+          },
+        )
+      rescue StandardError => ex
+        # A signup must never fail because its audit event could not be
+        # assembled.
+        OT.le('[CreateAccountRateLimiter] audit record failed', exception: ex)
+      end
+
+      # Composite per-IP keys, or nil when no IP is available.
+      #
+      # Skipping is correct rather than fail-closed here: a blank suffix would
+      # build ONE key shared by every IP-less caller, so the first few would lock
+      # the bucket and every later one would be denied — a global signup outage
+      # driven by whatever made the IP unresolvable. Same rationale as
+      # LoginRateLimiter#login_ip_keys and ResetRequestRateLimiter's ip tier.
+      # Unlike the reset limiter there is no second tier to fall back on, so this
+      # is a genuine (small) hole: it needs the resolved client IP to be empty,
+      # which in the mounted stack means IPPrivacyMiddleware did not run.
+      def create_account_ip_keys(client_ip)
+        return nil if client_ip.to_s.empty?
+
+        {
+          attempts: "create_account:attempts:ip:#{client_ip}",
+          lockout: "create_account:locked:ip:#{client_ip}",
+        }
+      end
+
+      def create_account_rate_limit_config
+        OT.conf.dig('site', 'authentication', 'create_account_rate_limit') || {}
+      end
+
+      # Enabled unless config explicitly sets enabled:false. Absent config keeps
+      # the protective default on; the test config disables it so suite signups
+      # are not throttled.
+      def create_account_rate_limit_enabled?
+        create_account_rate_limit_config.fetch('enabled', true) != false
+      end
+
+      def create_account_max_per_ip
+        positive_create_account_setting('max_per_ip', DEFAULT_MAX_PER_IP)
+      end
+
+      def create_account_window
+        positive_create_account_setting('window', DEFAULT_WINDOW)
+      end
+
+      def create_account_lockout
+        positive_create_account_setting('lockout', DEFAULT_LOCKOUT)
+      end
+
+      # Read a numeric setting, falling back to its default unless the configured
+      # value coerces to a POSITIVE integer. A zero/garbage value (a typo'd env
+      # var: `to_i` turns "abc" into 0) would otherwise invert enforcement — a
+      # zero cap locks on the first request and a non-positive lockout makes the
+      # Lua SETEX fail, turning every signup into a 500 instead of a throttle.
+      def positive_create_account_setting(key, default)
+        value = create_account_rate_limit_config[key].to_i
+        value.positive? ? value : default
+      end
+
+      # Obscure the IP for logs: IPv4 keeps the /16, IPv6 is truncated to a short
+      # prefix. The resolved value never reaches logs.
+      def obscured_create_account_ip(client_ip)
+        value = client_ip.to_s
+        parts = value.split('.')
+        return "#{parts[0]}.#{parts[1]}.x.x" if parts.length == 4
+
+        value[0..8]
+      end
+
+      # Operator diagnostic appended to the lockout LOG LINE (server side only —
+      # it never reaches a response body) when the deployment has not declared a
+      # trusted reverse proxy, in which case the resolved client IP is
+      # REMOTE_ADDR and every visitor shares one bucket. Self-contained on
+      # purpose: it restates the condition and names both remedy env vars inline,
+      # so an operator reading only the log line has the whole diagnosis. Keep it
+      # that way — do not swap it for a doc pointer.
+      #
+      # Deliberately NOT a boot-time check: the same config is correct for a
+      # direct-connect deployment and boot has no evidence a proxy exists, so a
+      # boot warning would fire on every default install. A lockout is the first
+      # moment the condition is actually demonstrated.
+      def collapsed_create_account_ip_hint
+        return '' if OT.conf.dig('site', 'network', 'trusted_proxy', 'enabled') == true
+
+        '. NOTE: site.network.trusted_proxy is not enabled, so the client IP is ' \
+          'REMOTE_ADDR; if this deployment is behind a reverse proxy every visitor ' \
+          'shares this bucket and signup is blocked deployment-wide. Set ' \
+          'TRUSTED_PROXY_ENABLED=true, or raise CREATE_ACCOUNT_RATE_LIMIT_MAX_PER_IP'
+      end
+
+      # Redis connection via the Customer model's dbclient — the subject is a
+      # signup on the auth surface, so the counters live on the same shard as the
+      # login/account rate-limit state (matches LoginRateLimiter and
+      # ResetRequestRateLimiter).
+      def create_account_redis
+        Onetime::Customer.dbclient
+      end
+    end
+  end
+end

--- a/lib/onetime/security/create_account_rate_limiter.rb
+++ b/lib/onetime/security/create_account_rate_limiter.rb
@@ -8,13 +8,44 @@ module Onetime
   module Security
     # CreateAccountRateLimiter - Throttles unauthenticated account creation
     #
-    # Closes finding #4 of the 2026-07-30 audit: POST /auth/create-account
-    # (routes.txt, auth=noauth) reached AccountAPI::Logic::Account::CreateAccount
-    # with no limiter of any kind. The reachable primitive is unauthenticated,
-    # unthrottled account creation — one Customer record plus one welcome email
-    # per DISTINCT address, with subaddressing (victim+1@, victim+2@, ...)
-    # collapsing arbitrarily many addresses onto one mailbox. Impact is datastore
-    # growth (the Customer hash carries no TTL) and unsolicited mail.
+    # Closes finding #4 of the 2026-07-30 audit: POST /auth/create-account had
+    # no limiter of any kind in EITHER auth mode. The reachable primitive is
+    # unauthenticated, unthrottled account creation — one Customer record plus
+    # one welcome email per DISTINCT address, with subaddressing (victim+1@,
+    # victim+2@, ...) collapsing arbitrarily many addresses onto one mailbox.
+    # Impact is datastore growth (the Customer hash carries no TTL) and
+    # unsolicited mail.
+    #
+    # Enforced on BOTH auth-mode paths to POST /auth/create-account:
+    #
+    #   - full mode (what production runs): the Rodauth
+    #     before_create_account_route hook (apps/web/auth/config/hooks/
+    #     create_account.rb), at the top of the route and therefore ahead of the
+    #     route body and of every before_create_account check;
+    #   - simple mode (the application default for self-hosted installs): the
+    #     shared logic class,
+    #     AccountAPI::Logic::Account::CreateAccount#raise_concerns (routed via
+    #     apps/web/core/routes.txt →
+    #     Core::Controllers::Registration#create_account), ahead of the format
+    #     and signup-domain checks and the Customer lookup.
+    #
+    # Only one of the two is reachable in a given deployment — the Auth app owns
+    # /auth/* whenever it is mounted, and Rack::URLMap dispatches
+    # longest-prefix-first (lib/onetime/application/registry.rb) — so this is
+    # parity of PROTECTION, not double counting. Both take their subject from
+    # env['otto.client_ip'], so in the mounted stack — where IPPrivacyMiddleware
+    # always sets it — the keyspace and any operator remediation are identical
+    # in either mode. The FALLBACKS differ and are unreachable there: full mode
+    # falls back to Rack::Request#ip, simple mode to AuthStrategies::Helpers
+    # #client_ip (Otto::Utils.resolve_client_ip, then Rack::Request#ip). Keep
+    # the two call sites in lockstep on ORDERING and on the subject passed: a
+    # change to one belongs in the other.
+    #
+    # Internal requests are excluded in full mode — the invite-signup path calls
+    # Auth::Config.create_account via :internal_request, which runs the same
+    # route block with a synthesized POST env, and it is already throttled by
+    # {InviteTokenRateLimiter}. See the hook file for why that exclusion is
+    # explicit rather than incidental.
     #
     # SINGLE TIER, IP ONLY — and unlike {ResetRequestRateLimiter} that is not a
     # tradeoff, it is the only tier that can work here. That limiter's per-email
@@ -41,10 +72,20 @@ module Onetime
     # are byte-identical (see #process), and a limiter keyed on anything
     # account-derived would have punched a hole straight through it.
     #
-    # ORDERING: enforced from #raise_concerns, ahead of the format and
-    # signup-domain checks and therefore ahead of the Customer.find_by_email
-    # lookup and Customer.create! in #process. Deliberately AFTER the
-    # already-authenticated guard on the first line of that method: a signed-in
+    # ORDERING — the same shape in both modes, before any account lookup or
+    # write and after the already-authenticated guard:
+    #
+    #   - simple mode: enforced from #raise_concerns, ahead of the format and
+    #     signup-domain checks and therefore ahead of the Customer.find_by_email
+    #     lookup and Customer.create! in #process, but AFTER the
+    #     already-authenticated guard on the first line of that method;
+    #   - full mode: enforced from before_create_account_route, which Rodauth
+    #     runs at the top of the route — ahead of the POST body, of the
+    #     db[:accounts] lookup and Onetime::Customer.email_exists? check in the
+    #     before_create_account hook, and of the account INSERT — but AFTER
+    #     Rodauth's own check_already_logged_in on the line above it.
+    #
+    # The already-authenticated exclusion is deliberate in both: a signed-in
     # caller hitting this route is a UI mistake, not the abuse this bounds, and
     # charging them budget would let one authenticated user's stray form posts
     # consume a shared masked-IP bucket. Malformed and disallowed-domain
@@ -88,7 +129,9 @@ module Onetime
     # set enabled:false to disable (the test config does, so suite signups are not
     # throttled).
     #
-    # Usage:
+    # Usage (both call sites above do exactly this — the simple-mode logic class
+    # includes the module directly, the full-mode hook includes it into the
+    # Rodauth class via auth_class_eval):
     #   include Onetime::Security::CreateAccountRateLimiter
     #   enforce_create_account_rate_limit!(client_ip) # before any account write
     module CreateAccountRateLimiter

--- a/spec/config.test.yaml
+++ b/spec/config.test.yaml
@@ -81,6 +81,12 @@ site:
     # reset_request_rate_limiter.rb.
     reset_request_rate_limit:
       enabled: false
+    # Disabled under test so the many specs that sign accounts up are not
+    # throttled (the cap is per masked IP, and the whole suite shares one);
+    # the finding-#4 limiter tests enable it in-process. See
+    # create_account_rate_limiter.rb.
+    create_account_rate_limit:
+      enabled: false
 
 features:
   regions:

--- a/spec/integration/simple/create_account_rate_limit_spec.rb
+++ b/spec/integration/simple/create_account_rate_limit_spec.rb
@@ -6,14 +6,22 @@
 # TEST TYPE: Integration — account-creation rate limiting in SIMPLE mode
 # =============================================================================
 #
-# Closes finding #4 of the 2026-07-30 audit. POST /auth/create-account
-# (apps/web/core/routes.txt:32, auth=noauth) reached
-# AccountAPI::Logic::Account::CreateAccount with NO limiter of any kind — a
-# grep for rate_limit/enforce_ across that logic class and
+# Covers the SIMPLE-mode half of finding #4 of the 2026-07-30 audit. In simple
+# mode POST /auth/create-account (apps/web/core/routes.txt:32, auth=noauth)
+# reaches AccountAPI::Logic::Account::CreateAccount, which had NO limiter of
+# any kind — a grep for rate_limit/enforce_ across that logic class and
 # Core::Controllers::Registration returned nothing. The reachable primitive was
 # unauthenticated, unthrottled account creation: one Customer record (the hash
 # carries no TTL) plus one welcome email per DISTINCT address, with
 # subaddressing folding arbitrarily many addresses onto one mailbox.
+#
+# The FULL-mode half of the same finding is covered by
+# apps/web/auth/spec/integration/full/create_account_rate_limit_spec.rb: there
+# the Auth app owns /auth/* and Rodauth serves this route, so the identical
+# limiter is enforced from the before_create_account_route hook instead
+# (apps/web/auth/config/hooks/create_account.rb). Neither spec's assertions
+# transfer to the other mode — hence the skip guard below — but the two together
+# are what close the finding for every deployment shape.
 #
 # The limiter is single-tier and keyed on the client IP alone. That is a
 # necessity, not a preference: every request in the abuse pattern carries a

--- a/spec/integration/simple/create_account_rate_limit_spec.rb
+++ b/spec/integration/simple/create_account_rate_limit_spec.rb
@@ -1,0 +1,315 @@
+# spec/integration/simple/create_account_rate_limit_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration — account-creation rate limiting in SIMPLE mode
+# =============================================================================
+#
+# Closes finding #4 of the 2026-07-30 audit. POST /auth/create-account
+# (apps/web/core/routes.txt:32, auth=noauth) reached
+# AccountAPI::Logic::Account::CreateAccount with NO limiter of any kind — a
+# grep for rate_limit/enforce_ across that logic class and
+# Core::Controllers::Registration returned nothing. The reachable primitive was
+# unauthenticated, unthrottled account creation: one Customer record (the hash
+# carries no TTL) plus one welcome email per DISTINCT address, with
+# subaddressing folding arbitrarily many addresses onto one mailbox.
+#
+# The limiter is single-tier and keyed on the client IP alone. That is a
+# necessity, not a preference: every request in the abuse pattern carries a
+# fresh address, so a per-email tier would mint one bucket per request and cap
+# nothing. It also must not key on anything account-derived — this route's whole
+# response contract is that new and existing accounts are byte-identical.
+#
+# These tests drive the REAL middleware stack, so the subject under test is the
+# privacy-masked client IP that IPPrivacyMiddleware resolves, not a raw
+# REMOTE_ADDR the app never sees.
+#
+# Sibling coverage: try/unit/security/create_account_rate_limiter_try.rb (unit,
+# including the audit-write bound and the collapsed-IP operator hint).
+#
+# REQUIREMENTS:
+# - Valkey running on port 2121: pnpm run test:database:start
+# - AUTHENTICATION_MODE=simple
+#
+# RUN:
+#   RACK_ENV=test AUTHENTICATION_MODE=simple bundle exec rspec \
+#     spec/integration/simple/create_account_rate_limit_spec.rb
+#
+# =============================================================================
+
+require_relative '../integration_spec_helper'
+
+RSpec.describe 'Account-creation rate limiting — simple mode (#3948 finding #4)', type: :integration do
+  include Rack::Test::Methods
+
+  # Full Rack::URLMap so requests traverse the complete middleware stack.
+  # Memoized: repeated generate_rack_url_map calls corrupt middleware state.
+  def app
+    @rack_app ||= begin
+      Onetime::Application::Registry.reset!
+      Onetime::Application::Registry.prepare_application_registry
+      Onetime::Application::Registry.generate_rack_url_map
+    end
+  end
+
+  before(:all) do
+    Onetime.boot! :test
+    app
+  end
+
+  before do
+    # Full mode routes /auth/create-account to Rodauth, so these assertions
+    # would be exercising the wrong code path entirely.
+    skip 'requires simple auth mode' if Onetime.auth_config.full_enabled?
+
+    # Intercept delivery at the Mailer seam: send_verification_email delivers
+    # synchronously (lib/onetime/logic/base.rb), so without this every allowed
+    # signup would attempt real SMTP. Everything upstream still runs for real.
+    allow(Onetime::Mail::Mailer).to receive(:deliver).and_return(true)
+
+    @saved_conf     = YAML.load(YAML.dump(OT.conf))
+    @created_emails = []
+    clear_limiter_keys
+  end
+
+  after do
+    OT.send(:conf=, @saved_conf) if @saved_conf
+    clear_limiter_keys
+
+    Array(@created_emails).each do |email|
+      cust = Onetime::Customer.find_by_email(email)
+      next unless cust
+
+      Onetime::Customer.dbclient.del("verification_resend:cooldown:#{cust.objid}")
+      cust.destroy!
+    rescue StandardError => e
+      warn "[create-account limiter spec] customer cleanup failed: #{e.message}"
+    end
+  end
+
+  # The counters live on the Customer shard (see
+  # CreateAccountRateLimiter#create_account_redis), which is not necessarily the
+  # logical DB the integration helper flushes.
+  let(:rl_redis) { Onetime::Customer.dbclient }
+
+  def clear_limiter_keys
+    stale = rl_redis.keys('create_account:attempts:*') +
+            rl_redis.keys('create_account:locked:*')
+    rl_redis.del(*stale) unless stale.empty?
+  end
+
+  # Enable the limiter in-process with an example-specific cap
+  # (spec/config.test.yaml ships it disabled so the rest of the suite's signups
+  # are not throttled). Restored from @saved_conf in the after hook.
+  def enable_limiter(max_per_ip:)
+    new_conf = YAML.load(YAML.dump(OT.conf))
+    site     = (new_conf['site'] ||= {})
+    auth     = (site['authentication'] ||= {})
+
+    auth['create_account_rate_limit'] = {
+      'enabled' => true,
+      'max_per_ip' => max_per_ip,
+      'window' => 900,
+      'lockout' => 900,
+    }
+
+    OT.send(:conf=, new_conf)
+  end
+
+  def disable_limiter
+    new_conf                          = YAML.load(YAML.dump(OT.conf))
+    site                              = (new_conf['site'] ||= {})
+    auth                              = (site['authentication'] ||= {})
+    auth['create_account_rate_limit'] = { 'enabled' => false }
+    OT.send(:conf=, new_conf)
+  end
+
+  def unique_email(prefix = 'signup')
+    "#{prefix}-#{SecureRandom.hex(8)}@integration-test.example.com"
+  end
+
+  # Fresh session + CSRF token per request: an attacker is not obliged to reuse
+  # a session, so the limiter must bite regardless of session identity. `from:`
+  # drives REMOTE_ADDR; IPPrivacyMiddleware resolves and masks it into
+  # env['otto.client_ip'], which is what the limiter keys on.
+  #
+  # Setup failure must be LOUD: a silently-nil shrimp draws a 403 from the CSRF
+  # middleware and surfaces as a misleading status assertion further down.
+  def post_signup(login, from: nil, password: 'integration-test-pw')
+    clear_cookies
+    rack_env = from ? { 'REMOTE_ADDR' => from } : {}
+
+    header 'Content-Type', nil
+    header 'Content-Length', nil
+    header 'Accept', 'application/json'
+    get '/', {}, rack_env
+    token = last_response.headers['X-CSRF-Token']
+
+    if token.to_s.empty?
+      raise "CSRF setup failed: GET / returned #{last_response.status} with no X-CSRF-Token header " \
+            "(headers: #{last_response.headers.keys.sort.join(', ')})."
+    end
+
+    header 'Content-Type', 'application/json'
+    header 'Accept', 'application/json'
+    header 'X-CSRF-Token', token
+    post '/auth/create-account',
+      JSON.generate(login: login, password: password, skill: '', shrimp: token),
+      rack_env
+
+    if last_response.status == 403
+      raise "CSRF rejected by the stack (403): #{last_response.body}. " \
+            'This is a session/middleware problem, not a signup result.'
+    end
+
+    last_response
+  end
+
+  # The /24 (IPv4) mask IPPrivacyMiddleware applies before the app sees the
+  # address — the bucket is that masked network, never the raw source.
+  def masked(ip)
+    "#{ip.split('.').first(3).join('.')}.0"
+  end
+
+  it 'runs the simple-mode path (the Auth app is not mounted)' do
+    expect(Onetime.auth_config.full_enabled?).to be false
+    expect(Onetime::Application::Registry.mount_mappings.key?('/auth')).to be false
+  end
+
+  describe 'per-IP cap' do
+    let(:source_a) { '203.0.113.10' }
+    let(:source_b) { '198.51.100.20' }
+
+    it 'caps signup volume from one source across DIFFERENT addresses (the abuse pattern)' do
+      enable_limiter(max_per_ip: 2)
+
+      2.times do |i|
+        email    = unique_email("burst-#{i}")
+        @created_emails << email
+        response = post_signup(email, from: source_a)
+        expect(response.status).to eq(200),
+          "Under-cap signup #{i + 1} should pass, got #{response.status}: #{response.body}"
+      end
+
+      # Assert the EXACT key, not merely that something locked. A constant or
+      # global bucket (one caller shutting off signup deployment-wide) and a
+      # raw-REMOTE_ADDR key would both satisfy a glob count; this pins the
+      # subject to the privacy-masked address the middleware resolved. Every
+      # signup above used a distinct email, so only an IP-keyed tier can be
+      # what engaged.
+      expect(rl_redis.keys('create_account:locked:ip:*'))
+        .to eq(["create_account:locked:ip:#{masked(source_a)}"])
+
+      response = post_signup(unique_email('burst-over'), from: source_a)
+      expect(response.status).to eq(429),
+        "Over-cap signup must be throttled, got #{response.status}: #{response.body}"
+      body     = JSON.parse(response.body)
+      expect(body['error_type']).to eq('LimitExceeded')
+      expect(body['retry_after']).to be_a(Integer)
+      expect(body['max_attempts']).to eq(2)
+    end
+
+    it 'carries a Retry-After header on the 429, not only a body field' do
+      enable_limiter(max_per_ip: 1)
+
+      first = unique_email('hdr')
+      @created_emails << first
+      post_signup(first, from: source_a)
+
+      response = post_signup(unique_email('hdr-over'), from: source_a)
+      expect(response.status).to eq(429)
+      # RetryAfterHeader middleware (#3956) turns the body's retry_after into
+      # the RFC 9110 header for every LimitExceeded, this limiter included.
+      expect(response.headers['Retry-After']).to match(/\A\d+\z/)
+      expect(response.headers['Retry-After'].to_i).to be_positive
+    end
+
+    it 'isolates sources: one locked-out network does not throttle another' do
+      enable_limiter(max_per_ip: 1)
+
+      first = unique_email('iso-a')
+      @created_emails << first
+      post_signup(first, from: source_a)
+
+      expect(post_signup(unique_email('iso-a-over'), from: source_a).status).to eq(429)
+
+      second   = unique_email('iso-b')
+      @created_emails << second
+      response = post_signup(second, from: source_b)
+      expect(response.status).to eq(200),
+        "A different source must be unaffected, got #{response.status}: #{response.body}"
+    end
+  end
+
+  describe 'ordering and enumeration safety' do
+    let(:source) { '192.0.2.30' }
+
+    it 'creates NO customer for a throttled signup' do
+      enable_limiter(max_per_ip: 1)
+
+      first = unique_email('order')
+      @created_emails << first
+      post_signup(first, from: source)
+
+      blocked  = unique_email('order-blocked')
+      response = post_signup(blocked, from: source)
+      expect(response.status).to eq(429)
+
+      # The limiter runs in #raise_concerns, ahead of the find_by_email lookup
+      # and the Customer.create! in #process. If it were enforced anywhere later
+      # the record would exist despite the 429 — which is the entire point of
+      # the finding (datastore growth), so assert the absence directly.
+      expect(Onetime::Customer.find_by_email(blocked)).to be_nil
+    end
+
+    it 'never writes a key derived from the submitted address' do
+      enable_limiter(max_per_ip: 3)
+
+      email = unique_email('nokey')
+      @created_emails << email
+      post_signup(email, from: source)
+
+      # An address-keyed bucket would be an enumeration oracle on a route whose
+      # contract is that existing and new accounts respond identically.
+      local_part = email.split('@').first
+      expect(rl_redis.keys('create_account:*').grep(/#{Regexp.escape(local_part)}|@/)).to be_empty
+    end
+
+    it 'charges budget for submissions rejected as malformed' do
+      enable_limiter(max_per_ip: 2)
+
+      # Malformed addresses are free to generate and equally good for flooding,
+      # so they must cost budget even though they never reach #process. The
+      # limiter sits ahead of the format check for exactly this reason.
+      expect(post_signup('not-an-email', from: source).status).to eq(422).or eq(400)
+
+      valid = unique_email('after-malformed')
+      @created_emails << valid
+      post_signup(valid, from: source)
+
+      response = post_signup(unique_email('after-malformed-over'), from: source)
+      expect(response.status).to eq(429),
+        "The malformed submission should have consumed budget, got #{response.status}: #{response.body}"
+    end
+  end
+
+  describe 'when disabled' do
+    let(:source) { '198.51.100.77' }
+
+    it 'writes no keys and never throttles' do
+      disable_limiter
+
+      3.times do |i|
+        email    = unique_email("off-#{i}")
+        @created_emails << email
+        response = post_signup(email, from: source)
+        expect(response.status).to eq(200),
+          "Signup #{i + 1} should pass with the limiter off, got #{response.status}: #{response.body}"
+      end
+
+      expect(rl_redis.keys('create_account:attempts:*')).to be_empty
+      expect(rl_redis.keys('create_account:locked:*')).to be_empty
+    end
+  end
+end

--- a/try/unit/operations/email_ratelimit_tools_try.rb
+++ b/try/unit/operations/email_ratelimit_tools_try.rb
@@ -137,7 +137,7 @@ AE.count
 
 ## the registry knows the canonical limiter kinds, in registry order
 Onetime::Operations::RateLimit::Registry.kinds
-#=> ["feedback", "passphrase", "invite", "login", "reset_request_ip", "reset_request_email", "dns"]
+#=> ["feedback", "passphrase", "invite", "login", "reset_request_ip", "reset_request_email", "create_account_ip", "dns"]
 
 ## keys_for expands the templates byte-identically to the CLI's emitted keys
 Onetime::Operations::RateLimit::Registry.keys_for('feedback', '1.2.3.4')

--- a/try/unit/security/create_account_rate_limiter_try.rb
+++ b/try/unit/security/create_account_rate_limiter_try.rb
@@ -1,0 +1,315 @@
+# try/unit/security/create_account_rate_limiter_try.rb
+#
+# frozen_string_literal: true
+
+# #3948 (audit 2026-07-30 finding #4): CreateAccountRateLimiter caps
+# unauthenticated account creation, which previously had no limiter at all —
+# one Customer record (no TTL) plus one welcome email per distinct address,
+# with subaddressing folding many addresses onto one mailbox.
+#
+# Single tier, keyed on the client IP alone. Unlike ResetRequestRateLimiter
+# there is no per-email backstop and there cannot be one: every request in the
+# abuse pattern carries a FRESH address, so a per-email tier would mint one
+# bucket per request and cap nothing.
+#
+# We test:
+# 1. Under-limit requests are allowed; key shape and TTL
+# 2. Over-limit raises LimitExceeded with the configured cap + lockout state
+# 3. The limiter NEVER keys on the submitted address (enumeration safety)
+# 4. nil/empty IP skips rather than sharing one global bucket
+# 5. Cap-hit writes exactly one AdminAuditEvent, in the SECURITY trail, and
+#    denied requests write no further ones
+# 6. Garbage/non-positive config falls back to defaults instead of inverting
+# 7. Configured-off (enabled:false) is a total no-op
+# 8. The collapsed-IP operator hint is present and WIRED IN to the log line
+
+require_relative '../../support/test_models'
+require 'onetime/security/create_account_rate_limiter'
+
+OT.boot! :test, true
+
+# Tryout files share one process and OT.conf is global; snapshot the booted
+# config so the teardown can restore it for later files.
+@saved_conf = YAML.load(YAML.dump(OT.conf))
+
+# Enable the limiter with small, known caps (test config ships it disabled).
+def set_create_account_rate_limit(cfg)
+  new_conf = YAML.load(YAML.dump(OT.conf))
+  new_conf['site'] ||= {}
+  new_conf['site']['authentication'] ||= {}
+  new_conf['site']['authentication']['create_account_rate_limit'] = cfg
+  OT.send(:conf=, new_conf)
+end
+
+# Toggle site.network.trusted_proxy.enabled for the collapsed-IP hint cases;
+# the teardown restores @saved_conf wholesale.
+def set_trusted_proxy_enabled(value)
+  new_conf = YAML.load(YAML.dump(OT.conf))
+  new_conf['site'] ||= {}
+  new_conf['site']['network'] ||= {}
+  new_conf['site']['network']['trusted_proxy'] = value.nil? ? {} : { 'enabled' => value }
+  OT.send(:conf=, new_conf)
+end
+
+set_create_account_rate_limit(
+  'enabled' => true,
+  'max_per_ip' => 3,
+  'window' => 900,
+  'lockout' => 900,
+)
+
+class CreateAccountRateLimiterTester
+  include Onetime::Security::CreateAccountRateLimiter
+end
+
+@tester = CreateAccountRateLimiterTester.new
+@redis  = Onetime::Customer.dbclient
+
+@ip_a = '203.0.113.10'
+@ip_b = '198.51.100.20'
+@tag  = "#{Familia.now.to_i}_#{rand(10_000)}"
+
+# true if a single enforce call raises LimitExceeded, false otherwise.
+@raises = lambda do |ip|
+  @tester.enforce_create_account_rate_limit!(ip)
+  false
+rescue Onetime::LimitExceeded
+  true
+end
+
+def cleanup(redis, ip)
+  redis.del("create_account:attempts:ip:#{ip}", "create_account:locked:ip:#{ip}")
+end
+
+cleanup(@redis, @ip_a)
+cleanup(@redis, @ip_b)
+
+## -- Under-limit ----------------------------------------------------------
+
+## A single signup under the cap is allowed
+@raises.call(@ip_a)
+#=> false
+
+## The attempts counter uses the documented key shape (the one the ratelimit
+## Registry and the bin/ots CLI emit commands for)
+@redis.exists?("create_account:attempts:ip:#{@ip_a}")
+#=> true
+
+## The counter carries a TTL within the configured window
+ttl = @redis.ttl("create_account:attempts:ip:#{@ip_a}")
+ttl.positive? && ttl <= 900
+#=> true
+
+## -- Enumeration safety ---------------------------------------------------
+
+## The limiter keys ONLY on the IP: no key anywhere carries the submitted
+## address. CreateAccount's whole response contract is that existing and new
+## accounts are byte-identical, so an address-derived key would punch a hole
+## straight through it. Two signups from one IP for two different addresses
+## share one bucket and mint no address-keyed key.
+@tester.enforce_create_account_rate_limit!(@ip_b)
+[@redis.get("create_account:attempts:ip:#{@ip_b}").to_i,
+ @redis.keys('create_account:*@*').length]
+#=> [1, 0]
+
+## -- Over-limit (cap = 3) -------------------------------------------------
+
+## Two more requests reach the cap (total 3) and lock the tier
+[@raises.call(@ip_a), @raises.call(@ip_a)]
+#=> [false, false]
+
+## The lockout key is now set
+@redis.exists?("create_account:locked:ip:#{@ip_a}")
+#=> true
+
+## The attempts counter is cleared once the tier locks
+@redis.exists?("create_account:attempts:ip:#{@ip_a}")
+#=> false
+
+## The next signup from that IP raises LimitExceeded
+@raises.call(@ip_a)
+#=> true
+
+## The raised error reports the configured cap and a positive retry_after,
+## which the shared RetryAfterHeader middleware turns into the HTTP header
+begin
+  @tester.enforce_create_account_rate_limit!(@ip_a)
+  nil
+rescue Onetime::LimitExceeded => e
+  [e.max_attempts, e.retry_after.positive?]
+end
+#=> [3, true]
+
+## A different IP is unaffected by that lockout
+@raises.call(@ip_b)
+#=> false
+
+## -- Missing IP skips rather than sharing a global bucket -----------------
+
+## A nil IP does not build a blank "ip:" key. Sharing one bucket across every
+## IP-less caller would let the first few lock it and deny everyone after —
+## a global signup outage driven by whatever made the IP unresolvable.
+result_nil = @raises.call(nil)
+[result_nil, @redis.exists?('create_account:attempts:ip:')]
+#=> [false, false]
+
+## An empty-string IP behaves identically
+result_empty = @raises.call('')
+[result_empty, @redis.exists?('create_account:attempts:ip:')]
+#=> [false, false]
+
+## -- Audit trail ----------------------------------------------------------
+
+## A cap-hit writes ONE queryable AdminAuditEvent, so a signup flood leaves
+## more than a log line. Counted as a delta rather than by clearing the shared
+## store, which other tryout files also write to.
+set_create_account_rate_limit(
+  'enabled' => true, 'max_per_ip' => 2, 'window' => 900, 'lockout' => 900,
+)
+@audit_verb  = Onetime::Security::CreateAccountRateLimiter::AUDIT_VERB
+@audit_count = -> { Onetime::AdminAuditEvent.recent_security(500).count { |e| e['verb'] == @audit_verb } }
+@admin_count = -> { Onetime::AdminAuditEvent.count }
+@audit_ip    = '203.0.113.99'
+cleanup(@redis, @audit_ip)
+@audit_before = @audit_count.call
+@admin_before = @admin_count.call
+2.times { @raises.call(@audit_ip) }
+@audit_count.call - @audit_before
+#=> 1
+
+## The event lands in the SECURITY trail, never the operator trail. That trail
+## is count-capped with no TTL and evicts oldest-first, so this — the SECOND
+## unauthenticated writer — sharing it could flush purge/role-change records.
+@admin_count.call - @admin_before
+#=> 0
+
+## The event names the tier, the caps, and an unauthenticated actor
+@audit_event = Onetime::AdminAuditEvent.recent_security(500).find { |e| e['verb'] == @audit_verb }
+[@audit_event['actor'], @audit_event['result'], @audit_event['detail']['tier'],
+ @audit_event['detail']['count'], @audit_event['detail']['max_attempts']]
+#=> ['anonymous', 'failure', 'ip', 2, 2]
+
+## The target is the OBSCURED IP (/16), never the resolved one
+@audit_event['target']
+#=> 'ip:203.0.x.x'
+
+## Denied requests write NO further events: only the cap-reaching request
+## records, bounding writes to one per masked network per lockout window. The
+## AdminAuditEvent MAX_EVENTS rationale REQUIRES this of any unauthenticated
+## writer; keep it.
+3.times { @raises.call(@audit_ip) }
+@audit_count.call - @audit_before
+#=> 1
+
+## ...and the flood still leaves the operator trail untouched
+@admin_count.call - @admin_before
+#=> 0
+
+## -- Config validation ----------------------------------------------------
+
+## Non-positive / garbage numeric settings fall back to the defaults instead of
+## inverting enforcement (a zero cap would otherwise lock on the very first
+## signup, and a non-positive lockout would make the Lua SETEX fail, turning
+## every signup into a 500 rather than a throttle)
+set_create_account_rate_limit(
+  'enabled' => true, 'max_per_ip' => 0, 'window' => -5, 'lockout' => 'abc',
+)
+@cfg_ip = '198.51.100.77'
+cleanup(@redis, @cfg_ip)
+result_cfg = @raises.call(@cfg_ip)
+[result_cfg, @redis.exists?("create_account:locked:ip:#{@cfg_ip}")]
+#=> [false, false]
+
+## -- Configured off -------------------------------------------------------
+
+## With enabled:false the limiter is a total no-op even past the caps
+set_create_account_rate_limit('enabled' => false, 'max_per_ip' => 3)
+@off_ip = '192.0.2.55'
+cleanup(@redis, @off_ip)
+results = (1..6).map { @raises.call(@off_ip) }
+results.none?
+#=> true
+
+## A disabled limiter writes no keys at all
+@redis.exists?("create_account:attempts:ip:#{@off_ip}")
+#=> false
+
+## -- Collapsed IP operator hint (log line only) ---------------------------
+
+## Without a declared trusted proxy the resolved client IP is REMOTE_ADDR, so a
+## lockout may be deployment-wide — which for THIS limiter means signup is shut
+## off for every new visitor. The hint says so and names the remedy inline. It
+## is appended to a server LOG line, never to a response.
+set_trusted_proxy_enabled(false)
+hint = @tester.send(:collapsed_create_account_ip_hint)
+[hint.empty?, hint.include?('trusted_proxy'), hint.include?('TRUSTED_PROXY_ENABLED=true')]
+#=> [false, true, true]
+
+## An absent trusted_proxy config reads the same as disabled
+set_trusted_proxy_enabled(nil)
+@tester.send(:collapsed_create_account_ip_hint).match?(/trusted_proxy/)
+#=> true
+
+## With the trusted proxy declared the hint is empty, so a correctly configured
+## deployment's lockout line stays byte-identical
+set_trusted_proxy_enabled(true)
+@tester.send(:collapsed_create_account_ip_hint)
+#=> ""
+
+## The hint is WIRED IN: a REAL cap hit (trusted proxy not declared) emits
+## exactly one OT.le line carrying both the cap text and the hint. The three
+## cases above call the private helper directly, so they stay green even if the
+## interpolation is dropped from enforce_create_account_rate_limit!; this case
+## is the one that fails.
+set_trusted_proxy_enabled(false)
+set_create_account_rate_limit(
+  'enabled' => true, 'max_per_ip' => 2, 'window' => 900, 'lockout' => 900,
+)
+@hint_ip = '192.0.2.99'
+cleanup(@redis, @hint_ip)
+captured = []
+OT.singleton_class.alias_method(:__ca_hint_real_le, :le)
+OT.define_singleton_method(:le) { |*msgs, **_payload| captured << msgs.join(' ') }
+begin
+  2.times { @tester.enforce_create_account_rate_limit!(@hint_ip) }
+ensure
+  OT.singleton_class.remove_method(:le)
+  OT.singleton_class.alias_method(:le, :__ca_hint_real_le)
+  OT.singleton_class.remove_method(:__ca_hint_real_le)
+end
+line = captured.find { |msg| msg.include?('hit cap') }.to_s
+[
+  captured.length,
+  line.include?('[CreateAccountRateLimiter] ip'),
+  line.include?('hit cap (2/2)'),
+  line.include?('TRUSTED_PROXY_ENABLED=true'),
+]
+#=> [1, true, true, true]
+
+## With the trusted proxy declared the same cap hit logs WITHOUT the hint
+set_trusted_proxy_enabled(true)
+@hint_ip_ok = '192.0.2.100'
+cleanup(@redis, @hint_ip_ok)
+captured_ok = []
+OT.singleton_class.alias_method(:__ca_hint_real_le, :le)
+OT.define_singleton_method(:le) { |*msgs, **_payload| captured_ok << msgs.join(' ') }
+begin
+  2.times { @tester.enforce_create_account_rate_limit!(@hint_ip_ok) }
+ensure
+  OT.singleton_class.remove_method(:le)
+  OT.singleton_class.alias_method(:le, :__ca_hint_real_le)
+  OT.singleton_class.remove_method(:__ca_hint_real_le)
+end
+line_ok = captured_ok.find { |msg| msg.include?('hit cap') }.to_s
+[line_ok.end_with?('locked for 900s'), line_ok.include?('TRUSTED_PROXY_ENABLED')]
+#=> [true, false]
+
+# Clean up test keys and restore the shared config for later tryout files.
+cleanup(@redis, @ip_a)
+cleanup(@redis, @ip_b)
+cleanup(@redis, @audit_ip)
+cleanup(@redis, @cfg_ip)
+cleanup(@redis, @off_ip)
+cleanup(@redis, @hint_ip)
+cleanup(@redis, @hint_ip_ok)
+OT.send(:conf=, @saved_conf)

--- a/try/unit/security/create_account_rate_limiter_try.rb
+++ b/try/unit/security/create_account_rate_limiter_try.rb
@@ -220,6 +220,24 @@ result_cfg = @raises.call(@cfg_ip)
 [result_cfg, @redis.exists?("create_account:locked:ip:#{@cfg_ip}")]
 #=> [false, false]
 
+## A PARTIAL config block — present, but with every numeric key absent — falls
+## back to the defaults rather than raising. The read is
+## `create_account_rate_limit_config[key].to_i`, and NilClass#to_i is core Ruby
+## returning 0, so a missing key takes the same not-positive path as a garbage
+## one. Pinned because a misconfigured deploy hitting this would be a 500 on
+## every signup, which is strictly worse than the flood the limiter bounds.
+set_create_account_rate_limit('enabled' => true)
+[@tester.send(:create_account_max_per_ip),
+ @tester.send(:create_account_window),
+ @tester.send(:create_account_lockout)]
+#=> [Onetime::Security::CreateAccountRateLimiter::DEFAULT_MAX_PER_IP, Onetime::Security::CreateAccountRateLimiter::DEFAULT_WINDOW, Onetime::Security::CreateAccountRateLimiter::DEFAULT_LOCKOUT]
+
+## and it still enforces on those defaults rather than erroring
+@partial_ip = '203.0.113.99'
+cleanup(@redis, @partial_ip)
+@raises.call(@partial_ip)
+#=> false
+
 ## -- Configured off -------------------------------------------------------
 
 ## With enabled:false the limiter is a total no-op even past the caps


### PR DESCRIPTION
Closes finding #4 of the 2026-07-30 audit — the last open publication gate on that report.

`POST /auth/create-account` (`routes.txt:32`, `auth=noauth`) reached `CreateAccount` with **no limiter of any kind**. The reachable primitive was unauthenticated, unthrottled account creation: one Customer record — the hash carries no TTL — plus one welcome email per distinct address, with subaddressing (`victim+N@…`) folding arbitrarily many addresses onto one mailbox. Impact is datastore growth and unsolicited mail.

### Why a single IP tier

`ResetRequestRateLimiter` has a per-email backstop that catches an IP-rotating attacker sampling one target, because there the target address is what's held fixed. Account-creation abuse holds nothing fixed — every request carries a fresh address. A per-address tier would mint one bucket per request and cap nothing, so IP is not the tighter of two options here, it's the only one that functions.

Nor can this key on anything account-derived: `CreateAccount`'s entire contract is that new and existing accounts respond byte-identically, and an address-keyed bucket would punch straight through it. A test asserts no key ever derives from the submitted address.

I also considered and rejected a per-mailbox tier that folds subaddresses. The fold is provider-specific (Gmail strips dots, others don't), so a wrong guess silently merges *different people's* addresses into one bucket and one stranger's signups lock out another's — a worse failure than the spam it prevents, for a LOW finding.

### The default cap is deliberately loose

10/hour, same as the reset limiter, despite one person needing exactly one signup ever. The bucket is a whole masked /24 — office, campus NAT, coworking space — and under the collapse condition inherited from the reset limiter (no trusted proxy declared behind a reverse proxy → resolved IP is the proxy's own address) it is the **entire deployment**.

That collapse is worse here than for reset requests: a reset lockout delays a recovery flow for someone who already has an account, but a signup lockout turns away every new visitor. A tight cap would be a funnel outage worse than the LOW-severity spam. The lockout log line carries the same self-contained operator hint naming both remedies.

### Also in this PR: a latent nil-IP bug

`create_account.rb:132` was the **only** site in the codebase indexing strategy metadata with the string `'ip'`. `build_metadata` builds that hash with symbol keys, so it returned nil and the `[new-customer]` log line has been recording a blank IP. Found while wiring the limiter subject, which would have inherited the same nil. Both now read one private method.

Per the project convention — strings where a structure crosses an API boundary, symbols for internal Ruby and third-party libs — this hash is internal, handed to Otto's `StrategyResult`, so the symbol is correct. (This fix is folded into the wiring commit rather than standing alone; same file, staged together.)

### Audit-write constraints

Cap-hits write one `AdminAuditEvent` to the **security** trail, never the operator trail, and **only** on the cap-reaching request — never on the deny path, which an attacker drives as fast as they can send. This is the second unauthenticated writer into that store, and the `MAX_EVENTS` rationale on `AdminAuditEvent` (rewritten when `ResetRequestRateLimiter` became the first) requires exactly those two properties of any further one. Both are pinned by tests.

### Verification

- `try/unit/security/create_account_rate_limiter_try.rb` — 26 cases; whole `try/unit/security/` suite 172/172
- `spec/integration/simple/create_account_rate_limit_spec.rb` — 8 examples through the real middleware stack
- `spec/integration/simple/` + account logic specs — 107 examples, 0 failures
- `bin/ots ratelimit keys create_account_ip <masked-ip>` emits the right commands; the kind appears in the limiter list
- `scripts/check-env-reference.sh` — PASS (361 consumed, 347 documented)

### Not done here

The audit notes an adjacent dead control on the same class: the `skill` honeypot is captured at `create_account.rb:39` and never read anywhere. Wiring it changes signup behaviour for anyone whose client populates that field, so it wants its own change and its own tests.