### PR TITLE
Apply tax policy and pmc pin to immediate currency-migration checkout

### DIFF
--- a/apps/web/billing/controllers/billing.rb
+++ b/apps/web/billing/controllers/billing.rb
@@ -1006,6 +1006,11 @@ module Billing
 
         json_response(result)
       rescue Stripe::InvalidRequestError => ex
+        # ADR-033: a missing payment_method_configuration must be loud and
+        # operator-actionable, same as the other checkout-creation paths.
+        if ::Billing::PmcResourceMissing.pmc_resource_missing?(ex)
+          billing_logger.error ::Billing::PmcResourceMissing.operator_message(ex)
+        end
         billing_logger.warn 'Currency migration request failed',
           {
             exception: ex,

--- a/apps/web/billing/lib/currency_migration_service.rb
+++ b/apps/web/billing/lib/currency_migration_service.rb
@@ -4,6 +4,7 @@
 
 require 'stripe'
 require_relative 'stripe_client'
+require_relative '../operations/create_checkout_link'
 
 module Billing
   # CurrencyMigrationService - Handles Stripe currency conflict resolution
@@ -304,6 +305,14 @@ module Billing
           },
         },
       }
+
+      # Deployment tax policy + payment-method-configuration pin: shared with
+      # every other checkout path (see Plans#checkout_redirect). Applied after
+      # :customer is bound because customer_update requires a customer id.
+      Billing::Operations::CreateCheckoutLink.apply_tax_policy!(session_params)
+
+      pmc                                           = Onetime.billing_config.payment_method_configuration
+      session_params[:payment_method_configuration] = pmc if pmc
 
       checkout_session = stripe_client.create(
         Stripe::Checkout::Session,

--- a/spec/unit/billing/currency_migration_service_spec.rb
+++ b/spec/unit/billing/currency_migration_service_spec.rb
@@ -461,6 +461,10 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
       double(id: 'cs_new_123', url: 'https://checkout.stripe.com/c/pay/cs_new_123')
     end
 
+    let(:stripe_client)                { double('StripeClient', create: checkout_session) }
+    let(:automatic_tax)                { false }
+    let(:payment_method_configuration) { nil }
+
     let(:proration_preview) do
       Stripe::Invoice.construct_from({
         id: 'in_preview',
@@ -478,8 +482,10 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
       allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
       allow(Stripe::Invoice).to receive(:list).and_return(double(data: []))
       allow(Stripe::Invoice).to receive(:create_preview).and_return(proration_preview)
-      allow(Billing::StripeClient).to receive(:new).and_return(
-        double(create: checkout_session)
+      allow(Billing::StripeClient).to receive(:new).and_return(stripe_client)
+      allow(Onetime.billing_config).to receive_messages(
+        automatic_tax?: automatic_tax,
+        payment_method_configuration: payment_method_configuration,
       )
       allow(org).to receive(:clear_currency_migration_intent!)
     end
@@ -552,6 +558,68 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
         )
       )
       expect(result[:migration][:refund_amount]).to eq(1450)
+    end
+
+    # Deployment tax policy + pmc pin: shared with every other checkout path
+    # (regression coverage for #4025 — this path previously built session
+    # params inline without them).
+    context 'when billing_config.automatic_tax? is enabled' do
+      let(:automatic_tax) { true }
+
+      it 'applies the deployment tax policy to the checkout session' do
+        described_class.execute_immediate_migration(
+          org, 'price_cad_456',
+          success_url: 'https://example.com/success',
+          cancel_url: 'https://example.com/cancel',
+        )
+
+        expect(stripe_client).to have_received(:create).with(
+          Stripe::Checkout::Session,
+          hash_including(
+            automatic_tax: { enabled: true },
+            billing_address_collection: 'required',
+            tax_id_collection: { enabled: true },
+            # customer_update is present because :customer is always bound
+            # on this path (org.stripe_customer_id).
+            customer_update: { address: 'auto' },
+          ),
+        )
+      end
+    end
+
+    context 'when billing_config.payment_method_configuration is set' do
+      let(:payment_method_configuration) { 'pmc_test_abc123' }
+
+      it 'pins the session to the configured payment method configuration' do
+        described_class.execute_immediate_migration(
+          org, 'price_cad_456',
+          success_url: 'https://example.com/success',
+          cancel_url: 'https://example.com/cancel',
+        )
+
+        expect(stripe_client).to have_received(:create).with(
+          Stripe::Checkout::Session,
+          hash_including(payment_method_configuration: 'pmc_test_abc123'),
+        )
+      end
+    end
+
+    context 'when automatic tax is disabled and no pmc is configured' do
+      it 'omits the tax and payment method configuration params' do
+        described_class.execute_immediate_migration(
+          org, 'price_cad_456',
+          success_url: 'https://example.com/success',
+          cancel_url: 'https://example.com/cancel',
+        )
+
+        expect(stripe_client).to have_received(:create) do |_resource, params|
+          expect(params).not_to have_key(:automatic_tax)
+          expect(params).not_to have_key(:billing_address_collection)
+          expect(params).not_to have_key(:tax_id_collection)
+          expect(params).not_to have_key(:customer_update)
+          expect(params).not_to have_key(:payment_method_configuration)
+        end
+      end
     end
 
     it 'falls back to manual calculation when invoice preview fails' do


### PR DESCRIPTION
Fixes #4025.

## Problem

The immediate currency-migration path (`CurrencyMigrationService#execute_immediate_migration`) built its Stripe Checkout session params inline, bypassing the shared deployment policy every other checkout-creation path applies. On deployments with `STRIPE_AUTOMATIC_TAX` enabled, a customer completing an immediate currency migration got an untaxed checkout — and the resulting subscription had no saved address for tax on renewals. The session also fell back to Dashboard-default payment methods, bypassing the `payment_method_configuration` pin from #4013 / PR #4019.

## Changes

- `currency_migration_service.rb`: after customer binding, route session params through `CreateCheckoutLink.apply_tax_policy!` (automatic_tax, billing_address_collection, tax_id_collection, customer_update) and apply the pmc pin, matching `Plans#checkout_redirect`.
- `controllers/billing.rb`: the migration endpoint's `InvalidRequestError` rescue now emits the ADR-033 `PmcResourceMissing` operator message, matching the other two checkout paths — the pin introduces this failure mode on a path that runs after cancel+refund, so it must be operator-actionable.
- `spec/unit/billing/currency_migration_service_spec.rb`: regression coverage — asserts tax params and pmc are present when enabled and absent when disabled. The positive examples fail against the pre-fix service.

Deliberately **not** consolidated onto `build_session_params` — that refactor is tracked as #4017; this is the minimal shared-policy fix (the pmc two-liner is now in three places, which #4017 should collapse).

## Testing

Full unit lane green: 7,857 RSpec examples 0 failures, 7,367 tryouts 0 failures. Adversarial review confirmed no require cycle (lib → operations is acyclic; no non-web context loads the service), correct accessor names, and that the graceful path is untouched.