### PR TITLE
Port currency migration service to basil/clover Stripe API

### DIFF
--- a/TASKS-stripe-audit-critical.md
+++ b/TASKS-stripe-audit-critical.md
@@ -1,0 +1,99 @@
+# Stripe Checkout/Tax Audit — Critical & High Tasks
+
+Source: Stripe Checkout/Tax audit 2026-08-07 (branch `fix/4025-currency-migration-tax-policy`).
+Root cause for CM-1..CM-3: `apps/web/billing/lib/currency_migration_service.rb` still speaks the
+pre-basil Stripe API while the deployment pins `stripe_api_version: "2025-12-15.clover"` with
+stripe gem 18.4.2. The rest of billing was migrated (items-level `current_period_end`,
+`subscription_details` in `preview_plan_change`, `total_taxes`); this service was not.
+Specs (`spec/unit/billing/currency_migration_service_spec.rb`) stub the old field shapes, so
+CI is green while the production path is broken.
+
+## Task states
+
+| Marker | Meaning |
+|--------|---------|
+| `[ ] TODO` | Not started |
+| `[~] IN PROGRESS` | Actively being worked (note owner/branch) |
+| `[!] BLOCKED` | Blocked — note blocker inline |
+| `[x] DONE` | Fixed, tested, merged |
+
+---
+
+## CM-1 `[x] DONE` (fix/4025-currency-migration-clover-drift) — CRITICAL: `invoice.payment_intent` removed → immediate migration 500s AFTER canceling subscription
+
+- **Where:** `apps/web/billing/lib/currency_migration_service.rb:532,536` (`issue_prorated_refund`)
+- **Problem:** `Invoice#payment_intent` was removed in basil (2025-03-31). Gem 18.4.2 raises a
+  bespoke "BREAKING CHANGE" `NoMethodError` for exactly this access
+  (`stripe-18.4.2/lib/stripe/stripe_object.rb:449`). The local rescue only catches
+  `Stripe::InvalidRequestError`; `migrate_currency`'s rescues (`billing.rb:1008-1027`) are
+  Stripe-only → unhandled 500.
+- **Blast radius:** Fires on every immediate migration with positive prorated credit (the normal
+  mid-period case). Sequence at crash time: old subscription already canceled, no refund issued,
+  no new checkout session created, migration intent not cleared. Customer stranded.
+- **Fix:** Replace payment-intent lookup with `Stripe::CreditNote.create(invoice:, refund_amount:)`
+  (also resolves CM-4). If a raw refund must stay, resolve the payment via `invoice.payments`.
+- **Verify:** Spec that stubs a clover-shaped Invoice (no `payment_intent` reader; raises
+  NoMethodError on access) and asserts the refund path completes; manual immediate migration in
+  Stripe test mode mid-period.
+
+## CM-2 `[x] DONE` (fix/4025-currency-migration-clover-drift) — CRITICAL: proration preview uses removed params → silent fallback to naive refund math
+
+- **Where:** `apps/web/billing/lib/currency_migration_service.rb:470-478` (`calculate_prorated_credit`)
+- **Problem:** `Invoice.create_preview` called with top-level `subscription_items` /
+  `subscription_proration_behavior` / `subscription_proration_date` — all rejected under clover
+  (basil moved them into `subscription_details`; correct shape already exists at
+  `billing.rb:467-477`). The `rescue Stripe::StripeError` silently drops to
+  `manual_prorated_credit`, which ignores discounts, taxes, and Stripe's proration logic.
+- **Blast radius:** Preview path is permanently dead; every immediate-migration refund is computed
+  by the naive fallback. A customer with a 50%-off coupon is computed a full-price refund
+  (over-refund). Only a debug-level log marks the fallback.
+- **Fix:** Rewrite the preview call to the `subscription_details` shape (mirror
+  `preview_plan_change`). Raise the fallback log to warn so a dead preview path is visible.
+- **Verify:** Spec asserting the exact param shape sent to `create_preview`; test-mode migration
+  with an amount-off coupon confirming refund reflects the discounted price.
+
+## CM-3 `[x] DONE` (fix/4025-currency-migration-clover-drift) — CRITICAL: unexpanded `subscription.discounts` → 500 on migration pre-check for couponed subscribers
+
+- **Where:** `apps/web/billing/lib/currency_migration_service.rb:376-379` (`check_migration_warnings`)
+- **Problem:** Under clover, `subscription.discounts` returns unexpanded discount ID strings
+  (gem doc: "Use `expand[]=discounts`"). `discount&.coupon` on a String raises `NoMethodError`.
+- **Blast radius:** `GET check_currency_migration` (`billing.rb:889`) calls `assess_migration`
+  unwrapped → 500 for any subscriber with a coupon. In `create_checkout_session`'s 409 path the
+  `rescue StandardError` swallows it and silently reports `has_incompatible_coupons: false`.
+  Specs at `currency_migration_service_spec.rb:282,309` stub expanded coupon hashes, masking this.
+- **Fix:** Retrieve the subscription with `expand: ['discounts']` in `check_migration_warnings`
+  (and anywhere `.coupon` is read). Update specs to unexpanded-by-default shapes.
+- **Verify:** Spec with `discounts: ['di_123']` (string IDs) asserting no raise; test-mode
+  pre-check against a couponed subscription.
+
+## CM-4 `[x] DONE` (fix/4025-currency-migration-clover-drift) — HIGH: refunds bypass Stripe Tax accounting (no credit note, pre-tax amount)
+
+- **Where:** `apps/web/billing/lib/currency_migration_service.rb:523-547` (`issue_prorated_refund`)
+- **Problem:** Raw `Stripe::Refund` against the latest paid invoice's payment intent. For
+  `automatic_tax` deployments: (a) refund amount is a pre-tax manual proration while the customer
+  paid tax on the full period; (b) no credit note is generated, so Stripe Tax reporting continues
+  to count the full tax as collected — tax liability overstated.
+- **Fix:** Use `Stripe::CreditNote` with `refund_amount` (tax-correct, and closes CM-1 in the
+  same change). Target the invoice being partially refunded explicitly, not "latest paid".
+- **Verify:** Test-mode migration with automatic tax on; confirm credit note appears and tax
+  reporting adjusts.
+
+## CM-5 `[x] DONE` (fix/4025-currency-migration-clover-drift) — HIGH: `refund_amount` reported to customer even when refund failed
+
+- **Where:** `apps/web/billing/lib/currency_migration_service.rb:286-288,325-333`
+  (`execute_immediate_migration`)
+- **Problem:** `issue_prorated_refund` returns nil on failure (warn-level log only) — e.g. refund
+  amount exceeds the latest invoice's charge, plausible when the most recent paid invoice is a
+  small proration invoice. The result hash reports `refund_amount` / `refund_formatted` from the
+  computed credit unconditionally: customer told they were refunded money that never moved.
+- **Fix:** Thread the actual refund/credit-note result into the response; report 0 / omit with an
+  explicit `refund_failed` flag when nil, and log at error level.
+- **Verify:** Spec where the refund call fails, asserting the response does not claim a refund.
+
+---
+
+## Sequencing note
+
+CM-1 + CM-4 are one change (credit-note refund). CM-2 and CM-3 are independent. CM-5 lands last
+(depends on the refund call's final return shape). All five touch only
+`currency_migration_service.rb` + specs; no schema or config changes.

--- a/TASKS-stripe-audit-followup.md
+++ b/TASKS-stripe-audit-followup.md
@@ -1,0 +1,82 @@
+# Stripe Checkout/Tax Audit — Follow-up Tasks (Medium/Low)
+
+Source: Stripe Checkout/Tax audit 2026-08-07 (branch `fix/4025-currency-migration-tax-policy`).
+Critical/high items live in `TASKS-stripe-audit-critical.md`. Nothing here blocks a release;
+FU-1 changes runtime behavior, the rest are hygiene/consistency.
+
+## Task states
+
+| Marker | Meaning |
+|--------|---------|
+| `[ ] TODO` | Not started |
+| `[~] IN PROGRESS` | Actively being worked (note owner/branch) |
+| `[!] BLOCKED` | Blocked — note blocker inline |
+| `[x] DONE` | Fixed, tested, merged |
+
+---
+
+## FU-1 `[ ] TODO` — MEDIUM: dead idempotent-replay fallback in `ProcessCheckoutSession`
+
+- **Where:** `apps/web/billing/logic/welcome.rb:350-351` (`find_target_organization`)
+- **Problem:** The session is retrieved with `expand: %w[subscription customer]`, so
+  `checkout_session.customer` is a `Stripe::Customer` object; the
+  `is_a?(String) && start_with?('cus_')` guard never matches and the
+  `find_by_stripe_customer_id` fallback (priority 2) is dead code. Resolution falls through to
+  the customer's default org.
+- **Impact:** Matters for `Plans#checkout_redirect` sessions, which carry no `orgid` metadata
+  (#4017): replays resolve by default-org instead of by bound Stripe customer.
+- **Fix:** Read `customer.id` when expanded (accept both String and object), or drop `customer`
+  from the expand list. Coordinate with #4017 (metadata unification may make the fallback moot).
+
+## FU-2 `[ ] TODO` — MEDIUM: `detect_region` divergence between checkout surfaces
+
+- **Where:** `apps/web/billing/controllers/plans.rb:354-358` (hardcodes `'EU'`) vs
+  `apps/web/billing/operations/create_checkout_link.rb:189-191` (reads
+  `features.regions.current_jurisdiction`, default `'LL'`)
+- **Problem:** Webhook-visible subscription metadata (`checkout_region` / `region`) differs by
+  which surface created the session.
+- **Fix:** Point `Plans#detect_region` at the shared implementation. Fold into the #4017
+  `build_session_params` migration rather than fixing standalone.
+
+## FU-3 `[ ] TODO` — LOW: raw Stripe error messages returned to API clients
+
+- **Where:** `apps/web/billing/controllers/billing.rb:1020` (`migrate_currency`),
+  `:536` (`preview_plan_change`), `:695` (`change_plan`) — all `json_error(ex.message, ...)`
+- **Problem:** Stripe `InvalidRequestError` messages can embed object IDs and parameter names;
+  other billing paths deliberately return generic messages.
+- **Fix:** Replace with generic client messages; keep full detail in the existing log lines.
+
+## FU-4 `[x] DONE` (fix/4025-currency-migration-clover-drift) — LOW: hardcoded `'cad'` currency fallback in migration result
+
+- **Where:** `apps/web/billing/lib/currency_migration_service.rb:331`
+  (`subscription&.currency || 'cad'`)
+- **Problem:** Ignores `Onetime.billing_config.currency` (which itself defaults to `'cad'`);
+  wrong display currency for non-CAD deployments when the org had no subscription.
+- **Fix:** `subscription&.currency || Onetime.billing_config.currency`.
+
+## FU-5 `[x] DONE` (fix/4025-currency-migration-clover-drift) — LOW: doc drift in `issue_prorated_refund`
+
+- **Where:** `apps/web/billing/lib/currency_migration_service.rb:519-521`
+- **Problem:** YARD documents `@param currency` but the method signature is
+  `(customer_id, amount)`.
+- **Fix:** Remove the stale param (or reintroduce currency if the CM-4 credit-note rewrite
+  needs it). Fold into the CM-1/CM-4 change.
+
+## FU-6 `[ ] TODO` — LOW: spec fidelity — stub clover-shaped Stripe objects
+
+- **Where:** `spec/unit/billing/currency_migration_service_spec.rb` (e.g. `:282,309` expanded
+  discount hashes), billing spec support doubles generally
+- **Problem:** Doubles model pre-basil field shapes (`payment_intent` on Invoice, expanded
+  `discounts`), which is exactly why CM-1..CM-3 shipped green.
+- **Fix:** Align shared Stripe doubles/factories (`apps/web/billing/spec/support/`) with the
+  pinned `2025-12-15.clover` shapes: no `Invoice#payment_intent`, unexpanded `discounts`,
+  items-level `current_period_end`. Consider `verify_partial_doubles`-style guards or a factory
+  comment pinning the API version.
+
+---
+
+## Sequencing note
+
+FU-1 and FU-2 belong with the #4017 checkout-metadata unification. FU-4/FU-5 ride along with the
+CM-1/CM-4 refund rewrite. FU-6 should land with (or immediately after) the critical fixes so the
+new specs enforce clover shapes.

--- a/apps/web/billing/lib/currency_migration_service.rb
+++ b/apps/web/billing/lib/currency_migration_service.rb
@@ -298,7 +298,7 @@ module Billing
 
         # Issue refund for prorated unused time if applicable
         if prorated_credit.positive?
-          issue_prorated_refund(customer_id, prorated_credit)
+          issue_prorated_refund(customer_id, subscription.id, prorated_credit)
         end
       end
 
@@ -528,30 +528,38 @@ module Billing
 
     # Issue refund for prorated unused time
     #
-    # Finds the latest paid invoice for the customer and creates a partial refund.
-    # Uses Stripe::Refund instead of customer credit balance (credit is currency-specific
-    # and won't transfer to the new currency).
+    # Finds the migrated subscription's latest paid invoice and issues a
+    # credit note with refund_amount against it. A credit note (rather than a
+    # raw Stripe::Refund) adjusts Stripe Tax reporting so collected tax is not
+    # overstated after the partial refund. Customer credit balance is not used
+    # (credit is currency-specific and won't transfer to the new currency).
     #
     # @param customer_id [String] Stripe customer ID
+    # @param subscription_id [String] Stripe subscription ID being migrated
     # @param amount [Integer] Refund amount in smallest currency unit
-    # @param currency [String] Currency code
-    # @return [Stripe::Refund, nil] The refund object or nil if no eligible invoice
-    def issue_prorated_refund(customer_id, amount)
-      # Find the latest paid invoice with a payment intent
+    # @return [Stripe::CreditNote, nil] The credit note, or nil if there is no
+    #   eligible invoice or Stripe rejected the amount
+    def issue_prorated_refund(customer_id, subscription_id, amount)
+      # Scope to the migrated subscription — the customer's latest paid
+      # invoice may be an unrelated one
       invoices = Stripe::Invoice.list(
         customer: customer_id,
+        subscription: subscription_id,
         status: 'paid',
         limit: 1,
       )
 
       invoice = invoices.data.first
-      return nil unless invoice&.payment_intent
+      return nil unless invoice
 
-      Stripe::Refund.create(
+      # refund_amount must reconcile against the invoice's post-payment
+      # amount; Stripe raises InvalidRequestError otherwise
+      Billing::StripeClient.new.create(
+        Stripe::CreditNote,
         {
-          payment_intent: invoice.payment_intent,
-          amount: amount,
-          reason: 'requested_by_customer',
+          invoice: invoice.id,
+          refund_amount: amount,
+          memo: 'Prorated refund for unused time (currency migration)',
           metadata: {
             reason: 'currency_migration_proration',
           },

--- a/apps/web/billing/lib/currency_migration_service.rb
+++ b/apps/web/billing/lib/currency_migration_service.rb
@@ -142,10 +142,24 @@ module Billing
 
       customer_id = org.stripe_customer_id
 
-      # Build current plan info from active subscription
+      # Single retrieve shared with the coupon check below. Discounts come
+      # back as bare ID strings unless expanded.
+      subscription = nil
       if org.stripe_subscription_id
-        subscription = Stripe::Subscription.retrieve(org.stripe_subscription_id)
-        first_item   = subscription.items.data.first
+        begin
+          subscription = Stripe::Subscription.retrieve(
+            id: org.stripe_subscription_id,
+            expand: ['discounts'],
+          )
+        rescue Stripe::InvalidRequestError
+          # Subscription deleted between mismatch check and retrieve —
+          # assess as if there were none
+        end
+      end
+
+      # Build current plan info from active subscription
+      if subscription
+        first_item = subscription.items.data.first
 
         if subscription.status == 'past_due'
           result[:blockers] << 'Subscription is past_due — resolve payment before migrating'
@@ -184,7 +198,7 @@ module Billing
       end
 
       # Warning flags
-      warnings          = check_migration_warnings(customer_id, existing_currency, org.stripe_subscription_id)
+      warnings          = check_migration_warnings(customer_id, existing_currency, subscription)
       result[:warnings] = warnings
 
       result
@@ -339,9 +353,10 @@ module Billing
     #
     # @param customer_id [String] Stripe customer ID
     # @param existing_currency [String] Current currency
-    # @param subscription_id [String, nil] Current subscription ID
+    # @param subscription [Stripe::Subscription, nil] Current subscription,
+    #   retrieved with expand: ['discounts'] (nil when the org has none)
     # @return [Hash] Warning flags
-    def check_migration_warnings(customer_id, existing_currency, subscription_id)
+    def check_migration_warnings(customer_id, existing_currency, subscription)
       warnings = {
         has_credit_balance: false,
         credit_balance_amount: 0,
@@ -371,15 +386,13 @@ module Billing
       end
 
       # Amount-off coupon check (currency-specific; percentage coupons are fine)
-      if subscription_id
-        begin
-          sub      = Stripe::Subscription.retrieve(subscription_id)
-          discount = sub.discounts&.first
-          if discount&.coupon&.amount_off && discount.coupon.currency == existing_currency
-            warnings[:has_incompatible_coupons] = true
-          end
-        rescue Stripe::InvalidRequestError
-          # Subscription may have been deleted between check and retrieve
+      if subscription
+        discount = subscription.discounts&.first
+        # Unexpanded discounts are bare ID strings — coupon data requires
+        # the subscription retrieved with expand: ['discounts']
+        if discount.respond_to?(:coupon) && discount.coupon&.amount_off &&
+           discount.coupon.currency == existing_currency
+          warnings[:has_incompatible_coupons] = true
         end
       end
 

--- a/apps/web/billing/lib/currency_migration_service.rb
+++ b/apps/web/billing/lib/currency_migration_service.rb
@@ -467,21 +467,24 @@ module Billing
       first_item = subscription.items.data.first
       return 0 unless first_item
 
+      # Basil (2025-03-31) moved item changes into subscription_details
       invoice = Stripe::Invoice.create_preview(
         customer: subscription.customer,
         subscription: subscription.id,
-        subscription_items: [{
-          id: first_item.id,
-          deleted: true,
-        }],
-        subscription_proration_behavior: 'create_prorations',
-        subscription_proration_date: Time.now.to_i,
+        subscription_details: {
+          items: [{
+            id: first_item.id,
+            deleted: true,
+          }],
+          proration_behavior: 'create_prorations',
+          proration_date: Time.now.to_i,
+        },
       )
 
       # Credit lines have negative amounts
       invoice.lines.data.select { |line| line.amount < 0 }.sum(&:amount).abs
     rescue Stripe::StripeError => ex
-      OT.ld "[CurrencyMigrationService] Invoice preview failed (#{ex.message}), falling back to manual calculation"
+      OT.lw "[CurrencyMigrationService] Invoice preview failed (#{ex.message}), falling back to manual calculation"
       manual_prorated_credit(subscription)
     end
 

--- a/apps/web/billing/lib/currency_migration_service.rb
+++ b/apps/web/billing/lib/currency_migration_service.rb
@@ -550,8 +550,14 @@ module Billing
     # @param customer_id [String] Stripe customer ID
     # @param subscription_id [String] Stripe subscription ID being migrated
     # @param amount [Integer] Refund amount in smallest currency unit
+    # The refund is best-effort: any Stripe failure (invalid params, rate
+    # limits, connectivity) returns nil so the migration checkout can still
+    # proceed — the caller reports refund_failed instead of stranding the
+    # customer with a cancelled subscription and no new checkout. Non-Stripe
+    # errors still raise (programming bugs must surface).
+    #
     # @return [Stripe::CreditNote, nil] The credit note, or nil if there is no
-    #   eligible invoice or Stripe rejected the amount
+    #   eligible invoice or any Stripe error occurred
     def issue_prorated_refund(customer_id, subscription_id, amount)
       # Scope to the migrated subscription — the customer's latest paid
       # invoice may be an unrelated one
@@ -581,8 +587,8 @@ module Billing
           },
         },
       )
-    rescue Stripe::InvalidRequestError => ex
-      OT.lw "[CurrencyMigrationService] Could not issue prorated refund: #{ex.message}"
+    rescue Stripe::StripeError => ex
+      OT.lw "[CurrencyMigrationService] Could not issue prorated refund (#{ex.class}): #{ex.message}"
       nil
     end
 

--- a/apps/web/billing/lib/currency_migration_service.rb
+++ b/apps/web/billing/lib/currency_migration_service.rb
@@ -151,9 +151,11 @@ module Billing
             id: org.stripe_subscription_id,
             expand: ['discounts'],
           )
-        rescue Stripe::InvalidRequestError
+        rescue Stripe::InvalidRequestError => ex
           # Subscription deleted between mismatch check and retrieve —
-          # assess as if there were none
+          # assess as if there were none. Any other failure must surface
+          # rather than report a clean can_migrate: true
+          raise unless ex.code == 'resource_missing'
         end
       end
 
@@ -563,12 +565,15 @@ module Billing
       invoice = invoices.data.first
       return nil unless invoice
 
-      # refund_amount must reconcile against the invoice's post-payment
-      # amount; Stripe raises InvalidRequestError otherwise
+      # amount defines the note total (one of amount/lines/shipping_cost is
+      # required); refund_amount controls how much of it is refunded. Both
+      # must reconcile against the invoice's post-payment amount; Stripe
+      # raises InvalidRequestError otherwise
       Billing::StripeClient.new.create(
         Stripe::CreditNote,
         {
           invoice: invoice.id,
+          amount: amount,
           refund_amount: amount,
           memo: 'Prorated refund for unused time (currency migration)',
           metadata: {

--- a/apps/web/billing/lib/currency_migration_service.rb
+++ b/apps/web/billing/lib/currency_migration_service.rb
@@ -268,6 +268,8 @@ module Billing
     def execute_immediate_migration(org, new_price_id, success_url:, cancel_url:)
       customer_id     = org.stripe_customer_id
       prorated_credit = 0
+      credit_note     = nil
+      subscription    = nil
 
       # Pre-flight: clean up
       expire_open_checkout_sessions(customer_id)
@@ -298,7 +300,7 @@ module Billing
 
         # Issue refund for prorated unused time if applicable
         if prorated_credit.positive?
-          issue_prorated_refund(customer_id, subscription.id, prorated_credit)
+          credit_note = issue_prorated_refund(customer_id, subscription.id, prorated_credit)
         end
       end
 
@@ -336,13 +338,22 @@ module Billing
       # Clear any pending migration intent (immediate path completes in one step)
       org.clear_currency_migration_intent!
 
+      # Report the credit note's actual amount, not the computed credit —
+      # a nil credit note means no money moved
+      refund_failed = prorated_credit.positive? && credit_note.nil?
+      if refund_failed
+        OT.le "[CurrencyMigrationService] Prorated refund of #{prorated_credit} failed for #{customer_id} — reporting refund_amount 0"
+      end
+      refund_amount = credit_note ? credit_note.amount : 0
+
       {
         success: true,
         migration: {
           mode: 'immediate',
           checkout_url: checkout_session.url,
-          refund_amount: prorated_credit,
-          refund_formatted: format_amount(prorated_credit, subscription&.currency || 'cad'),
+          refund_amount: refund_amount,
+          refund_formatted: format_amount(refund_amount, subscription&.currency || Onetime.billing_config.currency),
+          refund_failed: refund_failed,
         },
       }
     end

--- a/apps/web/billing/spec/controllers/billing_controller_unit_spec.rb
+++ b/apps/web/billing/spec/controllers/billing_controller_unit_spec.rb
@@ -259,10 +259,10 @@ RSpec.describe 'Billing::Controllers::BillingController - Unit Tests' do
       end
 
       it 'returns 409 with fallback assessment instead of 500' do
-        # This test requires a plan with stripe_price_id, but config-only plans
-        # don't have Stripe price IDs. Need to mock Plan.load or use VCR cassettes.
-        skip 'Config-only plans lack stripe_price_id - test needs VCR cassette or mock'
-
+        # Plans loaded from billing.test.yaml via with_test_plans DO carry
+        # stripe_price_id (ConfigLoader maps prices[].price_id), so the
+        # request reaches Stripe::Checkout::Session.create and the stubbed
+        # currency-conflict error.
         post "/billing/api/org/#{organization.extid}/checkout", {
           product: product,
           interval: interval,

--- a/locales/content/en/workspace-billing.json
+++ b/locales/content/en/workspace-billing.json
@@ -1037,6 +1037,14 @@
     "context": "Button to start checkout for the new currency plan",
     "content_hash": "fa794e0c"
   },
+  "web.billing.currency_migration.refund_failed_warning": {
+    "text": "Your previous plan was cancelled, but we couldn't automatically issue the refund for your unused time. Please contact support to receive your refund. You still need to complete checkout to activate your new plan.",
+    "context": "Warning shown when an immediate currency migration succeeds but the prorated refund could not be issued"
+  },
+  "web.billing.currency_migration.refund_failed_continue": {
+    "text": "Continue to Checkout",
+    "context": "Button to proceed to checkout after acknowledging the refund failure warning"
+  },
   "web.billing.checkout_session_failed": {
     "text": "Failed to create checkout session",
     "context": "Error when Stripe checkout session creation returns no URL",

--- a/locales/content/en/workspace-billing.json
+++ b/locales/content/en/workspace-billing.json
@@ -1039,11 +1039,13 @@
   },
   "web.billing.currency_migration.refund_failed_warning": {
     "text": "Your previous plan was cancelled, but we couldn't automatically issue the refund for your unused time. Please contact support to receive your refund. You still need to complete checkout to activate your new plan.",
-    "context": "Warning shown when an immediate currency migration succeeds but the prorated refund could not be issued"
+    "context": "Warning shown when an immediate currency migration succeeds but the prorated refund could not be issued",
+    "content_hash": "a390c498"
   },
   "web.billing.currency_migration.refund_failed_continue": {
     "text": "Continue to Checkout",
-    "context": "Button to proceed to checkout after acknowledging the refund failure warning"
+    "context": "Button to proceed to checkout after acknowledging the refund failure warning",
+    "content_hash": "eccdb8aa"
   },
   "web.billing.checkout_session_failed": {
     "text": "Failed to create checkout session",

--- a/spec/unit/billing/currency_migration_service_spec.rb
+++ b/spec/unit/billing/currency_migration_service_spec.rb
@@ -343,7 +343,9 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
     context 'when the subscription was deleted between check and retrieve' do
       before do
         allow(Stripe::Subscription).to receive(:retrieve)
-          .and_raise(Stripe::InvalidRequestError.new('No such subscription: sub_123', 'id'))
+          .and_raise(Stripe::InvalidRequestError.new(
+            'No such subscription: sub_123', 'id', code: 'resource_missing'
+          ))
         allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
       end
 
@@ -352,6 +354,21 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
 
         expect(result[:current_plan]).to be_nil
         expect(result[:warnings][:has_incompatible_coupons]).to be false
+      end
+    end
+
+    context 'when the subscription retrieve fails for another reason' do
+      before do
+        allow(Stripe::Subscription).to receive(:retrieve)
+          .and_raise(Stripe::InvalidRequestError.new(
+            'Invalid array', 'expand', code: 'parameter_invalid_empty'
+          ))
+      end
+
+      it 're-raises instead of assessing a clean migration' do
+        expect do
+          described_class.assess_migration(org, 'eur', 'cad', target_price_id)
+        end.to raise_error(Stripe::InvalidRequestError, /Invalid array/)
       end
     end
 
@@ -624,6 +641,7 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
           Stripe::CreditNote,
           {
             invoice: 'in_123',
+            amount: 1450,
             refund_amount: 1450,
             memo: kind_of(String),
             metadata: { reason: 'currency_migration_proration' },

--- a/spec/unit/billing/currency_migration_service_spec.rb
+++ b/spec/unit/billing/currency_migration_service_spec.rb
@@ -163,7 +163,8 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
       end
 
       before do
-        allow(Stripe::Subscription).to receive(:retrieve).with('sub_123').and_return(subscription)
+        allow(Stripe::Subscription).to receive(:retrieve)
+          .with({ id: 'sub_123', expand: ['discounts'] }).and_return(subscription)
         allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
         allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
       end
@@ -205,7 +206,8 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
       end
 
       before do
-        allow(Stripe::Subscription).to receive(:retrieve).with('sub_123').and_return(subscription)
+        allow(Stripe::Subscription).to receive(:retrieve)
+          .with({ id: 'sub_123', expand: ['discounts'] }).and_return(subscription)
         allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
         allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
       end
@@ -231,7 +233,8 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
 
       before do
         allow(mock_customer).to receive(:balance).and_return(-5000)
-        allow(Stripe::Subscription).to receive(:retrieve).with('sub_123').and_return(subscription)
+        allow(Stripe::Subscription).to receive(:retrieve)
+          .with({ id: 'sub_123', expand: ['discounts'] }).and_return(subscription)
         allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
         allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
       end
@@ -256,7 +259,8 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
       end
 
       before do
-        allow(Stripe::Subscription).to receive(:retrieve).with('sub_123').and_return(subscription)
+        allow(Stripe::Subscription).to receive(:retrieve)
+          .with({ id: 'sub_123', expand: ['discounts'] }).and_return(subscription)
         allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
 
         items = [
@@ -286,7 +290,8 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
       end
 
       before do
-        allow(Stripe::Subscription).to receive(:retrieve).with('sub_123').and_return(subscription)
+        allow(Stripe::Subscription).to receive(:retrieve)
+          .with({ id: 'sub_123', expand: ['discounts'] }).and_return(subscription)
         allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
         allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
       end
@@ -296,32 +301,57 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
 
         expect(result[:warnings][:has_incompatible_coupons]).to be true
       end
+
+      it 'retrieves the subscription once with discounts expanded' do
+        described_class.assess_migration(org, 'eur', 'cad', target_price_id)
+
+        expect(Stripe::Subscription).to have_received(:retrieve)
+          .with({ id: 'sub_123', expand: ['discounts'] }).once
+      end
     end
 
-    # Regression: Stripe API returns `discounts` (array) not `discount` (singular).
-    # Prior to fix, accessing sub.discount on newer API versions raised NoMethodError.
-    context 'with discounts array containing amount-off coupon (Stripe API regression)' do
+    # Regression: without expand: ['discounts'], clover returns bare discount
+    # ID strings; `discount&.coupon` on a String raised NoMethodError.
+    context 'with unexpanded discount ID strings (clover regression)' do
       let(:subscription) do
         Stripe::Subscription.construct_from({
           id: 'sub_123', object: 'subscription', customer: customer_id,
           status: 'active', currency: 'eur',
           cancel_at_period_end: false,
-          discounts: [{ coupon: { id: 'coupon_10_eur', amount_off: 1000, currency: 'eur', name: '10 EUR off' } }],
+          discounts: ['di_123'],
           items: { data: [{ price: { id: 'price_eur', unit_amount: 2900, recurring: { interval: 'month' } }, current_period_end: (Time.now + 30 * 86400).to_i }] },
           metadata: {},
         })
       end
 
       before do
-        allow(Stripe::Subscription).to receive(:retrieve).with('sub_123').and_return(subscription)
+        allow(Stripe::Subscription).to receive(:retrieve)
+          .with({ id: 'sub_123', expand: ['discounts'] }).and_return(subscription)
         allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
         allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
       end
 
-      it 'detects incompatible coupon from discounts array' do
+      it 'does not raise and reports no incompatible coupons' do
+        result = nil
+        expect do
+          result = described_class.assess_migration(org, 'eur', 'cad', target_price_id)
+        end.not_to raise_error
+        expect(result[:warnings][:has_incompatible_coupons]).to be false
+      end
+    end
+
+    context 'when the subscription was deleted between check and retrieve' do
+      before do
+        allow(Stripe::Subscription).to receive(:retrieve)
+          .and_raise(Stripe::InvalidRequestError.new('No such subscription: sub_123', 'id'))
+        allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
+      end
+
+      it 'treats it as no subscription instead of raising' do
         result = described_class.assess_migration(org, 'eur', 'cad', target_price_id)
 
-        expect(result[:warnings][:has_incompatible_coupons]).to be true
+        expect(result[:current_plan]).to be_nil
+        expect(result[:warnings][:has_incompatible_coupons]).to be false
       end
     end
 
@@ -338,7 +368,8 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
       end
 
       before do
-        allow(Stripe::Subscription).to receive(:retrieve).with('sub_123').and_return(subscription)
+        allow(Stripe::Subscription).to receive(:retrieve)
+          .with({ id: 'sub_123', expand: ['discounts'] }).and_return(subscription)
         allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
         allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
       end
@@ -363,7 +394,8 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
       end
 
       before do
-        allow(Stripe::Subscription).to receive(:retrieve).with('sub_123').and_return(subscription)
+        allow(Stripe::Subscription).to receive(:retrieve)
+          .with({ id: 'sub_123', expand: ['discounts'] }).and_return(subscription)
         allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
         allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
       end

--- a/spec/unit/billing/currency_migration_service_spec.rb
+++ b/spec/unit/billing/currency_migration_service_spec.rb
@@ -676,6 +676,32 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
           expect(OT).to have_received(:le).with(/Prorated refund of 1450 failed/)
         end
       end
+
+      # The old subscription is already cancelled by the time the credit note
+      # is created — a transient Stripe failure here must not abort the
+      # migration (HTTP 500 with no checkout URL and the intent never
+      # cleared would strand the customer without a subscription).
+      context 'when Stripe is unreachable during the credit note' do
+        before do
+          allow(stripe_client).to receive(:create)
+            .with(Stripe::CreditNote, anything)
+            .and_raise(Stripe::APIConnectionError.new('Connection to Stripe failed'))
+          allow(OT).to receive(:lw)
+          allow(OT).to receive(:le)
+        end
+
+        it 'proceeds with the checkout and reports the failed refund' do
+          result = execute
+
+          expect(result[:success]).to be true
+          expect(result[:migration][:checkout_url]).to include('stripe.com')
+          expect(result[:migration][:refund_failed]).to be true
+          expect(result[:migration][:refund_amount]).to eq(0)
+          expect(org).to have_received(:clear_currency_migration_intent!)
+          expect(OT).to have_received(:lw)
+            .with(/Stripe::APIConnectionError.*Connection to Stripe failed/)
+        end
+      end
     end
 
     # Deployment tax policy + pmc pin: shared with every other checkout path

--- a/spec/unit/billing/currency_migration_service_spec.rb
+++ b/spec/unit/billing/currency_migration_service_spec.rb
@@ -7,7 +7,7 @@
 # Tests currency conflict detection, diagnostic assessment, and
 # migration execution (graceful and immediate paths).
 #
-# Run: pnpm run test:rspec spec/unit/billing/currency_migration_service_spec.rb
+# Run: tests/lanes/run unit
 
 require 'spec_helper'
 
@@ -531,33 +531,53 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
       expect(result[:success]).to be true
     end
 
-    it 'issues prorated refund using Stripe invoice preview amount' do
-      invoice = double(id: 'in_123', payment_intent: 'pi_123')
-      allow(Stripe::Invoice).to receive(:list).and_return(double(data: [invoice]))
-      allow(Stripe::Invoice).to receive(:void_invoice).and_return(nil)
-      allow(Stripe::Refund).to receive(:create).and_return(double(id: 're_123'))
+    context 'with a paid invoice eligible for a prorated refund' do
+      let(:paid_invoice) { double(id: 'in_123', payment_intent: 'pi_123') }
 
-      result = described_class.execute_immediate_migration(
-        org, 'price_cad_456',
-        success_url: 'https://example.com/success',
-        cancel_url: 'https://example.com/cancel',
-      )
+      before do
+        allow(Stripe::Invoice).to receive(:list)
+          .with(hash_including(status: 'paid'))
+          .and_return(double(data: [paid_invoice]))
+        allow(Stripe::Refund).to receive(:create).and_return(double(id: 're_123'))
+      end
 
-      expect(Stripe::Invoice).to have_received(:create_preview).with(
-        hash_including(
+      def execute
+        described_class.execute_immediate_migration(
+          org, 'price_cad_456',
+          success_url: 'https://example.com/success',
+          cancel_url: 'https://example.com/cancel',
+        )
+      end
+
+      # Basil (2025-03-31) moved subscription_items/subscription_proration_*
+      # into subscription_details; the old top-level params are rejected under
+      # the pinned clover version and silently fell back to manual math.
+      it 'requests the proration preview with the subscription_details shape' do
+        execute
+
+        expect(Stripe::Invoice).to have_received(:create_preview).with(
           customer: 'cus_123',
           subscription: 'sub_123',
-          subscription_proration_behavior: 'create_prorations'
+          subscription_details: {
+            items: [{ id: 'si_123', deleted: true }],
+            proration_behavior: 'create_prorations',
+            proration_date: kind_of(Integer),
+          },
         )
-      )
-      expect(Stripe::Refund).to have_received(:create).with(
-        hash_including(
-          payment_intent: 'pi_123',
-          amount: 1450,
-          reason: 'requested_by_customer'
+      end
+
+      it 'issues the prorated refund for the preview amount' do
+        result = execute
+
+        expect(Stripe::Refund).to have_received(:create).with(
+          hash_including(
+            payment_intent: 'pi_123',
+            amount: 1450,
+            reason: 'requested_by_customer'
+          )
         )
-      )
-      expect(result[:migration][:refund_amount]).to eq(1450)
+        expect(result[:migration][:refund_amount]).to eq(1450)
+      end
     end
 
     # Deployment tax policy + pmc pin: shared with every other checkout path
@@ -626,7 +646,7 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
       allow(Stripe::Invoice).to receive(:create_preview)
         .and_raise(Stripe::InvalidRequestError.new('No such subscription', 'subscription'))
       allow(Stripe::Invoice).to receive(:void_invoice).and_return(nil)
-      allow(OT).to receive(:ld)
+      allow(OT).to receive(:lw)
 
       result = described_class.execute_immediate_migration(
         org, 'price_cad_456',
@@ -637,6 +657,7 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
       # Manual calculation should produce a positive credit (halfway through period)
       expect(result[:migration][:refund_amount]).to be > 0
       expect(result[:migration][:refund_amount]).to be_a(Integer)
+      expect(OT).to have_received(:lw).with(/Invoice preview failed/)
     end
   end
 end

--- a/spec/unit/billing/currency_migration_service_spec.rb
+++ b/spec/unit/billing/currency_migration_service_spec.rb
@@ -564,13 +564,24 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
     end
 
     context 'with a paid invoice eligible for a prorated refund' do
-      let(:paid_invoice) { double(id: 'in_123', payment_intent: 'pi_123') }
+      # Clover-shaped invoice: no payment_intent reader. Must be a real
+      # Stripe::Invoice (not a bare double) so the gem's breaking-change
+      # guard for payment_intent access stays armed.
+      let(:paid_invoice) do
+        Stripe::Invoice.construct_from({
+          id: 'in_123', object: 'invoice',
+          customer: 'cus_123', status: 'paid',
+          amount_paid: 2900, currency: 'eur',
+        })
+      end
+      let(:credit_note) { double(id: 'cn_123', amount: 1450) }
 
       before do
         allow(Stripe::Invoice).to receive(:list)
           .with(hash_including(status: 'paid'))
           .and_return(double(data: [paid_invoice]))
-        allow(Stripe::Refund).to receive(:create).and_return(double(id: 're_123'))
+        allow(stripe_client).to receive(:create)
+          .with(Stripe::CreditNote, anything).and_return(credit_note)
       end
 
       def execute
@@ -598,17 +609,27 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
         )
       end
 
-      it 'issues the prorated refund for the preview amount' do
+      it 'issues a credit note refund against the subscription invoice' do
         result = execute
 
-        expect(Stripe::Refund).to have_received(:create).with(
-          hash_including(
-            payment_intent: 'pi_123',
-            amount: 1450,
-            reason: 'requested_by_customer'
-          )
+        expect(stripe_client).to have_received(:create).with(
+          Stripe::CreditNote,
+          {
+            invoice: 'in_123',
+            refund_amount: 1450,
+            memo: kind_of(String),
+            metadata: { reason: 'currency_migration_proration' },
+          },
         )
         expect(result[:migration][:refund_amount]).to eq(1450)
+      end
+
+      it 'targets the migrated subscription when listing paid invoices' do
+        execute
+
+        expect(Stripe::Invoice).to have_received(:list).with(
+          hash_including(customer: 'cus_123', subscription: 'sub_123', status: 'paid')
+        )
       end
     end
 

--- a/spec/unit/billing/currency_migration_service_spec.rb
+++ b/spec/unit/billing/currency_migration_service_spec.rb
@@ -552,6 +552,7 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
 
     it 'works when org has no active subscription' do
       allow(org).to receive(:stripe_subscription_id).and_return(nil)
+      allow(Onetime.billing_config).to receive(:currency).and_return('usd')
 
       result = described_class.execute_immediate_migration(
         org, 'price_cad_456',
@@ -561,6 +562,11 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
 
       expect(Stripe::Subscription).not_to have_received(:cancel)
       expect(result[:success]).to be true
+      expect(result[:migration][:refund_amount]).to eq(0)
+      expect(result[:migration][:refund_failed]).to be false
+      # No subscription to take a currency from — falls back to the
+      # configured billing currency, not a hardcoded one
+      expect(result[:migration][:refund_formatted]).to eq('USD 0.00')
     end
 
     context 'with a paid invoice eligible for a prorated refund' do
@@ -574,7 +580,9 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
           amount_paid: 2900, currency: 'eur',
         })
       end
-      let(:credit_note) { double(id: 'cn_123', amount: 1450) }
+      # Amount differs from the computed credit (e.g. tax adjustments) to
+      # prove the response reports what actually moved
+      let(:credit_note) { double(id: 'cn_123', amount: 1425) }
 
       before do
         allow(Stripe::Invoice).to receive(:list)
@@ -621,7 +629,8 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
             metadata: { reason: 'currency_migration_proration' },
           },
         )
-        expect(result[:migration][:refund_amount]).to eq(1450)
+        expect(result[:migration][:refund_amount]).to eq(1425)
+        expect(result[:migration][:refund_failed]).to be false
       end
 
       it 'targets the migrated subscription when listing paid invoices' do
@@ -630,6 +639,24 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
         expect(Stripe::Invoice).to have_received(:list).with(
           hash_including(customer: 'cus_123', subscription: 'sub_123', status: 'paid')
         )
+      end
+
+      context 'when Stripe rejects the credit note' do
+        before do
+          allow(stripe_client).to receive(:create)
+            .with(Stripe::CreditNote, anything)
+            .and_raise(Stripe::InvalidRequestError.new('Amount exceeds refundable amount', 'refund_amount'))
+          allow(OT).to receive(:lw)
+          allow(OT).to receive(:le)
+        end
+
+        it 'reports the failure instead of claiming a refund' do
+          result = execute
+
+          expect(result[:migration][:refund_failed]).to be true
+          expect(result[:migration][:refund_amount]).to eq(0)
+          expect(OT).to have_received(:le).with(/Prorated refund of 1450 failed/)
+        end
       end
     end
 

--- a/spec/unit/billing/currency_migration_service_spec.rb
+++ b/spec/unit/billing/currency_migration_service_spec.rb
@@ -725,7 +725,15 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
     it 'falls back to manual calculation when invoice preview fails' do
       allow(Stripe::Invoice).to receive(:create_preview)
         .and_raise(Stripe::InvalidRequestError.new('No such subscription', 'subscription'))
-      allow(Stripe::Invoice).to receive(:void_invoice).and_return(nil)
+      paid_invoice = Stripe::Invoice.construct_from({
+        id: 'in_123', object: 'invoice', customer: 'cus_123', status: 'paid',
+      })
+      allow(Stripe::Invoice).to receive(:list)
+        .with(hash_including(status: 'paid'))
+        .and_return(double(data: [paid_invoice]))
+      allow(stripe_client).to receive(:create)
+        .with(Stripe::CreditNote, anything)
+        .and_return(double(id: 'cn_123', amount: 1450))
       allow(OT).to receive(:lw)
 
       result = described_class.execute_immediate_migration(
@@ -734,9 +742,14 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
         cancel_url: 'https://example.com/cancel',
       )
 
-      # Manual calculation should produce a positive credit (halfway through period)
-      expect(result[:migration][:refund_amount]).to be > 0
-      expect(result[:migration][:refund_amount]).to be_a(Integer)
+      # Manual calculation should produce a positive credit (halfway through
+      # period) which drives the credit-note refund
+      expect(stripe_client).to have_received(:create).with(
+        Stripe::CreditNote,
+        hash_including(refund_amount: (a_value > 0))
+      )
+      expect(result[:migration][:refund_amount]).to eq(1450)
+      expect(result[:migration][:refund_failed]).to be false
       expect(OT).to have_received(:lw).with(/Invoice preview failed/)
     end
   end

--- a/src/apps/workspace/billing/CurrencyMigrationModal.vue
+++ b/src/apps/workspace/billing/CurrencyMigrationModal.vue
@@ -28,12 +28,19 @@ const emit = defineEmits<{
 const isMigrating = ref(false);
 const error = ref('');
 const selectedMode = ref<MigrationMode>('graceful');
+// Immediate migration completed but the prorated refund could not be issued.
+// The old subscription is already cancelled, so checkout must stay reachable —
+// but we stop auto-redirecting and surface the failure first.
+const refundFailed = ref(false);
+const pendingCheckoutUrl = ref('');
 
 // Reset state when modal opens
 watch(() => props.open, (isOpen) => {
   if (isOpen) {
     error.value = '';
     selectedMode.value = 'graceful';
+    refundFailed.value = false;
+    pendingCheckoutUrl.value = '';
   }
 });
 
@@ -78,6 +85,12 @@ async function handleConfirm() {
     if (result.success) {
       if (result.migration.mode === 'graceful') {
         emit('graceful-confirmed', result.migration.cancel_at);
+      } else if (result.migration.refund_failed) {
+        // Do not auto-redirect: the customer would land in checkout with no
+        // refund and no indication it failed. Show the warning and require an
+        // explicit action to continue.
+        refundFailed.value = true;
+        pendingCheckoutUrl.value = result.migration.checkout_url;
       } else {
         emit('immediate-redirect', result.migration.checkout_url);
       }
@@ -90,6 +103,12 @@ async function handleConfirm() {
     console.error('[CurrencyMigrationModal] Migration error:', err);
   } finally {
     isMigrating.value = false;
+  }
+}
+
+function handleContinueToCheckout() {
+  if (pendingCheckoutUrl.value) {
+    emit('immediate-redirect', pendingCheckoutUrl.value);
   }
 }
 
@@ -218,8 +237,10 @@ function handleClose() {
                   </div>
                 </div>
 
-                <!-- Migration Mode Selection -->
-                <fieldset class="mt-5">
+                <!-- Migration Mode Selection (hidden once migration has run) -->
+                <fieldset
+                  v-if="!refundFailed"
+                  class="mt-5">
                   <legend class="text-sm font-medium text-gray-900 dark:text-white">
                     {{ t('web.billing.currency_migration.choose_timing') }}
                   </legend>
@@ -277,6 +298,26 @@ function handleClose() {
                 </fieldset>
               </div>
 
+              <!-- Refund Failed Warning: migration completed, refund could not be issued -->
+              <div
+                v-if="refundFailed"
+                class="mt-4 rounded-md bg-amber-50 p-4 dark:bg-amber-900/20"
+                role="alert"
+                aria-live="polite">
+                <div class="flex">
+                  <OIcon
+                    collection="heroicons"
+                    name="exclamation-triangle"
+                    class="size-5 shrink-0 text-amber-400"
+                    aria-hidden="true" />
+                  <div class="ml-3">
+                    <p class="text-sm text-amber-700 dark:text-amber-300">
+                      {{ t('web.billing.currency_migration.refund_failed_warning') }}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
               <!-- Error State -->
               <div
                 v-if="error"
@@ -298,6 +339,14 @@ function handleClose() {
               <!-- Actions -->
               <div class="mt-6 sm:flex sm:flex-row-reverse sm:gap-3">
                 <button
+                  v-if="refundFailed"
+                  type="button"
+                  class="inline-flex w-full justify-center rounded-md bg-brand-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-500 dark:bg-brand-500 dark:hover:bg-brand-400 sm:w-auto"
+                  @click="handleContinueToCheckout">
+                  {{ t('web.billing.currency_migration.refund_failed_continue') }}
+                </button>
+                <button
+                  v-else
                   type="button"
                   :disabled="isMigrating || !details"
                   :class="[

--- a/src/schemas/contracts/billing.ts
+++ b/src/schemas/contracts/billing.ts
@@ -229,6 +229,14 @@ export const immediateMigrationResponseSchema = z.object({
     checkout_url: checkoutUrlSchema,
     refund_amount: z.number(),
     refund_formatted: z.string(),
+    /**
+     * True when the prorated refund (Stripe credit note) could not be issued.
+     * The old subscription is already cancelled at this point, so the customer
+     * must still complete checkout — but the UI must surface the failure
+     * instead of silently redirecting. Defaults to false so responses from
+     * older backends that omit the flag still parse.
+     */
+    refund_failed: z.boolean().default(false),
   }),
 });
 

--- a/src/tests/apps/workspace/billing/CurrencyMigrationModal.spec.ts
+++ b/src/tests/apps/workspace/billing/CurrencyMigrationModal.spec.ts
@@ -303,6 +303,91 @@ describe('CurrencyMigrationModal', () => {
     });
   });
 
+  describe('Refund Failure (immediate mode)', () => {
+    const confirmImmediate = async (w: VueWrapper) => {
+      const immediateRadio = w.find('input[value="immediate"]');
+      await immediateRadio.setValue(true);
+      await nextTick();
+      const confirmBtn = w.findAll('button').find(
+        btn => btn.text().includes('currency_migration.confirm')
+      );
+      await confirmBtn?.trigger('click');
+      await nextTick();
+      await nextTick();
+    };
+
+    it('shows warning and does NOT auto-redirect when refund_failed is true', async () => {
+      mockMigrateCurrency.mockResolvedValueOnce({
+        success: true,
+        migration: {
+          mode: 'immediate',
+          checkout_url: 'https://checkout.stripe.com/cs_789',
+          refund_amount: 0,
+          refund_formatted: '€0.00',
+          refund_failed: true,
+        },
+      });
+
+      wrapper = await mountComponent();
+      await confirmImmediate(wrapper);
+
+      expect(wrapper.emitted('immediate-redirect')).toBeFalsy();
+      expect(wrapper.text()).toContain('web.billing.currency_migration.refund_failed_warning');
+    });
+
+    it('reaches checkout via explicit continue action after refund failure', async () => {
+      mockMigrateCurrency.mockResolvedValueOnce({
+        success: true,
+        migration: {
+          mode: 'immediate',
+          checkout_url: 'https://checkout.stripe.com/cs_789',
+          refund_amount: 0,
+          refund_formatted: '€0.00',
+          refund_failed: true,
+        },
+      });
+
+      wrapper = await mountComponent();
+      await confirmImmediate(wrapper);
+
+      const continueBtn = wrapper.findAll('button').find(
+        btn => btn.text().includes('currency_migration.refund_failed_continue')
+      );
+      expect(continueBtn).toBeTruthy();
+      await continueBtn?.trigger('click');
+      await nextTick();
+
+      expect(wrapper.emitted('immediate-redirect')).toBeTruthy();
+      expect(wrapper.emitted('immediate-redirect')![0][0]).toBe(
+        'https://checkout.stripe.com/cs_789'
+      );
+    });
+
+    it('auto-redirects unchanged when refund_failed is false', async () => {
+      mockMigrateCurrency.mockResolvedValueOnce({
+        success: true,
+        migration: {
+          mode: 'immediate',
+          checkout_url: 'https://checkout.stripe.com/cs_790',
+          refund_amount: 700,
+          refund_formatted: '€7.00',
+          refund_failed: false,
+        },
+      });
+
+      wrapper = await mountComponent();
+      await confirmImmediate(wrapper);
+
+      expect(wrapper.emitted('immediate-redirect')).toBeTruthy();
+      expect(wrapper.emitted('immediate-redirect')![0][0]).toBe(
+        'https://checkout.stripe.com/cs_790'
+      );
+      expect(wrapper.text()).not.toContain(
+        'web.billing.currency_migration.refund_failed_warning'
+      );
+    });
+  });
+
   describe('Error Handling', () => {
     it('displays error when migration fails', async () => {
       mockMigrateCurrency.mockRejectedValueOnce(new Error('past_due subscription'));

--- a/src/tests/services/billing.service.currency-migration.spec.ts
+++ b/src/tests/services/billing.service.currency-migration.spec.ts
@@ -20,6 +20,10 @@ import {
   BillingService,
   extractCurrencyConflict,
 } from '@/services/billing.service';
+import {
+  immediateMigrationResponseSchema,
+  migrateCurrencyResponseSchema,
+} from '@/schemas/contracts/billing';
 
 describe('Currency migration service methods', () => {
   beforeEach(() => {
@@ -89,6 +93,41 @@ describe('Currency migration service methods', () => {
           mode: 'graceful',
         })
       ).rejects.toThrow('Subscription is past_due');
+    });
+  });
+
+  describe('immediateMigrationResponseSchema refund_failed', () => {
+    const baseResponse = {
+      success: true as const,
+      migration: {
+        mode: 'immediate' as const,
+        checkout_url: 'https://checkout.stripe.com/c/pay/cs_test_123',
+        refund_amount: 0,
+        refund_formatted: '€0.00',
+      },
+    };
+
+    it('preserves refund_failed: true through parsing (Zod must not strip it)', () => {
+      const parsed = immediateMigrationResponseSchema.parse({
+        ...baseResponse,
+        migration: { ...baseResponse.migration, refund_failed: true },
+      });
+      expect(parsed.migration.refund_failed).toBe(true);
+    });
+
+    it('defaults refund_failed to false when absent (older backend tolerance)', () => {
+      const parsed = immediateMigrationResponseSchema.parse(baseResponse);
+      expect(parsed.migration.refund_failed).toBe(false);
+    });
+
+    it('preserves refund_failed through the migrate-currency union schema', () => {
+      const parsed = migrateCurrencyResponseSchema.parse({
+        ...baseResponse,
+        migration: { ...baseResponse.migration, refund_failed: true },
+      });
+      expect(
+        parsed.migration.mode === 'immediate' && parsed.migration.refund_failed
+      ).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

`currency_migration_service.rb` still spoke the pre-basil (pre-2025-03-31) Stripe API while the deployment pins `stripe_api_version: "2025-12-15.clover"` with stripe gem 18.4.2. Specs stubbed the old field shapes, so CI was green while the production immediate-migration path was broken. Fixes tasks CM-1..CM-5 + FU-4/FU-5 from the 2026-08-07 Stripe checkout/tax audit.

**Stacked on #4032** (`fix/4025-currency-migration-tax-policy`) — merge that first; CM-5 edits the same method as its tax-policy commit.

## Fixes

- **CM-2** (`1a64db10e`): `Invoice.create_preview` used removed top-level `subscription_items`/`subscription_proration_*` params — every call silently fell back to naive refund math that ignores discounts and taxes (a customer with a 50%-off coupon got a full-price refund computed). Ported to the `subscription_details` shape; fallback log raised debug → warn.
- **CM-3** (`7ff8cd821`): `subscription.discounts` returns unexpanded String IDs under clover → `NoMethodError` → 500 on `GET check_currency_migration` for any couponed subscriber. Now a single retrieve with `expand: ['discounts']` in `assess_migration`, passed down (also collapses a triple retrieve of the same subscription).
- **CM-1 + CM-4** (`6da9d918b`): `invoice.payment_intent` was removed in basil; gem 18.4.2 raises a bespoke NoMethodError uncaught by the Stripe-only rescues — an unhandled 500 fired **after** the old subscription was canceled, stranding the customer with no refund and no checkout. The raw `Stripe::Refund` also bypassed Stripe Tax (no credit note, pre-tax amount → tax liability overstated). Rewritten to `Stripe::CreditNote.create` (tax-correct) routed through `Billing::StripeClient`, invoice lookup scoped to customer **and** subscription.
- **CM-5 + FU-4** (`b8c31218b`): the response reported `refund_amount` from the computed credit even when the refund call failed — customer told they were refunded money that never moved. Result now threaded through; `refund_failed` boolean always present, error-level log on failure. Currency fallback `'cad'` → `Onetime.billing_config.currency`.
- **Review fixes** (`e0775d216b`): `CreditNote.create` requires `amount` (one of amount/lines/shipping_cost) — `refund_amount` alone fails; added. Narrowed the retrieve rescue to `resource_missing` so a genuinely failing Stripe call surfaces instead of returning `can_migrate: true`.
- **Test coverage** (`f61661a4d`, `f20b6bf42`): un-skipped the 409 currency-conflict fallback regression spec (skip reason was stale — the path was fully wired); specs now use `Stripe::Invoice.construct_from` clover-shaped objects instead of the bare doubles that masked CM-1..CM-3, and pin the exact new param shapes.

## Testing

- `tests/lanes/run unit` green: 7367 tryouts, all RSpec groups 0 failures (main unit group 3316 examples).
- Adversarial review pass over the full diff: clover param shapes verified against the live API reference; full-file scan confirms no surviving pre-basil field access.
- **Not yet done:** manual Stripe test-mode immediate migration mid-period with an amount-off coupon + automatic tax (covers CM-1/2/3/4 acceptance end-to-end).

## Out of scope (tracked in audit task files)

FU-1/FU-2 (belong with #4017 checkout consolidation), FU-3 (raw Stripe error messages to clients), FU-6 shared-factory clover alignment (`stripe_mock_factory.rb`, 5 dependent spec files).