### PR TITLE
fix(ui): gate Activity entry points on ORGS_AUDIT_LOGS_ENABLED

### DIFF
--- a/src/apps/workspace/components/navigation/OrganizationContextBar.vue
+++ b/src/apps/workspace/components/navigation/OrganizationContextBar.vue
@@ -22,7 +22,7 @@ import DomainContextSwitcher from '@/apps/workspace/components/navigation/Domain
 import OrganizationScopeSwitcher from '@/apps/workspace/components/navigation/OrganizationScopeSwitcher.vue';
 import { useOrganizationStore } from '@/shared/stores/organizationStore';
 import { useScopeSwitcherVisibility } from '@/shared/composables/useScopeSwitcherVisibility';
-import { isOrganizationSwitcherEnabled } from '@/utils/features';
+import { isOrganizationSwitcherEnabled, isOrgsAuditLogsEnabled } from '@/utils/features';
 import { computed, onMounted, ref } from 'vue';
 import { RouterLink } from 'vue-router';
 import { useI18n } from 'vue-i18n';
@@ -72,13 +72,17 @@ const orgSettingsPath = computed(() => {
   return `/org/${org.extid}`;
 });
 
-// Explicit deep link to the org audit trail. The tab is entitlement-proof (an
-// unentitled org lands on it and sees the upgrade notice rather than being
-// redirected), so this is gated on role alone — the same owner/admin gate the
-// /org/:extid route itself enforces. Suppressed where the route hides org
-// scope entirely.
+// Explicit deep link to the org audit trail. Gated on the owner/admin role the
+// /org/:extid route enforces (via orgSettingsPath), on the instance flag —
+// ORGS_AUDIT_LOGS_ENABLED=false removes the Activity tab entirely, so the link
+// would dead-end on the Domains panel — and suppressed where the route hides
+// org scope. The audit_logs ENTITLEMENT is deliberately not a gate: the tab is
+// entitlement-proof (an unentitled org lands on it and sees the upgrade notice
+// rather than being redirected). Mirrors OrganizationSettings.vue.
 const orgActivityPath = computed(() =>
-  visibility.value.organization !== 'hide' && orgSettingsPath.value
+  visibility.value.organization !== 'hide' &&
+  orgSettingsPath.value &&
+  isOrgsAuditLogsEnabled()
     ? `${orgSettingsPath.value}/activity`
     : null
 );

--- a/src/shared/components/navigation/UserMenu.vue
+++ b/src/shared/components/navigation/UserMenu.vue
@@ -35,6 +35,7 @@ import { usePreviewPlanMode } from '@/shared/composables/usePreviewPlanMode';
 import { useScopeSwitcherVisibility } from '@/shared/composables/useScopeSwitcherVisibility';
 import { type Customer } from '@/schemas/shapes/v3';
 import { ENTITLEMENTS } from '@/types/organization';
+import { isOrgsAuditLogsEnabled } from '@/utils/features';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { useProductIdentity } from '@/shared/stores/identityStore';
 import { useOrganizationStore } from '@/shared/stores/organizationStore';
@@ -99,12 +100,19 @@ const userRole = computed(() =>
 // Org extid for display/copy (useful for support and testing)
 const orgExtid = computed(() => currentOrganization.value?.extid || null);
 
-// Deep link to the active org's audit trail. The tab is entitlement-proof (an
-// unentitled org lands on it and sees an upgrade notice instead of being
-// redirected), so the only gate is the owner/admin role the /org/:extid route
-// itself requires.
+// Deep link to the active org's audit trail. Two gates on different axes:
+//  - the owner/admin role the /org/:extid route itself requires;
+//  - the instance flag (ORGS_AUDIT_LOGS_ENABLED=false removes the Activity tab
+//    entirely, so the link would dead-end on the Domains panel).
+// The audit_logs ENTITLEMENT is deliberately not a gate: the tab is
+// entitlement-proof — an unentitled org lands on it and sees an upgrade notice
+// instead of being redirected. Mirrors OrganizationSettings.vue.
+const auditLogsFeatureEnabled = computed(() => isOrgsAuditLogsEnabled());
+
 const orgActivityPath = computed(() =>
-  orgExtid.value ? `/org/${orgExtid.value}/activity` : null
+  orgExtid.value && auditLogsFeatureEnabled.value
+    ? `/org/${orgExtid.value}/activity`
+    : null
 );
 
 // Only restrict members on custom domains — admins see the full menu like owners.

--- a/src/tests/apps/workspace/components/OrganizationContextBar.spec.ts
+++ b/src/tests/apps/workspace/components/OrganizationContextBar.spec.ts
@@ -46,9 +46,13 @@ vi.mock('@/shared/composables/useScopeSwitcherVisibility', () => ({
 }));
 
 // Enable the org switcher feature flag so the static-org-name fallback path
-// (gated on isOrganizationSwitcherEnabled) can be exercised.
+// (gated on isOrganizationSwitcherEnabled) can be exercised. The audit-logs
+// flag is default-ON (ORGS_AUDIT_LOGS_ENABLED=false is the only way off), so
+// the mock ref starts true and the Activity-link tests flip it.
+const mockAuditLogsEnabled = ref(true);
 vi.mock('@/utils/features', () => ({
   isOrganizationSwitcherEnabled: () => true,
+  isOrgsAuditLogsEnabled: () => mockAuditLogsEnabled.value,
 }));
 
 // Mock axios
@@ -83,6 +87,7 @@ describe('OrganizationContextBar', () => {
     mockLockDomainSwitcher.value = false;
     mockIsSoloDefaultContext.value = false;
     mockVisibility.value = { organization: 'show', domain: 'hide' };
+    mockAuditLogsEnabled.value = true;
   });
 
   afterEach(() => {
@@ -245,6 +250,24 @@ describe('OrganizationContextBar', () => {
 
     it('is hidden when the route hides org scope', async () => {
       mockVisibility.value = { organization: 'hide', domain: 'show' };
+
+      wrapper = mountComponent({
+        organizations: [ownerOrg],
+        currentOrganization: ownerOrg,
+        isListFetched: true,
+      });
+
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="org-context-activity"]').exists()).toBe(false);
+    });
+
+    // Instance-flag axis, distinct from role and from the audit_logs
+    // entitlement: with ORGS_AUDIT_LOGS_ENABLED=false the Activity tab does not
+    // exist, so the entry point must not either — otherwise an owner clicks
+    // through and lands silently on the Domains panel.
+    it('is hidden when the instance audit-logs flag is off', async () => {
+      mockAuditLogsEnabled.value = false;
 
       wrapper = mountComponent({
         organizations: [ownerOrg],

--- a/src/tests/shared/components/navigation/UserMenu.spec.ts
+++ b/src/tests/shared/components/navigation/UserMenu.spec.ts
@@ -128,6 +128,15 @@ vi.mock('@/shared/composables/useScopeSwitcherVisibility', () => ({
   }),
 }));
 
+// Instance-level audit-logs flag (ORGS_AUDIT_LOGS_ENABLED). Default-ON, so the
+// ref starts true; the Activity tests flip it. Spreads the real module so the
+// other feature helpers this component graph reaches keep their behaviour.
+const mockAuditLogsEnabled = ref(true);
+vi.mock('@/utils/features', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils/features')>()),
+  isOrgsAuditLogsEnabled: () => mockAuditLogsEnabled.value,
+}));
+
 // Mock product identity store state (mutable for per-test customization)
 // The component uses storeToRefs(useProductIdentity()), so isCustom must be
 // a ref for storeToRefs to extract it properly.
@@ -159,6 +168,7 @@ describe('UserMenu', () => {
     mockCurrentOrganizationRef.value = null;
     mockIsCustomRef.value = false;
     mockIsSoloDefaultContext.value = false;
+    mockAuditLogsEnabled.value = true;
   });
 
   afterEach(() => {
@@ -430,6 +440,20 @@ describe('UserMenu', () => {
       mockCurrentOrganizationRef.value = { current_user_role: 'owner', extid: 'org_abc' };
 
       wrapper = mountComponent({ awaitingMfa: true });
+      await openMenu();
+
+      expect(wrapper.find('a[href="/org/org_abc/activity"]').exists()).toBe(false);
+    });
+
+    // Instance-flag axis, distinct from role and from the audit_logs
+    // entitlement: with ORGS_AUDIT_LOGS_ENABLED=false the Activity tab does not
+    // exist, so the menu entry must not either — otherwise an owner clicks
+    // through and lands silently on the Domains panel.
+    it('is hidden when the instance audit-logs flag is off', async () => {
+      mockCurrentOrganizationRef.value = { current_user_role: 'owner', extid: 'org_abc' };
+      mockAuditLogsEnabled.value = false;
+
+      wrapper = mountComponent();
       await openMenu();
 
       expect(wrapper.find('a[href="/org/org_abc/activity"]').exists()).toBe(false);


### PR DESCRIPTION
Closes #4057

## Summary

- The Activity entry points added in 810ac7d37f (UserMenu item, OrganizationContextBar inline link) gated on the owner/admin **role** only. With `ORGS_AUDIT_LOGS_ENABLED=false` the tab they point at does not exist, so owners were offered a link that silently lands on the Domains panel — and on a fresh load the URL keeps reading `/activity`, because `checkInitialTabRedirect()` is guarded on `activeTab === 'activity'` and never fires to correct it.
- Both components now also gate on `isOrgsAuditLogsEnabled()`, matching the three gates `OrganizationSettings.vue` already applies (`:128`, `:253`, `:723`).
- Comments in both name all three axes — role / instance flag / entitlement — and state why the entitlement is deliberately *not* a gate. The original comment said only "gates on role only" with no reason, which is what let the flag slip through.

The entitlement axis is unchanged and still deliberately ungated: the tab is entitlement-proof, so an unentitled org lands on it and sees the upgrade notice rather than being redirected. The instance flag is the opposite — it removes the tab entirely.

## Behaviour

| State | Before | After |
|---|---|---|
| Flag on, owner/admin | link shown | link shown |
| Flag on, member | hidden | hidden |
| Flag off, owner/admin | **link shown → dead end** | hidden |
| Key absent (older backend) | link shown | link shown |

Default-ON is preserved — `isOrgsAuditLogsEnabled()` is `!== false`, so only an explicit `false` hides the links. `src/tests/utils/features.spec.ts:837-854` already covers all three absent-key shapes.

No data exposure either way: `list_secret_activity.rb:69` independently returns 403 on the flag, comparing `.to_s == 'false'` so a hand-edited string config disables both surfaces. This is UI coherence only.

## Test plan

- [x] `pnpm vitest run` on both spec files — 57 pass
- [x] `pnpm vue-tsc --noEmit` clean
- [x] New case in each spec asserting the link is absent when the flag is off; the existing owner/admin cases pin the flag-on side
- [x] Manual: boot with `ORGS_AUDIT_LOGS_ENABLED=false`, confirm Activity is absent from the user menu, the context bar, and the org settings tab bar
- [x] Manual: boot with the flag unset, confirm all three still appear for an owner

### Note on the specs

The ContextBar's `@/utils/features` mock is a **full** module replacement that exported only `isOrganizationSwitcherEnabled`; it needed `isOrgsAuditLogsEnabled` added or the new import would resolve `undefined` at runtime. UserMenu previously had no features mock at all, so it uses a partial mock spreading `importOriginal` to leave the rest of the module's behaviour intact.

## Follow-up (not in this PR)

`auditLogsFeatureEnabled` in UserMenu is a `computed()` wrapping a non-reactive module read (`bootstrapSnapshot` is a plain variable — `bootstrap.service.ts:87`), so it has no reactive dependencies and caches after first evaluation. Harmless today since the flag is fixed at boot, and it matches the existing `OrganizationSettings.vue:253` pattern, but it reads as reactive without being so. ContextBar calls the function inline instead, where the enclosing computed's other deps happen to keep it fresh. Worth unifying — a plain `const` in both would be honest about what it is.
