### PR TITLE
DetectHost consumes otto's tri-state trust key; retire the grant-only OR

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ source 'https://rubygems.org/'
 # (present => authoritative, absent => legacy heuristics apply). Pinned to
 # an immutable commit (delano/otto#228 head) so installs stay reproducible
 # even if the branch moves or is deleted.
-gem 'otto', git: 'https://github.com/delano/otto', ref: '65003bb69ca970de0e1878962fdfb78b61f3f018'
+gem 'otto', git: 'https://github.com/delano/otto', ref: '98b22ceeb51f01a865c2ca7b3498cb4aac4c36cf'
 gem 'rhales', '~> 0.7.1'
 gem 'roda', '~> 3.0'
 gem 'rodauth', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -18,15 +18,10 @@ source 'https://rubygems.org/'
 # Core Application Framework
 # ====================================
 
-# TODO(#4024): revert to a plain version constraint (the release after otto
-# 2.7.0) once the depth-mode peer-trust fix (delano/otto#226) and the
-# tri-state otto.via_trusted_proxy contract (delano/otto#228) ship to
-# RubyGems. The git ref consumes both: depth mode gets a forwarded-host
-# trust signal, and the key is written only when proxy trust is configured
-# (present => authoritative, absent => legacy heuristics apply). Pinned to
-# an immutable commit (delano/otto#228 head) so installs stay reproducible
-# even if the branch moves or is deleted.
-gem 'otto', git: 'https://github.com/delano/otto', ref: '98b22ceeb51f01a865c2ca7b3498cb4aac4c36cf'
+# 2.8+: depth mode records a forwarded-host trust signal (delano/otto#226),
+# and otto.via_trusted_proxy is tri-state — written only when proxy trust is
+# configured (present => authoritative, absent => legacy heuristics apply).
+gem 'otto', '~> 2.8'
 gem 'rhales', '~> 0.7.1'
 gem 'roda', '~> 3.0'
 gem 'rodauth', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ source 'https://rubygems.org/'
 # (present => authoritative, absent => legacy heuristics apply). Pinned to
 # an immutable commit (delano/otto#228 head) so installs stay reproducible
 # even if the branch moves or is deleted.
-gem 'otto', git: 'https://github.com/delano/otto', ref: 'f720e48aee60f2e4bd107a795f24edf6714d1b11'
+gem 'otto', git: 'https://github.com/delano/otto', ref: 'fc4a6915e21a53eafa650e9f7f1e55463ae08166'
 gem 'rhales', '~> 0.7.1'
 gem 'roda', '~> 3.0'
 gem 'rodauth', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ source 'https://rubygems.org/'
 # (present => authoritative, absent => legacy heuristics apply). Pinned to
 # an immutable commit (delano/otto#228 head) so installs stay reproducible
 # even if the branch moves or is deleted.
-gem 'otto', git: 'https://github.com/delano/otto', ref: 'fc4a6915e21a53eafa650e9f7f1e55463ae08166'
+gem 'otto', git: 'https://github.com/delano/otto', ref: '65003bb69ca970de0e1878962fdfb78b61f3f018'
 gem 'rhales', '~> 0.7.1'
 gem 'roda', '~> 3.0'
 gem 'rodauth', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -19,12 +19,14 @@ source 'https://rubygems.org/'
 # ====================================
 
 # TODO(#4024): revert to a plain version constraint (the release after otto
-# 2.7.0) once the depth-mode peer-trust fix (delano/otto#226) ships to
-# RubyGems. The git ref consumes that fix so depth mode gets a forwarded-host
-# trust signal (otto.via_trusted_proxy) ahead of the release. Pinned to an
-# immutable commit (delano/otto#227 head) so installs stay reproducible even
-# if the branch moves or is deleted.
-gem 'otto', git: 'https://github.com/delano/otto', ref: 'd11847467359d6aa080c3f1b7ef973c1e8e65573'
+# 2.7.0) once the depth-mode peer-trust fix (delano/otto#226) and the
+# tri-state otto.via_trusted_proxy contract (delano/otto#228) ship to
+# RubyGems. The git ref consumes both: depth mode gets a forwarded-host
+# trust signal, and the key is written only when proxy trust is configured
+# (present => authoritative, absent => legacy heuristics apply). Pinned to
+# an immutable commit (delano/otto#228 head) so installs stay reproducible
+# even if the branch moves or is deleted.
+gem 'otto', git: 'https://github.com/delano/otto', ref: 'f720e48aee60f2e4bd107a795f24edf6714d1b11'
 gem 'rhales', '~> 0.7.1'
 gem 'roda', '~> 3.0'
 gem 'rodauth', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/delano/otto
-  revision: f720e48aee60f2e4bd107a795f24edf6714d1b11
-  ref: f720e48aee60f2e4bd107a795f24edf6714d1b11
+  revision: fc4a6915e21a53eafa650e9f7f1e55463ae08166
+  ref: fc4a6915e21a53eafa650e9f7f1e55463ae08166
   specs:
     otto (2.7.0)
       concurrent-ruby (~> 1.3, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/delano/otto
-  revision: fc4a6915e21a53eafa650e9f7f1e55463ae08166
-  ref: fc4a6915e21a53eafa650e9f7f1e55463ae08166
+  revision: 65003bb69ca970de0e1878962fdfb78b61f3f018
+  ref: 65003bb69ca970de0e1878962fdfb78b61f3f018
   specs:
     otto (2.7.0)
       concurrent-ruby (~> 1.3, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/delano/otto
-  revision: 65003bb69ca970de0e1878962fdfb78b61f3f018
-  ref: 65003bb69ca970de0e1878962fdfb78b61f3f018
+  revision: 98b22ceeb51f01a865c2ca7b3498cb4aac4c36cf
+  ref: 98b22ceeb51f01a865c2ca7b3498cb4aac4c36cf
   specs:
     otto (2.7.0)
       concurrent-ruby (~> 1.3, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,3 @@
-GIT
-  remote: https://github.com/delano/otto
-  revision: 98b22ceeb51f01a865c2ca7b3498cb4aac4c36cf
-  ref: 98b22ceeb51f01a865c2ca7b3498cb4aac4c36cf
-  specs:
-    otto (2.7.0)
-      concurrent-ruby (~> 1.3, < 2.0)
-      logger (~> 1, < 2.0)
-      loofah (~> 2.20)
-      rack (~> 3.1, < 4.0)
-      rack-parser (~> 0.7)
-      rexml (~> 3.4)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -288,6 +275,13 @@ GEM
     openssl-signature_algorithm (1.3.0)
       openssl (> 2.0)
     ostruct (0.6.3)
+    otto (2.8.0)
+      concurrent-ruby (~> 1.3, < 2.0)
+      logger (~> 1, < 2.0)
+      loofah (~> 2.20)
+      rack (~> 3.1, < 4.0)
+      rack-parser (~> 0.7)
+      rexml (~> 3.4)
     parallel (2.1.0)
     parlour (9.1.2)
       commander (~> 5.0)
@@ -636,7 +630,7 @@ DEPENDENCIES
   omniauth-github (~> 2.0)
   omniauth-google-oauth2 (~> 1.2)
   omniauth_openid_connect (~> 0.8)
-  otto!
+  otto (~> 2.8)
   passforge (~> 1.1)
   pg (~> 1.6)
   psych (~> 5.2.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/delano/otto
-  revision: d11847467359d6aa080c3f1b7ef973c1e8e65573
-  ref: d11847467359d6aa080c3f1b7ef973c1e8e65573
+  revision: f720e48aee60f2e4bd107a795f24edf6714d1b11
+  ref: f720e48aee60f2e4bd107a795f24edf6714d1b11
   specs:
     otto (2.7.0)
       concurrent-ruby (~> 1.3, < 2.0)

--- a/changelog.d/20260807_170000_claude_4024_detect_host_tri_state.rst
+++ b/changelog.d/20260807_170000_claude_4024_detect_host_tri_state.rst
@@ -1,0 +1,17 @@
+.. A new scriv changelog fragment.
+
+Changed
+-------
+
+- ``Rack::DetectHost`` now treats a present ``otto.via_trusted_proxy`` env
+  key as authoritative in both directions, consuming otto's tri-state
+  contract (delano/otto#228): otto writes the key only when proxy trust is
+  actually configured, so ``true`` grants forwarded-host trust, ``false``
+  (or any non-boolean) denies it — a request resolving to a private
+  ``REMOTE_ADDR`` can no longer bypass an operator's explicit trust
+  decision. The legacy private-IP heuristic now applies only when the key
+  is absent (no proxy trust configured, or no ``IPPrivacyMiddleware``
+  mounted), which keeps default-config self-hosted installs behind a local
+  reverse proxy working unchanged. The middleware's key constant now
+  references ``Otto::EnvKeys::VIA_TRUSTED_PROXY`` directly, leaving one
+  rename surface instead of two duplicated literals. (#4024)

--- a/docs/specs/domain-ip-allowlist/domain-ip-allowlist.md
+++ b/docs/specs/domain-ip-allowlist/domain-ip-allowlist.md
@@ -122,8 +122,9 @@ resolution behind proxies — but no filtering primitive.
    exclusive, so `otto.via_trusted_proxy` is always false in depth mode).
    *Since fixed: otto#226 grants depth-mode peer trust
    (`via_trusted_proxy=true`, forwarded proto honored), otto#228 makes the
-   key tri-state, and the depth `+1` remap off-by-one was dropped (#4028),
-   so depth resolves the documented client and resists XFF padding.*
+   key tri-state, and the depth `+1` remap off-by-one was dropped
+   (PR #4028, for #4024), so depth resolves the documented client and
+   resists XFF padding.*
 4. **Geo headers are trusted unconditionally** in the released 2.6.0
    (`otto-2.6.0/lib/otto/privacy/geo_resolver.rb:164-197`): `CF-IPCountry`
    et al. are honored with no trusted-proxy gate, and the built-in range

--- a/docs/specs/domain-ip-allowlist/domain-ip-allowlist.md
+++ b/docs/specs/domain-ip-allowlist/domain-ip-allowlist.md
@@ -83,9 +83,12 @@ resolution behind proxies — but no filtering primitive.
   (`resolve_client_ip_by_depth`, `utils.rb:208`) counts exactly N trusted
   hops from the right with junk positions preserved — not spoofable by XFF
   padding, but assumes origin lockdown.
-- **IP privacy middleware** (`IPPrivacyMiddleware`, auto-mounted innermost):
-  sets `env['otto.client_ip']` and `env['otto.via_trusted_proxy']`; masks
-  IPs, scrubs UA/referer, rewrites forwarded headers.
+- **IP privacy middleware** (`IPPrivacyMiddleware`, auto-mounted innermost
+  in 2.6.0; *since otto#219 it mounts outermost, so all other middleware
+  sees masked values*): sets `env['otto.client_ip']` and
+  `env['otto.via_trusted_proxy']` (*tri-state since otto#228: written only
+  when proxy trust is configured*); masks IPs, scrubs UA/referer, rewrites
+  forwarded headers.
 - **Rejection plumbing**: `raise Otto::ForbiddenError` from anywhere in the
   Otto request chain yields a content-negotiated 403 with security headers
   (`otto-2.6.0/lib/otto/core/error_handler.rb:13`). (Not available to plain
@@ -117,6 +120,10 @@ resolution behind proxies — but no filtering primitive.
    Depth mode is the robust option but permanently disables
    `Request#secure?`'s forwarded-proto trust (modes are mutually
    exclusive, so `otto.via_trusted_proxy` is always false in depth mode).
+   *Since fixed: otto#226 grants depth-mode peer trust
+   (`via_trusted_proxy=true`, forwarded proto honored), otto#228 makes the
+   key tri-state, and the depth `+1` remap off-by-one was dropped (#4028),
+   so depth resolves the documented client and resists XFF padding.*
 4. **Geo headers are trusted unconditionally** in the released 2.6.0
    (`otto-2.6.0/lib/otto/privacy/geo_resolver.rb:164-197`): `CF-IPCountry`
    et al. are honored with no trusted-proxy gate, and the built-in range

--- a/lib/middleware/detect_host.rb
+++ b/lib/middleware/detect_host.rb
@@ -107,8 +107,10 @@ module Rack
     # and is not used for host detection
     unless defined?(HEADER_PRECEDENCE)
       # Forwarded headers that require trusted proxy validation.
-      # These headers can be spoofed by clients and should only be trusted
-      # when the request comes from a private/loopback IP (trusted proxy).
+      # These headers can be spoofed by clients and are only trusted when
+      # otto's tri-state key grants it (otto.via_trusted_proxy == true) or,
+      # with the key absent (no proxy trust configured), when REMOTE_ADDR is
+      # a private/loopback address — see the trust decision in #call.
       FORWARDED_HEADERS = [
         'X-Forwarded-Host',   # Common proxy header (AWS ALB, nginx)
         'Apx-Incoming-Host',  # Approximated-specific (approximated.app custom-domain ingress); like all forwarded headers, only honored behind trusted infra

--- a/lib/middleware/detect_host.rb
+++ b/lib/middleware/detect_host.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'ipaddr'
+require 'otto/env_keys'
 require_relative 'logging'
 
 module Rack
@@ -65,24 +66,27 @@ module Rack
   #
   # **Trusted Proxy Validation**: This middleware only trusts forwarded host
   # headers (X-Forwarded-Host, X-Original-Host, Apx-Incoming-Host, Forwarded)
-  # when the request arrived via a trusted reverse proxy. Trust is granted
-  # when EITHER of two independent signals says so:
+  # when the request arrived via a trusted reverse proxy. The otto trust key
+  # is TRI-STATE (otto#228) and, when present, authoritative in BOTH
+  # directions:
   #
-  # - env['otto.via_trusted_proxy'] is true — recorded by Otto's
+  # - env['otto.via_trusted_proxy'] PRESENT — recorded by Otto's
   #   IPPrivacyMiddleware (mounted earlier in the stack) from the ORIGINAL
   #   connecting peer, before it rewrites REMOTE_ADDR to the resolved client
-  #   IP. Otto grants it when the peer matches a configured trusted-proxy
-  #   CIDR (filter mode) or whenever count-based depth mode is active
-  #   (configuring a depth asserts the peer is the proxy tier; otto#226); or
-  # - REMOTE_ADDR is a private/loopback address — the legacy heuristic that
-  #   keeps self-hosted installs behind a local reverse proxy working when
-  #   no trusted-proxy list is configured.
+  #   IP, and only when the operator configured proxy trust. true = the peer
+  #   matched a trusted-proxy CIDR (filter mode) or count-based depth mode
+  #   is active (configuring a depth asserts the peer is the proxy tier;
+  #   otto#226). false = trust IS configured and the peer failed it — an
+  #   authoritative deny; the heuristic below does not apply.
+  # - Key ABSENT — no proxy trust configured (or the otto middleware is not
+  #   mounted). Only then does the legacy heuristic apply: a private/
+  #   loopback REMOTE_ADDR grants trust, keeping self-hosted installs behind
+  #   a local reverse proxy working without any trusted-proxy config.
   #
-  # A false (or missing, or non-boolean) key never suppresses the heuristic:
-  # IPPrivacyMiddleware is mounted unconditionally and writes false on every
-  # request when proxy trust is unconfigured, so false is ambiguous between
-  # "untrusted peer" and "no proxy trust configured". Direct requests from
-  # public IPs can only use the Host header.
+  # A present-but-non-boolean value (a future otto surprise) is treated as
+  # untrusted rather than falling through to the heuristic: presence implies
+  # the authoritative contract. Direct requests from public IPs can only use
+  # the Host header.
   #
   # This prevents header spoofing attacks where malicious clients set
   # X-Forwarded-Host to impersonate different hosts.
@@ -107,7 +111,7 @@ module Rack
       # when the request comes from a private/loopback IP (trusted proxy).
       FORWARDED_HEADERS = [
         'X-Forwarded-Host',   # Common proxy header (AWS ALB, nginx)
-        'Apx-Incoming-Host',  # Check Approximated (if it exists)
+        'Apx-Incoming-Host',  # Approximated-specific (approximated.app custom-domain ingress); like all forwarded headers, only honored behind trusted infra
         'X-Original-Host',    # Various proxy services
         'Forwarded',          # RFC 7239 standard (host parameter)
       ].freeze
@@ -126,10 +130,10 @@ module Rack
         '::1',
       ].freeze
 
-      # Rack env key written by Otto's IPPrivacyMiddleware. Mirrors
-      # Otto::EnvKeys::VIA_TRUSTED_PROXY — kept as a literal so this
-      # middleware stays otto-agnostic (a tryout pins the equality).
-      VIA_TRUSTED_PROXY_KEY = 'otto.via_trusted_proxy'
+      # Rack env key written by Otto's IPPrivacyMiddleware. Referenced from
+      # Otto::EnvKeys so a rename upstream has exactly one surface to update
+      # (previously a duplicated literal pinned by a tryout).
+      VIA_TRUSTED_PROXY_KEY = Otto::EnvKeys::VIA_TRUSTED_PROXY
     end
 
     # Class-level setting initialized from ENV variable
@@ -175,41 +179,41 @@ module Rack
       # a trusted proxy. Forwarded headers can be spoofed by clients, so they
       # are only honored for requests that arrived via trusted infrastructure.
       #
-      # Trust is a deliberate OR of two independent signals — the otto key
-      # can GRANT trust but never REVOKE the legacy heuristic:
+      # The otto key is tri-state (otto#228); a PRESENT key is authoritative
+      # in both directions and the heuristic applies only when it is absent:
       #
-      # a. env['otto.via_trusted_proxy'] == true wins outright. Otto's
-      #    IPPrivacyMiddleware (mounted earlier in the stack) records it from
-      #    the ORIGINAL connecting peer against the configured trusted-proxy
-      #    CIDRs, then rewrites REMOTE_ADDR to the resolved client IP. After
-      #    that rewrite REMOTE_ADDR no longer identifies the peer — with
-      #    proxy trust enabled it holds the real (public) visitor IP, so
-      #    re-checking it here would wrongly discard forwarded host headers
-      #    and fail every custom domain to canonical (2026-08-05 incident).
-      # b. A false key does NOT suppress private_ip?(REMOTE_ADDR).
-      #    IPPrivacyMiddleware is mounted unconditionally and writes false on
-      #    every request when no trusted proxies are configured, so false is
-      #    ambiguous between "untrusted peer" and "no proxy trust
-      #    configured". Treating it as authoritative stripped forwarded-host
-      #    trust from default-config self-hosters behind a local reverse
-      #    proxy, whose masked REMOTE_ADDR stays private. Non-boolean values
-      #    (nil, strings from a future otto) also fall through gracefully.
-      # c. TRUSTED_PROXY_MODE=depth: fixed upstream in otto#226. Depth and
-      #    CIDRs are mutually exclusive so otto's matcher list is empty, but
-      #    configuring a depth is the operator's assertion that the
-      #    connecting peer is their proxy tier, so otto records the key true
-      #    and grant (a) applies. Depth counts hops from the right with the
-      #    peer as hop 1 (the otto#151 remap was dropped), so extra leftmost
-      #    XFF entries — forged or from farther upstream — never shift the
-      #    selection. The hazard is a depth/topology mismatch: a chain
-      #    shorter than the depth falls back to the peer (misattribution),
-      #    and a depth larger than the real proxy hop count selects a
-      #    client-supplied entry (spoofable). Each counted hop must append
-      #    exactly one entry. As with all count-based trust, the origin must
-      #    be unreachable except through the proxy tier.
+      # a. Key present: otto's IPPrivacyMiddleware (mounted earlier in the
+      #    stack) recorded it from the ORIGINAL connecting peer — before
+      #    rewriting REMOTE_ADDR to the resolved client IP — and only
+      #    because the operator configured proxy trust (CIDR matchers, or a
+      #    depth: otto#226 grants depth-mode peer trust; the otto#151 remap
+      #    was dropped, so extra leftmost XFF entries never shift the
+      #    right-anchored selection; a chain shorter than the depth falls
+      #    back to the peer, and a depth larger than the real hop count
+      #    selects a client-supplied entry — each hop must append exactly
+      #    one entry and the origin must stay unreachable except through
+      #    the proxy tier). After the rewrite REMOTE_ADDR no
+      #    longer identifies the peer — with proxy trust enabled it holds
+      #    the real (public) visitor IP, so re-checking it here would
+      #    wrongly discard forwarded host headers and fail every custom
+      #    domain to canonical (2026-08-05 incident). A false key means the
+      #    configured trust REJECTED this peer — honoring the private-IP
+      #    heuristic anyway would let any request that resolves to a
+      #    private REMOTE_ADDR bypass the operator's explicit trust
+      #    decision. A present-but-non-boolean value (a future otto
+      #    surprise) is treated as untrusted: presence implies the
+      #    authoritative contract.
+      # b. Key absent: no proxy trust configured, or the otto middleware is
+      #    not mounted (bare-Rack stacks). Only here does the legacy
+      #    heuristic apply: a private/loopback REMOTE_ADDR grants trust,
+      #    keeping default-config self-hosted installs behind a local
+      #    reverse proxy (nginx/Caddy on the same box or LAN) working.
       remote_addr        = env['REMOTE_ADDR']
-      from_trusted_proxy = env[VIA_TRUSTED_PROXY_KEY] == true ||
-                           self.class.private_ip?(remote_addr)
+      from_trusted_proxy = if env.key?(VIA_TRUSTED_PROXY_KEY)
+        env[VIA_TRUSTED_PROXY_KEY] == true
+      else
+        self.class.private_ip?(remote_addr)
+      end
 
       headers_to_check = if from_trusted_proxy
         HEADER_PRECEDENCE

--- a/try/integration/middleware/detect_host_ip_privacy_stack_try.rb
+++ b/try/integration/middleware/detect_host_ip_privacy_stack_try.rb
@@ -41,7 +41,7 @@ require_relative '../../support/test_helpers'
 require 'logger'
 require 'stringio'
 require 'otto'
-# Documentation-only module: NOT loaded by `require 'otto'`, must be explicit.
+# Not loaded by `require 'otto'` — consumers must require it explicitly.
 require 'otto/env_keys'
 
 require 'middleware/detect_host'

--- a/try/integration/middleware/detect_host_ip_privacy_stack_try.rb
+++ b/try/integration/middleware/detect_host_ip_privacy_stack_try.rb
@@ -9,15 +9,17 @@
 # (MiddlewareStack.ip_privacy_security_config) so config-construction drift is
 # covered too, not just the middleware contract.
 #
-# Purpose: pin the cross-gem contract that DetectHost depends on. DetectHost
-# trusts forwarded host headers when EITHER env['otto.via_trusted_proxy'] is
-# true (recorded by otto from the ORIGINAL connecting peer before it rewrites
-# REMOTE_ADDR to the resolved/masked client IP) OR REMOTE_ADDR is private
-# (legacy heuristic). The detect_host_try.rb tryouts inject the otto key by
-# hand, so they would keep passing if a future otto release renamed the key or
-# stopped setting it — while production silently regressed to the
-# private_ip?(REMOTE_ADDR) fallback and re-broke every custom domain (the
-# 2026-08-05 TRUSTED_PROXY_ENABLED incident). These tests fail instead.
+# Purpose: pin the cross-gem contract that DetectHost depends on. The otto
+# key is tri-state (otto#228): PRESENT means proxy trust is configured and
+# the boolean is authoritative both directions (recorded by otto from the
+# ORIGINAL connecting peer before it rewrites REMOTE_ADDR to the resolved/
+# masked client IP); ABSENT means no proxy trust configured, the only case
+# where DetectHost's private_ip?(REMOTE_ADDR) heuristic applies. The
+# detect_host_try.rb tryouts inject the otto key by hand, so they would keep
+# passing if a future otto release renamed the key or stopped setting it —
+# while production silently regressed to the heuristic and re-broke every
+# custom domain (the 2026-08-05 TRUSTED_PROXY_ENABLED incident). These tests
+# fail instead.
 #
 # We're testing:
 # 1. The key-name contract: Otto::EnvKeys::VIA_TRUSTED_PROXY still equals
@@ -26,8 +28,9 @@
 # 3. The incident shape: trusted proxy peer + public visitor in XFF ->
 #    REMOTE_ADDR rewritten to a public IP, forwarded host headers still trusted
 # 4. Direct public request: forwarded host headers ignored, Host wins
-# 5. Direct-connect config + private peer: forwarded host headers trusted via
-#    the private-peer heuristic (back-compat for self-hosted installs)
+# 5. Direct-connect config + private peer: otto leaves the key ABSENT
+#    (tri-state), so the private-peer heuristic grants trust (back-compat
+#    for self-hosted installs)
 # 6. Depth mode: otto records peer trust from the depth assertion (otto#226),
 #    so forwarded host headers are honored via the otto key alone
 # 7. Depth padding resistance (the otto#151 remap fix): a forged leftmost
@@ -101,11 +104,12 @@ OT.send(:conf=, @saved_conf)
   @direct_config,
 )
 
-## Key-name contract pin: DetectHost carries its own frozen literal (to stay
-## otto-agnostic) that must mirror otto's documented env key
-## (Otto::EnvKeys::VIA_TRUSTED_PROXY). If an otto upgrade renames the key,
-## this fails loudly instead of DetectHost silently never seeing the trust
-## signal. (Pinned as a value pair, not a bare `==`, so rubocop's Lint/Void
+## Key-name contract pin: DetectHost::VIA_TRUSTED_PROXY_KEY now references
+## Otto::EnvKeys::VIA_TRUSTED_PROXY directly (one rename surface), so the
+## two can no longer drift — this case pins the canonical STRING value, so
+## an upstream rename still fails here as a deliberate decision point
+## rather than silently changing the env contract other consumers read.
+## (Pinned as a value pair, not a bare `==`, so rubocop's Lint/Void
 ## autocorrect cannot delete the expression.)
 [Otto::EnvKeys::VIA_TRUSTED_PROXY, Rack::DetectHost::VIA_TRUSTED_PROXY_KEY]
 #=> ['otto.via_trusted_proxy', 'otto.via_trusted_proxy']
@@ -158,12 +162,14 @@ OT.send(:conf=, @saved_conf)
 #=> ['eu.onetimesecret.com', false]
 
 ## Direct-connect deployment (no trusted proxies configured): a private peer
-## still gets forwarded-host trust. Otto records via_trusted_proxy=false (its
-## trust list is empty), but the masked REMOTE_ADDR (10.0.0.0) stays private,
-## so DetectHost's private-peer heuristic grants trust — the false key never
-## revokes it. This pins pre-incident back-compat for default-config
-## self-hosted installs behind a local reverse proxy (nginx/Caddy on the same
-## box or LAN), which never declare site.network.trusted_proxy.
+## still gets forwarded-host trust. Under the tri-state contract (otto#228)
+## otto leaves the key ABSENT when no proxy trust is configured — absence,
+## not a spurious false, is what lets DetectHost's private-peer heuristic
+## apply (the masked REMOTE_ADDR 10.0.0.0 stays private). This pins
+## back-compat for default-config self-hosted installs behind a local
+## reverse proxy (nginx/Caddy on the same box or LAN), which never declare
+## site.network.trusted_proxy — AND pins that otto no longer writes the
+## ambiguous false that forced the old grant-only read.
 @direct_stack.call(
   {
     'REMOTE_ADDR' => '10.0.0.5',
@@ -171,7 +177,7 @@ OT.send(:conf=, @saved_conf)
     'HTTP_HOST' => 'eu.onetimesecret.com',
   },
 )
-[@captured['rack.detected_host'], @captured['otto.via_trusted_proxy']]
+[@captured['rack.detected_host'], @captured.key?('otto.via_trusted_proxy')]
 #=> ['forwarded.example.com', false]
 
 ## Depth mode grants forwarded-host trust (otto#226 — the deliberate flip of

--- a/try/integration/middleware/detect_host_try.rb
+++ b/try/integration/middleware/detect_host_try.rb
@@ -13,11 +13,12 @@
 # 3. Port stripping
 # 4. Multiple host handling
 # 5. Empty and missing header handling
-# 6. Trusted proxy validation: forwarded headers are trusted when EITHER
-#    env['otto.via_trusted_proxy'] == true (recorded by Otto's
-#    IPPrivacyMiddleware from the original peer) OR REMOTE_ADDR is a
-#    private/loopback IP (legacy heuristic). The otto key can grant trust
-#    but never revoke the heuristic.
+# 6. Trusted proxy validation (tri-state, otto#228): when
+#    env['otto.via_trusted_proxy'] is PRESENT it is authoritative in both
+#    directions — true grants forwarded-header trust, false (or any
+#    non-true value) denies it. When the key is ABSENT (no proxy trust
+#    configured, or no IPPrivacyMiddleware mounted) the legacy heuristic
+#    applies: a private/loopback REMOTE_ADDR grants trust.
 
 require_relative '../../support/test_helpers'
 
@@ -131,14 +132,15 @@ env = {
 env['rack.detected_host']
 #=> 'custom.example.com'
 
-## Still trusts forwarded headers when otto.via_trusted_proxy is false but
-## REMOTE_ADDR is private: trust is a grant-only OR — the key can GRANT
-## trust, it never REVOKES the private-peer heuristic. This is deliberate
-## back-compat: IPPrivacyMiddleware is mounted unconditionally and records
-## false on every request when no trusted proxies are configured, so false
-## is ambiguous between "untrusted peer" and "no proxy trust configured".
-## Treating it as authoritative stripped forwarded-host trust from
-## default-config self-hosters behind a local reverse proxy.
+## A false key is an AUTHORITATIVE DENY (tri-state, otto#228), even with a
+## private REMOTE_ADDR: otto writes the key only when the operator
+## configured proxy trust, so false means "trust is configured and this
+## peer failed it". Honoring the private-IP heuristic anyway would let any
+## request resolving to a private REMOTE_ADDR bypass the operator's
+## explicit trust decision. (The pre-tri-state grant-only OR existed
+## because otto wrote false on every unconfigured request, making false
+## ambiguous — that ambiguity is gone: unconfigured deployments get an
+## ABSENT key, pinned below.)
 env = {
   'REMOTE_ADDR' => '10.0.0.1',
   'otto.via_trusted_proxy' => false,
@@ -147,12 +149,12 @@ env = {
 }
 @middleware.call(env)
 env['rack.detected_host']
-#=> 'proxied.example.com'
+#=> 'direct.example.com'
 
 ## Non-boolean key values (nil, or a truthy-looking string from a future
-## otto) never grant trust — only `true` does. With a public REMOTE_ADDR the
-## heuristic also declines, so the request degrades gracefully to the Host
-## header instead of a spoofable trust cliff.
+## otto) never grant trust — only `true` does. With a public REMOTE_ADDR
+## the request degrades gracefully to the Host header instead of a
+## spoofable trust cliff.
 [nil, 'true'].map do |value|
   env = {
     'REMOTE_ADDR' => '203.0.113.50',
@@ -164,6 +166,20 @@ env['rack.detected_host']
   env['rack.detected_host']
 end
 #=> ['real.example.com', 'real.example.com']
+
+## A PRESENT non-boolean key suppresses the private-IP heuristic too:
+## presence implies the authoritative contract, so the value must be
+## exactly true to grant. (nil here means "key present, value nil" —
+## distinct from the absent-key fallback pinned below.)
+env = {
+  'REMOTE_ADDR' => '10.0.0.1',
+  'otto.via_trusted_proxy' => nil,
+  'HTTP_X_FORWARDED_HOST' => 'proxied.example.com',
+  'HTTP_HOST' => 'direct.example.com',
+}
+@middleware.call(env)
+env['rack.detected_host']
+#=> 'direct.example.com'
 
 ## Discarding Apx-Incoming-Host from an untrusted source escalates the log
 ## to WARN — the 2026-08-05 incident signature (custom domains silently


### PR DESCRIPTION
## Summary

**Stacked on #4028** (which stacks on #4026) — merge bottom-up; this diff shows only the tri-state work once #4028 lands. Downstream half of delano/otto#228, which is merged and released: **otto 2.8.0 is on RubyGems**, and this PR now consumes it via a plain version constraint — the temporary git pin is gone.

Otto's `otto.via_trusted_proxy` is now tri-state (delano/otto#228): written only when proxy trust is configured, so a present key is authoritative in both directions and an absent key means "unconfigured". `Rack::DetectHost` now reads it that way, retiring the grant-only OR from #4021 — a bespoke trust algebra that existed only because otto wrote an ambiguous `false` on every unconfigured request.

- **Gemfile / Gemfile.lock**: `gem 'otto', '~> 2.8'` (released 2026-08-07, shipping otto#226 + #228). Lockfile regenerated via a shadow bundle: the otto stanza moved GIT → GEM, `concurrent-ruby (1.3.7)` and `RUBY VERSION ruby 3.4.10` verified intact, no other dependency churn.
- **`lib/middleware/detect_host.rb`**: `env.key?` ⇒ the boolean decides (`true` grants; `false` **or any non-boolean** denies — a request resolving to a private `REMOTE_ADDR` can no longer bypass the operator's explicit trust decision); key absent ⇒ legacy `private_ip?` heuristic, preserving default-config self-hosters behind a local reverse proxy. `VIA_TRUSTED_PROXY_KEY` now references `Otto::EnvKeys::VIA_TRUSTED_PROXY` (one rename surface instead of two duplicated literals). The `Apx-Incoming-Host` entry now notes it's Approximated-specific.
- **`docs/specs/domain-ip-allowlist/domain-ip-allowlist.md`**: annotated the since-fixed items in the doc's own style (otto#219 mount position, otto#226/#228 trust signal, #4028 remap fix).

## Related Issues

Completes the #4024 arc. Depends on delano/otto#228 (merged and released as otto 2.8.0, 2026-08-07). Follow-up to #4021; retires its grant-only OR.

## Test Plan

- `try/integration/middleware/detect_host_try.rb` — **19/19 pass locally** against released otto 2.8.0: the false-key case flipped to authoritative deny; new present-but-`nil` case pins that key *presence* suppresses the heuristic (distinct from the absent-key fallback, which is unchanged).
- `try/integration/middleware/detect_host_ip_privacy_stack_try.rb` — **7/7 pass locally** through the production config builder + real `IPPrivacyMiddleware`: the direct-connect case now asserts the key is ABSENT (pinning that otto no longer writes the ambiguous `false`); the key-name pin keeps the canonical string as a loud upstream-rename tripwire.
- rspec parity/middleware-stack specs run in CI (Ruby 3.4; this sandbox is 3.3.6 and cannot boot spec_helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJ6BDA3VXsTtToXKp2To1x

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJ6BDA3VXsTtToXKp2To1x)_