### PR TITLE
*Clarify environment terminology and scoping

### DIFF
--- a/docs/architecture/decision-records/adr-008-secret-management-architecture.md
+++ b/docs/architecture/decision-records/adr-008-secret-management-architecture.md
@@ -59,3 +59,14 @@ The derived/independent split follows from an asymmetry in rotation capability: 
 - **We lose**: Operational simplicity of one root secret. Operators must back up three independent values plus coordinate FEDERATION_SECRET across instances.
 - **We gain**: Rotation isolation. Familia's rolling key versioning handles SECRET rotation cleanly; auth and password secrets rotate on their own timelines via Rodauth's `hmac_old_secret` and re-hash-on-login respectively.
 - **Risk**: AUTH_SECRET and ARGON2_SECRET cannot be regenerated if lost. This is the explicit trade for rotation isolation.
+
+## Familia 2.12 Capabilities (v0.26.4+)
+
+Familia 2.12 unlocks additional cryptographic options. These are available but not yet enabled:
+
+| Capability | Status | Notes |
+|------------|--------|-------|
+| `encryption_personalization` rotation | Available | Set a per-deployment value; legacy `'FamilialMatters'` decrypts automatically via built-in fallback. No history entry needed for the default. |
+| Per-field `algorithm:` override | Available | Enables reader-before-writer XChaCha20 rollout: deploy readers that accept both algorithms, then flip writers per-field. |
+| Blank `VERIFIABLE_ID_HMAC_SECRET` rejection | Active | Library rejects blank secrets at mint time (delano/familia#335). OTS boot-time derivation guard (`configure_familia.rb`) is defense-in-depth. |
+| Verification-on-read | Blocked | `verified_identifier?` would reject identifiers minted under prior keys. Requires upstream secret-history mechanism; re-minting is not viable. Tracked in #3630. |

--- a/docs/architecture/encryption-at-rest-dpa-audit.md
+++ b/docs/architecture/encryption-at-rest-dpa-audit.md
@@ -71,8 +71,11 @@ under the new default cannot be read by 2.10.x (which has no fallback
 loop). Mitigations in this branch: rbnacl + libsodium ship in the same
 image as the familia upgrade (no AES-writes-under-new-salt window in
 practice), and we pin `encryption_hkdf_salt = 'FamiliaEncryption'`
-(Finding F3) so any AES write remains 2.10.x-compatible. Deploy the whole
-fleet in one rollout; do not run mixed old/new nodes longer than necessary.
+(Finding F3) so any AES write remains 2.10.x-compatible. Upgrade every
+process sharing a datastore in one rollout; do not run mixed old/new
+nodes against the same datastore longer than necessary. (Regions are
+independent — each region's rollout stands alone, and the same rule
+holds for a self-hosted install.)
 
 **F3 (high, latent): domain-separation inputs were implicit.** We never set
 `encryption_personalization` (XChaCha BLAKE2b) or `encryption_hkdf_salt`
@@ -183,7 +186,7 @@ familia encrypted fields eventually.
    (`apt install libsodium23` / `apk add libsodium` / `brew install
    libsodium`). Without it, `require 'rbnacl'` fails to find the library
    and boot fails — which is preferable to silently staying on AES.
-3. **Deploy fleet-wide in one rollout** (F2). Verify post-deploy:
+3. **Deploy every node sharing a datastore in one rollout** (F2). Verify post-deploy:
    `Familia::Encryption.status[:default_algorithm] == 'xchacha20poly1305'`.
 4. **Rollback window**: removing rbnacl/libsodium after deploy makes
    secrets created since the deploy unreadable (clean errors). Rolling the

--- a/docs/architecture/regions.md
+++ b/docs/architecture/regions.md
@@ -4,6 +4,8 @@ labels: regions, jurisdictions, data-sovereignty
 
 # Regions Architecture
 
+> Terminology (fleet vs. federation vs. region vs. deployment): see [terminology.md](./terminology.md#deployment-topology-terminology).
+
 Regions enable multi-jurisdiction deployments where each geographic instance runs independently with its own domain, billing catalog, and data store. Users can see which region they're on and switch between them.
 
 ## Use Cases

--- a/docs/architecture/terminology.md
+++ b/docs/architecture/terminology.md
@@ -7,4 +7,16 @@
 | authorize_domain_sso! | Policy / Authorizer          | Pundit, CanCanCan, Laravel Policies, Phoenix authorize/3 |
 | raise_concerns      | Before Action / Middleware   | Rails before_action, Laravel middleware, Phoenix plugs |
 | Session org → Domain org | Tenant Resolution / Scope Binding | Multi-tenancy libraries (Apartment, acts_as_tenant)    |
-```
+
+## Deployment Topology Terminology
+
+| Term | Meaning |
+| ---- | ------- |
+| **fleet** | The entire operated estate: every region/instance the Onetime Secret team runs, as opposed to third-party self-hosted installs (the ADR-030 sense: "not merely convenient for our fleet"). Never use "fleet" for the set of processes in one region — that coupling unit is a region/environment. "Fleet" is also fine for a managed population of like entities ("fleet of custom domains", "fleet of organizations" in colonel/domains tooling); that usage is correct. |
+| **federation / federated** | The cross-region layer only: regional instances sharing identity/billing linkage via `FEDERATION_SECRET` (ADR-008: "shared per-federation-group", cross-region email hashing for billing federation). Correct wherever cross-region billing/identity is meant; a misuse is applying it to anything intra-region. |
+| **region / environment** | Interchangeable. One datastore-scoped operating unit: the app processes (web workers + background workers) sharing one Valkey/Redis and authdb. This is the decryption-coupling boundary — a secret encrypted in Region A never needs decrypting in Region B. Rollout constraints about mixed old/new code sharing a datastore are region-scoped (better: datastore-scoped), not fleet-scoped. |
+| **deployment / jurisdiction** | Interchangeable depending on context. "Jurisdiction" is the identifier/data-residency framing of a region (EU, US, NZ — see [regions.md](./regions.md), `JURISDICTION` env var); "deployment" is the install/rollout framing, including a self-hoster's single install. A self-hoster's deployment is its own single region. |
+
+**Rollout invariants are datastore-scoped, not fleet-scoped.** Statements about code-version coupling through shared data (e.g. "deploy X everywhere before Y writes the new format") must be scoped to the datastore/region, not the fleet. Prefer the datastore-scoped phrasing — "no process may write the new format until every process reading that datastore is upgraded" — because it is also correct for self-hosters.
+
+See [regions.md](./regions.md) for region/jurisdiction configuration, ADR-008 for federation, and ADR-030 for the fleet sense.

--- a/docs/specs/early-access-flags/early-access-feature-flags.md
+++ b/docs/specs/early-access-flags/early-access-feature-flags.md
@@ -152,8 +152,8 @@ derived from it (mirror of the `entitlement_keys_spec.rb` pattern).
 ### 2.2 Storage — the existing hashkey, unchanged
 
 `Customer#feature_flags` (`customer.rb:99`) stays as-is. Per-customer Redis
-hash means revoking a bad experiment for every customer is a scan-and-delete
-script, not a migration. No org- or membership-level storage: if an
+hash means revoking a bad experiment across a datastore is a scan-and-delete
+script (per region in multi-region deployments), not a migration. No org- or membership-level storage: if an
 experiment must be limited to certain plans later, that is the plan-feature
 axis composing with this one (§3.2), not a reason to move the flag.
 
@@ -200,7 +200,7 @@ effective(flag, cust) =
 - **Support/operator**: colonel customer screen (fits
   `docs/specs/colonel-ui/22-customers-ui.md` surface) gets a flag editor for
   any registry flag, plus a CLI (`bin/ots customers flags ...`) for scripted
-  grant/revoke and the all-customers clear.
+  grant/revoke and per-datastore bulk clear.
 
 ### 2.6 Read paths — exactly one per side (the ADR-020 rule)
 
@@ -261,7 +261,7 @@ user-visible change.*
 
 **Stage 1 — write paths.**
 Self-serve settings endpoint + "Early access" settings UI. Colonel flag
-editor + CLI (incl. all-customers clear). Install-config kill-switch path
+editor + CLI (incl. per-datastore bulk clear). Install-config kill-switch path
 through `config_serializer`, ANDed in both read paths. *Outcome: opt-in is
 self-serve, revocation is layered, ops can act without a deploy.*
 

--- a/docs/specs/early-access-flags/early-access-feature-flags.md
+++ b/docs/specs/early-access-flags/early-access-feature-flags.md
@@ -152,7 +152,7 @@ derived from it (mirror of the `entitlement_keys_spec.rb` pattern).
 ### 2.2 Storage — the existing hashkey, unchanged
 
 `Customer#feature_flags` (`customer.rb:99`) stays as-is. Per-customer Redis
-hash means fleet-wide revocation of a bad experiment is a scan-and-delete
+hash means revoking a bad experiment for every customer is a scan-and-delete
 script, not a migration. No org- or membership-level storage: if an
 experiment must be limited to certain plans later, that is the plan-feature
 axis composing with this one (§3.2), not a reason to move the flag.
@@ -200,7 +200,7 @@ effective(flag, cust) =
 - **Support/operator**: colonel customer screen (fits
   `docs/specs/colonel-ui/22-customers-ui.md` surface) gets a flag editor for
   any registry flag, plus a CLI (`bin/ots customers flags ...`) for scripted
-  grant/revoke and the fleet-wide clear.
+  grant/revoke and the all-customers clear.
 
 ### 2.6 Read paths — exactly one per side (the ADR-020 rule)
 
@@ -261,7 +261,7 @@ user-visible change.*
 
 **Stage 1 — write paths.**
 Self-serve settings endpoint + "Early access" settings UI. Colonel flag
-editor + CLI (incl. fleet-wide clear). Install-config kill-switch path
+editor + CLI (incl. all-customers clear). Install-config kill-switch path
 through `config_serializer`, ANDed in both read paths. *Outcome: opt-in is
 self-serve, revocation is layered, ops can act without a deploy.*
 

--- a/lib/onetime/initializers/configure_familia.rb
+++ b/lib/onetime/initializers/configure_familia.rb
@@ -133,8 +133,12 @@ module Onetime
         #
         # Safe to set per deployment: nothing reads identifiers back through
         # Familia::VerifiableIdentifier.verified_identifier? yet, so tags minted
-        # under any prior (committed-fallback or empty) key still resolve. Revisit
-        # if verification-on-read is ever introduced -- tracked in issue #3630.
+        # under any prior (committed-fallback or empty) key still resolve.
+        #
+        # Verification-on-read (#3630): enabling verified_identifier? would reject
+        # identifiers minted under prior keys. Requires upstream secret-history
+        # mechanism (no familia support as of 2.12); re-minting is not viable since
+        # existing links must keep resolving.
         identifier_secret                  = ENV['IDENTIFIER_SECRET'].to_s
         if identifier_secret.empty?
           identifier_secret = Onetime::KeyDerivation.derive_hex(secret_key, :identifier)
@@ -146,12 +150,14 @@ module Onetime
         # can never silently strand ciphertext.
         #
         # encryption_personalization feeds BLAKE2b key derivation for
-        # XChaCha20-Poly1305 (used once rbnacl/libsodium are present). It is
-        # PERMANENT: Familia has no rotation/history mechanism for it, so
-        # changing this value makes every existing XChaCha20 envelope
-        # undecryptable. 'FamilialMatters' is Familia's long-standing default
-        # and therefore the only value compatible with any XChaCha20 data an
-        # installation may already hold.
+        # XChaCha20-Poly1305 (used once rbnacl/libsodium are present).
+        # 'FamilialMatters' is Familia's long-standing default and the only
+        # value compatible with any XChaCha20 data an installation may hold.
+        #
+        # Familia 2.12 supports rotation via encryption_personalization_history:
+        # set a per-deployment value and the library falls back to prior values
+        # (including the hardcoded 'FamilialMatters' default) on decrypt. See
+        # #3987 for the v0.27 rotation plan.
         Familia.config.encryption_personalization = 'FamilialMatters'
 
         # encryption_hkdf_salt feeds HKDF-SHA256 key derivation for

--- a/lib/onetime/initializers/configure_familia.rb
+++ b/lib/onetime/initializers/configure_familia.rb
@@ -160,9 +160,10 @@ module Onetime
         # default to 'FamilialMatters' and only *falls back* to the legacy
         # value on decrypt. Pinning the legacy value keeps any AES writes
         # byte-compatible with existing data and with familia 2.10.x nodes
-        # (mixed fleets / rollback), and makes legacy decrypts succeed on the
-        # first salt candidate instead of the fallback. Rotating this later is
-        # supported via encryption_hkdf_salt_history.
+        # (mixed-version nodes on one datastore / rollback), and makes legacy
+        # decrypts succeed on the first salt candidate instead of the
+        # fallback. Rotating this later is supported via
+        # encryption_hkdf_salt_history.
         # (Guarded: the knob only exists in familia >= 2.11.)
         if Familia.config.respond_to?(:encryption_hkdf_salt=)
           Familia.config.encryption_hkdf_salt         = 'FamiliaEncryption'


### PR DESCRIPTION
Add deployment topology definitions to the documentation and update rollout guidance to use 'datastore-scoped' terminology instead of 'fleet-wide' to ensure accuracy for both managed regions and self-hosted installs.

> [!IMPORTANT]
> **Encryption rotation, part 1 of 2**. This release upgrades the Familia gem to 2.12. It can decrypt secrets that were encrypted under an older encryption configuration, which makes it possible to change encryption settings in a future release without losing access to existing data. v0.26.4 itself changes no encryption settings: secrets are encrypted and stored exactly as in previous releases, and you can roll back safely.
>
> The settings change comes in v0.27.0. From that point, new secrets will be unreadable by processes still running versions older than v0.26.4. Before installing v0.27.0, make sure every process that connects to the same Redis/Valkey database (e.g. background workers) is running v0.26.4 or later. If you run everything on one host and upgrade all containers at the same time, no extra steps are needed.
> 
> See https://github.com/onetimesecret/onetimesecret/issues/3987 for part 2 of 2.
