### PR TITLE
fix(security): resolve admin allowlist IP before privacy masking

### DIFF
--- a/lib/onetime/application/middleware_stack.rb
+++ b/lib/onetime/application/middleware_stack.rb
@@ -278,6 +278,28 @@ module Onetime
           # off, so native Rack X-Forwarded-Proto handling is unaffected.
           builder.use Onetime::Middleware::AssumeHttps
 
+          # Built once, shared by both AdminNetworkIsolation (below) and
+          # IPPrivacyMiddleware, so their trusted-proxy resolution can never
+          # drift apart. See ip_privacy_security_config.
+          ip_privacy_config = ip_privacy_security_config
+
+          # Admin network isolation - optional CIDR allowlist for the Colonel
+          # surfaces (/colonel + /api/colonel). No-op unless
+          # site.admin.allowed_cidrs is configured; then a request from
+          # outside the allowlist gets a 404 (indistinguishable-from-absent).
+          #
+          # Mounted BEFORE IPPrivacyMiddleware and given the same security
+          # config so it resolves the REAL client IP itself, rather than the
+          # masked value IPPrivacyMiddleware would otherwise have already
+          # written to REMOTE_ADDR / X-Forwarded-For by the time this ran. An
+          # allowlist entry finer than the masking granularity (a /32 or /128
+          # host entry) would otherwise silently never match against the
+          # masked value, or silently over-match the masked block (#3912).
+          # The real IP is used for the containment check only and never
+          # written to env, so the privacy contract is unaffected.
+          logger.debug 'Setting up Admin Network Isolation middleware'
+          builder.use Onetime::Middleware::AdminNetworkIsolation, ip_privacy_config
+
           # IP Privacy - masks public IPs before logging/monitoring
           # Private/localhost IPs are automatically exempted for development
           # Uses Otto's privacy middleware as a standalone Rack component.
@@ -288,7 +310,6 @@ module Onetime
           # visitor IP from every downstream consumer (ban checks, sessions,
           # identity resolution, the Colonel "current IP" panel). See
           # ip_privacy_security_config.
-          ip_privacy_config = ip_privacy_security_config
           logger.debug 'Setting up IP Privacy middleware',
             {
               note: 'masks public and private IPs',
@@ -313,14 +334,6 @@ module Onetime
           # Health endpoint access control - restrict to localhost/private networks
           logger.debug 'Setting up Health Access Control middleware'
           builder.use Onetime::Middleware::HealthAccessControl
-
-          # Admin network isolation - optional CIDR allowlist for the Colonel
-          # surfaces (/colonel + /api/colonel). No-op unless
-          # site.admin.allowed_cidrs is configured; then a request from outside
-          # the allowlist gets a 404 (indistinguishable-from-absent). Runs after
-          # IP privacy so it can use the trusted-proxy-resolved client IP.
-          logger.debug 'Setting up Admin Network Isolation middleware'
-          builder.use Onetime::Middleware::AdminNetworkIsolation
 
           builder.use Rack::ContentLength
           builder.use Onetime::Middleware::StartupReadiness

--- a/lib/onetime/middleware/admin_network_isolation.rb
+++ b/lib/onetime/middleware/admin_network_isolation.rb
@@ -30,14 +30,24 @@ module Onetime
     #
     # The allowlist check MUST use the trusted-proxy-resolved client IP, never a
     # raw forwarding header, or the allowlist is trivially spoofable by sending
-    # `X-Forwarded-For: <an-allowed-ip>`. We resolve from the canonical
-    # env['otto.client_ip'] set once by the universal IPPrivacyMiddleware mount
-    # (configured from site.network.trusted_proxy via
-    # MiddlewareStack.ip_privacy_security_config), with the same
-    # Otto::Utils.resolve_client_ip fallback the auth strategies use. This is the
-    # identical resolution the rest of the stack relies on, so the network gate
-    # agrees with ban checks, sessions, and audit attribution. When the IP cannot
-    # be resolved and an allowlist is configured, the request is denied (404) —
+    # `X-Forwarded-For: <an-allowed-ip>`. It must ALSO use the real client IP,
+    # never the IP-privacy-MASKED one — an allowlist entry finer than the
+    # privacy masking granularity (IPv4 finer than /24, IPv6 finer than /48)
+    # would otherwise silently never match (a /32 or /128 host entry) or
+    # silently over-match (any entry whose host bits are zero matches the
+    # entire masked block) (#3912).
+    #
+    # So this middleware is mounted BEFORE the universal IPPrivacyMiddleware
+    # (MiddlewareStack.configure) and resolves the client IP itself, via the
+    # same Otto::Utils.resolve_client_ip the auth strategies and
+    # IPPrivacyMiddleware itself use, fed the identical
+    # Otto::Security::Config (MiddlewareStack.ip_privacy_security_config) —
+    # so this gate's trusted-proxy trust decision cannot drift from the rest
+    # of the stack's. The resolved real IP is used for the containment check
+    # ONLY; it is never written to env, so no downstream consumer (logging,
+    # sessions, the privacy fingerprint) ever sees it — the privacy contract
+    # is unaffected by this middleware running first. When the IP cannot be
+    # resolved and an allowlist is configured, the request is denied (404) —
     # fail closed.
     #
     # ## Path matching
@@ -50,8 +60,14 @@ module Onetime
     # which app is handling the request.
     #
     class AdminNetworkIsolation
-      def initialize(app)
+      # @param app [#call] Rack application
+      # @param security_config [Otto::Security::Config, nil] the same config
+      #   handed to IPPrivacyMiddleware (MiddlewareStack.ip_privacy_security_config),
+      #   so this middleware's client-IP resolution and trusted-proxy trust
+      #   decision agree with the rest of the stack's.
+      def initialize(app, security_config = nil)
         @app             = app
+        @security_config = security_config
         @logger          = Onetime.get_logger('AdminNetworkIsolation')
         @allowed_ranges  = parse_allowed_cidrs(configured_cidrs)
 
@@ -109,19 +125,22 @@ module Onetime
       def allowed?(client_ip)
         return false if client_ip.nil? || client_ip.empty?
 
-        addr = IPAddr.new(client_ip)
+        # .native collapses an IPv4-mapped IPv6 address (::ffff:203.0.113.7,
+        # common on dual-stack sockets) to its IPv4 form. Without it,
+        # IPAddr#include? never matches across families, so such a client
+        # would never match an IPv4 CIDR entry even when it should (#3912).
+        addr = IPAddr.new(client_ip).native
         @allowed_ranges.any? { |range| range.include?(addr) }
       rescue IPAddr::InvalidAddressError
         false
       end
 
-      # Resolve the client IP from the trusted-proxy-aware canonical value, with
-      # the same fallback the auth strategies use. Never trusts a raw header.
+      # Resolve the REAL client IP (never the IP-privacy-masked one — this
+      # middleware runs before IPPrivacyMiddleware precisely so it can see the
+      # real value) via the same trusted-proxy-aware resolver and config the
+      # rest of the stack uses. Never trusts a raw header directly.
       def resolve_client_ip(env)
-        canonical = env['otto.client_ip']
-        return canonical if canonical && !canonical.empty?
-
-        Otto::Utils.resolve_client_ip(env, env['otto.security_config'])
+        Otto::Utils.resolve_client_ip(env, @security_config)
       rescue StandardError => ex
         @logger.warn "Client IP resolution failed; denying admin surface: #{ex.message}"
         nil

--- a/try/unit/middleware/admin_network_isolation_try.rb
+++ b/try/unit/middleware/admin_network_isolation_try.rb
@@ -10,15 +10,25 @@
 # 404 (indistinguishable-from-absent, NOT 403). When the allowlist is
 # unset/empty the middleware is a strict no-op (both surfaces reachable).
 #
-# Client IP is resolved from the trusted-proxy-aware env['otto.client_ip'], so a
-# raw X-Forwarded-For header cannot bypass the allowlist.
+# Client IP is resolved via Otto::Utils.resolve_client_ip fed the SAME
+# Otto::Security::Config as IPPrivacyMiddleware -- never a raw header, and
+# never the IP-privacy-masked value (#3912): this middleware is mounted
+# BEFORE IPPrivacyMiddleware precisely so it sees the real client IP before
+# masking would otherwise have already overwritten REMOTE_ADDR /
+# X-Forwarded-For. A /32 (or /128) allowlist entry -- finer than the masking
+# granularity (/24 IPv4, /48 IPv6) -- would otherwise silently never match
+# the masked value, or silently over-match the whole masked block.
 #
 # Test categories:
 #   1. Path matching (colonel_shell? / colonel_api?), full-path reconstruction
 #   2. No-op when allowlist empty
 #   3. Outside allowlist -> 404 on both surfaces
 #   4. Inside allowlist -> pass-through to auth layers
-#   5. Spoofed X-Forwarded-For cannot bypass
+#   5. Spoofed X-Forwarded-For (from an untrusted peer) cannot bypass
+#   6. Masking interaction: a /32 entry matches the real IP even though the
+#      masked value (what env['otto.client_ip'] would hold, downstream of
+#      this middleware) never would (#3912 core repro)
+#   7. IPv4-mapped IPv6 client normalizes to match an IPv4 CIDR entry
 
 require_relative '../../support/test_helpers'
 
@@ -36,22 +46,34 @@ end
 # Mock app that returns 200 OK — stands in for the downstream auth layers.
 @mock_app = ->(_env) { [200, { 'Content-Type' => 'text/plain' }, ['OK']] }
 
+# No trusted proxy declared: Otto::Utils.resolve_client_ip resolves straight
+# from REMOTE_ADDR (the direct-connect default — matches the self-hosted
+# posture most of these examples exercise).
+@direct_config = Otto::Security::Config.new
+
+# A trusted reverse proxy IS declared, for the spoofed-XFF examples: only
+# then does resolve_client_ip walk X-Forwarded-For at all.
+@proxied_config = Otto::Security::Config.new
+@proxied_config.add_trusted_proxy('192.0.2.0/24') # the (fictional) proxy tier
+
 # Set the allowlist in config, then build a middleware instance that reads it.
-def set_allowlist(cidrs)
+def set_allowlist(cidrs, security_config: @direct_config)
   OT.conf['site'] ||= {}
   OT.conf['site']['admin'] ||= {}
   OT.conf['site']['admin']['allowed_cidrs'] = cidrs
-  TestAdminNetworkIsolation.new(@mock_app)
+  TestAdminNetworkIsolation.new(@mock_app, security_config)
 end
 
-# Build a Rack env for a full path, injecting the resolved (otto) client IP.
-# script_name simulates Rack::URLMap mounting (colonel API is mounted at
-# /api/colonel, so PATH_INFO is stripped to e.g. /info).
-def admin_env(script_name:, path_info:, client_ip:, xff: nil)
+# Build a Rack env for a full path. remote_addr is the direct TCP peer
+# (REMOTE_ADDR); xff simulates a proxy-forwarded chain. script_name simulates
+# Rack::URLMap mounting (colonel API is mounted at /api/colonel, so
+# PATH_INFO is stripped to e.g. /info).
+def admin_env(script_name:, path_info:, remote_addr:, xff: nil)
   env = Rack::MockRequest.env_for("http://example.com#{script_name}#{path_info}")
   env['SCRIPT_NAME'] = script_name
   env['PATH_INFO'] = path_info
-  env['otto.client_ip'] = client_ip if client_ip
+  env['REMOTE_ADDR'] = remote_addr if remote_addr
+  env.delete('REMOTE_ADDR') if remote_addr.nil?
   env['HTTP_X_FORWARDED_FOR'] = xff if xff
   env
 end
@@ -122,26 +144,31 @@ end
 @mw.allowed?('not_an_ip')
 #=> false
 
+## allowed? - IPv4-mapped IPv6 client normalizes to match an IPv4 CIDR entry (#3912)
+## (::ffff:10.1.2.3 is the dual-stack-socket form of 10.1.2.3)
+@mw.allowed?('::ffff:10.1.2.3')
+#=> true
+
 # =================================================================
 # No-op when allowlist is empty/unset (self-hosted default)
 # =================================================================
 
 ## empty allowlist - /colonel from a public IP passes through (200)
 @noop = set_allowlist([])
-@env = admin_env(script_name: '', path_info: '/colonel', client_ip: '203.0.113.9')
+@env = admin_env(script_name: '', path_info: '/colonel', remote_addr: '203.0.113.9')
 @status, _, _ = @noop.call(@env)
 @status
 #=> 200
 
 ## empty allowlist - /api/colonel from a public IP passes through (200)
-@env = admin_env(script_name: '/api/colonel', path_info: '/info', client_ip: '203.0.113.9')
+@env = admin_env(script_name: '/api/colonel', path_info: '/info', remote_addr: '203.0.113.9')
 @status, _, _ = @noop.call(@env)
 @status
 #=> 200
 
 ## nil allowlist - also a no-op
 @nilmw = set_allowlist(nil)
-@env = admin_env(script_name: '', path_info: '/colonel', client_ip: '203.0.113.9')
+@env = admin_env(script_name: '', path_info: '/colonel', remote_addr: '203.0.113.9')
 @status, _, _ = @nilmw.call(@env)
 @status
 #=> 200
@@ -152,39 +179,38 @@ end
 
 ## outside allowlist - /colonel shell returns 404 (not 403)
 @iso = set_allowlist(['10.0.0.0/8', '100.64.0.0/10'])
-@env = admin_env(script_name: '', path_info: '/colonel', client_ip: '203.0.113.9')
+@env = admin_env(script_name: '', path_info: '/colonel', remote_addr: '203.0.113.9')
 @status, @headers, @body = @iso.call(@env)
 @status
 #=> 404
 
 ## outside allowlist - /colonel shell returns HTML content type
-@env = admin_env(script_name: '', path_info: '/colonel', client_ip: '203.0.113.9')
+@env = admin_env(script_name: '', path_info: '/colonel', remote_addr: '203.0.113.9')
 @status, @headers, @body = @iso.call(@env)
 @headers['Content-Type']
 #=> 'text/html; charset=utf-8'
 
 ## outside allowlist - /colonel/customers subpath returns 404
-@env = admin_env(script_name: '', path_info: '/colonel/customers', client_ip: '8.8.8.8')
+@env = admin_env(script_name: '', path_info: '/colonel/customers', remote_addr: '8.8.8.8')
 @status, _, _ = @iso.call(@env)
 @status
 #=> 404
 
 ## outside allowlist - /api/colonel returns 404
-@env = admin_env(script_name: '/api/colonel', path_info: '/info', client_ip: '203.0.113.9')
+@env = admin_env(script_name: '/api/colonel', path_info: '/info', remote_addr: '203.0.113.9')
 @status, @headers, @body = @iso.call(@env)
 @status
 #=> 404
 
 ## outside allowlist - /api/colonel returns JSON content type + error body
-@env = admin_env(script_name: '/api/colonel', path_info: '/info', client_ip: '203.0.113.9')
+@env = admin_env(script_name: '/api/colonel', path_info: '/info', remote_addr: '203.0.113.9')
 @status, @headers, @body = @iso.call(@env)
 [@headers['Content-Type'], JSON.parse(@body.first)['error']]
 #=> ['application/json', 'Not Found']
 
 ## outside allowlist - unresolvable client IP fails closed (404)
-@env = admin_env(script_name: '', path_info: '/colonel', client_ip: nil)
+@env = admin_env(script_name: '', path_info: '/colonel', remote_addr: nil)
 @env.delete('HTTP_X_FORWARDED_FOR')
-@env.delete('REMOTE_ADDR')
 @status, _, _ = @iso.call(@env)
 @status
 #=> 404
@@ -194,19 +220,19 @@ end
 # =================================================================
 
 ## inside allowlist - /colonel from 10.0.0.5 passes through (200)
-@env = admin_env(script_name: '', path_info: '/colonel', client_ip: '10.0.0.5')
+@env = admin_env(script_name: '', path_info: '/colonel', remote_addr: '10.0.0.5')
 @status, _, _ = @iso.call(@env)
 @status
 #=> 200
 
 ## inside allowlist - /api/colonel from Tailscale CGNAT passes through (200)
-@env = admin_env(script_name: '/api/colonel', path_info: '/info', client_ip: '100.64.7.7')
+@env = admin_env(script_name: '/api/colonel', path_info: '/info', remote_addr: '100.64.7.7')
 @status, _, _ = @iso.call(@env)
 @status
 #=> 200
 
 ## configured - non-admin path passes through regardless of IP
-@env = admin_env(script_name: '', path_info: '/dashboard', client_ip: '203.0.113.9')
+@env = admin_env(script_name: '', path_info: '/dashboard', remote_addr: '203.0.113.9')
 @status, _, _ = @iso.call(@env)
 @status
 #=> 200
@@ -214,31 +240,91 @@ end
 # =================================================================
 # Spoofed X-Forwarded-For cannot bypass the allowlist
 # =================================================================
-# The middleware resolves from the trusted-proxy-aware env['otto.client_ip'],
-# never the raw header. An outside client that spoofs XFF to an allowed IP is
-# still denied; the resolved IP is authoritative.
+# resolve_client_ip only honors X-Forwarded-For from a TRUSTED proxy peer
+# (REMOTE_ADDR). An untrusted direct peer's forged XFF is ignored entirely —
+# REMOTE_ADDR itself is authoritative.
 
-## spoofed XFF - outside client with allowed-IP XFF is still denied (404)
+## spoofed XFF from an untrusted direct peer - REMOTE_ADDR is authoritative, still denied (404)
+@iso_direct = set_allowlist(['10.0.0.0/8', '100.64.0.0/10']) # @direct_config: no trusted proxy
 @env = admin_env(
   script_name: '/api/colonel',
   path_info: '/info',
-  client_ip: '203.0.113.9',    # trusted-proxy-resolved (real) client
-  xff: '10.0.0.5',             # attacker-supplied header claiming an allowed IP
+  remote_addr: '203.0.113.9', # untrusted direct peer, outside the allowlist
+  xff: '10.0.0.5',            # attacker-supplied header claiming an allowed IP
 )
-@status, _, _ = @iso.call(@env)
+@status, _, _ = @iso_direct.call(@env)
 @status
 #=> 404
 
-## resolved IP is authoritative - inside client is allowed even with a public XFF
+# =================================================================
+# Trusted-proxy chain - resolves the real client past a trusted hop
+# =================================================================
+
+## behind the trusted proxy - the forwarded (real) client IP is used, and allowed
+@iso_proxied = set_allowlist(['203.0.113.0/24'], security_config: @proxied_config)
 @env = admin_env(
   script_name: '',
   path_info: '/colonel',
-  client_ip: '10.0.0.5',       # trusted-proxy-resolved (real) client, allowed
-  xff: '203.0.113.9',          # noise header
+  remote_addr: '192.0.2.10', # the trusted proxy hop
+  xff: '203.0.113.7',        # real client, inside the allowlist
 )
-@status, _, _ = @iso.call(@env)
+@status, _, _ = @iso_proxied.call(@env)
 @status
 #=> 200
+
+## behind the trusted proxy - the forwarded (real) client IP is used, and denied
+@iso_proxied = set_allowlist(['203.0.113.0/24'], security_config: @proxied_config)
+@env = admin_env(
+  script_name: '',
+  path_info: '/colonel',
+  remote_addr: '192.0.2.10', # the trusted proxy hop
+  xff: '8.8.8.8',            # real client, outside the allowlist
+)
+@status, _, _ = @iso_proxied.call(@env)
+@status
+#=> 404
+
+# =================================================================
+# Masking interaction (#3912 core repro)
+# =================================================================
+#
+# The bug: AdminNetworkIsolation used to read env['otto.client_ip'], which
+# IPPrivacyMiddleware (mounted earlier, before the fix) had already masked to
+# a /24 (IPv4) or /48 (IPv6) boundary. A /32 allowlist entry for the exact
+# admin host then NEVER matched -- only the coarser masked block did. Fixed
+# by mounting this middleware BEFORE IPPrivacyMiddleware and resolving the
+# real IP itself, so it never observes the masked value at all. These
+# examples pin that: build BOTH middlewares in the real stack order (this one
+# first) and confirm the real IP is what the containment check sees, distinct
+# from what IPPrivacyMiddleware would go on to mask it to downstream.
+
+## a /32 entry for the exact real IP passes (this middleware never sees the masked value)
+@masking_config = Otto::Security::Config.new
+@masking_config.ip_privacy_config.mask_private_ips = true
+OT.conf['site']['admin']['allowed_cidrs'] = ['203.0.113.7/32']
+@exact_host_iso = TestAdminNetworkIsolation.new(@mock_app, @masking_config)
+@env = admin_env(script_name: '', path_info: '/colonel', remote_addr: '203.0.113.7')
+@status, _, _ = @exact_host_iso.call(@env)
+@status
+#=> 200
+
+## the same request denied for a neighbor on the same /24 (no over-match via a masked .0)
+@env = admin_env(script_name: '', path_info: '/colonel', remote_addr: '203.0.113.9')
+@status, _, _ = @exact_host_iso.call(@env)
+@status
+#=> 404
+
+## confirms the repro premise: masking 203.0.113.7 to its /24 network boundary
+## produces .0 -- the value the OLD (buggy) code compared the /32 entry
+## against, via env['otto.client_ip'] once IPPrivacyMiddleware had masked it
+IPAddr.new('203.0.113.7/24').to_range.first.to_s
+#=> '203.0.113.0'
+
+## ...and a /32 can never be persuaded it contains that masked /24 network
+## address -- which is exactly why the OLD code kept denying the legitimate
+## exact-host operator even though their real IP matched the entry
+IPAddr.new('203.0.113.7/32').include?(IPAddr.new('203.0.113.0'))
+#=> false
 
 # Restore config to a clean empty allowlist so later tryouts see a no-op posture.
 OT.conf['site']['admin']['allowed_cidrs'] = []


### PR DESCRIPTION
## Summary
- `AdminNetworkIsolation` (the `site.admin.allowed_cidrs` gate for `/colonel` + `/api/colonel`) compared the allowlist against `env['otto.client_ip']` — but `IPPrivacyMiddleware`, mounted earlier in the universal stack, had already masked that value to a `/24` (IPv4) or `/48` (IPv6) boundary before this middleware ever saw it. Verified: `IPAddr.new("203.0.113.7/32").include?(IPAddr.new("203.0.113.0"))` is `false` — a `/32` (or `/128`) allowlist entry for an operator's exact admin host could never match the masked value, silently locking them out with the intentional indistinguishable-from-absent 404. Conversely, an entry whose host bits are zero (`203.0.113.0/32`) matched **every** client in that masked `/24`, silently widening the network gate (defense-in-depth erosion, not a bypass — the two app-layer auth checks still enforce beneath it).
- Fix mirrors the issue's own proposed direction: mount `AdminNetworkIsolation` **before** `IPPrivacyMiddleware`, sharing the same `Otto::Security::Config` (`ip_privacy_security_config`), and have it resolve the client IP itself via `Otto::Utils.resolve_client_ip` for the containment check only — the real IP is never written to `env`, so nothing downstream (logging, sessions, the privacy fingerprint) ever observes it. The privacy contract is unaffected; this middleware just gets to look at the real value before it's overwritten.
- Also normalizes with `IPAddr#native` in `allowed?` so an IPv4-mapped IPv6 client (`::ffff:203.0.113.7`, common on dual-stack sockets) matches an IPv4 CIDR entry — previously `IPAddr#include?` never matches across families.

Closes #3912

## Test plan
- [x] Rewrote `try/unit/middleware/admin_network_isolation_try.rb` to stop stubbing `env['otto.client_ip']` directly (the issue calls out this exact gap: "the masking interaction is never exercised") — now drives `REMOTE_ADDR`/`X-Forwarded-For` through the real `Otto::Utils.resolve_client_ip` with real `Otto::Security::Config` objects (direct-connect, trusted-proxy chain, and masking-enabled configs)
- [x] New coverage matches the acceptance criteria: a `/32` entry admits the exact real IP under masking; a neighbor on the same masked `/24` is still denied (no over-match); an IPv4-mapped IPv6 client passes an IPv4 `/32` entry; a spoofed `X-Forwarded-For` from an untrusted direct peer cannot bypass; a real trusted-proxy chain resolves and gates on the forwarded client correctly in both directions
- [x] `bundle exec try try/unit/middleware/admin_network_isolation_try.rb` — 34 passed
- [x] `bundle exec rake try:unit` (full unit tryout suite) — 7366 passed, 0 failed
- [x] `bundle exec rake spec:fast` — 322 examples, 0 failures
- [x] `bundle exec rubocop` on the two production files — no offenses (the tryout file's offenses are the same pre-existing classes the original file already had, from the tryouts `#=>` assertion idiom rubocop doesn't understand)
- [x] Full app boot (`Onetime.boot! :app`) succeeds with the reordered middleware stack