### PR TITLE
fix(billing): resolve federated plan from subscription metadata, refuse planless claims

### DIFF
--- a/apps/web/auth/operations/create_default_workspace.rb
+++ b/apps/web/auth/operations/create_default_workspace.rb
@@ -294,6 +294,24 @@ module Auth
         return false unless pending
         return false unless pending.active?
 
+        # A pending record without a resolved planid cannot deliver any
+        # benefit. Claiming it anyway would mark the org federated (showing
+        # the "subscription synced" notification for a sync that applied
+        # nothing) and destroy the only copy of the pending state. Leave the
+        # record intact: now that the org exists with an email_hash, the next
+        # subscription webhook re-syncs it directly through the federated
+        # path, which resolves the plan from subscription metadata.
+        if pending.planid.to_s.strip.empty?
+          auth_logger.error '[create-default-workspace] Pending federated subscription has no planid; leaving unclaimed',
+            {
+              org: org.extid,
+              hash_prefix: org.email_hash[0..7],
+              status: pending.subscription_status,
+              region: pending.region,
+            }
+          return false
+        end
+
         # SECURITY AUDIT (verify-disabled residual): we are about to apply a
         # cross-region subscription benefit. If the customer's email ownership
         # was never proven AND this deployment has no email-verification step at
@@ -316,7 +334,7 @@ module Auth
 
         # Apply subscription benefits
         org.subscription_status     = pending.subscription_status
-        org.planid                  = pending.planid if pending.planid
+        org.planid                  = pending.planid
         org.subscription_period_end = pending.subscription_period_end
         org.mark_subscription_federated!
 

--- a/apps/web/auth/spec/operations/create_default_workspace_federation_spec.rb
+++ b/apps/web/auth/spec/operations/create_default_workspace_federation_spec.rb
@@ -206,6 +206,41 @@ RSpec.describe 'CreateDefaultWorkspace: federated subscription claim gate', type
   end
 
   # ---------------------------------------------------------------------------
+  # Planless pending records must not be claimed (cross-region catalog miss)
+  # ---------------------------------------------------------------------------
+  describe 'pending record without a resolved planid' do
+    # Regression: PendingFederatedSubscription used to resolve the plan via
+    # local catalog lookup, which fails by design for cross-region price IDs,
+    # storing planid=nil. Claiming such a record marked the org federated
+    # (showing the "subscription synced" notification) while applying no
+    # benefit, and destroyed the pending record so nothing could retry.
+    it 'skips the claim, does not mark federated, and preserves the pending record' do
+      email = unique_email('planless')
+      create_pending_for(email, planid: nil)
+      customer = create_customer(email: email, verified: true)
+
+      result = Auth::Operations::CreateDefaultWorkspace.new(customer: customer).call
+      org = result[:organization]
+      created_organizations << org
+
+      # Workspace exists, but no phantom federation happened: no synced
+      # notification, no subscription status, planid stays the free default.
+      expect(org.subscription_federated?).to be(false)
+      expect(org.show_federation_notification?).to be(false)
+      expect(org.subscription_status.to_s).to eq('')
+      expect(org.planid.to_s).to eq(Billing::Metadata::FREE_PLAN_ID)
+
+      # The pending record survives for the webhook path to re-sync later.
+      expect(pending_exists?(email)).to be(true)
+
+      # The verify-path entry point also refuses it.
+      applied = Auth::Operations::CreateDefaultWorkspace.claim_pending_federation_for(customer)
+      expect(applied).to be(false)
+      expect(pending_exists?(email)).to be(true)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Idempotency / safety of the verify-path claim entry point
   # ---------------------------------------------------------------------------
   describe 'claim_pending_federation_for is idempotent and safe' do

--- a/apps/web/billing/models/pending_federated_subscription.rb
+++ b/apps/web/billing/models/pending_federated_subscription.rb
@@ -2,7 +2,9 @@
 #
 # frozen_string_literal: true
 
+require_relative '../metadata'
 require_relative '../lib/plan_validator'
+require_relative '../lib/plan_resolver'
 
 module Billing
   # PendingFederatedSubscription - Temporary storage for federation webhooks
@@ -103,23 +105,40 @@ module Billing
       pending
     end
 
-    # Extract plan ID from subscription using PlanValidator
+    # Extract plan ID from subscription
     #
-    # Uses the same resolution logic as update_federated_org in the mixin,
-    # avoiding direct Stripe API calls in the model.
+    # Metadata-first: pending records exist precisely for CROSS-REGION
+    # subscriptions, whose price IDs are not in the local catalog by design.
+    # The canonical family plan_id stamped into subscription metadata at
+    # checkout is the authoritative source — the same rule as the federated
+    # path in ApplySubscriptionToOrg#apply_plan_id. Catalog lookup is only a
+    # fallback for subscriptions without plan_id metadata (legacy Payment
+    # Links), where a local price match is still possible.
     #
     # @param subscription [Stripe::Subscription]
     # @return [String, nil]
     def self.extract_plan_id(subscription)
-      item = subscription.items&.data&.first
-      return nil unless item
+      plan_id = subscription.metadata&.[](Billing::Metadata::FIELD_PLAN_ID).to_s.strip
 
-      price_id = item.price&.id
+      return plan_id if !plan_id.empty? && Billing::PlanResolver.canonical_plan_id?(plan_id)
+
+      unless plan_id.empty?
+        Onetime.billing_logger.warn '[PendingFederatedSubscription] Malformed plan_id metadata, trying catalog',
+          plan_id: plan_id,
+          subscription_id: subscription.id
+      end
+
+      item     = subscription.items&.data&.first
+      price_id = item&.price&.id
       return nil unless price_id
 
-      # Use PlanValidator for consistent plan resolution (no Stripe API call)
       Billing::PlanValidator.resolve_plan_id(price_id)
-    rescue StandardError
+    rescue Billing::CatalogMissError
+      # Expected for cross-region prices when metadata is absent: store the
+      # pending record without a plan; the claim path skips planless records
+      # and the next subscription webhook re-syncs the org directly.
+      Onetime.billing_logger.warn '[PendingFederatedSubscription] No plan_id metadata and price not in local catalog',
+        subscription_id: subscription.id
       nil
     end
 

--- a/apps/web/billing/models/pending_federated_subscription.rb
+++ b/apps/web/billing/models/pending_federated_subscription.rb
@@ -129,8 +129,8 @@ module Billing
       end
 
       item     = subscription.items&.data&.first
-      price_id = item&.price&.id
-      return nil unless price_id
+      price_id = item&.price&.id.to_s.strip
+      return nil if price_id.empty?
 
       Billing::PlanValidator.resolve_plan_id(price_id)
     rescue Billing::CatalogMissError

--- a/apps/web/billing/spec/integration/pending_federation_spec.rb
+++ b/apps/web/billing/spec/integration/pending_federation_spec.rb
@@ -367,6 +367,17 @@ RSpec.describe 'PendingFederatedSubscription Model', :unit do
       expect(described_planid(subscription)).to be_nil
     end
 
+    it 'returns nil for an empty-string price id instead of raising ArgumentError' do
+      subscription = Stripe::Subscription.construct_from(
+        id: "sub_extract_#{SecureRandom.hex(4)}",
+        object: 'subscription',
+        metadata: { 'plan_id' => nil },
+        items: { data: [{ price: { id: '' } }] },
+      )
+      expect(Billing::PlanValidator).not_to receive(:resolve_plan_id)
+      expect(described_planid(subscription)).to be_nil
+    end
+
     it 'does not store a malformed metadata plan_id verbatim' do
       subscription = build_subscription('plan_id' => 'Identity Plus!')
       allow(Billing::PlanValidator).to receive(:resolve_plan_id)

--- a/apps/web/billing/spec/integration/pending_federation_spec.rb
+++ b/apps/web/billing/spec/integration/pending_federation_spec.rb
@@ -114,6 +114,15 @@ RSpec.describe 'PendingFederation: Webhook Storage', :integration, :process_webh
       expect(pending.subscription_status).to eq('active')
     end
 
+    it 'stores the plan id from subscription metadata (cross-region price not in local catalog)' do
+      # The fixture's price ('price_test') is deliberately absent from the
+      # local catalog, mirroring a cross-region webhook. The plan must come
+      # from subscription metadata, or the later claim applies no benefit.
+      operation.call
+      pending = track_pending(Billing::PendingFederatedSubscription.find_by_email_hash(email_hash))
+      expect(pending.planid).to eq('identity_plus_v1')
+    end
+
     it 'stores region from metadata' do
       operation.call
       pending = track_pending(Billing::PendingFederatedSubscription.find_by_email_hash(email_hash))
@@ -299,6 +308,8 @@ RSpec.describe 'PendingFederation: Webhook Storage', :integration, :process_webh
 end
 
 RSpec.describe 'PendingFederatedSubscription Model', :unit do
+  include ProcessWebhookEventHelpers
+
   let(:email_hash) { "test_hash_#{SecureRandom.hex(8)}" }
   let(:created_pending_records) { [] }
 
@@ -322,6 +333,50 @@ RSpec.describe 'PendingFederatedSubscription Model', :unit do
     pending.save
     created_pending_records << pending
     pending
+  end
+
+  describe '.extract_plan_id' do
+    def build_subscription(metadata_overrides = {})
+      build_stripe_subscription(
+        id: "sub_extract_#{SecureRandom.hex(4)}",
+        customer: "cus_extract_#{SecureRandom.hex(4)}",
+        status: 'active',
+        metadata: metadata_overrides,
+      )
+    end
+
+    it 'prefers the canonical plan_id from subscription metadata (no catalog dependency)' do
+      # The fixture's price ('price_test') is not in the local catalog; the
+      # metadata path must resolve without ever reaching the catalog.
+      subscription = build_subscription # fixture default: plan_id => identity_plus_v1
+      expect(Billing::PlanValidator).not_to receive(:resolve_plan_id)
+      expect(described_planid(subscription)).to eq('identity_plus_v1')
+    end
+
+    it 'falls back to catalog lookup when metadata has no plan_id' do
+      subscription = build_subscription('plan_id' => nil)
+      allow(Billing::PlanValidator).to receive(:resolve_plan_id)
+        .with('price_test').and_return('basic_v1')
+      expect(described_planid(subscription)).to eq('basic_v1')
+    end
+
+    it 'returns nil when metadata is absent and the price is not in the local catalog' do
+      subscription = build_subscription('plan_id' => nil)
+      allow(Billing::PlanValidator).to receive(:resolve_plan_id)
+        .and_raise(Billing::CatalogMissError.new(price_id: 'price_test'))
+      expect(described_planid(subscription)).to be_nil
+    end
+
+    it 'does not store a malformed metadata plan_id verbatim' do
+      subscription = build_subscription('plan_id' => 'Identity Plus!')
+      allow(Billing::PlanValidator).to receive(:resolve_plan_id)
+        .and_raise(Billing::CatalogMissError.new(price_id: 'price_test'))
+      expect(described_planid(subscription)).to be_nil
+    end
+
+    def described_planid(subscription)
+      Billing::PendingFederatedSubscription.extract_plan_id(subscription)
+    end
   end
 
   describe '#active?' do

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,7 +79,7 @@ importers:
         version: 4.1.0
       dompurify:
         specifier: ^3.4.0
-        version: 3.4.12
+        version: 3.4.13
       focus-trap:
         specifier: ^7.8.0
         version: 7.8.0
@@ -97,7 +97,7 @@ importers:
         version: 2.2.3(marked@17.0.4)
       nanoid:
         specifier: ^5.1.7
-        version: 5.1.7
+        version: 5.1.16
       pinia:
         specifier: ^3.0.4
         version: 3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))
@@ -2515,8 +2515,8 @@ packages:
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -3565,8 +3565,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.7:
-    resolution: {integrity: sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==}
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -6961,7 +6961,7 @@ snapshots:
 
   dom-accessibility-api@0.5.16: {}
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -8098,7 +8098,7 @@ snapshots:
 
   nanoid@3.3.17: {}
 
-  nanoid@5.1.7: {}
+  nanoid@5.1.16: {}
 
   napi-postinstall@0.3.4: {}
 


### PR DESCRIPTION
## Summary

Fixes the #2471 cross-region federation bug: subscribe in Region A, create a same-email account in Region B → billing page showed a permanent "Subscription Synced" banner while the plan stayed Free.

Two root causes, both in the pending-federation path (the live webhook path via `ApplySubscriptionToOrg` was always correct):

1. **`PendingFederatedSubscription.extract_plan_id` used a catalog lookup** (`PlanValidator.resolve_plan_id(price_id)`). Cross-region price IDs are not in the local catalog by design, so this raised `CatalogMissError`, a blanket rescue swallowed it, and the pending record was stored with `planid=nil`. Now resolves metadata-first (`subscription.metadata['plan_id']` validated via `PlanResolver.canonical_plan_id?`) with catalog lookup only as a same-region fallback; the rescue is narrowed to `CatalogMissError`.

2. **`apply_pending_federation!` claimed planless pendings anyway** — set status=active, marked the org federated (producing the banner), and destroyed the pending record, making the state unrecoverable. Now refuses to claim when `planid` is blank and leaves the record intact so the next `customer.subscription.updated` event can re-sync it.

## Remediation for affected users

Region B: `bin/ots billing webhooks replay --type customer.subscription.updated --customer <id>` — the org now exists, so the live federated path heals the plan.

## Tests

- New spec: cross-region price round-trip through `PendingFederatedSubscription` (`pending_federation_spec.rb`)
- New spec: nil-planid claim refusal in `create_default_workspace_federation_spec.rb`
- Blast radius verified across workspace/webhook specs; rubocop clean.

## Follow-ups (filed)

- #4041 — legacy Payment-Link subscriptions have no `plan_id` metadata and still cannot federate cross-region
- #4042 — pre-existing order-dependent spec leak (seed 4638, free plan vanishes from catalog mid-suite), confirmed on pristine main

Closes #2471