### PR TITLE
[#4063] Address code review of the link-domains pool branch

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -876,6 +876,10 @@ DEFAULT_DOMAIN=
 #   set           -> exactly these hosts; canonical only if listed
 #   set-but-empty -> boot error (this is why the line below is commented
 #                    out rather than left bare like DEFAULT_DOMAIN above)
+# A set list naming only hosts that cannot be parsed (e.g. an internal
+# hostname with no public suffix) is also a boot error, and the message
+# echoes the entries so the typo is easy to spot. Mixing a good host
+# with a bad one boots; the bad one is dropped and logged.
 #LINK_DOMAINS=links.example.com,short.example.net
 
 # Validation strategy: passthrough (default), approximated, caddy_on_demand

--- a/apps/api/v1/logic/secrets/base_secret_action.rb
+++ b/apps/api/v1/logic/secrets/base_secret_action.rb
@@ -540,9 +540,18 @@ module V1::Logic
       # branch wins — matching DomainStrategy, where the exact canonical
       # match outranks :custom. ConfigureDomains warns about that config.
       #
-      # Normalization mirrors CustomDomain.default_domain?: display_domain
-      # on the input, DomainParser on the configured hosts, so
-      # 'Short.Example.COM' matches a pool entry of 'short.example.com'.
+      # Membership is answered by Middleware::DomainStrategy.link_pool_host?,
+      # NOT by reading features.domains.link_domains out of config. The config
+      # read skipped both of the middleware's gates — features.domains.enabled,
+      # and membership in the parsed canonical set — so with domains disabled,
+      # or with an entry that does not parse, this admitted hosts the
+      # middleware classifies :invalid and the picker never offers. Admission
+      # here and classification there must answer from the same set.
+      #
+      # Normalization mirrors CustomDomain.default_domain?: display_domain on
+      # the input (which also rejects garbage, via the rescue below),
+      # DomainParser on the resolved pool, so 'Short.Example.COM' matches a
+      # pool entry of 'short.example.com'.
       #
       # Keep logically parallel with the V2 implementation
       # (apps/api/v2/logic/secrets/base_secret_action.rb); logging differs
@@ -553,9 +562,7 @@ module V1::Logic
       def link_pool_host?(domain)
         input_display = Onetime::CustomDomain.display_domain(domain)
 
-        Onetime::Utils::CanonicalHosts.link_pool.any? do |host|
-          Onetime::Utils::DomainParser.extract_hostname(host) == input_display
-        end
+        Onetime::Middleware::DomainStrategy.link_pool_host?(input_display)
       rescue PublicSuffix::Error, Onetime::Problem => ex
         # Unparseable input is not a pool member. Fall through to the
         # CustomDomain lookup, which rejects it as an unknown domain.

--- a/apps/api/v1/spec/logic/secrets/base_secret_action_spec.rb
+++ b/apps/api/v1/spec/logic/secrets/base_secret_action_spec.rb
@@ -270,23 +270,53 @@ class V1ShareDomainTestAction < V1::Logic::Secrets::BaseSecretAction
   end
 end
 
-# Sets features.domains.link_domains on the LIVE booted config for the
-# duration of the block, restoring the previous state (including the key's
-# absence) afterwards. OT.conf is not deep-frozen under test.
+# Puts the process in the state an operator actually gets by setting
+# LINK_DOMAINS, on the LIVE booted config, restoring everything (including a
+# key's absence) afterwards. OT.conf is not deep-frozen under test.
 #
-# Deliberately NOT a stub of Utils::CanonicalHosts.link_pool: the chain that
-# actually broke is OT.conf -> CanonicalHosts.link_pool -> link_pool_host?,
-# and stubbing the pool reader would skip the config layer under test.
+# Three things, not one, because link_pool_host? answers from
+# Middleware::DomainStrategy's RESOLVED pool rather than re-reading config:
+#
+#   features.domains.enabled  - the middleware gates its pool on this, and the
+#                               shipped test config has domains OFF.
+#   site.host                 - must PARSE, or initialize_from_config lands in
+#                               its DomainInvalid rescue and disables the
+#                               feature. The test config's '127.0.0.1:3000'
+#                               does not parse.
+#   link_domains              - the pool itself.
+#
+# Deliberately NOT a stub of the pool reader: the chain under test is
+# OT.conf -> DomainStrategy.initialize_from_config -> link_pool_host?, and
+# stubbing its far end is what let admission drift away from classification in
+# the first place (a config-only read admitted hosts with the feature off and
+# hosts that never parsed). Keep in step with the V2 helper.
 module V1LinkPoolConfigHelper
-  def with_link_domains(pool)
-    domains  = OT.conf['features']['domains']
-    had_key  = domains.key?('link_domains')
-    previous = domains['link_domains']
+  def with_link_domains(pool, canonical_host: 'onetimesecret.com', enabled: true)
+    domains       = OT.conf['features']['domains']
+    site          = OT.conf['site']
+    had_pool_key  = domains.key?('link_domains')
+    previous_pool = domains['link_domains']
+    previous_on   = domains['enabled']
+    previous_host = site['host']
 
     domains['link_domains'] = pool
+    domains['enabled']      = enabled
+    site['host']            = canonical_host
+    reload_domain_strategy!
     yield
   ensure
-    had_key ? domains['link_domains'] = previous : domains.delete('link_domains')
+    had_pool_key ? domains['link_domains'] = previous_pool : domains.delete('link_domains')
+    domains['enabled'] = previous_on
+    site['host']       = previous_host
+    reload_domain_strategy!
+  end
+
+  # Re-derives DomainStrategy's class state from the current OT.conf, the way
+  # booting a Rack app would.
+  def reload_domain_strategy!
+    Onetime::Middleware::DomainStrategy.initialize_from_config(
+      OT.conf.dig('features', 'domains') || {},
+    )
   end
 end
 
@@ -451,8 +481,12 @@ RSpec.describe 'V1 BaseSecretAction validate_anonymous_share_domain' do
   context 'with an operator link pool configured (#4063)' do
     around { |example| with_link_domains(%w[short.example.com go.acme.com]) { example.run } }
 
-    it 'is a precondition that the pool really is readable from config' do
-      expect(Onetime::Utils::CanonicalHosts.link_pool).to eq(%w[short.example.com go.acme.com])
+    # Pins the RESOLVED pool, not the raw config value: admission answers from
+    # DomainStrategy, so a precondition on config alone would stay green while
+    # the middleware resolved something else entirely.
+    it 'is a precondition that the pool really resolved in the middleware' do
+      expect(Onetime::Middleware::DomainStrategy.link_domains)
+        .to eq(%w[short.example.com go.acme.com])
     end
 
     it 'allows a guest on the canonical host to name a pool member' do
@@ -574,6 +608,26 @@ RSpec.describe 'V1 BaseSecretAction link-pool domain access (#4063)' do
 
     it "still raises 'Unknown domain' for a host that is neither pooled nor registered" do
       subject = build_v1_access_subject(share_domain: 'unknown.example.com', display_domain: 'onetimesecret.com', custom_domain: false, anonymous: false)
+
+      expect { subject.send(:validate_share_domain) }
+        .to raise_error(OT::FormError, /Unknown domain/)
+    end
+  end
+
+  # Parity with V2: admission is GATED on the middleware's resolved pool, not
+  # a raw config read. A pool configured while the domains feature is off is
+  # a pool the middleware never serves, so it must not be admitted here — the
+  # config-only read used to admit it, letting a guest anchor secrets on a
+  # host that classifies :invalid on the very next request.
+  context 'with a link pool configured but the domains feature disabled' do
+    around { |example| with_link_domains(%w[short.example.com], enabled: false) { example.run } }
+
+    it 'is a precondition that the middleware admits no pool member' do
+      expect(Onetime::Middleware::DomainStrategy.link_pool_host?('short.example.com')).to be false
+    end
+
+    it "rejects the pool member with 'Unknown domain'" do
+      subject = build_v1_access_subject(share_domain: 'short.example.com', display_domain: 'onetimesecret.com', custom_domain: false, anonymous: false)
 
       expect { subject.send(:validate_share_domain) }
         .to raise_error(OT::FormError, /Unknown domain/)

--- a/apps/api/v2/logic/secrets/base_secret_action.rb
+++ b/apps/api/v2/logic/secrets/base_secret_action.rb
@@ -601,9 +601,18 @@ module V2::Logic
       # branch wins — matching DomainStrategy, where the exact canonical
       # match outranks :custom. ConfigureDomains warns about that config.
       #
-      # Normalization mirrors CustomDomain.default_domain?: display_domain
-      # on the input, DomainParser on the configured hosts, so
-      # 'Short.Example.COM' matches a pool entry of 'short.example.com'.
+      # Membership is answered by Middleware::DomainStrategy.link_pool_host?,
+      # NOT by reading features.domains.link_domains out of config. The config
+      # read skipped both of the middleware's gates — features.domains.enabled,
+      # and membership in the parsed canonical set — so with domains disabled,
+      # or with an entry that does not parse, this admitted hosts the
+      # middleware classifies :invalid and the picker never offers. Admission
+      # here and classification there must answer from the same set.
+      #
+      # Normalization mirrors CustomDomain.default_domain?: display_domain on
+      # the input (which also rejects garbage, via the rescue below),
+      # DomainParser on the resolved pool, so 'Short.Example.COM' matches a
+      # pool entry of 'short.example.com'.
       #
       # Keep logically parallel with the V1 implementation (apps/api/v1/...);
       # logging differs because V1 has no structured secret_logger.
@@ -613,9 +622,7 @@ module V2::Logic
       def link_pool_host?(domain)
         input_display = Onetime::CustomDomain.display_domain(domain)
 
-        Onetime::Utils::CanonicalHosts.link_pool.any? do |host|
-          Onetime::Utils::DomainParser.extract_hostname(host) == input_display
-        end
+        Onetime::Middleware::DomainStrategy.link_pool_host?(input_display)
       rescue PublicSuffix::Error, Onetime::Problem => ex
         # Unparseable input is not a pool member. Fall through to the
         # CustomDomain lookup, which rejects it as an unknown domain.

--- a/apps/api/v2/spec/logic/secrets/base_secret_action_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/base_secret_action_spec.rb
@@ -97,22 +97,52 @@ RSpec.describe 'V2 BaseSecretAction config path bug' do
     )
   end
 
-  # Sets features.domains.link_domains on the LIVE booted config for the
-  # duration of the block, restoring the previous state (including the key's
-  # absence) afterwards. OT.conf is not deep-frozen under test.
+  # Puts the process in the state an operator actually gets by setting
+  # LINK_DOMAINS, on the LIVE booted config, restoring everything (including
+  # a key's absence) afterwards. OT.conf is not deep-frozen under test.
   #
-  # Deliberately NOT a stub of Utils::CanonicalHosts.link_pool: the chain that
-  # actually broke is OT.conf -> CanonicalHosts.link_pool -> link_pool_host?,
-  # and stubbing the pool reader would skip the config layer under test.
-  def with_link_domains(pool)
-    domains  = OT.conf['features']['domains']
-    had_key  = domains.key?('link_domains')
-    previous = domains['link_domains']
+  # Three things, not one, because link_pool_host? answers from
+  # Middleware::DomainStrategy's RESOLVED pool rather than re-reading config:
+  #
+  #   features.domains.enabled  - the middleware gates its pool on this, and
+  #                               the shipped test config has domains OFF.
+  #   site.host                 - must PARSE, or initialize_from_config lands
+  #                               in its DomainInvalid rescue and disables the
+  #                               feature. The test config's '127.0.0.1:3000'
+  #                               does not parse.
+  #   link_domains              - the pool itself.
+  #
+  # Deliberately NOT a stub of the pool reader: the chain under test is
+  # OT.conf -> DomainStrategy.initialize_from_config -> link_pool_host?, and
+  # stubbing its far end is what let admission drift away from classification
+  # in the first place (a config-only read admitted hosts with the feature off
+  # and hosts that never parsed).
+  def with_link_domains(pool, canonical_host: 'onetimesecret.com', enabled: true)
+    domains       = OT.conf['features']['domains']
+    site          = OT.conf['site']
+    had_pool_key  = domains.key?('link_domains')
+    previous_pool = domains['link_domains']
+    previous_on   = domains['enabled']
+    previous_host = site['host']
 
     domains['link_domains'] = pool
+    domains['enabled']      = enabled
+    site['host']            = canonical_host
+    reload_domain_strategy!
     yield
   ensure
-    had_key ? domains['link_domains'] = previous : domains.delete('link_domains')
+    had_pool_key ? domains['link_domains'] = previous_pool : domains.delete('link_domains')
+    domains['enabled'] = previous_on
+    site['host']       = previous_host
+    reload_domain_strategy!
+  end
+
+  # Re-derives DomainStrategy's class state from the current OT.conf, the way
+  # booting a Rack app would.
+  def reload_domain_strategy!
+    Onetime::Middleware::DomainStrategy.initialize_from_config(
+      OT.conf.dig('features', 'domains') || {},
+    )
   end
 
   describe '#process_ttl config path' do
@@ -913,8 +943,11 @@ RSpec.describe 'V2 BaseSecretAction config path bug' do
     context 'with an operator link pool configured (#4063)' do
       around { |example| with_link_domains(%w[short.example.com go.acme.com]) { example.run } }
 
-      it 'is a precondition that the pool really is readable from config' do
-        expect(Onetime::Utils::CanonicalHosts.link_pool)
+      # Pins the RESOLVED pool, not the raw config value: admission answers
+      # from DomainStrategy, so a precondition on config alone would stay green
+      # while the middleware resolved something else entirely.
+      it 'is a precondition that the pool really resolved in the middleware' do
+        expect(Onetime::Middleware::DomainStrategy.link_domains)
           .to eq(%w[short.example.com go.acme.com])
       end
 
@@ -1417,6 +1450,88 @@ RSpec.describe 'V2 BaseSecretAction config path bug' do
           expect { subject.send(:validate_share_domain) }.not_to raise_error
           expect(subject.share_domain).to eq(host_domain)
         end
+      end
+    end
+
+    # ------------------------------------------------------------------------
+    # Pool admission is GATED, not a raw config read (#4063)
+    #
+    # link_pool_host? used to read features.domains.link_domains straight out
+    # of config, which skipped both gates the middleware applies. Admission
+    # then disagreed with classification in two ways an operator can reach by
+    # accident: a pool configured while the domains feature is off, and a pool
+    # entry that does not parse. In both cases the middleware classifies the
+    # host :invalid and the picker never offers it, so admitting it here let a
+    # guest anchor secrets on a host the deployment does not serve.
+    #
+    # These two contexts are the reason link_pool_host? delegates to
+    # DomainStrategy at all; without them the delegation looks like a
+    # refactor.
+    # ------------------------------------------------------------------------
+    context 'with a link pool configured but the domains feature disabled (#4063)' do
+      subject do
+        build_integration_subject(
+          cust: authenticated_member,
+          share_domain: 'short.example.com',
+          display_domain: 'onetimesecret.com',
+          custom_domain: false,
+        )
+      end
+
+      around do |example|
+        with_link_domains(%w[short.example.com], enabled: false) { example.run }
+      end
+
+      before do
+        allow(Onetime::CustomDomain).to receive(:from_display_domain).and_return(nil)
+      end
+
+      it 'is a precondition that the middleware admits no pool member' do
+        expect(Onetime::Middleware::DomainStrategy.link_pool_host?('short.example.com'))
+          .to be false
+      end
+
+      it "rejects the pool member with 'Unknown domain'" do
+        expect { subject.send(:validate_share_domain) }
+          .to raise_error(Onetime::FormError, /Unknown domain/)
+      end
+    end
+
+    context 'with a link pool whose entry does not parse (#4063)' do
+      subject do
+        build_integration_subject(
+          cust: authenticated_member,
+          share_domain: 'links.internal',
+          display_domain: 'onetimesecret.com',
+          custom_domain: false,
+        )
+      end
+
+      around do |example|
+        with_link_domains(%w[links.internal]) { example.run }
+      end
+
+      before do
+        allow(Onetime::CustomDomain).to receive(:from_display_domain).and_return(nil)
+      end
+
+      it 'is a precondition that the entry was dropped from the resolved pool' do
+        expect(Onetime::Middleware::DomainStrategy.link_domains).to eq([])
+      end
+
+      it 'does not admit the unparseable host' do
+        expect { subject.send(:validate_share_domain) }
+          .to raise_error(Onetime::FormError, /Unknown domain/)
+      end
+
+      # The dangerous fallback: resolving an all-unparseable pool back to
+      # [canonical_domain] would put the internal platform host in the picker,
+      # the exact outcome LINK_DOMAINS exists to prevent. Boot now refuses this
+      # config outright (Onetime::Config.validate_link_domains!); this pins the
+      # middleware's behavior for the paths that bypass boot validation.
+      it 'does not fall back to the canonical host' do
+        expect(Onetime::Middleware::DomainStrategy.link_domains)
+          .not_to include('onetimesecret.com')
       end
     end
   end

--- a/apps/web/auth/spec/unit/omniauth_tenant_helpers_spec.rb
+++ b/apps/web/auth/spec/unit/omniauth_tenant_helpers_spec.rb
@@ -23,6 +23,16 @@ require_relative '../spec_helper'
 # wrong type, so the reopen raises a TypeError ("Config is not a class") and boot
 # is marked permanently not-ready for every later spec in the process.
 require 'rodauth'
+
+# Load the OmniAuth strategy classes the verifying doubles below reference.
+# This spec deliberately skips the app boot, so nothing else in the process
+# pulls the provider gems in; without these requires every
+# `instance_double(OmniAuth::Strategies::X)` raises NameError.
+require 'omniauth_openid_connect'
+require 'omniauth-entra-id'
+require 'omniauth-github'
+require 'omniauth-google-oauth2'
+
 module Auth; end
 Auth.const_set(:Config, Class.new(Rodauth::Auth)) unless defined?(Auth::Config)
 Auth::Config.const_set(:Hooks, Module.new) unless Auth::Config.const_defined?(:Hooks, false)

--- a/changelog.d/20260808_210000_claude_4063_link_domains_config.rst
+++ b/changelog.d/20260808_210000_claude_4063_link_domains_config.rst
@@ -11,13 +11,50 @@ Added
   existing install is unchanged. Set, the picker offers exactly the
   listed hosts and every entry also joins the canonical host set, so
   requests to them serve rather than classifying ``:invalid``. (#4063)
-- ``LINK_DOMAINS`` set but naming no host (``LINK_DOMAINS=`` or
-  ``LINK_DOMAINS="  "``) now aborts boot with an
-  ``Onetime::ConfigError`` naming both the env var and the config path.
-  Deliberately the opposite polarity from an empty admin host
-  allowlist: an empty link pool silently falling back to the canonical
-  domain would hide the typo and put the internal host back in the
-  picker — the exact outcome the setting exists to prevent. (#4063)
+- ``LINK_DOMAINS`` set but yielding no usable host now aborts boot with
+  an ``Onetime::ConfigError`` naming both the env var and the config
+  path. Two cases: naming no host at all (``LINK_DOMAINS=`` or
+  ``LINK_DOMAINS="  "``), and naming only hosts that cannot be parsed
+  (``LINK_DOMAINS=links.internal``), which the error echoes back so the
+  typo is visible. A list that mixes parseable and unparseable entries
+  still boots — the bad entry is dropped and logged, and the pool keeps
+  a host to offer. Deliberately the opposite polarity from an empty
+  admin host allowlist: an empty link pool silently falling back to the
+  canonical domain would hide the typo and put the internal host back in
+  the picker — the exact outcome the setting exists to prevent. (#4063)
+
+Fixed
+-----
+
+- A request to ``www.<base-domain>`` no longer classifies ``:canonical``
+  merely because some ``LINK_DOMAINS`` entry shares that base domain.
+  The ``www.`` tolerance applies to the anchor hosts (``site.host``,
+  ``features.domains.default``) only; a link-pool member participates in
+  classification by exact match alone. Previously, with
+  ``LINK_DOMAINS=go.acme.com``, a tenant's registered ``www.acme.com``
+  was classified ahead of the custom-domain lookup and silently lost its
+  per-domain brand and sign-in configuration. (#4063)
+- Secret creation no longer admits a ``share_domain`` the middleware
+  would reject. The link-pool check read ``features.domains.link_domains``
+  straight out of config, skipping both the ``features.domains.enabled``
+  gate and the parsed-host filter, so a pool configured with the domains
+  feature off — or containing an unparseable entry — let guests anchor
+  secrets on hosts that classify ``:invalid`` and that the picker never
+  offers. (#4063)
+- The domain-context picker no longer offers the canonical domain while
+  the browser is on a tenant-branded host, where selecting it was
+  silently ignored and the link was anchored on the branded host
+  anyway. (#4063)
+- Selecting the canonical domain in the picker is now written through to
+  the server session. It previously cleared only ``sessionStorage``,
+  leaving ``sess['domain_context']`` naming the previous selection — and
+  since the server value is read first, the next page load silently
+  reverted the switch. (#4063)
+- Host comparisons in the picker are normalized (lowercased,
+  port-stripped) on both sides. ``link_domains`` arrives normalized from
+  the server while ``canonical_domain``/``site_host`` do not, so a
+  canonical host configured with a port was never recognized as a member
+  of its own link pool. (#4063)
 
 AI Assistance
 -------------
@@ -25,3 +62,7 @@ AI Assistance
 - Claude added the ``link_domains`` config template, the
   ``Onetime::Config.validate_link_domains!`` boot guard, the
   ``.env.reference`` entry, and the test-lane env scrub. (#4063)
+- Claude addressed a code review of the branch: the anchor-only ``www.``
+  tolerance, the boot guard for an unparseable pool, the gated
+  ``DomainStrategy.link_pool_host?`` predicate that secret creation now
+  answers from, and the four frontend picker fixes above. (#4063)

--- a/changelog.d/20260808_210000_claude_4063_link_domains_config.rst
+++ b/changelog.d/20260808_210000_claude_4063_link_domains_config.rst
@@ -55,6 +55,14 @@ Fixed
   the server while ``canonical_domain``/``site_host`` do not, so a
   canonical host configured with a port was never recognized as a member
   of its own link pool. (#4063)
+- Resetting the picker on a tenant-branded host now lands on that host
+  rather than on nothing. With ``LINK_DOMAINS`` unset — the default — the
+  pool is canonical-only and the canonical entry is not offered from a
+  branded host, so the reset cleared ``sessionStorage`` while
+  ``sess['domain_context']`` kept naming the previous selection, which
+  the next page load restored. A blank domain cannot be written back
+  (the endpoint rejects it), and the served host is where links from
+  that host are anchored regardless. (#4063)
 
 AI Assistance
 -------------

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -790,6 +790,13 @@ features:
     #   set-but-empty  -> boot error naming LINK_DOMAINS
     #                     (Onetime::Config.validate_link_domains!)
     #
+    # A set list that names only UNPARSEABLE hosts is the same boot
+    # error: there is no safe fallback for it. Offering the canonical
+    # domain instead would contradict the request (hiding that host is
+    # the whole point), and offering nothing leaves the picker empty, so
+    # the typo has to fail loud. A list that mixes good and bad entries
+    # boots — the bad one is dropped and logged.
+    #
     # This is NOT a UI-only setting: every entry joins the canonical
     # host set, so requests to these hosts are classified :canonical and
     # serve the app instead of being rejected as :invalid.

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -4,7 +4,9 @@
 
 require 'date' # ensure Date/Time constants resolve for permitted_classes
 require 'json' # String#to_json for YAML-safe BRAND_* interpolation (see brand block)
+require 'public_suffix' # validate_link_domains! parses LINK_DOMAINS entries at boot
 require_relative 'utils/config_resolver'
+require_relative 'utils/domain_parser'
 require_relative 'utils/enumerables'
 
 module Onetime
@@ -991,16 +993,27 @@ module Onetime
       validate_link_domains!(conf.dig('features', 'domains', 'link_domains'))
     end
 
-    # Rejects a LINK_DOMAINS that was set but names no host.
+    # Rejects a LINK_DOMAINS that was set but yields no usable host.
     #
     # Takes the raw config value rather than reading OT.conf so it can be
     # driven directly by a spec without a booted config.
     #
-    #   nil          -> return (unset; the link picker offers the canonical
-    #                   domain, which is the pre-#4063 behavior)
-    #   ['a.com']    -> return
-    #   []           -> raise (LINK_DOMAINS="")
-    #   ['']         -> raise (LINK_DOMAINS="  ")
+    #   nil                -> return (unset; the link picker offers the
+    #                         canonical domain, the pre-#4063 behavior)
+    #   ['a.com']          -> return
+    #   ['a.com', 'oops']  -> return (partial failure; DomainStrategy drops
+    #                         'oops' and logs it — the pool still has a host)
+    #   []                 -> raise (LINK_DOMAINS="")
+    #   ['']               -> raise (LINK_DOMAINS="  ")
+    #   ['links.internal'] -> raise (nothing parses: no usable pool)
+    #
+    # Both raising cases are the same defect wearing different clothes — the
+    # operator asked for a pool and there is none — and both must fail at boot
+    # rather than resolve to something. There is no safe fallback: offering
+    # the canonical domain contradicts the request (that internal platform
+    # host is exactly what LINK_DOMAINS exists to hide from the picker), and
+    # offering nothing leaves the picker empty. Failing loud, naming the
+    # entries, is the only honest option.
     #
     # NOTE: this is deliberately the OPPOSITE polarity from #4062's
     # security.admin allowed_hosts, where an empty list means canonical-only.
@@ -1010,18 +1023,50 @@ module Onetime
     # prevent: the internal platform host offered in the customer-facing
     # picker. Do not "fix" one of these to match the other.
     #
+    # Parseability is judged exactly as Middleware::DomainStrategy judges it
+    # (DomainParser.extract_hostname, then PublicSuffix with default_rule:
+    # nil), so a host that boots here is a host the middleware will serve. Keep
+    # the two in step.
+    #
     # @param raw [Array<String>, nil] features.domains.link_domains as loaded
-    # @raise [Onetime::ConfigError] when set but empty after stripping blanks
+    # @raise [Onetime::ConfigError] when set but blank, or set with no
+    #   parseable host
     # @return [void]
     def validate_link_domains!(raw)
       return if raw.nil?
-      return unless Array(raw).map { |host| host.to_s.strip }.reject(&:empty?).empty?
+
+      listed = Array(raw).map { |host| host.to_s.strip }.reject(&:empty?)
+      if listed.empty?
+        raise OT::ConfigError,
+          'LINK_DOMAINS (features.domains.link_domains) is set but names no host. ' \
+          'It lists the domains offered in the link picker and cannot be blank. ' \
+          'List at least one host (LINK_DOMAINS=links.example.com), or unset ' \
+          'LINK_DOMAINS entirely to offer the canonical domain.'
+      end
+
+      return if listed.any? { |host| parseable_link_domain?(host) }
 
       raise OT::ConfigError,
-        'LINK_DOMAINS (features.domains.link_domains) is set but names no host. ' \
-        'It lists the domains offered in the link picker and cannot be blank. ' \
-        'List at least one host (LINK_DOMAINS=links.example.com), or unset ' \
-        'LINK_DOMAINS entirely to offer the canonical domain.'
+        "LINK_DOMAINS (features.domains.link_domains) #{listed.inspect} names no parseable " \
+        'domain, so the link picker would have nothing to offer. Check for typos and ' \
+        'private/internal hostnames (a host must have a public suffix, e.g. ' \
+        'links.example.com). Unset LINK_DOMAINS entirely to offer the canonical domain.'
+    end
+
+    # Whether a configured link-pool host survives the same parse the
+    # DomainStrategy middleware applies. Any parse failure is a rejection —
+    # this runs at boot, where a raised exception would be reported as an
+    # unrelated crash rather than the config error it is.
+    #
+    # @param host [String]
+    # @return [Boolean]
+    def parseable_link_domain?(host)
+      hostname = Onetime::Utils::DomainParser.extract_hostname(host)
+      return false if hostname.nil?
+
+      PublicSuffix.valid?(hostname, default_rule: nil)
+    rescue StandardError
+      false
     end
 
     # True when this process can participate in the Vite dev-server workflow:

--- a/lib/onetime/middleware/domain_strategy.rb
+++ b/lib/onetime/middleware/domain_strategy.rb
@@ -262,13 +262,22 @@ module Onetime
           # ## Exact-match set vs. sweep set (#4063)
           #
           # `canonical_domains` is the EXACT-match set: every canonical host,
-          # including features.domains.link_domains members.
+          # including features.domains.link_domains members. Matched with
+          # `exact_host?` (name equality), NOT `equal_to?` — the latter also
+          # accepts the `www.` variant of a host's registrable domain, which
+          # over a pool member silently widens the grant to a host the
+          # operator never blessed. With link_domains=['go.acme.com'], an
+          # `equal_to?` match here classified `www.acme.com` :canonical ahead
+          # of the known_custom_domain? lookup below, dropping that tenant's
+          # brand/signin config. The www tolerance is retained, scoped to the
+          # ANCHORS, by the second half of the same arm.
           #
-          # `anchor_domains` is the set the peer/parent and subdomain SWEEPS
-          # iterate, and it is deliberately narrower — the two ANCHOR hosts
-          # (site.host, features.domains.default). It defaults to
-          # `canonical_domains`, which is the pre-#4063 identity for any
-          # caller that has no pool (the two sets are then equal).
+          # `anchor_domains` is the set the www-variant tolerance and the
+          # peer/parent and subdomain SWEEPS iterate, and it is deliberately
+          # narrower — the two ANCHOR hosts (site.host,
+          # features.domains.default). It defaults to `canonical_domains`,
+          # which is the pre-#4063 identity for any caller that has no pool
+          # (the two sets are then equal).
           #
           # DO NOT "fix" the sweeps back onto the full set for consistency.
           # An operator blesses one specific link host, not its base domain.
@@ -303,7 +312,13 @@ module Onetime
 
             request_domain = Parser.parse(request_domain)
 
-            if canonical_domains.any? { |host| equal_to?(request_domain, host) }
+            # Exact match against the FULL canonical set (pool included), plus
+            # the `www.` variant tolerance against the ANCHORS only. Splitting
+            # the arm this way keeps the pre-#4063 behavior identical whenever
+            # the two sets are equal, while a pool member participates by exact
+            # match alone.
+            if canonical_domains.any? { |host| exact_host?(request_domain, host) } ||
+               sweep_domains.any? { |host| equal_to?(request_domain, host) }
               :canonical
             elsif known_custom_domain?(request_domain.name)
               :custom
@@ -364,6 +379,26 @@ module Onetime
             )
           end
 
+          # Strict host equality: the same name, nothing else. This is the ONLY
+          # predicate safe to run over the full canonical set, because that set
+          # includes features.domains.link_domains members (#4063) and an
+          # operator blesses one specific link host — never a sibling of it.
+          #
+          # @param left [PublicSuffix::Domain]
+          # @param right [PublicSuffix::Domain]
+          # @return [Boolean]
+          def exact_host?(left, right)
+            return false unless left.domain? && right.domain?
+
+            left.name.eql?(right.name)
+          end
+          # exact_host?('example.com', 'example.com')     # => true
+          # exact_host?('www.example.com', 'example.com') # => false (see equal_to?)
+
+          # Host equality WITH the `www.` variant tolerance. Only ever applied
+          # to ANCHOR hosts: over a pool member the second arm matches any
+          # `www.<registrable-domain>` sibling, which is a grant the operator
+          # did not make.
           def equal_to?(left, right)
             return false unless left.domain? && right.domain?
 
@@ -643,12 +678,23 @@ module Onetime
         # are taken from the parsed set, so the picker can compare them
         # directly against CustomDomain display_domain values.
         #
+        # An UNSET pool (link_hosts nil) resolves to [canonical_domain] — the
+        # pre-#4063 behavior, and the only case that may fall back. A pool the
+        # operator DID configure never falls back to the canonical host: doing
+        # so re-exposes the internal platform address in the picker, which is
+        # the precise outcome LINK_DOMAINS exists to prevent. A configured pool
+        # where nothing resolves is operator error, and
+        # Onetime::Config.validate_link_domains! already fails boot on it — the
+        # empty return here only covers callers that drive
+        # initialize_from_config directly (specs, console) and so never passed
+        # through that gate.
+        #
         # @param link_hosts [Array<String>, nil] features.domains.link_domains,
         #   already gated on domains_enabled by the caller
-        # @return [Array<String>] never empty when a canonical domain exists
+        # @return [Array<String>] [canonical_domain] when unset; otherwise the
+        #   resolved subset of the configured pool, possibly empty
         def resolve_link_domains(link_hosts)
-          fallback = [canonical_domain].compact
-          return fallback if link_hosts.nil?
+          return [canonical_domain].compact if link_hosts.nil?
 
           parsed_names = Array(canonical_domains_parsed).map(&:name)
           configured   = Onetime::Utils::CanonicalHosts.link_pool(link_hosts: link_hosts)
@@ -659,7 +705,40 @@ module Onetime
           end
           resolved.uniq!
 
-          resolved.empty? ? fallback : resolved
+          if resolved.empty?
+            OT.le '[middleware] DomainStrategy: features.domains.link_domains ' \
+                  "#{configured.inspect} named no parseable host; the link picker pool is empty. " \
+                  'Fix LINK_DOMAINS or unset it to offer the canonical domain.'
+          end
+
+          resolved
+        end
+
+        # Whether a host is a member of the resolved operator link pool
+        # (#4063), and therefore admissible as a share_domain.
+        #
+        # Single authority for that question, so the secret-creation logic
+        # (apps/api/v{1,2}/logic/secrets/base_secret_action.rb#link_pool_host?)
+        # can never admit a host the middleware would classify :invalid.
+        # Reading features.domains.link_domains out of config directly is what
+        # let that drift happen: it skipped BOTH gates applied here — the
+        # features.domains.enabled check, and membership in the PARSED
+        # canonical set — so with domains disabled, or with a typo'd entry,
+        # guests could anchor secrets on hosts the middleware never serves as
+        # canonical and the picker never offers.
+        #
+        # @param host [String, nil] Host to test (port/case-insensitive)
+        # @return [Boolean]
+        def link_pool_host?(host)
+          return false unless domains_enabled?
+
+          pool = link_domains
+          return false if pool.nil? || pool.empty?
+
+          normalized = Onetime::Utils::DomainParser.extract_hostname(host)
+          return false if normalized.nil?
+
+          pool.any? { |candidate| Onetime::Utils::DomainParser.extract_hostname(candidate) == normalized }
         end
 
         def reset!

--- a/spec/unit/onetime/config/link_domains_spec.rb
+++ b/spec/unit/onetime/config/link_domains_spec.rb
@@ -82,6 +82,58 @@ RSpec.describe Onetime::Config, 'LINK_DOMAINS validation (#4063)' do
           .to raise_error(Onetime::ConfigError, /LINK_DOMAINS/)
       end
     end
+
+    # A typo'd pool is the same defect as a blank one — the operator asked for
+    # a pool and there is none — and it used to boot clean. DomainStrategy
+    # then fell back to [canonical_domain], so the picker offered the internal
+    # platform host: precisely the outcome LINK_DOMAINS exists to prevent.
+    # There is no safe fallback, so this must fail at boot.
+    context 'when LINK_DOMAINS names no parseable host' do
+      it 'raises for a private/internal hostname with no public suffix' do
+        expect { described_class.validate_link_domains!(['links.internal']) }
+          .to raise_error(Onetime::ConfigError, /LINK_DOMAINS/)
+      end
+
+      it 'raises for a bare hostname' do
+        expect { described_class.validate_link_domains!(['localhost']) }
+          .to raise_error(Onetime::ConfigError, /LINK_DOMAINS/)
+      end
+
+      it 'raises when no entry in a multi-entry list parses' do
+        expect { described_class.validate_link_domains!(%w[links.internal shortener]) }
+          .to raise_error(Onetime::ConfigError, /LINK_DOMAINS/)
+      end
+
+      it 'echoes the offending entries so the operator can spot the typo' do
+        expect { described_class.validate_link_domains!(['links.internal']) }
+          .to raise_error(Onetime::ConfigError, /links\.internal/)
+      end
+
+      it 'tells the operator how to resolve it' do
+        expect { described_class.validate_link_domains!(['links.internal']) }
+          .to raise_error(Onetime::ConfigError, /[Uu]nset LINK_DOMAINS/)
+      end
+    end
+
+    # Partial failure is NOT a boot error: DomainStrategy drops the bad entry
+    # and logs it, and the pool still has a host to offer. Only a pool with
+    # nothing usable in it is fatal.
+    context 'when LINK_DOMAINS mixes parseable and unparseable hosts' do
+      it 'accepts the list' do
+        expect { described_class.validate_link_domains!(%w[links.internal go.example.com]) }
+          .not_to raise_error
+      end
+    end
+
+    # Parseability is judged exactly as the middleware judges it, so a host
+    # that boots is a host DomainStrategy will serve. Ports are stripped
+    # before the public-suffix check on both sides.
+    context 'when a LINK_DOMAINS entry carries a port' do
+      it 'accepts it' do
+        expect { described_class.validate_link_domains!(['go.example.com:8443']) }
+          .not_to raise_error
+      end
+    end
   end
 
   # The helper is only useful if boot actually calls it. A spec that drives
@@ -117,6 +169,11 @@ RSpec.describe Onetime::Config, 'LINK_DOMAINS validation (#4063)' do
 
     it 'boots when LINK_DOMAINS names a host' do
       expect { described_class.raise_concerns(conf_with(['links.example.net'])) }.not_to raise_error
+    end
+
+    it 'aborts boot when LINK_DOMAINS names no parseable host' do
+      expect { described_class.raise_concerns(conf_with(['links.internal'])) }
+        .to raise_error(Onetime::ConfigError, /LINK_DOMAINS/)
     end
 
     # Deliberate: the operator explicitly wrote a blank LINK_DOMAINS, and

--- a/src/apps/workspace/components/navigation/DomainContextSwitcher.vue
+++ b/src/apps/workspace/components/navigation/DomainContextSwitcher.vue
@@ -28,6 +28,7 @@ import OIcon from '@/shared/components/icons/OIcon.vue';
 import type { ScopeSwitcherItem } from '@/shared/components/navigation/scopeSwitcher';
 import ScopeSwitcher from '@/shared/components/navigation/ScopeSwitcher.vue';
 import { useDomainContext } from '@/shared/composables/useDomainContext';
+import { normalizeDomainHost } from '@/shared/utils/domain-host';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { useOrganizationStore } from '@/shared/stores/organizationStore';
 import { ENTITLEMENTS } from '@/types/organization';
@@ -117,10 +118,15 @@ const canManageDomains = computed(() => {
 /**
  * The canonical link domain, for row copy only (never for identity).
  * Note it is NOT necessarily selectable: with LINK_DOMAINS (#4063) an operator
- * can keep the canonical host out of the picker entirely.
+ * can keep the canonical host out of the picker entirely, and on a branded
+ * host it is dropped from the pool outright.
+ *
+ * Normalized through the same helper useDomainContext applies to
+ * `availableDomains`, so a port-bearing `site.host` still matches the row it
+ * names (`localhost:3000` vs `localhost`).
  */
-const canonicalDomain = computed<string>(
-  () => bootstrapStore.canonical_domain || bootstrapStore.site_host || ''
+const canonicalDomain = computed<string>(() =>
+  normalizeDomainHost(bootstrapStore.canonical_domain || bootstrapStore.site_host)
 );
 
 /**

--- a/src/shared/composables/useDomainContext.ts
+++ b/src/shared/composables/useDomainContext.ts
@@ -94,10 +94,13 @@ function getConfig() {
     // straight from domain_strategy, and NOT inferred from `display_domain !==
     // canonical_domain` the way the pre-#4063 code did: on an operator
     // link-pool host those two also differ, but the strategy is :canonical and
-    // none of the branded-host rules apply. (display_domain and
-    // domain_strategy are no longer surfaced raw — this predicate is the only
-    // thing either was still being read for.)
+    // none of the branded-host rules apply. (domain_strategy is not surfaced
+    // raw — this predicate is the only thing it is read for.)
     onCustomDomain: store.domain_strategy === 'custom',
+    // The host actually serving this page. Only meaningful alongside
+    // onCustomDomain, where it names the branded host and is the domain the
+    // server anchors links on no matter what share_domain asks for.
+    displayDomain: normalizeDomainHost(store.display_domain),
   };
 }
 
@@ -251,9 +254,12 @@ async function persistDomainContext(
     sessionStorage.setItem('domainContext', domain);
     if (!skipBackendSync) await syncDomainContextToServer($api, domain);
   } else {
-    // Unreachable from setContext (availableDomains gates it) -- this is the
-    // no-offerable-pool tail, where '' is the honest selection and the server
-    // anchors on whichever host served the page.
+    // Unreachable from setContext (availableDomains gates it), and no longer
+    // reachable from resetContext either now that the reset lands on the
+    // served host. What is left is the pre-init tail with no domain at all,
+    // where clearing is the only honest move: '' cannot be synced (the
+    // endpoint rejects a blank domain outright), so writing it would leave the
+    // two halves disagreeing rather than agreeing on "nothing".
     sessionStorage.removeItem('domainContext');
   }
 }
@@ -286,12 +292,24 @@ function buildCurrentContext(): DomainContext {
  * Goes through persistDomainContext rather than only clearing sessionStorage:
  * `sess['domain_context']` has no clear endpoint, so a local-only reset leaves
  * the server still naming the old selection and selectBestDomain restores it
- * on the next load. Writing the default through both halves IS the reset --
- * and when there is no offerable pool to land on, persistDomainContext's own
- * tail clears sessionStorage, which is the old behavior.
+ * on the next load. Writing the default through both halves IS the reset.
+ *
+ * On a branded host the pool fallback can be '' -- getOfferableLinkDomains
+ * drops the canonical entry there, and with LINK_DOMAINS unset that is the
+ * whole pool, which makes this the DEFAULT configuration rather than an edge
+ * case. '' is not a resettable value: the endpoint rejects a blank domain
+ * (UpdateDomainContext#field_specific_concerns), the rejection is swallowed by
+ * syncDomainContextToServer's catch, and the server half would keep naming the
+ * old selection for selectBestDomain to restore. So fall back to the host being
+ * browsed instead. It is a value both halves accept -- it is one of the
+ * customer's own custom domains, so valid_domain? admits it and it is already
+ * in availableDomains -- and it is where determine_share_domain anchors links
+ * from this host regardless of what share_domain asks for. "Reset to canonical"
+ * was always fiction on a branded host; this is what actually happens.
  */
 async function resetDomainContext($api: AxiosInstance | undefined): Promise<void> {
-  const domain = getPoolFallbackDomain();
+  const { onCustomDomain, displayDomain } = getConfig();
+  const domain = getPoolFallbackDomain() || (onCustomDomain ? displayDomain : '');
   currentDomain.value = domain;
   await persistDomainContext($api, domain, false);
 }

--- a/src/shared/composables/useDomainContext.ts
+++ b/src/shared/composables/useDomainContext.ts
@@ -17,6 +17,7 @@ import { loggingService } from '@/services/logging.service';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { useResourcePermissions } from '@/shared/composables/useResourcePermissions';
 import { useOrganizationStore } from '@/shared/stores/organizationStore';
+import { normalizeDomainHost } from '@/shared/utils/domain-host';
 import type { AxiosInstance } from 'axios';
 import { computed, inject, ref, watch } from 'vue';
 
@@ -65,48 +66,77 @@ function getPermissions(): ReturnType<typeof useResourcePermissions> {
   return permissionsInstance;
 }
 
-/** Get config values from bootstrap store (reads current values) */
+/** Get config values from bootstrap store (reads current values, normalized) */
 function getConfig() {
   const store = getBootstrapStore();
   // canonical_domain is the canonical LINK domain (DEFAULT_DOMAIN, resolved
   // server-side as default||site.host). site_host is the app's own hostname
   // and may differ; fall back to it only for older bootstrap payloads.
-  const canonicalDomain = store.canonical_domain || store.site_host;
-  const pool = store.link_domains ?? [];
+  const canonicalDomain = normalizeDomainHost(store.canonical_domain || store.site_host);
+  const pool = (store.link_domains ?? []).map(normalizeDomainHost).filter(Boolean);
   return {
     domainsEnabled: store.domains_enabled,
     canonicalDomain,
     // Operator link pool (LINK_DOMAINS, #4063): the domains offered in the
     // picker. The server always resolves an unset LINK_DOMAINS to
-    // [canonical_domain], so an empty array here means exactly one thing --
-    // a stale pre-#4063 payload -- and only then do we re-derive the
-    // canonical entry ourselves. canonicalDomain is NOT guaranteed to be a
-    // member: the canonical host may be an internal platform address the
-    // operator deliberately hides from the picker.
+    // [canonical_domain] and fails boot when a configured pool names no
+    // parseable host (Onetime::Config.validate_link_domains!), so an empty
+    // array here means exactly one thing -- a stale pre-#4063 payload -- and
+    // only then do we re-derive the canonical entry ourselves. canonicalDomain
+    // is NOT guaranteed to be a member: the canonical host may be an internal
+    // platform address the operator deliberately hides from the picker.
     linkDomains: pool.length ? pool : [canonicalDomain].filter(Boolean),
-    displayDomain: store.display_domain,
-    serverDomainContext: store.domain_context,
-    domainStrategy: store.domain_strategy,
-    customDomains: store.custom_domains ?? [],
+    serverDomainContext: normalizeDomainHost(store.domain_context),
+    // Already display_domain values server-side; normalized anyway so the
+    // membership tests below cannot depend on which side produced a string.
+    customDomains: (store.custom_domains ?? []).map(normalizeDomainHost).filter(Boolean),
+    // True when this page is being served from a tenant-branded host. Read
+    // straight from domain_strategy, and NOT inferred from `display_domain !==
+    // canonical_domain` the way the pre-#4063 code did: on an operator
+    // link-pool host those two also differ, but the strategy is :canonical and
+    // none of the branded-host rules apply. (display_domain and
+    // domain_strategy are no longer surfaced raw — this predicate is the only
+    // thing either was still being read for.)
+    onCustomDomain: store.domain_strategy === 'custom',
   };
 }
 
 /**
- * Preferred fallback drawn from the link pool, for the paths that have no
- * user selection yet (currentContext before init, resetContext, and the
- * domains-disabled init branch).
+ * The link-pool entries actually offerable in the CURRENT browsing context.
  *
- * Canonical wins when it is a pool member -- that keeps the historical
- * "reset returns you to the canonical domain" behavior -- otherwise the pool
- * head. Both are guaranteed members of availableDomains (buildAvailableDomains
- * appends every pool entry), so setContext can round-trip the result. Returns
- * '' only when there is no pool at all, which is the one value the
- * availableDomains invariant explicitly permits.
+ * On a tenant-branded host the canonical domain is dropped. Selecting it there
+ * is silently ignored end-to-end: process_share_domain nils out anchor hosts,
+ * then determine_share_domain falls through to `display_domain if
+ * custom_domain?` and anchors the link on the branded host anyway. Offering a
+ * row whose selection the generated link contradicts is worse than not
+ * offering it. (Pool members are NOT dropped -- v2 honors an authenticated
+ * user's explicit pool selection from a branded host.)
+ */
+function getOfferableLinkDomains(): string[] {
+  const { linkDomains, canonicalDomain, onCustomDomain } = getConfig();
+  if (!onCustomDomain) return linkDomains;
+  return linkDomains.filter((domain) => domain !== canonicalDomain);
+}
+
+/**
+ * Preferred fallback drawn from the offerable link pool, for the paths that
+ * have no user selection yet (currentContext before init, resetContext, and
+ * the domains-disabled init branch).
+ *
+ * Canonical wins when it is offerable -- that keeps the historical "reset
+ * returns you to the canonical domain" behavior -- otherwise the pool head.
+ * Both are guaranteed members of availableDomains (buildAvailableDomains
+ * appends every offerable pool entry), so setContext can round-trip the
+ * result. Returns '' only when there is no offerable pool at all, which is the
+ * one value the availableDomains invariant explicitly permits: the server
+ * reads an empty share_domain as "no request" and anchors the link on
+ * whichever host served the page.
  */
 function getPoolFallbackDomain(): string {
-  const { linkDomains, canonicalDomain } = getConfig();
-  if (canonicalDomain && linkDomains.includes(canonicalDomain)) return canonicalDomain;
-  return linkDomains[0] ?? '';
+  const { canonicalDomain } = getConfig();
+  const offerable = getOfferableLinkDomains();
+  if (canonicalDomain && offerable.includes(canonicalDomain)) return canonicalDomain;
+  return offerable[0] ?? '';
 }
 
 /** Get display name for a given domain */
@@ -123,12 +153,13 @@ function getDomainDisplayName(domain: string): string {
 /** Build available domains list from store */
 function buildAvailableDomains(storeDomains: Array<{ display_domain: string }>): string[] {
   // Ordering contract: the org's custom domains first (permissions order),
-  // then every link-pool entry not already listed (pool order). Every entry
-  // currentContext/resetContext/getPreferredDomain can produce must appear
-  // here, because setContext silently rejects anything that does not.
-  const { linkDomains } = getConfig();
-  const domainNames = storeDomains.map((d) => d.display_domain);
-  linkDomains.forEach((domain) => {
+  // then every OFFERABLE link-pool entry not already listed (pool order).
+  // Every entry currentContext/resetContext/getPreferredDomain can produce
+  // must appear here, because setContext silently rejects anything that does
+  // not -- and nothing may appear here that the server would then ignore, see
+  // getOfferableLinkDomains.
+  const domainNames = storeDomains.map((d) => normalizeDomainHost(d.display_domain));
+  getOfferableLinkDomains().forEach((domain) => {
     if (domain && !domainNames.includes(domain)) {
       domainNames.push(domain);
     }
@@ -152,7 +183,11 @@ function findExtidByDomain(
   storeDomains: Array<{ display_domain: string; extid: string }>,
   domain: string
 ): string | undefined {
-  return storeDomains.find((d) => d.display_domain === domain)?.extid;
+  // Both sides normalized: availableDomains entries have been through
+  // normalizeDomainHost, so a raw comparison would miss on any host the
+  // permissions API spelled differently (case, port).
+  const target = normalizeDomainHost(domain);
+  return storeDomains.find((d) => normalizeDomainHost(d.display_domain) === target)?.extid;
 }
 
 /** Find display_domain for a given extid from store domains */
@@ -160,7 +195,10 @@ function findDomainByExtid(
   storeDomains: Array<{ display_domain: string; extid: string }>,
   extid: string
 ): string | undefined {
-  return storeDomains.find((d) => d.extid === extid)?.display_domain;
+  const found = storeDomains.find((d) => d.extid === extid)?.display_domain;
+  // Normalized so the result round-trips through setContext, which tests
+  // membership against the normalized availableDomains list.
+  return found === undefined ? undefined : normalizeDomainHost(found);
 }
 
 /** Sync domain context to backend (fire-and-forget) */
@@ -180,7 +218,7 @@ async function syncDomainContextToServer(
  * Persist domain selection: registered custom domains and operator link-pool
  * entries sync to server + sessionStorage; everything else clears the session.
  *
- * The predicate is `custom_domains ∪ link_domains`, minus the canonical domain.
+ * The predicate is `custom_domains ∪ link_domains`, canonical domain INCLUDED.
  *
  * - Pool entries (LINK_DOMAINS, #4063) have no CustomDomain row and so are never
  *   in `custom_domains`. Gating on that list alone wrote nothing and synced
@@ -191,24 +229,71 @@ async function syncDomainContextToServer(
  *   canonical set, which every pool member joined -- or the customer's own
  *   custom domains. A peer/sibling of a pool member matches neither list here
  *   and would be rejected there, so we must not persist it.
- * - The canonical domain is carved out deliberately: absent sessionStorage IS
- *   the canonical/default state, so selecting it clears rather than writes. It
- *   is a pool member whenever LINK_DOMAINS is unset, which would otherwise
- *   invert that long-standing behavior.
+ * - The canonical domain used to be carved OUT of this set, on the reasoning
+ *   that absent sessionStorage is itself the canonical/default state. That
+ *   held only as long as nothing else remembered a selection. It does not:
+ *   `sess['domain_context']` outlives sessionStorage and there is no endpoint
+ *   that clears it, so selecting canonical dropped the local half of the
+ *   preference while leaving the server half pointing at the previously
+ *   selected custom domain -- and selectBestDomain reads the server half
+ *   FIRST, so the next reload silently reverted the switch. Writing the
+ *   canonical selection through both halves is what keeps them from diverging;
+ *   it needs no clear path because there is no longer a selection that
+ *   deliberately leaves one half stale.
  */
 async function persistDomainContext(
   $api: AxiosInstance | undefined,
   domain: string,
   skipBackendSync: boolean
 ): Promise<void> {
-  const { customDomains, linkDomains, canonicalDomain } = getConfig();
-  const isPoolMember = domain !== canonicalDomain && linkDomains.includes(domain);
-  if (customDomains.includes(domain) || isPoolMember) {
+  const { customDomains, linkDomains } = getConfig();
+  if (customDomains.includes(domain) || linkDomains.includes(domain)) {
     sessionStorage.setItem('domainContext', domain);
     if (!skipBackendSync) await syncDomainContextToServer($api, domain);
   } else {
+    // Unreachable from setContext (availableDomains gates it) -- this is the
+    // no-offerable-pool tail, where '' is the honest selection and the server
+    // anchors on whichever host served the page.
     sessionStorage.removeItem('domainContext');
   }
+}
+
+/**
+ * Resolve the active DomainContext from module state.
+ *
+ * Module-level rather than inline in the composable so the reactive read set
+ * is identical for every caller (all state it touches is module-level too).
+ */
+function buildCurrentContext(): DomainContext {
+  const { canonicalDomain } = getConfig();
+  // Pre-init / anonymous callers land here. The fallback must be offerable:
+  // SecretForm posts currentContext.domain as share_domain on every creation
+  // (the anonymous homepage included), and guests may only name pool members.
+  const domain = currentDomain.value || getPoolFallbackDomain();
+  const isCanonical = domain === canonicalDomain;
+  return {
+    domain,
+    extid: isCanonical ? undefined : findExtidByDomain(permissionsDomains.value, domain),
+    displayName: getDomainDisplayName(domain),
+    isCanonical,
+  };
+}
+
+/**
+ * Reset to the pool's preferred entry (canonical when it is offerable), never
+ * to a canonical host the operator excluded from the picker.
+ *
+ * Goes through persistDomainContext rather than only clearing sessionStorage:
+ * `sess['domain_context']` has no clear endpoint, so a local-only reset leaves
+ * the server still naming the old selection and selectBestDomain restores it
+ * on the next load. Writing the default through both halves IS the reset --
+ * and when there is no offerable pool to land on, persistDomainContext's own
+ * tail clears sessionStorage, which is the old behavior.
+ */
+async function resetDomainContext($api: AxiosInstance | undefined): Promise<void> {
+  const domain = getPoolFallbackDomain();
+  currentDomain.value = domain;
+  await persistDomainContext($api, domain, false);
 }
 
 /**
@@ -262,7 +347,9 @@ function createPermissionsFetcher(
  */
 function selectBestDomain(available: string[]): string {
   const { serverDomainContext } = getConfig();
-  const localContext = sessionStorage.getItem('domainContext');
+  // Normalized: a value stored by an older build (or by a server that kept the
+  // configured spelling) must still match the normalized `available` list.
+  const localContext = normalizeDomainHost(sessionStorage.getItem('domainContext'));
 
   if (serverDomainContext && available.includes(serverDomainContext)) {
     // Server-side preference takes priority
@@ -354,26 +441,15 @@ export function useDomainContext() {
     () => availableDomains.value
   );
 
-  const currentContext = computed<DomainContext>(() => {
-    const { canonicalDomain } = getConfig();
-    // Pre-init / anonymous callers land here. The fallback must be a pool
-    // member: SecretForm posts currentContext.domain as share_domain on every
-    // creation (including the anonymous homepage), and the server only admits
-    // pool members from guests.
-    const domain = currentDomain.value || getPoolFallbackDomain();
-    const isCanonical = domain === canonicalDomain;
-    return {
-      domain,
-      extid: isCanonical ? undefined : findExtidByDomain(permissionsDomains.value, domain),
-      displayName: getDomainDisplayName(domain),
-      isCanonical,
-    };
-  });
+  const currentContext = computed<DomainContext>(buildCurrentContext);
 
   const setContext = async (domain: string, skipBackendSync = false): Promise<void> => {
-    if (!availableDomains.value.includes(domain)) return;
-    currentDomain.value = domain;
-    await persistDomainContext($api, domain, skipBackendSync);
+    // Normalized first: availableDomains holds normalized hosts, so a raw host
+    // from a caller (route param, stored preference) would be silently rejected.
+    const selected = normalizeDomainHost(domain);
+    if (!availableDomains.value.includes(selected)) return;
+    currentDomain.value = selected;
+    await persistDomainContext($api, selected, skipBackendSync);
   };
 
   /** Reverse lookup: find display_domain for a given extid */
@@ -397,9 +473,7 @@ export function useDomainContext() {
     availableDomains,
     isLoadingDomains: computed(() => isLoadingDomains.value),
     setContext,
-    // Reset to the pool's preferred entry (canonical when it is a member),
-    // never to a canonical host the operator excluded from the picker.
-    resetContext: () => { currentDomain.value = getPoolFallbackDomain(); sessionStorage.removeItem('domainContext'); },
+    resetContext: () => resetDomainContext($api),
     refreshDomains: fetchDomainsForOrganization,
     getDomainDisplayName,
     getExtidByDomain: (domain: string) => findExtidByDomain(permissionsDomains.value, domain),

--- a/src/shared/composables/useDomainContext.ts
+++ b/src/shared/composables/useDomainContext.ts
@@ -173,11 +173,18 @@ function buildAvailableDomains(storeDomains: Array<{ display_domain: string }>):
 /** Get the preferred default domain (custom domain preferred over link pool) */
 function getPreferredDomain(available: string[]): string {
   const { linkDomains } = getConfig();
-  // Prefer the first real custom domain; pool membership (not "!== canonical")
-  // is what distinguishes an operator-blessed entry from a customer's domain.
+  // Prefer the first entry the operator did NOT bless -- pool membership, not
+  // "!== canonical", is what separates an operator entry from a customer's own
+  // domain. The two sets can overlap (ConfigureDomains warns about, but does
+  // not prevent, listing a registered CustomDomain in LINK_DOMAINS), so this
+  // predicate is a sufficient test for "customer's domain" and not a necessary
+  // one: an overlapping host fails it and falls to the tail.
   const customDomain = available.find((d) => !linkDomains.includes(d));
-  // Tail is `available[0]` (the pool head, given the ordering above) or ''.
-  // Never a value absent from `available` -- setContext would drop it.
+  // The tail is not a coin flip. buildAvailableDomains puts the org's domains
+  // ahead of every pool entry, so `available[0]` is a customer domain whenever
+  // the org has any, and the pool head only when it has none -- which is the
+  // same answer the predicate would give. Never a value absent from
+  // `available` -- setContext would drop it.
   return customDomain || available[0] || '';
 }
 

--- a/src/shared/utils/domain-host.ts
+++ b/src/shared/utils/domain-host.ts
@@ -1,0 +1,37 @@
+// src/shared/utils/domain-host.ts
+
+/**
+ * Host normalization shared by every consumer of the bootstrap payload's
+ * domain fields.
+ *
+ * Lives in its own module rather than beside its main caller
+ * (`useDomainContext`) so that components which mock the composable wholesale
+ * still get the real function — normalizing a hostname is not composable state
+ * and there is nothing meaningful to stub.
+ */
+
+/**
+ * Normalize a host for comparison: trimmed, lowercased, port stripped.
+ *
+ * The server hands the frontend two families of host strings that are NOT
+ * normalized the same way. `link_domains` comes out of DomainStrategy's PARSED
+ * canonical set, so it is already lowercased and port-free; `canonical_domain`
+ * / `site_host` / `display_domain` are the configured strings verbatim, and
+ * `site.host` legally carries a port (the shipped dev default is
+ * `localhost:3000`). Comparing the two families raw made every
+ * `linkDomains.includes(canonicalDomain)` test fail on a port-bearing
+ * canonical host — the single test that decides whether the canonical domain
+ * counts as a link-pool member at all.
+ *
+ * Ruby-side equivalent: `Onetime::Utils::DomainParser.extract_hostname`. Every
+ * server endpoint these values are handed to (share_domain,
+ * update-domain-context) normalizes the same way, so nothing is lost by
+ * normalizing before comparison here.
+ *
+ * @param host Raw host string from the bootstrap payload, a route param, or
+ *   sessionStorage. Nullish and blank inputs normalize to ''.
+ */
+export function normalizeDomainHost(host: string | null | undefined): string {
+  if (!host) return '';
+  return host.trim().toLowerCase().replace(/:\d+$/, '');
+}

--- a/src/tests/composables/useDomainContext.spec.ts
+++ b/src/tests/composables/useDomainContext.spec.ts
@@ -1259,16 +1259,44 @@ describe('useDomainContext', () => {
       expect(mockSessionStorage.getItem('domainContext')).toBe('onetimesecret.com');
     });
 
-    it('clears domainContext when there is no offerable pool to reset to', async () => {
-      // On a branded host with no LINK_DOMAINS configured, the pool is
-      // canonical-only and canonical is dropped -- so the reset has nothing to
-      // select and '' is the honest answer (the server then anchors on
-      // whichever host served the page).
+    it('falls back to the served host when there is no offerable pool', async () => {
+      // On a branded host with no LINK_DOMAINS configured the pool is
+      // canonical-only and canonical is dropped, so the pool fallback is ''.
+      // Resetting to '' would be a half-reset: the endpoint rejects a blank
+      // domain, so sess['domain_context'] would keep the old selection and
+      // selectBestDomain would restore it. The served host is the value both
+      // halves accept, and the one links anchor on from here regardless.
       setupBootstrapStore({
         domains_enabled: true,
         site_host: 'onetimesecret.com',
         display_domain: 'acme.example.com',
         domain_strategy: 'custom',
+        custom_domains: ['acme.example.com'],
+      });
+
+      setMockDomains('org-ext-test-123', ['acme.example.com']);
+
+      const { useDomainContext } = await import('@/shared/composables/useDomainContext');
+      const { setContext, resetContext } = useDomainContext();
+
+      await waitForInit();
+
+      await setContext('acme.example.com');
+      expect(mockSessionStorage.getItem('domainContext')).toBe('acme.example.com');
+
+      await resetContext();
+      expect(mockSessionStorage.getItem('domainContext')).toBe('acme.example.com');
+    });
+
+    it('clears domainContext when not on a branded host and nothing is offerable', async () => {
+      // No pool and no branded host to fall back to: '' is the honest answer,
+      // and clearing is the only coherent write (a blank domain cannot be
+      // synced, so storing it would make the two halves disagree).
+      setupBootstrapStore({
+        domains_enabled: true,
+        site_host: '',
+        canonical_domain: '',
+        display_domain: '',
         custom_domains: ['acme.example.com'],
       });
 
@@ -1969,6 +1997,47 @@ describe('useDomainContext', () => {
         { domain: 'onetimesecret.com' }
       );
       expect(mockSessionStorage.getItem('domainContext')).toBe('onetimesecret.com');
+    });
+
+    // The branded-host reset used to land on '' and take persistDomainContext's
+    // clearing tail: sessionStorage was dropped while sess['domain_context']
+    // kept naming the old selection, and selectBestDomain -- which reads the
+    // server half FIRST -- restored it on the next load. This is the DEFAULT
+    // configuration, not an edge case: getOfferableLinkDomains drops the
+    // canonical entry on a branded host, and with LINK_DOMAINS unset that is
+    // the entire pool. '' cannot be synced (the endpoint rejects a blank
+    // domain), so the reset lands on the served host instead -- which is where
+    // determine_share_domain anchors links from here anyway.
+    it('resetContext on a branded host writes the served host through both halves', async () => {
+      setupBootstrapStore({
+        domains_enabled: true,
+        site_host: 'onetimesecret.com',
+        canonical_domain: 'onetimesecret.com',
+        display_domain: 'acme.example.com',
+        domain_strategy: 'custom',
+        custom_domains: ['acme.example.com', 'widgets.example.com'],
+      });
+
+      setMockDomains('org-ext-test-123', ['acme.example.com', 'widgets.example.com']);
+
+      const { useDomainContext } = await importWithMockApi();
+      const { currentContext, setContext, resetContext } = useDomainContext();
+
+      await waitForInit();
+
+      await setContext('widgets.example.com');
+      expect(currentContext.value.domain).toBe('widgets.example.com');
+      mockApiPost.mockClear();
+
+      await resetContext();
+
+      expect(currentContext.value.domain).toBe('acme.example.com');
+      expect(mockSessionStorage.getItem('domainContext')).toBe('acme.example.com');
+      // The half that used to be left stale.
+      expect(mockApiPost).toHaveBeenCalledWith(
+        '/api/account/update-domain-context',
+        { domain: 'acme.example.com' }
+      );
     });
 
     it('selecting canonical domain updates currentContext correctly', async () => {

--- a/src/tests/composables/useDomainContext.spec.ts
+++ b/src/tests/composables/useDomainContext.spec.ts
@@ -619,7 +619,7 @@ describe('useDomainContext', () => {
       await setContext('links.example.net');
       expect(currentContext.value.domain).toBe('links.example.net');
 
-      resetContext();
+      await resetContext();
 
       // Pool head, not the hidden canonical host.
       expect(currentContext.value.domain).toBe('short.example.com');
@@ -719,7 +719,7 @@ describe('useDomainContext', () => {
       await setContext('acme.example.com');
       expect(currentContext.value.domain).toBe('acme.example.com');
 
-      resetContext();
+      await resetContext();
 
       // Canonical wins over the pool head because it is a member.
       expect(currentContext.value.domain).toBe('onetimesecret.com');
@@ -837,6 +837,119 @@ describe('useDomainContext', () => {
 
       await setContext('acme.example.com');
       expect(currentContext.value.extid).toBe('cd_acme_example_com');
+    });
+
+    // ------------------------------------------------------------------------
+    // Branded host: the canonical domain is not offerable
+    //
+    // Selecting it there is ignored end to end -- process_share_domain nils
+    // anchor hosts, then determine_share_domain falls through to
+    // `display_domain if custom_domain?` and anchors the link on the branded
+    // host regardless. Offering a row the generated link contradicts is worse
+    // than not offering it. Pool members are a different question: v2 honors
+    // an authenticated user's explicit pool selection from a branded host, so
+    // they stay.
+    // ------------------------------------------------------------------------
+    it('drops the canonical domain from the picker while browsing a branded host', async () => {
+      setupBootstrapStore({
+        domains_enabled: true,
+        site_host: 'onetimesecret.com',
+        canonical_domain: 'onetimesecret.com',
+        display_domain: 'acme.example.com',
+        domain_strategy: 'custom',
+        custom_domains: ['acme.example.com'],
+        link_domains: ['onetimesecret.com', 'short.example.com'],
+      });
+
+      setMockDomains('org-ext-test-123', ['acme.example.com']);
+
+      const { useDomainContext } = await import('@/shared/composables/useDomainContext');
+      const { availableDomains, setContext, currentContext } = useDomainContext();
+
+      await waitForInit();
+
+      // Canonical gone; the pool member survives.
+      expect(availableDomains.value).toEqual(['acme.example.com', 'short.example.com']);
+      expect(availableDomains.value).not.toContain('onetimesecret.com');
+
+      // And it is genuinely unselectable, not merely hidden.
+      await setContext('onetimesecret.com');
+      expect(currentContext.value.domain).not.toBe('onetimesecret.com');
+    });
+
+    it('keeps the canonical domain offerable on a link-pool host', async () => {
+      // Discriminates the guard from the `displayDomain !== canonicalDomain`
+      // heuristic it replaced: on a pool host those two also differ, but the
+      // strategy is :canonical and none of the branded-host rules apply.
+      setupBootstrapStore({
+        domains_enabled: true,
+        site_host: 'onetimesecret.com',
+        canonical_domain: 'onetimesecret.com',
+        display_domain: 'short.example.com',
+        domain_strategy: 'canonical',
+        link_domains: ['onetimesecret.com', 'short.example.com'],
+      });
+
+      setMockDomains('org-ext-test-123', []);
+
+      const { useDomainContext } = await import('@/shared/composables/useDomainContext');
+      const { availableDomains } = useDomainContext();
+
+      await waitForInit();
+
+      expect(availableDomains.value).toEqual(['onetimesecret.com', 'short.example.com']);
+    });
+
+    // ------------------------------------------------------------------------
+    // Host normalization
+    //
+    // link_domains comes out of the server's PARSED canonical set (lowercased,
+    // port-stripped) while canonical_domain / site_host are the configured
+    // strings verbatim -- and site.host legally carries a port. Comparing the
+    // two families raw made `linkDomains.includes(canonicalDomain)` fail on
+    // every port-bearing canonical host, which is the single test deciding
+    // whether canonical counts as a pool member at all.
+    // ------------------------------------------------------------------------
+    it('treats a port-bearing canonical host as the pool member it is', async () => {
+      setupBootstrapStore({
+        domains_enabled: true,
+        site_host: 'onetimesecret.com:3000',
+        canonical_domain: 'onetimesecret.com:3000',
+        display_domain: 'onetimesecret.com:3000',
+        link_domains: ['onetimesecret.com', 'short.example.com'],
+      });
+
+      setMockDomains('org-ext-test-123', []);
+
+      const { useDomainContext } = await import('@/shared/composables/useDomainContext');
+      const { currentContext, availableDomains } = useDomainContext();
+
+      await waitForInit();
+
+      expect(availableDomains.value).toEqual(['onetimesecret.com', 'short.example.com']);
+      // Canonical is preferred (it IS a member) and reports itself as such.
+      expect(currentContext.value.domain).toBe('onetimesecret.com');
+      expect(currentContext.value.isCanonical).toBe(true);
+    });
+
+    it('accepts a raw host in setContext and normalizes it', async () => {
+      setupBootstrapStore({
+        domains_enabled: true,
+        site_host: 'onetimesecret.com',
+        canonical_domain: 'onetimesecret.com',
+        display_domain: 'onetimesecret.com',
+        link_domains: ['onetimesecret.com', 'short.example.com'],
+      });
+
+      setMockDomains('org-ext-test-123', []);
+
+      const { useDomainContext } = await import('@/shared/composables/useDomainContext');
+      const { currentContext, setContext } = useDomainContext();
+
+      await waitForInit();
+
+      await setContext('Short.Example.COM:8443');
+      expect(currentContext.value.domain).toBe('short.example.com');
     });
   });
 
@@ -1111,16 +1224,20 @@ describe('useDomainContext', () => {
       await waitForInit();
 
       // Start with custom domain
-      setContext('acme.example.com');
+      await setContext('acme.example.com');
       expect(currentContext.value.domain).toBe('acme.example.com');
 
       // Reset
-      resetContext();
+      await resetContext();
       expect(currentContext.value.domain).toBe('onetimesecret.com');
       expect(currentContext.value.isCanonical).toBe(true);
     });
 
-    it('removes domainContext from sessionStorage', async () => {
+    // The reset writes the default through BOTH halves of the preference
+    // rather than clearing the local half. `sess['domain_context']` has no
+    // clear endpoint, so a local-only reset left the server still naming the
+    // old selection and selectBestDomain restored it on the next load.
+    it('replaces domainContext in sessionStorage with the default domain', async () => {
       setupBootstrapStore({
         domains_enabled: true,
         site_host: 'onetimesecret.com',
@@ -1135,10 +1252,37 @@ describe('useDomainContext', () => {
 
       await waitForInit();
 
-      setContext('acme.example.com');
+      await setContext('acme.example.com');
       expect(mockSessionStorage.getItem('domainContext')).toBe('acme.example.com');
 
-      resetContext();
+      await resetContext();
+      expect(mockSessionStorage.getItem('domainContext')).toBe('onetimesecret.com');
+    });
+
+    it('clears domainContext when there is no offerable pool to reset to', async () => {
+      // On a branded host with no LINK_DOMAINS configured, the pool is
+      // canonical-only and canonical is dropped -- so the reset has nothing to
+      // select and '' is the honest answer (the server then anchors on
+      // whichever host served the page).
+      setupBootstrapStore({
+        domains_enabled: true,
+        site_host: 'onetimesecret.com',
+        display_domain: 'acme.example.com',
+        domain_strategy: 'custom',
+        custom_domains: ['acme.example.com'],
+      });
+
+      setMockDomains('org-ext-test-123', ['acme.example.com']);
+
+      const { useDomainContext } = await import('@/shared/composables/useDomainContext');
+      const { setContext, resetContext } = useDomainContext();
+
+      await waitForInit();
+
+      await setContext('acme.example.com');
+      expect(mockSessionStorage.getItem('domainContext')).toBe('acme.example.com');
+
+      await resetContext();
       expect(mockSessionStorage.getItem('domainContext')).toBeNull();
     });
   });
@@ -1743,7 +1887,13 @@ describe('useDomainContext', () => {
       expect(mockSessionStorage.getItem('domainContext')).toBe('acme.example.com');
     });
 
-    it('selecting canonical domain should NOT trigger backend sync POST', async () => {
+    // Selecting canonical persists like any other pool member. It used to be
+    // carved out on the reasoning that "absent sessionStorage IS canonical",
+    // which held only while nothing else remembered a selection --
+    // `sess['domain_context']` does, outlives sessionStorage, and has no clear
+    // endpoint. selectBestDomain reads the server half first, so the carve-out
+    // made switching back to canonical revert on the next reload.
+    it('selecting canonical domain syncs to the backend', async () => {
       setupBootstrapStore({
         domains_enabled: true,
         site_host: 'onetimesecret.com',
@@ -1762,11 +1912,13 @@ describe('useDomainContext', () => {
 
       await setContext('onetimesecret.com');
 
-      // No POST should have been made for canonical domain
-      expect(mockApiPost).not.toHaveBeenCalled();
+      expect(mockApiPost).toHaveBeenCalledWith(
+        '/api/account/update-domain-context',
+        { domain: 'onetimesecret.com' }
+      );
     });
 
-    it('selecting canonical domain should clear sessionStorage domainContext', async () => {
+    it('selecting canonical domain overwrites a stale sessionStorage domainContext', async () => {
       mockSessionStorage.setItem('domainContext', 'acme.example.com');
 
       setupBootstrapStore({
@@ -1784,8 +1936,39 @@ describe('useDomainContext', () => {
 
       await setContext('onetimesecret.com');
 
-      // Canonical is the default state -- session storage should be cleared
-      expect(mockSessionStorage.getItem('domainContext')).toBeNull();
+      expect(mockSessionStorage.getItem('domainContext')).toBe('onetimesecret.com');
+    });
+
+    // Regression, the bug the carve-out caused: a stale server-side
+    // domain_context must not survive an explicit switch back to canonical.
+    it('switching back to canonical survives a reload driven by the server context', async () => {
+      setupBootstrapStore({
+        domains_enabled: true,
+        site_host: 'onetimesecret.com',
+        display_domain: 'onetimesecret.com',
+        domain_context: 'acme.example.com',
+        custom_domains: ['acme.example.com'],
+      });
+
+      setMockDomains('org-ext-test-123', ['acme.example.com']);
+
+      const { useDomainContext } = await importWithMockApi();
+      const { setContext, currentContext } = useDomainContext();
+
+      await waitForInit();
+
+      // The server preference wins on load...
+      expect(currentContext.value.domain).toBe('acme.example.com');
+
+      await setContext('onetimesecret.com');
+
+      // ...and the switch back must be written through to the server, not just
+      // dropped locally, or the next load restores 'acme.example.com'.
+      expect(mockApiPost).toHaveBeenCalledWith(
+        '/api/account/update-domain-context',
+        { domain: 'onetimesecret.com' }
+      );
+      expect(mockSessionStorage.getItem('domainContext')).toBe('onetimesecret.com');
     });
 
     it('selecting canonical domain updates currentContext correctly', async () => {

--- a/src/tests/composables/useDomainContext.spec.ts
+++ b/src/tests/composables/useDomainContext.spec.ts
@@ -749,6 +749,35 @@ describe('useDomainContext', () => {
       expect(currentContext.value.extid).toBe('cd_acme_example_com');
     });
 
+    it('prefers a registered custom domain that is ALSO a pool entry', async () => {
+      // Overlap case: ConfigureDomains warns but does not prevent an operator
+      // from listing a host that is a registered CustomDomain, so both sets can
+      // name the same host. getPreferredDomain's predicate ("not a pool entry")
+      // then matches nothing and the tail takes over -- which is still correct,
+      // because buildAvailableDomains puts the org's own domains ahead of every
+      // pool entry, so `available[0]` IS the customer's domain. The pool entry
+      // cannot win here regardless of the pool's own order.
+      setupBootstrapStore({
+        domains_enabled: true,
+        site_host: INTERNAL_HOST,
+        canonical_domain: INTERNAL_HOST,
+        display_domain: INTERNAL_HOST,
+        custom_domains: ['brand.example.com'],
+        link_domains: ['go.example.com', 'brand.example.com'],
+      });
+
+      setMockDomains('org-ext-test-123', ['brand.example.com']);
+
+      const { useDomainContext } = await import('@/shared/composables/useDomainContext');
+      const { currentContext, availableDomains } = useDomainContext();
+
+      await waitForInit();
+
+      expect(availableDomains.value).toEqual(['brand.example.com', 'go.example.com']);
+      expect(currentContext.value.domain).toBe('brand.example.com');
+      expect(currentContext.value.extid).toBe('cd_brand_example_com');
+    });
+
     it('prefers the canonical entry over a sibling pool entry when no custom domains exist', async () => {
       // The discriminating case for "is this a real custom domain?": the old
       // test was `d !== canonicalDomain`, which picks the SECOND pool entry

--- a/try/integration/middleware/domain_strategy/domain_context_override_try.rb
+++ b/try/integration/middleware/domain_strategy/domain_context_override_try.rb
@@ -84,11 +84,17 @@ middleware.detect_domain_override(env)
 #=> nil
 
 ## detect_domain_override returns env var when set
+# The `result` binding is load-bearing: ENV.delete has to run before the
+# block ends (it is this case's own cleanup), and a tryouts block asserts on
+# its LAST expression. Without the binding the assertion runs against
+# ENV.delete's return value — the deleted string — which can never match the
+# expected tuple. Same for the two cases below.
 middleware            = create_middleware_with_override_enabled
 ENV['DOMAIN_CONTEXT'] = 'secrets.acme.com'
 env                   = {}
-middleware.detect_domain_override(env)
+result                = middleware.detect_domain_override(env)
 ENV.delete('DOMAIN_CONTEXT')
+result
 #=> ['secrets.acme.com', :env_var]
 
 ## detect_domain_override returns header when set
@@ -101,16 +107,18 @@ middleware.detect_domain_override(env)
 middleware            = create_middleware_with_override_enabled
 ENV['DOMAIN_CONTEXT'] = 'env-domain.com'
 env                   = { 'HTTP_O_DOMAIN_CONTEXT' => 'header-domain.com' }
-middleware.detect_domain_override(env)
+result                = middleware.detect_domain_override(env)
 ENV.delete('DOMAIN_CONTEXT')
+result
 #=> ['env-domain.com', :env_var]
 
 ## detect_domain_override ignores empty env var
 middleware            = create_middleware_with_override_enabled
 ENV['DOMAIN_CONTEXT'] = ''
 env                   = { 'HTTP_O_DOMAIN_CONTEXT' => 'header-domain.com' }
-middleware.detect_domain_override(env)
+result                = middleware.detect_domain_override(env)
 ENV.delete('DOMAIN_CONTEXT')
+result
 #=> ['header-domain.com', :header]
 
 ## detect_domain_override returns nil tuple when no override found

--- a/try/integration/middleware/domain_strategy/multiple_canonical_try.rb
+++ b/try/integration/middleware/domain_strategy/multiple_canonical_try.rb
@@ -301,6 +301,100 @@ config                  = { 'enabled' => true, 'default' => @default_host, 'link
  )]
 #=> [false, nil]
 
+# T17: the `www.` variant tolerance is ANCHOR-only
+#
+# equal_to? matches a host against `www.<registrable-domain>` as well as
+# against its own name. Run over the FULL canonical set that second arm
+# reaches straight past the pool member the operator blessed and onto any
+# `www.` sibling on the same base domain -- the same widening the
+# anchor-only sweeps exist to prevent, arriving through the exact-match
+# arm instead. Worse than the sweep case: this arm runs BEFORE
+# known_custom_domain?, so it takes the classification away from a tenant
+# who registered that host, silently dropping their brand/signin config.
+#
+# The fix splits the arm: exact_host? over the full set (pool included),
+# equal_to? over the anchors only.
+
+## T17: `www.` of a POOL member's base domain is not :canonical
+@strategy_class.reset!
+OT.conf['site']['host'] = @site_host
+config                  = { 'enabled' => true, 'default' => @default_host, 'link_domains' => [@pool_host] }
+@strategy_class.initialize_from_config(config)
+@chooser.choose_strategy(
+  'www.acme.com',
+  @strategy_class.canonical_domains_parsed,
+  anchor_domains: @strategy_class.anchor_domains_parsed,
+)
+#=> nil
+
+## T17: and a tenant who REGISTERED that host keeps :custom
+# This is the consequence that matters. Under the old arm the www variant
+# classified :canonical ahead of the registration lookup, so the tenant's
+# per-domain configuration silently never applied.
+Onetime::CustomDomain.singleton_class.send(:alias_method, :www_orig_from_display_domain, :from_display_domain)
+Onetime::CustomDomain.define_singleton_method(:from_display_domain) do |domain|
+  domain == 'www.acme.com' ? Object.new : nil
+end
+result = @chooser.choose_strategy(
+  'www.acme.com',
+  @strategy_class.canonical_domains_parsed,
+  anchor_domains: @strategy_class.anchor_domains_parsed,
+)
+Onetime::CustomDomain.singleton_class.send(:alias_method, :from_display_domain, :www_orig_from_display_domain)
+Onetime::CustomDomain.singleton_class.send(:remove_method, :www_orig_from_display_domain)
+result
+#=> :custom
+
+## T17 control: `www.` of an ANCHOR host is still :canonical
+# The tolerance itself is untouched -- it just no longer reaches the pool.
+@chooser.choose_strategy(
+  "www.#{@site_host}",
+  @strategy_class.canonical_domains_parsed,
+  anchor_domains: @strategy_class.anchor_domains_parsed,
+)
+#=> :canonical
+
+## T17 control: `www.` of the OTHER anchor is :canonical too
+@chooser.choose_strategy(
+  "www.#{@default_host}",
+  @strategy_class.canonical_domains_parsed,
+  anchor_domains: @strategy_class.anchor_domains_parsed,
+)
+#=> :canonical
+
+## T17: `www.` of the pool member itself gets nothing either
+# The operator blessed go.acme.com. www.go.acme.com is a different host.
+@chooser.choose_strategy(
+  "www.#{@pool_host}",
+  @strategy_class.canonical_domains_parsed,
+  anchor_domains: @strategy_class.anchor_domains_parsed,
+)
+#=> nil
+
+## T17 fence: with no pool the two sets are equal and nothing changes
+# anchor_domains defaults to the canonical set, so a caller with no pool
+# (every pre-#4063 call site) sees the exact pre-#4063 answers.
+@strategy_class.reset!
+OT.conf['site']['host'] = @site_host
+@strategy_class.initialize_from_config({ 'enabled' => true, 'default' => @default_host })
+[@chooser.choose_strategy("www.#{@site_host}", @strategy_class.canonical_domains_parsed),
+ @chooser.choose_strategy("www.#{@default_host}", @strategy_class.canonical_domains_parsed)]
+#=> [:canonical, :canonical]
+
+## T17 wiring: the middleware call path rejects the pool-adjacent www host
+# Guards the real request path, not just Chooserator.
+middleware                                           = @strategy_class.new(create_app)
+@strategy_class.reset!
+OT.conf['site']['host']                              = @site_host
+@strategy_class.initialize_from_config(
+  { 'enabled' => true, 'default' => @default_host, 'link_domains' => [@pool_host] },
+)
+@strategy_class.class_eval { @domain_context_enabled = false }
+env                                                  = { Rack::DetectHost.result_field_name => 'www.acme.com' }
+with_runtime_domains { middleware.call(env) }
+env['onetime.domain_strategy']
+#=> :invalid
+
 # T16: exact-match set vs. sweep set
 #
 # Two sets come out of initialize_from_config. canonical_domains_parsed is
@@ -466,13 +560,14 @@ Onetime::CustomDomain.singleton_class.send(:alias_method, :sibling_orig_from_dis
 Onetime::CustomDomain.define_singleton_method(:from_display_domain) do |domain|
   domain == 'sibling.acme.com' ? Object.new : nil
 end
-@chooser.choose_strategy(
+result = @chooser.choose_strategy(
   'sibling.acme.com',
   @strategy_class.canonical_domains_parsed,
   anchor_domains: @strategy_class.anchor_domains_parsed,
 )
 Onetime::CustomDomain.singleton_class.send(:alias_method, :from_display_domain, :sibling_orig_from_display_domain)
 Onetime::CustomDomain.singleton_class.send(:remove_method, :sibling_orig_from_display_domain)
+result
 #=> :custom
 
 ## AC7 control: a fully parseable pool logs no skip line (capture_le is discriminating)

--- a/try/integration/middleware/domain_strategy/response_headers_try.rb
+++ b/try/integration/middleware/domain_strategy/response_headers_try.rb
@@ -161,8 +161,7 @@ enable_domains_fully!
 disable_domain_context!
 env         = { Rack::DetectHost.result_field_name => @canonical_domain }
 _, headers, = middleware.call(env)
-headers['O-Domain-Strategy']
-env['onetime.domain_strategy'].to_s
+headers['O-Domain-Strategy'] == env['onetime.domain_strategy'].to_s
 #=> true
 
 ## O-Display-Domain header matches env['onetime.display_domain'].to_s
@@ -171,8 +170,7 @@ enable_domains_fully!
 disable_domain_context!
 env         = { Rack::DetectHost.result_field_name => @canonical_domain }
 _, headers, = middleware.call(env)
-headers['O-Display-Domain']
-env['onetime.display_domain'].to_s
+headers['O-Display-Domain'] == env['onetime.display_domain'].to_s
 #=> true
 
 ## Header/env consistency holds for subdomain requests
@@ -224,10 +222,11 @@ headers['O-Display-Domain']
 # -- Response status is passed through --
 
 ## Middleware does not alter the status code from the inner app
-middleware = @strategy_class.new(create_app)
+middleware  = @strategy_class.new(create_app)
 disable_runtime_domains!
-env        = {}
-middleware.call(env)
+env         = {}
+status,     = middleware.call(env)
+status
 #=> 200
 
 # Teardown


### PR DESCRIPTION
## Summary

[#4063](https://github.com/onetimesecret/onetimesecret/issues/4063)

Follow-up to a code review of `feature/4063-link-domains-pool`. Seven review findings, plus seven tests the branch had broken.

### Classification — `www.` tolerance is now anchor-only

The exact-match arm ran `equal_to?` over the **full** canonical set, and that predicate also accepts `www.<registrable-domain>`. With `LINK_DOMAINS=go.acme.com`, an unrelated `www.acme.com` therefore classified `:canonical` **ahead of** the `known_custom_domain?` lookup, silently dropping that tenant's brand/signin config — the same widening the anchor-only sweeps exist to prevent, arriving through a different arm.

Split into `exact_host?` over the full set (pool included) plus `equal_to?` over the anchors only. The two sets are equal for any caller with no pool, so pre-#4063 behavior is byte-identical.

### Admission — one authority instead of a raw config read

`link_pool_host?` in both API versions read `features.domains.link_domains` straight out of config, skipping the `features.domains.enabled` gate and the parsed-host filter the middleware applies. A pool configured with domains off — or holding an unparseable entry — let guests anchor secrets on hosts the middleware classifies `:invalid` and the picker never offers.

Both now delegate to a new `Middleware::DomainStrategy.link_pool_host?`, so admission and classification answer from the same set.

### Boot — no fallback for an unusable pool

`resolve_link_domains` fell back to `[canonical_domain]` when no configured entry resolved, re-exposing the internal platform host in the picker — precisely the outcome the feature exists to prevent. There is no safe fallback for that state (offering canonical contradicts the request; offering nothing empties the picker), so `validate_link_domains!` now fails boot when a set pool names no parseable host, echoing the entries so the typo is visible. A list mixing good and bad entries still boots; the bad one is dropped and logged.

### Picker

- The canonical domain is no longer offered while browsing a tenant-branded host, where selecting it was ignored end-to-end (`process_share_domain` nils anchor hosts, `determine_share_domain` returns `display_domain`) and the link anchored on the branded host anyway. Pool members stay — v2 honors an authenticated user's explicit pool selection there.
- Selecting the canonical domain now writes through to the server. Clearing only `sessionStorage` left `sess['domain_context']` naming the previous selection, and `selectBestDomain` reads the server half first — so the next reload silently reverted the switch. `resetContext` goes through the same path, which removes the need for a clear endpoint.
- Host comparisons are normalized on both sides (new `src/shared/utils/domain-host.ts`). `link_domains` arrives normalized from the server's parsed canonical set while `canonical_domain`/`site_host` are the configured strings verbatim, so a canonical host configured with a port was never recognized as a member of its own link pool.

### Tests fixed along the way

A formatting pass on this branch had broken six of its own tryouts, none of which could pass:

- `response_headers_try.rb` — `a == b` split across two lines in two header/env consistency cases; the `status` binding dropped in the status-passthrough case.
- `domain_context_override_try.rb` — the `result =` capture deleted in three cases, leaving `ENV.delete`'s return value as the assertion subject.

Plus one pre-existing case in `multiple_canonical_try.rb` ending on `remove_method`.

### One finding that did not reproduce

The review's fifth finding — `UpdateDomainContext` persisting `'EXAMPLE.COM:443'` verbatim — does not reproduce. `normalize_domain` downcases and `DOMAIN_CHAR_PATTERN` rejects any `:`, so the input is refused outright. The real port defect was its mirror image on the frontend, covered by the normalization change above.

## Related Issues

Refs #4063

## Test Plan

Ruby 3.4.9 (3.4.10 is not available in this environment), Redis on the lane port; RabbitMQ stubbed with a TCP listener.

- `tests/lanes/run unit` — green across every suite (3480 unit + ~4700 app/CLI examples, 0 failures)
- `rake try:unit` — 7474 testcases, 0 failed, 355 files
- `rake try:integration:simple` — 1141 testcases, 0 failed, 69 files
- `vitest run` (full suite) — 8496 passed, 0 failures, 382 files
- `rubocop` — clean on the three linted files among the changes (`try/`, `spec/`, `apps/**/spec/`, and `apps/api/v1/**` are excluded by `.rubocop.yml`)
- `eslint` + `vue-tsc --noEmit` — clean

`spec:integration:simple` reports 5 failures, all in `spec/integration/all/puma_rabbitmq_fork_spec.rb`, which needs a real RabbitMQ rather than the stub listener — unrelated to these changes.

New coverage added with the fixes:

- `multiple_canonical_try.rb` — T17 block: `www.` of a pool member's base domain is not `:canonical`; a tenant who registered it keeps `:custom`; `www.` of either anchor still `:canonical`; the no-pool fence; and the middleware `call` path.
- `link_domains_spec.rb` — unparseable-pool boot error, partial-failure tolerance, port-bearing entries, and the `raise_concerns` wiring.
- v1/v2 `base_secret_action_spec.rb` — pool admission with the domains feature off, and with an entry that does not parse. The `with_link_domains` helper now drives the real chain (`OT.conf` → `initialize_from_config` → `link_pool_host?`) rather than a config-only read.
- `useDomainContext.spec.ts` — the branded-host guard and its link-pool-host control, port-bearing canonical membership, raw-host `setContext`, and the stale-server-context regression.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KW2hRJ3WdJDRyRtYXoTaLt)_