### PR TITLE
fix(workspace): keep recipient field in generate-password mode

### DIFF
--- a/src/apps/workspace/components/forms/WorkspaceSecretForm.vue
+++ b/src/apps/workspace/components/forms/WorkspaceSecretForm.vue
@@ -200,12 +200,12 @@
   // Track selected action from SplitButton
   const selectedAction = ref<'create-link' | 'generate-password'>('create-link');
 
-  // Recipient field shows in create-link mode unless ui.capabilities.recipient
-  // is explicitly disabled. An unset flag is treated as enabled (config default).
+  // Recipient field shows in both modes unless ui.capabilities.recipient is
+  // explicitly disabled. An unset flag is treated as enabled (config default).
+  // Generated passwords are mailed too, so hiding the field in generate mode
+  // silently dropped the only way to reach the recipient.
   const { uiCapabilities } = storeToRefs(bootstrapStore);
-  const showRecipient = computed(
-    () => selectedAction.value === 'create-link' && uiCapabilities.value?.recipient !== false
-  );
+  const showRecipient = computed(() => uiCapabilities.value?.recipient !== false);
 
   // Platform detection for keyboard hint (desktop only)
   const isDesktop = useMediaQuery('(min-width: 640px)');
@@ -327,7 +327,7 @@
             </div>
           </div>
 
-          <!-- Recipient Field (create-link mode only) -->
+          <!-- Recipient Field (both modes: generated passwords are mailed too) -->
           <div
             v-if="showRecipient"
             class="mt-4">

--- a/src/apps/workspace/components/forms/WorkspaceSecretForm.vue
+++ b/src/apps/workspace/components/forms/WorkspaceSecretForm.vue
@@ -327,36 +327,6 @@
             </div>
           </div>
 
-          <!-- Recipient Field (both modes: generated passwords are mailed too) -->
-          <div
-            v-if="showRecipient"
-            class="mt-4">
-            <label
-              for="workspace-recipient"
-              class="mb-1 block font-brand text-sm text-gray-600 dark:text-gray-300">
-              {{ t('web.COMMON.secret_recipient_address') || 'Email Recipient' }}
-            </label>
-            <div class="relative">
-              <input
-                id="workspace-recipient"
-                :value="form.recipient"
-                type="email"
-                name="recipient[]"
-                autocomplete="email"
-                :placeholder="t('web.COMMON.email_placeholder')"
-                :class="[cornerClass]"
-                class="w-full border border-gray-200/60 bg-white/80 backdrop-blur-sm
-                  py-2.5 pl-4 pr-4 text-sm text-gray-900 placeholder:text-gray-400
-                  transition-colors duration-200
-                  hover:border-gray-300/80 hover:bg-white/90
-                  focus:border-blue-500/80 focus:bg-white focus:outline-none focus:ring-4 focus:ring-blue-500/20
-                  dark:border-gray-700/60 dark:bg-slate-800/80 dark:text-white dark:placeholder:text-gray-500
-                  dark:hover:border-gray-600/80 dark:hover:bg-slate-800/90
-                  dark:focus:border-blue-400/80 dark:focus:bg-slate-800 dark:focus:ring-blue-400/20"
-                @input="(e) => operations.updateField('recipient', (e.target as HTMLInputElement).value)" />
-            </div>
-          </div>
-
           <!-- Generate Password display for Generate mode -->
           <div
             v-show="selectedAction === 'generate-password'"
@@ -414,6 +384,40 @@
                 class="mx-auto max-w-md text-gray-600 dark:text-gray-300">
                 {{ t('web.homepage.password_generation_description') }}
               </p>
+            </div>
+          </div>
+
+          <!--
+            Recipient Field, shown in both modes: generated passwords are
+            mailed too. It sits below the content area and the generator panel
+            so the reading order stays "what gets shared" then "who receives it".
+          -->
+          <div
+            v-if="showRecipient"
+            class="mt-4">
+            <label
+              for="workspace-recipient"
+              class="mb-1 block font-brand text-sm text-gray-600 dark:text-gray-300">
+              {{ t('web.COMMON.secret_recipient_address') || 'Email Recipient' }}
+            </label>
+            <div class="relative">
+              <input
+                id="workspace-recipient"
+                :value="form.recipient"
+                type="email"
+                name="recipient[]"
+                autocomplete="email"
+                :placeholder="t('web.COMMON.email_placeholder')"
+                :class="[cornerClass]"
+                class="w-full border border-gray-200/60 bg-white/80 backdrop-blur-sm
+                  py-2.5 pl-4 pr-4 text-sm text-gray-900 placeholder:text-gray-400
+                  transition-colors duration-200
+                  hover:border-gray-300/80 hover:bg-white/90
+                  focus:border-blue-500/80 focus:bg-white focus:outline-none focus:ring-4 focus:ring-blue-500/20
+                  dark:border-gray-700/60 dark:bg-slate-800/80 dark:text-white dark:placeholder:text-gray-500
+                  dark:hover:border-gray-600/80 dark:hover:bg-slate-800/90
+                  dark:focus:border-blue-400/80 dark:focus:bg-slate-800 dark:focus:ring-blue-400/20"
+                @input="(e) => operations.updateField('recipient', (e.target as HTMLInputElement).value)" />
             </div>
           </div>
         </div>

--- a/src/shared/composables/useSecretConcealer.ts
+++ b/src/shared/composables/useSecretConcealer.ts
@@ -110,8 +110,12 @@ export function useSecretConcealer(options?: SecretConcealerOptions) {
         type,
       });
 
-      // Skip validation for generate operations
-      if (type === 'conceal' && !validation.validate()) {
+      // Generate mode skips full-form validation (the schema requires
+      // `secret`, which isn't user-typed there) but recipient is still
+      // user input and still gets mailed, so it's checked on its own.
+      const isValid =
+        type === 'conceal' ? validation.validate() : validation.validateRecipient();
+      if (!isValid) {
         throw createError('Please check the form for errors', 'human');
       }
 

--- a/src/shared/composables/useSecretForm.ts
+++ b/src/shared/composables/useSecretForm.ts
@@ -11,6 +11,7 @@ export interface SecretFormState {
   validation: {
     errors: Map<keyof SecretFormData, string>;
     validate: () => boolean;
+    validateRecipient: () => boolean;
   };
   operations: {
     updateField: <K extends keyof SecretFormData>(field: K, value: SecretFormData[K]) => void;
@@ -146,6 +147,20 @@ export function useSecretForm() {
         }
 
         return errors.size === 0;
+      },
+
+      // Recipient-only check for flows that skip full-form validation (e.g.
+      // generate mode, where `secret` isn't user-typed so the full schema
+      // can't pass). Recipient is still user input in that mode and still
+      // gets mailed, so it needs its own format check.
+      validateRecipient: () => {
+        const result = formSchema.shape.recipient.safeParse(form.recipient);
+        errors.delete('recipient');
+        if (!result.success) {
+          errors.set('recipient', result.error.issues[0]?.message ?? 'Invalid recipient email');
+          return false;
+        }
+        return true;
       },
     },
     operations,

--- a/src/tests/components/WorkspaceSecretFormCapabilities.spec.ts
+++ b/src/tests/components/WorkspaceSecretFormCapabilities.spec.ts
@@ -5,6 +5,7 @@ import { createTestingPinia } from '@pinia/testing';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ref } from 'vue';
 import WorkspaceSecretForm from '@/apps/workspace/components/forms/WorkspaceSecretForm.vue';
+import SplitButton from '@/shared/components/ui/SplitButton.vue';
 
 vi.mock('@/shared/composables/useDomainContext', () => ({
   useDomainContext: vi.fn(() => ({
@@ -93,6 +94,12 @@ describe('WorkspaceSecretForm - recipient capability gating', () => {
 
   it('shows the recipient field when the capability flag is unset (default enabled)', () => {
     const wrapper = mountForm(undefined);
+    expect(wrapper.find(RECIPIENT_SELECTOR).exists()).toBe(true);
+  });
+
+  it('keeps the recipient field after switching to generate-password mode', async () => {
+    const wrapper = mountForm(undefined);
+    await wrapper.findComponent(SplitButton).vm.$emit('update:action', 'generate-password');
     expect(wrapper.find(RECIPIENT_SELECTOR).exists()).toBe(true);
   });
 });

--- a/src/tests/composables/useSecretConcealer.spec.ts
+++ b/src/tests/composables/useSecretConcealer.spec.ts
@@ -136,6 +136,23 @@ describe('useSecretConcealer', () => {
 
       expect(vi.mocked(useSecretStore)).toHaveBeenCalled();
     });
+
+    it('rejects generate submission with a malformed recipient email', async () => {
+      const store = {
+        conceal: vi.fn(),
+        generate: vi.fn(),
+        setApiMode: vi.fn(),
+      };
+      vi.mocked(useSecretStore).mockReturnValue(store);
+
+      const { form, operations, submit } = useSecretConcealer();
+      operations.updateField('recipient', 'not-an-email');
+
+      await submit('generate');
+
+      expect(form.recipient).toBe('not-an-email');
+      expect(store.generate).not.toHaveBeenCalled();
+    });
   });
 
   describe('API mode selection', () => {


### PR DESCRIPTION
Fixes #4009.

Picking Generate Password from the split button unmounts the recipient input, so the generated password never gets mailed and the link is the only way to share it. Fill in a recipient before switching and the same submit does send the mail, so the result depends on the order you click things.

`createPayload` in `useSecretConcealer.ts` already sends `recipient` for both `conceal` and `generate`, and the generate path reaches `send_email_to_recipient` on the server, so dropping the `selectedAction === 'create-link'` term from `showRecipient` is the whole fix.

The second commit moves the field below the generator panel. The textarea is hidden in that mode, so the input was otherwise the first thing in the card, sitting above the box that explains a password will be generated.

The new case in `WorkspaceSecretFormCapabilities.spec.ts` fails on the old code and passes on the new one. Reported on v0.26.3, same code path on main.
