### PR TITLE
i18n: update mi_NZ translations

### DIFF
--- a/locales/content/mi_NZ/00-common.json
+++ b/locales/content/mi_NZ/00-common.json
@@ -1539,5 +1539,9 @@
   "web.TITLES.domain_dns": {
     "text": "Whakaritenga DNS",
     "source_hash": "6c63df31"
+  },
+  "web.TITLES.connected_identities": {
+    "text": "Ngā Tuakiri Hono",
+    "source_hash": "e132c4d9"
   }
 }

--- a/locales/content/mi_NZ/admin-audit.json
+++ b/locales/content/mi_NZ/admin-audit.json
@@ -98,5 +98,41 @@
   "web.admin.audit.result.failure": {
     "text": "Rahunga",
     "source_hash": "7031edbc"
+  },
+  "web.admin.audit.categories.secret": {
+    "text": "Ngā Karere Huna",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.audit.categories.membership": {
+    "text": "Ngā Mematanga",
+    "source_hash": "b50f1a42"
+  },
+  "web.admin.audit.categories.entitlement_preview": {
+    "text": "Ngā arokite tika",
+    "source_hash": "255c5797"
+  },
+  "web.admin.audit.categories.colonel": {
+    "text": "Ngā takiuru Colonel",
+    "source_hash": "01eeeb38"
+  },
+  "web.admin.audit.filters.actorLabel": {
+    "text": "Kaimahi",
+    "source_hash": "449995c4"
+  },
+  "web.admin.audit.filters.searchButton": {
+    "text": "Rapu",
+    "source_hash": "49c266ba"
+  },
+  "web.admin.audit.filters.searchHint": {
+    "text": "Pātōhia he kaimahi, kātahi pēhia Enter, pēhia rānei Rapu kia whakahaere. Kāore te rārangi e whakahou i a koe e pato ana.",
+    "source_hash": "45eceb12"
+  },
+  "web.admin.audit.filters.pendingSearch": {
+    "text": "Kāore anō kia rapuhia — pēhia Enter, kōwhiria rānei Rapu kia tono i tēnei kaimahi.",
+    "source_hash": "f76095c2"
+  },
+  "web.admin.audit.list.contractError": {
+    "text": "I whakautu te tūmau, engari kāore ngā raraunga arotake i ōrite ki te hōputu e tūmanakohia ana. Kāore e taea te whakaatu i ngā takahanga — he hē pūrongo tēnei, ehara i te rārangi kau.",
+    "source_hash": "7f48137e"
   }
 }

--- a/locales/content/mi_NZ/admin-billing.json
+++ b/locales/content/mi_NZ/admin-billing.json
@@ -122,5 +122,85 @@
   "web.admin.billing.status.changed": {
     "text": "Kua panonitia",
     "source_hash": "2a6141e4"
+  },
+  "web.admin.billing.diff.backToCatalog": {
+    "text": "Hoki ki te rārangi utu",
+    "source_hash": "8532b373"
+  },
+  "web.admin.billing.diff.driftedFields": {
+    "text": "Ngā āpure rerekē:",
+    "source_hash": "9890c95b"
+  },
+  "web.admin.billing.diff.notFound": {
+    "text": "Kāore te mahere i te rārangi",
+    "source_hash": "0253898b"
+  },
+  "web.admin.billing.diff.notFoundDescription": {
+    "text": "Kāore i kitea he mahere me te tuakiri {planid} i te rārangi kua whirihorahia, i te keteroki Stripe-tukutahi ora rānei.",
+    "source_hash": "2e69551c"
+  },
+  "web.admin.billing.stripeOrgs.title": {
+    "text": "Ngā kiritaki Stripe",
+    "source_hash": "0463ae27"
+  },
+  "web.admin.billing.stripeOrgs.description": {
+    "text": "Ngā whakahaere kua hono ki tētahi pūkete kiritaki Stripe.",
+    "source_hash": "2ab09aec"
+  },
+  "web.admin.billing.stripeOrgs.searchPlaceholder": {
+    "text": "Rapu mā te tuakiri kiritaki Stripe",
+    "source_hash": "d5acf08f"
+  },
+  "web.admin.billing.stripeOrgs.empty": {
+    "text": "Kāore he whakahaere he tuakiri kiritaki Stripe.",
+    "source_hash": "2e373537"
+  },
+  "web.admin.billing.stripeOrgs.emptySearch": {
+    "text": "Kāore he tuakiri kiritaki Stripe e ōrite ana ki taua rapunga.",
+    "source_hash": "75011174"
+  },
+  "web.admin.billing.stripeOrgs.loadError": {
+    "text": "Kāore i taea te uta i te rārangi kiritaki Stripe.",
+    "source_hash": "15e2d9a7"
+  },
+  "web.admin.billing.stripeOrgs.unavailable": {
+    "text": "Kāore anō te rārangi kiritaki Stripe i te wātea i runga i tēnei tūmau.",
+    "source_hash": "aab6451a"
+  },
+  "web.admin.billing.stripeOrgs.none": {
+    "text": "Kore",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.billing.stripeOrgs.capped": {
+    "text": "Kua pā te matawai taupū ki tōna rohe, nā reira he rohe o raro te tapeke — whakaiti te rapunga kia kite ai i te toenga.",
+    "source_hash": "20bcaa38"
+  },
+  "web.admin.billing.stripeOrgs.stale": {
+    "text": "{count} taurangi taupū i tēnei whārangi e tohu ana ki tētahi whakahaere kāore e uta ana, ā, i pekehia.",
+    "source_hash": "51980f83"
+  },
+  "web.admin.billing.stripeOrgs.copyStripeId": {
+    "text": "Tārua tuakiri kiritaki Stripe",
+    "source_hash": "a77d18b1"
+  },
+  "web.admin.billing.stripeOrgs.columns.organization": {
+    "text": "Whakahaere",
+    "source_hash": "d764d425"
+  },
+  "web.admin.billing.stripeOrgs.columns.owner": {
+    "text": "Rangatira",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.billing.stripeOrgs.columns.plan": {
+    "text": "Mahere",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.billing.stripeOrgs.columns.subscription": {
+    "text": "Ohaurunga",
+    "source_hash": "4999c6c6"
+  },
+  "web.admin.billing.stripeOrgs.columns.stripeCustomer": {
+    "text": "Tuakiri kiritaki Stripe",
+    "source_hash": "7e1d8bbb"
   }
 }

--- a/locales/content/mi_NZ/admin-colonel.json
+++ b/locales/content/mi_NZ/admin-colonel.json
@@ -838,5 +838,37 @@
   "web.colonel.nav.groups.communications": {
     "text": "Ngā Whakawhitiwhiti Kōrero",
     "source_hash": "919a9253"
+  },
+  "web.colonel.organizations.sameAsContact": {
+    "text": "Ōrite ki te whakapā",
+    "source_hash": "ed18ff43"
+  },
+  "web.colonel.organizations.refresh": {
+    "text": "Whakahou",
+    "source_hash": "0e916101"
+  },
+  "web.colonel.organizations.updatedAgo": {
+    "text": "I whakahoutia {ago}",
+    "source_hash": "cda30b9c"
+  },
+  "web.colonel.organizations.columns.name": {
+    "text": "Ingoa",
+    "source_hash": "dcd1d522"
+  },
+  "web.colonel.organizations.columns.contactEmail": {
+    "text": "Īmēra whakapā",
+    "source_hash": "6d7fce11"
+  },
+  "web.colonel.organizations.columns.billingEmail": {
+    "text": "Īmēra utu",
+    "source_hash": "8805b928"
+  },
+  "web.colonel.organizations.columns.planSubscription": {
+    "text": "Mahere me te ohaurunga",
+    "source_hash": "b396caac"
+  },
+  "web.colonel.organizations.filters.searchPlaceholder": {
+    "text": "Rapu mā te tuakiri, ingoa, īmēra rānei",
+    "source_hash": "6fe16473"
   }
 }

--- a/locales/content/mi_NZ/admin-customers.json
+++ b/locales/content/mi_NZ/admin-customers.json
@@ -4,8 +4,8 @@
     "source_hash": "aabe76f1"
   },
   "web.admin.customers.description": {
-    "text": "Rapua he kiritaki, whakaotia ngā take tautoko me te kore SSH.",
-    "source_hash": "c8487e68"
+    "text": "Kimihia he kiritaki, whakatikahia ngā take tautoko.",
+    "source_hash": "00961ea3"
   },
   "web.admin.customers.actions.plan.label": {
     "text": "Mahere",
@@ -482,5 +482,213 @@
   "web.admin.customers.suspended.badge": {
     "text": "Kua Whakatārewatia",
     "source_hash": "e392a389"
+  },
+  "web.admin.customers.actions.checkoutLink.button": {
+    "text": "Waihanga hononga utu",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.modalTitle": {
+    "text": "Waihanga hononga utu",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.planLabel": {
+    "text": "Mahere",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.actions.checkoutLink.planPlaceholder": {
+    "text": "Tuakiri whānau mahere (hei tauira identity_plus_v1)",
+    "source_hash": "12eba027"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleLabel": {
+    "text": "Huringa utu",
+    "source_hash": "d69f731e"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleMonthly": {
+    "text": "Ia marama",
+    "source_hash": "9b11f6b7"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleYearly": {
+    "text": "Ia tau",
+    "source_hash": "6e69b59e"
+  },
+  "web.admin.customers.actions.checkoutLink.allowPromo": {
+    "text": "Tukua ngā waehere whakatairanga",
+    "source_hash": "ebe7bc8b"
+  },
+  "web.admin.customers.actions.checkoutLink.submit": {
+    "text": "Waihanga hononga",
+    "source_hash": "e6b850cf"
+  },
+  "web.admin.customers.actions.checkoutLink.resultLead": {
+    "text": "Kua hangaia te hononga utu. Tohaina ki te kiritaki — kotahi noa te wā e taea ai te whakamahi, ka pau te wā.",
+    "source_hash": "6ff1fb0e"
+  },
+  "web.admin.customers.actions.checkoutLink.copy": {
+    "text": "Tārua hononga utu",
+    "source_hash": "f1e51ca7"
+  },
+  "web.admin.customers.actions.checkoutLink.expiry": {
+    "text": "Ka pau te wā i roto i ~{hours}h ({date}).",
+    "source_hash": "4c878a15"
+  },
+  "web.admin.customers.actions.checkoutLink.regionLabel": {
+    "text": "Rohe",
+    "source_hash": "d3a008ef"
+  },
+  "web.admin.customers.actions.checkoutLink.parseError": {
+    "text": "I whakaae te tūmau ki te tono engari i whakahoki mai he whakautu kāore e taea te pānui, nā reira kāore e taea te whakaatu i te hononga. Tirohia Stripe i mua i te ngana anō.",
+    "source_hash": "e7e08290"
+  },
+  "web.admin.customers.actions.checkoutLink.done": {
+    "text": "Kua oti",
+    "source_hash": "11a6767d"
+  },
+  "web.admin.customers.actions.purge.typePrompt": {
+    "text": "Hei whakaū, pātōhia te wāhitau īmēra pūkete {token} ki raro nei",
+    "source_hash": "8b2a1819"
+  },
+  "web.admin.customers.actions.purge.unavailable": {
+    "text": "Kāore e wātea te mukua: kāore tēnei pūkete he wāhitau īmēra hei pato anō hei whakaū.",
+    "source_hash": "5f20f7e5"
+  },
+  "web.admin.customers.columns.actions": {
+    "text": "Ngā mahi",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.diagnostics.title": {
+    "text": "Ngā Arowhai Pūkete",
+    "source_hash": "5574ece8"
+  },
+  "web.admin.customers.detail.diagnostics.loading": {
+    "text": "Kei te whakahaere arowhai…",
+    "source_hash": "062c83d5"
+  },
+  "web.admin.customers.detail.diagnostics.loadError": {
+    "text": "Kāore i taea te uta i ngā arowhai.",
+    "source_hash": "69e69f49"
+  },
+  "web.admin.customers.detail.diagnostics.healthy": {
+    "text": "Kāore i kitea he āhuatanga aukati. He pai te āhua o te tūnga motuhēhē — whakapae he take taha-kiritaki (pihikete, whirihoranga takiuru rohe-ritenga) te rohe hē rānei.",
+    "source_hash": "f6d5f8d1"
+  },
+  "web.admin.customers.detail.diagnostics.authUnavailable": {
+    "text": "Kāore e wātea te pātengi raraunga motuhēhē (aratau motuhēhē māmā) — i pekehia ngā tirotiro taha-SQL.",
+    "source_hash": "d668907c"
+  },
+  "web.admin.customers.detail.diagnostics.authFailed": {
+    "text": "Kāore te pātengi raraunga motuhēhē i whakautu, nā reira kāore i taea te whakahaere i ngā tirotiro taha-SQL: {reason}",
+    "source_hash": "46d047c0"
+  },
+  "web.admin.customers.detail.diagnostics.unknown": {
+    "text": "Kāore e mōhiotia",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.title": {
+    "text": "Rārangi motuhēhē",
+    "source_hash": "48ad8ba8"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.empty": {
+    "text": "Kāore he takahanga motuhēhē i rekoatatia.",
+    "source_hash": "d2332558"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.unavailable": {
+    "text": "Kāore i taea te pānui i te rārangi motuhēhē: {reason}",
+    "source_hash": "ab18af57"
+  },
+  "web.admin.customers.detail.diagnostics.facts.authStatus": {
+    "text": "Tūnga motuhēhē",
+    "source_hash": "34def169"
+  },
+  "web.admin.customers.detail.diagnostics.facts.noAccount": {
+    "text": "Kāore he pūkete motuhēhē",
+    "source_hash": "a9968e9e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.password": {
+    "text": "Kupuhipa",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordSet": {
+    "text": "Kua whakatūria",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordNone": {
+    "text": "Kore",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfa": {
+    "text": "MFA",
+    "source_hash": "d39ce053"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfaNone": {
+    "text": "Kore",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.loginFailures": {
+    "text": "Ngā ngana i rahua",
+    "source_hash": "63e7f0a8"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lockedBadge": {
+    "text": "Kua rakaina",
+    "source_hash": "ace29f74"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiter": {
+    "text": "Kaiwhakarōrahi",
+    "source_hash": "32892404"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterEngaged": {
+    "text": "Kua whakahohea",
+    "source_hash": "1b0d851e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterClear": {
+    "text": "Māmā",
+    "source_hash": "83b12c22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verification": {
+    "text": "Īmēra whakaū",
+    "source_hash": "23fac8fb"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationPending": {
+    "text": "E tatari ana — i tukuna whakamutunga {date}",
+    "source_hash": "9ab8d1b6"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationNone": {
+    "text": "Kāore e tatari ana",
+    "source_hash": "a4d4cc22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.sessions": {
+    "text": "Ngā hōtaka kaha",
+    "source_hash": "61ad9909"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lastLogin": {
+    "text": "Takiuru whakamutunga (motuhēhē)",
+    "source_hash": "373e7fb1"
+  },
+  "web.admin.customers.detail.receipts.partial": {
+    "text": "Rārangi wāhanga — e whakaatu ana i te {count} hou rawa. He nui ake ngā rihīti a tēnei kiritaki i ngā mea e whakaatuhia ana i konei.",
+    "source_hash": "127fd4db"
+  },
+  "web.admin.customers.detail.secrets.partial": {
+    "text": "Rārangi wāhanga — e whakaatu ana i te {count} hou rawa. He nui ake ngā karere huna a tēnei kiritaki i ngā mea e whakaatuhia ana i konei.",
+    "source_hash": "a537c8f3"
+  },
+  "web.admin.customers.detail.sessions.columns.country": {
+    "text": "Whenua",
+    "source_hash": "701d021d"
+  },
+  "web.admin.customers.detail.sessions.current.badge": {
+    "text": "Tēnei hōtaka",
+    "source_hash": "6da6530a"
+  },
+  "web.admin.customers.detail.sessions.current.tooltip": {
+    "text": "Tō hōtaka whakahaere o nāianei. Kāore he hua o te whakakore i konei — ka hangaia anō mō te toenga o tēnei tono.",
+    "source_hash": "ef097ab1"
+  },
+  "web.admin.customers.verification.verified": {
+    "text": "Kua whakaūngia",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.verification.unverified": {
+    "text": "Kāore anō kia whakaūngia",
+    "source_hash": "15133907"
   }
 }

--- a/locales/content/mi_NZ/admin-domains.json
+++ b/locales/content/mi_NZ/admin-domains.json
@@ -190,5 +190,657 @@
   "web.admin.domains.verify.success.done": {
     "text": "Kua oti te manatoko mō {domain}.",
     "source_hash": "ed67e22d"
+  },
+  "web.admin.domains.actions.preview": {
+    "text": "Arokite",
+    "source_hash": "324b134f"
+  },
+  "web.admin.domains.actions.probe.button": {
+    "text": "Mātai",
+    "source_hash": "3bd51ab9"
+  },
+  "web.admin.domains.actions.remove.button": {
+    "text": "Tangohia te rohe",
+    "source_hash": "5ce43507"
+  },
+  "web.admin.domains.actions.remove.previewButton": {
+    "text": "Arokite tangohanga",
+    "source_hash": "6b81bd92"
+  },
+  "web.admin.domains.actions.remove.previewStatus": {
+    "text": "Tūnga:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.remove.previewOrg": {
+    "text": "Whakahaere:",
+    "source_hash": "5300e286"
+  },
+  "web.admin.domains.actions.remove.reassertsSurvivor": {
+    "text": "He pūkete anō e kerēmi ana i te ingoa rohe kotahi, ā, ka riro māna te taupū rapu.",
+    "source_hash": "902838f4"
+  },
+  "web.admin.domains.actions.remove.confirmTitle": {
+    "text": "Tangohia te rohe?",
+    "source_hash": "716dfac9"
+  },
+  "web.admin.domains.actions.remove.confirmDescription": {
+    "text": "Ka mukua pūmautia {domain} me ōna pūkete waitohu, DNS me ngā whirihoranga. Kāore e taea te whakakore. Pātōhia anō te tuakiri tūmatanui o te rohe kia haere tonu.",
+    "source_hash": "d0b67b47"
+  },
+  "web.admin.domains.actions.remove.success": {
+    "text": "Kua tangohia te rohe.",
+    "source_hash": "2ccaa6d3"
+  },
+  "web.admin.domains.actions.remove.notApplied": {
+    "text": "I arokitea te tangohanga e te tūmau kaua i te whakatinana — KĀORE i tangohia te rohe. Ngana anō, pūrongotia mēnā ka mau tonu.",
+    "source_hash": "dc6d70ae"
+  },
+  "web.admin.domains.actions.repair.title": {
+    "text": "Whakatikahia te hononga whakahaere",
+    "source_hash": "82b40352"
+  },
+  "web.admin.domains.actions.repair.description": {
+    "text": "Kimihia, whakatikahia ngā hononga pakaru i waenga i tēnei rohe me tōna whakahaere. Arokitea i te tuatahi kia kite ai he aha ngā mea ka huri.",
+    "source_hash": "531ed287"
+  },
+  "web.admin.domains.actions.repair.orgIdLabel": {
+    "text": "Tuakiri whakahaere (mō ngā rohe pani anake)",
+    "source_hash": "0d3010eb"
+  },
+  "web.admin.domains.actions.repair.orgIdPlaceholder": {
+    "text": "Waiho kia kau ki te mea kāore he rangatira o te rohe",
+    "source_hash": "118b7132"
+  },
+  "web.admin.domains.actions.repair.statusLabel": {
+    "text": "Tūnga:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.repair.noIssues": {
+    "text": "Kāore i kitea he raruraru — kāore he mea hei whakatika.",
+    "source_hash": "17735887"
+  },
+  "web.admin.domains.actions.repair.button": {
+    "text": "Whakamahia te whakatika",
+    "source_hash": "4d0ab2d4"
+  },
+  "web.admin.domains.actions.repair.confirmTitle": {
+    "text": "Whakamahia te whakatika?",
+    "source_hash": "ef0ffae5"
+  },
+  "web.admin.domains.actions.repair.confirmDescription": {
+    "text": "Ka tuhia anō te hononga whakahaere mō {domain}. Pātōhia anō te tuakiri tūmatanui o te rohe kia haere tonu.",
+    "source_hash": "a9f2702f"
+  },
+  "web.admin.domains.actions.repair.success": {
+    "text": "Kua whakamahia te whakatika.",
+    "source_hash": "850bd784"
+  },
+  "web.admin.domains.actions.transfer.title": {
+    "text": "Whakawhiti ki tētahi whakahaere kē",
+    "source_hash": "1b0b0655"
+  },
+  "web.admin.domains.actions.transfer.description": {
+    "text": "Nukuhia tēnei rohe ki tētahi whakahaere kē. Arokitea i te tuatahi kia whakaū ai i ngā taha e rua o te nekuneku.",
+    "source_hash": "457e852d"
+  },
+  "web.admin.domains.actions.transfer.toOrgLabel": {
+    "text": "Tuakiri whakahaere mutunga",
+    "source_hash": "1a3f05c4"
+  },
+  "web.admin.domains.actions.transfer.fromOrgLabel": {
+    "text": "Tuakiri whakahaere o nāianei e tūmanakohia ana (kōwhiri)",
+    "source_hash": "f6e75729"
+  },
+  "web.admin.domains.actions.transfer.fromOrgPlaceholder": {
+    "text": "Whakaūngia te rangatira o nāianei i mua i te nekuneku",
+    "source_hash": "1ac6c59b"
+  },
+  "web.admin.domains.actions.transfer.from": {
+    "text": "Mai i",
+    "source_hash": "21819769"
+  },
+  "web.admin.domains.actions.transfer.to": {
+    "text": "Ki",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.domains.actions.transfer.orphaned": {
+    "text": "Kāore he whakahaere (pani)",
+    "source_hash": "6f4c745c"
+  },
+  "web.admin.domains.actions.transfer.button": {
+    "text": "Whakamahia te whakawhiti",
+    "source_hash": "fb546c5c"
+  },
+  "web.admin.domains.actions.transfer.confirmTitle": {
+    "text": "Whakawhitihia te rohe?",
+    "source_hash": "801eb986"
+  },
+  "web.admin.domains.actions.transfer.confirmDescription": {
+    "text": "Ka nukuhia {domain} ki te whakahaere {org}. Pātōhia anō te tuakiri tūmatanui o te rohe kia haere tonu.",
+    "source_hash": "52c8808d"
+  },
+  "web.admin.domains.actions.transfer.success": {
+    "text": "Kua whakawhitihia te rohe.",
+    "source_hash": "91e681ae"
+  },
+  "web.admin.domains.columns.domain": {
+    "text": "Rohe",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domains.columns.organization": {
+    "text": "Whakahaere",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.columns.state": {
+    "text": "Whakaūnga",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.domains.columns.tls": {
+    "text": "TLS",
+    "source_hash": "d1c18ec0"
+  },
+  "web.admin.domains.columns.created": {
+    "text": "I hangaia",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.columns.actions": {
+    "text": "Ngā mahi",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.configs.title": {
+    "text": "Whirihoranga rohe",
+    "source_hash": "d46aa480"
+  },
+  "web.admin.domains.configs.description": {
+    "text": "Ngā pūkete whirihoranga ia-rohe e aukati ana i te takiuru, waitohu, karere huna whārangi matua, uru API, karere huna tae mai, SSO kairīwhi me te tuku mēra. Ko te pūkete ngaro ka kati mō ngā mea tuatahi e rima.",
+    "source_hash": "1df99789"
+  },
+  "web.admin.domains.configs.loadError": {
+    "text": "Kāore i taea te uta i ngā pūkete whirihoranga rohe.",
+    "source_hash": "9417d718"
+  },
+  "web.admin.domains.configs.retry": {
+    "text": "Ngana anō",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.configs.degraded": {
+    "text": "Kāore te whakautu whirihoranga i ōrite ki te kirimana e tūmanakohia ana. Whakahouhia, pūrongotia mēnā ka mau tonu.",
+    "source_hash": "b5d890c0"
+  },
+  "web.admin.domains.configs.notFoundNote": {
+    "text": "Kāore kē tēnei rohe i te noho, nā reira kāore e taea te uta i ōna pūkete whirihoranga.",
+    "source_hash": "2d88a392"
+  },
+  "web.admin.domains.configs.detailsToggle": {
+    "text": "Ngā taipitopito",
+    "source_hash": "45989de4"
+  },
+  "web.admin.domains.configs.notEditable": {
+    "text": "Ka whakahaerea i ngā tautuhinga rohe wāhi mahi.",
+    "source_hash": "54fe891f"
+  },
+  "web.admin.domains.configs.delete.button": {
+    "text": "Mukua",
+    "source_hash": "e2d0a549"
+  },
+  "web.admin.domains.configs.delete.confirmTitle": {
+    "text": "Mukua te whirihoranga {kind}?",
+    "source_hash": "98e672db"
+  },
+  "web.admin.domains.configs.delete.confirmDescription": {
+    "text": "Ka mukua pūmautia te pūkete whirihoranga {kind} mō {domain}. Ka hoki te rohe ki te whanonga pūkete-ngaro. Pātōhia anō te momo kia haere tonu.",
+    "source_hash": "8272c40c"
+  },
+  "web.admin.domains.configs.delete.success": {
+    "text": "Kua mukua te whirihoranga.",
+    "source_hash": "a0184b66"
+  },
+  "web.admin.domains.configs.edit.button": {
+    "text": "Whakatika",
+    "source_hash": "464c4ffd"
+  },
+  "web.admin.domains.configs.edit.createButton": {
+    "text": "Waihanga",
+    "source_hash": "4759498a"
+  },
+  "web.admin.domains.configs.edit.title": {
+    "text": "Whirihora {kind}",
+    "source_hash": "8592148f"
+  },
+  "web.admin.domains.configs.edit.submit": {
+    "text": "Tiaki",
+    "source_hash": "1509f561"
+  },
+  "web.admin.domains.configs.edit.success": {
+    "text": "Kua tiakina te whirihoranga.",
+    "source_hash": "6b5b3c69"
+  },
+  "web.admin.domains.configs.edit.unsetOption": {
+    "text": "Kāore i whakatūria",
+    "source_hash": "4895f731"
+  },
+  "web.admin.domains.configs.edit.domainsHint": {
+    "text": "Kotahi te rohe ia rārangi.",
+    "source_hash": "6c03f4f7"
+  },
+  "web.admin.domains.configs.ensure.button": {
+    "text": "Waihanga whirihoranga ngaro",
+    "source_hash": "77991b75"
+  },
+  "web.admin.domains.configs.ensure.confirmTitle": {
+    "text": "Waihanga pūkete whirihoranga ngaro?",
+    "source_hash": "3f41dec2"
+  },
+  "web.admin.domains.configs.ensure.confirmDescription": {
+    "text": "Ka hangaia ngā pūkete monokia i runga i {domain} mō: {kinds}. Ka tīmata ngā mea katoa i te moni, nā reira kāore e huri te whanonga kia whakahohea rā anō tētahi pūkete.",
+    "source_hash": "fed66221"
+  },
+  "web.admin.domains.configs.ensure.applyButton": {
+    "text": "Waihanga pūkete",
+    "source_hash": "4bcbef42"
+  },
+  "web.admin.domains.configs.ensure.success": {
+    "text": "Kua hangaia ngā pūkete whirihoranga ngaro.",
+    "source_hash": "3b6ead80"
+  },
+  "web.admin.domains.configs.ensure.nothingMissing": {
+    "text": "Kāore he mea hei hanga — kua noho kē ngā pūkete whirihoranga katoa. Kua whakahouhia te rārangi.",
+    "source_hash": "ad0df0ae"
+  },
+  "web.admin.domains.configs.ensure.notApplied": {
+    "text": "I arokitea te huringa e te tūmau kaua i te whakatinana — kāore i hangaia he pūkete. Ngana anō, pūrongotia mēnā ka mau tonu.",
+    "source_hash": "09d26379"
+  },
+  "web.admin.domains.configs.fields.enabled": {
+    "text": "Kua whakahohea",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.fields.signin_enabled": {
+    "text": "Kua whakahohea te takiuru",
+    "source_hash": "cabe4898"
+  },
+  "web.admin.domains.configs.fields.email_auth_enabled": {
+    "text": "Kua whakahohea te motuhēhē īmēra",
+    "source_hash": "4a762960"
+  },
+  "web.admin.domains.configs.fields.sso_enabled": {
+    "text": "Kua whakahohea SSO",
+    "source_hash": "6e77e673"
+  },
+  "web.admin.domains.configs.fields.restrict_to": {
+    "text": "Whakaiti ki",
+    "source_hash": "a0bdf50a"
+  },
+  "web.admin.domains.configs.fields.signup_enabled": {
+    "text": "Kua whakahohea te waitohu",
+    "source_hash": "2637d0b2"
+  },
+  "web.admin.domains.configs.fields.autoverify": {
+    "text": "Whakaū-aunoa",
+    "source_hash": "7e02211c"
+  },
+  "web.admin.domains.configs.fields.validation_strategy": {
+    "text": "Rautaki whakaū",
+    "source_hash": "a2e95531"
+  },
+  "web.admin.domains.configs.fields.allowed_signup_domains": {
+    "text": "Ngā rohe waitohu whakaaetia",
+    "source_hash": "9b5bb5b1"
+  },
+  "web.admin.domains.configs.fields.secrets_mode": {
+    "text": "Aratau karere huna",
+    "source_hash": "8d4349d6"
+  },
+  "web.admin.domains.configs.fields.disabled_homepage_variant": {
+    "text": "Tauira whārangi matua kua monokia",
+    "source_hash": "4695633b"
+  },
+  "web.admin.domains.configs.fields.ready": {
+    "text": "Kua rite",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.configs.fields.recipients": {
+    "text": "Ngā kaiwhiwhi",
+    "source_hash": "1e8568a8"
+  },
+  "web.admin.domains.configs.fields.provider_type": {
+    "text": "Momo kaiwhakarato",
+    "source_hash": "8c0f6d3e"
+  },
+  "web.admin.domains.configs.fields.display_name": {
+    "text": "Ingoa whakaatu",
+    "source_hash": "2b7f6a84"
+  },
+  "web.admin.domains.configs.fields.issuer": {
+    "text": "Kaiwhakaputa",
+    "source_hash": "39e02c46"
+  },
+  "web.admin.domains.configs.fields.tenant_id": {
+    "text": "Tuakiri kairīwhi",
+    "source_hash": "de1f5fff"
+  },
+  "web.admin.domains.configs.fields.has_client_id": {
+    "text": "Kua whakatūria tuakiri kiritaki",
+    "source_hash": "04a9fa3d"
+  },
+  "web.admin.domains.configs.fields.has_client_secret": {
+    "text": "Kua whakatūria karere huna kiritaki",
+    "source_hash": "6ee1c9e6"
+  },
+  "web.admin.domains.configs.fields.allowed_domains": {
+    "text": "Ngā rohe whakaaetia",
+    "source_hash": "bcd60db0"
+  },
+  "web.admin.domains.configs.fields.enforce_sso_only": {
+    "text": "SSO anake",
+    "source_hash": "b3a3f694"
+  },
+  "web.admin.domains.configs.fields.grant_org_scope": {
+    "text": "Tuku wāhi whakahaere",
+    "source_hash": "698ea5de"
+  },
+  "web.admin.domains.configs.fields.provider": {
+    "text": "Kaiwhakarato",
+    "source_hash": "472590ae"
+  },
+  "web.admin.domains.configs.fields.from_name": {
+    "text": "Ingoa mai",
+    "source_hash": "b28f93ea"
+  },
+  "web.admin.domains.configs.fields.from_address": {
+    "text": "Wāhitau mai",
+    "source_hash": "d465bcfa"
+  },
+  "web.admin.domains.configs.fields.reply_to": {
+    "text": "Whakautu-ki",
+    "source_hash": "6b9c49b7"
+  },
+  "web.admin.domains.configs.fields.sending_mode": {
+    "text": "Aratau tuku",
+    "source_hash": "e2d6bcf7"
+  },
+  "web.admin.domains.configs.fields.verification_status": {
+    "text": "Tūnga whakaū",
+    "source_hash": "aedfff7e"
+  },
+  "web.admin.domains.configs.fields.dns_verified": {
+    "text": "Kua whakaūngia DNS",
+    "source_hash": "8b2128c8"
+  },
+  "web.admin.domains.configs.fields.provider_verified": {
+    "text": "Kua whakaūngia kaiwhakarato",
+    "source_hash": "6f4d9cc4"
+  },
+  "web.admin.domains.configs.fields.has_api_key": {
+    "text": "Kua whakatūria kī API",
+    "source_hash": "d5115386"
+  },
+  "web.admin.domains.configs.fields.created": {
+    "text": "I hangaia",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.configs.fields.updated": {
+    "text": "I whakahoutia",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.configs.kinds.signin": {
+    "text": "Takiuru",
+    "source_hash": "5bbbe531"
+  },
+  "web.admin.domains.configs.kinds.signup": {
+    "text": "Waitohu",
+    "source_hash": "3cc08ebe"
+  },
+  "web.admin.domains.configs.kinds.homepage": {
+    "text": "Whārangi matua",
+    "source_hash": "9e3391e9"
+  },
+  "web.admin.domains.configs.kinds.api": {
+    "text": "API",
+    "source_hash": "c8e5998f"
+  },
+  "web.admin.domains.configs.kinds.incoming": {
+    "text": "Tae mai",
+    "source_hash": "e301820a"
+  },
+  "web.admin.domains.configs.kinds.sso": {
+    "text": "SSO",
+    "source_hash": "5ba3ac9f"
+  },
+  "web.admin.domains.configs.kinds.mailer": {
+    "text": "Kaituku mēra",
+    "source_hash": "6c07ba63"
+  },
+  "web.admin.domains.configs.missingNotes.signin": {
+    "text": "Kāore he pūkete: kua monokia te takiuru i runga i tēnei rohe ki te mea kāore SSO kairīwhi i te kaha.",
+    "source_hash": "17dd6099"
+  },
+  "web.admin.domains.configs.missingNotes.signup": {
+    "text": "Kāore he pūkete: kua monokia te waitohu i runga i tēnei rohe.",
+    "source_hash": "c3c98956"
+  },
+  "web.admin.domains.configs.missingNotes.homepage": {
+    "text": "Kāore he pūkete: kua monokia ngā karere huna whārangi matua (ka rahua kati, ka tuhi hē).",
+    "source_hash": "9a258a88"
+  },
+  "web.admin.domains.configs.missingNotes.api": {
+    "text": "Kāore he pūkete: kua monokia te API tūmatanui (ka rahua kati, ka tuhi hē).",
+    "source_hash": "fed99f73"
+  },
+  "web.admin.domains.configs.missingNotes.incoming": {
+    "text": "Kāore he pūkete: kua monokia ngā karere huna tae mai.",
+    "source_hash": "b957fbe8"
+  },
+  "web.admin.domains.configs.missingNotes.sso": {
+    "text": "Kāore he pūkete: kāore e wātea SSO kairīwhi; ka whakamahi te kaupapa here hoki SSO pūhara.",
+    "source_hash": "7b05ade8"
+  },
+  "web.admin.domains.configs.missingNotes.mailer": {
+    "text": "Kāore he pūkete: ka whakamahia te kaituku mēra pūhara.",
+    "source_hash": "e027cc99"
+  },
+  "web.admin.domains.configs.status.missing": {
+    "text": "Ngaro",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.domains.configs.status.disabled": {
+    "text": "Kua monokia",
+    "source_hash": "75081b59"
+  },
+  "web.admin.domains.configs.status.enabled": {
+    "text": "Kua whakahohea",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.status.enabledNotReady": {
+    "text": "Kua whakahohea, kāore anō kia rite",
+    "source_hash": "cb806ba4"
+  },
+  "web.admin.domains.detail.openFullPage": {
+    "text": "Whakatuwherahia te whārangi katoa",
+    "source_hash": "a467911c"
+  },
+  "web.admin.domains.detail.backToList": {
+    "text": "Hoki ki ngā rohe",
+    "source_hash": "22fd50fe"
+  },
+  "web.admin.domains.detail.notFound": {
+    "text": "Kāore i kitea te rohe",
+    "source_hash": "7b8fc0e6"
+  },
+  "web.admin.domains.detail.notFoundDescription": {
+    "text": "Kāore tēnei rohe i te noho, kua tangohia kē rānei.",
+    "source_hash": "e0f0b987"
+  },
+  "web.admin.domains.detail.loadError": {
+    "text": "Kāore i taea te uta i tēnei rohe.",
+    "source_hash": "39e9c657"
+  },
+  "web.admin.domains.detail.retry": {
+    "text": "Ngana anō",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.detail.never": {
+    "text": "Kore rawa",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.domains.detail.none": {
+    "text": "Kore",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.domains.detail.yes": {
+    "text": "Āe",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.domains.detail.no": {
+    "text": "Kāo",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.domains.detail.organization.open": {
+    "text": "Whakatuwherahia te whakahaere",
+    "source_hash": "54a43621"
+  },
+  "web.admin.domains.detail.organization.unknown": {
+    "text": "Kāore te whakahaere rangatira i te uru ki tēnei whakautu. Whakatuwherahia tēnei rohe mai i te rārangi rohe kia kite ai.",
+    "source_hash": "bb5bdc9c"
+  },
+  "web.admin.domains.detail.sections.overview": {
+    "text": "Tirohanga whānui",
+    "source_hash": "d4b1ea57"
+  },
+  "web.admin.domains.detail.sections.actions": {
+    "text": "Ngā mahi",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.detail.sections.organization": {
+    "text": "Whakahaere rangatira",
+    "source_hash": "39ad6d9c"
+  },
+  "web.admin.domains.detail.sections.dns": {
+    "text": "DNS",
+    "source_hash": "020965a2"
+  },
+  "web.admin.domains.detail.sections.diagnostics": {
+    "text": "Ngā arowhai",
+    "source_hash": "268f14bb"
+  },
+  "web.admin.domains.detail.sections.operations": {
+    "text": "Ngā mahi rangatiratanga",
+    "source_hash": "eb9a8cbc"
+  },
+  "web.admin.domains.detail.sections.operationsHint": {
+    "text": "Ka arokite ia mahi i te tuatahi. Kāore e tuhia he mea kia whakaū ai koe i te hikoi whakamahi.",
+    "source_hash": "f09bf7bd"
+  },
+  "web.admin.domains.fields.publicId": {
+    "text": "Tuakiri tūmatanui",
+    "source_hash": "3705b64f"
+  },
+  "web.admin.domains.fields.domainId": {
+    "text": "Tuakiri o roto",
+    "source_hash": "e468bb47"
+  },
+  "web.admin.domains.fields.organization": {
+    "text": "Whakahaere",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.fields.baseDomain": {
+    "text": "Rohe tūāpapa",
+    "source_hash": "33295d5b"
+  },
+  "web.admin.domains.fields.subdomain": {
+    "text": "Rohe iti",
+    "source_hash": "ba4520ab"
+  },
+  "web.admin.domains.fields.apex": {
+    "text": "Rohe tītihi",
+    "source_hash": "0a8a42fa"
+  },
+  "web.admin.domains.fields.status": {
+    "text": "Tūnga",
+    "source_hash": "920e413c"
+  },
+  "web.admin.domains.fields.created": {
+    "text": "I hangaia",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.fields.updated": {
+    "text": "I whakahoutia",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.fields.verified": {
+    "text": "Kua whakaūngia",
+    "source_hash": "4f783840"
+  },
+  "web.admin.domains.fields.resolving": {
+    "text": "Kei te whakatau",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.fields.ready": {
+    "text": "Kua rite",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.list.searchPlaceholder": {
+    "text": "Rapu mā te ingoa rohe, tuakiri rānei",
+    "source_hash": "aecdd873"
+  },
+  "web.admin.domains.list.stateFilter": {
+    "text": "Tūnga",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.domains.list.emptyFilter": {
+    "text": "Kāore he rohe e ōrite ana ki ngā tātari o nāianei.",
+    "source_hash": "be4d64ec"
+  },
+  "web.admin.domains.probe.healthLabel": {
+    "text": "Hauora",
+    "source_hash": "55898449"
+  },
+  "web.admin.domains.probe.certInvalid": {
+    "text": "Kāore e taea te whakamahi i te tiwhikete",
+    "source_hash": "5535f4d4"
+  },
+  "web.admin.domains.probe.noCertificate": {
+    "text": "Kāore i whakahokia he tiwhikete — i rahua te hononga i mua i te TLS.",
+    "source_hash": "8ffd63be"
+  },
+  "web.admin.domains.probe.fields.httpStatus": {
+    "text": "Tūnga HTTP",
+    "source_hash": "0f7cf91f"
+  },
+  "web.admin.domains.probe.fields.httpError": {
+    "text": "Hē HTTP",
+    "source_hash": "5c6896d4"
+  },
+  "web.admin.domains.probe.fields.sslError": {
+    "text": "Hē TLS",
+    "source_hash": "7b827515"
+  },
+  "web.admin.domains.probe.fields.issuer": {
+    "text": "Kaiwhakaputa tiwhikete",
+    "source_hash": "2912559a"
+  },
+  "web.admin.domains.probe.fields.subject": {
+    "text": "Kaupapa tiwhikete",
+    "source_hash": "d7816b16"
+  },
+  "web.admin.domains.probe.fields.notAfter": {
+    "text": "Ka pau te tiwhikete",
+    "source_hash": "1e73119d"
+  },
+  "web.admin.domains.probe.fields.expiresIn": {
+    "text": "{date} ({days} rā)",
+    "source_hash": "a71a6e81"
+  },
+  "web.admin.domains.tls.serving": {
+    "text": "Kei te tuku",
+    "source_hash": "f55e53f9"
+  },
+  "web.admin.domains.tls.resolving": {
+    "text": "Kei te whakatau",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.tls.none": {
+    "text": "Kāore i te tuku",
+    "source_hash": "da8a5ab9"
   }
 }

--- a/locales/content/mi_NZ/admin-organizations.json
+++ b/locales/content/mi_NZ/admin-organizations.json
@@ -400,7 +400,7 @@
     "source_hash": "15133907"
   },
   "web.admin.organizations.addMember.badges.suspended": {
-    "text": "Kua whakatārewahia",
+    "text": "Kua whakatārewatia",
     "source_hash": "e392a389"
   },
   "web.admin.organizations.addMember.badges.alreadyMember": {

--- a/locales/content/mi_NZ/admin-organizations.json
+++ b/locales/content/mi_NZ/admin-organizations.json
@@ -310,5 +310,333 @@
   "web.admin.organizations.list.loadError": {
     "text": "Kāore i taea te uta i ngā whakahaere.",
     "source_hash": "130d5e70"
+  },
+  "web.admin.organizations.addMember.button": {
+    "text": "Tāpiri pūkete kua noho",
+    "source_hash": "45a3b757"
+  },
+  "web.admin.organizations.addMember.title": {
+    "text": "Tāpiri pūkete kua noho",
+    "source_hash": "2f676a94"
+  },
+  "web.admin.organizations.addMember.description": {
+    "text": "Tāpiri tētahi kua whai pūkete kē ki {org}. Whakamahia tēnei ina waitohu tētahi tangata mā rātou anō, ā, kāore e taea te pōwhiri nā te mea kua noho kē te pūkete.",
+    "source_hash": "bb41faa6"
+  },
+  "web.admin.organizations.addMember.searchLabel": {
+    "text": "Wāhitau īmēra, tuakiri pūkete rānei",
+    "source_hash": "82b3040b"
+  },
+  "web.admin.organizations.addMember.searchPlaceholder": {
+    "text": "Rapu mā te wāhitau īmēra",
+    "source_hash": "b75cc66c"
+  },
+  "web.admin.organizations.addMember.searchHint": {
+    "text": "Ka ōrite ki tētahi wāhanga o te wāhitau īmēra, ki tētahi tuakiri pūkete tika rānei.",
+    "source_hash": "84547a60"
+  },
+  "web.admin.organizations.addMember.searchError": {
+    "text": "Kāore i taea te rapu i ngā pūkete. Tirohia te hononga, ka ngana anō.",
+    "source_hash": "4b6caa41"
+  },
+  "web.admin.organizations.addMember.searchParseError": {
+    "text": "I whakahoki te rapunga pūkete i tētahi whakautu ohorere. Kāore pea i oti ngā hua.",
+    "source_hash": "0c814231"
+  },
+  "web.admin.organizations.addMember.idle": {
+    "text": "Whakauru wāhitau īmēra kia kitea ai te pūkete.",
+    "source_hash": "f6340d35"
+  },
+  "web.admin.organizations.addMember.noResults": {
+    "text": "Kāore he pūkete e ōrite ana ki \"{term}\".",
+    "source_hash": "199b662a"
+  },
+  "web.admin.organizations.addMember.noResultsHint": {
+    "text": "Ko ngā pūkete kua noho anake ka taea te tāpiri i konei. Mēnā kāore anō te tangata i waitohu, pōwhiritia kē.",
+    "source_hash": "ee90aeeb"
+  },
+  "web.admin.organizations.addMember.select": {
+    "text": "Kōwhiri",
+    "source_hash": "2a78025d"
+  },
+  "web.admin.organizations.addMember.selectedEyebrow": {
+    "text": "Pūkete kua kōwhiria",
+    "source_hash": "8b63d947"
+  },
+  "web.admin.organizations.addMember.change": {
+    "text": "Kōwhiria he pūkete kē",
+    "source_hash": "d4fe39ab"
+  },
+  "web.admin.organizations.addMember.createdOn": {
+    "text": "I waitohu {date}",
+    "source_hash": "cfc0e19f"
+  },
+  "web.admin.organizations.addMember.organizationsUnavailable": {
+    "text": "Kāore i taea te uta i ngā whakahaere o nāianei o tēnei pūkete.",
+    "source_hash": "a35b6bfc"
+  },
+  "web.admin.organizations.addMember.defaultOrg": {
+    "text": "taunoa",
+    "source_hash": "37a8eec1"
+  },
+  "web.admin.organizations.addMember.roleLabel": {
+    "text": "Tūranga i tēnei whakahaere",
+    "source_hash": "817475fa"
+  },
+  "web.admin.organizations.addMember.submit": {
+    "text": "Tāpiri ki te whakahaere",
+    "source_hash": "0e0cb636"
+  },
+  "web.admin.organizations.addMember.success": {
+    "text": "Kua tāpiri {account} hei {role}.",
+    "source_hash": "533be0dc"
+  },
+  "web.admin.organizations.addMember.badges.verified": {
+    "text": "Kua whakaūngia",
+    "source_hash": "4f783840"
+  },
+  "web.admin.organizations.addMember.badges.unverified": {
+    "text": "Kāore anō kia whakaūngia",
+    "source_hash": "15133907"
+  },
+  "web.admin.organizations.addMember.badges.suspended": {
+    "text": "Kua whakatārewahia",
+    "source_hash": "e392a389"
+  },
+  "web.admin.organizations.addMember.badges.alreadyMember": {
+    "text": "He mema kē",
+    "source_hash": "1739ed7c"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMember": {
+    "text": "He mema kē tēnei pūkete o tēnei whakahaere, me te tūranga {role}. Kāore te tāpiri e huri i te tūranga kua noho — whakamahia te mahi whakatū-tūranga mō tērā.",
+    "source_hash": "cb6a4774"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMemberUnknownRole": {
+    "text": "He mema kē tēnei pūkete o tēnei whakahaere. Kāore te tāpiri e huri i te tūranga kua noho.",
+    "source_hash": "035641ec"
+  },
+  "web.admin.organizations.addMember.errors.notFound": {
+    "text": "Kāore kē taua pūkete, whakahaere rānei i te noho. Rapua anō kia whakaū ai i te pūkete.",
+    "source_hash": "bd88db18"
+  },
+  "web.admin.organizations.addMember.errors.invalidRole": {
+    "text": "I whakahēngia taua tūranga. Kōwhiria tētahi o ngā tūranga kua rārangihia, ka ngana anō.",
+    "source_hash": "eb696a8f"
+  },
+  "web.admin.organizations.addMember.errors.noSelection": {
+    "text": "Kāore he pūkete i kōwhiria.",
+    "source_hash": "dd15bb5b"
+  },
+  "web.admin.organizations.addMember.fields.created": {
+    "text": "I waitohu",
+    "source_hash": "486b3fe0"
+  },
+  "web.admin.organizations.addMember.fields.verified": {
+    "text": "Whakaūnga",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.organizations.addMember.fields.lastLogin": {
+    "text": "Takiuru whakamutunga",
+    "source_hash": "0b70af7a"
+  },
+  "web.admin.organizations.addMember.fields.organizations": {
+    "text": "Ngā whakahaere o nāianei",
+    "source_hash": "cbb5b92f"
+  },
+  "web.admin.organizations.addMember.roleHints.member": {
+    "text": "Uru o ia rā ki ngā karere huna me ngā rohe o te whakahaere.",
+    "source_hash": "d0c7439e"
+  },
+  "web.admin.organizations.addMember.roleHints.admin": {
+    "text": "Ka taea te whakahaere i ngā mema, rohe, me ngā tautuhinga whakahaere.",
+    "source_hash": "beaa50d7"
+  },
+  "web.admin.organizations.addMember.roleHints.owner": {
+    "text": "Mana katoa, tae atu ki te utu. Tukua tēnei ina tonoa anake.",
+    "source_hash": "614ace63"
+  },
+  "web.admin.organizations.addMember.roles.member": {
+    "text": "Mema",
+    "source_hash": "7c968fb7"
+  },
+  "web.admin.organizations.addMember.roles.admin": {
+    "text": "Kaiwhakahaere",
+    "source_hash": "c1c224b0"
+  },
+  "web.admin.organizations.addMember.roles.owner": {
+    "text": "Rangatira",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.detail.members.openCustomer": {
+    "text": "Whakatuwherahia te pūkete kiritaki",
+    "source_hash": "c057ca13"
+  },
+  "web.admin.organizations.detail.reconcile.memberships": {
+    "text": "Ngā mematanga kua whakaatu-anō:",
+    "source_hash": "fe7db10c"
+  },
+  "web.admin.organizations.detail.reconcile.membershipsFailed": {
+    "text": "i rahua, kei te noho tonu ngā tika tawhito:",
+    "source_hash": "cc4dae37"
+  },
+  "web.admin.organizations.entitlements.catalogWarning": {
+    "text": "Kāore \"{entitlement}\" i te rārangi utu — tirohia he hapa pato. Ka haere tonu: ka tautokohia te tuku tika kāore i te rārangi o nāianei, ā, kāore e aukatingia.",
+    "source_hash": "cbde548a"
+  },
+  "web.admin.organizations.entitlements.matrix.caption": {
+    "text": "Poukapa whakatau tika: mahere, ngā tuku whakakore me ngā whakakore, te huinga whakatau, me ngā mea kua whakaatuhia.",
+    "source_hash": "9eac8999"
+  },
+  "web.admin.organizations.entitlements.matrix.yes": {
+    "text": "Āe",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.matrix.no": {
+    "text": "Kāo",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.matrix.empty": {
+    "text": "Kāore he tika o tēnei whakahaere mai i tōna mahere, kāore hoki he whakakore.",
+    "source_hash": "f6cf2169"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.entitlement": {
+    "text": "Tika",
+    "source_hash": "0d8f0b2d"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.inPlan": {
+    "text": "I te mahere",
+    "source_hash": "e2222361"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.granted": {
+    "text": "Kua tukuna",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.revoked": {
+    "text": "Kua whakahēngia",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.expected": {
+    "text": "E tūmanakohia ana",
+    "source_hash": "ca99b7f1"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.materialized": {
+    "text": "Kua whakaatuhia",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.state": {
+    "text": "Tūnga",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.formula": {
+    "text": "Whakatau: e tūmanakohia ana = (mahere ∪ tuku) − whakakore. Ko te whakaatuhia ko ngā mea kua rokirokitia i runga i te whakahaere.",
+    "source_hash": "bc4bff2d"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.orphaned": {
+    "text": "Pani — kua whakaatuhia engari kāore i tūmanakohia, ko te tikanga i mahue i tētahi whakakore kāore anō i whakaatu-anō. Ka tangohia e te whakatika.",
+    "source_hash": "3a27a9af"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.missing": {
+    "text": "Ngaro — e tūmanakohia ana engari kāore i whakaatuhia. Ko tēnei te whakaaetanga kāore ngā mema i te whai i tēnei wā.",
+    "source_hash": "485e44ad"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.revoked": {
+    "text": "Ko ngā rārangi poro-wawae kua whakahēngia e tētahi whakakore kaiwhakahaere, e tango ana i a rātou mai i te huinga e tūmanakohia ana.",
+    "source_hash": "89a2e9b6"
+  },
+  "web.admin.organizations.entitlements.matrix.state.plan": {
+    "text": "Mai i te mahere",
+    "source_hash": "1d346b26"
+  },
+  "web.admin.organizations.entitlements.matrix.state.granted": {
+    "text": "Kua tukuna",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.state.revoked": {
+    "text": "Kua whakahēngia",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.state.orphaned": {
+    "text": "Pani",
+    "source_hash": "8d827807"
+  },
+  "web.admin.organizations.entitlements.matrix.state.missing": {
+    "text": "Ngaro",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.organizations.entitlements.picker.selectPlaceholder": {
+    "text": "Kōwhiria he tika…",
+    "source_hash": "53af3be8"
+  },
+  "web.admin.organizations.entitlements.picker.other": {
+    "text": "Kē atu — kāore i te rārangi…",
+    "source_hash": "f08bc3a3"
+  },
+  "web.admin.organizations.entitlements.picker.customLabel": {
+    "text": "Ingoa tika (kāore i te rārangi)",
+    "source_hash": "52783229"
+  },
+  "web.admin.organizations.entitlements.picker.backToCatalog": {
+    "text": "Hoki ki te rārangi",
+    "source_hash": "9b727f40"
+  },
+  "web.admin.organizations.entitlements.picker.uncategorized": {
+    "text": "Kāore i whakarōpūhia",
+    "source_hash": "8d40d123"
+  },
+  "web.admin.organizations.entitlements.picker.catalogUnavailable": {
+    "text": "Kāore i taea te pānui i te rārangi utu, nā reira kāore e tirohia ngā ingoa tika i konei.",
+    "source_hash": "724869ec"
+  },
+  "web.admin.organizations.entitlements.picker.tags.inPlan": {
+    "text": "i te mahere",
+    "source_hash": "5f2251bb"
+  },
+  "web.admin.organizations.entitlements.picker.tags.granted": {
+    "text": "kua tukuna",
+    "source_hash": "dd515d19"
+  },
+  "web.admin.organizations.entitlements.picker.tags.revoked": {
+    "text": "kua whakahēngia",
+    "source_hash": "4bb47f18"
+  },
+  "web.admin.organizations.entitlements.summary.sync": {
+    "text": "Tukutahi",
+    "source_hash": "8d261a37"
+  },
+  "web.admin.organizations.entitlements.summary.materialized": {
+    "text": "Kua whakaatuhia",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.summary.materializedAt": {
+    "text": "I whakaatu whakamutunga",
+    "source_hash": "9325dce9"
+  },
+  "web.admin.organizations.entitlements.summary.planDefinition": {
+    "text": "Whakamāramatanga mahere",
+    "source_hash": "6b531454"
+  },
+  "web.admin.organizations.entitlements.summary.yes": {
+    "text": "Āe",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.summary.no": {
+    "text": "Kāo",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.summary.never": {
+    "text": "Kore rawa",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.organizations.entitlements.summary.planStale": {
+    "text": "Kua huri mai i te whakaatuhanga",
+    "source_hash": "e682d8a4"
+  },
+  "web.admin.organizations.entitlements.summary.planCurrent": {
+    "text": "O nāianei",
+    "source_hash": "e0d1b682"
+  },
+  "web.admin.organizations.entitlements.summary.planUnknown": {
+    "text": "Kāore e mōhiotia — kāore i taea te whakataurite",
+    "source_hash": "b607e540"
   }
 }

--- a/locales/content/mi_NZ/admin-secrets.json
+++ b/locales/content/mi_NZ/admin-secrets.json
@@ -1,11 +1,11 @@
 {
   "web.admin.secrets.title": {
-    "text": "Ngā Karere Huna",
-    "source_hash": "d8707d41"
+    "text": "Ngā Rihīti Karere Huna",
+    "source_hash": "a8a2d0e4"
   },
   "web.admin.secrets.description": {
-    "text": "Tirohia te rīhiti o tētahi karere huna, ka mukua me te kore SSH — rapua mā tōna kī.",
-    "source_hash": "07775a11"
+    "text": "Tirohia te tūnga, ngā waitohu wā, rihīti, mea kē atu.",
+    "source_hash": "91fba2a1"
   },
   "web.admin.secrets.never": {
     "text": "Kāore rawa",
@@ -108,20 +108,20 @@
     "source_hash": "504101bc"
   },
   "web.admin.secrets.lookup.resultTitle": {
-    "text": "Karere huna {shortid}",
-    "source_hash": "8b311d32"
+    "text": "Pūkete karere huna {shortid}",
+    "source_hash": "ee06d765"
   },
   "web.admin.secrets.lookup.notFound": {
-    "text": "Kāore i kitea te karere huna",
-    "source_hash": "70a9532c"
+    "text": "Kāore i kitea he pūkete",
+    "source_hash": "40f4d9e9"
   },
   "web.admin.secrets.lookup.notFoundDescription": {
     "text": "Kāore he karere huna e ora ana mā tēnei kī. Kua pau pea, kua mukua rānei.",
     "source_hash": "9f068a81"
   },
   "web.admin.secrets.lookup.loadError": {
-    "text": "Kāore i taea te uta i tēnei karere huna.",
-    "source_hash": "c96672e4"
+    "text": "Kāore i taea te uta i tēnei pūkete.",
+    "source_hash": "de77cc72"
   },
   "web.admin.secrets.lookup.retry": {
     "text": "Ngana anō",
@@ -188,8 +188,8 @@
     "source_hash": "c127dab6"
   },
   "web.admin.secrets.sections.secret": {
-    "text": "Karere Huna",
-    "source_hash": "7e32a729"
+    "text": "Pūkete karere huna",
+    "source_hash": "263813c6"
   },
   "web.admin.secrets.sections.receipt": {
     "text": "Rīhiti",
@@ -214,5 +214,25 @@
   "web.admin.secrets.state.viewed": {
     "text": "Kua Tirohia",
     "source_hash": "1b28d178"
+  },
+  "web.admin.secrets.capability.title": {
+    "text": "Raraunga meta anake",
+    "source_hash": "df0453d1"
+  },
+  "web.admin.secrets.capability.canRead": {
+    "text": "Ka pānui i ngā raraunga meta me te rihīti o te karere huna: tūnga, waitohu wā, rangatira, me te rahi o te kuputuhi muhumuhu kua rokirokitia.",
+    "source_hash": "d438ecc7"
+  },
+  "web.admin.secrets.capability.cannotRead": {
+    "text": "Kāore e taea te wetewete, te whakaatu rānei i ngā ihirangi karere huna. Kāore te pito mutunga i muri i tēnei mata e whakahoki ana i a ia.",
+    "source_hash": "7f69f222"
+  },
+  "web.admin.secrets.capability.canDelete": {
+    "text": "Ka taea te muku pūmau i te karere huna me tōna rihīti, ka whakangaro i ngā ihirangi kāore i te whakaatu.",
+    "source_hash": "77f2bc7e"
+  },
+  "web.admin.secrets.lookup.hint": {
+    "text": "Te tuakiri mai i te hononga o te karere huna — ehara i te ihirangi karere huna.",
+    "source_hash": "acfbc352"
   }
 }

--- a/locales/content/mi_NZ/admin-system.json
+++ b/locales/content/mi_NZ/admin-system.json
@@ -154,5 +154,133 @@
   "web.admin.system.redis.captured": {
     "text": "I hopukina {at}",
     "source_hash": "57b40c0f"
+  },
+  "web.admin.system.brand.title": {
+    "text": "Ngā Arowhai Waitohu",
+    "source_hash": "1cf9abd5"
+  },
+  "web.admin.system.brand.description": {
+    "text": "Ko tēhea pēke waitohu i whakatau te tauira e whakahaere ana i runga i te kōpae — ka whakaatu he aha te rohe e tuku ana i te waitohu whakakore.",
+    "source_hash": "be29e282"
+  },
+  "web.admin.system.brand.loadError": {
+    "text": "Kāore i taea te uta i ngā arowhai waitohu.",
+    "source_hash": "80607303"
+  },
+  "web.admin.system.brand.none": {
+    "text": "(kore)",
+    "source_hash": "552e4230"
+  },
+  "web.admin.system.brand.resolution": {
+    "text": "Whakataunga",
+    "source_hash": "d4055faf"
+  },
+  "web.admin.system.brand.envVsConfig": {
+    "text": "Taiao vs Whirihoranga",
+    "source_hash": "bee3debb"
+  },
+  "web.admin.system.brand.absorbed": {
+    "text": "Ngā Kī Kua Ngongohia",
+    "source_hash": "9784e110"
+  },
+  "web.admin.system.brand.operatorKeys": {
+    "text": "Ngā Kī Kaiwhakahaere",
+    "source_hash": "434e8248"
+  },
+  "web.admin.system.brand.overlayAssets": {
+    "text": "Ngā Rawa Papamuri",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.exists.yes": {
+    "text": "Kei te noho",
+    "source_hash": "43f9b89c"
+  },
+  "web.admin.system.brand.exists.no": {
+    "text": "Ngaro",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.system.brand.fields.resolvedDir": {
+    "text": "Whaiaronga Kua Whakatau",
+    "source_hash": "0623b983"
+  },
+  "web.admin.system.brand.fields.home": {
+    "text": "Kāinga",
+    "source_hash": "3a786953"
+  },
+  "web.admin.system.brand.fields.envPack": {
+    "text": "Pēke Waitohu ENV",
+    "source_hash": "940aeb5c"
+  },
+  "web.admin.system.brand.fields.configPack": {
+    "text": "Pēke Waitohu Whirihoranga",
+    "source_hash": "761b9550"
+  },
+  "web.admin.system.brand.fields.envAssetsDir": {
+    "text": "Whaiaronga Rawa Waitohu ENV",
+    "source_hash": "05854f1f"
+  },
+  "web.admin.system.brand.fields.configAssetsDir": {
+    "text": "Whaiaronga Rawa Waitohu Whirihoranga",
+    "source_hash": "e91e5c46"
+  },
+  "web.admin.system.brand.flags.fellBack.danger": {
+    "text": "I hoki ki te pēke taunoa",
+    "source_hash": "7bf7ba2f"
+  },
+  "web.admin.system.brand.flags.fellBack.ok": {
+    "text": "Kua whakatau te pēke waitohu",
+    "source_hash": "1ab3162f"
+  },
+  "web.admin.system.brand.flags.mismatch.danger": {
+    "text": "Kāore i ōrite te tīmata / ora",
+    "source_hash": "0a022192"
+  },
+  "web.admin.system.brand.flags.mismatch.ok": {
+    "text": "Kua ōrite te tīmata ki te ora",
+    "source_hash": "d4792c09"
+  },
+  "web.admin.system.brand.manifest.title": {
+    "text": "Whakaaturanga",
+    "source_hash": "3c99f1f3"
+  },
+  "web.admin.system.brand.manifest.path": {
+    "text": "Ara",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.manifest.exists": {
+    "text": "Kei te noho",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.manifest.keysOnDisk": {
+    "text": "Ngā Kī i runga i te Kōpae",
+    "source_hash": "52439c03"
+  },
+  "web.admin.system.brand.roots.title": {
+    "text": "Ngā Pūtake Rapu",
+    "source_hash": "d8696f2b"
+  },
+  "web.admin.system.brand.roots.empty": {
+    "text": "Kāore he pūtake rapu",
+    "source_hash": "867a471c"
+  },
+  "web.admin.system.brand.roots.columns.path": {
+    "text": "Ara",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.roots.columns.exists": {
+    "text": "Kei te noho",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.stats.brandPack": {
+    "text": "Pēke Waitohu",
+    "source_hash": "884437d0"
+  },
+  "web.admin.system.brand.stats.overlayAssets": {
+    "text": "Ngā Rawa Papamuri",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.stats.manifestKeys": {
+    "text": "Ngā Kī Whakaaturanga",
+    "source_hash": "c4267198"
   }
 }

--- a/locales/content/mi_NZ/email.json
+++ b/locales/content/mi_NZ/email.json
@@ -870,7 +870,7 @@
     "source_hash": "dc75bf9f"
   },
   "email.sso_link_verification.postscript": {
-    "text": "R.M. I tukuna tēnei īmēra ki %{email_address}.",
+    "text": "P.S. I tukuna tēnei īmēra ki %{email_address}.",
     "source_hash": "8ab1dbea"
   }
 }

--- a/locales/content/mi_NZ/email.json
+++ b/locales/content/mi_NZ/email.json
@@ -836,5 +836,41 @@
   "email.secret_link.footer_note": {
     "text": "I whiwhi koe i tēnei nā te mea i whakamahi a %{sender_email} i %{product_name} ki te tiri karere huna ki a koe. Ki te kore koe i te tatari ki tēnei, ka taea e koe te waiho noa i tēnei īmēra.",
     "source_hash": "2d544dad"
+  },
+  "email.sso_link_verification.subject": {
+    "text": "Whakaūngia te hono i a %{provider} ki tō pūkete %{product_name}",
+    "source_hash": "65e70296"
+  },
+  "email.sso_link_verification.title": {
+    "text": "Whakaūngia tō takiuru SSO",
+    "source_hash": "35bce6cc"
+  },
+  "email.sso_link_verification.request_notice": {
+    "text": "I takiuru tētahi mā %{provider} mā te īmēra %{email_address}. Hei whakaoti i te hono i a %{provider} ki tō pūkete %{product_name}, whakaūngia i raro nei.",
+    "source_hash": "baeb18c0"
+  },
+  "email.sso_link_verification.confirm_button": {
+    "text": "Whakaū, honoa %{provider}",
+    "source_hash": "9809e210"
+  },
+  "email.sso_link_verification.copy_link_prompt": {
+    "text": "Tāruatia rānei, whakapiri i tēnei hononga:",
+    "source_hash": "88c72144"
+  },
+  "email.sso_link_verification.expiration_notice": {
+    "text": "Ka pau te wā o tēnei hononga i roto i te 15 meneti, kotahi noa te wā e taea ai te whakamahi.",
+    "source_hash": "1a437f42"
+  },
+  "email.sso_link_verification.ignore_notice": {
+    "text": "Mēnā kāore koe i ngana ki te takiuru mā %{provider}, whakakore noa i tēnei īmēra — kāore he mea ka honoa ki tō pūkete.",
+    "source_hash": "d7317d30"
+  },
+  "email.sso_link_verification.signature": {
+    "text": "Te Tīma Tautoko",
+    "source_hash": "dc75bf9f"
+  },
+  "email.sso_link_verification.postscript": {
+    "text": "R.M. I tukuna tēnei īmēra ki %{email_address}.",
+    "source_hash": "8ab1dbea"
   }
 }

--- a/locales/content/mi_NZ/session-auth-extended.json
+++ b/locales/content/mi_NZ/session-auth-extended.json
@@ -730,5 +730,201 @@
   "web.auth.sessions.session_plural": {
     "text": "ngā wātū",
     "source_hash": "1225ae6c"
+  },
+  "web.auth.connections.title": {
+    "text": "Ngā Tuakiri Hono",
+    "source_hash": "e132c4d9"
+  },
+  "web.auth.connections.description": {
+    "text": "Whakahaerea ngā kaiwhakarato takiuru-kotahi kua hono ki tō pūkete.",
+    "source_hash": "42c6d148"
+  },
+  "web.auth.connections.section_title": {
+    "text": "Takiuru-kotahi",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.section_subtitle": {
+    "text": "Ngā kaiwhakarato tuakiri ka taea e koe te whakamahi hei takiuru ki tēnei pūkete",
+    "source_hash": "507254cd"
+  },
+  "web.auth.connections.connect_title": {
+    "text": "Hono he kaiwhakarato",
+    "source_hash": "a002b3f3"
+  },
+  "web.auth.connections.connect_description": {
+    "text": "Honoa he kaiwhakarato takiuru-kotahi anō ka taea e koe te whakamahi hei takiuru ki tēnei pūkete.",
+    "source_hash": "32895a5a"
+  },
+  "web.auth.connections.connect_action": {
+    "text": "Honoa {provider}",
+    "source_hash": "c77540af"
+  },
+  "web.auth.connections.issuer": {
+    "text": "Kaiwhakaputa",
+    "source_hash": "39e02c46"
+  },
+  "web.auth.connections.identifier": {
+    "text": "Tuakiri",
+    "source_hash": "9b10587f"
+  },
+  "web.auth.connections.remove": {
+    "text": "Tangohia",
+    "source_hash": "c3812fc4"
+  },
+  "web.auth.connections.remove_confirm_title": {
+    "text": "Tangohia te tuakiri hono",
+    "source_hash": "4e8ffe4c"
+  },
+  "web.auth.connections.remove_confirm_message": {
+    "text": "Kei te tino hiahia koe ki te tango i tēnei tuakiri hono? Kāore e taea e koe te takiuru mā tēnei.",
+    "source_hash": "64939c89"
+  },
+  "web.auth.connections.removed_success": {
+    "text": "Kua tangohia te tuakiri hono",
+    "source_hash": "cf87daf3"
+  },
+  "web.auth.connections.no_identities": {
+    "text": "Kāore he tuakiri hono",
+    "source_hash": "5254048e"
+  },
+  "web.auth.connections.no_identities_description": {
+    "text": "Kāore anō koe i hono i tētahi kaiwhakarato takiuru-kotahi ki tēnei pūkete.",
+    "source_hash": "0f58d5d0"
+  },
+  "web.auth.connections.overview_status": {
+    "text": "Takiuru-kotahi",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.errors.last_credential": {
+    "text": "Ko tēnei tō huarahi takiuru anake. Honoa he kaiwhakarato kē i te tuatahi, whakatūria rānei he kupuhipa mai i Tautuhinga → Haumarutanga, kia kore ai koe e rakaina ki waho.",
+    "source_hash": "3de8084d"
+  },
+  "web.auth.connections.errors.last_credential_sso_enforced": {
+    "text": "Ko tēnei tō huarahi takiuru anake. Honoa he kaiwhakarato kē i te tuatahi kia kore ai koe e rakaina ki waho.",
+    "source_hash": "eed7a50e"
+  },
+  "web.auth.connections.errors.not_found": {
+    "text": "Kāore i kitea taua tuakiri hono. Tērā pea kua tangohia kē.",
+    "source_hash": "cf2c7673"
+  },
+  "web.auth.connections.errors.unauthorized": {
+    "text": "Kua pau te wā o tō hōtaka. Takiurua anō.",
+    "source_hash": "b529fce2"
+  },
+  "web.auth.connections.errors.generic": {
+    "text": "Kāore i taea te whakaoti i taua mahi. Ngana anō.",
+    "source_hash": "a0d4edc0"
+  },
+  "web.link_sso.title": {
+    "text": "Honoa tō tikanga takiuru",
+    "source_hash": "46339bac"
+  },
+  "web.link_sso.prompt": {
+    "text": "I takiuru koe mā {provider}, e ōrite ana ki te pūkete {email} kua noho. Whakauru te kupuhipa o taua pūkete hei hono i a {provider}, ka haere tonu.",
+    "source_hash": "59da1c08"
+  },
+  "web.link_sso.password_label": {
+    "text": "Kupuhipa",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.link_sso.password_placeholder": {
+    "text": "Tō kupuhipa kua noho",
+    "source_hash": "ad4e56da"
+  },
+  "web.link_sso.submit": {
+    "text": "Honoa, haere tonu",
+    "source_hash": "c969b759"
+  },
+  "web.link_sso.cancel": {
+    "text": "Whakakore",
+    "source_hash": "19766ed6"
+  },
+  "web.link_sso.unavailable_title": {
+    "text": "Kua pau te wā o tēnei tono hono",
+    "source_hash": "b53c7e55"
+  },
+  "web.link_sso.unavailable_message": {
+    "text": "Mō tō haumarutanga, kāore kē te tono hono i tēnei tikanga takiuru e whaimana ana. Takiurua mā tō kupuhipa kua noho, kātahi honoa tēnei kaiwhakarato i raro i ngā tautuhinga Haumarutanga → Ngā tuakiri hono.",
+    "source_hash": "f7e349d1"
+  },
+  "web.link_sso.unavailable_action": {
+    "text": "Haere tonu ki te takiuru",
+    "source_hash": "d398cd0a"
+  },
+  "web.link_sso.errors.invalid_password": {
+    "text": "Kāore taua kupuhipa e ōrite ana ki tēnei pūkete. Ngana anō.",
+    "source_hash": "3259b4f5"
+  },
+  "web.link_sso.errors.invalid_token": {
+    "text": "Kua pau te wā o tēnei tono hono, kua whakamahia kē rānei. Takiurua mā tō kupuhipa kua noho, kātahi honoa tēnei kaiwhakarato mai i ō tautuhinga pūkete.",
+    "source_hash": "541f9127"
+  },
+  "web.link_sso.errors.link_conflict": {
+    "text": "Kāore i taea te hono i tēnei tikanga takiuru. Tērā pea kua huri tō pūkete, kua hono kē rānei tēnei kaiwhakarato ki tētahi pūkete kē. Takiurua mā tō kupuhipa kua noho, kātahi whakahaerea ngā hononga i raro i ngā tautuhinga Haumarutanga → Ngā tuakiri hono.",
+    "source_hash": "7b0e0d0e"
+  },
+  "web.link_sso.errors.link_rate_limited": {
+    "text": "He nui rawa ngā ngana kupuhipa. Tatari mō ētahi meneti, kātahi ngana anō.",
+    "source_hash": "a95e78cd"
+  },
+  "web.link_sso.errors.invalid_request": {
+    "text": "Kāore i taea te whakahaere i tēnei tono hono. Takiurua mā tō kaiwhakarato SSO anō.",
+    "source_hash": "053b9fc6"
+  },
+  "web.link_sso.errors.generic": {
+    "text": "Kāore i taea te hono i tō pūkete. Ngana anō.",
+    "source_hash": "f727c174"
+  },
+  "web.sso_link_confirm.title": {
+    "text": "Whakaūngia te hono i tō pūkete",
+    "source_hash": "ad80bfe7"
+  },
+  "web.sso_link_confirm.prompt": {
+    "text": "I takiuru koe mā {provider}, e ōrite ana ki tō pūkete {email}. Whakaūngia kia hono i a {provider} ki tēnei pūkete, ka whakaoti i te takiuru.",
+    "source_hash": "6ff0d6cc"
+  },
+  "web.sso_link_confirm.submit": {
+    "text": "Whakaū, honoa",
+    "source_hash": "5cf663e6"
+  },
+  "web.sso_link_confirm.cancel": {
+    "text": "Whakakore",
+    "source_hash": "19766ed6"
+  },
+  "web.sso_link_confirm.unavailable_title": {
+    "text": "Kāore e taea te whakaoti i tēnei tono hono",
+    "source_hash": "47abb784"
+  },
+  "web.sso_link_confirm.unavailable_message": {
+    "text": "Mō tō haumarutanga, kāore kē tēnei tono hono i tō tikanga takiuru e whaimana ana. Takiurua mā tō kaiwhakarato anō, ka tuku mātou he hononga hou ki tō īmēra.",
+    "source_hash": "080e6f9f"
+  },
+  "web.sso_link_confirm.unavailable_action": {
+    "text": "Hoki ki te takiuru",
+    "source_hash": "8504054f"
+  },
+  "web.sso_link_confirm.errors.link_expired": {
+    "text": "Kua pau te wā o tēnei tono hono, kua whakamahia kē rānei. Takiurua mā tō kaiwhakarato anō, ka tuku mātou he hononga hou ki tō īmēra.",
+    "source_hash": "a50538df"
+  },
+  "web.sso_link_confirm.errors.link_conflict": {
+    "text": "Kāore i taea te hono i tēnei tikanga takiuru. Tērā pea kua huri tō pūkete, kua hono kē rānei tēnei kaiwhakarato ki tētahi pūkete kē. Takiurua mā tō kaiwhakarato anō kia haere tonu.",
+    "source_hash": "c954854b"
+  },
+  "web.sso_link_confirm.errors.link_invalidated": {
+    "text": "I huri ō taipitopito pūkete i muri i te tukutanga o tēnei hononga, nā reira kāore kē e whaimana ana. Takiurua mā tō kaiwhakarato anō, ka tuku mātou he hononga hou ki tō īmēra.",
+    "source_hash": "db88cb1d"
+  },
+  "web.sso_link_confirm.errors.link_error": {
+    "text": "I hē tētahi mea i tō mātou taha, kāore i taea te whakaū i tēnei hononga. Takiurua mā tō kaiwhakarato anō, ka tuku mātou he mea hou ki tō īmēra.",
+    "source_hash": "ec24e0a1"
+  },
+  "web.sso_link_confirm.errors.confirm_rate_limited": {
+    "text": "He nui rawa ngā ngana mai i tō pūrere. Tatari mō ētahi meneti, kātahi whakatuwherahia anō te hononga i īmēratia, takiurua rānei mā tō kaiwhakarato mō tētahi mea hou.",
+    "source_hash": "f29af782"
+  },
+  "web.sso_link_confirm.errors.generic": {
+    "text": "Kāore i taea te whakaū i tēnei hononga. Takiurua mā tō kaiwhakarato anō.",
+    "source_hash": "076fa25a"
   }
 }

--- a/locales/content/mi_NZ/session-auth-extended.json
+++ b/locales/content/mi_NZ/session-auth-extended.json
@@ -757,6 +757,7 @@
   },
   "web.auth.connections.connect_action": {
     "text": "Honoa {provider}",
+    "context": "Button label to start linking a specific SSO provider; {provider} is the provider display name",
     "source_hash": "c77540af"
   },
   "web.auth.connections.issuer": {
@@ -821,6 +822,7 @@
   },
   "web.link_sso.prompt": {
     "text": "I takiuru koe mā {provider}, e ōrite ana ki te pūkete {email} kua noho. Whakauru te kupuhipa o taua pūkete hei hono i a {provider}, ka haere tonu.",
+    "context": "Instruction on the sign-in interstitial. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/link-sso/:token.",
     "source_hash": "59da1c08"
   },
   "web.link_sso.password_label": {
@@ -881,6 +883,7 @@
   },
   "web.sso_link_confirm.prompt": {
     "text": "I takiuru koe mā {provider}, e ōrite ana ki tō pūkete {email}. Whakaūngia kia hono i a {provider} ki tēnei pūkete, ka whakaoti i te takiuru.",
+    "context": "Consent instruction on the #3840 Phase 4 mailbox-proof SSO linking page. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/sso-link-confirm/:token. No password is asked — clicking the emailed link is the proof.",
     "source_hash": "6ff0d6cc"
   },
   "web.sso_link_confirm.submit": {

--- a/locales/content/mi_NZ/session-auth.json
+++ b/locales/content/mi_NZ/session-auth.json
@@ -483,5 +483,41 @@
   "web.login.verified_notice": {
     "text": "Kua manatokona tō īmēra — ka taea e koe te takiuru ināianei.",
     "source_hash": "c8d4b5a8"
+  },
+  "web.auth.password_setup_request.title": {
+    "text": "Whakatū Kupuhipa",
+    "source_hash": "11b6978b"
+  },
+  "web.auth.password_setup_request.description": {
+    "text": "Kāore anō tō pūkete he kupuhipa. Ka tuku mātou he hononga haumaru ki tō īmēra hei whakatū i tētahi kia taea ai e koe te takiuru tika.",
+    "source_hash": "dc0b561f"
+  },
+  "web.auth.password_setup_request.button": {
+    "text": "Tukuna Hononga Whakatū",
+    "source_hash": "22807292"
+  },
+  "web.auth.password_setup_request.emailSent": {
+    "text": "Kua tukuna he īmēra ki a koe me te hononga hei whakatū kupuhipa mō tō pūkete",
+    "source_hash": "82b686c7"
+  },
+  "web.login.errors.account_exists_link_required": {
+    "text": "He pūkete kua noho me tēnei wāhitau īmēra, engari kāore i hono ki tēnei tikanga takiuru. Takiurua mā tō tikanga kua noho, kātahi honoa tēnei kaiwhakarato i raro i ngā tautuhinga Haumarutanga → Ngā tuakiri hono.",
+    "source_hash": "7fbbb7e7"
+  },
+  "web.login.errors.identity_connect_conflict": {
+    "text": "Kāore i taea te hono i tēnei tuakiri. Tērā pea i tīmata te hononga i te rohe hē, kua pau rānei te wā o tō hōtaka. Takiurua anō, kātahi honoa mai i ō tautuhinga pūkete.",
+    "source_hash": "4238bbf2"
+  },
+  "web.login.errors.org_join_failed": {
+    "text": "Kāore i taea te whakaoti i te tāpiri i a koe ki tō whakahaere. Whakapā ki tō kaiwhakahaere.",
+    "source_hash": "155e71bb"
+  },
+  "web.login.errors.link_sso_failed": {
+    "text": "Kāore i taea te hono i taua tikanga takiuru. Takiurua mā tō kupuhipa kua noho, kātahi honoa tēnei kaiwhakarato i raro i ngā tautuhinga Haumarutanga → Ngā tuakiri hono.",
+    "source_hash": "49954127"
+  },
+  "web.login.notices.link_verification_sent": {
+    "text": "Tirohia tō pouaka tae mai — i tuku mātou he hononga ki a koe hei whakaū i te hono i tō pūkete. Whakatuwherahia kia whakaoti ai i te takiuru.",
+    "source_hash": "b251c8f3"
   }
 }

--- a/locales/content/mi_NZ/workspace-account.json
+++ b/locales/content/mi_NZ/workspace-account.json
@@ -694,5 +694,33 @@
   "web.settings.api.api_disabled_notice": {
     "text": "Kua monokia te API mō tēnei taupānga.",
     "source_hash": "66d12d6b"
+  },
+  "web.settings.api.api_username": {
+    "text": "Ingoa Kaiwhakamahi API",
+    "source_hash": "0b3e483e"
+  },
+  "web.settings.api.api_username_description": {
+    "text": "Tō ingoa kaiwhakamahi mō te motuhēhē HTTP Basic",
+    "source_hash": "f3e65de3"
+  },
+  "web.settings.api.basic_auth_hint": {
+    "text": "Mō te motuhēhē HTTP Basic, whakamahia tō īmēra pūkete, tēnei tuakiri rānei hei ingoa kaiwhakamahi, me tō tōkena API hei kupuhipa.",
+    "source_hash": "cfa3806d"
+  },
+  "web.settings.security.set": {
+    "text": "Kua whakatūria",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.settings.security.not_set": {
+    "text": "Kāore i whakatūria",
+    "source_hash": "4895f731"
+  },
+  "web.settings.security.set_password_title": {
+    "text": "Whakatū kupuhipa",
+    "source_hash": "4e411687"
+  },
+  "web.settings.security.set_password_description": {
+    "text": "Tāpiri kupuhipa ki tō pūkete kia taea ai e koe te takiuru kāore he kaiwhakarato tuakiri",
+    "source_hash": "a6970402"
   }
 }

--- a/locales/content/mi_NZ/workspace-billing.json
+++ b/locales/content/mi_NZ/workspace-billing.json
@@ -1044,5 +1044,21 @@
   "web.billing.plans.reactivate": {
     "text": "Whakahohe Anō",
     "source_hash": "2dc7478f"
+  },
+  "web.billing.currency_migration.refund_failed_warning": {
+    "text": "I whakakore tō mahere o mua, engari kāore i taea te tuku aunoa i te whakahoki moni mō tō wā kāore i whakamahia. Whakapā ki te tautoko kia whiwhi i tō whakahoki moni. Me whakaoti tonu koe i te utu kia whakahohea tō mahere hou.",
+    "source_hash": "a390c498"
+  },
+  "web.billing.currency_migration.refund_failed_continue": {
+    "text": "Haere tonu ki te Utu",
+    "source_hash": "eccdb8aa"
+  },
+  "web.billing.plans.per_year": {
+    "text": "/tau",
+    "source_hash": "a2d5f1bc"
+  },
+  "web.billing.plans.billing_interval": {
+    "text": "Huringa utu",
+    "source_hash": "3ce28209"
   }
 }

--- a/locales/content/mi_NZ/workspace-branding.json
+++ b/locales/content/mi_NZ/workspace-branding.json
@@ -56,12 +56,12 @@
     "source_hash": "e36598ef"
   },
   "web.branding.example_pre_reveal_instructions": {
-    "text": "Whakamahia tō waea hei matawai i te waehere QR",
-    "source_hash": "99ecf59f"
+    "text": "hei tauira: Whakamahia tō waea hei matawai i te waehere QR",
+    "source_hash": "9cf0caf8"
   },
   "web.branding.example_post_reveal_instructions": {
-    "text": "Whakapā atu ki onboarding{'@'}example.com mō ngā pātai",
-    "source_hash": "bee120a7"
+    "text": "hei tauira: Whakapā ki onboarding{'@'}example.com mēnā he pātai",
+    "source_hash": "71749811"
   },
   "web.branding.these_instructions_will_be_shown_to_recipients_before": {
     "text": "Ka whakaaturia ēnei tohutohu ki ngā kaiwhiwhi i mua i tā rātou whakaatu i te ihirangi karere huna",
@@ -320,8 +320,8 @@
     "source_hash": "bc79cdff"
   },
   "web.branding.paths_carryover_hint": {
-    "text": "He arokite ora tēnei — kāore ō huringa e kitea e ngā manuhiri kia tiaki rā anō koe.",
-    "source_hash": "cb4b82de"
+    "text": "He arokite ora tēnei — kāore ō huringa e kitea e ngā manuhiri kia pāwhiria e koe Whakahou.",
+    "source_hash": "9a34df71"
   },
   "web.branding.coming_soon_match_blurb": {
     "text": "Tohua mai tō paetukutuku, ka pānui mātou i ōna tae me ōna momotuhi, kātahi ka kati i te āputa i te pāwhiri kotahi.",
@@ -406,5 +406,57 @@
   "web.branding.delivery_after_reveal": {
     "text": "I muri i te whakaatu",
     "source_hash": "d5bfe7fd"
+  },
+  "web.branding.favicon": {
+    "text": "Favicon",
+    "source_hash": "42955289"
+  },
+  "web.branding.refresh_favicon": {
+    "text": "Whakahou favicon mai i te rohe",
+    "source_hash": "7cc3d5dc"
+  },
+  "web.branding.refresh_favicon_hint": {
+    "text": "Tikina te favicon mai i tō rohe anō. Ka puta wawe te ata hou.",
+    "source_hash": "ee007e44"
+  },
+  "web.branding.refresh_favicon_queued": {
+    "text": "Kei te whakahou favicon — ka puta wawe te ata hou.",
+    "source_hash": "6bf38e6e"
+  },
+  "web.branding.refresh_favicon_user_upload_hint": {
+    "text": "Kua tukuake koe i tētahi favicon ritenga, nā reira kāore te ata i tikina e whakakapi.",
+    "source_hash": "c22e1ed6"
+  },
+  "web.branding.upload_favicon": {
+    "text": "Tukuake favicon",
+    "source_hash": "ceda39cb"
+  },
+  "web.branding.replace_favicon": {
+    "text": "Whakakapi",
+    "source_hash": "95e15439"
+  },
+  "web.branding.remove_favicon": {
+    "text": "Tangohia favicon",
+    "source_hash": "03693698"
+  },
+  "web.branding.favicon_field_hint": {
+    "text": "ICO, PNG, SVG rānei. Ka whakakapi te tukuake i te ata i tikina.",
+    "source_hash": "dfa0bfcb"
+  },
+  "web.branding.favicon_preview_alt": {
+    "text": "Favicon rohe",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_title": {
+    "text": "Favicon rohe",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_hint": {
+    "text": "ICO, PNG, SVG rānei. Tae noa ki te 256KB. Ka whakakapi i te ata aunoa-tikina.",
+    "source_hash": "c9eafc83"
+  },
+  "web.branding.favicon_modal_save": {
+    "text": "Tiaki favicon",
+    "source_hash": "c8a1566c"
   }
 }

--- a/locales/content/mi_NZ/workspace-organizations.json
+++ b/locales/content/mi_NZ/workspace-organizations.json
@@ -1034,5 +1034,153 @@
   "web.organizations.create_workspace": {
     "text": "Waihanga Wāhi Mahi",
     "source_hash": "c63c14cf"
+  },
+  "web.organizations.organization_id": {
+    "text": "Tuakiri Whakahaere",
+    "source_hash": "1f466322"
+  },
+  "web.organizations.organization_id_hint": {
+    "text": "Whakamahia tēnei tuakiri ina whakapā ki te tautoko, ina whakaiti rānei i ngā tono API ki tēnei whakahaere. Ehara i te taipitopito takiuru.",
+    "source_hash": "29549b3a"
+  },
+  "web.organizations.audit.title": {
+    "text": "Ngā Mahi Karere Huna",
+    "source_hash": "6d6d41f3"
+  },
+  "web.organizations.audit.description": {
+    "text": "Ara arotake o ngā takahanga waihanga me te uru karere huna kua rekoatatia mō tēnei whakahaere.",
+    "source_hash": "553c564b"
+  },
+  "web.organizations.audit.country_unknown": {
+    "text": "Kāore e mōhiotia",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.empty_title": {
+    "text": "Kāore anō he mahi",
+    "source_hash": "0a12b92c"
+  },
+  "web.organizations.audit.empty_description": {
+    "text": "Ka puta ki konei ngā takahanga waihanga me te uru karere huna i te wā e tohatoha ana tō tīma i ngā karere huna.",
+    "source_hash": "62fb14c2"
+  },
+  "web.organizations.audit.capped_notice": {
+    "text": "Ko ngā takahanga hou rawa {max} anake e pupuri ana; kua tapahia ngā mahi tawhito.",
+    "source_hash": "da7901e2"
+  },
+  "web.organizations.audit.collection_paused_notice": {
+    "text": "Kua tārewa te kohikohi takahanga; kāore ngā mahi karere huna hou e rekoatatia.",
+    "source_hash": "cb09d147"
+  },
+  "web.organizations.audit.load_error": {
+    "text": "Kāore i taea te uta i ngā mahi karere huna.",
+    "source_hash": "52fde814"
+  },
+  "web.organizations.audit.contract_mismatch": {
+    "text": "Kāore i taea te pānui i ngā raraunga mahi i whakahokia mai e te tūmau. Kāore te ara i te kau — kāore noa e taea te whakaatu i tēnei wā.",
+    "source_hash": "db0d007a"
+  },
+  "web.organizations.audit.retry": {
+    "text": "Ngana anō",
+    "source_hash": "d8b8392e"
+  },
+  "web.organizations.audit.showing_range": {
+    "text": "E whakaatu ana i te {from}–{to} o te {total}",
+    "source_hash": "c329279d"
+  },
+  "web.organizations.audit.upgrade_prompt": {
+    "text": "E hiahia ana ngā mahi karere huna ki tētahi mahere me ngā rārangi arotake. Whakapikia kia kite ai ko wai i hanga, i tiro, i whakaatu i ngā karere huna i tēnei whakahaere.",
+    "source_hash": "453649ce"
+  },
+  "web.organizations.audit.role_required": {
+    "text": "He wātea ngā mahi karere huna ki ngā rangatira me ngā kaiwhakahaere o te whakahaere.",
+    "source_hash": "e066ec63"
+  },
+  "web.organizations.audit.actors.creator": {
+    "text": "Kaihanga",
+    "source_hash": "88447b83"
+  },
+  "web.organizations.audit.actors.authenticated_other": {
+    "text": "He kaiwhakamahi takiuru kē",
+    "source_hash": "ee45aa5a"
+  },
+  "web.organizations.audit.actors.anonymous": {
+    "text": "Mōhio kore",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.organizations.audit.actors.system": {
+    "text": "Pūnaha",
+    "source_hash": "6725e7bb"
+  },
+  "web.organizations.audit.actors.unknown": {
+    "text": "Kāore e mōhiotia",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.columns.event": {
+    "text": "Takahanga",
+    "source_hash": "4e1f49a9"
+  },
+  "web.organizations.audit.columns.secret": {
+    "text": "Karere huna",
+    "source_hash": "7e32a729"
+  },
+  "web.organizations.audit.columns.actor": {
+    "text": "Kaimahi",
+    "source_hash": "449995c4"
+  },
+  "web.organizations.audit.columns.country": {
+    "text": "Whenua",
+    "source_hash": "701d021d"
+  },
+  "web.organizations.audit.columns.when": {
+    "text": "Āhea",
+    "source_hash": "cf9c7aa2"
+  },
+  "web.organizations.audit.kinds.created": {
+    "text": "Kua hangaia te karere huna",
+    "source_hash": "e4a1e1fd"
+  },
+  "web.organizations.audit.kinds.status_get": {
+    "text": "Kua tirohia te tūnga hononga",
+    "source_hash": "0753f60e"
+  },
+  "web.organizations.audit.kinds.secret_get": {
+    "text": "Kua whakatūwhera te hononga karere huna",
+    "source_hash": "e271e060"
+  },
+  "web.organizations.audit.kinds.previewed": {
+    "text": "Kua arokitea e te kaihanga",
+    "source_hash": "639fc1e2"
+  },
+  "web.organizations.audit.kinds.creator_status_get": {
+    "text": "Kua tirohia te tūnga e te kaihanga",
+    "source_hash": "7e4b5de5"
+  },
+  "web.organizations.audit.kinds.receipt_viewed": {
+    "text": "Kua tirohia te rihīti",
+    "source_hash": "a417ead4"
+  },
+  "web.organizations.audit.kinds.revealed": {
+    "text": "Kua whakaatuhia te karere huna",
+    "source_hash": "aff2c84d"
+  },
+  "web.organizations.audit.kinds.burned": {
+    "text": "Kua whakawarekia te karere huna",
+    "source_hash": "5ac68dc6"
+  },
+  "web.organizations.audit.kinds.expired": {
+    "text": "Kua pau te wā o te karere huna",
+    "source_hash": "c127dab6"
+  },
+  "web.organizations.audit.kinds.orphaned": {
+    "text": "Kua pani te karere huna",
+    "source_hash": "23fe1a47"
+  },
+  "web.organizations.audit.kinds.reveal_failed_undecryptable": {
+    "text": "I rahua te whakaatu (kāore e taea te wetewete)",
+    "source_hash": "d5616abf"
+  },
+  "web.organizations.tabs.activity": {
+    "text": "Ngā mahi",
+    "source_hash": "38da1505"
   }
 }


### PR DESCRIPTION
## `mi_NZ` translation update

Automated export of completed **mi_NZ** translations from the translation task DB.
Scope: `locales/content/mi_NZ/` only — 16 file(s), +2020/-20.

⚠️ `i18n validate variables` reports **3** variable mismatch(es) for `mi_NZ` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ✅ Looks good — no real placeholder/brand issues found.

**Summary:** The 3 "errors" from the variable-consistency check are false positives against `.context` fields — those are English-only translator/dev annotations (sibling of `text`, describing what `{provider}`/`{email}` mean), never populated in *any* locale's content files, mi_NZ included. The actual `text` values for those three keys (`web.auth.connections.connect_action`, `web.link_sso.prompt`, `web.sso_link_confirm.prompt`) are present in the diff and correctly preserve every `{provider}`/`{email}` occurrence and count against the English source.

**Critical (must fix):** None.

**Warnings:**
- Terminology drift on the same source string (hash `e392a389`, English "Suspended"): pre-existing `web.admin.customers.suspended.badge` uses "Kua Whakatārewatia" while the newly added `web.admin.organizations.addMember.badges.suspended` uses "Kua whakatārewahia" — different passive suffix (-tia vs -hia) and casing for the identical source label. Worth aligning for consistency, not a functional bug.

**Notes:**
- `email.sso_link_verification.postscript` translates "P.S." as "R.M." — unusual/uncommon abbreviation in te reo Māori; worth a native-speaker glance to confirm it's not a machine-translation artifact.
- Variable-consistency tooling should probably exclude `.context` fields from its scan (they're dev-facing metadata, not translatable UI strings) to avoid spurious "error" noise on future runs.
- Spot-checked placeholder counts across the larger diff (admin-domains, admin-organizations, admin-billing, email.json, session-auth*, workspace-*): all `{var}`/`%{var}` tokens match source in set and count; brand placeholders (`%{product_name}`) left untranslated as required.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
