### PR TITLE
i18n: update fr_FR translations

### DIFF
--- a/locales/content/fr_FR/00-common.json
+++ b/locales/content/fr_FR/00-common.json
@@ -5,7 +5,7 @@
     "note": "empty"
   },
   "web.COMMON.tagline": {
-    "text": "Des liens sécurisés à usage unique",
+    "text": "Des liens sécurisés qui ne fonctionnent qu'une seule fois",
     "source_hash": "9da7aece"
   },
   "web.COMMON.powered_by": {
@@ -13,7 +13,7 @@
     "source_hash": "fdc5d2e9"
   },
   "web.COMMON.website_url": {
-    "text": "https://onetimesecret.com/fr",
+    "text": "https://onetimesecret.com/en",
     "source_hash": "440f5303"
   },
   "web.COMMON.button_generate_secret_short": {
@@ -21,7 +21,7 @@
     "source_hash": "fdcbfcc7"
   },
   "web.COMMON.generate_password_disabled": {
-    "text": "Générer un mot de passe est désactivé lorsque le formulaire est valide",
+    "text": "La génération de mot de passe est désactivée lorsque le formulaire est valide",
     "source_hash": "dc0e2b8c"
   },
   "web.COMMON.email_placeholder": {
@@ -37,7 +37,7 @@
     "source_hash": "6170ab94"
   },
   "web.COMMON.custom_domains_description": {
-    "text": "Renforcez les liens et établissez la confiance avec vos propres liens secrets personnalisés.",
+    "text": "Renforcez vos relations et instaurez la confiance avec vos propres liens secrets personnalisés.",
     "source_hash": "71fddc05"
   },
   "web.COMMON.get_started_button": {
@@ -57,7 +57,7 @@
     "source_hash": "155f816c"
   },
   "web.COMMON.submitting": {
-    "text": "Envoi en cours...",
+    "text": "Envoi...",
     "source_hash": "64115d5b"
   },
   "web.COMMON.processing": {
@@ -65,7 +65,7 @@
     "source_hash": "f40a853e"
   },
   "web.COMMON.description": {
-    "text": "Gardez les informations sensibles hors de vos historiques de conversation et e-mails. Partagez un lien secret qui n'est disponible qu'une seule fois.",
+    "text": "Gardez les informations sensibles hors de vos messageries et de vos journaux de discussion. Partagez un lien secret consultable une seule fois.",
     "source_hash": "4c895f85"
   },
   "web.COMMON.incorrect_passphrase": {
@@ -73,7 +73,7 @@
     "source_hash": "a55f9636"
   },
   "web.COMMON.keywords": {
-    "text": "secret,générateur de mot de passe,partager un secret,usage unique",
+    "text": "secret,générateur de mot de passe,partager un secret,onetime",
     "source_hash": "52728258"
   },
   "web.COMMON.button_create_secret": {
@@ -101,7 +101,7 @@
     "source_hash": "f6f6311d"
   },
   "web.COMMON.secret_placeholder": {
-    "text": "Saisissez votre contenu secret ici...",
+    "text": "Le contenu secret va ici...",
     "source_hash": "54630bab"
   },
   "web.COMMON.header_create_account": {
@@ -113,7 +113,7 @@
     "source_hash": "4efca0d1"
   },
   "web.COMMON.header_sign_in": {
-    "text": "Connexion",
+    "text": "Se connecter",
     "source_hash": "bcc0bcc9"
   },
   "web.COMMON.header_dashboard": {
@@ -129,7 +129,7 @@
     "source_hash": "c7ebd045"
   },
   "web.COMMON.recent": {
-    "text": "Récent",
+    "text": "Récents",
     "source_hash": "690dbe9d"
   },
   "web.COMMON.not_set": {
@@ -161,7 +161,7 @@
     "source_hash": "ffff30e8"
   },
   "web.COMMON.burn_this_secret_hint": {
-    "text": "Brûler un secret le supprimera avant qu'il n'ait été lu (cliquer pour confirmer)",
+    "text": "Brûler un secret le supprimera avant qu'il ne soit lu (cliquez pour confirmer)",
     "source_hash": "c6a8b145"
   },
   "web.COMMON.burn_this_secret_confirm_hint": {
@@ -169,15 +169,15 @@
     "source_hash": "ab774967"
   },
   "web.COMMON.msg_check_email": {
-    "text": "Vérifiez vos e-mails",
+    "text": "Consultez votre messagerie",
     "source_hash": "77322879"
   },
   "web.COMMON.click_to_continue": {
-    "text": "Cliquer pour révéler →",
+    "text": "Cliquez pour révéler →",
     "source_hash": "41658f99"
   },
   "web.COMMON.click_to_verify": {
-    "text": "Continuer pour vérifier votre compte :",
+    "text": "Continuez pour vérifier votre compte :",
     "source_hash": "954d6fc9"
   },
   "web.COMMON.error_secret": {
@@ -185,7 +185,7 @@
     "source_hash": "9ac6488f"
   },
   "web.COMMON.error_passphrase": {
-    "text": "Vérifiez cette phrase secrète",
+    "text": "Vérifiez à nouveau cette phrase secrète",
     "source_hash": "b582f3a6"
   },
   "web.COMMON.enter_passphrase_here": {
@@ -193,11 +193,11 @@
     "source_hash": "ee855dad"
   },
   "web.COMMON.view_secret": {
-    "text": "Voir le secret",
+    "text": "Consulter le secret",
     "source_hash": "01835e7c"
   },
   "web.COMMON.careful_only_see_once": {
-    "text": "Attention : nous ne l'afficherons qu'une seule fois.",
+    "text": "Attention : nous ne l'afficherons qu'une seule fois.",
     "source_hash": "d29e2820"
   },
   "web.COMMON.warning": {
@@ -205,7 +205,7 @@
     "source_hash": "e981ddae"
   },
   "web.COMMON.oops": {
-    "text": "Oups !",
+    "text": "Oups !",
     "source_hash": "8344947a"
   },
   "web.COMMON.error": {
@@ -213,7 +213,7 @@
     "source_hash": "54a0e8c1"
   },
   "web.COMMON.unexpected_error": {
-    "text": "Une erreur inattendue est survenue. Veuillez réessayer.",
+    "text": "Une erreur inattendue s'est produite. Veuillez réessayer.",
     "source_hash": "e198269c"
   },
   "web.COMMON.secret_was_truncated": {
@@ -221,7 +221,7 @@
     "source_hash": "1d1730d4"
   },
   "web.COMMON.signup_for_more": {
-    "text": "Inscrivez-vous pour plus",
+    "text": "Inscrivez-vous pour en savoir plus",
     "source_hash": "cc1421d0"
   },
   "web.COMMON.login_to_your_account": {
@@ -229,7 +229,7 @@
     "source_hash": "62f1fe13"
   },
   "web.COMMON.sent_to": {
-    "text": "Envoyé à :",
+    "text": "Envoyé à : ",
     "source_hash": "e79c8bcb"
   },
   "web.COMMON.field_email": {
@@ -289,11 +289,11 @@
     "source_hash": "76900f1b"
   },
   "web.COMMON.feedback_text": {
-    "text": "Partagez vos réflexions, idées ou expériences...",
+    "text": "Partagez vos réflexions, vos idées ou vos expériences...",
     "source_hash": "6bd0351a"
   },
   "web.COMMON.button_send_feedback": {
-    "text": "Envoyer un commentaire",
+    "text": "Envoyer les commentaires",
     "source_hash": "84195de9"
   },
   "web.COMMON.verification_sent_to": {
@@ -305,11 +305,11 @@
     "source_hash": "fd3610bf"
   },
   "web.COMMON.signup_success_generic": {
-    "text": "Si un compte existe avec cet e-mail, vous recevrez un e-mail de vérification.",
+    "text": "Si un compte associé à cette adresse e-mail existe, vous recevrez un e-mail de vérification.",
     "source_hash": "f596cdd0"
   },
   "web.COMMON.burn_this_secret_aria": {
-    "text": "Brûler ce secret définitivement",
+    "text": "Brûler définitivement ce secret",
     "source_hash": "0a7afc29"
   },
   "web.COMMON.burn_confirmation_title": {
@@ -317,7 +317,7 @@
     "source_hash": "dcd78dfb"
   },
   "web.COMMON.burn_confirmation_message": {
-    "text": "Êtes-vous sûr de vouloir brûler ce secret ? Cette action est irréversible.",
+    "text": "Voulez-vous vraiment brûler ce secret ? Cette action est irréversible.",
     "source_hash": "5dde5dd9"
   },
   "web.COMMON.confirm_burn": {
@@ -325,11 +325,11 @@
     "source_hash": "6e5b02a7"
   },
   "web.COMMON.burn_security_notice": {
-    "text": "Brûler un secret le supprimera avant qu'il n'ait été reçu.",
+    "text": "Brûler un secret le supprimera avant qu'il ne soit reçu.",
     "source_hash": "b4c8bbc3"
   },
   "web.COMMON.share_link_securely": {
-    "text": "Pour la sécurité, partagez ce lien séparément des autres informations.",
+    "text": "Par sécurité, partagez ce lien séparément des autres informations.",
     "source_hash": "c46e6204"
   },
   "web.COMMON.copied_to_clipboard": {
@@ -337,7 +337,7 @@
     "source_hash": "d37078fe"
   },
   "web.COMMON.button_create_incoming": {
-    "text": "Créer une réception",
+    "text": "Créer un secret entrant",
     "source_hash": "5bb95106"
   },
   "web.COMMON.faq_title": {
@@ -361,11 +361,11 @@
     "source_hash": "a60a56c5"
   },
   "web.COMMON.minimum_8_characters": {
-    "text": "Le mot de passe doit contenir au moins 8 caractères",
+    "text": "Le mot de passe doit comporter au moins 8 caractères",
     "source_hash": "e3b8d09d"
   },
   "web.COMMON.password_requirements": {
-    "text": "Le mot de passe doit contenir au moins 8 caractères",
+    "text": "Le mot de passe doit comporter au moins 8 caractères",
     "source_hash": "e5054833"
   },
   "web.COMMON.passwords_do_not_match": {
@@ -393,7 +393,7 @@
     "source_hash": "31fbef16"
   },
   "web.COMMON.are_you_sure": {
-    "text": "Êtes-vous sûr ?",
+    "text": "Voulez-vous vraiment continuer ?",
     "source_hash": "f0762c4f"
   },
   "web.COMMON.danger_zone": {
@@ -401,7 +401,7 @@
     "source_hash": "3c1c01b4"
   },
   "web.COMMON.caution_zone": {
-    "text": "Zone de prudence",
+    "text": "Zone à considérer avec prudence",
     "source_hash": "fe27a3a8"
   },
   "web.COMMON.user_menu": {
@@ -429,7 +429,7 @@
     "source_hash": "dc85af8f"
   },
   "web.COMMON.adding_ellipses": {
-    "text": "Ajout en cours",
+    "text": "Ajout",
     "source_hash": "0a6691ef"
   },
   "web.COMMON.e_g_example": {
@@ -441,7 +441,7 @@
     "source_hash": "cc921aaa"
   },
   "web.COMMON.status": {
-    "text": "Statut",
+    "text": "État",
     "source_hash": "920e413c"
   },
   "web.COMMON.escape": {
@@ -461,7 +461,7 @@
     "source_hash": "c3812fc4"
   },
   "web.COMMON.press_esc_to_close": {
-    "text": "Appuyez sur Échap pour fermer",
+    "text": "Appuyez sur ÉCHAP pour fermer",
     "source_hash": "5aa83883"
   },
   "web.COMMON.enter": {
@@ -497,7 +497,7 @@
     "source_hash": "c910d474"
   },
   "web.COMMON.note": {
-    "text": "Note",
+    "text": "Remarque",
     "source_hash": "d8da2c49"
   },
   "web.COMMON.monthly": {
@@ -533,7 +533,7 @@
     "source_hash": "f2488fd4"
   },
   "web.COMMON.switch": {
-    "text": "basculer",
+    "text": "changer",
     "source_hash": "78b49fb2"
   },
   "web.COMMON.features": {
@@ -581,7 +581,7 @@
     "source_hash": "8b3795aa"
   },
   "web.COMMON.email_address_copied_to_clipboard": {
-    "text": "Adresse e-mail copiée dans le presse-papiers !",
+    "text": "Adresse e-mail copiée dans le presse-papiers !",
     "source_hash": "23238b4e"
   },
   "web.COMMON.value": {
@@ -605,27 +605,27 @@
     "source_hash": "1ff57a29"
   },
   "web.COMMON.password_strength": {
-    "text": "Robustesse du mot de passe :",
+    "text": "Robustesse du mot de passe :",
     "source_hash": "663d6499"
   },
   "web.COMMON.great": {
-    "text": "Très bien",
+    "text": "Excellente",
     "source_hash": "c8cc1c7b"
   },
   "web.COMMON.pretty_good": {
-    "text": "Plutôt bien",
+    "text": "Plutôt bonne",
     "source_hash": "521a41b6"
   },
   "web.COMMON.fair": {
-    "text": "Correct",
+    "text": "Correcte",
     "source_hash": "f7b19afc"
   },
   "web.COMMON.meh": {
-    "text": "Bof",
+    "text": "Passable",
     "source_hash": "8b0d6190"
   },
   "web.COMMON.not_great": {
-    "text": "Pas terrible",
+    "text": "Insuffisante",
     "source_hash": "00561207"
   },
   "web.COMMON.open_options": {
@@ -637,7 +637,7 @@
     "source_hash": "ac7c949f"
   },
   "web.COMMON.an_error_occurred": {
-    "text": "Une erreur est survenue",
+    "text": "Une erreur s'est produite",
     "source_hash": "ddf785b7"
   },
   "web.COMMON.copy_secret_to_clipboard": {
@@ -649,11 +649,11 @@
     "source_hash": "da84ff02"
   },
   "web.COMMON.double_check_that_passphrase": {
-    "text": "Vérifiez cette phrase secrète",
+    "text": "Vérifiez à nouveau cette phrase secrète",
     "source_hash": "b582f3a6"
   },
   "web.COMMON.press_copy_button_below": {
-    "text": "Appuyez sur le bouton copier ci-dessous.",
+    "text": "Appuyez sur le bouton de copie ci-dessous.",
     "source_hash": "77fcf6fb"
   },
   "web.COMMON.external_link": {
@@ -741,11 +741,11 @@
     "source_hash": "f45aef6e"
   },
   "web.LABELS.secret_status": {
-    "text": "Statut du secret",
+    "text": "État du secret",
     "source_hash": "57330d93"
   },
   "web.LABELS.need_help": {
-    "text": "Besoin d'aide ?",
+    "text": "Besoin d'aide ?",
     "source_hash": "c225cdfb"
   },
   "web.LABELS.create_new_secret": {
@@ -765,7 +765,7 @@
     "source_hash": "b749e205"
   },
   "web.LABELS.receipts": {
-    "text": "Accusés de réception",
+    "text": "Reçus",
     "source_hash": "60a627df"
   },
   "web.LABELS.share": {
@@ -793,11 +793,11 @@
     "source_hash": "48187543"
   },
   "web.LABELS.view": {
-    "text": "Voir",
+    "text": "Consulter",
     "source_hash": "dcc839a4"
   },
   "web.LABELS.views": {
-    "text": "Vues",
+    "text": "Consultations",
     "source_hash": "69c40459"
   },
   "web.LABELS.times_viewed": {
@@ -805,7 +805,7 @@
     "source_hash": "73758343"
   },
   "web.LABELS.view_progress": {
-    "text": "Voir la progression",
+    "text": "Progression des consultations",
     "source_hash": "6c072c1f"
   },
   "web.LABELS.help_section": {
@@ -813,11 +813,11 @@
     "source_hash": "614e14f0"
   },
   "web.LABELS.passphrase_protected": {
-    "text": "Protégé par phrase secrète",
+    "text": "Protégé par une phrase secrète",
     "source_hash": "a52b9edf"
   },
   "web.LABELS.feedback_received": {
-    "text": "Commentaire reçu.",
+    "text": "Commentaires reçus.",
     "source_hash": "3fa595ef"
   },
   "web.LABELS.sending_ellipses": {
@@ -849,7 +849,7 @@
     "source_hash": "83b12c22"
   },
   "web.LABELS.caption_recent_secrets": {
-    "text": "Liens secrets créés lors de cette session",
+    "text": "Liens secrets créés durant cette session",
     "source_hash": "6c7ceab8"
   },
   "web.LABELS.create_link_short": {
@@ -882,7 +882,7 @@
     "source_hash": "57db069e"
   },
   "web.LABELS.scope_indicator": {
-    "text": "Création de secrets dans {domain}",
+    "text": "Création de secrets sur {domain}",
     "source_hash": "3bbed96b"
   },
   "web.STATUS.new": {
@@ -902,7 +902,7 @@
     "source_hash": "49f19bee"
   },
   "web.STATUS.previewed": {
-    "text": "Prévisualisé",
+    "text": "Aperçu",
     "source_hash": "3d391a9b"
   },
   "web.STATUS.revealed": {
@@ -990,7 +990,7 @@
     "source_hash": "e182e8f4"
   },
   "web.STATUS.orphaned_description": {
-    "text": "Le secret a été orphelin et sera bientôt détruit",
+    "text": "Le secret est orphelin et sera bientôt détruit",
     "source_hash": "49b87422"
   },
   "web.STATUS.expired_description": {
@@ -1002,7 +1002,7 @@
     "source_hash": "c88a0b90"
   },
   "web.STATUS.delivered": {
-    "text": "Livré",
+    "text": "Remis",
     "source_hash": "90611565"
   },
   "web.STATUS.dns_incorrect": {
@@ -1018,11 +1018,11 @@
     "source_hash": "ac7c949f"
   },
   "web.FEATURES.unlimited_views": {
-    "text": "Vues illimitées",
+    "text": "Consultations illimitées",
     "source_hash": "3f6859b0"
   },
   "web.FEATURES.custom_domain_protected": {
-    "text": "Image de marque sur domaine de confiance",
+    "text": "Personnalisation avec un domaine de confiance",
     "source_hash": "5e39b05c"
   },
   "web.FEATURES.encrypted_in_transit": {
@@ -1054,7 +1054,7 @@
     "source_hash": "cb3f91d5"
   },
   "web.UNITS.ttl_remaining.duration": {
-    "text": "{count} {unit} restantes",
+    "text": "{count} {unit} restant",
     "source_hash": "18f6c6e8"
   },
   "web.UNITS.ttl_remaining.time.day": {
@@ -1106,7 +1106,7 @@
     "source_hash": "b79cac92"
   },
   "web.TITLES.signin": {
-    "text": "Connexion",
+    "text": "Se connecter",
     "source_hash": "bcc0bcc9"
   },
   "web.TITLES.signup": {
@@ -1122,7 +1122,7 @@
     "source_hash": "4e70f1fd"
   },
   "web.TITLES.logout": {
-    "text": "Déconnexion en cours",
+    "text": "Déconnexion",
     "source_hash": "afbce8a6"
   },
   "web.TITLES.verify_account": {
@@ -1150,7 +1150,7 @@
     "source_hash": "c11bd410"
   },
   "web.TITLES.receipt": {
-    "text": "Accusé de réception du secret",
+    "text": "Reçu du secret",
     "source_hash": "fe0c79e9"
   },
   "web.TITLES.burn_secret": {
@@ -1178,7 +1178,7 @@
     "source_hash": "b416f537"
   },
   "web.TITLES.domain_brand": {
-    "text": "Domaine de marque",
+    "text": "Personnalisation du domaine",
     "source_hash": "35e4dfbe"
   },
   "web.TITLES.account": {
@@ -1218,11 +1218,11 @@
     "source_hash": "78801183"
   },
   "web.TITLES.change_email": {
-    "text": "Modifier l'e-mail",
+    "text": "Modifier l'adresse e-mail",
     "source_hash": "18c3f2d5"
   },
   "web.TITLES.confirm_email_change": {
-    "text": "Confirmer le changement d'e-mail",
+    "text": "Confirmer le changement d'adresse e-mail",
     "source_hash": "c2736949"
   },
   "web.TITLES.security_overview": {
@@ -1251,7 +1251,7 @@
     "source_hash": "c87ccdb4"
   },
   "web.TITLES.api_settings": {
-    "text": "Paramètres API",
+    "text": "Paramètres de l'API",
     "source_hash": "6c2a9675"
   },
   "web.TITLES.advanced_settings": {
@@ -1295,19 +1295,19 @@
     "source_hash": "c348d386"
   },
   "web.INSTRUCTION.secure_channel_instruction": {
-    "text": "Utilisez un canal sécurisé différent pour partager les informations sensibles",
+    "text": "Utilisez un autre canal sécurisé pour partager les informations sensibles",
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Vérifiez toujours que vous êtes sur le site officiel {product_name}. Des fraudeurs créent parfois de faux sites web identiques à {product_name} pour voler vos secrets. Pour éviter les attaques par hameçonnage, vérifiez le domaine de la région dans votre barre d'adresse avant de créer de nouveaux liens.",
+    "text": "Vérifiez toujours que vous êtes sur le site officiel de {product_name}. Des fraudeurs créent parfois de faux sites qui ressemblent exactement à {product_name} pour voler vos secrets. Pour éviter les attaques par hameçonnage, vérifiez le domaine régional dans votre barre d'adresse avant de créer de nouveaux liens.",
     "source_hash": "2e3b856e"
   },
   "web.pricing.title": {
-    "text": "Tarification simple et transparente",
+    "text": "Une tarification simple et transparente",
     "source_hash": "97e283c7"
   },
   "web.pricing.subtitle": {
-    "text": "Choisissez le forfait qui correspond à vos besoins. Tous les forfaits incluent le partage illimité de secrets et une conception axée sur la confidentialité.",
+    "text": "Choisissez le forfait adapté à vos besoins. Tous les forfaits incluent le partage illimité de secrets et une conception axée sur la confidentialité.",
     "source_hash": "9204dff4"
   },
   "web.pricing.get_started_free": {
@@ -1319,7 +1319,7 @@
     "source_hash": "983f3110"
   },
   "web.pricing.already_have_account": {
-    "text": "Vous avez déjà un compte ?",
+    "text": "Vous avez déjà un compte ?",
     "source_hash": "e77fea93"
   },
   "web.pricing.sign_in": {
@@ -1355,7 +1355,7 @@
     "source_hash": "3a4f2bc0"
   },
   "web.COMMON.enter_password_to_continue": {
-    "text": "Entrez votre mot de passe pour continuer",
+    "text": "Saisissez votre mot de passe pour continuer",
     "context": "Prompt for password confirmation modal",
     "source_hash": "09055357"
   },
@@ -1380,7 +1380,7 @@
     "source_hash": "fb961f3f"
   },
   "web.COMMON.upgrade_description": {
-    "text": "Mettre à niveau pour débloquer plus de fonctionnalités",
+    "text": "Mettez à niveau pour débloquer davantage de fonctionnalités",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
   },
@@ -1421,7 +1421,7 @@
     "source_hash": "46832415"
   },
   "web.COMMON.http_status": {
-    "text": "Statut HTTP",
+    "text": "État HTTP",
     "source_hash": "b2a629f2"
   },
   "web.COMMON.details": {
@@ -1457,11 +1457,11 @@
     "source_hash": "61b94846"
   },
   "web.COMMON.copy_id": {
-    "text": "Copier l'ID du compte",
+    "text": "Copier l'identifiant du compte",
     "source_hash": "fd493ffd"
   },
   "web.COMMON.org_id_tooltip": {
-    "text": "L'identifiant unique de votre organisation",
+    "text": "Identifiant unique de votre organisation",
     "source_hash": "c8c08d29"
   },
   "web.COMMON.success": {
@@ -1493,7 +1493,7 @@
     "source_hash": "d1a5fc0c"
   },
   "web.LABELS.copied_icon": {
-    "text": "Icône de copie effectuée",
+    "text": "Icône copié",
     "source_hash": "90a4b4f1"
   },
   "web.STATUS.unverified": {
@@ -1513,11 +1513,11 @@
     "source_hash": "13161464"
   },
   "web.TITLES.domain_signup": {
-    "text": "Validation de l'inscription au domaine",
+    "text": "Validation des inscriptions du domaine",
     "source_hash": "c8ce809a"
   },
   "web.TITLES.domain_email": {
-    "text": "Configuration de l'e-mail",
+    "text": "Configuration des e-mails",
     "source_hash": "6f38aa51"
   },
   "web.TITLES.domain_incoming": {
@@ -1533,11 +1533,15 @@
     "source_hash": "0a4e0b71"
   },
   "web.TITLES.check_email": {
-    "text": "Vérification de votre e-mail",
+    "text": "Consultez votre messagerie",
     "source_hash": "0e5fc27d"
   },
   "web.TITLES.domain_dns": {
     "text": "Configuration DNS",
     "source_hash": "6c63df31"
+  },
+  "web.TITLES.connected_identities": {
+    "text": "Identités connectées",
+    "source_hash": "e132c4d9"
   }
 }

--- a/locales/content/fr_FR/00-common.json
+++ b/locales/content/fr_FR/00-common.json
@@ -13,7 +13,7 @@
     "source_hash": "fdc5d2e9"
   },
   "web.COMMON.website_url": {
-    "text": "https://onetimesecret.com/en",
+    "text": "https://onetimesecret.com/fr",
     "source_hash": "440f5303"
   },
   "web.COMMON.button_generate_secret_short": {

--- a/locales/content/fr_FR/10-layout.json
+++ b/locales/content/fr_FR/10-layout.json
@@ -1,10 +1,10 @@
 {
   "web.footer.api_docs": {
-    "text": "Documentation API",
+    "text": "Documentation de l'API",
     "source_hash": "f4137804"
   },
   "web.footer.branding_guide": {
-    "text": "Guide de marque",
+    "text": "Guide de personnalisation",
     "source_hash": "53f994c5"
   },
   "web.footer.customize": {
@@ -20,7 +20,7 @@
     "source_hash": "8f6fb4eb"
   },
   "web.footer.learn_about_our_security_measures": {
-    "text": "En savoir plus sur nos mesures de sécurité",
+    "text": "Découvrez nos mesures de sécurité",
     "source_hash": "16c8adae"
   },
   "web.footer.view_our_terms_and_conditions": {
@@ -48,7 +48,7 @@
     "source_hash": "0a410c78"
   },
   "web.feedback.when_you_submit_feedback_well_see": {
-    "text": "Lorsque vous envoyez un commentaire, nous verrons :",
+    "text": "Lorsque vous envoyez des commentaires, nous voyons :",
     "source_hash": "fe77172e"
   },
   "web.footer.read_our_privacy_policy": {
@@ -60,7 +60,7 @@
     "source_hash": "1f04937e"
   },
   "web.footer.explore_our_api_documentation": {
-    "text": "Explorer notre documentation API",
+    "text": "Explorer la documentation de notre API",
     "source_hash": "45beb8f8"
   },
   "web.footer.docs": {
@@ -124,19 +124,19 @@
     "source_hash": "4d4a570f"
   },
   "web.meta.were_making_onetime_secret_available_in_multiple": {
-    "text": "Nous rendons {onetime-secret} disponible en plusieurs langues. Cette fonctionnalité étant nouvelle, vous pourriez rencontrer des erreurs de traduction ou des formulations maladroites. Vos retours nous aident à améliorer le service. Si vous repérez des problèmes, veuillez {send-feedback}",
+    "text": "Nous rendons {onetime-secret} disponible en plusieurs langues. Comme il s'agit d'une nouvelle fonctionnalité, vous pourriez rencontrer des erreurs de traduction ou des formulations maladroites. Vos commentaires nous aident à nous améliorer - si vous repérez un problème, veuillez {send-feedback}",
     "source_hash": "3b482d7f"
   },
   "web.meta.translations_are_new_spotted_an_error": {
-    "text": "Les traductions sont nouvelles. Vous avez repéré une erreur ? {send-feedback}",
+    "text": "Les traductions sont récentes. Vous avez repéré une erreur ? {send-feedback}",
     "source_hash": "31eca08d"
   },
   "web.meta.we_recently_added_translations": {
-    "text": "Nous avons récemment ajouté des traductions. Vous avez repéré une erreur ? {send-feedback}",
+    "text": "Nous avons récemment ajouté des traductions. Vous avez repéré une erreur ? {send-feedback}",
     "source_hash": "6e2455c1"
   },
   "web.meta.privacy_and_security_should_be_accessible": {
-    "text": "La confidentialité et la sécurité doivent être accessibles à tous, quelle que soit la langue. Nous ajoutons des traductions pour aider nos utilisateurs et les destinataires de leurs messages à mieux comprendre comment utiliser et accéder en toute sécurité aux messages et liens sécurisés. Cette fonctionnalité étant nouvelle, vous pourriez rencontrer des erreurs de traduction ou des instructions peu claires. Pour nous aider à améliorer la clarté et l'exactitude de nos traductions, en particulier pour le contenu critique lié à la sécurité, veuillez {send-feedback} si vous repérez des problèmes",
+    "text": "La confidentialité et la sécurité doivent être accessibles à tous, quelle que soit la langue. Nous ajoutons des traductions pour aider nos utilisateurs et les destinataires de leurs messages à mieux comprendre comment utiliser et consulter en toute sécurité les messages et liens sécurisés. Comme il s'agit d'une nouvelle fonctionnalité, vous pourriez rencontrer des erreurs de traduction ou des instructions peu claires. Pour nous aider à améliorer la clarté et l'exactitude de nos traductions, en particulier pour les contenus critiques liés à la sécurité, veuillez {send-feedback} si vous repérez un problème",
     "source_hash": "1b8bb38f"
   },
   "web.help.learn_more": {
@@ -144,7 +144,7 @@
     "source_hash": "1445799c"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.title": {
-    "text": "Que suis-je en train de regarder ?",
+    "text": "Qu'est-ce que je consulte ?",
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
@@ -152,15 +152,15 @@
     "source_hash": "7a4e9d16"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
-    "text": "Puis-je consulter ce secret à nouveau plus tard ?",
+    "text": "Puis-je consulter ce secret à nouveau plus tard ?",
     "source_hash": "c8c2c9da"
   },
   "web.help.secret_view_faq.can_i_view_again.description": {
-    "text": "Non. Pour des raisons de sécurité, ce secret n'est consultable qu'une seule fois. Après avoir fermé cette page, le contenu sera définitivement supprimé et ne pourra être récupéré par personne, y compris nous.",
+    "text": "Non. Pour des raisons de sécurité, ce secret n'est consultable qu'une seule fois. Après la fermeture de cette page, le contenu sera définitivement supprimé et ne pourra être récupéré par personne, pas même par nous.",
     "source_hash": "4bf980a4"
   },
   "web.help.secret_view_faq.how_to_copy.title": {
-    "text": "Comment enregistrer ces informations ?",
+    "text": "Comment puis-je enregistrer ces informations ?",
     "source_hash": "90deddbb"
   },
   "web.help.secret_view_faq.how_to_copy.description": {
@@ -168,19 +168,19 @@
     "source_hash": "440aa828"
   },
   "web.help.secret_view_faq.is_my_viewing_tracked.title": {
-    "text": "Ma consultation de ce secret est-elle suivie ?",
+    "text": "Ma consultation de ce secret est-elle suivie ?",
     "source_hash": "90145e28"
   },
   "web.help.secret_view_faq.is_my_viewing_tracked.description": {
-    "text": "L'expéditeur sera informé que son secret a été consulté, mais nous ne suivons pas qui l'a consulté ni depuis quel endroit. Votre vie privée est protégée.",
+    "text": "L'expéditeur sera informé que son secret a été consulté, mais nous n'enregistrons ni qui l'a consulté ni depuis quel endroit. Votre vie privée est protégée.",
     "source_hash": "70737473"
   },
   "web.help.secret_view_faq.one_time_warning": {
-    "text": "Une fois que vous quittez ou actualisez cette page, ce secret sera définitivement supprimé et ne pourra être récupéré par personne.",
+    "text": "Dès que vous quitterez ou actualiserez cette page, ce secret sera définitivement supprimé et ne pourra être récupéré par personne.",
     "source_hash": "47feab6e"
   },
   "web.layout.go_back_to_previous_page": {
-    "text": "Retour à la page précédente",
+    "text": "Revenir à la page précédente",
     "source_hash": "1778f2e7"
   },
   "web.layout.site_footer": {
@@ -188,11 +188,11 @@
     "source_hash": "6ca09429"
   },
   "web.layout.toggle_dark_mode": {
-    "text": "Activer/désactiver le mode sombre",
+    "text": "Basculer le mode sombre",
     "source_hash": "ffe32a00"
   },
   "web.layout.provide_feedback": {
-    "text": "Donner un commentaire",
+    "text": "Envoyer des commentaires",
     "source_hash": "a70766ae"
   },
   "web.layout.company_logo": {
@@ -200,7 +200,7 @@
     "source_hash": "87a86135"
   },
   "web.layout.brand_logo": {
-    "text": "Logo de marque",
+    "text": "Logo de la marque",
     "source_hash": "e458e2b5"
   },
   "web.layout.dashboard_navigation": {
@@ -224,7 +224,7 @@
     "source_hash": "bd4702c1"
   },
   "web.layout.loading_settings_content": {
-    "text": "Chargement du contenu des paramètres...",
+    "text": "Chargement des paramètres...",
     "source_hash": "81a2a30e"
   },
   "web.layout.settings_sections_0": {
@@ -240,7 +240,7 @@
     "source_hash": "e26d51d3"
   },
   "web.layout.customize_your_app_preferences_and_settings": {
-    "text": "Personnaliser les préférences et les paramètres de l'application",
+    "text": "Personnalisez vos préférences et paramètres d'application",
     "source_hash": "00d74c98"
   },
   "web.layout.return_home": {
@@ -248,7 +248,7 @@
     "source_hash": "bbcc935e"
   },
   "web.layout.return_to_home_page": {
-    "text": "Retour à la page d'accueil",
+    "text": "Revenir à la page d'accueil",
     "source_hash": "8d27b81d"
   },
   "web.layout.return_to_home": {
@@ -256,11 +256,11 @@
     "source_hash": "299291b0"
   },
   "web.layout.view_privacy_policy": {
-    "text": "Consulter la politique de confidentialité",
+    "text": "Voir la politique de confidentialité",
     "source_hash": "377733b6"
   },
   "web.layout.view_terms_of_service": {
-    "text": "Consulter les conditions d'utilisation",
+    "text": "Voir les conditions d'utilisation",
     "source_hash": "e2f124cd"
   },
   "web.layout.visit_onetime_secret_homepage": {
@@ -288,7 +288,7 @@
     "source_hash": "7c7afa99"
   },
   "web.layout.material_design_icons": {
-    "text": "Icônes Material Design",
+    "text": "Material Design Icons",
     "source_hash": "0fb27437"
   },
   "web.layout.heroicons": {
@@ -308,15 +308,15 @@
     "source_hash": "75e96614"
   },
   "web.layout.website_version_v_ot_version": {
-    "text": "Version du site : v{0}",
+    "text": "Version du site : v{0}",
     "source_hash": "343f57de"
   },
   "web.layout.current_language_is_currentlocal": {
-    "text": "Changer la langue. Langue actuelle : {0}",
+    "text": "Changer de langue. La langue actuelle est {0}",
     "source_hash": "77f9c322"
   },
   "web.layout.language_changed_to_newlocale": {
-    "text": "Langue modifiée en {0}",
+    "text": "Langue changée pour {0}",
     "source_hash": "1680f4fe"
   },
   "web.layout.reset_to_default_language": {
@@ -344,11 +344,11 @@
     "source_hash": "87bb59ba"
   },
   "web.help.default_content": {
-    "text": "Veuillez contacter le support pour obtenir de l'aide",
+    "text": "Veuillez contacter l'assistance pour obtenir de l'aide",
     "source_hash": "752bca14"
   },
   "web.layout.colonels_only_badge": {
-    "text": "Réservé aux colonels",
+    "text": "Colonels uniquement",
     "source_hash": "3f1e2dbd"
   }
 }

--- a/locales/content/fr_FR/admin-audit.json
+++ b/locales/content/fr_FR/admin-audit.json
@@ -4,7 +4,7 @@
     "source_hash": "47751f88"
   },
   "web.admin.audit.description": {
-    "text": "Chaque action d'administration modifiant des données, la plus récente en premier — qui a fait quoi à qui, et comment cela s'est déroulé.",
+    "text": "Chaque action d'administration modifiante, la plus récente en premier — qui a fait quoi, sur qui, et avec quel résultat.",
     "source_hash": "2326a1a0"
   },
   "web.admin.audit.categories.customer": {
@@ -98,5 +98,41 @@
   "web.admin.audit.result.failure": {
     "text": "Échec",
     "source_hash": "7031edbc"
+  },
+  "web.admin.audit.categories.secret": {
+    "text": "Secrets",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.audit.categories.membership": {
+    "text": "Adhésions",
+    "source_hash": "b50f1a42"
+  },
+  "web.admin.audit.categories.entitlement_preview": {
+    "text": "Aperçus des droits",
+    "source_hash": "255c5797"
+  },
+  "web.admin.audit.categories.colonel": {
+    "text": "Connexions des colonels",
+    "source_hash": "01eeeb38"
+  },
+  "web.admin.audit.filters.actorLabel": {
+    "text": "Acteur",
+    "source_hash": "449995c4"
+  },
+  "web.admin.audit.filters.searchButton": {
+    "text": "Rechercher",
+    "source_hash": "49c266ba"
+  },
+  "web.admin.audit.filters.searchHint": {
+    "text": "Saisissez un acteur, puis appuyez sur Entrée ou choisissez Rechercher pour lancer la recherche. La liste ne se met pas à jour pendant la saisie.",
+    "source_hash": "45eceb12"
+  },
+  "web.admin.audit.filters.pendingSearch": {
+    "text": "Recherche non effectuée — appuyez sur Entrée ou choisissez Rechercher pour appliquer cet acteur.",
+    "source_hash": "f76095c2"
+  },
+  "web.admin.audit.list.contractError": {
+    "text": "Le serveur a répondu, mais les données d'audit ne correspondent pas au format attendu. Aucun événement ne peut être affiché — il s'agit d'une erreur de restitution, et non d'un journal vide.",
+    "source_hash": "7f48137e"
   }
 }

--- a/locales/content/fr_FR/admin-bannedips.json
+++ b/locales/content/fr_FR/admin-bannedips.json
@@ -4,7 +4,7 @@
     "source_hash": "0ece5643"
   },
   "web.admin.bannedIps.description": {
-    "text": "Bannir et débannir des adresses IP au périmètre du site.",
+    "text": "Bannissez et débannissez des adresses IP au périmètre du site.",
     "source_hash": "69c0c992"
   },
   "web.admin.bannedIps.currentIp": {
@@ -48,11 +48,11 @@
     "source_hash": "f81ab834"
   },
   "web.admin.bannedIps.columns.bannedAt": {
-    "text": "Banni le",
+    "text": "Bannie le",
     "source_hash": "dfbd120e"
   },
   "web.admin.bannedIps.columns.bannedBy": {
-    "text": "Banni par",
+    "text": "Bannie par",
     "source_hash": "9f47db0e"
   },
   "web.admin.bannedIps.columns.actions": {
@@ -72,7 +72,7 @@
     "source_hash": "0f7d4664"
   },
   "web.admin.bannedIps.form.reasonPlaceholder": {
-    "text": "par ex. credential stuffing",
+    "text": "ex. bourrage d'identifiants",
     "source_hash": "828a15ae"
   },
   "web.admin.bannedIps.form.submit": {

--- a/locales/content/fr_FR/admin-banner.json
+++ b/locales/content/fr_FR/admin-banner.json
@@ -4,7 +4,7 @@
     "source_hash": "0bc449a3"
   },
   "web.admin.banner.description": {
-    "text": "Publier une annonce à l'échelle du site affichée à chaque visiteur, ou effacer l'annonce actuelle.",
+    "text": "Publiez une annonce visible sur tout le site par chaque visiteur, ou effacez l'annonce en cours.",
     "source_hash": "a0f720d7"
   },
   "web.admin.banner.loadError": {
@@ -24,7 +24,7 @@
     "source_hash": "46d9c35a"
   },
   "web.admin.banner.clear.confirmDescription": {
-    "text": "Cela supprime la bannière active pour chaque visiteur. Saisissez le mot de confirmation pour continuer.",
+    "text": "Cela supprime la bannière active pour tous les visiteurs. Saisissez le mot de confirmation pour continuer.",
     "source_hash": "9a56e4be"
   },
   "web.admin.banner.clear.success": {
@@ -40,7 +40,7 @@
     "source_hash": "487b2cac"
   },
   "web.admin.banner.current.status": {
-    "text": "Statut",
+    "text": "État",
     "source_hash": "920e413c"
   },
   "web.admin.banner.current.live": {
@@ -52,7 +52,7 @@
     "source_hash": "6956d814"
   },
   "web.admin.banner.current.persistent": {
-    "text": "Persistante (sans expiration)",
+    "text": "Permanente (sans expiration)",
     "source_hash": "5f95d1b0"
   },
   "web.admin.banner.current.expiresIn": {
@@ -60,11 +60,11 @@
     "source_hash": "f353f9a7"
   },
   "web.admin.banner.current.audience": {
-    "text": "Public",
+    "text": "Audience",
     "source_hash": "545c0235"
   },
   "web.admin.banner.current.storedContent": {
-    "text": "Contenu stocké",
+    "text": "Contenu enregistré",
     "source_hash": "3579f3e6"
   },
   "web.admin.banner.current.htmlNote": {
@@ -88,7 +88,7 @@
     "source_hash": "2f77668a"
   },
   "web.admin.banner.set.contentPlaceholder": {
-    "text": "Maintenance planifiée dim. 02:00 UTC",
+    "text": "Maintenance planifiée dimanche à 02h00 UTC",
     "source_hash": "4ec99d7d"
   },
   "web.admin.banner.set.contentHelp": {
@@ -100,7 +100,7 @@
     "source_hash": "72134116"
   },
   "web.admin.banner.set.ttlPlaceholder": {
-    "text": "Laisser vide pour aucune expiration",
+    "text": "Laissez vide pour aucune expiration",
     "source_hash": "a8fd81e1"
   },
   "web.admin.banner.set.ttlHelp": {
@@ -108,19 +108,19 @@
     "source_hash": "ba0237f5"
   },
   "web.admin.banner.set.scopeLabel": {
-    "text": "Public",
+    "text": "Audience",
     "source_hash": "545c0235"
   },
   "web.admin.banner.set.scopeHelp": {
-    "text": "Quelles pages affichent la bannière. Les pages de domaine personnalisé ne l'affichent que si l'option « toutes les pages » est sélectionnée.",
+    "text": "Les pages qui affichent la bannière. Les pages sur domaine personnalisé ne l'affichent que si l'option toutes les pages est choisie.",
     "source_hash": "28cc3018"
   },
   "web.admin.banner.set.scopeNoRecipient": {
-    "text": "Tout sauf les pages destinataires",
+    "text": "Tout sauf les pages des destinataires",
     "source_hash": "8575b3c0"
   },
   "web.admin.banner.set.scopeWorkspace": {
-    "text": "Pages d'espace de travail uniquement",
+    "text": "Pages de l'espace de travail uniquement",
     "source_hash": "563e003e"
   },
   "web.admin.banner.set.scopeAll": {
@@ -140,7 +140,7 @@
     "source_hash": "8b72b5c3"
   },
   "web.admin.banner.set.confirmDescription": {
-    "text": "Cette bannière sera affichée à chaque visiteur sur l'ensemble du site jusqu'à ce qu'elle soit effacée ou expire.",
+    "text": "Cette bannière sera affichée à tous les visiteurs sur l'ensemble du site jusqu'à ce qu'elle soit effacée ou qu'elle expire.",
     "source_hash": "c61bbec1"
   },
   "web.admin.banner.set.confirmButton": {

--- a/locales/content/fr_FR/admin-billing.json
+++ b/locales/content/fr_FR/admin-billing.json
@@ -4,7 +4,7 @@
     "source_hash": "bfde7e68"
   },
   "web.admin.billing.description": {
-    "text": "Vue en lecture seule des forfaits configurés et de leurs droits, ainsi que tout écart par rapport au catalogue synchronisé en direct avec Stripe.",
+    "text": "Vue en lecture seule des forfaits configurés et de leurs droits, ainsi que des écarts avec le catalogue synchronisé avec Stripe.",
     "source_hash": "05d5b332"
   },
   "web.admin.billing.retry": {
@@ -16,7 +16,7 @@
     "source_hash": "c3110f77"
   },
   "web.admin.billing.localConfigWarning": {
-    "text": "Le cache des forfaits synchronisés avec Stripe est vide ; les forfaits en direct et les écarts ne peuvent donc pas être évalués. Seul le catalogue configuré (billing.yaml) est affiché — ce qui est habituel en développement ou lorsque Stripe n'est pas configuré.",
+    "text": "Le cache des forfaits synchronisés avec Stripe est vide ; les forfaits actifs et les écarts ne peuvent donc pas être évalués. Seul le catalogue configuré (billing.yaml) est affiché — situation courante en développement ou lorsque Stripe n'est pas configuré.",
     "source_hash": "905d95f8"
   },
   "web.admin.billing.inSync": {
@@ -28,7 +28,7 @@
     "source_hash": "166538f5"
   },
   "web.admin.billing.inSyncDetail": {
-    "text": "Le catalogue configuré correspond aux forfaits en direct. Aucun écart détecté.",
+    "text": "Le catalogue configuré correspond aux forfaits actifs. Aucun écart détecté.",
     "source_hash": "57ab60a6"
   },
   "web.admin.billing.columns.planid": {
@@ -44,7 +44,7 @@
     "source_hash": "cb9e8664"
   },
   "web.admin.billing.columns.status": {
-    "text": "Statut",
+    "text": "État",
     "source_hash": "920e413c"
   },
   "web.admin.billing.diff.title": {
@@ -52,7 +52,7 @@
     "source_hash": "bc86e5f7"
   },
   "web.admin.billing.diff.subtitle": {
-    "text": "Catalogue configuré (billing.yaml) et forfait synchronisé en direct avec Stripe, côte à côte.",
+    "text": "Catalogue configuré (billing.yaml) et forfait actif synchronisé avec Stripe, côte à côte.",
     "source_hash": "d92e93ae"
   },
   "web.admin.billing.diff.config": {
@@ -60,7 +60,7 @@
     "source_hash": "6bf2ff04"
   },
   "web.admin.billing.diff.live": {
-    "text": "En direct (cache Stripe)",
+    "text": "Actif (cache Stripe)",
     "source_hash": "4886945d"
   },
   "web.admin.billing.diff.absentConfig": {
@@ -68,7 +68,7 @@
     "source_hash": "0b594c88"
   },
   "web.admin.billing.diff.absentLive": {
-    "text": "Ce forfait n'est pas présent dans le cache synchronisé en direct avec Stripe.",
+    "text": "Ce forfait n'est pas présent dans le cache actif synchronisé avec Stripe.",
     "source_hash": "c53f31c3"
   },
   "web.admin.billing.plans.title": {
@@ -80,7 +80,7 @@
     "source_hash": "39db3c13"
   },
   "web.admin.billing.plans.viewDiff": {
-    "text": "Afficher les différences",
+    "text": "Voir les différences",
     "source_hash": "0e5d6873"
   },
   "web.admin.billing.source.stripe": {
@@ -96,7 +96,7 @@
     "source_hash": "4fda4796"
   },
   "web.admin.billing.stats.live": {
-    "text": "Forfaits en direct",
+    "text": "Forfaits actifs",
     "source_hash": "faaa88d9"
   },
   "web.admin.billing.stats.source": {
@@ -116,11 +116,91 @@
     "source_hash": "15836cba"
   },
   "web.admin.billing.status.only_live": {
-    "text": "En direct uniquement",
+    "text": "Actif uniquement",
     "source_hash": "8f4ed495"
   },
   "web.admin.billing.status.changed": {
     "text": "Modifié",
     "source_hash": "2a6141e4"
+  },
+  "web.admin.billing.diff.backToCatalog": {
+    "text": "Retour au catalogue de facturation",
+    "source_hash": "8532b373"
+  },
+  "web.admin.billing.diff.driftedFields": {
+    "text": "Champs qui diffèrent :",
+    "source_hash": "9890c95b"
+  },
+  "web.admin.billing.diff.notFound": {
+    "text": "Forfait absent du catalogue",
+    "source_hash": "0253898b"
+  },
+  "web.admin.billing.diff.notFoundDescription": {
+    "text": "Aucun forfait portant l'identifiant {planid} n'a été trouvé dans le catalogue configuré ni dans le cache actif synchronisé avec Stripe.",
+    "source_hash": "2e69551c"
+  },
+  "web.admin.billing.stripeOrgs.title": {
+    "text": "Clients Stripe",
+    "source_hash": "0463ae27"
+  },
+  "web.admin.billing.stripeOrgs.description": {
+    "text": "Organisations liées à une fiche client Stripe.",
+    "source_hash": "2ab09aec"
+  },
+  "web.admin.billing.stripeOrgs.searchPlaceholder": {
+    "text": "Rechercher par ID client Stripe",
+    "source_hash": "d5acf08f"
+  },
+  "web.admin.billing.stripeOrgs.empty": {
+    "text": "Aucune organisation ne possède d'ID client Stripe.",
+    "source_hash": "2e373537"
+  },
+  "web.admin.billing.stripeOrgs.emptySearch": {
+    "text": "Aucun ID client Stripe ne correspond à cette recherche.",
+    "source_hash": "75011174"
+  },
+  "web.admin.billing.stripeOrgs.loadError": {
+    "text": "Impossible de charger la liste des clients Stripe.",
+    "source_hash": "15e2d9a7"
+  },
+  "web.admin.billing.stripeOrgs.unavailable": {
+    "text": "La liste des clients Stripe n'est pas encore disponible sur ce serveur.",
+    "source_hash": "aab6451a"
+  },
+  "web.admin.billing.stripeOrgs.none": {
+    "text": "Aucun",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.billing.stripeOrgs.capped": {
+    "text": "L'analyse de l'index a atteint sa limite ; le total est donc une valeur minimale — affinez la recherche pour voir le reste.",
+    "source_hash": "20bcaa38"
+  },
+  "web.admin.billing.stripeOrgs.stale": {
+    "text": "{count} entrée(s) d'index sur cette page pointent vers une organisation qui ne se charge plus et ont été ignorées.",
+    "source_hash": "51980f83"
+  },
+  "web.admin.billing.stripeOrgs.copyStripeId": {
+    "text": "Copier l'ID client Stripe",
+    "source_hash": "a77d18b1"
+  },
+  "web.admin.billing.stripeOrgs.columns.organization": {
+    "text": "Organisation",
+    "source_hash": "d764d425"
+  },
+  "web.admin.billing.stripeOrgs.columns.owner": {
+    "text": "Propriétaire",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.billing.stripeOrgs.columns.plan": {
+    "text": "Forfait",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.billing.stripeOrgs.columns.subscription": {
+    "text": "Abonnement",
+    "source_hash": "4999c6c6"
+  },
+  "web.admin.billing.stripeOrgs.columns.stripeCustomer": {
+    "text": "ID client Stripe",
+    "source_hash": "7e1d8bbb"
   }
 }

--- a/locales/content/fr_FR/admin-colonel.json
+++ b/locales/content/fr_FR/admin-colonel.json
@@ -4,11 +4,11 @@
     "source_hash": "74a883a0"
   },
   "web.colonel.configEditorDescription": {
-    "text": "Modifiez les paramètres de configuration du système. Les modifications s'appliquent immédiatement après l'enregistrement.",
+    "text": "Modifiez les paramètres de configuration du système. Les changements s'appliquent immédiatement après l'enregistrement.",
     "source_hash": "6025d269"
   },
   "web.colonel.invalidJson": {
-    "text": "JSON invalide dans la section {section}",
+    "text": "JSON non valide dans la section {section}",
     "source_hash": "a75ac7a3"
   },
   "web.colonel.validationError": {
@@ -32,11 +32,11 @@
     "source_hash": "74e8897e"
   },
   "web.colonel.multipleSectionsInvalid": {
-    "text": "Plusieurs sections contiennent des erreurs de validation : {sections}",
+    "text": "Plusieurs sections comportent des erreurs de validation : {sections}",
     "source_hash": "71fdaea1"
   },
   "web.colonel.sectionHasError": {
-    "text": "{section} contient des erreurs de validation : {error}",
+    "text": "{section} comporte des erreurs de validation : {error}",
     "source_hash": "e5e01aa0"
   },
   "web.colonel.sectionSaved": {
@@ -56,15 +56,15 @@
     "source_hash": "a710c2b9"
   },
   "web.colonel.schemaValidationError": {
-    "text": "Erreur de validation du schéma : {message} ({path})",
+    "text": "Erreur de validation du schéma : {message} ({path})",
     "source_hash": "5f838cb2"
   },
   "web.colonel.unknownValidationError": {
-    "text": "Erreur de validation inconnue : {error}",
+    "text": "Erreur de validation inconnue : {error}",
     "source_hash": "b6cf56ca"
   },
   "web.colonel.sectionEffectivelyEmpty": {
-    "text": "La section {section} n'a pas de valeurs configurées",
+    "text": "La section {section} ne contient aucune valeur configurée",
     "source_hash": "efb63b77"
   },
   "web.colonel.dashboard": {
@@ -72,7 +72,7 @@
     "source_hash": "67b69646"
   },
   "web.colonel.admin": {
-    "text": "Admin",
+    "text": "Administration",
     "source_hash": "c1c224b0"
   },
   "web.colonel.activity": {
@@ -88,7 +88,7 @@
     "source_hash": "6b0cc904"
   },
   "web.colonel.usersDescription": {
-    "text": "Gérer les comptes utilisateurs et les permissions",
+    "text": "Gérer les comptes utilisateurs et les autorisations",
     "source_hash": "6cfc012c"
   },
   "web.colonel.domains": {
@@ -104,7 +104,7 @@
     "source_hash": "6725e7bb"
   },
   "web.colonel.welcome": {
-    "text": "Bienvenue sur Colonel",
+    "text": "Bienvenue dans Colonel",
     "source_hash": "7881ca9e"
   },
   "web.colonel.welcomeDesc": {
@@ -120,11 +120,11 @@
     "source_hash": "9ef7d438"
   },
   "web.colonel.viewAll": {
-    "text": "Tout voir",
+    "text": "Tout afficher",
     "source_hash": "ff5573a6"
   },
   "web.colonel.activityPlaceholder": {
-    "text": "Les données d'activité seront affichées ici",
+    "text": "Les données d'activité s'afficheront ici",
     "source_hash": "aaf9e948"
   },
   "web.colonel.stats.totalSecrets": {
@@ -148,7 +148,7 @@
     "source_hash": "5deb082c"
   },
   "web.colonel.stats.totalCustomers": {
-    "text": "Total d'utilisateurs",
+    "text": "Total des utilisateurs",
     "source_hash": "0ca3aa44"
   },
   "web.colonel.stats.emailsSent": {
@@ -160,11 +160,11 @@
     "source_hash": "c3d66242"
   },
   "web.colonel.stats.healthy": {
-    "text": "En bonne santé",
+    "text": "Sain",
     "source_hash": "7f1e323b"
   },
   "web.colonel.actions.viewActivity": {
-    "text": "Voir l'activité",
+    "text": "Afficher l'activité",
     "source_hash": "9c28f55c"
   },
   "web.colonel.actions.viewActivityDesc": {
@@ -200,7 +200,7 @@
     "source_hash": "48937049"
   },
   "web.colonel.queueStatus": {
-    "text": "État de la file d'attente",
+    "text": "État des files d'attente",
     "source_hash": "3421ffa8"
   },
   "web.colonel.queueName": {
@@ -216,7 +216,7 @@
     "source_hash": "212b350d"
   },
   "web.colonel.processingRate": {
-    "text": "Taux/sec",
+    "text": "Débit/s",
     "source_hash": "cfde439c"
   },
   "web.colonel.connectionStatus": {
@@ -240,7 +240,7 @@
     "source_hash": "a3762a00"
   },
   "web.colonel.testPlanMode": {
-    "text": "Mode test de forfait",
+    "text": "Mode forfait de test",
     "source_hash": "eba59223"
   },
   "web.colonel.testingAsPlan": {
@@ -248,15 +248,15 @@
     "source_hash": "b3032f1a"
   },
   "web.colonel.clickToReset": {
-    "text": "Cliquer pour réinitialiser",
+    "text": "Cliquez pour réinitialiser",
     "source_hash": "4b25034d"
   },
   "web.colonel.selectTestPlan": {
-    "text": "Sélectionner un forfait à tester",
+    "text": "Sélectionnez un forfait à tester",
     "source_hash": "9e6e12fe"
   },
   "web.colonel.resetToActual": {
-    "text": "Réinitialiser au forfait actuel",
+    "text": "Revenir au forfait réel",
     "source_hash": "2cea3f92"
   },
   "web.colonel.currentActualPlan": {
@@ -280,7 +280,7 @@
     "source_hash": "be03a409"
   },
   "web.colonel.warningTestMode": {
-    "text": "Vous testez avec les droits {planName} (remplacement temporaire de session).",
+    "text": "Vous effectuez des tests avec les droits du forfait {planName} (remplacement temporaire de session).",
     "source_hash": "1a8aecf1"
   },
   "web.colonel.organizations.title": {
@@ -288,11 +288,11 @@
     "source_hash": "2730183d"
   },
   "web.colonel.organizations.description": {
-    "text": "Surveiller la santé de synchronisation de facturation des organisations",
+    "text": "Surveiller la synchronisation de la facturation des organisations",
     "source_hash": "d8f4398b"
   },
   "web.colonel.organizations.pageTitle": {
-    "text": "Moniteur de santé de facturation",
+    "text": "Moniteur de santé de la facturation",
     "source_hash": "9ef57da4"
   },
   "web.colonel.organizations.organizationsCount": {
@@ -304,7 +304,7 @@
     "source_hash": "1c8e5840"
   },
   "web.colonel.organizations.unknownCount": {
-    "text": "{count} inconnus",
+    "text": "{count} inconnues",
     "source_hash": "b7bf2cf1"
   },
   "web.colonel.organizations.noOrganizations": {
@@ -340,11 +340,11 @@
     "source_hash": "92340695"
   },
   "web.colonel.organizations.filters.trialing": {
-    "text": "En période d'essai",
+    "text": "Période d'essai",
     "source_hash": "3792573d"
   },
   "web.colonel.organizations.filters.pastDue": {
-    "text": "En retard",
+    "text": "En retard de paiement",
     "source_hash": "2bda1c7b"
   },
   "web.colonel.organizations.filters.canceled": {
@@ -360,7 +360,7 @@
     "source_hash": "3ac8bbca"
   },
   "web.colonel.organizations.columns.status": {
-    "text": "Statut",
+    "text": "État",
     "source_hash": "920e413c"
   },
   "web.colonel.organizations.columns.usage": {
@@ -400,15 +400,15 @@
     "source_hash": "53aa279e"
   },
   "web.colonel.organizations.columns.has_billing": {
-    "text": "A une facturation",
+    "text": "Facturation activée",
     "source_hash": "db0628ed"
   },
   "web.colonel.organizations.legacy.title": {
-    "text": "Administration de facturation des organisations",
+    "text": "Administration de la facturation des organisations",
     "source_hash": "5c7e07e7"
   },
   "web.colonel.organizations.legacy.description": {
-    "text": "Gérer les organisations et surveiller la santé de synchronisation de facturation ({total} au total)",
+    "text": "Gérer les organisations et surveiller la synchronisation de la facturation ({total} au total)",
     "source_hash": "996b446d"
   },
   "web.colonel.organizations.legacy.empty": {
@@ -432,7 +432,7 @@
     "source_hash": "96879611"
   },
   "web.colonel.organizations.actions.investigate": {
-    "text": "Examiner",
+    "text": "Analyser",
     "source_hash": "e2641093"
   },
   "web.colonel.organizations.actions.checking": {
@@ -448,15 +448,15 @@
     "source_hash": "4999c6c6"
   },
   "web.colonel.organizations.expanded.orgId": {
-    "text": "ID d'organisation",
+    "text": "ID de l'organisation",
     "source_hash": "5e6b9932"
   },
   "web.colonel.organizations.investigation.failed": {
-    "text": "Échec de l'examen",
+    "text": "Échec de l'analyse",
     "source_hash": "193aa900"
   },
   "web.colonel.organizations.investigation.result": {
-    "text": "Résultat de l'examen",
+    "text": "Résultat de l'analyse",
     "source_hash": "2dbc5cc3"
   },
   "web.colonel.organizations.investigation.verifiedSynced": {
@@ -468,7 +468,7 @@
     "source_hash": "361d22f3"
   },
   "web.colonel.organizations.investigation.unableToCompare": {
-    "text": "Impossible de comparer",
+    "text": "Comparaison impossible",
     "source_hash": "64c822ee"
   },
   "web.colonel.organizations.investigation.stripeDetails": {
@@ -476,7 +476,7 @@
     "source_hash": "53a7b0ea"
   },
   "web.colonel.organizations.investigation.statusLabel": {
-    "text": "Statut",
+    "text": "État",
     "source_hash": "920e413c"
   },
   "web.colonel.organizations.investigation.product": {
@@ -488,7 +488,7 @@
     "source_hash": "17c5b37a"
   },
   "web.colonel.organizations.investigation.priceId": {
-    "text": "ID de prix",
+    "text": "ID du prix",
     "source_hash": "b39a8f3e"
   },
   "web.colonel.organizations.investigation.local": {
@@ -512,11 +512,11 @@
     "source_hash": "d8707d41"
   },
   "web.colonel.secrets.description": {
-    "text": "Voir et gérer tous les secrets",
+    "text": "Consulter et gérer tous les secrets",
     "source_hash": "48f8052e"
   },
   "web.colonel.bannedIps.title": {
-    "text": "Adresses IP bannies",
+    "text": "IP bannies",
     "source_hash": "0ece5643"
   },
   "web.colonel.bannedIps.description": {
@@ -544,11 +544,11 @@
     "source_hash": "6170ab94"
   },
   "web.colonel.customDomains.description": {
-    "text": "Gérer les domaines personnalisés et l'image de marque",
+    "text": "Gérer les domaines personnalisés et la personnalisation graphique",
     "source_hash": "808ee2cb"
   },
   "web.colonel.feedback.send_feedback": {
-    "text": "Envoyer un commentaire",
+    "text": "Envoyer des commentaires",
     "source_hash": "8235980b"
   },
   "web.colonel.feedback.sending_ellipses": {
@@ -580,7 +580,7 @@
     "source_hash": "c683c9a6"
   },
   "web.colonel.titles.bannedIps": {
-    "text": "Adresses IP bannies",
+    "text": "IP bannies",
     "source_hash": "0ece5643"
   },
   "web.colonel.titles.usage": {
@@ -600,15 +600,15 @@
     "source_hash": "a7f64157"
   },
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
-    "text": "Lorsque vous envoyez un commentaire, nous verrons :",
+    "text": "Lorsque vous envoyez des commentaires, nous voyons :",
     "source_hash": "fe77172e"
   },
   "web.colonel.previewPlanMode": {
-    "text": "Mode d'aperçu du forfait",
+    "text": "Mode aperçu de forfait",
     "source_hash": "cf53f19d"
   },
   "web.colonel.previewModeDescription": {
-    "text": "Prévisualisez l'application telle qu'elle apparaît aux clients sur un autre forfait. Cela n'affecte que votre vue et ne modifie pas le forfait réel d'une organisation.",
+    "text": "Prévisualisez l'application telle qu'elle apparaît aux clients disposant d'un autre forfait. Cela n'affecte que votre affichage et ne modifie le forfait réel d'aucune organisation.",
     "source_hash": "6fe23f23"
   },
   "web.colonel.previewModeActive": {
@@ -652,11 +652,11 @@
     "source_hash": "f81ab834"
   },
   "web.colonel.bannedIps.columns.bannedAt": {
-    "text": "Banni le",
+    "text": "Bannie le",
     "source_hash": "dfbd120e"
   },
   "web.colonel.bannedIps.columns.bannedBy": {
-    "text": "Banni par",
+    "text": "Bannie par",
     "source_hash": "9f47db0e"
   },
   "web.colonel.bannedIps.error.banFailed": {
@@ -668,7 +668,7 @@
     "source_hash": "66bbac9a"
   },
   "web.colonel.bannedIps.form.title": {
-    "text": "Bannissement d'une adresse IP",
+    "text": "Bannir une adresse IP",
     "source_hash": "3f5b3dfa"
   },
   "web.colonel.bannedIps.form.ipLabel": {
@@ -708,11 +708,11 @@
     "source_hash": "69da56ba"
   },
   "web.colonel.customDomains.labels.created": {
-    "text": "Créé le",
+    "text": "Créé",
     "source_hash": "d70b9e24"
   },
   "web.colonel.customDomains.labels.updated": {
-    "text": "Mis à jour le",
+    "text": "Mis à jour",
     "source_hash": "3a5ecca1"
   },
   "web.colonel.customDomains.labels.favicon": {
@@ -724,7 +724,7 @@
     "source_hash": "4f783840"
   },
   "web.colonel.customDomains.status.resolving": {
-    "text": "Résolution en cours",
+    "text": "Résolution",
     "source_hash": "3287a034"
   },
   "web.colonel.customDomains.status.ready": {
@@ -744,7 +744,7 @@
     "source_hash": "331551b0"
   },
   "web.colonel.pagination.showing": {
-    "text": "Affichage de {start}–{end} sur {total}",
+    "text": "Affichage de {start} à {end} sur {total}",
     "source_hash": "64af6de2"
   },
   "web.colonel.pagination.itemsPerPage": {
@@ -776,7 +776,7 @@
     "source_hash": "a3b50c47"
   },
   "web.colonel.secrets.columns.created": {
-    "text": "Créé le",
+    "text": "Créé",
     "source_hash": "d70b9e24"
   },
   "web.colonel.secrets.columns.expiration": {
@@ -808,7 +808,7 @@
     "source_hash": "79fa3361"
   },
   "web.colonel.customDomains.labels.status": {
-    "text": "Statut",
+    "text": "État",
     "source_hash": "920e413c"
   },
   "web.colonel.customDomains.labels.actions": {
@@ -838,5 +838,37 @@
   "web.colonel.nav.groups.communications": {
     "text": "Communications",
     "source_hash": "919a9253"
+  },
+  "web.colonel.organizations.sameAsContact": {
+    "text": "Identique au contact",
+    "source_hash": "ed18ff43"
+  },
+  "web.colonel.organizations.refresh": {
+    "text": "Actualiser",
+    "source_hash": "0e916101"
+  },
+  "web.colonel.organizations.updatedAgo": {
+    "text": "Mis à jour {ago}",
+    "source_hash": "cda30b9c"
+  },
+  "web.colonel.organizations.columns.name": {
+    "text": "Nom",
+    "source_hash": "dcd1d522"
+  },
+  "web.colonel.organizations.columns.contactEmail": {
+    "text": "E-mail de contact",
+    "source_hash": "6d7fce11"
+  },
+  "web.colonel.organizations.columns.billingEmail": {
+    "text": "E-mail de facturation",
+    "source_hash": "8805b928"
+  },
+  "web.colonel.organizations.columns.planSubscription": {
+    "text": "Forfait et abonnement",
+    "source_hash": "b396caac"
+  },
+  "web.colonel.organizations.filters.searchPlaceholder": {
+    "text": "Rechercher par ID, nom ou e-mail",
+    "source_hash": "6fe16473"
   }
 }

--- a/locales/content/fr_FR/admin-customers.json
+++ b/locales/content/fr_FR/admin-customers.json
@@ -4,8 +4,8 @@
     "source_hash": "aabe76f1"
   },
   "web.admin.customers.description": {
-    "text": "Trouver un client et résoudre les problèmes d'assistance sans SSH.",
-    "source_hash": "c8487e68"
+    "text": "Trouvez un client et résolvez les problèmes d'assistance.",
+    "source_hash": "00961ea3"
   },
   "web.admin.customers.actions.plan.label": {
     "text": "Forfait",
@@ -28,7 +28,7 @@
     "source_hash": "ebe8d40c"
   },
   "web.admin.customers.actions.plan.localConfigWarning": {
-    "text": "Forfaits chargés depuis la configuration locale — Stripe n'est pas configuré ou est injoignable.",
+    "text": "Forfaits chargés depuis la configuration locale — Stripe n'est pas configuré ou est inaccessible.",
     "source_hash": "df83e326"
   },
   "web.admin.customers.actions.purge.button": {
@@ -60,7 +60,7 @@
     "source_hash": "227f57d7"
   },
   "web.admin.customers.actions.role.confirmDescription": {
-    "text": "Faire passer {email} au rôle {role}.",
+    "text": "Attribuer le rôle {role} à {email}.",
     "source_hash": "9ba063c6"
   },
   "web.admin.customers.actions.role.success": {
@@ -160,7 +160,7 @@
     "source_hash": "d8707d41"
   },
   "web.admin.customers.columns.created": {
-    "text": "Créé le",
+    "text": "Créé",
     "source_hash": "d70b9e24"
   },
   "web.admin.customers.columns.lastLogin": {
@@ -172,7 +172,7 @@
     "source_hash": "077807fb"
   },
   "web.admin.customers.detail.openFullPage": {
-    "text": "Ouvrir la page complète",
+    "text": "Ouvrir en pleine page",
     "source_hash": "a467911c"
   },
   "web.admin.customers.detail.notFound": {
@@ -216,11 +216,11 @@
     "source_hash": "90c94ee1"
   },
   "web.admin.customers.detail.billing.subscriptionStatus": {
-    "text": "Statut de l'abonnement",
+    "text": "État de l'abonnement",
     "source_hash": "f0723c4e"
   },
   "web.admin.customers.detail.billing.periodEnd": {
-    "text": "Fin de la période actuelle",
+    "text": "Fin de la période en cours",
     "source_hash": "742b8229"
   },
   "web.admin.customers.detail.billing.latestInvoice": {
@@ -268,11 +268,11 @@
     "source_hash": "ca3dc612"
   },
   "web.admin.customers.detail.fields.created": {
-    "text": "Créé le",
+    "text": "Créé",
     "source_hash": "d70b9e24"
   },
   "web.admin.customers.detail.fields.updated": {
-    "text": "Mis à jour le",
+    "text": "Mis à jour",
     "source_hash": "3a5ecca1"
   },
   "web.admin.customers.detail.fields.lastLogin": {
@@ -288,7 +288,7 @@
     "source_hash": "e0830524"
   },
   "web.admin.customers.detail.fields.suspendedReason": {
-    "text": "Motif de suspension",
+    "text": "Motif de la suspension",
     "source_hash": "d6b08d8e"
   },
   "web.admin.customers.detail.organizations.empty": {
@@ -308,7 +308,7 @@
     "source_hash": "a3b50c47"
   },
   "web.admin.customers.detail.receiptColumns.created": {
-    "text": "Créé le",
+    "text": "Créé",
     "source_hash": "d70b9e24"
   },
   "web.admin.customers.detail.receipts.empty": {
@@ -324,7 +324,7 @@
     "source_hash": "a3b50c47"
   },
   "web.admin.customers.detail.secretColumns.created": {
-    "text": "Créé le",
+    "text": "Créé",
     "source_hash": "d70b9e24"
   },
   "web.admin.customers.detail.secretColumns.expiration": {
@@ -420,7 +420,7 @@
     "source_hash": "a4fa4c65"
   },
   "web.admin.customers.detail.sessions.revokeAll.confirmDescription": {
-    "text": "Cela déconnecte l'utilisateur de tous les appareils et navigateurs — y compris les sessions non affichées dans cette liste — et bloque immédiatement ses routes authentifiées. À utiliser pour un départ ou en cas de suspicion de piratage de compte. Saisissez l'ID de l'utilisateur pour confirmer.",
+    "text": "Cela déconnecte l'utilisateur de tous les appareils et navigateurs — y compris les sessions non affichées dans cette liste — et bloque immédiatement ses routes authentifiées. À utiliser pour un départ ou en cas de suspicion de compromission de compte. Saisissez l'ID de l'utilisateur pour confirmer.",
     "source_hash": "483cdd88"
   },
   "web.admin.customers.detail.sessions.revokeAll.success": {
@@ -428,7 +428,7 @@
     "source_hash": "4e1cce55"
   },
   "web.admin.customers.detail.sessions.revokeAll.capped": {
-    "text": "{count} sessions supprimées, mais le balayage des sessions non suivies a été tronqué — une session plus ancienne peut subsister. Relancez pour en être sûr.",
+    "text": "{count} sessions supprimées, mais le balayage des sessions non suivies a été tronqué — une session plus ancienne peut subsister. Relancez l'opération pour en être sûr.",
     "source_hash": "e3d295a6"
   },
   "web.admin.customers.detail.stats.secretsCreated": {
@@ -482,5 +482,213 @@
   "web.admin.customers.suspended.badge": {
     "text": "Suspendu",
     "source_hash": "e392a389"
+  },
+  "web.admin.customers.actions.checkoutLink.button": {
+    "text": "Créer un lien de paiement",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.modalTitle": {
+    "text": "Créer un lien de paiement",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.planLabel": {
+    "text": "Forfait",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.actions.checkoutLink.planPlaceholder": {
+    "text": "ID de la famille de forfaits (ex. identity_plus_v1)",
+    "source_hash": "12eba027"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleLabel": {
+    "text": "Cycle de facturation",
+    "source_hash": "d69f731e"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleMonthly": {
+    "text": "Mensuel",
+    "source_hash": "9b11f6b7"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleYearly": {
+    "text": "Annuel",
+    "source_hash": "6e69b59e"
+  },
+  "web.admin.customers.actions.checkoutLink.allowPromo": {
+    "text": "Autoriser les codes promotionnels",
+    "source_hash": "ebe7bc8b"
+  },
+  "web.admin.customers.actions.checkoutLink.submit": {
+    "text": "Créer le lien",
+    "source_hash": "e6b850cf"
+  },
+  "web.admin.customers.actions.checkoutLink.resultLead": {
+    "text": "Lien de paiement créé. Partagez-le avec le client — il est utilisable une seule fois et expire.",
+    "source_hash": "6ff1fb0e"
+  },
+  "web.admin.customers.actions.checkoutLink.copy": {
+    "text": "Copier le lien de paiement",
+    "source_hash": "f1e51ca7"
+  },
+  "web.admin.customers.actions.checkoutLink.expiry": {
+    "text": "Expire dans environ {hours} h ({date}).",
+    "source_hash": "4c878a15"
+  },
+  "web.admin.customers.actions.checkoutLink.regionLabel": {
+    "text": "Région",
+    "source_hash": "d3a008ef"
+  },
+  "web.admin.customers.actions.checkoutLink.parseError": {
+    "text": "Le serveur a accepté la demande mais a renvoyé une réponse illisible ; aucun lien ne peut être affiché. Vérifiez dans Stripe avant de réessayer.",
+    "source_hash": "e7e08290"
+  },
+  "web.admin.customers.actions.checkoutLink.done": {
+    "text": "Terminé",
+    "source_hash": "11a6767d"
+  },
+  "web.admin.customers.actions.purge.typePrompt": {
+    "text": "Pour confirmer, saisissez ci-dessous l'adresse e-mail du compte {token}",
+    "source_hash": "8b2a1819"
+  },
+  "web.admin.customers.actions.purge.unavailable": {
+    "text": "La purge est indisponible : ce compte n'a pas d'adresse e-mail à ressaisir comme confirmation.",
+    "source_hash": "5f20f7e5"
+  },
+  "web.admin.customers.columns.actions": {
+    "text": "Actions",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.diagnostics.title": {
+    "text": "Diagnostic du compte",
+    "source_hash": "5574ece8"
+  },
+  "web.admin.customers.detail.diagnostics.loading": {
+    "text": "Diagnostic en cours…",
+    "source_hash": "062c83d5"
+  },
+  "web.admin.customers.detail.diagnostics.loadError": {
+    "text": "Impossible de charger le diagnostic.",
+    "source_hash": "69e69f49"
+  },
+  "web.admin.customers.detail.diagnostics.healthy": {
+    "text": "Aucune condition bloquante trouvée. L'état d'authentification semble sain — suspectez des problèmes côté client (cookies, configuration de connexion sur domaine personnalisé) ou une mauvaise région.",
+    "source_hash": "f6d5f8d1"
+  },
+  "web.admin.customers.detail.diagnostics.authUnavailable": {
+    "text": "Base de données d'authentification indisponible (mode d'authentification simple) — les vérifications côté SQL ont été ignorées.",
+    "source_hash": "d668907c"
+  },
+  "web.admin.customers.detail.diagnostics.authFailed": {
+    "text": "La base de données d'authentification n'a pas répondu ; les vérifications côté SQL n'ont pas pu être effectuées : {reason}",
+    "source_hash": "46d047c0"
+  },
+  "web.admin.customers.detail.diagnostics.unknown": {
+    "text": "Inconnu",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.title": {
+    "text": "Journal d'authentification",
+    "source_hash": "48ad8ba8"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.empty": {
+    "text": "Aucun événement d'authentification enregistré.",
+    "source_hash": "d2332558"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.unavailable": {
+    "text": "Impossible de lire le journal d'authentification : {reason}",
+    "source_hash": "ab18af57"
+  },
+  "web.admin.customers.detail.diagnostics.facts.authStatus": {
+    "text": "État d'authentification",
+    "source_hash": "34def169"
+  },
+  "web.admin.customers.detail.diagnostics.facts.noAccount": {
+    "text": "Aucun compte d'authentification",
+    "source_hash": "a9968e9e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.password": {
+    "text": "Mot de passe",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordSet": {
+    "text": "Défini",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordNone": {
+    "text": "Aucun",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfa": {
+    "text": "MFA",
+    "source_hash": "d39ce053"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfaNone": {
+    "text": "Aucune",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.loginFailures": {
+    "text": "Tentatives échouées",
+    "source_hash": "63e7f0a8"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lockedBadge": {
+    "text": "Verrouillé",
+    "source_hash": "ace29f74"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiter": {
+    "text": "Limiteur de débit",
+    "source_hash": "32892404"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterEngaged": {
+    "text": "Activé",
+    "source_hash": "1b0d851e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterClear": {
+    "text": "Inactif",
+    "source_hash": "83b12c22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verification": {
+    "text": "E-mail de vérification",
+    "source_hash": "23fac8fb"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationPending": {
+    "text": "En attente — dernier envoi {date}",
+    "source_hash": "9ab8d1b6"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationNone": {
+    "text": "Aucun en attente",
+    "source_hash": "a4d4cc22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.sessions": {
+    "text": "Sessions actives",
+    "source_hash": "61ad9909"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lastLogin": {
+    "text": "Dernière connexion (authentification)",
+    "source_hash": "373e7fb1"
+  },
+  "web.admin.customers.detail.receipts.partial": {
+    "text": "Liste partielle — les {count} plus récents sont affichés. Ce client possède davantage de reçus que ceux affichés ici.",
+    "source_hash": "127fd4db"
+  },
+  "web.admin.customers.detail.secrets.partial": {
+    "text": "Liste partielle — les {count} plus récents sont affichés. Ce client possède davantage de secrets que ceux affichés ici.",
+    "source_hash": "a537c8f3"
+  },
+  "web.admin.customers.detail.sessions.columns.country": {
+    "text": "Pays",
+    "source_hash": "701d021d"
+  },
+  "web.admin.customers.detail.sessions.current.badge": {
+    "text": "Cette session",
+    "source_hash": "6da6530a"
+  },
+  "web.admin.customers.detail.sessions.current.tooltip": {
+    "text": "Votre session d'administration actuelle. La révoquer ici n'a aucun effet — elle est recréée pour la suite de cette requête.",
+    "source_hash": "ef097ab1"
+  },
+  "web.admin.customers.verification.verified": {
+    "text": "Vérifié",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.verification.unverified": {
+    "text": "Non vérifié",
+    "source_hash": "15133907"
   }
 }

--- a/locales/content/fr_FR/admin-domains.json
+++ b/locales/content/fr_FR/admin-domains.json
@@ -36,11 +36,11 @@
     "source_hash": "2263ec6a"
   },
   "web.admin.domains.addDomain.strategy.approximated": {
-    "text": "Approximated — vérification de propriété DNS, sans proxy.",
+    "text": "Approximated — vérification de la propriété DNS, sans proxy.",
     "source_hash": "79a7245c"
   },
   "web.admin.domains.addDomain.strategy.passthrough": {
-    "text": "Passthrough — vous pointez le DNS vers le proxy de ce déploiement.",
+    "text": "Passthrough — vous dirigez le DNS vers le proxy de ce déploiement.",
     "source_hash": "9702d758"
   },
   "web.admin.domains.addDomain.strategy.external": {
@@ -48,7 +48,7 @@
     "source_hash": "acaede35"
   },
   "web.admin.domains.addDomain.strategy.caddy_on_demand": {
-    "text": "Caddy on-demand — certificats émis automatiquement à la première requête.",
+    "text": "Caddy à la demande — certificats émis automatiquement à la première requête.",
     "source_hash": "deb90ae6"
   },
   "web.admin.domains.addDomain.strategy.caddy": {
@@ -56,11 +56,11 @@
     "source_hash": "a0f3c2dc"
   },
   "web.admin.domains.addDomain.strategy.unknown": {
-    "text": "Stratégie de validation à l'échelle du déploiement.",
+    "text": "Stratégie de validation applicable à l'ensemble du déploiement.",
     "source_hash": "4587f9cf"
   },
   "web.admin.domains.attach.cta": {
-    "text": "Rattacher le domaine à l'organisation",
+    "text": "Rattacher le domaine à une organisation",
     "source_hash": "736d74ce"
   },
   "web.admin.domains.attach.recordEyebrow": {
@@ -96,7 +96,7 @@
     "source_hash": "5c626f53"
   },
   "web.admin.domains.dns.propagationNote": {
-    "text": "Les modifications DNS peuvent prendre quelques minutes à se propager avant que la vérification n'aboutisse.",
+    "text": "La propagation des modifications DNS peut prendre quelques minutes avant que la vérification n'aboutisse.",
     "source_hash": "7caf70a7"
   },
   "web.admin.domains.dns.toggle": {
@@ -124,7 +124,7 @@
     "source_hash": "bb5d0055"
   },
   "web.admin.domains.orgPicker.searchHint": {
-    "text": "Rechercher par objid, extid ou l'adresse e-mail d'un membre.",
+    "text": "Recherchez par objid, extid ou l'adresse e-mail d'un membre.",
     "source_hash": "fdef7332"
   },
   "web.admin.domains.orgPicker.loadError": {
@@ -140,7 +140,7 @@
     "source_hash": "0352e6e6"
   },
   "web.admin.domains.orgPicker.noResults": {
-    "text": "Aucune organisation ne correspond à « {term} ».",
+    "text": "Aucune organisation ne correspond à « {term} ».",
     "source_hash": "761db594"
   },
   "web.admin.domains.orgPicker.unnamedOrg": {
@@ -168,7 +168,7 @@
     "source_hash": "06797824"
   },
   "web.admin.domains.verify.failed": {
-    "text": "La vérification a échoué. Veuillez réessayer.",
+    "text": "Échec de la vérification. Veuillez réessayer.",
     "source_hash": "3c8432b0"
   },
   "web.admin.domains.verify.success.verified": {
@@ -176,7 +176,7 @@
     "source_hash": "802b5d1e"
   },
   "web.admin.domains.verify.success.resolving": {
-    "text": "{domain} se résout mais n'est pas encore vérifié.",
+    "text": "{domain} se résout, mais n'est pas encore vérifié.",
     "source_hash": "bc8aecad"
   },
   "web.admin.domains.verify.success.pending": {
@@ -190,5 +190,657 @@
   "web.admin.domains.verify.success.done": {
     "text": "Vérification terminée pour {domain}.",
     "source_hash": "ed67e22d"
+  },
+  "web.admin.domains.actions.preview": {
+    "text": "Aperçu",
+    "source_hash": "324b134f"
+  },
+  "web.admin.domains.actions.probe.button": {
+    "text": "Sonder",
+    "source_hash": "3bd51ab9"
+  },
+  "web.admin.domains.actions.remove.button": {
+    "text": "Supprimer le domaine",
+    "source_hash": "5ce43507"
+  },
+  "web.admin.domains.actions.remove.previewButton": {
+    "text": "Prévisualiser la suppression",
+    "source_hash": "6b81bd92"
+  },
+  "web.admin.domains.actions.remove.previewStatus": {
+    "text": "État :",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.remove.previewOrg": {
+    "text": "Organisation :",
+    "source_hash": "5300e286"
+  },
+  "web.admin.domains.actions.remove.reassertsSurvivor": {
+    "text": "Un autre enregistrement revendique le même nom de domaine et prendra le contrôle de l'index de recherche.",
+    "source_hash": "902838f4"
+  },
+  "web.admin.domains.actions.remove.confirmTitle": {
+    "text": "Supprimer le domaine ?",
+    "source_hash": "716dfac9"
+  },
+  "web.admin.domains.actions.remove.confirmDescription": {
+    "text": "Cela supprime définitivement {domain} ainsi que ses enregistrements de personnalisation, DNS et de configuration. Cette action est irréversible. Ressaisissez l'ID public du domaine pour continuer.",
+    "source_hash": "d0b67b47"
+  },
+  "web.admin.domains.actions.remove.success": {
+    "text": "Domaine supprimé.",
+    "source_hash": "2ccaa6d3"
+  },
+  "web.admin.domains.actions.remove.notApplied": {
+    "text": "Le serveur a prévisualisé la suppression au lieu de l'appliquer — le domaine n'a PAS été supprimé. Réessayez et signalez le problème s'il persiste.",
+    "source_hash": "dc6d70ae"
+  },
+  "web.admin.domains.actions.repair.title": {
+    "text": "Réparer le lien avec l'organisation",
+    "source_hash": "82b40352"
+  },
+  "web.admin.domains.actions.repair.description": {
+    "text": "Détectez et corrigez les liens rompus entre ce domaine et son organisation. Prévisualisez d'abord pour voir ce qui changerait.",
+    "source_hash": "531ed287"
+  },
+  "web.admin.domains.actions.repair.orgIdLabel": {
+    "text": "ID de l'organisation (domaines orphelins uniquement)",
+    "source_hash": "0d3010eb"
+  },
+  "web.admin.domains.actions.repair.orgIdPlaceholder": {
+    "text": "Laissez vide sauf si le domaine n'a pas de propriétaire",
+    "source_hash": "118b7132"
+  },
+  "web.admin.domains.actions.repair.statusLabel": {
+    "text": "État :",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.repair.noIssues": {
+    "text": "Aucun problème détecté — rien à réparer.",
+    "source_hash": "17735887"
+  },
+  "web.admin.domains.actions.repair.button": {
+    "text": "Appliquer la réparation",
+    "source_hash": "4d0ab2d4"
+  },
+  "web.admin.domains.actions.repair.confirmTitle": {
+    "text": "Appliquer la réparation ?",
+    "source_hash": "ef0ffae5"
+  },
+  "web.admin.domains.actions.repair.confirmDescription": {
+    "text": "Cela réécrit le lien avec l'organisation pour {domain}. Ressaisissez l'ID public du domaine pour continuer.",
+    "source_hash": "a9f2702f"
+  },
+  "web.admin.domains.actions.repair.success": {
+    "text": "Réparation appliquée.",
+    "source_hash": "850bd784"
+  },
+  "web.admin.domains.actions.transfer.title": {
+    "text": "Transférer vers une autre organisation",
+    "source_hash": "1b0b0655"
+  },
+  "web.admin.domains.actions.transfer.description": {
+    "text": "Déplacez ce domaine vers une autre organisation. Prévisualisez d'abord pour confirmer les deux côtés du transfert.",
+    "source_hash": "457e852d"
+  },
+  "web.admin.domains.actions.transfer.toOrgLabel": {
+    "text": "ID de l'organisation de destination",
+    "source_hash": "1a3f05c4"
+  },
+  "web.admin.domains.actions.transfer.fromOrgLabel": {
+    "text": "ID de l'organisation actuelle attendue (facultatif)",
+    "source_hash": "f6e75729"
+  },
+  "web.admin.domains.actions.transfer.fromOrgPlaceholder": {
+    "text": "Confirmez le propriétaire actuel avant le transfert",
+    "source_hash": "1ac6c59b"
+  },
+  "web.admin.domains.actions.transfer.from": {
+    "text": "De",
+    "source_hash": "21819769"
+  },
+  "web.admin.domains.actions.transfer.to": {
+    "text": "Vers",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.domains.actions.transfer.orphaned": {
+    "text": "Aucune organisation (orphelin)",
+    "source_hash": "6f4c745c"
+  },
+  "web.admin.domains.actions.transfer.button": {
+    "text": "Appliquer le transfert",
+    "source_hash": "fb546c5c"
+  },
+  "web.admin.domains.actions.transfer.confirmTitle": {
+    "text": "Transférer le domaine ?",
+    "source_hash": "801eb986"
+  },
+  "web.admin.domains.actions.transfer.confirmDescription": {
+    "text": "Cela déplace {domain} vers l'organisation {org}. Ressaisissez l'ID public du domaine pour continuer.",
+    "source_hash": "52c8808d"
+  },
+  "web.admin.domains.actions.transfer.success": {
+    "text": "Domaine transféré.",
+    "source_hash": "91e681ae"
+  },
+  "web.admin.domains.columns.domain": {
+    "text": "Domaine",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domains.columns.organization": {
+    "text": "Organisation",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.columns.state": {
+    "text": "Vérification",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.domains.columns.tls": {
+    "text": "TLS",
+    "source_hash": "d1c18ec0"
+  },
+  "web.admin.domains.columns.created": {
+    "text": "Créé",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.columns.actions": {
+    "text": "Actions",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.configs.title": {
+    "text": "Configuration du domaine",
+    "source_hash": "d46aa480"
+  },
+  "web.admin.domains.configs.description": {
+    "text": "Enregistrements de configuration par domaine régissant la connexion, l'inscription, les secrets de la page d'accueil, l'accès à l'API, les secrets entrants, le SSO du locataire et l'envoi d'e-mails. Un enregistrement manquant bloque par défaut les cinq premiers.",
+    "source_hash": "1df99789"
+  },
+  "web.admin.domains.configs.loadError": {
+    "text": "Impossible de charger les enregistrements de configuration du domaine.",
+    "source_hash": "9417d718"
+  },
+  "web.admin.domains.configs.retry": {
+    "text": "Réessayer",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.configs.degraded": {
+    "text": "La réponse de configuration ne correspond pas au contrat attendu. Actualisez, et signalez le problème s'il persiste.",
+    "source_hash": "b5d890c0"
+  },
+  "web.admin.domains.configs.notFoundNote": {
+    "text": "Ce domaine n'existe plus ; ses enregistrements de configuration ne peuvent donc pas être chargés.",
+    "source_hash": "2d88a392"
+  },
+  "web.admin.domains.configs.detailsToggle": {
+    "text": "Détails",
+    "source_hash": "45989de4"
+  },
+  "web.admin.domains.configs.notEditable": {
+    "text": "Géré dans les paramètres de domaine de l'espace de travail.",
+    "source_hash": "54fe891f"
+  },
+  "web.admin.domains.configs.delete.button": {
+    "text": "Supprimer",
+    "source_hash": "e2d0a549"
+  },
+  "web.admin.domains.configs.delete.confirmTitle": {
+    "text": "Supprimer la configuration {kind} ?",
+    "source_hash": "98e672db"
+  },
+  "web.admin.domains.configs.delete.confirmDescription": {
+    "text": "Cela supprime définitivement l'enregistrement de configuration {kind} pour {domain}. Le domaine revient au comportement appliqué en l'absence d'enregistrement. Ressaisissez le type pour continuer.",
+    "source_hash": "8272c40c"
+  },
+  "web.admin.domains.configs.delete.success": {
+    "text": "Configuration supprimée.",
+    "source_hash": "a0184b66"
+  },
+  "web.admin.domains.configs.edit.button": {
+    "text": "Modifier",
+    "source_hash": "464c4ffd"
+  },
+  "web.admin.domains.configs.edit.createButton": {
+    "text": "Créer",
+    "source_hash": "4759498a"
+  },
+  "web.admin.domains.configs.edit.title": {
+    "text": "Configurer {kind}",
+    "source_hash": "8592148f"
+  },
+  "web.admin.domains.configs.edit.submit": {
+    "text": "Enregistrer",
+    "source_hash": "1509f561"
+  },
+  "web.admin.domains.configs.edit.success": {
+    "text": "Configuration enregistrée.",
+    "source_hash": "6b5b3c69"
+  },
+  "web.admin.domains.configs.edit.unsetOption": {
+    "text": "Non défini",
+    "source_hash": "4895f731"
+  },
+  "web.admin.domains.configs.edit.domainsHint": {
+    "text": "Un domaine par ligne.",
+    "source_hash": "6c03f4f7"
+  },
+  "web.admin.domains.configs.ensure.button": {
+    "text": "Créer les configurations manquantes",
+    "source_hash": "77991b75"
+  },
+  "web.admin.domains.configs.ensure.confirmTitle": {
+    "text": "Créer les enregistrements de configuration manquants ?",
+    "source_hash": "3f41dec2"
+  },
+  "web.admin.domains.configs.ensure.confirmDescription": {
+    "text": "Crée des enregistrements désactivés sur {domain} pour : {kinds}. Tout démarre à l'état désactivé, le comportement ne change donc pas tant qu'un enregistrement n'est pas activé.",
+    "source_hash": "fed66221"
+  },
+  "web.admin.domains.configs.ensure.applyButton": {
+    "text": "Créer les enregistrements",
+    "source_hash": "4bcbef42"
+  },
+  "web.admin.domains.configs.ensure.success": {
+    "text": "Enregistrements de configuration manquants créés.",
+    "source_hash": "3b6ead80"
+  },
+  "web.admin.domains.configs.ensure.nothingMissing": {
+    "text": "Rien à créer — tous les enregistrements de configuration existent déjà. La liste a été actualisée.",
+    "source_hash": "ad0df0ae"
+  },
+  "web.admin.domains.configs.ensure.notApplied": {
+    "text": "Le serveur a prévisualisé la modification au lieu de l'appliquer — aucun enregistrement n'a été créé. Réessayez et signalez le problème s'il persiste.",
+    "source_hash": "09d26379"
+  },
+  "web.admin.domains.configs.fields.enabled": {
+    "text": "Activé",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.fields.signin_enabled": {
+    "text": "Connexion activée",
+    "source_hash": "cabe4898"
+  },
+  "web.admin.domains.configs.fields.email_auth_enabled": {
+    "text": "Authentification par e-mail activée",
+    "source_hash": "4a762960"
+  },
+  "web.admin.domains.configs.fields.sso_enabled": {
+    "text": "SSO activé",
+    "source_hash": "6e77e673"
+  },
+  "web.admin.domains.configs.fields.restrict_to": {
+    "text": "Restreindre à",
+    "source_hash": "a0bdf50a"
+  },
+  "web.admin.domains.configs.fields.signup_enabled": {
+    "text": "Inscription activée",
+    "source_hash": "2637d0b2"
+  },
+  "web.admin.domains.configs.fields.autoverify": {
+    "text": "Vérification automatique",
+    "source_hash": "7e02211c"
+  },
+  "web.admin.domains.configs.fields.validation_strategy": {
+    "text": "Stratégie de validation",
+    "source_hash": "a2e95531"
+  },
+  "web.admin.domains.configs.fields.allowed_signup_domains": {
+    "text": "Domaines d'inscription autorisés",
+    "source_hash": "9b5bb5b1"
+  },
+  "web.admin.domains.configs.fields.secrets_mode": {
+    "text": "Mode des secrets",
+    "source_hash": "8d4349d6"
+  },
+  "web.admin.domains.configs.fields.disabled_homepage_variant": {
+    "text": "Variante de page d'accueil désactivée",
+    "source_hash": "4695633b"
+  },
+  "web.admin.domains.configs.fields.ready": {
+    "text": "Prêt",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.configs.fields.recipients": {
+    "text": "Destinataires",
+    "source_hash": "1e8568a8"
+  },
+  "web.admin.domains.configs.fields.provider_type": {
+    "text": "Type de fournisseur",
+    "source_hash": "8c0f6d3e"
+  },
+  "web.admin.domains.configs.fields.display_name": {
+    "text": "Nom d'affichage",
+    "source_hash": "2b7f6a84"
+  },
+  "web.admin.domains.configs.fields.issuer": {
+    "text": "Émetteur",
+    "source_hash": "39e02c46"
+  },
+  "web.admin.domains.configs.fields.tenant_id": {
+    "text": "ID du locataire",
+    "source_hash": "de1f5fff"
+  },
+  "web.admin.domains.configs.fields.has_client_id": {
+    "text": "ID client défini",
+    "source_hash": "04a9fa3d"
+  },
+  "web.admin.domains.configs.fields.has_client_secret": {
+    "text": "Secret client défini",
+    "source_hash": "6ee1c9e6"
+  },
+  "web.admin.domains.configs.fields.allowed_domains": {
+    "text": "Domaines autorisés",
+    "source_hash": "bcd60db0"
+  },
+  "web.admin.domains.configs.fields.enforce_sso_only": {
+    "text": "Imposer le SSO uniquement",
+    "source_hash": "b3a3f694"
+  },
+  "web.admin.domains.configs.fields.grant_org_scope": {
+    "text": "Accorder la portée organisation",
+    "source_hash": "698ea5de"
+  },
+  "web.admin.domains.configs.fields.provider": {
+    "text": "Fournisseur",
+    "source_hash": "472590ae"
+  },
+  "web.admin.domains.configs.fields.from_name": {
+    "text": "Nom de l'expéditeur",
+    "source_hash": "b28f93ea"
+  },
+  "web.admin.domains.configs.fields.from_address": {
+    "text": "Adresse de l'expéditeur",
+    "source_hash": "d465bcfa"
+  },
+  "web.admin.domains.configs.fields.reply_to": {
+    "text": "Répondre à",
+    "source_hash": "6b9c49b7"
+  },
+  "web.admin.domains.configs.fields.sending_mode": {
+    "text": "Mode d'envoi",
+    "source_hash": "e2d6bcf7"
+  },
+  "web.admin.domains.configs.fields.verification_status": {
+    "text": "État de la vérification",
+    "source_hash": "aedfff7e"
+  },
+  "web.admin.domains.configs.fields.dns_verified": {
+    "text": "DNS vérifié",
+    "source_hash": "8b2128c8"
+  },
+  "web.admin.domains.configs.fields.provider_verified": {
+    "text": "Fournisseur vérifié",
+    "source_hash": "6f4d9cc4"
+  },
+  "web.admin.domains.configs.fields.has_api_key": {
+    "text": "Clé d'API définie",
+    "source_hash": "d5115386"
+  },
+  "web.admin.domains.configs.fields.created": {
+    "text": "Créé",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.configs.fields.updated": {
+    "text": "Mis à jour",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.configs.kinds.signin": {
+    "text": "Connexion",
+    "source_hash": "5bbbe531"
+  },
+  "web.admin.domains.configs.kinds.signup": {
+    "text": "Inscription",
+    "source_hash": "3cc08ebe"
+  },
+  "web.admin.domains.configs.kinds.homepage": {
+    "text": "Page d'accueil",
+    "source_hash": "9e3391e9"
+  },
+  "web.admin.domains.configs.kinds.api": {
+    "text": "API",
+    "source_hash": "c8e5998f"
+  },
+  "web.admin.domains.configs.kinds.incoming": {
+    "text": "Secrets entrants",
+    "source_hash": "e301820a"
+  },
+  "web.admin.domains.configs.kinds.sso": {
+    "text": "SSO",
+    "source_hash": "5ba3ac9f"
+  },
+  "web.admin.domains.configs.kinds.mailer": {
+    "text": "Service d'e-mail",
+    "source_hash": "6c07ba63"
+  },
+  "web.admin.domains.configs.missingNotes.signin": {
+    "text": "Aucun enregistrement : la connexion est désactivée sur ce domaine, sauf si le SSO du locataire est actif.",
+    "source_hash": "17dd6099"
+  },
+  "web.admin.domains.configs.missingNotes.signup": {
+    "text": "Aucun enregistrement : l'inscription est désactivée sur ce domaine.",
+    "source_hash": "c3c98956"
+  },
+  "web.admin.domains.configs.missingNotes.homepage": {
+    "text": "Aucun enregistrement : les secrets de la page d'accueil sont désactivés (blocage par défaut et journalisation d'une erreur).",
+    "source_hash": "9a258a88"
+  },
+  "web.admin.domains.configs.missingNotes.api": {
+    "text": "Aucun enregistrement : l'API publique est désactivée (blocage par défaut et journalisation d'une erreur).",
+    "source_hash": "fed99f73"
+  },
+  "web.admin.domains.configs.missingNotes.incoming": {
+    "text": "Aucun enregistrement : les secrets entrants sont désactivés.",
+    "source_hash": "b957fbe8"
+  },
+  "web.admin.domains.configs.missingNotes.sso": {
+    "text": "Aucun enregistrement : le SSO du locataire est indisponible ; la politique de repli du SSO de la plateforme s'applique.",
+    "source_hash": "7b05ade8"
+  },
+  "web.admin.domains.configs.missingNotes.mailer": {
+    "text": "Aucun enregistrement : le service d'e-mail de la plateforme est utilisé.",
+    "source_hash": "e027cc99"
+  },
+  "web.admin.domains.configs.status.missing": {
+    "text": "Manquant",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.domains.configs.status.disabled": {
+    "text": "Désactivé",
+    "source_hash": "75081b59"
+  },
+  "web.admin.domains.configs.status.enabled": {
+    "text": "Activé",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.status.enabledNotReady": {
+    "text": "Activé, non prêt",
+    "source_hash": "cb806ba4"
+  },
+  "web.admin.domains.detail.openFullPage": {
+    "text": "Ouvrir en pleine page",
+    "source_hash": "a467911c"
+  },
+  "web.admin.domains.detail.backToList": {
+    "text": "Retour aux domaines",
+    "source_hash": "22fd50fe"
+  },
+  "web.admin.domains.detail.notFound": {
+    "text": "Domaine introuvable",
+    "source_hash": "7b8fc0e6"
+  },
+  "web.admin.domains.detail.notFoundDescription": {
+    "text": "Ce domaine n'existe pas ou a déjà été supprimé.",
+    "source_hash": "e0f0b987"
+  },
+  "web.admin.domains.detail.loadError": {
+    "text": "Impossible de charger ce domaine.",
+    "source_hash": "39e9c657"
+  },
+  "web.admin.domains.detail.retry": {
+    "text": "Réessayer",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.detail.never": {
+    "text": "Jamais",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.domains.detail.none": {
+    "text": "Aucun",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.domains.detail.yes": {
+    "text": "Oui",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.domains.detail.no": {
+    "text": "Non",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.domains.detail.organization.open": {
+    "text": "Ouvrir l'organisation",
+    "source_hash": "54a43621"
+  },
+  "web.admin.domains.detail.organization.unknown": {
+    "text": "L'organisation propriétaire n'est pas incluse dans cette réponse. Ouvrez ce domaine depuis la liste des domaines pour la voir.",
+    "source_hash": "bb5bdc9c"
+  },
+  "web.admin.domains.detail.sections.overview": {
+    "text": "Vue d'ensemble",
+    "source_hash": "d4b1ea57"
+  },
+  "web.admin.domains.detail.sections.actions": {
+    "text": "Actions",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.detail.sections.organization": {
+    "text": "Organisation propriétaire",
+    "source_hash": "39ad6d9c"
+  },
+  "web.admin.domains.detail.sections.dns": {
+    "text": "DNS",
+    "source_hash": "020965a2"
+  },
+  "web.admin.domains.detail.sections.diagnostics": {
+    "text": "Diagnostics",
+    "source_hash": "268f14bb"
+  },
+  "web.admin.domains.detail.sections.operations": {
+    "text": "Opérations de propriété",
+    "source_hash": "eb9a8cbc"
+  },
+  "web.admin.domains.detail.sections.operationsHint": {
+    "text": "Chaque opération est d'abord prévisualisée. Rien n'est écrit tant que vous n'avez pas confirmé l'étape d'application.",
+    "source_hash": "f09bf7bd"
+  },
+  "web.admin.domains.fields.publicId": {
+    "text": "ID public",
+    "source_hash": "3705b64f"
+  },
+  "web.admin.domains.fields.domainId": {
+    "text": "ID interne",
+    "source_hash": "e468bb47"
+  },
+  "web.admin.domains.fields.organization": {
+    "text": "Organisation",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.fields.baseDomain": {
+    "text": "Domaine de base",
+    "source_hash": "33295d5b"
+  },
+  "web.admin.domains.fields.subdomain": {
+    "text": "Sous-domaine",
+    "source_hash": "ba4520ab"
+  },
+  "web.admin.domains.fields.apex": {
+    "text": "Domaine apex",
+    "source_hash": "0a8a42fa"
+  },
+  "web.admin.domains.fields.status": {
+    "text": "État",
+    "source_hash": "920e413c"
+  },
+  "web.admin.domains.fields.created": {
+    "text": "Créé",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.fields.updated": {
+    "text": "Mis à jour",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.fields.verified": {
+    "text": "Vérifié",
+    "source_hash": "4f783840"
+  },
+  "web.admin.domains.fields.resolving": {
+    "text": "Résolution",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.fields.ready": {
+    "text": "Prêt",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.list.searchPlaceholder": {
+    "text": "Rechercher par nom de domaine ou ID",
+    "source_hash": "aecdd873"
+  },
+  "web.admin.domains.list.stateFilter": {
+    "text": "État",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.domains.list.emptyFilter": {
+    "text": "Aucun domaine ne correspond aux filtres actuels.",
+    "source_hash": "be4d64ec"
+  },
+  "web.admin.domains.probe.healthLabel": {
+    "text": "Santé",
+    "source_hash": "55898449"
+  },
+  "web.admin.domains.probe.certInvalid": {
+    "text": "Certificat inutilisable",
+    "source_hash": "5535f4d4"
+  },
+  "web.admin.domains.probe.noCertificate": {
+    "text": "Aucun certificat n'a été renvoyé — la connexion a échoué avant TLS.",
+    "source_hash": "8ffd63be"
+  },
+  "web.admin.domains.probe.fields.httpStatus": {
+    "text": "État HTTP",
+    "source_hash": "0f7cf91f"
+  },
+  "web.admin.domains.probe.fields.httpError": {
+    "text": "Erreur HTTP",
+    "source_hash": "5c6896d4"
+  },
+  "web.admin.domains.probe.fields.sslError": {
+    "text": "Erreur TLS",
+    "source_hash": "7b827515"
+  },
+  "web.admin.domains.probe.fields.issuer": {
+    "text": "Émetteur du certificat",
+    "source_hash": "2912559a"
+  },
+  "web.admin.domains.probe.fields.subject": {
+    "text": "Sujet du certificat",
+    "source_hash": "d7816b16"
+  },
+  "web.admin.domains.probe.fields.notAfter": {
+    "text": "Expiration du certificat",
+    "source_hash": "1e73119d"
+  },
+  "web.admin.domains.probe.fields.expiresIn": {
+    "text": "{date} ({days} jours)",
+    "source_hash": "a71a6e81"
+  },
+  "web.admin.domains.tls.serving": {
+    "text": "En service",
+    "source_hash": "f55e53f9"
+  },
+  "web.admin.domains.tls.resolving": {
+    "text": "Résolution",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.tls.none": {
+    "text": "Hors service",
+    "source_hash": "da8a5ab9"
   }
 }

--- a/locales/content/fr_FR/admin-domaintoolbox.json
+++ b/locales/content/fr_FR/admin-domaintoolbox.json
@@ -1,10 +1,10 @@
 {
   "web.admin.domaintoolbox.title": {
-    "text": "Boîte à outils de domaine",
+    "text": "Boîte à outils des domaines",
     "source_hash": "5a9333db"
   },
   "web.admin.domaintoolbox.description": {
-    "text": "Diagnostiquer et réparer les relations de domaine personnalisé : détecter les orphelins, sonder le DNS/SSL, réparer la propriété et transférer entre organisations.",
+    "text": "Diagnostiquez et réparez les relations des domaines personnalisés : recherchez les orphelins, sondez le DNS/SSL, réparez la propriété et transférez entre organisations.",
     "source_hash": "778537aa"
   },
   "web.admin.domaintoolbox.retry": {
@@ -28,7 +28,7 @@
     "source_hash": "ddcea596"
   },
   "web.admin.domaintoolbox.orphaned.description": {
-    "text": "Domaines personnalisés sans organisation propriétaire. Utilisez « Réparer » pour en réattribuer un.",
+    "text": "Domaines personnalisés sans organisation propriétaire. Utilisez Réparer pour en réattribuer un.",
     "source_hash": "967268f5"
   },
   "web.admin.domaintoolbox.orphaned.empty": {
@@ -56,7 +56,7 @@
     "source_hash": "4f783840"
   },
   "web.admin.domaintoolbox.orphaned.columns.created": {
-    "text": "Créé le",
+    "text": "Créé",
     "source_hash": "d70b9e24"
   },
   "web.admin.domaintoolbox.orphaned.columns.actions": {
@@ -68,7 +68,7 @@
     "source_hash": "ec69a087"
   },
   "web.admin.domaintoolbox.probe.description": {
-    "text": "Effectuer une requête HTTPS en direct pour confirmer que le domaine sert du trafic et inspecter son certificat TLS. Lecture seule.",
+    "text": "Effectuez une requête HTTPS en direct pour confirmer que le domaine sert du trafic et inspecter son certificat TLS. Lecture seule.",
     "source_hash": "1eecfa96"
   },
   "web.admin.domaintoolbox.probe.button": {
@@ -76,7 +76,7 @@
     "source_hash": "3bd51ab9"
   },
   "web.admin.domaintoolbox.probe.healthLabel": {
-    "text": "État de santé",
+    "text": "Santé",
     "source_hash": "55898449"
   },
   "web.admin.domaintoolbox.repair.title": {
@@ -84,7 +84,7 @@
     "source_hash": "0053d07c"
   },
   "web.admin.domaintoolbox.repair.description": {
-    "text": "Corriger les incohérences de relation d'organisation pour un domaine. Prévisualisez d'abord, puis appliquez.",
+    "text": "Corrigez les incohérences de relation avec l'organisation pour un domaine. Prévisualisez d'abord, puis appliquez.",
     "source_hash": "18ca490b"
   },
   "web.admin.domaintoolbox.repair.orgIdLabel": {
@@ -92,11 +92,11 @@
     "source_hash": "f95b010a"
   },
   "web.admin.domaintoolbox.repair.orgIdPlaceholder": {
-    "text": "id d'organisation ou extid",
+    "text": "id ou extid de l'organisation",
     "source_hash": "a87d634e"
   },
   "web.admin.domaintoolbox.repair.statusLabel": {
-    "text": "Statut",
+    "text": "État",
     "source_hash": "920e413c"
   },
   "web.admin.domaintoolbox.repair.noIssues": {
@@ -116,7 +116,7 @@
     "source_hash": "9429998b"
   },
   "web.admin.domaintoolbox.repair.confirmDescription": {
-    "text": "Cela modifiera l'état de propriété/relation pour {domain}. Saisissez à nouveau l'ID externe du domaine pour confirmer.",
+    "text": "Cela modifiera l'état de propriété et de relation pour {domain}. Ressaisissez l'ID externe du domaine pour confirmer.",
     "source_hash": "426d267b"
   },
   "web.admin.domaintoolbox.reverify.button": {
@@ -132,7 +132,7 @@
     "source_hash": "3667f939"
   },
   "web.admin.domaintoolbox.transfer.description": {
-    "text": "Réattribuer un domaine à une autre organisation. Action au plus fort impact — prévisualisez et confirmez avec soin.",
+    "text": "Réattribuez un domaine à une autre organisation. Action au rayon d'impact le plus large — prévisualisez et confirmez avec soin.",
     "source_hash": "d4e26e03"
   },
   "web.admin.domaintoolbox.transfer.toOrgLabel": {
@@ -144,7 +144,7 @@
     "source_hash": "3666815f"
   },
   "web.admin.domaintoolbox.transfer.fromOrgPlaceholder": {
-    "text": "affirmer le propriétaire actuel",
+    "text": "confirmer le propriétaire actuel",
     "source_hash": "cd9e769c"
   },
   "web.admin.domaintoolbox.transfer.from": {
@@ -152,7 +152,7 @@
     "source_hash": "21819769"
   },
   "web.admin.domaintoolbox.transfer.to": {
-    "text": "À",
+    "text": "Vers",
     "source_hash": "f4b06ef6"
   },
   "web.admin.domaintoolbox.transfer.orphaned": {
@@ -172,7 +172,7 @@
     "source_hash": "d306a15a"
   },
   "web.admin.domaintoolbox.transfer.confirmDescription": {
-    "text": "Cela réattribue la propriété de {domain} à une autre organisation. Saisissez à nouveau l'ID externe du domaine pour confirmer.",
+    "text": "Cela réattribue la propriété de {domain} à une autre organisation. Ressaisissez l'ID externe du domaine pour confirmer.",
     "source_hash": "edefd97c"
   }
 }

--- a/locales/content/fr_FR/admin-emailtools.json
+++ b/locales/content/fr_FR/admin-emailtools.json
@@ -4,15 +4,15 @@
     "source_hash": "f9643d5a"
   },
   "web.admin.emailtools.description": {
-    "text": "Prévisualiser les modèles d'e-mail, envoyer un test de livraison et surveiller la délivrabilité — les diagnostics qui nécessitaient auparavant SSH.",
+    "text": "Prévisualisez les modèles d'e-mail, envoyez un test de distribution et surveillez la délivrabilité — les diagnostics qui nécessitaient auparavant un accès SSH.",
     "source_hash": "be85c9e9"
   },
   "web.admin.emailtools.config.title": {
-    "text": "Configuration du serveur de messagerie",
+    "text": "Configuration du service d'e-mail",
     "source_hash": "d2a71028"
   },
   "web.admin.emailtools.config.description": {
-    "text": "La configuration de messagerie permanente résolue au démarrage. Les identifiants ne sont jamais affichés — seulement leur présence.",
+    "text": "La configuration de messagerie permanente résolue au démarrage. Les identifiants ne sont jamais affichés — seule leur présence est indiquée.",
     "source_hash": "f0e8a118"
   },
   "web.admin.emailtools.config.provider": {
@@ -32,11 +32,11 @@
     "source_hash": "a69c7f9e"
   },
   "web.admin.emailtools.config.fromAddress": {
-    "text": "Adresse d'expéditeur",
+    "text": "Adresse de l'expéditeur",
     "source_hash": "d465bcfa"
   },
   "web.admin.emailtools.config.fromName": {
-    "text": "Nom d'expéditeur",
+    "text": "Nom de l'expéditeur",
     "source_hash": "b28f93ea"
   },
   "web.admin.emailtools.config.host": {
@@ -64,7 +64,7 @@
     "source_hash": "1ea442a1"
   },
   "web.admin.emailtools.config.loggerWarning": {
-    "text": "Les e-mails ne sont pas livrés. Le fournisseur de transport est en mode sans envoi (logger, disabled ou none), aucun e-mail ne quitte donc ce serveur — les messages sortants sont écrits dans le journal de l'application ou abandonnés.",
+    "text": "Les e-mails ne sont pas distribués. Le fournisseur de transport est en mode sans envoi (logger, désactivé ou aucun) ; aucun e-mail ne quitte donc ce serveur — les messages sortants sont écrits dans le journal de l'application ou abandonnés.",
     "source_hash": "1883dfd5"
   },
   "web.admin.emailtools.deliverability.title": {
@@ -72,7 +72,7 @@
     "source_hash": "66b4d300"
   },
   "web.admin.emailtools.deliverability.description": {
-    "text": "Ce qui revient après l'envoi : rebonds, plaintes et liste de suppression qui protège votre réputation d'expéditeur.",
+    "text": "Ce qui revient après l'envoi : rejets, plaintes et liste de suppression qui protège votre réputation d'expéditeur.",
     "source_hash": "e8363bb5"
   },
   "web.admin.emailtools.deliverability.retry": {
@@ -84,11 +84,11 @@
     "source_hash": "8ecce94d"
   },
   "web.admin.emailtools.deliverability.events.description": {
-    "text": "Le flux brut des rebonds et des plaintes, le plus récent en premier.",
+    "text": "Le flux brut des rejets et des plaintes, le plus récent en premier.",
     "source_hash": "0e7a533b"
   },
   "web.admin.emailtools.deliverability.events.empty": {
-    "text": "Aucune donnée de rebond ou de plainte pour l'instant. Transmettez les retours de votre ESP via POST /api/colonel/email/deliverability/events (authentifié colonel — voir la documentation du point de terminaison pour le format d'enregistrement). Les rebonds durs SMTP synchrones sont enregistrés automatiquement.",
+    "text": "Aucune donnée de rejet ou de plainte pour l'instant. Transmettez le retour de votre ESP via POST /api/colonel/email/deliverability/events (authentification colonel — consultez la documentation du point de terminaison pour le format des enregistrements). Les rejets définitifs SMTP synchrones sont enregistrés automatiquement.",
     "source_hash": "a90f259c"
   },
   "web.admin.emailtools.deliverability.events.loadError": {
@@ -116,7 +116,7 @@
     "source_hash": "f81ab834"
   },
   "web.admin.emailtools.deliverability.events.kinds.bounce": {
-    "text": "rebond",
+    "text": "rejet",
     "source_hash": "4d6723e5"
   },
   "web.admin.emailtools.deliverability.events.kinds.complaint": {
@@ -128,7 +128,7 @@
     "source_hash": "7569985b"
   },
   "web.admin.emailtools.deliverability.lookup.description": {
-    "text": "Vérifier si une adresse est supprimée, à la fois dans le magasin local et en direct chez le fournisseur de messagerie actif. Les deux sont indexés par la même adresse normalisée.",
+    "text": "Vérifiez si une adresse est supprimée, à la fois dans le magasin local et en direct chez le fournisseur de messagerie actif. Les deux utilisent la même adresse normalisée comme clé.",
     "source_hash": "c341d614"
   },
   "web.admin.emailtools.deliverability.lookup.addressLabel": {
@@ -164,7 +164,7 @@
     "source_hash": "0e570ca6"
   },
   "web.admin.emailtools.deliverability.lookup.unavailable": {
-    "text": "La recherche en direct chez le fournisseur est indisponible ; le magasin local ci-dessus fait foi.",
+    "text": "La recherche en direct auprès du fournisseur est indisponible ; le magasin local ci-dessus fait foi.",
     "source_hash": "aebed0f2"
   },
   "web.admin.emailtools.deliverability.messages.title": {
@@ -172,7 +172,7 @@
     "source_hash": "522e089e"
   },
   "web.admin.emailtools.deliverability.messages.description": {
-    "text": "Les messages les plus récents enregistrés par le fournisseur de messagerie actif, le plus récent en premier. Récupérés en direct auprès du fournisseur — jamais stockés ici.",
+    "text": "Les messages les plus récents enregistrés par le fournisseur de messagerie actif, le plus récent en premier. Provenance en direct du fournisseur — jamais stockés ici.",
     "source_hash": "9970fa0a"
   },
   "web.admin.emailtools.deliverability.messages.empty": {
@@ -180,7 +180,7 @@
     "source_hash": "a7ef4d79"
   },
   "web.admin.emailtools.deliverability.messages.notSupported": {
-    "text": "Un journal d'envoi n'est pas disponible sur le transport {provider}, qui n'offre pas d'API par message.",
+    "text": "Aucun journal d'envoi n'est disponible sur le transport {provider}, qui n'offre pas d'API par message.",
     "source_hash": "21e6b6f9"
   },
   "web.admin.emailtools.deliverability.messages.error": {
@@ -188,7 +188,7 @@
     "source_hash": "4f671e55"
   },
   "web.admin.emailtools.deliverability.messages.col.status": {
-    "text": "Statut",
+    "text": "État",
     "source_hash": "920e413c"
   },
   "web.admin.emailtools.deliverability.messages.col.subject": {
@@ -204,7 +204,7 @@
     "source_hash": "c16bc82b"
   },
   "web.admin.emailtools.deliverability.messages.status.delivered": {
-    "text": "livré",
+    "text": "distribué",
     "source_hash": "373e0712"
   },
   "web.admin.emailtools.deliverability.messages.status.opened": {
@@ -228,11 +228,11 @@
     "source_hash": "58190ffa"
   },
   "web.admin.emailtools.deliverability.messages.status.hard_bounced": {
-    "text": "rebond dur",
+    "text": "rejet définitif",
     "source_hash": "b0aa6fd4"
   },
   "web.admin.emailtools.deliverability.messages.status.soft_bounced": {
-    "text": "rebond léger",
+    "text": "rejet temporaire",
     "source_hash": "ac844ff2"
   },
   "web.admin.emailtools.deliverability.messages.status.complained": {
@@ -256,7 +256,7 @@
     "source_hash": "9f3e322f"
   },
   "web.admin.emailtools.deliverability.suppressions.description": {
-    "text": "Adresses que les e-mails sortants ignorent. Les entrées proviennent de l'ingestion des retours de l'ESP ou d'un import manuel ; en supprimer une reprend la livraison.",
+    "text": "Adresses que les envois sortants ignorent. Les entrées proviennent de l'ingestion des retours de l'ESP ou d'un import manuel ; en supprimer une rétablit la distribution.",
     "source_hash": "3651887e"
   },
   "web.admin.emailtools.deliverability.suppressions.searchLabel": {
@@ -276,7 +276,7 @@
     "source_hash": "83b12c22"
   },
   "web.admin.emailtools.deliverability.suppressions.empty": {
-    "text": "Aucune adresse supprimée pour l'instant. Elles apparaîtront ici au fur et à mesure de l'ingestion des retours de rebonds et de plaintes.",
+    "text": "Aucune adresse supprimée pour l'instant. Elles apparaîtront ici au fur et à mesure de l'ingestion des retours de rejets et de plaintes.",
     "source_hash": "dd3f4d61"
   },
   "web.admin.emailtools.deliverability.suppressions.emptySearch": {
@@ -300,7 +300,7 @@
     "source_hash": "40a0d2a6"
   },
   "web.admin.emailtools.deliverability.suppressions.add.confirmDescription": {
-    "text": "Les e-mails sortants vers {address} seront ignorés jusqu'à ce que la suppression soit retirée. Cela est enregistré comme une entrée manuelle.",
+    "text": "Les e-mails sortants vers {address} seront ignorés jusqu'à la levée de la suppression. Cela est enregistré comme une entrée manuelle.",
     "source_hash": "e3d0d799"
   },
   "web.admin.emailtools.deliverability.suppressions.add.success": {
@@ -308,7 +308,7 @@
     "source_hash": "e2cd2c3b"
   },
   "web.admin.emailtools.deliverability.suppressions.add.successExisting": {
-    "text": "L'adresse {address} était déjà supprimée ; entrée mise à jour.",
+    "text": "L'adresse {address} était déjà supprimée ; l'entrée a été mise à jour.",
     "source_hash": "0852101e"
   },
   "web.admin.emailtools.deliverability.suppressions.add.error": {
@@ -328,7 +328,7 @@
     "source_hash": "0e570ca6"
   },
   "web.admin.emailtools.deliverability.suppressions.columns.added": {
-    "text": "Ajoutée le",
+    "text": "Ajoutée",
     "source_hash": "6b02e0d3"
   },
   "web.admin.emailtools.deliverability.suppressions.columns.actions": {
@@ -344,7 +344,7 @@
     "source_hash": "0b0aec2e"
   },
   "web.admin.emailtools.deliverability.suppressions.remove.confirmDescription": {
-    "text": "Les e-mails sortants vers {address} reprendront. Cette adresse a précédemment rebondi ou déposé une plainte — ne la retirez que si vous savez qu'elle est à nouveau joignable.",
+    "text": "Les e-mails sortants vers {address} reprendront. Cette adresse a précédemment généré un rejet ou une plainte — ne la retirez que si vous savez qu'elle est de nouveau joignable.",
     "source_hash": "09442f9c"
   },
   "web.admin.emailtools.deliverability.suppressions.remove.success": {
@@ -364,7 +364,7 @@
     "source_hash": "1bc18c45"
   },
   "web.admin.emailtools.deliverability.sync.neverRun": {
-    "text": "La synchronisation des retours du fournisseur n'a jamais été exécutée. Les données de rebonds et de plaintes ne sont pas importées automatiquement — configurez une synchronisation du fournisseur ou ingérez les retours via le point de terminaison des événements.",
+    "text": "La synchronisation des retours du fournisseur n'a jamais été exécutée. Les données de rejets et de plaintes ne sont pas importées automatiquement — configurez une synchronisation avec le fournisseur ou ingérez les retours via le point de terminaison des événements.",
     "source_hash": "d19f5755"
   },
   "web.admin.emailtools.deliverability.sync.button": {
@@ -376,7 +376,7 @@
     "source_hash": "d36f5578"
   },
   "web.admin.emailtools.deliverability.sync.hint": {
-    "text": "Une synchronisation manuelle — l'import automatique nécessite toujours une tâche cron `ots email sync-feedback` planifiée.",
+    "text": "Il s'agit d'une synchronisation manuelle — l'import automatique nécessite toujours une tâche cron planifiée `ots email sync-feedback`.",
     "source_hash": "7a509b75"
   },
   "web.admin.emailtools.deliverability.tiles.suppressed": {
@@ -384,7 +384,7 @@
     "source_hash": "b31a245e"
   },
   "web.admin.emailtools.deliverability.tiles.bounces": {
-    "text": "Rebonds ({days} j)",
+    "text": "Rejets ({days} j)",
     "source_hash": "3a4d0f09"
   },
   "web.admin.emailtools.deliverability.tiles.complaints": {
@@ -400,7 +400,7 @@
     "source_hash": "df89bd92"
   },
   "web.admin.emailtools.preview.description": {
-    "text": "Générer un modèle avec ses données d'exemple. L'aperçu n'a aucun effet de bord — aucun e-mail n'est envoyé.",
+    "text": "Affichez un modèle avec ses données d'exemple. L'aperçu n'a aucun effet secondaire — aucun e-mail n'est envoyé.",
     "source_hash": "9b0e40f3"
   },
   "web.admin.emailtools.preview.templateLabel": {
@@ -420,27 +420,27 @@
     "source_hash": "324b134f"
   },
   "web.admin.emailtools.providerStatus.title": {
-    "text": "Statut du fournisseur",
+    "text": "État du fournisseur",
     "source_hash": "231b7f03"
   },
   "web.admin.emailtools.providerStatus.rateUnavailable": {
-    "text": "Ce fournisseur n'expose aucun taux numérique de rebond ou de plainte ; le niveau de réputation ci-dessus est déduit uniquement du statut d'application et du quota d'envoi.",
+    "text": "Ce fournisseur n'expose aucun taux numérique de rejets ou de plaintes ; le niveau de réputation ci-dessus est déduit uniquement de l'état d'application des règles et du quota d'envoi.",
     "source_hash": "1e6b82e9"
   },
   "web.admin.emailtools.providerStatus.complaintsUnavailable": {
-    "text": "Lettermint ne signale pas les plaintes dans son API de statistiques ; le taux de plaintes est donc affiché comme « — » (non signalé) et non comme zéro. Le taux de rebond ci-dessus est complet.",
+    "text": "Lettermint ne signale pas les plaintes dans son API de statistiques ; le taux de plaintes est donc affiché sous la forme « — » (non communiqué) et non zéro. Le taux de rejets ci-dessus est complet.",
     "source_hash": "72aaa845"
   },
   "web.admin.emailtools.providerStatus.unavailable": {
-    "text": "Le statut du fournisseur est temporairement indisponible.",
+    "text": "L'état du fournisseur est temporairement indisponible.",
     "source_hash": "8e69ff29"
   },
   "web.admin.emailtools.providerStatus.notSupported": {
-    "text": "Le statut du fournisseur en direct n'est pas disponible sur le transport {provider}.",
+    "text": "L'état en direct du fournisseur n'est pas disponible sur le transport {provider}.",
     "source_hash": "125ed6eb"
   },
   "web.admin.emailtools.providerStatus.error": {
-    "text": "Impossible de joindre le fournisseur de messagerie pour obtenir le statut. Réessayez.",
+    "text": "Impossible de joindre le fournisseur de messagerie pour obtenir son état. Réessayez.",
     "source_hash": "594ab7b1"
   },
   "web.admin.emailtools.providerStatus.quota.max24h": {
@@ -452,11 +452,11 @@
     "source_hash": "d0c4fe45"
   },
   "web.admin.emailtools.providerStatus.quota.maxRate": {
-    "text": "Débit d'envoi maximal (par sec)",
+    "text": "Débit d'envoi maximal (par seconde)",
     "source_hash": "59e76cf8"
   },
   "web.admin.emailtools.providerStatus.rate.bounce": {
-    "text": "Taux de rebond",
+    "text": "Taux de rejets",
     "source_hash": "9eba32f0"
   },
   "web.admin.emailtools.providerStatus.rate.complaint": {
@@ -468,11 +468,11 @@
     "source_hash": "e553b7e1"
   },
   "web.admin.emailtools.providerStatus.stats.delivered": {
-    "text": "Livrés",
+    "text": "Distribués",
     "source_hash": "90611565"
   },
   "web.admin.emailtools.providerStatus.stats.hardBounced": {
-    "text": "Rebonds durs",
+    "text": "Rejets définitifs",
     "source_hash": "c76631c0"
   },
   "web.admin.emailtools.providerStatus.stats.complaints": {
@@ -488,7 +488,7 @@
     "source_hash": "9e8a3b64"
   },
   "web.admin.emailtools.providerStatus.tier.shutdown": {
-    "text": "Envoi suspendu",
+    "text": "Envois suspendus",
     "source_hash": "52e6757c"
   },
   "web.admin.emailtools.test.title": {
@@ -496,7 +496,7 @@
     "source_hash": "5fab5d67"
   },
   "web.admin.emailtools.test.description": {
-    "text": "Envoyer un e-mail de diagnostic en texte brut pour vérifier la connectivité de livraison. Prévisualisez-le d'abord, puis confirmez pour envoyer un véritable e-mail.",
+    "text": "Envoyez un e-mail de diagnostic en texte brut pour vérifier la connectivité de distribution. Prévisualisez-le d'abord, puis confirmez pour envoyer un e-mail réel.",
     "source_hash": "4130741c"
   },
   "web.admin.emailtools.test.toLabel": {
@@ -504,7 +504,7 @@
     "source_hash": "51fac985"
   },
   "web.admin.emailtools.test.toPlaceholder": {
-    "text": "you{'@'}example.com",
+    "text": "vous{'@'}example.com",
     "source_hash": "cf0a9acc"
   },
   "web.admin.emailtools.test.enqueueLabel": {
@@ -540,7 +540,7 @@
     "source_hash": "64a16b62"
   },
   "web.admin.emailtools.test.confirmDescription": {
-    "text": "Cela envoie un e-mail réel à {to} via le serveur de messagerie configuré.",
+    "text": "Cela envoie un e-mail réel à {to} via le service de messagerie configuré.",
     "source_hash": "10114929"
   },
   "web.admin.emailtools.test.success": {

--- a/locales/content/fr_FR/admin-organizations.json
+++ b/locales/content/fr_FR/admin-organizations.json
@@ -12,7 +12,7 @@
     "source_hash": "00c50f7a"
   },
   "web.admin.organizations.detail.notFoundDescription": {
-    "text": "Cette organisation a peut-être été supprimée, ou l'id est incorrect.",
+    "text": "Cette organisation a peut-être été supprimée, ou l'identifiant est incorrect.",
     "source_hash": "e5459ef5"
   },
   "web.admin.organizations.detail.loadError": {
@@ -40,7 +40,7 @@
     "source_hash": "a3b50c47"
   },
   "web.admin.organizations.detail.domains.created": {
-    "text": "Créé le",
+    "text": "Créé",
     "source_hash": "d70b9e24"
   },
   "web.admin.organizations.detail.domains.ready": {
@@ -48,7 +48,7 @@
     "source_hash": "5fa7aac5"
   },
   "web.admin.organizations.detail.domains.resolving": {
-    "text": "Résolution en cours",
+    "text": "Résolution",
     "source_hash": "3287a034"
   },
   "web.admin.organizations.detail.domains.empty": {
@@ -56,7 +56,7 @@
     "source_hash": "1b840c7e"
   },
   "web.admin.organizations.detail.entitlements.description": {
-    "text": "Les droits effectifs correspondent à (forfait ∪ octrois) − révocations. Examinez le détail avant d'effectuer un remplacement.",
+    "text": "Les droits effectifs se résolvent en (forfait ∪ octrois) − révocations. Examinez le détail avant d'appliquer un remplacement.",
     "source_hash": "23080475"
   },
   "web.admin.organizations.detail.entitlements.inSync": {
@@ -72,11 +72,11 @@
     "source_hash": "ffe63800"
   },
   "web.admin.organizations.detail.entitlements.driftWarning": {
-    "text": "Les droits matérialisés ne correspondent pas à l'ensemble attendu. Réconciliez pour rematérialiser.",
+    "text": "Les droits matérialisés ne correspondent pas à l'ensemble attendu. Lancez une réconciliation pour les rematérialiser.",
     "source_hash": "4859983a"
   },
   "web.admin.organizations.detail.entitlements.driftExtra": {
-    "text": "Supplémentaires (matérialisés, non attendus)",
+    "text": "En trop (matérialisés, non attendus)",
     "source_hash": "08d60730"
   },
   "web.admin.organizations.detail.entitlements.driftMissing": {
@@ -100,7 +100,7 @@
     "source_hash": "14736a2e"
   },
   "web.admin.organizations.detail.members.status": {
-    "text": "Statut",
+    "text": "État",
     "source_hash": "920e413c"
   },
   "web.admin.organizations.detail.members.joined": {
@@ -124,7 +124,7 @@
     "source_hash": "fc1a2762"
   },
   "web.admin.organizations.detail.reconcile.confirmDescription": {
-    "text": "Cela récupère à nouveau les données Stripe et réécrit l'état de facturation et les droits pour {org}. Saisissez à nouveau l'id de l'organisation pour confirmer.",
+    "text": "Cela récupère à nouveau les données Stripe et réécrit l'état de facturation et les droits de {org}. Ressaisissez l'identifiant de l'organisation pour confirmer.",
     "source_hash": "b4ef0850"
   },
   "web.admin.organizations.detail.reconcile.success": {
@@ -168,7 +168,7 @@
     "source_hash": "ced67718"
   },
   "web.admin.organizations.detail.sections.investigate": {
-    "text": "Investiguer et réconcilier",
+    "text": "Analyser et réconcilier",
     "source_hash": "b05aa349"
   },
   "web.admin.organizations.entitlements.section": {
@@ -176,7 +176,7 @@
     "source_hash": "48812068"
   },
   "web.admin.organizations.entitlements.description": {
-    "text": "Octroyer ou révoquer des droits indépendamment du forfait. Effectifs = droits du forfait + octrois - révocations.",
+    "text": "Octroyez ou révoquez des droits indépendamment du forfait. Effectifs = droits du forfait + octrois - révocations.",
     "source_hash": "4c38425b"
   },
   "web.admin.organizations.entitlements.inputLabel": {
@@ -184,7 +184,7 @@
     "source_hash": "0d8f0b2d"
   },
   "web.admin.organizations.entitlements.placeholder": {
-    "text": "par ex. custom_domains",
+    "text": "ex. custom_domains",
     "source_hash": "05346c68"
   },
   "web.admin.organizations.entitlements.grant": {
@@ -220,7 +220,7 @@
     "source_hash": "a4b2c57b"
   },
   "web.admin.organizations.entitlements.confirm.grantDescription": {
-    "text": "Octroyer « {entitlement} » à {org}. Cela modifie les droits de facturation de l'organisation.",
+    "text": "Octroyer « {entitlement} » à {org}. Cela modifie les droits de facturation de l'organisation.",
     "source_hash": "542ce26a"
   },
   "web.admin.organizations.entitlements.confirm.revokeTitle": {
@@ -228,7 +228,7 @@
     "source_hash": "c93d520a"
   },
   "web.admin.organizations.entitlements.confirm.revokeDescription": {
-    "text": "Révoquer « {entitlement} » de {org}. Cela modifie les droits de facturation de l'organisation.",
+    "text": "Révoquer « {entitlement} » pour {org}. Cela modifie les droits de facturation de l'organisation.",
     "source_hash": "a5d2a8a6"
   },
   "web.admin.organizations.entitlements.confirm.clearTitle": {
@@ -236,15 +236,15 @@
     "source_hash": "e36eb218"
   },
   "web.admin.organizations.entitlements.confirm.clearDescription": {
-    "text": "Supprimer tous les remplacements d'octroi et de révocation pour {org}, en la réinitialisant aux droits de son forfait.",
+    "text": "Supprimer tous les octrois et révocations pour {org}, la réinitialisant aux droits de son forfait.",
     "source_hash": "96bad079"
   },
   "web.admin.organizations.entitlements.success.granted": {
-    "text": "Droit « {entitlement} » octroyé.",
+    "text": "Droit « {entitlement} » octroyé.",
     "source_hash": "cf52fb0e"
   },
   "web.admin.organizations.entitlements.success.revoked": {
-    "text": "Droit « {entitlement} » révoqué.",
+    "text": "Droit « {entitlement} » révoqué.",
     "source_hash": "279d425d"
   },
   "web.admin.organizations.entitlements.success.cleared": {
@@ -264,7 +264,7 @@
     "source_hash": "fa8ed0bd"
   },
   "web.admin.organizations.fields.subscription": {
-    "text": "Statut de l'abonnement",
+    "text": "État de l'abonnement",
     "source_hash": "f0723c4e"
   },
   "web.admin.organizations.fields.periodEnd": {
@@ -288,27 +288,355 @@
     "source_hash": "1f466322"
   },
   "web.admin.organizations.fields.created": {
-    "text": "Créé le",
+    "text": "Créée",
     "source_hash": "d70b9e24"
   },
   "web.admin.organizations.fields.updated": {
-    "text": "Mis à jour le",
+    "text": "Mise à jour",
     "source_hash": "3a5ecca1"
   },
   "web.admin.organizations.investigate.description": {
-    "text": "Comparer l'état de facturation local à l'abonnement Stripe en direct.",
+    "text": "Comparez l'état de facturation local avec l'abonnement Stripe actif.",
     "source_hash": "d7bbe9ed"
   },
   "web.admin.organizations.investigate.rawPayload": {
-    "text": "Charge utile d'investigation brute",
+    "text": "Charge utile brute de l'analyse",
     "source_hash": "29ca7df2"
   },
   "web.admin.organizations.investigate.parseError": {
-    "text": "La réponse de l'investigation ne correspondait pas au format attendu.",
+    "text": "La réponse de l'analyse ne correspond pas au format attendu.",
     "source_hash": "db59cab1"
   },
   "web.admin.organizations.list.loadError": {
     "text": "Impossible de charger les organisations.",
     "source_hash": "130d5e70"
+  },
+  "web.admin.organizations.addMember.button": {
+    "text": "Ajouter un compte existant",
+    "source_hash": "45a3b757"
+  },
+  "web.admin.organizations.addMember.title": {
+    "text": "Ajouter un compte existant",
+    "source_hash": "2f676a94"
+  },
+  "web.admin.organizations.addMember.description": {
+    "text": "Ajoutez à {org} une personne qui possède déjà un compte. Utilisez cette option lorsqu'une personne s'est inscrite d'elle-même et ne peut pas être invitée parce que le compte existe déjà.",
+    "source_hash": "bb41faa6"
+  },
+  "web.admin.organizations.addMember.searchLabel": {
+    "text": "Adresse e-mail ou identifiant de compte",
+    "source_hash": "82b3040b"
+  },
+  "web.admin.organizations.addMember.searchPlaceholder": {
+    "text": "Rechercher par adresse e-mail",
+    "source_hash": "b75cc66c"
+  },
+  "web.admin.organizations.addMember.searchHint": {
+    "text": "Correspond à une partie d'une adresse e-mail ou à un identifiant de compte exact.",
+    "source_hash": "84547a60"
+  },
+  "web.admin.organizations.addMember.searchError": {
+    "text": "Impossible de rechercher les comptes. Vérifiez la connexion et réessayez.",
+    "source_hash": "4b6caa41"
+  },
+  "web.admin.organizations.addMember.searchParseError": {
+    "text": "La recherche de comptes a renvoyé une réponse inattendue. Les résultats peuvent être incomplets.",
+    "source_hash": "0c814231"
+  },
+  "web.admin.organizations.addMember.idle": {
+    "text": "Saisissez une adresse e-mail pour trouver le compte.",
+    "source_hash": "f6340d35"
+  },
+  "web.admin.organizations.addMember.noResults": {
+    "text": "Aucun compte ne correspond à « {term} ».",
+    "source_hash": "199b662a"
+  },
+  "web.admin.organizations.addMember.noResultsHint": {
+    "text": "Seuls les comptes existants peuvent être ajoutés ici. Si la personne ne s'est jamais inscrite, invitez-la à la place.",
+    "source_hash": "ee90aeeb"
+  },
+  "web.admin.organizations.addMember.select": {
+    "text": "Sélectionner",
+    "source_hash": "2a78025d"
+  },
+  "web.admin.organizations.addMember.selectedEyebrow": {
+    "text": "Compte sélectionné",
+    "source_hash": "8b63d947"
+  },
+  "web.admin.organizations.addMember.change": {
+    "text": "Choisir un autre compte",
+    "source_hash": "d4fe39ab"
+  },
+  "web.admin.organizations.addMember.createdOn": {
+    "text": "Inscrit le {date}",
+    "source_hash": "cfc0e19f"
+  },
+  "web.admin.organizations.addMember.organizationsUnavailable": {
+    "text": "Impossible de charger les organisations actuelles de ce compte.",
+    "source_hash": "a35b6bfc"
+  },
+  "web.admin.organizations.addMember.defaultOrg": {
+    "text": "par défaut",
+    "source_hash": "37a8eec1"
+  },
+  "web.admin.organizations.addMember.roleLabel": {
+    "text": "Rôle dans cette organisation",
+    "source_hash": "817475fa"
+  },
+  "web.admin.organizations.addMember.submit": {
+    "text": "Ajouter à l'organisation",
+    "source_hash": "0e0cb636"
+  },
+  "web.admin.organizations.addMember.success": {
+    "text": "{account} ajouté en tant que {role}.",
+    "source_hash": "533be0dc"
+  },
+  "web.admin.organizations.addMember.badges.verified": {
+    "text": "Vérifié",
+    "source_hash": "4f783840"
+  },
+  "web.admin.organizations.addMember.badges.unverified": {
+    "text": "Non vérifié",
+    "source_hash": "15133907"
+  },
+  "web.admin.organizations.addMember.badges.suspended": {
+    "text": "Suspendu",
+    "source_hash": "e392a389"
+  },
+  "web.admin.organizations.addMember.badges.alreadyMember": {
+    "text": "Déjà membre",
+    "source_hash": "1739ed7c"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMember": {
+    "text": "Ce compte est déjà membre de cette organisation, avec le rôle {role}. L'ajout ne modifie pas un rôle existant — utilisez l'action de définition de rôle pour cela.",
+    "source_hash": "cb6a4774"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMemberUnknownRole": {
+    "text": "Ce compte est déjà membre de cette organisation. L'ajout ne modifie pas un rôle existant.",
+    "source_hash": "035641ec"
+  },
+  "web.admin.organizations.addMember.errors.notFound": {
+    "text": "Ce compte ou cette organisation n'existe plus. Relancez la recherche pour confirmer le compte.",
+    "source_hash": "bd88db18"
+  },
+  "web.admin.organizations.addMember.errors.invalidRole": {
+    "text": "Ce rôle a été refusé. Choisissez l'un des rôles proposés et réessayez.",
+    "source_hash": "eb696a8f"
+  },
+  "web.admin.organizations.addMember.errors.noSelection": {
+    "text": "Aucun compte sélectionné.",
+    "source_hash": "dd15bb5b"
+  },
+  "web.admin.organizations.addMember.fields.created": {
+    "text": "Inscrit le",
+    "source_hash": "486b3fe0"
+  },
+  "web.admin.organizations.addMember.fields.verified": {
+    "text": "Vérification",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.organizations.addMember.fields.lastLogin": {
+    "text": "Dernière connexion",
+    "source_hash": "0b70af7a"
+  },
+  "web.admin.organizations.addMember.fields.organizations": {
+    "text": "Organisations actuelles",
+    "source_hash": "cbb5b92f"
+  },
+  "web.admin.organizations.addMember.roleHints.member": {
+    "text": "Accès quotidien aux secrets et aux domaines de l'organisation.",
+    "source_hash": "d0c7439e"
+  },
+  "web.admin.organizations.addMember.roleHints.admin": {
+    "text": "Peut gérer les membres, les domaines et les paramètres de l'organisation.",
+    "source_hash": "beaa50d7"
+  },
+  "web.admin.organizations.addMember.roleHints.owner": {
+    "text": "Contrôle total, y compris la facturation. N'accordez ce rôle que sur demande.",
+    "source_hash": "614ace63"
+  },
+  "web.admin.organizations.addMember.roles.member": {
+    "text": "Membre",
+    "source_hash": "7c968fb7"
+  },
+  "web.admin.organizations.addMember.roles.admin": {
+    "text": "Administrateur",
+    "source_hash": "c1c224b0"
+  },
+  "web.admin.organizations.addMember.roles.owner": {
+    "text": "Propriétaire",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.detail.members.openCustomer": {
+    "text": "Ouvrir la fiche client",
+    "source_hash": "c057ca13"
+  },
+  "web.admin.organizations.detail.reconcile.memberships": {
+    "text": "Adhésions rematérialisées :",
+    "source_hash": "fe7db10c"
+  },
+  "web.admin.organizations.detail.reconcile.membershipsFailed": {
+    "text": "en échec, des droits obsolètes subsistent :",
+    "source_hash": "cc4dae37"
+  },
+  "web.admin.organizations.entitlements.catalogWarning": {
+    "text": "« {entitlement} » ne figure pas dans le catalogue de facturation — vérifiez qu'il n'y a pas de faute de frappe. L'opération se poursuit malgré tout : octroyer un droit livré dans un catalogue ultérieur est pris en charge et volontairement non bloqué.",
+    "source_hash": "cbde548a"
+  },
+  "web.admin.organizations.entitlements.matrix.caption": {
+    "text": "Matrice de résolution des droits : forfait, octrois et révocations de remplacement, ensemble résolu et éléments matérialisés.",
+    "source_hash": "9eac8999"
+  },
+  "web.admin.organizations.entitlements.matrix.yes": {
+    "text": "Oui",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.matrix.no": {
+    "text": "Non",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.matrix.empty": {
+    "text": "Cette organisation n'a aucun droit issu de son forfait ni aucun remplacement.",
+    "source_hash": "f6cf2169"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.entitlement": {
+    "text": "Droit",
+    "source_hash": "0d8f0b2d"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.inPlan": {
+    "text": "Dans le forfait",
+    "source_hash": "e2222361"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.granted": {
+    "text": "Octroyé",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.revoked": {
+    "text": "Révoqué",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.expected": {
+    "text": "Attendu",
+    "source_hash": "ca99b7f1"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.materialized": {
+    "text": "Matérialisé",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.state": {
+    "text": "État",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.formula": {
+    "text": "Résolution : attendu = (forfait ∪ octrois) − révocations. Le matérialisé correspond à ce qui est réellement stocké sur l'organisation.",
+    "source_hash": "bc4bff2d"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.orphaned": {
+    "text": "Orphelin — matérialisé mais non attendu, généralement laissé par une révocation jamais rematérialisée. La réconciliation le supprime.",
+    "source_hash": "3a27a9af"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.missing": {
+    "text": "Manquant — attendu mais non matérialisé. C'est l'autorisation qui manque réellement aux membres en ce moment.",
+    "source_hash": "485e44ad"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.revoked": {
+    "text": "Les lignes barrées sont révoquées par un remplacement administrateur, ce qui les retire de l'ensemble attendu.",
+    "source_hash": "89a2e9b6"
+  },
+  "web.admin.organizations.entitlements.matrix.state.plan": {
+    "text": "Issu du forfait",
+    "source_hash": "1d346b26"
+  },
+  "web.admin.organizations.entitlements.matrix.state.granted": {
+    "text": "Octroyé",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.state.revoked": {
+    "text": "Révoqué",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.state.orphaned": {
+    "text": "Orphelin",
+    "source_hash": "8d827807"
+  },
+  "web.admin.organizations.entitlements.matrix.state.missing": {
+    "text": "Manquant",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.organizations.entitlements.picker.selectPlaceholder": {
+    "text": "Sélectionnez un droit…",
+    "source_hash": "53af3be8"
+  },
+  "web.admin.organizations.entitlements.picker.other": {
+    "text": "Autre — absent du catalogue…",
+    "source_hash": "f08bc3a3"
+  },
+  "web.admin.organizations.entitlements.picker.customLabel": {
+    "text": "Nom du droit (absent du catalogue)",
+    "source_hash": "52783229"
+  },
+  "web.admin.organizations.entitlements.picker.backToCatalog": {
+    "text": "Retour au catalogue",
+    "source_hash": "9b727f40"
+  },
+  "web.admin.organizations.entitlements.picker.uncategorized": {
+    "text": "Non catégorisé",
+    "source_hash": "8d40d123"
+  },
+  "web.admin.organizations.entitlements.picker.catalogUnavailable": {
+    "text": "Le catalogue de facturation n'a pas pu être lu ; les noms de droits ne sont donc pas vérifiés ici.",
+    "source_hash": "724869ec"
+  },
+  "web.admin.organizations.entitlements.picker.tags.inPlan": {
+    "text": "dans le forfait",
+    "source_hash": "5f2251bb"
+  },
+  "web.admin.organizations.entitlements.picker.tags.granted": {
+    "text": "octroyé",
+    "source_hash": "dd515d19"
+  },
+  "web.admin.organizations.entitlements.picker.tags.revoked": {
+    "text": "révoqué",
+    "source_hash": "4bb47f18"
+  },
+  "web.admin.organizations.entitlements.summary.sync": {
+    "text": "Synchronisation",
+    "source_hash": "8d261a37"
+  },
+  "web.admin.organizations.entitlements.summary.materialized": {
+    "text": "Matérialisé",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.summary.materializedAt": {
+    "text": "Dernière matérialisation",
+    "source_hash": "9325dce9"
+  },
+  "web.admin.organizations.entitlements.summary.planDefinition": {
+    "text": "Définition du forfait",
+    "source_hash": "6b531454"
+  },
+  "web.admin.organizations.entitlements.summary.yes": {
+    "text": "Oui",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.summary.no": {
+    "text": "Non",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.summary.never": {
+    "text": "Jamais",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.organizations.entitlements.summary.planStale": {
+    "text": "Modifiée depuis la matérialisation",
+    "source_hash": "e682d8a4"
+  },
+  "web.admin.organizations.entitlements.summary.planCurrent": {
+    "text": "À jour",
+    "source_hash": "e0d1b682"
+  },
+  "web.admin.organizations.entitlements.summary.planUnknown": {
+    "text": "Inconnue — comparaison impossible",
+    "source_hash": "b607e540"
   }
 }

--- a/locales/content/fr_FR/admin-overview.json
+++ b/locales/content/fr_FR/admin-overview.json
@@ -4,7 +4,7 @@
     "source_hash": "942087cc"
   },
   "web.admin.overview.feedback.title": {
-    "text": "Retours des utilisateurs",
+    "text": "Commentaires des utilisateurs",
     "source_hash": "cb7b24c6"
   },
   "web.admin.overview.feedback.total": {
@@ -24,11 +24,11 @@
     "source_hash": "03281c88"
   },
   "web.admin.overview.feedback.empty": {
-    "text": "Aucun retour sur cette période",
+    "text": "Aucun commentaire sur cette période",
     "source_hash": "e09d594d"
   },
   "web.admin.overview.feedback.loadError": {
-    "text": "Impossible de charger les retours.",
+    "text": "Impossible de charger les commentaires.",
     "source_hash": "4011c408"
   },
   "web.admin.overview.stats.heading": {

--- a/locales/content/fr_FR/admin-secrets.json
+++ b/locales/content/fr_FR/admin-secrets.json
@@ -1,11 +1,11 @@
 {
   "web.admin.secrets.title": {
-    "text": "Secrets",
-    "source_hash": "d8707d41"
+    "text": "Reçus de secrets",
+    "source_hash": "a8a2d0e4"
   },
   "web.admin.secrets.description": {
-    "text": "Inspecter le reçu d'un secret et le supprimer sans SSH — recherchez-le par sa clé.",
-    "source_hash": "07775a11"
+    "text": "Consultez l'état, les horodatages, le reçu, etc.",
+    "source_hash": "91fba2a1"
   },
   "web.admin.secrets.never": {
     "text": "Jamais",
@@ -60,11 +60,11 @@
     "source_hash": "a3b50c47"
   },
   "web.admin.secrets.fields.created": {
-    "text": "Créé le",
+    "text": "Créé",
     "source_hash": "d70b9e24"
   },
   "web.admin.secrets.fields.updated": {
-    "text": "Mis à jour le",
+    "text": "Mis à jour",
     "source_hash": "3a5ecca1"
   },
   "web.admin.secrets.fields.expiration": {
@@ -108,20 +108,20 @@
     "source_hash": "504101bc"
   },
   "web.admin.secrets.lookup.resultTitle": {
-    "text": "Secret {shortid}",
-    "source_hash": "8b311d32"
+    "text": "Enregistrement du secret {shortid}",
+    "source_hash": "ee06d765"
   },
   "web.admin.secrets.lookup.notFound": {
-    "text": "Secret introuvable",
-    "source_hash": "70a9532c"
+    "text": "Aucun enregistrement trouvé",
+    "source_hash": "40f4d9e9"
   },
   "web.admin.secrets.lookup.notFoundDescription": {
     "text": "Aucun secret n'existe avec cette clé. Il a peut-être expiré ou été supprimé.",
     "source_hash": "9f068a81"
   },
   "web.admin.secrets.lookup.loadError": {
-    "text": "Impossible de charger ce secret.",
-    "source_hash": "c96672e4"
+    "text": "Impossible de charger cet enregistrement.",
+    "source_hash": "de77cc72"
   },
   "web.admin.secrets.lookup.retry": {
     "text": "Réessayer",
@@ -172,7 +172,7 @@
     "source_hash": "1e8568a8"
   },
   "web.admin.secrets.receiptFields.hasPassphrase": {
-    "text": "Contient une phrase secrète",
+    "text": "Protégé par une phrase secrète",
     "source_hash": "af458f26"
   },
   "web.admin.secrets.receiptFields.shareDomain": {
@@ -180,7 +180,7 @@
     "source_hash": "db963805"
   },
   "web.admin.secrets.receiptFields.created": {
-    "text": "Créé le",
+    "text": "Créé",
     "source_hash": "d70b9e24"
   },
   "web.admin.secrets.receiptFields.secretExpired": {
@@ -188,8 +188,8 @@
     "source_hash": "c127dab6"
   },
   "web.admin.secrets.sections.secret": {
-    "text": "Secret",
-    "source_hash": "7e32a729"
+    "text": "Enregistrement du secret",
+    "source_hash": "263813c6"
   },
   "web.admin.secrets.sections.receipt": {
     "text": "Reçu",
@@ -214,5 +214,25 @@
   "web.admin.secrets.state.viewed": {
     "text": "Consulté",
     "source_hash": "1b28d178"
+  },
+  "web.admin.secrets.capability.title": {
+    "text": "Métadonnées uniquement",
+    "source_hash": "df0453d1"
+  },
+  "web.admin.secrets.capability.canRead": {
+    "text": "Lit les métadonnées d'un secret et son reçu : état, horodatages, propriétaire et taille du texte chiffré stocké.",
+    "source_hash": "d438ecc7"
+  },
+  "web.admin.secrets.capability.cannotRead": {
+    "text": "Ne peut ni déchiffrer ni afficher le contenu du secret. Le point de terminaison derrière cet écran ne le renvoie jamais.",
+    "source_hash": "7f69f222"
+  },
+  "web.admin.secrets.capability.canDelete": {
+    "text": "Peut supprimer définitivement un secret et son reçu, ce qui détruit le contenu sans jamais le révéler.",
+    "source_hash": "77f2bc7e"
+  },
+  "web.admin.secrets.lookup.hint": {
+    "text": "L'identifiant figurant dans le lien du secret — et non le contenu du secret.",
+    "source_hash": "acfbc352"
   }
 }

--- a/locales/content/fr_FR/admin-sessions.json
+++ b/locales/content/fr_FR/admin-sessions.json
@@ -4,7 +4,7 @@
     "source_hash": "6fa3cbf4"
   },
   "web.admin.sessions.description": {
-    "text": "Inspecter, rechercher et révoquer les sessions actives pour la réponse aux incidents.",
+    "text": "Inspectez, recherchez et révoquez les sessions actives lors de la réponse à incident.",
     "source_hash": "784a3a44"
   },
   "web.admin.sessions.anonymous": {
@@ -16,7 +16,7 @@
     "source_hash": "cb9ac5c5"
   },
   "web.admin.sessions.columns.authenticated": {
-    "text": "Auth",
+    "text": "Authentification",
     "source_hash": "8eb3ea9b"
   },
   "web.admin.sessions.columns.email": {
@@ -32,7 +32,7 @@
     "source_hash": "3c3de0c9"
   },
   "web.admin.sessions.columns.created": {
-    "text": "Authentifié le",
+    "text": "Authentifiée le",
     "source_hash": "8d6c9b01"
   },
   "web.admin.sessions.columns.actions": {
@@ -60,11 +60,11 @@
     "source_hash": "b764cdc0"
   },
   "web.admin.sessions.detail.noExpiry": {
-    "text": "Sans expiration",
+    "text": "Aucune expiration",
     "source_hash": "fe06351d"
   },
   "web.admin.sessions.detail.expired": {
-    "text": "Expiré",
+    "text": "Expirée",
     "source_hash": "424a2551"
   },
   "web.admin.sessions.detail.ttlSeconds": {
@@ -80,7 +80,7 @@
     "source_hash": "0969eab8"
   },
   "web.admin.sessions.drawer.notFoundDescription": {
-    "text": "Cette session n'existe plus dans Redis. Elle a peut-être expiré ou déjà été révoquée.",
+    "text": "Cette session n'existe plus dans Redis. Elle a peut-être expiré ou été déjà révoquée.",
     "source_hash": "11e3ef05"
   },
   "web.admin.sessions.drawer.loadError": {
@@ -104,7 +104,7 @@
     "source_hash": "76f6014f"
   },
   "web.admin.sessions.fields.authenticated": {
-    "text": "Authentifié",
+    "text": "Authentifiée",
     "source_hash": "6ab694cf"
   },
   "web.admin.sessions.fields.email": {
@@ -116,7 +116,7 @@
     "source_hash": "69da56ba"
   },
   "web.admin.sessions.fields.accountId": {
-    "text": "ID de compte",
+    "text": "ID du compte",
     "source_hash": "919bb4cb"
   },
   "web.admin.sessions.fields.role": {
@@ -132,11 +132,11 @@
     "source_hash": "3c3de0c9"
   },
   "web.admin.sessions.fields.authenticatedAt": {
-    "text": "Authentifié le",
+    "text": "Authentifiée le",
     "source_hash": "8d6c9b01"
   },
   "web.admin.sessions.fields.authenticatedBy": {
-    "text": "Authentifié par",
+    "text": "Authentifiée par",
     "source_hash": "3ebbabfe"
   },
   "web.admin.sessions.fields.activeSessionId": {
@@ -148,7 +148,7 @@
     "source_hash": "62e01345"
   },
   "web.admin.sessions.fields.orgContext": {
-    "text": "Contexte d'organisation",
+    "text": "Contexte de l'organisation",
     "source_hash": "a596d9f2"
   },
   "web.admin.sessions.list.loadError": {
@@ -184,7 +184,7 @@
     "source_hash": "34cb67a4"
   },
   "web.admin.sessions.scan.capped": {
-    "text": "Analyse limitée aux {scanned} premières clés — les sessions authentifiées au-delà de cette fenêtre ne sont pas répertoriées. Inspectez une session spécifique par ID pour y accéder.",
+    "text": "Analyse limitée aux {scanned} premières clés — les sessions authentifiées au-delà de cette fenêtre ne sont pas listées. Inspectez une session précise par son ID pour l'atteindre.",
     "source_hash": "fa418b4e"
   },
   "web.admin.sessions.search.placeholder": {
@@ -196,11 +196,11 @@
     "source_hash": "6959b415"
   },
   "web.admin.sessions.sections.raw": {
-    "text": "Données de session brutes",
+    "text": "Données brutes de la session",
     "source_hash": "c9f11eb4"
   },
   "web.admin.sessions.status.authenticated": {
-    "text": "Authentifié",
+    "text": "Authentifiée",
     "source_hash": "6ab694cf"
   },
   "web.admin.sessions.status.anonymous": {

--- a/locales/content/fr_FR/admin-system.json
+++ b/locales/content/fr_FR/admin-system.json
@@ -4,7 +4,7 @@
     "source_hash": "6725e7bb"
   },
   "web.admin.system.description": {
-    "text": "Statut de la base de données, de la file d'attente et de l'infrastructure.",
+    "text": "État de la base de données, des files d'attente et de l'infrastructure.",
     "source_hash": "0115f495"
   },
   "web.admin.system.retry": {
@@ -32,7 +32,7 @@
     "source_hash": "61d2afe2"
   },
   "web.admin.system.database.dbSummary": {
-    "text": "{keys} clés, {expires} avec TTL",
+    "text": "{keys} clés, dont {expires} avec TTL",
     "source_hash": "26b9e17c"
   },
   "web.admin.system.database.fields.version": {
@@ -44,7 +44,7 @@
     "source_hash": "5e23ec6a"
   },
   "web.admin.system.database.fields.uptimeDays": {
-    "text": "Disponibilité (jours)",
+    "text": "Temps de fonctionnement (jours)",
     "source_hash": "7ab314f8"
   },
   "web.admin.system.database.fields.connectedClients": {
@@ -52,7 +52,7 @@
     "source_hash": "434adc3a"
   },
   "web.admin.system.database.fields.opsPerSec": {
-    "text": "Ops/sec",
+    "text": "Opérations/s",
     "source_hash": "6634251d"
   },
   "web.admin.system.database.fields.totalCommands": {
@@ -96,7 +96,7 @@
     "source_hash": "3b2fe03e"
   },
   "web.admin.system.queue.loadError": {
-    "text": "Impossible de charger les métriques de la file d'attente.",
+    "text": "Impossible de charger les métriques des files d'attente.",
     "source_hash": "715bdc88"
   },
   "web.admin.system.queue.empty": {
@@ -152,7 +152,135 @@
     "source_hash": "ca5945d6"
   },
   "web.admin.system.redis.captured": {
-    "text": "Capturé le {at}",
+    "text": "Relevé {at}",
     "source_hash": "57b40c0f"
+  },
+  "web.admin.system.brand.title": {
+    "text": "Diagnostic de la marque",
+    "source_hash": "1cf9abd5"
+  },
+  "web.admin.system.brand.description": {
+    "text": "Le pack de marque que l'instance en cours d'exécution a résolu sur le disque — met en évidence pourquoi une région peut afficher une personnalisation neutre.",
+    "source_hash": "be29e282"
+  },
+  "web.admin.system.brand.loadError": {
+    "text": "Impossible de charger le diagnostic de la marque.",
+    "source_hash": "80607303"
+  },
+  "web.admin.system.brand.none": {
+    "text": "(aucun)",
+    "source_hash": "552e4230"
+  },
+  "web.admin.system.brand.resolution": {
+    "text": "Résolution",
+    "source_hash": "d4055faf"
+  },
+  "web.admin.system.brand.envVsConfig": {
+    "text": "Environnement et configuration",
+    "source_hash": "bee3debb"
+  },
+  "web.admin.system.brand.absorbed": {
+    "text": "Clés absorbées",
+    "source_hash": "9784e110"
+  },
+  "web.admin.system.brand.operatorKeys": {
+    "text": "Clés opérateur",
+    "source_hash": "434e8248"
+  },
+  "web.admin.system.brand.overlayAssets": {
+    "text": "Ressources de superposition",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.exists.yes": {
+    "text": "Présent",
+    "source_hash": "43f9b89c"
+  },
+  "web.admin.system.brand.exists.no": {
+    "text": "Manquant",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.system.brand.fields.resolvedDir": {
+    "text": "Répertoire résolu",
+    "source_hash": "0623b983"
+  },
+  "web.admin.system.brand.fields.home": {
+    "text": "Répertoire de base",
+    "source_hash": "3a786953"
+  },
+  "web.admin.system.brand.fields.envPack": {
+    "text": "Pack de marque ENV",
+    "source_hash": "940aeb5c"
+  },
+  "web.admin.system.brand.fields.configPack": {
+    "text": "Pack de marque de configuration",
+    "source_hash": "761b9550"
+  },
+  "web.admin.system.brand.fields.envAssetsDir": {
+    "text": "Répertoire des ressources de marque ENV",
+    "source_hash": "05854f1f"
+  },
+  "web.admin.system.brand.fields.configAssetsDir": {
+    "text": "Répertoire des ressources de marque de configuration",
+    "source_hash": "e91e5c46"
+  },
+  "web.admin.system.brand.flags.fellBack.danger": {
+    "text": "Repli sur le pack par défaut",
+    "source_hash": "7bf7ba2f"
+  },
+  "web.admin.system.brand.flags.fellBack.ok": {
+    "text": "Pack de marque résolu",
+    "source_hash": "1ab3162f"
+  },
+  "web.admin.system.brand.flags.mismatch.danger": {
+    "text": "Incohérence entre le démarrage et l'exécution",
+    "source_hash": "0a022192"
+  },
+  "web.admin.system.brand.flags.mismatch.ok": {
+    "text": "Le démarrage correspond à l'exécution",
+    "source_hash": "d4792c09"
+  },
+  "web.admin.system.brand.manifest.title": {
+    "text": "Manifeste",
+    "source_hash": "3c99f1f3"
+  },
+  "web.admin.system.brand.manifest.path": {
+    "text": "Chemin",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.manifest.exists": {
+    "text": "Existe",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.manifest.keysOnDisk": {
+    "text": "Clés sur le disque",
+    "source_hash": "52439c03"
+  },
+  "web.admin.system.brand.roots.title": {
+    "text": "Racines de recherche",
+    "source_hash": "d8696f2b"
+  },
+  "web.admin.system.brand.roots.empty": {
+    "text": "Aucune racine de recherche",
+    "source_hash": "867a471c"
+  },
+  "web.admin.system.brand.roots.columns.path": {
+    "text": "Chemin",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.roots.columns.exists": {
+    "text": "Existe",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.stats.brandPack": {
+    "text": "Pack de marque",
+    "source_hash": "884437d0"
+  },
+  "web.admin.system.brand.stats.overlayAssets": {
+    "text": "Ressources de superposition",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.stats.manifestKeys": {
+    "text": "Clés du manifeste",
+    "source_hash": "c4267198"
   }
 }

--- a/locales/content/fr_FR/admin-usage.json
+++ b/locales/content/fr_FR/admin-usage.json
@@ -4,7 +4,7 @@
     "source_hash": "8d59829c"
   },
   "web.admin.usage.description": {
-    "text": "Exporter les métriques d'utilisation pour une plage de dates.",
+    "text": "Exportez les métriques d'utilisation pour une plage de dates.",
     "source_hash": "97bd3325"
   },
   "web.admin.usage.startDate": {

--- a/locales/content/fr_FR/api-account-errors.json
+++ b/locales/content/fr_FR/api-account-errors.json
@@ -1,6 +1,6 @@
 {
   "api.account.errors.invalid_email": {
-    "text": "Est-ce une adresse e-mail valide ?",
+    "text": "S'agit-il d'une adresse e-mail valide ?",
     "source_hash": "21d55b60"
   },
   "api.account.errors.password_too_short": {

--- a/locales/content/fr_FR/api-domains-errors.json
+++ b/locales/content/fr_FR/api-domains-errors.json
@@ -20,7 +20,7 @@
     "source_hash": "1af54ec2"
   },
   "api.domains.errors.incoming_config_not_found": {
-    "text": "Configuration entrante introuvable pour le domaine : %{extid}",
+    "text": "Configuration des secrets entrants introuvable pour le domaine : %{extid}",
     "source_hash": "491644a8"
   },
   "api.domains.errors.recipients_max_exceeded": {
@@ -28,7 +28,7 @@
     "source_hash": "159842ad"
   },
   "api.domains.errors.recipients_invalid_email": {
-    "text": "E-mail invalide : %{email}",
+    "text": "E-mail non valide : %{email}",
     "source_hash": "e9c729c7"
   },
   "api.domains.errors.recipients_duplicate": {
@@ -40,11 +40,11 @@
     "source_hash": "cf093a04"
   },
   "api.domains.errors.homepage_incoming_entitlement_required": {
-    "text": "Le mode Secrets entrants nécessite le droit incoming_secrets. Veuillez mettre à niveau votre forfait.",
+    "text": "Le mode secrets entrants nécessite le droit incoming_secrets. Veuillez mettre à niveau votre forfait.",
     "source_hash": "d68b13d8"
   },
   "api.domains.errors.homepage_incoming_not_ready": {
-    "text": "Les secrets entrants doivent être activés avec au moins un destinataire avant de pouvoir être utilisés comme page d'accueil.",
+    "text": "Les secrets entrants doivent être activés avec au moins un destinataire avant de pouvoir servir de page d'accueil.",
     "source_hash": "556da6e2"
   }
 }

--- a/locales/content/fr_FR/api-entitlements-errors.json
+++ b/locales/content/fr_FR/api-entitlements-errors.json
@@ -1,6 +1,6 @@
 {
   "api.entitlements.errors.context_unavailable": {
-    "text": "Impossible de vérifier les droits (contexte d'organisation indisponible)",
+    "text": "Impossible de vérifier les droits (contexte de l'organisation indisponible)",
     "source_hash": "704dc629"
   },
   "api.entitlements.errors.api_access_required": {
@@ -8,11 +8,11 @@
     "source_hash": "844d294b"
   },
   "api.entitlements.errors.custom_privacy_defaults_required": {
-    "text": "Les paramètres de confidentialité par défaut personnalisés nécessitent une mise à niveau du forfait",
+    "text": "Les paramètres de confidentialité personnalisés par défaut nécessitent une mise à niveau du forfait",
     "source_hash": "4e71274d"
   },
   "api.entitlements.errors.extended_default_expiration_required": {
-    "text": "L'expiration par défaut prolongée nécessite une mise à niveau du forfait",
+    "text": "L'expiration par défaut étendue nécessite une mise à niveau du forfait",
     "source_hash": "efa702e7"
   },
   "api.entitlements.errors.custom_domains_required": {
@@ -20,11 +20,11 @@
     "source_hash": "a23e2184"
   },
   "api.entitlements.errors.custom_branding_required": {
-    "text": "L'image de marque personnalisée nécessite une mise à niveau du forfait",
+    "text": "La personnalisation graphique nécessite une mise à niveau du forfait",
     "source_hash": "a4c40a3a"
   },
   "api.entitlements.errors.homepage_secrets_required": {
-    "text": "Les secrets de la page d'accueil nécessitent une mise à niveau du forfait",
+    "text": "Les secrets sur la page d'accueil nécessitent une mise à niveau du forfait",
     "source_hash": "650eeca8"
   },
   "api.entitlements.errors.incoming_secrets_required": {
@@ -32,11 +32,11 @@
     "source_hash": "ce1d47ef"
   },
   "api.entitlements.errors.custom_mail_sender_required": {
-    "text": "L'expéditeur d'e-mail personnalisé nécessite une mise à niveau du forfait",
+    "text": "Un expéditeur d'e-mail personnalisé nécessite une mise à niveau du forfait",
     "source_hash": "e058da13"
   },
   "api.entitlements.errors.flexible_from_domain_required": {
-    "text": "Le domaine d'expéditeur flexible nécessite une mise à niveau du forfait",
+    "text": "Le domaine d'expédition flexible nécessite une mise à niveau du forfait",
     "source_hash": "4931dc05"
   },
   "api.entitlements.errors.manage_org_required": {
@@ -68,7 +68,7 @@
     "source_hash": "01091fed"
   },
   "api.entitlements.errors.view_receipt_required": {
-    "text": "L'affichage des reçus nécessite une mise à niveau du forfait",
+    "text": "La consultation des reçus nécessite une mise à niveau du forfait",
     "source_hash": "e6370d8c"
   },
   "api.entitlements.errors.notifications_required": {
@@ -76,11 +76,11 @@
     "source_hash": "82353ba6"
   },
   "api.entitlements.errors.workspace_branding_required": {
-    "text": "L'image de marque de l'espace de travail nécessite une mise à niveau du forfait",
+    "text": "La personnalisation de l'espace de travail nécessite une mise à niveau du forfait",
     "source_hash": "79ac8099"
   },
   "api.entitlements.errors.ip_access_rules_required": {
-    "text": "Les règles d'accès IP nécessitent une mise à niveau du forfait",
+    "text": "Les règles d'accès par IP nécessitent une mise à niveau du forfait",
     "source_hash": "3e1d276e"
   },
   "api.entitlements.errors.manage_billing_required": {

--- a/locales/content/fr_FR/api-feedback-errors.json
+++ b/locales/content/fr_FR/api-feedback-errors.json
@@ -1,6 +1,6 @@
 {
   "api.feedback.errors.rate_limit_exceeded": {
-    "text": "Trop de retours d'information envoyés. Veuillez réessayer plus tard.",
+    "text": "Trop d'envois de commentaires. Veuillez réessayer plus tard.",
     "source_hash": "3a890eb2"
   }
 }

--- a/locales/content/fr_FR/api-invite-errors.json
+++ b/locales/content/fr_FR/api-invite-errors.json
@@ -4,7 +4,7 @@
     "source_hash": "63657979"
   },
   "api.invite.errors.token_required": {
-    "text": "Le jeton est requis",
+    "text": "Un jeton est requis",
     "source_hash": "6c718161"
   },
   "api.invite.errors.organization_no_longer_exists": {

--- a/locales/content/fr_FR/api-organizations-errors.json
+++ b/locales/content/fr_FR/api-organizations-errors.json
@@ -20,11 +20,11 @@
     "source_hash": "cd9e8c0e"
   },
   "api.organizations.errors.extid_required": {
-    "text": "ID d'organisation requis",
+    "text": "ID de l'organisation requis",
     "source_hash": "02fbe301"
   },
   "api.organizations.errors.display_name_required": {
-    "text": "Le nom de l'organisation est requis",
+    "text": "Le nom de l'organisation est obligatoire",
     "source_hash": "c3f6e9af"
   },
   "api.organizations.errors.display_name_too_long": {
@@ -52,11 +52,11 @@
     "source_hash": "775ba9eb"
   },
   "api.organizations.invitations.errors.email_required": {
-    "text": "L'e-mail est requis",
+    "text": "L'adresse e-mail est obligatoire",
     "source_hash": "aae92911"
   },
   "api.organizations.invitations.errors.invalid_email_format": {
-    "text": "Format d'e-mail invalide",
+    "text": "Format d'adresse e-mail non valide",
     "source_hash": "0bcecf66"
   },
   "api.organizations.invitations.errors.invalid_role": {
@@ -72,7 +72,7 @@
     "source_hash": "8eb45780"
   },
   "api.organizations.invitations.errors.invitation_already_pending": {
-    "text": "Une invitation est déjà en attente pour cet e-mail",
+    "text": "Une invitation est déjà en attente pour cette adresse e-mail",
     "source_hash": "7f5e3093"
   },
   "api.organizations.invitations.errors.member_limit_reached": {
@@ -104,7 +104,7 @@
     "source_hash": "a51b8760"
   },
   "api.organizations.members.errors.invalid_role_value": {
-    "text": "Rôle invalide. Doit être l'un des suivants : %{roles}",
+    "text": "Rôle non valide. Il doit s'agir de l'un des rôles suivants : %{roles}",
     "source_hash": "c3331aa0"
   },
   "api.organizations.members.errors.cannot_change_owner_role": {
@@ -116,7 +116,7 @@
     "source_hash": "6771166a"
   },
   "api.organizations.members.errors.cannot_promote_to_owner": {
-    "text": "Impossible de promouvoir au rang de propriétaire. Utilisez plutôt le transfert de propriété.",
+    "text": "Impossible de promouvoir en tant que propriétaire. Utilisez plutôt le transfert de propriété.",
     "source_hash": "cd574007"
   },
   "api.organizations.members.errors.must_be_member": {
@@ -128,7 +128,7 @@
     "source_hash": "d4f33003"
   },
   "api.organizations.members.errors.cannot_remove_self": {
-    "text": "Impossible de vous retirer vous-même. Utilisez plutôt l'option de quitter l'organisation.",
+    "text": "Impossible de vous retirer vous-même. Utilisez plutôt l'option pour quitter l'organisation.",
     "source_hash": "d64cec91"
   },
   "api.organizations.members.errors.admin_cannot_remove_admin": {
@@ -136,7 +136,7 @@
     "source_hash": "2b3e6e30"
   },
   "api.organizations.members.errors.no_permission_to_remove": {
-    "text": "Vous n'avez pas la permission de retirer des membres",
+    "text": "Vous n'avez pas l'autorisation de retirer des membres",
     "source_hash": "b0ac7287"
   }
 }

--- a/locales/content/fr_FR/api-secrets-errors.json
+++ b/locales/content/fr_FR/api-secrets-errors.json
@@ -1,18 +1,18 @@
 {
   "api.secrets.errors.domain_permission_authenticated_non_owner": {
-    "text": "Vous n'avez pas la permission d'utiliser le domaine : %{domain}",
+    "text": "Vous n'avez pas l'autorisation d'utiliser le domaine : %{domain}",
     "source_hash": "b41920ba"
   },
   "api.secrets.errors.domain_public_sharing_disabled": {
-    "text": "Partage public désactivé pour le domaine : %{domain}",
+    "text": "Le partage public est désactivé pour le domaine : %{domain}",
     "source_hash": "b15efec8"
   },
   "api.secrets.errors.domain_permission_anonymous_cross_domain": {
-    "text": "Vous n'avez pas la permission d'utiliser le domaine : %{domain}",
+    "text": "Vous n'avez pas l'autorisation d'utiliser le domaine : %{domain}",
     "source_hash": "b41920ba"
   },
   "api.secrets.errors.secret_undecryptable": {
-    "text": "Ce secret ne peut pas être déchiffré pour le moment. Le lien est toujours intact — l'opérateur du site doit restaurer la clé de chiffrement avant qu'il puisse être révélé.",
+    "text": "Ce secret ne peut pas être déchiffré pour le moment. Le lien reste intact — l'opérateur du site doit restaurer la clé de chiffrement avant qu'il puisse être révélé.",
     "source_hash": "56e283ee"
   }
 }

--- a/locales/content/fr_FR/email.json
+++ b/locales/content/fr_FR/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Assistance Secret",
+    "text": "L'équipe d'assistance Onetime Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/fr_FR/email.json
+++ b/locales/content/fr_FR/email.json
@@ -1,6 +1,6 @@
 {
   "email.incomingsupport.subject": {
-    "text": "[Ticket : %s]",
+    "text": "[Ticket : %s]",
     "renderer": "erb",
     "source_hash": "9e2074ae"
   },
@@ -15,12 +15,12 @@
     "source_hash": "3156abde"
   },
   "email.secret_link.sent_you_secret": {
-    "text": "vous a envoyé un secret :",
+    "text": "vous a envoyé un secret :",
     "renderer": "erb",
     "source_hash": "c0571266"
   },
   "email.secret_link.important_label": {
-    "text": "Important :",
+    "text": "Important :",
     "renderer": "erb",
     "source_hash": "496d6960"
   },
@@ -35,17 +35,17 @@
     "source_hash": "d01479b3"
   },
   "email.welcome.subject": {
-    "text": "Bienvenue sur %{product_name} - Veuillez vérifier votre e-mail",
+    "text": "Bienvenue sur %{product_name} - Veuillez vérifier votre adresse e-mail",
     "renderer": "erb",
     "source_hash": "96008c17"
   },
   "email.welcome.title": {
-    "text": "Bienvenue sur %{product_name} !",
+    "text": "Bienvenue sur %{product_name} !",
     "renderer": "erb",
     "source_hash": "77e7dda4"
   },
   "email.welcome.verify_prompt": {
-    "text": "Veuillez vérifier votre adresse e-mail en cliquant sur le lien ci-dessous :",
+    "text": "Veuillez vérifier votre adresse e-mail en cliquant sur le lien ci-dessous :",
     "renderer": "erb",
     "source_hash": "e373dcee"
   },
@@ -55,7 +55,7 @@
     "source_hash": "d261b9df"
   },
   "email.welcome.copy_link_prompt": {
-    "text": "Ou copiez et collez ce lien :",
+    "text": "Ou copiez et collez ce lien :",
     "renderer": "erb",
     "source_hash": "88c72144"
   },
@@ -65,17 +65,17 @@
     "source_hash": "dc75bf9f"
   },
   "email.welcome.postscript": {
-    "text": "P.S. Cet e-mail a été envoyé à %{email_address}. Si vous n'avez pas créé de compte, vous pouvez ignorer ce message en toute sécurité.",
+    "text": "P.-S. Cet e-mail a été envoyé à %{email_address}. Si vous n'avez pas créé de compte, vous pouvez ignorer ce message.",
     "renderer": "erb",
     "source_hash": "05709148"
   },
   "email.password_request.subject": {
-    "text": "Réinitialiser votre mot de passe (%{display_domain})",
+    "text": "Réinitialisez votre mot de passe (%{display_domain})",
     "renderer": "erb",
     "source_hash": "a9882af1"
   },
   "email.password_request.title": {
-    "text": "Réinitialiser votre mot de passe",
+    "text": "Réinitialisez votre mot de passe",
     "renderer": "erb",
     "source_hash": "0568c7b0"
   },
@@ -90,12 +90,12 @@
     "source_hash": "4e70f1fd"
   },
   "email.password_request.copy_link_prompt": {
-    "text": "Ou copiez et collez ce lien :",
+    "text": "Ou copiez et collez ce lien :",
     "renderer": "erb",
     "source_hash": "88c72144"
   },
   "email.password_request.ignore_notice": {
-    "text": "Si vous n'avez pas demandé de réinitialisation de mot de passe, vous pouvez ignorer cet e-mail en toute sécurité.",
+    "text": "Si vous n'avez pas demandé de réinitialisation de mot de passe, vous pouvez ignorer cet e-mail.",
     "renderer": "erb",
     "source_hash": "fbb7eb2d"
   },
@@ -105,17 +105,17 @@
     "source_hash": "dc75bf9f"
   },
   "email.password_request.postscript": {
-    "text": "P.S. Cet e-mail a été envoyé à %{email_address}.",
+    "text": "P.-S. Cet e-mail a été envoyé à %{email_address}.",
     "renderer": "erb",
     "source_hash": "8ab1dbea"
   },
   "email.magic_link.subject": {
-    "text": "Connexion à %{display_domain}",
+    "text": "Connectez-vous à %{display_domain}",
     "renderer": "erb",
     "source_hash": "2967293e"
   },
   "email.magic_link.title": {
-    "text": "Connexion avec lien magique",
+    "text": "Se connecter avec un lien magique",
     "renderer": "erb",
     "source_hash": "0b84879b"
   },
@@ -130,7 +130,7 @@
     "source_hash": "bcc0bcc9"
   },
   "email.magic_link.copy_link_prompt": {
-    "text": "Ou copiez et collez ce lien :",
+    "text": "Ou copiez et collez ce lien :",
     "renderer": "erb",
     "source_hash": "88c72144"
   },
@@ -140,7 +140,7 @@
     "source_hash": "a6967fa7"
   },
   "email.magic_link.ignore_notice": {
-    "text": "Si vous n'avez pas demandé ce lien, vous pouvez ignorer cet e-mail en toute sécurité.",
+    "text": "Si vous n'avez pas demandé ce lien, vous pouvez ignorer cet e-mail.",
     "renderer": "erb",
     "source_hash": "1863f5be"
   },
@@ -150,7 +150,7 @@
     "source_hash": "dc75bf9f"
   },
   "email.magic_link.postscript": {
-    "text": "P.S. Cet e-mail a été envoyé à %{email_address}.",
+    "text": "P.-S. Cet e-mail a été envoyé à %{email_address}.",
     "renderer": "erb",
     "source_hash": "8ab1dbea"
   },
@@ -160,12 +160,12 @@
     "source_hash": "c7c36a80"
   },
   "email.incoming_secret.received_message": {
-    "text": "Vous avez reçu un message sécurisé :",
+    "text": "Vous avez reçu un message sécurisé :",
     "renderer": "erb",
     "source_hash": "7d3cd4cb"
   },
   "email.incoming_secret.memo_label": {
-    "text": "Mémo :",
+    "text": "Mémo :",
     "renderer": "erb",
     "source_hash": "8bab5066"
   },
@@ -175,12 +175,12 @@
     "source_hash": "12ac0a81"
   },
   "email.incoming_secret.view_instructions": {
-    "text": "Pour voir ce secret, cliquez sur le lien ci-dessous :",
+    "text": "Pour consulter ce secret, cliquez sur le lien ci-dessous :",
     "renderer": "erb",
     "source_hash": "1dcdc014"
   },
   "email.incoming_secret.important_label": {
-    "text": "Important :",
+    "text": "Important :",
     "renderer": "erb",
     "source_hash": "496d6960"
   },
@@ -195,7 +195,7 @@
     "source_hash": "1e49826b"
   },
   "email.incoming_secret.passphrase_label": {
-    "text": "Phrase secrète requise :",
+    "text": "Phrase secrète requise :",
     "renderer": "erb",
     "source_hash": "1ab9a20f"
   },
@@ -220,7 +220,7 @@
     "source_hash": "6a3d346c"
   },
   "email.secret_revealed.secret_id_label": {
-    "text": "ID du secret :",
+    "text": "ID du secret :",
     "renderer": "erb",
     "source_hash": "ab567438"
   },
@@ -240,12 +240,12 @@
     "source_hash": "a76d7ce0"
   },
   "email.secret_revealed.manage_preferences_prompt": {
-    "text": "Pour gérer vos préférences de notification :",
+    "text": "Pour gérer vos préférences de notification :",
     "renderer": "erb",
     "source_hash": "83cbd163"
   },
   "email.expiration_warning.subject": {
-    "text": "Votre lien secret va bientôt expirer",
+    "text": "Votre lien secret expirera bientôt",
     "renderer": "erb",
     "source_hash": "74813c5f"
   },
@@ -255,12 +255,12 @@
     "source_hash": "e7bb47f6"
   },
   "email.expiration_warning.view_button": {
-    "text": "Voir votre secret avant qu'il n'expire",
+    "text": "Consultez votre secret avant son expiration",
     "renderer": "erb",
     "source_hash": "9e7d7396"
   },
   "email.expiration_warning.reminder_label": {
-    "text": "Rappel :",
+    "text": "Rappel :",
     "renderer": "erb",
     "source_hash": "e945d640"
   },
@@ -275,7 +275,7 @@
     "source_hash": "d01479b3"
   },
   "email.expiration_warning.view_before_gone": {
-    "text": "Consultez-le avant qu'il ne disparaisse :",
+    "text": "Consultez-le avant qu'il ne disparaisse :",
     "renderer": "erb",
     "source_hash": "30342c04"
   },
@@ -285,37 +285,37 @@
     "source_hash": "bd0a9bee"
   },
   "email.feedback_email.subject": {
-    "text": "Commentaire le %{date} via %{display_domain} (%{strategy})",
+    "text": "Commentaires du %{date} via %{display_domain} (%{strategy})",
     "renderer": "erb",
     "source_hash": "f7498c8b"
   },
   "email.feedback_email.title": {
-    "text": "Commentaire utilisateur",
+    "text": "Commentaires d'un utilisateur",
     "renderer": "erb",
     "source_hash": "47296999"
   },
   "email.feedback_email.from_label": {
-    "text": "De :",
+    "text": "De :",
     "renderer": "erb",
     "source_hash": "dc45d36f"
   },
   "email.feedback_email.domain_label": {
-    "text": "Domaine :",
+    "text": "Domaine :",
     "renderer": "erb",
     "source_hash": "a4c7de06"
   },
   "email.feedback_email.strategy_label": {
-    "text": "Stratégie :",
+    "text": "Stratégie :",
     "renderer": "erb",
     "source_hash": "8132ec6b"
   },
   "email.feedback_email.message_label": {
-    "text": "Message :",
+    "text": "Message :",
     "renderer": "erb",
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "L'équipe d'assistance Onetime Secret",
+    "text": "Assistance Secret",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },
@@ -325,7 +325,7 @@
     "source_hash": "58591e00"
   },
   "email.organization_invitation.title": {
-    "text": "Vous avez été invité à rejoindre %{organization_name} !",
+    "text": "Vous avez été invité à rejoindre %{organization_name} !",
     "renderer": "erb",
     "source_hash": "19548dfd"
   },
@@ -340,7 +340,7 @@
     "source_hash": "ce7cfeaf"
   },
   "email.organization_invitation.link_instruction": {
-    "text": "Ou copiez et collez ce lien :",
+    "text": "Ou copiez et collez ce lien :",
     "renderer": "erb",
     "source_hash": "88c72144"
   },
@@ -350,7 +350,7 @@
     "source_hash": "dabc54d5"
   },
   "email.organization_invitation.decline_instruction": {
-    "text": "Si vous ne souhaitez pas rejoindre l'organisation, vous pouvez simplement ignorer cet e-mail ou décliner l'invitation.",
+    "text": "Si vous ne souhaitez pas la rejoindre, il vous suffit d'ignorer cet e-mail ou de refuser l'invitation.",
     "renderer": "erb",
     "source_hash": "734882d2"
   },
@@ -360,7 +360,7 @@
     "source_hash": "dc75bf9f"
   },
   "email.organization_invitation.postscript": {
-    "text": "P.S. Cet e-mail a été envoyé à %{invited_email}. Si vous n'attendiez pas cette invitation, vous pouvez ignorer ce message en toute sécurité.",
+    "text": "P.-S. Cet e-mail a été envoyé à %{invited_email}. Si vous n'attendiez pas cette invitation, vous pouvez ignorer ce message.",
     "renderer": "erb",
     "source_hash": "608e2b40"
   },
@@ -390,7 +390,7 @@
     "source_hash": "21f5117c"
   },
   "email.password_changed.security_notice": {
-    "text": "Si vous n'avez pas effectué cette modification, veuillez sécuriser votre compte immédiatement en réinitialisant votre mot de passe et en contactant le support.",
+    "text": "Si vous n'êtes pas à l'origine de cette modification, sécurisez immédiatement votre compte en réinitialisant votre mot de passe et en contactant l'assistance.",
     "renderer": "erb",
     "source_hash": "be92cff3"
   },
@@ -410,7 +410,7 @@
     "source_hash": "db70f965"
   },
   "email.email_changed.security_notice": {
-    "text": "Si vous n'avez pas effectué cette modification, veuillez contacter immédiatement le support car votre compte pourrait être compromis.",
+    "text": "Si vous n'êtes pas à l'origine de cette modification, contactez immédiatement l'assistance, car votre compte pourrait être compromis.",
     "renderer": "erb",
     "source_hash": "f505b562"
   },
@@ -420,27 +420,27 @@
     "source_hash": "7fc0e27c"
   },
   "email.email_changed.new_email_label": {
-    "text": "Nouvel e-mail :",
+    "text": "Nouvelle adresse e-mail :",
     "renderer": "erb",
     "source_hash": "0161371a"
   },
   "email.email_changed.changed_at_label": {
-    "text": "Modifié le :",
+    "text": "Modifiée le :",
     "renderer": "erb",
     "source_hash": "f4a9cdda"
   },
   "email.email_changed.if_you_initiated": {
-    "text": "Si vous avez effectué ce changement, aucune action supplémentaire n'est requise.",
+    "text": "Si vous êtes à l'origine de cette modification, aucune action supplémentaire n'est nécessaire.",
     "renderer": "erb",
     "source_hash": "5cb54887"
   },
   "email.email_changed.not_you_notice": {
-    "text": "Si vous n'avez pas effectué ce changement, votre compte pourrait être compromis.",
+    "text": "Si vous n'êtes pas à l'origine de cette modification, votre compte pourrait être compromis.",
     "renderer": "erb",
     "source_hash": "08f479fb"
   },
   "email.email_changed.contact_support": {
-    "text": "Contacter le support",
+    "text": "Contacter l'assistance",
     "renderer": "erb",
     "source_hash": "f8d47b82"
   },
@@ -450,47 +450,47 @@
     "source_hash": "dc75bf9f"
   },
   "email.email_changed.postscript": {
-    "text": "P.S. Cet e-mail a été envoyé à %{email_address} pour vous informer d'un changement d'adresse e-mail.",
+    "text": "P.-S. Cet e-mail a été envoyé à %{email_address} pour vous informer d'un changement d'adresse e-mail.",
     "renderer": "erb",
     "source_hash": "475cae37"
   },
   "email.email_change_requested.subject": {
-    "text": "Changement d'e-mail demandé (%{display_domain})",
+    "text": "Changement d'adresse e-mail demandé (%{display_domain})",
     "renderer": "erb",
     "source_hash": "be3441d6"
   },
   "email.email_change_requested.title": {
-    "text": "Changement d'e-mail demandé",
+    "text": "Changement d'adresse e-mail demandé",
     "renderer": "erb",
     "source_hash": "704cbdca"
   },
   "email.email_change_requested.change_notice": {
-    "text": "Une demande de changement d'adresse e-mail a été effectuée sur votre compte %{product_name}.",
+    "text": "Une demande a été faite pour modifier l'adresse e-mail de votre compte %{product_name}.",
     "renderer": "erb",
     "source_hash": "d7e39154"
   },
   "email.email_change_requested.new_email_label": {
-    "text": "Nouvel e-mail demandé :",
+    "text": "Nouvelle adresse e-mail demandée :",
     "renderer": "erb",
     "source_hash": "243f3e03"
   },
   "email.email_change_requested.requested_at_label": {
-    "text": "Demandé le :",
+    "text": "Demandé le :",
     "renderer": "erb",
     "source_hash": "ada23c51"
   },
   "email.email_change_requested.if_you_initiated": {
-    "text": "Si vous avez fait cette demande, vérifiez votre nouvelle adresse e-mail pour un lien de confirmation. Aucune modification n'a encore été effectuée.",
+    "text": "Si vous êtes à l'origine de cette demande, consultez votre nouvelle messagerie pour y trouver un lien de confirmation. Aucune modification n'a encore été effectuée.",
     "renderer": "erb",
     "source_hash": "aa1bf526"
   },
   "email.email_change_requested.not_you_notice": {
-    "text": "Si vous n'avez pas fait cette demande, vous pouvez ignorer cet e-mail en toute sécurité. Votre compte n'a pas été modifié.",
+    "text": "Si vous n'êtes pas à l'origine de cette demande, vous pouvez ignorer cet e-mail. Votre compte n'a pas été modifié.",
     "renderer": "erb",
     "source_hash": "ff41a7b7"
   },
   "email.email_change_requested.contact_support": {
-    "text": "Contacter le support",
+    "text": "Contacter l'assistance",
     "renderer": "erb",
     "source_hash": "f8d47b82"
   },
@@ -500,7 +500,7 @@
     "source_hash": "dc75bf9f"
   },
   "email.email_change_requested.postscript": {
-    "text": "P.S. Cet e-mail a été envoyé à %{email_address} car un changement d'adresse e-mail a été demandé pour votre compte.",
+    "text": "P.-S. Cet e-mail a été envoyé à %{email_address} car un changement d'adresse e-mail a été demandé pour votre compte.",
     "renderer": "erb",
     "source_hash": "500e085e"
   },
@@ -525,17 +525,17 @@
     "source_hash": "d261b9df"
   },
   "email.email_change_confirmation.request_notice": {
-    "text": "Une demande a été effectuée pour changer l'adresse e-mail de votre compte %{product_name} en %{new_email}.",
+    "text": "Une demande a été faite pour remplacer l'adresse e-mail de votre compte %{product_name} par %{new_email}.",
     "renderer": "erb",
     "source_hash": "33277e1b"
   },
   "email.email_change_confirmation.confirm_button": {
-    "text": "Confirmer le changement d'e-mail",
+    "text": "Confirmer le changement d'adresse e-mail",
     "renderer": "erb",
     "source_hash": "c2736949"
   },
   "email.email_change_confirmation.copy_link_prompt": {
-    "text": "Ou copiez et collez ce lien :",
+    "text": "Ou copiez et collez ce lien :",
     "renderer": "erb",
     "source_hash": "88c72144"
   },
@@ -545,7 +545,7 @@
     "source_hash": "e744f5a7"
   },
   "email.email_change_confirmation.ignore_notice": {
-    "text": "Si vous n'avez pas demandé ce changement, vous pouvez ignorer cet e-mail en toute sécurité. Votre adresse e-mail ne sera pas modifiée.",
+    "text": "Si vous n'êtes pas à l'origine de cette demande, vous pouvez ignorer cet e-mail. Votre adresse e-mail ne sera pas modifiée.",
     "renderer": "erb",
     "source_hash": "d4d835fc"
   },
@@ -555,7 +555,7 @@
     "source_hash": "dc75bf9f"
   },
   "email.email_change_confirmation.postscript": {
-    "text": "P.S. Cet e-mail a été envoyé à %{email_address} pour confirmer un changement d'adresse e-mail.",
+    "text": "P.-S. Cet e-mail a été envoyé à %{email_address} pour confirmer un changement d'adresse e-mail.",
     "renderer": "erb",
     "source_hash": "b72f557c"
   },
@@ -575,7 +575,7 @@
     "source_hash": "9f6be43f"
   },
   "email.mfa_enabled.security_notice": {
-    "text": "Votre compte est maintenant plus sécurisé. Vous devrez saisir un code de vérification de votre application d'authentification lors de la connexion.",
+    "text": "Votre compte est désormais mieux sécurisé. Vous devrez saisir un code de vérification issu de votre application d'authentification lors de la connexion.",
     "renderer": "erb",
     "source_hash": "e7c11bb0"
   },
@@ -600,7 +600,7 @@
     "source_hash": "0248389d"
   },
   "email.mfa_disabled.warning_notice": {
-    "text": "Votre compte est maintenant moins sécurisé. Si vous n'avez pas effectué cette modification, veuillez sécuriser votre compte immédiatement.",
+    "text": "Votre compte est désormais moins sécurisé. Si vous n'êtes pas à l'origine de cette modification, sécurisez immédiatement votre compte.",
     "renderer": "erb",
     "source_hash": "97ef0a3e"
   },
@@ -625,17 +625,17 @@
     "source_hash": "040f8f48"
   },
   "email.new_login_alert.device_label": {
-    "text": "Appareil :",
+    "text": "Appareil :",
     "renderer": "erb",
     "source_hash": "9f8d3539"
   },
   "email.new_login_alert.location_label": {
-    "text": "Localisation :",
+    "text": "Emplacement :",
     "renderer": "erb",
     "source_hash": "bbdffe25"
   },
   "email.new_login_alert.ip_address_label": {
-    "text": "Adresse IP :",
+    "text": "Adresse IP :",
     "renderer": "erb",
     "source_hash": "a2cb73e4"
   },
@@ -685,7 +685,7 @@
     "source_hash": "8f892809"
   },
   "email.role_changed.body": {
-    "text": "Votre rôle dans « %{organization_name} » a été modifié de %{old_role} à %{new_role}.",
+    "text": "Votre rôle dans « %{organization_name} » est passé de %{old_role} à %{new_role}.",
     "renderer": "erb",
     "source_hash": "c2280c0c"
   },
@@ -725,7 +725,7 @@
     "source_hash": "36200518"
   },
   "email.trial_expiring.body": {
-    "text": "Votre période d'essai gratuite de %{product_name} expirera dans %{days_remaining} jours. Mettez à niveau maintenant pour conserver l'accès à toutes les fonctionnalités.",
+    "text": "Votre essai gratuit de %{product_name} expirera dans %{days_remaining} jours. Mettez à niveau dès maintenant pour conserver l'accès à toutes les fonctionnalités.",
     "renderer": "erb",
     "source_hash": "17fc32dd"
   },
@@ -750,12 +750,12 @@
     "source_hash": "7523a022"
   },
   "email.subscription_changed.body": {
-    "text": "Votre abonnement %{product_name} a été modifié de %{old_plan} à %{new_plan}.",
+    "text": "Votre abonnement %{product_name} est passé de %{old_plan} à %{new_plan}.",
     "renderer": "erb",
     "source_hash": "72f81a65"
   },
   "email.subscription_changed.effective_date": {
-    "text": "Cette modification est effective à partir du %{date}.",
+    "text": "Cette modification prend effet le %{date}.",
     "renderer": "erb",
     "source_hash": "5a96ae38"
   },
@@ -780,7 +780,7 @@
     "source_hash": "3e92efb7"
   },
   "email.common.view_in_browser": {
-    "text": "Voir dans le navigateur",
+    "text": "Afficher dans le navigateur",
     "renderer": "erb",
     "source_hash": "be843876"
   },
@@ -790,7 +790,7 @@
     "source_hash": "1cd0194a"
   },
   "email.common.secret_link_label": {
-    "text": "Lien du secret",
+    "text": "Lien secret",
     "renderer": "erb",
     "source_hash": "18ddf44f"
   },
@@ -800,7 +800,7 @@
     "source_hash": "8fbabfba"
   },
   "email.common.support_label": {
-    "text": "Support",
+    "text": "Assistance",
     "source_hash": "be91940b"
   },
   "email.expiration_warning.signature": {
@@ -809,7 +809,7 @@
     "source_hash": "dc75bf9f"
   },
   "email.expiration_warning.footer_note": {
-    "text": "Vous avez reçu ce message parce qu'un secret que vous avez créé sur %{product_name} est sur le point d'expirer.",
+    "text": "Vous recevez cet e-mail parce qu'un secret que vous avez créé sur %{product_name} est sur le point d'expirer.",
     "renderer": "erb",
     "source_hash": "920779e4"
   },
@@ -829,7 +829,7 @@
     "source_hash": "4c5726ee"
   },
   "email.incoming_secret.footer_note": {
-    "text": "Vous avez reçu ce message parce que quelqu'un a utilisé %{product_name} pour vous envoyer un secret. Si vous ne l'attendiez pas, vous pouvez ignorer cet e-mail en toute sécurité.",
+    "text": "Vous recevez cet e-mail parce que quelqu'un a utilisé %{product_name} pour vous envoyer un secret. Si vous ne l'attendiez pas, vous pouvez ignorer cet e-mail.",
     "renderer": "erb",
     "source_hash": "91ee6e8d"
   },
@@ -844,8 +844,44 @@
     "source_hash": "1e49826b"
   },
   "email.secret_link.footer_note": {
-    "text": "Vous avez reçu ce message parce que %{sender_email} a utilisé %{product_name} pour partager un secret avec vous. Si vous ne l'attendiez pas, vous pouvez ignorer cet e-mail en toute sécurité.",
+    "text": "Vous recevez cet e-mail parce que %{sender_email} a utilisé %{product_name} pour partager un secret avec vous. Si vous ne l'attendiez pas, vous pouvez ignorer cet e-mail.",
     "renderer": "erb",
     "source_hash": "2d544dad"
+  },
+  "email.sso_link_verification.subject": {
+    "text": "Confirmez la liaison de %{provider} à votre compte %{product_name}",
+    "source_hash": "65e70296"
+  },
+  "email.sso_link_verification.title": {
+    "text": "Confirmez votre connexion SSO",
+    "source_hash": "35bce6cc"
+  },
+  "email.sso_link_verification.request_notice": {
+    "text": "Quelqu'un s'est connecté avec %{provider} en utilisant l'adresse e-mail %{email_address}. Pour finaliser la connexion de %{provider} à votre compte %{product_name}, confirmez ci-dessous.",
+    "source_hash": "baeb18c0"
+  },
+  "email.sso_link_verification.confirm_button": {
+    "text": "Confirmer et lier %{provider}",
+    "source_hash": "9809e210"
+  },
+  "email.sso_link_verification.copy_link_prompt": {
+    "text": "Ou copiez et collez ce lien :",
+    "source_hash": "88c72144"
+  },
+  "email.sso_link_verification.expiration_notice": {
+    "text": "Ce lien expire dans 15 minutes et ne peut être utilisé qu'une seule fois.",
+    "source_hash": "1a437f42"
+  },
+  "email.sso_link_verification.ignore_notice": {
+    "text": "Si vous n'avez pas tenté de vous connecter avec %{provider}, vous pouvez ignorer cet e-mail — rien ne sera lié à votre compte.",
+    "source_hash": "d7317d30"
+  },
+  "email.sso_link_verification.signature": {
+    "text": "L'équipe d'assistance",
+    "source_hash": "dc75bf9f"
+  },
+  "email.sso_link_verification.postscript": {
+    "text": "P.-S. Cet e-mail a été envoyé à %{email_address}.",
+    "source_hash": "8ab1dbea"
   }
 }

--- a/locales/content/fr_FR/error-pages.json
+++ b/locales/content/fr_FR/error-pages.json
@@ -1,18 +1,18 @@
 {
   "web.errors.why_is_this_secret_unavailable": {
-    "text": "Pourquoi ce secret est-il indisponible ?",
+    "text": "Pourquoi ce secret est-il indisponible ?",
     "source_hash": "bd545472"
   },
   "web.errors.secrets_are_designed_to_be_viewed_only_once": {
-    "text": "Les secrets sont conçus pour n'être consultés qu'une seule fois. Ce lien a peut-être déjà été consulté, a expiré, ou a été supprimé manuellement par l'expéditeur.",
+    "text": "Les secrets sont conçus pour n'être consultés qu'une seule fois. Ce lien a peut-être déjà été ouvert, a expiré ou a été supprimé manuellement par l'expéditeur.",
     "source_hash": "44c54ed2"
   },
   "web.errors.what_should_i_do_now": {
-    "text": "Que dois-je faire maintenant ?",
+    "text": "Que dois-je faire maintenant ?",
     "source_hash": "fbf3e67f"
   },
   "web.errors.contact_the_person_who_sent_you_this_link": {
-    "text": "Veuillez contacter la personne qui vous a envoyé ce lien et demandez-lui de créer un nouveau secret. Informez-la que vous n'avez pas pu accéder aux informations originales.",
+    "text": "Contactez la personne qui vous a envoyé ce lien et demandez-lui de créer un nouveau secret. Indiquez-lui que vous n'avez pas pu accéder aux informations d'origine.",
     "source_hash": "d9f4f41a"
   },
   "web.errors.warning_dismissed": {
@@ -24,7 +24,7 @@
     "source_hash": "79e02fe6"
   },
   "web.errors.oops_the_page_you_are_looking_for_doesnt_exist_o": {
-    "text": "Oups ! La page que vous recherchez n'existe pas ou a été déplacée.",
+    "text": "Oups ! La page que vous recherchez n'existe pas ou a été déplacée.",
     "source_hash": "78207a09"
   },
   "web.errors.404_page_not_found_0": {
@@ -44,27 +44,27 @@
     "source_hash": "b7bb3f34"
   },
   "web.errors.if_youre_unsure_what_to_do_next_please_follow_up": {
-    "text": "Si vous n'êtes pas sûr de la marche à suivre, veuillez contacter la personne qui vous a envoyé ce lien pour plus d'informations.",
+    "text": "Si vous ne savez pas quoi faire ensuite, contactez la personne qui vous a envoyé ce lien pour obtenir plus d'informations.",
     "source_hash": "0df00d3f"
   },
   "web.errors.information_shared_through_our_service_can_only_": {
-    "text": "Les informations partagées par le biais de notre service ne peuvent être consultées qu'une seule fois. Une fois consulté, le contenu est définitivement supprimé de nos serveurs afin de garantir la confidentialité. Cette approche permet de protéger vos données sensibles en limitant leur exposition et en empêchant tout accès non autorisé.",
+    "text": "Les informations partagées via notre service ne sont accessibles qu'une seule fois. Une fois consulté, le contenu est définitivement supprimé de nos serveurs afin de garantir la confidentialité. Cette approche protège vos données sensibles en limitant leur exposition et en empêchant tout accès non autorisé.",
     "source_hash": "a3fd8283"
   },
   "web.errors.were_sorry_but_an_unexpected_error_occurred_whil": {
-    "text": "Nous sommes désolés, mais une erreur inattendue s'est produite lors du traitement de votre demande. Notre équipe en a été informée et nous travaillons à sa résolution.",
+    "text": "Nous sommes désolés, une erreur inattendue s'est produite lors du traitement de votre demande. Notre équipe a été prévenue et travaille à sa résolution.",
     "source_hash": "f3b50965"
   },
   "web.errors.t_web_common_oops_something_went_wrong": {
-    "text": "{0} Quelque chose s'est mal passé",
+    "text": "{0} Une erreur est survenue",
     "source_hash": "93529f24"
   },
   "web.errors.go_share_a_secret": {
-    "text": "Allez partager un secret !",
+    "text": "Allez partager un secret !",
     "source_hash": "04c04b1a"
   },
   "web.errors.the_page_youre_looking_for_doesnt_exist_or_has_b": {
-    "text": "La page que vous recherchez n'existe pas ou a été déplacée. Ne vous inquiétez pas, cela arrive aux meilleurs d'entre nous !",
+    "text": "La page que vous recherchez n'existe pas ou a été déplacée. Pas d'inquiétude, cela arrive à tout le monde !",
     "source_hash": "e26522de"
   },
   "web.errors.t_web_common_oops_404": {
@@ -72,7 +72,7 @@
     "source_hash": "ba5b5737"
   },
   "web.errors.unable_to_load_data_due_to_data_format_issues_pl": {
-    "text": "Impossible de charger les données en raison d'un problème de format. Veuillez réessayer plus tard.",
+    "text": "Impossible de charger les données en raison de problèmes de format. Veuillez réessayer plus tard.",
     "source_hash": "a7b6f998"
   }
 }

--- a/locales/content/fr_FR/feature-feedback.json
+++ b/locales/content/fr_FR/feature-feedback.json
@@ -1,10 +1,10 @@
 {
   "web.feedback.your_feedback": {
-    "text": "Votre commentaire",
+    "text": "Vos commentaires",
     "source_hash": "cdb1c0a5"
   },
   "web.feedback.all_feedback_welcome": {
-    "text": "Tous les commentaires sont les bienvenus !",
+    "text": "Tous les commentaires sont les bienvenus !",
     "source_hash": "c57d3006"
   },
   "web.feedback.help_us_improve": {
@@ -12,11 +12,11 @@
     "source_hash": "f35439c4"
   },
   "web.feedback.close_feedback_modal": {
-    "text": "Fermer la fenêtre de commentaire",
+    "text": "Fermer la fenêtre de commentaires",
     "source_hash": "41689bb4"
   },
   "web.feedback.share_your_feedback": {
-    "text": "Partagez votre commentaire",
+    "text": "Partagez vos commentaires",
     "source_hash": "6d62dfbd"
   },
   "web.feedback.delano_mandelbaum": {
@@ -28,39 +28,39 @@
     "source_hash": "f58154f7"
   },
   "web.feedback.help_content_goes_here": {
-    "text": "Le contenu d'aide apparaît ici.",
+    "text": "Le contenu d'aide s'affiche ici.",
     "source_hash": "796979ea"
   },
   "web.feedback.founder_note_line1": {
-    "text": "Je lis chaque commentaire qui arrive ici. C'est comme cela que je détermine sur quoi consacrer mon temps.",
+    "text": "Je lis chaque commentaire qui arrive ici. C'est ainsi que je détermine sur quoi passer du temps.",
     "source_hash": "8b430d93"
   },
   "web.feedback.founder_note_line2": {
-    "text": "Si quelque chose ne va pas, ou si vous avez des idées sur la façon dont cela devrait fonctionner, c'est le bon endroit.",
+    "text": "Si quelque chose ne va pas, ou si vous avez des idées sur son fonctionnement, c'est le bon endroit.",
     "source_hash": "d4b8f073"
   },
   "web.feedback.open_feedback_form": {
-    "text": "Ouvrir le formulaire de commentaire",
+    "text": "Ouvrir le formulaire de commentaires",
     "source_hash": "acd8409b"
   },
   "web.feedback.enter_your_feedback": {
-    "text": "Saisissez votre commentaire",
+    "text": "Saisissez vos commentaires",
     "source_hash": "1bb310f4"
   },
   "web.feedback.send_feedback": {
-    "text": "Envoyer un commentaire",
+    "text": "Envoyer les commentaires",
     "source_hash": "8235980b"
   },
   "web.feedback.sending_ellipses": {
-    "text": "Envoi en cours...",
+    "text": "Envoi...",
     "source_hash": "286a3af7"
   },
   "web.feedback.reason_email_change_unauthorized": {
-    "text": "Il semble que vous signalez un changement d'e-mail non autorisé sur votre compte. Veuillez décrire ce qui s'est passé et nous enquêterons immédiatement.",
+    "text": "Il semble que vous signaliez un changement d'adresse e-mail non autorisé sur votre compte. Veuillez décrire ce qui s'est passé et nous enquêterons immédiatement.",
     "source_hash": "00e56551"
   },
   "web.feedback.anonymous_no_reply": {
-    "text": "Remarque : si vous souhaitez une réponse, veuillez signer ou inclure une adresse e-mail dans le message.",
+    "text": "Remarque : si vous souhaitez une réponse, veuillez signer votre message ou y inclure une adresse e-mail.",
     "source_hash": "c984f705"
   },
   "web.feedback.characters_remaining": {

--- a/locales/content/fr_FR/feature-homepage-secrets.json
+++ b/locales/content/fr_FR/feature-homepage-secrets.json
@@ -20,11 +20,11 @@
     "source_hash": "78c621b6"
   },
   "homepage_secrets.disabled.team_subtitle": {
-    "text": "Seuls les coéquipiers autorisés de {domain} peuvent créer de nouveaux liens à usage unique ici. Les destinataires peuvent toujours ouvrir tout lien qui leur a été envoyé.",
+    "text": "Seuls les collaborateurs autorisés de {domain} peuvent générer de nouveaux liens à usage unique ici. Les destinataires peuvent toujours ouvrir un lien qui leur a été envoyé.",
     "source_hash": "62198a0e"
   },
   "homepage_secrets.disabled.public_subtitle": {
-    "text": "Seuls les membres autorisés de cette instance peuvent créer de nouveaux liens à usage unique. Les destinataires peuvent toujours ouvrir tout lien qui leur a été envoyé.",
+    "text": "Seuls les membres autorisés de cette instance peuvent générer de nouveaux liens à usage unique. Les destinataires peuvent toujours ouvrir un lien qui leur a été envoyé.",
     "source_hash": "0208d739"
   },
   "homepage_secrets.disabled.signin_cta": {
@@ -36,7 +36,7 @@
     "source_hash": "0b12ba39"
   },
   "homepage_secrets.disabled.trust_viewed_once": {
-    "text": "Consulté une fois, puis supprimé",
+    "text": "Consulté une fois, puis effacé",
     "source_hash": "abb7a947"
   },
   "homepage_secrets.disabled.trust_zero_retained": {
@@ -44,11 +44,11 @@
     "source_hash": "db6d7cc9"
   },
   "homepage_secrets.disabled.promo_title": {
-    "text": "Nouveau : les forfaits gratuits incluent désormais les domaines personnalisés.",
+    "text": "Nouveauté : les forfaits gratuits incluent désormais les domaines personnalisés.",
     "source_hash": "00888d63"
   },
   "homepage_secrets.disabled.promo_subtitle": {
-    "text": "Pointez votre domaine vers Onetime Secret et diffusez des secrets sous votre propre marque.",
+    "text": "Dirigez votre domaine vers Onetime Secret et partagez des secrets sous votre propre marque.",
     "source_hash": "27ecd53c"
   },
   "homepage_secrets.disabled.promo_learn_how": {

--- a/locales/content/fr_FR/feature-incoming.json
+++ b/locales/content/fr_FR/feature-incoming.json
@@ -16,11 +16,11 @@
     "source_hash": "6410ad42"
   },
   "incoming.feature_disabled_title": {
-    "text": "Fonctionnalité non disponible",
+    "text": "Fonctionnalité indisponible",
     "source_hash": "bfd624f7"
   },
   "incoming.feature_disabled_description": {
-    "text": "Cette fonctionnalité est actuellement désactivée. Veuillez contacter le support pour obtenir de l'aide.",
+    "text": "Cette fonctionnalité est actuellement désactivée. Veuillez contacter l'assistance pour obtenir de l'aide.",
     "source_hash": "f13fbf2b"
   },
   "incoming.memo_label": {
@@ -28,11 +28,11 @@
     "source_hash": "64cecb8a"
   },
   "incoming.memo_placeholder": {
-    "text": "Brève description (ex. Demande de réinitialisation de mot de passe)",
+    "text": "Brève description (ex. demande de réinitialisation de mot de passe)",
     "source_hash": "16bf83fd"
   },
   "incoming.memo_hint": {
-    "text": "Aidez-nous à acheminer votre message vers la bonne personne",
+    "text": "Aidez-nous à transmettre votre message à la bonne personne",
     "source_hash": "185a207e"
   },
   "incoming.recipient_label": {
@@ -40,11 +40,11 @@
     "source_hash": "9bcbb3bc"
   },
   "incoming.recipient_placeholder": {
-    "text": "Sélectionner un destinataire",
+    "text": "Sélectionnez un destinataire",
     "source_hash": "4eb1ed54"
   },
   "incoming.recipient_aria_label": {
-    "text": "Sélectionner un destinataire pour ce secret",
+    "text": "Sélectionnez un destinataire pour ce secret",
     "source_hash": "c98ac75f"
   },
   "incoming.recipient_hint": {
@@ -60,7 +60,7 @@
     "source_hash": "b4f8c120"
   },
   "incoming.secret_content_placeholder": {
-    "text": "Collez les informations sensibles ici (mots de passe, clés, etc.)",
+    "text": "Collez ici les informations sensibles (mots de passe, clés, etc.)",
     "source_hash": "7d7abb48"
   },
   "incoming.secret_content_hint": {
@@ -96,7 +96,7 @@
     "source_hash": "261e9a7e"
   },
   "incoming.success_description": {
-    "text": "Votre message sécurisé a été livré.",
+    "text": "Votre message sécurisé a été distribué.",
     "source_hash": "e1538e3e"
   },
   "incoming.reference_id": {
@@ -104,7 +104,7 @@
     "source_hash": "293aba9f"
   },
   "incoming.success_info_title": {
-    "text": "Que se passe-t-il ensuite ?",
+    "text": "Que se passe-t-il ensuite ?",
     "source_hash": "c72895ba"
   },
   "incoming.success_info_description": {
@@ -120,7 +120,7 @@
     "source_hash": "099ff0c7"
   },
   "incoming.tagline2": {
-    "text": "Gardez les mots de passe et les données privées hors des e-mails et des historiques de conversation",
+    "text": "Gardez les mots de passe et les données privées hors des e-mails et des journaux de discussion",
     "source_hash": "55566199"
   },
   "incoming.end_of_experience_suggestion": {
@@ -128,7 +128,7 @@
     "source_hash": "db3d9c98"
   },
   "incoming.receipt_link_text": {
-    "text": "accusé de réception",
+    "text": "reçu",
     "source_hash": "6f328609"
   },
   "incoming.upgrade_required_title": {
@@ -144,7 +144,7 @@
     "source_hash": "5727f2d3"
   },
   "incoming.validation_secret_required": {
-    "text": "Le contenu du secret est requis",
+    "text": "Le contenu du secret est obligatoire",
     "source_hash": "699783c9"
   },
   "incoming.validation_recipient_required": {
@@ -152,11 +152,11 @@
     "source_hash": "67bb4666"
   },
   "incoming.validation_feature_disabled": {
-    "text": "La fonctionnalité de secrets entrants n'est pas activée",
+    "text": "La fonctionnalité des secrets entrants n'est pas activée",
     "source_hash": "0616d3f4"
   },
   "incoming.validation_form_errors": {
-    "text": "Veuillez vérifier les erreurs dans le formulaire",
+    "text": "Veuillez vérifier les erreurs du formulaire",
     "source_hash": "9056e064"
   }
 }

--- a/locales/content/fr_FR/feature-regions.json
+++ b/locales/content/fr_FR/feature-regions.json
@@ -4,19 +4,19 @@
     "source_hash": "1e6287f1"
   },
   "web.regions.data_sovereignty_description": {
-    "text": "Vos données résident exclusivement dans la région que vous avez choisie et ne sont jamais transférées entre régions",
+    "text": "Vos données résident exclusivement dans la région que vous avez choisie et ne sont jamais transférées d'une région à l'autre",
     "source_hash": "5e904993"
   },
   "web.regions.separate_environments_explanation": {
-    "text": "Chaque région fonctionne comme un environnement complètement indépendant avec sa propre infrastructure, ses propres clés de chiffrement et son propre stockage de données",
+    "text": "Chaque région fonctionne comme un environnement totalement indépendant, avec sa propre infrastructure, ses propres clés de chiffrement et son propre stockage de données",
     "source_hash": "cd996732"
   },
   "web.regions.no_data_transfer_policy": {
-    "text": "Nous maintenons une politique stricte : les données des clients ne sont jamais transférées entre régions en aucune circonstance",
+    "text": "Nous appliquons une politique stricte : les données clients ne sont jamais transférées entre régions, en aucune circonstance",
     "source_hash": "33b74be3"
   },
   "web.regions.switching_creates_new_account": {
-    "text": "Important : Changer de région crée un nouveau compte. Vos données restent dans votre région d'origine.",
+    "text": "Important : passer à une autre région crée un nouveau compte. Vos données restent dans votre région d'origine.",
     "source_hash": "40e3ee34"
   },
   "web.regions.your_region": {
@@ -48,11 +48,11 @@
     "source_hash": "97fd57ab"
   },
   "web.regions.privacy_title": {
-    "text": "Droits à la vie privée",
+    "text": "Droits en matière de confidentialité",
     "source_hash": "d13d2931"
   },
   "web.regions.privacy_description": {
-    "text": "Assurez-vous que vos informations personnelles sont traitées conformément aux lois et réglementations de votre pays en matière de vie privée, empêchant tout accès ou utilisation non autorisés.",
+    "text": "Assurez-vous que vos informations personnelles sont traitées conformément aux lois et réglementations de votre pays en matière de confidentialité, empêchant tout accès non autorisé ou toute utilisation abusive.",
     "source_hash": "28d9d42e"
   },
   "web.regions.compliance_title": {
@@ -60,7 +60,7 @@
     "source_hash": "8aa0df2a"
   },
   "web.regions.compliance_description": {
-    "text": "Respectez les exigences du RGPD, HIPAA, CCPA et autres réglementations régionales de protection des données",
+    "text": "Répondez aux exigences du RGPD, de l'HIPAA, du CCPA et des autres réglementations régionales de protection des données",
     "source_hash": "c3b2ee43"
   },
   "web.regions.performance_title": {
@@ -76,7 +76,7 @@
     "source_hash": "610c65d8"
   },
   "web.regions.contact_our_compliance_team": {
-    "text": "contacter notre équipe de conformité",
+    "text": "contacter notre équipe conformité",
     "source_hash": "87e6746e"
   },
   "web.regions.review_our_documentation": {
@@ -84,19 +84,19 @@
     "source_hash": "9cbd03df"
   },
   "web.regions.your_account_and_data_are_protected_under_the_la": {
-    "text": "Votre compte et vos données sont protégés par les lois et règlements des pays suivants",
+    "text": "Votre compte et vos données sont protégés par les lois de",
     "source_hash": "5f5ef5b6"
   },
   "web.regions.this_regulatory_framework_is_determined_by_your_": {
-    "text": "Ce cadre réglementaire est déterminé par votre domaine d'accès :",
+    "text": "Votre cadre réglementaire est déterminé par votre domaine d'accès :",
     "source_hash": "7fdbc59c"
   },
   "web.regions.each_jurisdiction_maintains_separate_legal_compl": {
-    "text": "Chaque juridiction maintient une conformité légale et une gouvernance des données distinctes. Bien que vous puissiez créer des comptes dans plusieurs juridictions, celles-ci restent juridiquement distinctes et les données ne sont pas partagées entre les zones réglementaires.",
+    "text": "Chaque région est totalement distincte, avec sa propre infrastructure et, lorsque c'est possible, son propre hébergeur local. Vous pouvez créer des comptes dans plusieurs régions, mais aucune donnée n'est partagée entre elles.",
     "source_hash": "5c0b350e"
   },
   "web.regions.to_understand_the_specific_regulations_and_prote": {
-    "text": "Pour comprendre les réglementations et protections spécifiques qui s'appliquent à votre compte, veuillez",
+    "text": "Pour en savoir plus sur les réglementations et protections applicables à votre compte,",
     "source_hash": "e8acc835"
   },
   "web.regions.current": {
@@ -116,7 +116,7 @@
     "source_hash": "d69b9ac7"
   },
   "web.regions.data_center_location_currentjurisdiction_identif": {
-    "text": "Emplacement du centre de données : {0}",
+    "text": "Emplacement du centre de données : {0}",
     "source_hash": "f1699c90"
   },
   "web.regions.data_region": {
@@ -128,7 +128,7 @@
     "source_hash": "eae2e122"
   },
   "web.regions.serving_you_from_the": {
-    "text": "Vous êtes servi depuis",
+    "text": "Nous vous servons depuis",
     "source_hash": "25db17aa"
   },
   "web.regions.continue_to_jurisdiction_domain": {
@@ -136,35 +136,35 @@
     "source_hash": "dd1a44e4"
   },
   "web.regions.current_jurisdiction": {
-    "text": "Juridiction actuelle :",
+    "text": "Juridiction actuelle :",
     "source_hash": "d0f2192d"
   },
   "web.regions.changing_regions_title": {
-    "text": "Changement de région",
+    "text": "Changer de région",
     "source_hash": "189d6685"
   },
   "web.regions.changing_regions_description": {
-    "text": "Notre politique est de ne jamais transférer de données entre les régions. Chaque région fonctionne comme un environnement totalement indépendant.",
+    "text": "Notre politique est de ne jamais transférer de données entre régions. Chaque région fonctionne comme un environnement totalement indépendant.",
     "source_hash": "cf45b8be"
   },
   "web.regions.changing_regions_how_to": {
-    "text": "Pour utiliser une autre région, créez un nouveau compte en utilisant la même adresse e-mail associée à votre e-mail de contact de facturation.",
+    "text": "Pour utiliser une autre région, créez-y un nouveau compte en utilisant la même adresse e-mail que celle associée à votre contact de facturation.",
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "Si votre e-mail de contact de facturation diffère de l'e-mail de votre compte {product_name}, utilisez l'e-mail de contact de facturation pour le compte de la nouvelle région afin de conserver les avantages de votre abonnement.",
+    "text": "Si votre e-mail de contact de facturation diffère de l'adresse e-mail de votre compte {product_name}, utilisez l'e-mail de contact de facturation pour le compte de la nouvelle région afin de conserver les avantages de votre abonnement.",
     "source_hash": "d49662b0"
   },
   "web.regions.changing_regions_subscription_note": {
-    "text": "Vos avantages d'abonnement s'appliqueront automatiquement à tout compte créé avec votre adresse e-mail de facturation.",
+    "text": "Les avantages de votre abonnement s'appliqueront automatiquement à tout compte créé avec votre adresse e-mail de facturation.",
     "source_hash": "5b2238b2"
   },
   "web.regions.jurisdictions.eu.name": {
-    "text": "European Union",
+    "text": "Union européenne",
     "source_hash": "7fe24f2b"
   },
   "web.regions.jurisdictions.us.name": {
-    "text": "United States",
+    "text": "États-Unis",
     "source_hash": "49dca65f"
   },
   "web.regions.jurisdictions.ca.name": {
@@ -172,19 +172,19 @@
     "source_hash": "be55ef3f"
   },
   "web.regions.jurisdictions.uk.name": {
-    "text": "United Kingdom",
+    "text": "Royaume-Uni",
     "source_hash": "8d23a6e3"
   },
   "web.regions.jurisdictions.nz.name": {
-    "text": "New Zealand",
+    "text": "Nouvelle-Zélande",
     "source_hash": "2898e16d"
   },
   "web.regions.jurisdictions.at.name": {
-    "text": "Austria",
+    "text": "Autriche",
     "source_hash": "c9cab023"
   },
   "web.regions.jurisdictions.apac.name": {
-    "text": "Asia-Pacific",
+    "text": "Asie-Pacifique",
     "source_hash": "7a757670"
   },
   "web.regions.no_region_configured": {

--- a/locales/content/fr_FR/feature-testimonials.json
+++ b/locales/content/fr_FR/feature-testimonials.json
@@ -16,7 +16,7 @@
     "source_hash": "a06d9daa"
   },
   "web.testimonials.randomtestimonial_quote": {
-    "text": "\"{0}\"",
+    "text": "« {0} »",
     "source_hash": "7a27d02b"
   },
   "web.testimonials.t_ai_generated_testimonial": {

--- a/locales/content/fr_FR/feature-testimonials.json
+++ b/locales/content/fr_FR/feature-testimonials.json
@@ -4,7 +4,7 @@
     "source_hash": "ff4d6634"
   },
   "web.testimonials.ai_generated_content_disclaimer": {
-    "text": "Contenu généré par IA à des fins de démonstration. Ne provient pas d'une personne ou entreprise réelle.",
+    "text": "Contenu généré par IA à des fins de démonstration. Il ne provient ni d'une personne ni d'une entreprise réelles.",
     "source_hash": "d7093de7"
   },
   "web.testimonials.randomtestimonial_stars_5": {
@@ -16,15 +16,15 @@
     "source_hash": "a06d9daa"
   },
   "web.testimonials.randomtestimonial_quote": {
-    "text": "« {0} »",
+    "text": "\"{0}\"",
     "source_hash": "7a27d02b"
   },
   "web.testimonials.t_ai_generated_testimonial": {
-    "text": "{0} :",
+    "text": "{0} :",
     "source_hash": "14159dd9"
   },
   "web.testimonials.what_leading_ai_says_about_us": {
-    "text": "Ce que l'IA de pointe dit de nous",
+    "text": "Ce que les principales IA disent de nous",
     "source_hash": "f46a8839"
   },
   "web.testimonials.ai_generated_testimonials": {
@@ -36,15 +36,15 @@
     "source_hash": "7879a747"
   },
   "web.testimonials.it_was_based_on_the_content_of_the_page_and_does": {
-    "text": "Elle est basée sur le contenu de la page et ne représente pas une personne ou une entreprise réelle.",
+    "text": "Elle s'appuie sur le contenu de la page et ne représente ni une personne ni une entreprise réelles.",
     "source_hash": "8b290e9a"
   },
   "web.testimonials.artificial_feedback": {
-    "text": "Commentaire artificiel",
+    "text": "Commentaires artificiels",
     "source_hash": "4c8d20ba"
   },
   "web.testimonials.this_content_is_ai_generated_based_on_the_conten": {
-    "text": "Ce contenu est généré par l'IA sur la base du contenu de cette page et ne représente pas une personne ou une entreprise réelle.",
+    "text": "Ce contenu est généré par IA à partir du contenu de cette page et ne représente ni une personne ni une entreprise réelles.",
     "source_hash": "03c16436"
   }
 }

--- a/locales/content/fr_FR/feature-translations.json
+++ b/locales/content/fr_FR/feature-translations.json
@@ -1,6 +1,6 @@
 {
   "web.translations.welcomes_contributors_for_both_existing_and_new_": {
-    "text": "accueille des contributeurs pour les langues existantes et nouvelles.",
+    "text": "accueille les contributeurs pour les langues existantes comme pour les nouvelles.",
     "source_hash": "87abcdeb"
   },
   "web.translations.our_github_project": {
@@ -8,27 +8,27 @@
     "source_hash": "dabd28e2"
   },
   "web.translations.if_youre_interested_in_translation": {
-    "text": "Si vous êtes intéressé par la traduction,",
+    "text": "Si la traduction vous intéresse,",
     "source_hash": "10056bff"
   },
   "web.translations.whove_helped_with_translations_as_we_continue_to": {
-    "text": "qui ont participé aux traductions, alors que nous continuons à développer de nouvelles fonctionnalités.",
+    "text": "qui ont contribué aux traductions tandis que nous continuons à développer de nouvelles fonctionnalités.",
     "source_hash": "d629cc71"
   },
   "web.translations.25_contributors": {
-    "text": "Plus de 25 contributeurs",
+    "text": "plus de 25 contributeurs",
     "source_hash": "080aa720"
   },
   "web.translations.were_grateful_to_the": {
-    "text": "Nous sommes reconnaissants envers les",
+    "text": "Nous remercions les",
     "source_hash": "cf446287"
   },
   "web.translations.as_we_add_new_features_our_translations_graduall": {
-    "text": "Au fur et à mesure que nous ajoutons de nouvelles fonctionnalités, nos traductions doivent être mises à jour pour rester actuelles. Cela concerne à la fois onetimesecret.com et des milliers d'installations auto-hébergées dans le monde entier.",
+    "text": "À mesure que nous ajoutons de nouvelles fonctionnalités, nos traductions doivent être mises à jour pour rester à jour. Cela concerne aussi bien onetimesecret.com que des milliers d'installations auto-hébergées dans le monde.",
     "source_hash": "c6fb1cf5"
   },
   "web.translations.remember_to_include_your_email_if_youre_not_logg": {
-    "text": "- n'oubliez pas d'indiquer votre adresse électronique si vous n'êtes pas connecté. Chaque traduction permet à un plus grand nombre de personnes de communiquer en toute sécurité.",
+    "text": "- pensez à indiquer votre adresse e-mail si vous n'êtes pas connecté. Chaque traduction aide davantage de personnes à communiquer en toute sécurité.",
     "source_hash": "1a8ccc7d"
   },
   "web.translations.reach_out_to_us": {
@@ -36,35 +36,35 @@
     "source_hash": "fee7dd79"
   },
   "web.translations.have_questions": {
-    "text": "Vous avez des questions ?",
+    "text": "Vous avez des questions ?",
     "source_hash": "75e4b61a"
   },
   "web.translations.send_translations_by_email_to": {
-    "text": "Envoyez les traductions par e-mail à",
+    "text": "Envoyez vos traductions par e-mail à",
     "source_hash": "f96a59a1"
   },
   "web.translations.english_template": {
-    "text": "Modèle anglais",
+    "text": "modèle anglais",
     "source_hash": "1a843644"
   },
   "web.translations.start_a_new_translation_from_our": {
-    "text": "Commencez une nouvelle traduction à partir de notre",
+    "text": "Démarrez une nouvelle traduction à partir de notre",
     "source_hash": "b963b7e9"
   },
   "web.translations.update_a_language_directly_through_our_github_pr": {
-    "text": "Mettre à jour une langue directement via notre projet GitHub",
+    "text": "Mettez à jour une langue directement via notre projet GitHub",
     "source_hash": "449cde87"
   },
   "web.translations.review_existing_translations_using_the_language_": {
-    "text": "Réviser les traductions existantes à l'aide du sélecteur de langue ci-dessus",
+    "text": "Relisez les traductions existantes à l'aide du sélecteur de langue ci-dessus",
     "source_hash": "74ea57e9"
   },
   "web.translations.ready_to_help_some_ways_to_contribute": {
-    "text": "Prêt à aider ? Quelques façons de contribuer :",
+    "text": "Prêt à aider ? Voici quelques façons de contribuer :",
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "Les personnes suivantes ont donné de leur temps pour aider à étendre la portée de {product_name} :",
+    "text": "Les personnes suivantes ont donné de leur temps pour étendre la portée de {product_name} :",
     "source_hash": "6cc876ae"
   },
   "web.translations.translations": {
@@ -76,19 +76,19 @@
     "source_hash": "bb60a45d"
   },
   "web.translations.your_language_skills_can_help_expand_access_to_s": {
-    "text": "Vos compétences linguistiques peuvent contribuer à élargir l'accès aux communications sécurisées.",
+    "text": "Vos compétences linguistiques peuvent élargir l'accès à une communication sécurisée.",
     "source_hash": "ad22076b"
   },
   "web.translations.thanks_to_our_community_we_support_over_20_langu": {
-    "text": "Grâce à notre communauté, nous prenons aujourd'hui en charge plus de 20 langues. Cependant, avec notre rythme de développement rapide, de nombreuses traductions ont besoin de mises à jour pour rester d'actualité. Cela concerne à la fois onetimesecret.com et les milliers d'installations auto-hébergées dans le monde.",
+    "text": "Grâce à notre communauté, nous prenons aujourd'hui en charge plus de 20 langues. Toutefois, compte tenu de notre rythme de développement rapide, de nombreuses traductions doivent être mises à jour. Cela concerne aussi bien onetimesecret.com que les milliers d'installations auto-hébergées dans le monde.",
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "Depuis 2012, {product_name} offre un moyen sécurisé de partager des informations sensibles dans le monde entier. Avec des utilisateurs dans des régions où l'anglais n'est pas la langue principale, des traductions précises sont essentielles pour rendre la communication sécurisée accessible à tous.",
+    "text": "Depuis 2012, {product_name} offre un moyen sécurisé de partager des informations sensibles dans le monde entier. Avec des utilisateurs dans des régions où l'anglais n'est pas la langue principale, des traductions exactes sont essentielles pour rendre la communication sécurisée accessible à tous.",
     "source_hash": "ded965d5"
   },
   "web.translations.help_secure_communication_go_global": {
-    "text": "Aidez la communication sécurisée à devenir mondiale",
+    "text": "Aidez la communication sécurisée à se mondialiser",
     "source_hash": "e94bdc8e"
   }
 }

--- a/locales/content/fr_FR/secret-homepage.json
+++ b/locales/content/fr_FR/secret-homepage.json
@@ -1,18 +1,18 @@
 {
   "web.homepage.tagline1": {
-    "text": "Collez un mot de passe, un message secret ou un lien privé ci-dessous.",
+    "text": "Collez ci-dessous un mot de passe, un message secret ou un lien privé.",
     "source_hash": "5785816e"
   },
   "web.homepage.tagline2": {
-    "text": "Gardez les informations sensibles hors de vos e-mails et historiques de conversation.",
+    "text": "Gardez les informations sensibles hors de vos e-mails et de vos journaux de discussion.",
     "source_hash": "69dd8d56"
   },
   "web.homepage.secret_hint": {
-    "text": "* Un lien secret ne fonctionne qu'une seule fois et disparaît ensuite pour toujours.",
+    "text": "* Un lien secret ne fonctionne qu'une seule fois, puis disparaît à jamais.",
     "source_hash": "3c66e4e7"
   },
   "web.homepage.secret_form_more_text1": {
-    "text": "Inscrivez-vous pour un",
+    "text": "Inscrivez-vous pour obtenir un",
     "source_hash": "bc6d69e8"
   },
   "web.homepage.secret_form_more_text2": {
@@ -24,11 +24,11 @@
     "source_hash": "004dda26"
   },
   "web.homepage.cta_title": {
-    "text": "Augmentez la confiance et partagez en toute sérénité",
+    "text": "Renforcez la confiance et partagez sereinement",
     "source_hash": "f0d63307"
   },
   "web.homepage.cta_subtitle": {
-    "text": "Valorisez votre marque et partagez en toute confiance",
+    "text": "Valorisez votre marque et partagez sereinement",
     "source_hash": "0034dcc3"
   },
   "web.homepage.cta_feature1": {
@@ -40,15 +40,15 @@
     "source_hash": "e5bb7fc8"
   },
   "web.homepage.cta_feature3": {
-    "text": "Augmentez la confiance et l'engagement des clients",
+    "text": "Renforcez la confiance et l'engagement de vos clients",
     "source_hash": "d91e6ecc"
   },
   "web.homepage.explore_premium_plans": {
-    "text": "Avec domaines personnalisés",
+    "text": "Avec des domaines personnalisés",
     "source_hash": "3f1bf1de"
   },
   "web.homepage.need_free_account": {
-    "text": "Vous débutez ? Envoyez des e-mails avec un compte gratuit.",
+    "text": "Vous débutez ? Envoyez des e-mails avec un compte gratuit.",
     "source_hash": "35d2ac76"
   },
   "web.homepage.sign_up_free": {
@@ -64,11 +64,11 @@
     "source_hash": "7bec027a"
   },
   "web.homepage.password_generation_description": {
-    "text": "Cliquez sur « Générer un mot de passe » pour créer un mot de passe aléatoire sécurisé que vous pouvez partager.",
+    "text": " Cliquez sur « Générer un mot de passe » pour créer un mot de passe aléatoire sécurisé que vous pourrez partager.",
     "source_hash": "82c42d54"
   },
   "web.homepage.protip1": {
-    "text": "Votre message s'autodétruira après consultation. Le lien ne peut être consulté qu'une seule fois.",
+    "text": "Votre message s'autodétruira après avoir été consulté. Le lien n'est accessible qu'une seule fois.",
     "source_hash": "085cd9bd"
   },
   "web.homepage.authonly.tagline2": {
@@ -84,7 +84,7 @@
     "source_hash": "8a727004"
   },
   "web.homepage.disabled.tagline1": {
-    "text": "L'interface utilisateur et les fonctionnalités de connexion ne sont pas disponibles.",
+    "text": "L'interface utilisateur et les fonctions de connexion ne sont pas disponibles.",
     "source_hash": "275605c2"
   },
   "web.homepage.link_preview": {
@@ -92,15 +92,15 @@
     "source_hash": "140c4b1a"
   },
   "web.homepage.meets_and_exceeds_compliance_standards": {
-    "text": "Respecter et dépasser les normes de conformité",
+    "text": "Répond aux normes de conformité et les dépasse",
     "source_hash": "4bd4c8a0"
   },
   "web.homepage.secure_your_brand_build_customer_trust_etc": {
-    "text": "Sécurisez votre marque, renforcez la confiance de vos clients avec des liens depuis votre domaine.",
+    "text": "Sécurisez votre marque et instaurez la confiance de vos clients avec des liens issus de votre domaine.",
     "source_hash": "101a3149"
   },
   "web.homepage.a_trusted_way_to_share_sensitive_information_etc": {
-    "text": "Un moyen fiable de partager des informations sensibles qui s'autodétruisent après avoir été consultées.",
+    "text": "Un moyen fiable de partager des informations sensibles qui s'autodétruisent après consultation.",
     "source_hash": "a5429343"
   },
   "web.homepage.secure_links": {
@@ -120,7 +120,7 @@
     "source_hash": "b3046356"
   },
   "web.homepage.signup_individual_and_business_plans": {
-    "text": "Inscription - Plans individuels et professionnels",
+    "text": "Inscription - Forfaits particuliers et entreprises",
     "source_hash": "3fcd1682"
   },
   "web.homepage.tagline_signed": {
@@ -152,7 +152,7 @@
     "source_hash": "0792b61e"
   },
   "web.homepage.send_sensitive_information_that_can_only_be_viewed_once": {
-    "text": "Envoyer des informations sensibles qui ne peuvent être consultées qu'une seule fois",
+    "text": "Envoyez des informations sensibles consultables une seule fois",
     "source_hash": "8c43aaaf"
   },
   "web.homepage.create_a_secure_link": {
@@ -160,11 +160,11 @@
     "source_hash": "550bb21e"
   },
   "web.homepage.now_with_custom_domains": {
-    "text": "Maintenant avec domaines personnalisés",
+    "text": "Désormais avec des domaines personnalisés",
     "source_hash": "94d5249b"
   },
   "web.homepage.this_is_a_private_instance_only_authorized_team_": {
-    "text": "Il s'agit d'une instance privée. Seuls les membres autorisés de l'équipe peuvent générer de nouveaux liens sécurisés.",
+    "text": "Ceci est une instance privée. Seuls les membres autorisés de l'équipe peuvent générer de nouveaux liens sécurisés.",
     "source_hash": "e1073c60"
   },
   "web.homepage.welcome_to_onetime_secret": {
@@ -176,11 +176,11 @@
     "source_hash": "7e9192bd"
   },
   "web.homepage.information_shared_through_this_service_can_only": {
-    "text": "Les informations partagées par l'intermédiaire de ce service ne peuvent être consultées qu'une seule fois. Une fois consulté, le contenu est définitivement supprimé afin de garantir la confidentialité.",
+    "text": "Les informations partagées via ce service ne sont accessibles qu'une seule fois. Une fois consulté, le contenu est définitivement supprimé afin de garantir la confidentialité.",
     "source_hash": "fc58212a"
   },
   "web.homepage.welcome_to_the_global_broadcast": {
-    "text": "Bienvenue sur la diffusion mondiale !",
+    "text": "Bienvenue dans la diffusion mondiale !",
     "source_hash": "210e1894"
   },
   "web.homepage.send_a_secret": {

--- a/locales/content/fr_FR/secret-manage.json
+++ b/locales/content/fr_FR/secret-manage.json
@@ -4,7 +4,7 @@
     "source_hash": "643a6921"
   },
   "web.secrets.selectDuration": {
-    "text": "Sélectionner la durée",
+    "text": "Sélectionner une durée",
     "source_hash": "6ad4537b"
   },
   "web.secrets.expiresIn": {
@@ -12,7 +12,7 @@
     "source_hash": "f353f9a7"
   },
   "web.secrets.enterPassphrase": {
-    "text": "Saisir la phrase secrète",
+    "text": "Saisissez la phrase secrète",
     "source_hash": "263439f5"
   },
   "web.secrets.passphraseMinimumLength": {
@@ -20,15 +20,15 @@
     "source_hash": "94997839"
   },
   "web.secrets.passphraseComplexityRequired": {
-    "text": "Doit inclure majuscules, minuscules, chiffres et symboles",
+    "text": "Doit contenir une majuscule, une minuscule, un chiffre et un symbole",
     "source_hash": "1ddceea9"
   },
   "web.secrets.theyll_appear_here_once_youve_shared_them": {
-    "text": "Les éléments partagés apparaîtront ici",
+    "text": "Ils apparaîtront ici une fois que vous les aurez partagés.",
     "source_hash": "f8e8fe7d"
   },
   "web.secrets.recipient_delivery_is_optional": {
-    "text": "La livraison au destinataire est optionnelle",
+    "text": "L'envoi à un destinataire est facultatif",
     "source_hash": "4b6e1c1d"
   },
   "web.secrets.recent_secrets_count": {
@@ -48,7 +48,7 @@
     "source_hash": "d6fe071f"
   },
   "web.secrets.view_secret_message": {
-    "text": "Voir le message secret",
+    "text": "Consulter le message secret",
     "source_hash": "5da08cab"
   },
   "web.secrets.content_hidden": {
@@ -56,7 +56,7 @@
     "source_hash": "2e5a27e1"
   },
   "web.secrets.sample_secret_content_this_could_be_sensitive_data": {
-    "text": "Exemple de contenu de secret. Il pourrait s'agir de données sensibles\n\nOu d'un message sur plusieurs lignes",
+    "text": "Exemple de contenu secret. Il peut s'agir de données sensibles\n\nOu d'un message sur plusieurs lignes",
     "source_hash": "5e1bffcb"
   },
   "web.secrets.sample_secret_content": {
@@ -72,15 +72,15 @@
     "source_hash": "d11c5b24"
   },
   "web.secrets.content_status": {
-    "text": "Statut du contenu",
+    "text": "État du contenu",
     "source_hash": "5efa57d2"
   },
   "web.secrets.secret_content_copied_to_clipboard": {
-    "text": "Contenu secret copié dans le presse-papiers",
+    "text": "Contenu du secret copié dans le presse-papiers",
     "source_hash": "decf849f"
   },
   "web.secrets.secret_content": {
-    "text": "Contenu secret",
+    "text": "Contenu du secret",
     "source_hash": "a0c96d15"
   },
   "web.secrets.secret_confirmation": {
@@ -88,15 +88,15 @@
     "source_hash": "a6a2af3c"
   },
   "web.secrets.secret_value_not_available": {
-    "text": "Valeur du secret non disponible",
+    "text": "Valeur du secret indisponible",
     "source_hash": "ade77605"
   },
   "web.secrets.you_can_safely_close_this_tab": {
-    "text": "Vous pouvez fermer cette fenêtre lorsque vous avez terminé.",
+    "text": "Vous pouvez fermer cette fenêtre une fois terminé.",
     "source_hash": "7e488229"
   },
   "web.secrets.enter_the_secret_content_here": {
-    "text": "Saisissez le contenu secret ici",
+    "text": "Saisissez ici le contenu du secret",
     "source_hash": "d69e2157"
   },
   "web.secrets.enter_the_secret_content_to_share_here": {
@@ -108,23 +108,23 @@
     "source_hash": "f4a35731"
   },
   "web.secrets.enter_a_passphrase": {
-    "text": "Saisir une phrase secrète",
+    "text": "Saisissez une phrase secrète",
     "source_hash": "8b450877"
   },
   "web.secrets.when_ready_click_the_view_secret_button_at_the_t": {
-    "text": "Lorsque vous êtes prêt, cliquez sur le bouton \"Voir le secret\" en haut de la page pour révéler votre message unique.",
+    "text": "Lorsque vous êtes prêt, cliquez sur le bouton en haut de la page pour révéler votre message à usage unique.",
     "source_hash": "7a65b13e"
   },
   "web.secrets.what_happens_next": {
-    "text": "Que se passe-t-il ensuite ?",
+    "text": "Que se passe-t-il ensuite ?",
     "source_hash": "c72895ba"
   },
   "web.secrets.yes_after_viewing_the_secret_is_permanently_dele": {
-    "text": "Oui. Après avoir été visionné, le secret est définitivement supprimé de nos serveurs, ce qui garantit le respect de votre vie privée.",
+    "text": "Oui. Après consultation, le secret est définitivement supprimé de nos serveurs, garantissant votre confidentialité.",
     "source_hash": "15e6ab70"
   },
   "web.secrets.is_it_secure": {
-    "text": "Est-ce sécurisé ?",
+    "text": "Est-ce sécurisé ?",
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
@@ -132,19 +132,19 @@
     "source_hash": "bd0c6182"
   },
   "web.secrets.what_is_this": {
-    "text": "Qu'est-ce que c'est ?",
+    "text": "Qu'est-ce que c'est ?",
     "source_hash": "0b12ba39"
   },
   "web.secrets.before_you_open_it_heres_what_you_should_know": {
-    "text": "Avant de l'ouvrir, voici ce qu'il faut savoir :",
+    "text": "Avant de l'ouvrir, voici ce que vous devez savoir :",
     "source_hash": "f5c3bda4"
   },
   "web.secrets.a_secure_one_time_message_awaits_you": {
-    "text": "Un message sécurisé et unique vous attend.",
+    "text": "Un message sécurisé à usage unique vous attend.",
     "source_hash": "8e1ef474"
   },
   "web.secrets.youve_got_secret_mail": {
-    "text": "Vous avez du courrier (secret)",
+    "text": "Vous avez un courrier (secret)",
     "source_hash": "1cb809ea"
   },
   "web.secrets.auto_expire_after_viewing": {
@@ -152,15 +152,15 @@
     "source_hash": "08489543"
   },
   "web.secrets.secure_encrypted_storage": {
-    "text": "Stockage sécurisé et chiffré",
+    "text": "Stockage chiffré et sécurisé",
     "source_hash": "63f3282e"
   },
   "web.secrets.that_information_is_no_longer_available": {
-    "text": "Cette information n'est plus disponible.",
+    "text": "Ce secret a été consulté ou a expiré.",
     "source_hash": "4de19d63"
   },
   "web.secrets.information_no_longer_available": {
-    "text": "Information plus disponible",
+    "text": "Informations plus disponibles",
     "source_hash": "7e2f55cf"
   },
   "web.secrets.create_another_secret": {
@@ -196,7 +196,7 @@
     "source_hash": "72884098"
   },
   "web.receipt.pretext": {
-    "text": "Partager ce lien :",
+    "text": "Partagez ce lien :",
     "source_hash": "316cf396"
   },
   "web.receipt.requires_passphrase": {
@@ -208,19 +208,19 @@
     "source_hash": "ede466b1"
   },
   "web.receipt.only_see_once": {
-    "text": "Attention : vous ne verrez ceci qu'une seule fois.",
+    "text": "Attention : vous ne verrez ceci qu'une seule fois.",
     "source_hash": "a7c79715"
   },
   "web.receipt.created_success": {
-    "text": "Secret créé avec succès !",
+    "text": "Secret créé avec succès !",
     "source_hash": "ce65f4ad"
   },
   "web.receipt.created_success_key": {
-    "text": "Secret {shortKey} créé avec succès !",
+    "text": "Secret {shortKey} créé avec succès !",
     "source_hash": "73708d50"
   },
   "web.receipt.created_securely": {
-    "text": "Votre secret a été créé de manière sécurisée",
+    "text": "Votre secret a été créé en toute sécurité",
     "source_hash": "8f3c17cc"
   },
   "web.receipt.burned_ago": {
@@ -248,7 +248,7 @@
     "source_hash": "1b28d178"
   },
   "web.receipt.view_receipt": {
-    "text": "Voir les accusés de réception",
+    "text": "Consulter les reçus",
     "source_hash": "6c664c31"
   },
   "web.receipt.destroyed": {
@@ -256,31 +256,31 @@
     "source_hash": "ff49630c"
   },
   "web.receipt.have_more_questions_visit_our": {
-    "text": "D'autres questions ? Visitez notre",
+    "text": "Vous avez d'autres questions ? Consultez notre",
     "source_hash": "aadb8006"
   },
   "web.receipt.the_burn_feature_lets_you_permanently_delete_a_s": {
-    "text": "La fonction de suppression immédiate permet d'effacer définitivement un secret avant sa consultation. Utile pour révoquer l'accès ou corriger des informations partagées par erreur. Une fois supprimé, le secret est irrécupérable.",
+    "text": "La fonction de brûlage vous permet de supprimer définitivement un secret avant que quiconque ne le consulte. C'est utile si vous devez révoquer un accès ou si vous avez partagé les mauvaises informations. Une fois brûlé, le secret ne peut pas être récupéré.",
     "source_hash": "8f82008b"
   },
   "web.receipt.whats_the_burn_feature": {
-    "text": "Qu'est-ce que la fonction brûler ?",
+    "text": "Qu'est-ce que la fonction de brûlage ?",
     "source_hash": "783da354"
   },
   "web.receipt.your_secret_will_remain_available_for_record_nat": {
-    "text": "Votre secret reste disponible pendant {0} ou jusqu'à sa première consultation. Une fois l'une de ces conditions remplie, le secret est définitivement supprimé.",
+    "text": "Votre secret restera disponible pendant {0} ou jusqu'à sa consultation, selon ce qui survient en premier. Dès que l'une de ces conditions est remplie, le secret est définitivement supprimé.",
     "source_hash": "d690ea63"
   },
   "web.receipt.how_does_secret_expiration_work": {
-    "text": "Comment fonctionne l'expiration des secrets ?",
+    "text": "Comment fonctionne l'expiration d'un secret ?",
     "source_hash": "b69dacd2"
   },
   "web.receipt.for_security_reasons_we_cant_recover_lost_secret": {
-    "text": "Pour des raisons de sécurité, les liens perdus sont irrécupérables. Veuillez créer un nouveau secret avec un nouveau lien. Nous recommandons de sauvegarder le lien dès sa création.",
+    "text": "Pour des raisons de sécurité, nous ne pouvons pas récupérer les liens secrets perdus. Vous devrez créer un nouveau secret et générer un nouveau lien. Nous vous recommandons de copier le lien immédiatement après sa création.",
     "source_hash": "3b229db9"
   },
   "web.receipt.lost_your_secret_link": {
-    "text": "Vous avez perdu votre lien secret ?",
+    "text": "Vous avez perdu votre lien secret ?",
     "source_hash": "a968fd0b"
   },
   "web.receipt.expires_in_record_natural_expiration_0": {
@@ -288,23 +288,23 @@
     "source_hash": "1dceeb03"
   },
   "web.receipt.we_display_the_value_for_you_so_that_you_can_ver": {
-    "text": "L'affichage unique permet la vérification tout en garantissant la sécurité en cas d'accès non autorisé à cette page privée.",
+    "text": "Nous affichons la valeur pour que vous puissiez la vérifier, mais une seule fois : ainsi, si quelqu'un accède à cette page privée (via votre historique de navigation ou si vous envoyez par erreur le lien privé au lieu du lien secret), il ne verra pas la valeur du secret.",
     "source_hash": "cc1facdd"
   },
   "web.receipt.why_can_i_only_see_the_secret_value_once": {
-    "text": "Pourquoi ne puis-je voir la valeur du secret qu'une seule fois ?",
+    "text": "Pourquoi ne puis-je voir la valeur du secret qu'une seule fois ?",
     "source_hash": "b2e497d6"
   },
   "web.receipt.burning_a_secret_permanently_deletes_it_before_a": {
-    "text": "La suppression immédiate efface définitivement le secret avant consultation. Le destinataire sera notifié de sa non-existence. Fonction utile en cas d'erreur de partage ou nécessité de révocation.",
+    "text": "Brûler un secret le supprime définitivement avant que quiconque puisse le lire. Le destinataire verra un message indiquant que le secret n'existe pas. C'est utile si vous partagez par erreur de mauvaises informations ou si vous devez empêcher tout accès.",
     "source_hash": "f3fa5bbb"
   },
   "web.receipt.what_happens_when_i_burn_a_secret": {
-    "text": "Que se passe-t-il lorsque je brûle un secret ?",
+    "text": "Que se passe-t-il lorsque je brûle un secret ?",
     "source_hash": "cfc61708"
   },
   "web.receipt.and_never_stored_in_its_original_form_this_appro": {
-    "text": "et n'est jamais stocké sous forme non chiffrée. Cette approche garantit l'impossibilité d'accéder ou récupérer votre secret sans la phrase secrète correspondante.",
+    "text": "et n'est jamais stocké sous sa forme d'origine. Cette approche signifie que nous ne pouvons ni accéder à votre secret ni le récupérer — seule une personne disposant de la bonne phrase secrète le peut.",
     "source_hash": "9b760dad"
   },
   "web.receipt.passphrase_protection": {
@@ -312,15 +312,15 @@
     "source_hash": "0a6c3735"
   },
   "web.receipt.each_secret_can_only_be_viewed_once_after_viewin": {
-    "text": "Chaque secret n'est consultable qu'une seule fois. Après consultation, il est définitivement supprimé de nos serveurs, évitant toute exposition accidentelle via l'historique ou le partage erroné de liens.",
+    "text": "Chaque secret ne peut être consulté qu'une seule fois. Après consultation, il est définitivement supprimé de nos serveurs. Vos informations sensibles ne risquent ainsi pas d'être exposées par l'historique du navigateur ou par le partage accidentel de liens privés.",
     "source_hash": "581b5abf"
   },
   "web.receipt.one_time_access": {
-    "text": "Accès unique",
+    "text": "Accès à usage unique",
     "source_hash": "76f1cd7e"
   },
   "web.receipt.core_security_features": {
-    "text": "Fonctionnalités de sécurité principales",
+    "text": "Principales fonctionnalités de sécurité",
     "source_hash": "aa0fc6f9"
   },
   "web.receipt.expires_in_record_natural_expiration": {
@@ -328,7 +328,7 @@
     "source_hash": "1dceeb03"
   },
   "web.receipt.send_feedback": {
-    "text": "Envoyer un retour",
+    "text": "Envoyer des commentaires",
     "source_hash": "8235980b"
   },
   "web.shared.requires_passphrase": {
@@ -336,7 +336,7 @@
     "source_hash": "b38e604d"
   },
   "web.shared.viewed_own_secret": {
-    "text": "Vous avez consulté votre propre secret. Il n'est plus disponible pour quiconque.",
+    "text": "Vous avez consulté votre propre secret. Il n'est plus disponible pour personne d'autre.",
     "source_hash": "521e9a6f"
   },
   "web.shared.you_created_this_secret": {
@@ -344,11 +344,11 @@
     "source_hash": "1a4ac4ed"
   },
   "web.shared.your_secret_message": {
-    "text": "Votre message secret :",
+    "text": "Votre message secret :",
     "source_hash": "eb762113"
   },
   "web.shared.this_message_for_you": {
-    "text": "Ce message est pour vous :",
+    "text": "Ce message vous est destiné :",
     "source_hash": "4f6ba844"
   },
   "web.shared.your_message_is_ready": {
@@ -364,7 +364,7 @@
     "source_hash": "d489958b"
   },
   "web.shared.post_reveal_default": {
-    "text": "Votre message sécurisé est affiché ci-dessous.",
+    "text": "Votre message sécurisé s'affiche ci-dessous.",
     "source_hash": "01dfb737"
   },
   "web.shared.secret_was_truncated": {
@@ -372,7 +372,7 @@
     "source_hash": "edae5139"
   },
   "web.secrets.workspace_mode_disabled_for_generate": {
-    "text": "Désactivé pour les mots de passe générés — vous devez consulter le reçu pour voir le mot de passe",
+    "text": "Désactivé pour les mots de passe générés - vous devez consulter le reçu pour voir le mot de passe",
     "source_hash": "29969ba9"
   },
   "web.secrets.scope_org": {
@@ -384,7 +384,7 @@
     "source_hash": "f2a0be60"
   },
   "web.secrets.errors.domain_extid_required": {
-    "text": "Identifiant externe du domaine requis pour la portée du domaine",
+    "text": "Extid de domaine requis pour la portée du domaine",
     "source_hash": "d95b7bbc"
   },
   "web.secrets.errors.no_organization_context": {
@@ -392,7 +392,7 @@
     "source_hash": "6b90d7bc"
   },
   "web.secrets.errors.invalid_domain": {
-    "text": "Domaine invalide",
+    "text": "Domaine non valide",
     "source_hash": "a16151c0"
   },
   "web.secrets.errors.access_denied_to_domain": {

--- a/locales/content/fr_FR/session-auth-extended.json
+++ b/locales/content/fr_FR/session-auth-extended.json
@@ -58,7 +58,7 @@
     "source_hash": "3cff3311"
   },
   "web.auth.complete_mfa_verification": {
-    "text": "Terminer la vérification MFA",
+    "text": "Effectuer la vérification MFA",
     "source_hash": "0e681134"
   },
   "web.auth.security._guidance": {
@@ -78,7 +78,7 @@
     "source_hash": "f6f51186"
   },
   "web.auth.security.recovery_code_not_found": {
-    "text": "Code de récupération introuvable. Veuillez vérifier que vous l'avez saisi correctement.",
+    "text": "Code de récupération introuvable. Veuillez vérifier votre saisie.",
     "source_hash": "f5f1bd09"
   },
   "web.auth.security.recovery_code_used": {
@@ -90,7 +90,7 @@
     "source_hash": "31f2678d"
   },
   "web.auth.security.internal_error": {
-    "text": "Une erreur est survenue. Veuillez réessayer.",
+    "text": "Une erreur s'est produite. Veuillez réessayer.",
     "source_hash": "9c170dda"
   },
   "web.auth.methods.password": {
@@ -103,11 +103,11 @@
     "source_hash": "1b6ffed2"
   },
   "web.auth.methods.webauthn": {
-    "text": "Biométrique",
+    "text": "Biométrie",
     "source_hash": "ab2ba7db"
   },
   "web.auth.magicLink.title": {
-    "text": "Se connecter avec l'e-mail",
+    "text": "Se connecter par e-mail",
     "source_hash": "79a864df"
   },
   "web.auth.magicLink.description": {
@@ -115,7 +115,7 @@
     "source_hash": "5d75aeb0"
   },
   "web.auth.magicLink.emailPlaceholder": {
-    "text": "Saisissez votre e-mail",
+    "text": "Saisissez votre adresse e-mail",
     "source_hash": "2837f6fa"
   },
   "web.auth.magicLink.sendLink": {
@@ -123,7 +123,7 @@
     "source_hash": "f5f52392"
   },
   "web.auth.magicLink.checkEmail": {
-    "text": "Vérifiez vos e-mails",
+    "text": "Consultez votre messagerie",
     "source_hash": "77322879"
   },
   "web.auth.magicLink.sentTo": {
@@ -135,11 +135,11 @@
     "source_hash": "91b5f027"
   },
   "web.auth.magicLink.tryDifferentEmail": {
-    "text": "Essayer un autre e-mail",
+    "text": "Essayer une autre adresse e-mail",
     "source_hash": "98657c0b"
   },
   "web.auth.magicLink.noPasswordNeeded": {
-    "text": "Aucun mot de passe nécessaire — cliquez simplement sur le lien dans votre e-mail",
+    "text": "Aucun mot de passe requis — il suffit de cliquer sur le lien reçu par e-mail",
     "source_hash": "5f539b97"
   },
   "web.auth.magicLink.networkError": {
@@ -151,7 +151,7 @@
     "source_hash": "4c685e97"
   },
   "web.auth.magicLink.invalidLink": {
-    "text": "Lien de connexion invalide ou manquant",
+    "text": "Lien de connexion non valide ou manquant",
     "source_hash": "d726c0da"
   },
   "web.auth.magicLink.sessionExpired": {
@@ -167,7 +167,7 @@
     "source_hash": "9d432ef1"
   },
   "web.auth.magicLink.pleaseWait": {
-    "text": "Veuillez patienter pendant que nous vérifions votre lien",
+    "text": "Veuillez patienter pendant la vérification de votre lien",
     "source_hash": "81e4efed"
   },
   "web.auth.magicLink.error": {
@@ -187,11 +187,11 @@
     "source_hash": "7593dd46"
   },
   "web.auth.webauthn.notSupported": {
-    "text": "L'authentification biométrique n'est pas prise en charge dans ce navigateur",
+    "text": "L'authentification biométrique n'est pas prise en charge par ce navigateur",
     "source_hash": "fe2a2c2b"
   },
   "web.auth.webauthn.requiresModernBrowser": {
-    "text": "Veuillez utiliser un navigateur moderne qui prend en charge WebAuthn (Chrome, Safari, Firefox ou Edge)",
+    "text": "Veuillez utiliser un navigateur récent prenant en charge WebAuthn (Chrome, Safari, Firefox ou Edge)",
     "source_hash": "fd9752eb"
   },
   "web.auth.webauthn.setupSuccess": {
@@ -203,7 +203,7 @@
     "source_hash": "290cca44"
   },
   "web.auth.webauthn.passwordRequired": {
-    "text": "Le mot de passe est requis pour configurer une clé d'accès",
+    "text": "Un mot de passe est requis pour configurer une clé d'accès",
     "source_hash": "085bb238"
   },
   "web.auth.webauthn.authFailed": {
@@ -215,11 +215,11 @@
     "source_hash": "57461b04"
   },
   "web.auth.webauthn.processing": {
-    "text": "Authentification en cours...",
+    "text": "Authentification...",
     "source_hash": "1f6087c2"
   },
   "web.auth.webauthn.description": {
-    "text": "Utilisez votre empreinte digitale, votre visage ou votre clé de sécurité pour vous connecter",
+    "text": "Utilisez votre empreinte, votre visage ou une clé de sécurité pour vous connecter",
     "source_hash": "f02f0427"
   },
   "web.auth.webauthn.supportedMethods": {
@@ -242,7 +242,7 @@
     "source_hash": "85630bef"
   },
   "web.auth.passkeys.not_configured": {
-    "text": "Non configurée",
+    "text": "Non configuré",
     "context": "Status when no passkeys are registered",
     "source_hash": "dd1841d2"
   },
@@ -267,7 +267,7 @@
     "source_hash": "67b1d47c"
   },
   "web.auth.passkeys.confirm_remove": {
-    "text": "Êtes-vous sûr de vouloir supprimer cette clé d'accès ? Vous ne pourrez plus vous connecter avec elle.",
+    "text": "Voulez-vous vraiment supprimer cette clé d'accès ? Vous ne pourrez plus l'utiliser pour vous connecter.",
     "context": "Confirmation message for passkey removal",
     "source_hash": "487ab72c"
   },
@@ -287,7 +287,7 @@
     "source_hash": "1d97fde4"
   },
   "web.auth.passkeys.no_passkeys_description": {
-    "text": "Ajoutez une clé d'accès pour vous connecter plus facilement sans saisir de mot de passe",
+    "text": "Ajoutez une clé d'accès pour vous connecter plus sûrement sans saisir de mot de passe",
     "context": "Description for empty state",
     "source_hash": "e5bc07f1"
   },
@@ -302,7 +302,7 @@
     "source_hash": "d70b9e24"
   },
   "web.auth.passkeys.last_used": {
-    "text": "Dernière utilisation : {time}",
+    "text": "Dernière utilisation : {time}",
     "context": "Last used timestamp",
     "source_hash": "e1af94fe"
   },
@@ -312,17 +312,17 @@
     "source_hash": "24d3236c"
   },
   "web.auth.passkeys.benefit_secure": {
-    "text": "Plus sécurisées que les mots de passe - résistantes aux attaques de phishing",
+    "text": "Plus sûres que les mots de passe - résistantes aux attaques par hameçonnage",
     "context": "Passkey benefit",
     "source_hash": "41afb6ec"
   },
   "web.auth.passkeys.benefit_fast": {
-    "text": "Rapide et facile - utilisez simplement votre empreinte digitale, votre visage ou une clé de sécurité",
+    "text": "Rapides et simples - utilisez votre empreinte, votre visage ou une clé de sécurité",
     "context": "Passkey benefit",
     "source_hash": "5a0ce96c"
   },
   "web.auth.passkeys.benefit_synced": {
-    "text": "Synchronisées sur tous vos appareils lors de l'utilisation d'authentificateurs de plateforme",
+    "text": "Synchronisées entre vos appareils lorsque vous utilisez les authentificateurs de plateforme",
     "context": "Passkey benefit",
     "source_hash": "7480c7ae"
   },
@@ -332,11 +332,11 @@
     "source_hash": "c87ccdb4"
   },
   "web.auth.lockout.attempts_remaining": {
-    "text": "Avertissement : {count} tentative(s) de connexion restante(s)",
+    "text": "Avertissement : {count} tentative(s) de connexion restante(s)",
     "source_hash": "151dcb5e"
   },
   "web.auth.lockout.account_locked": {
-    "text": "Compte verrouillé en raison de trop nombreuses tentatives de connexion échouées",
+    "text": "Compte verrouillé en raison d'un trop grand nombre de tentatives de connexion échouées",
     "source_hash": "5247f389"
   },
   "web.auth.lockout.locked_until": {
@@ -344,7 +344,7 @@
     "source_hash": "1a8f382e"
   },
   "web.auth.lockout.contact_support": {
-    "text": "Contactez le support si vous avez besoin d'un accès immédiat",
+    "text": "Contactez l'assistance si vous avez besoin d'un accès immédiat",
     "source_hash": "23d82e46"
   },
   "web.auth.lockout.try_password_reset": {
@@ -372,7 +372,7 @@
     "source_hash": "6ba0bdec"
   },
   "web.auth.sessions.location": {
-    "text": "Localisation",
+    "text": "Emplacement",
     "source_hash": "15b61974"
   },
   "web.auth.sessions.ip_address": {
@@ -384,7 +384,7 @@
     "source_hash": "b6dc1b95"
   },
   "web.auth.sessions.created": {
-    "text": "Créé",
+    "text": "Créée",
     "source_hash": "d70b9e24"
   },
   "web.auth.sessions.remove": {
@@ -396,11 +396,11 @@
     "source_hash": "412bb9e2"
   },
   "web.auth.sessions.confirm_remove": {
-    "text": "Êtes-vous sûr de vouloir supprimer cette session ?",
+    "text": "Voulez-vous vraiment supprimer cette session ?",
     "source_hash": "ef12c1ba"
   },
   "web.auth.sessions.confirm_remove_all": {
-    "text": "Cela vous déconnectera de tous les autres appareils. Êtes-vous sûr ?",
+    "text": "Cela vous déconnectera de tous les autres appareils. Voulez-vous continuer ?",
     "source_hash": "4a1a73e9"
   },
   "web.auth.sessions.no_sessions": {
@@ -448,11 +448,11 @@
     "source_hash": "d47240b9"
   },
   "web.auth.mfa.step_scan": {
-    "text": "1. Scanner le code QR",
+    "text": "1. Scannez le code QR",
     "source_hash": "efd0134a"
   },
   "web.auth.mfa.step_verify": {
-    "text": "2. Vérifier la configuration",
+    "text": "2. Vérifiez la configuration",
     "source_hash": "59bba5f7"
   },
   "web.auth.mfa.scan_qr": {
@@ -468,7 +468,7 @@
     "source_hash": "38f61733"
   },
   "web.auth.mfa.enter_code": {
-    "text": "Saisir le code d'authentification",
+    "text": "Saisissez le code d'authentification",
     "source_hash": "186a582a"
   },
   "web.auth.mfa.verify": {
@@ -480,11 +480,11 @@
     "source_hash": "eea2745e"
   },
   "web.auth.mfa.code_required": {
-    "text": "Le code d'authentification est requis",
+    "text": "Le code d'authentification est obligatoire",
     "source_hash": "217de0fc"
   },
   "web.auth.mfa.invalid_code": {
-    "text": "Code invalide. Les codes expirent toutes les 30 secondes. Essayez le dernier code de votre application d'authentification.",
+    "text": "Code non valide. Les codes expirent toutes les 30 secondes. Essayez le dernier code de votre application d'authentification.",
     "source_hash": "94b58889"
   },
   "web.auth.mfa.success_enabled": {
@@ -508,7 +508,7 @@
     "source_hash": "09a96c07"
   },
   "web.auth.mfa.last_used": {
-    "text": "Dernière utilisation : {time}",
+    "text": "Dernière utilisation : {time}",
     "source_hash": "e1af94fe"
   },
   "web.auth.mfa.never_used": {
@@ -528,7 +528,7 @@
     "source_hash": "6fa090b4"
   },
   "web.auth.mfa.cancel": {
-    "text": "Annuler et retourner à la connexion",
+    "text": "Annuler et revenir à la connexion",
     "source_hash": "83256742"
   },
   "web.auth.mfa.cancel_sign_in": {
@@ -536,7 +536,7 @@
     "source_hash": "1bebad2f"
   },
   "web.auth.mfa.loading_status": {
-    "text": "Chargement du statut MFA...",
+    "text": "Chargement de l'état MFA...",
     "source_hash": "01919f0e"
   },
   "web.auth.mfa.protected_description": {
@@ -552,7 +552,7 @@
     "source_hash": "61d99c71"
   },
   "web.auth.mfa.benefit_apps": {
-    "text": "Fonctionne avec Google Authenticator, Authy et d'autres applications TOTP",
+    "text": "Compatible avec Google Authenticator, Authy et les autres applications TOTP",
     "source_hash": "6ee8ab12"
   },
   "web.auth.mfa.benefit_recovery": {
@@ -580,7 +580,7 @@
     "source_hash": "a8eaef9d"
   },
   "web.auth.mfa.continue_verification": {
-    "text": "Continuer vers la vérification",
+    "text": "Passer à la vérification",
     "source_hash": "4da96e87"
   },
   "web.auth.mfa.enter_code_description": {
@@ -636,7 +636,7 @@
     "source_hash": "579c7f4e"
   },
   "web.auth.recovery_codes.description": {
-    "text": "Conservez ces codes dans un endroit sûr. Chacun peut être utilisé une fois si vous perdez l'accès à votre authentificateur.",
+    "text": "Conservez ces codes en lieu sûr. Chacun peut être utilisé une fois si vous perdez l'accès à votre application d'authentification.",
     "source_hash": "87aebdfb"
   },
   "web.auth.recovery_codes.warning": {
@@ -692,11 +692,11 @@
     "source_hash": "231aedff"
   },
   "web.auth.recovery_codes.remaining": {
-    "text": "{count} sur {limit} codes de récupération restants",
+    "text": "{count} codes de récupération restants sur {limit}",
     "source_hash": "b5d484e7"
   },
   "web.auth.recovery_codes.usage_hint": {
-    "text": "Chaque code ne peut être utilisé qu'une seule fois. Régénérez les codes si vous en manquez.",
+    "text": "Chaque code ne peut être utilisé qu'une seule fois. Régénérez les codes s'il vous en reste peu.",
     "source_hash": "737a7702"
   },
   "web.auth.recovery_codes.none_remaining": {
@@ -730,5 +730,201 @@
   "web.auth.sessions.session_plural": {
     "text": "sessions",
     "source_hash": "1225ae6c"
+  },
+  "web.auth.connections.title": {
+    "text": "Identités connectées",
+    "source_hash": "e132c4d9"
+  },
+  "web.auth.connections.description": {
+    "text": "Gérez les fournisseurs d'authentification unique liés à votre compte.",
+    "source_hash": "42c6d148"
+  },
+  "web.auth.connections.section_title": {
+    "text": "Authentification unique",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.section_subtitle": {
+    "text": "Fournisseurs d'identité que vous pouvez utiliser pour vous connecter à ce compte",
+    "source_hash": "507254cd"
+  },
+  "web.auth.connections.connect_title": {
+    "text": "Connecter un fournisseur",
+    "source_hash": "a002b3f3"
+  },
+  "web.auth.connections.connect_description": {
+    "text": "Liez un autre fournisseur d'authentification unique que vous pourrez utiliser pour vous connecter à ce compte.",
+    "source_hash": "32895a5a"
+  },
+  "web.auth.connections.connect_action": {
+    "text": "Connecter {provider}",
+    "source_hash": "c77540af"
+  },
+  "web.auth.connections.issuer": {
+    "text": "Émetteur",
+    "source_hash": "39e02c46"
+  },
+  "web.auth.connections.identifier": {
+    "text": "Identifiant",
+    "source_hash": "9b10587f"
+  },
+  "web.auth.connections.remove": {
+    "text": "Supprimer",
+    "source_hash": "c3812fc4"
+  },
+  "web.auth.connections.remove_confirm_title": {
+    "text": "Supprimer l'identité connectée",
+    "source_hash": "4e8ffe4c"
+  },
+  "web.auth.connections.remove_confirm_message": {
+    "text": "Voulez-vous vraiment supprimer cette identité connectée ? Vous ne pourrez plus vous en servir pour vous connecter.",
+    "source_hash": "64939c89"
+  },
+  "web.auth.connections.removed_success": {
+    "text": "Identité connectée supprimée",
+    "source_hash": "cf87daf3"
+  },
+  "web.auth.connections.no_identities": {
+    "text": "Aucune identité connectée",
+    "source_hash": "5254048e"
+  },
+  "web.auth.connections.no_identities_description": {
+    "text": "Vous n'avez encore lié aucun fournisseur d'authentification unique à ce compte.",
+    "source_hash": "0f58d5d0"
+  },
+  "web.auth.connections.overview_status": {
+    "text": "Authentification unique",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.errors.last_credential": {
+    "text": "C'est votre seul moyen de vous connecter. Connectez d'abord un autre fournisseur, ou définissez un mot de passe dans Paramètres → Sécurité, afin de ne pas perdre l'accès.",
+    "source_hash": "3de8084d"
+  },
+  "web.auth.connections.errors.last_credential_sso_enforced": {
+    "text": "C'est votre seul moyen de vous connecter. Connectez d'abord un autre fournisseur afin de ne pas perdre l'accès.",
+    "source_hash": "eed7a50e"
+  },
+  "web.auth.connections.errors.not_found": {
+    "text": "Cette identité connectée est introuvable. Elle a peut-être déjà été supprimée.",
+    "source_hash": "cf2c7673"
+  },
+  "web.auth.connections.errors.unauthorized": {
+    "text": "Votre session a expiré. Veuillez vous reconnecter.",
+    "source_hash": "b529fce2"
+  },
+  "web.auth.connections.errors.generic": {
+    "text": "Nous n'avons pas pu effectuer cette action. Veuillez réessayer.",
+    "source_hash": "a0d4edc0"
+  },
+  "web.link_sso.title": {
+    "text": "Liez votre méthode de connexion",
+    "source_hash": "46339bac"
+  },
+  "web.link_sso.prompt": {
+    "text": "Vous vous êtes connecté avec {provider}, qui correspond au compte existant {email}. Saisissez le mot de passe de ce compte pour lier {provider} et continuer.",
+    "source_hash": "59da1c08"
+  },
+  "web.link_sso.password_label": {
+    "text": "Mot de passe",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.link_sso.password_placeholder": {
+    "text": "Votre mot de passe existant",
+    "source_hash": "ad4e56da"
+  },
+  "web.link_sso.submit": {
+    "text": "Lier et continuer",
+    "source_hash": "c969b759"
+  },
+  "web.link_sso.cancel": {
+    "text": "Annuler",
+    "source_hash": "19766ed6"
+  },
+  "web.link_sso.unavailable_title": {
+    "text": "Cette demande de liaison a expiré",
+    "source_hash": "b53c7e55"
+  },
+  "web.link_sso.unavailable_message": {
+    "text": "Pour votre sécurité, la demande de liaison de cette méthode de connexion n'est plus valide. Connectez-vous avec votre mot de passe existant, puis connectez ce fournisseur dans Paramètres de sécurité → Identités connectées.",
+    "source_hash": "f7e349d1"
+  },
+  "web.link_sso.unavailable_action": {
+    "text": "Passer à la connexion",
+    "source_hash": "d398cd0a"
+  },
+  "web.link_sso.errors.invalid_password": {
+    "text": "Ce mot de passe ne correspond pas à ce compte. Veuillez réessayer.",
+    "source_hash": "3259b4f5"
+  },
+  "web.link_sso.errors.invalid_token": {
+    "text": "Cette demande de liaison a expiré ou a déjà été utilisée. Connectez-vous avec votre mot de passe existant, puis connectez ce fournisseur depuis les paramètres de votre compte.",
+    "source_hash": "541f9127"
+  },
+  "web.link_sso.errors.link_conflict": {
+    "text": "Nous n'avons pas pu lier cette méthode de connexion. Votre compte a peut-être changé, ou ce fournisseur est déjà lié à un autre compte. Connectez-vous avec votre mot de passe existant, puis gérez les connexions dans Paramètres de sécurité → Identités connectées.",
+    "source_hash": "7b0e0d0e"
+  },
+  "web.link_sso.errors.link_rate_limited": {
+    "text": "Trop de tentatives de mot de passe. Veuillez patienter quelques minutes, puis réessayer.",
+    "source_hash": "a95e78cd"
+  },
+  "web.link_sso.errors.invalid_request": {
+    "text": "Nous n'avons pas pu traiter cette demande de liaison. Veuillez vous reconnecter avec votre fournisseur SSO.",
+    "source_hash": "053b9fc6"
+  },
+  "web.link_sso.errors.generic": {
+    "text": "Nous n'avons pas pu lier votre compte. Veuillez réessayer.",
+    "source_hash": "f727c174"
+  },
+  "web.sso_link_confirm.title": {
+    "text": "Confirmez la connexion de votre compte",
+    "source_hash": "ad80bfe7"
+  },
+  "web.sso_link_confirm.prompt": {
+    "text": "Vous vous êtes connecté avec {provider}, qui correspond à votre compte {email}. Confirmez pour connecter {provider} à ce compte et finaliser la connexion.",
+    "source_hash": "6ff0d6cc"
+  },
+  "web.sso_link_confirm.submit": {
+    "text": "Confirmer et connecter",
+    "source_hash": "5cf663e6"
+  },
+  "web.sso_link_confirm.cancel": {
+    "text": "Annuler",
+    "source_hash": "19766ed6"
+  },
+  "web.sso_link_confirm.unavailable_title": {
+    "text": "Cette demande de liaison ne peut pas être finalisée",
+    "source_hash": "47abb784"
+  },
+  "web.sso_link_confirm.unavailable_message": {
+    "text": "Pour votre sécurité, cette demande de connexion de votre méthode d'authentification n'est plus valide. Reconnectez-vous avec votre fournisseur et nous vous enverrons un nouveau lien par e-mail.",
+    "source_hash": "080e6f9f"
+  },
+  "web.sso_link_confirm.unavailable_action": {
+    "text": "Revenir à la connexion",
+    "source_hash": "8504054f"
+  },
+  "web.sso_link_confirm.errors.link_expired": {
+    "text": "Cette demande de liaison a expiré ou a déjà été utilisée. Reconnectez-vous avec votre fournisseur et nous vous enverrons un nouveau lien par e-mail.",
+    "source_hash": "a50538df"
+  },
+  "web.sso_link_confirm.errors.link_conflict": {
+    "text": "Nous n'avons pas pu connecter cette méthode de connexion. Votre compte a peut-être changé, ou ce fournisseur est déjà lié à un autre compte. Reconnectez-vous avec votre fournisseur pour continuer.",
+    "source_hash": "c954854b"
+  },
+  "web.sso_link_confirm.errors.link_invalidated": {
+    "text": "Les identifiants de votre compte ont changé après l'envoi de ce lien ; il n'est donc plus valide. Reconnectez-vous avec votre fournisseur et nous vous enverrons un nouveau lien par e-mail.",
+    "source_hash": "db88cb1d"
+  },
+  "web.sso_link_confirm.errors.link_error": {
+    "text": "Un problème est survenu de notre côté et nous n'avons pas pu vérifier ce lien. Reconnectez-vous avec votre fournisseur et nous vous en enverrons un nouveau par e-mail.",
+    "source_hash": "ec24e0a1"
+  },
+  "web.sso_link_confirm.errors.confirm_rate_limited": {
+    "text": "Trop de tentatives depuis votre appareil. Veuillez patienter quelques minutes, puis rouvrez le lien reçu par e-mail ou reconnectez-vous avec votre fournisseur pour en obtenir un nouveau.",
+    "source_hash": "f29af782"
+  },
+  "web.sso_link_confirm.errors.generic": {
+    "text": "Nous n'avons pas pu confirmer cette connexion. Veuillez vous reconnecter avec votre fournisseur.",
+    "source_hash": "076fa25a"
   }
 }

--- a/locales/content/fr_FR/session-auth-extended.json
+++ b/locales/content/fr_FR/session-auth-extended.json
@@ -757,6 +757,7 @@
   },
   "web.auth.connections.connect_action": {
     "text": "Connecter {provider}",
+    "context": "Button label to start linking a specific SSO provider; {provider} is the provider display name",
     "source_hash": "c77540af"
   },
   "web.auth.connections.issuer": {
@@ -821,6 +822,7 @@
   },
   "web.link_sso.prompt": {
     "text": "Vous vous êtes connecté avec {provider}, qui correspond au compte existant {email}. Saisissez le mot de passe de ce compte pour lier {provider} et continuer.",
+    "context": "Instruction on the sign-in interstitial. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/link-sso/:token.",
     "source_hash": "59da1c08"
   },
   "web.link_sso.password_label": {
@@ -881,6 +883,7 @@
   },
   "web.sso_link_confirm.prompt": {
     "text": "Vous vous êtes connecté avec {provider}, qui correspond à votre compte {email}. Confirmez pour connecter {provider} à ce compte et finaliser la connexion.",
+    "context": "Consent instruction on the #3840 Phase 4 mailbox-proof SSO linking page. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/sso-link-confirm/:token. No password is asked — clicking the emailed link is the proof.",
     "source_hash": "6ff0d6cc"
   },
   "web.sso_link_confirm.submit": {

--- a/locales/content/fr_FR/session-auth.json
+++ b/locales/content/fr_FR/session-auth.json
@@ -1,6 +1,6 @@
 {
   "web.login.alternate_prefix": {
-    "text": "Besoin d'un compte ?",
+    "text": "Vous avez besoin d'un compte ?",
     "source_hash": "8b827e19"
   },
   "web.login.need_an_account": {
@@ -8,7 +8,7 @@
     "source_hash": "10647723"
   },
   "web.login.forgot_your_password": {
-    "text": "Mot de passe oublié ?",
+    "text": "Vous avez oublié votre mot de passe ?",
     "source_hash": "afd25fdf"
   },
   "web.login.button_sign_in": {
@@ -28,7 +28,7 @@
     "source_hash": "b1402b67"
   },
   "web.login.secure_link_helper": {
-    "text": "Un lien sécurisé sera envoyé à votre boîte de réception.",
+    "text": "Un lien sécurisé sera envoyé dans votre boîte de réception.",
     "source_hash": "d31d20cf"
   },
   "web.login.or_divider": {
@@ -64,7 +64,7 @@
     "source_hash": "904c9aa9"
   },
   "web.login.need_help": {
-    "text": "Besoin d'aide ?",
+    "text": "Besoin d'aide ?",
     "source_hash": "c225cdfb"
   },
   "web.login.or_continue_with": {
@@ -72,7 +72,7 @@
     "source_hash": "eb4e8d3b"
   },
   "web.login.sign_in_with_sso": {
-    "text": "Se connecter avec SSO",
+    "text": "Se connecter avec le SSO",
     "source_hash": "73e984e9"
   },
   "web.login.sign_in_with_provider": {
@@ -88,7 +88,7 @@
     "source_hash": "45a1e65d"
   },
   "web.login.errors.sso_failed": {
-    "text": "L'authentification SSO a échoué. Veuillez réessayer ou utiliser la connexion par mot de passe.",
+    "text": "Échec de l'authentification SSO. Veuillez réessayer ou utiliser la connexion par mot de passe.",
     "source_hash": "13a2210a"
   },
   "web.login.errors.token_missing": {
@@ -100,15 +100,15 @@
     "source_hash": "f0de42ec"
   },
   "web.login.errors.token_invalid": {
-    "text": "Ce lien de connexion est invalide. Veuillez en demander un nouveau.",
+    "text": "Ce lien de connexion n'est pas valide. Veuillez en demander un nouveau.",
     "source_hash": "270c6401"
   },
   "web.signup.create_your_account": {
-    "text": "Créer votre compte",
+    "text": "Créez votre compte",
     "source_hash": "5f4c33d7"
   },
   "web.signup.alternate_prefix": {
-    "text": "Vous avez déjà un compte ?",
+    "text": "Vous avez déjà un compte ?",
     "source_hash": "f5dcb5d5"
   },
   "web.signup.have_an_account": {
@@ -116,7 +116,7 @@
     "source_hash": "6c52846f"
   },
   "web.signup.error_title": {
-    "text": "Erreur de création de compte",
+    "text": "Erreur lors de la création du compte",
     "source_hash": "e380a0b6"
   },
   "web.signup.password_error": {
@@ -131,7 +131,7 @@
     "context": "Email verification flow after signup"
   },
   "web.auth.verify.title": {
-    "text": "Vérifier votre compte",
+    "text": "Vérifiez votre compte",
     "source_hash": "3e2303ab"
   },
   "web.auth.verify.success": {
@@ -139,7 +139,7 @@
     "source_hash": "902d0f47"
   },
   "web.auth.verify.invalid_key": {
-    "text": "Clé de vérification invalide ou expirée",
+    "text": "Clé de vérification non valide ou expirée",
     "source_hash": "70fe7dfe"
   },
   "web.auth.verify.expired_key": {
@@ -147,15 +147,15 @@
     "source_hash": "ee3ed5d2"
   },
   "web.auth.verify.already_verified": {
-    "text": "Ce compte a déjà été vérifié. Vous pouvez maintenant vous connecter.",
+    "text": "Ce compte a déjà été vérifié. Vous pouvez vous connecter dès maintenant.",
     "source_hash": "cec1312b"
   },
   "web.auth.verify.unable_to_verify": {
-    "text": "Impossible de vérifier le compte. Veuillez réessayer ou contacter le support.",
+    "text": "Impossible de vérifier le compte. Veuillez réessayer ou contacter l'assistance.",
     "source_hash": "c0df463f"
   },
   "web.auth.verify.check_email": {
-    "text": "Veuillez vérifier vos e-mails pour trouver un lien de vérification",
+    "text": "Veuillez consulter votre messagerie pour y trouver un lien de vérification",
     "source_hash": "79ffefd8"
   },
   "web.auth.verify.error": {
@@ -167,19 +167,19 @@
     "source_hash": "cb3a722b"
   },
   "web.auth.verify.what_to_do": {
-    "text": "Que dois-je faire ?",
+    "text": "Que dois-je faire ?",
     "source_hash": "00eeea79"
   },
   "web.auth.verify.check_email_help": {
-    "text": "Vérifiez vos e-mails pour trouver le lien de vérification le plus récent",
+    "text": "Cherchez dans votre messagerie le lien de vérification le plus récent",
     "source_hash": "1c4a5748"
   },
   "web.auth.verify.check_spam": {
-    "text": "Vérifiez votre dossier spam/indésirables si vous ne trouvez pas l'e-mail",
+    "text": "Vérifiez votre dossier de courrier indésirable si vous ne trouvez pas l'e-mail",
     "source_hash": "ae481e5e"
   },
   "web.auth.verify.contact_support": {
-    "text": "Contactez le support si vous continuez à rencontrer des problèmes",
+    "text": "Contactez l'assistance si le problème persiste",
     "source_hash": "c0067275"
   },
   "web.auth.verify.missing_key_title": {
@@ -243,7 +243,7 @@
     "source_hash": "19766ed6"
   },
   "web.auth.password_reset_request.title": {
-    "text": "Demander une réinitialisation de mot de passe",
+    "text": "Demander la réinitialisation du mot de passe",
     "source_hash": "456d421c"
   },
   "web.auth.password_reset_request.description": {
@@ -255,16 +255,16 @@
     "source_hash": "7d5f16d4"
   },
   "web.auth.password_reset.title": {
-    "text": "Choisir un nouveau mot de passe",
+    "text": "Choisissez un nouveau mot de passe",
     "context": "Password reset request flow - user requests a reset link",
     "source_hash": "3dfdf7c4"
   },
   "web.auth.password_reset.description": {
-    "text": "Veuillez saisir votre nouveau mot de passe ci-dessous. Assurez-vous qu'il est robuste et unique pour protéger votre compte.",
+    "text": "Veuillez saisir votre nouveau mot de passe ci-dessous. Assurez-vous qu'il est robuste et unique afin de protéger votre compte.",
     "source_hash": "5c789083"
   },
   "web.auth.passwordReset.emailSent": {
-    "text": "Un e-mail vous a été envoyé avec un lien pour réinitialiser le mot de passe de votre compte",
+    "text": "Un e-mail contenant un lien de réinitialisation du mot de passe de votre compte vous a été envoyé",
     "source_hash": "63a6af45"
   },
   "web.auth.terms.agree_prefix": {
@@ -281,11 +281,11 @@
     "source_hash": "09bf25ef"
   },
   "web.auth.account.created": {
-    "text": "Compte créé",
+    "text": "Compte créé le",
     "source_hash": "9966be40"
   },
   "web.auth.account.verified": {
-    "text": "E-mail vérifié",
+    "text": "Adresse e-mail vérifiée",
     "source_hash": "bc512ab0"
   },
   "web.auth.account.region": {
@@ -293,7 +293,7 @@
     "source_hash": "d3a008ef"
   },
   "web.auth.account.not_verified": {
-    "text": "E-mail non vérifié",
+    "text": "Adresse e-mail non vérifiée",
     "source_hash": "53955e0e"
   },
   "web.auth.account.verify_email": {
@@ -341,51 +341,51 @@
     "source_hash": "e1513814"
   },
   "web.help.title": {
-    "text": "Aide et support",
+    "text": "Aide et assistance",
     "source_hash": "1f8ecc24"
   },
   "web.help.signin_troubleshooting": {
-    "text": "Dépannage de connexion",
+    "text": "Résolution des problèmes de connexion",
     "source_hash": "a9a88a01"
   },
   "web.help.magic_link_not_arriving": {
-    "text": "Le lien magique n'arrive pas ?",
+    "text": "Le lien magique n'arrive pas ?",
     "source_hash": "6919ce70"
   },
   "web.help.check_spam_folder": {
-    "text": "Vérifiez votre dossier spam ou indésirables",
+    "text": "Vérifiez votre dossier de courrier indésirable",
     "source_hash": "813fe2d8"
   },
   "web.help.check_email_spelling": {
-    "text": "Vérifiez que vous avez saisi correctement votre adresse e-mail",
+    "text": "Vérifiez que vous avez correctement saisi votre adresse e-mail",
     "source_hash": "5f319557"
   },
   "web.help.wait_few_minutes": {
-    "text": "Attendez quelques minutes - les e-mails peuvent parfois être retardés",
+    "text": "Patientez quelques minutes - les e-mails peuvent parfois être retardés",
     "source_hash": "884fc272"
   },
   "web.help.try_again": {
-    "text": "Essayez de demander un nouveau lien si cela fait plus de 10 minutes",
+    "text": "Essayez de demander un nouveau lien si plus de 10 minutes se sont écoulées",
     "source_hash": "68109f96"
   },
   "web.help.forgot_password": {
-    "text": "Mot de passe oublié ?",
+    "text": "Vous avez oublié votre mot de passe ?",
     "source_hash": "afd25fdf"
   },
   "web.help.use_magic_link_instead": {
-    "text": "Vous pouvez demander un lien de réinitialisation du mot de passe pour créer un nouveau mot de passe.",
+    "text": "Vous pouvez demander un lien de réinitialisation pour créer un nouveau mot de passe.",
     "source_hash": "3c3eabad"
   },
   "web.help.account_locked": {
-    "text": "Compte temporairement verrouillé ?",
+    "text": "Compte temporairement verrouillé ?",
     "source_hash": "ef1251c1"
   },
   "web.help.account_locked_explanation": {
-    "text": "Après plusieurs tentatives de connexion échouées, les comptes sont temporairement verrouillés pour des raisons de sécurité. Attendez 15 minutes et réessayez, ou utilisez le Lien magique pour vous connecter.",
+    "text": "Après plusieurs tentatives de connexion échouées, les comptes sont temporairement verrouillés par sécurité. Patientez 15 minutes et réessayez, ou utilisez le lien magique pour vous connecter.",
     "source_hash": "4b2cf891"
   },
   "web.help.still_need_help": {
-    "text": "Vous avez encore besoin d'aide ?",
+    "text": "Vous avez encore besoin d'aide ?",
     "source_hash": "5ff7d19e"
   },
   "web.help.contact_us_description": {
@@ -393,7 +393,7 @@
     "source_hash": "d97c90fe"
   },
   "web.help.contact_support": {
-    "text": "Contacter le support",
+    "text": "Contacter l'assistance",
     "source_hash": "f8d47b82"
   },
   "web.auth.account.sso_linked": {
@@ -409,7 +409,7 @@
     "source_hash": "af87d51e"
   },
   "web.login.custom_domain_sso_description": {
-    "text": "L'administrateur de l'organisation peut activer le SSO pour permettre aux membres de l'équipe de se connecter ici. Contactez l'administrateur pour obtenir l'accès.",
+    "text": "L'administrateur de l'organisation peut activer le SSO pour permettre aux membres de l'équipe de se connecter ici. Contactez l'administrateur pour obtenir un accès.",
     "source_hash": "f3726509"
   },
   "web.login.signin_disabled_heading": {
@@ -425,15 +425,15 @@
     "source_hash": "b39ef93e"
   },
   "web.login.errors.invalid_email": {
-    "text": "L'adresse e-mail provenant de votre fournisseur d'identité est invalide. Veuillez contacter votre administrateur.",
+    "text": "L'adresse e-mail fournie par votre fournisseur d'identité n'est pas valide. Veuillez contacter votre administrateur.",
     "source_hash": "10c12029"
   },
   "web.login.errors.domain_not_allowed": {
-    "text": "Votre domaine de messagerie n'est pas autorisé pour l'inscription via SSO. Veuillez contacter votre administrateur.",
+    "text": "Le domaine de votre adresse e-mail n'est pas autorisé pour l'inscription via SSO. Veuillez contacter votre administrateur.",
     "source_hash": "87603782"
   },
   "web.auth.check_email.title": {
-    "text": "Vérifiez votre e-mail",
+    "text": "Consultez votre messagerie",
     "source_hash": "77322879"
   },
   "web.auth.check_email.sent_to_generic": {
@@ -445,7 +445,7 @@
     "source_hash": "8babedc4"
   },
   "web.auth.check_email.spam_hint": {
-    "text": "Vous ne le trouvez pas ? Vérifiez votre dossier de spam.",
+    "text": "Vous ne le trouvez pas ? Vérifiez votre dossier de courrier indésirable.",
     "source_hash": "d166d9a4"
   },
   "web.auth.check_email.wrong_email": {
@@ -461,7 +461,7 @@
     "source_hash": "e7cf3ef4"
   },
   "web.auth.verify.resend_help_text": {
-    "text": "Vous n'avez pas reçu l'e-mail de vérification ? Saisissez votre e-mail pour le renvoyer.",
+    "text": "Vous n'avez pas reçu l'e-mail de vérification ? Saisissez votre adresse e-mail pour le renvoyer.",
     "source_hash": "e0df48bb"
   },
   "web.auth.verify.resend_button": {
@@ -469,7 +469,7 @@
     "source_hash": "5173cc04"
   },
   "web.auth.verify.resend_sent": {
-    "text": "Si un compte nécessite une vérification, un nouvel e-mail a été envoyé. Veuillez vérifier votre boîte de réception et votre dossier de spam.",
+    "text": "Si un compte nécessite une vérification, un nouvel e-mail a été envoyé. Veuillez consulter votre boîte de réception et votre dossier de courrier indésirable.",
     "source_hash": "6f838ffb"
   },
   "web.auth.verify.resend_error": {
@@ -481,7 +481,43 @@
     "source_hash": "4f44603e"
   },
   "web.login.verified_notice": {
-    "text": "Votre e-mail a été vérifié — vous pouvez maintenant vous connecter.",
+    "text": "Votre adresse e-mail a été vérifiée — vous pouvez maintenant vous connecter.",
     "source_hash": "c8d4b5a8"
+  },
+  "web.auth.password_setup_request.title": {
+    "text": "Définir un mot de passe",
+    "source_hash": "11b6978b"
+  },
+  "web.auth.password_setup_request.description": {
+    "text": "Votre compte n'a pas encore de mot de passe. Nous vous enverrons par e-mail un lien sécurisé pour en définir un afin que vous puissiez aussi vous connecter directement.",
+    "source_hash": "dc0b561f"
+  },
+  "web.auth.password_setup_request.button": {
+    "text": "Envoyer le lien de configuration",
+    "source_hash": "22807292"
+  },
+  "web.auth.password_setup_request.emailSent": {
+    "text": "Un e-mail contenant un lien permettant de définir un mot de passe pour votre compte vous a été envoyé",
+    "source_hash": "82b686c7"
+  },
+  "web.login.errors.account_exists_link_required": {
+    "text": "Un compte associé à cette adresse e-mail existe déjà, mais il n'est pas lié à cette méthode de connexion. Connectez-vous avec votre méthode existante, puis liez ce fournisseur dans Paramètres de sécurité → Identités connectées.",
+    "source_hash": "7fbbb7e7"
+  },
+  "web.login.errors.identity_connect_conflict": {
+    "text": "Cette identité n'a pas pu être connectée. La connexion a peut-être été lancée sur le mauvais domaine, ou votre session a expiré. Veuillez vous reconnecter, puis la connecter depuis les paramètres de votre compte.",
+    "source_hash": "4238bbf2"
+  },
+  "web.login.errors.org_join_failed": {
+    "text": "Nous n'avons pas pu terminer votre ajout à votre organisation. Veuillez contacter votre administrateur.",
+    "source_hash": "155e71bb"
+  },
+  "web.login.errors.link_sso_failed": {
+    "text": "Nous n'avons pas pu lier cette méthode de connexion. Connectez-vous avec votre mot de passe existant, puis connectez ce fournisseur dans Paramètres de sécurité → Identités connectées.",
+    "source_hash": "49954127"
+  },
+  "web.login.notices.link_verification_sent": {
+    "text": "Consultez votre boîte de réception — nous vous avons envoyé par e-mail un lien pour confirmer la connexion de votre compte. Ouvrez-le pour finaliser la connexion.",
+    "source_hash": "b251c8f3"
   }
 }

--- a/locales/content/fr_FR/workspace-account.json
+++ b/locales/content/fr_FR/workspace-account.json
@@ -28,11 +28,11 @@
     "source_hash": "8258db6d"
   },
   "web.account.customer_since": {
-    "text": "Client depuis :",
+    "text": "Client depuis :",
     "source_hash": "0b37cff3"
   },
   "web.account.email": {
-    "text": "E-mail :",
+    "text": "E-mail :",
     "source_hash": "17507dcf"
   },
   "web.account.region": {
@@ -40,7 +40,7 @@
     "source_hash": "d3a008ef"
   },
   "web.account.account_balance": {
-    "text": "Solde :",
+    "text": "Solde :",
     "source_hash": "e0351221"
   },
   "web.account.default_payment_method": {
@@ -56,11 +56,11 @@
     "source_hash": "a151f2e9"
   },
   "web.account.quantity": {
-    "text": "Quantité :",
+    "text": "Quantité :",
     "source_hash": "d4b2cb96"
   },
   "web.account.next_billing_date": {
-    "text": "Prochaine date de facturation :",
+    "text": "Prochaine date de facturation :",
     "source_hash": "8e6f9cfe"
   },
   "web.account.changePassword.username": {
@@ -96,11 +96,11 @@
     "source_hash": "62566c64"
   },
   "web.account.account_id_customerid": {
-    "text": "ID de compte",
+    "text": "ID du compte",
     "source_hash": "919bb4cb"
   },
   "web.account.created_windowprops_cust_secrets_created_secrets": {
-    "text": "Créé {0} secrets depuis {1}.",
+    "text": "{0} secrets créés depuis {1}.",
     "source_hash": "8cb99810"
   },
   "web.account.delete_account": {
@@ -108,11 +108,11 @@
     "source_hash": "c031bf99"
   },
   "web.account.api_key": {
-    "text": "Clé API",
+    "text": "Clé d'API",
     "source_hash": "23189d55"
   },
   "web.account.account_type_windowprops_plan_options_name": {
-    "text": "Type de compte : {0}",
+    "text": "Type de compte : {0}",
     "source_hash": "617bfe67"
   },
   "web.account.your_account": {
@@ -120,7 +120,7 @@
     "source_hash": "89e60bfb"
   },
   "web.account.support_details": {
-    "text": "Détails du support",
+    "text": "Détails d'assistance",
     "source_hash": "cbad8751"
   },
   "web.account.back_to_details": {
@@ -128,7 +128,7 @@
     "source_hash": "f6f841b9"
   },
   "web.account.customer_id_cust_custid": {
-    "text": "ID client : {0}",
+    "text": "ID client : {0}",
     "source_hash": "7e2d4201"
   },
   "web.account.token_generated": {
@@ -136,7 +136,7 @@
     "source_hash": "05986d95"
   },
   "web.account.keep_this_token_secure_it_provides_full_access_t": {
-    "text": "Conservez ce jeton en lieu sûr. Il peut être utilisé pour créer et gérer des secrets via l'API.",
+    "text": "Conservez ce jeton en lieu sûr. Il permet de créer et de gérer des secrets via l'API.",
     "source_hash": "a63cc8ec"
   },
   "web.account.confirm_with_your_password": {
@@ -144,7 +144,7 @@
     "source_hash": "ff2147fd"
   },
   "web.account.are_you_sure_you_want_to_permanently_delete_your": {
-    "text": "Êtes-vous sûr de vouloir supprimer définitivement votre compte ? Cette action ne peut être annulée.",
+    "text": "Voulez-vous vraiment supprimer définitivement votre compte ? Cette action est irréversible.",
     "source_hash": "4fa3e4b8"
   },
   "web.account.confirm_account_deletion": {
@@ -176,15 +176,15 @@
     "source_hash": "f89a5794"
   },
   "web.account.any_secrets_you_wish_to_remove": {
-    "text": "Tous les secrets que vous souhaitez supprimer,",
+    "text": "Les secrets que vous souhaitez supprimer,",
     "source_hash": "b45e2dd5"
   },
   "web.account.secrets_will_remain_active_until_they_expire": {
-    "text": "Les secrets restent accessibles jusqu'à expiration.",
+    "text": "Les secrets resteront actifs jusqu'à leur expiration.",
     "source_hash": "ddb4e2b5"
   },
   "web.account.please_be_advised": {
-    "text": "Veuillez noter :",
+    "text": "Veuillez noter :",
     "source_hash": "086020fd"
   },
   "web.account.account_deleted_successfully": {
@@ -196,7 +196,7 @@
     "source_hash": "fb1e6fa5"
   },
   "web.account.are_you_sure_you_want_to_deactivate_your_account": {
-    "text": "Êtes-vous sûr de vouloir désactiver votre compte ? Toutes vos données seront définitivement supprimées de nos serveurs. Cette action ne peut être annulée.",
+    "text": "Voulez-vous vraiment désactiver votre compte ? Toutes vos données seront définitivement supprimées de nos serveurs. Cette action est irréversible.",
     "source_hash": "4940e20a"
   },
   "web.account.deactivate_account": {
@@ -212,7 +212,7 @@
     "source_hash": "2ff0853c"
   },
   "web.settings.manage_your_account_settings_and_preferences": {
-    "text": "Gérer les paramètres et préférences de votre compte",
+    "text": "Gérez les paramètres et préférences de votre compte",
     "source_hash": "2ff0853c"
   },
   "web.settings.back_to_dashboard": {
@@ -248,11 +248,11 @@
     "source_hash": "efb52e71"
   },
   "web.settings.theme.description": {
-    "text": "Choisir le thème clair ou sombre",
+    "text": "Choisissez le thème clair ou sombre",
     "source_hash": "ff0ae84f"
   },
   "web.settings.theme.choose_light_or_dark_theme": {
-    "text": "Choisir le thème clair ou sombre",
+    "text": "Choisissez le thème clair ou sombre",
     "source_hash": "ff0ae84f"
   },
   "web.settings.language.title": {
@@ -280,11 +280,11 @@
     "source_hash": "d696a35b"
   },
   "web.settings.profile.change_email": {
-    "text": "Modifier l'e-mail",
+    "text": "Modifier l'adresse e-mail",
     "source_hash": "18c3f2d5"
   },
   "web.settings.profile.current_email": {
-    "text": "E-mail actuel",
+    "text": "Adresse e-mail actuelle",
     "source_hash": "5f1cab64"
   },
   "web.settings.profile.current_password": {
@@ -292,7 +292,7 @@
     "source_hash": "8ac76099"
   },
   "web.settings.profile.new_email": {
-    "text": "Nouvel e-mail",
+    "text": "Nouvelle adresse e-mail",
     "source_hash": "5bafb4be"
   },
   "web.settings.profile.enter_password_to_confirm": {
@@ -308,7 +308,7 @@
     "source_hash": "575082a1"
   },
   "web.settings.profile.update_email": {
-    "text": "Mettre à jour l'e-mail",
+    "text": "Mettre à jour l'adresse e-mail",
     "source_hash": "6ec61b2e"
   },
   "web.settings.profile.change_email_description": {
@@ -324,15 +324,15 @@
     "source_hash": "b00f7e3a"
   },
   "web.settings.profile.email_same_as_current": {
-    "text": "Le nouvel e-mail doit être différent de l'e-mail actuel",
+    "text": "La nouvelle adresse e-mail doit être différente de l'actuelle",
     "source_hash": "f7cfed6e"
   },
   "web.settings.profile.email_change_success": {
-    "text": "E-mail de vérification envoyé. Veuillez vérifier votre nouvelle boîte de réception et cliquer sur le lien de confirmation pour finaliser la modification.",
+    "text": "E-mail de vérification envoyé. Veuillez consulter votre nouvelle boîte de réception et cliquer sur le lien de confirmation pour finaliser la modification.",
     "source_hash": "45f0a4b5"
   },
   "web.settings.profile.email_change_error": {
-    "text": "Échec de la mise à jour de l'e-mail. Veuillez réessayer.",
+    "text": "Échec de la mise à jour de l'adresse e-mail. Veuillez réessayer.",
     "source_hash": "aeba6591"
   },
   "web.settings.sessions.title": {
@@ -352,11 +352,11 @@
     "source_hash": "e7cf3ef4"
   },
   "web.settings.password.description": {
-    "text": "Mettre à jour le mot de passe de votre compte",
+    "text": "Mettez à jour le mot de passe de votre compte",
     "source_hash": "cb3ae40b"
   },
   "web.settings.password.update_account_password": {
-    "text": "Mettre à jour le mot de passe de votre compte",
+    "text": "Mettez à jour le mot de passe de votre compte",
     "source_hash": "cb3ae40b"
   },
   "web.settings.delete_account.title": {
@@ -364,11 +364,11 @@
     "source_hash": "c031bf99"
   },
   "web.settings.delete_account.description": {
-    "text": "Supprimer définitivement votre compte et toutes vos données",
+    "text": "Supprimez définitivement votre compte et toutes vos données",
     "source_hash": "7a3a6da2"
   },
   "web.settings.delete_account.permanently_delete_your_account": {
-    "text": "Supprimer définitivement votre compte et toutes vos données",
+    "text": "Supprimez définitivement votre compte et toutes vos données",
     "source_hash": "7a3a6da2"
   },
   "web.settings.security.security_score": {
@@ -376,7 +376,7 @@
     "source_hash": "02d2f374"
   },
   "web.settings.security.score_description": {
-    "text": "L'état de santé global de la sécurité de votre compte",
+    "text": "L'état général de la sécurité de votre compte",
     "source_hash": "cf20935e"
   },
   "web.settings.security.excellent": {
@@ -384,7 +384,7 @@
     "source_hash": "0dc8ee55"
   },
   "web.settings.security.good": {
-    "text": "Bien",
+    "text": "Bon",
     "source_hash": "c939327c"
   },
   "web.settings.security.fair": {
@@ -396,7 +396,7 @@
     "source_hash": "8d6cea25"
   },
   "web.settings.security.improve_security": {
-    "text": "Améliorer votre sécurité",
+    "text": "Améliorez votre sécurité",
     "source_hash": "c38bcbf5"
   },
   "web.settings.security.enable_mfa_recommendation": {
@@ -404,7 +404,7 @@
     "source_hash": "6beda528"
   },
   "web.settings.security.generate_recovery_codes_recommendation": {
-    "text": "Générez des codes de récupération comme sauvegarde",
+    "text": "Générez des codes de récupération comme solution de secours",
     "source_hash": "eb5f3ebd"
   },
   "web.settings.security.configured": {
@@ -448,11 +448,11 @@
     "source_hash": "107e4898"
   },
   "web.settings.security.save_recovery_codes_safely": {
-    "text": "Conservez vos codes de récupération dans un endroit sûr",
+    "text": "Conservez vos codes de récupération en lieu sûr",
     "source_hash": "605513fc"
   },
   "web.settings.security.review_sessions_regularly": {
-    "text": "Vérifiez et révoquez régulièrement les sessions inutilisées",
+    "text": "Passez régulièrement en revue et révoquez les sessions inutilisées",
     "source_hash": "efe59445"
   },
   "web.settings.security.view_details": {
@@ -464,15 +464,15 @@
     "source_hash": "21fc84f3"
   },
   "web.settings.api.description": {
-    "text": "Gérez les clés API et les intégrations",
+    "text": "Gérez les clés d'API et les intégrations",
     "source_hash": "70976099"
   },
   "web.settings.api.manage_api_keys": {
-    "text": "Gérez les clés API et les intégrations",
+    "text": "Gérez les clés d'API et les intégrations",
     "source_hash": "70976099"
   },
   "web.settings.api.documentation": {
-    "text": "Documentation API",
+    "text": "Documentation de l'API",
     "source_hash": "1cc77e60"
   },
   "web.settings.api.documentation_description": {
@@ -492,7 +492,7 @@
     "source_hash": "216d28e4"
   },
   "web.settings.api.example_code_and_libraries": {
-    "text": "Exemples de code et bibliothèques client",
+    "text": "Exemples de code et bibliothèques clientes",
     "source_hash": "61c5956f"
   },
   "web.settings.api.security_best_practices": {
@@ -500,19 +500,19 @@
     "source_hash": "fd71b2da"
   },
   "web.settings.api.never_commit_api_keys": {
-    "text": "Ne jamais commiter de clés API dans le contrôle de version",
+    "text": "Ne validez jamais de clés d'API dans un système de gestion de versions",
     "source_hash": "cc8c327e"
   },
   "web.settings.api.use_environment_variables": {
-    "text": "Utilisez des variables d'environnement pour stocker les clés API",
+    "text": "Utilisez des variables d'environnement pour stocker les clés d'API",
     "source_hash": "c05e8802"
   },
   "web.settings.api.rotate_keys_regularly": {
-    "text": "Changez régulièrement vos clés API pour la sécurité",
+    "text": "Renouvelez régulièrement les clés d'API par sécurité",
     "source_hash": "eda6a5db"
   },
   "web.settings.api.use_https_only": {
-    "text": "Utilisez toujours HTTPS lors des requêtes API",
+    "text": "Utilisez toujours HTTPS pour vos requêtes d'API",
     "source_hash": "b3f405ef"
   },
   "web.settings.api.monitor_api_usage": {
@@ -524,7 +524,7 @@
     "source_hash": "03d3ba93"
   },
   "web.settings.api.regenerating_key_warning": {
-    "text": "La régénération de votre clé API invalidera la clé actuelle. Mettez à jour toutes les applications utilisant l'ancienne clé.",
+    "text": "La régénération de votre clé d'API invalidera la clé actuelle. Mettez à jour toutes les applications utilisant l'ancienne clé.",
     "source_hash": "ab168f83"
   },
   "web.settings.privacy.title": {
@@ -536,7 +536,7 @@
     "source_hash": "add087da"
   },
   "web.settings.privacy.your_privacy": {
-    "text": "Votre vie privée",
+    "text": "Votre confidentialité",
     "source_hash": "cad972db"
   },
   "web.settings.privacy.non_negotiable": {
@@ -548,11 +548,11 @@
     "source_hash": "41278ece"
   },
   "web.settings.privacy.no_analytics_statement": {
-    "text": "Pas d'analyse. Pas de suivi. Point final.",
+    "text": "Aucune analyse. Aucun suivi. Point final.",
     "source_hash": "3e154b1c"
   },
   "web.settings.privacy.explanation": {
-    "text": "Ce n'est pas un paramètre car il n'y a rien à activer ou désactiver. Votre vie privée est intégrée dans notre façon de fonctionner.",
+    "text": "Ce n'est pas un paramètre car il n'y a rien à activer ou à désactiver. Votre confidentialité est intégrée à notre fonctionnement.",
     "source_hash": "ed943792"
   },
   "web.settings.notifications.title": {
@@ -560,11 +560,11 @@
     "source_hash": "07a063ca"
   },
   "web.settings.notifications.description": {
-    "text": "Gérez comment vous recevez les notifications",
+    "text": "Gérez la façon dont vous recevez les notifications",
     "source_hash": "148c5ff6"
   },
   "web.settings.notifications.error_updating": {
-    "text": "Échec de la mise à jour des préférences de notification. Veuillez réessayer.",
+    "text": "Échec de la mise à jour de la préférence de notification. Veuillez réessayer.",
     "source_hash": "c08abc04"
   },
   "web.settings.notifications.reveal_notifications.title": {
@@ -572,19 +572,19 @@
     "source_hash": "c0fb2e25"
   },
   "web.settings.notifications.reveal_notifications.description": {
-    "text": "Recevoir un e-mail lorsque quelqu'un consulte votre secret",
+    "text": "Recevez un e-mail lorsque quelqu'un consulte votre secret",
     "source_hash": "a3a67095"
   },
   "web.settings.notifications.reveal_notifications.help": {
-    "text": "Vous serez notifié chaque fois qu'un destinataire révèle l'un de vos secrets",
+    "text": "Vous serez averti chaque fois qu'un destinataire révèle l'un de vos secrets",
     "source_hash": "ba93106d"
   },
   "web.settings.notifications.privacy_note": {
-    "text": "Les e-mails de notification incluent uniquement l'horodatage et l'ID du secret. Les informations sur le lecteur ne sont jamais incluses.",
+    "text": "Les e-mails de notification n'incluent que l'horodatage et l'ID du secret. Aucune information sur le lecteur n'est jamais incluse.",
     "source_hash": "7aac282f"
   },
   "web.settings.caution.title": {
-    "text": "Zone de prudence",
+    "text": "Zone à considérer avec prudence",
     "source_hash": "fe27a3a8"
   },
   "web.settings.caution.description": {
@@ -592,23 +592,23 @@
     "source_hash": "223ee55d"
   },
   "web.settings.caution.data_export": {
-    "text": "Export de données",
+    "text": "Export des données",
     "source_hash": "bdcea052"
   },
   "web.settings.caution.export_your_data": {
-    "text": "Exporter les données de votre compte",
+    "text": "Exportez les données de votre compte",
     "source_hash": "dc5ffcb0"
   },
   "web.settings.caution.export_description": {
-    "text": "Demander une copie complète des données de votre compte dans un format lisible par machine",
+    "text": "Demandez une copie complète des données de votre compte dans un format lisible par machine",
     "source_hash": "369c3391"
   },
   "web.settings.caution.request_data_export": {
-    "text": "Demander un export de données",
+    "text": "Demander un export des données",
     "source_hash": "902394be"
   },
   "web.settings.caution.export_info": {
-    "text": "Temps de traitement de l'export",
+    "text": "Délai de traitement de l'export",
     "source_hash": "2ebb2d44"
   },
   "web.settings.caution.export_info_description": {
@@ -616,19 +616,19 @@
     "source_hash": "a2f81e3b"
   },
   "web.settings.caution.deletion_warning_title": {
-    "text": "La suppression de votre compte entraînera :",
+    "text": "La suppression de votre compte va :",
     "source_hash": "17a8a676"
   },
   "web.settings.caution.deletion_warning_secrets": {
-    "text": "Supprimer définitivement tous vos secrets",
+    "text": "supprimer définitivement tous vos secrets",
     "source_hash": "974ccdb9"
   },
   "web.settings.caution.deletion_warning_metadata": {
-    "text": "Supprimer toutes les métadonnées et l'historique des secrets",
+    "text": "supprimer toutes les métadonnées et tout l'historique des secrets",
     "source_hash": "ec4ee372"
   },
   "web.settings.caution.deletion_warning_api_keys": {
-    "text": "Invalider toutes les clés API",
+    "text": "invalider toutes les clés d'API",
     "source_hash": "7581333b"
   },
   "web.settings.caution.deletion_warning_irreversible": {
@@ -640,7 +640,7 @@
     "source_hash": "cf02eb0c"
   },
   "web.settings.profile.email_confirmed_success": {
-    "text": "Votre e-mail a été mis à jour avec succès. Veuillez vous connecter avec votre nouvelle adresse e-mail.",
+    "text": "Votre adresse e-mail a été mise à jour avec succès. Veuillez vous connecter avec votre nouvelle adresse e-mail.",
     "source_hash": "a84efcea"
   },
   "web.settings.profile.email_confirm_verifying": {
@@ -648,11 +648,11 @@
     "source_hash": "a6a4745f"
   },
   "web.settings.profile.email_confirm_error_title": {
-    "text": "Échec du changement d'e-mail",
+    "text": "Échec du changement d'adresse e-mail",
     "source_hash": "953f3936"
   },
   "web.settings.profile.email_confirm_invalid": {
-    "text": "Ce lien de vérification est invalide ou a expiré.",
+    "text": "Ce lien de vérification n'est pas valide ou a expiré.",
     "source_hash": "f54594c2"
   },
   "web.settings.profile.email_confirm_back_to_settings": {
@@ -672,15 +672,15 @@
     "source_hash": "2287783b"
   },
   "web.settings.profile.resend_confirmation_sending": {
-    "text": "Envoi en cours...",
+    "text": "Envoi...",
     "source_hash": "286a3af7"
   },
   "web.settings.profile.email_change_pending": {
-    "text": "Un e-mail de vérification a été envoyé. Vérifiez votre boîte de réception et cliquez sur le lien de confirmation.",
+    "text": "Un e-mail de vérification a été envoyé. Consultez votre boîte de réception et cliquez sur le lien de confirmation.",
     "source_hash": "5806c93f"
   },
   "web.settings.profile.didnt_receive_email": {
-    "text": "Vous n'avez pas reçu l'e-mail ?",
+    "text": "Vous n'avez pas reçu l'e-mail ?",
     "source_hash": "fe3ac3ad"
   },
   "web.settings.api.api_disabled_notice": {
@@ -694,5 +694,33 @@
   "web.settings.security.sso_managed_description": {
     "text": "Votre compte est authentifié via le fournisseur d'authentification unique de votre organisation. Le mot de passe, l'authentification multifacteur et les codes de récupération sont gérés par votre fournisseur d'identité.",
     "source_hash": "cd0cf39f"
+  },
+  "web.settings.api.api_username": {
+    "text": "Nom d'utilisateur de l'API",
+    "source_hash": "0b3e483e"
+  },
+  "web.settings.api.api_username_description": {
+    "text": "Votre nom d'utilisateur pour l'authentification HTTP Basic",
+    "source_hash": "f3e65de3"
+  },
+  "web.settings.api.basic_auth_hint": {
+    "text": "Pour l'authentification HTTP Basic, utilisez l'adresse e-mail de votre compte ou cet identifiant comme nom d'utilisateur et votre jeton d'API comme mot de passe.",
+    "source_hash": "cfa3806d"
+  },
+  "web.settings.security.set": {
+    "text": "Définir",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.settings.security.not_set": {
+    "text": "Non défini",
+    "source_hash": "4895f731"
+  },
+  "web.settings.security.set_password_title": {
+    "text": "Définir un mot de passe",
+    "source_hash": "4e411687"
+  },
+  "web.settings.security.set_password_description": {
+    "text": "Ajoutez un mot de passe à votre compte afin de pouvoir aussi vous connecter sans votre fournisseur d'identité",
+    "source_hash": "a6970402"
   }
 }

--- a/locales/content/fr_FR/workspace-billing.json
+++ b/locales/content/fr_FR/workspace-billing.json
@@ -16,19 +16,19 @@
     "source_hash": "a865d424"
   },
   "web.billing.upgrade.needTeams": {
-    "text": "La gestion d'équipe nécessite Identity Plus ou supérieur",
+    "text": "La gestion des équipes nécessite Identity Plus ou une offre supérieure",
     "source_hash": "95bdda65"
   },
   "web.billing.upgrade.needCustomDomains": {
-    "text": "Les domaines personnalisés nécessitent Identity Plus ou supérieur",
+    "text": "Les domaines personnalisés nécessitent Identity Plus ou une offre supérieure",
     "source_hash": "e8af8484"
   },
   "web.billing.upgrade.needApiAccess": {
-    "text": "L'accès API nécessite Identity Plus ou supérieur",
+    "text": "L'accès à l'API nécessite Identity Plus ou une offre supérieure",
     "source_hash": "ab8be865"
   },
   "web.billing.upgrade.needAuditLogs": {
-    "text": "Les journaux d'audit nécessitent le forfait Multi-équipes ou supérieur",
+    "text": "Les journaux d'audit nécessitent le forfait Multi-équipes ou une offre supérieure",
     "source_hash": "91df96b0"
   },
   "web.billing.manage_subscription_and_billing": {
@@ -40,11 +40,11 @@
     "source_hash": "479a3c4c"
   },
   "web.billing.overview.description": {
-    "text": "Consultez et gérez votre abonnement et vos détails de paiement",
+    "text": "Consultez et gérez votre abonnement et vos informations de paiement",
     "source_hash": "60e5a00e"
   },
   "web.billing.overview.billing_for_organization": {
-    "text": "Facturation pour cette organisation",
+    "text": "Facturation de cette organisation",
     "source_hash": "21806992"
   },
   "web.billing.overview.current_plan": {
@@ -88,15 +88,15 @@
     "source_hash": "cbc4ef92"
   },
   "web.billing.plans.legacy_plan_info": {
-    "text": "Vous bénéficiez d'un forfait avec tarification spéciale maintenue.",
+    "text": "Vous bénéficiez d'un forfait historique à tarif préférentiel.",
     "source_hash": "e9aa8bf0"
   },
   "web.billing.plans.early_supporter_plan": {
-    "text": "Identity Plus (Soutien de la première heure)",
+    "text": "Identity Plus (soutien de la première heure)",
     "source_hash": "f37cd0d9"
   },
   "web.billing.plans.legacy_plan_warning": {
-    "text": "Changer de forfait entraînera la perte de votre tarif préférentiel. Cette action est irréversible.",
+    "text": "Changer de forfait vous fera perdre votre tarif historique. Cette action est irréversible.",
     "source_hash": "eda13d64"
   },
   "web.billing.overview.no_payment_method": {
@@ -156,7 +156,7 @@
     "source_hash": "00ac43f8"
   },
   "web.billing.overview.upgrade_success_description": {
-    "text": "Votre nouveau forfait est maintenant actif. Merci pour votre achat.",
+    "text": "Votre nouveau forfait est désormais actif. Merci pour votre achat.",
     "source_hash": "fd1caeb1"
   },
   "web.billing.overview.billing_contact": {
@@ -168,11 +168,11 @@
     "source_hash": "0320541d"
   },
   "web.billing.overview.entitlements.view_receipt": {
-    "text": "Voir les accusés de réception",
+    "text": "Consulter les reçus",
     "source_hash": "6c664c31"
   },
   "web.billing.overview.entitlements.api_access": {
-    "text": "Accès API",
+    "text": "Accès à l'API",
     "source_hash": "5f31cc2f"
   },
   "web.billing.overview.entitlements.custom_domains": {
@@ -184,19 +184,19 @@
     "source_hash": "e677e27d"
   },
   "web.billing.overview.entitlements.extended_default_expiration": {
-    "text": "Expiration par défaut prolongée",
+    "text": "Expiration par défaut étendue",
     "source_hash": "19b19637"
   },
   "web.billing.overview.entitlements.custom_mail_sender": {
-    "text": "Paramètres de messagerie personnalisés par défaut",
+    "text": "Paramètres d'e-mail personnalisés par défaut",
     "source_hash": "95aebfb9"
   },
   "web.billing.overview.entitlements.custom_branding": {
-    "text": "Image de marque personnalisée",
+    "text": "Personnalisation graphique",
     "source_hash": "237dabec"
   },
   "web.billing.overview.entitlements.homepage_secrets": {
-    "text": "Secrets de la page d'accueil",
+    "text": "Secrets sur la page d'accueil",
     "source_hash": "6360f7ec"
   },
   "web.billing.overview.entitlements.incoming_secrets": {
@@ -224,7 +224,7 @@
     "source_hash": "5db5c812"
   },
   "web.billing.overview.entitlements.priority_support": {
-    "text": "Support prioritaire",
+    "text": "Assistance prioritaire",
     "source_hash": "ed8a65c8"
   },
   "web.billing.overview.entitlements.sla": {
@@ -232,7 +232,7 @@
     "source_hash": "436f2550"
   },
   "web.billing.overview.entitlements_load_error": {
-    "text": "Impossible de charger les détails des fonctionnalités",
+    "text": "Impossible de charger le détail des fonctionnalités",
     "source_hash": "c350973c"
   },
   "web.billing.overview.no_entitlements": {
@@ -244,7 +244,7 @@
     "source_hash": "303f9386"
   },
   "web.billing.features.api_access": {
-    "text": "Accès API",
+    "text": "Accès à l'API",
     "source_hash": "5f31cc2f"
   },
   "web.billing.features.custom_domains": {
@@ -260,15 +260,15 @@
     "source_hash": "53eb7521"
   },
   "web.billing.features.custom_branding": {
-    "text": "Image de marque personnalisée",
+    "text": "Personnalisation graphique",
     "source_hash": "237dabec"
   },
   "web.billing.features.homepage_secrets": {
-    "text": "Secrets de la page d'accueil",
+    "text": "Secrets sur la page d'accueil",
     "source_hash": "6360f7ec"
   },
   "web.billing.features.manage_teams": {
-    "text": "Gestion d'équipe",
+    "text": "Gestion des équipes",
     "source_hash": "6bcbac8f"
   },
   "web.billing.features.manage_members": {
@@ -284,7 +284,7 @@
     "source_hash": "5ba3ac9f"
   },
   "web.billing.features.priority_support": {
-    "text": "Support prioritaire",
+    "text": "Assistance prioritaire",
     "source_hash": "ed8a65c8"
   },
   "web.billing.features.sla": {
@@ -304,7 +304,7 @@
     "source_hash": "b9c6cba7"
   },
   "web.billing.features.handoff_workflows": {
-    "text": "Flux de travail de transfert",
+    "text": "Flux de transmission",
     "source_hash": "07202af3"
   },
   "web.billing.plans.title": {
@@ -312,11 +312,11 @@
     "source_hash": "79506c82"
   },
   "web.billing.plans.choose_plan": {
-    "text": "Choisissez le forfait qui correspond à vos besoins",
+    "text": "Choisissez le forfait adapté à vos besoins",
     "source_hash": "5f039cb9"
   },
   "web.billing.plans.subtitle": {
-    "text": "Choisissez le forfait parfait pour votre organisation",
+    "text": "Choisissez le forfait idéal pour votre organisation",
     "source_hash": "308076f2"
   },
   "web.billing.plans.current": {
@@ -352,7 +352,7 @@
     "source_hash": "eec5d08b"
   },
   "web.billing.plans.save_yearly": {
-    "text": "Économisez {percent}% avec la facturation annuelle",
+    "text": "Économisez {percent} % avec la facturation annuelle",
     "source_hash": "88c451f2"
   },
   "web.billing.plans.free_plan": {
@@ -388,15 +388,15 @@
     "source_hash": "0f077568"
   },
   "web.billing.plans.api_access": {
-    "text": "Accès API",
+    "text": "Accès à l'API",
     "source_hash": "923fd434"
   },
   "web.billing.plans.priority_support": {
-    "text": "Support prioritaire",
+    "text": "Assistance prioritaire",
     "source_hash": "acea4b40"
   },
   "web.billing.plans.select_plan": {
-    "text": "Sélectionner un forfait",
+    "text": "Sélectionner le forfait",
     "source_hash": "8709f894"
   },
   "web.billing.plans.contact_sales": {
@@ -404,11 +404,11 @@
     "source_hash": "484aa053"
   },
   "web.billing.plans.custom_needs_title": {
-    "text": "Vous avez des questions ou besoin de quelque chose de personnalisé ?",
+    "text": "Vous avez des questions ou des besoins spécifiques ?",
     "source_hash": "2f68484c"
   },
   "web.billing.plans.custom_needs_description": {
-    "text": "Nous serions ravis de vous entendre. Faites-nous savoir ce que vous recherchez.",
+    "text": "Nous serions ravis d'échanger avec vous. Dites-nous ce que vous recherchez.",
     "source_hash": "a6b7f407"
   },
   "web.billing.plans.teams_limit": {
@@ -436,11 +436,11 @@
     "source_hash": "93b63bab"
   },
   "web.billing.plans.everything_in": {
-    "text": "Inclut tout ce qui est dans {plan}",
+    "text": "Inclut tout ce que contient {plan}",
     "source_hash": "1c73c298"
   },
   "web.billing.plans.no_plans_available": {
-    "text": "Aucun forfait {interval} disponible actuellement.",
+    "text": "Aucun forfait {interval} disponible pour le moment.",
     "source_hash": "d8454436"
   },
   "web.billing.plans.load_error": {
@@ -452,23 +452,23 @@
     "source_hash": "889d13be"
   },
   "web.billing.plans.current_plan_label": {
-    "text": "Forfait actuel :",
+    "text": "Forfait actuel :",
     "source_hash": "648a0ab2"
   },
   "web.billing.plans.new_plan_label": {
-    "text": "Nouveau forfait :",
+    "text": "Nouveau forfait :",
     "source_hash": "edb868c4"
   },
   "web.billing.plans.credit_label": {
-    "text": "Crédit pour le temps non utilisé :",
+    "text": "Crédit pour la période non utilisée :",
     "source_hash": "001e4901"
   },
   "web.billing.plans.due_today": {
-    "text": "Dû aujourd'hui :",
+    "text": "À payer aujourd'hui :",
     "source_hash": "e370e3aa"
   },
   "web.billing.plans.next_billing": {
-    "text": "Prochaine facturation ({date}) :",
+    "text": "Prochaine facturation ({date}) :",
     "source_hash": "a6846a85"
   },
   "web.billing.plans.next_invoice": {
@@ -492,31 +492,31 @@
     "source_hash": "deaf8189"
   },
   "web.billing.plans.upgrade_to": {
-    "text": "Passer à {plan} ?",
+    "text": "Passer à {plan} ?",
     "source_hash": "b1e4e88c"
   },
   "web.billing.plans.downgrade_to": {
-    "text": "Rétrograder vers {plan} ?",
+    "text": "Rétrograder vers {plan} ?",
     "source_hash": "8eb8ea81"
   },
   "web.billing.plans.credit_applies_heading": {
-    "text": "Comment votre crédit s'applique :",
+    "text": "Comment votre crédit est appliqué :",
     "source_hash": "a0943c3b"
   },
   "web.billing.plans.next_bill_amount": {
-    "text": "Montant de la prochaine facture :",
+    "text": "Montant de la prochaine facture :",
     "source_hash": "526ad28f"
   },
   "web.billing.plans.credit_applied_to_bill": {
-    "text": "Crédit appliqué :",
+    "text": "Crédit appliqué :",
     "source_hash": "e5f2e81a"
   },
   "web.billing.plans.amount_due_next_billing": {
-    "text": "Montant dû à la prochaine facturation :",
+    "text": "Montant dû à la prochaine facturation :",
     "source_hash": "22ee868a"
   },
   "web.billing.plans.remaining_account_credit": {
-    "text": "Crédit de compte restant :",
+    "text": "Crédit restant sur le compte :",
     "source_hash": "eedd0c0a"
   },
   "web.billing.plans.credit_future_note": {
@@ -540,7 +540,7 @@
     "source_hash": "49e96d7c"
   },
   "web.billing.invoices.invoice_status": {
-    "text": "Statut",
+    "text": "État",
     "source_hash": "920e413c"
   },
   "web.billing.invoices.invoice_download": {
@@ -548,15 +548,15 @@
     "source_hash": "d6eafe82"
   },
   "web.billing.invoices.invoice_number": {
-    "text": "Facture n°",
+    "text": "N° de facture",
     "source_hash": "48a67cac"
   },
   "web.billing.invoices.no_invoices": {
-    "text": "Aucune facture pour le moment",
+    "text": "Aucune facture pour l'instant",
     "source_hash": "92d2d0ce"
   },
   "web.billing.invoices.no_invoices_description": {
-    "text": "Vos factures apparaîtront ici une fois que vous aurez souscrit à un forfait payant",
+    "text": "Vos factures apparaîtront ici dès que vous passerez à un forfait payant",
     "source_hash": "7f16be70"
   },
   "web.billing.invoices.view_plans": {
@@ -564,7 +564,7 @@
     "source_hash": "a865d424"
   },
   "web.billing.invoices.paid": {
-    "text": "Payé",
+    "text": "Payée",
     "source_hash": "fb81b961"
   },
   "web.billing.invoices.pending": {
@@ -572,7 +572,7 @@
     "source_hash": "331551b0"
   },
   "web.billing.invoices.failed": {
-    "text": "Échoué",
+    "text": "Échouée",
     "source_hash": "031a8f0f"
   },
   "web.billing.invoices.draft": {
@@ -608,7 +608,7 @@
     "source_hash": "ce8f2a24"
   },
   "web.billing.limits.members_upgrade": {
-    "text": "Mettez à niveau pour ajouter plus de membres",
+    "text": "Mettez à niveau pour ajouter davantage de membres",
     "source_hash": "602bdef4"
   },
   "web.billing.subscription.title": {
@@ -616,7 +616,7 @@
     "source_hash": "4999c6c6"
   },
   "web.billing.subscription.status": {
-    "text": "Statut de l'abonnement",
+    "text": "État de l'abonnement",
     "source_hash": "c7a08e1d"
   },
   "web.billing.subscription.active": {
@@ -628,7 +628,7 @@
     "source_hash": "ac7c949f"
   },
   "web.billing.subscription.past_due": {
-    "text": "En retard",
+    "text": "En retard de paiement",
     "source_hash": "2bda1c7b"
   },
   "web.billing.subscription.canceled": {
@@ -664,7 +664,7 @@
     "source_hash": "b6f47df3"
   },
   "web.billing.start_today": {
-    "text": "Commencer aujourd'hui",
+    "text": "Commencez aujourd'hui",
     "source_hash": "80e73fc7"
   },
   "web.billing.start_today_with_identity_plus": {
@@ -688,7 +688,7 @@
     "source_hash": "bb273516"
   },
   "web.billing.click_this_lightning_bolt_to_upgrade_for_custom_domains": {
-    "text": "Cliquez sur cet éclair pour mettre à niveau les domaines personnalisés",
+    "text": "Cliquez sur cet éclair pour passer aux domaines personnalisés",
     "source_hash": "84cb4258"
   },
   "web.billing.maybe_later": {
@@ -704,7 +704,7 @@
     "source_hash": "272d3c80"
   },
   "web.billing.upgrade_for_teams": {
-    "text": "Mettre à niveau pour les équipes",
+    "text": "Mise à niveau pour les équipes",
     "source_hash": "90dfb533"
   },
   "web.billing.benefits_of": {
@@ -712,7 +712,7 @@
     "source_hash": "75403743"
   },
   "web.billing.t_benefits_of_identity_plus": {
-    "text": "{0} : Identity Plus",
+    "text": "{0} : Identity Plus",
     "source_hash": "f13e5f3e"
   },
   "web.billing.upgrade_to": {
@@ -720,15 +720,15 @@
     "source_hash": "2ecdd437"
   },
   "web.billing.upgrade_for_yourdomain": {
-    "text": "Mettre à niveau pour secrets.votredomaine.com",
+    "text": "Mise à niveau pour secrets.yourdomain.com",
     "source_hash": "8e4d766a"
   },
   "web.billing.includes_all_features_and_unlimited_sharing_capa": {
-    "text": "Comprend toutes les fonctionnalités et une capacité de partage illimitée",
+    "text": "Tous les forfaits incluent les fonctionnalités de confidentialité et une capacité de partage illimitée",
     "source_hash": "e728e4e1"
   },
   "web.billing.includes_all_data_locality_options": {
-    "text": "Tous les forfaits incluent le choix de localisation des données : {0} régions",
+    "text": "Tous les forfaits incluent le choix de la localisation des données : {0} régions",
     "source_hash": "22a60b49"
   },
   "web.billing.get_started": {
@@ -736,7 +736,7 @@
     "source_hash": "61e8d44a"
   },
   "web.billing.frequency_value_annually_annual_monthly_subscrip": {
-    "text": "{0} souscription",
+    "text": "Abonnement {0}",
     "source_hash": "eaf5e2ef"
   },
   "web.billing.elevate_your_secure_sharing_with_custom_domains_": {
@@ -748,15 +748,15 @@
     "source_hash": "b2c87e39"
   },
   "web.billing.secure_your_brand_and_build_customer_trust_with_": {
-    "text": "Protégez votre marque et renforcez la confiance de vos clients grâce à des liens provenant de votre domaine. Parfait pour les entreprises qui accordent de l'importance à la confidentialité et au professionnalisme.",
+    "text": "Sécurisez votre marque et instaurez la confiance de vos clients avec des liens issus de votre domaine. Idéal pour les entreprises qui accordent de l'importance à la confidentialité et au professionnalisme.",
     "source_hash": "c07cd25c"
   },
   "web.billing.secure_links_stronger_connections": {
-    "text": "Liens sécurisés, connexions renforcées",
+    "text": "Des liens sécurisés, des relations renforcées",
     "source_hash": "dd8dae5d"
   },
   "web.billing.identity_tier_not_found_in_product_tiers": {
-    "text": "Le niveau d'identité n'est pas trouvé dans les niveaux de produits",
+    "text": "Niveau Identity introuvable parmi les niveaux de produit",
     "source_hash": "d0204fc4"
   },
   "web.billing.cancel.link_text": {
@@ -770,11 +770,11 @@
     "source_hash": "882e0c83"
   },
   "web.billing.cancel.confirmation": {
-    "text": "Êtes-vous sûr de vouloir annuler votre abonnement {plan} ?",
+    "text": "Voulez-vous vraiment annuler votre abonnement {plan} ?",
     "source_hash": "f4d1b6ee"
   },
   "web.billing.cancel.what_happens": {
-    "text": "Ce qui se passe lorsque vous annulez :",
+    "text": "Ce qui se passe lorsque vous annulez :",
     "source_hash": "4d8f5751"
   },
   "web.billing.cancel.access_until": {
@@ -782,7 +782,7 @@
     "source_hash": "eab1efe3"
   },
   "web.billing.cancel.access_until_period_end": {
-    "text": "Vous conserverez l'accès jusqu'à la fin de votre période de facturation actuelle",
+    "text": "Vous conserverez l'accès jusqu'à la fin de votre période de facturation en cours",
     "source_hash": "1b07a54a"
   },
   "web.billing.cancel.no_future_charges": {
@@ -812,17 +812,17 @@
     "source_hash": "68e8bdde"
   },
   "web.billing.cancel.scheduled_title": {
-    "text": "Annulation d'abonnement programmée",
+    "text": "Annulation de l'abonnement programmée",
     "context": "Alert banner heading shown when cancellation is pending",
     "source_hash": "1427d139"
   },
   "web.billing.cancel.scheduled_description": {
-    "text": "Votre abonnement restera actif jusqu'au {date}. Vous continuerez à avoir un accès complet à toutes les fonctionnalités jusque-là.",
+    "text": "Votre abonnement restera actif jusqu'au {date}. Vous conserverez un accès complet à toutes les fonctionnalités jusque-là.",
     "context": "Alert banner description explaining continued access",
     "source_hash": "aab4b1dc"
   },
   "web.billing.cancel.scheduled_note": {
-    "text": "Vous avez changé d'avis ? Vous pouvez réactiver votre abonnement à tout moment avant la date d'annulation.",
+    "text": "Vous avez changé d'avis ? Vous pouvez réactiver votre abonnement à tout moment avant la date d'annulation.",
     "context": "Alert banner note encouraging reactivation",
     "source_hash": "c94d5527"
   },
@@ -831,15 +831,15 @@
     "source_hash": "04e0f1e9"
   },
   "web.billing.overview.entitlements.ip_access_rules": {
-    "text": "Règles d'accès IP",
+    "text": "Règles d'accès par IP",
     "source_hash": "db966d47"
   },
   "web.billing.overview.entitlements.workspace_branding": {
-    "text": "Image de marque de l'espace de travail",
+    "text": "Personnalisation de l'espace de travail",
     "source_hash": "e7acbf6f"
   },
   "web.billing.features.extended_retention": {
-    "text": "Rétention des secrets de 30 jours",
+    "text": "Conservation des secrets pendant 30 jours",
     "source_hash": "21d6d514"
   },
   "web.billing.features.incoming_secrets": {
@@ -871,11 +871,11 @@
     "source_hash": "04e0f1e9"
   },
   "web.billing.features.ip_access_rules": {
-    "text": "Règles d'accès IP",
+    "text": "Règles d'accès par IP",
     "source_hash": "db966d47"
   },
   "web.billing.features.workspace_branding": {
-    "text": "Image de marque de l'espace de travail",
+    "text": "Personnalisation de l'espace de travail",
     "source_hash": "e7acbf6f"
   },
   "web.billing.features.dedicated_infrastructure": {
@@ -896,19 +896,19 @@
     "source_hash": "f0cdf727"
   },
   "web.billing.currency_migration.current_plan": {
-    "text": "Forfait actuel :",
+    "text": "Forfait actuel :",
     "source_hash": "648a0ab2"
   },
   "web.billing.currency_migration.new_plan": {
-    "text": "Nouveau forfait :",
+    "text": "Nouveau forfait :",
     "source_hash": "edb868c4"
   },
   "web.billing.currency_migration.current_period_ends": {
-    "text": "Fin de la période actuelle :",
+    "text": "Fin de la période en cours :",
     "source_hash": "2e20e596"
   },
   "web.billing.currency_migration.choose_timing": {
-    "text": "Quand le changement doit-il avoir lieu ?",
+    "text": "Quand le changement doit-il avoir lieu ?",
     "source_hash": "f4aabb13"
   },
   "web.billing.currency_migration.graceful_title": {
@@ -916,7 +916,7 @@
     "source_hash": "55cd980b"
   },
   "web.billing.currency_migration.graceful_description": {
-    "text": "Votre forfait actuel reste actif jusqu'au {date}. Après cela, vous finaliserez le paiement de votre nouveau forfait.",
+    "text": "Votre forfait actuel reste actif jusqu'au {date}. Ensuite, vous finaliserez le paiement de votre nouveau forfait.",
     "source_hash": "b8661418"
   },
   "web.billing.currency_migration.immediate_title": {
@@ -924,7 +924,7 @@
     "source_hash": "e9d0ba59"
   },
   "web.billing.currency_migration.immediate_description": {
-    "text": "Votre forfait actuel est annulé maintenant. Vous recevrez un remboursement pour le temps non utilisé et finaliserez le paiement du nouveau forfait.",
+    "text": "Votre forfait actuel est annulé dès maintenant. Vous serez remboursé pour la période non utilisée et finaliserez le paiement du nouveau forfait.",
     "source_hash": "b08de0ca"
   },
   "web.billing.currency_migration.confirm": {
@@ -940,15 +940,15 @@
     "source_hash": "a8bf437e"
   },
   "web.billing.currency_migration.graceful_success": {
-    "text": "Votre forfait actuel restera actif jusqu'à la fin de la période de facturation. Vous serez invité à finaliser le paiement de votre nouveau forfait après cela.",
+    "text": "Votre forfait actuel restera actif jusqu'à la fin de la période de facturation. Vous serez ensuite invité à finaliser le paiement de votre nouveau forfait.",
     "source_hash": "15d41483"
   },
   "web.billing.currency_migration.warning_credit_balance": {
-    "text": "Vous avez un solde créditeur en {currency} qui ne peut pas être transféré vers la nouvelle devise.",
+    "text": "Vous disposez d'un solde créditeur en {currency} qui ne peut pas être transféré vers la nouvelle devise.",
     "source_hash": "aa15be91"
   },
   "web.billing.currency_migration.warning_pending_items": {
-    "text": "Vous avez des éléments de facture en attente qui devront être résolus avant la migration.",
+    "text": "Vous avez des éléments de facture en attente qui devront être réglés avant la migration.",
     "source_hash": "7b4c5e10"
   },
   "web.billing.currency_migration.warning_coupons": {
@@ -961,11 +961,11 @@
     "source_hash": "018ae653"
   },
   "web.billing.currency_migration.pending_description": {
-    "text": "Votre forfait actuel se termine le {date}. Complétez votre passage à {plan} ({currency}).",
+    "text": "Votre forfait actuel se termine le {date}. Finalisez votre passage à {plan} ({currency}).",
     "source_hash": "998ba4ab"
   },
   "web.billing.currency_migration.complete_migration": {
-    "text": "Terminer la migration",
+    "text": "Finaliser la migration",
     "context": "Button to start checkout for the new currency plan",
     "source_hash": "fa794e0c"
   },
@@ -980,12 +980,12 @@
     "source_hash": "3ff06e41"
   },
   "web.billing.plan_switch_success": {
-    "text": "Passage au forfait {plan} effectué avec succès",
+    "text": "Passage au forfait {plan} réussi",
     "context": "Success message after plan change",
     "source_hash": "ab7c715c"
   },
   "web.billing.plan_unavailable_region_mismatch": {
-    "text": "Disponible uniquement dans votre région d'abonnement d'origine",
+    "text": "Disponible uniquement dans la région de votre abonnement d'origine",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
   },
@@ -1006,11 +1006,11 @@
     "source_hash": "d0c79bd4"
   },
   "web.billing.features.manage_orgs": {
-    "text": "Gestion de l'organisation",
+    "text": "Gestion des organisations",
     "source_hash": "780ad17c"
   },
   "web.billing.features.flexible_from_domain": {
-    "text": "Domaine d'expéditeur d'e-mail flexible",
+    "text": "Domaine d'expédition d'e-mail flexible",
     "source_hash": "607572c3"
   },
   "web.billing.features.unlimited_admins": {
@@ -1022,7 +1022,7 @@
     "source_hash": "5ba3ac9f"
   },
   "web.billing.overview.entitlements.flexible_from_domain": {
-    "text": "Domaine d'expéditeur d'e-mail flexible",
+    "text": "Domaine d'expédition d'e-mail flexible",
     "source_hash": "607572c3"
   },
   "web.billing.overview.entitlements.manage_orgs": {
@@ -1044,5 +1044,21 @@
   "web.billing.plans.reactivate": {
     "text": "Réactiver",
     "source_hash": "2dc7478f"
+  },
+  "web.billing.currency_migration.refund_failed_warning": {
+    "text": "Votre forfait précédent a été annulé, mais nous n'avons pas pu effectuer automatiquement le remboursement de votre période non utilisée. Veuillez contacter l'assistance pour obtenir votre remboursement. Vous devez toujours finaliser le paiement pour activer votre nouveau forfait.",
+    "source_hash": "a390c498"
+  },
+  "web.billing.currency_migration.refund_failed_continue": {
+    "text": "Continuer vers le paiement",
+    "source_hash": "eccdb8aa"
+  },
+  "web.billing.plans.per_year": {
+    "text": "/an",
+    "source_hash": "a2d5f1bc"
+  },
+  "web.billing.plans.billing_interval": {
+    "text": "Intervalle de facturation",
+    "source_hash": "3ce28209"
   }
 }

--- a/locales/content/fr_FR/workspace-branding.json
+++ b/locales/content/fr_FR/workspace-branding.json
@@ -4,7 +4,7 @@
     "source_hash": "ba42602c"
   },
   "web.branding.current_label_modelvalue_click_to_cycle_through_options": {
-    "text": "Courant {0} : {1}. Cliquez pour faire défiler les options.",
+    "text": "{0} actuel : {1}. Cliquez pour parcourir les options.",
     "source_hash": "84bf49e6"
   },
   "web.branding.use_setting": {
@@ -12,7 +12,7 @@
     "source_hash": "8a18d118"
   },
   "web.branding.font_family": {
-    "text": "Famille de polices",
+    "text": "Police",
     "source_hash": "f81339da"
   },
   "web.branding.corner_style": {
@@ -20,11 +20,11 @@
     "source_hash": "fcb3ecdf"
   },
   "web.branding.brand_color": {
-    "text": "Couleur de marque",
+    "text": "Couleur de la marque",
     "source_hash": "db3183e3"
   },
   "web.branding.preview_of_the_secret_link_page_for_recipients": {
-    "text": "Aperçu de la page du lien secret pour les destinataires",
+    "text": "Aperçu de la vue du destinataire lors de l'accès à votre lien sécurisé",
     "source_hash": "199c165f"
   },
   "web.branding.preview_and_customize": {
@@ -32,7 +32,7 @@
     "source_hash": "fc68a28c"
   },
   "web.branding.switch_to_safari_browser_view": {
-    "text": "Passer à la vue navigateur Safari",
+    "text": "Passer à la vue du navigateur Safari",
     "source_hash": "6e0fe791"
   },
   "web.branding.microsoft_edge": {
@@ -48,7 +48,7 @@
     "source_hash": "5cd54386"
   },
   "web.branding.switch_to_edge_browser_view": {
-    "text": "Passer à la vue navigateur Edge",
+    "text": "Passer à la vue du navigateur Edge",
     "source_hash": "a8fcd82d"
   },
   "web.branding.charactercount_500_characters": {
@@ -56,27 +56,27 @@
     "source_hash": "e36598ef"
   },
   "web.branding.example_pre_reveal_instructions": {
-    "text": "Utilisez votre téléphone pour scanner le code QR",
-    "source_hash": "99ecf59f"
+    "text": "ex. Utilisez votre téléphone pour scanner le code QR",
+    "source_hash": "9cf0caf8"
   },
   "web.branding.example_post_reveal_instructions": {
-    "text": "Contactez integration{'@'}exemple.com pour toute question",
-    "source_hash": "bee120a7"
+    "text": "ex. Contactez onboarding{'@'}example.com pour toute question",
+    "source_hash": "71749811"
   },
   "web.branding.these_instructions_will_be_shown_to_recipients_before": {
-    "text": "Ces instructions seront présentées aux destinataires avant la révélation du contenu confidentiel",
+    "text": "Ces instructions seront affichées aux destinataires avant qu'ils ne révèlent le contenu du secret",
     "source_hash": "9d5a6334"
   },
   "web.branding.these_instructions_will_be_shown_to_recipients_after": {
-    "text": "Ces instructions seront affichées aux destinataires après qu'ils auront révélé le secret",
+    "text": "Ces instructions seront affichées aux destinataires après qu'ils ont révélé le secret",
     "source_hash": "9f82bd94"
   },
   "web.branding.pre_reveal_instructions": {
-    "text": "Instructions pré-révélation",
+    "text": "Instructions avant révélation",
     "source_hash": "a299422e"
   },
   "web.branding.post_reveal_instructions": {
-    "text": "Instructions post-révélation",
+    "text": "Instructions après révélation",
     "source_hash": "72ecc23a"
   },
   "web.branding.instructions": {
@@ -84,15 +84,15 @@
     "source_hash": "934652dc"
   },
   "web.branding.logo_controls": {
-    "text": "Contrôles du logo",
+    "text": "Commandes du logo",
     "source_hash": "43e9a2d7"
   },
   "web.branding.click_to_upload_a_logo_with_recommendation": {
-    "text": "Cliquez pour gérer votre logo. Taille recommandée : 128x128 pixels. Taille de fichier maximale : 1 Mo. Formats pris en charge : PNG, JPG, SVG",
+    "text": "Cliquez pour gérer votre logo. Taille recommandée : 128x128 pixels. Taille maximale du fichier : 1 Mo. Formats pris en charge : PNG, JPG, SVG",
     "source_hash": "7bb92395"
   },
   "web.branding.upload_logo": {
-    "text": "Télécharger un logo",
+    "text": "Téléverser un logo",
     "source_hash": "c3330082"
   },
   "web.branding.loading_preview": {
@@ -100,7 +100,7 @@
     "source_hash": "c02130fa"
   },
   "web.branding.preview_how_recipients_will_see_your_secrets": {
-    "text": "Prévisualisez l'affichage des contenus confidentiels en testant le bouton « Consulter le contenu »",
+    "text": "Prévisualisez la façon dont les destinataires verront vos secrets en testant le bouton « Consulter le secret »",
     "source_hash": "3b58a297"
   },
   "web.branding.eye_icon": {
@@ -108,7 +108,7 @@
     "source_hash": "7f605d3c"
   },
   "web.branding.click_the_preview_image_below_to_update_your_logo": {
-    "text": "Cliquez sur l'aperçu ci-dessous pour modifier votre logo (minimum recommandé : 128x128 pixels, maximum : 1 Mo)",
+    "text": "Cliquez sur l'image d'aperçu ci-dessous pour mettre à jour votre logo (minimum 128x128 pixels recommandé, 1 Mo max.)",
     "source_hash": "77a19049"
   },
   "web.branding.image_icon": {
@@ -116,7 +116,7 @@
     "source_hash": "b0d64fcf"
   },
   "web.branding.use_the_controls_above_to_customize_brand_details": {
-    "text": "Utilisez les paramètres ci-dessus pour personnaliser la charte graphique et les instructions destinataires",
+    "text": "Utilisez les commandes ci-dessus pour personnaliser la couleur de la marque, les styles et les instructions destinées aux destinataires",
     "source_hash": "d6287134"
   },
   "web.branding.customization_icon": {
@@ -124,7 +124,7 @@
     "source_hash": "bde04d31"
   },
   "web.branding.you_have_unsaved_changes_are_you_sure": {
-    "text": "Vous avez des modifications non sauvegardées. En êtes-vous sûr ?",
+    "text": "Vous avez des modifications non enregistrées. Voulez-vous continuer ?",
     "source_hash": "184b6a83"
   },
   "web.branding.failed_to_load_brand_settings": {
@@ -132,15 +132,15 @@
     "source_hash": "a7a1575e"
   },
   "web.branding.this_is_an_interactive_preview_o": {
-    "text": "Ceci est un aperçu interactif de la façon dont les destinataires verront vos messages sécurisés. Vous pouvez : - Personnaliser les couleurs et les polices à l'aide des contrôles ci-dessus - Télécharger un logo (minimum 128x128 pixels recommandé, 1 Mo max) - Tester l'aperçu en utilisant le bouton « Voir le secret »",
+    "text": "Ceci est un aperçu interactif de la façon dont les destinataires verront vos messages sécurisés. Vous pouvez : - Personnaliser les couleurs et les polices à l'aide des commandes ci-dessus - Téléverser un logo (minimum 128x128 pixels recommandé, 1 Mo max.) - Tester l'aperçu avec le bouton « Consulter le secret »",
     "source_hash": "3d8b2c0d"
   },
   "web.branding.this_is_an_interactive_preview_of_how_recipients": {
-    "text": "Il s'agit d'un aperçu interactif de la façon dont les destinataires verront vos secrets. Vous pouvez : - Personnaliser les couleurs et les polices à l'aide des commandes ci-dessus - télécharger un logo (128x128 pixels minimum recommandés, 1MB maximum) - tester l'aperçu à l'aide du bouton \"Voir le secret\"",
+    "text": "Ceci est un aperçu interactif de la façon dont les destinataires verront vos messages sécurisés. Vous pouvez : - Personnaliser les couleurs et les polices à l'aide des commandes ci-dessus - Téléverser un logo (minimum 128x128 pixels recommandé, 1 Mo max.) - Tester l'aperçu avec le bouton « Consulter le secret »",
     "source_hash": "3d8b2c0d"
   },
   "web.branding.default_logo_icon": {
-    "text": "Kanji japonais '秘' (himitsu) signifiant 'secret' ou 'confidentiel'",
+    "text": "Kanji japonais « 秘 » (himitsu) signifiant « secret » ou « confidentiel »",
     "source_hash": "1e04ba2e"
   },
   "web.branding.powered_by_onetime_secret": {
@@ -176,7 +176,7 @@
     "source_hash": "f24ac447"
   },
   "web.branding.upgrade_to_customize": {
-    "text": "Mettez votre forfait à niveau pour personnaliser l'image de marque de ce domaine.",
+    "text": "Mettez à niveau votre forfait pour personnaliser la marque de ce domaine.",
     "source_hash": "9077bf79"
   },
   "web.branding.saved_successfully": {
@@ -184,7 +184,7 @@
     "source_hash": "9960c252"
   },
   "web.branding.keyhole_logo_icon": {
-    "text": "Icône de trou de serrure représentant un partage sécurisé et privé",
+    "text": "Icône de trou de serrure représentant un partage privé et sécurisé",
     "source_hash": "c868ac60"
   },
   "web.branding.secondary_color": {
@@ -208,7 +208,7 @@
     "source_hash": "6b5d30dc"
   },
   "web.branding.theme_presets": {
-    "text": "Préréglages de thème",
+    "text": "Thèmes prédéfinis",
     "source_hash": "931eeb74"
   },
   "web.branding.logo": {
@@ -220,7 +220,7 @@
     "source_hash": "95e15439"
   },
   "web.branding.logo_field_hint": {
-    "text": "Prévisualisez avant que vos modifications ne soient publiées.",
+    "text": "Prévisualisez avant la mise en ligne de vos modifications.",
     "source_hash": "e9e222fc"
   },
   "web.branding.logo_modal_title": {
@@ -228,7 +228,7 @@
     "source_hash": "5260dda5"
   },
   "web.branding.logo_modal_hint": {
-    "text": "PNG, JPG ou SVG. Recommandé 128x128px, jusqu'à 1 Mo.",
+    "text": "PNG, JPG ou SVG. 128x128 px recommandé, jusqu'à 1 Mo.",
     "source_hash": "75d00802"
   },
   "web.branding.logo_modal_save": {
@@ -244,7 +244,7 @@
     "source_hash": "ceed9fd5"
   },
   "web.branding.image_upload_drag_hint": {
-    "text": "ou glisser-déposer",
+    "text": "ou glissez-déposez",
     "source_hash": "6613b73c"
   },
   "web.branding.image_invalid_type": {
@@ -260,7 +260,7 @@
     "source_hash": "d94fa99a"
   },
   "web.branding.image_upload_failed": {
-    "text": "Une erreur s'est produite. Veuillez réessayer.",
+    "text": "Un problème est survenu. Veuillez réessayer.",
     "source_hash": "3ccd9d65"
   },
   "web.branding.undo": {
@@ -268,7 +268,7 @@
     "source_hash": "a8283ade"
   },
   "web.branding.low_contrast_text_bg_warning": {
-    "text": "Faible contraste texte/arrière-plan",
+    "text": "Contraste texte/arrière-plan faible",
     "source_hash": "1c676370"
   },
   "web.branding.path_simple": {
@@ -276,7 +276,7 @@
     "source_hash": "3fee95da"
   },
   "web.branding.path_match": {
-    "text": "Assortir à mon site",
+    "text": "Reproduire mon site",
     "source_hash": "776679cf"
   },
   "web.branding.path_advanced": {
@@ -288,7 +288,7 @@
     "source_hash": "7c9c0cca"
   },
   "web.branding.path_match_tag": {
-    "text": "Copier les paramètres d'un site existant.",
+    "text": "Copiez les paramètres d'un site existant.",
     "source_hash": "e4b0d1cd"
   },
   "web.branding.path_advanced_tag": {
@@ -320,19 +320,19 @@
     "source_hash": "bc79cdff"
   },
   "web.branding.paths_carryover_hint": {
-    "text": "Ceci est un aperçu en direct — vos modifications ne seront visibles par les visiteurs qu'après enregistrement.",
-    "source_hash": "cb4b82de"
+    "text": "Ceci est un aperçu en direct — vos modifications ne seront visibles par les visiteurs qu'après avoir cliqué sur Mettre à jour.",
+    "source_hash": "9a34df71"
   },
   "web.branding.coming_soon_match_blurb": {
-    "text": "Indiquez-nous votre site web et nous lirons ses couleurs et ses polices, puis comblerons l'écart en un clic.",
+    "text": "Indiquez-nous l'adresse de votre site web et nous en lirons les couleurs et les polices, puis comblerons l'écart en un clic.",
     "source_hash": "42c34cc1"
   },
   "web.branding.coming_soon_advanced_blurb": {
-    "text": "Modifiez directement les tokens {'@'}theme de Tailwind v4, ou collez votre propre feuille de style.",
+    "text": "Modifiez directement les jetons {'@'}theme de Tailwind v4, ou collez votre propre feuille de style.",
     "source_hash": "5a8473f5"
   },
   "web.branding.preview_recipient_page": {
-    "text": "Page destinataire",
+    "text": "Page du destinataire",
     "source_hash": "de8aa19f"
   },
   "web.branding.preview_badge": {
@@ -360,7 +360,7 @@
     "source_hash": "610fd42e"
   },
   "web.branding.tile_delivery_only": {
-    "text": "Livraison de messages sécurisés uniquement",
+    "text": "Distribution de messages sécurisés uniquement",
     "source_hash": "dc24dec2"
   },
   "web.branding.tile_no_create": {
@@ -368,7 +368,7 @@
     "source_hash": "17361d81"
   },
   "web.branding.recipient_page_content": {
-    "text": "Contenu de la page destinataire",
+    "text": "Contenu de la page du destinataire",
     "source_hash": "937733bd"
   },
   "web.branding.recipient_page_content_hint": {
@@ -380,7 +380,7 @@
     "source_hash": "090ed431"
   },
   "web.branding.tab_delivery": {
-    "text": "Livraison",
+    "text": "Distribution",
     "source_hash": "52bfe584"
   },
   "web.branding.delivery_language": {
@@ -396,7 +396,7 @@
     "source_hash": "7e1331f7"
   },
   "web.branding.delivery_reveal_instructions_hint": {
-    "text": "Affichées sur la page destinataire. Laissez vide pour utiliser le texte intégré dans la langue sélectionnée.",
+    "text": "Affichées sur la page du destinataire. Laissez vide pour utiliser le texte intégré dans la langue sélectionnée.",
     "source_hash": "51b9811d"
   },
   "web.branding.delivery_before_reveal": {
@@ -406,5 +406,57 @@
   "web.branding.delivery_after_reveal": {
     "text": "Après la révélation",
     "source_hash": "d5bfe7fd"
+  },
+  "web.branding.favicon": {
+    "text": "Favicon",
+    "source_hash": "42955289"
+  },
+  "web.branding.refresh_favicon": {
+    "text": "Actualiser le favicon depuis le domaine",
+    "source_hash": "7cc3d5dc"
+  },
+  "web.branding.refresh_favicon_hint": {
+    "text": "Récupérez à nouveau le favicon depuis votre domaine. La nouvelle icône apparaîtra sous peu.",
+    "source_hash": "ee007e44"
+  },
+  "web.branding.refresh_favicon_queued": {
+    "text": "Actualisation du favicon — la nouvelle icône apparaîtra sous peu.",
+    "source_hash": "6bf38e6e"
+  },
+  "web.branding.refresh_favicon_user_upload_hint": {
+    "text": "Vous avez téléversé un favicon personnalisé ; une icône récupérée ne le remplacera donc pas.",
+    "source_hash": "c22e1ed6"
+  },
+  "web.branding.upload_favicon": {
+    "text": "Téléverser un favicon",
+    "source_hash": "ceda39cb"
+  },
+  "web.branding.replace_favicon": {
+    "text": "Remplacer",
+    "source_hash": "95e15439"
+  },
+  "web.branding.remove_favicon": {
+    "text": "Supprimer le favicon",
+    "source_hash": "03693698"
+  },
+  "web.branding.favicon_field_hint": {
+    "text": "ICO, PNG ou SVG. Le téléversement remplace l'icône récupérée.",
+    "source_hash": "dfa0bfcb"
+  },
+  "web.branding.favicon_preview_alt": {
+    "text": "Favicon du domaine",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_title": {
+    "text": "Favicon du domaine",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_hint": {
+    "text": "ICO, PNG ou SVG. Jusqu'à 256 Ko. Remplace l'icône récupérée automatiquement.",
+    "source_hash": "c9eafc83"
+  },
+  "web.branding.favicon_modal_save": {
+    "text": "Enregistrer le favicon",
+    "source_hash": "c8a1566c"
   }
 }

--- a/locales/content/fr_FR/workspace-dashboard.json
+++ b/locales/content/fr_FR/workspace-dashboard.json
@@ -12,7 +12,7 @@
     "source_hash": "02b7b86b"
   },
   "web.dashboard.get_started_by_creating_your_first_secret": {
-    "text": "Commencez en créant votre premier message sécurisé",
+    "text": "Commencez par créer votre premier secret.",
     "source_hash": "e96db24d"
   },
   "web.dashboard.fetch_error_title": {

--- a/locales/content/fr_FR/workspace-domains.json
+++ b/locales/content/fr_FR/workspace-domains.json
@@ -4,7 +4,7 @@
     "source_hash": "c592a5c6"
   },
   "web.domains.view_domain_verification_status": {
-    "text": "Voir le statut de vérification du domaine",
+    "text": "Voir l'état de vérification du domaine",
     "source_hash": "23635e2d"
   },
   "web.domains.domain_already_in_organization": {
@@ -12,27 +12,27 @@
     "source_hash": "6e0d628f"
   },
   "web.domains.domain_in_other_organization": {
-    "text": "Ce domaine est déjà enregistré auprès d'une autre organisation. Veuillez contacter le support si vous pensez qu'il s'agit d'une erreur.",
+    "text": "Ce domaine est déjà enregistré auprès d'une autre organisation. Veuillez contacter l'assistance si vous pensez qu'il s'agit d'une erreur.",
     "source_hash": "7fae16a9"
   },
   "web.domains.domain_claimed_successfully": {
-    "text": "Domaine réclamé avec succès et ajouté à votre organisation",
+    "text": "Domaine revendiqué et ajouté à votre organisation avec succès",
     "source_hash": "d53e1ac1"
   },
   "web.domains.privacy_defaults_title": {
-    "text": "Valeurs par défaut de confidentialité",
+    "text": "Paramètres de confidentialité par défaut",
     "source_hash": "5bce069d"
   },
   "web.domains.privacy_defaults_description": {
-    "text": "Définissez les options de confidentialité par défaut pour les secrets créés sous ce domaine. Ces paramètres seront pré-remplis lors de la création de nouveaux secrets.",
+    "text": "Définissez les options de confidentialité par défaut pour les secrets créés sur ce domaine. Ces paramètres seront préremplis lors de la création de nouveaux secrets.",
     "source_hash": "1d98959c"
   },
   "web.domains.privacy_defaults": {
-    "text": "Valeurs par défaut de confidentialité",
+    "text": "Paramètres de confidentialité par défaut",
     "source_hash": "5bce069d"
   },
   "web.domains.privacy_defaults_icon": {
-    "text": "Icône des valeurs par défaut de confidentialité",
+    "text": "Icône des paramètres de confidentialité par défaut",
     "source_hash": "c6bef509"
   },
   "web.domains.default_ttl_label": {
@@ -40,7 +40,7 @@
     "source_hash": "ce3c65fe"
   },
   "web.domains.default_ttl_hint": {
-    "text": "Durée pendant laquelle les secrets doivent rester accessibles par défaut",
+    "text": "Durée pendant laquelle les secrets restent accessibles par défaut",
     "source_hash": "777b978d"
   },
   "web.domains.passphrase_required_label": {
@@ -56,11 +56,11 @@
     "source_hash": "682be64a"
   },
   "web.domains.notify_enabled_hint": {
-    "text": "Activer les notifications par e-mail par défaut lorsque les secrets sont consultés",
+    "text": "Activer par défaut les notifications par e-mail lorsque des secrets sont consultés",
     "source_hash": "3e16dd5f"
   },
   "web.domains.use_global_default": {
-    "text": "Utiliser la valeur par défaut globale",
+    "text": "Utiliser la valeur globale par défaut",
     "source_hash": "a83c91e4"
   },
   "web.domains.global_default": {
@@ -72,7 +72,7 @@
     "source_hash": "4850b174"
   },
   "web.domains.optional": {
-    "text": "Optionnel",
+    "text": "Facultatif",
     "source_hash": "59be7133"
   },
   "web.domains.enabled": {
@@ -108,7 +108,7 @@
     "source_hash": "c776f846"
   },
   "web.domains.switcher_locked": {
-    "text": "Changement de domaine non disponible sur cette page",
+    "text": "Le changement de domaine n'est pas disponible sur cette page",
     "source_hash": "ccd202fe"
   },
   "web.domains.scope_list_label": {
@@ -140,7 +140,7 @@
     "source_hash": "421b1e61"
   },
   "web.domains.control_whether_users_can_create_secret_links": {
-    "text": "Gérer les autorisations de création de liens sécurisés",
+    "text": "Déterminez si les utilisateurs peuvent créer des liens secrets depuis la page d'accueil de votre domaine",
     "source_hash": "a25d6fca"
   },
   "web.domains.homepage_access": {
@@ -148,7 +148,7 @@
     "source_hash": "00c89609"
   },
   "web.domains.and_status": {
-    "text": "et statut",
+    "text": "et état",
     "source_hash": "fe871d2c"
   },
   "web.domains.domain": {
@@ -156,7 +156,7 @@
     "source_hash": "79fa3361"
   },
   "web.domains.manage_and_configure_your_verified_custom_domains": {
-    "text": "Gestion des domaines personnalisés vérifiés",
+    "text": "Gérez et configurez vos domaines personnalisés vérifiés",
     "source_hash": "4e7f8311"
   },
   "web.domains.domains": {
@@ -168,7 +168,7 @@
     "source_hash": "8d39d1d0"
   },
   "web.domains.ssl_status": {
-    "text": "Statut SSL",
+    "text": "État SSL",
     "source_hash": "bec72630"
   },
   "web.domains.ssl_renews": {
@@ -184,7 +184,7 @@
     "source_hash": "5e812179"
   },
   "web.domains.domain_status": {
-    "text": "Statut du domaine",
+    "text": "État du domaine",
     "source_hash": "cd6b089b"
   },
   "web.domains.custom_domains_count": {
@@ -204,7 +204,7 @@
     "source_hash": "d1dc32ad"
   },
   "web.domains.return_to_domains_list": {
-    "text": "Retourner à la liste des domaines",
+    "text": "Revenir à la liste des domaines",
     "source_hash": "c7632413"
   },
   "web.domains.verify_domain": {
@@ -220,7 +220,7 @@
     "source_hash": "dc9ff9ec"
   },
   "web.domains.add_your_domain": {
-    "text": "Ajouter votre domaine",
+    "text": "Ajoutez votre domaine",
     "source_hash": "6b95c91c"
   },
   "web.domains.get_started_by_adding_a_custom_domain": {
@@ -236,23 +236,23 @@
     "source_hash": "b5549ff7"
   },
   "web.domains.in_order_to_connect_your_domain_youll_need_to_ha": {
-    "text": "Pour connecter votre domaine, vous devez disposer d'un enregistrement CNAME dans votre DNS qui pointe vers",
+    "text": "Pour connecter votre domaine, vous devez disposer dans votre DNS d'un enregistrement CNAME qui pointe",
     "source_hash": "c560710e"
   },
   "web.domains.if_you_already_have_a_cname_record_for_that_addr": {
-    "text": ". Si vous avez déjà un enregistrement CNAME pour cette adresse, veuillez le modifier pour qu'il pointe vers",
+    "text": "Si vous avez déjà un enregistrement CNAME pour cette adresse, modifiez-le pour qu'il pointe vers",
     "source_hash": "6f23e6db"
   },
   "web.domains.a_cname_record_is_not_allowed_instead_youll_need": {
-    "text": "), un enregistrement CNAME n'est pas autorisé. Vous devez donc créer un enregistrement A. Les détails sur la manière de procéder sont fournis plus bas dans la page.",
+    "text": "), un enregistrement CNAME n'est pas autorisé. Vous devrez plutôt créer un enregistrement A. La marche à suivre est détaillée plus bas sur cette page.",
     "source_hash": "76d5ab5f"
   },
   "web.domains.and_remove_any_other_a_aaaa_or_cname_records_for": {
-    "text": "et supprimez tous les autres enregistrements A, AAAA ou CNAME pour cette adresse exacte.",
+    "text": "et supprimez tout autre enregistrement A, AAAA ou CNAME pour cette adresse exacte.",
     "source_hash": "8978f5e7"
   },
   "web.domains.youll_need_to_complete_these_steps": {
-    "text": ", vous devrez compléter ces étapes.",
+    "text": ", vous devrez effectuer ces étapes.",
     "source_hash": "1d81c53e"
   },
   "web.domains.before_we_can_activate_links_for": {
@@ -260,31 +260,31 @@
     "source_hash": "aae43a00"
   },
   "web.domains.please_note_that_for_apex_domains": {
-    "text": "Veuillez noter que pour les domaines apex (ex.",
+    "text": "Veuillez noter que pour les domaines apex (par ex.,",
     "source_hash": "09a4b0ca"
   },
   "web.domains.verify_your_domain": {
-    "text": "Vérifier votre domaine",
+    "text": "Vérifiez votre domaine",
     "source_hash": "afa10517"
   },
   "web.domains.secrets_example_dot_com": {
-    "text": "secrets.exemple.com",
+    "text": "secrets.example.com",
     "source_hash": "9ea4d0d6"
   },
   "web.domains.customize_your_domain_branding": {
-    "text": "Personnalisez l'image de marque de votre domaine",
+    "text": "Personnalisez la marque de votre domaine",
     "source_hash": "e3f97ac1"
   },
   "web.domains.it_may_take_a_few_minutes_for_your_ssl_certifica": {
-    "text": "La propagation du certificat SSL peut prendre quelques minutes.",
+    "text": "L'activation de votre certificat SSL peut prendre quelques minutes.",
     "source_hash": "2e4f3179"
   },
   "web.domains.dns_changes_can_take_as_little_as_60_seconds_or_": {
-    "text": "La propagation DNS peut prendre de 60 secondes à 24 heures.",
+    "text": "La prise en compte des modifications DNS peut prendre de 60 secondes à 24 heures.",
     "source_hash": "38774290"
   },
   "web.domains.3_wait_for_propagation": {
-    "text": "3. Attendre la propagation",
+    "text": "3. Attendez la propagation",
     "source_hash": "3e6cf4e1"
   },
   "web.domains.value_2": {
@@ -308,7 +308,7 @@
     "source_hash": "baaddf70"
   },
   "web.domains.2_create_the_cname_record": {
-    "text": "2. Créer l'enregistrement CNAME",
+    "text": "2. Créez l'enregistrement CNAME",
     "source_hash": "781e438b"
   },
   "web.domains.value_0": {
@@ -324,19 +324,19 @@
     "source_hash": "baaddf70"
   },
   "web.domains.2_create_the_a_record": {
-    "text": "2. Créer l'enregistrement A",
+    "text": "2. Créez l'enregistrement A",
     "source_hash": "7b5aa1fc"
   },
   "web.domains.add_this_hostname_to_your_dns_configuration": {
-    "text": "Ajouter cette entrée DNS :",
+    "text": "Ajoutez ce nom d'hôte à votre configuration DNS :",
     "source_hash": "4bf09ead"
   },
   "web.domains.1_create_a_txt_record": {
-    "text": "1. Créer un enregistrement TXT",
+    "text": "1. Créez un enregistrement TXT",
     "source_hash": "62766ffd"
   },
   "web.domains.follow_these_steps_to_verify_domain_ownership_an": {
-    "text": "Suivez ces étapes pour valider la propriété du domaine :",
+    "text": "Suivez ces étapes pour vérifier la propriété du domaine et renforcer votre présence en ligne :",
     "source_hash": "a33f94d3"
   },
   "web.domains.domain_verification_steps": {
@@ -344,11 +344,11 @@
     "source_hash": "16dca977"
   },
   "web.domains.domain_verification_initiated_successfully": {
-    "text": "Validation du domaine initiée",
+    "text": "Vérification du domaine lancée avec succès.",
     "source_hash": "5969b924"
   },
   "web.domains.are_you_sure_you_want_to_remove_this_domain": {
-    "text": "Confirmer la suppression du domaine ? Cette action est irréversible.",
+    "text": "Voulez-vous vraiment supprimer ce domaine ? Cette action est irréversible.",
     "source_hash": "403c6d3b"
   },
   "web.domains.remove_domain": {
@@ -376,7 +376,7 @@
     "source_hash": "36dd9781"
   },
   "web.domains.global_defaults": {
-    "text": "Valeurs par défaut globales",
+    "text": "Valeurs globales par défaut",
     "source_hash": "4526107f"
   },
   "web.domains.edit_ttl": {
@@ -396,7 +396,7 @@
     "source_hash": "5932f0cb"
   },
   "web.domains.dns_widget_description": {
-    "text": "Utilisez l'outil ci-dessous pour détecter automatiquement votre fournisseur DNS et obtenir des instructions étape par étape pour configurer votre domaine.",
+    "text": "Utilisez l'outil ci-dessous pour détecter automatiquement votre fournisseur DNS et obtenir des instructions détaillées pour configurer votre domaine.",
     "source_hash": "91c1af2e"
   },
   "web.domains.email.title": {
@@ -408,7 +408,7 @@
     "source_hash": "6f38aa51"
   },
   "web.domains.email.config_description": {
-    "text": "Configurer l'envoi d'e-mails pour ce domaine",
+    "text": "Configurez l'envoi d'e-mails pour ce domaine",
     "source_hash": "1c275ff0"
   },
   "web.domains.email.provider_label": {
@@ -416,7 +416,7 @@
     "source_hash": "a7ed3f4e"
   },
   "web.domains.email.provider_placeholder": {
-    "text": "Sélectionner un fournisseur d'e-mail",
+    "text": "Sélectionnez un fournisseur d'e-mail",
     "source_hash": "63c8080c"
   },
   "web.domains.email.from_name_label": {
@@ -424,11 +424,11 @@
     "source_hash": "2f13b589"
   },
   "web.domains.email.from_name_placeholder": {
-    "text": "ex. Acme Sécurité",
+    "text": "ex. Acme Security",
     "source_hash": "03c0f138"
   },
   "web.domains.email.from_address_label": {
-    "text": "Adresse d'expédition",
+    "text": "Adresse de l'expéditeur",
     "source_hash": "60643eae"
   },
   "web.domains.email.from_address_placeholder": {
@@ -448,7 +448,7 @@
     "source_hash": "35322b5b"
   },
   "web.domains.email.discard_changes": {
-    "text": "Annuler les modifications",
+    "text": "Abandonner les modifications",
     "source_hash": "e07e053c"
   },
   "web.domains.email.provider_ses": {
@@ -464,11 +464,11 @@
     "source_hash": "ec994dad"
   },
   "web.domains.email.provider_inherit": {
-    "text": "Utiliser les paramètres par défaut du compte",
+    "text": "Utiliser les valeurs par défaut du compte",
     "source_hash": "f6fa84e7"
   },
   "web.domains.email.provider_ses_description": {
-    "text": "Nécessite la vérification du domaine via les enregistrements DKIM et SPF",
+    "text": "Nécessite la vérification du domaine via des enregistrements DKIM et SPF",
     "source_hash": "4df5aa60"
   },
   "web.domains.email.provider_sendgrid_description": {
@@ -488,7 +488,7 @@
     "source_hash": "34d2c307"
   },
   "web.domains.email.dns_records_description": {
-    "text": "Ajoutez les enregistrements DNS suivants pour vérifier votre domaine pour l'envoi d'e-mails.",
+    "text": "Ajoutez les enregistrements DNS suivants pour vérifier votre domaine en vue de l'envoi d'e-mails.",
     "source_hash": "9fa85863"
   },
   "web.domains.email.dns_column_type": {
@@ -504,11 +504,11 @@
     "source_hash": "8e37953d"
   },
   "web.domains.email.dns_optional_label": {
-    "text": "Recommended",
+    "text": "Recommandé",
     "source_hash": "d70604e8"
   },
   "web.domains.email.dns_optional_hint": {
-    "text": "This record is recommended but not required for verification. A DMARC policy at your organizational domain may already cover this subdomain.",
+    "text": "Cet enregistrement est recommandé, mais n'est pas requis pour la vérification. Une politique DMARC définie sur votre domaine organisationnel peut déjà couvrir ce sous-domaine.",
     "source_hash": "58e1a12b"
   },
   "web.domains.email.copy": {
@@ -528,7 +528,7 @@
     "source_hash": "331551b0"
   },
   "web.domains.email.status_failed": {
-    "text": "Échoué",
+    "text": "Échec",
     "source_hash": "031a8f0f"
   },
   "web.domains.email.revalidate": {
@@ -536,7 +536,7 @@
     "source_hash": "4918da12"
   },
   "web.domains.email.validating": {
-    "text": "Validation en cours...",
+    "text": "Validation...",
     "source_hash": "b28b48d5"
   },
   "web.domains.email.domain_verified": {
@@ -552,11 +552,11 @@
     "source_hash": "887dd486"
   },
   "web.domains.email.upgrade_to_configure": {
-    "text": "Passez à un forfait supérieur pour configurer l'envoi d'e-mails pour ce domaine.",
+    "text": "Mettez à niveau votre forfait pour configurer l'envoi d'e-mails pour ce domaine.",
     "source_hash": "16a876f7"
   },
   "web.domains.email.configure_email": {
-    "text": "Configurer l'e-mail",
+    "text": "Configurer les e-mails",
     "source_hash": "a48c0d40"
   },
   "web.domains.email.access_denied": {
@@ -564,7 +564,7 @@
     "source_hash": "d134ca02"
   },
   "web.domains.email.access_denied_description": {
-    "text": "Vous n'avez pas la permission de gérer les paramètres d'e-mail pour ce domaine. Contactez l'administrateur de votre organisation.",
+    "text": "Vous n'avez pas l'autorisation de gérer les paramètres d'e-mail de ce domaine. Contactez l'administrateur de votre organisation.",
     "source_hash": "32049ff0"
   },
   "web.domains.email.update_success": {
@@ -576,7 +576,7 @@
     "source_hash": "2ba99a91"
   },
   "web.domains.email.default_sender_notice": {
-    "text": "Les e-mails pour ce domaine sont actuellement envoyés depuis l'expéditeur global. Complétez la configuration des e-mails pour utiliser votre propre identité d'expéditeur.",
+    "text": "Les e-mails de ce domaine sont actuellement envoyés depuis l'expéditeur global. Terminez la configuration des e-mails pour utiliser votre propre identité d'expéditeur.",
     "source_hash": "ffcf39fb"
   },
   "web.domains.email.disabled_notice": {
@@ -588,7 +588,7 @@
     "source_hash": "dd1841d2"
   },
   "web.domains.email.badge_default_sender": {
-    "text": "Utilisation de l'expéditeur par défaut",
+    "text": "Expéditeur par défaut utilisé",
     "source_hash": "e1afb18f"
   },
   "web.domains.email.badge_verified": {
@@ -628,7 +628,7 @@
     "source_hash": "b3fef15b"
   },
   "web.domains.incoming.config_description": {
-    "text": "Permettre aux utilisateurs externes d'envoyer des secrets directement aux destinataires désignés sur ce domaine",
+    "text": "Permettez à des utilisateurs externes d'envoyer des secrets directement à des destinataires désignés sur ce domaine",
     "source_hash": "452ab4fe"
   },
   "web.domains.incoming.access_denied": {
@@ -636,11 +636,11 @@
     "source_hash": "d134ca02"
   },
   "web.domains.incoming.access_denied_description": {
-    "text": "Vous n'avez pas la permission de gérer les paramètres des secrets entrants pour ce domaine. Contactez l'administrateur de votre organisation.",
+    "text": "Vous n'avez pas l'autorisation de gérer les paramètres des secrets entrants pour ce domaine. Contactez l'administrateur de votre organisation.",
     "source_hash": "3e9d8adc"
   },
   "web.domains.incoming.upgrade_to_configure": {
-    "text": "Passez à un forfait supérieur pour configurer les secrets entrants pour ce domaine.",
+    "text": "Mettez à niveau votre forfait pour configurer les secrets entrants pour ce domaine.",
     "source_hash": "9dfdfeb5"
   },
   "web.domains.incoming.configure_incoming": {
@@ -648,7 +648,7 @@
     "source_hash": "eab52939"
   },
   "web.domains.incoming.not_configured_notice": {
-    "text": "Les secrets entrants ne sont pas configurés pour ce domaine. Ajoutez des destinataires pour permettre aux utilisateurs externes d'envoyer des secrets à votre équipe.",
+    "text": "Les secrets entrants ne sont pas configurés pour ce domaine. Ajoutez des destinataires pour permettre à des utilisateurs externes d'envoyer des secrets à votre équipe.",
     "source_hash": "dbc443a6"
   },
   "web.domains.incoming.disabled_notice": {
@@ -660,7 +660,7 @@
     "source_hash": "1e8568a8"
   },
   "web.domains.incoming.recipients_description": {
-    "text": "Définissez qui peut recevoir des secrets entrants sur ce domaine. Les destinataires recevront des notifications par e-mail lorsqu'un secret leur sera envoyé.",
+    "text": "Définissez qui peut recevoir des secrets entrants sur ce domaine. Les destinataires recevront des notifications par e-mail lorsqu'un secret leur est envoyé.",
     "source_hash": "026f9d9d"
   },
   "web.domains.incoming.add_recipient": {
@@ -684,7 +684,7 @@
     "source_hash": "18d67c99"
   },
   "web.domains.incoming.name_placeholder": {
-    "text": "ex. Équipe Sécurité",
+    "text": "ex. Équipe sécurité",
     "source_hash": "0c52400c"
   },
   "web.domains.incoming.empty_state": {
@@ -692,27 +692,27 @@
     "source_hash": "bc8c2058"
   },
   "web.domains.incoming.empty_state_description": {
-    "text": "Ajoutez des destinataires pour permettre aux utilisateurs externes d'envoyer des secrets à votre équipe.",
+    "text": "Ajoutez des destinataires pour permettre à des utilisateurs externes d'envoyer des secrets à votre équipe.",
     "source_hash": "2a647a40"
   },
   "web.domains.incoming.validation_invalid_email": {
-    "text": "Adresse e-mail invalide",
+    "text": "Adresse e-mail non valide",
     "source_hash": "4eaf1d80"
   },
   "web.domains.incoming.validation_duplicate_email": {
-    "text": "Cette adresse e-mail a déjà été ajoutée",
+    "text": "Cette adresse e-mail est déjà ajoutée",
     "source_hash": "f89de141"
   },
   "web.domains.incoming.validation_max_recipients": {
-    "text": "Maximum {max} destinataires autorisés",
+    "text": "Maximum de {max} destinataires autorisés",
     "source_hash": "e2585847"
   },
   "web.domains.incoming.validation_name_required": {
-    "text": "Le nom d'affichage est requis",
+    "text": "Le nom d'affichage est obligatoire",
     "source_hash": "c6892c89"
   },
   "web.domains.incoming.validation_email_required": {
-    "text": "L'adresse e-mail est requise",
+    "text": "L'adresse e-mail est obligatoire",
     "source_hash": "41381ba2"
   },
   "web.domains.incoming.save_changes": {
@@ -720,7 +720,7 @@
     "source_hash": "35322b5b"
   },
   "web.domains.incoming.discard_changes": {
-    "text": "Annuler les modifications",
+    "text": "Abandonner les modifications",
     "source_hash": "e07e053c"
   },
   "web.domains.incoming.update_success": {
@@ -764,7 +764,7 @@
     "source_hash": "c0b25980"
   },
   "web.domains.incoming.enabled_hint": {
-    "text": "Autoriser les utilisateurs externes à envoyer des secrets aux destinataires de ce domaine",
+    "text": "Permettre à des utilisateurs externes d'envoyer des secrets aux destinataires de ce domaine",
     "source_hash": "24aadd31"
   },
   "web.domains.incoming.public_url_label": {
@@ -784,11 +784,11 @@
     "source_hash": "2f396c3e"
   },
   "web.domains.incoming.remove_all_confirmation": {
-    "text": "Êtes-vous sûr de vouloir supprimer tous les destinataires ? Les utilisateurs externes ne pourront plus envoyer de secrets à ce domaine.",
+    "text": "Voulez-vous vraiment supprimer tous les destinataires ? Les utilisateurs externes ne pourront plus envoyer de secrets à ce domaine.",
     "source_hash": "06f9e551"
   },
   "web.domains.incoming.max_recipients_reached": {
-    "text": "Nombre maximum de destinataires atteint",
+    "text": "Nombre maximal de destinataires atteint",
     "source_hash": "ba659e54"
   },
   "web.domains.incoming.duplicate_recipient": {
@@ -796,7 +796,7 @@
     "source_hash": "ca598f6d"
   },
   "web.domains.incoming.save_will_replace_confirmation": {
-    "text": "L'enregistrement remplacera tous les destinataires existants par vos modifications en attente. Êtes-vous sûr ?",
+    "text": "L'enregistrement remplacera tous les destinataires existants par vos modifications en attente. Voulez-vous continuer ?",
     "source_hash": "f497862e"
   },
   "web.domains.incoming.delete_all_recipients": {
@@ -812,7 +812,7 @@
     "source_hash": "afd5751e"
   },
   "web.domains.sso.config_description": {
-    "text": "Configurer l'authentification unique pour ce domaine",
+    "text": "Configurez l'authentification unique pour ce domaine",
     "source_hash": "f37a0b47"
   },
   "web.domains.sso.access_denied": {
@@ -820,11 +820,11 @@
     "source_hash": "d134ca02"
   },
   "web.domains.sso.access_denied_description": {
-    "text": "Vous n'avez pas la permission de gérer les paramètres SSO pour ce domaine. Contactez l'administrateur de votre organisation.",
+    "text": "Vous n'avez pas l'autorisation de gérer les paramètres SSO de ce domaine. Contactez l'administrateur de votre organisation.",
     "source_hash": "db7fcfeb"
   },
   "web.domains.sso.upgrade_to_configure": {
-    "text": "Passez à un forfait supérieur pour configurer l'authentification unique pour ce domaine.",
+    "text": "Mettez à niveau votre forfait pour configurer l'authentification unique pour ce domaine.",
     "source_hash": "71fc0069"
   },
   "web.domains.sso.create_success": {
@@ -868,11 +868,11 @@
     "source_hash": "a9806710"
   },
   "web.domains.status_tooltip_unverified": {
-    "text": "Statut du domaine non vérifié — cliquez pour actualiser",
+    "text": "État du domaine non vérifié — cliquez pour actualiser",
     "source_hash": "a45aa76d"
   },
   "web.domains.last_check_failed": {
-    "text": "Échec de la dernière vérification",
+    "text": "La dernière vérification a échoué",
     "source_hash": "88b594b8"
   },
   "web.domains.last_check_failed_ago": {
@@ -888,7 +888,7 @@
     "source_hash": "6eae7d9c"
   },
   "web.domains.remove_domain_description": {
-    "text": "Supprimer définitivement ce domaine et toute sa configuration.",
+    "text": "Supprimez définitivement ce domaine et toute sa configuration.",
     "source_hash": "73946b9e"
   },
   "web.domains.add_access_denied": {
@@ -896,7 +896,7 @@
     "source_hash": "d134ca02"
   },
   "web.domains.add_access_denied_description": {
-    "text": "Vous n'avez pas la permission d'ajouter des domaines à cette organisation. Contactez l'administrateur de votre organisation.",
+    "text": "Vous n'avez pas l'autorisation d'ajouter des domaines à cette organisation. Contactez l'administrateur de votre organisation.",
     "source_hash": "25e035c6"
   },
   "web.domains.dns_widget_load_failed": {
@@ -904,7 +904,7 @@
     "source_hash": "5a1d8ab5"
   },
   "web.domains.dns_widget_not_available": {
-    "text": "Widget DNS non disponible",
+    "text": "Widget DNS indisponible",
     "source_hash": "4eed448b"
   },
   "web.domains.dns_widget_init_failed": {
@@ -920,7 +920,7 @@
     "source_hash": "77e07795"
   },
   "web.domains.unsaved_changes_confirmation": {
-    "text": "Vous avez des modifications non enregistrées. Êtes-vous sûr de vouloir quitter ?",
+    "text": "Vous avez des modifications non enregistrées. Voulez-vous vraiment quitter la page ?",
     "source_hash": "322380c1"
   },
   "web.domains.entitlement_required_owner": {
@@ -928,7 +928,7 @@
     "source_hash": "6de1f752"
   },
   "web.domains.entitlement_required_member": {
-    "text": "Cette fonctionnalité n'est pas disponible dans votre forfait actuel. Contactez le propriétaire de votre organisation.",
+    "text": "Cette fonctionnalité n'est pas disponible avec votre forfait actuel. Contactez le propriétaire de votre organisation.",
     "source_hash": "8f1688b2"
   },
   "web.domains.detail.manage": {
@@ -940,15 +940,15 @@
     "source_hash": "5697d03d"
   },
   "web.domains.detail.homepage_title": {
-    "text": "Secrets de la page d'accueil",
+    "text": "Secrets sur la page d'accueil",
     "source_hash": "6360f7ec"
   },
   "web.domains.detail.homepage_description": {
-    "text": "Autoriser l'accès public pour créer des secrets sur la page d'accueil de votre domaine",
+    "text": "Autoriser l'accès public à la création de secrets sur la page d'accueil de votre domaine",
     "source_hash": "209b3ded"
   },
   "web.domains.detail.brand_description": {
-    "text": "Logo, couleurs et image de marque personnalisée",
+    "text": "Logo, couleurs et personnalisation graphique",
     "source_hash": "69f7a9e8"
   },
   "web.domains.detail.sso_description": {
@@ -956,19 +956,19 @@
     "source_hash": "234e6150"
   },
   "web.domains.detail.email_description": {
-    "text": "Configuration de l'expéditeur d'e-mail personnalisé",
+    "text": "Configuration d'un expéditeur d'e-mail personnalisé",
     "source_hash": "7fcde01b"
   },
   "web.domains.detail.incoming_description": {
-    "text": "Paramètres des destinataires de secrets entrants",
+    "text": "Paramètres des destinataires des secrets entrants",
     "source_hash": "37c1fd6d"
   },
   "web.domains.detail.signup_description": {
-    "text": "Stratégie de validation d'inscription par domaine",
+    "text": "Stratégie de validation des inscriptions par domaine",
     "source_hash": "3c5a511f"
   },
   "web.domains.detail.signin_description": {
-    "text": "Configuration de la méthode de connexion par domaine",
+    "text": "Configuration des méthodes de connexion par domaine",
     "source_hash": "73e01e36"
   },
   "web.domains.email.dns_check_label": {
@@ -980,11 +980,11 @@
     "source_hash": "472590ae"
   },
   "web.domains.email.test_email_title": {
-    "text": "Tester la livraison des e-mails",
+    "text": "Tester la distribution des e-mails",
     "source_hash": "c1b3dee2"
   },
   "web.domains.email.test_email_hint": {
-    "text": "Envoyez-vous un e-mail de test en utilisant la configuration enregistrée. Fonctionne même lorsque la fonctionnalité n'est pas encore activée.",
+    "text": "Envoyez-vous un e-mail de test en utilisant la configuration enregistrée. Fonctionne même si la fonctionnalité n'est pas encore activée.",
     "source_hash": "33e876ad"
   },
   "web.domains.email.send_test": {
@@ -1004,7 +1004,7 @@
     "source_hash": "8ceb9588"
   },
   "web.domains.email.delivered_via": {
-    "text": "Livré via {provider}",
+    "text": "Distribué via {provider}",
     "source_hash": "f741959b"
   },
   "web.domains.incoming.feature_disabled": {
@@ -1024,7 +1024,7 @@
     "source_hash": "f72b58b5"
   },
   "web.domains.signin.config_description": {
-    "text": "Configurez les méthodes d'authentification de connexion pour ce domaine",
+    "text": "Configurez les méthodes d'authentification pour la connexion à ce domaine",
     "source_hash": "8efce428"
   },
   "web.domains.signin.access_denied": {
@@ -1036,7 +1036,7 @@
     "source_hash": "e242bb74"
   },
   "web.domains.signin.not_configured_notice": {
-    "text": "La configuration de connexion n'est pas encore définie pour ce domaine. Configurez des remplacements pour contrôler quelles méthodes d'authentification sont disponibles sur la page de connexion de ce domaine.",
+    "text": "La configuration de la connexion n'est pas encore définie pour ce domaine. Configurez des remplacements pour déterminer quelles méthodes d'authentification sont disponibles sur la page de connexion de ce domaine.",
     "source_hash": "cb788a2d"
   },
   "web.domains.signin.signin_enabled_label": {
@@ -1048,7 +1048,7 @@
     "source_hash": "5bbbe531"
   },
   "web.domains.signin.signin_enabled_hint": {
-    "text": "Indique si les utilisateurs peuvent se connecter sur ce domaine",
+    "text": "Détermine si les utilisateurs peuvent se connecter sur ce domaine",
     "source_hash": "57a92aee"
   },
   "web.domains.signin.restrict_to_label": {
@@ -1056,7 +1056,7 @@
     "source_hash": "edbec83f"
   },
   "web.domains.signin.restrict_to_hint": {
-    "text": "Restreignez ce domaine à une seule méthode d'authentification. Lorsqu'elle est définie, seule la méthode choisie est affichée sur la page de connexion.",
+    "text": "Restreignez ce domaine à une seule méthode d'authentification. Lorsque ce paramètre est défini, seule la méthode choisie s'affiche sur la page de connexion.",
     "source_hash": "682bc4c5"
   },
   "web.domains.signin.all_methods": {
@@ -1084,11 +1084,11 @@
     "source_hash": "cf7cd744"
   },
   "web.domains.signin.method_overrides_label": {
-    "text": "Remplacements de méthode",
+    "text": "Remplacements de méthodes",
     "source_hash": "5496cba6"
   },
   "web.domains.signin.method_overrides_hint": {
-    "text": "Activer ou désactiver des méthodes d'authentification individuelles pour ce domaine",
+    "text": "Activez ou désactivez individuellement les méthodes d'authentification pour ce domaine",
     "source_hash": "394e3878"
   },
   "web.domains.signin.mode_question": {
@@ -1096,11 +1096,11 @@
     "source_hash": "3694eb23"
   },
   "web.domains.signin.mode_any": {
-    "text": "N'importe quelle méthode disponible",
+    "text": "Toute méthode disponible",
     "source_hash": "23665425"
   },
   "web.domains.signin.mode_any_hint": {
-    "text": "Afficher toutes les méthodes disponibles sur ce domaine. Restreignez les méthodes individuelles ci-dessous.",
+    "text": "Afficher toutes les méthodes disponibles sur ce domaine. Restreignez chaque méthode ci-dessous.",
     "source_hash": "2f3dcba6"
   },
   "web.domains.signin.mode_one": {
@@ -1108,7 +1108,7 @@
     "source_hash": "601f5768"
   },
   "web.domains.signin.mode_one_hint": {
-    "text": "Restreindre la page de connexion à une seule méthode. Seules les méthodes disponibles sur ce domaine sont répertoriées.",
+    "text": "Restreindre la page de connexion à une seule méthode. Seules les méthodes disponibles sur ce domaine sont listées.",
     "source_hash": "58bde6d5"
   },
   "web.domains.signin.mode_disabled": {
@@ -1120,7 +1120,7 @@
     "source_hash": "8938f098"
   },
   "web.domains.signin.mode_disabled_notice": {
-    "text": "Les visiteurs de la page de connexion de ce domaine voient un avis indiquant que la connexion n'est pas disponible, avec un lien de retour vers la page d'accueil. Vos paramètres de méthode précédents sont conservés et restaurés lorsque vous réactivez la connexion.",
+    "text": "Les visiteurs de la page de connexion de ce domaine voient un message indiquant que la connexion n'est pas disponible, avec un lien vers la page d'accueil. Vos paramètres de méthodes précédents sont conservés et rétablis lorsque vous réactivez la connexion.",
     "source_hash": "1a04de18"
   },
   "web.domains.signin.methods_list_label": {
@@ -1128,7 +1128,7 @@
     "source_hash": "66fd133b"
   },
   "web.domains.signin.restrict_picker_hint": {
-    "text": "Seules les méthodes disponibles sur ce domaine sont répertoriées.",
+    "text": "Seules les méthodes disponibles sur ce domaine sont listées.",
     "source_hash": "c7a56f44"
   },
   "web.domains.signin.availability_always": {
@@ -1136,7 +1136,7 @@
     "source_hash": "0fda3772"
   },
   "web.domains.signin.availability_global_on": {
-    "text": "Suit la politique globale · Activé",
+    "text": "Suit la politique globale · Activée",
     "source_hash": "3844e6f7"
   },
   "web.domains.signin.availability_global_off": {
@@ -1156,11 +1156,11 @@
     "source_hash": "ed1a02fd"
   },
   "web.domains.signin.method_email_auth_blurb": {
-    "text": "Connexion par lien magique sans mot de passe",
+    "text": "Connexion sans mot de passe par lien magique",
     "source_hash": "7f776a85"
   },
   "web.domains.signin.method_webauthn_blurb": {
-    "text": "Données biométriques et clés de sécurité",
+    "text": "Biométrie et clés de sécurité",
     "source_hash": "7d6a7bd5"
   },
   "web.domains.signin.method_sso_blurb": {
@@ -1184,11 +1184,11 @@
     "source_hash": "22d78ad5"
   },
   "web.domains.signin.enabled_label": {
-    "text": "Activer la configuration de connexion",
+    "text": "Activer la configuration de la connexion",
     "source_hash": "dbd8e11c"
   },
   "web.domains.signin.enabled_hint": {
-    "text": "Lorsqu'elle est activée, ce domaine utilise les paramètres de connexion configurés ci-dessus",
+    "text": "Lorsque cette option est activée, ce domaine utilise les paramètres de connexion configurés ci-dessus",
     "source_hash": "6259f8a2"
   },
   "web.domains.signin.save_config": {
@@ -1196,7 +1196,7 @@
     "source_hash": "b2b158f2"
   },
   "web.domains.signin.update_success": {
-    "text": "Configuration de connexion mise à jour avec succès",
+    "text": "Configuration de la connexion mise à jour avec succès",
     "source_hash": "10ea50d8"
   },
   "web.domains.signin.reset_to_defaults": {
@@ -1204,7 +1204,7 @@
     "source_hash": "e240e635"
   },
   "web.domains.signin.reset_confirm": {
-    "text": "Réinitialiser la connexion aux valeurs par défaut globales ?",
+    "text": "Réinitialiser la connexion aux valeurs globales par défaut ?",
     "source_hash": "2c6bbc32"
   },
   "web.domains.signin.reset_keeps_sso": {
@@ -1216,15 +1216,15 @@
     "source_hash": "4bb21d8b"
   },
   "web.domains.signin.reset_success": {
-    "text": "Paramètres de connexion réinitialisés aux valeurs par défaut globales",
+    "text": "Paramètres de connexion réinitialisés aux valeurs globales par défaut",
     "source_hash": "0c364d89"
   },
   "web.domains.signup.title": {
-    "text": "Validation de l'inscription",
+    "text": "Validation des inscriptions",
     "source_hash": "2c34ac0a"
   },
   "web.domains.signup.config_description": {
-    "text": "Configurez la validation de l'inscription pour ce domaine",
+    "text": "Configurez la validation des inscriptions pour ce domaine",
     "source_hash": "e9c81e8a"
   },
   "web.domains.signup.access_denied": {
@@ -1232,19 +1232,19 @@
     "source_hash": "d134ca02"
   },
   "web.domains.signup.upgrade_to_configure": {
-    "text": "Mettez à niveau votre forfait pour configurer la validation de l'inscription par domaine.",
+    "text": "Mettez à niveau votre forfait pour configurer la validation des inscriptions par domaine.",
     "source_hash": "d87d6614"
   },
   "web.domains.signup.configure_signup": {
-    "text": "Configurer l'inscription",
+    "text": "Configurer les inscriptions",
     "source_hash": "e2697662"
   },
   "web.domains.signup.not_configured_notice": {
-    "text": "La validation de l'inscription n'est pas encore configurée pour ce domaine. Configurez une stratégie pour contrôler qui peut s'inscrire via ce domaine.",
+    "text": "La validation des inscriptions n'est pas encore configurée pour ce domaine. Configurez une stratégie pour déterminer qui peut s'inscrire via ce domaine.",
     "source_hash": "fc6c6eb8"
   },
   "web.domains.signup.site_signups_disabled_warning": {
-    "text": "Les inscriptions sont actuellement désactivées au niveau du site. Cette politique par domaine est configurée mais ne filtrera aucun trafic tant que les inscriptions ne seront pas activées au niveau du site.",
+    "text": "Les inscriptions sont actuellement désactivées au niveau du site. Cette politique par domaine est configurée, mais elle ne filtrera aucun trafic tant que les inscriptions du site ne seront pas activées.",
     "source_hash": "c0e59f86"
   },
   "web.domains.signup.strategy_label": {
@@ -1252,11 +1252,11 @@
     "source_hash": "a2e95531"
   },
   "web.domains.signup.strategy_description": {
-    "text": "Choisissez comment les adresses e-mail sont validées lorsque les utilisateurs s'inscrivent sur ce domaine.",
+    "text": "Choisissez comment les adresses e-mail sont validées lorsque des utilisateurs s'inscrivent sur ce domaine.",
     "source_hash": "8e232b03"
   },
   "web.domains.signup.network_validation_warning": {
-    "text": "Cette stratégie effectue des appels réseau pendant l'inscription, ce qui peut ajouter de la latence ou être bloqué par certains fournisseurs.",
+    "text": "Cette stratégie effectue des appels réseau lors de l'inscription, ce qui peut ajouter de la latence ou être bloqué par certains fournisseurs.",
     "source_hash": "53d4c266"
   },
   "web.domains.signup.allowed_domains_label": {
@@ -1272,7 +1272,7 @@
     "source_hash": "a379a6f6"
   },
   "web.domains.signup.invalid_domain": {
-    "text": "Veuillez saisir un domaine valide (par ex. example.com)",
+    "text": "Veuillez saisir un domaine valide (ex. example.com)",
     "source_hash": "16807983"
   },
   "web.domains.signup.domain_exists": {
@@ -1288,7 +1288,7 @@
     "source_hash": "db103925"
   },
   "web.domains.signup.enabled_hint": {
-    "text": "Lorsqu'elle est activée, les inscriptions sur ce domaine utilisent la stratégie ci-dessus au lieu de la politique globale.",
+    "text": "Lorsque cette option est activée, les inscriptions sur ce domaine utilisent la stratégie ci-dessus au lieu de la politique globale.",
     "source_hash": "99de2008"
   },
   "web.domains.signup.delete_config": {
@@ -1296,7 +1296,7 @@
     "source_hash": "a9a30c7f"
   },
   "web.domains.signup.delete_confirm": {
-    "text": "Supprimer la configuration de validation de l'inscription ? Les inscriptions reviendront à la politique globale.",
+    "text": "Supprimer la configuration de validation des inscriptions ? Les inscriptions reviendront à la politique globale.",
     "source_hash": "a8c9086e"
   },
   "web.domains.signup.save_config": {
@@ -1304,19 +1304,19 @@
     "source_hash": "b2b158f2"
   },
   "web.domains.signup.update_success": {
-    "text": "Validation de l'inscription mise à jour avec succès",
+    "text": "Validation des inscriptions mise à jour avec succès",
     "source_hash": "57a529ac"
   },
   "web.domains.signup.delete_success": {
-    "text": "Configuration de validation de l'inscription supprimée avec succès",
+    "text": "Configuration de la validation des inscriptions supprimée avec succès",
     "source_hash": "eb6add4d"
   },
   "web.domains.signup.domain_overrides_label": {
-    "text": "Remplacements de domaine",
+    "text": "Remplacements du domaine",
     "source_hash": "d25da3cd"
   },
   "web.domains.signup.domain_overrides_hint": {
-    "text": "Remplacer les paramètres d'inscription globaux pour ce domaine",
+    "text": "Remplacez les paramètres globaux d'inscription pour ce domaine",
     "source_hash": "53101057"
   },
   "web.domains.signup.signup_enabled_label": {
@@ -1324,7 +1324,7 @@
     "source_hash": "296ac66d"
   },
   "web.domains.signup.signup_enabled_hint": {
-    "text": "Remplacer l'activation de l'inscription pour ce domaine",
+    "text": "Remplacez l'activation ou non de l'inscription pour ce domaine",
     "source_hash": "2ee146b6"
   },
   "web.domains.signup.autoverify_label": {
@@ -1332,7 +1332,7 @@
     "source_hash": "4b103cd5"
   },
   "web.domains.signup.autoverify_hint": {
-    "text": "Remplacer la vérification automatique des nouveaux comptes sur ce domaine",
+    "text": "Remplacez la vérification automatique ou non des nouveaux comptes sur ce domaine",
     "source_hash": "63866ecd"
   },
   "web.domains.sso.test_success": {
@@ -1368,7 +1368,7 @@
     "source_hash": "3ba71f78"
   },
   "web.domains.add.echo_label": {
-    "text": "Vos liens secrets seront hébergés à",
+    "text": "Vos liens secrets seront hébergés à l'adresse",
     "source_hash": "ad60b17d"
   },
   "web.domains.add.apex_question": {
@@ -1384,11 +1384,11 @@
     "source_hash": "d70604e8"
   },
   "web.domains.add.no_wrong_answer": {
-    "text": "Il n'y a pas de mauvais choix — choisissez celui que votre équipe reconnaîtra.",
+    "text": "Il n'y a pas de mauvais choix — prenez celui que votre équipe reconnaîtra.",
     "source_hash": "a04f0086"
   },
   "web.domains.add.subdomains_label": {
-    "text": "Sous-domaines populaires",
+    "text": "Sous-domaines courants",
     "source_hash": "d6ee8eac"
   },
   "web.domains.add.root_group_label": {
@@ -1400,11 +1400,11 @@
     "source_hash": "9fbbe253"
   },
   "web.domains.add.root_domain_description": {
-    "text": "Cela pointe l'intégralité de {domain} vers nous — le site qui s'y trouve cesse de se résoudre — et nécessite un enregistrement A / ALIAS.",
+    "text": "Cela dirige l'intégralité de {domain} vers nous — le site qui s'y trouve cesse de se résoudre — et nécessite un enregistrement A / ALIAS.",
     "source_hash": "fae93847"
   },
   "web.domains.add.error_unrecognized_suffix": {
-    "text": "« .{0} » n'est pas une terminaison de domaine reconnue — vérifiez s'il y a une faute de frappe (par ex. {1}).",
+    "text": "« .{0} » n'est pas une terminaison de domaine reconnue — vérifiez qu'il n'y a pas de faute de frappe (par ex. {1}).",
     "source_hash": "4b90033d"
   },
   "web.domains.add.error_invalid_hostname": {
@@ -1428,7 +1428,7 @@
     "source_hash": "6c63df31"
   },
   "web.domains.detail.dns_description": {
-    "text": "Pointez votre domaine vers ce serveur avec un enregistrement CNAME",
+    "text": "Dirigez votre domaine vers ce serveur avec un enregistrement CNAME",
     "source_hash": "080f84f0"
   },
   "web.domains.dns.title": {
@@ -1436,7 +1436,7 @@
     "source_hash": "da78c35d"
   },
   "web.domains.dns.point_domain_intro": {
-    "text": "Pointez",
+    "text": "Dirigez",
     "source_hash": "2fc0c524"
   },
   "web.domains.dns.point_domain_outro": {
@@ -1444,15 +1444,15 @@
     "source_hash": "8d260c05"
   },
   "web.domains.dns.cname_heading": {
-    "text": "Créer un enregistrement CNAME",
+    "text": "Créez un enregistrement CNAME",
     "source_hash": "11aeef5a"
   },
   "web.domains.dns.apex_heading": {
-    "text": "Créer un enregistrement ALIAS ou ANAME",
+    "text": "Créez un enregistrement ALIAS ou ANAME",
     "source_hash": "41135375"
   },
   "web.domains.dns.apex_notice": {
-    "text": "Les domaines apex (racine) ne peuvent pas utiliser d'enregistrement CNAME. Utilisez plutôt l'enregistrement ALIAS ou ANAME de votre fournisseur DNS, ou pointez un enregistrement A vers l'adresse IP de votre serveur.",
+    "text": "Les domaines apex (racine) ne peuvent pas utiliser d'enregistrement CNAME. Utilisez plutôt l'enregistrement ALIAS ou ANAME de votre fournisseur DNS, ou dirigez un enregistrement A vers l'adresse IP de votre serveur.",
     "source_hash": "2d1c3298"
   },
   "web.domains.email.from_address_local_placeholder": {
@@ -1468,11 +1468,11 @@
     "source_hash": "974d159e"
   },
   "web.domains.homepage.option_private_title": {
-    "text": "Page d'atterrissage privée",
+    "text": "Page d'accueil privée",
     "source_hash": "dfd5bd1c"
   },
   "web.domains.homepage.option_private_description": {
-    "text": "Les visiteurs voient une page d'atterrissage privée sans formulaire interactif",
+    "text": "Les visiteurs voient une page d'accueil privée, sans formulaire interactif",
     "source_hash": "4d9aaf6f"
   },
   "web.domains.homepage.option_create_title": {
@@ -1488,11 +1488,11 @@
     "source_hash": "882997bf"
   },
   "web.domains.homepage.option_incoming_description": {
-    "text": "Les visiteurs peuvent envoyer des secrets à vos destinataires configurés",
+    "text": "Les visiteurs peuvent envoyer des secrets aux destinataires que vous avez configurés",
     "source_hash": "86bdaedb"
   },
   "web.domains.homepage.incoming_requires_recipients": {
-    "text": "Nécessite que les secrets entrants soient activés avec au moins un destinataire",
+    "text": "Nécessite l'activation des secrets entrants avec au moins un destinataire",
     "source_hash": "0462611d"
   },
   "web.domains.homepage.configure_recipients": {
@@ -1500,7 +1500,7 @@
     "source_hash": "1c3df8b4"
   },
   "web.domains.homepage.status_private": {
-    "text": "Page d'atterrissage privée",
+    "text": "Page d'accueil privée",
     "source_hash": "dfd5bd1c"
   },
   "web.domains.homepage.status_create": {
@@ -1512,7 +1512,7 @@
     "source_hash": "baa926b8"
   },
   "web.domains.homepage.status_incoming_unready": {
-    "text": "Entrants non prêts — affichage de la page d'atterrissage privée",
+    "text": "Secrets entrants non prêts — la page d'accueil privée est affichée",
     "source_hash": "a5cc237c"
   },
   "web.domains.homepage.badge_incoming": {
@@ -1524,7 +1524,7 @@
     "source_hash": "4eac9f45"
   },
   "web.domains.homepage.homepage_uses_incoming_warning": {
-    "text": "La page d'accueil de ce domaine présente actuellement le formulaire de secrets entrants. Désactiver les secrets entrants ou supprimer tous les destinataires fera basculer la page d'accueil vers une page d'atterrissage privée jusqu'à ce que les secrets entrants soient à nouveau prêts.",
+    "text": "La page d'accueil de ce domaine présente actuellement le formulaire de secrets entrants. Désactiver les secrets entrants ou supprimer tous les destinataires basculera la page d'accueil vers une page d'accueil privée jusqu'à ce que les secrets entrants soient de nouveau prêts.",
     "source_hash": "cc0d4997"
   },
   "web.domains.signin.effective_status_label": {
@@ -1532,7 +1532,7 @@
     "source_hash": "d8b884c3"
   },
   "web.domains.signin.dormant_notice": {
-    "text": "La connexion est désactivée à l'échelle de l'espace de travail ; elle est donc indisponible sur tous les domaines. Vos paramètres ici sont conservés et prennent effet lorsque la connexion de l'espace de travail est réactivée.",
+    "text": "La connexion est désactivée pour l'ensemble de l'espace de travail ; elle est donc indisponible sur tous les domaines. Vos paramètres sont conservés ici et prendront effet lorsque la connexion sera réactivée pour l'espace de travail.",
     "source_hash": "723d35dc"
   },
   "web.domains.signup.effective_status_label": {
@@ -1540,7 +1540,7 @@
     "source_hash": "115ab21b"
   },
   "web.domains.signup.dormant_notice": {
-    "text": "Les inscriptions sont désactivées à l'échelle de l'espace de travail ; elles sont donc indisponibles sur tous les domaines. Vos paramètres ici sont conservés et prennent effet lorsque les inscriptions de l'espace de travail sont réactivées.",
+    "text": "Les inscriptions sont désactivées pour l'ensemble de l'espace de travail ; elles sont donc indisponibles sur tous les domaines. Vos paramètres sont conservés ici et prendront effet lorsque les inscriptions seront réactivées pour l'espace de travail.",
     "source_hash": "49faefe4"
   }
 }

--- a/locales/content/fr_FR/workspace-organizations.json
+++ b/locales/content/fr_FR/workspace-organizations.json
@@ -52,7 +52,7 @@
     "source_hash": "98a583b4"
   },
   "web.organizations.create_organization_description": {
-    "text": "Créer un nouvel espace de travail",
+    "text": "Créez un nouvel espace de travail",
     "source_hash": "6ac2b5fc"
   },
   "web.organizations.create": {
@@ -80,7 +80,7 @@
     "source_hash": "526e0087"
   },
   "web.organizations.description_placeholder": {
-    "text": "À quoi sert cette organisation ?",
+    "text": "À quoi sert cette organisation ?",
     "source_hash": "27d7edae"
   },
   "web.organizations.contact_email": {
@@ -88,11 +88,11 @@
     "source_hash": "513332d3"
   },
   "web.organizations.contact_email_help": {
-    "text": "Contact principal pour les notifications de facturation et d'administration",
+    "text": "Contact principal pour la facturation et les notifications administratives",
     "source_hash": "ee81c03d"
   },
   "web.organizations.select_organization": {
-    "text": "Sélectionner un espace de travail",
+    "text": "Sélectionnez un espace de travail",
     "source_hash": "70a8ce66"
   },
   "web.organizations.switcher_locked": {
@@ -116,11 +116,11 @@
     "source_hash": "03b30208"
   },
   "web.organizations.organization_information": {
-    "text": "Informations sur l'organisation",
+    "text": "Informations de l'organisation",
     "source_hash": "85274cee"
   },
   "web.organizations.created": {
-    "text": "Créé",
+    "text": "Créée",
     "source_hash": "d70b9e24"
   },
   "web.organizations.last_updated": {
@@ -164,11 +164,11 @@
     "source_hash": "8a131415"
   },
   "web.organizations.billing_coming_soon": {
-    "text": "Intégration de facturation bientôt disponible",
+    "text": "Intégration de la facturation bientôt disponible",
     "source_hash": "d3e0ec75"
   },
   "web.organizations.billing_coming_soon_description": {
-    "text": "La gestion unifiée de la facturation et des abonnements sera disponible dans une version future.",
+    "text": "La facturation unifiée et la gestion des abonnements seront disponibles dans une prochaine version.",
     "source_hash": "8836108f"
   },
   "web.organizations.about_title": {
@@ -176,15 +176,15 @@
     "source_hash": "2f3e2ad8"
   },
   "web.organizations.about_description": {
-    "text": "Les organisations fournissent une facturation et une administration unifiées pour une gestion centralisée.",
+    "text": "Les organisations offrent une facturation et une administration unifiées pour une gestion centralisée.",
     "source_hash": "910f97a8"
   },
   "web.organizations.single_user_info_title": {
-    "text": "Gérer votre organisation",
+    "text": "Gérez votre organisation",
     "source_hash": "810a6c86"
   },
   "web.organizations.single_user_info_description": {
-    "text": "Mettez à jour le nom de votre entreprise et les détails de l'organisation ici. Ces informations aident à personnaliser votre compte et peuvent être utilisées pour les fonctionnalités de marque à l'avenir.",
+    "text": "Mettez à jour ici le nom de votre entreprise et les détails de votre organisation. Ces informations aident à personnaliser votre compte et pourront servir aux fonctionnalités de personnalisation graphique à l'avenir.",
     "source_hash": "96b2e4b5"
   },
   "web.organizations.getting_started_title": {
@@ -192,11 +192,11 @@
     "source_hash": "2871e738"
   },
   "web.organizations.getting_started_description": {
-    "text": "Créez votre première organisation pour gérer les informations de votre entreprise et préparer les futures fonctionnalités de marque.",
+    "text": "Créez votre première organisation pour gérer les informations de votre entreprise et préparer les futures fonctionnalités de personnalisation graphique.",
     "source_hash": "0487f33a"
   },
   "web.organizations.page_description": {
-    "text": "Gérez vos organisations et membres d'équipe",
+    "text": "Gérez vos organisations et les membres de votre équipe",
     "source_hash": "2d026be4"
   },
   "web.organizations.tabs.general": {
@@ -204,7 +204,7 @@
     "source_hash": "74a883a0"
   },
   "web.organizations.tabs.company_branding": {
-    "text": "Image de marque de l'entreprise",
+    "text": "Personnalisation de l'entreprise",
     "source_hash": "7ecc5d35"
   },
   "web.organizations.tabs.members": {
@@ -240,7 +240,7 @@
     "source_hash": "54b2edc7"
   },
   "web.organizations.delete_organization_confirm_message": {
-    "text": "Êtes-vous sûr de vouloir supprimer {name} ? Cette action est irréversible.",
+    "text": "Voulez-vous vraiment supprimer {name} ? Cette action est irréversible.",
     "source_hash": "db7e1f9d"
   },
   "web.organizations.delete_error": {
@@ -284,7 +284,7 @@
     "source_hash": "14736a2e"
   },
   "web.organizations.members.joined": {
-    "text": "A rejoint",
+    "text": "A rejoint le",
     "source_hash": "69318b0c"
   },
   "web.organizations.members.actions": {
@@ -292,11 +292,11 @@
     "source_hash": "ff8059dc"
   },
   "web.organizations.members.no_members": {
-    "text": "Aucun membre pour le moment. Invitez des membres d'équipe pour commencer.",
+    "text": "Aucun membre pour l'instant. Invitez des membres d'équipe pour commencer.",
     "source_hash": "6cbc5271"
   },
   "web.organizations.members.no_members_description": {
-    "text": "Cette organisation n'a pas encore de membres.",
+    "text": "Cette organisation n'a encore aucun membre.",
     "source_hash": "61dd2085"
   },
   "web.organizations.members.role_updated": {
@@ -308,19 +308,19 @@
     "source_hash": "17d5ca66"
   },
   "web.organizations.members.member_removed": {
-    "text": "Membre supprimé de l'organisation",
+    "text": "Membre retiré de l'organisation",
     "source_hash": "210a187b"
   },
   "web.organizations.members.member_remove_error": {
-    "text": "Échec de la suppression du membre",
+    "text": "Échec du retrait du membre",
     "source_hash": "1cff79b7"
   },
   "web.organizations.members.remove_member_title": {
-    "text": "Supprimer le membre",
+    "text": "Retirer le membre",
     "source_hash": "2b98b194"
   },
   "web.organizations.members.remove_member_confirm": {
-    "text": "Êtes-vous sûr de vouloir supprimer {name} de cette organisation ?",
+    "text": "Voulez-vous vraiment retirer {name} de cette organisation ?",
     "source_hash": "36695d98"
   },
   "web.organizations.members.cannot_change_own_role": {
@@ -328,15 +328,15 @@
     "source_hash": "0d874f75"
   },
   "web.organizations.members.cannot_remove_self": {
-    "text": "Vous ne pouvez pas vous retirer de l'organisation",
+    "text": "Vous ne pouvez pas vous retirer vous-même de l'organisation",
     "source_hash": "ab358307"
   },
   "web.organizations.members.cannot_remove_owner": {
-    "text": "Vous ne pouvez pas supprimer le propriétaire de l'organisation",
+    "text": "Vous ne pouvez pas retirer le propriétaire de l'organisation",
     "source_hash": "c92ed0f4"
   },
   "web.organizations.members.insufficient_permissions": {
-    "text": "Vous n'avez pas la permission de gérer les membres",
+    "text": "Vous n'avez pas l'autorisation de gérer les membres",
     "source_hash": "d6239f33"
   },
   "web.organizations.members.roles.owner": {
@@ -364,7 +364,7 @@
     "source_hash": "0ddca91a"
   },
   "web.organizations.invitations.title": {
-    "text": "Invitations d'organisation",
+    "text": "Invitations à l'organisation",
     "source_hash": "0289d92d"
   },
   "web.organizations.invitations.invite_member": {
@@ -388,7 +388,7 @@
     "source_hash": "09bf25ef"
   },
   "web.organizations.invitations.email_placeholder": {
-    "text": "membre{'@'}exemple.com",
+    "text": "membre{'@'}example.com",
     "source_hash": "7fd425f7"
   },
   "web.organizations.invitations.role": {
@@ -436,19 +436,19 @@
     "source_hash": "c7a6f156"
   },
   "web.organizations.invitations.invited_at": {
-    "text": "Invité",
+    "text": "Invité le",
     "source_hash": "63b17bec"
   },
   "web.organizations.invitations.expires_at": {
-    "text": "Expire",
+    "text": "Expire le",
     "source_hash": "f6725f3a"
   },
   "web.organizations.invitations.resent_count": {
-    "text": "Renvoyé {count} fois",
+    "text": "Renvoyée {count} fois",
     "source_hash": "e71d1c6d"
   },
   "web.organizations.invitations.resent_count_plural": {
-    "text": "Renvoyé {count} fois",
+    "text": "Renvoyée {count} fois",
     "source_hash": "e58d803d"
   },
   "web.organizations.invitations.status.pending": {
@@ -456,19 +456,19 @@
     "source_hash": "331551b0"
   },
   "web.organizations.invitations.status.accepted": {
-    "text": "Accepté",
+    "text": "Acceptée",
     "source_hash": "a00fb0c5"
   },
   "web.organizations.invitations.status.declined": {
-    "text": "Décliné",
+    "text": "Refusée",
     "source_hash": "dce083a2"
   },
   "web.organizations.invitations.status.expired": {
-    "text": "Expiré",
+    "text": "Expirée",
     "source_hash": "424a2551"
   },
   "web.organizations.invitations.status.revoked": {
-    "text": "Révoqué",
+    "text": "Révoquée",
     "source_hash": "f6f738d0"
   },
   "web.organizations.invitations.roles.member": {
@@ -484,7 +484,7 @@
     "source_hash": "ce7cfeaf"
   },
   "web.organizations.invitations.decline_invitation": {
-    "text": "Décliner l'invitation",
+    "text": "Refuser l'invitation",
     "source_hash": "f6e06ada"
   },
   "web.organizations.invitations.invitation_details": {
@@ -508,7 +508,7 @@
     "source_hash": "3ecc8b0f"
   },
   "web.organizations.invitations.decline_success": {
-    "text": "Invitation déclinée",
+    "text": "Invitation refusée",
     "source_hash": "31bffdcb"
   },
   "web.organizations.invitations.decline_error": {
@@ -520,7 +520,7 @@
     "source_hash": "b72770d7"
   },
   "web.organizations.invitations.invalid_token": {
-    "text": "Invitation invalide ou expirée",
+    "text": "Invitation non valide ou expirée",
     "source_hash": "6c0fc3de"
   },
   "web.organizations.invitations.must_sign_in": {
@@ -560,11 +560,11 @@
     "source_hash": "ced67718"
   },
   "web.organizations.invitations.email_mismatch_title": {
-    "text": "Compte différent connecté",
+    "text": "Un autre compte est connecté",
     "source_hash": "6516362a"
   },
   "web.organizations.invitations.email_mismatch_body": {
-    "text": "Cette invitation est pour {invitedEmail}. Vous êtes actuellement connecté en tant que {currentEmail}.",
+    "text": "Cette invitation est destinée à {invitedEmail}. Vous êtes actuellement connecté en tant que {currentEmail}.",
     "source_hash": "78a6f301"
   },
   "web.organizations.invitations.continue_as_invited_email": {
@@ -588,7 +588,7 @@
     "source_hash": "5db5c812"
   },
   "web.organizations.sso.description": {
-    "text": "Configurez le SSO pour permettre aux membres de se connecter avec le fournisseur d'identité de votre organisation",
+    "text": "Configurez le SSO pour permettre aux membres de se connecter via le fournisseur d'identité de votre organisation",
     "source_hash": "464f0a8b"
   },
   "web.organizations.sso.provider_type": {
@@ -656,11 +656,11 @@
     "source_hash": "9a638e9c"
   },
   "web.organizations.sso.allowed_domains": {
-    "text": "Domaines e-mail autorisés",
+    "text": "Domaines d'e-mail autorisés",
     "source_hash": "0295ad71"
   },
   "web.organizations.sso.allowed_domains_hint": {
-    "text": "Seuls les utilisateurs avec des adresses e-mail de ces domaines peuvent se connecter. Laissez vide pour autoriser tous les domaines.",
+    "text": "Seuls les utilisateurs disposant d'une adresse e-mail sur ces domaines peuvent se connecter. Laissez vide pour autoriser tous les domaines.",
     "source_hash": "1775e874"
   },
   "web.organizations.sso.domain_placeholder": {
@@ -668,11 +668,11 @@
     "source_hash": "e4420764"
   },
   "web.organizations.sso.invalid_domain": {
-    "text": "Veuillez entrer un domaine valide (ex. example.com)",
+    "text": "Veuillez saisir un domaine valide (ex. example.com)",
     "source_hash": "16807983"
   },
   "web.organizations.sso.domain_exists": {
-    "text": "Ce domaine est déjà dans la liste",
+    "text": "Ce domaine figure déjà dans la liste",
     "source_hash": "3fccb721"
   },
   "web.organizations.sso.remove_domain": {
@@ -684,7 +684,7 @@
     "source_hash": "d10d0801"
   },
   "web.organizations.sso.enabled_hint": {
-    "text": "Lorsqu'il est activé, les membres de l'organisation peuvent se connecter avec ce fournisseur SSO",
+    "text": "Lorsque cette option est activée, les membres de l'organisation peuvent se connecter via ce fournisseur SSO",
     "source_hash": "d7da2fa2"
   },
   "web.organizations.sso.save_config": {
@@ -696,7 +696,7 @@
     "source_hash": "9ac1ac7b"
   },
   "web.organizations.sso.delete_confirm": {
-    "text": "Êtes-vous sûr ? Cela désactivera le SSO pour votre organisation.",
+    "text": "Voulez-vous continuer ? Cela désactivera le SSO pour votre organisation.",
     "source_hash": "5b3f5b9d"
   },
   "web.organizations.sso.load_error": {
@@ -728,7 +728,7 @@
     "source_hash": "c02977b0"
   },
   "web.organizations.sso.test_connection_hint": {
-    "text": "Vérifier que le fournisseur d'identité est accessible (ne valide pas les identifiants)",
+    "text": "Vérifiez que le fournisseur d'identité est joignable (ne valide pas les identifiants)",
     "source_hash": "22a23b68"
   },
   "web.organizations.sso.test_button": {
@@ -760,11 +760,11 @@
     "source_hash": "84aebc69"
   },
   "web.organizations.sso.domain_sso_title": {
-    "text": "SSO par domaine",
+    "text": "SSO du domaine",
     "source_hash": "13161464"
   },
   "web.organizations.sso.domain_sso_description": {
-    "text": "Configurer le SSO pour chaque domaine vérifié",
+    "text": "Configurez le SSO pour chaque domaine vérifié",
     "source_hash": "af5b799e"
   },
   "web.organizations.sso.provider_type_locked_hint": {
@@ -808,11 +808,11 @@
     "source_hash": "52f73c8a"
   },
   "api.organizations.invitations.errors.email_required": {
-    "text": "L'adresse e-mail est requise",
+    "text": "L'adresse e-mail est obligatoire",
     "source_hash": "aae92911"
   },
   "api.organizations.invitations.errors.email_invalid": {
-    "text": "Format d'e-mail non valide",
+    "text": "Format d'adresse e-mail non valide",
     "source_hash": "0bcecf66"
   },
   "api.organizations.invitations.errors.role_invalid": {
@@ -852,7 +852,7 @@
     "source_hash": "8dc96729"
   },
   "api.organizations.invitations.errors.accept_token_required": {
-    "text": "Le jeton est requis",
+    "text": "Un jeton est requis",
     "source_hash": "6c718161"
   },
   "api.organizations.invitations.errors.accept_organization_gone": {
@@ -888,11 +888,11 @@
     "source_hash": "9191d915"
   },
   "web.organizations.default_org_delete_notice_before": {
-    "text": "Il s'agit de votre organisation par défaut, qui ne peut pas être supprimée depuis le tableau de bord. Pour la supprimer, veuillez nous contacter via le",
+    "text": "Il s'agit de votre organisation par défaut ; elle ne peut pas être supprimée depuis le tableau de bord. Pour la supprimer, contactez-nous via le",
     "source_hash": "e203607d"
   },
   "web.organizations.default_org_delete_notice_link": {
-    "text": "formulaire de retour d'information",
+    "text": "formulaire de commentaires",
     "source_hash": "94645a9e"
   },
   "web.organizations.default_org_delete_notice_after": {
@@ -912,7 +912,7 @@
     "source_hash": "ec8314da"
   },
   "web.organizations.leave_organization_confirm_message": {
-    "text": "Voulez-vous vraiment quitter {name} ? Vous aurez besoin d'une nouvelle invitation pour la rejoindre.",
+    "text": "Voulez-vous vraiment quitter {name} ? Une nouvelle invitation sera nécessaire pour la rejoindre.",
     "source_hash": "e21c5fec"
   },
   "web.organizations.leave_organization_success": {
@@ -988,7 +988,7 @@
     "source_hash": "26cdb6b8"
   },
   "web.organizations.sso.view_discovery_document": {
-    "text": "Afficher le document de découverte",
+    "text": "Voir le document de découverte",
     "source_hash": "513bda60"
   },
   "web.organizations.sso.callback_url": {
@@ -1004,15 +1004,15 @@
     "source_hash": "b3a3f694"
   },
   "web.organizations.sso.enforce_sso_only_hint": {
-    "text": "Exigez le SSO pour toutes les connexions sur ce domaine. Lorsque cette option est activée, l'authentification par mot de passe est désactivée.",
+    "text": "Exiger le SSO pour toutes les connexions sur ce domaine. Lorsque cette option est activée, l'authentification par mot de passe est désactivée.",
     "source_hash": "19432210"
   },
   "web.organizations.sso.grant_org_scope": {
-    "text": "Accorder l'accès à toute l'organisation",
+    "text": "Accorder un accès à toute l'organisation",
     "source_hash": "2070cef2"
   },
   "web.organizations.sso.grant_org_scope_hint": {
-    "text": "Les nouveaux membres qui rejoignent via le SSO de ce domaine se verront accorder l'accès à tous les domaines de l'organisation. Les membres existants ne sont pas affectés. Lorsque cette option est désactivée (par défaut), les nouveaux membres ne peuvent accéder qu'à ce domaine.",
+    "text": "Les nouveaux membres qui rejoignent via le SSO de ce domaine se verront accorder l'accès à tous les domaines de l'organisation. Les membres existants ne sont pas affectés. Lorsque cette option est désactivée (par défaut), les nouveaux membres n'ont accès qu'à ce domaine.",
     "source_hash": "2ac9f345"
   },
   "web.organizations.sso.no_domains": {
@@ -1034,5 +1034,153 @@
   "web.organizations.create_workspace": {
     "text": "Créer un espace de travail",
     "source_hash": "c63c14cf"
+  },
+  "web.organizations.organization_id": {
+    "text": "ID de l'organisation",
+    "source_hash": "1f466322"
+  },
+  "web.organizations.organization_id_hint": {
+    "text": "Utilisez cet identifiant lorsque vous contactez l'assistance ou que vous limitez des requêtes d'API à cette organisation. Ce n'est pas un identifiant de connexion.",
+    "source_hash": "29549b3a"
+  },
+  "web.organizations.audit.title": {
+    "text": "Activité des secrets",
+    "source_hash": "6d6d41f3"
+  },
+  "web.organizations.audit.description": {
+    "text": "Piste d'audit des événements de création et d'accès aux secrets enregistrés pour cette organisation.",
+    "source_hash": "553c564b"
+  },
+  "web.organizations.audit.country_unknown": {
+    "text": "Inconnu",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.empty_title": {
+    "text": "Aucune activité pour l'instant",
+    "source_hash": "0a12b92c"
+  },
+  "web.organizations.audit.empty_description": {
+    "text": "Les événements de création et d'accès aux secrets apparaîtront ici au fur et à mesure que votre équipe partagera des secrets.",
+    "source_hash": "62fb14c2"
+  },
+  "web.organizations.audit.capped_notice": {
+    "text": "Seuls les {max} événements les plus récents sont conservés ; l'activité plus ancienne a été supprimée.",
+    "source_hash": "da7901e2"
+  },
+  "web.organizations.audit.collection_paused_notice": {
+    "text": "La collecte des événements est en pause ; la nouvelle activité des secrets n'est pas enregistrée.",
+    "source_hash": "cb09d147"
+  },
+  "web.organizations.audit.load_error": {
+    "text": "Impossible de charger l'activité des secrets.",
+    "source_hash": "52fde814"
+  },
+  "web.organizations.audit.contract_mismatch": {
+    "text": "Les données d'activité renvoyées par le serveur n'ont pas pu être lues. La piste d'audit n'est pas vide — elle ne peut simplement pas être affichée pour le moment.",
+    "source_hash": "db0d007a"
+  },
+  "web.organizations.audit.retry": {
+    "text": "Réessayer",
+    "source_hash": "d8b8392e"
+  },
+  "web.organizations.audit.showing_range": {
+    "text": "Affichage de {from} à {to} sur {total}",
+    "source_hash": "c329279d"
+  },
+  "web.organizations.audit.upgrade_prompt": {
+    "text": "L'activité des secrets nécessite un forfait incluant les journaux d'audit. Mettez à niveau pour voir qui a créé, consulté et révélé des secrets dans cette organisation.",
+    "source_hash": "453649ce"
+  },
+  "web.organizations.audit.role_required": {
+    "text": "L'activité des secrets est réservée aux propriétaires et administrateurs de l'organisation.",
+    "source_hash": "e066ec63"
+  },
+  "web.organizations.audit.actors.creator": {
+    "text": "Créateur",
+    "source_hash": "88447b83"
+  },
+  "web.organizations.audit.actors.authenticated_other": {
+    "text": "Un autre utilisateur connecté",
+    "source_hash": "ee45aa5a"
+  },
+  "web.organizations.audit.actors.anonymous": {
+    "text": "Anonyme",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.organizations.audit.actors.system": {
+    "text": "Système",
+    "source_hash": "6725e7bb"
+  },
+  "web.organizations.audit.actors.unknown": {
+    "text": "Inconnu",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.columns.event": {
+    "text": "Événement",
+    "source_hash": "4e1f49a9"
+  },
+  "web.organizations.audit.columns.secret": {
+    "text": "Secret",
+    "source_hash": "7e32a729"
+  },
+  "web.organizations.audit.columns.actor": {
+    "text": "Acteur",
+    "source_hash": "449995c4"
+  },
+  "web.organizations.audit.columns.country": {
+    "text": "Pays",
+    "source_hash": "701d021d"
+  },
+  "web.organizations.audit.columns.when": {
+    "text": "Quand",
+    "source_hash": "cf9c7aa2"
+  },
+  "web.organizations.audit.kinds.created": {
+    "text": "Secret créé",
+    "source_hash": "e4a1e1fd"
+  },
+  "web.organizations.audit.kinds.status_get": {
+    "text": "État du lien vérifié",
+    "source_hash": "0753f60e"
+  },
+  "web.organizations.audit.kinds.secret_get": {
+    "text": "Lien secret ouvert",
+    "source_hash": "e271e060"
+  },
+  "web.organizations.audit.kinds.previewed": {
+    "text": "Prévisualisé par le créateur",
+    "source_hash": "639fc1e2"
+  },
+  "web.organizations.audit.kinds.creator_status_get": {
+    "text": "État vérifié par le créateur",
+    "source_hash": "7e4b5de5"
+  },
+  "web.organizations.audit.kinds.receipt_viewed": {
+    "text": "Reçu consulté",
+    "source_hash": "a417ead4"
+  },
+  "web.organizations.audit.kinds.revealed": {
+    "text": "Secret révélé",
+    "source_hash": "aff2c84d"
+  },
+  "web.organizations.audit.kinds.burned": {
+    "text": "Secret brûlé",
+    "source_hash": "5ac68dc6"
+  },
+  "web.organizations.audit.kinds.expired": {
+    "text": "Secret expiré",
+    "source_hash": "c127dab6"
+  },
+  "web.organizations.audit.kinds.orphaned": {
+    "text": "Secret orphelin",
+    "source_hash": "23fe1a47"
+  },
+  "web.organizations.audit.kinds.reveal_failed_undecryptable": {
+    "text": "Échec de la révélation (déchiffrement impossible)",
+    "source_hash": "d5616abf"
+  },
+  "web.organizations.tabs.activity": {
+    "text": "Activité",
+    "source_hash": "38da1505"
   }
 }


### PR DESCRIPTION
## `fr_FR` translation update

Automated export of completed **fr_FR** translations from the translation task DB.
Scope: `locales/content/fr_FR/` only — 42 file(s), +3126/-1126.

⚠️ `i18n validate variables` reports **3** variable mismatch(es) for `fr_FR` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ⚠️ Needs review — brand name dropped, wrong locale URL

**Summary:** Large, mostly high-quality update (typography normalization, new SSO-linking strings, admin panel additions) with correct token/variable preservation throughout the new SSO/link-account strings. Two real regressions surfaced despite unchanged English source hashes.

**Critical (must fix):**
- `email.feedback_email.signature`: `"L'équipe d'assistance Onetime Secret"` → `"Assistance Secret"` (`00-common`/`email.json`, source_hash unchanged `f6a6c90f`). Drops the brand name "Onetime" entirely and reads as a garbled fragment — violates the brand-preservation rule.
- `web.COMMON.website_url`: `"https://onetimesecret.com/fr"` → `"https://onetimesecret.com/en"` (source_hash unchanged `440f5303`). The fr_FR locale's own site link now points at the English page instead of the French one — likely a copy/paste or merge error.

**Warnings:**
- `web.testimonials.randomtestimonial_quote`: `"« {0} »"` → `"\"{0}\""` (source_hash unchanged `7a27d02b`). Regresses correct French guillemets to plain ASCII quotes; French quote style is used correctly everywhere else in this diff (e.g. `orgPicker.noResults`, `entitlements.confirm.grantDescription`), so this one looks like an accidental slip rather than intentional.

**Notes:**
- The 3 variable-validator errors (`web.auth.connections.connect_action.context`, `web.link_sso.prompt.context`, `web.sso_link_confirm.prompt.context`) are false positives: these are English-only translator-context metadata fields, not user-facing strings, and are correctly omitted from the locale file. The actual translatable strings (`connect_action`, `link_sso.prompt`, `sso_link_confirm.prompt`) all correctly preserve `{provider}`/`{email}`.
- Widespread NBSP-before-punctuation normalization (`:`, `!`, `»`) throughout is a genuine French-typography improvement, not a regression.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
