### PR TITLE
*feat(orgs): Secret Activity collection toggle and retention cap config

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -615,6 +615,18 @@ ORGS_INCOMING_SECRETS_ENABLED=false
 # false to exclude the feature. Event collection is not affected.
 ORGS_AUDIT_LOGS_ENABLED=true
 
+# Whether organization secret-activity events are recorded at all (GDPR
+# data minimization). Enabled by default; set to false to pause collection.
+# Pausing stops new events from being recorded — existing events stay
+# readable (pair with ORGS_AUDIT_LOGS_ENABLED=false to also hide them).
+SECRET_ACTIVITY_COLLECT=true
+
+# Newest secret-activity events retained per organization (floor: 100).
+# LOWERING this value DELETES (not hides) the oldest events past the new
+# cap in each org's trail, applied lazily on that org's next recorded
+# event. Setting SECRET_ACTIVITY_COLLECT=false does not trigger the trim.
+SECRET_ACTIVITY_MAX_EVENTS=10000
+
 # ═══════════════════════════════════════════════════════════
 #  CUSTOM MAIL SENDER DNS SETTINGS
 # ═══════════════════════════════════════════════════════════

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -36,4 +36,5 @@ jobs:
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           configuration-path: .github/labeler.yml
+          # Whether or not to remove labels when matching files are reverted or no longer present in the PR
           sync-labels: false

--- a/Gemfile
+++ b/Gemfile
@@ -74,15 +74,20 @@ gem 'truemail', '~> 3.3'
 # ORMs and database drivers
 # NOTE: We install both db drivers for the OCI images so that users can choose
 # which database to use at runtime via environment variable without rebuilding.
-# familia 2.11.2 floor: rejects a blank VERIFIABLE_ID_HMAC_SECRET at the library
-# layer (delano/familia#335); the 2.11 line decouples the AES-256-GCM HKDF salt
-# from the XChaCha20 personalization -- which activates the salt/personalization/
-# history pinning in ConfigureFamilia; and 2.11.2 stops persisting nil declared
-# fields as the JSON string "null" (HDEL on clear), restoring HSETNX/HEXISTS
-# atomic-claim semantics (no migration -- stale "null" decodes to nil on read).
-# Do NOT relax to 2.12: it lands breaking encryption personalization/salt-history
-# changes (delano/familia#333, #334) that need the migration tracked in issue #3630.
-gem 'familia', '~> 2.11.2'
+# familia 2.12 floor: read-side prep for the encryption rotation tracked in
+# issue #3630. 2.12.0 adds encryption_personalization_history (delano/familia#333)
+# so XChaCha20 decrypt walks current -> history -> the library default
+# 'FamilialMatters', making personalization rotatable without stranding old
+# envelopes; per-field `algorithm:` pinning (delano/familia#334, shipped 2.11.1)
+# plus envelope-driven provider dispatch means readers accept both aes-256-gcm
+# and xchacha20poly1305 ciphertext with zero configuration. This release changes
+# nothing on the write side -- ConfigureFamilia still pins the 2.11-era values
+# byte-for-byte; the write-side rotation flip lands in v0.27.0 and requires
+# every process reading the datastore to be on >= this release first.
+# (2.11.2 remains the behavior floor for blank VERIFIABLE_ID_HMAC_SECRET
+# rejection, delano/familia#335, and for nil declared fields persisting as HDEL
+# instead of the JSON string "null".)
+gem 'familia', '~> 2.12'
 gem 'pg', '~> 1.6'
 gem 'sequel', '~> 5.0'
 gem 'sqlite3', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,15 +89,13 @@ GEM
       tzinfo
     faker (3.8.0)
       i18n (>= 1.8.11, < 2)
-    familia (2.11.2)
+    familia (2.12.0)
       concurrent-ruby (~> 1.3)
       connection_pool (>= 2.4, < 4.0)
-      csv (~> 3.3)
       json_schemer (~> 2.0)
       logger (~> 1.7)
       oj (~> 3.16)
       redis (>= 5.0, < 6.0)
-      stringio (>= 3.1.1, < 3.3.0)
       uri-valkey (~> 1.4)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
@@ -616,7 +614,7 @@ DEPENDENCIES
   debug
   dry-cli (~> 1.2)
   faker (~> 3.2)
-  familia (~> 2.11.2)
+  familia (~> 2.12)
   fastimage (~> 2.4)
   htmlbeautifier
   httparty

--- a/apps/api/v2/spec/models/organization_secret_activity_spec.rb
+++ b/apps/api/v2/spec/models/organization_secret_activity_spec.rb
@@ -82,15 +82,31 @@ RSpec.describe Onetime::Organization, type: :integration do
     end
 
     it 'evicts only the oldest events past the retention cap' do
-      stub_const('Onetime::Organization::Features::SecretActivity::SECRET_ACTIVITY_MAX_EVENTS', 5)
+      feature = Onetime::Organization::Features::SecretActivity
 
-      base = Familia.now.to_f - 100
-      8.times { |i| org.record_secret_activity_event('secret_get', at: base + i) }
+      # configure! clamps to the MIN_MAX_EVENTS floor, so the smallest
+      # testable cap is the floor itself — pin the clamp while we're here.
+      expect(feature.configure!(5)).to eq(feature::MIN_MAX_EVENTS)
 
-      expect(org.secret_activity_event_count).to eq(5)
-      ats = org.secret_activity_events_page.map { |e| e['at'] }
+      # configure! is boot-time-only: an org whose accessor already ran has
+      # memoized a DataType with the old cap, so use a FRESH org here.
+      capped_org = described_class.new(
+        display_name: 'Capped Trail Org',
+        contact_email: "audit-cap-#{SecureRandom.hex(6)}@example.com",
+      ).tap(&:save)
+
+      cap  = feature::MIN_MAX_EVENTS
+      base = Familia.now.to_f - 200
+      (cap + 3).times { |i| capped_org.record_secret_activity_event('secret_get', at: base + i) }
+
+      expect(capped_org.secret_activity_event_count).to eq(cap)
+      ats = capped_org.secret_activity_events_page(limit: 200).map { |e| e['at'] }
       expect(ats.min).to be_within(0.001).of(base + 3)
-      expect(ats.max).to be_within(0.001).of(base + 7)
+      expect(ats.max).to be_within(0.001).of(base + cap + 2)
+    ensure
+      Onetime::Organization::Features::SecretActivity.configure!(
+        Onetime::Organization::Features::SecretActivity::DEFAULT_MAX_EVENTS,
+      )
     end
 
     it 'clamps pagination inputs and windows correctly' do
@@ -104,6 +120,140 @@ RSpec.describe Onetime::Organization, type: :integration do
 
       expect(org.secret_activity_events_page(offset: -3, limit: 0).size).to eq(1)
       expect(org.secret_activity_events_page(offset: 0, limit: 9_999).size).to eq(5)
+    end
+  end
+
+  # Instance-level collection toggle (SECRET_ACTIVITY_COLLECT, #3990) — the
+  # data-existence axis (GDPR minimization): whether events come to exist at
+  # all. Default-true contract: only an explicit false pauses recording — an
+  # absent key (older config file) must still record. Pausing never touches
+  # reads: existing events stay fully readable (hiding them is the separate
+  # ORGS_AUDIT_LOGS_ENABLED axis).
+  describe 'collection toggle (features.secret_activity.collect)' do
+    def conf_with_collect_flag(secret_activity)
+      base     = OT.conf
+      features = (base['features'] || {}).merge('secret_activity' => secret_activity)
+      base.merge('features' => features)
+    end
+
+    # Parity with ConfigSerializer#build_feature_flags: a hand-edited config
+    # can deliver the string 'false' where the shipped ERB emits a real
+    # boolean. If only the serializer handled it, the UI would show the
+    # paused banner while the backend kept recording.
+    it "pauses recording on the string 'false' while existing events stay readable" do
+      t1 = Familia.now.to_f - 10
+      org.record_secret_activity_event('created', at: t1, 'receipt' => 'abc123')
+
+      allow(OT).to receive(:conf)
+        .and_return(conf_with_collect_flag('collect' => 'false'))
+
+      expect(org.record_secret_activity_event('secret_get')).to be_nil
+      expect(org.secret_activity_event_count).to eq(1)
+
+      events = org.secret_activity_events_page
+      expect(events.size).to eq(1)
+      expect(events.first['kind']).to eq('created')
+      expect(events.first['at']).to be_within(0.001).of(t1)
+    end
+
+    it 'pauses recording on native false (shipped ERB boolean)' do
+      allow(OT).to receive(:conf)
+        .and_return(conf_with_collect_flag('collect' => false))
+
+      expect(org.record_secret_activity_event('secret_get')).to be_nil
+      expect(org.secret_activity_event_count).to eq(0)
+    end
+
+    it "keeps recording on the string 'true'" do
+      allow(OT).to receive(:conf)
+        .and_return(conf_with_collect_flag('collect' => 'true'))
+
+      expect(org.record_secret_activity_event('secret_get')).to be_a(Hash)
+      expect(org.secret_activity_event_count).to eq(1)
+    end
+
+    it 'keeps recording when nil (default-true contract)' do
+      allow(OT).to receive(:conf)
+        .and_return(conf_with_collect_flag('collect' => nil))
+
+      expect(org.record_secret_activity_event('secret_get')).to be_a(Hash)
+      expect(org.secret_activity_event_count).to eq(1)
+    end
+
+    it 'keeps recording when the key is absent (older config file)' do
+      allow(OT).to receive(:conf).and_return(conf_with_collect_flag({}))
+
+      expect(org.record_secret_activity_event('secret_get')).to be_a(Hash)
+      expect(org.secret_activity_event_count).to eq(1)
+    end
+  end
+
+  # Retention-cap configuration (SECRET_ACTIVITY_MAX_EVENTS, #3990). The cap
+  # lives on the stored related-field definition; configure! is the single
+  # boot-time mutation point (ConfigureSecretActivity initializer).
+  describe '.configure! (retention cap)' do
+    let(:feature) { Onetime::Organization::Features::SecretActivity }
+
+    def stored_cap
+      Onetime::Organization.related_fields[:secret_activity_events].opts[:max_length]
+    end
+
+    after do
+      feature.configure!(feature::DEFAULT_MAX_EVENTS)
+    end
+
+    it 'applies and returns a cap above the floor' do
+      expect(feature.configure!(2_500)).to eq(2_500)
+      expect(stored_cap).to eq(2_500)
+    end
+
+    it 'clamps values below the floor to MIN_MAX_EVENTS' do
+      expect(feature.configure!(99)).to eq(feature::MIN_MAX_EVENTS)
+      expect(feature.configure!(1)).to eq(feature::MIN_MAX_EVENTS)
+      expect(feature.configure!(0)).to eq(feature::MIN_MAX_EVENTS)
+      expect(feature.configure!(-10)).to eq(feature::MIN_MAX_EVENTS)
+      expect(stored_cap).to eq(feature::MIN_MAX_EVENTS)
+    end
+
+    it 'accepts the floor itself unclamped' do
+      expect(feature.configure!(feature::MIN_MAX_EVENTS)).to eq(feature::MIN_MAX_EVENTS)
+    end
+
+    it 'coerces an integer-shaped string (ENV/hand-edited YAML deliver one)' do
+      expect(feature.configure!('500')).to eq(500)
+      expect(stored_cap).to eq(500)
+    end
+
+    it 'raises on non-integer input before mutating anything (initializer owns the fallback)' do
+      expect { feature.configure!('unbounded') }.to raise_error(ArgumentError)
+      expect { feature.configure!(nil) }.to raise_error(TypeError)
+      # Integer() raised before the definition was touched: cap unchanged.
+      expect(stored_cap).to eq(feature::DEFAULT_MAX_EVENTS)
+    end
+
+    # BOOT-ORDERING (the memoization trap the initializer doc warns about):
+    # per-org DataType instances snapshot the definition's opts when they
+    # materialize (Familia copies opts into the frozen DataType), so
+    # configure! only reaches trails materialized AFTER it runs. This is why
+    # ConfigureSecretActivity must run at boot, before any org traffic.
+    it 'applies only to trails materialized after it runs (boot-time-only)' do
+      stale_org = described_class.new(
+        display_name: 'Materialized Before Configure',
+        contact_email: "audit-stale-#{SecureRandom.hex(6)}@example.com",
+      ).tap(&:save)
+      # Touch the accessor: the DataType memoizes with the current cap.
+      expect(stale_org.secret_activity_events.max_length).to eq(feature::DEFAULT_MAX_EVENTS)
+
+      feature.configure!(2_500)
+
+      fresh_org = described_class.new(
+        display_name: 'Materialized After Configure',
+        contact_email: "audit-fresh-#{SecureRandom.hex(6)}@example.com",
+      ).tap(&:save)
+
+      expect(fresh_org.secret_activity_events.max_length).to eq(2_500)
+      # The already-materialized trail keeps the cap it was born with.
+      expect(stale_org.secret_activity_events.max_length).to eq(feature::DEFAULT_MAX_EVENTS)
     end
   end
 

--- a/apps/web/core/spec/views/serializers/config_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/config_serializer_spec.rb
@@ -1175,6 +1175,120 @@ RSpec.describe Core::Views::ConfigSerializer do
           end
         end
       end
+
+      # secret_activity is the data-existence axis (#3990): whether events are
+      # recorded at all (SECRET_ACTIVITY_COLLECT) and how many are retained
+      # (SECRET_ACTIVITY_MAX_EVENTS). Same default-true / opt-out contract as
+      # audit_logs_enabled above, which remains the separate UI-exposure axis.
+      describe 'secret_activity (collection axis + retention cap)' do
+        def view_vars_with_secret_activity(secret_activity)
+          base_view_vars.merge(
+            'features' => base_view_vars['features'].merge('secret_activity' => secret_activity)
+          )
+        end
+
+        context 'when the key is absent (older config file)' do
+          it 'defaults to collect_enabled true with the 10,000 cap' do
+            result = described_class.build_feature_flags(base_view_vars)
+
+            expect(result['secret_activity']).to eq(
+              'collect_enabled' => true,
+              'max_events' => 10_000,
+            )
+          end
+        end
+
+        describe 'collect_enabled (default-true contract)' do
+          it 'is true when explicitly true' do
+            result = described_class.build_feature_flags(
+              view_vars_with_secret_activity('collect' => true)
+            )
+
+            expect(result['secret_activity']['collect_enabled']).to be true
+          end
+
+          it 'is false when explicitly false (operator opt-out)' do
+            result = described_class.build_feature_flags(
+              view_vars_with_secret_activity('collect' => false)
+            )
+
+            expect(result['secret_activity']['collect_enabled']).to be false
+          end
+
+          # Same hand-edited-config defense as audit_logs_enabled: the string
+          # 'false' must pause the banner-facing flag, or the UI would say
+          # "recording" while the model (which shares the string-compare
+          # idiom) had already paused.
+          it "treats the string 'false' as disabled (hand-edited config)" do
+            result = described_class.build_feature_flags(
+              view_vars_with_secret_activity('collect' => 'false')
+            )
+
+            expect(result['secret_activity']['collect_enabled']).to be false
+          end
+
+          it "stays enabled for the string 'true'" do
+            result = described_class.build_feature_flags(
+              view_vars_with_secret_activity('collect' => 'true')
+            )
+
+            expect(result['secret_activity']['collect_enabled']).to be true
+          end
+
+          it 'stays enabled when nil (key present, no value)' do
+            result = described_class.build_feature_flags(
+              view_vars_with_secret_activity('collect' => nil)
+            )
+
+            expect(result['secret_activity']['collect_enabled']).to be true
+          end
+        end
+
+        # max_events mirrors the boot-time coercion + clamp (SecretActivity
+        # .configure!) so the UI never advertises a cap the backend ignored.
+        describe 'max_events (coercion + floor clamp parity with boot)' do
+          it 'passes through a configured cap above the floor' do
+            result = described_class.build_feature_flags(
+              view_vars_with_secret_activity('max_events' => 5_000)
+            )
+
+            expect(result['secret_activity']['max_events']).to eq(5_000)
+          end
+
+          it 'clamps below-floor values up to MIN_MAX_EVENTS (floor 100)' do
+            result = described_class.build_feature_flags(
+              view_vars_with_secret_activity('max_events' => 5)
+            )
+
+            expect(result['secret_activity']['max_events'])
+              .to eq(Onetime::Organization::Features::SecretActivity::MIN_MAX_EVENTS)
+          end
+
+          it 'coerces an integer-shaped string (ENV/hand-edited YAML)' do
+            result = described_class.build_feature_flags(
+              view_vars_with_secret_activity('max_events' => '500')
+            )
+
+            expect(result['secret_activity']['max_events']).to eq(500)
+          end
+
+          it 'falls back to the 10,000 default for non-numeric garbage' do
+            result = described_class.build_feature_flags(
+              view_vars_with_secret_activity('max_events' => 'unbounded')
+            )
+
+            expect(result['secret_activity']['max_events']).to eq(10_000)
+          end
+
+          it 'falls back to the 10,000 default when nil' do
+            result = described_class.build_feature_flags(
+              view_vars_with_secret_activity('max_events' => nil)
+            )
+
+            expect(result['secret_activity']['max_events']).to eq(10_000)
+          end
+        end
+      end
     end
   end
 

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -259,7 +259,27 @@ module Core
               # 'false' (quoted/ERB-stringified) still disables the flag.
               'audit_logs_enabled' => features.dig('organizations', 'audit_logs_enabled').to_s != 'false',
             },
+            'secret_activity' => {
+              # Same default-true contract as audit_logs_enabled above: only
+              # an explicit false pauses collection; compare on the string
+              # form for quoted/ERB-stringified 'false'. This is the
+              # data-existence axis — audit_logs_enabled is UI exposure.
+              'collect_enabled' => features.dig('secret_activity', 'collect').to_s != 'false',
+              'max_events' => resolve_secret_activity_max_events(features),
+            },
           }
+        end
+
+        # The retention cap actually enforced on the org trail: mirrors the
+        # boot-time coercion (ConfigureSecretActivity) and clamp
+        # (SecretActivity.configure!) so the UI never advertises a cap the
+        # backend ignored.
+        def resolve_secret_activity_max_events(features)
+          feature = Onetime::Organization::Features::SecretActivity
+          max     = Integer(features.dig('secret_activity', 'max_events'))
+          [max, feature::MIN_MAX_EVENTS].max
+        rescue ArgumentError, TypeError
+          Onetime::Organization::Features::SecretActivity::DEFAULT_MAX_EVENTS
         end
 
         # Resolve restrict_to for the current request context.

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -779,6 +779,17 @@ features:
     # box — this is an opt-out exclusion (ORGS_AUDIT_LOGS_ENABLED=false),
     # not an opt-in feature. Does not stop event collection.
     audit_logs_enabled: <%= ENV['ORGS_AUDIT_LOGS_ENABLED'] != 'false' %>
+  # Secret Activity Trail (collection)
+  # The data-existence axis of the org secret-activity trail: whether events
+  # are recorded at all (GDPR data minimization). UI + list API exposure is
+  # the separate organizations.audit_logs_enabled axis above. Both default
+  # ON; these are opt-out exclusions.
+  secret_activity:
+    # When false, event recording pauses; existing events stay readable.
+    collect: <%= ENV['SECRET_ACTIVITY_COLLECT'] != 'false' %>
+    # Newest events retained per organization (floor: 100). Lowering this
+    # deletes (not hides) each org's oldest events on its next write.
+    max_events: <%= ENV['SECRET_ACTIVITY_MAX_EVENTS'] || 10000 %>
 
 # Main Database Configuration
 redis:

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -141,6 +141,10 @@ module Onetime
             'default_passphrase' => nil,
             'recipients' => [],
           },
+          'secret_activity' => {
+            'collect' => true,
+            'max_events' => 10_000,
+          },
         },
         'internationalization' => {
           'enabled' => false,

--- a/lib/onetime/initializers.rb
+++ b/lib/onetime/initializers.rb
@@ -19,6 +19,7 @@ require_relative 'initializers/setup_i18n'        # requires: [:i18n]
 require_relative 'initializers/setup_loggers'
 require_relative 'initializers/set_secrets'
 require_relative 'initializers/configure_domains'
+require_relative 'initializers/configure_secret_activity'
 require_relative 'initializers/configure_truemail'
 require_relative 'initializers/configure_rhales'
 require_relative 'initializers/load_fortunes'

--- a/lib/onetime/initializers/configure_familia.rb
+++ b/lib/onetime/initializers/configure_familia.rb
@@ -152,12 +152,22 @@ module Onetime
         # encryption_personalization feeds BLAKE2b key derivation for
         # XChaCha20-Poly1305 (used once rbnacl/libsodium are present).
         # 'FamilialMatters' is Familia's long-standing default and the only
-        # value compatible with any XChaCha20 data an installation may hold.
+        # value compatible with any XChaCha20 data an installation may already
+        # hold.
         #
-        # Familia 2.12 supports rotation via encryption_personalization_history:
-        # set a per-deployment value and the library falls back to prior values
-        # (including the hardcoded 'FamilialMatters' default) on decrypt. See
-        # #3987 for the v0.27 rotation plan.
+        # It is ROTATABLE as of familia 2.12 (delano/familia#333): decrypt walks
+        # the current value, then each encryption_personalization_history entry
+        # in order, then the library default 'FamilialMatters' (always appended
+        # automatically as the last candidate), trying each derived key until
+        # Poly1305 auth succeeds. Encrypt is fail-closed and only ever uses the
+        # current value.
+        #
+        # We intentionally leave the value at the library default in this
+        # release and do NOT set the history knob (nothing to rotate from yet).
+        # The per-deployment rotation is the v0.27.0 write-side flip (see
+        # #3987), and it requires every process reading this datastore to be on
+        # >= this release first -- a datastore-scoped invariant, not a
+        # fleet-scoped one.
         Familia.config.encryption_personalization = 'FamilialMatters'
 
         # encryption_hkdf_salt feeds HKDF-SHA256 key derivation for

--- a/lib/onetime/initializers/configure_secret_activity.rb
+++ b/lib/onetime/initializers/configure_secret_activity.rb
@@ -20,6 +20,9 @@ module Onetime
     # not a connection was opened. connect_to_db gates connections, not
     # model loading.
     #
+    # NOTE: configure! mutates Familia::RelatedFieldDefinition.opts — not a
+    # public API. Tracked upstream: https://github.com/delano/familia/issues/390
+    #
     class ConfigureSecretActivity < Onetime::Boot::Initializer
       @provides = [:secret_activity]
 

--- a/lib/onetime/initializers/configure_secret_activity.rb
+++ b/lib/onetime/initializers/configure_secret_activity.rb
@@ -1,0 +1,34 @@
+# lib/onetime/initializers/configure_secret_activity.rb
+#
+# frozen_string_literal: true
+
+module Onetime
+  module Initializers
+    # ConfigureSecretActivity initializer
+    #
+    # Applies features.secret_activity.max_events to the organization
+    # secret-activity trail's retention cap. Must run at boot, before any
+    # per-org trail accessor materializes (see SecretActivity.configure!):
+    # already-materialized DataType instances keep the compile-time default.
+    #
+    # Needs no datastore connection — it only mutates the stored field
+    # definition — so it also runs under connect_to_db=false boots (tryouts).
+    #
+    class ConfigureSecretActivity < Onetime::Boot::Initializer
+      @provides = [:secret_activity]
+
+      def execute(_context)
+        feature = Onetime::Organization::Features::SecretActivity
+
+        max_events = begin
+          Integer(OT.conf.dig('features', 'secret_activity', 'max_events'))
+        rescue ArgumentError, TypeError
+          feature::DEFAULT_MAX_EVENTS
+        end
+
+        applied = feature.configure!(max_events)
+        app_logger.debug "[init] ConfigureSecretActivity max_events=#{applied}"
+      end
+    end
+  end
+end

--- a/lib/onetime/initializers/configure_secret_activity.rb
+++ b/lib/onetime/initializers/configure_secret_activity.rb
@@ -12,7 +12,13 @@ module Onetime
     # already-materialized DataType instances keep the compile-time default.
     #
     # Needs no datastore connection — it only mutates the stored field
-    # definition — so it also runs under connect_to_db=false boots (tryouts).
+    # definition — so it also runs under connect_to_db=false boots (tryouts)
+    # and is deliberately absent from boot!'s skip-list. The model constants
+    # it touches are safe there: lib/onetime.rb requires lib/onetime/models
+    # eagerly at load time (a prerequisite of calling OT.boot! at all), so
+    # Organization.related_fields[:secret_activity_events] exists whether or
+    # not a connection was opened. connect_to_db gates connections, not
+    # model loading.
     #
     class ConfigureSecretActivity < Onetime::Boot::Initializer
       @provides = [:secret_activity]

--- a/lib/onetime/models/organization/features/secret_activity.rb
+++ b/lib/onetime/models/organization/features/secret_activity.rb
@@ -66,8 +66,15 @@ module Onetime::Organization::Features
     # Any org whose accessor already ran has memoized a DataType with the old
     # cap and will NOT pick this up.
     #
+    # Deliberately unrescued: a malformed cap is a configuration error, and
+    # the caller — not this method — owns the fallback policy (the boot
+    # initializer rescues to DEFAULT_MAX_EVENTS). Any future caller passing
+    # unvalidated input (admin endpoint, rake task) must do the same rather
+    # than silently applying a default it did not choose.
+    #
     # @param max_events [Integer] desired cap (newest events retained).
     # @return [Integer] the applied (clamped) cap.
+    # @raise [ArgumentError, TypeError] when max_events is not Integer-able.
     def self.configure!(max_events)
       max = [Integer(max_events), MIN_MAX_EVENTS].max
 

--- a/lib/onetime/models/organization/features/secret_activity.rb
+++ b/lib/onetime/models/organization/features/secret_activity.rb
@@ -19,10 +19,17 @@ module Onetime::Organization::Features
   # Design notes:
   # - Append-only; the trail never drives behavior, so there is no CAS and
   #   a failed append must never break the calling path (callers guard).
-  # - Capped at SECRET_ACTIVITY_MAX_EVENTS (newest kept) to bound memory
-  #   against mechanical hammering of anonymous read endpoints. For
-  #   long-horizon or compliance-grade retention, a durable export (e.g. via
-  #   the jobs publisher) can consume the same fan-out point later.
+  # - Capped via Familia's max_length (newest kept; write + trim in one
+  #   MULTI) to bound memory against mechanical hammering of anonymous read
+  #   endpoints. The cap is configurable through
+  #   features.secret_activity.max_events (applied at boot by .configure!).
+  #   For long-horizon or compliance-grade retention, a durable export (e.g.
+  #   via the jobs publisher) can consume the same fan-out point later.
+  # - Collection itself is switchable: features.secret_activity.collect
+  #   false pauses recording (GDPR data minimization — no events come to
+  #   exist) while leaving existing events readable. This is the
+  #   data-existence axis; UI/API exposure is the separate
+  #   organizations.audit_logs_enabled axis (#3985).
   # - No TTL: organizations are permanent records; the cap is the bound.
   # - Members are plain Hashes; Familia JSON round-trips them (string keys
   #   on read). A `nonce` field keeps members unique when two identical
@@ -30,15 +37,44 @@ module Onetime::Organization::Features
   module SecretActivity
     Familia::Base.add_feature self, :secret_activity
 
-    # Newest events retained when trimming the trail.
-    SECRET_ACTIVITY_MAX_EVENTS = 10_000
+    # Newest events retained when trimming the trail, absent configuration.
+    DEFAULT_MAX_EVENTS = 10_000
+
+    # Floor for the configurable cap: a paid audit trail that silently
+    # retains almost nothing is worse than no trail at all.
+    MIN_MAX_EVENTS = 100
 
     def self.included(base)
       OT.ld "[features] #{base}: #{name}"
 
-      base.sorted_set :secret_activity_events
+      # Familia validates max_length eagerly as a positive Integer (no lazy/
+      # proc form) and this declaration fires at require time, before
+      # Config.load — so the default is compiled in here and the configured
+      # value is applied at boot via .configure!.
+      base.sorted_set :secret_activity_events, max_length: DEFAULT_MAX_EVENTS
 
       base.include InstanceMethods
+    end
+
+    # Apply the configured retention cap (features.secret_activity.max_events)
+    # to the trail. Clamps to MIN_MAX_EVENTS.
+    #
+    # BOOT-TIME ONLY (see ConfigureSecretActivity): per-org DataType instances
+    # materialize lazily — Familia's initialize_relatives re-reads the stored
+    # RelatedFieldDefinition's opts on an instance's first accessor call, so
+    # mutating those opts here flows into every org materialized afterwards.
+    # Any org whose accessor already ran has memoized a DataType with the old
+    # cap and will NOT pick this up.
+    #
+    # @param max_events [Integer] desired cap (newest events retained).
+    # @return [Integer] the applied (clamped) cap.
+    def self.configure!(max_events)
+      max = [Integer(max_events), MIN_MAX_EVENTS].max
+
+      definition                   = Onetime::Organization.related_fields[:secret_activity_events]
+      definition.opts[:max_length] = max
+
+      max
     end
 
     module InstanceMethods
@@ -56,9 +92,15 @@ module Onetime::Organization::Features
       # @param attrs [Hash] additional context (receipt/secret shortids,
       #   actor when known). Keep values short and non-sensitive: never
       #   include secret content, full identifiers, or passphrases.
-      # @return [Hash, nil] the recorded event, or nil when kind is blank.
+      # @return [Hash, nil] the recorded event, or nil when kind is blank
+      #   or collection is paused.
       def record_secret_activity_event(kind, at: Familia.now, **attrs)
         return if kind.to_s.empty?
+        # Default-true contract: only an explicit false pauses collection —
+        # a missing key (older config file) must still record. Compare on
+        # the string form so a hand-edited config that yields 'false'
+        # (quoted/ERB-stringified) still disables the flag.
+        return if OT.conf.dig('features', 'secret_activity', 'collect').to_s == 'false'
 
         event = {
           'kind' => kind.to_s,
@@ -66,14 +108,14 @@ module Onetime::Organization::Features
           'nonce' => SecureRandom.hex(4),
         }.merge(attrs.transform_keys(&:to_s))
 
+        # max_length on the sorted set trims atomically with the write.
         secret_activity_events.add(event, at.to_f)
-        secret_activity_events.remrangebyrank(0, -(SECRET_ACTIVITY_MAX_EVENTS + 1))
 
         event
       end
 
       # @return [Integer] number of retained secret activity events
-      #   (saturates at SECRET_ACTIVITY_MAX_EVENTS).
+      #   (saturates at the configured max_events cap).
       def secret_activity_event_count
         secret_activity_events.element_count
       end

--- a/locales/content/en/workspace-organizations.json
+++ b/locales/content/en/workspace-organizations.json
@@ -761,8 +761,8 @@
     "content_hash": "62fb14c2"
   },
   "web.organizations.audit.capped_notice": {
-    "text": "Only the newest 10,000 events are retained; older activity has been trimmed.",
-    "content_hash": "6af1562d"
+    "text": "Only the newest {max} events are retained; older activity has been trimmed.",
+    "content_hash": "da7901e2"
   },
   "web.organizations.audit.collection_paused_notice": {
     "text": "Event collection is paused; new secret activity is not being recorded.",

--- a/locales/content/en/workspace-organizations.json
+++ b/locales/content/en/workspace-organizations.json
@@ -764,6 +764,10 @@
     "text": "Only the newest 10,000 events are retained; older activity has been trimmed.",
     "content_hash": "6af1562d"
   },
+  "web.organizations.audit.collection_paused_notice": {
+    "text": "Event collection is paused; new secret activity is not being recorded.",
+    "content_hash": "cb09d147"
+  },
   "web.organizations.audit.load_error": {
     "text": "Unable to load secret activity.",
     "content_hash": "52fde814"

--- a/spec/integration/all/initializers/boot_part2_spec.rb
+++ b/spec/integration/all/initializers/boot_part2_spec.rb
@@ -212,6 +212,18 @@ RSpec.describe "Onetime global state after boot", type: :integration do
         expect(initializer).not_to be_nil
         expect(initializer.completed?).to be true
       end
+
+      it "pins the crypto domain-separation config to the byte-compatible values" do
+        # Regression pin for issue #3630 (familia 2.12 read-side prep): these
+        # values determine whether existing ciphertext stays decryptable. The
+        # v0.27.0 write-side rotation flip must consciously edit this spec; no
+        # gem bump or initializer refactor may drift them silently.
+        Onetime.boot!(:test)
+
+        expect(Familia.config.encryption_personalization).to eq('FamilialMatters')
+        expect(Familia.config.encryption_hkdf_salt).to eq('FamiliaEncryption')
+        expect(Familia.config.encryption_hkdf_salt_history).to eq(['FamilialMatters'])
+      end
     end
 
     context "regarding error handling" do

--- a/src/apps/workspace/components/organizations/SecretActivityTable.vue
+++ b/src/apps/workspace/components/organizations/SecretActivityTable.vue
@@ -2,6 +2,7 @@
 
 <script setup lang="ts">
 import { SECRET_ACTIVITY_KINDS, type SecretActivityKind } from '@/schemas/api/organizations';
+import { isSecretActivityCollectEnabled } from '@/utils/features';
 import TableSkeleton from '@/shared/components/closet/TableSkeleton.vue';
 import OIcon from '@/shared/components/icons/OIcon.vue';
 import EmptyState from '@/shared/components/ui/EmptyState.vue';
@@ -28,6 +29,16 @@ const props = defineProps<{
 const { t } = useI18n();
 
 const orgExtid = toRef(props, 'orgExtid');
+
+/**
+ * Collection paused (#3990): SECRET_ACTIVITY_COLLECT=false stops event
+ * RECORDING instance-wide while historical events keep rendering. The notice
+ * must sit above every state — a live-looking trail (or an innocent-looking
+ * empty state) is a lie of omission when nothing new is being written.
+ * Read once at setup: the instance flag ships in the bootstrap payload and
+ * cannot change without a reload.
+ */
+const collectionPaused = !isSecretActivityCollectEnabled();
 
 const {
   records,
@@ -161,6 +172,23 @@ watch(orgExtid, () => {
 
 <template>
   <div>
+    <!--
+      Collection-paused notice (#3990) — warning tone, rendered above every
+      state: historical events still display while nothing new is recorded,
+      so a live-looking trail (or the empty state) must not read as current.
+    -->
+    <div
+      v-if="collectionPaused"
+      data-testid="org-audit-paused"
+      class="mb-4 flex items-center gap-2 rounded-md bg-amber-50 px-4 py-2.5 text-xs text-amber-700 dark:bg-amber-900/20 dark:text-amber-300">
+      <OIcon
+        collection="heroicons"
+        name="pause-circle"
+        class="size-4 shrink-0"
+        aria-hidden="true" />
+      {{ t('web.organizations.audit.collection_paused_notice') }}
+    </div>
+
     <!-- Loading State — initial fetch only; refetches keep their state mounted -->
     <TableSkeleton v-if="showSkeleton" />
 

--- a/src/apps/workspace/components/organizations/SecretActivityTable.vue
+++ b/src/apps/workspace/components/organizations/SecretActivityTable.vue
@@ -2,7 +2,7 @@
 
 <script setup lang="ts">
 import { SECRET_ACTIVITY_KINDS, type SecretActivityKind } from '@/schemas/api/organizations';
-import { isSecretActivityCollectEnabled } from '@/utils/features';
+import { getSecretActivityMaxEvents, isSecretActivityCollectEnabled } from '@/utils/features';
 import TableSkeleton from '@/shared/components/closet/TableSkeleton.vue';
 import OIcon from '@/shared/components/icons/OIcon.vue';
 import EmptyState from '@/shared/components/ui/EmptyState.vue';
@@ -39,6 +39,15 @@ const orgExtid = toRef(props, 'orgExtid');
  * cannot change without a reload.
  */
 const collectionPaused = !isSecretActivityCollectEnabled();
+
+/**
+ * Retention cap for the capped notice (#3990). The cap is operator-
+ * configurable, so the notice interpolates it — a hardcoded "10,000" would
+ * state a false retention claim on an instance configured to anything else.
+ * Read once at setup alongside collectionPaused: same bootstrap snapshot,
+ * same reload-to-change lifetime.
+ */
+const maxEventsLabel = getSecretActivityMaxEvents().toLocaleString();
 
 const {
   records,
@@ -254,7 +263,7 @@ watch(orgExtid, () => {
 
     <!-- Event List -->
     <div v-else>
-      <!-- Retention-cap notice — the trail keeps only the newest 10,000 events -->
+      <!-- Retention-cap notice — the trail keeps only the newest max_events -->
       <div
         v-if="isCapped"
         data-testid="org-audit-capped"
@@ -264,7 +273,7 @@ watch(orgExtid, () => {
           name="information-circle"
           class="size-4 shrink-0"
           aria-hidden="true" />
-        {{ t('web.organizations.audit.capped_notice') }}
+        {{ t('web.organizations.audit.capped_notice', { max: maxEventsLabel }) }}
       </div>
 
       <!--

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -289,6 +289,18 @@ const organizationFeaturesInner = z.object({
   audit_logs_enabled: z.boolean().default(true),
 });
 
+// Same cascade-default workaround as organizationFeaturesInner above.
+const secretActivityFeaturesInner = z.object({
+  // Default-ON: collection only stops on an explicit false — set via
+  // SECRET_ACTIVITY_COLLECT=false (GDPR data minimization, #3990). Absent
+  // (older backends without the flag) keeps events being recorded.
+  collect_enabled: z.boolean().default(true),
+  // Operator-configured retention cap (SECRET_ACTIVITY_MAX_EVENTS); the
+  // backend clamps to a floor of 100 at read time, so a positive int is
+  // the whole wire contract here.
+  max_events: z.number().int().positive().default(10000),
+});
+
 export const featuresSchema = z.object({
   markdown: z.boolean().default(false),
   // Sign-in availability for the current domain context (AND of global
@@ -307,6 +319,7 @@ export const featuresSchema = z.object({
   restrict_to: z.enum(['password', 'email_auth', 'webauthn', 'sso']).nullable().optional(),
   magic_links: z.boolean().optional(),
   organizations: organizationFeaturesInner.default(organizationFeaturesInner.parse({})),
+  secret_activity: secretActivityFeaturesInner.default(secretActivityFeaturesInner.parse({})),
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/shared/composables/useSecretActivity.ts
+++ b/src/shared/composables/useSecretActivity.ts
@@ -29,18 +29,12 @@ import {
 } from '@/schemas/api/organizations';
 import { classifyError } from '@/schemas/errors';
 import { useApi } from '@/shared/composables/useApi';
+import { getSecretActivityMaxEvents } from '@/utils/features';
 import { gracefulParse } from '@/utils/schemaValidation';
 import { computed, ref, type Ref } from 'vue';
 
 /** Server default page size (list_secret_activity.rb DEFAULT_LIMIT). */
 const DEFAULT_LIMIT = 50;
-
-/**
- * Per-org retention cap (secret_activity.rb SECRET_ACTIVITY_MAX_EVENTS). When `total`
- * saturates here the trail has been trimmed — older events are gone and the
- * UI should say so rather than imply a complete history.
- */
-const SECRET_ACTIVITY_RETENTION_MAX = 10_000;
 
 /* eslint-disable max-lines-per-function */
 export function useSecretActivity(orgExtid: Ref<string>) {
@@ -68,7 +62,12 @@ export function useSecretActivity(orgExtid: Ref<string>) {
   const count = computed(() => records.value.length);
   const hasNext = computed(() => offset.value + count.value < total.value);
   const hasPrev = computed(() => offset.value > 0);
-  const isCapped = computed(() => total.value >= SECRET_ACTIVITY_RETENTION_MAX);
+  // Per-org retention cap — features.secret_activity.max_events from the
+  // bootstrap payload (#3990; SECRET_ACTIVITY_MAX_EVENTS, default 10,000).
+  // When `total` saturates at the cap the trail has been trimmed — older
+  // events are gone and the UI should say so rather than imply a complete
+  // history.
+  const isCapped = computed(() => total.value >= getSecretActivityMaxEvents());
 
   /** Abort the in-flight request, if any. */
   function abort() {

--- a/src/tests/apps/workspace/components/organizations/SecretActivityTable.spec.ts
+++ b/src/tests/apps/workspace/components/organizations/SecretActivityTable.spec.ts
@@ -15,7 +15,10 @@
 import SecretActivityTable from '@/apps/workspace/components/organizations/SecretActivityTable.vue';
 import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { ref } from 'vue';
+import { createI18n } from 'vue-i18n';
 import { createTestI18n } from '@tests/setup';
 
 // ─── HTTP layer ──────────────────────────────────────────────────────────────
@@ -597,6 +600,40 @@ describe('SecretActivityTable', () => {
       wrapper = await mountComponent();
 
       expect(wrapper.find('[data-testid="org-audit-capped"]').exists()).toBe(false);
+    });
+
+    /**
+     * The notice states a retention number, so it must state the CONFIGURED
+     * one — the pre-#3990 string hardcoded "10,000" and lied on every instance
+     * running a different cap. Mounted against the REAL generated bundle (not
+     * the pass-through i18n, and not hand-typed copy) so the assertion tests
+     * the wiring: drop the `{ max }` argument and vue-i18n renders a silent
+     * double-space sentence rather than a visible `{max}`, which only the
+     * shipped string can catch.
+     *
+     * The cap is 10,000 rather than a small number so the thousands separator
+     * from toLocaleString() is part of the contract under test.
+     */
+    it('interpolates the configured cap into the capped notice (#3990)', async () => {
+      const realEn = JSON.parse(
+        readFileSync(resolve(process.cwd(), 'generated/locales/en.json'), 'utf-8')
+      );
+      const realI18n = createI18n({ legacy: false, locale: 'en', messages: { en: realEn } });
+
+      mockMaxEvents.value = 10_000;
+      respondWith(buildResponse({ records: [buildEvent()], total: 10_000 }));
+
+      wrapper = mount(SecretActivityTable, {
+        props: { orgExtid: 'on1abc123' },
+        global: { plugins: [realI18n] },
+      });
+      await flushPromises();
+
+      const text = wrapper.find('[data-testid="org-audit-capped"]').text();
+      // Locale-independent: whatever separator the runtime picks, the notice
+      // must carry the formatted cap the helper produced.
+      expect(text).toContain((10_000).toLocaleString());
+      expect(text).not.toContain('{max}');
     });
   });
 

--- a/src/tests/apps/workspace/components/organizations/SecretActivityTable.spec.ts
+++ b/src/tests/apps/workspace/components/organizations/SecretActivityTable.spec.ts
@@ -15,6 +15,7 @@
 import SecretActivityTable from '@/apps/workspace/components/organizations/SecretActivityTable.vue';
 import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
 import { createTestI18n } from '@tests/setup';
 
 // ─── HTTP layer ──────────────────────────────────────────────────────────────
@@ -22,6 +23,16 @@ const mockApi = {
   get: vi.fn(),
 };
 vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+// ─── Instance flags (#3990) ──────────────────────────────────────────────────
+// Collection axis + retention cap, both from the bootstrap features payload.
+// Defaults mirror the wire contract: collect on, cap 10,000.
+const mockCollectEnabled = ref(true);
+const mockMaxEvents = ref(10_000);
+vi.mock('@/utils/features', () => ({
+  isSecretActivityCollectEnabled: () => mockCollectEnabled.value,
+  getSecretActivityMaxEvents: () => mockMaxEvents.value,
+}));
 
 // Deterministic classifier output so the error banner's detail line is
 // assertable without pulling the whole error-classification module in.
@@ -140,6 +151,8 @@ describe('SecretActivityTable', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCollectEnabled.value = true;
+    mockMaxEvents.value = 10_000;
     // Default: one burned event on page 1.
     respondWith(buildResponse());
   });
@@ -566,6 +579,57 @@ describe('SecretActivityTable', () => {
       wrapper = await mountComponent();
 
       expect(wrapper.find('[data-testid="org-audit-capped"]').exists()).toBe(false);
+    });
+
+    it('honors a non-default operator-configured cap (#3990)', async () => {
+      mockMaxEvents.value = 500;
+      respondWith(buildResponse({ records: [buildEvent()], total: 500 }));
+
+      wrapper = await mountComponent();
+
+      expect(wrapper.find('[data-testid="org-audit-capped"]').exists()).toBe(true);
+    });
+
+    it('does not treat 10,000 as capped when the configured cap is higher', async () => {
+      mockMaxEvents.value = 50_000;
+      respondWith(buildResponse({ records: [buildEvent()], total: 10_000 }));
+
+      wrapper = await mountComponent();
+
+      expect(wrapper.find('[data-testid="org-audit-capped"]').exists()).toBe(false);
+    });
+  });
+
+  describe('collection-paused notice (#3990)', () => {
+    it('renders the paused banner above a populated trail when collection is off', async () => {
+      mockCollectEnabled.value = false;
+
+      wrapper = await mountComponent();
+
+      const notice = wrapper.find('[data-testid="org-audit-paused"]');
+      expect(notice.exists()).toBe(true);
+      expect(notice.text()).toContain('web.organizations.audit.collection_paused_notice');
+      // Historical events keep rendering — the banner warns the trail is
+      // frozen, it does not hide it.
+      expect(wrapper.find('[data-testid="org-audit-table"]').exists()).toBe(true);
+    });
+
+    it('renders the paused banner alongside the empty state (frozen ≠ no activity yet)', async () => {
+      mockCollectEnabled.value = false;
+      respondWith(buildResponse({ records: [], total: 0 }));
+
+      wrapper = await mountComponent();
+
+      expect(wrapper.find('[data-testid="org-audit-paused"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="org-audit-empty"]').exists()).toBe(true);
+    });
+
+    it('hides the paused banner when collection is on', async () => {
+      mockCollectEnabled.value = true;
+
+      wrapper = await mountComponent();
+
+      expect(wrapper.find('[data-testid="org-audit-paused"]').exists()).toBe(false);
     });
   });
 

--- a/src/tests/contracts/bootstrap-schema-contract.spec.ts
+++ b/src/tests/contracts/bootstrap-schema-contract.spec.ts
@@ -371,6 +371,27 @@ describe('Bootstrap Zod schema validation', () => {
       const result = featuresSchema.safeParse(features);
       expect(result.success).toBe(true);
     });
+
+    it('populates secret_activity nested defaults when absent (#3990)', () => {
+      // Cascade-default workaround: .default(inner.parse({})) must yield the
+      // contract defaults, not an empty object.
+      const result = featuresSchema.parse({});
+      expect(result.secret_activity).toEqual({ collect_enabled: true, max_events: 10_000 });
+    });
+
+    it('accepts an explicit secret_activity payload (#3990)', () => {
+      const result = featuresSchema.safeParse({
+        secret_activity: { collect_enabled: false, max_events: 500 },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects a non-positive secret_activity.max_events (#3990)', () => {
+      const result = featuresSchema.safeParse({
+        secret_activity: { collect_enabled: true, max_events: 0 },
+      });
+      expect(result.success).toBe(false);
+    });
   });
 
   describe('organizationSchema', () => {

--- a/src/tests/shared/composables/useSecretActivity.spec.ts
+++ b/src/tests/shared/composables/useSecretActivity.spec.ts
@@ -27,6 +27,13 @@ vi.mock('@/schemas/errors', () => ({
   }),
 }));
 
+// Operator-configured retention cap (#3990) — default mirrors the contract.
+const mockMaxEvents = ref(10_000);
+vi.mock('@/utils/features', () => ({
+  getSecretActivityMaxEvents: () => mockMaxEvents.value,
+  isSecretActivityCollectEnabled: () => true,
+}));
+
 // Full customer objid — the wire format for actor_id since #3637.
 const FULL_ACTOR_OBJID = '0198c0ffee15deadbeef4b1dfacade42';
 
@@ -138,6 +145,64 @@ describe('useSecretActivity — actors resolution map', () => {
     await flushPromises();
     expect(validationError.value).toBe(true);
     expect(actors.value).toEqual({});
+  });
+});
+
+describe('useSecretActivity — retention cap (isCapped, #3990)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMaxEvents.value = 10_000;
+  });
+
+  it('saturates at the default 10,000 cap', async () => {
+    mockApi.get.mockResolvedValue({
+      data: { ...buildResponse(), total: 10_000 },
+    });
+
+    const { isCapped, fetchPage } = useSecretActivity(ref('on1abc123'));
+    await fetchPage(0);
+    await flushPromises();
+
+    expect(isCapped.value).toBe(true);
+  });
+
+  it('honors a non-default operator-configured cap', async () => {
+    mockMaxEvents.value = 500;
+    mockApi.get.mockResolvedValue({
+      data: { ...buildResponse(), total: 500 },
+    });
+
+    const { isCapped, fetchPage } = useSecretActivity(ref('on1abc123'));
+    await fetchPage(0);
+    await flushPromises();
+
+    expect(isCapped.value).toBe(true);
+  });
+
+  it('stays uncapped below the configured cap', async () => {
+    mockMaxEvents.value = 500;
+    mockApi.get.mockResolvedValue({
+      data: { ...buildResponse(), total: 499 },
+    });
+
+    const { isCapped, fetchPage } = useSecretActivity(ref('on1abc123'));
+    await fetchPage(0);
+    await flushPromises();
+
+    expect(isCapped.value).toBe(false);
+  });
+
+  it('does not treat 10,000 as capped when the configured cap is higher', async () => {
+    mockMaxEvents.value = 50_000;
+    mockApi.get.mockResolvedValue({
+      data: { ...buildResponse(), total: 10_000 },
+    });
+
+    const { isCapped, fetchPage } = useSecretActivity(ref('on1abc123'));
+    await fetchPage(0);
+    await flushPromises();
+
+    expect(isCapped.value).toBe(false);
   });
 });
 

--- a/src/tests/utils/features.spec.ts
+++ b/src/tests/utils/features.spec.ts
@@ -17,6 +17,8 @@ import {
   isOrganizationSwitcherEnabled,
   isOrgsSsoEnabled,
   isOrgsAuditLogsEnabled,
+  isSecretActivityCollectEnabled,
+  getSecretActivityMaxEvents,
   isOrgsCustomMailEnabled,
   isOrgsIncomingSecretsEnabled,
   isOwnerOrAdminOf,
@@ -880,6 +882,128 @@ describe('features utility', () => {
       const result = isOrgsAuditLogsEnabled();
 
       expect(result).toBe(false);
+    });
+  });
+
+  // Collection axis (#3990) — default-ON like isOrgsAuditLogsEnabled: only an
+  // explicit `false` (SECRET_ACTIVITY_COLLECT=false) pauses collection.
+  describe('isSecretActivityCollectEnabled', () => {
+    it('returns true when secret_activity.collect_enabled is true', () => {
+      getBootstrapValueMock.mockReturnValue({ secret_activity: { collect_enabled: true } });
+
+      const result = isSecretActivityCollectEnabled();
+
+      expect(result).toBe(true);
+      expect(getBootstrapValueMock).toHaveBeenCalledWith('features');
+    });
+
+    it('returns false when secret_activity.collect_enabled is false', () => {
+      getBootstrapValueMock.mockReturnValue({ secret_activity: { collect_enabled: false } });
+
+      const result = isSecretActivityCollectEnabled();
+
+      expect(result).toBe(false);
+    });
+
+    it('returns true when secret_activity object is empty (absent key = default ON)', () => {
+      getBootstrapValueMock.mockReturnValue({ secret_activity: {} });
+
+      const result = isSecretActivityCollectEnabled();
+
+      expect(result).toBe(true);
+    });
+
+    it('returns true when secret_activity is undefined (older backend)', () => {
+      getBootstrapValueMock.mockReturnValue({});
+
+      const result = isSecretActivityCollectEnabled();
+
+      expect(result).toBe(true);
+    });
+
+    it('returns true when features object is undefined (no bootstrap key)', () => {
+      getBootstrapValueMock.mockReturnValue(undefined);
+
+      const result = isSecretActivityCollectEnabled();
+
+      expect(result).toBe(true);
+    });
+
+    it('returns true when collect_enabled is null (only literal false disables)', () => {
+      getBootstrapValueMock.mockReturnValue({ secret_activity: { collect_enabled: null } });
+
+      const result = isSecretActivityCollectEnabled();
+
+      expect(result).toBe(true);
+    });
+
+    it('returns true for non-boolean values (fail-open by design)', () => {
+      getBootstrapValueMock.mockReturnValue({ secret_activity: { collect_enabled: 'no' } });
+
+      const result = isSecretActivityCollectEnabled();
+
+      expect(result).toBe(true);
+    });
+  });
+
+  // Retention cap (#3990) — anything absent, non-numeric, or non-positive
+  // falls back to the 10,000 default; only a positive integer passes through.
+  describe('getSecretActivityMaxEvents', () => {
+    it('returns the configured cap when max_events is a positive integer', () => {
+      getBootstrapValueMock.mockReturnValue({ secret_activity: { max_events: 500 } });
+
+      const result = getSecretActivityMaxEvents();
+
+      expect(result).toBe(500);
+      expect(getBootstrapValueMock).toHaveBeenCalledWith('features');
+    });
+
+    it('returns 10000 when secret_activity is undefined (older backend)', () => {
+      getBootstrapValueMock.mockReturnValue({});
+
+      const result = getSecretActivityMaxEvents();
+
+      expect(result).toBe(10_000);
+    });
+
+    it('returns 10000 when features object is undefined (no bootstrap key)', () => {
+      getBootstrapValueMock.mockReturnValue(undefined);
+
+      const result = getSecretActivityMaxEvents();
+
+      expect(result).toBe(10_000);
+    });
+
+    it('returns 10000 when max_events is absent from secret_activity', () => {
+      getBootstrapValueMock.mockReturnValue({ secret_activity: { collect_enabled: true } });
+
+      const result = getSecretActivityMaxEvents();
+
+      expect(result).toBe(10_000);
+    });
+
+    it('returns 10000 for a non-numeric value', () => {
+      getBootstrapValueMock.mockReturnValue({ secret_activity: { max_events: 'lots' } });
+
+      const result = getSecretActivityMaxEvents();
+
+      expect(result).toBe(10_000);
+    });
+
+    it('returns 10000 for zero and negative values', () => {
+      getBootstrapValueMock.mockReturnValue({ secret_activity: { max_events: 0 } });
+      expect(getSecretActivityMaxEvents()).toBe(10_000);
+
+      getBootstrapValueMock.mockReturnValue({ secret_activity: { max_events: -5 } });
+      expect(getSecretActivityMaxEvents()).toBe(10_000);
+    });
+
+    it('returns 10000 for a non-integer value', () => {
+      getBootstrapValueMock.mockReturnValue({ secret_activity: { max_events: 99.5 } });
+
+      const result = getSecretActivityMaxEvents();
+
+      expect(result).toBe(10_000);
     });
   });
 

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -577,6 +577,50 @@ export function isOrgsAuditLogsEnabled(): boolean {
   return result;
 }
 
+/** Fallback retention cap when the bootstrap value is absent or malformed. */
+const SECRET_ACTIVITY_MAX_EVENTS_DEFAULT = 10_000;
+
+/**
+ * Checks if secret-activity event COLLECTION is enabled (#3990) — the GDPR
+ * data-minimization axis, distinct from isOrgsAuditLogsEnabled (UI exposure).
+ * Default is ON — only an explicit `false` (SECRET_ACTIVITY_COLLECT=false)
+ * pauses collection; an absent key (older backend) keeps events recorded.
+ *
+ * SSR/no-window guard returns true, and the read goes through
+ * getBootstrapValue directly rather than the memoized getValidatedFeatures()
+ * cache, for the reasons documented on isOrgsAuditLogsEnabled: the cache
+ * never invalidates, and `!== false` already implements the default-true
+ * contract against serializer-normalized booleans.
+ */
+export function isSecretActivityCollectEnabled(): boolean {
+  if (typeof window === 'undefined') return true;
+
+  const features = getBootstrapValue('features');
+  const result = features?.secret_activity?.collect_enabled !== false;
+  debugLog.features('features.isSecretActivityCollectEnabled', { collect_enabled: features?.secret_activity?.collect_enabled, result });
+  return result;
+}
+
+/**
+ * Returns the operator-configured secret-activity retention cap (#3990) —
+ * features.secret_activity.max_events, the Familia max_length applied to the
+ * per-org trail. Anything non-numeric or non-positive falls back to the
+ * 10,000 default so the isCapped math never divides by garbage. Reads the
+ * bootstrap snapshot directly (see isSecretActivityCollectEnabled).
+ */
+export function getSecretActivityMaxEvents(): number {
+  if (typeof window === 'undefined') return SECRET_ACTIVITY_MAX_EVENTS_DEFAULT;
+
+  const features = getBootstrapValue('features');
+  const raw: unknown = features?.secret_activity?.max_events;
+  const result =
+    typeof raw === 'number' && Number.isInteger(raw) && raw > 0
+      ? raw
+      : SECRET_ACTIVITY_MAX_EVENTS_DEFAULT;
+  debugLog.features('features.getSecretActivityMaxEvents', { max_events: raw, result });
+  return result;
+}
+
 /**
  * Checks if organization-level incoming secrets configuration is enabled.
  * When true, organizations with incoming_secrets entitlement can configure

--- a/try/unit/config/billing_config_try.rb
+++ b/try/unit/config/billing_config_try.rb
@@ -12,6 +12,11 @@ require 'fileutils'
 # Clear env vars that stripe_key reads before checking config
 @original_stripe_api_key = ENV.delete('STRIPE_API_KEY')
 
+# enabled? short-circuits on BILLING_ENABLED before reading the config file;
+# direnv exports it from .env.test locally, so clear it or the "no config
+# file" expectations below assert against the developer's shell, not the code.
+@original_billing_enabled = ENV.delete('BILLING_ENABLED')
+
 # Stub resolve to return nil for 'billing', forcing empty config
 Onetime::Utils::ConfigResolver.define_singleton_method(:resolve) do |name|
   return nil if name == 'billing'
@@ -145,5 +150,6 @@ end
 ENV.delete('STRIPE_CHECKOUT_HOST')
 ENV['STRIPE_CHECKOUT_HOST'] = @original_checkout_host unless @original_checkout_host.nil?
 
-# Restore env var cleared in setup
+# Restore env vars cleared in setup
 ENV['STRIPE_API_KEY'] = @original_stripe_api_key unless @original_stripe_api_key.nil?
+ENV['BILLING_ENABLED'] = @original_billing_enabled unless @original_billing_enabled.nil?

--- a/try/unit/logic/account/email_change_try.rb
+++ b/try/unit/logic/account/email_change_try.rb
@@ -455,11 +455,12 @@ rescue => e
 end
 #=> [true, { confirmed: true, redirect: '/signin' }]
 
-## Confirming for a customer the revoke cannot RESOLVE (never persisted, so it
-## is absent from the extid index) completes normally AND sweeps nobody: a
-## bystander's session blob survives. This is the blank-identity guard —
-## matching an empty extid against every blob would nuke the keyspace, so
-## RevokeAllForCustomer bails before scanning (purge_untracked).
+## Confirming for a customer that was never persisted REFUSES fail-closed
+## instead of completing: Familia 2.12 raises PersistenceError when
+## `update_in_class_email_index` runs on an unsaved record (familia#370), the
+## op rescues that into `:partial` (nothing committed, nothing to compensate),
+## and ConfirmEmailChange's fail-closed else maps `:partial` to a FormError.
+## The revoke step is never reached, so a bystander's session blob survives.
 @bare_cust = Onetime::Customer.new email: generate_unique_test_email('bare') # deliberately NOT saved
 @bystander_cust = Onetime::Customer.new email: generate_unique_test_email('bystander')
 @bystander_cust.save
@@ -468,11 +469,24 @@ end
 @sweep_db.set(@bystander_blob,
               @sweep_codec.encode({ 'external_id' => @bystander_cust.extid, 'authenticated' => true }),
               ex: 3600)
-[
-  build_confirm(@bare_cust, {}, generate_unique_test_email('bare-new')).process,
-  @sweep_db.exists(@bystander_blob),
-]
-#=> [{ confirmed: true, redirect: '/signin' }, 1]
+begin
+  build_confirm(@bare_cust, {}, generate_unique_test_email('bare-new')).process
+  :no_raise
+rescue OT::FormError => e
+  [e.message, @sweep_db.exists(@bystander_blob)]
+end
+#=> ['Email change could not be completed', 1]
+
+## The blank-identity guard itself, at the op level (the confirm path above can
+## no longer reach it — the op refuses before revoking): a custid that resolves
+## to NO customer bails before scanning (purge_untracked's nil-customer guard).
+## Matching an empty identity against every blob would nuke the keyspace, so an
+## unresolvable target sweeps nobody — the bystander's blob survives.
+result = Onetime::Operations::Sessions::RevokeAllForCustomer.new(
+  custid: 'ur_unresolvable_target', actor: 'ur_test_actor',
+).call
+[result.blobs_deleted, result.untracked_deleted, result.scan_capped, @sweep_db.exists(@bystander_blob)]
+#=> [0, 0, false, 1]
 
 ## Simple auth mode skips the Rodauth SQL path and still clears the session
 # In test env auth mode is simple, so full_enabled? is false and there is no


### PR DESCRIPTION
Introduces configurable event retention caps (`max_events`) and collection toggles (`collect`) for organization Secret Activity tracking. Exposes these limits through the bootstrapping contract to the frontend, displaying appropriate collection-paused notices and enforcement in the UI. Also upgrades Familia to 2.12 and updates the test suite to ensure hermetic configuration and persistence-guard compliance.

Resolves #3990

## Deployment Notes

> [!WARNING]
> **Familia 2.12 behavior change: indexing an unsaved record now raises.**
> `update_in_class_<index>` / `update_in_<scope>_<index>` begin with
> `_ensure_persisted_before_index_write!` (familia#370), which raises
> `Familia::PersistenceError` for any record not yet persisted, outside a
> familia transaction. Production paths are unaffected — every real caller of
> `ChangeEmail` passes a loaded, persisted customer — but one test relied on
> the old silent behavior: `email_change_try.rb:475` fed a deliberately
> never-saved customer through `ConfirmEmailChange`, and the raise inside
> `rekey_customer!` now surfaces as `:partial` → fail-closed `FormError`.
> Deterministic, not flake; the earlier "shared-state only" repro was a
> dev-shell env artifact.

> [!NOTE]
> **Resolution: fix the test, keep the gem behavior.** 2.12's refusal to index
> an unsaved record is more correct than the old silent index claim, so the
> testcase was rewritten rather than working around the guard:
> 1. The unsaved-customer case now asserts the **new refusal semantics** —
>    `FormError` ("Email change could not be completed") and an untouched
>    bystander session blob.
> 2. The blank-identity guard in `RevokeAllForCustomer#purge_untracked`
>    (unresolvable target must sweep nobody) is now covered **directly at the
>    op level**, since the confirm path can no longer reach it.
>
> The "save then remove the extid index entry" alternative doesn't work: the
> `external_identifier` feature's `save` override re-writes `extid_lookup`,
> and `rekey_customer!` saves before `revoke_sessions` — restoring the entry
> mid-op. Non-blocking follow-up: migrate `change_email.rb`'s raw `HSETNX`
> claim to 2.12's `claim_unique_email_index!`.