### PR TITLE
feat(branding): render tenant logo_dark_url on branded + disabled surfaces

### DIFF
--- a/src/apps/secret/components/branded/BrandedHero.vue
+++ b/src/apps/secret/components/branded/BrandedHero.vue
@@ -44,7 +44,14 @@
          so a broken or absent logo leaves the branded page text-only with no
          generic placeholder (empty fallback slot). The tenant's dark variant
          (logoDarkSource → BrandSettings.logo_dark_url) swaps in under the
-         site's class-based dark mode, matching MastHead. -->
+         site's class-based dark mode, matching MastHead.
+
+         The logo→heading gap (mb-8) rides on the image itself (via imgClass),
+         not this wrapper: the wrapper is gated on logoUri (non-null), which
+         stays true when the asset 404s, so putting the margin here would leave
+         a phantom 2rem gap above the heading once BrandMark falls back to its
+         empty slot. On the image, the spacing collapses with the image — the
+         same reason IncomingForm carries its spacing in imgClass. -->
     <!--
       Sizing: a fixed height with `w-auto max-w-full` lets wide, rectangular
       logos (common when they include the company name) use the full column
@@ -58,7 +65,7 @@
     -->
     <div
       v-if="logoUri"
-      class="mb-8 flex justify-center">
+      class="flex justify-center">
       <!-- One BrandMark, conditionally wrapped: forked link/bare copies of the
            logo markup drift independently (only one branch gets a fix). -->
       <component
@@ -68,7 +75,7 @@
           :logo-uri="logoUri"
           :logo-dark-uri="logoDarkSource"
           :alt="displayName"
-          :img-class="[cornerClass, 'h-16 w-auto max-w-full object-contain sm:h-20']"
+          :img-class="[cornerClass, 'mb-8 h-16 w-auto max-w-full object-contain sm:h-20']"
           data-testid="brand-logo" />
       </component>
     </div>

--- a/src/apps/secret/components/branded/BrandedHero.vue
+++ b/src/apps/secret/components/branded/BrandedHero.vue
@@ -20,9 +20,9 @@
    * @prop subtitle - Subline text (already translated); omit for logo-only
    * @prop logoLinkTo - When set, wraps the logo in a router-link to this route
    */
+  import BrandMark from '@/shared/components/logos/BrandMark.vue';
   import { useProductIdentity } from '@/shared/stores/identityStore';
   import { storeToRefs } from 'pinia';
-  import { ref } from 'vue';
   import { RouterLink } from 'vue-router';
 
   defineProps<{
@@ -32,22 +32,19 @@
   }>();
 
   const identityStore = useProductIdentity();
-  const { logoUri, displayName, cornerClass, headingFontClass, fontFamilyClass } =
+  const { logoUri, logoDarkSource, displayName, cornerClass, headingFontClass, fontFamilyClass } =
     storeToRefs(identityStore);
-
-  // Handle logo 404 errors gracefully
-  const imageError = ref(false);
-  const handleImageError = () => {
-    imageError.value = true;
-  };
 </script>
 
 <template>
   <div
     :class="fontFamilyClass"
     class="text-center">
-    <!-- Logo with error handling - hides if 404. No placeholder: a broken or
-         absent logo must not render a generic gray icon on a branded page. -->
+    <!-- Logo via BrandMark: renders the light/dark pair and owns 404 handling,
+         so a broken or absent logo leaves the branded page text-only with no
+         generic placeholder (empty fallback slot). The tenant's dark variant
+         (logoDarkSource → BrandSettings.logo_dark_url) swaps in under the
+         site's class-based dark mode, matching MastHead. -->
     <!--
       Sizing: a fixed height with `w-auto max-w-full` lets wide, rectangular
       logos (common when they include the company name) use the full column
@@ -60,20 +57,19 @@
       overflowing.
     -->
     <div
-      v-if="logoUri && !imageError"
+      v-if="logoUri"
       class="mb-8 flex justify-center">
-      <!-- One <img>, conditionally wrapped: forked link/bare copies of the
+      <!-- One BrandMark, conditionally wrapped: forked link/bare copies of the
            logo markup drift independently (only one branch gets a fix). -->
       <component
         :is="logoLinkTo ? RouterLink : 'span'"
         :to="logoLinkTo">
-        <img
-          :src="logoUri"
-          :class="cornerClass"
-          class="h-16 w-auto max-w-full object-contain sm:h-20"
+        <BrandMark
+          :logo-uri="logoUri"
+          :logo-dark-uri="logoDarkSource"
           :alt="displayName"
-          data-testid="brand-logo"
-          @error="handleImageError" />
+          :img-class="[cornerClass, 'h-16 w-auto max-w-full object-contain sm:h-20']"
+          data-testid="brand-logo" />
       </component>
     </div>
     <h1

--- a/src/apps/secret/conceal/IncomingForm.vue
+++ b/src/apps/secret/conceal/IncomingForm.vue
@@ -8,6 +8,7 @@
   import { useProductIdentity } from '@/shared/stores/identityStore';
   import IncomingSecretFormBody from '@/apps/secret/components/incoming/IncomingSecretFormBody.vue';
   import LoadingOverlay from '@/shared/components/common/LoadingOverlay.vue';
+  import BrandMark from '@/shared/components/logos/BrandMark.vue';
   import EmptyState from '@/shared/components/ui/EmptyState.vue';
   import { useI18n } from 'vue-i18n';
 
@@ -17,13 +18,11 @@
 
   // Custom-domain brand logo. The top masthead is suppressed on custom domains
   // (see guards.routes.ts), so the page body owns the logo — mirroring
-  // BrandedHomepage. Hidden when no logo is configured or the asset 404s, so
-  // the no-logo page stays title + subtitle + form with no placeholder box.
-  const { logoUri, displayName } = storeToRefs(useProductIdentity());
-  const logoError = ref(false);
-  const handleLogoError = () => {
-    logoError.value = true;
-  };
+  // BrandedHomepage. BrandMark hides it when no logo is configured or the asset
+  // 404s, so the no-logo page stays title + subtitle + form with no placeholder
+  // box, and swaps in the tenant's dark variant (logoDarkSource →
+  // BrandSettings.logo_dark_url) under the site's class-based dark mode.
+  const { logoUri, logoDarkSource, displayName } = storeToRefs(useProductIdentity());
 
   const isLoading = ref(true);
 
@@ -75,13 +74,14 @@
     <template v-else>
       <!-- Header -->
       <div class="mb-10">
-        <!-- Brand logo (custom domains) — hidden if unconfigured or 404s -->
-        <img
-          v-if="logoUri && !logoError"
-          :src="logoUri"
+        <!-- Brand logo (custom domains) — light/dark pair via BrandMark,
+             hidden if unconfigured or 404s -->
+        <BrandMark
+          v-if="logoUri"
+          :logo-uri="logoUri"
+          :logo-dark-uri="logoDarkSource"
           :alt="displayName"
-          class="mb-6 h-16 max-w-[200px] object-contain"
-          @error="handleLogoError" />
+          img-class="mb-6 h-16 max-w-[200px] object-contain" />
         <h1 class="text-3xl font-bold text-gray-900 dark:text-white sm:text-4xl">
           {{ t('incoming.page_title') }}
         </h1>

--- a/src/apps/secret/views/disabled/useDisabledConfig.ts
+++ b/src/apps/secret/views/disabled/useDisabledConfig.ts
@@ -91,11 +91,14 @@ export interface DisabledHomepageProps {
    */
   logoUri: string | null;
   /**
-   * Dark-theme variant of the install logo (brand.logo_dark_url). Non-null
-   * only while the install logo is the asset being rendered (the store nulls
-   * it when a tenant logo outranks it or no light install logo exists).
-   * Variants swap it in via class-based `dark:` utilities, mirroring
-   * MastHead.
+   * Dark-theme logo on the identity axis (logoDarkSource): the tenant's
+   * BrandSettings.logo_dark_url when the tenant logo is showing, else the
+   * operator's install BRAND_LOGO_DARK_URL when the install logo is showing.
+   * Each rung nulls itself against the other layer's light logo, so the dark
+   * asset always pairs with whichever light logo `logoUri` resolved — never
+   * the operator's dark variant over a tenant logo, or vice versa. Null when
+   * no dark variant applies. Variants swap it in via class-based `dark:`
+   * utilities, mirroring MastHead.
    */
   logoDarkUri: string | null;
   /**
@@ -234,7 +237,7 @@ export function useDisabledConfig(): DisabledHomepageBindings {
     primaryColor,
     logoUri,
     installLogoUri,
-    installLogoDarkUri,
+    logoDarkSource,
     installLogoAlt,
     displayName,
     displayDomain,
@@ -383,8 +386,12 @@ export function useDisabledConfig(): DisabledHomepageBindings {
     get logoUri() {
       return logoUri.value || installLogoUri.value;
     },
+    // Dark variant on the same identity axis (logoDarkSource): tenant dark when
+    // the tenant logo shows, else install dark when the install logo shows —
+    // mirroring MastHead so a tenant's logo_dark_url renders on the disabled
+    // homepage too, not just the operator's install dark logo.
     get logoDarkUri() {
-      return installLogoDarkUri.value;
+      return logoDarkSource.value;
     },
     get logoAlt() {
       return installLogoAlt.value;

--- a/src/tests/apps/secret/components/branded/BrandedHero.spec.ts
+++ b/src/tests/apps/secret/components/branded/BrandedHero.spec.ts
@@ -161,6 +161,21 @@ describe('BrandedHero logo', () => {
     expect(wrapper.find('svg').exists()).toBe(false);
   });
 
+  it('carries the logo→heading gap on the image, so a 404 leaves no phantom spacing', async () => {
+    wrapper = mountHero();
+    await nextTick();
+
+    // The mb-8 gap rides on the image, not the surviving logoUri-gated wrapper.
+    expect(wrapper.find('img').classes()).toContain('mb-8');
+
+    await wrapper.find('img').trigger('error');
+
+    // The image (and its margin) are gone; nothing keeps a 2rem gap above the
+    // heading. The wrapper survives (logoUri is still non-null) but is empty.
+    expect(wrapper.find('img').exists()).toBe(false);
+    expect(wrapper.find('.mb-8').exists()).toBe(false);
+  });
+
   it('wraps the logo in a router-link only when logoLinkTo is passed', async () => {
     wrapper = mountHero({ logoLinkTo: '/' });
     await nextTick();

--- a/src/tests/apps/secret/components/branded/BrandedHero.spec.ts
+++ b/src/tests/apps/secret/components/branded/BrandedHero.spec.ts
@@ -179,6 +179,49 @@ describe('BrandedHero logo', () => {
   });
 });
 
+describe('BrandedHero dark logo variant', () => {
+  let wrapper: VueWrapper;
+
+  afterEach(() => {
+    if (wrapper) wrapper.unmount();
+  });
+
+  // The tenant's BrandSettings.logo_dark_url reaches the hero through the
+  // identity resolver's logoDarkSource and BrandMark's class-based dark swap —
+  // the same seam MastHead uses.
+  it('renders the tenant dark logo (BrandMark dark swap) when configured', async () => {
+    wrapper = mountHero(
+      {},
+      {
+        domain_branding: {
+          description: 'Acme Corp',
+          primary_color: '#36454F',
+          logo_dark_url: 'https://cdn.example/acme-logo-dark.png',
+        },
+      }
+    );
+    await nextTick();
+
+    const dark = wrapper.find('[data-testid="logo-dark"]');
+    expect(dark.exists()).toBe(true);
+    expect(dark.attributes('src')).toBe('https://cdn.example/acme-logo-dark.png');
+    expect(dark.classes()).toContain('hidden');
+    expect(dark.classes()).toContain('dark:block');
+    // The light logo is swapped out in dark mode.
+    expect(wrapper.find('[data-testid="brand-logo"]').classes()).toContain('dark:hidden');
+  });
+
+  it('renders only the light logo when no dark variant is configured', async () => {
+    wrapper = mountHero();
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="logo-dark"]').exists()).toBe(false);
+    expect(wrapper.findAll('img')).toHaveLength(1);
+    // The lone light logo carries no dark:hidden — nothing to swap to.
+    expect(wrapper.find('[data-testid="brand-logo"]').classes()).not.toContain('dark:hidden');
+  });
+});
+
 describe('BrandedHero logo-only', () => {
   let wrapper: VueWrapper;
 

--- a/src/tests/apps/secret/conceal/IncomingForm.spec.ts
+++ b/src/tests/apps/secret/conceal/IncomingForm.spec.ts
@@ -57,10 +57,18 @@ import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import IncomingForm from '@/apps/secret/conceal/IncomingForm.vue';
 
 const LOGO_URL = 'https://cdn.example.com/imagine/ext123/logo.png';
+const DARK_LOGO_URL = 'https://cdn.example.com/imagine/ext123/logo-dark.png';
 
-async function mountIncoming(domainLogo: string | null) {
+async function mountIncoming(
+  domainLogo: string | null,
+  domainBranding: Record<string, unknown> | null = null
+) {
   const bootstrap = useBootstrapStore();
-  bootstrap.$patch({ domain_strategy: 'custom', domain_logo: domainLogo });
+  bootstrap.$patch({
+    domain_strategy: 'custom',
+    domain_logo: domainLogo,
+    domain_branding: domainBranding,
+  });
   const wrapper = mount(IncomingForm, {
     global: { plugins: [createTestI18n()] },
   });
@@ -99,5 +107,22 @@ describe('IncomingForm custom-domain header', () => {
     expect(wrapper.find('img').exists()).toBe(false);
     // Title still renders — the no-logo page is title + subtitle + form.
     expect(wrapper.findAll('h1')).toHaveLength(1);
+  });
+
+  it('renders the tenant dark logo variant (BrandMark dark swap) when configured', async () => {
+    const wrapper = await mountIncoming(LOGO_URL, { logo_dark_url: DARK_LOGO_URL });
+
+    const dark = wrapper.find('[data-testid="logo-dark"]');
+    expect(dark.exists()).toBe(true);
+    expect(dark.attributes('src')).toBe(DARK_LOGO_URL);
+    // The light logo is swapped out in dark mode via BrandMark.
+    expect(wrapper.findAll('img')[0].classes()).toContain('dark:hidden');
+  });
+
+  it('renders only the light logo when no dark variant is configured', async () => {
+    const wrapper = await mountIncoming(LOGO_URL);
+
+    expect(wrapper.find('[data-testid="logo-dark"]').exists()).toBe(false);
+    expect(wrapper.findAll('img')).toHaveLength(1);
   });
 });

--- a/src/tests/apps/secret/views/useDisabledConfig.spec.ts
+++ b/src/tests/apps/secret/views/useDisabledConfig.spec.ts
@@ -76,6 +76,10 @@ interface SetupOptions {
   /** Tenant-uploaded logo URL (bootstrap.domain_logo — the backend-computed
    *  /imagine URL identityStore surfaces as logoUri). */
   tenantLogo?: string | null;
+  /** Tenant dark-theme logo (BrandSettings.logo_dark_url on the identity
+   *  brand). Pairs with the tenant logo on the identity axis. Requires
+   *  brandDescription so the parsed brand object exists. */
+  tenantLogoDark?: string | null;
   /** Install-wide light logo (brand.logo_url → bootstrap.brand_logo_url). */
   installLogoUrl?: string | null;
   /** Install-wide dark-theme logo (brand.logo_dark_url). */
@@ -187,6 +191,7 @@ function setup(opts: SetupOptions = {}) {
               font_family: opts.fontFamily ?? 'sans',
               heading_font: opts.headingFont ?? null,
               border_radius: opts.borderRadius ?? null,
+              logo_dark_url: opts.tenantLogoDark ?? null,
               instructions_pre_reveal: '',
               instructions_post_reveal: '',
               instructions_reveal: '',
@@ -703,9 +708,25 @@ describe('useDisabledConfig', () => {
         installLogoAlt: 'Acme Corp',
       });
       expect(config.props.logoUri).toBe(tenant);
-      // Install-only companions must not leak onto a tenant logo.
+      // The install dark logo/alt must not leak onto a tenant logo. With no
+      // tenant dark URL set, the identity-axis dark source resolves to null.
       expect(config.props.logoDarkUri).toBeNull();
       expect(config.props.logoAlt).toBeNull();
+    });
+
+    it('renders the tenant dark logo when the tenant logo is showing', () => {
+      const tenantDark = 'https://cdn.example.com/imagine/tenant-dark.png';
+      const { config } = setup({
+        domainStrategy: 'custom',
+        brandDescription: 'Acme Corp',
+        tenantLogo: tenant,
+        tenantLogoDark: tenantDark,
+        // Install dark is also set to prove the tenant rung wins the axis.
+        installLogoUrl: install,
+        installLogoDarkUrl: installDark,
+      });
+      expect(config.props.logoUri).toBe(tenant);
+      expect(config.props.logoDarkUri).toBe(tenantDark);
     });
 
     it('falls back to the install logo on canonical when no tenant logo', () => {


### PR DESCRIPTION
## Summary

[#3954](https://github.com/onetimesecret/onetimesecret/issues/3954)

The masthead already consumes the identity resolver's `logoDarkSource` for the tenant/install dark-logo swap (landed in `ba8dac7`), but the remaining tenant-logo surfaces still ignored a per-domain `BrandSettings.logo_dark_url` — so a tenant's dark-theme logo was silently never shown outside the header. This picks up the two follow-up surface groups the issue named ("DefaultLogo-adjacent surfaces and disabled-homepage views").

**Changes**

- **Disabled-homepage views** (`useDisabledConfig.ts`): the `logoDarkUri` prop resolved the install-only `installLogoDarkUri`; it now consumes `logoDarkSource`, so a tenant dark logo swaps in through `BrandMark` (the `DisabledMinimal` / `DisabledV1` variants already bind `logoDarkUri`). One-line source swap — no variant markup changed.
- **`BrandedHero`** (branded homepage / reveal opener / `BrandedMastHead`) and **`IncomingForm`** (custom-domain `/incoming` header): these rendered a bare tenant `<img>` with no dark variant. Both now route the tenant logo through the shared **`BrandMark`** component consuming `logoDarkSource`, gaining the class-based `dark:` swap and 404-graceful fallback through one seam instead of forked markup. Existing sizing, corner radius, alt text, `data-testid`, and the "no placeholder on a branded page" behavior are preserved.

**Guards / scope**

- Web UI only; emails continue to use the light `logo_url`.
- Each `logoDarkSource` rung nulls itself against the other layer's light logo, so the dark asset always pairs with whichever light logo resolved — the operator's dark variant never lands over a tenant logo, or vice versa.
- **Out of scope (noted follow-up):** `AuthView`/`Login`'s `titleLogo` on the custom-domain sign-in card is another tenant-logo surface, but it's a shared auth layout that would need a new dark-logo prop plumbed through it. Left for a maintainer decision rather than expanding this PR into that component.

## Related Issues

Refs #3954 <!-- intentionally not auto-closing: the AuthView/Login sign-in surface remains -->

## Test Plan

- Extended unit coverage and ran the affected suites (162 + 55 tests green):
  - `useDisabledConfig.spec.ts` — new case: tenant dark logo wins the identity axis over the install dark logo; existing install-only cases still pass unchanged.
  - `BrandedHero.spec.ts` — new cases: renders the `logo-dark` swap when `logo_dark_url` is configured (light gets `dark:hidden`); light-only when absent. Existing sizing / alt / 404-hide / router-link cases still pass through `BrandMark`.
  - `IncomingForm.spec.ts` — new cases: dark swap when configured; light-only when absent.
  - Re-ran `identityStore.spec.ts`, `MastHead.spec.ts`, `BrandedMastHead.spec.ts`, `DisabledVariantsLogo.spec.ts` — all green.
- `pnpm run type-check` — clean.
- ESLint (repo gate, errors-only, non-test) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtPzJnHEJgd5cZFh5sB8WP)_