### PR TITLE
i18n: update ko translations

### DIFF
--- a/locales/content/ko/00-common.json
+++ b/locales/content/ko/00-common.json
@@ -1539,5 +1539,9 @@
   "web.TITLES.domain_dns": {
     "text": "DNS 설정",
     "source_hash": "6c63df31"
+  },
+  "web.TITLES.connected_identities": {
+    "text": "연결된 계정",
+    "source_hash": "e132c4d9"
   }
 }

--- a/locales/content/ko/admin-audit.json
+++ b/locales/content/ko/admin-audit.json
@@ -98,5 +98,41 @@
   "web.admin.audit.result.failure": {
     "text": "실패",
     "source_hash": "7031edbc"
+  },
+  "web.admin.audit.categories.secret": {
+    "text": "비밀 메시지",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.audit.categories.membership": {
+    "text": "멤버십",
+    "source_hash": "b50f1a42"
+  },
+  "web.admin.audit.categories.entitlement_preview": {
+    "text": "권한 미리보기",
+    "source_hash": "255c5797"
+  },
+  "web.admin.audit.categories.colonel": {
+    "text": "Colonel 로그인",
+    "source_hash": "01eeeb38"
+  },
+  "web.admin.audit.filters.actorLabel": {
+    "text": "사용자",
+    "source_hash": "449995c4"
+  },
+  "web.admin.audit.filters.searchButton": {
+    "text": "검색",
+    "source_hash": "49c266ba"
+  },
+  "web.admin.audit.filters.searchHint": {
+    "text": "사용자를 입력한 후 Enter를 누르거나 검색을 선택하여 실행하세요. 입력하는 동안 목록이 업데이트되지 않습니다.",
+    "source_hash": "45eceb12"
+  },
+  "web.admin.audit.filters.pendingSearch": {
+    "text": "아직 검색되지 않았습니다 — Enter를 누르거나 검색을 선택하여 이 사용자를 적용하세요.",
+    "source_hash": "f76095c2"
+  },
+  "web.admin.audit.list.contractError": {
+    "text": "서버가 응답했지만 감사 데이터가 예상 형식과 일치하지 않습니다. 이벤트를 표시할 수 없습니다 — 빈 로그가 아니라 보고 오류입니다.",
+    "source_hash": "7f48137e"
   }
 }

--- a/locales/content/ko/admin-billing.json
+++ b/locales/content/ko/admin-billing.json
@@ -122,5 +122,85 @@
   "web.admin.billing.status.changed": {
     "text": "변경됨",
     "source_hash": "2a6141e4"
+  },
+  "web.admin.billing.diff.backToCatalog": {
+    "text": "결제 카탈로그로 돌아가기",
+    "source_hash": "8532b373"
+  },
+  "web.admin.billing.diff.driftedFields": {
+    "text": "다른 필드:",
+    "source_hash": "9890c95b"
+  },
+  "web.admin.billing.diff.notFound": {
+    "text": "카탈로그에 플랜이 없습니다",
+    "source_hash": "0253898b"
+  },
+  "web.admin.billing.diff.notFoundDescription": {
+    "text": "구성된 카탈로그 또는 Stripe 실시간 동기화 캐시에서 ID가 {planid}인 플랜을 찾을 수 없습니다.",
+    "source_hash": "2e69551c"
+  },
+  "web.admin.billing.stripeOrgs.title": {
+    "text": "Stripe 고객",
+    "source_hash": "0463ae27"
+  },
+  "web.admin.billing.stripeOrgs.description": {
+    "text": "Stripe 고객 레코드에 연결된 조직입니다.",
+    "source_hash": "2ab09aec"
+  },
+  "web.admin.billing.stripeOrgs.searchPlaceholder": {
+    "text": "Stripe 고객 ID로 검색",
+    "source_hash": "d5acf08f"
+  },
+  "web.admin.billing.stripeOrgs.empty": {
+    "text": "Stripe 고객 ID가 있는 조직이 없습니다.",
+    "source_hash": "2e373537"
+  },
+  "web.admin.billing.stripeOrgs.emptySearch": {
+    "text": "검색과 일치하는 Stripe 고객 ID가 없습니다.",
+    "source_hash": "75011174"
+  },
+  "web.admin.billing.stripeOrgs.loadError": {
+    "text": "Stripe 고객 목록을 불러올 수 없습니다.",
+    "source_hash": "15e2d9a7"
+  },
+  "web.admin.billing.stripeOrgs.unavailable": {
+    "text": "이 서버에서 Stripe 고객 목록을 아직 사용할 수 없습니다.",
+    "source_hash": "aab6451a"
+  },
+  "web.admin.billing.stripeOrgs.none": {
+    "text": "없음",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.billing.stripeOrgs.capped": {
+    "text": "인덱스 스캔이 한도에 도달하여 총계는 최소값입니다 — 검색 범위를 좁혀 나머지를 확인하세요.",
+    "source_hash": "20bcaa38"
+  },
+  "web.admin.billing.stripeOrgs.stale": {
+    "text": "이 페이지의 인덱스 항목 {count}개가 더 이상 로드되지 않는 조직을 가리키고 있어 건너뛰었습니다.",
+    "source_hash": "51980f83"
+  },
+  "web.admin.billing.stripeOrgs.copyStripeId": {
+    "text": "Stripe 고객 ID 복사",
+    "source_hash": "a77d18b1"
+  },
+  "web.admin.billing.stripeOrgs.columns.organization": {
+    "text": "조직",
+    "source_hash": "d764d425"
+  },
+  "web.admin.billing.stripeOrgs.columns.owner": {
+    "text": "소유자",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.billing.stripeOrgs.columns.plan": {
+    "text": "플랜",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.billing.stripeOrgs.columns.subscription": {
+    "text": "구독",
+    "source_hash": "4999c6c6"
+  },
+  "web.admin.billing.stripeOrgs.columns.stripeCustomer": {
+    "text": "Stripe 고객 ID",
+    "source_hash": "7e1d8bbb"
   }
 }

--- a/locales/content/ko/admin-colonel.json
+++ b/locales/content/ko/admin-colonel.json
@@ -838,5 +838,37 @@
   "web.colonel.nav.groups.communications": {
     "text": "커뮤니케이션",
     "source_hash": "919a9253"
+  },
+  "web.colonel.organizations.sameAsContact": {
+    "text": "연락처와 동일",
+    "source_hash": "ed18ff43"
+  },
+  "web.colonel.organizations.refresh": {
+    "text": "새로고침",
+    "source_hash": "0e916101"
+  },
+  "web.colonel.organizations.updatedAgo": {
+    "text": "{ago} 전에 업데이트됨",
+    "source_hash": "cda30b9c"
+  },
+  "web.colonel.organizations.columns.name": {
+    "text": "이름",
+    "source_hash": "dcd1d522"
+  },
+  "web.colonel.organizations.columns.contactEmail": {
+    "text": "연락처 이메일",
+    "source_hash": "6d7fce11"
+  },
+  "web.colonel.organizations.columns.billingEmail": {
+    "text": "청구서 이메일",
+    "source_hash": "8805b928"
+  },
+  "web.colonel.organizations.columns.planSubscription": {
+    "text": "플랜 및 구독",
+    "source_hash": "b396caac"
+  },
+  "web.colonel.organizations.filters.searchPlaceholder": {
+    "text": "ID, 이름 또는 이메일로 검색",
+    "source_hash": "6fe16473"
   }
 }

--- a/locales/content/ko/admin-customers.json
+++ b/locales/content/ko/admin-customers.json
@@ -4,8 +4,8 @@
     "source_hash": "aabe76f1"
   },
   "web.admin.customers.description": {
-    "text": "SSH 없이 고객을 찾고 지원 문제를 해결합니다.",
-    "source_hash": "c8487e68"
+    "text": "고객을 찾고 지원 문제를 해결하세요.",
+    "source_hash": "00961ea3"
   },
   "web.admin.customers.actions.plan.label": {
     "text": "요금제",
@@ -482,5 +482,213 @@
   "web.admin.customers.suspended.badge": {
     "text": "정지됨",
     "source_hash": "e392a389"
+  },
+  "web.admin.customers.actions.checkoutLink.button": {
+    "text": "결제 링크 생성",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.modalTitle": {
+    "text": "결제 링크 생성",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.planLabel": {
+    "text": "플랜",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.actions.checkoutLink.planPlaceholder": {
+    "text": "플랜 패밀리 ID (예: identity_plus_v1)",
+    "source_hash": "12eba027"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleLabel": {
+    "text": "결제 주기",
+    "source_hash": "d69f731e"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleMonthly": {
+    "text": "월간",
+    "source_hash": "9b11f6b7"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleYearly": {
+    "text": "연간",
+    "source_hash": "6e69b59e"
+  },
+  "web.admin.customers.actions.checkoutLink.allowPromo": {
+    "text": "프로모션 코드 허용",
+    "source_hash": "ebe7bc8b"
+  },
+  "web.admin.customers.actions.checkoutLink.submit": {
+    "text": "링크 생성",
+    "source_hash": "e6b850cf"
+  },
+  "web.admin.customers.actions.checkoutLink.resultLead": {
+    "text": "결제 링크가 생성되었습니다. 고객에게 공유하세요 — 한 번만 사용 가능하며 만료됩니다.",
+    "source_hash": "6ff1fb0e"
+  },
+  "web.admin.customers.actions.checkoutLink.copy": {
+    "text": "결제 링크 복사",
+    "source_hash": "f1e51ca7"
+  },
+  "web.admin.customers.actions.checkoutLink.expiry": {
+    "text": "약 {hours}시간 후 만료 ({date}).",
+    "source_hash": "4c878a15"
+  },
+  "web.admin.customers.actions.checkoutLink.regionLabel": {
+    "text": "지역",
+    "source_hash": "d3a008ef"
+  },
+  "web.admin.customers.actions.checkoutLink.parseError": {
+    "text": "서버가 요청을 수락했지만 읽을 수 없는 응답을 반환하여 링크를 표시할 수 없습니다. 재시도하기 전에 Stripe를 확인하세요.",
+    "source_hash": "e7e08290"
+  },
+  "web.admin.customers.actions.checkoutLink.done": {
+    "text": "완료",
+    "source_hash": "11a6767d"
+  },
+  "web.admin.customers.actions.purge.typePrompt": {
+    "text": "확인하려면 아래에 계정 이메일 주소 {token}을(를) 입력하세요",
+    "source_hash": "8b2a1819"
+  },
+  "web.admin.customers.actions.purge.unavailable": {
+    "text": "삭제 불가: 이 계정에는 확인을 위해 다시 입력할 이메일 주소가 없습니다.",
+    "source_hash": "5f20f7e5"
+  },
+  "web.admin.customers.columns.actions": {
+    "text": "작업",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.diagnostics.title": {
+    "text": "계정 진단",
+    "source_hash": "5574ece8"
+  },
+  "web.admin.customers.detail.diagnostics.loading": {
+    "text": "진단 실행 중…",
+    "source_hash": "062c83d5"
+  },
+  "web.admin.customers.detail.diagnostics.loadError": {
+    "text": "진단을 불러올 수 없습니다.",
+    "source_hash": "69e69f49"
+  },
+  "web.admin.customers.detail.diagnostics.healthy": {
+    "text": "차단 조건을 찾을 수 없습니다. 인증 상태가 정상으로 보입니다 — 클라이언트 측 문제(쿠키, 사용자 지정 도메인 로그인 설정) 또는 잘못된 지역을 의심하세요.",
+    "source_hash": "f6d5f8d1"
+  },
+  "web.admin.customers.detail.diagnostics.authUnavailable": {
+    "text": "인증 데이터베이스를 사용할 수 없습니다(단순 인증 모드) — SQL 측 검사를 건너뛰었습니다.",
+    "source_hash": "d668907c"
+  },
+  "web.admin.customers.detail.diagnostics.authFailed": {
+    "text": "인증 데이터베이스가 응답하지 않아 SQL 측 검사를 실행할 수 없습니다: {reason}",
+    "source_hash": "46d047c0"
+  },
+  "web.admin.customers.detail.diagnostics.unknown": {
+    "text": "알 수 없음",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.title": {
+    "text": "인증 로그",
+    "source_hash": "48ad8ba8"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.empty": {
+    "text": "기록된 인증 이벤트가 없습니다.",
+    "source_hash": "d2332558"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.unavailable": {
+    "text": "인증 로그를 읽을 수 없습니다: {reason}",
+    "source_hash": "ab18af57"
+  },
+  "web.admin.customers.detail.diagnostics.facts.authStatus": {
+    "text": "인증 상태",
+    "source_hash": "34def169"
+  },
+  "web.admin.customers.detail.diagnostics.facts.noAccount": {
+    "text": "인증 계정 없음",
+    "source_hash": "a9968e9e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.password": {
+    "text": "비밀번호",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordSet": {
+    "text": "설정됨",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordNone": {
+    "text": "없음",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfa": {
+    "text": "MFA",
+    "source_hash": "d39ce053"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfaNone": {
+    "text": "없음",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.loginFailures": {
+    "text": "실패한 시도",
+    "source_hash": "63e7f0a8"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lockedBadge": {
+    "text": "잠김",
+    "source_hash": "ace29f74"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiter": {
+    "text": "속도 제한기",
+    "source_hash": "32892404"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterEngaged": {
+    "text": "작동 중",
+    "source_hash": "1b0d851e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterClear": {
+    "text": "정상",
+    "source_hash": "83b12c22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verification": {
+    "text": "확인 이메일",
+    "source_hash": "23fac8fb"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationPending": {
+    "text": "대기 중 — 마지막 발송: {date}",
+    "source_hash": "9ab8d1b6"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationNone": {
+    "text": "대기 중 없음",
+    "source_hash": "a4d4cc22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.sessions": {
+    "text": "활성 세션",
+    "source_hash": "61ad9909"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lastLogin": {
+    "text": "마지막 로그인 (인증)",
+    "source_hash": "373e7fb1"
+  },
+  "web.admin.customers.detail.receipts.partial": {
+    "text": "부분 목록 — 최근 {count}개를 표시합니다. 이 고객은 여기에 표시된 것보다 더 많은 수신 확인을 가지고 있습니다.",
+    "source_hash": "127fd4db"
+  },
+  "web.admin.customers.detail.secrets.partial": {
+    "text": "부분 목록 — 최근 {count}개를 표시합니다. 이 고객은 여기에 표시된 것보다 더 많은 비밀 메시지를 가지고 있습니다.",
+    "source_hash": "a537c8f3"
+  },
+  "web.admin.customers.detail.sessions.columns.country": {
+    "text": "국가",
+    "source_hash": "701d021d"
+  },
+  "web.admin.customers.detail.sessions.current.badge": {
+    "text": "현재 세션",
+    "source_hash": "6da6530a"
+  },
+  "web.admin.customers.detail.sessions.current.tooltip": {
+    "text": "현재 관리자 세션입니다. 여기서 취소해도 효과가 없습니다 — 이 요청이 끝날 때까지 다시 생성됩니다.",
+    "source_hash": "ef097ab1"
+  },
+  "web.admin.customers.verification.verified": {
+    "text": "확인됨",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.verification.unverified": {
+    "text": "확인되지 않음",
+    "source_hash": "15133907"
   }
 }

--- a/locales/content/ko/admin-domains.json
+++ b/locales/content/ko/admin-domains.json
@@ -190,5 +190,657 @@
   "web.admin.domains.verify.success.done": {
     "text": "{domain}에 대한 검증이 완료되었습니다.",
     "source_hash": "ed67e22d"
+  },
+  "web.admin.domains.actions.preview": {
+    "text": "미리보기",
+    "source_hash": "324b134f"
+  },
+  "web.admin.domains.actions.probe.button": {
+    "text": "검사",
+    "source_hash": "3bd51ab9"
+  },
+  "web.admin.domains.actions.remove.button": {
+    "text": "도메인 제거",
+    "source_hash": "5ce43507"
+  },
+  "web.admin.domains.actions.remove.previewButton": {
+    "text": "제거 미리보기",
+    "source_hash": "6b81bd92"
+  },
+  "web.admin.domains.actions.remove.previewStatus": {
+    "text": "상태:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.remove.previewOrg": {
+    "text": "조직:",
+    "source_hash": "5300e286"
+  },
+  "web.admin.domains.actions.remove.reassertsSurvivor": {
+    "text": "다른 레코드가 동일한 도메인 이름을 주장하며 조회 인덱스를 대신합니다.",
+    "source_hash": "902838f4"
+  },
+  "web.admin.domains.actions.remove.confirmTitle": {
+    "text": "도메인을 제거하시겠습니까?",
+    "source_hash": "716dfac9"
+  },
+  "web.admin.domains.actions.remove.confirmDescription": {
+    "text": "{domain} 및 브랜딩, DNS, 구성 레코드를 영구적으로 삭제합니다. 되돌릴 수 없습니다. 계속하려면 도메인의 공개 ID를 다시 입력하세요.",
+    "source_hash": "d0b67b47"
+  },
+  "web.admin.domains.actions.remove.success": {
+    "text": "도메인이 제거되었습니다.",
+    "source_hash": "2ccaa6d3"
+  },
+  "web.admin.domains.actions.remove.notApplied": {
+    "text": "서버가 적용 대신 제거를 미리보기했습니다 — 도메인이 제거되지 않았습니다. 다시 시도하고, 문제가 지속되면 보고하세요.",
+    "source_hash": "dc6d70ae"
+  },
+  "web.admin.domains.actions.repair.title": {
+    "text": "조직 연결 복구",
+    "source_hash": "82b40352"
+  },
+  "web.admin.domains.actions.repair.description": {
+    "text": "이 도메인과 조직 간의 끊어진 연결을 찾아 수정합니다. 변경 사항을 확인하려면 먼저 미리보기하세요.",
+    "source_hash": "531ed287"
+  },
+  "web.admin.domains.actions.repair.orgIdLabel": {
+    "text": "조직 ID (고아 도메인만 해당)",
+    "source_hash": "0d3010eb"
+  },
+  "web.admin.domains.actions.repair.orgIdPlaceholder": {
+    "text": "도메인에 소유자가 없는 경우에만 입력",
+    "source_hash": "118b7132"
+  },
+  "web.admin.domains.actions.repair.statusLabel": {
+    "text": "상태:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.repair.noIssues": {
+    "text": "문제를 찾을 수 없습니다 — 복구할 것이 없습니다.",
+    "source_hash": "17735887"
+  },
+  "web.admin.domains.actions.repair.button": {
+    "text": "복구 적용",
+    "source_hash": "4d0ab2d4"
+  },
+  "web.admin.domains.actions.repair.confirmTitle": {
+    "text": "복구를 적용하시겠습니까?",
+    "source_hash": "ef0ffae5"
+  },
+  "web.admin.domains.actions.repair.confirmDescription": {
+    "text": "{domain}의 조직 연결을 다시 작성합니다. 계속하려면 도메인의 공개 ID를 다시 입력하세요.",
+    "source_hash": "a9f2702f"
+  },
+  "web.admin.domains.actions.repair.success": {
+    "text": "복구가 적용되었습니다.",
+    "source_hash": "850bd784"
+  },
+  "web.admin.domains.actions.transfer.title": {
+    "text": "다른 조직으로 이전",
+    "source_hash": "1b0b0655"
+  },
+  "web.admin.domains.actions.transfer.description": {
+    "text": "이 도메인을 다른 조직으로 이동합니다. 이동의 양측을 확인하려면 먼저 미리보기하세요.",
+    "source_hash": "457e852d"
+  },
+  "web.admin.domains.actions.transfer.toOrgLabel": {
+    "text": "대상 조직 ID",
+    "source_hash": "1a3f05c4"
+  },
+  "web.admin.domains.actions.transfer.fromOrgLabel": {
+    "text": "예상 현재 조직 ID (선택사항)",
+    "source_hash": "f6e75729"
+  },
+  "web.admin.domains.actions.transfer.fromOrgPlaceholder": {
+    "text": "이동 전 현재 소유자 확인",
+    "source_hash": "1ac6c59b"
+  },
+  "web.admin.domains.actions.transfer.from": {
+    "text": "출발",
+    "source_hash": "21819769"
+  },
+  "web.admin.domains.actions.transfer.to": {
+    "text": "도착",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.domains.actions.transfer.orphaned": {
+    "text": "조직 없음 (고아)",
+    "source_hash": "6f4c745c"
+  },
+  "web.admin.domains.actions.transfer.button": {
+    "text": "이전 적용",
+    "source_hash": "fb546c5c"
+  },
+  "web.admin.domains.actions.transfer.confirmTitle": {
+    "text": "도메인을 이전하시겠습니까?",
+    "source_hash": "801eb986"
+  },
+  "web.admin.domains.actions.transfer.confirmDescription": {
+    "text": "{domain}을(를) 조직 {org}(으)로 이동합니다. 계속하려면 도메인의 공개 ID를 다시 입력하세요.",
+    "source_hash": "52c8808d"
+  },
+  "web.admin.domains.actions.transfer.success": {
+    "text": "도메인이 이전되었습니다.",
+    "source_hash": "91e681ae"
+  },
+  "web.admin.domains.columns.domain": {
+    "text": "도메인",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domains.columns.organization": {
+    "text": "조직",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.columns.state": {
+    "text": "인증",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.domains.columns.tls": {
+    "text": "TLS",
+    "source_hash": "d1c18ec0"
+  },
+  "web.admin.domains.columns.created": {
+    "text": "생성일",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.columns.actions": {
+    "text": "작업",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.configs.title": {
+    "text": "도메인 구성",
+    "source_hash": "d46aa480"
+  },
+  "web.admin.domains.configs.description": {
+    "text": "로그인, 가입, 홈페이지 비밀 메시지, API 접근, 수신 비밀 메시지, 테넌트 SSO 및 메일 발송을 제어하는 도메인별 구성 레코드입니다. 처음 다섯 개의 경우 레코드가 없으면 차단됩니다.",
+    "source_hash": "1df99789"
+  },
+  "web.admin.domains.configs.loadError": {
+    "text": "도메인 구성 레코드를 불러올 수 없습니다.",
+    "source_hash": "9417d718"
+  },
+  "web.admin.domains.configs.retry": {
+    "text": "재시도",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.configs.degraded": {
+    "text": "구성 응답이 예상 계약과 일치하지 않습니다. 새로고침하고, 문제가 지속되면 보고하세요.",
+    "source_hash": "b5d890c0"
+  },
+  "web.admin.domains.configs.notFoundNote": {
+    "text": "이 도메인은 더 이상 존재하지 않으므로 구성 레코드를 불러올 수 없습니다.",
+    "source_hash": "2d88a392"
+  },
+  "web.admin.domains.configs.detailsToggle": {
+    "text": "세부정보",
+    "source_hash": "45989de4"
+  },
+  "web.admin.domains.configs.notEditable": {
+    "text": "워크스페이스 도메인 설정에서 관리됩니다.",
+    "source_hash": "54fe891f"
+  },
+  "web.admin.domains.configs.delete.button": {
+    "text": "삭제",
+    "source_hash": "e2d0a549"
+  },
+  "web.admin.domains.configs.delete.confirmTitle": {
+    "text": "{kind} 구성을 삭제하시겠습니까?",
+    "source_hash": "98e672db"
+  },
+  "web.admin.domains.configs.delete.confirmDescription": {
+    "text": "{domain}의 {kind} 구성 레코드를 영구적으로 삭제합니다. 도메인은 레코드 없음 동작으로 되돌아갑니다. 계속하려면 종류를 다시 입력하세요.",
+    "source_hash": "8272c40c"
+  },
+  "web.admin.domains.configs.delete.success": {
+    "text": "구성이 삭제되었습니다.",
+    "source_hash": "a0184b66"
+  },
+  "web.admin.domains.configs.edit.button": {
+    "text": "편집",
+    "source_hash": "464c4ffd"
+  },
+  "web.admin.domains.configs.edit.createButton": {
+    "text": "생성",
+    "source_hash": "4759498a"
+  },
+  "web.admin.domains.configs.edit.title": {
+    "text": "{kind} 구성",
+    "source_hash": "8592148f"
+  },
+  "web.admin.domains.configs.edit.submit": {
+    "text": "저장",
+    "source_hash": "1509f561"
+  },
+  "web.admin.domains.configs.edit.success": {
+    "text": "구성이 저장되었습니다.",
+    "source_hash": "6b5b3c69"
+  },
+  "web.admin.domains.configs.edit.unsetOption": {
+    "text": "설정되지 않음",
+    "source_hash": "4895f731"
+  },
+  "web.admin.domains.configs.edit.domainsHint": {
+    "text": "한 줄에 하나의 도메인.",
+    "source_hash": "6c03f4f7"
+  },
+  "web.admin.domains.configs.ensure.button": {
+    "text": "누락된 구성 생성",
+    "source_hash": "77991b75"
+  },
+  "web.admin.domains.configs.ensure.confirmTitle": {
+    "text": "누락된 구성 레코드를 생성하시겠습니까?",
+    "source_hash": "3f41dec2"
+  },
+  "web.admin.domains.configs.ensure.confirmDescription": {
+    "text": "{domain}에 다음에 대한 비활성화된 레코드를 생성합니다: {kinds}. 모든 것이 비활성화된 상태로 시작되므로 레코드가 활성화될 때까지 동작이 변경되지 않습니다.",
+    "source_hash": "fed66221"
+  },
+  "web.admin.domains.configs.ensure.applyButton": {
+    "text": "레코드 생성",
+    "source_hash": "4bcbef42"
+  },
+  "web.admin.domains.configs.ensure.success": {
+    "text": "누락된 구성 레코드가 생성되었습니다.",
+    "source_hash": "3b6ead80"
+  },
+  "web.admin.domains.configs.ensure.nothingMissing": {
+    "text": "생성할 것이 없습니다 — 모든 구성 레코드가 이미 존재합니다. 목록이 새로고침되었습니다.",
+    "source_hash": "ad0df0ae"
+  },
+  "web.admin.domains.configs.ensure.notApplied": {
+    "text": "서버가 적용 대신 변경을 미리보기했습니다 — 레코드가 생성되지 않았습니다. 다시 시도하고, 문제가 지속되면 보고하세요.",
+    "source_hash": "09d26379"
+  },
+  "web.admin.domains.configs.fields.enabled": {
+    "text": "활성화됨",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.fields.signin_enabled": {
+    "text": "로그인 활성화됨",
+    "source_hash": "cabe4898"
+  },
+  "web.admin.domains.configs.fields.email_auth_enabled": {
+    "text": "이메일 인증 활성화됨",
+    "source_hash": "4a762960"
+  },
+  "web.admin.domains.configs.fields.sso_enabled": {
+    "text": "SSO 활성화됨",
+    "source_hash": "6e77e673"
+  },
+  "web.admin.domains.configs.fields.restrict_to": {
+    "text": "제한 대상",
+    "source_hash": "a0bdf50a"
+  },
+  "web.admin.domains.configs.fields.signup_enabled": {
+    "text": "가입 활성화됨",
+    "source_hash": "2637d0b2"
+  },
+  "web.admin.domains.configs.fields.autoverify": {
+    "text": "자동 확인",
+    "source_hash": "7e02211c"
+  },
+  "web.admin.domains.configs.fields.validation_strategy": {
+    "text": "유효성 검사 전략",
+    "source_hash": "a2e95531"
+  },
+  "web.admin.domains.configs.fields.allowed_signup_domains": {
+    "text": "허용된 가입 도메인",
+    "source_hash": "9b5bb5b1"
+  },
+  "web.admin.domains.configs.fields.secrets_mode": {
+    "text": "비밀 메시지 모드",
+    "source_hash": "8d4349d6"
+  },
+  "web.admin.domains.configs.fields.disabled_homepage_variant": {
+    "text": "비활성화된 홈페이지 변형",
+    "source_hash": "4695633b"
+  },
+  "web.admin.domains.configs.fields.ready": {
+    "text": "준비됨",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.configs.fields.recipients": {
+    "text": "수신자",
+    "source_hash": "1e8568a8"
+  },
+  "web.admin.domains.configs.fields.provider_type": {
+    "text": "제공자 유형",
+    "source_hash": "8c0f6d3e"
+  },
+  "web.admin.domains.configs.fields.display_name": {
+    "text": "표시 이름",
+    "source_hash": "2b7f6a84"
+  },
+  "web.admin.domains.configs.fields.issuer": {
+    "text": "발급자",
+    "source_hash": "39e02c46"
+  },
+  "web.admin.domains.configs.fields.tenant_id": {
+    "text": "테넌트 ID",
+    "source_hash": "de1f5fff"
+  },
+  "web.admin.domains.configs.fields.has_client_id": {
+    "text": "클라이언트 ID 설정됨",
+    "source_hash": "04a9fa3d"
+  },
+  "web.admin.domains.configs.fields.has_client_secret": {
+    "text": "클라이언트 시크릿 설정됨",
+    "source_hash": "6ee1c9e6"
+  },
+  "web.admin.domains.configs.fields.allowed_domains": {
+    "text": "허용된 도메인",
+    "source_hash": "bcd60db0"
+  },
+  "web.admin.domains.configs.fields.enforce_sso_only": {
+    "text": "SSO만 적용",
+    "source_hash": "b3a3f694"
+  },
+  "web.admin.domains.configs.fields.grant_org_scope": {
+    "text": "조직 범위 부여",
+    "source_hash": "698ea5de"
+  },
+  "web.admin.domains.configs.fields.provider": {
+    "text": "제공자",
+    "source_hash": "472590ae"
+  },
+  "web.admin.domains.configs.fields.from_name": {
+    "text": "발신자 이름",
+    "source_hash": "b28f93ea"
+  },
+  "web.admin.domains.configs.fields.from_address": {
+    "text": "발신자 주소",
+    "source_hash": "d465bcfa"
+  },
+  "web.admin.domains.configs.fields.reply_to": {
+    "text": "회신 주소",
+    "source_hash": "6b9c49b7"
+  },
+  "web.admin.domains.configs.fields.sending_mode": {
+    "text": "발송 모드",
+    "source_hash": "e2d6bcf7"
+  },
+  "web.admin.domains.configs.fields.verification_status": {
+    "text": "확인 상태",
+    "source_hash": "aedfff7e"
+  },
+  "web.admin.domains.configs.fields.dns_verified": {
+    "text": "DNS 확인됨",
+    "source_hash": "8b2128c8"
+  },
+  "web.admin.domains.configs.fields.provider_verified": {
+    "text": "제공자 확인됨",
+    "source_hash": "6f4d9cc4"
+  },
+  "web.admin.domains.configs.fields.has_api_key": {
+    "text": "API 키 설정됨",
+    "source_hash": "d5115386"
+  },
+  "web.admin.domains.configs.fields.created": {
+    "text": "생성됨",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.configs.fields.updated": {
+    "text": "업데이트됨",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.configs.kinds.signin": {
+    "text": "로그인",
+    "source_hash": "5bbbe531"
+  },
+  "web.admin.domains.configs.kinds.signup": {
+    "text": "가입",
+    "source_hash": "3cc08ebe"
+  },
+  "web.admin.domains.configs.kinds.homepage": {
+    "text": "홈페이지",
+    "source_hash": "9e3391e9"
+  },
+  "web.admin.domains.configs.kinds.api": {
+    "text": "API",
+    "source_hash": "c8e5998f"
+  },
+  "web.admin.domains.configs.kinds.incoming": {
+    "text": "수신",
+    "source_hash": "e301820a"
+  },
+  "web.admin.domains.configs.kinds.sso": {
+    "text": "SSO",
+    "source_hash": "5ba3ac9f"
+  },
+  "web.admin.domains.configs.kinds.mailer": {
+    "text": "메일러",
+    "source_hash": "6c07ba63"
+  },
+  "web.admin.domains.configs.missingNotes.signin": {
+    "text": "레코드 없음: 테넌트 SSO가 활성화되지 않으면 이 도메인에서 로그인이 비활성화됩니다.",
+    "source_hash": "17dd6099"
+  },
+  "web.admin.domains.configs.missingNotes.signup": {
+    "text": "레코드 없음: 이 도메인에서 가입이 비활성화됩니다.",
+    "source_hash": "c3c98956"
+  },
+  "web.admin.domains.configs.missingNotes.homepage": {
+    "text": "레코드 없음: 홈페이지 비밀 메시지가 비활성화됩니다(차단되고 오류가 기록됩니다).",
+    "source_hash": "9a258a88"
+  },
+  "web.admin.domains.configs.missingNotes.api": {
+    "text": "레코드 없음: 공개 API가 비활성화됩니다(차단되고 오류가 기록됩니다).",
+    "source_hash": "fed99f73"
+  },
+  "web.admin.domains.configs.missingNotes.incoming": {
+    "text": "레코드 없음: 수신 비밀 메시지가 비활성화됩니다.",
+    "source_hash": "b957fbe8"
+  },
+  "web.admin.domains.configs.missingNotes.sso": {
+    "text": "레코드 없음: 테넌트 SSO를 사용할 수 없습니다. 플랫폼 SSO 대체 정책이 적용됩니다.",
+    "source_hash": "7b05ade8"
+  },
+  "web.admin.domains.configs.missingNotes.mailer": {
+    "text": "레코드 없음: 플랫폼 메일러가 사용됩니다.",
+    "source_hash": "e027cc99"
+  },
+  "web.admin.domains.configs.status.missing": {
+    "text": "누락됨",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.domains.configs.status.disabled": {
+    "text": "비활성화됨",
+    "source_hash": "75081b59"
+  },
+  "web.admin.domains.configs.status.enabled": {
+    "text": "활성화됨",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.status.enabledNotReady": {
+    "text": "활성화됨, 준비되지 않음",
+    "source_hash": "cb806ba4"
+  },
+  "web.admin.domains.detail.openFullPage": {
+    "text": "전체 페이지 열기",
+    "source_hash": "a467911c"
+  },
+  "web.admin.domains.detail.backToList": {
+    "text": "도메인 목록으로 돌아가기",
+    "source_hash": "22fd50fe"
+  },
+  "web.admin.domains.detail.notFound": {
+    "text": "도메인을 찾을 수 없습니다",
+    "source_hash": "7b8fc0e6"
+  },
+  "web.admin.domains.detail.notFoundDescription": {
+    "text": "이 도메인이 존재하지 않거나 이미 제거되었습니다.",
+    "source_hash": "e0f0b987"
+  },
+  "web.admin.domains.detail.loadError": {
+    "text": "이 도메인을 불러올 수 없습니다.",
+    "source_hash": "39e9c657"
+  },
+  "web.admin.domains.detail.retry": {
+    "text": "재시도",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.detail.never": {
+    "text": "없음",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.domains.detail.none": {
+    "text": "없음",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.domains.detail.yes": {
+    "text": "예",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.domains.detail.no": {
+    "text": "아니요",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.domains.detail.organization.open": {
+    "text": "조직 열기",
+    "source_hash": "54a43621"
+  },
+  "web.admin.domains.detail.organization.unknown": {
+    "text": "소유 조직이 이 응답에 포함되어 있지 않습니다. 도메인 목록에서 이 도메인을 열어 확인하세요.",
+    "source_hash": "bb5bdc9c"
+  },
+  "web.admin.domains.detail.sections.overview": {
+    "text": "개요",
+    "source_hash": "d4b1ea57"
+  },
+  "web.admin.domains.detail.sections.actions": {
+    "text": "작업",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.detail.sections.organization": {
+    "text": "소유 조직",
+    "source_hash": "39ad6d9c"
+  },
+  "web.admin.domains.detail.sections.dns": {
+    "text": "DNS",
+    "source_hash": "020965a2"
+  },
+  "web.admin.domains.detail.sections.diagnostics": {
+    "text": "진단",
+    "source_hash": "268f14bb"
+  },
+  "web.admin.domains.detail.sections.operations": {
+    "text": "소유권 작업",
+    "source_hash": "eb9a8cbc"
+  },
+  "web.admin.domains.detail.sections.operationsHint": {
+    "text": "각 작업은 먼저 미리보기됩니다. 적용 단계를 확인하기 전까지는 아무것도 기록되지 않습니다.",
+    "source_hash": "f09bf7bd"
+  },
+  "web.admin.domains.fields.publicId": {
+    "text": "공개 ID",
+    "source_hash": "3705b64f"
+  },
+  "web.admin.domains.fields.domainId": {
+    "text": "내부 ID",
+    "source_hash": "e468bb47"
+  },
+  "web.admin.domains.fields.organization": {
+    "text": "조직",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.fields.baseDomain": {
+    "text": "기본 도메인",
+    "source_hash": "33295d5b"
+  },
+  "web.admin.domains.fields.subdomain": {
+    "text": "서브도메인",
+    "source_hash": "ba4520ab"
+  },
+  "web.admin.domains.fields.apex": {
+    "text": "Apex 도메인",
+    "source_hash": "0a8a42fa"
+  },
+  "web.admin.domains.fields.status": {
+    "text": "상태",
+    "source_hash": "920e413c"
+  },
+  "web.admin.domains.fields.created": {
+    "text": "생성됨",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.fields.updated": {
+    "text": "업데이트됨",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.fields.verified": {
+    "text": "확인됨",
+    "source_hash": "4f783840"
+  },
+  "web.admin.domains.fields.resolving": {
+    "text": "확인 중",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.fields.ready": {
+    "text": "준비됨",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.list.searchPlaceholder": {
+    "text": "도메인 이름 또는 ID로 검색",
+    "source_hash": "aecdd873"
+  },
+  "web.admin.domains.list.stateFilter": {
+    "text": "상태",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.domains.list.emptyFilter": {
+    "text": "현재 필터와 일치하는 도메인이 없습니다.",
+    "source_hash": "be4d64ec"
+  },
+  "web.admin.domains.probe.healthLabel": {
+    "text": "상태",
+    "source_hash": "55898449"
+  },
+  "web.admin.domains.probe.certInvalid": {
+    "text": "인증서를 사용할 수 없습니다",
+    "source_hash": "5535f4d4"
+  },
+  "web.admin.domains.probe.noCertificate": {
+    "text": "인증서가 반환되지 않았습니다 — TLS 전에 연결이 실패했습니다.",
+    "source_hash": "8ffd63be"
+  },
+  "web.admin.domains.probe.fields.httpStatus": {
+    "text": "HTTP 상태",
+    "source_hash": "0f7cf91f"
+  },
+  "web.admin.domains.probe.fields.httpError": {
+    "text": "HTTP 오류",
+    "source_hash": "5c6896d4"
+  },
+  "web.admin.domains.probe.fields.sslError": {
+    "text": "TLS 오류",
+    "source_hash": "7b827515"
+  },
+  "web.admin.domains.probe.fields.issuer": {
+    "text": "인증서 발급자",
+    "source_hash": "2912559a"
+  },
+  "web.admin.domains.probe.fields.subject": {
+    "text": "인증서 주체",
+    "source_hash": "d7816b16"
+  },
+  "web.admin.domains.probe.fields.notAfter": {
+    "text": "인증서 만료일",
+    "source_hash": "1e73119d"
+  },
+  "web.admin.domains.probe.fields.expiresIn": {
+    "text": "{date} ({days}일)",
+    "source_hash": "a71a6e81"
+  },
+  "web.admin.domains.tls.serving": {
+    "text": "제공 중",
+    "source_hash": "f55e53f9"
+  },
+  "web.admin.domains.tls.resolving": {
+    "text": "확인 중",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.tls.none": {
+    "text": "제공되지 않음",
+    "source_hash": "da8a5ab9"
   }
 }

--- a/locales/content/ko/admin-organizations.json
+++ b/locales/content/ko/admin-organizations.json
@@ -310,5 +310,333 @@
   "web.admin.organizations.list.loadError": {
     "text": "조직을 불러올 수 없습니다.",
     "source_hash": "130d5e70"
+  },
+  "web.admin.organizations.addMember.button": {
+    "text": "기존 계정 추가",
+    "source_hash": "45a3b757"
+  },
+  "web.admin.organizations.addMember.title": {
+    "text": "기존 계정 추가",
+    "source_hash": "2f676a94"
+  },
+  "web.admin.organizations.addMember.description": {
+    "text": "이미 계정이 있는 사람을 {org}에 추가합니다. 계정이 이미 존재하여 초대할 수 없는 경우에 사용하세요.",
+    "source_hash": "bb41faa6"
+  },
+  "web.admin.organizations.addMember.searchLabel": {
+    "text": "이메일 주소 또는 계정 ID",
+    "source_hash": "82b3040b"
+  },
+  "web.admin.organizations.addMember.searchPlaceholder": {
+    "text": "이메일 주소로 검색",
+    "source_hash": "b75cc66c"
+  },
+  "web.admin.organizations.addMember.searchHint": {
+    "text": "이메일 주소의 일부 또는 정확한 계정 ID와 일치합니다.",
+    "source_hash": "84547a60"
+  },
+  "web.admin.organizations.addMember.searchError": {
+    "text": "계정을 검색할 수 없습니다. 연결을 확인하고 다시 시도하세요.",
+    "source_hash": "4b6caa41"
+  },
+  "web.admin.organizations.addMember.searchParseError": {
+    "text": "계정 검색이 예기치 않은 응답을 반환했습니다. 결과가 불완전할 수 있습니다.",
+    "source_hash": "0c814231"
+  },
+  "web.admin.organizations.addMember.idle": {
+    "text": "이메일 주소를 입력하여 계정을 찾으세요.",
+    "source_hash": "f6340d35"
+  },
+  "web.admin.organizations.addMember.noResults": {
+    "text": "\"{term}\"와(과) 일치하는 계정이 없습니다.",
+    "source_hash": "199b662a"
+  },
+  "web.admin.organizations.addMember.noResultsHint": {
+    "text": "여기에는 기존 계정만 추가할 수 있습니다. 가입한 적이 없는 사람은 초대하세요.",
+    "source_hash": "ee90aeeb"
+  },
+  "web.admin.organizations.addMember.select": {
+    "text": "선택",
+    "source_hash": "2a78025d"
+  },
+  "web.admin.organizations.addMember.selectedEyebrow": {
+    "text": "선택된 계정",
+    "source_hash": "8b63d947"
+  },
+  "web.admin.organizations.addMember.change": {
+    "text": "다른 계정 선택",
+    "source_hash": "d4fe39ab"
+  },
+  "web.admin.organizations.addMember.createdOn": {
+    "text": "{date}에 가입",
+    "source_hash": "cfc0e19f"
+  },
+  "web.admin.organizations.addMember.organizationsUnavailable": {
+    "text": "이 계정의 현재 조직을 불러올 수 없습니다.",
+    "source_hash": "a35b6bfc"
+  },
+  "web.admin.organizations.addMember.defaultOrg": {
+    "text": "기본값",
+    "source_hash": "37a8eec1"
+  },
+  "web.admin.organizations.addMember.roleLabel": {
+    "text": "이 조직에서의 역할",
+    "source_hash": "817475fa"
+  },
+  "web.admin.organizations.addMember.submit": {
+    "text": "조직에 추가",
+    "source_hash": "0e0cb636"
+  },
+  "web.admin.organizations.addMember.success": {
+    "text": "{account}을(를) {role}(으)로 추가했습니다.",
+    "source_hash": "533be0dc"
+  },
+  "web.admin.organizations.addMember.badges.verified": {
+    "text": "확인됨",
+    "source_hash": "4f783840"
+  },
+  "web.admin.organizations.addMember.badges.unverified": {
+    "text": "확인되지 않음",
+    "source_hash": "15133907"
+  },
+  "web.admin.organizations.addMember.badges.suspended": {
+    "text": "정지됨",
+    "source_hash": "e392a389"
+  },
+  "web.admin.organizations.addMember.badges.alreadyMember": {
+    "text": "이미 멤버입니다",
+    "source_hash": "1739ed7c"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMember": {
+    "text": "이 계정은 이미 이 조직의 멤버이며 {role} 역할을 가지고 있습니다. 추가해도 기존 역할은 변경되지 않습니다 — 역할 변경은 역할 설정 작업을 사용하세요.",
+    "source_hash": "cb6a4774"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMemberUnknownRole": {
+    "text": "이 계정은 이미 이 조직의 멤버입니다. 추가해도 기존 역할은 변경되지 않습니다.",
+    "source_hash": "035641ec"
+  },
+  "web.admin.organizations.addMember.errors.notFound": {
+    "text": "해당 계정 또는 조직이 더 이상 존재하지 않습니다. 계정을 확인하려면 다시 검색하세요.",
+    "source_hash": "bd88db18"
+  },
+  "web.admin.organizations.addMember.errors.invalidRole": {
+    "text": "해당 역할이 거부되었습니다. 목록에 있는 역할 중 하나를 선택하고 다시 시도하세요.",
+    "source_hash": "eb696a8f"
+  },
+  "web.admin.organizations.addMember.errors.noSelection": {
+    "text": "선택된 계정이 없습니다.",
+    "source_hash": "dd15bb5b"
+  },
+  "web.admin.organizations.addMember.fields.created": {
+    "text": "가입일",
+    "source_hash": "486b3fe0"
+  },
+  "web.admin.organizations.addMember.fields.verified": {
+    "text": "확인",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.organizations.addMember.fields.lastLogin": {
+    "text": "마지막 로그인",
+    "source_hash": "0b70af7a"
+  },
+  "web.admin.organizations.addMember.fields.organizations": {
+    "text": "현재 조직",
+    "source_hash": "cbb5b92f"
+  },
+  "web.admin.organizations.addMember.roleHints.member": {
+    "text": "조직의 비밀 메시지 및 도메인에 대한 일상적인 접근.",
+    "source_hash": "d0c7439e"
+  },
+  "web.admin.organizations.addMember.roleHints.admin": {
+    "text": "멤버, 도메인 및 조직 설정을 관리할 수 있습니다.",
+    "source_hash": "beaa50d7"
+  },
+  "web.admin.organizations.addMember.roleHints.owner": {
+    "text": "결제를 포함한 모든 권한. 요청받은 경우에만 부여하세요.",
+    "source_hash": "614ace63"
+  },
+  "web.admin.organizations.addMember.roles.member": {
+    "text": "멤버",
+    "source_hash": "7c968fb7"
+  },
+  "web.admin.organizations.addMember.roles.admin": {
+    "text": "관리자",
+    "source_hash": "c1c224b0"
+  },
+  "web.admin.organizations.addMember.roles.owner": {
+    "text": "소유자",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.detail.members.openCustomer": {
+    "text": "고객 레코드 열기",
+    "source_hash": "c057ca13"
+  },
+  "web.admin.organizations.detail.reconcile.memberships": {
+    "text": "멤버십 재구체화:",
+    "source_hash": "fe7db10c"
+  },
+  "web.admin.organizations.detail.reconcile.membershipsFailed": {
+    "text": "실패, 오래된 권한이 남아 있음:",
+    "source_hash": "cc4dae37"
+  },
+  "web.admin.organizations.entitlements.catalogWarning": {
+    "text": "\"{entitlement}\"이(가) 결제 카탈로그에 없습니다 — 오타가 있는지 확인하세요. 그래도 진행합니다: 나중에 출시되는 카탈로그에 포함된 권한을 부여하는 것은 지원되며 의도적으로 차단되지 않습니다.",
+    "source_hash": "cbde548a"
+  },
+  "web.admin.organizations.entitlements.matrix.caption": {
+    "text": "권한 해결 매트릭스: 플랜, 재정의 부여 및 취소, 해결된 집합, 구체화된 내용.",
+    "source_hash": "9eac8999"
+  },
+  "web.admin.organizations.entitlements.matrix.yes": {
+    "text": "예",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.matrix.no": {
+    "text": "아니요",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.matrix.empty": {
+    "text": "이 조직은 플랜에서 권한이 없고 재정의도 없습니다.",
+    "source_hash": "f6cf2169"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.entitlement": {
+    "text": "권한",
+    "source_hash": "0d8f0b2d"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.inPlan": {
+    "text": "플랜에 포함",
+    "source_hash": "e2222361"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.granted": {
+    "text": "부여됨",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.revoked": {
+    "text": "취소됨",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.expected": {
+    "text": "예상",
+    "source_hash": "ca99b7f1"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.materialized": {
+    "text": "구체화됨",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.state": {
+    "text": "상태",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.formula": {
+    "text": "해결: 예상 = (플랜 ∪ 부여) − 취소. 구체화됨은 실제로 조직에 저장된 것입니다.",
+    "source_hash": "bc4bff2d"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.orphaned": {
+    "text": "고아 — 구체화되었지만 예상되지 않음, 일반적으로 재구체화되지 않은 취소로 남겨짐. 조정하면 제거됩니다.",
+    "source_hash": "3a27a9af"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.missing": {
+    "text": "누락 — 예상되지만 구체화되지 않음. 멤버에게 현재 실제로 없는 권한입니다.",
+    "source_hash": "485e44ad"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.revoked": {
+    "text": "취소선이 그어진 행은 관리자 재정의에 의해 취소되어 예상 집합에서 제거됩니다.",
+    "source_hash": "89a2e9b6"
+  },
+  "web.admin.organizations.entitlements.matrix.state.plan": {
+    "text": "플랜에서",
+    "source_hash": "1d346b26"
+  },
+  "web.admin.organizations.entitlements.matrix.state.granted": {
+    "text": "부여됨",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.state.revoked": {
+    "text": "취소됨",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.state.orphaned": {
+    "text": "고아",
+    "source_hash": "8d827807"
+  },
+  "web.admin.organizations.entitlements.matrix.state.missing": {
+    "text": "누락",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.organizations.entitlements.picker.selectPlaceholder": {
+    "text": "권한 선택…",
+    "source_hash": "53af3be8"
+  },
+  "web.admin.organizations.entitlements.picker.other": {
+    "text": "기타 — 카탈로그에 없음…",
+    "source_hash": "f08bc3a3"
+  },
+  "web.admin.organizations.entitlements.picker.customLabel": {
+    "text": "권한 이름 (카탈로그에 없음)",
+    "source_hash": "52783229"
+  },
+  "web.admin.organizations.entitlements.picker.backToCatalog": {
+    "text": "카탈로그로 돌아가기",
+    "source_hash": "9b727f40"
+  },
+  "web.admin.organizations.entitlements.picker.uncategorized": {
+    "text": "분류되지 않음",
+    "source_hash": "8d40d123"
+  },
+  "web.admin.organizations.entitlements.picker.catalogUnavailable": {
+    "text": "결제 카탈로그를 읽을 수 없어 여기서 권한 이름이 확인되지 않습니다.",
+    "source_hash": "724869ec"
+  },
+  "web.admin.organizations.entitlements.picker.tags.inPlan": {
+    "text": "플랜에 포함",
+    "source_hash": "5f2251bb"
+  },
+  "web.admin.organizations.entitlements.picker.tags.granted": {
+    "text": "부여됨",
+    "source_hash": "dd515d19"
+  },
+  "web.admin.organizations.entitlements.picker.tags.revoked": {
+    "text": "취소됨",
+    "source_hash": "4bb47f18"
+  },
+  "web.admin.organizations.entitlements.summary.sync": {
+    "text": "동기화",
+    "source_hash": "8d261a37"
+  },
+  "web.admin.organizations.entitlements.summary.materialized": {
+    "text": "구체화됨",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.summary.materializedAt": {
+    "text": "마지막 구체화",
+    "source_hash": "9325dce9"
+  },
+  "web.admin.organizations.entitlements.summary.planDefinition": {
+    "text": "플랜 정의",
+    "source_hash": "6b531454"
+  },
+  "web.admin.organizations.entitlements.summary.yes": {
+    "text": "예",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.summary.no": {
+    "text": "아니요",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.summary.never": {
+    "text": "없음",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.organizations.entitlements.summary.planStale": {
+    "text": "구체화 이후 변경됨",
+    "source_hash": "e682d8a4"
+  },
+  "web.admin.organizations.entitlements.summary.planCurrent": {
+    "text": "현재",
+    "source_hash": "e0d1b682"
+  },
+  "web.admin.organizations.entitlements.summary.planUnknown": {
+    "text": "알 수 없음 — 비교할 수 없습니다",
+    "source_hash": "b607e540"
   }
 }

--- a/locales/content/ko/admin-secrets.json
+++ b/locales/content/ko/admin-secrets.json
@@ -1,11 +1,11 @@
 {
   "web.admin.secrets.title": {
-    "text": "비밀 메시지",
-    "source_hash": "d8707d41"
+    "text": "비밀 메시지 수신 확인",
+    "source_hash": "a8a2d0e4"
   },
   "web.admin.secrets.description": {
-    "text": "비밀 메시지의 영수증을 검사하고 SSH 없이 삭제합니다 — 키로 조회하세요.",
-    "source_hash": "07775a11"
+    "text": "상태, 타임스탬프, 수신 확인 등을 조회합니다.",
+    "source_hash": "91fba2a1"
   },
   "web.admin.secrets.never": {
     "text": "한 번도 없음",
@@ -108,20 +108,20 @@
     "source_hash": "504101bc"
   },
   "web.admin.secrets.lookup.resultTitle": {
-    "text": "비밀 메시지 {shortid}",
-    "source_hash": "8b311d32"
+    "text": "비밀 메시지 레코드 {shortid}",
+    "source_hash": "ee06d765"
   },
   "web.admin.secrets.lookup.notFound": {
-    "text": "비밀 메시지를 찾을 수 없음",
-    "source_hash": "70a9532c"
+    "text": "레코드를 찾을 수 없습니다",
+    "source_hash": "40f4d9e9"
   },
   "web.admin.secrets.lookup.notFoundDescription": {
     "text": "이 키에 해당하는 비밀 메시지가 없습니다. 만료되었거나 삭제되었을 수 있습니다.",
     "source_hash": "9f068a81"
   },
   "web.admin.secrets.lookup.loadError": {
-    "text": "이 비밀 메시지를 불러올 수 없습니다.",
-    "source_hash": "c96672e4"
+    "text": "이 레코드를 불러올 수 없습니다.",
+    "source_hash": "de77cc72"
   },
   "web.admin.secrets.lookup.retry": {
     "text": "다시 시도",
@@ -188,8 +188,8 @@
     "source_hash": "c127dab6"
   },
   "web.admin.secrets.sections.secret": {
-    "text": "비밀 메시지",
-    "source_hash": "7e32a729"
+    "text": "비밀 메시지 레코드",
+    "source_hash": "263813c6"
   },
   "web.admin.secrets.sections.receipt": {
     "text": "영수증",
@@ -214,5 +214,25 @@
   "web.admin.secrets.state.viewed": {
     "text": "조회됨",
     "source_hash": "1b28d178"
+  },
+  "web.admin.secrets.capability.title": {
+    "text": "메타데이터만",
+    "source_hash": "df0453d1"
+  },
+  "web.admin.secrets.capability.canRead": {
+    "text": "비밀 메시지의 메타데이터와 수신 확인을 읽습니다: 상태, 타임스탬프, 소유자, 저장된 암호문의 크기.",
+    "source_hash": "d438ecc7"
+  },
+  "web.admin.secrets.capability.cannotRead": {
+    "text": "비밀 메시지 내용을 복호화하거나 표시할 수 없습니다. 이 화면 뒤의 엔드포인트는 내용을 반환하지 않습니다.",
+    "source_hash": "7f69f222"
+  },
+  "web.admin.secrets.capability.canDelete": {
+    "text": "비밀 메시지와 수신 확인을 영구적으로 삭제할 수 있으며, 내용을 공개하지 않고 파기합니다.",
+    "source_hash": "77f2bc7e"
+  },
+  "web.admin.secrets.lookup.hint": {
+    "text": "비밀 메시지 링크의 식별자 — 비밀 메시지 내용이 아닙니다.",
+    "source_hash": "acfbc352"
   }
 }

--- a/locales/content/ko/admin-system.json
+++ b/locales/content/ko/admin-system.json
@@ -154,5 +154,133 @@
   "web.admin.system.redis.captured": {
     "text": "{at}에 캡처됨",
     "source_hash": "57b40c0f"
+  },
+  "web.admin.system.brand.title": {
+    "text": "브랜드 진단",
+    "source_hash": "1cf9abd5"
+  },
+  "web.admin.system.brand.description": {
+    "text": "실행 중인 인스턴스가 디스크에서 해결한 브랜드 팩 — 지역이 중립 브랜딩을 제공하는 이유를 보여줍니다.",
+    "source_hash": "be29e282"
+  },
+  "web.admin.system.brand.loadError": {
+    "text": "브랜드 진단을 불러올 수 없습니다.",
+    "source_hash": "80607303"
+  },
+  "web.admin.system.brand.none": {
+    "text": "(없음)",
+    "source_hash": "552e4230"
+  },
+  "web.admin.system.brand.resolution": {
+    "text": "해결",
+    "source_hash": "d4055faf"
+  },
+  "web.admin.system.brand.envVsConfig": {
+    "text": "환경 vs 구성",
+    "source_hash": "bee3debb"
+  },
+  "web.admin.system.brand.absorbed": {
+    "text": "흡수된 키",
+    "source_hash": "9784e110"
+  },
+  "web.admin.system.brand.operatorKeys": {
+    "text": "운영자 키",
+    "source_hash": "434e8248"
+  },
+  "web.admin.system.brand.overlayAssets": {
+    "text": "오버레이 에셋",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.exists.yes": {
+    "text": "존재함",
+    "source_hash": "43f9b89c"
+  },
+  "web.admin.system.brand.exists.no": {
+    "text": "누락됨",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.system.brand.fields.resolvedDir": {
+    "text": "해결된 디렉터리",
+    "source_hash": "0623b983"
+  },
+  "web.admin.system.brand.fields.home": {
+    "text": "홈",
+    "source_hash": "3a786953"
+  },
+  "web.admin.system.brand.fields.envPack": {
+    "text": "ENV 브랜드 팩",
+    "source_hash": "940aeb5c"
+  },
+  "web.admin.system.brand.fields.configPack": {
+    "text": "Config 브랜드 팩",
+    "source_hash": "761b9550"
+  },
+  "web.admin.system.brand.fields.envAssetsDir": {
+    "text": "ENV 브랜드 에셋 디렉터리",
+    "source_hash": "05854f1f"
+  },
+  "web.admin.system.brand.fields.configAssetsDir": {
+    "text": "Config 브랜드 에셋 디렉터리",
+    "source_hash": "e91e5c46"
+  },
+  "web.admin.system.brand.flags.fellBack.danger": {
+    "text": "기본 팩으로 대체됨",
+    "source_hash": "7bf7ba2f"
+  },
+  "web.admin.system.brand.flags.fellBack.ok": {
+    "text": "브랜드 팩 해결됨",
+    "source_hash": "1ab3162f"
+  },
+  "web.admin.system.brand.flags.mismatch.danger": {
+    "text": "부팅 / 라이브 불일치",
+    "source_hash": "0a022192"
+  },
+  "web.admin.system.brand.flags.mismatch.ok": {
+    "text": "부팅이 라이브와 일치",
+    "source_hash": "d4792c09"
+  },
+  "web.admin.system.brand.manifest.title": {
+    "text": "매니페스트",
+    "source_hash": "3c99f1f3"
+  },
+  "web.admin.system.brand.manifest.path": {
+    "text": "경로",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.manifest.exists": {
+    "text": "존재함",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.manifest.keysOnDisk": {
+    "text": "디스크의 키",
+    "source_hash": "52439c03"
+  },
+  "web.admin.system.brand.roots.title": {
+    "text": "검색 루트",
+    "source_hash": "d8696f2b"
+  },
+  "web.admin.system.brand.roots.empty": {
+    "text": "검색 루트 없음",
+    "source_hash": "867a471c"
+  },
+  "web.admin.system.brand.roots.columns.path": {
+    "text": "경로",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.roots.columns.exists": {
+    "text": "존재함",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.stats.brandPack": {
+    "text": "브랜드 팩",
+    "source_hash": "884437d0"
+  },
+  "web.admin.system.brand.stats.overlayAssets": {
+    "text": "오버레이 에셋",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.stats.manifestKeys": {
+    "text": "매니페스트 키",
+    "source_hash": "c4267198"
   }
 }

--- a/locales/content/ko/email.json
+++ b/locales/content/ko/email.json
@@ -836,5 +836,41 @@
   "email.secret_link.footer_note": {
     "text": "%{sender_email}님이 %{product_name}을(를) 사용하여 비밀 메시지를 공유했기 때문에 이 메시지를 받으셨습니다. 예상하지 못한 메시지라면 이 이메일을 무시하셔도 안전합니다.",
     "source_hash": "2d544dad"
+  },
+  "email.sso_link_verification.subject": {
+    "text": "%{product_name} 계정에 %{provider} 연결 확인",
+    "source_hash": "65e70296"
+  },
+  "email.sso_link_verification.title": {
+    "text": "SSO 로그인 확인",
+    "source_hash": "35bce6cc"
+  },
+  "email.sso_link_verification.request_notice": {
+    "text": "누군가 %{email_address} 이메일을 사용하여 %{provider}(으)로 로그인했습니다. %{provider}을(를) %{product_name} 계정에 연결하려면 아래에서 확인하세요.",
+    "source_hash": "baeb18c0"
+  },
+  "email.sso_link_verification.confirm_button": {
+    "text": "확인 및 %{provider} 연결",
+    "source_hash": "9809e210"
+  },
+  "email.sso_link_verification.copy_link_prompt": {
+    "text": "또는 이 링크를 복사하여 붙여넣으세요:",
+    "source_hash": "88c72144"
+  },
+  "email.sso_link_verification.expiration_notice": {
+    "text": "이 링크는 15분 후에 만료되며 한 번만 사용할 수 있습니다.",
+    "source_hash": "1a437f42"
+  },
+  "email.sso_link_verification.ignore_notice": {
+    "text": "%{provider}(으)로 로그인하려고 하지 않았다면 이 이메일을 무시해도 됩니다 — 계정에 아무것도 연결되지 않습니다.",
+    "source_hash": "d7317d30"
+  },
+  "email.sso_link_verification.signature": {
+    "text": "지원팀",
+    "source_hash": "dc75bf9f"
+  },
+  "email.sso_link_verification.postscript": {
+    "text": "추신: 이 이메일은 %{email_address}(으)로 발송되었습니다.",
+    "source_hash": "8ab1dbea"
   }
 }

--- a/locales/content/ko/session-auth-extended.json
+++ b/locales/content/ko/session-auth-extended.json
@@ -736,11 +736,11 @@
     "source_hash": "e132c4d9"
   },
   "web.auth.connections.description": {
-    "text": "계정에 연결된 싱글 사인온 제공자를 관리합니다.",
+    "text": "계정에 연결된 Single Sign-On 제공자를 관리합니다.",
     "source_hash": "42c6d148"
   },
   "web.auth.connections.section_title": {
-    "text": "싱글 사인온",
+    "text": "Single Sign-On",
     "source_hash": "3bc44ac2"
   },
   "web.auth.connections.section_subtitle": {
@@ -752,11 +752,12 @@
     "source_hash": "a002b3f3"
   },
   "web.auth.connections.connect_description": {
-    "text": "이 계정에 로그인하는 데 사용할 수 있는 다른 싱글 사인온 제공자를 연결합니다.",
+    "text": "이 계정에 로그인하는 데 사용할 수 있는 다른 Single Sign-On 제공자를 연결합니다.",
     "source_hash": "32895a5a"
   },
   "web.auth.connections.connect_action": {
     "text": "{provider} 연결",
+    "context": "Button label to start linking a specific SSO provider; {provider} is the provider display name",
     "source_hash": "c77540af"
   },
   "web.auth.connections.issuer": {
@@ -788,11 +789,11 @@
     "source_hash": "5254048e"
   },
   "web.auth.connections.no_identities_description": {
-    "text": "아직 이 계정에 싱글 사인온 제공자를 연결하지 않았습니다.",
+    "text": "아직 이 계정에 Single Sign-On 제공자를 연결하지 않았습니다.",
     "source_hash": "0f58d5d0"
   },
   "web.auth.connections.overview_status": {
-    "text": "싱글 사인온",
+    "text": "Single Sign-On",
     "source_hash": "3bc44ac2"
   },
   "web.auth.connections.errors.last_credential": {
@@ -821,6 +822,7 @@
   },
   "web.link_sso.prompt": {
     "text": "{provider}(으)로 로그인했으며, 이는 기존 계정 {email}과(와) 일치합니다. {provider}을(를) 연결하고 계속하려면 해당 계정의 비밀번호를 입력하세요.",
+    "context": "Instruction on the sign-in interstitial. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/link-sso/:token.",
     "source_hash": "59da1c08"
   },
   "web.link_sso.password_label": {
@@ -881,6 +883,7 @@
   },
   "web.sso_link_confirm.prompt": {
     "text": "{provider}(으)로 로그인했으며, 이는 계정 {email}과(와) 일치합니다. {provider}을(를) 이 계정에 연결하고 로그인을 완료하려면 확인하세요.",
+    "context": "Consent instruction on the #3840 Phase 4 mailbox-proof SSO linking page. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/sso-link-confirm/:token. No password is asked — clicking the emailed link is the proof.",
     "source_hash": "6ff0d6cc"
   },
   "web.sso_link_confirm.submit": {

--- a/locales/content/ko/session-auth-extended.json
+++ b/locales/content/ko/session-auth-extended.json
@@ -730,5 +730,201 @@
   "web.auth.sessions.session_plural": {
     "text": "세션",
     "source_hash": "1225ae6c"
+  },
+  "web.auth.connections.title": {
+    "text": "연결된 계정",
+    "source_hash": "e132c4d9"
+  },
+  "web.auth.connections.description": {
+    "text": "계정에 연결된 싱글 사인온 제공자를 관리합니다.",
+    "source_hash": "42c6d148"
+  },
+  "web.auth.connections.section_title": {
+    "text": "싱글 사인온",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.section_subtitle": {
+    "text": "이 계정에 로그인하는 데 사용할 수 있는 ID 제공자",
+    "source_hash": "507254cd"
+  },
+  "web.auth.connections.connect_title": {
+    "text": "제공자 연결",
+    "source_hash": "a002b3f3"
+  },
+  "web.auth.connections.connect_description": {
+    "text": "이 계정에 로그인하는 데 사용할 수 있는 다른 싱글 사인온 제공자를 연결합니다.",
+    "source_hash": "32895a5a"
+  },
+  "web.auth.connections.connect_action": {
+    "text": "{provider} 연결",
+    "source_hash": "c77540af"
+  },
+  "web.auth.connections.issuer": {
+    "text": "발급자",
+    "source_hash": "39e02c46"
+  },
+  "web.auth.connections.identifier": {
+    "text": "식별자",
+    "source_hash": "9b10587f"
+  },
+  "web.auth.connections.remove": {
+    "text": "제거",
+    "source_hash": "c3812fc4"
+  },
+  "web.auth.connections.remove_confirm_title": {
+    "text": "연결된 계정 제거",
+    "source_hash": "4e8ffe4c"
+  },
+  "web.auth.connections.remove_confirm_message": {
+    "text": "이 연결된 계정을 제거하시겠습니까? 더 이상 이 계정으로 로그인할 수 없습니다.",
+    "source_hash": "64939c89"
+  },
+  "web.auth.connections.removed_success": {
+    "text": "연결된 계정이 제거되었습니다",
+    "source_hash": "cf87daf3"
+  },
+  "web.auth.connections.no_identities": {
+    "text": "연결된 계정 없음",
+    "source_hash": "5254048e"
+  },
+  "web.auth.connections.no_identities_description": {
+    "text": "아직 이 계정에 싱글 사인온 제공자를 연결하지 않았습니다.",
+    "source_hash": "0f58d5d0"
+  },
+  "web.auth.connections.overview_status": {
+    "text": "싱글 사인온",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.errors.last_credential": {
+    "text": "이것이 유일한 로그인 방법입니다. 잠기지 않도록 먼저 다른 제공자를 연결하거나 설정 → 보안에서 비밀번호를 설정하세요.",
+    "source_hash": "3de8084d"
+  },
+  "web.auth.connections.errors.last_credential_sso_enforced": {
+    "text": "이것이 유일한 로그인 방법입니다. 잠기지 않도록 먼저 다른 제공자를 연결하세요.",
+    "source_hash": "eed7a50e"
+  },
+  "web.auth.connections.errors.not_found": {
+    "text": "해당 연결된 계정을 찾을 수 없습니다. 이미 제거되었을 수 있습니다.",
+    "source_hash": "cf2c7673"
+  },
+  "web.auth.connections.errors.unauthorized": {
+    "text": "세션이 만료되었습니다. 다시 로그인하세요.",
+    "source_hash": "b529fce2"
+  },
+  "web.auth.connections.errors.generic": {
+    "text": "해당 작업을 완료할 수 없습니다. 다시 시도하세요.",
+    "source_hash": "a0d4edc0"
+  },
+  "web.link_sso.title": {
+    "text": "로그인 방법 연결",
+    "source_hash": "46339bac"
+  },
+  "web.link_sso.prompt": {
+    "text": "{provider}(으)로 로그인했으며, 이는 기존 계정 {email}과(와) 일치합니다. {provider}을(를) 연결하고 계속하려면 해당 계정의 비밀번호를 입력하세요.",
+    "source_hash": "59da1c08"
+  },
+  "web.link_sso.password_label": {
+    "text": "비밀번호",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.link_sso.password_placeholder": {
+    "text": "기존 비밀번호",
+    "source_hash": "ad4e56da"
+  },
+  "web.link_sso.submit": {
+    "text": "연결하고 계속",
+    "source_hash": "c969b759"
+  },
+  "web.link_sso.cancel": {
+    "text": "취소",
+    "source_hash": "19766ed6"
+  },
+  "web.link_sso.unavailable_title": {
+    "text": "이 연결 요청이 만료되었습니다",
+    "source_hash": "b53c7e55"
+  },
+  "web.link_sso.unavailable_message": {
+    "text": "보안을 위해 이 로그인 방법을 연결하는 요청이 더 이상 유효하지 않습니다. 기존 비밀번호로 로그인한 다음 보안 설정 → 연결된 계정에서 이 제공자를 연결하세요.",
+    "source_hash": "f7e349d1"
+  },
+  "web.link_sso.unavailable_action": {
+    "text": "로그인 계속",
+    "source_hash": "d398cd0a"
+  },
+  "web.link_sso.errors.invalid_password": {
+    "text": "비밀번호가 이 계정과 일치하지 않습니다. 다시 시도하세요.",
+    "source_hash": "3259b4f5"
+  },
+  "web.link_sso.errors.invalid_token": {
+    "text": "이 연결 요청이 만료되었거나 이미 사용되었습니다. 기존 비밀번호로 로그인한 다음 계정 설정에서 이 제공자를 연결하세요.",
+    "source_hash": "541f9127"
+  },
+  "web.link_sso.errors.link_conflict": {
+    "text": "이 로그인 방법을 연결할 수 없습니다. 계정이 변경되었거나 이 제공자가 이미 다른 계정에 연결되어 있을 수 있습니다. 기존 비밀번호로 로그인한 다음 보안 설정 → 연결된 계정에서 연결을 관리하세요.",
+    "source_hash": "7b0e0d0e"
+  },
+  "web.link_sso.errors.link_rate_limited": {
+    "text": "비밀번호 시도가 너무 많습니다. 몇 분 후에 다시 시도하세요.",
+    "source_hash": "a95e78cd"
+  },
+  "web.link_sso.errors.invalid_request": {
+    "text": "이 연결 요청을 처리할 수 없습니다. SSO 제공자로 다시 로그인하세요.",
+    "source_hash": "053b9fc6"
+  },
+  "web.link_sso.errors.generic": {
+    "text": "계정을 연결할 수 없습니다. 다시 시도하세요.",
+    "source_hash": "f727c174"
+  },
+  "web.sso_link_confirm.title": {
+    "text": "계정 연결 확인",
+    "source_hash": "ad80bfe7"
+  },
+  "web.sso_link_confirm.prompt": {
+    "text": "{provider}(으)로 로그인했으며, 이는 계정 {email}과(와) 일치합니다. {provider}을(를) 이 계정에 연결하고 로그인을 완료하려면 확인하세요.",
+    "source_hash": "6ff0d6cc"
+  },
+  "web.sso_link_confirm.submit": {
+    "text": "확인하고 연결",
+    "source_hash": "5cf663e6"
+  },
+  "web.sso_link_confirm.cancel": {
+    "text": "취소",
+    "source_hash": "19766ed6"
+  },
+  "web.sso_link_confirm.unavailable_title": {
+    "text": "이 연결 요청을 완료할 수 없습니다",
+    "source_hash": "47abb784"
+  },
+  "web.sso_link_confirm.unavailable_message": {
+    "text": "보안을 위해 로그인 방법을 연결하는 이 요청은 더 이상 유효하지 않습니다. 제공자로 다시 로그인하면 새 링크를 이메일로 보내드립니다.",
+    "source_hash": "080e6f9f"
+  },
+  "web.sso_link_confirm.unavailable_action": {
+    "text": "로그인으로 돌아가기",
+    "source_hash": "8504054f"
+  },
+  "web.sso_link_confirm.errors.link_expired": {
+    "text": "이 연결 요청이 만료되었거나 이미 사용되었습니다. 제공자로 다시 로그인하면 새 링크를 이메일로 보내드립니다.",
+    "source_hash": "a50538df"
+  },
+  "web.sso_link_confirm.errors.link_conflict": {
+    "text": "이 로그인 방법을 연결할 수 없습니다. 계정이 변경되었거나 이 제공자가 이미 다른 계정에 연결되어 있을 수 있습니다. 계속하려면 제공자로 다시 로그인하세요.",
+    "source_hash": "c954854b"
+  },
+  "web.sso_link_confirm.errors.link_invalidated": {
+    "text": "이 링크가 발송된 후 계정 자격 증명이 변경되어 더 이상 유효하지 않습니다. 제공자로 다시 로그인하면 새 링크를 이메일로 보내드립니다.",
+    "source_hash": "db88cb1d"
+  },
+  "web.sso_link_confirm.errors.link_error": {
+    "text": "저희 측에서 문제가 발생하여 이 링크를 확인할 수 없습니다. 제공자로 다시 로그인하면 새 링크를 이메일로 보내드립니다.",
+    "source_hash": "ec24e0a1"
+  },
+  "web.sso_link_confirm.errors.confirm_rate_limited": {
+    "text": "기기에서 시도가 너무 많습니다. 몇 분 후에 이메일로 받은 링크를 다시 열거나 제공자로 로그인하여 새 링크를 받으세요.",
+    "source_hash": "f29af782"
+  },
+  "web.sso_link_confirm.errors.generic": {
+    "text": "이 연결을 확인할 수 없습니다. 제공자로 다시 로그인하세요.",
+    "source_hash": "076fa25a"
   }
 }

--- a/locales/content/ko/session-auth.json
+++ b/locales/content/ko/session-auth.json
@@ -483,5 +483,41 @@
   "web.login.verified_notice": {
     "text": "이메일이 인증되었습니다 — 이제 로그인할 수 있습니다.",
     "source_hash": "c8d4b5a8"
+  },
+  "web.auth.password_setup_request.title": {
+    "text": "비밀번호 설정",
+    "source_hash": "11b6978b"
+  },
+  "web.auth.password_setup_request.description": {
+    "text": "계정에 아직 비밀번호가 없습니다. 직접 로그인할 수 있도록 비밀번호를 설정하는 안전한 링크를 이메일로 보내드립니다.",
+    "source_hash": "dc0b561f"
+  },
+  "web.auth.password_setup_request.button": {
+    "text": "설정 링크 보내기",
+    "source_hash": "22807292"
+  },
+  "web.auth.password_setup_request.emailSent": {
+    "text": "계정 비밀번호를 설정하는 링크가 포함된 이메일이 발송되었습니다",
+    "source_hash": "82b686c7"
+  },
+  "web.login.errors.account_exists_link_required": {
+    "text": "이 이메일 주소로 된 계정이 이미 존재하지만 이 로그인 방법에 연결되어 있지 않습니다. 기존 방법으로 로그인한 다음 보안 설정 → 연결된 계정에서 이 제공자를 연결하세요.",
+    "source_hash": "7fbbb7e7"
+  },
+  "web.login.errors.identity_connect_conflict": {
+    "text": "이 계정을 연결할 수 없습니다. 잘못된 도메인에서 연결을 시작했거나 세션이 만료되었을 수 있습니다. 다시 로그인한 다음 계정 설정에서 연결하세요.",
+    "source_hash": "4238bbf2"
+  },
+  "web.login.errors.org_join_failed": {
+    "text": "조직에 추가를 완료할 수 없습니다. 관리자에게 문의하세요.",
+    "source_hash": "155e71bb"
+  },
+  "web.login.errors.link_sso_failed": {
+    "text": "해당 로그인 방법을 연결할 수 없습니다. 기존 비밀번호로 로그인한 다음 보안 설정 → 연결된 계정에서 이 제공자를 연결하세요.",
+    "source_hash": "49954127"
+  },
+  "web.login.notices.link_verification_sent": {
+    "text": "받은 편지함을 확인하세요 — 계정 연결을 확인하는 링크를 이메일로 보냈습니다. 로그인을 완료하려면 링크를 열어주세요.",
+    "source_hash": "b251c8f3"
   }
 }

--- a/locales/content/ko/workspace-account.json
+++ b/locales/content/ko/workspace-account.json
@@ -694,5 +694,33 @@
   "web.settings.security.sso_managed_description": {
     "text": "회원님의 계정은 조직의 Single Sign-On 공급자를 통해 인증됩니다. 비밀번호, 다단계 인증, 복구 코드는 ID 공급자가 관리합니다.",
     "source_hash": "cd0cf39f"
+  },
+  "web.settings.api.api_username": {
+    "text": "API 사용자 이름",
+    "source_hash": "0b3e483e"
+  },
+  "web.settings.api.api_username_description": {
+    "text": "HTTP Basic 인증을 위한 사용자 이름",
+    "source_hash": "f3e65de3"
+  },
+  "web.settings.api.basic_auth_hint": {
+    "text": "HTTP Basic 인증의 경우 계정 이메일 또는 이 ID를 사용자 이름으로, API 토큰을 비밀번호로 사용하세요.",
+    "source_hash": "cfa3806d"
+  },
+  "web.settings.security.set": {
+    "text": "설정됨",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.settings.security.not_set": {
+    "text": "설정되지 않음",
+    "source_hash": "4895f731"
+  },
+  "web.settings.security.set_password_title": {
+    "text": "비밀번호 설정",
+    "source_hash": "4e411687"
+  },
+  "web.settings.security.set_password_description": {
+    "text": "ID 제공자 없이도 로그인할 수 있도록 계정에 비밀번호를 추가하세요",
+    "source_hash": "a6970402"
   }
 }

--- a/locales/content/ko/workspace-billing.json
+++ b/locales/content/ko/workspace-billing.json
@@ -1044,5 +1044,21 @@
   "web.billing.plans.reactivate": {
     "text": "재활성화",
     "source_hash": "2dc7478f"
+  },
+  "web.billing.currency_migration.refund_failed_warning": {
+    "text": "이전 플랜이 취소되었지만 미사용 기간에 대한 환불을 자동으로 발행할 수 없었습니다. 환불을 받으려면 지원팀에 문의하세요. 새 플랜을 활성화하려면 결제를 완료해야 합니다.",
+    "source_hash": "a390c498"
+  },
+  "web.billing.currency_migration.refund_failed_continue": {
+    "text": "결제 계속하기",
+    "source_hash": "eccdb8aa"
+  },
+  "web.billing.plans.per_year": {
+    "text": "/년",
+    "source_hash": "a2d5f1bc"
+  },
+  "web.billing.plans.billing_interval": {
+    "text": "결제 주기",
+    "source_hash": "3ce28209"
   }
 }

--- a/locales/content/ko/workspace-branding.json
+++ b/locales/content/ko/workspace-branding.json
@@ -56,12 +56,12 @@
     "source_hash": "e36598ef"
   },
   "web.branding.example_pre_reveal_instructions": {
-    "text": "휴대폰으로 QR 코드를 스캔하세요",
-    "source_hash": "99ecf59f"
+    "text": "예: 휴대폰으로 QR 코드를 스캔하세요",
+    "source_hash": "9cf0caf8"
   },
   "web.branding.example_post_reveal_instructions": {
-    "text": "질문이 있으시면 onboarding{'@'}example.com으로 연락해 주세요",
-    "source_hash": "bee120a7"
+    "text": "예: 질문이 있으시면 onboarding{'@'}example.com으로 연락하세요",
+    "source_hash": "71749811"
   },
   "web.branding.these_instructions_will_be_shown_to_recipients_before": {
     "text": "이 지침은 수신자가 비밀 내용을 확인하기 전에 표시됩니다",
@@ -320,8 +320,8 @@
     "source_hash": "bc79cdff"
   },
   "web.branding.paths_carryover_hint": {
-    "text": "실시간 미리 보기입니다 — 변경 사항은 저장하기 전까지 방문자에게 표시되지 않습니다.",
-    "source_hash": "cb4b82de"
+    "text": "이것은 실시간 미리보기입니다 — 업데이트를 클릭하기 전까지 변경 사항이 방문자에게 표시되지 않습니다.",
+    "source_hash": "9a34df71"
   },
   "web.branding.coming_soon_match_blurb": {
     "text": "웹사이트를 알려주시면 색상과 글꼴을 읽어들여 한 번의 클릭으로 격차를 좁혀 드립니다.",
@@ -406,5 +406,57 @@
   "web.branding.delivery_after_reveal": {
     "text": "표시 후",
     "source_hash": "d5bfe7fd"
+  },
+  "web.branding.favicon": {
+    "text": "파비콘",
+    "source_hash": "42955289"
+  },
+  "web.branding.refresh_favicon": {
+    "text": "도메인에서 파비콘 새로고침",
+    "source_hash": "7cc3d5dc"
+  },
+  "web.branding.refresh_favicon_hint": {
+    "text": "도메인에서 파비콘을 다시 가져옵니다. 새 아이콘이 곧 나타납니다.",
+    "source_hash": "ee007e44"
+  },
+  "web.branding.refresh_favicon_queued": {
+    "text": "파비콘 새로고침 중 — 새 아이콘이 곧 나타납니다.",
+    "source_hash": "6bf38e6e"
+  },
+  "web.branding.refresh_favicon_user_upload_hint": {
+    "text": "사용자 지정 파비콘을 업로드했으므로 가져온 아이콘이 대체되지 않습니다.",
+    "source_hash": "c22e1ed6"
+  },
+  "web.branding.upload_favicon": {
+    "text": "파비콘 업로드",
+    "source_hash": "ceda39cb"
+  },
+  "web.branding.replace_favicon": {
+    "text": "교체",
+    "source_hash": "95e15439"
+  },
+  "web.branding.remove_favicon": {
+    "text": "파비콘 제거",
+    "source_hash": "03693698"
+  },
+  "web.branding.favicon_field_hint": {
+    "text": "ICO, PNG 또는 SVG. 업로드하면 가져온 아이콘이 대체됩니다.",
+    "source_hash": "dfa0bfcb"
+  },
+  "web.branding.favicon_preview_alt": {
+    "text": "도메인 파비콘",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_title": {
+    "text": "도메인 파비콘",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_hint": {
+    "text": "ICO, PNG 또는 SVG. 최대 256KB. 자동으로 가져온 아이콘을 대체합니다.",
+    "source_hash": "c9eafc83"
+  },
+  "web.branding.favicon_modal_save": {
+    "text": "파비콘 저장",
+    "source_hash": "c8a1566c"
   }
 }

--- a/locales/content/ko/workspace-organizations.json
+++ b/locales/content/ko/workspace-organizations.json
@@ -1034,5 +1034,153 @@
   "web.organizations.create_workspace": {
     "text": "워크스페이스 생성",
     "source_hash": "c63c14cf"
+  },
+  "web.organizations.organization_id": {
+    "text": "조직 ID",
+    "source_hash": "1f466322"
+  },
+  "web.organizations.organization_id_hint": {
+    "text": "지원팀에 문의하거나 이 조직에 API 요청 범위를 지정할 때 이 ID를 사용하세요. 로그인 자격 증명이 아닙니다.",
+    "source_hash": "29549b3a"
+  },
+  "web.organizations.audit.title": {
+    "text": "비밀 메시지 활동",
+    "source_hash": "6d6d41f3"
+  },
+  "web.organizations.audit.description": {
+    "text": "이 조직에 기록된 비밀 메시지 생성 및 접근 이벤트의 감사 추적입니다.",
+    "source_hash": "553c564b"
+  },
+  "web.organizations.audit.country_unknown": {
+    "text": "알 수 없음",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.empty_title": {
+    "text": "아직 활동이 없습니다",
+    "source_hash": "0a12b92c"
+  },
+  "web.organizations.audit.empty_description": {
+    "text": "팀이 비밀 메시지를 공유하면 비밀 메시지 생성 및 접근 이벤트가 여기에 표시됩니다.",
+    "source_hash": "62fb14c2"
+  },
+  "web.organizations.audit.capped_notice": {
+    "text": "최신 {max}개의 이벤트만 보존됩니다. 오래된 활동은 삭제되었습니다.",
+    "source_hash": "da7901e2"
+  },
+  "web.organizations.audit.collection_paused_notice": {
+    "text": "이벤트 수집이 일시 중지되었습니다. 새로운 비밀 메시지 활동이 기록되지 않습니다.",
+    "source_hash": "cb09d147"
+  },
+  "web.organizations.audit.load_error": {
+    "text": "비밀 메시지 활동을 불러올 수 없습니다.",
+    "source_hash": "52fde814"
+  },
+  "web.organizations.audit.contract_mismatch": {
+    "text": "서버에서 반환한 활동 데이터를 읽을 수 없습니다. 추적이 비어 있지 않습니다 — 지금은 표시할 수 없습니다.",
+    "source_hash": "db0d007a"
+  },
+  "web.organizations.audit.retry": {
+    "text": "다시 시도",
+    "source_hash": "d8b8392e"
+  },
+  "web.organizations.audit.showing_range": {
+    "text": "{total} 중 {from}–{to} 표시",
+    "source_hash": "c329279d"
+  },
+  "web.organizations.audit.upgrade_prompt": {
+    "text": "비밀 메시지 활동에는 감사 로그가 포함된 플랜이 필요합니다. 이 조직에서 누가 비밀 메시지를 생성, 조회, 공개했는지 확인하려면 업그레이드하세요.",
+    "source_hash": "453649ce"
+  },
+  "web.organizations.audit.role_required": {
+    "text": "비밀 메시지 활동은 조직 소유자 및 관리자에게 제공됩니다.",
+    "source_hash": "e066ec63"
+  },
+  "web.organizations.audit.actors.creator": {
+    "text": "생성자",
+    "source_hash": "88447b83"
+  },
+  "web.organizations.audit.actors.authenticated_other": {
+    "text": "다른 로그인한 사용자",
+    "source_hash": "ee45aa5a"
+  },
+  "web.organizations.audit.actors.anonymous": {
+    "text": "익명",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.organizations.audit.actors.system": {
+    "text": "시스템",
+    "source_hash": "6725e7bb"
+  },
+  "web.organizations.audit.actors.unknown": {
+    "text": "알 수 없음",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.columns.event": {
+    "text": "이벤트",
+    "source_hash": "4e1f49a9"
+  },
+  "web.organizations.audit.columns.secret": {
+    "text": "비밀 메시지",
+    "source_hash": "7e32a729"
+  },
+  "web.organizations.audit.columns.actor": {
+    "text": "사용자",
+    "source_hash": "449995c4"
+  },
+  "web.organizations.audit.columns.country": {
+    "text": "국가",
+    "source_hash": "701d021d"
+  },
+  "web.organizations.audit.columns.when": {
+    "text": "시간",
+    "source_hash": "cf9c7aa2"
+  },
+  "web.organizations.audit.kinds.created": {
+    "text": "비밀 메시지 생성됨",
+    "source_hash": "e4a1e1fd"
+  },
+  "web.organizations.audit.kinds.status_get": {
+    "text": "링크 상태 확인됨",
+    "source_hash": "0753f60e"
+  },
+  "web.organizations.audit.kinds.secret_get": {
+    "text": "비밀 메시지 링크 열림",
+    "source_hash": "e271e060"
+  },
+  "web.organizations.audit.kinds.previewed": {
+    "text": "생성자가 미리보기함",
+    "source_hash": "639fc1e2"
+  },
+  "web.organizations.audit.kinds.creator_status_get": {
+    "text": "생성자가 상태 확인함",
+    "source_hash": "7e4b5de5"
+  },
+  "web.organizations.audit.kinds.receipt_viewed": {
+    "text": "수신 확인 조회됨",
+    "source_hash": "a417ead4"
+  },
+  "web.organizations.audit.kinds.revealed": {
+    "text": "비밀 메시지 공개됨",
+    "source_hash": "aff2c84d"
+  },
+  "web.organizations.audit.kinds.burned": {
+    "text": "비밀 메시지 소각됨",
+    "source_hash": "5ac68dc6"
+  },
+  "web.organizations.audit.kinds.expired": {
+    "text": "비밀 메시지 만료됨",
+    "source_hash": "c127dab6"
+  },
+  "web.organizations.audit.kinds.orphaned": {
+    "text": "비밀 메시지 고아됨",
+    "source_hash": "23fe1a47"
+  },
+  "web.organizations.audit.kinds.reveal_failed_undecryptable": {
+    "text": "공개 실패 (복호화 불가)",
+    "source_hash": "d5616abf"
+  },
+  "web.organizations.tabs.activity": {
+    "text": "활동",
+    "source_hash": "38da1505"
   }
 }


### PR DESCRIPTION
## `ko` translation update

Automated export of completed **ko** translations from the translation task DB.
Scope: `locales/content/ko/` only — 16 file(s), +2020/-20.

⚠️ `i18n validate variables` reports **3** variable mismatch(es) for `ko` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ✅ Looks good — minor terminology consistency nit only.

**Summary:** This drain adds ~230 new ko keys across admin, auth, billing, branding, and org-audit surfaces, with correct variable/placeholder preservation and consistent polite register throughout. The 3 validator-flagged "errors" are a known false positive, not real defects.

**Critical (must fix):** None.

**Warnings:**
- New keys `web.auth.connections.section_title` and `web.auth.connections.overview_status` render "Single sign-on" as phonetic Hangul "싱글 사인온," while every other occurrence of this term in ko (workspace-billing.json, workspace-organizations.json, session-auth.json, workspace-account.json, workspace-domains.json) keeps it as English "Single Sign-On (SSO)." Not a governed glossary term, but inconsistent within the same account-security surface — worth aligning before merge.

**Notes:**
- The 3 "missing variable" errors in the JSON check (`web.auth.connections.connect_action.context`, `web.link_sso.prompt.context`, `web.sso_link_confirm.prompt.context`) are `.context` fields — English-only translator notes, never rendered to users, and intentionally not carried into locale files by this pipeline (confirmed against existing ko content and en source). This is a known validator false positive already being fixed on `fix/4080-context-metadata` (issue #4080). The real `text` values for `connect_action`, `link_sso.prompt`, and `sso_link_confirm.prompt` are present and correctly preserve `{provider}`/`{email}`.
- Particle alternation (을(를), (으)로) is correctly applied around variables where batchim is unknown (e.g. `{account}을(를) {role}(으)로`).
- Source-side wording changes (e.g. `admin.customers.description` dropping "without SSH," `admin.secrets.title` → "Secret Receipts") are correctly reflected.
- No brand-term mistranslation, no mojibake, no leftover English in `text` fields observed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
