### PR TITLE
[#4047] fix(mail): normalize tag=value DNS records in email-config check pipeline

### DIFF
--- a/apps/api/domains/logic/sender_config/validate_sender_config.rb
+++ b/apps/api/domains/logic/sender_config/validate_sender_config.rb
@@ -70,6 +70,12 @@ module DomainsAPI
           if @mailer_config.from_address.to_s.empty?
             raise_form_error('Sender configuration must have from_address before validation', field: :from_address, error_type: :missing)
           end
+
+          # Require provisioned DNS records: without them there is nothing to
+          # check, and enqueueing would clear verification state for nothing.
+          unless @mailer_config.provisioned?
+            raise_form_error('Sender configuration must be provisioned before validation', field: :domain_id, error_type: :invalid)
+          end
         end
 
         def process

--- a/apps/api/domains/spec/logic/sender_config/validate_sender_config_spec.rb
+++ b/apps/api/domains/spec/logic/sender_config/validate_sender_config_spec.rb
@@ -1,0 +1,121 @@
+# apps/api/domains/spec/logic/sender_config/validate_sender_config_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for SenderConfig::ValidateSenderConfig#raise_concerns (issue #4047).
+#
+# Regression guard: validation must be rejected up front when the mailer
+# config has no provisioned DNS records. Without the guard, process would
+# clear verification state and enqueue both workers with nothing to check —
+# and DnsRecordCheckWorker's empty result set used to read as verified.
+#
+# RUN:
+#   pnpm run test:rspec apps/api/domains/spec/logic/sender_config/validate_sender_config_spec.rb
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require_relative '../../../../../../apps/api/domains/application'
+
+RSpec.describe DomainsAPI::Logic::SenderConfig::ValidateSenderConfig do
+  let(:owner) do
+    instance_double(
+      Onetime::Customer,
+      custid: 'owner123',
+      objid: 'owner123',
+      extid: 'ext-owner123',
+      anonymous?: false,
+      verified?: true,
+    )
+  end
+
+  let(:custom_domain) do
+    instance_double(
+      Onetime::CustomDomain,
+      identifier: 'domain123',
+      extid: 'ext-domain123',
+      display_domain: 'example.com',
+      org_id: 'org123',
+    )
+  end
+
+  let(:organization) do
+    instance_double(Onetime::Organization, objid: 'org123', extid: 'ext-org123', display_name: 'Test Org')
+  end
+
+  let(:session) { { 'authenticated' => true, 'csrf' => 'test-csrf-token' } }
+  let(:strategy_result) do
+    double('StrategyResult', session: session, user: owner, authenticated?: true, metadata: {})
+  end
+
+  # The route is /:extid/email-config/validate, so the logic reads params['extid'].
+  let(:params) { { 'extid' => 'ext-domain123' } }
+  let(:logic) { described_class.new(strategy_result, params) }
+
+  let(:from_address) { 'noreply@example.com' }
+  let(:mailer_config) do
+    instance_double(
+      Onetime::CustomDomain::MailerConfig,
+      from_address: from_address,
+      provisioned?: provisioned,
+    )
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+
+    # Bypass the (separately tested) authorization step; just set the ivars it
+    # would populate so raise_concerns can proceed to the mailer_config checks.
+    allow(logic).to receive(:authorize_sender_config!) do
+      logic.instance_variable_set(:@custom_domain, custom_domain)
+      logic.instance_variable_set(:@organization, organization)
+    end
+    allow(Onetime::CustomDomain::MailerConfig).to receive(:find_by_domain_id)
+      .with('domain123').and_return(mailer_config)
+  end
+
+  context 'when the mailer config is not provisioned' do
+    let(:provisioned) { false }
+
+    it 'rejects validation with a form error before any state is touched' do
+      expect { logic.raise_concerns }.to raise_error(OT::FormError) do |ex|
+        expect(ex.message).to match(/provisioned/i)
+        expect(ex.field).to eq(:domain_id)
+        expect(ex.error_type).to eq(:invalid)
+      end
+    end
+  end
+
+  context 'when the mailer config is provisioned' do
+    let(:provisioned) { true }
+
+    it 'passes raise_concerns' do
+      expect { logic.raise_concerns }.not_to raise_error
+    end
+  end
+
+  context 'when from_address is missing' do
+    let(:provisioned) { false }
+    let(:from_address) { '' }
+
+    it 'reports the missing from_address before the provisioned check' do
+      expect { logic.raise_concerns }.to raise_error(OT::FormError) do |ex|
+        expect(ex.field).to eq(:from_address)
+        expect(ex.error_type).to eq(:missing)
+      end
+    end
+  end
+
+  context 'when no mailer config exists for the domain' do
+    let(:mailer_config) { nil }
+
+    it 'reports the missing sender configuration' do
+      expect { logic.raise_concerns }.to raise_error(OT::FormError) do |ex|
+        expect(ex.message).to match(/no sender configuration/i)
+        expect(ex.field).to eq(:domain_id)
+        expect(ex.error_type).to eq(:missing)
+      end
+    end
+  end
+end

--- a/lib/onetime/domain_validation/record_matcher.rb
+++ b/lib/onetime/domain_validation/record_matcher.rb
@@ -1,0 +1,131 @@
+# lib/onetime/domain_validation/record_matcher.rb
+#
+# frozen_string_literal: true
+
+require_relative 'record_normalizer'
+
+module Onetime
+  module DomainValidation
+    # RecordMatcher - shared DNS record matching for both DNS pipelines.
+    #
+    # Two pipelines compare expected DNS records against live DNS results:
+    # the VERIFICATION pipeline (DomainValidation::SenderStrategies) and the
+    # FACT-FINDING pipeline (Mail::SenderStrategies). Duplicating the
+    # comparison logic between them produced twin bugs (#4023 / #4047), so
+    # both delegate here. Pure functions only: no logging, no state, no I/O.
+    #
+    # Dispatch discipline by record type:
+    # - TXT: content-aware. SPF records match on the include: mechanism,
+    #   DMARC/DKIM tag-lists match via RecordNormalizer subset comparison,
+    #   and opaque provider tokens require an exact match after trim.
+    #   Expected values are NOT globally downcased — DKIM p= base64 key
+    #   data is case-sensitive (RFC 6376 Section 3.2).
+    # - CNAME/MX: hostname comparison, case-insensitive with trailing dots
+    #   stripped (RFC 4343).
+    # - Anything else: never matches.
+    #
+    module RecordMatcher
+      extend self
+
+      # Check whether the expected value appears in the actual DNS results.
+      #
+      # @param type [String] Record type (TXT, CNAME, MX)
+      # @param expected [String] Expected value
+      # @param actual_values [Array<String>] DNS results
+      # @return [Boolean]
+      def record_matches?(type, expected, actual_values)
+        case type
+        when 'TXT'
+          txt_record_matches?(expected.to_s.strip, actual_values)
+        when 'CNAME', 'MX'
+          normalized_expected = expected.to_s.downcase.chomp('.')
+          actual_values.any? { |v| v.downcase.chomp('.') == normalized_expected }
+        else
+          false
+        end
+      end
+
+      # Check whether a TXT record matches expected value.
+      #
+      # Dispatch (issue #4023):
+      # - SPF (v=spf1): spf_record_matches? — customers commonly merge
+      #   multiple provider includes into one SPF record, so we extract the
+      #   include: directive and verify it appears in any actual SPF record.
+      # - DMARC/DKIM tag-lists (v=DMARC1 / v=DKIM1): RecordNormalizer
+      #   subset comparison per RFC 6376 Section 3.2 grammar. Raw string
+      #   comparison false-negatives on semantically identical records
+      #   ("v=DMARC1; p=none;" vs "v=DMARC1;p=none").
+      # - Anything else (opaque provider verification tokens): exact match
+      #   after trim. Deliberately tighter than the old substring check.
+      #
+      # @param expected [String] Expected value, trimmed
+      # @param actual_values [Array<String>] DNS results
+      # @return [Boolean]
+      def txt_record_matches?(expected, actual_values)
+        if RecordNormalizer.spf?(expected)
+          spf_record_matches?(expected.downcase, actual_values)
+        elsif RecordNormalizer.tag_list?(expected)
+          actual_values.any? { |v| RecordNormalizer.subset_match?(expected, v) }
+        else
+          actual_values.any? { |v| v.strip == expected }
+        end
+      end
+
+      # Check whether an SPF record matches expected value.
+      #
+      # Extracts the include: directive from the expected SPF record and
+      # verifies it appears in any actual SPF record, regardless of other
+      # mechanisms present. This allows customers to combine multiple
+      # provider includes in a single record.
+      #
+      # @param normalized_expected [String] Downcased expected SPF value
+      # @param actual_values [Array<String>] DNS results
+      # @return [Boolean]
+      def spf_record_matches?(normalized_expected, actual_values)
+        spf_include = normalized_expected[/include:\S+/]
+
+        if spf_include
+          actual_values.any? do |v|
+            downcased = v.downcase
+            downcased.start_with?('v=spf1') && downcased.include?(spf_include)
+          end
+        else
+          # SPF without include: directive - match the full record
+          actual_values.any? { |v| v.downcase.include?(normalized_expected) }
+        end
+      end
+
+      # Filter a TXT result set down to records relevant to the expected
+      # value. Only DMARC and SPF expectations have a discriminator; other
+      # types and TXT purposes pass through unfiltered.
+      #
+      # RFC 7489 Section 6.6.3 (DMARC) and RFC 7208 Section 4.5 (SPF) both
+      # require record-set selection before evaluation: filter the TXT set
+      # by discriminator, discard unrelated records, and treat more than
+      # one surviving record as ambiguous — never a pass. A duplicate DMARC
+      # or SPF record fails at receiving MTAs, so reporting it verified
+      # would be a false green (issue #4023).
+      #
+      # Zero survivors keeps existing not-found semantics (no match, no
+      # error). One survivor plus unrelated TXT records still verifies.
+      #
+      # @param type [String] Record type
+      # @param expected [String] Expected value
+      # @param actual_values [Array<String>] Full DNS result set
+      # @return [Array(Array<String>, Boolean)] [candidates, ambiguous]
+      def select_txt_record_set(type, expected, actual_values)
+        return [actual_values, false] unless type == 'TXT'
+
+        discriminator = if RecordNormalizer.dmarc?(expected)
+                          RecordNormalizer.method(:dmarc?)
+                        elsif RecordNormalizer.spf?(expected)
+                          RecordNormalizer.method(:spf?)
+                        end
+        return [actual_values, false] unless discriminator
+
+        survivors = actual_values.select { |v| discriminator.call(v) }
+        [survivors, survivors.size > 1]
+      end
+    end
+  end
+end

--- a/lib/onetime/domain_validation/record_matcher.rb
+++ b/lib/onetime/domain_validation/record_matcher.rb
@@ -73,26 +73,46 @@ module Onetime
 
       # Check whether an SPF record matches expected value.
       #
-      # Extracts the include: directive from the expected SPF record and
-      # verifies it appears in any actual SPF record, regardless of other
-      # mechanisms present. This allows customers to combine multiple
-      # provider includes in a single record.
+      # Comparison is term-wise, never substring. An SPF record is a
+      # whitespace-separated term list (RFC 7208 Section 4.6.1), so
+      # `include:amazonses.com` must appear as a whole term: a zone
+      # containing `include:amazonses.com.evil` is a different mechanism
+      # and must not verify.
+      #
+      # When the expected record carries an include: directive we require
+      # only that term, so customers can merge several provider includes
+      # into one record. Without an include: (a provider using only mx,
+      # a:, or redirect=) we require every expected term to be present —
+      # the same tolerance, applied to the whole term list. Substring
+      # containment would false-negative `v=spf1 mx -all` against a zone
+      # holding `v=spf1 mx include:other.com -all`.
       #
       # @param normalized_expected [String] Downcased expected SPF value
       # @param actual_values [Array<String>] DNS results
       # @return [Boolean]
       def spf_record_matches?(normalized_expected, actual_values)
-        spf_include = normalized_expected[/include:\S+/]
+        expected_terms = spf_terms(normalized_expected)
+        spf_include    = expected_terms.find { |term| term.start_with?('include:') }
+        required_terms = spf_include ? [spf_include] : expected_terms
 
-        if spf_include
-          actual_values.any? do |v|
-            downcased = v.downcase
-            downcased.start_with?('v=spf1') && downcased.include?(spf_include)
-          end
-        else
-          # SPF without include: directive - match the full record
-          actual_values.any? { |v| v.downcase.include?(normalized_expected) }
+        return false if required_terms.empty?
+
+        actual_values.any? do |v|
+          downcased = v.downcase
+          next false unless downcased.start_with?('v=spf1')
+
+          actual_terms = spf_terms(downcased)
+          required_terms.all? { |term| actual_terms.include?(term) }
         end
+      end
+
+      # Split an SPF record into its whitespace-separated terms
+      # (RFC 7208 Section 4.6.1). Callers pass downcased input.
+      #
+      # @param record [String] Downcased SPF record
+      # @return [Array<String>]
+      def spf_terms(record)
+        record.to_s.split(/\s+/).reject(&:empty?)
       end
 
       # Filter a TXT result set down to records relevant to the expected

--- a/lib/onetime/domain_validation/sender_strategies/base_strategy.rb
+++ b/lib/onetime/domain_validation/sender_strategies/base_strategy.rb
@@ -6,7 +6,7 @@ require 'resolv'
 require 'concurrent'
 require 'json'
 require_relative '../../utils/retry_helper'
-require_relative '../record_normalizer'
+require_relative '../record_matcher'
 
 module Onetime
   module DomainValidation
@@ -262,7 +262,10 @@ module Onetime
 
         # Check whether the expected value appears in the actual DNS results.
         #
-        # Delegates to type-specific matchers for clarity and testability.
+        # The matching discipline lives in RecordMatcher, shared with the
+        # Mail fact-finding pipeline (issue #4047). TXT dispatch goes
+        # through the instance method so per-strategy overrides (and
+        # instrumentation) keep working.
         #
         # @param type [String] Record type
         # @param expected [String] Expected value
@@ -270,70 +273,34 @@ module Onetime
         # @return [Boolean]
         #
         def record_matches?(type, expected, actual_values)
-          case type
-          when 'TXT'
-            txt_record_matches?(expected.to_s.strip, actual_values)
-          when 'CNAME', 'MX'
-            normalized_expected = expected.to_s.downcase.chomp('.')
-            actual_values.any? { |v| v.downcase.chomp('.') == normalized_expected }
-          else
-            false
-          end
+          return txt_record_matches?(expected.to_s.strip, actual_values) if type == 'TXT'
+
+          RecordMatcher.record_matches?(type, expected, actual_values)
         end
 
         # Check whether a TXT record matches expected value.
-        #
-        # Dispatch (issue #4023):
-        # - SPF (v=spf1): spf_record_matches? — customers commonly merge
-        #   multiple provider includes into one SPF record, so we extract the
-        #   include: directive and verify it appears in any actual SPF record.
-        # - DMARC/DKIM tag-lists (v=DMARC1 / v=DKIM1): RecordNormalizer
-        #   subset comparison per RFC 6376 Section 3.2 grammar. Raw string
-        #   comparison false-negatives on semantically identical records
-        #   ("v=DMARC1; p=none;" vs "v=DMARC1;p=none").
-        # - Anything else (opaque provider verification tokens): exact match
-        #   after trim. Deliberately tighter than the old substring check.
-        #
-        # Note: expected is NOT globally downcased here — DKIM p= base64 key
-        # data is case-sensitive (RFC 6376 Section 3.2).
+        # See RecordMatcher#txt_record_matches? for the dispatch discipline.
+        # SPF dispatch goes through the instance method (see record_matches?).
         #
         # @param expected [String] Expected value, trimmed
         # @param actual_values [Array<String>] DNS results
         # @return [Boolean]
         #
         def txt_record_matches?(expected, actual_values)
-          if RecordNormalizer.spf?(expected)
-            spf_record_matches?(expected.downcase, actual_values)
-          elsif RecordNormalizer.tag_list?(expected)
-            actual_values.any? { |v| RecordNormalizer.subset_match?(expected, v) }
-          else
-            actual_values.any? { |v| v.strip == expected }
-          end
+          return spf_record_matches?(expected.downcase, actual_values) if RecordNormalizer.spf?(expected)
+
+          RecordMatcher.txt_record_matches?(expected, actual_values)
         end
 
         # Check whether an SPF record matches expected value.
-        #
-        # Extracts the include: directive from the expected SPF record and
-        # verifies it appears in any actual SPF record, regardless of other
-        # mechanisms present. This allows customers to combine multiple
-        # provider includes in a single record.
+        # See RecordMatcher#spf_record_matches? for the include: semantics.
         #
         # @param normalized_expected [String] Downcased expected SPF value
         # @param actual_values [Array<String>] DNS results
         # @return [Boolean]
         #
         def spf_record_matches?(normalized_expected, actual_values)
-          spf_include = normalized_expected[/include:\S+/]
-
-          if spf_include
-            actual_values.any? do |v|
-              downcased = v.downcase
-              downcased.start_with?('v=spf1') && downcased.include?(spf_include)
-            end
-          else
-            # SPF without include: directive - match the full record
-            actual_values.any? { |v| v.downcase.include?(normalized_expected) }
-          end
+          RecordMatcher.spf_record_matches?(normalized_expected, actual_values)
         end
 
         # Run verification for all required records using per-thread resolvers.
@@ -476,26 +443,13 @@ module Onetime
         end
 
         # Filter a TXT result set down to records relevant to the expected
-        # value. Only DMARC and SPF expectations have a discriminator; other
-        # types and TXT purposes pass through unfiltered.
-        #
-        # Zero survivors keeps existing not-found semantics (no match, no
-        # error_type). One survivor plus unrelated TXT records still verifies.
+        # value. See RecordMatcher#select_txt_record_set for the selection
+        # rules and RFC references.
         #
         # @return [Array(Array<String>, Boolean)] [candidates, ambiguous]
         #
         def select_txt_record_set(type, expected, actual_values)
-          return [actual_values, false] unless type == 'TXT'
-
-          discriminator = if RecordNormalizer.dmarc?(expected)
-                            RecordNormalizer.method(:dmarc?)
-                          elsif RecordNormalizer.spf?(expected)
-                            RecordNormalizer.method(:spf?)
-                          end
-          return [actual_values, false] unless discriminator
-
-          survivors = actual_values.select { |v| discriminator.call(v) }
-          [survivors, survivors.size > 1]
+          RecordMatcher.select_txt_record_set(type, expected, actual_values)
         end
 
         # Lookup DNS records by type.

--- a/lib/onetime/jobs/workers/dns_record_check_worker.rb
+++ b/lib/onetime/jobs/workers/dns_record_check_worker.rb
@@ -135,10 +135,14 @@ module Onetime
             # dns_check_completed_at and updated are scalar fields — save_fields handles those.
             mailer_config.dns_check_results.value = result[:records]
 
-            # Compute dns_verified outcome: true if all records have value_matches=true
+            # Compute dns_verified outcome: true only when there is at least one
+            # checked record AND every one matched. An empty record set (domain
+            # not provisioned, or every record optional) is absence of evidence,
+            # not verification — [].all? would report true.
             records                    = result[:records] || []
             all_matched                = records.all? { |r| r['value_matches'] == true || r[:value_matches] == true }
-            mailer_config.dns_verified = all_matched
+            dns_verified               = records.any? && all_matched
+            mailer_config.dns_verified = dns_verified
 
             # Mark job as completed
             mailer_config.dns_check_status       = JobLifecycle::COMPLETED
@@ -155,12 +159,12 @@ module Onetime
               final_status = mailer_config.update_verification_status!
               log_info "DNS record check complete (final): #{domain_id}",
                 record_count: records.size,
-                dns_verified: all_matched,
+                dns_verified: dns_verified,
                 verification_status: final_status
             else
               log_info "DNS record check complete: #{domain_id}",
                 record_count: records.size,
-                dns_verified: all_matched,
+                dns_verified: dns_verified,
                 provider_check_status: mailer_config.provider_check_status
             end
 

--- a/lib/onetime/mail/sender_strategies/base_sender_strategy.rb
+++ b/lib/onetime/mail/sender_strategies/base_sender_strategy.rb
@@ -5,6 +5,8 @@
 require 'resolv'
 require 'digest'
 
+require_relative '../../domain_validation/record_matcher'
+
 module Onetime
   module Mail
     module SenderStrategies
@@ -117,9 +119,12 @@ module Onetime
         #     - :value [String] Expected value from provisioning
         #     - :dns_exists [Boolean] Whether any DNS records exist for this name+type
         #     - :value_matches [Boolean] Whether provisioned value matches DNS
-        #     - :error [String, nil] Error message on lookup failure
-        #     - :expected_digest [String] SHA256 hex digest of normalized expected value
-        #     - :actual_digest [String, nil] SHA256 hex digest of best-matching actual value
+        #     - :error [String, nil] Error message on lookup failure, or
+        #       'ambiguous_record_set' when duplicate DMARC/SPF records were found
+        #     - :expected_digest [String] SHA256 hex digest of the expected value
+        #       (reporting-only; does not gate matching)
+        #     - :actual_digest [String, nil] SHA256 hex digest of the sorted,
+        #       joined actual values (reporting-only; does not gate matching)
         #   - :checked_at [Time] When the check was performed
         #
         def check_dns_records(mailer_config, credentials: {}) # rubocop:disable Lint/UnusedMethodArgument
@@ -237,6 +242,12 @@ module Onetime
 
         # Check a single DNS record against live DNS.
         #
+        # Matching delegates to DomainValidation::RecordMatcher, the same
+        # dispatch used by the verification pipeline (issues #4023/#4047):
+        # record-set selection first (duplicate DMARC/SPF records are
+        # ambiguous, never a pass), then content-aware comparison. The
+        # digests are reporting-only diagnostics and do not gate matching.
+        #
         # @param record [Hash] Provisioned record with string keys: 'type', 'name', 'value'
         # @param resolver [Resolv::DNS] Shared resolver instance
         # @return [Hash] Check result with :dns_exists, :value_matches, :error, digests
@@ -246,27 +257,18 @@ module Onetime
           rec_name  = record['name'].to_s
           rec_value = record['value'].to_s
 
-          expected_normalized = normalize_dns_value(rec_value)
-          expected_digest     = Digest::SHA256.hexdigest(expected_normalized)
-
           actual_values, error = lookup_dns_record(rec_type, rec_name, resolver)
 
-          dns_exists    = !actual_values.empty?
-          value_matches = false
-          actual_digest = nil
+          dns_exists = !actual_values.empty?
 
-          if dns_exists
-            actual_values.each do |actual|
-              normalized_actual = normalize_dns_value(actual)
-              digest            = Digest::SHA256.hexdigest(normalized_actual)
-              if normalized_actual == expected_normalized || digest == expected_digest
-                value_matches = true
-                actual_digest = digest
-                break
-              end
-              # Track the first actual digest for debugging even if no match
-              actual_digest   ||= digest
-            end
+          matcher               = Onetime::DomainValidation::RecordMatcher
+          candidates, ambiguous = matcher.select_txt_record_set(rec_type, rec_value, actual_values)
+
+          if ambiguous
+            value_matches = false
+            error       ||= 'ambiguous_record_set'
+          else
+            value_matches = matcher.record_matches?(rec_type, rec_value, candidates)
           end
 
           {
@@ -276,8 +278,8 @@ module Onetime
             'dns_exists' => dns_exists,
             'value_matches' => value_matches,
             'error' => error,
-            'expected_digest' => expected_digest,
-            'actual_digest' => actual_digest,
+            'expected_digest' => Digest::SHA256.hexdigest(rec_value),
+            'actual_digest' => dns_exists ? Digest::SHA256.hexdigest(actual_values.sort.join("\n")) : nil,
           }
         end
 
@@ -309,18 +311,6 @@ module Onetime
           [[], 'timeout']
         rescue StandardError => ex
           [[], ex.message]
-        end
-
-        # Normalize a DNS value for comparison.
-        #
-        # Downcases and strips trailing dots to handle variations in DNS
-        # responses (e.g., "bounces.lmta.net." vs "bounces.lmta.net").
-        #
-        # @param value [String] Raw DNS value
-        # @return [String] Normalized value
-        #
-        def normalize_dns_value(value)
-          value.to_s.downcase.chomp('.')
         end
       end
     end

--- a/spec/unit/onetime/domain_validation/sender_strategies/base_strategy_spec.rb
+++ b/spec/unit/onetime/domain_validation/sender_strategies/base_strategy_spec.rb
@@ -734,9 +734,27 @@ RSpec.describe Onetime::DomainValidation::SenderStrategies::BaseStrategy do
       expect(strategy.spf_record_matches?(expected, actual)).to be false
     end
 
-    it 'falls back to substring match when no include directive in expected' do
+    it 'requires every expected term when no include directive in expected' do
       expected = 'v=spf1 mx ~all'
       actual = ['v=spf1 mx ~all']
+
+      expect(strategy.spf_record_matches?(expected, actual)).to be true
+    end
+
+    # PR #4051 review: String#include? accepted include:amazonses.com.evil
+    # as include:amazonses.com, reporting a misconfigured zone as verified.
+    it 'does not match an include whose domain merely starts with the expected one' do
+      expected = 'v=spf1 include:amazonses.com ~all'
+      actual = ['v=spf1 include:amazonses.com.evil ~all']
+
+      expect(strategy.spf_record_matches?(expected, actual)).to be false
+    end
+
+    # PR #4051 review: whole-record containment permanently false-negatived
+    # a correct zone whenever the provider's SPF carried no include:.
+    it 'tolerates extra mechanisms on the no-include path' do
+      expected = 'v=spf1 mx -all'
+      actual = ['v=spf1 mx include:other.com -all']
 
       expect(strategy.spf_record_matches?(expected, actual)).to be true
     end

--- a/spec/unit/onetime/jobs/workers/dns_record_check_worker_spec.rb
+++ b/spec/unit/onetime/jobs/workers/dns_record_check_worker_spec.rb
@@ -1,0 +1,128 @@
+# spec/unit/onetime/jobs/workers/dns_record_check_worker_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for DnsRecordCheckWorker's dns_verified computation (issue #4047).
+#
+# Regression: dns_verified used to be `records.all? { value_matches }`, so an
+# EMPTY record set (domain not provisioned, or every record optional) read as
+# verified — [].all? is vacuously true. It is now `records.any? && all_matched`:
+# absence of evidence is not verification.
+#
+# Seams: the worker is instantiated for real (Sneakers::Queue does not connect
+# until subscribe), but everything stateful is stubbed — trace context yields
+# straight through, the idempotency claim is granted, MailerConfig lookup and
+# the sender strategy return doubles, and the logger is a null object. ack! /
+# reject! are Sneakers methods that just return symbols; asserting on the
+# return value pins the outcome.
+
+require 'spec_helper'
+require 'onetime/jobs/workers/dns_record_check_worker'
+
+RSpec.describe Onetime::Jobs::Workers::DnsRecordCheckWorker do
+  let(:worker) { described_class.new }
+
+  let(:delivery_info) do
+    double('DeliveryInfo', delivery_tag: 1, routing_key: described_class::QUEUE_NAME, redelivered?: false)
+  end
+  let(:amqp_metadata) { double('MessageProperties', message_id: 'msg-4047', headers: nil) }
+  let(:msg) { { domain_id: 'domain-abc', requested_at: '2026-08-08T00:00:00Z' }.to_json }
+
+  let(:dns_check_results_key) { double('dns_check_results', :value= => nil) }
+  let(:mailer_config) do
+    double(
+      'MailerConfig',
+      dns_check_status: nil,
+      :dns_check_status= => nil,
+      :dns_verified= => nil,
+      :dns_check_completed_at= => nil,
+      :updated= => nil,
+      save_fields: true,
+      refresh!: true,
+      jobs_completed?: false,
+      provider_check_status: 'pending',
+      effective_provider: 'lettermint',
+      dns_check_results: dns_check_results_key,
+    )
+  end
+  let(:strategy) { double('SenderStrategy', check_dns_records: { records: dns_records, checked_at: Time.now }) }
+
+  before do
+    allow(worker).to receive(:logger).and_return(double('logger').as_null_object)
+    allow(worker).to receive(:with_trace_context).and_yield
+    allow(worker).to receive(:claim_for_processing).and_return(true)
+    allow(Onetime::CustomDomain::MailerConfig).to receive(:find_by_domain_id)
+      .with('domain-abc').and_return(mailer_config)
+    allow(Onetime::Mail::SenderStrategies).to receive(:for_provider)
+      .with('lettermint').and_return(strategy)
+  end
+
+  def work
+    worker.work_with_params(msg, delivery_info, amqp_metadata)
+  end
+
+  describe 'dns_verified computation' do
+    context 'with an empty record set (the #4047 vacuous-truth regression)' do
+      let(:dns_records) { [] }
+
+      it 'sets dns_verified false — absence of evidence is not verification' do
+        expect(work).to eq(:ack)
+        expect(mailer_config).to have_received(:dns_verified=).with(false)
+      end
+
+      it 'still persists the (empty) fact-finding results and completion' do
+        work
+        expect(dns_check_results_key).to have_received(:value=).with([])
+        expect(mailer_config).to have_received(:save_fields)
+          .with(:dns_check_status, :dns_verified, :dns_check_completed_at, :updated)
+      end
+    end
+
+    context 'when every record matched' do
+      let(:dns_records) do
+        [
+          { 'type' => 'CNAME', 'name' => 'a.example.com', 'value_matches' => true },
+          { 'type' => 'TXT', 'name' => 'b.example.com', 'value_matches' => true },
+        ]
+      end
+
+      it 'sets dns_verified true' do
+        expect(work).to eq(:ack)
+        expect(mailer_config).to have_received(:dns_verified=).with(true)
+      end
+    end
+
+    context 'when records use symbol keys' do
+      let(:dns_records) { [{ type: 'TXT', name: 'a.example.com', value_matches: true }] }
+
+      it 'still recognizes the match' do
+        work
+        expect(mailer_config).to have_received(:dns_verified=).with(true)
+      end
+    end
+
+    context 'when one record does not match' do
+      let(:dns_records) do
+        [
+          { 'type' => 'CNAME', 'name' => 'a.example.com', 'value_matches' => true },
+          { 'type' => 'TXT', 'name' => 'b.example.com', 'value_matches' => false, 'error' => 'ambiguous_record_set' },
+        ]
+      end
+
+      it 'sets dns_verified false' do
+        expect(work).to eq(:ack)
+        expect(mailer_config).to have_received(:dns_verified=).with(false)
+      end
+    end
+
+    context 'when the strategy result has no records key' do
+      let(:strategy) { double('SenderStrategy', check_dns_records: { checked_at: Time.now }) }
+      let(:dns_records) { nil }
+
+      it 'treats nil records as empty and sets dns_verified false' do
+        work
+        expect(mailer_config).to have_received(:dns_verified=).with(false)
+      end
+    end
+  end
+end

--- a/spec/unit/onetime/mail/sender_strategies/base_sender_strategy_spec.rb
+++ b/spec/unit/onetime/mail/sender_strategies/base_sender_strategy_spec.rb
@@ -1,0 +1,371 @@
+# spec/unit/onetime/mail/sender_strategies/base_sender_strategy_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for BaseSenderStrategy DNS fact-finding (issue #4047).
+#
+# check_single_dns_record used to normalize with a global downcase and a
+# strict-equality + digest gate, which false-negatived on semantically
+# identical DMARC records ('v=DMARC1; p=none;' vs 'v=DMARC1;p=none') and
+# false-positived on DKIM keys differing only in case. It now delegates to
+# DomainValidation::RecordMatcher — the same dispatch as the verification
+# pipeline — with record-set selection first (duplicate DMARC/SPF is
+# ambiguous, never a pass). Digests are reporting-only diagnostics.
+#
+# Seam: lookup_dns_record is stubbed for check_single_dns_record tests (it is
+# the network boundary); its own type dispatch and rescue mapping are covered
+# separately with an instance_double resolver.
+
+require 'spec_helper'
+require 'onetime/mail/sender_strategies/base_sender_strategy'
+
+RSpec.describe Onetime::Mail::SenderStrategies::BaseSenderStrategy do
+  # Publicize the private methods under test, mirroring the technique in
+  # spec/unit/onetime/domain_validation/sender_strategies/base_strategy_spec.rb
+  let(:test_strategy_class) do
+    Class.new(described_class) do
+      public :check_single_dns_record, :lookup_dns_record
+    end
+  end
+
+  let(:strategy) { test_strategy_class.new }
+  let(:resolver) { instance_double(Resolv::DNS) }
+
+  describe '#check_single_dns_record' do
+    def check_record(type:, name:, value:)
+      strategy.check_single_dns_record(
+        { 'type' => type, 'name' => name, 'value' => value },
+        resolver,
+      )
+    end
+
+    def stub_lookup(values, error = nil)
+      allow(strategy).to receive(:lookup_dns_record).and_return([values, error])
+    end
+
+    context 'with DMARC records (the #4047 false negative)' do
+      it 'matches SES advisory DMARC (with spaces) against a compact zone record' do
+        # ses_sender_strategy provisions 'v=DMARC1; p=none;' verbatim; zones
+        # commonly store the compact form. These are the same record.
+        stub_lookup(['v=DMARC1;p=none'])
+
+        result = check_record(type: 'TXT', name: '_dmarc.example.com', value: 'v=DMARC1; p=none;')
+
+        expect(result['dns_exists']).to be true
+        expect(result['value_matches']).to be true
+        expect(result['error']).to be_nil
+      end
+
+      it 'matches when the customer added reporting tags' do
+        stub_lookup(['v=DMARC1; p=none; rua=mailto:dmarc@example.com'])
+
+        result = check_record(type: 'TXT', name: '_dmarc.example.com', value: 'v=DMARC1; p=none;')
+
+        expect(result['value_matches']).to be true
+      end
+
+      it 'still verifies when unrelated TXT records share the name' do
+        stub_lookup(['v=DMARC1;p=none', 'google-site-verification=abc123'])
+
+        result = check_record(type: 'TXT', name: '_dmarc.example.com', value: 'v=DMARC1; p=none;')
+
+        expect(result['value_matches']).to be true
+        expect(result['error']).to be_nil
+      end
+
+      it 'reports ambiguous_record_set when the zone has two DMARC records' do
+        stub_lookup(['v=DMARC1; p=none;', 'v=DMARC1; p=reject'])
+
+        result = check_record(type: 'TXT', name: '_dmarc.example.com', value: 'v=DMARC1; p=none;')
+
+        expect(result['dns_exists']).to be true
+        expect(result['value_matches']).to be false
+        expect(result['error']).to eq('ambiguous_record_set')
+      end
+
+      it 'never passes duplicate identical DMARC records' do
+        stub_lookup(['v=DMARC1;p=none', 'v=DMARC1;p=none'])
+
+        result = check_record(type: 'TXT', name: '_dmarc.example.com', value: 'v=DMARC1;p=none')
+
+        expect(result['value_matches']).to be false
+        expect(result['error']).to eq('ambiguous_record_set')
+      end
+    end
+
+    context 'with SPF records' do
+      it 'matches the SES required SPF inside a merged customer record' do
+        stub_lookup(['v=spf1 include:amazonses.com include:_spf.google.com ~all'])
+
+        result = check_record(type: 'TXT', name: 'mail.example.com', value: 'v=spf1 include:amazonses.com ~all')
+
+        expect(result['value_matches']).to be true
+      end
+
+      it 'does not match when the required include: is absent' do
+        stub_lookup(['v=spf1 include:sendgrid.net ~all'])
+
+        result = check_record(type: 'TXT', name: 'mail.example.com', value: 'v=spf1 include:amazonses.com ~all')
+
+        expect(result['value_matches']).to be false
+      end
+
+      it 'reports ambiguous_record_set for duplicate SPF records' do
+        stub_lookup(['v=spf1 include:amazonses.com ~all', 'v=spf1 -all'])
+
+        result = check_record(type: 'TXT', name: 'mail.example.com', value: 'v=spf1 include:amazonses.com ~all')
+
+        expect(result['value_matches']).to be false
+        expect(result['error']).to eq('ambiguous_record_set')
+      end
+    end
+
+    context 'with DKIM records' do
+      it 'does NOT match keys differing only in p= case (old downcase false positive)' do
+        stub_lookup(['v=DKIM1;k=rsa;p=migfma0gcsqg'])
+
+        result = check_record(
+          type: 'TXT',
+          name: 'selector._domainkey.example.com',
+          value: 'v=DKIM1;k=rsa;p=MIGfMA0GCSqG',
+        )
+
+        expect(result['dns_exists']).to be true
+        expect(result['value_matches']).to be false
+      end
+
+      it 'matches identical keys despite tag-list spacing differences' do
+        stub_lookup(['v=DKIM1; k=rsa; p=MIGfMA0GCSqG'])
+
+        result = check_record(
+          type: 'TXT',
+          name: 'selector._domainkey.example.com',
+          value: 'v=DKIM1;k=rsa;p=MIGfMA0GCSqG',
+        )
+
+        expect(result['value_matches']).to be true
+      end
+    end
+
+    context 'with opaque verification tokens' do
+      it 'matches exactly' do
+        stub_lookup(['token-abc123'])
+
+        result = check_record(type: 'TXT', name: '_verify.example.com', value: 'token-abc123')
+
+        expect(result['value_matches']).to be true
+      end
+
+      it 'rejects substring containment' do
+        stub_lookup(['prefix-token-abc123-suffix'])
+
+        result = check_record(type: 'TXT', name: '_verify.example.com', value: 'token-abc123')
+
+        expect(result['value_matches']).to be false
+      end
+    end
+
+    context 'with CNAME records' do
+      it 'matches case-insensitively and ignores trailing dots' do
+        stub_lookup(['ABC123.dkim.amazonses.com.'])
+
+        result = check_record(
+          type: 'CNAME',
+          name: 'abc123._domainkey.example.com',
+          value: 'abc123.dkim.amazonses.com',
+        )
+
+        expect(result['value_matches']).to be true
+      end
+
+      it 'upcases the record type before dispatch' do
+        stub_lookup(['bounces.lmta.net.'])
+
+        result = check_record(type: 'cname', name: 'lm-bounces.example.com', value: 'bounces.lmta.net')
+
+        expect(result['type']).to eq('CNAME')
+        expect(result['value_matches']).to be true
+      end
+    end
+
+    context 'when the lookup fails' do
+      it 'preserves a timeout error with no values and a nil actual_digest' do
+        stub_lookup([], 'timeout')
+
+        result = check_record(type: 'TXT', name: '_dmarc.example.com', value: 'v=DMARC1;p=none')
+
+        expect(result['dns_exists']).to be false
+        expect(result['value_matches']).to be false
+        expect(result['error']).to eq('timeout')
+        expect(result['actual_digest']).to be_nil
+      end
+
+      it 'treats NXDOMAIN (empty values, no error) as not-found, not an error' do
+        stub_lookup([])
+
+        result = check_record(type: 'TXT', name: '_dmarc.example.com', value: 'v=DMARC1;p=none')
+
+        expect(result['dns_exists']).to be false
+        expect(result['value_matches']).to be false
+        expect(result['error']).to be_nil
+      end
+    end
+
+    context 'digests (reporting-only diagnostics)' do
+      it 'digests the raw expected value without normalization' do
+        stub_lookup(['v=DMARC1;p=none'])
+
+        result = check_record(type: 'TXT', name: '_dmarc.example.com', value: 'v=DMARC1; p=none;')
+
+        expect(result['expected_digest']).to eq(Digest::SHA256.hexdigest('v=DMARC1; p=none;'))
+      end
+
+      it 'digests the sorted joined actual values, independent of DNS ordering' do
+        stub_lookup(%w[bbb aaa])
+        unordered = check_record(type: 'TXT', name: 'x.example.com', value: 'aaa')
+
+        stub_lookup(%w[aaa bbb])
+        ordered = check_record(type: 'TXT', name: 'x.example.com', value: 'aaa')
+
+        expect(unordered['actual_digest']).to eq(Digest::SHA256.hexdigest("aaa\nbbb"))
+        expect(ordered['actual_digest']).to eq(unordered['actual_digest'])
+      end
+
+      it 'does not let a matching digest gate value_matches (digest equality is not a match)' do
+        # Same digest inputs, but content that does not satisfy the matcher:
+        # expected token differs from the actual value.
+        stub_lookup(['other-token'])
+
+        result = check_record(type: 'TXT', name: 'x.example.com', value: 'token-abc')
+
+        expect(result['value_matches']).to be false
+        expect(result['expected_digest']).not_to eq(result['actual_digest'])
+      end
+    end
+
+    it 'returns the stable result schema with string keys' do
+      stub_lookup(['token-abc'])
+
+      result = check_record(type: 'TXT', name: 'x.example.com', value: 'token-abc')
+
+      expect(result.keys).to match_array(
+        %w[type name value dns_exists value_matches error expected_digest actual_digest],
+      )
+    end
+  end
+
+  describe '#lookup_dns_record' do
+    it 'joins multi-chunk TXT strings into a single value' do
+      # DNS splits TXT payloads >255 octets into chunks; long DKIM keys are
+      # only comparable after re-joining.
+      resource = instance_double(Resolv::DNS::Resource::IN::TXT, strings: ['v=DKIM1; k=rsa; ', 'p=MIGfMA0GCSqG'])
+      allow(resolver).to receive(:getresources)
+        .with('selector._domainkey.example.com', Resolv::DNS::Resource::IN::TXT)
+        .and_return([resource])
+
+      values, error = strategy.lookup_dns_record('TXT', 'selector._domainkey.example.com', resolver)
+
+      expect(values).to eq(['v=DKIM1; k=rsa; p=MIGfMA0GCSqG'])
+      expect(error).to be_nil
+    end
+
+    it 'maps CNAME resources to their target names' do
+      resource = instance_double(Resolv::DNS::Resource::IN::CNAME, name: Resolv::DNS::Name.create('bounces.lmta.net'))
+      allow(resolver).to receive(:getresources)
+        .with('lm-bounces.example.com', Resolv::DNS::Resource::IN::CNAME)
+        .and_return([resource])
+
+      values, error = strategy.lookup_dns_record('CNAME', 'lm-bounces.example.com', resolver)
+
+      expect(values).to eq(['bounces.lmta.net'])
+      expect(error).to be_nil
+    end
+
+    it 'returns empty values without error for unknown record types' do
+      values, error = strategy.lookup_dns_record('A', 'example.com', resolver)
+
+      expect(values).to eq([])
+      expect(error).to be_nil
+    end
+
+    it 'treats ResolvError as an authoritative not-found, not an error' do
+      allow(resolver).to receive(:getresources).and_raise(Resolv::ResolvError)
+
+      values, error = strategy.lookup_dns_record('TXT', 'missing.example.com', resolver)
+
+      expect(values).to eq([])
+      expect(error).to be_nil
+    end
+
+    it 'reports timeouts as a preserved error string' do
+      allow(resolver).to receive(:getresources).and_raise(Resolv::ResolvTimeout)
+
+      values, error = strategy.lookup_dns_record('TXT', 'slow.example.com', resolver)
+
+      expect(values).to eq([])
+      expect(error).to eq('timeout')
+    end
+
+    it 'reports other errors by message' do
+      allow(resolver).to receive(:getresources).and_raise(StandardError, 'socket exploded')
+
+      values, error = strategy.lookup_dns_record('TXT', 'broken.example.com', resolver)
+
+      expect(values).to eq([])
+      expect(error).to eq('socket exploded')
+    end
+  end
+
+  describe '#check_dns_records' do
+    let(:mock_resolver) { instance_double(Resolv::DNS, :timeouts= => nil, close: nil) }
+
+    before do
+      allow(Resolv::DNS).to receive(:new).and_return(mock_resolver)
+    end
+
+    def mailer_config_with(records)
+      records_key = records.nil? ? nil : instance_double('Familia::JsonKey', value: records)
+      instance_double(Onetime::CustomDomain::MailerConfig, dns_records: records_key)
+    end
+
+    it 'short-circuits with empty records when nothing is provisioned (nil)' do
+      result = strategy.check_dns_records(mailer_config_with(nil))
+
+      expect(result[:records]).to eq([])
+      expect(result[:checked_at]).to be_a(Time)
+    end
+
+    it 'short-circuits with empty records when the provisioned list is empty' do
+      result = strategy.check_dns_records(mailer_config_with([]))
+
+      expect(result[:records]).to eq([])
+    end
+
+    it 'checks only required records, rejecting optional true and "true"' do
+      provisioned = [
+        { 'type' => 'CNAME', 'name' => 'required.example.com', 'value' => 'target.example.com' },
+        { 'type' => 'TXT', 'name' => 'advisory.example.com', 'value' => 'v=DMARC1; p=none;', 'optional' => true },
+        { 'type' => 'TXT', 'name' => 'advisory2.example.com', 'value' => 'v=DMARC1; p=none;', 'optional' => 'true' },
+        { 'type' => 'TXT', 'name' => 'explicit.example.com', 'value' => 'token', 'optional' => false },
+      ]
+      allow(strategy).to receive(:check_single_dns_record) do |record, _resolver|
+        { 'name' => record['name'] }
+      end
+
+      result = strategy.check_dns_records(mailer_config_with(provisioned))
+
+      expect(result[:records].map { |r| r['name'] })
+        .to eq(%w[required.example.com explicit.example.com])
+    end
+
+    it 'closes the resolver even on success' do
+      allow(strategy).to receive(:check_single_dns_record).and_return({})
+
+      strategy.check_dns_records(
+        mailer_config_with([{ 'type' => 'TXT', 'name' => 'x.example.com', 'value' => 'token' }]),
+      )
+
+      expect(mock_resolver).to have_received(:close)
+    end
+  end
+end

--- a/try/unit/domain_validation/record_matcher_try.rb
+++ b/try/unit/domain_validation/record_matcher_try.rb
@@ -1,0 +1,180 @@
+# try/unit/domain_validation/record_matcher_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for Onetime::DomainValidation::RecordMatcher (issue #4047)
+#
+# RecordMatcher is the shared DNS comparison module extracted from the #4046
+# fix so that BOTH pipelines — verification (DomainValidation::SenderStrategies)
+# and fact-finding (Mail::SenderStrategies) — dispatch identically. It is a
+# pure module (no OT state, no I/O), so this tryout is deliberately boot-free:
+# it requires the file directly instead of going through test_helpers/OT.boot!.
+#
+# Coverage:
+# 1. record_matches? type dispatch (TXT content-aware, CNAME/MX hostname,
+#    unknown types never match)
+# 2. txt_record_matches? dispatch: SPF include-subset, DMARC/DKIM tag-list
+#    normalization, opaque tokens exact-after-trim
+# 3. spf_record_matches? include: extraction and the no-include fallback
+# 4. select_txt_record_set: duplicate DMARC/SPF in the zone is ambiguous,
+#    never a pass; unrelated TXT records are discarded, not failures
+#
+# Motivating real-world cases (#4047):
+# - SES provisions advisory DMARC as 'v=DMARC1; p=none;' WITH spaces; zones
+#   often store 'v=DMARC1;p=none' — must MATCH (the #4047 false negative)
+# - SES required SPF vs a customer's merged record — must MATCH
+# - DKIM p= base64 differing only in case — must NOT match (the old global
+#   downcase made this a false positive)
+
+require_relative '../../../lib/onetime/domain_validation/record_matcher'
+
+@matcher = Onetime::DomainValidation::RecordMatcher
+
+# --- record_matches?: TXT/DMARC (the #4047 false negative) ---
+
+## SES advisory DMARC 'v=DMARC1; p=none;' (with spaces, per
+## ses_sender_strategy provisioning) matches a compact zone record
+@matcher.record_matches?('TXT', 'v=DMARC1; p=none;', ['v=DMARC1;p=none'])
+#=> true
+
+## Spacing tolerance works in the other direction too
+@matcher.record_matches?('TXT', 'v=DMARC1;p=none', ['v=DMARC1; p=none;'])
+#=> true
+
+## Customer-added DMARC tags (rua=) do not break the match
+@matcher.record_matches?('TXT', 'v=DMARC1; p=none;', ['v=DMARC1;p=none;rua=mailto:dmarc@example.com'])
+#=> true
+
+## A zone with no DMARC record does not match
+@matcher.record_matches?('TXT', 'v=DMARC1; p=none;', ['google-site-verification=abc123'])
+#=> false
+
+# --- record_matches?: TXT/SPF (merged customer records) ---
+
+## SES required SPF matches a customer record merged with another provider
+@matcher.record_matches?('TXT',
+  'v=spf1 include:amazonses.com ~all',
+  ['v=spf1 include:amazonses.com include:_spf.google.com ~all'])
+#=> true
+
+## Exact SPF record still matches, case-insensitively
+@matcher.record_matches?('TXT', 'v=spf1 include:amazonses.com ~all', ['V=SPF1 INCLUDE:AMAZONSES.COM ~ALL'])
+#=> true
+
+## SPF without the required include: mechanism does not match
+@matcher.record_matches?('TXT', 'v=spf1 include:amazonses.com ~all', ['v=spf1 include:sendgrid.net ~all'])
+#=> false
+
+# --- record_matches?: TXT/DKIM (case-sensitivity restored) ---
+
+## DKIM keys differing ONLY in p= case do NOT match (RFC 6376: base64 key
+## data is case-sensitive; the old global downcase made this a false positive)
+@matcher.record_matches?('TXT', 'v=DKIM1;k=rsa;p=MIGfMA0GCSqG', ['v=DKIM1;k=rsa;p=migfma0gcsqg'])
+#=> false
+
+## Identical DKIM keys match despite spacing differences in the tag list
+@matcher.record_matches?('TXT', 'v=DKIM1;k=rsa;p=MIGfMA0GCSqG', ['v=DKIM1; k=rsa; p=MIGfMA0GCSqG'])
+#=> true
+
+# --- record_matches?: TXT opaque verification tokens ---
+
+## Opaque tokens match exactly
+@matcher.record_matches?('TXT', 'token-abc123', ['token-abc123'])
+#=> true
+
+## Substring containment is NOT a match
+@matcher.record_matches?('TXT', 'token-abc123', ['prefix-token-abc123-suffix'])
+#=> false
+
+## Opaque tokens are case-sensitive
+@matcher.record_matches?('TXT', 'Token-ABC123', ['token-abc123'])
+#=> false
+
+## Edge whitespace on either side is trimmed before the exact comparison
+@matcher.record_matches?('TXT', '  token-abc123  ', ['token-abc123 '])
+#=> true
+
+## A nil expected value never matches
+@matcher.record_matches?('TXT', nil, ['token-abc123'])
+#=> false
+
+# --- record_matches?: CNAME / MX hostname comparison ---
+
+## CNAME comparison ignores the trailing dot DNS resolvers return
+@matcher.record_matches?('CNAME', 'abc123.dkim.amazonses.com', ['abc123.dkim.amazonses.com.'])
+#=> true
+
+## CNAME comparison is case-insensitive
+@matcher.record_matches?('CNAME', 'Bounces.LMTA.net', ['bounces.lmta.net'])
+#=> true
+
+## Trailing dot on the expected side is also tolerated
+@matcher.record_matches?('CNAME', 'bounces.lmta.net.', ['bounces.lmta.net'])
+#=> true
+
+## Different CNAME targets do not match
+@matcher.record_matches?('CNAME', 'bounces.lmta.net', ['other.example.com.'])
+#=> false
+
+## MX uses the same hostname comparison
+@matcher.record_matches?('MX', 'feedback-smtp.us-east-1.amazonses.com', ['FEEDBACK-SMTP.us-east-1.amazonses.com.'])
+#=> true
+
+## Unknown record types never match
+@matcher.record_matches?('A', '192.0.2.1', ['192.0.2.1'])
+#=> false
+
+## Dispatch is on the exact type string: callers must upcase first
+@matcher.record_matches?('txt', 'token-abc123', ['token-abc123'])
+#=> false
+
+# --- txt_record_matches? / spf_record_matches? internals ---
+
+## SPF expected without an include: falls back to whole-record containment
+@matcher.txt_record_matches?('v=spf1 -all', ['v=spf1 -all'])
+#=> true
+
+## The no-include fallback still requires the expected content to appear
+@matcher.txt_record_matches?('v=spf1 -all', ['v=spf1 mx ~all'])
+#=> false
+
+## spf_record_matches? only considers actual records that are SPF: an
+## include: mechanism embedded in a non-SPF TXT record does not count
+@matcher.spf_record_matches?('v=spf1 include:amazonses.com ~all', ['some-token include:amazonses.com'])
+#=> false
+
+## spf_record_matches? finds the include among other mechanisms, any case
+@matcher.spf_record_matches?('v=spf1 include:amazonses.com ~all', ['v=spf1 a mx INCLUDE:AMAZONSES.COM -all'])
+#=> true
+
+# --- select_txt_record_set: ambiguity detection ---
+
+## Two DMARC records in the zone survive selection and flag ambiguous
+@matcher.select_txt_record_set('TXT', 'v=DMARC1;p=none', ['v=DMARC1; p=none;', 'v=DMARC1; p=reject'])
+#=> [['v=DMARC1; p=none;', 'v=DMARC1; p=reject'], true]
+
+## Duplicate identical DMARC records are still ambiguous, never a pass
+@matcher.select_txt_record_set('TXT', 'v=DMARC1;p=none', ['v=DMARC1;p=none', 'v=DMARC1;p=none'])
+#=> [['v=DMARC1;p=none', 'v=DMARC1;p=none'], true]
+
+## Two SPF records are ambiguous (RFC 7208 permerror)
+@matcher.select_txt_record_set('TXT',
+  'v=spf1 include:amazonses.com ~all',
+  ['v=spf1 include:amazonses.com ~all', 'v=spf1 -all'])
+#=> [['v=spf1 include:amazonses.com ~all', 'v=spf1 -all'], true]
+
+## One DMARC record plus unrelated TXT junk: junk is discarded, not ambiguous
+@matcher.select_txt_record_set('TXT', 'v=DMARC1;p=none', ['v=DMARC1; p=none;', 'google-site-verification=abc123'])
+#=> [['v=DMARC1; p=none;'], false]
+
+## Zero survivors keeps not-found semantics (no candidates, not ambiguous)
+@matcher.select_txt_record_set('TXT', 'v=DMARC1;p=none', ['google-site-verification=abc123'])
+#=> [[], false]
+
+## Opaque-token expectations have no discriminator: full set passes through
+@matcher.select_txt_record_set('TXT', 'token-abc', ['token-abc', 'other-token'])
+#=> [['token-abc', 'other-token'], false]
+
+## Non-TXT types pass through unfiltered, never ambiguous
+@matcher.select_txt_record_set('CNAME', 'target.example.com', ['a.example.com.', 'b.example.com.'])
+#=> [['a.example.com.', 'b.example.com.'], false]

--- a/try/unit/domain_validation/record_matcher_try.rb
+++ b/try/unit/domain_validation/record_matcher_try.rb
@@ -130,13 +130,18 @@ require_relative '../../../lib/onetime/domain_validation/record_matcher'
 
 # --- txt_record_matches? / spf_record_matches? internals ---
 
-## SPF expected without an include: falls back to whole-record containment
+## SPF expected without an include: requires every expected term
 @matcher.txt_record_matches?('v=spf1 -all', ['v=spf1 -all'])
 #=> true
 
-## The no-include fallback still requires the expected content to appear
+## The no-include path still requires each expected term to appear
 @matcher.txt_record_matches?('v=spf1 -all', ['v=spf1 mx ~all'])
 #=> false
+
+## The no-include path tolerates extra terms in the customer record, the
+## same way the include: path does (PR #4051 review)
+@matcher.txt_record_matches?('v=spf1 mx -all', ['v=spf1 mx include:other.com -all'])
+#=> true
 
 ## spf_record_matches? only considers actual records that are SPF: an
 ## include: mechanism embedded in a non-SPF TXT record does not count
@@ -146,6 +151,19 @@ require_relative '../../../lib/onetime/domain_validation/record_matcher'
 ## spf_record_matches? finds the include among other mechanisms, any case
 @matcher.spf_record_matches?('v=spf1 include:amazonses.com ~all', ['v=spf1 a mx INCLUDE:AMAZONSES.COM -all'])
 #=> true
+
+## Mechanisms match as whole terms: a longer domain that merely starts
+## with the expected one is a different include (PR #4051 review)
+@matcher.spf_record_matches?('v=spf1 include:amazonses.com ~all', ['v=spf1 include:amazonses.com.evil ~all'])
+#=> false
+
+## The same term discipline applies to the no-include path
+@matcher.spf_record_matches?('v=spf1 mx -all', ['v=spf1 mxtra -all'])
+#=> false
+
+## An expected value that is SPF-flagged but carries no terms never matches
+@matcher.spf_record_matches?('', ['v=spf1 -all'])
+#=> false
 
 # --- select_txt_record_set: ambiguity detection ---
 


### PR DESCRIPTION
Closes #4047. Twin of #4023 (fixed for the DomainValidation path by #4046) — this is the customer-visible pipeline behind the domain email-config DNS badges.

## What

**Extract, don't copy.** The duplicated matching dispatch across the two DNS-check pipelines is what produced this twin bug, so the #4046 logic now lives in a shared pure module:

- **New `Onetime::DomainValidation::RecordMatcher`** (`extend self`, requires only `RecordNormalizer`): `record_matches?`, `txt_record_matches?`, `spf_record_matches?`, `select_txt_record_set`.
- **`domain_validation/sender_strategies/base_strategy.rb`** delegates to it. Behavior bit-for-bit identical — its pre-existing 114-example spec passes **unedited**.
- **`mail/sender_strategies/base_sender_strategy.rb`** — `check_single_dns_record` rewritten: record-set selection first (duplicate DMARC/SPF in zone → `value_matches: false`, `error: 'ambiguous_record_set'`), then `RecordMatcher.record_matches?`. The old `normalize_dns_value` (global downcase + strict equality + redundant SHA256 gate) is deleted; digests remain as reporting-only fields. Result-hash keys unchanged, so `required_dns_records` → serializer → `email-config.ts` contract is untouched.

This fixes, in the customer-visible pipeline:
1. **Tag-formatting false negative** — SES provisions advisory DMARC as `'v=DMARC1; p=none;'` *with* spaces; a zone storing `'v=DMARC1;p=none'` failed. Lettermint records carry no `optional` flag, so its DMARC/DKIM TXT records hit this as *required* records.
2. **No SPF handling** — a customer's merged SPF record (`v=spf1 include:amazonses.com include:_spf.google.com ~all`) failed against SES's required `v=spf1 include:amazonses.com ~all`.
3. **DKIM case false positive** — the global downcase made base64 `p=` keys differing only in case compare equal.
4. **Missing duplicate-record ambiguity detection** (same gap #4046 closed for the other pipeline).

## Related defects fixed in the same pass (per issue)

- **`DnsRecordCheckWorker`** — `[].all?` is vacuously true, so an empty record set persisted `dns_verified = true` with zero DNS evidence (reachable via unprovisioned domains). Now `records.any? && all_matched`.
- **`ValidateSenderConfig#raise_concerns`** — now rejects unprovisioned configs before clearing DNS state and enqueueing workers, closing the path that fed the vacuous-verified bug.

## Tests

72 new cases, all green; full combined batch **369 examples, 0 failures**:

- `try/unit/domain_validation/record_matcher_try.rb` — 32 boot-free tryouts over the shared matcher.
- `spec/unit/onetime/mail/sender_strategies/base_sender_strategy_spec.rb` — 30 examples: all motivating cases, ambiguity, digest determinism, lookup error mapping, optional-record filtering.
- `spec/unit/onetime/jobs/workers/dns_record_check_worker_spec.rb` — 6 examples pinning the empty-set regression.
- `apps/api/domains/spec/logic/sender_config/validate_sender_config_spec.rb` — 4 examples for the `provisioned?` guard (mirrors the `put_sender_config_spec` harness).
- Regressions: `base_strategy_spec.rb` (114) and `record_normalizer_try.rb` (41) pass unchanged.

Non-vacuity proven with a load-time mutant restoring the old downcase-equality semantics: 9/30 new strategy examples fail under the mutant, 0 under the real code.

## Follow-up (filed separately)

`required_dns_records` never copies the per-record `error` field into the API payload, so `ambiguous_record_set` (or a timeout) surfaces only as a generic "failed" badge. Pre-existing blind spot in unmodified code (`mailer_config.rb` / serializer / TS contract / Vue), newly relevant now that this pipeline can produce the error.