### PR TITLE
fix: add configurable TTL_CEILING for self-hosted deployments (#4008)

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -218,8 +218,10 @@ STDOUT_SYNC=false
 # ═══════════════════════════════════════════════════════════
 
 # Available TTL choices for users (space-separated seconds).
-# Example: '300 3600 86400 604800 2592000'
-#           5m   1h    1d    7d     30d
+# Values up to 31536000 (365 days) are supported. Plan limits and
+# anonymous ceilings still apply on top of whatever is listed here.
+# Example: '300 3600 86400 604800 2592000 7776000 31536000'
+#           5m   1h    1d    7d     30d     90d     365d
 #TTL_OPTIONS=
 
 # Default TTL when not specified (seconds). Default: 604800 (7 days)

--- a/.env.reference
+++ b/.env.reference
@@ -218,9 +218,10 @@ STDOUT_SYNC=false
 # ═══════════════════════════════════════════════════════════
 
 # Available TTL choices for users (space-separated seconds).
-# Values up to TTL_CEILING are shown in the UI; values above it are
-# silently clamped. Plan limits and anonymous ceilings still apply
-# independently on top of whatever is listed here.
+# The UI filters these against the effective ceiling (TTL_CEILING,
+# plan limit, or anonymous cap — whichever is lowest). Values above
+# the ceiling are hidden from the dropdown. Plan limits and anonymous
+# ceilings still apply independently on top of whatever is listed here.
 # Example: '300 3600 86400 604800 2592000 7776000 31536000'
 #           5m   1h    1d    7d     30d     90d     365d
 #TTL_OPTIONS=

--- a/.env.reference
+++ b/.env.reference
@@ -218,14 +218,23 @@ STDOUT_SYNC=false
 # ═══════════════════════════════════════════════════════════
 
 # Available TTL choices for users (space-separated seconds).
-# Values up to 31536000 (365 days) are supported. Plan limits and
-# anonymous ceilings still apply on top of whatever is listed here.
+# Values up to TTL_CEILING are shown in the UI; values above it are
+# silently clamped. Plan limits and anonymous ceilings still apply
+# independently on top of whatever is listed here.
 # Example: '300 3600 86400 604800 2592000 7776000 31536000'
 #           5m   1h    1d    7d     30d     90d     365d
 #TTL_OPTIONS=
 
 # Default TTL when not specified (seconds). Default: 604800 (7 days)
 #DEFAULT_TTL=604800
+
+# Absolute TTL ceiling applied to ALL secrets (seconds).
+# Default: 3888000 (45 days = 30 days + 50% grace period).
+# Max: 31536000 (365 days). Always enforced regardless of TTL_OPTIONS.
+# Self-hosted operators who want longer-lived secrets should raise this
+# AND add matching values to TTL_OPTIONS so the UI shows them.
+# Plan limits and anonymous ceilings still apply independently.
+#TTL_CEILING=3888000
 
 # Maximum TTL for secrets created without an account (seconds).
 # Default: 604800 (7 days). Max: 31536000 (365 days).

--- a/apps/api/v2/logic/secrets/base_secret_action.rb
+++ b/apps/api/v2/logic/secrets/base_secret_action.rb
@@ -125,8 +125,11 @@ module V2::Logic
           require_entitlement!('extended_default_expiration')
         end
 
-        # Apply a global maximum
-        @ttl = 30.days if ttl && ttl >= 30.days
+        # Apply the absolute safety ceiling (365 days). Plan/config limits
+        # are enforced by the bounds check below; this prevents resource
+        # exhaustion from values beyond any reasonable secret lifetime.
+        max_ttl_ceiling = Onetime::Models::Features::WithEntitlements::MAX_TTL
+        @ttl = max_ttl_ceiling if ttl && ttl >= max_ttl_ceiling
 
         # Enforce bounds
         @ttl = min_ttl if ttl < min_ttl

--- a/apps/api/v2/logic/secrets/base_secret_action.rb
+++ b/apps/api/v2/logic/secrets/base_secret_action.rb
@@ -129,7 +129,7 @@ module V2::Logic
         # raise it via TTL_CEILING env var for self-hosted deployments.
         # Plan/config limits are enforced by the bounds check below.
         ttl_ceiling = Onetime::Models::Features::WithEntitlements.configured_ttl_ceiling
-        @ttl = ttl_ceiling if ttl && ttl > ttl_ceiling
+        @ttl = ttl_ceiling if ttl > ttl_ceiling
 
         # Enforce bounds
         @ttl = min_ttl if ttl < min_ttl

--- a/apps/api/v2/logic/secrets/base_secret_action.rb
+++ b/apps/api/v2/logic/secrets/base_secret_action.rb
@@ -125,11 +125,11 @@ module V2::Logic
           require_entitlement!('extended_default_expiration')
         end
 
-        # Apply the absolute safety ceiling (365 days). Plan/config limits
-        # are enforced by the bounds check below; this prevents resource
-        # exhaustion from values beyond any reasonable secret lifetime.
-        max_ttl_ceiling = Onetime::Models::Features::WithEntitlements::MAX_TTL
-        @ttl = max_ttl_ceiling if ttl && ttl >= max_ttl_ceiling
+        # Apply the configured TTL ceiling (default: 45 days). Operators
+        # raise it via TTL_CEILING env var for self-hosted deployments.
+        # Plan/config limits are enforced by the bounds check below.
+        ttl_ceiling = Onetime::Models::Features::WithEntitlements.configured_ttl_ceiling
+        @ttl = ttl_ceiling if ttl && ttl > ttl_ceiling
 
         # Enforce bounds
         @ttl = min_ttl if ttl < min_ttl

--- a/apps/web/core/spec/views/base_spec.rb
+++ b/apps/web/core/spec/views/base_spec.rb
@@ -76,15 +76,16 @@ RSpec.describe Core::Views::BaseView do
       )
     end
 
-    # ttl_max_anonymous is not config: ConfigSerializer appends the hard
-    # anonymous TTL cap (WithEntitlements::ANONYMOUS_MAX_TTL) so the duration
-    # dropdown can filter out durations the server would clamp. Emitted on
-    # every deployment, billing enabled or not.
-    it 'includes secret options plus the anonymous TTL ceiling' do
+    # ttl_max_anonymous and ttl_ceiling are not raw config: ConfigSerializer
+    # appends the resolved anonymous TTL cap and global TTL ceiling so the
+    # duration dropdown can filter out durations the server would clamp.
+    # Emitted on every deployment, billing enabled or not.
+    it 'includes secret options plus the anonymous TTL ceiling and global TTL ceiling' do
       expect(subject.serialized_data['secret_options']).to eq({
         'default_ttl' => 86_400,
         'ttl_options' => [3600, 86_400],
         'ttl_max_anonymous' => Onetime::Models::Features::WithEntitlements::ANONYMOUS_MAX_TTL,
+        'ttl_ceiling' => Onetime::Models::Features::WithEntitlements::DEFAULT_TTL_CEILING,
       },
                                                              )
     end

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -136,7 +136,10 @@ module Core
           secret_options = site['secret_options']
           return secret_options unless secret_options.is_a?(Hash)
 
-          secret_options.merge('ttl_max_anonymous' => anonymous_ttl_ceiling)
+          secret_options.merge(
+            'ttl_max_anonymous' => anonymous_ttl_ceiling,
+            'ttl_ceiling' => Onetime::Models::Features::WithEntitlements.configured_ttl_ceiling,
+          )
         end
 
         # Anonymous TTL ceiling for the duration dropdown (2026-07-29 API

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -222,6 +222,11 @@ site:
     # These options will be presented to users when they create a new secret
     # Format: String of integers representing seconds
     ttl_options: <%= (ENV['TTL_OPTIONS'] || nil) %>
+    # Absolute TTL ceiling applied to all secrets, regardless of ttl_options.
+    # Default: 3888000 (45 days = 30 days + 50% grace period). Operators on
+    # self-hosted deployments can raise this up to 31536000 (365 days) to
+    # allow longer-lived secrets. Plan limits still apply independently.
+    ttl_ceiling: <%= ENV['TTL_CEILING'] || nil %>
     # Maximum TTL for secrets created without an account (anonymous callers).
     # Default: 604800 (7 days) — a sane default, not a hard limit. Self-hosted
     # deployments may raise or lower it; the effective ceiling is the lower of

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -40,7 +40,7 @@ module Onetime
             # These DEFAULTS are the effective values when the YAML config
             # sets ttl_options to nil (e.g. no TTL_OPTIONS env var). The
             # deep_merge nil-preservation rule means nil in YAML keeps
-            # this array intact. The max here (365.days) becomes the global
+            # this array intact. The max here (30.days) becomes the global
             # TTL ceiling — override via TTL_OPTIONS env var in production
             # if a lower cap is needed.
             'ttl_options' => [
@@ -55,10 +55,11 @@ module Onetime
               1.week,         # 604800
               2.weeks,        # 1209600
               30.days,        # 2592000
-              90.days,        # 7776000
-              180.days,       # 15552000
-              365.days,       # 31536000
             ],
+            # Absolute TTL ceiling applied to all secrets, regardless of
+            # ttl_options. Default: nil (uses DEFAULT_TTL_CEILING = 45 days).
+            # Operators raise via TTL_CEILING env var (max: 365 days).
+            'ttl_ceiling' => nil,
             # Ceiling for secrets created without an account. A default, not an
             # invariant: operators may raise or lower it (env TTL_MAX_ANONYMOUS).
             # Resolved and bounded by
@@ -506,6 +507,16 @@ module Onetime
         parsed = Integer(ttl_max_anonymous.to_s.strip, exception: false)
         unless parsed.nil?
           conf['site']['secret_options']['ttl_max_anonymous'] = parsed
+        end
+      end
+
+      # Same treatment for ttl_ceiling: ERB returns String from TTL_CEILING.
+      # Malformed values are left for configured_ttl_ceiling to reject loudly.
+      ttl_ceiling = conf.dig('site', 'secret_options', 'ttl_ceiling')
+      unless ttl_ceiling.nil? || ttl_ceiling.is_a?(Integer)
+        parsed = Integer(ttl_ceiling.to_s.strip, exception: false)
+        unless parsed.nil?
+          conf['site']['secret_options']['ttl_ceiling'] = parsed
         end
       end
 

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -40,7 +40,7 @@ module Onetime
             # These DEFAULTS are the effective values when the YAML config
             # sets ttl_options to nil (e.g. no TTL_OPTIONS env var). The
             # deep_merge nil-preservation rule means nil in YAML keeps
-            # this array intact. The max here (30.days) becomes the global
+            # this array intact. The max here (365.days) becomes the global
             # TTL ceiling — override via TTL_OPTIONS env var in production
             # if a lower cap is needed.
             'ttl_options' => [
@@ -55,6 +55,9 @@ module Onetime
               1.week,         # 604800
               2.weeks,        # 1209600
               30.days,        # 2592000
+              90.days,        # 7776000
+              180.days,       # 15552000
+              365.days,       # 31536000
             ],
             # Ceiling for secrets created without an account. A default, not an
             # invariant: operators may raise or lower it (env TTL_MAX_ANONYMOUS).

--- a/lib/onetime/models/features/with_entitlements.rb
+++ b/lib/onetime/models/features/with_entitlements.rb
@@ -53,6 +53,13 @@ module Onetime
         # plan. See #3111 for the drift bug this constant previously caused.
         DEFAULT_FREE_TTL = 1_209_600  # 14 days
 
+        # Default TTL ceiling for all secrets: 30 days + 50% grace period.
+        # Always enforced regardless of ttl_options. Operators raise it via
+        # TTL_CEILING env var (up to MAX_TTL). The grace period allows a
+        # request slightly above 30 days to succeed without requiring the
+        # operator to explicitly reconfigure.
+        DEFAULT_TTL_CEILING = 45 * 24 * 60 * 60  # 45 days
+
         # Default ceiling for secrets created by anonymous (unauthenticated)
         # callers: 7 days. This is the shipped default, NOT an invariant.
         #
@@ -102,6 +109,31 @@ module Onetime
           OT.le "[WithEntitlements] ttl_max_anonymous unreadable (#{ex.class}: #{ex.message}); " \
                 "using default #{ANONYMOUS_MAX_TTL}"
           ANONYMOUS_MAX_TTL
+        end
+
+        # Resolve the configured TTL ceiling.
+        #
+        # Always enforced as the global maximum TTL, independent of
+        # ttl_options. Operators set TTL_CEILING to allow longer-lived
+        # secrets on self-hosted deployments. Bounded to [1, MAX_TTL].
+        #
+        # @return [Integer] Global TTL ceiling in seconds
+        def self.configured_ttl_ceiling
+          raw = OT.conf.dig('site', 'secret_options', 'ttl_ceiling')
+          return DEFAULT_TTL_CEILING if raw.nil?
+
+          value = Integer(raw)
+          return DEFAULT_TTL_CEILING unless value.positive?
+
+          value.clamp(1, MAX_TTL)
+        rescue ArgumentError, TypeError
+          OT.lw '[WithEntitlements] Invalid site.secret_options.ttl_ceiling, using default',
+            { value: raw.inspect, default: DEFAULT_TTL_CEILING }
+          DEFAULT_TTL_CEILING
+        rescue StandardError => ex
+          OT.le "[WithEntitlements] ttl_ceiling unreadable (#{ex.class}: #{ex.message}); " \
+                "using default #{DEFAULT_TTL_CEILING}"
+          DEFAULT_TTL_CEILING
         end
 
         def self.included(base)

--- a/spec/api/v2/secret_ttl_entitlement_spec.rb
+++ b/spec/api/v2/secret_ttl_entitlement_spec.rb
@@ -243,11 +243,94 @@ RSpec.describe 'API V2 Secret TTL Entitlement Gate', type: :integration, billing
     end
   end
 
+  TTL_CEILING = Onetime::Models::Features::WithEntitlements::DEFAULT_TTL_CEILING
+
+  shared_examples 'TTL ceiling enforcement (#4008)' do |logic_class_proc|
+    let(:logic_class) { logic_class_proc.call }
+
+    def conceal_params(ttl)
+      { 'secret' => { 'secret' => 'test value', 'ttl' => ttl.to_s } }
+    end
+
+    context 'with the default TTL ceiling (45 days)' do
+      let(:org) do
+        mock_organization(
+          planid: 'identity_plus_v1',
+          entitlements: %w[create_secrets api_access extended_default_expiration],
+          secret_lifetime: 365 * 24 * 60 * 60,
+        )
+      end
+
+      it 'preserves a TTL at exactly the ceiling' do
+        logic = create_logic(logic_class, params: conceal_params(TTL_CEILING), org: org)
+        expect { logic.process_params }.not_to raise_error
+        expect(logic.ttl).to eq(TTL_CEILING)
+      end
+
+      it 'clamps a TTL above the ceiling to the ceiling' do
+        logic = create_logic(logic_class, params: conceal_params(TTL_CEILING + 1), org: org)
+        expect { logic.process_params }.not_to raise_error
+        expect(logic.ttl).to eq(TTL_CEILING)
+      end
+
+      it 'preserves a TTL below the ceiling' do
+        thirty_days = 30 * 24 * 60 * 60
+        logic = create_logic(logic_class, params: conceal_params(thirty_days), org: org)
+        expect { logic.process_params }.not_to raise_error
+        expect(logic.ttl).to eq(thirty_days)
+      end
+    end
+
+    context 'with an overridden TTL_CEILING' do
+      let(:org) do
+        mock_organization(
+          planid: 'identity_plus_v1',
+          entitlements: %w[create_secrets api_access extended_default_expiration],
+          secret_lifetime: 365 * 24 * 60 * 60,
+        )
+      end
+
+      it 'respects a raised ceiling (90 days)' do
+        ninety_days = 90 * 24 * 60 * 60
+        allow(OT).to receive(:conf).and_return(
+          'site' => {
+            'secret_options' => {
+              'default_ttl' => 7 * 24 * 60 * 60,
+              'ttl_options' => [60, 3600, 86_400, 604_800, 2_592_000, ninety_days],
+              'ttl_ceiling' => ninety_days,
+              'password_generation' => { 'default_length' => 12 },
+            },
+            'interface' => {
+              'api' => {
+                'guest_routes' => {
+                  'enabled' => true,
+                  'conceal' => true, 'generate' => true, 'reveal' => true,
+                  'burn' => true, 'show' => true, 'receipt' => true,
+                },
+              },
+            },
+          },
+        )
+
+        logic = create_logic(logic_class, params: conceal_params(ninety_days), org: org)
+        expect { logic.process_params }.not_to raise_error
+        expect(logic.ttl).to eq(ninety_days)
+      end
+    end
+
+    it 'DEFAULT_TTL_CEILING resolves to 45 days' do
+      expect(TTL_CEILING).to eq(45 * 24 * 60 * 60)
+      expect(TTL_CEILING).to eq(3_888_000)
+    end
+  end
+
   describe V2::Logic::Secrets::ConcealSecret do
     include_examples 'extended_default_expiration TTL gate', -> { V2::Logic::Secrets::ConcealSecret }
+    include_examples 'TTL ceiling enforcement (#4008)', -> { V2::Logic::Secrets::ConcealSecret }
   end
 
   describe V2::Logic::Secrets::GenerateSecret do
     include_examples 'extended_default_expiration TTL gate', -> { V2::Logic::Secrets::GenerateSecret }
+    include_examples 'TTL ceiling enforcement (#4008)', -> { V2::Logic::Secrets::GenerateSecret }
   end
 end

--- a/spec/api/v2/secret_ttl_entitlement_spec.rb
+++ b/spec/api/v2/secret_ttl_entitlement_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe 'API V2 Secret TTL Entitlement Gate', type: :integration, billing
       it 'silently clamps when ttl exceeds the plan secret_lifetime ceiling' do
         logic = create_logic(logic_class, params: conceal_params(7_776_000), org: org)
         expect { logic.process_params }.not_to raise_error
-        # 30 days global cap applies first (line 130: `@ttl = 30.days if ttl >= 30.days`)
+        # Plan secret_lifetime ceiling (2,592,000) applies via bounds enforcement
         expect(logic.ttl).to eq(2_592_000)
       end
     end

--- a/spec/integration/all/config/after_load_spec.rb
+++ b/spec/integration/all/config/after_load_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe "Onetime boot configuration process", type: :integration do
       # OT::Config is going to supply its defaults. OT.conf is nil because
       # this testing code path starts each testcase with it nil on purpose
       # so there is no influence from the config.test.yaml. That's why
-      # there are 14 ttl_options and not 3 (from the yaml).
+      # there are 11 ttl_options and not 3 (from the yaml).
       raw_config = minimal_config.dup
 
       processed_config = Onetime::Config.after_load(raw_config)
@@ -299,7 +299,7 @@ RSpec.describe "Onetime boot configuration process", type: :integration do
 
       expect(secret_options['default_ttl']).to eq(7.days)
       expect(secret_options['ttl_options']).to be_an(Array)
-      expect(secret_options['ttl_options'].length).to eq(14)
+      expect(secret_options['ttl_options'].length).to eq(11)
     end
 
     it 'uses values from config file when specified' do

--- a/spec/integration/all/config/after_load_spec.rb
+++ b/spec/integration/all/config/after_load_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe "Onetime boot configuration process", type: :integration do
       # OT::Config is going to supply its defaults. OT.conf is nil because
       # this testing code path starts each testcase with it nil on purpose
       # so there is no influence from the config.test.yaml. That's why
-      # there are 11 ttl_options and not 3 (from the yaml).
+      # there are 14 ttl_options and not 3 (from the yaml).
       raw_config = minimal_config.dup
 
       processed_config = Onetime::Config.after_load(raw_config)
@@ -299,7 +299,7 @@ RSpec.describe "Onetime boot configuration process", type: :integration do
 
       expect(secret_options['default_ttl']).to eq(7.days)
       expect(secret_options['ttl_options']).to be_an(Array)
-      expect(secret_options['ttl_options'].length).to eq(11)
+      expect(secret_options['ttl_options'].length).to eq(14)
     end
 
     it 'uses values from config file when specified' do

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -368,8 +368,8 @@ export const passphraseSchema = z.object({
 export const secretOptionsSchema = z.object({
   default_ttl: z.number().int().positive().default(604800),
   ttl_options: z
-    .array(z.number().int().positive().min(60).max(2592000))
-    .default([300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000]),
+    .array(z.number().int().positive().min(60).max(31536000))
+    .default([300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000, 7776000, 15552000, 31536000]),
   /**
    * TTL ceiling the server silently applies to anonymous (guest) secrets, in
    * seconds. A hard product cap (7 days) that holds on every deployment,

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -381,6 +381,16 @@ export const secretOptionsSchema = z.object({
    * @sync lib/onetime/models/features/with_entitlements.rb — ANONYMOUS_MAX_TTL
    */
   ttl_max_anonymous: z.number().int().positive().nullish(),
+  /**
+   * Global TTL ceiling the server applies to ALL secrets regardless of auth
+   * status (seconds). Operators raise it via TTL_CEILING env var.
+   * Default: 3888000 (45 days). Max: 31536000 (365 days).
+   *
+   * @sync apps/web/core/views/serializers/config_serializer.rb — build_secret_options
+   * @sync apps/api/v2/logic/secrets/base_secret_action.rb — process_ttl
+   * @sync lib/onetime/models/features/with_entitlements.rb — configured_ttl_ceiling
+   */
+  ttl_ceiling: z.number().int().positive().nullish(),
   passphrase: passphraseSchema.optional(),
   password_generation: passwordGenerationSchema.optional(),
 });

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -369,7 +369,7 @@ export const secretOptionsSchema = z.object({
   default_ttl: z.number().int().positive().default(604800),
   ttl_options: z
     .array(z.number().int().positive().min(60).max(31536000))
-    .default([300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000, 7776000, 15552000, 31536000]),
+    .default([300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000]),
   /**
    * TTL ceiling the server silently applies to anonymous (guest) secrets, in
    * seconds. A hard product cap (7 days) that holds on every deployment,

--- a/src/schemas/shapes/config/section/secret_options.ts
+++ b/src/schemas/shapes/config/section/secret_options.ts
@@ -36,13 +36,13 @@ const secretOptionBoundariesShape = augment(secretOptionBoundariesSchema, {
    * Available TTL options for secret creation (in seconds).
    * @min 60 - One minute
    * @max 31536000 - 365 days
-   * @default [300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000, 7776000, 15552000, 31536000]
+   * @default [300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000]
    */
   ttl_options: () =>
     z
       .array(z.number().int().positive().min(60).max(31536000))
       .nullable()
-      .default([300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000, 7776000, 15552000, 31536000]),
+      .default([300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000]),
 
   /**
    * Maximum secret size in bytes

--- a/src/schemas/shapes/config/section/secret_options.ts
+++ b/src/schemas/shapes/config/section/secret_options.ts
@@ -35,14 +35,14 @@ const secretOptionBoundariesShape = augment(secretOptionBoundariesSchema, {
   /**
    * Available TTL options for secret creation (in seconds).
    * @min 60 - One minute
-   * @max 2592000 - 30 days
-   * @default [300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000]
+   * @max 31536000 - 365 days
+   * @default [300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000, 7776000, 15552000, 31536000]
    */
   ttl_options: () =>
     z
-      .array(z.number().int().positive().min(60).max(2592000))
+      .array(z.number().int().positive().min(60).max(31536000))
       .nullable()
-      .default([300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000]),
+      .default([300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000, 7776000, 15552000, 31536000]),
 
   /**
    * Maximum secret size in bytes

--- a/src/shared/composables/usePrivacyOptions.ts
+++ b/src/shared/composables/usePrivacyOptions.ts
@@ -95,14 +95,20 @@ export function usePrivacyOptions(formOperations?: {
     const positiveOrNull = (value: number | null | undefined) =>
       typeof value === 'number' && value > 0 ? value : null;
 
+    const globalCeiling = positiveOrNull(secret_options.value?.ttl_ceiling);
+
+    let ceiling: number | null;
     if (authenticated.value) {
-      // No org means the server never consults a plan limit, so neither do we.
-      // -1 (unlimited) and 0 (unset) both fall through to null.
       const organization = bootstrapStore.organization;
-      return organization ? positiveOrNull(organization.limits?.secret_lifetime) : null;
+      ceiling = organization ? positiveOrNull(organization.limits?.secret_lifetime) : null;
+    } else {
+      ceiling = positiveOrNull(secret_options.value?.ttl_max_anonymous);
     }
 
-    return positiveOrNull(secret_options.value?.ttl_max_anonymous);
+    if (globalCeiling !== null && ceiling !== null) {
+      return Math.min(ceiling, globalCeiling);
+    }
+    return globalCeiling ?? ceiling;
   });
 
   /**

--- a/src/shared/composables/usePrivacyOptions.ts
+++ b/src/shared/composables/usePrivacyOptions.ts
@@ -114,7 +114,7 @@ export function usePrivacyOptions(formOperations?: {
    * get and are never told about.
    */
   const lifetimeOptions = computed<LifetimeOption[]>(() => {
-    const globalTtl = 3600 * 24 * 30; // 30 days
+    const globalTtl = 3600 * 24 * 365; // 365 days (absolute safety ceiling)
     const ceiling = ttlCeiling.value;
 
     const available = (secret_options.value?.ttl_options ?? []).filter(

--- a/src/shared/composables/usePrivacyOptions.ts
+++ b/src/shared/composables/usePrivacyOptions.ts
@@ -114,7 +114,7 @@ export function usePrivacyOptions(formOperations?: {
    * get and are never told about.
    */
   const lifetimeOptions = computed<LifetimeOption[]>(() => {
-    const globalTtl = 3600 * 24 * 365; // 365 days (absolute safety ceiling)
+    const globalTtl = Math.floor(3600 * 24 * 365 * 1.5); // 1 year + 50% grace period
     const ceiling = ttlCeiling.value;
 
     const available = (secret_options.value?.ttl_options ?? []).filter(

--- a/src/tests/composables/usePrivacyOptions.spec.ts
+++ b/src/tests/composables/usePrivacyOptions.spec.ts
@@ -176,8 +176,9 @@ describe('usePrivacyOptions', () => {
       expect(values()).toEqual([]);
     });
 
-    it('still applies the 30-day global cap', () => {
-      setupStore({ ttl_options: [WEEK, THIRTY_DAYS + 1], ttl_max_anonymous: null });
+    it('still applies the global safety cap (1 year + 50% grace)', () => {
+      const ONE_YEAR_PLUS_GRACE = Math.floor(3600 * 24 * 365 * 1.5);
+      setupStore({ ttl_options: [WEEK, ONE_YEAR_PLUS_GRACE + 1], ttl_max_anonymous: null });
 
       expect(values()).toEqual([WEEK]);
     });

--- a/src/tests/composables/usePrivacyOptions.spec.ts
+++ b/src/tests/composables/usePrivacyOptions.spec.ts
@@ -42,6 +42,7 @@ const TTL_OPTIONS = [MINUTE, HOUR, DAY, WEEK, TWO_WEEKS, THIRTY_DAYS];
 interface StoreSetup {
   ttl_options?: number[];
   ttl_max_anonymous?: number | null;
+  ttl_ceiling?: number | null;
   authenticated?: boolean;
   secret_lifetime?: number | null;
   /** Authenticated with no organization at all (server skips the plan limit). */
@@ -57,6 +58,7 @@ function setupStore(config: StoreSetup = {}) {
     default_ttl: WEEK,
     ttl_options: config.ttl_options ?? TTL_OPTIONS,
     ttl_max_anonymous: config.ttl_max_anonymous ?? undefined,
+    ttl_ceiling: config.ttl_ceiling ?? undefined,
   };
   bootstrapStore.authenticated = config.authenticated ?? false;
 
@@ -181,6 +183,52 @@ describe('usePrivacyOptions', () => {
       setupStore({ ttl_options: [WEEK, ONE_YEAR_PLUS_GRACE + 1], ttl_max_anonymous: null });
 
       expect(values()).toEqual([WEEK]);
+    });
+  });
+
+  describe('lifetimeOptions — global TTL ceiling (#4008)', () => {
+    it('filters anonymous options by ttl_ceiling when present', () => {
+      setupStore({ ttl_ceiling: WEEK, ttl_max_anonymous: null });
+
+      expect(values()).toEqual([MINUTE, HOUR, DAY, WEEK]);
+    });
+
+    it('uses the lower of ttl_ceiling and ttl_max_anonymous', () => {
+      setupStore({ ttl_ceiling: THIRTY_DAYS, ttl_max_anonymous: WEEK });
+
+      expect(values()).toEqual([MINUTE, HOUR, DAY, WEEK]);
+    });
+
+    it('uses ttl_ceiling when it is lower than ttl_max_anonymous', () => {
+      setupStore({ ttl_ceiling: DAY, ttl_max_anonymous: WEEK });
+
+      expect(values()).toEqual([MINUTE, HOUR, DAY]);
+    });
+
+    it('applies ttl_ceiling to authenticated callers', () => {
+      setupStore({
+        authenticated: true,
+        secret_lifetime: THIRTY_DAYS,
+        ttl_ceiling: WEEK,
+      });
+
+      expect(values()).toEqual([MINUTE, HOUR, DAY, WEEK]);
+    });
+
+    it('uses the lower of ttl_ceiling and plan limit for authenticated callers', () => {
+      setupStore({
+        authenticated: true,
+        secret_lifetime: DAY,
+        ttl_ceiling: THIRTY_DAYS,
+      });
+
+      expect(values()).toEqual([MINUTE, HOUR, DAY]);
+    });
+
+    it('fails open when ttl_ceiling is absent (legacy payloads)', () => {
+      setupStore({ ttl_ceiling: null, ttl_max_anonymous: null });
+
+      expect(values()).toEqual(TTL_OPTIONS);
     });
   });
 

--- a/src/tests/schemas/shapes/config/secret_options.spec.ts
+++ b/src/tests/schemas/shapes/config/secret_options.spec.ts
@@ -43,13 +43,13 @@ describe('secretOptionBoundariesShape — TTL bounds', () => {
     expect(() => secretOptionBoundariesShape.parse({ ttl_options: [30] })).toThrow();
   });
 
-  it('rejects ttl_options entries above 30 days', () => {
-    expect(() => secretOptionBoundariesShape.parse({ ttl_options: [2592001] })).toThrow();
+  it('rejects ttl_options entries above 365 days', () => {
+    expect(() => secretOptionBoundariesShape.parse({ ttl_options: [31536001] })).toThrow();
   });
 
-  it('accepts boundary values 60s and 30 days', () => {
-    const result = secretOptionBoundariesShape.parse({ ttl_options: [60, 2592000] });
-    expect(result.ttl_options).toEqual([60, 2592000]);
+  it('accepts boundary values 60s and 365 days', () => {
+    const result = secretOptionBoundariesShape.parse({ ttl_options: [60, 31536000] });
+    expect(result.ttl_options).toEqual([60, 31536000]);
   });
 
   it('rejects non-positive default_ttl', () => {


### PR DESCRIPTION
## Summary

Fixes #4008 — TTL above 30 days doesn't work on self-hosted (non-Docker) installations.

Self-hosted installations were unable to create secrets with TTL above 30 days due to a hard-coded 30-day cap in the V2 API (`base_secret_action.rb:129`). Rather than raising all defaults to 365 days, this PR introduces a **configurable TTL ceiling** that keeps the default experience at 30 days max while letting self-hosted operators opt into longer-lived secrets.

### Approach: configurable `TTL_CEILING`

- **New env var `TTL_CEILING`** — absolute ceiling applied to ALL secrets, independent of `ttl_options`. Default: `3888000` (45 days = 30 days + 50% grace period). Max: `31536000` (365 days).
- **Default `ttl_options` unchanged** — the dropdown still tops out at 30 days. Operators who raise `TTL_CEILING` should also add matching values to `TTL_OPTIONS` so the UI shows them.
- **The 50% grace period** means a request slightly above 30 days succeeds without requiring the operator to explicitly reconfigure.

### Changes

| File | What changed |
|------|-------------|
| `apps/api/v2/logic/secrets/base_secret_action.rb` | Replaced unconditional `@ttl = 30.days` with `configured_ttl_ceiling` (default: 45 days). Changed `>=` to `>` so the ceiling value itself is valid. |
| `lib/onetime/models/features/with_entitlements.rb` | Added `DEFAULT_TTL_CEILING` constant and `configured_ttl_ceiling` class method (follows `configured_anonymous_max_ttl` pattern). |
| `lib/onetime/config.rb` | Reverted default `ttl_options` to 11 entries (max: 30 days). Added `ttl_ceiling` key with `after_load` coercion. |
| `etc/defaults/config.defaults.yaml` | Added `ttl_ceiling` config key with `TTL_CEILING` env var. |
| `.env.reference` | Documented `TTL_CEILING` env var and updated `TTL_OPTIONS` docs. |
| `src/shared/composables/usePrivacyOptions.ts` | Raised frontend safety filter from 365 days to 1 year + 50% grace. |
| `src/schemas/contracts/bootstrap.ts` | Raised `.max()` to 365 days; default array kept at 10 entries (max: 30 days). |
| `src/schemas/shapes/config/section/secret_options.ts` | Raised `.max()` to 365 days; default array kept at 10 entries (max: 30 days). |
| `spec/integration/all/config/after_load_spec.rb` | Updated expected ttl_options count to 11 (was briefly 14). |

### What's unchanged

- **V1 API**: `V1_MAX_TTL = 2_592_000` kept at 30 days for backward compatibility.
- **Default ttl_options**: Still 11 entries, max 30 days — no new options in the dropdown by default.
- **Plan limits**: Billing-enabled deployments still enforce per-plan `secret_lifetime` limits.
- **Entitlement gate**: `extended_default_expiration` still required for TTL above `DEFAULT_FREE_TTL` (14 days).
- **Anonymous ceiling**: `ANONYMOUS_MAX_TTL` (7 days default) still caps unauthenticated secrets.
- **Absolute safety ceiling**: `MAX_TTL` (365 days) in `WithEntitlements` remains the software-level bound.

### How self-hosted operators use it

```bash
# Allow secrets up to 90 days
TTL_CEILING=7776000
TTL_OPTIONS='300 1800 3600 14400 43200 86400 259200 604800 1209600 2592000 7776000'
```

With billing disabled (the default for self-hosted), `limit_for('secret_lifetime')` returns `Float::INFINITY` and `extended_default_expiration` is granted via `STANDALONE_ENTITLEMENTS`. The only effective caps are `TTL_CEILING` and plan limits.

## Test plan

- [ ] Verify existing V2 TTL entitlement specs pass
- [ ] Verify config `after_load_spec` passes with 11 default ttl_options
- [ ] Self-hosted: create a secret with TTL of 45 days (within default ceiling) — should succeed
- [ ] Self-hosted: create a secret with TTL of 46 days (above default ceiling) — should be clamped to 45 days
- [ ] Self-hosted with `TTL_CEILING=7776000`: create a secret with TTL of 90 days — should succeed
- [ ] Hosted with billing: verify plan limits still cap TTL correctly
- [ ] Anonymous secret creation: verify 7-day cap still applies
- [ ] UI dropdown: verify only configured ttl_options appear (no extra entries by default)

---
_Generated by [Claude Code](https://claude.ai/code/session_011gKPNht6VcfjcU4LyfGzek)_