### PR TITLE
Remove hardcoded 30-day TTL clamp blocking configured longer TTLs

### DIFF
--- a/apps/api/v2/logic/secrets/base_secret_action.rb
+++ b/apps/api/v2/logic/secrets/base_secret_action.rb
@@ -125,8 +125,14 @@ module V2::Logic
           require_entitlement!('extended_default_expiration')
         end
 
-        # Apply a global maximum
-        @ttl = 30.days if ttl && ttl >= 30.days
+        # Absolute safety bound: nothing outlives MAX_TTL (365 days). The
+        # real ceilings — plan limit, anonymous cap, config ttl_options —
+        # are enforced by the bounds check below; this clamp exists because
+        # an unlimited plan resolves limit_for to Infinity and the ladder
+        # then has no terminal bound. (A hardcoded 30-day clamp here used
+        # to override all of those ceilings; see #4008.)
+        safety_max = Onetime::Models::Features::WithEntitlements::MAX_TTL
+        @ttl = safety_max if ttl > safety_max
 
         # Enforce bounds
         @ttl = min_ttl if ttl < min_ttl

--- a/docs/specs/ttl_policy/ttl_policy.md
+++ b/docs/specs/ttl_policy/ttl_policy.md
@@ -1,0 +1,242 @@
+# TTL Policy Resolution
+
+Design specification for collapsing secret-TTL bounds enforcement into a
+single resolution point. Status: **proposed** — this documents the target
+design; the code currently implements the layered model described under
+"Current state".
+
+## Problem
+
+How long a secret may live is decided by several independent bounds that
+accumulated over time. As of this writing the resolution logic exists in
+multiple places and two languages:
+
+| Layer | Where | Applies to | Kind |
+|---|---|---|---|
+| `MAX_TTL` (365d) | `WithEntitlements` | everyone | absolute software-safety bound |
+| Plan `secret_lifetime` | org `limit_for` via `process_ttl` | authenticated w/ org | billing limit |
+| Anonymous ceiling (7d default, `TTL_MAX_ANONYMOUS`) | `configured_anonymous_max_ttl` + `anonymous_max_ttl` | anonymous | product policy, operator-tunable |
+| Free-tier gate (14d, `DEFAULT_FREE_TTL`) | `process_ttl` entitlement gate | authenticated w/ org, billing on | loud 403 w/ upgrade path |
+| `ttl_options` min/max | config via `process_ttl` | varies by branch | UI inventory doubling as bounds |
+| Frontend safety cap | `usePrivacyOptions.ts` | browser UI | duplicate of backend policy |
+
+Two structural problems:
+
+1. **Duplication across languages.** The min-of-ceilings arithmetic is
+   implemented in Ruby (enforcement) and re-derived in TypeScript
+   (`usePrivacyOptions.ts` filters the duration dropdown). The two can
+   drift, and when they do the UI offers durations the server silently
+   shortens — the exact failure mode of the 2026-07-29 API audit, item 4,
+   and of #4008.
+2. **Inconsistent term semantics.** `ttl_options.max` is *ignored* when an
+   org has a positive plan limit but *included* in the anonymous minimum.
+   No single mental model explains the current branches.
+
+## Target design
+
+### One resolver: `Onetime::TtlPolicy`
+
+A stateless class owning every numeric TTL decision. All constants stay in
+`WithEntitlements`; `TtlPolicy` becomes their only consumer.
+
+```ruby
+module Onetime
+  class TtlPolicy
+    Entitlements = Onetime::Models::Features::WithEntitlements
+
+    Resolution = Data.define(:default, :min, :ceiling, :free_tier_threshold, :terms) do
+      # Silent clamp used by V2/V3. Loud rejection is the caller's choice
+      # (compare against .ceiling before clamping).
+      def clamp(requested)
+        requested.to_i.clamp(min, ceiling)
+      end
+    end
+
+    # @param organization [Organization, nil] resolved org context, if any
+    # @param anonymous    [Boolean] unauthenticated caller
+    def self.resolve(organization: nil, anonymous: false)
+      opts        = OT.conf.dig('site', 'secret_options') || {}
+      ttl_options = Array(opts['ttl_options'])
+
+      # Named terms, kept for logging so an operator can see WHICH bound
+      # clamped a request ("why is my 90-day secret 45 days?").
+      terms = {}
+
+      if organization&.respond_to?(:limit_for)
+        limit = organization.limit_for('secret_lifetime')
+        terms[:plan_limit] = limit if limit.positive?
+      end
+
+      if anonymous
+        terms[:anonymous_ceiling] = Entitlements.configured_anonymous_max_ttl
+        free_tier = billing_free_tier_lifetime
+        terms[:free_tier] = free_tier if free_tier&.positive?
+      end
+
+      terms[:max_ttl] = Entitlements::MAX_TTL if terms.empty?
+
+      Resolution.new(
+        default: opts['default_ttl'] || 7 * 86_400,
+        min: ttl_options.min || 60,
+        ceiling: terms.values.min.clamp(1, Entitlements::MAX_TTL),
+        free_tier_threshold: Entitlements::DEFAULT_FREE_TTL,
+        terms: terms.freeze,
+      )
+    end
+
+    def self.billing_free_tier_lifetime
+      return nil unless Onetime::BillingConfig.instance.enabled?
+      Onetime::Organization.free_tier_limits['secret_lifetime.max'].to_i
+    rescue StandardError => ex
+      OT.le "[TtlPolicy] billing unavailable (#{ex.class}); free-tier term skipped"
+      nil
+    end
+  end
+end
+```
+
+### V2 enforcement collapses
+
+`process_ttl` in `apps/api/v2/logic/secrets/base_secret_action.rb` shrinks
+to: resolve, apply default, run the loud entitlement gate against
+`policy.free_tier_threshold`, then `policy.clamp`. The private helpers
+`anonymous_max_ttl` and `free_tier_ttl_ceiling` are deleted. V3 inherits V2
+(`V3::Logic::Secrets::ConcealSecret < V2::Logic::Secrets::ConcealSecret`)
+and needs no changes.
+
+```ruby
+def process_ttl
+  requested = payload.fetch('ttl', nil)
+  policy = Onetime::TtlPolicy.resolve(
+    organization: auth_org, anonymous: anonymous_user?,
+  )
+
+  @ttl = requested.nil? ? policy.default : requested.to_i
+
+  # Loud gate first (clear upgrade-path error beats a silent clamp), then
+  # the silent clamp for everything else. Both thresholds come from the
+  # same resolution — no second opinion.
+  if ttl > policy.free_tier_threshold && auth_org && !auth_org.can?('extended_default_expiration')
+    require_entitlement!('extended_default_expiration')
+  end
+
+  @ttl = policy.clamp(ttl)
+end
+```
+
+### The serializer publishes one resolved number
+
+`ConfigSerializer#build_secret_options` runs per-request and knows the
+caller. Instead of shipping raw ingredients (`ttl_max_anonymous`, plan
+limits via the organization payload) and letting TypeScript re-derive the
+minimum, it ships the answer:
+
+```ruby
+policy = Onetime::TtlPolicy.resolve(
+  organization: current_organization, anonymous: !authenticated?,
+)
+secret_options.merge(
+  'ttl_ceiling' => policy.ceiling,
+  # Deprecated: superseded by the resolved ttl_ceiling. Kept one release
+  # for cached bundles still reading it.
+  'ttl_max_anonymous' => anonymous_ttl_ceiling,
+)
+```
+
+Semantic shift, stated plainly: `ttl_ceiling` means "the effective ceiling
+for *this caller, this request*", not a raw config knob. That is the point
+— but it is a bootstrap-contract change, hence the one-release overlap with
+the legacy key.
+
+### The frontend becomes a dumb filter
+
+`usePrivacyOptions.ts` loses the auth branch, the organization-store read,
+and the min-of-ceilings arithmetic:
+
+```typescript
+const ttlCeiling = computed<number | null>(() => {
+  const value = secret_options.value?.ttl_ceiling;
+  return typeof value === 'number' && value > 0 ? value : null;
+});
+// lifetimeOptions filters ttl_options against ttlCeiling; null fails open.
+```
+
+TypeScript can no longer disagree with Ruby about the ceiling because it
+never computes one. The min-of-two-ceilings test matrix migrates to the
+Ruby resolver spec; the TS spec keeps "filters by the number given" and
+"fails open when absent".
+
+## Namespacing and the policy/boundary model
+
+`Onetime::TtlPolicy` as sketched above claims a flat top-level name for a
+single policy. If more policies follow (secret size, passphrase
+requirements, rate limits are the obvious candidates), the namespacing
+should make room for them first — e.g. `Onetime::Policy::Ttl` (or
+`Onetime::Policies::SecretLifetime`), so each policy is a sibling under one
+namespace rather than a scattering of `*Policy` classes.
+
+The underlying concept — a **policy** (the rules) evaluated inside a
+**boundary container** (the scope that constrains what any policy inside it
+may grant) — is the same shape as AWS's policy model, where organization-
+level service control policies and permission boundaries cap what
+account-level IAM policies can allow, and the effective permission is the
+intersection. AWS's implementation is over-engineered for our needs, but
+the principle is sound. Mapped to Onetime Secret:
+
+- **Install/platform-level container**: the deployment's outer boundary and
+  its default policy — `MAX_TTL`, the anonymous ceiling, operator config.
+  Nothing inside may exceed it.
+- **Organization-level policies**: plan limits and entitlements, evaluated
+  inside the platform boundary. An org policy can only narrow, never widen,
+  what the platform container allows.
+
+`TtlPolicy.resolve` is the degenerate two-level case of this (platform
+terms ∩ org terms, take the minimum). Naming and structuring it as
+policy-within-boundary from the start keeps the door open for the other
+policies without inventing a new mental model per limit.
+
+## Deliberately out of scope
+
+- **V1** keeps its frozen `V1_MIN_TTL`/`V1_MAX_TTL` (60s / 30 days).
+  Routing V1 through the resolver would change documented legacy responses,
+  which a frozen API version must not do. A pointer comment in V1 prevents
+  future "helpful" unification.
+- **The entitlement gate's `raise`** stays in the action — it needs
+  `require_entitlement!` and request context. Only its threshold number
+  comes from the resolution.
+
+## Open decision: `ttl_options.max` as bound vs. inventory
+
+Today `ttl_options.max` caps the anonymous path and the no-org authenticated
+path, but not orgs with a positive plan limit. A min-of-all-terms resolver
+cannot preserve both semantics. Recommendation: treat `ttl_options` as UI
+inventory only — drop it from the ceiling terms (as the sketch above does)
+and let plan/anonymous/absolute bounds do enforcement. This makes the
+no-plan-limit paths cap at `MAX_TTL` for raw API callers, which is a small
+loosening that needs explicit sign-off before phase 1 lands.
+
+## Sequencing
+
+Two PRs, so the behavior-sensitive change and the contract change get
+separate review:
+
+1. **Resolver + V2 delegation.** Behavior-identical except the
+   `ttl_options.max` decision above. Table-driven resolver spec (caller
+   type × term combinations) replaces the per-endpoint mock scaffolding
+   for bounds logic.
+2. **Serializer/frontend collapse.** Publish resolved `ttl_ceiling`,
+   simplify `usePrivacyOptions.ts`, deprecate `ttl_max_anonymous` in the
+   bootstrap payload; remove the legacy key one release later.
+
+## History
+
+- #4008: hardcoded 30-day clamp in V2 blocked self-hosted operators from
+  configuring longer TTLs. Fixed minimally by deleting the redundant clamp
+  (the layered bounds already enforce every real limit) and raising the
+  frontend's mirrored caps to `MAX_TTL`. PR #4014 (closed unmerged)
+  prototyped a configurable `TTL_CEILING` knob instead; review concluded it
+  added a sixth layer rather than addressing the layering, which motivated
+  this spec.
+- 2026-07-29 API audit, item 4: anonymous ceiling derived from plan state
+  vanished when billing was disabled; fixed with
+  `configured_anonymous_max_ttl` — the pattern this design generalizes.

--- a/spec/api/v2/secret_ttl_entitlement_spec.rb
+++ b/spec/api/v2/secret_ttl_entitlement_spec.rb
@@ -177,7 +177,8 @@ RSpec.describe 'API V2 Secret TTL Entitlement Gate', type: :integration, billing
       it 'silently clamps when ttl exceeds the plan secret_lifetime ceiling' do
         logic = create_logic(logic_class, params: conceal_params(7_776_000), org: org)
         expect { logic.process_params }.not_to raise_error
-        # 30 days global cap applies first (line 130: `@ttl = 30.days if ttl >= 30.days`)
+        # Plan secret_lifetime (30 days here) is the binding ceiling; the
+        # former hardcoded 30-day global clamp is gone (#4008).
         expect(logic.ttl).to eq(2_592_000)
       end
     end
@@ -243,11 +244,99 @@ RSpec.describe 'API V2 Secret TTL Entitlement Gate', type: :integration, billing
     end
   end
 
+  # Regression suite for #4008 — process_ttl carried a hardcoded
+  # `@ttl = 30.days if ttl >= 30.days` clamp that overrode every configured
+  # ceiling, so self-hosted operators could not offer TTLs beyond 30 days
+  # no matter what ttl_options or plan limits said. The clamp is gone; the
+  # only remaining unconditional bound is WithEntitlements::MAX_TTL
+  # (365 days), which exists because an unlimited plan resolves
+  # limit_for('secret_lifetime') to Infinity.
+  shared_examples 'TTLs beyond 30 days (#4008)' do |logic_class_proc|
+    let(:logic_class) { logic_class_proc.call }
+    let(:max_ttl) { Onetime::Models::Features::WithEntitlements::MAX_TTL }
+
+    def conceal_params(ttl)
+      { 'secret' => { 'secret' => 'test value', 'ttl' => ttl.to_s } }
+    end
+
+    context 'when the plan allows more than 30 days' do
+      let(:org) do
+        mock_organization(
+          planid: 'identity_plus_v1',
+          entitlements: %w[create_secrets api_access extended_default_expiration],
+          secret_lifetime: 90 * 24 * 60 * 60,
+        )
+      end
+
+      it 'preserves a 90-day TTL (used to clamp to 30 days)' do
+        ninety_days = 90 * 24 * 60 * 60
+        logic = create_logic(logic_class, params: conceal_params(ninety_days), org: org)
+        expect { logic.process_params }.not_to raise_error
+        expect(logic.ttl).to eq(ninety_days)
+      end
+
+      it 'preserves a TTL of exactly 30 days (old clamp used >=)' do
+        thirty_days = 30 * 24 * 60 * 60
+        logic = create_logic(logic_class, params: conceal_params(thirty_days), org: org)
+        expect { logic.process_params }.not_to raise_error
+        expect(logic.ttl).to eq(thirty_days)
+      end
+
+      it 'still clamps to the plan limit above it' do
+        logic = create_logic(logic_class, params: conceal_params(120 * 24 * 60 * 60), org: org)
+        expect { logic.process_params }.not_to raise_error
+        expect(logic.ttl).to eq(90 * 24 * 60 * 60)
+      end
+    end
+
+    context 'with an unlimited plan (limit_for resolves to Infinity)' do
+      let(:org) do
+        org = mock_organization(
+          planid: 'identity_plus_v1',
+          entitlements: %w[create_secrets api_access extended_default_expiration],
+        )
+        allow(org).to receive(:limit_for) do |resource|
+          resource.to_s == 'secret_lifetime' ? Float::INFINITY : 0
+        end
+        org
+      end
+
+      it 'clamps to the absolute MAX_TTL safety bound (365 days)' do
+        two_years = 2 * 365 * 24 * 60 * 60
+        logic = create_logic(logic_class, params: conceal_params(two_years), org: org)
+        expect { logic.process_params }.not_to raise_error
+        expect(logic.ttl).to eq(max_ttl)
+      end
+
+      it 'preserves a TTL of exactly MAX_TTL' do
+        logic = create_logic(logic_class, params: conceal_params(max_ttl), org: org)
+        expect { logic.process_params }.not_to raise_error
+        expect(logic.ttl).to eq(max_ttl)
+      end
+    end
+
+    context 'for anonymous callers' do
+      it 'keeps the anonymous ceiling: removing the clamp loosened nothing here' do
+        anonymous_ceiling = Onetime::Models::Features::WithEntitlements.configured_anonymous_max_ttl
+        logic = create_logic(logic_class, params: conceal_params(90 * 24 * 60 * 60), org: nil, auth_method: 'noauth')
+        expect { logic.process_params }.not_to raise_error
+        expect(logic.ttl).to eq(anonymous_ceiling)
+      end
+    end
+
+    it 'MAX_TTL resolves to 365 days' do
+      expect(max_ttl).to eq(365 * 24 * 60 * 60)
+      expect(max_ttl).to eq(31_536_000)
+    end
+  end
+
   describe V2::Logic::Secrets::ConcealSecret do
     include_examples 'extended_default_expiration TTL gate', -> { V2::Logic::Secrets::ConcealSecret }
+    include_examples 'TTLs beyond 30 days (#4008)', -> { V2::Logic::Secrets::ConcealSecret }
   end
 
   describe V2::Logic::Secrets::GenerateSecret do
     include_examples 'extended_default_expiration TTL gate', -> { V2::Logic::Secrets::GenerateSecret }
+    include_examples 'TTLs beyond 30 days (#4008)', -> { V2::Logic::Secrets::GenerateSecret }
   end
 end

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -367,8 +367,11 @@ export const passphraseSchema = z.object({
  */
 export const secretOptionsSchema = z.object({
   default_ttl: z.number().int().positive().default(604800),
+  // Max mirrors the server's absolute bound (WithEntitlements::MAX_TTL,
+  // 365 days) so operator-configured options beyond 30 days survive
+  // bootstrap validation (#4008). Per-caller ceilings apply at request time.
   ttl_options: z
-    .array(z.number().int().positive().min(60).max(2592000))
+    .array(z.number().int().positive().min(60).max(31536000))
     .default([300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000]),
   /**
    * TTL ceiling the server silently applies to anonymous (guest) secrets, in

--- a/src/schemas/contracts/config/section/secret_options.ts
+++ b/src/schemas/contracts/config/section/secret_options.ts
@@ -7,7 +7,7 @@
  * Previously defined in Onetime::Plan.load_plans!
  *
  * Per contracts convention, this schema describes field names and types only.
- * Defaults, TTL bounds (min 60s / max 30d), and the secret-size cap live in
+ * Defaults, TTL bounds (min 60s / max 365d), and the secret-size cap live in
  * `shapes/config/section/secret_options.ts`.
  */
 

--- a/src/schemas/shapes/config/section/secret_options.ts
+++ b/src/schemas/shapes/config/section/secret_options.ts
@@ -34,13 +34,16 @@ const secretOptionBoundariesShape = augment(secretOptionBoundariesSchema, {
 
   /**
    * Available TTL options for secret creation (in seconds).
+   * The max mirrors the server's absolute bound
+   * (WithEntitlements::MAX_TTL); per-caller ceilings are enforced at
+   * request time, not here (#4008).
    * @min 60 - One minute
-   * @max 2592000 - 30 days
+   * @max 31536000 - 365 days
    * @default [300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000]
    */
   ttl_options: () =>
     z
-      .array(z.number().int().positive().min(60).max(2592000))
+      .array(z.number().int().positive().min(60).max(31536000))
       .nullable()
       .default([300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000]),
 

--- a/src/shared/composables/usePrivacyOptions.ts
+++ b/src/shared/composables/usePrivacyOptions.ts
@@ -114,7 +114,10 @@ export function usePrivacyOptions(formOperations?: {
    * get and are never told about.
    */
   const lifetimeOptions = computed<LifetimeOption[]>(() => {
-    const globalTtl = 3600 * 24 * 30; // 30 days
+    // Mirrors the server's absolute bound (WithEntitlements::MAX_TTL,
+    // 365 days). Real per-caller ceilings arrive via ttlCeiling; this only
+    // drops options the server would refuse on any deployment.
+    const globalTtl = 3600 * 24 * 365;
     const ceiling = ttlCeiling.value;
 
     const available = (secret_options.value?.ttl_options ?? []).filter(

--- a/src/tests/composables/usePrivacyOptions.spec.ts
+++ b/src/tests/composables/usePrivacyOptions.spec.ts
@@ -176,10 +176,37 @@ describe('usePrivacyOptions', () => {
       expect(values()).toEqual([]);
     });
 
-    it('still applies the 30-day global cap', () => {
-      setupStore({ ttl_options: [WEEK, THIRTY_DAYS + 1], ttl_max_anonymous: null });
+    it('still applies the absolute 365-day cap (MAX_TTL)', () => {
+      const ONE_YEAR = 3600 * 24 * 365;
+      setupStore({ ttl_options: [WEEK, ONE_YEAR + 1], ttl_max_anonymous: null });
 
       expect(values()).toEqual([WEEK]);
+    });
+  });
+
+  describe('lifetimeOptions — durations beyond 30 days (#4008)', () => {
+    const NINETY_DAYS = 3600 * 24 * 90;
+
+    // The composable used to hardcode a 30-day cap that silently hid
+    // longer durations a self-hosted operator had configured, even when
+    // the server would have honoured them.
+    it('offers a 90-day option to a guest when the server ceiling allows it', () => {
+      setupStore({
+        ttl_options: [WEEK, THIRTY_DAYS, NINETY_DAYS],
+        ttl_max_anonymous: NINETY_DAYS,
+      });
+
+      expect(values()).toEqual([WEEK, THIRTY_DAYS, NINETY_DAYS]);
+    });
+
+    it('offers a 90-day option to an authenticated caller within their plan limit', () => {
+      setupStore({
+        authenticated: true,
+        ttl_options: [WEEK, THIRTY_DAYS, NINETY_DAYS],
+        secret_lifetime: NINETY_DAYS,
+      });
+
+      expect(values()).toEqual([WEEK, THIRTY_DAYS, NINETY_DAYS]);
     });
   });
 

--- a/src/tests/schemas/contracts/bootstrap.secret_options.spec.ts
+++ b/src/tests/schemas/contracts/bootstrap.secret_options.spec.ts
@@ -1,0 +1,34 @@
+// src/tests/schemas/contracts/bootstrap.secret_options.spec.ts
+//
+// Bounds coverage for the bootstrap contract's secretOptionsSchema.
+//
+// #4008 regression: this schema validates the payload Rhales renders into
+// the page, so its ttl_options max is a second, independent copy of the
+// TTL bound — the shapes/config schema alone raising to 365 days is not
+// enough. When the two drift, an operator-configured option between 30 and
+// 365 days passes config validation but fails bootstrap validation, and
+// the whole secret_options block falls back to defaults.
+
+import { describe, expect, it } from 'vitest';
+import { secretOptionsSchema } from '@/schemas/contracts/bootstrap';
+
+describe('bootstrap secretOptionsSchema — ttl_options bounds', () => {
+  it('accepts entries between 30 and 365 days (#4008)', () => {
+    const ninetyDays = 90 * 86400;
+    const result = secretOptionsSchema.parse({ ttl_options: [ninetyDays] });
+    expect(result.ttl_options).toEqual([ninetyDays]);
+  });
+
+  it('accepts boundary values 60s and 365 days', () => {
+    const result = secretOptionsSchema.parse({ ttl_options: [60, 31536000] });
+    expect(result.ttl_options).toEqual([60, 31536000]);
+  });
+
+  it('rejects entries above 365 days (MAX_TTL)', () => {
+    expect(() => secretOptionsSchema.parse({ ttl_options: [31536001] })).toThrow();
+  });
+
+  it('rejects entries below 60s', () => {
+    expect(() => secretOptionsSchema.parse({ ttl_options: [30] })).toThrow();
+  });
+});

--- a/src/tests/schemas/shapes/config/secret_options.spec.ts
+++ b/src/tests/schemas/shapes/config/secret_options.spec.ts
@@ -2,7 +2,7 @@
 //
 // Coverage for the secret_options shape — the per-user-type boundaries
 // schema (`secretOptionBoundariesShape`) carries every default and bound
-// (TTL 60s..30d, size up to 10MB) and is composed via
+// (TTL 60s..365d, size up to 10MB) and is composed via
 // `z.record(UserTypeKeys, ...)` to form `secretOptionsShape`.
 
 import { describe, it, expect } from 'vitest';
@@ -43,13 +43,22 @@ describe('secretOptionBoundariesShape — TTL bounds', () => {
     expect(() => secretOptionBoundariesShape.parse({ ttl_options: [30] })).toThrow();
   });
 
-  it('rejects ttl_options entries above 30 days', () => {
-    expect(() => secretOptionBoundariesShape.parse({ ttl_options: [2592001] })).toThrow();
+  it('rejects ttl_options entries above 365 days (MAX_TTL)', () => {
+    expect(() => secretOptionBoundariesShape.parse({ ttl_options: [31536001] })).toThrow();
   });
 
-  it('accepts boundary values 60s and 30 days', () => {
-    const result = secretOptionBoundariesShape.parse({ ttl_options: [60, 2592000] });
-    expect(result.ttl_options).toEqual([60, 2592000]);
+  it('accepts boundary values 60s and 365 days', () => {
+    const result = secretOptionBoundariesShape.parse({ ttl_options: [60, 31536000] });
+    expect(result.ttl_options).toEqual([60, 31536000]);
+  });
+
+  // #4008 regression: the shape used to cap ttl_options at 30 days, which
+  // rejected self-hosted configs offering longer durations before the
+  // backend ever saw them.
+  it('accepts ttl_options entries between 30 and 365 days', () => {
+    const ninetyDays = 90 * 86400;
+    const result = secretOptionBoundariesShape.parse({ ttl_options: [ninetyDays] });
+    expect(result.ttl_options).toEqual([ninetyDays]);
   });
 
   it('rejects non-positive default_ttl', () => {


### PR DESCRIPTION
## Summary

[#4008](https://github.com/onetimesecret/onetimesecret/issues/4008)

Self-hosted operators could not offer secret TTLs beyond 30 days no matter what they configured. V2's `process_ttl` applied a hardcoded `@ttl = 30.days if ttl >= 30.days` *before* the real bounds check, silently overriding every configured ceiling (plan `secret_lifetime`, `ttl_options`, the anonymous cap). The frontend mirrored the same number twice — the duration-dropdown filter and the `ttl_options` Zod schema — hiding or rejecting longer durations before the backend ever saw them.

This PR removes the redundant clamp and raises both frontend mirrors to the existing absolute bound, `WithEntitlements::MAX_TTL` (365 days):

- **`apps/api/v2/logic/secrets/base_secret_action.rb`** — the 30-day clamp is replaced with a `MAX_TTL` safety clamp. The safety clamp is kept (rather than deleting the line outright) because an unlimited plan resolves `limit_for('secret_lifetime')` to `Float::INFINITY`, leaving the bounds ladder with no terminal bound.
- **`src/shared/composables/usePrivacyOptions.ts`** — the dropdown's hardcoded 30-day cap becomes 365 days; real per-caller ceilings still arrive via `ttlCeiling`.
- **`src/schemas/shapes/config/section/secret_options.ts`** — `ttl_options` entries accepted up to 365 days instead of 30.

No defaults change. All real ceilings — plan limits, the 7-day anonymous cap, config `ttl_options` — are unchanged and still enforced. V3 inherits the fix (its secret actions subclass V2's); V1 intentionally keeps its frozen 30-day contract.

Also adds `docs/specs/ttl_policy/ttl_policy.md`: a proposed design for collapsing the layered TTL bounds into a single `TtlPolicy` resolver (platform-level boundary container + org-level policies), superseding the configurable-ceiling approach prototyped in #4014 (closed unmerged).

## Related Issues

Fixes #4008

## Test Plan

- New regression suite in `spec/api/v2/secret_ttl_entitlement_spec.rb` (`TTLs beyond 30 days (#4008)`, run against both ConcealSecret and GenerateSecret): 90-day TTLs survive when the plan allows them, exactly-30-day requests are preserved, requests above an unlimited plan clamp at `MAX_TTL`, and the anonymous 7-day ceiling is proven unaffected by the clamp's removal.
- `src/tests/composables/usePrivacyOptions.spec.ts`: new `#4008` block — 90-day options render for guests and authenticated callers when the server ceiling allows; the absolute-cap test updated from 30 to 365 days.
- `src/tests/schemas/shapes/config/secret_options.spec.ts`: boundary tests moved to 365 days, plus a regression test that 30–365-day entries now validate.
- Ran locally: both TS suites (37 passed). Ruby suites run in CI (this container lacks the pinned Ruby 3.4.10).

---
_Generated by [Claude Code](https://claude.ai/code/session_011gKPNht6VcfjcU4LyfGzek)_