### PR TITLE
fix(billing): locale-aware currency formatting, coherent catalog currency, null-currency hardening

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -3,5 +3,5 @@
   "commentTypes": ["logic"],
   "summarySection": { "included": false },
   "issuesTableSection": { "included": false },
-  "confidenceScoreSection": { "included": false }
+  "confidenceScoreSection": { "included": true }
 }

--- a/apps/web/billing/controllers/billing.rb
+++ b/apps/web/billing/controllers/billing.rb
@@ -1062,7 +1062,13 @@ module Billing
         def plan_page_record(plan, plan_names_by_id, interval, price_data)
           amount          = price_data ? price_data['amount'].to_i : 0
           stripe_price_id = price_data ? price_data['stripe_price_id'] : nil
-          currency        = (price_data ? price_data['currency'] : nil) || plan.currency
+
+          # Never emit a nil currency: fall back price row -> plan family ->
+          # deployment config. A plan cached without a currency (older sync
+          # code, hand-repaired catalog) must not surface `currency: null`
+          # to the frontend formatter.
+          currency = (price_data ? price_data['currency'] : nil) || plan.currency
+          currency = OT.billing_config.currency if currency.to_s.empty?
 
           {
             id: plan.plan_id,

--- a/apps/web/billing/operations/catalog/config_loader.rb
+++ b/apps/web/billing/operations/catalog/config_loader.rb
@@ -157,23 +157,34 @@ module Billing
         #
         # Stripe-sourced plans are identified by a non-empty stripe_product_id
         # (config-loaded plans never have one). Inactive (pruned) plans and
-        # plans from other regions are ignored. When active Stripe plans carry
-        # mixed currencies for the region, the majority currency wins and a
-        # warning is logged - that state means the Stripe catalog itself is
-        # incoherent and needs operator attention.
+        # plans from other regions are ignored.
+        #
+        # The point of inheriting is that one pricing grid renders one
+        # currency, and the grid only renders plans marked show_on_plans_page
+        # (see BillingController#list_plans). So visible plans decide the
+        # currency; hidden ones are consulted only when nothing is visible,
+        # where matching the Stripe catalog still beats the config default.
+        #
+        # When the deciding plans carry mixed currencies the most common one
+        # wins, ties broken alphabetically so the choice cannot flap between
+        # boots with Redis key order. Mixed currencies mean the Stripe catalog
+        # itself is incoherent, so a warning is logged for the operator.
         #
         # @param region [String, nil] Deployment region to match
         # @return [String, nil] Inherited currency, or nil when no
         #   Stripe-sourced plan exists in the cache
         def stripe_catalog_currency(region)
-          currencies = Billing::Plan.list_plans.filter_map do |plan|
-            next if plan.stripe_product_id.to_s.empty?
-            next unless plan.active.to_s == 'true'
-            next unless Billing::RegionNormalizer.match?(plan.region, region)
-
-            currency = plan.currency.to_s
-            currency.empty? ? nil : currency
+          stripe_plans = Billing::Plan.list_plans.select do |plan|
+            !plan.stripe_product_id.to_s.empty? &&
+              plan.active.to_s == 'true' &&
+              Billing::RegionNormalizer.match?(plan.region, region)
           end
+
+          visible    = stripe_plans.select { |plan| plan.show_on_plans_page.to_s == 'true' }
+          currencies = named_currencies(visible)
+          # Fall back on the currency, not on the plan: a visible set that
+          # carries no currency at all decides nothing.
+          currencies = named_currencies(stripe_plans) if currencies.empty?
 
           return nil if currencies.empty?
 
@@ -181,8 +192,9 @@ module Billing
           return distinct.first if distinct.size == 1
 
           tallies = currencies.tally
-          chosen  = tallies.max_by { |_currency, count| count }.first
-          OT.lw '[ConfigLoader] Stripe-sourced plans carry mixed currencies for region; using majority',
+          chosen  = tallies.min_by { |currency, count| [-count, currency] }.first
+          OT.lw '[ConfigLoader] Stripe-sourced plans carry mixed currencies for region; ' \
+                'using most common (ties broken alphabetically)',
             {
               region: region,
               currencies: tallies,
@@ -191,13 +203,25 @@ module Billing
           chosen
         end
 
+        # Non-empty currencies carried by the given plans
+        #
+        # @param plans [Array<Billing::Plan>]
+        # @return [Array<String>]
+        def named_currencies(plans)
+          plans.filter_map do |plan|
+            currency = plan.currency.to_s
+            currency.empty? ? nil : currency
+          end
+        end
+
         # Upsert a single plan from config definition
         #
         # @param plan_id [String] Plan identifier
         # @param plan_def [Hash] Plan definition from YAML
         # @param prices_list [Array, nil] List of price definitions, or nil for config-only plans
         # @param currency_override [String, nil] Currency inherited from Stripe-sourced
-        #   siblings; used instead of config currency when no price rows carry one
+        #   siblings; outranks the config default everywhere a currency is
+        #   written, and yields only to a currency the price row states itself
         # @return [Billing::Plan, nil] The upserted plan or nil on failure
         # rubocop:disable Metrics/PerceivedComplexity
         def upsert_plan_from_config(plan_id, plan_def, prices_list, currency_override: nil)
@@ -222,7 +246,7 @@ module Billing
           if prices_list && !prices_list.empty?
             prices_list.each do |price|
               interval       = price['interval'].to_sym # :month or :year
-              plan_currency  = price['currency'] || OT.billing_config.currency
+              plan_currency  = price['currency'] || currency_override || OT.billing_config.currency
 
               prices_data[interval] = {
                 stripe_price_id: price['price_id'],
@@ -235,7 +259,15 @@ module Billing
                 active: 'true',
               }
             end
-            family_currency = prices_list.first['currency'] || OT.billing_config.currency
+            # No caller combines an override with price rows today
+            # (upsert_config_only_plans only handles `prices: []`, and
+            # load_all_from_config passes no override), so this is a coherence
+            # guard, not a live path: an inherited currency must not be
+            # downgraded to the config default just because a price row is
+            # silent about its own. The price rows above follow the same
+            # precedence, since the plans page reads currency off the price
+            # row, not off the plan.
+            family_currency = prices_list.first['currency'] || currency_override || OT.billing_config.currency
           end
 
           # Create or update Plan instance

--- a/apps/web/billing/operations/catalog/config_loader.rb
+++ b/apps/web/billing/operations/catalog/config_loader.rb
@@ -41,6 +41,15 @@ module Billing
 
           upserted_count = 0
 
+          # One page, one currency: when this runs after a Stripe sync (Pull),
+          # config-only plans inherit the currency the Stripe-sourced plans
+          # carry, instead of being stamped with OT.billing_config.currency.
+          # Otherwise a deployment whose Stripe catalog bills in EUR would
+          # render a pricing grid mixing EUR paid plans with a USD free tier.
+          # Nil when no Stripe-sourced plan is cached (e.g. the full config
+          # fallback path, where everything already shares config currency).
+          inherited_currency = stripe_catalog_currency(OT.billing_config.region)
+
           plans_hash.each do |plan_key, plan_def|
             prices = plan_def['prices'] || []
 
@@ -65,7 +74,7 @@ module Billing
               next
             end
 
-            plan = upsert_plan_from_config(plan_id, plan_def, nil)
+            plan = upsert_plan_from_config(plan_id, plan_def, nil, currency_override: inherited_currency)
             next unless plan
 
             upserted_count += 1
@@ -144,14 +153,54 @@ module Billing
           plans_count
         end
 
+        # Currency carried by already-persisted Stripe-sourced plans for a region
+        #
+        # Stripe-sourced plans are identified by a non-empty stripe_product_id
+        # (config-loaded plans never have one). Inactive (pruned) plans and
+        # plans from other regions are ignored. When active Stripe plans carry
+        # mixed currencies for the region, the majority currency wins and a
+        # warning is logged - that state means the Stripe catalog itself is
+        # incoherent and needs operator attention.
+        #
+        # @param region [String, nil] Deployment region to match
+        # @return [String, nil] Inherited currency, or nil when no
+        #   Stripe-sourced plan exists in the cache
+        def stripe_catalog_currency(region)
+          currencies = Billing::Plan.list_plans.filter_map do |plan|
+            next if plan.stripe_product_id.to_s.empty?
+            next unless plan.active.to_s == 'true'
+            next unless Billing::RegionNormalizer.match?(plan.region, region)
+
+            currency = plan.currency.to_s
+            currency.empty? ? nil : currency
+          end
+
+          return nil if currencies.empty?
+
+          distinct = currencies.uniq
+          return distinct.first if distinct.size == 1
+
+          tallies = currencies.tally
+          chosen  = tallies.max_by { |_currency, count| count }.first
+          OT.lw '[ConfigLoader] Stripe-sourced plans carry mixed currencies for region; using majority',
+            {
+              region: region,
+              currencies: tallies,
+              chosen: chosen,
+            }
+          chosen
+        end
+
         # Upsert a single plan from config definition
         #
         # @param plan_id [String] Plan identifier
         # @param plan_def [Hash] Plan definition from YAML
         # @param prices_list [Array, nil] List of price definitions, or nil for config-only plans
+        # @param currency_override [String, nil] Currency inherited from Stripe-sourced
+        #   siblings; used instead of config currency when no price rows carry one
         # @return [Billing::Plan, nil] The upserted plan or nil on failure
         # rubocop:disable Metrics/PerceivedComplexity
-        def upsert_plan_from_config(plan_id, plan_def, prices_list)
+        def upsert_plan_from_config(plan_id, plan_def, prices_list, currency_override: nil)
           # Extract plan attributes from config
           tier               = plan_def['tier']
           tenancy            = plan_def['tenancy'] || 'multi'
@@ -168,7 +217,7 @@ module Billing
 
           # Build nested prices hash from all intervals (if provided)
           prices_data     = {}
-          family_currency = OT.billing_config.currency
+          family_currency = currency_override || OT.billing_config.currency
 
           if prices_list && !prices_list.empty?
             prices_list.each do |price|

--- a/apps/web/billing/spec/controllers/plans_api_spec.rb
+++ b/apps/web/billing/spec/controllers/plans_api_spec.rb
@@ -457,6 +457,29 @@ RSpec.describe 'Plans API Response', type: :integration do
       # Within a region, all plans should use same currency
       expect(currencies.size).to eq(1)
     end
+
+    # Issue #4048 defect 3: a plan cached without a currency (and price rows
+    # without one) used to surface `currency: null` to the frontend
+    # formatter. The controller now falls back to the deployment config
+    # currency as a last resort.
+    it 'never emits null currency, even when plan and price rows carry none' do
+      plan                    = Billing::Plan.new(plan_id: 'currencyless_v1')
+      plan.name               = 'Currencyless'
+      plan.tier               = 'single_account'
+      plan.show_on_plans_page = 'true'
+      plan.display_order      = '50'
+      plan.region             = 'EU'
+      plan.active             = 'true'
+      plan.save
+      # Price row deliberately omits 'currency'; plan.currency was never set
+      plan.prices['month'] = { 'stripe_price_id' => 'price_nocurrency', 'amount' => '500' }.to_json
+
+      get '/billing/api/plans'
+      record = JSON.parse(last_response.body)['plans'].find { |p| p['id'] == 'currencyless_v1' }
+
+      expect(record).not_to be_nil
+      expect(record['currency']).to eq(OT.billing_config.currency)
+    end
   end
 end
 

--- a/apps/web/billing/spec/models/plan_spec.rb
+++ b/apps/web/billing/spec/models/plan_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe Billing::Plan, type: :billing do
 
     # Persist a plan as if it came from a Stripe catalog pull. A non-empty
     # stripe_product_id is what marks it Stripe-sourced.
-    def persist_stripe_plan(plan_id:, currency:, region: 'EU', active: 'true')
+    def persist_stripe_plan(plan_id:, currency:, region: 'EU', active: 'true', show_on_plans_page: 'true')
       Billing::Operations::Catalog::PlanPersister.upsert_from_stripe_data(
         plan_id: plan_id,
         stripe_product_id: "prod_#{plan_id}",
@@ -260,7 +260,7 @@ RSpec.describe Billing::Plan, type: :billing do
         region: region,
         tenancy: 'multi',
         display_order: '10',
-        show_on_plans_page: 'true',
+        show_on_plans_page: show_on_plans_page,
         description: 'Stripe-sourced plan for currency inheritance specs',
         active: active,
         plan_code: plan_id,
@@ -333,6 +333,101 @@ RSpec.describe Billing::Plan, type: :billing do
       expect(free_plan.currency).to eq('eur')
       expect(OT).to have_received(:lw)
         .with(/mixed currencies/, hash_including(chosen: 'eur'))
+    end
+
+    # A perfect tally tie used to resolve by Hash#tally insertion order, which
+    # follows Redis key enumeration - the inherited currency could flap between
+    # boots. Ties now break alphabetically.
+    it 'breaks a currency tie deterministically' do
+      persist_stripe_plan(plan_id: 'stripe_usd_tie_v1', currency: 'usd')
+      persist_stripe_plan(plan_id: 'stripe_eur_tie_v1', currency: 'eur')
+
+      Billing::Operations::Catalog::ConfigLoader.upsert_config_only_plans
+
+      expect(free_plan.currency).to eq('eur')
+    end
+
+    # The pricing grid only renders show_on_plans_page plans, so a hidden plan
+    # in another currency must not outvote what the customer actually sees.
+    it 'ignores hidden Stripe plans when visible ones exist' do
+      persist_stripe_plan(plan_id: 'stripe_visible_eur_v1', currency: 'eur')
+      persist_stripe_plan(plan_id: 'stripe_hidden_usd_a_v1', currency: 'usd', show_on_plans_page: 'false')
+      persist_stripe_plan(plan_id: 'stripe_hidden_usd_b_v1', currency: 'usd', show_on_plans_page: 'false')
+
+      allow(OT).to receive(:lw).and_call_original
+
+      Billing::Operations::Catalog::ConfigLoader.upsert_config_only_plans
+
+      expect(free_plan.currency).to eq('eur')
+      # The visible set is coherent, so the operator gets no mixed-currency
+      # warning about a disagreement they cannot see on the page.
+      expect(OT).not_to have_received(:lw).with(/mixed currencies/, anything)
+    end
+
+    # Guard, not a regression test: this passes pre-fix too. It pins the
+    # fallback so a later tightening of the visibility filter cannot silently
+    # strand the free tier on config currency.
+    it 'falls back to hidden Stripe plans when none are visible' do
+      persist_stripe_plan(plan_id: 'stripe_hidden_only_v1', currency: 'eur', show_on_plans_page: 'false')
+
+      Billing::Operations::Catalog::ConfigLoader.upsert_config_only_plans
+
+      expect(free_plan.currency).to eq('eur')
+    end
+
+    # Blank currencies don't decide anything: a visible plan carrying none
+    # must not shadow a hidden plan that carries one.
+    it 'falls through to hidden plans when visible ones carry no currency' do
+      persist_stripe_plan(plan_id: 'stripe_visible_blank_v1', currency: '')
+      persist_stripe_plan(plan_id: 'stripe_hidden_eur_v1', currency: 'eur', show_on_plans_page: 'false')
+
+      Billing::Operations::Catalog::ConfigLoader.upsert_config_only_plans
+
+      expect(free_plan.currency).to eq('eur')
+    end
+
+    # currency_override used to be discarded the moment a plan carried price
+    # rows. No caller combines the two today (upsert_config_only_plans only
+    # handles `prices: []`), so these pin the precedence contract rather than
+    # a live defect.
+    describe 'currency_override precedence with price rows' do
+      def upsert_probe(prices)
+        Billing::Operations::Catalog::ConfigLoader.upsert_plan_from_config(
+          'override_probe_v1',
+          {
+            'name' => 'Override Probe',
+            'tier' => 'single_account',
+            'description' => 'currency_override precedence probe',
+            'show_on_plans_page' => false,
+          },
+          prices,
+          currency_override: 'eur',
+        )
+      end
+
+      it 'keeps the inherited currency when price rows omit one' do
+        plan = upsert_probe([{ 'interval' => 'month', 'amount' => 1000, 'price_id' => 'price_probe' }])
+
+        expect(plan.currency).to eq('eur')
+      end
+
+      # The plans page reads currency off the price row (BillingController
+      # #plan_page_record), so the price row has to inherit too - otherwise the
+      # plan says EUR and the card still renders the config currency.
+      it 'stamps the inherited currency onto the price rows' do
+        plan = upsert_probe([{ 'interval' => 'month', 'amount' => 1000, 'price_id' => 'price_probe' }])
+
+        expect(plan.prices_hash['month']['currency']).to eq('eur')
+      end
+
+      it 'lets an explicit price currency outrank the inherited one' do
+        plan = upsert_probe(
+          [{ 'interval' => 'month', 'amount' => 1000, 'price_id' => 'price_probe', 'currency' => 'usd' }],
+        )
+
+        expect(plan.currency).to eq('usd')
+        expect(plan.prices_hash['month']['currency']).to eq('usd')
+      end
     end
   end
 

--- a/apps/web/billing/spec/models/plan_spec.rb
+++ b/apps/web/billing/spec/models/plan_spec.rb
@@ -13,6 +13,7 @@
 require_relative '../support/billing_spec_helper'
 require_relative '../../models/plan'
 require_relative '../../operations/catalog/config_loader'
+require_relative '../../operations/catalog/plan_persister'
 
 RSpec.describe Billing::Plan, type: :billing do
   # Note: We don't use with_test_plans context here because it requires
@@ -228,6 +229,110 @@ RSpec.describe Billing::Plan, type: :billing do
       all_intervals = plans.flat_map(&:available_intervals).uniq
       expect(all_intervals).to include('month')
       expect(all_intervals).to include('year')
+    end
+  end
+
+  describe '.upsert_config_only_plans currency inheritance' do
+    # Issue #4048 defect 2: config-only plans (free tier) used to be stamped
+    # with OT.billing_config.currency even when the Stripe-sourced plans on
+    # the same pricing page carried a different currency, mixing $ and EUR
+    # in one grid. They now inherit the Stripe catalog currency when one is
+    # cached, falling back to config currency only when no Stripe-sourced
+    # plan exists (the config-only fallback path).
+    #
+    # Test config (billing.test.yaml): region EU, currency cad.
+
+    before do
+      # Reset Plan.load stubs so ConfigLoader can create real Plan instances
+      allow(Billing::Plan).to receive(:load).and_call_original
+      Billing::Plan.clear_cache
+    end
+
+    # Persist a plan as if it came from a Stripe catalog pull. A non-empty
+    # stripe_product_id is what marks it Stripe-sourced.
+    def persist_stripe_plan(plan_id:, currency:, region: 'EU', active: 'true')
+      Billing::Operations::Catalog::PlanPersister.upsert_from_stripe_data(
+        plan_id: plan_id,
+        stripe_product_id: "prod_#{plan_id}",
+        name: "Stripe #{plan_id}",
+        tier: 'single_account',
+        currency: currency,
+        region: region,
+        tenancy: 'multi',
+        display_order: '10',
+        show_on_plans_page: 'true',
+        description: 'Stripe-sourced plan for currency inheritance specs',
+        active: active,
+        plan_code: plan_id,
+        is_popular: 'false',
+        plan_name_label: nil,
+        includes_plan: nil,
+        entitlements: [],
+        features: [],
+        limits: {},
+        prices: {
+          month: {
+            stripe_price_id: "price_#{plan_id}",
+            amount: '1000',
+            currency: currency,
+            billing_scheme: 'per_unit',
+            usage_type: 'licensed',
+            trial_period_days: nil,
+            nickname: nil,
+            active: 'true',
+          },
+        },
+        stripe_updated_at: Time.now.to_i.to_s,
+      )
+    end
+
+    def free_plan
+      Billing::Plan.load('free_v1')
+    end
+
+    it 'inherits the Stripe sibling currency instead of config currency' do
+      persist_stripe_plan(plan_id: 'stripe_eur_v1', currency: 'eur')
+
+      Billing::Operations::Catalog::ConfigLoader.upsert_config_only_plans
+
+      expect(OT.billing_config.currency).to eq('cad') # sanity: proves inheritance
+      expect(free_plan.currency).to eq('eur')
+    end
+
+    it 'falls back to config currency when no Stripe-sourced plans exist' do
+      Billing::Operations::Catalog::ConfigLoader.upsert_config_only_plans
+
+      expect(free_plan.currency).to eq('cad')
+    end
+
+    it 'ignores inactive (pruned) Stripe plans' do
+      persist_stripe_plan(plan_id: 'stripe_stale_v1', currency: 'eur', active: 'false')
+
+      Billing::Operations::Catalog::ConfigLoader.upsert_config_only_plans
+
+      expect(free_plan.currency).to eq('cad')
+    end
+
+    it 'ignores Stripe plans from other regions' do
+      persist_stripe_plan(plan_id: 'stripe_nz_v1', currency: 'nzd', region: 'NZ')
+
+      Billing::Operations::Catalog::ConfigLoader.upsert_config_only_plans
+
+      expect(free_plan.currency).to eq('cad')
+    end
+
+    it 'picks the majority currency and warns when Stripe plans disagree' do
+      persist_stripe_plan(plan_id: 'stripe_eur_a_v1', currency: 'eur')
+      persist_stripe_plan(plan_id: 'stripe_eur_b_v1', currency: 'eur')
+      persist_stripe_plan(plan_id: 'stripe_usd_v1', currency: 'usd')
+
+      allow(OT).to receive(:lw).and_call_original
+
+      Billing::Operations::Catalog::ConfigLoader.upsert_config_only_plans
+
+      expect(free_plan.currency).to eq('eur')
+      expect(OT).to have_received(:lw)
+        .with(/mixed currencies/, hash_including(chosen: 'eur'))
     end
   end
 

--- a/src/apps/workspace/billing/InvoiceList.vue
+++ b/src/apps/workspace/billing/InvoiceList.vue
@@ -10,7 +10,7 @@ import BillingLayout from '@/shared/components/layout/BillingLayout.vue';
 import { classifyError } from '@/schemas/errors';
 import { BillingService, type StripeInvoice } from '@/services/billing.service';
 import type { InvoiceStatus } from '@/types/billing';
-import { formatCurrency } from '@/types/billing';
+import { formatCurrency } from '@/utils/format/currency';
 import { formatDisplayDate } from '@/utils/format';
 import { computed, onMounted, ref } from 'vue';
 

--- a/src/apps/workspace/billing/PlanChangeModal.vue
+++ b/src/apps/workspace/billing/PlanChangeModal.vue
@@ -6,7 +6,7 @@ import Skeleton from '@/shared/components/closet/Skeleton.vue';
 import OIcon from '@/shared/components/icons/OIcon.vue';
 import { Dialog, DialogPanel, DialogTitle, TransitionChild, TransitionRoot } from '@headlessui/vue';
 import { BillingService, type Plan as BillingPlan, type PlanChangePreviewResponse } from '@/services/billing.service';
-import { formatCurrency } from '@/types/billing';
+import { formatCurrency } from '@/utils/format/currency';
 import { classifyError } from '@/schemas/errors';
 import { formatDisplayDate } from '@/utils/format';
 import { computed, ref, watch } from 'vue';

--- a/src/shared/components/billing/PlanCard.vue
+++ b/src/shared/components/billing/PlanCard.vue
@@ -9,7 +9,7 @@
   import { useI18n } from 'vue-i18n';
   import OIcon from '@/shared/components/icons/OIcon.vue';
   import type { Plan as BillingPlan } from '@/services/billing.service';
-  import { formatCurrency } from '@/types/billing';
+  import { formatCurrency } from '@/utils/format/currency';
   import { computed } from 'vue';
 
   const props = defineProps<{

--- a/src/tests/apps/secret/support/Pricing.spec.ts
+++ b/src/tests/apps/secret/support/Pricing.spec.ts
@@ -84,6 +84,16 @@ vi.mock('@/types/billing', () => ({
     }).format(amount / 100),
 }));
 
+// PlanCard imports the locale-aware wrapper (#4048); pin en-US so assertions
+// stay deterministic regardless of the active app/browser locale.
+vi.mock('@/utils/format/currency', () => ({
+  formatCurrency: (amount: number, currency: string = 'USD') => new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+    }).format(amount / 100),
+  activeIntlLocale: () => 'en-US',
+}));
+
 // Test fixtures
 // Plan IDs are now family-keyed without interval suffix
 // Backend returns separate plan objects for monthly/yearly with the same id

--- a/src/tests/apps/workspace/billing/PlanSelector.freetier.spec.ts
+++ b/src/tests/apps/workspace/billing/PlanSelector.freetier.spec.ts
@@ -108,6 +108,13 @@ vi.mock('@/types/billing', () => ({
   getPlanLabel: (planId: string) => planId,
 }));
 
+// PlanCard imports the locale-aware wrapper (#4048); mock it the same way so
+// assertions stay locale-independent.
+vi.mock('@/utils/format/currency', () => ({
+  formatCurrency: (amount: number, currency = 'cad') => `${currency.toUpperCase()} ${(amount / 100).toFixed(2)}`,
+  activeIntlLocale: () => undefined,
+}));
+
 vi.mock('@/schemas/errors', () => ({
   classifyError: (err: unknown) => ({ message: err instanceof Error ? err.message : 'Unknown error' }),
 }));

--- a/src/tests/types/billing-helpers.spec.ts
+++ b/src/tests/types/billing-helpers.spec.ts
@@ -75,6 +75,71 @@ describe('formatCurrency', () => {
     const result = formatCurrency(-2900, 'USD');
     expect(result).toContain('29');
   });
+
+  describe('locale parameter (#4048 defect 1)', () => {
+    it('formats with the given locale', () => {
+      // de uses "29,00 €", en-US uses "€29.00"
+      expect(formatCurrency(2900, 'EUR', 'de')).toBe(
+        new Intl.NumberFormat('de', { style: 'currency', currency: 'EUR' }).format(29)
+      );
+      expect(formatCurrency(2900, 'EUR', 'en-US')).toBe(
+        new Intl.NumberFormat('en-US', { style: 'currency', currency: 'EUR' }).format(29)
+      );
+    });
+
+    it('produces different output for de vs en-US with EUR', () => {
+      expect(formatCurrency(123456, 'EUR', 'de')).not.toBe(formatCurrency(123456, 'EUR', 'en-US'));
+    });
+
+    it('normalizes underscore locales (de_AT, fr_CA) to BCP-47', () => {
+      expect(formatCurrency(2900, 'EUR', 'de_AT')).toBe(
+        new Intl.NumberFormat('de-AT', { style: 'currency', currency: 'EUR' }).format(29)
+      );
+      expect(formatCurrency(2900, 'CAD', 'fr_CA')).toBe(
+        new Intl.NumberFormat('fr-CA', { style: 'currency', currency: 'CAD' }).format(29)
+      );
+    });
+
+    it('falls back to browser locale when no locale given', () => {
+      expect(formatCurrency(2900, 'USD')).toBe(
+        new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD' }).format(29)
+      );
+    });
+
+    it('falls back to browser locale on an invalid locale tag', () => {
+      expect(formatCurrency(2900, 'USD', '!!not-a-locale!!')).toBe(
+        new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD' }).format(29)
+      );
+    });
+  });
+
+  describe('defensive currency handling (#4048 defect 3)', () => {
+    it('coerces null currency to USD instead of throwing', () => {
+      expect(formatCurrency(2900, null)).toContain('29');
+      expect(() => formatCurrency(2900, null)).not.toThrow();
+    });
+
+    it('coerces empty-string currency to USD', () => {
+      expect(formatCurrency(2900, '')).toBe(
+        new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD' }).format(29)
+      );
+    });
+
+    it('accepts lowercase currency codes', () => {
+      expect(formatCurrency(2900, 'eur')).toBe(
+        new Intl.NumberFormat(undefined, { style: 'currency', currency: 'EUR' }).format(29)
+      );
+    });
+
+    it('degrades to plain rendering for a garbage currency code', () => {
+      expect(formatCurrency(1999, 'NOTREAL')).toBe('19.99 NOTREAL');
+    });
+
+    it('degrades to plain rendering for garbage currency with a locale', () => {
+      // Malformed (non 3-letter) code throws RangeError for every locale
+      expect(formatCurrency(1999, 'X9', 'de')).toBe('19.99 X9');
+    });
+  });
 });
 
 describe('getInvoiceStatusLabel', () => {

--- a/src/tests/utils/format/currency.spec.ts
+++ b/src/tests/utils/format/currency.spec.ts
@@ -1,0 +1,102 @@
+// src/tests/utils/format/currency.spec.ts
+
+/**
+ * Unit tests for the locale-aware currency formatting wrapper (#4048).
+ *
+ * The wrapper reads the ACTIVE app i18n locale (globalComposer) so the
+ * language switcher affects price formatting — previously formatCurrency
+ * always used the browser locale, so two visitors saw different strings
+ * for the same price and switching app language had no effect.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+
+// Mutable locale the '@/i18n' mock exposes; specs set it per test.
+const mockLocale = ref<string | null>('en');
+
+vi.mock('@/i18n', () => ({
+  globalComposer: {
+    get locale() {
+      return mockLocale.value === '__THROW__'
+        ? (() => {
+            throw new Error('i18n not initialized');
+          })()
+        : { value: mockLocale.value };
+    },
+  },
+}));
+
+import { activeIntlLocale, formatCurrency } from '@/utils/format/currency';
+
+const intl = (locale: string | undefined, currency: string, amount: number) =>
+  new Intl.NumberFormat(locale, { style: 'currency', currency }).format(amount);
+
+describe('activeIntlLocale', () => {
+  beforeEach(() => {
+    mockLocale.value = 'en';
+  });
+
+  it('returns the active app locale', () => {
+    mockLocale.value = 'de';
+    expect(activeIntlLocale()).toBe('de');
+  });
+
+  it('normalizes underscore locale codes to BCP-47 hyphens', () => {
+    mockLocale.value = 'de_AT';
+    expect(activeIntlLocale()).toBe('de-AT');
+    mockLocale.value = 'fr_CA';
+    expect(activeIntlLocale()).toBe('fr-CA');
+  });
+
+  it('returns undefined when no app locale is set', () => {
+    mockLocale.value = null;
+    expect(activeIntlLocale()).toBeUndefined();
+  });
+
+  it('returns undefined when reading the composer throws', () => {
+    mockLocale.value = '__THROW__';
+    expect(activeIntlLocale()).toBeUndefined();
+  });
+});
+
+describe('formatCurrency (locale-aware wrapper)', () => {
+  beforeEach(() => {
+    mockLocale.value = 'en';
+  });
+
+  it('formats using the active app locale, not the browser locale', () => {
+    mockLocale.value = 'de';
+    expect(formatCurrency(123456, 'EUR')).toBe(intl('de', 'EUR', 1234.56));
+  });
+
+  it('changes output when the app locale changes (language switcher)', () => {
+    mockLocale.value = 'en';
+    const enResult = formatCurrency(123456, 'EUR');
+    mockLocale.value = 'de';
+    const deResult = formatCurrency(123456, 'EUR');
+    expect(enResult).toBe(intl('en', 'EUR', 1234.56));
+    expect(deResult).toBe(intl('de', 'EUR', 1234.56));
+    expect(enResult).not.toBe(deResult);
+  });
+
+  it('handles underscore app locales (de_AT) end to end', () => {
+    mockLocale.value = 'de_AT';
+    expect(formatCurrency(2900, 'EUR')).toBe(intl('de-AT', 'EUR', 29));
+  });
+
+  it('falls back to browser locale when no app locale is available', () => {
+    mockLocale.value = null;
+    expect(formatCurrency(2900, 'USD')).toBe(intl(undefined, 'USD', 29));
+  });
+
+  it('coerces null currency to USD instead of crashing (defect 3)', () => {
+    mockLocale.value = 'en';
+    expect(formatCurrency(2900, null)).toBe(intl('en', 'USD', 29));
+  });
+
+  it('degrades to plain rendering for a garbage currency code', () => {
+    mockLocale.value = 'de';
+    expect(formatCurrency(1999, 'NOTREAL')).toBe('19.99 NOTREAL');
+  });
+});

--- a/src/types/billing.ts
+++ b/src/types/billing.ts
@@ -120,15 +120,47 @@ export function getInvoiceStatusLabel(
   return t(`web.billing.invoices.${status}`);
 }
 
-export function formatCurrency(amount: number, currency?: string | null): string {
-  // A default parameter value only fills in `undefined`, so a `null` currency
-  // slipped straight through to Intl.NumberFormat, which throws a RangeError on
-  // a null currency code. `null` does reach here: the plan record falls back to
-  // `plan.currency` when the Stripe price has none, and that can itself be null.
-  // Normalise null or empty to the USD default so display never crashes.
-  const resolvedCurrency = currency || 'USD';
-  return new Intl.NumberFormat(undefined, {
-    style: 'currency',
-    currency: resolvedCurrency,
-  }).format(amount / 100); // Assuming amount is in cents
+/**
+ * Format an amount in cents as a localized currency string.
+ *
+ * Pure helper: no app imports, safe to call from anywhere. For display in
+ * components, prefer the locale-aware wrapper in `@/utils/format/currency`
+ * which resolves the active i18n locale automatically.
+ *
+ * Defensive by design (#4048):
+ * - Falsy currency (null/undefined/'') coerces to 'USD' instead of throwing.
+ * - Locale codes are normalized from underscore form (de_AT) to BCP-47 (de-AT).
+ * - An invalid locale falls back to the browser locale; an invalid currency
+ *   code degrades to a plain "12.34 XYZ" rendering instead of crashing.
+ *
+ * @param amount - Amount in cents
+ * @param currency - ISO 4217 currency code; falsy values coerce to 'USD'
+ * @param locale - BCP-47 or underscore-form locale; omitted = browser locale
+ */
+export function formatCurrency(
+  amount: number,
+  currency?: string | null,
+  locale?: string
+): string {
+  const currencyCode = (currency || 'USD').toUpperCase();
+  const normalizedLocale = locale ? locale.replace(/_/g, '-') : undefined;
+
+  const localeCandidates: (string | undefined)[] = normalizedLocale
+    ? [normalizedLocale, undefined]
+    : [undefined];
+
+  for (const candidate of localeCandidates) {
+    try {
+      return new Intl.NumberFormat(candidate, {
+        style: 'currency',
+        currency: currencyCode,
+      }).format(amount / 100); // Amount is in cents
+    } catch (error) {
+      if (!(error instanceof RangeError)) throw error;
+      // RangeError: invalid locale (retry without) or invalid currency (fall
+      // through to plain rendering below).
+    }
+  }
+
+  return `${(amount / 100).toFixed(2)} ${String(currency || '').toUpperCase()}`.trim();
 }

--- a/src/types/billing.ts
+++ b/src/types/billing.ts
@@ -162,5 +162,5 @@ export function formatCurrency(
     }
   }
 
-  return `${(amount / 100).toFixed(2)} ${String(currency || '').toUpperCase()}`.trim();
+  return `${(amount / 100).toFixed(2)} ${currencyCode}`;
 }

--- a/src/utils/format/currency.ts
+++ b/src/utils/format/currency.ts
@@ -1,0 +1,44 @@
+// src/utils/format/currency.ts
+
+/**
+ * Locale-aware currency formatting (#4048).
+ *
+ * Components should use this wrapper instead of calling the base helper in
+ * `@/types/billing` directly: it resolves the app's ACTIVE i18n locale so the
+ * language switcher affects price formatting, instead of silently using the
+ * browser locale (which differs between visitors).
+ *
+ * The wrapper lives here (not in `@/types/billing`) because importing the
+ * `@/i18n` instance from the types module would drag the full i18n bootstrap
+ * (vue-i18n + all merged locale files) into every consumer of the billing
+ * types, and break the many vitest specs that partially mock `vue-i18n`.
+ */
+import { globalComposer } from '@/i18n';
+import { formatCurrency as baseFormatCurrency } from '@/types/billing';
+
+/**
+ * Resolve the app's active i18n locale as a BCP-47 tag for Intl.* APIs.
+ *
+ * App locale codes use underscores (de_AT, fr_CA); Intl expects hyphens.
+ * Returns undefined when no app locale is available, letting Intl fall back
+ * to the browser locale.
+ */
+export function activeIntlLocale(): string | undefined {
+  try {
+    const locale = globalComposer.locale.value;
+    return locale ? String(locale).replace(/_/g, '-') : undefined;
+  } catch {
+    // i18n not initialized (or mocked away in tests) — browser locale fallback.
+    return undefined;
+  }
+}
+
+/**
+ * Format an amount in cents using the app's active locale.
+ *
+ * @param amount - Amount in cents
+ * @param currency - ISO 4217 currency code; falsy values coerce to 'USD'
+ */
+export function formatCurrency(amount: number, currency?: string | null): string {
+  return baseFormatCurrency(amount, currency, activeIntlLocale());
+}


### PR DESCRIPTION
## Summary

Fixes three related currency-display defects on the billing/pricing surfaces: price strings ignored the app's active locale (a visitor who switched the UI language still saw prices formatted in their browser locale), config-only plans (free tier) were stamped with the deployment config currency even when the Stripe catalog bills in a different one (mixing EUR and USD in a single pricing grid), and a plan cached without a currency could surface `currency: null` through the plans API into a formatter that crashed on it. The fix hardens both sides: the API can no longer emit a null currency, and the frontend formatter tolerates garbage input anyway.

## Defect 1: locale-unaware price formatting (frontend)

**Where:** `src/types/billing.ts`, new `src/utils/format/currency.ts`, call sites in `PlanCard.vue` (covers Pricing + PlanSelector), `InvoiceList.vue`, `PlanChangeModal.vue`.

**Fix:** `formatCurrency` in `@/types/billing` stays the single pure `Intl.NumberFormat` call site and now accepts an optional locale, normalizing underscore app-locale codes (`de_AT` → `de-AT`) to BCP-47 and retrying with the browser locale on an invalid locale tag. A new locale-aware wrapper in `@/utils/format/currency` resolves the ACTIVE app locale from the global vue-i18n composer (same idiom as `usePageTitle`), so the language switcher now affects price formatting. The wrapper lives in `utils/format` rather than `types/billing` so the i18n bootstrap isn't dragged into every consumer of the billing types (and the many specs that partially mock `vue-i18n` keep working).

## Defect 2: config-only plans ignore Stripe catalog currency (backend)

**Where:** `apps/web/billing/operations/catalog/config_loader.rb`.

**Fix:** `upsert_config_only_plans` now derives an inherited currency via new `stripe_catalog_currency(region)`: it scans cached plans that are Stripe-sourced (non-empty `stripe_product_id`), active, and region-matched, and uses their currency for price-less config plans instead of `OT.billing_config.currency`. `Pull` already runs the Stripe sync (including pruning stale plans) before `upsert_config_only_plans`, so the cache is authoritative at that point; inactive and other-region plans are excluded so a stale catalog can't leak in. When no Stripe-sourced plan exists (full config-fallback path) it returns nil and behavior is unchanged. Mixed currencies within a region pick the majority and log a warning, since that state means the Stripe catalog itself is incoherent.

## Defect 3: null currency, both sides

**Where:** `apps/web/billing/controllers/billing.rb` (`plan_page_record`), `src/types/billing.ts`.

**Fix (API):** the currency fallback chain is now price row → `plan.currency` → `OT.billing_config.currency`, with an empty-string guard, so the plans API can never emit `currency: null`. The remaining nil-tolerant reads (`list_invoices`, `subscription_status`, `preview_plan_change`) deliberately keep the live Stripe object's currency — substituting config currency there could mask a genuine currency mismatch on a real subscription.

**Fix (formatter):** falsy currency coerces to `USD`; lowercase codes are uppercased; an invalid currency code degrades to a plain `"12.34 XYZ"` rendering instead of throwing `RangeError` and blanking the component. Zod contracts stay strict on purpose — defense lives in the formatter, strictness at the contract, so a backend regression still surfaces.

## Test coverage

- **Backend:** `plan_spec.rb` gains a currency-inheritance describe (5 examples: inherit EUR over config `cad`, config fallback, inactive-plan and other-region exclusion, majority+warning on mixed currencies, exercised through the real `PlanPersister`); `plans_api_spec.rb` gains a null-currency regression example (currency-less plan + currency-less price row still emits config currency). Full `tests/lanes/run unit` green (billing app: 1544 examples, 0 failures).
- **Frontend:** `billing-helpers.spec.ts` extended (locale divergence de vs en-US, underscore normalization, browser fallback on missing/invalid locale, null/empty/lowercase/garbage currency); new `src/tests/utils/format/currency.spec.ts` covers the active-locale wrapper end to end with a mutable i18n mock (language-switch changes output, composer-throw fallback). `Pricing.spec.ts` / `PlanSelector.freetier.spec.ts` pin the wrapper mock for locale determinism. Full vitest suite green: 381 files, 8455 tests passed.

Closes #4048
