### PR TITLE
Suppress session creation for anonymous one-off endpoints

### DIFF
--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -387,6 +387,24 @@ site:
     same_site: lax
     # Prevent JavaScript access to cookies (always true in Rack)
     httponly: true
+    # Paths that must NOT mint or persist a session (#3997).
+    # Anonymous probe endpoints polled by load balancers, uptime monitors and
+    # orchestrators — none keep cookies, so every poll used to write a
+    # session:<hex> key with the full expire_after TTL.
+    #
+    # Matching is EXACT string equality against the full external path
+    # (SCRIPT_NAME + PATH_INFO), so these are written as the client sees them
+    # even though the middleware runs per-mount inside Rack::URLMap.
+    #
+    # WARNING: never list /api/v*/secret/*/status here. Those are
+    # capability-token data reads audited via SecretActivity, not probes.
+    skip_paths:
+      - /health
+      - /health/advanced
+      - /auth/health
+      - /api/v1/status
+      - /api/v2/status
+      - /api/v3/status
   # Middleware Configuration
   # Controls which security and performance middleware components are enabled.
   # Each setting can be overridden via environment variables.

--- a/lib/onetime/application/middleware_stack.rb
+++ b/lib/onetime/application/middleware_stack.rb
@@ -17,6 +17,7 @@ require_relative '../middleware/csrf_response_header'
 require_relative '../middleware/normalize_content_type'
 require_relative '../middleware/retry_after_header'
 require_relative '../middleware/entitlement_preview_context'
+require_relative '../middleware/session_skip'
 require 'otto'
 
 module Onetime
@@ -349,6 +350,13 @@ module Onetime
               secure: session_config['secure'],
               same_site: session_config['same_site'].to_sym,
             }
+
+          # Suppress session persistence for anonymous probe endpoints (#3997).
+          # Must come after Onetime::Session so env['rack.session.options']
+          # already exists to be mutated. Exact, mount-aware path matching —
+          # see Onetime::Middleware::SessionSkip.
+          builder.use Onetime::Middleware::SessionSkip,
+            skip_paths: session_config['skip_paths']
 
           # Identity resolution middleware (after session)
           builder.use Onetime::Middleware::IdentityResolution

--- a/lib/onetime/boot.rb
+++ b/lib/onetime/boot.rb
@@ -77,9 +77,13 @@ module Onetime
 
     # Session configuration defaults
     # Ensures middleware always has valid values even if site.session is not configured
-    # NOTE: `merge` below is shallow, so an operator who defines site.session in
-    # their own yaml replaces each key they name. skip_paths must be listed here
-    # or such a config would hand SessionSkip a nil list (#3997).
+    # NOTE: when the config loads from the default path, config.defaults.yaml is
+    # deep-merged UNDER the operator's yaml (Config#load), so skip_paths
+    # normally resolves from the defaults file even when the operator sets
+    # other site.session keys. This copy is the fallback for explicit-path
+    # config loads and a missing defaults file. Either way, an operator-defined
+    # skip_paths REPLACES the shipped list wholesale — which is why boot! logs
+    # the resolved list (#3997).
     SESSION_DEFAULTS = {
       'expire_after' => 86_400,      # 24 hours
       'key' => 'onetime.session',
@@ -223,6 +227,12 @@ module Onetime
       end
 
       started!
+
+      # skip_paths is operator-overridable and an override REPLACES the shipped
+      # list wholesale, with no error for an empty or malformed result. Surface
+      # the resolved list so a config that silently re-enables per-probe
+      # session minting (#3997) is visible at boot.
+      OT.boot_logger.info "Session skip_paths: #{session_config['skip_paths'].inspect}"
 
       # Log completion with timing
       boot_elapsed_ms = ((Onetime.now_in_μs - boot_start) / 1000.0).round

--- a/lib/onetime/boot.rb
+++ b/lib/onetime/boot.rb
@@ -77,11 +77,24 @@ module Onetime
 
     # Session configuration defaults
     # Ensures middleware always has valid values even if site.session is not configured
+    # NOTE: `merge` below is shallow, so an operator who defines site.session in
+    # their own yaml replaces each key they name. skip_paths must be listed here
+    # or such a config would hand SessionSkip a nil list (#3997).
     SESSION_DEFAULTS = {
       'expire_after' => 86_400,      # 24 hours
       'key' => 'onetime.session',
       'same_site' => 'lax',
       'httponly' => true,
+      # Anonymous probe endpoints that must not mint a persisted session.
+      # Exact-match, full external paths. See config.defaults.yaml.
+      'skip_paths' => [
+        '/health',
+        '/health/advanced',
+        '/auth/health',
+        '/api/v1/status',
+        '/api/v2/status',
+        '/api/v3/status',
+      ].freeze,
     }.freeze
 
     attr_reader :conf, :instance, :boot_registry, :boot_error

--- a/lib/onetime/middleware/csrf_response_header.rb
+++ b/lib/onetime/middleware/csrf_response_header.rb
@@ -2,8 +2,9 @@
 #
 # frozen_string_literal: true
 
+require 'rack/constants'
+
 require_relative 'instrumented_authenticity_token'
-require_relative 'session_skip'
 
 module Onetime
   module Middleware
@@ -97,12 +98,15 @@ module Onetime
       # True when Onetime::Middleware::SessionSkip marked this request's session
       # as non-persisting (#3997). AuthenticityToken.token does
       # `session[:csrf] ||= random`, which both loads AND dirties the session —
-      # the decisive reason anonymous probe endpoints (/health, /api/v*/status)
-      # minted a Valkey session key per request. The :skip flag already
-      # suppresses the write, so minting here would only hand the client a token
-      # that no session will ever validate against. Read-only: never sets :skip.
+      # but this middleware is not the only dirtier, nor the first:
+      # InstrumentedAuthenticityToken's inherited `accepts?` runs the same
+      # `session[:csrf] ||= …` on every request before its safe-method check.
+      # It is rack-session's :skip flag that suppresses the Valkey write, not
+      # this gate; skipping the mint here only avoids handing the client a
+      # token that no persisted session will ever validate against (and the
+      # session load that minting would force). Read-only: never sets :skip.
       def session_skipped?(env)
-        options = env[Onetime::Middleware::SessionSkip::SESSION_OPTIONS_KEY]
+        options = env[Rack::RACK_SESSION_OPTIONS]
         options.respond_to?(:[]) && options[:skip] == true
       end
 

--- a/lib/onetime/middleware/csrf_response_header.rb
+++ b/lib/onetime/middleware/csrf_response_header.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative 'instrumented_authenticity_token'
+require_relative 'session_skip'
 
 module Onetime
   module Middleware
@@ -71,7 +72,7 @@ module Onetime
         status, headers, body = @app.call(env)
 
         session = env['rack.session']
-        if session
+        if session && !session_skipped?(env)
           csrf_token              = Rack::Protection::AuthenticityToken.token(session)
           headers['X-CSRF-Token'] = csrf_token if csrf_token
         end
@@ -91,6 +92,18 @@ module Onetime
       # marker without denying.
       def csrf_rejection?(env)
         env[CSRF_REJECTION_KEY] == true
+      end
+
+      # True when Onetime::Middleware::SessionSkip marked this request's session
+      # as non-persisting (#3997). AuthenticityToken.token does
+      # `session[:csrf] ||= random`, which both loads AND dirties the session —
+      # the decisive reason anonymous probe endpoints (/health, /api/v*/status)
+      # minted a Valkey session key per request. The :skip flag already
+      # suppresses the write, so minting here would only hand the client a token
+      # that no session will ever validate against. Read-only: never sets :skip.
+      def session_skipped?(env)
+        options = env[Onetime::Middleware::SessionSkip::SESSION_OPTIONS_KEY]
+        options.respond_to?(:[]) && options[:skip] == true
       end
 
       # True when the session already carries a non-empty raw CSRF token.

--- a/lib/onetime/middleware/health_access_control.rb
+++ b/lib/onetime/middleware/health_access_control.rb
@@ -9,7 +9,13 @@ module Onetime
     # Health check endpoints expose internal system status and should only be
     # accessible from trusted networks (localhost, private IP ranges).
     #
-    # Paths covered: /health, /health/*, /auth/health
+    # Paths covered (MOUNT-RELATIVE): /health and /health/*
+    #
+    # This middleware runs inside Rack::URLMap, once per mounted app, so
+    # PATH_INFO here has the mount prefix stripped. The auth app's health check
+    # is externally /auth/health but arrives as SCRIPT_NAME='/auth' +
+    # PATH_INFO='/health' — it is covered by the /health branch, not by any
+    # '/auth/health' literal. The same holds for any future mount.
     #
     # Uses Otto::Privacy::IPPrivacy.private_or_localhost? which covers:
     # - RFC 1918 (10/8, 172.16/12, 192.168/16)
@@ -77,10 +83,13 @@ module Onetime
         end
       end
 
+      # `path` is PATH_INFO, i.e. mount-relative (the URLMap prefix lives in
+      # SCRIPT_NAME). So '/health' covers every app's health endpoint whatever
+      # it is mounted under, including the auth app's external /auth/health.
+      # A literal '/auth/health' branch would be dead code here: no app is
+      # mounted such that PATH_INFO takes that value.
       def health_endpoint?(path)
-        path == '/health' ||
-          path.start_with?('/health/') ||
-          path == '/auth/health'
+        path == '/health' || path.start_with?('/health/')
       end
 
       def forbidden_response

--- a/lib/onetime/middleware/health_access_control.rb
+++ b/lib/onetime/middleware/health_access_control.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require 'otto/utils'
+
 module Onetime
   module Middleware
     # HealthAccessControl - Restricts health endpoints to localhost/private networks
@@ -12,10 +14,17 @@ module Onetime
     # Paths covered (MOUNT-RELATIVE): /health and /health/*
     #
     # This middleware runs inside Rack::URLMap, once per mounted app, so
-    # PATH_INFO here has the mount prefix stripped. The auth app's health check
-    # is externally /auth/health but arrives as SCRIPT_NAME='/auth' +
-    # PATH_INFO='/health' — it is covered by the /health branch, not by any
-    # '/auth/health' literal. The same holds for any future mount.
+    # PATH_INFO here has the mount prefix stripped. In full auth mode the auth
+    # app's health check is externally /auth/health but arrives as
+    # SCRIPT_NAME='/auth' + PATH_INFO='/health' — covered by the /health
+    # branch, not by any '/auth/health' literal. In simple/disabled modes the
+    # auth app is unmounted, so /auth/health falls through to the core app
+    # (PATH_INFO='/auth/health') where no route serves it: it passes this
+    # middleware unmatched and 404s at the router, disclosing nothing.
+    #
+    # Matching is on the NORMALIZED path (Otto::Utils.normalize_path), the
+    # same canonicalization the Otto router applies before dispatch — see
+    # health_endpoint?.
     #
     # Uses Otto::Privacy::IPPrivacy.private_or_localhost? which covers:
     # - RFC 1918 (10/8, 172.16/12, 192.168/16)
@@ -85,11 +94,19 @@ module Onetime
 
       # `path` is PATH_INFO, i.e. mount-relative (the URLMap prefix lives in
       # SCRIPT_NAME). So '/health' covers every app's health endpoint whatever
-      # it is mounted under, including the auth app's external /auth/health.
-      # A literal '/auth/health' branch would be dead code here: no app is
-      # mounted such that PATH_INFO takes that value.
+      # it is mounted under, including the auth app's external /auth/health in
+      # full mode. No mounted app ROUTES a PATH_INFO of '/auth/health' (in
+      # non-full modes the request reaches core unmatched and 404s at the
+      # router), so a literal '/auth/health' branch would only gate a 404.
+      #
+      # Normalize before matching, with the same canonicalization the Otto
+      # router applies before dispatch: the router serves `/health/` and
+      # percent-encoded spellings like `/health%2Fadvanced` as health routes,
+      # so gating the raw string would let those aliases through to the
+      # handler ungated.
       def health_endpoint?(path)
-        path == '/health' || path.start_with?('/health/')
+        normalized = Otto::Utils.normalize_path(path)
+        normalized == '/health' || normalized.start_with?('/health/')
       end
 
       def forbidden_response

--- a/lib/onetime/middleware/session_skip.rb
+++ b/lib/onetime/middleware/session_skip.rb
@@ -1,0 +1,91 @@
+# lib/onetime/middleware/session_skip.rb
+#
+# frozen_string_literal: true
+
+module Onetime
+  module Middleware
+    ##
+    # SessionSkip
+    #
+    # Suppresses session persistence for anonymous, unauthenticated probe
+    # endpoints (#3997).
+    #
+    # {Onetime::Session} is a `Rack::Session::Abstract::PersistedSecure`
+    # subclass, so every request that merely *loads* the session commits it —
+    # writing a `session:<64-hex>` key to Valkey with the full 24h TTL and
+    # returning a `Set-Cookie`. Health and status probes are polled constantly
+    # by load balancers, uptime monitors and orchestrators, none of which keep
+    # cookies, so each poll minted a fresh session that no one would ever use:
+    # unbounded key growth for zero benefit.
+    #
+    # Setting `options[:skip]` is rack-session's own lever for this.
+    # `commit_session?` (rack-session 2.1.2, abstract/id.rb:350) short-circuits
+    # on it BEFORE any dirty check, so both the datastore write and the
+    # `Set-Cookie` are suppressed regardless of what downstream middleware or
+    # the app did to the session. That matters because the decisive dirtier is
+    # not the app at all: {Onetime::Middleware::CsrfResponseHeader} calls
+    # `AuthenticityToken.token(session)` (which does `session[:csrf] ||= …`) on
+    # every response.
+    #
+    # ## Mounting
+    #
+    # Must be mounted AFTER {Onetime::Session}: `prepare_session` installs
+    # `env['rack.session.options']` before calling the downstream app, so
+    # anything below the session middleware can mutate that hash and the
+    # session middleware will read the mutation on the way back out. Same
+    # mechanism `apps/web/core/controllers/authentication.rb` uses to request
+    # `[:renew]`.
+    #
+    # ## Path matching: exact, and mount-relative aware
+    #
+    # The universal middleware stack runs INSIDE `Rack::URLMap`, i.e. once per
+    # mounted app, so `PATH_INFO` here is mount-relative: the v2 status route
+    # arrives as `SCRIPT_NAME='/api/v2'` + `PATH_INFO='/status'`, while core
+    # routes arrive as `SCRIPT_NAME=''` + `PATH_INFO='/health'`. Rejoining the
+    # two is what lets a single flat list of external paths be configured.
+    #
+    # Matching is exact string equality — never prefix, substring or regex.
+    # `/api/v*/secret/:identifier/status` is a capability-token data read
+    # audited via SecretActivity; a prefix or substring match would sweep those
+    # in and silently stop persisting sessions for real API traffic.
+    #
+    class SessionSkip
+      # Rack env key holding the per-request session options hash that
+      # rack-session's `commit_session?` consults.
+      SESSION_OPTIONS_KEY = 'rack.session.options'
+
+      # @param app [#call] downstream Rack app
+      # @param skip_paths [Array<String>] full external paths (SCRIPT_NAME +
+      #   PATH_INFO) for which session persistence is suppressed
+      def initialize(app, skip_paths: [])
+        @app        = app
+        # Frozen at boot: the list is read on every request and never varies
+        # per-request. nil-tolerant so a config gap degrades to "skip nothing"
+        # (the pre-#3997 behaviour) rather than raising at boot.
+        @skip_paths = Array(skip_paths).map { |path| path.to_s.freeze }.freeze
+      end
+
+      def call(env)
+        if skip?(env)
+          # Absent only if this middleware is mounted without a session
+          # middleware above it. Nothing to suppress in that case.
+          options        = env[SESSION_OPTIONS_KEY]
+          options[:skip] = true if options
+        end
+
+        @app.call(env)
+      end
+
+      private
+
+      # Full external path, reassembled from the URLMap mount prefix and the
+      # mount-relative remainder. Compared with `==` only — see the class doc.
+      def skip?(env)
+        return false if @skip_paths.empty?
+
+        path = "#{env['SCRIPT_NAME']}#{env['PATH_INFO']}"
+        @skip_paths.include?(path)
+      end
+    end
+  end
+end

--- a/lib/onetime/middleware/session_skip.rb
+++ b/lib/onetime/middleware/session_skip.rb
@@ -2,6 +2,9 @@
 #
 # frozen_string_literal: true
 
+require 'rack/constants'
+require 'otto/utils'
+
 module Onetime
   module Middleware
     ##
@@ -21,11 +24,21 @@ module Onetime
     # Setting `options[:skip]` is rack-session's own lever for this.
     # `commit_session?` (rack-session 2.1.2, abstract/id.rb:350) short-circuits
     # on it BEFORE any dirty check, so both the datastore write and the
-    # `Set-Cookie` are suppressed regardless of what downstream middleware or
-    # the app did to the session. That matters because the decisive dirtier is
-    # not the app at all: {Onetime::Middleware::CsrfResponseHeader} calls
-    # `AuthenticityToken.token(session)` (which does `session[:csrf] ||= …`) on
-    # every response.
+    # `Set-Cookie` are suppressed no matter which layer dirtied the session —
+    # and several do, before the app is ever involved:
+    # `Rack::Protection::AuthenticityToken#accepts?` runs
+    # `session[:csrf] ||= …` on every request ahead of its safe-method check,
+    # and {Onetime::Middleware::CsrfResponseHeader} mints the same key when
+    # exposing the masked token. Only :skip stops the write; suppressing any
+    # one dirtier would not.
+    #
+    # Caveat: `commit_session` consults `options[:drop]`/`options[:renew]`
+    # BEFORE :skip (abstract/id.rb:381) and deletes the stored session for
+    # them. A path that is both in skip_paths and reaches a drop/renew call
+    # site (logout in authentication.rb, password rotation in account.rb)
+    # would delete the live session and skip writing its replacement — a
+    # silent logout. None of the shipped probe paths route anywhere near
+    # those call sites; keep it that way when editing the list.
     #
     # ## Mounting
     #
@@ -36,7 +49,7 @@ module Onetime
     # mechanism `apps/web/core/controllers/authentication.rb` uses to request
     # `[:renew]`.
     #
-    # ## Path matching: exact, and mount-relative aware
+    # ## Path matching: normalized, exact, and mount-relative aware
     #
     # The universal middleware stack runs INSIDE `Rack::URLMap`, i.e. once per
     # mounted app, so `PATH_INFO` here is mount-relative: the v2 status route
@@ -44,16 +57,20 @@ module Onetime
     # routes arrive as `SCRIPT_NAME=''` + `PATH_INFO='/health'`. Rejoining the
     # two is what lets a single flat list of external paths be configured.
     #
-    # Matching is exact string equality — never prefix, substring or regex.
-    # `/api/v*/secret/:identifier/status` is a capability-token data read
-    # audited via SecretActivity; a prefix or substring match would sweep those
-    # in and silently stop persisting sessions for real API traffic.
+    # The joined path is canonicalized with `Otto::Utils.normalize_path` — the
+    # same normalization the Otto router applies before dispatch. The router
+    # serves `/api/v2/status/` and percent-encoded spellings like
+    # `/api/v2/%73tatus` as the status route, so matching the raw string would
+    # let those aliases reach the handler while dodging the skip — reopening
+    # the per-probe session mint for any client that appends a slash.
+    #
+    # After normalization, matching is exact string equality — never prefix,
+    # substring or regex. `/api/v*/secret/:identifier/status` is a
+    # capability-token data read audited via SecretActivity; a prefix or
+    # substring match would sweep those in and silently stop persisting
+    # sessions for real API traffic.
     #
     class SessionSkip
-      # Rack env key holding the per-request session options hash that
-      # rack-session's `commit_session?` consults.
-      SESSION_OPTIONS_KEY = 'rack.session.options'
-
       # @param app [#call] downstream Rack app
       # @param skip_paths [Array<String>] full external paths (SCRIPT_NAME +
       #   PATH_INFO) for which session persistence is suppressed
@@ -61,15 +78,17 @@ module Onetime
         @app        = app
         # Frozen at boot: the list is read on every request and never varies
         # per-request. nil-tolerant so a config gap degrades to "skip nothing"
-        # (the pre-#3997 behaviour) rather than raising at boot.
-        @skip_paths = Array(skip_paths).map { |path| path.to_s.freeze }.freeze
+        # (the pre-#3997 behaviour) rather than raising at boot. Entries are
+        # normalized the same way skip? normalizes the request path, so a
+        # configured `/health/` still matches.
+        @skip_paths = Array(skip_paths).map { |path| Otto::Utils.normalize_path(path.to_s).freeze }.freeze
       end
 
       def call(env)
         if skip?(env)
           # Absent only if this middleware is mounted without a session
           # middleware above it. Nothing to suppress in that case.
-          options        = env[SESSION_OPTIONS_KEY]
+          options        = env[Rack::RACK_SESSION_OPTIONS]
           options[:skip] = true if options
         end
 
@@ -78,12 +97,13 @@ module Onetime
 
       private
 
-      # Full external path, reassembled from the URLMap mount prefix and the
-      # mount-relative remainder. Compared with `==` only — see the class doc.
+      # Full external path — the URLMap mount prefix plus the mount-relative
+      # remainder — canonicalized the way the Otto router canonicalizes before
+      # dispatch. Compared with `==` only — see the class doc.
       def skip?(env)
         return false if @skip_paths.empty?
 
-        path = "#{env['SCRIPT_NAME']}#{env['PATH_INFO']}"
+        path = Otto::Utils.normalize_path("#{env['SCRIPT_NAME']}#{env['PATH_INFO']}")
         @skip_paths.include?(path)
       end
     end

--- a/spec/integration/all/session_skip_probe_endpoints_spec.rb
+++ b/spec/integration/all/session_skip_probe_endpoints_spec.rb
@@ -1,0 +1,297 @@
+# spec/integration/all/session_skip_probe_endpoints_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration (Rack-level, real middleware stack, real Valkey)
+# =============================================================================
+#
+# Regression guard for #3997: anonymous probe endpoints minted a persisted
+# session per request.
+#
+# Onetime::Session is a Rack::Session::Abstract::PersistedSecure subclass, so
+# any request that loads AND dirties the session commits it — a
+# `session:<64-hex>` string key in Valkey with the full 24h TTL, plus a
+# Set-Cookie. The decisive dirtier was not the app: CsrfResponseHeader calls
+# `AuthenticityToken.token(session)` on every response, and that does
+# `session[:csrf] ||= random`. Load balancers, uptime monitors and
+# orchestrators poll /health and /api/v*/status constantly and keep no
+# cookies, so every poll leaked a key nobody would ever use.
+#
+# The fix mounts Onetime::Middleware::SessionSkip immediately below
+# Onetime::Session; it sets `env['rack.session.options'][:skip] = true` for an
+# exact-match list of full external paths, which rack-session's
+# `commit_session?` short-circuits on before any dirty check.
+#
+# Mode-agnostic on purpose: the probe endpoints and the middleware stack are
+# identical in every AUTHENTICATION_MODE. /auth/health is the one exception
+# (the auth app only mounts in full mode) and is covered by
+# spec/integration/full/session_skip_auth_health_spec.rb.
+#
+# RUN (mode-agnostic — runs in every mode lane):
+#   tests/lanes/run simple
+#   tests/lanes/run full-sqlite
+#
+# Requires Valkey on port 2163 (pnpm run test:database:start).
+#
+# =============================================================================
+
+require_relative '../../spec_helper'
+require_relative '../integration_spec_helper'
+
+# Every probe path the middleware is configured with, minus /auth/health (full
+# mode only — see spec/integration/full/session_skip_auth_health_spec.rb). A
+# file-local rather than a constant so nothing leaks into the example group.
+mode_agnostic_probe_paths = [
+  '/health',
+  '/health/advanced',
+  '/api/v1/status',
+  '/api/v2/status',
+  '/api/v3/status',
+].freeze
+
+RSpec.describe 'Session skip on anonymous probe endpoints (#3997)', type: :integration do
+  include Rack::Test::Methods
+
+  before(:all) do
+    require 'onetime'
+    Onetime.boot! :test
+    # Without this, Rack::URLMap has no /api/* entries and every API request
+    # 404s at the map level — which would still show "no session key" and
+    # pass vacuously.
+    Onetime::Application::Registry.prepare_application_registry
+  end
+
+  def app
+    @app ||= Onetime::Application::Registry.generate_rack_url_map
+  end
+
+  let(:dbclient) { Familia.dbclient }
+
+  # Only the rack session blob is a plain string. `session_metadata:*` is a
+  # hash and the per-customer active-sessions index is a sorted set; both match
+  # a naive `session*` glob and neither is the thing under test.
+  def session_blob_keys
+    dbclient.keys('session:*').select { |key| dbclient.type(key) == 'string' }
+  end
+
+  def set_cookie_header
+    last_response.headers['set-cookie']
+  end
+
+  # A probe request as a load balancer makes it: no cookie jar, no CSRF token,
+  # nothing carried over from a previous example.
+  def probe(path)
+    clear_cookies
+    header 'Content-Type', nil
+    header 'Accept', 'application/json'
+    get path
+  end
+
+  # ---------------------------------------------------------------------------
+  # Configuration resolution — assert the middleware is actually configured.
+  # If skip_paths resolved to nil/[] every assertion below would be measuring
+  # a middleware that decided nothing.
+  # ---------------------------------------------------------------------------
+  describe 'configuration' do
+    it 'resolves a skip_paths list under the test-mode config' do
+      expect(Onetime.session_config['skip_paths']).to include(*mode_agnostic_probe_paths)
+    end
+
+    it 'does not list the capability-token secret status routes' do
+      skip_paths = Onetime.session_config['skip_paths']
+
+      expect(skip_paths).to all(satisfy { |path| !path.include?('/secret/') })
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # 1. Cookieless probe: no session key, no Set-Cookie, no CSRF token
+  # ---------------------------------------------------------------------------
+  mode_agnostic_probe_paths.each do |path|
+    describe "GET #{path} without a cookie" do
+      it 'is served (not a routing 404, so the assertions below are meaningful)' do
+        probe path
+
+        expect(last_response.status).to be < 400
+      end
+
+      it 'writes no session key to Valkey' do
+        expect { probe path }.not_to change { session_blob_keys.size }
+      end
+
+      it 'returns no Set-Cookie header' do
+        probe path
+
+        expect(set_cookie_header).to be_nil
+      end
+
+      it 'returns no X-CSRF-Token header' do
+        # AuthenticityToken.token is the dirtier; suppressing the header and
+        # suppressing the write are the same act.
+        probe path
+
+        expect(last_response.headers['x-csrf-token']).to be_nil
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # 2. The acceptance criterion from the issue: sustained polling adds nothing
+  # ---------------------------------------------------------------------------
+  describe 'sustained polling of /health' do
+    it 'leaves the session key count unchanged after 100 requests' do
+      before_count = session_blob_keys.size
+
+      100.times { probe '/health' }
+
+      expect(session_blob_keys.size).to eq(before_count)
+    end
+
+    it 'never emits a Set-Cookie across a poll burst' do
+      cookie_headers = Array.new(25) do
+        probe '/health'
+        set_cookie_header
+      end
+
+      expect(cookie_headers.compact).to be_empty
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # 3. Control: a normal route still mints a session.
+  #
+  #    Without this, an over-broad matcher (or a session layer that stopped
+  #    persisting entirely) would make every assertion above pass.
+  # ---------------------------------------------------------------------------
+  describe 'GET / (control — a normal route)' do
+    it 'still writes a session key' do
+      expect { probe '/' }.to change { session_blob_keys.size }.by(1)
+    end
+
+    it 'still returns a Set-Cookie header' do
+      probe '/'
+
+      expect(set_cookie_header).to include('onetime.session')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # 4. Scope guard: /api/v*/secret/:identifier/status is a capability-token
+  #    data read audited via SecretActivity, NOT a probe. A prefix or substring
+  #    matcher would sweep it in and silently stop persisting real API sessions.
+  # ---------------------------------------------------------------------------
+  %w[/api/v2 /api/v3].each do |mount|
+    describe "GET #{mount}/secret/:identifier/status (data read, not a probe)" do
+      let(:path) { "#{mount}/secret/nonexistent#{SecureRandom.hex(8)}/status" }
+
+      it 'reaches the logic layer rather than the URLMap 404 floor' do
+        # 404 here is MissingSecret from the logic layer; either way the
+        # request traversed the full middleware stack, which is what makes the
+        # session assertions below meaningful.
+        probe path
+
+        expect(last_response.status).to be_between(200, 499)
+      end
+
+      it 'keeps normal session behavior (writes a session key)' do
+        expect { probe path }.to change { session_blob_keys.size }.by(1)
+      end
+
+      it 'keeps returning a Set-Cookie header' do
+        probe path
+
+        expect(set_cookie_header).to include('onetime.session')
+      end
+    end
+
+    describe "POST #{mount}/secret/status (batch data read, not a probe)" do
+      it 'keeps normal session behavior' do
+        clear_cookies
+        header 'Content-Type', 'application/json'
+        header 'Accept', 'application/json'
+
+        expect { post "#{mount}/secret/status", JSON.generate(identifiers: []) }
+          .to change { session_blob_keys.size }.by(1)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # 5. Existing-session survival.
+  #
+  #    A browser session hitting /health (the frontend polls it) must not have
+  #    its session dropped, rewritten or its TTL renewed. `options[:skip]` is
+  #    rack-session's "do nothing" lever, so the stored blob must be byte-identical
+  #    and the TTL must keep counting down.
+  # ---------------------------------------------------------------------------
+  describe 'a request that presents an existing session cookie' do
+    # Deliberately short so a renewal back to expire_after (86400) is
+    # unmissable rather than a sub-second difference.
+    let(:pinned_ttl) { 120 }
+
+    def establish_session
+      clear_cookies
+      header 'Content-Type', nil
+      header 'Accept', 'application/json'
+      get '/'
+
+      key = session_blob_keys.first
+      raise 'control failed: GET / minted no session key' if key.nil?
+
+      dbclient.expire(key, pinned_ttl)
+      key
+    end
+
+    it 'leaves the session key in place' do
+      key = establish_session
+
+      get '/health'
+
+      expect(dbclient.exists?(key)).to be true
+    end
+
+    it 'leaves the stored session value byte-identical' do
+      key    = establish_session
+      before = dbclient.get(key)
+
+      get '/health'
+
+      expect(dbclient.get(key)).to eq(before)
+    end
+
+    it 'does not renew the TTL upward' do
+      key = establish_session
+
+      get '/health'
+
+      expect(dbclient.ttl(key)).to be <= pinned_ttl
+    end
+
+    it 'creates no additional session key' do
+      establish_session
+
+      expect { get '/health' }.not_to change { session_blob_keys.size }
+    end
+
+    it 'returns no Set-Cookie header' do
+      establish_session
+
+      get '/health'
+
+      expect(set_cookie_header).to be_nil
+    end
+
+    it 'still renews normally on a non-probe route (control for the TTL assertion)' do
+      # Proves the TTL assertion above can fail: the same session, same pinned
+      # TTL, hitting a route that is NOT in skip_paths, does get rewritten.
+      key = establish_session
+
+      header 'Content-Type', nil
+      header 'Accept', 'application/json'
+      get '/'
+
+      expect(dbclient.ttl(key)).to be > pinned_ttl
+    end
+  end
+end

--- a/spec/integration/all/session_skip_probe_endpoints_spec.rb
+++ b/spec/integration/all/session_skip_probe_endpoints_spec.rb
@@ -12,9 +12,11 @@
 # Onetime::Session is a Rack::Session::Abstract::PersistedSecure subclass, so
 # any request that loads AND dirties the session commits it — a
 # `session:<64-hex>` string key in Valkey with the full 24h TTL, plus a
-# Set-Cookie. The decisive dirtier was not the app: CsrfResponseHeader calls
-# `AuthenticityToken.token(session)` on every response, and that does
-# `session[:csrf] ||= random`. Load balancers, uptime monitors and
+# Set-Cookie. The dirtiers are middleware, not the app, and there is more than
+# one: InstrumentedAuthenticityToken's inherited `accepts?` does
+# `session[:csrf] ||= random` on every request before its safe-method check,
+# and CsrfResponseHeader calls `AuthenticityToken.token(session)` (the same
+# `||=`) when exposing the masked token. Load balancers, uptime monitors and
 # orchestrators poll /health and /api/v*/status constantly and keep no
 # cookies, so every poll leaked a key nobody would ever use.
 #
@@ -127,11 +129,44 @@ RSpec.describe 'Session skip on anonymous probe endpoints (#3997)', type: :integ
       end
 
       it 'returns no X-CSRF-Token header' do
-        # AuthenticityToken.token is the dirtier; suppressing the header and
-        # suppressing the write are the same act.
+        # The write is suppressed by rack-session's :skip flag, not by
+        # withholding this header (AuthenticityToken#accepts? dirties the
+        # session on the way in regardless). The header is withheld because a
+        # token backed by a session that will never persist could never
+        # validate.
         probe path
 
         expect(last_response.headers['x-csrf-token']).to be_nil
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # 1b. Path aliases: the Otto router normalizes (unescape + strip trailing
+  #     slash) before dispatch, so these spellings are served as the probe
+  #     route. The skip matcher normalizes identically; matching the raw
+  #     string here would serve the request AND mint a session.
+  # ---------------------------------------------------------------------------
+  {
+    '/health/' => 'trailing slash',
+    '/api/v2/status/' => 'trailing slash on a mounted probe route',
+    '/api/v2/%73tatus' => 'percent-encoded path segment',
+  }.each do |path, alias_kind|
+    describe "GET #{path} (#{alias_kind}) without a cookie" do
+      it 'is served (not a routing 404, so the assertion below is meaningful)' do
+        probe path
+
+        expect(last_response.status).to be < 400
+      end
+
+      it 'writes no session key to Valkey' do
+        expect { probe path }.not_to change { session_blob_keys.size }
+      end
+
+      it 'returns no Set-Cookie header' do
+        probe path
+
+        expect(set_cookie_header).to be_nil
       end
     end
   end

--- a/spec/integration/full/session_skip_auth_health_spec.rb
+++ b/spec/integration/full/session_skip_auth_health_spec.rb
@@ -1,0 +1,128 @@
+# spec/integration/full/session_skip_auth_health_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration (Rack-level, full auth mode, real Valkey)
+# =============================================================================
+#
+# Full-mode half of the #3997 coverage. The mode-agnostic probe endpoints live
+# in spec/integration/all/session_skip_probe_endpoints_spec.rb; /auth/health is
+# here because the Roda auth app only mounts when AUTHENTICATION_MODE=full.
+#
+# This path is the one that proves the matcher reassembles SCRIPT_NAME +
+# PATH_INFO. The universal middleware stack runs INSIDE Rack::URLMap, so
+# /auth/health arrives at Onetime::Middleware::SessionSkip as
+# SCRIPT_NAME='/auth' + PATH_INFO='/health'. A matcher reading PATH_INFO alone
+# would match it — but for the wrong reason, and it would then also match every
+# other mounted app's /health. A matcher reading only the configured literal
+# against PATH_INFO would miss it entirely.
+#
+# RUN:
+#   tests/lanes/run full-sqlite
+#
+# Requires Valkey on port 2163 (pnpm run test:database:start).
+#
+# =============================================================================
+
+require_relative '../../spec_helper'
+require_relative '../integration_spec_helper'
+
+RSpec.describe 'Session skip on /auth/health (#3997)', type: :integration do
+  include Rack::Test::Methods
+
+  before(:all) do
+    ENV['AUTHENTICATION_MODE'] = 'full'
+
+    Onetime::Application::Registry.reset!
+    Onetime.auth_config.reload!
+    Onetime.boot! :test
+    Onetime::Application::Registry.prepare_application_registry
+  end
+
+  after(:all) do
+    ENV.delete('AUTHENTICATION_MODE')
+  end
+
+  def app
+    @app ||= Onetime::Application::Registry.generate_rack_url_map
+  end
+
+  let(:dbclient) { Familia.dbclient }
+
+  # Only the rack session blob is a plain string; session_metadata:* is a hash
+  # and the per-customer active-sessions index is a sorted set.
+  def session_blob_keys
+    dbclient.keys('session:*').select { |key| dbclient.type(key) == 'string' }
+  end
+
+  # A probe as an orchestrator makes it: no cookie jar, nothing inherited.
+  def probe(path)
+    clear_cookies
+    header 'Content-Type', nil
+    header 'Accept', 'application/json'
+    get path
+  end
+
+  describe 'configuration' do
+    it 'lists /auth/health among the skip paths' do
+      expect(Onetime.session_config['skip_paths']).to include('/auth/health')
+    end
+  end
+
+  describe 'GET /auth/health without a cookie' do
+    it 'returns 200 (the auth app is mounted; the assertions below are meaningful)' do
+      probe '/auth/health'
+
+      expect(last_response.status).to eq(200)
+    end
+
+    it 'reports the health payload' do
+      probe '/auth/health'
+
+      expect(JSON.parse(last_response.body)).to include('status' => 'ok')
+    end
+
+    it 'writes no session key to Valkey' do
+      expect { probe '/auth/health' }.not_to change { session_blob_keys.size }
+    end
+
+    it 'returns no Set-Cookie header' do
+      probe '/auth/health'
+
+      expect(last_response.headers['set-cookie']).to be_nil
+    end
+
+    it 'returns no X-CSRF-Token header' do
+      probe '/auth/health'
+
+      expect(last_response.headers['x-csrf-token']).to be_nil
+    end
+  end
+
+  describe 'sustained polling of /auth/health' do
+    it 'leaves the session key count unchanged across a poll burst' do
+      before_count = session_blob_keys.size
+
+      25.times { probe '/auth/health' }
+
+      expect(session_blob_keys.size).to eq(before_count)
+    end
+  end
+
+  describe 'GET /auth (control — a normal auth-app route)' do
+    # Proves the suppression is scoped to the configured path rather than to
+    # the whole auth mount: without this, deleting the SCRIPT_NAME join (or
+    # skipping the entire /auth app) would still leave every assertion above
+    # green.
+    it 'still writes a session key' do
+      expect { probe '/auth' }.to change { session_blob_keys.size }.by(1)
+    end
+
+    it 'still returns a Set-Cookie header' do
+      probe '/auth'
+
+      expect(last_response.headers['set-cookie']).to include('onetime.session')
+    end
+  end
+end

--- a/spec/unit/onetime/middleware/csrf_response_header_spec.rb
+++ b/spec/unit/onetime/middleware/csrf_response_header_spec.rb
@@ -1,0 +1,315 @@
+# spec/unit/onetime/middleware/csrf_response_header_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'onetime/middleware/csrf_response_header'
+
+# Unit tests for the CSRF response-header middleware.
+#
+# Two behaviors live here and they are entangled by design:
+#
+#   1. Token exposure. `AuthenticityToken.token(session)` does
+#      `session[:csrf] ||= random` — it does not merely READ the session, it
+#      WRITES to it. That write is what made every anonymous probe request
+#      dirty its session and commit a `session:<hex>` key to Valkey (#3997).
+#      The `!session_skipped?` gate added for #3997 is therefore the decisive
+#      guard, not a cosmetic one: without it, SessionSkip's `:skip` flag would
+#      still suppress the commit, but the middleware would hand the client a
+#      masked token backed by a session that will never exist.
+#
+#   2. 403 classification (#3837). A CSRF 403 is either a token mismatch
+#      (forgery) or a session-continuity break (the session was lost). The two
+#      are only distinguishable BEFORE `@app.call`, because AuthenticityToken
+#      mints the token during validation. The `had_csrf` snapshot is that
+#      "before" reading.
+RSpec.describe Onetime::Middleware::CsrfResponseHeader do
+  let(:downstream_status) { 200 }
+  let(:downstream_headers) { { 'content-type' => 'application/json' } }
+
+  # Lets an example stamp env keys (e.g. the CSRF rejection marker) from where
+  # the real InstrumentedAuthenticityToken would stamp them: below this
+  # middleware, during @app.call.
+  let(:downstream_side_effect) { ->(_env) {} }
+
+  let(:downstream) do
+    lambda do |env|
+      downstream_side_effect.call(env)
+      [downstream_status, downstream_headers.dup, ['{}']]
+    end
+  end
+
+  let(:middleware) { described_class.new(downstream) }
+
+  # A plain Hash stands in for Onetime::Session's SessionHash: both respond to
+  # []/[]= with symbol keys, which is all AuthenticityToken.token touches.
+  let(:session) { {} }
+
+  def env_for(method: 'GET', session: nil, session_options: nil, script_name: '', path_info: '/')
+    env = {
+      'REQUEST_METHOD' => method,
+      'SCRIPT_NAME' => script_name,
+      'PATH_INFO' => path_info,
+    }
+    env['rack.session']         = session unless session.nil?
+    env['rack.session.options'] = session_options unless session_options.nil?
+    env
+  end
+
+  describe 'token exposure with a normal (non-skipped) session' do
+    it 'adds a masked X-CSRF-Token header' do
+      _status, headers, = middleware.call(env_for(session: session))
+
+      expect(headers['X-CSRF-Token']).to be_a(String)
+      expect(headers['X-CSRF-Token']).not_to be_empty
+    end
+
+    it 'seeds the raw token into the session' do
+      middleware.call(env_for(session: session))
+
+      expect(session[:csrf]).to be_a(String)
+    end
+
+    it 'masks the token rather than exposing the raw session value' do
+      # BREACH mitigation: the header must never be the raw session token.
+      _status, headers, = middleware.call(env_for(session: session))
+
+      expect(headers['X-CSRF-Token']).not_to eq(session[:csrf])
+    end
+
+    it 'issues a different masked value on each response for the same raw token' do
+      _s1, first_headers,  = middleware.call(env_for(session: session))
+      _s2, second_headers, = middleware.call(env_for(session: session))
+
+      expect(second_headers['X-CSRF-Token']).not_to eq(first_headers['X-CSRF-Token'])
+    end
+
+    it 'preserves an already-present raw token' do
+      # Must be a real base64 token: global_token decodes the stored value to
+      # build the HMAC, so an arbitrary string raises inside rack-protection.
+      existing       = Rack::Protection::AuthenticityToken.random_token
+      session[:csrf] = existing
+
+      middleware.call(env_for(session: session))
+
+      expect(session[:csrf]).to eq(existing)
+    end
+
+    it 'passes the downstream status and body through unchanged' do
+      status, _headers, body = middleware.call(env_for(session: session))
+
+      expect(status).to eq(200)
+      expect(body).to eq(['{}'])
+    end
+
+    it 'preserves the downstream headers' do
+      _status, headers, = middleware.call(env_for(session: session))
+
+      expect(headers['content-type']).to eq('application/json')
+    end
+
+    it 'adds the header when the options hash exists but carries no :skip' do
+      _status, headers, = middleware.call(
+        env_for(session: session, session_options: { expire_after: 86_400 })
+      )
+
+      expect(headers['X-CSRF-Token']).to be_a(String)
+    end
+
+    it 'adds the header when :skip is explicitly false' do
+      _status, headers, = middleware.call(
+        env_for(session: session, session_options: { skip: false })
+      )
+
+      expect(headers['X-CSRF-Token']).to be_a(String)
+    end
+  end
+
+  describe 'suppression when SessionSkip marked the request (#3997)' do
+    let(:skipped_env) do
+      env_for(
+        session: session,
+        session_options: { skip: true },
+        path_info: '/health',
+      )
+    end
+
+    it 'does not call AuthenticityToken.token' do
+      expect(Rack::Protection::AuthenticityToken).not_to receive(:token)
+
+      middleware.call(skipped_env)
+    end
+
+    it 'does not add an X-CSRF-Token header' do
+      _status, headers, = middleware.call(skipped_env)
+
+      expect(headers).not_to have_key('X-CSRF-Token')
+    end
+
+    it 'leaves the session undirtied — this is what stops the Valkey write' do
+      # The whole point: AuthenticityToken.token would do
+      # `session[:csrf] ||= random`, marking the session loaded-and-changed.
+      middleware.call(skipped_env)
+
+      expect(session).to be_empty
+    end
+
+    it 'still passes the response through unchanged' do
+      status, headers, body = middleware.call(skipped_env)
+
+      expect(status).to eq(200)
+      expect(headers['content-type']).to eq('application/json')
+      expect(body).to eq(['{}'])
+    end
+
+    it 'reads the :skip flag without setting it' do
+      # SessionSkip owns the flag; this middleware must be a pure reader, or a
+      # false positive here would silently disable session persistence.
+      options = { skip: false }
+
+      middleware.call(env_for(session: session, session_options: options))
+
+      expect(options).to eq(skip: false)
+    end
+
+    it 'treats a non-true :skip value as not skipped' do
+      # Guards against a truthy-but-not-true value (e.g. a config string)
+      # accidentally suppressing tokens on real routes.
+      _status, headers, = middleware.call(
+        env_for(session: session, session_options: { skip: 'true' })
+      )
+
+      expect(headers['X-CSRF-Token']).to be_a(String)
+    end
+
+    it 'tolerates a nil rack.session.options (no session middleware above)' do
+      # `respond_to?(:[])` in session_skipped? exists for exactly this: nil has
+      # no #[], so the guard short-circuits rather than raising.
+      env                         = env_for(session: session)
+      env['rack.session.options'] = nil
+
+      _status, headers, = middleware.call(env)
+
+      expect(headers['X-CSRF-Token']).to be_a(String)
+    end
+  end
+
+  describe 'sessionless requests' do
+    it 'adds no header and does not raise when rack.session is absent' do
+      status, headers, = middleware.call(env_for)
+
+      expect(status).to eq(200)
+      expect(headers).not_to have_key('X-CSRF-Token')
+    end
+
+    it 'adds no header when rack.session is nil' do
+      env                 = env_for
+      env['rack.session'] = nil
+
+      _status, headers, = middleware.call(env)
+
+      expect(headers).not_to have_key('X-CSRF-Token')
+    end
+
+    it 'does not raise on an unsafe sessionless request' do
+      # csrf_token_present? runs before @app.call for unsafe methods and must
+      # tolerate a nil session.
+      expect { middleware.call(env_for(method: 'POST')) }.not_to raise_error
+    end
+  end
+
+  describe 'CSRF 403 classification (#3837)' do
+    let(:rejection_key) { Onetime::Middleware::InstrumentedAuthenticityToken::REJECTION_ENV_KEY }
+    let(:downstream_status) { 403 }
+
+    # The marker is stamped by InstrumentedAuthenticityToken#deny, i.e. below
+    # this middleware while @app.call is on the stack.
+    let(:downstream_side_effect) { ->(env) { env[rejection_key] = true } }
+
+    it 'logs a token-mismatch when the session already held a CSRF token' do
+      session[:csrf] = Rack::Protection::AuthenticityToken.random_token
+
+      expect(OT).to receive(:lw).with(/token-mismatch/, hash_including(method: 'POST', path: '/api/v2/x'))
+
+      middleware.call(
+        env_for(method: 'POST', session: session, script_name: '/api/v2', path_info: '/x')
+      )
+    end
+
+    it 'logs a session-continuity break when the session had no token' do
+      expect(OT).to receive(:lw).with(/session-continuity break/, hash_including(method: 'POST'))
+
+      middleware.call(env_for(method: 'POST', session: session))
+    end
+
+    it 'logs the full external path, not the mount-relative remainder' do
+      expect(OT).to receive(:lw).with(anything, hash_including(path: '/api/v2/secret/conceal'))
+
+      middleware.call(
+        env_for(method: 'POST', session: session, script_name: '/api/v2', path_info: '/secret/conceal')
+      )
+    end
+
+    it 'does not log for a safe method' do
+      expect(OT).not_to receive(:lw)
+
+      middleware.call(env_for(method: 'GET', session: session))
+    end
+
+    it 'treats an empty-string token as absent when classifying' do
+      session[:csrf] = ''
+
+      expect(OT).to receive(:lw).with(/session-continuity break/, anything)
+
+      middleware.call(env_for(method: 'POST', session: session))
+    end
+
+    context 'when the 403 came from the app rather than the CSRF layer' do
+      let(:downstream_side_effect) { ->(_env) {} }
+
+      it 'does not log (no rejection marker)' do
+        expect(OT).not_to receive(:lw)
+
+        middleware.call(env_for(method: 'POST', session: session))
+      end
+    end
+
+    context 'when the marker is set but the status is not 403' do
+      let(:downstream_status) { 200 }
+
+      it 'does not log' do
+        expect(OT).not_to receive(:lw)
+
+        middleware.call(env_for(method: 'POST', session: session))
+      end
+    end
+
+    it 'still exposes a token on the 403 response' do
+      # The client needs a usable token to retry; the 403 path must not strip it.
+      _status, headers, = middleware.call(env_for(method: 'POST', session: session))
+
+      expect(headers['X-CSRF-Token']).to be_a(String)
+    end
+  end
+
+  describe 'unsafe-method session probing' do
+    it 'does not read the session on safe methods' do
+      # Reading the session lazy-loads it; safe requests must not pay that cost.
+      probed = double('session')
+      expect(probed).not_to receive(:[])
+
+      middleware.call(env_for(method: 'GET', session_options: { skip: true }).merge('rack.session' => probed))
+    end
+
+    %w[POST PUT PATCH DELETE].each do |method|
+      it "probes the session for a #{method} request" do
+        probed = {}
+        expect(probed).to receive(:[]).with(:csrf).and_return(nil).at_least(:once)
+
+        middleware.call(
+          env_for(method: method, session: probed, session_options: { skip: true })
+        )
+      end
+    end
+  end
+end

--- a/spec/unit/onetime/middleware/session_skip_spec.rb
+++ b/spec/unit/onetime/middleware/session_skip_spec.rb
@@ -1,0 +1,292 @@
+# spec/unit/onetime/middleware/session_skip_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'onetime/middleware/session_skip'
+
+# Unit tests for the probe-endpoint session suppression middleware (#3997).
+#
+# The middleware's entire job is a decision: for this request, should
+# rack-session's `commit_session?` short-circuit? It expresses that by setting
+# `env['rack.session.options'][:skip] = true`.
+#
+# Two properties carry all the risk:
+#
+#   1. The path it matches on is the FULL external path — SCRIPT_NAME +
+#      PATH_INFO — because the universal stack runs inside Rack::URLMap and
+#      PATH_INFO is therefore mount-relative. A matcher that read PATH_INFO
+#      alone would skip `/api/v2/status` and `/api/v3/status` correctly by
+#      accident while also skipping any other app's `/status`.
+#   2. The comparison is exact equality. Prefix/substring matching would sweep
+#      in `/api/v*/secret/:identifier/status`, a capability-token data read
+#      audited via SecretActivity, and silently stop persisting its session.
+#
+# Both are asserted below as a matcher table, with the near-miss rows
+# (trailing slash, case, traversal, hyphen/word extensions) present precisely
+# because they are what a looser matcher would let through.
+RSpec.describe Onetime::Middleware::SessionSkip do
+  # The full default probe list, as shipped in SESSION_DEFAULTS and
+  # config.defaults.yaml.
+  let(:skip_paths) do
+    %w[
+      /health
+      /health/advanced
+      /auth/health
+      /api/v1/status
+      /api/v2/status
+      /api/v3/status
+    ]
+  end
+
+  let(:downstream_calls) { [] }
+
+  # Records the env exactly as the app below the middleware sees it, which is
+  # the only place the :skip flag is observable before rack-session reads it
+  # back out on the way up.
+  let(:downstream) do
+    lambda do |env|
+      downstream_calls << env
+      [200, { 'content-type' => 'text/plain' }, ['ok']]
+    end
+  end
+
+  let(:middleware) { described_class.new(downstream, skip_paths: skip_paths) }
+
+  # Mirrors what rack-session's `prepare_session` installs before calling
+  # downstream: a session hash plus the per-request options hash whose :skip
+  # key `commit_session?` consults.
+  def env_for(script_name, path_info, session_options: {})
+    {
+      'SCRIPT_NAME' => script_name,
+      'PATH_INFO' => path_info,
+      'REQUEST_METHOD' => 'GET',
+      'rack.session.options' => session_options,
+    }
+  end
+
+  def skip_flag_for(script_name, path_info)
+    env = env_for(script_name, path_info)
+    middleware.call(env)
+    env['rack.session.options'][:skip]
+  end
+
+  describe 'paths that suppress session persistence' do
+    # [SCRIPT_NAME, PATH_INFO, description of the mount it arrives from]
+    [
+      ['',         '/health',          'core app mounted at /'],
+      ['',         '/health/advanced', 'core app, nested health path'],
+      ['/auth',    '/health',          'auth app mounted at /auth (full mode only)'],
+      ['/api/v1',  '/status',          'API v1 app'],
+      ['/api/v2',  '/status',          'API v2 app'],
+      ['/api/v3',  '/status',          'API v3 app'],
+    ].each do |script_name, path_info, mount_description|
+      it "sets :skip for #{script_name}#{path_info} (#{mount_description})" do
+        expect(skip_flag_for(script_name, path_info)).to be true
+      end
+    end
+
+    it 'still calls the downstream app' do
+      env = env_for('', '/health')
+
+      status, _headers, body = middleware.call(env)
+
+      expect(status).to eq(200)
+      expect(body).to eq(['ok'])
+      expect(downstream_calls.size).to eq(1)
+    end
+
+    it 'sets :skip before the downstream app runs' do
+      # Ordering matters: CsrfResponseHeader sits below this middleware and
+      # reads the flag to decide whether to mint a token. If the flag were set
+      # after @app.call, the token would already have dirtied the session.
+      observed = nil
+      app      = lambda do |env|
+        observed = env['rack.session.options'][:skip]
+        [200, {}, []]
+      end
+
+      described_class.new(app, skip_paths: skip_paths).call(env_for('', '/health'))
+
+      expect(observed).to be true
+    end
+  end
+
+  describe 'paths that must keep normal session behavior' do
+    # Every row here is a path a looser matcher would wrongly capture.
+    [
+      ['/api/v2', '/secret/abc/status', 'capability-token data read, not a probe (substring match would catch it)'],
+      ['/api/v3', '/secret/abc/status', 'v3 capability-token data read'],
+      ['',        '/statusboard',       'prefix match would catch it'],
+      ['',        '/health-check',      'prefix match would catch it'],
+      ['',        '/healthz',           'prefix match would catch it'],
+      ['',        '/',                  'homepage — the session-minting control'],
+      ['',        '/health/../colonel', 'unnormalized traversal must not match /health'],
+      ['/api/v2', '/status/',           'trailing slash is a different path'],
+      ['',        '/HEALTH',            'matching is case-sensitive'],
+      ['/api/v2', '/api/v2/status',     'double-prefixed path'],
+      ['/auth',   '/auth/health',       'double-prefixed auth health path'],
+      ['',        '/health/advanced/x', 'nested below a listed path'],
+    ].each do |script_name, path_info, rationale|
+      it "does not set :skip for #{script_name}#{path_info} (#{rationale})" do
+        expect(skip_flag_for(script_name, path_info)).to be_nil
+      end
+    end
+
+    it 'does not add any key to the session options hash' do
+      env = env_for('', '/')
+
+      middleware.call(env)
+
+      expect(env['rack.session.options']).to be_empty
+    end
+  end
+
+  describe 'session options hash handling' do
+    it 'does nothing and does not raise when rack.session.options is absent' do
+      # Happens if this middleware is ever mounted above the session
+      # middleware, or in a stack with no session at all. There is nothing to
+      # suppress, so the only correct behavior is to pass through.
+      env = { 'SCRIPT_NAME' => '', 'PATH_INFO' => '/health' }
+
+      status, = middleware.call(env)
+
+      expect(status).to eq(200)
+      expect(env).not_to have_key('rack.session.options')
+    end
+
+    it 'leaves the other entries of an existing options hash alone' do
+      # The real hash carries the cookie settings rack-session will apply, plus
+      # flags other code sets (authentication.rb requests :renew). Clobbering
+      # any of them would change cookie behavior for every skipped request.
+      options = { expire_after: 86_400, renew: true, path: '/', same_site: :lax }
+      env     = env_for('', '/health', session_options: options)
+
+      middleware.call(env)
+
+      expect(env['rack.session.options']).to eq(
+        expire_after: 86_400, renew: true, path: '/', same_site: :lax, skip: true
+      )
+    end
+
+    it 'mutates the same hash object rack-session installed' do
+      # rack-session reads back the hash it put in env; replacing it with a new
+      # object would leave the original — the one commit_session? consults —
+      # untouched.
+      options = {}
+      env     = env_for('', '/health', session_options: options)
+
+      middleware.call(env)
+
+      expect(env['rack.session.options']).to equal(options)
+      expect(options[:skip]).to be true
+    end
+
+    it 'leaves an already-set :skip flag true' do
+      env = env_for('', '/health', session_options: { skip: true })
+
+      middleware.call(env)
+
+      expect(env['rack.session.options'][:skip]).to be true
+    end
+
+    it 'does not clear a :skip flag another layer set on a non-probe path' do
+      env = env_for('', '/', session_options: { skip: true })
+
+      middleware.call(env)
+
+      expect(env['rack.session.options'][:skip]).to be true
+    end
+  end
+
+  describe 'skip_paths configuration' do
+    it 'skips nothing when skip_paths is nil (config gap degrades to pre-#3997 behavior)' do
+      env = env_for('', '/health')
+
+      described_class.new(downstream, skip_paths: nil).call(env)
+
+      expect(env['rack.session.options']).to be_empty
+    end
+
+    it 'skips nothing when skip_paths is empty' do
+      env = env_for('', '/health')
+
+      described_class.new(downstream, skip_paths: []).call(env)
+
+      expect(env['rack.session.options']).to be_empty
+    end
+
+    it 'skips nothing when skip_paths is omitted entirely' do
+      env = env_for('', '/health')
+
+      described_class.new(downstream).call(env)
+
+      expect(env['rack.session.options']).to be_empty
+    end
+
+    it 'still calls the downstream app when skip_paths is empty' do
+      status, = described_class.new(downstream, skip_paths: []).call(env_for('', '/health'))
+
+      expect(status).to eq(200)
+      expect(downstream_calls.size).to eq(1)
+    end
+
+    it 'coerces non-string entries so a YAML surprise cannot break matching' do
+      env = env_for('', '/health')
+
+      described_class.new(downstream, skip_paths: [:'/health']).call(env)
+
+      expect(env['rack.session.options'][:skip]).to be true
+    end
+
+    it 'accepts a single non-array value' do
+      env = env_for('', '/health')
+
+      described_class.new(downstream, skip_paths: '/health').call(env)
+
+      expect(env['rack.session.options'][:skip]).to be true
+    end
+  end
+
+  describe 'env key handling' do
+    it 'treats a missing SCRIPT_NAME as an empty mount prefix' do
+      env = { 'PATH_INFO' => '/health', 'rack.session.options' => {} }
+
+      middleware.call(env)
+
+      expect(env['rack.session.options'][:skip]).to be true
+    end
+
+    it 'treats a missing PATH_INFO as an empty remainder' do
+      env = { 'SCRIPT_NAME' => '/health', 'rack.session.options' => {} }
+
+      middleware.call(env)
+
+      expect(env['rack.session.options'][:skip]).to be true
+    end
+
+    it 'does not skip when both path components are absent' do
+      env = { 'rack.session.options' => {} }
+
+      middleware.call(env)
+
+      expect(env['rack.session.options']).to be_empty
+    end
+  end
+
+  describe 'request method independence' do
+    # The probe endpoints are GET-only routes, but the skip decision is made
+    # before routing. A POST to /health is a 404/405 from the router and still
+    # must not mint a session.
+    %w[GET HEAD POST PUT DELETE OPTIONS].each do |method|
+      it "skips a #{method} request to /health" do
+        env                   = env_for('', '/health')
+        env['REQUEST_METHOD'] = method
+
+        middleware.call(env)
+
+        expect(env['rack.session.options'][:skip]).to be true
+      end
+    end
+  end
+end

--- a/spec/unit/onetime/middleware/session_skip_spec.rb
+++ b/spec/unit/onetime/middleware/session_skip_spec.rb
@@ -249,6 +249,11 @@ RSpec.describe Onetime::Middleware::SessionSkip do
   end
 
   describe 'env key handling' do
+    # A Rack-conforming server always populates both SCRIPT_NAME and
+    # PATH_INFO; an env missing either means an upstream middleware
+    # mangled the stack. These tests guard the matcher's nil-tolerance
+    # for that degenerate input — they do not describe a request shape
+    # that occurs in practice.
     it 'treats a missing SCRIPT_NAME as an empty mount prefix' do
       env = { 'PATH_INFO' => '/health', 'rack.session.options' => {} }
 

--- a/spec/unit/onetime/middleware/session_skip_spec.rb
+++ b/spec/unit/onetime/middleware/session_skip_spec.rb
@@ -18,13 +18,19 @@ require 'onetime/middleware/session_skip'
 #      PATH_INFO is therefore mount-relative. A matcher that read PATH_INFO
 #      alone would skip `/api/v2/status` and `/api/v3/status` correctly by
 #      accident while also skipping any other app's `/status`.
-#   2. The comparison is exact equality. Prefix/substring matching would sweep
-#      in `/api/v*/secret/:identifier/status`, a capability-token data read
+#   2. The comparison is exact equality AFTER Otto::Utils.normalize_path — the
+#      same canonicalization the Otto router applies before dispatch. The
+#      router serves `/api/v2/status/` and percent-encoded spellings as the
+#      status route, so matching the raw string would let those aliases mint
+#      sessions; prefix/substring matching would instead sweep in
+#      `/api/v*/secret/:identifier/status`, a capability-token data read
 #      audited via SecretActivity, and silently stop persisting its session.
 #
 # Both are asserted below as a matcher table, with the near-miss rows
-# (trailing slash, case, traversal, hyphen/word extensions) present precisely
-# because they are what a looser matcher would let through.
+# (case, traversal, hyphen/word extensions) present precisely because they
+# are what a looser matcher would let through, and the alias rows (trailing
+# slash, percent-encoding) because they are what a raw-string matcher would
+# wrongly let mint sessions.
 RSpec.describe Onetime::Middleware::SessionSkip do
   # The full default probe list, as shipped in SESSION_DEFAULTS and
   # config.defaults.yaml.
@@ -80,6 +86,12 @@ RSpec.describe Onetime::Middleware::SessionSkip do
       ['/api/v1',  '/status',          'API v1 app'],
       ['/api/v2',  '/status',          'API v2 app'],
       ['/api/v3',  '/status',          'API v3 app'],
+      # Aliases the Otto router normalizes to a probe route before dispatch.
+      # Matching the raw string here would serve them AND mint a session.
+      ['',         '/health/',         'trailing slash — router strips it before dispatch'],
+      ['/api/v2',  '/status/',         'trailing slash on a mounted probe route'],
+      ['/api/v2',  '/%73tatus',        'percent-encoded — router unescapes before dispatch'],
+      ['',         '/%68ealth',        'percent-encoded core probe route'],
     ].each do |script_name, path_info, mount_description|
       it "sets :skip for #{script_name}#{path_info} (#{mount_description})" do
         expect(skip_flag_for(script_name, path_info)).to be true
@@ -121,8 +133,7 @@ RSpec.describe Onetime::Middleware::SessionSkip do
       ['',        '/health-check',      'prefix match would catch it'],
       ['',        '/healthz',           'prefix match would catch it'],
       ['',        '/',                  'homepage — the session-minting control'],
-      ['',        '/health/../colonel', 'unnormalized traversal must not match /health'],
-      ['/api/v2', '/status/',           'trailing slash is a different path'],
+      ['',        '/health/../colonel', 'dot segments are not collapsed (the router does not either)'],
       ['',        '/HEALTH',            'matching is case-sensitive'],
       ['/api/v2', '/api/v2/status',     'double-prefixed path'],
       ['/auth',   '/auth/health',       'double-prefixed auth health path'],
@@ -243,6 +254,14 @@ RSpec.describe Onetime::Middleware::SessionSkip do
       env = env_for('', '/health')
 
       described_class.new(downstream, skip_paths: '/health').call(env)
+
+      expect(env['rack.session.options'][:skip]).to be true
+    end
+
+    it 'normalizes configured entries so a trailing-slash entry still matches' do
+      env = env_for('', '/health')
+
+      described_class.new(downstream, skip_paths: ['/health/']).call(env)
 
       expect(env['rack.session.options'][:skip]).to be true
     end

--- a/src/schemas/contracts/config/section/site.ts
+++ b/src/schemas/contracts/config/section/site.ts
@@ -45,6 +45,11 @@ const sessionConfigSchema = z.object({
   secure: z.boolean().optional(),
   same_site: z.enum(['strict', 'lax', 'none']).optional(),
   httponly: z.boolean().optional(),
+  /**
+   * Full external paths (SCRIPT_NAME + PATH_INFO) matched EXACTLY, for which
+   * no session is persisted — anonymous probe endpoints only (#3997).
+   */
+  skip_paths: z.array(z.string()).optional(),
 });
 
 /**

--- a/src/schemas/shapes/config/section/site.ts
+++ b/src/schemas/shapes/config/section/site.ts
@@ -63,6 +63,18 @@ const sessionTree: AugmentTree = {
   secure: (b) => b.default(true),
   same_site: (e) => e.default('lax'),
   httponly: (b) => b.default(true),
+  // Anonymous probe endpoints that must not mint a persisted session (#3997).
+  // Exact-match against the full external path; never list
+  // /api/v*/secret/*/status here (capability-token data reads, not probes).
+  skip_paths: (a) =>
+    a.default([
+      '/health',
+      '/health/advanced',
+      '/auth/health',
+      '/api/v1/status',
+      '/api/v2/status',
+      '/api/v3/status',
+    ]),
 };
 
 const cspTree: AugmentTree = {

--- a/try/unit/boot/session_config_try.rb
+++ b/try/unit/boot/session_config_try.rb
@@ -35,7 +35,7 @@ SessionDefaults['same_site']
 ## SESSION_DEFAULTS has expected structure
 keys = SessionDefaults.keys.sort
 keys
-#=> ['expire_after', 'httponly', 'key', 'same_site']
+#=> ['expire_after', 'httponly', 'key', 'same_site', 'skip_paths']
 
 ## SESSION_DEFAULTS is frozen (immutable)
 SessionDefaults.frozen?

--- a/try/unit/middleware/health_access_control_try.rb
+++ b/try/unit/middleware/health_access_control_try.rb
@@ -11,7 +11,13 @@
 # sees PATH_INFO with the mount prefix stripped. The paths it matches are
 # therefore /health and /health/* — which covers the auth app's externally
 # visible /auth/health, since that arrives as SCRIPT_NAME='/auth' +
-# PATH_INFO='/health'.
+# PATH_INFO='/health' (full auth mode; in other modes the auth app is
+# unmounted and no app routes /auth/health at all).
+#
+# Matching is on the NORMALIZED path (Otto::Utils.normalize_path — unescape,
+# strip one trailing slash), the same canonicalization the Otto router applies
+# before dispatch. Gating the raw string would let `/health/` or
+# `/health%2Fadvanced` through to the handler ungated.
 #
 # IP classification is delegated to Otto::Privacy::IPPrivacy.private_or_localhost?
 #
@@ -66,10 +72,26 @@ end
 #=> true
 
 ## health_endpoint? - Does NOT match a mount-relative /auth/health
-## No app is mounted such that PATH_INFO equals '/auth/health'; the auth app's
-## health endpoint reaches this middleware as PATH_INFO='/health'.
+## No app ROUTES a PATH_INFO of '/auth/health': in full mode the auth app's
+## health endpoint reaches this middleware as PATH_INFO='/health'; in other
+## modes the auth app is unmounted and the request 404s at core's router, so
+## a literal branch here would only gate a 404.
 @middleware.health_endpoint?('/auth/health')
 #=> false
+
+## health_endpoint? - Matches /health/ (trailing slash — the router strips it
+## before dispatch, so the gate must too)
+@middleware.health_endpoint?('/health/')
+#=> true
+
+## health_endpoint? - Matches /health%2Fadvanced (percent-encoded — the router
+## unescapes before dispatch, so the gate must too)
+@middleware.health_endpoint?('/health%2Fadvanced')
+#=> true
+
+## health_endpoint? - Matches /%68ealth (percent-encoded first segment)
+@middleware.health_endpoint?('/%68ealth')
+#=> true
 
 ## health_endpoint? - Does NOT match root path
 @middleware.health_endpoint?('/')
@@ -236,6 +258,19 @@ Otto::Privacy::IPPrivacy.private_or_localhost?('not_an_ip')
 
 ## call - Blocks /health/advanced from public IP 1.1.1.1
 @env = create_env('/health/advanced', '1.1.1.1')
+@status, @headers, @body = @middleware.call(@env)
+@status
+#=> 403
+
+## call - Blocks the percent-encoded alias /health%2Fadvanced from a public IP
+## (the router would dispatch it as /health/advanced, so the gate must catch it)
+@env = create_env('/health%2Fadvanced', '8.8.8.8')
+@status, @headers, @body = @middleware.call(@env)
+@status
+#=> 403
+
+## call - Blocks /health/ (trailing slash) from a public IP
+@env = create_env('/health/', '8.8.8.8')
 @status, @headers, @body = @middleware.call(@env)
 @status
 #=> 403

--- a/try/unit/middleware/health_access_control_try.rb
+++ b/try/unit/middleware/health_access_control_try.rb
@@ -4,9 +4,14 @@
 
 # Tests for Onetime::Middleware::HealthAccessControl
 #
-# This middleware restricts health check endpoints (/health, /health/*, /auth/health)
-# to requests from localhost and private network IPs.
-# Public IPs receive a 403 JSON error response.
+# This middleware restricts health check endpoints to requests from localhost
+# and private network IPs. Public IPs receive a 403 JSON error response.
+#
+# Matching is MOUNT-RELATIVE: the middleware runs inside Rack::URLMap, so it
+# sees PATH_INFO with the mount prefix stripped. The paths it matches are
+# therefore /health and /health/* — which covers the auth app's externally
+# visible /auth/health, since that arrives as SCRIPT_NAME='/auth' +
+# PATH_INFO='/health'.
 #
 # IP classification is delegated to Otto::Privacy::IPPrivacy.private_or_localhost?
 #
@@ -55,9 +60,16 @@ end
 @middleware.health_endpoint?('/health/foo/bar/baz')
 #=> true
 
-## health_endpoint? - Matches /auth/health path
-@middleware.health_endpoint?('/auth/health')
+## health_endpoint? - Matches /health under ANY mount (auth app sees /health
+## after URLMap strips the '/auth' prefix into SCRIPT_NAME)
+@middleware.health_endpoint?('/health')
 #=> true
+
+## health_endpoint? - Does NOT match a mount-relative /auth/health
+## No app is mounted such that PATH_INFO equals '/auth/health'; the auth app's
+## health endpoint reaches this middleware as PATH_INFO='/health'.
+@middleware.health_endpoint?('/auth/health')
+#=> false
 
 ## health_endpoint? - Does NOT match root path
 @middleware.health_endpoint?('/')
@@ -185,8 +197,10 @@ Otto::Privacy::IPPrivacy.private_or_localhost?('not_an_ip')
 @status
 #=> 200
 
-## call - Allows /auth/health from 192.168.1.1
-@env = create_env('/auth/health', '192.168.1.1')
+## call - Allows the auth app's health endpoint from 192.168.1.1
+## Externally /auth/health; mount-relative PATH_INFO is '/health'.
+@env = create_env('/health', '192.168.1.1')
+@env['SCRIPT_NAME'] = '/auth'
 @status, @headers, @body = @middleware.call(@env)
 @status
 #=> 200
@@ -226,8 +240,10 @@ Otto::Privacy::IPPrivacy.private_or_localhost?('not_an_ip')
 @status
 #=> 403
 
-## call - Blocks /auth/health from public IP 203.0.113.50
-@env = create_env('/auth/health', '203.0.113.50')
+## call - Blocks the auth app's health endpoint from public IP 203.0.113.50
+## Externally /auth/health; mount-relative PATH_INFO is '/health'.
+@env = create_env('/health', '203.0.113.50')
+@env['SCRIPT_NAME'] = '/auth'
 @status, @headers, @body = @middleware.call(@env)
 @status
 #=> 403


### PR DESCRIPTION
Closes #3997

## Problem

Every request through the universal middleware stack minted and persisted a session — including anonymous probe endpoints that never present the cookie back. A Kubernetes liveness probe polling `/health` every 10s sustained ~8,640 orphan `session:<64-hex>` keys (24h TTL each) in Valkey per prober, each carrying IP/user-agent metadata for a subject that does not exist.

## Change

- **`Onetime::Middleware::SessionSkip`** (new), mounted immediately after `Onetime::Session`: sets `env['rack.session.options'][:skip] = true` for configured paths. rack-session's `commit_session?` short-circuits on `:skip`, suppressing both the Valkey write and the `Set-Cookie`.
- **`CsrfResponseHeader` guard**: it called `Rack::Protection::AuthenticityToken.token(session)` on every request, dirtying the session (`session[:csrf] ||= …`); now gated on the skip flag.
- **Config key `site.session.skip_paths`** (YAML defaults + `SESSION_DEFAULTS` + Zod contract/shape), defaulting to `/health`, `/health/advanced`, `/auth/health`, `/api/v{1,2,3}/status`.
- **`HealthAccessControl`**: removed the dead mount-relative `/auth/health` branch and corrected the docs; coupled tryout updated.

### Two deviations from the issue text

1. **Matcher input**: the issue suggested `SCRIPT_NAME + PATH_INFO` *or* `application_context[:prefix]`. The prefix variant is wrong — core's prefix is `'/'`, yielding `'//health'`. The matcher uses exact equality on `env['SCRIPT_NAME'] + env['PATH_INFO']`.
2. **Acceptance criterion 6** ("changes recorded by the config-change logger") is unmeetable as written: the only `ConfigChangeLogger` is per-custom-domain and requires domain/org/actor context; there is no static-config diff logger. The skip list is config-visible and follows the new-config-key checklist in `lib/onetime/config.rb:13-26`, which is the closest existing mechanism. Detailed in an issue comment.

## Scope guard

`/api/v*/secret/:identifier/status` and `POST /api/v*/secret/status` are capability-token data reads audited via SecretActivity and keep full session behavior. Exact-match-only matching plus explicit negative tests enforce this — a substring-matching mutant fails exactly those examples.

## Testing

122 new examples, 0 failures:

- Unit matcher table (41): six probe paths skip; `/api/v2/secret/abc/status`, `/statusboard`, `/health-check`, trailing slash, case variants, and traversal shapes do not.
- Unit CSRF guard (32): no token minted under skip; unchanged otherwise.
- Integration, all modes + real Valkey (40, also green on PostgreSQL): cookieless probes create zero `session:*` string keys and no `Set-Cookie`/`X-CSRF-Token`, including a 100-request `/health` loop; an existing session cookie presented to a skipped path survives with value and TTL intact; secret-status routes unaffected.
- Integration, full mode (9): same assertions for `/auth/health`, with a `/auth` control proving suppression is path-scoped, not mount-scoped.

Non-vacuity was checked with throwaway mutants (always-false skip, PATH_INFO-only matcher, substring matcher) — each reds the intended examples.

Regression: unit lane green (7,361 tryout cases + 3,303 spec:fast examples); simple/full-sqlite/disabled lanes green apart from failures reproduced on pristine HEAD (`domain_sender_config_spec` hits real AWS credentials on the dev box; `security_features_spec` has a pre-existing suite-isolation env leak).

## Rollback

Remove the `builder.use Onetime::Middleware::SessionSkip` line; the config key is inert without it.

## Behavior change: `/auth/health` in simple mode returns 404 (was 403)

Removing `HealthAccessControl`'s dead literal `/auth/health` branch means that in **simple mode** (auth app not mounted), an untrusted-IP request to `/auth/health` now gets the router's **404** instead of the middleware's **403**. This is deliberate — indistinguishable-from-absent is the better posture and matches `AdminNetworkIsolation` — but if you have monitors keyed on the 403, update them. Full mode is unchanged (`/auth/health` is mount-relative-matched and still access-controlled). Tracked with other follow-ups in #4007.
