### PR TITLE
feat(pricing): headline the actual yearly total, not a monthly-equivalent rate

### DIFF
--- a/locales/content/en/workspace-billing.json
+++ b/locales/content/en/workspace-billing.json
@@ -396,6 +396,14 @@
     "text": "/month",
     "content_hash": "eec5d08b"
   },
+  "web.billing.plans.per_year": {
+    "text": "/year",
+    "content_hash": "a2d5f1bc"
+  },
+  "web.billing.plans.billing_interval": {
+    "text": "Billing interval",
+    "content_hash": "3ce28209"
+  },
   "web.billing.plans.save_yearly": {
     "text": "Save {percent}% with yearly billing",
     "content_hash": "88c451f2"

--- a/src/apps/secret/support/Pricing.vue
+++ b/src/apps/secret/support/Pricing.vue
@@ -196,12 +196,13 @@
       <div
         class="mb-8 flex items-center justify-center gap-3"
         role="group"
-        aria-label="Billing interval">
+        :aria-label="t('web.billing.plans.billing_interval')">
         <button
+          type="button"
           @click="billingInterval = 'month'"
           :aria-pressed="billingInterval === 'month'"
           :class="[
-            'rounded-md px-4 py-2 text-sm font-medium transition-colors',
+            'rounded-md px-4 py-2 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600',
             billingInterval === 'month'
               ? 'bg-brand-600 text-white'
               : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700',
@@ -209,10 +210,11 @@
           {{ t('web.billing.plans.monthly') }}
         </button>
         <button
+          type="button"
           @click="billingInterval = 'year'"
           :aria-pressed="billingInterval === 'year'"
           :class="[
-            'rounded-md px-4 py-2 text-sm font-medium transition-colors',
+            'rounded-md px-4 py-2 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600',
             billingInterval === 'year'
               ? 'bg-brand-600 text-white'
               : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700',
@@ -247,7 +249,7 @@
           <RouterLink
             v-if="signupEnabled && freePlan"
             :to="getSignupUrl(freePlan)"
-            class="shrink-0 rounded-md bg-white px-4 py-2 text-sm font-semibold text-gray-700 ring-1 ring-inset ring-gray-300 transition-colors hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-600 dark:hover:bg-gray-700">
+            class="shrink-0 rounded-md bg-white px-4 py-2 text-sm font-semibold text-gray-700 ring-1 ring-inset ring-gray-300 transition-colors hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-600 dark:hover:bg-gray-700">
             {{ t('web.pricing.get_started_free') }}
           </RouterLink>
           <span
@@ -276,7 +278,7 @@
               v-if="signupEnabled"
               :to="getSignupUrl(currentPlan)"
               :class="[
-                'block w-full rounded-md px-4 py-2 text-center text-sm font-semibold transition-colors',
+                'block w-full rounded-md px-4 py-2 text-center text-sm font-semibold transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600',
                 isPlanRecommended(currentPlan) || isPlanHighlighted(currentPlan)
                   ? 'bg-brand-600 text-white hover:bg-brand-500'
                   : 'bg-white text-gray-700 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-600 dark:hover:bg-gray-700',
@@ -327,7 +329,7 @@
           {{ t('web.pricing.already_have_account') }}
           <RouterLink
             :to="signinUrl"
-            class="font-medium text-brand-600 hover:text-brand-500 dark:text-brand-400 dark:hover:text-brand-300">
+            class="rounded-sm font-medium text-brand-600 hover:text-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600 dark:text-brand-400 dark:hover:text-brand-300">
             {{ t('web.pricing.sign_in') }}
           </RouterLink>
         </p>

--- a/src/shared/components/billing/PlanCard.vue
+++ b/src/shared/components/billing/PlanCard.vue
@@ -39,15 +39,21 @@
   const { t } = useI18n();
 
   /**
-   * Get the monthly price for display.
-   * Uses API-provided monthly_equivalent_amount for yearly plans if available.
+   * PRICING DISPLAY POLICY: the headline price is always the amount we
+   * actually charge for the plan's interval — the full yearly total for
+   * yearly plans (e.g. $356/year), never a derived monthly-equivalent rate
+   * (e.g. $29.67/month). The divided rate produces unrounded decimals that
+   * undercut our intentionally round price points and misrepresents what
+   * the customer is billed. Do not reintroduce monthly_equivalent_amount
+   * (or amount / 12) as the prominent price.
    */
-  const pricePerMonth = computed((): number => {
-    if (props.plan.interval === 'year') {
-      return props.plan.monthly_equivalent_amount ?? Math.floor(props.plan.amount / 12);
-    }
-    return props.plan.amount;
-  });
+  const headlineAmount = computed((): number => props.plan.amount);
+
+  const intervalLabelKey = computed((): string =>
+    props.plan.interval === 'year'
+      ? 'web.billing.plans.per_year'
+      : 'web.billing.plans.per_month'
+  );
 
   /**
    * Determine card styling based on state
@@ -137,24 +143,19 @@
         </div>
       </div>
 
-      <!-- Price -->
+      <!-- Price: the actual charged amount for the interval (see PRICING DISPLAY POLICY) -->
       <div class="mb-6">
         <div class="flex items-baseline gap-2">
           <!-- All tiers display formatted currency for consistency -->
           <span class="font-brand text-4xl font-bold text-gray-900 dark:text-white">
-            {{ formatCurrency(pricePerMonth, plan.currency) }}
+            {{ formatCurrency(headlineAmount, plan.currency) }}
           </span>
           <span
             v-if="plan.tier !== 'free'"
             class="text-sm text-gray-500 dark:text-gray-400">
-            {{ t('web.billing.plans.per_month') }}
+            {{ t(intervalLabelKey) }}
           </span>
         </div>
-        <p
-          v-if="plan.interval === 'year' && plan.amount > 0"
-          class="mt-1 text-sm font-medium text-gray-500 dark:text-gray-400">
-          {{ t('web.billing.plans.yearly') }}: {{ formatCurrency(plan.amount, plan.currency) }}
-        </p>
       </div>
 
       <!-- Features -->

--- a/src/tests/apps/secret/support/Pricing.spec.ts
+++ b/src/tests/apps/secret/support/Pricing.spec.ts
@@ -212,21 +212,23 @@ describe('Pricing.vue', () => {
       expect(planCards.length).toBe(monthlyPaidPlanIds.length);
     });
 
-    it('calculates monthly equivalent for yearly plans', async () => {
+    it('shows the actual yearly total for yearly plans', async () => {
       mockRouteParamsValue = { interval: 'yearly' };
       await mountComponent();
 
-      // Check that yearly plans show monthly equivalent price
-      // The single_team_yearly has monthly_equivalent_amount: 2417 ($24.17)
-      expect(wrapper.text()).toContain('$24.17');
+      // PRICING DISPLAY POLICY (see PlanCard.vue): yearly plans headline the
+      // charged yearly amount, never a derived monthly-equivalent rate.
+      // single_team_yearly has amount: 29000 ($290.00)
+      expect(wrapper.text()).toContain('$290.00');
+      expect(wrapper.text()).not.toContain('$24.17');
     });
 
-    it('uses API monthly_equivalent_amount when provided', async () => {
+    it('never displays monthly_equivalent_amount even when the API provides it', async () => {
       const planWithEquivalent = createMockPlan({
         id: 'test_yearly',
         interval: 'year',
         amount: 12000, // $120/year
-        monthly_equivalent_amount: 999, // $9.99/month (API override)
+        monthly_equivalent_amount: 999, // $9.99/month (must NOT be shown)
       });
 
       mockListPlans.mockResolvedValueOnce({
@@ -236,8 +238,8 @@ describe('Pricing.vue', () => {
 
       await mountComponent();
 
-      // Should show $9.99 from monthly_equivalent_amount, not $10.00 from calculation
-      expect(wrapper.text()).toContain('$9.99');
+      expect(wrapper.text()).toContain('$120.00');
+      expect(wrapper.text()).not.toContain('$9.99');
     });
 
     it('shows "Most Popular" badge for is_popular plans', async () => {
@@ -545,7 +547,8 @@ describe('Pricing.vue', () => {
 
       const group = wrapper.find('[role="group"]');
       expect(group.exists()).toBe(true);
-      expect(group.attributes('aria-label')).toBe('Billing interval');
+      // t() is mocked to return the key; the label is now translatable
+      expect(group.attributes('aria-label')).toBe('web.billing.plans.billing_interval');
     });
   });
 
@@ -603,11 +606,11 @@ describe('Pricing.vue', () => {
       expect(wrapper.text()).toContain('web.pricing.start_trial');
     });
 
-    it('calculates fallback monthly equivalent when API field missing', async () => {
+    it('shows the yearly total when monthly_equivalent_amount is missing', async () => {
       const yearlyWithoutEquivalent = createMockPlan({
         id: 'test_yearly',
         interval: 'year',
-        amount: 12000, // $120/year -> $10/month
+        amount: 12000, // $120/year
         // monthly_equivalent_amount is undefined
       });
 
@@ -618,8 +621,7 @@ describe('Pricing.vue', () => {
 
       await mountComponent();
 
-      // 12000 / 12 = 1000 cents = $10.00
-      expect(wrapper.text()).toContain('$10.00');
+      expect(wrapper.text()).toContain('$120.00');
     });
   });
 
@@ -863,10 +865,10 @@ describe('Pricing.vue', () => {
 
       expect(wrapper.findAll('[data-testid="plan-card-free_v1"]')).toHaveLength(1);
       // Monthly paid cards are filtered out; yearly ones remain. Asserted via
-      // the yearly-only price ($24.17 from monthly_equivalent_amount: 2417) —
-      // both interval variants share id 'identity_plus_v1', so the card testid
-      // resolves in either view and cannot distinguish them.
-      expect(wrapper.text()).toContain('$24.17');
+      // the yearly-only total ($290.00 from amount: 29000) — both interval
+      // variants share id 'identity_plus_v1', so the card testid resolves in
+      // either view and cannot distinguish them.
+      expect(wrapper.text()).toContain('$290.00');
     });
   });
 });

--- a/src/tests/apps/workspace/billing/PlanSelector.spec.ts
+++ b/src/tests/apps/workspace/billing/PlanSelector.spec.ts
@@ -57,27 +57,10 @@ function getNewFeatures(plan: BillingPlan, allPlans: BillingPlan[]): string[] {
   return plan.entitlements.filter(ent => !basePlan.entitlements.includes(ent));
 }
 
-/**
- * Logic extracted from PlanSelector.vue: getPlanPricePerMonth
- *
- * Returns the monthly display price for a plan.
- * ISSUE: Uses amount / 12 for yearly plans (loses precision)
- * FIX: Should use monthly_equivalent_amount from API when available.
- */
-function getPlanPricePerMonth(
-  plan: BillingPlan & { monthly_equivalent_amount?: number }
-): number {
-  // For yearly plans, prefer API-provided monthly equivalent
-  if (plan.interval === 'year') {
-    if (plan.monthly_equivalent_amount !== undefined) {
-      return plan.monthly_equivalent_amount;
-    }
-    // Fallback to calculation (may lose precision)
-    return Math.floor(plan.amount / 12);
-  }
-  // For monthly plans, show the amount as-is
-  return plan.amount;
-}
+// NOTE: getPlanPricePerMonth (monthly-equivalent display for yearly plans) was
+// removed. PRICING DISPLAY POLICY (see PlanCard.vue): the headline price is
+// always the amount actually charged for the plan's interval — never a derived
+// monthly-equivalent rate.
 
 /**
  * Deduplicate plans by plan_code
@@ -478,57 +461,6 @@ describe('PlanSelector Logic', () => {
     });
   });
 
-  describe('getPlanPricePerMonth', () => {
-    it('uses monthly_equivalent_amount for yearly plans when available', () => {
-      const yearlyPlan = createMockPlan({
-        interval: 'year',
-        amount: 14388, // $143.88/year
-      }) as BillingPlan & { monthly_equivalent_amount?: number };
-      yearlyPlan.monthly_equivalent_amount = 1199; // $11.99/month (API literal)
-
-      expect(getPlanPricePerMonth(yearlyPlan)).toBe(1199);
-    });
-
-    it('falls back to amount/12 calculation when monthly_equivalent not available', () => {
-      const yearlyPlan = createMockPlan({
-        interval: 'year',
-        amount: 14388, // $143.88/year
-      });
-
-      // 14388 / 12 = 1199
-      expect(getPlanPricePerMonth(yearlyPlan)).toBe(1199);
-    });
-
-    it('handles precision loss in fallback calculation', () => {
-      const yearlyPlan = createMockPlan({
-        interval: 'year',
-        amount: 15000, // $150/year
-      });
-
-      // 15000 / 12 = 1250 (loses 0.00 cents)
-      expect(getPlanPricePerMonth(yearlyPlan)).toBe(1250);
-    });
-
-    it('returns amount directly for monthly plans', () => {
-      const monthlyPlan = createMockPlan({
-        interval: 'month',
-        amount: 1499, // $14.99/month
-      });
-
-      expect(getPlanPricePerMonth(monthlyPlan)).toBe(1499);
-    });
-
-    it('ignores monthly_equivalent_amount for monthly plans', () => {
-      const monthlyPlan = createMockPlan({
-        interval: 'month',
-        amount: 1499,
-      }) as BillingPlan & { monthly_equivalent_amount?: number };
-      monthlyPlan.monthly_equivalent_amount = 999; // Should be ignored
-
-      expect(getPlanPricePerMonth(monthlyPlan)).toBe(1499);
-    });
-  });
-
   describe('deduplicatePlans', () => {
     it('removes duplicate plans by plan_code', () => {
       const plans = [
@@ -800,31 +732,6 @@ describe('PlanSelector Logic', () => {
         freePlan.is_popular = false;
 
         expect(isPlanRecommended(freePlan)).toBe(false);
-      });
-    });
-
-    describe('free plan pricing display', () => {
-      it('getPlanPricePerMonth returns 0 for free plan', () => {
-        const freePlan = createMockPlan({
-          id: 'free_v1',
-          tier: 'free',
-          interval: 'month',
-          amount: 0,
-        });
-
-        expect(getPlanPricePerMonth(freePlan)).toBe(0);
-      });
-
-      it('free plan yearly also returns 0', () => {
-        const freePlanYearly = createMockPlan({
-          id: 'free_v1',
-          tier: 'free',
-          interval: 'year',
-          amount: 0,
-        });
-
-        // 0 / 12 = 0
-        expect(getPlanPricePerMonth(freePlanYearly)).toBe(0);
       });
     });
 


### PR DESCRIPTION
Yearly plan cards headlined a derived monthly-equivalent price (`monthly_equivalent_amount ?? amount/12`, e.g. $24.17/month) with the real yearly total in small text. The headline is now always `plan.amount` — the amount actually charged — with a `/month` or `/year` suffix, emphasizing our intentionally round price points. A PRICING DISPLAY POLICY comment in `PlanCard.vue` pins the rule so the equivalent rate doesn't creep back.

Also tidies `/pricing` for a11y (`type="button"` on the interval toggle, focus-visible outlines, translatable toggle-group `aria-label`) and adds `per_year` + `billing_interval` en locale keys (hashes validated). Tests pin the new headline behavior and drop the stale `getPlanPricePerMonth` spec-local mirror.