### PR TITLE
*Add ORGS_AUDIT_LOGS_ENABLED instance flag to exclude the org activity trail

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -609,6 +609,12 @@ ORGS_CUSTOM_MAIL_ENABLED=false
 # sent to the domain are routed to the organization's inbox.
 ORGS_INCOMING_SECRETS_ENABLED=false
 
+# When enabled (the default), organizations with the audit_logs entitlement
+# can view their secret activity trail (UI + list API). Unlike the flags
+# above, this defaults ON because the trail works out of the box — set to
+# false to exclude the feature. Event collection is not affected.
+ORGS_AUDIT_LOGS_ENABLED=true
+
 # ═══════════════════════════════════════════════════════════
 #  CUSTOM MAIL SENDER DNS SETTINGS
 # ═══════════════════════════════════════════════════════════

--- a/.env.reference
+++ b/.env.reference
@@ -1107,8 +1107,12 @@ TRUSTED_PROXY_ENABLED=false
 #   X-Forwarded-For with the real peer address, otherwise a client-supplied
 #   entry is returned as the client IP and IP rate limits/bans are spoofable:
 #     nginx:  proxy_set_header X-Forwarded-For $remote_addr;
-#     Caddy:  header_up X-Forwarded-For {remote_host}
-#   Use depth mode when you cannot make the edge overwrite.
+#     Caddy:  header_up X-Forwarded-For {client_ip}
+#   ({client_ip} honours Caddy's own trusted_proxies, so it resolves the real
+#   visitor when Caddy is itself behind a declared CDN; with none declared it
+#   is the direct peer, same as {remote_host}. See etc/examples/Caddyfile-example.)
+#   Use depth mode when you cannot make the edge overwrite. Do NOT combine the
+#   overwrite above with depth mode: it collapses the chain that depth counts.
 #
 #   Note: filter mode ignores TRUSTED_PROXY_HEADER and reads the
 #   X-Forwarded-For family (X-Forwarded-For, X-Real-IP, X-Client-IP).

--- a/.env.reference
+++ b/.env.reference
@@ -1082,8 +1082,17 @@ FOOTER_VERSION_ENABLED=true
 # client access is blocked by firewall, and the proxy strips/overwrites
 # client-provided forwarding headers.
 
-# Master switch. When false (default), all forwarded headers are ignored
-# and REMOTE_ADDR is used directly.
+# Turns proxy-aware IP resolution on. The mode, CIDR, and depth settings
+# below do nothing while this is false.
+#
+# When false (default), forwarded headers are ignored and the client IP is
+# REMOTE_ADDR (the address that opened the connection). That is right only
+# when clients connect to the app directly: put a proxy in front and
+# REMOTE_ADDR is the proxy, so every request looks like it came from one
+# address. When true, the client IP is read out of the forwarded headers
+# using the mode below. Behind a proxy you trust, set this to true. Behind one
+# you don't trust to overwrite X-Forwarded-For, set true and set the mode
+# below to depth, which picks the client by its position in the chain.
 TRUSTED_PROXY_ENABLED=false
 
 # How to resolve client IP behind proxies. Default: filter.
@@ -1109,9 +1118,27 @@ TRUSTED_PROXY_ENABLED=false
 #   when you need deterministic hop selection regardless of IP class.
 TRUSTED_PROXY_MODE=filter
 
-# Which header to read the forwarding chain from. Default: X-Forwarded-For.
-# One of: X-Forwarded-For, Forwarded (RFC 7239), Both (Forwarded first,
-# then fall back to X-Forwarded-For).
+# depth mode only: which header to read the forwarding chain from.
+# Default: X-Forwarded-For. The accepted set is closed — exactly one of:
+# - X-Forwarded-For  the de facto standard, written by nginx, Caddy, HAProxy,
+#                    ALB/ELB, Cloudflare, Fastly, and most k8s ingresses
+# - Forwarded        RFC 7239 (for=/by=/proto=), emitted by HAProxy and Apache
+#                    when configured for it; still uncommon in practice
+# - Both             read Forwarded first, fall back to X-Forwarded-For
+# Case-insensitive, so `forwarded` is accepted and canonicalized. Any other
+# value fails the boot with an ArgumentError rather than silently resolving
+# from the wrong header.
+#
+# Vendor client-IP headers are NOT selectable here — CF-Connecting-IP,
+# True-Client-IP and friends are never read for client-IP resolution. They
+# also carry a single address rather than a chain, so there are no hops to
+# count. (Vendor GEO headers such as CF-IPCountry are a separate concern with
+# its own resolution path; this setting does not affect them.) If your
+# edge only sets one of those, have it write the chain into X-Forwarded-For:
+#   Cloudflare: enable "Add visitor IP headers" (sets X-Forwarded-For), or
+#   transform-rule X-Forwarded-For = cf.connecting_ip
+# Filter mode ignores this setting entirely and reads the X-Forwarded-For
+# family (X-Forwarded-For, X-Real-IP, X-Client-IP).
 TRUSTED_PROXY_HEADER=X-Forwarded-For
 
 # filter mode only: additional CIDR ranges to trust as proxies beyond the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,17 @@ turn; ask only when irreversible.
 
 When context gets large: write current state to tasks/mission.md. Include: what's done, what's next, what's blocked, any open questions. The next session should be able to continue from tasks/mission.md without reading the full history.
 
+### Using git
+
+NEVER AMEND, RESTORE or REBASE unless asked.
+
+Use `--no-pager` to avoid hanging on paging. Pipe to head or tail if you suspect a large output. For example:
+
+```bash
+git --no-pager diff
+git --no-pager show abcd1234 | head -n 20
+```
+
 ### Responses
 
 Use short responses. Write in plain language.

--- a/apps/api/organizations/logic/organizations/list_secret_activity.rb
+++ b/apps/api/organizations/logic/organizations/list_secret_activity.rb
@@ -61,9 +61,19 @@ module OrganizationAPI::Logic
         # key (older config file) counts as enabled. Gates exposure only:
         # event collection (Organization::Features::SecretActivity) is
         # unaffected. Mirrors DomainConfigAuthorization#verify_feature_flag!.
-        if OT.conf.dig('features', 'organizations', 'audit_logs_enabled') == false
+        #
+        # Compared on the string form, same as ConfigSerializer#build_feature_flags:
+        # a hand-edited config that yields the string 'false' must disable BOTH
+        # surfaces. A strict `== false` here would leave the API serving the
+        # trail while the UI hides the tab — the operator would believe the
+        # feature is off while it is still readable.
+        if OT.conf.dig('features', 'organizations', 'audit_logs_enabled').to_s == 'false'
+          # Keyword args reach OT.info's **payload and are emitted as
+          # SemanticLogger structured payload (filterable/alertable), not
+          # concatenated into the message string.
           OT.info '[ListSecretActivity] Authorization denied: audit_logs_enabled feature flag disabled',
-            { extid: @extid, actor: cust&.custid }.to_json
+            extid: @extid,
+            actor: cust&.custid
           raise_form_error('Secret activity is not enabled on this instance', error_type: :forbidden)
         end
 

--- a/apps/api/organizations/logic/organizations/list_secret_activity.rb
+++ b/apps/api/organizations/logic/organizations/list_secret_activity.rb
@@ -55,6 +55,18 @@ module OrganizationAPI::Logic
           )
         end
 
+        # Instance-level exclusion: self-hosted operators can remove the
+        # activity trail from the product with ORGS_AUDIT_LOGS_ENABLED=false.
+        # Default-true contract — only an explicit false disables; a missing
+        # key (older config file) counts as enabled. Gates exposure only:
+        # event collection (Organization::Features::SecretActivity) is
+        # unaffected. Mirrors DomainConfigAuthorization#verify_feature_flag!.
+        if OT.conf.dig('features', 'organizations', 'audit_logs_enabled') == false
+          OT.info '[ListSecretActivity] Authorization denied: audit_logs_enabled feature flag disabled',
+            { extid: @extid, actor: cust&.custid }.to_json
+          raise_form_error('Secret activity is not enabled on this instance', error_type: :forbidden)
+        end
+
         @organization = load_organization(@extid)
 
         # Membership + plan gate in one: materialized entitlements are the

--- a/apps/api/organizations/spec/logic/organizations/list_secret_activity_spec.rb
+++ b/apps/api/organizations/spec/logic/organizations/list_secret_activity_spec.rb
@@ -184,6 +184,53 @@ RSpec.describe OrganizationAPI::Logic::Organizations::ListSecretActivity do
       expect(Onetime::Organization).not_to have_received(:find_by_extid)
     end
 
+    # The denial is an operator-visible security event: extid/actor must land
+    # in OT.info's **payload (structured, filterable) rather than being
+    # concatenated into the message string.
+    it 'logs the denial with a structured payload' do
+      allow(OT).to receive(:conf)
+        .and_return(conf_with_audit_logs_flag('audit_logs_enabled' => false))
+
+      logic.process_params
+      expect { logic.raise_concerns }.to raise_error(Onetime::FormError)
+
+      expect(OT).to have_received(:info).with(
+        a_string_including('audit_logs_enabled feature flag disabled'),
+        hash_including(extid: anything, actor: anything),
+      )
+    end
+
+    # Parity with ConfigSerializer#build_feature_flags: a hand-edited config
+    # can deliver the string 'false' where the shipped ERB emits a real
+    # boolean. If only the serializer handled it, the UI would hide the tab
+    # while this endpoint kept serving the trail.
+    it "rejects when the flag is the string 'false' (hand-edited config)" do
+      allow(OT).to receive(:conf)
+        .and_return(conf_with_audit_logs_flag('audit_logs_enabled' => 'false'))
+
+      logic.process_params
+      expect { logic.raise_concerns }.to raise_error(Onetime::FormError) { |ex|
+        expect(ex.error_type).to eq(:forbidden)
+      }
+      expect(Onetime::Organization).not_to have_received(:find_by_extid)
+    end
+
+    it "proceeds when the flag is the string 'true'" do
+      allow(OT).to receive(:conf)
+        .and_return(conf_with_audit_logs_flag('audit_logs_enabled' => 'true'))
+
+      logic.process_params
+      expect { logic.raise_concerns }.not_to raise_error
+    end
+
+    it 'counts nil as enabled (default-true contract)' do
+      allow(OT).to receive(:conf)
+        .and_return(conf_with_audit_logs_flag('audit_logs_enabled' => nil))
+
+      logic.process_params
+      expect { logic.raise_concerns }.not_to raise_error
+    end
+
     it 'proceeds when the flag is explicitly true' do
       allow(OT).to receive(:conf)
         .and_return(conf_with_audit_logs_flag('audit_logs_enabled' => true))

--- a/apps/api/organizations/spec/logic/organizations/list_secret_activity_spec.rb
+++ b/apps/api/organizations/spec/logic/organizations/list_secret_activity_spec.rb
@@ -162,6 +162,44 @@ RSpec.describe OrganizationAPI::Logic::Organizations::ListSecretActivity do
     end
   end
 
+  # Instance-level exclusion (ORGS_AUDIT_LOGS_ENABLED). Default-true contract:
+  # only an explicit false disables — an absent key (older config file) must
+  # count as enabled. The check gates exposure only; SecretActivity collection
+  # is out of scope here.
+  describe 'instance feature flag' do
+    def conf_with_audit_logs_flag(orgs_features)
+      base     = OT.conf
+      features = (base['features'] || {}).merge('organizations' => orgs_features)
+      base.merge('features' => features)
+    end
+
+    it 'rejects with forbidden before loading the org when the flag is false' do
+      allow(OT).to receive(:conf)
+        .and_return(conf_with_audit_logs_flag('audit_logs_enabled' => false))
+
+      logic.process_params
+      expect { logic.raise_concerns }.to raise_error(Onetime::FormError) { |ex|
+        expect(ex.error_type).to eq(:forbidden)
+      }
+      expect(Onetime::Organization).not_to have_received(:find_by_extid)
+    end
+
+    it 'proceeds when the flag is explicitly true' do
+      allow(OT).to receive(:conf)
+        .and_return(conf_with_audit_logs_flag('audit_logs_enabled' => true))
+
+      logic.process_params
+      expect { logic.raise_concerns }.not_to raise_error
+    end
+
+    it 'counts an absent key as enabled (default-true contract)' do
+      allow(OT).to receive(:conf).and_return(conf_with_audit_logs_flag({}))
+
+      logic.process_params
+      expect { logic.raise_concerns }.not_to raise_error
+    end
+  end
+
   describe 'response shape' do
     it 'returns the page newest-first with count, total, and paging details' do
       logic.process_params

--- a/apps/web/core/spec/views/serializers/config_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/config_serializer_spec.rb
@@ -1122,6 +1122,58 @@ RSpec.describe Core::Views::ConfigSerializer do
             expect(orgs['incoming_secrets_enabled']).to be false
           end
         end
+
+        # Defense-in-depth for hand-edited config files: a YAML loader (or a
+        # quoted value) can deliver the string 'false' where the shipped ERB
+        # emits a real boolean. Ruby's 'false' != false is true, so a raw
+        # comparison would silently re-enable the flag against operator intent.
+        context "when the string 'false' (hand-edited config)" do
+          let(:view_vars_string_false) do
+            base_view_vars.merge(
+              'features' => base_view_vars['features'].merge(
+                'organizations' => { 'enabled' => true, 'audit_logs_enabled' => 'false' }
+              )
+            )
+          end
+
+          it 'treats it as disabled' do
+            result = described_class.build_feature_flags(view_vars_string_false)
+
+            expect(result['organizations']['audit_logs_enabled']).to be false
+          end
+        end
+
+        context "when the string 'true'" do
+          let(:view_vars_string_true) do
+            base_view_vars.merge(
+              'features' => base_view_vars['features'].merge(
+                'organizations' => { 'enabled' => true, 'audit_logs_enabled' => 'true' }
+              )
+            )
+          end
+
+          it 'stays enabled' do
+            result = described_class.build_feature_flags(view_vars_string_true)
+
+            expect(result['organizations']['audit_logs_enabled']).to be true
+          end
+        end
+
+        context 'when nil (key present, no value)' do
+          let(:view_vars_nil_audit_logs) do
+            base_view_vars.merge(
+              'features' => base_view_vars['features'].merge(
+                'organizations' => { 'enabled' => true, 'audit_logs_enabled' => nil }
+              )
+            )
+          end
+
+          it 'stays enabled (default-true contract)' do
+            result = described_class.build_feature_flags(view_vars_nil_audit_logs)
+
+            expect(result['organizations']['audit_logs_enabled']).to be true
+          end
+        end
       end
     end
   end

--- a/apps/web/core/spec/views/serializers/config_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/config_serializer_spec.rb
@@ -1068,6 +1068,61 @@ RSpec.describe Core::Views::ConfigSerializer do
           expect(orgs['incoming_secrets_enabled']).to be true
         end
       end
+
+      # audit_logs_enabled inverts the sibling default: it is an opt-out
+      # exclusion (ORGS_AUDIT_LOGS_ENABLED=false), so a missing key — e.g.
+      # an install running an older config file — must still read as true.
+      describe 'audit_logs_enabled (default-true contract)' do
+        context 'when the key is absent (older config file)' do
+          it 'defaults to true, unlike sibling flags' do
+            result = described_class.build_feature_flags(base_view_vars)
+
+            expect(result['organizations']['audit_logs_enabled']).to be true
+          end
+        end
+
+        context 'when explicitly true' do
+          let(:view_vars_with_audit_logs) do
+            base_view_vars.merge(
+              'features' => base_view_vars['features'].merge(
+                'organizations' => { 'enabled' => true, 'audit_logs_enabled' => true }
+              )
+            )
+          end
+
+          it 'includes audit_logs_enabled as true' do
+            result = described_class.build_feature_flags(view_vars_with_audit_logs)
+
+            expect(result['organizations']['audit_logs_enabled']).to be true
+          end
+        end
+
+        context 'when explicitly false (operator opt-out)' do
+          let(:view_vars_without_audit_logs) do
+            base_view_vars.merge(
+              'features' => base_view_vars['features'].merge(
+                'organizations' => { 'enabled' => true, 'audit_logs_enabled' => false }
+              )
+            )
+          end
+
+          it 'includes audit_logs_enabled as false' do
+            result = described_class.build_feature_flags(view_vars_without_audit_logs)
+
+            expect(result['organizations']['audit_logs_enabled']).to be false
+          end
+
+          it 'does not affect other organization flags' do
+            result = described_class.build_feature_flags(view_vars_without_audit_logs)
+            orgs = result['organizations']
+
+            expect(orgs['enabled']).to be true
+            expect(orgs['sso_enabled']).to be false
+            expect(orgs['custom_mail_enabled']).to be false
+            expect(orgs['incoming_secrets_enabled']).to be false
+          end
+        end
+      end
     end
   end
 

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -255,7 +255,9 @@ module Core
               'incoming_secrets_enabled' => features.dig('organizations', 'incoming_secrets_enabled') || false,
               # Default-true contract: only an explicit false disables — a
               # missing key (older config file) must still read as enabled.
-              'audit_logs_enabled' => features.dig('organizations', 'audit_logs_enabled') != false,
+              # Compare on the string form so a hand-edited config that yields
+              # 'false' (quoted/ERB-stringified) still disables the flag.
+              'audit_logs_enabled' => features.dig('organizations', 'audit_logs_enabled').to_s != 'false',
             },
           }
         end

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -253,6 +253,9 @@ module Core
               # could never reach IncomingConfig.ready?. Same canonical/custom
               # split as RecipientResolver / HomepageConfig#incoming_available?.
               'incoming_secrets_enabled' => features.dig('organizations', 'incoming_secrets_enabled') || false,
+              # Default-true contract: only an explicit false disables — a
+              # missing key (older config file) must still read as enabled.
+              'audit_logs_enabled' => features.dig('organizations', 'audit_logs_enabled') != false,
             },
           }
         end

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -465,8 +465,19 @@ site:
     # - Each proxy appends its own IP to the forwarding header
     #
     trusted_proxy:
-      # Master switch. When false, all forwarded headers are ignored
-      # and REMOTE_ADDR is used directly.
+      # Turns proxy-aware IP resolution on. The mode, cidrs, and depth
+      # settings below do nothing while this is false.
+      #
+      # When false, forwarded headers are ignored and the client IP is
+      # REMOTE_ADDR — the address that opened the connection. That is right
+      # only when clients connect to the app directly: put a
+      # proxy in front and REMOTE_ADDR is the proxy, so every request looks
+      # like it came from one address. When true, the client IP is read out
+      # of the forwarded headers using `mode` below. Behind a proxy you
+      # control, you want true. Behind one you cannot configure to overwrite
+      # X-Forwarded-For, set true and set `mode` to depth, which picks the
+      # client by its position in the chain so a forged entry is never
+      # reached.
       enabled: <%= ENV['TRUSTED_PROXY_ENABLED'] == 'true' %>
 
       # How to resolve client IP behind proxies:
@@ -504,11 +515,26 @@ site:
       #
       mode: <%= ENV['TRUSTED_PROXY_MODE'] || 'filter' %>
 
-      # Which header to read the forwarding chain from.
-      # - X-Forwarded-For: Most common (nginx, Caddy, AWS ALB)
+      # Depth mode only: which header to read the forwarding chain from.
+      # The accepted set is closed — exactly one of:
+      # - X-Forwarded-For: Most common (nginx, Caddy, HAProxy, AWS ALB/ELB,
+      #   Cloudflare, Fastly, most k8s ingresses)
       # - Forwarded: RFC 7239 standard; IPv6 addresses are bracketed,
-      #   e.g. for="[2001:db8::1]"
+      #   e.g. for="[2001:db8::1]". HAProxy and Apache can emit it, but it
+      #   remains uncommon in practice
       # - Both: Try Forwarded first, fall back to X-Forwarded-For
+      #
+      # Matched case-insensitively and canonicalized; any other value raises
+      # at boot instead of silently resolving from the wrong header.
+      #
+      # Vendor client-IP headers are NOT selectable — CF-Connecting-IP,
+      # True-Client-IP and friends are never read for client-IP resolution,
+      # and they carry a single address rather than a chain, so there are no
+      # hops to count. (Vendor GEO headers such as CF-IPCountry are a separate
+      # concern with its own resolution path; this setting does not affect
+      # them.) If the edge only sets one of those, have it write the chain
+      # into X-Forwarded-For. Filter mode ignores this setting and reads the
+      # X-Forwarded-For family (X-Forwarded-For, X-Real-IP, X-Client-IP).
       header: <%= ENV['TRUSTED_PROXY_HEADER'] || 'X-Forwarded-For' %>
 
       # Filter mode only: Additional CIDR ranges to trust as proxies

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -747,6 +747,12 @@ features:
     sso_enabled: <%= ENV['ORGS_SSO_ENABLED'] == 'true' %>
     custom_mail_enabled: <%= ENV['ORGS_CUSTOM_MAIL_ENABLED'] == 'true' %>
     incoming_secrets_enabled: <%= ENV['ORGS_INCOMING_SECRETS_ENABLED'] == 'true' %>
+    # Gates exposure (UI + list API) of the organization secret-activity
+    # trail; pairs with the `audit_logs` entitlement. Defaults ON, unlike
+    # the sibling flags above, because the trail ships working out of the
+    # box — this is an opt-out exclusion (ORGS_AUDIT_LOGS_ENABLED=false),
+    # not an opt-in feature. Does not stop event collection.
+    audit_logs_enabled: <%= ENV['ORGS_AUDIT_LOGS_ENABLED'] != 'false' %>
 
 # Main Database Configuration
 redis:

--- a/etc/examples/Caddyfile-example
+++ b/etc/examples/Caddyfile-example
@@ -236,7 +236,15 @@
 			header_up X-Forwarded-Proto {http.request.scheme}
 			header_up X-Geo-Country {http.request.header.X-Geo-Country}
 			header_up X-Original-Host {http.request.host}
-			header_up X-Real-IP {http.request.remote.host}
+
+			# IP Forwarding & TRUSTED_PROXY_ENABLED security:
+			# To safely use TRUSTED_PROXY_ENABLED=true (default 'filter' mode), we must
+			# explicitly overwrite X-Forwarded-For and X-Real-IP with Caddy's resolved
+			# client IP. If we do not overwrite X-Forwarded-For, Caddy's default behavior
+			# of appending the client IP allows clients to inject/spoof arbitrary leftmost
+			# IPs into the forwarded header.
+			header_up X-Forwarded-For {client_ip}
+			header_up X-Real-IP {client_ip}
 
 			# Filter request headers to prevent header smuggling
 			header_down -Server

--- a/etc/examples/Caddyfile-example
+++ b/etc/examples/Caddyfile-example
@@ -243,6 +243,24 @@
 			# client IP. If we do not overwrite X-Forwarded-For, Caddy's default behavior
 			# of appending the client IP allows clients to inject/spoof arbitrary leftmost
 			# IPs into the forwarded header.
+			#
+			# {client_ip} honours Caddy's own `trusted_proxies` setting: with none
+			# configured it equals the direct peer ({remote_host}); with a CDN's ranges
+			# declared there it resolves to the real visitor. If Caddy sits behind
+			# another proxy, declare that proxy in `trusted_proxies` or this writes the
+			# upstream's address as the client IP.
+			#
+			# ONLY correct for filter mode. TRUSTED_PROXY_MODE=depth picks the client
+			# by counting TRUSTED_PROXY_DEPTH hops from the RIGHT of the chain, so
+			# collapsing X-Forwarded-For to a single entry leaves nothing to count and
+			# resolution falls back to the wrong address — IP rate limits, audit
+			# attribution, and network restrictions then key on a proxy, not the user.
+			# Running depth mode? Drop the X-Forwarded-For line below and let Caddy
+			# append, preserving the hop chain, and set TRUSTED_PROXY_DEPTH to the
+			# number of hops your topology puts in the chain (see .env.reference).
+			# Depth mode tolerates an untrusted leftmost entry only while that hop
+			# count is fixed and correct — a chain shorter or longer than configured
+			# selects the peer or a client-supplied entry.
 			header_up X-Forwarded-For {client_ip}
 			header_up X-Real-IP {client_ip}
 

--- a/src/apps/workspace/account/settings/OrganizationSettings.vue
+++ b/src/apps/workspace/account/settings/OrganizationSettings.vue
@@ -1,803 +1,849 @@
 <!-- src/apps/workspace/account/settings/OrganizationSettings.vue -->
 
 <script setup lang="ts">
-import EntitlementUpgradePrompt from '@/apps/workspace/components/billing/EntitlementUpgradePrompt.vue';
-import DomainsTable from '@/apps/workspace/components/domains/DomainsTable.vue';
-import MembersTable from '@/apps/workspace/components/members/MembersTable.vue';
-import SecretActivityTable from '@/apps/workspace/components/organizations/SecretActivityTable.vue';
-import { classifyError } from '@/schemas/errors';
-import type { ApplicationError } from '@/schemas/errors';
-import { BillingService } from '@/services/billing.service';
-import ListSkeleton from '@/shared/components/closet/ListSkeleton.vue';
-import SettingsSkeleton from '@/shared/components/closet/SettingsSkeleton.vue';
-import BasicFormAlerts from '@/shared/components/forms/BasicFormAlerts.vue';
-import OIcon from '@/shared/components/icons/OIcon.vue';
-import CopyButton from '@/shared/components/ui/CopyButton.vue';
-import ConfirmDialog from '@/shared/components/modals/ConfirmDialog.vue';
-import EmptyState from '@/shared/components/ui/EmptyState.vue';
-import TableSkeleton from '@/shared/components/closet/TableSkeleton.vue';
-import { useAsyncHandler } from '@/shared/composables/useAsyncHandler';
-import { useDomainsManager } from '@/shared/composables/useDomainsManager';
-import { useEntitlementError } from '@/shared/composables/useEntitlementError';
-import { useEntitlements } from '@/shared/composables/useEntitlements';
-import { useOrgPermissions } from '@/shared/composables/useOrgPermissions';
-import { useResourcePermissions } from '@/shared/composables/useResourcePermissions';
-import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
-import { useMembersStore } from '@/shared/stores/membersStore';
-import { useOrganizationStore } from '@/shared/stores/organizationStore';
-import type { Subscription } from '@/types/billing';
-import { getPlanLabel, getSubscriptionStatusLabel, isFreePlan, isLegacyPlan } from '@/types/billing';
-import type { CreateInvitationPayload, Organization, OrganizationInvitation, OrganizationRole } from '@/types/organization';
-import { INVITATION_STATUSES, effectiveInvitationStatus, invitationStatusLabelKey } from '@/types/organization';
-import { isOrgsSsoEnabled } from '@/utils/features';
-import { formatDisplayDate } from '@/utils/format';
-import { useConfirmDialog, useNow } from '@vueuse/core';
-import { storeToRefs } from 'pinia';
-import { SsoService } from '@/services/sso.service';
-import { computed, nextTick, onMounted, reactive, ref, watch } from 'vue';
-import { useI18n } from 'vue-i18n';
-import { useRoute, useRouter } from 'vue-router';
-import { z } from 'zod';
+  import EntitlementUpgradePrompt from '@/apps/workspace/components/billing/EntitlementUpgradePrompt.vue';
+  import DomainsTable from '@/apps/workspace/components/domains/DomainsTable.vue';
+  import MembersTable from '@/apps/workspace/components/members/MembersTable.vue';
+  import SecretActivityTable from '@/apps/workspace/components/organizations/SecretActivityTable.vue';
+  import { classifyError } from '@/schemas/errors';
+  import type { ApplicationError } from '@/schemas/errors';
+  import { BillingService } from '@/services/billing.service';
+  import ListSkeleton from '@/shared/components/closet/ListSkeleton.vue';
+  import SettingsSkeleton from '@/shared/components/closet/SettingsSkeleton.vue';
+  import BasicFormAlerts from '@/shared/components/forms/BasicFormAlerts.vue';
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import CopyButton from '@/shared/components/ui/CopyButton.vue';
+  import ConfirmDialog from '@/shared/components/modals/ConfirmDialog.vue';
+  import EmptyState from '@/shared/components/ui/EmptyState.vue';
+  import TableSkeleton from '@/shared/components/closet/TableSkeleton.vue';
+  import { useAsyncHandler } from '@/shared/composables/useAsyncHandler';
+  import { useDomainsManager } from '@/shared/composables/useDomainsManager';
+  import { useEntitlementError } from '@/shared/composables/useEntitlementError';
+  import { useEntitlements } from '@/shared/composables/useEntitlements';
+  import { useOrgPermissions } from '@/shared/composables/useOrgPermissions';
+  import { useResourcePermissions } from '@/shared/composables/useResourcePermissions';
+  import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
+  import { useMembersStore } from '@/shared/stores/membersStore';
+  import { useOrganizationStore } from '@/shared/stores/organizationStore';
+  import type { Subscription } from '@/types/billing';
+  import {
+    getPlanLabel,
+    getSubscriptionStatusLabel,
+    isFreePlan,
+    isLegacyPlan,
+  } from '@/types/billing';
+  import type {
+    CreateInvitationPayload,
+    Organization,
+    OrganizationInvitation,
+    OrganizationRole,
+  } from '@/types/organization';
+  import {
+    INVITATION_STATUSES,
+    effectiveInvitationStatus,
+    invitationStatusLabelKey,
+  } from '@/types/organization';
+  import { isOrgsAuditLogsEnabled, isOrgsSsoEnabled } from '@/utils/features';
+  import { formatDisplayDate } from '@/utils/format';
+  import { useConfirmDialog, useNow } from '@vueuse/core';
+  import { storeToRefs } from 'pinia';
+  import { SsoService } from '@/services/sso.service';
+  import { computed, nextTick, onMounted, reactive, ref, watch } from 'vue';
+  import { useI18n } from 'vue-i18n';
+  import { useRoute, useRouter } from 'vue-router';
+  import { z } from 'zod';
 
-type TabType = 'general' | 'members' | 'domains' | 'subscription' | 'sso' | 'activity';
+  type TabType = 'general' | 'members' | 'domains' | 'subscription' | 'sso' | 'activity';
 
-// URL tab names map to internal tab names
-// URL: members -> internal: members (team kept as backwards-compat alias)
-// URL: settings -> internal: general
-// URL: subscription -> internal: subscription (billing kept as backwards-compat alias)
-// URL: sso -> internal: sso
-// URL: activity -> internal: activity
-const URL_TO_TAB: Record<string, TabType> = {
-  members: 'members',
-  team: 'members', // backwards compatibility for old URLs
-  domains: 'domains',
-  subscription: 'subscription',
-  billing: 'subscription', // backwards compatibility for old URLs
-  settings: 'general',
-  sso: 'sso',
-  activity: 'activity',
-};
+  // URL tab names map to internal tab names
+  // URL: members -> internal: members (team kept as backwards-compat alias)
+  // URL: settings -> internal: general
+  // URL: subscription -> internal: subscription (billing kept as backwards-compat alias)
+  // URL: sso -> internal: sso
+  // URL: activity -> internal: activity
+  const URL_TO_TAB: Record<string, TabType> = {
+    members: 'members',
+    team: 'members', // backwards compatibility for old URLs
+    domains: 'domains',
+    subscription: 'subscription',
+    billing: 'subscription', // backwards compatibility for old URLs
+    settings: 'general',
+    sso: 'sso',
+    activity: 'activity',
+  };
 
-const TAB_TO_URL: Record<TabType, string> = {
-  members: 'members',
-  domains: 'domains',
-  subscription: 'subscription',
-  general: 'settings',
-  sso: 'sso',
-  activity: 'activity',
-};
+  const TAB_TO_URL: Record<TabType, string> = {
+    members: 'members',
+    domains: 'domains',
+    subscription: 'subscription',
+    general: 'settings',
+    sso: 'sso',
+    activity: 'activity',
+  };
 
-const props = withDefaults(defineProps<{
-  initialTab?: TabType;
-}>(), {
-  initialTab: 'domains',
-});
+  const props = withDefaults(
+    defineProps<{
+      initialTab?: TabType;
+    }>(),
+    {
+      initialTab: 'domains',
+    }
+  );
 
-const { t } = useI18n();
-const route = useRoute();
-const router = useRouter();
-const organizationStore = useOrganizationStore();
-const membersStore = useMembersStore();
+  const { t } = useI18n();
+  const route = useRoute();
+  const router = useRouter();
+  const organizationStore = useOrganizationStore();
+  const membersStore = useMembersStore();
 
-// Reactive clock so expiry-derived display (invitation status badge + countdown)
-// refreshes on its own instead of going stale until the next user action. Ticks
-// coarsely — these values change on a minute/hour scale, not per frame.
-const now = useNow({ interval: 30_000 });
+  // Reactive clock so expiry-derived display (invitation status badge + countdown)
+  // refreshes on its own instead of going stale until the next user action. Ticks
+  // coarsely — these values change on a minute/hour scale, not per frame.
+  const now = useNow({ interval: 30_000 });
 
-const orgId = computed(() => route.params.extid as string);
+  const orgId = computed(() => route.params.extid as string);
 
-// Resolve initial tab from route param or prop
-const resolveInitialTab = (): TabType => {
-  const urlTab = route.params.tab as string | undefined;
-  if (urlTab && URL_TO_TAB[urlTab]) {
-    return URL_TO_TAB[urlTab];
-  }
-  return props.initialTab;
-};
-const organization = ref<Organization | null>(null);
-const subscription = ref<Subscription | null>(null);
-const invitations = ref<OrganizationInvitation[]>([]);
-
-/**
- * UX Principle: Optimize for frequency of use
- *
- * Tab order and default selection follow the principle that the most frequently
- * performed actions should require the fewest clicks. When users navigate to an
- * organization's detail page, their intent hierarchy is typically:
- *
- *   1. Domains         - Most frequent: managing sender domains for platform operators
- *   2. Members         - Team management: invite members, manage roles, review team
- *   3. Subscription    - Occasional: check plan, view usage, upgrade
- *   4. Settings        - Rare: change org name or billing email (set-and-forget)
- *   5. SSO             - Rarest: configuration that's set once and rarely touched
- *
- * By defaulting to the Domains tab, we eliminate one click for the most common
- * workflow. SSO is placed last since it's configured once during setup and
- * rarely revisited.
- *
- * This aligns with Fitts's Law corollary: reduce interaction cost for frequent
- * actions, accept higher cost for infrequent ones.
- */
-const activeTab = ref<TabType>(resolveInitialTab());
-
-// Update URL when tab changes (without adding history entries)
-const setActiveTab = (tab: TabType) => {
-  activeTab.value = tab;
-  const urlTab = TAB_TO_URL[tab];
-  router.replace({ params: { ...route.params, tab: urlTab } });
-};
-
-// Watch for route param changes (e.g., back/forward navigation).
-// Reject navigation to entitlement-gated tabs the user can't access.
-// NOTE: 'activity' is deliberately NOT in this gated list — the tab stays
-// reachable when unentitled and renders an inline upgrade notice instead.
-watch(
-  () => route.params.tab,
-  (newTab) => {
-    const urlTab = newTab as string | undefined;
+  // Resolve initial tab from route param or prop
+  const resolveInitialTab = (): TabType => {
+    const urlTab = route.params.tab as string | undefined;
     if (urlTab && URL_TO_TAB[urlTab]) {
-      const resolved = URL_TO_TAB[urlTab];
-      if (
-        (resolved === 'members' && !canManageMembers.value) ||
-        (resolved === 'sso' && !canManageSso.value)
-      ) {
-        setActiveTab('domains');
-        return;
-      }
-      activeTab.value = resolved;
-    } else if (!urlTab) {
-      activeTab.value = props.initialTab;
+      return URL_TO_TAB[urlTab];
     }
-  }
-);
+    return props.initialTab;
+  };
+  const organization = ref<Organization | null>(null);
+  const subscription = ref<Subscription | null>(null);
+  const invitations = ref<OrganizationInvitation[]>([]);
 
-// Domains management
-const {
-  isLoading: isLoadingDomains,
-  records: domainRecords,
-  recordCount: domainCount,
-  error: domainsError,
-  refreshRecords: refreshDomains,
-} = useDomainsManager();
+  /**
+   * UX Principle: Optimize for frequency of use
+   *
+   * Tab order and default selection follow the principle that the most frequently
+   * performed actions should require the fewest clicks. When users navigate to an
+   * organization's detail page, their intent hierarchy is typically:
+   *
+   *   1. Domains         - Most frequent: managing sender domains for platform operators
+   *   2. Members         - Team management: invite members, manage roles, review team
+   *   3. Subscription    - Occasional: check plan, view usage, upgrade
+   *   4. Settings        - Rare: change org name or billing email (set-and-forget)
+   *   5. SSO             - Rarest: configuration that's set once and rarely touched
+   *
+   * By defaulting to the Domains tab, we eliminate one click for the most common
+   * workflow. SSO is placed last since it's configured once during setup and
+   * rarely revisited.
+   *
+   * This aligns with Fitts's Law corollary: reduce interaction cost for frequent
+   * actions, accept higher cost for infrequent ones.
+   */
+  const activeTab = ref<TabType>(resolveInitialTab());
 
-// Best practice: Initialize loading states to `true` to prevent uninitialized
-// content, empty states, or gated upgrade notices from briefly flashing on mount.
-const isLoading = ref(true);
-const isSaving = ref(false);
-const isLoadingBilling = ref(false);
-// Billing email editing has been moved to BillingOverview.vue
-const error = ref('');
-const success = ref('');
-const orgNotFound = ref(false);
+  // Update URL when tab changes (without adding history entries)
+  const setActiveTab = (tab: TabType) => {
+    activeTab.value = tab;
+    const urlTab = TAB_TO_URL[tab];
+    router.replace({ params: { ...route.params, tab: urlTab } });
+  };
 
-// Plan data from billing overview
-const planName = ref<string>('');
-const planFeatures = ref<string[]>([]);
-
-const showInviteForm = ref(false);
-const inviteFormData = ref<CreateInvitationPayload>({
-  email: '',
-  role: 'member',
-});
-const inviteErrors = ref<Record<string, string>>({});
-const inviteGeneralError = ref('');
-const inviteUpgradeError = ref<ApplicationError | null>(null);
-const isInviting = ref(false);
-
-const { wrap } = useAsyncHandler({
-  notify: false,
-});
-
-const bootstrapStore = useBootstrapStore();
-const { billing_enabled } = storeToRefs(bootstrapStore);
-const billingEnabled = computed(() => billing_enabled.value ?? false);
-
-// Entitlements - formatEntitlement uses API-driven i18n keys
-const {
-  entitlements,
-  can,
-  formatEntitlement,
-  isStandaloneMode,
-  initDefinitions,
-  ENTITLEMENTS,
-} = useEntitlements(organization);
-
-const sortedEntitlements = computed(() =>
-  [...entitlements.value].sort((a, b) => formatEntitlement(a).localeCompare(formatEntitlement(b)))
-);
-
-// SSO visibility: feature flag AND entitlement must both pass (dual-control)
-const canManageSso = computed(() => isOrgsSsoEnabled() && can(ENTITLEMENTS.MANAGE_SSO));
-
-// Secret Activity (audit trail) — gates the panel CONTENT only, never the
-// tab. Mirrors the backend contract (list_secret_activity.rb): the materialized
-// membership entitlements are plan ∩ role, and audit_logs sits in the
-// admin tier — so a plain member is 403'd server-side even on an entitled
-// plan. org.entitlements in the API payload is the PLAN-level set, so the
-// role must be checked separately here or members mount the table and land
-// in a generic error state.
-const isAuditRoleAllowed = computed(() =>
-  ['owner', 'admin'].includes(organization.value?.current_user_role ?? '')
-);
-const canViewAuditLogs = computed(() => {
-  if (!organization.value) return false;
-  return isAuditRoleAllowed.value && can(ENTITLEMENTS.AUDIT_LOGS);
-});
-
-// Role-based gate: only owners and admins can add new domains (mirrors
-// route guard `requireDomainAdminRole` and backend check). Hides the UI
-// affordance so members don't see a dead-end link.
-const { canCreateDomain } = useOrgPermissions(organization);
-
-const { fetchAllPermissions, getOrgPermissions } = useResourcePermissions();
-
-const assignableRoles = computed<OrganizationRole[]>(() => {
-  const orgPerms = getOrgPermissions(orgId.value);
-  return (orgPerms?.assignable_roles ?? ['member']) as OrganizationRole[];
-});
-
-const isOwner = computed(() => organization.value?.current_user_role === 'owner');
-const hasDomains = computed(() => (organization.value?.domain_count ?? 0) > 0);
-
-const currentUserMember = computed(() =>
-  membersStore.members.find(m => m.is_current_user)
-);
-
-const { isRevealed: isDeleteRevealed, reveal: revealDelete, confirm: confirmDelete, cancel: cancelDelete } = useConfirmDialog();
-const { isRevealed: isLeaveRevealed, reveal: revealLeave, confirm: confirmLeave, cancel: cancelLeave } = useConfirmDialog();
-
-const handleDeleteOrganization = async () => {
-  const { isCanceled } = await revealDelete();
-  if (isCanceled) return;
-
-  try {
-    await organizationStore.deleteOrganization(orgId.value);
-    router.push('/dashboard');
-  } catch (err) {
-    const classified = classifyError(err);
-    error.value = classified.message || t('web.organizations.delete_error');
-    console.error('[OrganizationSettings] Error deleting organization:', err);
-  }
-};
-
-const handleLeaveOrganization = async () => {
-  const member = currentUserMember.value;
-  if (!member) return;
-
-  const { isCanceled } = await revealLeave();
-  if (isCanceled) return;
-
-  try {
-    await membersStore.removeMember(orgId.value, member.extid);
-    router.push('/dashboard');
-  } catch (err) {
-    const classified = classifyError(err);
-    error.value = classified.message || t('web.organizations.leave_error');
-    console.error('[OrganizationSettings] Error leaving organization:', err);
-  }
-};
-
-// SSO status per domain — populated on-demand when SSO tab is shown
-interface DomainSsoStatus {
-  configured: boolean;
-  enabled: boolean;
-}
-const domainSsoStatus: Record<string, DomainSsoStatus> = reactive({});
-const isSsoStatusLoading = ref(false);
-const isSsoStatusLoaded = ref(false);
-
-/**
- * Fetch SSO configuration status for each domain in the list.
- * Only called when canManageSso is true and domains are loaded.
- * Uses SsoService.getConfigForDomain which returns { record: null }
- * for 404 (no config), so no error handling needed for that case.
- */
-const loadDomainSsoStatus = async () => {
-  if (!canManageSso.value || !domainRecords.value?.length) return;
-  // Guard against concurrent calls and redundant loads
-  if (isSsoStatusLoading.value || isSsoStatusLoaded.value) return;
-  isSsoStatusLoading.value = true;
-
-  const domains = domainRecords.value;
-  const results = await Promise.allSettled(
-    domains.map(async (domain) => {
-      const { record } = await SsoService.getConfigForDomain(domain.extid);
-      return { extid: domain.extid, record };
-    })
+  // Watch for route param changes (e.g., back/forward navigation).
+  // Reject navigation to entitlement-gated tabs the user can't access.
+  // NOTE: 'activity' has two distinct gates on different axes:
+  //  - instance flag OFF (ORGS_AUDIT_LOGS_ENABLED=false) → tab is absent
+  //    entirely, so deep links bounce to the default tab here;
+  //  - entitlement missing → tab stays reachable and renders an inline
+  //    upgrade notice, so it is deliberately NOT entitlement-gated here.
+  watch(
+    () => route.params.tab,
+    (newTab) => {
+      const urlTab = newTab as string | undefined;
+      if (urlTab && URL_TO_TAB[urlTab]) {
+        const resolved = URL_TO_TAB[urlTab];
+        if (
+          (resolved === 'members' && !canManageMembers.value) ||
+          (resolved === 'sso' && !canManageSso.value) ||
+          (resolved === 'activity' && !orgAuditLogsFeatureEnabled.value)
+        ) {
+          setActiveTab('domains');
+          return;
+        }
+        activeTab.value = resolved;
+      } else if (!urlTab) {
+        activeTab.value = props.initialTab;
+      }
+    }
   );
 
-  try {
-    for (const result of results) {
-      if (result.status === 'fulfilled') {
-        const { extid, record } = result.value;
-        domainSsoStatus[extid] = {
-          configured: record !== null,
-          enabled: record?.enabled === true,
-        };
-      }
-      // Rejected promises (network errors) are silently skipped —
-      // the badge simply won't appear for that domain.
-    }
+  // Domains management
+  const {
+    isLoading: isLoadingDomains,
+    records: domainRecords,
+    recordCount: domainCount,
+    error: domainsError,
+    refreshRecords: refreshDomains,
+  } = useDomainsManager();
 
-    isSsoStatusLoaded.value = true;
-  } finally {
-    isSsoStatusLoading.value = false;
-  }
-};
+  // Best practice: Initialize loading states to `true` to prevent uninitialized
+  // content, empty states, or gated upgrade notices from briefly flashing on mount.
+  const isLoading = ref(true);
+  const isSaving = ref(false);
+  const isLoadingBilling = ref(false);
+  // Billing email editing has been moved to BillingOverview.vue
+  const error = ref('');
+  const success = ref('');
+  const orgNotFound = ref(false);
 
-// Form data
-const formData = ref({
-  display_name: '',
-  description: '',
-  contact_email: '',
-});
+  // Plan data from billing overview
+  const planName = ref<string>('');
+  const planFeatures = ref<string[]>([]);
 
-const isDirty = computed(() => {
-  if (!organization.value) return false;
-  return (
-    formData.value.display_name !== organization.value.display_name ||
-    formData.value.description !== (organization.value.description || '') ||
-    formData.value.contact_email !== (organization.value.contact_email || '')
+  const showInviteForm = ref(false);
+  const inviteFormData = ref<CreateInvitationPayload>({
+    email: '',
+    role: 'member',
+  });
+  const inviteErrors = ref<Record<string, string>>({});
+  const inviteGeneralError = ref('');
+  const inviteUpgradeError = ref<ApplicationError | null>(null);
+  const isInviting = ref(false);
+
+  const { wrap } = useAsyncHandler({
+    notify: false,
+  });
+
+  const bootstrapStore = useBootstrapStore();
+  const { billing_enabled } = storeToRefs(bootstrapStore);
+  const billingEnabled = computed(() => billing_enabled.value ?? false);
+
+  // Entitlements - formatEntitlement uses API-driven i18n keys
+  const { entitlements, can, formatEntitlement, isStandaloneMode, initDefinitions, ENTITLEMENTS } =
+    useEntitlements(organization);
+
+  const sortedEntitlements = computed(() =>
+    [...entitlements.value].sort((a, b) => formatEntitlement(a).localeCompare(formatEntitlement(b)))
   );
-});
 
-// Clear success banner when user starts editing again
-watch(formData, () => {
-  if (success.value && isDirty.value) {
-    success.value = '';
-  }
-}, { deep: true });
+  // SSO visibility: feature flag AND entitlement must both pass (dual-control)
+  const canManageSso = computed(() => isOrgsSsoEnabled() && can(ENTITLEMENTS.MANAGE_SSO));
 
-const hasPaidPlan = computed(() => !isFreePlan(organization.value?.planid));
+  // Instance-level Secret Activity flag (default ON; ORGS_AUDIT_LOGS_ENABLED=false
+  // turns it off). Distinct axis from the audit_logs ENTITLEMENT below:
+  //  - flag OFF  → the Activity tab and panel are excluded entirely (unlike the
+  //    SSO tab, which renders disabled when unentitled — this one is hidden);
+  //  - flag ON + entitlement missing → tab visible, panel shows upgrade notice.
+  const orgAuditLogsFeatureEnabled = computed(() => isOrgsAuditLogsEnabled());
 
-// Legacy plan detection for grandfathered Early Supporter customers
-const isLegacyCustomer = computed(() =>
-  organization.value?.planid ? isLegacyPlan(organization.value.planid) : false
-);
+  // Secret Activity (audit trail) — gates the panel CONTENT only, never the
+  // tab. Mirrors the backend contract (list_secret_activity.rb): the materialized
+  // membership entitlements are plan ∩ role, and audit_logs sits in the
+  // admin tier — so a plain member is 403'd server-side even on an entitled
+  // plan. org.entitlements in the API payload is the PLAN-level set, so the
+  // role must be checked separately here or members mount the table and land
+  // in a generic error state.
+  const isAuditRoleAllowed = computed(() =>
+    ['owner', 'admin'].includes(organization.value?.current_user_role ?? '')
+  );
+  const canViewAuditLogs = computed(() => {
+    if (!organization.value) return false;
+    return isAuditRoleAllowed.value && can(ENTITLEMENTS.AUDIT_LOGS);
+  });
 
-const loadOrganization = async () => {
-  isLoading.value = true;
-  error.value = '';
-  orgNotFound.value = false;
-  try {
-    const org = await organizationStore.fetchOrganization(orgId.value);
-    organization.value = org;
-    formData.value = {
-      display_name: org.display_name,
-      description: org.description || '',
-      contact_email: org.contact_email || '',
-    };
-  } catch (err) {
-    organization.value = null;
-    const classified = classifyError(err);
-    if (classified.code === 404) {
-      orgNotFound.value = true;
-      error.value = t('web.organizations.not_found');
-    } else {
-      error.value = classified.message || t('web.organizations.load_error');
+  // Role-based gate: only owners and admins can add new domains (mirrors
+  // route guard `requireDomainAdminRole` and backend check). Hides the UI
+  // affordance so members don't see a dead-end link.
+  const { canCreateDomain } = useOrgPermissions(organization);
+
+  const { fetchAllPermissions, getOrgPermissions } = useResourcePermissions();
+
+  const assignableRoles = computed<OrganizationRole[]>(() => {
+    const orgPerms = getOrgPermissions(orgId.value);
+    return (orgPerms?.assignable_roles ?? ['member']) as OrganizationRole[];
+  });
+
+  const isOwner = computed(() => organization.value?.current_user_role === 'owner');
+  const hasDomains = computed(() => (organization.value?.domain_count ?? 0) > 0);
+
+  const currentUserMember = computed(() => membersStore.members.find((m) => m.is_current_user));
+
+  const {
+    isRevealed: isDeleteRevealed,
+    reveal: revealDelete,
+    confirm: confirmDelete,
+    cancel: cancelDelete,
+  } = useConfirmDialog();
+  const {
+    isRevealed: isLeaveRevealed,
+    reveal: revealLeave,
+    confirm: confirmLeave,
+    cancel: cancelLeave,
+  } = useConfirmDialog();
+
+  const handleDeleteOrganization = async () => {
+    const { isCanceled } = await revealDelete();
+    if (isCanceled) return;
+
+    try {
+      await organizationStore.deleteOrganization(orgId.value);
+      router.push('/dashboard');
+    } catch (err) {
+      const classified = classifyError(err);
+      error.value = classified.message || t('web.organizations.delete_error');
+      console.error('[OrganizationSettings] Error deleting organization:', err);
     }
-    console.error('[OrganizationSettings] Error loading organization:', err);
-  } finally {
-    isLoading.value = false;
+  };
+
+  const handleLeaveOrganization = async () => {
+    const member = currentUserMember.value;
+    if (!member) return;
+
+    const { isCanceled } = await revealLeave();
+    if (isCanceled) return;
+
+    try {
+      await membersStore.removeMember(orgId.value, member.extid);
+      router.push('/dashboard');
+    } catch (err) {
+      const classified = classifyError(err);
+      error.value = classified.message || t('web.organizations.leave_error');
+      console.error('[OrganizationSettings] Error leaving organization:', err);
+    }
+  };
+
+  // SSO status per domain — populated on-demand when SSO tab is shown
+  interface DomainSsoStatus {
+    configured: boolean;
+    enabled: boolean;
   }
-};
+  const domainSsoStatus: Record<string, DomainSsoStatus> = reactive({});
+  const isSsoStatusLoading = ref(false);
+  const isSsoStatusLoaded = ref(false);
 
-const loadInvitations = async () => {
-  try {
-    invitations.value = await organizationStore.fetchInvitations(orgId.value);
-  } catch (err) {
-    console.error('[OrganizationSettings] Error loading invitations:', err);
-  }
-};
+  /**
+   * Fetch SSO configuration status for each domain in the list.
+   * Only called when canManageSso is true and domains are loaded.
+   * Uses SsoService.getConfigForDomain which returns { record: null }
+   * for 404 (no config), so no error handling needed for that case.
+   */
+  const loadDomainSsoStatus = async () => {
+    if (!canManageSso.value || !domainRecords.value?.length) return;
+    // Guard against concurrent calls and redundant loads
+    if (isSsoStatusLoading.value || isSsoStatusLoaded.value) return;
+    isSsoStatusLoading.value = true;
 
-const loadMembers = async () => {
-  try {
-    await membersStore.fetchMembers(orgId.value);
-  } catch (err) {
-    console.error('[OrganizationSettings] Error loading members:', err);
-  }
-};
+    const domains = domainRecords.value;
+    const results = await Promise.allSettled(
+      domains.map(async (domain) => {
+        const { record } = await SsoService.getConfigForDomain(domain.extid);
+        return { extid: domain.extid, record };
+      })
+    );
 
-const loadBilling = async () => {
-  if (!billingEnabled.value) return;
+    try {
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          const { extid, record } = result.value;
+          domainSsoStatus[extid] = {
+            configured: record !== null,
+            enabled: record?.enabled === true,
+          };
+        }
+        // Rejected promises (network errors) are silently skipped —
+        // the badge simply won't appear for that domain.
+      }
 
-  isLoadingBilling.value = true;
-  try {
-    if (organization.value?.extid) {
-      const overview = await BillingService.getOverview(organization.value.extid);
+      isSsoStatusLoaded.value = true;
+    } finally {
+      isSsoStatusLoading.value = false;
+    }
+  };
 
-      // Convert API response to Subscription type
-      if (overview.subscription && overview.plan) {
-        subscription.value = {
-          id: overview.subscription.id,
-          org_id: organization.value.objid,
-          plan_type: overview.plan.tier as any,
-          status: overview.subscription.status as any,
-          teams_limit: overview.plan.limits.teams || 0,
-          teams_used: 0, // Teams removed from usage data for 0.24; will be re-added
-          total_members_per_org_limit: overview.plan.limits.total_members_per_org || 0,
-          billing_interval: overview.plan.interval as any,
-          current_period_start: new Date(overview.subscription.period_end * 1000), // Placeholder
-          current_period_end: new Date(overview.subscription.period_end * 1000),
-          cancel_at_period_end: overview.subscription.canceled,
-          created_at: new Date(),
-          updated_at: new Date(),
-        };
-        // Store plan name and features for display
-        planName.value = overview.plan.name || '';
-        planFeatures.value = overview.plan.features || [];
+  // Form data
+  const formData = ref({
+    display_name: '',
+    description: '',
+    contact_email: '',
+  });
+
+  const isDirty = computed(() => {
+    if (!organization.value) return false;
+    return (
+      formData.value.display_name !== organization.value.display_name ||
+      formData.value.description !== (organization.value.description || '') ||
+      formData.value.contact_email !== (organization.value.contact_email || '')
+    );
+  });
+
+  // Clear success banner when user starts editing again
+  watch(
+    formData,
+    () => {
+      if (success.value && isDirty.value) {
+        success.value = '';
+      }
+    },
+    { deep: true }
+  );
+
+  const hasPaidPlan = computed(() => !isFreePlan(organization.value?.planid));
+
+  // Legacy plan detection for grandfathered Early Supporter customers
+  const isLegacyCustomer = computed(() =>
+    organization.value?.planid ? isLegacyPlan(organization.value.planid) : false
+  );
+
+  const loadOrganization = async () => {
+    isLoading.value = true;
+    error.value = '';
+    orgNotFound.value = false;
+    try {
+      const org = await organizationStore.fetchOrganization(orgId.value);
+      organization.value = org;
+      formData.value = {
+        display_name: org.display_name,
+        description: org.description || '',
+        contact_email: org.contact_email || '',
+      };
+    } catch (err) {
+      organization.value = null;
+      const classified = classifyError(err);
+      if (classified.code === 404) {
+        orgNotFound.value = true;
+        error.value = t('web.organizations.not_found');
+      } else {
+        error.value = classified.message || t('web.organizations.load_error');
+      }
+      console.error('[OrganizationSettings] Error loading organization:', err);
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  const loadInvitations = async () => {
+    try {
+      invitations.value = await organizationStore.fetchInvitations(orgId.value);
+    } catch (err) {
+      console.error('[OrganizationSettings] Error loading invitations:', err);
+    }
+  };
+
+  const loadMembers = async () => {
+    try {
+      await membersStore.fetchMembers(orgId.value);
+    } catch (err) {
+      console.error('[OrganizationSettings] Error loading members:', err);
+    }
+  };
+
+  const loadBilling = async () => {
+    if (!billingEnabled.value) return;
+
+    isLoadingBilling.value = true;
+    try {
+      if (organization.value?.extid) {
+        const overview = await BillingService.getOverview(organization.value.extid);
+
+        // Convert API response to Subscription type
+        if (overview.subscription && overview.plan) {
+          subscription.value = {
+            id: overview.subscription.id,
+            org_id: organization.value.objid,
+            plan_type: overview.plan.tier as any,
+            status: overview.subscription.status as any,
+            teams_limit: overview.plan.limits.teams || 0,
+            teams_used: 0, // Teams removed from usage data for 0.24; will be re-added
+            total_members_per_org_limit: overview.plan.limits.total_members_per_org || 0,
+            billing_interval: overview.plan.interval as any,
+            current_period_start: new Date(overview.subscription.period_end * 1000), // Placeholder
+            current_period_end: new Date(overview.subscription.period_end * 1000),
+            cancel_at_period_end: overview.subscription.canceled,
+            created_at: new Date(),
+            updated_at: new Date(),
+          };
+          // Store plan name and features for display
+          planName.value = overview.plan.name || '';
+          planFeatures.value = overview.plan.features || [];
+        } else {
+          subscription.value = null;
+          planName.value = '';
+          planFeatures.value = [];
+        }
       } else {
         subscription.value = null;
-        planName.value = '';
-        planFeatures.value = [];
       }
-    } else {
-      subscription.value = null;
+    } catch (err) {
+      console.error('[OrganizationSettings] Error loading billing:', err);
+    } finally {
+      isLoadingBilling.value = false;
     }
-  } catch (err) {
-    console.error('[OrganizationSettings] Error loading billing:', err);
-  } finally {
-    isLoadingBilling.value = false;
-  }
-};
+  };
 
-const handleSave = async () => {
-  if (!organization.value || !isDirty.value) return;
+  const handleSave = async () => {
+    if (!organization.value || !isDirty.value) return;
 
-  isSaving.value = true;
-  error.value = '';
-  success.value = '';
+    isSaving.value = true;
+    error.value = '';
+    success.value = '';
 
-  try {
-    // Use extid from route params for API call
-    await organizationStore.updateOrganization(orgId.value, {
-      display_name: formData.value.display_name,
-      description: formData.value.description,
-    });
-    success.value = t('web.organizations.update_success');
-    await loadOrganization(); // Reload to get latest data
-  } catch (err) {
-    const classified = classifyError(err);
-    error.value = classified.message || t('web.organizations.update_error');
-    console.error('[OrganizationSettings] Error updating organization:', err);
-  } finally {
-    isSaving.value = false;
-  }
-};
-
-const handleCancel = () => {
-  if (organization.value) {
-    formData.value = {
-      display_name: organization.value.display_name,
-      description: organization.value.description || '',
-      contact_email: organization.value.contact_email || '',
-    };
-  }
-};
-
-const handleInviteMember = async () => {
-  if (isInviting.value) return;
-
-  inviteErrors.value = {};
-  inviteGeneralError.value = '';
-  inviteUpgradeError.value = null;
-  isInviting.value = true;
-
-  try {
-    await organizationStore.createInvitation(orgId.value, inviteFormData.value);
-
-    inviteFormData.value = {
-      email: '',
-      role: 'member',
-    };
-    showInviteForm.value = false;
-    success.value = t('web.organizations.invitations.invite_sent');
-
-    await loadInvitations();
-  } catch (err) {
-    if (err instanceof z.ZodError) {
-      err.issues.forEach((issue) => {
-        const field = issue.path[0] as string;
-        inviteErrors.value[field] = issue.message;
+    try {
+      // Use extid from route params for API call
+      await organizationStore.updateOrganization(orgId.value, {
+        display_name: formData.value.display_name,
+        description: formData.value.description,
       });
-    } else {
+      success.value = t('web.organizations.update_success');
+      await loadOrganization(); // Reload to get latest data
+    } catch (err) {
       const classified = classifyError(err);
-      const { isUpgradeRequired } = useEntitlementError(classified);
+      error.value = classified.message || t('web.organizations.update_error');
+      console.error('[OrganizationSettings] Error updating organization:', err);
+    } finally {
+      isSaving.value = false;
+    }
+  };
 
-      // Check if this is an upgrade-required error
-      if (isUpgradeRequired.value) {
-        inviteUpgradeError.value = classified;
+  const handleCancel = () => {
+    if (organization.value) {
+      formData.value = {
+        display_name: organization.value.display_name,
+        description: organization.value.description || '',
+        contact_email: organization.value.contact_email || '',
+      };
+    }
+  };
+
+  const handleInviteMember = async () => {
+    if (isInviting.value) return;
+
+    inviteErrors.value = {};
+    inviteGeneralError.value = '';
+    inviteUpgradeError.value = null;
+    isInviting.value = true;
+
+    try {
+      await organizationStore.createInvitation(orgId.value, inviteFormData.value);
+
+      inviteFormData.value = {
+        email: '',
+        role: 'member',
+      };
+      showInviteForm.value = false;
+      success.value = t('web.organizations.invitations.invite_sent');
+
+      await loadInvitations();
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        err.issues.forEach((issue) => {
+          const field = issue.path[0] as string;
+          inviteErrors.value[field] = issue.message;
+        });
       } else {
-        inviteGeneralError.value = classified.message || t('web.organizations.invitations.invite_error');
+        const classified = classifyError(err);
+        const { isUpgradeRequired } = useEntitlementError(classified);
+
+        // Check if this is an upgrade-required error
+        if (isUpgradeRequired.value) {
+          inviteUpgradeError.value = classified;
+        } else {
+          inviteGeneralError.value =
+            classified.message || t('web.organizations.invitations.invite_error');
+        }
       }
+    } finally {
+      isInviting.value = false;
     }
-  } finally {
-    isInviting.value = false;
-  }
-};
+  };
 
-const handleResendInvitation = async (token: string) => {
-  error.value = '';
-  success.value = '';
+  const handleResendInvitation = async (token: string) => {
+    error.value = '';
+    success.value = '';
 
-  const result = await wrap(() => organizationStore.resendInvitation(orgId.value, token));
+    const result = await wrap(() => organizationStore.resendInvitation(orgId.value, token));
 
-  if (result !== null) {
-    success.value = t('web.organizations.invitations.resend_success');
-    await loadInvitations(); // Refresh the list
-  } else {
-    error.value = t('web.organizations.invitations.resend_error');
-  }
-};
+    if (result !== null) {
+      success.value = t('web.organizations.invitations.resend_success');
+      await loadInvitations(); // Refresh the list
+    } else {
+      error.value = t('web.organizations.invitations.resend_error');
+    }
+  };
 
-const handleRevokeInvitation = async (token: string) => {
-  error.value = '';
-  success.value = '';
+  const handleRevokeInvitation = async (token: string) => {
+    error.value = '';
+    success.value = '';
 
-  const result = await wrap(() => organizationStore.revokeInvitation(orgId.value, token));
+    const result = await wrap(() => organizationStore.revokeInvitation(orgId.value, token));
 
-  if (result !== null) {
-    success.value = t('web.organizations.invitations.revoke_success');
-    await loadInvitations(); // Refresh the list
-  } else {
-    error.value = t('web.organizations.invitations.revoke_error');
-  }
-};
+    if (result !== null) {
+      success.value = t('web.organizations.invitations.revoke_success');
+      await loadInvitations(); // Refresh the list
+    } else {
+      error.value = t('web.organizations.invitations.revoke_error');
+    }
+  };
 
-const formatTimeRemaining = (expiresAt: number, nowMs: number = Date.now()): string => {
-  const remaining = expiresAt - Math.floor(nowMs / 1000);
+  const formatTimeRemaining = (expiresAt: number, nowMs: number = Date.now()): string => {
+    const remaining = expiresAt - Math.floor(nowMs / 1000);
 
-  if (remaining <= 0) {
-    return t('web.organizations.invitations.status.expired');
-  }
+    if (remaining <= 0) {
+      return t('web.organizations.invitations.status.expired');
+    }
 
-  const days = Math.floor(remaining / 86400);
-  const hours = Math.floor((remaining % 86400) / 3600);
+    const days = Math.floor(remaining / 86400);
+    const hours = Math.floor((remaining % 86400) / 3600);
 
-  if (days > 0) {
-    return t('web.organizations.invitations.expires_in_days', { days });
-  } else if (hours > 0) {
-    return t('web.organizations.invitations.expires_in_hours', { hours });
-  } else {
-    return t('web.organizations.invitations.expires_soon');
-  }
-};
+    if (days > 0) {
+      return t('web.organizations.invitations.expires_in_days', { days });
+    } else if (hours > 0) {
+      return t('web.organizations.invitations.expires_in_hours', { hours });
+    } else {
+      return t('web.organizations.invitations.expires_soon');
+    }
+  };
 
-/** Tailwind badge classes keyed to an invitation's effective status. */
-const invitationStatusBadgeClass = (status: string): string => {
-  switch (status) {
-    case INVITATION_STATUSES.ACCEPTED:
-      return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400';
-    case INVITATION_STATUSES.DECLINED:
-      return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400';
-    case INVITATION_STATUSES.PENDING:
-      return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400';
-    // 'revoked' is deleted server-side today so it never reaches here, but keep
-    // it explicit for symmetry with LOCALIZED_INVITATION_STATUSES.
-    case 'revoked':
-    case INVITATION_STATUSES.EXPIRED:
-    default:
-      return 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300';
-  }
-};
+  /** Tailwind badge classes keyed to an invitation's effective status. */
+  const invitationStatusBadgeClass = (status: string): string => {
+    switch (status) {
+      case INVITATION_STATUSES.ACCEPTED:
+        return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400';
+      case INVITATION_STATUSES.DECLINED:
+        return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400';
+      case INVITATION_STATUSES.PENDING:
+        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400';
+      // 'revoked' is deleted server-side today so it never reaches here, but keep
+      // it explicit for symmetry with LOCALIZED_INVITATION_STATUSES.
+      case 'revoked':
+      case INVITATION_STATUSES.EXPIRED:
+      default:
+        return 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300';
+    }
+  };
 
-/**
- * Invitation rows decorated with their expiry-aware display fields. Resolving
- * the effective status once per row here (rather than in each template binding)
- * avoids recomputing it, and reading `now` makes every derived field — status
- * badge and countdown — refresh on the clock tick, so a pending invitation that
- * lapses while the tab stays open updates on its own instead of showing a stale
- * "Pending" badge.
- */
-const decoratedInvitations = computed(() => {
-  const nowMs = now.value.getTime();
-  return invitations.value.map((invitation) => {
-    const status = effectiveInvitationStatus(invitation.status, invitation.expires_at, nowMs);
-    const labelKey = invitationStatusLabelKey(status);
-    return {
-      invitation,
-      statusLabel: labelKey ? t(labelKey) : status,
-      statusBadgeClass: invitationStatusBadgeClass(status),
-      timeRemaining: formatTimeRemaining(invitation.expires_at, nowMs),
-    };
+  /**
+   * Invitation rows decorated with their expiry-aware display fields. Resolving
+   * the effective status once per row here (rather than in each template binding)
+   * avoids recomputing it, and reading `now` makes every derived field — status
+   * badge and countdown — refresh on the clock tick, so a pending invitation that
+   * lapses while the tab stays open updates on its own instead of showing a stale
+   * "Pending" badge.
+   */
+  const decoratedInvitations = computed(() => {
+    const nowMs = now.value.getTime();
+    return invitations.value.map((invitation) => {
+      const status = effectiveInvitationStatus(invitation.status, invitation.expires_at, nowMs);
+      const labelKey = invitationStatusLabelKey(status);
+      return {
+        invitation,
+        statusLabel: labelKey ? t(labelKey) : status,
+        statusBadgeClass: invitationStatusBadgeClass(status),
+        timeRemaining: formatTimeRemaining(invitation.expires_at, nowMs),
+      };
+    });
   });
-});
 
-const canManageMembers = computed(() => {
-  if (!organization.value) return false;
-  return can(ENTITLEMENTS.MANAGE_MEMBERS);
-});
+  const canManageMembers = computed(() => {
+    if (!organization.value) return false;
+    return can(ENTITLEMENTS.MANAGE_MEMBERS);
+  });
 
-// Mirror backend check (create_invitation.rb:130): member_count + pending invitations
-// vs total_members_per_org limit. Limit of -1 means unlimited; null/undefined means
-// unknown (e.g. self-hosted) — treat as no limit.
-//
-// Counts the raw 'pending' status, NOT the expiry-aware effective status: the
-// backend keeps a lapsed invitation's seat reserved until cleanup, so this
-// limit check must match it. A row can therefore read "Expired" in its badge
-// while still counting toward the quota here — intentional.
-const pendingInvitationCount = computed(() =>
-  invitations.value.filter((inv) => inv.status === 'pending').length
-);
+  // Mirror backend check (create_invitation.rb:130): member_count + pending invitations
+  // vs total_members_per_org limit. Limit of -1 means unlimited; null/undefined means
+  // unknown (e.g. self-hosted) — treat as no limit.
+  //
+  // Counts the raw 'pending' status, NOT the expiry-aware effective status: the
+  // backend keeps a lapsed invitation's seat reserved until cleanup, so this
+  // limit check must match it. A row can therefore read "Expired" in its badge
+  // while still counting toward the quota here — intentional.
+  const pendingInvitationCount = computed(
+    () => invitations.value.filter((inv) => inv.status === 'pending').length
+  );
 
-const memberLimitReached = computed(() => {
-  const limit = organization.value?.limits?.total_members_per_org;
-  if (limit === null || limit === undefined || limit < 0) return false;
-  return membersStore.memberCount + pendingInvitationCount.value >= limit;
-});
+  const memberLimitReached = computed(() => {
+    const limit = organization.value?.limits?.total_members_per_org;
+    if (limit === null || limit === undefined || limit < 0) return false;
+    return membersStore.memberCount + pendingInvitationCount.value >= limit;
+  });
 
-// Finite quota cap (positive int) or null when unlimited/unknown. Drives the
-// "X of Y" count format in the title slot.
-const memberQuotaLimit = computed(() => {
-  const limit = organization.value?.limits?.total_members_per_org;
-  if (limit === null || limit === undefined || limit < 0) return null;
-  return limit;
-});
+  // Finite quota cap (positive int) or null when unlimited/unknown. Drives the
+  // "X of Y" count format in the title slot.
+  const memberQuotaLimit = computed(() => {
+    const limit = organization.value?.limits?.total_members_per_org;
+    if (limit === null || limit === undefined || limit < 0) return null;
+    return limit;
+  });
 
-// Active members only — matches what the user sees in the table. Pending is
-// shown as a separate "(N pending)" qualifier rather than folded into the
-// numerator, so the count line maps directly to visible rows. memberLimitReached
-// still uses active + pending to mirror the backend; the two can diverge here
-// without confusing the reader because the pending qualifier explains why the
-// button may be disabled at a count below the limit.
-const memberQuotaUsed = computed(() => membersStore.memberCount);
+  // Active members only — matches what the user sees in the table. Pending is
+  // shown as a separate "(N pending)" qualifier rather than folded into the
+  // numerator, so the count line maps directly to visible rows. memberLimitReached
+  // still uses active + pending to mirror the backend; the two can diverge here
+  // without confusing the reader because the pending qualifier explains why the
+  // button may be disabled at a count below the limit.
+  const memberQuotaUsed = computed(() => membersStore.memberCount);
 
-// Member management event handlers
-const handleMemberUpdated = () => {
-  // Member was updated in the store, no additional action needed
-  success.value = t('web.organizations.members.role_updated');
-};
+  // Member management event handlers
+  const handleMemberUpdated = () => {
+    // Member was updated in the store, no additional action needed
+    success.value = t('web.organizations.members.role_updated');
+  };
 
-const handleMemberRemoved = () => {
-  success.value = t('web.organizations.members.member_removed');
-};
+  const handleMemberRemoved = () => {
+    success.value = t('web.organizations.members.member_removed');
+  };
 
-onMounted(async () => {
-  // Point the store at this org immediately so the context bar doesn't
-  // flash the previously-selected org while the full fetch is in flight.
-  const cached = organizationStore.organizations?.find((o) => o.extid === orgId.value);
-  if (cached) {
-    organizationStore.setCurrentOrganization(cached);
-  }
-
-  // Initialize entitlement definitions for formatting
-  await initDefinitions();
-
-  // Fetch resource-scoped permissions (includes assignable_roles)
-  await fetchAllPermissions();
-
-  await loadOrganization();
-
-  // Redirect away from entitlement-gated tabs the user can't access
-  // (e.g. direct URL navigation to /org/.../members without manage_members).
-  // 'activity' is deliberately absent: deep links to it always land, and the
-  // panel itself swaps in an upgrade notice when unentitled.
-  if (
-    (activeTab.value === 'members' && !canManageMembers.value) ||
-    (activeTab.value === 'sso' && !canManageSso.value)
-  ) {
-    setActiveTab('domains');
-  }
-
-  // Members are always loaded so the general tab's "Leave" button can
-  // identify the current user's membership record.
-  loadMembers();
-
-  // Load data for the initial tab. 'activity' needs no case here:
-  // SecretActivityTable owns its fetching and mounts lazily with the panel.
-  if (activeTab.value === 'members') {
-    await loadInvitations();
-  } else if (activeTab.value === 'domains') {
-    await refreshDomains();
-  } else if (activeTab.value === 'subscription' && billingEnabled.value) {
-    await loadBilling();
-  } else if (activeTab.value === 'sso' && canManageSso.value) {
-    await refreshDomains();
-    await loadDomainSsoStatus();
-  }
-});
-
-// Per-tab lazy loads on tab switch. 'activity' has no case here on purpose:
-// its panel is v-if'd on the active tab, so SecretActivityTable mounts on
-// activation and fetches its own first page (refetching fresh on each visit —
-// desirable for an audit trail).
-watch(activeTab, async (newTab) => {
-  if (newTab === 'members') {
-    // Load members and invitations when switching to members tab
-    const promises: Promise<void>[] = [];
-    if (!membersStore.isInitialized || membersStore.currentOrgExtid !== orgId.value) {
-      promises.push(loadMembers());
+  const checkInitialTabRedirect = () => {
+    // Redirect away from entitlement-gated tabs the user can't access
+    // (e.g. direct URL navigation to /org/.../members without manage_members).
+    // 'activity' is entitlement-exempt (deep links land; the panel swaps in an
+    // upgrade notice when unentitled) but IS gated on the instance flag: when
+    // ORGS_AUDIT_LOGS_ENABLED=false the tab doesn't exist, so deep links bounce.
+    if (
+      (activeTab.value === 'members' && !canManageMembers.value) ||
+      (activeTab.value === 'sso' && !canManageSso.value) ||
+      (activeTab.value === 'activity' && !orgAuditLogsFeatureEnabled.value)
+    ) {
+      setActiveTab('domains');
     }
-    if (invitations.value.length === 0) {
-      promises.push(loadInvitations());
-    }
-    if (promises.length > 0) {
-      await Promise.all(promises);
-    }
-  } else if (newTab === 'domains') {
-    // Load domains when switching to domains tab
-    await refreshDomains();
-  } else if (newTab === 'subscription' && !subscription.value && billingEnabled.value) {
-    await loadBilling();
-  } else if (newTab === 'sso' && canManageSso.value) {
-    // Ensure domains are loaded, then fetch SSO status for each
-    await refreshDomains();
-    await loadDomainSsoStatus();
-  }
-});
+  };
 
-// Watch for org changes via URL navigation (e.g., /org/A/domains -> /org/B/domains)
-// Vue Router reuses the component, so onMounted doesn't run again.
-// This ensures currentOrganization in the store is updated to match the URL.
-watch(orgId, async (newOrgId, oldOrgId) => {
-  if (newOrgId && newOrgId !== oldOrgId) {
-    // Reset SSO status cache when switching orgs — domains differ per org
-    isSsoStatusLoaded.value = false;
-    for (const key of Object.keys(domainSsoStatus)) {
-      delete domainSsoStatus[key];
+  const loadInitialTabData = async () => {
+    if (activeTab.value === 'members') {
+      await loadInvitations();
+    } else if (activeTab.value === 'domains') {
+      await refreshDomains();
+    } else if (activeTab.value === 'subscription' && billingEnabled.value) {
+      await loadBilling();
+    } else if (activeTab.value === 'sso' && canManageSso.value) {
+      await refreshDomains();
+      await loadDomainSsoStatus();
     }
+  };
+
+  onMounted(async () => {
+    // Point the store at this org immediately so the context bar doesn't
+    // flash the previously-selected org while the full fetch is in flight.
+    const cached = organizationStore.organizations?.find((o) => o.extid === orgId.value);
+    if (cached) {
+      organizationStore.setCurrentOrganization(cached);
+    }
+
+    // Initialize entitlement definitions for formatting
+    await initDefinitions();
+
+    // Fetch resource-scoped permissions (includes assignable_roles)
+    await fetchAllPermissions();
 
     await loadOrganization();
-    // Guard against stale responses from rapid org navigation — if the
-    // user navigated again while we were loading, orgId has already
-    // changed and a newer watcher invocation will handle it.
-    if (orgId.value !== newOrgId) return;
-    // Only load tab-specific data if the org loaded successfully
-    if (!orgNotFound.value && !error.value) {
-      loadMembers();
-      if (activeTab.value === 'members') {
-        await loadInvitations();
-      } else if (activeTab.value === 'domains') {
-        await refreshDomains();
-      } else if (activeTab.value === 'subscription' && billingEnabled.value) {
-        await loadBilling();
-      } else if (activeTab.value === 'sso' && canManageSso.value) {
-        await refreshDomains();
-        await loadDomainSsoStatus();
+
+    checkInitialTabRedirect();
+
+    // Members are always loaded so the general tab's "Leave" button can
+    // identify the current user's membership record.
+    loadMembers();
+
+    // Load data for the initial tab. 'activity' needs no case here:
+    // SecretActivityTable owns its fetching and mounts lazily with the panel.
+    await loadInitialTabData();
+  });
+
+  // Per-tab lazy loads on tab switch. 'activity' has no case here on purpose:
+  // its panel is v-if'd on the active tab, so SecretActivityTable mounts on
+  // activation and fetches its own first page (refetching fresh on each visit —
+  // desirable for an audit trail).
+  watch(activeTab, async (newTab) => {
+    if (newTab === 'members') {
+      // Load members and invitations when switching to members tab
+      const promises: Promise<void>[] = [];
+      if (!membersStore.isInitialized || membersStore.currentOrgExtid !== orgId.value) {
+        promises.push(loadMembers());
+      }
+      if (invitations.value.length === 0) {
+        promises.push(loadInvitations());
+      }
+      if (promises.length > 0) {
+        await Promise.all(promises);
+      }
+    } else if (newTab === 'domains') {
+      // Load domains when switching to domains tab
+      await refreshDomains();
+    } else if (newTab === 'subscription' && !subscription.value && billingEnabled.value) {
+      await loadBilling();
+    } else if (newTab === 'sso' && canManageSso.value) {
+      // Ensure domains are loaded, then fetch SSO status for each
+      await refreshDomains();
+      await loadDomainSsoStatus();
+    }
+  });
+
+  // Watch for org changes via URL navigation (e.g., /org/A/domains -> /org/B/domains)
+  // Vue Router reuses the component, so onMounted doesn't run again.
+  // This ensures currentOrganization in the store is updated to match the URL.
+  watch(orgId, async (newOrgId, oldOrgId) => {
+    if (newOrgId && newOrgId !== oldOrgId) {
+      // Reset SSO status cache when switching orgs — domains differ per org
+      isSsoStatusLoaded.value = false;
+      for (const key of Object.keys(domainSsoStatus)) {
+        delete domainSsoStatus[key];
+      }
+
+      await loadOrganization();
+      // Guard against stale responses from rapid org navigation — if the
+      // user navigated again while we were loading, orgId has already
+      // changed and a newer watcher invocation will handle it.
+      if (orgId.value !== newOrgId) return;
+      // Only load tab-specific data if the org loaded successfully
+      if (!orgNotFound.value && !error.value) {
+        loadMembers();
+        if (activeTab.value === 'members') {
+          await loadInvitations();
+        } else if (activeTab.value === 'domains') {
+          await refreshDomains();
+        } else if (activeTab.value === 'subscription' && billingEnabled.value) {
+          await loadBilling();
+        } else if (activeTab.value === 'sso' && canManageSso.value) {
+          await refreshDomains();
+          await loadDomainSsoStatus();
+        }
       }
     }
-  }
-});
+  });
 
-// Keyboard navigation for tabs (WCAG 2.1 AA)
-const handleTabKeydown = (e: KeyboardEvent) => {
-  // Build navigable tabs array — only tabs the user can actually reach.
-  // 'activity' is always included: even unentitled users can open it (the
-  // panel shows the upgrade prompt), so it must stay keyboard-reachable.
-  const tabs: TabType[] = ['domains'];
-  if (canManageMembers.value) tabs.push('members');
-  if (canManageSso.value) tabs.push('sso');
-  tabs.push('activity');
-  tabs.push('general');
+  // Keyboard navigation for tabs (WCAG 2.1 AA)
+  const handleTabKeydown = (e: KeyboardEvent) => {
+    // Build navigable tabs array — only tabs the user can actually reach.
+    // 'activity' is included whenever the instance flag is on: even unentitled
+    // users can open it (the panel shows the upgrade prompt), so it must stay
+    // keyboard-reachable. When the flag is off the tab doesn't render at all.
+    const tabs: TabType[] = ['domains'];
+    if (canManageMembers.value) tabs.push('members');
+    if (canManageSso.value) tabs.push('sso');
+    if (orgAuditLogsFeatureEnabled.value) tabs.push('activity');
+    tabs.push('general');
 
-  const currentIndex = tabs.indexOf(activeTab.value);
-  if (currentIndex === -1) return;
+    const currentIndex = tabs.indexOf(activeTab.value);
+    if (currentIndex === -1) return;
 
-  switch (e.key) {
-    case 'ArrowRight':
-    case 'ArrowDown':
-      e.preventDefault();
-      setActiveTab(tabs[(currentIndex + 1) % tabs.length]);
-      nextTick(() => document.getElementById(`org-tab-${activeTab.value}`)?.focus());
-      break;
-    case 'ArrowLeft':
-    case 'ArrowUp':
-      e.preventDefault();
-      setActiveTab(tabs[(currentIndex - 1 + tabs.length) % tabs.length]);
-      nextTick(() => document.getElementById(`org-tab-${activeTab.value}`)?.focus());
-      break;
-    case 'Home':
-      e.preventDefault();
-      setActiveTab(tabs[0]);
-      nextTick(() => document.getElementById(`org-tab-${tabs[0]}`)?.focus());
-      break;
-    case 'End':
-      e.preventDefault();
-      setActiveTab(tabs[tabs.length - 1]);
-      nextTick(() => document.getElementById(`org-tab-${tabs[tabs.length - 1]}`)?.focus());
-      break;
-  }
-};
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        e.preventDefault();
+        setActiveTab(tabs[(currentIndex + 1) % tabs.length]);
+        nextTick(() => document.getElementById(`org-tab-${activeTab.value}`)?.focus());
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        e.preventDefault();
+        setActiveTab(tabs[(currentIndex - 1 + tabs.length) % tabs.length]);
+        nextTick(() => document.getElementById(`org-tab-${activeTab.value}`)?.focus());
+        break;
+      case 'Home':
+        e.preventDefault();
+        setActiveTab(tabs[0]);
+        nextTick(() => document.getElementById(`org-tab-${tabs[0]}`)?.focus());
+        break;
+      case 'End':
+        e.preventDefault();
+        setActiveTab(tabs[tabs.length - 1]);
+        nextTick(() => document.getElementById(`org-tab-${tabs[tabs.length - 1]}`)?.focus());
+        break;
+    }
+  };
 </script>
 
 <template>
@@ -830,12 +876,18 @@ const handleTabKeydown = (e: KeyboardEvent) => {
             name="credit-card"
             class="size-3.5"
             aria-hidden="true" />
-          {{ organization.planid ? getPlanLabel(organization.planid) : t('web.billing.plans.free_plan') }}
+          {{
+            organization.planid
+              ? getPlanLabel(organization.planid)
+              : t('web.billing.plans.free_plan')
+          }}
         </router-link>
       </div>
 
-      <!-- Tabs: Domains, Members, SSO (conditional), Settings -->
-      <div v-if="!orgNotFound && organization" class="border-b border-gray-200 dark:border-gray-700">
+      <!-- Tabs: Domains, Members, SSO (conditional), Activity (conditional), Settings -->
+      <div
+        v-if="!orgNotFound && organization"
+        class="border-b border-gray-200 dark:border-gray-700">
         <nav
           role="tablist"
           aria-orientation="horizontal"
@@ -900,9 +952,12 @@ const handleTabKeydown = (e: KeyboardEvent) => {
             ]">
             {{ t('web.organizations.tabs.sso') }}
           </button>
-          <!-- Activity tab — always visible; the panel gates on the
-               audit_logs entitlement (upgrade notice when unentitled) -->
+          <!-- Activity tab — excluded entirely when the instance flag
+               (ORGS_AUDIT_LOGS_ENABLED) is off; when on, always visible and
+               the panel gates on the audit_logs entitlement (upgrade notice
+               when unentitled) -->
           <button
+            v-if="orgAuditLogsFeatureEnabled"
             id="org-tab-activity"
             role="tab"
             :aria-selected="activeTab === 'activity'"
@@ -942,7 +997,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
       <SettingsSkeleton v-if="isLoading" />
 
       <!-- Error State: Organization not found or failed to load -->
-      <div v-else-if="orgNotFound || (error && !organization)" class="flex items-center justify-center py-12">
+      <div
+        v-else-if="orgNotFound || (error && !organization)"
+        class="flex items-center justify-center py-12">
         <div class="text-center">
           <OIcon
             collection="heroicons"
@@ -952,7 +1009,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
           <h3 class="mt-2 text-sm font-semibold text-gray-900 dark:text-white">
             {{ orgNotFound ? t('web.organizations.not_found') : t('web.organizations.load_error') }}
           </h3>
-          <p v-if="error && !orgNotFound" class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          <p
+            v-if="error && !orgNotFound"
+            class="mt-1 text-sm text-gray-500 dark:text-gray-400">
             {{ error }}
           </p>
           <router-link
@@ -969,7 +1028,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
       </div>
 
       <!-- Content -->
-      <div v-else class="space-y-6">
+      <div
+        v-else
+        class="space-y-6">
         <!-- General Tab -->
         <section
           v-if="activeTab === 'general'"
@@ -993,7 +1054,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
               v-if="success"
               :success="success" />
 
-            <form @submit.prevent="handleSave" class="mt-4 space-y-6">
+            <form
+              @submit.prevent="handleSave"
+              class="mt-4 space-y-6">
               <!-- Display Name -->
               <div>
                 <label
@@ -1052,7 +1115,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
               </div>
 
               <!-- Billing Email - read-only display for paid plans, editable on Billing Overview -->
-              <div v-if="billingEnabled && hasPaidPlan" data-testid="org-billing-email-field">
+              <div
+                v-if="billingEnabled && hasPaidPlan"
+                data-testid="org-billing-email-field">
                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
                   {{ t('web.organizations.contact_email') }}
                 </label>
@@ -1099,7 +1164,8 @@ const handleTabKeydown = (e: KeyboardEvent) => {
           v-if="activeTab === 'general' && !isStandaloneMode"
           class="rounded-lg border border-gray-200/60 bg-white/60 shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/60">
           <div class="border-b border-gray-200 px-6 py-4 dark:border-gray-700">
-            <h3 class="flex items-center gap-3 text-base font-semibold text-gray-900 dark:text-white">
+            <h3
+              class="flex items-center gap-3 text-base font-semibold text-gray-900 dark:text-white">
               <OIcon
                 collection="heroicons"
                 name="puzzle-piece"
@@ -1154,8 +1220,8 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                 <router-link
                   to="/feedback"
                   class="font-medium text-brand-600 hover:text-brand-500 dark:text-brand-400 dark:hover:text-brand-300">
-                  {{ t('web.organizations.default_org_delete_notice_link') }}
-                </router-link>{{ t('web.organizations.default_org_delete_notice_after') }}
+                  {{ t('web.organizations.default_org_delete_notice_link') }} </router-link
+                >{{ t('web.organizations.default_org_delete_notice_after') }}
               </p>
             </div>
           </div>
@@ -1168,10 +1234,12 @@ const handleTabKeydown = (e: KeyboardEvent) => {
             <h2 class="mb-4 text-sm font-medium text-red-600 dark:text-red-400">
               {{ t('web.COMMON.caution_zone') }}
             </h2>
-            <div class="rounded-lg border border-red-200 bg-red-50/50 dark:border-red-900/50 dark:bg-red-950/20">
+            <div
+              class="rounded-lg border border-red-200 bg-red-50/50 dark:border-red-900/50 dark:bg-red-950/20">
               <div class="flex items-center justify-between gap-4 px-5 py-4">
                 <div class="flex min-w-0 items-center gap-4">
-                  <div class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-red-100 dark:bg-red-900/30">
+                  <div
+                    class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-red-100 dark:bg-red-900/30">
                     <OIcon
                       collection="heroicons"
                       name="trash"
@@ -1185,7 +1253,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                     <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
                       {{ t('web.organizations.delete_organization_warning') }}
                     </p>
-                    <p v-if="hasDomains" class="mt-1 text-xs text-red-600 dark:text-red-400">
+                    <p
+                      v-if="hasDomains"
+                      class="mt-1 text-xs text-red-600 dark:text-red-400">
                       {{ t('web.organizations.delete_organization_remove_domains_first') }}
                     </p>
                   </div>
@@ -1206,10 +1276,12 @@ const handleTabKeydown = (e: KeyboardEvent) => {
         <template v-if="activeTab === 'general' && !isOwner">
           <hr class="my-10 border-gray-200 dark:border-gray-700/50" />
           <div>
-            <div class="rounded-lg border border-gray-200/60 bg-white/60 shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/60">
+            <div
+              class="rounded-lg border border-gray-200/60 bg-white/60 shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/60">
               <div class="flex items-center justify-between gap-4 px-5 py-4">
                 <div class="flex min-w-0 items-center gap-4">
-                  <div class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-gray-100 dark:bg-gray-700">
+                  <div
+                    class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-gray-100 dark:bg-gray-700">
                     <OIcon
                       collection="heroicons"
                       name="arrow-right-start-on-rectangle"
@@ -1254,12 +1326,28 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                 </h3>
                 <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
                   <template v-if="memberQuotaLimit !== null">
-                    {{ t('web.organizations.members.member_quota', { used: memberQuotaUsed, limit: memberQuotaLimit }) }}
+                    {{
+                      t('web.organizations.members.member_quota', {
+                        used: memberQuotaUsed,
+                        limit: memberQuotaLimit,
+                      })
+                    }}
                   </template>
                   <template v-else>
-                    {{ membersStore.memberCount }} {{ membersStore.memberCount === 1 ? t('web.organizations.members.member_singular') : t('web.organizations.members.member_plural') }}
+                    {{ membersStore.memberCount }}
+                    {{
+                      membersStore.memberCount === 1
+                        ? t('web.organizations.members.member_singular')
+                        : t('web.organizations.members.member_plural')
+                    }}
                   </template>
-                  <span v-if="pendingInvitationCount > 0">&nbsp;{{ t('web.organizations.members.pending_suffix', { count: pendingInvitationCount }) }}</span>
+                  <span v-if="pendingInvitationCount > 0"
+                    >&nbsp;{{
+                      t('web.organizations.members.pending_suffix', {
+                        count: pendingInvitationCount,
+                      })
+                    }}</span
+                  >
                 </p>
               </div>
               <!--
@@ -1286,7 +1374,11 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                   type="button"
                   @click="canManageMembers && (showInviteForm = true)"
                   :disabled="!canManageMembers"
-                  :title="!canManageMembers ? t('web.organizations.invitations.upgrade_to_invite') : undefined"
+                  :title="
+                    !canManageMembers
+                      ? t('web.organizations.invitations.upgrade_to_invite')
+                      : undefined
+                  "
                   :class="[
                     'inline-flex items-center rounded-md px-3 py-2 font-brand text-sm font-semibold shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
                     canManageMembers
@@ -1408,7 +1500,11 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                       type="submit"
                       :disabled="isInviting || !inviteFormData.email"
                       class="rounded-md bg-brand-600 px-3 py-2 font-brand text-sm font-semibold text-white shadow-sm hover:bg-brand-500 disabled:opacity-50 dark:bg-brand-500 dark:hover:bg-brand-400">
-                      {{ isInviting ? t('web.COMMON.processing') : t('web.organizations.invitations.send_invite') }}
+                      {{
+                        isInviting
+                          ? t('web.COMMON.processing')
+                          : t('web.organizations.invitations.send_invite')
+                      }}
                     </button>
                   </div>
                 </div>
@@ -1426,7 +1522,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                 @member-removed="handleMemberRemoved" />
             </div>
 
-            <div v-else-if="!membersStore.loading" class="py-8 text-center">
+            <div
+              v-else-if="!membersStore.loading"
+              class="py-8 text-center">
               <OIcon
                 collection="heroicons"
                 name="users"
@@ -1439,18 +1537,27 @@ const handleTabKeydown = (e: KeyboardEvent) => {
 
             <TableSkeleton v-else />
 
-            <div v-if="invitations.length > 0" class="mt-6 border-t border-gray-200 pt-6 dark:border-gray-700">
+            <div
+              v-if="invitations.length > 0"
+              class="mt-6 border-t border-gray-200 pt-6 dark:border-gray-700">
               <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300">
                 {{ t('web.organizations.invitations.pending_invitations') }}
               </h4>
               <div class="mt-3 space-y-2">
                 <div
-                  v-for="{ invitation, statusLabel, statusBadgeClass, timeRemaining } in decoratedInvitations"
+                  v-for="{
+                    invitation,
+                    statusLabel,
+                    statusBadgeClass,
+                    timeRemaining,
+                  } in decoratedInvitations"
                   :key="invitation.id"
                   data-testid="org-invitation-row"
                   class="flex items-center justify-between rounded-md bg-gray-50 px-4 py-3 dark:bg-gray-700/50">
                   <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3">
-                    <span class="text-sm font-medium text-gray-900 dark:text-white">{{ invitation.email }}</span>
+                    <span class="text-sm font-medium text-gray-900 dark:text-white">{{
+                      invitation.email
+                    }}</span>
                     <div class="flex items-center gap-2">
                       <span
                         :class="statusBadgeClass"
@@ -1458,7 +1565,8 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                         {{ statusLabel }}
                       </span>
                       <span class="text-xs text-gray-500 dark:text-gray-400">
-                        {{ t('web.organizations.invitations.invited_at') }} {{ formatDisplayDate(new Date(invitation.invited_at * 1000)) }}
+                        {{ t('web.organizations.invitations.invited_at') }}
+                        {{ formatDisplayDate(new Date(invitation.invited_at * 1000)) }}
                       </span>
                       <span class="text-xs text-gray-500 dark:text-gray-400">·</span>
                       <span class="text-xs text-gray-500 dark:text-gray-400">
@@ -1466,7 +1574,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                       </span>
                     </div>
                   </div>
-                  <div v-if="invitation.token" class="flex gap-2">
+                  <div
+                    v-if="invitation.token"
+                    class="flex gap-2">
                     <button
                       type="button"
                       @click="handleResendInvitation(invitation.token!)"
@@ -1563,9 +1673,12 @@ const handleTabKeydown = (e: KeyboardEvent) => {
           data-testid="org-section-subscription"
           class="space-y-6">
           <!-- Billing Disabled Notice -->
-          <div v-if="!billingEnabled" class="rounded-lg border border-gray-200/60 bg-white/60 shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/60">
+          <div
+            v-if="!billingEnabled"
+            class="rounded-lg border border-gray-200/60 bg-white/60 shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/60">
             <div class="p-6">
-              <div class="rounded-lg border-2 border-dashed border-gray-300 p-12 text-center dark:border-gray-600">
+              <div
+                class="rounded-lg border-2 border-dashed border-gray-300 p-12 text-center dark:border-gray-600">
                 <OIcon
                   collection="heroicons"
                   name="credit-card"
@@ -1584,7 +1697,8 @@ const handleTabKeydown = (e: KeyboardEvent) => {
           <!-- Billing Enabled -->
           <template v-else>
             <!-- Subscription Overview -->
-            <div class="rounded-lg border border-gray-200/60 bg-white/60 shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/60">
+            <div
+              class="rounded-lg border border-gray-200/60 bg-white/60 shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/60">
               <div class="border-b border-gray-200 px-6 py-4 dark:border-gray-700">
                 <h3 class="text-base font-semibold text-gray-900 dark:text-white">
                   {{ t('web.billing.subscription.status') }}
@@ -1596,7 +1710,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                   v-if="isLoadingBilling"
                   :heading="false" />
 
-                <div v-else-if="subscription" class="space-y-4">
+                <div
+                  v-else-if="subscription"
+                  class="space-y-4">
                   <!-- Plan Info -->
                   <div class="flex items-start justify-between">
                     <div>
@@ -1624,9 +1740,15 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                       {{ t('web.billing.subscription.team_usage') }}
                     </p>
                     <p class="mt-1 text-sm text-gray-900 dark:text-white">
-                      {{ t('web.billing.subscription.teams_used', { used: subscription.teams_used, limit: subscription.teams_limit }) }}
+                      {{
+                        t('web.billing.subscription.teams_used', {
+                          used: subscription.teams_used,
+                          limit: subscription.teams_limit,
+                        })
+                      }}
                     </p>
-                    <div class="mt-2 h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+                    <div
+                      class="mt-2 h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
                       <div
                         :class="[
                           'h-full transition-all',
@@ -1634,7 +1756,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                             ? 'bg-red-500'
                             : 'bg-brand-500',
                         ]"
-                        :style="{ width: `${Math.min((subscription.teams_used / subscription.teams_limit) * 100, 100)}%` }"></div>
+                        :style="{
+                          width: `${Math.min((subscription.teams_used / subscription.teams_limit) * 100, 100)}%`,
+                        }"></div>
                     </div>
                   </div>
 
@@ -1645,7 +1769,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                     </p>
 
                     <!-- Features from billing overview (i18n locale keys) -->
-                    <div v-if="planFeatures.length > 0" class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                    <div
+                      v-if="planFeatures.length > 0"
+                      class="grid grid-cols-1 gap-2 sm:grid-cols-2">
                       <div
                         v-for="feature in planFeatures"
                         :key="feature"
@@ -1660,7 +1786,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                     </div>
 
                     <!-- Fallback to org entitlements if no plan features -->
-                    <div v-else-if="entitlements.length > 0" class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                    <div
+                      v-else-if="entitlements.length > 0"
+                      class="grid grid-cols-1 gap-2 sm:grid-cols-2">
                       <div
                         v-for="ent in entitlements"
                         :key="ent"
@@ -1675,7 +1803,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                     </div>
 
                     <!-- Loading skeleton -->
-                    <div v-else-if="isLoadingBilling" class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                    <div
+                      v-else-if="isLoadingBilling"
+                      class="grid grid-cols-1 gap-2 sm:grid-cols-2">
                       <div
                         v-for="i in 4"
                         :key="i"
@@ -1686,7 +1816,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                     </div>
 
                     <!-- No features available -->
-                    <div v-else class="text-sm text-gray-500 dark:text-gray-400">
+                    <div
+                      v-else
+                      class="text-sm text-gray-500 dark:text-gray-400">
                       {{ t('web.billing.overview.no_entitlements') }}
                     </div>
                   </div>
@@ -1729,7 +1861,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                 </div>
 
                 <!-- Legacy Plan (Early Supporter) - no modern subscription record but has planid -->
-                <div v-else-if="isLegacyCustomer" class="space-y-4">
+                <div
+                  v-else-if="isLegacyCustomer"
+                  class="space-y-4">
                   <div class="flex items-start justify-between">
                     <div>
                       <p class="text-sm font-medium text-gray-500 dark:text-gray-400">
@@ -1739,7 +1873,8 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                         {{ t('web.billing.plans.early_supporter_plan') }}
                       </p>
                     </div>
-                    <span class="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-400">
+                    <span
+                      class="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-400">
                       {{ t('web.organizations.early_supporter_badge') }}
                     </span>
                   </div>
@@ -1771,7 +1906,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                 </div>
 
                 <!-- No Subscription (Free Plan) -->
-                <div v-else class="text-center">
+                <div
+                  v-else
+                  class="text-center">
                   <OIcon
                     collection="tabler"
                     name="square-letter-s"
@@ -1809,10 +1946,12 @@ const handleTabKeydown = (e: KeyboardEvent) => {
           data-testid="org-section-sso"
           class="space-y-6">
           <!-- Domain SSO Configuration -->
-          <div class="rounded-lg border border-gray-200/60 bg-white/60 shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/60">
+          <div
+            class="rounded-lg border border-gray-200/60 bg-white/60 shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/60">
             <div class="border-b border-gray-200 px-6 py-4 dark:border-gray-700">
               <div class="flex items-center gap-3">
-                <div class="flex size-10 items-center justify-center rounded-lg bg-brand-100 dark:bg-brand-900/30">
+                <div
+                  class="flex size-10 items-center justify-center rounded-lg bg-brand-100 dark:bg-brand-900/30">
                   <OIcon
                     collection="heroicons"
                     name="shield-check"
@@ -1852,7 +1991,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
               </EmptyState>
 
               <!-- Domain list -->
-              <div v-else class="space-y-3">
+              <div
+                v-else
+                class="space-y-3">
                 <div
                   v-for="domain in domainRecords"
                   :key="domain.extid"
@@ -1873,7 +2014,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                         class="text-xs text-yellow-700 hover:underline dark:text-yellow-400">
                         {{ t('web.domains.pending_verification') }}
                       </router-link>
-                      <p v-else class="text-xs text-gray-500 dark:text-gray-400">
+                      <p
+                        v-else
+                        class="text-xs text-gray-500 dark:text-gray-400">
                         {{ t('web.domains.verified') }}
                       </p>
                     </div>
@@ -1913,10 +2056,11 @@ const handleTabKeydown = (e: KeyboardEvent) => {
           </div>
         </section>
 
-        <!-- Activity Tab (Secret Activity audit trail) — the panel always
-             renders; only its CONTENT gates on the audit_logs entitlement -->
+        <!-- Activity Tab (Secret Activity audit trail) — absent when the
+             instance flag is off; when on, the panel always renders and only
+             its CONTENT gates on the audit_logs entitlement -->
         <section
-          v-if="activeTab === 'activity'"
+          v-if="orgAuditLogsFeatureEnabled && activeTab === 'activity'"
           id="org-panel-activity"
           role="tabpanel"
           aria-labelledby="org-tab-activity"
@@ -1971,7 +2115,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
             </div>
           </div>
 
-          <div v-if="canViewAuditLogs" class="p-6">
+          <div
+            v-if="canViewAuditLogs"
+            class="p-6">
             <SecretActivityTable :org-extid="orgId" />
           </div>
         </section>
@@ -1981,7 +2127,11 @@ const handleTabKeydown = (e: KeyboardEvent) => {
     <ConfirmDialog
       v-if="isDeleteRevealed"
       :title="t('web.organizations.delete_organization_confirm_title')"
-      :message="t('web.organizations.delete_organization_confirm_message', { name: organization?.display_name })"
+      :message="
+        t('web.organizations.delete_organization_confirm_message', {
+          name: organization?.display_name,
+        })
+      "
       type="danger"
       @confirm="confirmDelete"
       @cancel="cancelDelete" />
@@ -1989,7 +2139,11 @@ const handleTabKeydown = (e: KeyboardEvent) => {
     <ConfirmDialog
       v-if="isLeaveRevealed"
       :title="t('web.organizations.leave_organization_confirm_title')"
-      :message="t('web.organizations.leave_organization_confirm_message', { name: organization?.display_name })"
+      :message="
+        t('web.organizations.leave_organization_confirm_message', {
+          name: organization?.display_name,
+        })
+      "
       type="danger"
       @confirm="confirmLeave"
       @cancel="cancelLeave" />

--- a/src/apps/workspace/account/settings/OrganizationSettings.vue
+++ b/src/apps/workspace/account/settings/OrganizationSettings.vue
@@ -103,11 +103,32 @@
 
   const orgId = computed(() => route.params.extid as string);
 
-  // Resolve initial tab from route param or prop
+  // Resolve initial tab from route param or prop.
+  //
+  // Only the INSTANCE flag is applied here — it's the one gate knowable
+  // synchronously from the bootstrap snapshot. A deep link to /activity on an
+  // install with ORGS_AUDIT_LOGS_ENABLED=false would otherwise seat
+  // activeTab='activity' with no matching tab or panel until onMounted's three
+  // awaits resolve and checkInitialTabRedirect() fires. Nothing is painted in
+  // that window today — isLoading starts true so the skeleton covers the
+  // content area, and the tab bar is v-if'd on `organization`, which is still
+  // null — but guarding here removes the invalid state rather than leaving it
+  // to hold on that await ordering. The entitlement-gated tabs ('members',
+  // 'sso') are deliberately NOT handled here: they depend on permissions that
+  // aren't known until fetchAllPermissions() resolves, so they stay in
+  // checkInitialTabRedirect().
+  //
+  // Calls isOrgsAuditLogsEnabled() rather than the orgAuditLogsFeatureEnabled
+  // computed below — that binding is declared later and is still in its TDZ
+  // when this runs during setup.
   const resolveInitialTab = (): TabType => {
     const urlTab = route.params.tab as string | undefined;
     if (urlTab && URL_TO_TAB[urlTab]) {
-      return URL_TO_TAB[urlTab];
+      const resolved = URL_TO_TAB[urlTab];
+      if (resolved === 'activity' && !isOrgsAuditLogsEnabled()) {
+        return props.initialTab;
+      }
+      return resolved;
     }
     return props.initialTab;
   };

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -283,6 +283,10 @@ const organizationFeaturesInner = z.object({
   sso_enabled: z.boolean().default(false),
   custom_mail_enabled: z.boolean().default(false),
   incoming_secrets_enabled: z.boolean().default(false),
+  // Default-ON (unlike siblings): only an explicit false — set via
+  // ORGS_AUDIT_LOGS_ENABLED=false — hides the org Secret Activity tab.
+  // Absent (older backends without the flag) keeps the feature enabled.
+  audit_logs_enabled: z.boolean().default(true),
 });
 
 export const featuresSchema = z.object({

--- a/src/tests/apps/workspace/account/OrganizationSettings.spec.ts
+++ b/src/tests/apps/workspace/account/OrganizationSettings.spec.ts
@@ -195,10 +195,12 @@ vi.mock('@/shared/composables/useEntitlements', () => ({
   }),
 }));
 
-// Mock features (SSO feature flag)
+// Mock features (SSO opt-in flag + default-ON audit logs instance flag)
 const mockOrgsSsoEnabled = ref(false);
+const mockOrgsAuditLogsEnabled = ref(true);
 vi.mock('@/utils/features', () => ({
   isOrgsSsoEnabled: () => mockOrgsSsoEnabled.value,
+  isOrgsAuditLogsEnabled: () => mockOrgsAuditLogsEnabled.value,
 }));
 
 vi.mock('@/shared/composables/useAsyncHandler', () => ({
@@ -236,6 +238,7 @@ describe('OrganizationSettings', () => {
     mockDomainCount.value = 0;
     mockCanCreateDomain.value = true;
     mockOrgsSsoEnabled.value = false;
+    mockOrgsAuditLogsEnabled.value = true;
   });
 
   afterEach(() => {
@@ -664,6 +667,62 @@ describe('OrganizationSettings', () => {
         await switchToActivityTab(wrapper);
 
         expect(findActivityTable(wrapper).exists()).toBe(false);
+      });
+    });
+
+    describe('instance flag off (ORGS_AUDIT_LOGS_ENABLED=false)', () => {
+      // Distinct axis from the entitlement: when the instance flag is off the
+      // tab is EXCLUDED entirely (not disabled, not upgrade-noticed) — even
+      // for an entitled admin.
+      beforeEach(() => {
+        mockOrgsAuditLogsEnabled.value = false;
+        mockEntitlements.value = ['manage_members', 'audit_logs'];
+      });
+
+      it('does not render the Activity tab at all', async () => {
+        wrapper = await mountComponent();
+
+        const navTabs = wrapper.find('nav[aria-label="Organization settings tabs"]');
+        const activityTab = navTabs
+          .findAll('button')
+          .find((tab) => tab.attributes('id') === 'org-tab-activity');
+        expect(activityTab).toBeUndefined();
+        expect(findPanel(wrapper).exists()).toBe(false);
+      });
+
+      it('never activates activity via keyboard traversal', async () => {
+        wrapper = await mountComponent();
+        const navTabs = wrapper.find('nav[aria-label="Organization settings tabs"]');
+
+        // Cycle through every reachable tab; activity must never become
+        // selected and its panel must never mount.
+        const tabCount = navTabs.findAll('button').length;
+        for (let i = 0; i <= tabCount; i++) {
+          await navTabs.trigger('keydown', { key: 'ArrowRight' });
+          await flushPromises();
+          await nextTick();
+
+          const selected = navTabs
+            .findAll('button')
+            .find((tab) => tab.attributes('aria-selected') === 'true');
+          expect(selected?.attributes('id')).not.toBe('org-tab-activity');
+          expect(findPanel(wrapper).exists()).toBe(false);
+          expect(findActivityTable(wrapper).exists()).toBe(false);
+        }
+      });
+    });
+
+    describe('instance flag on (default)', () => {
+      it('renders the Activity tab (unchanged behavior)', async () => {
+        // beforeEach default: mockOrgsAuditLogsEnabled = true (absent key on
+        // older backends also reads as ON — see features.spec.ts)
+        wrapper = await mountComponent();
+
+        const navTabs = wrapper.find('nav[aria-label="Organization settings tabs"]');
+        const activityTab = navTabs
+          .findAll('button')
+          .find((tab) => tab.attributes('id') === 'org-tab-activity');
+        expect(activityTab).toBeDefined();
       });
     });
 

--- a/src/tests/apps/workspace/account/OrganizationSettings.spec.ts
+++ b/src/tests/apps/workspace/account/OrganizationSettings.spec.ts
@@ -7,11 +7,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { nextTick, ref } from 'vue';
 import { createTestI18n } from '@tests/setup';
 
-// Mock vue-router
+// Mock vue-router.
+// `params` is a shared mutable object so tests can simulate a deep link
+// (e.g. /org/on1abc123/activity) by setting `mockRouteParams.tab` before mount.
+// Reset in beforeEach.
+const mockRouteParams: Record<string, string | undefined> = {
+  extid: 'on1abc123',
+  orgid: 'on1abc123',
+};
 vi.mock('vue-router', () => ({
   useRoute: () => ({
     path: '/org/on1abc123',
-    params: { extid: 'on1abc123', orgid: 'on1abc123' },
+    params: mockRouteParams,
     query: {},
   }),
   useRouter: () => ({
@@ -239,13 +246,17 @@ describe('OrganizationSettings', () => {
     mockCanCreateDomain.value = true;
     mockOrgsSsoEnabled.value = false;
     mockOrgsAuditLogsEnabled.value = true;
+    delete mockRouteParams.tab;
   });
 
   afterEach(() => {
     wrapper?.unmount();
   });
 
-  const mountComponent = async () => {
+  // Mounts without awaiting. Use when a test needs the pre-fetch render, i.e.
+  // the window before onMounted's awaits (initDefinitions / fetchAllPermissions
+  // / loadOrganization) resolve.
+  const mountComponentUnsettled = () => {
     const pinia = createTestingPinia({
       createSpy: vi.fn,
       initialState: {
@@ -263,6 +274,11 @@ describe('OrganizationSettings', () => {
         },
       },
     });
+    return wrapper;
+  };
+
+  const mountComponent = async () => {
+    mountComponentUnsettled();
     await flushPromises();
     await nextTick();
     return wrapper;
@@ -710,6 +726,47 @@ describe('OrganizationSettings', () => {
           expect(findActivityTable(wrapper).exists()).toBe(false);
         }
       });
+
+      // Deep link (/org/<extid>/activity) on a flag-off install. The URL
+      // segment must never seat activeTab='activity' — not even for the window
+      // before onMounted's three awaits (initDefinitions / fetchAllPermissions
+      // / loadOrganization) resolve, since no tab and no panel matches
+      // 'activity' when the flag is off. resolveInitialTab() applies the
+      // instance flag synchronously; checkInitialTabRedirect() only corrects
+      // it after those fetches land, which is too late to be the only guard.
+      describe('deep link to /activity', () => {
+        beforeEach(() => {
+          mockRouteParams.tab = 'activity';
+        });
+
+        it('never seats activity before the mount fetches resolve', () => {
+          wrapper = mountComponentUnsettled();
+
+          // Synchronous assertion: no flushPromises, so onMounted's awaits
+          // (and checkInitialTabRedirect) have not run yet.
+          expect((wrapper.vm as unknown as { activeTab: string }).activeTab).toBe('domains');
+          expect(findPanel(wrapper).exists()).toBe(false);
+          // The loading skeleton (isLoading starts true) covers this window,
+          // so the invalid tab state was never painted — but the state itself
+          // must still be valid, independent of that coverage.
+          expect(wrapper.find('[role="status"][aria-busy="true"]').exists()).toBe(true);
+        });
+
+        it('lands on the default tab with its panel rendered, not a blank area', async () => {
+          wrapper = await mountComponent();
+
+          const navTabs = wrapper.find('nav[aria-label="Organization settings tabs"]');
+          const selected = navTabs
+            .findAll('button')
+            .find((tab) => tab.attributes('aria-selected') === 'true');
+          expect(selected?.attributes('id')).toBe('org-tab-domains');
+
+          // Content area is populated, not empty.
+          expect(wrapper.find('[data-testid="org-section-domains"]').exists()).toBe(true);
+          expect(findPanel(wrapper).exists()).toBe(false);
+          expect(findActivityTable(wrapper).exists()).toBe(false);
+        });
+      });
     });
 
     describe('instance flag on (default)', () => {
@@ -723,6 +780,16 @@ describe('OrganizationSettings', () => {
           .findAll('button')
           .find((tab) => tab.attributes('id') === 'org-tab-activity');
         expect(activityTab).toBeDefined();
+      });
+
+      it('honours a deep link to /activity (flag guard does not overreach)', async () => {
+        mockRouteParams.tab = 'activity';
+        mockEntitlements.value = ['manage_members', 'audit_logs'];
+
+        wrapper = await mountComponent();
+
+        expect((wrapper.vm as unknown as { activeTab: string }).activeTab).toBe('activity');
+        expect(findPanel(wrapper).exists()).toBe(true);
       });
     });
 

--- a/src/tests/utils/features.spec.ts
+++ b/src/tests/utils/features.spec.ts
@@ -16,6 +16,7 @@ import {
   getAuthFeatures,
   isOrganizationSwitcherEnabled,
   isOrgsSsoEnabled,
+  isOrgsAuditLogsEnabled,
   isOrgsCustomMailEnabled,
   isOrgsIncomingSecretsEnabled,
   isOwnerOrAdminOf,
@@ -805,6 +806,78 @@ describe('features utility', () => {
       });
 
       const result = isOrgsSsoEnabled();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  // Default-ON flag (unlike the opt-in siblings): only an explicit `false`
+  // disables. Absent keys — including the ambient vitest state where the
+  // bootstrap seeds no `features` at all — must read as enabled.
+  describe('isOrgsAuditLogsEnabled', () => {
+    it('returns true when organizations.audit_logs_enabled is true', () => {
+      getBootstrapValueMock.mockReturnValue({ organizations: { audit_logs_enabled: true } });
+
+      const result = isOrgsAuditLogsEnabled();
+
+      expect(result).toBe(true);
+      expect(getBootstrapValueMock).toHaveBeenCalledWith('features');
+    });
+
+    it('returns false when organizations.audit_logs_enabled is false', () => {
+      getBootstrapValueMock.mockReturnValue({ organizations: { audit_logs_enabled: false } });
+
+      const result = isOrgsAuditLogsEnabled();
+
+      expect(result).toBe(false);
+    });
+
+    it('returns true when organizations object is empty (absent key = default ON)', () => {
+      getBootstrapValueMock.mockReturnValue({ organizations: {} });
+
+      const result = isOrgsAuditLogsEnabled();
+
+      expect(result).toBe(true);
+    });
+
+    it('returns true when organizations is undefined (older backend)', () => {
+      getBootstrapValueMock.mockReturnValue({});
+
+      const result = isOrgsAuditLogsEnabled();
+
+      expect(result).toBe(true);
+    });
+
+    it('returns true when features object is undefined (no bootstrap key)', () => {
+      getBootstrapValueMock.mockReturnValue(undefined);
+
+      const result = isOrgsAuditLogsEnabled();
+
+      expect(result).toBe(true);
+    });
+
+    it('returns true when audit_logs_enabled is null (only literal false disables)', () => {
+      getBootstrapValueMock.mockReturnValue({ organizations: { audit_logs_enabled: null } });
+
+      const result = isOrgsAuditLogsEnabled();
+
+      expect(result).toBe(true);
+    });
+
+    it('returns true for non-boolean values (fail-open by design)', () => {
+      getBootstrapValueMock.mockReturnValue({ organizations: { audit_logs_enabled: 'no' } });
+
+      const result = isOrgsAuditLogsEnabled();
+
+      expect(result).toBe(true);
+    });
+
+    it('is independent of the sibling opt-in flags', () => {
+      getBootstrapValueMock.mockReturnValue({
+        organizations: { enabled: false, sso_enabled: false, audit_logs_enabled: false },
+      });
+
+      const result = isOrgsAuditLogsEnabled();
 
       expect(result).toBe(false);
     });

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -548,6 +548,27 @@ export function isOrgsCustomMailEnabled(): boolean {
 }
 
 /**
+ * Checks if the organization Secret Activity (audit trail) UI is enabled.
+ * When true (the default), the Activity tab renders in org settings and the
+ * panel content gates on the audit_logs entitlement + admin/owner role.
+ * Default is ON — only an explicit `false` (ORGS_AUDIT_LOGS_ENABLED=false)
+ * disables it; an absent key (older backend without the flag) keeps the
+ * feature on. This inverts the sibling helpers' `=== true` opt-in check.
+ *
+ * SSR/no-window guard returns true (not false like the default-OFF siblings):
+ * absent information means ON for this flag, matching featuresSchema.parse({})
+ * which yields audit_logs_enabled: true.
+ */
+export function isOrgsAuditLogsEnabled(): boolean {
+  if (typeof window === 'undefined') return true;
+
+  const features = getBootstrapValue('features');
+  const result = features?.organizations?.audit_logs_enabled !== false;
+  debugLog.features('features.isOrgsAuditLogsEnabled', { audit_logs_enabled: features?.organizations?.audit_logs_enabled, result });
+  return result;
+}
+
+/**
  * Checks if organization-level incoming secrets configuration is enabled.
  * When true, organizations with incoming_secrets entitlement can configure
  * incoming secret receiving for their domains.

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -558,6 +558,15 @@ export function isOrgsCustomMailEnabled(): boolean {
  * SSR/no-window guard returns true (not false like the default-OFF siblings):
  * absent information means ON for this flag, matching featuresSchema.parse({})
  * which yields audit_logs_enabled: true.
+ *
+ * Reads the bootstrap snapshot directly via getBootstrapValue, like the other
+ * organizations flag wrappers here, rather than through getValidatedFeatures()
+ * (used only by isSsoEnforcedForDomain). That helper memoizes the parsed
+ * features in a module-level cache that is never invalidated, so a flag read
+ * through it would freeze at the first parse instead of following
+ * bootstrapStore.update() -> updateBootstrapSnapshot. Schema validation buys
+ * nothing here either: the serializer normalizes this key to a real boolean,
+ * and `!== false` already implements the default-true contract.
  */
 export function isOrgsAuditLogsEnabled(): boolean {
   if (typeof window === 'undefined') return true;


### PR DESCRIPTION
Adds an instance-level exclusion flag for the organization Secret Activity (audit trail) feature, giving self-hosted operators the same control the other `ORGS_*` flags provide for SSO, custom mail, and incoming secrets. Unlike those siblings it defaults **ON** (`ORGS_AUDIT_LOGS_ENABLED=false` to opt out), since the trail already ships working — the default-true contract (absent key = enabled) is enforced at all three layers: config ERB, `config_serializer.rb`, and the `isOrgsAuditLogsEnabled()` frontend helper. Enforcement is server-side first (`ListSecretActivity` rejects `:forbidden`, mirroring `DomainConfigAuthorization#verify_feature_flag!`); the Activity tab is hidden entirely in `OrganizationSettings.vue` across all activation paths (click, keyboard, deep link, back/forward). Exposure-only: event collection (`SecretActivity` fan-out) and `ColonelAuditEvent` are deliberately untouched.

Also carries two small env-settings commits: Caddyfile example hardening for IP header forwarding, and AGENTS.md git-usage guidelines.

> [!IMPORTANT]
> If running behind a reverse proxy that you trust, set `TRUSTED_PROXY_ENABLED=true`. This is not a new setting  (since v0.25) but we've updated the documentation to be more clear. When not set or set incorrectly, the proper request client IP address will be the internal private address of one of the proxies. See `.env.reference`. 