### PR TITLE
*fix(middleware): respect otto.via_trusted_proxy in DetectHost

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -1160,6 +1160,15 @@ TRUSTED_PROXY_HEADER=X-Forwarded-For
 # filter mode only: additional CIDR ranges to trust as proxies beyond the
 # RFC1918 defaults (e.g. a CDN/proxy with public IPs). Comma-separated.
 # Example: 203.0.113.0/24,2001:db8::/32
+#
+# SECURITY: listing a range here is a full infrastructure-trust grant, not
+# just client-IP trust. Requests arriving from these ranges also have their
+# forwarded HOST headers honored (X-Forwarded-Host, X-Original-Host,
+# Apx-Incoming-Host, Forwarded) for custom-domain detection. The proxy MUST
+# therefore set or strip those headers itself rather than pass them through
+# from clients — a pass-through proxy lets a client pick the tenant domain
+# the app renders. This is the same requirement stated above for
+# X-Forwarded-For, extended to the host headers.
 #TRUSTED_PROXY_CIDRS=
 
 # depth mode only: number of proxy hops to skip from the right. Default: 1.

--- a/apps/api/organizations/spec/logic/organizations/list_secret_activity_spec.rb
+++ b/apps/api/organizations/spec/logic/organizations/list_secret_activity_spec.rb
@@ -186,7 +186,9 @@ RSpec.describe OrganizationAPI::Logic::Organizations::ListSecretActivity do
 
     # The denial is an operator-visible security event: extid/actor must land
     # in OT.info's **payload (structured, filterable) rather than being
-    # concatenated into the message string.
+    # concatenated into the message string. Values are pinned, not `anything` —
+    # `actor: anything` matches nil, so a regression that dropped the actor
+    # would still pass while leaving the alert unattributable.
     it 'logs the denial with a structured payload' do
       allow(OT).to receive(:conf)
         .and_return(conf_with_audit_logs_flag('audit_logs_enabled' => false))
@@ -196,7 +198,7 @@ RSpec.describe OrganizationAPI::Logic::Organizations::ListSecretActivity do
 
       expect(OT).to have_received(:info).with(
         a_string_including('audit_logs_enabled feature flag disabled'),
-        hash_including(extid: anything, actor: anything),
+        hash_including(extid: 'ext-org-123', actor: 'cust-123'),
       )
     end
 

--- a/lib/middleware/detect_host.rb
+++ b/lib/middleware/detect_host.rb
@@ -65,9 +65,12 @@ module Rack
   #
   # **Trusted Proxy Validation**: This middleware only trusts forwarded host
   # headers (X-Forwarded-Host, X-Original-Host, Apx-Incoming-Host, Forwarded)
-  # when the request originates from a private or loopback IP address. This
-  # indicates the request passed through a trusted reverse proxy in the local
-  # network. Direct requests from public IPs can only use the Host header.
+  # when the request arrived via a trusted reverse proxy. The trust decision
+  # comes from env['otto.via_trusted_proxy'] when Otto's IPPrivacyMiddleware
+  # is mounted upstream (it checks the original connecting peer against the
+  # configured trusted-proxy CIDRs before rewriting REMOTE_ADDR), falling
+  # back to a private/loopback REMOTE_ADDR check when that key is absent.
+  # Direct requests from public IPs can only use the Host header.
   #
   # This prevents header spoofing attacks where malicious clients set
   # X-Forwarded-Host to impersonate different hosts.
@@ -150,11 +153,28 @@ module Rack
       result_field_name = self.class.result_field_name
       detected_host     = nil
 
-      # Determine which headers to check based on whether request comes from trusted proxy
-      # Forwarded headers can be spoofed by clients, so we only trust them when
-      # REMOTE_ADDR is a private/loopback IP (indicating a trusted reverse proxy)
+      # Determine which headers to check based on whether request comes from
+      # a trusted proxy. Forwarded headers can be spoofed by clients, so they
+      # are only honored for requests that arrived via trusted infrastructure.
+      #
+      # Trust source, in order:
+      #
+      # 1. env['otto.via_trusted_proxy'] — recorded by Otto's
+      #    IPPrivacyMiddleware (mounted earlier in the stack) from the
+      #    ORIGINAL REMOTE_ADDR against the configured trusted-proxy CIDRs,
+      #    before it rewrites REMOTE_ADDR to the resolved client IP. Once
+      #    that rewrite happens, REMOTE_ADDR no longer identifies the
+      #    connecting peer: with proxy trust enabled it holds the real
+      #    (public) visitor IP, so re-checking it here would wrongly discard
+      #    forwarded host headers and fail every custom domain to canonical.
+      # 2. private_ip?(REMOTE_ADDR) — legacy heuristic for stacks where
+      #    IPPrivacyMiddleware is absent (bare-Rack tests, standalone use).
       remote_addr        = env['REMOTE_ADDR']
-      from_trusted_proxy = self.class.private_ip?(remote_addr)
+      from_trusted_proxy = if env.key?('otto.via_trusted_proxy')
+        env['otto.via_trusted_proxy'] == true
+      else
+        self.class.private_ip?(remote_addr)
+      end
 
       headers_to_check = if from_trusted_proxy
         HEADER_PRECEDENCE

--- a/lib/middleware/detect_host.rb
+++ b/lib/middleware/detect_host.rb
@@ -65,12 +65,22 @@ module Rack
   #
   # **Trusted Proxy Validation**: This middleware only trusts forwarded host
   # headers (X-Forwarded-Host, X-Original-Host, Apx-Incoming-Host, Forwarded)
-  # when the request arrived via a trusted reverse proxy. The trust decision
-  # comes from env['otto.via_trusted_proxy'] when Otto's IPPrivacyMiddleware
-  # is mounted upstream (it checks the original connecting peer against the
-  # configured trusted-proxy CIDRs before rewriting REMOTE_ADDR), falling
-  # back to a private/loopback REMOTE_ADDR check when that key is absent.
-  # Direct requests from public IPs can only use the Host header.
+  # when the request arrived via a trusted reverse proxy. Trust is granted
+  # when EITHER of two independent signals says so:
+  #
+  # - env['otto.via_trusted_proxy'] is true — recorded by Otto's
+  #   IPPrivacyMiddleware (mounted earlier in the stack) from the ORIGINAL
+  #   connecting peer against the configured trusted-proxy CIDRs, before it
+  #   rewrites REMOTE_ADDR to the resolved client IP; or
+  # - REMOTE_ADDR is a private/loopback address — the legacy heuristic that
+  #   keeps self-hosted installs behind a local reverse proxy working when
+  #   no trusted-proxy list is configured.
+  #
+  # A false (or missing, or non-boolean) key never suppresses the heuristic:
+  # IPPrivacyMiddleware is mounted unconditionally and writes false on every
+  # request when proxy trust is unconfigured, so false is ambiguous between
+  # "untrusted peer" and "no proxy trust configured". Direct requests from
+  # public IPs can only use the Host header.
   #
   # This prevents header spoofing attacks where malicious clients set
   # X-Forwarded-Host to impersonate different hosts.
@@ -113,6 +123,11 @@ module Rack
         '127.0.0.1',
         '::1',
       ].freeze
+
+      # Rack env key written by Otto's IPPrivacyMiddleware. Mirrors
+      # Otto::EnvKeys::VIA_TRUSTED_PROXY — kept as a literal so this
+      # middleware stays otto-agnostic (a tryout pins the equality).
+      VIA_TRUSTED_PROXY_KEY = 'otto.via_trusted_proxy'
     end
 
     # Class-level setting initialized from ENV variable
@@ -143,7 +158,8 @@ module Rack
     # @return [Array] Standard Rack response array from the next middleware
     #
     # This method:
-    # 1. Determines if request is from a trusted proxy (private/loopback IP)
+    # 1. Determines if request is from a trusted proxy (otto's trusted-proxy
+    #    signal, or a private/loopback REMOTE_ADDR)
     # 2. Examines headers in order of precedence (forwarded headers only from trusted proxies)
     # 3. Normalizes and validates each potential host
     # 4. Accepts the first valid host found
@@ -157,30 +173,39 @@ module Rack
       # a trusted proxy. Forwarded headers can be spoofed by clients, so they
       # are only honored for requests that arrived via trusted infrastructure.
       #
-      # Trust source, in order:
+      # Trust is a deliberate OR of two independent signals — the otto key
+      # can GRANT trust but never REVOKE the legacy heuristic:
       #
-      # 1. env['otto.via_trusted_proxy'] — recorded by Otto's
-      #    IPPrivacyMiddleware (mounted earlier in the stack) from the
-      #    ORIGINAL REMOTE_ADDR against the configured trusted-proxy CIDRs,
-      #    before it rewrites REMOTE_ADDR to the resolved client IP. Once
-      #    that rewrite happens, REMOTE_ADDR no longer identifies the
-      #    connecting peer: with proxy trust enabled it holds the real
-      #    (public) visitor IP, so re-checking it here would wrongly discard
-      #    forwarded host headers and fail every custom domain to canonical.
-      # 2. private_ip?(REMOTE_ADDR) — legacy heuristic for stacks where
-      #    IPPrivacyMiddleware is absent (bare-Rack tests, standalone use).
+      # a. env['otto.via_trusted_proxy'] == true wins outright. Otto's
+      #    IPPrivacyMiddleware (mounted earlier in the stack) records it from
+      #    the ORIGINAL connecting peer against the configured trusted-proxy
+      #    CIDRs, then rewrites REMOTE_ADDR to the resolved client IP. After
+      #    that rewrite REMOTE_ADDR no longer identifies the peer — with
+      #    proxy trust enabled it holds the real (public) visitor IP, so
+      #    re-checking it here would wrongly discard forwarded host headers
+      #    and fail every custom domain to canonical (2026-08-05 incident).
+      # b. A false key does NOT suppress private_ip?(REMOTE_ADDR).
+      #    IPPrivacyMiddleware is mounted unconditionally and writes false on
+      #    every request when no trusted proxies are configured, so false is
+      #    ambiguous between "untrusted peer" and "no proxy trust
+      #    configured". Treating it as authoritative stripped forwarded-host
+      #    trust from default-config self-hosters behind a local reverse
+      #    proxy, whose masked REMOTE_ADDR stays private. Non-boolean values
+      #    (nil, strings from a future otto) also fall through gracefully.
+      # c. Known gap: in TRUSTED_PROXY_MODE=depth otto's trust list is empty
+      #    so the key is always false AND REMOTE_ADDR is rewritten to the
+      #    public client IP — forwarded-host trust is unavailable. This is a
+      #    pre-existing limitation tracked upstream in otto; do not attempt
+      #    to work around it here.
       remote_addr        = env['REMOTE_ADDR']
-      from_trusted_proxy = if env.key?('otto.via_trusted_proxy')
-        env['otto.via_trusted_proxy'] == true
-      else
-        self.class.private_ip?(remote_addr)
-      end
+      from_trusted_proxy = env[VIA_TRUSTED_PROXY_KEY] == true ||
+                           self.class.private_ip?(remote_addr)
 
       headers_to_check = if from_trusted_proxy
         HEADER_PRECEDENCE
       else
-        # Direct public requests: only trust the Host header, not forwarded headers
-        logger.debug("[DetectHost] Direct request from #{remote_addr}, ignoring forwarded headers")
+        # Untrusted source: only the Host header is honored.
+        log_untrusted_request(env, remote_addr)
         ['Host']
       end
 
@@ -212,6 +237,48 @@ module Rack
       env[result_field_name] = detected_host
 
       @app.call(env)
+    end
+
+    private
+
+    # Logs why forwarded host headers are being ignored for this request,
+    # stating the actual trust inputs (the otto key's presence/value and the
+    # private_ip? result). REMOTE_ADDR is labeled post-proxy-resolution: by
+    # the time this middleware runs, IPPrivacyMiddleware may have rewritten
+    # it, so it does not necessarily identify the connecting peer.
+    #
+    # Escalates to WARN when Apx-Incoming-Host is among the discarded
+    # headers: Approximated ingress always sends it and a legitimate direct
+    # public client never does, so a discard here is the exact signature of
+    # the 2026-08-05 incident (custom domains falling back to canonical).
+    #
+    # @param env [Hash] Rack environment hash
+    # @param remote_addr [String, nil] env['REMOTE_ADDR'] after any rewrite
+    # @return [void]
+    def log_untrusted_request(env, remote_addr)
+      via_key      = env.key?(VIA_TRUSTED_PROXY_KEY) ? env[VIA_TRUSTED_PROXY_KEY].inspect : 'absent'
+      trust_inputs = "#{VIA_TRUSTED_PROXY_KEY}=#{via_key}, " \
+                     "private_ip=#{self.class.private_ip?(remote_addr)}, " \
+                     "remote_addr=#{remote_addr} (post-proxy-resolution)"
+
+      discarded    = FORWARDED_HEADERS.select do |header|
+        env.key?("HTTP_#{header.tr('-', '_').upcase}")
+      end
+
+      if discarded.empty?
+        logger.debug("[DetectHost] Untrusted source, no forwarded host headers present (#{trust_inputs})")
+      elsif discarded.include?('Apx-Incoming-Host')
+        logger.warn(
+          "[DetectHost] Discarding forwarded host headers (#{discarded.join(', ')}) " \
+          'from untrusted source; Apx-Incoming-Host present — matches the 2026-08-05 ' \
+          "Approximated-ingress incident signature (#{trust_inputs})",
+        )
+      else
+        logger.debug(
+          "[DetectHost] Discarding forwarded host headers (#{discarded.join(', ')}) " \
+          "from untrusted source (#{trust_inputs})",
+        )
+      end
     end
 
     module ClassMethods

--- a/scripts/init-test-lanes.sh
+++ b/scripts/init-test-lanes.sh
@@ -270,14 +270,78 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Hermetic boundary: clear every variable the lane files own. Whatever
-# direnv loaded for dev (or a previous lane) stops here.
-unset RACK_ENV AUTHENTICATION_MODE BILLING_ENABLED ORGS_SSO_ENABLED \
+# ── Hermetic boundary: the ONE env scrub block ──────────────────────────
+# Clears everything a dev shell exports (direnv-loaded or otherwise) that
+# the config templates (etc/defaults/config.defaults.yaml,
+# spec/config.test.yaml) or the suites read. Ownership rule:
+#   - variable FAMILIES we own are cleared with prefix globs ("${!PREFIX_@}");
+#     never re-list a glob-covered name explicitly;
+#   - SINGLETONS (no family prefix) are listed explicitly, grouped by why
+#     they matter;
+#   - families whose prefix we don't own (libpq's PG*, GOOGLE_/GITHUB_)
+#     are named var-by-var so we don't take out GITHUB_PERSONAL_ACCESS_TOKEN
+#     or CI's GITHUB_* and friends, which tests never read.
+# Do not add a second unset block elsewhere — extend this one. Lane env
+# files re-set anything a lane actually owns (AUTH_SECRET from base.env,
+# AUTH_DATABASE_URL* from the full/migrations lanes).
+
+# Core mode, endpoint, and secret singletons.
+unset RACK_ENV AUTHENTICATION_MODE BILLING_ENABLED \
       REDIS_URL VALKEY_URL RABBITMQ_URL \
-      AUTH_DATABASE_URL AUTH_DATABASE_URL_MIGRATIONS \
-      AUTH_DATABASE_URL_PG AUTH_DATABASE_URL_MIGRATIONS_PG \
-      SECRET SESSION_SECRET AUTH_SECRET ARGON2_SECRET ACCOUNT_ID_SECRET \
+      SECRET SESSION_SECRET ARGON2_SECRET ACCOUNT_ID_SECRET \
       FEDERATION_SECRET IDENTIFIER_SECRET
+
+# libpq reads these ambiently (a dev shell's .env.test exports PGPORT and a
+# passwordless superuser URL via direnv); they must not reach the lane either.
+unset PGHOST PGHOSTADDR PGPORT PGUSER PGPASSWORD PGDATABASE \
+      PGSERVICE PGSSLMODE PGOPTIONS PGPASSFILE
+
+# Feature families that flip behavior the suites assert against:
+# CUSTOM_MAIL_* configures a real mail provider (live SES creds ->
+# WebMock-blocked real HTTP calls), INCOMING_*/ORGS_*/DOMAINS_* enable
+# features the specs expect off, AUTH_* flips auth-config predicates
+# (AUTH_SSO_ENABLED, AUTH_AUTOVERIFY, AUTH_PASSWORD_REQUIREMENTS_ENABLED)
+# and carries AUTH_SECRET/AUTH_DATABASE_URL*, TRUSTED_PROXY_* rewires
+# proxy trust (REMOTE_ADDR resolution feeding DetectHost), ACME_* opens
+# the ACME endpoint, BRAND_* overrides neutral brand defaults,
+# APPROXIMATED_* is a live third-party API key, STRIPE_* is a live sandbox
+# key (billing specs replay committed VCR cassettes; no key needed), and
+# SENTRY_* carries DSNs plus an auth token.
+unset "${!CUSTOM_MAIL_@}" "${!INCOMING_@}" "${!ORGS_@}" \
+      "${!DOMAINS_@}" "${!AUTH_@}" "${!TRUSTED_PROXY_@}" "${!ACME_@}" \
+      "${!BRAND_@}" "${!APPROXIMATED_@}" "${!STRIPE_@}" "${!SENTRY_@}"
+
+# Feature master-switch singletons the globs above cannot reach
+# (ENABLE_ORGS is the orgs master switch but has no ORGS_ prefix).
+unset ENABLE_ORGS REGIONS_ENABLED JOBS_ENABLED I18N_ENABLED \
+      DIAGNOSTICS_ENABLED
+
+# Site identity: a dev shell exports HOST=dev.onetime.dev and SSL=true via
+# direnv. The suites assert against the shipped default (127.0.0.1:3000,
+# http), so these must not survive either. Same story for the domain and
+# jurisdiction identity vars.
+unset HOST SSL DEFAULT_DOMAIN JURISDICTION JURISDICTIONS SUPPORT_HOST
+
+# SSO provider credentials. AuthConfig#sso_providers registers a provider
+# purely from the presence of its required_vars (lib/onetime/auth_config.rb
+# #provider_definitions), and restrict_to only resolves to 'sso' when at
+# least one provider registers — so a dev shell's ENTRA_* silently turns
+# "no provider configured" assertions into "SSO-only is active".
+unset "${!OIDC_@}" "${!ENTRA_@}" "${!SSO_@}" \
+      GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GOOGLE_ROUTE_NAME \
+      GOOGLE_DISPLAY_NAME GOOGLE_TRUST_EMAIL_FOR_LINKING \
+      GITHUB_CLIENT_ID GITHUB_CLIENT_SECRET GITHUB_ROUTE_NAME \
+      GITHUB_DISPLAY_NAME GITHUB_TRUST_EMAIL_FOR_LINKING
+
+# Mail provider config. The defaults ERB interpolates these straight into
+# config.defaults.yaml, so an exported EMAILER_REGION= (empty) yields a nil
+# where the schema demands a string, a real LETTERMINT_API_TOKEN makes the
+# "token missing" validation specs pass a token, and SMTP_* points mail at
+# a real relay. FROM/REPLYTO/FEEDBACK/VERIFIER identities leak dev
+# addresses into rendered-mail assertions.
+unset "${!EMAILER_@}" "${!LETTERMINT_@}" "${!SMTP_@}" \
+      FROM FROM_NAME FROM_EMAIL REPLYTO_EMAIL FEEDBACK_TO_EMAIL \
+      VERIFIER_EMAIL
 
 set -a
 # shellcheck source=/dev/null
@@ -296,6 +360,51 @@ if [[ ${#OVERLAYS[@]} -gt 0 ]]; then
   done
 fi
 set +a
+
+# Billing rides on the full-mode auth stack (Stripe customer records live
+# in the auth database); it has no meaning in other modes.
+if [[ "${BILLING_ENABLED:-false}" == "true" && "${AUTHENTICATION_MODE:-}" != "full" ]]; then
+  echo "error: billing requires AUTHENTICATION_MODE=full (lane '${LANE}' is '${AUTHENTICATION_MODE:-unset}')" >&2
+  exit 64
+fi
+
+# ── Service preflight ────────────────────────────────────────────────────
+# Test services live in containers on 127.0.0.1 21xx ports (compose.test.yml
+# is the single source of truth). If they aren't up, start them — the
+# sanctioned path must also be the zero-setup path. Opt out (e.g. CI, where
+# the workflow owns service lifecycle): LANES_NO_AUTOSTART=1.
+port_open() { (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null; }
+
+# Ports come from the lane's own env, so this can't drift from
+# compose.test.yml (whose URLs the lane files mirror).
+REQUIRED_PORTS=()
+for _url in "${REDIS_URL:-}" "${RABBITMQ_URL:-}" "${AUTH_DATABASE_URL:-}"; do
+  [[ "$_url" =~ 127\.0\.0\.1:([0-9]+) ]] && REQUIRED_PORTS+=("${BASH_REMATCH[1]}")
+done
+
+missing=0
+for p in ${REQUIRED_PORTS[@]+"${REQUIRED_PORTS[@]}"}; do port_open "$p" || missing=1; done
+
+if [[ $missing -eq 1 && -z "${LANES_NO_AUTOSTART:-}" ]]; then
+  echo "[lane:${LANE}] test services not reachable; starting compose.test.yml" >&2
+  if command -v docker >/dev/null 2>&1; then
+    docker compose -f "${REPO_ROOT}/compose.test.yml" up --wait -d
+  elif command -v podman >/dev/null 2>&1; then
+    podman compose -f "${REPO_ROOT}/compose.test.yml" up --wait -d
+  else
+    echo "error: docker/podman not found; start test services manually:" >&2
+    echo "  docker compose -f compose.test.yml up --wait -d" >&2
+    exit 69
+  fi
+fi
+
+for p in ${REQUIRED_PORTS[@]+"${REQUIRED_PORTS[@]}"}; do
+  if ! port_open "$p"; then
+    echo "error: test service on 127.0.0.1:${p} unreachable. Start with:" >&2
+    echo "  docker compose -f compose.test.yml up --wait -d" >&2
+    exit 69
+  fi
+done
 
 echo "[lane:${LANE}] mode=${AUTHENTICATION_MODE:-?}" \
      "billing=${BILLING_ENABLED:-false}" \

--- a/src/apps/workspace/account/settings/OrganizationSettings.vue
+++ b/src/apps/workspace/account/settings/OrganizationSettings.vue
@@ -712,8 +712,11 @@
     // Redirect away from entitlement-gated tabs the user can't access
     // (e.g. direct URL navigation to /org/.../members without manage_members).
     // 'activity' is entitlement-exempt (deep links land; the panel swaps in an
-    // upgrade notice when unentitled) but IS gated on the instance flag: when
-    // ORGS_AUDIT_LOGS_ENABLED=false the tab doesn't exist, so deep links bounce.
+    // upgrade notice when unentitled). Its instance-flag clause below is
+    // unreachable in practice — resolveInitialTab() rejects a flag-off
+    // /activity deep link synchronously during setup, and the route watcher
+    // bounces later navigations — so it stands as defense in depth against a
+    // future path that seats activeTab without passing either gate.
     if (
       (activeTab.value === 'members' && !canManageMembers.value) ||
       (activeTab.value === 'sso' && !canManageSso.value) ||

--- a/tests/lanes/run
+++ b/tests/lanes/run
@@ -87,6 +87,13 @@ unset RACK_ENV AUTHENTICATION_MODE BILLING_ENABLED ORGS_SSO_ENABLED \
 unset PGHOST PGHOSTADDR PGPORT PGUSER PGPASSWORD PGDATABASE \
       PGSERVICE PGSSLMODE PGOPTIONS PGPASSFILE
 
+# Dev-shell feature exports flip behavior the suites assert against:
+# CUSTOM_MAIL_* configures a real mail provider (live SES creds ->
+# WebMock-blocked real HTTP calls), INCOMING_*/ORGS_* enable features the
+# specs expect off, BRAND_PACK overrides neutral brand defaults. Clear the
+# whole families; lane env files re-set anything a lane actually owns.
+unset "${!CUSTOM_MAIL_@}" "${!INCOMING_@}" "${!ORGS_@}" BRAND_PACK
+
 set -a
 # shellcheck source=/dev/null
 source "${LANES_DIR}/base.env"

--- a/tests/lanes/run
+++ b/tests/lanes/run
@@ -72,14 +72,25 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Hermetic boundary: clear every variable the lane files own. Whatever
-# direnv loaded for dev (or a previous lane) stops here.
-unset RACK_ENV AUTHENTICATION_MODE BILLING_ENABLED ORGS_SSO_ENABLED \
+# ── Hermetic boundary: the ONE env scrub block ──────────────────────────
+# Clears everything a dev shell exports (direnv-loaded or otherwise) that
+# the config templates (etc/defaults/config.defaults.yaml,
+# spec/config.test.yaml) or the suites read. Ownership rule:
+#   - variable FAMILIES we own are cleared with prefix globs ("${!PREFIX_@}");
+#     never re-list a glob-covered name explicitly;
+#   - SINGLETONS (no family prefix) are listed explicitly, grouped by why
+#     they matter;
+#   - families whose prefix we don't own (libpq's PG*, GOOGLE_/GITHUB_)
+#     are named var-by-var so we don't take out GITHUB_PERSONAL_ACCESS_TOKEN
+#     or CI's GITHUB_* and friends, which tests never read.
+# Do not add a second unset block elsewhere — extend this one. Lane env
+# files re-set anything a lane actually owns (AUTH_SECRET from base.env,
+# AUTH_DATABASE_URL* from the full/migrations lanes).
+
+# Core mode, endpoint, and secret singletons.
+unset RACK_ENV AUTHENTICATION_MODE BILLING_ENABLED \
       REDIS_URL VALKEY_URL RABBITMQ_URL \
-      AUTH_DATABASE_URL AUTH_DATABASE_URL_MIGRATIONS \
-      AUTH_DATABASE_URL_PG AUTH_DATABASE_URL_MIGRATIONS_PG \
-      AUTH_DATABASE_URL_TEST_SUPERUSER \
-      SECRET SESSION_SECRET AUTH_SECRET ARGON2_SECRET ACCOUNT_ID_SECRET \
+      SECRET SESSION_SECRET ARGON2_SECRET ACCOUNT_ID_SECRET \
       FEDERATION_SECRET IDENTIFIER_SECRET
 
 # libpq reads these ambiently (a dev shell's .env.test exports PGPORT and a
@@ -87,29 +98,37 @@ unset RACK_ENV AUTHENTICATION_MODE BILLING_ENABLED ORGS_SSO_ENABLED \
 unset PGHOST PGHOSTADDR PGPORT PGUSER PGPASSWORD PGDATABASE \
       PGSERVICE PGSSLMODE PGOPTIONS PGPASSFILE
 
-# Dev-shell feature exports flip behavior the suites assert against:
+# Feature families that flip behavior the suites assert against:
 # CUSTOM_MAIL_* configures a real mail provider (live SES creds ->
 # WebMock-blocked real HTTP calls), INCOMING_*/ORGS_*/DOMAINS_* enable
 # features the specs expect off, AUTH_* flips auth-config predicates
-# (AUTH_SSO_ENABLED, AUTH_AUTOVERIFY, AUTH_PASSWORD_REQUIREMENTS_ENABLED),
-# BRAND_PACK overrides neutral brand defaults. Clear the whole families;
-# lane env files re-set anything a lane actually owns (AUTH_SECRET from
-# base.env, AUTH_DATABASE_URL* from the full/migrations lanes).
+# (AUTH_SSO_ENABLED, AUTH_AUTOVERIFY, AUTH_PASSWORD_REQUIREMENTS_ENABLED)
+# and carries AUTH_SECRET/AUTH_DATABASE_URL*, TRUSTED_PROXY_* rewires
+# proxy trust (REMOTE_ADDR resolution feeding DetectHost), ACME_* opens
+# the ACME endpoint, BRAND_* overrides neutral brand defaults,
+# APPROXIMATED_* is a live third-party API key, STRIPE_* is a live sandbox
+# key (billing specs replay committed VCR cassettes; no key needed), and
+# SENTRY_* carries DSNs plus an auth token.
 unset "${!CUSTOM_MAIL_@}" "${!INCOMING_@}" "${!ORGS_@}" \
-      "${!DOMAINS_@}" "${!AUTH_@}" BRAND_PACK
+      "${!DOMAINS_@}" "${!AUTH_@}" "${!TRUSTED_PROXY_@}" "${!ACME_@}" \
+      "${!BRAND_@}" "${!APPROXIMATED_@}" "${!STRIPE_@}" "${!SENTRY_@}"
+
+# Feature master-switch singletons the globs above cannot reach
+# (ENABLE_ORGS is the orgs master switch but has no ORGS_ prefix).
+unset ENABLE_ORGS REGIONS_ENABLED JOBS_ENABLED I18N_ENABLED \
+      DIAGNOSTICS_ENABLED
 
 # Site identity: a dev shell exports HOST=dev.onetime.dev and SSL=true via
 # direnv. The suites assert against the shipped default (127.0.0.1:3000,
-# http), so these must not survive either.
-unset HOST SSL
+# http), so these must not survive either. Same story for the domain and
+# jurisdiction identity vars.
+unset HOST SSL DEFAULT_DOMAIN JURISDICTION JURISDICTIONS SUPPORT_HOST
 
 # SSO provider credentials. AuthConfig#sso_providers registers a provider
 # purely from the presence of its required_vars (lib/onetime/auth_config.rb
 # #provider_definitions), and restrict_to only resolves to 'sso' when at
 # least one provider registers — so a dev shell's ENTRA_* silently turns
 # "no provider configured" assertions into "SSO-only is active".
-# GOOGLE_/GITHUB_ are named var-by-var: a bare prefix scrub would also take
-# out GITHUB_PERSONAL_ACCESS_TOKEN and friends, which tests never read.
 unset "${!OIDC_@}" "${!ENTRA_@}" "${!SSO_@}" \
       GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GOOGLE_ROUTE_NAME \
       GOOGLE_DISPLAY_NAME GOOGLE_TRUST_EMAIL_FOR_LINKING \
@@ -118,9 +137,13 @@ unset "${!OIDC_@}" "${!ENTRA_@}" "${!SSO_@}" \
 
 # Mail provider config. The defaults ERB interpolates these straight into
 # config.defaults.yaml, so an exported EMAILER_REGION= (empty) yields a nil
-# where the schema demands a string, and a real LETTERMINT_API_TOKEN makes
-# the "token missing" validation specs pass a token.
-unset "${!EMAILER_@}" "${!LETTERMINT_@}" FROM_EMAIL FEEDBACK_TO_EMAIL
+# where the schema demands a string, a real LETTERMINT_API_TOKEN makes the
+# "token missing" validation specs pass a token, and SMTP_* points mail at
+# a real relay. FROM/REPLYTO/FEEDBACK/VERIFIER identities leak dev
+# addresses into rendered-mail assertions.
+unset "${!EMAILER_@}" "${!LETTERMINT_@}" "${!SMTP_@}" \
+      FROM FROM_NAME FROM_EMAIL REPLYTO_EMAIL FEEDBACK_TO_EMAIL \
+      VERIFIER_EMAIL
 
 set -a
 # shellcheck source=/dev/null

--- a/tests/lanes/run
+++ b/tests/lanes/run
@@ -89,10 +89,38 @@ unset PGHOST PGHOSTADDR PGPORT PGUSER PGPASSWORD PGDATABASE \
 
 # Dev-shell feature exports flip behavior the suites assert against:
 # CUSTOM_MAIL_* configures a real mail provider (live SES creds ->
-# WebMock-blocked real HTTP calls), INCOMING_*/ORGS_* enable features the
-# specs expect off, BRAND_PACK overrides neutral brand defaults. Clear the
-# whole families; lane env files re-set anything a lane actually owns.
-unset "${!CUSTOM_MAIL_@}" "${!INCOMING_@}" "${!ORGS_@}" BRAND_PACK
+# WebMock-blocked real HTTP calls), INCOMING_*/ORGS_*/DOMAINS_* enable
+# features the specs expect off, AUTH_* flips auth-config predicates
+# (AUTH_SSO_ENABLED, AUTH_AUTOVERIFY, AUTH_PASSWORD_REQUIREMENTS_ENABLED),
+# BRAND_PACK overrides neutral brand defaults. Clear the whole families;
+# lane env files re-set anything a lane actually owns (AUTH_SECRET from
+# base.env, AUTH_DATABASE_URL* from the full/migrations lanes).
+unset "${!CUSTOM_MAIL_@}" "${!INCOMING_@}" "${!ORGS_@}" \
+      "${!DOMAINS_@}" "${!AUTH_@}" BRAND_PACK
+
+# Site identity: a dev shell exports HOST=dev.onetime.dev and SSL=true via
+# direnv. The suites assert against the shipped default (127.0.0.1:3000,
+# http), so these must not survive either.
+unset HOST SSL
+
+# SSO provider credentials. AuthConfig#sso_providers registers a provider
+# purely from the presence of its required_vars (lib/onetime/auth_config.rb
+# #provider_definitions), and restrict_to only resolves to 'sso' when at
+# least one provider registers — so a dev shell's ENTRA_* silently turns
+# "no provider configured" assertions into "SSO-only is active".
+# GOOGLE_/GITHUB_ are named var-by-var: a bare prefix scrub would also take
+# out GITHUB_PERSONAL_ACCESS_TOKEN and friends, which tests never read.
+unset "${!OIDC_@}" "${!ENTRA_@}" "${!SSO_@}" \
+      GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GOOGLE_ROUTE_NAME \
+      GOOGLE_DISPLAY_NAME GOOGLE_TRUST_EMAIL_FOR_LINKING \
+      GITHUB_CLIENT_ID GITHUB_CLIENT_SECRET GITHUB_ROUTE_NAME \
+      GITHUB_DISPLAY_NAME GITHUB_TRUST_EMAIL_FOR_LINKING
+
+# Mail provider config. The defaults ERB interpolates these straight into
+# config.defaults.yaml, so an exported EMAILER_REGION= (empty) yields a nil
+# where the schema demands a string, and a real LETTERMINT_API_TOKEN makes
+# the "token missing" validation specs pass a token.
+unset "${!EMAILER_@}" "${!LETTERMINT_@}" FROM_EMAIL FEEDBACK_TO_EMAIL
 
 set -a
 # shellcheck source=/dev/null

--- a/try/integration/middleware/detect_host_ip_privacy_stack_try.rb
+++ b/try/integration/middleware/detect_host_ip_privacy_stack_try.rb
@@ -1,0 +1,115 @@
+# try/integration/middleware/detect_host_ip_privacy_stack_try.rb
+#
+# frozen_string_literal: true
+
+# These tryouts mount the REAL Otto::Security::Middleware::IPPrivacyMiddleware
+# in front of Rack::DetectHost — the production ordering from
+# lib/onetime/application/middleware_stack.rb — and drive requests through the
+# combined stack.
+#
+# Purpose: pin the cross-gem contract that DetectHost depends on. DetectHost
+# trusts forwarded host headers based on env['otto.via_trusted_proxy'], which
+# otto records from the ORIGINAL connecting peer before rewriting REMOTE_ADDR
+# to the resolved (masked) client IP. The detect_host_try.rb tryouts inject
+# that key by hand, so they would keep passing if a future otto release
+# renamed the key or stopped setting it — while production silently regressed
+# to the private_ip?(REMOTE_ADDR) fallback and re-broke every custom domain
+# (the 2026-08-05 TRUSTED_PROXY_ENABLED incident). These tests fail instead.
+#
+# We're testing:
+# 1. otto still records env['otto.via_trusted_proxy'] (contract pin)
+# 2. The incident shape: trusted proxy peer + public visitor in XFF ->
+#    REMOTE_ADDR rewritten to a public IP, forwarded host headers still trusted
+# 3. Direct public request: forwarded host headers ignored, Host wins
+# 4. Direct-connect config (no trusted proxies): forwarded host headers ignored
+
+require_relative '../../support/test_helpers'
+
+require 'logger'
+require 'stringio'
+require 'otto'
+
+require 'middleware/detect_host'
+
+@logger = Logger.new(StringIO.new)
+
+# Capture the env DetectHost's downstream app receives, so assertions can see
+# both the detected host and the post-otto REMOTE_ADDR.
+@captured = nil
+@capture_app = lambda do |env|
+  @captured = env
+  [200, {}, ['OK']]
+end
+
+# Mirror the production filter-mode config built by
+# MiddlewareStack.ip_privacy_security_config: private ranges trusted as
+# proxies, private/localhost masking on.
+@trusted_config = Otto::Security::Config.new
+@trusted_config.ip_privacy_config.mask_private_ips = true
+@trusted_config.add_trusted_proxy('10.0.0.0/8')
+
+@trusted_stack = Otto::Security::Middleware::IPPrivacyMiddleware.new(
+  Rack::DetectHost.new(@capture_app, logger: @logger),
+  @trusted_config,
+)
+
+# Direct-connect config: masking on, no trusted proxies (the default returned
+# by ip_privacy_security_config when site.network.trusted_proxy is disabled).
+@direct_config = Otto::Security::Config.new
+@direct_config.ip_privacy_config.mask_private_ips = true
+
+@direct_stack = Otto::Security::Middleware::IPPrivacyMiddleware.new(
+  Rack::DetectHost.new(@capture_app, logger: @logger),
+  @direct_config,
+)
+
+## Contract pin: otto records otto.via_trusted_proxy for downstream consumers.
+## If an otto upgrade renames or drops this key, DetectHost silently falls
+## back to the private_ip? heuristic — fail here instead.
+@trusted_stack.call({
+  'REMOTE_ADDR' => '10.0.0.5',
+  'HTTP_X_FORWARDED_FOR' => '203.0.113.50',
+  'HTTP_HOST' => 'eu.onetimesecret.com',
+})
+[@captured.key?('otto.via_trusted_proxy'), @captured['otto.via_trusted_proxy']]
+#=> [true, true]
+
+## Incident shape (2026-08-05): request arrives via trusted proxy (10.0.0.5)
+## carrying the public visitor in X-Forwarded-For and the customer domain in
+## Apx-Incoming-Host. Otto resolves and rewrites REMOTE_ADDR to the (masked)
+## PUBLIC visitor IP before DetectHost runs — the old private_ip?(REMOTE_ADDR)
+## gate failed here and every custom domain fell back to canonical. The
+## forwarded host header must survive the rewrite.
+@trusted_stack.call({
+  'REMOTE_ADDR' => '10.0.0.5',
+  'HTTP_X_FORWARDED_FOR' => '203.0.113.50',
+  'HTTP_APX_INCOMING_HOST' => 'ca.metalbaum.example.com',
+  'HTTP_HOST' => 'eu.onetimesecret.com',
+})
+[
+  @captured['rack.detected_host'],
+  Rack::DetectHost.private_ip?(@captured['REMOTE_ADDR']),
+]
+#=> ['ca.metalbaum.example.com', false]
+
+## Spoofing still blocked: a direct public client sending forged forwarded
+## host headers gets only its Host header honored, and the trust flag is false.
+@trusted_stack.call({
+  'REMOTE_ADDR' => '198.51.100.7',
+  'HTTP_APX_INCOMING_HOST' => 'spoofed.example.com',
+  'HTTP_X_FORWARDED_HOST' => 'also-spoofed.example.com',
+  'HTTP_HOST' => 'eu.onetimesecret.com',
+})
+[@captured['rack.detected_host'], @captured['otto.via_trusted_proxy']]
+#=> ['eu.onetimesecret.com', false]
+
+## Direct-connect deployment (no trusted proxies configured): even a private
+## peer gets no forwarded-host trust — the recorded decision (empty CIDR list)
+## overrides the old any-RFC-1918-peer heuristic.
+@direct_stack.call({
+  'REMOTE_ADDR' => '10.0.0.5',
+  'HTTP_X_FORWARDED_HOST' => 'spoofed.example.com',
+  'HTTP_HOST' => 'eu.onetimesecret.com',
+})
+[@captured['rack.detected_host'], @captured['otto.via_trusted_proxy']]
+#=> ['eu.onetimesecret.com', false]

--- a/try/integration/middleware/detect_host_ip_privacy_stack_try.rb
+++ b/try/integration/middleware/detect_host_ip_privacy_stack_try.rb
@@ -5,72 +5,117 @@
 # These tryouts mount the REAL Otto::Security::Middleware::IPPrivacyMiddleware
 # in front of Rack::DetectHost — the production ordering from
 # lib/onetime/application/middleware_stack.rb — and drive requests through the
-# combined stack.
+# combined stack, with the security config built by the PRODUCTION builder
+# (MiddlewareStack.ip_privacy_security_config) so config-construction drift is
+# covered too, not just the middleware contract.
 #
 # Purpose: pin the cross-gem contract that DetectHost depends on. DetectHost
-# trusts forwarded host headers based on env['otto.via_trusted_proxy'], which
-# otto records from the ORIGINAL connecting peer before rewriting REMOTE_ADDR
-# to the resolved (masked) client IP. The detect_host_try.rb tryouts inject
-# that key by hand, so they would keep passing if a future otto release
-# renamed the key or stopped setting it — while production silently regressed
-# to the private_ip?(REMOTE_ADDR) fallback and re-broke every custom domain
-# (the 2026-08-05 TRUSTED_PROXY_ENABLED incident). These tests fail instead.
+# trusts forwarded host headers when EITHER env['otto.via_trusted_proxy'] is
+# true (recorded by otto from the ORIGINAL connecting peer before it rewrites
+# REMOTE_ADDR to the resolved/masked client IP) OR REMOTE_ADDR is private
+# (legacy heuristic). The detect_host_try.rb tryouts inject the otto key by
+# hand, so they would keep passing if a future otto release renamed the key or
+# stopped setting it — while production silently regressed to the
+# private_ip?(REMOTE_ADDR) fallback and re-broke every custom domain (the
+# 2026-08-05 TRUSTED_PROXY_ENABLED incident). These tests fail instead.
 #
 # We're testing:
-# 1. otto still records env['otto.via_trusted_proxy'] (contract pin)
-# 2. The incident shape: trusted proxy peer + public visitor in XFF ->
+# 1. The key-name contract: Otto::EnvKeys::VIA_TRUSTED_PROXY still equals
+#    Rack::DetectHost::VIA_TRUSTED_PROXY_KEY (catches otto key renames)
+# 2. otto still records env['otto.via_trusted_proxy'] (contract pin)
+# 3. The incident shape: trusted proxy peer + public visitor in XFF ->
 #    REMOTE_ADDR rewritten to a public IP, forwarded host headers still trusted
-# 3. Direct public request: forwarded host headers ignored, Host wins
-# 4. Direct-connect config (no trusted proxies): forwarded host headers ignored
+# 4. Direct public request: forwarded host headers ignored, Host wins
+# 5. Direct-connect config + private peer: forwarded host headers trusted via
+#    the private-peer heuristic (back-compat for self-hosted installs)
+# 6. Depth mode: forwarded-host trust unavailable (known otto limitation)
 
 require_relative '../../support/test_helpers'
 
 require 'logger'
 require 'stringio'
 require 'otto'
+# Documentation-only module: NOT loaded by `require 'otto'`, must be explicit.
+require 'otto/env_keys'
 
 require 'middleware/detect_host'
+require 'onetime/application/middleware_stack'
 
 @logger = Logger.new(StringIO.new)
 
 # Capture the env DetectHost's downstream app receives, so assertions can see
 # both the detected host and the post-otto REMOTE_ADDR.
-@captured = nil
-@capture_app = lambda do |env|
+@captured    = nil
+@capture_app = ->(env) do
   @captured = env
   [200, {}, ['OK']]
 end
 
-# Mirror the production filter-mode config built by
-# MiddlewareStack.ip_privacy_security_config: private ranges trusted as
-# proxies, private/localhost masking on.
-@trusted_config = Otto::Security::Config.new
-@trusted_config.ip_privacy_config.mask_private_ips = true
-@trusted_config.add_trusted_proxy('10.0.0.0/8')
+# Build every security config through the PRODUCTION builder,
+# MiddlewareStack.ip_privacy_security_config — the single source of truth
+# that translates site.network.trusted_proxy YAML into Otto::Security::Config
+# (PRIVATE_PROXY_RANGES in filter mode, the depth+1 remap in depth mode,
+# mask_private_ips always). A hand-built config here could not catch
+# config-construction drift; see also
+# spec/unit/onetime/application/ip_privacy_parity_spec.rb.
+#
+# The builder reads only OT.conf['site']['network']['trusted_proxy'], so a
+# minimal conf hash suffices (no full boot / defaults load needed). OT is not
+# booted in this tryout (OT.conf is nil), so swap a purpose-built hash in via
+# the private conf= writer and restore afterwards — all builds happen here in
+# setup, before any test case runs, so nothing leaks between cases.
+@saved_conf              = OT.conf
+@build_production_config = ->(trusted_proxy) do
+  OT.send(:conf=, { 'site' => { 'network' => { 'trusted_proxy' => trusted_proxy } } })
+  Onetime::Application::MiddlewareStack.ip_privacy_security_config
+end
+
+# Filter mode (the incident config): PRIVATE_PROXY_RANGES trusted as proxies.
+@trusted_config = @build_production_config.call('enabled' => true, 'mode' => 'filter')
+
+# Depth mode: count-based, Onetime depth 1 => otto trusted_proxy_depth 2.
+# Depth and CIDRs are mutually exclusive in otto (it raises if both are set).
+@depth_config = @build_production_config.call('enabled' => true, 'mode' => 'depth', 'depth' => 1)
+
+# Direct-connect: trusted_proxy disabled — masking on, empty proxy trust list.
+@direct_config = @build_production_config.call('enabled' => false)
+
+OT.send(:conf=, @saved_conf)
 
 @trusted_stack = Otto::Security::Middleware::IPPrivacyMiddleware.new(
   Rack::DetectHost.new(@capture_app, logger: @logger),
   @trusted_config,
 )
 
-# Direct-connect config: masking on, no trusted proxies (the default returned
-# by ip_privacy_security_config when site.network.trusted_proxy is disabled).
-@direct_config = Otto::Security::Config.new
-@direct_config.ip_privacy_config.mask_private_ips = true
+@depth_stack = Otto::Security::Middleware::IPPrivacyMiddleware.new(
+  Rack::DetectHost.new(@capture_app, logger: @logger),
+  @depth_config,
+)
 
 @direct_stack = Otto::Security::Middleware::IPPrivacyMiddleware.new(
   Rack::DetectHost.new(@capture_app, logger: @logger),
   @direct_config,
 )
 
+## Key-name contract pin: DetectHost carries its own frozen literal (to stay
+## otto-agnostic) that must mirror otto's documented env key
+## (Otto::EnvKeys::VIA_TRUSTED_PROXY). If an otto upgrade renames the key,
+## this fails loudly instead of DetectHost silently never seeing the trust
+## signal. (Pinned as a value pair, not a bare `==`, so rubocop's Lint/Void
+## autocorrect cannot delete the expression.)
+[Otto::EnvKeys::VIA_TRUSTED_PROXY, Rack::DetectHost::VIA_TRUSTED_PROXY_KEY]
+#=> ['otto.via_trusted_proxy', 'otto.via_trusted_proxy']
+
 ## Contract pin: otto records otto.via_trusted_proxy for downstream consumers.
-## If an otto upgrade renames or drops this key, DetectHost silently falls
-## back to the private_ip? heuristic — fail here instead.
-@trusted_stack.call({
-  'REMOTE_ADDR' => '10.0.0.5',
-  'HTTP_X_FORWARDED_FOR' => '203.0.113.50',
-  'HTTP_HOST' => 'eu.onetimesecret.com',
-})
+## If an otto upgrade stops setting this key, DetectHost silently falls back
+## to the private_ip? heuristic — fail here instead.
+@trusted_stack.call(
+  {
+    'REMOTE_ADDR' => '10.0.0.5',
+    'HTTP_X_FORWARDED_FOR' => '203.0.113.50',
+    'HTTP_HOST' => 'eu.onetimesecret.com',
+  },
+)
 [@captured.key?('otto.via_trusted_proxy'), @captured['otto.via_trusted_proxy']]
 #=> [true, true]
 
@@ -80,36 +125,70 @@ end
 ## PUBLIC visitor IP before DetectHost runs — the old private_ip?(REMOTE_ADDR)
 ## gate failed here and every custom domain fell back to canonical. The
 ## forwarded host header must survive the rewrite.
-@trusted_stack.call({
-  'REMOTE_ADDR' => '10.0.0.5',
-  'HTTP_X_FORWARDED_FOR' => '203.0.113.50',
-  'HTTP_APX_INCOMING_HOST' => 'ca.metalbaum.example.com',
-  'HTTP_HOST' => 'eu.onetimesecret.com',
-})
+@trusted_stack.call(
+  {
+    'REMOTE_ADDR' => '10.0.0.5',
+    'HTTP_X_FORWARDED_FOR' => '203.0.113.50',
+    'HTTP_APX_INCOMING_HOST' => 'ca.metalbaum.example.com',
+    'HTTP_HOST' => 'eu.onetimesecret.com',
+  },
+)
 [
   @captured['rack.detected_host'],
   Rack::DetectHost.private_ip?(@captured['REMOTE_ADDR']),
 ]
 #=> ['ca.metalbaum.example.com', false]
 
-## Spoofing still blocked: a direct public client sending forged forwarded
-## host headers gets only its Host header honored, and the trust flag is false.
-@trusted_stack.call({
-  'REMOTE_ADDR' => '198.51.100.7',
-  'HTTP_APX_INCOMING_HOST' => 'spoofed.example.com',
-  'HTTP_X_FORWARDED_HOST' => 'also-spoofed.example.com',
-  'HTTP_HOST' => 'eu.onetimesecret.com',
-})
+## Spoofing still blocked (the security invariant): a direct public client
+## sending forged forwarded host headers gets only its Host header honored,
+## and the trust flag is false.
+@trusted_stack.call(
+  {
+    'REMOTE_ADDR' => '198.51.100.7',
+    'HTTP_APX_INCOMING_HOST' => 'spoofed.example.com',
+    'HTTP_X_FORWARDED_HOST' => 'also-spoofed.example.com',
+    'HTTP_HOST' => 'eu.onetimesecret.com',
+  },
+)
 [@captured['rack.detected_host'], @captured['otto.via_trusted_proxy']]
 #=> ['eu.onetimesecret.com', false]
 
-## Direct-connect deployment (no trusted proxies configured): even a private
-## peer gets no forwarded-host trust — the recorded decision (empty CIDR list)
-## overrides the old any-RFC-1918-peer heuristic.
-@direct_stack.call({
-  'REMOTE_ADDR' => '10.0.0.5',
-  'HTTP_X_FORWARDED_HOST' => 'spoofed.example.com',
-  'HTTP_HOST' => 'eu.onetimesecret.com',
-})
+## Direct-connect deployment (no trusted proxies configured): a private peer
+## still gets forwarded-host trust. Otto records via_trusted_proxy=false (its
+## trust list is empty), but the masked REMOTE_ADDR (10.0.0.0) stays private,
+## so DetectHost's private-peer heuristic grants trust — the false key never
+## revokes it. This pins pre-incident back-compat for default-config
+## self-hosted installs behind a local reverse proxy (nginx/Caddy on the same
+## box or LAN), which never declare site.network.trusted_proxy.
+@direct_stack.call(
+  {
+    'REMOTE_ADDR' => '10.0.0.5',
+    'HTTP_X_FORWARDED_HOST' => 'forwarded.example.com',
+    'HTTP_HOST' => 'eu.onetimesecret.com',
+  },
+)
 [@captured['rack.detected_host'], @captured['otto.via_trusted_proxy']]
-#=> ['eu.onetimesecret.com', false]
+#=> ['forwarded.example.com', false]
+
+## KNOWN LIMITATION (pinned deliberately; tracked for an upstream otto fix):
+## in depth mode otto's trusted-proxy list is empty (depth and CIDRs are
+## mutually exclusive), so it records via_trusted_proxy=false even though the
+## request DID arrive through the counted proxy tier, AND it rewrites
+## REMOTE_ADDR to the (masked) public client — both trust signals decline and
+## forwarded-host trust is unavailable: Apx-Incoming-Host is discarded, Host
+## wins. When otto learns to record depth-based trust in via_trusted_proxy,
+## this expectation flips and must be updated deliberately.
+@depth_stack.call(
+  {
+    'REMOTE_ADDR' => '10.0.0.5',
+    'HTTP_X_FORWARDED_FOR' => '203.0.113.50, 10.0.0.5',
+    'HTTP_APX_INCOMING_HOST' => 'ca.metalbaum.example.com',
+    'HTTP_HOST' => 'eu.onetimesecret.com',
+  },
+)
+[
+  @captured['rack.detected_host'],
+  @captured['otto.via_trusted_proxy'],
+  Rack::DetectHost.private_ip?(@captured['REMOTE_ADDR']),
+]
+#=> ['eu.onetimesecret.com', false, false]

--- a/try/integration/middleware/detect_host_try.rb
+++ b/try/integration/middleware/detect_host_try.rb
@@ -13,7 +13,11 @@
 # 3. Port stripping
 # 4. Multiple host handling
 # 5. Empty and missing header handling
-# 6. Trusted proxy validation (forwarded headers only trusted from private IPs)
+# 6. Trusted proxy validation: forwarded headers are trusted when EITHER
+#    env['otto.via_trusted_proxy'] == true (recorded by Otto's
+#    IPPrivacyMiddleware from the original peer) OR REMOTE_ADDR is a
+#    private/loopback IP (legacy heuristic). The otto key can grant trust
+#    but never revoke the heuristic.
 
 require_relative '../../support/test_helpers'
 
@@ -23,64 +27,64 @@ require 'stringio'
 require 'middleware/detect_host'
 
 # Capture log output for verification
-@log_output = StringIO.new
-@logger = Logger.new(@log_output)
-@app = ->(env) { [200, {}, ['OK']] }
+@log_output     = StringIO.new
+@logger         = Logger.new(@log_output)
+@app            = ->(_env) { [200, {}, ['OK']] }
 @original_value = OT.debug?
-OT.debug = true  # log messages are only avalable in debug mode
-@middleware = Rack::DetectHost.new(@app, logger: @logger)
+OT.debug        = true  # log messages are only avalable in debug mode
+@middleware     = Rack::DetectHost.new(@app, logger: @logger)
 
 ## X-Forwarded-Host takes precedence over Host header (from trusted proxy)
 # REMOTE_ADDR must be a private IP for forwarded headers to be trusted
-env = {'REMOTE_ADDR' => '10.0.0.1', 'HTTP_X_FORWARDED_HOST' => 'first.com', 'HTTP_HOST' => 'last.com'}
+env = { 'REMOTE_ADDR' => '10.0.0.1', 'HTTP_X_FORWARDED_HOST' => 'first.com', 'HTTP_HOST' => 'last.com' }
 @middleware.call(env)
 env['rack.detected_host']
 #=> 'first.com'
 
 ## Strips port number from hostname
-env = {'HTTP_HOST' => 'example.com:8080'}
+env = { 'HTTP_HOST' => 'example.com:8080' }
 @middleware.call(env)
 env['rack.detected_host']
 #=> 'example.com'
 
 ## Handles host with extra spaces and port
-env = {'HTTP_HOST' => '  example.com:8080  '}
+env = { 'HTTP_HOST' => '  example.com:8080  ' }
 @middleware.call(env)
 env['rack.detected_host']
 #=> 'example.com'
 
 ## Rejects localhost as invalid host
-env = {'HTTP_HOST' => 'localhost'}
+env = { 'HTTP_HOST' => 'localhost' }
 @middleware.call(env)
 [env['rack.detected_host'], @log_output.string.include?('Invalid host detected')]
 #=> [nil, true]
 
 ## Rejects localhost with port as invalid host
-env = {'HTTP_HOST' => 'localhost:3000'}
+env = { 'HTTP_HOST' => 'localhost:3000' }
 @middleware.call(env)
 [env['rack.detected_host'], @log_output.string.include?('Invalid host detected')]
 #=> [nil, true]
 
 ## Rejects IPv4 address as invalid host
-env = {'HTTP_HOST' => '127.0.0.1'}
+env = { 'HTTP_HOST' => '127.0.0.1' }
 @middleware.call(env)
 [env['rack.detected_host'], @log_output.string.include?('Invalid host detected')]
 #=> [nil, true]
 
 ## Rejects IPv6 address as invalid host
-env = {'HTTP_HOST' => '::1'}
+env = { 'HTTP_HOST' => '::1' }
 @middleware.call(env)
 [env['rack.detected_host'], @log_output.string.include?('Invalid host detected')]
 #=> [nil, true]
 
 ## Takes first host when multiple are provided (from trusted proxy)
-env = {'REMOTE_ADDR' => '192.168.1.1', 'HTTP_X_FORWARDED_HOST' => 'first.com, second.com'}
+env = { 'REMOTE_ADDR' => '192.168.1.1', 'HTTP_X_FORWARDED_HOST' => 'first.com, second.com' }
 @middleware.call(env)
 env['rack.detected_host']
 #=> 'first.com'
 
 ## Handles missing headers gracefully
-env = {}
+env    = {}
 @middleware.call(env)
 output = @log_output.string
 puts output
@@ -88,26 +92,26 @@ puts output
 #=> [nil, true]
 
 ## Always forwards request to app regardless of host validity
-env = {'HTTP_HOST' => 'example.com'}
+env             = { 'HTTP_HOST' => 'example.com' }
 status, _, body = @middleware.call(env)
 [status, body]
 #=> [200, ['OK']]
 
 ## Ignores X-Forwarded-Host from direct public request (security)
 # Direct requests from public IPs should not trust forwarded headers
-env = {'REMOTE_ADDR' => '203.0.113.50', 'HTTP_X_FORWARDED_HOST' => 'spoofed.com', 'HTTP_HOST' => 'real.com'}
+env = { 'REMOTE_ADDR' => '203.0.113.50', 'HTTP_X_FORWARDED_HOST' => 'spoofed.com', 'HTTP_HOST' => 'real.com' }
 @middleware.call(env)
 env['rack.detected_host']
 #=> 'real.com'
 
 ## Trusts X-Forwarded-Host from private network (loopback)
-env = {'REMOTE_ADDR' => '127.0.0.1', 'HTTP_X_FORWARDED_HOST' => 'forwarded.com', 'HTTP_HOST' => 'fallback.com'}
+env = { 'REMOTE_ADDR' => '127.0.0.1', 'HTTP_X_FORWARDED_HOST' => 'forwarded.com', 'HTTP_HOST' => 'fallback.com' }
 @middleware.call(env)
 env['rack.detected_host']
 #=> 'forwarded.com'
 
 ## Trusts X-Forwarded-Host from private network (RFC 1918)
-env = {'REMOTE_ADDR' => '172.16.5.100', 'HTTP_X_FORWARDED_HOST' => 'internal.example.com', 'HTTP_HOST' => 'external.com'}
+env = { 'REMOTE_ADDR' => '172.16.5.100', 'HTTP_X_FORWARDED_HOST' => 'internal.example.com', 'HTTP_HOST' => 'external.com' }
 @middleware.call(env)
 env['rack.detected_host']
 #=> 'internal.example.com'
@@ -127,27 +131,58 @@ env = {
 env['rack.detected_host']
 #=> 'custom.example.com'
 
-## Ignores forwarded headers when otto.via_trusted_proxy is false, even with
-## private REMOTE_ADDR. The recorded trust decision (configured CIDRs) wins
-## over the any-RFC-1918-peer heuristic.
+## Still trusts forwarded headers when otto.via_trusted_proxy is false but
+## REMOTE_ADDR is private: trust is a grant-only OR — the key can GRANT
+## trust, it never REVOKES the private-peer heuristic. This is deliberate
+## back-compat: IPPrivacyMiddleware is mounted unconditionally and records
+## false on every request when no trusted proxies are configured, so false
+## is ambiguous between "untrusted peer" and "no proxy trust configured".
+## Treating it as authoritative stripped forwarded-host trust from
+## default-config self-hosters behind a local reverse proxy.
 env = {
   'REMOTE_ADDR' => '10.0.0.1',
   'otto.via_trusted_proxy' => false,
-  'HTTP_X_FORWARDED_HOST' => 'spoofed.example.com',
-  'HTTP_HOST' => 'real.example.com',
+  'HTTP_X_FORWARDED_HOST' => 'proxied.example.com',
+  'HTTP_HOST' => 'direct.example.com',
 }
 @middleware.call(env)
 env['rack.detected_host']
-#=> 'real.example.com'
+#=> 'proxied.example.com'
+
+## Non-boolean key values (nil, or a truthy-looking string from a future
+## otto) never grant trust — only `true` does. With a public REMOTE_ADDR the
+## heuristic also declines, so the request degrades gracefully to the Host
+## header instead of a spoofable trust cliff.
+[nil, 'true'].map do |value|
+  env = {
+    'REMOTE_ADDR' => '203.0.113.50',
+    'otto.via_trusted_proxy' => value,
+    'HTTP_X_FORWARDED_HOST' => 'spoofed.example.com',
+    'HTTP_HOST' => 'real.example.com',
+  }
+  @middleware.call(env)
+  env['rack.detected_host']
+end
+#=> ['real.example.com', 'real.example.com']
+
+## Discarding Apx-Incoming-Host from an untrusted source escalates the log
+## to WARN — the 2026-08-05 incident signature (custom domains silently
+## falling back to canonical under Approximated ingress).
+env = {
+  'REMOTE_ADDR' => '203.0.113.50',
+  'HTTP_APX_INCOMING_HOST' => 'custom.example.com',
+  'HTTP_HOST' => 'canonical.example.com',
+}
+@middleware.call(env)
+[env['rack.detected_host'], @log_output.string.include?('Apx-Incoming-Host present')]
+#=> ['canonical.example.com', true]
 
 ## Falls back to private_ip? heuristic when otto.via_trusted_proxy is absent
 ## (bare-Rack stacks without IPPrivacyMiddleware)
-env = {'REMOTE_ADDR' => '10.0.0.1', 'HTTP_X_FORWARDED_HOST' => 'forwarded.example.com', 'HTTP_HOST' => 'direct.example.com'}
+env = { 'REMOTE_ADDR' => '10.0.0.1', 'HTTP_X_FORWARDED_HOST' => 'forwarded.example.com', 'HTTP_HOST' => 'direct.example.com' }
 @middleware.call(env)
 env['rack.detected_host']
 #=> 'forwarded.example.com'
-
-
 
 # Put everything back the way we found it
 OT.debug = @original_value

--- a/try/integration/middleware/detect_host_try.rb
+++ b/try/integration/middleware/detect_host_try.rb
@@ -112,6 +112,41 @@ env = {'REMOTE_ADDR' => '172.16.5.100', 'HTTP_X_FORWARDED_HOST' => 'internal.exa
 env['rack.detected_host']
 #=> 'internal.example.com'
 
+## Trusts forwarded headers when otto.via_trusted_proxy is true, even with
+## public REMOTE_ADDR. Regression: with TRUSTED_PROXY_ENABLED, Otto's
+## IPPrivacyMiddleware rewrites REMOTE_ADDR to the resolved public visitor
+## IP before DetectHost runs; the private_ip? heuristic then discarded
+## forwarded host headers and every custom domain fell back to canonical.
+env = {
+  'REMOTE_ADDR' => '203.0.113.50',
+  'otto.via_trusted_proxy' => true,
+  'HTTP_APX_INCOMING_HOST' => 'custom.example.com',
+  'HTTP_HOST' => 'canonical.example.com',
+}
+@middleware.call(env)
+env['rack.detected_host']
+#=> 'custom.example.com'
+
+## Ignores forwarded headers when otto.via_trusted_proxy is false, even with
+## private REMOTE_ADDR. The recorded trust decision (configured CIDRs) wins
+## over the any-RFC-1918-peer heuristic.
+env = {
+  'REMOTE_ADDR' => '10.0.0.1',
+  'otto.via_trusted_proxy' => false,
+  'HTTP_X_FORWARDED_HOST' => 'spoofed.example.com',
+  'HTTP_HOST' => 'real.example.com',
+}
+@middleware.call(env)
+env['rack.detected_host']
+#=> 'real.example.com'
+
+## Falls back to private_ip? heuristic when otto.via_trusted_proxy is absent
+## (bare-Rack stacks without IPPrivacyMiddleware)
+env = {'REMOTE_ADDR' => '10.0.0.1', 'HTTP_X_FORWARDED_HOST' => 'forwarded.example.com', 'HTTP_HOST' => 'direct.example.com'}
+@middleware.call(env)
+env['rack.detected_host']
+#=> 'forwarded.example.com'
+
 
 
 # Put everything back the way we found it


### PR DESCRIPTION
> [!IMPORTANT]
> **Deploy checklist** — no new config vars, but the fix only takes effect when Otto's existing proxy-trust settings cover the ingress:
> - [ ] `TRUSTED_PROXY_ENABLED=true` and `TRUSTED_PROXY_MODE=filter` (depth mode gets no forwarded-host trust — known gap, otto #4024)
> - [ ] Current Approximated egress ranges present in `TRUSTED_PROXY_CIDRS` — unlisted egress IPs get `via_trusted_proxy=false` and custom domains still fall to canonical
> - [ ] Edge proxy sets or strips `X-Forwarded-Host`/`Forwarded` rather than passing them through from clients (see `TRUSTED_PROXY_CIDRS` note in `.env.reference`)
> - [ ] Post-deploy: watch for the `Apx-Incoming-Host … 2026-08-05 incident signature` WARN — silence plus resolving custom domains confirms the trust path

When `TRUSTED_PROXY_ENABLED` is on (filter mode), Otto's IPPrivacyMiddleware rewrites `REMOTE_ADDR` to the resolved public visitor IP before DetectHost runs, so DetectHost's `private_ip?(REMOTE_ADDR)` trust check failed and forwarded host headers (`Apx-Incoming-Host`, `X-Forwarded-Host`, …) were discarded — every custom domain fell back to canonical (2026-08-05 incident).

**Fix — grant-only trust semantics:** `otto.via_trusted_proxy == true` (recorded by otto from the original peer, pre-rewrite) grants forwarded-host trust; a false/absent/non-boolean key falls through to the legacy private-IP heuristic rather than suppressing it. IPPrivacyMiddleware is mounted unconditionally, so with proxy trust unconfigured the key is false on every request — suppressing the heuristic would strip forwarded-host trust from default-config self-hosted installs behind a local reverse proxy. The security invariant is unchanged: direct public clients get Host-only, and the OR is a strict superset of pre-incident behavior adding only the otto-verified case.

Also: key literal centralized in `VIA_TRUSTED_PROXY_KEY` (contract-pinned against `Otto::EnvKeys::VIA_TRUSTED_PROXY`), the untrusted-path log now names the actual trust inputs, and discarding a header set that includes `Apx-Incoming-Host` logs at WARN — the incident's exact signature, per the incident-report alerting suggestion.

**Tests:** unit tryouts pin grant-only semantics, non-boolean graceful fallthrough, and the WARN escalation; a new cross-gem stack tryout mounts the real IPPrivacyMiddleware in production order via the production `ip_privacy_security_config` builder (catches config-construction drift), reproduces the incident shape, and pins the depth-mode gap as a KNOWN LIMITATION (depth mode has an empty trust list, so the key is always false — forwarded-host trust unavailable; pre-existing, needs an upstream otto change).

**Lane runner:** env scrub consolidated into one owned block (family globs + explicit singletons), extended with `ENABLE_ORGS`, `TRUSTED_PROXY_*`, `APPROXIMATED_*`, mail/identity vars and friends; generator script's embedded runner synced byte-identical.

Verified: `try/integration/middleware/` 98/98; `tests/lanes/run unit` green (try:unit 7367/0, spec:fast 3307/0 incl. `ip_privacy_parity_spec`); `tests/lanes/run disabled` 838/0; rubocop clean.
