### PR TITLE
Block bad writes on the i18n translation path: tasks update --strict, tasks audit, export gating

### DIFF
--- a/locales/AGENT_TRANSLATION_PROTOCOL.md
+++ b/locales/AGENT_TRANSLATION_PROTOCOL.md
@@ -96,22 +96,25 @@ Loop this until the queue is dry:
    file, not inline JSON: apostrophes and quotes (common in fr/es/it) break
    shell single-quoting and HEREDOCs.
 
-4. **Save it back** with validation:
+4. **Save it back** with the write gate:
    ```bash
-   python3 locales/scripts/i18n tasks update <ID> --file /tmp/trans_<LOCALE>.json --validate
+   python3 locales/scripts/i18n tasks update <ID> --file /tmp/trans_<LOCALE>.json --validate --strict
    ```
 
-5. **Read the output.** `--validate` is **advisory**: it warns on missing/extra
-   keys but still saves and still exits 0 — it does **not** block a bad write. On
-   any `Warning:` line (e.g. "Missing keys" / "Extra keys"), rebuild the object
-   with the exact source key set and re-run the update. A completed row's key set
-   must match the source exactly.
+5. **Check the exit status.** `--strict` makes the key-set check a **gate**: on
+   any missing or extra key the command prints the mismatch, writes **nothing**
+   to the DB, and exits 1. A non-zero exit means the task is still pending —
+   rebuild `/tmp/trans_<LOCALE>.json` with the exact source key set and re-run
+   step 4 until it exits 0. Do not move on to the next task on a failed write.
+   (Bare `--validate` without `--strict` only warns and saves anyway; always
+   pass both.)
 
 6. **Loop** back to step 1. Continue until:
    ```bash
    python3 locales/scripts/i18n tasks next <LOCALE> --stats
    ```
-   shows `pending: 0`.
+   shows `pending: 0`. That ends the loop, not the job — go to
+   [Audit stage](#audit-stage-after-a-locale-drains).
 
 ## Translation rules
 
@@ -125,20 +128,49 @@ Loop this until the queue is dry:
 
 ## Audit stage (after a locale drains)
 
-Because `--validate` does not gate writes, the queue showing 0 pending does not
-prove the writes are clean. After a locale drains, audit its completed rows for:
+An empty queue is not a clean locale: `pending: 0` says every row left the
+queue, not that what it wrote is correct. **A drained locale is done only when
+the audit exits 0.** Run it on the completed rows in the DB, before any export:
 
-- **key-set match** — each completed row's keys equal the source keys exactly.
-- **token preservation** — every `{var}`, `{{var}}`, `%{var}`, `%s`, `<tag>`
-  from the source survives in the translation, with the same set and count.
-- **untranslated-English leakage** — values left in English where a translation
-  was expected.
-
-Fix any problem in place by rewriting `/tmp/trans_<LOCALE>.json` with the
-corrected object and re-running:
 ```bash
-python3 locales/scripts/i18n tasks update <ID> --file /tmp/trans_<LOCALE>.json --validate
+python3 locales/scripts/i18n tasks audit <LOCALE> --strict
 ```
+
+`--strict` exits 1 on any **error** finding, and also when zero completed rows
+could be checked — a gate that verified nothing must not read green. Without
+`--strict` the audit is advisory and exits 0. Each finding names the task ID,
+key, severity, and which check failed:
+
+- **status** (error) — no row left in `in_progress`. A claimed-then-abandoned
+  row is counted separately from `pending`, so it makes the locale *look*
+  drained while its keys never export. Release it with
+  `tasks update <ID> --status pending` and translate it.
+- **key-set match** (error) — each completed row's keys equal the source keys
+  exactly, and none of the values is blank. A whitespace "translation" passes a
+  naive key comparison but `tasks export` skips it, so the key would stay
+  English forever.
+- **token preservation** (error) — every `{var}`, `{{var}}`, `%{var}`, `%s`,
+  `<tag>` from the source survives in the translation, with the same set and
+  count. Compared **per plural form**: the number of `|`-separated forms is a
+  property of your language (en 2, ja 1, ru 3) and is never itself a finding.
+- **untranslated-English leakage** (**advisory** — reported, never gates) —
+  values left byte-identical to the English source. Treat it as a review list,
+  not a task list: an identical string is the *correct* answer for many short
+  labels ("Status", "TTL", "Redis", "Amazon SES", "Canada"). Never invent a
+  wrong translation to silence it. Brand names that must stay English (Onetime
+  Secret, Identity Plus, Starlight), empty sources, `skip` keys, and strings
+  with no letters (numbers, punctuation, bare placeholders) are already
+  excluded.
+
+Fix each **error** finding in place: rewrite `/tmp/trans_<LOCALE>.json` with the
+corrected object for that task ID and re-run
+```bash
+python3 locales/scripts/i18n tasks update <ID> --file /tmp/trans_<LOCALE>.json --validate --strict
+```
+then re-run the audit. Loop until it exits 0. `export-all.sh` runs the same
+`--strict` audit as its export gate, so a locale you leave with error findings
+is not exported at all. Advisory findings do not block the export; report the
+ones you believe are genuine leaks alongside your glossary candidates.
 
 ## Glossary candidates (report, don't write)
 
@@ -171,4 +203,5 @@ Do **not** export (`tasks export`), do **not** sync (`pnpm run locales:sync` /
 `content compile`), do **not** commit or create branches, and do **not** write
 the glossary/committable DB tables. Those are human/orchestrator steps
 documented in `TRANSLATION_PROTOCOL.md`. The agent's job ends when the locale
-shows `pending: 0`, the audit is clean, and the glossary candidates are reported.
+shows `pending: 0`, `tasks audit <LOCALE> --strict` exits 0, and the glossary
+candidates are reported.

--- a/locales/BATCH_OPERATIONS.md
+++ b/locales/BATCH_OPERATIONS.md
@@ -6,30 +6,63 @@
 
 Pipeline order (each step assumes the previous one ran):
 
-1. **Export** — drained DB -> `locales/content/` + shared tables via `export-all.sh`
-   (dry-run by default). Exports every locale with `pending: 0`, skips the rest, then
-   runs `i18n db export` once. Leaves uncommitted changes in the working tree;
-   everything below operates on those. See [README.md](README.md) step 4.
+1. **Export** — drained *and audit-clean* DB -> `locales/content/` + shared tables via
+   `export-all.sh` (dry-run by default). Exports a locale only when `pending: 0` **and**
+   `tasks audit <locale> --strict` is clean, skips the rest, then runs `i18n db export`
+   once. Leaves uncommitted changes in the working tree; everything below operates on
+   those. **It exits non-zero when any locale failed the audit, failed to export, or
+   landed dirty** — read the summary before moving on to step 2, because the set of
+   changed locales is then smaller than the set you asked for.
+   See [README.md](README.md) step 4.
 2. **Create branches** — one `i18n/update-<locale>` branch per changed locale (below).
 3. **Open PRs** — one PR per branch (below).
 4. **Rebase / respond to feedback / merge back** — the original sections that follow.
 
-### Exporting drained locales
+### Exporting drained and clean locales
 
-`export-all.sh` writes each fully drained locale's DB translations into `locales/content/`, then
-runs `i18n db export` once. Skips any locale with `pending > 0`. Dry-run is the default — pass
+`export-all.sh` writes each drained *and clean* locale's DB translations into
+`locales/content/`, then runs `i18n db export` once. Dry-run is the default — pass
 `--execute` to act.
 
+Two gates, both must pass, both reported per locale:
+
+- **drained** — skips any locale with `pending > 0`.
+- **audit-clean** — `i18n tasks audit <locale> --strict` must exit 0: no stranded
+  `in_progress` row, no key-set or blank-translation defect, no lost interpolation
+  token, and at least one completed row actually checked. `pending: 0` alone proves
+  only that the rows left the queue, not that what they wrote is correct. The audit's
+  `en_leak` check is advisory and never blocks an export.
+
+After a successful export the written content is re-checked in place with
+`validate variables` and (when the derived governance cache exists) the register lint.
+Failures are reported as **dirty**; nothing is reverted, because surfacing the problem
+while the content is still unstaged is the point.
+
 ```bash
-# preview: which locales are drained, what it would export
+# preview: which locales are drained + clean, what it would export
 locales/scripts/export-all.sh
 
-# do it: export every drained locale + shared db tables (once)
+# do it: export every gated locale + shared db tables (once)
 locales/scripts/export-all.sh --execute
 
 # or a specific subset
 locales/scripts/export-all.sh --execute de es fr_FR
 ```
+
+**Exit status is part of the output.** Non-zero means at least one locale failed the
+audit, failed to export, or landed dirty — the summary names each set:
+
+```
+Done: 27 locale(s) exported, 1 skipped, 1 failed audit, 0 failed export, 1 dirty
+Not drained (skipped): pl
+Failed audit (not exported): ja
+Exported but dirty (fix the content, it is unstaged): ru
+```
+
+A locale that is merely not drained is a normal state and does not affect the exit
+status. Fix audit findings with `tasks update <ID> --file ... --validate --strict`,
+re-audit, and re-run the export before continuing to **Creating the branches** —
+otherwise you will branch a locale set that silently omits the failures.
 
 Leaves uncommitted changes in the working tree for **Creating the branches** below.
 

--- a/locales/README.md
+++ b/locales/README.md
@@ -50,6 +50,7 @@ locales/scripts/review-locale-branches.sh validate         # deterministic check
 
 Two rules that bite:
 
+- **Export before you re-create.** `tasks create --apply` reopens a completed level that still has work, discarding its translations. That is free once the level was exported (the text is in `content/`), and refused outright when it wasn't — exit 3, nothing written, offending levels named. Clear it with `tasks export <locale>` to keep the work or `--reopen` to discard it on purpose. `create-all.sh` reports blocked locales at the end and exits non-zero rather than aborting the batch.
 - **`0 pending` proves nothing — neither current nor clean.** A drained queue can hide stale keys (English changed after translation): trust the `--stats` coverage line (current/stale/missing/skipped), not the queue. It can also hide bad writes (wrong key set, dropped placeholder, English left in place): `python3 locales/scripts/i18n tasks audit <locale> --strict` is the cleanliness signal, and it's the gate `export-all.sh` enforces.
 - **Never hand-author hashes.** New en keys are bare `{"text": "..."}`; `locales:hashes:apply` does the rest.
 

--- a/locales/README.md
+++ b/locales/README.md
@@ -27,10 +27,18 @@ python3 locales/scripts/i18n db migrate
 #    translates, verifies; agents report glossary candidates, they don't write them)
 /i18n:translate-parallel-agents        # installed from locales/slash_commands/
 
-# 4. Export every fully drained locale, then the shared tables once
-locales/scripts/export-all.sh                              # preview (dry-run)
-locales/scripts/export-all.sh --execute                   # export drained locales + db export
-# Skips any locale with pending > 0; run per-locale manually if you need finer control:
+# 4. Export every drained AND clean locale, then the shared tables once
+locales/scripts/export-all.sh                              # preview (dry-run, still runs the audit gate)
+locales/scripts/export-all.sh --execute                   # export gated locales + db export
+# Gate: exports a locale only when pending == 0 AND `tasks audit <locale> --strict`
+# is clean (no stranded in_progress row, no key-set/blank/token defect, and at least
+# one completed row actually checked; the en-leak check is advisory and never gates).
+# After each export it re-checks the written content with
+# `validate variables --locale <locale>` plus the register lint (skipped when
+# .translation-rules/ or generated/i18n/.resolved/ is absent). Failing locales are
+# skipped or reported dirty, nothing is reverted, the loop still finishes every
+# locale, and the script exits non-zero. Per-locale, if you need finer control:
+#   python3 locales/scripts/i18n tasks audit <locale> --strict
 #   python3 locales/scripts/i18n tasks export <locale>
 #   python3 locales/scripts/i18n db export
 
@@ -42,7 +50,7 @@ locales/scripts/review-locale-branches.sh validate         # deterministic check
 
 Two rules that bite:
 
-- **`0 pending` ≠ current.** A drained queue can hide stale keys (English changed after translation). Trust the `--stats` coverage line (current/stale/missing/skipped), not the queue.
+- **`0 pending` proves nothing — neither current nor clean.** A drained queue can hide stale keys (English changed after translation): trust the `--stats` coverage line (current/stale/missing/skipped), not the queue. It can also hide bad writes (wrong key set, dropped placeholder, English left in place): `python3 locales/scripts/i18n tasks audit <locale> --strict` is the cleanliness signal, and it's the gate `export-all.sh` enforces.
 - **Never hand-author hashes.** New en keys are bare `{"text": "..."}`; `locales:hashes:apply` does the rest.
 
 ## Content format

--- a/locales/README.md
+++ b/locales/README.md
@@ -23,7 +23,7 @@ pnpm run locales:hashes:apply     # writes hashes + seeds watermarks
 python3 locales/scripts/i18n db init      # no-op if DB exists
 python3 locales/scripts/i18n db migrate
 
-# 3. Drain all locales with parallel agents (creates tasks --missing-only,
+# 3. Drain all locales with parallel agents (creates tasks — missing + stale only,
 #    translates, verifies; agents report glossary candidates, they don't write them)
 /i18n:translate-parallel-agents        # installed from locales/slash_commands/
 

--- a/locales/TRANSLATION_PROTOCOL.md
+++ b/locales/TRANSLATION_PROTOCOL.md
@@ -69,7 +69,19 @@ python3 locales/scripts/i18n tasks create eo --apply    # enqueue for real
 ```
 Without `--apply`, `create` is a preview: it prints what would be enqueued and writes nothing. This populates the `translation_tasks` table required by `tasks next`. Run once per locale, or re-run to refresh after English source changes — it enqueues only the keys that still need work: **missing** (untranslated) plus **stale** (translated, but en changed since: the target `source_hash` no longer matches en's `content_hash`), never re-touching still-current reviewed strings. A brand-new locale needs no flag: with no `content/<locale>` yet, every key is missing. `tasks next <locale> --stats` prints a `current/stale/missing` coverage block so you can see drift even before enqueuing it.
 
-Applying is not free on a populated DB: a completed level that still has work is **reopened** — status back to `pending`, its translations discarded. That is the point (a stranded completed row would never be re-served), but it means running `create --apply` between completing tasks and `tasks export` throws away the unexported work. Export first, then refresh the queue.
+Applying is not a no-op on a populated DB: a completed level that still has work is **reopened** — status back to `pending`, its translations discarded. That is the point (a stranded completed row would never be re-served), and it is free once the level has been exported, because the text is already in `locales/content/<locale>/`.
+
+When it would *not* be free, `create --apply` refuses. A completed level whose translations were never exported exists only inside `tasks.db`, so the run stops before writing anything, names the levels at risk, and exits **3**:
+
+```
+Error: Refusing to write: 2 completed levels hold translations for 'de' that were never exported.
+  auth.json:web.LABELS  (14 keys, completed 2026-08-08 21:04:11)
+  ...
+```
+
+Resolve it one of two ways — `tasks export <locale>` to keep the work (then re-run `create`), or `create <locale> --apply --reopen` to discard it deliberately. The preview reports the same thing as `WOULD BE REFUSED`, so a dry run tells you whether the real run will be gated.
+
+The receipt behind this is the `exported_at` column: `tasks export` stamps it on every row it writes, and it is cleared again whenever a row is reopened or its translations are rewritten — so a level that is exported, revised in place, and then re-created is protected afresh rather than waved through on a stale receipt.
 
 Catch-up is the only mode. There is no target-blind switch that re-queues reviewed keys — it was removed, and `create` rejects the old `--all` rather than quietly ignoring it. To redo a locale wholesale, delete `locales/content/<locale>/` and re-run `create --apply`: every key is then missing, which is the same queue by a route that makes the intent visible in git.
 

--- a/locales/TRANSLATION_PROTOCOL.md
+++ b/locales/TRANSLATION_PROTOCOL.md
@@ -71,7 +71,7 @@ Without `--apply`, `create` is a preview: it prints what would be enqueued and w
 
 Applying is not free on a populated DB: a completed level that still has work is **reopened** — status back to `pending`, its translations discarded. That is the point (a stranded completed row would never be re-served), but it means running `create --apply` between completing tasks and `tasks export` throws away the unexported work. Export first, then refresh the queue.
 
-`--all` is the opposite of the default and is rarely what you want: it is target-blind, queues every en key including reviewed ones, and `tasks export` then overwrites the reviewed content with the fresh output. Reach for it only to redo a locale wholesale.
+Catch-up is the only mode. There is no target-blind switch that re-queues reviewed keys — it was removed, and `create` rejects the old `--all` rather than quietly ignoring it. To redo a locale wholesale, delete `locales/content/<locale>/` and re-run `create --apply`: every key is then missing, which is the same queue by a route that makes the intent visible in git.
 
 Tasks are grouped by parent path (e.g., all keys under `web.COMMON.buttons`). This keeps work productive by batching related strings together rather than handling thousands of individual keys. Translators get more context since messages at the same level are usually related.
 

--- a/locales/TRANSLATION_PROTOCOL.md
+++ b/locales/TRANSLATION_PROTOCOL.md
@@ -66,7 +66,9 @@ Replace `[LOCALE]` with the target locale code (e.g., `eo`, `fr_CA`, `de`).
 ```bash
 python3 locales/scripts/i18n tasks create eo
 ```
-This populates the `translation_tasks` table required by `tasks next`. Run once per locale, or re-run to refresh after English source changes. Add `--missing-only` to enqueue only the keys that still need work — **missing** (untranslated) plus **stale** (translated, but en changed since: the target `source_hash` no longer matches en's `content_hash`) — without re-touching still-current reviewed strings. `tasks next <locale> --stats` prints a `current/stale/missing` coverage block so you can see drift even before enqueuing it.
+This populates the `translation_tasks` table required by `tasks next`. Run once per locale, or re-run to refresh after English source changes — it enqueues only the keys that still need work: **missing** (untranslated) plus **stale** (translated, but en changed since: the target `source_hash` no longer matches en's `content_hash`), never re-touching still-current reviewed strings. A brand-new locale needs no flag: with no `content/<locale>` yet, every key is missing. `tasks next <locale> --stats` prints a `current/stale/missing` coverage block so you can see drift even before enqueuing it.
+
+`--all` is the opposite and is rarely what you want: it is target-blind, queues every en key including reviewed ones, and `tasks export` then overwrites the reviewed content with the fresh output. Reach for it only to redo a locale wholesale.
 
 Tasks are grouped by parent path (e.g., all keys under `web.COMMON.buttons`). This keeps work productive by batching related strings together rather than handling thousands of individual keys. Translators get more context since messages at the same level are usually related.
 

--- a/locales/TRANSLATION_PROTOCOL.md
+++ b/locales/TRANSLATION_PROTOCOL.md
@@ -100,12 +100,13 @@ python3 locales/scripts/i18n db query "INSERT INTO glossary (locale, term, trans
 
 ### 6. End session - export to content
 ```bash
+python3 locales/scripts/i18n tasks audit eo --strict
 python3 locales/scripts/i18n tasks export eo
 python3 locales/scripts/i18n db export
 ```
 The frontend auto-generates `generated/locales/` on startup from `locales/content/`.
 
-`tasks export` is per-locale — run it once for each finished locale, and only when fully drained (`tasks next <locale> --stats` shows `pending: 0`); a partial locale would write half-translated content. `db export` is locale-independent — it dumps the committable tables (glossary, session_log, translation_issues) to `db/*.sql` and regenerates `checksums.sha256` — so run it once after the per-locale loop, not inside it.
+`tasks export` is per-locale — run it once for each finished locale, and only when the locale is both drained (`tasks next <locale> --stats` shows `pending: 0`) and audit-clean (`tasks audit <locale> --strict` exits 0, having found no stranded `in_progress` row, no key-set or blank-translation defect, and no lost interpolation token; the English-leak check is advisory and never gates). A partial locale would write half-translated content; a drained-but-dirty one would write broken content just as happily, which is why `pending: 0` is not the export condition — note that `pending: 0` does not even prove the locale is drained, since an abandoned `in_progress` claim is counted separately, which is why the audit checks for those too. Fix findings with `tasks update <ID> --validate --strict` and re-audit before exporting. `export-all.sh` applies both gates automatically across all locales. `db export` is locale-independent — it dumps the committable tables (glossary, session_log, translation_issues) to `db/*.sql` and regenerates `checksums.sha256` — so run it once after the per-locale loop, not inside it.
 
 ### 7. Commit
 ```bash

--- a/locales/TRANSLATION_PROTOCOL.md
+++ b/locales/TRANSLATION_PROTOCOL.md
@@ -64,11 +64,14 @@ Replace `[LOCALE]` with the target locale code (e.g., `eo`, `fr_CA`, `de`).
 
 ### 0. Generate tasks (if not already done)
 ```bash
-python3 locales/scripts/i18n tasks create eo
+python3 locales/scripts/i18n tasks create eo            # preview (writes nothing)
+python3 locales/scripts/i18n tasks create eo --apply    # enqueue for real
 ```
-This populates the `translation_tasks` table required by `tasks next`. Run once per locale, or re-run to refresh after English source changes — it enqueues only the keys that still need work: **missing** (untranslated) plus **stale** (translated, but en changed since: the target `source_hash` no longer matches en's `content_hash`), never re-touching still-current reviewed strings. A brand-new locale needs no flag: with no `content/<locale>` yet, every key is missing. `tasks next <locale> --stats` prints a `current/stale/missing` coverage block so you can see drift even before enqueuing it.
+Without `--apply`, `create` is a preview: it prints what would be enqueued and writes nothing. This populates the `translation_tasks` table required by `tasks next`. Run once per locale, or re-run to refresh after English source changes — it enqueues only the keys that still need work: **missing** (untranslated) plus **stale** (translated, but en changed since: the target `source_hash` no longer matches en's `content_hash`), never re-touching still-current reviewed strings. A brand-new locale needs no flag: with no `content/<locale>` yet, every key is missing. `tasks next <locale> --stats` prints a `current/stale/missing` coverage block so you can see drift even before enqueuing it.
 
-`--all` is the opposite and is rarely what you want: it is target-blind, queues every en key including reviewed ones, and `tasks export` then overwrites the reviewed content with the fresh output. Reach for it only to redo a locale wholesale.
+Applying is not free on a populated DB: a completed level that still has work is **reopened** — status back to `pending`, its translations discarded. That is the point (a stranded completed row would never be re-served), but it means running `create --apply` between completing tasks and `tasks export` throws away the unexported work. Export first, then refresh the queue.
+
+`--all` is the opposite of the default and is rarely what you want: it is target-blind, queues every en key including reviewed ones, and `tasks export` then overwrites the reviewed content with the fresh output. Reach for it only to redo a locale wholesale.
 
 Tasks are grouped by parent path (e.g., all keys under `web.COMMON.buttons`). This keeps work productive by batching related strings together rather than handling thousands of individual keys. Translators get more context since messages at the same level are usually related.
 

--- a/locales/db/schema.sql
+++ b/locales/db/schema.sql
@@ -22,6 +22,13 @@ CREATE TABLE IF NOT EXISTS translation_tasks (
                                       -- target key's source_hash so staleness (en moved after
                                       -- translation) is detectable. NULL for pre-column rows and
                                       -- for leaves whose en key has no content_hash yet.
+    exported_at TEXT,                 -- datetime('now') stamped by `tasks export` on every row it
+                                      -- actually wrote to content/<locale>. NULL means the row's
+                                      -- translations exist ONLY in this DB, so `tasks create
+                                      -- --apply` refuses to reopen it (the work would be lost);
+                                      -- non-NULL means the text is safely on disk and reopening
+                                      -- costs nothing. Cleared again whenever translations_json is
+                                      -- rewritten, so a re-translated level is protected afresh.
     notes TEXT,
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT (datetime('now')),

--- a/locales/scripts/create-all.sh
+++ b/locales/scripts/create-all.sh
@@ -10,9 +10,11 @@
 # already caught up produces no tasks at all. Pass nothing to get that; `tasks
 # create --all` (target-blind, full re-translation) is deliberately not used here.
 #
-# Safe to re-run: `tasks create` upserts via ON CONFLICT(file, level_path, locale)
-# and only refreshes keys_json + updated_at — it never touches `status` or
-# `translations_json`, so in-flight / completed work is preserved.
+# Re-running is safe for in-flight work (pending rows get refreshed keys,
+# in_progress/skipped rows keep their status) but NOT a no-op for drained
+# levels: a completed row that still has work is REOPENED — status back to
+# pending, its unexported translations discarded. Export before re-running if
+# completed-but-unexported work must be kept.
 #
 # By default this SKIPS locales that already have tasks (so the locales currently
 # being translated are left untouched). Use --force to (re)generate for every
@@ -90,9 +92,9 @@ for locale in "${locales[@]}"; do
 
   echo "== $locale: generating tasks (existing: $existing) =="
   if [ "$DRY_RUN" -eq 1 ]; then
-    python3 locales/scripts/i18n tasks create "$locale" --dry-run | tail -4
-  else
     python3 locales/scripts/i18n tasks create "$locale" | tail -4
+  else
+    python3 locales/scripts/i18n tasks create "$locale" --apply | tail -4
   fi
   created=$((created + 1))
   echo

--- a/locales/scripts/create-all.sh
+++ b/locales/scripts/create-all.sh
@@ -3,8 +3,12 @@
 # Populate the translation tasks DB for every current locale.
 #
 # "Current locales" = every directory under locales/content/ except the English
-# source (en). For each, runs `i18n tasks create LOCALE`, which mirrors the full
-# English level structure into the translation_tasks table (one task per level).
+# source (en). For each, runs `i18n tasks create LOCALE`, which enqueues one task
+# per English level — but only the keys that still need work: missing
+# (untranslated) plus stale (en changed after the translation was made).
+# Reviewed, still-current translations are never re-enqueued, so a locale that is
+# already caught up produces no tasks at all. Pass nothing to get that; `tasks
+# create --all` (target-blind, full re-translation) is deliberately not used here.
 #
 # Safe to re-run: `tasks create` upserts via ON CONFLICT(file, level_path, locale)
 # and only refreshes keys_json + updated_at — it never touches `status` or

--- a/locales/scripts/create-all.sh
+++ b/locales/scripts/create-all.sh
@@ -13,8 +13,15 @@
 # Re-running is safe for in-flight work (pending rows get refreshed keys,
 # in_progress/skipped rows keep their status) but NOT a no-op for drained
 # levels: a completed row that still has work is REOPENED — status back to
-# pending, its unexported translations discarded. Export before re-running if
-# completed-but-unexported work must be kept.
+# pending, its translations discarded. That is free once the text has been
+# exported to content/, so the routine catch-up needs no ceremony.
+#
+# A locale holding completed-but-NEVER-exported translations is instead BLOCKED:
+# `tasks create --apply` exits 3 and writes nothing for it. This script keeps
+# going, processes every other locale, lists the blocked ones at the end, and
+# exits non-zero. Resolve each with `i18n tasks export LOCALE` (keeps the work)
+# or `i18n tasks create LOCALE --apply --reopen` (discards it) — deliberately
+# per-locale, since discarding work in bulk should never be one flag away.
 #
 # By default this SKIPS locales that already have tasks (so the locales currently
 # being translated are left untouched). Use --force to (re)generate for every
@@ -81,6 +88,7 @@ echo
 
 created=0
 skipped=0
+blocked=()
 for locale in "${locales[@]}"; do
   existing="$(sqlite3 "$DB_FILE" "SELECT COUNT(*) FROM translation_tasks WHERE locale='$locale';")"
 
@@ -91,16 +99,42 @@ for locale in "${locales[@]}"; do
   fi
 
   echo "== $locale: generating tasks (existing: $existing) =="
+  # `|| status=$?` keeps `set -e` from aborting the batch on a per-locale
+  # failure: one blocked locale must not strand every locale after it. The
+  # refusal message goes to stderr, so `tail` (stdout only) never hides it.
+  status=0
   if [ "$DRY_RUN" -eq 1 ]; then
-    python3 locales/scripts/i18n tasks create "$locale" | tail -4
+    python3 locales/scripts/i18n tasks create "$locale" | tail -4 || status=$?
   else
-    python3 locales/scripts/i18n tasks create "$locale" --apply | tail -4
+    python3 locales/scripts/i18n tasks create "$locale" --apply | tail -4 || status=$?
   fi
-  created=$((created + 1))
+
+  case "$status" in
+    0) created=$((created + 1)) ;;
+    3)
+      # Refused: unexported translations would have been discarded. Nothing was
+      # written for this locale; the operator decides its fate individually.
+      blocked+=("$locale")
+      ;;
+    *)
+      echo "Error: tasks create failed for '$locale' (exit $status)." >&2
+      exit "$status"
+      ;;
+  esac
   echo
 done
 
-echo "Done. Generated/refreshed: $created  |  skipped (already populated): $skipped"
+echo "Done. Generated/refreshed: $created  |  skipped (already populated): $skipped  |  blocked: ${#blocked[@]}"
+
+if [ "${#blocked[@]}" -gt 0 ]; then
+  echo
+  echo "=== BLOCKED: unexported translations would have been discarded ==="
+  for locale in "${blocked[@]}"; do
+    echo "  $locale"
+    echo "    keep:    python3 locales/scripts/i18n tasks export $locale"
+    echo "    discard: python3 locales/scripts/i18n tasks create $locale --apply --reopen"
+  done
+fi
 
 if [ "$DRY_RUN" -eq 0 ]; then
   echo
@@ -111,4 +145,10 @@ if [ "$DRY_RUN" -eq 0 ]; then
             SUM(status='pending')   AS pending,
             COUNT(*)                AS total
      FROM translation_tasks GROUP BY locale ORDER BY locale;" -header -column
+fi
+
+# Non-zero when any locale was refused, so CI and orchestrators notice that the
+# batch is incomplete. Every other locale was still processed.
+if [ "${#blocked[@]}" -gt 0 ]; then
+  exit 1
 fi

--- a/locales/scripts/export-all.sh
+++ b/locales/scripts/export-all.sh
@@ -1,21 +1,46 @@
 #!/usr/bin/env bash
 #
-# Exports every fully drained locale's translations from the SQLite DB into
-# locales/content/, then exports the shared DB tables once. Leaves the changes
-# uncommitted in the working tree for branch-per-locale.sh to split up.
+# Exports every fully drained AND clean locale's translations from the SQLite DB
+# into locales/content/, then exports the shared DB tables once. Leaves the
+# changes uncommitted in the working tree for branch-per-locale.sh to split up.
 #
-# A locale is only exported when its task stats show pending: 0. Locales with
-# pending tasks are skipped and reported (drain them first).
+# A locale is exported only when both gates pass:
+#   1. task stats show pending: 0 (drained)
+#   2. `i18n tasks audit <locale> --strict` is clean — no stranded in_progress
+#      row, no key-set/blank-translation defect, no token loss, and at least one
+#      completed row actually checked
+# pending: 0 alone does not prove the writes are clean, so the audit is the real
+# gate; locales failing either one are skipped and named in the summary. The
+# audit's en_leak check is advisory (an identical string is the correct
+# translation for many short labels) and never blocks an export — its count is
+# echoed on the TOTAL line; run `i18n tasks audit <locale>` for the detail.
+#
+# After a successful export the content is re-checked in the working tree:
+#   - `i18n validate variables --locale <locale> --json` (placeholder parity),
+#     counting only keys the export can influence — en-only authoring metadata
+#     (`.context`, `.note`, `.source_hash`) is excluded, since `tasks export`
+#     writes `text` and nothing else
+#   - the register lint, when .translation-rules/ and generated/i18n/.resolved/
+#     exist (run locales/scripts/derive-governance.sh); skipped otherwise, and a
+#     skip never fails the run
+# A locale failing those is reported as dirty. Nothing is reverted — the point is
+# to surface the problem while the content is still unstaged.
+#
+# Exit status is non-zero if any locale failed the audit, failed to export, or
+# landed dirty; a locale that is merely not drained is a normal state and exits
+# 0. The loop never aborts early: every locale is processed, then reported.
 #
 # Usage:
 #   locales/scripts/export-all.sh [--dry-run] [--execute] [locale...]
 #
 # Options:
-#   --dry-run   Preview without writing (default)
+#   --dry-run   Preview without writing (default). Still runs the read-only
+#               audit gate, so a dirty locale is reported (and exits non-zero)
+#               before you commit to --execute.
 #   --execute   Actually run the exports
 #
 # Examples:
-#   locales/scripts/export-all.sh --execute            # all drained locales + shared tables
+#   locales/scripts/export-all.sh --execute            # all clean drained locales + shared tables
 #   locales/scripts/export-all.sh ar bg ca_ES          # preview specific locales
 #   locales/scripts/export-all.sh --execute ar bg      # export specific locales only
 
@@ -23,12 +48,18 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LOCALES_DIR="$(dirname "$SCRIPT_DIR")"
+ROOT="$(dirname "$LOCALES_DIR")"
 CONTENT_DIR="$LOCALES_DIR/content"
 I18N="$SCRIPT_DIR/i18n"
+
+# Register lint (governance-derived; absent unless derive-governance.sh has run).
+RULES_LINT_REL=".translation-rules/lib/resolver/lint_content.py"
+RESOLVED_DIR_REL="generated/i18n/.resolved"
 
 DRY_RUN=true
 
 die() { echo "error: $1" >&2; exit 1; }
+indent() { sed 's/^/  /'; }
 
 # Parse arguments
 LOCALES=()
@@ -55,8 +86,13 @@ fi
 
 [[ ${#LOCALES[@]} -eq 0 ]] && die "no locales found in $CONTENT_DIR"
 
+# The audit is the gate. An i18n CLI without it would let every locale through
+# unchecked, so fail closed here rather than failing open per locale.
+python3 "$I18N" tasks audit --help >/dev/null 2>&1 \
+  || die "this i18n CLI has no 'tasks audit' subcommand; the export gate cannot run"
+
 echo "Locales to consider: ${LOCALES[*]}"
-$DRY_RUN && echo "DRY RUN - no changes will be made"
+$DRY_RUN && echo "DRY RUN - no changes will be made (the audit gate still runs; it is read-only)"
 echo
 
 # pending count for a locale (empty if stats unavailable)
@@ -66,15 +102,113 @@ pending_count() {
     | python3 -c "import sys,json; print(json.load(sys.stdin).get('pending',''))" 2>/dev/null || echo ""
 }
 
+# Pre-export gate: the DB rows themselves (stranded rows, key sets, tokens).
+# 0 = clean, 1 = error findings, nothing verified, or the audit could not run.
+# en_leak findings are advisory in the audit and do not gate here either.
+audit_locale() {
+  local locale="$1" out rc=0
+  out="$(python3 "$I18N" tasks audit "$locale" --strict 2>&1)" || rc=$?
+  if [[ $rc -ne 0 ]]; then
+    echo "[$locale] audit FAILED (exit $rc), not exporting"
+    if [[ -n "$out" ]]; then printf '%s\n' "$out" | indent; fi
+    return 1
+  fi
+  # Echo the TOTAL line even on success. "exit 0" alone cannot distinguish a
+  # verified locale from one that merely had nothing to verify, and the advisory
+  # (en_leak) count is only visible here — run `i18n tasks audit <locale>` for
+  # the detail.
+  printf '%s\n' "$out" | grep '^TOTAL:' | sed "s/^/[$locale] /" || true
+  return 0
+}
+
+# Post-export check: placeholder parity in the content just written.
+# `validate variables` exits with the ISSUE COUNT, and exit 1 is ambiguous (it is
+# also the "locale not found"/crash path, which prints no JSON). Decide on the
+# parsed report, treating an unparseable one as dirty — never as clean.
+#
+# Counted from `details`, not `summary`, so en-only authoring metadata can be
+# excluded: `validate variables` flattens each content entry, so `<key>.context`
+# is compared as if it were translatable, while `tasks export` writes only
+# `{"text": ...}`. Three en keys carry {provider}/{email} inside their `context`
+# and are absent from all 29 locales, so a summary-based gate reports >=3
+# mismatches for every locale after even a byte-perfect export — permanently
+# non-zero, and therefore ignored. Only keys the export can actually influence
+# are counted.
+VALIDATE_VARIABLES_COUNT_PY='
+import sys, json
+
+METADATA_FIELDS = ("context", "note", "source_hash")
+
+data = json.load(sys.stdin)
+count = 0
+for files in data.get("details", {}).values():
+    for issues in files.values():
+        for issue in issues:
+            key = str(issue.get("key", ""))
+            if key.rsplit(".", 1)[-1] in METADATA_FIELDS:
+                continue
+            count += 1
+print(count)
+'
+
+validate_variables() {
+  local locale="$1" out count rc=0
+  out="$(python3 "$I18N" validate variables --locale "$locale" --json 2>/dev/null)" || rc=$?
+  count="$(printf '%s' "$out" \
+    | python3 -c "$VALIDATE_VARIABLES_COUNT_PY" 2>/dev/null || true)"
+  if ! [[ "$count" =~ ^[0-9]+$ ]]; then
+    echo "[$locale] variable validation produced no parseable report (exit $rc)"
+    return 1
+  fi
+  if [[ "$count" -gt 0 ]]; then
+    echo "[$locale] $count variable mismatch(es) in exported content"
+    return 1
+  fi
+  return 0
+}
+
+# Post-export check: register (politeness level) lint — same engine as the
+# validate-register CI gate. Needs the derived governance cache; when either half
+# is missing we say so and pass, because "governance not derived" is not a
+# content defect.
+register_lint() {
+  local locale="$1" out rc=0
+  if [[ ! -f "$ROOT/$RULES_LINT_REL" || ! -f "$ROOT/$RESOLVED_DIR_REL/$locale.json" ]]; then
+    echo "[$locale] register lint skipped (no $RESOLVED_DIR_REL/$locale.json; run locales/scripts/derive-governance.sh)"
+    return 0
+  fi
+  out="$(cd "$ROOT" && python3 "$RULES_LINT_REL" \
+    --resolved "$RESOLVED_DIR_REL/$locale.json" \
+    --content-root . \
+    "locales/content/$locale/*.json" 2>&1)" || rc=$?
+  if [[ $rc -ne 0 ]]; then
+    echo "[$locale] register lint FAILED (exit $rc)"
+    if [[ -n "$out" ]]; then printf '%s\n' "$out" | indent; fi
+    return 1
+  fi
+  return 0
+}
+
+# `exported` counts locales whose content was actually written, dirty or not —
+# the summary's job is to describe the working tree, and a locale that exported
+# and then failed a validator still changed files on disk.
 exported=0
 skipped=0
 not_drained=()
+failed_audit=()
+failed_export=()
+dirty_locales=()
+EXIT_CODE=0
 
 for locale in "${LOCALES[@]}"; do
   pending="$(pending_count "$locale")"
 
+  # Empty means the DB file is missing or the CLI crashed — an unknown locale
+  # reports 0 pending. The audit below is the real not-in-DB guard: it fails
+  # when zero completed rows were checked, so a content/<locale>/ directory that
+  # has never been through `tasks create` cannot preview as ready-to-export.
   if [[ -z "$pending" ]]; then
-    echo "[$locale] no task stats (not in DB?), skipping"
+    echo "[$locale] no task stats (DB missing or CLI failed), skipping"
     ((skipped++)) || true
     continue
   fi
@@ -86,29 +220,80 @@ for locale in "${LOCALES[@]}"; do
     continue
   fi
 
-  echo "[$locale] drained (pending: 0), exporting..."
+  echo "[$locale] drained (pending: 0), auditing..."
+  if ! audit_locale "$locale"; then
+    failed_audit+=("$locale")
+    EXIT_CODE=1
+    continue
+  fi
+
+  echo "[$locale] audit clean, exporting..."
   if $DRY_RUN; then
     echo "  would: i18n tasks export $locale"
-  else
-    python3 "$I18N" tasks export "$locale"
+    echo "  would: i18n validate variables --locale $locale --json"
+    echo "  would: register lint (.translation-rules + $RESOLVED_DIR_REL/$locale.json)"
+    ((exported++)) || true
+    continue
   fi
+
+  # `tasks export` exits 2 when there is nothing completed to export (e.g. every
+  # row skipped). Guard it: under set -e an unguarded call kills the whole run.
+  # A failed export wrote nothing, so it is NOT "dirty" — reporting it under
+  # "fix the unstaged content" would send the operator after files that do not
+  # exist.
+  if ! python3 "$I18N" tasks export "$locale"; then
+    echo "[$locale] export FAILED"
+    failed_export+=("$locale")
+    EXIT_CODE=1
+    continue
+  fi
+
+  # Content is on disk from here on: count it as exported whatever the
+  # validators say, then report separately whether it landed clean.
   ((exported++)) || true
+
+  # Post-export validators. Run both (do not short-circuit) so one report names
+  # every problem with the locale. Nothing is reverted: the content is unstaged
+  # and surfacing it before `git add` is the point.
+  locale_dirty=false
+  validate_variables "$locale" || locale_dirty=true
+  register_lint "$locale" || locale_dirty=true
+
+  if $locale_dirty; then
+    dirty_locales+=("$locale")
+    EXIT_CODE=1
+  fi
 done
 
 echo
 # Shared tables (glossary, session_log, translation_issues) — once, after locales.
 echo "Shared DB tables (glossary + translation_issues + session_log)..."
+# Guarded like every other external call: under set -e an unguarded failure here
+# would abort before the summary and before `exit $EXIT_CODE`, throwing away the
+# per-locale report this script exists to produce.
 if $DRY_RUN; then
   echo "  would: i18n db export"
-else
-  python3 "$I18N" db export
+elif ! python3 "$I18N" db export; then
+  echo "shared db export FAILED"
+  EXIT_CODE=1
 fi
 
 echo
-echo "Done: $exported locale(s) exported, $skipped skipped"
+verb="exported"
+$DRY_RUN && verb="ready to export"
+echo "Done: $exported locale(s) $verb, $skipped skipped, ${#failed_audit[@]} failed audit, ${#failed_export[@]} failed export, ${#dirty_locales[@]} dirty"
 if [[ ${#not_drained[@]} -gt 0 ]]; then
   echo "Not drained (skipped): ${not_drained[*]}"
 fi
+if [[ ${#failed_audit[@]} -gt 0 ]]; then
+  echo "Failed audit (not exported): ${failed_audit[*]}"
+fi
+if [[ ${#failed_export[@]} -gt 0 ]]; then
+  echo "Export failed (nothing written): ${failed_export[*]}"
+fi
+if [[ ${#dirty_locales[@]} -gt 0 ]]; then
+  echo "Exported but dirty (fix the content, it is unstaged): ${dirty_locales[*]}"
+fi
 $DRY_RUN && echo "Re-run with --execute to apply."
 
-exit 0
+exit $EXIT_CODE

--- a/locales/scripts/i18n/commands/tasks.py
+++ b/locales/scripts/i18n/commands/tasks.py
@@ -59,13 +59,12 @@ def _register_create(gsub) -> None:
         description="Generate translation tasks by comparing locales.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
-Default (catch-up) enqueues only keys that still need work: MISSING (absent
-from content/<locale>, or empty text without skip) plus STALE (translated, but
-the target's source_hash watermark no longer matches en's content_hash). Levels
+Enqueues only keys that still need work: MISSING (absent from
+content/<locale>, or empty text without skip) plus STALE (translated, but the
+target's source_hash watermark no longer matches en's content_hash). Levels
 with no work produce no row, and reviewed translations are never re-enqueued.
-
-For a locale with no content/ directory yet, every key is missing, so the
-default and --all produce exactly the same tasks: a new language needs no flag.
+There is no target-blind mode: for a locale with no content/ directory yet
+every key is missing anyway, so a new language needs no flag.
 
 Without --apply this is a preview: it prints what would be enqueued and writes
 nothing. Writing is not idempotent for drained levels — a conflicting completed
@@ -75,7 +74,6 @@ the write is an explicit decision, not the default.
 Examples:
     python3 locales/scripts/i18n tasks create fr_CA            # preview the catch-up (no writes)
     python3 locales/scripts/i18n tasks create eo --apply       # actually enqueue the tasks
-    python3 locales/scripts/i18n tasks create de --all --apply # re-enqueue EVERYTHING (rare)
         """,
     )
     c.add_argument(
@@ -96,16 +94,6 @@ Examples:
         "--dry-run",
         action="store_true",
         help=argparse.SUPPRESS,  # now the default; accepted so old callers work
-    )
-    c.add_argument(
-        "--all",
-        action="store_true",
-        help=(
-            "Target-blind: enqueue EVERY en key, including ones already "
-            "translated and reviewed. Queues a full re-translation of the "
-            "locale, and export then overwrites reviewed content with the new "
-            "output. Only for rebuilding a locale you intend to redo wholesale."
-        ),
     )
     c.add_argument(
         "--missing-only",
@@ -476,28 +464,21 @@ def classify_key(entry: Optional[dict], en_hash: Optional[str]) -> str:
 def generate_tasks(
     locale: str,
     dry_run: bool = False,
-    missing_only: bool = True,
 ) -> tuple[list[TranslationTask], dict[str, int]]:
     """Generate translation tasks from English source files.
 
-    Default (``missing_only``) filters each English file against
-    ``content/<locale>`` so only keys that still need work are enqueued —
-    **missing** (absent, or empty ``text`` without ``skip``) *and* **stale**
-    (translated, but the target's ``source_hash`` watermark no longer matches
-    en's ``content_hash`` — English moved after the translation was made).
-    Levels left with no work produce no row. This is the catch-up path for
-    bringing a locale up to a grown *or edited* English source without
-    re-touching still-current reviewed translations.
-
-    ``missing_only=False`` is target-blind: every English key becomes a task
-    regardless of what the locale already has. That queues a full
-    re-translation, and ``export`` then overwrites reviewed content with the new
-    output — which is why it is not the default and why the CLI spells it
-    ``--all``. For a locale with no ``content/`` directory the two modes are
-    identical (every key is missing), so a new language never needs the flag.
+    Filters each English file against ``content/<locale>`` so only keys that
+    still need work are enqueued — **missing** (absent, or empty ``text``
+    without ``skip``) *and* **stale** (translated, but the target's
+    ``source_hash`` watermark no longer matches en's ``content_hash`` — English
+    moved after the translation was made). Levels left with no work produce no
+    row. This is the only mode: the catch-up path for bringing a locale up to a
+    grown *or edited* English source without re-touching still-current reviewed
+    translations. A locale with no ``content/`` directory has every key missing,
+    so a brand-new language comes out the same as a target-blind pass would.
 
     Every generated task also snapshots the current en ``content_hash`` per leaf
-    into ``source_hashes_json`` (both modes), so ``export`` can stamp the target
+    into ``source_hashes_json``, so ``export`` can stamp the target
     ``source_hash`` with exactly what was translated against — the watermark that
     later marks the key stale if en changes again.
     """
@@ -526,19 +507,18 @@ def generate_tasks(
         # filter and the snapshot stamped into each task row.
         en_hashes = get_source_hashes_from_file(en_file)
 
-        if missing_only:
-            target = get_target_entries(locale, file_name)
-            kept: dict[str, str] = {}
-            for full_key, text in en_keys.items():
-                state = classify_key(target.get(full_key), en_hashes.get(full_key))
-                if state == "missing":
-                    kept[full_key] = text
-                    stats["missing_keys"] += 1
-                elif state == "stale":
-                    kept[full_key] = text
-                    stats["stale_keys"] += 1
-                # "current"/"skipped" → leave the reviewed translation alone.
-            en_keys = kept
+        target = get_target_entries(locale, file_name)
+        kept: dict[str, str] = {}
+        for full_key, text in en_keys.items():
+            state = classify_key(target.get(full_key), en_hashes.get(full_key))
+            if state == "missing":
+                kept[full_key] = text
+                stats["missing_keys"] += 1
+            elif state == "stale":
+                kept[full_key] = text
+                stats["stale_keys"] += 1
+            # "current"/"skipped" → leave the reviewed translation alone.
+        en_keys = kept
 
         # A fully-translated (or empty) file contributes no tasks.
         if not en_keys:
@@ -588,8 +568,8 @@ def insert_tasks(tasks: list[TranslationTask]) -> int:
 
     A conflicting **completed** row is REOPENED: status back to ``pending`` and
     ``translations_json`` cleared. ``generate_tasks`` only emits a level when it
-    has real work (missing/stale keys, or ``--all``), so a conflict with a
-    completed row always means that work must be redone — leaving the row
+    has real work (missing/stale keys), so a conflict with a completed row
+    always means that work must be redone — leaving the row
     completed would strand it: ``tasks next`` never re-serves it, and its old
     translations no longer match the refreshed key set. The clobber window is
     deliberate: a completed level whose translations were never exported loses
@@ -669,18 +649,13 @@ def insert_tasks(tasks: list[TranslationTask]) -> int:
 
 
 def _create_handler(args) -> int:
-    # `--missing-only` is the default as of the write-gate work; the flag is
-    # still accepted (hidden) so older scripts and slash commands keep working.
-    # Asking for both modes at once is a contradiction, not a preference.
-    if args.all and args.missing_only:
-        print(
-            "Error: --all and --missing-only are opposites; --missing-only is "
-            "the default, so pass neither for catch-up.",
-            file=sys.stderr,
-        )
-        return 1
-
-    # Same for `--dry-run`: previewing is the default, writing is opt-in.
+    # `--missing-only` is the only mode; the flag is still accepted (hidden) so
+    # older scripts and slash commands keep working. `--all` is gone entirely —
+    # argparse rejects it, which is the loud failure a target-blind re-queue
+    # deserves now that nothing implements it.
+    #
+    # `--dry-run` is likewise the default; writing is opt-in, and asking for
+    # both at once is a contradiction, not a preference.
     if args.apply and args.dry_run:
         print(
             "Error: --apply and --dry-run are opposites; --dry-run is the "
@@ -690,17 +665,12 @@ def _create_handler(args) -> int:
         return 1
 
     dry_run = not args.apply
-    missing_only = not args.all
-    # Only the dangerous mode gets a marker: the default is unremarkable, and a
-    # full re-translation must never be something you scroll past.
-    mode = "" if missing_only else " (--all: EVERY key, re-translating reviewed work)"
-    print(f"Generating translation tasks for '{args.locale}'{mode}")
+    print(f"Generating translation tasks for '{args.locale}'")
     print()
 
     tasks, stats = generate_tasks(
         locale=args.locale,
         dry_run=dry_run,
-        missing_only=missing_only,
     )
 
     print()
@@ -708,10 +678,9 @@ def _create_handler(args) -> int:
     print(f"  Files: {stats['total_files']}")
     print(f"  Levels: {stats['total_levels']}")
     print(f"  Keys: {stats['total_keys']}")
-    if missing_only:
-        # In catch-up mode, break the enqueued keys into new vs re-translate.
-        print(f"    missing (new/untranslated): {stats['missing_keys']}")
-        print(f"    stale (en changed since):   {stats['stale_keys']}")
+    # Break the enqueued keys into new vs re-translate.
+    print(f"    missing (new/untranslated): {stats['missing_keys']}")
+    print(f"    stale (en changed since):   {stats['stale_keys']}")
 
     if dry_run:
         print()
@@ -1316,11 +1285,10 @@ def export_locale(
                 translation = translations[key]
 
                 # An empty/whitespace "translation" must never overwrite an
-                # existing value or strip an intentional skip flag. This closes
-                # the target-blind (`create --all`) hazard where a locale's
-                # already-skipped/translated key could be enqueued, "completed"
-                # blank, and clobbered here. The default create never enqueues
-                # such keys; this guards the --all path too.
+                # existing value or strip an intentional skip flag. `create`
+                # never enqueues an already-skipped/translated key, so this is
+                # belt-and-braces against a row blanked by hand (or by a caller
+                # that wrote translations_json directly).
                 if not (isinstance(translation, str) and translation.strip()):
                     continue
 

--- a/locales/scripts/i18n/commands/tasks.py
+++ b/locales/scripts/i18n/commands/tasks.py
@@ -37,6 +37,44 @@ from ..tokens import extract_tokens, strip_tokens
 
 VALID_STATUSES = ("pending", "in_progress", "completed", "skipped")
 
+# `tasks create --apply` exit code when the run was refused because completed
+# levels hold translations that were never exported. Distinct from 1 (usage /
+# environment error) so export-all.sh and the drain orchestrators can tell
+# "you must export first" apart from "the tool broke".
+EXIT_UNEXPORTED_WORK = 3
+
+
+class UnexportedWorkError(RuntimeError):
+    """`create --apply` would have discarded translations that exist only in the DB.
+
+    Raised by :func:`insert_tasks` *before* it writes anything, so the run is
+    all-or-nothing: either every task is enqueued or the DB is untouched.
+    """
+
+    def __init__(self, locale: str, rows: list[dict]) -> None:
+        self.locale = locale
+        self.rows = rows
+        super().__init__(self._message())
+
+    def _message(self) -> str:
+        listing = "\n".join(
+            f"  {r['file']}:{r['level_path']}  "
+            f"({r['key_count']} keys, completed {r['updated_at']})"
+            for r in self.rows
+        )
+        n = len(self.rows)
+        subject = "level holds" if n == 1 else "levels hold"
+        return (
+            f"Refusing to write: {n} completed {subject} translations for "
+            f"'{self.locale}' that were never exported.\n"
+            f"{listing}\n\n"
+            f"Re-creating would reopen them and discard that work. Either:\n"
+            f"  python3 locales/scripts/i18n tasks export {self.locale}"
+            f"   # keep it — writes to content/, then re-run create\n"
+            f"  python3 locales/scripts/i18n tasks create {self.locale} "
+            f"--apply --reopen   # discard it deliberately"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Registration
@@ -67,13 +105,19 @@ There is no target-blind mode: for a locale with no content/ directory yet
 every key is missing anyway, so a new language needs no flag.
 
 Without --apply this is a preview: it prints what would be enqueued and writes
-nothing. Writing is not idempotent for drained levels — a conflicting completed
-row is reopened (status back to pending, its translations_json discarded) — so
-the write is an explicit decision, not the default.
+nothing.
+
+Writing is not idempotent for drained levels: a conflicting completed row is
+reopened (status back to pending, its translations_json discarded). When that
+row was already exported the text is safe on disk and the reopen is silent;
+when it was NOT exported the run is REFUSED (exit 3) and names the levels, so
+unexported work is never lost to a routine catch-up. Export first to keep it,
+or pass --reopen to discard it on purpose.
 
 Examples:
     python3 locales/scripts/i18n tasks create fr_CA            # preview the catch-up (no writes)
     python3 locales/scripts/i18n tasks create eo --apply       # actually enqueue the tasks
+    python3 locales/scripts/i18n tasks create eo --apply --reopen   # ...discarding unexported work
         """,
     )
     c.add_argument(
@@ -85,9 +129,17 @@ Examples:
         action="store_true",
         help=(
             "Write the generated tasks to the DB. Without it, create only "
-            "previews. Reopens any conflicting completed level (status back to "
-            "pending, its unexported translations discarded), so export before "
-            "re-running create if you want that work kept."
+            "previews. Reopens any conflicting completed level that has "
+            "already been exported; refuses the run (exit 3) if one has not."
+        ),
+    )
+    c.add_argument(
+        "--reopen",
+        action="store_true",
+        help=(
+            "Reopen conflicting completed levels even when their translations "
+            "were never exported, discarding that work. Only meaningful with "
+            "--apply."
         ),
     )
     c.add_argument(
@@ -560,22 +612,79 @@ def generate_tasks(
     return tasks, stats
 
 
-def insert_tasks(tasks: list[TranslationTask]) -> int:
+def find_unexported_conflicts(
+    conn: sqlite3.Connection, tasks: list[TranslationTask]
+) -> list[dict]:
+    """Rows this ``create`` run would reopen whose translations are unsaved.
+
+    A row qualifies only when all three hold:
+
+    - it collides with a level about to be written (same file/level_path/locale);
+    - it is ``completed`` **with** a ``translations_json`` payload — a completed
+      row with no payload has nothing to lose, and gating on it would wedge
+      ``create`` forever, since ``export`` skips such rows and so never stamps
+      the receipt that would clear the gate;
+    - ``exported_at IS NULL`` — the payload was never written to
+      ``content/<locale>``, so this DB row is the only copy.
+
+    Everything else (pending, in_progress, skipped, or completed-and-exported)
+    is safe to upsert and is not reported here.
+    """
+    conflicts: list[dict] = []
+    cursor = conn.cursor()
+    for task in tasks:
+        cursor.execute(
+            """
+            SELECT file, level_path, translations_json, updated_at
+            FROM translation_tasks
+            WHERE file = ? AND level_path = ? AND locale = ?
+              AND status = 'completed'
+              AND translations_json IS NOT NULL
+              AND exported_at IS NULL
+            """,
+            (task.file, task.level_path, task.locale),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            continue
+        try:
+            key_count = len(json.loads(row["translations_json"]))
+        except (json.JSONDecodeError, TypeError):
+            # An unparseable payload is still somebody's work: report the row
+            # rather than let a malformed one slip through the gate.
+            key_count = 0
+        conflicts.append(
+            {
+                "file": row["file"],
+                "level_path": row["level_path"],
+                "key_count": key_count,
+                "updated_at": row["updated_at"],
+            }
+        )
+    return conflicts
+
+
+def insert_tasks(tasks: list[TranslationTask], reopen: bool = False) -> int:
     """Insert translation tasks into the database.
 
     Upserts on (file, level_path, locale): inserts new levels, refreshes
     keys_json + source_hashes_json + updated_at on ones that already exist.
 
-    A conflicting **completed** row is REOPENED: status back to ``pending`` and
-    ``translations_json`` cleared. ``generate_tasks`` only emits a level when it
+    A conflicting **completed** row is REOPENED: status back to ``pending``,
+    ``translations_json`` cleared, and the ``exported_at`` receipt dropped (the
+    row is unwritten work again). ``generate_tasks`` only emits a level when it
     has real work (missing/stale keys), so a conflict with a completed row
     always means that work must be redone — leaving the row
     completed would strand it: ``tasks next`` never re-serves it, and its old
-    translations no longer match the refreshed key set. The clobber window is
-    deliberate: a completed level whose translations were never exported loses
-    them and is re-queued, so export before re-running ``create`` (the CLI
-    defaults to a dry run and requires ``--apply`` to make this an explicit
-    decision).
+    translations no longer match the refreshed key set.
+
+    Reopening is silent only when it is **free**. If any conflicting completed
+    row was never exported (``exported_at IS NULL``), its translations exist
+    nowhere but this DB, and the entire run is refused with
+    :class:`UnexportedWorkError` before a single write; ``reopen=True`` is the
+    explicit "discard that work" override. Once a level is on disk, reopening
+    costs nothing and proceeds without ceremony — which is what keeps the
+    routine catch-up path (en edited, level re-emitted as stale) quiet.
 
     ``pending`` rows just get their keys/hashes refreshed; ``in_progress`` and
     ``skipped`` keep their status — an active claim isn't yanked, and a
@@ -583,6 +692,10 @@ def insert_tasks(tasks: list[TranslationTask]) -> int:
 
     Returns:
         Count of inserted/updated rows.
+
+    Raises:
+        UnexportedWorkError: a conflicting completed level holds unexported
+            translations and ``reopen`` is False. Nothing was written.
     """
     if not DB_FILE.exists():
         raise FileNotFoundError(
@@ -594,21 +707,34 @@ def insert_tasks(tasks: list[TranslationTask]) -> int:
     with get_connection() as conn:
         cursor = conn.cursor()
 
-        # Fail loud on a pre-schema-008 DB: the INSERT below names
-        # source_hashes_json, and the per-row `except` further down would
-        # otherwise swallow "no such column" on EVERY row and still exit 0 with
-        # an empty queue. A fresh `db init` has the column; an old local tasks.db
+        # Fail loud on a pre-schema-009 DB: the statements below name
+        # source_hashes_json and exported_at, and the per-row `except` further
+        # down would otherwise swallow "no such column" on EVERY row and still
+        # exit 0 with an empty queue. Worse for exported_at: a missing column
+        # would take the *gate* offline, silently restoring the clobber it
+        # exists to prevent. A fresh `db init` has both; an old local tasks.db
         # needs `db migrate`.
         columns = {
             row[1]
             for row in cursor.execute("PRAGMA table_info(translation_tasks)")
         }
-        if "source_hashes_json" not in columns:
+        absent = [
+            c for c in ("source_hashes_json", "exported_at") if c not in columns
+        ]
+        if absent:
             raise RuntimeError(
-                "translation_tasks is missing the 'source_hashes_json' column "
-                "(task DB predates schema 008). Run "
+                "translation_tasks is missing the "
+                f"{', '.join(repr(c) for c in absent)} column(s) "
+                "(task DB predates schema 009). Run "
                 "'python3 locales/scripts/i18n db migrate' first."
             )
+
+        # Preflight BEFORE the first INSERT, so a refusal leaves the DB exactly
+        # as it was: a half-enqueued run would be its own kind of damage.
+        if not reopen and tasks:
+            conflicts = find_unexported_conflicts(conn, tasks)
+            if conflicts:
+                raise UnexportedWorkError(tasks[0].locale, conflicts)
 
         for task in tasks:
             try:
@@ -629,6 +755,16 @@ def insert_tasks(tasks: list[TranslationTask]) -> int:
                             WHEN translation_tasks.status = 'completed'
                                 THEN NULL
                             ELSE translation_tasks.translations_json
+                        END,
+                        -- Drop the export receipt alongside the translations it
+                        -- vouched for. Without this, a reopened level would be
+                        -- re-translated, left unexported, and then clobbered by
+                        -- the NEXT create -- the gate would read the stale
+                        -- receipt as proof that the new work is on disk.
+                        exported_at = CASE
+                            WHEN translation_tasks.status = 'completed'
+                                THEN NULL
+                            ELSE translation_tasks.exported_at
                         END,
                         updated_at = datetime('now')
                     """,
@@ -664,6 +800,17 @@ def _create_handler(args) -> int:
         )
         return 1
 
+    # --reopen only decides what a WRITE does, so asking for it without --apply
+    # is a misunderstanding worth naming: silently previewing would let someone
+    # believe they had authorized a discard that never happened.
+    if args.reopen and not args.apply:
+        print(
+            "Error: --reopen has no meaning without --apply (create writes "
+            "nothing by default).",
+            file=sys.stderr,
+        )
+        return 1
+
     dry_run = not args.apply
     print(f"Generating translation tasks for '{args.locale}'")
     print()
@@ -683,6 +830,25 @@ def _create_handler(args) -> int:
     print(f"    stale (en changed since):   {stats['stale_keys']}")
 
     if dry_run:
+        # A preview that doesn't mention the gate isn't a preview of the run.
+        # Report what --apply would refuse, so the operator learns it here
+        # rather than from a failed write in a batch script.
+        blocked = _preview_unexported_conflicts(tasks)
+        if blocked:
+            print()
+            print(
+                f"WOULD BE REFUSED: {len(blocked)} completed level(s) hold "
+                f"unexported translations."
+            )
+            for row in blocked:
+                print(
+                    f"  {row['file']}:{row['level_path']}  "
+                    f"({row['key_count']} keys)"
+                )
+            print(
+                f"  Run 'tasks export {args.locale}' first to keep that work, "
+                f"or pass --reopen to discard it."
+            )
         print()
         print("Preview only - no changes made. Pass --apply to write.")
         return 0
@@ -694,13 +860,46 @@ def _create_handler(args) -> int:
 
     # Insert into database
     try:
-        count = insert_tasks(tasks)
+        count = insert_tasks(tasks, reopen=args.reopen)
+    except UnexportedWorkError as e:
+        # Ordered before RuntimeError (its base): this is a refusal to destroy
+        # work, not a tool failure, and gets its own exit code so callers can
+        # branch on it.
+        print(f"\nError: {e}", file=sys.stderr)
+        return EXIT_UNEXPORTED_WORK
     except (FileNotFoundError, RuntimeError) as e:
         print(f"\nError: {e}", file=sys.stderr)
         sys.exit(1)
 
+    if args.reopen:
+        print("\n--reopen: conflicting completed levels were reopened.")
     print(f"\nInserted/updated {count} tasks into {DB_FILE}")
     return 0
+
+
+def _preview_unexported_conflicts(tasks: list[TranslationTask]) -> list[dict]:
+    """Best-effort dry-run read of what :func:`insert_tasks` would refuse.
+
+    Advisory only, so every reason the real gate can't be consulted yet — no DB,
+    pre-009 schema, unreadable file — degrades to "nothing to report" instead of
+    failing a preview that writes nothing anyway. ``--apply`` still hits the
+    authoritative check.
+    """
+    if not tasks or not DB_FILE.exists():
+        return []
+    try:
+        with get_connection() as conn:
+            columns = {
+                row[1]
+                for row in conn.execute(
+                    "PRAGMA table_info(translation_tasks)"
+                )
+            }
+            if "exported_at" not in columns:
+                return []
+            return find_unexported_conflicts(conn, tasks)
+    except sqlite3.Error:
+        return []
 
 
 # ---------------------------------------------------------------------------
@@ -1013,6 +1212,13 @@ def update_task(
             updates.append("translations_json = ?")
             params.append(translations_json)
 
+            # New text invalidates any prior export receipt: what's in
+            # content/<locale> is the OLD translation, so this row is once again
+            # the only copy of the current one and must be protected from
+            # `create`'s reopen. (Matters for a level exported, then revised
+            # in-place before the next export.)
+            updates.append("exported_at = NULL")
+
             # Auto-mark as completed if providing translations and no explicit status
             if status is None:
                 status = "completed"
@@ -1205,7 +1411,7 @@ def get_completed_tasks(
         cursor = conn.cursor()
 
         query = """
-            SELECT file, level_path, keys_json, translations_json,
+            SELECT id, file, level_path, keys_json, translations_json,
                    source_hashes_json
             FROM translation_tasks
             WHERE locale = ? AND status = 'completed' AND translations_json IS NOT NULL
@@ -1220,6 +1426,24 @@ def get_completed_tasks(
 
         cursor.execute(query, params)
         return [dict(row) for row in cursor.fetchall()]
+
+
+def mark_tasks_exported(task_ids: list[int]) -> None:
+    """Record that these rows' translations now exist in ``content/<locale>``.
+
+    The receipt `tasks create` reads to decide whether reopening a completed
+    level is free (text is on disk) or destructive (DB is the only copy).
+    Re-exporting an already-stamped row just refreshes the timestamp.
+    """
+    if not task_ids:
+        return
+    with get_connection() as conn:
+        conn.executemany(
+            "UPDATE translation_tasks SET exported_at = datetime('now') "
+            "WHERE id = ?",
+            [(tid,) for tid in task_ids],
+        )
+        conn.commit()
 
 
 def export_locale(
@@ -1337,6 +1561,13 @@ def export_locale(
                             print(f"  {task['level_path']}.{k}: {v[:40]}...")
         else:
             save_json_file(content_file, content)
+            # Stamp the export receipt only AFTER the content file is safely on
+            # disk, and only for the rows that went into THIS file. Ordering
+            # matters: a receipt written before a failed save would tell the
+            # create gate the work is durable when it isn't, which is the exact
+            # lie the column exists to prevent. Per-file (not once at the end)
+            # keeps earlier files' receipts truthful if a later save throws.
+            mark_tasks_exported([t["id"] for t in file_tasks])
             if not quiet:
                 print(f"{verb.capitalize()}d {file_name}: {key_count} keys")
 

--- a/locales/scripts/i18n/commands/tasks.py
+++ b/locales/scripts/i18n/commands/tasks.py
@@ -59,9 +59,18 @@ def _register_create(gsub) -> None:
         description="Generate translation tasks by comparing locales.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
+Default (catch-up) enqueues only keys that still need work: MISSING (absent
+from content/<locale>, or empty text without skip) plus STALE (translated, but
+the target's source_hash watermark no longer matches en's content_hash). Levels
+with no work produce no row, and reviewed translations are never re-enqueued.
+
+For a locale with no content/ directory yet, every key is missing, so the
+default and --all produce exactly the same tasks: a new language needs no flag.
+
 Examples:
-    python3 locales/scripts/i18n tasks create fr_CA            # Generate tasks for Canadian French
-    python3 locales/scripts/i18n tasks create eo --dry-run     # Preview without writing
+    python3 locales/scripts/i18n tasks create fr_CA            # catch up to the en source
+    python3 locales/scripts/i18n tasks create eo --dry-run     # preview without writing
+    python3 locales/scripts/i18n tasks create de --all         # re-enqueue EVERYTHING (rare)
         """,
     )
     c.add_argument(
@@ -74,15 +83,19 @@ Examples:
         help="Show what would be generated without writing",
     )
     c.add_argument(
-        "--missing-only",
+        "--all",
         action="store_true",
         help=(
-            "Enqueue keys untranslated in content/<locale> (absent, or empty "
-            "text without skip) plus stale ones (translated, but the en source "
-            "changed since), skipping levels with no work. Catches a "
-            "locale up to a grown English source without re-touching reviewed "
-            "translations. Run once per locale (re-running rewrites keys_json)."
+            "Target-blind: enqueue EVERY en key, including ones already "
+            "translated and reviewed. Queues a full re-translation of the "
+            "locale, and export then overwrites reviewed content with the new "
+            "output. Only for rebuilding a locale you intend to redo wholesale."
         ),
+    )
+    c.add_argument(
+        "--missing-only",
+        action="store_true",
+        help=argparse.SUPPRESS,  # now the default; accepted so old callers work
     )
     c.set_defaults(func=_create_handler)
 
@@ -448,19 +461,25 @@ def classify_key(entry: Optional[dict], en_hash: Optional[str]) -> str:
 def generate_tasks(
     locale: str,
     dry_run: bool = False,
-    missing_only: bool = False,
+    missing_only: bool = True,
 ) -> tuple[list[TranslationTask], dict[str, int]]:
     """Generate translation tasks from English source files.
 
-    Default behaviour is target-blind: every English key becomes a task,
-    regardless of the locale's existing translations. With ``missing_only``,
-    each English file is filtered against ``content/<locale>`` so only keys that
-    still need work are enqueued — **missing** (absent, or empty ``text`` without
-    ``skip``) *and* **stale** (translated, but the target's ``source_hash``
-    watermark no longer matches en's ``content_hash`` — English moved after the
-    translation was made). Levels left with no work produce no row. This is the
-    catch-up path for bringing a locale up to a grown *or edited* English source
-    without re-touching still-current reviewed translations.
+    Default (``missing_only``) filters each English file against
+    ``content/<locale>`` so only keys that still need work are enqueued —
+    **missing** (absent, or empty ``text`` without ``skip``) *and* **stale**
+    (translated, but the target's ``source_hash`` watermark no longer matches
+    en's ``content_hash`` — English moved after the translation was made).
+    Levels left with no work produce no row. This is the catch-up path for
+    bringing a locale up to a grown *or edited* English source without
+    re-touching still-current reviewed translations.
+
+    ``missing_only=False`` is target-blind: every English key becomes a task
+    regardless of what the locale already has. That queues a full
+    re-translation, and ``export`` then overwrites reviewed content with the new
+    output — which is why it is not the default and why the CLI spells it
+    ``--all``. For a locale with no ``content/`` directory the two modes are
+    identical (every key is missing), so a new language never needs the flag.
 
     Every generated task also snapshots the current en ``content_hash`` per leaf
     into ``source_hashes_json`` (both modes), so ``export`` can stamp the target
@@ -624,14 +643,28 @@ def insert_tasks(tasks: list[TranslationTask]) -> int:
 
 
 def _create_handler(args) -> int:
-    mode = " (missing-only)" if args.missing_only else ""
+    # `--missing-only` is the default as of the write-gate work; the flag is
+    # still accepted (hidden) so older scripts and slash commands keep working.
+    # Asking for both modes at once is a contradiction, not a preference.
+    if args.all and args.missing_only:
+        print(
+            "Error: --all and --missing-only are opposites; --missing-only is "
+            "the default, so pass neither for catch-up.",
+            file=sys.stderr,
+        )
+        return 1
+
+    missing_only = not args.all
+    # Only the dangerous mode gets a marker: the default is unremarkable, and a
+    # full re-translation must never be something you scroll past.
+    mode = "" if missing_only else " (--all: EVERY key, re-translating reviewed work)"
     print(f"Generating translation tasks for '{args.locale}'{mode}")
     print()
 
     tasks, stats = generate_tasks(
         locale=args.locale,
         dry_run=args.dry_run,
-        missing_only=args.missing_only,
+        missing_only=missing_only,
     )
 
     print()
@@ -639,7 +672,7 @@ def _create_handler(args) -> int:
     print(f"  Files: {stats['total_files']}")
     print(f"  Levels: {stats['total_levels']}")
     print(f"  Keys: {stats['total_keys']}")
-    if args.missing_only:
+    if missing_only:
         # In catch-up mode, break the enqueued keys into new vs re-translate.
         print(f"    missing (new/untranslated): {stats['missing_keys']}")
         print(f"    stale (en changed since):   {stats['stale_keys']}")
@@ -801,7 +834,7 @@ def compute_coverage(locale: str) -> dict[str, int]:
     ``skipped``. This answers "how current is this locale" — which the task
     queue's ``0 pending`` cannot: a fully drained queue can still hide keys whose
     English moved after they were translated (``stale``) until the next
-    ``tasks create --missing-only`` re-enqueues them.
+    ``tasks create`` re-enqueues them.
     """
     counts = {"current": 0, "stale": 0, "missing": 0, "skipped": 0}
     if not EN_DIR.exists():
@@ -1248,10 +1281,10 @@ def export_locale(
 
                 # An empty/whitespace "translation" must never overwrite an
                 # existing value or strip an intentional skip flag. This closes
-                # the default (target-blind) create hazard where a locale's
+                # the target-blind (`create --all`) hazard where a locale's
                 # already-skipped/translated key could be enqueued, "completed"
-                # blank, and clobbered here. --missing-only never enqueues such
-                # keys; this guards the default path too.
+                # blank, and clobbered here. The default create never enqueues
+                # such keys; this guards the --all path too.
                 if not (isinstance(translation, str) and translation.strip()):
                     continue
 

--- a/locales/scripts/i18n/commands/tasks.py
+++ b/locales/scripts/i18n/commands/tasks.py
@@ -19,10 +19,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import operator
+import re
 import sqlite3
 import sys
-from collections import defaultdict
+from collections import Counter, defaultdict
 from dataclasses import dataclass
+from functools import reduce
 from pathlib import Path
 from typing import Optional
 
@@ -30,6 +33,7 @@ from ..config import CONTENT_DIR, DB_FILE, EN_DIR
 from ..console import render_table
 from ..db import get_connection
 from ..io import load_json_file, save_json_file, walk_keys
+from ..tokens import extract_tokens, strip_tokens
 
 VALID_STATUSES = ("pending", "in_progress", "completed", "skipped")
 
@@ -45,6 +49,7 @@ def register(subparsers) -> None:
     _register_next(gsub)
     _register_update(gsub)
     _register_export(gsub)
+    _register_audit(gsub)
 
 
 def _register_create(gsub) -> None:
@@ -201,6 +206,16 @@ Examples:
             "and re-run with the corrected key set if any appear."
         ),
     )
+    c.add_argument(
+        "--strict",
+        action="store_true",
+        help=(
+            "Turn --validate into a gate (implies --validate): on any key "
+            "mismatch, print the same warnings, write NOTHING to the DB, and "
+            "exit 1. Use this in scripted/agent loops where an unread warning "
+            "would otherwise be committed."
+        ),
+    )
     c.set_defaults(func=_update_handler)
 
 
@@ -244,6 +259,60 @@ Examples:
         help="Quiet output (only errors)",
     )
     c.set_defaults(func=_export_handler)
+
+
+def _register_audit(gsub) -> None:
+    c = gsub.add_parser(
+        "audit",
+        help="Audit a locale's completed tasks in the DB, before export",
+        description=(
+            "Audit a locale's translation_tasks rows, in the DB and BEFORE any "
+            "export writes content/<locale>. Checks: status (no stranded "
+            "in_progress rows), key_set (translation keys equal source keys "
+            "exactly, and none is blank), tokens (interpolation and markup "
+            "tokens preserved with the same set AND count, compared per plural "
+            "form), en_leak (translation left byte-identical to the English "
+            "source). Needed because 'tasks update --validate' is advisory: a "
+            "drained queue does not prove the writes are clean."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Severity: status/key_set/tokens are errors and gate --strict. en_leak is
+ADVISORY — it is reported but never affects the exit code, because an identical
+string is the correct translation for a large class of short UI labels
+("Status", "TTL", "Redis", "Amazon SES", "Canada"). It also does not flag brand
+names that must stay English (Onetime Secret, Identity Plus, Starlight), empty
+sources, strings with no letters, keys marked skip, or English target locales.
+
+--strict also fails when zero completed rows were checked: a gate that verified
+nothing must not read green (same rule as `validate glossary --strict`).
+
+Examples:
+    python3 locales/scripts/i18n tasks audit de             # advisory, exit 0
+    python3 locales/scripts/i18n tasks audit de --strict    # gate, exit 1 on errors
+    python3 locales/scripts/i18n tasks audit de --json      # machine-readable
+        """,
+    )
+    c.add_argument(
+        "locale",
+        help="Target locale code (e.g., 'eo', 'de')",
+    )
+    c.add_argument(
+        "--json",
+        "-j",
+        action="store_true",
+        help="Output as JSON",
+    )
+    c.add_argument(
+        "--strict",
+        action="store_true",
+        help=(
+            "Exit non-zero on any error finding, or when no completed row "
+            "could be checked (default: advisory, exit 0). Advisory findings "
+            "(en_leak) are reported either way and never gate."
+        ),
+    )
+    c.set_defaults(func=_audit_handler)
 
 
 # ---------------------------------------------------------------------------
@@ -948,6 +1017,22 @@ def update_task(
         return task
 
 
+def diff_key_sets(
+    source_map: dict, translation_map: dict
+) -> tuple[list[str], list[str]]:
+    """``(missing, extra)`` leaf names, sorted.
+
+    The one definition of "the key sets disagree", shared by ``tasks update
+    --validate/--strict`` and the ``key_set`` check of ``tasks audit``.
+    """
+    expected_keys = set(source_map.keys())
+    provided_keys = set(translation_map.keys())
+    return (
+        sorted(expected_keys - provided_keys),
+        sorted(provided_keys - expected_keys),
+    )
+
+
 def validate_translations(keys_json: str, translations_json: str) -> list[str]:
     """Validate that translations match expected keys."""
     warnings = []
@@ -958,18 +1043,12 @@ def validate_translations(keys_json: str, translations_json: str) -> list[str]:
     except json.JSONDecodeError:
         return ["Invalid JSON"]
 
-    expected_keys = set(keys.keys())
-    provided_keys = set(translations.keys())
-
-    missing = expected_keys - provided_keys
-    extra = provided_keys - expected_keys
+    missing, extra = diff_key_sets(keys, translations)
 
     if missing:
-        warnings.append(
-            f"Missing translations for: {', '.join(sorted(missing))}"
-        )
+        warnings.append(f"Missing translations for: {', '.join(missing)}")
     if extra:
-        warnings.append(f"Extra keys not in source: {', '.join(sorted(extra))}")
+        warnings.append(f"Extra keys not in source: {', '.join(extra)}")
 
     return warnings
 
@@ -1004,9 +1083,16 @@ def _update_handler(args) -> int:
         )
         return 1
 
+    # --strict is --validate plus a gate. Resolved here rather than via an
+    # argparse default so the advisory path stays byte-for-byte what it was.
+    validate = getattr(args, "validate", False) or getattr(
+        args, "strict", False
+    )
+    strict = getattr(args, "strict", False)
+
     try:
         # Validation if requested
-        if args.validate and translations_json:
+        if validate and translations_json:
             # Need to fetch the task first to get keys_json
             task = get_task_by_id(args.task_id)
             if not task:
@@ -1021,6 +1107,17 @@ def _update_handler(args) -> int:
                     print(f"Warning: {warning}", file=sys.stderr)
                 # Advisory only: we warn but still save (exit 0). Callers must
                 # read these warnings and re-submit with the correct keys.
+                if strict:
+                    # ...unless --strict, which refuses the write. Nothing has
+                    # touched the DB yet (update_task below is the only writer),
+                    # so returning here leaves the row exactly as it was.
+                    print(
+                        "Refusing to write task "
+                        f"{args.task_id}: key set does not match the source "
+                        "(--strict).",
+                        file=sys.stderr,
+                    )
+                    return 1
 
         # Update the task
         task = update_task(
@@ -1249,3 +1346,580 @@ def _export_handler(args) -> int:
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
+
+
+# ---------------------------------------------------------------------------
+# audit  (pre-export gate over the completed rows in the DB)
+# ---------------------------------------------------------------------------
+# `tasks update --validate` is advisory, so `pending: 0` does not prove the
+# writes are clean (AGENT_TRANSLATION_PROTOCOL.md "Audit stage"). This reads the
+# rows back out of SQLite -- before any export touches
+# locales/content/<locale> -- and runs four checks.
+#
+# Everything below the CHECKS banner is pure: (source_map, translation_map) in,
+# findings out. No I/O, no printing, no argparse. The handler is the only part
+# that knows about the DB or the console.
+
+AUDIT_CHECKS = ("status", "key_set", "tokens", "en_leak")
+
+# Two severities, because one of the checks cannot be a gate.
+#
+# ERROR   -- a defect the export would carry into locales/content, or silently
+#            drop. `--strict` fails on these; export-all.sh refuses the locale.
+# ADVISORY-- reported, never gates. `en_leak` lives here: a translation being
+#            byte-identical to English is the CORRECT answer for a large class
+#            of short UI strings ("Status", "Version", "TTL", "Redis", product
+#            names, region names). Measured against the shipped tree it fires on
+#            132 correct de strings, 133 nl, 107 fr_FR. As a gate that makes a
+#            correctly translated locale unexportable unless someone enters a
+#            WRONG translation, so it reports and stays out of the exit code.
+SEVERITY_ERROR = "error"
+SEVERITY_ADVISORY = "advisory"
+
+ADVISORY_CHECKS = ("en_leak",)
+
+# Brand names that MUST stay English (AGENT_TRANSLATION_PROTOCOL.md
+# "Translation rules"). A string made of nothing but these is not a leak.
+ENGLISH_BRANDS = ("Onetime Secret", "Identity Plus", "Starlight")
+
+# Any Unicode letter. Used to decide whether a string contains something a
+# human could actually have translated.
+_LETTER_RE = re.compile(r"[^\W\d_]", re.UNICODE)
+
+# Vue i18n plural separator. "{count} item | {count} items" is ONE message with
+# two forms, and the number of forms is a property of the target language (ja 1,
+# en 2, ru 3). Token checks therefore compare per form, never whole-string.
+PLURAL_SEPARATOR = "|"
+
+
+@dataclass(frozen=True)
+class TaskRef:
+    """Where a finding came from. Empty defaults keep the checks callable bare."""
+
+    locale: str = ""
+    task_id: Optional[int] = None
+    file: str = ""
+    level_path: str = ""
+
+
+@dataclass(frozen=True)
+class AuditFinding:
+    """One problem with one completed row.
+
+    The single record type behind both output paths: ``--json`` serializes
+    exactly what the human renderer prints, so the two can never disagree.
+    ``leaf`` is the name inside ``keys_json``; ``key`` is the dotted path an
+    operator can grep for (``level_path.leaf``). Row-level findings carry an
+    empty ``leaf``.
+    """
+
+    check: str
+    detail: str
+    leaf: str = ""
+    ref: TaskRef = TaskRef()
+    source: Optional[str] = None
+    translation: Optional[str] = None
+
+    @property
+    def severity(self) -> str:
+        """``error`` (gates ``--strict``) or ``advisory`` (reported only)."""
+        return (
+            SEVERITY_ADVISORY
+            if self.check in ADVISORY_CHECKS
+            else SEVERITY_ERROR
+        )
+
+    @property
+    def key(self) -> str:
+        if not self.leaf:
+            return self.ref.level_path
+        if not self.ref.level_path:
+            return self.leaf
+        return f"{self.ref.level_path}.{self.leaf}"
+
+    def to_dict(self) -> dict:
+        return {
+            "locale": self.ref.locale,
+            "task_id": self.ref.task_id,
+            "file": self.ref.file,
+            "level_path": self.ref.level_path,
+            "key": self.key,
+            "leaf": self.leaf,
+            "check": self.check,
+            "severity": self.severity,
+            "detail": self.detail,
+            "source": self.source,
+            "translation": self.translation,
+        }
+
+
+# ----- CHECKS (pure) -------------------------------------------------------
+
+
+def _exportable(value) -> bool:
+    """Would :func:`export_locale` actually write ``value``?
+
+    It skips anything failing ``isinstance(str) and .strip()``. The audit uses
+    the same predicate so the two cannot disagree about what "translated" means.
+    """
+    return isinstance(value, str) and bool(value.strip())
+
+
+def check_key_set(
+    source_map: dict, translation_map: dict, ref: TaskRef = TaskRef()
+) -> list[AuditFinding]:
+    """The row's translation keys must equal its source keys exactly.
+
+    "Present" means *exportable*, not merely a key in the dict: a blank
+    translation passes a naive key-set diff but ``export_locale`` drops it, so
+    the key would never reach ``content/<locale>`` while the audit read green.
+    That is exactly the "pending: 0 does not prove the writes are clean" hole
+    this command exists to close, so a blank value is a key_set finding.
+    """
+    missing, extra = diff_key_sets(source_map, translation_map)
+    findings = [
+        AuditFinding(
+            check="key_set",
+            detail="missing from translations",
+            leaf=leaf,
+            ref=ref,
+            source=source_map.get(leaf),
+        )
+        for leaf in missing
+    ]
+    findings.extend(
+        AuditFinding(
+            check="key_set",
+            detail="extra key not in source",
+            leaf=leaf,
+            ref=ref,
+            translation=translation_map.get(leaf),
+        )
+        for leaf in extra
+    )
+    for leaf in sorted(set(source_map) & set(translation_map)):
+        source_text = source_map[leaf]
+        # An empty source has nothing to translate; export skips both sides.
+        if not _exportable(source_text):
+            continue
+        if _exportable(translation_map[leaf]):
+            continue
+        findings.append(
+            AuditFinding(
+                check="key_set",
+                detail="translation is blank; export would skip this key",
+                leaf=leaf,
+                ref=ref,
+                source=source_text,
+                translation=(
+                    translation_map[leaf]
+                    if isinstance(translation_map[leaf], str)
+                    else None
+                ),
+            )
+        )
+    return findings
+
+
+def _format_token_counts(counts: Counter[str]) -> str:
+    return ", ".join(
+        f"{token}x{n}" if n > 1 else token for token, n in sorted(counts.items())
+    )
+
+
+def _token_forms(text) -> list[Counter[str]]:
+    """Token multiset per Vue-i18n plural form.
+
+    A message is split on ``|`` because the FORM COUNT is a property of the
+    target language, not of the source: en has 2 plural forms, ja 1, ru 3.
+    Counting tokens over the whole string makes a correct ``ja`` translation of
+    ``"{count} team | {count} teams"`` look like a dropped ``{count}`` and a
+    correct ``ru`` one look like an extra. Non-strings yield one empty form.
+    """
+    if not isinstance(text, str):
+        return [extract_tokens(text)]
+    return [extract_tokens(form) for form in text.split(PLURAL_SEPARATOR)]
+
+
+def _pair_plural_forms(
+    source_forms: list[Counter[str]], translation_forms: list[Counter[str]]
+) -> list[tuple[Counter[str], Counter[str]]]:
+    """``(expected, actual)`` per translation form.
+
+    Same number of forms on both sides -> compare positionally. Different
+    numbers (the normal case for ja/ru/zh) -> every translation form is measured
+    against the source's per-form multiset. All 16 plural messages in the
+    shipped en tree carry identical tokens in every form, so "the source's form"
+    is well defined; the union is only a fallback for a source whose forms
+    disagree, where refusing to guess would be worse than being lenient.
+    """
+    if len(source_forms) == len(translation_forms):
+        return list(zip(source_forms, translation_forms))
+
+    expected = source_forms[0]
+    if not all(form == expected for form in source_forms):
+        expected = reduce(operator.or_, source_forms)
+    return [(expected, actual) for actual in translation_forms]
+
+
+def check_tokens(
+    source_map: dict, translation_map: dict, ref: TaskRef = TaskRef()
+) -> list[AuditFinding]:
+    """Per key, the translation's token multiset must equal the source's.
+
+    Multiset, not set: dropping one of two ``{count}`` occurrences is a bug.
+    Compared per plural form (see :func:`_pair_plural_forms`) so a language with
+    a different number of forms is not flagged for having them. Token families
+    and their one definition live in :mod:`i18n.tokens`. Only keys present on
+    both sides are compared -- absences are ``key_set``'s job.
+    """
+    findings: list[AuditFinding] = []
+    for leaf in sorted(source_map):
+        if leaf not in translation_map:
+            continue
+        source_text = source_map[leaf]
+        translation = translation_map[leaf]
+        pairs = _pair_plural_forms(
+            _token_forms(source_text), _token_forms(translation)
+        )
+
+        details = []
+        for index, (expected, actual) in enumerate(pairs, start=1):
+            if expected == actual:
+                continue
+            dropped = expected - actual
+            added = actual - expected
+            parts = []
+            if dropped:
+                parts.append(f"missing {_format_token_counts(dropped)}")
+            if added:
+                parts.append(f"extra {_format_token_counts(added)}")
+            prefix = f"form {index}: " if len(pairs) > 1 else ""
+            details.append(prefix + "; ".join(parts))
+
+        if not details:
+            continue
+        findings.append(
+            AuditFinding(
+                check="tokens",
+                detail="; ".join(details),
+                leaf=leaf,
+                ref=ref,
+                source=source_text if isinstance(source_text, str) else None,
+                translation=(
+                    translation if isinstance(translation, str) else None
+                ),
+            )
+        )
+    return findings
+
+
+def _is_translatable_prose(source_text: str) -> bool:
+    """Would a real translation of ``source_text`` differ from the English?
+
+    False for the cases where an identical string is the CORRECT answer, so the
+    leak check never fires on them:
+
+    * empty / whitespace-only source;
+    * strings with no letters at all -- numbers, punctuation, symbols, and bare
+      placeholders like ``{count}`` or ``%s`` (tokens are stripped first);
+    * strings whose only letters belong to a brand that must stay English
+      (``Onetime Secret``, ``Identity Plus``, ``Starlight``).
+    """
+    if not isinstance(source_text, str) or not source_text.strip():
+        return False
+
+    residue = strip_tokens(source_text)
+    for brand in ENGLISH_BRANDS:
+        residue = re.sub(re.escape(brand), " ", residue, flags=re.IGNORECASE)
+    return bool(_LETTER_RE.search(residue))
+
+
+def check_en_leak(
+    source_map: dict, translation_map: dict, ref: TaskRef = TaskRef()
+) -> list[AuditFinding]:
+    """Flag translations left byte-identical to their English source.
+
+    ADVISORY, never a gate (see :data:`ADVISORY_CHECKS`). No amount of exclusion
+    tuning makes this safe to block on: "Status", "Version", "TTL", "Redis",
+    "Amazon SES", "Canada" and a long tail like them are correct German, and a
+    gate on them can only be satisfied by entering a wrong translation.
+
+    Still deliberately conservative, because it is read by humans. It fires only
+    on an exact byte match of a source that :func:`_is_translatable_prose` says
+    had something to translate, and never for an English target locale (``en``,
+    ``en_GB``, ...), where identical IS the translation. Keys marked ``skip`` in
+    the en source never reach ``keys_json`` at all (``io.walk_keys``), and
+    ``status='skipped'`` rows are outside the completed set the handler reads,
+    so both are excluded upstream.
+    """
+    # An English target (en, en_GB, ...) is identical to en by definition. An
+    # unset locale (bare TaskRef) is NOT treated as English -- the check must
+    # still run when called directly with two maps.
+    if (ref.locale or "").split("_")[0].lower() == "en":
+        return []
+
+    findings: list[AuditFinding] = []
+    for leaf in sorted(source_map):
+        if leaf not in translation_map:
+            continue
+        source_text = source_map[leaf]
+        translation = translation_map[leaf]
+        if not isinstance(translation, str) or translation != source_text:
+            continue
+        if not _is_translatable_prose(source_text):
+            continue
+        findings.append(
+            AuditFinding(
+                check="en_leak",
+                detail="translation is byte-identical to the English source",
+                leaf=leaf,
+                ref=ref,
+                source=source_text,
+                translation=translation,
+            )
+        )
+    return findings
+
+
+def audit_maps(
+    source_map: dict, translation_map: dict, ref: TaskRef = TaskRef()
+) -> list[AuditFinding]:
+    """Run all three checks over one row's key maps."""
+    return [
+        *check_key_set(source_map, translation_map, ref),
+        *check_tokens(source_map, translation_map, ref),
+        *check_en_leak(source_map, translation_map, ref),
+    ]
+
+
+def audit_row(row: dict) -> list[AuditFinding]:
+    """Audit one completed ``translation_tasks`` row (JSON columns still raw)."""
+    ref = TaskRef(
+        locale=row.get("locale") or "",
+        task_id=row.get("id"),
+        file=row.get("file") or "",
+        level_path=row.get("level_path") or "",
+    )
+
+    try:
+        source_map = json.loads(row["keys_json"]) if row.get("keys_json") else {}
+    except json.JSONDecodeError as e:
+        return [
+            AuditFinding(
+                check="key_set", detail=f"invalid keys_json: {e}", ref=ref
+            )
+        ]
+
+    # A completed row with no translations is itself a finding -- the export
+    # query hides these behind `translations_json IS NOT NULL`, so the audit is
+    # the only place it surfaces.
+    if not row.get("translations_json"):
+        return [
+            AuditFinding(
+                check="key_set",
+                detail=(
+                    f"completed row has no translations stored "
+                    f"({len(source_map)} source keys)"
+                ),
+                ref=ref,
+            )
+        ]
+
+    try:
+        translation_map = json.loads(row["translations_json"])
+    except json.JSONDecodeError as e:
+        return [
+            AuditFinding(
+                check="key_set",
+                detail=f"invalid translations_json: {e}",
+                ref=ref,
+            )
+        ]
+
+    if not isinstance(source_map, dict) or not isinstance(translation_map, dict):
+        return [
+            AuditFinding(
+                check="key_set",
+                detail="keys_json/translations_json are not JSON objects",
+                ref=ref,
+            )
+        ]
+
+    return audit_maps(source_map, translation_map, ref)
+
+
+# ----- DB + CLI ------------------------------------------------------------
+
+
+def _rows_for_audit(locale: str, status: str) -> list[dict]:
+    """Raw ``translation_tasks`` rows for ``locale`` in ``status``.
+
+    Separate from :func:`get_completed_tasks` on purpose: that one omits ``id``
+    (the audit reports it so an operator can re-run ``tasks update``) and
+    filters out NULL ``translations_json`` (load-bearing for export, but the
+    exact thing the audit must see).
+    """
+    if not DB_FILE.exists():
+        raise FileNotFoundError(f"Database not found: {DB_FILE}")
+
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT id, file, level_path, locale, status, keys_json,
+                   translations_json
+            FROM translation_tasks
+            WHERE locale = ? AND status = ?
+            ORDER BY file, level_path, id
+            """,
+            (locale, status),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
+
+def get_completed_rows_for_audit(locale: str) -> list[dict]:
+    """Every ``status='completed'`` row for ``locale``, raw JSON columns."""
+    return _rows_for_audit(locale, "completed")
+
+
+def check_stranded_rows(rows: list[dict]) -> list[AuditFinding]:
+    """``in_progress`` rows: claimed, never finished, invisible to both gates.
+
+    ``tasks next --stats`` counts them separately from ``pending``, so a locale
+    with nothing but a stranded claim reports ``pending: 0`` and reads as
+    drained; the per-key checks only look at ``completed`` rows, so it reads as
+    clean too. The export then writes a silently truncated locale at exit 0 --
+    and ``tasks next`` never re-serves an ``in_progress`` row, so it strands
+    indefinitely. Recover with ``tasks update <ID> --status pending``.
+
+    ``pending`` is deliberately NOT reported here: that is the drained gate's
+    job, and duplicating it would make the audit shout about every locale that
+    has simply not been translated yet.
+    """
+    findings = []
+    for row in rows:
+        try:
+            key_count = len(json.loads(row["keys_json"] or "{}"))
+        except (json.JSONDecodeError, TypeError):
+            key_count = 0
+        findings.append(
+            AuditFinding(
+                check="status",
+                detail=(
+                    f"row is still in_progress; its {key_count} key(s) will "
+                    "not be exported (reset with `tasks update "
+                    f"{row.get('id')} --status pending`)"
+                ),
+                ref=TaskRef(
+                    locale=row.get("locale") or "",
+                    task_id=row.get("id"),
+                    file=row.get("file") or "",
+                    level_path=row.get("level_path") or "",
+                ),
+            )
+        )
+    return findings
+
+
+def audit_locale(locale: str) -> tuple[list[AuditFinding], int]:
+    """``(findings, rows_checked)`` for ``locale``.
+
+    ``rows_checked`` counts only the completed rows the per-key checks ran over;
+    stranded ``in_progress`` rows are findings, not checked rows.
+    """
+    rows = get_completed_rows_for_audit(locale)
+    findings: list[AuditFinding] = check_stranded_rows(
+        _rows_for_audit(locale, "in_progress")
+    )
+    for row in rows:
+        findings.extend(audit_row(row))
+    return findings, len(rows)
+
+
+def _print_audit_human(
+    locale: str, findings: list[AuditFinding], rows_checked: int
+) -> None:
+    by_task: dict[tuple, list[AuditFinding]] = defaultdict(list)
+    for finding in findings:
+        by_task[
+            (finding.ref.task_id, finding.ref.file, finding.ref.level_path)
+        ].append(finding)
+
+    for (task_id, file_name, level_path), group in by_task.items():
+        print(f"\ntask {task_id} · {file_name} · {level_path}")
+        for finding in group:
+            marker = "" if finding.severity == SEVERITY_ERROR else " (advisory)"
+            print(
+                f"  [{finding.check}]{marker} {finding.key}: {finding.detail}"
+            )
+            if finding.source is not None:
+                print(f'    en:       "{finding.source}"')
+            if finding.translation is not None:
+                print(f'    {locale}: "{finding.translation}"')
+
+    errors, advisories = _split_by_severity(findings)
+    if rows_checked == 0:
+        print(
+            f"\nNothing was verified for '{locale}': no completed rows in the "
+            "DB. This is not a clean locale, it is an unverified one."
+        )
+    # Always print the row count: a locale with zero completed rows produces
+    # zero findings, and "0 findings" alone would read green to export-all.sh.
+    print(
+        f"\nTOTAL: {len(findings)} finding(s) ({len(errors)} error, "
+        f"{len(advisories)} advisory) across {rows_checked} completed row(s) "
+        f"for '{locale}'"
+    )
+
+
+def _split_by_severity(
+    findings: list[AuditFinding],
+) -> tuple[list[AuditFinding], list[AuditFinding]]:
+    errors = [f for f in findings if f.severity == SEVERITY_ERROR]
+    advisories = [f for f in findings if f.severity != SEVERITY_ERROR]
+    return errors, advisories
+
+
+def _audit_handler(args) -> int:
+    try:
+        findings, rows_checked = audit_locale(args.locale)
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except sqlite3.Error as e:
+        print(f"Database error: {e}", file=sys.stderr)
+        return 1
+
+    errors, advisories = _split_by_severity(findings)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "locale": args.locale,
+                    "rows_checked": rows_checked,
+                    "findings_total": len(findings),
+                    "errors_total": len(errors),
+                    "advisories_total": len(advisories),
+                    "counts_by_check": {
+                        check: sum(1 for f in findings if f.check == check)
+                        for check in AUDIT_CHECKS
+                    },
+                    "findings": [f.to_dict() for f in findings],
+                },
+                indent=2,
+                default=str,
+            )
+        )
+    else:
+        _print_audit_human(args.locale, findings, rows_checked)
+
+    # Advisory by default (mirrors `validate glossary`): print and exit 0.
+    # --strict is the gate export-all.sh runs before it writes content, and it
+    # follows `validate glossary --strict` exactly: fail on an error finding,
+    # and ALSO fail when nothing could be checked — a gate that verifies nothing
+    # must not read green. `en_leak` findings are advisory and never gate.
+    if args.strict and (errors or rows_checked == 0):
+        return 1
+    return 0

--- a/locales/scripts/i18n/commands/tasks.py
+++ b/locales/scripts/i18n/commands/tasks.py
@@ -67,10 +67,15 @@ with no work produce no row, and reviewed translations are never re-enqueued.
 For a locale with no content/ directory yet, every key is missing, so the
 default and --all produce exactly the same tasks: a new language needs no flag.
 
+Without --apply this is a preview: it prints what would be enqueued and writes
+nothing. Writing is not idempotent for drained levels — a conflicting completed
+row is reopened (status back to pending, its translations_json discarded) — so
+the write is an explicit decision, not the default.
+
 Examples:
-    python3 locales/scripts/i18n tasks create fr_CA            # catch up to the en source
-    python3 locales/scripts/i18n tasks create eo --dry-run     # preview without writing
-    python3 locales/scripts/i18n tasks create de --all         # re-enqueue EVERYTHING (rare)
+    python3 locales/scripts/i18n tasks create fr_CA            # preview the catch-up (no writes)
+    python3 locales/scripts/i18n tasks create eo --apply       # actually enqueue the tasks
+    python3 locales/scripts/i18n tasks create de --all --apply # re-enqueue EVERYTHING (rare)
         """,
     )
     c.add_argument(
@@ -78,9 +83,19 @@ Examples:
         help="Target locale code (e.g., 'eo', 'fr_CA', 'de')",
     )
     c.add_argument(
+        "--apply",
+        action="store_true",
+        help=(
+            "Write the generated tasks to the DB. Without it, create only "
+            "previews. Reopens any conflicting completed level (status back to "
+            "pending, its unexported translations discarded), so export before "
+            "re-running create if you want that work kept."
+        ),
+    )
+    c.add_argument(
         "--dry-run",
         action="store_true",
-        help="Show what would be generated without writing",
+        help=argparse.SUPPRESS,  # now the default; accepted so old callers work
     )
     c.add_argument(
         "--all",
@@ -568,18 +583,23 @@ def generate_tasks(
 def insert_tasks(tasks: list[TranslationTask]) -> int:
     """Insert translation tasks into the database.
 
-    Upserts on (file, level_path, locale): inserts new levels, and for levels
-    that already exist refreshes keys_json + updated_at. It never touches status
-    or translations_json, so in-flight / completed work is preserved.
+    Upserts on (file, level_path, locale): inserts new levels, refreshes
+    keys_json + source_hashes_json + updated_at on ones that already exist.
 
-    ``source_hashes_json`` is refreshed on conflict ONLY for non-completed rows.
-    A completed row's snapshot is the en hash its translation was actually made
-    against — the watermark export must stamp. Refreshing it to the current en
-    hash on a re-run (after en drifted post-translation, pre-export) would make
-    export stamp a hash newer than the translation, falsely marking a stale key
-    current and hiding it forever. Freezing it on completed rows keeps the
-    watermark truthful; the drifted key stays stale and a fresh-DB catch-up
-    re-enqueues it.
+    A conflicting **completed** row is REOPENED: status back to ``pending`` and
+    ``translations_json`` cleared. ``generate_tasks`` only emits a level when it
+    has real work (missing/stale keys, or ``--all``), so a conflict with a
+    completed row always means that work must be redone — leaving the row
+    completed would strand it: ``tasks next`` never re-serves it, and its old
+    translations no longer match the refreshed key set. The clobber window is
+    deliberate: a completed level whose translations were never exported loses
+    them and is re-queued, so export before re-running ``create`` (the CLI
+    defaults to a dry run and requires ``--apply`` to make this an explicit
+    decision).
+
+    ``pending`` rows just get their keys/hashes refreshed; ``in_progress`` and
+    ``skipped`` keep their status — an active claim isn't yanked, and a
+    row-level skip is an operator decision create shouldn't override.
 
     Returns:
         Count of inserted/updated rows.
@@ -619,10 +639,16 @@ def insert_tasks(tasks: list[TranslationTask]) -> int:
                     VALUES (?, ?, ?, ?, ?)
                     ON CONFLICT(file, level_path, locale) DO UPDATE SET
                         keys_json = excluded.keys_json,
-                        source_hashes_json = CASE
+                        source_hashes_json = excluded.source_hashes_json,
+                        status = CASE
                             WHEN translation_tasks.status = 'completed'
-                                THEN translation_tasks.source_hashes_json
-                            ELSE excluded.source_hashes_json
+                                THEN 'pending'
+                            ELSE translation_tasks.status
+                        END,
+                        translations_json = CASE
+                            WHEN translation_tasks.status = 'completed'
+                                THEN NULL
+                            ELSE translation_tasks.translations_json
                         END,
                         updated_at = datetime('now')
                     """,
@@ -654,6 +680,16 @@ def _create_handler(args) -> int:
         )
         return 1
 
+    # Same for `--dry-run`: previewing is the default, writing is opt-in.
+    if args.apply and args.dry_run:
+        print(
+            "Error: --apply and --dry-run are opposites; --dry-run is the "
+            "default, so pass neither to preview.",
+            file=sys.stderr,
+        )
+        return 1
+
+    dry_run = not args.apply
     missing_only = not args.all
     # Only the dangerous mode gets a marker: the default is unremarkable, and a
     # full re-translation must never be something you scroll past.
@@ -663,7 +699,7 @@ def _create_handler(args) -> int:
 
     tasks, stats = generate_tasks(
         locale=args.locale,
-        dry_run=args.dry_run,
+        dry_run=dry_run,
         missing_only=missing_only,
     )
 
@@ -677,9 +713,9 @@ def _create_handler(args) -> int:
         print(f"    missing (new/untranslated): {stats['missing_keys']}")
         print(f"    stale (en changed since):   {stats['stale_keys']}")
 
-    if args.dry_run:
+    if dry_run:
         print()
-        print("Dry run - no changes made.")
+        print("Preview only - no changes made. Pass --apply to write.")
         return 0
 
     if not tasks:

--- a/locales/scripts/i18n/commands/validate.py
+++ b/locales/scripts/i18n/commands/validate.py
@@ -31,34 +31,25 @@ from typing import Any
 
 from ..config import CONTENT_DIR, RESOLVED_DIR, SOURCE_LOCALE, iter_locale_dirs
 from ..io import load_json_file, walk_keys
+from ..tokens import (  # noqa: F401  (re-exported: historical public names)
+    ERB_VAR_PATTERN,
+    PRINTF_PATTERN,
+    VUE_VAR_PATTERN,
+    extract_variables,
+)
 
 # ---------------------------------------------------------------------------
-# Shared variable patterns (identical in both legacy scripts)
+# Shared variable patterns
 # ---------------------------------------------------------------------------
-
-# Vue i18n: {variable} - use negative lookbehind to exclude ERB %{variable}
-VUE_VAR_PATTERN = re.compile(r"(?<!%)(?<!\{)\{([a-zA-Z0-9_]+)\}")
-ERB_VAR_PATTERN = re.compile(r"%\{([a-zA-Z0-9_]+)\}")
-PRINTF_PATTERN = re.compile(r"%[sdifuxXoeEgGcp]")
+# The patterns and `extract_variables` moved to :mod:`i18n.tokens` -- ONE
+# definition of "what is a token", shared with ``tasks audit``. Twin
+# normalizers drifting apart has bitten this repo twice (#4023, #4047), so do
+# not re-declare them here. Imported under their historical names, so every
+# call site below (and any outside importer) is unchanged.
 
 # Files that must use Ruby ERB format only (%{var}), not Vue ({var}).
 # Email templates are rendered server-side by Ruby, not by Vue.
 RUBY_ONLY_FILES = {"email.json"}
-
-
-def extract_variables(text: Any) -> dict[str, set[str]]:
-    """Extract all variable patterns from a string.
-
-    Accepts Any type for defensive validation of JSON values.
-    """
-    if not isinstance(text, str):
-        return {"vue": set(), "erb": set(), "printf": set()}
-
-    return {
-        "vue": set(VUE_VAR_PATTERN.findall(text)),
-        "erb": set(ERB_VAR_PATTERN.findall(text)),
-        "printf": set(PRINTF_PATTERN.findall(text)),
-    }
 
 
 def flatten_json(obj: dict[str, Any], prefix: str = "") -> dict[str, str]:

--- a/locales/scripts/i18n/db.py
+++ b/locales/scripts/i18n/db.py
@@ -87,6 +87,7 @@ SCHEMA_VERSIONS = [
     ("006", "rename_columns"),
     ("007", "translation_issues"),
     ("008", "task_source_hashes"),
+    ("009", "task_exported_at"),
 ]
 
 
@@ -113,6 +114,21 @@ def _ensure_task_columns(conn: sqlite3.Connection) -> list[str]:
             "ALTER TABLE translation_tasks ADD COLUMN source_hashes_json TEXT"
         )
         added.append("source_hashes_json")
+
+    # 009_task_exported_at: export receipt guarding the create/reopen clobber.
+    #
+    # Deliberately NOT backfilled. Every pre-existing completed row lands on
+    # NULL — "not known to be exported" — even though most of them almost
+    # certainly were. That direction is the safe one: a false NULL costs one
+    # refusal that `tasks export` (idempotent: it rewrites identical content and
+    # stamps the receipt) or `--reopen` clears, while a false stamp would
+    # silently drop the protection for exactly the unexported work this column
+    # exists to save.
+    if "exported_at" not in existing:
+        cursor.execute(
+            "ALTER TABLE translation_tasks ADD COLUMN exported_at TEXT"
+        )
+        added.append("exported_at")
 
     return added
 

--- a/locales/scripts/i18n/tokens.py
+++ b/locales/scripts/i18n/tokens.py
@@ -1,0 +1,125 @@
+# locales/scripts/i18n/tokens.py
+
+"""Single definition of "what is an interpolation/markup token".
+
+Lifted verbatim out of :mod:`i18n.commands.validate` so the ``validate``
+subcommands and ``tasks audit`` share one parser. This repo has twice been
+bitten by twin normalizers drifting apart (issues #4023, #4047); a second token
+regex is therefore not allowed. ``validate.py`` re-exports the names it used to
+define so its call sites are unchanged.
+
+Two views of the same patterns:
+
+* :func:`extract_variables` -- the historical **set** view, returning exactly
+  the three families (``vue``/``erb``/``printf``) the ``validate`` subcommands
+  compare. Its shape is load-bearing (``check_empty_with_vars`` tests
+  ``any(...)`` over ``.values()``), so nothing is added to it.
+* :func:`extract_tokens` -- the **multiset** view over all five families
+  documented in ``AGENT_TRANSLATION_PROTOCOL.md`` (``{var}``, ``{{var}}``,
+  ``%{var}``, printf, ``<tag>``), used by ``tasks audit`` where dropping one of
+  two ``{count}`` occurrences is a finding.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Patterns (identical in both legacy validate scripts -- do not "fix" them)
+# ---------------------------------------------------------------------------
+
+# Vue i18n: {variable} - use negative lookbehind to exclude ERB %{variable}
+VUE_VAR_PATTERN = re.compile(r"(?<!%)(?<!\{)\{([a-zA-Z0-9_]+)\}")
+ERB_VAR_PATTERN = re.compile(r"%\{([a-zA-Z0-9_]+)\}")
+# NOTE: deliberately no word boundary. It fires on things like "100%discount"
+# (%d). Pre-existing behaviour that every `validate variables` / `validate pr`
+# baseline already tolerates -- tightening it here would change their output.
+PRINTF_PATTERN = re.compile(r"%[sdifuxXoeEgGcp]")
+
+# Mustache / Vue slot interpolation: {{var}} (optionally padded). Matched by
+# NOTHING in the historical three patterns: VUE_VAR_PATTERN's (?<!\{) lookbehind
+# kills the inner {var} and the outer position fails because `{` is not in
+# [a-zA-Z0-9_]. Only used by the multiset view.
+MUSTACHE_VAR_PATTERN = re.compile(r"\{\{\s*([a-zA-Z0-9_.]+)\s*\}\}")
+
+# Markup: <b>, </b>, <br/>, <a href="...">. Requires a letter after `<` so
+# prose like "a < b" and "<3" never register.
+TAG_PATTERN = re.compile(r"<(/?)([a-zA-Z][a-zA-Z0-9]*)(?:\s[^<>]*?)?\s*(/?)>")
+
+
+def extract_variables(text: Any) -> dict[str, set[str]]:
+    """Extract all variable patterns from a string.
+
+    Accepts Any type for defensive validation of JSON values.
+
+    Returns **sets** and exactly the three historical families; call sites in
+    :mod:`i18n.commands.validate` do set arithmetic on the result. Use
+    :func:`extract_tokens` when counts or the full five families matter.
+    """
+    if not isinstance(text, str):
+        return {"vue": set(), "erb": set(), "printf": set()}
+
+    return {
+        "vue": set(VUE_VAR_PATTERN.findall(text)),
+        "erb": set(ERB_VAR_PATTERN.findall(text)),
+        "printf": set(PRINTF_PATTERN.findall(text)),
+    }
+
+
+def normalize_tag(closing: str, name: str, self_closing: str) -> str:
+    """Canonical rendering of a markup tag: ``<b>`` / ``</b>`` / ``<br/>``.
+
+    Attributes are dropped on purpose. Comparing ``<a href="/x">`` verbatim
+    would flag benign quoting/ordering differences; the protocol rule is that
+    the *tag* survives translation. Losing an attribute is therefore a false
+    negative we accept in exchange for a quiet check.
+    """
+    return f"<{closing}{name}{self_closing}>"
+
+
+def extract_tokens(text: Any) -> Counter[str]:
+    """Multiset of every interpolation/markup token in ``text``.
+
+    Keys are the tokens as an operator would grep for them (``{count}``,
+    ``{{count}}``, ``%{count}``, ``%s``, ``<b>``); values are occurrence counts.
+    Non-string input yields an empty Counter.
+    """
+    counts: Counter[str] = Counter()
+    if not isinstance(text, str):
+        return counts
+
+    # {{var}} first, then blank it out, so a mustache token can never also be
+    # counted as a vue token. (The lookbehinds already guarantee that today;
+    # not depending on them keeps the two families independent.)
+    for match in MUSTACHE_VAR_PATTERN.finditer(text):
+        counts[f"{{{{{match.group(1)}}}}}"] += 1
+    rest = MUSTACHE_VAR_PATTERN.sub(" ", text)
+
+    for name in VUE_VAR_PATTERN.findall(rest):
+        counts[f"{{{name}}}"] += 1
+    for name in ERB_VAR_PATTERN.findall(rest):
+        counts[f"%{{{name}}}"] += 1
+    for spec in PRINTF_PATTERN.findall(rest):
+        counts[spec] += 1
+    for closing, name, self_closing in TAG_PATTERN.findall(rest):
+        counts[normalize_tag(closing, name, self_closing)] += 1
+
+    return counts
+
+
+def strip_tokens(text: str) -> str:
+    """``text`` with every token removed -- what a human is asked to translate.
+
+    Used by the ``tasks audit`` English-leak check to tell "this string is one
+    bare placeholder" from "this string is untranslated prose".
+    """
+    if not isinstance(text, str):
+        return ""
+    out = MUSTACHE_VAR_PATTERN.sub(" ", text)
+    out = ERB_VAR_PATTERN.sub(" ", out)
+    out = VUE_VAR_PATTERN.sub(" ", out)
+    out = PRINTF_PATTERN.sub(" ", out)
+    out = TAG_PATTERN.sub(" ", out)
+    return out

--- a/locales/scripts/tests/test_i18n_cli.py
+++ b/locales/scripts/tests/test_i18n_cli.py
@@ -439,15 +439,30 @@ class TasksFlowTest(I18nCliTestCase):
             f"missing-only enqueued {enqueued}, expected only {missing_key}",
         )
 
-    def test_create_defaults_to_missing_only_and_all_is_opt_in(self) -> None:
-        # The default must be the safe one: a locale that is already fully
-        # translated enqueues NOTHING, and only --all re-queues reviewed work.
+    def test_create_is_catch_up_only_and_all_is_rejected(self) -> None:
+        # create has exactly one mode (catch-up) and one write gate (--apply):
+        # a fully-translated locale enqueues NOTHING, a preview never reaches
+        # the DB even when there IS work, and the retired target-blind --all is
+        # refused outright rather than silently ignored.
         import sqlite3
 
         eo = self.content / "eo"
         eo.mkdir(parents=True)
+        victim: tuple[Path, str] | None = None
         for f in sorted((self.content / "en").glob("*.json")):
+            data = json.loads(f.read_text("utf-8"))
             shutil.copy(f, eo / f.name)
+            translatable = [
+                k
+                for k, v in data.items()
+                if isinstance(v, dict)
+                and not v.get("skip")
+                and v.get("text", "") != ""
+                and not k.startswith("_")
+            ]
+            if victim is None and translatable:
+                victim = (eo / f.name, translatable[0])
+        self.assertIsNotNone(victim, "need an en file with a translatable key")
 
         def enqueued() -> int:
             conn = sqlite3.connect(self.db_dir / "tasks.db")
@@ -460,35 +475,43 @@ class TasksFlowTest(I18nCliTestCase):
         # Applied create: fully-translated locale, nothing to do.
         self.assertOk(self.run_cli("tasks", "create", "eo", "--apply"), "create")
         self.assertEqual(
-            enqueued(), 0, "default create re-enqueued already-translated keys"
+            enqueued(), 0, "create re-enqueued already-translated keys"
         )
 
-        # Without --apply even --all is a preview: nothing may reach the DB.
-        self.assertOk(
-            self.run_cli("tasks", "create", "eo", "--all"), "preview --all"
-        )
+        # Now there is real work — but without --apply it stays a preview.
+        path, missing_key = victim
+        d = json.loads(path.read_text("utf-8"))
+        del d[missing_key]
+        path.write_text(json.dumps(d), encoding="utf-8")
+
+        self.assertOk(self.run_cli("tasks", "create", "eo"), "preview")
         self.assertEqual(enqueued(), 0, "create without --apply wrote to the DB")
 
-        # --all --apply: target-blind, queues the whole en key set.
         self.assertOk(
-            self.run_cli("tasks", "create", "eo", "--all", "--apply"),
-            "create --all --apply",
+            self.run_cli("tasks", "create", "eo", "--apply"), "create --apply"
         )
-        self.assertGreater(enqueued(), 0, "--all --apply enqueued nothing")
+        self.assertGreater(enqueued(), 0, "--apply enqueued nothing")
 
-        # The retired flags still parse (old scripts/slash commands pass them),
-        # but contradicting the current default is an error, not a preference.
+        # --all is gone: argparse must reject it, so a caller that still passes
+        # it fails loudly instead of quietly getting a catch-up run.
+        for flag in ("--all", "--all --apply"):
+            rejected = self.run_cli("tasks", "create", "eo", *flag.split())
+            self.assertNotEqual(
+                rejected.returncode, 0, f"{flag} must be rejected"
+            )
+
+        # --missing-only still parses (old scripts/slash commands pass it), but
+        # contradicting the current default is an error, not a preference.
         self.assertOk(
             self.run_cli("tasks", "create", "eo", "--missing-only", "--apply"),
             "create --missing-only (accepted, now the default)",
         )
-        for combo in (("--all", "--missing-only"), ("--apply", "--dry-run")):
-            contradiction = self.run_cli("tasks", "create", "eo", *combo)
-            self.assertNotEqual(
-                contradiction.returncode,
-                0,
-                f"{' '.join(combo)} must not succeed",
-            )
+        contradiction = self.run_cli(
+            "tasks", "create", "eo", "--apply", "--dry-run"
+        )
+        self.assertNotEqual(
+            contradiction.returncode, 0, "--apply --dry-run must not succeed"
+        )
 
     def test_export_skips_empty_translation_preserving_skip(self) -> None:
         # An empty/whitespace completed translation must not blank existing

--- a/locales/scripts/tests/test_i18n_cli.py
+++ b/locales/scripts/tests/test_i18n_cli.py
@@ -84,12 +84,20 @@ class I18nCliTestCase(unittest.TestCase):
         for f in _en_slice():
             shutil.copy(f, self.content / "en" / f.name)
 
+        # Drop every ambient I18N_* override before re-adding our own: an
+        # exported I18N_DB_FILE in the developer's shell outranks
+        # I18N_DB_DIR (config.py cascades DB_DIR -> DB_FILE only as a
+        # default) and would point the whole suite at the real tasks.db.
         self.env = {
-            **os.environ,
-            "I18N_CONTENT_DIR": str(self.content),
-            "I18N_GENERATED_DIR": str(self.generated),
-            "I18N_DB_DIR": str(self.db_dir),
+            k: v for k, v in os.environ.items() if not k.startswith("I18N_")
         }
+        self.env.update(
+            {
+                "I18N_CONTENT_DIR": str(self.content),
+                "I18N_GENERATED_DIR": str(self.generated),
+                "I18N_DB_DIR": str(self.db_dir),
+            }
+        )
 
     def run_cli(
         self, *args: str, cwd: Path | None = None, env: dict | None = None
@@ -892,6 +900,556 @@ class ValidatePrGitDiffTest(I18nCliTestCase):
         # git discovery routed exactly the changed eo file; en (source) filtered.
         self.assertEqual(summary["files_checked"], 1)
         self.assertEqual(summary["locales"], ["eo"])
+
+
+class TasksUpdateStrictTest(I18nCliTestCase):
+    """`tasks update --validate` stays advisory; `--strict` turns it into a gate.
+
+    The advisory contract is documented in AGENT_TRANSLATION_PROTOCOL.md and
+    existing callers depend on it, so the no-``--strict`` path is pinned here
+    as a regression guard, not just as a foil for the gate.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Controlled two-leaf level so one task owns exactly {submit, cancel}.
+        en = self.content / "en"
+        for f in en.glob("*.json"):
+            f.unlink()
+        (en / "00.json").write_text(
+            json.dumps(
+                {
+                    "web.U.submit": {
+                        "text": "Submit",
+                        "content_hash": "aaaa1111",
+                    },
+                    "web.U.cancel": {
+                        "text": "Cancel",
+                        "content_hash": "bbbb2222",
+                    },
+                }
+            ),
+            "utf-8",
+        )
+        self.assertOk(self.run_cli("db", "init"), "db init")
+        self.assertOk(self.run_cli("tasks", "create", "de"), "create")
+        self.task_id = self._only_task_id()
+
+    def _only_task_id(self) -> int:
+        import sqlite3
+
+        conn = sqlite3.connect(self.db_dir / "tasks.db")
+        rows = conn.execute(
+            "SELECT id FROM translation_tasks WHERE locale='de'"
+        ).fetchall()
+        conn.close()
+        self.assertEqual(len(rows), 1, f"expected one de task, got {rows}")
+        return rows[0][0]
+
+    def _stored(self) -> dict | None:
+        import sqlite3
+
+        conn = sqlite3.connect(self.db_dir / "tasks.db")
+        (raw,) = conn.execute(
+            "SELECT translations_json FROM translation_tasks WHERE id=?",
+            (self.task_id,),
+        ).fetchone()
+        conn.close()
+        return json.loads(raw) if raw else None
+
+    def _seed_clean(self) -> dict:
+        """A known-good stored payload, so a refused write is observable."""
+        good = {"submit": "Senden", "cancel": "Abbrechen"}
+        self.assertOk(
+            self.run_cli(
+                "tasks", "update", str(self.task_id), json.dumps(good)
+            ),
+            "seed",
+        )
+        self.assertEqual(self._stored(), good)
+        return good
+
+    # --- advisory (no --strict) --------------------------------------------
+
+    def test_validate_without_strict_warns_saves_and_exits_zero(self) -> None:
+        # THE regression guard: documented advisory behaviour. A key-set
+        # mismatch under plain --validate must warn on stderr and STILL write.
+        proc = self.run_cli(
+            "tasks",
+            "update",
+            str(self.task_id),
+            json.dumps({"submit": "Senden"}),
+            "--validate",
+        )
+        self.assertOk(proc, "--validate advisory")
+        self.assertIn("Missing translations for: cancel", proc.stderr)
+        self.assertEqual(
+            self._stored(),
+            {"submit": "Senden"},
+            "--validate without --strict must still save (advisory contract)",
+        )
+
+    def test_validate_without_strict_warns_on_extra_keys_and_saves(self) -> None:
+        payload = {"submit": "Senden", "cancel": "Abbrechen", "bogus": "X"}
+        proc = self.run_cli(
+            "tasks",
+            "update",
+            str(self.task_id),
+            json.dumps(payload),
+            "--validate",
+        )
+        self.assertOk(proc, "--validate advisory (extra)")
+        self.assertIn("Extra keys not in source: bogus", proc.stderr)
+        self.assertEqual(self._stored(), payload)
+
+    # --- gate (--strict) ----------------------------------------------------
+
+    def test_strict_refuses_write_on_missing_keys(self) -> None:
+        good = self._seed_clean()
+        proc = self.run_cli(
+            "tasks",
+            "update",
+            str(self.task_id),
+            json.dumps({"submit": "POISON"}),
+            "--validate",
+            "--strict",
+        )
+        self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
+        self.assertIn("Missing translations for: cancel", proc.stderr)
+        self.assertEqual(
+            self._stored(), good, "--strict wrote despite refusing"
+        )
+
+    def test_strict_refuses_write_on_extra_keys(self) -> None:
+        good = self._seed_clean()
+        proc = self.run_cli(
+            "tasks",
+            "update",
+            str(self.task_id),
+            json.dumps({"submit": "A", "cancel": "B", "bogus": "C"}),
+            "--validate",
+            "--strict",
+        )
+        self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
+        self.assertIn("Extra keys not in source: bogus", proc.stderr)
+        self.assertEqual(self._stored(), good)
+
+    def test_strict_implies_validate(self) -> None:
+        # --strict alone (no --validate) must still validate and gate.
+        good = self._seed_clean()
+        proc = self.run_cli(
+            "tasks",
+            "update",
+            str(self.task_id),
+            json.dumps({"submit": "POISON"}),
+            "--strict",
+        )
+        self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
+        self.assertIn("Missing translations for: cancel", proc.stderr)
+        self.assertEqual(self._stored(), good)
+
+    def test_strict_saves_a_clean_payload(self) -> None:
+        payload = {"submit": "Senden", "cancel": "Abbrechen"}
+        proc = self.run_cli(
+            "tasks",
+            "update",
+            str(self.task_id),
+            json.dumps(payload),
+            "--strict",
+        )
+        self.assertOk(proc, "--strict clean payload")
+        self.assertEqual(self._stored(), payload)
+
+    def test_strict_without_translations_does_not_gate(self) -> None:
+        # A status-only update carries no key set to compare; --strict must not
+        # invent a mismatch out of it.
+        proc = self.run_cli(
+            "tasks",
+            "update",
+            str(self.task_id),
+            "--status",
+            "in_progress",
+            "--strict",
+        )
+        self.assertOk(proc, "--strict status-only update")
+
+
+class TasksAuditTest(I18nCliTestCase):
+    """`tasks audit <locale>` — the pre-export gate over completed DB rows.
+
+    Rows are inserted directly: the audit reads ``translation_tasks`` and
+    nothing else, so hand-built rows give exact control over each check
+    (and let a completed-but-empty row exist at all, which the CLI write path
+    cannot produce).
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.assertOk(self.run_cli("db", "init"), "db init")
+        self._seq = 0
+
+    def _insert(
+        self,
+        keys: dict,
+        translations: dict | None,
+        locale: str = "de",
+        status: str = "completed",
+    ) -> int:
+        import sqlite3
+
+        self._seq += 1
+        conn = sqlite3.connect(self.db_dir / "tasks.db")
+        cur = conn.execute(
+            "INSERT INTO translation_tasks "
+            "(file, level_path, locale, status, keys_json, translations_json) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "00.json",
+                f"web.A{self._seq}",
+                locale,
+                status,
+                json.dumps(keys),
+                None if translations is None else json.dumps(translations),
+            ),
+        )
+        task_id = cur.lastrowid
+        conn.commit()
+        conn.close()
+        return task_id
+
+    def _audit(self, *args: str, locale: str = "de"):
+        return self.run_cli("tasks", "audit", locale, *args)
+
+    def _findings(self, locale: str = "de") -> list[dict]:
+        proc = self._audit("--json", locale=locale)
+        self.assertOk(proc, "audit --json")
+        return json.loads(proc.stdout)["findings"]
+
+    def _checks(self, locale: str = "de") -> list[str]:
+        return [f["check"] for f in self._findings(locale)]
+
+    # --- clean --------------------------------------------------------------
+
+    def test_clean_locale_has_no_findings_under_either_mode(self) -> None:
+        self._insert(
+            {"hello": "Hello {name}", "bye": "Goodbye"},
+            {"hello": "Hallo {name}", "bye": "Tschüss"},
+        )
+        proc = self._audit()
+        self.assertOk(proc, "audit advisory")
+        self.assertIn(
+            "TOTAL: 0 finding(s) (0 error, 0 advisory) across 1 completed row(s)",
+            proc.stdout,
+        )
+        self.assertOk(self._audit("--strict"), "audit --strict on a clean locale")
+
+    def test_zero_completed_rows_fails_strict(self) -> None:
+        # Same rule as `validate glossary --strict`: a gate that verified
+        # nothing must not read green. Without this, a content/<locale>/ that
+        # has never been through `tasks create` reports pending 0, audits
+        # "clean", and previews as ready-to-export.
+        self._insert({"hello": "Hello"}, None, status="pending")
+        proc = self._audit("--strict")
+        self.assertEqual(
+            proc.returncode, 1, "nothing verified must not pass the gate"
+        )
+        self.assertIn("across 0 completed row(s)", proc.stdout)
+        self.assertIn("Nothing was verified", proc.stdout)
+        self.assertOk(self._audit(), "advisory mode still exits 0")
+
+    def test_stranded_in_progress_row_is_an_error_finding(self) -> None:
+        # `tasks next --stats` counts in_progress separately from pending, so a
+        # stranded claim reads as drained; the per-key checks only see completed
+        # rows, so it reads as clean too. Without this check the locale exports
+        # silently truncated at exit 0.
+        self._insert({"done": "Done"}, {"done": "Fertig"})
+        stranded = self._insert(
+            {"c": "Cee", "d": "Dee"}, None, status="in_progress"
+        )
+        findings = self._findings()
+        self.assertEqual([f["check"] for f in findings], ["status"])
+        self.assertEqual(findings[0]["task_id"], stranded)
+        self.assertEqual(findings[0]["severity"], "error")
+        self.assertIn("2 key(s) will not be exported", findings[0]["detail"])
+        self.assertEqual(
+            self._audit("--strict").returncode,
+            1,
+            "a stranded row must block the export",
+        )
+
+    # --- key_set ------------------------------------------------------------
+
+    def test_key_set_flags_missing_and_extra_keys(self) -> None:
+        self._insert(
+            {"submit": "Submit", "cancel": "Cancel"},
+            {"submit": "Senden", "bogus": "X"},
+        )
+        findings = self._findings()
+        self.assertEqual([f["check"] for f in findings], ["key_set", "key_set"])
+        by_leaf = {f["leaf"]: f for f in findings}
+        self.assertIn("missing", by_leaf["cancel"]["detail"])
+        self.assertIn("extra", by_leaf["bogus"]["detail"])
+        # The dotted key an operator can grep for, not just the leaf.
+        self.assertEqual(by_leaf["cancel"]["key"], "web.A1.cancel")
+
+    def test_completed_row_with_no_translations_is_a_finding(self) -> None:
+        # The export query hides these behind `translations_json IS NOT NULL`;
+        # the audit is the only place a drained-but-empty row surfaces.
+        self._insert({"submit": "Submit"}, None)
+        findings = self._findings()
+        self.assertEqual([f["check"] for f in findings], ["key_set"])
+        self.assertIn("no translations", findings[0]["detail"])
+
+    def test_blank_translation_is_a_finding(self) -> None:
+        # export_locale skips any value failing `.strip()`, so a whitespace
+        # "translation" passes a naive key-set diff and then silently never
+        # reaches content/<locale>. Both sides must agree on what "translated"
+        # means, or the audit reports green for a key that stays English.
+        self._insert(
+            {"submit": "Submit", "cancel": "Cancel", "sep": "  "},
+            {"submit": "   ", "cancel": "Abbrechen", "sep": "  "},
+        )
+        findings = self._findings()
+        self.assertEqual(
+            [(f["check"], f["leaf"]) for f in findings],
+            [("key_set", "submit")],
+            "only the blank translation of a non-blank source is a finding",
+        )
+        self.assertIn("blank", findings[0]["detail"])
+        self.assertEqual(
+            self._audit("--strict").returncode, 1, "a blank must gate"
+        )
+
+    # --- tokens -------------------------------------------------------------
+
+    def test_tokens_flags_dropped_added_and_count_changes(self) -> None:
+        self._insert(
+            {
+                # dropped {var}
+                "vue_drop": "Hello {name}",
+                # renamed -> one dropped + one added, across %{var}
+                "erb_rename": "Hi %{name}",
+                # added printf token
+                "printf_add": "Total",
+                # dropped markup tag pair
+                "tag_drop": "<b>Bold</b> text",
+                # count change: two {n} in source, one in the translation
+                "count_drop": "{n} of {n}",
+            },
+            {
+                "vue_drop": "Hallo",
+                "erb_rename": "Hallo %{nombre}",
+                "printf_add": "Gesamt %s",
+                "tag_drop": "Fetter Text",
+                "count_drop": "{n} insgesamt",
+            },
+        )
+        findings = self._findings()
+        self.assertEqual(
+            sorted({f["check"] for f in findings}),
+            ["tokens"],
+            f"expected only token findings, got {findings}",
+        )
+        detail = {f["leaf"]: f["detail"] for f in findings}
+        self.assertEqual(sorted(detail), sorted(
+            ["vue_drop", "erb_rename", "printf_add", "tag_drop", "count_drop"]
+        ))
+        self.assertIn("missing {name}", detail["vue_drop"])
+        self.assertIn("missing %{name}", detail["erb_rename"])
+        self.assertIn("extra %{nombre}", detail["erb_rename"])
+        self.assertIn("extra %s", detail["printf_add"])
+        # Tokens are listed sorted, so the closing tag leads: "</b>, <b>".
+        self.assertIn("missing </b>, <b>", detail["tag_drop"])
+        # Multiset, not set: {n} survives, but only once.
+        self.assertIn("missing {n}", detail["count_drop"])
+
+    def test_tokens_tolerates_reordering_and_tag_attributes(self) -> None:
+        self._insert(
+            {
+                "reorder": "{a} then {b}",
+                "attrs": 'Read <a href="/en/docs">the docs</a>',
+                "mustache": "{{count}} items",
+            },
+            {
+                "reorder": "{b} dann {a}",
+                "attrs": 'Lies <a href="/de/docs">die Doku</a>',
+                "mustache": "{{count}} Artikel",
+            },
+        )
+        self.assertEqual(self._findings(), [])
+
+    def test_tokens_tolerates_a_different_plural_form_count(self) -> None:
+        # The number of Vue-i18n plural forms is a property of the TARGET
+        # language: en 2, ja 1, ru 3. Counting tokens over the whole string
+        # makes every correct ja translation look like a dropped {count} and
+        # every correct ru one like an extra — which, wired into export-all.sh
+        # as a hard gate, permanently blocks both locales.
+        source = {
+            "fewer": "{count} team | {count} teams",
+            "more": "{count} team | {count} teams",
+            # en singular, translation went plural (a real case in ru).
+            "grew": "Enabled with {count} recipient(s)",
+        }
+        self._insert(
+            source,
+            {
+                "fewer": "{count}チーム",
+                "more": "{count} команда | {count} команды | {count} команд",
+                "grew": "С {count} получателем | С {count} получателями",
+            },
+            locale="ru",
+        )
+        self.assertEqual(self._findings(locale="ru"), [])
+        self.assertOk(
+            self._audit("--strict", locale="ru"),
+            "plural-form counts must not gate an export",
+        )
+
+    def test_tokens_still_catches_a_drop_inside_one_plural_form(self) -> None:
+        self._insert(
+            {"n": "{count} team | {count} teams"},
+            {"n": "{count} Team | Teams"},
+        )
+        findings = self._findings()
+        self.assertEqual([f["check"] for f in findings], ["tokens"])
+        self.assertIn("form 2: missing {count}", findings[0]["detail"])
+
+    # --- en_leak ------------------------------------------------------------
+
+    def test_en_leak_flags_an_untranslated_string(self) -> None:
+        self._insert(
+            {"warn": "Delete this secret forever"},
+            {"warn": "Delete this secret forever"},
+        )
+        findings = self._findings()
+        self.assertEqual([f["check"] for f in findings], ["en_leak"])
+        self.assertEqual(findings[0]["leaf"], "warn")
+
+    def test_en_leak_is_advisory_and_never_gates(self) -> None:
+        # An identical string is the CORRECT translation for a large class of
+        # short UI labels — measured against the shipped tree this check fires
+        # on 132 correct de strings. As a gate the only way to export de would
+        # be to enter a wrong translation, so it reports and stays out of the
+        # exit code.
+        self._insert(
+            {"status": "Status", "ttl": "TTL", "vendor": "Amazon SES"},
+            {"status": "Status", "ttl": "TTL", "vendor": "Amazon SES"},
+        )
+        findings = self._findings()
+        self.assertEqual({f["check"] for f in findings}, {"en_leak"})
+        self.assertEqual({f["severity"] for f in findings}, {"advisory"})
+        proc = self._audit("--strict")
+        self.assertOk(proc, "en_leak alone must not block an export")
+        self.assertIn("(0 error, 3 advisory)", proc.stdout)
+
+    def test_en_leak_does_not_fire_on_brands_empty_or_letterless(self) -> None:
+        # These identical strings are the CORRECT answer. A noisy audit gets
+        # ignored, so the false-positive guards matter more than the catch.
+        keys = {
+            "brand": "Onetime Secret",
+            "brand_plan": "Identity Plus",
+            "brand_tier": "Starlight",
+            "brand_wrapped": "  Onetime Secret  ",
+            "empty": "",
+            "blank": "   ",
+            "numeric": "1,024",
+            "punct": "— · —",
+            "placeholder": "{count}",
+            "printf_only": "%s",
+            "tag_only": "<b></b>",
+            "brand_token": "{app} Starlight",
+        }
+        self._insert(keys, dict(keys))
+        self.assertEqual(
+            self._findings(),
+            [],
+            "en_leak fired on a string that is legitimately identical",
+        )
+
+    def test_en_leak_still_fires_on_prose_around_a_brand(self) -> None:
+        self._insert(
+            {"hero": "Welcome to Onetime Secret"},
+            {"hero": "Welcome to Onetime Secret"},
+        )
+        self.assertEqual(self._checks(), ["en_leak"])
+
+    def test_skipped_rows_are_outside_the_audit_set(self) -> None:
+        # status='skipped' is the row-level "skip" marker (key-level skip never
+        # reaches keys_json at all — io.walk_keys drops it).
+        self._insert(
+            {"warn": "Delete this secret forever"},
+            {"warn": "Delete this secret forever"},
+            status="skipped",
+        )
+        self._insert({"ok": "OK"}, {"ok": "Gut"})
+        proc = self._audit("--strict")
+        self.assertOk(proc, "skipped rows must not gate an export")
+        self.assertIn("across 1 completed row(s)", proc.stdout)
+
+    def test_en_leak_is_silent_for_an_english_target_locale(self) -> None:
+        self._insert(
+            {"warn": "Delete this secret forever"},
+            {"warn": "Delete this secret forever"},
+            locale="en_GB",
+        )
+        proc = self._audit("--strict", locale="en_GB")
+        self.assertOk(proc, "identical IS the translation for en_GB")
+        self.assertIn("across 1 completed row(s)", proc.stdout)
+
+    # --- exit convention + output parity ------------------------------------
+
+    def test_exit_convention_matches_validate_glossary(self) -> None:
+        self._insert({"submit": "Submit"}, {"nope": "X"})
+        self.assertOk(self._audit(), "default is advisory, exit 0")
+        self.assertEqual(
+            self._audit("--strict").returncode,
+            1,
+            "--strict must gate on a finding",
+        )
+        self.assertEqual(
+            self._audit("--json", "--strict").returncode,
+            1,
+            "--json must not swallow the gate",
+        )
+
+    def test_json_carries_the_same_findings_as_the_human_output(self) -> None:
+        self._insert(
+            {"a": "Hello {name}", "b": "Cancel", "c": "Delete forever"},
+            {"a": "Hallo", "b": "Abbrechen", "c": "Delete forever", "d": "X"},
+        )
+        human = self._audit()
+        self.assertOk(human, "audit human")
+        proc = self._audit("--json")
+        self.assertOk(proc, "audit --json")
+        data = json.loads(proc.stdout)
+
+        self.assertEqual(data["locale"], "de")
+        self.assertEqual(data["rows_checked"], 1)
+        self.assertEqual(data["findings_total"], len(data["findings"]))
+        self.assertEqual(
+            data["counts_by_check"],
+            {"status": 0, "key_set": 1, "tokens": 1, "en_leak": 1},
+            f"expected one finding per check, got {data['findings']}",
+        )
+        self.assertEqual(
+            data["findings_total"],
+            3,
+            "human/JSON parity check assumes 3 findings",
+        )
+        self.assertEqual(data["errors_total"], 2)
+        self.assertEqual(data["advisories_total"], 1)
+        # Every JSON finding must be locatable in the human rendering.
+        for finding in data["findings"]:
+            self.assertIn(f"[{finding['check']}]", human.stdout)
+            self.assertIn(f" {finding['key']}: ", human.stdout)
+        self.assertIn("TOTAL: 3 finding(s) (2 error, 1 advisory)", human.stdout)
+
+    def test_missing_db_errors_without_a_traceback(self) -> None:
+        env = {**self.env, "I18N_DB_FILE": str(self.tmp / "absent.db")}
+        proc = self.run_cli("tasks", "audit", "de", env=env)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("Database not found", proc.stderr)
+        self.assertNotIn("Traceback", proc.stderr)
 
 
 if __name__ == "__main__":

--- a/locales/scripts/tests/test_i18n_cli.py
+++ b/locales/scripts/tests/test_i18n_cli.py
@@ -366,7 +366,7 @@ class TasksFlowTest(I18nCliTestCase):
         self.assertOk(self.run_cli("db", "init"), "db init")
 
     def test_create_next_update_export_roundtrip(self) -> None:
-        self.assertOk(self.run_cli("tasks", "create", "eo"), "create")
+        self.assertOk(self.run_cli("tasks", "create", "eo", "--apply"), "create")
         nxt = self.run_cli("tasks", "next", "eo", "--json")
         self.assertOk(nxt, "next")
         task = json.loads(nxt.stdout)
@@ -419,7 +419,7 @@ class TasksFlowTest(I18nCliTestCase):
         path.write_text(json.dumps(d), encoding="utf-8")
 
         self.assertOk(
-            self.run_cli("tasks", "create", "eo", "--missing-only"),
+            self.run_cli("tasks", "create", "eo", "--missing-only", "--apply"),
             "create --missing-only",
         )
         conn = sqlite3.connect(self.db_dir / "tasks.db")
@@ -457,28 +457,38 @@ class TasksFlowTest(I18nCliTestCase):
             conn.close()
             return sum(len(json.loads(k)) for (k,) in rows)
 
-        # Bare create: fully-translated locale, nothing to do.
-        self.assertOk(self.run_cli("tasks", "create", "eo"), "bare create")
+        # Applied create: fully-translated locale, nothing to do.
+        self.assertOk(self.run_cli("tasks", "create", "eo", "--apply"), "create")
         self.assertEqual(
-            enqueued(), 0, "bare create re-enqueued already-translated keys"
+            enqueued(), 0, "default create re-enqueued already-translated keys"
         )
 
-        # --all: target-blind, queues the whole en key set for re-translation.
-        self.assertOk(self.run_cli("tasks", "create", "eo", "--all"), "create --all")
-        self.assertGreater(enqueued(), 0, "--all enqueued nothing")
-
-        # The retired flag still parses (old scripts/slash commands pass it),
-        # but contradicting --all is an error, not a silent preference.
+        # Without --apply even --all is a preview: nothing may reach the DB.
         self.assertOk(
-            self.run_cli("tasks", "create", "eo", "--missing-only"),
+            self.run_cli("tasks", "create", "eo", "--all"), "preview --all"
+        )
+        self.assertEqual(enqueued(), 0, "create without --apply wrote to the DB")
+
+        # --all --apply: target-blind, queues the whole en key set.
+        self.assertOk(
+            self.run_cli("tasks", "create", "eo", "--all", "--apply"),
+            "create --all --apply",
+        )
+        self.assertGreater(enqueued(), 0, "--all --apply enqueued nothing")
+
+        # The retired flags still parse (old scripts/slash commands pass them),
+        # but contradicting the current default is an error, not a preference.
+        self.assertOk(
+            self.run_cli("tasks", "create", "eo", "--missing-only", "--apply"),
             "create --missing-only (accepted, now the default)",
         )
-        contradiction = self.run_cli(
-            "tasks", "create", "eo", "--all", "--missing-only"
-        )
-        self.assertNotEqual(
-            contradiction.returncode, 0, "--all --missing-only must not succeed"
-        )
+        for combo in (("--all", "--missing-only"), ("--apply", "--dry-run")):
+            contradiction = self.run_cli("tasks", "create", "eo", *combo)
+            self.assertNotEqual(
+                contradiction.returncode,
+                0,
+                f"{' '.join(combo)} must not succeed",
+            )
 
     def test_export_skips_empty_translation_preserving_skip(self) -> None:
         # An empty/whitespace completed translation must not blank existing
@@ -503,7 +513,7 @@ class TasksFlowTest(I18nCliTestCase):
             json.dumps({full_key: {"text": "KEEP", "skip": True}}),
             encoding="utf-8",
         )
-        self.assertOk(self.run_cli("tasks", "create", "eo"), "create")
+        self.assertOk(self.run_cli("tasks", "create", "eo", "--apply"), "create")
         db = sqlite3.connect(self.db_dir / "tasks.db")
         (task_id,) = db.execute(
             "SELECT id FROM translation_tasks "
@@ -532,7 +542,7 @@ class TasksFlowTest(I18nCliTestCase):
     def test_next_human_header_uses_locale_not_hardcoded(self) -> None:
         # Regression: format_task_human once hardcoded 'Esperanto' as the third
         # column header for every locale.
-        self.assertOk(self.run_cli("tasks", "create", "eo"), "create")
+        self.assertOk(self.run_cli("tasks", "create", "eo", "--apply"), "create")
         proc = self.run_cli("tasks", "next", "eo")
         self.assertOk(proc, "next")
         self.assertIn("eo", proc.stdout)
@@ -587,7 +597,7 @@ class StaleKeysWatermarkTest(I18nCliTestCase):
 
     def test_missing_only_enqueues_missing_and_stale_not_current(self) -> None:
         self.assertOk(
-            self.run_cli("tasks", "create", "de", "--missing-only"),
+            self.run_cli("tasks", "create", "de", "--missing-only", "--apply"),
             "create --missing-only",
         )
         self.assertEqual(
@@ -601,7 +611,8 @@ class StaleKeysWatermarkTest(I18nCliTestCase):
         import sqlite3
 
         self.assertOk(
-            self.run_cli("tasks", "create", "de", "--missing-only"), "create"
+            self.run_cli("tasks", "create", "de", "--missing-only", "--apply"),
+            "create",
         )
         conn = sqlite3.connect(self.db_dir / "tasks.db")
         (snap,) = conn.execute(
@@ -615,7 +626,8 @@ class StaleKeysWatermarkTest(I18nCliTestCase):
 
     def test_export_stamps_and_advances_source_hash(self) -> None:
         self.assertOk(
-            self.run_cli("tasks", "create", "de", "--missing-only"), "create"
+            self.run_cli("tasks", "create", "de", "--missing-only", "--apply"),
+            "create",
         )
         nxt = json.loads(self.run_cli("tasks", "next", "de", "--json").stdout)
         trans = {leaf: f"X-{leaf}" for leaf in nxt["keys"]}
@@ -641,16 +653,18 @@ class StaleKeysWatermarkTest(I18nCliTestCase):
         self.assertRegex(proc.stdout, r"missing.*:\s*1")
         self.assertRegex(proc.stdout, r"current:\s*1")
 
-    def test_recreate_after_completion_freezes_watermark(self) -> None:
-        # The false-'current' trap: complete a translation against en hash H1,
-        # let en drift to H2 without re-translating, then re-create + export.
-        # export must stamp the FROZEN snapshot (H1) — the hash the text was
-        # actually made against — so the key stays correctly stale, instead of
-        # advancing to H2 and reading 'current' forever.
+    def test_recreate_after_completion_reopens_the_level(self) -> None:
+        # Complete a translation against en hash H1, let en drift to H2 without
+        # exporting, then re-create. The completed row must be REOPENED — status
+        # back to pending, unexported translations discarded, snapshot advanced
+        # to H2 — not left completed with a refreshed key set it can't satisfy
+        # (stranded: `tasks next` never re-serves completed rows) and not
+        # exported with a watermark newer than the text (false-'current').
         import sqlite3
 
         self.assertOk(
-            self.run_cli("tasks", "create", "de", "--missing-only"), "create"
+            self.run_cli("tasks", "create", "de", "--missing-only", "--apply"),
+            "create",
         )
         nxt = json.loads(self.run_cli("tasks", "next", "de", "--json").stdout)
         trans = {leaf: f"T-{leaf}" for leaf in nxt["keys"]}
@@ -667,28 +681,35 @@ class StaleKeysWatermarkTest(I18nCliTestCase):
 
         # Re-create hits the completed level row via ON CONFLICT.
         self.assertOk(
-            self.run_cli("tasks", "create", "de", "--missing-only"), "re-create"
+            self.run_cli("tasks", "create", "de", "--missing-only", "--apply"),
+            "re-create",
         )
-        # The completed row's snapshot must NOT have advanced to newhash1.
         conn = sqlite3.connect(self.db_dir / "tasks.db")
-        (snap,) = conn.execute(
-            "SELECT source_hashes_json FROM translation_tasks "
-            "WHERE locale='de' AND status='completed'"
+        (status, translations, snap) = conn.execute(
+            "SELECT status, translations_json, source_hashes_json "
+            "FROM translation_tasks WHERE locale='de'"
         ).fetchone()
         conn.close()
+        self.assertEqual(status, "pending", "completed row was not reopened")
+        self.assertIsNone(
+            translations, "reopened row kept its discarded translations"
+        )
         self.assertEqual(
             json.loads(snap).get("tagline"),
-            "aaaa1111",
-            "completed row's snapshot was refreshed to the drifted en hash",
+            "newhash1",
+            "reopened row's snapshot must track the en hash it will be "
+            "re-translated against",
         )
 
-        self.assertOk(self.run_cli("tasks", "export", "de"), "export")
+        # Nothing is completed anymore: export finds no rows (nonzero exit)
+        # and must not touch the stale key.
+        proc = self.run_cli("tasks", "export", "de")
+        self.assertIn("No completed tasks", proc.stdout)
         de = json.loads((self.content / "de" / "00.json").read_text("utf-8"))
         self.assertEqual(
             de["web.C.tagline"]["source_hash"],
-            "aaaa1111",
-            "export stamped the drifted hash instead of the frozen watermark; "
-            "the stale key would read 'current' forever",
+            "deadbeef",
+            "export wrote a discarded translation's watermark",
         )
 
     def test_stats_json_stays_flat_for_consumers(self) -> None:
@@ -760,7 +781,7 @@ class MigrateAddsColumnTest(I18nCliTestCase):
         conn.close()
 
         env = {**self.env, "I18N_DB_FILE": str(legacy)}
-        proc = self.run_cli("tasks", "create", "eo", env=env)
+        proc = self.run_cli("tasks", "create", "eo", "--apply", env=env)
         self.assertNotEqual(
             proc.returncode, 0, "create on a pre-column DB must not exit 0"
         )
@@ -973,7 +994,7 @@ class TasksUpdateStrictTest(I18nCliTestCase):
             "utf-8",
         )
         self.assertOk(self.run_cli("db", "init"), "db init")
-        self.assertOk(self.run_cli("tasks", "create", "de"), "create")
+        self.assertOk(self.run_cli("tasks", "create", "de", "--apply"), "create")
         self.task_id = self._only_task_id()
 
     def _only_task_id(self) -> int:

--- a/locales/scripts/tests/test_i18n_cli.py
+++ b/locales/scripts/tests/test_i18n_cli.py
@@ -439,6 +439,47 @@ class TasksFlowTest(I18nCliTestCase):
             f"missing-only enqueued {enqueued}, expected only {missing_key}",
         )
 
+    def test_create_defaults_to_missing_only_and_all_is_opt_in(self) -> None:
+        # The default must be the safe one: a locale that is already fully
+        # translated enqueues NOTHING, and only --all re-queues reviewed work.
+        import sqlite3
+
+        eo = self.content / "eo"
+        eo.mkdir(parents=True)
+        for f in sorted((self.content / "en").glob("*.json")):
+            shutil.copy(f, eo / f.name)
+
+        def enqueued() -> int:
+            conn = sqlite3.connect(self.db_dir / "tasks.db")
+            rows = conn.execute(
+                "SELECT keys_json FROM translation_tasks WHERE locale='eo'"
+            ).fetchall()
+            conn.close()
+            return sum(len(json.loads(k)) for (k,) in rows)
+
+        # Bare create: fully-translated locale, nothing to do.
+        self.assertOk(self.run_cli("tasks", "create", "eo"), "bare create")
+        self.assertEqual(
+            enqueued(), 0, "bare create re-enqueued already-translated keys"
+        )
+
+        # --all: target-blind, queues the whole en key set for re-translation.
+        self.assertOk(self.run_cli("tasks", "create", "eo", "--all"), "create --all")
+        self.assertGreater(enqueued(), 0, "--all enqueued nothing")
+
+        # The retired flag still parses (old scripts/slash commands pass it),
+        # but contradicting --all is an error, not a silent preference.
+        self.assertOk(
+            self.run_cli("tasks", "create", "eo", "--missing-only"),
+            "create --missing-only (accepted, now the default)",
+        )
+        contradiction = self.run_cli(
+            "tasks", "create", "eo", "--all", "--missing-only"
+        )
+        self.assertNotEqual(
+            contradiction.returncode, 0, "--all --missing-only must not succeed"
+        )
+
     def test_export_skips_empty_translation_preserving_skip(self) -> None:
         # An empty/whitespace completed translation must not blank existing
         # content or strip an intentional skip flag on export.

--- a/locales/scripts/tests/test_i18n_cli.py
+++ b/locales/scripts/tests/test_i18n_cli.py
@@ -676,15 +676,8 @@ class StaleKeysWatermarkTest(I18nCliTestCase):
         self.assertRegex(proc.stdout, r"missing.*:\s*1")
         self.assertRegex(proc.stdout, r"current:\s*1")
 
-    def test_recreate_after_completion_reopens_the_level(self) -> None:
-        # Complete a translation against en hash H1, let en drift to H2 without
-        # exporting, then re-create. The completed row must be REOPENED — status
-        # back to pending, unexported translations discarded, snapshot advanced
-        # to H2 — not left completed with a refreshed key set it can't satisfy
-        # (stranded: `tasks next` never re-serves completed rows) and not
-        # exported with a watermark newer than the text (false-'current').
-        import sqlite3
-
+    def _complete_the_level(self) -> dict:
+        """create -> claim -> translate, leaving one completed unexported row."""
         self.assertOk(
             self.run_cli("tasks", "create", "de", "--missing-only", "--apply"),
             "create",
@@ -695,12 +688,168 @@ class StaleKeysWatermarkTest(I18nCliTestCase):
             self.run_cli("tasks", "update", str(nxt["id"]), json.dumps(trans)),
             "complete",
         )
+        return nxt
 
-        # en drifts: tagline's content_hash moves aaaa1111 -> newhash1.
+    def _drift_en_tagline(self, new_hash: str) -> None:
+        """Move en's tagline content_hash so the level is re-emitted as stale."""
         en = self.content / "en" / "00.json"
         doc = json.loads(en.read_text("utf-8"))
-        doc["web.C.tagline"]["content_hash"] = "newhash1"
+        doc["web.C.tagline"]["content_hash"] = new_hash
         en.write_text(json.dumps(doc), "utf-8")
+
+    def _row(self, *columns: str) -> tuple:
+        import sqlite3
+
+        conn = sqlite3.connect(self.db_dir / "tasks.db")
+        row = conn.execute(
+            f"SELECT {', '.join(columns)} FROM translation_tasks "
+            "WHERE locale='de'"
+        ).fetchone()
+        conn.close()
+        return row
+
+    def test_recreate_refuses_to_discard_unexported_work(self) -> None:
+        # The gate: completed + never exported means this DB row is the only
+        # copy, so create --apply must refuse the WHOLE run and leave it intact.
+        self._complete_the_level()
+        self._drift_en_tagline("newhash1")
+
+        proc = self.run_cli(
+            "tasks", "create", "de", "--missing-only", "--apply"
+        )
+        self.assertEqual(
+            proc.returncode, 3, f"expected refusal exit 3\n{proc.stderr}"
+        )
+        # Names the level at risk, so the operator can judge what's at stake.
+        self.assertIn("00.json:web.C", proc.stderr)
+        self.assertIn("never exported", proc.stderr)
+
+        status, translations = self._row("status", "translations_json")
+        self.assertEqual(
+            status, "completed", "refused run must not touch the row"
+        )
+        self.assertEqual(
+            json.loads(translations)["tagline"],
+            "T-tagline",
+            "refused run discarded the translations it refused to discard",
+        )
+
+    def test_reopen_flag_discards_unexported_work_deliberately(self) -> None:
+        self._complete_the_level()
+        self._drift_en_tagline("newhash1")
+
+        self.assertOk(
+            self.run_cli(
+                "tasks", "create", "de", "--apply", "--reopen"
+            ),
+            "create --reopen",
+        )
+        status, translations = self._row("status", "translations_json")
+        self.assertEqual(status, "pending")
+        self.assertIsNone(translations)
+
+    def test_export_then_recreate_needs_no_flag(self) -> None:
+        # The routine catch-up path must stay quiet: once the text is on disk,
+        # reopening costs nothing, so no gate, no flag, no prompt.
+        self._complete_the_level()
+        self.assertOk(self.run_cli("tasks", "export", "de"), "export")
+        self._drift_en_tagline("newhash1")
+        self.assertOk(
+            self.run_cli(
+                "tasks", "create", "de", "--missing-only", "--apply"
+            ),
+            "create after export must not be gated",
+        )
+
+    def test_export_stamps_the_receipt(self) -> None:
+        self._complete_the_level()
+        self.assertIsNone(
+            self._row("exported_at")[0],
+            "a completed-but-unexported row must have no receipt",
+        )
+        self.assertOk(self.run_cli("tasks", "export", "de"), "export")
+        self.assertIsNotNone(
+            self._row("exported_at")[0],
+            "export must stamp exported_at on the rows it wrote",
+        )
+
+    def test_revising_an_exported_level_reprotects_it(self) -> None:
+        # Export, then edit the translation in place without re-exporting. The
+        # receipt is now a lie (content/ holds the OLD text), so it must be
+        # cleared and the next create must be gated again.
+        nxt = self._complete_the_level()
+        self.assertOk(self.run_cli("tasks", "export", "de"), "export")
+        self.assertOk(
+            self.run_cli(
+                "tasks",
+                "update",
+                str(nxt["id"]),
+                json.dumps({leaf: f"REV-{leaf}" for leaf in nxt["keys"]}),
+            ),
+            "revise",
+        )
+        self.assertIsNone(
+            self._row("exported_at")[0],
+            "rewriting translations must invalidate the export receipt",
+        )
+        self._drift_en_tagline("newhash1")
+        proc = self.run_cli(
+            "tasks", "create", "de", "--missing-only", "--apply"
+        )
+        self.assertEqual(
+            proc.returncode, 3, "revised-but-unexported work was not protected"
+        )
+
+    def test_dry_run_previews_the_refusal(self) -> None:
+        self._complete_the_level()
+        self._drift_en_tagline("newhash1")
+        proc = self.run_cli("tasks", "create", "de")
+        self.assertOk(proc, "preview")
+        self.assertIn("WOULD BE REFUSED", proc.stdout)
+        self.assertIn("00.json:web.C", proc.stdout)
+
+    def test_reopen_without_apply_is_rejected(self) -> None:
+        proc = self.run_cli("tasks", "create", "de", "--reopen")
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("--apply", proc.stderr)
+
+    def test_completed_row_without_translations_does_not_wedge_create(
+        self,
+    ) -> None:
+        # A completed row with a NULL payload has nothing to lose, and export
+        # never picks it up to stamp a receipt — so gating on it would block
+        # create forever. It must upsert freely.
+        import sqlite3
+
+        self._complete_the_level()
+        conn = sqlite3.connect(self.db_dir / "tasks.db")
+        conn.execute(
+            "UPDATE translation_tasks SET translations_json = NULL "
+            "WHERE locale='de'"
+        )
+        conn.commit()
+        conn.close()
+
+        self._drift_en_tagline("newhash1")
+        self.assertOk(
+            self.run_cli(
+                "tasks", "create", "de", "--missing-only", "--apply"
+            ),
+            "payload-less completed row must not gate create",
+        )
+
+    def test_recreate_after_completion_reopens_the_level(self) -> None:
+        # Complete a translation against en hash H1, EXPORT it, let en drift to
+        # H2, then re-create. Because the text is safely on disk, the completed
+        # row must be REOPENED without ceremony — status back to pending,
+        # translations cleared, snapshot advanced to H2 — not left completed
+        # with a refreshed key set it can't satisfy (stranded: `tasks next`
+        # never re-serves completed rows).
+        import sqlite3
+
+        self._complete_the_level()
+        self.assertOk(self.run_cli("tasks", "export", "de"), "export")
+        self._drift_en_tagline("newhash1")
 
         # Re-create hits the completed level row via ON CONFLICT.
         self.assertOk(
@@ -708,14 +857,19 @@ class StaleKeysWatermarkTest(I18nCliTestCase):
             "re-create",
         )
         conn = sqlite3.connect(self.db_dir / "tasks.db")
-        (status, translations, snap) = conn.execute(
-            "SELECT status, translations_json, source_hashes_json "
+        (status, translations, snap, exported_at) = conn.execute(
+            "SELECT status, translations_json, source_hashes_json, exported_at "
             "FROM translation_tasks WHERE locale='de'"
         ).fetchone()
         conn.close()
         self.assertEqual(status, "pending", "completed row was not reopened")
         self.assertIsNone(
             translations, "reopened row kept its discarded translations"
+        )
+        self.assertIsNone(
+            exported_at,
+            "reopening must drop the export receipt, else the NEXT create "
+            "would read it as proof the re-translation is on disk",
         )
         self.assertEqual(
             json.loads(snap).get("tagline"),
@@ -725,14 +879,14 @@ class StaleKeysWatermarkTest(I18nCliTestCase):
         )
 
         # Nothing is completed anymore: export finds no rows (nonzero exit)
-        # and must not touch the stale key.
+        # and must not advance the watermark past the exported text.
         proc = self.run_cli("tasks", "export", "de")
         self.assertIn("No completed tasks", proc.stdout)
         de = json.loads((self.content / "de" / "00.json").read_text("utf-8"))
         self.assertEqual(
             de["web.C.tagline"]["source_hash"],
-            "deadbeef",
-            "export wrote a discarded translation's watermark",
+            "aaaa1111",
+            "export moved the watermark for text it did not write",
         )
 
     def test_stats_json_stays_flat_for_consumers(self) -> None:
@@ -782,6 +936,83 @@ class MigrateAddsColumnTest(I18nCliTestCase):
             )
         }
         self.assertIn("source_hashes_json", cols)
+
+    def test_migrate_backfills_exported_at_column(self) -> None:
+        import sqlite3
+
+        legacy = self._legacy_db()
+        env = {**self.env, "I18N_DB_FILE": str(legacy)}
+        self.assertOk(self.run_cli("db", "migrate", env=env), "migrate")
+        cols = {
+            r[1]
+            for r in sqlite3.connect(legacy).execute(
+                "PRAGMA table_info(translation_tasks)"
+            )
+        }
+        self.assertIn("exported_at", cols)
+
+    def test_migrate_leaves_existing_rows_unstamped(self) -> None:
+        # exported_at must NOT be backfilled. A pre-009 completed row's export
+        # state is unknowable, and guessing "exported" would silently disable
+        # the gate for the one case it exists to protect.
+        import sqlite3
+
+        legacy = self._legacy_db()
+        conn = sqlite3.connect(legacy)
+        conn.execute(
+            "INSERT INTO translation_tasks (file, level_path, locale, status, "
+            "keys_json, translations_json) VALUES "
+            "('00.json', 'web.C', 'de', 'completed', '{}', '{\"a\": \"b\"}')"
+        )
+        conn.commit()
+        conn.close()
+
+        env = {**self.env, "I18N_DB_FILE": str(legacy)}
+        self.assertOk(self.run_cli("db", "migrate", env=env), "migrate")
+        (stamp,) = (
+            sqlite3.connect(legacy)
+            .execute("SELECT exported_at FROM translation_tasks")
+            .fetchone()
+        )
+        self.assertIsNone(stamp)
+
+    def test_create_on_pre009_db_fails_loud(self) -> None:
+        # A DB with source_hashes_json but no exported_at would run the create
+        # path with the gate OFFLINE — silently restoring the clobber. Refuse.
+        import sqlite3
+
+        legacy = self._legacy_db()
+        conn = sqlite3.connect(legacy)
+        conn.execute(
+            "ALTER TABLE translation_tasks ADD COLUMN source_hashes_json TEXT"
+        )
+        conn.commit()
+        conn.close()
+
+        env = {**self.env, "I18N_DB_FILE": str(legacy)}
+        proc = self.run_cli("tasks", "create", "eo", "--apply", env=env)
+        self.assertNotEqual(proc.returncode, 0)
+        out = (proc.stdout + proc.stderr).lower()
+        self.assertIn("exported_at", out)
+        self.assertIn("migrate", out)
+
+    def _legacy_db(self) -> Path:
+        import sqlite3
+
+        legacy = self.db_dir / "legacy.db"
+        conn = sqlite3.connect(legacy)
+        conn.executescript(
+            "CREATE TABLE schema_migrations (version TEXT PRIMARY KEY, "
+            "name TEXT, applied_at TEXT);\n"
+            "CREATE TABLE translation_tasks (id INTEGER PRIMARY KEY, file TEXT, "
+            "level_path TEXT, locale TEXT, status TEXT DEFAULT 'pending', "
+            "keys_json TEXT, translations_json TEXT, notes TEXT, "
+            "created_at TEXT, updated_at TEXT, "
+            "UNIQUE(file, level_path, locale));"
+        )
+        conn.commit()
+        conn.close()
+        return legacy
 
     def test_create_on_precolumn_db_fails_loud(self) -> None:
         # tasks create against an un-migrated pre-column DB must FAIL (non-zero +

--- a/locales/slash_commands/start-translation-session.md
+++ b/locales/slash_commands/start-translation-session.md
@@ -59,14 +59,14 @@ python3 locales/scripts/i18n tasks next fr_CA --stats
 
 ### 1. Create Tasks (if needed)
 
-For each eligible locale that needs tasks generated, enqueue the keys still
-untranslated in `content/LOCALE` **plus** stale ones (translated, but en changed
-since) — already-translated, still-current reviewed strings are never requeued.
-Use `--missing-only` for existing locales; drop it only to bootstrap a
-brand-new, empty locale:
+For each eligible locale that needs tasks generated, run `create` with no flags.
+It enqueues the keys still untranslated in `content/LOCALE` **plus** stale ones
+(translated, but en changed since) — already-translated, still-current reviewed
+strings are never requeued. A brand-new locale needs no flag either: with no
+`content/LOCALE` every key is missing, so the result is the full key set anyway.
 
 ```bash
-python3 locales/scripts/i18n tasks create LOCALE --missing-only
+python3 locales/scripts/i18n tasks create LOCALE
 ```
 
 ### 2. Track Agents with TodoWrite

--- a/locales/slash_commands/start-translation-session.md
+++ b/locales/slash_commands/start-translation-session.md
@@ -64,9 +64,12 @@ For each eligible locale that needs tasks generated, run `create --apply`
 `content/LOCALE` **plus** stale ones (translated, but en changed since) —
 already-translated, still-current reviewed strings are never requeued. A
 brand-new locale needs no extra flag: with no `content/LOCALE` every key is
-missing, so the result is the full key set anyway. Note that applying reopens
-any completed level that still has work, discarding its unexported
-translations — export before refreshing a queue you care about.
+missing, so the result is the full key set anyway. Applying reopens any
+completed level that still has work, discarding its translations; that is free
+for already-exported levels and **refused** (exit 3, nothing written) for levels
+whose translations were never exported. If you hit the refusal, run
+`tasks export LOCALE` to keep that work, or re-run with `--reopen` to discard it
+on purpose.
 
 ```bash
 python3 locales/scripts/i18n tasks create LOCALE --apply

--- a/locales/slash_commands/start-translation-session.md
+++ b/locales/slash_commands/start-translation-session.md
@@ -59,14 +59,17 @@ python3 locales/scripts/i18n tasks next fr_CA --stats
 
 ### 1. Create Tasks (if needed)
 
-For each eligible locale that needs tasks generated, run `create` with no flags.
-It enqueues the keys still untranslated in `content/LOCALE` **plus** stale ones
-(translated, but en changed since) — already-translated, still-current reviewed
-strings are never requeued. A brand-new locale needs no flag either: with no
-`content/LOCALE` every key is missing, so the result is the full key set anyway.
+For each eligible locale that needs tasks generated, run `create --apply`
+(without `--apply` it only previews). It enqueues the keys still untranslated in
+`content/LOCALE` **plus** stale ones (translated, but en changed since) —
+already-translated, still-current reviewed strings are never requeued. A
+brand-new locale needs no extra flag: with no `content/LOCALE` every key is
+missing, so the result is the full key set anyway. Note that applying reopens
+any completed level that still has work, discarding its unexported
+translations — export before refreshing a queue you care about.
 
 ```bash
-python3 locales/scripts/i18n tasks create LOCALE
+python3 locales/scripts/i18n tasks create LOCALE --apply
 ```
 
 ### 2. Track Agents with TodoWrite

--- a/locales/slash_commands/translate-new-language.md
+++ b/locales/slash_commands/translate-new-language.md
@@ -73,9 +73,10 @@ If not eligible, stop and report — do not translate without the resolved artif
    translations. `tasks create` reads only the English source, and `tasks export`
    creates the per-file target JSON on first write; no seeding is needed.
 
-3. **Build the task queue** so the agent has pending work:
+3. **Build the task queue** so the agent has pending work (`--apply` is
+   required; bare `create` only previews):
    ```bash
-   python3 locales/scripts/i18n tasks create {lang}
+   python3 locales/scripts/i18n tasks create {lang} --apply
    python3 locales/scripts/i18n tasks next {lang} --stats
    ```
 

--- a/locales/slash_commands/translate-parallel-agents.md
+++ b/locales/slash_commands/translate-parallel-agents.md
@@ -77,9 +77,8 @@ queues both **untranslated** keys and **stale** ones (translated, but en changed
 since — the target `source_hash` no longer matches en's `content_hash`), and
 never requeues already-translated, still-current reviewed strings. A brand-new
 locale needs no extra flag — with no `content/LOCALE` every key is missing, so
-you get the full key set regardless. Never pass `--all` here: it re-queues
-reviewed work for re-translation, and export overwrites the reviewed content
-with the new output. Applying reopens completed levels that still have work
+you get the full key set regardless. Catch-up is the only mode; there is no
+target-blind re-queue. Applying reopens completed levels that still have work
 (their unexported translations are discarded), so export before re-initializing
 a locale mid-drain.
 

--- a/locales/slash_commands/translate-parallel-agents.md
+++ b/locales/slash_commands/translate-parallel-agents.md
@@ -72,16 +72,19 @@ Only launch agents for `ELIGIBLE` locales.
 
 ### 1. Initialize Locales
 
-For each eligible locale, run `create` with no flags: it queues both
-**untranslated** keys and **stale** ones (translated, but en changed since — the
-target `source_hash` no longer matches en's `content_hash`), and never requeues
-already-translated, still-current reviewed strings. A brand-new locale needs no
-flag either — with no `content/LOCALE` every key is missing, so you get the full
-key set regardless. Never pass `--all` here: it re-queues reviewed work for
-re-translation, and export overwrites the reviewed content with the new output.
+For each eligible locale, run `create --apply` (bare `create` only previews): it
+queues both **untranslated** keys and **stale** ones (translated, but en changed
+since — the target `source_hash` no longer matches en's `content_hash`), and
+never requeues already-translated, still-current reviewed strings. A brand-new
+locale needs no extra flag — with no `content/LOCALE` every key is missing, so
+you get the full key set regardless. Never pass `--all` here: it re-queues
+reviewed work for re-translation, and export overwrites the reviewed content
+with the new output. Applying reopens completed levels that still have work
+(their unexported translations are discarded), so export before re-initializing
+a locale mid-drain.
 
 ```bash
-python3 locales/scripts/i18n tasks create LOCALE
+python3 locales/scripts/i18n tasks create LOCALE --apply
 ```
 
 The `create` summary breaks the enqueued keys into `missing` vs `stale`; a large

--- a/locales/slash_commands/translate-parallel-agents.md
+++ b/locales/slash_commands/translate-parallel-agents.md
@@ -72,15 +72,16 @@ Only launch agents for `ELIGIBLE` locales.
 
 ### 1. Initialize Locales
 
-For each eligible locale, enqueue the keys that still need work with
-`--missing-only`: it queues both **untranslated** keys and **stale** ones
-(translated, but en changed since — the target `source_hash` no longer matches
-en's `content_hash`), and never requeues already-translated, still-current
-reviewed strings. Omit `--missing-only` only to bootstrap a brand-new, empty
-locale:
+For each eligible locale, run `create` with no flags: it queues both
+**untranslated** keys and **stale** ones (translated, but en changed since — the
+target `source_hash` no longer matches en's `content_hash`), and never requeues
+already-translated, still-current reviewed strings. A brand-new locale needs no
+flag either — with no `content/LOCALE` every key is missing, so you get the full
+key set regardless. Never pass `--all` here: it re-queues reviewed work for
+re-translation, and export overwrites the reviewed content with the new output.
 
 ```bash
-python3 locales/scripts/i18n tasks create LOCALE --missing-only
+python3 locales/scripts/i18n tasks create LOCALE
 ```
 
 The `create` summary breaks the enqueued keys into `missing` vs `stale`; a large

--- a/locales/slash_commands/translate-parallel-agents.md
+++ b/locales/slash_commands/translate-parallel-agents.md
@@ -78,9 +78,12 @@ since — the target `source_hash` no longer matches en's `content_hash`), and
 never requeues already-translated, still-current reviewed strings. A brand-new
 locale needs no extra flag — with no `content/LOCALE` every key is missing, so
 you get the full key set regardless. Catch-up is the only mode; there is no
-target-blind re-queue. Applying reopens completed levels that still have work
-(their unexported translations are discarded), so export before re-initializing
-a locale mid-drain.
+target-blind re-queue. Applying reopens completed levels that still have work,
+discarding their translations — silently when the level was already exported,
+and never otherwise: a level holding never-exported translations makes the run
+exit 3 with nothing written. Run `tasks export LOCALE` to keep that work (then
+re-create), or `--reopen` to discard it deliberately. This is what makes
+re-initializing a locale mid-drain safe rather than merely discouraged.
 
 ```bash
 python3 locales/scripts/i18n tasks create LOCALE --apply

--- a/locales/slash_commands/translate-workflow.md
+++ b/locales/slash_commands/translate-workflow.md
@@ -56,11 +56,13 @@ Discover, do not assume. Run these yourself in the main loop first:
    jq -e '((.register // {}) | length > 0) and ((.glossary // {}) | length > 0)' "generated/i18n/.resolved/$loc.json" >/dev/null 2>&1 || echo "SKIP (not governed at pin): $loc"
    ```
 4. **Refresh each eligible target's queue, THEN filter on pending.** Build the
-   queue before checking pending. `create` takes no flags: an existing locale
+   queue before checking pending. `create --apply` on an existing locale
    enqueues only keys still untranslated in `content/<loc>` and never requeues
-   already-translated, reviewed strings:
+   already-translated, reviewed strings (bare `create` is a preview; applying
+   reopens completed levels that still have work, discarding unexported
+   translations — export first if any are in flight):
    ```bash
-   i18n tasks create <loc>                     # per eligible target
+   i18n tasks create <loc> --apply             # per eligible target
    i18n tasks next <loc> --stats               # keep targets now showing pending > 0
    ```
    The default enqueues both **missing** and **stale** keys (translated

--- a/locales/slash_commands/translate-workflow.md
+++ b/locales/slash_commands/translate-workflow.md
@@ -56,14 +56,14 @@ Discover, do not assume. Run these yourself in the main loop first:
    jq -e '((.register // {}) | length > 0) and ((.glossary // {}) | length > 0)' "generated/i18n/.resolved/$loc.json" >/dev/null 2>&1 || echo "SKIP (not governed at pin): $loc"
    ```
 4. **Refresh each eligible target's queue, THEN filter on pending.** Build the
-   queue before checking pending. Use `--missing-only` so an existing locale
+   queue before checking pending. `create` takes no flags: an existing locale
    enqueues only keys still untranslated in `content/<loc>` and never requeues
    already-translated, reviewed strings:
    ```bash
-   i18n tasks create <loc> --missing-only      # per eligible target
+   i18n tasks create <loc>                     # per eligible target
    i18n tasks next <loc> --stats               # keep targets now showing pending > 0
    ```
-   `--missing-only` now enqueues both **missing** and **stale** keys (translated
+   The default enqueues both **missing** and **stale** keys (translated
    but `en` changed since — target `source_hash` ≠ en `content_hash`), so a
    refreshed queue reflects genuine drift too. `--stats` prints a content-truth
    `current/stale/missing` coverage block; use that, not just `pending`, to judge

--- a/locales/slash_commands/translate-workflow.md
+++ b/locales/slash_commands/translate-workflow.md
@@ -59,8 +59,10 @@ Discover, do not assume. Run these yourself in the main loop first:
    queue before checking pending. `create --apply` on an existing locale
    enqueues only keys still untranslated in `content/<loc>` and never requeues
    already-translated, reviewed strings (bare `create` is a preview; applying
-   reopens completed levels that still have work, discarding unexported
-   translations — export first if any are in flight):
+   reopens completed levels that still have work. Already-exported levels
+   reopen silently; a level holding never-exported translations makes the run
+   exit 3 without writing — `tasks export <loc>` to keep it, `--reopen` to
+   discard it):
    ```bash
    i18n tasks create <loc> --apply             # per eligible target
    i18n tasks next <loc> --stats               # keep targets now showing pending > 0


### PR DESCRIPTION
## Problem

Nothing between "a translator agent writes the DB" and "content is committed" could refuse a bad write.

`tasks update --validate` is advisory: it warns on a key-set mismatch, then saves anyway and exits 0. `AGENT_TRANSLATION_PROTOCOL.md` handles this by asking the agent to notice its own `Warning:` line and retry — self-policing by the same agent, in the same turn, that produced the error. The audit stage that follows is prose telling that agent to eyeball its own rows for key-set match, token preservation and English leakage.

`export-all.sh` then gates only on `pending == 0`, which the protocol itself says does not prove the writes are clean.

## Change

**`tasks update --strict`** (implies `--validate`) — refuses the write and exits 1 on a key-set mismatch, before the only writer. Without `--strict` the advisory path is preserved byte-for-byte; it is documented behaviour with existing callers.

**`tasks audit <locale> [--json] [--strict]`** — audits completed rows pre-export:

| check | severity | catches |
|---|---|---|
| `key_set` | error | key-set drift; blank translations `export_locale` would silently drop |
| `tokens` | error | `{var}` `{{var}}` `%{var}` printf `<tag>` multiset drift, per plural form |
| `status` | error | `in_progress` rows invisible to both the pending gate and a completed-only audit |
| `en_leak` | advisory | untranslated English — reported, not blocking |

**`export-all.sh`** — audit gate before export, `validate variables` and the register lint after, non-zero exit on any dirty locale. "Not drained" remains a normal state and still exits 0.

## Notes for review

- **One token definition.** The regexes moved verbatim into `i18n/tokens.py`; `validate.py` re-exports them under their historical names. #4023 and #4047 were both twin normalizers drifting apart.
- **`en_leak` is advisory on purpose.** As a gate it fired on "Status", "TTL", "Amazon SES", "Canada" — strings whose correct translation *is* the English string. No allowlist covers that; the only way to pass would have been to write a wrong translation.
- **Plural strings are compared per form.** Comparing a Vue-i18n `a | b` string whole flagged every locale whose plural-form count differs from English — ja and ru went 7 findings → 0.
- **`validate variables` exits 0 even when it finds mismatches**, so the shell inspects the JSON. It also compares the en-only `context` authoring note, which `tasks export` structurally cannot write, so metadata leaves are excluded — otherwise every locale reads dirty after a perfect export.
- **The register lint is optional.** It needs `.translation-rules/` and a derived `generated/i18n/.resolved/<locale>.json`; absent either, it skips with a notice and never fails the run.
- **`--strict` fails on zero rows checked**, matching the `validate glossary --strict` convention: a locale with nothing to verify is unverified, not clean.

## Verification

- 62 tests (was 36). `validate variables/pr/hashes/glossary` output byte-identical to `main`, diffed against `git show` copies of the pre-change modules.
- `validate glossary de --strict` still exits 1.
- `export-all.sh de fr_FR` dry-run exits 0 with both locales correctly reported not-drained.
- `tasks audit de --strict` exits 1 on zero completed rows.
- Suite passes with a bogus `I18N_DB_FILE` exported — `setUp` previously let an ambient value point the whole suite at the real `tasks.db`, fixed here.
