### PR TITLE
Drop the +1 depth remap that double-counted the connecting peer

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -1147,9 +1147,13 @@ TRUSTED_PROXY_ENABLED=false
 #   Note: filter mode ignores TRUSTED_PROXY_HEADER and reads the
 #   X-Forwarded-For family (X-Forwarded-For, X-Real-IP, X-Client-IP).
 # - depth:  position-based; skip exactly TRUSTED_PROXY_DEPTH rightmost hops.
-#   Counts positions from the RIGHT of the chain, so a forged leftmost entry
-#   is never reached. Use for CDNs with public IPs, variable proxy depth, or
-#   when you need deterministic hop selection regardless of IP class.
+#   Counts positions from the RIGHT of the chain, so extra leftmost entries
+#   (forged or from farther upstream) never shift the selection. Requires a
+#   FIXED hop count with each counted hop appending exactly one entry: a
+#   chain shorter than the depth falls back to the peer, and a depth larger
+#   than the real hop count selects a client-supplied entry. Use for proxies
+#   with public IPs that filter mode would misread as the client, or when
+#   you need deterministic hop selection regardless of IP class.
 TRUSTED_PROXY_MODE=filter
 
 # depth mode only: which header to read the forwarding chain from.

--- a/.env.reference
+++ b/.env.reference
@@ -1138,8 +1138,11 @@ TRUSTED_PROXY_ENABLED=false
 #   ({client_ip} honours Caddy's own trusted_proxies, so it resolves the real
 #   visitor when Caddy is itself behind a declared CDN; with none declared it
 #   is the direct peer, same as {remote_host}. See etc/examples/Caddyfile-example.)
-#   Use depth mode when you cannot make the edge overwrite. Do NOT combine the
-#   overwrite above with depth mode: it collapses the chain that depth counts.
+#   Use depth mode when you cannot make the edge overwrite. Combining the
+#   overwrite above with depth mode is correct ONLY for TRUSTED_PROXY_DEPTH=1
+#   (the overwrite leaves exactly one attested entry, which depth 1 selects);
+#   a depth of 2 or more needs each counted hop to append one entry, and the
+#   overwrite collapses that chain, so resolution falls back to the peer.
 #
 #   Note: filter mode ignores TRUSTED_PROXY_HEADER and reads the
 #   X-Forwarded-For family (X-Forwarded-For, X-Real-IP, X-Client-IP).

--- a/changelog.d/20260807_160000_claude_4024_depth_remap_fix.rst
+++ b/changelog.d/20260807_160000_claude_4024_depth_remap_fix.rst
@@ -21,10 +21,12 @@ Fixed
   client that smuggled one forged leftmost ``X-Forwarded-For`` entry past
   the proxy got the forged value resolved as its client IP. The depth value
   now maps directly (``trusted_proxy_depth = depth``), which resolves the
-  true client on honest chains and never selects a forged leftmost entry,
-  provided each counted hop appends exactly one entry (positions are counted
-  raw from the right; a chain shorter or longer than the configured depth
-  selects the peer or a client-supplied entry — keep the edge locked down).
+  true client on honest chains and never selects a forged leftmost entry:
+  positions are counted raw from the right, so left-side padding cannot
+  shift the selection. The depth must match the real hop count, each hop
+  appending exactly one entry — a shorter chain falls back to the peer,
+  while a depth larger than the real hop count selects a client-supplied
+  entry (keep the edge locked down).
   Operators who compensated for the bug by setting ``depth`` one lower than
   their real hop count should correct it to the actual number of proxies.
   (#4024)

--- a/changelog.d/20260807_160000_claude_4024_depth_remap_fix.rst
+++ b/changelog.d/20260807_160000_claude_4024_depth_remap_fix.rst
@@ -1,0 +1,22 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- ``TRUSTED_PROXY_MODE=depth`` now resolves the real client IP. The
+  YAML→otto translator added 1 to the configured ``depth`` (the otto#151
+  remap), which double-counted the connecting peer: otto's hop chain is
+  ``X-Forwarded-For + [REMOTE_ADDR]`` with the client selected at
+  ``chain[-(depth+1)]``, so ``depth: N`` already means "N proxy hops,
+  counting the peer as hop 1" — exactly what the config documents
+  ("1 = standard single reverse proxy"). Under the remap, every honest
+  request in a documented topology hit otto's short-chain fallback and
+  resolved the PROXY address as the client (IP rate limits, bans, and audit
+  attribution all keyed on the proxy), while a client that smuggled one
+  forged leftmost ``X-Forwarded-For`` entry past the proxy got the forged
+  value resolved as its client IP. The depth value now maps directly
+  (``trusted_proxy_depth = depth``), which resolves the true client on
+  honest chains and never selects a forged leftmost entry (positions are
+  counted raw from the right). Operators who compensated for the bug by
+  setting ``depth`` one lower than their real hop count should correct it to
+  the actual number of proxies. (#4024)

--- a/changelog.d/20260807_160000_claude_4024_depth_remap_fix.rst
+++ b/changelog.d/20260807_160000_claude_4024_depth_remap_fix.rst
@@ -11,12 +11,20 @@ Fixed
   counting the peer as hop 1" — exactly what the config documents
   ("1 = standard single reverse proxy"). Under the remap, every honest
   request in a documented topology hit otto's short-chain fallback and
-  resolved the PROXY address as the client (IP rate limits, bans, and audit
-  attribution all keyed on the proxy), while a client that smuggled one
-  forged leftmost ``X-Forwarded-For`` entry past the proxy got the forged
-  value resolved as its client IP. The depth value now maps directly
-  (``trusted_proxy_depth = depth``), which resolves the true client on
-  honest chains and never selects a forged leftmost entry (positions are
-  counted raw from the right). Operators who compensated for the bug by
-  setting ``depth`` one lower than their real hop count should correct it to
-  the actual number of proxies. (#4024)
+  resolved the PROXY address as the client. IP rate limits, bans, and audit
+  attribution all keyed on the proxy — and because the masked proxy address
+  stays private, access controls that match the resolved IP against private
+  ranges passed for EVERY proxied request: depth-mode operators using
+  admin/colonel network isolation (``admin.allowed_cidrs`` with private
+  ranges, as the operations doc recommends) or health-endpoint access
+  control should audit access logs for the affected window. Meanwhile a
+  client that smuggled one forged leftmost ``X-Forwarded-For`` entry past
+  the proxy got the forged value resolved as its client IP. The depth value
+  now maps directly (``trusted_proxy_depth = depth``), which resolves the
+  true client on honest chains and never selects a forged leftmost entry,
+  provided each counted hop appends exactly one entry (positions are counted
+  raw from the right; a chain shorter or longer than the configured depth
+  selects the peer or a client-supplied entry — keep the edge locked down).
+  Operators who compensated for the bug by setting ``depth`` one lower than
+  their real hop count should correct it to the actual number of proxies.
+  (#4024)

--- a/etc/examples/Caddyfile-example
+++ b/etc/examples/Caddyfile-example
@@ -260,9 +260,11 @@
 			# depth >= 2? Drop the X-Forwarded-For line below and let Caddy append,
 			# preserving the hop chain, and set TRUSTED_PROXY_DEPTH to the number of
 			# hops your topology puts in the chain (see .env.reference).
-			# Depth mode tolerates an untrusted leftmost entry only while that hop
-			# count is fixed and correct — a chain shorter or longer than configured
-			# selects the peer or a client-supplied entry.
+			# Depth mode tolerates untrusted leftmost entries (selection is anchored
+			# at the right, so left-side padding never shifts it), but the count must
+			# match the topology: a chain shorter than the depth falls back to the
+			# peer, and a depth larger than the real hop count selects a
+			# client-supplied entry.
 			header_up X-Forwarded-For {client_ip}
 			header_up X-Real-IP {client_ip}
 

--- a/etc/examples/Caddyfile-example
+++ b/etc/examples/Caddyfile-example
@@ -250,14 +250,16 @@
 			# another proxy, declare that proxy in `trusted_proxies` or this writes the
 			# upstream's address as the client IP.
 			#
-			# ONLY correct for filter mode. TRUSTED_PROXY_MODE=depth picks the client
-			# by counting TRUSTED_PROXY_DEPTH hops from the RIGHT of the chain, so
-			# collapsing X-Forwarded-For to a single entry leaves nothing to count and
-			# resolution falls back to the wrong address — IP rate limits, audit
-			# attribution, and network restrictions then key on a proxy, not the user.
-			# Running depth mode? Drop the X-Forwarded-For line below and let Caddy
-			# append, preserving the hop chain, and set TRUSTED_PROXY_DEPTH to the
-			# number of hops your topology puts in the chain (see .env.reference).
+			# Correct for filter mode AND for TRUSTED_PROXY_MODE=depth with
+			# TRUSTED_PROXY_DEPTH=1: the overwrite leaves exactly one attested entry
+			# (Caddy's resolved client), which depth 1 selects — the safest
+			# single-proxy depth config. With a depth of 2 or more, collapsing
+			# X-Forwarded-For to a single entry leaves fewer hops than the count and
+			# resolution falls back to the peer — IP rate limits, audit attribution,
+			# and network restrictions then key on a proxy, not the user. Running
+			# depth >= 2? Drop the X-Forwarded-For line below and let Caddy append,
+			# preserving the hop chain, and set TRUSTED_PROXY_DEPTH to the number of
+			# hops your topology puts in the chain (see .env.reference).
 			# Depth mode tolerates an untrusted leftmost entry only while that hop
 			# count is fixed and correct — a chain shorter or longer than configured
 			# selects the peer or a client-supplied entry.

--- a/lib/middleware/detect_host.rb
+++ b/lib/middleware/detect_host.rb
@@ -200,9 +200,11 @@ module Rack
       #    connecting peer is their proxy tier, so otto records the key true
       #    and grant (a) applies. Depth counts hops from the right with the
       #    peer as hop 1 (the otto#151 remap was dropped), so a forged
-      #    leftmost XFF entry is never selected; as with all count-based
-      #    trust, the origin must be unreachable except through the proxy
-      #    tier.
+      #    leftmost XFF entry is never selected — provided each counted hop
+      #    appends exactly one entry; a chain shorter or longer than the
+      #    configured depth selects the peer or a client-supplied entry. As
+      #    with all count-based trust, the origin must be unreachable except
+      #    through the proxy tier.
       remote_addr        = env['REMOTE_ADDR']
       from_trusted_proxy = env[VIA_TRUSTED_PROXY_KEY] == true ||
                            self.class.private_ip?(remote_addr)

--- a/lib/middleware/detect_host.rb
+++ b/lib/middleware/detect_host.rb
@@ -199,12 +199,14 @@ module Rack
       #    configuring a depth is the operator's assertion that the
       #    connecting peer is their proxy tier, so otto records the key true
       #    and grant (a) applies. Depth counts hops from the right with the
-      #    peer as hop 1 (the otto#151 remap was dropped), so a forged
-      #    leftmost XFF entry is never selected — provided each counted hop
-      #    appends exactly one entry; a chain shorter or longer than the
-      #    configured depth selects the peer or a client-supplied entry. As
-      #    with all count-based trust, the origin must be unreachable except
-      #    through the proxy tier.
+      #    peer as hop 1 (the otto#151 remap was dropped), so extra leftmost
+      #    XFF entries — forged or from farther upstream — never shift the
+      #    selection. The hazard is a depth/topology mismatch: a chain
+      #    shorter than the depth falls back to the peer (misattribution),
+      #    and a depth larger than the real proxy hop count selects a
+      #    client-supplied entry (spoofable). Each counted hop must append
+      #    exactly one entry. As with all count-based trust, the origin must
+      #    be unreachable except through the proxy tier.
       remote_addr        = env['REMOTE_ADDR']
       from_trusted_proxy = env[VIA_TRUSTED_PROXY_KEY] == true ||
                            self.class.private_ip?(remote_addr)

--- a/lib/middleware/detect_host.rb
+++ b/lib/middleware/detect_host.rb
@@ -198,9 +198,11 @@ module Rack
       #    CIDRs are mutually exclusive so otto's matcher list is empty, but
       #    configuring a depth is the operator's assertion that the
       #    connecting peer is their proxy tier, so otto records the key true
-      #    and grant (a) applies. (Until the otto#151 depth remap is
-      #    reconciled, depth mode remains spoofable in the documented
-      #    single-proxy setup — operator docs steer to filter mode.)
+      #    and grant (a) applies. Depth counts hops from the right with the
+      #    peer as hop 1 (the otto#151 remap was dropped), so a forged
+      #    leftmost XFF entry is never selected; as with all count-based
+      #    trust, the origin must be unreachable except through the proxy
+      #    tier.
       remote_addr        = env['REMOTE_ADDR']
       from_trusted_proxy = env[VIA_TRUSTED_PROXY_KEY] == true ||
                            self.class.private_ip?(remote_addr)

--- a/lib/onetime/application/middleware_stack.rb
+++ b/lib/onetime/application/middleware_stack.rb
@@ -167,9 +167,10 @@ module Onetime
         # ConfigureTrustedProxy Rack monkeypatch or a ClientIpHelpers depth
         # walker — this method is the whole of the translation.
         #
-        # Returns nil when trusted proxy support is disabled, which leaves the
-        # middleware in its default direct-connection mode (REMOTE_ADDR is the
-        # client) — correct for deployments not behind a proxy.
+        # When trusted proxy support is disabled the config carries an empty
+        # trust list, which leaves the middleware in its default
+        # direct-connection mode (REMOTE_ADDR is the client) — correct for
+        # deployments not behind a proxy.
         #
         # The returned config also enables full IP masking (mask_private_ips)
         # so the single universal IPPrivacyMiddleware mount masks private/
@@ -185,8 +186,10 @@ module Onetime
         #   - depth: count-based. Trusts the last N hops, counting the
         #     connecting peer as hop 1: Onetime depth N maps DIRECTLY to otto
         #     trusted_proxy_depth = N (otto's chain[-(N+1)] index already
-        #     accounts for the appended REMOTE_ADDR — see the corrected otto
-        #     v2.3.0 migration guide). Mutually exclusive with add_trusted_proxy.
+        #     accounts for the appended REMOTE_ADDR — see delano/otto#228's
+        #     migration-guide correction; the former `+ 1` here reproduced the
+        #     deleted walker's off-by-one). Mutually exclusive with
+        #     add_trusted_proxy.
         #
         # Header (site.network.trusted_proxy.header): in depth mode otto 2.3.1
         # counts hops from the configured forwarded header — 'X-Forwarded-For'

--- a/lib/onetime/application/middleware_stack.rb
+++ b/lib/onetime/application/middleware_stack.rb
@@ -182,10 +182,11 @@ module Onetime
         #     PRIVATE_PROXY_RANGES regex PLUS every entry in `cidrs` (real IPAddr
         #     CIDR containment via add_trusted_proxy). Otto::Utils.resolve_client_ip
         #     walks the forwarded chain and returns the first non-proxy hop.
-        #   - depth: count-based. Trusts the last N hops. Onetime depth N maps to
-        #     otto trusted_proxy_depth = N + 1 because otto's chain appends
-        #     REMOTE_ADDR (one hop longer than Onetime's XFF-only chain). See the
-        #     otto v2.3.0 migration guide. Mutually exclusive with add_trusted_proxy.
+        #   - depth: count-based. Trusts the last N hops, counting the
+        #     connecting peer as hop 1: Onetime depth N maps DIRECTLY to otto
+        #     trusted_proxy_depth = N (otto's chain[-(N+1)] index already
+        #     accounts for the appended REMOTE_ADDR — see the corrected otto
+        #     v2.3.0 migration guide). Mutually exclusive with add_trusted_proxy.
         #
         # Header (site.network.trusted_proxy.header): in depth mode otto 2.3.1
         # counts hops from the configured forwarded header — 'X-Forwarded-For'
@@ -231,11 +232,17 @@ module Onetime
 
           if mode == 'depth'
             ots_depth                  = tp['depth'].to_i.clamp(1, 10)
-            # otto#151 remap: otto's chain is XFF + [REMOTE_ADDR], one hop longer
-            # than Onetime's XFF-only chain, so resolve the same client by
-            # trusting one extra hop. Mutually exclusive with add_trusted_proxy —
-            # do NOT also register CIDRs (otto raises).
-            config.trusted_proxy_depth = ots_depth + 1
+            # Direct mapping — no +1. Otto's chain is XFF + [REMOTE_ADDR] with
+            # the client at chain[-(N+1)], so depth N already means "N proxy
+            # hops counting the connecting peer as hop 1" — exactly what the
+            # operator-facing `depth: N` documents (1 = single reverse proxy).
+            # The former otto#151 `+ 1` remap reproduced an off-by-one of the
+            # deleted ClientIpHelpers walker: honest documented-topology
+            # requests hit otto's short-chain fallback and resolved the PROXY
+            # address, and one forged leftmost XFF entry got selected as the
+            # client. Mutually exclusive with add_trusted_proxy — do NOT also
+            # register CIDRs (otto raises).
+            config.trusted_proxy_depth = ots_depth
           else
             # filter / CIDR-walk: trust the private proxy ranges plus any
             # operator-configured public CIDRs (e.g. a CDN's egress ranges).

--- a/spec/unit/onetime/application/ip_privacy_parity_spec.rb
+++ b/spec/unit/onetime/application/ip_privacy_parity_spec.rb
@@ -72,11 +72,12 @@ RSpec.describe 'IP privacy / trusted-proxy parity (#3436)' do
     before { stub_trusted_proxy('enabled' => true, 'mode' => 'depth', 'depth' => 1) }
 
     it "resolves the client by hop count into env['otto.client_ip'] and masks to its /24" do
-      # Onetime depth 1 => otto trusted_proxy_depth 2 (chain = XFF + REMOTE_ADDR).
-      # chain = [203.0.113.42, 10.244.10.5, 10.244.10.5] ; client = chain[-(2+1)].
+      # Onetime depth 1 => otto trusted_proxy_depth 1 (direct mapping, no +1).
+      # Honest single-proxy topology: the proxy appends the client to XFF.
+      # chain = [203.0.113.42, 10.244.10.5] ; client = chain[-(1+1)].
       env = {
         'REMOTE_ADDR' => '10.244.10.5',
-        'HTTP_X_FORWARDED_FOR' => '203.0.113.42, 10.244.10.5',
+        'HTTP_X_FORWARDED_FOR' => '203.0.113.42',
       }
 
       build_mount.call(env)
@@ -84,9 +85,28 @@ RSpec.describe 'IP privacy / trusted-proxy parity (#3436)' do
       expect(captured[:env]['otto.client_ip']).to eq('203.0.113.0')
     end
 
-    it 'falls back to the peer (masked) on a short chain (stricter than OTS)' do
-      # Chain shorter than depth+1: otto returns REMOTE_ADDR rather than a
-      # spoofable forwarded entry. Here REMOTE_ADDR is private, masked to /24.
+    it 'never selects a forged leftmost XFF entry (padding-resistant)' do
+      # A client sends its own X-Forwarded-For: 9.9.9.9 before the request
+      # reaches the proxy; the proxy appends the real peer, yielding
+      # XFF = [forged, client]. Positions are counted raw from the RIGHT
+      # (chain = [9.9.9.9, 203.0.113.42, 10.244.10.5], client = chain[-2]),
+      # so padding only pushes the forged entry further left — it is never
+      # selected. Under the former +1 remap this exact shape selected the
+      # forged 9.9.9.9 as the client.
+      env = {
+        'REMOTE_ADDR' => '10.244.10.5',
+        'HTTP_X_FORWARDED_FOR' => '9.9.9.9, 203.0.113.42',
+      }
+
+      build_mount.call(env)
+
+      expect(captured[:env]['otto.client_ip']).to eq('203.0.113.0')
+    end
+
+    it 'falls back to the peer (masked) on a short chain (stricter than OTS legacy)' do
+      # Chain shorter than depth+1 (no XFF at all — a request that bypassed
+      # the proxy tier): otto returns REMOTE_ADDR rather than a spoofable
+      # forwarded entry. Here REMOTE_ADDR is private, masked to /24.
       env = { 'REMOTE_ADDR' => '10.244.10.5' }
 
       build_mount.call(env)
@@ -103,11 +123,11 @@ RSpec.describe 'IP privacy / trusted-proxy parity (#3436)' do
     before { stub_trusted_proxy('enabled' => true, 'mode' => 'depth', 'depth' => 1, 'header' => 'Forwarded') }
 
     it "resolves the client from `Forwarded for=` into env['otto.client_ip'] and masks to its /24" do
-      # Onetime depth 1 => otto depth 2; chain = Forwarded `for=` list + REMOTE_ADDR.
-      # chain = [203.0.113.42, 10.244.10.5, 10.244.10.5] ; client = chain[-(2+1)].
+      # Onetime depth 1 => otto depth 1; chain = Forwarded `for=` list + REMOTE_ADDR.
+      # chain = [203.0.113.42, 10.244.10.5] ; client = chain[-(1+1)].
       env = {
         'REMOTE_ADDR' => '10.244.10.5',
-        'HTTP_FORWARDED' => 'for=203.0.113.42, for=10.244.10.5',
+        'HTTP_FORWARDED' => 'for=203.0.113.42',
         # An X-Forwarded-For present but NOT consulted in Forwarded mode.
         'HTTP_X_FORWARDED_FOR' => '198.51.100.7',
       }
@@ -124,8 +144,9 @@ RSpec.describe 'IP privacy / trusted-proxy parity (#3436)' do
     it 'prefers RFC 7239 Forwarded when it carries a for=' do
       env = {
         'REMOTE_ADDR' => '10.244.10.5',
-        'HTTP_FORWARDED' => 'for=203.0.113.42, for=10.244.10.5',
-        'HTTP_X_FORWARDED_FOR' => '198.51.100.7, 10.244.10.5',
+        'HTTP_FORWARDED' => 'for=203.0.113.42',
+        # Decoy: present but ignored because Forwarded carries a for=.
+        'HTTP_X_FORWARDED_FOR' => '198.51.100.7',
       }
 
       build_mount.call(env)
@@ -136,7 +157,7 @@ RSpec.describe 'IP privacy / trusted-proxy parity (#3436)' do
     it 'falls back to X-Forwarded-For when no Forwarded header is present' do
       env = {
         'REMOTE_ADDR' => '10.244.10.5',
-        'HTTP_X_FORWARDED_FOR' => '198.51.100.7, 10.244.10.5',
+        'HTTP_X_FORWARDED_FOR' => '198.51.100.7',
       }
 
       build_mount.call(env)

--- a/spec/unit/onetime/application/middleware_stack_spec.rb
+++ b/spec/unit/onetime/application/middleware_stack_spec.rb
@@ -138,10 +138,13 @@ RSpec.describe Onetime::Application::MiddlewareStack do
         )
       end
 
-      it 'maps Onetime depth N to otto trusted_proxy_depth N + 1' do
-        # otto#151 remap: otto appends REMOTE_ADDR to the chain, one hop longer
-        # than Onetime's XFF-only chain.
-        expect(config.trusted_proxy_depth).to eq(3)
+      it 'maps Onetime depth N DIRECTLY to otto trusted_proxy_depth N' do
+        # No +1: otto's chain[-(N+1)] index already accounts for the appended
+        # REMOTE_ADDR, so depth N = "N proxy hops counting the connecting peer"
+        # — the operator-facing meaning of `depth: N`. The former +1 remap
+        # made honest documented-topology requests resolve the proxy address
+        # (short-chain fallback) and let one forged leftmost XFF entry win.
+        expect(config.trusted_proxy_depth).to eq(2)
       end
 
       it 'activates count-based depth mode' do
@@ -152,14 +155,14 @@ RSpec.describe Onetime::Application::MiddlewareStack do
         expect(config.trusted_proxies).to be_empty
       end
 
-      it 'clamps Onetime depth to 1..10 before the +1 remap' do
+      it 'clamps Onetime depth to 1..10' do
         stub_conf('enabled' => true, 'mode' => 'depth', 'depth' => 50)
-        expect(config.trusted_proxy_depth).to eq(11) # clamp(1,10) => 10, +1 => 11
+        expect(config.trusted_proxy_depth).to eq(10) # clamp(1,10) => 10
       end
 
-      it 'treats a zero/blank depth as the minimum (1) before remap' do
+      it 'treats a zero/blank depth as the minimum (1)' do
         stub_conf('enabled' => true, 'mode' => 'depth', 'depth' => 0)
-        expect(config.trusted_proxy_depth).to eq(2) # clamp(1,10) => 1, +1 => 2
+        expect(config.trusted_proxy_depth).to eq(1) # clamp(1,10) => 1
       end
     end
 

--- a/spec/unit/onetime/application/middleware_stack_spec.rb
+++ b/spec/unit/onetime/application/middleware_stack_spec.rb
@@ -160,9 +160,14 @@ RSpec.describe Onetime::Application::MiddlewareStack do
         expect(config.trusted_proxy_depth).to eq(10) # clamp(1,10) => 10
       end
 
-      it 'treats a zero/blank depth as the minimum (1)' do
+      it 'treats a zero depth as the minimum (1)' do
         stub_conf('enabled' => true, 'mode' => 'depth', 'depth' => 0)
         expect(config.trusted_proxy_depth).to eq(1) # clamp(1,10) => 1
+      end
+
+      it 'treats an absent depth as the minimum (1)' do
+        stub_conf('enabled' => true, 'mode' => 'depth')
+        expect(config.trusted_proxy_depth).to eq(1) # nil.to_i => 0, clamp => 1
       end
     end
 

--- a/try/integration/middleware/detect_host_ip_privacy_stack_try.rb
+++ b/try/integration/middleware/detect_host_ip_privacy_stack_try.rb
@@ -30,6 +30,8 @@
 #    the private-peer heuristic (back-compat for self-hosted installs)
 # 6. Depth mode: otto records peer trust from the depth assertion (otto#226),
 #    so forwarded host headers are honored via the otto key alone
+# 7. Depth padding resistance (the otto#151 remap fix): a forged leftmost
+#    X-Forwarded-For entry is never selected as the client
 
 require_relative '../../support/test_helpers'
 
@@ -55,8 +57,8 @@ end
 # Build every security config through the PRODUCTION builder,
 # MiddlewareStack.ip_privacy_security_config — the single source of truth
 # that translates site.network.trusted_proxy YAML into Otto::Security::Config
-# (PRIVATE_PROXY_RANGES in filter mode, the depth+1 remap in depth mode,
-# mask_private_ips always). A hand-built config here could not catch
+# (PRIVATE_PROXY_RANGES in filter mode, the direct depth mapping in depth
+# mode, mask_private_ips always). A hand-built config here could not catch
 # config-construction drift; see also
 # spec/unit/onetime/application/ip_privacy_parity_spec.rb.
 #
@@ -74,7 +76,8 @@ end
 # Filter mode (the incident config): PRIVATE_PROXY_RANGES trusted as proxies.
 @trusted_config = @build_production_config.call('enabled' => true, 'mode' => 'filter')
 
-# Depth mode: count-based, Onetime depth 1 => otto trusted_proxy_depth 2.
+# Depth mode: count-based, Onetime depth 1 => otto trusted_proxy_depth 1
+# (direct mapping — the former +1 remap double-counted the appended peer).
 # Depth and CIDRs are mutually exclusive in otto (it raises if both are set).
 @depth_config = @build_production_config.call('enabled' => true, 'mode' => 'depth', 'depth' => 1)
 
@@ -180,16 +183,17 @@ OT.send(:conf=, @saved_conf)
 ## still declines — the otto key is the ONLY trust signal here, which is
 ## exactly the cross-gem contract this file exists to pin.
 ##
-## The two-entry XFF is load-bearing: otto's depth chain is XFF + REMOTE_ADDR
-## and this config trusts depth 2 (ots depth 1 + the otto#151 remap), so a
-## single-entry XFF would leave the chain too short — otto would fall back to
-## REMOTE_ADDR (10.0.0.5, private), the private-peer heuristic would grant
-## trust, and the otto-key-only assertion would silently weaken. Do NOT
-## "align" this XFF with the single-entry filter-mode case above.
+## The single-entry XFF is the honest documented topology for depth: 1 (the
+## proxy appends the client): chain = [203.0.113.50, 10.0.0.5], client =
+## chain[-2] -> REMOTE_ADDR is rewritten to the masked PUBLIC client and the
+## private-peer heuristic stays out of the picture. (Under the former +1
+## remap this shape hit the short-chain fallback and resolved the PRIVATE
+## proxy peer — the fixture then needed a two-entry XFF to keep the
+## otto-key-only assertion honest.)
 @depth_stack.call(
   {
     'REMOTE_ADDR' => '10.0.0.5',
-    'HTTP_X_FORWARDED_FOR' => '203.0.113.50, 10.0.0.5',
+    'HTTP_X_FORWARDED_FOR' => '203.0.113.50',
     'HTTP_APX_INCOMING_HOST' => 'ca.metalbaum.example.com',
     'HTTP_HOST' => 'eu.onetimesecret.com',
   },
@@ -200,3 +204,26 @@ OT.send(:conf=, @saved_conf)
   Rack::DetectHost.private_ip?(@captured['REMOTE_ADDR']),
 ]
 #=> ['ca.metalbaum.example.com', true, false]
+
+## Depth mode is padding-resistant (the otto#151 remap fix): a client smuggles
+## a forged leftmost XFF entry past the proxy (proxy appends the real client,
+## so XFF = [forged, client]). Positions are counted raw from the RIGHT —
+## chain = [9.9.9.9, 203.0.113.50, 10.0.0.5], client = chain[-2] — so the
+## forged entry is never selected: the resolved (masked) client is
+## 203.0.113.0, not 9.9.9.0. Under the former +1 remap this exact shape
+## selected the forged entry as the client. Host detection still works via
+## the depth-granted otto key.
+@depth_stack.call(
+  {
+    'REMOTE_ADDR' => '10.0.0.5',
+    'HTTP_X_FORWARDED_FOR' => '9.9.9.9, 203.0.113.50',
+    'HTTP_APX_INCOMING_HOST' => 'ca.metalbaum.example.com',
+    'HTTP_HOST' => 'eu.onetimesecret.com',
+  },
+)
+[
+  @captured['rack.detected_host'],
+  @captured['otto.via_trusted_proxy'],
+  @captured['otto.client_ip'],
+]
+#=> ['ca.metalbaum.example.com', true, '203.0.113.0']


### PR DESCRIPTION
## Summary

**Stacked on #4026** — merge #4026 first; this diff shows only the remap fix once that lands. Reverses the otto#151 `+1` remap decision with the maintainer's sign-off; the corrected porting guidance ships in otto (delano/otto#228).

The YAML→otto translator mapped `depth: N` to otto `trusted_proxy_depth = N + 1`, reasoning that otto's hop chain (`X-Forwarded-For + [REMOTE_ADDR]`) is one hop longer than the legacy XFF-only chain. But otto's index arithmetic already accounts for the appended peer — the client sits at `chain[-(N+1)]`, so otto depth N means "N proxy hops counting the connecting peer as hop 1", which is exactly what the operator-facing `depth: N` documents ("1 = standard single reverse proxy"). The `+1` faithfully reproduced an internal off-by-one of the *deleted* `ClientIpHelpers` walker (verified against the pre-deletion source), whose documented topologies only ever resolved correctly via its spoofable leftmost-XFF fallback.

**Under the remap** (all documented topologies): honest requests hit otto's short-chain fallback and resolved the **proxy** address as the client — IP rate limits, bans, and audit attribution keyed on the proxy IP — and one forged leftmost `X-Forwarded-For` entry smuggled past the proxy was selected as the client IP. **With the direct mapping**: the true client resolves on honest chains, and padding never wins (positions counted raw from the right; a forged entry only pushes the index onto proxy-appended entries).

- `lib/onetime/application/middleware_stack.rb`: `config.trusted_proxy_depth = ots_depth` (clamp 1..10 unchanged); comments corrected.
- `lib/middleware/detect_host.rb`: the "depth mode remains spoofable in the documented single-proxy setup" caveat is obsolete — replaced with the standing origin-lockdown note.
- Operator note: deployments that empirically compensated for the bug (set `depth` one lower than the real hop count) should correct it to the actual number of proxies — see the changelog fragment.

## Related Issues

Follow-up to #4024 / delano/otto#226. Reconciles otto#151 (comment posted there). Depends on #4026 (which pins otto @ d118474 — the depth peer-trust grant this fix relies on: with the true client resolved, `REMOTE_ADDR` is rewritten to a masked *public* address, so the otto key is the only forwarded-host trust signal).

## Test Plan

- `spec/unit/onetime/application/middleware_stack_spec.rb`: remap specs pin the direct mapping (depth 2 → 2, clamp 50 → 10, blank → 1). CI-run (Ruby 3.4).
- `spec/unit/onetime/application/ip_privacy_parity_spec.rb`: depth fixtures corrected to the honest single-proxy topology; **new padding-resistance spec** — forged leftmost XFF entry is never selected. CI-run.
- `try/integration/middleware/detect_host_ip_privacy_stack_try.rb`: depth case flipped to the honest single-entry XFF (REMOTE_ADDR rewrites to the masked PUBLIC client, keeping the otto key the only trust signal); **new case 7** pins padding resistance through the production config builder + real middleware stack. **7/7 pass locally**; `detect_host_try.rb` 18/18 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJ6BDA3VXsTtToXKp2To1x

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJ6BDA3VXsTtToXKp2To1x)_