### PR TITLE
fix(billing): stop formatCurrency crashing on a null currency

### DIFF
--- a/src/tests/types/billing-helpers.spec.ts
+++ b/src/tests/types/billing-helpers.spec.ts
@@ -49,6 +49,18 @@ describe('formatCurrency', () => {
     expect(result).toContain('50');
   });
 
+  it('falls back to USD when currency is null instead of throwing', () => {
+    // A plan can reach the UI with a null currency (no Stripe price currency
+    // and no plan currency), which used to crash Intl.NumberFormat.
+    expect(() => formatCurrency(5000, null)).not.toThrow();
+    expect(formatCurrency(5000, null)).toContain('50');
+  });
+
+  it('falls back to USD when currency is an empty string', () => {
+    expect(() => formatCurrency(5000, '')).not.toThrow();
+    expect(formatCurrency(5000, '')).toContain('50');
+  });
+
   it('formats EUR currency', () => {
     const result = formatCurrency(1999, 'EUR');
     expect(result).toContain('19.99');

--- a/src/types/billing.ts
+++ b/src/types/billing.ts
@@ -120,9 +120,15 @@ export function getInvoiceStatusLabel(
   return t(`web.billing.invoices.${status}`);
 }
 
-export function formatCurrency(amount: number, currency: string = 'USD'): string {
+export function formatCurrency(amount: number, currency?: string | null): string {
+  // A default parameter value only fills in `undefined`, so a `null` currency
+  // slipped straight through to Intl.NumberFormat, which throws a RangeError on
+  // a null currency code. `null` does reach here: the plan record falls back to
+  // `plan.currency` when the Stripe price has none, and that can itself be null.
+  // Normalise null or empty to the USD default so display never crashes.
+  const resolvedCurrency = currency || 'USD';
   return new Intl.NumberFormat(undefined, {
     style: 'currency',
-    currency,
+    currency: resolvedCurrency,
   }).format(amount / 100); // Assuming amount is in cents
 }


### PR DESCRIPTION
### The bug

`formatCurrency` in `src/types/billing.ts` declared `currency: string = 'USD'`:

```ts
export function formatCurrency(amount: number, currency: string = 'USD'): string {
  return new Intl.NumberFormat(undefined, {
    style: 'currency',
    currency,
  }).format(amount / 100);
}
```

A default parameter value only applies when the argument is `undefined`. A `null` currency passes straight through, and `Intl.NumberFormat` throws a `RangeError` on a null currency code, which takes the price display down.

`null` really can reach here. `plan_page_record` in `apps/web/billing/controllers/billing.rb` computes:

```ruby
currency = (price_data ? price_data['currency'] : nil) || plan.currency
```

so when the Stripe price carries no currency it falls back to `plan.currency`, which can itself be nil. After serialization the frontend calls `formatCurrency(amount, null)` and crashes.

This is defect 3 in #4048.

### The fix

Normalise a null or empty currency to the `USD` default before handing it to `Intl.NumberFormat`:

```ts
const resolvedCurrency = currency || 'USD';
```

I also widened the parameter type to `string | null` so it matches what actually arrives at runtime. Calling with no argument still defaults to USD, so existing callers are unaffected.

### Tests

Added two cases to `src/tests/types/billing-helpers.spec.ts`: a null currency and an empty-string currency both fall back to USD instead of throwing. Verified against the same Intl engine that `currency: null` raises `RangeError` today and that `currency || 'USD'` formats cleanly.

The other two defects in #4048 (locale-blind formatting and mixed free/paid symbols across a pricing grid) are separate concerns and left for their own changes.
