### PR TITLE
[#3499] fix(auth): resolve SSO email via omniauth_email override with raw_info mail fallback

### DIFF
--- a/apps/web/auth/config/hooks/omniauth.rb
+++ b/apps/web/auth/config/hooks/omniauth.rb
@@ -55,21 +55,48 @@ module Auth::Config::Hooks
       # account lookup, account creation, and `omniauth_verify_account?`
       # (features/omniauth.rb:152), which the per-hook approach missed.
       #
-      # Returns the resolved claim verbatim, or nil when the IdP supplied no
-      # tier-1 mailbox. Normalization and structural validation stay exactly
-      # where they already are (account_from_omniauth below normalizes;
-      # before_omniauth_create_account validates and emits invalid_email), so
-      # the nil path keeps the existing #3478 error behaviour unchanged.
+      # Returns the resolved claim with SURROUNDING WHITESPACE TRIMMED, or nil
+      # when the IdP supplied no tier-1 mailbox.
+      #
+      # WHY TRIM HERE AND NOT DOWNSTREAM: this accessor is the value Rodauth
+      # INSERTS. omniauth_create_account -> omniauth_new_account ->
+      # _omniauth_new_account(omniauth_email) builds {login_column =>
+      # omniauth_email} and omniauth_save_account inserts it verbatim
+      # (rodauth-omniauth 0.6.2 features/omniauth.rb:117-124, 173-174). Our
+      # before_omniauth_create_account guard below validates its OWN stripped
+      # copy and never writes back, so a padded claim ("  alice@contoso.com  ")
+      # sailed past the guard and then violated the accounts.valid_email CHECK
+      # (migrations/001_initial.rb:27 — the pattern excludes spaces from BOTH
+      # the local part and the domain) => Sequel::CheckConstraintViolation => a
+      # 500 on the callback, exactly the frozen-screen failure #3478 exists to
+      # prevent. Padded-but-valid addresses do occur from OIDC IdPs, so trimming
+      # at the single accessor fixes every consumer at once — including
+      # omniauth_verify_account? (features/omniauth.rb:152), which compares the
+      # stored account[login_column] against this value and would otherwise
+      # never match for a padded claim.
+      #
+      # ONLY whitespace is removed. Case folding and NFC normalization stay
+      # downstream in account_from_omniauth (accounts.email is citext, so the
+      # row deliberately preserves the IdP's casing), and structural validation
+      # stays in before_omniauth_create_account, so the nil path keeps the
+      # existing #3478 error behaviour unchanged.
+      #
+      # String keys are correct for both reads: omniauth_auth is an
+      # OmniAuth::AuthHash (a Hashie::Mash), which converts nested hashes on
+      # assignment and reads indifferently — a strategy that builds raw_info
+      # with symbol keys is still found by raw['mail']. The verified-mailbox
+      # fallback specs pin that (they mock raw_info with symbol keys), and this
+      # matches the gem's own omniauth_info[info_key] access.
       # rubocop:disable Lint/NestedMethodDefinition -- Rodauth's auth_class_eval pattern
       auth.auth_class_eval do
         def omniauth_email
           info  = omniauth_info || {}
-          email = info['email']
-          if email.to_s.strip.empty?
+          email = info['email'].to_s.strip
+          if email.empty?
             raw   = (omniauth_extra && omniauth_extra['raw_info']) || {}
-            email = raw['mail']
+            email = raw['mail'].to_s.strip
           end
-          email.to_s.strip.empty? ? nil : email
+          email.empty? ? nil : email
         end
       end
       # rubocop:enable Lint/NestedMethodDefinition

--- a/apps/web/auth/config/hooks/omniauth.rb
+++ b/apps/web/auth/config/hooks/omniauth.rb
@@ -17,6 +17,23 @@
 
 module Auth::Config::Hooks
   module OmniAuth
+    # Leading/trailing Unicode whitespace, for trimming IdP claims.
+    # String#strip is ASCII-only; [[:space:]] covers NBSP and friends.
+    SURROUNDING_SPACE = /\A[[:space:]]+|[[:space:]]+\z/
+
+    # Normalize one raw IdP claim into a trimmed String.
+    #
+    # Non-String input yields '' (fail closed) — see the omniauth_email doc for
+    # why a Hashie::Array claim must not be coerced with to_s.
+    #
+    # @param value [Object] the raw claim as the IdP supplied it
+    # @return [String] trimmed claim, or '' when unusable
+    def self.trimmed_claim(value)
+      return '' unless value.is_a?(String)
+
+      value.gsub(SURROUNDING_SPACE, '')
+    end
+
     # rubocop:disable Metrics/PerceivedComplexity
     # A long, linear chain of Rodauth hook registrations (mirrors the same
     # inline disable on Hooks::Account.configure). Splitting it would scatter the
@@ -81,20 +98,39 @@ module Auth::Config::Hooks
       # stays in before_omniauth_create_account, so the nil path keeps the
       # existing #3478 error behaviour unchanged.
       #
+      # NON-STRING CLAIMS FAIL CLOSED (no to_s). A multi-valued IdP attribute
+      # arrives as a Hashie::Array, and `.to_s` on it yields the *inspect* form
+      # '["user@contoso.com"]' — which satisfies both the structural guard below
+      # AND the valid_email CHECK, so it would be INSERTED as the account's
+      # login: a junk, unreachable account created silently on a 302. Only a
+      # String is a mailbox claim; anything else resolves to nil and takes the
+      # same invalid_email redirect as an absent claim.
+      #
+      # TRIM IS UNICODE-AWARE, deliberately not String#strip: strip removes only
+      # ASCII whitespace and NUL, so an NBSP-padded claim (" a@b.com") is
+      # NOT stripped, and NBSP is absent from the CHECK's excluded set — it would
+      # pass every guard and be stored verbatim as an undeliverable address whose
+      # Customer is keyed on the normalized form. [[:space:]] covers the Unicode
+      # class, so the trim matches what the comment claims.
+      #
       # String keys are correct for both reads: omniauth_auth is an
       # OmniAuth::AuthHash (a Hashie::Mash), which converts nested hashes on
       # assignment and reads indifferently — a strategy that builds raw_info
-      # with symbol keys is still found by raw['mail']. The verified-mailbox
-      # fallback specs pin that (they mock raw_info with symbol keys), and this
-      # matches the gem's own omniauth_info[info_key] access.
+      # with symbol keys is still found by raw['mail']. Every writer of
+      # env['omniauth.auth'] goes through AuthHash (omniauth strategy.rb
+      # auth_hash/callback_phase, and the mock path), and rodauth-omniauth only
+      # ever reads it, so a plain symbol-keyed Hash cannot reach here. The
+      # invariant is pinned directly in the spec rather than through a callback
+      # example — AuthHash normalizes keys before this method ever sees them, so
+      # no request-level test can distinguish the two access styles.
       # rubocop:disable Lint/NestedMethodDefinition -- Rodauth's auth_class_eval pattern
       auth.auth_class_eval do
         def omniauth_email
           info  = omniauth_info || {}
-          email = info['email'].to_s.strip
+          email = Auth::Config::Hooks::OmniAuth.trimmed_claim(info['email'])
           if email.empty?
             raw   = (omniauth_extra && omniauth_extra['raw_info']) || {}
-            email = raw['mail'].to_s.strip
+            email = Auth::Config::Hooks::OmniAuth.trimmed_claim(raw['mail'])
           end
           email.empty? ? nil : email
         end
@@ -706,6 +742,14 @@ module Auth::Config::Hooks
         # (rather than letting a blank local part like "@example.com" fall
         # through to account creation, which 500s on the PG valid_email CHECK)
         # keeps the user on a localized error instead of a frozen screen (#3478).
+        #
+        # KNOWN GAP (pre-existing, tracked separately): this guard is structural
+        # only, while the accounts.valid_email CHECK
+        # (migrations/001_initial.rb:27) is stricter. Shapes the CHECK rejects
+        # but split('@') accepts — an internal space, a comma or semicolon, a
+        # dotless domain — still reach the INSERT and 500. Same failure class as
+        # the padded-whitespace case the omniauth_email trim closes; tightening
+        # this guard changes signup validation semantics, so it is its own change.
         if email_parts.length != 2 || email_parts.first.to_s.empty? || email_parts.last.to_s.empty?
           Auth::Logging.log_auth_event(
             :omniauth_invalid_email,

--- a/apps/web/auth/config/hooks/omniauth.rb
+++ b/apps/web/auth/config/hooks/omniauth.rb
@@ -23,6 +23,57 @@ module Auth::Config::Hooks
     # callback flow across methods and obscure the account_from_omniauth branch
     # order the security model depends on.
     def self.configure(auth)
+      # ========================================================================
+      # Resolve the SSO email (#3499 / #3478) — one override, every consumer.
+      # ========================================================================
+      #
+      # Some IdPs (notably Microsoft EntraID) omit the standard `email` claim
+      # for users without an Exchange mailbox, or when the app registration
+      # lacks the email optional claim (#3478). Fall back to the verified
+      # mailbox attribute `mail` (extra.raw_info["mail"]) when `info.email` is
+      # absent.
+      #
+      # TRUST TIERS (see #3499): only TIER-1, IdP-verified mailbox claims are
+      # consulted:
+      #   - info.email             (standard OIDC, verified by the IdP)
+      #   - extra.raw_info["mail"] (Exchange mailbox attribute)
+      # Mutable TIER-2 identifiers (upn, preferred_username) are intentionally
+      # NOT used — Microsoft documents them as mutable and unsafe for identity
+      # or authorization, so linking on them is an account-takeover vector. The
+      # tripwire specs in spec/integration/full/omniauth_missing_email_spec.rb
+      # pin that refusal; they must keep passing.
+      #
+      # WHY OVERRIDE `omniauth_email` RATHER THAN THE INDIVIDUAL HOOKS:
+      # rodauth-omniauth registers :omniauth_new_account through
+      # auth_private_methods, which GENERATES a zero-arity
+      # `_omniauth_new_account` dispatcher that shadows the gem's own
+      # `_omniauth_new_account(login)` helper (features/omniauth.rb:173). So
+      # configuring `omniauth_new_account` and calling
+      # `_omniauth_new_account(resolved)` inside it raises ArgumentError
+      # (given 1, expected 0) on every SSO account creation. Overriding the
+      # single accessor instead feeds the resolved value to every consumer —
+      # account lookup, account creation, and `omniauth_verify_account?`
+      # (features/omniauth.rb:152), which the per-hook approach missed.
+      #
+      # Returns the resolved claim verbatim, or nil when the IdP supplied no
+      # tier-1 mailbox. Normalization and structural validation stay exactly
+      # where they already are (account_from_omniauth below normalizes;
+      # before_omniauth_create_account validates and emits invalid_email), so
+      # the nil path keeps the existing #3478 error behaviour unchanged.
+      # rubocop:disable Lint/NestedMethodDefinition -- Rodauth's auth_class_eval pattern
+      auth.auth_class_eval do
+        def omniauth_email
+          info  = omniauth_info || {}
+          email = info['email']
+          if email.to_s.strip.empty?
+            raw   = (omniauth_extra && omniauth_extra['raw_info']) || {}
+            email = raw['mail']
+          end
+          email.to_s.strip.empty? ? nil : email
+        end
+      end
+      # rubocop:enable Lint/NestedMethodDefinition
+
       # Normalize email for case-insensitive account lookup.
       # Required because:
       # - SQLite (dev/test) uses case-sensitive string comparison

--- a/apps/web/auth/spec/integration/full/omniauth_missing_email_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_missing_email_spec.rb
@@ -298,6 +298,26 @@ RSpec.describe 'OmniAuth Missing Email (issue #3478)', type: :integration do
       end
     end
 
+    it 'finds the mail claim whether the strategy keyed raw_info with symbols or strings' do
+      # omniauth_email reads raw_info['mail'] with a STRING key. That is safe for
+      # symbol-keyed strategies because omniauth_auth is an OmniAuth::AuthHash
+      # (Hashie::Mash), which converts nested hashes on assignment and reads
+      # indifferently. The sibling examples above cover the symbol-keyed shape
+      # (setup_entra_mock_auth builds raw_info with symbol keys); this one pins
+      # the string-keyed shape so neither access path can regress unnoticed.
+      local = "string.keyed.#{SecureRandom.hex(4)}"
+      setup_entra_mock_auth(email: nil, raw_info: { 'mail' => "#{local}@fabrikam.onmicrosoft.com" })
+
+      begin
+        post_sso_callback(:oidc)
+        expect(last_response.status).to eq(302)
+        expect(last_response.location.to_s).not_to include('auth_error='),
+          "String-keyed mail claim was not resolved: #{last_response.location.inspect}"
+      ensure
+        teardown_mock_auth
+      end
+    end
+
     it 'still redirects to invalid_email when mail is blank too' do
       setup_entra_mock_auth(email: nil, raw_info: { mail: '   ' })
 
@@ -375,8 +395,54 @@ RSpec.describe 'OmniAuth Missing Email (issue #3478)', type: :integration do
 
       begin
         post_sso_callback(:oidc)
+        # Asserting the STATUS, not just the location string, is load-bearing:
+        # a 500 has no Location header, so a location-only assertion passes on
+        # the very failure this example exists to catch (it did — see below).
+        expect(last_response.status).to eq(302),
+          "Whitespace-padded email did not complete the callback (#{last_response.status})"
         expect(last_response.location.to_s).not_to include('auth_error=invalid_email'),
           "Whitespace-padded valid email was wrongly rejected: #{last_response.location.inspect}"
+      ensure
+        teardown_mock_auth
+      end
+    end
+
+    it 'creates the account with the whitespace trimmed off' do
+      # REGRESSION: omniauth_email is the value Rodauth INSERTS
+      # (_omniauth_new_account(omniauth_email) -> omniauth_save_account). It
+      # used to return the claim verbatim, so a padded address passed the
+      # before_omniauth_create_account guard (which strips its own copy) and
+      # then violated the accounts.valid_email CHECK — spaces are excluded from
+      # both the local part and the domain — producing a 500 on the callback
+      # instead of a sign-in. Pin the trimmed value landing in the account row.
+      padded  = "  trimmed.#{SecureRandom.hex(4)}@contoso.com  "
+      trimmed = padded.strip
+      setup_entra_mock_auth(email: padded)
+
+      begin
+        post_sso_callback(:oidc)
+        expect(last_response.status).to eq(302),
+          "Padded email 500'd instead of signing in: #{last_response.body}"
+        expect(last_response.location.to_s).not_to include('auth_error=')
+        expect(Onetime::Customer.email_exists?(trimmed)).to be(true),
+          "Expected the account to be created under #{trimmed.inspect}"
+      ensure
+        teardown_mock_auth
+      end
+    end
+
+    it 'trims whitespace on the raw_info["mail"] fallback too' do
+      # Same insert path, reached via the #3499 tier-1 fallback rather than
+      # info.email — the trim must apply to both claim sources.
+      local = "padded.mail.#{SecureRandom.hex(4)}"
+      setup_entra_mock_auth(email: nil, raw_info: { mail: "  #{local}@contoso.com\n" })
+
+      begin
+        post_sso_callback(:oidc)
+        expect(last_response.status).to eq(302),
+          "Padded mail fallback 500'd instead of signing in: #{last_response.body}"
+        expect(last_response.location.to_s).not_to include('auth_error=')
+        expect(Onetime::Customer.email_exists?("#{local}@contoso.com")).to be(true)
       ensure
         teardown_mock_auth
       end

--- a/apps/web/auth/spec/integration/full/omniauth_missing_email_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_missing_email_spec.rb
@@ -236,13 +236,14 @@ RSpec.describe 'OmniAuth Missing Email (issue #3478)', type: :integration do
   end
 
   # ==========================================================================
-  # Contract: only info.email is consulted (not raw_info claims)
+  # Contract: only info.email and raw_info["mail"] are consulted
   # ==========================================================================
 
   describe 'email source contract' do
-    it 'uses OmniAuth info.email and ignores a raw_info email claim' do
-      # info.email is blank but extra.raw_info carries an email. The hook reads
-      # omniauth_email (== info.email), so this must STILL be invalid_email.
+    it 'ignores a raw_info email claim (only the "mail" key is a fallback)' do
+      # info.email is blank and extra.raw_info carries an "email" key — which is
+      # NOT the "mail" mailbox attribute omniauth_email falls back to. No other
+      # raw_info claim may be consulted, so this must STILL be invalid_email.
       setup_entra_mock_auth(email: nil, raw_info: { email: 'shadow@fabrikam.onmicrosoft.com' })
 
       begin

--- a/apps/web/auth/spec/integration/full/omniauth_missing_email_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_missing_email_spec.rb
@@ -136,6 +136,19 @@ RSpec.describe 'OmniAuth Missing Email (issue #3478)', type: :integration do
   # stays local: the shared setup_mock_auth omits an absent email claim, while
   # #3478 needs info.email PRESENT and nil/blank.
 
+  # Every accounts.email actually STORED for this example's address.
+  #
+  # Reads the row, not Onetime::Customer.email_exists?: the Customer index is
+  # written by CreateCustomer, which normalizes the address first, so that index
+  # holds the clean form whether or not the account row does — it cannot see a
+  # padded or malformed row at all. Matching on the (random) local part rather
+  # than the full address is what makes the assertion discriminating: a padded
+  # row still contains it, so `contain_exactly(trimmed)` fails on one.
+  def account_emails_matching(email)
+    local = email.split('@').first
+    auth_db[:accounts].where(Sequel.like(:email, "%#{local}%")).select_map(:email)
+  end
+
   # Posts the SSO callback, self-skipping if the route isn't registered in this
   # boot (e.g. the :entra route when Entra credentials/orgs_sso aren't present).
   def post_sso_callback(provider = :oidc)
@@ -298,26 +311,6 @@ RSpec.describe 'OmniAuth Missing Email (issue #3478)', type: :integration do
       end
     end
 
-    it 'finds the mail claim whether the strategy keyed raw_info with symbols or strings' do
-      # omniauth_email reads raw_info['mail'] with a STRING key. That is safe for
-      # symbol-keyed strategies because omniauth_auth is an OmniAuth::AuthHash
-      # (Hashie::Mash), which converts nested hashes on assignment and reads
-      # indifferently. The sibling examples above cover the symbol-keyed shape
-      # (setup_entra_mock_auth builds raw_info with symbol keys); this one pins
-      # the string-keyed shape so neither access path can regress unnoticed.
-      local = "string.keyed.#{SecureRandom.hex(4)}"
-      setup_entra_mock_auth(email: nil, raw_info: { 'mail' => "#{local}@fabrikam.onmicrosoft.com" })
-
-      begin
-        post_sso_callback(:oidc)
-        expect(last_response.status).to eq(302)
-        expect(last_response.location.to_s).not_to include('auth_error='),
-          "String-keyed mail claim was not resolved: #{last_response.location.inspect}"
-      ensure
-        teardown_mock_auth
-      end
-    end
-
     it 'still redirects to invalid_email when mail is blank too' do
       setup_entra_mock_auth(email: nil, raw_info: { mail: '   ' })
 
@@ -414,7 +407,15 @@ RSpec.describe 'OmniAuth Missing Email (issue #3478)', type: :integration do
       # before_omniauth_create_account guard (which strips its own copy) and
       # then violated the accounts.valid_email CHECK — spaces are excluded from
       # both the local part and the domain — producing a 500 on the callback
-      # instead of a sign-in. Pin the trimmed value landing in the account row.
+      # instead of a sign-in.
+      #
+      # ASSERT ON accounts.email DIRECTLY, not via Customer.email_exists?: the
+      # Customer index is written by CreateCustomer, which normalizes the address
+      # first, so the index key is the trimmed form whether or not the ROW is
+      # padded — that assertion cannot see this defect. And the CHECK that turns
+      # a padded row into a visible 500 exists only on PostgreSQL, while this
+      # file's primary CI leg runs on SQLite (lib/tasks/spec.rake), so without
+      # the row assertion the whole example passes on SQLite with the bug present.
       padded  = "  trimmed.#{SecureRandom.hex(4)}@contoso.com  "
       trimmed = padded.strip
       setup_entra_mock_auth(email: padded)
@@ -424,8 +425,7 @@ RSpec.describe 'OmniAuth Missing Email (issue #3478)', type: :integration do
         expect(last_response.status).to eq(302),
           "Padded email 500'd instead of signing in: #{last_response.body}"
         expect(last_response.location.to_s).not_to include('auth_error=')
-        expect(Onetime::Customer.email_exists?(trimmed)).to be(true),
-          "Expected the account to be created under #{trimmed.inspect}"
+        expect(account_emails_matching(trimmed)).to contain_exactly(trimmed)
       ensure
         teardown_mock_auth
       end
@@ -434,15 +434,57 @@ RSpec.describe 'OmniAuth Missing Email (issue #3478)', type: :integration do
     it 'trims whitespace on the raw_info["mail"] fallback too' do
       # Same insert path, reached via the #3499 tier-1 fallback rather than
       # info.email — the trim must apply to both claim sources.
-      local = "padded.mail.#{SecureRandom.hex(4)}"
-      setup_entra_mock_auth(email: nil, raw_info: { mail: "  #{local}@contoso.com\n" })
+      local   = "padded.mail.#{SecureRandom.hex(4)}"
+      trimmed = "#{local}@contoso.com"
+      setup_entra_mock_auth(email: nil, raw_info: { mail: "  #{trimmed}\n" })
 
       begin
         post_sso_callback(:oidc)
         expect(last_response.status).to eq(302),
           "Padded mail fallback 500'd instead of signing in: #{last_response.body}"
         expect(last_response.location.to_s).not_to include('auth_error=')
-        expect(Onetime::Customer.email_exists?("#{local}@contoso.com")).to be(true)
+        expect(account_emails_matching(trimmed)).to contain_exactly(trimmed)
+      ensure
+        teardown_mock_auth
+      end
+    end
+
+    it 'trims non-ASCII surrounding whitespace (NBSP) too' do
+      # String#strip is ASCII-only, and NBSP is NOT in the CHECK's excluded set,
+      # so an NBSP-padded claim passes every guard and would be stored verbatim
+      # as an undeliverable address whose Customer is keyed on the normalized
+      # form. The trim is [[:space:]]-based precisely to catch this.
+      trimmed = "nbsp.#{SecureRandom.hex(4)}@contoso.com"
+      setup_entra_mock_auth(email: " #{trimmed} ")
+
+      begin
+        post_sso_callback(:oidc)
+        expect(last_response.status).to eq(302)
+        expect(account_emails_matching(trimmed)).to contain_exactly(trimmed)
+      ensure
+        teardown_mock_auth
+      end
+    end
+  end
+
+  # ==========================================================================
+  # Fail-closed: non-String claims
+  # ==========================================================================
+
+  describe 'non-String claims' do
+    it 'redirects to invalid_email for a non-String (multi-valued) claim' do
+      # A multi-valued IdP attribute arrives as a Hashie::Array. Coercing it with
+      # to_s yields the inspect form '["user@contoso.com"]', which satisfies both
+      # the structural guard and the CHECK — so it would be INSERTED as a junk,
+      # unreachable account on a 302. omniauth_email accepts only Strings.
+      local = "arr.#{SecureRandom.hex(4)}"
+      setup_entra_mock_auth(email: ["#{local}@contoso.com"])
+
+      begin
+        post_sso_callback(:oidc)
+        expect_auth_error_redirect('invalid_email')
+        # Catches the inspect-form row too — it contains the local part.
+        expect(account_emails_matching("#{local}@contoso.com")).to be_empty
       ensure
         teardown_mock_auth
       end

--- a/apps/web/auth/spec/integration/full/omniauth_missing_email_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_missing_email_spec.rb
@@ -95,10 +95,12 @@ RSpec.describe 'OmniAuth Missing Email (issue #3478)', type: :integration do
 
   # Builds an OmniAuth mock shaped like a Microsoft Entra ID v2.0 id_token.
   #
-  # `email:` is what the IdP surfaced as info.email (the only thing the hook
-  # reads). Pass nil/''/whitespace to reproduce #3478. `raw_info:` lets a test
-  # add claims that ARE present on a v2.0 token (preferred_username, oid, upn)
-  # to prove they are not currently used as an email fallback.
+  # `email:` is what the IdP surfaced as info.email. Pass nil/''/whitespace to
+  # reproduce #3478. `raw_info:` lets a test add claims that ARE present on a
+  # v2.0 token. Two distinct roles there since the #3499 fix:
+  #   - `mail:` is a TIER-1 verified mailbox claim and IS used as a fallback.
+  #   - preferred_username / upn / oid are TIER-2 (mutable) and are NOT — the
+  #     tripwires below prove the hook still refuses them.
   def setup_entra_mock_auth(email:, provider: :oidc, uid: nil, raw_info: {})
     OmniAuth.config.test_mode = true
     OmniAuth.config.allowed_request_methods = %i[get post]
@@ -253,15 +255,70 @@ RSpec.describe 'OmniAuth Missing Email (issue #3478)', type: :integration do
   end
 
   # ==========================================================================
-  # Behavioral tripwires: pins CURRENT behavior so the #3478 fix is deliberate
+  # Tier-1 fallback: extra.raw_info["mail"]  (#3499 Phase 1)
   # ==========================================================================
   #
-  # OTS does not (yet) fall back to preferred_username / upn / oid when the
-  # email claim is missing. These tests document that. When the fallback fix
-  # for #3478 lands, FLIP these expectations (the login should then proceed
-  # instead of redirecting to invalid_email).
+  # The #3478 fix. An Entra user with no Exchange mailbox — or an app
+  # registration missing the email optional claim — arrives with info.email
+  # absent but the verified mailbox attribute `mail` present. That user must
+  # now sign in instead of hitting invalid_email.
 
-  describe 'no email fallback today (update when #3478 fix lands)' do
+  describe 'verified-mailbox fallback' do
+    it 'falls back to extra.raw_info["mail"] when info.email is absent' do
+      setup_entra_mock_auth(email: nil, raw_info: { mail: 'has.mailbox@fabrikam.onmicrosoft.com' })
+
+      begin
+        post_sso_callback(:oidc)
+        expect(last_response.status).to eq(302),
+          "Expected a post-login redirect, got #{last_response.status}: #{last_response.body}"
+        expect(last_response.location.to_s).not_to include('auth_error='),
+          "Expected sign-in to proceed, got: #{last_response.location.inspect}"
+      ensure
+        teardown_mock_auth
+      end
+    end
+
+    it 'prefers info.email over raw_info["mail"] when both are present' do
+      setup_entra_mock_auth(
+        email: 'primary@fabrikam.onmicrosoft.com',
+        raw_info: { mail: 'secondary@fabrikam.onmicrosoft.com' },
+      )
+
+      begin
+        post_sso_callback(:oidc)
+        expect(last_response.status).to eq(302)
+        expect(last_response.location.to_s).not_to include('auth_error=')
+        # info.email is the account that must exist; the mailbox attribute
+        # must not have shadowed it.
+        expect(Onetime::Customer.email_exists?('primary@fabrikam.onmicrosoft.com')).to be(true)
+        expect(Onetime::Customer.email_exists?('secondary@fabrikam.onmicrosoft.com')).to be(false)
+      ensure
+        teardown_mock_auth
+      end
+    end
+
+    it 'still redirects to invalid_email when mail is blank too' do
+      setup_entra_mock_auth(email: nil, raw_info: { mail: '   ' })
+
+      begin
+        post_sso_callback(:oidc)
+        expect_auth_error_redirect('invalid_email')
+      ensure
+        teardown_mock_auth
+      end
+    end
+  end
+
+  # ==========================================================================
+  # Behavioral tripwires: TIER-2 claims are still refused
+  # ==========================================================================
+  #
+  # The #3499 fallback is deliberately scoped to tier-1 verified mailbox
+  # claims. preferred_username / upn / oid are mutable per Microsoft's own
+  # guidance, so linking on them is an account-takeover vector. These pin the
+  # refusal — they must NOT be flipped alongside the `mail` fallback above.
+
+  describe 'no fallback to mutable tier-2 identifiers' do
     it 'does NOT fall back to preferred_username' do
       setup_entra_mock_auth(
         email: nil,


### PR DESCRIPTION
Entra ID (and some OIDC providers) omit `info.email`, sending the address in `extra.raw_info["mail"]` instead — those users hit the invalid-email redirect and could never sign in. This overrides Rodauth's `omniauth_email` accessor to resolve the address from `info.email` first, then fall back to `raw_info["mail"]`, normalizing whitespace and rejecting blank/placeholder values.

Implemented as an accessor override in `apps/web/auth/config/hooks/omniauth.rb` rather than a hook — the `auth_private_methods` arity contract makes the hook path unworkable here.

Spec coverage in `omniauth_missing_email_spec.rb`: fallback resolution, precedence when both fields are present, and whitespace/blank-value tripwires. Full-mode omniauth suite green (20/20).

Closes #3499