### PR TITLE
[#3642] Secret Activity: include domain context on org audit events

### DIFF
--- a/apps/api/organizations/logic/organizations/list_audit_events.rb
+++ b/apps/api/organizations/logic/organizations/list_audit_events.rb
@@ -21,7 +21,10 @@ module OrganizationAPI::Logic
     #   receipt/metadata page was loaded — distinct from opening the secret
     #   link itself), 'revealed', 'burned', 'expired', 'orphaned'. Events
     #   carry receipt/secret shortids only — never full identifiers, which
-    #   are capability tokens.
+    #   are capability tokens. Custom-domain shares additionally carry
+    #   domain context: 'domain_id' (8-char shortid) and 'domain' (the
+    #   public FQDN, e.g. secrets.acme.com); both are absent for
+    #   default-domain shares.
     class ListAuditEvents < OrganizationAPI::Logic::Base
       DEFAULT_LIMIT = 50
 

--- a/apps/api/v2/spec/models/organization_audit_trail_spec.rb
+++ b/apps/api/v2/spec/models/organization_audit_trail_spec.rb
@@ -415,6 +415,67 @@ RSpec.describe Onetime::Organization, type: :integration do
     end
   end
 
+  # Domain context on custom-domain shares (#3642). Events for receipts
+  # created through a registered custom domain carry WHERE the share lives:
+  # the domain_id shortid (8 chars, matching the trail-wide shortid policy)
+  # and the public FQDN. Default-domain shares carry neither key -- absent,
+  # not null. The guard is domain_id: share_domain can be set even when no
+  # CustomDomain record resolved, and alone it must not imply one.
+  describe 'domain context on custom-domain shares (#3642)' do
+    # Realistic CustomDomain objid: long enough that the 8-char slice
+    # differs from the full value, so leakage is detectable.
+    let(:domain_id) { '01997b2a8f3e4d5c6b7a8901' }
+
+    before { link_to_org!(receipt, org) }
+
+    it 'carries the domain_id shortid and FQDN for a custom-domain receipt' do
+      receipt.domain_id    = domain_id
+      receipt.share_domain = 'secrets.example.com'
+      receipt.save_fields(:domain_id, :share_domain)
+
+      receipt.record_org_audit_event('created')
+
+      event = org.audit_events_page.first
+      expect(event['domain_id']).to eq(domain_id[0, 8])
+      expect(event['domain']).to eq('secrets.example.com')
+      # Alongside the existing shortid context, not instead of it.
+      expect(event['receipt']).to eq(receipt.shortid)
+      expect(event['secret']).to eq(receipt.secret_shortid)
+    end
+
+    it 'omits both keys entirely for a default-domain receipt' do
+      receipt.record_org_audit_event('created')
+
+      event = org.audit_events_page.first
+      expect(event.keys).not_to include('domain_id', 'domain')
+    end
+
+    it 'omits both keys when share_domain is set without a registered domain' do
+      # index_receipt_to_domain can stamp share_domain with no CustomDomain
+      # resolved; the trail must not fabricate a domain_id-less "custom
+      # domain" event from it.
+      receipt.share_domain = 'secrets.example.com'
+      receipt.save_fields(:share_domain)
+
+      receipt.record_org_audit_event('created')
+
+      event = org.audit_events_page.first
+      expect(event.keys).not_to include('domain_id', 'domain')
+    end
+
+    it 'never leaks the full domain objid into the trail' do
+      receipt.domain_id    = domain_id
+      receipt.share_domain = 'secrets.example.com'
+      receipt.save_fields(:domain_id, :share_domain)
+
+      receipt.record_org_audit_event('secret_get')
+
+      raw = org.audit_events.membersraw.join
+      expect(raw).to include(domain_id[0, 8])
+      expect(raw).not_to include(domain_id)
+    end
+  end
+
   describe 'isolation' do
     let(:other_org) do
       described_class.new(

--- a/apps/api/v2/spec/models/organization_audit_trail_spec.rb
+++ b/apps/api/v2/spec/models/organization_audit_trail_spec.rb
@@ -450,6 +450,20 @@ RSpec.describe Onetime::Organization, type: :integration do
       expect(event.keys).not_to include('domain_id', 'domain')
     end
 
+    it 'omits the domain key when domain_id is set without a share_domain' do
+      # A writer outside spawn_pair (migration, admin tool) can stamp
+      # domain_id alone; the absent-not-null contract applies per key, so
+      # the event must not carry 'domain' => nil.
+      receipt.domain_id = domain_id
+      receipt.save_fields(:domain_id)
+
+      receipt.record_org_audit_event('created')
+
+      event = org.audit_events_page.first
+      expect(event['domain_id']).to eq(domain_id[0, 8])
+      expect(event.keys).not_to include('domain')
+    end
+
     it 'omits both keys when share_domain is set without a registered domain' do
       # index_receipt_to_domain can stamp share_domain with no CustomDomain
       # resolved; the trail must not fabricate a domain_id-less "custom

--- a/lib/onetime/models/receipt/features/access_timeline.rb
+++ b/lib/onetime/models/receipt/features/access_timeline.rb
@@ -130,7 +130,12 @@ module Onetime::Receipt::Features
         domain_attrs = if domain_id.to_s.empty?
                          {}
                        else
-                         { 'domain_id' => domain_id.to_s.slice(0, 8), 'domain' => share_domain }
+                         # share_domain can be unset even when domain_id is
+                         # stamped (writers outside spawn_pair); the
+                         # absent-not-null contract applies per key.
+                         attrs           = { 'domain_id' => domain_id.to_s.slice(0, 8) }
+                         attrs['domain'] = share_domain unless share_domain.to_s.empty?
+                         attrs
                        end
 
         organization.record_audit_event(

--- a/lib/onetime/models/receipt/features/access_timeline.rb
+++ b/lib/onetime/models/receipt/features/access_timeline.rb
@@ -122,18 +122,31 @@ module Onetime::Receipt::Features
         organization ||= Onetime::Organization.load(org_id) unless org_id.to_s.empty?
         return if organization.nil?
 
+        # Domain context for custom-domain shares (#3642): the domain_id
+        # shortid plus the public FQDN. Keyed on domain_id -- the strict
+        # "registered custom domain" signal (share_domain can be set without a
+        # resolved CustomDomain). Absent entirely, never null, for
+        # default-domain shares.
+        domain_attrs = if domain_id.to_s.empty?
+                         {}
+                       else
+                         { 'domain_id' => domain_id.to_s.slice(0, 8), 'domain' => share_domain }
+                       end
+
         organization.record_audit_event(
           kind,
           at: at,
           **event_attrs,
           # Shortids only: full identifiers are capability tokens (the
-          # secret identifier IS the link) and must not leak into the trail.
-          # Placed AFTER the splat so these canonical fields always win over a
-          # caller-supplied attr sharing the same key -- a composed caller
-          # (#3639 actor, #3640 network context) can never override the
-          # receipt/secret identity of the event it is annotating.
+          # secret identifier IS the link; a full domain objid is likewise
+          # withheld) and must not leak into the trail. Placed AFTER the splat
+          # so these canonical fields always win over a caller-supplied attr
+          # sharing the same key -- a composed caller (#3639 actor, #3640
+          # network context) can never override the receipt/secret/domain
+          # identity of the event it is annotating.
           'receipt' => shortid,
           'secret' => secret_shortid.to_s,
+          **domain_attrs,
         )
       rescue StandardError => ex
         OT.le "[audit-trail] #{ex.class}: #{ex.message} (kind=#{kind}, receipt=#{shortid})"


### PR DESCRIPTION
Closes #3642. Part of the event-side capture work for the org audit trail (#3633).

## Change

`Receipt#record_org_audit_event` now stamps org audit events with domain context for custom-domain shares:

- `domain_id` — 8-char shortid slice of the CustomDomain objid, matching the trail's existing `receipt`/`secret`/`actor_id` shortid posture (full identifiers are capability tokens and stay out of the trail).
- `domain` — the public FQDN from `receipt.share_domain` (already safe-dumped; the UI filter/render label).

Both keys are **absent entirely** for default-domain shares (absent-not-null, per the #3640 convention), and the guard keys on `domain_id` — the strict "registered custom domain" signal, since `share_domain` can be set without a resolved CustomDomain record.

Why both identifiers: events are not backfillable. A shortid alone can't be rendered as a hostname once a CustomDomain is deleted; a hostname alone is ambiguous across re-registrations. Capturing both now is what saves the migration later.

Placed after the caller splat alongside the existing canonical fields, so composed callers (#3639 actor, #3640 network context) can never override the event's domain identity. Zero extra Redis reads — both fields are persisted on the receipt, so creation-time (in-memory) and lifecycle (fresh-load) paths both work.

## Also

- `ListAuditEvents` doc comment updated (was "receipt/secret shortids only").

## Testing

New describe block in `organization_audit_trail_spec.rb` (4 examples): round-trip through `audit_events_page`, absence for default-domain receipts, absence when `share_domain` is set without `domain_id`, and non-leakage of the full domain objid from raw sorted-set members.

`bundle exec rspec apps/api/v2/spec/models/organization_audit_trail_spec.rb apps/api/v2/spec/models/receipt_access_timeline_spec.rb` — 65 examples, 0 failures.