### PR TITLE
fix(masthead): resolve neutral alt/site-name from productName directly

### DIFF
--- a/src/shared/components/layout/MastHead.vue
+++ b/src/shared/components/layout/MastHead.vue
@@ -97,9 +97,7 @@
   const getLogoAlt = () =>
     props.logo?.alt ||
     installLogoAlt.value ||
-    (showPlatformIdentity.value
-      ? t('web.homepage.one_time_secret_literal', { product_name: productName.value })
-      : displayName.value);
+    (showPlatformIdentity.value ? productName.value : displayName.value);
   const getLogoHref = () => props.logo?.href || headerConfig.value?.logo?.href || '/';
 
   // Custom install-wide logo: operator set BRAND_LOGO_URL. Distinct from the
@@ -146,7 +144,13 @@
   // The wordmark text is the resolver's productName (brand.product_name or
   // the neutral default) — the deprecated header.branding.site_name is
   // absorbed into brand.product_name by Config#normalize_brand (#3612).
-  const getSiteName = () => props.logo?.siteName || t('web.homepage.one_time_secret_literal', { product_name: productName.value });
+  //
+  // Read directly from the resolver rather than through the
+  // `web.homepage.one_time_secret_literal` i18n key: several locale
+  // translations of that key still carry a hardcoded literal brand string
+  // instead of the `{product_name}` placeholder, which would leak the
+  // platform brand onto a neutral/private-label install (#3571).
+  const getSiteName = () => props.logo?.siteName || productName.value;
   const getAriaLabel = () => props.logo?.ariaLabel;
   const getIsColonelArea = () => props.logo?.isColonelArea ?? props.colonel;
 

--- a/src/tests/shared/brandingResolverConsolidation.guard.spec.ts
+++ b/src/tests/shared/brandingResolverConsolidation.guard.spec.ts
@@ -98,6 +98,14 @@ describe('branding resolver consolidation guardrail', () => {
       expect(raw).toContain('installLogoAlt');
       expect(raw).toContain('logoSource');
     });
+
+    it('does not route the neutral alt/site-name fallback through the stale-translatable literal key (#3571)', () => {
+      // web.homepage.one_time_secret_literal still carries a hardcoded
+      // translated brand string in several locales, ignoring the
+      // {product_name} interpolation. Routing through it here would leak the
+      // platform brand onto a neutral/private-label install in those locales.
+      expect(code).not.toContain('one_time_secret_literal');
+    });
   });
 
   describe('identityStore is the one place the raw install-brand fields are read', () => {


### PR DESCRIPTION
## Summary
- `MastHead`'s logo `alt` / site-name neutral fallback routed through the i18n key `web.homepage.one_time_secret_literal`. The `en` source value is `{product_name}`, correctly interpolating the resolver's neutral product name, but 9 other locales still carry a hardcoded literal brand string translated against a stale pre-`{product_name}` source, so `{product_name}` interpolation is ignored in those locales.
- Result: on a private-label/unbranded install, switching the UI locale to one of the 9 affected locales (`de_AT`, `eo`, `fr_FR`, `ja`, `mi_NZ`, `pt_BR`, `sv_SE`, `tr`, `zh`) leaked the platform brand into the masthead logo alt-text / site-name.
- Applies the structural fix recommended in the issue: `getLogoAlt` / `getSiteName` in `MastHead.vue` now read `productName` from the identity resolver directly instead of going through the i18n key. This is a no-op for `en` and the 20 already-correct locales, fixes the 9 stale ones, and can't re-leak via future locale data drift.
- Adds a guard assertion to `brandingResolverConsolidation.guard.spec.ts` so `MastHead` cannot re-route through `one_time_secret_literal` in the future.

Closes #3571

## Test plan
- [x] `pnpm vitest run` on `brandingResolverConsolidation.guard.spec.ts`, `MastHead.spec.ts`, `MastHead.customDomain.spec.ts`, `BrandedMastHead.spec.ts` — all passing
- [x] Full `pnpm vitest run` — passing (one pre-existing unrelated flaky timeout in `useEntitlements.spec.ts`, not touched by this change)
- [x] `vue-tsc --noEmit` — no new type errors
- [x] `eslint` — no new errors