### PR TITLE
Fix RFC 7239 Forwarded host detection

### DIFF
--- a/changelog.d/20260808_170500_codex_4040_forwarded_host.rst
+++ b/changelog.d/20260808_170500_codex_4040_forwarded_host.rst
@@ -1,0 +1,14 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- ``Rack::DetectHost`` now extracts the RFC 7239 ``host=`` parameter from
+  trusted ``Forwarded`` headers, including quoted host values and ports,
+  instead of treating the complete parameter list as a hostname. (#4040)
+
+AI Assistance
+-------------
+
+- Codex assisted with the implementation and regression tests for the
+  ``Forwarded`` host parsing fix. (#4040)

--- a/lib/middleware/detect_host.rb
+++ b/lib/middleware/detect_host.rb
@@ -228,7 +228,7 @@ module Rack
       # Try headers in order of precedence
       headers_to_check.each do |header|
         header_key = "HTTP_#{header.tr('-', '_').upcase}"
-        host       = self.class.normalize_host(env[header_key])
+        host       = self.class.normalize_host(env[header_key], forwarded: header == 'Forwarded')
         next if host.nil?
 
         if self.class.valid_domain_name?(host)
@@ -301,19 +301,83 @@ module Rack
       # Extracts and normalizes the host from a header value.
       #
       # @param value_unsafe [String, nil] Raw header value from the request
+      # @param forwarded [Boolean] Whether the value uses RFC 7239 Forwarded syntax
       # @return [String, nil] Normalized host without port number, or nil if empty
       #
       # This method:
       # - Takes the first host if multiple are provided (comma-separated)
+      # - Extracts the host parameter from the first RFC 7239 Forwarded element
       # - Delegates to DomainParser for port stripping and normalization
       # - Returns nil for empty values
-      def normalize_host(value_unsafe)
-        # Handle comma-separated hosts (e.g., X-Forwarded-Host header)
-        first_host = value_unsafe.to_s.split(',').first.to_s
+      def normalize_host(value_unsafe, forwarded: false)
+        first_host = if forwarded
+          forwarded_host(value_unsafe)
+        else
+          # Handle comma-separated hosts (e.g., X-Forwarded-Host header)
+          value_unsafe.to_s.split(',').first.to_s
+        end
 
         # Delegate core normalization to DomainParser
         Onetime::Utils::DomainParser.extract_hostname(first_host)
       end
+
+      # Extracts the host parameter from the first RFC 7239 Forwarded element.
+      # Delimiters inside quoted strings do not split elements or parameters.
+      # Malformed quoted strings fail closed so the next header in the
+      # precedence list can be considered.
+      def forwarded_host(value_unsafe)
+        first_element = split_quoted_header(value_unsafe.to_s, ',').first
+        return nil if first_element.nil?
+
+        split_quoted_header(first_element, ';').each do |pair|
+          name, raw_value = pair.split('=', 2)
+          next unless name&.strip&.casecmp?('host')
+
+          return decode_forwarded_value(raw_value)
+        end
+
+        nil
+      end
+
+      def split_quoted_header(value, delimiter)
+        parts   = []
+        current = +''
+        quoted  = false
+        escaped = false
+
+        value.each_char do |character|
+          if escaped
+            current << character
+            escaped = false
+          elsif quoted && character == '\\'
+            current << character
+            escaped = true
+          elsif character == '"'
+            current << character
+            quoted = !quoted
+          elsif character == delimiter && !quoted
+            parts << current
+            current = +''
+          else
+            current << character
+          end
+        end
+
+        return [] if quoted || escaped
+
+        parts << current
+      end
+
+      def decode_forwarded_value(raw_value)
+        value = raw_value.to_s.strip
+        return nil if value.empty?
+        return value unless value.start_with?('"')
+        return nil unless value.length >= 2 && value.end_with?('"')
+
+        value[1...-1].gsub(/\\(.)/m, '\\1')
+      end
+
+      private :forwarded_host, :split_quoted_header, :decode_forwarded_value
 
       # Determines if a string is a valid host for use in this application.
       #

--- a/try/integration/middleware/detect_host_try.rb
+++ b/try/integration/middleware/detect_host_try.rb
@@ -84,6 +84,56 @@ env = { 'REMOTE_ADDR' => '192.168.1.1', 'HTTP_X_FORWARDED_HOST' => 'first.com, s
 env['rack.detected_host']
 #=> 'first.com'
 
+## Extracts host from the first RFC 7239 Forwarded element
+env = {
+  'REMOTE_ADDR' => '192.168.1.1',
+  'HTTP_FORWARDED' => 'for=203.0.113.7;host=forwarded.example.com;proto=https',
+  'HTTP_HOST' => 'fallback.example.com',
+}
+@middleware.call(env)
+env['rack.detected_host']
+#=> 'forwarded.example.com'
+
+## Handles a quoted RFC 7239 host value and strips its port
+env = {
+  'REMOTE_ADDR' => '192.168.1.1',
+  'HTTP_FORWARDED' => 'for=203.0.113.7;host="Forwarded.Example.COM:8443";proto=https',
+  'HTTP_HOST' => 'fallback.example.com',
+}
+@middleware.call(env)
+env['rack.detected_host']
+#=> 'forwarded.example.com'
+
+## Honors only the first Forwarded element, without splitting on quoted commas
+env = {
+  'REMOTE_ADDR' => '192.168.1.1',
+  'HTTP_FORWARDED' => 'for="client,alias";host=first.example.com, for=203.0.113.8;host=second.example.com',
+  'HTTP_HOST' => 'fallback.example.com',
+}
+@middleware.call(env)
+env['rack.detected_host']
+#=> 'first.example.com'
+
+## Falls back when the first Forwarded element has no host parameter
+env = {
+  'REMOTE_ADDR' => '192.168.1.1',
+  'HTTP_FORWARDED' => 'for=203.0.113.7;proto=https, for=203.0.113.8;host=second.example.com',
+  'HTTP_HOST' => 'fallback.example.com',
+}
+@middleware.call(env)
+env['rack.detected_host']
+#=> 'fallback.example.com'
+
+## A malformed quoted Forwarded value fails closed and falls back to Host
+env = {
+  'REMOTE_ADDR' => '192.168.1.1',
+  'HTTP_FORWARDED' => 'for=203.0.113.7;host="unterminated.example.com',
+  'HTTP_HOST' => 'fallback.example.com',
+}
+@middleware.call(env)
+env['rack.detected_host']
+#=> 'fallback.example.com'
+
 ## Handles missing headers gracefully
 env    = {}
 @middleware.call(env)


### PR DESCRIPTION
## Summary

[#4040](https://github.com/onetimesecret/onetimesecret/issues/4040)

- extract the `host=` parameter from the first RFC 7239 `Forwarded` element
- support quoted host values, escaped quoted strings, ports, and quoted delimiters
- fail closed on malformed values and continue to the next host header
- add regression coverage and a changelog fragment

## Related Issues

Fixes #4040

## Test Plan

- `tests/lanes/run unit` — 7,415 Tryouts passed; all RSpec unit groups passed with zero failures
- `bundle exec rubocop lib/middleware/detect_host.rb try/integration/middleware/detect_host_try.rb`
- exercised unquoted, quoted-with-port, multi-element, missing-host, and malformed-quote cases
