### PR TITLE
i18n: update ja translations

### DIFF
--- a/locales/content/ja/00-common.json
+++ b/locales/content/ja/00-common.json
@@ -13,7 +13,7 @@
     "source_hash": "fdc5d2e9"
   },
   "web.COMMON.website_url": {
-    "text": "https://onetimesecret.com/en",
+    "text": "https://onetimesecret.com/ja",
     "source_hash": "440f5303"
   },
   "web.COMMON.button_generate_secret_short": {

--- a/locales/content/ja/00-common.json
+++ b/locales/content/ja/00-common.json
@@ -5,15 +5,15 @@
     "note": "empty source"
   },
   "web.COMMON.tagline": {
-    "text": "一度しか使えないセキュアなリンク",
+    "text": "一度だけ使える安全なリンク",
     "source_hash": "9da7aece"
   },
   "web.COMMON.powered_by": {
-    "text": "Powered by",
+    "text": "提供:",
     "source_hash": "fdc5d2e9"
   },
   "web.COMMON.website_url": {
-    "text": "https://onetimesecret.com/ja",
+    "text": "https://onetimesecret.com/en",
     "source_hash": "440f5303"
   },
   "web.COMMON.button_generate_secret_short": {
@@ -21,7 +21,7 @@
     "source_hash": "fdcbfcc7"
   },
   "web.COMMON.generate_password_disabled": {
-    "text": "フォームが有効な場合、パスワード生成は無効になります",
+    "text": "フォームが有効な場合、パスワードの生成は無効になります",
     "source_hash": "dc0e2b8c"
   },
   "web.COMMON.email_placeholder": {
@@ -29,7 +29,7 @@
     "source_hash": "f2350739"
   },
   "web.COMMON.password_placeholder": {
-    "text": "パスワードを入力",
+    "text": "パスワードを入力してください",
     "source_hash": "c06bf967"
   },
   "web.COMMON.custom_domains_title": {
@@ -37,7 +37,7 @@
     "source_hash": "6170ab94"
   },
   "web.COMMON.custom_domains_description": {
-    "text": "独自のブランドシークレットリンクで、つながりを強化し信頼を築きましょう。",
+    "text": "独自ブランドのシークレットリンクで、つながりを強化し信頼を築きます。",
     "source_hash": "71fddc05"
   },
   "web.COMMON.get_started_button": {
@@ -45,7 +45,7 @@
     "source_hash": "983f3110"
   },
   "web.COMMON.confirm_password_placeholder": {
-    "text": "パスワードを再入力",
+    "text": "パスワードを再入力してください",
     "source_hash": "bfd8c343"
   },
   "web.COMMON.header_settings": {
@@ -65,7 +65,7 @@
     "source_hash": "f40a853e"
   },
   "web.COMMON.description": {
-    "text": "チャットログやメールに機密情報を残さないでください。一度しか利用できないシークレットリンクを共有しましょう。",
+    "text": "機密情報をチャットログやメールに残さないでください。一度だけ利用できるシークレットリンクで共有できます。",
     "source_hash": "4c895f85"
   },
   "web.COMMON.incorrect_passphrase": {
@@ -73,7 +73,7 @@
     "source_hash": "a55f9636"
   },
   "web.COMMON.keywords": {
-    "text": "シークレット,パスワード生成,シークレット共有,ワンタイム",
+    "text": "シークレット,パスワード生成,シークレットの共有,ワンタイム",
     "source_hash": "52728258"
   },
   "web.COMMON.button_create_secret": {
@@ -93,7 +93,7 @@
     "source_hash": "e7611f05"
   },
   "web.COMMON.secret_passphrase_hint": {
-    "text": "推測されにくい単語やフレーズ",
+    "text": "推測されにくい単語またはフレーズ",
     "source_hash": "29d0cf13"
   },
   "web.COMMON.secret_recipient_address": {
@@ -101,7 +101,7 @@
     "source_hash": "f6f6311d"
   },
   "web.COMMON.secret_placeholder": {
-    "text": "シークレットの内容をここに入力...",
+    "text": "ここにシークレットの内容を入力...",
     "source_hash": "54630bab"
   },
   "web.COMMON.header_create_account": {
@@ -161,15 +161,15 @@
     "source_hash": "ffff30e8"
   },
   "web.COMMON.burn_this_secret_hint": {
-    "text": "シークレットを削除すると、閲覧される前に消去されます(クリックして確認)",
+    "text": "シークレットを削除すると、閲覧される前に消去されます (クリックして確認)",
     "source_hash": "c6a8b145"
   },
   "web.COMMON.burn_this_secret_confirm_hint": {
-    "text": "シークレットの削除は取り消すことができません",
+    "text": "シークレットの削除は永続的で、元に戻せません",
     "source_hash": "ab774967"
   },
   "web.COMMON.msg_check_email": {
-    "text": "メールを確認してください",
+    "text": "メールをご確認ください",
     "source_hash": "77322879"
   },
   "web.COMMON.click_to_continue": {
@@ -177,7 +177,7 @@
     "source_hash": "41658f99"
   },
   "web.COMMON.click_to_verify": {
-    "text": "続けてアカウントを認証:",
+    "text": "続けてアカウントを認証してください:",
     "source_hash": "954d6fc9"
   },
   "web.COMMON.error_secret": {
@@ -185,11 +185,11 @@
     "source_hash": "9ac6488f"
   },
   "web.COMMON.error_passphrase": {
-    "text": "パスフレーズを再確認してください",
+    "text": "パスフレーズをもう一度ご確認ください",
     "source_hash": "b582f3a6"
   },
   "web.COMMON.enter_passphrase_here": {
-    "text": "パスフレーズを入力してください",
+    "text": "ここにパスフレーズを入力してください",
     "source_hash": "ee855dad"
   },
   "web.COMMON.view_secret": {
@@ -197,7 +197,7 @@
     "source_hash": "01835e7c"
   },
   "web.COMMON.careful_only_see_once": {
-    "text": "注意: これは一度しか表示されません。",
+    "text": "ご注意: 一度しか表示されません。",
     "source_hash": "d29e2820"
   },
   "web.COMMON.warning": {
@@ -217,11 +217,11 @@
     "source_hash": "e198269c"
   },
   "web.COMMON.secret_was_truncated": {
-    "text": "メッセージが切り詰められました",
+    "text": "メッセージは切り詰められました",
     "source_hash": "1d1730d4"
   },
   "web.COMMON.signup_for_more": {
-    "text": "詳しくはサインアップ",
+    "text": "登録して機能を追加",
     "source_hash": "cc1421d0"
   },
   "web.COMMON.login_to_your_account": {
@@ -229,11 +229,11 @@
     "source_hash": "62f1fe13"
   },
   "web.COMMON.sent_to": {
-    "text": "送信先:",
+    "text": "送信先: ",
     "source_hash": "e79c8bcb"
   },
   "web.COMMON.field_email": {
-    "text": "メール",
+    "text": "メールアドレス",
     "source_hash": "969ccbd3"
   },
   "web.COMMON.field_password": {
@@ -277,7 +277,7 @@
     "source_hash": "19766ed6"
   },
   "web.COMMON.word_continue": {
-    "text": "続ける",
+    "text": "続行",
     "source_hash": "31fbef16"
   },
   "web.COMMON.word_done": {
@@ -289,7 +289,7 @@
     "source_hash": "76900f1b"
   },
   "web.COMMON.feedback_text": {
-    "text": "ご意見、アイデア、ご感想をお聞かせください...",
+    "text": "ご意見、アイデア、体験などをお聞かせください...",
     "source_hash": "6bd0351a"
   },
   "web.COMMON.button_send_feedback": {
@@ -297,15 +297,15 @@
     "source_hash": "84195de9"
   },
   "web.COMMON.verification_sent_to": {
-    "text": "認証メールを送信しました:",
+    "text": "確認メールの送信先",
     "source_hash": "62da29c0"
   },
   "web.COMMON.autoverified_success": {
-    "text": "アカウントが作成されました。ログインしてください。",
+    "text": "アカウントを作成しました。ログインしてください。",
     "source_hash": "fd3610bf"
   },
   "web.COMMON.signup_success_generic": {
-    "text": "このメールアドレスに紐づくアカウントが存在する場合、認証メールが送信されます。",
+    "text": "このメールアドレスのアカウントが存在する場合、確認メールが届きます。",
     "source_hash": "f596cdd0"
   },
   "web.COMMON.burn_this_secret_aria": {
@@ -313,15 +313,15 @@
     "source_hash": "0a7afc29"
   },
   "web.COMMON.burn_confirmation_title": {
-    "text": "確認してください",
+    "text": "ご確認ください",
     "source_hash": "dcd78dfb"
   },
   "web.COMMON.burn_confirmation_message": {
-    "text": "このシークレットを削除してもよろしいですか?この操作は取り消すことができません。",
+    "text": "このシークレットを削除してもよろしいですか? この操作は元に戻せません。",
     "source_hash": "5dde5dd9"
   },
   "web.COMMON.confirm_burn": {
-    "text": "はい、このシークレットを削除",
+    "text": "はい、このシークレットを削除します",
     "source_hash": "6e5b02a7"
   },
   "web.COMMON.burn_security_notice": {
@@ -329,7 +329,7 @@
     "source_hash": "b4c8bbc3"
   },
   "web.COMMON.share_link_securely": {
-    "text": "セキュリティのため、このリンクは他の情報とは別に共有してください。",
+    "text": "安全のため、このリンクは他の情報とは別に共有してください。",
     "source_hash": "c46e6204"
   },
   "web.COMMON.copied_to_clipboard": {
@@ -337,7 +337,7 @@
     "source_hash": "d37078fe"
   },
   "web.COMMON.button_create_incoming": {
-    "text": "受信リンクを作成",
+    "text": "受信を作成",
     "source_hash": "5bb95106"
   },
   "web.COMMON.faq_title": {
@@ -349,7 +349,7 @@
     "source_hash": "abf07ced"
   },
   "web.COMMON.verification_already_logged_in": {
-    "text": "ログイン中はアカウントを認証できません",
+    "text": "すでにログインしている状態ではアカウントを認証できません",
     "source_hash": "f0a17c5f"
   },
   "web.COMMON.show_password": {
@@ -361,11 +361,11 @@
     "source_hash": "a60a56c5"
   },
   "web.COMMON.minimum_8_characters": {
-    "text": "パスワードは8文字以上必要です",
+    "text": "パスワードは8文字以上である必要があります",
     "source_hash": "e3b8d09d"
   },
   "web.COMMON.password_requirements": {
-    "text": "パスワードは8文字以上必要です",
+    "text": "パスワードは8文字以上である必要があります",
     "source_hash": "e5054833"
   },
   "web.COMMON.passwords_do_not_match": {
@@ -377,11 +377,11 @@
     "source_hash": "6876f12e"
   },
   "web.COMMON.form_processing": {
-    "text": "リクエストを処理中",
+    "text": "リクエストを処理しています",
     "source_hash": "a512a73b"
   },
   "web.COMMON.remember_me_description": {
-    "text": "30日間ログイン状態を維持",
+    "text": "30日間ログイン状態を保持する",
     "source_hash": "6e069c11"
   },
   "web.COMMON.redirecting": {
@@ -389,7 +389,7 @@
     "source_hash": "cd23991b"
   },
   "web.COMMON.continue": {
-    "text": "続ける",
+    "text": "続行",
     "source_hash": "31fbef16"
   },
   "web.COMMON.are_you_sure": {
@@ -397,11 +397,11 @@
     "source_hash": "f0762c4f"
   },
   "web.COMMON.danger_zone": {
-    "text": "危険ゾーン",
+    "text": "危険な操作",
     "source_hash": "3c1c01b4"
   },
   "web.COMMON.caution_zone": {
-    "text": "注意が必要なゾーン",
+    "text": "慎重な操作が必要な項目",
     "source_hash": "fe27a3a8"
   },
   "web.COMMON.user_menu": {
@@ -433,7 +433,7 @@
     "source_hash": "0a6691ef"
   },
   "web.COMMON.e_g_example": {
-    "text": "例",
+    "text": "例:",
     "source_hash": "a79b4bf9"
   },
   "web.COMMON.example_placeholder": {
@@ -461,7 +461,7 @@
     "source_hash": "c3812fc4"
   },
   "web.COMMON.press_esc_to_close": {
-    "text": "ESCキーで閉じる",
+    "text": "ESCキーで閉じます",
     "source_hash": "5aa83883"
   },
   "web.COMMON.enter": {
@@ -501,15 +501,15 @@
     "source_hash": "d8da2c49"
   },
   "web.COMMON.monthly": {
-    "text": "月間",
+    "text": "月額",
     "source_hash": "9b11f6b7"
   },
   "web.COMMON.yearly": {
-    "text": "年間",
+    "text": "年額",
     "source_hash": "6e69b59e"
   },
   "web.COMMON.go_on_then": {
-    "text": "続けてください。",
+    "text": "どうぞお進みください。",
     "source_hash": "fb697cc7"
   },
   "web.COMMON.loading_ellipses": {
@@ -533,7 +533,7 @@
     "source_hash": "f2488fd4"
   },
   "web.COMMON.switch": {
-    "text": "切替",
+    "text": "切り替え",
     "source_hash": "78b49fb2"
   },
   "web.COMMON.features": {
@@ -553,7 +553,7 @@
     "source_hash": "1d456424"
   },
   "web.COMMON.supported": {
-    "text": "対応",
+    "text": "対応済み",
     "source_hash": "c1658000"
   },
   "web.COMMON.version": {
@@ -593,7 +593,7 @@
     "source_hash": "4a823118"
   },
   "web.COMMON.type": {
-    "text": "タイプ",
+    "text": "種類",
     "source_hash": "baaddf70"
   },
   "web.COMMON.previous": {
@@ -609,11 +609,11 @@
     "source_hash": "663d6499"
   },
   "web.COMMON.great": {
-    "text": "とても良い",
+    "text": "非常に強い",
     "source_hash": "c8cc1c7b"
   },
   "web.COMMON.pretty_good": {
-    "text": "かなり良い",
+    "text": "かなり強い",
     "source_hash": "521a41b6"
   },
   "web.COMMON.fair": {
@@ -621,11 +621,11 @@
     "source_hash": "f7b19afc"
   },
   "web.COMMON.meh": {
-    "text": "まあまあ",
+    "text": "やや弱い",
     "source_hash": "8b0d6190"
   },
   "web.COMMON.not_great": {
-    "text": "あまり良くない",
+    "text": "弱い",
     "source_hash": "00561207"
   },
   "web.COMMON.open_options": {
@@ -649,7 +649,7 @@
     "source_hash": "da84ff02"
   },
   "web.COMMON.double_check_that_passphrase": {
-    "text": "パスフレーズを再確認してください",
+    "text": "パスフレーズをもう一度ご確認ください",
     "source_hash": "b582f3a6"
   },
   "web.COMMON.press_copy_button_below": {
@@ -673,7 +673,7 @@
     "source_hash": "ba8a80fd"
   },
   "web.LABELS.view_toggle.show_less": {
-    "text": "閉じる",
+    "text": "表示を減らす",
     "source_hash": "0264d7b0"
   },
   "web.LABELS.enable": {
@@ -721,7 +721,7 @@
     "source_hash": "dc85af8f"
   },
   "web.LABELS.saved": {
-    "text": "保存済み",
+    "text": "保存しました",
     "source_hash": "b5c120b3"
   },
   "web.LABELS.save": {
@@ -745,7 +745,7 @@
     "source_hash": "57330d93"
   },
   "web.LABELS.need_help": {
-    "text": "ヘルプが必要ですか?",
+    "text": "サポートが必要ですか?",
     "source_hash": "c225cdfb"
   },
   "web.LABELS.create_new_secret": {
@@ -789,7 +789,7 @@
     "source_hash": "63e0dea7"
   },
   "web.LABELS.recipients_count": {
-    "text": "{count}人の受信者",
+    "text": "受信者{count}名",
     "source_hash": "48187543"
   },
   "web.LABELS.view": {
@@ -805,7 +805,7 @@
     "source_hash": "73758343"
   },
   "web.LABELS.view_progress": {
-    "text": "進捗を表示",
+    "text": "閲覧状況",
     "source_hash": "6c072c1f"
   },
   "web.LABELS.help_section": {
@@ -813,7 +813,7 @@
     "source_hash": "614e14f0"
   },
   "web.LABELS.passphrase_protected": {
-    "text": "パスフレーズで保護",
+    "text": "パスフレーズで保護されています",
     "source_hash": "a52b9edf"
   },
   "web.LABELS.feedback_received": {
@@ -841,7 +841,7 @@
     "source_hash": "bdc090ec"
   },
   "web.LABELS.filter": {
-    "text": "フィルター",
+    "text": "絞り込み",
     "source_hash": "638e249f"
   },
   "web.LABELS.clear": {
@@ -869,7 +869,7 @@
     "source_hash": "190463dc"
   },
   "web.LABELS.related_settings": {
-    "text": "関連設定",
+    "text": "関連する設定",
     "source_hash": "68574b20"
   },
   "web.LABELS.benefits": {
@@ -878,11 +878,11 @@
     "source_hash": "d5b67bc9"
   },
   "web.LABELS.creating_links_for": {
-    "text": "リンクを作成中:",
+    "text": "リンクの作成先",
     "source_hash": "57db069e"
   },
   "web.LABELS.scope_indicator": {
-    "text": "{domain}でシークレットを作成中",
+    "text": "{domain}でシークレットを作成しています",
     "source_hash": "3bbed96b"
   },
   "web.STATUS.new": {
@@ -894,7 +894,7 @@
     "source_hash": "1b9f384c"
   },
   "web.STATUS.viewed": {
-    "text": "リンクが開かれました",
+    "text": "リンクを開封",
     "source_hash": "66844573"
   },
   "web.STATUS.received": {
@@ -906,7 +906,7 @@
     "source_hash": "3d391a9b"
   },
   "web.STATUS.revealed": {
-    "text": "閲覧済み",
+    "text": "表示済み",
     "source_hash": "17376ee4"
   },
   "web.STATUS.burned": {
@@ -914,7 +914,7 @@
     "source_hash": "6d747b33"
   },
   "web.STATUS.destroyed": {
-    "text": "削除済み",
+    "text": "消去済み",
     "source_hash": "ff49630c"
   },
   "web.STATUS.expiring_soon": {
@@ -922,7 +922,7 @@
     "source_hash": "0259442c"
   },
   "web.STATUS.created": {
-    "text": "作成済み",
+    "text": "作成日時",
     "source_hash": "d70b9e24"
   },
   "web.STATUS.expires": {
@@ -958,23 +958,23 @@
     "source_hash": "447c4445"
   },
   "web.STATUS.unread_description": {
-    "text": "シークレットリンクが作成され、まだ閲覧されていません",
+    "text": "シークレットリンクが作成され、閲覧されていません",
     "source_hash": "83b9a0ca"
   },
   "web.STATUS.viewed_description": {
-    "text": "シークレットリンクが開かれ、閲覧可能な状態です",
+    "text": "シークレットリンクが開かれ、閲覧できる状態です",
     "source_hash": "f392af12"
   },
   "web.STATUS.received_description": {
-    "text": "シークレットは受信者に閲覧されました",
+    "text": "シークレットが受信者に表示されました",
     "source_hash": "ceb756b4"
   },
   "web.STATUS.previewed_description": {
-    "text": "シークレットリンクが開かれ、閲覧可能な状態です",
+    "text": "シークレットリンクが開かれ、表示できる状態です",
     "source_hash": "cc7d1e92"
   },
   "web.STATUS.revealed_description": {
-    "text": "シークレットの内容が受信者に閲覧されました",
+    "text": "シークレットの内容が受信者に表示されました",
     "source_hash": "39b32f80"
   },
   "web.STATUS.burned_description": {
@@ -982,15 +982,15 @@
     "source_hash": "e7aa1ec1"
   },
   "web.STATUS.destroyed_description": {
-    "text": "シークレットは完全に削除されました",
+    "text": "シークレットは完全に消去されました",
     "source_hash": "9bcb9949"
   },
   "web.STATUS.expiring_soon_description": {
-    "text": "シークレットがまもなく期限切れになります",
+    "text": "シークレットはまもなく期限切れになります",
     "source_hash": "e182e8f4"
   },
   "web.STATUS.orphaned_description": {
-    "text": "シークレットは孤立状態となり、まもなく削除されます",
+    "text": "シークレットは孤立しており、まもなく消去されます",
     "source_hash": "49b87422"
   },
   "web.STATUS.expired_description": {
@@ -1006,7 +1006,7 @@
     "source_hash": "90611565"
   },
   "web.STATUS.dns_incorrect": {
-    "text": "DNS設定エラー",
+    "text": "DNSが正しくありません",
     "source_hash": "7848d601"
   },
   "web.STATUS.active": {
@@ -1018,15 +1018,15 @@
     "source_hash": "ac7c949f"
   },
   "web.FEATURES.unlimited_views": {
-    "text": "無制限の閲覧",
+    "text": "閲覧回数無制限",
     "source_hash": "3f6859b0"
   },
   "web.FEATURES.custom_domain_protected": {
-    "text": "信頼できるドメインブランディング",
+    "text": "信頼できるドメインでのブランディング",
     "source_hash": "5e39b05c"
   },
   "web.FEATURES.encrypted_in_transit": {
-    "text": "転送中および保存時に暗号化",
+    "text": "転送時および保存時に暗号化",
     "source_hash": "314c7974"
   },
   "web.UNITS.ttl.duration": {
@@ -1054,7 +1054,7 @@
     "source_hash": "cb3f91d5"
   },
   "web.UNITS.ttl_remaining.duration": {
-    "text": "残り{count}{unit}",
+    "text": "残り{count} {unit}",
     "source_hash": "18f6c6e8"
   },
   "web.UNITS.ttl_remaining.time.day": {
@@ -1078,7 +1078,7 @@
     "source_hash": "cb3f91d5"
   },
   "web.UNITS.limited_views": {
-    "text": "閲覧制限: {count}回",
+    "text": "閲覧回数の上限{count}回",
     "source_hash": "8db0e228"
   },
   "web.UNITS.days_remaining": {
@@ -1114,19 +1114,19 @@
     "source_hash": "0dffe234"
   },
   "web.TITLES.forgot_password": {
-    "text": "パスワードを忘れた場合",
+    "text": "パスワードをお忘れの場合",
     "source_hash": "fdfd41de"
   },
   "web.TITLES.reset_password": {
-    "text": "パスワードのリセット",
+    "text": "パスワードをリセット",
     "source_hash": "4e70f1fd"
   },
   "web.TITLES.logout": {
-    "text": "ログアウト中",
+    "text": "ログアウトしています",
     "source_hash": "afbce8a6"
   },
   "web.TITLES.verify_account": {
-    "text": "アカウントの検証",
+    "text": "アカウントを認証",
     "source_hash": "2f3ea760"
   },
   "web.TITLES.mfa_verify": {
@@ -1134,7 +1134,7 @@
     "source_hash": "bc074b60"
   },
   "web.TITLES.email_login": {
-    "text": "メールログイン",
+    "text": "メールでログイン",
     "source_hash": "c316e3d7"
   },
   "web.TITLES.accept_invitation": {
@@ -1174,11 +1174,11 @@
     "source_hash": "0f09df73"
   },
   "web.TITLES.domain_verify": {
-    "text": "ドメインの検証",
+    "text": "ドメインを検証",
     "source_hash": "b416f537"
   },
   "web.TITLES.domain_brand": {
-    "text": "ブランドドメイン",
+    "text": "ドメインのブランディング",
     "source_hash": "35e4dfbe"
   },
   "web.TITLES.account": {
@@ -1218,11 +1218,11 @@
     "source_hash": "78801183"
   },
   "web.TITLES.change_email": {
-    "text": "メールアドレスの変更",
+    "text": "メールアドレスを変更",
     "source_hash": "18c3f2d5"
   },
   "web.TITLES.confirm_email_change": {
-    "text": "メールアドレス変更の確認",
+    "text": "メールアドレスの変更を確認",
     "source_hash": "c2736949"
   },
   "web.TITLES.security_overview": {
@@ -1230,7 +1230,7 @@
     "source_hash": "8f6fb4eb"
   },
   "web.TITLES.change_password": {
-    "text": "パスワードの変更",
+    "text": "パスワードを変更",
     "source_hash": "a949f462"
   },
   "web.TITLES.mfa_settings": {
@@ -1238,7 +1238,7 @@
     "source_hash": "bc074b60"
   },
   "web.TITLES.active_sessions": {
-    "text": "アクティブセッション",
+    "text": "アクティブなセッション",
     "source_hash": "b58fa4e0"
   },
   "web.TITLES.recovery_codes": {
@@ -1279,35 +1279,35 @@
     "source_hash": "dfe95783"
   },
   "web.ARIA.focus_is_now_in_the_main_text_area": {
-    "text": "メインテキストエリアにフォーカスが移動しました",
+    "text": "フォーカスがメインのテキストエリアに移動しました",
     "source_hash": "e00dd260"
   },
   "web.INSTRUCTION.sharing_instructions": {
-    "text": "共有方法",
+    "text": "共有の手順",
     "source_hash": "1a450046"
   },
   "web.INSTRUCTION.share_link_instruction": {
-    "text": "意図した受信者にリンクを共有してください",
+    "text": "リンクを意図した受信者と共有してください",
     "source_hash": "43bdee1d"
   },
   "web.INSTRUCTION.share_passphrase_instruction": {
-    "text": "パスフレーズは安全なチャネルで別途共有してください",
+    "text": "パスフレーズは安全な別の経路で共有してください",
     "source_hash": "c348d386"
   },
   "web.INSTRUCTION.secure_channel_instruction": {
-    "text": "機密情報を共有する際は、別の安全なチャネルを使用してください",
+    "text": "機密情報の共有には別の安全な経路をご利用ください",
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "常に公式の{product_name}ウェブサイトにアクセスしていることを確認してください。詐欺師は、シークレットを盗むために{product_name}とまったく同じように見える偽のウェブサイトを作成することがあります。フィッシング攻撃を防ぐため、新しいリンクを作成する前に、アドレスバーでリージョンのドメインを確認してください。",
+    "text": "必ず公式の{product_name}のウェブサイトであることをご確認ください。詐欺者がシークレットを盗むために、{product_name}とまったく同じ見た目の偽サイトを作成する場合があります。フィッシング攻撃を避けるため、新しいリンクを作成する前にアドレスバーでリージョンのドメインをご確認ください。",
     "source_hash": "2e3b856e"
   },
   "web.pricing.title": {
-    "text": "シンプルで透明な料金",
+    "text": "シンプルで透明性のある料金",
     "source_hash": "97e283c7"
   },
   "web.pricing.subtitle": {
-    "text": "ニーズに合ったプランをお選びください。すべてのプランで無制限のシークレット共有とプライバシー第一の設計が含まれています。",
+    "text": "ニーズに合ったプランをお選びください。すべてのプランに無制限のシークレット共有とプライバシー第一の設計が含まれます。",
     "source_hash": "9204dff4"
   },
   "web.pricing.get_started_free": {
@@ -1319,7 +1319,7 @@
     "source_hash": "983f3110"
   },
   "web.pricing.already_have_account": {
-    "text": "既にアカウントをお持ちですか?",
+    "text": "すでにアカウントをお持ちですか?",
     "source_hash": "e77fea93"
   },
   "web.pricing.sign_in": {
@@ -1327,7 +1327,7 @@
     "source_hash": "bfd402b2"
   },
   "web.pricing.recommended_for_you": {
-    "text": "おすすめ",
+    "text": "おすすめのプラン",
     "source_hash": "00093fbd"
   },
   "web.COMMON.received": {
@@ -1351,7 +1351,7 @@
     "source_hash": "0ec1a5db"
   },
   "web.pricing.free_tier_description": {
-    "text": "基本機能でシークレットを作成・共有。クレジットカード不要。",
+    "text": "基本機能でシークレットを作成・共有できます。クレジットカードは不要です。",
     "source_hash": "3a4f2bc0"
   },
   "web.COMMON.enter_password_to_continue": {
@@ -1370,7 +1370,7 @@
     "source_hash": "6615bf1c"
   },
   "api.errors.service_unavailable": {
-    "text": "サービスが一時的に利用できません。しばらくしてから再度お試しください。",
+    "text": "サービスが一時的に利用できません。しばらくしてからもう一度お試しください。",
     "context": "Error message when database connection fails",
     "source_hash": "343ccdcb"
   },
@@ -1380,7 +1380,7 @@
     "source_hash": "fb961f3f"
   },
   "web.COMMON.upgrade_description": {
-    "text": "アップグレードしてより多くの機能を利用する",
+    "text": "アップグレードするとさらに多くの機能を利用できます",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
   },
@@ -1389,7 +1389,7 @@
     "source_hash": "0fcfb12d"
   },
   "api.errors.sso_only_action_blocked": {
-    "text": "このアクションはSSO専用モードでは利用できません",
+    "text": "この操作はSSO専用モードでは利用できません",
     "source_hash": "9bc26394"
   },
   "web.COMMON.configure": {
@@ -1505,7 +1505,7 @@
     "source_hash": "e24f338d"
   },
   "web.TITLES.domain_signin": {
-    "text": "サインイン設定",
+    "text": "ログイン設定",
     "source_hash": "2da38c03"
   },
   "web.TITLES.domain_sso": {
@@ -1513,7 +1513,7 @@
     "source_hash": "13161464"
   },
   "web.TITLES.domain_signup": {
-    "text": "ドメインサインアップ検証",
+    "text": "ドメイン登録検証",
     "source_hash": "c8ce809a"
   },
   "web.TITLES.domain_email": {
@@ -1539,5 +1539,9 @@
   "web.TITLES.domain_dns": {
     "text": "DNS設定",
     "source_hash": "6c63df31"
+  },
+  "web.TITLES.connected_identities": {
+    "text": "連携済みのID",
+    "source_hash": "e132c4d9"
   }
 }

--- a/locales/content/ja/10-layout.json
+++ b/locales/content/ja/10-layout.json
@@ -20,7 +20,7 @@
     "source_hash": "8f6fb4eb"
   },
   "web.footer.learn_about_our_security_measures": {
-    "text": "セキュリティ対策について詳しく見る",
+    "text": "当社のセキュリティ対策について",
     "source_hash": "16c8adae"
   },
   "web.footer.view_our_terms_and_conditions": {
@@ -48,7 +48,7 @@
     "source_hash": "0a410c78"
   },
   "web.feedback.when_you_submit_feedback_well_see": {
-    "text": "フィードバックを送信すると、以下の情報が送信されます:",
+    "text": "フィードバックを送信すると、当社では次の情報を確認します:",
     "source_hash": "fe77172e"
   },
   "web.footer.read_our_privacy_policy": {
@@ -56,7 +56,7 @@
     "source_hash": "eb443229"
   },
   "web.footer.check_our_service_status": {
-    "text": "サービスステータスを確認",
+    "text": "サービスの稼働状況を確認",
     "source_hash": "1f04937e"
   },
   "web.footer.explore_our_api_documentation": {
@@ -88,15 +88,15 @@
     "source_hash": "77468d43"
   },
   "web.footer.view_our_subscription_pricing": {
-    "text": "サブスクリプション料金を見る",
+    "text": "サブスクリプションの料金を見る",
     "source_hash": "55f1f590"
   },
   "web.footer.learn_about_our_company": {
-    "text": "会社について詳しく見る",
+    "text": "当社について",
     "source_hash": "780e18cd"
   },
   "web.footer.company": {
-    "text": "会社概要",
+    "text": "会社情報",
     "source_hash": "de4743c8"
   },
   "web.footer.product": {
@@ -120,23 +120,23 @@
     "source_hash": "2730183d"
   },
   "web.site.website_version": {
-    "text": "ウェブサイトバージョン",
+    "text": "ウェブサイトのバージョン",
     "source_hash": "4d4a570f"
   },
   "web.meta.were_making_onetime_secret_available_in_multiple": {
-    "text": "私たちは{onetime-secret}を複数の言語で提供しています。これは新機能のため、翻訳エラーや不自然な表現に遭遇する可能性があります。あなたのフィードバックは私たちの改善に役立ちます - 問題を見つけた場合は、{send-feedback}してください",
+    "text": "{onetime-secret}を複数の言語でご利用いただけるようにしています。新しい機能のため、翻訳の誤りや不自然な表現が含まれる場合があります。改善のためにご意見をお寄せください。問題を見つけた場合は{send-feedback}",
     "source_hash": "3b482d7f"
   },
   "web.meta.translations_are_new_spotted_an_error": {
-    "text": "翻訳は新しい機能です。エラーを見つけましたか？{send-feedback}",
+    "text": "翻訳は新しい機能です。誤りを見つけましたか? {send-feedback}",
     "source_hash": "31eca08d"
   },
   "web.meta.we_recently_added_translations": {
-    "text": "最近翻訳を追加しました。誤りを見つけましたか? {send-feedback}",
+    "text": "最近、翻訳を追加しました。誤りを見つけましたか? {send-feedback}",
     "source_hash": "6e2455c1"
   },
   "web.meta.privacy_and_security_should_be_accessible": {
-    "text": "プライバシーとセキュリティは言語に関係なく、すべての人がアクセスできるべきです。私たちは、ユーザーとメッセージ受信者の両方が安全なメッセージやリンクの使用方法と理解をより良くするために翻訳を追加しています。これは新機能のため、翻訳エラーや不明確な指示に遭遇する可能性があります。特に重要なセキュリティ関連のコンテンツの明確さと正確さを向上させるため、問題を見つけた場合は{send-feedback}してください",
+    "text": "プライバシーとセキュリティは、言語を問わずすべての人が利用できるべきものです。当社は、ユーザーとメッセージの受信者の双方が、安全なメッセージやリンクの利用方法をより理解できるよう翻訳を追加しています。新しい機能のため、翻訳の誤りや分かりにくい説明が含まれる場合があります。特にセキュリティに関わる重要な内容について、翻訳の明確さと正確さを改善できるよう、問題を見つけた場合は{send-feedback}",
     "source_hash": "1b8bb38f"
   },
   "web.help.learn_more": {
@@ -148,35 +148,35 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "{product_name}を通じて共有された安全なメッセージを表示しています。このコンテンツは一度だけ表示され、その後サーバーから完全に削除されます。",
+    "text": "{product_name}を通じて共有された安全なメッセージを表示しています。この内容は一度だけ表示され、その後サーバーから完全に削除されます。",
     "source_hash": "7a4e9d16"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
-    "text": "このシークレットを後で再度表示できますか?",
+    "text": "このシークレットを後でもう一度表示できますか?",
     "source_hash": "c8c2c9da"
   },
   "web.help.secret_view_faq.can_i_view_again.description": {
-    "text": "いいえ。セキュリティ上の理由から、このシークレットは1回のみ閲覧可能です。このページを閉じると、内容は完全に削除され、私たちを含め誰も復元できません。",
+    "text": "いいえ。セキュリティ上の理由から、このシークレットは一度しか表示できません。このページを閉じると内容は完全に削除され、当社を含め誰も復元できません。",
     "source_hash": "4bf980a4"
   },
   "web.help.secret_view_faq.how_to_copy.title": {
-    "text": "この情報を保存するにはどうすればいいですか?",
+    "text": "この情報を保存するにはどうすればよいですか?",
     "source_hash": "90deddbb"
   },
   "web.help.secret_view_faq.how_to_copy.description": {
-    "text": "「クリップボードにコピー」ボタンを使用して、シークレット全体をコピーしてください。長いシークレットの場合は、このページを離れる前に内容が完全にコピーされたことを確認してください。",
+    "text": "「クリップボードにコピー」ボタンでシークレット全体をコピーしてください。内容が長い場合は、このページを離れる前にすべてコピーできたかご確認ください。",
     "source_hash": "440aa828"
   },
   "web.help.secret_view_faq.is_my_viewing_tracked.title": {
-    "text": "このシークレットの閲覧は追跡されますか?",
+    "text": "このシークレットの閲覧は記録されますか?",
     "source_hash": "90145e28"
   },
   "web.help.secret_view_faq.is_my_viewing_tracked.description": {
-    "text": "送信者にはシークレットが閲覧されたことが通知されますが、誰がどこから閲覧したかは追跡されません。あなたのプライバシーは保護されています。",
+    "text": "送信者にはシークレットが閲覧されたことが通知されますが、誰がどこから閲覧したかは記録していません。お客様のプライバシーは保護されます。",
     "source_hash": "70737473"
   },
   "web.help.secret_view_faq.one_time_warning": {
-    "text": "このページを離れるか更新すると、このシークレットは完全に削除され、誰も復元できなくなります。",
+    "text": "このページを離れるか再読み込みすると、このシークレットは完全に削除され、誰も復元できません。",
     "source_hash": "47feab6e"
   },
   "web.layout.go_back_to_previous_page": {
@@ -192,7 +192,7 @@
     "source_hash": "ffe32a00"
   },
   "web.layout.provide_feedback": {
-    "text": "フィードバックを送信",
+    "text": "フィードバックを送る",
     "source_hash": "a70766ae"
   },
   "web.layout.company_logo": {
@@ -204,7 +204,7 @@
     "source_hash": "e458e2b5"
   },
   "web.layout.dashboard_navigation": {
-    "text": "ダッシュボードナビゲーション",
+    "text": "ダッシュボードのナビゲーション",
     "source_hash": "da5c1c43"
   },
   "web.layout.mobile_navigation": {
@@ -216,7 +216,7 @@
     "source_hash": "56ea852a"
   },
   "web.layout.mobile_nav_item_count": {
-    "text": "{count}項目",
+    "text": "{count}件",
     "source_hash": "f65216b3"
   },
   "web.layout.release_notes": {
@@ -224,7 +224,7 @@
     "source_hash": "bd4702c1"
   },
   "web.layout.loading_settings_content": {
-    "text": "設定コンテンツを読み込み中...",
+    "text": "設定を読み込んでいます...",
     "source_hash": "81a2a30e"
   },
   "web.layout.settings_sections_0": {
@@ -240,7 +240,7 @@
     "source_hash": "e26d51d3"
   },
   "web.layout.customize_your_app_preferences_and_settings": {
-    "text": "アプリの設定と環境設定をカスタマイズする",
+    "text": "アプリの環境設定をカスタマイズします",
     "source_hash": "00d74c98"
   },
   "web.layout.return_home": {
@@ -308,11 +308,11 @@
     "source_hash": "75e96614"
   },
   "web.layout.website_version_v_ot_version": {
-    "text": "ウェブサイトバージョン: v{0}",
+    "text": "ウェブサイトのバージョン: v{0}",
     "source_hash": "343f57de"
   },
   "web.layout.current_language_is_currentlocal": {
-    "text": "言語を変更。現在の言語: {0}",
+    "text": "言語を変更します。現在の言語は{0}です",
     "source_hash": "77f9c322"
   },
   "web.layout.language_changed_to_newlocale": {
@@ -328,7 +328,7 @@
     "source_hash": "c8b909e0"
   },
   "web.layout.blank_mode_enabled": {
-    "text": "{0}モードが有効",
+    "text": "{0}モードを有効にしました",
     "source_hash": "e1d200cb"
   },
   "web.layout.workspace": {
@@ -336,7 +336,7 @@
     "source_hash": "87bb59ba"
   },
   "web.layout.workspace_context": {
-    "text": "ワークスペースコンテキスト",
+    "text": "ワークスペースのコンテキスト",
     "source_hash": "dc6fa4f5"
   },
   "web.footer.workspace": {
@@ -344,7 +344,7 @@
     "source_hash": "87bb59ba"
   },
   "web.help.default_content": {
-    "text": "サポートが必要な場合はサポートにお問い合わせください",
+    "text": "サポートまでお問い合わせください",
     "source_hash": "752bca14"
   },
   "web.layout.colonels_only_badge": {

--- a/locales/content/ja/admin-audit.json
+++ b/locales/content/ja/admin-audit.json
@@ -4,7 +4,7 @@
     "source_hash": "47751f88"
   },
   "web.admin.audit.description": {
-    "text": "変更を伴うすべての管理者操作を新しい順に表示します。誰が誰に対して何を行い、その結果どうなったかを確認できます。",
+    "text": "変更を伴うすべての管理操作を新しい順に表示します — 誰が誰に対して何を行い、結果はどうだったか。",
     "source_hash": "2326a1a0"
   },
   "web.admin.audit.categories.customer": {
@@ -52,7 +52,7 @@
     "source_hash": "449995c4"
   },
   "web.admin.audit.columns.action": {
-    "text": "アクション",
+    "text": "操作",
     "source_hash": "64cff131"
   },
   "web.admin.audit.columns.target": {
@@ -68,15 +68,15 @@
     "source_hash": "fb5f27d5"
   },
   "web.admin.audit.filters.actorPlaceholder": {
-    "text": "実行者で絞り込む(extidまたはメール)",
+    "text": "実行者で絞り込み (extidまたはメールアドレス)",
     "source_hash": "966aa580"
   },
   "web.admin.audit.filters.actionLabel": {
-    "text": "アクション",
+    "text": "操作",
     "source_hash": "64cff131"
   },
   "web.admin.audit.filters.allActions": {
-    "text": "すべてのアクション",
+    "text": "すべての操作",
     "source_hash": "83140cf1"
   },
   "web.admin.audit.list.loadError": {
@@ -88,7 +88,7 @@
     "source_hash": "942087cc"
   },
   "web.admin.audit.list.empty": {
-    "text": "監査イベントはまだ記録されていません",
+    "text": "記録された監査イベントはまだありません",
     "source_hash": "8fe0cac3"
   },
   "web.admin.audit.result.success": {
@@ -98,5 +98,41 @@
   "web.admin.audit.result.failure": {
     "text": "失敗",
     "source_hash": "7031edbc"
+  },
+  "web.admin.audit.categories.secret": {
+    "text": "シークレット",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.audit.categories.membership": {
+    "text": "メンバーシップ",
+    "source_hash": "b50f1a42"
+  },
+  "web.admin.audit.categories.entitlement_preview": {
+    "text": "エンタイトルメントのプレビュー",
+    "source_hash": "255c5797"
+  },
+  "web.admin.audit.categories.colonel": {
+    "text": "Colonelのログイン",
+    "source_hash": "01eeeb38"
+  },
+  "web.admin.audit.filters.actorLabel": {
+    "text": "実行者",
+    "source_hash": "449995c4"
+  },
+  "web.admin.audit.filters.searchButton": {
+    "text": "検索",
+    "source_hash": "49c266ba"
+  },
+  "web.admin.audit.filters.searchHint": {
+    "text": "実行者を入力し、Enterキーを押すか「検索」を選択して実行してください。入力中は一覧は更新されません。",
+    "source_hash": "45eceb12"
+  },
+  "web.admin.audit.filters.pendingSearch": {
+    "text": "まだ検索されていません — Enterキーを押すか「検索」を選択して、この実行者を適用してください。",
+    "source_hash": "f76095c2"
+  },
+  "web.admin.audit.list.contractError": {
+    "text": "サーバーは応答しましたが、監査データが想定された形式と一致しませんでした。イベントを表示できません — これはログが空なのではなく、レポート処理の不具合です。",
+    "source_hash": "7f48137e"
   }
 }

--- a/locales/content/ja/admin-bannedips.json
+++ b/locales/content/ja/admin-bannedips.json
@@ -1,10 +1,10 @@
 {
   "web.admin.bannedIps.title": {
-    "text": "禁止IP",
+    "text": "禁止されたIP",
     "source_hash": "0ece5643"
   },
   "web.admin.bannedIps.description": {
-    "text": "サイト境界でIPアドレスを禁止または禁止解除します。",
+    "text": "サイトの境界でIPアドレスを禁止または解除します。",
     "source_hash": "69c0c992"
   },
   "web.admin.bannedIps.currentIp": {
@@ -28,7 +28,7 @@
     "source_hash": "512acd7b"
   },
   "web.admin.bannedIps.ban.confirmDescription": {
-    "text": "これにより、サイト境界で{ip}がブロックされます。確認のためにIPを入力してください。",
+    "text": "サイトの境界で{ip}をブロックします。確認のためIPアドレスを入力してください。",
     "source_hash": "d8f6142e"
   },
   "web.admin.bannedIps.ban.button": {
@@ -52,11 +52,11 @@
     "source_hash": "dfbd120e"
   },
   "web.admin.bannedIps.columns.bannedBy": {
-    "text": "禁止した実行者",
+    "text": "実行者",
     "source_hash": "9f47db0e"
   },
   "web.admin.bannedIps.columns.actions": {
-    "text": "アクション",
+    "text": "操作",
     "source_hash": "ff8059dc"
   },
   "web.admin.bannedIps.form.title": {
@@ -68,11 +68,11 @@
     "source_hash": "133d0819"
   },
   "web.admin.bannedIps.form.reasonLabel": {
-    "text": "理由(任意)",
+    "text": "理由 (任意)",
     "source_hash": "0f7d4664"
   },
   "web.admin.bannedIps.form.reasonPlaceholder": {
-    "text": "例:クレデンシャルスタッフィング",
+    "text": "例: クレデンシャルスタッフィング",
     "source_hash": "828a15ae"
   },
   "web.admin.bannedIps.form.submit": {
@@ -80,7 +80,7 @@
     "source_hash": "f91a5285"
   },
   "web.admin.bannedIps.list.loadError": {
-    "text": "禁止IPを読み込めませんでした。",
+    "text": "禁止されたIPを読み込めませんでした。",
     "source_hash": "539f2e34"
   },
   "web.admin.bannedIps.list.retry": {
@@ -88,11 +88,11 @@
     "source_hash": "942087cc"
   },
   "web.admin.bannedIps.list.empty": {
-    "text": "現在禁止されているIPはありません",
+    "text": "現在、禁止されているIPはありません",
     "source_hash": "b72cc9c5"
   },
   "web.admin.bannedIps.stats.total": {
-    "text": "禁止合計",
+    "text": "禁止の合計数",
     "source_hash": "41059c94"
   },
   "web.admin.bannedIps.unban.confirmTitle": {
@@ -100,7 +100,7 @@
     "source_hash": "88473e59"
   },
   "web.admin.bannedIps.unban.confirmDescription": {
-    "text": "これにより、{ip}のブロックが解除されます。確認のためにIPを入力してください。",
+    "text": "{ip}のブロックを解除します。確認のためIPアドレスを入力してください。",
     "source_hash": "6bec3191"
   },
   "web.admin.bannedIps.unban.button": {

--- a/locales/content/ja/admin-banner.json
+++ b/locales/content/ja/admin-banner.json
@@ -4,7 +4,7 @@
     "source_hash": "0bc449a3"
   },
   "web.admin.banner.description": {
-    "text": "すべての訪問者に表示されるサイト全体のお知らせを公開するか、現在のお知らせを消去します。",
+    "text": "すべての訪問者に表示されるサイト全体のお知らせを公開、または現在のお知らせを削除します。",
     "source_hash": "a0f720d7"
   },
   "web.admin.banner.loadError": {
@@ -16,19 +16,19 @@
     "source_hash": "942087cc"
   },
   "web.admin.banner.clear.button": {
-    "text": "バナーを消去",
+    "text": "バナーを削除",
     "source_hash": "da6b2e5d"
   },
   "web.admin.banner.clear.confirmTitle": {
-    "text": "ブロードキャストバナーを消去しますか?",
+    "text": "ブロードキャストバナーを削除しますか?",
     "source_hash": "46d9c35a"
   },
   "web.admin.banner.clear.confirmDescription": {
-    "text": "これにより、すべての訪問者に表示されている公開中のバナーが削除されます。続行するには確認用の単語を入力してください。",
+    "text": "すべての訪問者に表示されている公開中のバナーを削除します。続行するには確認用の単語を入力してください。",
     "source_hash": "9a56e4be"
   },
   "web.admin.banner.clear.success": {
-    "text": "ブロードキャストバナーを消去しました。",
+    "text": "ブロードキャストバナーを削除しました。",
     "source_hash": "b0f52af4"
   },
   "web.admin.banner.current.title": {
@@ -36,7 +36,7 @@
     "source_hash": "d17ab873"
   },
   "web.admin.banner.current.none": {
-    "text": "現在、バナーは設定されていません。",
+    "text": "現在、設定されているバナーはありません。",
     "source_hash": "487b2cac"
   },
   "web.admin.banner.current.status": {
@@ -52,7 +52,7 @@
     "source_hash": "6956d814"
   },
   "web.admin.banner.current.persistent": {
-    "text": "永続(有効期限なし)",
+    "text": "常時表示 (有効期限なし)",
     "source_hash": "5f95d1b0"
   },
   "web.admin.banner.current.expiresIn": {
@@ -60,15 +60,15 @@
     "source_hash": "f353f9a7"
   },
   "web.admin.banner.current.audience": {
-    "text": "対象者",
+    "text": "対象",
     "source_hash": "545c0235"
   },
   "web.admin.banner.current.storedContent": {
-    "text": "保存されたコンテンツ",
+    "text": "保存されている内容",
     "source_hash": "3579f3e6"
   },
   "web.admin.banner.current.htmlNote": {
-    "text": "コンテンツはHTMLです。表示時にサイトがリンクのみにサニタイズします。",
+    "text": "内容はHTMLです。表示時にはリンクのみを残すようサニタイズされます。",
     "source_hash": "e45a7dfe"
   },
   "web.admin.banner.current.edit": {
@@ -88,43 +88,43 @@
     "source_hash": "2f77668a"
   },
   "web.admin.banner.set.contentPlaceholder": {
-    "text": "定期メンテナンス 日曜 02:00 UTC",
+    "text": "メンテナンス予定 日曜 02:00 UTC",
     "source_hash": "4ec99d7d"
   },
   "web.admin.banner.set.contentHelp": {
-    "text": "HTMLを使用できます。サイトはリンクのみにサニタイズします。",
+    "text": "HTMLを使用できます。表示時にはリンクのみを残すようサニタイズされます。",
     "source_hash": "7253d1cd"
   },
   "web.admin.banner.set.ttlLabel": {
-    "text": "自動期限切れまでの時間(秒)",
+    "text": "自動的に期限切れにする時間 (秒)",
     "source_hash": "72134116"
   },
   "web.admin.banner.set.ttlPlaceholder": {
-    "text": "有効期限なしの場合は空欄",
+    "text": "有効期限を設けない場合は空欄にしてください",
     "source_hash": "a8fd81e1"
   },
   "web.admin.banner.set.ttlHelp": {
-    "text": "任意。この秒数が経過すると、バナーは自動的に削除されます。",
+    "text": "任意。指定した秒数の経過後、バナーは自動的に削除されます。",
     "source_hash": "ba0237f5"
   },
   "web.admin.banner.set.scopeLabel": {
-    "text": "対象者",
+    "text": "対象",
     "source_hash": "545c0235"
   },
   "web.admin.banner.set.scopeHelp": {
-    "text": "バナーを表示するページ。カスタムドメインのページは「すべてのページ」に設定した場合のみ表示されます。",
+    "text": "バナーを表示するページです。カスタムドメインのページは、すべてのページに設定した場合のみ表示されます。",
     "source_hash": "28cc3018"
   },
   "web.admin.banner.set.scopeNoRecipient": {
-    "text": "受信者ページを除くすべて",
+    "text": "受信者向けページを除くすべて",
     "source_hash": "8575b3c0"
   },
   "web.admin.banner.set.scopeWorkspace": {
-    "text": "ワークスペースページのみ",
+    "text": "ワークスペースのページのみ",
     "source_hash": "563e003e"
   },
   "web.admin.banner.set.scopeAll": {
-    "text": "すべてのページ(カスタムドメインを含む)",
+    "text": "すべてのページ (カスタムドメインを含む)",
     "source_hash": "b9b74870"
   },
   "web.admin.banner.set.publishButton": {
@@ -140,7 +140,7 @@
     "source_hash": "8b72b5c3"
   },
   "web.admin.banner.set.confirmDescription": {
-    "text": "このバナーは、消去されるか期限切れになるまで、サイト全体のすべての訪問者に表示されます。",
+    "text": "このバナーは、削除されるか期限切れになるまで、サイト全体のすべての訪問者に表示されます。",
     "source_hash": "c61bbec1"
   },
   "web.admin.banner.set.confirmButton": {

--- a/locales/content/ja/admin-billing.json
+++ b/locales/content/ja/admin-billing.json
@@ -4,7 +4,7 @@
     "source_hash": "bfde7e68"
   },
   "web.admin.billing.description": {
-    "text": "設定済みプランとそのエンタイトルメント、およびStripe同期済みの公開カタログとの差分を読み取り専用で表示します。",
+    "text": "設定済みのプランとそのエンタイトルメント、およびStripeと同期された最新カタログとの差異を読み取り専用で表示します。",
     "source_hash": "05d5b332"
   },
   "web.admin.billing.retry": {
@@ -16,7 +16,7 @@
     "source_hash": "c3110f77"
   },
   "web.admin.billing.localConfigWarning": {
-    "text": "Stripe同期済みプランのキャッシュが空のため、公開プランと差分を評価できません。設定済みカタログ(billing.yaml)のみを表示しています。開発環境やStripeが未設定の場合によく見られます。",
+    "text": "Stripeと同期されたプランのキャッシュが空のため、最新のプランと差異を評価できません。設定済みのカタログ (billing.yaml) のみを表示しています — 開発環境やStripeが未設定の場合によくある状態です。",
     "source_hash": "905d95f8"
   },
   "web.admin.billing.inSync": {
@@ -24,11 +24,11 @@
     "source_hash": "5701958c"
   },
   "web.admin.billing.driftCount": {
-    "text": "{count}件の差分",
+    "text": "{count}件の差異",
     "source_hash": "166538f5"
   },
   "web.admin.billing.inSyncDetail": {
-    "text": "設定済みカタログは公開プランと一致しています。差分は検出されませんでした。",
+    "text": "設定済みのカタログは最新のプランと一致しています。差異は検出されませんでした。",
     "source_hash": "57ab60a6"
   },
   "web.admin.billing.columns.planid": {
@@ -36,7 +36,7 @@
     "source_hash": "1f0d4dc6"
   },
   "web.admin.billing.columns.name": {
-    "text": "名前",
+    "text": "名称",
     "source_hash": "dcd1d522"
   },
   "web.admin.billing.columns.tier": {
@@ -48,19 +48,19 @@
     "source_hash": "920e413c"
   },
   "web.admin.billing.diff.title": {
-    "text": "プラン差分:{planid}",
+    "text": "プランの差分: {planid}",
     "source_hash": "bc86e5f7"
   },
   "web.admin.billing.diff.subtitle": {
-    "text": "設定済みカタログ(billing.yaml)と公開中のStripe同期済みプランを並べて比較します。",
+    "text": "設定済みカタログ (billing.yaml) とStripeと同期された最新プランを並べて比較します。",
     "source_hash": "d92e93ae"
   },
   "web.admin.billing.diff.config": {
-    "text": "設定済み(billing.yaml)",
+    "text": "設定済み (billing.yaml)",
     "source_hash": "6bf2ff04"
   },
   "web.admin.billing.diff.live": {
-    "text": "公開中(Stripeキャッシュ)",
+    "text": "最新 (Stripeキャッシュ)",
     "source_hash": "4886945d"
   },
   "web.admin.billing.diff.absentConfig": {
@@ -68,7 +68,7 @@
     "source_hash": "0b594c88"
   },
   "web.admin.billing.diff.absentLive": {
-    "text": "このプランは公開中のStripe同期済みキャッシュに存在しません。",
+    "text": "このプランはStripeと同期された最新キャッシュに存在しません。",
     "source_hash": "c53f31c3"
   },
   "web.admin.billing.plans.title": {
@@ -76,7 +76,7 @@
     "source_hash": "dfe8b2f0"
   },
   "web.admin.billing.plans.empty": {
-    "text": "カタログにプランが見つかりません。",
+    "text": "カタログにプランが見つかりませんでした。",
     "source_hash": "39db3c13"
   },
   "web.admin.billing.plans.viewDiff": {
@@ -92,11 +92,11 @@
     "source_hash": "49de43d2"
   },
   "web.admin.billing.stats.configured": {
-    "text": "設定済みプラン",
+    "text": "設定済みのプラン",
     "source_hash": "4fda4796"
   },
   "web.admin.billing.stats.live": {
-    "text": "公開中のプラン",
+    "text": "稼働中のプラン",
     "source_hash": "faaa88d9"
   },
   "web.admin.billing.stats.source": {
@@ -104,7 +104,7 @@
     "source_hash": "0e570ca6"
   },
   "web.admin.billing.stats.drift": {
-    "text": "差分",
+    "text": "差異",
     "source_hash": "8b4c8240"
   },
   "web.admin.billing.status.in_sync": {
@@ -116,11 +116,91 @@
     "source_hash": "15836cba"
   },
   "web.admin.billing.status.only_live": {
-    "text": "公開中のみ",
+    "text": "稼働中のみ",
     "source_hash": "8f4ed495"
   },
   "web.admin.billing.status.changed": {
     "text": "変更あり",
     "source_hash": "2a6141e4"
+  },
+  "web.admin.billing.diff.backToCatalog": {
+    "text": "請求カタログに戻る",
+    "source_hash": "8532b373"
+  },
+  "web.admin.billing.diff.driftedFields": {
+    "text": "差異のある項目:",
+    "source_hash": "9890c95b"
+  },
+  "web.admin.billing.diff.notFound": {
+    "text": "プランがカタログにありません",
+    "source_hash": "0253898b"
+  },
+  "web.admin.billing.diff.notFoundDescription": {
+    "text": "ID {planid}のプランは、設定済みカタログにもStripeと同期された最新キャッシュにも見つかりませんでした。",
+    "source_hash": "2e69551c"
+  },
+  "web.admin.billing.stripeOrgs.title": {
+    "text": "Stripeの顧客",
+    "source_hash": "0463ae27"
+  },
+  "web.admin.billing.stripeOrgs.description": {
+    "text": "Stripeの顧客レコードに紐付けられている組織です。",
+    "source_hash": "2ab09aec"
+  },
+  "web.admin.billing.stripeOrgs.searchPlaceholder": {
+    "text": "Stripe顧客IDで検索",
+    "source_hash": "d5acf08f"
+  },
+  "web.admin.billing.stripeOrgs.empty": {
+    "text": "Stripe顧客IDを持つ組織はありません。",
+    "source_hash": "2e373537"
+  },
+  "web.admin.billing.stripeOrgs.emptySearch": {
+    "text": "検索条件に一致するStripe顧客IDはありません。",
+    "source_hash": "75011174"
+  },
+  "web.admin.billing.stripeOrgs.loadError": {
+    "text": "Stripeの顧客一覧を読み込めませんでした。",
+    "source_hash": "15e2d9a7"
+  },
+  "web.admin.billing.stripeOrgs.unavailable": {
+    "text": "このサーバーではStripeの顧客一覧をまだ利用できません。",
+    "source_hash": "aab6451a"
+  },
+  "web.admin.billing.stripeOrgs.none": {
+    "text": "なし",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.billing.stripeOrgs.capped": {
+    "text": "インデックスのスキャンが上限に達したため、合計値は下限値です — 残りを表示するには検索条件を絞り込んでください。",
+    "source_hash": "20bcaa38"
+  },
+  "web.admin.billing.stripeOrgs.stale": {
+    "text": "このページの{count}件のインデックスエントリは、読み込めなくなった組織を参照しているためスキップされました。",
+    "source_hash": "51980f83"
+  },
+  "web.admin.billing.stripeOrgs.copyStripeId": {
+    "text": "Stripe顧客IDをコピー",
+    "source_hash": "a77d18b1"
+  },
+  "web.admin.billing.stripeOrgs.columns.organization": {
+    "text": "組織",
+    "source_hash": "d764d425"
+  },
+  "web.admin.billing.stripeOrgs.columns.owner": {
+    "text": "オーナー",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.billing.stripeOrgs.columns.plan": {
+    "text": "プラン",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.billing.stripeOrgs.columns.subscription": {
+    "text": "サブスクリプション",
+    "source_hash": "4999c6c6"
+  },
+  "web.admin.billing.stripeOrgs.columns.stripeCustomer": {
+    "text": "Stripe顧客ID",
+    "source_hash": "7e1d8bbb"
   }
 }

--- a/locales/content/ja/admin-colonel.json
+++ b/locales/content/ja/admin-colonel.json
@@ -4,7 +4,7 @@
     "source_hash": "74a883a0"
   },
   "web.colonel.configEditorDescription": {
-    "text": "システム設定を編集します。変更は保存後すぐに適用されます。",
+    "text": "システム構成の設定を編集します。変更は保存後すぐに適用されます。",
     "source_hash": "6025d269"
   },
   "web.colonel.invalidJson": {
@@ -12,7 +12,7 @@
     "source_hash": "a75ac7a3"
   },
   "web.colonel.validationError": {
-    "text": "バリデーションエラー",
+    "text": "検証エラー",
     "source_hash": "2aa2d0b4"
   },
   "web.colonel.errorFetchingConfig": {
@@ -24,7 +24,7 @@
     "source_hash": "48df54c7"
   },
   "web.colonel.configSaved": {
-    "text": "設定を正常に保存しました",
+    "text": "設定を保存しました",
     "source_hash": "93b3d3e4"
   },
   "web.colonel.mustBeObject": {
@@ -32,11 +32,11 @@
     "source_hash": "74e8897e"
   },
   "web.colonel.multipleSectionsInvalid": {
-    "text": "複数のセクションにバリデーションエラーがあります: {sections}",
+    "text": "複数のセクションに検証エラーがあります: {sections}",
     "source_hash": "71fdaea1"
   },
   "web.colonel.sectionHasError": {
-    "text": "{section}にバリデーションエラーがあります: {error}",
+    "text": "{section}に検証エラーがあります: {error}",
     "source_hash": "e5e01aa0"
   },
   "web.colonel.sectionSaved": {
@@ -56,15 +56,15 @@
     "source_hash": "a710c2b9"
   },
   "web.colonel.schemaValidationError": {
-    "text": "スキーマバリデーションエラー: {message} ({path})",
+    "text": "スキーマ検証エラー: {message} ({path})",
     "source_hash": "5f838cb2"
   },
   "web.colonel.unknownValidationError": {
-    "text": "不明なバリデーションエラー: {error}",
+    "text": "不明な検証エラー: {error}",
     "source_hash": "b6cf56ca"
   },
   "web.colonel.sectionEffectivelyEmpty": {
-    "text": "{section}セクションに設定値がありません",
+    "text": "{section}セクションには設定された値がありません",
     "source_hash": "efb63b77"
   },
   "web.colonel.dashboard": {
@@ -72,7 +72,7 @@
     "source_hash": "67b69646"
   },
   "web.colonel.admin": {
-    "text": "管理者",
+    "text": "管理",
     "source_hash": "c1c224b0"
   },
   "web.colonel.activity": {
@@ -88,7 +88,7 @@
     "source_hash": "6b0cc904"
   },
   "web.colonel.usersDescription": {
-    "text": "ユーザーアカウントと権限を管理",
+    "text": "ユーザーアカウントと権限を管理します",
     "source_hash": "6cfc012c"
   },
   "web.colonel.domains": {
@@ -112,7 +112,7 @@
     "source_hash": "57c1e752"
   },
   "web.colonel.quickActions": {
-    "text": "クイックアクション",
+    "text": "クイック操作",
     "source_hash": "2cc2b6f7"
   },
   "web.colonel.recentActivity": {
@@ -124,39 +124,39 @@
     "source_hash": "ff5573a6"
   },
   "web.colonel.activityPlaceholder": {
-    "text": "アクティビティデータがここに表示されます",
+    "text": "ここにアクティビティのデータが表示されます",
     "source_hash": "aaf9e948"
   },
   "web.colonel.stats.totalSecrets": {
-    "text": "シークレット総数",
+    "text": "シークレットの合計数",
     "source_hash": "e17a5459"
   },
   "web.colonel.stats.activeUsers": {
-    "text": "アクティブユーザー",
+    "text": "アクティブユーザー数",
     "source_hash": "5639b9f1"
   },
   "web.colonel.stats.secretsToday": {
-    "text": "本日のシークレット",
+    "text": "本日のシークレット数",
     "source_hash": "aefbd2db"
   },
   "web.colonel.stats.secretsCreated": {
-    "text": "作成されたシークレット",
+    "text": "作成されたシークレット数",
     "source_hash": "a97ee479"
   },
   "web.colonel.stats.secretsShared": {
-    "text": "共有されたシークレット",
+    "text": "共有されたシークレット数",
     "source_hash": "5deb082c"
   },
   "web.colonel.stats.totalCustomers": {
-    "text": "総ユーザー数",
+    "text": "ユーザーの合計数",
     "source_hash": "0ca3aa44"
   },
   "web.colonel.stats.emailsSent": {
-    "text": "送信メール数",
+    "text": "送信されたメール数",
     "source_hash": "87cfb3ab"
   },
   "web.colonel.stats.systemHealth": {
-    "text": "システム状態",
+    "text": "システムの健全性",
     "source_hash": "c3d66242"
   },
   "web.colonel.stats.healthy": {
@@ -168,7 +168,7 @@
     "source_hash": "9c28f55c"
   },
   "web.colonel.actions.viewActivityDesc": {
-    "text": "システムアクティビティと使用状況を監視",
+    "text": "システムのアクティビティと利用状況を監視します",
     "source_hash": "f88e9eda"
   },
   "web.colonel.actions.manageAccounts": {
@@ -176,7 +176,7 @@
     "source_hash": "9d114268"
   },
   "web.colonel.actions.manageAccountsDesc": {
-    "text": "ユーザーアカウント管理",
+    "text": "ユーザーアカウントの管理",
     "source_hash": "d73af927"
   },
   "web.colonel.actions.configureDomains": {
@@ -184,7 +184,7 @@
     "source_hash": "74402af9"
   },
   "web.colonel.actions.configureDomainsDesc": {
-    "text": "ドメインとDNS設定",
+    "text": "ドメインとDNSの設定",
     "source_hash": "1f712094"
   },
   "web.colonel.actions.systemSettings": {
@@ -192,7 +192,7 @@
     "source_hash": "1f87f883"
   },
   "web.colonel.actions.systemSettingsDesc": {
-    "text": "アプリケーション設定",
+    "text": "アプリケーションの構成",
     "source_hash": "923dc672"
   },
   "web.colonel.backgroundJobs": {
@@ -200,7 +200,7 @@
     "source_hash": "48937049"
   },
   "web.colonel.queueStatus": {
-    "text": "キューステータス",
+    "text": "キューのステータス",
     "source_hash": "3421ffa8"
   },
   "web.colonel.queueName": {
@@ -216,7 +216,7 @@
     "source_hash": "212b350d"
   },
   "web.colonel.processingRate": {
-    "text": "処理速度/秒",
+    "text": "件/秒",
     "source_hash": "cfde439c"
   },
   "web.colonel.connectionStatus": {
@@ -228,19 +228,19 @@
     "source_hash": "52be3ac1"
   },
   "web.colonel.activeWorkers": {
-    "text": "アクティブワーカー",
+    "text": "稼働中のワーカー",
     "source_hash": "ea68cfee"
   },
   "web.colonel.noQueueData": {
-    "text": "キューデータがありません",
+    "text": "キューのデータがありません",
     "source_hash": "331ffa6b"
   },
   "web.colonel.loadingQueueData": {
-    "text": "キューデータを読み込み中...",
+    "text": "キューのデータを読み込んでいます...",
     "source_hash": "a3762a00"
   },
   "web.colonel.testPlanMode": {
-    "text": "テストプランモード",
+    "text": "プランのテストモード",
     "source_hash": "eba59223"
   },
   "web.colonel.testingAsPlan": {
@@ -256,7 +256,7 @@
     "source_hash": "9e6e12fe"
   },
   "web.colonel.resetToActual": {
-    "text": "実際のプランにリセット",
+    "text": "実際のプランに戻す",
     "source_hash": "2cea3f92"
   },
   "web.colonel.currentActualPlan": {
@@ -268,7 +268,7 @@
     "source_hash": "20efa44d"
   },
   "web.colonel.activateTestMode": {
-    "text": "テストモードを有効化",
+    "text": "テストモードを有効にする",
     "source_hash": "0f469baa"
   },
   "web.colonel.testModeActive": {
@@ -276,11 +276,11 @@
     "source_hash": "ae2c8dd9"
   },
   "web.colonel.testModeDescription": {
-    "text": "異なるプランのエンタイトルメントでアプリケーションをテストします。変更は一時的で、あなたのセッションのみに影響します。",
+    "text": "異なるプランのエンタイトルメントでアプリケーションをテストします。変更は一時的で、ご自身のセッションにのみ影響します。",
     "source_hash": "be03a409"
   },
   "web.colonel.warningTestMode": {
-    "text": "{planName}のエンタイトルメントでテスト中です(一時的なセッションオーバーライド)。",
+    "text": "{planName}のエンタイトルメントでテスト中です (一時的なセッションの上書き設定)。",
     "source_hash": "1a8aecf1"
   },
   "web.colonel.organizations.title": {
@@ -288,11 +288,11 @@
     "source_hash": "2730183d"
   },
   "web.colonel.organizations.description": {
-    "text": "組織の請求同期状態を監視",
+    "text": "組織の請求同期の健全性を監視します",
     "source_hash": "d8f4398b"
   },
   "web.colonel.organizations.pageTitle": {
-    "text": "請求状態モニター",
+    "text": "請求ヘルスモニター",
     "source_hash": "9ef57da4"
   },
   "web.colonel.organizations.organizationsCount": {
@@ -300,15 +300,15 @@
     "source_hash": "bc2feb56"
   },
   "web.colonel.organizations.needAttention": {
-    "text": "{count}件要対応",
+    "text": "要対応 {count}件",
     "source_hash": "1c8e5840"
   },
   "web.colonel.organizations.unknownCount": {
-    "text": "{count}件不明",
+    "text": "不明 {count}件",
     "source_hash": "b7bf2cf1"
   },
   "web.colonel.organizations.noOrganizations": {
-    "text": "組織が見つかりません",
+    "text": "組織が見つかりませんでした",
     "source_hash": "538995db"
   },
   "web.colonel.organizations.filters.syncStatus": {
@@ -344,7 +344,7 @@
     "source_hash": "3792573d"
   },
   "web.colonel.organizations.filters.pastDue": {
-    "text": "期限超過",
+    "text": "支払い期限超過",
     "source_hash": "2bda1c7b"
   },
   "web.colonel.organizations.filters.canceled": {
@@ -364,11 +364,11 @@
     "source_hash": "920e413c"
   },
   "web.colonel.organizations.columns.usage": {
-    "text": "使用量",
+    "text": "使用状況",
     "source_hash": "8d59829c"
   },
   "web.colonel.organizations.columns.created": {
-    "text": "作成日",
+    "text": "作成日時",
     "source_hash": "d70b9e24"
   },
   "web.colonel.organizations.columns.details": {
@@ -396,7 +396,7 @@
     "source_hash": "4999c6c6"
   },
   "web.colonel.organizations.columns.default_workspace": {
-    "text": "デフォルトワークスペース",
+    "text": "既定のワークスペース",
     "source_hash": "53aa279e"
   },
   "web.colonel.organizations.columns.has_billing": {
@@ -404,15 +404,15 @@
     "source_hash": "db0628ed"
   },
   "web.colonel.organizations.legacy.title": {
-    "text": "組織請求管理",
+    "text": "組織の請求管理",
     "source_hash": "5c7e07e7"
   },
   "web.colonel.organizations.legacy.description": {
-    "text": "組織の管理と請求同期状態の監視 (合計{total}件)",
+    "text": "組織を管理し、請求同期の健全性を監視します (合計{total}件)",
     "source_hash": "996b446d"
   },
   "web.colonel.organizations.legacy.empty": {
-    "text": "組織が見つかりません",
+    "text": "組織が見つかりませんでした",
     "source_hash": "538995db"
   },
   "web.colonel.organizations.legacy.potentially_stale": {
@@ -460,19 +460,19 @@
     "source_hash": "2dbc5cc3"
   },
   "web.colonel.organizations.investigation.verifiedSynced": {
-    "text": "同期を確認",
+    "text": "同期を確認済み",
     "source_hash": "d92625c2"
   },
   "web.colonel.organizations.investigation.mismatchFound": {
-    "text": "不一致を検出",
+    "text": "不一致が見つかりました",
     "source_hash": "361d22f3"
   },
   "web.colonel.organizations.investigation.unableToCompare": {
-    "text": "比較不可",
+    "text": "比較できません",
     "source_hash": "64c822ee"
   },
   "web.colonel.organizations.investigation.stripeDetails": {
-    "text": "Stripeサブスクリプション詳細",
+    "text": "Stripeサブスクリプションの詳細",
     "source_hash": "53a7b0ea"
   },
   "web.colonel.organizations.investigation.statusLabel": {
@@ -484,7 +484,7 @@
     "source_hash": "fb9ef894"
   },
   "web.colonel.organizations.investigation.resolvedPlan": {
-    "text": "解決済みプラン",
+    "text": "解決されたプラン",
     "source_hash": "17c5b37a"
   },
   "web.colonel.organizations.investigation.priceId": {
@@ -500,11 +500,11 @@
     "source_hash": "961a6062"
   },
   "web.colonel.organizations.usage.members": {
-    "text": "{count}人のメンバー",
+    "text": "メンバー{count}名",
     "source_hash": "201eb3d9"
   },
   "web.colonel.organizations.usage.domains": {
-    "text": "{count}件のドメイン",
+    "text": "ドメイン{count}件",
     "source_hash": "cf548c8c"
   },
   "web.colonel.secrets.title": {
@@ -512,23 +512,23 @@
     "source_hash": "d8707d41"
   },
   "web.colonel.secrets.description": {
-    "text": "すべてのシークレットを表示・管理",
+    "text": "すべてのシークレットを表示・管理します",
     "source_hash": "48f8052e"
   },
   "web.colonel.bannedIps.title": {
-    "text": "禁止IP",
+    "text": "禁止されたIP",
     "source_hash": "0ece5643"
   },
   "web.colonel.bannedIps.description": {
-    "text": "IP禁止リストを管理",
+    "text": "IPの禁止リストを管理します",
     "source_hash": "dd0d2614"
   },
   "web.colonel.usageExport.title": {
-    "text": "使用量エクスポート",
+    "text": "使用状況のエクスポート",
     "source_hash": "10a0cb94"
   },
   "web.colonel.usageExport.description": {
-    "text": "使用量データと統計をエクスポート",
+    "text": "使用状況のデータと統計をエクスポートします",
     "source_hash": "2fd0a2e2"
   },
   "web.colonel.systemSettings.title": {
@@ -536,7 +536,7 @@
     "source_hash": "6725e7bb"
   },
   "web.colonel.systemSettings.description": {
-    "text": "システム設定、データベース、および構成",
+    "text": "システム設定、データベース、構成",
     "source_hash": "7690b296"
   },
   "web.colonel.customDomains.title": {
@@ -544,7 +544,7 @@
     "source_hash": "6170ab94"
   },
   "web.colonel.customDomains.description": {
-    "text": "カスタムドメインとブランディングを管理",
+    "text": "カスタムドメインとブランディングを管理します",
     "source_hash": "808ee2cb"
   },
   "web.colonel.feedback.send_feedback": {
@@ -580,11 +580,11 @@
     "source_hash": "c683c9a6"
   },
   "web.colonel.titles.bannedIps": {
-    "text": "禁止IP",
+    "text": "禁止されたIP",
     "source_hash": "0ece5643"
   },
   "web.colonel.titles.usage": {
-    "text": "使用量エクスポート",
+    "text": "使用状況のエクスポート",
     "source_hash": "10a0cb94"
   },
   "web.colonel.titles.info": {
@@ -600,23 +600,23 @@
     "source_hash": "a7f64157"
   },
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
-    "text": "フィードバックを送信すると、以下の情報が送信されます:",
+    "text": "フィードバックを送信すると、当社では次の情報を確認します:",
     "source_hash": "fe77172e"
   },
   "web.colonel.previewPlanMode": {
-    "text": "プランプレビューモード",
+    "text": "プランのプレビューモード",
     "source_hash": "cf53f19d"
   },
   "web.colonel.previewModeDescription": {
-    "text": "別のプランの顧客に表示されるアプリケーションをプレビューします。これはあなたの表示にのみ影響し、組織の実際のプランは変更されません。",
+    "text": "別のプランを利用している顧客に表示される画面をプレビューします。これは表示にのみ影響し、組織の実際のプランは変更されません。",
     "source_hash": "6fe23f23"
   },
   "web.colonel.previewModeActive": {
-    "text": "プレビュー有効",
+    "text": "プレビュー中",
     "source_hash": "a558d603"
   },
   "web.colonel.bannedIps.empty": {
-    "text": "禁止されたIPはありません",
+    "text": "禁止されているIPはありません",
     "source_hash": "bd101143"
   },
   "web.colonel.bannedIps.currentIp": {
@@ -624,7 +624,7 @@
     "source_hash": "72f9fefe"
   },
   "web.colonel.bannedIps.confirmUnban": {
-    "text": "{ip}の禁止を解除しますか？",
+    "text": "{ip}の禁止を解除しますか?",
     "source_hash": "ff009b1c"
   },
   "web.colonel.bannedIps.actions.ban": {
@@ -656,7 +656,7 @@
     "source_hash": "dfbd120e"
   },
   "web.colonel.bannedIps.columns.bannedBy": {
-    "text": "禁止者",
+    "text": "実行者",
     "source_hash": "9f47db0e"
   },
   "web.colonel.bannedIps.error.banFailed": {
@@ -680,19 +680,19 @@
     "source_hash": "f81ab834"
   },
   "web.colonel.bannedIps.form.reasonPlaceholder": {
-    "text": "理由（任意）",
+    "text": "理由 (任意)",
     "source_hash": "956688a5"
   },
   "web.colonel.bannedIps.success.banned": {
-    "text": "IPアドレス {ip} を禁止しました",
+    "text": "IPアドレス{ip}を禁止しました",
     "source_hash": "b6f861d5"
   },
   "web.colonel.bannedIps.success.unbanned": {
-    "text": "IPアドレス {ip} の禁止を解除しました",
+    "text": "IPアドレス{ip}の禁止を解除しました",
     "source_hash": "dbe93550"
   },
   "web.colonel.customDomains.empty": {
-    "text": "カスタムドメインが設定されていません",
+    "text": "設定されているカスタムドメインはありません",
     "source_hash": "e10b39f7"
   },
   "web.colonel.customDomains.noLogo": {
@@ -708,11 +708,11 @@
     "source_hash": "69da56ba"
   },
   "web.colonel.customDomains.labels.created": {
-    "text": "作成日",
+    "text": "作成日時",
     "source_hash": "d70b9e24"
   },
   "web.colonel.customDomains.labels.updated": {
-    "text": "更新日",
+    "text": "更新日時",
     "source_hash": "3a5ecca1"
   },
   "web.colonel.customDomains.labels.favicon": {
@@ -724,7 +724,7 @@
     "source_hash": "4f783840"
   },
   "web.colonel.customDomains.status.resolving": {
-    "text": "解決中",
+    "text": "名前解決中",
     "source_hash": "3287a034"
   },
   "web.colonel.customDomains.status.ready": {
@@ -744,7 +744,7 @@
     "source_hash": "331551b0"
   },
   "web.colonel.pagination.showing": {
-    "text": "{total}件中 {start}–{end}件を表示",
+    "text": "{total}件中{start}〜{end}件を表示",
     "source_hash": "64af6de2"
   },
   "web.colonel.pagination.itemsPerPage": {
@@ -760,7 +760,7 @@
     "source_hash": "f0df6412"
   },
   "web.colonel.secrets.empty": {
-    "text": "シークレットが見つかりません",
+    "text": "シークレットが見つかりませんでした",
     "source_hash": "28647b3b"
   },
   "web.colonel.secrets.never": {
@@ -776,7 +776,7 @@
     "source_hash": "a3b50c47"
   },
   "web.colonel.secrets.columns.created": {
-    "text": "作成日",
+    "text": "作成日時",
     "source_hash": "d70b9e24"
   },
   "web.colonel.secrets.columns.expiration": {
@@ -784,7 +784,7 @@
     "source_hash": "f38d6e0e"
   },
   "web.colonel.secrets.columns.age": {
-    "text": "経過日数（日）",
+    "text": "経過日数",
     "source_hash": "52ae64c6"
   },
   "web.colonel.secrets.state.new": {
@@ -812,7 +812,7 @@
     "source_hash": "920e413c"
   },
   "web.colonel.customDomains.labels.actions": {
-    "text": "アクション",
+    "text": "操作",
     "source_hash": "ff8059dc"
   },
   "web.colonel.nav.consoleTag": {
@@ -838,5 +838,37 @@
   "web.colonel.nav.groups.communications": {
     "text": "コミュニケーション",
     "source_hash": "919a9253"
+  },
+  "web.colonel.organizations.sameAsContact": {
+    "text": "連絡先と同じ",
+    "source_hash": "ed18ff43"
+  },
+  "web.colonel.organizations.refresh": {
+    "text": "更新",
+    "source_hash": "0e916101"
+  },
+  "web.colonel.organizations.updatedAgo": {
+    "text": "{ago}に更新",
+    "source_hash": "cda30b9c"
+  },
+  "web.colonel.organizations.columns.name": {
+    "text": "名称",
+    "source_hash": "dcd1d522"
+  },
+  "web.colonel.organizations.columns.contactEmail": {
+    "text": "連絡先メールアドレス",
+    "source_hash": "6d7fce11"
+  },
+  "web.colonel.organizations.columns.billingEmail": {
+    "text": "請求先メールアドレス",
+    "source_hash": "8805b928"
+  },
+  "web.colonel.organizations.columns.planSubscription": {
+    "text": "プランとサブスクリプション",
+    "source_hash": "b396caac"
+  },
+  "web.colonel.organizations.filters.searchPlaceholder": {
+    "text": "ID、名称、またはメールアドレスで検索",
+    "source_hash": "6fe16473"
   }
 }

--- a/locales/content/ja/admin-customers.json
+++ b/locales/content/ja/admin-customers.json
@@ -4,8 +4,8 @@
     "source_hash": "aabe76f1"
   },
   "web.admin.customers.description": {
-    "text": "SSHを使わずに顧客を検索し、サポート問題を解決します。",
-    "source_hash": "c8487e68"
+    "text": "顧客を検索し、サポートの問題を解決します。",
+    "source_hash": "00961ea3"
   },
   "web.admin.customers.actions.plan.label": {
     "text": "プラン",
@@ -20,7 +20,7 @@
     "source_hash": "910a4de9"
   },
   "web.admin.customers.actions.plan.confirmDescription": {
-    "text": "{email}を{plan}プランに変更します。",
+    "text": "{email}のプランを{plan}に変更します。",
     "source_hash": "83fb4158"
   },
   "web.admin.customers.actions.plan.success": {
@@ -28,23 +28,23 @@
     "source_hash": "ebe8d40c"
   },
   "web.admin.customers.actions.plan.localConfigWarning": {
-    "text": "プランはローカル設定から読み込まれました。Stripeが未設定か、到達できません。",
+    "text": "プランはローカル設定から読み込まれました — Stripeが未設定か、接続できません。",
     "source_hash": "df83e326"
   },
   "web.admin.customers.actions.purge.button": {
-    "text": "顧客を完全削除",
+    "text": "顧客を完全に削除",
     "source_hash": "ff658f69"
   },
   "web.admin.customers.actions.purge.confirmTitle": {
-    "text": "顧客を完全削除しますか?",
+    "text": "顧客を完全に削除しますか?",
     "source_hash": "9feed9f1"
   },
   "web.admin.customers.actions.purge.confirmDescription": {
-    "text": "これにより、{email}とそのすべてのデータが完全に削除されます。この操作は元に戻せません。",
+    "text": "{email}とそのすべてのデータを完全に削除します。この操作は元に戻せません。",
     "source_hash": "a74dd5d1"
   },
   "web.admin.customers.actions.purge.success": {
-    "text": "顧客を完全削除しました。",
+    "text": "顧客を完全に削除しました。",
     "source_hash": "6145e5c8"
   },
   "web.admin.customers.actions.role.label": {
@@ -60,7 +60,7 @@
     "source_hash": "227f57d7"
   },
   "web.admin.customers.actions.role.confirmDescription": {
-    "text": "{email}を{role}ロールに変更します。",
+    "text": "{email}のロールを{role}に変更します。",
     "source_hash": "9ba063c6"
   },
   "web.admin.customers.actions.role.success": {
@@ -72,11 +72,11 @@
     "source_hash": "95a04f27"
   },
   "web.admin.customers.actions.suspend.reasonLabel": {
-    "text": "理由(任意)",
+    "text": "理由 (任意)",
     "source_hash": "0f7d4664"
   },
   "web.admin.customers.actions.suspend.reasonPlaceholder": {
-    "text": "このアカウントを停止する理由は?",
+    "text": "このアカウントを停止する理由は何ですか?",
     "source_hash": "8eca975e"
   },
   "web.admin.customers.actions.suspend.confirmTitle": {
@@ -84,7 +84,7 @@
     "source_hash": "cbfa275b"
   },
   "web.admin.customers.actions.suspend.confirmDescription": {
-    "text": "{email}のログインをブロックし、アクティブなセッションを取り消します。データは削除されません。この操作は元に戻せます。",
+    "text": "{email}のログインをブロックし、有効なセッションを無効化します。データは削除されません — この操作は元に戻せます。",
     "source_hash": "e5d046bc"
   },
   "web.admin.customers.actions.suspend.success": {
@@ -100,7 +100,7 @@
     "source_hash": "6fd78a72"
   },
   "web.admin.customers.actions.unsuspend.confirmDescription": {
-    "text": "{email}のログインを復元します。",
+    "text": "{email}のログインを再び有効にします。",
     "source_hash": "cb2bb4e0"
   },
   "web.admin.customers.actions.unsuspend.success": {
@@ -108,39 +108,39 @@
     "source_hash": "c5b4377f"
   },
   "web.admin.customers.actions.unverify.button": {
-    "text": "検証を解除",
+    "text": "未認証にする",
     "source_hash": "b0dee41f"
   },
   "web.admin.customers.actions.unverify.confirmTitle": {
-    "text": "顧客の検証を解除しますか?",
+    "text": "顧客を未認証にしますか?",
     "source_hash": "62ed2854"
   },
   "web.admin.customers.actions.unverify.confirmDescription": {
-    "text": "{email}を未検証としてマークします。",
+    "text": "{email}を未認証としてマークします。",
     "source_hash": "592ffd27"
   },
   "web.admin.customers.actions.unverify.success": {
-    "text": "顧客の検証を解除しました。",
+    "text": "顧客を未認証にしました。",
     "source_hash": "a9b7bbac"
   },
   "web.admin.customers.actions.verify.button": {
-    "text": "検証",
+    "text": "認証する",
     "source_hash": "eea2745e"
   },
   "web.admin.customers.actions.verify.confirmTitle": {
-    "text": "顧客を検証しますか?",
+    "text": "顧客を認証しますか?",
     "source_hash": "43037ce1"
   },
   "web.admin.customers.actions.verify.confirmDescription": {
-    "text": "{email}を検証済みとしてマークします。",
+    "text": "{email}を認証済みとしてマークします。",
     "source_hash": "7052d79d"
   },
   "web.admin.customers.actions.verify.success": {
-    "text": "顧客を検証しました。",
+    "text": "顧客を認証しました。",
     "source_hash": "19e382dc"
   },
   "web.admin.customers.columns.email": {
-    "text": "メール",
+    "text": "メールアドレス",
     "source_hash": "969ccbd3"
   },
   "web.admin.customers.columns.role": {
@@ -148,7 +148,7 @@
     "source_hash": "14736a2e"
   },
   "web.admin.customers.columns.verified": {
-    "text": "検証済み",
+    "text": "認証済み",
     "source_hash": "4f783840"
   },
   "web.admin.customers.columns.plan": {
@@ -160,7 +160,7 @@
     "source_hash": "d8707d41"
   },
   "web.admin.customers.columns.created": {
-    "text": "作成日",
+    "text": "作成日時",
     "source_hash": "d70b9e24"
   },
   "web.admin.customers.columns.lastLogin": {
@@ -168,7 +168,7 @@
     "source_hash": "0d39602d"
   },
   "web.admin.customers.detail.backToList": {
-    "text": "顧客に戻る",
+    "text": "顧客一覧に戻る",
     "source_hash": "077807fb"
   },
   "web.admin.customers.detail.openFullPage": {
@@ -180,7 +180,7 @@
     "source_hash": "5e3f5824"
   },
   "web.admin.customers.detail.notFoundDescription": {
-    "text": "この識別子に一致する顧客はいません。完全削除された可能性があります。",
+    "text": "この識別子に一致する顧客はありません。完全に削除された可能性があります。",
     "source_hash": "82b04725"
   },
   "web.admin.customers.detail.loadError": {
@@ -212,7 +212,7 @@
     "source_hash": "fa8ed0bd"
   },
   "web.admin.customers.detail.billing.organization": {
-    "text": "請求組織",
+    "text": "請求先の組織",
     "source_hash": "90c94ee1"
   },
   "web.admin.customers.detail.billing.subscriptionStatus": {
@@ -236,7 +236,7 @@
     "source_hash": "dfa7c41d"
   },
   "web.admin.customers.detail.billing.unavailable": {
-    "text": "Stripeのデータを利用できません:{reason}",
+    "text": "Stripeのデータを利用できません: {reason}",
     "source_hash": "9fe08e49"
   },
   "web.admin.customers.detail.billing.notConfigured": {
@@ -244,7 +244,7 @@
     "source_hash": "6e90375e"
   },
   "web.admin.customers.detail.fields.email": {
-    "text": "メール",
+    "text": "メールアドレス",
     "source_hash": "969ccbd3"
   },
   "web.admin.customers.detail.fields.publicId": {
@@ -256,7 +256,7 @@
     "source_hash": "14736a2e"
   },
   "web.admin.customers.detail.fields.verified": {
-    "text": "検証済み",
+    "text": "認証済み",
     "source_hash": "4f783840"
   },
   "web.admin.customers.detail.fields.plan": {
@@ -268,11 +268,11 @@
     "source_hash": "ca3dc612"
   },
   "web.admin.customers.detail.fields.created": {
-    "text": "作成日",
+    "text": "作成日時",
     "source_hash": "d70b9e24"
   },
   "web.admin.customers.detail.fields.updated": {
-    "text": "更新日",
+    "text": "更新日時",
     "source_hash": "3a5ecca1"
   },
   "web.admin.customers.detail.fields.lastLogin": {
@@ -288,7 +288,7 @@
     "source_hash": "e0830524"
   },
   "web.admin.customers.detail.fields.suspendedReason": {
-    "text": "停止理由",
+    "text": "停止の理由",
     "source_hash": "d6b08d8e"
   },
   "web.admin.customers.detail.organizations.empty": {
@@ -296,7 +296,7 @@
     "source_hash": "c256efdc"
   },
   "web.admin.customers.detail.organizations.default": {
-    "text": "デフォルト",
+    "text": "既定",
     "source_hash": "21b111cb"
   },
   "web.admin.customers.detail.receiptColumns.shortId": {
@@ -308,7 +308,7 @@
     "source_hash": "a3b50c47"
   },
   "web.admin.customers.detail.receiptColumns.created": {
-    "text": "作成日",
+    "text": "作成日時",
     "source_hash": "d70b9e24"
   },
   "web.admin.customers.detail.receipts.empty": {
@@ -324,7 +324,7 @@
     "source_hash": "a3b50c47"
   },
   "web.admin.customers.detail.secretColumns.created": {
-    "text": "作成日",
+    "text": "作成日時",
     "source_hash": "d70b9e24"
   },
   "web.admin.customers.detail.secretColumns.expiration": {
@@ -352,7 +352,7 @@
     "source_hash": "2730183d"
   },
   "web.admin.customers.detail.sections.actions": {
-    "text": "アクション",
+    "text": "操作",
     "source_hash": "ff8059dc"
   },
   "web.admin.customers.detail.sections.billing": {
@@ -392,55 +392,55 @@
     "source_hash": "bc4ea262"
   },
   "web.admin.customers.detail.sessions.columns.actions": {
-    "text": "アクション",
+    "text": "操作",
     "source_hash": "ff8059dc"
   },
   "web.admin.customers.detail.sessions.revoke.button": {
-    "text": "取り消し",
+    "text": "無効化",
     "source_hash": "87e6d00b"
   },
   "web.admin.customers.detail.sessions.revoke.confirmTitle": {
-    "text": "セッションを取り消しますか?",
+    "text": "セッションを無効化しますか?",
     "source_hash": "7735d1ef"
   },
   "web.admin.customers.detail.sessions.revoke.confirmDescription": {
-    "text": "これにより、このセッションからユーザーが直ちにログアウトされます。ユーザーは再度ログインする必要があります。",
+    "text": "このセッションからユーザーを直ちにログアウトさせます。ユーザーは再度ログインする必要があります。",
     "source_hash": "b4291af0"
   },
   "web.admin.customers.detail.sessions.revoke.success": {
-    "text": "セッションを取り消しました。",
+    "text": "セッションを無効化しました。",
     "source_hash": "5e4762e5"
   },
   "web.admin.customers.detail.sessions.revokeAll.button": {
-    "text": "すべて取り消し",
+    "text": "すべて無効化",
     "source_hash": "c6847a4b"
   },
   "web.admin.customers.detail.sessions.revokeAll.confirmTitle": {
-    "text": "すべてのセッションを取り消しますか?",
+    "text": "すべてのセッションを無効化しますか?",
     "source_hash": "a4fa4c65"
   },
   "web.admin.customers.detail.sessions.revokeAll.confirmDescription": {
-    "text": "これにより、このリストに表示されていないセッションを含むすべてのデバイスとブラウザからユーザーがログアウトされ、認証されたルートへのアクセスが直ちにロックされます。オフボーディングやアカウント乗っ取りの疑いがある場合に使用してください。確認のためにユーザーのIDを入力してください。",
+    "text": "この一覧に表示されていないセッションを含め、すべてのデバイスとブラウザーからユーザーをログアウトさせ、認証が必要なルートへのアクセスを直ちに遮断します。退職手続きやアカウント乗っ取りが疑われる場合にご利用ください。確認のためユーザーのIDを入力してください。",
     "source_hash": "483cdd88"
   },
   "web.admin.customers.detail.sessions.revokeAll.success": {
-    "text": "すべてのセッションを取り消しました({count}件を終了)。",
+    "text": "すべてのセッションを無効化しました ({count}件を終了)。",
     "source_hash": "4e1cce55"
   },
   "web.admin.customers.detail.sessions.revokeAll.capped": {
-    "text": "{count}件のセッションを終了しましたが、追跡されていないセッションのスイープが途中で打ち切られました。古いセッションが残っている可能性があります。確実にするには再実行してください。",
+    "text": "{count}件のセッションを終了しましたが、追跡されていないセッションの掃引が途中で打ち切られました — 古いセッションが残っている可能性があります。念のため再実行してください。",
     "source_hash": "e3d295a6"
   },
   "web.admin.customers.detail.stats.secretsCreated": {
-    "text": "作成されたシークレット",
+    "text": "作成されたシークレット数",
     "source_hash": "7d17719e"
   },
   "web.admin.customers.detail.stats.secretsShared": {
-    "text": "共有されたシークレット",
+    "text": "共有されたシークレット数",
     "source_hash": "ba85b265"
   },
   "web.admin.customers.detail.stats.emailsSent": {
-    "text": "送信されたメール",
+    "text": "送信されたメール数",
     "source_hash": "be604792"
   },
   "web.admin.customers.list.roleFilter": {
@@ -448,7 +448,7 @@
     "source_hash": "14736a2e"
   },
   "web.admin.customers.list.empty": {
-    "text": "顧客が見つかりません",
+    "text": "顧客が見つかりませんでした",
     "source_hash": "dc754ec0"
   },
   "web.admin.customers.list.loadError": {
@@ -456,11 +456,11 @@
     "source_hash": "81783303"
   },
   "web.admin.customers.list.searchPlaceholder": {
-    "text": "メール、extid、またはobjidで検索",
+    "text": "メールアドレス、extid、またはobjidで検索",
     "source_hash": "c06d5a3b"
   },
   "web.admin.customers.list.emptySearch": {
-    "text": "この検索に一致する顧客はいません",
+    "text": "検索条件に一致する顧客はありません",
     "source_hash": "ea7e7012"
   },
   "web.admin.customers.roles.colonel": {
@@ -482,5 +482,213 @@
   "web.admin.customers.suspended.badge": {
     "text": "停止中",
     "source_hash": "e392a389"
+  },
+  "web.admin.customers.actions.checkoutLink.button": {
+    "text": "チェックアウトリンクを作成",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.modalTitle": {
+    "text": "チェックアウトリンクを作成",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.planLabel": {
+    "text": "プラン",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.actions.checkoutLink.planPlaceholder": {
+    "text": "プランファミリーID (例: identity_plus_v1)",
+    "source_hash": "12eba027"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleLabel": {
+    "text": "請求サイクル",
+    "source_hash": "d69f731e"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleMonthly": {
+    "text": "月額",
+    "source_hash": "9b11f6b7"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleYearly": {
+    "text": "年額",
+    "source_hash": "6e69b59e"
+  },
+  "web.admin.customers.actions.checkoutLink.allowPromo": {
+    "text": "プロモーションコードを許可する",
+    "source_hash": "ebe7bc8b"
+  },
+  "web.admin.customers.actions.checkoutLink.submit": {
+    "text": "リンクを作成",
+    "source_hash": "e6b850cf"
+  },
+  "web.admin.customers.actions.checkoutLink.resultLead": {
+    "text": "チェックアウトリンクを作成しました。顧客に共有してください — 一度だけ使用でき、期限があります。",
+    "source_hash": "6ff1fb0e"
+  },
+  "web.admin.customers.actions.checkoutLink.copy": {
+    "text": "チェックアウトリンクをコピー",
+    "source_hash": "f1e51ca7"
+  },
+  "web.admin.customers.actions.checkoutLink.expiry": {
+    "text": "約{hours}時間後に期限切れになります ({date})。",
+    "source_hash": "4c878a15"
+  },
+  "web.admin.customers.actions.checkoutLink.regionLabel": {
+    "text": "リージョン",
+    "source_hash": "d3a008ef"
+  },
+  "web.admin.customers.actions.checkoutLink.parseError": {
+    "text": "サーバーはリクエストを受け付けましたが、応答を解釈できなかったためリンクを表示できません。再試行する前にStripeをご確認ください。",
+    "source_hash": "e7e08290"
+  },
+  "web.admin.customers.actions.checkoutLink.done": {
+    "text": "完了",
+    "source_hash": "11a6767d"
+  },
+  "web.admin.customers.actions.purge.typePrompt": {
+    "text": "確認のため、下にアカウントのメールアドレス{token}を入力してください",
+    "source_hash": "8b2a1819"
+  },
+  "web.admin.customers.actions.purge.unavailable": {
+    "text": "完全削除は利用できません: このアカウントには確認用に入力するメールアドレスがありません。",
+    "source_hash": "5f20f7e5"
+  },
+  "web.admin.customers.columns.actions": {
+    "text": "操作",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.diagnostics.title": {
+    "text": "アカウント診断",
+    "source_hash": "5574ece8"
+  },
+  "web.admin.customers.detail.diagnostics.loading": {
+    "text": "診断を実行しています…",
+    "source_hash": "062c83d5"
+  },
+  "web.admin.customers.detail.diagnostics.loadError": {
+    "text": "診断を読み込めません。",
+    "source_hash": "69e69f49"
+  },
+  "web.admin.customers.detail.diagnostics.healthy": {
+    "text": "ブロック要因は見つかりませんでした。認証の状態は正常です — クライアント側の問題 (Cookie、カスタムドメインのログイン設定) やリージョンの誤りが疑われます。",
+    "source_hash": "f6d5f8d1"
+  },
+  "web.admin.customers.detail.diagnostics.authUnavailable": {
+    "text": "認証データベースを利用できません (シンプル認証モード) — SQL側のチェックはスキップされました。",
+    "source_hash": "d668907c"
+  },
+  "web.admin.customers.detail.diagnostics.authFailed": {
+    "text": "認証データベースから応答がなかったため、SQL側のチェックを実行できませんでした: {reason}",
+    "source_hash": "46d047c0"
+  },
+  "web.admin.customers.detail.diagnostics.unknown": {
+    "text": "不明",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.title": {
+    "text": "認証ログ",
+    "source_hash": "48ad8ba8"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.empty": {
+    "text": "記録された認証イベントはありません。",
+    "source_hash": "d2332558"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.unavailable": {
+    "text": "認証ログを読み取れませんでした: {reason}",
+    "source_hash": "ab18af57"
+  },
+  "web.admin.customers.detail.diagnostics.facts.authStatus": {
+    "text": "認証ステータス",
+    "source_hash": "34def169"
+  },
+  "web.admin.customers.detail.diagnostics.facts.noAccount": {
+    "text": "認証アカウントなし",
+    "source_hash": "a9968e9e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.password": {
+    "text": "パスワード",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordSet": {
+    "text": "設定済み",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordNone": {
+    "text": "なし",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfa": {
+    "text": "多要素認証",
+    "source_hash": "d39ce053"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfaNone": {
+    "text": "なし",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.loginFailures": {
+    "text": "失敗した試行回数",
+    "source_hash": "63e7f0a8"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lockedBadge": {
+    "text": "ロックアウト中",
+    "source_hash": "ace29f74"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiter": {
+    "text": "レートリミッター",
+    "source_hash": "32892404"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterEngaged": {
+    "text": "作動中",
+    "source_hash": "1b0d851e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterClear": {
+    "text": "解除済み",
+    "source_hash": "83b12c22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verification": {
+    "text": "確認メール",
+    "source_hash": "23fac8fb"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationPending": {
+    "text": "保留中 — 最終送信 {date}",
+    "source_hash": "9ab8d1b6"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationNone": {
+    "text": "保留中のものはありません",
+    "source_hash": "a4d4cc22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.sessions": {
+    "text": "アクティブなセッション",
+    "source_hash": "61ad9909"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lastLogin": {
+    "text": "最終ログイン (認証)",
+    "source_hash": "373e7fb1"
+  },
+  "web.admin.customers.detail.receipts.partial": {
+    "text": "一部のみの一覧です — 最新の{count}件を表示しています。この顧客には表示件数より多くの受信確認があります。",
+    "source_hash": "127fd4db"
+  },
+  "web.admin.customers.detail.secrets.partial": {
+    "text": "一部のみの一覧です — 最新の{count}件を表示しています。この顧客は表示件数より多くのシークレットを所有しています。",
+    "source_hash": "a537c8f3"
+  },
+  "web.admin.customers.detail.sessions.columns.country": {
+    "text": "国",
+    "source_hash": "701d021d"
+  },
+  "web.admin.customers.detail.sessions.current.badge": {
+    "text": "このセッション",
+    "source_hash": "6da6530a"
+  },
+  "web.admin.customers.detail.sessions.current.tooltip": {
+    "text": "現在の管理セッションです。ここで無効化しても効果はありません — このリクエストの残りの処理のために再作成されます。",
+    "source_hash": "ef097ab1"
+  },
+  "web.admin.customers.verification.verified": {
+    "text": "認証済み",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.verification.unverified": {
+    "text": "未認証",
+    "source_hash": "15133907"
   }
 }

--- a/locales/content/ja/admin-domains.json
+++ b/locales/content/ja/admin-domains.json
@@ -36,11 +36,11 @@
     "source_hash": "2263ec6a"
   },
   "web.admin.domains.addDomain.strategy.approximated": {
-    "text": "Approximated — DNS所有権チェック、プロキシなし。",
+    "text": "Approximated — DNSによる所有権の確認のみで、プロキシは行いません。",
     "source_hash": "79a7245c"
   },
   "web.admin.domains.addDomain.strategy.passthrough": {
-    "text": "Passthrough — DNSをこのデプロイのプロキシに向けます。",
+    "text": "Passthrough — このデプロイのプロキシにDNSを向けます。",
     "source_hash": "9702d758"
   },
   "web.admin.domains.addDomain.strategy.external": {
@@ -48,23 +48,23 @@
     "source_hash": "acaede35"
   },
   "web.admin.domains.addDomain.strategy.caddy_on_demand": {
-    "text": "Caddyオンデマンド — 初回リクエスト時に証明書が自動的に発行されます。",
+    "text": "Caddy on-demand — 最初のリクエスト時に証明書が自動発行されます。",
     "source_hash": "deb90ae6"
   },
   "web.admin.domains.addDomain.strategy.caddy": {
-    "text": "Caddy — 初回リクエスト時に証明書が自動的に発行されます。",
+    "text": "Caddy — 最初のリクエスト時に証明書が自動発行されます。",
     "source_hash": "a0f3c2dc"
   },
   "web.admin.domains.addDomain.strategy.unknown": {
-    "text": "デプロイ全体の検証方法。",
+    "text": "デプロイ全体の検証方法です。",
     "source_hash": "4587f9cf"
   },
   "web.admin.domains.attach.cta": {
-    "text": "ドメインを組織に紐付け",
+    "text": "ドメインを組織に紐付ける",
     "source_hash": "736d74ce"
   },
   "web.admin.domains.attach.recordEyebrow": {
-    "text": "作業レコード",
+    "text": "作業中のレコード",
     "source_hash": "2fadf983"
   },
   "web.admin.domains.attach.rosterError": {
@@ -84,11 +84,11 @@
     "source_hash": "e4efbe2b"
   },
   "web.admin.domains.dns.txtStep": {
-    "text": "1. 所有権を証明するためにTXTレコードを追加します。",
+    "text": "1. 所有権を証明するTXTレコードを追加します。",
     "source_hash": "fdcfcfb0"
   },
   "web.admin.domains.dns.aStep": {
-    "text": "2. apexをプロキシに向けるAレコードを追加します。",
+    "text": "2. Apexドメインをプロキシに向けるAレコードを追加します。",
     "source_hash": "aedbf197"
   },
   "web.admin.domains.dns.cnameStep": {
@@ -96,7 +96,7 @@
     "source_hash": "5c626f53"
   },
   "web.admin.domains.dns.propagationNote": {
-    "text": "DNSの変更が反映され、検証が成功するまでに数分かかる場合があります。",
+    "text": "DNSの変更が反映され検証が成功するまでに、数分かかる場合があります。",
     "source_hash": "7caf70a7"
   },
   "web.admin.domains.dns.toggle": {
@@ -120,11 +120,11 @@
     "source_hash": "d764d425"
   },
   "web.admin.domains.orgPicker.searchPlaceholder": {
-    "text": "オブジェクトID、外部ID、またはメール",
+    "text": "オブジェクトID、外部ID、またはメールアドレス",
     "source_hash": "bb5d0055"
   },
   "web.admin.domains.orgPicker.searchHint": {
-    "text": "objid、extid、またはメンバーのメールアドレスで検索します。",
+    "text": "objid、extid、またはメンバーのメールアドレスで検索できます。",
     "source_hash": "fdef7332"
   },
   "web.admin.domains.orgPicker.loadError": {
@@ -132,7 +132,7 @@
     "source_hash": "b9e45dcf"
   },
   "web.admin.domains.orgPicker.parseError": {
-    "text": "組織の結果を読み取れませんでした。",
+    "text": "組織の検索結果を読み取れませんでした。",
     "source_hash": "44e1b9fd"
   },
   "web.admin.domains.orgPicker.idle": {
@@ -144,11 +144,11 @@
     "source_hash": "761db594"
   },
   "web.admin.domains.orgPicker.unnamedOrg": {
-    "text": "名前のない組織",
+    "text": "名称未設定の組織",
     "source_hash": "f218dc9d"
   },
   "web.admin.domains.orgPicker.domainCount": {
-    "text": "{count}件のドメイン",
+    "text": "ドメイン{count}件",
     "source_hash": "cf548c8c"
   },
   "web.admin.domains.orgPicker.select": {
@@ -164,7 +164,7 @@
     "source_hash": "07c4dc4f"
   },
   "web.admin.domains.verify.confirmDescription": {
-    "text": "{domain}のDNSおよびSSL検証チェックを実行します。",
+    "text": "{domain}のDNSおよびSSLの検証チェックを実行します。",
     "source_hash": "06797824"
   },
   "web.admin.domains.verify.failed": {
@@ -172,15 +172,15 @@
     "source_hash": "3c8432b0"
   },
   "web.admin.domains.verify.success.verified": {
-    "text": "{domain}は検証されました。",
+    "text": "{domain}は検証済みです。",
     "source_hash": "802b5d1e"
   },
   "web.admin.domains.verify.success.resolving": {
-    "text": "{domain}は名前解決されていますが、まだ検証されていません。",
+    "text": "{domain}は名前解決中ですが、まだ検証されていません。",
     "source_hash": "bc8aecad"
   },
   "web.admin.domains.verify.success.pending": {
-    "text": "{domain}は保留中です。DNSがまだ名前解決されていません。",
+    "text": "{domain}は保留中です — DNSがまだ名前解決されていません。",
     "source_hash": "0d9f66d5"
   },
   "web.admin.domains.verify.success.unverified": {
@@ -190,5 +190,657 @@
   "web.admin.domains.verify.success.done": {
     "text": "{domain}の検証が完了しました。",
     "source_hash": "ed67e22d"
+  },
+  "web.admin.domains.actions.preview": {
+    "text": "プレビュー",
+    "source_hash": "324b134f"
+  },
+  "web.admin.domains.actions.probe.button": {
+    "text": "検査",
+    "source_hash": "3bd51ab9"
+  },
+  "web.admin.domains.actions.remove.button": {
+    "text": "ドメインを削除",
+    "source_hash": "5ce43507"
+  },
+  "web.admin.domains.actions.remove.previewButton": {
+    "text": "削除をプレビュー",
+    "source_hash": "6b81bd92"
+  },
+  "web.admin.domains.actions.remove.previewStatus": {
+    "text": "ステータス:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.remove.previewOrg": {
+    "text": "組織:",
+    "source_hash": "5300e286"
+  },
+  "web.admin.domains.actions.remove.reassertsSurvivor": {
+    "text": "別のレコードが同じドメイン名を要求しており、ルックアップインデックスを引き継ぎます。",
+    "source_hash": "902838f4"
+  },
+  "web.admin.domains.actions.remove.confirmTitle": {
+    "text": "ドメインを削除しますか?",
+    "source_hash": "716dfac9"
+  },
+  "web.admin.domains.actions.remove.confirmDescription": {
+    "text": "{domain}とそのブランディング、DNS、構成の各レコードを完全に削除します。この操作は元に戻せません。続行するにはドメインの公開IDを入力してください。",
+    "source_hash": "d0b67b47"
+  },
+  "web.admin.domains.actions.remove.success": {
+    "text": "ドメインを削除しました。",
+    "source_hash": "2ccaa6d3"
+  },
+  "web.admin.domains.actions.remove.notApplied": {
+    "text": "サーバーは削除を適用せずにプレビューしました — ドメインは削除されていません。再試行し、解消しない場合はご報告ください。",
+    "source_hash": "dc6d70ae"
+  },
+  "web.admin.domains.actions.repair.title": {
+    "text": "組織との紐付けを修復",
+    "source_hash": "82b40352"
+  },
+  "web.admin.domains.actions.repair.description": {
+    "text": "このドメインと組織の間の壊れた紐付けを検出して修復します。まずプレビューで変更内容をご確認ください。",
+    "source_hash": "531ed287"
+  },
+  "web.admin.domains.actions.repair.orgIdLabel": {
+    "text": "組織ID (所有者のないドメインのみ)",
+    "source_hash": "0d3010eb"
+  },
+  "web.admin.domains.actions.repair.orgIdPlaceholder": {
+    "text": "ドメインに所有者がない場合を除き、空欄にしてください",
+    "source_hash": "118b7132"
+  },
+  "web.admin.domains.actions.repair.statusLabel": {
+    "text": "ステータス:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.repair.noIssues": {
+    "text": "問題は見つかりませんでした — 修復は不要です。",
+    "source_hash": "17735887"
+  },
+  "web.admin.domains.actions.repair.button": {
+    "text": "修復を適用",
+    "source_hash": "4d0ab2d4"
+  },
+  "web.admin.domains.actions.repair.confirmTitle": {
+    "text": "修復を適用しますか?",
+    "source_hash": "ef0ffae5"
+  },
+  "web.admin.domains.actions.repair.confirmDescription": {
+    "text": "{domain}の組織との紐付けを書き換えます。続行するにはドメインの公開IDを入力してください。",
+    "source_hash": "a9f2702f"
+  },
+  "web.admin.domains.actions.repair.success": {
+    "text": "修復を適用しました。",
+    "source_hash": "850bd784"
+  },
+  "web.admin.domains.actions.transfer.title": {
+    "text": "別の組織に移管",
+    "source_hash": "1b0b0655"
+  },
+  "web.admin.domains.actions.transfer.description": {
+    "text": "このドメインを別の組織に移動します。まずプレビューで移動元と移動先をご確認ください。",
+    "source_hash": "457e852d"
+  },
+  "web.admin.domains.actions.transfer.toOrgLabel": {
+    "text": "移動先の組織ID",
+    "source_hash": "1a3f05c4"
+  },
+  "web.admin.domains.actions.transfer.fromOrgLabel": {
+    "text": "現在の組織ID (任意)",
+    "source_hash": "f6e75729"
+  },
+  "web.admin.domains.actions.transfer.fromOrgPlaceholder": {
+    "text": "移動前に現在の所有者を確認します",
+    "source_hash": "1ac6c59b"
+  },
+  "web.admin.domains.actions.transfer.from": {
+    "text": "移動元",
+    "source_hash": "21819769"
+  },
+  "web.admin.domains.actions.transfer.to": {
+    "text": "移動先",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.domains.actions.transfer.orphaned": {
+    "text": "組織なし (孤立)",
+    "source_hash": "6f4c745c"
+  },
+  "web.admin.domains.actions.transfer.button": {
+    "text": "移管を適用",
+    "source_hash": "fb546c5c"
+  },
+  "web.admin.domains.actions.transfer.confirmTitle": {
+    "text": "ドメインを移管しますか?",
+    "source_hash": "801eb986"
+  },
+  "web.admin.domains.actions.transfer.confirmDescription": {
+    "text": "{domain}を組織{org}に移動します。続行するにはドメインの公開IDを入力してください。",
+    "source_hash": "52c8808d"
+  },
+  "web.admin.domains.actions.transfer.success": {
+    "text": "ドメインを移管しました。",
+    "source_hash": "91e681ae"
+  },
+  "web.admin.domains.columns.domain": {
+    "text": "ドメイン",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domains.columns.organization": {
+    "text": "組織",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.columns.state": {
+    "text": "検証",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.domains.columns.tls": {
+    "text": "TLS",
+    "source_hash": "d1c18ec0"
+  },
+  "web.admin.domains.columns.created": {
+    "text": "作成日時",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.columns.actions": {
+    "text": "操作",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.configs.title": {
+    "text": "ドメインの構成",
+    "source_hash": "d46aa480"
+  },
+  "web.admin.domains.configs.description": {
+    "text": "ログイン、登録、ホームページのシークレット、APIアクセス、受信シークレット、テナントSSO、メール送信を制御するドメインごとの構成レコードです。レコードがない場合、最初の5つは無効側 (フェイルクローズ) になります。",
+    "source_hash": "1df99789"
+  },
+  "web.admin.domains.configs.loadError": {
+    "text": "ドメインの構成レコードを読み込めませんでした。",
+    "source_hash": "9417d718"
+  },
+  "web.admin.domains.configs.retry": {
+    "text": "再試行",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.configs.degraded": {
+    "text": "構成の応答が想定された契約と一致しませんでした。再読み込みし、解消しない場合はご報告ください。",
+    "source_hash": "b5d890c0"
+  },
+  "web.admin.domains.configs.notFoundNote": {
+    "text": "このドメインはすでに存在しないため、構成レコードを読み込めません。",
+    "source_hash": "2d88a392"
+  },
+  "web.admin.domains.configs.detailsToggle": {
+    "text": "詳細",
+    "source_hash": "45989de4"
+  },
+  "web.admin.domains.configs.notEditable": {
+    "text": "ワークスペースのドメイン設定で管理されます。",
+    "source_hash": "54fe891f"
+  },
+  "web.admin.domains.configs.delete.button": {
+    "text": "削除",
+    "source_hash": "e2d0a549"
+  },
+  "web.admin.domains.configs.delete.confirmTitle": {
+    "text": "{kind}の構成を削除しますか?",
+    "source_hash": "98e672db"
+  },
+  "web.admin.domains.configs.delete.confirmDescription": {
+    "text": "{domain}の{kind}構成レコードを完全に削除します。ドメインはレコードがない場合の動作に戻ります。続行するには種別を入力してください。",
+    "source_hash": "8272c40c"
+  },
+  "web.admin.domains.configs.delete.success": {
+    "text": "構成を削除しました。",
+    "source_hash": "a0184b66"
+  },
+  "web.admin.domains.configs.edit.button": {
+    "text": "編集",
+    "source_hash": "464c4ffd"
+  },
+  "web.admin.domains.configs.edit.createButton": {
+    "text": "作成",
+    "source_hash": "4759498a"
+  },
+  "web.admin.domains.configs.edit.title": {
+    "text": "{kind}を設定",
+    "source_hash": "8592148f"
+  },
+  "web.admin.domains.configs.edit.submit": {
+    "text": "保存",
+    "source_hash": "1509f561"
+  },
+  "web.admin.domains.configs.edit.success": {
+    "text": "構成を保存しました。",
+    "source_hash": "6b5b3c69"
+  },
+  "web.admin.domains.configs.edit.unsetOption": {
+    "text": "未設定",
+    "source_hash": "4895f731"
+  },
+  "web.admin.domains.configs.edit.domainsHint": {
+    "text": "1行につき1つのドメインを入力してください。",
+    "source_hash": "6c03f4f7"
+  },
+  "web.admin.domains.configs.ensure.button": {
+    "text": "不足している構成を作成",
+    "source_hash": "77991b75"
+  },
+  "web.admin.domains.configs.ensure.confirmTitle": {
+    "text": "不足している構成レコードを作成しますか?",
+    "source_hash": "3f41dec2"
+  },
+  "web.admin.domains.configs.ensure.confirmDescription": {
+    "text": "{domain}に次の無効状態のレコードを作成します: {kinds}。すべて無効の状態で作成されるため、レコードを有効にするまで動作は変わりません。",
+    "source_hash": "fed66221"
+  },
+  "web.admin.domains.configs.ensure.applyButton": {
+    "text": "レコードを作成",
+    "source_hash": "4bcbef42"
+  },
+  "web.admin.domains.configs.ensure.success": {
+    "text": "不足していた構成レコードを作成しました。",
+    "source_hash": "3b6ead80"
+  },
+  "web.admin.domains.configs.ensure.nothingMissing": {
+    "text": "作成するものはありません — すべての構成レコードがすでに存在します。一覧を更新しました。",
+    "source_hash": "ad0df0ae"
+  },
+  "web.admin.domains.configs.ensure.notApplied": {
+    "text": "サーバーは変更を適用せずにプレビューしました — レコードは作成されていません。再試行し、解消しない場合はご報告ください。",
+    "source_hash": "09d26379"
+  },
+  "web.admin.domains.configs.fields.enabled": {
+    "text": "有効",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.fields.signin_enabled": {
+    "text": "ログインを有効化",
+    "source_hash": "cabe4898"
+  },
+  "web.admin.domains.configs.fields.email_auth_enabled": {
+    "text": "メール認証を有効化",
+    "source_hash": "4a762960"
+  },
+  "web.admin.domains.configs.fields.sso_enabled": {
+    "text": "SSOを有効化",
+    "source_hash": "6e77e673"
+  },
+  "web.admin.domains.configs.fields.restrict_to": {
+    "text": "制限対象",
+    "source_hash": "a0bdf50a"
+  },
+  "web.admin.domains.configs.fields.signup_enabled": {
+    "text": "登録を有効化",
+    "source_hash": "2637d0b2"
+  },
+  "web.admin.domains.configs.fields.autoverify": {
+    "text": "自動認証",
+    "source_hash": "7e02211c"
+  },
+  "web.admin.domains.configs.fields.validation_strategy": {
+    "text": "検証方法",
+    "source_hash": "a2e95531"
+  },
+  "web.admin.domains.configs.fields.allowed_signup_domains": {
+    "text": "登録を許可するドメイン",
+    "source_hash": "9b5bb5b1"
+  },
+  "web.admin.domains.configs.fields.secrets_mode": {
+    "text": "シークレットのモード",
+    "source_hash": "8d4349d6"
+  },
+  "web.admin.domains.configs.fields.disabled_homepage_variant": {
+    "text": "無効時のホームページの表示",
+    "source_hash": "4695633b"
+  },
+  "web.admin.domains.configs.fields.ready": {
+    "text": "準備完了",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.configs.fields.recipients": {
+    "text": "受信者",
+    "source_hash": "1e8568a8"
+  },
+  "web.admin.domains.configs.fields.provider_type": {
+    "text": "プロバイダーの種類",
+    "source_hash": "8c0f6d3e"
+  },
+  "web.admin.domains.configs.fields.display_name": {
+    "text": "表示名",
+    "source_hash": "2b7f6a84"
+  },
+  "web.admin.domains.configs.fields.issuer": {
+    "text": "発行者",
+    "source_hash": "39e02c46"
+  },
+  "web.admin.domains.configs.fields.tenant_id": {
+    "text": "テナントID",
+    "source_hash": "de1f5fff"
+  },
+  "web.admin.domains.configs.fields.has_client_id": {
+    "text": "クライアントID設定済み",
+    "source_hash": "04a9fa3d"
+  },
+  "web.admin.domains.configs.fields.has_client_secret": {
+    "text": "クライアントシークレット設定済み",
+    "source_hash": "6ee1c9e6"
+  },
+  "web.admin.domains.configs.fields.allowed_domains": {
+    "text": "許可するドメイン",
+    "source_hash": "bcd60db0"
+  },
+  "web.admin.domains.configs.fields.enforce_sso_only": {
+    "text": "SSO専用を強制",
+    "source_hash": "b3a3f694"
+  },
+  "web.admin.domains.configs.fields.grant_org_scope": {
+    "text": "組織スコープを付与",
+    "source_hash": "698ea5de"
+  },
+  "web.admin.domains.configs.fields.provider": {
+    "text": "プロバイダー",
+    "source_hash": "472590ae"
+  },
+  "web.admin.domains.configs.fields.from_name": {
+    "text": "送信者名",
+    "source_hash": "b28f93ea"
+  },
+  "web.admin.domains.configs.fields.from_address": {
+    "text": "送信元アドレス",
+    "source_hash": "d465bcfa"
+  },
+  "web.admin.domains.configs.fields.reply_to": {
+    "text": "返信先",
+    "source_hash": "6b9c49b7"
+  },
+  "web.admin.domains.configs.fields.sending_mode": {
+    "text": "送信モード",
+    "source_hash": "e2d6bcf7"
+  },
+  "web.admin.domains.configs.fields.verification_status": {
+    "text": "検証ステータス",
+    "source_hash": "aedfff7e"
+  },
+  "web.admin.domains.configs.fields.dns_verified": {
+    "text": "DNS検証済み",
+    "source_hash": "8b2128c8"
+  },
+  "web.admin.domains.configs.fields.provider_verified": {
+    "text": "プロバイダー検証済み",
+    "source_hash": "6f4d9cc4"
+  },
+  "web.admin.domains.configs.fields.has_api_key": {
+    "text": "APIキー設定済み",
+    "source_hash": "d5115386"
+  },
+  "web.admin.domains.configs.fields.created": {
+    "text": "作成日時",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.configs.fields.updated": {
+    "text": "更新日時",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.configs.kinds.signin": {
+    "text": "ログイン",
+    "source_hash": "5bbbe531"
+  },
+  "web.admin.domains.configs.kinds.signup": {
+    "text": "登録",
+    "source_hash": "3cc08ebe"
+  },
+  "web.admin.domains.configs.kinds.homepage": {
+    "text": "ホームページ",
+    "source_hash": "9e3391e9"
+  },
+  "web.admin.domains.configs.kinds.api": {
+    "text": "API",
+    "source_hash": "c8e5998f"
+  },
+  "web.admin.domains.configs.kinds.incoming": {
+    "text": "受信",
+    "source_hash": "e301820a"
+  },
+  "web.admin.domains.configs.kinds.sso": {
+    "text": "SSO",
+    "source_hash": "5ba3ac9f"
+  },
+  "web.admin.domains.configs.kinds.mailer": {
+    "text": "メーラー",
+    "source_hash": "6c07ba63"
+  },
+  "web.admin.domains.configs.missingNotes.signin": {
+    "text": "レコードなし: テナントSSOが有効でない限り、このドメインではログインが無効です。",
+    "source_hash": "17dd6099"
+  },
+  "web.admin.domains.configs.missingNotes.signup": {
+    "text": "レコードなし: このドメインでは登録が無効です。",
+    "source_hash": "c3c98956"
+  },
+  "web.admin.domains.configs.missingNotes.homepage": {
+    "text": "レコードなし: ホームページのシークレットは無効です (フェイルクローズし、エラーを記録します)。",
+    "source_hash": "9a258a88"
+  },
+  "web.admin.domains.configs.missingNotes.api": {
+    "text": "レコードなし: 公開APIは無効です (フェイルクローズし、エラーを記録します)。",
+    "source_hash": "fed99f73"
+  },
+  "web.admin.domains.configs.missingNotes.incoming": {
+    "text": "レコードなし: 受信シークレットは無効です。",
+    "source_hash": "b957fbe8"
+  },
+  "web.admin.domains.configs.missingNotes.sso": {
+    "text": "レコードなし: テナントSSOは利用できません。プラットフォームのSSOフォールバックポリシーが適用されます。",
+    "source_hash": "7b05ade8"
+  },
+  "web.admin.domains.configs.missingNotes.mailer": {
+    "text": "レコードなし: プラットフォームのメーラーが使用されます。",
+    "source_hash": "e027cc99"
+  },
+  "web.admin.domains.configs.status.missing": {
+    "text": "なし",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.domains.configs.status.disabled": {
+    "text": "無効",
+    "source_hash": "75081b59"
+  },
+  "web.admin.domains.configs.status.enabled": {
+    "text": "有効",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.status.enabledNotReady": {
+    "text": "有効 (準備未完了)",
+    "source_hash": "cb806ba4"
+  },
+  "web.admin.domains.detail.openFullPage": {
+    "text": "全画面で開く",
+    "source_hash": "a467911c"
+  },
+  "web.admin.domains.detail.backToList": {
+    "text": "ドメイン一覧に戻る",
+    "source_hash": "22fd50fe"
+  },
+  "web.admin.domains.detail.notFound": {
+    "text": "ドメインが見つかりません",
+    "source_hash": "7b8fc0e6"
+  },
+  "web.admin.domains.detail.notFoundDescription": {
+    "text": "このドメインは存在しないか、すでに削除されています。",
+    "source_hash": "e0f0b987"
+  },
+  "web.admin.domains.detail.loadError": {
+    "text": "このドメインを読み込めませんでした。",
+    "source_hash": "39e9c657"
+  },
+  "web.admin.domains.detail.retry": {
+    "text": "再試行",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.detail.never": {
+    "text": "なし",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.domains.detail.none": {
+    "text": "なし",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.domains.detail.yes": {
+    "text": "はい",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.domains.detail.no": {
+    "text": "いいえ",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.domains.detail.organization.open": {
+    "text": "組織を開く",
+    "source_hash": "54a43621"
+  },
+  "web.admin.domains.detail.organization.unknown": {
+    "text": "所有する組織はこの応答に含まれていません。ドメイン一覧からこのドメインを開くと確認できます。",
+    "source_hash": "bb5bdc9c"
+  },
+  "web.admin.domains.detail.sections.overview": {
+    "text": "概要",
+    "source_hash": "d4b1ea57"
+  },
+  "web.admin.domains.detail.sections.actions": {
+    "text": "操作",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.detail.sections.organization": {
+    "text": "所有する組織",
+    "source_hash": "39ad6d9c"
+  },
+  "web.admin.domains.detail.sections.dns": {
+    "text": "DNS",
+    "source_hash": "020965a2"
+  },
+  "web.admin.domains.detail.sections.diagnostics": {
+    "text": "診断",
+    "source_hash": "268f14bb"
+  },
+  "web.admin.domains.detail.sections.operations": {
+    "text": "所有権に関する操作",
+    "source_hash": "eb9a8cbc"
+  },
+  "web.admin.domains.detail.sections.operationsHint": {
+    "text": "各操作はまずプレビューされます。適用の確認を行うまで、何も書き込まれません。",
+    "source_hash": "f09bf7bd"
+  },
+  "web.admin.domains.fields.publicId": {
+    "text": "公開ID",
+    "source_hash": "3705b64f"
+  },
+  "web.admin.domains.fields.domainId": {
+    "text": "内部ID",
+    "source_hash": "e468bb47"
+  },
+  "web.admin.domains.fields.organization": {
+    "text": "組織",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.fields.baseDomain": {
+    "text": "ベースドメイン",
+    "source_hash": "33295d5b"
+  },
+  "web.admin.domains.fields.subdomain": {
+    "text": "サブドメイン",
+    "source_hash": "ba4520ab"
+  },
+  "web.admin.domains.fields.apex": {
+    "text": "Apexドメイン",
+    "source_hash": "0a8a42fa"
+  },
+  "web.admin.domains.fields.status": {
+    "text": "ステータス",
+    "source_hash": "920e413c"
+  },
+  "web.admin.domains.fields.created": {
+    "text": "作成日時",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.fields.updated": {
+    "text": "更新日時",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.fields.verified": {
+    "text": "検証済み",
+    "source_hash": "4f783840"
+  },
+  "web.admin.domains.fields.resolving": {
+    "text": "名前解決中",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.fields.ready": {
+    "text": "準備完了",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.list.searchPlaceholder": {
+    "text": "ドメイン名またはIDで検索",
+    "source_hash": "aecdd873"
+  },
+  "web.admin.domains.list.stateFilter": {
+    "text": "状態",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.domains.list.emptyFilter": {
+    "text": "現在の絞り込み条件に一致するドメインはありません。",
+    "source_hash": "be4d64ec"
+  },
+  "web.admin.domains.probe.healthLabel": {
+    "text": "健全性",
+    "source_hash": "55898449"
+  },
+  "web.admin.domains.probe.certInvalid": {
+    "text": "証明書を使用できません",
+    "source_hash": "5535f4d4"
+  },
+  "web.admin.domains.probe.noCertificate": {
+    "text": "証明書が返されませんでした — TLSの前に接続が失敗しました。",
+    "source_hash": "8ffd63be"
+  },
+  "web.admin.domains.probe.fields.httpStatus": {
+    "text": "HTTPステータス",
+    "source_hash": "0f7cf91f"
+  },
+  "web.admin.domains.probe.fields.httpError": {
+    "text": "HTTPエラー",
+    "source_hash": "5c6896d4"
+  },
+  "web.admin.domains.probe.fields.sslError": {
+    "text": "TLSエラー",
+    "source_hash": "7b827515"
+  },
+  "web.admin.domains.probe.fields.issuer": {
+    "text": "証明書の発行者",
+    "source_hash": "2912559a"
+  },
+  "web.admin.domains.probe.fields.subject": {
+    "text": "証明書のサブジェクト",
+    "source_hash": "d7816b16"
+  },
+  "web.admin.domains.probe.fields.notAfter": {
+    "text": "証明書の有効期限",
+    "source_hash": "1e73119d"
+  },
+  "web.admin.domains.probe.fields.expiresIn": {
+    "text": "{date} (あと{days}日)",
+    "source_hash": "a71a6e81"
+  },
+  "web.admin.domains.tls.serving": {
+    "text": "配信中",
+    "source_hash": "f55e53f9"
+  },
+  "web.admin.domains.tls.resolving": {
+    "text": "名前解決中",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.tls.none": {
+    "text": "配信していません",
+    "source_hash": "da8a5ab9"
   }
 }

--- a/locales/content/ja/admin-domaintoolbox.json
+++ b/locales/content/ja/admin-domaintoolbox.json
@@ -4,7 +4,7 @@
     "source_hash": "5a9333db"
   },
   "web.admin.domaintoolbox.description": {
-    "text": "カスタムドメインの関係を診断・修復します。孤立レコードのスキャン、DNS/SSLのプローブ、所有権の修復、組織間の移管を行えます。",
+    "text": "カスタムドメインの関連付けを診断・修復します: 孤立したドメインのスキャン、DNS/SSLの検査、所有権の修復、組織間の移管を行えます。",
     "source_hash": "778537aa"
   },
   "web.admin.domaintoolbox.retry": {
@@ -16,11 +16,11 @@
     "source_hash": "324b134f"
   },
   "web.admin.domaintoolbox.fields.extid": {
-    "text": "ドメイン外部ID",
+    "text": "ドメインの外部ID",
     "source_hash": "f52af6c5"
   },
   "web.admin.domaintoolbox.fields.extidPlaceholder": {
-    "text": "cd_…(ドメインのextid)",
+    "text": "cd_… (ドメインのextid)",
     "source_hash": "bb9bf49a"
   },
   "web.admin.domaintoolbox.orphaned.title": {
@@ -28,7 +28,7 @@
     "source_hash": "ddcea596"
   },
   "web.admin.domaintoolbox.orphaned.description": {
-    "text": "所有する組織のないカスタムドメインです。「修復」を使って再割り当てします。",
+    "text": "所有する組織がないカスタムドメインです。「修復」で再割り当てできます。",
     "source_hash": "967268f5"
   },
   "web.admin.domaintoolbox.orphaned.empty": {
@@ -56,39 +56,39 @@
     "source_hash": "4f783840"
   },
   "web.admin.domaintoolbox.orphaned.columns.created": {
-    "text": "作成日",
+    "text": "作成日時",
     "source_hash": "d70b9e24"
   },
   "web.admin.domaintoolbox.orphaned.columns.actions": {
-    "text": "アクション",
+    "text": "操作",
     "source_hash": "ff8059dc"
   },
   "web.admin.domaintoolbox.probe.title": {
-    "text": "プローブ(DNS / SSL)",
+    "text": "検査 (DNS / SSL)",
     "source_hash": "ec69a087"
   },
   "web.admin.domaintoolbox.probe.description": {
-    "text": "ライブHTTPSリクエストを送信し、ドメインがトラフィックを処理していることを確認し、TLS証明書を検査します。読み取り専用です。",
+    "text": "実際にHTTPSリクエストを送信して、ドメインがトラフィックを処理していることを確認し、TLS証明書を調べます。読み取り専用です。",
     "source_hash": "1eecfa96"
   },
   "web.admin.domaintoolbox.probe.button": {
-    "text": "プローブ",
+    "text": "検査",
     "source_hash": "3bd51ab9"
   },
   "web.admin.domaintoolbox.probe.healthLabel": {
-    "text": "ヘルス",
+    "text": "健全性",
     "source_hash": "55898449"
   },
   "web.admin.domaintoolbox.repair.title": {
-    "text": "関係を修復",
+    "text": "関連付けを修復",
     "source_hash": "0053d07c"
   },
   "web.admin.domaintoolbox.repair.description": {
-    "text": "ドメインの組織関係の不整合を修正します。まずプレビューし、その後適用してください。",
+    "text": "ドメインの組織との関連付けの不整合を修正します。まずプレビューし、その後適用してください。",
     "source_hash": "18ca490b"
   },
   "web.admin.domaintoolbox.repair.orgIdLabel": {
-    "text": "組織を割り当て(孤立している場合)",
+    "text": "組織を割り当てる (孤立している場合)",
     "source_hash": "f95b010a"
   },
   "web.admin.domaintoolbox.repair.orgIdPlaceholder": {
@@ -100,7 +100,7 @@
     "source_hash": "920e413c"
   },
   "web.admin.domaintoolbox.repair.noIssues": {
-    "text": "問題は見つかりませんでした。関係は整合しています。",
+    "text": "問題は見つかりませんでした — 関連付けは整合しています。",
     "source_hash": "e1a4c49d"
   },
   "web.admin.domaintoolbox.repair.applyButton": {
@@ -108,7 +108,7 @@
     "source_hash": "3f92b29f"
   },
   "web.admin.domaintoolbox.repair.success": {
-    "text": "修復を正常に適用しました。",
+    "text": "修復を適用しました。",
     "source_hash": "24f25b9b"
   },
   "web.admin.domaintoolbox.repair.confirmTitle": {
@@ -116,7 +116,7 @@
     "source_hash": "9429998b"
   },
   "web.admin.domaintoolbox.repair.confirmDescription": {
-    "text": "これにより、{domain}の所有権/関係の状態が変更されます。確認のためにドメインの外部IDを再入力してください。",
+    "text": "{domain}の所有権および関連付けの状態を変更します。確認のためドメインの外部IDを入力してください。",
     "source_hash": "426d267b"
   },
   "web.admin.domaintoolbox.reverify.button": {
@@ -128,31 +128,31 @@
     "source_hash": "497a2348"
   },
   "web.admin.domaintoolbox.transfer.title": {
-    "text": "所有権を移管",
+    "text": "所有権を譲渡",
     "source_hash": "3667f939"
   },
   "web.admin.domaintoolbox.transfer.description": {
-    "text": "ドメインを別の組織に再割り当てします。影響範囲が最も大きい操作です。プレビューして慎重に確認してください。",
+    "text": "ドメインを別の組織に再割り当てします。影響範囲が最も大きい操作です — プレビューして慎重にご確認ください。",
     "source_hash": "d4e26e03"
   },
   "web.admin.domaintoolbox.transfer.toOrgLabel": {
-    "text": "移管先の組織",
+    "text": "移動先の組織",
     "source_hash": "4e4486eb"
   },
   "web.admin.domaintoolbox.transfer.fromOrgLabel": {
-    "text": "移管元の組織(任意)",
+    "text": "移動元の組織 (任意)",
     "source_hash": "3666815f"
   },
   "web.admin.domaintoolbox.transfer.fromOrgPlaceholder": {
-    "text": "現在の所有者を指定",
+    "text": "現在の所有者を確認します",
     "source_hash": "cd9e769c"
   },
   "web.admin.domaintoolbox.transfer.from": {
-    "text": "移管元",
+    "text": "移動元",
     "source_hash": "21819769"
   },
   "web.admin.domaintoolbox.transfer.to": {
-    "text": "移管先",
+    "text": "移動先",
     "source_hash": "f4b06ef6"
   },
   "web.admin.domaintoolbox.transfer.orphaned": {
@@ -164,15 +164,15 @@
     "source_hash": "9517aeb9"
   },
   "web.admin.domaintoolbox.transfer.success": {
-    "text": "ドメインを正常に移管しました。",
+    "text": "ドメインを移管しました。",
     "source_hash": "bbca9de9"
   },
   "web.admin.domaintoolbox.transfer.confirmTitle": {
-    "text": "ドメインの所有権を移管しますか?",
+    "text": "ドメインの所有権を譲渡しますか?",
     "source_hash": "d306a15a"
   },
   "web.admin.domaintoolbox.transfer.confirmDescription": {
-    "text": "これにより、{domain}の所有権が別の組織に再割り当てされます。確認のためにドメインの外部IDを再入力してください。",
+    "text": "{domain}の所有権を別の組織に再割り当てします。確認のためドメインの外部IDを入力してください。",
     "source_hash": "edefd97c"
   }
 }

--- a/locales/content/ja/admin-emailtools.json
+++ b/locales/content/ja/admin-emailtools.json
@@ -4,23 +4,23 @@
     "source_hash": "f9643d5a"
   },
   "web.admin.emailtools.description": {
-    "text": "メールテンプレートのプレビュー、配信テストの送信、到達性の監視ができます。これまでSSHが必要だった診断機能です。",
+    "text": "メールテンプレートのプレビュー、配信テストの送信、到達性の監視を行えます — 従来はSSHが必要だった診断です。",
     "source_hash": "be85c9e9"
   },
   "web.admin.emailtools.config.title": {
-    "text": "メーラー設定",
+    "text": "メーラーの構成",
     "source_hash": "d2a71028"
   },
   "web.admin.emailtools.config.description": {
-    "text": "起動時に解決された常設のメール設定です。認証情報は表示されず、設定されているかどうかのみが表示されます。",
+    "text": "起動時に解決された現在のメール構成です。認証情報は表示されず、設定の有無のみが示されます。",
     "source_hash": "f0e8a118"
   },
   "web.admin.emailtools.config.provider": {
-    "text": "トランスポートプロバイダー",
+    "text": "トランスポートのプロバイダー",
     "source_hash": "4f0e5025"
   },
   "web.admin.emailtools.config.senderProvider": {
-    "text": "送信元プロバイダー",
+    "text": "送信元のプロバイダー",
     "source_hash": "e881964f"
   },
   "web.admin.emailtools.config.senderDiffers": {
@@ -64,7 +64,7 @@
     "source_hash": "1ea442a1"
   },
   "web.admin.emailtools.config.loggerWarning": {
-    "text": "メールが配信されていません。トランスポートプロバイダーが無送信モード(logger、disabled、またはnone)に設定されているため、このサーバーからメールは送信されません。送信メッセージはアプリケーションログに記録されるか破棄されます。",
+    "text": "メールは配信されていません。トランスポートのプロバイダーが送信しないモード (logger、disabled、none) に設定されているため、このサーバーからメールは送信されません — 送信メッセージはアプリケーションログに記録されるか破棄されます。",
     "source_hash": "1883dfd5"
   },
   "web.admin.emailtools.deliverability.title": {
@@ -72,7 +72,7 @@
     "source_hash": "66b4d300"
   },
   "web.admin.emailtools.deliverability.description": {
-    "text": "送信後に返ってくる情報です。バウンス、苦情、そして送信者の評価を保護する抑制リストが含まれます。",
+    "text": "送信後に返ってくる情報です: バウンス、苦情、および送信者レピュテーションを保護する抑制リスト。",
     "source_hash": "e8363bb5"
   },
   "web.admin.emailtools.deliverability.retry": {
@@ -84,11 +84,11 @@
     "source_hash": "8ecce94d"
   },
   "web.admin.emailtools.deliverability.events.description": {
-    "text": "バウンスと苦情の生フィードを新しい順に表示します。",
+    "text": "バウンスと苦情の生のフィードを新しい順に表示します。",
     "source_hash": "0e7a533b"
   },
   "web.admin.emailtools.deliverability.events.empty": {
-    "text": "バウンスや苦情のデータはまだありません。POST /api/colonel/email/deliverability/events(colonel認証が必要 — レコード形式についてはエンドポイントのドキュメントを参照)経由でESPのフィードバックを送信してください。同期SMTPのハードバウンスは自動的に記録されます。",
+    "text": "バウンスや苦情のデータはまだありません。POST /api/colonel/email/deliverability/events 経由でESPのフィードバックを送信してください (Colonel認証が必要です — レコード形式はエンドポイントのドキュメントをご覧ください)。同期的なSMTPのハードバウンスは自動的に記録されます。",
     "source_hash": "a90f259c"
   },
   "web.admin.emailtools.deliverability.events.loadError": {
@@ -96,7 +96,7 @@
     "source_hash": "02244c61"
   },
   "web.admin.emailtools.deliverability.events.columns.time": {
-    "text": "時刻",
+    "text": "日時",
     "source_hash": "33b93476"
   },
   "web.admin.emailtools.deliverability.events.columns.kind": {
@@ -124,19 +124,19 @@
     "source_hash": "5d08b02d"
   },
   "web.admin.emailtools.deliverability.lookup.title": {
-    "text": "受信者検索",
+    "text": "受信者の照会",
     "source_hash": "7569985b"
   },
   "web.admin.emailtools.deliverability.lookup.description": {
-    "text": "アドレスが抑制されているかどうかを、ローカルストアとアクティブなメールプロバイダーの両方で確認します。どちらも同じ正規化されたアドレスをキーとしています。",
+    "text": "アドレスが抑制されているかどうかを、ローカルストアと現在のメールプロバイダーの両方で確認します。どちらも同じ正規化済みアドレスをキーとしています。",
     "source_hash": "c341d614"
   },
   "web.admin.emailtools.deliverability.lookup.addressLabel": {
-    "text": "受信者アドレス",
+    "text": "受信者のアドレス",
     "source_hash": "454d0391"
   },
   "web.admin.emailtools.deliverability.lookup.submit": {
-    "text": "検索",
+    "text": "照会",
     "source_hash": "504101bc"
   },
   "web.admin.emailtools.deliverability.lookup.local": {
@@ -164,7 +164,7 @@
     "source_hash": "0e570ca6"
   },
   "web.admin.emailtools.deliverability.lookup.unavailable": {
-    "text": "プロバイダーのライブ検索は利用できません。上記のローカルストアが正となります。",
+    "text": "プロバイダーへの照会は利用できません。上記のローカルストアが正となります。",
     "source_hash": "aebed0f2"
   },
   "web.admin.emailtools.deliverability.messages.title": {
@@ -172,7 +172,7 @@
     "source_hash": "522e089e"
   },
   "web.admin.emailtools.deliverability.messages.description": {
-    "text": "アクティブなメールプロバイダーが記録した最新のメッセージを新しい順に表示します。プロバイダーからライブで取得しており、ここには保存されません。",
+    "text": "現在のメールプロバイダーが記録した最新のメッセージを新しい順に表示します。プロバイダーから直接取得しており、ここには保存されません。",
     "source_hash": "9970fa0a"
   },
   "web.admin.emailtools.deliverability.messages.empty": {
@@ -180,7 +180,7 @@
     "source_hash": "a7ef4d79"
   },
   "web.admin.emailtools.deliverability.messages.notSupported": {
-    "text": "{provider}トランスポートでは送信ログを利用できません。メッセージごとのAPIが提供されていません。",
+    "text": "{provider}トランスポートにはメッセージ単位のAPIがないため、送信ログを利用できません。",
     "source_hash": "21e6b6f9"
   },
   "web.admin.emailtools.deliverability.messages.error": {
@@ -244,11 +244,11 @@
     "source_hash": "f63d5b6b"
   },
   "web.admin.emailtools.deliverability.messages.status.unsubscribed": {
-    "text": "購読解除済み",
+    "text": "配信停止済み",
     "source_hash": "621e1970"
   },
   "web.admin.emailtools.deliverability.summary.loadError": {
-    "text": "到達性の概要を読み込めませんでした。",
+    "text": "到達性のサマリーを読み込めませんでした。",
     "source_hash": "0c16ef96"
   },
   "web.admin.emailtools.deliverability.suppressions.title": {
@@ -256,11 +256,11 @@
     "source_hash": "9f3e322f"
   },
   "web.admin.emailtools.deliverability.suppressions.description": {
-    "text": "送信メールがスキップするアドレスです。エントリはESPフィードバックの取り込みまたは手動インポートに由来します。削除すると配信が再開されます。",
+    "text": "送信メールがスキップするアドレスです。エントリはESPのフィードバック取り込みまたは手動インポートで追加されます。削除すると配信が再開されます。",
     "source_hash": "3651887e"
   },
   "web.admin.emailtools.deliverability.suppressions.searchLabel": {
-    "text": "完全なアドレス",
+    "text": "完全一致のアドレス",
     "source_hash": "f4338ff8"
   },
   "web.admin.emailtools.deliverability.suppressions.searchPlaceholder": {
@@ -268,7 +268,7 @@
     "source_hash": "333f0f15"
   },
   "web.admin.emailtools.deliverability.suppressions.searchButton": {
-    "text": "検索",
+    "text": "照会",
     "source_hash": "504101bc"
   },
   "web.admin.emailtools.deliverability.suppressions.clearButton": {
@@ -292,7 +292,7 @@
     "source_hash": "8be5aa33"
   },
   "web.admin.emailtools.deliverability.suppressions.add.button": {
-    "text": "抑制",
+    "text": "抑制する",
     "source_hash": "60b19987"
   },
   "web.admin.emailtools.deliverability.suppressions.add.confirmTitle": {
@@ -300,7 +300,7 @@
     "source_hash": "40a0d2a6"
   },
   "web.admin.emailtools.deliverability.suppressions.add.confirmDescription": {
-    "text": "抑制が解除されるまで、{address}への送信メールはスキップされます。これは手動エントリとして記録されます。",
+    "text": "抑制が解除されるまで、{address}宛ての送信メールはスキップされます。手動エントリとして記録されます。",
     "source_hash": "e3d0d799"
   },
   "web.admin.emailtools.deliverability.suppressions.add.success": {
@@ -328,11 +328,11 @@
     "source_hash": "0e570ca6"
   },
   "web.admin.emailtools.deliverability.suppressions.columns.added": {
-    "text": "追加日",
+    "text": "追加日時",
     "source_hash": "6b02e0d3"
   },
   "web.admin.emailtools.deliverability.suppressions.columns.actions": {
-    "text": "アクション",
+    "text": "操作",
     "source_hash": "ff8059dc"
   },
   "web.admin.emailtools.deliverability.suppressions.remove.button": {
@@ -340,19 +340,19 @@
     "source_hash": "c3812fc4"
   },
   "web.admin.emailtools.deliverability.suppressions.remove.confirmTitle": {
-    "text": "この抑制を削除しますか?",
+    "text": "この抑制を解除しますか?",
     "source_hash": "0b0aec2e"
   },
   "web.admin.emailtools.deliverability.suppressions.remove.confirmDescription": {
-    "text": "{address}への送信メールが再開されます。このアドレスは以前バウンスまたは苦情がありました。再び配信可能だとわかっている場合のみ削除してください。",
+    "text": "{address}宛ての送信メールが再開されます。このアドレスは過去にバウンスまたは苦情がありました — 再び配信可能であることが確認できている場合のみ解除してください。",
     "source_hash": "09442f9c"
   },
   "web.admin.emailtools.deliverability.suppressions.remove.success": {
-    "text": "{address}の抑制を削除しました。",
+    "text": "{address}の抑制を解除しました。",
     "source_hash": "bfc0de36"
   },
   "web.admin.emailtools.deliverability.sync.title": {
-    "text": "フィードバック同期",
+    "text": "フィードバックの同期",
     "source_hash": "d4056915"
   },
   "web.admin.emailtools.deliverability.sync.lastSynced": {
@@ -360,11 +360,11 @@
     "source_hash": "5a99666b"
   },
   "web.admin.emailtools.deliverability.sync.imported": {
-    "text": "{count}件インポート",
+    "text": "{count}件を取り込み",
     "source_hash": "1bc18c45"
   },
   "web.admin.emailtools.deliverability.sync.neverRun": {
-    "text": "プロバイダーのフィードバック同期は一度も実行されていません。バウンスと苦情のデータは自動的にインポートされていません。プロバイダー同期を設定するか、イベントエンドポイント経由でフィードバックを取り込んでください。",
+    "text": "プロバイダーのフィードバック同期は一度も実行されていません。バウンスや苦情のデータは自動的に取り込まれていません — プロバイダー同期を設定するか、イベントのエンドポイント経由でフィードバックを取り込んでください。",
     "source_hash": "d19f5755"
   },
   "web.admin.emailtools.deliverability.sync.button": {
@@ -372,11 +372,11 @@
     "source_hash": "885e8f48"
   },
   "web.admin.emailtools.deliverability.sync.success": {
-    "text": "{provider}の同期が完了しました:{accepted}件インポート、{rejected}件拒否({fetched}件取得)。",
+    "text": "{provider}の同期が完了しました: {accepted}件を取り込み、{rejected}件を却下 ({fetched}件を取得)。",
     "source_hash": "d36f5578"
   },
   "web.admin.emailtools.deliverability.sync.hint": {
-    "text": "手動同期です。自動インポートには、スケジュールされた`ots email sync-feedback` cronが引き続き必要です。",
+    "text": "これは手動同期です — 自動取り込みには`ots email sync-feedback`のcron設定が必要です。",
     "source_hash": "7a509b75"
   },
   "web.admin.emailtools.deliverability.tiles.suppressed": {
@@ -384,11 +384,11 @@
     "source_hash": "b31a245e"
   },
   "web.admin.emailtools.deliverability.tiles.bounces": {
-    "text": "バウンス({days}日)",
+    "text": "バウンス ({days}日間)",
     "source_hash": "3a4d0f09"
   },
   "web.admin.emailtools.deliverability.tiles.complaints": {
-    "text": "苦情({days}日)",
+    "text": "苦情 ({days}日間)",
     "source_hash": "16ad856f"
   },
   "web.admin.emailtools.deliverability.tiles.skipped": {
@@ -396,11 +396,11 @@
     "source_hash": "391467f9"
   },
   "web.admin.emailtools.preview.title": {
-    "text": "テンプレートプレビュー",
+    "text": "テンプレートのプレビュー",
     "source_hash": "df89bd92"
   },
   "web.admin.emailtools.preview.description": {
-    "text": "サンプルデータを使ってテンプレートをレンダリングします。プレビューには副作用がなく、メールは送信されません。",
+    "text": "サンプルデータでテンプレートを表示します。プレビューに副作用はなく、メールは送信されません。",
     "source_hash": "9b0e40f3"
   },
   "web.admin.emailtools.preview.templateLabel": {
@@ -424,11 +424,11 @@
     "source_hash": "231b7f03"
   },
   "web.admin.emailtools.providerStatus.rateUnavailable": {
-    "text": "このプロバイダーは数値でのバウンス率や苦情率を公開していません。上記の評価ティアは、適用ステータスと送信クォータのみから導き出されています。",
+    "text": "このプロバイダーはバウンス率や苦情率の数値を公開していません。上記のレピュテーション区分は、強制ステータスと送信クォータのみから導出されています。",
     "source_hash": "1e6b82e9"
   },
   "web.admin.emailtools.providerStatus.complaintsUnavailable": {
-    "text": "Lettermintは統計APIで苦情を報告しないため、苦情率はゼロではなく「—」(未報告)と表示されます。上記のバウンス率は完全です。",
+    "text": "Lettermintは統計APIで苦情を報告しないため、苦情率はゼロではなく「—」(未報告) と表示されます。上記のバウンス率は完全な値です。",
     "source_hash": "72aaa845"
   },
   "web.admin.emailtools.providerStatus.unavailable": {
@@ -436,7 +436,7 @@
     "source_hash": "8e69ff29"
   },
   "web.admin.emailtools.providerStatus.notSupported": {
-    "text": "{provider}トランスポートではプロバイダーのライブステータスを利用できません。",
+    "text": "{provider}トランスポートではプロバイダーの最新ステータスを利用できません。",
     "source_hash": "125ed6eb"
   },
   "web.admin.emailtools.providerStatus.error": {
@@ -448,11 +448,11 @@
     "source_hash": "e5ea4c3d"
   },
   "web.admin.emailtools.providerStatus.quota.sent24h": {
-    "text": "送信済み(過去24時間)",
+    "text": "送信数 (過去24時間)",
     "source_hash": "d0c4fe45"
   },
   "web.admin.emailtools.providerStatus.quota.maxRate": {
-    "text": "最大送信レート(毎秒)",
+    "text": "最大送信レート (毎秒)",
     "source_hash": "59e76cf8"
   },
   "web.admin.emailtools.providerStatus.rate.bounce": {
@@ -464,7 +464,7 @@
     "source_hash": "430a23a9"
   },
   "web.admin.emailtools.providerStatus.stats.sent": {
-    "text": "送信済み({days}日)",
+    "text": "送信数 ({days}日間)",
     "source_hash": "e553b7e1"
   },
   "web.admin.emailtools.providerStatus.stats.delivered": {
@@ -488,7 +488,7 @@
     "source_hash": "9e8a3b64"
   },
   "web.admin.emailtools.providerStatus.tier.shutdown": {
-    "text": "送信一時停止",
+    "text": "送信停止中",
     "source_hash": "52e6757c"
   },
   "web.admin.emailtools.test.title": {
@@ -496,7 +496,7 @@
     "source_hash": "5fab5d67"
   },
   "web.admin.emailtools.test.description": {
-    "text": "配信の接続性を確認するため、プレーンテキストの診断メールを送信します。まずプレビューし、その後確認すると実際のメールが送信されます。",
+    "text": "配信の疎通を確認するため、プレーンテキストの診断メールを送信します。まずプレビューし、その後確認して実際のメールを送信してください。",
     "source_hash": "4130741c"
   },
   "web.admin.emailtools.test.toLabel": {
@@ -512,7 +512,7 @@
     "source_hash": "97897017"
   },
   "web.admin.emailtools.test.previewButton": {
-    "text": "プレビュー(送信なし)",
+    "text": "プレビュー (送信しません)",
     "source_hash": "747ced83"
   },
   "web.admin.emailtools.test.sendButton": {
@@ -540,7 +540,7 @@
     "source_hash": "64a16b62"
   },
   "web.admin.emailtools.test.confirmDescription": {
-    "text": "これにより、設定済みのメーラーを通じて{to}へライブメールが送信されます。",
+    "text": "設定済みのメーラーを通じて、{to}宛てに実際のメールを送信します。",
     "source_hash": "10114929"
   },
   "web.admin.emailtools.test.success": {

--- a/locales/content/ja/admin-kit.json
+++ b/locales/content/ja/admin-kit.json
@@ -4,7 +4,7 @@
     "source_hash": "282445b6"
   },
   "web.admin.kit.confirmDialog.inputLabel": {
-    "text": "確認テキスト",
+    "text": "確認用テキスト",
     "source_hash": "8edc1113"
   },
   "web.admin.kit.confirmDialog.mismatchHint": {
@@ -12,7 +12,7 @@
     "source_hash": "f0cc7389"
   },
   "web.admin.kit.dataTable.empty": {
-    "text": "レコードが見つかりません",
+    "text": "レコードが見つかりませんでした",
     "source_hash": "6e2ea637"
   },
   "web.admin.kit.dataTable.sortBy": {
@@ -28,7 +28,7 @@
     "source_hash": "7336265a"
   },
   "web.admin.kit.filterBar.clearFilters": {
-    "text": "フィルターをクリア",
+    "text": "絞り込みをクリア",
     "source_hash": "7179ea00"
   },
   "web.admin.kit.filterBar.all": {
@@ -44,7 +44,7 @@
     "source_hash": "25f7b372"
   },
   "web.admin.kit.jsonViewer.empty": {
-    "text": "データなし",
+    "text": "データがありません",
     "source_hash": "3b41ba9c"
   },
   "web.admin.kit.jsonViewer.copyLabel": {

--- a/locales/content/ja/admin-organizations.json
+++ b/locales/content/ja/admin-organizations.json
@@ -4,7 +4,7 @@
     "source_hash": "942087cc"
   },
   "web.admin.organizations.detail.backToList": {
-    "text": "組織に戻る",
+    "text": "組織一覧に戻る",
     "source_hash": "2257dc4a"
   },
   "web.admin.organizations.detail.notFound": {
@@ -24,7 +24,7 @@
     "source_hash": "bda05058"
   },
   "web.admin.organizations.detail.badges.default": {
-    "text": "デフォルトワークスペース",
+    "text": "既定のワークスペース",
     "source_hash": "6d67c6eb"
   },
   "web.admin.organizations.detail.badges.archived": {
@@ -40,7 +40,7 @@
     "source_hash": "a3b50c47"
   },
   "web.admin.organizations.detail.domains.created": {
-    "text": "作成日",
+    "text": "作成日時",
     "source_hash": "d70b9e24"
   },
   "web.admin.organizations.detail.domains.ready": {
@@ -56,7 +56,7 @@
     "source_hash": "1b840c7e"
   },
   "web.admin.organizations.detail.entitlements.description": {
-    "text": "有効なエンタイトルメントは(プラン ∪ 付与)− 取り消しとして解決されます。上書きを行う前に内訳を確認してください。",
+    "text": "実効エンタイトルメントは (プラン ∪ 付与) − 取消 で決まります。上書き設定を行う前に内訳をご確認ください。",
     "source_hash": "23080475"
   },
   "web.admin.organizations.detail.entitlements.inSync": {
@@ -64,7 +64,7 @@
     "source_hash": "5701958c"
   },
   "web.admin.organizations.detail.entitlements.driftBadge": {
-    "text": "差分",
+    "text": "差異",
     "source_hash": "8b4c8240"
   },
   "web.admin.organizations.detail.entitlements.staleBadge": {
@@ -72,23 +72,23 @@
     "source_hash": "ffe63800"
   },
   "web.admin.organizations.detail.entitlements.driftWarning": {
-    "text": "実体化されたエンタイトルメントが期待される集合と一致しません。再実体化するには調整してください。",
+    "text": "実体化されたエンタイトルメントが期待される内容と一致しません。再調整して再度実体化してください。",
     "source_hash": "4859983a"
   },
   "web.admin.organizations.detail.entitlements.driftExtra": {
-    "text": "余分(実体化済み、期待外)",
+    "text": "余分 (実体化されているが期待されていない)",
     "source_hash": "08d60730"
   },
   "web.admin.organizations.detail.entitlements.driftMissing": {
-    "text": "不足(期待されるが未実体化)",
+    "text": "不足 (期待されているが実体化されていない)",
     "source_hash": "fe12c83a"
   },
   "web.admin.organizations.detail.entitlements.plan": {
-    "text": "プランから",
+    "text": "プラン由来",
     "source_hash": "1d346b26"
   },
   "web.admin.organizations.detail.entitlements.materialized": {
-    "text": "実体化済み(有効)",
+    "text": "実体化済み (実効)",
     "source_hash": "72ca5f45"
   },
   "web.admin.organizations.detail.members.email": {
@@ -116,31 +116,31 @@
     "source_hash": "b99c59dc"
   },
   "web.admin.organizations.detail.reconcile.button": {
-    "text": "調整",
+    "text": "整合",
     "source_hash": "b59be565"
   },
   "web.admin.organizations.detail.reconcile.confirmTitle": {
-    "text": "組織の請求を調整しますか?",
+    "text": "組織の請求情報を整合しますか？",
     "source_hash": "fc1a2762"
   },
   "web.admin.organizations.detail.reconcile.confirmDescription": {
-    "text": "これにより、Stripeを再取得し、{org}の請求状態とエンタイトルメントを書き換えます。確認のために組織IDを再入力してください。",
+    "text": "Stripeから再取得し、{org}の請求ステータスとエンタイトルメントを再書き込みします。確認のため、組織IDを再入力してください。",
     "source_hash": "b4ef0850"
   },
   "web.admin.organizations.detail.reconcile.success": {
-    "text": "組織を調整しました。",
+    "text": "組織が整合されました。",
     "source_hash": "caf87844"
   },
   "web.admin.organizations.detail.reconcile.resultTitle": {
-    "text": "調整結果",
+    "text": "整合結果",
     "source_hash": "11f4c6b8"
   },
   "web.admin.organizations.detail.reconcile.before": {
-    "text": "調整前",
+    "text": "変更前",
     "source_hash": "9bb72500"
   },
   "web.admin.organizations.detail.reconcile.after": {
-    "text": "調整後",
+    "text": "変更後",
     "source_hash": "7b68fe55"
   },
   "web.admin.organizations.detail.reconcile.materializedCount": {
@@ -168,11 +168,11 @@
     "source_hash": "ced67718"
   },
   "web.admin.organizations.detail.sections.investigate": {
-    "text": "調査と調整",
+    "text": "調査と整合",
     "source_hash": "b05aa349"
   },
   "web.admin.organizations.entitlements.section": {
-    "text": "エンタイトルメントの上書き",
+    "text": "エンタイトルメントのオーバーライド",
     "source_hash": "48812068"
   },
   "web.admin.organizations.entitlements.description": {
@@ -184,7 +184,7 @@
     "source_hash": "0d8f0b2d"
   },
   "web.admin.organizations.entitlements.placeholder": {
-    "text": "例:custom_domains",
+    "text": "例: custom_domains",
     "source_hash": "05346c68"
   },
   "web.admin.organizations.entitlements.grant": {
@@ -196,7 +196,7 @@
     "source_hash": "87e6d00b"
   },
   "web.admin.organizations.entitlements.clear": {
-    "text": "すべての上書きをクリア",
+    "text": "すべてのオーバーライドをクリア",
     "source_hash": "f0e485c3"
   },
   "web.admin.organizations.entitlements.effective": {
@@ -212,43 +212,43 @@
     "source_hash": "f0e69b17"
   },
   "web.admin.organizations.entitlements.noOverrides": {
-    "text": "この組織の現在の上書き状態を表示するには、操作を実行してください。",
+    "text": "この組織の現在のオーバーライド状態を表示するには、アクションを実行してください。",
     "source_hash": "98d2e30d"
   },
   "web.admin.organizations.entitlements.confirm.grantTitle": {
-    "text": "エンタイトルメントを付与しますか?",
+    "text": "エンタイトルメントを付与しますか？",
     "source_hash": "a4b2c57b"
   },
   "web.admin.organizations.entitlements.confirm.grantDescription": {
-    "text": "「{entitlement}」を{org}に付与します。これにより、組織の請求エンタイトルメントが変更されます。",
+    "text": "「{entitlement}」を{org}に付与します。これにより組織の請求エンタイトルメントが変更されます。",
     "source_hash": "542ce26a"
   },
   "web.admin.organizations.entitlements.confirm.revokeTitle": {
-    "text": "エンタイトルメントを取り消しますか?",
+    "text": "エンタイトルメントを取り消しますか？",
     "source_hash": "c93d520a"
   },
   "web.admin.organizations.entitlements.confirm.revokeDescription": {
-    "text": "「{entitlement}」を{org}から取り消します。これにより、組織の請求エンタイトルメントが変更されます。",
+    "text": "「{entitlement}」を{org}から取り消します。これにより組織の請求エンタイトルメントが変更されます。",
     "source_hash": "a5d2a8a6"
   },
   "web.admin.organizations.entitlements.confirm.clearTitle": {
-    "text": "すべてのエンタイトルメント上書きをクリアしますか?",
+    "text": "すべてのエンタイトルメントオーバーライドをクリアしますか？",
     "source_hash": "e36eb218"
   },
   "web.admin.organizations.entitlements.confirm.clearDescription": {
-    "text": "{org}のすべての付与および取り消しの上書きを削除し、プランのエンタイトルメントにリセットします。",
+    "text": "{org}のすべての付与および取り消しオーバーライドを削除し、プランのエンタイトルメントにリセットします。",
     "source_hash": "96bad079"
   },
   "web.admin.organizations.entitlements.success.granted": {
-    "text": "エンタイトルメント「{entitlement}」を付与しました。",
+    "text": "エンタイトルメント「{entitlement}」が付与されました。",
     "source_hash": "cf52fb0e"
   },
   "web.admin.organizations.entitlements.success.revoked": {
-    "text": "エンタイトルメント「{entitlement}」を取り消しました。",
+    "text": "エンタイトルメント「{entitlement}」が取り消されました。",
     "source_hash": "279d425d"
   },
   "web.admin.organizations.entitlements.success.cleared": {
-    "text": "すべてのエンタイトルメント上書きをクリアしました。",
+    "text": "すべてのエンタイトルメントオーバーライドがクリアされました。",
     "source_hash": "a482743b"
   },
   "web.admin.organizations.fields.contactEmail": {
@@ -264,15 +264,15 @@
     "source_hash": "fa8ed0bd"
   },
   "web.admin.organizations.fields.subscription": {
-    "text": "サブスクリプションのステータス",
+    "text": "サブスクリプション状態",
     "source_hash": "f0723c4e"
   },
   "web.admin.organizations.fields.periodEnd": {
-    "text": "期間終了日",
+    "text": "期間終了",
     "source_hash": "eeae9fdd"
   },
   "web.admin.organizations.fields.billingEmail": {
-    "text": "請求メール",
+    "text": "請求先メール",
     "source_hash": "8805b928"
   },
   "web.admin.organizations.fields.stripeCustomer": {
@@ -288,27 +288,355 @@
     "source_hash": "1f466322"
   },
   "web.admin.organizations.fields.created": {
-    "text": "作成日",
+    "text": "作成日時",
     "source_hash": "d70b9e24"
   },
   "web.admin.organizations.fields.updated": {
-    "text": "更新日",
+    "text": "更新日時",
     "source_hash": "3a5ecca1"
   },
   "web.admin.organizations.investigate.description": {
-    "text": "ローカルの請求状態を、公開中のStripeサブスクリプションと比較します。",
+    "text": "ローカルの請求状態とStripeサブスクリプションのライブ状態を比較します。",
     "source_hash": "d7bbe9ed"
   },
   "web.admin.organizations.investigate.rawPayload": {
-    "text": "調査の生ペイロード",
+    "text": "調査の生データペイロード",
     "source_hash": "29ca7df2"
   },
   "web.admin.organizations.investigate.parseError": {
-    "text": "調査のレスポンスが期待される形式と一致しませんでした。",
+    "text": "調査レスポンスが期待された形式と一致しませんでした。",
     "source_hash": "db59cab1"
   },
   "web.admin.organizations.list.loadError": {
     "text": "組織を読み込めませんでした。",
     "source_hash": "130d5e70"
+  },
+  "web.admin.organizations.addMember.button": {
+    "text": "既存のアカウントを追加",
+    "source_hash": "45a3b757"
+  },
+  "web.admin.organizations.addMember.title": {
+    "text": "既存のアカウントを追加",
+    "source_hash": "2f676a94"
+  },
+  "web.admin.organizations.addMember.description": {
+    "text": "すでにアカウントを持っている人を{org}に追加します。本人が自分で登録済みで、アカウントが存在するため招待できない場合にご利用ください。",
+    "source_hash": "bb41faa6"
+  },
+  "web.admin.organizations.addMember.searchLabel": {
+    "text": "メールアドレスまたはアカウントID",
+    "source_hash": "82b3040b"
+  },
+  "web.admin.organizations.addMember.searchPlaceholder": {
+    "text": "メールアドレスで検索",
+    "source_hash": "b75cc66c"
+  },
+  "web.admin.organizations.addMember.searchHint": {
+    "text": "メールアドレスの一部、または完全一致のアカウントIDで検索できます。",
+    "source_hash": "84547a60"
+  },
+  "web.admin.organizations.addMember.searchError": {
+    "text": "アカウントを検索できませんでした。接続を確認して、もう一度お試しください。",
+    "source_hash": "4b6caa41"
+  },
+  "web.admin.organizations.addMember.searchParseError": {
+    "text": "アカウント検索が想定外の応答を返しました。結果が不完全な可能性があります。",
+    "source_hash": "0c814231"
+  },
+  "web.admin.organizations.addMember.idle": {
+    "text": "アカウントを検索するにはメールアドレスを入力してください。",
+    "source_hash": "f6340d35"
+  },
+  "web.admin.organizations.addMember.noResults": {
+    "text": "「{term}」に一致するアカウントはありません。",
+    "source_hash": "199b662a"
+  },
+  "web.admin.organizations.addMember.noResultsHint": {
+    "text": "ここで追加できるのは既存のアカウントのみです。まだ登録していない場合は、招待してください。",
+    "source_hash": "ee90aeeb"
+  },
+  "web.admin.organizations.addMember.select": {
+    "text": "選択",
+    "source_hash": "2a78025d"
+  },
+  "web.admin.organizations.addMember.selectedEyebrow": {
+    "text": "選択したアカウント",
+    "source_hash": "8b63d947"
+  },
+  "web.admin.organizations.addMember.change": {
+    "text": "別のアカウントを選択",
+    "source_hash": "d4fe39ab"
+  },
+  "web.admin.organizations.addMember.createdOn": {
+    "text": "登録日 {date}",
+    "source_hash": "cfc0e19f"
+  },
+  "web.admin.organizations.addMember.organizationsUnavailable": {
+    "text": "このアカウントの現在の組織を読み込めませんでした。",
+    "source_hash": "a35b6bfc"
+  },
+  "web.admin.organizations.addMember.defaultOrg": {
+    "text": "既定",
+    "source_hash": "37a8eec1"
+  },
+  "web.admin.organizations.addMember.roleLabel": {
+    "text": "この組織でのロール",
+    "source_hash": "817475fa"
+  },
+  "web.admin.organizations.addMember.submit": {
+    "text": "組織に追加",
+    "source_hash": "0e0cb636"
+  },
+  "web.admin.organizations.addMember.success": {
+    "text": "{account}を{role}として追加しました。",
+    "source_hash": "533be0dc"
+  },
+  "web.admin.organizations.addMember.badges.verified": {
+    "text": "認証済み",
+    "source_hash": "4f783840"
+  },
+  "web.admin.organizations.addMember.badges.unverified": {
+    "text": "未認証",
+    "source_hash": "15133907"
+  },
+  "web.admin.organizations.addMember.badges.suspended": {
+    "text": "停止中",
+    "source_hash": "e392a389"
+  },
+  "web.admin.organizations.addMember.badges.alreadyMember": {
+    "text": "すでにメンバーです",
+    "source_hash": "1739ed7c"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMember": {
+    "text": "このアカウントはすでにこの組織のメンバーで、ロールは{role}です。追加しても既存のロールは変更されません — 変更するにはロール設定の操作をご利用ください。",
+    "source_hash": "cb6a4774"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMemberUnknownRole": {
+    "text": "このアカウントはすでにこの組織のメンバーです。追加しても既存のロールは変更されません。",
+    "source_hash": "035641ec"
+  },
+  "web.admin.organizations.addMember.errors.notFound": {
+    "text": "そのアカウントまたは組織はすでに存在しません。もう一度検索してアカウントをご確認ください。",
+    "source_hash": "bd88db18"
+  },
+  "web.admin.organizations.addMember.errors.invalidRole": {
+    "text": "そのロールは受け付けられませんでした。一覧にあるロールを選択して、もう一度お試しください。",
+    "source_hash": "eb696a8f"
+  },
+  "web.admin.organizations.addMember.errors.noSelection": {
+    "text": "アカウントが選択されていません。",
+    "source_hash": "dd15bb5b"
+  },
+  "web.admin.organizations.addMember.fields.created": {
+    "text": "登録日",
+    "source_hash": "486b3fe0"
+  },
+  "web.admin.organizations.addMember.fields.verified": {
+    "text": "認証",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.organizations.addMember.fields.lastLogin": {
+    "text": "最終ログイン",
+    "source_hash": "0b70af7a"
+  },
+  "web.admin.organizations.addMember.fields.organizations": {
+    "text": "現在の組織",
+    "source_hash": "cbb5b92f"
+  },
+  "web.admin.organizations.addMember.roleHints.member": {
+    "text": "組織のシークレットとドメインへの日常的なアクセス権。",
+    "source_hash": "d0c7439e"
+  },
+  "web.admin.organizations.addMember.roleHints.admin": {
+    "text": "メンバー、ドメイン、組織設定を管理できます。",
+    "source_hash": "beaa50d7"
+  },
+  "web.admin.organizations.addMember.roleHints.owner": {
+    "text": "請求を含むすべての権限。依頼があった場合のみ付与してください。",
+    "source_hash": "614ace63"
+  },
+  "web.admin.organizations.addMember.roles.member": {
+    "text": "メンバー",
+    "source_hash": "7c968fb7"
+  },
+  "web.admin.organizations.addMember.roles.admin": {
+    "text": "管理者",
+    "source_hash": "c1c224b0"
+  },
+  "web.admin.organizations.addMember.roles.owner": {
+    "text": "オーナー",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.detail.members.openCustomer": {
+    "text": "顧客レコードを開く",
+    "source_hash": "c057ca13"
+  },
+  "web.admin.organizations.detail.reconcile.memberships": {
+    "text": "再具体化されたメンバーシップ:",
+    "source_hash": "fe7db10c"
+  },
+  "web.admin.organizations.detail.reconcile.membershipsFailed": {
+    "text": "失敗、古いエンタイトルメントが残っています:",
+    "source_hash": "cc4dae37"
+  },
+  "web.admin.organizations.entitlements.catalogWarning": {
+    "text": "「{entitlement}」は請求カタログにありません。タイプミスがないか確認してください。続行します: 後のカタログで出荷されるエンタイトルメントの付与はサポートされており、意図的にブロックされていません。",
+    "source_hash": "cbde548a"
+  },
+  "web.admin.organizations.entitlements.matrix.caption": {
+    "text": "エンタイトルメント解決マトリックス: プラン、オーバーライドの付与と取り消し、解決済みセット、具体化されたもの。",
+    "source_hash": "9eac8999"
+  },
+  "web.admin.organizations.entitlements.matrix.yes": {
+    "text": "はい",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.matrix.no": {
+    "text": "いいえ",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.matrix.empty": {
+    "text": "この組織にはプランからのエンタイトルメントもオーバーライドもありません。",
+    "source_hash": "f6cf2169"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.entitlement": {
+    "text": "エンタイトルメント",
+    "source_hash": "0d8f0b2d"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.inPlan": {
+    "text": "プラン内",
+    "source_hash": "e2222361"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.granted": {
+    "text": "付与済み",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.revoked": {
+    "text": "取り消し済み",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.expected": {
+    "text": "期待値",
+    "source_hash": "ca99b7f1"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.materialized": {
+    "text": "具体化済み",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.state": {
+    "text": "状態",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.formula": {
+    "text": "解決: 期待値 = (プラン ∪ 付与) − 取り消し。具体化済みは組織に実際に保存されているものです。",
+    "source_hash": "bc4bff2d"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.orphaned": {
+    "text": "孤立 — 具体化されているが期待されていない、通常は再具体化されなかった取り消しによって残されたもの。整合で削除されます。",
+    "source_hash": "3a27a9af"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.missing": {
+    "text": "欠落 — 期待されているが具体化されていない。これは現在メンバーが実際に欠落している権限です。",
+    "source_hash": "485e44ad"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.revoked": {
+    "text": "取り消し線の行は管理者オーバーライドにより取り消されており、期待セットから削除されています。",
+    "source_hash": "89a2e9b6"
+  },
+  "web.admin.organizations.entitlements.matrix.state.plan": {
+    "text": "プランから",
+    "source_hash": "1d346b26"
+  },
+  "web.admin.organizations.entitlements.matrix.state.granted": {
+    "text": "付与済み",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.state.revoked": {
+    "text": "取り消し済み",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.state.orphaned": {
+    "text": "孤立",
+    "source_hash": "8d827807"
+  },
+  "web.admin.organizations.entitlements.matrix.state.missing": {
+    "text": "欠落",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.organizations.entitlements.picker.selectPlaceholder": {
+    "text": "エンタイトルメントを選択…",
+    "source_hash": "53af3be8"
+  },
+  "web.admin.organizations.entitlements.picker.other": {
+    "text": "その他 — カタログにないもの…",
+    "source_hash": "f08bc3a3"
+  },
+  "web.admin.organizations.entitlements.picker.customLabel": {
+    "text": "エンタイトルメント名（カタログにないもの）",
+    "source_hash": "52783229"
+  },
+  "web.admin.organizations.entitlements.picker.backToCatalog": {
+    "text": "カタログに戻る",
+    "source_hash": "9b727f40"
+  },
+  "web.admin.organizations.entitlements.picker.uncategorized": {
+    "text": "未分類",
+    "source_hash": "8d40d123"
+  },
+  "web.admin.organizations.entitlements.picker.catalogUnavailable": {
+    "text": "請求カタログを読み取れなかったため、ここではエンタイトルメント名はチェックされません。",
+    "source_hash": "724869ec"
+  },
+  "web.admin.organizations.entitlements.picker.tags.inPlan": {
+    "text": "プラン内",
+    "source_hash": "5f2251bb"
+  },
+  "web.admin.organizations.entitlements.picker.tags.granted": {
+    "text": "付与済み",
+    "source_hash": "dd515d19"
+  },
+  "web.admin.organizations.entitlements.picker.tags.revoked": {
+    "text": "取り消し済み",
+    "source_hash": "4bb47f18"
+  },
+  "web.admin.organizations.entitlements.summary.sync": {
+    "text": "同期",
+    "source_hash": "8d261a37"
+  },
+  "web.admin.organizations.entitlements.summary.materialized": {
+    "text": "具体化済み",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.summary.materializedAt": {
+    "text": "最終具体化日時",
+    "source_hash": "9325dce9"
+  },
+  "web.admin.organizations.entitlements.summary.planDefinition": {
+    "text": "プラン定義",
+    "source_hash": "6b531454"
+  },
+  "web.admin.organizations.entitlements.summary.yes": {
+    "text": "はい",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.summary.no": {
+    "text": "いいえ",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.summary.never": {
+    "text": "なし",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.organizations.entitlements.summary.planStale": {
+    "text": "具体化以降に変更あり",
+    "source_hash": "e682d8a4"
+  },
+  "web.admin.organizations.entitlements.summary.planCurrent": {
+    "text": "最新",
+    "source_hash": "e0d1b682"
+  },
+  "web.admin.organizations.entitlements.summary.planUnknown": {
+    "text": "不明 — 比較できませんでした",
+    "source_hash": "b607e540"
   }
 }

--- a/locales/content/ja/admin-overview.json
+++ b/locales/content/ja/admin-overview.json
@@ -8,7 +8,7 @@
     "source_hash": "cb7b24c6"
   },
   "web.admin.overview.feedback.total": {
-    "text": "過去30日間に{count}件",
+    "text": "過去30日間で{count}件",
     "source_hash": "b6b9147c"
   },
   "web.admin.overview.feedback.today": {
@@ -24,7 +24,7 @@
     "source_hash": "03281c88"
   },
   "web.admin.overview.feedback.empty": {
-    "text": "この期間のフィードバックはありません",
+    "text": "この期間にフィードバックはありません",
     "source_hash": "e09d594d"
   },
   "web.admin.overview.feedback.loadError": {
@@ -48,15 +48,15 @@
     "source_hash": "61ad9909"
   },
   "web.admin.overview.stats.receipts": {
-    "text": "受信確認",
+    "text": "受領証",
     "source_hash": "60a627df"
   },
   "web.admin.overview.stats.secretsCreated": {
-    "text": "作成されたシークレット(累計)",
+    "text": "作成されたシークレット（累計）",
     "source_hash": "bdb49794"
   },
   "web.admin.overview.stats.emailsSent": {
-    "text": "送信されたメール(累計)",
+    "text": "送信されたメール（累計）",
     "source_hash": "1c9a7518"
   },
   "web.admin.overview.stats.loadError": {
@@ -72,7 +72,7 @@
     "source_hash": "8db399dc"
   },
   "web.admin.overview.trends.secretsCreated": {
-    "text": "1日あたりのシークレット作成数",
+    "text": "1日あたりの作成シークレット数",
     "source_hash": "d6852656"
   },
   "web.admin.overview.trends.today": {
@@ -80,11 +80,11 @@
     "source_hash": "e0f4f767"
   },
   "web.admin.overview.trends.collectingNote": {
-    "text": "最初のデータポイントから収集しています。それ以前の日はゼロと表示されます。",
+    "text": "最初のデータポイント以降を収集 — それ以前の日はゼロと表示されます。",
     "source_hash": "269ee1eb"
   },
   "web.admin.overview.trends.sparklineAria": {
-    "text": "{label}:30日間のトレンド、今日{count}件",
+    "text": "{label}: 30日間のトレンド、今日は{count}",
     "source_hash": "eb57a7b2"
   },
   "web.admin.overview.trends.loadError": {

--- a/locales/content/ja/admin-secrets.json
+++ b/locales/content/ja/admin-secrets.json
@@ -1,11 +1,11 @@
 {
   "web.admin.secrets.title": {
-    "text": "シークレット",
-    "source_hash": "d8707d41"
+    "text": "シークレット受領証",
+    "source_hash": "a8a2d0e4"
   },
   "web.admin.secrets.description": {
-    "text": "SSHを使わずにシークレットの受信確認を検査し、削除できます。キーで検索してください。",
-    "source_hash": "07775a11"
+    "text": "状態、タイムスタンプ、受領証などを検索します。",
+    "source_hash": "91fba2a1"
   },
   "web.admin.secrets.never": {
     "text": "なし",
@@ -24,15 +24,15 @@
     "source_hash": "1a48c8c8"
   },
   "web.admin.secrets.actions.delete.confirmTitle": {
-    "text": "シークレットを削除しますか?",
+    "text": "シークレットを削除しますか？",
     "source_hash": "4a779a67"
   },
   "web.admin.secrets.actions.delete.confirmDescription": {
-    "text": "これにより、シークレット{shortid}とその受信確認が完全に削除されます。この操作は元に戻せません。",
+    "text": "シークレット{shortid}とその受領証が完全に削除されます。この操作は元に戻せません。",
     "source_hash": "51f807ad"
   },
   "web.admin.secrets.actions.delete.success": {
-    "text": "シークレットを削除しました。",
+    "text": "シークレットが削除されました。",
     "source_hash": "52f1640f"
   },
   "web.admin.secrets.detail.yes": {
@@ -52,7 +52,7 @@
     "source_hash": "79592419"
   },
   "web.admin.secrets.fields.shortId": {
-    "text": "短縮ID",
+    "text": "ショートID",
     "source_hash": "7eaeb4a7"
   },
   "web.admin.secrets.fields.state": {
@@ -60,11 +60,11 @@
     "source_hash": "a3b50c47"
   },
   "web.admin.secrets.fields.created": {
-    "text": "作成日",
+    "text": "作成日時",
     "source_hash": "d70b9e24"
   },
   "web.admin.secrets.fields.updated": {
-    "text": "更新日",
+    "text": "更新日時",
     "source_hash": "3a5ecca1"
   },
   "web.admin.secrets.fields.expiration": {
@@ -72,7 +72,7 @@
     "source_hash": "f38d6e0e"
   },
   "web.admin.secrets.fields.age": {
-    "text": "経過期間",
+    "text": "経過時間",
     "source_hash": "39b7370f"
   },
   "web.admin.secrets.fields.lifespan": {
@@ -80,11 +80,11 @@
     "source_hash": "58994285"
   },
   "web.admin.secrets.fields.owner": {
-    "text": "オーナー",
+    "text": "所有者",
     "source_hash": "4b1b8aa3"
   },
   "web.admin.secrets.fields.receiptId": {
-    "text": "受信確認ID",
+    "text": "受領証ID",
     "source_hash": "2c13d799"
   },
   "web.admin.secrets.fields.hasCiphertext": {
@@ -108,27 +108,27 @@
     "source_hash": "504101bc"
   },
   "web.admin.secrets.lookup.resultTitle": {
-    "text": "シークレット{shortid}",
-    "source_hash": "8b311d32"
+    "text": "シークレットレコード {shortid}",
+    "source_hash": "ee06d765"
   },
   "web.admin.secrets.lookup.notFound": {
-    "text": "シークレットが見つかりません",
-    "source_hash": "70a9532c"
+    "text": "レコードが見つかりません",
+    "source_hash": "40f4d9e9"
   },
   "web.admin.secrets.lookup.notFoundDescription": {
-    "text": "このキーのシークレットは存在しません。有効期限が切れたか、削除された可能性があります。",
+    "text": "このキーのシークレットは存在しません。期限切れまたは削除された可能性があります。",
     "source_hash": "9f068a81"
   },
   "web.admin.secrets.lookup.loadError": {
-    "text": "このシークレットを読み込めませんでした。",
-    "source_hash": "c96672e4"
+    "text": "このレコードを読み込めませんでした。",
+    "source_hash": "de77cc72"
   },
   "web.admin.secrets.lookup.retry": {
     "text": "再試行",
     "source_hash": "942087cc"
   },
   "web.admin.secrets.owner.anonymous": {
-    "text": "匿名(オーナーなし)",
+    "text": "匿名（所有者なし）",
     "source_hash": "390f11ad"
   },
   "web.admin.secrets.ownerFields.email": {
@@ -144,19 +144,19 @@
     "source_hash": "14736a2e"
   },
   "web.admin.secrets.ownerFields.verified": {
-    "text": "検証済み",
+    "text": "確認済み",
     "source_hash": "4f783840"
   },
   "web.admin.secrets.receipt.none": {
-    "text": "このシークレットに関連付けられた受信確認はありません。",
+    "text": "このシークレットに関連付けられた受領証はありません。",
     "source_hash": "5ddceaed"
   },
   "web.admin.secrets.receiptFields.receiptId": {
-    "text": "受信確認ID",
+    "text": "受領証ID",
     "source_hash": "2c13d799"
   },
   "web.admin.secrets.receiptFields.shortId": {
-    "text": "短縮ID",
+    "text": "ショートID",
     "source_hash": "7eaeb4a7"
   },
   "web.admin.secrets.receiptFields.state": {
@@ -164,7 +164,7 @@
     "source_hash": "a3b50c47"
   },
   "web.admin.secrets.receiptFields.secretTtl": {
-    "text": "シークレットのTTL",
+    "text": "シークレットTTL",
     "source_hash": "b89c0b51"
   },
   "web.admin.secrets.receiptFields.recipients": {
@@ -180,23 +180,23 @@
     "source_hash": "db963805"
   },
   "web.admin.secrets.receiptFields.created": {
-    "text": "作成日",
+    "text": "作成日時",
     "source_hash": "d70b9e24"
   },
   "web.admin.secrets.receiptFields.secretExpired": {
-    "text": "シークレットの有効期限切れ",
+    "text": "シークレット期限切れ",
     "source_hash": "c127dab6"
   },
   "web.admin.secrets.sections.secret": {
-    "text": "シークレット",
-    "source_hash": "7e32a729"
+    "text": "シークレットレコード",
+    "source_hash": "263813c6"
   },
   "web.admin.secrets.sections.receipt": {
-    "text": "受信確認",
+    "text": "受領証",
     "source_hash": "dad5a969"
   },
   "web.admin.secrets.sections.owner": {
-    "text": "オーナー",
+    "text": "所有者",
     "source_hash": "4b1b8aa3"
   },
   "web.admin.secrets.sections.raw": {
@@ -214,5 +214,25 @@
   "web.admin.secrets.state.viewed": {
     "text": "閲覧済み",
     "source_hash": "1b28d178"
+  },
+  "web.admin.secrets.capability.title": {
+    "text": "メタデータのみ",
+    "source_hash": "df0453d1"
+  },
+  "web.admin.secrets.capability.canRead": {
+    "text": "シークレットのメタデータと受領証を読み取ります: 状態、タイムスタンプ、所有者、保存された暗号文のサイズ。",
+    "source_hash": "d438ecc7"
+  },
+  "web.admin.secrets.capability.cannotRead": {
+    "text": "シークレットの内容を復号または表示することはできません。この画面のエンドポイントは内容を返しません。",
+    "source_hash": "7f69f222"
+  },
+  "web.admin.secrets.capability.canDelete": {
+    "text": "シークレットとその受領証を完全に削除できます。これにより内容が公開されることなく破棄されます。",
+    "source_hash": "77f2bc7e"
+  },
+  "web.admin.secrets.lookup.hint": {
+    "text": "シークレットリンクの識別子です。シークレットの内容ではありません。",
+    "source_hash": "acfbc352"
   }
 }

--- a/locales/content/ja/admin-sessions.json
+++ b/locales/content/ja/admin-sessions.json
@@ -4,7 +4,7 @@
     "source_hash": "6fa3cbf4"
   },
   "web.admin.sessions.description": {
-    "text": "インシデント対応のため、アクティブなセッションの検査、検索、取り消しを行います。",
+    "text": "インシデント対応のためにアクティブなセッションを検査、検索、取り消します。",
     "source_hash": "784a3a44"
   },
   "web.admin.sessions.anonymous": {
@@ -60,7 +60,7 @@
     "source_hash": "b764cdc0"
   },
   "web.admin.sessions.detail.noExpiry": {
-    "text": "有効期限なし",
+    "text": "期限なし",
     "source_hash": "fe06351d"
   },
   "web.admin.sessions.detail.expired": {
@@ -72,7 +72,7 @@
     "source_hash": "3c9d75ce"
   },
   "web.admin.sessions.drawer.title": {
-    "text": "セッション{id}",
+    "text": "セッション {id}",
     "source_hash": "29dcbd66"
   },
   "web.admin.sessions.drawer.notFound": {
@@ -80,7 +80,7 @@
     "source_hash": "0969eab8"
   },
   "web.admin.sessions.drawer.notFoundDescription": {
-    "text": "このセッションはRedisに存在しません。有効期限が切れたか、すでに取り消された可能性があります。",
+    "text": "このセッションはRedisに存在しません。期限切れまたはすでに取り消された可能性があります。",
     "source_hash": "11e3ef05"
   },
   "web.admin.sessions.drawer.loadError": {
@@ -136,11 +136,11 @@
     "source_hash": "8d6c9b01"
   },
   "web.admin.sessions.fields.authenticatedBy": {
-    "text": "認証した実行者",
+    "text": "認証方法",
     "source_hash": "3ebbabfe"
   },
   "web.admin.sessions.fields.activeSessionId": {
-    "text": "アクティブなセッションID",
+    "text": "アクティブセッションID",
     "source_hash": "f32b1158"
   },
   "web.admin.sessions.fields.userAgent": {
@@ -168,15 +168,15 @@
     "source_hash": "87e6d00b"
   },
   "web.admin.sessions.revoke.confirmTitle": {
-    "text": "このセッションを取り消しますか?",
+    "text": "このセッションを取り消しますか？",
     "source_hash": "0c6605c1"
   },
   "web.admin.sessions.revoke.confirmDescription": {
-    "text": "これにより、セッション{id}が削除され、ユーザーが直ちにログアウトされます。確認のためにセッションIDを入力してください。",
+    "text": "セッション{id}を削除することで、ユーザーを即座にログアウトさせます。確認のため、セッションIDを入力してください。",
     "source_hash": "9e08b1b8"
   },
   "web.admin.sessions.revoke.success": {
-    "text": "セッションを取り消しました",
+    "text": "セッションが取り消されました",
     "source_hash": "0af5e14d"
   },
   "web.admin.sessions.scan.summary": {
@@ -184,7 +184,7 @@
     "source_hash": "34cb67a4"
   },
   "web.admin.sessions.scan.capped": {
-    "text": "スキャンは最初の{scanned}件のキーで打ち切られました。このウィンドウを超える認証済みセッションは一覧に表示されません。特定のセッションにアクセスするには、IDで検査してください。",
+    "text": "スキャンは最初の{scanned}キーに制限されています。この範囲外の認証済みセッションはリストに表示されません。IDで特定のセッションを検査してアクセスしてください。",
     "source_hash": "fa418b4e"
   },
   "web.admin.sessions.search.placeholder": {

--- a/locales/content/ja/admin-system.json
+++ b/locales/content/ja/admin-system.json
@@ -4,7 +4,7 @@
     "source_hash": "6725e7bb"
   },
   "web.admin.system.description": {
-    "text": "データベース、キュー、インフラのステータス。",
+    "text": "データベース、キュー、インフラストラクチャのステータス。",
     "source_hash": "0115f495"
   },
   "web.admin.system.retry": {
@@ -12,7 +12,7 @@
     "source_hash": "942087cc"
   },
   "web.admin.system.database.title": {
-    "text": "メインデータベース({engine})",
+    "text": "メインデータベース ({engine})",
     "source_hash": "1391230b"
   },
   "web.admin.system.database.loadError": {
@@ -32,7 +32,7 @@
     "source_hash": "61d2afe2"
   },
   "web.admin.system.database.dbSummary": {
-    "text": "{keys}件のキー、うち{expires}件にTTL",
+    "text": "{keys}キー、{expires}にTTLあり",
     "source_hash": "26b9e17c"
   },
   "web.admin.system.database.fields.version": {
@@ -44,19 +44,19 @@
     "source_hash": "5e23ec6a"
   },
   "web.admin.system.database.fields.uptimeDays": {
-    "text": "稼働時間(日)",
+    "text": "稼働時間（日）",
     "source_hash": "7ab314f8"
   },
   "web.admin.system.database.fields.connectedClients": {
-    "text": "接続中のクライアント",
+    "text": "接続クライアント数",
     "source_hash": "434adc3a"
   },
   "web.admin.system.database.fields.opsPerSec": {
-    "text": "1秒あたりの操作数",
+    "text": "Ops/秒",
     "source_hash": "6634251d"
   },
   "web.admin.system.database.fields.totalCommands": {
-    "text": "コマンド総数",
+    "text": "総コマンド数",
     "source_hash": "c5ce5aaf"
   },
   "web.admin.system.database.fields.usedMemory": {
@@ -72,7 +72,7 @@
     "source_hash": "9d44afa6"
   },
   "web.admin.system.database.fields.fragmentation": {
-    "text": "断片化率",
+    "text": "フラグメンテーション率",
     "source_hash": "721494dd"
   },
   "web.admin.system.database.stats.customers": {
@@ -84,11 +84,11 @@
     "source_hash": "d8707d41"
   },
   "web.admin.system.database.stats.receipts": {
-    "text": "受信確認",
+    "text": "受領証",
     "source_hash": "60a627df"
   },
   "web.admin.system.database.stats.totalKeys": {
-    "text": "キー総数",
+    "text": "総キー数",
     "source_hash": "4e0d27f5"
   },
   "web.admin.system.queue.title": {
@@ -108,11 +108,11 @@
     "source_hash": "22965568"
   },
   "web.admin.system.queue.disconnected": {
-    "text": "切断済み",
+    "text": "切断",
     "source_hash": "04dfac36"
   },
   "web.admin.system.queue.activeWorkers": {
-    "text": "{count}件のアクティブなワーカー",
+    "text": "{count}アクティブワーカー",
     "source_hash": "49e6369c"
   },
   "web.admin.system.queue.columns.name": {
@@ -132,7 +132,7 @@
     "source_hash": "7f1e323b"
   },
   "web.admin.system.queue.health.degraded": {
-    "text": "低下",
+    "text": "劣化",
     "source_hash": "a8494c12"
   },
   "web.admin.system.queue.health.unhealthy": {
@@ -154,5 +154,133 @@
   "web.admin.system.redis.captured": {
     "text": "{at}に取得",
     "source_hash": "57b40c0f"
+  },
+  "web.admin.system.brand.title": {
+    "text": "ブランド診断",
+    "source_hash": "1cf9abd5"
+  },
+  "web.admin.system.brand.description": {
+    "text": "実行中のインスタンスがディスク上で解決したブランドパック — リージョンがニュートラルなブランディングを提供する理由を明らかにします。",
+    "source_hash": "be29e282"
+  },
+  "web.admin.system.brand.loadError": {
+    "text": "ブランド診断を読み込めませんでした。",
+    "source_hash": "80607303"
+  },
+  "web.admin.system.brand.none": {
+    "text": "(なし)",
+    "source_hash": "552e4230"
+  },
+  "web.admin.system.brand.resolution": {
+    "text": "解決",
+    "source_hash": "d4055faf"
+  },
+  "web.admin.system.brand.envVsConfig": {
+    "text": "環境 vs 設定",
+    "source_hash": "bee3debb"
+  },
+  "web.admin.system.brand.absorbed": {
+    "text": "吸収されたキー",
+    "source_hash": "9784e110"
+  },
+  "web.admin.system.brand.operatorKeys": {
+    "text": "オペレーターキー",
+    "source_hash": "434e8248"
+  },
+  "web.admin.system.brand.overlayAssets": {
+    "text": "オーバーレイアセット",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.exists.yes": {
+    "text": "あり",
+    "source_hash": "43f9b89c"
+  },
+  "web.admin.system.brand.exists.no": {
+    "text": "なし",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.system.brand.fields.resolvedDir": {
+    "text": "解決済みディレクトリ",
+    "source_hash": "0623b983"
+  },
+  "web.admin.system.brand.fields.home": {
+    "text": "ホーム",
+    "source_hash": "3a786953"
+  },
+  "web.admin.system.brand.fields.envPack": {
+    "text": "ENV ブランドパック",
+    "source_hash": "940aeb5c"
+  },
+  "web.admin.system.brand.fields.configPack": {
+    "text": "設定ブランドパック",
+    "source_hash": "761b9550"
+  },
+  "web.admin.system.brand.fields.envAssetsDir": {
+    "text": "ENV ブランドアセットディレクトリ",
+    "source_hash": "05854f1f"
+  },
+  "web.admin.system.brand.fields.configAssetsDir": {
+    "text": "設定ブランドアセットディレクトリ",
+    "source_hash": "e91e5c46"
+  },
+  "web.admin.system.brand.flags.fellBack.danger": {
+    "text": "デフォルトパックにフォールバック",
+    "source_hash": "7bf7ba2f"
+  },
+  "web.admin.system.brand.flags.fellBack.ok": {
+    "text": "ブランドパックが解決されました",
+    "source_hash": "1ab3162f"
+  },
+  "web.admin.system.brand.flags.mismatch.danger": {
+    "text": "起動時/ライブの不一致",
+    "source_hash": "0a022192"
+  },
+  "web.admin.system.brand.flags.mismatch.ok": {
+    "text": "起動時とライブが一致",
+    "source_hash": "d4792c09"
+  },
+  "web.admin.system.brand.manifest.title": {
+    "text": "マニフェスト",
+    "source_hash": "3c99f1f3"
+  },
+  "web.admin.system.brand.manifest.path": {
+    "text": "パス",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.manifest.exists": {
+    "text": "存在",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.manifest.keysOnDisk": {
+    "text": "ディスク上のキー",
+    "source_hash": "52439c03"
+  },
+  "web.admin.system.brand.roots.title": {
+    "text": "検索ルート",
+    "source_hash": "d8696f2b"
+  },
+  "web.admin.system.brand.roots.empty": {
+    "text": "検索ルートがありません",
+    "source_hash": "867a471c"
+  },
+  "web.admin.system.brand.roots.columns.path": {
+    "text": "パス",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.roots.columns.exists": {
+    "text": "存在",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.stats.brandPack": {
+    "text": "ブランドパック",
+    "source_hash": "884437d0"
+  },
+  "web.admin.system.brand.stats.overlayAssets": {
+    "text": "オーバーレイアセット",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.stats.manifestKeys": {
+    "text": "マニフェストキー",
+    "source_hash": "c4267198"
   }
 }

--- a/locales/content/ja/admin-usage.json
+++ b/locales/content/ja/admin-usage.json
@@ -4,7 +4,7 @@
     "source_hash": "8d59829c"
   },
   "web.admin.usage.description": {
-    "text": "指定した期間の使用状況メトリクスをエクスポートします。",
+    "text": "日付範囲の使用状況メトリクスをエクスポートします。",
     "source_hash": "97bd3325"
   },
   "web.admin.usage.startDate": {
@@ -28,19 +28,19 @@
     "source_hash": "942087cc"
   },
   "web.admin.usage.empty": {
-    "text": "この期間のデータはありません",
+    "text": "この範囲にデータがありません",
     "source_hash": "5fed1795"
   },
   "web.admin.usage.byState": {
-    "text": "状態別のシークレット",
+    "text": "状態別シークレット",
     "source_hash": "916bbcb6"
   },
   "web.admin.usage.secretsByDay": {
-    "text": "日別のシークレット",
+    "text": "日別シークレット",
     "source_hash": "24a01e8e"
   },
   "web.admin.usage.usersByDay": {
-    "text": "日別の新規ユーザー",
+    "text": "日別新規ユーザー",
     "source_hash": "8c1f089f"
   },
   "web.admin.usage.exportJson": {
@@ -68,11 +68,11 @@
     "source_hash": "d3ee48b0"
   },
   "web.admin.usage.stats.avgSecrets": {
-    "text": "1日あたりの平均シークレット数",
+    "text": "平均シークレット数/日",
     "source_hash": "948b0701"
   },
   "web.admin.usage.stats.avgUsers": {
-    "text": "1日あたりの平均ユーザー数",
+    "text": "平均ユーザー数/日",
     "source_hash": "491f626d"
   }
 }

--- a/locales/content/ja/api-account-errors.json
+++ b/locales/content/ja/api-account-errors.json
@@ -1,6 +1,6 @@
 {
   "api.account.errors.invalid_email": {
-    "text": "有効なメールアドレスを入力してください",
+    "text": "有効なメールアドレスですか？",
     "source_hash": "21d55b60"
   },
   "api.account.errors.password_too_short": {

--- a/locales/content/ja/api-domains-errors.json
+++ b/locales/content/ja/api-domains-errors.json
@@ -12,11 +12,11 @@
     "source_hash": "632afc93"
   },
   "api.domains.errors.incoming_secrets_disabled": {
-    "text": "このインスタンスでは受信シークレットが有効になっていません",
+    "text": "このインスタンスでは受信シークレットは有効になっていません",
     "source_hash": "45c0b5c4"
   },
   "api.domains.errors.incoming_secrets_entitlement_required": {
-    "text": "受信シークレットの管理にはincoming_secretsエンタイトルメントが必要です。プランをアップグレードしてください。",
+    "text": "受信シークレット管理にはincoming_secretsエンタイトルメントが必要です。プランをアップグレードしてください。",
     "source_hash": "1af54ec2"
   },
   "api.domains.errors.incoming_config_not_found": {
@@ -24,19 +24,19 @@
     "source_hash": "491644a8"
   },
   "api.domains.errors.recipients_max_exceeded": {
-    "text": "受信者は最大%{max}名まで指定できます",
+    "text": "受信者は最大%{max}人までです",
     "source_hash": "159842ad"
   },
   "api.domains.errors.recipients_invalid_email": {
-    "text": "無効なメールアドレス: %{email}",
+    "text": "無効なメール: %{email}",
     "source_hash": "e9c729c7"
   },
   "api.domains.errors.recipients_duplicate": {
-    "text": "受信者のメールアドレスを重複して指定することはできません",
+    "text": "重複する受信者メールは許可されていません",
     "source_hash": "6de22182"
   },
   "api.domains.errors.homepage_secrets_mode_invalid": {
-    "text": "無効なsecrets_mode:%{secrets_mode}",
+    "text": "無効なsecrets_mode: %{secrets_mode}",
     "source_hash": "cf093a04"
   },
   "api.domains.errors.homepage_incoming_entitlement_required": {
@@ -44,7 +44,7 @@
     "source_hash": "d68b13d8"
   },
   "api.domains.errors.homepage_incoming_not_ready": {
-    "text": "受信シークレットは、ホームページとして使用する前に、少なくとも1人の受信者を設定して有効にする必要があります。",
+    "text": "受信シークレットをホームページとして使用するには、少なくとも1人の受信者を設定して有効にする必要があります。",
     "source_hash": "556da6e2"
   }
 }

--- a/locales/content/ja/api-entitlements-errors.json
+++ b/locales/content/ja/api-entitlements-errors.json
@@ -1,6 +1,6 @@
 {
   "api.entitlements.errors.context_unavailable": {
-    "text": "エンタイトルメントを検証できません（組織のコンテキストが利用できません）",
+    "text": "エンタイトルメントを確認できません（組織コンテキストが利用できません）",
     "source_hash": "704dc629"
   },
   "api.entitlements.errors.api_access_required": {
@@ -8,11 +8,11 @@
     "source_hash": "844d294b"
   },
   "api.entitlements.errors.custom_privacy_defaults_required": {
-    "text": "カスタムプライバシーのデフォルト設定にはプランのアップグレードが必要です",
+    "text": "カスタムプライバシーデフォルトにはプランのアップグレードが必要です",
     "source_hash": "4e71274d"
   },
   "api.entitlements.errors.extended_default_expiration_required": {
-    "text": "デフォルト有効期限の延長にはプランのアップグレードが必要です",
+    "text": "延長されたデフォルト有効期限にはプランのアップグレードが必要です",
     "source_hash": "efa702e7"
   },
   "api.entitlements.errors.custom_domains_required": {
@@ -36,23 +36,23 @@
     "source_hash": "e058da13"
   },
   "api.entitlements.errors.flexible_from_domain_required": {
-    "text": "柔軟な送信元ドメインにはプランのアップグレードが必要です",
+    "text": "フレキシブルfrom-domainにはプランのアップグレードが必要です",
     "source_hash": "4931dc05"
   },
   "api.entitlements.errors.manage_org_required": {
-    "text": "組織の管理にはプランのアップグレードが必要です",
+    "text": "組織管理にはプランのアップグレードが必要です",
     "source_hash": "66a2cd10"
   },
   "api.entitlements.errors.manage_teams_required": {
-    "text": "チームの管理にはプランのアップグレードが必要です",
+    "text": "チーム管理にはプランのアップグレードが必要です",
     "source_hash": "f7f4062f"
   },
   "api.entitlements.errors.manage_members_required": {
-    "text": "メンバーの管理にはプランのアップグレードが必要です",
+    "text": "メンバー管理にはプランのアップグレードが必要です",
     "source_hash": "f73b80db"
   },
   "api.entitlements.errors.manage_sso_required": {
-    "text": "シングルサインオン (SSO) の管理にはプランのアップグレードが必要です",
+    "text": "SSO管理にはプランのアップグレードが必要です",
     "source_hash": "4e5da22d"
   },
   "api.entitlements.errors.audit_logs_required": {
@@ -64,11 +64,11 @@
     "source_hash": "93c9befa"
   },
   "api.entitlements.errors.create_secrets_required": {
-    "text": "シークレットの作成にはプランのアップグレードが必要です",
+    "text": "シークレット作成にはプランのアップグレードが必要です",
     "source_hash": "01091fed"
   },
   "api.entitlements.errors.view_receipt_required": {
-    "text": "受信確認の表示にはプランのアップグレードが必要です",
+    "text": "受領証の閲覧にはプランのアップグレードが必要です",
     "source_hash": "e6370d8c"
   },
   "api.entitlements.errors.notifications_required": {
@@ -84,7 +84,7 @@
     "source_hash": "3e1d276e"
   },
   "api.entitlements.errors.manage_billing_required": {
-    "text": "請求の管理にはプランのアップグレードが必要です",
+    "text": "請求管理にはプランのアップグレードが必要です",
     "source_hash": "dec5d6aa"
   },
   "api.entitlements.errors.custom_signin_config_required": {

--- a/locales/content/ja/api-feedback-errors.json
+++ b/locales/content/ja/api-feedback-errors.json
@@ -1,6 +1,6 @@
 {
   "api.feedback.errors.rate_limit_exceeded": {
-    "text": "フィードバックの送信回数が多すぎます。しばらくしてからもう一度お試しください。",
+    "text": "フィードバックの送信が多すぎます。しばらくしてからもう一度お試しください。",
     "source_hash": "3a890eb2"
   }
 }

--- a/locales/content/ja/api-invite-errors.json
+++ b/locales/content/ja/api-invite-errors.json
@@ -1,6 +1,6 @@
 {
   "api.invite.errors.invitation_not_found_or_expired": {
-    "text": "招待が見つからないか、有効期限が切れています",
+    "text": "招待が見つからないか期限切れです",
     "source_hash": "63657979"
   },
   "api.invite.errors.token_required": {
@@ -8,7 +8,7 @@
     "source_hash": "6c718161"
   },
   "api.invite.errors.organization_no_longer_exists": {
-    "text": "組織は存在しなくなりました",
+    "text": "組織は存在しません",
     "source_hash": "a5df7d22"
   },
   "api.invite.errors.invitation_already_processed": {
@@ -16,7 +16,7 @@
     "source_hash": "4cfedf4f"
   },
   "api.invite.errors.invitation_expired": {
-    "text": "招待の有効期限が切れています",
+    "text": "招待の期限が切れています",
     "source_hash": "7186297b"
   },
   "api.invite.errors.email_mismatch": {

--- a/locales/content/ja/api-organizations-errors.json
+++ b/locales/content/ja/api-organizations-errors.json
@@ -1,6 +1,6 @@
 {
   "api.organizations.errors.domain_scoped_forbidden": {
-    "text": "ドメインに限定されたメンバーはこの操作を実行できません",
+    "text": "ドメインスコープのメンバーはこのアクションを実行できません",
     "source_hash": "0a06a035"
   },
   "api.organizations.errors.organization_not_found": {
@@ -8,15 +8,15 @@
     "source_hash": "c8d058eb"
   },
   "api.organizations.errors.organization_owner_required": {
-    "text": "この操作を実行できるのは組織のオーナーのみです",
+    "text": "組織のオーナーのみがこのアクションを実行できます",
     "source_hash": "5a729e94"
   },
   "api.organizations.errors.organization_member_required": {
-    "text": "この操作を実行するには組織のメンバーである必要があります",
+    "text": "このアクションを実行するには組織のメンバーである必要があります",
     "source_hash": "f66f4a60"
   },
   "api.organizations.errors.organization_admin_required": {
-    "text": "この操作を実行できるのは組織のオーナーと管理者のみです",
+    "text": "組織のオーナーと管理者のみがこのアクションを実行できます",
     "source_hash": "cd9e8c0e"
   },
   "api.organizations.errors.extid_required": {
@@ -24,7 +24,7 @@
     "source_hash": "02fbe301"
   },
   "api.organizations.errors.display_name_required": {
-    "text": "組織名は必須です",
+    "text": "組織名が必要です",
     "source_hash": "c3f6e9af"
   },
   "api.organizations.errors.display_name_too_long": {
@@ -36,15 +36,15 @@
     "source_hash": "562b7250"
   },
   "api.organizations.errors.contact_email_exists": {
-    "text": "この連絡先メールアドレスの組織はすでに存在します",
+    "text": "この連絡先メールを持つ組織はすでに存在します",
     "source_hash": "e9fdce56"
   },
   "api.organizations.errors.creation_in_progress": {
-    "text": "組織を作成しています。もう一度お試しください。",
+    "text": "組織の作成が進行中です。もう一度お試しください。",
     "source_hash": "ef68bc2d"
   },
   "api.organizations.errors.organization_limit_reached": {
-    "text": "組織数の上限に達しました。さらに組織を作成するにはプランをアップグレードしてください。",
+    "text": "組織の上限に達しました。プランをアップグレードして、より多くの組織を作成してください。",
     "source_hash": "69e2e61b"
   },
   "api.organizations.invitations.errors.invitation_not_found": {
@@ -52,11 +52,11 @@
     "source_hash": "775ba9eb"
   },
   "api.organizations.invitations.errors.email_required": {
-    "text": "メールアドレスは必須です",
+    "text": "メールが必要です",
     "source_hash": "aae92911"
   },
   "api.organizations.invitations.errors.invalid_email_format": {
-    "text": "メールアドレスの形式が無効です",
+    "text": "無効なメール形式です",
     "source_hash": "0bcecf66"
   },
   "api.organizations.invitations.errors.invalid_role": {
@@ -72,23 +72,23 @@
     "source_hash": "8eb45780"
   },
   "api.organizations.invitations.errors.invitation_already_pending": {
-    "text": "このメールアドレス宛の招待はすでに保留中です",
+    "text": "このメールへの招待はすでに保留中です",
     "source_hash": "7f5e3093"
   },
   "api.organizations.invitations.errors.member_limit_reached": {
-    "text": "メンバー数の上限に達しました。さらにメンバーを招待するにはプランをアップグレードしてください。",
+    "text": "メンバーの上限に達しました。プランをアップグレードして、より多くのメンバーを招待してください。",
     "source_hash": "b8f316e8"
   },
   "api.organizations.invitations.errors.resend_only_pending": {
-    "text": "再送信できるのは保留中の招待のみです",
+    "text": "保留中の招待のみ再送信できます",
     "source_hash": "b7578b3e"
   },
   "api.organizations.invitations.errors.resend_limit_reached": {
-    "text": "再送信回数の上限(%{max})に達しました",
+    "text": "再送信の上限（%{max}）に達しました",
     "source_hash": "8dc96729"
   },
   "api.organizations.invitations.errors.revoke_only_pending": {
-    "text": "取り消せるのは保留中の招待のみです",
+    "text": "保留中の招待のみ取り消しできます",
     "source_hash": "732b78a6"
   },
   "api.organizations.members.errors.member_not_found": {
@@ -100,7 +100,7 @@
     "source_hash": "dcab71ff"
   },
   "api.organizations.members.errors.member_not_active": {
-    "text": "メンバーは有効ではありません",
+    "text": "メンバーはアクティブではありません",
     "source_hash": "a51b8760"
   },
   "api.organizations.members.errors.invalid_role_value": {
@@ -108,15 +108,15 @@
     "source_hash": "c3331aa0"
   },
   "api.organizations.members.errors.cannot_change_owner_role": {
-    "text": "オーナーのロールは変更できません。代わりに所有権の譲渡を使用してください。",
+    "text": "オーナーのロールは変更できません。代わりに所有権の移転を使用してください。",
     "source_hash": "76015424"
   },
   "api.organizations.members.errors.member_already_has_role": {
-    "text": "メンバーはすでに次のロールを持っています: %{role}",
+    "text": "メンバーはすでにロールを持っています: %{role}",
     "source_hash": "6771166a"
   },
   "api.organizations.members.errors.cannot_promote_to_owner": {
-    "text": "オーナーに昇格させることはできません。代わりに所有権の譲渡を使用してください。",
+    "text": "オーナーに昇格することはできません。代わりに所有権の移転を使用してください。",
     "source_hash": "cd574007"
   },
   "api.organizations.members.errors.must_be_member": {
@@ -124,15 +124,15 @@
     "source_hash": "de1c77b8"
   },
   "api.organizations.members.errors.cannot_remove_owner": {
-    "text": "組織のオーナーは削除できません。先に所有権を譲渡してください。",
+    "text": "組織のオーナーを削除することはできません。先に所有権を移転してください。",
     "source_hash": "d4f33003"
   },
   "api.organizations.members.errors.cannot_remove_self": {
-    "text": "自分自身を削除することはできません。代わりに組織からの退出を使用してください。",
+    "text": "自分自身を削除することはできません。代わりに組織を退出してください。",
     "source_hash": "d64cec91"
   },
   "api.organizations.members.errors.admin_cannot_remove_admin": {
-    "text": "管理者は他の管理者を削除できません。オーナーのみが削除できます。",
+    "text": "管理者は他の管理者を削除できません。オーナーのみが可能です。",
     "source_hash": "2b3e6e30"
   },
   "api.organizations.members.errors.no_permission_to_remove": {

--- a/locales/content/ja/api-secrets-errors.json
+++ b/locales/content/ja/api-secrets-errors.json
@@ -1,18 +1,18 @@
 {
   "api.secrets.errors.domain_permission_authenticated_non_owner": {
-    "text": "このドメインを使用する権限がありません: %{domain}",
+    "text": "ドメインを使用する権限がありません: %{domain}",
     "source_hash": "b41920ba"
   },
   "api.secrets.errors.domain_public_sharing_disabled": {
-    "text": "このドメインでは公開共有が無効になっています: %{domain}",
+    "text": "このドメインでは公開共有が無効です: %{domain}",
     "source_hash": "b15efec8"
   },
   "api.secrets.errors.domain_permission_anonymous_cross_domain": {
-    "text": "このドメインを使用する権限がありません: %{domain}",
+    "text": "ドメインを使用する権限がありません: %{domain}",
     "source_hash": "b41920ba"
   },
   "api.secrets.errors.secret_undecryptable": {
-    "text": "このシークレットは現在復号できません。リンクは有効なままです。表示するには、サイト運営者が暗号化キーを復元する必要があります。",
+    "text": "このシークレットは現在復号できません。リンクはまだ有効ですが、公開するにはサイト運営者が暗号化キーを復元する必要があります。",
     "source_hash": "56e283ee"
   }
 }

--- a/locales/content/ja/email.json
+++ b/locales/content/ja/email.json
@@ -10,7 +10,7 @@
     "source_hash": "9c965ab8"
   },
   "email.secret_link.subject": {
-    "text": "%{sender_email}からシークレットが届きました",
+    "text": "%{sender_email}がシークレットを送信しました",
     "renderer": "erb",
     "source_hash": "3156abde"
   },
@@ -25,32 +25,32 @@
     "source_hash": "496d6960"
   },
   "email.secret_link.link_works_once": {
-    "text": "このリンクは1回のみ有効です。閲覧後、シークレットは完全に削除されます。",
+    "text": "このリンクは1回のみ有効です。表示後、シークレットは完全に削除されます。",
     "renderer": "erb",
     "source_hash": "fecaf0a1"
   },
   "email.secret_link.sent_via": {
-    "text": "経由",
+    "text": "送信元",
     "renderer": "erb",
     "source_hash": "d01479b3"
   },
   "email.welcome.subject": {
-    "text": "%{product_name}へようこそ - メールアドレスを認証してください",
+    "text": "%{product_name}へようこそ - メールを確認してください",
     "renderer": "erb",
     "source_hash": "96008c17"
   },
   "email.welcome.title": {
-    "text": "%{product_name}へようこそ!",
+    "text": "%{product_name}へようこそ！",
     "renderer": "erb",
     "source_hash": "77e7dda4"
   },
   "email.welcome.verify_prompt": {
-    "text": "下のリンクをクリックして、メールアドレスを認証してください:",
+    "text": "下のリンクをクリックしてメールアドレスを確認してください:",
     "renderer": "erb",
     "source_hash": "e373dcee"
   },
   "email.welcome.verify_button": {
-    "text": "メールアドレスを認証",
+    "text": "メールアドレスを確認",
     "renderer": "erb",
     "source_hash": "d261b9df"
   },
@@ -65,12 +65,12 @@
     "source_hash": "dc75bf9f"
   },
   "email.welcome.postscript": {
-    "text": "追伸: このメールは%{email_address}宛に送信されました。アカウントを作成していない場合は、このメッセージを無視してください。",
+    "text": "追伸: このメールは%{email_address}に送信されました。アカウントを作成していない場合は、このメッセージを無視しても問題ありません。",
     "renderer": "erb",
     "source_hash": "05709148"
   },
   "email.password_request.subject": {
-    "text": "パスワードをリセット (%{display_domain})",
+    "text": "パスワードをリセット（%{display_domain}）",
     "renderer": "erb",
     "source_hash": "a9882af1"
   },
@@ -80,7 +80,7 @@
     "source_hash": "0568c7b0"
   },
   "email.password_request.request_notice": {
-    "text": "%{product_name}のパスワードリセットのリクエストを受け付けました。",
+    "text": "%{product_name}のパスワードリセットのリクエストを受け取りました。",
     "renderer": "erb",
     "source_hash": "4ad3b5cd"
   },
@@ -95,7 +95,7 @@
     "source_hash": "88c72144"
   },
   "email.password_request.ignore_notice": {
-    "text": "パスワードリセットをリクエストしていない場合は、このメールを無視してください。",
+    "text": "パスワードリセットをリクエストしていない場合は、このメールを無視しても問題ありません。",
     "renderer": "erb",
     "source_hash": "fbb7eb2d"
   },
@@ -105,27 +105,27 @@
     "source_hash": "dc75bf9f"
   },
   "email.password_request.postscript": {
-    "text": "追伸: このメールは%{email_address}宛に送信されました。",
+    "text": "追伸: このメールは%{email_address}に送信されました。",
     "renderer": "erb",
     "source_hash": "8ab1dbea"
   },
   "email.magic_link.subject": {
-    "text": "%{display_domain}にログイン",
+    "text": "%{display_domain}にサインイン",
     "renderer": "erb",
     "source_hash": "2967293e"
   },
   "email.magic_link.title": {
-    "text": "マジックリンクでログイン",
+    "text": "マジックリンクでサインイン",
     "renderer": "erb",
     "source_hash": "0b84879b"
   },
   "email.magic_link.request_notice": {
-    "text": "%{product_name}アカウントへのログインリンクのリクエストがありました。",
+    "text": "%{product_name}アカウントのログインリンクをリクエストしました。",
     "renderer": "erb",
     "source_hash": "3a34aa1f"
   },
   "email.magic_link.login_button": {
-    "text": "ログイン",
+    "text": "サインイン",
     "renderer": "erb",
     "source_hash": "bcc0bcc9"
   },
@@ -135,12 +135,12 @@
     "source_hash": "88c72144"
   },
   "email.magic_link.expiration_notice": {
-    "text": "このリンクは15分で期限切れになります。",
+    "text": "このリンクは15分後に期限切れになります。",
     "renderer": "erb",
     "source_hash": "a6967fa7"
   },
   "email.magic_link.ignore_notice": {
-    "text": "このリンクをリクエストしていない場合は、このメールを無視してください。",
+    "text": "このリンクをリクエストしていない場合は、このメールを無視しても問題ありません。",
     "renderer": "erb",
     "source_hash": "1863f5be"
   },
@@ -150,7 +150,7 @@
     "source_hash": "dc75bf9f"
   },
   "email.magic_link.postscript": {
-    "text": "追伸: このメールは%{email_address}宛に送信されました。",
+    "text": "追伸: このメールは%{email_address}に送信されました。",
     "renderer": "erb",
     "source_hash": "8ab1dbea"
   },
@@ -170,7 +170,7 @@
     "source_hash": "8bab5066"
   },
   "email.incoming_secret.someone_sent": {
-    "text": "%{display_domain}を通じて安全なメッセージが送信されました。",
+    "text": "誰かが%{display_domain}を通じて安全なメッセージを送信しました。",
     "renderer": "erb",
     "source_hash": "12ac0a81"
   },
@@ -185,22 +185,22 @@
     "source_hash": "496d6960"
   },
   "email.incoming_secret.link_works_once": {
-    "text": "このリンクは1回のみ有効です。閲覧後、シークレットは完全に削除されます。",
+    "text": "このリンクは1回のみ有効です。表示後、シークレットは完全に削除されます。",
     "renderer": "erb",
     "source_hash": "fecaf0a1"
   },
   "email.incoming_secret.passphrase_required": {
-    "text": "このシークレットはパスフレーズで保護されています。送信者から別途パスフレーズを受け取ってください。",
+    "text": "このシークレットはパスフレーズで保護されています。送信者が別途お知らせします。",
     "renderer": "erb",
     "source_hash": "1e49826b"
   },
   "email.incoming_secret.passphrase_label": {
-    "text": "パスフレーズが必要です:",
+    "text": "パスフレーズが必要:",
     "renderer": "erb",
     "source_hash": "1ab9a20f"
   },
   "email.incoming_secret.sent_via": {
-    "text": "経由",
+    "text": "送信元",
     "renderer": "erb",
     "source_hash": "d01479b3"
   },
@@ -215,7 +215,7 @@
     "source_hash": "6a530d71"
   },
   "email.secret_revealed.viewed_on": {
-    "text": "シークレットは%{date}に閲覧されました。",
+    "text": "シークレットが%{date}に閲覧されました。",
     "renderer": "erb",
     "source_hash": "6a3d346c"
   },
@@ -225,7 +225,7 @@
     "source_hash": "ab567438"
   },
   "email.secret_revealed.automated_notice": {
-    "text": "これは自動通知です。対応は不要です。",
+    "text": "これは自動通知です。対応は必要ありません。",
     "renderer": "erb",
     "source_hash": "3f6b45dd"
   },
@@ -270,12 +270,12 @@
     "source_hash": "deb92a01"
   },
   "email.expiration_warning.sent_via": {
-    "text": "経由",
+    "text": "送信元",
     "renderer": "erb",
     "source_hash": "d01479b3"
   },
   "email.expiration_warning.view_before_gone": {
-    "text": "消える前に確認してください:",
+    "text": "なくなる前に表示してください:",
     "renderer": "erb",
     "source_hash": "30342c04"
   },
@@ -285,7 +285,7 @@
     "source_hash": "bd0a9bee"
   },
   "email.feedback_email.subject": {
-    "text": "%{display_domain}からのフィードバック (%{date}) (%{strategy})",
+    "text": "%{date}のフィードバック（%{display_domain}経由、%{strategy}）",
     "renderer": "erb",
     "source_hash": "f7498c8b"
   },
@@ -295,7 +295,7 @@
     "source_hash": "47296999"
   },
   "email.feedback_email.from_label": {
-    "text": "送信元:",
+    "text": "送信者:",
     "renderer": "erb",
     "source_hash": "dc45d36f"
   },
@@ -305,7 +305,7 @@
     "source_hash": "a4c7de06"
   },
   "email.feedback_email.strategy_label": {
-    "text": "戦略:",
+    "text": "ストラテジー:",
     "renderer": "erb",
     "source_hash": "8132ec6b"
   },
@@ -315,22 +315,22 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Onetime Secret サポートチーム",
+    "text": "Secret Support",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },
   "email.organization_invitation.subject": {
-    "text": "%{organization_name}への招待",
+    "text": "%{organization_name}への参加に招待されました",
     "renderer": "erb",
     "source_hash": "58591e00"
   },
   "email.organization_invitation.title": {
-    "text": "%{organization_name}への招待を受けました!",
+    "text": "%{organization_name}への参加に招待されました！",
     "renderer": "erb",
     "source_hash": "19548dfd"
   },
   "email.organization_invitation.body": {
-    "text": "%{inviter_email}から「%{organization_name}」に%{role_description}として招待されました。",
+    "text": "%{inviter_email}があなたを「%{organization_name}」に%{role_description}として招待しました。",
     "renderer": "erb",
     "source_hash": "e4d3fb65"
   },
@@ -350,7 +350,7 @@
     "source_hash": "dabc54d5"
   },
   "email.organization_invitation.decline_instruction": {
-    "text": "参加を希望しない場合は、このメールを無視するか、招待を辞退してください。",
+    "text": "参加したくない場合は、このメールを無視するか、招待を辞退してください。",
     "renderer": "erb",
     "source_hash": "734882d2"
   },
@@ -360,7 +360,7 @@
     "source_hash": "dc75bf9f"
   },
   "email.organization_invitation.postscript": {
-    "text": "追伸: このメールは%{invited_email}宛に送信されました。この招待に心当たりがない場合は、このメッセージを無視してください。",
+    "text": "追伸: このメールは%{invited_email}に送信されました。この招待に心当たりがない場合は、このメッセージを無視しても問題ありません。",
     "renderer": "erb",
     "source_hash": "608e2b40"
   },
@@ -375,7 +375,7 @@
     "source_hash": "603fd5c3"
   },
   "email.password_changed.subject": {
-    "text": "パスワードが変更されました (%{display_domain})",
+    "text": "パスワードが変更されました（%{display_domain}）",
     "renderer": "erb",
     "source_hash": "b030deff"
   },
@@ -390,7 +390,7 @@
     "source_hash": "21f5117c"
   },
   "email.password_changed.security_notice": {
-    "text": "この変更を行っていない場合は、すぐにパスワードをリセットし、サポートに連絡してアカウントを保護してください。",
+    "text": "この変更をしていない場合は、パスワードをリセットしてサポートに連絡し、すぐにアカウントを保護してください。",
     "renderer": "erb",
     "source_hash": "be92cff3"
   },
@@ -400,7 +400,7 @@
     "source_hash": "dc75bf9f"
   },
   "email.email_changed.subject": {
-    "text": "メールアドレスが変更されました(%{display_domain})",
+    "text": "メールアドレスが変更されました（%{display_domain}）",
     "renderer": "erb",
     "source_hash": "4386fc57"
   },
@@ -410,7 +410,7 @@
     "source_hash": "db70f965"
   },
   "email.email_changed.security_notice": {
-    "text": "この変更を行っていない場合は、アカウントが侵害されている可能性がありますので、すぐにサポートにご連絡ください。",
+    "text": "この変更をしていない場合は、アカウントが侵害されている可能性がありますので、すぐにサポートにご連絡ください。",
     "renderer": "erb",
     "source_hash": "f505b562"
   },
@@ -420,7 +420,7 @@
     "source_hash": "7fc0e27c"
   },
   "email.email_changed.new_email_label": {
-    "text": "新しいメールアドレス:",
+    "text": "新しいメール:",
     "renderer": "erb",
     "source_hash": "0161371a"
   },
@@ -430,12 +430,12 @@
     "source_hash": "f4a9cdda"
   },
   "email.email_changed.if_you_initiated": {
-    "text": "この変更をご自身で行った場合、追加の操作は必要ありません。",
+    "text": "この変更をした場合は、これ以上の操作は必要ありません。",
     "renderer": "erb",
     "source_hash": "5cb54887"
   },
   "email.email_changed.not_you_notice": {
-    "text": "この変更に心当たりがない場合、アカウントが不正アクセスを受けている可能性があります。",
+    "text": "この変更をしていない場合は、アカウントが侵害されている可能性があります。",
     "renderer": "erb",
     "source_hash": "08f479fb"
   },
@@ -450,17 +450,17 @@
     "source_hash": "dc75bf9f"
   },
   "email.email_changed.postscript": {
-    "text": "追伸: このメールはメールアドレスの変更をお知らせするために%{email_address}宛てに送信されました。",
+    "text": "追伸: このメールはメールアドレス変更の通知のため%{email_address}に送信されました。",
     "renderer": "erb",
     "source_hash": "475cae37"
   },
   "email.email_change_requested.subject": {
-    "text": "メールアドレス変更のリクエスト (%{display_domain})",
+    "text": "メール変更がリクエストされました（%{display_domain}）",
     "renderer": "erb",
     "source_hash": "be3441d6"
   },
   "email.email_change_requested.title": {
-    "text": "メールアドレス変更のリクエスト",
+    "text": "メール変更リクエスト",
     "renderer": "erb",
     "source_hash": "704cbdca"
   },
@@ -470,7 +470,7 @@
     "source_hash": "d7e39154"
   },
   "email.email_change_requested.new_email_label": {
-    "text": "リクエストされた新しいメールアドレス:",
+    "text": "リクエストされた新しいメール:",
     "renderer": "erb",
     "source_hash": "243f3e03"
   },
@@ -480,12 +480,12 @@
     "source_hash": "ada23c51"
   },
   "email.email_change_requested.if_you_initiated": {
-    "text": "このリクエストをされた場合は、新しいメールアドレスに届く確認リンクをご確認ください。まだ変更は行われていません。",
+    "text": "このリクエストをした場合は、新しいメールに確認リンクが届いているか確認してください。まだ変更は行われていません。",
     "renderer": "erb",
     "source_hash": "aa1bf526"
   },
   "email.email_change_requested.not_you_notice": {
-    "text": "このリクエストに覚えがない場合は、このメールを無視していただいて問題ありません。アカウントは変更されていません。",
+    "text": "このリクエストをしていない場合は、このメールを無視しても問題ありません。アカウントは変更されていません。",
     "renderer": "erb",
     "source_hash": "ff41a7b7"
   },
@@ -500,27 +500,27 @@
     "source_hash": "dc75bf9f"
   },
   "email.email_change_requested.postscript": {
-    "text": "追伸: このメールは、アカウントのメールアドレス変更がリクエストされたため、%{email_address}宛てに送信されました。",
+    "text": "追伸: このメールはアカウントのメール変更がリクエストされたため%{email_address}に送信されました。",
     "renderer": "erb",
     "source_hash": "500e085e"
   },
   "email.email_change_confirmation.subject": {
-    "text": "新しいメールアドレスを認証してください (%{display_domain})",
+    "text": "新しいメールアドレスを確認してください（%{display_domain}）",
     "renderer": "erb",
     "source_hash": "6caae414"
   },
   "email.email_change_confirmation.title": {
-    "text": "新しいメールアドレスを認証",
+    "text": "新しいメールアドレスを確認",
     "renderer": "erb",
     "source_hash": "0ec73977"
   },
   "email.email_change_confirmation.body": {
-    "text": "%{product_name}アカウントの変更を完了するために、このメールアドレスを認証してください。",
+    "text": "%{product_name}アカウントの変更を完了するため、このメールアドレスを確認してください。",
     "renderer": "erb",
     "source_hash": "4df742ab"
   },
   "email.email_change_confirmation.verify_button": {
-    "text": "メールアドレスを認証",
+    "text": "メールアドレスを確認",
     "renderer": "erb",
     "source_hash": "d261b9df"
   },
@@ -530,7 +530,7 @@
     "source_hash": "33277e1b"
   },
   "email.email_change_confirmation.confirm_button": {
-    "text": "メールアドレス変更を確認",
+    "text": "メール変更を確認",
     "renderer": "erb",
     "source_hash": "c2736949"
   },
@@ -545,7 +545,7 @@
     "source_hash": "e744f5a7"
   },
   "email.email_change_confirmation.ignore_notice": {
-    "text": "この変更をリクエストしていない場合、このメールは無視して問題ありません。メールアドレスは変更されません。",
+    "text": "この変更をリクエストしていない場合は、このメールを無視しても問題ありません。メールアドレスは変更されません。",
     "renderer": "erb",
     "source_hash": "d4d835fc"
   },
@@ -555,27 +555,27 @@
     "source_hash": "dc75bf9f"
   },
   "email.email_change_confirmation.postscript": {
-    "text": "追伸: このメールはメールアドレスの変更を確認するために%{email_address}宛てに送信されました。",
+    "text": "追伸: このメールはメールアドレス変更の確認のため%{email_address}に送信されました。",
     "renderer": "erb",
     "source_hash": "b72f557c"
   },
   "email.mfa_enabled.subject": {
-    "text": "二要素認証が有効になりました (%{display_domain})",
+    "text": "二要素認証が有効化されました（%{display_domain}）",
     "renderer": "erb",
     "source_hash": "c067e466"
   },
   "email.mfa_enabled.title": {
-    "text": "二要素認証が有効になりました",
+    "text": "二要素認証が有効化されました",
     "renderer": "erb",
     "source_hash": "2398ed9e"
   },
   "email.mfa_enabled.body": {
-    "text": "%{product_name}アカウントの二要素認証が%{date}に有効になりました。",
+    "text": "%{product_name}アカウントの二要素認証が%{date}に有効化されました。",
     "renderer": "erb",
     "source_hash": "9f6be43f"
   },
   "email.mfa_enabled.security_notice": {
-    "text": "アカウントのセキュリティが向上しました。ログイン時に認証アプリから確認コードを入力する必要があります。",
+    "text": "アカウントのセキュリティが向上しました。サインイン時に認証アプリから確認コードを入力する必要があります。",
     "renderer": "erb",
     "source_hash": "e7c11bb0"
   },
@@ -585,22 +585,22 @@
     "source_hash": "dc75bf9f"
   },
   "email.mfa_disabled.subject": {
-    "text": "二要素認証が無効になりました (%{display_domain})",
+    "text": "二要素認証が無効化されました（%{display_domain}）",
     "renderer": "erb",
     "source_hash": "228a686a"
   },
   "email.mfa_disabled.title": {
-    "text": "二要素認証が無効になりました",
+    "text": "二要素認証が無効化されました",
     "renderer": "erb",
     "source_hash": "372d577a"
   },
   "email.mfa_disabled.body": {
-    "text": "%{product_name}アカウントの二要素認証が%{date}に無効になりました。",
+    "text": "%{product_name}アカウントの二要素認証が%{date}に無効化されました。",
     "renderer": "erb",
     "source_hash": "0248389d"
   },
   "email.mfa_disabled.warning_notice": {
-    "text": "アカウントのセキュリティが低下しています。この変更を行っていない場合は、すぐにアカウントを保護してください。",
+    "text": "アカウントのセキュリティが低下しました。この変更をしていない場合は、すぐにアカウントを保護してください。",
     "renderer": "erb",
     "source_hash": "97ef0a3e"
   },
@@ -610,17 +610,17 @@
     "source_hash": "dc75bf9f"
   },
   "email.new_login_alert.subject": {
-    "text": "アカウントへの新しいログイン (%{display_domain})",
+    "text": "アカウントへの新しいサインイン（%{display_domain}）",
     "renderer": "erb",
     "source_hash": "a704f0bb"
   },
   "email.new_login_alert.title": {
-    "text": "新しいログインが検出されました",
+    "text": "新しいサインインを検出",
     "renderer": "erb",
     "source_hash": "61172ee4"
   },
   "email.new_login_alert.body": {
-    "text": "%{product_name}アカウントへの新しいログインが%{date} %{time}に検出されました。",
+    "text": "%{product_name}アカウントへの新しいサインインが%{date} %{time}に検出されました。",
     "renderer": "erb",
     "source_hash": "040f8f48"
   },
@@ -640,12 +640,12 @@
     "source_hash": "a2cb73e4"
   },
   "email.new_login_alert.not_you_notice": {
-    "text": "これがあなたではない場合、アカウントが侵害されている可能性があります。",
+    "text": "心当たりがない場合は、アカウントが侵害されている可能性があります。",
     "renderer": "erb",
     "source_hash": "e2f819c9"
   },
   "email.new_login_alert.secure_account_button": {
-    "text": "アカウントを保護する",
+    "text": "アカウントを保護",
     "renderer": "erb",
     "source_hash": "450c54c5"
   },
@@ -675,17 +675,17 @@
     "source_hash": "dc75bf9f"
   },
   "email.role_changed.subject": {
-    "text": "%{organization_name}でのあなたの役割が変更されました",
+    "text": "%{organization_name}でのロールが変更されました",
     "renderer": "erb",
     "source_hash": "f987a7ad"
   },
   "email.role_changed.title": {
-    "text": "あなたの役割が変更されました",
+    "text": "ロールが変更されました",
     "renderer": "erb",
     "source_hash": "8f892809"
   },
   "email.role_changed.body": {
-    "text": "「%{organization_name}」でのあなたの役割が%{old_role}から%{new_role}に変更されました。",
+    "text": "「%{organization_name}」でのロールが%{old_role}から%{new_role}に変更されました。",
     "renderer": "erb",
     "source_hash": "c2280c0c"
   },
@@ -715,7 +715,7 @@
     "source_hash": "dc75bf9f"
   },
   "email.trial_expiring.subject": {
-    "text": "%{product_name}のトライアルがあと%{days_remaining}日で終了します",
+    "text": "%{product_name}のトライアルが%{days_remaining}日後に期限切れになります",
     "renderer": "erb",
     "source_hash": "82114f95"
   },
@@ -725,7 +725,7 @@
     "source_hash": "36200518"
   },
   "email.trial_expiring.body": {
-    "text": "%{product_name}の無料トライアルは%{days_remaining}日後に終了します。すべての機能へのアクセスを維持するには、今すぐアップグレードしてください。",
+    "text": "%{product_name}の無料トライアルが%{days_remaining}日後に期限切れになります。すべての機能へのアクセスを維持するには、今すぐアップグレードしてください。",
     "renderer": "erb",
     "source_hash": "17fc32dd"
   },
@@ -740,22 +740,22 @@
     "source_hash": "dc75bf9f"
   },
   "email.subscription_changed.subject": {
-    "text": "%{product_name}のサブスクリプションが変更されました",
+    "text": "%{product_name}サブスクリプションが変更されました",
     "renderer": "erb",
     "source_hash": "c9b61a4d"
   },
   "email.subscription_changed.title": {
-    "text": "サブスクリプションが変更されました",
+    "text": "サブスクリプション変更",
     "renderer": "erb",
     "source_hash": "7523a022"
   },
   "email.subscription_changed.body": {
-    "text": "%{product_name}のサブスクリプションが%{old_plan}から%{new_plan}に変更されました。",
+    "text": "%{product_name}サブスクリプションが%{old_plan}から%{new_plan}に変更されました。",
     "renderer": "erb",
     "source_hash": "72f81a65"
   },
   "email.subscription_changed.effective_date": {
-    "text": "この変更は%{date}から有効です。",
+    "text": "この変更は%{date}に有効になります。",
     "renderer": "erb",
     "source_hash": "5a96ae38"
   },
@@ -770,12 +770,12 @@
     "source_hash": "dafe7694"
   },
   "email.common.thanks": {
-    "text": "よろしくお願いいたします。",
+    "text": "ありがとうございます。",
     "renderer": "erb",
     "source_hash": "11dfba8f"
   },
   "email.common.unsubscribe": {
-    "text": "配信停止",
+    "text": "購読解除",
     "renderer": "erb",
     "source_hash": "3e92efb7"
   },
@@ -794,7 +794,7 @@
     "source_hash": "18ddf44f"
   },
   "email.common.automated_notice": {
-    "text": "これは%{product_name}からの自動送信メッセージです。",
+    "text": "これは%{product_name}からの自動メッセージです。",
     "source_hash": "8fbabfba"
   },
   "email.common.support_label": {
@@ -806,7 +806,7 @@
     "source_hash": "dc75bf9f"
   },
   "email.expiration_warning.footer_note": {
-    "text": "%{product_name}で作成したシークレットの有効期限が近づいているため、このメールが送信されました。",
+    "text": "%{product_name}で作成したシークレットがまもなく期限切れになるため、このメールを受信しました。",
     "source_hash": "920779e4"
   },
   "email.feedback_email.user_id_label": {
@@ -822,19 +822,55 @@
     "source_hash": "4c5726ee"
   },
   "email.incoming_secret.footer_note": {
-    "text": "誰かが%{product_name}を使用してシークレットを送信したため、このメールが送信されました。心当たりがない場合は、このメールを無視していただいて問題ありません。",
+    "text": "誰かが%{product_name}を使用してシークレットを送信したため、このメールを受信しました。予期していない場合は、このメールを無視しても問題ありません。",
     "source_hash": "91ee6e8d"
   },
   "email.secret_link.passphrase_label": {
-    "text": "パスフレーズが必要です:",
+    "text": "パスフレーズが必要:",
     "source_hash": "1ab9a20f"
   },
   "email.secret_link.passphrase_required": {
-    "text": "このシークレットはパスフレーズで保護されています。送信者から別途お知らせがあるはずです。",
+    "text": "このシークレットはパスフレーズで保護されています。送信者が別途お知らせします。",
     "source_hash": "1e49826b"
   },
   "email.secret_link.footer_note": {
-    "text": "%{sender_email}が%{product_name}を使用してシークレットを共有したため、このメールが送信されました。心当たりがない場合は、このメールを無視していただいて問題ありません。",
+    "text": "%{sender_email}が%{product_name}を使用してシークレットを共有したため、このメールを受信しました。予期していない場合は、このメールを無視しても問題ありません。",
     "source_hash": "2d544dad"
+  },
+  "email.sso_link_verification.subject": {
+    "text": "%{provider}を%{product_name}アカウントにリンクすることを確認",
+    "source_hash": "65e70296"
+  },
+  "email.sso_link_verification.title": {
+    "text": "SSOサインインを確認",
+    "source_hash": "35bce6cc"
+  },
+  "email.sso_link_verification.request_notice": {
+    "text": "誰かがメール%{email_address}を使用して%{provider}でサインインしました。%{provider}を%{product_name}アカウントに接続するには、下で確認してください。",
+    "source_hash": "baeb18c0"
+  },
+  "email.sso_link_verification.confirm_button": {
+    "text": "確認して%{provider}をリンク",
+    "source_hash": "9809e210"
+  },
+  "email.sso_link_verification.copy_link_prompt": {
+    "text": "または、このリンクをコピーして貼り付けてください:",
+    "source_hash": "88c72144"
+  },
+  "email.sso_link_verification.expiration_notice": {
+    "text": "このリンクは15分で期限切れになり、1回のみ使用できます。",
+    "source_hash": "1a437f42"
+  },
+  "email.sso_link_verification.ignore_notice": {
+    "text": "%{provider}でサインインしようとしていない場合は、このメールを無視しても問題ありません。アカウントには何も接続されません。",
+    "source_hash": "d7317d30"
+  },
+  "email.sso_link_verification.signature": {
+    "text": "サポートチーム",
+    "source_hash": "dc75bf9f"
+  },
+  "email.sso_link_verification.postscript": {
+    "text": "追伸: このメールは%{email_address}に送信されました。",
+    "source_hash": "8ab1dbea"
   }
 }

--- a/locales/content/ja/email.json
+++ b/locales/content/ja/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Secret Support",
+    "text": "Onetime Secret サポートチーム",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/ja/error-pages.json
+++ b/locales/content/ja/error-pages.json
@@ -1,18 +1,18 @@
 {
   "web.errors.why_is_this_secret_unavailable": {
-    "text": "このシークレットが利用できない理由は?",
+    "text": "なぜこのシークレットは利用できないのですか？",
     "source_hash": "bd545472"
   },
   "web.errors.secrets_are_designed_to_be_viewed_only_once": {
-    "text": "シークレットは一度だけ表示されるように設計されています。このリンクはすでにアクセスされたか、期限切れになったか、送信者によって手動で削除された可能性があります。",
+    "text": "シークレットは1回のみ閲覧できるように設計されています。このリンクはすでにアクセスされたか、期限切れになったか、送信者によって手動で削除された可能性があります。",
     "source_hash": "44c54ed2"
   },
   "web.errors.what_should_i_do_now": {
-    "text": "どうすればいいですか?",
+    "text": "今、何をすればいいですか？",
     "source_hash": "fbf3e67f"
   },
   "web.errors.contact_the_person_who_sent_you_this_link": {
-    "text": "このリンクを送信した人に連絡し、新しいシークレットを作成するよう依頼してください。元の情報にアクセスできなかったことを伝えてください。",
+    "text": "このリンクを送った人に連絡して、新しいシークレットを作成するよう依頼してください。元の情報にアクセスできなかったことを伝えてください。",
     "source_hash": "d9f4f41a"
   },
   "web.errors.warning_dismissed": {
@@ -20,11 +20,11 @@
     "source_hash": "e6d67409"
   },
   "web.errors.dismiss_truncation_warning": {
-    "text": "切り詰め警告を閉じる",
+    "text": "切り捨て警告を閉じる",
     "source_hash": "79e02fe6"
   },
   "web.errors.oops_the_page_you_are_looking_for_doesnt_exist_o": {
-    "text": "おっと！お探しのページは存在しないか、移動されました。",
+    "text": "お探しのページは存在しないか、移動されました。",
     "source_hash": "78207a09"
   },
   "web.errors.404_page_not_found_0": {
@@ -44,27 +44,27 @@
     "source_hash": "b7bb3f34"
   },
   "web.errors.if_youre_unsure_what_to_do_next_please_follow_up": {
-    "text": "次に何をすべきか分からない場合は、このリンクを送信した人に詳細な情報を確認してください。",
+    "text": "次に何をすべきか分からない場合は、このリンクを送った人に詳細を確認してください。",
     "source_hash": "0df00d3f"
   },
   "web.errors.information_shared_through_our_service_can_only_": {
-    "text": "私たちのサービスを通じて共有された情報は一度だけアクセスできます。一度表示されると、コンテンツは機密性を確保するために私たちのサーバーから完全に削除されます。このアプローチは、露出を制限し、不正アクセスを防止することで、機密データを保護するのに役立ちます。",
+    "text": "当サービスで共有された情報は1回のみアクセスできます。閲覧後、コンテンツはサーバーから完全に削除され、機密性が確保されます。このアプローチにより、露出を制限し、不正アクセスを防ぐことで、機密データを保護します。",
     "source_hash": "a3fd8283"
   },
   "web.errors.were_sorry_but_an_unexpected_error_occurred_whil": {
-    "text": "申し訳ありませんが、リクエストの処理中に予期しないエラーが発生しました。チームに通知されており、修正に取り組んでいます。",
+    "text": "申し訳ありませんが、リクエストの処理中に予期しないエラーが発生しました。チームに通知され、修正に取り組んでいます。",
     "source_hash": "f3b50965"
   },
   "web.errors.t_web_common_oops_something_went_wrong": {
-    "text": "{0} 何かがうまくいきませんでした",
+    "text": "{0} 問題が発生しました",
     "source_hash": "93529f24"
   },
   "web.errors.go_share_a_secret": {
-    "text": "シークレットを共有しましょう!",
+    "text": "シークレットを共有しましょう！",
     "source_hash": "04c04b1a"
   },
   "web.errors.the_page_youre_looking_for_doesnt_exist_or_has_b": {
-    "text": "お探しのページは存在しないか、移動された可能性があります。心配しないでください、誰にでも起こることです！",
+    "text": "お探しのページは存在しないか、移動されました。ご安心ください。誰にでも起こることです！",
     "source_hash": "e26522de"
   },
   "web.errors.t_web_common_oops_404": {

--- a/locales/content/ja/feature-feedback.json
+++ b/locales/content/ja/feature-feedback.json
@@ -4,7 +4,7 @@
     "source_hash": "cdb1c0a5"
   },
   "web.feedback.all_feedback_welcome": {
-    "text": "すべてのフィードバックを歓迎します!",
+    "text": "すべてのフィードバックを歓迎します！",
     "source_hash": "c57d3006"
   },
   "web.feedback.help_us_improve": {
@@ -28,15 +28,15 @@
     "source_hash": "f58154f7"
   },
   "web.feedback.help_content_goes_here": {
-    "text": "ヘルプコンテンツはこちら。",
+    "text": "ヘルプコンテンツはここに表示されます。",
     "source_hash": "796979ea"
   },
   "web.feedback.founder_note_line1": {
-    "text": "ここに届くすべてのフィードバックを読んでいます。これが何に時間を費やすべきかを判断する方法です。",
+    "text": "ここに届くすべてのフィードバックを読んでいます。何に時間を費やすべきかを判断するために役立てています。",
     "source_hash": "8b430d93"
   },
   "web.feedback.founder_note_line2": {
-    "text": "何か問題がある場合や、どう機能すべきかについてアイデアがあれば、ここが適切な場所です。",
+    "text": "何か問題があったり、どのように動作すべきかについてアイデアがあれば、ここが適切な場所です。",
     "source_hash": "d4b8f073"
   },
   "web.feedback.open_feedback_form": {
@@ -56,11 +56,11 @@
     "source_hash": "286a3af7"
   },
   "web.feedback.reason_email_change_unauthorized": {
-    "text": "アカウントでの不正なメールアドレス変更を報告されているようです。何が起きたかをご説明ください。すぐに調査いたします。",
+    "text": "アカウントの不正なメール変更を報告されているようです。何が起こったかを説明してください。すぐに調査します。",
     "source_hash": "00e56551"
   },
   "web.feedback.anonymous_no_reply": {
-    "text": "注意: 返信をご希望の場合は、メッセージに署名するか、メールアドレスを記載してください。",
+    "text": "注: 返信が必要な場合は、メッセージに署名またはメールアドレスを含めてください。",
     "source_hash": "c984f705"
   },
   "web.feedback.characters_remaining": {
@@ -68,7 +68,7 @@
     "source_hash": "8d796f40"
   },
   "web.feedback.character_limit_reached": {
-    "text": "文字数の上限に達しました",
+    "text": "文字数制限に達しました",
     "source_hash": "031e9310"
   }
 }

--- a/locales/content/ja/feature-homepage-secrets.json
+++ b/locales/content/ja/feature-homepage-secrets.json
@@ -1,6 +1,6 @@
 {
   "homepage_secrets.disabled.members_only_eyebrow": {
-    "text": "メンバー限定インスタンス",
+    "text": "メンバー専用インスタンス",
     "source_hash": "979899b1"
   },
   "homepage_secrets.disabled.private_instance_eyebrow": {
@@ -12,7 +12,7 @@
     "source_hash": "d17f49d1"
   },
   "homepage_secrets.disabled.signin_headline": {
-    "text": "{action}を作成するにはログインしてください。",
+    "text": "{action}を作成するにはサインインしてください。",
     "source_hash": "08b665e2"
   },
   "homepage_secrets.disabled.signin_headline_action": {
@@ -20,47 +20,47 @@
     "source_hash": "78c621b6"
   },
   "homepage_secrets.disabled.team_subtitle": {
-    "text": "{domain}の権限のあるチームメンバーのみが、ここで新しいワンタイムリンクを作成できます。受信者は送信されたリンクをこれまで通り開くことができます。",
+    "text": "{domain}の承認されたチームメンバーのみが、ここで新しい一回限りのリンクを作成できます。受信者は送られたリンクを開くことができます。",
     "source_hash": "62198a0e"
   },
   "homepage_secrets.disabled.public_subtitle": {
-    "text": "このインスタンスの権限のあるメンバーのみが、新しいワンタイムリンクを作成できます。受信者は送信されたリンクをこれまで通り開くことができます。",
+    "text": "このインスタンスの承認されたメンバーのみが、新しい一回限りのリンクを作成できます。受信者は送られたリンクを開くことができます。",
     "source_hash": "0208d739"
   },
   "homepage_secrets.disabled.signin_cta": {
-    "text": "アカウントにログイン",
+    "text": "アカウントにサインイン",
     "source_hash": "54f9715d"
   },
   "homepage_secrets.disabled.what_is_this": {
-    "text": "これは何ですか?",
+    "text": "これは何ですか？",
     "source_hash": "0b12ba39"
   },
   "homepage_secrets.disabled.trust_viewed_once": {
-    "text": "一度表示されたら消去",
+    "text": "1回閲覧後に消去",
     "source_hash": "abb7a947"
   },
   "homepage_secrets.disabled.trust_zero_retained": {
-    "text": "データを一切保持しません",
+    "text": "データ保持なし",
     "source_hash": "db6d7cc9"
   },
   "homepage_secrets.disabled.promo_title": {
-    "text": "新着: 無料プランにカスタムドメインが含まれるようになりました。",
+    "text": "新機能: 無料プランにカスタムドメインが含まれるようになりました。",
     "source_hash": "00888d63"
   },
   "homepage_secrets.disabled.promo_subtitle": {
-    "text": "ドメインをOnetime Secretに向けて、自社ブランドでシークレットを送信しましょう。",
+    "text": "ドメインをOnetime Secretに向けて、独自のブランドでシークレットを共有しましょう。",
     "source_hash": "27ecd53c"
   },
   "homepage_secrets.disabled.promo_learn_how": {
-    "text": "詳しく見る",
+    "text": "詳細を見る",
     "source_hash": "99c61c4c"
   },
   "homepage_secrets.disabled.logo_alt": {
-    "text": "{name}のロゴ",
+    "text": "{name}ロゴ",
     "source_hash": "f555df26"
   },
   "homepage_secrets.disabled.opens_in_new_tab": {
-    "text": "(新しいタブで開きます)",
+    "text": "（新しいタブで開きます）",
     "source_hash": "1d183356"
   }
 }

--- a/locales/content/ja/feature-incoming.json
+++ b/locales/content/ja/feature-incoming.json
@@ -20,7 +20,7 @@
     "source_hash": "bfd624f7"
   },
   "incoming.feature_disabled_description": {
-    "text": "この機能は現在無効になっています。サポートにお問い合わせください。",
+    "text": "この機能は現在無効です。サポートにお問い合わせください。",
     "source_hash": "f13fbf2b"
   },
   "incoming.memo_label": {
@@ -28,11 +28,11 @@
     "source_hash": "64cecb8a"
   },
   "incoming.memo_placeholder": {
-    "text": "簡単な説明(例: パスワードリセットのリクエスト)",
+    "text": "簡単な説明（例: パスワードリセットリクエスト）",
     "source_hash": "16bf83fd"
   },
   "incoming.memo_hint": {
-    "text": "メッセージを適切な担当者に届けるためにご記入ください",
+    "text": "メッセージを適切な担当者に転送するのに役立ちます",
     "source_hash": "185a207e"
   },
   "incoming.recipient_label": {
@@ -48,7 +48,7 @@
     "source_hash": "c98ac75f"
   },
   "incoming.recipient_hint": {
-    "text": "この安全なメッセージを受け取る人を選択",
+    "text": "この安全なメッセージを受け取る人を選択してください",
     "source_hash": "0dfafc45"
   },
   "incoming.no_recipients_available": {
@@ -60,7 +60,7 @@
     "source_hash": "b4f8c120"
   },
   "incoming.secret_content_placeholder": {
-    "text": "機密情報をここに貼り付け(パスワード、キーなど)",
+    "text": "機密情報をここに貼り付けてください（パスワード、キーなど）",
     "source_hash": "7d7abb48"
   },
   "incoming.secret_content_hint": {
@@ -104,7 +104,7 @@
     "source_hash": "293aba9f"
   },
   "incoming.success_info_title": {
-    "text": "次に何が起こりますか?",
+    "text": "次のステップは？",
     "source_hash": "c72895ba"
   },
   "incoming.success_info_description": {
@@ -120,31 +120,31 @@
     "source_hash": "099ff0c7"
   },
   "incoming.tagline2": {
-    "text": "パスワードや個人データをメールやチャットログから守ります",
+    "text": "パスワードやプライベートデータをメールやチャットログから除外",
     "source_hash": "55566199"
   },
   "incoming.end_of_experience_suggestion": {
-    "text": "記録のために{receipt}を保存してください。",
+    "text": "記録用に{receipt}を保存してください。",
     "source_hash": "db3d9c98"
   },
   "incoming.receipt_link_text": {
-    "text": "受信確認",
+    "text": "受領証",
     "source_hash": "6f328609"
   },
   "incoming.upgrade_required_title": {
-    "text": "アップグレードが必要です",
+    "text": "アップグレードが必要",
     "source_hash": "16487236"
   },
   "incoming.upgrade_required_description": {
-    "text": "この機能にはプランのアップグレードが必要です。受信シークレットを有効にするには、アカウントのオーナーにお問い合わせください。",
+    "text": "この機能にはプランのアップグレードが必要です。受信シークレットを有効にするには、アカウントオーナーにお問い合わせください。",
     "source_hash": "5df7f715"
   },
   "incoming.validation_memo_too_long": {
-    "text": "メモは{max}文字以下である必要があります",
+    "text": "メモは{max}文字以内にしてください",
     "source_hash": "5727f2d3"
   },
   "incoming.validation_secret_required": {
-    "text": "シークレットの内容は必須です",
+    "text": "シークレット内容が必要です",
     "source_hash": "699783c9"
   },
   "incoming.validation_recipient_required": {
@@ -152,11 +152,11 @@
     "source_hash": "67bb4666"
   },
   "incoming.validation_feature_disabled": {
-    "text": "受信シークレット機能が有効になっていません",
+    "text": "受信シークレット機能は有効になっていません",
     "source_hash": "0616d3f4"
   },
   "incoming.validation_form_errors": {
-    "text": "フォームにエラーがないか確認してください",
+    "text": "フォームのエラーを確認してください",
     "source_hash": "9056e064"
   }
 }

--- a/locales/content/ja/feature-regions.json
+++ b/locales/content/ja/feature-regions.json
@@ -8,11 +8,11 @@
     "source_hash": "5e904993"
   },
   "web.regions.separate_environments_explanation": {
-    "text": "各リージョンは、独自のインフラストラクチャ、暗号化キー、データストレージを持つ完全に独立した環境として運用されます",
+    "text": "各リージョンは独自のインフラストラクチャ、暗号化キー、データストレージを持つ完全に独立した環境として運用されています",
     "source_hash": "cd996732"
   },
   "web.regions.no_data_transfer_policy": {
-    "text": "私たちは厳格な方針を維持しています: 顧客データは いかなる状況でもリージョン間で転送されません",
+    "text": "厳格なポリシーを維持しています: いかなる状況でも顧客データはリージョン間で転送されません",
     "source_hash": "33b74be3"
   },
   "web.regions.switching_creates_new_account": {
@@ -20,7 +20,7 @@
     "source_hash": "40e3ee34"
   },
   "web.regions.your_region": {
-    "text": "あなたのリージョン",
+    "text": "リージョン",
     "source_hash": "cafa720f"
   },
   "web.regions.your_current_region": {
@@ -28,11 +28,11 @@
     "source_hash": "45e2a9d6"
   },
   "web.regions.active": {
-    "text": "有効",
+    "text": "アクティブ",
     "source_hash": "92340695"
   },
   "web.regions.explore_other_regions": {
-    "text": "他の利用可能なリージョンを見る",
+    "text": "他の利用可能なリージョンを探す",
     "source_hash": "953d0057"
   },
   "web.regions.why_it_matters": {
@@ -44,7 +44,7 @@
     "source_hash": "6170c9b0"
   },
   "web.regions.trust_description": {
-    "text": "データの保存場所と、その保護を規定する法律を正確に把握できます。",
+    "text": "データがどこに保存され、どの法律が保護を管理しているかを正確に把握できます。",
     "source_hash": "97fd57ab"
   },
   "web.regions.privacy_title": {
@@ -52,7 +52,7 @@
     "source_hash": "d13d2931"
   },
   "web.regions.privacy_description": {
-    "text": "個人情報があなたの国のプライバシー法と規制に従って取り扱われ、不正アクセスや悪用を防ぎます。",
+    "text": "個人情報が国のプライバシー法や規制に従って処理され、不正アクセスや悪用を防ぎます。",
     "source_hash": "28d9d42e"
   },
   "web.regions.compliance_title": {
@@ -60,7 +60,7 @@
     "source_hash": "8aa0df2a"
   },
   "web.regions.compliance_description": {
-    "text": "GDPR、HIPAA、CCPAなどの地域データ保護要件に対応",
+    "text": "GDPR、HIPAA、CCPAなどの地域データ保護要件を満たします",
     "source_hash": "c3b2ee43"
   },
   "web.regions.performance_title": {
@@ -68,7 +68,7 @@
     "source_hash": "504b7b49"
   },
   "web.regions.performance_description": {
-    "text": "データが近くに保存されることで、低遅延と高パフォーマンスを実現します。",
+    "text": "近くに保存されたデータは、低遅延と優れたパフォーマンスを意味します。",
     "source_hash": "e133ef1d"
   },
   "web.regions.regions": {
@@ -76,27 +76,27 @@
     "source_hash": "610c65d8"
   },
   "web.regions.contact_our_compliance_team": {
-    "text": "コンプライアンスチームに連絡",
+    "text": "コンプライアンスチームにお問い合わせください",
     "source_hash": "87e6746e"
   },
   "web.regions.review_our_documentation": {
-    "text": "ドキュメントを確認",
+    "text": "ドキュメントをご覧ください",
     "source_hash": "9cbd03df"
   },
   "web.regions.your_account_and_data_are_protected_under_the_la": {
-    "text": "あなたのアカウントとデータは次の法律と規制の下で保護されています",
+    "text": "アカウントとデータは以下の法律で保護されています",
     "source_hash": "5f5ef5b6"
   },
   "web.regions.this_regulatory_framework_is_determined_by_your_": {
-    "text": "この規制フレームワークは、アクセスドメインによって決定されます：",
+    "text": "規制フレームワークはアクセスドメインによって決定されます:",
     "source_hash": "7fdbc59c"
   },
   "web.regions.each_jurisdiction_maintains_separate_legal_compl": {
-    "text": "各管轄区域は、別々の法的コンプライアンスとデータガバナンスを維持しています。複数の管轄区域でアカウントを作成することはできますが、それらは法的に区別されており、規制区域間でデータの共有はありません。",
+    "text": "各リージョンは独自のインフラストラクチャを持つ完全に独立しており、可能な場合は独自のローカルホスティングプロバイダーを使用しています。複数のリージョンでアカウントを作成できますが、データは共有されません。",
     "source_hash": "5c0b350e"
   },
   "web.regions.to_understand_the_specific_regulations_and_prote": {
-    "text": "あなたのアカウントに適用される特定の規制と保護を理解するには、",
+    "text": "アカウントに適用される規制と保護の詳細については、",
     "source_hash": "e8acc835"
   },
   "web.regions.current": {
@@ -112,7 +112,7 @@
     "source_hash": "ee788590"
   },
   "web.regions.jurisdiction": {
-    "text": "管轄",
+    "text": "管轄区域",
     "source_hash": "d69b9ac7"
   },
   "web.regions.data_center_location_currentjurisdiction_identif": {
@@ -124,11 +124,11 @@
     "source_hash": "a1c6039f"
   },
   "web.regions.unknown_jurisdiction": {
-    "text": "不明な管轄",
+    "text": "不明な管轄区域",
     "source_hash": "eae2e122"
   },
   "web.regions.serving_you_from_the": {
-    "text": "サービス提供元:",
+    "text": "サービス提供元",
     "source_hash": "25db17aa"
   },
   "web.regions.continue_to_jurisdiction_domain": {
@@ -136,7 +136,7 @@
     "source_hash": "dd1a44e4"
   },
   "web.regions.current_jurisdiction": {
-    "text": "現在の管轄:",
+    "text": "現在の管轄区域:",
     "source_hash": "d0f2192d"
   },
   "web.regions.changing_regions_title": {
@@ -144,51 +144,51 @@
     "source_hash": "189d6685"
   },
   "web.regions.changing_regions_description": {
-    "text": "リージョン間でデータを転送しないことが当社のポリシーです。各リージョンは完全に独立した環境として運用されています。",
+    "text": "リージョン間でデータを転送しないポリシーを維持しています。各リージョンは完全に独立した環境として運用されています。",
     "source_hash": "cf45b8be"
   },
   "web.regions.changing_regions_how_to": {
-    "text": "別のリージョンを利用するには、請求先メールアドレスに紐づいた同じメールアドレスでそのリージョンに新しいアカウントを作成してください。",
+    "text": "別のリージョンを使用するには、請求連絡先メールに関連付けられた同じメールアドレスを使用して、そこで新しいアカウントを作成してください。",
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "請求先の連絡用メールアドレスが{product_name}アカウントのメールアドレスと異なる場合は、サブスクリプションの特典を維持するために、新しいリージョンのアカウントで請求先の連絡用メールアドレスを使用してください。",
+    "text": "請求連絡先メールが{product_name}アカウントメールと異なる場合は、サブスクリプション特典を維持するために、新しいリージョンアカウントに請求連絡先メールを使用してください。",
     "source_hash": "d49662b0"
   },
   "web.regions.changing_regions_subscription_note": {
-    "text": "サブスクリプション特典は、請求先メールアドレスで作成されたすべてのアカウントに自動的に適用されます。",
+    "text": "サブスクリプション特典は、請求メールアドレスで作成されたすべてのアカウントに自動的に適用されます。",
     "source_hash": "5b2238b2"
   },
   "web.regions.jurisdictions.eu.name": {
-    "text": "European Union",
+    "text": "欧州連合",
     "source_hash": "7fe24f2b"
   },
   "web.regions.jurisdictions.us.name": {
-    "text": "United States",
+    "text": "アメリカ合衆国",
     "source_hash": "49dca65f"
   },
   "web.regions.jurisdictions.ca.name": {
-    "text": "Canada",
+    "text": "カナダ",
     "source_hash": "be55ef3f"
   },
   "web.regions.jurisdictions.uk.name": {
-    "text": "United Kingdom",
+    "text": "イギリス",
     "source_hash": "8d23a6e3"
   },
   "web.regions.jurisdictions.nz.name": {
-    "text": "New Zealand",
+    "text": "ニュージーランド",
     "source_hash": "2898e16d"
   },
   "web.regions.jurisdictions.at.name": {
-    "text": "Austria",
+    "text": "オーストリア",
     "source_hash": "c9cab023"
   },
   "web.regions.jurisdictions.apac.name": {
-    "text": "Asia-Pacific",
+    "text": "アジア太平洋",
     "source_hash": "7a757670"
   },
   "web.regions.no_region_configured": {
-    "text": "現在、お客様のアカウントで利用可能なリージョン情報はありません。",
+    "text": "アカウントのリージョン情報は現在利用できません。",
     "source_hash": "bbfe2a32"
   }
 }

--- a/locales/content/ja/feature-testimonials.json
+++ b/locales/content/ja/feature-testimonials.json
@@ -4,7 +4,7 @@
     "source_hash": "ff4d6634"
   },
   "web.testimonials.ai_generated_content_disclaimer": {
-    "text": "デモンストレーション用のAI生成コンテンツです。実際の人物や企業のものではありません。",
+    "text": "デモンストレーション用のAI生成コンテンツです。実在の人物や企業からのものではありません。",
     "source_hash": "d7093de7"
   },
   "web.testimonials.randomtestimonial_stars_5": {
@@ -24,7 +24,7 @@
     "source_hash": "14159dd9"
   },
   "web.testimonials.what_leading_ai_says_about_us": {
-    "text": "主要なAIが私たちについて語ること",
+    "text": "AIが語る私たちについて",
     "source_hash": "f46a8839"
   },
   "web.testimonials.ai_generated_testimonials": {
@@ -32,19 +32,19 @@
     "source_hash": "947cd6b4"
   },
   "web.testimonials.this_quote_was_generated_by": {
-    "text": "この引用は以下によって生成されました:",
+    "text": "この引用は以下によって生成されました",
     "source_hash": "7879a747"
   },
   "web.testimonials.it_was_based_on_the_content_of_the_page_and_does": {
-    "text": "ページの内容に基づいており、実際の人物や会社を表すものではありません。",
+    "text": "ページのコンテンツに基づいており、実在の人物や企業を表すものではありません。",
     "source_hash": "8b290e9a"
   },
   "web.testimonials.artificial_feedback": {
-    "text": "人工的なフィードバック",
+    "text": "人工フィードバック",
     "source_hash": "4c8d20ba"
   },
   "web.testimonials.this_content_is_ai_generated_based_on_the_conten": {
-    "text": "このコンテンツはページの内容に基づいてAIが生成したもので、実際の人物や会社を表すものではありません。",
+    "text": "このコンテンツはこのページのコンテンツに基づいてAI生成されており、実在の人物や企業を表すものではありません。",
     "source_hash": "03c16436"
   }
 }

--- a/locales/content/ja/feature-translations.json
+++ b/locales/content/ja/feature-translations.json
@@ -1,6 +1,6 @@
 {
   "web.translations.welcomes_contributors_for_both_existing_and_new_": {
-    "text": "既存および新しい言語の両方の貢献者を歓迎します。",
+    "text": "既存言語と新言語の両方の翻訳者を歓迎しています。",
     "source_hash": "87abcdeb"
   },
   "web.translations.our_github_project": {
@@ -12,7 +12,7 @@
     "source_hash": "10056bff"
   },
   "web.translations.whove_helped_with_translations_as_we_continue_to": {
-    "text": "新機能の開発を続ける中で、翻訳を手伝ってくれた人々。",
+    "text": "新機能を開発する中で翻訳を手伝ってくださった方々に感謝します。",
     "source_hash": "d629cc71"
   },
   "web.translations.25_contributors": {
@@ -20,15 +20,15 @@
     "source_hash": "080aa720"
   },
   "web.translations.were_grateful_to_the": {
-    "text": "感謝しています:",
+    "text": "感謝しています",
     "source_hash": "cf446287"
   },
   "web.translations.as_we_add_new_features_our_translations_graduall": {
-    "text": "新機能を追加するにつれて、翻訳は徐々に更新が必要になります。これは、onetimesecret.comと世界中の何千ものセルフホスティングインストールの両方に影響します。",
+    "text": "新機能を追加するにつれて、翻訳は最新の状態を維持するために徐々に更新が必要になります。これはonetimesecret.comと世界中の何千ものセルフホストインストールの両方に影響します。",
     "source_hash": "c6fb1cf5"
   },
   "web.translations.remember_to_include_your_email_if_youre_not_logg": {
-    "text": "- ログインしていない場合は、メールを含めることを忘れないでください。すべての翻訳は、より多くの人々が安全に通信するのに役立ちます。",
+    "text": "- ログインしていない場合はメールアドレスを含めることを忘れないでください。すべての翻訳が、より多くの人々が安全にコミュニケーションするのに役立ちます。",
     "source_hash": "1a8ccc7d"
   },
   "web.translations.reach_out_to_us": {
@@ -36,11 +36,11 @@
     "source_hash": "fee7dd79"
   },
   "web.translations.have_questions": {
-    "text": "質問がありますか?",
+    "text": "ご質問はありますか？",
     "source_hash": "75e4b61a"
   },
   "web.translations.send_translations_by_email_to": {
-    "text": "翻訳をメールで送信:",
+    "text": "翻訳をメールで送信",
     "source_hash": "f96a59a1"
   },
   "web.translations.english_template": {
@@ -48,23 +48,23 @@
     "source_hash": "1a843644"
   },
   "web.translations.start_a_new_translation_from_our": {
-    "text": "以下から新しい翻訳を開始:",
+    "text": "新しい翻訳を開始するには",
     "source_hash": "b963b7e9"
   },
   "web.translations.update_a_language_directly_through_our_github_pr": {
-    "text": "GitHubプロジェクトを通じて言語を直接更新する",
+    "text": "GitHubプロジェクトを通じて言語を直接更新",
     "source_hash": "449cde87"
   },
   "web.translations.review_existing_translations_using_the_language_": {
-    "text": "上記の言語セレクターを使用して、既存の翻訳を確認する",
+    "text": "上の言語セレクターを使用して既存の翻訳をレビュー",
     "source_hash": "74ea57e9"
   },
   "web.translations.ready_to_help_some_ways_to_contribute": {
-    "text": "お手伝いする準備はできていますか？貢献方法はいくつかあります：",
+    "text": "手伝う準備はできましたか？貢献する方法:",
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "以下の方々が、{product_name}の普及を支援するために時間を提供してくださいました:",
+    "text": "以下の方々が{product_name}の普及を支援するために時間を提供してくださいました:",
     "source_hash": "6cc876ae"
   },
   "web.translations.translations": {
@@ -72,23 +72,23 @@
     "source_hash": "266a41b9"
   },
   "web.translations.fork_on_github_and_submit_a_pr": {
-    "text": "GitHubでフォークしてPRを送信",
+    "text": "GitHubでフォークしてPRを提出",
     "source_hash": "bb60a45d"
   },
   "web.translations.your_language_skills_can_help_expand_access_to_s": {
-    "text": "あなたの言語スキルは、安全な通信へのアクセスを拡大するのに役立ちます。",
+    "text": "あなたの言語スキルが安全なコミュニケーションへのアクセスを拡大するのに役立ちます。",
     "source_hash": "ad22076b"
   },
   "web.translations.thanks_to_our_community_we_support_over_20_langu": {
-    "text": "コミュニティのおかげで、現在20以上の言語をサポートしています。しかし、急速な開発ペースにより、多くの翻訳は最新の状態を維持するために更新が必要です。これは、onetimesecret.comと世界中の何千ものセルフホスティングインストールの両方に影響します。",
+    "text": "コミュニティのおかげで、現在20以上の言語をサポートしています。しかし、急速な開発ペースにより、多くの翻訳は最新の状態を維持するために更新が必要です。これはonetimesecret.comと世界中の何千ものセルフホストインストールの両方に影響します。",
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "2012年以来、{product_name}は機密情報を世界中で安全に共有する手段を提供してきました。英語が主要言語ではない地域にもユーザーがいるため、誰もが安全なコミュニケーションを利用できるようにするには、正確な翻訳が不可欠です。",
+    "text": "2012年以来、{product_name}は世界中で機密情報を安全に共有する方法を提供してきました。英語が主要言語ではない地域のユーザーが多いため、安全なコミュニケーションを誰もが利用できるようにするには、正確な翻訳が不可欠です。",
     "source_hash": "ded965d5"
   },
   "web.translations.help_secure_communication_go_global": {
-    "text": "安全なコミュニケーションをグローバルに",
+    "text": "安全なコミュニケーションのグローバル化を支援",
     "source_hash": "e94bdc8e"
   }
 }

--- a/locales/content/ja/secret-homepage.json
+++ b/locales/content/ja/secret-homepage.json
@@ -1,10 +1,10 @@
 {
   "web.homepage.tagline1": {
-    "text": "下にパスワード、シークレットメッセージ、またはプライベートリンクを貼り付けてください。",
+    "text": "パスワード、シークレットメッセージ、またはプライベートリンクを下に貼り付けてください。",
     "source_hash": "5785816e"
   },
   "web.homepage.tagline2": {
-    "text": "機密情報をメールやチャットログから守ります。",
+    "text": "機密情報をメールやチャットログから除外しましょう。",
     "source_hash": "69dd8d56"
   },
   "web.homepage.secret_hint": {
@@ -20,7 +20,7 @@
     "source_hash": "cf05fe3b"
   },
   "web.homepage.secret_form_more_text3": {
-    "text": "シークレットをメールで送信できます。",
+    "text": "を取得すると、シークレットをメールで送信できます。",
     "source_hash": "004dda26"
   },
   "web.homepage.cta_title": {
@@ -48,39 +48,39 @@
     "source_hash": "3f1bf1de"
   },
   "web.homepage.need_free_account": {
-    "text": "はじめたばかりですか? 無料アカウントでメールを送信できます。",
+    "text": "始めたばかりですか？無料アカウントでメールを送信できます。",
     "source_hash": "35d2ac76"
   },
   "web.homepage.sign_up_free": {
-    "text": "無料登録",
+    "text": "無料サインアップ",
     "source_hash": "5e218489"
   },
   "web.homepage.visit_onetime_secret_home": {
-    "text": "{product_name}のホームページにアクセス",
+    "text": "{product_name}ホームページにアクセス",
     "source_hash": "87802af5"
   },
   "web.homepage.password_generation_title": {
-    "text": "パスワード生成",
+    "text": "パスワードジェネレーター",
     "source_hash": "7bec027a"
   },
   "web.homepage.password_generation_description": {
-    "text": "「パスワードを生成」をクリックして、共有可能な安全なランダムパスワードを作成します。",
+    "text": "「パスワードを生成」をクリックして、共有できる安全なランダムパスワードを作成します。",
     "source_hash": "82c42d54"
   },
   "web.homepage.protip1": {
-    "text": "メッセージは閲覧後に自己破壊します。リンクは1回のみアクセス可能です。",
+    "text": "メッセージは閲覧後に自動削除されます。リンクは1回のみアクセス可能です。",
     "source_hash": "085cd9bd"
   },
   "web.homepage.authonly.tagline2": {
-    "text": "セキュアメッセージングサービスは内部利用のみです。",
+    "text": "セキュアメッセージングサービスは内部使用専用です。",
     "source_hash": "d21ee2dd"
   },
   "web.homepage.authonly.tagline1": {
-    "text": "アカウントをお持ちの場合は、ログインしてください。",
+    "text": "アカウントをお持ちの場合は、ログインして続行してください。",
     "source_hash": "c6148896"
   },
   "web.homepage.disabled.tagline2": {
-    "text": "このサービスは内部利用専用に設定されています。",
+    "text": "このサービスは内部使用専用に設定されています。",
     "source_hash": "8a727004"
   },
   "web.homepage.disabled.tagline1": {
@@ -92,15 +92,15 @@
     "source_hash": "140c4b1a"
   },
   "web.homepage.meets_and_exceeds_compliance_standards": {
-    "text": "コンプライアンス基準を満たし、それを上回っています",
+    "text": "コンプライアンス基準を満たし、それを超えています",
     "source_hash": "4bd4c8a0"
   },
   "web.homepage.secure_your_brand_build_customer_trust_etc": {
-    "text": "あなたのブランドを保護し、あなたのドメインからのリンクでお客様の信頼を構築します。",
+    "text": "ブランドを保護し、独自のドメインからのリンクで顧客の信頼を構築します。",
     "source_hash": "101a3149"
   },
   "web.homepage.a_trusted_way_to_share_sensitive_information_etc": {
-    "text": "閲覧後に自動的に削除される機密情報を共有するための信頼された方法。",
+    "text": "閲覧後に自動削除される機密情報を共有する信頼できる方法です。",
     "source_hash": "a5429343"
   },
   "web.homepage.secure_links": {
@@ -132,7 +132,7 @@
     "source_hash": "bbb86506"
   },
   "web.homepage.tagline_delivered": {
-    "text": "配信済み",
+    "text": "配達済み",
     "source_hash": "90611565"
   },
   "web.homepage.onetime_secret": {
@@ -148,11 +148,11 @@
     "source_hash": "7bec5899"
   },
   "web.homepage.onetime_secret_homepage": {
-    "text": "{product_name}のホームページ",
+    "text": "{product_name}ホームページ",
     "source_hash": "0792b61e"
   },
   "web.homepage.send_sensitive_information_that_can_only_be_viewed_once": {
-    "text": "一度だけ閲覧できる機密情報を送信する",
+    "text": "1回のみ閲覧可能な機密情報を送信",
     "source_hash": "8c43aaaf"
   },
   "web.homepage.create_a_secure_link": {
@@ -164,7 +164,7 @@
     "source_hash": "94d5249b"
   },
   "web.homepage.this_is_a_private_instance_only_authorized_team_": {
-    "text": "これはプライベートインスタンスです。許可されたチームメンバーのみが新しいセキュアリンクを生成できます。",
+    "text": "これはプライベートインスタンスです。承認されたチームメンバーのみが新しいセキュアリンクを生成できます。",
     "source_hash": "e1073c60"
   },
   "web.homepage.welcome_to_onetime_secret": {
@@ -172,15 +172,15 @@
     "source_hash": "f4f49058"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "{product_name}は、プロフェッショナルな体裁を保ちながら、機密情報を安全に共有するのに役立ちます。",
+    "text": "{product_name}は、プロフェッショナルな外観を維持しながら機密情報を安全に共有するのに役立ちます。",
     "source_hash": "7e9192bd"
   },
   "web.homepage.information_shared_through_this_service_can_only": {
-    "text": "このサービスを通じて共有された情報は一度だけアクセスできます。一度表示されると、機密性を確保するためにコンテンツは完全に削除されます。",
+    "text": "このサービスを通じて共有された情報は1回のみアクセスできます。閲覧後、コンテンツは機密性を確保するために完全に削除されます。",
     "source_hash": "fc58212a"
   },
   "web.homepage.welcome_to_the_global_broadcast": {
-    "text": "グローバルブロードキャストへようこそ!",
+    "text": "グローバルブロードキャストへようこそ！",
     "source_hash": "210e1894"
   },
   "web.homepage.send_a_secret": {
@@ -188,7 +188,7 @@
     "source_hash": "31fd9e03"
   },
   "web.homepage.deliver_sensitive_information_directly_and_securely": {
-    "text": "機密情報を私たちのチームに直接届けられます。一度だけ表示できます。",
+    "text": "機密情報をチームに直接安全に配信します。1回のみ閲覧可能です。",
     "source_hash": "9976cf01"
   }
 }

--- a/locales/content/ja/secret-manage.json
+++ b/locales/content/ja/secret-manage.json
@@ -60,7 +60,7 @@
     "source_hash": "5e1bffcb"
   },
   "web.secrets.sample_secret_content": {
-    "text": "シークレットコンテンツのサンプル",
+    "text": "サンプルのシークレット内容",
     "source_hash": "88e4064e"
   },
   "web.secrets.create_a_secret": {
@@ -72,15 +72,15 @@
     "source_hash": "d11c5b24"
   },
   "web.secrets.content_status": {
-    "text": "コンテンツのステータス",
+    "text": "コンテンツの状態",
     "source_hash": "5efa57d2"
   },
   "web.secrets.secret_content_copied_to_clipboard": {
-    "text": "シークレットの内容をクリップボードにコピーしました",
+    "text": "シークレット内容がクリップボードにコピーされました",
     "source_hash": "decf849f"
   },
   "web.secrets.secret_content": {
-    "text": "シークレットの内容",
+    "text": "シークレット内容",
     "source_hash": "a0c96d15"
   },
   "web.secrets.secret_confirmation": {
@@ -96,15 +96,15 @@
     "source_hash": "7e488229"
   },
   "web.secrets.enter_the_secret_content_here": {
-    "text": "シークレットの内容をここに入力",
+    "text": "ここにシークレット内容を入力",
     "source_hash": "d69e2157"
   },
   "web.secrets.enter_the_secret_content_to_share_here": {
-    "text": "ここに共有するシークレットコンテンツを入力",
+    "text": "共有するシークレット内容をここに入力",
     "source_hash": "d4d20dc3"
   },
   "web.secrets.formattedcharcount_formattedmaxlength_chars": {
-    "text": "{0} / {1} 文字",
+    "text": "{0} / {1}文字",
     "source_hash": "f4a35731"
   },
   "web.secrets.enter_a_passphrase": {
@@ -112,39 +112,39 @@
     "source_hash": "8b450877"
   },
   "web.secrets.when_ready_click_the_view_secret_button_at_the_t": {
-    "text": "準備ができたら、ページ上部のボタンをクリックして一度限りのメッセージを表示します。",
+    "text": "準備ができたら、ページ上部のボタンをクリックして1回限りのメッセージを表示してください。",
     "source_hash": "7a65b13e"
   },
   "web.secrets.what_happens_next": {
-    "text": "次に何が起こりますか?",
+    "text": "次は何が起こりますか？",
     "source_hash": "c72895ba"
   },
   "web.secrets.yes_after_viewing_the_secret_is_permanently_dele": {
-    "text": "はい。表示後、シークレットは私たちのサーバーから完全に削除され、プライバシーが確保されます。",
+    "text": "はい。閲覧後、シークレットはサーバーから完全に削除され、プライバシーが確保されます。",
     "source_hash": "15e6ab70"
   },
   "web.secrets.is_it_secure": {
-    "text": "安全ですか?",
+    "text": "安全ですか？",
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "{product_name}は、一度表示されると自動的に消去される、機密情報を安全に共有する方法です。",
+    "text": "{product_name}は、1回閲覧後に自動削除される機密情報を安全に共有する方法です。",
     "source_hash": "bd0c6182"
   },
   "web.secrets.what_is_this": {
-    "text": "これは何ですか?",
+    "text": "これは何ですか？",
     "source_hash": "0b12ba39"
   },
   "web.secrets.before_you_open_it_heres_what_you_should_know": {
-    "text": "開く前に、知っておくべきことがあります：",
+    "text": "開く前に知っておくべきこと:",
     "source_hash": "f5c3bda4"
   },
   "web.secrets.a_secure_one_time_message_awaits_you": {
-    "text": "安全な一度限りのメッセージがあなたを待っています。",
+    "text": "安全な1回限りのメッセージが届いています。",
     "source_hash": "8e1ef474"
   },
   "web.secrets.youve_got_secret_mail": {
-    "text": "(シークレット)メールが届いています",
+    "text": "シークレットメールが届いています",
     "source_hash": "1cb809ea"
   },
   "web.secrets.auto_expire_after_viewing": {
@@ -156,7 +156,7 @@
     "source_hash": "63f3282e"
   },
   "web.secrets.that_information_is_no_longer_available": {
-    "text": "このシークレットは表示されたか、期限切れになりました。",
+    "text": "このシークレットは閲覧されたか期限切れです。",
     "source_hash": "4de19d63"
   },
   "web.secrets.information_no_longer_available": {
@@ -200,7 +200,7 @@
     "source_hash": "316cf396"
   },
   "web.receipt.requires_passphrase": {
-    "text": "パスフレーズが必要です",
+    "text": "パスフレーズが必要",
     "source_hash": "83b1998d"
   },
   "web.receipt.this_msg_is_encrypted": {
@@ -208,23 +208,23 @@
     "source_hash": "ede466b1"
   },
   "web.receipt.only_see_once": {
-    "text": "注意: これは一度しか表示されません。",
+    "text": "注意: これは1回のみ表示されます。",
     "source_hash": "a7c79715"
   },
   "web.receipt.created_success": {
-    "text": "シークレットが正常に作成されました",
+    "text": "シークレットが正常に作成されました！",
     "source_hash": "ce65f4ad"
   },
   "web.receipt.created_success_key": {
-    "text": "シークレット{shortKey}が正常に作成されました",
+    "text": "シークレット{shortKey}が正常に作成されました！",
     "source_hash": "73708d50"
   },
   "web.receipt.created_securely": {
-    "text": "シークレットは安全に作成されました",
+    "text": "シークレットが安全に作成されました",
     "source_hash": "8f3c17cc"
   },
   "web.receipt.burned_ago": {
-    "text": "{time}に削除",
+    "text": "{time}に削除済み",
     "source_hash": "855f10aa"
   },
   "web.receipt.viewed_ago": {
@@ -236,7 +236,7 @@
     "source_hash": "093462e8"
   },
   "web.receipt.destroyed_ago": {
-    "text": "{time}に破棄",
+    "text": "{time}に破棄済み",
     "source_hash": "277581ac"
   },
   "web.receipt.burned": {
@@ -248,7 +248,7 @@
     "source_hash": "1b28d178"
   },
   "web.receipt.view_receipt": {
-    "text": "受領確認を表示",
+    "text": "受領証を表示",
     "source_hash": "6c664c31"
   },
   "web.receipt.destroyed": {
@@ -256,23 +256,23 @@
     "source_hash": "ff49630c"
   },
   "web.receipt.have_more_questions_visit_our": {
-    "text": "ご質問がありますか?こちらをご覧ください",
+    "text": "他にご質問がありますか？",
     "source_hash": "aadb8006"
   },
   "web.receipt.the_burn_feature_lets_you_permanently_delete_a_s": {
-    "text": "削除機能を使用すると、誰かが表示する前にシークレットを完全に削除できます。これは、アクセスを取り消す必要がある場合や、誤った情報を共有した場合に役立ちます。一度削除すると、シークレットは復元できません。",
+    "text": "削除機能を使用すると、誰かが閲覧する前にシークレットを完全に削除できます。アクセスを取り消す必要がある場合や、間違った情報を共有した場合に便利です。削除後、シークレットは復元できません。",
     "source_hash": "8f82008b"
   },
   "web.receipt.whats_the_burn_feature": {
-    "text": "削除機能とは?",
+    "text": "削除機能とは何ですか？",
     "source_hash": "783da354"
   },
   "web.receipt.your_secret_will_remain_available_for_record_nat": {
-    "text": "シークレットは{0}、または表示されるまで利用可能です（どちらか早い方）。いずれかの条件が満たされると、シークレットは完全に削除されます。",
+    "text": "シークレットは{0}の間、または閲覧されるまでのいずれか早い方まで利用可能です。いずれかの条件が満たされると、シークレットは完全に削除されます。",
     "source_hash": "d690ea63"
   },
   "web.receipt.how_does_secret_expiration_work": {
-    "text": "シークレットの有効期限はどのように機能しますか?",
+    "text": "シークレットの有効期限はどのように機能しますか？",
     "source_hash": "b69dacd2"
   },
   "web.receipt.for_security_reasons_we_cant_recover_lost_secret": {
@@ -280,31 +280,31 @@
     "source_hash": "3b229db9"
   },
   "web.receipt.lost_your_secret_link": {
-    "text": "シークレットリンクを紛失しましたか?",
+    "text": "シークレットリンクを紛失しましたか？",
     "source_hash": "a968fd0b"
   },
   "web.receipt.expires_in_record_natural_expiration_0": {
-    "text": "{0}で期限切れ",
+    "text": "{0}後に期限切れ",
     "source_hash": "1dceeb03"
   },
   "web.receipt.we_display_the_value_for_you_so_that_you_can_ver": {
-    "text": "私たちはあなたが確認できるように値を表示しますが、それは一度だけ行います。誰かがこのプライベートページを取得した場合（ブラウザの履歴や、秘密のリンクの代わりにプライベートリンクを誤って送信した場合など）、秘密の値は表示されません。",
+    "text": "確認できるように値を表示しますが、1回のみ表示されます。これにより、誰かがこのプライベートページを取得した場合（ブラウザ履歴や、シークレットリンクの代わりにプライベートリンクを誤って送信した場合）、シークレットの値を見ることはできません。",
     "source_hash": "cc1facdd"
   },
   "web.receipt.why_can_i_only_see_the_secret_value_once": {
-    "text": "なぜシークレットの値は一度しか見られないのですか?",
+    "text": "なぜシークレットの値を1回しか見られないのですか？",
     "source_hash": "b2e497d6"
   },
   "web.receipt.burning_a_secret_permanently_deletes_it_before_a": {
-    "text": "シークレットを削除すると、誰かが読む前に完全に削除されます。受信者はシークレットが存在しないというメッセージを見ることになります。これは、誤った情報を誤って共有した場合やアクセスを防止する必要がある場合に役立ちます。",
+    "text": "シークレットを削除すると、誰も読む前に完全に削除されます。受信者にはシークレットが存在しないことを示すメッセージが表示されます。間違った情報を誤って共有した場合や、アクセスを防ぐ必要がある場合に便利です。",
     "source_hash": "f3fa5bbb"
   },
   "web.receipt.what_happens_when_i_burn_a_secret": {
-    "text": "シークレットを削除するとどうなりますか?",
+    "text": "シークレットを削除するとどうなりますか？",
     "source_hash": "cfc61708"
   },
   "web.receipt.and_never_stored_in_its_original_form_this_appro": {
-    "text": "そして元の形式では保存されません。このアプローチにより、私たちはあなたのシークレットにアクセスしたり復元したりすることができません - 正しいパスフレーズを持つ人だけがアクセスできます。",
+    "text": "元の形式で保存されることはありません。このアプローチにより、私たちはシークレットにアクセスしたり復元したりすることができません。正しいパスフレーズを持つ人だけが可能です。",
     "source_hash": "9b760dad"
   },
   "web.receipt.passphrase_protection": {
@@ -312,7 +312,7 @@
     "source_hash": "0a6c3735"
   },
   "web.receipt.each_secret_can_only_be_viewed_once_after_viewin": {
-    "text": "各シークレットは一度だけ表示できます。表示後、サーバーから完全に削除されます。これにより、機密情報がブラウザの履歴や誤って共有されたプライベートリンクを通じて誤って公開されることがなくなります。",
+    "text": "各シークレットは1回のみ閲覧できます。閲覧後、サーバーから完全に削除されます。これにより、ブラウザ履歴や誤って共有されたプライベートリンクを通じて機密情報が偶然公開されることを防ぎます。",
     "source_hash": "581b5abf"
   },
   "web.receipt.one_time_access": {
@@ -320,11 +320,11 @@
     "source_hash": "76f1cd7e"
   },
   "web.receipt.core_security_features": {
-    "text": "主要なセキュリティ機能",
+    "text": "コアセキュリティ機能",
     "source_hash": "aa0fc6f9"
   },
   "web.receipt.expires_in_record_natural_expiration": {
-    "text": "{0}で期限切れ",
+    "text": "{0}後に期限切れ",
     "source_hash": "1dceeb03"
   },
   "web.receipt.send_feedback": {
@@ -348,11 +348,11 @@
     "source_hash": "eb762113"
   },
   "web.shared.this_message_for_you": {
-    "text": "このメッセージはあなた宛です:",
+    "text": "このメッセージはあなた宛てです:",
     "source_hash": "4f6ba844"
   },
   "web.shared.your_message_is_ready": {
-    "text": "安全なメッセージが準備できました。",
+    "text": "安全なメッセージの準備ができました。",
     "source_hash": "94b7b921"
   },
   "web.shared.reply_with_secret": {
@@ -364,15 +364,15 @@
     "source_hash": "d489958b"
   },
   "web.shared.post_reveal_default": {
-    "text": "安全なメッセージが下に表示されています。",
+    "text": "安全なメッセージが下に表示されます。",
     "source_hash": "01dfb737"
   },
   "web.shared.secret_was_truncated": {
-    "text": "シークレットは切り詰められました",
+    "text": "シークレットは切り捨てられました",
     "source_hash": "edae5139"
   },
   "web.secrets.workspace_mode_disabled_for_generate": {
-    "text": "生成されたパスワードでは無効です - パスワードを確認するには受信確認を表示してください",
+    "text": "生成されたパスワードでは無効です。パスワードを見るには受領証を表示する必要があります",
     "source_hash": "29969ba9"
   },
   "web.secrets.scope_org": {
@@ -476,7 +476,7 @@
     "source_hash": "aab63f85"
   },
   "web.secrets.messageDeleted": {
-    "text": "メッセージを削除しました",
+    "text": "メッセージは削除されました",
     "source_hash": "7e94d4b9"
   }
 }

--- a/locales/content/ja/session-auth-extended.json
+++ b/locales/content/ja/session-auth-extended.json
@@ -66,15 +66,15 @@
     "context": "⚠️ SECURITY-CRITICAL: Messages prevent information disclosure. See src/locales/SECURITY-TRANSLATION-GUIDE.md"
   },
   "web.auth.security.authentication_failed": {
-    "text": "認証に失敗しました。認証情報を確認してもう一度お試しください。",
+    "text": "認証に失敗しました。資格情報を確認してもう一度お試しください。",
     "source_hash": "b0eeece9"
   },
   "web.auth.security.rate_limited": {
-    "text": "試行回数が多すぎます。後でもう一度お試しください。",
+    "text": "試行回数が多すぎます。しばらくしてからもう一度お試しください。",
     "source_hash": "282db6f3"
   },
   "web.auth.security.session_expired": {
-    "text": "セッションが期限切れです。再度ログインしてください。",
+    "text": "セッションの有効期限が切れました。もう一度ログインしてください。",
     "source_hash": "f6f51186"
   },
   "web.auth.security.recovery_code_not_found": {
@@ -82,7 +82,7 @@
     "source_hash": "f5f1bd09"
   },
   "web.auth.security.recovery_code_used": {
-    "text": "このリカバリーコードは既に使用されています。各コードは1回のみ使用できます。",
+    "text": "このリカバリーコードはすでに使用されています。各コードは1回のみ使用できます。",
     "source_hash": "b51d6820"
   },
   "web.auth.security.network_error": {
@@ -107,7 +107,7 @@
     "source_hash": "ab2ba7db"
   },
   "web.auth.magicLink.title": {
-    "text": "メールでログイン",
+    "text": "メールでサインイン",
     "source_hash": "79a864df"
   },
   "web.auth.magicLink.description": {
@@ -115,7 +115,7 @@
     "source_hash": "5d75aeb0"
   },
   "web.auth.magicLink.emailPlaceholder": {
-    "text": "メールアドレスを入力",
+    "text": "メールを入力",
     "source_hash": "2837f6fa"
   },
   "web.auth.magicLink.sendLink": {
@@ -127,19 +127,19 @@
     "source_hash": "77322879"
   },
   "web.auth.magicLink.sentTo": {
-    "text": "{email}にログインリンクを送信しました",
+    "text": "ログインリンクを{email}に送信しました",
     "source_hash": "d9193f59"
   },
   "web.auth.magicLink.linkExpiresIn": {
-    "text": "このリンクは15分で期限切れになります",
+    "text": "このリンクは15分後に期限切れになります",
     "source_hash": "91b5f027"
   },
   "web.auth.magicLink.tryDifferentEmail": {
-    "text": "別のメールアドレスを試す",
+    "text": "別のメールを試す",
     "source_hash": "98657c0b"
   },
   "web.auth.magicLink.noPasswordNeeded": {
-    "text": "パスワード不要 - メール内のリンクをクリックするだけ",
+    "text": "パスワードは不要です。メール内のリンクをクリックするだけです",
     "source_hash": "5f539b97"
   },
   "web.auth.magicLink.networkError": {
@@ -151,7 +151,7 @@
     "source_hash": "4c685e97"
   },
   "web.auth.magicLink.invalidLink": {
-    "text": "無効またはログインリンクがありません",
+    "text": "無効または欠落しているログインリンク",
     "source_hash": "d726c0da"
   },
   "web.auth.magicLink.sessionExpired": {
@@ -163,7 +163,7 @@
     "source_hash": "c95b4875"
   },
   "web.auth.magicLink.signingYouIn": {
-    "text": "ログイン中...",
+    "text": "サインイン中...",
     "source_hash": "9d432ef1"
   },
   "web.auth.magicLink.pleaseWait": {
@@ -175,23 +175,23 @@
     "source_hash": "797b4f03"
   },
   "web.auth.magicLink.back_to_signin": {
-    "text": "ログインに戻る",
+    "text": "サインインに戻る",
     "source_hash": "ee9eb75e"
   },
   "web.auth.webauthn.signIn": {
-    "text": "Face ID / Touch IDでログイン",
+    "text": "Face ID / Touch IDでサインイン",
     "source_hash": "46f75469"
   },
   "web.auth.webauthn.setup": {
-    "text": "生体認証ログインを設定",
+    "text": "生体認証ログインをセットアップ",
     "source_hash": "7593dd46"
   },
   "web.auth.webauthn.notSupported": {
-    "text": "このブラウザでは生体認証がサポートされていません",
+    "text": "このブラウザでは生体認証はサポートされていません",
     "source_hash": "fe2a2c2b"
   },
   "web.auth.webauthn.requiresModernBrowser": {
-    "text": "WebAuthnをサポートする最新のブラウザ(Chrome、Safari、Firefox、またはEdge)をご使用ください",
+    "text": "WebAuthnをサポートする最新のブラウザ（Chrome、Safari、Firefox、またはEdge）を使用してください",
     "source_hash": "fd9752eb"
   },
   "web.auth.webauthn.setupSuccess": {
@@ -199,11 +199,11 @@
     "source_hash": "63407e97"
   },
   "web.auth.webauthn.setupFailed": {
-    "text": "生体認証ログインの設定に失敗しました",
+    "text": "生体認証ログインのセットアップに失敗しました",
     "source_hash": "290cca44"
   },
   "web.auth.webauthn.passwordRequired": {
-    "text": "パスキーを設定するにはパスワードが必要です",
+    "text": "パスキーをセットアップするにはパスワードが必要です",
     "source_hash": "085bb238"
   },
   "web.auth.webauthn.authFailed": {
@@ -219,11 +219,11 @@
     "source_hash": "1f6087c2"
   },
   "web.auth.webauthn.description": {
-    "text": "指紋、顔、またはセキュリティキーでログイン",
+    "text": "指紋、顔、またはセキュリティキーを使用してサインイン",
     "source_hash": "f02f0427"
   },
   "web.auth.webauthn.supportedMethods": {
-    "text": "Face ID、Touch ID、Windows Hello、セキュリティキーに対応",
+    "text": "Face ID、Touch ID、Windows Hello、セキュリティキーをサポート",
     "source_hash": "3ea1c1a2"
   },
   "web.auth.passkeys.title": {
@@ -267,7 +267,7 @@
     "source_hash": "67b1d47c"
   },
   "web.auth.passkeys.confirm_remove": {
-    "text": "このパスキーを削除してもよろしいですか?削除すると、このパスキーでサインインできなくなります。",
+    "text": "このパスキーを削除してもよろしいですか？これを使用してサインインできなくなります。",
     "context": "Confirmation message for passkey removal",
     "source_hash": "487ab72c"
   },
@@ -282,12 +282,12 @@
     "source_hash": "fbfb0713"
   },
   "web.auth.passkeys.no_passkeys": {
-    "text": "登録されたパスキーはありません",
+    "text": "パスキーが登録されていません",
     "context": "Empty state when no passkeys exist",
     "source_hash": "1d97fde4"
   },
   "web.auth.passkeys.no_passkeys_description": {
-    "text": "パスキーを追加して、パスワードを入力せずにより安全にサインインしましょう",
+    "text": "パスワードを入力せずにより安全にサインインするためにパスキーを追加してください",
     "context": "Description for empty state",
     "source_hash": "e5bc07f1"
   },
@@ -297,7 +297,7 @@
     "source_hash": "22eefa67"
   },
   "web.auth.passkeys.created": {
-    "text": "作成日",
+    "text": "作成日時",
     "context": "Label for creation date",
     "source_hash": "d70b9e24"
   },
@@ -312,17 +312,17 @@
     "source_hash": "24d3236c"
   },
   "web.auth.passkeys.benefit_secure": {
-    "text": "パスワードより安全 - フィッシング攻撃に強い",
+    "text": "パスワードより安全 - フィッシング攻撃に耐性あり",
     "context": "Passkey benefit",
     "source_hash": "41afb6ec"
   },
   "web.auth.passkeys.benefit_fast": {
-    "text": "高速で簡単 - 指紋、顔認証、またはセキュリティキーを使用するだけ",
+    "text": "高速で簡単 - 指紋、顔、またはセキュリティキーを使用するだけ",
     "context": "Passkey benefit",
     "source_hash": "5a0ce96c"
   },
   "web.auth.passkeys.benefit_synced": {
-    "text": "プラットフォーム認証を使用すると、デバイス間で同期されます",
+    "text": "プラットフォーム認証機能を使用する場合、デバイス間で同期",
     "context": "Passkey benefit",
     "source_hash": "7480c7ae"
   },
@@ -332,11 +332,11 @@
     "source_hash": "c87ccdb4"
   },
   "web.auth.lockout.attempts_remaining": {
-    "text": "警告: ログイン試行回数が残り{count}回です",
+    "text": "警告: 残りログイン試行回数{count}回",
     "source_hash": "151dcb5e"
   },
   "web.auth.lockout.account_locked": {
-    "text": "ログイン失敗回数が多すぎるためアカウントがロックされました",
+    "text": "ログイン失敗が多すぎるため、アカウントがロックされました",
     "source_hash": "5247f389"
   },
   "web.auth.lockout.locked_until": {
@@ -356,7 +356,7 @@
     "context": "User's logged-in devices/browsers management page"
   },
   "web.auth.sessions.title": {
-    "text": "アクティブセッション",
+    "text": "アクティブなセッション",
     "source_hash": "b58fa4e0"
   },
   "web.auth.sessions.current": {
@@ -364,7 +364,7 @@
     "source_hash": "386c7932"
   },
   "web.auth.sessions.other": {
-    "text": "その他のセッション",
+    "text": "他のセッション",
     "source_hash": "8409f445"
   },
   "web.auth.sessions.device": {
@@ -384,7 +384,7 @@
     "source_hash": "b6dc1b95"
   },
   "web.auth.sessions.created": {
-    "text": "作成日",
+    "text": "作成日時",
     "source_hash": "d70b9e24"
   },
   "web.auth.sessions.remove": {
@@ -392,15 +392,15 @@
     "source_hash": "c3812fc4"
   },
   "web.auth.sessions.remove_all": {
-    "text": "他のすべてのセッションをログアウト",
+    "text": "他のすべてのセッションからログアウト",
     "source_hash": "412bb9e2"
   },
   "web.auth.sessions.confirm_remove": {
-    "text": "このセッションを削除してもよろしいですか?",
+    "text": "このセッションを削除してもよろしいですか？",
     "source_hash": "ef12c1ba"
   },
   "web.auth.sessions.confirm_remove_all": {
-    "text": "他のすべてのデバイスからログアウトします。よろしいですか?",
+    "text": "他のすべてのデバイスからログアウトされます。よろしいですか？",
     "source_hash": "4a1a73e9"
   },
   "web.auth.sessions.no_sessions": {
@@ -408,15 +408,15 @@
     "source_hash": "b83317f2"
   },
   "web.auth.sessions.removed_success": {
-    "text": "セッションを削除しました",
+    "text": "セッションが正常に削除されました",
     "source_hash": "6d27d44a"
   },
   "web.auth.sessions.removed_all_success": {
-    "text": "他のすべてのセッションをログアウトしました",
+    "text": "他のすべてのセッションがログアウトされました",
     "source_hash": "1b49e75c"
   },
   "web.auth.sessions.link_title": {
-    "text": "アクティブセッション",
+    "text": "アクティブなセッション",
     "source_hash": "b58fa4e0"
   },
   "web.auth.mfa.title": {
@@ -432,15 +432,15 @@
     "source_hash": "0af18e50"
   },
   "web.auth.mfa.enable": {
-    "text": "二要素認証を有効化",
+    "text": "二要素認証を有効にする",
     "source_hash": "9b83e658"
   },
   "web.auth.mfa.disable": {
-    "text": "二要素認証を無効化",
+    "text": "二要素認証を無効にする",
     "source_hash": "c9698815"
   },
   "web.auth.mfa.setup_title": {
-    "text": "二要素認証を設定",
+    "text": "二要素認証のセットアップ",
     "source_hash": "04e05601"
   },
   "web.auth.mfa.setup_description": {
@@ -456,15 +456,15 @@
     "source_hash": "59bba5f7"
   },
   "web.auth.mfa.scan_qr": {
-    "text": "認証アプリでこのQRコードをスキャン",
+    "text": "認証アプリでこのQRコードをスキャンしてください",
     "source_hash": "65752db3"
   },
   "web.auth.mfa.manual_entry": {
-    "text": "またはこのコードを手動で入力",
+    "text": "または、このコードを手動で入力してください",
     "source_hash": "3ea15b3e"
   },
   "web.auth.mfa.verify_code": {
-    "text": "アプリからの6桁のコードを入力",
+    "text": "アプリから6桁のコードを入力してください",
     "source_hash": "38f61733"
   },
   "web.auth.mfa.enter_code": {
@@ -472,7 +472,7 @@
     "source_hash": "186a582a"
   },
   "web.auth.mfa.verify": {
-    "text": "確認して有効化",
+    "text": "確認して有効にする",
     "source_hash": "7c08f68d"
   },
   "web.auth.mfa.verify_login": {
@@ -496,7 +496,7 @@
     "source_hash": "4fd6b4b4"
   },
   "web.auth.mfa.require_password": {
-    "text": "2FAを無効化するにはパスワードを入力",
+    "text": "2FAを無効にするにはパスワードを入力してください",
     "source_hash": "c384b93c"
   },
   "web.auth.mfa.password_confirmation": {
@@ -504,7 +504,7 @@
     "source_hash": "e7cf3ef4"
   },
   "web.auth.mfa.password_reason": {
-    "text": "二要素認証設定を変更するには本人確認が必要です",
+    "text": "二要素認証の設定を変更するために本人確認を行います",
     "source_hash": "09a96c07"
   },
   "web.auth.mfa.last_used": {
@@ -528,11 +528,11 @@
     "source_hash": "6fa090b4"
   },
   "web.auth.mfa.cancel": {
-    "text": "キャンセルしてログインに戻る",
+    "text": "キャンセルしてサインインに戻る",
     "source_hash": "83256742"
   },
   "web.auth.mfa.cancel_sign_in": {
-    "text": "ログインをキャンセル",
+    "text": "サインインをキャンセル",
     "source_hash": "1bebad2f"
   },
   "web.auth.mfa.loading_status": {
@@ -556,7 +556,7 @@
     "source_hash": "6ee8ab12"
   },
   "web.auth.mfa.benefit_recovery": {
-    "text": "緊急アクセス用のリカバリーコードをバックアップ",
+    "text": "緊急アクセス用のバックアップリカバリーコード",
     "source_hash": "747917bb"
   },
   "web.auth.mfa.password_placeholder": {
@@ -568,7 +568,7 @@
     "source_hash": "e4080e19"
   },
   "web.auth.mfa.disable_button": {
-    "text": "2FAを無効化",
+    "text": "2FAを無効にする",
     "source_hash": "1c3193f3"
   },
   "web.auth.mfa.generating_qr": {
@@ -580,15 +580,15 @@
     "source_hash": "a8eaef9d"
   },
   "web.auth.mfa.continue_verification": {
-    "text": "確認を続ける",
+    "text": "確認に進む",
     "source_hash": "4da96e87"
   },
   "web.auth.mfa.enter_code_description": {
-    "text": "認証アプリからの6桁のコードを入力",
+    "text": "認証アプリから6桁のコードを入力してください",
     "source_hash": "a160dee6"
   },
   "web.auth.mfa.enable_and_continue": {
-    "text": "MFAを有効化",
+    "text": "MFAを有効にする",
     "source_hash": "37c8090d"
   },
   "web.auth.mfa.complete_setup": {
@@ -596,7 +596,7 @@
     "source_hash": "30e87601"
   },
   "web.auth.mfa.enter_recovery_code": {
-    "text": "リカバリーコードの1つを入力",
+    "text": "リカバリーコードの1つを入力してください",
     "source_hash": "91ab44cf"
   },
   "web.auth.mfa.recovery_code_label": {
@@ -636,11 +636,11 @@
     "source_hash": "579c7f4e"
   },
   "web.auth.recovery_codes.description": {
-    "text": "これらのコードを安全な場所に保存してください。認証アプリにアクセスできなくなった場合、各コードを1回使用できます。",
+    "text": "これらのコードを安全な場所に保存してください。認証アプリにアクセスできなくなった場合、各コードは1回使用できます。",
     "source_hash": "87aebdfb"
   },
   "web.auth.recovery_codes.warning": {
-    "text": "これらのコードは一度だけ表示されます",
+    "text": "これらのコードは1回のみ表示されます",
     "source_hash": "d13f2877"
   },
   "web.auth.recovery_codes.save_required": {
@@ -656,7 +656,7 @@
     "source_hash": "aa652d21"
   },
   "web.auth.recovery_codes.generate_new_warning": {
-    "text": "これにより既存のすべてのリカバリーコードが無効になります",
+    "text": "これにより、既存のすべてのリカバリーコードが無効になります",
     "source_hash": "9795a175"
   },
   "web.auth.recovery_codes.download": {
@@ -664,7 +664,7 @@
     "source_hash": "9c23dbba"
   },
   "web.auth.recovery_codes.downloaded": {
-    "text": "リカバリーコードをダウンロードしました",
+    "text": "リカバリーコードがダウンロードされました",
     "source_hash": "10486340"
   },
   "web.auth.recovery_codes.print": {
@@ -676,11 +676,11 @@
     "source_hash": "ee956b2b"
   },
   "web.auth.recovery_codes.copied": {
-    "text": "コードをクリップボードにコピーしました",
+    "text": "コードがクリップボードにコピーされました",
     "source_hash": "06ebb466"
   },
   "web.auth.recovery_codes.copy_failed": {
-    "text": "コードのコピーに失敗しました",
+    "text": "コードをクリップボードにコピーできませんでした",
     "source_hash": "e8be6a51"
   },
   "web.auth.recovery_codes.code_used": {
@@ -692,7 +692,7 @@
     "source_hash": "231aedff"
   },
   "web.auth.recovery_codes.remaining": {
-    "text": "リカバリーコード: {limit}件中{count}件残り",
+    "text": "リカバリーコード残り{count}/{limit}",
     "source_hash": "b5d484e7"
   },
   "web.auth.recovery_codes.usage_hint": {
@@ -716,11 +716,11 @@
     "source_hash": "ce770667"
   },
   "web.auth.mfa.alternative_auth_options": {
-    "text": "別の認証方法",
+    "text": "代替認証オプション",
     "source_hash": "5ddea736"
   },
   "web.auth.remember.enabled": {
-    "text": "ログイン状態を保持する",
+    "text": "サインイン状態を維持",
     "source_hash": "b0a1ca80"
   },
   "web.auth.sessions.session_singular": {
@@ -730,5 +730,201 @@
   "web.auth.sessions.session_plural": {
     "text": "セッション",
     "source_hash": "1225ae6c"
+  },
+  "web.auth.connections.title": {
+    "text": "接続済みのID",
+    "source_hash": "e132c4d9"
+  },
+  "web.auth.connections.description": {
+    "text": "アカウントにリンクされたシングルサインオンプロバイダーを管理します。",
+    "source_hash": "42c6d148"
+  },
+  "web.auth.connections.section_title": {
+    "text": "シングルサインオン",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.section_subtitle": {
+    "text": "このアカウントへのサインインに使用できるIDプロバイダー",
+    "source_hash": "507254cd"
+  },
+  "web.auth.connections.connect_title": {
+    "text": "プロバイダーを接続",
+    "source_hash": "a002b3f3"
+  },
+  "web.auth.connections.connect_description": {
+    "text": "このアカウントへのサインインに使用できる別のシングルサインオンプロバイダーをリンクします。",
+    "source_hash": "32895a5a"
+  },
+  "web.auth.connections.connect_action": {
+    "text": "{provider}を接続",
+    "source_hash": "c77540af"
+  },
+  "web.auth.connections.issuer": {
+    "text": "発行者",
+    "source_hash": "39e02c46"
+  },
+  "web.auth.connections.identifier": {
+    "text": "識別子",
+    "source_hash": "9b10587f"
+  },
+  "web.auth.connections.remove": {
+    "text": "削除",
+    "source_hash": "c3812fc4"
+  },
+  "web.auth.connections.remove_confirm_title": {
+    "text": "接続済みのIDを削除",
+    "source_hash": "4e8ffe4c"
+  },
+  "web.auth.connections.remove_confirm_message": {
+    "text": "この接続済みのIDを削除してもよろしいですか？これを使用してサインインできなくなります。",
+    "source_hash": "64939c89"
+  },
+  "web.auth.connections.removed_success": {
+    "text": "接続済みのIDが削除されました",
+    "source_hash": "cf87daf3"
+  },
+  "web.auth.connections.no_identities": {
+    "text": "接続済みのIDがありません",
+    "source_hash": "5254048e"
+  },
+  "web.auth.connections.no_identities_description": {
+    "text": "このアカウントにはまだシングルサインオンプロバイダーがリンクされていません。",
+    "source_hash": "0f58d5d0"
+  },
+  "web.auth.connections.overview_status": {
+    "text": "シングルサインオン",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.errors.last_credential": {
+    "text": "これはサインインする唯一の方法です。ロックアウトされないように、まず別のプロバイダーを接続するか、設定→セキュリティからパスワードを設定してください。",
+    "source_hash": "3de8084d"
+  },
+  "web.auth.connections.errors.last_credential_sso_enforced": {
+    "text": "これはサインインする唯一の方法です。ロックアウトされないように、まず別のプロバイダーを接続してください。",
+    "source_hash": "eed7a50e"
+  },
+  "web.auth.connections.errors.not_found": {
+    "text": "その接続済みのIDが見つかりませんでした。すでに削除されている可能性があります。",
+    "source_hash": "cf2c7673"
+  },
+  "web.auth.connections.errors.unauthorized": {
+    "text": "セッションの有効期限が切れました。もう一度サインインしてください。",
+    "source_hash": "b529fce2"
+  },
+  "web.auth.connections.errors.generic": {
+    "text": "そのアクションを完了できませんでした。もう一度お試しください。",
+    "source_hash": "a0d4edc0"
+  },
+  "web.link_sso.title": {
+    "text": "サインイン方法をリンク",
+    "source_hash": "46339bac"
+  },
+  "web.link_sso.prompt": {
+    "text": "{provider}でサインインしました。これは既存のアカウント{email}と一致します。{provider}をリンクして続行するには、そのアカウントのパスワードを入力してください。",
+    "source_hash": "59da1c08"
+  },
+  "web.link_sso.password_label": {
+    "text": "パスワード",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.link_sso.password_placeholder": {
+    "text": "既存のパスワード",
+    "source_hash": "ad4e56da"
+  },
+  "web.link_sso.submit": {
+    "text": "リンクして続行",
+    "source_hash": "c969b759"
+  },
+  "web.link_sso.cancel": {
+    "text": "キャンセル",
+    "source_hash": "19766ed6"
+  },
+  "web.link_sso.unavailable_title": {
+    "text": "このリンクリクエストは期限切れです",
+    "source_hash": "b53c7e55"
+  },
+  "web.link_sso.unavailable_message": {
+    "text": "セキュリティ上の理由から、このサインイン方法をリンクするリクエストは無効になりました。既存のパスワードでサインインしてから、セキュリティ設定→接続済みのIDでこのプロバイダーを接続してください。",
+    "source_hash": "f7e349d1"
+  },
+  "web.link_sso.unavailable_action": {
+    "text": "サインインに進む",
+    "source_hash": "d398cd0a"
+  },
+  "web.link_sso.errors.invalid_password": {
+    "text": "パスワードがこのアカウントと一致しません。もう一度お試しください。",
+    "source_hash": "3259b4f5"
+  },
+  "web.link_sso.errors.invalid_token": {
+    "text": "このリンクリクエストは期限切れか、すでに使用されています。既存のパスワードでサインインしてから、アカウント設定からこのプロバイダーを接続してください。",
+    "source_hash": "541f9127"
+  },
+  "web.link_sso.errors.link_conflict": {
+    "text": "このサインイン方法をリンクできませんでした。アカウントが変更されたか、このプロバイダーがすでに別のアカウントにリンクされている可能性があります。既存のパスワードでサインインしてから、セキュリティ設定→接続済みのIDで接続を管理してください。",
+    "source_hash": "7b0e0d0e"
+  },
+  "web.link_sso.errors.link_rate_limited": {
+    "text": "パスワードの試行回数が多すぎます。数分待ってからもう一度お試しください。",
+    "source_hash": "a95e78cd"
+  },
+  "web.link_sso.errors.invalid_request": {
+    "text": "このリンクリクエストを処理できませんでした。SSOプロバイダーでもう一度サインインしてください。",
+    "source_hash": "053b9fc6"
+  },
+  "web.link_sso.errors.generic": {
+    "text": "アカウントをリンクできませんでした。もう一度お試しください。",
+    "source_hash": "f727c174"
+  },
+  "web.sso_link_confirm.title": {
+    "text": "アカウント接続の確認",
+    "source_hash": "ad80bfe7"
+  },
+  "web.sso_link_confirm.prompt": {
+    "text": "{provider}でサインインしました。これはアカウント{email}と一致します。{provider}をこのアカウントに接続してサインインを完了するには、確認してください。",
+    "source_hash": "6ff0d6cc"
+  },
+  "web.sso_link_confirm.submit": {
+    "text": "確認して接続",
+    "source_hash": "5cf663e6"
+  },
+  "web.sso_link_confirm.cancel": {
+    "text": "キャンセル",
+    "source_hash": "19766ed6"
+  },
+  "web.sso_link_confirm.unavailable_title": {
+    "text": "このリンクリクエストを完了できません",
+    "source_hash": "47abb784"
+  },
+  "web.sso_link_confirm.unavailable_message": {
+    "text": "セキュリティ上の理由から、このサインイン方法を接続するリクエストは無効になりました。プロバイダーで再度サインインすると、新しいリンクをメールで送信します。",
+    "source_hash": "080e6f9f"
+  },
+  "web.sso_link_confirm.unavailable_action": {
+    "text": "サインインに戻る",
+    "source_hash": "8504054f"
+  },
+  "web.sso_link_confirm.errors.link_expired": {
+    "text": "このリンクリクエストは期限切れか、すでに使用されています。プロバイダーで再度サインインすると、新しいリンクをメールで送信します。",
+    "source_hash": "a50538df"
+  },
+  "web.sso_link_confirm.errors.link_conflict": {
+    "text": "このサインイン方法を接続できませんでした。アカウントが変更されたか、このプロバイダーがすでに別のアカウントにリンクされている可能性があります。続行するにはプロバイダーで再度サインインしてください。",
+    "source_hash": "c954854b"
+  },
+  "web.sso_link_confirm.errors.link_invalidated": {
+    "text": "このリンクが送信された後にアカウントの資格情報が変更されたため、リンクは無効になりました。プロバイダーで再度サインインすると、新しいリンクをメールで送信します。",
+    "source_hash": "db88cb1d"
+  },
+  "web.sso_link_confirm.errors.link_error": {
+    "text": "このリンクを確認できませんでした。プロバイダーで再度サインインすると、新しいリンクをメールで送信します。",
+    "source_hash": "ec24e0a1"
+  },
+  "web.sso_link_confirm.errors.confirm_rate_limited": {
+    "text": "デバイスからの試行回数が多すぎます。数分待ってから、メールで送信されたリンクを再度開くか、プロバイダーでサインインして新しいリンクを取得してください。",
+    "source_hash": "f29af782"
+  },
+  "web.sso_link_confirm.errors.generic": {
+    "text": "この接続を確認できませんでした。プロバイダーで再度サインインしてください。",
+    "source_hash": "076fa25a"
   }
 }

--- a/locales/content/ja/session-auth.json
+++ b/locales/content/ja/session-auth.json
@@ -1,22 +1,22 @@
 {
   "web.login.alternate_prefix": {
-    "text": "アカウントが必要ですか?",
+    "text": "アカウントが必要ですか？",
     "source_hash": "8b827e19"
   },
   "web.login.need_an_account": {
-    "text": "登録する",
+    "text": "サインアップ。",
     "source_hash": "10647723"
   },
   "web.login.forgot_your_password": {
-    "text": "パスワードを忘れましたか?",
+    "text": "パスワードを忘れましたか？",
     "source_hash": "afd25fdf"
   },
   "web.login.button_sign_in": {
-    "text": "ログイン",
+    "text": "サインイン",
     "source_hash": "bcc0bcc9"
   },
   "web.login.enter_your_credentials": {
-    "text": "認証情報を入力",
+    "text": "資格情報を入力",
     "source_hash": "07e1c44e"
   },
   "web.login.remember_me": {
@@ -24,11 +24,11 @@
     "source_hash": "f93267aa"
   },
   "web.login.send_sign_in_link": {
-    "text": "ログインリンクを送信",
+    "text": "サインインリンクを送信",
     "source_hash": "b1402b67"
   },
   "web.login.secure_link_helper": {
-    "text": "安全なリンクがメールに送信されます。",
+    "text": "安全なリンクがメールの受信トレイに送信されます。",
     "source_hash": "d31d20cf"
   },
   "web.login.or_divider": {
@@ -36,11 +36,11 @@
     "source_hash": "7175517a"
   },
   "web.login.sign_in_with_password": {
-    "text": "パスワードでログイン",
+    "text": "パスワードでサインイン",
     "source_hash": "bedac809"
   },
   "web.login.use_passwordless": {
-    "text": "パスワードなしでログイン",
+    "text": "パスワードなしでサインイン",
     "source_hash": "dddc0097"
   },
   "web.login.create_account": {
@@ -64,19 +64,19 @@
     "source_hash": "904c9aa9"
   },
   "web.login.need_help": {
-    "text": "ヘルプが必要ですか?",
+    "text": "ヘルプが必要ですか？",
     "source_hash": "c225cdfb"
   },
   "web.login.or_continue_with": {
-    "text": "または次で続行",
+    "text": "または以下で続行",
     "source_hash": "eb4e8d3b"
   },
   "web.login.sign_in_with_sso": {
-    "text": "SSOでログイン",
+    "text": "SSOでサインイン",
     "source_hash": "73e984e9"
   },
   "web.login.sign_in_with_provider": {
-    "text": "{provider}でログイン",
+    "text": "{provider}でサインイン",
     "source_hash": "b8794f11"
   },
   "web.auth.sso.signing_in": {
@@ -88,7 +88,7 @@
     "source_hash": "45a1e65d"
   },
   "web.login.errors.sso_failed": {
-    "text": "SSO認証に失敗しました。もう一度お試しいただくか、パスワードでログインしてください。",
+    "text": "SSO認証に失敗しました。もう一度試すか、パスワードでログインしてください。",
     "source_hash": "13a2210a"
   },
   "web.login.errors.token_missing": {
@@ -108,11 +108,11 @@
     "source_hash": "5f4c33d7"
   },
   "web.signup.alternate_prefix": {
-    "text": "既にアカウントをお持ちですか?",
+    "text": "すでにアカウントをお持ちですか？",
     "source_hash": "f5dcb5d5"
   },
   "web.signup.have_an_account": {
-    "text": "ログイン",
+    "text": "サインイン。",
     "source_hash": "6c52846f"
   },
   "web.signup.error_title": {
@@ -131,51 +131,51 @@
     "context": "Email verification flow after signup"
   },
   "web.auth.verify.title": {
-    "text": "アカウントを認証",
+    "text": "アカウントを確認",
     "source_hash": "3e2303ab"
   },
   "web.auth.verify.success": {
-    "text": "アカウントが正常に認証されました",
+    "text": "アカウントが正常に確認されました",
     "source_hash": "902d0f47"
   },
   "web.auth.verify.invalid_key": {
-    "text": "無効または期限切れの認証キー",
+    "text": "無効または期限切れの確認キー",
     "source_hash": "70fe7dfe"
   },
   "web.auth.verify.expired_key": {
-    "text": "この認証リンクは期限切れです。新しいリンクをリクエストしてください。",
+    "text": "この確認リンクは期限切れです。新しいリンクをリクエストしてください。",
     "source_hash": "ee3ed5d2"
   },
   "web.auth.verify.already_verified": {
-    "text": "このアカウントは既に認証されています。ログインできます。",
+    "text": "このアカウントはすでに確認済みです。今すぐサインインできます。",
     "source_hash": "cec1312b"
   },
   "web.auth.verify.unable_to_verify": {
-    "text": "アカウントを認証できませんでした。もう一度お試しいただくか、サポートにお問い合わせください。",
+    "text": "アカウントを確認できません。もう一度お試しいただくか、サポートにお問い合わせください。",
     "source_hash": "c0df463f"
   },
   "web.auth.verify.check_email": {
-    "text": "認証リンクについてメールを確認してください",
+    "text": "確認リンクについてメールを確認してください",
     "source_hash": "79ffefd8"
   },
   "web.auth.verify.error": {
-    "text": "アカウントの認証に失敗しました。認証リンクを確認するか、新しいリンクをリクエストしてください。",
+    "text": "アカウントの確認に失敗しました。確認リンクを確認するか、新しいリンクをリクエストしてください。",
     "source_hash": "7aac4a45"
   },
   "web.auth.verify.error_title": {
-    "text": "認証に失敗しました",
+    "text": "確認に失敗しました",
     "source_hash": "cb3a722b"
   },
   "web.auth.verify.what_to_do": {
-    "text": "どうすればいいですか?",
+    "text": "どうすればいいですか？",
     "source_hash": "00eeea79"
   },
   "web.auth.verify.check_email_help": {
-    "text": "最新の認証リンクについてメールを確認してください",
+    "text": "最新の確認リンクについてメールを確認してください",
     "source_hash": "1c4a5748"
   },
   "web.auth.verify.check_spam": {
-    "text": "メールが見つからない場合は迷惑メールフォルダを確認してください",
+    "text": "メールが見つからない場合は、迷惑メールフォルダを確認してください",
     "source_hash": "ae481e5e"
   },
   "web.auth.verify.contact_support": {
@@ -183,11 +183,11 @@
     "source_hash": "c0067275"
   },
   "web.auth.verify.missing_key_title": {
-    "text": "認証リンクが必要です",
+    "text": "確認リンクが必要です",
     "source_hash": "e0b448ac"
   },
   "web.auth.verify.missing_key_message": {
-    "text": "アカウントを認証するには、メールアドレスに送信された認証リンクを使用してください。",
+    "text": "アカウントを確認するには、メールアドレスに送信された確認リンクを使用してください。",
     "source_hash": "b1a8cfc6"
   },
   "web.auth.verify.create_new_account": {
@@ -223,11 +223,11 @@
     "source_hash": "e1513814"
   },
   "web.auth.close_account.warning": {
-    "text": "この操作は取り消せません。すべてのシークレットが完全に削除されます。",
+    "text": "この操作は元に戻せません。すべてのシークレットが完全に削除されます。",
     "source_hash": "f12de64e"
   },
   "web.auth.close_account.confirm": {
-    "text": "この操作は取り消せないことを理解しています",
+    "text": "この操作は永久的であることを理解しています",
     "source_hash": "b44b1366"
   },
   "web.auth.close_account.password": {
@@ -247,7 +247,7 @@
     "source_hash": "456d421c"
   },
   "web.auth.password_reset_request.description": {
-    "text": "以下にメールアドレスを入力すると、パスワードをリセットするためのリンクを送信します",
+    "text": "下にメールアドレスを入力すると、パスワードをリセットするためのリンクを送信します",
     "source_hash": "31c5f80f"
   },
   "web.auth.password_reset_request.button": {
@@ -260,15 +260,15 @@
     "source_hash": "3dfdf7c4"
   },
   "web.auth.password_reset.description": {
-    "text": "以下に新しいパスワードを入力してください。アカウントを保護するため、強力でユニークなものにしてください。",
+    "text": "下に新しいパスワードを入力してください。アカウントを保護するために、強力でユニークなパスワードにしてください。",
     "source_hash": "5c789083"
   },
   "web.auth.passwordReset.emailSent": {
-    "text": "アカウントのパスワードをリセットするためのリンクが記載されたメールを送信しました",
+    "text": "アカウントのパスワードをリセットするためのリンクを含むメールが送信されました",
     "source_hash": "63a6af45"
   },
   "web.auth.terms.agree_prefix": {
-    "text": "同意します:",
+    "text": "同意します",
     "source_hash": "26a58d00"
   },
   "web.auth.account.title": {
@@ -285,7 +285,7 @@
     "source_hash": "9966be40"
   },
   "web.auth.account.verified": {
-    "text": "メール認証済み",
+    "text": "メール確認済み",
     "source_hash": "bc512ab0"
   },
   "web.auth.account.region": {
@@ -293,11 +293,11 @@
     "source_hash": "d3a008ef"
   },
   "web.auth.account.not_verified": {
-    "text": "メール未認証",
+    "text": "メール未確認",
     "source_hash": "53955e0e"
   },
   "web.auth.account.verify_email": {
-    "text": "メールアドレスを認証",
+    "text": "メールアドレスを確認",
     "source_hash": "d261b9df"
   },
   "web.auth.account.mfa_status": {
@@ -313,11 +313,11 @@
     "source_hash": "75081b59"
   },
   "web.auth.account.active_sessions": {
-    "text": "アクティブセッション",
+    "text": "アクティブなセッション",
     "source_hash": "b58fa4e0"
   },
   "web.auth.account.session_count": {
-    "text": "{count}件のアクティブセッション",
+    "text": "アクティブなセッション{count}件",
     "source_hash": "7de8d92a"
   },
   "web.auth.account.quick_actions": {
@@ -329,7 +329,7 @@
     "source_hash": "06fc8f72"
   },
   "web.auth.account.manage_sessions": {
-    "text": "アクティブセッションを管理",
+    "text": "アクティブなセッションを管理",
     "source_hash": "c5d54d87"
   },
   "web.auth.account.change_password": {
@@ -345,11 +345,11 @@
     "source_hash": "1f8ecc24"
   },
   "web.help.signin_troubleshooting": {
-    "text": "ログインのトラブルシューティング",
+    "text": "サインインのトラブルシューティング",
     "source_hash": "a9a88a01"
   },
   "web.help.magic_link_not_arriving": {
-    "text": "マジックリンクが届きませんか?",
+    "text": "マジックリンクが届きませんか？",
     "source_hash": "6919ce70"
   },
   "web.help.check_spam_folder": {
@@ -361,35 +361,35 @@
     "source_hash": "5f319557"
   },
   "web.help.wait_few_minutes": {
-    "text": "数分お待ちください - メールが遅れることがあります",
+    "text": "数分お待ちください。メールが遅れることがあります",
     "source_hash": "884fc272"
   },
   "web.help.try_again": {
-    "text": "10分以上経過した場合は、新しいリンクをリクエストしてください",
+    "text": "10分以上経過した場合は、新しいリンクをリクエストしてみてください",
     "source_hash": "68109f96"
   },
   "web.help.forgot_password": {
-    "text": "パスワードを忘れましたか?",
+    "text": "パスワードを忘れましたか？",
     "source_hash": "afd25fdf"
   },
   "web.help.use_magic_link_instead": {
-    "text": "新しいパスワードを作成するために、パスワードリセットリンクをリクエストできます。",
+    "text": "パスワードリセットリンクをリクエストして新しいパスワードを作成できます。",
     "source_hash": "3c3eabad"
   },
   "web.help.account_locked": {
-    "text": "アカウントが一時的にロックされましたか?",
+    "text": "アカウントが一時的にロックされていますか？",
     "source_hash": "ef1251c1"
   },
   "web.help.account_locked_explanation": {
-    "text": "複数回のログイン失敗後、セキュリティのためアカウントは一時的にロックされます。15分待ってから再試行するか、マジックリンクを使用してログインしてください。",
+    "text": "複数回のサインイン失敗後、アカウントはセキュリティのために一時的にロックされます。15分待ってから再試行するか、マジックリンクを使用してサインインしてください。",
     "source_hash": "4b2cf891"
   },
   "web.help.still_need_help": {
-    "text": "まだ助けが必要ですか?",
+    "text": "まだお困りですか？",
     "source_hash": "5ff7d19e"
   },
   "web.help.contact_us_description": {
-    "text": "まだ問題がある場合は、お手伝いします。メッセージをお送りいただければ、できるだけ早くご連絡いたします。",
+    "text": "まだ問題が解決しない場合は、私たちがお手伝いします。メッセージを送信してください。できるだけ早くご連絡いたします。",
     "source_hash": "d97c90fe"
   },
   "web.help.contact_support": {
@@ -405,19 +405,19 @@
     "source_hash": "e0edfeb3"
   },
   "web.login.custom_domain_sso_title": {
-    "text": "このドメインではシングルサインオンを利用できます",
+    "text": "このドメインではシングルサインオンが利用可能です",
     "source_hash": "af87d51e"
   },
   "web.login.custom_domain_sso_description": {
-    "text": "組織の管理者がSSOを有効にすると、チームメンバーはここからログインできるようになります。アクセスについては管理者にお問い合わせください。",
+    "text": "組織の管理者はSSOを有効にして、チームメンバーがここでサインインできるようにすることができます。アクセスについては管理者にお問い合わせください。",
     "source_hash": "f3726509"
   },
   "web.login.signin_disabled_heading": {
-    "text": "ログインは利用できません",
+    "text": "サインインは利用できません",
     "source_hash": "6b435c76"
   },
   "web.login.signin_disabled_message": {
-    "text": "このドメインでは現在ログインを利用できません。",
+    "text": "このドメインでは現在サインインは利用できません。",
     "source_hash": "b681c35d"
   },
   "web.login.errors.sso_not_configured": {
@@ -425,19 +425,19 @@
     "source_hash": "b39ef93e"
   },
   "web.login.errors.invalid_email": {
-    "text": "IDプロバイダーから取得したメールアドレスが無効です。管理者にお問い合わせください。",
+    "text": "IDプロバイダーからのメールアドレスが無効です。管理者にお問い合わせください。",
     "source_hash": "10c12029"
   },
   "web.login.errors.domain_not_allowed": {
-    "text": "お使いのメールドメインはSSO登録の対象として許可されていません。管理者にお問い合わせください。",
+    "text": "メールドメインはSSOサインアップに対して承認されていません。管理者にお問い合わせください。",
     "source_hash": "87603782"
   },
   "web.auth.check_email.title": {
-    "text": "メールをご確認ください",
+    "text": "メールを確認してください",
     "source_hash": "77322879"
   },
   "web.auth.check_email.sent_to_generic": {
-    "text": "確認リンクをお客様のメールアドレスに送信しました。",
+    "text": "メールアドレスに確認リンクを送信しました。",
     "source_hash": "4e5510af"
   },
   "web.auth.check_email.help": {
@@ -445,11 +445,11 @@
     "source_hash": "8babedc4"
   },
   "web.auth.check_email.spam_hint": {
-    "text": "見つかりませんか?迷惑メールフォルダをご確認ください。",
+    "text": "見つかりませんか？迷惑メールフォルダを確認してください。",
     "source_hash": "d166d9a4"
   },
   "web.auth.check_email.wrong_email": {
-    "text": "間違ったアドレスを入力しましたか?",
+    "text": "間違ったアドレスを入力しましたか？",
     "source_hash": "0aa863e5"
   },
   "web.auth.check_email.start_over": {
@@ -461,7 +461,7 @@
     "source_hash": "e7cf3ef4"
   },
   "web.auth.verify.resend_help_text": {
-    "text": "確認メールが届きませんでしたか?メールアドレスを入力して再送信してください。",
+    "text": "確認メールが届きませんでしたか？メールを入力して再送信してください。",
     "source_hash": "e0df48bb"
   },
   "web.auth.verify.resend_button": {
@@ -469,7 +469,7 @@
     "source_hash": "5173cc04"
   },
   "web.auth.verify.resend_sent": {
-    "text": "アカウントの確認が必要な場合は、新しいメールが送信されました。受信トレイと迷惑メールフォルダをご確認ください。",
+    "text": "アカウントに確認が必要な場合は、新しいメールが送信されました。受信トレイと迷惑メールフォルダを確認してください。",
     "source_hash": "6f838ffb"
   },
   "web.auth.verify.resend_error": {
@@ -481,7 +481,43 @@
     "source_hash": "4f44603e"
   },
   "web.login.verified_notice": {
-    "text": "メールが確認されました。ログインできるようになりました。",
+    "text": "メールが確認されました。今すぐサインインできます。",
     "source_hash": "c8d4b5a8"
+  },
+  "web.auth.password_setup_request.title": {
+    "text": "パスワードを設定",
+    "source_hash": "11b6978b"
+  },
+  "web.auth.password_setup_request.description": {
+    "text": "アカウントにはまだパスワードがありません。直接サインインできるように、パスワードを設定するための安全なリンクをメールで送信します。",
+    "source_hash": "dc0b561f"
+  },
+  "web.auth.password_setup_request.button": {
+    "text": "設定リンクを送信",
+    "source_hash": "22807292"
+  },
+  "web.auth.password_setup_request.emailSent": {
+    "text": "アカウントにパスワードを設定するためのリンクを含むメールが送信されました",
+    "source_hash": "82b686c7"
+  },
+  "web.login.errors.account_exists_link_required": {
+    "text": "このメールアドレスのアカウントはすでに存在しますが、このサインイン方法にリンクされていません。既存の方法でサインインしてから、セキュリティ設定→接続済みのIDでこのプロバイダーをリンクしてください。",
+    "source_hash": "7fbbb7e7"
+  },
+  "web.login.errors.identity_connect_conflict": {
+    "text": "このIDを接続できませんでした。接続が間違ったドメインで開始されたか、セッションの有効期限が切れた可能性があります。もう一度サインインしてから、アカウント設定から接続してください。",
+    "source_hash": "4238bbf2"
+  },
+  "web.login.errors.org_join_failed": {
+    "text": "組織への追加を完了できませんでした。管理者にお問い合わせください。",
+    "source_hash": "155e71bb"
+  },
+  "web.login.errors.link_sso_failed": {
+    "text": "そのサインイン方法をリンクできませんでした。既存のパスワードでサインインしてから、セキュリティ設定→接続済みのIDでこのプロバイダーを接続してください。",
+    "source_hash": "49954127"
+  },
+  "web.login.notices.link_verification_sent": {
+    "text": "受信トレイを確認してください。アカウントの接続を確認するためのリンクをメールで送信しました。サインインを完了するには、リンクを開いてください。",
+    "source_hash": "b251c8f3"
   }
 }

--- a/locales/content/ja/workspace-account.json
+++ b/locales/content/ja/workspace-account.json
@@ -12,7 +12,7 @@
     "source_hash": "e1513814"
   },
   "web.account.verify_account": {
-    "text": "アカウントを認証",
+    "text": "アカウントを確認",
     "source_hash": "2f3ea760"
   },
   "web.account.subscription_title": {
@@ -48,7 +48,7 @@
     "source_hash": "c60f014b"
   },
   "web.account.card_ending": {
-    "text": "末尾",
+    "text": "下4桁",
     "source_hash": "0195bccf"
   },
   "web.account.subscriptions_title": {
@@ -100,7 +100,7 @@
     "source_hash": "919bb4cb"
   },
   "web.account.created_windowprops_cust_secrets_created_secrets": {
-    "text": "{1}以降に{0}個のシークレットが作成されました。",
+    "text": "{1}以降に{0}個のシークレットを作成しました。",
     "source_hash": "8cb99810"
   },
   "web.account.delete_account": {
@@ -116,7 +116,7 @@
     "source_hash": "617bfe67"
   },
   "web.account.your_account": {
-    "text": "あなたのアカウント",
+    "text": "アカウント",
     "source_hash": "89e60bfb"
   },
   "web.account.support_details": {
@@ -136,7 +136,7 @@
     "source_hash": "05986d95"
   },
   "web.account.keep_this_token_secure_it_provides_full_access_t": {
-    "text": "このトークンは安全に保管してください。APIを通じてシークレットを作成・管理するために使用できます。",
+    "text": "このトークンを安全に保管してください。APIを介してシークレットを作成および管理するために使用できます。",
     "source_hash": "a63cc8ec"
   },
   "web.account.confirm_with_your_password": {
@@ -148,7 +148,7 @@
     "source_hash": "4fa3e4b8"
   },
   "web.account.confirm_account_deletion": {
-    "text": "アカウント削除を確認",
+    "text": "アカウント削除の確認",
     "source_hash": "bb3fc7e5"
   },
   "web.account.deleting_cust_custid": {
@@ -164,7 +164,7 @@
     "source_hash": "f894e42c"
   },
   "web.account.permanent_and_non_reversible": {
-    "text": "取り消しができません。",
+    "text": "永久的で元に戻せません。",
     "source_hash": "6121225e"
   },
   "web.account.deleting_your_account_is": {
@@ -180,7 +180,7 @@
     "source_hash": "b45e2dd5"
   },
   "web.account.secrets_will_remain_active_until_they_expire": {
-    "text": "シークレットは有効期限が切れるまでアクティブのままです。",
+    "text": "シークレットは期限切れになるまでアクティブのままです。",
     "source_hash": "ddb4e2b5"
   },
   "web.account.please_be_advised": {
@@ -196,7 +196,7 @@
     "source_hash": "fb1e6fa5"
   },
   "web.account.are_you_sure_you_want_to_deactivate_your_account": {
-    "text": "アカウントを無効化してもよろしいですか？すべてのデータは永久にサーバーから削除されます。この操作は元に戻せません。",
+    "text": "アカウントを無効化してもよろしいですか？すべてのデータがサーバーから永久に削除されます。この操作は元に戻せません。",
     "source_hash": "4940e20a"
   },
   "web.account.deactivate_account": {
@@ -208,11 +208,11 @@
     "source_hash": "74a883a0"
   },
   "web.settings.description": {
-    "text": "アカウント設定と環境設定を管理",
+    "text": "アカウントの設定と環境設定を管理できます",
     "source_hash": "2ff0853c"
   },
   "web.settings.manage_your_account_settings_and_preferences": {
-    "text": "アカウント設定と環境設定を管理します",
+    "text": "アカウントの設定と環境設定を管理できます",
     "source_hash": "2ff0853c"
   },
   "web.settings.back_to_dashboard": {
@@ -228,7 +228,7 @@
     "source_hash": "3ac8bbca"
   },
   "web.settings.sections.advanced": {
-    "text": "詳細",
+    "text": "詳細設定",
     "source_hash": "9f088dbe"
   },
   "web.settings.general": {
@@ -248,11 +248,11 @@
     "source_hash": "efb52e71"
   },
   "web.settings.theme.description": {
-    "text": "ライトまたはダークテーマを選択",
+    "text": "ライトまたはダークテーマを選択できます",
     "source_hash": "ff0ae84f"
   },
   "web.settings.theme.choose_light_or_dark_theme": {
-    "text": "ライトまたはダークテーマを選択",
+    "text": "ライトまたはダークテーマを選択できます",
     "source_hash": "ff0ae84f"
   },
   "web.settings.language.title": {
@@ -260,19 +260,19 @@
     "source_hash": "a4fe6526"
   },
   "web.settings.language.description": {
-    "text": "お好みの言語を選択",
+    "text": "ご希望の言語を選択してください",
     "source_hash": "475bba7a"
   },
   "web.settings.language.select_your_preferred_language": {
-    "text": "お好みの言語を選択",
+    "text": "ご希望の言語を選択してください",
     "source_hash": "475bba7a"
   },
   "web.settings.security_settings_description": {
-    "text": "認証とアカウントセキュリティを管理",
+    "text": "認証とアカウントのセキュリティを管理できます",
     "source_hash": "945109d1"
   },
   "web.settings.profile_settings_description": {
-    "text": "アカウント情報を管理",
+    "text": "アカウント情報を管理できます",
     "source_hash": "4a23a29f"
   },
   "web.settings.profile.title": {
@@ -280,11 +280,11 @@
     "source_hash": "d696a35b"
   },
   "web.settings.profile.change_email": {
-    "text": "メールを変更",
+    "text": "メールアドレスを変更",
     "source_hash": "18c3f2d5"
   },
   "web.settings.profile.current_email": {
-    "text": "現在のメール",
+    "text": "現在のメールアドレス",
     "source_hash": "5f1cab64"
   },
   "web.settings.profile.current_password": {
@@ -292,31 +292,31 @@
     "source_hash": "8ac76099"
   },
   "web.settings.profile.new_email": {
-    "text": "新しいメール",
+    "text": "新しいメールアドレス",
     "source_hash": "5bafb4be"
   },
   "web.settings.profile.enter_password_to_confirm": {
-    "text": "現在のパスワードを入力",
+    "text": "現在のパスワードを入力してください",
     "source_hash": "27814c03"
   },
   "web.settings.profile.password_required_for_security": {
-    "text": "セキュリティのためパスワードが必要です",
+    "text": "セキュリティのためにパスワードが必要です",
     "source_hash": "d18f62f2"
   },
   "web.settings.profile.verification_email_notice": {
-    "text": "新しいアドレスに認証メールが送信されます",
+    "text": "新しいアドレスに確認メールが送信されます",
     "source_hash": "575082a1"
   },
   "web.settings.profile.update_email": {
-    "text": "メールを更新",
+    "text": "メールアドレスを更新",
     "source_hash": "6ec61b2e"
   },
   "web.settings.profile.change_email_description": {
-    "text": "アカウントに関連付けられているメールアドレスを更新",
+    "text": "アカウントに関連付けられたメールアドレスを更新できます",
     "source_hash": "636abb16"
   },
   "web.settings.profile.all_fields_required": {
-    "text": "すべての項目が必須です",
+    "text": "すべてのフィールドが必須です",
     "source_hash": "04814271"
   },
   "web.settings.profile.invalid_email": {
@@ -324,7 +324,7 @@
     "source_hash": "b00f7e3a"
   },
   "web.settings.profile.email_same_as_current": {
-    "text": "新しいメールは現在のメールと異なる必要があります",
+    "text": "新しいメールアドレスは現在のものと異なる必要があります",
     "source_hash": "f7cfed6e"
   },
   "web.settings.profile.email_change_success": {
@@ -332,19 +332,19 @@
     "source_hash": "45f0a4b5"
   },
   "web.settings.profile.email_change_error": {
-    "text": "メールの更新に失敗しました。もう一度お試しください。",
+    "text": "メールアドレスの更新に失敗しました。もう一度お試しください。",
     "source_hash": "aeba6591"
   },
   "web.settings.sessions.title": {
-    "text": "アクティブセッション",
+    "text": "アクティブなセッション",
     "source_hash": "b58fa4e0"
   },
   "web.settings.sessions.description": {
-    "text": "アクティブセッションを管理",
+    "text": "アクティブなセッションを管理できます",
     "source_hash": "e5646da4"
   },
   "web.settings.sessions.manage_active_sessions": {
-    "text": "アクティブセッションを管理",
+    "text": "アクティブなセッションを管理できます",
     "source_hash": "e5646da4"
   },
   "web.settings.password.title": {
@@ -352,11 +352,11 @@
     "source_hash": "e7cf3ef4"
   },
   "web.settings.password.description": {
-    "text": "アカウントパスワードを更新",
+    "text": "アカウントのパスワードを更新できます",
     "source_hash": "cb3ae40b"
   },
   "web.settings.password.update_account_password": {
-    "text": "アカウントパスワードを更新",
+    "text": "アカウントのパスワードを更新できます",
     "source_hash": "cb3ae40b"
   },
   "web.settings.delete_account.title": {
@@ -364,11 +364,11 @@
     "source_hash": "c031bf99"
   },
   "web.settings.delete_account.description": {
-    "text": "アカウントとすべてのデータを完全に削除",
+    "text": "アカウントとすべてのデータを完全に削除します",
     "source_hash": "7a3a6da2"
   },
   "web.settings.delete_account.permanently_delete_your_account": {
-    "text": "アカウントとすべてのデータを完全に削除",
+    "text": "アカウントとすべてのデータを完全に削除します",
     "source_hash": "7a3a6da2"
   },
   "web.settings.security.security_score": {
@@ -376,7 +376,7 @@
     "source_hash": "02d2f374"
   },
   "web.settings.security.score_description": {
-    "text": "アカウント全体のセキュリティ状態",
+    "text": "アカウントの全体的なセキュリティ状態",
     "source_hash": "cf20935e"
   },
   "web.settings.security.excellent": {
@@ -396,11 +396,11 @@
     "source_hash": "8d6cea25"
   },
   "web.settings.security.improve_security": {
-    "text": "セキュリティを向上",
+    "text": "セキュリティを向上させる",
     "source_hash": "c38bcbf5"
   },
   "web.settings.security.enable_mfa_recommendation": {
-    "text": "より強力な保護のために二要素認証を有効化",
+    "text": "より強力な保護のために二要素認証を有効にしてください",
     "source_hash": "6beda528"
   },
   "web.settings.security.generate_recovery_codes_recommendation": {
@@ -420,19 +420,19 @@
     "source_hash": "5a234448"
   },
   "web.settings.security.enable": {
-    "text": "有効化",
+    "text": "有効にする",
     "source_hash": "5342e09f"
   },
   "web.settings.security.codes_available": {
-    "text": "{0}件のコードが利用可能",
+    "text": "{0}個のコードが利用可能",
     "source_hash": "76d6236d"
   },
   "web.settings.security.no_codes": {
-    "text": "コード未生成",
+    "text": "コードは生成されていません",
     "source_hash": "3b2eae20"
   },
   "web.settings.security.active_sessions": {
-    "text": "{0}件のアクティブセッション",
+    "text": "{0}個のアクティブなセッション",
     "source_hash": "30737484"
   },
   "web.settings.security.best_practices": {
@@ -440,19 +440,19 @@
     "source_hash": "fd71b2da"
   },
   "web.settings.security.use_strong_unique_password": {
-    "text": "アカウントには強力でユニークなパスワードを使用",
+    "text": "アカウントには強力でユニークなパスワードを使用してください",
     "source_hash": "5fc8cbf4"
   },
   "web.settings.security.enable_mfa_for_protection": {
-    "text": "追加の保護のために二要素認証を有効化",
+    "text": "追加の保護のために二要素認証を有効にしてください",
     "source_hash": "107e4898"
   },
   "web.settings.security.save_recovery_codes_safely": {
-    "text": "リカバリーコードを安全な場所に保存",
+    "text": "リカバリーコードは安全な場所に保存してください",
     "source_hash": "605513fc"
   },
   "web.settings.security.review_sessions_regularly": {
-    "text": "定期的にセッションを確認し、未使用のものを取り消す",
+    "text": "未使用のセッションを定期的に確認し、取り消してください",
     "source_hash": "efe59445"
   },
   "web.settings.security.view_details": {
@@ -460,15 +460,15 @@
     "source_hash": "d1bf045b"
   },
   "web.settings.api.title": {
-    "text": "APIと統合",
+    "text": "APIとインテグレーション",
     "source_hash": "21fc84f3"
   },
   "web.settings.api.description": {
-    "text": "APIキーと統合を管理",
+    "text": "APIキーとインテグレーションを管理できます",
     "source_hash": "70976099"
   },
   "web.settings.api.manage_api_keys": {
-    "text": "APIキーと統合を管理",
+    "text": "APIキーとインテグレーションを管理できます",
     "source_hash": "70976099"
   },
   "web.settings.api.documentation": {
@@ -500,23 +500,23 @@
     "source_hash": "fd71b2da"
   },
   "web.settings.api.never_commit_api_keys": {
-    "text": "APIキーをバージョン管理にコミットしない",
+    "text": "APIキーをバージョン管理にコミットしないでください",
     "source_hash": "cc8c327e"
   },
   "web.settings.api.use_environment_variables": {
-    "text": "APIキーの保存には環境変数を使用",
+    "text": "環境変数を使用してAPIキーを保存してください",
     "source_hash": "c05e8802"
   },
   "web.settings.api.rotate_keys_regularly": {
-    "text": "セキュリティのためAPIキーを定期的にローテーション",
+    "text": "セキュリティのためにAPIキーを定期的にローテーションしてください",
     "source_hash": "eda6a5db"
   },
   "web.settings.api.use_https_only": {
-    "text": "APIリクエストには常にHTTPSを使用",
+    "text": "APIリクエストには必ずHTTPSを使用してください",
     "source_hash": "b3f405ef"
   },
   "web.settings.api.monitor_api_usage": {
-    "text": "API使用状況を監視し、アラートを設定",
+    "text": "API使用状況を監視し、アラートを設定してください",
     "source_hash": "abb08beb"
   },
   "web.settings.api.important_notice": {
@@ -524,7 +524,7 @@
     "source_hash": "03d3ba93"
   },
   "web.settings.api.regenerating_key_warning": {
-    "text": "APIキーを再生成すると、現在のキーが無効になります。古いキーを使用しているすべてのアプリケーションを更新してください。",
+    "text": "APIキーを再生成すると、現在のキーは無効になります。古いキーを使用しているすべてのアプリケーションを更新してください。",
     "source_hash": "ab168f83"
   },
   "web.settings.privacy.title": {
@@ -532,15 +532,15 @@
     "source_hash": "eefad6ba"
   },
   "web.settings.privacy.manage_privacy_settings": {
-    "text": "プライバシー設定を管理",
+    "text": "プライバシー設定を管理できます",
     "source_hash": "add087da"
   },
   "web.settings.privacy.your_privacy": {
-    "text": "あなたのプライバシー",
+    "text": "プライバシーについて",
     "source_hash": "cad972db"
   },
   "web.settings.privacy.non_negotiable": {
-    "text": "交渉の余地なし",
+    "text": "妥協なし",
     "source_hash": "ad090a29"
   },
   "web.settings.privacy.not_a_setting": {
@@ -548,11 +548,11 @@
     "source_hash": "41278ece"
   },
   "web.settings.privacy.no_analytics_statement": {
-    "text": "分析なし。追跡なし。以上。",
+    "text": "アナリティクスなし。トラッキングなし。以上です。",
     "source_hash": "3e154b1c"
   },
   "web.settings.privacy.explanation": {
-    "text": "オン/オフにするものがないため、これは設定ではありません。プライバシーは私たちの運用方法に組み込まれています。",
+    "text": "オンにもオフにもできるものがないため、これは設定ではありません。プライバシーは私たちの運営方針に組み込まれています。",
     "source_hash": "ed943792"
   },
   "web.settings.notifications.title": {
@@ -560,7 +560,7 @@
     "source_hash": "07a063ca"
   },
   "web.settings.notifications.description": {
-    "text": "通知の受け取り方を管理",
+    "text": "通知の受け取り方法を管理できます",
     "source_hash": "148c5ff6"
   },
   "web.settings.notifications.error_updating": {
@@ -572,23 +572,23 @@
     "source_hash": "c0fb2e25"
   },
   "web.settings.notifications.reveal_notifications.description": {
-    "text": "誰かがシークレットを閲覧したときにメールを受信",
+    "text": "誰かがシークレットを閲覧したときにメールを受け取ります",
     "source_hash": "a3a67095"
   },
   "web.settings.notifications.reveal_notifications.help": {
-    "text": "受信者があなたのシークレットを閲覧するたびに通知されます",
+    "text": "受信者がシークレットを閲覧するたびに通知されます",
     "source_hash": "ba93106d"
   },
   "web.settings.notifications.privacy_note": {
-    "text": "通知メールにはタイムスタンプとシークレットIDのみが含まれます。閲覧者情報は含まれません。",
+    "text": "通知メールにはタイムスタンプとシークレットIDのみが含まれます。閲覧者の情報は含まれません。",
     "source_hash": "7aac282f"
   },
   "web.settings.caution.title": {
-    "text": "注意が必要なゾーン",
+    "text": "注意が必要な設定",
     "source_hash": "fe27a3a8"
   },
   "web.settings.caution.description": {
-    "text": "詳細設定とデータ管理",
+    "text": "高度な設定とデータ管理",
     "source_hash": "223ee55d"
   },
   "web.settings.caution.data_export": {
@@ -600,7 +600,7 @@
     "source_hash": "dc5ffcb0"
   },
   "web.settings.caution.export_description": {
-    "text": "機械可読形式でアカウントデータの完全なコピーをリクエスト",
+    "text": "アカウントデータの完全なコピーを機械可読形式でリクエストできます",
     "source_hash": "369c3391"
   },
   "web.settings.caution.request_data_export": {
@@ -620,15 +620,15 @@
     "source_hash": "17a8a676"
   },
   "web.settings.caution.deletion_warning_secrets": {
-    "text": "すべてのシークレットを完全に削除",
+    "text": "すべてのシークレットが完全に削除されます",
     "source_hash": "974ccdb9"
   },
   "web.settings.caution.deletion_warning_metadata": {
-    "text": "すべてのシークレットメタデータと履歴を削除",
+    "text": "すべてのシークレットのメタデータと履歴が削除されます",
     "source_hash": "ec4ee372"
   },
   "web.settings.caution.deletion_warning_api_keys": {
-    "text": "すべてのAPIキーを無効化",
+    "text": "すべてのAPIキーが無効になります",
     "source_hash": "7581333b"
   },
   "web.settings.caution.deletion_warning_irreversible": {
@@ -640,11 +640,11 @@
     "source_hash": "cf02eb0c"
   },
   "web.settings.profile.email_confirmed_success": {
-    "text": "メールアドレスが正常に更新されました。新しいメールアドレスでログインしてください。",
+    "text": "メールアドレスが正常に更新されました。新しいメールアドレスでサインインしてください。",
     "source_hash": "a84efcea"
   },
   "web.settings.profile.email_confirm_verifying": {
-    "text": "新しいメールアドレスを確認中...",
+    "text": "新しいメールアドレスを確認しています...",
     "source_hash": "a6a4745f"
   },
   "web.settings.profile.email_confirm_error_title": {
@@ -652,7 +652,7 @@
     "source_hash": "953f3936"
   },
   "web.settings.profile.email_confirm_invalid": {
-    "text": "この確認リンクは無効または期限切れです。",
+    "text": "この確認リンクは無効か、有効期限が切れています。",
     "source_hash": "f54594c2"
   },
   "web.settings.profile.email_confirm_back_to_settings": {
@@ -660,7 +660,7 @@
     "source_hash": "fd49b66b"
   },
   "web.settings.profile.redirecting_to_signin": {
-    "text": "ログインページにリダイレクト中...",
+    "text": "サインインにリダイレクトしています...",
     "source_hash": "c65f7dcc"
   },
   "web.settings.profile.resend_confirmation": {
@@ -668,7 +668,7 @@
     "source_hash": "c617fff7"
   },
   "web.settings.profile.resend_confirmation_success": {
-    "text": "確認メールが再送信されました。",
+    "text": "確認メールを再送信しました。",
     "source_hash": "2287783b"
   },
   "web.settings.profile.resend_confirmation_sending": {
@@ -676,11 +676,11 @@
     "source_hash": "286a3af7"
   },
   "web.settings.profile.email_change_pending": {
-    "text": "確認メールが送信されました。受信トレイを確認し、確認リンクをクリックしてください。",
+    "text": "確認メールを送信しました。受信トレイを確認し、確認リンクをクリックしてください。",
     "source_hash": "5806c93f"
   },
   "web.settings.profile.didnt_receive_email": {
-    "text": "メールが届きませんか？",
+    "text": "メールが届きませんでしたか?",
     "source_hash": "fe3ac3ad"
   },
   "web.settings.api.api_disabled_notice": {
@@ -688,11 +688,39 @@
     "source_hash": "66d12d6b"
   },
   "web.settings.security.sso_managed_title": {
-    "text": "SSOによって管理されるセキュリティ",
+    "text": "SSOによるセキュリティ管理",
     "source_hash": "1f6c9472"
   },
   "web.settings.security.sso_managed_description": {
-    "text": "お使いのアカウントは、組織のシングルサインオンプロバイダーを通じて認証されます。パスワード、多要素認証、リカバリーコードはIDプロバイダーによって管理されます。",
+    "text": "アカウントは組織のシングルサインオンプロバイダーを通じて認証されています。パスワード、多要素認証、リカバリーコードはIDプロバイダーによって管理されています。",
     "source_hash": "cd0cf39f"
+  },
+  "web.settings.api.api_username": {
+    "text": "APIユーザー名",
+    "source_hash": "0b3e483e"
+  },
+  "web.settings.api.api_username_description": {
+    "text": "HTTP Basic認証用のユーザー名",
+    "source_hash": "f3e65de3"
+  },
+  "web.settings.api.basic_auth_hint": {
+    "text": "HTTP Basic認証では、アカウントのメールアドレスまたはこのIDをユーザー名として、APIトークンをパスワードとして使用してください。",
+    "source_hash": "cfa3806d"
+  },
+  "web.settings.security.set": {
+    "text": "設定",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.settings.security.not_set": {
+    "text": "未設定",
+    "source_hash": "4895f731"
+  },
+  "web.settings.security.set_password_title": {
+    "text": "パスワードを設定",
+    "source_hash": "4e411687"
+  },
+  "web.settings.security.set_password_description": {
+    "text": "IDプロバイダーなしでもサインインできるように、アカウントにパスワードを追加できます",
+    "source_hash": "a6970402"
   }
 }

--- a/locales/content/ja/workspace-billing.json
+++ b/locales/content/ja/workspace-billing.json
@@ -1,14 +1,14 @@
 {
   "web.billing.subscription_synced_title": {
-    "text": "サブスクリプション同期完了",
+    "text": "サブスクリプションが同期されました",
     "source_hash": "3086ef43"
   },
   "web.billing.subscription_synced_description": {
-    "text": "サブスクリプション特典が別のリージョンから同期されました。",
+    "text": "サブスクリプションの特典が別のリージョンから同期されました。",
     "source_hash": "a99b7a98"
   },
   "web.billing.upgrade.required": {
-    "text": "アップグレードが必要",
+    "text": "アップグレードが必要です",
     "source_hash": "16487236"
   },
   "web.billing.upgrade.viewPlans": {
@@ -32,7 +32,7 @@
     "source_hash": "91df96b0"
   },
   "web.billing.manage_subscription_and_billing": {
-    "text": "サブスクリプション、組織、請求設定を管理",
+    "text": "サブスクリプション、組織、請求設定を管理できます",
     "source_hash": "3995095c"
   },
   "web.billing.overview.title": {
@@ -40,7 +40,7 @@
     "source_hash": "479a3c4c"
   },
   "web.billing.overview.description": {
-    "text": "サブスクリプションと支払いの詳細を表示・管理",
+    "text": "サブスクリプションと支払いの詳細を確認・管理できます",
     "source_hash": "60e5a00e"
   },
   "web.billing.overview.billing_for_organization": {
@@ -92,15 +92,15 @@
     "source_hash": "e9aa8bf0"
   },
   "web.billing.plans.early_supporter_plan": {
-    "text": "Identity Plus（アーリーサポーター）",
+    "text": "Identity Plus(早期サポーター)",
     "source_hash": "f37cd0d9"
   },
   "web.billing.plans.legacy_plan_warning": {
-    "text": "プランを変更すると旧プランの特別価格が失われます。この操作は取り消せません。",
+    "text": "プランを切り替えると、旧プランの料金は失われます。この操作は取り消せません。",
     "source_hash": "eda13d64"
   },
   "web.billing.overview.no_payment_method": {
-    "text": "登録された支払い方法がありません",
+    "text": "支払い方法が登録されていません",
     "source_hash": "77f71037"
   },
   "web.billing.overview.no_upcoming_billing": {
@@ -120,7 +120,7 @@
     "source_hash": "a865d424"
   },
   "web.billing.overview.view_plans_description": {
-    "text": "比較とアップグレード",
+    "text": "比較してアップグレード",
     "source_hash": "40e02bff"
   },
   "web.billing.overview.view_invoices_action": {
@@ -144,7 +144,7 @@
     "source_hash": "c7f70723"
   },
   "web.billing.overview.no_organizations_description": {
-    "text": "ワークスペースを作成して、請求とサブスクリプションを管理してください",
+    "text": "請求とサブスクリプションを管理するにはワークスペースを作成してください",
     "source_hash": "e0fd27a5"
   },
   "web.billing.overview.load_error": {
@@ -160,7 +160,7 @@
     "source_hash": "fd1caeb1"
   },
   "web.billing.overview.billing_contact": {
-    "text": "請求連絡先",
+    "text": "請求担当者",
     "source_hash": "8f782ad8"
   },
   "web.billing.overview.entitlements.create_secrets": {
@@ -168,7 +168,7 @@
     "source_hash": "0320541d"
   },
   "web.billing.overview.entitlements.view_receipt": {
-    "text": "受信確認を表示",
+    "text": "受領書を見る",
     "source_hash": "6c664c31"
   },
   "web.billing.overview.entitlements.api_access": {
@@ -180,15 +180,15 @@
     "source_hash": "6170ab94"
   },
   "web.billing.overview.entitlements.custom_privacy_defaults": {
-    "text": "カスタムプライバシー設定",
+    "text": "カスタムプライバシーデフォルト",
     "source_hash": "e677e27d"
   },
   "web.billing.overview.entitlements.extended_default_expiration": {
-    "text": "延長されたデフォルト有効期限",
+    "text": "延長デフォルト有効期限",
     "source_hash": "19b19637"
   },
   "web.billing.overview.entitlements.custom_mail_sender": {
-    "text": "カスタムメール設定",
+    "text": "カスタムメールデフォルト",
     "source_hash": "95aebfb9"
   },
   "web.billing.overview.entitlements.custom_branding": {
@@ -220,7 +220,7 @@
     "source_hash": "5428d7fe"
   },
   "web.billing.overview.entitlements.sso": {
-    "text": "シングルサインオン (SSO)",
+    "text": "シングルサインオン(SSO)",
     "source_hash": "5db5c812"
   },
   "web.billing.overview.entitlements.priority_support": {
@@ -252,11 +252,11 @@
     "source_hash": "6170ab94"
   },
   "web.billing.features.custom_domain": {
-    "text": "カスタムドメイン1件",
+    "text": "カスタムドメイン1つ",
     "source_hash": "6a6be744"
   },
   "web.billing.features.unlimited_custom_domains": {
-    "text": "無制限のカスタムドメイン",
+    "text": "カスタムドメイン無制限",
     "source_hash": "53eb7521"
   },
   "web.billing.features.custom_branding": {
@@ -292,7 +292,7 @@
     "source_hash": "436f2550"
   },
   "web.billing.features.centralized_billing": {
-    "text": "一元請求",
+    "text": "一元的な請求管理",
     "source_hash": "62042d3b"
   },
   "web.billing.features.audit_trail": {
@@ -304,7 +304,7 @@
     "source_hash": "b9c6cba7"
   },
   "web.billing.features.handoff_workflows": {
-    "text": "ハンドオフワークフロー",
+    "text": "引き継ぎワークフロー",
     "source_hash": "07202af3"
   },
   "web.billing.plans.title": {
@@ -312,11 +312,11 @@
     "source_hash": "79506c82"
   },
   "web.billing.plans.choose_plan": {
-    "text": "ニーズに合ったプランを選択",
+    "text": "ニーズに合ったプランを選択してください",
     "source_hash": "5f039cb9"
   },
   "web.billing.plans.subtitle": {
-    "text": "組織に最適なプランを選択",
+    "text": "組織に最適なプランを選択してください",
     "source_hash": "308076f2"
   },
   "web.billing.plans.current": {
@@ -340,11 +340,11 @@
     "source_hash": "1c4cda89"
   },
   "web.billing.plans.monthly": {
-    "text": "月間",
+    "text": "月額",
     "source_hash": "9b11f6b7"
   },
   "web.billing.plans.yearly": {
-    "text": "年間",
+    "text": "年額",
     "source_hash": "6e69b59e"
   },
   "web.billing.plans.per_month": {
@@ -352,7 +352,7 @@
     "source_hash": "eec5d08b"
   },
   "web.billing.plans.save_yearly": {
-    "text": "年間払いで{percent}%お得",
+    "text": "年額請求で{percent}%お得",
     "source_hash": "88c451f2"
   },
   "web.billing.plans.free_plan": {
@@ -384,7 +384,7 @@
     "source_hash": "5697d03d"
   },
   "web.billing.plans.unlimited_secrets": {
-    "text": "無制限のシークレット",
+    "text": "シークレット無制限",
     "source_hash": "0f077568"
   },
   "web.billing.plans.api_access": {
@@ -400,15 +400,15 @@
     "source_hash": "8709f894"
   },
   "web.billing.plans.contact_sales": {
-    "text": "営業に連絡",
+    "text": "お問い合わせ",
     "source_hash": "484aa053"
   },
   "web.billing.plans.custom_needs_title": {
-    "text": "質問やカスタムのご要望がありますか?",
+    "text": "ご質問やカスタムのご要望がありますか?",
     "source_hash": "2f68484c"
   },
   "web.billing.plans.custom_needs_description": {
-    "text": "ご連絡をお待ちしております。お探しのものをお知らせください。",
+    "text": "ぜひお聞かせください。ご要望をお知らせください。",
     "source_hash": "a6b7f407"
   },
   "web.billing.plans.teams_limit": {
@@ -416,19 +416,19 @@
     "source_hash": "a83641bc"
   },
   "web.billing.plans.members_limit": {
-    "text": "チームあたり{count}メンバー",
+    "text": "チームあたり{count}名",
     "source_hash": "54fb2b4b"
   },
   "web.billing.plans.unlimited_teams": {
-    "text": "無制限のチーム",
+    "text": "チーム数無制限",
     "source_hash": "6d9fde65"
   },
   "web.billing.plans.unlimited_members": {
-    "text": "チームごとに無制限のメンバー",
+    "text": "チームメンバー無制限",
     "source_hash": "728ecef0"
   },
   "web.billing.plans.most_popular": {
-    "text": "最も人気",
+    "text": "人気",
     "source_hash": "9e1006a4"
   },
   "web.billing.plans.suggested": {
@@ -440,7 +440,7 @@
     "source_hash": "1c73c298"
   },
   "web.billing.plans.no_plans_available": {
-    "text": "現在{interval}プランは利用できません。",
+    "text": "現在、{interval}プランはご利用いただけません。",
     "source_hash": "d8454436"
   },
   "web.billing.plans.load_error": {
@@ -448,7 +448,7 @@
     "source_hash": "a37d4d9a"
   },
   "web.billing.plans.change_immediate": {
-    "text": "プランはすぐに変更されます。",
+    "text": "プランは即座に変更されます。",
     "source_hash": "889d13be"
   },
   "web.billing.plans.current_plan_label": {
@@ -476,7 +476,7 @@
     "source_hash": "5670e027"
   },
   "web.billing.plans.limits_update_notice": {
-    "text": "機能の制限はプラン変更後すぐに更新されます。",
+    "text": "プラン変更後、機能の制限は即座に更新されます。",
     "source_hash": "9cb09f73"
   },
   "web.billing.plans.change_failed": {
@@ -512,7 +512,7 @@
     "source_hash": "e5f2e81a"
   },
   "web.billing.plans.amount_due_next_billing": {
-    "text": "次回請求時の支払額:",
+    "text": "次回請求時のお支払い額:",
     "source_hash": "22ee868a"
   },
   "web.billing.plans.remaining_account_credit": {
@@ -520,7 +520,7 @@
     "source_hash": "eedd0c0a"
   },
   "web.billing.plans.credit_future_note": {
-    "text": "今後の請求書に適用",
+    "text": "将来の請求書に適用されます",
     "source_hash": "5007add6"
   },
   "web.billing.invoices.title": {
@@ -528,7 +528,7 @@
     "source_hash": "5ade0861"
   },
   "web.billing.invoices.view_history": {
-    "text": "請求履歴を表示し、請求書をダウンロード",
+    "text": "請求履歴を確認し、請求書をダウンロードできます",
     "source_hash": "eb72573c"
   },
   "web.billing.invoices.invoice_date": {
@@ -552,15 +552,15 @@
     "source_hash": "48a67cac"
   },
   "web.billing.invoices.no_invoices": {
-    "text": "請求書はまだありません",
+    "text": "請求書がありません",
     "source_hash": "92d2d0ce"
   },
   "web.billing.invoices.no_invoices_description": {
-    "text": "有料プランにアップグレードすると、ここに請求書が表示されます",
+    "text": "有料プランにアップグレードすると、請求書がここに表示されます",
     "source_hash": "7f16be70"
   },
   "web.billing.invoices.view_plans": {
-    "text": "プランを表示",
+    "text": "プランを見る",
     "source_hash": "a865d424"
   },
   "web.billing.invoices.paid": {
@@ -600,7 +600,7 @@
     "source_hash": "6cfe0fb4"
   },
   "web.billing.notices.view_org_billing": {
-    "text": "組織の請求を表示",
+    "text": "組織の請求を見る",
     "source_hash": "2ae16262"
   },
   "web.billing.limits.members_reached": {
@@ -608,7 +608,7 @@
     "source_hash": "ce8f2a24"
   },
   "web.billing.limits.members_upgrade": {
-    "text": "メンバーを追加するにはアップグレード",
+    "text": "メンバーを追加するにはアップグレードしてください",
     "source_hash": "602bdef4"
   },
   "web.billing.subscription.title": {
@@ -616,19 +616,19 @@
     "source_hash": "4999c6c6"
   },
   "web.billing.subscription.status": {
-    "text": "サブスクリプションステータス",
+    "text": "サブスクリプションのステータス",
     "source_hash": "c7a08e1d"
   },
   "web.billing.subscription.active": {
-    "text": "有効",
+    "text": "アクティブ",
     "source_hash": "92340695"
   },
   "web.billing.subscription.inactive": {
-    "text": "無効",
+    "text": "非アクティブ",
     "source_hash": "ac7c949f"
   },
   "web.billing.subscription.past_due": {
-    "text": "期限超過",
+    "text": "支払い遅延",
     "source_hash": "2bda1c7b"
   },
   "web.billing.subscription.canceled": {
@@ -644,7 +644,7 @@
     "source_hash": "f9989642"
   },
   "web.billing.subscription.teams_used": {
-    "text": "{limit}チーム中{used}チーム",
+    "text": "{limit}チーム中{used}チーム使用中",
     "source_hash": "1db6b53c"
   },
   "web.billing.portal.title": {
@@ -652,7 +652,7 @@
     "source_hash": "9baaf69e"
   },
   "web.billing.portal.description": {
-    "text": "サブスクリプション、支払い方法、請求履歴を管理",
+    "text": "サブスクリプション、支払い方法、請求履歴を管理できます",
     "source_hash": "1a8f3c19"
   },
   "web.billing.portal.open_portal": {
@@ -660,7 +660,7 @@
     "source_hash": "23fbfa2b"
   },
   "web.billing.portal.redirecting": {
-    "text": "請求ポータルにリダイレクト中...",
+    "text": "請求ポータルにリダイレクトしています...",
     "source_hash": "b6f47df3"
   },
   "web.billing.start_today": {
@@ -668,7 +668,7 @@
     "source_hash": "80e73fc7"
   },
   "web.billing.start_today_with_identity_plus": {
-    "text": "Identity Plusを今すぐ始める",
+    "text": "今すぐIdentity Plusを始める",
     "source_hash": "cce4c7d7"
   },
   "web.billing.per_month": {
@@ -680,7 +680,7 @@
     "source_hash": "f5bedf1c"
   },
   "web.billing.privacy_first_design": {
-    "text": "プライバシー第一の設計",
+    "text": "プライバシー優先の設計",
     "source_hash": "587d738c"
   },
   "web.billing.identity_plus": {
@@ -688,7 +688,7 @@
     "source_hash": "bb273516"
   },
   "web.billing.click_this_lightning_bolt_to_upgrade_for_custom_domains": {
-    "text": "カスタムドメインのアップグレードには、このライトニングボルトをクリックしてください",
+    "text": "カスタムドメインにアップグレードするには、この稲妻をクリックしてください",
     "source_hash": "84cb4258"
   },
   "web.billing.maybe_later": {
@@ -704,11 +704,11 @@
     "source_hash": "272d3c80"
   },
   "web.billing.upgrade_for_teams": {
-    "text": "チーム向けアップグレード",
+    "text": "チーム向けにアップグレード",
     "source_hash": "90dfb533"
   },
   "web.billing.benefits_of": {
-    "text": "メリット:",
+    "text": "特典",
     "source_hash": "75403743"
   },
   "web.billing.t_benefits_of_identity_plus": {
@@ -716,19 +716,19 @@
     "source_hash": "f13e5f3e"
   },
   "web.billing.upgrade_to": {
-    "text": "アップグレード:",
+    "text": "アップグレード",
     "source_hash": "2ecdd437"
   },
   "web.billing.upgrade_for_yourdomain": {
-    "text": "secrets.yourdomain.comをアップグレード",
+    "text": "secrets.yourdomain.comにアップグレード",
     "source_hash": "8e4d766a"
   },
   "web.billing.includes_all_features_and_unlimited_sharing_capa": {
-    "text": "すべてのプランにはプライバシー機能と無制限の共有容量が含まれています",
+    "text": "すべてのプランにプライバシー機能と無制限の共有容量が含まれます",
     "source_hash": "e728e4e1"
   },
   "web.billing.includes_all_data_locality_options": {
-    "text": "すべてのプランでデータ所在地を選択可能: {0}リージョン",
+    "text": "すべてのプランに{0}リージョンのデータロケーション選択が含まれます",
     "source_hash": "22a60b49"
   },
   "web.billing.get_started": {
@@ -740,7 +740,7 @@
     "source_hash": "eaf5e2ef"
   },
   "web.billing.elevate_your_secure_sharing_with_custom_domains_": {
-    "text": "カスタムドメイン、無制限の容量、エンタープライズグレードの機能で、安全な共有を向上させましょう。",
+    "text": "カスタムドメイン、無制限の容量、エンタープライズグレードの機能で安全な共有を向上させましょう。",
     "source_hash": "db458d30"
   },
   "web.billing.payment_frequency": {
@@ -748,15 +748,15 @@
     "source_hash": "b2c87e39"
   },
   "web.billing.secure_your_brand_and_build_customer_trust_with_": {
-    "text": "あなたのドメインからのリンクでブランドを保護し、顧客の信頼を構築します。プライバシーとプロフェッショナリズムを重視するビジネスに最適です。",
+    "text": "独自ドメインのリンクでブランドを守り、顧客の信頼を築きましょう。プライバシーとプロフェッショナリズムを重視する企業に最適です。",
     "source_hash": "c07cd25c"
   },
   "web.billing.secure_links_stronger_connections": {
-    "text": "セキュアリンクで、より強い絆を",
+    "text": "安全なリンクで、より強いつながりを",
     "source_hash": "dd8dae5d"
   },
   "web.billing.identity_tier_not_found_in_product_tiers": {
-    "text": "製品ティアにIdentityティアが見つかりません",
+    "text": "プロダクトティアにIdentityティアが見つかりません",
     "source_hash": "d0204fc4"
   },
   "web.billing.cancel.link_text": {
@@ -817,12 +817,12 @@
     "source_hash": "1427d139"
   },
   "web.billing.cancel.scheduled_description": {
-    "text": "サブスクリプションは{date}までアクティブのままです。それまですべての機能にフルアクセスできます。",
+    "text": "サブスクリプションは{date}までアクティブのままです。それまですべての機能に完全にアクセスできます。",
     "context": "Alert banner description explaining continued access",
     "source_hash": "aab4b1dc"
   },
   "web.billing.cancel.scheduled_note": {
-    "text": "お気持ちが変わりましたか? キャンセル日より前であれば、いつでもサブスクリプションを再開できます。",
+    "text": "お気が変わりましたか?キャンセル日の前ならいつでもサブスクリプションを再開できます。",
     "context": "Alert banner note encouraging reactivation",
     "source_hash": "c94d5527"
   },
@@ -863,7 +863,7 @@
     "source_hash": "3c2d9a14"
   },
   "web.billing.features.unlimited_members": {
-    "text": "無制限のチームメンバー",
+    "text": "チームメンバー無制限",
     "source_hash": "b7491ee9"
   },
   "web.billing.features.notifications": {
@@ -904,7 +904,7 @@
     "source_hash": "edb868c4"
   },
   "web.billing.currency_migration.current_period_ends": {
-    "text": "現在の期間の終了:",
+    "text": "現在の期間の終了日:",
     "source_hash": "2e20e596"
   },
   "web.billing.currency_migration.choose_timing": {
@@ -912,27 +912,27 @@
     "source_hash": "f4aabb13"
   },
   "web.billing.currency_migration.graceful_title": {
-    "text": "請求期間の終了時に切り替え",
+    "text": "請求期間の終了時に切り替える",
     "source_hash": "55cd980b"
   },
   "web.billing.currency_migration.graceful_description": {
-    "text": "現在のプランは{date}まで有効です。その後、新しいプランのお支払いを完了していただきます。",
+    "text": "現在のプランは{date}までアクティブのままです。その後、新しいプランのチェックアウトを完了できます。",
     "source_hash": "b8661418"
   },
   "web.billing.currency_migration.immediate_title": {
-    "text": "今すぐ切り替え",
+    "text": "今すぐ切り替える",
     "source_hash": "e9d0ba59"
   },
   "web.billing.currency_migration.immediate_description": {
-    "text": "現在のプランは今すぐキャンセルされます。未使用期間の払い戻しを受け、新しいプランのお支払いを完了していただきます。",
+    "text": "現在のプランは今すぐキャンセルされます。未使用期間の返金を受け取り、新しいプランのチェックアウトを完了できます。",
     "source_hash": "b08de0ca"
   },
   "web.billing.currency_migration.confirm": {
-    "text": "通貨変更を確認",
+    "text": "通貨の変更を確認",
     "source_hash": "1edc1c78"
   },
   "web.billing.currency_migration.error": {
-    "text": "通貨移行に失敗しました。もう一度お試しください。",
+    "text": "通貨の移行に失敗しました。もう一度お試しください。",
     "source_hash": "4a6e1ced"
   },
   "web.billing.currency_migration.success": {
@@ -940,11 +940,11 @@
     "source_hash": "a8bf437e"
   },
   "web.billing.currency_migration.graceful_success": {
-    "text": "現在のプランは請求期間の終了まで有効です。その後、新しいプランのお支払いを完了するよう案内されます。",
+    "text": "現在のプランは請求期間の終了までアクティブのままです。その後、新しいプランのチェックアウトを完了するよう案内されます。",
     "source_hash": "15d41483"
   },
   "web.billing.currency_migration.warning_credit_balance": {
-    "text": "{currency}のクレジット残高があり、新しい通貨に移行することはできません。",
+    "text": "{currency}のクレジット残高があり、新しい通貨に移行できません。",
     "source_hash": "aa15be91"
   },
   "web.billing.currency_migration.warning_pending_items": {
@@ -952,11 +952,11 @@
     "source_hash": "7b4c5e10"
   },
   "web.billing.currency_migration.warning_coupons": {
-    "text": "アカウントの有効なクーポンは、新しい通貨と互換性がない場合があります。",
+    "text": "アカウントのアクティブなクーポンは新しい通貨と互換性がない場合があります。",
     "source_hash": "f572ee81"
   },
   "web.billing.currency_migration.pending_title": {
-    "text": "通貨移行を保留中",
+    "text": "通貨の移行が保留中です",
     "context": "Banner heading when graceful migration is scheduled",
     "source_hash": "018ae653"
   },
@@ -980,17 +980,17 @@
     "source_hash": "3ff06e41"
   },
   "web.billing.plan_switch_success": {
-    "text": "{plan}への切り替えが完了しました",
+    "text": "{plan}への切り替えに成功しました",
     "context": "Success message after plan change",
     "source_hash": "ab7c715c"
   },
   "web.billing.plan_unavailable_region_mismatch": {
-    "text": "元のサブスクリプションリージョンでのみ利用可能",
+    "text": "元のサブスクリプションリージョンでのみ利用可能です",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
   },
   "web.billing.already_subscribed": {
-    "text": "すでにこのプランに登録済みです。",
+    "text": "すでにこのプランに登録されています。",
     "source_hash": "2b02438b"
   },
   "web.billing.cancel.reactivate_button": {
@@ -998,7 +998,7 @@
     "source_hash": "aa036442"
   },
   "web.billing.cancel.reactivate_success": {
-    "text": "サブスクリプションが再開されました。通常どおり請求が継続されます。",
+    "text": "サブスクリプションが再開されました。通常通り請求が継続されます。",
     "source_hash": "523bf7bf"
   },
   "web.billing.cancel.reactivate_error": {
@@ -1010,11 +1010,11 @@
     "source_hash": "780ad17c"
   },
   "web.billing.features.flexible_from_domain": {
-    "text": "柔軟な送信元メールドメイン",
+    "text": "柔軟なメール送信ドメイン",
     "source_hash": "607572c3"
   },
   "web.billing.features.unlimited_admins": {
-    "text": "管理者数無制限",
+    "text": "管理者無制限",
     "source_hash": "5871a536"
   },
   "web.billing.features.manage_sso": {
@@ -1022,7 +1022,7 @@
     "source_hash": "5ba3ac9f"
   },
   "web.billing.overview.entitlements.flexible_from_domain": {
-    "text": "柔軟な送信元メールドメイン",
+    "text": "柔軟なメール送信ドメイン",
     "source_hash": "607572c3"
   },
   "web.billing.overview.entitlements.manage_orgs": {
@@ -1030,7 +1030,7 @@
     "source_hash": "be0fe4c3"
   },
   "web.billing.overview.entitlements.manage_sso": {
-    "text": "シングルサインオン (SSO)",
+    "text": "シングルサインオン(SSO)",
     "source_hash": "5db5c812"
   },
   "web.billing.overview.entitlements.manage_billing": {
@@ -1038,11 +1038,27 @@
     "source_hash": "6d3a16f5"
   },
   "web.billing.overview.entitlements.custom_signup_validation": {
-    "text": "カスタム登録検証",
+    "text": "カスタムサインアップ検証",
     "source_hash": "0ff55bfa"
   },
   "web.billing.plans.reactivate": {
     "text": "再開",
     "source_hash": "2dc7478f"
+  },
+  "web.billing.currency_migration.refund_failed_warning": {
+    "text": "以前のプランはキャンセルされましたが、未使用期間の返金を自動的に発行できませんでした。返金を受け取るにはサポートにお問い合わせください。新しいプランを有効にするには、チェックアウトを完了する必要があります。",
+    "source_hash": "a390c498"
+  },
+  "web.billing.currency_migration.refund_failed_continue": {
+    "text": "チェックアウトに進む",
+    "source_hash": "eccdb8aa"
+  },
+  "web.billing.plans.per_year": {
+    "text": "/年",
+    "source_hash": "a2d5f1bc"
+  },
+  "web.billing.plans.billing_interval": {
+    "text": "請求間隔",
+    "source_hash": "3ce28209"
   }
 }

--- a/locales/content/ja/workspace-branding.json
+++ b/locales/content/ja/workspace-branding.json
@@ -24,7 +24,7 @@
     "source_hash": "db3183e3"
   },
   "web.branding.preview_of_the_secret_link_page_for_recipients": {
-    "text": "セキュアリンクにアクセスする受信者の表示のプレビュー",
+    "text": "受信者が安全なリンクにアクセスしたときの表示プレビュー",
     "source_hash": "199c165f"
   },
   "web.branding.preview_and_customize": {
@@ -32,7 +32,7 @@
     "source_hash": "fc68a28c"
   },
   "web.branding.switch_to_safari_browser_view": {
-    "text": "Safariブラウザビューに切り替え",
+    "text": "Safariブラウザ表示に切り替え",
     "source_hash": "6e0fe791"
   },
   "web.branding.microsoft_edge": {
@@ -48,7 +48,7 @@
     "source_hash": "5cd54386"
   },
   "web.branding.switch_to_edge_browser_view": {
-    "text": "Edgeブラウザビューに切り替え",
+    "text": "Edgeブラウザ表示に切り替え",
     "source_hash": "a8fcd82d"
   },
   "web.branding.charactercount_500_characters": {
@@ -56,31 +56,31 @@
     "source_hash": "e36598ef"
   },
   "web.branding.example_pre_reveal_instructions": {
-    "text": "スマートフォンでQRコードをスキャンしてください",
-    "source_hash": "99ecf59f"
+    "text": "例:スマートフォンでQRコードをスキャンしてください",
+    "source_hash": "9cf0caf8"
   },
   "web.branding.example_post_reveal_instructions": {
-    "text": "ご質問はonboarding{'@'}example.comまでお問い合わせください",
-    "source_hash": "bee120a7"
+    "text": "例:ご質問はonboarding{'@'}example.comまでお問い合わせください",
+    "source_hash": "71749811"
   },
   "web.branding.these_instructions_will_be_shown_to_recipients_before": {
-    "text": "これらの指示は、受信者がシークレットの内容を表示する前に表示されます",
+    "text": "これらの手順は、受信者がシークレットの内容を閲覧する前に表示されます",
     "source_hash": "9d5a6334"
   },
   "web.branding.these_instructions_will_be_shown_to_recipients_after": {
-    "text": "これらの指示は、受信者がシークレットを表示した後に表示されます",
+    "text": "これらの手順は、受信者がシークレットを閲覧した後に表示されます",
     "source_hash": "9f82bd94"
   },
   "web.branding.pre_reveal_instructions": {
-    "text": "公開前の説明",
+    "text": "閲覧前の手順",
     "source_hash": "a299422e"
   },
   "web.branding.post_reveal_instructions": {
-    "text": "公開後の説明",
+    "text": "閲覧後の手順",
     "source_hash": "72ecc23a"
   },
   "web.branding.instructions": {
-    "text": "説明",
+    "text": "手順",
     "source_hash": "934652dc"
   },
   "web.branding.logo_controls": {
@@ -100,7 +100,7 @@
     "source_hash": "c02130fa"
   },
   "web.branding.preview_how_recipients_will_see_your_secrets": {
-    "text": "「シークレットを表示」ボタンをテストして、受信者がどのようにあなたのシークレットを見るかをプレビューします",
+    "text": "「シークレットを表示」ボタンをテストして、受信者にどのように表示されるかプレビューできます",
     "source_hash": "3b58a297"
   },
   "web.branding.eye_icon": {
@@ -108,7 +108,7 @@
     "source_hash": "7f605d3c"
   },
   "web.branding.click_the_preview_image_below_to_update_your_logo": {
-    "text": "以下のプレビュー画像をクリックして、ロゴを更新します（最小128x128ピクセル推奨、最大1MB）",
+    "text": "下のプレビュー画像をクリックしてロゴを更新できます(推奨:128x128ピクセル以上、最大1MB)",
     "source_hash": "77a19049"
   },
   "web.branding.image_icon": {
@@ -116,7 +116,7 @@
     "source_hash": "b0d64fcf"
   },
   "web.branding.use_the_controls_above_to_customize_brand_details": {
-    "text": "上のコントロールを使用して、ブランドの色、スタイル、受信者への指示をカスタマイズします",
+    "text": "上のコントロールを使用してブランドカラー、スタイル、受信者への手順をカスタマイズできます",
     "source_hash": "d6287134"
   },
   "web.branding.customization_icon": {
@@ -124,7 +124,7 @@
     "source_hash": "bde04d31"
   },
   "web.branding.you_have_unsaved_changes_are_you_sure": {
-    "text": "保存されていない変更があります。よろしいですか？",
+    "text": "保存されていない変更があります。よろしいですか?",
     "source_hash": "184b6a83"
   },
   "web.branding.failed_to_load_brand_settings": {
@@ -132,15 +132,15 @@
     "source_hash": "a7a1575e"
   },
   "web.branding.this_is_an_interactive_preview_o": {
-    "text": "これは、受信者があなたの安全なメッセージをどのように見るかのインタラクティブなプレビューです。次のことができます： - 上部のコントロールを使用して色とフォントをカスタマイズ - ロゴをアップロード（最小128x128ピクセル推奨、最大1MB） - 「秘密を表示」ボタンを使用してプレビューをテスト",
+    "text": "受信者に安全なメッセージがどのように表示されるかのインタラクティブなプレビューです。以下の操作ができます:上のコントロールを使用して色とフォントをカスタマイズ、ロゴをアップロード(推奨:128x128ピクセル以上、最大1MB)、「シークレットを表示」ボタンでプレビューをテスト",
     "source_hash": "3d8b2c0d"
   },
   "web.branding.this_is_an_interactive_preview_of_how_recipients": {
-    "text": "これは、受信者があなたの安全なメッセージをどのように見るかのインタラクティブなプレビューです。次のことができます： - 上部のコントロールを使用して色とフォントをカスタマイズ - ロゴをアップロード（最小128x128ピクセル推奨、最大1MB） - 「秘密を表示」ボタンを使用してプレビューをテスト",
+    "text": "受信者に安全なメッセージがどのように表示されるかのインタラクティブなプレビューです。以下の操作ができます:上のコントロールを使用して色とフォントをカスタマイズ、ロゴをアップロード(推奨:128x128ピクセル以上、最大1MB)、「シークレットを表示」ボタンでプレビューをテスト",
     "source_hash": "3d8b2c0d"
   },
   "web.branding.default_logo_icon": {
-    "text": "日本語の漢字「秘」(ひみつ) - 「秘密」または「機密」を意味する",
+    "text": "「秘」の漢字(機密または秘密を意味する)",
     "source_hash": "1e04ba2e"
   },
   "web.branding.powered_by_onetime_secret": {
@@ -180,7 +180,7 @@
     "source_hash": "9077bf79"
   },
   "web.branding.saved_successfully": {
-    "text": "ブランド設定を保存しました",
+    "text": "ブランド設定が正常に保存されました",
     "source_hash": "9960c252"
   },
   "web.branding.keyhole_logo_icon": {
@@ -196,11 +196,11 @@
     "source_hash": "b48bc969"
   },
   "web.branding.text_color": {
-    "text": "テキストの色",
+    "text": "テキスト色",
     "source_hash": "2ea23234"
   },
   "web.branding.border_radius": {
-    "text": "角の丸み",
+    "text": "角丸",
     "source_hash": "e758d7db"
   },
   "web.branding.heading_font": {
@@ -216,19 +216,19 @@
     "source_hash": "d707dc2f"
   },
   "web.branding.replace_logo": {
-    "text": "置き換え",
+    "text": "置換",
     "source_hash": "95e15439"
   },
   "web.branding.logo_field_hint": {
-    "text": "変更が公開される前にプレビューできます。",
+    "text": "変更を公開する前にプレビューできます。",
     "source_hash": "e9e222fc"
   },
   "web.branding.logo_modal_title": {
-    "text": "ドメインのロゴ",
+    "text": "ドメインロゴ",
     "source_hash": "5260dda5"
   },
   "web.branding.logo_modal_hint": {
-    "text": "PNG、JPG、またはSVG。推奨128x128px、最大1MB。",
+    "text": "PNG、JPG、SVG。推奨128x128px、最大1MB。",
     "source_hash": "75d00802"
   },
   "web.branding.logo_modal_save": {
@@ -248,7 +248,7 @@
     "source_hash": "6613b73c"
   },
   "web.branding.image_invalid_type": {
-    "text": "そのファイル形式はサポートされていません。画像を選択してください。",
+    "text": "このファイル形式はサポートされていません。画像を選択してください。",
     "source_hash": "50e18866"
   },
   "web.branding.image_too_large": {
@@ -260,7 +260,7 @@
     "source_hash": "d94fa99a"
   },
   "web.branding.image_upload_failed": {
-    "text": "問題が発生しました。もう一度お試しください。",
+    "text": "エラーが発生しました。もう一度お試しください。",
     "source_hash": "3ccd9d65"
   },
   "web.branding.undo": {
@@ -276,23 +276,23 @@
     "source_hash": "3fee95da"
   },
   "web.branding.path_match": {
-    "text": "自分のサイトに合わせる",
+    "text": "サイトに合わせる",
     "source_hash": "776679cf"
   },
   "web.branding.path_advanced": {
-    "text": "詳細",
+    "text": "詳細設定",
     "source_hash": "9f088dbe"
   },
   "web.branding.path_simple_tag": {
-    "text": "ブランドの基本要素。",
+    "text": "ブランドの基本設定",
     "source_hash": "7c9c0cca"
   },
   "web.branding.path_match_tag": {
-    "text": "既存のサイトから設定をコピー。",
+    "text": "既存のサイトから設定をコピー",
     "source_hash": "e4b0d1cd"
   },
   "web.branding.path_advanced_tag": {
-    "text": "独自のTailwind v4 CSSを作成。",
+    "text": "独自のTailwind v4 CSSを作成",
     "source_hash": "2405bb6d"
   },
   "web.branding.badge_default": {
@@ -304,11 +304,11 @@
     "source_hash": "4f7d6401"
   },
   "web.branding.your_brand": {
-    "text": "あなたのブランド",
+    "text": "ブランド設定",
     "source_hash": "406265d3"
   },
   "web.branding.your_brand_subtitle": {
-    "text": "いくつかの簡単な選択だけで、あとは私たちが対応します。",
+    "text": "簡単な選択をするだけ — 残りは私たちにお任せください。",
     "source_hash": "dbc8ec33"
   },
   "web.branding.corners": {
@@ -320,15 +320,15 @@
     "source_hash": "bc79cdff"
   },
   "web.branding.paths_carryover_hint": {
-    "text": "これはライブプレビューです。保存するまで、変更は訪問者には表示されません。",
-    "source_hash": "cb4b82de"
+    "text": "これはライブプレビューです — 更新をクリックするまで、訪問者には変更が表示されません。",
+    "source_hash": "9a34df71"
   },
   "web.branding.coming_soon_match_blurb": {
-    "text": "ウェブサイトを指定していただければ、その色とフォントを読み取り、ワンクリックでギャップを埋めます。",
+    "text": "ウェブサイトを指定すると、その色とフォントを読み取り、ワンクリックで調整します。",
     "source_hash": "42c34cc1"
   },
   "web.branding.coming_soon_advanced_blurb": {
-    "text": "Tailwind v4の{'@'}themeトークンを直接編集するか、独自のスタイルシートを貼り付けます。",
+    "text": "Tailwind v4の{'@'}themeトークンを直接編集するか、独自のスタイルシートを貼り付けられます。",
     "source_hash": "5a8473f5"
   },
   "web.branding.preview_recipient_page": {
@@ -368,11 +368,11 @@
     "source_hash": "17361d81"
   },
   "web.branding.recipient_page_content": {
-    "text": "受信者ページの内容",
+    "text": "受信者ページのコンテンツ",
     "source_hash": "937733bd"
   },
   "web.branding.recipient_page_content_hint": {
-    "text": "このドメインで受信者に表示される言語と表示手順。",
+    "text": "このドメインで受信者に表示される言語と閲覧手順。",
     "source_hash": "04162b70"
   },
   "web.branding.tab_brand": {
@@ -388,23 +388,75 @@
     "source_hash": "a4fe6526"
   },
   "web.branding.delivery_language_hint": {
-    "text": "このドメインの受信者ページとメールのデフォルトです。受信者はページで言語を切り替えられます。",
+    "text": "このドメインの受信者ページとメールのデフォルト。受信者はページで言語を切り替えられます。",
     "source_hash": "bfbc5599"
   },
   "web.branding.delivery_reveal_instructions": {
-    "text": "表示手順",
+    "text": "閲覧手順",
     "source_hash": "7e1331f7"
   },
   "web.branding.delivery_reveal_instructions_hint": {
-    "text": "受信者ページに表示されます。空欄の場合、選択した言語の組み込みテキストが使用されます。",
+    "text": "受信者ページに表示されます。空白のままにすると、選択した言語の組み込みコピーが使用されます。",
     "source_hash": "51b9811d"
   },
   "web.branding.delivery_before_reveal": {
-    "text": "表示前",
+    "text": "閲覧前",
     "source_hash": "5ce82b01"
   },
   "web.branding.delivery_after_reveal": {
-    "text": "表示後",
+    "text": "閲覧後",
     "source_hash": "d5bfe7fd"
+  },
+  "web.branding.favicon": {
+    "text": "ファビコン",
+    "source_hash": "42955289"
+  },
+  "web.branding.refresh_favicon": {
+    "text": "ドメインからファビコンを更新",
+    "source_hash": "7cc3d5dc"
+  },
+  "web.branding.refresh_favicon_hint": {
+    "text": "ドメインから再度ファビコンを取得します。新しいアイコンはまもなく表示されます。",
+    "source_hash": "ee007e44"
+  },
+  "web.branding.refresh_favicon_queued": {
+    "text": "ファビコンを更新中 — 新しいアイコンはまもなく表示されます。",
+    "source_hash": "6bf38e6e"
+  },
+  "web.branding.refresh_favicon_user_upload_hint": {
+    "text": "カスタムファビコンをアップロードしているため、取得したアイコンでは置き換えられません。",
+    "source_hash": "c22e1ed6"
+  },
+  "web.branding.upload_favicon": {
+    "text": "ファビコンをアップロード",
+    "source_hash": "ceda39cb"
+  },
+  "web.branding.replace_favicon": {
+    "text": "置換",
+    "source_hash": "95e15439"
+  },
+  "web.branding.remove_favicon": {
+    "text": "ファビコンを削除",
+    "source_hash": "03693698"
+  },
+  "web.branding.favicon_field_hint": {
+    "text": "ICO、PNG、SVG。アップロードすると取得したアイコンが置き換えられます。",
+    "source_hash": "dfa0bfcb"
+  },
+  "web.branding.favicon_preview_alt": {
+    "text": "ドメインファビコン",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_title": {
+    "text": "ドメインファビコン",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_hint": {
+    "text": "ICO、PNG、SVG。最大256KB。自動取得したアイコンを置き換えます。",
+    "source_hash": "c9eafc83"
+  },
+  "web.branding.favicon_modal_save": {
+    "text": "ファビコンを保存",
+    "source_hash": "c8a1566c"
   }
 }

--- a/locales/content/ja/workspace-dashboard.json
+++ b/locales/content/ja/workspace-dashboard.json
@@ -16,7 +16,7 @@
     "source_hash": "e96db24d"
   },
   "web.dashboard.fetch_error_title": {
-    "text": "データを読み込めません",
+    "text": "データを読み込めませんでした",
     "source_hash": "ba7df1be"
   },
   "web.dashboard.fetch_error_description": {
@@ -28,7 +28,7 @@
     "source_hash": "54693f14"
   },
   "web.teams.create_first_team_description": {
-    "text": "チームを使うと、共有ワークスペースで他のメンバーと共同作業ができます。",
+    "text": "チームを使用すると、共有ワークスペースで他のメンバーと共同作業できます。",
     "source_hash": "d61b86b5"
   },
   "web.teams.create_team": {

--- a/locales/content/ja/workspace-domains.json
+++ b/locales/content/ja/workspace-domains.json
@@ -4,7 +4,7 @@
     "source_hash": "c592a5c6"
   },
   "web.domains.view_domain_verification_status": {
-    "text": "ドメイン検証ステータスを表示",
+    "text": "ドメイン検証ステータスを見る",
     "source_hash": "23635e2d"
   },
   "web.domains.domain_already_in_organization": {
@@ -12,23 +12,23 @@
     "source_hash": "6e0d628f"
   },
   "web.domains.domain_in_other_organization": {
-    "text": "このドメインは既に別の組織に登録されています。これが誤りだと思われる場合は、サポートにお問い合わせください。",
+    "text": "このドメインは既に別の組織に登録されています。エラーと思われる場合はサポートにお問い合わせください。",
     "source_hash": "7fae16a9"
   },
   "web.domains.domain_claimed_successfully": {
-    "text": "ドメインが正常に申請され、組織に追加されました",
+    "text": "ドメインが正常に登録され、組織に追加されました",
     "source_hash": "d53e1ac1"
   },
   "web.domains.privacy_defaults_title": {
-    "text": "プライバシーのデフォルト",
+    "text": "プライバシーデフォルト",
     "source_hash": "5bce069d"
   },
   "web.domains.privacy_defaults_description": {
-    "text": "このドメインで作成されるシークレットのデフォルトプライバシーオプションを設定します。これらの設定は、新しいシークレットを作成する際に事前入力されます。",
+    "text": "このドメインで作成されるシークレットのデフォルトプライバシーオプションを設定します。これらの設定は新しいシークレットを作成する際に事前入力されます。",
     "source_hash": "1d98959c"
   },
   "web.domains.privacy_defaults": {
-    "text": "プライバシーのデフォルト",
+    "text": "プライバシーデフォルト",
     "source_hash": "5bce069d"
   },
   "web.domains.privacy_defaults_icon": {
@@ -48,7 +48,7 @@
     "source_hash": "3a448e69"
   },
   "web.domains.passphrase_required_hint": {
-    "text": "このドメインのすべてのシークレットにパスフレーズを必須にする",
+    "text": "このドメインのすべてのシークレットにパスフレーズを必須にします",
     "source_hash": "6ac05bce"
   },
   "web.domains.notify_enabled_label": {
@@ -56,7 +56,7 @@
     "source_hash": "682be64a"
   },
   "web.domains.notify_enabled_hint": {
-    "text": "シークレットが閲覧されたときのメール通知をデフォルトで有効にする",
+    "text": "シークレットが閲覧されたときのメール通知をデフォルトで有効にします",
     "source_hash": "3e16dd5f"
   },
   "web.domains.use_global_default": {
@@ -76,7 +76,7 @@
     "source_hash": "59be7133"
   },
   "web.domains.enabled": {
-    "text": "有効化",
+    "text": "有効",
     "source_hash": "5342e09f"
   },
   "web.domains.disabled": {
@@ -108,7 +108,7 @@
     "source_hash": "c776f846"
   },
   "web.domains.switcher_locked": {
-    "text": "このページではドメイン切り替えは利用できません",
+    "text": "このページではドメイン切り替えはできません",
     "source_hash": "ccd202fe"
   },
   "web.domains.scope_list_label": {
@@ -140,7 +140,7 @@
     "source_hash": "421b1e61"
   },
   "web.domains.control_whether_users_can_create_secret_links": {
-    "text": "ユーザーがあなたのドメインのホームページから秘密リンクを作成できるかどうかを制御します",
+    "text": "ユーザーがドメインのホームページからシークレットリンクを作成できるかどうかを制御します",
     "source_hash": "a25d6fca"
   },
   "web.domains.homepage_access": {
@@ -156,7 +156,7 @@
     "source_hash": "79fa3361"
   },
   "web.domains.manage_and_configure_your_verified_custom_domains": {
-    "text": "確認済みのカスタムドメインを管理および設定する",
+    "text": "検証済みのカスタムドメインを管理・設定できます",
     "source_hash": "4e7f8311"
   },
   "web.domains.domains": {
@@ -164,7 +164,7 @@
     "source_hash": "ced67718"
   },
   "web.domains.last_monitored": {
-    "text": "最終監視日時",
+    "text": "最終監視",
     "source_hash": "8d39d1d0"
   },
   "web.domains.ssl_status": {
@@ -172,7 +172,7 @@
     "source_hash": "bec72630"
   },
   "web.domains.ssl_renews": {
-    "text": "SSL更新日",
+    "text": "SSL更新",
     "source_hash": "c49a8cff"
   },
   "web.domains.dns_record": {
@@ -196,7 +196,7 @@
     "source_hash": "c1683eeb"
   },
   "web.domains.open_domain_in_new_tab": {
-    "text": "新しいタブでドメインを開く",
+    "text": "ドメインを新しいタブで開く",
     "source_hash": "01571f31"
   },
   "web.domains.back_to_domains": {
@@ -204,7 +204,7 @@
     "source_hash": "d1dc32ad"
   },
   "web.domains.return_to_domains_list": {
-    "text": "ドメインリストに戻る",
+    "text": "ドメイン一覧に戻る",
     "source_hash": "c7632413"
   },
   "web.domains.verify_domain": {
@@ -216,7 +216,7 @@
     "source_hash": "b6ec5cd4"
   },
   "web.domains.added_formatdistancetonow_domain_created_addsuffix_true": {
-    "text": "{0}を追加",
+    "text": "{0}に追加",
     "source_hash": "dc9ff9ec"
   },
   "web.domains.add_your_domain": {
@@ -224,7 +224,7 @@
     "source_hash": "6b95c91c"
   },
   "web.domains.get_started_by_adding_a_custom_domain": {
-    "text": "カスタム ドメインを追加して開始します。",
+    "text": "カスタムドメインを追加して始めましょう。",
     "source_hash": "abdbe9ab"
   },
   "web.domains.no_domains_found": {
@@ -236,19 +236,19 @@
     "source_hash": "b5549ff7"
   },
   "web.domains.in_order_to_connect_your_domain_youll_need_to_ha": {
-    "text": "ドメインを接続するには、DNSにCNAMEレコードが必要です",
+    "text": "ドメインを接続するには、DNSに以下を指すCNAMEレコードが必要です",
     "source_hash": "c560710e"
   },
   "web.domains.if_you_already_have_a_cname_record_for_that_addr": {
-    "text": "そのアドレスのCNAMEレコードがすでにある場合は、向き先を変更してください",
+    "text": "そのアドレスのCNAMEレコードが既にある場合は、以下を指すように変更してください",
     "source_hash": "6f23e6db"
   },
   "web.domains.a_cname_record_is_not_allowed_instead_youll_need": {
-    "text": "）、CNAMEレコードは許可されていません。代わりに、Aレコードを作成する必要があります。これを行う方法の詳細は、ページの下部に記載されています。",
+    "text": ")、CNAMEレコードは使用できません。代わりにAレコードを作成する必要があります。詳細はページの下部に記載されています。",
     "source_hash": "76d5ab5f"
   },
   "web.domains.and_remove_any_other_a_aaaa_or_cname_records_for": {
-    "text": "そして、その正確なアドレスの他のA、AAAA、またはCNAMEレコードを削除してください。",
+    "text": "その正確なアドレスの他のA、AAAA、またはCNAMEレコードを削除してください。",
     "source_hash": "8978f5e7"
   },
   "web.domains.youll_need_to_complete_these_steps": {
@@ -276,15 +276,15 @@
     "source_hash": "e3f97ac1"
   },
   "web.domains.it_may_take_a_few_minutes_for_your_ssl_certifica": {
-    "text": "SSL証明書が有効になるまでに数分かかる場合があります。",
+    "text": "SSL証明書が有効になるまで数分かかる場合があります。",
     "source_hash": "2e4f3179"
   },
   "web.domains.dns_changes_can_take_as_little_as_60_seconds_or_": {
-    "text": "DNS変更は最短で60秒、最長で24時間かかることがあります。",
+    "text": "DNS変更が反映されるまで、60秒から最大24時間かかる場合があります。",
     "source_hash": "38774290"
   },
   "web.domains.3_wait_for_propagation": {
-    "text": "3. 伝播を待つ",
+    "text": "3. 反映を待つ",
     "source_hash": "3e6cf4e1"
   },
   "web.domains.value_2": {
@@ -328,7 +328,7 @@
     "source_hash": "7b5aa1fc"
   },
   "web.domains.add_this_hostname_to_your_dns_configuration": {
-    "text": "このホスト名をDNS設定に追加してください：",
+    "text": "このホスト名をDNS設定に追加してください:",
     "source_hash": "4bf09ead"
   },
   "web.domains.1_create_a_txt_record": {
@@ -336,19 +336,19 @@
     "source_hash": "62766ffd"
   },
   "web.domains.follow_these_steps_to_verify_domain_ownership_an": {
-    "text": "ドメインの所有権を確認し、オンラインプレゼンスを向上させるには、以下の手順に従ってください：",
+    "text": "以下の手順に従ってドメイン所有権を検証し、オンラインプレゼンスを向上させましょう:",
     "source_hash": "a33f94d3"
   },
   "web.domains.domain_verification_steps": {
-    "text": "ドメイン検証ステップ",
+    "text": "ドメイン検証手順",
     "source_hash": "16dca977"
   },
   "web.domains.domain_verification_initiated_successfully": {
-    "text": "ドメイン確認が正常に開始されました。",
+    "text": "ドメイン検証が正常に開始されました。",
     "source_hash": "5969b924"
   },
   "web.domains.are_you_sure_you_want_to_remove_this_domain": {
-    "text": "このドメインを削除してもよろしいですか？この操作は元に戻せません。",
+    "text": "このドメインを削除してもよろしいですか?この操作は取り消せません。",
     "source_hash": "403c6d3b"
   },
   "web.domains.remove_domain": {
@@ -396,7 +396,7 @@
     "source_hash": "5932f0cb"
   },
   "web.domains.dns_widget_description": {
-    "text": "以下のツールを使用してDNSプロバイダーを自動検出し、ドメイン設定のステップバイステップの手順を取得できます。",
+    "text": "以下のツールを使用して、DNSプロバイダーを自動検出し、ドメイン設定の手順を取得できます。",
     "source_hash": "91c1af2e"
   },
   "web.domains.email.title": {
@@ -408,7 +408,7 @@
     "source_hash": "6f38aa51"
   },
   "web.domains.email.config_description": {
-    "text": "このドメインのメール送信を設定します",
+    "text": "このドメインのメール送信を設定できます",
     "source_hash": "1c275ff0"
   },
   "web.domains.email.provider_label": {
@@ -424,7 +424,7 @@
     "source_hash": "2f13b589"
   },
   "web.domains.email.from_name_placeholder": {
-    "text": "例: Acme Security",
+    "text": "例:Acme Security",
     "source_hash": "03c0f138"
   },
   "web.domains.email.from_address_label": {
@@ -432,7 +432,7 @@
     "source_hash": "60643eae"
   },
   "web.domains.email.from_address_placeholder": {
-    "text": "例: secrets{'@'}example.com",
+    "text": "例:secrets{'@'}example.com",
     "source_hash": "a09b3928"
   },
   "web.domains.email.reply_to_label": {
@@ -440,7 +440,7 @@
     "source_hash": "4538ea9c"
   },
   "web.domains.email.reply_to_placeholder": {
-    "text": "例: support{'@'}example.com",
+    "text": "例:support{'@'}example.com",
     "source_hash": "fa3e5f0b"
   },
   "web.domains.email.save_changes": {
@@ -468,7 +468,7 @@
     "source_hash": "f6fa84e7"
   },
   "web.domains.email.provider_ses_description": {
-    "text": "DKIMおよびSPFレコードによるドメイン検証が必要です",
+    "text": "DKIMとSPFレコードによるドメイン検証が必要です",
     "source_hash": "4df5aa60"
   },
   "web.domains.email.provider_sendgrid_description": {
@@ -488,7 +488,7 @@
     "source_hash": "34d2c307"
   },
   "web.domains.email.dns_records_description": {
-    "text": "メール送信用にドメインを検証するため、以下のDNSレコードを追加してください。",
+    "text": "以下のDNSレコードを追加して、メール送信用のドメインを検証してください。",
     "source_hash": "9fa85863"
   },
   "web.domains.email.dns_column_type": {
@@ -504,11 +504,11 @@
     "source_hash": "8e37953d"
   },
   "web.domains.email.dns_optional_label": {
-    "text": "Recommended",
+    "text": "推奨",
     "source_hash": "d70604e8"
   },
   "web.domains.email.dns_optional_hint": {
-    "text": "This record is recommended but not required for verification. A DMARC policy at your organizational domain may already cover this subdomain.",
+    "text": "このレコードは推奨されますが、検証には必須ではありません。組織ドメインのDMARCポリシーがこのサブドメインをカバーしている場合があります。",
     "source_hash": "58e1a12b"
   },
   "web.domains.email.copy": {
@@ -548,7 +548,7 @@
     "source_hash": "23a86f5a"
   },
   "web.domains.email.last_validated": {
-    "text": "最終検証日",
+    "text": "最終検証",
     "source_hash": "887dd486"
   },
   "web.domains.email.upgrade_to_configure": {
@@ -560,7 +560,7 @@
     "source_hash": "a48c0d40"
   },
   "web.domains.email.access_denied": {
-    "text": "アクセス拒否",
+    "text": "アクセスが拒否されました",
     "source_hash": "d134ca02"
   },
   "web.domains.email.access_denied_description": {
@@ -580,7 +580,7 @@
     "source_hash": "ffcf39fb"
   },
   "web.domains.email.disabled_notice": {
-    "text": "カスタムメール送信は現在無効です。メールはグローバル送信者から送信されます。カスタム送信者IDを使用するには、以下の機能を有効にしてください。",
+    "text": "カスタムメール送信は現在無効になっています。メールはグローバル送信者から送信されます。カスタム送信者IDを使用するには、以下の機能を有効にしてください。",
     "source_hash": "60a26f5b"
   },
   "web.domains.email.badge_not_configured": {
@@ -604,55 +604,55 @@
     "source_hash": "75081b59"
   },
   "web.domains.email.tooltip_not_configured": {
-    "text": "メール送信者が未設定 — メールはプラットフォームのデフォルト送信者を使用します",
+    "text": "メール送信者が設定されていません — メールはプラットフォームのデフォルト送信者を使用します",
     "source_hash": "360083bb"
   },
   "web.domains.email.tooltip_pending": {
-    "text": "メール送信者の設定が検証待ち — メールはプラットフォームのデフォルト送信者を使用します",
+    "text": "メール送信者の設定は検証待ちです — メールはプラットフォームのデフォルト送信者を使用します",
     "source_hash": "c8c2449c"
   },
   "web.domains.email.tooltip_disabled": {
-    "text": "メール送信者が無効 — メールはプラットフォームのデフォルト送信者を使用します",
+    "text": "メール送信者は無効です — メールはプラットフォームのデフォルト送信者を使用します",
     "source_hash": "64e84955"
   },
   "web.domains.email.tooltip_verified": {
-    "text": "メール送信者が検証済み — このドメインからメールが送信されます",
+    "text": "メール送信者が検証されました — メールはこのドメインから送信されます",
     "source_hash": "0e9a005c"
   },
   "web.domains.incoming.title": {
-    "text": "シークレット受信",
+    "text": "受信シークレット",
     "source_hash": "883dbca9"
   },
   "web.domains.incoming.config_title": {
-    "text": "シークレット受信設定",
+    "text": "受信シークレットの設定",
     "source_hash": "b3fef15b"
   },
   "web.domains.incoming.config_description": {
-    "text": "外部ユーザーがこのドメインの指定された受信者に直接シークレットを送信できるようにします",
+    "text": "外部ユーザーがこのドメインの指定された受信者にシークレットを直接送信できるようにします",
     "source_hash": "452ab4fe"
   },
   "web.domains.incoming.access_denied": {
-    "text": "アクセス拒否",
+    "text": "アクセスが拒否されました",
     "source_hash": "d134ca02"
   },
   "web.domains.incoming.access_denied_description": {
-    "text": "このドメインのシークレット受信設定を管理する権限がありません。組織の管理者にお問い合わせください。",
+    "text": "このドメインの受信シークレット設定を管理する権限がありません。組織の管理者にお問い合わせください。",
     "source_hash": "3e9d8adc"
   },
   "web.domains.incoming.upgrade_to_configure": {
-    "text": "このドメインのシークレット受信を設定するには、プランをアップグレードしてください。",
+    "text": "このドメインの受信シークレットを設定するには、プランをアップグレードしてください。",
     "source_hash": "9dfdfeb5"
   },
   "web.domains.incoming.configure_incoming": {
-    "text": "シークレット受信を設定",
+    "text": "受信シークレットを設定",
     "source_hash": "eab52939"
   },
   "web.domains.incoming.not_configured_notice": {
-    "text": "このドメインではシークレット受信が設定されていません。外部ユーザーがチームにシークレットを送信できるよう、受信者を追加してください。",
+    "text": "このドメインでは受信シークレットが設定されていません。外部ユーザーがチームにシークレットを送信できるように受信者を追加してください。",
     "source_hash": "dbc443a6"
   },
   "web.domains.incoming.disabled_notice": {
-    "text": "シークレット受信は現在無効です。外部ユーザーはこのドメインの受信者にシークレットを送信できません。シークレット受信を許可するには、以下の機能を有効にしてください。",
+    "text": "受信シークレットは現在無効になっています。外部ユーザーはこのドメインの受信者にシークレットを送信できません。受信シークレットを許可するには、以下の機能を有効にしてください。",
     "source_hash": "d1f8dafb"
   },
   "web.domains.incoming.recipients_title": {
@@ -660,7 +660,7 @@
     "source_hash": "1e8568a8"
   },
   "web.domains.incoming.recipients_description": {
-    "text": "このドメインでシークレットを受信できる人を定義します。シークレットが送信されると、受信者にメール通知が届きます。",
+    "text": "このドメインで受信シークレットを受け取れるユーザーを定義します。受信者はシークレットが送信されるとメール通知を受け取ります。",
     "source_hash": "026f9d9d"
   },
   "web.domains.incoming.add_recipient": {
@@ -684,7 +684,7 @@
     "source_hash": "18d67c99"
   },
   "web.domains.incoming.name_placeholder": {
-    "text": "例: セキュリティチーム",
+    "text": "例:セキュリティチーム",
     "source_hash": "0c52400c"
   },
   "web.domains.incoming.empty_state": {
@@ -692,11 +692,11 @@
     "source_hash": "bc8c2058"
   },
   "web.domains.incoming.empty_state_description": {
-    "text": "外部ユーザーがチームにシークレットを送信できるよう、受信者を追加してください。",
+    "text": "外部ユーザーがチームにシークレットを送信できるように受信者を追加してください。",
     "source_hash": "2a647a40"
   },
   "web.domains.incoming.validation_invalid_email": {
-    "text": "メールアドレスが無効です",
+    "text": "無効なメールアドレスです",
     "source_hash": "4eaf1d80"
   },
   "web.domains.incoming.validation_duplicate_email": {
@@ -724,15 +724,15 @@
     "source_hash": "e07e053c"
   },
   "web.domains.incoming.update_success": {
-    "text": "シークレット受信設定が正常に保存されました",
+    "text": "受信シークレットの設定が正常に保存されました",
     "source_hash": "9317e02d"
   },
   "web.domains.incoming.delete_success": {
-    "text": "シークレット受信設定が正常に削除されました",
+    "text": "受信シークレットの設定が正常に削除されました",
     "source_hash": "4c4a33ae"
   },
   "web.domains.incoming.recipient_count": {
-    "text": "受信者{count}名",
+    "text": "{count}名の受信者",
     "source_hash": "0e4f5985"
   },
   "web.domains.incoming.badge_not_configured": {
@@ -748,31 +748,31 @@
     "source_hash": "75081b59"
   },
   "web.domains.incoming.tooltip_not_configured": {
-    "text": "シークレット受信が未設定 - 外部ユーザーはこのドメインにシークレットを送信できません",
+    "text": "受信シークレットが設定されていません - 外部ユーザーはこのドメインにシークレットを送信できません",
     "source_hash": "79786d5c"
   },
   "web.domains.incoming.tooltip_configured": {
-    "text": "シークレット受信が有効（受信者{count}名）",
+    "text": "受信シークレットが有効で{count}名の受信者がいます",
     "source_hash": "c205cc54"
   },
   "web.domains.incoming.tooltip_disabled": {
-    "text": "このドメインではシークレット受信機能が無効です",
+    "text": "このドメインでは受信シークレット機能が無効になっています",
     "source_hash": "0413f96b"
   },
   "web.domains.incoming.enabled_label": {
-    "text": "シークレット受信を有効化",
+    "text": "受信シークレットを有効にする",
     "source_hash": "c0b25980"
   },
   "web.domains.incoming.enabled_hint": {
-    "text": "このドメインの受信者に外部ユーザーがシークレットを送信できるようにします",
+    "text": "外部ユーザーがこのドメインの受信者にシークレットを送信できるようにします",
     "source_hash": "24aadd31"
   },
   "web.domains.incoming.public_url_label": {
-    "text": "公開URL",
+    "text": "パブリックURL",
     "source_hash": "f7b60b04"
   },
   "web.domains.incoming.public_url_description": {
-    "text": "外部ユーザーがシークレットを送信できるよう、このURLを共有してください",
+    "text": "外部ユーザーがシークレットを送信できるようにこのURLを共有してください",
     "source_hash": "df47a894"
   },
   "web.domains.incoming.copy_url": {
@@ -812,11 +812,11 @@
     "source_hash": "afd5751e"
   },
   "web.domains.sso.config_description": {
-    "text": "このドメインのシングルサインオン認証を設定します",
+    "text": "このドメインのシングルサインオン認証を設定できます",
     "source_hash": "f37a0b47"
   },
   "web.domains.sso.access_denied": {
-    "text": "アクセス拒否",
+    "text": "アクセスが拒否されました",
     "source_hash": "d134ca02"
   },
   "web.domains.sso.access_denied_description": {
@@ -844,15 +844,15 @@
     "source_hash": "80d3a144"
   },
   "web.domains.sso.not_configured_notice": {
-    "text": "このドメインではSSOがまだ設定されていません。シングルサインオンを有効にして、チームメンバーが組織のIDプロバイダーを使用して認証できるようにしましょう。",
+    "text": "このドメインではSSOがまだ設定されていません。シングルサインオンを有効にして、チームメンバーが組織のIDプロバイダーを使用して認証できるようにしてください。",
     "source_hash": "c439214b"
   },
   "api.domains.errors.add_admin_required": {
-    "text": "カスタムドメインを追加できるのは、組織のオーナーと管理者のみです",
+    "text": "カスタムドメインを追加できるのは組織のオーナーと管理者のみです",
     "source_hash": "3324aabe"
   },
   "web.domains.public_homepage": {
-    "text": "公開ホームページ",
+    "text": "パブリックホームページ",
     "source_hash": "2ae3ccba"
   },
   "web.domains.status_tooltip_active": {
@@ -864,19 +864,19 @@
     "source_hash": "892cb2cb"
   },
   "web.domains.status_tooltip_not_verified": {
-    "text": "ドメインが未検証です — クリックして検証",
+    "text": "ドメインは未検証です — クリックして検証",
     "source_hash": "a9806710"
   },
   "web.domains.status_tooltip_unverified": {
-    "text": "ドメインの状態が未確認です — クリックして更新",
+    "text": "ドメインのステータスが未検証です — クリックして更新",
     "source_hash": "a45aa76d"
   },
   "web.domains.last_check_failed": {
-    "text": "前回の検証チェックに失敗しました",
+    "text": "最後の検証チェックが失敗しました",
     "source_hash": "88b594b8"
   },
   "web.domains.last_check_failed_ago": {
-    "text": "前回のチェックに失敗しました {0}",
+    "text": "最後のチェックが{0}に失敗しました",
     "source_hash": "ddfb6412"
   },
   "web.domains.verify_now": {
@@ -888,7 +888,7 @@
     "source_hash": "6eae7d9c"
   },
   "web.domains.remove_domain_description": {
-    "text": "このドメインとそのすべての設定を完全に削除します。",
+    "text": "このドメインとすべての設定を完全に削除します。",
     "source_hash": "73946b9e"
   },
   "web.domains.add_access_denied": {
@@ -904,7 +904,7 @@
     "source_hash": "5a1d8ab5"
   },
   "web.domains.dns_widget_not_available": {
-    "text": "DNSウィジェットを利用できません",
+    "text": "DNSウィジェットは利用できません",
     "source_hash": "4eed448b"
   },
   "web.domains.dns_widget_init_failed": {
@@ -920,7 +920,7 @@
     "source_hash": "77e07795"
   },
   "web.domains.unsaved_changes_confirmation": {
-    "text": "保存されていない変更があります。このページから移動してもよろしいですか?",
+    "text": "保存されていない変更があります。このまま離れますか?",
     "source_hash": "322380c1"
   },
   "web.domains.entitlement_required_owner": {
@@ -928,7 +928,7 @@
     "source_hash": "6de1f752"
   },
   "web.domains.entitlement_required_member": {
-    "text": "この機能は現在のプランではご利用いただけません。組織のオーナーにお問い合わせください。",
+    "text": "この機能は現在のプランでは利用できません。組織のオーナーにお問い合わせください。",
     "source_hash": "8f1688b2"
   },
   "web.domains.detail.manage": {
@@ -944,11 +944,11 @@
     "source_hash": "6360f7ec"
   },
   "web.domains.detail.homepage_description": {
-    "text": "ドメインのホームページでのシークレット作成を一般公開で許可します",
+    "text": "ドメインのホームページでシークレットを作成するためのパブリックアクセスを許可します",
     "source_hash": "209b3ded"
   },
   "web.domains.detail.brand_description": {
-    "text": "ロゴ、配色、カスタムブランディング",
+    "text": "ロゴ、色、カスタムブランディング",
     "source_hash": "69f7a9e8"
   },
   "web.domains.detail.sso_description": {
@@ -956,7 +956,7 @@
     "source_hash": "234e6150"
   },
   "web.domains.detail.email_description": {
-    "text": "カスタムメール送信元の設定",
+    "text": "カスタムメール送信者の設定",
     "source_hash": "7fcde01b"
   },
   "web.domains.detail.incoming_description": {
@@ -964,11 +964,11 @@
     "source_hash": "37c1fd6d"
   },
   "web.domains.detail.signup_description": {
-    "text": "ドメインごとの登録検証の方式",
+    "text": "ドメインごとのサインアップ検証戦略",
     "source_hash": "3c5a511f"
   },
   "web.domains.detail.signin_description": {
-    "text": "ドメインごとのログイン方法の設定",
+    "text": "ドメインごとのサインイン方法の設定",
     "source_hash": "73e01e36"
   },
   "web.domains.email.dns_check_label": {
@@ -980,11 +980,11 @@
     "source_hash": "472590ae"
   },
   "web.domains.email.test_email_title": {
-    "text": "メール配信のテスト",
+    "text": "メール配信テスト",
     "source_hash": "c1b3dee2"
   },
   "web.domains.email.test_email_hint": {
-    "text": "保存された設定を使用して、自分宛てにテストメールを送信します。機能がまだ有効になっていない場合でも動作します。",
+    "text": "保存された設定を使用して、自分宛てにテストメールを送信します。機能がまだ有効になっていなくても動作します。",
     "source_hash": "33e876ad"
   },
   "web.domains.email.send_test": {
@@ -1004,7 +1004,7 @@
     "source_hash": "8ceb9588"
   },
   "web.domains.email.delivered_via": {
-    "text": "{provider}経由で配信されました",
+    "text": "{provider}経由で配信",
     "source_hash": "f741959b"
   },
   "web.domains.incoming.feature_disabled": {
@@ -1016,15 +1016,15 @@
     "source_hash": "dce981e0"
   },
   "web.domains.signin.title": {
-    "text": "ログイン設定",
+    "text": "サインイン設定",
     "source_hash": "2da38c03"
   },
   "web.domains.signin.configure_signin": {
-    "text": "ログインを設定",
+    "text": "サインインを設定",
     "source_hash": "f72b58b5"
   },
   "web.domains.signin.config_description": {
-    "text": "このドメインのログイン認証方法を設定します",
+    "text": "このドメインのサインイン認証方法を設定できます",
     "source_hash": "8efce428"
   },
   "web.domains.signin.access_denied": {
@@ -1032,31 +1032,31 @@
     "source_hash": "d134ca02"
   },
   "web.domains.signin.upgrade_to_configure": {
-    "text": "このドメインのログイン方法を設定するには、プランをアップグレードしてください。",
+    "text": "このドメインのサインイン方法を設定するには、プランをアップグレードしてください。",
     "source_hash": "e242bb74"
   },
   "web.domains.signin.not_configured_notice": {
-    "text": "このドメインのログイン設定はまだ行われていません。上書き設定を構成して、このドメインのログインページで利用できる認証方法を制御してください。",
+    "text": "このドメインではサインイン設定がまだ設定されていません。このドメインのサインインページで利用可能な認証方法を制御するオーバーライドを設定してください。",
     "source_hash": "cb788a2d"
   },
   "web.domains.signin.signin_enabled_label": {
-    "text": "ログインを有効化",
+    "text": "サインインが有効",
     "source_hash": "cabe4898"
   },
   "web.domains.signin.header_toggle_label": {
-    "text": "ログイン",
+    "text": "サインイン",
     "source_hash": "5bbbe531"
   },
   "web.domains.signin.signin_enabled_hint": {
-    "text": "このドメインでユーザーがログインできるかどうか",
+    "text": "ユーザーがこのドメインでサインインできるかどうか",
     "source_hash": "57a92aee"
   },
   "web.domains.signin.restrict_to_label": {
-    "text": "ログイン方法を制限",
+    "text": "サインイン方法を制限",
     "source_hash": "edbec83f"
   },
   "web.domains.signin.restrict_to_hint": {
-    "text": "このドメインを単一の認証方法に制限します。設定すると、選択した方法のみがログインページに表示されます。",
+    "text": "このドメインを単一の認証方法に制限します。設定すると、選択した方法のみがサインインページに表示されます。",
     "source_hash": "682bc4c5"
   },
   "web.domains.signin.all_methods": {
@@ -1064,7 +1064,7 @@
     "source_hash": "e601c19e"
   },
   "web.domains.signin.all_methods_description": {
-    "text": "有効なすべての認証方法をログインページに表示します",
+    "text": "サインインページにすべての有効な認証方法を表示します",
     "source_hash": "62723340"
   },
   "web.domains.signin.method_password": {
@@ -1084,7 +1084,7 @@
     "source_hash": "cf7cd744"
   },
   "web.domains.signin.method_overrides_label": {
-    "text": "方法の上書き設定",
+    "text": "方法のオーバーライド",
     "source_hash": "5496cba6"
   },
   "web.domains.signin.method_overrides_hint": {
@@ -1092,7 +1092,7 @@
     "source_hash": "394e3878"
   },
   "web.domains.signin.mode_question": {
-    "text": "ユーザーはどのようにログインできますか?",
+    "text": "ユーザーはどのようにサインインできますか?",
     "source_hash": "3694eb23"
   },
   "web.domains.signin.mode_any": {
@@ -1100,7 +1100,7 @@
     "source_hash": "23665425"
   },
   "web.domains.signin.mode_any_hint": {
-    "text": "このドメインで利用可能なすべての方法を表示します。個々の方法は以下で絞り込めます。",
+    "text": "このドメインで利用可能なすべての方法を表示します。以下で個々の方法を絞り込めます。",
     "source_hash": "2f3dcba6"
   },
   "web.domains.signin.mode_one": {
@@ -1108,27 +1108,27 @@
     "source_hash": "601f5768"
   },
   "web.domains.signin.mode_one_hint": {
-    "text": "ログインページを単一の方法に制限します。このドメインで利用可能な方法のみが表示されます。",
+    "text": "サインインページを単一の方法に制限します。このドメインで利用可能な方法のみがリストされます。",
     "source_hash": "58bde6d5"
   },
   "web.domains.signin.mode_disabled": {
-    "text": "ログインを無効化",
+    "text": "サインイン無効",
     "source_hash": "bb807607"
   },
   "web.domains.signin.mode_disabled_hint": {
-    "text": "このドメインではユーザーはログインできません。",
+    "text": "ユーザーはこのドメインでサインインできません。",
     "source_hash": "8938f098"
   },
   "web.domains.signin.mode_disabled_notice": {
-    "text": "このドメインのログインページへの訪問者には、ログインが利用できない旨の通知と、ホームページに戻るリンクが表示されます。以前の方法の設定は保持され、ログインを再度有効にすると復元されます。",
+    "text": "このドメインのサインインページにアクセスすると、サインインが利用できないという通知とホームページへのリンクが表示されます。以前の方法設定は保持され、サインインを再度有効にすると復元されます。",
     "source_hash": "1a04de18"
   },
   "web.domains.signin.methods_list_label": {
-    "text": "ログインページに表示される方法",
+    "text": "サインインページに表示される方法",
     "source_hash": "66fd133b"
   },
   "web.domains.signin.restrict_picker_hint": {
-    "text": "このドメインで利用可能な方法のみが表示されます。",
+    "text": "このドメインで利用可能な方法のみがリストされます。",
     "source_hash": "c7a56f44"
   },
   "web.domains.signin.availability_always": {
@@ -1156,7 +1156,7 @@
     "source_hash": "ed1a02fd"
   },
   "web.domains.signin.method_email_auth_blurb": {
-    "text": "パスワードなしのマジックリンクログイン",
+    "text": "パスワードレスのマジックリンクサインイン",
     "source_hash": "7f776a85"
   },
   "web.domains.signin.method_webauthn_blurb": {
@@ -1172,7 +1172,7 @@
     "source_hash": "68c38f94"
   },
   "web.domains.signin.email_auth_hint": {
-    "text": "このドメインでパスワードなしのメール認証を許可します",
+    "text": "このドメインでパスワードレスのメール認証を許可します",
     "source_hash": "6ad82127"
   },
   "web.domains.signin.sso_enabled_label": {
@@ -1184,11 +1184,11 @@
     "source_hash": "22d78ad5"
   },
   "web.domains.signin.enabled_label": {
-    "text": "ログイン設定を有効化",
+    "text": "サインイン設定を有効にする",
     "source_hash": "dbd8e11c"
   },
   "web.domains.signin.enabled_hint": {
-    "text": "有効にすると、このドメインは上記で構成したログイン設定を使用します",
+    "text": "有効にすると、このドメインは上で設定したサインイン設定を使用します",
     "source_hash": "6259f8a2"
   },
   "web.domains.signin.save_config": {
@@ -1196,7 +1196,7 @@
     "source_hash": "b2b158f2"
   },
   "web.domains.signin.update_success": {
-    "text": "ログイン設定が正常に更新されました",
+    "text": "サインイン設定が正常に更新されました",
     "source_hash": "10ea50d8"
   },
   "web.domains.signin.reset_to_defaults": {
@@ -1204,27 +1204,27 @@
     "source_hash": "e240e635"
   },
   "web.domains.signin.reset_confirm": {
-    "text": "ログインをグローバルのデフォルトにリセットしますか?",
+    "text": "サインインをグローバルデフォルトにリセットしますか?",
     "source_hash": "2c6bbc32"
   },
   "web.domains.signin.reset_keeps_sso": {
-    "text": "SSO認証情報は保持されます。削除する場合は、SSO設定画面で個別に行ってください。",
+    "text": "SSO資格情報は保持されます。SSO設定画面で別途削除してください。",
     "source_hash": "edc0c756"
   },
   "web.domains.signin.reset_action": {
-    "text": "はい、リセットします",
+    "text": "はい、リセット",
     "source_hash": "4bb21d8b"
   },
   "web.domains.signin.reset_success": {
-    "text": "ログイン設定がグローバルのデフォルトにリセットされました",
+    "text": "サインイン設定がグローバルデフォルトにリセットされました",
     "source_hash": "0c364d89"
   },
   "web.domains.signup.title": {
-    "text": "登録検証",
+    "text": "サインアップ検証",
     "source_hash": "2c34ac0a"
   },
   "web.domains.signup.config_description": {
-    "text": "このドメインの登録検証を設定します",
+    "text": "このドメインのサインアップ検証を設定できます",
     "source_hash": "e9c81e8a"
   },
   "web.domains.signup.access_denied": {
@@ -1232,39 +1232,39 @@
     "source_hash": "d134ca02"
   },
   "web.domains.signup.upgrade_to_configure": {
-    "text": "ドメインごとの登録検証を設定するには、プランをアップグレードしてください。",
+    "text": "ドメインごとのサインアップ検証を設定するには、プランをアップグレードしてください。",
     "source_hash": "d87d6614"
   },
   "web.domains.signup.configure_signup": {
-    "text": "登録を設定",
+    "text": "サインアップを設定",
     "source_hash": "e2697662"
   },
   "web.domains.signup.not_configured_notice": {
-    "text": "このドメインの登録検証はまだ設定されていません。方式を構成して、このドメイン経由で登録できるユーザーを制御してください。",
+    "text": "このドメインではサインアップ検証がまだ設定されていません。このドメイン経由でサインアップできるユーザーを制御する戦略を設定してください。",
     "source_hash": "fc6c6eb8"
   },
   "web.domains.signup.site_signups_disabled_warning": {
-    "text": "現在、サイトレベルで登録が無効になっています。このドメインごとのポリシーは構成されていますが、サイトの登録が有効になるまでトラフィックを制御しません。",
+    "text": "サインアップは現在サイトレベルで無効になっています。このドメインごとのポリシーは設定されていますが、サイトのサインアップが有効になるまでトラフィックを制限しません。",
     "source_hash": "c0e59f86"
   },
   "web.domains.signup.strategy_label": {
-    "text": "検証方式",
+    "text": "検証戦略",
     "source_hash": "a2e95531"
   },
   "web.domains.signup.strategy_description": {
-    "text": "このドメインでユーザーが登録する際に、メールアドレスをどのように検証するかを選択します。",
+    "text": "このドメインでユーザーがサインアップする際のメールアドレスの検証方法を選択してください。",
     "source_hash": "8e232b03"
   },
   "web.domains.signup.network_validation_warning": {
-    "text": "この方式は登録時にネットワーク通信を行うため、遅延が発生したり、一部のプロバイダーによってブロックされたりする場合があります。",
+    "text": "この戦略はサインアップ中にネットワーク呼び出しを行うため、遅延が発生したり、一部のプロバイダーによってブロックされる可能性があります。",
     "source_hash": "53d4c266"
   },
   "web.domains.signup.allowed_domains_label": {
-    "text": "登録を許可するドメイン",
+    "text": "許可されたサインアップドメイン",
     "source_hash": "9b5bb5b1"
   },
   "web.domains.signup.allowed_domains_hint": {
-    "text": "これらのメールドメインのみが登録を許可されます。1行につき1つのドメインを追加してください。",
+    "text": "これらのメールドメインのみがサインアップを許可されます。1エントリにつき1ドメインを追加してください。",
     "source_hash": "c082414d"
   },
   "web.domains.signup.domain_placeholder": {
@@ -1272,11 +1272,11 @@
     "source_hash": "a379a6f6"
   },
   "web.domains.signup.invalid_domain": {
-    "text": "有効なドメインを入力してください (例: example.com)",
+    "text": "有効なドメインを入力してください(例:example.com)",
     "source_hash": "16807983"
   },
   "web.domains.signup.domain_exists": {
-    "text": "このドメインはすでにリストに含まれています",
+    "text": "このドメインは既にリストにあります",
     "source_hash": "3fccb721"
   },
   "web.domains.signup.remove_domain": {
@@ -1284,11 +1284,11 @@
     "source_hash": "ae708a1d"
   },
   "web.domains.signup.enabled_label": {
-    "text": "ドメインごとの検証を有効化",
+    "text": "ドメインごとの検証を有効にする",
     "source_hash": "db103925"
   },
   "web.domains.signup.enabled_hint": {
-    "text": "有効にすると、このドメインの登録はグローバルポリシーではなく上記の方式を使用します。",
+    "text": "有効にすると、このドメインでのサインアップはグローバルポリシーの代わりに上の戦略を使用します。",
     "source_hash": "99de2008"
   },
   "web.domains.signup.delete_config": {
@@ -1296,7 +1296,7 @@
     "source_hash": "a9a30c7f"
   },
   "web.domains.signup.delete_confirm": {
-    "text": "登録検証の設定を削除しますか? 登録はグローバルポリシーに戻ります。",
+    "text": "サインアップ検証設定を削除しますか?サインアップはグローバルポリシーにフォールバックします。",
     "source_hash": "a8c9086e"
   },
   "web.domains.signup.save_config": {
@@ -1304,35 +1304,35 @@
     "source_hash": "b2b158f2"
   },
   "web.domains.signup.update_success": {
-    "text": "登録検証が正常に更新されました",
+    "text": "サインアップ検証が正常に更新されました",
     "source_hash": "57a529ac"
   },
   "web.domains.signup.delete_success": {
-    "text": "登録検証の設定が正常に削除されました",
+    "text": "サインアップ検証設定が正常に削除されました",
     "source_hash": "eb6add4d"
   },
   "web.domains.signup.domain_overrides_label": {
-    "text": "ドメインの上書き設定",
+    "text": "ドメインオーバーライド",
     "source_hash": "d25da3cd"
   },
   "web.domains.signup.domain_overrides_hint": {
-    "text": "このドメインのグローバル登録設定を上書きします",
+    "text": "このドメインのグローバルサインアップ設定をオーバーライドします",
     "source_hash": "53101057"
   },
   "web.domains.signup.signup_enabled_label": {
-    "text": "登録を有効化",
+    "text": "サインアップが有効",
     "source_hash": "296ac66d"
   },
   "web.domains.signup.signup_enabled_hint": {
-    "text": "このドメインで登録を有効にするかどうかを上書きします",
+    "text": "このドメインでサインアップが有効かどうかをオーバーライドします",
     "source_hash": "2ee146b6"
   },
   "web.domains.signup.autoverify_label": {
-    "text": "アカウントの自動検証",
+    "text": "アカウントを自動検証",
     "source_hash": "4b103cd5"
   },
   "web.domains.signup.autoverify_hint": {
-    "text": "このドメインで新規アカウントを自動的に検証するかどうかを上書きします",
+    "text": "このドメインで新しいアカウントを自動的に検証するかどうかをオーバーライドします",
     "source_hash": "63866ecd"
   },
   "web.domains.sso.test_success": {
@@ -1344,11 +1344,11 @@
     "source_hash": "a45a37dd"
   },
   "web.domains.sso.enforce_moved_notice": {
-    "text": "このドメインのすべてのログインでSSOを必須にするには、ドメインのログイン設定で構成してください。SSO専用モードでは、ログインページがここで構成したSSOプロバイダーに制限されます。",
+    "text": "このドメインのすべてのサインインにSSOを必須にするには、ドメインのサインイン設定で設定してください。SSO専用モードでは、ログインページはここで設定されたSSOプロバイダーに制限されます。",
     "source_hash": "d26627a5"
   },
   "web.domains.sso.edit_credentials": {
-    "text": "認証情報を編集",
+    "text": "資格情報を編集",
     "source_hash": "5a6622b6"
   },
   "web.domains.sso.configure_button": {
@@ -1356,7 +1356,7 @@
     "source_hash": "6defafa2"
   },
   "web.domains.sso.upgrade_required": {
-    "text": "アップグレードして設定",
+    "text": "設定するにはアップグレードが必要です",
     "source_hash": "571cfa98"
   },
   "web.domains.add.field_label": {
@@ -1364,19 +1364,19 @@
     "source_hash": "d7d4c1e4"
   },
   "web.domains.add.field_help": {
-    "text": "チームが使用する正確なホスト名({example}など)。",
+    "text": "{example}のように、チームが使用する正確なホスト名を入力してください。",
     "source_hash": "3ba71f78"
   },
   "web.domains.add.echo_label": {
-    "text": "シークレットリンクの公開先",
+    "text": "シークレットリンクは以下でホストされます",
     "source_hash": "ad60b17d"
   },
   "web.domains.add.apex_question": {
-    "text": "それはドメイン全体です。シークレットリンクはどこに公開しますか?",
+    "text": "これはルートドメインです — シークレットリンクはどこに配置しますか?",
     "source_hash": "efacad1b"
   },
   "web.domains.add.apex_help": {
-    "text": "サブドメインを使えば、{domain}の残りの部分はそのまま維持されます。",
+    "text": "サブドメインを使用すると、{domain}の残りの部分はそのまま維持されます。",
     "source_hash": "0f7e6181"
   },
   "web.domains.add.recommended": {
@@ -1384,7 +1384,7 @@
     "source_hash": "d70604e8"
   },
   "web.domains.add.no_wrong_answer": {
-    "text": "間違った選択肢はありません。チームが認識しやすいものを選んでください。",
+    "text": "どちらを選んでも問題ありません — チームが認識しやすい方を選んでください。",
     "source_hash": "a04f0086"
   },
   "web.domains.add.subdomains_label": {
@@ -1392,7 +1392,7 @@
     "source_hash": "d6ee8eac"
   },
   "web.domains.add.root_group_label": {
-    "text": "またはドメイン全体を使用",
+    "text": "またはルートドメインを使用",
     "source_hash": "5c23c007"
   },
   "web.domains.add.root_domain_label": {
@@ -1400,15 +1400,15 @@
     "source_hash": "9fbbe253"
   },
   "web.domains.add.root_domain_description": {
-    "text": "これは{domain}全体を当社に向けます。そこのサイトは名前解決されなくなり、AまたはALIASレコードが必要です。",
+    "text": "これは{domain}全体を当社に向けます — そこにあるサイトは解決されなくなります — A / ALIASレコードが必要です。",
     "source_hash": "fae93847"
   },
   "web.domains.add.error_unrecognized_suffix": {
-    "text": "「.{0}」は認識されているドメインの末尾ではありません。入力ミスがないか確認してください(例:{1})。",
+    "text": "「.{0}」は認識されているドメイン末尾ではありません — 入力ミスがないか確認してください(例:{1})。",
     "source_hash": "4b90033d"
   },
   "web.domains.add.error_invalid_hostname": {
-    "text": "有効なホスト名を入力してください。使用できるのは英字、数字、単一のドットとダッシュです(例:{0})。",
+    "text": "有効なホスト名を入力してください — 文字、数字、単一のドットとダッシュ(例:{0})。",
     "source_hash": "c4ceabc1"
   },
   "web.domains.add.error_empty": {
@@ -1436,7 +1436,7 @@
     "source_hash": "da78c35d"
   },
   "web.domains.dns.point_domain_intro": {
-    "text": "次のDNSレコードをプロバイダーで追加して、",
+    "text": "以下のDNSレコードをプロバイダーに追加して、",
     "source_hash": "2fc0c524"
   },
   "web.domains.dns.point_domain_outro": {
@@ -1452,7 +1452,7 @@
     "source_hash": "41135375"
   },
   "web.domains.dns.apex_notice": {
-    "text": "Apex(ルート)ドメインはCNAMEレコードを使用できません。DNSプロバイダーのALIASまたはANAMEレコードを使用するか、サーバーのIPアドレスにAレコードを向けてください。",
+    "text": "Apex(ルート)ドメインはCNAMEレコードを使用できません。代わりにDNSプロバイダーのALIASまたはANAMEレコードを使用するか、AレコードをサーバーのIPアドレスに向けてください。",
     "source_hash": "2d1c3298"
   },
   "web.domains.email.from_address_local_placeholder": {
@@ -1480,7 +1480,7 @@
     "source_hash": "6539dfc1"
   },
   "web.domains.homepage.option_create_description": {
-    "text": "訪問者は自分のシークレットリンクを作成できます",
+    "text": "訪問者が独自のシークレットリンクを作成できます",
     "source_hash": "884310f4"
   },
   "web.domains.homepage.option_incoming_title": {
@@ -1488,11 +1488,11 @@
     "source_hash": "882997bf"
   },
   "web.domains.homepage.option_incoming_description": {
-    "text": "訪問者は設定済みの受信者にシークレットを送信できます",
+    "text": "訪問者が設定された受信者にシークレットを送信できます",
     "source_hash": "86bdaedb"
   },
   "web.domains.homepage.incoming_requires_recipients": {
-    "text": "受信シークレットを有効にし、少なくとも1人の受信者を設定する必要があります",
+    "text": "受信シークレットを有効にし、少なくとも1人の受信者が必要です",
     "source_hash": "0462611d"
   },
   "web.domains.homepage.configure_recipients": {
@@ -1504,15 +1504,15 @@
     "source_hash": "dfd5bd1c"
   },
   "web.domains.homepage.status_create": {
-    "text": "公開:訪問者がシークレットを作成",
+    "text": "パブリック:訪問者がシークレットを作成",
     "source_hash": "251cfb95"
   },
   "web.domains.homepage.status_incoming": {
-    "text": "公開:訪問者があなたにシークレットを送信",
+    "text": "パブリック:訪問者がシークレットを送信",
     "source_hash": "baa926b8"
   },
   "web.domains.homepage.status_incoming_unready": {
-    "text": "受信の準備ができていません。プライベートランディングページを表示しています",
+    "text": "受信準備ができていません — プライベートランディングページを表示中",
     "source_hash": "a5cc237c"
   },
   "web.domains.homepage.badge_incoming": {
@@ -1520,19 +1520,19 @@
     "source_hash": "e301820a"
   },
   "web.domains.homepage.update_success": {
-    "text": "ホームページ設定を保存しました",
+    "text": "ホームページ設定が保存されました",
     "source_hash": "4eac9f45"
   },
   "web.domains.homepage.homepage_uses_incoming_warning": {
-    "text": "このドメインのホームページは現在、受信シークレットフォームを表示しています。受信シークレットを無効にするか、すべての受信者を削除すると、受信が再び準備できるまで、ホームページはプライベートランディングページに切り替わります。",
+    "text": "このドメインのホームページは現在、受信シークレットフォームを表示しています。受信シークレットを無効にするか、すべての受信者を削除すると、受信が再び準備できるまでホームページはプライベートランディングページに切り替わります。",
     "source_hash": "cc0d4997"
   },
   "web.domains.signin.effective_status_label": {
-    "text": "このドメインでのログイン",
+    "text": "このドメインでのサインイン",
     "source_hash": "d8b884c3"
   },
   "web.domains.signin.dormant_notice": {
-    "text": "ログインはワークスペース全体で無効になっているため、すべてのドメインで利用できません。ここでの設定は保持され、ワークスペースのログインが再び有効になると適用されます。",
+    "text": "サインインはワークスペース全体でオフになっているため、すべてのドメインで利用できません。ここでの設定は保持され、ワークスペースのサインインが再度有効になると適用されます。",
     "source_hash": "723d35dc"
   },
   "web.domains.signup.effective_status_label": {
@@ -1540,7 +1540,7 @@
     "source_hash": "115ab21b"
   },
   "web.domains.signup.dormant_notice": {
-    "text": "サインアップはワークスペース全体で無効になっているため、すべてのドメインで利用できません。ここでの設定は保持され、ワークスペースのサインアップが再び有効になると適用されます。",
+    "text": "サインアップはワークスペース全体でオフになっているため、すべてのドメインで利用できません。ここでの設定は保持され、ワークスペースのサインアップが再度有効になると適用されます。",
     "source_hash": "49faefe4"
   }
 }

--- a/locales/content/ja/workspace-organizations.json
+++ b/locales/content/ja/workspace-organizations.json
@@ -12,7 +12,7 @@
     "source_hash": "2730183d"
   },
   "web.organizations.organizations_description": {
-    "text": "組織を管理",
+    "text": "組織を管理できます",
     "source_hash": "dbaa4f92"
   },
   "web.organizations.my_organizations": {
@@ -28,7 +28,7 @@
     "source_hash": "4876e647"
   },
   "web.organizations.no_organizations": {
-    "text": "ワークスペースはまだありません",
+    "text": "ワークスペースがありません",
     "source_hash": "97d0b117"
   },
   "web.organizations.no_organizations_description": {
@@ -52,7 +52,7 @@
     "source_hash": "98a583b4"
   },
   "web.organizations.create_organization_description": {
-    "text": "新しいワークスペースを作成",
+    "text": "新しいワークスペースを作成できます",
     "source_hash": "6ac2b5fc"
   },
   "web.organizations.create": {
@@ -68,7 +68,7 @@
     "source_hash": "6fa5a5b1"
   },
   "web.organizations.organization_name_placeholder": {
-    "text": "例: 株式会社サンプル",
+    "text": "例:株式会社ACME",
     "source_hash": "ac1c804b"
   },
   "web.organizations.display_name": {
@@ -80,7 +80,7 @@
     "source_hash": "526e0087"
   },
   "web.organizations.description_placeholder": {
-    "text": "この組織の目的は?",
+    "text": "この組織の目的は何ですか?",
     "source_hash": "27d7edae"
   },
   "web.organizations.contact_email": {
@@ -88,7 +88,7 @@
     "source_hash": "513332d3"
   },
   "web.organizations.contact_email_help": {
-    "text": "請求と管理通知の主要連絡先",
+    "text": "請求と管理通知の主要な連絡先",
     "source_hash": "ee81c03d"
   },
   "web.organizations.select_organization": {
@@ -124,7 +124,7 @@
     "source_hash": "d70b9e24"
   },
   "web.organizations.last_updated": {
-    "text": "最終更新",
+    "text": "最終更新日",
     "source_hash": "048c7f2e"
   },
   "web.organizations.organization_settings": {
@@ -132,7 +132,7 @@
     "source_hash": "cc1d9e61"
   },
   "web.organizations.organization_settings_description": {
-    "text": "組織名と説明を更新",
+    "text": "組織名と説明を更新できます",
     "source_hash": "2d8b5b2b"
   },
   "web.organizations.general_settings": {
@@ -164,11 +164,11 @@
     "source_hash": "8a131415"
   },
   "web.organizations.billing_coming_soon": {
-    "text": "請求統合は近日公開",
+    "text": "請求統合は近日公開予定",
     "source_hash": "d3e0ec75"
   },
   "web.organizations.billing_coming_soon_description": {
-    "text": "統合された請求とサブスクリプション管理は、将来のリリースで利用可能になります。",
+    "text": "統合された請求とサブスクリプション管理は、今後のリリースで利用可能になります。",
     "source_hash": "8836108f"
   },
   "web.organizations.about_title": {
@@ -176,7 +176,7 @@
     "source_hash": "2f3e2ad8"
   },
   "web.organizations.about_description": {
-    "text": "組織は、一元管理のための統合された請求と管理を提供します。",
+    "text": "組織は一元管理のための統合された請求と管理を提供します。",
     "source_hash": "910f97a8"
   },
   "web.organizations.single_user_info_title": {
@@ -184,7 +184,7 @@
     "source_hash": "810a6c86"
   },
   "web.organizations.single_user_info_description": {
-    "text": "ここで会社名と組織の詳細を更新します。この情報はアカウントをパーソナライズし、将来のブランディング機能に使用できます。",
+    "text": "会社名と組織の詳細をここで更新できます。この情報はアカウントのパーソナライズに役立ち、将来的にブランディング機能に使用できます。",
     "source_hash": "96b2e4b5"
   },
   "web.organizations.getting_started_title": {
@@ -196,7 +196,7 @@
     "source_hash": "0487f33a"
   },
   "web.organizations.page_description": {
-    "text": "組織とチームメンバーを管理",
+    "text": "組織とチームメンバーを管理できます",
     "source_hash": "2d026be4"
   },
   "web.organizations.tabs.general": {
@@ -204,7 +204,7 @@
     "source_hash": "74a883a0"
   },
   "web.organizations.tabs.company_branding": {
-    "text": "会社ブランディング",
+    "text": "会社のブランディング",
     "source_hash": "7ecc5d35"
   },
   "web.organizations.tabs.members": {
@@ -220,7 +220,7 @@
     "source_hash": "4999c6c6"
   },
   "web.organizations.danger_zone": {
-    "text": "危険ゾーン",
+    "text": "危険な操作",
     "source_hash": "3c1c01b4"
   },
   "web.organizations.delete_organization": {
@@ -228,7 +228,7 @@
     "source_hash": "54b2edc7"
   },
   "web.organizations.delete_organization_warning": {
-    "text": "これにより組織が完全に削除されます。この操作は取り消せません。",
+    "text": "組織は完全に削除されます。この操作は取り消せません。",
     "source_hash": "ab2d2c05"
   },
   "web.organizations.delete": {
@@ -240,7 +240,7 @@
     "source_hash": "54b2edc7"
   },
   "web.organizations.delete_organization_confirm_message": {
-    "text": "{name}を削除してもよろしいですか? この操作は取り消せません。",
+    "text": "{name}を削除してもよろしいですか?この操作は取り消せません。",
     "source_hash": "db7e1f9d"
   },
   "web.organizations.delete_error": {
@@ -252,7 +252,7 @@
     "source_hash": "1044a4c0"
   },
   "web.organizations.members.description": {
-    "text": "組織のメンバーと役割を管理",
+    "text": "組織のメンバーとそのロールを管理できます",
     "source_hash": "1353774c"
   },
   "web.organizations.members.current_members": {
@@ -280,7 +280,7 @@
     "source_hash": "969ccbd3"
   },
   "web.organizations.members.role": {
-    "text": "役割",
+    "text": "ロール",
     "source_hash": "14736a2e"
   },
   "web.organizations.members.joined": {
@@ -292,7 +292,7 @@
     "source_hash": "ff8059dc"
   },
   "web.organizations.members.no_members": {
-    "text": "メンバーがまだいません。チームメンバーを招待して始めましょう。",
+    "text": "メンバーがいません。チームメンバーを招待して始めましょう。",
     "source_hash": "6cbc5271"
   },
   "web.organizations.members.no_members_description": {
@@ -300,15 +300,15 @@
     "source_hash": "61dd2085"
   },
   "web.organizations.members.role_updated": {
-    "text": "メンバーの役割を更新しました",
+    "text": "メンバーのロールが正常に更新されました",
     "source_hash": "d0d332c6"
   },
   "web.organizations.members.role_update_error": {
-    "text": "メンバーの役割の更新に失敗しました",
+    "text": "メンバーのロールの更新に失敗しました",
     "source_hash": "17d5ca66"
   },
   "web.organizations.members.member_removed": {
-    "text": "メンバーを組織から削除しました",
+    "text": "メンバーが組織から削除されました",
     "source_hash": "210a187b"
   },
   "web.organizations.members.member_remove_error": {
@@ -324,11 +324,11 @@
     "source_hash": "36695d98"
   },
   "web.organizations.members.cannot_change_own_role": {
-    "text": "自分の役割は変更できません",
+    "text": "自分のロールは変更できません",
     "source_hash": "0d874f75"
   },
   "web.organizations.members.cannot_remove_self": {
-    "text": "自分自身を組織から削除することはできません",
+    "text": "組織から自分を削除することはできません",
     "source_hash": "ab358307"
   },
   "web.organizations.members.cannot_remove_owner": {
@@ -352,19 +352,19 @@
     "source_hash": "7c968fb7"
   },
   "web.organizations.members.role_descriptions.owner": {
-    "text": "すべての組織設定とメンバーへのフルアクセス",
+    "text": "すべての組織設定とメンバーへの完全なアクセス権",
     "source_hash": "d49381bf"
   },
   "web.organizations.members.role_descriptions.admin": {
-    "text": "メンバーとほとんどの組織設定を管理可能",
+    "text": "メンバーとほとんどの組織設定を管理できます",
     "source_hash": "3d7ade92"
   },
   "web.organizations.members.role_descriptions.member": {
-    "text": "組織リソースへの基本的なアクセス",
+    "text": "組織リソースへの基本的なアクセス権",
     "source_hash": "0ddca91a"
   },
   "web.organizations.invitations.title": {
-    "text": "組織の招待",
+    "text": "組織への招待",
     "source_hash": "0289d92d"
   },
   "web.organizations.invitations.invite_member": {
@@ -392,7 +392,7 @@
     "source_hash": "7fd425f7"
   },
   "web.organizations.invitations.role": {
-    "text": "役割",
+    "text": "ロール",
     "source_hash": "14736a2e"
   },
   "web.organizations.invitations.send_invite": {
@@ -400,7 +400,7 @@
     "source_hash": "d076aa0f"
   },
   "web.organizations.invitations.invite_sent": {
-    "text": "招待を正常に送信しました",
+    "text": "招待が正常に送信されました",
     "source_hash": "81facbe6"
   },
   "web.organizations.invitations.invite_error": {
@@ -416,7 +416,7 @@
     "source_hash": "87e6d00b"
   },
   "web.organizations.invitations.resend_success": {
-    "text": "招待を再送信しました",
+    "text": "招待が正常に再送信されました",
     "source_hash": "099eb255"
   },
   "web.organizations.invitations.resend_error": {
@@ -424,7 +424,7 @@
     "source_hash": "82750487"
   },
   "web.organizations.invitations.revoke_success": {
-    "text": "招待を取り消しました",
+    "text": "招待が正常に取り消されました",
     "source_hash": "4ce1262c"
   },
   "web.organizations.invitations.revoke_error": {
@@ -492,15 +492,15 @@
     "source_hash": "59936259"
   },
   "web.organizations.invitations.you_are_invited": {
-    "text": "以下の組織に招待されました:",
+    "text": "参加への招待を受けました",
     "source_hash": "60e635c6"
   },
   "web.organizations.invitations.invited_as": {
-    "text": "以下の役割で招待されました:",
+    "text": "以下のロールで招待されました",
     "source_hash": "f9809eae"
   },
   "web.organizations.invitations.accept_success": {
-    "text": "招待を承諾しました",
+    "text": "招待が正常に承諾されました",
     "source_hash": "7eb6b234"
   },
   "web.organizations.invitations.accept_error": {
@@ -520,11 +520,11 @@
     "source_hash": "b72770d7"
   },
   "web.organizations.invitations.invalid_token": {
-    "text": "無効または期限切れの招待",
+    "text": "無効または期限切れの招待です",
     "source_hash": "6c0fc3de"
   },
   "web.organizations.invitations.must_sign_in": {
-    "text": "この招待を承諾するにはログインしてください",
+    "text": "この招待を承諾するにはサインインしてください",
     "source_hash": "469fc705"
   },
   "web.organizations.invitations.loading_invitation": {
@@ -532,11 +532,11 @@
     "source_hash": "58884885"
   },
   "web.organizations.invitations.upgrade_to_invite": {
-    "text": "チームメンバーを招待するにはプランをアップグレード",
+    "text": "チームメンバーを招待するにはプランをアップグレードしてください",
     "source_hash": "5e3f8df8"
   },
   "web.organizations.invitations.upgrade_prompt": {
-    "text": "メンバーの招待には有料プランが必要です。組織に共同編集者を追加するには、プランをアップグレードしてください。",
+    "text": "メンバーの招待には有料プランが必要です。アップグレードして組織に共同作業者を追加できます。",
     "source_hash": "47d0eeab"
   },
   "web.organizations.paid_badge": {
@@ -544,15 +544,15 @@
     "source_hash": "957b0b87"
   },
   "web.organizations.early_supporter_badge": {
-    "text": "アーリーサポーター",
+    "text": "早期サポーター",
     "source_hash": "e67d2ef8"
   },
   "web.organizations.member_count": {
-    "text": "{count}人のメンバー",
+    "text": "{count}名のメンバー",
     "source_hash": "f652af0c"
   },
   "web.organizations.domain_count": {
-    "text": "{count}件のドメイン",
+    "text": "{count}ドメイン",
     "source_hash": "09f52efa"
   },
   "web.organizations.tabs.domains": {
@@ -560,11 +560,11 @@
     "source_hash": "ced67718"
   },
   "web.organizations.invitations.email_mismatch_title": {
-    "text": "別のアカウントでログイン中",
+    "text": "別のアカウントでサインインしています",
     "source_hash": "6516362a"
   },
   "web.organizations.invitations.email_mismatch_body": {
-    "text": "この招待は{invitedEmail}宛てです。現在{currentEmail}としてログインしています。",
+    "text": "この招待は{invitedEmail}宛てです。現在{currentEmail}としてサインインしています。",
     "source_hash": "78a6f301"
   },
   "web.organizations.invitations.continue_as_invited_email": {
@@ -584,11 +584,11 @@
     "source_hash": "a5dcfef9"
   },
   "web.organizations.sso.title": {
-    "text": "シングルサインオン（SSO）",
+    "text": "シングルサインオン(SSO)",
     "source_hash": "5db5c812"
   },
   "web.organizations.sso.description": {
-    "text": "組織のIDプロバイダーを使用してメンバーがサインインできるようにSSOを設定します",
+    "text": "組織のIDプロバイダーでメンバーがサインインできるようにSSOを設定できます",
     "source_hash": "464f0a8b"
   },
   "web.organizations.sso.provider_type": {
@@ -604,11 +604,11 @@
     "source_hash": "18d67c99"
   },
   "web.organizations.sso.display_name_hint": {
-    "text": "サインイン時にユーザーに表示されるフレンドリー名",
+    "text": "サインイン時にユーザーに表示されるわかりやすい名前",
     "source_hash": "a83f1fba"
   },
   "web.organizations.sso.display_name_placeholder": {
-    "text": "例: Acme Corp SSO",
+    "text": "例:ACME Corp SSO",
     "source_hash": "43c655c5"
   },
   "web.organizations.sso.client_id": {
@@ -628,7 +628,7 @@
     "source_hash": "14e4a8c8"
   },
   "web.organizations.sso.client_secret_update_hint": {
-    "text": "既存のシークレットを維持する場合は空白のままにしてください",
+    "text": "既存のシークレットを維持するには空白のままにしてください",
     "source_hash": "98bc3b40"
   },
   "web.organizations.sso.tenant_id": {
@@ -640,7 +640,7 @@
     "source_hash": "3c5b707a"
   },
   "web.organizations.sso.tenant_id_placeholder": {
-    "text": "例: 12345678-1234-1234-1234-123456789abc",
+    "text": "例:12345678-1234-1234-1234-123456789abc",
     "source_hash": "1a166316"
   },
   "web.organizations.sso.issuer": {
@@ -648,31 +648,31 @@
     "source_hash": "4d03ba8a"
   },
   "web.organizations.sso.issuer_hint": {
-    "text": "IDプロバイダーのOIDCディスカバリURL",
+    "text": "IDプロバイダーのOIDCディスカバリーURL",
     "source_hash": "6102d81b"
   },
   "web.organizations.sso.issuer_placeholder": {
-    "text": "例: https://login.example.com",
+    "text": "例:https://login.example.com",
     "source_hash": "9a638e9c"
   },
   "web.organizations.sso.allowed_domains": {
-    "text": "許可するメールドメイン",
+    "text": "許可されたメールドメイン",
     "source_hash": "0295ad71"
   },
   "web.organizations.sso.allowed_domains_hint": {
-    "text": "これらのドメインのメールアドレスを持つユーザーのみがサインインできます。すべてのドメインを許可する場合は空白のままにしてください。",
+    "text": "これらのドメインのメールアドレスを持つユーザーのみがサインインできます。すべてのドメインを許可するには空白のままにしてください。",
     "source_hash": "1775e874"
   },
   "web.organizations.sso.domain_placeholder": {
-    "text": "例: acme.com",
+    "text": "例:acme.com",
     "source_hash": "e4420764"
   },
   "web.organizations.sso.invalid_domain": {
-    "text": "有効なドメインを入力してください（例: example.com）",
+    "text": "有効なドメインを入力してください(例:example.com)",
     "source_hash": "16807983"
   },
   "web.organizations.sso.domain_exists": {
-    "text": "このドメインは既にリストに含まれています",
+    "text": "このドメインは既にリストにあります",
     "source_hash": "3fccb721"
   },
   "web.organizations.sso.remove_domain": {
@@ -680,7 +680,7 @@
     "source_hash": "ae708a1d"
   },
   "web.organizations.sso.enabled": {
-    "text": "SSOを有効化",
+    "text": "SSOを有効にする",
     "source_hash": "d10d0801"
   },
   "web.organizations.sso.enabled_hint": {
@@ -696,7 +696,7 @@
     "source_hash": "9ac1ac7b"
   },
   "web.organizations.sso.delete_confirm": {
-    "text": "本当に削除しますか?組織のSSOが無効になります。",
+    "text": "よろしいですか?これにより組織のSSOが無効になります。",
     "source_hash": "5b3f5b9d"
   },
   "web.organizations.sso.load_error": {
@@ -724,15 +724,15 @@
     "source_hash": "4a960fe4"
   },
   "web.organizations.sso.test_connection": {
-    "text": "接続をテスト",
+    "text": "接続テスト",
     "source_hash": "c02977b0"
   },
   "web.organizations.sso.test_connection_hint": {
-    "text": "IDプロバイダーに到達可能かどうかを確認します（認証情報の検証は行いません）",
+    "text": "IDプロバイダーに到達可能か確認します(資格情報の検証は行いません)",
     "source_hash": "22a23b68"
   },
   "web.organizations.sso.test_button": {
-    "text": "接続をテスト",
+    "text": "接続テスト",
     "source_hash": "c02977b0"
   },
   "web.organizations.sso.testing": {
@@ -744,11 +744,11 @@
     "source_hash": "c1d1f310"
   },
   "web.organizations.sso.auth_endpoint": {
-    "text": "認証エンドポイント",
+    "text": "認可エンドポイント",
     "source_hash": "b42b956f"
   },
   "web.organizations.sso.missing_fields": {
-    "text": "未入力の項目",
+    "text": "不足しているフィールド",
     "source_hash": "757df777"
   },
   "web.organizations.sso.status_enabled": {
@@ -764,7 +764,7 @@
     "source_hash": "13161464"
   },
   "web.organizations.sso.domain_sso_description": {
-    "text": "検証済みの各ドメインにSSOを設定します",
+    "text": "検証済みの各ドメインのSSOを設定できます",
     "source_hash": "af5b799e"
   },
   "web.organizations.sso.provider_type_locked_hint": {
@@ -780,31 +780,31 @@
     "source_hash": "c8d058eb"
   },
   "api.organizations.errors.owner_required": {
-    "text": "この操作を実行できるのは、組織のオーナーのみです",
+    "text": "この操作は組織のオーナーのみが実行できます",
     "source_hash": "5a729e94"
   },
   "api.organizations.errors.admin_required": {
-    "text": "この操作を実行できるのは、組織のオーナーと管理者のみです",
+    "text": "この操作は組織のオーナーと管理者のみが実行できます",
     "source_hash": "cd9e8c0e"
   },
   "api.organizations.errors.member_required": {
-    "text": "この操作を実行するには、組織のメンバーである必要があります",
+    "text": "この操作を実行するには組織のメンバーである必要があります",
     "source_hash": "f66f4a60"
   },
   "api.organizations.invitations.errors.create_admin_required": {
-    "text": "招待を作成できるのは、組織のオーナーと管理者のみです",
+    "text": "招待を作成できるのは組織のオーナーと管理者のみです",
     "source_hash": "777d150d"
   },
   "api.organizations.invitations.errors.resend_admin_required": {
-    "text": "招待を再送信できるのは、組織のオーナーと管理者のみです",
+    "text": "招待を再送信できるのは組織のオーナーと管理者のみです",
     "source_hash": "6a857d59"
   },
   "api.organizations.invitations.errors.view_admin_required": {
-    "text": "招待を表示できるのは、組織のオーナーと管理者のみです",
+    "text": "招待を確認できるのは組織のオーナーと管理者のみです",
     "source_hash": "42f5878b"
   },
   "api.organizations.invitations.errors.revoke_admin_required": {
-    "text": "招待を取り消せるのは、組織のオーナーと管理者のみです",
+    "text": "招待を取り消しできるのは組織のオーナーと管理者のみです",
     "source_hash": "52f73c8a"
   },
   "api.organizations.invitations.errors.email_required": {
@@ -812,11 +812,11 @@
     "source_hash": "aae92911"
   },
   "api.organizations.invitations.errors.email_invalid": {
-    "text": "メールアドレスの形式が無効です",
+    "text": "無効なメールアドレス形式です",
     "source_hash": "0bcecf66"
   },
   "api.organizations.invitations.errors.role_invalid": {
-    "text": "役割はメンバーまたは管理者のいずれかである必要があります",
+    "text": "ロールはメンバーまたは管理者である必要があります",
     "source_hash": "650ea5f6"
   },
   "api.organizations.invitations.errors.cannot_invite_owner": {
@@ -824,15 +824,15 @@
     "source_hash": "e6581025"
   },
   "api.organizations.invitations.errors.already_member": {
-    "text": "ユーザーはすでにこの組織のメンバーです",
+    "text": "このユーザーは既に組織のメンバーです",
     "source_hash": "8eb45780"
   },
   "api.organizations.invitations.errors.already_pending": {
-    "text": "このメールアドレスへの招待はすでに保留中です",
+    "text": "このメールアドレスへの招待は既に保留中です",
     "source_hash": "7f5e3093"
   },
   "api.organizations.invitations.errors.member_limit_reached": {
-    "text": "メンバー数の上限に達しました。さらにメンバーを招待するには、プランをアップグレードしてください。",
+    "text": "メンバーの上限に達しました。プランをアップグレードしてメンバーを追加してください。",
     "source_hash": "b8f316e8"
   },
   "api.organizations.invitations.errors.not_found": {
@@ -840,23 +840,23 @@
     "source_hash": "775ba9eb"
   },
   "api.organizations.invitations.errors.cannot_resend_non_pending": {
-    "text": "再送信できるのは保留中の招待のみです",
+    "text": "保留中の招待のみ再送信できます",
     "source_hash": "b7578b3e"
   },
   "api.organizations.invitations.errors.cannot_revoke_non_pending": {
-    "text": "取り消せるのは保留中の招待のみです",
+    "text": "保留中の招待のみ取り消しできます",
     "source_hash": "732b78a6"
   },
   "api.organizations.invitations.errors.resend_limit_reached": {
-    "text": "再送信の上限回数 (%{max}) に達しました",
+    "text": "最大再送信回数(%{max}回)に達しました",
     "source_hash": "8dc96729"
   },
   "api.organizations.invitations.errors.accept_token_required": {
-    "text": "トークンは必須です",
+    "text": "トークンが必要です",
     "source_hash": "6c718161"
   },
   "api.organizations.invitations.errors.accept_organization_gone": {
-    "text": "組織はすでに存在しません",
+    "text": "組織は存在しません",
     "source_hash": "a5df7d22"
   },
   "api.organizations.invitations.errors.accept_expired": {
@@ -864,11 +864,11 @@
     "source_hash": "7186297b"
   },
   "api.organizations.invitations.errors.accept_email_mismatch": {
-    "text": "お使いのメールアドレスが招待と一致しません",
+    "text": "メールアドレスが招待と一致しません",
     "source_hash": "11026f46"
   },
   "api.organizations.invitations.errors.accept_already_member": {
-    "text": "あなたはすでにこの組織のメンバーです",
+    "text": "既にこの組織のメンバーです",
     "source_hash": "f56ad547"
   },
   "web.organizations.entitlements_title": {
@@ -876,7 +876,7 @@
     "source_hash": "36054d4f"
   },
   "web.organizations.page_description_short": {
-    "text": "ワークスペースの表示と設定",
+    "text": "ワークスペースを確認・設定できます",
     "source_hash": "524fcb9a"
   },
   "web.organizations.delete_organization_remove_domains_first": {
@@ -884,11 +884,11 @@
     "source_hash": "44678715"
   },
   "web.organizations.default_org_delete_notice_title": {
-    "text": "この組織の削除",
+    "text": "この組織の削除について",
     "source_hash": "9191d915"
   },
   "web.organizations.default_org_delete_notice_before": {
-    "text": "これはデフォルトの組織であり、ダッシュボードから削除することはできません。削除するには、",
+    "text": "これはデフォルトの組織であり、ダッシュボードから削除できません。削除するには、",
     "source_hash": "e203607d"
   },
   "web.organizations.default_org_delete_notice_link": {
@@ -896,11 +896,11 @@
     "source_hash": "94645a9e"
   },
   "web.organizations.default_org_delete_notice_after": {
-    "text": "からご連絡ください。",
+    "text": "からお問い合わせください。",
     "source_hash": "cdb4ee2a"
   },
   "web.organizations.leave_organization": {
-    "text": "この組織から退出",
+    "text": "この組織を離れる",
     "source_hash": "d534cff9"
   },
   "web.organizations.leave_organization_warning": {
@@ -908,19 +908,19 @@
     "source_hash": "e9daab07"
   },
   "web.organizations.leave_organization_confirm_title": {
-    "text": "組織から退出",
+    "text": "組織を離れる",
     "source_hash": "ec8314da"
   },
   "web.organizations.leave_organization_confirm_message": {
-    "text": "{name}から退出してもよろしいですか? 再参加するには新しい招待が必要になります。",
+    "text": "{name}を離れてもよろしいですか?再度参加するには新しい招待が必要です。",
     "source_hash": "e21c5fec"
   },
   "web.organizations.leave_organization_success": {
-    "text": "組織から退出しました。",
+    "text": "組織を離れました。",
     "source_hash": "fc803eb3"
   },
   "web.organizations.leave_error": {
-    "text": "組織からの退出に失敗しました",
+    "text": "組織を離れることに失敗しました",
     "source_hash": "6cb6af43"
   },
   "web.organizations.organizations": {
@@ -928,7 +928,7 @@
     "source_hash": "2730183d"
   },
   "web.organizations.invitations.invited_by_inline": {
-    "text": "{email}より",
+    "text": "{email}による",
     "source_hash": "969a7050"
   },
   "web.organizations.invitations.invited_as_inline": {
@@ -940,27 +940,27 @@
     "source_hash": "76c5505f"
   },
   "web.organizations.invitations.email_locked_hint": {
-    "text": "この招待はこのメールアドレス宛てに送信されました",
+    "text": "この招待はこのメールアドレスに送信されました",
     "source_hash": "2cff7075"
   },
   "web.organizations.invitations.signup_continue": {
-    "text": "続ける",
+    "text": "続行",
     "source_hash": "31fbef16"
   },
   "web.organizations.invitations.signin_continue": {
-    "text": "ログイン",
+    "text": "サインイン",
     "source_hash": "bcc0bcc9"
   },
   "web.organizations.invitations.confirm_join_below": {
-    "text": "あと少しです — 以下で確認して組織に参加してください。",
+    "text": "もう少しです — 以下を確認して組織に参加してください。",
     "source_hash": "2d14f9b0"
   },
   "web.organizations.invitations.go_to_organizations": {
-    "text": "組織へ移動",
+    "text": "組織に移動",
     "source_hash": "2afa38a3"
   },
   "web.organizations.invitations.already_member": {
-    "text": "あなたはすでにこの組織のメンバーです",
+    "text": "既にこの組織のメンバーです",
     "source_hash": "f56ad547"
   },
   "web.organizations.invitations.join_organization": {
@@ -968,7 +968,7 @@
     "source_hash": "1aea9194"
   },
   "web.organizations.invitations.sign_in_to_join": {
-    "text": "ログインして{orgName}に参加",
+    "text": "サインインして{orgName}に参加",
     "source_hash": "f94ed8b4"
   },
   "web.organizations.invitations.decline": {
@@ -976,19 +976,19 @@
     "source_hash": "a2d285b3"
   },
   "web.organizations.members.member_quota": {
-    "text": "{limit}人中{used}人のメンバー",
+    "text": "{limit}名中{used}名のメンバー",
     "source_hash": "51183b79"
   },
   "web.organizations.members.pending_suffix": {
-    "text": "({count}件保留中)",
+    "text": "({count}名保留中)",
     "source_hash": "c13f787f"
   },
   "web.organizations.members.limit_reached_hint": {
-    "text": "メンバー数の上限に達しました。",
+    "text": "メンバーの上限に達しました。",
     "source_hash": "26cdb6b8"
   },
   "web.organizations.sso.view_discovery_document": {
-    "text": "ディスカバリードキュメントを表示",
+    "text": "ディスカバリードキュメントを見る",
     "source_hash": "513bda60"
   },
   "web.organizations.sso.callback_url": {
@@ -1000,19 +1000,19 @@
     "source_hash": "65d55683"
   },
   "web.organizations.sso.enforce_sso_only": {
-    "text": "SSOのみを強制",
+    "text": "SSO専用を強制",
     "source_hash": "b3a3f694"
   },
   "web.organizations.sso.enforce_sso_only_hint": {
-    "text": "このドメインのすべてのログインでSSOを必須にします。有効にすると、パスワードによる認証は無効になります。",
+    "text": "このドメインのすべてのサインインにSSOを必須にします。有効にすると、パスワードベースの認証は無効になります。",
     "source_hash": "19432210"
   },
   "web.organizations.sso.grant_org_scope": {
-    "text": "組織全体へのアクセスを付与",
+    "text": "組織全体のアクセスを付与",
     "source_hash": "2070cef2"
   },
   "web.organizations.sso.grant_org_scope_hint": {
-    "text": "このドメインのSSO経由で参加した新規メンバーには、すべての組織ドメインへのアクセス権が付与されます。既存のメンバーには影響しません。無効にした場合(デフォルト)、新規メンバーはこのドメインにのみアクセスできます。",
+    "text": "このドメインのSSO経由で参加した新しいメンバーは、すべての組織ドメインへのアクセス権が付与されます。既存のメンバーには影響しません。無効(デフォルト)の場合、新しいメンバーはこのドメインのみにアクセスできます。",
     "source_hash": "2ac9f345"
   },
   "web.organizations.sso.no_domains": {
@@ -1034,5 +1034,153 @@
   "web.organizations.create_workspace": {
     "text": "ワークスペースを作成",
     "source_hash": "c63c14cf"
+  },
+  "web.organizations.organization_id": {
+    "text": "組織ID",
+    "source_hash": "1f466322"
+  },
+  "web.organizations.organization_id_hint": {
+    "text": "このIDはサポートへの問い合わせや、この組織へのAPIリクエストのスコープ設定に使用します。サインイン資格情報ではありません。",
+    "source_hash": "29549b3a"
+  },
+  "web.organizations.audit.title": {
+    "text": "シークレットアクティビティ",
+    "source_hash": "6d6d41f3"
+  },
+  "web.organizations.audit.description": {
+    "text": "この組織で記録されたシークレットの作成とアクセスイベントの監査証跡。",
+    "source_hash": "553c564b"
+  },
+  "web.organizations.audit.country_unknown": {
+    "text": "不明",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.empty_title": {
+    "text": "アクティビティがありません",
+    "source_hash": "0a12b92c"
+  },
+  "web.organizations.audit.empty_description": {
+    "text": "チームがシークレットを共有すると、シークレットの作成とアクセスイベントがここに表示されます。",
+    "source_hash": "62fb14c2"
+  },
+  "web.organizations.audit.capped_notice": {
+    "text": "最新の{max}件のイベントのみが保持されています。古いアクティビティは削除されました。",
+    "source_hash": "da7901e2"
+  },
+  "web.organizations.audit.collection_paused_notice": {
+    "text": "イベント収集は一時停止中です。新しいシークレットアクティビティは記録されていません。",
+    "source_hash": "cb09d147"
+  },
+  "web.organizations.audit.load_error": {
+    "text": "シークレットアクティビティを読み込めませんでした。",
+    "source_hash": "52fde814"
+  },
+  "web.organizations.audit.contract_mismatch": {
+    "text": "サーバーから返されたアクティビティデータを読み取れませんでした。証跡は空ではありませんが、現在表示できません。",
+    "source_hash": "db0d007a"
+  },
+  "web.organizations.audit.retry": {
+    "text": "再試行",
+    "source_hash": "d8b8392e"
+  },
+  "web.organizations.audit.showing_range": {
+    "text": "{total}件中{from}〜{to}件を表示",
+    "source_hash": "c329279d"
+  },
+  "web.organizations.audit.upgrade_prompt": {
+    "text": "シークレットアクティビティには監査ログ付きのプランが必要です。アップグレードして、この組織で誰がシークレットを作成、閲覧、表示したかを確認できます。",
+    "source_hash": "453649ce"
+  },
+  "web.organizations.audit.role_required": {
+    "text": "シークレットアクティビティは組織のオーナーと管理者が利用できます。",
+    "source_hash": "e066ec63"
+  },
+  "web.organizations.audit.actors.creator": {
+    "text": "作成者",
+    "source_hash": "88447b83"
+  },
+  "web.organizations.audit.actors.authenticated_other": {
+    "text": "別のサインイン済みユーザー",
+    "source_hash": "ee45aa5a"
+  },
+  "web.organizations.audit.actors.anonymous": {
+    "text": "匿名",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.organizations.audit.actors.system": {
+    "text": "システム",
+    "source_hash": "6725e7bb"
+  },
+  "web.organizations.audit.actors.unknown": {
+    "text": "不明",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.columns.event": {
+    "text": "イベント",
+    "source_hash": "4e1f49a9"
+  },
+  "web.organizations.audit.columns.secret": {
+    "text": "シークレット",
+    "source_hash": "7e32a729"
+  },
+  "web.organizations.audit.columns.actor": {
+    "text": "アクター",
+    "source_hash": "449995c4"
+  },
+  "web.organizations.audit.columns.country": {
+    "text": "国",
+    "source_hash": "701d021d"
+  },
+  "web.organizations.audit.columns.when": {
+    "text": "日時",
+    "source_hash": "cf9c7aa2"
+  },
+  "web.organizations.audit.kinds.created": {
+    "text": "シークレットが作成されました",
+    "source_hash": "e4a1e1fd"
+  },
+  "web.organizations.audit.kinds.status_get": {
+    "text": "リンクのステータスが確認されました",
+    "source_hash": "0753f60e"
+  },
+  "web.organizations.audit.kinds.secret_get": {
+    "text": "シークレットリンクが開かれました",
+    "source_hash": "e271e060"
+  },
+  "web.organizations.audit.kinds.previewed": {
+    "text": "作成者がプレビューしました",
+    "source_hash": "639fc1e2"
+  },
+  "web.organizations.audit.kinds.creator_status_get": {
+    "text": "作成者がステータスを確認しました",
+    "source_hash": "7e4b5de5"
+  },
+  "web.organizations.audit.kinds.receipt_viewed": {
+    "text": "受領書が閲覧されました",
+    "source_hash": "a417ead4"
+  },
+  "web.organizations.audit.kinds.revealed": {
+    "text": "シークレットが閲覧されました",
+    "source_hash": "aff2c84d"
+  },
+  "web.organizations.audit.kinds.burned": {
+    "text": "シークレットが削除されました",
+    "source_hash": "5ac68dc6"
+  },
+  "web.organizations.audit.kinds.expired": {
+    "text": "シークレットが期限切れになりました",
+    "source_hash": "c127dab6"
+  },
+  "web.organizations.audit.kinds.orphaned": {
+    "text": "シークレットが孤立しました",
+    "source_hash": "23fe1a47"
+  },
+  "web.organizations.audit.kinds.reveal_failed_undecryptable": {
+    "text": "閲覧に失敗しました(復号化不可)",
+    "source_hash": "d5616abf"
+  },
+  "web.organizations.tabs.activity": {
+    "text": "アクティビティ",
+    "source_hash": "38da1505"
   }
 }


### PR DESCRIPTION
## `ja` translation update

Automated export of completed **ja** translations from the translation task DB.
Scope: `locales/content/ja/` only — 43 file(s), +3460/-1460.

⚠️ `i18n validate variables` reports **3** variable mismatch(es) for `ja` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ⚠️ Needs review — two real content regressions

**Summary:** Large stylistic-normalization pass across most files; the 3 automated-validator errors are false positives (see below), but two independent, unrelated-to-this-diff-scope content regressions were found that should be fixed before merge.

**Critical (must fix):**
- `web.COMMON.website_url` (00-common.json): text changed from `https://onetimesecret.com/ja` to `.../en` — breaks the localized link for ja users. `source_hash` is unchanged, meaning the English source wasn't touched, so this is a pure translation regression.
- `email.feedback_email.signature` (email.json): "Onetime Secret サポートチーム" → "Secret Support" — the brand name "Onetime Secret" is dropped entirely and the replacement is left untranslated in English. `source_hash` unchanged here too.

**Warnings:**
- The 3 variable-validator errors (`web.auth.connections.connect_action.context`, `web.link_sso.prompt.context`, `web.sso_link_confirm.prompt.context`) are all on `.context` fields — English-only translator annotations, not user-facing text — being empty there is expected. This is the same validator false-positive pattern seen in today's other locale reviews (de, el_GR, eo, es, hu); non-blocking, but the validator script should stop treating `.context` as translatable.
- `api.account.errors.invalid_email`: reworded from an instruction ("有効なメールアドレスを入力してください") to a rhetorical question ("有効なメールアドレスですか？") — unnatural phrasing for a form error message, reads like an MT artifact.
- `web.regions.each_jurisdiction_maintains_separate_legal_compl`: `source_hash` unchanged, but the new translation shifts topic from legal/jurisdiction compliance to infrastructure independence, duplicating `separate_environments_explanation` — possible content mix-up.

**Notes:**
- Broad, internally consistent style normalization (politeness forms, CJK parenthesis/spacing conventions, 削除→消去 for "destroyed") — no issues.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
