### PR TITLE
Harden RFC 7239 Forwarded host parsing and hostname validation

### DIFF
--- a/changelog.d/20260808_190000_claude_4040_forwarded_host_hardening.rst
+++ b/changelog.d/20260808_190000_claude_4040_forwarded_host_hardening.rst
@@ -9,9 +9,6 @@ Changed
   escapes, DoS bounds — delegate; don't reimplement. Earliest
   ``host=`` wins, matching the ``X-Forwarded-Host`` first-value
   convention. (#4040)
-- IIS original-URL headers (``X-Original-URL``, ``X-Rewrite-URL``)
-  join the trust-gated precedence list; only absolute-URL values can
-  contribute a host. (#4040)
 - Detected hosts must pass ``DomainParser.basically_valid?`` —
   extract, then validate, the same gate ``DomainStrategy`` already
   applies. (#4040)
@@ -21,8 +18,8 @@ Fixed
 
 - ``DomainParser.extract_hostname`` now unwraps bracketed IPv6 literals
   (``[2001:db8::1]:8080`` → ``2001:db8::1``) instead of mangling them by
-  splitting on the first colon, and returns nil for malformed bracket
-  expressions. (#4040)
+  splitting on the first colon. Bracket contents must parse as IPv6 —
+  malformed or counterfeit literals (``[dead.beef]``) return nil. (#4040)
 
 AI Assistance
 -------------

--- a/changelog.d/20260808_190000_claude_4040_forwarded_host_hardening.rst
+++ b/changelog.d/20260808_190000_claude_4040_forwarded_host_hardening.rst
@@ -8,6 +8,10 @@ Changed
   parser with denial-of-service bounds. The earliest ``host=`` parameter
   in the header wins, mirroring the first-value convention already used
   for ``X-Forwarded-Host``. (#4040)
+- ``Rack::DetectHost`` now also consults the IIS-family original-URL
+  headers (``X-Original-URL``, ``X-Rewrite-URL``) in its trust-gated
+  precedence list; a host is extracted only when the value is an
+  absolute URL — the usual path-only form falls through. (#4040)
 - ``Rack::DetectHost`` rejects detected hosts that fail
   ``DomainParser.basically_valid?``, so header values containing control
   characters, quotes, or other non-hostname junk can no longer become

--- a/changelog.d/20260808_190000_claude_4040_forwarded_host_hardening.rst
+++ b/changelog.d/20260808_190000_claude_4040_forwarded_host_hardening.rst
@@ -1,0 +1,28 @@
+.. A new scriv changelog fragment.
+
+Changed
+-------
+
+- ``Rack::DetectHost`` now delegates RFC 7239 ``Forwarded`` parsing to
+  ``Rack::Utils.forwarded_values``, Rack's hardened quoted-string-aware
+  parser with denial-of-service bounds. The earliest ``host=`` parameter
+  in the header wins, mirroring the first-value convention already used
+  for ``X-Forwarded-Host``. (#4040)
+- ``Rack::DetectHost`` rejects detected hosts that fail
+  ``DomainParser.basically_valid?``, so header values containing control
+  characters, quotes, or other non-hostname junk can no longer become
+  the detected host. (#4040)
+
+Fixed
+-----
+
+- ``DomainParser.extract_hostname`` now unwraps bracketed IPv6 literals
+  (``[2001:db8::1]:8080`` → ``2001:db8::1``) instead of mangling them by
+  splitting on the first colon, and returns nil for malformed bracket
+  expressions. (#4040)
+
+AI Assistance
+-------------
+
+- Claude reviewed #4053, then implemented the Rack delegation, hostname
+  validation gate, and IPv6 literal handling with regression tests. (#4040)

--- a/changelog.d/20260808_190000_claude_4040_forwarded_host_hardening.rst
+++ b/changelog.d/20260808_190000_claude_4040_forwarded_host_hardening.rst
@@ -3,19 +3,18 @@
 Changed
 -------
 
-- ``Rack::DetectHost`` now delegates RFC 7239 ``Forwarded`` parsing to
-  ``Rack::Utils.forwarded_values``, Rack's hardened quoted-string-aware
-  parser with denial-of-service bounds. The earliest ``host=`` parameter
-  in the header wins, mirroring the first-value convention already used
-  for ``X-Forwarded-Host``. (#4040)
-- ``Rack::DetectHost`` now also consults the IIS-family original-URL
-  headers (``X-Original-URL``, ``X-Rewrite-URL``) in its trust-gated
-  precedence list; a host is extracted only when the value is an
-  absolute URL — the usual path-only form falls through. (#4040)
-- ``Rack::DetectHost`` rejects detected hosts that fail
-  ``DomainParser.basically_valid?``, so header values containing control
-  characters, quotes, or other non-hostname junk can no longer become
-  the detected host. (#4040)
+- ``Rack::DetectHost`` parses ``Forwarded`` via
+  ``Rack::Utils.forwarded_values`` instead of a hand-rolled scanner.
+  When the framework already ships a hardened parser — quoting,
+  escapes, DoS bounds — delegate; don't reimplement. Earliest
+  ``host=`` wins, matching the ``X-Forwarded-Host`` first-value
+  convention. (#4040)
+- IIS original-URL headers (``X-Original-URL``, ``X-Rewrite-URL``)
+  join the trust-gated precedence list; only absolute-URL values can
+  contribute a host. (#4040)
+- Detected hosts must pass ``DomainParser.basically_valid?`` —
+  extract, then validate, the same gate ``DomainStrategy`` already
+  applies. (#4040)
 
 Fixed
 -----

--- a/lib/middleware/detect_host.rb
+++ b/lib/middleware/detect_host.rb
@@ -4,6 +4,7 @@
 
 require 'ipaddr'
 require 'otto/env_keys'
+require 'rack/utils'
 require_relative 'logging'
 
 module Rack
@@ -29,12 +30,16 @@ module Rack
   # to accurately determine the host for proper URL generation, redirection,
   # and processing in multi-tenant applications.
   #
-  # This middleware prioritizes host detection in the following order:
+  # This middleware prioritizes host detection in the following order
+  # (mirroring HEADER_PRECEDENCE below):
   #
   # 1. `X-Forwarded-Host` - Commonly used by proxies and load balancers.
-  # 2. `X-Original-Host` - Used by various proxy services.
-  # 3. `Forwarded` - The standard header as per RFC 7239.
-  # 4. `Host` - Default HTTP host header.
+  # 2. `Apx-Incoming-Host` - Approximated.app custom-domain ingress.
+  # 3. `X-Original-Host` - Used by various proxy services.
+  # 4. `Forwarded` - RFC 7239 standard; the first `host=` parameter is
+  #    extracted (via `Rack::Utils.forwarded_values`), with quoted values
+  #    and ports handled per the RFC.
+  # 5. `Host` - Default HTTP host header.
   #
   # It also includes validation to filter out invalid or local hosts (e.g.,
   # `localhost`, `127.0.0.1`) and IP addresses, ensuring only legitimate
@@ -306,7 +311,7 @@ module Rack
       #
       # This method:
       # - Takes the first host if multiple are provided (comma-separated)
-      # - Extracts the host parameter from the first RFC 7239 Forwarded element
+      # - Extracts the first host parameter from RFC 7239 Forwarded values
       # - Delegates to DomainParser for port stripping and normalization
       # - Returns nil for empty values
       def normalize_host(value_unsafe, forwarded: false)
@@ -321,63 +326,25 @@ module Rack
         Onetime::Utils::DomainParser.extract_hostname(first_host)
       end
 
-      # Extracts the host parameter from the first RFC 7239 Forwarded element.
-      # Delimiters inside quoted strings do not split elements or parameters.
-      # Malformed quoted strings fail closed so the next header in the
-      # precedence list can be considered.
+      # Extracts the first host parameter from an RFC 7239 Forwarded value.
+      #
+      # Parsing is delegated to Rack::Utils.forwarded_values, which handles
+      # quoted strings and escape sequences, bounds parameter and escape
+      # counts against denial of service, and fails closed (nil) on
+      # malformed input or unknown parameter names — letting the next header
+      # in the precedence list be considered. Element boundaries are
+      # flattened: the earliest host parameter anywhere in the header wins,
+      # mirroring the first-value convention used for X-Forwarded-Host.
       def forwarded_host(value_unsafe)
-        first_element = split_quoted_header(value_unsafe.to_s, ',').first
-        return nil if first_element.nil?
-
-        split_quoted_header(first_element, ';').each do |pair|
-          name, raw_value = pair.split('=', 2)
-          next unless name&.strip&.casecmp?('host')
-
-          return decode_forwarded_value(raw_value)
+        case Rack::Utils.forwarded_values(value_unsafe)
+        in { host: [first_host, *] }
+          first_host
+        else
+          nil
         end
-
-        nil
       end
 
-      def split_quoted_header(value, delimiter)
-        parts   = []
-        current = +''
-        quoted  = false
-        escaped = false
-
-        value.each_char do |character|
-          if escaped
-            current << character
-            escaped = false
-          elsif quoted && character == '\\'
-            current << character
-            escaped = true
-          elsif character == '"'
-            current << character
-            quoted = !quoted
-          elsif character == delimiter && !quoted
-            parts << current
-            current = +''
-          else
-            current << character
-          end
-        end
-
-        return [] if quoted || escaped
-
-        parts << current
-      end
-
-      def decode_forwarded_value(raw_value)
-        value = raw_value.to_s.strip
-        return nil if value.empty?
-        return value unless value.start_with?('"')
-        return nil unless value.length >= 2 && value.end_with?('"')
-
-        value[1...-1].gsub(/\\(.)/m, '\\1')
-      end
-
-      private :forwarded_host, :split_quoted_header, :decode_forwarded_value
+      private :forwarded_host
 
       # Determines if a string is a valid host for use in this application.
       #
@@ -385,12 +352,16 @@ module Rack
       # @return [Boolean] true if the host is a valid domain name
       #
       # Note: This method intentionally rejects IP addresses as we require
-      # domain names for our application's routing logic.
+      # domain names for our application's routing logic. It also requires
+      # DomainParser.basically_valid? (RFC 952/1123 charset, label and
+      # length limits) so header junk that survives extraction — control
+      # characters, quotes, semicolons — can never become the detected
+      # host. DomainStrategy applies the same gate after extraction.
       def valid_domain_name?(host)
         return false if INVALID_HOSTS.include?(host)
         return false if valid_ip?(host)
 
-        true
+        Onetime::Utils::DomainParser.basically_valid?(host)
       end
 
       # Determines if a string represents a private IP address.

--- a/lib/middleware/detect_host.rb
+++ b/lib/middleware/detect_host.rb
@@ -36,14 +36,10 @@ module Rack
   # 1. `X-Forwarded-Host` - Commonly used by proxies and load balancers.
   # 2. `Apx-Incoming-Host` - Approximated.app custom-domain ingress.
   # 3. `X-Original-Host` - Used by various proxy services.
-  # 4. `X-Original-URL` - IIS/ARR original URL; host extracted only when
-  #    the value is an absolute URL (IIS normally sends path + query only,
-  #    which fails hostname validation and falls through).
-  # 5. `X-Rewrite-URL` - IIS URL Rewrite pre-rewrite URL; same caveat.
-  # 6. `Forwarded` - RFC 7239 standard; the first `host=` parameter is
+  # 4. `Forwarded` - RFC 7239 standard; the first `host=` parameter is
   #    extracted (via `Rack::Utils.forwarded_values`), with quoted values
   #    and ports handled per the RFC.
-  # 7. `Host` - Default HTTP host header.
+  # 5. `Host` - Default HTTP host header.
   #
   # It also includes validation to filter out invalid or local hosts (e.g.,
   # `localhost`, `127.0.0.1`) and IP addresses, ensuring only legitimate
@@ -120,16 +116,20 @@ module Rack
       # otto's tri-state key grants it (otto.via_trusted_proxy == true) or,
       # with the key absent (no proxy trust configured), when REMOTE_ADDR is
       # a private/loopback address — see the trust decision in #call.
-      # X-Forwarded-Server is deliberately absent: it typically names the
-      # proxy's own hostname, not the client-requested host. Scheme-only
-      # headers (X-Forwarded-Proto, CF-Visitor, ...) don't belong here
-      # either — this middleware detects hosts, not schemes.
+      # Every header listed here is an implicit contract with the proxy
+      # tier: the trusted-proxy gate assumes the proxy overwrites or strips
+      # it, so an entry the proxy doesn't manage becomes a client spoofing
+      # vector THROUGH trusted infra (the example Caddyfile pins
+      # X-Original-Host but would pass an unlisted header untouched). That
+      # is why the IIS originals (X-Original-URL, X-Rewrite-URL) and
+      # X-Forwarded-Server (names the proxy itself) are absent — add a
+      # header only together with proxy-config guidance that sanitizes it.
+      # Scheme-only headers (X-Forwarded-Proto, CF-Visitor, ...) don't
+      # belong here either: this middleware detects hosts, not schemes.
       FORWARDED_HEADERS = [
         'X-Forwarded-Host',   # Common proxy header (AWS ALB, nginx)
         'Apx-Incoming-Host',  # Approximated-specific (approximated.app custom-domain ingress); like all forwarded headers, only honored behind trusted infra
         'X-Original-Host',    # Various proxy services
-        'X-Original-URL',     # IIS/ARR original URL; contributes a host only in absolute-URI form — path-only values fail hostname validation and fall through
-        'X-Rewrite-URL',      # IIS URL Rewrite pre-rewrite URL; same absolute-URI caveat as X-Original-URL
         'Forwarded',          # RFC 7239 standard (host parameter)
       ].freeze
 

--- a/lib/middleware/detect_host.rb
+++ b/lib/middleware/detect_host.rb
@@ -36,10 +36,14 @@ module Rack
   # 1. `X-Forwarded-Host` - Commonly used by proxies and load balancers.
   # 2. `Apx-Incoming-Host` - Approximated.app custom-domain ingress.
   # 3. `X-Original-Host` - Used by various proxy services.
-  # 4. `Forwarded` - RFC 7239 standard; the first `host=` parameter is
+  # 4. `X-Original-URL` - IIS/ARR original URL; host extracted only when
+  #    the value is an absolute URL (IIS normally sends path + query only,
+  #    which fails hostname validation and falls through).
+  # 5. `X-Rewrite-URL` - IIS URL Rewrite pre-rewrite URL; same caveat.
+  # 6. `Forwarded` - RFC 7239 standard; the first `host=` parameter is
   #    extracted (via `Rack::Utils.forwarded_values`), with quoted values
   #    and ports handled per the RFC.
-  # 5. `Host` - Default HTTP host header.
+  # 7. `Host` - Default HTTP host header.
   #
   # It also includes validation to filter out invalid or local hosts (e.g.,
   # `localhost`, `127.0.0.1`) and IP addresses, ensuring only legitimate
@@ -116,10 +120,16 @@ module Rack
       # otto's tri-state key grants it (otto.via_trusted_proxy == true) or,
       # with the key absent (no proxy trust configured), when REMOTE_ADDR is
       # a private/loopback address — see the trust decision in #call.
+      # X-Forwarded-Server is deliberately absent: it typically names the
+      # proxy's own hostname, not the client-requested host. Scheme-only
+      # headers (X-Forwarded-Proto, CF-Visitor, ...) don't belong here
+      # either — this middleware detects hosts, not schemes.
       FORWARDED_HEADERS = [
         'X-Forwarded-Host',   # Common proxy header (AWS ALB, nginx)
         'Apx-Incoming-Host',  # Approximated-specific (approximated.app custom-domain ingress); like all forwarded headers, only honored behind trusted infra
         'X-Original-Host',    # Various proxy services
+        'X-Original-URL',     # IIS/ARR original URL; contributes a host only in absolute-URI form — path-only values fail hostname validation and fall through
+        'X-Rewrite-URL',      # IIS URL Rewrite pre-rewrite URL; same absolute-URI caveat as X-Original-URL
         'Forwarded',          # RFC 7239 standard (host parameter)
       ].freeze
 

--- a/lib/onetime/utils/domain_parser.rb
+++ b/lib/onetime/utils/domain_parser.rb
@@ -61,6 +61,7 @@ module Onetime
         # @example
         #   extract_hostname('https://Example.COM:443/path') # => 'example.com'
         #   extract_hostname('Example.COM:8080')            # => 'example.com'
+        #   extract_hostname('[2001:db8::1]:8080')          # => '2001:db8::1'
         #   extract_hostname(URI('https://foo.bar'))        # => 'foo.bar'
         #   extract_hostname(nil)                           # => nil
         #
@@ -69,7 +70,9 @@ module Onetime
 
           host = case input
                  when URI
-                   input.host
+                   # #hostname (not #host) so bracketed IPv6 literals come back
+                   # as the bare address ("::1" rather than "[::1]")
+                   input.hostname
                  when String
                    extract_from_string(input)
                  else
@@ -241,11 +244,21 @@ module Onetime
           str = str.to_s.strip
           return nil if str.empty?
 
+          # Bracketed IPv6 literal per RFC 3986 §3.2.2, optionally with a
+          # port (e.g. "[2001:db8::1]:8080"). Splitting these on ':' like a
+          # hostname:port pair would mangle them into garbage like "[2001",
+          # so extract the address inside the brackets; anything bracketed
+          # but malformed yields nil rather than a mangled host.
+          if str.start_with?('[')
+            match = str.match(/\A\[([0-9a-fA-F:.]+)\](?::\d+)?\z/)
+            return match && match[1]
+          end
+
           # If it looks like a URL, only extract via URI parsing - don't guess
           if str.include?('://')
             begin
               uri  = URI.parse(str)
-              host = uri.host
+              host = uri.hostname
 
               # For file:// URLs, treat "localhost" (any case) as local machine
               # Ruby's URI::File is case-sensitive but RFC 8089 treats localhost specially

--- a/lib/onetime/utils/domain_parser.rb
+++ b/lib/onetime/utils/domain_parser.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'concurrent/map'
+require 'ipaddr'
 require 'public_suffix'
 require 'uri'
 
@@ -244,14 +245,22 @@ module Onetime
           str = str.to_s.strip
           return nil if str.empty?
 
-          # Bracketed IPv6 literal per RFC 3986 §3.2.2, optionally with a
+          # Bracketed IP literal per RFC 3986 §3.2.2, optionally with a
           # port (e.g. "[2001:db8::1]:8080"). Splitting these on ':' like a
           # hostname:port pair would mangle them into garbage like "[2001",
-          # so extract the address inside the brackets; anything bracketed
-          # but malformed yields nil rather than a mangled host.
+          # so extract the address inside the brackets. Brackets are
+          # reserved for IPv6 literals, so the content must parse as one —
+          # anything else ("[dead.beef]", "[1.2.3.4]", unbalanced brackets)
+          # yields nil rather than a counterfeit hostname.
           if str.start_with?('[')
-            match = str.match(/\A\[([0-9a-fA-F:.]+)\](?::\d+)?\z/)
-            return match && match[1]
+            match = str.match(/\A\[([^\]]+)\](?::\d+)?\z/)
+            return nil unless match
+
+            begin
+              return IPAddr.new(match[1]).ipv6? ? match[1] : nil
+            rescue IPAddr::InvalidAddressError
+              return nil
+            end
           end
 
           # If it looks like a URL, only extract via URI parsing - don't guess

--- a/try/integration/middleware/detect_host_try.rb
+++ b/try/integration/middleware/detect_host_try.rb
@@ -156,6 +156,57 @@ env = {
 env['rack.detected_host']
 #=> 'fallback.example.com'
 
+## X-Original-URL (IIS/ARR) contributes a host when it carries an absolute URL
+env = {
+  'REMOTE_ADDR' => '192.168.1.1',
+  'HTTP_X_ORIGINAL_URL' => 'https://original.example.com/admin?tab=1',
+  'HTTP_HOST' => 'fallback.example.com',
+}
+@middleware.call(env)
+env['rack.detected_host']
+#=> 'original.example.com'
+
+## X-Original-URL with the usual IIS path-only form falls through
+env = {
+  'REMOTE_ADDR' => '192.168.1.1',
+  'HTTP_X_ORIGINAL_URL' => '/admin?tab=1',
+  'HTTP_HOST' => 'fallback.example.com',
+}
+@middleware.call(env)
+env['rack.detected_host']
+#=> 'fallback.example.com'
+
+## X-Rewrite-URL (IIS URL Rewrite) contributes a host from an absolute URL
+env = {
+  'REMOTE_ADDR' => '192.168.1.1',
+  'HTTP_X_REWRITE_URL' => 'https://rewrite.example.com/page',
+  'HTTP_HOST' => 'fallback.example.com',
+}
+@middleware.call(env)
+env['rack.detected_host']
+#=> 'rewrite.example.com'
+
+## X-Original-Host takes precedence over X-Original-URL
+env = {
+  'REMOTE_ADDR' => '192.168.1.1',
+  'HTTP_X_ORIGINAL_HOST' => 'orig-host.example.com',
+  'HTTP_X_ORIGINAL_URL' => 'https://orig-url.example.com/page',
+  'HTTP_HOST' => 'fallback.example.com',
+}
+@middleware.call(env)
+env['rack.detected_host']
+#=> 'orig-host.example.com'
+
+## IIS URL headers are ignored from untrusted sources like other forwarded headers
+env = {
+  'REMOTE_ADDR' => '203.0.113.99',
+  'HTTP_X_ORIGINAL_URL' => 'https://spoofed.example.com/page',
+  'HTTP_HOST' => 'fallback.example.com',
+}
+@middleware.call(env)
+env['rack.detected_host']
+#=> 'fallback.example.com'
+
 ## Header junk in X-Forwarded-Host (invalid hostname characters) is rejected
 env = {
   'REMOTE_ADDR' => '192.168.1.1',

--- a/try/integration/middleware/detect_host_try.rb
+++ b/try/integration/middleware/detect_host_try.rb
@@ -156,51 +156,13 @@ env = {
 env['rack.detected_host']
 #=> 'fallback.example.com'
 
-## X-Original-URL (IIS/ARR) contributes a host when it carries an absolute URL
+## Headers outside FORWARDED_HEADERS (e.g. IIS X-Original-URL) are never
+## consulted, even from a trusted source — proxies aren't expected to
+## sanitize headers this middleware doesn't list
 env = {
   'REMOTE_ADDR' => '192.168.1.1',
-  'HTTP_X_ORIGINAL_URL' => 'https://original.example.com/admin?tab=1',
-  'HTTP_HOST' => 'fallback.example.com',
-}
-@middleware.call(env)
-env['rack.detected_host']
-#=> 'original.example.com'
-
-## X-Original-URL with the usual IIS path-only form falls through
-env = {
-  'REMOTE_ADDR' => '192.168.1.1',
-  'HTTP_X_ORIGINAL_URL' => '/admin?tab=1',
-  'HTTP_HOST' => 'fallback.example.com',
-}
-@middleware.call(env)
-env['rack.detected_host']
-#=> 'fallback.example.com'
-
-## X-Rewrite-URL (IIS URL Rewrite) contributes a host from an absolute URL
-env = {
-  'REMOTE_ADDR' => '192.168.1.1',
-  'HTTP_X_REWRITE_URL' => 'https://rewrite.example.com/page',
-  'HTTP_HOST' => 'fallback.example.com',
-}
-@middleware.call(env)
-env['rack.detected_host']
-#=> 'rewrite.example.com'
-
-## X-Original-Host takes precedence over X-Original-URL
-env = {
-  'REMOTE_ADDR' => '192.168.1.1',
-  'HTTP_X_ORIGINAL_HOST' => 'orig-host.example.com',
-  'HTTP_X_ORIGINAL_URL' => 'https://orig-url.example.com/page',
-  'HTTP_HOST' => 'fallback.example.com',
-}
-@middleware.call(env)
-env['rack.detected_host']
-#=> 'orig-host.example.com'
-
-## IIS URL headers are ignored from untrusted sources like other forwarded headers
-env = {
-  'REMOTE_ADDR' => '203.0.113.99',
   'HTTP_X_ORIGINAL_URL' => 'https://spoofed.example.com/page',
+  'HTTP_X_REWRITE_URL' => 'https://spoofed.example.com/page',
   'HTTP_HOST' => 'fallback.example.com',
 }
 @middleware.call(env)

--- a/try/integration/middleware/detect_host_try.rb
+++ b/try/integration/middleware/detect_host_try.rb
@@ -114,10 +114,62 @@ env = {
 env['rack.detected_host']
 #=> 'first.example.com'
 
-## Falls back when the first Forwarded element has no host parameter
+## Uses the earliest host parameter when the first element lacks one,
+## mirroring Rack::Utils.forwarded_values and the X-Forwarded-Host
+## first-value convention
 env = {
   'REMOTE_ADDR' => '192.168.1.1',
   'HTTP_FORWARDED' => 'for=203.0.113.7;proto=https, for=203.0.113.8;host=second.example.com',
+  'HTTP_HOST' => 'fallback.example.com',
+}
+@middleware.call(env)
+env['rack.detected_host']
+#=> 'second.example.com'
+
+## Falls back when no Forwarded element carries a host parameter
+env = {
+  'REMOTE_ADDR' => '192.168.1.1',
+  'HTTP_FORWARDED' => 'for=203.0.113.7;proto=https, for=203.0.113.8;proto=https',
+  'HTTP_HOST' => 'fallback.example.com',
+}
+@middleware.call(env)
+env['rack.detected_host']
+#=> 'fallback.example.com'
+
+## A non-RFC bare hostname in Forwarded is not a host parameter; falls back
+env = {
+  'REMOTE_ADDR' => '192.168.1.1',
+  'HTTP_FORWARDED' => 'legacy.example.com',
+  'HTTP_HOST' => 'fallback.example.com',
+}
+@middleware.call(env)
+env['rack.detected_host']
+#=> 'fallback.example.com'
+
+## A bracketed IPv6 Forwarded host is rejected (domain names required)
+env = {
+  'REMOTE_ADDR' => '192.168.1.1',
+  'HTTP_FORWARDED' => 'for=203.0.113.7;host="[2001:db8::1]:8443"',
+  'HTTP_HOST' => 'fallback.example.com',
+}
+@middleware.call(env)
+env['rack.detected_host']
+#=> 'fallback.example.com'
+
+## Header junk in X-Forwarded-Host (invalid hostname characters) is rejected
+env = {
+  'REMOTE_ADDR' => '192.168.1.1',
+  'HTTP_X_FORWARDED_HOST' => 'semi;colon.example.com',
+  'HTTP_HOST' => 'fallback.example.com',
+}
+@middleware.call(env)
+env['rack.detected_host']
+#=> 'fallback.example.com'
+
+## A bracketed IPv6 X-Forwarded-Host no longer yields a mangled host
+env = {
+  'REMOTE_ADDR' => '192.168.1.1',
+  'HTTP_X_FORWARDED_HOST' => '[2001:db8::1]:8080',
   'HTTP_HOST' => 'fallback.example.com',
 }
 @middleware.call(env)

--- a/try/unit/utils/domain_parser_try.rb
+++ b/try/unit/utils/domain_parser_try.rb
@@ -42,6 +42,22 @@ Onetime::Utils::DomainParser.extract_hostname('example.com:443')
 Onetime::Utils::DomainParser.extract_hostname('example.com:8080')
 #=> 'example.com'
 
+## Extract hostname unwraps a bracketed IPv6 literal
+Onetime::Utils::DomainParser.extract_hostname('[2001:db8::1]')
+#=> '2001:db8::1'
+
+## Extract hostname unwraps a bracketed IPv6 literal and strips the port
+Onetime::Utils::DomainParser.extract_hostname('[2001:db8::1]:8080')
+#=> '2001:db8::1'
+
+## Extract hostname rejects a malformed bracketed literal instead of mangling it
+Onetime::Utils::DomainParser.extract_hostname('[2001:db8::1')
+#=> nil
+
+## Extract hostname unwraps brackets in an https URL with IPv6 host
+Onetime::Utils::DomainParser.extract_hostname('https://[2001:db8::1]:8443/path')
+#=> '2001:db8::1'
+
 ## Extract hostname from https URL
 Onetime::Utils::DomainParser.extract_hostname('https://example.com/path')
 #=> 'example.com'

--- a/try/unit/utils/domain_parser_try.rb
+++ b/try/unit/utils/domain_parser_try.rb
@@ -54,6 +54,14 @@ Onetime::Utils::DomainParser.extract_hostname('[2001:db8::1]:8080')
 Onetime::Utils::DomainParser.extract_hostname('[2001:db8::1')
 #=> nil
 
+## Brackets are IPv6-only: hex-and-dot junk is not a hostname
+Onetime::Utils::DomainParser.extract_hostname('[dead.beef]')
+#=> nil
+
+## Brackets are IPv6-only: bracketed IPv4 is invalid syntax
+Onetime::Utils::DomainParser.extract_hostname('[1.2.3.4]')
+#=> nil
+
 ## Extract hostname unwraps brackets in an https URL with IPv6 host
 Onetime::Utils::DomainParser.extract_hostname('https://[2001:db8::1]:8443/path')
 #=> '2001:db8::1'


### PR DESCRIPTION
## Summary

[#4040](https://github.com/onetimesecret/onetimesecret/issues/4040)

Builds on #4053 (its commit is included, preserving @XX-Q's authorship) and addresses the follow-ups from its review:

- Replace the hand-rolled quoted-string scanner with `Rack::Utils.forwarded_values` — Rack 3.2's hardened RFC 7239 parser (quoted strings, escapes, DoS bounds on parameter/escape counts, fails closed on malformed input) — deconstructed with Ruby pattern matching (`case/in`).
- Gate `DetectHost.valid_domain_name?` on `DomainParser.basically_valid?` so header junk (control characters, quotes, semicolons, null bytes) can never become the detected host. This is the same post-extraction gate `DomainStrategy` already applies.
- Fix `DomainParser.extract_hostname` for bracketed IPv6 literals: `[2001:db8::1]:8080` now yields `2001:db8::1` instead of the mangled `[2001`. Bracket contents must parse as IPv6 (`IPAddr`), so malformed or counterfeit literals (`[dead.beef]`, `[1.2.3.4]`) return nil. URI inputs use `URI#hostname` for the same unbracketing.
- Document the `FORWARDED_HEADERS` contract: every listed header must be sanitized by the proxy tier, so IIS `X-Original-URL`/`X-Rewrite-URL` (briefly added, then removed per review — the example Caddyfile doesn't sanitize them) and `X-Forwarded-Server` are deliberately excluded, with a regression tryout asserting unlisted headers are never consulted.
- Update the `DetectHost` class doc precedence list per #4040 (adds `Apx-Incoming-Host`, documents `host=` parsing).

One deliberate semantic change vs #4053: Rack's parser flattens element boundaries, so when the first `Forwarded` element lacks `host=` but a later one carries it, the earliest `host=` anywhere in the header is used (instead of falling back to the `Host` header). This mirrors the first-value convention already used for `X-Forwarded-Host`.

## Related Issues

Closes #4040
Supersedes/extends #4053

## Test Plan

- `try/integration/middleware/detect_host_try.rb` — 30 pass, including new coverage: earliest-host selection, no-host fallback, bare non-RFC hostname, bracketed IPv6 rejection (Forwarded and X-Forwarded-Host), invalid-character rejection, unlisted-header regression
- `try/unit/utils/domain_parser_try.rb` — 6 new bracketed-literal extraction cases (file's `OT.boot!` setup requires Ruby 3.4; cases verified directly on this container's 3.3)
- `detect_host_instances_try.rb`, `detect_host_ip_privacy_stack_try.rb`, `domain_strategy/chooserator_try.rb` all pass
- Adversarial probe of hostile inputs (CRLF, null bytes, unterminated quotes, quoted delimiters, bracketed junk like `[dead.beef]`) — every detected host is either a clean RFC-valid hostname or the request falls back to the next header
- `rubocop` on changed files: no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ToJV4iGDPxB1dAZEc95mYE