### PR TITLE
i18n: update ar translations

### DIFF
--- a/locales/content/ar/00-common.json
+++ b/locales/content/ar/00-common.json
@@ -1539,5 +1539,9 @@
   "web.TITLES.domain_dns": {
     "text": "إعداد DNS",
     "source_hash": "6c63df31"
+  },
+  "web.TITLES.connected_identities": {
+    "text": "الهويات المرتبطة",
+    "source_hash": "e132c4d9"
   }
 }

--- a/locales/content/ar/admin-audit.json
+++ b/locales/content/ar/admin-audit.json
@@ -98,5 +98,41 @@
   "web.admin.audit.result.failure": {
     "text": "فشل",
     "source_hash": "7031edbc"
+  },
+  "web.admin.audit.categories.secret": {
+    "text": "الأسرار",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.audit.categories.membership": {
+    "text": "العضويات",
+    "source_hash": "b50f1a42"
+  },
+  "web.admin.audit.categories.entitlement_preview": {
+    "text": "معاينات الاستحقاقات",
+    "source_hash": "255c5797"
+  },
+  "web.admin.audit.categories.colonel": {
+    "text": "تسجيلات دخول Colonel",
+    "source_hash": "01eeeb38"
+  },
+  "web.admin.audit.filters.actorLabel": {
+    "text": "الفاعل",
+    "source_hash": "449995c4"
+  },
+  "web.admin.audit.filters.searchButton": {
+    "text": "بحث",
+    "source_hash": "49c266ba"
+  },
+  "web.admin.audit.filters.searchHint": {
+    "text": "اكتب اسم الفاعل، ثم اضغط Enter أو اختر بحث لتنفيذه. لا تتحدث القائمة أثناء الكتابة.",
+    "source_hash": "45eceb12"
+  },
+  "web.admin.audit.filters.pendingSearch": {
+    "text": "لم يتم البحث بعد — اضغط Enter أو اختر بحث لتطبيق هذا الفاعل.",
+    "source_hash": "f76095c2"
+  },
+  "web.admin.audit.list.contractError": {
+    "text": "استجاب الخادم، لكن بيانات التدقيق لم تتطابق مع التنسيق المتوقع. لا يمكن عرض الأحداث — هذا خطأ في التقارير وليس سجلاً فارغاً.",
+    "source_hash": "7f48137e"
   }
 }

--- a/locales/content/ar/admin-billing.json
+++ b/locales/content/ar/admin-billing.json
@@ -122,5 +122,85 @@
   "web.admin.billing.status.changed": {
     "text": "تم التغيير",
     "source_hash": "2a6141e4"
+  },
+  "web.admin.billing.diff.backToCatalog": {
+    "text": "العودة إلى كتالوج الفوترة",
+    "source_hash": "8532b373"
+  },
+  "web.admin.billing.diff.driftedFields": {
+    "text": "الحقول المختلفة:",
+    "source_hash": "9890c95b"
+  },
+  "web.admin.billing.diff.notFound": {
+    "text": "الخطة غير موجودة في الكتالوج",
+    "source_hash": "0253898b"
+  },
+  "web.admin.billing.diff.notFoundDescription": {
+    "text": "لم يتم العثور على خطة بالمعرف {planid} في الكتالوج المكون أو ذاكرة التخزين المؤقت المتزامنة مع Stripe.",
+    "source_hash": "2e69551c"
+  },
+  "web.admin.billing.stripeOrgs.title": {
+    "text": "عملاء Stripe",
+    "source_hash": "0463ae27"
+  },
+  "web.admin.billing.stripeOrgs.description": {
+    "text": "المؤسسات المرتبطة بسجل عميل Stripe.",
+    "source_hash": "2ab09aec"
+  },
+  "web.admin.billing.stripeOrgs.searchPlaceholder": {
+    "text": "البحث بمعرف عميل Stripe",
+    "source_hash": "d5acf08f"
+  },
+  "web.admin.billing.stripeOrgs.empty": {
+    "text": "لا توجد مؤسسات لديها معرف عميل Stripe.",
+    "source_hash": "2e373537"
+  },
+  "web.admin.billing.stripeOrgs.emptySearch": {
+    "text": "لا يوجد معرف عميل Stripe يطابق هذا البحث.",
+    "source_hash": "75011174"
+  },
+  "web.admin.billing.stripeOrgs.loadError": {
+    "text": "تعذر تحميل قائمة عملاء Stripe.",
+    "source_hash": "15e2d9a7"
+  },
+  "web.admin.billing.stripeOrgs.unavailable": {
+    "text": "قائمة عملاء Stripe غير متاحة على هذا الخادم بعد.",
+    "source_hash": "aab6451a"
+  },
+  "web.admin.billing.stripeOrgs.none": {
+    "text": "لا يوجد",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.billing.stripeOrgs.capped": {
+    "text": "وصل مسح الفهرس إلى حده الأقصى، لذا العدد الإجمالي هو الحد الأدنى — قم بتضييق البحث لرؤية البقية.",
+    "source_hash": "20bcaa38"
+  },
+  "web.admin.billing.stripeOrgs.stale": {
+    "text": "{count} إدخال فهرس في هذه الصفحة يشير إلى مؤسسة لم تعد تحمل وتم تخطيه.",
+    "source_hash": "51980f83"
+  },
+  "web.admin.billing.stripeOrgs.copyStripeId": {
+    "text": "نسخ معرف عميل Stripe",
+    "source_hash": "a77d18b1"
+  },
+  "web.admin.billing.stripeOrgs.columns.organization": {
+    "text": "المؤسسة",
+    "source_hash": "d764d425"
+  },
+  "web.admin.billing.stripeOrgs.columns.owner": {
+    "text": "المالك",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.billing.stripeOrgs.columns.plan": {
+    "text": "الخطة",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.billing.stripeOrgs.columns.subscription": {
+    "text": "الاشتراك",
+    "source_hash": "4999c6c6"
+  },
+  "web.admin.billing.stripeOrgs.columns.stripeCustomer": {
+    "text": "معرف عميل Stripe",
+    "source_hash": "7e1d8bbb"
   }
 }

--- a/locales/content/ar/admin-colonel.json
+++ b/locales/content/ar/admin-colonel.json
@@ -838,5 +838,37 @@
   "web.colonel.nav.groups.communications": {
     "text": "الاتصالات",
     "source_hash": "919a9253"
+  },
+  "web.colonel.organizations.sameAsContact": {
+    "text": "نفس جهة الاتصال",
+    "source_hash": "ed18ff43"
+  },
+  "web.colonel.organizations.refresh": {
+    "text": "تحديث",
+    "source_hash": "0e916101"
+  },
+  "web.colonel.organizations.updatedAgo": {
+    "text": "تم التحديث {ago}",
+    "source_hash": "cda30b9c"
+  },
+  "web.colonel.organizations.columns.name": {
+    "text": "الاسم",
+    "source_hash": "dcd1d522"
+  },
+  "web.colonel.organizations.columns.contactEmail": {
+    "text": "البريد الإلكتروني للتواصل",
+    "source_hash": "6d7fce11"
+  },
+  "web.colonel.organizations.columns.billingEmail": {
+    "text": "البريد الإلكتروني للفوترة",
+    "source_hash": "8805b928"
+  },
+  "web.colonel.organizations.columns.planSubscription": {
+    "text": "الخطة والاشتراك",
+    "source_hash": "b396caac"
+  },
+  "web.colonel.organizations.filters.searchPlaceholder": {
+    "text": "البحث بالمعرف أو الاسم أو البريد الإلكتروني",
+    "source_hash": "6fe16473"
   }
 }

--- a/locales/content/ar/admin-customers.json
+++ b/locales/content/ar/admin-customers.json
@@ -4,8 +4,8 @@
     "source_hash": "aabe76f1"
   },
   "web.admin.customers.description": {
-    "text": "ابحث عن عميل وحلّ مشكلات الدعم دون الحاجة إلى SSH.",
-    "source_hash": "c8487e68"
+    "text": "ابحث عن عميل وحل مشكلات الدعم.",
+    "source_hash": "00961ea3"
   },
   "web.admin.customers.actions.plan.label": {
     "text": "الخطة",
@@ -482,5 +482,213 @@
   "web.admin.customers.suspended.badge": {
     "text": "معلّق",
     "source_hash": "e392a389"
+  },
+  "web.admin.customers.actions.checkoutLink.button": {
+    "text": "إنشاء رابط الدفع",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.modalTitle": {
+    "text": "إنشاء رابط الدفع",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.planLabel": {
+    "text": "الخطة",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.actions.checkoutLink.planPlaceholder": {
+    "text": "معرف عائلة الخطة (مثل identity_plus_v1)",
+    "source_hash": "12eba027"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleLabel": {
+    "text": "دورة الفوترة",
+    "source_hash": "d69f731e"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleMonthly": {
+    "text": "شهري",
+    "source_hash": "9b11f6b7"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleYearly": {
+    "text": "سنوي",
+    "source_hash": "6e69b59e"
+  },
+  "web.admin.customers.actions.checkoutLink.allowPromo": {
+    "text": "السماح برموز الترويج",
+    "source_hash": "ebe7bc8b"
+  },
+  "web.admin.customers.actions.checkoutLink.submit": {
+    "text": "إنشاء الرابط",
+    "source_hash": "e6b850cf"
+  },
+  "web.admin.customers.actions.checkoutLink.resultLead": {
+    "text": "تم إنشاء رابط الدفع. شاركه مع العميل — يمكن استخدامه مرة واحدة وله تاريخ انتهاء.",
+    "source_hash": "6ff1fb0e"
+  },
+  "web.admin.customers.actions.checkoutLink.copy": {
+    "text": "نسخ رابط الدفع",
+    "source_hash": "f1e51ca7"
+  },
+  "web.admin.customers.actions.checkoutLink.expiry": {
+    "text": "ينتهي خلال ~{hours} ساعة ({date}).",
+    "source_hash": "4c878a15"
+  },
+  "web.admin.customers.actions.checkoutLink.regionLabel": {
+    "text": "المنطقة",
+    "source_hash": "d3a008ef"
+  },
+  "web.admin.customers.actions.checkoutLink.parseError": {
+    "text": "قبل الخادم الطلب لكنه أعاد استجابة غير قابلة للقراءة، لذا لا يمكن عرض الرابط. تحقق من Stripe قبل إعادة المحاولة.",
+    "source_hash": "e7e08290"
+  },
+  "web.admin.customers.actions.checkoutLink.done": {
+    "text": "تم",
+    "source_hash": "11a6767d"
+  },
+  "web.admin.customers.actions.purge.typePrompt": {
+    "text": "للتأكيد، اكتب عنوان البريد الإلكتروني للحساب {token} أدناه",
+    "source_hash": "8b2a1819"
+  },
+  "web.admin.customers.actions.purge.unavailable": {
+    "text": "الحذف النهائي غير متاح: هذا الحساب ليس لديه عنوان بريد إلكتروني لإعادة كتابته للتأكيد.",
+    "source_hash": "5f20f7e5"
+  },
+  "web.admin.customers.columns.actions": {
+    "text": "الإجراءات",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.diagnostics.title": {
+    "text": "تشخيصات الحساب",
+    "source_hash": "5574ece8"
+  },
+  "web.admin.customers.detail.diagnostics.loading": {
+    "text": "جارٍ التشخيص…",
+    "source_hash": "062c83d5"
+  },
+  "web.admin.customers.detail.diagnostics.loadError": {
+    "text": "تعذر تحميل التشخيصات.",
+    "source_hash": "69e69f49"
+  },
+  "web.admin.customers.detail.diagnostics.healthy": {
+    "text": "لم يتم العثور على حالة حظر. حالة المصادقة تبدو سليمة — تحقق من مشكلات جانب العميل (ملفات تعريف الارتباط، إعدادات تسجيل الدخول للنطاق المخصص) أو المنطقة الخاطئة.",
+    "source_hash": "f6d5f8d1"
+  },
+  "web.admin.customers.detail.diagnostics.authUnavailable": {
+    "text": "قاعدة بيانات المصادقة غير متاحة (وضع المصادقة البسيط) — تم تخطي فحوصات SQL.",
+    "source_hash": "d668907c"
+  },
+  "web.admin.customers.detail.diagnostics.authFailed": {
+    "text": "لم تستجب قاعدة بيانات المصادقة، لذا تعذر تشغيل فحوصات SQL: {reason}",
+    "source_hash": "46d047c0"
+  },
+  "web.admin.customers.detail.diagnostics.unknown": {
+    "text": "غير معروف",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.title": {
+    "text": "سجل المصادقة",
+    "source_hash": "48ad8ba8"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.empty": {
+    "text": "لم يتم تسجيل أي أحداث مصادقة.",
+    "source_hash": "d2332558"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.unavailable": {
+    "text": "تعذرت قراءة سجل المصادقة: {reason}",
+    "source_hash": "ab18af57"
+  },
+  "web.admin.customers.detail.diagnostics.facts.authStatus": {
+    "text": "حالة المصادقة",
+    "source_hash": "34def169"
+  },
+  "web.admin.customers.detail.diagnostics.facts.noAccount": {
+    "text": "لا يوجد حساب مصادقة",
+    "source_hash": "a9968e9e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.password": {
+    "text": "كلمة المرور",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordSet": {
+    "text": "تم التعيين",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordNone": {
+    "text": "لا يوجد",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfa": {
+    "text": "MFA",
+    "source_hash": "d39ce053"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfaNone": {
+    "text": "لا يوجد",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.loginFailures": {
+    "text": "محاولات فاشلة",
+    "source_hash": "63e7f0a8"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lockedBadge": {
+    "text": "مغلق",
+    "source_hash": "ace29f74"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiter": {
+    "text": "محدد المعدل",
+    "source_hash": "32892404"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterEngaged": {
+    "text": "مفعّل",
+    "source_hash": "1b0d851e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterClear": {
+    "text": "واضح",
+    "source_hash": "83b12c22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verification": {
+    "text": "بريد التحقق",
+    "source_hash": "23fac8fb"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationPending": {
+    "text": "قيد الانتظار — آخر إرسال {date}",
+    "source_hash": "9ab8d1b6"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationNone": {
+    "text": "لا يوجد قيد الانتظار",
+    "source_hash": "a4d4cc22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.sessions": {
+    "text": "الجلسات النشطة",
+    "source_hash": "61ad9909"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lastLogin": {
+    "text": "آخر تسجيل دخول (مصادقة)",
+    "source_hash": "373e7fb1"
+  },
+  "web.admin.customers.detail.receipts.partial": {
+    "text": "قائمة جزئية — تعرض أحدث {count}. هذا العميل لديه إيصالات أكثر مما هو معروض هنا.",
+    "source_hash": "127fd4db"
+  },
+  "web.admin.customers.detail.secrets.partial": {
+    "text": "قائمة جزئية — تعرض أحدث {count}. هذا العميل يملك أسراراً أكثر مما هو معروض هنا.",
+    "source_hash": "a537c8f3"
+  },
+  "web.admin.customers.detail.sessions.columns.country": {
+    "text": "البلد",
+    "source_hash": "701d021d"
+  },
+  "web.admin.customers.detail.sessions.current.badge": {
+    "text": "هذه الجلسة",
+    "source_hash": "6da6530a"
+  },
+  "web.admin.customers.detail.sessions.current.tooltip": {
+    "text": "جلسة المشرف الحالية. إلغاؤها هنا ليس له تأثير — يتم إعادة إنشائها لبقية هذا الطلب.",
+    "source_hash": "ef097ab1"
+  },
+  "web.admin.customers.verification.verified": {
+    "text": "تم التحقق",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.verification.unverified": {
+    "text": "لم يتم التحقق",
+    "source_hash": "15133907"
   }
 }

--- a/locales/content/ar/admin-domains.json
+++ b/locales/content/ar/admin-domains.json
@@ -190,5 +190,657 @@
   "web.admin.domains.verify.success.done": {
     "text": "اكتمل التحقق من {domain}.",
     "source_hash": "ed67e22d"
+  },
+  "web.admin.domains.actions.preview": {
+    "text": "معاينة",
+    "source_hash": "324b134f"
+  },
+  "web.admin.domains.actions.probe.button": {
+    "text": "فحص",
+    "source_hash": "3bd51ab9"
+  },
+  "web.admin.domains.actions.remove.button": {
+    "text": "إزالة النطاق",
+    "source_hash": "5ce43507"
+  },
+  "web.admin.domains.actions.remove.previewButton": {
+    "text": "معاينة الإزالة",
+    "source_hash": "6b81bd92"
+  },
+  "web.admin.domains.actions.remove.previewStatus": {
+    "text": "الحالة:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.remove.previewOrg": {
+    "text": "المؤسسة:",
+    "source_hash": "5300e286"
+  },
+  "web.admin.domains.actions.remove.reassertsSurvivor": {
+    "text": "سجل آخر يطالب بنفس اسم النطاق وسيتولى فهرس البحث.",
+    "source_hash": "902838f4"
+  },
+  "web.admin.domains.actions.remove.confirmTitle": {
+    "text": "إزالة النطاق؟",
+    "source_hash": "716dfac9"
+  },
+  "web.admin.domains.actions.remove.confirmDescription": {
+    "text": "هذا يحذف {domain} نهائياً مع سجلات العلامة التجارية وDNS والإعدادات. لا يمكن التراجع عن هذا. أعد كتابة المعرف العام للنطاق للمتابعة.",
+    "source_hash": "d0b67b47"
+  },
+  "web.admin.domains.actions.remove.success": {
+    "text": "تمت إزالة النطاق.",
+    "source_hash": "2ccaa6d3"
+  },
+  "web.admin.domains.actions.remove.notApplied": {
+    "text": "عاين الخادم الإزالة بدلاً من تطبيقها — لم تتم إزالة النطاق. أعد المحاولة، وأبلغ عن هذا إذا استمر.",
+    "source_hash": "dc6d70ae"
+  },
+  "web.admin.domains.actions.repair.title": {
+    "text": "إصلاح ارتباط المؤسسة",
+    "source_hash": "82b40352"
+  },
+  "web.admin.domains.actions.repair.description": {
+    "text": "ابحث عن الارتباطات المعطلة بين هذا النطاق ومؤسسته وأصلحها. معاينة أولاً لرؤية ما سيتغير.",
+    "source_hash": "531ed287"
+  },
+  "web.admin.domains.actions.repair.orgIdLabel": {
+    "text": "معرف المؤسسة (للنطاقات اليتيمة فقط)",
+    "source_hash": "0d3010eb"
+  },
+  "web.admin.domains.actions.repair.orgIdPlaceholder": {
+    "text": "اتركه فارغاً إلا إذا لم يكن للنطاق مالك",
+    "source_hash": "118b7132"
+  },
+  "web.admin.domains.actions.repair.statusLabel": {
+    "text": "الحالة:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.repair.noIssues": {
+    "text": "لم يتم العثور على مشاكل — لا شيء للإصلاح.",
+    "source_hash": "17735887"
+  },
+  "web.admin.domains.actions.repair.button": {
+    "text": "تطبيق الإصلاح",
+    "source_hash": "4d0ab2d4"
+  },
+  "web.admin.domains.actions.repair.confirmTitle": {
+    "text": "تطبيق الإصلاح؟",
+    "source_hash": "ef0ffae5"
+  },
+  "web.admin.domains.actions.repair.confirmDescription": {
+    "text": "هذا يعيد كتابة ارتباط المؤسسة لـ {domain}. أعد كتابة المعرف العام للنطاق للمتابعة.",
+    "source_hash": "a9f2702f"
+  },
+  "web.admin.domains.actions.repair.success": {
+    "text": "تم تطبيق الإصلاح.",
+    "source_hash": "850bd784"
+  },
+  "web.admin.domains.actions.transfer.title": {
+    "text": "نقل إلى مؤسسة أخرى",
+    "source_hash": "1b0b0655"
+  },
+  "web.admin.domains.actions.transfer.description": {
+    "text": "انقل هذا النطاق إلى مؤسسة مختلفة. معاينة أولاً لتأكيد جانبي النقل.",
+    "source_hash": "457e852d"
+  },
+  "web.admin.domains.actions.transfer.toOrgLabel": {
+    "text": "معرف المؤسسة الوجهة",
+    "source_hash": "1a3f05c4"
+  },
+  "web.admin.domains.actions.transfer.fromOrgLabel": {
+    "text": "معرف المؤسسة الحالية المتوقع (اختياري)",
+    "source_hash": "f6e75729"
+  },
+  "web.admin.domains.actions.transfer.fromOrgPlaceholder": {
+    "text": "تأكيد المالك الحالي قبل النقل",
+    "source_hash": "1ac6c59b"
+  },
+  "web.admin.domains.actions.transfer.from": {
+    "text": "من",
+    "source_hash": "21819769"
+  },
+  "web.admin.domains.actions.transfer.to": {
+    "text": "إلى",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.domains.actions.transfer.orphaned": {
+    "text": "لا مؤسسة (يتيم)",
+    "source_hash": "6f4c745c"
+  },
+  "web.admin.domains.actions.transfer.button": {
+    "text": "تطبيق النقل",
+    "source_hash": "fb546c5c"
+  },
+  "web.admin.domains.actions.transfer.confirmTitle": {
+    "text": "نقل النطاق؟",
+    "source_hash": "801eb986"
+  },
+  "web.admin.domains.actions.transfer.confirmDescription": {
+    "text": "هذا ينقل {domain} إلى المؤسسة {org}. أعد كتابة المعرف العام للنطاق للمتابعة.",
+    "source_hash": "52c8808d"
+  },
+  "web.admin.domains.actions.transfer.success": {
+    "text": "تم نقل النطاق.",
+    "source_hash": "91e681ae"
+  },
+  "web.admin.domains.columns.domain": {
+    "text": "النطاق",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domains.columns.organization": {
+    "text": "المؤسسة",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.columns.state": {
+    "text": "التحقق",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.domains.columns.tls": {
+    "text": "TLS",
+    "source_hash": "d1c18ec0"
+  },
+  "web.admin.domains.columns.created": {
+    "text": "تاريخ الإنشاء",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.columns.actions": {
+    "text": "الإجراءات",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.configs.title": {
+    "text": "إعدادات النطاق",
+    "source_hash": "d46aa480"
+  },
+  "web.admin.domains.configs.description": {
+    "text": "سجلات الإعدادات لكل نطاق التي تتحكم في تسجيل الدخول والتسجيل وأسرار الصفحة الرئيسية والوصول إلى API والأسرار الواردة وSSO للمستأجر وإرسال البريد. السجل المفقود يفشل مغلقاً للخمسة الأولى.",
+    "source_hash": "1df99789"
+  },
+  "web.admin.domains.configs.loadError": {
+    "text": "تعذر تحميل سجلات إعدادات النطاق.",
+    "source_hash": "9417d718"
+  },
+  "web.admin.domains.configs.retry": {
+    "text": "إعادة المحاولة",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.configs.degraded": {
+    "text": "استجابة الإعدادات لم تتطابق مع العقد المتوقع. قم بالتحديث، وأبلغ عن هذا إذا استمر.",
+    "source_hash": "b5d890c0"
+  },
+  "web.admin.domains.configs.notFoundNote": {
+    "text": "هذا النطاق لم يعد موجوداً، لذا لا يمكن تحميل سجلات إعداداته.",
+    "source_hash": "2d88a392"
+  },
+  "web.admin.domains.configs.detailsToggle": {
+    "text": "التفاصيل",
+    "source_hash": "45989de4"
+  },
+  "web.admin.domains.configs.notEditable": {
+    "text": "تُدار في إعدادات نطاق مساحة العمل.",
+    "source_hash": "54fe891f"
+  },
+  "web.admin.domains.configs.delete.button": {
+    "text": "حذف",
+    "source_hash": "e2d0a549"
+  },
+  "web.admin.domains.configs.delete.confirmTitle": {
+    "text": "حذف إعدادات {kind}؟",
+    "source_hash": "98e672db"
+  },
+  "web.admin.domains.configs.delete.confirmDescription": {
+    "text": "هذا يحذف نهائياً سجل إعدادات {kind} لـ {domain}. يعود النطاق إلى سلوك السجل المفقود. أعد كتابة النوع للمتابعة.",
+    "source_hash": "8272c40c"
+  },
+  "web.admin.domains.configs.delete.success": {
+    "text": "تم حذف الإعدادات.",
+    "source_hash": "a0184b66"
+  },
+  "web.admin.domains.configs.edit.button": {
+    "text": "تعديل",
+    "source_hash": "464c4ffd"
+  },
+  "web.admin.domains.configs.edit.createButton": {
+    "text": "إنشاء",
+    "source_hash": "4759498a"
+  },
+  "web.admin.domains.configs.edit.title": {
+    "text": "إعداد {kind}",
+    "source_hash": "8592148f"
+  },
+  "web.admin.domains.configs.edit.submit": {
+    "text": "حفظ",
+    "source_hash": "1509f561"
+  },
+  "web.admin.domains.configs.edit.success": {
+    "text": "تم حفظ الإعدادات.",
+    "source_hash": "6b5b3c69"
+  },
+  "web.admin.domains.configs.edit.unsetOption": {
+    "text": "غير محدد",
+    "source_hash": "4895f731"
+  },
+  "web.admin.domains.configs.edit.domainsHint": {
+    "text": "نطاق واحد في كل سطر.",
+    "source_hash": "6c03f4f7"
+  },
+  "web.admin.domains.configs.ensure.button": {
+    "text": "إنشاء الإعدادات المفقودة",
+    "source_hash": "77991b75"
+  },
+  "web.admin.domains.configs.ensure.confirmTitle": {
+    "text": "إنشاء سجلات الإعدادات المفقودة؟",
+    "source_hash": "3f41dec2"
+  },
+  "web.admin.domains.configs.ensure.confirmDescription": {
+    "text": "ينشئ سجلات معطلة على {domain} لـ: {kinds}. كل شيء يبدأ معطلاً، لذا لا يتغير السلوك حتى يتم تفعيل سجل.",
+    "source_hash": "fed66221"
+  },
+  "web.admin.domains.configs.ensure.applyButton": {
+    "text": "إنشاء السجلات",
+    "source_hash": "4bcbef42"
+  },
+  "web.admin.domains.configs.ensure.success": {
+    "text": "تم إنشاء سجلات الإعدادات المفقودة.",
+    "source_hash": "3b6ead80"
+  },
+  "web.admin.domains.configs.ensure.nothingMissing": {
+    "text": "لا شيء لإنشائه — كل سجلات الإعدادات موجودة بالفعل. تم تحديث القائمة.",
+    "source_hash": "ad0df0ae"
+  },
+  "web.admin.domains.configs.ensure.notApplied": {
+    "text": "عاين الخادم التغيير بدلاً من تطبيقه — لم يتم إنشاء سجلات. أعد المحاولة، وأبلغ عن هذا إذا استمر.",
+    "source_hash": "09d26379"
+  },
+  "web.admin.domains.configs.fields.enabled": {
+    "text": "مفعّل",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.fields.signin_enabled": {
+    "text": "تسجيل الدخول مفعّل",
+    "source_hash": "cabe4898"
+  },
+  "web.admin.domains.configs.fields.email_auth_enabled": {
+    "text": "مصادقة البريد الإلكتروني مفعّلة",
+    "source_hash": "4a762960"
+  },
+  "web.admin.domains.configs.fields.sso_enabled": {
+    "text": "SSO مفعّل",
+    "source_hash": "6e77e673"
+  },
+  "web.admin.domains.configs.fields.restrict_to": {
+    "text": "تقييد إلى",
+    "source_hash": "a0bdf50a"
+  },
+  "web.admin.domains.configs.fields.signup_enabled": {
+    "text": "التسجيل مفعّل",
+    "source_hash": "2637d0b2"
+  },
+  "web.admin.domains.configs.fields.autoverify": {
+    "text": "التحقق التلقائي",
+    "source_hash": "7e02211c"
+  },
+  "web.admin.domains.configs.fields.validation_strategy": {
+    "text": "استراتيجية التحقق",
+    "source_hash": "a2e95531"
+  },
+  "web.admin.domains.configs.fields.allowed_signup_domains": {
+    "text": "نطاقات التسجيل المسموح بها",
+    "source_hash": "9b5bb5b1"
+  },
+  "web.admin.domains.configs.fields.secrets_mode": {
+    "text": "وضع الأسرار",
+    "source_hash": "8d4349d6"
+  },
+  "web.admin.domains.configs.fields.disabled_homepage_variant": {
+    "text": "متغير الصفحة الرئيسية المعطل",
+    "source_hash": "4695633b"
+  },
+  "web.admin.domains.configs.fields.ready": {
+    "text": "جاهز",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.configs.fields.recipients": {
+    "text": "المستلمون",
+    "source_hash": "1e8568a8"
+  },
+  "web.admin.domains.configs.fields.provider_type": {
+    "text": "نوع المزود",
+    "source_hash": "8c0f6d3e"
+  },
+  "web.admin.domains.configs.fields.display_name": {
+    "text": "اسم العرض",
+    "source_hash": "2b7f6a84"
+  },
+  "web.admin.domains.configs.fields.issuer": {
+    "text": "المُصدر",
+    "source_hash": "39e02c46"
+  },
+  "web.admin.domains.configs.fields.tenant_id": {
+    "text": "معرف المستأجر",
+    "source_hash": "de1f5fff"
+  },
+  "web.admin.domains.configs.fields.has_client_id": {
+    "text": "تم تعيين معرف العميل",
+    "source_hash": "04a9fa3d"
+  },
+  "web.admin.domains.configs.fields.has_client_secret": {
+    "text": "تم تعيين سر العميل",
+    "source_hash": "6ee1c9e6"
+  },
+  "web.admin.domains.configs.fields.allowed_domains": {
+    "text": "النطاقات المسموح بها",
+    "source_hash": "bcd60db0"
+  },
+  "web.admin.domains.configs.fields.enforce_sso_only": {
+    "text": "فرض SSO فقط",
+    "source_hash": "b3a3f694"
+  },
+  "web.admin.domains.configs.fields.grant_org_scope": {
+    "text": "منح نطاق المؤسسة",
+    "source_hash": "698ea5de"
+  },
+  "web.admin.domains.configs.fields.provider": {
+    "text": "المزود",
+    "source_hash": "472590ae"
+  },
+  "web.admin.domains.configs.fields.from_name": {
+    "text": "اسم المرسل",
+    "source_hash": "b28f93ea"
+  },
+  "web.admin.domains.configs.fields.from_address": {
+    "text": "عنوان المرسل",
+    "source_hash": "d465bcfa"
+  },
+  "web.admin.domains.configs.fields.reply_to": {
+    "text": "الرد على",
+    "source_hash": "6b9c49b7"
+  },
+  "web.admin.domains.configs.fields.sending_mode": {
+    "text": "وضع الإرسال",
+    "source_hash": "e2d6bcf7"
+  },
+  "web.admin.domains.configs.fields.verification_status": {
+    "text": "حالة التحقق",
+    "source_hash": "aedfff7e"
+  },
+  "web.admin.domains.configs.fields.dns_verified": {
+    "text": "تم التحقق من DNS",
+    "source_hash": "8b2128c8"
+  },
+  "web.admin.domains.configs.fields.provider_verified": {
+    "text": "تم التحقق من المزود",
+    "source_hash": "6f4d9cc4"
+  },
+  "web.admin.domains.configs.fields.has_api_key": {
+    "text": "تم تعيين مفتاح API",
+    "source_hash": "d5115386"
+  },
+  "web.admin.domains.configs.fields.created": {
+    "text": "تاريخ الإنشاء",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.configs.fields.updated": {
+    "text": "تاريخ التحديث",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.configs.kinds.signin": {
+    "text": "تسجيل الدخول",
+    "source_hash": "5bbbe531"
+  },
+  "web.admin.domains.configs.kinds.signup": {
+    "text": "التسجيل",
+    "source_hash": "3cc08ebe"
+  },
+  "web.admin.domains.configs.kinds.homepage": {
+    "text": "الصفحة الرئيسية",
+    "source_hash": "9e3391e9"
+  },
+  "web.admin.domains.configs.kinds.api": {
+    "text": "API",
+    "source_hash": "c8e5998f"
+  },
+  "web.admin.domains.configs.kinds.incoming": {
+    "text": "الوارد",
+    "source_hash": "e301820a"
+  },
+  "web.admin.domains.configs.kinds.sso": {
+    "text": "SSO",
+    "source_hash": "5ba3ac9f"
+  },
+  "web.admin.domains.configs.kinds.mailer": {
+    "text": "البريد",
+    "source_hash": "6c07ba63"
+  },
+  "web.admin.domains.configs.missingNotes.signin": {
+    "text": "لا يوجد سجل: تسجيل الدخول معطل على هذا النطاق ما لم يكن SSO للمستأجر نشطاً.",
+    "source_hash": "17dd6099"
+  },
+  "web.admin.domains.configs.missingNotes.signup": {
+    "text": "لا يوجد سجل: التسجيل معطل على هذا النطاق.",
+    "source_hash": "c3c98956"
+  },
+  "web.admin.domains.configs.missingNotes.homepage": {
+    "text": "لا يوجد سجل: أسرار الصفحة الرئيسية معطلة (يفشل مغلقاً ويسجل خطأ).",
+    "source_hash": "9a258a88"
+  },
+  "web.admin.domains.configs.missingNotes.api": {
+    "text": "لا يوجد سجل: API العام معطل (يفشل مغلقاً ويسجل خطأ).",
+    "source_hash": "fed99f73"
+  },
+  "web.admin.domains.configs.missingNotes.incoming": {
+    "text": "لا يوجد سجل: الأسرار الواردة معطلة.",
+    "source_hash": "b957fbe8"
+  },
+  "web.admin.domains.configs.missingNotes.sso": {
+    "text": "لا يوجد سجل: SSO للمستأجر غير متاح؛ تُطبق سياسة SSO الاحتياطية للمنصة.",
+    "source_hash": "7b05ade8"
+  },
+  "web.admin.domains.configs.missingNotes.mailer": {
+    "text": "لا يوجد سجل: يُستخدم بريد المنصة.",
+    "source_hash": "e027cc99"
+  },
+  "web.admin.domains.configs.status.missing": {
+    "text": "مفقود",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.domains.configs.status.disabled": {
+    "text": "معطل",
+    "source_hash": "75081b59"
+  },
+  "web.admin.domains.configs.status.enabled": {
+    "text": "مفعّل",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.status.enabledNotReady": {
+    "text": "مفعّل، غير جاهز",
+    "source_hash": "cb806ba4"
+  },
+  "web.admin.domains.detail.openFullPage": {
+    "text": "فتح الصفحة الكاملة",
+    "source_hash": "a467911c"
+  },
+  "web.admin.domains.detail.backToList": {
+    "text": "العودة إلى النطاقات",
+    "source_hash": "22fd50fe"
+  },
+  "web.admin.domains.detail.notFound": {
+    "text": "النطاق غير موجود",
+    "source_hash": "7b8fc0e6"
+  },
+  "web.admin.domains.detail.notFoundDescription": {
+    "text": "هذا النطاق غير موجود، أو تمت إزالته بالفعل.",
+    "source_hash": "e0f0b987"
+  },
+  "web.admin.domains.detail.loadError": {
+    "text": "تعذر تحميل هذا النطاق.",
+    "source_hash": "39e9c657"
+  },
+  "web.admin.domains.detail.retry": {
+    "text": "إعادة المحاولة",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.detail.never": {
+    "text": "أبداً",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.domains.detail.none": {
+    "text": "لا يوجد",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.domains.detail.yes": {
+    "text": "نعم",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.domains.detail.no": {
+    "text": "لا",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.domains.detail.organization.open": {
+    "text": "فتح المؤسسة",
+    "source_hash": "54a43621"
+  },
+  "web.admin.domains.detail.organization.unknown": {
+    "text": "المؤسسة المالكة غير مضمنة في هذه الاستجابة. افتح هذا النطاق من قائمة النطاقات لرؤيتها.",
+    "source_hash": "bb5bdc9c"
+  },
+  "web.admin.domains.detail.sections.overview": {
+    "text": "نظرة عامة",
+    "source_hash": "d4b1ea57"
+  },
+  "web.admin.domains.detail.sections.actions": {
+    "text": "الإجراءات",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.detail.sections.organization": {
+    "text": "المؤسسة المالكة",
+    "source_hash": "39ad6d9c"
+  },
+  "web.admin.domains.detail.sections.dns": {
+    "text": "DNS",
+    "source_hash": "020965a2"
+  },
+  "web.admin.domains.detail.sections.diagnostics": {
+    "text": "التشخيصات",
+    "source_hash": "268f14bb"
+  },
+  "web.admin.domains.detail.sections.operations": {
+    "text": "عمليات الملكية",
+    "source_hash": "eb9a8cbc"
+  },
+  "web.admin.domains.detail.sections.operationsHint": {
+    "text": "كل عملية تعاين أولاً. لا يُكتب شيء حتى تؤكد خطوة التطبيق.",
+    "source_hash": "f09bf7bd"
+  },
+  "web.admin.domains.fields.publicId": {
+    "text": "المعرف العام",
+    "source_hash": "3705b64f"
+  },
+  "web.admin.domains.fields.domainId": {
+    "text": "المعرف الداخلي",
+    "source_hash": "e468bb47"
+  },
+  "web.admin.domains.fields.organization": {
+    "text": "المؤسسة",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.fields.baseDomain": {
+    "text": "النطاق الأساسي",
+    "source_hash": "33295d5b"
+  },
+  "web.admin.domains.fields.subdomain": {
+    "text": "النطاق الفرعي",
+    "source_hash": "ba4520ab"
+  },
+  "web.admin.domains.fields.apex": {
+    "text": "نطاق Apex",
+    "source_hash": "0a8a42fa"
+  },
+  "web.admin.domains.fields.status": {
+    "text": "الحالة",
+    "source_hash": "920e413c"
+  },
+  "web.admin.domains.fields.created": {
+    "text": "تاريخ الإنشاء",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.fields.updated": {
+    "text": "تاريخ التحديث",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.fields.verified": {
+    "text": "تم التحقق",
+    "source_hash": "4f783840"
+  },
+  "web.admin.domains.fields.resolving": {
+    "text": "جارٍ الحل",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.fields.ready": {
+    "text": "جاهز",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.list.searchPlaceholder": {
+    "text": "البحث باسم النطاق أو المعرف",
+    "source_hash": "aecdd873"
+  },
+  "web.admin.domains.list.stateFilter": {
+    "text": "الحالة",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.domains.list.emptyFilter": {
+    "text": "لا توجد نطاقات تطابق الفلاتر الحالية.",
+    "source_hash": "be4d64ec"
+  },
+  "web.admin.domains.probe.healthLabel": {
+    "text": "الصحة",
+    "source_hash": "55898449"
+  },
+  "web.admin.domains.probe.certInvalid": {
+    "text": "الشهادة غير صالحة للاستخدام",
+    "source_hash": "5535f4d4"
+  },
+  "web.admin.domains.probe.noCertificate": {
+    "text": "لم يتم إرجاع شهادة — فشل الاتصال قبل TLS.",
+    "source_hash": "8ffd63be"
+  },
+  "web.admin.domains.probe.fields.httpStatus": {
+    "text": "حالة HTTP",
+    "source_hash": "0f7cf91f"
+  },
+  "web.admin.domains.probe.fields.httpError": {
+    "text": "خطأ HTTP",
+    "source_hash": "5c6896d4"
+  },
+  "web.admin.domains.probe.fields.sslError": {
+    "text": "خطأ TLS",
+    "source_hash": "7b827515"
+  },
+  "web.admin.domains.probe.fields.issuer": {
+    "text": "مُصدر الشهادة",
+    "source_hash": "2912559a"
+  },
+  "web.admin.domains.probe.fields.subject": {
+    "text": "موضوع الشهادة",
+    "source_hash": "d7816b16"
+  },
+  "web.admin.domains.probe.fields.notAfter": {
+    "text": "انتهاء الشهادة",
+    "source_hash": "1e73119d"
+  },
+  "web.admin.domains.probe.fields.expiresIn": {
+    "text": "{date} ({days} يوم)",
+    "source_hash": "a71a6e81"
+  },
+  "web.admin.domains.tls.serving": {
+    "text": "يخدم",
+    "source_hash": "f55e53f9"
+  },
+  "web.admin.domains.tls.resolving": {
+    "text": "جارٍ الحل",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.tls.none": {
+    "text": "لا يخدم",
+    "source_hash": "da8a5ab9"
   }
 }

--- a/locales/content/ar/admin-organizations.json
+++ b/locales/content/ar/admin-organizations.json
@@ -310,5 +310,333 @@
   "web.admin.organizations.list.loadError": {
     "text": "تعذّر تحميل المؤسسات.",
     "source_hash": "130d5e70"
+  },
+  "web.admin.organizations.addMember.button": {
+    "text": "إضافة حساب موجود",
+    "source_hash": "45a3b757"
+  },
+  "web.admin.organizations.addMember.title": {
+    "text": "إضافة حساب موجود",
+    "source_hash": "2f676a94"
+  },
+  "web.admin.organizations.addMember.description": {
+    "text": "أضف شخصاً لديه حساب بالفعل إلى {org}. استخدم هذا عندما يكون الشخص قد سجل بنفسه ولا يمكن دعوته لأن الحساب موجود بالفعل.",
+    "source_hash": "bb41faa6"
+  },
+  "web.admin.organizations.addMember.searchLabel": {
+    "text": "عنوان البريد الإلكتروني أو معرف الحساب",
+    "source_hash": "82b3040b"
+  },
+  "web.admin.organizations.addMember.searchPlaceholder": {
+    "text": "البحث بعنوان البريد الإلكتروني",
+    "source_hash": "b75cc66c"
+  },
+  "web.admin.organizations.addMember.searchHint": {
+    "text": "يطابق جزءاً من عنوان البريد الإلكتروني، أو معرف حساب محدد.",
+    "source_hash": "84547a60"
+  },
+  "web.admin.organizations.addMember.searchError": {
+    "text": "تعذر البحث في الحسابات. تحقق من الاتصال وحاول مرة أخرى.",
+    "source_hash": "4b6caa41"
+  },
+  "web.admin.organizations.addMember.searchParseError": {
+    "text": "أرجع البحث في الحسابات استجابة غير متوقعة. قد تكون النتائج غير مكتملة.",
+    "source_hash": "0c814231"
+  },
+  "web.admin.organizations.addMember.idle": {
+    "text": "أدخل عنوان بريد إلكتروني للعثور على الحساب.",
+    "source_hash": "f6340d35"
+  },
+  "web.admin.organizations.addMember.noResults": {
+    "text": "لا يوجد حساب يطابق \"{term}\".",
+    "source_hash": "199b662a"
+  },
+  "web.admin.organizations.addMember.noResultsHint": {
+    "text": "يمكن إضافة الحسابات الموجودة فقط هنا. إذا لم يسجل الشخص من قبل، قم بدعوته بدلاً من ذلك.",
+    "source_hash": "ee90aeeb"
+  },
+  "web.admin.organizations.addMember.select": {
+    "text": "اختيار",
+    "source_hash": "2a78025d"
+  },
+  "web.admin.organizations.addMember.selectedEyebrow": {
+    "text": "الحساب المحدد",
+    "source_hash": "8b63d947"
+  },
+  "web.admin.organizations.addMember.change": {
+    "text": "اختيار حساب مختلف",
+    "source_hash": "d4fe39ab"
+  },
+  "web.admin.organizations.addMember.createdOn": {
+    "text": "تم التسجيل {date}",
+    "source_hash": "cfc0e19f"
+  },
+  "web.admin.organizations.addMember.organizationsUnavailable": {
+    "text": "تعذر تحميل مؤسسات هذا الحساب الحالية.",
+    "source_hash": "a35b6bfc"
+  },
+  "web.admin.organizations.addMember.defaultOrg": {
+    "text": "افتراضي",
+    "source_hash": "37a8eec1"
+  },
+  "web.admin.organizations.addMember.roleLabel": {
+    "text": "الدور في هذه المؤسسة",
+    "source_hash": "817475fa"
+  },
+  "web.admin.organizations.addMember.submit": {
+    "text": "إضافة إلى المؤسسة",
+    "source_hash": "0e0cb636"
+  },
+  "web.admin.organizations.addMember.success": {
+    "text": "تمت إضافة {account} كـ {role}.",
+    "source_hash": "533be0dc"
+  },
+  "web.admin.organizations.addMember.badges.verified": {
+    "text": "تم التحقق",
+    "source_hash": "4f783840"
+  },
+  "web.admin.organizations.addMember.badges.unverified": {
+    "text": "لم يتم التحقق",
+    "source_hash": "15133907"
+  },
+  "web.admin.organizations.addMember.badges.suspended": {
+    "text": "موقوف",
+    "source_hash": "e392a389"
+  },
+  "web.admin.organizations.addMember.badges.alreadyMember": {
+    "text": "عضو بالفعل",
+    "source_hash": "1739ed7c"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMember": {
+    "text": "هذا الحساب عضو بالفعل في هذه المؤسسة، بدور {role}. الإضافة لا تغير دوراً موجوداً — استخدم إجراء تعيين الدور لذلك.",
+    "source_hash": "cb6a4774"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMemberUnknownRole": {
+    "text": "هذا الحساب عضو بالفعل في هذه المؤسسة. الإضافة لا تغير دوراً موجوداً.",
+    "source_hash": "035641ec"
+  },
+  "web.admin.organizations.addMember.errors.notFound": {
+    "text": "هذا الحساب أو المؤسسة لم يعد موجوداً. ابحث مرة أخرى للتأكد من الحساب.",
+    "source_hash": "bd88db18"
+  },
+  "web.admin.organizations.addMember.errors.invalidRole": {
+    "text": "تم رفض هذا الدور. اختر أحد الأدوار المدرجة وحاول مرة أخرى.",
+    "source_hash": "eb696a8f"
+  },
+  "web.admin.organizations.addMember.errors.noSelection": {
+    "text": "لم يتم تحديد حساب.",
+    "source_hash": "dd15bb5b"
+  },
+  "web.admin.organizations.addMember.fields.created": {
+    "text": "تاريخ التسجيل",
+    "source_hash": "486b3fe0"
+  },
+  "web.admin.organizations.addMember.fields.verified": {
+    "text": "التحقق",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.organizations.addMember.fields.lastLogin": {
+    "text": "آخر تسجيل دخول",
+    "source_hash": "0b70af7a"
+  },
+  "web.admin.organizations.addMember.fields.organizations": {
+    "text": "المؤسسات الحالية",
+    "source_hash": "cbb5b92f"
+  },
+  "web.admin.organizations.addMember.roleHints.member": {
+    "text": "الوصول اليومي إلى أسرار المؤسسة ونطاقاتها.",
+    "source_hash": "d0c7439e"
+  },
+  "web.admin.organizations.addMember.roleHints.admin": {
+    "text": "يمكنه إدارة الأعضاء والنطاقات وإعدادات المؤسسة.",
+    "source_hash": "beaa50d7"
+  },
+  "web.admin.organizations.addMember.roleHints.owner": {
+    "text": "تحكم كامل، بما في ذلك الفوترة. امنح هذا فقط عند الطلب.",
+    "source_hash": "614ace63"
+  },
+  "web.admin.organizations.addMember.roles.member": {
+    "text": "عضو",
+    "source_hash": "7c968fb7"
+  },
+  "web.admin.organizations.addMember.roles.admin": {
+    "text": "مشرف",
+    "source_hash": "c1c224b0"
+  },
+  "web.admin.organizations.addMember.roles.owner": {
+    "text": "مالك",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.detail.members.openCustomer": {
+    "text": "فتح سجل العميل",
+    "source_hash": "c057ca13"
+  },
+  "web.admin.organizations.detail.reconcile.memberships": {
+    "text": "تمت إعادة تجسيد العضويات:",
+    "source_hash": "fe7db10c"
+  },
+  "web.admin.organizations.detail.reconcile.membershipsFailed": {
+    "text": "فشل، تبقى الاستحقاقات القديمة:",
+    "source_hash": "cc4dae37"
+  },
+  "web.admin.organizations.entitlements.catalogWarning": {
+    "text": "\"{entitlement}\" غير موجود في كتالوج الفوترة — تحقق من الأخطاء الإملائية. المتابعة على أي حال: منح استحقاق سيُشحن في كتالوج لاحق مدعوم ولا يُحظر عمداً.",
+    "source_hash": "cbde548a"
+  },
+  "web.admin.organizations.entitlements.matrix.caption": {
+    "text": "مصفوفة حل الاستحقاقات: الخطة، تجاوزات المنح والإلغاء، المجموعة المحلولة، وما هو مجسد.",
+    "source_hash": "9eac8999"
+  },
+  "web.admin.organizations.entitlements.matrix.yes": {
+    "text": "نعم",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.matrix.no": {
+    "text": "لا",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.matrix.empty": {
+    "text": "هذه المؤسسة ليس لديها استحقاقات من خطتها ولا تجاوزات.",
+    "source_hash": "f6cf2169"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.entitlement": {
+    "text": "الاستحقاق",
+    "source_hash": "0d8f0b2d"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.inPlan": {
+    "text": "في الخطة",
+    "source_hash": "e2222361"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.granted": {
+    "text": "ممنوح",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.revoked": {
+    "text": "ملغى",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.expected": {
+    "text": "المتوقع",
+    "source_hash": "ca99b7f1"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.materialized": {
+    "text": "المجسد",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.state": {
+    "text": "الحالة",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.formula": {
+    "text": "الحل: المتوقع = (الخطة ∪ المنح) − الإلغاءات. المجسد هو ما يُخزن فعلياً على المؤسسة.",
+    "source_hash": "bc4bff2d"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.orphaned": {
+    "text": "يتيم — مجسد لكن غير متوقع، عادة متروك من إلغاء لم تُعد تجسيده. التسوية تزيله.",
+    "source_hash": "3a27a9af"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.missing": {
+    "text": "مفقود — متوقع لكن غير مجسد. هذا هو الإذن الذي يفتقده الأعضاء فعلياً الآن.",
+    "source_hash": "485e44ad"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.revoked": {
+    "text": "الصفوف المشطوبة ملغاة بواسطة تجاوز مشرف، مما يزيلها من المجموعة المتوقعة.",
+    "source_hash": "89a2e9b6"
+  },
+  "web.admin.organizations.entitlements.matrix.state.plan": {
+    "text": "من الخطة",
+    "source_hash": "1d346b26"
+  },
+  "web.admin.organizations.entitlements.matrix.state.granted": {
+    "text": "ممنوح",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.state.revoked": {
+    "text": "ملغى",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.state.orphaned": {
+    "text": "يتيم",
+    "source_hash": "8d827807"
+  },
+  "web.admin.organizations.entitlements.matrix.state.missing": {
+    "text": "مفقود",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.organizations.entitlements.picker.selectPlaceholder": {
+    "text": "اختر استحقاقاً…",
+    "source_hash": "53af3be8"
+  },
+  "web.admin.organizations.entitlements.picker.other": {
+    "text": "آخر — غير موجود في الكتالوج…",
+    "source_hash": "f08bc3a3"
+  },
+  "web.admin.organizations.entitlements.picker.customLabel": {
+    "text": "اسم الاستحقاق (غير موجود في الكتالوج)",
+    "source_hash": "52783229"
+  },
+  "web.admin.organizations.entitlements.picker.backToCatalog": {
+    "text": "العودة إلى الكتالوج",
+    "source_hash": "9b727f40"
+  },
+  "web.admin.organizations.entitlements.picker.uncategorized": {
+    "text": "غير مصنف",
+    "source_hash": "8d40d123"
+  },
+  "web.admin.organizations.entitlements.picker.catalogUnavailable": {
+    "text": "تعذرت قراءة كتالوج الفوترة، لذا لا يتم التحقق من أسماء الاستحقاقات هنا.",
+    "source_hash": "724869ec"
+  },
+  "web.admin.organizations.entitlements.picker.tags.inPlan": {
+    "text": "في الخطة",
+    "source_hash": "5f2251bb"
+  },
+  "web.admin.organizations.entitlements.picker.tags.granted": {
+    "text": "ممنوح",
+    "source_hash": "dd515d19"
+  },
+  "web.admin.organizations.entitlements.picker.tags.revoked": {
+    "text": "ملغى",
+    "source_hash": "4bb47f18"
+  },
+  "web.admin.organizations.entitlements.summary.sync": {
+    "text": "مزامنة",
+    "source_hash": "8d261a37"
+  },
+  "web.admin.organizations.entitlements.summary.materialized": {
+    "text": "مجسد",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.summary.materializedAt": {
+    "text": "آخر تجسيد",
+    "source_hash": "9325dce9"
+  },
+  "web.admin.organizations.entitlements.summary.planDefinition": {
+    "text": "تعريف الخطة",
+    "source_hash": "6b531454"
+  },
+  "web.admin.organizations.entitlements.summary.yes": {
+    "text": "نعم",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.summary.no": {
+    "text": "لا",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.summary.never": {
+    "text": "أبداً",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.organizations.entitlements.summary.planStale": {
+    "text": "تغير منذ التجسيد",
+    "source_hash": "e682d8a4"
+  },
+  "web.admin.organizations.entitlements.summary.planCurrent": {
+    "text": "حالي",
+    "source_hash": "e0d1b682"
+  },
+  "web.admin.organizations.entitlements.summary.planUnknown": {
+    "text": "غير معروف — تعذرت المقارنة",
+    "source_hash": "b607e540"
   }
 }

--- a/locales/content/ar/admin-secrets.json
+++ b/locales/content/ar/admin-secrets.json
@@ -1,11 +1,11 @@
 {
   "web.admin.secrets.title": {
-    "text": "الأسرار",
-    "source_hash": "d8707d41"
+    "text": "إيصالات الأسرار",
+    "source_hash": "a8a2d0e4"
   },
   "web.admin.secrets.description": {
-    "text": "افحص إيصال السر واحذفه دون الحاجة إلى SSH — ابحث عنه باستخدام مفتاحه.",
-    "source_hash": "07775a11"
+    "text": "البحث عن الحالة والطوابع الزمنية والإيصال وما إلى ذلك.",
+    "source_hash": "91fba2a1"
   },
   "web.admin.secrets.never": {
     "text": "أبداً",
@@ -108,20 +108,20 @@
     "source_hash": "504101bc"
   },
   "web.admin.secrets.lookup.resultTitle": {
-    "text": "السر {shortid}",
-    "source_hash": "8b311d32"
+    "text": "سجل السر {shortid}",
+    "source_hash": "ee06d765"
   },
   "web.admin.secrets.lookup.notFound": {
-    "text": "لم يتم العثور على السر",
-    "source_hash": "70a9532c"
+    "text": "لم يتم العثور على سجل",
+    "source_hash": "40f4d9e9"
   },
   "web.admin.secrets.lookup.notFoundDescription": {
     "text": "لا يوجد سر بهذا المفتاح. ربما انتهت صلاحيته أو تم حذفه.",
     "source_hash": "9f068a81"
   },
   "web.admin.secrets.lookup.loadError": {
-    "text": "تعذّر تحميل هذا السر.",
-    "source_hash": "c96672e4"
+    "text": "تعذر تحميل هذا السجل.",
+    "source_hash": "de77cc72"
   },
   "web.admin.secrets.lookup.retry": {
     "text": "إعادة المحاولة",
@@ -188,8 +188,8 @@
     "source_hash": "c127dab6"
   },
   "web.admin.secrets.sections.secret": {
-    "text": "السر",
-    "source_hash": "7e32a729"
+    "text": "سجل السر",
+    "source_hash": "263813c6"
   },
   "web.admin.secrets.sections.receipt": {
     "text": "الإيصال",
@@ -214,5 +214,25 @@
   "web.admin.secrets.state.viewed": {
     "text": "تمت المشاهدة",
     "source_hash": "1b28d178"
+  },
+  "web.admin.secrets.capability.title": {
+    "text": "البيانات الوصفية فقط",
+    "source_hash": "df0453d1"
+  },
+  "web.admin.secrets.capability.canRead": {
+    "text": "يقرأ البيانات الوصفية للسر وإيصاله: الحالة والطوابع الزمنية والمالك وحجم النص المشفر المخزن.",
+    "source_hash": "d438ecc7"
+  },
+  "web.admin.secrets.capability.cannotRead": {
+    "text": "لا يمكن فك تشفير أو عرض محتوى السر. نقطة النهاية خلف هذه الشاشة لا تعيده أبداً.",
+    "source_hash": "7f69f222"
+  },
+  "web.admin.secrets.capability.canDelete": {
+    "text": "يمكنه حذف السر وإيصاله نهائياً، مما يدمر المحتوى دون الكشف عنه.",
+    "source_hash": "77f2bc7e"
+  },
+  "web.admin.secrets.lookup.hint": {
+    "text": "المعرف من رابط السر — وليس محتوى السر.",
+    "source_hash": "acfbc352"
   }
 }

--- a/locales/content/ar/admin-system.json
+++ b/locales/content/ar/admin-system.json
@@ -154,5 +154,133 @@
   "web.admin.system.redis.captured": {
     "text": "تم الالتقاط {at}",
     "source_hash": "57b40c0f"
+  },
+  "web.admin.system.brand.title": {
+    "text": "تشخيصات العلامة التجارية",
+    "source_hash": "1cf9abd5"
+  },
+  "web.admin.system.brand.description": {
+    "text": "حزمة العلامة التجارية التي حلها المثيل الجاري على القرص — يوضح لماذا قد تخدم منطقة علامة تجارية محايدة.",
+    "source_hash": "be29e282"
+  },
+  "web.admin.system.brand.loadError": {
+    "text": "تعذر تحميل تشخيصات العلامة التجارية.",
+    "source_hash": "80607303"
+  },
+  "web.admin.system.brand.none": {
+    "text": "(لا يوجد)",
+    "source_hash": "552e4230"
+  },
+  "web.admin.system.brand.resolution": {
+    "text": "الحل",
+    "source_hash": "d4055faf"
+  },
+  "web.admin.system.brand.envVsConfig": {
+    "text": "البيئة مقابل الإعدادات",
+    "source_hash": "bee3debb"
+  },
+  "web.admin.system.brand.absorbed": {
+    "text": "المفاتيح الممتصة",
+    "source_hash": "9784e110"
+  },
+  "web.admin.system.brand.operatorKeys": {
+    "text": "مفاتيح المشغل",
+    "source_hash": "434e8248"
+  },
+  "web.admin.system.brand.overlayAssets": {
+    "text": "أصول التراكب",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.exists.yes": {
+    "text": "موجود",
+    "source_hash": "43f9b89c"
+  },
+  "web.admin.system.brand.exists.no": {
+    "text": "مفقود",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.system.brand.fields.resolvedDir": {
+    "text": "الدليل المحلول",
+    "source_hash": "0623b983"
+  },
+  "web.admin.system.brand.fields.home": {
+    "text": "الرئيسية",
+    "source_hash": "3a786953"
+  },
+  "web.admin.system.brand.fields.envPack": {
+    "text": "حزمة علامة ENV التجارية",
+    "source_hash": "940aeb5c"
+  },
+  "web.admin.system.brand.fields.configPack": {
+    "text": "حزمة علامة Config التجارية",
+    "source_hash": "761b9550"
+  },
+  "web.admin.system.brand.fields.envAssetsDir": {
+    "text": "دليل أصول علامة ENV التجارية",
+    "source_hash": "05854f1f"
+  },
+  "web.admin.system.brand.fields.configAssetsDir": {
+    "text": "دليل أصول علامة Config التجارية",
+    "source_hash": "e91e5c46"
+  },
+  "web.admin.system.brand.flags.fellBack.danger": {
+    "text": "رجع إلى الحزمة الافتراضية",
+    "source_hash": "7bf7ba2f"
+  },
+  "web.admin.system.brand.flags.fellBack.ok": {
+    "text": "تم حل حزمة العلامة التجارية",
+    "source_hash": "1ab3162f"
+  },
+  "web.admin.system.brand.flags.mismatch.danger": {
+    "text": "عدم تطابق البدء / المباشر",
+    "source_hash": "0a022192"
+  },
+  "web.admin.system.brand.flags.mismatch.ok": {
+    "text": "البدء يطابق المباشر",
+    "source_hash": "d4792c09"
+  },
+  "web.admin.system.brand.manifest.title": {
+    "text": "البيان",
+    "source_hash": "3c99f1f3"
+  },
+  "web.admin.system.brand.manifest.path": {
+    "text": "المسار",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.manifest.exists": {
+    "text": "موجود",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.manifest.keysOnDisk": {
+    "text": "المفاتيح على القرص",
+    "source_hash": "52439c03"
+  },
+  "web.admin.system.brand.roots.title": {
+    "text": "جذور البحث",
+    "source_hash": "d8696f2b"
+  },
+  "web.admin.system.brand.roots.empty": {
+    "text": "لا توجد جذور بحث",
+    "source_hash": "867a471c"
+  },
+  "web.admin.system.brand.roots.columns.path": {
+    "text": "المسار",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.roots.columns.exists": {
+    "text": "موجود",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.stats.brandPack": {
+    "text": "حزمة العلامة التجارية",
+    "source_hash": "884437d0"
+  },
+  "web.admin.system.brand.stats.overlayAssets": {
+    "text": "أصول التراكب",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.stats.manifestKeys": {
+    "text": "مفاتيح البيان",
+    "source_hash": "c4267198"
   }
 }

--- a/locales/content/ar/email.json
+++ b/locales/content/ar/email.json
@@ -836,5 +836,41 @@
   "email.secret_link.footer_note": {
     "text": "لقد تلقيت هذه الرسالة لأن %{sender_email} استخدم %{product_name} لمشاركة سر معك. إذا لم تكن تتوقعها، يمكنك تجاهل هذا البريد الإلكتروني بأمان.",
     "source_hash": "2d544dad"
+  },
+  "email.sso_link_verification.subject": {
+    "text": "تأكيد ربط %{provider} بحسابك في %{product_name}",
+    "source_hash": "65e70296"
+  },
+  "email.sso_link_verification.title": {
+    "text": "تأكيد تسجيل الدخول عبر SSO",
+    "source_hash": "35bce6cc"
+  },
+  "email.sso_link_verification.request_notice": {
+    "text": "قام شخص ما بتسجيل الدخول باستخدام %{provider} بالبريد الإلكتروني %{email_address}. لإكمال ربط %{provider} بحسابك في %{product_name}، قم بالتأكيد أدناه.",
+    "source_hash": "baeb18c0"
+  },
+  "email.sso_link_verification.confirm_button": {
+    "text": "تأكيد وربط %{provider}",
+    "source_hash": "9809e210"
+  },
+  "email.sso_link_verification.copy_link_prompt": {
+    "text": "أو انسخ والصق هذا الرابط:",
+    "source_hash": "88c72144"
+  },
+  "email.sso_link_verification.expiration_notice": {
+    "text": "ينتهي هذا الرابط خلال 15 دقيقة ويمكن استخدامه مرة واحدة فقط.",
+    "source_hash": "1a437f42"
+  },
+  "email.sso_link_verification.ignore_notice": {
+    "text": "إذا لم تحاول تسجيل الدخول باستخدام %{provider}، يمكنك تجاهل هذا البريد الإلكتروني بأمان — لن يتم ربط أي شيء بحسابك.",
+    "source_hash": "d7317d30"
+  },
+  "email.sso_link_verification.signature": {
+    "text": "فريق الدعم",
+    "source_hash": "dc75bf9f"
+  },
+  "email.sso_link_verification.postscript": {
+    "text": "ملاحظة: تم إرسال هذا البريد الإلكتروني إلى %{email_address}.",
+    "source_hash": "8ab1dbea"
   }
 }

--- a/locales/content/ar/session-auth-extended.json
+++ b/locales/content/ar/session-auth-extended.json
@@ -719,5 +719,201 @@
   "web.auth.sessions.session_plural": {
     "text": "جلسات",
     "source_hash": "1225ae6c"
+  },
+  "web.auth.connections.title": {
+    "text": "الهويات المرتبطة",
+    "source_hash": "e132c4d9"
+  },
+  "web.auth.connections.description": {
+    "text": "إدارة مزودي تسجيل الدخول الموحد المرتبطين بحسابك.",
+    "source_hash": "42c6d148"
+  },
+  "web.auth.connections.section_title": {
+    "text": "تسجيل الدخول الموحد",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.section_subtitle": {
+    "text": "مزودو الهوية الذين يمكنك استخدامهم لتسجيل الدخول إلى هذا الحساب",
+    "source_hash": "507254cd"
+  },
+  "web.auth.connections.connect_title": {
+    "text": "ربط مزود",
+    "source_hash": "a002b3f3"
+  },
+  "web.auth.connections.connect_description": {
+    "text": "اربط مزود تسجيل دخول موحد آخر يمكنك استخدامه لتسجيل الدخول إلى هذا الحساب.",
+    "source_hash": "32895a5a"
+  },
+  "web.auth.connections.connect_action": {
+    "text": "ربط {provider}",
+    "source_hash": "c77540af"
+  },
+  "web.auth.connections.issuer": {
+    "text": "المُصدر",
+    "source_hash": "39e02c46"
+  },
+  "web.auth.connections.identifier": {
+    "text": "المعرف",
+    "source_hash": "9b10587f"
+  },
+  "web.auth.connections.remove": {
+    "text": "إزالة",
+    "source_hash": "c3812fc4"
+  },
+  "web.auth.connections.remove_confirm_title": {
+    "text": "إزالة الهوية المرتبطة",
+    "source_hash": "4e8ffe4c"
+  },
+  "web.auth.connections.remove_confirm_message": {
+    "text": "هل أنت متأكد من أنك تريد إزالة هذه الهوية المرتبطة؟ لن تتمكن من تسجيل الدخول بها بعد الآن.",
+    "source_hash": "64939c89"
+  },
+  "web.auth.connections.removed_success": {
+    "text": "تمت إزالة الهوية المرتبطة",
+    "source_hash": "cf87daf3"
+  },
+  "web.auth.connections.no_identities": {
+    "text": "لا توجد هويات مرتبطة",
+    "source_hash": "5254048e"
+  },
+  "web.auth.connections.no_identities_description": {
+    "text": "لم تربط أي مزودي تسجيل دخول موحد بهذا الحساب بعد.",
+    "source_hash": "0f58d5d0"
+  },
+  "web.auth.connections.overview_status": {
+    "text": "تسجيل الدخول الموحد",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.errors.last_credential": {
+    "text": "هذه هي طريقتك الوحيدة لتسجيل الدخول. اربط مزوداً آخر أولاً، أو عيّن كلمة مرور من الإعدادات ← الأمان، حتى لا تُحرم من الدخول.",
+    "source_hash": "3de8084d"
+  },
+  "web.auth.connections.errors.last_credential_sso_enforced": {
+    "text": "هذه هي طريقتك الوحيدة لتسجيل الدخول. اربط مزوداً آخر أولاً حتى لا تُحرم من الدخول.",
+    "source_hash": "eed7a50e"
+  },
+  "web.auth.connections.errors.not_found": {
+    "text": "تعذر العثور على تلك الهوية المرتبطة. قد تكون قد أُزيلت بالفعل.",
+    "source_hash": "cf2c7673"
+  },
+  "web.auth.connections.errors.unauthorized": {
+    "text": "انتهت صلاحية جلستك. يرجى تسجيل الدخول مرة أخرى.",
+    "source_hash": "b529fce2"
+  },
+  "web.auth.connections.errors.generic": {
+    "text": "تعذر إكمال هذا الإجراء. يرجى المحاولة مرة أخرى.",
+    "source_hash": "a0d4edc0"
+  },
+  "web.link_sso.title": {
+    "text": "ربط طريقة تسجيل الدخول",
+    "source_hash": "46339bac"
+  },
+  "web.link_sso.prompt": {
+    "text": "سجلت الدخول باستخدام {provider}، والذي يطابق الحساب الموجود {email}. أدخل كلمة مرور هذا الحساب لربط {provider} والمتابعة.",
+    "source_hash": "59da1c08"
+  },
+  "web.link_sso.password_label": {
+    "text": "كلمة المرور",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.link_sso.password_placeholder": {
+    "text": "كلمة المرور الحالية",
+    "source_hash": "ad4e56da"
+  },
+  "web.link_sso.submit": {
+    "text": "ربط ومتابعة",
+    "source_hash": "c969b759"
+  },
+  "web.link_sso.cancel": {
+    "text": "إلغاء",
+    "source_hash": "19766ed6"
+  },
+  "web.link_sso.unavailable_title": {
+    "text": "انتهت صلاحية طلب الربط هذا",
+    "source_hash": "b53c7e55"
+  },
+  "web.link_sso.unavailable_message": {
+    "text": "لأمانك، لم يعد طلب ربط طريقة تسجيل الدخول هذه صالحاً. سجل الدخول بكلمة المرور الحالية، ثم اربط هذا المزود ضمن إعدادات الأمان ← الهويات المرتبطة.",
+    "source_hash": "f7e349d1"
+  },
+  "web.link_sso.unavailable_action": {
+    "text": "متابعة تسجيل الدخول",
+    "source_hash": "d398cd0a"
+  },
+  "web.link_sso.errors.invalid_password": {
+    "text": "كلمة المرور هذه لا تطابق هذا الحساب. يرجى المحاولة مرة أخرى.",
+    "source_hash": "3259b4f5"
+  },
+  "web.link_sso.errors.invalid_token": {
+    "text": "انتهت صلاحية طلب الربط هذا أو تم استخدامه بالفعل. سجل الدخول بكلمة المرور الحالية، ثم اربط هذا المزود من إعدادات حسابك.",
+    "source_hash": "541f9127"
+  },
+  "web.link_sso.errors.link_conflict": {
+    "text": "تعذر ربط طريقة تسجيل الدخول هذه. قد يكون حسابك قد تغير، أو هذا المزود مرتبط بالفعل بحساب آخر. سجل الدخول بكلمة المرور الحالية، ثم أدر الاتصالات ضمن إعدادات الأمان ← الهويات المرتبطة.",
+    "source_hash": "7b0e0d0e"
+  },
+  "web.link_sso.errors.link_rate_limited": {
+    "text": "محاولات كلمة مرور كثيرة جداً. يرجى الانتظار بضع دقائق، ثم المحاولة مرة أخرى.",
+    "source_hash": "a95e78cd"
+  },
+  "web.link_sso.errors.invalid_request": {
+    "text": "تعذرت معالجة طلب الربط هذا. يرجى تسجيل الدخول بمزود SSO مرة أخرى.",
+    "source_hash": "053b9fc6"
+  },
+  "web.link_sso.errors.generic": {
+    "text": "تعذر ربط حسابك. يرجى المحاولة مرة أخرى.",
+    "source_hash": "f727c174"
+  },
+  "web.sso_link_confirm.title": {
+    "text": "تأكيد ربط حسابك",
+    "source_hash": "ad80bfe7"
+  },
+  "web.sso_link_confirm.prompt": {
+    "text": "سجلت الدخول باستخدام {provider}، والذي يطابق حسابك {email}. قم بالتأكيد لربط {provider} بهذا الحساب وإكمال تسجيل الدخول.",
+    "source_hash": "6ff0d6cc"
+  },
+  "web.sso_link_confirm.submit": {
+    "text": "تأكيد وربط",
+    "source_hash": "5cf663e6"
+  },
+  "web.sso_link_confirm.cancel": {
+    "text": "إلغاء",
+    "source_hash": "19766ed6"
+  },
+  "web.sso_link_confirm.unavailable_title": {
+    "text": "لا يمكن إكمال طلب الربط هذا",
+    "source_hash": "47abb784"
+  },
+  "web.sso_link_confirm.unavailable_message": {
+    "text": "لأمانك، لم يعد هذا الطلب لربط طريقة تسجيل الدخول صالحاً. سجل الدخول بمزودك مرة أخرى وسنرسل لك رابطاً جديداً بالبريد الإلكتروني.",
+    "source_hash": "080e6f9f"
+  },
+  "web.sso_link_confirm.unavailable_action": {
+    "text": "العودة إلى تسجيل الدخول",
+    "source_hash": "8504054f"
+  },
+  "web.sso_link_confirm.errors.link_expired": {
+    "text": "انتهت صلاحية طلب الربط هذا أو تم استخدامه بالفعل. سجل الدخول بمزودك مرة أخرى وسنرسل لك رابطاً جديداً بالبريد الإلكتروني.",
+    "source_hash": "a50538df"
+  },
+  "web.sso_link_confirm.errors.link_conflict": {
+    "text": "تعذر ربط طريقة تسجيل الدخول هذه. قد يكون حسابك قد تغير، أو هذا المزود مرتبط بالفعل بحساب آخر. سجل الدخول بمزودك مرة أخرى للمتابعة.",
+    "source_hash": "c954854b"
+  },
+  "web.sso_link_confirm.errors.link_invalidated": {
+    "text": "تغيرت بيانات اعتماد حسابك بعد إرسال هذا الرابط، لذا لم يعد صالحاً. سجل الدخول بمزودك مرة أخرى وسنرسل لك رابطاً جديداً بالبريد الإلكتروني.",
+    "source_hash": "db88cb1d"
+  },
+  "web.sso_link_confirm.errors.link_error": {
+    "text": "حدث خطأ من جانبنا ولم نتمكن من التحقق من هذا الرابط. سجل الدخول بمزودك مرة أخرى وسنرسل لك رابطاً جديداً بالبريد الإلكتروني.",
+    "source_hash": "ec24e0a1"
+  },
+  "web.sso_link_confirm.errors.confirm_rate_limited": {
+    "text": "محاولات كثيرة جداً من جهازك. يرجى الانتظار بضع دقائق، ثم افتح الرابط المرسل بالبريد الإلكتروني مرة أخرى أو سجل الدخول بمزودك للحصول على رابط جديد.",
+    "source_hash": "f29af782"
+  },
+  "web.sso_link_confirm.errors.generic": {
+    "text": "تعذر تأكيد هذا الاتصال. يرجى تسجيل الدخول بمزودك مرة أخرى.",
+    "source_hash": "076fa25a"
   }
 }

--- a/locales/content/ar/session-auth-extended.json
+++ b/locales/content/ar/session-auth-extended.json
@@ -746,6 +746,7 @@
   },
   "web.auth.connections.connect_action": {
     "text": "ربط {provider}",
+    "context": "Button label to start linking a specific SSO provider; {provider} is the provider display name",
     "source_hash": "c77540af"
   },
   "web.auth.connections.issuer": {
@@ -810,6 +811,7 @@
   },
   "web.link_sso.prompt": {
     "text": "سجلت الدخول باستخدام {provider}، والذي يطابق الحساب الموجود {email}. أدخل كلمة مرور هذا الحساب لربط {provider} والمتابعة.",
+    "context": "Instruction on the sign-in interstitial. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/link-sso/:token.",
     "source_hash": "59da1c08"
   },
   "web.link_sso.password_label": {
@@ -870,6 +872,7 @@
   },
   "web.sso_link_confirm.prompt": {
     "text": "سجلت الدخول باستخدام {provider}، والذي يطابق حسابك {email}. قم بالتأكيد لربط {provider} بهذا الحساب وإكمال تسجيل الدخول.",
+    "context": "Consent instruction on the #3840 Phase 4 mailbox-proof SSO linking page. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/sso-link-confirm/:token. No password is asked — clicking the emailed link is the proof.",
     "source_hash": "6ff0d6cc"
   },
   "web.sso_link_confirm.submit": {

--- a/locales/content/ar/session-auth.json
+++ b/locales/content/ar/session-auth.json
@@ -483,5 +483,41 @@
   "web.login.verified_notice": {
     "text": "تم التحقق من بريدك الإلكتروني — يمكنك الآن تسجيل الدخول.",
     "source_hash": "c8d4b5a8"
+  },
+  "web.auth.password_setup_request.title": {
+    "text": "تعيين كلمة مرور",
+    "source_hash": "11b6978b"
+  },
+  "web.auth.password_setup_request.description": {
+    "text": "حسابك ليس لديه كلمة مرور بعد. سنرسل لك رابطاً آمناً بالبريد الإلكتروني لتعيين واحدة حتى تتمكن أيضاً من تسجيل الدخول مباشرة.",
+    "source_hash": "dc0b561f"
+  },
+  "web.auth.password_setup_request.button": {
+    "text": "إرسال رابط الإعداد",
+    "source_hash": "22807292"
+  },
+  "web.auth.password_setup_request.emailSent": {
+    "text": "تم إرسال بريد إلكتروني إليك يحتوي على رابط لتعيين كلمة مرور لحسابك",
+    "source_hash": "82b686c7"
+  },
+  "web.login.errors.account_exists_link_required": {
+    "text": "يوجد حساب بهذا العنوان البريدي بالفعل لكنه غير مرتبط بطريقة تسجيل الدخول هذه. سجل الدخول بطريقتك الحالية، ثم اربط هذا المزود ضمن إعدادات الأمان ← الهويات المرتبطة.",
+    "source_hash": "7fbbb7e7"
+  },
+  "web.login.errors.identity_connect_conflict": {
+    "text": "تعذر ربط هذه الهوية. قد يكون الربط قد بدأ على نطاق خاطئ، أو انتهت صلاحية جلستك. يرجى تسجيل الدخول مرة أخرى، ثم ربطها من إعدادات حسابك.",
+    "source_hash": "4238bbf2"
+  },
+  "web.login.errors.org_join_failed": {
+    "text": "تعذر إكمال إضافتك إلى مؤسستك. يرجى الاتصال بالمشرف.",
+    "source_hash": "155e71bb"
+  },
+  "web.login.errors.link_sso_failed": {
+    "text": "تعذر ربط طريقة تسجيل الدخول تلك. سجل الدخول بكلمة المرور الحالية، ثم اربط هذا المزود ضمن إعدادات الأمان ← الهويات المرتبطة.",
+    "source_hash": "49954127"
+  },
+  "web.login.notices.link_verification_sent": {
+    "text": "تحقق من بريدك الوارد — أرسلنا لك رابطاً بالبريد الإلكتروني لتأكيد ربط حسابك. افتحه لإكمال تسجيل الدخول.",
+    "source_hash": "b251c8f3"
   }
 }

--- a/locales/content/ar/workspace-account.json
+++ b/locales/content/ar/workspace-account.json
@@ -694,5 +694,33 @@
   "web.settings.security.sso_managed_description": {
     "text": "تتم مصادقة حسابك عبر موفّر تسجيل الدخول الموحّد الخاص بمؤسستك. تتم إدارة كلمة المرور والمصادقة متعددة العوامل ورموز الاسترداد بواسطة موفّر الهوية الخاص بك.",
     "source_hash": "cd0cf39f"
+  },
+  "web.settings.api.api_username": {
+    "text": "اسم مستخدم API",
+    "source_hash": "0b3e483e"
+  },
+  "web.settings.api.api_username_description": {
+    "text": "اسم المستخدم لمصادقة HTTP الأساسية",
+    "source_hash": "f3e65de3"
+  },
+  "web.settings.api.basic_auth_hint": {
+    "text": "لمصادقة HTTP الأساسية، استخدم بريدك الإلكتروني أو هذا المعرف كاسم المستخدم ورمز API كلمة المرور.",
+    "source_hash": "cfa3806d"
+  },
+  "web.settings.security.set": {
+    "text": "تم التعيين",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.settings.security.not_set": {
+    "text": "لم يتم التعيين",
+    "source_hash": "4895f731"
+  },
+  "web.settings.security.set_password_title": {
+    "text": "تعيين كلمة المرور",
+    "source_hash": "4e411687"
+  },
+  "web.settings.security.set_password_description": {
+    "text": "أضف كلمة مرور إلى حسابك حتى تتمكن أيضاً من تسجيل الدخول بدون مزود الهوية",
+    "source_hash": "a6970402"
   }
 }

--- a/locales/content/ar/workspace-billing.json
+++ b/locales/content/ar/workspace-billing.json
@@ -1044,5 +1044,21 @@
   "web.billing.plans.reactivate": {
     "text": "إعادة التفعيل",
     "source_hash": "2dc7478f"
+  },
+  "web.billing.currency_migration.refund_failed_warning": {
+    "text": "تم إلغاء خطتك السابقة، لكننا لم نتمكن من إصدار استرداد تلقائي للوقت غير المستخدم. يرجى الاتصال بالدعم لاستلام استردادك. لا تزال بحاجة إلى إكمال الدفع لتفعيل خطتك الجديدة.",
+    "source_hash": "a390c498"
+  },
+  "web.billing.currency_migration.refund_failed_continue": {
+    "text": "المتابعة إلى الدفع",
+    "source_hash": "eccdb8aa"
+  },
+  "web.billing.plans.per_year": {
+    "text": "/سنة",
+    "source_hash": "a2d5f1bc"
+  },
+  "web.billing.plans.billing_interval": {
+    "text": "فترة الفوترة",
+    "source_hash": "3ce28209"
   }
 }

--- a/locales/content/ar/workspace-branding.json
+++ b/locales/content/ar/workspace-branding.json
@@ -56,12 +56,12 @@
     "source_hash": "e36598ef"
   },
   "web.branding.example_pre_reveal_instructions": {
-    "text": "استخدم هاتفك لمسح رمز QR",
-    "source_hash": "99ecf59f"
+    "text": "مثال: استخدم هاتفك لمسح رمز QR",
+    "source_hash": "9cf0caf8"
   },
   "web.branding.example_post_reveal_instructions": {
-    "text": "تواصل مع support{'@'}example.com لأي أسئلة",
-    "source_hash": "bee120a7"
+    "text": "مثال: تواصل مع onboarding{'@'}example.com لأي أسئلة",
+    "source_hash": "71749811"
   },
   "web.branding.these_instructions_will_be_shown_to_recipients_before": {
     "text": "ستُعرض هذه التعليمات للمستلمين قبل الكشف عن محتوى السر",
@@ -320,8 +320,8 @@
     "source_hash": "bc79cdff"
   },
   "web.branding.paths_carryover_hint": {
-    "text": "هذه معاينة مباشرة — لن تكون تغييراتك مرئية للزوار حتى تحفظها.",
-    "source_hash": "cb4b82de"
+    "text": "هذه معاينة مباشرة — لن تكون تغييراتك مرئية للزوار حتى تنقر على تحديث.",
+    "source_hash": "9a34df71"
   },
   "web.branding.coming_soon_match_blurb": {
     "text": "وجّهنا إلى موقعك وسنقرأ ألوانه وخطوطه، ثم نسدّ الفجوة بنقرة واحدة.",
@@ -406,5 +406,57 @@
   "web.branding.delivery_after_reveal": {
     "text": "بعد الكشف",
     "source_hash": "d5bfe7fd"
+  },
+  "web.branding.favicon": {
+    "text": "أيقونة الموقع",
+    "source_hash": "42955289"
+  },
+  "web.branding.refresh_favicon": {
+    "text": "تحديث أيقونة الموقع من النطاق",
+    "source_hash": "7cc3d5dc"
+  },
+  "web.branding.refresh_favicon_hint": {
+    "text": "جلب أيقونة الموقع من نطاقك مرة أخرى. تظهر الأيقونة الجديدة قريباً.",
+    "source_hash": "ee007e44"
+  },
+  "web.branding.refresh_favicon_queued": {
+    "text": "جارٍ تحديث أيقونة الموقع — ستظهر الأيقونة الجديدة قريباً.",
+    "source_hash": "6bf38e6e"
+  },
+  "web.branding.refresh_favicon_user_upload_hint": {
+    "text": "لقد رفعت أيقونة موقع مخصصة، لذا لن تحل محلها الأيقونة المجلوبة.",
+    "source_hash": "c22e1ed6"
+  },
+  "web.branding.upload_favicon": {
+    "text": "رفع أيقونة الموقع",
+    "source_hash": "ceda39cb"
+  },
+  "web.branding.replace_favicon": {
+    "text": "استبدال",
+    "source_hash": "95e15439"
+  },
+  "web.branding.remove_favicon": {
+    "text": "إزالة أيقونة الموقع",
+    "source_hash": "03693698"
+  },
+  "web.branding.favicon_field_hint": {
+    "text": "ICO أو PNG أو SVG. الرفع يستبدل الأيقونة المجلوبة.",
+    "source_hash": "dfa0bfcb"
+  },
+  "web.branding.favicon_preview_alt": {
+    "text": "أيقونة موقع النطاق",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_title": {
+    "text": "أيقونة موقع النطاق",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_hint": {
+    "text": "ICO أو PNG أو SVG. حتى 256 كيلوبايت. يستبدل الأيقونة المجلوبة تلقائياً.",
+    "source_hash": "c9eafc83"
+  },
+  "web.branding.favicon_modal_save": {
+    "text": "حفظ أيقونة الموقع",
+    "source_hash": "c8a1566c"
   }
 }

--- a/locales/content/ar/workspace-organizations.json
+++ b/locales/content/ar/workspace-organizations.json
@@ -1034,5 +1034,153 @@
   "web.organizations.create_workspace": {
     "text": "إنشاء مساحة عمل",
     "source_hash": "c63c14cf"
+  },
+  "web.organizations.organization_id": {
+    "text": "معرف المؤسسة",
+    "source_hash": "1f466322"
+  },
+  "web.organizations.organization_id_hint": {
+    "text": "استخدم هذا المعرف عند الاتصال بالدعم أو تحديد نطاق طلبات API لهذه المؤسسة. ليس بيانات اعتماد تسجيل دخول.",
+    "source_hash": "29549b3a"
+  },
+  "web.organizations.audit.title": {
+    "text": "نشاط الأسرار",
+    "source_hash": "6d6d41f3"
+  },
+  "web.organizations.audit.description": {
+    "text": "سجل تدقيق لأحداث إنشاء الأسرار والوصول إليها المسجلة لهذه المؤسسة.",
+    "source_hash": "553c564b"
+  },
+  "web.organizations.audit.country_unknown": {
+    "text": "غير معروف",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.empty_title": {
+    "text": "لا يوجد نشاط بعد",
+    "source_hash": "0a12b92c"
+  },
+  "web.organizations.audit.empty_description": {
+    "text": "ستظهر أحداث إنشاء الأسرار والوصول إليها هنا عندما يشارك فريقك الأسرار.",
+    "source_hash": "62fb14c2"
+  },
+  "web.organizations.audit.capped_notice": {
+    "text": "يتم الاحتفاظ فقط بأحدث {max} حدث؛ تم تقليم النشاط الأقدم.",
+    "source_hash": "da7901e2"
+  },
+  "web.organizations.audit.collection_paused_notice": {
+    "text": "جمع الأحداث متوقف مؤقتاً؛ لا يتم تسجيل نشاط الأسرار الجديد.",
+    "source_hash": "cb09d147"
+  },
+  "web.organizations.audit.load_error": {
+    "text": "تعذر تحميل نشاط الأسرار.",
+    "source_hash": "52fde814"
+  },
+  "web.organizations.audit.contract_mismatch": {
+    "text": "تعذرت قراءة بيانات النشاط التي أعادها الخادم. السجل ليس فارغاً — فقط لا يمكن عرضه الآن.",
+    "source_hash": "db0d007a"
+  },
+  "web.organizations.audit.retry": {
+    "text": "المحاولة مرة أخرى",
+    "source_hash": "d8b8392e"
+  },
+  "web.organizations.audit.showing_range": {
+    "text": "عرض {from}–{to} من {total}",
+    "source_hash": "c329279d"
+  },
+  "web.organizations.audit.upgrade_prompt": {
+    "text": "نشاط الأسرار يتطلب خطة مع سجلات التدقيق. قم بالترقية لرؤية من أنشأ وعرض وكشف الأسرار في هذه المؤسسة.",
+    "source_hash": "453649ce"
+  },
+  "web.organizations.audit.role_required": {
+    "text": "نشاط الأسرار متاح لمالكي المؤسسة والمشرفين.",
+    "source_hash": "e066ec63"
+  },
+  "web.organizations.audit.actors.creator": {
+    "text": "المنشئ",
+    "source_hash": "88447b83"
+  },
+  "web.organizations.audit.actors.authenticated_other": {
+    "text": "مستخدم آخر مسجل الدخول",
+    "source_hash": "ee45aa5a"
+  },
+  "web.organizations.audit.actors.anonymous": {
+    "text": "مجهول",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.organizations.audit.actors.system": {
+    "text": "النظام",
+    "source_hash": "6725e7bb"
+  },
+  "web.organizations.audit.actors.unknown": {
+    "text": "غير معروف",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.columns.event": {
+    "text": "الحدث",
+    "source_hash": "4e1f49a9"
+  },
+  "web.organizations.audit.columns.secret": {
+    "text": "السر",
+    "source_hash": "7e32a729"
+  },
+  "web.organizations.audit.columns.actor": {
+    "text": "الفاعل",
+    "source_hash": "449995c4"
+  },
+  "web.organizations.audit.columns.country": {
+    "text": "البلد",
+    "source_hash": "701d021d"
+  },
+  "web.organizations.audit.columns.when": {
+    "text": "متى",
+    "source_hash": "cf9c7aa2"
+  },
+  "web.organizations.audit.kinds.created": {
+    "text": "تم إنشاء السر",
+    "source_hash": "e4a1e1fd"
+  },
+  "web.organizations.audit.kinds.status_get": {
+    "text": "تم التحقق من حالة الرابط",
+    "source_hash": "0753f60e"
+  },
+  "web.organizations.audit.kinds.secret_get": {
+    "text": "تم فتح رابط السر",
+    "source_hash": "e271e060"
+  },
+  "web.organizations.audit.kinds.previewed": {
+    "text": "تمت المعاينة من قبل المنشئ",
+    "source_hash": "639fc1e2"
+  },
+  "web.organizations.audit.kinds.creator_status_get": {
+    "text": "تم التحقق من الحالة من قبل المنشئ",
+    "source_hash": "7e4b5de5"
+  },
+  "web.organizations.audit.kinds.receipt_viewed": {
+    "text": "تم عرض الإيصال",
+    "source_hash": "a417ead4"
+  },
+  "web.organizations.audit.kinds.revealed": {
+    "text": "تم الكشف عن السر",
+    "source_hash": "aff2c84d"
+  },
+  "web.organizations.audit.kinds.burned": {
+    "text": "تم حذف السر نهائياً",
+    "source_hash": "5ac68dc6"
+  },
+  "web.organizations.audit.kinds.expired": {
+    "text": "انتهت صلاحية السر",
+    "source_hash": "c127dab6"
+  },
+  "web.organizations.audit.kinds.orphaned": {
+    "text": "أصبح السر يتيماً",
+    "source_hash": "23fe1a47"
+  },
+  "web.organizations.audit.kinds.reveal_failed_undecryptable": {
+    "text": "فشل الكشف (غير قابل لفك التشفير)",
+    "source_hash": "d5616abf"
+  },
+  "web.organizations.tabs.activity": {
+    "text": "النشاط",
+    "source_hash": "38da1505"
   }
 }


### PR DESCRIPTION
## `ar` translation update

Automated export of completed **ar** translations from the translation task DB.
Scope: `locales/content/ar/` only — 16 file(s), +2020/-20.

⚠️ `i18n validate variables` reports **3** variable mismatch(es) for `ar` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ✅ Looks good — validator hits are known false positives.

**Summary:** Large batch of new/updated `ar` strings across admin, auth, email, and workspace modules; spot-checked placeholders, brand terms, and RTL punctuation with no defects found.

**Critical (must fix):** None.

**Warnings:** None.

**Notes:**
- The 3 flagged "empty with missing vars" errors (`connect_action.context`, `link_sso.prompt.context`, `sso_link_confirm.prompt.context`) are `.context` fields — English-only translator-note metadata, never translated/exported. `locales/scripts/export-all.sh` explicitly documents and excludes these same three keys from its gate for this exact reason. Not a real defect.
- All `{var}`/`%{var}` placeholders sampled across `admin-domains`, `admin-organizations`, `admin-customers`, `session-auth-extended`, and `email.json` preserve the source set/count correctly (e.g. `{domain}`/`{kind}`, `%{provider}`/`%{product_name}`, `{provider}`/`{email}` in the new SSO-linking strings).
- Modified (not just added) entries — `admin-customers.description`, several `admin-secrets` keys, and 3 `workspace-branding` strings — were diffed against current `en` source; all match the updated English wording and `content_hash`, confirming they track a source text change rather than translation drift.
- Arabic question mark (`؟`) and comma (`،`) used consistently in new confirm dialogs; no mojibake or encoding artifacts observed.
- A few technical acronyms/identifiers (`MFA`, `TLS`, `API`, `identity_plus_v1`) are left in Latin script — expected/acceptable, consistent with existing convention.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
