### PR TITLE
feat(cli): add customers role reconcile to repair role-index drift

### DIFF
--- a/lib/onetime/cli/customers/role_command.rb
+++ b/lib/onetime/cli/customers/role_command.rb
@@ -11,6 +11,7 @@
 #   bin/ots customers role demote user@example.com               # Demote to customer
 #   bin/ots customers role list                                  # List all colonels
 #   bin/ots customers role list --role admin                     # List users with specific role
+#   bin/ots customers role reconcile                              # Rebuild the role index from source
 #
 # The actual role mutation + admin audit event is performed by the shared
 # Auth::Operations::Customers::SetRole op (single implementation); this command
@@ -27,7 +28,7 @@ module Onetime
       argument :action,
         type: :string,
         required: true,
-        desc: 'Action to perform: promote, demote, or list'
+        desc: 'Action to perform: promote, demote, list, or reconcile'
 
       argument :email,
         type: :string,
@@ -59,9 +60,11 @@ module Onetime
           demote_customer(email, force)
         when 'list'
           list_customers_by_role(role)
+        when 'reconcile'
+          reconcile_role_index
         else
           puts "Unknown action: #{action}"
-          puts 'Valid actions: promote, demote, list'
+          puts 'Valid actions: promote, demote, list, reconcile'
           exit 1
         end
       end
@@ -148,6 +151,20 @@ module Onetime
 
         puts '-' * 40
         puts "Total: #{customers.size}"
+      end
+
+      # Rebuilds customer:role_index:* from the authoritative `role` field on
+      # every customer record. The index is a derived cache -- targeted
+      # writers (save_fields, multi_field_update, multi_field_fast_write)
+      # persist `role` without going through the full Familia#save path that
+      # maintains the index, so a customer's role and its index membership
+      # can drift apart silently (#3974). This does not affect authorization
+      # (authorization_policies.rb reads the field directly), only the
+      # trustworthiness of `role list` / `colonel_count` as an audit tool.
+      def reconcile_role_index
+        puts 'Rebuilding customer role index from source (customer.role field)...'
+        processed = Onetime::Customer.rebuild_role_index
+        puts "Done: #{processed} customers scanned."
       end
 
       def validate_email_provided!(email, action)

--- a/try/unit/cli/customers/role_command_try.rb
+++ b/try/unit/cli/customers/role_command_try.rb
@@ -369,6 +369,36 @@ demote_customer(@colonel_email)
 reset_role(@colonel_email, 'colonel')
 #=> "colonel"
 
+# -------------------------------------------------------------------
+# Reconcile: rebuild_role_index repairs drift between the role field
+# and the index (#3974). Targeted writers (save_fields et al.) persist
+# `role` without going through the full Familia#save path that
+# maintains customer:role_index:*, so the two can drift apart silently.
+# -------------------------------------------------------------------
+
+## A customer promoted via a targeted writer (save_fields) is NOT
+## reflected in the role index -- this is the drift #3974 describes
+@drifted_email = "drifted_#{@test_suffix}@test.example.com"
+@drifted = Onetime::Customer.create!(email: @drifted_email)
+@drifted.role = 'colonel'
+@drifted.save_fields(:role)
+Onetime::Customer.find_all_by_role('colonel').map(&:email).include?(@drifted_email)
+#=> false
+
+## ...even though the field itself says colonel
+Onetime::Customer.find_by_email(@drifted_email).role.to_s
+#=> "colonel"
+
+## rebuild_role_index reconciles the drifted entry into the index
+Onetime::Customer.rebuild_role_index
+Onetime::Customer.find_all_by_role('colonel').map(&:email).include?(@drifted_email)
+#=> true
+
+## Reset drifted customer to non-colonel and clean up
+@drifted.destroy!
+Onetime::Customer.email_exists?(@drifted_email)
+#=> false
+
 # TEARDOWN
 
 [@regular_email, @colonel_email, @admin_email, @staff_email].each do |email|


### PR DESCRIPTION
## Summary
- Root cause confirmed: `customer:role_index:*` (Familia `multi_index`) is only kept in sync automatically on the full `Familia#save` path (`auto_update_class_indexes`, called from `persist_to_storage`). Targeted writers — `save_fields`, `multi_field_update`, `multi_field_fast_write` — persist scalar fields directly and never call it, so a customer's `role` field and its index membership can drift apart silently. Reproduced locally: a customer set to `role = 'colonel'` via `save_fields(:role)` never appears in `find_all_by_role('colonel')`, even though `customer.role` correctly reads `'colonel'` (and authorization, which reads the field directly, is unaffected).
- Adds `bin/ots customers role reconcile`, which calls Familia's existing (already-generated but previously unexposed) `Customer.rebuild_role_index` to rebuild the index from the authoritative `role` field on every customer record.
- This directly addresses the issue's own conclusion: the index is a derived cache and needs "a reconcile/rebuild path so a drifted index can be repaired rather than silently trusted."
- Does not affect authorization (`has_system_role?` reads the field directly, never the index) — this only restores trust in `role list` / `colonel_count` as an audit tool.

Closes #3974

## Test plan
- [x] New tryout section in `try/unit/cli/customers/role_command_try.rb` reproduces the drift via `save_fields(:role)` and asserts `rebuild_role_index` repairs it
- [x] `bundle exec try try/unit/cli/customers/role_command_try.rb try/unit/models/v2/customer_role_index_try.rb` — 78 passed
- [x] `bundle exec rake try:unit` (full unit tryout suite) — 7364 passed, 0 failed
- [x] `bundle exec rake spec:fast` — 322 examples, 0 failures
- [x] `bundle exec rubocop` on changed files — no new offenses
- [x] Manually ran `bin/ots customers role reconcile` end-to-end