### PR TITLE
i18n: update hu translations

### DIFF
--- a/locales/content/hu/00-common.json
+++ b/locales/content/hu/00-common.json
@@ -1539,5 +1539,9 @@
   "web.TITLES.domain_dns": {
     "text": "DNS-beállítás",
     "source_hash": "6c63df31"
+  },
+  "web.TITLES.connected_identities": {
+    "text": "Összekapcsolt azonosítók",
+    "source_hash": "e132c4d9"
   }
 }

--- a/locales/content/hu/admin-audit.json
+++ b/locales/content/hu/admin-audit.json
@@ -98,5 +98,41 @@
   "web.admin.audit.result.failure": {
     "text": "Sikertelen",
     "source_hash": "7031edbc"
+  },
+  "web.admin.audit.categories.secret": {
+    "text": "Titkok",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.audit.categories.membership": {
+    "text": "Tagságok",
+    "source_hash": "b50f1a42"
+  },
+  "web.admin.audit.categories.entitlement_preview": {
+    "text": "Jogosultság előnézetek",
+    "source_hash": "255c5797"
+  },
+  "web.admin.audit.categories.colonel": {
+    "text": "Colonel bejelentkezések",
+    "source_hash": "01eeeb38"
+  },
+  "web.admin.audit.filters.actorLabel": {
+    "text": "Szereplő",
+    "source_hash": "449995c4"
+  },
+  "web.admin.audit.filters.searchButton": {
+    "text": "Keresés",
+    "source_hash": "49c266ba"
+  },
+  "web.admin.audit.filters.searchHint": {
+    "text": "Adjon meg egy szereplőt, majd nyomja meg az Entert, vagy válassza a Keresés gombot a futtatáshoz. A lista nem frissül gépelés közben.",
+    "source_hash": "45eceb12"
+  },
+  "web.admin.audit.filters.pendingSearch": {
+    "text": "Még nincs keresve — nyomja meg az Entert, vagy válassza a Keresés gombot a szereplő alkalmazásához.",
+    "source_hash": "f76095c2"
+  },
+  "web.admin.audit.list.contractError": {
+    "text": "A szerver válaszolt, de az audit adatok nem feleltek meg a várt formátumnak. Nem lehet eseményeket megjeleníteni — ez egy jelentéskészítési hiba, nem üres napló.",
+    "source_hash": "7f48137e"
   }
 }

--- a/locales/content/hu/admin-billing.json
+++ b/locales/content/hu/admin-billing.json
@@ -122,5 +122,85 @@
   "web.admin.billing.status.changed": {
     "text": "Módosítva",
     "source_hash": "2a6141e4"
+  },
+  "web.admin.billing.diff.backToCatalog": {
+    "text": "Vissza a számlázási katalógushoz",
+    "source_hash": "8532b373"
+  },
+  "web.admin.billing.diff.driftedFields": {
+    "text": "Eltérő mezők:",
+    "source_hash": "9890c95b"
+  },
+  "web.admin.billing.diff.notFound": {
+    "text": "A csomag nem található a katalógusban",
+    "source_hash": "0253898b"
+  },
+  "web.admin.billing.diff.notFoundDescription": {
+    "text": "Nem található {planid} azonosítójú csomag a konfigurált katalógusban vagy az élő Stripe-szinkronizált gyorsítótárban.",
+    "source_hash": "2e69551c"
+  },
+  "web.admin.billing.stripeOrgs.title": {
+    "text": "Stripe ügyfelek",
+    "source_hash": "0463ae27"
+  },
+  "web.admin.billing.stripeOrgs.description": {
+    "text": "Stripe ügyfélrekordhoz kapcsolt szervezetek.",
+    "source_hash": "2ab09aec"
+  },
+  "web.admin.billing.stripeOrgs.searchPlaceholder": {
+    "text": "Keresés Stripe ügyfél-azonosító alapján",
+    "source_hash": "d5acf08f"
+  },
+  "web.admin.billing.stripeOrgs.empty": {
+    "text": "Egyetlen szervezetnek sincs Stripe ügyfél-azonosítója.",
+    "source_hash": "2e373537"
+  },
+  "web.admin.billing.stripeOrgs.emptySearch": {
+    "text": "Nincs a keresésnek megfelelő Stripe ügyfél-azonosító.",
+    "source_hash": "75011174"
+  },
+  "web.admin.billing.stripeOrgs.loadError": {
+    "text": "Nem sikerült betölteni a Stripe ügyfelek listáját.",
+    "source_hash": "15e2d9a7"
+  },
+  "web.admin.billing.stripeOrgs.unavailable": {
+    "text": "A Stripe ügyfelek listája még nem érhető el ezen a szerveren.",
+    "source_hash": "aab6451a"
+  },
+  "web.admin.billing.stripeOrgs.none": {
+    "text": "Nincs",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.billing.stripeOrgs.capped": {
+    "text": "Az indexkeresés elérte a korlátot, így az összeg alsó korlát — szűkítse a keresést a többi megtekintéséhez.",
+    "source_hash": "20bcaa38"
+  },
+  "web.admin.billing.stripeOrgs.stale": {
+    "text": "{count} indexbejegyzés ezen az oldalon olyan szervezetre mutat, amely már nem töltődik be, és ki lett hagyva.",
+    "source_hash": "51980f83"
+  },
+  "web.admin.billing.stripeOrgs.copyStripeId": {
+    "text": "Stripe ügyfél-azonosító másolása",
+    "source_hash": "a77d18b1"
+  },
+  "web.admin.billing.stripeOrgs.columns.organization": {
+    "text": "Szervezet",
+    "source_hash": "d764d425"
+  },
+  "web.admin.billing.stripeOrgs.columns.owner": {
+    "text": "Tulajdonos",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.billing.stripeOrgs.columns.plan": {
+    "text": "Csomag",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.billing.stripeOrgs.columns.subscription": {
+    "text": "Előfizetés",
+    "source_hash": "4999c6c6"
+  },
+  "web.admin.billing.stripeOrgs.columns.stripeCustomer": {
+    "text": "Stripe ügyfél-azonosító",
+    "source_hash": "7e1d8bbb"
   }
 }

--- a/locales/content/hu/admin-colonel.json
+++ b/locales/content/hu/admin-colonel.json
@@ -838,5 +838,37 @@
   "web.colonel.nav.groups.communications": {
     "text": "Kommunikáció",
     "source_hash": "919a9253"
+  },
+  "web.colonel.organizations.sameAsContact": {
+    "text": "Ugyanaz, mint a kapcsolattartó",
+    "source_hash": "ed18ff43"
+  },
+  "web.colonel.organizations.refresh": {
+    "text": "Frissítés",
+    "source_hash": "0e916101"
+  },
+  "web.colonel.organizations.updatedAgo": {
+    "text": "Frissítve {ago}",
+    "source_hash": "cda30b9c"
+  },
+  "web.colonel.organizations.columns.name": {
+    "text": "Név",
+    "source_hash": "dcd1d522"
+  },
+  "web.colonel.organizations.columns.contactEmail": {
+    "text": "Kapcsolattartási e-mail",
+    "source_hash": "6d7fce11"
+  },
+  "web.colonel.organizations.columns.billingEmail": {
+    "text": "Számlázási e-mail",
+    "source_hash": "8805b928"
+  },
+  "web.colonel.organizations.columns.planSubscription": {
+    "text": "Csomag és előfizetés",
+    "source_hash": "b396caac"
+  },
+  "web.colonel.organizations.filters.searchPlaceholder": {
+    "text": "Keresés azonosító, név vagy e-mail alapján",
+    "source_hash": "6fe16473"
   }
 }

--- a/locales/content/hu/admin-customers.json
+++ b/locales/content/hu/admin-customers.json
@@ -4,8 +4,8 @@
     "source_hash": "aabe76f1"
   },
   "web.admin.customers.description": {
-    "text": "Keressen meg egy ügyfelet, és oldjon meg támogatási problémákat SSH nélkül.",
-    "source_hash": "c8487e68"
+    "text": "Keressen ügyfeleket és oldjon meg támogatási problémákat.",
+    "source_hash": "00961ea3"
   },
   "web.admin.customers.actions.plan.label": {
     "text": "Csomag",
@@ -482,5 +482,213 @@
   "web.admin.customers.suspended.badge": {
     "text": "Felfüggesztve",
     "source_hash": "e392a389"
+  },
+  "web.admin.customers.actions.checkoutLink.button": {
+    "text": "Fizetési hivatkozás létrehozása",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.modalTitle": {
+    "text": "Fizetési hivatkozás létrehozása",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.planLabel": {
+    "text": "Csomag",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.actions.checkoutLink.planPlaceholder": {
+    "text": "Csomagcsalád azonosító (pl. identity_plus_v1)",
+    "source_hash": "12eba027"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleLabel": {
+    "text": "Számlázási ciklus",
+    "source_hash": "d69f731e"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleMonthly": {
+    "text": "Havi",
+    "source_hash": "9b11f6b7"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleYearly": {
+    "text": "Éves",
+    "source_hash": "6e69b59e"
+  },
+  "web.admin.customers.actions.checkoutLink.allowPromo": {
+    "text": "Promóciós kódok engedélyezése",
+    "source_hash": "ebe7bc8b"
+  },
+  "web.admin.customers.actions.checkoutLink.submit": {
+    "text": "Hivatkozás létrehozása",
+    "source_hash": "e6b850cf"
+  },
+  "web.admin.customers.actions.checkoutLink.resultLead": {
+    "text": "Fizetési hivatkozás létrehozva. Ossza meg az ügyféllel — egyszer használható és lejár.",
+    "source_hash": "6ff1fb0e"
+  },
+  "web.admin.customers.actions.checkoutLink.copy": {
+    "text": "Fizetési hivatkozás másolása",
+    "source_hash": "f1e51ca7"
+  },
+  "web.admin.customers.actions.checkoutLink.expiry": {
+    "text": "Lejár ~{hours} óra múlva ({date}).",
+    "source_hash": "4c878a15"
+  },
+  "web.admin.customers.actions.checkoutLink.regionLabel": {
+    "text": "Régió",
+    "source_hash": "d3a008ef"
+  },
+  "web.admin.customers.actions.checkoutLink.parseError": {
+    "text": "A szerver elfogadta a kérést, de olvashatatlan választ adott, így a hivatkozás nem jeleníthető meg. Ellenőrizze a Stripe-ot az újrapróbálkozás előtt.",
+    "source_hash": "e7e08290"
+  },
+  "web.admin.customers.actions.checkoutLink.done": {
+    "text": "Kész",
+    "source_hash": "11a6767d"
+  },
+  "web.admin.customers.actions.purge.typePrompt": {
+    "text": "A megerősítéshez írja be a fiók e-mail címét ({token}) alább",
+    "source_hash": "8b2a1819"
+  },
+  "web.admin.customers.actions.purge.unavailable": {
+    "text": "A törlés nem érhető el: ennek a fióknak nincs e-mail címe, amelyet megerősítésként beírhatna.",
+    "source_hash": "5f20f7e5"
+  },
+  "web.admin.customers.columns.actions": {
+    "text": "Műveletek",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.diagnostics.title": {
+    "text": "Fiók diagnosztika",
+    "source_hash": "5574ece8"
+  },
+  "web.admin.customers.detail.diagnostics.loading": {
+    "text": "Diagnosztika futtatása…",
+    "source_hash": "062c83d5"
+  },
+  "web.admin.customers.detail.diagnostics.loadError": {
+    "text": "Nem sikerült betölteni a diagnosztikát.",
+    "source_hash": "69e69f49"
+  },
+  "web.admin.customers.detail.diagnostics.healthy": {
+    "text": "Nem található blokkoló állapot. A hitelesítési állapot egészségesnek tűnik — gyanítson kliens oldali problémákat (sütik, egyéni domain bejelentkezési beállítások) vagy rossz régiót.",
+    "source_hash": "f6d5f8d1"
+  },
+  "web.admin.customers.detail.diagnostics.authUnavailable": {
+    "text": "Hitelesítési adatbázis nem érhető el (egyszerű hitelesítési mód) — SQL oldali ellenőrzések kihagyva.",
+    "source_hash": "d668907c"
+  },
+  "web.admin.customers.detail.diagnostics.authFailed": {
+    "text": "A hitelesítési adatbázis nem válaszolt, így az SQL oldali ellenőrzések nem futhattak: {reason}",
+    "source_hash": "46d047c0"
+  },
+  "web.admin.customers.detail.diagnostics.unknown": {
+    "text": "Ismeretlen",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.title": {
+    "text": "Hitelesítési napló",
+    "source_hash": "48ad8ba8"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.empty": {
+    "text": "Nincsenek rögzített hitelesítési események.",
+    "source_hash": "d2332558"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.unavailable": {
+    "text": "A hitelesítési napló nem olvasható: {reason}",
+    "source_hash": "ab18af57"
+  },
+  "web.admin.customers.detail.diagnostics.facts.authStatus": {
+    "text": "Hitelesítési állapot",
+    "source_hash": "34def169"
+  },
+  "web.admin.customers.detail.diagnostics.facts.noAccount": {
+    "text": "Nincs hitelesítési fiók",
+    "source_hash": "a9968e9e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.password": {
+    "text": "Jelszó",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordSet": {
+    "text": "Beállítva",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordNone": {
+    "text": "Nincs",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfa": {
+    "text": "MFA",
+    "source_hash": "d39ce053"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfaNone": {
+    "text": "Nincs",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.loginFailures": {
+    "text": "Sikertelen próbálkozások",
+    "source_hash": "63e7f0a8"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lockedBadge": {
+    "text": "Zárolva",
+    "source_hash": "ace29f74"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiter": {
+    "text": "Sebességkorlátozó",
+    "source_hash": "32892404"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterEngaged": {
+    "text": "Aktív",
+    "source_hash": "1b0d851e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterClear": {
+    "text": "Szabad",
+    "source_hash": "83b12c22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verification": {
+    "text": "Ellenőrző e-mail",
+    "source_hash": "23fac8fb"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationPending": {
+    "text": "Függőben — utoljára küldve {date}",
+    "source_hash": "9ab8d1b6"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationNone": {
+    "text": "Nincs függőben",
+    "source_hash": "a4d4cc22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.sessions": {
+    "text": "Aktív munkamenetek",
+    "source_hash": "61ad9909"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lastLogin": {
+    "text": "Utolsó bejelentkezés (hitelesítés)",
+    "source_hash": "373e7fb1"
+  },
+  "web.admin.customers.detail.receipts.partial": {
+    "text": "Részleges lista — a legfrissebb {count} tétel látható. Ennek az ügyfélnek több nyugtája van, mint ami itt megjelenik.",
+    "source_hash": "127fd4db"
+  },
+  "web.admin.customers.detail.secrets.partial": {
+    "text": "Részleges lista — a legfrissebb {count} tétel látható. Ennek az ügyfélnek több titka van, mint ami itt megjelenik.",
+    "source_hash": "a537c8f3"
+  },
+  "web.admin.customers.detail.sessions.columns.country": {
+    "text": "Ország",
+    "source_hash": "701d021d"
+  },
+  "web.admin.customers.detail.sessions.current.badge": {
+    "text": "Ez a munkamenet",
+    "source_hash": "6da6530a"
+  },
+  "web.admin.customers.detail.sessions.current.tooltip": {
+    "text": "Az Ön jelenlegi admin munkamenete. A visszavonásnak itt nincs hatása — a kérés hátralévő részére újra létrejön.",
+    "source_hash": "ef097ab1"
+  },
+  "web.admin.customers.verification.verified": {
+    "text": "Ellenőrzött",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.verification.unverified": {
+    "text": "Nem ellenőrzött",
+    "source_hash": "15133907"
   }
 }

--- a/locales/content/hu/admin-domains.json
+++ b/locales/content/hu/admin-domains.json
@@ -190,5 +190,657 @@
   "web.admin.domains.verify.success.done": {
     "text": "A(z) {domain} ellenőrzése befejeződött.",
     "source_hash": "ed67e22d"
+  },
+  "web.admin.domains.actions.preview": {
+    "text": "Előnézet",
+    "source_hash": "324b134f"
+  },
+  "web.admin.domains.actions.probe.button": {
+    "text": "Ellenőrzés",
+    "source_hash": "3bd51ab9"
+  },
+  "web.admin.domains.actions.remove.button": {
+    "text": "Domain eltávolítása",
+    "source_hash": "5ce43507"
+  },
+  "web.admin.domains.actions.remove.previewButton": {
+    "text": "Eltávolítás előnézete",
+    "source_hash": "6b81bd92"
+  },
+  "web.admin.domains.actions.remove.previewStatus": {
+    "text": "Állapot:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.remove.previewOrg": {
+    "text": "Szervezet:",
+    "source_hash": "5300e286"
+  },
+  "web.admin.domains.actions.remove.reassertsSurvivor": {
+    "text": "Egy másik rekord igényli ugyanezt a domain nevet, és átveszi a keresési indexet.",
+    "source_hash": "902838f4"
+  },
+  "web.admin.domains.actions.remove.confirmTitle": {
+    "text": "Eltávolítja a domaint?",
+    "source_hash": "716dfac9"
+  },
+  "web.admin.domains.actions.remove.confirmDescription": {
+    "text": "Ez véglegesen törli a(z) {domain} domaint és annak márkajelzését, DNS és konfigurációs rekordjait. Ez nem vonható vissza. A folytatáshoz írja be újra a domain nyilvános azonosítóját.",
+    "source_hash": "d0b67b47"
+  },
+  "web.admin.domains.actions.remove.success": {
+    "text": "Domain eltávolítva.",
+    "source_hash": "2ccaa6d3"
+  },
+  "web.admin.domains.actions.remove.notApplied": {
+    "text": "A szerver az eltávolítás előnézetét készítette el az alkalmazás helyett — a domain NEM lett eltávolítva. Próbálja újra, és jelentse, ha a probléma fennáll.",
+    "source_hash": "dc6d70ae"
+  },
+  "web.admin.domains.actions.repair.title": {
+    "text": "Szervezeti kapcsolat javítása",
+    "source_hash": "82b40352"
+  },
+  "web.admin.domains.actions.repair.description": {
+    "text": "Keresse meg és javítsa ki a törött kapcsolatokat a domain és a szervezete között. Először tekintse meg az előnézetet, hogy lássa, mi változna.",
+    "source_hash": "531ed287"
+  },
+  "web.admin.domains.actions.repair.orgIdLabel": {
+    "text": "Szervezet azonosító (csak árva domainek esetén)",
+    "source_hash": "0d3010eb"
+  },
+  "web.admin.domains.actions.repair.orgIdPlaceholder": {
+    "text": "Hagyja üresen, kivéve ha a domainnek nincs tulajdonosa",
+    "source_hash": "118b7132"
+  },
+  "web.admin.domains.actions.repair.statusLabel": {
+    "text": "Állapot:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.repair.noIssues": {
+    "text": "Nem található probléma — nincs mit javítani.",
+    "source_hash": "17735887"
+  },
+  "web.admin.domains.actions.repair.button": {
+    "text": "Javítás alkalmazása",
+    "source_hash": "4d0ab2d4"
+  },
+  "web.admin.domains.actions.repair.confirmTitle": {
+    "text": "Alkalmazza a javítást?",
+    "source_hash": "ef0ffae5"
+  },
+  "web.admin.domains.actions.repair.confirmDescription": {
+    "text": "Ez újraírja a szervezeti kapcsolatot a(z) {domain} domain esetében. A folytatáshoz írja be újra a domain nyilvános azonosítóját.",
+    "source_hash": "a9f2702f"
+  },
+  "web.admin.domains.actions.repair.success": {
+    "text": "Javítás alkalmazva.",
+    "source_hash": "850bd784"
+  },
+  "web.admin.domains.actions.transfer.title": {
+    "text": "Áthelyezés másik szervezethez",
+    "source_hash": "1b0b0655"
+  },
+  "web.admin.domains.actions.transfer.description": {
+    "text": "Helyezze át ezt a domaint egy másik szervezethez. Először tekintse meg az előnézetet az áthelyezés mindkét oldalának megerősítéséhez.",
+    "source_hash": "457e852d"
+  },
+  "web.admin.domains.actions.transfer.toOrgLabel": {
+    "text": "Cél szervezet azonosító",
+    "source_hash": "1a3f05c4"
+  },
+  "web.admin.domains.actions.transfer.fromOrgLabel": {
+    "text": "Várt jelenlegi szervezet azonosító (opcionális)",
+    "source_hash": "f6e75729"
+  },
+  "web.admin.domains.actions.transfer.fromOrgPlaceholder": {
+    "text": "Erősítse meg a jelenlegi tulajdonost az áthelyezés előtt",
+    "source_hash": "1ac6c59b"
+  },
+  "web.admin.domains.actions.transfer.from": {
+    "text": "Innen",
+    "source_hash": "21819769"
+  },
+  "web.admin.domains.actions.transfer.to": {
+    "text": "Ide",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.domains.actions.transfer.orphaned": {
+    "text": "Nincs szervezet (árva)",
+    "source_hash": "6f4c745c"
+  },
+  "web.admin.domains.actions.transfer.button": {
+    "text": "Áthelyezés alkalmazása",
+    "source_hash": "fb546c5c"
+  },
+  "web.admin.domains.actions.transfer.confirmTitle": {
+    "text": "Áthelyezi a domaint?",
+    "source_hash": "801eb986"
+  },
+  "web.admin.domains.actions.transfer.confirmDescription": {
+    "text": "Ez áthelyezi a(z) {domain} domaint a(z) {org} szervezethez. A folytatáshoz írja be újra a domain nyilvános azonosítóját.",
+    "source_hash": "52c8808d"
+  },
+  "web.admin.domains.actions.transfer.success": {
+    "text": "Domain áthelyezve.",
+    "source_hash": "91e681ae"
+  },
+  "web.admin.domains.columns.domain": {
+    "text": "Domain",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domains.columns.organization": {
+    "text": "Szervezet",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.columns.state": {
+    "text": "Ellenőrzés",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.domains.columns.tls": {
+    "text": "TLS",
+    "source_hash": "d1c18ec0"
+  },
+  "web.admin.domains.columns.created": {
+    "text": "Létrehozva",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.columns.actions": {
+    "text": "Műveletek",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.configs.title": {
+    "text": "Domain konfiguráció",
+    "source_hash": "d46aa480"
+  },
+  "web.admin.domains.configs.description": {
+    "text": "Domain-szintű konfigurációs rekordok a bejelentkezés, regisztráció, kezdőlapi titkok, API hozzáférés, bejövő titkok, bérlői SSO és levelezés vezérléséhez. Hiányzó rekord esetén az első öt zárt módon meghiúsul.",
+    "source_hash": "1df99789"
+  },
+  "web.admin.domains.configs.loadError": {
+    "text": "Nem sikerült betölteni a domain konfigurációs rekordokat.",
+    "source_hash": "9417d718"
+  },
+  "web.admin.domains.configs.retry": {
+    "text": "Újrapróbálkozás",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.configs.degraded": {
+    "text": "A konfigurációs válasz nem felelt meg a várt formátumnak. Frissítsen, és jelentse, ha a probléma fennáll.",
+    "source_hash": "b5d890c0"
+  },
+  "web.admin.domains.configs.notFoundNote": {
+    "text": "Ez a domain már nem létezik, így a konfigurációs rekordjai nem tölthetők be.",
+    "source_hash": "2d88a392"
+  },
+  "web.admin.domains.configs.detailsToggle": {
+    "text": "Részletek",
+    "source_hash": "45989de4"
+  },
+  "web.admin.domains.configs.notEditable": {
+    "text": "A munkaterület domain beállításaiban kezelhető.",
+    "source_hash": "54fe891f"
+  },
+  "web.admin.domains.configs.delete.button": {
+    "text": "Törlés",
+    "source_hash": "e2d0a549"
+  },
+  "web.admin.domains.configs.delete.confirmTitle": {
+    "text": "Törli a(z) {kind} konfigurációt?",
+    "source_hash": "98e672db"
+  },
+  "web.admin.domains.configs.delete.confirmDescription": {
+    "text": "Ez véglegesen törli a(z) {kind} konfigurációs rekordot a(z) {domain} domain esetében. A domain visszaáll a hiányzó rekord viselkedésére. A folytatáshoz írja be újra a típust.",
+    "source_hash": "8272c40c"
+  },
+  "web.admin.domains.configs.delete.success": {
+    "text": "Konfiguráció törölve.",
+    "source_hash": "a0184b66"
+  },
+  "web.admin.domains.configs.edit.button": {
+    "text": "Szerkesztés",
+    "source_hash": "464c4ffd"
+  },
+  "web.admin.domains.configs.edit.createButton": {
+    "text": "Létrehozás",
+    "source_hash": "4759498a"
+  },
+  "web.admin.domains.configs.edit.title": {
+    "text": "{kind} konfigurálása",
+    "source_hash": "8592148f"
+  },
+  "web.admin.domains.configs.edit.submit": {
+    "text": "Mentés",
+    "source_hash": "1509f561"
+  },
+  "web.admin.domains.configs.edit.success": {
+    "text": "Konfiguráció mentve.",
+    "source_hash": "6b5b3c69"
+  },
+  "web.admin.domains.configs.edit.unsetOption": {
+    "text": "Nincs beállítva",
+    "source_hash": "4895f731"
+  },
+  "web.admin.domains.configs.edit.domainsHint": {
+    "text": "Soronként egy domain.",
+    "source_hash": "6c03f4f7"
+  },
+  "web.admin.domains.configs.ensure.button": {
+    "text": "Hiányzó konfigurációk létrehozása",
+    "source_hash": "77991b75"
+  },
+  "web.admin.domains.configs.ensure.confirmTitle": {
+    "text": "Létrehozza a hiányzó konfigurációs rekordokat?",
+    "source_hash": "3f41dec2"
+  },
+  "web.admin.domains.configs.ensure.confirmDescription": {
+    "text": "Letiltott rekordokat hoz létre a(z) {domain} domainen a következőkhöz: {kinds}. Minden letiltva indul, így a viselkedés nem változik, amíg egy rekordot nem engedélyeznek.",
+    "source_hash": "fed66221"
+  },
+  "web.admin.domains.configs.ensure.applyButton": {
+    "text": "Rekordok létrehozása",
+    "source_hash": "4bcbef42"
+  },
+  "web.admin.domains.configs.ensure.success": {
+    "text": "Hiányzó konfigurációs rekordok létrehozva.",
+    "source_hash": "3b6ead80"
+  },
+  "web.admin.domains.configs.ensure.nothingMissing": {
+    "text": "Nincs mit létrehozni — minden konfigurációs rekord már létezik. A lista frissítve.",
+    "source_hash": "ad0df0ae"
+  },
+  "web.admin.domains.configs.ensure.notApplied": {
+    "text": "A szerver a módosítás előnézetét készítette el az alkalmazás helyett — nem jöttek létre rekordok. Próbálja újra, és jelentse, ha a probléma fennáll.",
+    "source_hash": "09d26379"
+  },
+  "web.admin.domains.configs.fields.enabled": {
+    "text": "Engedélyezve",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.fields.signin_enabled": {
+    "text": "Bejelentkezés engedélyezve",
+    "source_hash": "cabe4898"
+  },
+  "web.admin.domains.configs.fields.email_auth_enabled": {
+    "text": "E-mail hitelesítés engedélyezve",
+    "source_hash": "4a762960"
+  },
+  "web.admin.domains.configs.fields.sso_enabled": {
+    "text": "SSO engedélyezve",
+    "source_hash": "6e77e673"
+  },
+  "web.admin.domains.configs.fields.restrict_to": {
+    "text": "Korlátozás",
+    "source_hash": "a0bdf50a"
+  },
+  "web.admin.domains.configs.fields.signup_enabled": {
+    "text": "Regisztráció engedélyezve",
+    "source_hash": "2637d0b2"
+  },
+  "web.admin.domains.configs.fields.autoverify": {
+    "text": "Automatikus ellenőrzés",
+    "source_hash": "7e02211c"
+  },
+  "web.admin.domains.configs.fields.validation_strategy": {
+    "text": "Ellenőrzési stratégia",
+    "source_hash": "a2e95531"
+  },
+  "web.admin.domains.configs.fields.allowed_signup_domains": {
+    "text": "Engedélyezett regisztrációs domainek",
+    "source_hash": "9b5bb5b1"
+  },
+  "web.admin.domains.configs.fields.secrets_mode": {
+    "text": "Titkok mód",
+    "source_hash": "8d4349d6"
+  },
+  "web.admin.domains.configs.fields.disabled_homepage_variant": {
+    "text": "Letiltott kezdőlap változat",
+    "source_hash": "4695633b"
+  },
+  "web.admin.domains.configs.fields.ready": {
+    "text": "Kész",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.configs.fields.recipients": {
+    "text": "Címzettek",
+    "source_hash": "1e8568a8"
+  },
+  "web.admin.domains.configs.fields.provider_type": {
+    "text": "Szolgáltató típusa",
+    "source_hash": "8c0f6d3e"
+  },
+  "web.admin.domains.configs.fields.display_name": {
+    "text": "Megjelenített név",
+    "source_hash": "2b7f6a84"
+  },
+  "web.admin.domains.configs.fields.issuer": {
+    "text": "Kibocsátó",
+    "source_hash": "39e02c46"
+  },
+  "web.admin.domains.configs.fields.tenant_id": {
+    "text": "Bérlő azonosító",
+    "source_hash": "de1f5fff"
+  },
+  "web.admin.domains.configs.fields.has_client_id": {
+    "text": "Kliens azonosító beállítva",
+    "source_hash": "04a9fa3d"
+  },
+  "web.admin.domains.configs.fields.has_client_secret": {
+    "text": "Kliens titkos kulcs beállítva",
+    "source_hash": "6ee1c9e6"
+  },
+  "web.admin.domains.configs.fields.allowed_domains": {
+    "text": "Engedélyezett domainek",
+    "source_hash": "bcd60db0"
+  },
+  "web.admin.domains.configs.fields.enforce_sso_only": {
+    "text": "Csak SSO kikényszerítése",
+    "source_hash": "b3a3f694"
+  },
+  "web.admin.domains.configs.fields.grant_org_scope": {
+    "text": "Szervezeti hatókör megadása",
+    "source_hash": "698ea5de"
+  },
+  "web.admin.domains.configs.fields.provider": {
+    "text": "Szolgáltató",
+    "source_hash": "472590ae"
+  },
+  "web.admin.domains.configs.fields.from_name": {
+    "text": "Feladó neve",
+    "source_hash": "b28f93ea"
+  },
+  "web.admin.domains.configs.fields.from_address": {
+    "text": "Feladó címe",
+    "source_hash": "d465bcfa"
+  },
+  "web.admin.domains.configs.fields.reply_to": {
+    "text": "Válaszcím",
+    "source_hash": "6b9c49b7"
+  },
+  "web.admin.domains.configs.fields.sending_mode": {
+    "text": "Küldési mód",
+    "source_hash": "e2d6bcf7"
+  },
+  "web.admin.domains.configs.fields.verification_status": {
+    "text": "Ellenőrzési állapot",
+    "source_hash": "aedfff7e"
+  },
+  "web.admin.domains.configs.fields.dns_verified": {
+    "text": "DNS ellenőrizve",
+    "source_hash": "8b2128c8"
+  },
+  "web.admin.domains.configs.fields.provider_verified": {
+    "text": "Szolgáltató ellenőrizve",
+    "source_hash": "6f4d9cc4"
+  },
+  "web.admin.domains.configs.fields.has_api_key": {
+    "text": "API kulcs beállítva",
+    "source_hash": "d5115386"
+  },
+  "web.admin.domains.configs.fields.created": {
+    "text": "Létrehozva",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.configs.fields.updated": {
+    "text": "Frissítve",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.configs.kinds.signin": {
+    "text": "Bejelentkezés",
+    "source_hash": "5bbbe531"
+  },
+  "web.admin.domains.configs.kinds.signup": {
+    "text": "Regisztráció",
+    "source_hash": "3cc08ebe"
+  },
+  "web.admin.domains.configs.kinds.homepage": {
+    "text": "Kezdőlap",
+    "source_hash": "9e3391e9"
+  },
+  "web.admin.domains.configs.kinds.api": {
+    "text": "API",
+    "source_hash": "c8e5998f"
+  },
+  "web.admin.domains.configs.kinds.incoming": {
+    "text": "Bejövő",
+    "source_hash": "e301820a"
+  },
+  "web.admin.domains.configs.kinds.sso": {
+    "text": "SSO",
+    "source_hash": "5ba3ac9f"
+  },
+  "web.admin.domains.configs.kinds.mailer": {
+    "text": "Levelező",
+    "source_hash": "6c07ba63"
+  },
+  "web.admin.domains.configs.missingNotes.signin": {
+    "text": "Nincs rekord: a bejelentkezés le van tiltva ezen a domainen, kivéve ha a bérlői SSO aktív.",
+    "source_hash": "17dd6099"
+  },
+  "web.admin.domains.configs.missingNotes.signup": {
+    "text": "Nincs rekord: a regisztráció le van tiltva ezen a domainen.",
+    "source_hash": "c3c98956"
+  },
+  "web.admin.domains.configs.missingNotes.homepage": {
+    "text": "Nincs rekord: a kezdőlapi titkok le vannak tiltva (zárt módon meghiúsul és hibát naplóz).",
+    "source_hash": "9a258a88"
+  },
+  "web.admin.domains.configs.missingNotes.api": {
+    "text": "Nincs rekord: a nyilvános API le van tiltva (zárt módon meghiúsul és hibát naplóz).",
+    "source_hash": "fed99f73"
+  },
+  "web.admin.domains.configs.missingNotes.incoming": {
+    "text": "Nincs rekord: a bejövő titkok le vannak tiltva.",
+    "source_hash": "b957fbe8"
+  },
+  "web.admin.domains.configs.missingNotes.sso": {
+    "text": "Nincs rekord: a bérlői SSO nem érhető el; a platform SSO tartalék szabályzat érvényes.",
+    "source_hash": "7b05ade8"
+  },
+  "web.admin.domains.configs.missingNotes.mailer": {
+    "text": "Nincs rekord: a platform levelezője van használatban.",
+    "source_hash": "e027cc99"
+  },
+  "web.admin.domains.configs.status.missing": {
+    "text": "Hiányzik",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.domains.configs.status.disabled": {
+    "text": "Letiltva",
+    "source_hash": "75081b59"
+  },
+  "web.admin.domains.configs.status.enabled": {
+    "text": "Engedélyezve",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.status.enabledNotReady": {
+    "text": "Engedélyezve, nem áll készen",
+    "source_hash": "cb806ba4"
+  },
+  "web.admin.domains.detail.openFullPage": {
+    "text": "Teljes oldal megnyitása",
+    "source_hash": "a467911c"
+  },
+  "web.admin.domains.detail.backToList": {
+    "text": "Vissza a domainekhez",
+    "source_hash": "22fd50fe"
+  },
+  "web.admin.domains.detail.notFound": {
+    "text": "Domain nem található",
+    "source_hash": "7b8fc0e6"
+  },
+  "web.admin.domains.detail.notFoundDescription": {
+    "text": "Ez a domain nem létezik, vagy már el lett távolítva.",
+    "source_hash": "e0f0b987"
+  },
+  "web.admin.domains.detail.loadError": {
+    "text": "Nem sikerült betölteni ezt a domaint.",
+    "source_hash": "39e9c657"
+  },
+  "web.admin.domains.detail.retry": {
+    "text": "Újrapróbálkozás",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.detail.never": {
+    "text": "Soha",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.domains.detail.none": {
+    "text": "Nincs",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.domains.detail.yes": {
+    "text": "Igen",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.domains.detail.no": {
+    "text": "Nem",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.domains.detail.organization.open": {
+    "text": "Szervezet megnyitása",
+    "source_hash": "54a43621"
+  },
+  "web.admin.domains.detail.organization.unknown": {
+    "text": "A tulajdonos szervezet nincs benne ebben a válaszban. Nyissa meg ezt a domaint a domainek listájából a megtekintéséhez.",
+    "source_hash": "bb5bdc9c"
+  },
+  "web.admin.domains.detail.sections.overview": {
+    "text": "Áttekintés",
+    "source_hash": "d4b1ea57"
+  },
+  "web.admin.domains.detail.sections.actions": {
+    "text": "Műveletek",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.detail.sections.organization": {
+    "text": "Tulajdonos szervezet",
+    "source_hash": "39ad6d9c"
+  },
+  "web.admin.domains.detail.sections.dns": {
+    "text": "DNS",
+    "source_hash": "020965a2"
+  },
+  "web.admin.domains.detail.sections.diagnostics": {
+    "text": "Diagnosztika",
+    "source_hash": "268f14bb"
+  },
+  "web.admin.domains.detail.sections.operations": {
+    "text": "Tulajdonosi műveletek",
+    "source_hash": "eb9a8cbc"
+  },
+  "web.admin.domains.detail.sections.operationsHint": {
+    "text": "Minden művelet először előnézetet készít. Semmi nem kerül mentésre, amíg meg nem erősíti az alkalmazási lépést.",
+    "source_hash": "f09bf7bd"
+  },
+  "web.admin.domains.fields.publicId": {
+    "text": "Nyilvános azonosító",
+    "source_hash": "3705b64f"
+  },
+  "web.admin.domains.fields.domainId": {
+    "text": "Belső azonosító",
+    "source_hash": "e468bb47"
+  },
+  "web.admin.domains.fields.organization": {
+    "text": "Szervezet",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.fields.baseDomain": {
+    "text": "Alap domain",
+    "source_hash": "33295d5b"
+  },
+  "web.admin.domains.fields.subdomain": {
+    "text": "Aldomain",
+    "source_hash": "ba4520ab"
+  },
+  "web.admin.domains.fields.apex": {
+    "text": "Apex domain",
+    "source_hash": "0a8a42fa"
+  },
+  "web.admin.domains.fields.status": {
+    "text": "Állapot",
+    "source_hash": "920e413c"
+  },
+  "web.admin.domains.fields.created": {
+    "text": "Létrehozva",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.fields.updated": {
+    "text": "Frissítve",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.fields.verified": {
+    "text": "Ellenőrizve",
+    "source_hash": "4f783840"
+  },
+  "web.admin.domains.fields.resolving": {
+    "text": "Feloldás folyamatban",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.fields.ready": {
+    "text": "Kész",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.list.searchPlaceholder": {
+    "text": "Keresés domain név vagy azonosító alapján",
+    "source_hash": "aecdd873"
+  },
+  "web.admin.domains.list.stateFilter": {
+    "text": "Állapot",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.domains.list.emptyFilter": {
+    "text": "Nincs a jelenlegi szűrőknek megfelelő domain.",
+    "source_hash": "be4d64ec"
+  },
+  "web.admin.domains.probe.healthLabel": {
+    "text": "Állapot",
+    "source_hash": "55898449"
+  },
+  "web.admin.domains.probe.certInvalid": {
+    "text": "A tanúsítvány nem használható",
+    "source_hash": "5535f4d4"
+  },
+  "web.admin.domains.probe.noCertificate": {
+    "text": "Nem érkezett tanúsítvány — a kapcsolat a TLS előtt meghiúsult.",
+    "source_hash": "8ffd63be"
+  },
+  "web.admin.domains.probe.fields.httpStatus": {
+    "text": "HTTP státusz",
+    "source_hash": "0f7cf91f"
+  },
+  "web.admin.domains.probe.fields.httpError": {
+    "text": "HTTP hiba",
+    "source_hash": "5c6896d4"
+  },
+  "web.admin.domains.probe.fields.sslError": {
+    "text": "TLS hiba",
+    "source_hash": "7b827515"
+  },
+  "web.admin.domains.probe.fields.issuer": {
+    "text": "Tanúsítvány kibocsátója",
+    "source_hash": "2912559a"
+  },
+  "web.admin.domains.probe.fields.subject": {
+    "text": "Tanúsítvány tárgya",
+    "source_hash": "d7816b16"
+  },
+  "web.admin.domains.probe.fields.notAfter": {
+    "text": "Tanúsítvány lejár",
+    "source_hash": "1e73119d"
+  },
+  "web.admin.domains.probe.fields.expiresIn": {
+    "text": "{date} ({days} nap)",
+    "source_hash": "a71a6e81"
+  },
+  "web.admin.domains.tls.serving": {
+    "text": "Kiszolgálás",
+    "source_hash": "f55e53f9"
+  },
+  "web.admin.domains.tls.resolving": {
+    "text": "Feloldás",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.tls.none": {
+    "text": "Nem kiszolgál",
+    "source_hash": "da8a5ab9"
   }
 }

--- a/locales/content/hu/admin-organizations.json
+++ b/locales/content/hu/admin-organizations.json
@@ -310,5 +310,333 @@
   "web.admin.organizations.list.loadError": {
     "text": "Nem sikerült betölteni a szervezeteket.",
     "source_hash": "130d5e70"
+  },
+  "web.admin.organizations.addMember.button": {
+    "text": "Meglévő fiók hozzáadása",
+    "source_hash": "45a3b757"
+  },
+  "web.admin.organizations.addMember.title": {
+    "text": "Meglévő fiók hozzáadása",
+    "source_hash": "2f676a94"
+  },
+  "web.admin.organizations.addMember.description": {
+    "text": "Adjon hozzá valakit, akinek már van fiókja, a(z) {org} szervezethez. Használja ezt, ha valaki önállóan regisztrált és nem hívható meg, mert a fiók már létezik.",
+    "source_hash": "bb41faa6"
+  },
+  "web.admin.organizations.addMember.searchLabel": {
+    "text": "E-mail cím vagy fiók azonosító",
+    "source_hash": "82b3040b"
+  },
+  "web.admin.organizations.addMember.searchPlaceholder": {
+    "text": "Keresés e-mail cím alapján",
+    "source_hash": "b75cc66c"
+  },
+  "web.admin.organizations.addMember.searchHint": {
+    "text": "E-mail cím részletére vagy pontos fiók azonosítóra illeszkedik.",
+    "source_hash": "84547a60"
+  },
+  "web.admin.organizations.addMember.searchError": {
+    "text": "Nem sikerült keresni a fiókokban. Ellenőrizze a kapcsolatot és próbálja újra.",
+    "source_hash": "4b6caa41"
+  },
+  "web.admin.organizations.addMember.searchParseError": {
+    "text": "A fiókkeresés váratlan választ adott. Az eredmények hiányosak lehetnek.",
+    "source_hash": "0c814231"
+  },
+  "web.admin.organizations.addMember.idle": {
+    "text": "Adjon meg egy e-mail címet a fiók megkereséséhez.",
+    "source_hash": "f6340d35"
+  },
+  "web.admin.organizations.addMember.noResults": {
+    "text": "Nincs \"{term}\" kifejezésnek megfelelő fiók.",
+    "source_hash": "199b662a"
+  },
+  "web.admin.organizations.addMember.noResultsHint": {
+    "text": "Itt csak meglévő fiókok adhatók hozzá. Ha a személy még nem regisztrált, hívja meg helyette.",
+    "source_hash": "ee90aeeb"
+  },
+  "web.admin.organizations.addMember.select": {
+    "text": "Kiválasztás",
+    "source_hash": "2a78025d"
+  },
+  "web.admin.organizations.addMember.selectedEyebrow": {
+    "text": "Kiválasztott fiók",
+    "source_hash": "8b63d947"
+  },
+  "web.admin.organizations.addMember.change": {
+    "text": "Másik fiók választása",
+    "source_hash": "d4fe39ab"
+  },
+  "web.admin.organizations.addMember.createdOn": {
+    "text": "Regisztrálva {date}",
+    "source_hash": "cfc0e19f"
+  },
+  "web.admin.organizations.addMember.organizationsUnavailable": {
+    "text": "Nem sikerült betölteni ennek a fióknak a jelenlegi szervezeteit.",
+    "source_hash": "a35b6bfc"
+  },
+  "web.admin.organizations.addMember.defaultOrg": {
+    "text": "alapértelmezett",
+    "source_hash": "37a8eec1"
+  },
+  "web.admin.organizations.addMember.roleLabel": {
+    "text": "Szerepkör ebben a szervezetben",
+    "source_hash": "817475fa"
+  },
+  "web.admin.organizations.addMember.submit": {
+    "text": "Hozzáadás a szervezethez",
+    "source_hash": "0e0cb636"
+  },
+  "web.admin.organizations.addMember.success": {
+    "text": "{account} hozzáadva mint {role}.",
+    "source_hash": "533be0dc"
+  },
+  "web.admin.organizations.addMember.badges.verified": {
+    "text": "Ellenőrzött",
+    "source_hash": "4f783840"
+  },
+  "web.admin.organizations.addMember.badges.unverified": {
+    "text": "Nem ellenőrzött",
+    "source_hash": "15133907"
+  },
+  "web.admin.organizations.addMember.badges.suspended": {
+    "text": "Felfüggesztve",
+    "source_hash": "e392a389"
+  },
+  "web.admin.organizations.addMember.badges.alreadyMember": {
+    "text": "Már tag",
+    "source_hash": "1739ed7c"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMember": {
+    "text": "Ez a fiók már tagja ennek a szervezetnek {role} szerepkörrel. A hozzáadás nem módosítja a meglévő szerepkört — ehhez használja a szerepkör-beállítás műveletet.",
+    "source_hash": "cb6a4774"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMemberUnknownRole": {
+    "text": "Ez a fiók már tagja ennek a szervezetnek. A hozzáadás nem módosítja a meglévő szerepkört.",
+    "source_hash": "035641ec"
+  },
+  "web.admin.organizations.addMember.errors.notFound": {
+    "text": "Ez a fiók vagy szervezet már nem létezik. Keressen újra a fiók megerősítéséhez.",
+    "source_hash": "bd88db18"
+  },
+  "web.admin.organizations.addMember.errors.invalidRole": {
+    "text": "Ez a szerepkör el lett utasítva. Válasszon a felsorolt szerepkörök közül és próbálja újra.",
+    "source_hash": "eb696a8f"
+  },
+  "web.admin.organizations.addMember.errors.noSelection": {
+    "text": "Nincs kiválasztott fiók.",
+    "source_hash": "dd15bb5b"
+  },
+  "web.admin.organizations.addMember.fields.created": {
+    "text": "Regisztrálva",
+    "source_hash": "486b3fe0"
+  },
+  "web.admin.organizations.addMember.fields.verified": {
+    "text": "Ellenőrzés",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.organizations.addMember.fields.lastLogin": {
+    "text": "Utolsó bejelentkezés",
+    "source_hash": "0b70af7a"
+  },
+  "web.admin.organizations.addMember.fields.organizations": {
+    "text": "Jelenlegi szervezetek",
+    "source_hash": "cbb5b92f"
+  },
+  "web.admin.organizations.addMember.roleHints.member": {
+    "text": "Mindennapi hozzáférés a szervezet titkaihoz és domainjeihez.",
+    "source_hash": "d0c7439e"
+  },
+  "web.admin.organizations.addMember.roleHints.admin": {
+    "text": "Kezelhet tagokat, domaineket és szervezeti beállításokat.",
+    "source_hash": "beaa50d7"
+  },
+  "web.admin.organizations.addMember.roleHints.owner": {
+    "text": "Teljes irányítás, beleértve a számlázást. Csak kérésre adja meg.",
+    "source_hash": "614ace63"
+  },
+  "web.admin.organizations.addMember.roles.member": {
+    "text": "Tag",
+    "source_hash": "7c968fb7"
+  },
+  "web.admin.organizations.addMember.roles.admin": {
+    "text": "Admin",
+    "source_hash": "c1c224b0"
+  },
+  "web.admin.organizations.addMember.roles.owner": {
+    "text": "Tulajdonos",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.detail.members.openCustomer": {
+    "text": "Ügyfélrekord megnyitása",
+    "source_hash": "c057ca13"
+  },
+  "web.admin.organizations.detail.reconcile.memberships": {
+    "text": "Tagságok újramaterializálva:",
+    "source_hash": "fe7db10c"
+  },
+  "web.admin.organizations.detail.reconcile.membershipsFailed": {
+    "text": "sikertelen, elavult jogosultságok maradtak:",
+    "source_hash": "cc4dae37"
+  },
+  "web.admin.organizations.entitlements.catalogWarning": {
+    "text": "\"{entitlement}\" nem található a számlázási katalógusban — ellenőrizze az elgépelést. Folytatás mindenesetre: egy későbbi katalógusban szállított jogosultság megadása támogatott és szándékosan nincs blokkolva.",
+    "source_hash": "cbde548a"
+  },
+  "web.admin.organizations.entitlements.matrix.caption": {
+    "text": "Jogosultság feloldási mátrix: csomag, felülbírálási megadások és visszavonások, a feloldott készlet és ami materializálva van.",
+    "source_hash": "9eac8999"
+  },
+  "web.admin.organizations.entitlements.matrix.yes": {
+    "text": "Igen",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.matrix.no": {
+    "text": "Nem",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.matrix.empty": {
+    "text": "Ennek a szervezetnek nincs jogosultsága a csomagjából és nincsenek felülbírálásai.",
+    "source_hash": "f6cf2169"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.entitlement": {
+    "text": "Jogosultság",
+    "source_hash": "0d8f0b2d"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.inPlan": {
+    "text": "Csomagban",
+    "source_hash": "e2222361"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.granted": {
+    "text": "Megadva",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.revoked": {
+    "text": "Visszavonva",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.expected": {
+    "text": "Várt",
+    "source_hash": "ca99b7f1"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.materialized": {
+    "text": "Materializált",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.state": {
+    "text": "Állapot",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.formula": {
+    "text": "Feloldás: várt = (csomag ∪ megadások) − visszavonások. A materializált az, ami ténylegesen tárolva van a szervezeten.",
+    "source_hash": "bc4bff2d"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.orphaned": {
+    "text": "Árva — materializált, de nem várt, általában egy soha nem újramaterializált visszavonás hagyta hátra. Az egyeztetés eltávolítja.",
+    "source_hash": "3a27a9af"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.missing": {
+    "text": "Hiányzó — várt, de nem materializált. Ez az az engedély, ami a tagoknak jelenleg ténylegesen hiányzik.",
+    "source_hash": "485e44ad"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.revoked": {
+    "text": "Az áthúzott sorok admin felülbírálással visszavonva, ami eltávolítja őket a várt készletből.",
+    "source_hash": "89a2e9b6"
+  },
+  "web.admin.organizations.entitlements.matrix.state.plan": {
+    "text": "Csomagból",
+    "source_hash": "1d346b26"
+  },
+  "web.admin.organizations.entitlements.matrix.state.granted": {
+    "text": "Megadva",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.state.revoked": {
+    "text": "Visszavonva",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.state.orphaned": {
+    "text": "Árva",
+    "source_hash": "8d827807"
+  },
+  "web.admin.organizations.entitlements.matrix.state.missing": {
+    "text": "Hiányzó",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.organizations.entitlements.picker.selectPlaceholder": {
+    "text": "Válasszon jogosultságot…",
+    "source_hash": "53af3be8"
+  },
+  "web.admin.organizations.entitlements.picker.other": {
+    "text": "Egyéb — nincs a katalógusban…",
+    "source_hash": "f08bc3a3"
+  },
+  "web.admin.organizations.entitlements.picker.customLabel": {
+    "text": "Jogosultság neve (nincs a katalógusban)",
+    "source_hash": "52783229"
+  },
+  "web.admin.organizations.entitlements.picker.backToCatalog": {
+    "text": "Vissza a katalógushoz",
+    "source_hash": "9b727f40"
+  },
+  "web.admin.organizations.entitlements.picker.uncategorized": {
+    "text": "Kategorizálatlan",
+    "source_hash": "8d40d123"
+  },
+  "web.admin.organizations.entitlements.picker.catalogUnavailable": {
+    "text": "A számlázási katalógus nem olvasható, így a jogosultságnevek itt nincsenek ellenőrizve.",
+    "source_hash": "724869ec"
+  },
+  "web.admin.organizations.entitlements.picker.tags.inPlan": {
+    "text": "csomagban",
+    "source_hash": "5f2251bb"
+  },
+  "web.admin.organizations.entitlements.picker.tags.granted": {
+    "text": "megadva",
+    "source_hash": "dd515d19"
+  },
+  "web.admin.organizations.entitlements.picker.tags.revoked": {
+    "text": "visszavonva",
+    "source_hash": "4bb47f18"
+  },
+  "web.admin.organizations.entitlements.summary.sync": {
+    "text": "Szinkronizálás",
+    "source_hash": "8d261a37"
+  },
+  "web.admin.organizations.entitlements.summary.materialized": {
+    "text": "Materializált",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.summary.materializedAt": {
+    "text": "Utoljára materializálva",
+    "source_hash": "9325dce9"
+  },
+  "web.admin.organizations.entitlements.summary.planDefinition": {
+    "text": "Csomag definíció",
+    "source_hash": "6b531454"
+  },
+  "web.admin.organizations.entitlements.summary.yes": {
+    "text": "Igen",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.summary.no": {
+    "text": "Nem",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.summary.never": {
+    "text": "Soha",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.organizations.entitlements.summary.planStale": {
+    "text": "Változott a materializálás óta",
+    "source_hash": "e682d8a4"
+  },
+  "web.admin.organizations.entitlements.summary.planCurrent": {
+    "text": "Aktuális",
+    "source_hash": "e0d1b682"
+  },
+  "web.admin.organizations.entitlements.summary.planUnknown": {
+    "text": "Ismeretlen — nem sikerült összehasonlítani",
+    "source_hash": "b607e540"
   }
 }

--- a/locales/content/hu/admin-secrets.json
+++ b/locales/content/hu/admin-secrets.json
@@ -1,11 +1,11 @@
 {
   "web.admin.secrets.title": {
-    "text": "Titkok",
-    "source_hash": "d8707d41"
+    "text": "Titok nyugták",
+    "source_hash": "a8a2d0e4"
   },
   "web.admin.secrets.description": {
-    "text": "Egy titok visszaigazolásának vizsgálata és a titok törlése SSH nélkül — keresse meg a kulcsa alapján.",
-    "source_hash": "07775a11"
+    "text": "Állapot, időbélyegek, nyugta stb. keresése.",
+    "source_hash": "91fba2a1"
   },
   "web.admin.secrets.never": {
     "text": "Soha",
@@ -108,20 +108,20 @@
     "source_hash": "504101bc"
   },
   "web.admin.secrets.lookup.resultTitle": {
-    "text": "Titok: {shortid}",
-    "source_hash": "8b311d32"
+    "text": "Titok rekord {shortid}",
+    "source_hash": "ee06d765"
   },
   "web.admin.secrets.lookup.notFound": {
-    "text": "A titok nem található",
-    "source_hash": "70a9532c"
+    "text": "Nem található rekord",
+    "source_hash": "40f4d9e9"
   },
   "web.admin.secrets.lookup.notFoundDescription": {
     "text": "Nincs ehhez a kulcshoz tartozó titok. Lehet, hogy lejárt, vagy törölték.",
     "source_hash": "9f068a81"
   },
   "web.admin.secrets.lookup.loadError": {
-    "text": "Nem sikerült betölteni ezt a titkot.",
-    "source_hash": "c96672e4"
+    "text": "Nem sikerült betölteni ezt a rekordot.",
+    "source_hash": "de77cc72"
   },
   "web.admin.secrets.lookup.retry": {
     "text": "Újrapróbálkozás",
@@ -188,8 +188,8 @@
     "source_hash": "c127dab6"
   },
   "web.admin.secrets.sections.secret": {
-    "text": "Titok",
-    "source_hash": "7e32a729"
+    "text": "Titok rekord",
+    "source_hash": "263813c6"
   },
   "web.admin.secrets.sections.receipt": {
     "text": "Visszaigazolás",
@@ -214,5 +214,25 @@
   "web.admin.secrets.state.viewed": {
     "text": "Megtekintve",
     "source_hash": "1b28d178"
+  },
+  "web.admin.secrets.capability.title": {
+    "text": "Csak metaadatok",
+    "source_hash": "df0453d1"
+  },
+  "web.admin.secrets.capability.canRead": {
+    "text": "Olvassa a titok metaadatait és nyugtáját: állapot, időbélyegek, tulajdonos és a tárolt titkosított szöveg mérete.",
+    "source_hash": "d438ecc7"
+  },
+  "web.admin.secrets.capability.cannotRead": {
+    "text": "Nem tudja visszafejteni vagy megjeleníteni a titok tartalmát. A képernyő mögötti végpont soha nem adja vissza.",
+    "source_hash": "7f69f222"
+  },
+  "web.admin.secrets.capability.canDelete": {
+    "text": "Véglegesen törölheti a titkot és nyugtáját, ami megsemmisíti a tartalmat anélkül, hogy felfedné.",
+    "source_hash": "77f2bc7e"
+  },
+  "web.admin.secrets.lookup.hint": {
+    "text": "Az azonosító a titok hivatkozásából — nem a titok tartalma.",
+    "source_hash": "acfbc352"
   }
 }

--- a/locales/content/hu/admin-system.json
+++ b/locales/content/hu/admin-system.json
@@ -154,5 +154,133 @@
   "web.admin.system.redis.captured": {
     "text": "Rögzítve: {at}",
     "source_hash": "57b40c0f"
+  },
+  "web.admin.system.brand.title": {
+    "text": "Márka diagnosztika",
+    "source_hash": "1cf9abd5"
+  },
+  "web.admin.system.brand.description": {
+    "text": "Melyik márkacsomagot oldotta fel a futó példány a lemezen — feltárja, miért szolgálhat egy régió semleges arculatot.",
+    "source_hash": "be29e282"
+  },
+  "web.admin.system.brand.loadError": {
+    "text": "Nem sikerült betölteni a márka diagnosztikát.",
+    "source_hash": "80607303"
+  },
+  "web.admin.system.brand.none": {
+    "text": "(nincs)",
+    "source_hash": "552e4230"
+  },
+  "web.admin.system.brand.resolution": {
+    "text": "Feloldás",
+    "source_hash": "d4055faf"
+  },
+  "web.admin.system.brand.envVsConfig": {
+    "text": "Környezet vs Konfiguráció",
+    "source_hash": "bee3debb"
+  },
+  "web.admin.system.brand.absorbed": {
+    "text": "Felszívott kulcsok",
+    "source_hash": "9784e110"
+  },
+  "web.admin.system.brand.operatorKeys": {
+    "text": "Operátor kulcsok",
+    "source_hash": "434e8248"
+  },
+  "web.admin.system.brand.overlayAssets": {
+    "text": "Réteg eszközök",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.exists.yes": {
+    "text": "Jelen van",
+    "source_hash": "43f9b89c"
+  },
+  "web.admin.system.brand.exists.no": {
+    "text": "Hiányzik",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.system.brand.fields.resolvedDir": {
+    "text": "Feloldott könyvtár",
+    "source_hash": "0623b983"
+  },
+  "web.admin.system.brand.fields.home": {
+    "text": "Kezdőkönyvtár",
+    "source_hash": "3a786953"
+  },
+  "web.admin.system.brand.fields.envPack": {
+    "text": "ENV márkamcsomag",
+    "source_hash": "940aeb5c"
+  },
+  "web.admin.system.brand.fields.configPack": {
+    "text": "Config márkacsomag",
+    "source_hash": "761b9550"
+  },
+  "web.admin.system.brand.fields.envAssetsDir": {
+    "text": "ENV márka eszközök könyvtár",
+    "source_hash": "05854f1f"
+  },
+  "web.admin.system.brand.fields.configAssetsDir": {
+    "text": "Config márka eszközök könyvtár",
+    "source_hash": "e91e5c46"
+  },
+  "web.admin.system.brand.flags.fellBack.danger": {
+    "text": "Visszaállt az alapértelmezett csomagra",
+    "source_hash": "7bf7ba2f"
+  },
+  "web.admin.system.brand.flags.fellBack.ok": {
+    "text": "Márkacsomag feloldva",
+    "source_hash": "1ab3162f"
+  },
+  "web.admin.system.brand.flags.mismatch.danger": {
+    "text": "Indítási / élő eltérés",
+    "source_hash": "0a022192"
+  },
+  "web.admin.system.brand.flags.mismatch.ok": {
+    "text": "Indítási megegyezik az élővel",
+    "source_hash": "d4792c09"
+  },
+  "web.admin.system.brand.manifest.title": {
+    "text": "Manifest",
+    "source_hash": "3c99f1f3"
+  },
+  "web.admin.system.brand.manifest.path": {
+    "text": "Útvonal",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.manifest.exists": {
+    "text": "Létezik",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.manifest.keysOnDisk": {
+    "text": "Kulcsok a lemezen",
+    "source_hash": "52439c03"
+  },
+  "web.admin.system.brand.roots.title": {
+    "text": "Keresési gyökerek",
+    "source_hash": "d8696f2b"
+  },
+  "web.admin.system.brand.roots.empty": {
+    "text": "Nincsenek keresési gyökerek",
+    "source_hash": "867a471c"
+  },
+  "web.admin.system.brand.roots.columns.path": {
+    "text": "Útvonal",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.roots.columns.exists": {
+    "text": "Létezik",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.stats.brandPack": {
+    "text": "Márkacsomag",
+    "source_hash": "884437d0"
+  },
+  "web.admin.system.brand.stats.overlayAssets": {
+    "text": "Réteg eszközök",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.stats.manifestKeys": {
+    "text": "Manifest kulcsok",
+    "source_hash": "c4267198"
   }
 }

--- a/locales/content/hu/admin-system.json
+++ b/locales/content/hu/admin-system.json
@@ -208,7 +208,7 @@
     "source_hash": "3a786953"
   },
   "web.admin.system.brand.fields.envPack": {
-    "text": "ENV márkamcsomag",
+    "text": "ENV márkacsomag",
     "source_hash": "940aeb5c"
   },
   "web.admin.system.brand.fields.configPack": {

--- a/locales/content/hu/email.json
+++ b/locales/content/hu/email.json
@@ -836,5 +836,41 @@
   "email.secret_link.footer_note": {
     "text": "Azért kapta ezt az értesítést, mert %{sender_email} a(z) %{product_name} szolgáltatással osztott meg Önnel egy titkot. Ha nem számított rá, nyugodtan figyelmen kívül hagyhatja ezt az e-mailt.",
     "source_hash": "2d544dad"
+  },
+  "email.sso_link_verification.subject": {
+    "text": "Erősítse meg a(z) %{provider} összekapcsolását a(z) %{product_name} fiókjával",
+    "source_hash": "65e70296"
+  },
+  "email.sso_link_verification.title": {
+    "text": "Erősítse meg az SSO bejelentkezését",
+    "source_hash": "35bce6cc"
+  },
+  "email.sso_link_verification.request_notice": {
+    "text": "Valaki bejelentkezett a(z) %{provider} szolgáltatással a(z) %{email_address} e-mail címmel. A(z) %{provider} és a(z) %{product_name} fiókja összekapcsolásának befejezéséhez erősítse meg alább.",
+    "source_hash": "baeb18c0"
+  },
+  "email.sso_link_verification.confirm_button": {
+    "text": "Megerősítés és a(z) %{provider} összekapcsolása",
+    "source_hash": "9809e210"
+  },
+  "email.sso_link_verification.copy_link_prompt": {
+    "text": "Vagy másolja és illessze be ezt a hivatkozást:",
+    "source_hash": "88c72144"
+  },
+  "email.sso_link_verification.expiration_notice": {
+    "text": "Ez a hivatkozás 15 perc múlva lejár, és csak egyszer használható.",
+    "source_hash": "1a437f42"
+  },
+  "email.sso_link_verification.ignore_notice": {
+    "text": "Ha nem próbált bejelentkezni a(z) %{provider} szolgáltatással, nyugodtan figyelmen kívül hagyhatja ezt az e-mailt — semmi nem lesz összekapcsolva a fiókjával.",
+    "source_hash": "d7317d30"
+  },
+  "email.sso_link_verification.signature": {
+    "text": "Támogatási csapat",
+    "source_hash": "dc75bf9f"
+  },
+  "email.sso_link_verification.postscript": {
+    "text": "U.i. Ez az e-mail a(z) %{email_address} címre lett küldve.",
+    "source_hash": "8ab1dbea"
   }
 }

--- a/locales/content/hu/session-auth-extended.json
+++ b/locales/content/hu/session-auth-extended.json
@@ -757,6 +757,7 @@
   },
   "web.auth.connections.connect_action": {
     "text": "{provider} csatlakoztatása",
+    "context": "Button label to start linking a specific SSO provider; {provider} is the provider display name",
     "source_hash": "c77540af"
   },
   "web.auth.connections.issuer": {
@@ -821,6 +822,7 @@
   },
   "web.link_sso.prompt": {
     "text": "Bejelentkezett a(z) {provider} szolgáltatással, amely megegyezik a meglévő {email} fiókkal. Adja meg a fiók jelszavát a(z) {provider} összekapcsolásához és a folytatáshoz.",
+    "context": "Instruction on the sign-in interstitial. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/link-sso/:token.",
     "source_hash": "59da1c08"
   },
   "web.link_sso.password_label": {
@@ -881,6 +883,7 @@
   },
   "web.sso_link_confirm.prompt": {
     "text": "Bejelentkezett a(z) {provider} szolgáltatással, amely megegyezik a(z) {email} fiókjával. Erősítse meg a(z) {provider} csatlakoztatását ehhez a fiókhoz és a bejelentkezés befejezését.",
+    "context": "Consent instruction on the #3840 Phase 4 mailbox-proof SSO linking page. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/sso-link-confirm/:token. No password is asked — clicking the emailed link is the proof.",
     "source_hash": "6ff0d6cc"
   },
   "web.sso_link_confirm.submit": {

--- a/locales/content/hu/session-auth-extended.json
+++ b/locales/content/hu/session-auth-extended.json
@@ -730,5 +730,201 @@
   "web.auth.sessions.session_plural": {
     "text": "munkamenet",
     "source_hash": "1225ae6c"
+  },
+  "web.auth.connections.title": {
+    "text": "Összekapcsolt azonosítók",
+    "source_hash": "e132c4d9"
+  },
+  "web.auth.connections.description": {
+    "text": "Kezelje a fiókjához kapcsolt egyszeri bejelentkezés szolgáltatókat.",
+    "source_hash": "42c6d148"
+  },
+  "web.auth.connections.section_title": {
+    "text": "Egyszeri bejelentkezés",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.section_subtitle": {
+    "text": "Azonosítószolgáltatók, amelyekkel bejelentkezhet ebbe a fiókba",
+    "source_hash": "507254cd"
+  },
+  "web.auth.connections.connect_title": {
+    "text": "Szolgáltató csatlakoztatása",
+    "source_hash": "a002b3f3"
+  },
+  "web.auth.connections.connect_description": {
+    "text": "Kapcsoljon hozzá egy másik egyszeri bejelentkezés szolgáltatót, amellyel bejelentkezhet ebbe a fiókba.",
+    "source_hash": "32895a5a"
+  },
+  "web.auth.connections.connect_action": {
+    "text": "{provider} csatlakoztatása",
+    "source_hash": "c77540af"
+  },
+  "web.auth.connections.issuer": {
+    "text": "Kibocsátó",
+    "source_hash": "39e02c46"
+  },
+  "web.auth.connections.identifier": {
+    "text": "Azonosító",
+    "source_hash": "9b10587f"
+  },
+  "web.auth.connections.remove": {
+    "text": "Eltávolítás",
+    "source_hash": "c3812fc4"
+  },
+  "web.auth.connections.remove_confirm_title": {
+    "text": "Összekapcsolt azonosító eltávolítása",
+    "source_hash": "4e8ffe4c"
+  },
+  "web.auth.connections.remove_confirm_message": {
+    "text": "Biztosan el szeretné távolítani ezt az összekapcsolt azonosítót? Többé nem fog tudni vele bejelentkezni.",
+    "source_hash": "64939c89"
+  },
+  "web.auth.connections.removed_success": {
+    "text": "Összekapcsolt azonosító eltávolítva",
+    "source_hash": "cf87daf3"
+  },
+  "web.auth.connections.no_identities": {
+    "text": "Nincsenek összekapcsolt azonosítók",
+    "source_hash": "5254048e"
+  },
+  "web.auth.connections.no_identities_description": {
+    "text": "Még nem kapcsolt egyszeri bejelentkezés szolgáltatót ehhez a fiókhoz.",
+    "source_hash": "0f58d5d0"
+  },
+  "web.auth.connections.overview_status": {
+    "text": "Egyszeri bejelentkezés",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.errors.last_credential": {
+    "text": "Ez az egyetlen módja a bejelentkezésnek. Először csatlakoztasson egy másik szolgáltatót, vagy állítson be jelszót a Beállítások → Biztonság menüpontban, hogy ne zárja ki magát.",
+    "source_hash": "3de8084d"
+  },
+  "web.auth.connections.errors.last_credential_sso_enforced": {
+    "text": "Ez az egyetlen módja a bejelentkezésnek. Először csatlakoztasson egy másik szolgáltatót, hogy ne zárja ki magát.",
+    "source_hash": "eed7a50e"
+  },
+  "web.auth.connections.errors.not_found": {
+    "text": "Ez az összekapcsolt azonosító nem található. Lehet, hogy már eltávolították.",
+    "source_hash": "cf2c7673"
+  },
+  "web.auth.connections.errors.unauthorized": {
+    "text": "A munkamenete lejárt. Jelentkezzen be újra.",
+    "source_hash": "b529fce2"
+  },
+  "web.auth.connections.errors.generic": {
+    "text": "Nem sikerült végrehajtani a műveletet. Próbálja újra.",
+    "source_hash": "a0d4edc0"
+  },
+  "web.link_sso.title": {
+    "text": "Bejelentkezési módszer összekapcsolása",
+    "source_hash": "46339bac"
+  },
+  "web.link_sso.prompt": {
+    "text": "Bejelentkezett a(z) {provider} szolgáltatással, amely megegyezik a meglévő {email} fiókkal. Adja meg a fiók jelszavát a(z) {provider} összekapcsolásához és a folytatáshoz.",
+    "source_hash": "59da1c08"
+  },
+  "web.link_sso.password_label": {
+    "text": "Jelszó",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.link_sso.password_placeholder": {
+    "text": "Meglévő jelszava",
+    "source_hash": "ad4e56da"
+  },
+  "web.link_sso.submit": {
+    "text": "Összekapcsolás és folytatás",
+    "source_hash": "c969b759"
+  },
+  "web.link_sso.cancel": {
+    "text": "Mégse",
+    "source_hash": "19766ed6"
+  },
+  "web.link_sso.unavailable_title": {
+    "text": "Ez az összekapcsolási kérelem lejárt",
+    "source_hash": "b53c7e55"
+  },
+  "web.link_sso.unavailable_message": {
+    "text": "Az Ön biztonsága érdekében a bejelentkezési módszer összekapcsolásának kérelme már nem érvényes. Jelentkezzen be meglévő jelszavával, majd csatlakoztassa ezt a szolgáltatót a Biztonsági beállítások → Összekapcsolt azonosítók menüpontban.",
+    "source_hash": "f7e349d1"
+  },
+  "web.link_sso.unavailable_action": {
+    "text": "Tovább a bejelentkezéshez",
+    "source_hash": "d398cd0a"
+  },
+  "web.link_sso.errors.invalid_password": {
+    "text": "Ez a jelszó nem egyezik ezzel a fiókkal. Próbálja újra.",
+    "source_hash": "3259b4f5"
+  },
+  "web.link_sso.errors.invalid_token": {
+    "text": "Ez az összekapcsolási kérelem lejárt vagy már felhasználták. Jelentkezzen be meglévő jelszavával, majd csatlakoztassa ezt a szolgáltatót a fiókbeállításokból.",
+    "source_hash": "541f9127"
+  },
+  "web.link_sso.errors.link_conflict": {
+    "text": "Nem sikerült összekapcsolni ezt a bejelentkezési módszert. Lehet, hogy a fiókja megváltozott, vagy ez a szolgáltató már másik fiókhoz van kapcsolva. Jelentkezzen be meglévő jelszavával, majd kezelje a kapcsolatokat a Biztonsági beállítások → Összekapcsolt azonosítók menüpontban.",
+    "source_hash": "7b0e0d0e"
+  },
+  "web.link_sso.errors.link_rate_limited": {
+    "text": "Túl sok jelszópróbálkozás. Várjon néhány percet, majd próbálja újra.",
+    "source_hash": "a95e78cd"
+  },
+  "web.link_sso.errors.invalid_request": {
+    "text": "Nem sikerült feldolgozni ezt az összekapcsolási kérelmet. Jelentkezzen be újra az SSO szolgáltatójával.",
+    "source_hash": "053b9fc6"
+  },
+  "web.link_sso.errors.generic": {
+    "text": "Nem sikerült összekapcsolni a fiókját. Próbálja újra.",
+    "source_hash": "f727c174"
+  },
+  "web.sso_link_confirm.title": {
+    "text": "Fiók csatlakoztatásának megerősítése",
+    "source_hash": "ad80bfe7"
+  },
+  "web.sso_link_confirm.prompt": {
+    "text": "Bejelentkezett a(z) {provider} szolgáltatással, amely megegyezik a(z) {email} fiókjával. Erősítse meg a(z) {provider} csatlakoztatását ehhez a fiókhoz és a bejelentkezés befejezését.",
+    "source_hash": "6ff0d6cc"
+  },
+  "web.sso_link_confirm.submit": {
+    "text": "Megerősítés és csatlakoztatás",
+    "source_hash": "5cf663e6"
+  },
+  "web.sso_link_confirm.cancel": {
+    "text": "Mégse",
+    "source_hash": "19766ed6"
+  },
+  "web.sso_link_confirm.unavailable_title": {
+    "text": "Ez az összekapcsolási kérelem nem teljesíthető",
+    "source_hash": "47abb784"
+  },
+  "web.sso_link_confirm.unavailable_message": {
+    "text": "Az Ön biztonsága érdekében a bejelentkezési módszer csatlakoztatásának kérelme már nem érvényes. Jelentkezzen be újra a szolgáltatójával, és új hivatkozást küldünk e-mailben.",
+    "source_hash": "080e6f9f"
+  },
+  "web.sso_link_confirm.unavailable_action": {
+    "text": "Vissza a bejelentkezéshez",
+    "source_hash": "8504054f"
+  },
+  "web.sso_link_confirm.errors.link_expired": {
+    "text": "Ez az összekapcsolási kérelem lejárt vagy már felhasználták. Jelentkezzen be újra a szolgáltatójával, és új hivatkozást küldünk e-mailben.",
+    "source_hash": "a50538df"
+  },
+  "web.sso_link_confirm.errors.link_conflict": {
+    "text": "Nem sikerült csatlakoztatni ezt a bejelentkezési módszert. Lehet, hogy a fiókja megváltozott, vagy ez a szolgáltató már másik fiókhoz van kapcsolva. A folytatáshoz jelentkezzen be újra a szolgáltatójával.",
+    "source_hash": "c954854b"
+  },
+  "web.sso_link_confirm.errors.link_invalidated": {
+    "text": "A fiók hitelesítő adatai megváltoztak a hivatkozás küldése után, így az már nem érvényes. Jelentkezzen be újra a szolgáltatójával, és új hivatkozást küldünk e-mailben.",
+    "source_hash": "db88cb1d"
+  },
+  "web.sso_link_confirm.errors.link_error": {
+    "text": "Valami hiba történt nálunk, és nem tudtuk ellenőrizni ezt a hivatkozást. Jelentkezzen be újra a szolgáltatójával, és új hivatkozást küldünk e-mailben.",
+    "source_hash": "ec24e0a1"
+  },
+  "web.sso_link_confirm.errors.confirm_rate_limited": {
+    "text": "Túl sok próbálkozás az eszközéről. Várjon néhány percet, majd nyissa meg újra az e-mailben kapott hivatkozást, vagy jelentkezzen be a szolgáltatójával új hivatkozásért.",
+    "source_hash": "f29af782"
+  },
+  "web.sso_link_confirm.errors.generic": {
+    "text": "Nem sikerült megerősíteni ezt a kapcsolatot. Jelentkezzen be újra a szolgáltatójával.",
+    "source_hash": "076fa25a"
   }
 }

--- a/locales/content/hu/session-auth.json
+++ b/locales/content/hu/session-auth.json
@@ -483,5 +483,41 @@
   "web.login.verified_notice": {
     "text": "Az e-mail-címe ellenőrizve — most már bejelentkezhet.",
     "source_hash": "c8d4b5a8"
+  },
+  "web.auth.password_setup_request.title": {
+    "text": "Jelszó beállítása",
+    "source_hash": "11b6978b"
+  },
+  "web.auth.password_setup_request.description": {
+    "text": "A fiókjának még nincs jelszava. Küldünk egy biztonságos hivatkozást e-mailben a beállításához, hogy közvetlenül is bejelentkezhessen.",
+    "source_hash": "dc0b561f"
+  },
+  "web.auth.password_setup_request.button": {
+    "text": "Beállítási hivatkozás küldése",
+    "source_hash": "22807292"
+  },
+  "web.auth.password_setup_request.emailSent": {
+    "text": "E-mailt küldtünk Önnek egy hivatkozással a fiókja jelszavának beállításához",
+    "source_hash": "82b686c7"
+  },
+  "web.login.errors.account_exists_link_required": {
+    "text": "Ezzel az e-mail címmel már létezik fiók, de nincs összekapcsolva ezzel a bejelentkezési módszerrel. Jelentkezzen be meglévő módszerével, majd kapcsolja össze ezt a szolgáltatót a Biztonsági beállítások → Összekapcsolt azonosítók menüpontban.",
+    "source_hash": "7fbbb7e7"
+  },
+  "web.login.errors.identity_connect_conflict": {
+    "text": "Ezt az azonosítót nem sikerült csatlakoztatni. A csatlakoztatás rossz domainen indulhatott, vagy a munkamenete lejárt. Jelentkezzen be újra, majd csatlakoztassa a fiókbeállításokból.",
+    "source_hash": "4238bbf2"
+  },
+  "web.login.errors.org_join_failed": {
+    "text": "Nem sikerült befejezni a szervezethez való hozzáadását. Forduljon a rendszergazdához.",
+    "source_hash": "155e71bb"
+  },
+  "web.login.errors.link_sso_failed": {
+    "text": "Nem sikerült összekapcsolni azt a bejelentkezési módszert. Jelentkezzen be meglévő jelszavával, majd csatlakoztassa ezt a szolgáltatót a Biztonsági beállítások → Összekapcsolt azonosítók menüpontban.",
+    "source_hash": "49954127"
+  },
+  "web.login.notices.link_verification_sent": {
+    "text": "Ellenőrizze a postaládáját — e-mailt küldtünk egy hivatkozással a fiók csatlakoztatásának megerősítéséhez. Nyissa meg a bejelentkezés befejezéséhez.",
+    "source_hash": "b251c8f3"
   }
 }

--- a/locales/content/hu/workspace-account.json
+++ b/locales/content/hu/workspace-account.json
@@ -694,5 +694,33 @@
   "web.settings.security.sso_managed_description": {
     "text": "Az Ön fiókját a szervezete egyszeri bejelentkezési szolgáltatóján keresztül hitelesítik. A jelszót, a többfaktoros hitelesítést és a helyreállítási kódokat az identitásszolgáltató kezeli.",
     "source_hash": "cd0cf39f"
+  },
+  "web.settings.api.api_username": {
+    "text": "API felhasználónév",
+    "source_hash": "0b3e483e"
+  },
+  "web.settings.api.api_username_description": {
+    "text": "Az Ön felhasználóneve a HTTP Basic hitelesítéshez",
+    "source_hash": "f3e65de3"
+  },
+  "web.settings.api.basic_auth_hint": {
+    "text": "HTTP Basic hitelesítéshez használja a fiókja e-mail címét vagy ezt az azonosítót felhasználónévként, és az API tokenét jelszóként.",
+    "source_hash": "cfa3806d"
+  },
+  "web.settings.security.set": {
+    "text": "Beállítva",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.settings.security.not_set": {
+    "text": "Nincs beállítva",
+    "source_hash": "4895f731"
+  },
+  "web.settings.security.set_password_title": {
+    "text": "Jelszó beállítása",
+    "source_hash": "4e411687"
+  },
+  "web.settings.security.set_password_description": {
+    "text": "Adjon hozzá jelszót a fiókjához, hogy azonosítószolgáltató nélkül is bejelentkezhessen",
+    "source_hash": "a6970402"
   }
 }

--- a/locales/content/hu/workspace-billing.json
+++ b/locales/content/hu/workspace-billing.json
@@ -1044,5 +1044,21 @@
   "web.billing.plans.reactivate": {
     "text": "Újraaktiválás",
     "source_hash": "2dc7478f"
+  },
+  "web.billing.currency_migration.refund_failed_warning": {
+    "text": "Az előző csomagja megszűnt, de nem tudtuk automatikusan visszatéríteni a fel nem használt időt. A visszatérítésért forduljon az ügyfélszolgálathoz. Az új csomag aktiválásához még be kell fejeznie a fizetést.",
+    "source_hash": "a390c498"
+  },
+  "web.billing.currency_migration.refund_failed_continue": {
+    "text": "Tovább a fizetéshez",
+    "source_hash": "eccdb8aa"
+  },
+  "web.billing.plans.per_year": {
+    "text": "/év",
+    "source_hash": "a2d5f1bc"
+  },
+  "web.billing.plans.billing_interval": {
+    "text": "Számlázási időszak",
+    "source_hash": "3ce28209"
   }
 }

--- a/locales/content/hu/workspace-branding.json
+++ b/locales/content/hu/workspace-branding.json
@@ -56,12 +56,12 @@
     "source_hash": "e36598ef"
   },
   "web.branding.example_pre_reveal_instructions": {
-    "text": "Használja telefonját a QR-kód beolvasásához",
-    "source_hash": "99ecf59f"
+    "text": "pl. Használja a telefonját a QR-kód beolvasásához",
+    "source_hash": "9cf0caf8"
   },
   "web.branding.example_post_reveal_instructions": {
-    "text": "Kérdésekkel forduljon a onboarding{'@'}example.com címre",
-    "source_hash": "bee120a7"
+    "text": "pl. Kérdéseivel forduljon a bevezetés{'@'}example.com címre",
+    "source_hash": "71749811"
   },
   "web.branding.these_instructions_will_be_shown_to_recipients_before": {
     "text": "Ezek az utasítások megjelennek a címzetteknek, mielőtt felfednék a titok tartalmát",
@@ -320,8 +320,8 @@
     "source_hash": "bc79cdff"
   },
   "web.branding.paths_carryover_hint": {
-    "text": "Ez egy élő előnézet — a módosításai csak mentés után válnak láthatóvá a látogatók számára.",
-    "source_hash": "cb4b82de"
+    "text": "Ez egy élő előnézet — a módosítások csak a Frissítés gombra kattintás után lesznek láthatók a látogatók számára.",
+    "source_hash": "9a34df71"
   },
   "web.branding.coming_soon_match_blurb": {
     "text": "Adja meg a webhelye címét, mi pedig beolvassuk a színeit és betűtípusait, majd egyetlen kattintással áthidaljuk a különbséget.",
@@ -406,5 +406,57 @@
   "web.branding.delivery_after_reveal": {
     "text": "Felfedés után",
     "source_hash": "d5bfe7fd"
+  },
+  "web.branding.favicon": {
+    "text": "Favicon",
+    "source_hash": "42955289"
+  },
+  "web.branding.refresh_favicon": {
+    "text": "Favicon frissítése a domainről",
+    "source_hash": "7cc3d5dc"
+  },
+  "web.branding.refresh_favicon_hint": {
+    "text": "A favicon újbóli lekérése a domainről. Az új ikon hamarosan megjelenik.",
+    "source_hash": "ee007e44"
+  },
+  "web.branding.refresh_favicon_queued": {
+    "text": "Favicon frissítése — az új ikon hamarosan megjelenik.",
+    "source_hash": "6bf38e6e"
+  },
+  "web.branding.refresh_favicon_user_upload_hint": {
+    "text": "Egyéni favicont töltött fel, így a lekért ikon nem cseréli le.",
+    "source_hash": "c22e1ed6"
+  },
+  "web.branding.upload_favicon": {
+    "text": "Favicon feltöltése",
+    "source_hash": "ceda39cb"
+  },
+  "web.branding.replace_favicon": {
+    "text": "Csere",
+    "source_hash": "95e15439"
+  },
+  "web.branding.remove_favicon": {
+    "text": "Favicon eltávolítása",
+    "source_hash": "03693698"
+  },
+  "web.branding.favicon_field_hint": {
+    "text": "ICO, PNG vagy SVG. A feltöltés lecseréli a lekért ikont.",
+    "source_hash": "dfa0bfcb"
+  },
+  "web.branding.favicon_preview_alt": {
+    "text": "Domain favicon",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_title": {
+    "text": "Domain favicon",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_hint": {
+    "text": "ICO, PNG vagy SVG. Maximum 256KB. Lecseréli az automatikusan lekért ikont.",
+    "source_hash": "c9eafc83"
+  },
+  "web.branding.favicon_modal_save": {
+    "text": "Favicon mentése",
+    "source_hash": "c8a1566c"
   }
 }

--- a/locales/content/hu/workspace-organizations.json
+++ b/locales/content/hu/workspace-organizations.json
@@ -1034,5 +1034,153 @@
   "web.organizations.create_workspace": {
     "text": "Munkaterület létrehozása",
     "source_hash": "c63c14cf"
+  },
+  "web.organizations.organization_id": {
+    "text": "Szervezet azonosító",
+    "source_hash": "1f466322"
+  },
+  "web.organizations.organization_id_hint": {
+    "text": "Használja ezt az azonosítót az ügyfélszolgálattal való kapcsolatfelvételkor vagy API kérések szervezethez rendelésekor. Ez nem bejelentkezési hitelesítő adat.",
+    "source_hash": "29549b3a"
+  },
+  "web.organizations.audit.title": {
+    "text": "Titok tevékenység",
+    "source_hash": "6d6d41f3"
+  },
+  "web.organizations.audit.description": {
+    "text": "A szervezet számára rögzített titok létrehozási és hozzáférési események naplója.",
+    "source_hash": "553c564b"
+  },
+  "web.organizations.audit.country_unknown": {
+    "text": "Ismeretlen",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.empty_title": {
+    "text": "Még nincs tevékenység",
+    "source_hash": "0a12b92c"
+  },
+  "web.organizations.audit.empty_description": {
+    "text": "A titok létrehozási és hozzáférési események itt jelennek meg, ahogy a csapata titkokat oszt meg.",
+    "source_hash": "62fb14c2"
+  },
+  "web.organizations.audit.capped_notice": {
+    "text": "Csak a legújabb {max} esemény van megőrizve; a régebbi tevékenység törölve lett.",
+    "source_hash": "da7901e2"
+  },
+  "web.organizations.audit.collection_paused_notice": {
+    "text": "Az eseménygyűjtés szünetel; az új titok tevékenység nem kerül rögzítésre.",
+    "source_hash": "cb09d147"
+  },
+  "web.organizations.audit.load_error": {
+    "text": "Nem sikerült betölteni a titok tevékenységet.",
+    "source_hash": "52fde814"
+  },
+  "web.organizations.audit.contract_mismatch": {
+    "text": "A szerver által visszaadott tevékenységi adatok nem olvashatók. A napló nem üres — csak jelenleg nem jeleníthető meg.",
+    "source_hash": "db0d007a"
+  },
+  "web.organizations.audit.retry": {
+    "text": "Próbálja újra",
+    "source_hash": "d8b8392e"
+  },
+  "web.organizations.audit.showing_range": {
+    "text": "{from}–{to} megjelenítése, összesen: {total}",
+    "source_hash": "c329279d"
+  },
+  "web.organizations.audit.upgrade_prompt": {
+    "text": "A titok tevékenység audit naplós csomagot igényel. Frissítsen, hogy lássa, ki hozta létre, tekintette meg és fedte fel a titkokat ebben a szervezetben.",
+    "source_hash": "453649ce"
+  },
+  "web.organizations.audit.role_required": {
+    "text": "A titok tevékenység a szervezet tulajdonosai és adminjai számára érhető el.",
+    "source_hash": "e066ec63"
+  },
+  "web.organizations.audit.actors.creator": {
+    "text": "Létrehozó",
+    "source_hash": "88447b83"
+  },
+  "web.organizations.audit.actors.authenticated_other": {
+    "text": "Másik bejelentkezett felhasználó",
+    "source_hash": "ee45aa5a"
+  },
+  "web.organizations.audit.actors.anonymous": {
+    "text": "Névtelen",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.organizations.audit.actors.system": {
+    "text": "Rendszer",
+    "source_hash": "6725e7bb"
+  },
+  "web.organizations.audit.actors.unknown": {
+    "text": "Ismeretlen",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.columns.event": {
+    "text": "Esemény",
+    "source_hash": "4e1f49a9"
+  },
+  "web.organizations.audit.columns.secret": {
+    "text": "Titok",
+    "source_hash": "7e32a729"
+  },
+  "web.organizations.audit.columns.actor": {
+    "text": "Szereplő",
+    "source_hash": "449995c4"
+  },
+  "web.organizations.audit.columns.country": {
+    "text": "Ország",
+    "source_hash": "701d021d"
+  },
+  "web.organizations.audit.columns.when": {
+    "text": "Mikor",
+    "source_hash": "cf9c7aa2"
+  },
+  "web.organizations.audit.kinds.created": {
+    "text": "Titok létrehozva",
+    "source_hash": "e4a1e1fd"
+  },
+  "web.organizations.audit.kinds.status_get": {
+    "text": "Hivatkozás állapota ellenőrizve",
+    "source_hash": "0753f60e"
+  },
+  "web.organizations.audit.kinds.secret_get": {
+    "text": "Titok hivatkozás megnyitva",
+    "source_hash": "e271e060"
+  },
+  "web.organizations.audit.kinds.previewed": {
+    "text": "Létrehozó által megtekintve",
+    "source_hash": "639fc1e2"
+  },
+  "web.organizations.audit.kinds.creator_status_get": {
+    "text": "Létrehozó által ellenőrizve",
+    "source_hash": "7e4b5de5"
+  },
+  "web.organizations.audit.kinds.receipt_viewed": {
+    "text": "Nyugta megtekintve",
+    "source_hash": "a417ead4"
+  },
+  "web.organizations.audit.kinds.revealed": {
+    "text": "Titok felfedve",
+    "source_hash": "aff2c84d"
+  },
+  "web.organizations.audit.kinds.burned": {
+    "text": "Titok véglegesen törölve",
+    "source_hash": "5ac68dc6"
+  },
+  "web.organizations.audit.kinds.expired": {
+    "text": "Titok lejárt",
+    "source_hash": "c127dab6"
+  },
+  "web.organizations.audit.kinds.orphaned": {
+    "text": "Titok árva lett",
+    "source_hash": "23fe1a47"
+  },
+  "web.organizations.audit.kinds.reveal_failed_undecryptable": {
+    "text": "Felfedés sikertelen (nem visszafejthető)",
+    "source_hash": "d5616abf"
+  },
+  "web.organizations.tabs.activity": {
+    "text": "Tevékenység",
+    "source_hash": "38da1505"
   }
 }


### PR DESCRIPTION
## `hu` translation update

Automated export of completed **hu** translations from the translation task DB.
Scope: `locales/content/hu/` only — 16 file(s), +2020/-20.

⚠️ `i18n validate variables` reports **3** variable mismatch(es) for `hu` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ⚠️ Needs review — one spelling typo, validator noise

**Summary:** Large hu update (admin, auth/SSO linking, billing, branding, i18n) preserves all `{var}`/`%{var}` placeholders correctly and consistently applies the `a(z)` article convention before variables. One genuine typo found; the 3 validator hits are the same known false-positive pattern seen across today's other locale reviews.

**Critical (must fix):** None

**Warnings:**
- `admin-system.json` → `web.admin.system.brand.fields.envPack`: "ENV **márkamcsomag**" — typo (extra "m"); sibling key `configPack` correctly reads "márkacsomag". Fix to "ENV márkacsomag".

**Notes:**
- The 3 flagged `[EMPTY]` errors (`web.auth.connections.connect_action.context`, `web.link_sso.prompt.context`, `web.sso_link_confirm.prompt.context`) are `.context` metadata keys (developer-facing notes describing `{provider}`/`{email}`, not user-facing UI strings) and don't appear anywhere in this diff. This matches the "context-field bug" false-positive pattern already confirmed for de/el_GR/eo/es today — not a real translation gap. Worth confirming the validator excludes `.context` keys going forward, but not a merge blocker.
- `web.branding.example_post_reveal_instructions`: the example email's local part was translated ("onboarding" → "bevezetés"), producing "bevezetés{'@'}example.com". Placeholder token preserved correctly; just an unusual stylistic choice for illustrative text, not a functional issue.
- No untranslated English, encoding/mojibake, or brand-name alteration ("Onetime Secret" doesn't appear in this diff) observed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
