### PR TITLE
*fix: sanitize domains config and enforce serializer output boundary

### DIFF
--- a/apps/web/core/spec/views/serializers/config_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/config_serializer_spec.rb
@@ -262,6 +262,65 @@ RSpec.describe Core::Views::ConfigSerializer do
       end
     end
 
+    # The features.domains config subtree carries the Approximated proxy
+    # credentials (approximated.api_key et al.) and the internal ACME
+    # listener config. The bootstrap payload is served to every visitor, so
+    # the serializer must allowlist the frontend-facing fields instead of
+    # passing the subtree through verbatim. DNS proxy targets for domain
+    # owners are served by the authenticated domains API
+    # (DomainValidation::Features.safe_dump), not the bootstrap.
+    describe 'domains allowlist' do
+      let(:domains_config) do
+        {
+          'enabled' => true,
+          'require_verified' => true,
+          'default' => 'eu.example.com',
+          'validation_strategy' => 'approximated',
+          'approximated' => {
+            'api_key' => 'secret-api-key',
+            'proxy_ip' => '203.0.113.10',
+            'proxy_host' => 'proxy.example.net',
+            'proxy_name' => 'proxy',
+            'vhost_target' => 'target.example.net',
+          },
+          'acme' => {
+            'enabled' => true,
+            'listen_address' => '127.0.0.1',
+            'port' => 12_020,
+          },
+        }
+      end
+
+      let(:domains_view_vars) do
+        base_view_vars.merge(
+          'features' => base_view_vars['features'].merge('domains' => domains_config)
+        )
+      end
+
+      it 'emits only the allowlisted fields' do
+        result = described_class.serialize(domains_view_vars)
+        expect(result['domains']).to eq(
+          'enabled' => true,
+          'require_verified' => true,
+          'default' => 'eu.example.com',
+          'validation_strategy' => 'approximated'
+        )
+      end
+
+      it 'never emits the Approximated credentials or ACME config' do
+        result = described_class.serialize(domains_view_vars)
+        expect(result['domains']).not_to have_key('approximated')
+        expect(result['domains']).not_to have_key('acme')
+        expect(result.to_s).not_to include('secret-api-key')
+      end
+
+      it 'omits the domains key entirely when the feature is disabled' do
+        result = described_class.serialize(base_view_vars)
+        expect(result['domains_enabled']).to be(false)
+        expect(result['domains']).to be_nil
+      end
+    end
+
     describe 'brand_* bootstrap exposure' do
       let(:brand_view_vars) do
         base_view_vars.merge(

--- a/apps/web/core/spec/views/serializers/registry_spec.rb
+++ b/apps/web/core/spec/views/serializers/registry_spec.rb
@@ -1,0 +1,53 @@
+# apps/web/core/spec/views/serializers/registry_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for SerializerRegistry output boundary enforcement.
+#
+# The output_template is each serializer's boundary schema for the bootstrap
+# payload: keys a serializer never declared are stripped (not just warned
+# about) so accidental additions cannot reach the browser.
+#
+# Run with:
+#   source .env.test && bundle exec rspec apps/web/core/spec/views/serializers/registry_spec.rb
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require_relative '../../../views/serializers'
+
+RSpec.describe Core::Views::SerializerRegistry do
+  let(:declared_serializer) do
+    Module.new do
+      def self.to_s = 'DeclaredSerializer'
+
+      def self.output_template
+        { 'declared_key' => nil, 'other_declared' => nil }
+      end
+
+      def self.serialize(_vars)
+        {
+          'declared_key' => 'value',
+          'undeclared_key' => 'must-not-ship',
+        }
+      end
+    end
+  end
+
+  after do
+    described_class.serializers.delete(declared_serializer)
+    described_class.dependencies.delete(declared_serializer)
+  end
+
+  describe '.run' do
+    it 'passes through keys declared in the output_template' do
+      described_class.register(declared_serializer)
+      result = described_class.run([declared_serializer], {})
+      expect(result['declared_key']).to eq('value')
+    end
+
+    it 'strips keys the serializer did not declare' do
+      described_class.register(declared_serializer)
+      result = described_class.run([declared_serializer], {})
+      expect(result).not_to have_key('undeclared_key')
+    end
+  end
+end

--- a/apps/web/core/views/helpers/initialize_view_vars.rb
+++ b/apps/web/core/views/helpers/initialize_view_vars.rb
@@ -340,9 +340,17 @@ module Core
         # Deep copy to prevent mutations
         safe_features = OT::Config.deep_clone(features_config)
 
-        # Remove sensitive cluster credentials from domains config
-        if safe_features.dig('domains', 'cluster')
-          safe_features['domains'].delete('cluster')
+        # Remove sensitive credentials and internal endpoints from the domains
+        # config. 'approximated' carries the Approximated API key and proxy
+        # settings; 'acme' is the internal ACME listener; 'cluster' is the
+        # pre-rename key the approximated block used to live under. This scrub
+        # was blocklisting only 'cluster' after the rename, which is how the
+        # Approximated api_key reached view_vars — ConfigSerializer's
+        # transform_domains allowlist is the primary gate, this is depth.
+        if safe_features['domains'].is_a?(Hash)
+          %w[cluster approximated acme].each do |sensitive_key|
+            safe_features['domains'].delete(sensitive_key)
+          end
         end
 
         safe_features

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -57,8 +57,13 @@ module Core
         output['regions_enabled'] = regions.fetch('enabled', false)
         output['regions']         = transform_regions(regions) if output['regions_enabled']
 
+        # Only send the allowlisted domains fields when the feature is enabled.
+        # The raw config subtree also carries the Approximated credentials
+        # (approximated.api_key et al.) and the internal ACME listener — the
+        # DNS proxy targets a domain owner needs are served by the
+        # authenticated domains API via DomainValidation::Features.safe_dump.
         output['domains_enabled'] = domains.fetch('enabled', false)
-        output['domains']         = domains if output['domains_enabled']
+        output['domains']         = transform_domains(domains) if output['domains_enabled']
 
         # Link to the pricing page can be seen regardless of authentication status
         output['billing_enabled'] = OT.billing_config.enabled?
@@ -491,6 +496,26 @@ module Core
                 'display_name' => config.display_name.to_s,
               },
             ],
+          }
+        end
+
+        # Transform domains config for frontend consumption
+        #
+        # Allowlist, not blocklist: the features.domains subtree includes the
+        # Approximated proxy credentials and the internal ACME endpoint
+        # config, which must never reach the bootstrap payload. The frontend
+        # consumes validation_strategy (src/utils/features.ts) and the
+        # optional require_verified/default fields; everything else stays
+        # server-side.
+        #
+        # @param domains [Hash] Raw domains config from features
+        # @return [Hash] Frontend-safe domains fields
+        def transform_domains(domains)
+          {
+            'enabled' => domains.fetch('enabled', false),
+            'require_verified' => domains.fetch('require_verified', false),
+            'default' => domains['default'],
+            'validation_strategy' => domains.fetch('validation_strategy', 'passthrough'),
           }
         end
 

--- a/apps/web/core/views/serializers/registry.rb
+++ b/apps/web/core/views/serializers/registry.rb
@@ -79,7 +79,11 @@ module Core
             # payload, even by accident. This guards top-level keys only —
             # nested subtrees are each serializer's job to allowlist (e.g.
             # ConfigSerializer#transform_domains).
-            declared, undeclared = output.partition { |key, _| serializer.output_template.key?(key) }.map(&:to_h)
+            #
+            # output_template builds a fresh hash on every call, so hoist it
+            # out of the block rather than rebuilding it once per output key.
+            template             = serializer.output_template
+            declared, undeclared = output.partition { |key, _| template.key?(key) }.map(&:to_h)
 
             undeclared.each_key do |key|
               app_logger.warn 'Serializer key not in output template; stripped',

--- a/apps/web/core/views/serializers/registry.rb
+++ b/apps/web/core/views/serializers/registry.rb
@@ -73,17 +73,24 @@ module Core
               next result
             end
 
-            output.each_key do |key|
-              # Detect keys that are not defined in the serializer output_template
-              unless serializer.output_template.key?(key)
-                app_logger.warn 'Serializer key not in output template',
-                  {
-                    key: key,
-                    serializer: serializer.to_s,
-                    module: 'SerializerRegistry',
-                  }
-              end
+            # Strip keys that are not defined in the serializer
+            # output_template. The template is the output boundary schema: a
+            # key a serializer never declared must not reach the bootstrap
+            # payload, even by accident. This guards top-level keys only —
+            # nested subtrees are each serializer's job to allowlist (e.g.
+            # ConfigSerializer#transform_domains).
+            declared, undeclared = output.partition { |key, _| serializer.output_template.key?(key) }.map(&:to_h)
 
+            undeclared.each_key do |key|
+              app_logger.warn 'Serializer key not in output template; stripped',
+                {
+                  key: key,
+                  serializer: serializer.to_s,
+                  module: 'SerializerRegistry',
+                }
+            end
+
+            declared.each_key do |key|
               # Detect key collisions with output from previous serializers
               if seen_keys.key?(key)
                 app_logger.warn 'Serializer key collision detected',
@@ -98,7 +105,7 @@ module Core
               end
             end
 
-            result.merge(output)
+            result.merge(declared)
           end
         end
 

--- a/src/schemas/contracts/config/public.ts
+++ b/src/schemas/contracts/config/public.ts
@@ -186,50 +186,20 @@ const regionsSchema = z.object({
 });
 
 /**
- * Schema for the :approximated section within :domains
- *
- * Approximated proxy configuration (used by the 'approximated' validation
- * strategy). All fields default to nil in the Ruby YAML when env vars are
- * unset, so every key is optional/nullable here.
- */
-const approximatedSchema = z
-  .object({
-    api_key: z.string().nullable().optional(),
-    proxy_ip: z.string().nullable().optional(),
-    proxy_host: z.string().nullable().optional(),
-    proxy_name: z.string().nullable().optional(),
-    vhost_target: z.string().nullable().optional(),
-  })
-  .strip();
-
-/**
- * Schema for the :acme section within :domains
- *
- * Internal ACME endpoint configuration (used by the 'caddy_on_demand'
- * validation strategy).
- */
-const acmeSchema = z
-  .object({
-    enabled: z.boolean(),
-    listen_address: z.string().optional(),
-    port: z.union([z.string(), z.number()]).optional(),
-  })
-  .strip();
-
-/**
  * Schema for the :domains section
  *
- * Mirrors `features.domains` in etc/defaults/config.defaults.yaml. The
- * bootstrap payload is the raw Ruby hash (see ConfigSerializer), so any
- * rename here must be applied on the Ruby side as well.
+ * Allowlisted subset of `features.domains` from
+ * etc/defaults/config.defaults.yaml, serialized by
+ * ConfigSerializer#transform_domains. The `approximated` (proxy
+ * credentials) and `acme` (internal listener) blocks are server-side only
+ * and must never appear in a client-facing payload — do not re-add them
+ * here; per-domain DNS targets come from the authenticated domains API.
  */
 const domainsSchema = z.object({
   enabled: z.boolean(),
   require_verified: z.boolean().optional(),
   default: z.string().nullable().optional(),
   validation_strategy: z.string().optional(),
-  approximated: approximatedSchema.optional(),
-  acme: acmeSchema.optional(),
 });
 
 /**

--- a/src/schemas/contracts/config/section/features.ts
+++ b/src/schemas/contracts/config/section/features.ts
@@ -65,36 +65,15 @@ const featuresRegionsSchema = z.object({
 });
 
 /**
- * Domain proxy configuration (for approximated strategy)
- */
-const featuresDomainsProxySchema = z.object({
-  api_key: nullableString,
-  proxy_ip: nullableString,
-  proxy_host: nullableString,
-  proxy_name: nullableString,
-  vhost_target: nullableString,
-});
-
-/**
- * ACME endpoint configuration (for caddy_on_demand strategy)
- *
- * `port` accepts string or number: the shipped YAML uses
- * `<%= ENV['ACME_PORT'] || '12020' %>`, which renders to the bareword
- * `12020`, and YAML auto-coerces that to an integer at parse time.
- * Both representations are semantically the same TCP port.
- */
-const featuresDomainsAcmeSchema = z.object({
-  enabled: z.boolean().optional(),
-  listen_address: z.string().optional(),
-  port: z.union([z.string(), z.number()]).optional(),
-});
-
-/**
  * Domains feature configuration
  *
- * Field names mirror `features.domains` in etc/defaults/config.defaults.yaml.
- * The bootstrap payload is the raw Ruby hash (see ConfigSerializer), so any
- * rename here must be applied on the Ruby side as well.
+ * Allowlisted subset of `features.domains` from
+ * etc/defaults/config.defaults.yaml, serialized by
+ * ConfigSerializer#transform_domains — any rename here must be applied on
+ * the Ruby side as well. The `approximated` (proxy credentials) and `acme`
+ * (internal listener) blocks are server-side only and must never appear in
+ * a client-facing payload — do not re-add them here; per-domain DNS targets
+ * come from the authenticated domains API.
  */
 const featuresDomainsSchema = z.object({
   enabled: z.boolean().optional(),
@@ -103,8 +82,6 @@ const featuresDomainsSchema = z.object({
   validation_strategy: z
     .enum(['passthrough', 'approximated', 'caddy_on_demand'])
     .optional(),
-  approximated: featuresDomainsProxySchema.optional(),
-  acme: featuresDomainsAcmeSchema.optional(),
 });
 
 /**
@@ -121,6 +98,4 @@ export {
   featuresRegionsSchema,
   featuresIncomingSchema,
   featuresDomainsSchema,
-  featuresDomainsProxySchema,
-  featuresDomainsAcmeSchema,
 };

--- a/src/schemas/shapes/config/index.ts
+++ b/src/schemas/shapes/config/index.ts
@@ -40,8 +40,6 @@ export {
   featuresRegionsShape,
   featuresIncomingShape,
   featuresDomainsShape,
-  featuresDomainsProxyShape,
-  featuresDomainsAcmeShape,
 } from './section/features';
 
 export { i18nShape } from './section/i18n';

--- a/src/schemas/shapes/config/section/features.ts
+++ b/src/schemas/shapes/config/section/features.ts
@@ -5,7 +5,7 @@
  *
  * Adds runtime defaults and value constraints on top of the type-only
  * features contract — incoming-secret memo/TTL bounds, region defaults,
- * domain validation defaults, and ACME listener defaults.
+ * and domain validation defaults.
  *
  * @see src/schemas/contracts/config/section/features.ts
  */
@@ -15,8 +15,6 @@ import {
   featuresRegionsSchema,
   featuresIncomingSchema,
   featuresDomainsSchema,
-  featuresDomainsProxySchema,
-  featuresDomainsAcmeSchema,
 } from '@/schemas/contracts/config/section/features';
 import { augment } from '@/schemas/utils/augment';
 
@@ -25,8 +23,6 @@ export {
   featuresRegionsSchema,
   featuresIncomingSchema,
   featuresDomainsSchema,
-  featuresDomainsProxySchema,
-  featuresDomainsAcmeSchema,
 };
 
 const featuresIncomingShape = augment(featuresIncomingSchema, {
@@ -39,32 +35,10 @@ const featuresRegionsShape = augment(featuresRegionsSchema, {
   enabled: (b) => b.default(false),
 });
 
-const featuresDomainsProxyShape = featuresDomainsProxySchema;
-
-/**
- * ACME endpoint shape.
- *
- * `port` stays a string|number union — the shipped YAML uses
- * `<%= ENV['ACME_PORT'] || '12020' %>`, which renders to the bareword
- * `12020` that YAML auto-coerces to an integer. Both representations are
- * the same TCP port. The default keeps the string form to match the
- * env-unset path.
- */
-const featuresDomainsAcmeShape = augment(featuresDomainsAcmeSchema, {
-  enabled: (b) => b.default(false),
-  listen_address: (s) => s.default('127.0.0.1'),
-  port: (u) => u.default('12020'),
-});
-
 const featuresDomainsShape = augment(featuresDomainsSchema, {
   enabled: (b) => b.default(false),
   require_verified: (b) => b.default(false),
   validation_strategy: (e) => e.default('passthrough'),
-  acme: {
-    enabled: (b) => b.default(false),
-    listen_address: (s) => s.default('127.0.0.1'),
-    port: (u) => u.default('12020'),
-  },
 });
 
 const featuresShape = augment(featuresSchema, {
@@ -78,11 +52,6 @@ const featuresShape = augment(featuresSchema, {
     enabled: (b) => b.default(false),
     require_verified: (b) => b.default(false),
     validation_strategy: (e) => e.default('passthrough'),
-    acme: {
-      enabled: (b) => b.default(false),
-      listen_address: (s) => s.default('127.0.0.1'),
-      port: (u) => u.default('12020'),
-    },
   },
 });
 
@@ -91,6 +60,4 @@ export {
   featuresRegionsShape,
   featuresIncomingShape,
   featuresDomainsShape,
-  featuresDomainsProxyShape,
-  featuresDomainsAcmeShape,
 };

--- a/src/tests/schemas/shapes/config/features.spec.ts
+++ b/src/tests/schemas/shapes/config/features.spec.ts
@@ -1,14 +1,19 @@
 // src/tests/schemas/shapes/config/features.spec.ts
 //
-// Coverage for the features shape — regions, incoming, domains (incl. the
-// ACME endpoint and proxy sub-trees). The `jurisdictions` union added in
-// PR #3206 lives on the contract because `z.union(...)` is a type-format
-// helper; this file exercises all three branches there to lock that down.
+// Coverage for the features shape — regions, incoming, and domains. The
+// `jurisdictions` union added in PR #3206 lives on the contract because
+// `z.union(...)` is a type-format helper; this file exercises all three
+// branches there to lock that down.
+//
+// The domains contract is the allowlisted subset ConfigSerializer emits:
+// the `approximated` (proxy credentials) and `acme` (internal listener)
+// blocks are server-side only and are asserted absent here so they cannot
+// quietly rejoin the client-facing contract.
 
 import { describe, it, expect } from 'vitest';
 import {
   featuresIncomingSchema,
-  featuresDomainsAcmeSchema,
+  featuresDomainsSchema,
   featuresRegionsSchema,
 } from '@/schemas/contracts/config/section/features';
 import {
@@ -16,8 +21,6 @@ import {
   featuresRegionsShape,
   featuresIncomingShape,
   featuresDomainsShape,
-  featuresDomainsProxyShape,
-  featuresDomainsAcmeShape,
 } from '@/schemas/shapes/config/section/features';
 
 describe('featuresIncomingShape — defaults and bounds', () => {
@@ -75,51 +78,30 @@ describe('featuresRegions jurisdictions union (contract-side)', () => {
   });
 });
 
-describe('featuresDomainsAcmeShape — defaults', () => {
-  it('defaults enabled/listen_address/port on empty input', () => {
-    const result = featuresDomainsAcmeShape.parse({});
-    expect(result.enabled).toBe(false);
-    expect(result.listen_address).toBe('127.0.0.1');
-    expect(result.port).toBe('12020');
-  });
-
-  it('accepts both string and number forms of port', () => {
-    expect(featuresDomainsAcmeShape.parse({ port: 12020 }).port).toBe(12020);
-    expect(featuresDomainsAcmeShape.parse({ port: '8443' }).port).toBe('8443');
-  });
-
-  it('contract leaves enabled/port undefined', () => {
-    const result = featuresDomainsAcmeSchema.parse({});
-    expect(result.enabled).toBeUndefined();
-    expect(result.port).toBeUndefined();
-  });
-});
-
-describe('featuresDomainsProxyShape — passthrough', () => {
-  it('is a re-export of the contract (no augmentation)', () => {
-    expect(featuresDomainsProxyShape.parse({})).toEqual({});
-  });
-
-  it('preserves nullable string fields', () => {
-    const result = featuresDomainsProxyShape.parse({ api_key: null, proxy_ip: '10.0.0.1' });
-    expect(result.api_key).toBeNull();
-    expect(result.proxy_ip).toBe('10.0.0.1');
-  });
-});
-
 describe('featuresDomainsShape — composed defaults', () => {
-  it('defaults enabled/require_verified/validation_strategy and nested acme', () => {
-    const result = featuresDomainsShape.parse({ acme: {} });
+  it('defaults enabled/require_verified/validation_strategy', () => {
+    const result = featuresDomainsShape.parse({});
     expect(result.enabled).toBe(false);
     expect(result.require_verified).toBe(false);
     expect(result.validation_strategy).toBe('passthrough');
-    expect(result.acme?.enabled).toBe(false);
-    expect(result.acme?.listen_address).toBe('127.0.0.1');
-    expect(result.acme?.port).toBe('12020');
   });
 
   it('rejects validation_strategy values outside the enum', () => {
     expect(() => featuresDomainsShape.parse({ validation_strategy: 'made_up' })).toThrow();
+  });
+
+  it('does not declare the server-side approximated/acme blocks', () => {
+    expect(featuresDomainsSchema.shape).not.toHaveProperty('approximated');
+    expect(featuresDomainsSchema.shape).not.toHaveProperty('acme');
+  });
+
+  it('strips server-side blocks if they ever appear in input', () => {
+    const result = featuresDomainsShape.parse({
+      approximated: { api_key: 'leaked' },
+      acme: { listen_address: '127.0.0.1' },
+    });
+    expect(result).not.toHaveProperty('approximated');
+    expect(result).not.toHaveProperty('acme');
   });
 });
 
@@ -128,13 +110,12 @@ describe('featuresShape — composed defaults', () => {
     const result = featuresShape.parse({
       regions: {},
       incoming: {},
-      domains: { acme: {} },
+      domains: {},
     });
     expect(result.regions?.enabled).toBe(false);
     expect(result.incoming?.enabled).toBe(false);
     expect(result.incoming?.memo_max_length).toBe(50);
     expect(result.incoming?.default_ttl).toBe(604800);
     expect(result.domains?.enabled).toBe(false);
-    expect(result.domains?.acme?.port).toBe('12020');
   });
 });

--- a/src/tests/schemas/shapes/config/sections.spec.ts
+++ b/src/tests/schemas/shapes/config/sections.spec.ts
@@ -18,7 +18,6 @@ import {
   redisSchema,
   emailerSchema,
   featuresIncomingSchema,
-  featuresDomainsAcmeSchema,
   siteSchema,
   passphraseSchema,
 } from '@/schemas/contracts/config';
@@ -33,7 +32,6 @@ import {
   redisDbsShape,
   emailerShape,
   featuresIncomingShape,
-  featuresDomainsAcmeShape,
   siteShape,
   passphraseShape,
 } from '@/schemas/shapes/config';
@@ -139,18 +137,6 @@ describe('contract vs shape: defaults are absent on contracts, applied on shapes
     expect(s.enabled).toBe(false);
     expect(s.memo_max_length).toBe(50);
     expect(s.default_ttl).toBe(604800);
-  });
-
-  it('features.domains.acme', () => {
-    const c = featuresDomainsAcmeSchema.parse({});
-    expect(c.enabled).toBeUndefined();
-    expect(c.listen_address).toBeUndefined();
-    expect(c.port).toBeUndefined();
-
-    const s = featuresDomainsAcmeShape.parse({});
-    expect(s.enabled).toBe(false);
-    expect(s.listen_address).toBe('127.0.0.1');
-    expect(s.port).toBe('12020');
   });
 
   it('site', () => {


### PR DESCRIPTION
Sanitizes the public domain configuration and enforces a strict output boundary on serializers to prevent the accidental leak of internal server-side configuration (such as ACME or DNS credentials) into the bootstrap payload.

It also aligns the frontend configuration schemas and validation tests to exclude these internal fields.