### PR TITLE
i18n: update he translations

### DIFF
--- a/locales/content/he/00-common.json
+++ b/locales/content/he/00-common.json
@@ -1539,5 +1539,9 @@
   "web.TITLES.domain_dns": {
     "text": "הגדרת DNS",
     "source_hash": "6c63df31"
+  },
+  "web.TITLES.connected_identities": {
+    "text": "זהויות מחוברות",
+    "source_hash": "e132c4d9"
   }
 }

--- a/locales/content/he/admin-audit.json
+++ b/locales/content/he/admin-audit.json
@@ -98,5 +98,41 @@
   "web.admin.audit.result.failure": {
     "text": "כישלון",
     "source_hash": "7031edbc"
+  },
+  "web.admin.audit.categories.secret": {
+    "text": "סודות",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.audit.categories.membership": {
+    "text": "חברויות",
+    "source_hash": "b50f1a42"
+  },
+  "web.admin.audit.categories.entitlement_preview": {
+    "text": "תצוגות מקדימות של זכויות",
+    "source_hash": "255c5797"
+  },
+  "web.admin.audit.categories.colonel": {
+    "text": "כניסות Colonel",
+    "source_hash": "01eeeb38"
+  },
+  "web.admin.audit.filters.actorLabel": {
+    "text": "פעיל",
+    "source_hash": "449995c4"
+  },
+  "web.admin.audit.filters.searchButton": {
+    "text": "חיפוש",
+    "source_hash": "49c266ba"
+  },
+  "web.admin.audit.filters.searchHint": {
+    "text": "הקלד שם פעיל, ולאחר מכן לחץ Enter או בחר חיפוש להפעלה. הרשימה לא מתעדכנת בזמן ההקלדה.",
+    "source_hash": "45eceb12"
+  },
+  "web.admin.audit.filters.pendingSearch": {
+    "text": "טרם בוצע חיפוש — לחץ Enter או בחר חיפוש להחלת פעיל זה.",
+    "source_hash": "f76095c2"
+  },
+  "web.admin.audit.list.contractError": {
+    "text": "השרת הגיב, אך נתוני הביקורת לא תאמו את הפורמט הצפוי. לא ניתן להציג אירועים — זו תקלת דיווח, לא יומן ריק.",
+    "source_hash": "7f48137e"
   }
 }

--- a/locales/content/he/admin-billing.json
+++ b/locales/content/he/admin-billing.json
@@ -122,5 +122,85 @@
   "web.admin.billing.status.changed": {
     "text": "השתנה",
     "source_hash": "2a6141e4"
+  },
+  "web.admin.billing.diff.backToCatalog": {
+    "text": "חזרה לקטלוג החיובים",
+    "source_hash": "8532b373"
+  },
+  "web.admin.billing.diff.driftedFields": {
+    "text": "שדות שונים:",
+    "source_hash": "9890c95b"
+  },
+  "web.admin.billing.diff.notFound": {
+    "text": "התוכנית לא נמצאה בקטלוג",
+    "source_hash": "0253898b"
+  },
+  "web.admin.billing.diff.notFoundDescription": {
+    "text": "לא נמצאה תוכנית עם המזהה {planid} בקטלוג המוגדר או במטמון המסונכרן עם Stripe.",
+    "source_hash": "2e69551c"
+  },
+  "web.admin.billing.stripeOrgs.title": {
+    "text": "לקוחות Stripe",
+    "source_hash": "0463ae27"
+  },
+  "web.admin.billing.stripeOrgs.description": {
+    "text": "ארגונים המקושרים לרשומת לקוח Stripe.",
+    "source_hash": "2ab09aec"
+  },
+  "web.admin.billing.stripeOrgs.searchPlaceholder": {
+    "text": "חיפוש לפי מזהה לקוח Stripe",
+    "source_hash": "d5acf08f"
+  },
+  "web.admin.billing.stripeOrgs.empty": {
+    "text": "לאף ארגון אין מזהה לקוח Stripe.",
+    "source_hash": "2e373537"
+  },
+  "web.admin.billing.stripeOrgs.emptySearch": {
+    "text": "אין מזהה לקוח Stripe התואם לחיפוש זה.",
+    "source_hash": "75011174"
+  },
+  "web.admin.billing.stripeOrgs.loadError": {
+    "text": "לא ניתן לטעון את רשימת לקוחות Stripe.",
+    "source_hash": "15e2d9a7"
+  },
+  "web.admin.billing.stripeOrgs.unavailable": {
+    "text": "רשימת לקוחות Stripe עדיין אינה זמינה בשרת זה.",
+    "source_hash": "aab6451a"
+  },
+  "web.admin.billing.stripeOrgs.none": {
+    "text": "אין",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.billing.stripeOrgs.capped": {
+    "text": "סריקת האינדקס הגיעה למגבלתה, לכן הסכום הוא חסם תחתון — צמצם את החיפוש כדי לראות את השאר.",
+    "source_hash": "20bcaa38"
+  },
+  "web.admin.billing.stripeOrgs.stale": {
+    "text": "{count} רשומות אינדקס בדף זה מפנות לארגון שכבר לא נטען ודולגו.",
+    "source_hash": "51980f83"
+  },
+  "web.admin.billing.stripeOrgs.copyStripeId": {
+    "text": "העתק מזהה לקוח Stripe",
+    "source_hash": "a77d18b1"
+  },
+  "web.admin.billing.stripeOrgs.columns.organization": {
+    "text": "ארגון",
+    "source_hash": "d764d425"
+  },
+  "web.admin.billing.stripeOrgs.columns.owner": {
+    "text": "בעלים",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.billing.stripeOrgs.columns.plan": {
+    "text": "תוכנית",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.billing.stripeOrgs.columns.subscription": {
+    "text": "מנוי",
+    "source_hash": "4999c6c6"
+  },
+  "web.admin.billing.stripeOrgs.columns.stripeCustomer": {
+    "text": "מזהה לקוח Stripe",
+    "source_hash": "7e1d8bbb"
   }
 }

--- a/locales/content/he/admin-colonel.json
+++ b/locales/content/he/admin-colonel.json
@@ -838,5 +838,37 @@
   "web.colonel.nav.groups.communications": {
     "text": "תקשורת",
     "source_hash": "919a9253"
+  },
+  "web.colonel.organizations.sameAsContact": {
+    "text": "זהה לאיש הקשר",
+    "source_hash": "ed18ff43"
+  },
+  "web.colonel.organizations.refresh": {
+    "text": "רענון",
+    "source_hash": "0e916101"
+  },
+  "web.colonel.organizations.updatedAgo": {
+    "text": "עודכן {ago}",
+    "source_hash": "cda30b9c"
+  },
+  "web.colonel.organizations.columns.name": {
+    "text": "שם",
+    "source_hash": "dcd1d522"
+  },
+  "web.colonel.organizations.columns.contactEmail": {
+    "text": "דוא״ל ליצירת קשר",
+    "source_hash": "6d7fce11"
+  },
+  "web.colonel.organizations.columns.billingEmail": {
+    "text": "דוא״ל לחיוב",
+    "source_hash": "8805b928"
+  },
+  "web.colonel.organizations.columns.planSubscription": {
+    "text": "תוכנית ומנוי",
+    "source_hash": "b396caac"
+  },
+  "web.colonel.organizations.filters.searchPlaceholder": {
+    "text": "חיפוש לפי מזהה, שם או דוא״ל",
+    "source_hash": "6fe16473"
   }
 }

--- a/locales/content/he/admin-customers.json
+++ b/locales/content/he/admin-customers.json
@@ -4,8 +4,8 @@
     "source_hash": "aabe76f1"
   },
   "web.admin.customers.description": {
-    "text": "מצא לקוח ופתור בעיות תמיכה ללא SSH.",
-    "source_hash": "c8487e68"
+    "text": "מצא לקוח ופתור בעיות תמיכה.",
+    "source_hash": "00961ea3"
   },
   "web.admin.customers.actions.plan.label": {
     "text": "תוכנית",
@@ -482,5 +482,213 @@
   "web.admin.customers.suspended.badge": {
     "text": "מושעה",
     "source_hash": "e392a389"
+  },
+  "web.admin.customers.actions.checkoutLink.button": {
+    "text": "צור קישור לתשלום",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.modalTitle": {
+    "text": "צור קישור לתשלום",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.planLabel": {
+    "text": "תוכנית",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.actions.checkoutLink.planPlaceholder": {
+    "text": "מזהה משפחת תוכנית (למשל identity_plus_v1)",
+    "source_hash": "12eba027"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleLabel": {
+    "text": "מחזור חיוב",
+    "source_hash": "d69f731e"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleMonthly": {
+    "text": "חודשי",
+    "source_hash": "9b11f6b7"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleYearly": {
+    "text": "שנתי",
+    "source_hash": "6e69b59e"
+  },
+  "web.admin.customers.actions.checkoutLink.allowPromo": {
+    "text": "אפשר קודי קידום",
+    "source_hash": "ebe7bc8b"
+  },
+  "web.admin.customers.actions.checkoutLink.submit": {
+    "text": "צור קישור",
+    "source_hash": "e6b850cf"
+  },
+  "web.admin.customers.actions.checkoutLink.resultLead": {
+    "text": "קישור לתשלום נוצר. שתף אותו עם הלקוח — ניתן להשתמש בו פעם אחת והוא פג תוקף.",
+    "source_hash": "6ff1fb0e"
+  },
+  "web.admin.customers.actions.checkoutLink.copy": {
+    "text": "העתק קישור לתשלום",
+    "source_hash": "f1e51ca7"
+  },
+  "web.admin.customers.actions.checkoutLink.expiry": {
+    "text": "פג תוקף בעוד ~{hours} שעות ({date}).",
+    "source_hash": "4c878a15"
+  },
+  "web.admin.customers.actions.checkoutLink.regionLabel": {
+    "text": "אזור",
+    "source_hash": "d3a008ef"
+  },
+  "web.admin.customers.actions.checkoutLink.parseError": {
+    "text": "השרת קיבל את הבקשה אך החזיר תגובה בלתי קריאה, לכן לא ניתן להציג קישור. בדוק את Stripe לפני ניסיון חוזר.",
+    "source_hash": "e7e08290"
+  },
+  "web.admin.customers.actions.checkoutLink.done": {
+    "text": "סיום",
+    "source_hash": "11a6767d"
+  },
+  "web.admin.customers.actions.purge.typePrompt": {
+    "text": "לאישור, הקלד את כתובת הדוא״ל של החשבון {token} למטה",
+    "source_hash": "8b2a1819"
+  },
+  "web.admin.customers.actions.purge.unavailable": {
+    "text": "מחיקה לא זמינה: לחשבון זה אין כתובת דוא״ל להקלדה חוזרת כאישור.",
+    "source_hash": "5f20f7e5"
+  },
+  "web.admin.customers.columns.actions": {
+    "text": "פעולות",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.diagnostics.title": {
+    "text": "אבחון חשבון",
+    "source_hash": "5574ece8"
+  },
+  "web.admin.customers.detail.diagnostics.loading": {
+    "text": "מריץ אבחון…",
+    "source_hash": "062c83d5"
+  },
+  "web.admin.customers.detail.diagnostics.loadError": {
+    "text": "לא ניתן לטעון אבחון.",
+    "source_hash": "69e69f49"
+  },
+  "web.admin.customers.detail.diagnostics.healthy": {
+    "text": "לא נמצא תנאי חוסם. מצב האימות נראה תקין — חשוד בבעיות בצד הלקוח (עוגיות, תצורת כניסה בדומיין מותאם אישית) או באזור שגוי.",
+    "source_hash": "f6d5f8d1"
+  },
+  "web.admin.customers.detail.diagnostics.authUnavailable": {
+    "text": "מסד נתוני האימות אינו זמין (מצב אימות פשוט) — בדיקות SQL דולגו.",
+    "source_hash": "d668907c"
+  },
+  "web.admin.customers.detail.diagnostics.authFailed": {
+    "text": "מסד נתוני האימות לא הגיב, לכן בדיקות SQL לא יכלו לרוץ: {reason}",
+    "source_hash": "46d047c0"
+  },
+  "web.admin.customers.detail.diagnostics.unknown": {
+    "text": "לא ידוע",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.title": {
+    "text": "יומן אימות",
+    "source_hash": "48ad8ba8"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.empty": {
+    "text": "לא נרשמו אירועי אימות.",
+    "source_hash": "d2332558"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.unavailable": {
+    "text": "לא ניתן לקרוא את יומן האימות: {reason}",
+    "source_hash": "ab18af57"
+  },
+  "web.admin.customers.detail.diagnostics.facts.authStatus": {
+    "text": "מצב אימות",
+    "source_hash": "34def169"
+  },
+  "web.admin.customers.detail.diagnostics.facts.noAccount": {
+    "text": "אין חשבון אימות",
+    "source_hash": "a9968e9e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.password": {
+    "text": "סיסמה",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordSet": {
+    "text": "מוגדרת",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordNone": {
+    "text": "אין",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfa": {
+    "text": "MFA",
+    "source_hash": "d39ce053"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfaNone": {
+    "text": "אין",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.loginFailures": {
+    "text": "ניסיונות כושלים",
+    "source_hash": "63e7f0a8"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lockedBadge": {
+    "text": "נעול",
+    "source_hash": "ace29f74"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiter": {
+    "text": "מגביל קצב",
+    "source_hash": "32892404"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterEngaged": {
+    "text": "פעיל",
+    "source_hash": "1b0d851e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterClear": {
+    "text": "נקי",
+    "source_hash": "83b12c22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verification": {
+    "text": "דוא״ל אימות",
+    "source_hash": "23fac8fb"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationPending": {
+    "text": "ממתין — נשלח לאחרונה {date}",
+    "source_hash": "9ab8d1b6"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationNone": {
+    "text": "אין ממתינים",
+    "source_hash": "a4d4cc22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.sessions": {
+    "text": "הפעלות פעילות",
+    "source_hash": "61ad9909"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lastLogin": {
+    "text": "כניסה אחרונה (אימות)",
+    "source_hash": "373e7fb1"
+  },
+  "web.admin.customers.detail.receipts.partial": {
+    "text": "רשימה חלקית — מציג את {count} האחרונים ביותר. ללקוח זה יש יותר קבלות ממה שמוצג כאן.",
+    "source_hash": "127fd4db"
+  },
+  "web.admin.customers.detail.secrets.partial": {
+    "text": "רשימה חלקית — מציג את {count} האחרונים ביותר. ללקוח זה יש יותר סודות ממה שמוצג כאן.",
+    "source_hash": "a537c8f3"
+  },
+  "web.admin.customers.detail.sessions.columns.country": {
+    "text": "מדינה",
+    "source_hash": "701d021d"
+  },
+  "web.admin.customers.detail.sessions.current.badge": {
+    "text": "הפעלה זו",
+    "source_hash": "6da6530a"
+  },
+  "web.admin.customers.detail.sessions.current.tooltip": {
+    "text": "הפעלת המנהל הנוכחית שלך. ביטול כאן לא ישפיע — היא נוצרת מחדש לשאר הבקשה הזו.",
+    "source_hash": "ef097ab1"
+  },
+  "web.admin.customers.verification.verified": {
+    "text": "מאומת",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.verification.unverified": {
+    "text": "לא מאומת",
+    "source_hash": "15133907"
   }
 }

--- a/locales/content/he/admin-domains.json
+++ b/locales/content/he/admin-domains.json
@@ -190,5 +190,657 @@
   "web.admin.domains.verify.success.done": {
     "text": "האימות הושלם עבור {domain}.",
     "source_hash": "ed67e22d"
+  },
+  "web.admin.domains.actions.preview": {
+    "text": "תצוגה מקדימה",
+    "source_hash": "324b134f"
+  },
+  "web.admin.domains.actions.probe.button": {
+    "text": "בדיקה",
+    "source_hash": "3bd51ab9"
+  },
+  "web.admin.domains.actions.remove.button": {
+    "text": "הסר דומיין",
+    "source_hash": "5ce43507"
+  },
+  "web.admin.domains.actions.remove.previewButton": {
+    "text": "תצוגה מקדימה של הסרה",
+    "source_hash": "6b81bd92"
+  },
+  "web.admin.domains.actions.remove.previewStatus": {
+    "text": "מצב:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.remove.previewOrg": {
+    "text": "ארגון:",
+    "source_hash": "5300e286"
+  },
+  "web.admin.domains.actions.remove.reassertsSurvivor": {
+    "text": "רשומה אחרת טוענת לאותו שם דומיין ותשתלט על אינדקס החיפוש.",
+    "source_hash": "902838f4"
+  },
+  "web.admin.domains.actions.remove.confirmTitle": {
+    "text": "להסיר דומיין?",
+    "source_hash": "716dfac9"
+  },
+  "web.admin.domains.actions.remove.confirmDescription": {
+    "text": "פעולה זו מוחקת לצמיתות את {domain} ואת רשומות המיתוג, ה-DNS וההגדרות שלו. לא ניתן לבטל זאת. הקלד מחדש את המזהה הציבורי של הדומיין כדי להמשיך.",
+    "source_hash": "d0b67b47"
+  },
+  "web.admin.domains.actions.remove.success": {
+    "text": "הדומיין הוסר.",
+    "source_hash": "2ccaa6d3"
+  },
+  "web.admin.domains.actions.remove.notApplied": {
+    "text": "השרת הציג תצוגה מקדימה של ההסרה במקום להחיל אותה — הדומיין לא הוסר. נסה שוב, ודווח אם הבעיה נמשכת.",
+    "source_hash": "dc6d70ae"
+  },
+  "web.admin.domains.actions.repair.title": {
+    "text": "תיקון קישור ארגון",
+    "source_hash": "82b40352"
+  },
+  "web.admin.domains.actions.repair.description": {
+    "text": "מצא ותקן קישורים שבורים בין דומיין זה לארגון שלו. הצג תצוגה מקדימה תחילה כדי לראות מה ישתנה.",
+    "source_hash": "531ed287"
+  },
+  "web.admin.domains.actions.repair.orgIdLabel": {
+    "text": "מזהה ארגון (לדומיינים יתומים בלבד)",
+    "source_hash": "0d3010eb"
+  },
+  "web.admin.domains.actions.repair.orgIdPlaceholder": {
+    "text": "השאר ריק אלא אם לדומיין אין בעלים",
+    "source_hash": "118b7132"
+  },
+  "web.admin.domains.actions.repair.statusLabel": {
+    "text": "מצב:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.repair.noIssues": {
+    "text": "לא נמצאו בעיות — אין מה לתקן.",
+    "source_hash": "17735887"
+  },
+  "web.admin.domains.actions.repair.button": {
+    "text": "החל תיקון",
+    "source_hash": "4d0ab2d4"
+  },
+  "web.admin.domains.actions.repair.confirmTitle": {
+    "text": "להחיל תיקון?",
+    "source_hash": "ef0ffae5"
+  },
+  "web.admin.domains.actions.repair.confirmDescription": {
+    "text": "פעולה זו משכתבת את קישור הארגון עבור {domain}. הקלד מחדש את המזהה הציבורי של הדומיין כדי להמשיך.",
+    "source_hash": "a9f2702f"
+  },
+  "web.admin.domains.actions.repair.success": {
+    "text": "התיקון הוחל.",
+    "source_hash": "850bd784"
+  },
+  "web.admin.domains.actions.transfer.title": {
+    "text": "העברה לארגון אחר",
+    "source_hash": "1b0b0655"
+  },
+  "web.admin.domains.actions.transfer.description": {
+    "text": "העבר דומיין זה לארגון אחר. הצג תצוגה מקדימה תחילה כדי לאשר את שני צדדי ההעברה.",
+    "source_hash": "457e852d"
+  },
+  "web.admin.domains.actions.transfer.toOrgLabel": {
+    "text": "מזהה ארגון יעד",
+    "source_hash": "1a3f05c4"
+  },
+  "web.admin.domains.actions.transfer.fromOrgLabel": {
+    "text": "מזהה ארגון נוכחי צפוי (אופציונלי)",
+    "source_hash": "f6e75729"
+  },
+  "web.admin.domains.actions.transfer.fromOrgPlaceholder": {
+    "text": "אשר את הבעלים הנוכחי לפני ההעברה",
+    "source_hash": "1ac6c59b"
+  },
+  "web.admin.domains.actions.transfer.from": {
+    "text": "מ",
+    "source_hash": "21819769"
+  },
+  "web.admin.domains.actions.transfer.to": {
+    "text": "אל",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.domains.actions.transfer.orphaned": {
+    "text": "אין ארגון (יתום)",
+    "source_hash": "6f4c745c"
+  },
+  "web.admin.domains.actions.transfer.button": {
+    "text": "החל העברה",
+    "source_hash": "fb546c5c"
+  },
+  "web.admin.domains.actions.transfer.confirmTitle": {
+    "text": "להעביר דומיין?",
+    "source_hash": "801eb986"
+  },
+  "web.admin.domains.actions.transfer.confirmDescription": {
+    "text": "פעולה זו מעבירה את {domain} לארגון {org}. הקלד מחדש את המזהה הציבורי של הדומיין כדי להמשיך.",
+    "source_hash": "52c8808d"
+  },
+  "web.admin.domains.actions.transfer.success": {
+    "text": "הדומיין הועבר.",
+    "source_hash": "91e681ae"
+  },
+  "web.admin.domains.columns.domain": {
+    "text": "דומיין",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domains.columns.organization": {
+    "text": "ארגון",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.columns.state": {
+    "text": "אימות",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.domains.columns.tls": {
+    "text": "TLS",
+    "source_hash": "d1c18ec0"
+  },
+  "web.admin.domains.columns.created": {
+    "text": "נוצר",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.columns.actions": {
+    "text": "פעולות",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.configs.title": {
+    "text": "תצורת דומיין",
+    "source_hash": "d46aa480"
+  },
+  "web.admin.domains.configs.description": {
+    "text": "רשומות תצורה לכל דומיין השולטות בכניסה, הרשמה, סודות בדף הבית, גישת API, סודות נכנסים, SSO של דיירים ושליחת דואר. רשומה חסרה נכשלת סגורה עבור חמשת הראשונים.",
+    "source_hash": "1df99789"
+  },
+  "web.admin.domains.configs.loadError": {
+    "text": "לא ניתן לטעון את רשומות תצורת הדומיין.",
+    "source_hash": "9417d718"
+  },
+  "web.admin.domains.configs.retry": {
+    "text": "נסה שוב",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.configs.degraded": {
+    "text": "תגובת התצורה לא תאמה את החוזה הצפוי. רענן, ודווח אם הבעיה נמשכת.",
+    "source_hash": "b5d890c0"
+  },
+  "web.admin.domains.configs.notFoundNote": {
+    "text": "דומיין זה כבר לא קיים, לכן לא ניתן לטעון את רשומות התצורה שלו.",
+    "source_hash": "2d88a392"
+  },
+  "web.admin.domains.configs.detailsToggle": {
+    "text": "פרטים",
+    "source_hash": "45989de4"
+  },
+  "web.admin.domains.configs.notEditable": {
+    "text": "מנוהל בהגדרות דומיין מרחב העבודה.",
+    "source_hash": "54fe891f"
+  },
+  "web.admin.domains.configs.delete.button": {
+    "text": "מחק",
+    "source_hash": "e2d0a549"
+  },
+  "web.admin.domains.configs.delete.confirmTitle": {
+    "text": "למחוק תצורת {kind}?",
+    "source_hash": "98e672db"
+  },
+  "web.admin.domains.configs.delete.confirmDescription": {
+    "text": "פעולה זו מוחקת לצמיתות את רשומת התצורה {kind} עבור {domain}. הדומיין חוזר להתנהגות של רשומה חסרה. הקלד מחדש את הסוג כדי להמשיך.",
+    "source_hash": "8272c40c"
+  },
+  "web.admin.domains.configs.delete.success": {
+    "text": "התצורה נמחקה.",
+    "source_hash": "a0184b66"
+  },
+  "web.admin.domains.configs.edit.button": {
+    "text": "עריכה",
+    "source_hash": "464c4ffd"
+  },
+  "web.admin.domains.configs.edit.createButton": {
+    "text": "צור",
+    "source_hash": "4759498a"
+  },
+  "web.admin.domains.configs.edit.title": {
+    "text": "הגדר {kind}",
+    "source_hash": "8592148f"
+  },
+  "web.admin.domains.configs.edit.submit": {
+    "text": "שמור",
+    "source_hash": "1509f561"
+  },
+  "web.admin.domains.configs.edit.success": {
+    "text": "התצורה נשמרה.",
+    "source_hash": "6b5b3c69"
+  },
+  "web.admin.domains.configs.edit.unsetOption": {
+    "text": "לא מוגדר",
+    "source_hash": "4895f731"
+  },
+  "web.admin.domains.configs.edit.domainsHint": {
+    "text": "דומיין אחד בכל שורה.",
+    "source_hash": "6c03f4f7"
+  },
+  "web.admin.domains.configs.ensure.button": {
+    "text": "צור תצורות חסרות",
+    "source_hash": "77991b75"
+  },
+  "web.admin.domains.configs.ensure.confirmTitle": {
+    "text": "ליצור רשומות תצורה חסרות?",
+    "source_hash": "3f41dec2"
+  },
+  "web.admin.domains.configs.ensure.confirmDescription": {
+    "text": "יוצר רשומות מושבתות ב-{domain} עבור: {kinds}. הכל מתחיל מושבת, כך שההתנהגות לא משתנה עד שרשומה מופעלת.",
+    "source_hash": "fed66221"
+  },
+  "web.admin.domains.configs.ensure.applyButton": {
+    "text": "צור רשומות",
+    "source_hash": "4bcbef42"
+  },
+  "web.admin.domains.configs.ensure.success": {
+    "text": "רשומות תצורה חסרות נוצרו.",
+    "source_hash": "3b6ead80"
+  },
+  "web.admin.domains.configs.ensure.nothingMissing": {
+    "text": "אין מה ליצור — כל רשומות התצורה כבר קיימות. הרשימה רועננה.",
+    "source_hash": "ad0df0ae"
+  },
+  "web.admin.domains.configs.ensure.notApplied": {
+    "text": "השרת הציג תצוגה מקדימה של השינוי במקום להחיל אותו — לא נוצרו רשומות. נסה שוב, ודווח אם הבעיה נמשכת.",
+    "source_hash": "09d26379"
+  },
+  "web.admin.domains.configs.fields.enabled": {
+    "text": "מופעל",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.fields.signin_enabled": {
+    "text": "כניסה מופעלת",
+    "source_hash": "cabe4898"
+  },
+  "web.admin.domains.configs.fields.email_auth_enabled": {
+    "text": "אימות דוא״ל מופעל",
+    "source_hash": "4a762960"
+  },
+  "web.admin.domains.configs.fields.sso_enabled": {
+    "text": "SSO מופעל",
+    "source_hash": "6e77e673"
+  },
+  "web.admin.domains.configs.fields.restrict_to": {
+    "text": "הגבל ל",
+    "source_hash": "a0bdf50a"
+  },
+  "web.admin.domains.configs.fields.signup_enabled": {
+    "text": "הרשמה מופעלת",
+    "source_hash": "2637d0b2"
+  },
+  "web.admin.domains.configs.fields.autoverify": {
+    "text": "אימות אוטומטי",
+    "source_hash": "7e02211c"
+  },
+  "web.admin.domains.configs.fields.validation_strategy": {
+    "text": "אסטרטגיית אימות",
+    "source_hash": "a2e95531"
+  },
+  "web.admin.domains.configs.fields.allowed_signup_domains": {
+    "text": "דומיינים מורשים להרשמה",
+    "source_hash": "9b5bb5b1"
+  },
+  "web.admin.domains.configs.fields.secrets_mode": {
+    "text": "מצב סודות",
+    "source_hash": "8d4349d6"
+  },
+  "web.admin.domains.configs.fields.disabled_homepage_variant": {
+    "text": "גרסת דף בית מושבתת",
+    "source_hash": "4695633b"
+  },
+  "web.admin.domains.configs.fields.ready": {
+    "text": "מוכן",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.configs.fields.recipients": {
+    "text": "נמענים",
+    "source_hash": "1e8568a8"
+  },
+  "web.admin.domains.configs.fields.provider_type": {
+    "text": "סוג ספק",
+    "source_hash": "8c0f6d3e"
+  },
+  "web.admin.domains.configs.fields.display_name": {
+    "text": "שם תצוגה",
+    "source_hash": "2b7f6a84"
+  },
+  "web.admin.domains.configs.fields.issuer": {
+    "text": "מנפיק",
+    "source_hash": "39e02c46"
+  },
+  "web.admin.domains.configs.fields.tenant_id": {
+    "text": "מזהה דייר",
+    "source_hash": "de1f5fff"
+  },
+  "web.admin.domains.configs.fields.has_client_id": {
+    "text": "מזהה לקוח מוגדר",
+    "source_hash": "04a9fa3d"
+  },
+  "web.admin.domains.configs.fields.has_client_secret": {
+    "text": "סוד לקוח מוגדר",
+    "source_hash": "6ee1c9e6"
+  },
+  "web.admin.domains.configs.fields.allowed_domains": {
+    "text": "דומיינים מורשים",
+    "source_hash": "bcd60db0"
+  },
+  "web.admin.domains.configs.fields.enforce_sso_only": {
+    "text": "אכוף SSO בלבד",
+    "source_hash": "b3a3f694"
+  },
+  "web.admin.domains.configs.fields.grant_org_scope": {
+    "text": "הענק היקף ארגון",
+    "source_hash": "698ea5de"
+  },
+  "web.admin.domains.configs.fields.provider": {
+    "text": "ספק",
+    "source_hash": "472590ae"
+  },
+  "web.admin.domains.configs.fields.from_name": {
+    "text": "שם שולח",
+    "source_hash": "b28f93ea"
+  },
+  "web.admin.domains.configs.fields.from_address": {
+    "text": "כתובת שולח",
+    "source_hash": "d465bcfa"
+  },
+  "web.admin.domains.configs.fields.reply_to": {
+    "text": "מענה אל",
+    "source_hash": "6b9c49b7"
+  },
+  "web.admin.domains.configs.fields.sending_mode": {
+    "text": "מצב שליחה",
+    "source_hash": "e2d6bcf7"
+  },
+  "web.admin.domains.configs.fields.verification_status": {
+    "text": "מצב אימות",
+    "source_hash": "aedfff7e"
+  },
+  "web.admin.domains.configs.fields.dns_verified": {
+    "text": "DNS מאומת",
+    "source_hash": "8b2128c8"
+  },
+  "web.admin.domains.configs.fields.provider_verified": {
+    "text": "ספק מאומת",
+    "source_hash": "6f4d9cc4"
+  },
+  "web.admin.domains.configs.fields.has_api_key": {
+    "text": "מפתח API מוגדר",
+    "source_hash": "d5115386"
+  },
+  "web.admin.domains.configs.fields.created": {
+    "text": "נוצר",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.configs.fields.updated": {
+    "text": "עודכן",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.configs.kinds.signin": {
+    "text": "כניסה",
+    "source_hash": "5bbbe531"
+  },
+  "web.admin.domains.configs.kinds.signup": {
+    "text": "הרשמה",
+    "source_hash": "3cc08ebe"
+  },
+  "web.admin.domains.configs.kinds.homepage": {
+    "text": "דף הבית",
+    "source_hash": "9e3391e9"
+  },
+  "web.admin.domains.configs.kinds.api": {
+    "text": "API",
+    "source_hash": "c8e5998f"
+  },
+  "web.admin.domains.configs.kinds.incoming": {
+    "text": "נכנס",
+    "source_hash": "e301820a"
+  },
+  "web.admin.domains.configs.kinds.sso": {
+    "text": "SSO",
+    "source_hash": "5ba3ac9f"
+  },
+  "web.admin.domains.configs.kinds.mailer": {
+    "text": "שליחת דואר",
+    "source_hash": "6c07ba63"
+  },
+  "web.admin.domains.configs.missingNotes.signin": {
+    "text": "אין רשומה: כניסה מושבתת בדומיין זה אלא אם SSO דייר פעיל.",
+    "source_hash": "17dd6099"
+  },
+  "web.admin.domains.configs.missingNotes.signup": {
+    "text": "אין רשומה: הרשמה מושבתת בדומיין זה.",
+    "source_hash": "c3c98956"
+  },
+  "web.admin.domains.configs.missingNotes.homepage": {
+    "text": "אין רשומה: סודות דף הבית מושבתים (נכשל סגור ומתעד שגיאה).",
+    "source_hash": "9a258a88"
+  },
+  "web.admin.domains.configs.missingNotes.api": {
+    "text": "אין רשומה: ה-API הציבורי מושבת (נכשל סגור ומתעד שגיאה).",
+    "source_hash": "fed99f73"
+  },
+  "web.admin.domains.configs.missingNotes.incoming": {
+    "text": "אין רשומה: סודות נכנסים מושבתים.",
+    "source_hash": "b957fbe8"
+  },
+  "web.admin.domains.configs.missingNotes.sso": {
+    "text": "אין רשומה: SSO דייר אינו זמין; מדיניות גיבוי SSO של הפלטפורמה חלה.",
+    "source_hash": "7b05ade8"
+  },
+  "web.admin.domains.configs.missingNotes.mailer": {
+    "text": "אין רשומה: נעשה שימוש בשולח הדואר של הפלטפורמה.",
+    "source_hash": "e027cc99"
+  },
+  "web.admin.domains.configs.status.missing": {
+    "text": "חסר",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.domains.configs.status.disabled": {
+    "text": "מושבת",
+    "source_hash": "75081b59"
+  },
+  "web.admin.domains.configs.status.enabled": {
+    "text": "מופעל",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.status.enabledNotReady": {
+    "text": "מופעל, לא מוכן",
+    "source_hash": "cb806ba4"
+  },
+  "web.admin.domains.detail.openFullPage": {
+    "text": "פתח עמוד מלא",
+    "source_hash": "a467911c"
+  },
+  "web.admin.domains.detail.backToList": {
+    "text": "חזרה לדומיינים",
+    "source_hash": "22fd50fe"
+  },
+  "web.admin.domains.detail.notFound": {
+    "text": "הדומיין לא נמצא",
+    "source_hash": "7b8fc0e6"
+  },
+  "web.admin.domains.detail.notFoundDescription": {
+    "text": "דומיין זה לא קיים, או שהוא כבר הוסר.",
+    "source_hash": "e0f0b987"
+  },
+  "web.admin.domains.detail.loadError": {
+    "text": "לא ניתן לטעון דומיין זה.",
+    "source_hash": "39e9c657"
+  },
+  "web.admin.domains.detail.retry": {
+    "text": "נסה שוב",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.detail.never": {
+    "text": "אף פעם",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.domains.detail.none": {
+    "text": "אין",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.domains.detail.yes": {
+    "text": "כן",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.domains.detail.no": {
+    "text": "לא",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.domains.detail.organization.open": {
+    "text": "פתח ארגון",
+    "source_hash": "54a43621"
+  },
+  "web.admin.domains.detail.organization.unknown": {
+    "text": "הארגון הבעלים אינו כלול בתגובה זו. פתח דומיין זה מרשימת הדומיינים כדי לראות אותו.",
+    "source_hash": "bb5bdc9c"
+  },
+  "web.admin.domains.detail.sections.overview": {
+    "text": "סקירה כללית",
+    "source_hash": "d4b1ea57"
+  },
+  "web.admin.domains.detail.sections.actions": {
+    "text": "פעולות",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.detail.sections.organization": {
+    "text": "ארגון בעלים",
+    "source_hash": "39ad6d9c"
+  },
+  "web.admin.domains.detail.sections.dns": {
+    "text": "DNS",
+    "source_hash": "020965a2"
+  },
+  "web.admin.domains.detail.sections.diagnostics": {
+    "text": "אבחון",
+    "source_hash": "268f14bb"
+  },
+  "web.admin.domains.detail.sections.operations": {
+    "text": "פעולות בעלות",
+    "source_hash": "eb9a8cbc"
+  },
+  "web.admin.domains.detail.sections.operationsHint": {
+    "text": "כל פעולה מציגה תצוגה מקדימה תחילה. שום דבר לא נכתב עד שתאשר את שלב ההחלה.",
+    "source_hash": "f09bf7bd"
+  },
+  "web.admin.domains.fields.publicId": {
+    "text": "מזהה ציבורי",
+    "source_hash": "3705b64f"
+  },
+  "web.admin.domains.fields.domainId": {
+    "text": "מזהה פנימי",
+    "source_hash": "e468bb47"
+  },
+  "web.admin.domains.fields.organization": {
+    "text": "ארגון",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.fields.baseDomain": {
+    "text": "דומיין בסיס",
+    "source_hash": "33295d5b"
+  },
+  "web.admin.domains.fields.subdomain": {
+    "text": "תת-דומיין",
+    "source_hash": "ba4520ab"
+  },
+  "web.admin.domains.fields.apex": {
+    "text": "דומיין ראשי",
+    "source_hash": "0a8a42fa"
+  },
+  "web.admin.domains.fields.status": {
+    "text": "מצב",
+    "source_hash": "920e413c"
+  },
+  "web.admin.domains.fields.created": {
+    "text": "נוצר",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.fields.updated": {
+    "text": "עודכן",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.fields.verified": {
+    "text": "מאומת",
+    "source_hash": "4f783840"
+  },
+  "web.admin.domains.fields.resolving": {
+    "text": "בתהליך פתרון",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.fields.ready": {
+    "text": "מוכן",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.list.searchPlaceholder": {
+    "text": "חיפוש לפי שם דומיין או מזהה",
+    "source_hash": "aecdd873"
+  },
+  "web.admin.domains.list.stateFilter": {
+    "text": "מצב",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.domains.list.emptyFilter": {
+    "text": "אין דומיינים התואמים למסננים הנוכחיים.",
+    "source_hash": "be4d64ec"
+  },
+  "web.admin.domains.probe.healthLabel": {
+    "text": "בריאות",
+    "source_hash": "55898449"
+  },
+  "web.admin.domains.probe.certInvalid": {
+    "text": "האישור אינו שמיש",
+    "source_hash": "5535f4d4"
+  },
+  "web.admin.domains.probe.noCertificate": {
+    "text": "לא הוחזר אישור — החיבור נכשל לפני TLS.",
+    "source_hash": "8ffd63be"
+  },
+  "web.admin.domains.probe.fields.httpStatus": {
+    "text": "מצב HTTP",
+    "source_hash": "0f7cf91f"
+  },
+  "web.admin.domains.probe.fields.httpError": {
+    "text": "שגיאת HTTP",
+    "source_hash": "5c6896d4"
+  },
+  "web.admin.domains.probe.fields.sslError": {
+    "text": "שגיאת TLS",
+    "source_hash": "7b827515"
+  },
+  "web.admin.domains.probe.fields.issuer": {
+    "text": "מנפיק האישור",
+    "source_hash": "2912559a"
+  },
+  "web.admin.domains.probe.fields.subject": {
+    "text": "נושא האישור",
+    "source_hash": "d7816b16"
+  },
+  "web.admin.domains.probe.fields.notAfter": {
+    "text": "האישור פג בתאריך",
+    "source_hash": "1e73119d"
+  },
+  "web.admin.domains.probe.fields.expiresIn": {
+    "text": "{date} ({days} ימים)",
+    "source_hash": "a71a6e81"
+  },
+  "web.admin.domains.tls.serving": {
+    "text": "משרת",
+    "source_hash": "f55e53f9"
+  },
+  "web.admin.domains.tls.resolving": {
+    "text": "בתהליך פתרון",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.tls.none": {
+    "text": "לא משרת",
+    "source_hash": "da8a5ab9"
   }
 }

--- a/locales/content/he/admin-organizations.json
+++ b/locales/content/he/admin-organizations.json
@@ -310,5 +310,333 @@
   "web.admin.organizations.list.loadError": {
     "text": "לא ניתן לטעון ארגונים.",
     "source_hash": "130d5e70"
+  },
+  "web.admin.organizations.addMember.button": {
+    "text": "הוסף חשבון קיים",
+    "source_hash": "45a3b757"
+  },
+  "web.admin.organizations.addMember.title": {
+    "text": "הוסף חשבון קיים",
+    "source_hash": "2f676a94"
+  },
+  "web.admin.organizations.addMember.description": {
+    "text": "הוסף מישהו שכבר יש לו חשבון ל-{org}. השתמש בזה כשאדם נרשם בעצמו ולא ניתן להזמין אותו כי החשבון כבר קיים.",
+    "source_hash": "bb41faa6"
+  },
+  "web.admin.organizations.addMember.searchLabel": {
+    "text": "כתובת דוא״ל או מזהה חשבון",
+    "source_hash": "82b3040b"
+  },
+  "web.admin.organizations.addMember.searchPlaceholder": {
+    "text": "חיפוש לפי כתובת דוא״ל",
+    "source_hash": "b75cc66c"
+  },
+  "web.admin.organizations.addMember.searchHint": {
+    "text": "מתאים לחלק מכתובת דוא״ל, או למזהה חשבון מדויק.",
+    "source_hash": "84547a60"
+  },
+  "web.admin.organizations.addMember.searchError": {
+    "text": "לא ניתן לחפש חשבונות. בדוק את החיבור ונסה שוב.",
+    "source_hash": "4b6caa41"
+  },
+  "web.admin.organizations.addMember.searchParseError": {
+    "text": "חיפוש החשבון החזיר תגובה בלתי צפויה. התוצאות עשויות להיות חלקיות.",
+    "source_hash": "0c814231"
+  },
+  "web.admin.organizations.addMember.idle": {
+    "text": "הזן כתובת דוא״ל כדי למצוא את החשבון.",
+    "source_hash": "f6340d35"
+  },
+  "web.admin.organizations.addMember.noResults": {
+    "text": "אין חשבון התואם ל-“{term}”.",
+    "source_hash": "199b662a"
+  },
+  "web.admin.organizations.addMember.noResultsHint": {
+    "text": "רק חשבונות קיימים ניתנים להוספה כאן. אם האדם מעולם לא נרשם, הזמן אותו במקום.",
+    "source_hash": "ee90aeeb"
+  },
+  "web.admin.organizations.addMember.select": {
+    "text": "בחר",
+    "source_hash": "2a78025d"
+  },
+  "web.admin.organizations.addMember.selectedEyebrow": {
+    "text": "חשבון נבחר",
+    "source_hash": "8b63d947"
+  },
+  "web.admin.organizations.addMember.change": {
+    "text": "בחר חשבון אחר",
+    "source_hash": "d4fe39ab"
+  },
+  "web.admin.organizations.addMember.createdOn": {
+    "text": "נרשם ב-{date}",
+    "source_hash": "cfc0e19f"
+  },
+  "web.admin.organizations.addMember.organizationsUnavailable": {
+    "text": "לא ניתן לטעון את הארגונים הנוכחיים של חשבון זה.",
+    "source_hash": "a35b6bfc"
+  },
+  "web.admin.organizations.addMember.defaultOrg": {
+    "text": "ברירת מחדל",
+    "source_hash": "37a8eec1"
+  },
+  "web.admin.organizations.addMember.roleLabel": {
+    "text": "תפקיד בארגון זה",
+    "source_hash": "817475fa"
+  },
+  "web.admin.organizations.addMember.submit": {
+    "text": "הוסף לארגון",
+    "source_hash": "0e0cb636"
+  },
+  "web.admin.organizations.addMember.success": {
+    "text": "{account} נוסף כ-{role}.",
+    "source_hash": "533be0dc"
+  },
+  "web.admin.organizations.addMember.badges.verified": {
+    "text": "מאומת",
+    "source_hash": "4f783840"
+  },
+  "web.admin.organizations.addMember.badges.unverified": {
+    "text": "לא מאומת",
+    "source_hash": "15133907"
+  },
+  "web.admin.organizations.addMember.badges.suspended": {
+    "text": "מושעה",
+    "source_hash": "e392a389"
+  },
+  "web.admin.organizations.addMember.badges.alreadyMember": {
+    "text": "כבר חבר",
+    "source_hash": "1739ed7c"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMember": {
+    "text": "חשבון זה כבר חבר בארגון זה, עם התפקיד {role}. הוספה אינה משנה תפקיד קיים — השתמש בפעולת הגדרת-תפקיד לכך.",
+    "source_hash": "cb6a4774"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMemberUnknownRole": {
+    "text": "חשבון זה כבר חבר בארגון זה. הוספה אינה משנה תפקיד קיים.",
+    "source_hash": "035641ec"
+  },
+  "web.admin.organizations.addMember.errors.notFound": {
+    "text": "חשבון או ארגון זה כבר לא קיים. חפש שוב כדי לאשר את החשבון.",
+    "source_hash": "bd88db18"
+  },
+  "web.admin.organizations.addMember.errors.invalidRole": {
+    "text": "התפקיד נדחה. בחר אחד מהתפקידים המפורטים ונסה שוב.",
+    "source_hash": "eb696a8f"
+  },
+  "web.admin.organizations.addMember.errors.noSelection": {
+    "text": "לא נבחר חשבון.",
+    "source_hash": "dd15bb5b"
+  },
+  "web.admin.organizations.addMember.fields.created": {
+    "text": "נרשם",
+    "source_hash": "486b3fe0"
+  },
+  "web.admin.organizations.addMember.fields.verified": {
+    "text": "אימות",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.organizations.addMember.fields.lastLogin": {
+    "text": "כניסה אחרונה",
+    "source_hash": "0b70af7a"
+  },
+  "web.admin.organizations.addMember.fields.organizations": {
+    "text": "ארגונים נוכחיים",
+    "source_hash": "cbb5b92f"
+  },
+  "web.admin.organizations.addMember.roleHints.member": {
+    "text": "גישה יומיומית לסודות ולדומיינים של הארגון.",
+    "source_hash": "d0c7439e"
+  },
+  "web.admin.organizations.addMember.roleHints.admin": {
+    "text": "יכול לנהל חברים, דומיינים והגדרות ארגון.",
+    "source_hash": "beaa50d7"
+  },
+  "web.admin.organizations.addMember.roleHints.owner": {
+    "text": "שליטה מלאה, כולל חיובים. הענק זאת רק כשמתבקש.",
+    "source_hash": "614ace63"
+  },
+  "web.admin.organizations.addMember.roles.member": {
+    "text": "חבר",
+    "source_hash": "7c968fb7"
+  },
+  "web.admin.organizations.addMember.roles.admin": {
+    "text": "מנהל",
+    "source_hash": "c1c224b0"
+  },
+  "web.admin.organizations.addMember.roles.owner": {
+    "text": "בעלים",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.detail.members.openCustomer": {
+    "text": "פתח רשומת לקוח",
+    "source_hash": "c057ca13"
+  },
+  "web.admin.organizations.detail.reconcile.memberships": {
+    "text": "חברויות הומטעו מחדש:",
+    "source_hash": "fe7db10c"
+  },
+  "web.admin.organizations.detail.reconcile.membershipsFailed": {
+    "text": "נכשל, זכויות מיושנות נותרו:",
+    "source_hash": "cc4dae37"
+  },
+  "web.admin.organizations.entitlements.catalogWarning": {
+    "text": "\"{entitlement}\" אינו בקטלוג החיובים — בדוק שגיאת כתיב. ממשיך בכל זאת: הענקת זכות שתשלח בקטלוג מאוחר יותר נתמכת ואינה נחסמת בכוונה.",
+    "source_hash": "cbde548a"
+  },
+  "web.admin.organizations.entitlements.matrix.caption": {
+    "text": "מטריצת פתרון זכויות: תוכנית, הענקות ושלילות דריסה, הסט המפותר, ומה שמומטע.",
+    "source_hash": "9eac8999"
+  },
+  "web.admin.organizations.entitlements.matrix.yes": {
+    "text": "כן",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.matrix.no": {
+    "text": "לא",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.matrix.empty": {
+    "text": "לארגון זה אין זכויות מהתוכנית שלו ואין דריסות.",
+    "source_hash": "f6cf2169"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.entitlement": {
+    "text": "זכות",
+    "source_hash": "0d8f0b2d"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.inPlan": {
+    "text": "בתוכנית",
+    "source_hash": "e2222361"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.granted": {
+    "text": "הוענק",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.revoked": {
+    "text": "בוטל",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.expected": {
+    "text": "צפוי",
+    "source_hash": "ca99b7f1"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.materialized": {
+    "text": "מומטע",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.state": {
+    "text": "מצב",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.formula": {
+    "text": "פתרון: צפוי = (תוכנית ∪ הענקות) − שלילות. מומטע הוא מה שמאוחסן בפועל בארגון.",
+    "source_hash": "bc4bff2d"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.orphaned": {
+    "text": "יתום — מומטע אך לא צפוי, בדרך כלל נשאר מאחורי שלילה שמעולם לא הומטעה מחדש. התאמה מסירה אותו.",
+    "source_hash": "3a27a9af"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.missing": {
+    "text": "חסר — צפוי אך לא מומטע. זו ההרשאה שחברים חסרים בפועל כרגע.",
+    "source_hash": "485e44ad"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.revoked": {
+    "text": "שורות מחוקות בוטלו על ידי דריסת מנהל, שמסירה אותן מהסט הצפוי.",
+    "source_hash": "89a2e9b6"
+  },
+  "web.admin.organizations.entitlements.matrix.state.plan": {
+    "text": "מהתוכנית",
+    "source_hash": "1d346b26"
+  },
+  "web.admin.organizations.entitlements.matrix.state.granted": {
+    "text": "הוענק",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.state.revoked": {
+    "text": "בוטל",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.state.orphaned": {
+    "text": "יתום",
+    "source_hash": "8d827807"
+  },
+  "web.admin.organizations.entitlements.matrix.state.missing": {
+    "text": "חסר",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.organizations.entitlements.picker.selectPlaceholder": {
+    "text": "בחר זכות…",
+    "source_hash": "53af3be8"
+  },
+  "web.admin.organizations.entitlements.picker.other": {
+    "text": "אחר — לא בקטלוג…",
+    "source_hash": "f08bc3a3"
+  },
+  "web.admin.organizations.entitlements.picker.customLabel": {
+    "text": "שם זכות (לא בקטלוג)",
+    "source_hash": "52783229"
+  },
+  "web.admin.organizations.entitlements.picker.backToCatalog": {
+    "text": "חזרה לקטלוג",
+    "source_hash": "9b727f40"
+  },
+  "web.admin.organizations.entitlements.picker.uncategorized": {
+    "text": "ללא קטגוריה",
+    "source_hash": "8d40d123"
+  },
+  "web.admin.organizations.entitlements.picker.catalogUnavailable": {
+    "text": "לא ניתן לקרוא את קטלוג החיובים, לכן שמות הזכויות אינם נבדקים כאן.",
+    "source_hash": "724869ec"
+  },
+  "web.admin.organizations.entitlements.picker.tags.inPlan": {
+    "text": "בתוכנית",
+    "source_hash": "5f2251bb"
+  },
+  "web.admin.organizations.entitlements.picker.tags.granted": {
+    "text": "הוענק",
+    "source_hash": "dd515d19"
+  },
+  "web.admin.organizations.entitlements.picker.tags.revoked": {
+    "text": "בוטל",
+    "source_hash": "4bb47f18"
+  },
+  "web.admin.organizations.entitlements.summary.sync": {
+    "text": "סנכרון",
+    "source_hash": "8d261a37"
+  },
+  "web.admin.organizations.entitlements.summary.materialized": {
+    "text": "מומטע",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.summary.materializedAt": {
+    "text": "הומטע לאחרונה",
+    "source_hash": "9325dce9"
+  },
+  "web.admin.organizations.entitlements.summary.planDefinition": {
+    "text": "הגדרת תוכנית",
+    "source_hash": "6b531454"
+  },
+  "web.admin.organizations.entitlements.summary.yes": {
+    "text": "כן",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.summary.no": {
+    "text": "לא",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.summary.never": {
+    "text": "אף פעם",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.organizations.entitlements.summary.planStale": {
+    "text": "השתנה מאז ההמטעה",
+    "source_hash": "e682d8a4"
+  },
+  "web.admin.organizations.entitlements.summary.planCurrent": {
+    "text": "עדכני",
+    "source_hash": "e0d1b682"
+  },
+  "web.admin.organizations.entitlements.summary.planUnknown": {
+    "text": "לא ידוע — לא ניתן להשוות",
+    "source_hash": "b607e540"
   }
 }

--- a/locales/content/he/admin-secrets.json
+++ b/locales/content/he/admin-secrets.json
@@ -1,11 +1,11 @@
 {
   "web.admin.secrets.title": {
-    "text": "סודות",
-    "source_hash": "d8707d41"
+    "text": "קבלות סודות",
+    "source_hash": "a8a2d0e4"
   },
   "web.admin.secrets.description": {
-    "text": "בדוק את אישור הקבלה של סוד ומחק אותו ללא SSH — חפש אותו לפי המפתח שלו.",
-    "source_hash": "07775a11"
+    "text": "חפש מצב, חותמות זמן, קבלה וכו'.",
+    "source_hash": "91fba2a1"
   },
   "web.admin.secrets.never": {
     "text": "מעולם לא",
@@ -108,20 +108,20 @@
     "source_hash": "504101bc"
   },
   "web.admin.secrets.lookup.resultTitle": {
-    "text": "סוד {shortid}",
-    "source_hash": "8b311d32"
+    "text": "רשומת סוד {shortid}",
+    "source_hash": "ee06d765"
   },
   "web.admin.secrets.lookup.notFound": {
-    "text": "הסוד לא נמצא",
-    "source_hash": "70a9532c"
+    "text": "לא נמצאה רשומה",
+    "source_hash": "40f4d9e9"
   },
   "web.admin.secrets.lookup.notFoundDescription": {
     "text": "לא קיים סוד עם מפתח זה. ייתכן שפג תוקפו או שנמחק.",
     "source_hash": "9f068a81"
   },
   "web.admin.secrets.lookup.loadError": {
-    "text": "לא ניתן לטעון סוד זה.",
-    "source_hash": "c96672e4"
+    "text": "לא ניתן לטעון רשומה זו.",
+    "source_hash": "de77cc72"
   },
   "web.admin.secrets.lookup.retry": {
     "text": "נסה שוב",
@@ -188,8 +188,8 @@
     "source_hash": "c127dab6"
   },
   "web.admin.secrets.sections.secret": {
-    "text": "סוד",
-    "source_hash": "7e32a729"
+    "text": "רשומת סוד",
+    "source_hash": "263813c6"
   },
   "web.admin.secrets.sections.receipt": {
     "text": "אישור קבלה",
@@ -214,5 +214,25 @@
   "web.admin.secrets.state.viewed": {
     "text": "נצפה",
     "source_hash": "1b28d178"
+  },
+  "web.admin.secrets.capability.title": {
+    "text": "מטא-נתונים בלבד",
+    "source_hash": "df0453d1"
+  },
+  "web.admin.secrets.capability.canRead": {
+    "text": "קורא מטא-נתונים של סוד ואת הקבלה שלו: מצב, חותמות זמן, בעלים, וגודל הטקסט המוצפן המאוחסן.",
+    "source_hash": "d438ecc7"
+  },
+  "web.admin.secrets.capability.cannotRead": {
+    "text": "לא יכול לפענח או להציג תוכן סוד. נקודת הקצה מאחורי מסך זה לעולם אינה מחזירה אותו.",
+    "source_hash": "7f69f222"
+  },
+  "web.admin.secrets.capability.canDelete": {
+    "text": "יכול למחוק לצמיתות סוד ואת הקבלה שלו, מה שמשמיד את התוכן מבלי לחשוף אותו אי פעם.",
+    "source_hash": "77f2bc7e"
+  },
+  "web.admin.secrets.lookup.hint": {
+    "text": "המזהה מקישור הסוד — לא תוכן הסוד.",
+    "source_hash": "acfbc352"
   }
 }

--- a/locales/content/he/admin-system.json
+++ b/locales/content/he/admin-system.json
@@ -154,5 +154,133 @@
   "web.admin.system.redis.captured": {
     "text": "נלכד {at}",
     "source_hash": "57b40c0f"
+  },
+  "web.admin.system.brand.title": {
+    "text": "אבחון מיתוג",
+    "source_hash": "1cf9abd5"
+  },
+  "web.admin.system.brand.description": {
+    "text": "איזו חבילת מיתוג המופע הפעיל פתר על הדיסק — מציג מדוע אזור עשוי להגיש מיתוג ניטרלי.",
+    "source_hash": "be29e282"
+  },
+  "web.admin.system.brand.loadError": {
+    "text": "לא ניתן לטעון אבחון מיתוג.",
+    "source_hash": "80607303"
+  },
+  "web.admin.system.brand.none": {
+    "text": "(אין)",
+    "source_hash": "552e4230"
+  },
+  "web.admin.system.brand.resolution": {
+    "text": "פתרון",
+    "source_hash": "d4055faf"
+  },
+  "web.admin.system.brand.envVsConfig": {
+    "text": "סביבה מול תצורה",
+    "source_hash": "bee3debb"
+  },
+  "web.admin.system.brand.absorbed": {
+    "text": "מפתחות נספגים",
+    "source_hash": "9784e110"
+  },
+  "web.admin.system.brand.operatorKeys": {
+    "text": "מפתחות מפעיל",
+    "source_hash": "434e8248"
+  },
+  "web.admin.system.brand.overlayAssets": {
+    "text": "נכסי שכבת-על",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.exists.yes": {
+    "text": "קיים",
+    "source_hash": "43f9b89c"
+  },
+  "web.admin.system.brand.exists.no": {
+    "text": "חסר",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.system.brand.fields.resolvedDir": {
+    "text": "ספריה שנפתרה",
+    "source_hash": "0623b983"
+  },
+  "web.admin.system.brand.fields.home": {
+    "text": "בית",
+    "source_hash": "3a786953"
+  },
+  "web.admin.system.brand.fields.envPack": {
+    "text": "חבילת מיתוג ENV",
+    "source_hash": "940aeb5c"
+  },
+  "web.admin.system.brand.fields.configPack": {
+    "text": "חבילת מיתוג תצורה",
+    "source_hash": "761b9550"
+  },
+  "web.admin.system.brand.fields.envAssetsDir": {
+    "text": "ספריית נכסי מיתוג ENV",
+    "source_hash": "05854f1f"
+  },
+  "web.admin.system.brand.fields.configAssetsDir": {
+    "text": "ספריית נכסי מיתוג תצורה",
+    "source_hash": "e91e5c46"
+  },
+  "web.admin.system.brand.flags.fellBack.danger": {
+    "text": "נפל חזרה לחבילת ברירת מחדל",
+    "source_hash": "7bf7ba2f"
+  },
+  "web.admin.system.brand.flags.fellBack.ok": {
+    "text": "חבילת מיתוג נפתרה",
+    "source_hash": "1ab3162f"
+  },
+  "web.admin.system.brand.flags.mismatch.danger": {
+    "text": "אי-התאמה בין אתחול לחי",
+    "source_hash": "0a022192"
+  },
+  "web.admin.system.brand.flags.mismatch.ok": {
+    "text": "אתחול תואם לחי",
+    "source_hash": "d4792c09"
+  },
+  "web.admin.system.brand.manifest.title": {
+    "text": "מניפסט",
+    "source_hash": "3c99f1f3"
+  },
+  "web.admin.system.brand.manifest.path": {
+    "text": "נתיב",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.manifest.exists": {
+    "text": "קיים",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.manifest.keysOnDisk": {
+    "text": "מפתחות בדיסק",
+    "source_hash": "52439c03"
+  },
+  "web.admin.system.brand.roots.title": {
+    "text": "שורשי חיפוש",
+    "source_hash": "d8696f2b"
+  },
+  "web.admin.system.brand.roots.empty": {
+    "text": "אין שורשי חיפוש",
+    "source_hash": "867a471c"
+  },
+  "web.admin.system.brand.roots.columns.path": {
+    "text": "נתיב",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.roots.columns.exists": {
+    "text": "קיים",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.stats.brandPack": {
+    "text": "חבילת מיתוג",
+    "source_hash": "884437d0"
+  },
+  "web.admin.system.brand.stats.overlayAssets": {
+    "text": "נכסי שכבת-על",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.stats.manifestKeys": {
+    "text": "מפתחות מניפסט",
+    "source_hash": "c4267198"
   }
 }

--- a/locales/content/he/email.json
+++ b/locales/content/he/email.json
@@ -836,5 +836,41 @@
   "email.secret_link.footer_note": {
     "text": "קיבלת הודעה זו מכיוון ש-%{sender_email} השתמש ב-%{product_name} כדי לשתף איתך סוד. אם לא ציפית לכך, באפשרותך להתעלם מהודעת דוא״ל זו בבטחה.",
     "source_hash": "2d544dad"
+  },
+  "email.sso_link_verification.subject": {
+    "text": "אשר קישור %{provider} לחשבון %{product_name} שלך",
+    "source_hash": "65e70296"
+  },
+  "email.sso_link_verification.title": {
+    "text": "אשר את כניסת ה-SSO שלך",
+    "source_hash": "35bce6cc"
+  },
+  "email.sso_link_verification.request_notice": {
+    "text": "מישהו נכנס עם %{provider} באמצעות הדוא\"ל %{email_address}. כדי לסיים לחבר את %{provider} לחשבון %{product_name} שלך, אשר למטה.",
+    "source_hash": "baeb18c0"
+  },
+  "email.sso_link_verification.confirm_button": {
+    "text": "אשר וקשר %{provider}",
+    "source_hash": "9809e210"
+  },
+  "email.sso_link_verification.copy_link_prompt": {
+    "text": "או העתק והדבק קישור זה:",
+    "source_hash": "88c72144"
+  },
+  "email.sso_link_verification.expiration_notice": {
+    "text": "קישור זה פג תוקף תוך 15 דקות וניתן להשתמש בו פעם אחת בלבד.",
+    "source_hash": "1a437f42"
+  },
+  "email.sso_link_verification.ignore_notice": {
+    "text": "אם לא ניסית להיכנס עם %{provider}, תוכל להתעלם מדוא\"ל זה בבטחה — שום דבר לא יחובר לחשבון שלך.",
+    "source_hash": "d7317d30"
+  },
+  "email.sso_link_verification.signature": {
+    "text": "צוות התמיכה",
+    "source_hash": "dc75bf9f"
+  },
+  "email.sso_link_verification.postscript": {
+    "text": "נ.ב. דוא\"ל זה נשלח אל %{email_address}.",
+    "source_hash": "8ab1dbea"
   }
 }

--- a/locales/content/he/email.json
+++ b/locales/content/he/email.json
@@ -846,7 +846,7 @@
     "source_hash": "35bce6cc"
   },
   "email.sso_link_verification.request_notice": {
-    "text": "מישהו נכנס עם %{provider} באמצעות הדוא\"ל %{email_address}. כדי לסיים לחבר את %{provider} לחשבון %{product_name} שלך, אשר למטה.",
+    "text": "מישהו נכנס עם %{provider} באמצעות הדוא״ל %{email_address}. כדי לסיים לחבר את %{provider} לחשבון %{product_name} שלך, אשר למטה.",
     "source_hash": "baeb18c0"
   },
   "email.sso_link_verification.confirm_button": {
@@ -862,7 +862,7 @@
     "source_hash": "1a437f42"
   },
   "email.sso_link_verification.ignore_notice": {
-    "text": "אם לא ניסית להיכנס עם %{provider}, תוכל להתעלם מדוא\"ל זה בבטחה — שום דבר לא יחובר לחשבון שלך.",
+    "text": "אם לא ניסית להיכנס עם %{provider}, תוכל להתעלם מדוא״ל זה בבטחה — שום דבר לא יחובר לחשבון שלך.",
     "source_hash": "d7317d30"
   },
   "email.sso_link_verification.signature": {
@@ -870,7 +870,7 @@
     "source_hash": "dc75bf9f"
   },
   "email.sso_link_verification.postscript": {
-    "text": "נ.ב. דוא\"ל זה נשלח אל %{email_address}.",
+    "text": "נ.ב. דוא״ל זה נשלח אל %{email_address}.",
     "source_hash": "8ab1dbea"
   }
 }

--- a/locales/content/he/session-auth-extended.json
+++ b/locales/content/he/session-auth-extended.json
@@ -757,6 +757,7 @@
   },
   "web.auth.connections.connect_action": {
     "text": "חבר {provider}",
+    "context": "Button label to start linking a specific SSO provider; {provider} is the provider display name",
     "source_hash": "c77540af"
   },
   "web.auth.connections.issuer": {
@@ -821,6 +822,7 @@
   },
   "web.link_sso.prompt": {
     "text": "נכנסת עם {provider}, שמתאים לחשבון הקיים {email}. הזן את הסיסמה של חשבון זה כדי לקשר את {provider} ולהמשיך.",
+    "context": "Instruction on the sign-in interstitial. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/link-sso/:token.",
     "source_hash": "59da1c08"
   },
   "web.link_sso.password_label": {
@@ -881,6 +883,7 @@
   },
   "web.sso_link_confirm.prompt": {
     "text": "נכנסת עם {provider}, שמתאים לחשבון שלך {email}. אשר כדי לחבר את {provider} לחשבון זה ולסיים את הכניסה.",
+    "context": "Consent instruction on the #3840 Phase 4 mailbox-proof SSO linking page. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/sso-link-confirm/:token. No password is asked — clicking the emailed link is the proof.",
     "source_hash": "6ff0d6cc"
   },
   "web.sso_link_confirm.submit": {

--- a/locales/content/he/session-auth-extended.json
+++ b/locales/content/he/session-auth-extended.json
@@ -730,5 +730,201 @@
   "web.auth.sessions.session_plural": {
     "text": "הפעלות",
     "source_hash": "1225ae6c"
+  },
+  "web.auth.connections.title": {
+    "text": "זהויות מחוברות",
+    "source_hash": "e132c4d9"
+  },
+  "web.auth.connections.description": {
+    "text": "נהל את ספקי ה-SSO המקושרים לחשבון שלך.",
+    "source_hash": "42c6d148"
+  },
+  "web.auth.connections.section_title": {
+    "text": "כניסה יחידה",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.section_subtitle": {
+    "text": "ספקי זהות שבהם תוכל להשתמש כדי להיכנס לחשבון זה",
+    "source_hash": "507254cd"
+  },
+  "web.auth.connections.connect_title": {
+    "text": "חבר ספק",
+    "source_hash": "a002b3f3"
+  },
+  "web.auth.connections.connect_description": {
+    "text": "קשר ספק כניסה יחידה נוסף שבו תוכל להשתמש כדי להיכנס לחשבון זה.",
+    "source_hash": "32895a5a"
+  },
+  "web.auth.connections.connect_action": {
+    "text": "חבר {provider}",
+    "source_hash": "c77540af"
+  },
+  "web.auth.connections.issuer": {
+    "text": "מנפיק",
+    "source_hash": "39e02c46"
+  },
+  "web.auth.connections.identifier": {
+    "text": "מזהה",
+    "source_hash": "9b10587f"
+  },
+  "web.auth.connections.remove": {
+    "text": "הסר",
+    "source_hash": "c3812fc4"
+  },
+  "web.auth.connections.remove_confirm_title": {
+    "text": "הסר זהות מחוברת",
+    "source_hash": "4e8ffe4c"
+  },
+  "web.auth.connections.remove_confirm_message": {
+    "text": "האם אתה בטוח שברצונך להסיר זהות מחוברת זו? לא תוכל עוד להיכנס איתה.",
+    "source_hash": "64939c89"
+  },
+  "web.auth.connections.removed_success": {
+    "text": "זהות מחוברת הוסרה",
+    "source_hash": "cf87daf3"
+  },
+  "web.auth.connections.no_identities": {
+    "text": "אין זהויות מחוברות",
+    "source_hash": "5254048e"
+  },
+  "web.auth.connections.no_identities_description": {
+    "text": "עדיין לא קישרת ספקי כניסה יחידה לחשבון זה.",
+    "source_hash": "0f58d5d0"
+  },
+  "web.auth.connections.overview_status": {
+    "text": "כניסה יחידה",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.errors.last_credential": {
+    "text": "זו הדרך היחידה שלך להיכנס. חבר ספק נוסף תחילה, או הגדר סיסמה מהגדרות ← אבטחה, כדי שלא תינעל.",
+    "source_hash": "3de8084d"
+  },
+  "web.auth.connections.errors.last_credential_sso_enforced": {
+    "text": "זו הדרך היחידה שלך להיכנס. חבר ספק נוסף תחילה כדי שלא תינעל.",
+    "source_hash": "eed7a50e"
+  },
+  "web.auth.connections.errors.not_found": {
+    "text": "לא ניתן למצוא את הזהות המחוברת. ייתכן שהיא כבר הוסרה.",
+    "source_hash": "cf2c7673"
+  },
+  "web.auth.connections.errors.unauthorized": {
+    "text": "ההפעלה שלך פגה. היכנס שוב.",
+    "source_hash": "b529fce2"
+  },
+  "web.auth.connections.errors.generic": {
+    "text": "לא יכולנו להשלים פעולה זו. נסה שוב.",
+    "source_hash": "a0d4edc0"
+  },
+  "web.link_sso.title": {
+    "text": "קשר את שיטת הכניסה שלך",
+    "source_hash": "46339bac"
+  },
+  "web.link_sso.prompt": {
+    "text": "נכנסת עם {provider}, שמתאים לחשבון הקיים {email}. הזן את הסיסמה של חשבון זה כדי לקשר את {provider} ולהמשיך.",
+    "source_hash": "59da1c08"
+  },
+  "web.link_sso.password_label": {
+    "text": "סיסמה",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.link_sso.password_placeholder": {
+    "text": "הסיסמה הקיימת שלך",
+    "source_hash": "ad4e56da"
+  },
+  "web.link_sso.submit": {
+    "text": "קשר והמשך",
+    "source_hash": "c969b759"
+  },
+  "web.link_sso.cancel": {
+    "text": "ביטול",
+    "source_hash": "19766ed6"
+  },
+  "web.link_sso.unavailable_title": {
+    "text": "בקשת הקישור פגה תוקף",
+    "source_hash": "b53c7e55"
+  },
+  "web.link_sso.unavailable_message": {
+    "text": "למען אבטחתך, הבקשה לקשר שיטת כניסה זו אינה תקפה עוד. היכנס עם הסיסמה הקיימת שלך, ואז חבר ספק זה תחת הגדרות אבטחה ← זהויות מחוברות.",
+    "source_hash": "f7e349d1"
+  },
+  "web.link_sso.unavailable_action": {
+    "text": "המשך לכניסה",
+    "source_hash": "d398cd0a"
+  },
+  "web.link_sso.errors.invalid_password": {
+    "text": "הסיסמה אינה תואמת לחשבון זה. נסה שוב.",
+    "source_hash": "3259b4f5"
+  },
+  "web.link_sso.errors.invalid_token": {
+    "text": "בקשת הקישור פגה תוקף או כבר נוצלה. היכנס עם הסיסמה הקיימת שלך, ואז חבר ספק זה מהגדרות החשבון שלך.",
+    "source_hash": "541f9127"
+  },
+  "web.link_sso.errors.link_conflict": {
+    "text": "לא יכולנו לקשר שיטת כניסה זו. ייתכן שהחשבון שלך השתנה, או שספק זה כבר מקושר לחשבון אחר. היכנס עם הסיסמה הקיימת שלך, ואז נהל חיבורים תחת הגדרות אבטחה ← זהויות מחוברות.",
+    "source_hash": "7b0e0d0e"
+  },
+  "web.link_sso.errors.link_rate_limited": {
+    "text": "יותר מדי ניסיונות סיסמה. המתן מספר דקות, ואז נסה שוב.",
+    "source_hash": "a95e78cd"
+  },
+  "web.link_sso.errors.invalid_request": {
+    "text": "לא יכולנו לעבד בקשת קישור זו. היכנס שוב עם ספק ה-SSO שלך.",
+    "source_hash": "053b9fc6"
+  },
+  "web.link_sso.errors.generic": {
+    "text": "לא יכולנו לקשר את החשבון שלך. נסה שוב.",
+    "source_hash": "f727c174"
+  },
+  "web.sso_link_confirm.title": {
+    "text": "אשר חיבור החשבון שלך",
+    "source_hash": "ad80bfe7"
+  },
+  "web.sso_link_confirm.prompt": {
+    "text": "נכנסת עם {provider}, שמתאים לחשבון שלך {email}. אשר כדי לחבר את {provider} לחשבון זה ולסיים את הכניסה.",
+    "source_hash": "6ff0d6cc"
+  },
+  "web.sso_link_confirm.submit": {
+    "text": "אשר וחבר",
+    "source_hash": "5cf663e6"
+  },
+  "web.sso_link_confirm.cancel": {
+    "text": "ביטול",
+    "source_hash": "19766ed6"
+  },
+  "web.sso_link_confirm.unavailable_title": {
+    "text": "לא ניתן להשלים בקשת קישור זו",
+    "source_hash": "47abb784"
+  },
+  "web.sso_link_confirm.unavailable_message": {
+    "text": "למען אבטחתך, בקשה זו לחבר את שיטת הכניסה שלך אינה תקפה עוד. היכנס שוב עם הספק שלך ונשלח לך קישור חדש בדוא\"ל.",
+    "source_hash": "080e6f9f"
+  },
+  "web.sso_link_confirm.unavailable_action": {
+    "text": "חזור לכניסה",
+    "source_hash": "8504054f"
+  },
+  "web.sso_link_confirm.errors.link_expired": {
+    "text": "בקשת הקישור פגה תוקף או כבר נוצלה. היכנס שוב עם הספק שלך ונשלח לך קישור חדש בדוא\"ל.",
+    "source_hash": "a50538df"
+  },
+  "web.sso_link_confirm.errors.link_conflict": {
+    "text": "לא יכולנו לחבר שיטת כניסה זו. ייתכן שהחשבון שלך השתנה, או שספק זה כבר מקושר לחשבון אחר. היכנס שוב עם הספק שלך כדי להמשיך.",
+    "source_hash": "c954854b"
+  },
+  "web.sso_link_confirm.errors.link_invalidated": {
+    "text": "אישורי החשבון שלך השתנו לאחר שליחת קישור זה, לכן הוא אינו תקף עוד. היכנס שוב עם הספק שלך ונשלח לך קישור חדש בדוא\"ל.",
+    "source_hash": "db88cb1d"
+  },
+  "web.sso_link_confirm.errors.link_error": {
+    "text": "משהו השתבש בצד שלנו ולא יכולנו לאמת קישור זה. היכנס שוב עם הספק שלך ונשלח לך קישור חדש.",
+    "source_hash": "ec24e0a1"
+  },
+  "web.sso_link_confirm.errors.confirm_rate_limited": {
+    "text": "יותר מדי ניסיונות מהמכשיר שלך. המתן מספר דקות, ואז פתח שוב את הקישור שנשלח בדוא\"ל או היכנס עם הספק שלך לקישור חדש.",
+    "source_hash": "f29af782"
+  },
+  "web.sso_link_confirm.errors.generic": {
+    "text": "לא יכולנו לאשר חיבור זה. היכנס שוב עם הספק שלך.",
+    "source_hash": "076fa25a"
   }
 }

--- a/locales/content/he/session-auth.json
+++ b/locales/content/he/session-auth.json
@@ -483,5 +483,41 @@
   "web.login.verified_notice": {
     "text": "הדוא״ל שלך אומת — כעת באפשרותך להתחבר.",
     "source_hash": "c8d4b5a8"
+  },
+  "web.auth.password_setup_request.title": {
+    "text": "הגדר סיסמה",
+    "source_hash": "11b6978b"
+  },
+  "web.auth.password_setup_request.description": {
+    "text": "לחשבון שלך עדיין אין סיסמה. נשלח לך קישור מאובטח בדוא\"ל להגדרת אחת כדי שתוכל גם להיכנס ישירות.",
+    "source_hash": "dc0b561f"
+  },
+  "web.auth.password_setup_request.button": {
+    "text": "שלח קישור הגדרה",
+    "source_hash": "22807292"
+  },
+  "web.auth.password_setup_request.emailSent": {
+    "text": "נשלח אליך דוא\"ל עם קישור להגדרת סיסמה לחשבון שלך",
+    "source_hash": "82b686c7"
+  },
+  "web.login.errors.account_exists_link_required": {
+    "text": "כבר קיים חשבון עם כתובת דוא\"ל זו אך הוא אינו מקושר לשיטת כניסה זו. היכנס עם השיטה הקיימת שלך, ואז קשר ספק זה תחת הגדרות אבטחה ← זהויות מחוברות.",
+    "source_hash": "7fbbb7e7"
+  },
+  "web.login.errors.identity_connect_conflict": {
+    "text": "לא ניתן לחבר זהות זו. ייתכן שהחיבור הוחל בדומיין שגוי, או שההפעלה שלך פגה. היכנס שוב, ואז חבר אותה מהגדרות החשבון שלך.",
+    "source_hash": "4238bbf2"
+  },
+  "web.login.errors.org_join_failed": {
+    "text": "לא יכולנו לסיים להוסיף אותך לארגון שלך. צור קשר עם המנהל שלך.",
+    "source_hash": "155e71bb"
+  },
+  "web.login.errors.link_sso_failed": {
+    "text": "לא יכולנו לקשר שיטת כניסה זו. היכנס עם הסיסמה הקיימת שלך, ואז חבר ספק זה תחת הגדרות אבטחה ← זהויות מחוברות.",
+    "source_hash": "49954127"
+  },
+  "web.login.notices.link_verification_sent": {
+    "text": "בדוק את תיבת הדואר הנכנס שלך — שלחנו לך קישור בדוא\"ל לאישור חיבור החשבון שלך. פתח אותו כדי לסיים את הכניסה.",
+    "source_hash": "b251c8f3"
   }
 }

--- a/locales/content/he/workspace-account.json
+++ b/locales/content/he/workspace-account.json
@@ -694,5 +694,33 @@
   "web.settings.security.sso_managed_description": {
     "text": "החשבון שלך מאומת באמצעות ספק הכניסה היחידה (SSO) של הארגון שלך. סיסמה, אימות רב-שלבי וקודי שחזור מנוהלים על ידי ספק הזהויות שלך.",
     "source_hash": "cd0cf39f"
+  },
+  "web.settings.api.api_username": {
+    "text": "שם משתמש API",
+    "source_hash": "0b3e483e"
+  },
+  "web.settings.api.api_username_description": {
+    "text": "שם המשתמש שלך לאימות HTTP Basic",
+    "source_hash": "f3e65de3"
+  },
+  "web.settings.api.basic_auth_hint": {
+    "text": "לאימות HTTP Basic, השתמש בדוא\"ל החשבון שלך או במזהה זה כשם משתמש ובאסימון ה-API שלך כסיסמה.",
+    "source_hash": "cfa3806d"
+  },
+  "web.settings.security.set": {
+    "text": "מוגדר",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.settings.security.not_set": {
+    "text": "לא מוגדר",
+    "source_hash": "4895f731"
+  },
+  "web.settings.security.set_password_title": {
+    "text": "הגדר סיסמה",
+    "source_hash": "4e411687"
+  },
+  "web.settings.security.set_password_description": {
+    "text": "הוסף סיסמה לחשבון שלך כדי שתוכל גם להיכנס ללא ספק הזהות שלך",
+    "source_hash": "a6970402"
   }
 }

--- a/locales/content/he/workspace-account.json
+++ b/locales/content/he/workspace-account.json
@@ -704,7 +704,7 @@
     "source_hash": "f3e65de3"
   },
   "web.settings.api.basic_auth_hint": {
-    "text": "לאימות HTTP Basic, השתמש בדוא\"ל החשבון שלך או במזהה זה כשם משתמש ובאסימון ה-API שלך כסיסמה.",
+    "text": "לאימות HTTP Basic, השתמש בדוא״ל החשבון שלך או במזהה זה כשם משתמש ובאסימון ה-API שלך כסיסמה.",
     "source_hash": "cfa3806d"
   },
   "web.settings.security.set": {

--- a/locales/content/he/workspace-billing.json
+++ b/locales/content/he/workspace-billing.json
@@ -1044,5 +1044,21 @@
   "web.billing.plans.reactivate": {
     "text": "הפעל מחדש",
     "source_hash": "2dc7478f"
+  },
+  "web.billing.currency_migration.refund_failed_warning": {
+    "text": "התוכנית הקודמת שלך בוטלה, אך לא יכולנו להנפיק אוטומטית החזר עבור הזמן שלא נוצל. צור קשר עם התמיכה כדי לקבל את ההחזר. עדיין עליך להשלים את התשלום כדי להפעיל את התוכנית החדשה שלך.",
+    "source_hash": "a390c498"
+  },
+  "web.billing.currency_migration.refund_failed_continue": {
+    "text": "המשך לתשלום",
+    "source_hash": "eccdb8aa"
+  },
+  "web.billing.plans.per_year": {
+    "text": "/שנה",
+    "source_hash": "a2d5f1bc"
+  },
+  "web.billing.plans.billing_interval": {
+    "text": "תדירות חיוב",
+    "source_hash": "3ce28209"
   }
 }

--- a/locales/content/he/workspace-branding.json
+++ b/locales/content/he/workspace-branding.json
@@ -56,12 +56,12 @@
     "source_hash": "e36598ef"
   },
   "web.branding.example_pre_reveal_instructions": {
-    "text": "השתמש בטלפון שלך כדי לסרוק את קוד ה-QR",
-    "source_hash": "99ecf59f"
+    "text": "למשל: השתמש בטלפון שלך לסריקת קוד ה-QR",
+    "source_hash": "9cf0caf8"
   },
   "web.branding.example_post_reveal_instructions": {
-    "text": "צור קשר עם onboarding{'@'}example.com לכל שאלה",
-    "source_hash": "bee120a7"
+    "text": "למשל: צור קשר עם onboarding{'@'}example.com לכל שאלה",
+    "source_hash": "71749811"
   },
   "web.branding.these_instructions_will_be_shown_to_recipients_before": {
     "text": "הוראות אלו יוצגו לנמענים לפני שיחשפו את תוכן הסוד",
@@ -320,8 +320,8 @@
     "source_hash": "bc79cdff"
   },
   "web.branding.paths_carryover_hint": {
-    "text": "זוהי תצוגה מקדימה חיה — השינויים שלך לא יהיו גלויים למבקרים עד שתשמור.",
-    "source_hash": "cb4b82de"
+    "text": "זו תצוגה מקדימה חיה — השינויים שלך לא יהיו גלויים למבקרים עד שתלחץ עדכון.",
+    "source_hash": "9a34df71"
   },
   "web.branding.coming_soon_match_blurb": {
     "text": "הפנה אותנו לאתר שלך ואנחנו נקרא את הצבעים והגופנים שלו, ואז נסגור את הפער בלחיצה אחת.",
@@ -406,5 +406,57 @@
   "web.branding.delivery_after_reveal": {
     "text": "אחרי החשיפה",
     "source_hash": "d5bfe7fd"
+  },
+  "web.branding.favicon": {
+    "text": "סמל אתר",
+    "source_hash": "42955289"
+  },
+  "web.branding.refresh_favicon": {
+    "text": "רענן סמל אתר מהדומיין",
+    "source_hash": "7cc3d5dc"
+  },
+  "web.branding.refresh_favicon_hint": {
+    "text": "שלוף שוב את סמל האתר מהדומיין שלך. הסמל החדש יופיע בקרוב.",
+    "source_hash": "ee007e44"
+  },
+  "web.branding.refresh_favicon_queued": {
+    "text": "מרענן סמל אתר — הסמל החדש יופיע בקרוב.",
+    "source_hash": "6bf38e6e"
+  },
+  "web.branding.refresh_favicon_user_upload_hint": {
+    "text": "העלית סמל אתר מותאם אישית, לכן סמל שנשלף לא יחליף אותו.",
+    "source_hash": "c22e1ed6"
+  },
+  "web.branding.upload_favicon": {
+    "text": "העלה סמל אתר",
+    "source_hash": "ceda39cb"
+  },
+  "web.branding.replace_favicon": {
+    "text": "החלף",
+    "source_hash": "95e15439"
+  },
+  "web.branding.remove_favicon": {
+    "text": "הסר סמל אתר",
+    "source_hash": "03693698"
+  },
+  "web.branding.favicon_field_hint": {
+    "text": "ICO, PNG או SVG. העלאה מחליפה את הסמל שנשלף.",
+    "source_hash": "dfa0bfcb"
+  },
+  "web.branding.favicon_preview_alt": {
+    "text": "סמל אתר של הדומיין",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_title": {
+    "text": "סמל אתר של הדומיין",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_hint": {
+    "text": "ICO, PNG או SVG. עד 256KB. מחליף את הסמל שנשלף אוטומטית.",
+    "source_hash": "c9eafc83"
+  },
+  "web.branding.favicon_modal_save": {
+    "text": "שמור סמל אתר",
+    "source_hash": "c8a1566c"
   }
 }

--- a/locales/content/he/workspace-organizations.json
+++ b/locales/content/he/workspace-organizations.json
@@ -1034,5 +1034,153 @@
   "web.organizations.create_workspace": {
     "text": "צור סביבת עבודה",
     "source_hash": "c63c14cf"
+  },
+  "web.organizations.organization_id": {
+    "text": "מזהה ארגון",
+    "source_hash": "1f466322"
+  },
+  "web.organizations.organization_id_hint": {
+    "text": "השתמש במזהה זה כאשר יוצר קשר עם התמיכה או מגביל בקשות API לארגון זה. זה אינו אישור כניסה.",
+    "source_hash": "29549b3a"
+  },
+  "web.organizations.audit.title": {
+    "text": "פעילות סודות",
+    "source_hash": "6d6d41f3"
+  },
+  "web.organizations.audit.description": {
+    "text": "מסלול ביקורת של אירועי יצירה וגישה לסודות שנרשמו עבור ארגון זה.",
+    "source_hash": "553c564b"
+  },
+  "web.organizations.audit.country_unknown": {
+    "text": "לא ידוע",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.empty_title": {
+    "text": "אין עדיין פעילות",
+    "source_hash": "0a12b92c"
+  },
+  "web.organizations.audit.empty_description": {
+    "text": "אירועי יצירה וגישה לסודות יופיעו כאן כאשר הצוות שלך משתף סודות.",
+    "source_hash": "62fb14c2"
+  },
+  "web.organizations.audit.capped_notice": {
+    "text": "רק {max} האירועים החדשים ביותר נשמרים; פעילות ישנה יותר נחתכה.",
+    "source_hash": "da7901e2"
+  },
+  "web.organizations.audit.collection_paused_notice": {
+    "text": "איסוף אירועים מושהה; פעילות סודות חדשה אינה נרשמת.",
+    "source_hash": "cb09d147"
+  },
+  "web.organizations.audit.load_error": {
+    "text": "לא ניתן לטעון פעילות סודות.",
+    "source_hash": "52fde814"
+  },
+  "web.organizations.audit.contract_mismatch": {
+    "text": "לא ניתן לקרוא את נתוני הפעילות שהוחזרו מהשרת. המסלול אינו ריק — פשוט לא ניתן להציג אותו כרגע.",
+    "source_hash": "db0d007a"
+  },
+  "web.organizations.audit.retry": {
+    "text": "נסה שוב",
+    "source_hash": "d8b8392e"
+  },
+  "web.organizations.audit.showing_range": {
+    "text": "מציג {from}–{to} מתוך {total}",
+    "source_hash": "c329279d"
+  },
+  "web.organizations.audit.upgrade_prompt": {
+    "text": "פעילות סודות דורשת תוכנית עם יומני ביקורת. שדרג כדי לראות מי יצר, צפה וחשף סודות בארגון זה.",
+    "source_hash": "453649ce"
+  },
+  "web.organizations.audit.role_required": {
+    "text": "פעילות סודות זמינה לבעלים ומנהלי ארגון.",
+    "source_hash": "e066ec63"
+  },
+  "web.organizations.audit.actors.creator": {
+    "text": "יוצר",
+    "source_hash": "88447b83"
+  },
+  "web.organizations.audit.actors.authenticated_other": {
+    "text": "משתמש מחובר אחר",
+    "source_hash": "ee45aa5a"
+  },
+  "web.organizations.audit.actors.anonymous": {
+    "text": "אנונימי",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.organizations.audit.actors.system": {
+    "text": "מערכת",
+    "source_hash": "6725e7bb"
+  },
+  "web.organizations.audit.actors.unknown": {
+    "text": "לא ידוע",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.columns.event": {
+    "text": "אירוע",
+    "source_hash": "4e1f49a9"
+  },
+  "web.organizations.audit.columns.secret": {
+    "text": "סוד",
+    "source_hash": "7e32a729"
+  },
+  "web.organizations.audit.columns.actor": {
+    "text": "פעיל",
+    "source_hash": "449995c4"
+  },
+  "web.organizations.audit.columns.country": {
+    "text": "מדינה",
+    "source_hash": "701d021d"
+  },
+  "web.organizations.audit.columns.when": {
+    "text": "מתי",
+    "source_hash": "cf9c7aa2"
+  },
+  "web.organizations.audit.kinds.created": {
+    "text": "סוד נוצר",
+    "source_hash": "e4a1e1fd"
+  },
+  "web.organizations.audit.kinds.status_get": {
+    "text": "מצב קישור נבדק",
+    "source_hash": "0753f60e"
+  },
+  "web.organizations.audit.kinds.secret_get": {
+    "text": "קישור סוד נפתח",
+    "source_hash": "e271e060"
+  },
+  "web.organizations.audit.kinds.previewed": {
+    "text": "תצוגה מקדימה על ידי היוצר",
+    "source_hash": "639fc1e2"
+  },
+  "web.organizations.audit.kinds.creator_status_get": {
+    "text": "מצב נבדק על ידי היוצר",
+    "source_hash": "7e4b5de5"
+  },
+  "web.organizations.audit.kinds.receipt_viewed": {
+    "text": "קבלה נצפתה",
+    "source_hash": "a417ead4"
+  },
+  "web.organizations.audit.kinds.revealed": {
+    "text": "סוד נחשף",
+    "source_hash": "aff2c84d"
+  },
+  "web.organizations.audit.kinds.burned": {
+    "text": "סוד נמחק סופית",
+    "source_hash": "5ac68dc6"
+  },
+  "web.organizations.audit.kinds.expired": {
+    "text": "סוד פג תוקף",
+    "source_hash": "c127dab6"
+  },
+  "web.organizations.audit.kinds.orphaned": {
+    "text": "סוד הפך ליתום",
+    "source_hash": "23fe1a47"
+  },
+  "web.organizations.audit.kinds.reveal_failed_undecryptable": {
+    "text": "חשיפה נכשלה (לא ניתן לפענוח)",
+    "source_hash": "d5616abf"
+  },
+  "web.organizations.tabs.activity": {
+    "text": "פעילות",
+    "source_hash": "38da1505"
   }
 }


### PR DESCRIPTION
## `he` translation update

Automated export of completed **he** translations from the translation task DB.
Scope: `locales/content/he/` only — 16 file(s), +2020/-20.

⚠️ `i18n validate variables` reports **3** variable mismatch(es) for `he` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ⚠️ Needs review — punctuation inconsistency, validator false positives

**Summary:** Large addition (~700 keys) across admin, auth/SSO, billing, branding, and email modules; all interpolation variables ({var}, %{var}) are preserved correctly in the actual translated strings, and brand terms (Onetime Secret, Stripe, SSO, API, TLS, MFA) are left appropriately untranslated.

**Critical (must fix):** None — the 3 flagged validator errors are `.context` metadata keys (translator-facing English annotations describing what `{provider}`/`{email}` mean), not user-facing strings; the corresponding real keys (`web.auth.connections.connect_action`, `web.link_sso.prompt`, `web.sso_link_confirm.prompt`) are present in the diff and correctly translated with variables intact. These `.context` keys aren't touched by this diff (pre-existing empty state), matching the known context-field validator false-positive pattern seen in other locales today.

**Warnings:**
- Inconsistent punctuation for the דוא"ל (email) abbreviation: most entries correctly use the Hebrew gershayim mark (״, e.g. `web.admin.organizations.addMember.searchLabel`), but four new entries use a straight/escaped ASCII quote instead (`email.sso_link_verification.request_notice`, `.ignore_notice`, `.postscript`, and `web.settings.api.basic_auth_hint` — all render as `דוא\"ל`). Cosmetic but visibly inconsistent in RTL Hebrew typography; worth normalizing to ״.

**Notes:**
- `web.admin.customers.description` and `web.branding.example_pre_reveal_instructions`/`paths_carryover_hint` show intentional re-wording tied to source_hash changes (e.g. "without SSH" removed, "e.g.:" prefix added, "Save"→"Update" button rename) — consistent with English source updates, not translation drift.
- RTL breadcrumb arrows (`←`) used consistently for "Settings → Security → Connected Identities" style paths — correct direction for RTL reading order.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
