### PR TITLE
Depth mode grants forwarded-host trust via otto peer-trust fix (#4024)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,11 @@ source 'https://rubygems.org/'
 # Core Application Framework
 # ====================================
 
-gem 'otto', '~> 2.5'
+# TODO(#4024): revert to a plain version constraint (the release after otto
+# 2.7.0) once the depth-mode peer-trust fix (delano/otto#226) ships to
+# RubyGems. The git ref consumes that fix so depth mode gets a forwarded-host
+# trust signal (otto.via_trusted_proxy) ahead of the release.
+gem 'otto', git: 'https://github.com/delano/otto', branch: 'claude/depth-mode-peer-trust-slv7bv'
 gem 'rhales', '~> 0.7.1'
 gem 'roda', '~> 3.0'
 gem 'rodauth', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ source 'https://rubygems.org/'
 # trust signal (otto.via_trusted_proxy) ahead of the release. Pinned to an
 # immutable commit (delano/otto#227 head) so installs stay reproducible even
 # if the branch moves or is deleted.
-gem 'otto', git: 'https://github.com/delano/otto', ref: 'e7fa0b21410342d4f239c64bdd85e94972fe686f'
+gem 'otto', git: 'https://github.com/delano/otto', ref: 'd11847467359d6aa080c3f1b7ef973c1e8e65573'
 gem 'rhales', '~> 0.7.1'
 gem 'roda', '~> 3.0'
 gem 'rodauth', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,10 @@ source 'https://rubygems.org/'
 # TODO(#4024): revert to a plain version constraint (the release after otto
 # 2.7.0) once the depth-mode peer-trust fix (delano/otto#226) ships to
 # RubyGems. The git ref consumes that fix so depth mode gets a forwarded-host
-# trust signal (otto.via_trusted_proxy) ahead of the release.
-gem 'otto', git: 'https://github.com/delano/otto', branch: 'claude/depth-mode-peer-trust-slv7bv'
+# trust signal (otto.via_trusted_proxy) ahead of the release. Pinned to an
+# immutable commit (delano/otto#227 head) so installs stay reproducible even
+# if the branch moves or is deleted.
+gem 'otto', git: 'https://github.com/delano/otto', ref: 'e7fa0b21410342d4f239c64bdd85e94972fe686f'
 gem 'rhales', '~> 0.7.1'
 gem 'roda', '~> 3.0'
 gem 'rodauth', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -697,7 +697,7 @@ DEPENDENCIES
   webmock (~> 3.0)
 
 RUBY VERSION
-  ruby 3.3.6
+  ruby 3.4.10
 
 BUNDLED WITH
   4.0.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/delano/otto
-  revision: e7fa0b21410342d4f239c64bdd85e94972fe686f
-  ref: e7fa0b21410342d4f239c64bdd85e94972fe686f
+  revision: d11847467359d6aa080c3f1b7ef973c1e8e65573
+  ref: d11847467359d6aa080c3f1b7ef973c1e8e65573
   specs:
     otto (2.7.0)
       concurrent-ruby (~> 1.3, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/delano/otto
   revision: e7fa0b21410342d4f239c64bdd85e94972fe686f
-  branch: claude/depth-mode-peer-trust-slv7bv
+  ref: e7fa0b21410342d4f239c64bdd85e94972fe686f
   specs:
     otto (2.7.0)
       concurrent-ruby (~> 1.3, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,16 @@
+GIT
+  remote: https://github.com/delano/otto
+  revision: e7fa0b21410342d4f239c64bdd85e94972fe686f
+  branch: claude/depth-mode-peer-trust-slv7bv
+  specs:
+    otto (2.7.0)
+      concurrent-ruby (~> 1.3, < 2.0)
+      logger (~> 1, < 2.0)
+      loofah (~> 2.20)
+      rack (~> 3.1, < 4.0)
+      rack-parser (~> 0.7)
+      rexml (~> 3.4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -275,13 +288,6 @@ GEM
     openssl-signature_algorithm (1.3.0)
       openssl (> 2.0)
     ostruct (0.6.3)
-    otto (2.6.0)
-      concurrent-ruby (~> 1.3, < 2.0)
-      logger (~> 1, < 2.0)
-      loofah (~> 2.20)
-      rack (~> 3.1, < 4.0)
-      rack-parser (~> 0.7)
-      rexml (~> 3.4)
     parallel (2.1.0)
     parlour (9.1.2)
       commander (~> 5.0)
@@ -630,7 +636,7 @@ DEPENDENCIES
   omniauth-github (~> 2.0)
   omniauth-google-oauth2 (~> 1.2)
   omniauth_openid_connect (~> 0.8)
-  otto (~> 2.5)
+  otto!
   passforge (~> 1.1)
   pg (~> 1.6)
   psych (~> 5.2.3)
@@ -691,7 +697,7 @@ DEPENDENCIES
   webmock (~> 3.0)
 
 RUBY VERSION
-  ruby 3.4.10
+  ruby 3.3.6
 
 BUNDLED WITH
   4.0.9

--- a/lib/middleware/detect_host.rb
+++ b/lib/middleware/detect_host.rb
@@ -70,8 +70,10 @@ module Rack
   #
   # - env['otto.via_trusted_proxy'] is true — recorded by Otto's
   #   IPPrivacyMiddleware (mounted earlier in the stack) from the ORIGINAL
-  #   connecting peer against the configured trusted-proxy CIDRs, before it
-  #   rewrites REMOTE_ADDR to the resolved client IP; or
+  #   connecting peer, before it rewrites REMOTE_ADDR to the resolved client
+  #   IP. Otto grants it when the peer matches a configured trusted-proxy
+  #   CIDR (filter mode) or whenever count-based depth mode is active
+  #   (configuring a depth asserts the peer is the proxy tier; otto#226); or
   # - REMOTE_ADDR is a private/loopback address — the legacy heuristic that
   #   keeps self-hosted installs behind a local reverse proxy working when
   #   no trusted-proxy list is configured.
@@ -192,11 +194,13 @@ module Rack
       #    trust from default-config self-hosters behind a local reverse
       #    proxy, whose masked REMOTE_ADDR stays private. Non-boolean values
       #    (nil, strings from a future otto) also fall through gracefully.
-      # c. Known gap: in TRUSTED_PROXY_MODE=depth otto's trust list is empty
-      #    so the key is always false AND REMOTE_ADDR is rewritten to the
-      #    public client IP — forwarded-host trust is unavailable. This is a
-      #    pre-existing limitation tracked upstream in otto; do not attempt
-      #    to work around it here.
+      # c. TRUSTED_PROXY_MODE=depth: fixed upstream in otto#226. Depth and
+      #    CIDRs are mutually exclusive so otto's matcher list is empty, but
+      #    configuring a depth is the operator's assertion that the
+      #    connecting peer is their proxy tier, so otto records the key true
+      #    and grant (a) applies. (Until the otto#151 depth remap is
+      #    reconciled, depth mode remains spoofable in the documented
+      #    single-proxy setup — operator docs steer to filter mode.)
       remote_addr        = env['REMOTE_ADDR']
       from_trusted_proxy = env[VIA_TRUSTED_PROXY_KEY] == true ||
                            self.class.private_ip?(remote_addr)

--- a/try/integration/middleware/detect_host_ip_privacy_stack_try.rb
+++ b/try/integration/middleware/detect_host_ip_privacy_stack_try.rb
@@ -28,7 +28,8 @@
 # 4. Direct public request: forwarded host headers ignored, Host wins
 # 5. Direct-connect config + private peer: forwarded host headers trusted via
 #    the private-peer heuristic (back-compat for self-hosted installs)
-# 6. Depth mode: forwarded-host trust unavailable (known otto limitation)
+# 6. Depth mode: otto records peer trust from the depth assertion (otto#226),
+#    so forwarded host headers are honored via the otto key alone
 
 require_relative '../../support/test_helpers'
 
@@ -170,14 +171,14 @@ OT.send(:conf=, @saved_conf)
 [@captured['rack.detected_host'], @captured['otto.via_trusted_proxy']]
 #=> ['forwarded.example.com', false]
 
-## KNOWN LIMITATION (pinned deliberately; tracked for an upstream otto fix):
-## in depth mode otto's trusted-proxy list is empty (depth and CIDRs are
-## mutually exclusive), so it records via_trusted_proxy=false even though the
-## request DID arrive through the counted proxy tier, AND it rewrites
-## REMOTE_ADDR to the (masked) public client — both trust signals decline and
-## forwarded-host trust is unavailable: Apx-Incoming-Host is discarded, Host
-## wins. When otto learns to record depth-based trust in via_trusted_proxy,
-## this expectation flips and must be updated deliberately.
+## Depth mode grants forwarded-host trust (otto#226 — the deliberate flip of
+## the KNOWN LIMITATION this case used to pin): depth and CIDRs are mutually
+## exclusive so otto's matcher list is empty, but configuring a depth asserts
+## the connecting peer is the proxy tier, so otto records
+## via_trusted_proxy=true from the pre-rewrite peer. REMOTE_ADDR is still
+## rewritten to the (masked) PUBLIC client, so the private-peer heuristic
+## still declines — the otto key is the ONLY trust signal here, which is
+## exactly the cross-gem contract this file exists to pin.
 @depth_stack.call(
   {
     'REMOTE_ADDR' => '10.0.0.5',
@@ -191,4 +192,4 @@ OT.send(:conf=, @saved_conf)
   @captured['otto.via_trusted_proxy'],
   Rack::DetectHost.private_ip?(@captured['REMOTE_ADDR']),
 ]
-#=> ['eu.onetimesecret.com', false, false]
+#=> ['ca.metalbaum.example.com', true, false]

--- a/try/integration/middleware/detect_host_ip_privacy_stack_try.rb
+++ b/try/integration/middleware/detect_host_ip_privacy_stack_try.rb
@@ -179,6 +179,13 @@ OT.send(:conf=, @saved_conf)
 ## rewritten to the (masked) PUBLIC client, so the private-peer heuristic
 ## still declines — the otto key is the ONLY trust signal here, which is
 ## exactly the cross-gem contract this file exists to pin.
+##
+## The two-entry XFF is load-bearing: otto's depth chain is XFF + REMOTE_ADDR
+## and this config trusts depth 2 (ots depth 1 + the otto#151 remap), so a
+## single-entry XFF would leave the chain too short — otto would fall back to
+## REMOTE_ADDR (10.0.0.5, private), the private-peer heuristic would grant
+## trust, and the otto-key-only assertion would silently weaken. Do NOT
+## "align" this XFF with the single-entry filter-mode case above.
 @depth_stack.call(
   {
     'REMOTE_ADDR' => '10.0.0.5',


### PR DESCRIPTION
## Summary

[#4024](https://github.com/onetimesecret/onetimesecret/issues/4024)

Downstream half of the depth-mode trust fix. Consumes the upstream otto#226 fix (delano/otto#227): in `TRUSTED_PROXY_MODE=depth`, otto now records `otto.via_trusted_proxy = true` from the pre-rewrite connecting peer (configuring a `trusted_proxy_depth` asserts the peer is the operator's proxy tier), so `Rack::DetectHost`'s existing grant-only OR honors forwarded host headers (`Apx-Incoming-Host`, `X-Forwarded-Host`) in depth mode and custom domains classify correctly instead of all falling back to canonical.

- **Gemfile / Gemfile.lock**: pin otto to the delano/otto#227 head (`d118474`, immutable commit). otto#227 is **merged** and released as **otto 2.8.0** — this git pin is safe to merge (the commit is reachable from otto main) and is retired in #4029, which swaps to `gem 'otto', '~> 2.8'`. The lockfile diff is otto-only (`concurrent-ruby` and `RUBY VERSION` drift reverted by hand).
- **`try/integration/middleware/detect_host_ip_privacy_stack_try.rb`**: the deliberate flip of the pinned KNOWN LIMITATION case — depth mode now detects `ca.metalbaum.example.com` with `via_trusted_proxy=true` while `REMOTE_ADDR` stays rewritten to the (masked) public client, so the otto key is the *only* trust signal, which is exactly the cross-gem contract this file pins.
- **`lib/middleware/detect_host.rb`**: comment-only — trust-grant docs updated for the depth grant.

No code change in DetectHost itself: the grant-only OR from #4021 already honors the key.

**Stacked follow-ups** (merge bottom-up after this PR): **#4028** drops the otto#151 depth `+1` remap — the source of the old "depth mode remains spoofable in the documented single-proxy setup" caveat — with padding-resistance tests; **#4029** consumes otto's tri-state trust key (delano/otto#228) and retires the grant-only OR.

## Related Issues

Fixes #4024. Depends on delano/otto#227 (otto#226 — merged, released in otto 2.8.0). Follow-up to #4021. Stack continues in #4028 → #4029.

## Test Plan

- `try/integration/middleware/detect_host_ip_privacy_stack_try.rb` — all 6 pass against the pinned otto, including the flipped depth-mode case (production config builder, real `IPPrivacyMiddleware` in front of real `DetectHost`).
- `try/integration/middleware/detect_host_try.rb` — 18 pass (unchanged; hand-injected-key contract cases still hold).
- Upstream: otto suite green on the fix branch (2044 examples, 0 failures); otto 2.8.0 released with the full 2055-example suite green.
- Re-verified after the 2026-08-07 rebase onto main (`dd798bf`): both tryout files green locally.
- rspec (`ip_privacy_parity_spec.rb` etc.) couldn't run in this sandbox (Ruby 3.3.6 vs the repo's 3.4.10 — spec_helper uses 3.4 `it` block params); CI on 3.4.10 will cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJ6BDA3VXsTtToXKp2To1x