### PR TITLE
Sender DNS verification: normalize tag=value records before comparing

### DIFF
--- a/lib/onetime/domain_validation/record_normalizer.rb
+++ b/lib/onetime/domain_validation/record_normalizer.rb
@@ -1,0 +1,166 @@
+# lib/onetime/domain_validation/record_normalizer.rb
+#
+# frozen_string_literal: true
+
+module Onetime
+  module DomainValidation
+    # RecordNormalizer - semantic comparison of DNS TXT records that follow
+    # the tag=value list grammar shared by DKIM (RFC 6376 Section 3.2) and
+    # DMARC (RFC 7489 Section 6.4):
+    #
+    #   tag-list  =  tag-spec *( ";" tag-spec ) [ ";" ]
+    #   tag-spec  =  [FWS] tag-name [FWS] "=" [FWS] tag-value [FWS]
+    #
+    # Raw string comparison fails on semantically equivalent records: the
+    # published "v=DMARC1; p=none;" and the expected "v=DMARC1;p=none" parse
+    # to the same tag list (issue #4023). This module parses both sides and
+    # compares tags instead of bytes.
+    #
+    # Matching is SUBSET, not equality: every expected tag must be present in
+    # the published record. Customer-added tags (e.g. rua=mailto:...) never
+    # cause a mismatch, and unrecognized tags are ignored per RFC 6376.
+    #
+    # Deliberate divergence from RFC 6376: tag NAMES are folded to lowercase
+    # even though the RFC declares them case-sensitive. No provider or DNS UI
+    # honors that, and folding errs toward verifying a working configuration.
+    #
+    module RecordNormalizer
+      extend self
+
+      # tag-name = ALPHA 0*ALNUMPUNC (ALNUMPUNC = ALPHA / DIGIT / "_").
+      # WSP around the name, the "=", and the value is not part of the value;
+      # WSP inside the value is significant and preserved.
+      TAG_SPEC = /\A\s*([A-Za-z][A-Za-z0-9_]*)\s*=\s*(.*?)\s*\z/m
+
+      # RFC 7489 Section 6.6.3: DMARC record discovery keeps records whose
+      # first tag is v=DMARC1; everything else is discarded. Lenient on WSP
+      # per the tag-spec grammar.
+      DMARC_DISCRIMINATOR = /\A\s*v\s*=\s*DMARC1\s*(?:;|\z)/i
+
+      # RFC 6376 Section 3.6.1: DKIM key records carry v=DKIM1 as first tag.
+      DKIM_DISCRIMINATOR = /\A\s*v\s*=\s*DKIM1\s*(?:;|\z)/i
+
+      # RFC 7208 Section 4.5: the SPF version section is exactly "v=spf1"
+      # followed by a space or the end of the record. SPF is NOT a tag-list;
+      # it only gets a discriminator here for record-set selection.
+      SPF_DISCRIMINATOR = /\A\s*v=spf1(?:\s|\z)/i
+
+      # DMARC policy tags where presence of the tag satisfies the
+      # expectation regardless of value: a customer publishing p=reject
+      # against our expected p=none has hardened their policy, not broken it.
+      DMARC_POLICY_TAGS = %w[p sp].freeze
+
+      # DKIM tags whose values compare case-insensitively (key type, hash
+      # algorithms, service type). Everything else in a DKIM record defaults
+      # to case-sensitive per RFC 6376 Section 3.2.
+      DKIM_CASE_INSENSITIVE_TAGS = %w[k h s].freeze
+
+      def dmarc?(value)
+        DMARC_DISCRIMINATOR.match?(value.to_s)
+      end
+
+      def dkim?(value)
+        DKIM_DISCRIMINATOR.match?(value.to_s)
+      end
+
+      def spf?(value)
+        SPF_DISCRIMINATOR.match?(value.to_s)
+      end
+
+      # True when the value should be compared as a tag-list (DMARC or DKIM).
+      def tag_list?(value)
+        dmarc?(value) || dkim?(value)
+      end
+
+      # Parse a tag-list into { tag_name => tag_value }.
+      #
+      # Tag names fold to lowercase; values keep their case and internal
+      # whitespace (trimmed at the edges). A single trailing ";" is allowed
+      # by the grammar; empty tag-specs elsewhere are not.
+      #
+      # @param value [String] Raw TXT record value
+      # @return [Hash<String, String>, nil] nil when the record is not a
+      #   valid tag-list, including when a tag name repeats (RFC 6376:
+      #   "if a tag name does occur more than once, the entire tag-list
+      #   is invalid")
+      def parse(value)
+        segments = value.to_s.split(';', -1)
+        segments.pop if segments.size > 1 && segments.last.strip.empty?
+
+        tags = {}
+        segments.each do |segment|
+          match = TAG_SPEC.match(segment)
+          return nil unless match
+
+          name = match[1].downcase
+          return nil if tags.key?(name)
+
+          tags[name] = match[2]
+        end
+        tags.empty? ? nil : tags
+      end
+
+      # Does the published record satisfy every tag the expected record
+      # requires? Returns false when either side fails to parse — an invalid
+      # published record (e.g. duplicate tags) never verifies.
+      #
+      # @param expected [String] The record we told the customer to publish
+      # @param published [String] A record found in DNS
+      # @return [Boolean]
+      def subset_match?(expected, published)
+        expected_tags  = parse(expected)
+        published_tags = parse(published)
+        return false if expected_tags.nil? || published_tags.nil?
+
+        kind = record_kind(expected_tags)
+
+        expected_tags.all? do |name, expected_value|
+          published_tags.key?(name) &&
+            tag_satisfied?(kind, name, expected_value, published_tags[name])
+        end
+      end
+
+      # @param tags [Hash<String, String>] Parsed tag-list
+      # @return [Symbol] :dmarc, :dkim, or :unknown
+      def record_kind(tags)
+        case tags['v'].to_s
+        when /\ADMARC1\z/i then :dmarc
+        when /\ADKIM1\z/i  then :dkim
+        else :unknown
+        end
+      end
+
+      # Per-tag comparison policy. RFC 6376 Section 3.2: "Values MUST be
+      # processed as case sensitive unless the specific tag description of
+      # semantics specifies case insensitivity."
+      def tag_satisfied?(kind, name, expected, published)
+        return expected.casecmp?(published) if name == 'v'
+
+        case kind
+        when :dmarc
+          return true if DMARC_POLICY_TAGS.include?(name)
+
+          # Remaining DMARC values are ABNF keywords (case-insensitive per
+          # RFC 5234 Section 2.3), URIs, or domain names (RFC 4343).
+          expected.casecmp?(published)
+        when :dkim
+          if name == 'p'
+            # Base64 key data is case-sensitive, but DNS UIs wrap long keys,
+            # so internal whitespace is not significant.
+            strip_wsp(expected) == strip_wsp(published)
+          elsif DKIM_CASE_INSENSITIVE_TAGS.include?(name)
+            expected.casecmp?(published)
+          else
+            expected == published
+          end
+        else
+          expected == published
+        end
+      end
+
+      def strip_wsp(value)
+        value.gsub(/\s+/, '')
+      end
+    end
+  end
+end

--- a/lib/onetime/domain_validation/record_normalizer.rb
+++ b/lib/onetime/domain_validation/record_normalizer.rb
@@ -45,10 +45,15 @@ module Onetime
       # it only gets a discriminator here for record-set selection.
       SPF_DISCRIMINATOR = /\A\s*v=spf1(?:\s|\z)/i
 
-      # DMARC policy tags where presence of the tag satisfies the
-      # expectation regardless of value: a customer publishing p=reject
-      # against our expected p=none has hardened their policy, not broken it.
+      # DMARC policy tags compared by strength, not equality: a customer
+      # publishing p=reject against our expected p=none has hardened their
+      # policy, not broken it. A weaker published policy (p=none against
+      # expected p=quarantine) fails, as does any value outside the RFC 7489
+      # Section 6.3 keywords (none / quarantine / reject).
       DMARC_POLICY_TAGS = %w[p sp].freeze
+
+      # RFC 7489 Section 6.3 policy keywords in increasing strength.
+      DMARC_POLICY_STRENGTH = { 'none' => 0, 'quarantine' => 1, 'reject' => 2 }.freeze
 
       # DKIM tags whose values compare case-insensitively (key type, hash
       # algorithms, service type). Everything else in a DKIM record defaults
@@ -138,7 +143,7 @@ module Onetime
 
         case kind
         when :dmarc
-          return true if DMARC_POLICY_TAGS.include?(name)
+          return policy_satisfied?(expected, published) if DMARC_POLICY_TAGS.include?(name)
 
           # Remaining DMARC values are ABNF keywords (case-insensitive per
           # RFC 5234 Section 2.3), URIs, or domain names (RFC 4343).
@@ -156,6 +161,19 @@ module Onetime
         else
           expected == published
         end
+      end
+
+      # Policy keywords are ABNF keywords (case-insensitive per RFC 5234
+      # Section 2.3). The published policy must be a recognized keyword at
+      # least as strong as the expected one. When the expected value itself
+      # is not a recognized keyword, fall back to case-insensitive equality
+      # rather than accepting any published value.
+      def policy_satisfied?(expected, published)
+        expected_strength = DMARC_POLICY_STRENGTH[expected.downcase]
+        return expected.casecmp?(published) if expected_strength.nil?
+
+        published_strength = DMARC_POLICY_STRENGTH[published.downcase]
+        !published_strength.nil? && published_strength >= expected_strength
       end
 
       def strip_wsp(value)

--- a/lib/onetime/domain_validation/sender_strategies/base_strategy.rb
+++ b/lib/onetime/domain_validation/sender_strategies/base_strategy.rb
@@ -6,6 +6,7 @@ require 'resolv'
 require 'concurrent'
 require 'json'
 require_relative '../../utils/retry_helper'
+require_relative '../record_normalizer'
 
 module Onetime
   module DomainValidation
@@ -259,41 +260,6 @@ module Onetime
           dns&.close unless resolver
         end
 
-        # Verify a single DNS record by comparing expected value against live DNS.
-        #
-        # Uses a shared resolver to avoid opening/closing connections per record.
-        #
-        # @param record [Hash] A record hash from required_dns_records
-        # @param resolver [Resolv::DNS] Shared resolver instance
-        # @param bypass_cache [Boolean] Skip cache read/write when true
-        # @return [Hash] Verification result with optional :error_type
-        #
-        def verify_record(record, resolver:, bypass_cache: false)
-          actual, error_type = case record[:type]
-                               when 'TXT'
-                                 lookup_txt_records(record[:host], resolver: resolver, bypass_cache: bypass_cache)
-                               when 'CNAME'
-                                 lookup_cname_records(record[:host], resolver: resolver, bypass_cache: bypass_cache)
-                               when 'MX'
-                                 lookup_mx_records(record[:host], resolver: resolver, bypass_cache: bypass_cache)
-                               else
-                                 [[], nil]
-                               end
-
-          verified = record_matches?(record[:type], record[:value], actual)
-
-          result              = {
-            type: record[:type],
-            host: record[:host],
-            expected: record[:value],
-            actual: actual,
-            verified: verified,
-            purpose: record[:purpose],
-          }
-          result[:error_type] = error_type if error_type
-          result
-        end
-
         # Check whether the expected value appears in the actual DNS results.
         #
         # Delegates to type-specific matchers for clarity and testability.
@@ -304,12 +270,11 @@ module Onetime
         # @return [Boolean]
         #
         def record_matches?(type, expected, actual_values)
-          normalized_expected = expected.to_s.downcase.chomp('.')
-
           case type
           when 'TXT'
-            txt_record_matches?(normalized_expected, actual_values)
+            txt_record_matches?(expected.to_s.strip, actual_values)
           when 'CNAME', 'MX'
+            normalized_expected = expected.to_s.downcase.chomp('.')
             actual_values.any? { |v| v.downcase.chomp('.') == normalized_expected }
           else
             false
@@ -318,22 +283,31 @@ module Onetime
 
         # Check whether a TXT record matches expected value.
         #
-        # Handles SPF records specially: customers commonly merge multiple
-        # provider includes into one SPF record (e.g., "v=spf1 include:amazonses.com
-        # include:sendgrid.net ~all"). We extract the include: directive and verify
-        # it appears in any actual TXT record starting with "v=spf1".
+        # Dispatch (issue #4023):
+        # - SPF (v=spf1): spf_record_matches? — customers commonly merge
+        #   multiple provider includes into one SPF record, so we extract the
+        #   include: directive and verify it appears in any actual SPF record.
+        # - DMARC/DKIM tag-lists (v=DMARC1 / v=DKIM1): RecordNormalizer
+        #   subset comparison per RFC 6376 Section 3.2 grammar. Raw string
+        #   comparison false-negatives on semantically identical records
+        #   ("v=DMARC1; p=none;" vs "v=DMARC1;p=none").
+        # - Anything else (opaque provider verification tokens): exact match
+        #   after trim. Deliberately tighter than the old substring check.
         #
-        # For non-SPF TXT records, full substring match is used.
+        # Note: expected is NOT globally downcased here — DKIM p= base64 key
+        # data is case-sensitive (RFC 6376 Section 3.2).
         #
-        # @param normalized_expected [String] Downcased expected value
+        # @param expected [String] Expected value, trimmed
         # @param actual_values [Array<String>] DNS results
         # @return [Boolean]
         #
-        def txt_record_matches?(normalized_expected, actual_values)
-          if normalized_expected.start_with?('v=spf1')
-            spf_record_matches?(normalized_expected, actual_values)
+        def txt_record_matches?(expected, actual_values)
+          if RecordNormalizer.spf?(expected)
+            spf_record_matches?(expected.downcase, actual_values)
+          elsif RecordNormalizer.tag_list?(expected)
+            actual_values.any? { |v| RecordNormalizer.subset_match?(expected, v) }
           else
-            actual_values.any? { |v| v.downcase.include?(normalized_expected) }
+            actual_values.any? { |v| v.strip == expected }
           end
         end
 
@@ -438,6 +412,9 @@ module Onetime
 
         # Verify a single record, using a pre-fetched cached value if available.
         #
+        # Both branches evaluate the full record set (selection + matching),
+        # so a cache hit can also surface 'ambiguous_record_set'.
+        #
         # @param record [Hash] A record hash from required_dns_records
         # @param resolver [Resolv::DNS] Shared resolver instance
         # @param cached_value [Array<String>, nil] Pre-fetched cache value or nil
@@ -446,9 +423,8 @@ module Onetime
         #
         def verify_record_with_cache(record, resolver:, cached_value:, bypass_cache:)
           if cached_value && !bypass_cache
-            # Use cached value directly - no error_type since cache hit
-            verified = record_matches?(record[:type], record[:value], cached_value)
-            return {
+            verified, match_error = evaluate_record_set(record, cached_value)
+            result                = {
               type: record[:type],
               host: record[:host],
               expected: record[:value],
@@ -457,11 +433,13 @@ module Onetime
               purpose: record[:purpose],
               from_cache: true,
             }
+            result[:error_type]   = match_error if match_error
+            return result
           end
 
           # Perform live DNS lookup
-          actual, error_type = lookup_dns_by_type(record[:type], record[:host], resolver: resolver, bypass_cache: true)
-          verified           = record_matches?(record[:type], record[:value], actual)
+          actual, error_type    = lookup_dns_by_type(record[:type], record[:host], resolver: resolver, bypass_cache: true)
+          verified, match_error = evaluate_record_set(record, actual)
 
           result              = {
             type: record[:type],
@@ -472,8 +450,52 @@ module Onetime
             purpose: record[:purpose],
             from_cache: false,
           }
-          result[:error_type] = error_type if error_type
+          effective_error     = error_type || match_error
+          result[:error_type] = effective_error if effective_error
           result
+        end
+
+        # Select the relevant records from the DNS result set, then match.
+        #
+        # RFC 7489 Section 6.6.3 (DMARC) and RFC 7208 Section 4.5 (SPF) both
+        # require record-set selection before evaluation: filter the TXT set
+        # by discriminator, discard unrelated records, and treat more than
+        # one surviving record as an error — never a pass. A duplicate DMARC
+        # or SPF record fails at receiving MTAs, so reporting it verified
+        # would be a false green (issue #4023).
+        #
+        # @param record [Hash] A record hash from required_dns_records
+        # @param actual_values [Array<String>] Full DNS result set
+        # @return [Array(Boolean, String|nil)] [verified, error_type or nil]
+        #
+        def evaluate_record_set(record, actual_values)
+          candidates, ambiguous = select_txt_record_set(record[:type], record[:value], actual_values)
+          return [false, 'ambiguous_record_set'] if ambiguous
+
+          [record_matches?(record[:type], record[:value], candidates), nil]
+        end
+
+        # Filter a TXT result set down to records relevant to the expected
+        # value. Only DMARC and SPF expectations have a discriminator; other
+        # types and TXT purposes pass through unfiltered.
+        #
+        # Zero survivors keeps existing not-found semantics (no match, no
+        # error_type). One survivor plus unrelated TXT records still verifies.
+        #
+        # @return [Array(Array<String>, Boolean)] [candidates, ambiguous]
+        #
+        def select_txt_record_set(type, expected, actual_values)
+          return [actual_values, false] unless type == 'TXT'
+
+          discriminator = if RecordNormalizer.dmarc?(expected)
+                            RecordNormalizer.method(:dmarc?)
+                          elsif RecordNormalizer.spf?(expected)
+                            RecordNormalizer.method(:spf?)
+                          end
+          return [actual_values, false] unless discriminator
+
+          survivors = actual_values.select { |v| discriminator.call(v) }
+          [survivors, survivors.size > 1]
         end
 
         # Lookup DNS records by type.

--- a/lib/onetime/domain_validation/sender_strategies/strategy.rb
+++ b/lib/onetime/domain_validation/sender_strategies/strategy.rb
@@ -15,6 +15,7 @@
 #   results  = strategy.verify_dns_records(mailer_config)
 #
 
+require_relative '../record_normalizer'
 require_relative 'base_strategy'
 require_relative 'provider_config'
 require_relative 'ses_validation'

--- a/spec/unit/onetime/domain_validation/sender_strategies/base_strategy_spec.rb
+++ b/spec/unit/onetime/domain_validation/sender_strategies/base_strategy_spec.rb
@@ -798,6 +798,27 @@ RSpec.describe Onetime::DomainValidation::SenderStrategies::BaseStrategy do
         expect(strategy.txt_record_matches?('v=DMARC1; p=none;', ['v=DMARC1; p=reject'])).to be true
       end
 
+      it 'compares policy keywords case-insensitively (RFC 5234 ABNF keywords)' do
+        expect(strategy.txt_record_matches?('v=DMARC1;p=none', ['v=DMARC1; p=NONE'])).to be true
+      end
+
+      it 'rejects a weaker published policy (p=none against expected p=quarantine)' do
+        expect(strategy.txt_record_matches?('v=DMARC1;p=quarantine', ['v=DMARC1; p=none'])).to be false
+      end
+
+      it 'rejects a published policy outside the RFC 7489 keywords (p=bogus)' do
+        expect(strategy.txt_record_matches?('v=DMARC1;p=none', ['v=DMARC1; p=bogus'])).to be false
+      end
+
+      it 'rejects an empty published policy value (p=)' do
+        expect(strategy.txt_record_matches?('v=DMARC1;p=none', ['v=DMARC1; p='])).to be false
+      end
+
+      it 'applies the same strength ordering to sp=' do
+        expect(strategy.txt_record_matches?('v=DMARC1;p=none;sp=none', ['v=DMARC1;p=none;sp=reject'])).to be true
+        expect(strategy.txt_record_matches?('v=DMARC1;p=none;sp=reject', ['v=DMARC1;p=none;sp=none'])).to be false
+      end
+
       it 'does not match when an expected tag is absent' do
         expect(strategy.txt_record_matches?('v=DMARC1;p=none', ['v=DMARC1'])).to be false
       end

--- a/spec/unit/onetime/domain_validation/sender_strategies/base_strategy_spec.rb
+++ b/spec/unit/onetime/domain_validation/sender_strategies/base_strategy_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Onetime::DomainValidation::SenderStrategies::BaseStrategy do
       public :dns_cache_key, :fetch_from_cache, :store_in_cache, :redis
       public :fetch_cache_bulk, :store_cache_bulk
       public :record_matches?, :txt_record_matches?, :spf_record_matches?
+      public :verify_record_with_cache, :evaluate_record_set, :select_txt_record_set
       public :with_retry
 
       def required_dns_records(_mailer_config)
@@ -759,18 +760,67 @@ RSpec.describe Onetime::DomainValidation::SenderStrategies::BaseStrategy do
       expect(strategy.txt_record_matches?(expected, actual)).to be true
     end
 
-    it 'uses substring match for non-SPF TXT records' do
+    # Issue #4023: opaque provider verification tokens require exact match.
+    # The old substring behavior allowed 'prefix-token-suffix' to satisfy
+    # 'token' — deliberately tightened.
+    it 'requires exact match for opaque tokens, not substring (issue #4023)' do
       expected = 'some-verification-token'
-      actual = ['prefix-some-verification-token-suffix']
 
-      expect(strategy.txt_record_matches?(expected, actual)).to be true
+      expect(strategy.txt_record_matches?(expected, ['some-verification-token'])).to be true
+      expect(strategy.txt_record_matches?(expected, ['prefix-some-verification-token-suffix'])).to be false
     end
 
-    it 'is case insensitive for non-SPF records' do
+    it 'is case sensitive for opaque tokens (issue #4023)' do
       expected = 'verification-token'
-      actual = ['VERIFICATION-TOKEN']
 
-      expect(strategy.txt_record_matches?(expected, actual)).to be true
+      expect(strategy.txt_record_matches?(expected, ['verification-token'])).to be true
+      expect(strategy.txt_record_matches?(expected, ['VERIFICATION-TOKEN'])).to be false
+    end
+
+    it 'trims edge whitespace on the actual value for opaque tokens' do
+      expect(strategy.txt_record_matches?('token-abc', ['  token-abc  '])).to be true
+    end
+
+    context 'with DMARC tag-list records (issue #4023)' do
+      it 'matches semantically equivalent formatting variants' do
+        # Real Lettermint case (eu-direct.metalbaum.dev): published record has
+        # spaces after ";" and a trailing ";" — same tag list per RFC 6376 3.2.
+        expect(strategy.txt_record_matches?('v=DMARC1;p=none', ['v=DMARC1; p=none;'])).to be true
+      end
+
+      it 'is satisfied by a published record with extra customer tags' do
+        expect(
+          strategy.txt_record_matches?('v=DMARC1;p=none', ['v=DMARC1; p=none; rua=mailto:dmarc@example.com']),
+        ).to be true
+      end
+
+      it 'treats a hardened published policy (p=reject) as satisfying p=none' do
+        expect(strategy.txt_record_matches?('v=DMARC1; p=none;', ['v=DMARC1; p=reject'])).to be true
+      end
+
+      it 'does not match when an expected tag is absent' do
+        expect(strategy.txt_record_matches?('v=DMARC1;p=none', ['v=DMARC1'])).to be false
+      end
+
+      it 'never matches a published record invalidated by duplicate tags' do
+        expect(strategy.txt_record_matches?('v=DMARC1;p=none', ['v=DMARC1;p=none;p=reject'])).to be false
+      end
+    end
+
+    context 'with DKIM tag-list records (issue #4023)' do
+      it 'matches by tag subset with case-insensitive k= and wrapped p=' do
+        expected = 'v=DKIM1;k=rsa;p=MIGfMA0GCSqGSIb3'
+        actual = ['v=DKIM1; k=RSA; p=MIGfMA0G CSqG SIb3'] # DNS UI wraps long keys
+
+        expect(strategy.txt_record_matches?(expected, actual)).to be true
+      end
+
+      it 'compares p= base64 key data case-sensitively (RFC 6376 3.2)' do
+        expected = 'v=DKIM1;k=rsa;p=MIGfMA0GCSqGSIb3'
+        actual = ['v=DKIM1; k=rsa; p=migfma0gcsqgsib3']
+
+        expect(strategy.txt_record_matches?(expected, actual)).to be false
+      end
     end
   end
 
@@ -795,6 +845,227 @@ RSpec.describe Onetime::DomainValidation::SenderStrategies::BaseStrategy do
     it 'returns false for unknown record types' do
       result = strategy.record_matches?('AAAA', '::1', ['::1'])
       expect(result).to be false
+    end
+
+    it 'does not downcase TXT expected values before dispatch (issue #4023)' do
+      # Global downcasing would case-fold DKIM base64 p= key data; the
+      # published key must match the expected key byte-for-byte.
+      expect(strategy.record_matches?('TXT', 'v=DKIM1;p=MIGfMA0', ['v=DKIM1; p=MIGfMA0'])).to be true
+      expect(strategy.record_matches?('TXT', 'v=DKIM1;p=MIGfMA0', ['v=DKIM1; p=migfma0'])).to be false
+    end
+  end
+
+  describe '#select_txt_record_set' do
+    it 'passes non-TXT sets through unfiltered' do
+      candidates, ambiguous = strategy.select_txt_record_set(
+        'CNAME', 'target.example.com', ['target.example.com.', 'other.example.com.'],
+      )
+      expect(candidates).to eq(['target.example.com.', 'other.example.com.'])
+      expect(ambiguous).to be false
+    end
+
+    it 'filters DMARC candidates by discriminator, discarding unrelated TXT records' do
+      candidates, ambiguous = strategy.select_txt_record_set(
+        'TXT', 'v=DMARC1;p=none', ['google-site-verification=abc', 'v=DMARC1; p=none;', 'MS=ms123'],
+      )
+      expect(candidates).to eq(['v=DMARC1; p=none;'])
+      expect(ambiguous).to be false
+    end
+
+    it 'flags two surviving DMARC records as ambiguous' do
+      _, ambiguous = strategy.select_txt_record_set(
+        'TXT', 'v=DMARC1;p=none', ['v=DMARC1; p=none;', 'v=DMARC1; p=reject'],
+      )
+      expect(ambiguous).to be true
+    end
+
+    it 'flags two surviving SPF records as ambiguous (RFC 7208 permerror)' do
+      _, ambiguous = strategy.select_txt_record_set(
+        'TXT', 'v=spf1 include:amazonses.com ~all', ['v=spf1 include:amazonses.com ~all', 'v=spf1 -all'],
+      )
+      expect(ambiguous).to be true
+    end
+
+    it 'does not apply uniqueness selection to DKIM expectations' do
+      # Spec scope: record-set selection applies to DMARC and SPF only.
+      candidates, ambiguous = strategy.select_txt_record_set(
+        'TXT', 'v=DKIM1;k=rsa;p=ABC', ['v=DKIM1;k=rsa;p=ABC', 'v=DKIM1;k=rsa;p=DEF'],
+      )
+      expect(candidates).to eq(['v=DKIM1;k=rsa;p=ABC', 'v=DKIM1;k=rsa;p=DEF'])
+      expect(ambiguous).to be false
+    end
+
+    it 'does not apply uniqueness selection to opaque token expectations' do
+      candidates, ambiguous = strategy.select_txt_record_set(
+        'TXT', 'token-abc', ['token-abc', 'token-def'],
+      )
+      expect(candidates).to eq(%w[token-abc token-def])
+      expect(ambiguous).to be false
+    end
+  end
+
+  describe '#verify_record_with_cache' do
+    let(:resolver) { instance_double('Resolv::DNS') }
+    let(:dmarc_record) do
+      {
+        type: 'TXT',
+        host: '_dmarc.example.com',
+        value: 'v=DMARC1;p=none',
+        purpose: 'DMARC',
+      }
+    end
+
+    def txt_resources(values)
+      values.map { |v| double('TXT', strings: [v]) }
+    end
+
+    context 'cache-hit branch' do
+      it 'fails with ambiguous_record_set when the cached set has two DMARC records' do
+        result = strategy.verify_record_with_cache(
+          dmarc_record,
+          resolver: resolver,
+          cached_value: ['v=DMARC1; p=none;', 'v=DMARC1; p=reject'],
+          bypass_cache: false,
+        )
+
+        expect(result[:verified]).to be false
+        expect(result[:error_type]).to eq('ambiguous_record_set')
+        expect(result[:from_cache]).to be true
+      end
+
+      it 'fails duplicate IDENTICAL cached DMARC records too (never a pass)' do
+        result = strategy.verify_record_with_cache(
+          dmarc_record,
+          resolver: resolver,
+          cached_value: ['v=DMARC1;p=none', 'v=DMARC1;p=none'],
+          bypass_cache: false,
+        )
+
+        expect(result[:verified]).to be false
+        expect(result[:error_type]).to eq('ambiguous_record_set')
+      end
+
+      it 'verifies one cached DMARC record among unrelated junk TXT records' do
+        cached = ['google-site-verification=abc', 'v=DMARC1; p=none;', 'MS=ms123']
+        result = strategy.verify_record_with_cache(
+          dmarc_record,
+          resolver: resolver,
+          cached_value: cached,
+          bypass_cache: false,
+        )
+
+        expect(result[:verified]).to be true
+        expect(result).not_to have_key(:error_type)
+        # :actual keeps the full unfiltered set for diagnostics and re-caching
+        expect(result[:actual]).to eq(cached)
+      end
+
+      it 'keeps not-found semantics when zero DMARC records survive' do
+        result = strategy.verify_record_with_cache(
+          dmarc_record,
+          resolver: resolver,
+          cached_value: ['google-site-verification=abc'],
+          bypass_cache: false,
+        )
+
+        expect(result[:verified]).to be false
+        expect(result).not_to have_key(:error_type)
+        expect(result[:from_cache]).to be true
+      end
+    end
+
+    context 'live branch' do
+      it 'fails with ambiguous_record_set when DNS returns two DMARC records' do
+        allow(resolver).to receive(:getresources)
+          .with('_dmarc.example.com', Resolv::DNS::Resource::IN::TXT)
+          .and_return(txt_resources(['v=DMARC1; p=none;', 'v=DMARC1; p=reject']))
+
+        result = strategy.verify_record_with_cache(
+          dmarc_record,
+          resolver: resolver,
+          cached_value: nil,
+          bypass_cache: false,
+        )
+
+        expect(result[:verified]).to be false
+        expect(result[:error_type]).to eq('ambiguous_record_set')
+        expect(result[:from_cache]).to be false
+      end
+
+      it 'fails with ambiguous_record_set when DNS returns two SPF records' do
+        spf_record = {
+          type: 'TXT',
+          host: 'example.com',
+          value: 'v=spf1 include:amazonses.com ~all',
+          purpose: 'SPF',
+        }
+        allow(resolver).to receive(:getresources)
+          .with('example.com', Resolv::DNS::Resource::IN::TXT)
+          .and_return(txt_resources(['v=spf1 include:amazonses.com ~all', 'v=spf1 -all']))
+
+        result = strategy.verify_record_with_cache(
+          spf_record,
+          resolver: resolver,
+          cached_value: nil,
+          bypass_cache: false,
+        )
+
+        expect(result[:verified]).to be false
+        expect(result[:error_type]).to eq('ambiguous_record_set')
+      end
+
+      it 'verifies one live DMARC record among unrelated junk TXT records' do
+        live = ['MS=ms123', 'v=DMARC1; p=none;', 'google-site-verification=abc']
+        allow(resolver).to receive(:getresources)
+          .with('_dmarc.example.com', Resolv::DNS::Resource::IN::TXT)
+          .and_return(txt_resources(live))
+
+        result = strategy.verify_record_with_cache(
+          dmarc_record,
+          resolver: resolver,
+          cached_value: nil,
+          bypass_cache: false,
+        )
+
+        expect(result[:verified]).to be true
+        expect(result).not_to have_key(:error_type)
+        expect(result[:actual]).to eq(live)
+      end
+
+      it 'reports the DNS lookup error_type when the lookup itself fails' do
+        allow(resolver).to receive(:getresources)
+          .and_raise(Resolv::ResolvError, 'NXDOMAIN')
+
+        result = strategy.verify_record_with_cache(
+          dmarc_record,
+          resolver: resolver,
+          cached_value: nil,
+          bypass_cache: false,
+        )
+
+        expect(result[:verified]).to be false
+        expect(result[:error_type]).to eq('not_found')
+        expect(result[:actual]).to eq([])
+      end
+
+      it 'ignores the cached value when bypass_cache is true' do
+        # Stale two-record cache must not produce a false ambiguity once DNS
+        # has been fixed to a single record.
+        allow(resolver).to receive(:getresources)
+          .with('_dmarc.example.com', Resolv::DNS::Resource::IN::TXT)
+          .and_return(txt_resources(['v=DMARC1; p=none;']))
+
+        result = strategy.verify_record_with_cache(
+          dmarc_record,
+          resolver: resolver,
+          cached_value: ['v=DMARC1;p=none', 'v=DMARC1;p=reject'],
+          bypass_cache: true,
+        )
+
+        expect(result[:verified]).to be true
+        expect(result).not_to have_key(:error_type)
+        expect(result[:from_cache]).to be false
+      end
     end
   end
 

--- a/try/unit/domain_validation/record_normalizer_try.rb
+++ b/try/unit/domain_validation/record_normalizer_try.rb
@@ -1,0 +1,219 @@
+# try/unit/domain_validation/record_normalizer_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for Onetime::DomainValidation::RecordNormalizer (issue #4023)
+#
+# Source of truth for tag-list normalization semantics (RFC 6376 Section 3.2,
+# RFC 7489 Section 6.4):
+# 1. Tag-list parsing: WSP tolerance, trailing ";", duplicate-tag invalidation
+# 2. Subset matching: expected tags must be present, extras ignored
+# 3. Per-tag case policy: DMARC keywords fold, DKIM p= base64 does not
+# 4. Record-kind discriminators (dmarc?, dkim?, spf?)
+# 5. BaseStrategy#record_matches? dispatch: tag-lists normalize, SPF keeps
+#    include: extraction, opaque tokens require exact match after trim
+# 6. Record-set selection: duplicate DMARC/SPF records are ambiguous, never
+#    a pass (RFC 7489 Section 6.6.3, RFC 7208 permerror)
+
+require_relative '../../support/test_helpers'
+
+OT.boot! :test
+
+require 'onetime/domain_validation/record_normalizer'
+require 'onetime/domain_validation/sender_strategies/strategy'
+
+@normalizer = Onetime::DomainValidation::RecordNormalizer
+@base       = Onetime::DomainValidation::SenderStrategies::BaseStrategy.new
+
+# --- Parsing (RFC 6376 Section 3.2 tag-list grammar) ---
+
+## Parses a compact tag-list into name => value pairs
+@normalizer.parse('v=DMARC1;p=none')
+#=> {'v' => 'DMARC1', 'p' => 'none'}
+
+## Tolerates WSP around names, "=", and values; trailing ";" allowed
+@normalizer.parse(' v = DMARC1 ; p = none ; ')
+#=> {'v' => 'DMARC1', 'p' => 'none'}
+
+## Tag names fold to lowercase; values keep their case
+@normalizer.parse('V=DKIM1;P=MIGfMA0')
+#=> {'v' => 'DKIM1', 'p' => 'MIGfMA0'}
+
+## Internal whitespace in a value is significant and preserved
+@normalizer.parse('v=spf1 include:example.com ~all;note=a b')['note']
+#=> 'a b'
+
+## Empty tag-value is permitted by the grammar
+@normalizer.parse('v=DKIM1;g=')
+#=> {'v' => 'DKIM1', 'g' => ''}
+
+## Duplicate tag names invalidate the entire record
+@normalizer.parse('v=DMARC1;p=none;p=reject')
+#=> nil
+
+## Duplicate detection is case-insensitive on the tag name
+@normalizer.parse('v=DMARC1;p=none;P=reject')
+#=> nil
+
+## Empty tag-spec in the middle is invalid (only trailing ";" is optional)
+@normalizer.parse('v=DMARC1;;p=none')
+#=> nil
+
+## Non-tag-list input returns nil
+@normalizer.parse('some-verification-token')
+#=> nil
+
+## Empty string returns nil
+@normalizer.parse('')
+#=> nil
+
+# --- Subset matching: the #4023 regression ---
+
+## Issue #4023: published "v=DMARC1; p=none;" satisfies expected
+## "v=DMARC1;p=none" (real Lettermint case, eu-direct.metalbaum.dev)
+@normalizer.subset_match?('v=DMARC1;p=none', 'v=DMARC1; p=none;')
+#=> true
+
+## Spacing tolerance works in the other direction too
+@normalizer.subset_match?('v=DMARC1; p=none;', 'v=DMARC1;p=none')
+#=> true
+
+## Customer-added tags (rua=) do not fail verification
+@normalizer.subset_match?('v=DMARC1;p=none', 'v=DMARC1; p=none; rua=mailto:dmarc@example.com')
+#=> true
+
+## Published p=reject satisfies expected p=none (hardening is not a mismatch)
+@normalizer.subset_match?('v=DMARC1;p=none', 'v=DMARC1; p=reject')
+#=> true
+
+## Published sp= value also satisfies by presence
+@normalizer.subset_match?('v=DMARC1;p=none;sp=none', 'v=DMARC1;p=quarantine;sp=reject')
+#=> true
+
+## Missing expected tag fails
+@normalizer.subset_match?('v=DMARC1;p=none', 'v=DMARC1')
+#=> false
+
+## Version tag compares case-insensitively
+@normalizer.subset_match?('v=DMARC1;p=none', 'v=dmarc1; p=none')
+#=> true
+
+## Wrong version fails
+@normalizer.subset_match?('v=DMARC1;p=none', 'v=DMARC2;p=none')
+#=> false
+
+## DMARC alignment values compare case-insensitively (adkim=r vs ADKIM=R)
+@normalizer.subset_match?('v=DMARC1;p=none;adkim=r', 'v=DMARC1;p=none;ADKIM=R')
+#=> true
+
+## Published record with duplicate tags is invalid and never matches
+@normalizer.subset_match?('v=DMARC1;p=none', 'v=DMARC1;p=none;p=reject')
+#=> false
+
+## Malformed expected record never matches
+@normalizer.subset_match?('v=DMARC1;p=none;p=none', 'v=DMARC1;p=none')
+#=> false
+
+# --- DKIM case policy ---
+
+## DKIM k= (key type) compares case-insensitively
+@normalizer.subset_match?('v=DKIM1;k=rsa;p=MIGfMA0', 'v=DKIM1; k=RSA; p=MIGfMA0')
+#=> true
+
+## DKIM p= base64 is case-SENSITIVE: MIGfMA0 does not match migfma0
+@normalizer.subset_match?('v=DKIM1;k=rsa;p=MIGfMA0', 'v=DKIM1;k=rsa;p=migfma0')
+#=> false
+
+## DKIM p= ignores internal whitespace (DNS UIs wrap long keys)
+@normalizer.subset_match?('v=DKIM1;k=rsa;p=MIGfMA0GCSqGSIb3', 'v=DKIM1; k=rsa; p=MIGfMA0 GCSqG SIb3')
+#=> true
+
+# --- Discriminators ---
+
+## dmarc? accepts WSP and trailing content
+@normalizer.dmarc?(' v = DMARC1 ; p=none;')
+#=> true
+
+## dmarc? rejects non-DMARC records
+[@normalizer.dmarc?('v=spf1 -all'), @normalizer.dmarc?('token'), @normalizer.dmarc?('v=DMARC10;p=none')]
+#=> [false, false, false]
+
+## spf? requires exactly v=spf1 followed by space or end (RFC 7208 4.5)
+[@normalizer.spf?('v=spf1 include:x.com ~all'), @normalizer.spf?('v=spf1'), @normalizer.spf?('v=spf10 -all')]
+#=> [true, true, false]
+
+## dkim? identifies DKIM key records
+[@normalizer.dkim?('v=DKIM1; k=rsa; p=ABC'), @normalizer.dkim?('v=DMARC1;p=none')]
+#=> [true, false]
+
+# --- BaseStrategy dispatch (record_matches?) ---
+
+## The #4023 regression verifies end-to-end through record_matches?
+@base.send(:record_matches?, 'TXT', 'v=DMARC1;p=none', ['v=DMARC1; p=none;'])
+#=> true
+
+## DKIM records normalize through record_matches? too
+@base.send(:record_matches?, 'TXT', 'v=DKIM1;k=rsa;p=TESTKEY', ['v=DKIM1; k=rsa; p=TESTKEY'])
+#=> true
+
+## SPF matching still uses include: extraction (unchanged behavior)
+@base.send(:record_matches?, 'TXT',
+  'v=spf1 include:amazonses.com ~all',
+  ['v=spf1 include:amazonses.com include:sendgrid.net ~all'])
+#=> true
+
+## Opaque tokens require exact match: substring is no longer enough
+@base.send(:record_matches?, 'TXT', 'token-abc', ['prefix-token-abc-suffix'])
+#=> false
+
+## Opaque tokens match exactly after trimming edge whitespace
+@base.send(:record_matches?, 'TXT', 'token-abc', ['  token-abc  '])
+#=> true
+
+## Opaque tokens are case-sensitive (exact means exact)
+@base.send(:record_matches?, 'TXT', 'Token-ABC', ['token-abc'])
+#=> false
+
+# --- Record-set selection (evaluate_record_set) ---
+
+## One DMARC record plus unrelated TXT junk still verifies (6.6.3 discard)
+@base.send(:evaluate_record_set,
+  { type: 'TXT', value: 'v=DMARC1;p=none' },
+  ['v=DMARC1; p=none;', 'google-site-verification=abc123'])
+#=> [true, nil]
+
+## Two DMARC records are ambiguous: verified false, error_type set
+@base.send(:evaluate_record_set,
+  { type: 'TXT', value: 'v=DMARC1;p=none' },
+  ['v=DMARC1; p=none;', 'v=DMARC1; p=reject'])
+#=> [false, 'ambiguous_record_set']
+
+## Duplicate identical DMARC records are still ambiguous, never a pass
+@base.send(:evaluate_record_set,
+  { type: 'TXT', value: 'v=DMARC1;p=none' },
+  ['v=DMARC1;p=none', 'v=DMARC1;p=none'])
+#=> [false, 'ambiguous_record_set']
+
+## Two SPF records are ambiguous (RFC 7208 permerror)
+@base.send(:evaluate_record_set,
+  { type: 'TXT', value: 'v=spf1 include:amazonses.com ~all' },
+  ['v=spf1 include:amazonses.com ~all', 'v=spf1 -all'])
+#=> [false, 'ambiguous_record_set']
+
+## Zero surviving records keeps not-found semantics (no error_type)
+@base.send(:evaluate_record_set,
+  { type: 'TXT', value: 'v=DMARC1;p=none' },
+  ['google-site-verification=abc123'])
+#=> [false, nil]
+
+## Opaque-token expectations have no discriminator: duplicates allowed
+@base.send(:evaluate_record_set,
+  { type: 'TXT', value: 'token-abc' },
+  ['token-abc', 'other-token'])
+#=> [true, nil]
+
+## CNAME sets pass through unfiltered
+@base.send(:evaluate_record_set,
+  { type: 'CNAME', value: 'target.example.com' },
+  ['target.example.com.', 'other.example.com.'])
+#=> [true, nil]

--- a/try/unit/domain_validation/record_normalizer_try.rb
+++ b/try/unit/domain_validation/record_normalizer_try.rb
@@ -86,9 +86,38 @@ require 'onetime/domain_validation/sender_strategies/strategy'
 @normalizer.subset_match?('v=DMARC1;p=none', 'v=DMARC1; p=reject')
 #=> true
 
-## Published sp= value also satisfies by presence
+## Published sp= follows the same strength ordering (both hardened here)
 @normalizer.subset_match?('v=DMARC1;p=none;sp=none', 'v=DMARC1;p=quarantine;sp=reject')
 #=> true
+
+## Policy keywords compare case-insensitively (ABNF keywords, RFC 5234 2.3)
+@normalizer.subset_match?('v=DMARC1;p=none', 'v=DMARC1; p=NONE')
+#=> true
+
+## Weaker published policy fails: p=none does not satisfy expected p=quarantine
+@normalizer.subset_match?('v=DMARC1;p=quarantine', 'v=DMARC1; p=none')
+#=> false
+
+## Unrecognized published policy value fails (p=bogus is not an RFC 7489 keyword)
+@normalizer.subset_match?('v=DMARC1;p=none', 'v=DMARC1; p=bogus')
+#=> false
+
+## Empty published policy value fails
+@normalizer.subset_match?('v=DMARC1;p=none', 'v=DMARC1; p=')
+#=> false
+
+## WSP around a policy value trims away (TAG_SPEC); strength still applies
+@normalizer.subset_match?('v=DMARC1;p=quarantine', 'v=DMARC1; p= REJECT ')
+#=> true
+
+## Weaker published sp= fails even when p= is satisfied
+@normalizer.subset_match?('v=DMARC1;p=none;sp=reject', 'v=DMARC1;p=none;sp=none')
+#=> false
+
+## Unrecognized EXPECTED policy falls back to case-insensitive equality
+[@normalizer.subset_match?('v=DMARC1;p=custom', 'v=DMARC1;p=CUSTOM'),
+ @normalizer.subset_match?('v=DMARC1;p=custom', 'v=DMARC1;p=reject')]
+#=> [true, false]
 
 ## Missing expected tag fails
 @normalizer.subset_match?('v=DMARC1;p=none', 'v=DMARC1')


### PR DESCRIPTION
Closes #4023

## What

Replaces raw-substring TXT matching in sender-domain DNS verification with RFC-grounded tag-list normalization, fixing all three defects from the issue:

1. **False negative** — `v=DMARC1; p=none;` (as published by DNS providers) now verifies against expected `v=DMARC1;p=none` (the live Lettermint case, pinned as a labeled regression test).
2. **False positive** — a TXT set with duplicate DMARC/SPF records no longer passes via `.any?`; record-set selection runs before matching in both branches of `verify_record_with_cache` and reports the new log-only `error_type: 'ambiguous_record_set'` (RFC 7489 §6.6.3, RFC 7208 permerror). One valid record among unrelated TXT records still verifies.
3. **Latent DKIM case-folding** — the global downcase is gone from the TXT path; DKIM `p=` base64 compares case-sensitively with internal whitespace stripped (DNS UI line-wrapping), per RFC 6376 §3.2.

## How

- New `Onetime::DomainValidation::RecordNormalizer`: RFC 6376 §3.2 tag-list grammar (WSP-tolerant around name/`=`/value, optional trailing `;`, duplicate tag names invalidate the record) with subset matching — customer-added tags (`rua=`) pass, and published `p=reject` satisfies expected `p=none`.
- `record_matches?` dispatches by discriminator: `v=DMARC1`/`v=DKIM1` → tag-subset compare; `v=spf1` → existing `spf_record_matches?` byte-identical; opaque provider tokens → exact match after trim (deliberately tightened from case-insensitive substring per the acceptance criteria).
- Deleted the uncalled `verify_record` single-record path (zero callers repo-wide) — one code path going forward.
- CNAME/MX matching, `classify_dns_error` values, multi-string TXT concatenation, cache format, and private lookup signatures all unchanged.

## Testing

- New tryouts corpus `try/unit/domain_validation/record_normalizer_try.rb` (41 cases) — source of truth for normalizer behavior, covering every acceptance criterion.
- `base_strategy_spec.rb` extended (~30 examples): ambiguity via both cache-hit and live branches, junk-record discard, dispatch coverage; the two pins asserting substring/case-insensitive token matching are flipped to exact-match as the issue requires.
- **211 rspec examples, 0 failures at three seeds** (order-independent); **232 tryout cases, 0 failures**; RuboCop clean. Adversarial review pass: no findings.

## Rollout note

Verification-only; no schema/key migration. Domains stuck in `failed` for formatting reasons self-heal on their next scheduled check (10-min DNS cache TTL). The tightening can flip genuinely misconfigured domains (duplicate DMARC/SPF sets, substring-matched tokens) from `verified` to `failed` — the correct outcome, and the distinct `ambiguous_record_set` error_type in logs sizes the affected set. `error_type` remains log-only end-to-end (no serializer/UI consumer reads it), so this is not a UI contract change; surfacing it to customers is a candidate follow-up.