### PR TITLE
fix(auth): set verified on SSO-provisioned customers, reconcile drifted ones

### DIFF
--- a/apps/web/auth/config/hooks/omniauth.rb
+++ b/apps/web/auth/config/hooks/omniauth.rb
@@ -704,6 +704,16 @@ module Auth::Config::Hooks
         signup_domain_id = custom_domain&.identifier
 
         # Create Customer record (same as regular signup)
+        #
+        # verified: true when the Rodauth account is already status=Verified
+        # (status_id == 2) — the IdP asserted the email, so Rodauth creates
+        # the account pre-verified and never fires after_verify_account (the
+        # hook that flips this flag for password signups). Hardcoding false
+        # unconditionally here left every SSO-provisioned customer unable to
+        # exercise any system role, since has_system_role? gates on
+        # verified? before it checks the role field (#3973). 'sso' keeps the
+        # provenance distinguishable from 'email'/'invite_token' — a
+        # federated assertion is a different kind of proof.
         customer = Onetime::ErrorHandler.safe_execute(
           'create_customer_omniauth',
           account_id: account_id,
@@ -715,6 +725,8 @@ module Auth::Config::Hooks
             db: db,
             provisioning_origin: 'sso_jit',
             signup_domain_id: signup_domain_id,
+            verified: account[:status_id] == 2,
+            verified_by: 'sso',
           ).call
         end
 

--- a/apps/web/auth/operations/create_customer.rb
+++ b/apps/web/auth/operations/create_customer.rb
@@ -22,12 +22,26 @@ module Auth
       #   Set on newly-created Customer records. Ignored for existing customers to
       #   preserve original signup context (same "don't rewrite history" rule as
       #   provisioning_origin).
-      def initialize(account_id:, account:, db: nil, provisioning_origin: nil, signup_domain_id: nil)
+      # @param verified [Boolean] Verification state for a newly-created Customer.
+      #   Defaults to false (the password-signup path: verification happens later,
+      #   via after_verify_account). SSO/OmniAuth JIT provisioning passes true here
+      #   when the Rodauth account is already status=Verified (the IdP asserted the
+      #   email) — hardcoding false unconditionally left every SSO-provisioned
+      #   customer unable to exercise any system role (#3973), since
+      #   has_system_role? gates on verified? before it checks the role field.
+      #   Ignored when the customer already exists (we don't rewrite history).
+      # @param verified_by [String, nil] Provenance for `verified`, distinguishing
+      #   a federated IdP assertion ('sso') from email confirmation ('email') or
+      #   an invite token ('invite_token'). Ignored when the customer already exists.
+      def initialize(account_id:, account:, db: nil, provisioning_origin: nil, signup_domain_id: nil,
+                     verified: false, verified_by: nil)
         @account_id          = account_id
         @account             = account
         @db                  = db || Auth::Database.connection
         @provisioning_origin = provisioning_origin
         @signup_domain_id    = signup_domain_id
+        @verified            = verified
+        @verified_by         = verified_by
       end
 
       # Executes the customer creation/loading operation
@@ -62,7 +76,8 @@ module Auth
           customer = Onetime::Customer.create!(
             email: email,
             role: 'customer',
-            verified: false, # needs to be updated in after_verify_account
+            verified: @verified,
+            verified_by: @verified ? @verified_by : nil,
             provisioning_origin: @provisioning_origin,
             signup_domain_id: @signup_domain_id,
           )

--- a/apps/web/auth/operations/sync_session.rb
+++ b/apps/web/auth/operations/sync_session.rb
@@ -207,8 +207,41 @@ module Auth
           end
           retried_customer || raise(OT::Problem, "Customer index sync failed for #{@account[:email]}")
         end
+        reconcile_verification_state(customer)
         link_customer_to_account(customer) unless customer_linked?(customer)
         customer
+      end
+
+      # Reconciles customer.verified with the Rodauth account's own status
+      # when they've drifted apart (#3973).
+      #
+      # Rodauth is the source of truth for verification. A password account
+      # only reaches status=Verified via after_verify_account, which already
+      # flips this flag in lockstep -- so this is a no-op there. An
+      # SSO-provisioned account, though, is created already-verified by
+      # Rodauth (the IdP asserted the email) while
+      # Auth::Operations::CreateCustomer previously hardcoded verified: false
+      # at creation time with no path back to correct it, since this method's
+      # caller (find_existing_customer) only runs create_customer -- the one
+      # branch that DOES set it correctly -- when no customer record exists
+      # yet. Running the check here, on every login via the find branch,
+      # self-heals any customer already stuck in that state without an
+      # operator having to reach for `bin/ots customers verify`.
+      # @param customer [Onetime::Customer]
+      def reconcile_verification_state(customer)
+        return if customer.verified?
+        return unless rodauth_status_verified?
+
+        customer.verified    = true
+        customer.verified_by = 'sso'
+        customer.save_fields(:verified, :verified_by)
+
+        Auth::Logging.log_operation(
+          :customer_verification_reconciled,
+          level: :info,
+          customer_id: customer.custid,
+          correlation_id: @correlation_id,
+        )
       end
 
       # Finds existing customer by external_id or email

--- a/apps/web/auth/spec/operations/sync_session_verification_reconcile_spec.rb
+++ b/apps/web/auth/spec/operations/sync_session_verification_reconcile_spec.rb
@@ -1,0 +1,101 @@
+# apps/web/auth/spec/operations/sync_session_verification_reconcile_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for Auth::Operations::SyncSession#reconcile_verification_state
+# (#3973).
+#
+# An SSO/OmniAuth-provisioned account is created already status=Verified by
+# Rodauth (the IdP asserted the email), but Auth::Operations::CreateCustomer
+# previously hardcoded verified: false unconditionally at creation time, with
+# no path back to correct it: SyncSession only reconciled verification state
+# on the branch where IT creates the customer record, never on the branch
+# where it finds an already-existing one -- which is what happens on every
+# subsequent SSO login, since the customer was already created by the
+# OmniAuth callback on first login. This left an SSO-provisioned customer
+# permanently unable to exercise any system role (has_system_role? gates on
+# verified? before it checks the role field), even after promotion via
+# `bin/ots customers role promote`.
+#
+# These examples drive #reconcile_verification_state directly (same pattern
+# as sync_session_colonel_signin_spec.rb): the surrounding #call needs the
+# auth database, and what needs pinning here is the reconcile decision itself.
+#
+# Run: pnpm run test:rspec apps/web/auth/spec/operations/sync_session_verification_reconcile_spec.rb
+
+require 'spec_helper'
+require 'auth/operations/sync_session'
+
+RSpec.describe Auth::Operations::SyncSession do
+  let(:session) { {} }
+  let(:request) { double('Request', ip: '203.0.113.7', user_agent: 'rspec') }
+  let(:db) { double('Sequel::Database') }
+
+  def build_op(account)
+    described_class.new(
+      account: account,
+      account_id: 42,
+      session: session,
+      request: request,
+      correlation_id: 'corr_1',
+      db: db,
+    )
+  end
+
+  before do
+    allow(Auth::Logging).to receive(:log_operation)
+  end
+
+  context 'when the Rodauth account is verified (status_id == 2) but the customer is not' do
+    let(:op) { build_op({ email: 'sso-user@example.com', status_id: 2 }) }
+
+    it 'sets the customer verified and stamps sso provenance' do
+      customer = double('Customer', custid: 'sso-user@example.com', verified?: false)
+      expect(customer).to receive(:verified=).with(true)
+      expect(customer).to receive(:verified_by=).with('sso')
+      expect(customer).to receive(:save_fields).with(:verified, :verified_by)
+
+      op.send(:reconcile_verification_state, customer)
+    end
+
+    it 'logs the reconciliation' do
+      customer = double('Customer', custid: 'sso-user@example.com', verified?: false)
+      allow(customer).to receive(:verified=)
+      allow(customer).to receive(:verified_by=)
+      allow(customer).to receive(:save_fields)
+
+      op.send(:reconcile_verification_state, customer)
+
+      expect(Auth::Logging).to have_received(:log_operation).with(
+        :customer_verification_reconciled,
+        level: :info,
+        customer_id: 'sso-user@example.com',
+        correlation_id: 'corr_1',
+      )
+    end
+  end
+
+  context 'when the customer is already verified' do
+    let(:op) { build_op({ email: 'user@example.com', status_id: 2 }) }
+
+    it 'does not touch the record (no redundant writes on every login)' do
+      customer = double('Customer', verified?: true)
+      expect(customer).not_to receive(:verified=)
+      expect(customer).not_to receive(:save_fields)
+
+      op.send(:reconcile_verification_state, customer)
+    end
+  end
+
+  context 'when the Rodauth account is not verified (status_id != 2)' do
+    let(:op) { build_op({ email: 'unverified@example.com', status_id: 1 }) }
+
+    it 'does not verify the customer (an unverified password signup stays unverified)' do
+      customer = double('Customer', verified?: false)
+      expect(customer).not_to receive(:verified=)
+      expect(customer).not_to receive(:save_fields)
+
+      op.send(:reconcile_verification_state, customer)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `Auth::Operations::CreateCustomer` hardcoded `verified: false` for every new customer, including SSO/OmniAuth JIT signups. Rodauth creates an SSO account already `status=Verified` (the IdP asserted the email) and never fires `after_verify_account` — the hook that flips this flag for password signups. Since `has_system_role?` gates on `verified?` *before* it checks the role field, an SSO-provisioned account could never exercise any system role, even after `bin/ots customers role promote`.
- `CreateCustomer` now accepts `verified:`/`verified_by:`, defaulting to the prior behavior (`false`/`nil`) so the password-signup path is unchanged. The OmniAuth `after_omniauth_create_account` hook passes `verified: account[:status_id] == 2, verified_by: 'sso'` — mirroring the logic `Auth::Operations::SyncSession#create_customer` already got right.
- `SyncSession` reconciles `verified` on every login now, not just when it has to create the customer itself (previously the only branch that set it correctly) — so an account already stuck unverified from before this fix self-heals on next login instead of requiring the `bin/ots customers verify` workaround. Safe for password accounts: Rodauth only reaches `status=Verified` for those via `after_verify_account`, which already sets this flag in lockstep, so the reconcile is a no-op there.
- `'sso'` is a new distinct `verified_by` provenance value, alongside the existing `'email'`/`'invite_token'`/`'stripe_payment'` — a federated IdP assertion is a different kind of proof than email confirmation.

Closes #3973

## Test plan
- [x] New `apps/web/auth/spec/operations/sync_session_verification_reconcile_spec.rb` (same doubles-based pattern as `sync_session_colonel_signin_spec.rb`) covers: reconciles an unverified customer when Rodauth says verified; is a no-op when already verified (no redundant writes on every login); is a no-op when Rodauth itself is not verified (password path unaffected)
- [x] `bundle exec rake spec:apps:web_auth` — 1090 examples (1086 + 4 new), 0 failures
- [x] `bundle exec rake spec:fast` — 322 examples, 0 failures
- [x] `bundle exec rake try:unit` (full unit tryout suite) — 0 failed
- [x] `bundle exec rubocop` on changed files — no new offenses beyond the same pre-existing classes (`RSpec/VerifiedDoubles`, `RSpec/MultipleExpectations`) already present in the sibling spec this one mirrors