### PR TITLE
fix(auth): mirror accounts.valid_email CHECK in the SSO email guard

### DIFF
--- a/apps/web/auth/config/hooks/omniauth.rb
+++ b/apps/web/auth/config/hooks/omniauth.rb
@@ -631,19 +631,20 @@ module Auth::Config::Hooks
       # Global: Set via ALLOWED_SIGNUP_DOMAIN environment variable (comma-separated)
       #
       auth.before_omniauth_create_account do
-        email       = omniauth_email.to_s.strip.downcase
-        email_parts = email.split('@')
+        email = omniauth_email.to_s.strip.downcase
 
         # Reject unusable emails from IdP (distinct from policy rejection): a
-        # missing/empty claim, or one without both a local part and a domain.
+        # missing/empty claim, or any shape the accounts.valid_email CHECK
+        # constraint would reject (internal spaces, comma/semicolon in either
+        # part, a dotless domain, etc. — see SignupValidation::VALID_EMAIL_PATTERN).
         # Redirect with a stable error code so Login.vue can show a localized
         # message — matches the email_auth/omniauth_on_failure convention.
         # Inline JSON via throw_error_status was clobbered by omniauth_on_failure,
         # collapsing the specific code into the generic sso_failed. Failing here
-        # (rather than letting a blank local part like "@example.com" fall
-        # through to account creation, which 500s on the PG valid_email CHECK)
-        # keeps the user on a localized error instead of a frozen screen (#3478).
-        if email_parts.length != 2 || email_parts.first.to_s.empty? || email_parts.last.to_s.empty?
+        # (rather than letting a claim the CHECK rejects fall through to account
+        # creation, which 500s as Sequel::CheckConstraintViolation) keeps the
+        # user on a localized error instead of a frozen screen (#3478, #3971).
+        unless Onetime::SignupValidation.structurally_valid_email?(email)
           Auth::Logging.log_auth_event(
             :omniauth_invalid_email,
             level: :warn,
@@ -662,7 +663,7 @@ module Auth::Config::Hooks
             :omniauth_domain_rejected,
             level: :warn,
             email: OT::Utils.obscure_email(email),
-            domain: email_parts.last,
+            domain: email.split('@').last,
             display_domain: display_domain,
             provider: omniauth_provider,
           )

--- a/lib/onetime/signup_validation.rb
+++ b/lib/onetime/signup_validation.rb
@@ -17,6 +17,32 @@ module Onetime
   module SignupValidation
     extend self
 
+    # Mirrors the `accounts.valid_email` CHECK constraint
+    # (apps/web/auth/migrations/001_initial.rb) so a claim rejected by the
+    # database is also rejected here, before it ever reaches the INSERT.
+    #
+    # The CHECK is PostgreSQL-only (SQLite stores email as a plain String —
+    # see that migration), so an SSO/OmniAuth email guard that only counts
+    # '@' characters lets shapes through that 500 on the CHECK (internal
+    # spaces, comma/semicolon in either part, a dotless domain) — the
+    # Sequel::CheckConstraintViolation surfaces as the frozen-loading-screen
+    # failure #3478 exists to prevent. Duplicating the pattern here — rather
+    # than only relying on the database to raise — keeps the guard effective
+    # on SQLite installs too, whose primary CI leg has no CHECK to catch a
+    # regression of this kind.
+    #
+    # Anchored with \A/\z, not ^/$: Ruby's ^/$ match at line boundaries, so
+    # "ok@example.com\nbad" would pass a ^/$ guard here and still be
+    # rejected by PG (whose ^/$ are string anchors) — reintroducing the 500
+    # this exists to prevent (#3971).
+    VALID_EMAIL_PATTERN = /\A[^,;@ \r\n]+@[^,@; \r\n]+\.[^,@; \r\n]+\z/
+
+    # @param email [String] Email address to validate
+    # @return [Boolean] true if the email matches the accounts.valid_email shape
+    def structurally_valid_email?(email)
+      email.to_s.match?(VALID_EMAIL_PATTERN)
+    end
+
     # Validate an email address for signup, with per-domain strategy support.
     #
     # @param email [String] Email address to validate

--- a/try/unit/signup_validation_try.rb
+++ b/try/unit/signup_validation_try.rb
@@ -117,6 +117,52 @@ Onetime::SignupValidation.resolve_signup_config('nonexistent.example.com')
 Onetime::SignupValidation.resolve_signup_config(nil)
 #=> nil
 
+# --- structurally_valid_email? mirrors the accounts.valid_email CHECK (#3971) ---
+#
+# constraint :valid_email, email: /^[^,;@ \r\n]+@[^,@; \r\n]+\.[^,@; \r\n]+$/
+# (apps/web/auth/migrations/001_initial.rb). Every shape below that the CHECK
+# rejects but a naive `email.split('@').length == 2` guard accepts previously
+# reached the INSERT and raised Sequel::CheckConstraintViolation -> 500 on the
+# SSO callback (the frozen-loading-screen failure #3478 exists to prevent).
+
+## A normal email is structurally valid
+Onetime::SignupValidation.structurally_valid_email?('alice@contoso.com')
+#=> true
+
+## An internal space in the local part is rejected (PG CHECK rejects it too)
+Onetime::SignupValidation.structurally_valid_email?('al ice@contoso.com')
+#=> false
+
+## A comma in the local part is rejected
+Onetime::SignupValidation.structurally_valid_email?('al,ice@contoso.com')
+#=> false
+
+## A semicolon in the domain is rejected
+Onetime::SignupValidation.structurally_valid_email?('alice@cont;oso.com')
+#=> false
+
+## A dotless domain is rejected (plausible from internal AD FS / OIDC issuers)
+Onetime::SignupValidation.structurally_valid_email?('alice@contoso')
+#=> false
+
+## An empty claim is rejected
+Onetime::SignupValidation.structurally_valid_email?('')
+#=> false
+
+## A claim with no '@' is rejected
+Onetime::SignupValidation.structurally_valid_email?('alice.contoso.com')
+#=> false
+
+## A blank local part (leading '@') is rejected
+Onetime::SignupValidation.structurally_valid_email?('@contoso.com')
+#=> false
+
+## \A/\z anchoring rejects an embedded newline that ^/$ would let through
+## ("ok@example.com\nbad" would pass a ^/$-anchored guard here and still be
+## rejected by PG, whose ^/$ are string anchors -- reintroducing the 500)
+Onetime::SignupValidation.structurally_valid_email?("ok@example.com\nbad")
+#=> false
+
 # --- Cleanup ---
 
 OT.conf['site']['authentication']['allowed_signup_domains'] = @original_allowed


### PR DESCRIPTION
## Summary
- `before_omniauth_create_account` (`apps/web/auth/config/hooks/omniauth.rb`) only validated the IdP email claim by counting `@` characters, but the `accounts.valid_email` CHECK it's protecting (`apps/web/auth/migrations/001_initial.rb:27`) is stricter. Every shape the CHECK rejects but the old guard accepted reached the INSERT and raised `Sequel::CheckConstraintViolation` → 500 on the SSO callback — the same frozen-loading-screen failure class #3478 exists to prevent.
- Adds `Onetime::SignupValidation.structurally_valid_email?`, which duplicates the CHECK's regex in Ruby rather than relying on the database to raise: the CHECK is PostgreSQL-only (SQLite stores email as a plain String per that same migration), and SQLite is this file's primary CI leg, so a guard that only counted `@` would leave that leg blind to a regression of this kind.
- Anchored with `\A`/`\z`, not `^`/`$` — Ruby's `^`/`$` match at line boundaries, so `"ok@example.com\nbad"` would slip past a `^`/`$`-anchored guard and still be rejected by PG (whose `^`/`$` are string anchors), reintroducing the 500.
- Fixes the four repro shapes from the issue: internal space in local part, comma in local part, semicolon in domain, dotless domain (plausible from internal AD FS / OIDC issuers).

Closes #3971

## Test plan
- [x] New cases in `try/unit/signup_validation_try.rb` cover all four repro shapes plus empty/no-`@`/blank-local-part/embedded-newline edge cases
- [x] `bundle exec try try/unit/signup_validation_try.rb` — 24 passed
- [x] `bundle exec rspec apps/web/auth/spec/config/hooks/omniauth_spec.rb apps/web/auth/spec/unit/omniauth_domain_validation_spec.rb` — 126 examples, 0 failures (both re-derive their own test-local email-parsing helpers, unaffected by the guard swap, confirmed still green)
- [x] `bundle exec rake try:unit` (full unit tryout suite) — 7369 passed, 0 failed
- [x] `bundle exec rake spec:fast` — 322 examples, 0 failures
- [x] `bundle exec rubocop` on changed files — no new offenses