### PR TITLE
i18n: update nl translations

### DIFF
--- a/locales/content/nl/00-common.json
+++ b/locales/content/nl/00-common.json
@@ -489,7 +489,7 @@
     "source_hash": "11a6767d"
   },
   "web.COMMON.end": {
-    "text": "End",
+    "text": "Einde",
     "source_hash": "f4db1e48"
   },
   "web.COMMON.general": {

--- a/locales/content/nl/00-common.json
+++ b/locales/content/nl/00-common.json
@@ -37,7 +37,7 @@
     "source_hash": "6170ab94"
   },
   "web.COMMON.custom_domains_description": {
-    "text": "Versterk verbindingen en bouw vertrouwen met je eigen merkgebonden beveiligde links.",
+    "text": "Versterk connecties en bouw vertrouwen op met je eigen beveiligde links in je huisstijl.",
     "source_hash": "71fddc05"
   },
   "web.COMMON.get_started_button": {
@@ -57,15 +57,15 @@
     "source_hash": "155f816c"
   },
   "web.COMMON.submitting": {
-    "text": "Verzenden...",
+    "text": "Bezig met verzenden...",
     "source_hash": "64115d5b"
   },
   "web.COMMON.processing": {
-    "text": "Verwerken...",
+    "text": "Bezig met verwerken...",
     "source_hash": "f40a853e"
   },
   "web.COMMON.description": {
-    "text": "Houd gevoelige informatie uit je chatgeschiedenis en e-mail. Deel een beveiligde link die slechts één keer beschikbaar is.",
+    "text": "Houd gevoelige informatie uit je chatlogs en e-mail. Deel een beveiligde link die maar één keer beschikbaar is.",
     "source_hash": "4c895f85"
   },
   "web.COMMON.incorrect_passphrase": {
@@ -73,7 +73,7 @@
     "source_hash": "a55f9636"
   },
   "web.COMMON.keywords": {
-    "text": "bericht,wachtwoord generator,deel een bericht,eenmalig",
+    "text": "bericht,wachtwoordgenerator,deel een bericht,eenmalig",
     "source_hash": "52728258"
   },
   "web.COMMON.button_create_secret": {
@@ -97,11 +97,11 @@
     "source_hash": "29d0cf13"
   },
   "web.COMMON.secret_recipient_address": {
-    "text": "Adres ontvanger",
+    "text": "Adres van ontvanger",
     "source_hash": "f6f6311d"
   },
   "web.COMMON.secret_placeholder": {
-    "text": "Plaats hier de inhoud van je bericht...",
+    "text": "Berichtinhoud komt hier...",
     "source_hash": "54630bab"
   },
   "web.COMMON.header_create_account": {
@@ -157,7 +157,7 @@
     "source_hash": "de996752"
   },
   "web.COMMON.burn_this_secret": {
-    "text": "Dit bericht verbranden",
+    "text": "Verbrand dit bericht",
     "source_hash": "ffff30e8"
   },
   "web.COMMON.burn_this_secret_hint": {
@@ -185,7 +185,7 @@
     "source_hash": "9ac6488f"
   },
   "web.COMMON.error_passphrase": {
-    "text": "Controleer de wachtwoordzin nogmaals",
+    "text": "Controleer die wachtwoordzin nog eens",
     "source_hash": "b582f3a6"
   },
   "web.COMMON.enter_passphrase_here": {
@@ -221,7 +221,7 @@
     "source_hash": "1d1730d4"
   },
   "web.COMMON.signup_for_more": {
-    "text": "Registreer voor meer",
+    "text": "Meld je aan voor meer",
     "source_hash": "cc1421d0"
   },
   "web.COMMON.login_to_your_account": {
@@ -229,7 +229,7 @@
     "source_hash": "62f1fe13"
   },
   "web.COMMON.sent_to": {
-    "text": "Verzonden naar:",
+    "text": "Verzonden naar: ",
     "source_hash": "e79c8bcb"
   },
   "web.COMMON.field_email": {
@@ -241,7 +241,7 @@
     "source_hash": "e7cf3ef4"
   },
   "web.COMMON.field_password2": {
-    "text": "Wachtwoord bevestigen",
+    "text": "Bevestig wachtwoord",
     "source_hash": "c292210c"
   },
   "web.COMMON.button_create_account": {
@@ -293,15 +293,15 @@
     "source_hash": "6bd0351a"
   },
   "web.COMMON.button_send_feedback": {
-    "text": "Feedback verzenden",
+    "text": "Feedback versturen",
     "source_hash": "84195de9"
   },
   "web.COMMON.verification_sent_to": {
-    "text": "Een verificatie is verzonden naar",
+    "text": "Er is een verificatie verzonden naar",
     "source_hash": "62da29c0"
   },
   "web.COMMON.autoverified_success": {
-    "text": "Account aangemaakt. Log alsjeblieft in.",
+    "text": "Account aangemaakt. Log in.",
     "source_hash": "fd3610bf"
   },
   "web.COMMON.signup_success_generic": {
@@ -309,11 +309,11 @@
     "source_hash": "f596cdd0"
   },
   "web.COMMON.burn_this_secret_aria": {
-    "text": "Dit bericht permanent verbranden",
+    "text": "Verbrand dit bericht permanent",
     "source_hash": "0a7afc29"
   },
   "web.COMMON.burn_confirmation_title": {
-    "text": "Bevestig alsjeblieft",
+    "text": "Bevestig",
     "source_hash": "dcd78dfb"
   },
   "web.COMMON.burn_confirmation_message": {
@@ -321,7 +321,7 @@
     "source_hash": "5dde5dd9"
   },
   "web.COMMON.confirm_burn": {
-    "text": "Ja, dit bericht verbranden",
+    "text": "Ja, verbrand dit bericht",
     "source_hash": "6e5b02a7"
   },
   "web.COMMON.burn_security_notice": {
@@ -341,7 +341,7 @@
     "source_hash": "5bb95106"
   },
   "web.COMMON.faq_title": {
-    "text": "Veelgestelde vragen",
+    "text": "F.A.Q.",
     "source_hash": "bd7394ac"
   },
   "web.COMMON.verification_not_valid": {
@@ -349,7 +349,7 @@
     "source_hash": "abf07ced"
   },
   "web.COMMON.verification_already_logged_in": {
-    "text": "Je kunt geen account verifiëren als je al bent ingelogd",
+    "text": "Je kunt een account niet verifiëren terwijl je al bent ingelogd",
     "source_hash": "f0a17c5f"
   },
   "web.COMMON.show_password": {
@@ -385,7 +385,7 @@
     "source_hash": "6e069c11"
   },
   "web.COMMON.redirecting": {
-    "text": "Doorverwijzen...",
+    "text": "Bezig met doorsturen...",
     "source_hash": "cd23991b"
   },
   "web.COMMON.continue": {
@@ -417,7 +417,7 @@
     "source_hash": "5a234448"
   },
   "web.COMMON.loading": {
-    "text": "Laden...",
+    "text": "Bezig met laden...",
     "source_hash": "47d2a515"
   },
   "web.COMMON.save_changes": {
@@ -425,11 +425,11 @@
     "source_hash": "35322b5b"
   },
   "web.COMMON.saving": {
-    "text": "Opslaan...",
+    "text": "Bezig met opslaan...",
     "source_hash": "dc85af8f"
   },
   "web.COMMON.adding_ellipses": {
-    "text": "Toevoegen",
+    "text": "Bezig met toevoegen",
     "source_hash": "0a6691ef"
   },
   "web.COMMON.e_g_example": {
@@ -489,7 +489,7 @@
     "source_hash": "11a6767d"
   },
   "web.COMMON.end": {
-    "text": "Einde",
+    "text": "End",
     "source_hash": "f4db1e48"
   },
   "web.COMMON.general": {
@@ -497,7 +497,7 @@
     "source_hash": "c910d474"
   },
   "web.COMMON.note": {
-    "text": "Opmerking",
+    "text": "Let op",
     "source_hash": "d8da2c49"
   },
   "web.COMMON.monthly": {
@@ -509,11 +509,11 @@
     "source_hash": "6e69b59e"
   },
   "web.COMMON.go_on_then": {
-    "text": "Ga door.",
+    "text": "Ga je gang.",
     "source_hash": "fb697cc7"
   },
   "web.COMMON.loading_ellipses": {
-    "text": "Laden...",
+    "text": "Bezig met laden...",
     "source_hash": "47d2a515"
   },
   "web.COMMON.not_received": {
@@ -521,7 +521,7 @@
     "source_hash": "d84ee92c"
   },
   "web.COMMON.confirm_password": {
-    "text": "Wachtwoord bevestigen",
+    "text": "Bevestig wachtwoord",
     "source_hash": "5ac265f3"
   },
   "web.COMMON.new_password": {
@@ -561,7 +561,7 @@
     "source_hash": "dd167905"
   },
   "web.COMMON.other": {
-    "text": "Anders",
+    "text": "Overig",
     "source_hash": "f97e9da0"
   },
   "web.COMMON.min_width_1024px": {
@@ -613,7 +613,7 @@
     "source_hash": "c8cc1c7b"
   },
   "web.COMMON.pretty_good": {
-    "text": "Behoorlijk goed",
+    "text": "Best goed",
     "source_hash": "521a41b6"
   },
   "web.COMMON.fair": {
@@ -621,11 +621,11 @@
     "source_hash": "f7b19afc"
   },
   "web.COMMON.meh": {
-    "text": "Mwah",
+    "text": "Matig",
     "source_hash": "8b0d6190"
   },
   "web.COMMON.not_great": {
-    "text": "Niet geweldig",
+    "text": "Niet goed",
     "source_hash": "00561207"
   },
   "web.COMMON.open_options": {
@@ -641,7 +641,7 @@
     "source_hash": "ddf785b7"
   },
   "web.COMMON.copy_secret_to_clipboard": {
-    "text": "Bericht kopiëren naar klembord",
+    "text": "Bericht naar klembord kopiëren",
     "source_hash": "a2ceff6d"
   },
   "web.COMMON.secret_copied_to_clipboard": {
@@ -649,7 +649,7 @@
     "source_hash": "da84ff02"
   },
   "web.COMMON.double_check_that_passphrase": {
-    "text": "Controleer de wachtwoordzin nogmaals",
+    "text": "Controleer die wachtwoordzin nog eens",
     "source_hash": "b582f3a6"
   },
   "web.COMMON.press_copy_button_below": {
@@ -709,7 +709,7 @@
     "source_hash": "7d9eb7ac"
   },
   "web.LABELS.loading": {
-    "text": "Laden...",
+    "text": "Bezig met laden...",
     "source_hash": "47d2a515"
   },
   "web.LABELS.cancel": {
@@ -717,7 +717,7 @@
     "source_hash": "19766ed6"
   },
   "web.LABELS.saving": {
-    "text": "Opslaan...",
+    "text": "Bezig met opslaan...",
     "source_hash": "dc85af8f"
   },
   "web.LABELS.saved": {
@@ -805,11 +805,11 @@
     "source_hash": "73758343"
   },
   "web.LABELS.view_progress": {
-    "text": "Voortgang bekijken",
+    "text": "Weergavevoortgang",
     "source_hash": "6c072c1f"
   },
   "web.LABELS.help_section": {
-    "text": "Helpsectie",
+    "text": "Hulpsectie",
     "source_hash": "614e14f0"
   },
   "web.LABELS.passphrase_protected": {
@@ -821,7 +821,7 @@
     "source_hash": "3fa595ef"
   },
   "web.LABELS.sending_ellipses": {
-    "text": "Verzenden...",
+    "text": "Bezig met verzenden...",
     "source_hash": "286a3af7"
   },
   "web.LABELS.title_recent_secrets": {
@@ -837,7 +837,7 @@
     "source_hash": "0e916101"
   },
   "web.LABELS.reload": {
-    "text": "Herladen",
+    "text": "Opnieuw laden",
     "source_hash": "bdc090ec"
   },
   "web.LABELS.filter": {
@@ -849,7 +849,7 @@
     "source_hash": "83b12c22"
   },
   "web.LABELS.caption_recent_secrets": {
-    "text": "Beveiligde links aangemaakt in deze sessie",
+    "text": "Beveiligde links die in deze sessie zijn aangemaakt",
     "source_hash": "6c7ceab8"
   },
   "web.LABELS.create_link_short": {
@@ -902,7 +902,7 @@
     "source_hash": "49f19bee"
   },
   "web.STATUS.previewed": {
-    "text": "Voorbekeken",
+    "text": "Bekeken in voorbeeld",
     "source_hash": "3d391a9b"
   },
   "web.STATUS.revealed": {
@@ -942,7 +942,7 @@
     "source_hash": "b0cbaa5b"
   },
   "web.STATUS.securing": {
-    "text": "Beveiligen",
+    "text": "Bezig met beveiligen",
     "source_hash": "37c84053"
   },
   "web.STATUS.copied": {
@@ -1002,7 +1002,7 @@
     "source_hash": "c88a0b90"
   },
   "web.STATUS.delivered": {
-    "text": "Afgeleverd",
+    "text": "Bezorgd",
     "source_hash": "90611565"
   },
   "web.STATUS.dns_incorrect": {
@@ -1018,15 +1018,15 @@
     "source_hash": "ac7c949f"
   },
   "web.FEATURES.unlimited_views": {
-    "text": "Onbeperkte weergaven",
+    "text": "Onbeperkt aantal weergaven",
     "source_hash": "3f6859b0"
   },
   "web.FEATURES.custom_domain_protected": {
-    "text": "Vertrouwd merkdomein",
+    "text": "Branding op een vertrouwd domein",
     "source_hash": "5e39b05c"
   },
   "web.FEATURES.encrypted_in_transit": {
-    "text": "Versleuteld tijdens transport en in rust",
+    "text": "Versleuteld tijdens verzending en opslag",
     "source_hash": "314c7974"
   },
   "web.UNITS.ttl.duration": {
@@ -1038,7 +1038,7 @@
     "source_hash": "6ac0d345"
   },
   "web.UNITS.ttl.time.hour": {
-    "text": "uur | uren",
+    "text": "uur | uur",
     "source_hash": "f4fef91b"
   },
   "web.UNITS.ttl.time.minute": {
@@ -1054,7 +1054,7 @@
     "source_hash": "cb3f91d5"
   },
   "web.UNITS.ttl_remaining.duration": {
-    "text": "Nog {count} {unit}",
+    "text": "nog {count} {unit}",
     "source_hash": "18f6c6e8"
   },
   "web.UNITS.ttl_remaining.time.day": {
@@ -1062,7 +1062,7 @@
     "source_hash": "6702855e"
   },
   "web.UNITS.ttl_remaining.time.hour": {
-    "text": "uur resterend | uren resterend",
+    "text": "uur resterend | uur resterend",
     "source_hash": "2eaebd6f"
   },
   "web.UNITS.ttl_remaining.time.minute": {
@@ -1078,7 +1078,7 @@
     "source_hash": "cb3f91d5"
   },
   "web.UNITS.limited_views": {
-    "text": "{count} weergavelimiet",
+    "text": "Limiet van {count} weergaven",
     "source_hash": "8db0e228"
   },
   "web.UNITS.days_remaining": {
@@ -1118,11 +1118,11 @@
     "source_hash": "fdfd41de"
   },
   "web.TITLES.reset_password": {
-    "text": "Wachtwoord herstellen",
+    "text": "Wachtwoord opnieuw instellen",
     "source_hash": "4e70f1fd"
   },
   "web.TITLES.logout": {
-    "text": "Uitloggen",
+    "text": "Bezig met uitloggen",
     "source_hash": "afbce8a6"
   },
   "web.TITLES.verify_account": {
@@ -1150,7 +1150,7 @@
     "source_hash": "c11bd410"
   },
   "web.TITLES.receipt": {
-    "text": "Berichtontvangstbewijs",
+    "text": "Ontvangstbewijs van bericht",
     "source_hash": "fe0c79e9"
   },
   "web.TITLES.burn_secret": {
@@ -1178,7 +1178,7 @@
     "source_hash": "b416f537"
   },
   "web.TITLES.domain_brand": {
-    "text": "Merkdomein",
+    "text": "Domeinbranding",
     "source_hash": "35e4dfbe"
   },
   "web.TITLES.account": {
@@ -1218,11 +1218,11 @@
     "source_hash": "78801183"
   },
   "web.TITLES.change_email": {
-    "text": "E-mail wijzigen",
+    "text": "E-mailadres wijzigen",
     "source_hash": "18c3f2d5"
   },
   "web.TITLES.confirm_email_change": {
-    "text": "E-mailadres wijzigen bevestigen",
+    "text": "E-mailwijziging bevestigen",
     "source_hash": "c2736949"
   },
   "web.TITLES.security_overview": {
@@ -1279,7 +1279,7 @@
     "source_hash": "dfe95783"
   },
   "web.ARIA.focus_is_now_in_the_main_text_area": {
-    "text": "De focus is nu in het hoofdtekstveld",
+    "text": "Focus staat nu in het hoofdtekstvak",
     "source_hash": "e00dd260"
   },
   "web.INSTRUCTION.sharing_instructions": {
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Controleer altijd of je op de officiële website van {product_name} bent. Fraudeurs maken soms nepwebsites die er precies zo uitzien als {product_name} om je berichten te stelen. Om phishingaanvallen te voorkomen, controleer je het regiodomein in je adresbalk voordat je nieuwe links aanmaakt.",
+    "text": "Controleer altijd of je op de officiële website van {product_name} bent. Fraudeurs maken soms nepwebsites die er precies uitzien als {product_name} om je berichten te stelen. Controleer het regiodomein in je adresbalk voordat je nieuwe links aanmaakt, om phishingaanvallen te voorkomen.",
     "source_hash": "2e3b856e"
   },
   "web.pricing.title": {
@@ -1307,11 +1307,11 @@
     "source_hash": "97e283c7"
   },
   "web.pricing.subtitle": {
-    "text": "Kies het plan dat bij je past. Alle plannen bevatten onbeperkt berichten delen en privacy-eerst ontwerp.",
+    "text": "Kies het plan dat bij je past. Alle plannen bevatten onbeperkt berichten delen en een privacy-first ontwerp.",
     "source_hash": "9204dff4"
   },
   "web.pricing.get_started_free": {
-    "text": "Gratis starten",
+    "text": "Gratis aan de slag",
     "source_hash": "6bb5a4a7"
   },
   "web.pricing.start_trial": {
@@ -1351,7 +1351,7 @@
     "source_hash": "0ec1a5db"
   },
   "web.pricing.free_tier_description": {
-    "text": "Maak en deel berichten met basisfuncties. Geen creditcard vereist.",
+    "text": "Maak en deel berichten met basisfuncties. Geen creditcard nodig.",
     "source_hash": "3a4f2bc0"
   },
   "web.COMMON.enter_password_to_continue": {
@@ -1370,12 +1370,12 @@
     "source_hash": "6615bf1c"
   },
   "api.errors.service_unavailable": {
-    "text": "Service tijdelijk niet beschikbaar. Probeer het zo opnieuw.",
+    "text": "Service tijdelijk niet beschikbaar. Probeer het zo meteen opnieuw.",
     "context": "Error message when database connection fails",
     "source_hash": "343ccdcb"
   },
   "api.errors.request_processing_error": {
-    "text": "Je verzoek kan momenteel niet worden verwerkt",
+    "text": "Kan je verzoek op dit moment niet verwerken",
     "context": "Error message for recoverable server errors",
     "source_hash": "fb961f3f"
   },
@@ -1429,7 +1429,7 @@
     "source_hash": "45989de4"
   },
   "web.COMMON.field_confirm_password": {
-    "text": "Wachtwoord bevestigen",
+    "text": "Bevestig wachtwoord",
     "source_hash": "c292210c"
   },
   "web.COMMON.passwords_must_match": {
@@ -1477,7 +1477,7 @@
     "source_hash": "55cd1515"
   },
   "web.COMMON.focus_is_now_in_the_main_text_area": {
-    "text": "De focus ligt nu in het hoofdtekstvak",
+    "text": "Focus staat nu in het hoofdtekstvak",
     "source_hash": "e00dd260"
   },
   "web.LABELS.show_passphrase": {
@@ -1513,7 +1513,7 @@
     "source_hash": "13161464"
   },
   "web.TITLES.domain_signup": {
-    "text": "Validatie van domeinaanmelding",
+    "text": "Aanmeldingsvalidatie voor domein",
     "source_hash": "c8ce809a"
   },
   "web.TITLES.domain_email": {
@@ -1529,7 +1529,7 @@
     "source_hash": "c1c1009d"
   },
   "web.LABELS.updating": {
-    "text": "Bijwerken...",
+    "text": "Bezig met bijwerken...",
     "source_hash": "0a4e0b71"
   },
   "web.TITLES.check_email": {
@@ -1539,5 +1539,9 @@
   "web.TITLES.domain_dns": {
     "text": "DNS-configuratie",
     "source_hash": "6c63df31"
+  },
+  "web.TITLES.connected_identities": {
+    "text": "Gekoppelde identiteiten",
+    "source_hash": "e132c4d9"
   }
 }

--- a/locales/content/nl/10-layout.json
+++ b/locales/content/nl/10-layout.json
@@ -4,7 +4,7 @@
     "source_hash": "f4137804"
   },
   "web.footer.branding_guide": {
-    "text": "Merkrichtlijnen",
+    "text": "Brandinggids",
     "source_hash": "53f994c5"
   },
   "web.footer.customize": {
@@ -20,7 +20,7 @@
     "source_hash": "8f6fb4eb"
   },
   "web.footer.learn_about_our_security_measures": {
-    "text": "Leer meer over onze beveiligingsmaatregelen",
+    "text": "Lees meer over onze beveiligingsmaatregelen",
     "source_hash": "16c8adae"
   },
   "web.footer.view_our_terms_and_conditions": {
@@ -40,7 +40,7 @@
     "source_hash": "2b5c3d26"
   },
   "web.footer.support": {
-    "text": "Ondersteuning",
+    "text": "Support",
     "source_hash": "be91940b"
   },
   "web.footer.legals": {
@@ -60,7 +60,7 @@
     "source_hash": "1f04937e"
   },
   "web.footer.explore_our_api_documentation": {
-    "text": "Verken onze API-documentatie",
+    "text": "Ontdek onze API-documentatie",
     "source_hash": "45beb8f8"
   },
   "web.footer.docs": {
@@ -68,7 +68,7 @@
     "source_hash": "7af023c4"
   },
   "web.footer.access_our_documentation": {
-    "text": "Bekijk onze documentatie",
+    "text": "Raadpleeg onze documentatie",
     "source_hash": "37686da2"
   },
   "web.footer.view_our_source_code_on_github": {
@@ -76,7 +76,7 @@
     "source_hash": "d5def0ab"
   },
   "web.footer.resources": {
-    "text": "Bronnen",
+    "text": "Resources",
     "source_hash": "e89b30aa"
   },
   "web.footer.blog": {
@@ -84,7 +84,7 @@
     "source_hash": "8c6bc099"
   },
   "web.footer.read_our_latest_blog_posts": {
-    "text": "Lees onze laatste blogposts",
+    "text": "Lees onze nieuwste blogberichten",
     "source_hash": "77468d43"
   },
   "web.footer.view_our_subscription_pricing": {
@@ -92,7 +92,7 @@
     "source_hash": "55f1f590"
   },
   "web.footer.learn_about_our_company": {
-    "text": "Leer meer over ons bedrijf",
+    "text": "Lees meer over ons bedrijf",
     "source_hash": "780e18cd"
   },
   "web.footer.company": {
@@ -108,7 +108,7 @@
     "source_hash": "bc47da66"
   },
   "web.navigation.billing": {
-    "text": "Facturering",
+    "text": "Facturatie",
     "source_hash": "3ac8bbca"
   },
   "web.navigation.billingOverview": {
@@ -124,19 +124,19 @@
     "source_hash": "4d4a570f"
   },
   "web.meta.were_making_onetime_secret_available_in_multiple": {
-    "text": "We maken {onetime-secret} beschikbaar in meerdere talen. Aangezien dit een nieuwe functie is, kun je vertaalfouten of onhandige formuleringen tegenkomen. Je feedback helpt ons te verbeteren - als je problemen opmerkt, {send-feedback}",
+    "text": "We maken {onetime-secret} in meerdere talen beschikbaar. Omdat dit een nieuwe functie is, kun je vertaalfouten of onhandige formuleringen tegenkomen. Jouw feedback helpt ons verbeteren - zie je iets dat niet klopt, {send-feedback}",
     "source_hash": "3b482d7f"
   },
   "web.meta.translations_are_new_spotted_an_error": {
-    "text": "Vertalingen zijn nieuw. Een fout gespot? {send-feedback}",
+    "text": "Vertalingen zijn nieuw. Zie je een fout? {send-feedback}",
     "source_hash": "31eca08d"
   },
   "web.meta.we_recently_added_translations": {
-    "text": "We hebben onlangs vertalingen toegevoegd. Een fout gezien? {send-feedback}",
+    "text": "We hebben onlangs vertalingen toegevoegd. Zie je een fout? {send-feedback}",
     "source_hash": "6e2455c1"
   },
   "web.meta.privacy_and_security_should_be_accessible": {
-    "text": "Privacy en veiligheid moeten voor iedereen toegankelijk zijn, ongeacht taal. We voegen vertalingen toe om zowel onze gebruikers als hun berichtontvangers beter te laten begrijpen hoe ze veilig gebruik kunnen maken van en toegang kunnen krijgen tot beveiligde berichten en links. Aangezien dit een nieuwe functie is, kun je enkele vertaalfouten of onduidelijke instructies tegenkomen. Om ons te helpen de duidelijkheid en nauwkeurigheid van onze vertalingen te verbeteren, vooral voor kritieke beveiligingsgerelateerde inhoud, {send-feedback} als je problemen opmerkt.",
+    "text": "Privacy en beveiliging moeten voor iedereen toegankelijk zijn, ongeacht de taal. We voegen vertalingen toe zodat zowel onze gebruikers als hun ontvangers beter begrijpen hoe ze beveiligde berichten en links veilig gebruiken en openen. Omdat dit een nieuwe functie is, kun je vertaalfouten of onduidelijke instructies tegenkomen. Help ons de duidelijkheid en juistheid van onze vertalingen te verbeteren, vooral voor kritieke beveiligingsgerelateerde inhoud: {send-feedback} als je iets ziet dat niet klopt",
     "source_hash": "1b8bb38f"
   },
   "web.help.learn_more": {
@@ -144,11 +144,11 @@
     "source_hash": "1445799c"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.title": {
-    "text": "Waar kijk ik naar?",
+    "text": "Wat zie ik hier?",
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "Je bekijkt een beveiligd bericht dat via {product_name} met je is gedeeld. Deze inhoud wordt maar één keer weergegeven en daarna permanent van onze servers verwijderd.",
+    "text": "Je bekijkt een beveiligd bericht dat via {product_name} met je is gedeeld. Deze inhoud wordt maar één keer getoond en daarna permanent van onze servers verwijderd.",
     "source_hash": "7a4e9d16"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
@@ -156,7 +156,7 @@
     "source_hash": "c8c2c9da"
   },
   "web.help.secret_view_faq.can_i_view_again.description": {
-    "text": "Nee. Om veiligheidsredenen is dit bericht slechts één keer te bekijken. Na het sluiten van deze pagina wordt de inhoud permanent verwijderd en kan deze door niemand meer worden hersteld, ook niet door ons.",
+    "text": "Nee. Om veiligheidsredenen is dit bericht maar één keer te bekijken. Nadat je deze pagina hebt gesloten, wordt de inhoud permanent verwijderd en kan niemand die meer herstellen, ook wij niet.",
     "source_hash": "4bf980a4"
   },
   "web.help.secret_view_faq.how_to_copy.title": {
@@ -164,31 +164,31 @@
     "source_hash": "90deddbb"
   },
   "web.help.secret_view_faq.how_to_copy.description": {
-    "text": "Gebruik de knop 'Kopiëren naar klembord' om het volledige bericht te kopiëren. Controleer bij langere berichten of je de volledige inhoud hebt gekopieerd voordat je deze pagina verlaat.",
+    "text": "Gebruik de knop 'Kopiëren naar klembord' om het hele bericht te kopiëren. Controleer bij langere berichten of je de volledige inhoud hebt gekopieerd voordat je deze pagina verlaat.",
     "source_hash": "440aa828"
   },
   "web.help.secret_view_faq.is_my_viewing_tracked.title": {
-    "text": "Wordt het bekijken van dit bericht gevolgd?",
+    "text": "Wordt bijgehouden dat ik dit bericht bekijk?",
     "source_hash": "90145e28"
   },
   "web.help.secret_view_faq.is_my_viewing_tracked.description": {
-    "text": "De afzender wordt op de hoogte gebracht dat het bericht is bekeken, maar we volgen niet wie het heeft bekeken of vanaf welke locatie. Je privacy is beschermd.",
+    "text": "De afzender krijgt een melding dat het bericht is bekeken, maar we houden niet bij wie het heeft bekeken of vanaf welke locatie. Je privacy blijft beschermd.",
     "source_hash": "70737473"
   },
   "web.help.secret_view_faq.one_time_warning": {
-    "text": "Zodra je deze pagina verlaat of ververst, wordt dit bericht permanent verwijderd en kan het door niemand meer worden hersteld.",
+    "text": "Zodra je deze pagina verlaat of vernieuwt, wordt dit bericht permanent verwijderd en kan niemand het meer herstellen.",
     "source_hash": "47feab6e"
   },
   "web.layout.go_back_to_previous_page": {
-    "text": "Terug naar vorige pagina",
+    "text": "Terug naar de vorige pagina",
     "source_hash": "1778f2e7"
   },
   "web.layout.site_footer": {
-    "text": "Sitefoter",
+    "text": "Sitevoettekst",
     "source_hash": "6ca09429"
   },
   "web.layout.toggle_dark_mode": {
-    "text": "Donkere modus wisselen",
+    "text": "Donkere modus aan/uit",
     "source_hash": "ffe32a00"
   },
   "web.layout.provide_feedback": {
@@ -220,15 +220,15 @@
     "source_hash": "f65216b3"
   },
   "web.layout.release_notes": {
-    "text": "Release-opmerkingen",
+    "text": "Releasenotities",
     "source_hash": "bd4702c1"
   },
   "web.layout.loading_settings_content": {
-    "text": "Instellingsinhoud laden...",
+    "text": "Instellingen worden geladen...",
     "source_hash": "81a2a30e"
   },
   "web.layout.settings_sections_0": {
-    "text": "Instellingssecties",
+    "text": "Instellingensecties",
     "source_hash": "e26d51d3"
   },
   "web.layout.close_settings": {
@@ -236,11 +236,11 @@
     "source_hash": "0ccfef82"
   },
   "web.layout.settings_sections": {
-    "text": "Instellingssecties",
+    "text": "Instellingensecties",
     "source_hash": "e26d51d3"
   },
   "web.layout.customize_your_app_preferences_and_settings": {
-    "text": "Pas je app-voorkeuren en instellingen aan",
+    "text": "Pas je app-voorkeuren en -instellingen aan",
     "source_hash": "00d74c98"
   },
   "web.layout.return_home": {
@@ -248,7 +248,7 @@
     "source_hash": "bbcc935e"
   },
   "web.layout.return_to_home_page": {
-    "text": "Terug naar homepagina",
+    "text": "Terug naar de homepage",
     "source_hash": "8d27b81d"
   },
   "web.layout.return_to_home": {
@@ -324,11 +324,11 @@
     "source_hash": "c0cfa9b2"
   },
   "web.layout.switch_to_blank_mode": {
-    "text": "Overschakelen naar {0}-modus",
+    "text": "Overschakelen naar {0} modus",
     "source_hash": "c8b909e0"
   },
   "web.layout.blank_mode_enabled": {
-    "text": "{0}-modus ingeschakeld",
+    "text": "{0} modus ingeschakeld",
     "source_hash": "e1d200cb"
   },
   "web.layout.workspace": {

--- a/locales/content/nl/10-layout.json
+++ b/locales/content/nl/10-layout.json
@@ -40,7 +40,7 @@
     "source_hash": "2b5c3d26"
   },
   "web.footer.support": {
-    "text": "Support",
+    "text": "Ondersteuning",
     "source_hash": "be91940b"
   },
   "web.footer.legals": {
@@ -76,7 +76,7 @@
     "source_hash": "d5def0ab"
   },
   "web.footer.resources": {
-    "text": "Resources",
+    "text": "Bronnen",
     "source_hash": "e89b30aa"
   },
   "web.footer.blog": {

--- a/locales/content/nl/admin-audit.json
+++ b/locales/content/nl/admin-audit.json
@@ -4,7 +4,7 @@
     "source_hash": "47751f88"
   },
   "web.admin.audit.description": {
-    "text": "Elke muterende beheerdersactie, nieuwste eerst — wie deed wat met wie, en hoe het is verlopen.",
+    "text": "Elke wijzigende beheerdersactie, nieuwste eerst — wie deed wat bij wie, en hoe het afliep.",
     "source_hash": "2326a1a0"
   },
   "web.admin.audit.categories.customer": {
@@ -36,11 +36,11 @@
     "source_hash": "969ccbd3"
   },
   "web.admin.audit.categories.ratelimit": {
-    "text": "Snelheidslimieten",
+    "text": "Rate limits",
     "source_hash": "6ed021f7"
   },
   "web.admin.audit.categories.ip": {
-    "text": "IP-blokkades",
+    "text": "IP-blokkeringen",
     "source_hash": "48cdea49"
   },
   "web.admin.audit.columns.timestamp": {
@@ -48,7 +48,7 @@
     "source_hash": "115a2cc9"
   },
   "web.admin.audit.columns.actor": {
-    "text": "Uitvoerder",
+    "text": "Actor",
     "source_hash": "449995c4"
   },
   "web.admin.audit.columns.action": {
@@ -68,7 +68,7 @@
     "source_hash": "fb5f27d5"
   },
   "web.admin.audit.filters.actorPlaceholder": {
-    "text": "Filter op uitvoerder (extid of e-mail)",
+    "text": "Filter op actor (extid of e-mail)",
     "source_hash": "966aa580"
   },
   "web.admin.audit.filters.actionLabel": {
@@ -80,7 +80,7 @@
     "source_hash": "83140cf1"
   },
   "web.admin.audit.list.loadError": {
-    "text": "Kon het auditlogboek niet laden.",
+    "text": "Het auditlogboek kon niet worden geladen.",
     "source_hash": "acf244f4"
   },
   "web.admin.audit.list.retry": {
@@ -92,11 +92,47 @@
     "source_hash": "8fe0cac3"
   },
   "web.admin.audit.result.success": {
-    "text": "Geslaagd",
+    "text": "Gelukt",
     "source_hash": "c88a0b90"
   },
   "web.admin.audit.result.failure": {
     "text": "Mislukt",
     "source_hash": "7031edbc"
+  },
+  "web.admin.audit.categories.secret": {
+    "text": "Berichten",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.audit.categories.membership": {
+    "text": "Lidmaatschappen",
+    "source_hash": "b50f1a42"
+  },
+  "web.admin.audit.categories.entitlement_preview": {
+    "text": "Entitlement-voorbeelden",
+    "source_hash": "255c5797"
+  },
+  "web.admin.audit.categories.colonel": {
+    "text": "Colonel-aanmeldingen",
+    "source_hash": "01eeeb38"
+  },
+  "web.admin.audit.filters.actorLabel": {
+    "text": "Actor",
+    "source_hash": "449995c4"
+  },
+  "web.admin.audit.filters.searchButton": {
+    "text": "Zoeken",
+    "source_hash": "49c266ba"
+  },
+  "web.admin.audit.filters.searchHint": {
+    "text": "Typ een actor en druk op Enter of kies Zoeken om te zoeken. De lijst wordt niet bijgewerkt terwijl je typt.",
+    "source_hash": "45eceb12"
+  },
+  "web.admin.audit.filters.pendingSearch": {
+    "text": "Nog niet gezocht — druk op Enter of kies Zoeken om deze actor toe te passen.",
+    "source_hash": "f76095c2"
+  },
+  "web.admin.audit.list.contractError": {
+    "text": "De server heeft geantwoord, maar de auditgegevens kwamen niet overeen met het verwachte formaat. Er kunnen geen gebeurtenissen worden getoond — dit is een rapportagefout, geen leeg logboek.",
+    "source_hash": "7f48137e"
   }
 }

--- a/locales/content/nl/admin-audit.json
+++ b/locales/content/nl/admin-audit.json
@@ -36,7 +36,7 @@
     "source_hash": "969ccbd3"
   },
   "web.admin.audit.categories.ratelimit": {
-    "text": "Rate limits",
+    "text": "Snelheidslimieten",
     "source_hash": "6ed021f7"
   },
   "web.admin.audit.categories.ip": {

--- a/locales/content/nl/admin-bannedips.json
+++ b/locales/content/nl/admin-bannedips.json
@@ -28,7 +28,7 @@
     "source_hash": "512acd7b"
   },
   "web.admin.bannedIps.ban.confirmDescription": {
-    "text": "Dit blokkeert {ip} aan de rand van de site. Typ het IP om te bevestigen.",
+    "text": "Hiermee wordt {ip} aan de rand van de site geblokkeerd. Typ het IP om te bevestigen.",
     "source_hash": "d8f6142e"
   },
   "web.admin.bannedIps.ban.button": {
@@ -80,7 +80,7 @@
     "source_hash": "f91a5285"
   },
   "web.admin.bannedIps.list.loadError": {
-    "text": "Kon geblokkeerde IP's niet laden.",
+    "text": "Geblokkeerde IP's konden niet worden geladen.",
     "source_hash": "539f2e34"
   },
   "web.admin.bannedIps.list.retry": {
@@ -96,11 +96,11 @@
     "source_hash": "41059c94"
   },
   "web.admin.bannedIps.unban.confirmTitle": {
-    "text": "Deze blokkade opheffen?",
+    "text": "Deze blokkering opheffen?",
     "source_hash": "88473e59"
   },
   "web.admin.bannedIps.unban.confirmDescription": {
-    "text": "Dit deblokkeert {ip}. Typ het IP om te bevestigen.",
+    "text": "Hiermee wordt {ip} gedeblokkeerd. Typ het IP om te bevestigen.",
     "source_hash": "6bec3191"
   },
   "web.admin.bannedIps.unban.button": {

--- a/locales/content/nl/admin-banner.json
+++ b/locales/content/nl/admin-banner.json
@@ -1,14 +1,14 @@
 {
   "web.admin.banner.title": {
-    "text": "Uitzendbanner",
+    "text": "Broadcastbanner",
     "source_hash": "0bc449a3"
   },
   "web.admin.banner.description": {
-    "text": "Publiceer een sitebrede aankondiging die aan elke bezoeker wordt getoond, of wis de huidige.",
+    "text": "Publiceer een sitebrede aankondiging voor elke bezoeker, of wis de huidige.",
     "source_hash": "a0f720d7"
   },
   "web.admin.banner.loadError": {
-    "text": "Kon de huidige banner niet laden.",
+    "text": "De huidige banner kon niet worden geladen.",
     "source_hash": "04954e72"
   },
   "web.admin.banner.retry": {
@@ -20,15 +20,15 @@
     "source_hash": "da6b2e5d"
   },
   "web.admin.banner.clear.confirmTitle": {
-    "text": "De uitzendbanner wissen?",
+    "text": "De broadcastbanner wissen?",
     "source_hash": "46d9c35a"
   },
   "web.admin.banner.clear.confirmDescription": {
-    "text": "Dit verwijdert de actieve banner voor elke bezoeker. Typ het bevestigingswoord om door te gaan.",
+    "text": "Hiermee verdwijnt de live banner voor elke bezoeker. Typ het bevestigingswoord om door te gaan.",
     "source_hash": "9a56e4be"
   },
   "web.admin.banner.clear.success": {
-    "text": "Uitzendbanner gewist.",
+    "text": "Broadcastbanner gewist.",
     "source_hash": "b0f52af4"
   },
   "web.admin.banner.current.title": {
@@ -68,7 +68,7 @@
     "source_hash": "3579f3e6"
   },
   "web.admin.banner.current.htmlNote": {
-    "text": "Inhoud is HTML; de site zuivert deze bij weergave tot alleen links.",
+    "text": "De inhoud is HTML; de site schoont die bij weergave op tot alleen links.",
     "source_hash": "e45a7dfe"
   },
   "web.admin.banner.current.edit": {
@@ -88,11 +88,11 @@
     "source_hash": "2f77668a"
   },
   "web.admin.banner.set.contentPlaceholder": {
-    "text": "Gepland onderhoud zo 02:00 UTC",
+    "text": "Gepland onderhoud zo. 02:00 UTC",
     "source_hash": "4ec99d7d"
   },
   "web.admin.banner.set.contentHelp": {
-    "text": "HTML is toegestaan; de site zuivert deze tot alleen links.",
+    "text": "HTML is toegestaan; de site schoont die op tot alleen links.",
     "source_hash": "7253d1cd"
   },
   "web.admin.banner.set.ttlLabel": {
@@ -104,7 +104,7 @@
     "source_hash": "a8fd81e1"
   },
   "web.admin.banner.set.ttlHelp": {
-    "text": "Optioneel. De banner wordt automatisch na dit aantal seconden verwijderd.",
+    "text": "Optioneel. De banner wordt na dit aantal seconden automatisch verwijderd.",
     "source_hash": "ba0237f5"
   },
   "web.admin.banner.set.scopeLabel": {
@@ -112,11 +112,11 @@
     "source_hash": "545c0235"
   },
   "web.admin.banner.set.scopeHelp": {
-    "text": "Welke pagina's de banner tonen. Pagina's met een aangepast domein zien de banner alleen wanneer die is ingesteld op alle pagina's.",
+    "text": "Op welke pagina's de banner wordt getoond. Pagina's op aangepaste domeinen zien de banner alleen bij 'alle pagina's'.",
     "source_hash": "28cc3018"
   },
   "web.admin.banner.set.scopeNoRecipient": {
-    "text": "Alles behalve ontvangerpagina's",
+    "text": "Overal behalve op ontvangerspagina's",
     "source_hash": "8575b3c0"
   },
   "web.admin.banner.set.scopeWorkspace": {
@@ -136,11 +136,11 @@
     "source_hash": "69b6e40e"
   },
   "web.admin.banner.set.confirmTitle": {
-    "text": "Uitzendbanner publiceren?",
+    "text": "Broadcastbanner publiceren?",
     "source_hash": "8b72b5c3"
   },
   "web.admin.banner.set.confirmDescription": {
-    "text": "Deze banner wordt aan elke bezoeker op de site getoond totdat die wordt gewist of verloopt.",
+    "text": "Deze banner wordt op de hele site aan elke bezoeker getoond totdat hij wordt gewist of verloopt.",
     "source_hash": "c61bbec1"
   },
   "web.admin.banner.set.confirmButton": {
@@ -148,7 +148,7 @@
     "source_hash": "859390eb"
   },
   "web.admin.banner.set.success": {
-    "text": "Uitzendbanner gepubliceerd.",
+    "text": "Broadcastbanner gepubliceerd.",
     "source_hash": "55c06cab"
   }
 }

--- a/locales/content/nl/admin-billing.json
+++ b/locales/content/nl/admin-billing.json
@@ -40,7 +40,7 @@
     "source_hash": "dcd1d522"
   },
   "web.admin.billing.columns.tier": {
-    "text": "Tier",
+    "text": "Niveau",
     "source_hash": "cb9e8664"
   },
   "web.admin.billing.columns.status": {

--- a/locales/content/nl/admin-billing.json
+++ b/locales/content/nl/admin-billing.json
@@ -4,7 +4,7 @@
     "source_hash": "bfde7e68"
   },
   "web.admin.billing.description": {
-    "text": "Alleen-lezen weergave van geconfigureerde plannen en hun entitlements, en eventuele afwijkingen ten opzichte van de live Stripe-gesynchroniseerde catalogus.",
+    "text": "Alleen-lezen weergave van geconfigureerde plannen en hun entitlements, en eventuele afwijkingen ten opzichte van de live via Stripe gesynchroniseerde catalogus.",
     "source_hash": "05d5b332"
   },
   "web.admin.billing.retry": {
@@ -12,11 +12,11 @@
     "source_hash": "942087cc"
   },
   "web.admin.billing.loadError": {
-    "text": "Kon de facturatiecatalogus niet laden.",
+    "text": "De facturatiecatalogus kon niet worden geladen.",
     "source_hash": "c3110f77"
   },
   "web.admin.billing.localConfigWarning": {
-    "text": "De Stripe-gesynchroniseerde plancache is leeg, dus live plannen en afwijkingen kunnen niet worden geëvalueerd. Toont alleen de geconfigureerde catalogus (billing.yaml) — gebruikelijk in dev of wanneer Stripe niet is geconfigureerd.",
+    "text": "De cache met via Stripe gesynchroniseerde plannen is leeg, dus live plannen en afwijkingen kunnen niet worden beoordeeld. Alleen de geconfigureerde catalogus (billing.yaml) wordt getoond — gebruikelijk in dev of wanneer Stripe niet is geconfigureerd.",
     "source_hash": "905d95f8"
   },
   "web.admin.billing.inSync": {
@@ -28,7 +28,7 @@
     "source_hash": "166538f5"
   },
   "web.admin.billing.inSyncDetail": {
-    "text": "De geconfigureerde catalogus komt overeen met de live plannen. Geen afwijkingen gedetecteerd.",
+    "text": "De geconfigureerde catalogus komt overeen met de live plannen. Geen afwijkingen gevonden.",
     "source_hash": "57ab60a6"
   },
   "web.admin.billing.columns.planid": {
@@ -40,7 +40,7 @@
     "source_hash": "dcd1d522"
   },
   "web.admin.billing.columns.tier": {
-    "text": "Niveau",
+    "text": "Tier",
     "source_hash": "cb9e8664"
   },
   "web.admin.billing.columns.status": {
@@ -52,7 +52,7 @@
     "source_hash": "bc86e5f7"
   },
   "web.admin.billing.diff.subtitle": {
-    "text": "Geconfigureerde catalogus (billing.yaml) vs. live Stripe-gesynchroniseerd plan, naast elkaar.",
+    "text": "Geconfigureerde catalogus (billing.yaml) naast het live via Stripe gesynchroniseerde plan.",
     "source_hash": "d92e93ae"
   },
   "web.admin.billing.diff.config": {
@@ -64,11 +64,11 @@
     "source_hash": "4886945d"
   },
   "web.admin.billing.diff.absentConfig": {
-    "text": "Dit plan is niet aanwezig in de geconfigureerde catalogus.",
+    "text": "Dit plan staat niet in de geconfigureerde catalogus.",
     "source_hash": "0b594c88"
   },
   "web.admin.billing.diff.absentLive": {
-    "text": "Dit plan is niet aanwezig in de live Stripe-gesynchroniseerde cache.",
+    "text": "Dit plan staat niet in de live via Stripe gesynchroniseerde cache.",
     "source_hash": "c53f31c3"
   },
   "web.admin.billing.plans.title": {
@@ -112,7 +112,7 @@
     "source_hash": "5701958c"
   },
   "web.admin.billing.status.only_config": {
-    "text": "Alleen config",
+    "text": "Alleen configuratie",
     "source_hash": "15836cba"
   },
   "web.admin.billing.status.only_live": {
@@ -122,5 +122,85 @@
   "web.admin.billing.status.changed": {
     "text": "Gewijzigd",
     "source_hash": "2a6141e4"
+  },
+  "web.admin.billing.diff.backToCatalog": {
+    "text": "Terug naar facturatiecatalogus",
+    "source_hash": "8532b373"
+  },
+  "web.admin.billing.diff.driftedFields": {
+    "text": "Velden die verschillen:",
+    "source_hash": "9890c95b"
+  },
+  "web.admin.billing.diff.notFound": {
+    "text": "Plan niet in de catalogus",
+    "source_hash": "0253898b"
+  },
+  "web.admin.billing.diff.notFoundDescription": {
+    "text": "Er is geen plan met de id {planid} gevonden in de geconfigureerde catalogus of de live via Stripe gesynchroniseerde cache.",
+    "source_hash": "2e69551c"
+  },
+  "web.admin.billing.stripeOrgs.title": {
+    "text": "Stripe-klanten",
+    "source_hash": "0463ae27"
+  },
+  "web.admin.billing.stripeOrgs.description": {
+    "text": "Organisaties die aan een Stripe-klantrecord zijn gekoppeld.",
+    "source_hash": "2ab09aec"
+  },
+  "web.admin.billing.stripeOrgs.searchPlaceholder": {
+    "text": "Zoeken op Stripe-klant-ID",
+    "source_hash": "d5acf08f"
+  },
+  "web.admin.billing.stripeOrgs.empty": {
+    "text": "Geen enkele organisatie heeft een Stripe-klant-ID.",
+    "source_hash": "2e373537"
+  },
+  "web.admin.billing.stripeOrgs.emptySearch": {
+    "text": "Geen Stripe-klant-ID komt overeen met die zoekopdracht.",
+    "source_hash": "75011174"
+  },
+  "web.admin.billing.stripeOrgs.loadError": {
+    "text": "De lijst met Stripe-klanten kon niet worden geladen.",
+    "source_hash": "15e2d9a7"
+  },
+  "web.admin.billing.stripeOrgs.unavailable": {
+    "text": "De lijst met Stripe-klanten is op deze server nog niet beschikbaar.",
+    "source_hash": "aab6451a"
+  },
+  "web.admin.billing.stripeOrgs.none": {
+    "text": "Geen",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.billing.stripeOrgs.capped": {
+    "text": "De indexscan heeft zijn limiet bereikt, dus het totaal is een ondergrens — verfijn de zoekopdracht om de rest te zien.",
+    "source_hash": "20bcaa38"
+  },
+  "web.admin.billing.stripeOrgs.stale": {
+    "text": "{count} indexvermelding(en) op deze pagina verwijzen naar een organisatie die niet meer laadt en zijn overgeslagen.",
+    "source_hash": "51980f83"
+  },
+  "web.admin.billing.stripeOrgs.copyStripeId": {
+    "text": "Stripe-klant-ID kopiëren",
+    "source_hash": "a77d18b1"
+  },
+  "web.admin.billing.stripeOrgs.columns.organization": {
+    "text": "Organisatie",
+    "source_hash": "d764d425"
+  },
+  "web.admin.billing.stripeOrgs.columns.owner": {
+    "text": "Eigenaar",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.billing.stripeOrgs.columns.plan": {
+    "text": "Plan",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.billing.stripeOrgs.columns.subscription": {
+    "text": "Abonnement",
+    "source_hash": "4999c6c6"
+  },
+  "web.admin.billing.stripeOrgs.columns.stripeCustomer": {
+    "text": "Stripe-klant-ID",
+    "source_hash": "7e1d8bbb"
   }
 }

--- a/locales/content/nl/admin-colonel.json
+++ b/locales/content/nl/admin-colonel.json
@@ -212,7 +212,7 @@
     "source_hash": "331551b0"
   },
   "web.colonel.consumers": {
-    "text": "Consumers",
+    "text": "Consumenten",
     "source_hash": "212b350d"
   },
   "web.colonel.processingRate": {

--- a/locales/content/nl/admin-colonel.json
+++ b/locales/content/nl/admin-colonel.json
@@ -4,11 +4,11 @@
     "source_hash": "74a883a0"
   },
   "web.colonel.configEditorDescription": {
-    "text": "Bewerk systeemconfiguratie-instellingen. Wijzigingen worden direct toegepast na opslaan.",
+    "text": "Bewerk de systeemconfiguratie. Wijzigingen gelden direct na het opslaan.",
     "source_hash": "6025d269"
   },
   "web.colonel.invalidJson": {
-    "text": "Ongeldige JSON in {section}-sectie",
+    "text": "Ongeldige JSON in sectie {section}",
     "source_hash": "a75ac7a3"
   },
   "web.colonel.validationError": {
@@ -16,15 +16,15 @@
     "source_hash": "2aa2d0b4"
   },
   "web.colonel.errorFetchingConfig": {
-    "text": "Fout bij laden van configuratie",
+    "text": "Fout bij het laden van de configuratie",
     "source_hash": "08baf6d2"
   },
   "web.colonel.errorSavingConfig": {
-    "text": "Fout bij opslaan van configuratie",
+    "text": "Fout bij het opslaan van de configuratie",
     "source_hash": "48df54c7"
   },
   "web.colonel.configSaved": {
-    "text": "Configuratie succesvol opgeslagen",
+    "text": "Configuratie opgeslagen",
     "source_hash": "93b3d3e4"
   },
   "web.colonel.mustBeObject": {
@@ -40,7 +40,7 @@
     "source_hash": "e5e01aa0"
   },
   "web.colonel.sectionSaved": {
-    "text": "{section} succesvol opgeslagen",
+    "text": "{section} opgeslagen",
     "source_hash": "7be1d5d2"
   },
   "web.colonel.saveSection": {
@@ -64,7 +64,7 @@
     "source_hash": "b6cf56ca"
   },
   "web.colonel.sectionEffectivelyEmpty": {
-    "text": "{section}-sectie heeft geen geconfigureerde waarden",
+    "text": "Sectie {section} heeft geen geconfigureerde waarden",
     "source_hash": "efb63b77"
   },
   "web.colonel.dashboard": {
@@ -108,7 +108,7 @@
     "source_hash": "7881ca9e"
   },
   "web.colonel.welcomeDesc": {
-    "text": "Beheerderspaneel voor OneTimeSecret",
+    "text": "Administratief configuratiescherm voor OneTimeSecret",
     "source_hash": "57c1e752"
   },
   "web.colonel.quickActions": {
@@ -128,7 +128,7 @@
     "source_hash": "aaf9e948"
   },
   "web.colonel.stats.totalSecrets": {
-    "text": "Totaal berichten",
+    "text": "Totaal aantal berichten",
     "source_hash": "e17a5459"
   },
   "web.colonel.stats.activeUsers": {
@@ -140,23 +140,23 @@
     "source_hash": "aefbd2db"
   },
   "web.colonel.stats.secretsCreated": {
-    "text": "Berichten aangemaakt",
+    "text": "Aangemaakte berichten",
     "source_hash": "a97ee479"
   },
   "web.colonel.stats.secretsShared": {
-    "text": "Berichten gedeeld",
+    "text": "Gedeelde berichten",
     "source_hash": "5deb082c"
   },
   "web.colonel.stats.totalCustomers": {
-    "text": "Totaal gebruikers",
+    "text": "Totaal aantal gebruikers",
     "source_hash": "0ca3aa44"
   },
   "web.colonel.stats.emailsSent": {
-    "text": "E-mails verzonden",
+    "text": "Verzonden e-mails",
     "source_hash": "87cfb3ab"
   },
   "web.colonel.stats.systemHealth": {
-    "text": "Systeemgezondheid",
+    "text": "Systeemstatus",
     "source_hash": "c3d66242"
   },
   "web.colonel.stats.healthy": {
@@ -168,7 +168,7 @@
     "source_hash": "9c28f55c"
   },
   "web.colonel.actions.viewActivityDesc": {
-    "text": "Systeemactiviteit en gebruik monitoren",
+    "text": "Systeemactiviteit en gebruik volgen",
     "source_hash": "f88e9eda"
   },
   "web.colonel.actions.manageAccounts": {
@@ -176,7 +176,7 @@
     "source_hash": "9d114268"
   },
   "web.colonel.actions.manageAccountsDesc": {
-    "text": "Gebruikersaccountbeheer",
+    "text": "Beheer van gebruikersaccounts",
     "source_hash": "d73af927"
   },
   "web.colonel.actions.configureDomains": {
@@ -208,11 +208,11 @@
     "source_hash": "3b2fe03e"
   },
   "web.colonel.pendingMessages": {
-    "text": "Wachtend",
+    "text": "In behandeling",
     "source_hash": "331551b0"
   },
   "web.colonel.consumers": {
-    "text": "Consumenten",
+    "text": "Consumers",
     "source_hash": "212b350d"
   },
   "web.colonel.processingRate": {
@@ -224,11 +224,11 @@
     "source_hash": "3693e288"
   },
   "web.colonel.workerHealth": {
-    "text": "Werkerstatus",
+    "text": "Workerstatus",
     "source_hash": "52be3ac1"
   },
   "web.colonel.activeWorkers": {
-    "text": "actieve werkers",
+    "text": "actieve workers",
     "source_hash": "ea68cfee"
   },
   "web.colonel.noQueueData": {
@@ -236,7 +236,7 @@
     "source_hash": "331ffa6b"
   },
   "web.colonel.loadingQueueData": {
-    "text": "Wachtrijgegevens laden...",
+    "text": "Wachtrijgegevens worden geladen...",
     "source_hash": "a3762a00"
   },
   "web.colonel.testPlanMode": {
@@ -256,7 +256,7 @@
     "source_hash": "9e6e12fe"
   },
   "web.colonel.resetToActual": {
-    "text": "Terugzetten naar werkelijk plan",
+    "text": "Terugzetten naar het werkelijke plan",
     "source_hash": "2cea3f92"
   },
   "web.colonel.currentActualPlan": {
@@ -276,11 +276,11 @@
     "source_hash": "ae2c8dd9"
   },
   "web.colonel.testModeDescription": {
-    "text": "Test je applicatie met verschillende planrechten. Wijzigingen zijn tijdelijk en zijn alleen van toepassing op je sessie.",
+    "text": "Test je applicatie met verschillende plan-entitlements. Wijzigingen zijn tijdelijk en gelden alleen voor je sessie.",
     "source_hash": "be03a409"
   },
   "web.colonel.warningTestMode": {
-    "text": "Je test met {planName}-rechten (tijdelijke sessie-override).",
+    "text": "Je test met de entitlements van {planName} (tijdelijke sessie-override).",
     "source_hash": "1a8aecf1"
   },
   "web.colonel.organizations.title": {
@@ -288,11 +288,11 @@
     "source_hash": "2730183d"
   },
   "web.colonel.organizations.description": {
-    "text": "Organisatie-factureringssynchronisatie monitoren",
+    "text": "Bewaak de synchronisatiestatus van organisatiefacturatie",
     "source_hash": "d8f4398b"
   },
   "web.colonel.organizations.pageTitle": {
-    "text": "Factureringsmonitor",
+    "text": "Facturatiestatusmonitor",
     "source_hash": "9ef57da4"
   },
   "web.colonel.organizations.organizationsCount": {
@@ -300,7 +300,7 @@
     "source_hash": "bc2feb56"
   },
   "web.colonel.organizations.needAttention": {
-    "text": "{count} hebben aandacht nodig",
+    "text": "{count} vereisen aandacht",
     "source_hash": "1c8e5840"
   },
   "web.colonel.organizations.unknownCount": {
@@ -356,7 +356,7 @@
     "source_hash": "7e1b0d56"
   },
   "web.colonel.organizations.columns.billing": {
-    "text": "Facturering",
+    "text": "Facturatie",
     "source_hash": "3ac8bbca"
   },
   "web.colonel.organizations.columns.status": {
@@ -400,15 +400,15 @@
     "source_hash": "53aa279e"
   },
   "web.colonel.organizations.columns.has_billing": {
-    "text": "Heeft facturering",
+    "text": "Heeft facturatie",
     "source_hash": "db0628ed"
   },
   "web.colonel.organizations.legacy.title": {
-    "text": "Organisaties factureringsbeheer",
+    "text": "Facturatiebeheer voor organisaties",
     "source_hash": "5c7e07e7"
   },
   "web.colonel.organizations.legacy.description": {
-    "text": "Organisaties beheren en factureringssynchronisatie monitoren ({total} totaal)",
+    "text": "Beheer organisaties en bewaak de synchronisatiestatus van de facturatie ({total} in totaal)",
     "source_hash": "996b446d"
   },
   "web.colonel.organizations.legacy.empty": {
@@ -436,7 +436,7 @@
     "source_hash": "e2641093"
   },
   "web.colonel.organizations.actions.checking": {
-    "text": "Controleren...",
+    "text": "Bezig met controleren...",
     "source_hash": "2e5f79bb"
   },
   "web.colonel.organizations.expanded.customer": {
@@ -460,19 +460,19 @@
     "source_hash": "2dbc5cc3"
   },
   "web.colonel.organizations.investigation.verifiedSynced": {
-    "text": "Geverifieerd gesynchroniseerd",
+    "text": "Synchronisatie geverifieerd",
     "source_hash": "d92625c2"
   },
   "web.colonel.organizations.investigation.mismatchFound": {
-    "text": "Afwijking gevonden",
+    "text": "Verschil gevonden",
     "source_hash": "361d22f3"
   },
   "web.colonel.organizations.investigation.unableToCompare": {
-    "text": "Kan niet vergelijken",
+    "text": "Vergelijken niet mogelijk",
     "source_hash": "64c822ee"
   },
   "web.colonel.organizations.investigation.stripeDetails": {
-    "text": "Stripe-abonnementsdetails",
+    "text": "Details van Stripe-abonnement",
     "source_hash": "53a7b0ea"
   },
   "web.colonel.organizations.investigation.statusLabel": {
@@ -484,7 +484,7 @@
     "source_hash": "fb9ef894"
   },
   "web.colonel.organizations.investigation.resolvedPlan": {
-    "text": "Opgelost plan",
+    "text": "Bepaald plan",
     "source_hash": "17c5b37a"
   },
   "web.colonel.organizations.investigation.priceId": {
@@ -520,7 +520,7 @@
     "source_hash": "0ece5643"
   },
   "web.colonel.bannedIps.description": {
-    "text": "IP-blokkadelijst beheren",
+    "text": "Beheer de lijst met geblokkeerde IP's",
     "source_hash": "dd0d2614"
   },
   "web.colonel.usageExport.title": {
@@ -528,7 +528,7 @@
     "source_hash": "10a0cb94"
   },
   "web.colonel.usageExport.description": {
-    "text": "Gebruiksgegevens en statistieken exporteren",
+    "text": "Exporteer gebruiksgegevens en statistieken",
     "source_hash": "2fd0a2e2"
   },
   "web.colonel.systemSettings.title": {
@@ -544,15 +544,15 @@
     "source_hash": "6170ab94"
   },
   "web.colonel.customDomains.description": {
-    "text": "Aangepaste domeinen en branding beheren",
+    "text": "Beheer aangepaste domeinen en branding",
     "source_hash": "808ee2cb"
   },
   "web.colonel.feedback.send_feedback": {
-    "text": "Feedback verzenden",
+    "text": "Feedback versturen",
     "source_hash": "8235980b"
   },
   "web.colonel.feedback.sending_ellipses": {
-    "text": "Verzenden...",
+    "text": "Bezig met verzenden...",
     "source_hash": "286a3af7"
   },
   "web.colonel.titles.index": {
@@ -576,7 +576,7 @@
     "source_hash": "c4545e98"
   },
   "web.colonel.titles.authdb": {
-    "text": "Authenticatiedatabase",
+    "text": "Auth-database",
     "source_hash": "c683c9a6"
   },
   "web.colonel.titles.bannedIps": {
@@ -608,7 +608,7 @@
     "source_hash": "cf53f19d"
   },
   "web.colonel.previewModeDescription": {
-    "text": "Bekijk de applicatie zoals deze verschijnt voor klanten met een ander plan. Dit beïnvloedt alleen jouw weergave en verandert niets aan het werkelijke plan van een organisatie.",
+    "text": "Bekijk de applicatie zoals klanten met een ander plan die zien. Dit geldt alleen voor jouw weergave en verandert niets aan het werkelijke plan van een organisatie.",
     "source_hash": "6fe23f23"
   },
   "web.colonel.previewModeActive": {
@@ -660,11 +660,11 @@
     "source_hash": "9f47db0e"
   },
   "web.colonel.bannedIps.error.banFailed": {
-    "text": "Blokkeren van IP-adres mislukt",
+    "text": "IP-adres blokkeren is mislukt",
     "source_hash": "24e94d9b"
   },
   "web.colonel.bannedIps.error.unbanFailed": {
-    "text": "Deblokkeren van IP-adres mislukt",
+    "text": "IP-adres deblokkeren is mislukt",
     "source_hash": "66bbac9a"
   },
   "web.colonel.bannedIps.form.title": {
@@ -780,7 +780,7 @@
     "source_hash": "d70b9e24"
   },
   "web.colonel.secrets.columns.expiration": {
-    "text": "Vervaldatum",
+    "text": "Verval",
     "source_hash": "f38d6e0e"
   },
   "web.colonel.secrets.columns.age": {
@@ -800,7 +800,7 @@
     "source_hash": "1b28d178"
   },
   "web.colonel.backToSite": {
-    "text": "Terug naar site",
+    "text": "Terug naar de site",
     "source_hash": "4ee0f819"
   },
   "web.colonel.customDomains.labels.domain": {
@@ -824,7 +824,7 @@
     "source_hash": "999f23fc"
   },
   "web.colonel.nav.groups.security": {
-    "text": "Toegang & Beveiliging",
+    "text": "Toegang en beveiliging",
     "source_hash": "abb29a3f"
   },
   "web.colonel.nav.groups.platform": {
@@ -838,5 +838,37 @@
   "web.colonel.nav.groups.communications": {
     "text": "Communicatie",
     "source_hash": "919a9253"
+  },
+  "web.colonel.organizations.sameAsContact": {
+    "text": "Hetzelfde als contactpersoon",
+    "source_hash": "ed18ff43"
+  },
+  "web.colonel.organizations.refresh": {
+    "text": "Vernieuwen",
+    "source_hash": "0e916101"
+  },
+  "web.colonel.organizations.updatedAgo": {
+    "text": "Bijgewerkt {ago}",
+    "source_hash": "cda30b9c"
+  },
+  "web.colonel.organizations.columns.name": {
+    "text": "Naam",
+    "source_hash": "dcd1d522"
+  },
+  "web.colonel.organizations.columns.contactEmail": {
+    "text": "Contact-e-mail",
+    "source_hash": "6d7fce11"
+  },
+  "web.colonel.organizations.columns.billingEmail": {
+    "text": "Facturatie-e-mail",
+    "source_hash": "8805b928"
+  },
+  "web.colonel.organizations.columns.planSubscription": {
+    "text": "Plan en abonnement",
+    "source_hash": "b396caac"
+  },
+  "web.colonel.organizations.filters.searchPlaceholder": {
+    "text": "Zoeken op ID, naam of e-mail",
+    "source_hash": "6fe16473"
   }
 }

--- a/locales/content/nl/admin-customers.json
+++ b/locales/content/nl/admin-customers.json
@@ -4,8 +4,8 @@
     "source_hash": "aabe76f1"
   },
   "web.admin.customers.description": {
-    "text": "Vind een klant en los ondersteuningsproblemen op zonder SSH.",
-    "source_hash": "c8487e68"
+    "text": "Zoek een klant en los supportproblemen op.",
+    "source_hash": "00961ea3"
   },
   "web.admin.customers.actions.plan.label": {
     "text": "Plan",
@@ -20,7 +20,7 @@
     "source_hash": "910a4de9"
   },
   "web.admin.customers.actions.plan.confirmDescription": {
-    "text": "Wijzig {email} naar het {plan}-plan.",
+    "text": "Zet {email} over naar het plan {plan}.",
     "source_hash": "83fb4158"
   },
   "web.admin.customers.actions.plan.success": {
@@ -40,7 +40,7 @@
     "source_hash": "9feed9f1"
   },
   "web.admin.customers.actions.purge.confirmDescription": {
-    "text": "Dit verwijdert {email} en al hun gegevens permanent. Dit kan niet ongedaan worden gemaakt.",
+    "text": "Hiermee worden {email} en al hun gegevens permanent verwijderd. Dit kan niet ongedaan worden gemaakt.",
     "source_hash": "a74dd5d1"
   },
   "web.admin.customers.actions.purge.success": {
@@ -84,7 +84,7 @@
     "source_hash": "cbfa275b"
   },
   "web.admin.customers.actions.suspend.confirmDescription": {
-    "text": "Blokkeert het inloggen van {email} en trekt hun actieve sessies in. Er worden geen gegevens verwijderd — dit is omkeerbaar.",
+    "text": "Blokkeert inloggen voor {email} en trekt hun actieve sessies in. Er worden geen gegevens verwijderd — dit is omkeerbaar.",
     "source_hash": "e5d046bc"
   },
   "web.admin.customers.actions.suspend.success": {
@@ -100,7 +100,7 @@
     "source_hash": "6fd78a72"
   },
   "web.admin.customers.actions.unsuspend.confirmDescription": {
-    "text": "Herstelt het inloggen voor {email}.",
+    "text": "Herstelt inloggen voor {email}.",
     "source_hash": "cb2bb4e0"
   },
   "web.admin.customers.actions.unsuspend.success": {
@@ -108,11 +108,11 @@
     "source_hash": "c5b4377f"
   },
   "web.admin.customers.actions.unverify.button": {
-    "text": "Verificatie opheffen",
+    "text": "Verificatie intrekken",
     "source_hash": "b0dee41f"
   },
   "web.admin.customers.actions.unverify.confirmTitle": {
-    "text": "Verificatie van klant opheffen?",
+    "text": "Verificatie van klant intrekken?",
     "source_hash": "62ed2854"
   },
   "web.admin.customers.actions.unverify.confirmDescription": {
@@ -120,7 +120,7 @@
     "source_hash": "592ffd27"
   },
   "web.admin.customers.actions.unverify.success": {
-    "text": "Verificatie van klant opgeheven.",
+    "text": "Verificatie van klant ingetrokken.",
     "source_hash": "a9b7bbac"
   },
   "web.admin.customers.actions.verify.button": {
@@ -164,7 +164,7 @@
     "source_hash": "d70b9e24"
   },
   "web.admin.customers.columns.lastLogin": {
-    "text": "Laatste login",
+    "text": "Laatste keer ingelogd",
     "source_hash": "0d39602d"
   },
   "web.admin.customers.detail.backToList": {
@@ -184,7 +184,7 @@
     "source_hash": "82b04725"
   },
   "web.admin.customers.detail.loadError": {
-    "text": "Kon deze klant niet laden.",
+    "text": "Deze klant kon niet worden geladen.",
     "source_hash": "cfd1bcca"
   },
   "web.admin.customers.detail.retry": {
@@ -264,7 +264,7 @@
     "source_hash": "fa8ed0bd"
   },
   "web.admin.customers.detail.fields.locale": {
-    "text": "Landinstelling",
+    "text": "Taalinstelling",
     "source_hash": "ca3dc612"
   },
   "web.admin.customers.detail.fields.created": {
@@ -276,7 +276,7 @@
     "source_hash": "3a5ecca1"
   },
   "web.admin.customers.detail.fields.lastLogin": {
-    "text": "Laatste login",
+    "text": "Laatste keer ingelogd",
     "source_hash": "0d39602d"
   },
   "web.admin.customers.detail.fields.suspendedAt": {
@@ -328,7 +328,7 @@
     "source_hash": "d70b9e24"
   },
   "web.admin.customers.detail.secretColumns.expiration": {
-    "text": "Vervaldatum",
+    "text": "Verval",
     "source_hash": "f38d6e0e"
   },
   "web.admin.customers.detail.secrets.empty": {
@@ -368,7 +368,7 @@
     "source_hash": "6f064eb9"
   },
   "web.admin.customers.detail.sessions.loadError": {
-    "text": "Kan sessies niet laden.",
+    "text": "Sessies kunnen niet worden geladen.",
     "source_hash": "d2884313"
   },
   "web.admin.customers.detail.sessions.unknown": {
@@ -388,7 +388,7 @@
     "source_hash": "6ba0bdec"
   },
   "web.admin.customers.detail.sessions.columns.authMethod": {
-    "text": "Authenticatiemethode",
+    "text": "Auth-methode",
     "source_hash": "bc4ea262"
   },
   "web.admin.customers.detail.sessions.columns.actions": {
@@ -404,7 +404,7 @@
     "source_hash": "7735d1ef"
   },
   "web.admin.customers.detail.sessions.revoke.confirmDescription": {
-    "text": "Dit logt de gebruiker onmiddellijk uit deze sessie uit. Ze moeten opnieuw inloggen.",
+    "text": "Hiermee wordt de gebruiker direct uitgelogd uit deze sessie. Diegene moet opnieuw inloggen.",
     "source_hash": "b4291af0"
   },
   "web.admin.customers.detail.sessions.revoke.success": {
@@ -412,15 +412,15 @@
     "source_hash": "5e4762e5"
   },
   "web.admin.customers.detail.sessions.revokeAll.button": {
-    "text": "Alles intrekken",
+    "text": "Alle intrekken",
     "source_hash": "c6847a4b"
   },
   "web.admin.customers.detail.sessions.revokeAll.confirmTitle": {
-    "text": "Elke sessie intrekken?",
+    "text": "Alle sessies intrekken?",
     "source_hash": "a4fa4c65"
   },
   "web.admin.customers.detail.sessions.revokeAll.confirmDescription": {
-    "text": "Dit logt de gebruiker uit op elk apparaat en in elke browser — inclusief sessies die niet in deze lijst worden getoond — en blokkeert onmiddellijk hun geauthenticeerde routes. Gebruik dit bij offboarding of een vermoedelijke accountovername. Typ de ID van de gebruiker om te bevestigen.",
+    "text": "Hiermee wordt de gebruiker op elk apparaat en in elke browser uitgelogd — ook sessies die niet in deze lijst staan — en worden hun geverifieerde routes direct geblokkeerd. Gebruik dit bij offboarding of een vermoedelijke accountovername. Typ de ID van de gebruiker om te bevestigen.",
     "source_hash": "483cdd88"
   },
   "web.admin.customers.detail.sessions.revokeAll.success": {
@@ -428,19 +428,19 @@
     "source_hash": "4e1cce55"
   },
   "web.admin.customers.detail.sessions.revokeAll.capped": {
-    "text": "{count} sessies beëindigd, maar de opschoning van niet-bijgehouden sessies werd afgekapt — een oudere sessie kan achterblijven. Voer opnieuw uit om zeker te zijn.",
+    "text": "{count} sessies beëindigd, maar het opschonen van niet-bijgehouden sessies is afgekapt — er kan nog een oudere sessie bestaan. Voer dit nogmaals uit om zeker te zijn.",
     "source_hash": "e3d295a6"
   },
   "web.admin.customers.detail.stats.secretsCreated": {
-    "text": "Berichten aangemaakt",
+    "text": "Aangemaakte berichten",
     "source_hash": "7d17719e"
   },
   "web.admin.customers.detail.stats.secretsShared": {
-    "text": "Berichten gedeeld",
+    "text": "Gedeelde berichten",
     "source_hash": "ba85b265"
   },
   "web.admin.customers.detail.stats.emailsSent": {
-    "text": "E-mails verzonden",
+    "text": "Verzonden e-mails",
     "source_hash": "be604792"
   },
   "web.admin.customers.list.roleFilter": {
@@ -452,7 +452,7 @@
     "source_hash": "dc754ec0"
   },
   "web.admin.customers.list.loadError": {
-    "text": "Kon klanten niet laden.",
+    "text": "Klanten konden niet worden geladen.",
     "source_hash": "81783303"
   },
   "web.admin.customers.list.searchPlaceholder": {
@@ -482,5 +482,213 @@
   "web.admin.customers.suspended.badge": {
     "text": "Opgeschort",
     "source_hash": "e392a389"
+  },
+  "web.admin.customers.actions.checkoutLink.button": {
+    "text": "Afrekenlink aanmaken",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.modalTitle": {
+    "text": "Afrekenlink aanmaken",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.planLabel": {
+    "text": "Plan",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.actions.checkoutLink.planPlaceholder": {
+    "text": "Plan-family-id (bijv. identity_plus_v1)",
+    "source_hash": "12eba027"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleLabel": {
+    "text": "Facturatiecyclus",
+    "source_hash": "d69f731e"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleMonthly": {
+    "text": "Maandelijks",
+    "source_hash": "9b11f6b7"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleYearly": {
+    "text": "Jaarlijks",
+    "source_hash": "6e69b59e"
+  },
+  "web.admin.customers.actions.checkoutLink.allowPromo": {
+    "text": "Promotiecodes toestaan",
+    "source_hash": "ebe7bc8b"
+  },
+  "web.admin.customers.actions.checkoutLink.submit": {
+    "text": "Link aanmaken",
+    "source_hash": "e6b850cf"
+  },
+  "web.admin.customers.actions.checkoutLink.resultLead": {
+    "text": "Afrekenlink aangemaakt. Deel deze met de klant — hij kan één keer worden gebruikt en verloopt daarna.",
+    "source_hash": "6ff1fb0e"
+  },
+  "web.admin.customers.actions.checkoutLink.copy": {
+    "text": "Afrekenlink kopiëren",
+    "source_hash": "f1e51ca7"
+  },
+  "web.admin.customers.actions.checkoutLink.expiry": {
+    "text": "Verloopt over ~{hours} uur ({date}).",
+    "source_hash": "4c878a15"
+  },
+  "web.admin.customers.actions.checkoutLink.regionLabel": {
+    "text": "Regio",
+    "source_hash": "d3a008ef"
+  },
+  "web.admin.customers.actions.checkoutLink.parseError": {
+    "text": "De server heeft het verzoek geaccepteerd maar gaf een onleesbaar antwoord terug, dus er kan geen link worden getoond. Controleer Stripe voordat je het opnieuw probeert.",
+    "source_hash": "e7e08290"
+  },
+  "web.admin.customers.actions.checkoutLink.done": {
+    "text": "Klaar",
+    "source_hash": "11a6767d"
+  },
+  "web.admin.customers.actions.purge.typePrompt": {
+    "text": "Typ ter bevestiging het e-mailadres van het account {token} hieronder",
+    "source_hash": "8b2a1819"
+  },
+  "web.admin.customers.actions.purge.unavailable": {
+    "text": "Wissen is niet beschikbaar: dit account heeft geen e-mailadres om ter bevestiging over te typen.",
+    "source_hash": "5f20f7e5"
+  },
+  "web.admin.customers.columns.actions": {
+    "text": "Acties",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.diagnostics.title": {
+    "text": "Accountdiagnose",
+    "source_hash": "5574ece8"
+  },
+  "web.admin.customers.detail.diagnostics.loading": {
+    "text": "Diagnose wordt uitgevoerd…",
+    "source_hash": "062c83d5"
+  },
+  "web.admin.customers.detail.diagnostics.loadError": {
+    "text": "Diagnose kan niet worden geladen.",
+    "source_hash": "69e69f49"
+  },
+  "web.admin.customers.detail.diagnostics.healthy": {
+    "text": "Geen blokkerende toestand gevonden. De auth-status ziet er gezond uit — denk aan problemen aan clientzijde (cookies, inlogconfiguratie voor aangepaste domeinen) of de verkeerde regio.",
+    "source_hash": "f6d5f8d1"
+  },
+  "web.admin.customers.detail.diagnostics.authUnavailable": {
+    "text": "Auth-database niet beschikbaar (eenvoudige auth-modus) — controles aan SQL-zijde zijn overgeslagen.",
+    "source_hash": "d668907c"
+  },
+  "web.admin.customers.detail.diagnostics.authFailed": {
+    "text": "De auth-database gaf geen antwoord, dus controles aan SQL-zijde konden niet worden uitgevoerd: {reason}",
+    "source_hash": "46d047c0"
+  },
+  "web.admin.customers.detail.diagnostics.unknown": {
+    "text": "Onbekend",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.title": {
+    "text": "Authenticatielogboek",
+    "source_hash": "48ad8ba8"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.empty": {
+    "text": "Geen authenticatiegebeurtenissen vastgelegd.",
+    "source_hash": "d2332558"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.unavailable": {
+    "text": "Het authenticatielogboek kon niet worden gelezen: {reason}",
+    "source_hash": "ab18af57"
+  },
+  "web.admin.customers.detail.diagnostics.facts.authStatus": {
+    "text": "Auth-status",
+    "source_hash": "34def169"
+  },
+  "web.admin.customers.detail.diagnostics.facts.noAccount": {
+    "text": "Geen auth-account",
+    "source_hash": "a9968e9e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.password": {
+    "text": "Wachtwoord",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordSet": {
+    "text": "Ingesteld",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordNone": {
+    "text": "Geen",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfa": {
+    "text": "MFA",
+    "source_hash": "d39ce053"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfaNone": {
+    "text": "Geen",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.loginFailures": {
+    "text": "Mislukte pogingen",
+    "source_hash": "63e7f0a8"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lockedBadge": {
+    "text": "Vergrendeld",
+    "source_hash": "ace29f74"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiter": {
+    "text": "Rate limiter",
+    "source_hash": "32892404"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterEngaged": {
+    "text": "Actief",
+    "source_hash": "1b0d851e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterClear": {
+    "text": "Vrij",
+    "source_hash": "83b12c22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verification": {
+    "text": "Verificatie-e-mail",
+    "source_hash": "23fac8fb"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationPending": {
+    "text": "In behandeling — laatst verzonden {date}",
+    "source_hash": "9ab8d1b6"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationNone": {
+    "text": "Niets in behandeling",
+    "source_hash": "a4d4cc22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.sessions": {
+    "text": "Actieve sessies",
+    "source_hash": "61ad9909"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lastLogin": {
+    "text": "Laatste keer ingelogd (auth)",
+    "source_hash": "373e7fb1"
+  },
+  "web.admin.customers.detail.receipts.partial": {
+    "text": "Gedeeltelijke lijst — de {count} meest recente worden getoond. Deze klant heeft meer ontvangstbewijzen dan hier zichtbaar.",
+    "source_hash": "127fd4db"
+  },
+  "web.admin.customers.detail.secrets.partial": {
+    "text": "Gedeeltelijke lijst — de {count} meest recente worden getoond. Deze klant heeft meer berichten dan hier zichtbaar.",
+    "source_hash": "a537c8f3"
+  },
+  "web.admin.customers.detail.sessions.columns.country": {
+    "text": "Land",
+    "source_hash": "701d021d"
+  },
+  "web.admin.customers.detail.sessions.current.badge": {
+    "text": "Deze sessie",
+    "source_hash": "6da6530a"
+  },
+  "web.admin.customers.detail.sessions.current.tooltip": {
+    "text": "Je huidige beheerderssessie. Deze hier intrekken heeft geen effect — hij wordt voor de rest van dit verzoek opnieuw aangemaakt.",
+    "source_hash": "ef097ab1"
+  },
+  "web.admin.customers.verification.verified": {
+    "text": "Geverifieerd",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.verification.unverified": {
+    "text": "Niet geverifieerd",
+    "source_hash": "15133907"
   }
 }

--- a/locales/content/nl/admin-domains.json
+++ b/locales/content/nl/admin-domains.json
@@ -36,15 +36,15 @@
     "source_hash": "2263ec6a"
   },
   "web.admin.domains.addDomain.strategy.approximated": {
-    "text": "Approximated — DNS-eigendomscontrole, geen proxying.",
+    "text": "Approximated — controle van DNS-eigendom, geen proxying.",
     "source_hash": "79a7245c"
   },
   "web.admin.domains.addDomain.strategy.passthrough": {
-    "text": "Passthrough — je wijst DNS naar de proxy van deze deployment.",
+    "text": "Passthrough — je wijst DNS aan de proxy van deze deployment toe.",
     "source_hash": "9702d758"
   },
   "web.admin.domains.addDomain.strategy.external": {
-    "text": "External — DNS wordt buiten deze deployment beheerd.",
+    "text": "Extern — DNS wordt buiten deze deployment beheerd.",
     "source_hash": "acaede35"
   },
   "web.admin.domains.addDomain.strategy.caddy_on_demand": {
@@ -60,23 +60,23 @@
     "source_hash": "4587f9cf"
   },
   "web.admin.domains.attach.cta": {
-    "text": "Domein koppelen aan organisatie",
+    "text": "Domein aan organisatie koppelen",
     "source_hash": "736d74ce"
   },
   "web.admin.domains.attach.recordEyebrow": {
-    "text": "Werkrecord",
+    "text": "Actief record",
     "source_hash": "2fadf983"
   },
   "web.admin.domains.attach.rosterError": {
-    "text": "Kon de domeinen van deze organisatie niet laden.",
+    "text": "De domeinen van deze organisatie konden niet worden geladen.",
     "source_hash": "d3055fed"
   },
   "web.admin.domains.attach.noDomains": {
-    "text": "Nog geen domeinen gekoppeld aan deze organisatie.",
+    "text": "Nog geen domeinen aan deze organisatie gekoppeld.",
     "source_hash": "e9a25fc4"
   },
   "web.admin.domains.attach.openExternal": {
-    "text": "Open {domain} in een nieuw tabblad",
+    "text": "{domain} openen in een nieuw tabblad",
     "source_hash": "c5fbdeaa"
   },
   "web.admin.domains.dns.heading": {
@@ -88,15 +88,15 @@
     "source_hash": "fdcfcfb0"
   },
   "web.admin.domains.dns.aStep": {
-    "text": "2. Voeg een A-record toe dat de apex naar de proxy wijst.",
+    "text": "2. Voeg een A-record toe dat het apex naar de proxy verwijst.",
     "source_hash": "aedbf197"
   },
   "web.admin.domains.dns.cnameStep": {
-    "text": "2. Voeg een CNAME-record toe dat het subdomein naar de proxy wijst.",
+    "text": "2. Voeg een CNAME-record toe dat het subdomein naar de proxy verwijst.",
     "source_hash": "5c626f53"
   },
   "web.admin.domains.dns.propagationNote": {
-    "text": "DNS-wijzigingen kunnen een paar minuten duren om te propageren voordat verificatie slaagt.",
+    "text": "DNS-wijzigingen kunnen enkele minuten nodig hebben om te propageren voordat verificatie slaagt.",
     "source_hash": "7caf70a7"
   },
   "web.admin.domains.dns.toggle": {
@@ -128,7 +128,7 @@
     "source_hash": "fdef7332"
   },
   "web.admin.domains.orgPicker.loadError": {
-    "text": "Kon organisaties niet doorzoeken.",
+    "text": "Kon organisaties niet zoeken.",
     "source_hash": "b9e45dcf"
   },
   "web.admin.domains.orgPicker.parseError": {
@@ -176,11 +176,11 @@
     "source_hash": "802b5d1e"
   },
   "web.admin.domains.verify.success.resolving": {
-    "text": "{domain} wordt opgelost maar is nog niet geverifieerd.",
+    "text": "{domain} is aan het verifiëren maar nog niet geverifieerd.",
     "source_hash": "bc8aecad"
   },
   "web.admin.domains.verify.success.pending": {
-    "text": "{domain} is in behandeling — DNS wordt nog niet opgelost.",
+    "text": "{domain} is in behandeling — DNS is nog niet aan het verifiëren.",
     "source_hash": "0d9f66d5"
   },
   "web.admin.domains.verify.success.unverified": {
@@ -190,5 +190,657 @@
   "web.admin.domains.verify.success.done": {
     "text": "Verificatie voltooid voor {domain}.",
     "source_hash": "ed67e22d"
+  },
+  "web.admin.domains.actions.preview": {
+    "text": "Voorbeeld",
+    "source_hash": "324b134f"
+  },
+  "web.admin.domains.actions.probe.button": {
+    "text": "Testen",
+    "source_hash": "3bd51ab9"
+  },
+  "web.admin.domains.actions.remove.button": {
+    "text": "Domein verwijderen",
+    "source_hash": "5ce43507"
+  },
+  "web.admin.domains.actions.remove.previewButton": {
+    "text": "Verwijdering in voorbeeld bekijken",
+    "source_hash": "6b81bd92"
+  },
+  "web.admin.domains.actions.remove.previewStatus": {
+    "text": "Status:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.remove.previewOrg": {
+    "text": "Organisatie:",
+    "source_hash": "5300e286"
+  },
+  "web.admin.domains.actions.remove.reassertsSurvivor": {
+    "text": "Een ander record claimt dezelfde domeinnaam en neemt de opzoekindex over.",
+    "source_hash": "902838f4"
+  },
+  "web.admin.domains.actions.remove.confirmTitle": {
+    "text": "Domein verwijderen?",
+    "source_hash": "716dfac9"
+  },
+  "web.admin.domains.actions.remove.confirmDescription": {
+    "text": "Hiermee worden {domain} en de bijbehorende branding-, DNS- en configuratierecords permanent verwijderd. Dit kan niet ongedaan worden gemaakt. Typ de openbare ID van het domein opnieuw om door te gaan.",
+    "source_hash": "d0b67b47"
+  },
+  "web.admin.domains.actions.remove.success": {
+    "text": "Domein verwijderd.",
+    "source_hash": "2ccaa6d3"
+  },
+  "web.admin.domains.actions.remove.notApplied": {
+    "text": "De server heeft de verwijdering alleen in voorbeeld getoond in plaats van toegepast — het domein is NIET verwijderd. Probeer het opnieuw en meld dit als het blijft gebeuren.",
+    "source_hash": "dc6d70ae"
+  },
+  "web.admin.domains.actions.repair.title": {
+    "text": "Organisatiekoppeling herstellen",
+    "source_hash": "82b40352"
+  },
+  "web.admin.domains.actions.repair.description": {
+    "text": "Zoek en herstel verbroken koppelingen tussen dit domein en zijn organisatie. Bekijk eerst een voorbeeld om te zien wat er zou veranderen.",
+    "source_hash": "531ed287"
+  },
+  "web.admin.domains.actions.repair.orgIdLabel": {
+    "text": "Organisatie-ID (alleen voor verweesde domeinen)",
+    "source_hash": "0d3010eb"
+  },
+  "web.admin.domains.actions.repair.orgIdPlaceholder": {
+    "text": "Laat leeg tenzij het domein geen eigenaar heeft",
+    "source_hash": "118b7132"
+  },
+  "web.admin.domains.actions.repair.statusLabel": {
+    "text": "Status:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.repair.noIssues": {
+    "text": "Geen problemen gevonden — niets te herstellen.",
+    "source_hash": "17735887"
+  },
+  "web.admin.domains.actions.repair.button": {
+    "text": "Herstel toepassen",
+    "source_hash": "4d0ab2d4"
+  },
+  "web.admin.domains.actions.repair.confirmTitle": {
+    "text": "Herstel toepassen?",
+    "source_hash": "ef0ffae5"
+  },
+  "web.admin.domains.actions.repair.confirmDescription": {
+    "text": "Hiermee wordt de organisatiekoppeling voor {domain} herschreven. Typ de openbare ID van het domein opnieuw om door te gaan.",
+    "source_hash": "a9f2702f"
+  },
+  "web.admin.domains.actions.repair.success": {
+    "text": "Herstel toegepast.",
+    "source_hash": "850bd784"
+  },
+  "web.admin.domains.actions.transfer.title": {
+    "text": "Overdragen aan een andere organisatie",
+    "source_hash": "1b0b0655"
+  },
+  "web.admin.domains.actions.transfer.description": {
+    "text": "Verplaats dit domein naar een andere organisatie. Bekijk eerst een voorbeeld om beide kanten van de verplaatsing te bevestigen.",
+    "source_hash": "457e852d"
+  },
+  "web.admin.domains.actions.transfer.toOrgLabel": {
+    "text": "ID van de doelorganisatie",
+    "source_hash": "1a3f05c4"
+  },
+  "web.admin.domains.actions.transfer.fromOrgLabel": {
+    "text": "Verwachte huidige organisatie-ID (optioneel)",
+    "source_hash": "f6e75729"
+  },
+  "web.admin.domains.actions.transfer.fromOrgPlaceholder": {
+    "text": "Bevestig de huidige eigenaar vóór het verplaatsen",
+    "source_hash": "1ac6c59b"
+  },
+  "web.admin.domains.actions.transfer.from": {
+    "text": "Van",
+    "source_hash": "21819769"
+  },
+  "web.admin.domains.actions.transfer.to": {
+    "text": "Naar",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.domains.actions.transfer.orphaned": {
+    "text": "Geen organisatie (verweesd)",
+    "source_hash": "6f4c745c"
+  },
+  "web.admin.domains.actions.transfer.button": {
+    "text": "Overdracht toepassen",
+    "source_hash": "fb546c5c"
+  },
+  "web.admin.domains.actions.transfer.confirmTitle": {
+    "text": "Domein overdragen?",
+    "source_hash": "801eb986"
+  },
+  "web.admin.domains.actions.transfer.confirmDescription": {
+    "text": "Hiermee wordt {domain} verplaatst naar organisatie {org}. Typ de openbare ID van het domein opnieuw om door te gaan.",
+    "source_hash": "52c8808d"
+  },
+  "web.admin.domains.actions.transfer.success": {
+    "text": "Domein overgedragen.",
+    "source_hash": "91e681ae"
+  },
+  "web.admin.domains.columns.domain": {
+    "text": "Domein",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domains.columns.organization": {
+    "text": "Organisatie",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.columns.state": {
+    "text": "Verificatie",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.domains.columns.tls": {
+    "text": "TLS",
+    "source_hash": "d1c18ec0"
+  },
+  "web.admin.domains.columns.created": {
+    "text": "Aangemaakt",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.columns.actions": {
+    "text": "Acties",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.configs.title": {
+    "text": "Domeinconfiguratie",
+    "source_hash": "d46aa480"
+  },
+  "web.admin.domains.configs.description": {
+    "text": "Configuratierecords per domein die inloggen, aanmelden, homepageberichten, API-toegang, inkomende berichten, tenant-SSO en e-mailverzending regelen. Bij een ontbrekend record blijven de eerste vijf uitgeschakeld.",
+    "source_hash": "1df99789"
+  },
+  "web.admin.domains.configs.loadError": {
+    "text": "De domeinconfiguratierecords konden niet worden geladen.",
+    "source_hash": "9417d718"
+  },
+  "web.admin.domains.configs.retry": {
+    "text": "Opnieuw proberen",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.configs.degraded": {
+    "text": "Het configuratieantwoord voldeed niet aan het verwachte contract. Vernieuw de pagina en meld dit als het blijft gebeuren.",
+    "source_hash": "b5d890c0"
+  },
+  "web.admin.domains.configs.notFoundNote": {
+    "text": "Dit domein bestaat niet meer, dus de configuratierecords kunnen niet worden geladen.",
+    "source_hash": "2d88a392"
+  },
+  "web.admin.domains.configs.detailsToggle": {
+    "text": "Details",
+    "source_hash": "45989de4"
+  },
+  "web.admin.domains.configs.notEditable": {
+    "text": "Beheerd in de domeininstellingen van de werkruimte.",
+    "source_hash": "54fe891f"
+  },
+  "web.admin.domains.configs.delete.button": {
+    "text": "Verwijderen",
+    "source_hash": "e2d0a549"
+  },
+  "web.admin.domains.configs.delete.confirmTitle": {
+    "text": "Configuratie {kind} verwijderen?",
+    "source_hash": "98e672db"
+  },
+  "web.admin.domains.configs.delete.confirmDescription": {
+    "text": "Hiermee wordt het configuratierecord {kind} voor {domain} permanent verwijderd. Het domein valt terug op het gedrag bij een ontbrekend record. Typ de soort opnieuw om door te gaan.",
+    "source_hash": "8272c40c"
+  },
+  "web.admin.domains.configs.delete.success": {
+    "text": "Configuratie verwijderd.",
+    "source_hash": "a0184b66"
+  },
+  "web.admin.domains.configs.edit.button": {
+    "text": "Bewerken",
+    "source_hash": "464c4ffd"
+  },
+  "web.admin.domains.configs.edit.createButton": {
+    "text": "Aanmaken",
+    "source_hash": "4759498a"
+  },
+  "web.admin.domains.configs.edit.title": {
+    "text": "{kind} configureren",
+    "source_hash": "8592148f"
+  },
+  "web.admin.domains.configs.edit.submit": {
+    "text": "Opslaan",
+    "source_hash": "1509f561"
+  },
+  "web.admin.domains.configs.edit.success": {
+    "text": "Configuratie opgeslagen.",
+    "source_hash": "6b5b3c69"
+  },
+  "web.admin.domains.configs.edit.unsetOption": {
+    "text": "Niet ingesteld",
+    "source_hash": "4895f731"
+  },
+  "web.admin.domains.configs.edit.domainsHint": {
+    "text": "Eén domein per regel.",
+    "source_hash": "6c03f4f7"
+  },
+  "web.admin.domains.configs.ensure.button": {
+    "text": "Maak ontbrekende configuraties aan",
+    "source_hash": "77991b75"
+  },
+  "web.admin.domains.configs.ensure.confirmTitle": {
+    "text": "Ontbrekende configuratierecords aanmaken?",
+    "source_hash": "3f41dec2"
+  },
+  "web.admin.domains.configs.ensure.confirmDescription": {
+    "text": "Maakt uitgeschakelde records aan op {domain} voor: {kinds}. Alles start uitgeschakeld, dus het gedrag verandert pas als een record wordt ingeschakeld.",
+    "source_hash": "fed66221"
+  },
+  "web.admin.domains.configs.ensure.applyButton": {
+    "text": "Records aanmaken",
+    "source_hash": "4bcbef42"
+  },
+  "web.admin.domains.configs.ensure.success": {
+    "text": "Ontbrekende configuratierecords aangemaakt.",
+    "source_hash": "3b6ead80"
+  },
+  "web.admin.domains.configs.ensure.nothingMissing": {
+    "text": "Niets aan te maken — elk configuratierecord bestaat al. De lijst is vernieuwd.",
+    "source_hash": "ad0df0ae"
+  },
+  "web.admin.domains.configs.ensure.notApplied": {
+    "text": "De server heeft de wijziging alleen bekeken in plaats van toegepast — er zijn geen records aangemaakt. Probeer opnieuw en meld dit als het probleem aanhoudt.",
+    "source_hash": "09d26379"
+  },
+  "web.admin.domains.configs.fields.enabled": {
+    "text": "Ingeschakeld",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.fields.signin_enabled": {
+    "text": "Inloggen ingeschakeld",
+    "source_hash": "cabe4898"
+  },
+  "web.admin.domains.configs.fields.email_auth_enabled": {
+    "text": "E-mailauthenticatie ingeschakeld",
+    "source_hash": "4a762960"
+  },
+  "web.admin.domains.configs.fields.sso_enabled": {
+    "text": "SSO ingeschakeld",
+    "source_hash": "6e77e673"
+  },
+  "web.admin.domains.configs.fields.restrict_to": {
+    "text": "Beperken tot",
+    "source_hash": "a0bdf50a"
+  },
+  "web.admin.domains.configs.fields.signup_enabled": {
+    "text": "Registratie ingeschakeld",
+    "source_hash": "2637d0b2"
+  },
+  "web.admin.domains.configs.fields.autoverify": {
+    "text": "Automatisch verifiëren",
+    "source_hash": "7e02211c"
+  },
+  "web.admin.domains.configs.fields.validation_strategy": {
+    "text": "Validatiestrategie",
+    "source_hash": "a2e95531"
+  },
+  "web.admin.domains.configs.fields.allowed_signup_domains": {
+    "text": "Toegestane registratiedomeinen",
+    "source_hash": "9b5bb5b1"
+  },
+  "web.admin.domains.configs.fields.secrets_mode": {
+    "text": "Berichtenmodus",
+    "source_hash": "8d4349d6"
+  },
+  "web.admin.domains.configs.fields.disabled_homepage_variant": {
+    "text": "Uitgeschakelde homepaginavariant",
+    "source_hash": "4695633b"
+  },
+  "web.admin.domains.configs.fields.ready": {
+    "text": "Gereed",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.configs.fields.recipients": {
+    "text": "Ontvangers",
+    "source_hash": "1e8568a8"
+  },
+  "web.admin.domains.configs.fields.provider_type": {
+    "text": "Providertype",
+    "source_hash": "8c0f6d3e"
+  },
+  "web.admin.domains.configs.fields.display_name": {
+    "text": "Weergavenaam",
+    "source_hash": "2b7f6a84"
+  },
+  "web.admin.domains.configs.fields.issuer": {
+    "text": "Uitgever",
+    "source_hash": "39e02c46"
+  },
+  "web.admin.domains.configs.fields.tenant_id": {
+    "text": "Tenant-ID",
+    "source_hash": "de1f5fff"
+  },
+  "web.admin.domains.configs.fields.has_client_id": {
+    "text": "Client-ID ingesteld",
+    "source_hash": "04a9fa3d"
+  },
+  "web.admin.domains.configs.fields.has_client_secret": {
+    "text": "Clientgeheim ingesteld",
+    "source_hash": "6ee1c9e6"
+  },
+  "web.admin.domains.configs.fields.allowed_domains": {
+    "text": "Toegestane domeinen",
+    "source_hash": "bcd60db0"
+  },
+  "web.admin.domains.configs.fields.enforce_sso_only": {
+    "text": "Alleen SSO afdwingen",
+    "source_hash": "b3a3f694"
+  },
+  "web.admin.domains.configs.fields.grant_org_scope": {
+    "text": "Organisatiebereik toekennen",
+    "source_hash": "698ea5de"
+  },
+  "web.admin.domains.configs.fields.provider": {
+    "text": "Provider",
+    "source_hash": "472590ae"
+  },
+  "web.admin.domains.configs.fields.from_name": {
+    "text": "Afzendernaam",
+    "source_hash": "b28f93ea"
+  },
+  "web.admin.domains.configs.fields.from_address": {
+    "text": "Afzenderadres",
+    "source_hash": "d465bcfa"
+  },
+  "web.admin.domains.configs.fields.reply_to": {
+    "text": "Antwoordadres",
+    "source_hash": "6b9c49b7"
+  },
+  "web.admin.domains.configs.fields.sending_mode": {
+    "text": "Verzendmodus",
+    "source_hash": "e2d6bcf7"
+  },
+  "web.admin.domains.configs.fields.verification_status": {
+    "text": "Verificatiestatus",
+    "source_hash": "aedfff7e"
+  },
+  "web.admin.domains.configs.fields.dns_verified": {
+    "text": "DNS geverifieerd",
+    "source_hash": "8b2128c8"
+  },
+  "web.admin.domains.configs.fields.provider_verified": {
+    "text": "Provider geverifieerd",
+    "source_hash": "6f4d9cc4"
+  },
+  "web.admin.domains.configs.fields.has_api_key": {
+    "text": "API-sleutel ingesteld",
+    "source_hash": "d5115386"
+  },
+  "web.admin.domains.configs.fields.created": {
+    "text": "Aangemaakt",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.configs.fields.updated": {
+    "text": "Bijgewerkt",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.configs.kinds.signin": {
+    "text": "Inloggen",
+    "source_hash": "5bbbe531"
+  },
+  "web.admin.domains.configs.kinds.signup": {
+    "text": "Registratie",
+    "source_hash": "3cc08ebe"
+  },
+  "web.admin.domains.configs.kinds.homepage": {
+    "text": "Homepagina",
+    "source_hash": "9e3391e9"
+  },
+  "web.admin.domains.configs.kinds.api": {
+    "text": "API",
+    "source_hash": "c8e5998f"
+  },
+  "web.admin.domains.configs.kinds.incoming": {
+    "text": "Inkomend",
+    "source_hash": "e301820a"
+  },
+  "web.admin.domains.configs.kinds.sso": {
+    "text": "SSO",
+    "source_hash": "5ba3ac9f"
+  },
+  "web.admin.domains.configs.kinds.mailer": {
+    "text": "Mailer",
+    "source_hash": "6c07ba63"
+  },
+  "web.admin.domains.configs.missingNotes.signin": {
+    "text": "Geen record: inloggen is uitgeschakeld op dit domein tenzij tenant-SSO actief is.",
+    "source_hash": "17dd6099"
+  },
+  "web.admin.domains.configs.missingNotes.signup": {
+    "text": "Geen record: registratie is uitgeschakeld op dit domein.",
+    "source_hash": "c3c98956"
+  },
+  "web.admin.domains.configs.missingNotes.homepage": {
+    "text": "Geen record: homepagina-berichten zijn uitgeschakeld (faalt gesloten en logt een fout).",
+    "source_hash": "9a258a88"
+  },
+  "web.admin.domains.configs.missingNotes.api": {
+    "text": "Geen record: de publieke API is uitgeschakeld (faalt gesloten en logt een fout).",
+    "source_hash": "fed99f73"
+  },
+  "web.admin.domains.configs.missingNotes.incoming": {
+    "text": "Geen record: inkomende berichten zijn uitgeschakeld.",
+    "source_hash": "b957fbe8"
+  },
+  "web.admin.domains.configs.missingNotes.sso": {
+    "text": "Geen record: tenant-SSO is niet beschikbaar; het platform-SSO-terugvalbeleid is van toepassing.",
+    "source_hash": "7b05ade8"
+  },
+  "web.admin.domains.configs.missingNotes.mailer": {
+    "text": "Geen record: de platformmailer wordt gebruikt.",
+    "source_hash": "e027cc99"
+  },
+  "web.admin.domains.configs.status.missing": {
+    "text": "Ontbreekt",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.domains.configs.status.disabled": {
+    "text": "Uitgeschakeld",
+    "source_hash": "75081b59"
+  },
+  "web.admin.domains.configs.status.enabled": {
+    "text": "Ingeschakeld",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.status.enabledNotReady": {
+    "text": "Ingeschakeld, niet gereed",
+    "source_hash": "cb806ba4"
+  },
+  "web.admin.domains.detail.openFullPage": {
+    "text": "Open volledige pagina",
+    "source_hash": "a467911c"
+  },
+  "web.admin.domains.detail.backToList": {
+    "text": "Terug naar domeinen",
+    "source_hash": "22fd50fe"
+  },
+  "web.admin.domains.detail.notFound": {
+    "text": "Domein niet gevonden",
+    "source_hash": "7b8fc0e6"
+  },
+  "web.admin.domains.detail.notFoundDescription": {
+    "text": "Dit domein bestaat niet of is al verwijderd.",
+    "source_hash": "e0f0b987"
+  },
+  "web.admin.domains.detail.loadError": {
+    "text": "Kon dit domein niet laden.",
+    "source_hash": "39e9c657"
+  },
+  "web.admin.domains.detail.retry": {
+    "text": "Opnieuw proberen",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.detail.never": {
+    "text": "Nooit",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.domains.detail.none": {
+    "text": "Geen",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.domains.detail.yes": {
+    "text": "Ja",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.domains.detail.no": {
+    "text": "Nee",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.domains.detail.organization.open": {
+    "text": "Open organisatie",
+    "source_hash": "54a43621"
+  },
+  "web.admin.domains.detail.organization.unknown": {
+    "text": "De eigenaar-organisatie is niet opgenomen in dit antwoord. Open dit domein vanuit de domeinenlijst om deze te zien.",
+    "source_hash": "bb5bdc9c"
+  },
+  "web.admin.domains.detail.sections.overview": {
+    "text": "Overzicht",
+    "source_hash": "d4b1ea57"
+  },
+  "web.admin.domains.detail.sections.actions": {
+    "text": "Acties",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.detail.sections.organization": {
+    "text": "Eigenaar-organisatie",
+    "source_hash": "39ad6d9c"
+  },
+  "web.admin.domains.detail.sections.dns": {
+    "text": "DNS",
+    "source_hash": "020965a2"
+  },
+  "web.admin.domains.detail.sections.diagnostics": {
+    "text": "Diagnostiek",
+    "source_hash": "268f14bb"
+  },
+  "web.admin.domains.detail.sections.operations": {
+    "text": "Eigendomsbewerkingen",
+    "source_hash": "eb9a8cbc"
+  },
+  "web.admin.domains.detail.sections.operationsHint": {
+    "text": "Elke bewerking toont eerst een voorbeeld. Er wordt niets geschreven totdat je de toepassing bevestigt.",
+    "source_hash": "f09bf7bd"
+  },
+  "web.admin.domains.fields.publicId": {
+    "text": "Publieke ID",
+    "source_hash": "3705b64f"
+  },
+  "web.admin.domains.fields.domainId": {
+    "text": "Interne ID",
+    "source_hash": "e468bb47"
+  },
+  "web.admin.domains.fields.organization": {
+    "text": "Organisatie",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.fields.baseDomain": {
+    "text": "Basisdomein",
+    "source_hash": "33295d5b"
+  },
+  "web.admin.domains.fields.subdomain": {
+    "text": "Subdomein",
+    "source_hash": "ba4520ab"
+  },
+  "web.admin.domains.fields.apex": {
+    "text": "Apex-domein",
+    "source_hash": "0a8a42fa"
+  },
+  "web.admin.domains.fields.status": {
+    "text": "Status",
+    "source_hash": "920e413c"
+  },
+  "web.admin.domains.fields.created": {
+    "text": "Aangemaakt",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.fields.updated": {
+    "text": "Bijgewerkt",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.fields.verified": {
+    "text": "Geverifieerd",
+    "source_hash": "4f783840"
+  },
+  "web.admin.domains.fields.resolving": {
+    "text": "Verifiëren",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.fields.ready": {
+    "text": "Gereed",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.list.searchPlaceholder": {
+    "text": "Zoeken op domeinnaam of ID",
+    "source_hash": "aecdd873"
+  },
+  "web.admin.domains.list.stateFilter": {
+    "text": "Status",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.domains.list.emptyFilter": {
+    "text": "Geen domeinen komen overeen met de huidige filters.",
+    "source_hash": "be4d64ec"
+  },
+  "web.admin.domains.probe.healthLabel": {
+    "text": "Gezondheid",
+    "source_hash": "55898449"
+  },
+  "web.admin.domains.probe.certInvalid": {
+    "text": "Certificaat niet bruikbaar",
+    "source_hash": "5535f4d4"
+  },
+  "web.admin.domains.probe.noCertificate": {
+    "text": "Er is geen certificaat geretourneerd — de verbinding mislukte vóór TLS.",
+    "source_hash": "8ffd63be"
+  },
+  "web.admin.domains.probe.fields.httpStatus": {
+    "text": "HTTP-status",
+    "source_hash": "0f7cf91f"
+  },
+  "web.admin.domains.probe.fields.httpError": {
+    "text": "HTTP-fout",
+    "source_hash": "5c6896d4"
+  },
+  "web.admin.domains.probe.fields.sslError": {
+    "text": "TLS-fout",
+    "source_hash": "7b827515"
+  },
+  "web.admin.domains.probe.fields.issuer": {
+    "text": "Certificaatuitgever",
+    "source_hash": "2912559a"
+  },
+  "web.admin.domains.probe.fields.subject": {
+    "text": "Certificaatonderwerp",
+    "source_hash": "d7816b16"
+  },
+  "web.admin.domains.probe.fields.notAfter": {
+    "text": "Certificaat verloopt",
+    "source_hash": "1e73119d"
+  },
+  "web.admin.domains.probe.fields.expiresIn": {
+    "text": "{date} ({days} dagen)",
+    "source_hash": "a71a6e81"
+  },
+  "web.admin.domains.tls.serving": {
+    "text": "Actief",
+    "source_hash": "f55e53f9"
+  },
+  "web.admin.domains.tls.resolving": {
+    "text": "Verifiëren",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.tls.none": {
+    "text": "Niet actief",
+    "source_hash": "da8a5ab9"
   }
 }

--- a/locales/content/nl/admin-domaintoolbox.json
+++ b/locales/content/nl/admin-domaintoolbox.json
@@ -4,7 +4,7 @@
     "source_hash": "5a9333db"
   },
   "web.admin.domaintoolbox.description": {
-    "text": "Diagnosticeer en herstel relaties van aangepaste domeinen: scan verweesde records, test DNS/SSL, herstel eigendom en draag over tussen organisaties.",
+    "text": "Diagnose en repareer aangepaste-domeinrelaties: scan wezen, controleer DNS/SSL, repareer eigendom en draag over tussen organisaties.",
     "source_hash": "778537aa"
   },
   "web.admin.domaintoolbox.retry": {
@@ -28,7 +28,7 @@
     "source_hash": "ddcea596"
   },
   "web.admin.domaintoolbox.orphaned.description": {
-    "text": "Aangepaste domeinen zonder eigenaarsorganisatie. Gebruik Herstellen om er een opnieuw toe te wijzen.",
+    "text": "Aangepaste domeinen zonder eigenaar-organisatie. Gebruik Repareren om er een toe te wijzen.",
     "source_hash": "967268f5"
   },
   "web.admin.domaintoolbox.orphaned.empty": {
@@ -40,7 +40,7 @@
     "source_hash": "ca0e33bf"
   },
   "web.admin.domaintoolbox.orphaned.repairAction": {
-    "text": "Herstellen",
+    "text": "Repareren",
     "source_hash": "1196b6c5"
   },
   "web.admin.domaintoolbox.orphaned.columns.domain": {
@@ -64,15 +64,15 @@
     "source_hash": "ff8059dc"
   },
   "web.admin.domaintoolbox.probe.title": {
-    "text": "Test (DNS / SSL)",
+    "text": "Probe (DNS / SSL)",
     "source_hash": "ec69a087"
   },
   "web.admin.domaintoolbox.probe.description": {
-    "text": "Doe een live HTTPS-verzoek om te bevestigen dat het domein verkeer bedient en om het TLS-certificaat te inspecteren. Alleen-lezen.",
+    "text": "Doe een live HTTPS-verzoek om te bevestigen dat het domein verkeer bedient en inspecteer het TLS-certificaat. Alleen-lezen.",
     "source_hash": "1eecfa96"
   },
   "web.admin.domaintoolbox.probe.button": {
-    "text": "Testen",
+    "text": "Probe",
     "source_hash": "3bd51ab9"
   },
   "web.admin.domaintoolbox.probe.healthLabel": {
@@ -80,11 +80,11 @@
     "source_hash": "55898449"
   },
   "web.admin.domaintoolbox.repair.title": {
-    "text": "Relatie herstellen",
+    "text": "Relatie repareren",
     "source_hash": "0053d07c"
   },
   "web.admin.domaintoolbox.repair.description": {
-    "text": "Herstel inconsistenties in de organisatierelatie voor een domein. Bekijk eerst een voorbeeld en pas daarna toe.",
+    "text": "Los organisatie-relatie-inconsistenties voor een domein op. Bekijk eerst een voorbeeld, pas daarna toe.",
     "source_hash": "18ca490b"
   },
   "web.admin.domaintoolbox.repair.orgIdLabel": {
@@ -104,15 +104,15 @@
     "source_hash": "e1a4c49d"
   },
   "web.admin.domaintoolbox.repair.applyButton": {
-    "text": "Herstellingen toepassen",
+    "text": "Reparaties toepassen",
     "source_hash": "3f92b29f"
   },
   "web.admin.domaintoolbox.repair.success": {
-    "text": "Herstellingen succesvol toegepast.",
+    "text": "Reparaties succesvol toegepast.",
     "source_hash": "24f25b9b"
   },
   "web.admin.domaintoolbox.repair.confirmTitle": {
-    "text": "Domeinherstellingen toepassen?",
+    "text": "Domeinreparaties toepassen?",
     "source_hash": "9429998b"
   },
   "web.admin.domaintoolbox.repair.confirmDescription": {
@@ -124,7 +124,7 @@
     "source_hash": "0344860a"
   },
   "web.admin.domaintoolbox.reverify.success": {
-    "text": "Herverificatie van domein voltooid.",
+    "text": "Domein-herverificatie voltooid.",
     "source_hash": "497a2348"
   },
   "web.admin.domaintoolbox.transfer.title": {
@@ -132,7 +132,7 @@
     "source_hash": "3667f939"
   },
   "web.admin.domaintoolbox.transfer.description": {
-    "text": "Wijs een domein toe aan een andere organisatie. Actie met de grootste impact — bekijk een voorbeeld en bevestig zorgvuldig.",
+    "text": "Wijs een domein toe aan een andere organisatie. Actie met de grootste impact — bekijk en bevestig zorgvuldig.",
     "source_hash": "d4e26e03"
   },
   "web.admin.domaintoolbox.transfer.toOrgLabel": {
@@ -144,7 +144,7 @@
     "source_hash": "3666815f"
   },
   "web.admin.domaintoolbox.transfer.fromOrgPlaceholder": {
-    "text": "huidige eigenaar bevestigen",
+    "text": "bevestig huidige eigenaar",
     "source_hash": "cd9e769c"
   },
   "web.admin.domaintoolbox.transfer.from": {
@@ -172,7 +172,7 @@
     "source_hash": "d306a15a"
   },
   "web.admin.domaintoolbox.transfer.confirmDescription": {
-    "text": "Dit draagt het eigendom van {domain} over aan een andere organisatie. Typ de externe domein-ID opnieuw om te bevestigen.",
+    "text": "Dit wijst het eigendom van {domain} toe aan een andere organisatie. Typ de externe domein-ID opnieuw om te bevestigen.",
     "source_hash": "edefd97c"
   }
 }

--- a/locales/content/nl/admin-domaintoolbox.json
+++ b/locales/content/nl/admin-domaintoolbox.json
@@ -64,7 +64,7 @@
     "source_hash": "ff8059dc"
   },
   "web.admin.domaintoolbox.probe.title": {
-    "text": "Probe (DNS / SSL)",
+    "text": "Test (DNS / SSL)",
     "source_hash": "ec69a087"
   },
   "web.admin.domaintoolbox.probe.description": {
@@ -72,7 +72,7 @@
     "source_hash": "1eecfa96"
   },
   "web.admin.domaintoolbox.probe.button": {
-    "text": "Probe",
+    "text": "Testen",
     "source_hash": "3bd51ab9"
   },
   "web.admin.domaintoolbox.probe.healthLabel": {

--- a/locales/content/nl/admin-emailtools.json
+++ b/locales/content/nl/admin-emailtools.json
@@ -4,7 +4,7 @@
     "source_hash": "f9643d5a"
   },
   "web.admin.emailtools.description": {
-    "text": "Bekijk e-mailsjablonen, verstuur een bezorgtest en bewaak de bezorgbaarheid — de diagnostiek waarvoor voorheen SSH nodig was.",
+    "text": "Bekijk e-mailsjablonen, stuur een bezorgingstest en monitor bezorgbaarheid — de diagnostiek waarvoor voorheen SSH nodig was.",
     "source_hash": "be85c9e9"
   },
   "web.admin.emailtools.config.title": {
@@ -12,7 +12,7 @@
     "source_hash": "d2a71028"
   },
   "web.admin.emailtools.config.description": {
-    "text": "De vaste mailconfiguratie die bij het opstarten is bepaald. Inloggegevens worden nooit getoond — alleen of ze aanwezig zijn.",
+    "text": "De standaard mailconfiguratie opgelost bij het opstarten. Inloggegevens worden nooit getoond — alleen of ze aanwezig zijn.",
     "source_hash": "f0e8a118"
   },
   "web.admin.emailtools.config.provider": {
@@ -32,11 +32,11 @@
     "source_hash": "a69c7f9e"
   },
   "web.admin.emailtools.config.fromAddress": {
-    "text": "Van-adres",
+    "text": "Afzenderadres",
     "source_hash": "d465bcfa"
   },
   "web.admin.emailtools.config.fromName": {
-    "text": "Van-naam",
+    "text": "Afzendernaam",
     "source_hash": "b28f93ea"
   },
   "web.admin.emailtools.config.host": {
@@ -64,7 +64,7 @@
     "source_hash": "1ea442a1"
   },
   "web.admin.emailtools.config.loggerWarning": {
-    "text": "E-mail wordt niet bezorgd. De transportprovider is ingesteld op een niet-verzendmodus (logger, uitgeschakeld of geen), dus er verlaat geen e-mail deze server — uitgaande berichten worden naar het applicatielogboek geschreven of verwijderd.",
+    "text": "Mail wordt niet bezorgd. De transportprovider is ingesteld op een niet-verzendmodus (logger, uitgeschakeld of geen), dus er verlaat geen e-mail deze server — uitgaande berichten worden naar het applicatielog geschreven of verwijderd.",
     "source_hash": "1883dfd5"
   },
   "web.admin.emailtools.deliverability.title": {
@@ -72,7 +72,7 @@
     "source_hash": "66b4d300"
   },
   "web.admin.emailtools.deliverability.description": {
-    "text": "Wat er terugkomt na het verzenden: bounces, klachten en de onderdrukkingslijst die je afzenderreputatie beschermt.",
+    "text": "Wat terugkomt na verzending: bounces, klachten en de onderdrukkingslijst die je afzenderreputatie beschermt.",
     "source_hash": "e8363bb5"
   },
   "web.admin.emailtools.deliverability.retry": {
@@ -88,7 +88,7 @@
     "source_hash": "0e7a533b"
   },
   "web.admin.emailtools.deliverability.events.empty": {
-    "text": "Nog geen bounce- of klachtgegevens. Voer de feedback van je ESP door via POST /api/colonel/email/deliverability/events (colonel-geauthenticeerd — zie de documentatie van het endpoint voor het recordformaat). Synchrone SMTP hard bounces worden automatisch vastgelegd.",
+    "text": "Nog geen bounce- of klachtengegevens. Stuur de feedback van je ESP via POST /api/colonel/email/deliverability/events (colonel-geauthenticeerd — zie de documentatie van het eindpunt voor het recordformaat). Synchrone SMTP-harde bounces worden automatisch geregistreerd.",
     "source_hash": "a90f259c"
   },
   "web.admin.emailtools.deliverability.events.loadError": {
@@ -128,11 +128,11 @@
     "source_hash": "7569985b"
   },
   "web.admin.emailtools.deliverability.lookup.description": {
-    "text": "Controleer of een adres is onderdrukt, zowel in de lokale opslag als live bij de actieve mailprovider. Beide worden geïndexeerd op hetzelfde genormaliseerde adres.",
+    "text": "Controleer of een adres is onderdrukt, zowel in de lokale opslag als live bij de actieve mailprovider. Beide zijn gebaseerd op hetzelfde genormaliseerde adres.",
     "source_hash": "c341d614"
   },
   "web.admin.emailtools.deliverability.lookup.addressLabel": {
-    "text": "Ontvangeradres",
+    "text": "Ontvangersadres",
     "source_hash": "454d0391"
   },
   "web.admin.emailtools.deliverability.lookup.submit": {
@@ -164,7 +164,7 @@
     "source_hash": "0e570ca6"
   },
   "web.admin.emailtools.deliverability.lookup.unavailable": {
-    "text": "Live provider-opzoeken is niet beschikbaar; de lokale opslag hierboven is gezaghebbend.",
+    "text": "Live provider-opzoeken is niet beschikbaar; de lokale opslag hierboven is leidend.",
     "source_hash": "aebed0f2"
   },
   "web.admin.emailtools.deliverability.messages.title": {
@@ -172,7 +172,7 @@
     "source_hash": "522e089e"
   },
   "web.admin.emailtools.deliverability.messages.description": {
-    "text": "De meest recente berichten die de actieve mailprovider heeft vastgelegd, nieuwste eerst. Live opgehaald bij de provider — nooit hier opgeslagen.",
+    "text": "De meest recente berichten die de actieve mailprovider heeft geregistreerd, nieuwste eerst. Live opgehaald van de provider — nooit hier opgeslagen.",
     "source_hash": "9970fa0a"
   },
   "web.admin.emailtools.deliverability.messages.empty": {
@@ -180,11 +180,11 @@
     "source_hash": "a7ef4d79"
   },
   "web.admin.emailtools.deliverability.messages.notSupported": {
-    "text": "Een verzendlogboek is niet beschikbaar op het {provider}-transport, dat geen API per bericht biedt.",
+    "text": "Een verzendlog is niet beschikbaar op het {provider}-transport, dat geen per-bericht-API biedt.",
     "source_hash": "21e6b6f9"
   },
   "web.admin.emailtools.deliverability.messages.error": {
-    "text": "Kon het verzendlogboek niet laden bij de provider. Probeer het opnieuw.",
+    "text": "Kon het verzendlog niet laden van de provider. Probeer opnieuw.",
     "source_hash": "4f671e55"
   },
   "web.admin.emailtools.deliverability.messages.col.status": {
@@ -228,15 +228,15 @@
     "source_hash": "58190ffa"
   },
   "web.admin.emailtools.deliverability.messages.status.hard_bounced": {
-    "text": "hard gebounced",
+    "text": "hard bounce",
     "source_hash": "b0aa6fd4"
   },
   "web.admin.emailtools.deliverability.messages.status.soft_bounced": {
-    "text": "soft gebounced",
+    "text": "soft bounce",
     "source_hash": "ac844ff2"
   },
   "web.admin.emailtools.deliverability.messages.status.complained": {
-    "text": "geklaagd",
+    "text": "klacht ingediend",
     "source_hash": "c26fe786"
   },
   "web.admin.emailtools.deliverability.messages.status.suppressed": {
@@ -244,11 +244,11 @@
     "source_hash": "f63d5b6b"
   },
   "web.admin.emailtools.deliverability.messages.status.unsubscribed": {
-    "text": "afgemeld",
+    "text": "uitgeschreven",
     "source_hash": "621e1970"
   },
   "web.admin.emailtools.deliverability.summary.loadError": {
-    "text": "Kon het bezorgbaarheidsoverzicht niet laden.",
+    "text": "Kon de bezorgbaarheidssamenvatting niet laden.",
     "source_hash": "0c16ef96"
   },
   "web.admin.emailtools.deliverability.suppressions.title": {
@@ -256,7 +256,7 @@
     "source_hash": "9f3e322f"
   },
   "web.admin.emailtools.deliverability.suppressions.description": {
-    "text": "Adressen die uitgaande mail overslaat. Vermeldingen komen van ESP-feedbackverwerking of handmatige import; een verwijderen hervat de bezorging.",
+    "text": "Adressen die uitgaande mail overslaat. Vermeldingen komen van ESP-feedbackverwerking of handmatige import; verwijderen hervat de bezorging.",
     "source_hash": "3651887e"
   },
   "web.admin.emailtools.deliverability.suppressions.searchLabel": {
@@ -264,7 +264,7 @@
     "source_hash": "f4338ff8"
   },
   "web.admin.emailtools.deliverability.suppressions.searchPlaceholder": {
-    "text": "user{'@'}example.com",
+    "text": "gebruiker{'@'}voorbeeld.com",
     "source_hash": "333f0f15"
   },
   "web.admin.emailtools.deliverability.suppressions.searchButton": {
@@ -276,7 +276,7 @@
     "source_hash": "83b12c22"
   },
   "web.admin.emailtools.deliverability.suppressions.empty": {
-    "text": "Nog geen onderdrukte adressen. Ze verschijnen hier zodra bounce- en klachtfeedback wordt verwerkt.",
+    "text": "Nog geen onderdrukte adressen. Ze verschijnen hier zodra bounce- en klachtenfeedback wordt verwerkt.",
     "source_hash": "dd3f4d61"
   },
   "web.admin.emailtools.deliverability.suppressions.emptySearch": {
@@ -300,7 +300,7 @@
     "source_hash": "40a0d2a6"
   },
   "web.admin.emailtools.deliverability.suppressions.add.confirmDescription": {
-    "text": "Uitgaande mail naar {address} wordt overgeslagen totdat de onderdrukking wordt verwijderd. Dit wordt vastgelegd als een handmatige vermelding.",
+    "text": "Uitgaande mail naar {address} wordt overgeslagen totdat de onderdrukking wordt verwijderd. Dit wordt geregistreerd als een handmatige vermelding.",
     "source_hash": "e3d0d799"
   },
   "web.admin.emailtools.deliverability.suppressions.add.success": {
@@ -344,7 +344,7 @@
     "source_hash": "0b0aec2e"
   },
   "web.admin.emailtools.deliverability.suppressions.remove.confirmDescription": {
-    "text": "Uitgaande mail naar {address} wordt hervat. Dit adres bouncede of klaagde eerder — verwijder het alleen als je weet dat het weer bezorgbaar is.",
+    "text": "Uitgaande mail naar {address} wordt hervat. Dit adres heeft eerder gebounced of een klacht ingediend — verwijder alleen als je weet dat het weer bezorgbaar is.",
     "source_hash": "09442f9c"
   },
   "web.admin.emailtools.deliverability.suppressions.remove.success": {
@@ -364,7 +364,7 @@
     "source_hash": "1bc18c45"
   },
   "web.admin.emailtools.deliverability.sync.neverRun": {
-    "text": "Providerfeedbacksynchronisatie is nooit uitgevoerd. Bounce- en klachtgegevens worden niet automatisch geïmporteerd — configureer een providersynchronisatie of verwerk feedback via het events-endpoint.",
+    "text": "Provider-feedbacksynchronisatie is nog nooit uitgevoerd. Bounce- en klachtengegevens worden niet automatisch geïmporteerd — configureer een providersynchronisatie of verwerk feedback via het events-eindpunt.",
     "source_hash": "d19f5755"
   },
   "web.admin.emailtools.deliverability.sync.button": {
@@ -372,7 +372,7 @@
     "source_hash": "885e8f48"
   },
   "web.admin.emailtools.deliverability.sync.success": {
-    "text": "{provider}-synchronisatie voltooid: {accepted} geïmporteerd, {rejected} geweigerd ({fetched} opgehaald).",
+    "text": "{provider}-synchronisatie voltooid: {accepted} geïmporteerd, {rejected} afgewezen ({fetched} opgehaald).",
     "source_hash": "d36f5578"
   },
   "web.admin.emailtools.deliverability.sync.hint": {
@@ -392,7 +392,7 @@
     "source_hash": "16ad856f"
   },
   "web.admin.emailtools.deliverability.tiles.skipped": {
-    "text": "Overgeslagen verzendingen",
+    "text": "Verzendingen overgeslagen",
     "source_hash": "391467f9"
   },
   "web.admin.emailtools.preview.title": {
@@ -400,7 +400,7 @@
     "source_hash": "df89bd92"
   },
   "web.admin.emailtools.preview.description": {
-    "text": "Render een sjabloon met de bijbehorende voorbeeldgegevens. Een voorbeeld heeft geen neveneffecten — er wordt geen e-mail verzonden.",
+    "text": "Render een sjabloon met voorbeeldgegevens. Voorbeeld heeft geen bijwerkingen — er wordt geen e-mail verzonden.",
     "source_hash": "9b0e40f3"
   },
   "web.admin.emailtools.preview.templateLabel": {
@@ -412,7 +412,7 @@
     "source_hash": "2f343666"
   },
   "web.admin.emailtools.preview.localeLabel": {
-    "text": "Landinstelling",
+    "text": "Taal",
     "source_hash": "ca3dc612"
   },
   "web.admin.emailtools.preview.button": {
@@ -424,11 +424,11 @@
     "source_hash": "231b7f03"
   },
   "web.admin.emailtools.providerStatus.rateUnavailable": {
-    "text": "Deze provider stelt geen numerieke bounce- of klachtratio beschikbaar; het reputatieniveau hierboven is uitsluitend afgeleid van de handhavingsstatus en het verzendquotum.",
+    "text": "Deze provider toont geen numeriek bounce- of klachtenpercentage; de reputatielaag hierboven is alleen afgeleid van de handhavingsstatus en verzendquota.",
     "source_hash": "1e6b82e9"
   },
   "web.admin.emailtools.providerStatus.complaintsUnavailable": {
-    "text": "Lettermint rapporteert geen klachten in zijn stats-API, dus de klachtratio wordt getoond als “—” (niet gerapporteerd), niet nul. De bounceratio hierboven is volledig.",
+    "text": "Lettermint rapporteert geen klachten in zijn stats-API, dus het klachtenpercentage wordt getoond als \"—\" (niet gerapporteerd), niet nul. Het bouncepercentage hierboven is volledig.",
     "source_hash": "72aaa845"
   },
   "web.admin.emailtools.providerStatus.unavailable": {
@@ -440,11 +440,11 @@
     "source_hash": "125ed6eb"
   },
   "web.admin.emailtools.providerStatus.error": {
-    "text": "Kon de mailprovider niet bereiken voor status. Probeer het opnieuw.",
+    "text": "Kon de mailprovider niet bereiken voor status. Probeer opnieuw.",
     "source_hash": "594ab7b1"
   },
   "web.admin.emailtools.providerStatus.quota.max24h": {
-    "text": "Verzendlimiet 24u",
+    "text": "24u verzendlimiet",
     "source_hash": "e5ea4c3d"
   },
   "web.admin.emailtools.providerStatus.quota.sent24h": {
@@ -456,11 +456,11 @@
     "source_hash": "59e76cf8"
   },
   "web.admin.emailtools.providerStatus.rate.bounce": {
-    "text": "Bounceratio",
+    "text": "Bouncepercentage",
     "source_hash": "9eba32f0"
   },
   "web.admin.emailtools.providerStatus.rate.complaint": {
-    "text": "Klachtratio",
+    "text": "Klachtenpercentage",
     "source_hash": "430a23a9"
   },
   "web.admin.emailtools.providerStatus.stats.sent": {
@@ -472,7 +472,7 @@
     "source_hash": "90611565"
   },
   "web.admin.emailtools.providerStatus.stats.hardBounced": {
-    "text": "Hard gebounced",
+    "text": "Hard bounce",
     "source_hash": "c76631c0"
   },
   "web.admin.emailtools.providerStatus.stats.complaints": {
@@ -484,7 +484,7 @@
     "source_hash": "7f1e323b"
   },
   "web.admin.emailtools.providerStatus.tier.probation": {
-    "text": "In beoordeling",
+    "text": "Onder beoordeling",
     "source_hash": "9e8a3b64"
   },
   "web.admin.emailtools.providerStatus.tier.shutdown": {
@@ -496,7 +496,7 @@
     "source_hash": "5fab5d67"
   },
   "web.admin.emailtools.test.description": {
-    "text": "Verstuur een diagnostische e-mail in platte tekst om de bezorgconnectiviteit te controleren. Bekijk deze eerst als voorbeeld en bevestig daarna om een echte e-mail te versturen.",
+    "text": "Stuur een diagnostische platte-tekst-e-mail om bezorgingsconnectiviteit te verifiëren. Bekijk eerst een voorbeeld en bevestig dan om een echte e-mail te verzenden.",
     "source_hash": "4130741c"
   },
   "web.admin.emailtools.test.toLabel": {
@@ -504,11 +504,11 @@
     "source_hash": "51fac985"
   },
   "web.admin.emailtools.test.toPlaceholder": {
-    "text": "you{'@'}example.com",
+    "text": "jij{'@'}voorbeeld.com",
     "source_hash": "cf0a9acc"
   },
   "web.admin.emailtools.test.enqueueLabel": {
-    "text": "Via workerwachtrij",
+    "text": "Via werkerwachtrij",
     "source_hash": "97897017"
   },
   "web.admin.emailtools.test.previewButton": {
@@ -516,7 +516,7 @@
     "source_hash": "747ced83"
   },
   "web.admin.emailtools.test.sendButton": {
-    "text": "Test-e-mail versturen",
+    "text": "Test-e-mail verzenden",
     "source_hash": "46ebd7db"
   },
   "web.admin.emailtools.test.provider": {
@@ -524,7 +524,7 @@
     "source_hash": "472590ae"
   },
   "web.admin.emailtools.test.host": {
-    "text": "Oorsprong-host",
+    "text": "Oorsprongshost",
     "source_hash": "968925cb"
   },
   "web.admin.emailtools.test.from": {
@@ -536,7 +536,7 @@
     "source_hash": "68971283"
   },
   "web.admin.emailtools.test.confirmTitle": {
-    "text": "Een echte test-e-mail versturen?",
+    "text": "Een echte test-e-mail verzenden?",
     "source_hash": "64a16b62"
   },
   "web.admin.emailtools.test.confirmDescription": {

--- a/locales/content/nl/admin-kit.json
+++ b/locales/content/nl/admin-kit.json
@@ -1,6 +1,6 @@
 {
   "web.admin.kit.confirmDialog.typePrompt": {
-    "text": "Typ ter bevestiging {token} hieronder",
+    "text": "Typ {token} hieronder om te bevestigen",
     "source_hash": "282445b6"
   },
   "web.admin.kit.confirmDialog.inputLabel": {
@@ -52,7 +52,7 @@
     "source_hash": "7708c6e2"
   },
   "web.admin.kit.revealEmail.reveal": {
-    "text": "E-mailadres weergeven",
+    "text": "E-mailadres tonen",
     "source_hash": "f6272277"
   },
   "web.admin.kit.revealEmail.hide": {

--- a/locales/content/nl/admin-organizations.json
+++ b/locales/content/nl/admin-organizations.json
@@ -12,7 +12,7 @@
     "source_hash": "00c50f7a"
   },
   "web.admin.organizations.detail.notFoundDescription": {
-    "text": "Deze organisatie is mogelijk verwijderd, of de id is onjuist.",
+    "text": "Deze organisatie is mogelijk verwijderd of de id is onjuist.",
     "source_hash": "e5459ef5"
   },
   "web.admin.organizations.detail.loadError": {
@@ -48,7 +48,7 @@
     "source_hash": "5fa7aac5"
   },
   "web.admin.organizations.detail.domains.resolving": {
-    "text": "Bezig met oplossen",
+    "text": "Verifiëren",
     "source_hash": "3287a034"
   },
   "web.admin.organizations.detail.domains.empty": {
@@ -56,7 +56,7 @@
     "source_hash": "1b840c7e"
   },
   "web.admin.organizations.detail.entitlements.description": {
-    "text": "Effectieve entitlements worden opgelost tot (plan ∪ toekenningen) − intrekkingen. Bekijk de uitsplitsing voordat je een override maakt.",
+    "text": "Effectieve rechten worden opgelost als (plan ∪ toekenningen) − intrekkingen. Bekijk de uitsplitsing voordat je een overschrijving maakt.",
     "source_hash": "23080475"
   },
   "web.admin.organizations.detail.entitlements.inSync": {
@@ -72,7 +72,7 @@
     "source_hash": "ffe63800"
   },
   "web.admin.organizations.detail.entitlements.driftWarning": {
-    "text": "Gematerialiseerde entitlements komen niet overeen met de verwachte set. Stem af om opnieuw te materialiseren.",
+    "text": "Gematerialiseerde rechten komen niet overeen met de verwachte set. Verzoen om opnieuw te materialiseren.",
     "source_hash": "4859983a"
   },
   "web.admin.organizations.detail.entitlements.driftExtra": {
@@ -104,7 +104,7 @@
     "source_hash": "920e413c"
   },
   "web.admin.organizations.detail.members.joined": {
-    "text": "Lid geworden",
+    "text": "Toegetreden",
     "source_hash": "69318b0c"
   },
   "web.admin.organizations.detail.members.owner": {
@@ -116,23 +116,23 @@
     "source_hash": "b99c59dc"
   },
   "web.admin.organizations.detail.reconcile.button": {
-    "text": "Afstemmen",
+    "text": "Verzoenen",
     "source_hash": "b59be565"
   },
   "web.admin.organizations.detail.reconcile.confirmTitle": {
-    "text": "Organisatiefacturatie afstemmen?",
+    "text": "Organisatiefacturering verzoenen?",
     "source_hash": "fc1a2762"
   },
   "web.admin.organizations.detail.reconcile.confirmDescription": {
-    "text": "Dit haalt Stripe opnieuw op en herschrijft de facturatiestatus en entitlements voor {org}. Typ de organisatie-id opnieuw om te bevestigen.",
+    "text": "Dit haalt Stripe opnieuw op en herschrijft de factureringsstatus en rechten voor {org}. Typ de organisatie-id opnieuw om te bevestigen.",
     "source_hash": "b4ef0850"
   },
   "web.admin.organizations.detail.reconcile.success": {
-    "text": "Organisatie afgestemd.",
+    "text": "Organisatie verzoend.",
     "source_hash": "caf87844"
   },
   "web.admin.organizations.detail.reconcile.resultTitle": {
-    "text": "Afstemresultaat",
+    "text": "Verzoeningsresultaat",
     "source_hash": "11f4c6b8"
   },
   "web.admin.organizations.detail.reconcile.before": {
@@ -144,7 +144,7 @@
     "source_hash": "7b68fe55"
   },
   "web.admin.organizations.detail.reconcile.materializedCount": {
-    "text": "Aantal entitlements",
+    "text": "Aantal rechten",
     "source_hash": "59cede5c"
   },
   "web.admin.organizations.detail.reconcile.mode.stripe_sync": {
@@ -152,11 +152,11 @@
     "source_hash": "02f9546c"
   },
   "web.admin.organizations.detail.reconcile.mode.entitlements_only": {
-    "text": "Alleen entitlements",
+    "text": "Alleen rechten",
     "source_hash": "8cf49a5d"
   },
   "web.admin.organizations.detail.sections.billing": {
-    "text": "Facturatie",
+    "text": "Facturering",
     "source_hash": "3ac8bbca"
   },
   "web.admin.organizations.detail.sections.members": {
@@ -168,19 +168,19 @@
     "source_hash": "ced67718"
   },
   "web.admin.organizations.detail.sections.investigate": {
-    "text": "Onderzoeken & afstemmen",
+    "text": "Onderzoeken en verzoenen",
     "source_hash": "b05aa349"
   },
   "web.admin.organizations.entitlements.section": {
-    "text": "Entitlement-overrides",
+    "text": "Rechtenoverschrijvingen",
     "source_hash": "48812068"
   },
   "web.admin.organizations.entitlements.description": {
-    "text": "Ken entitlements toe of trek ze in onafhankelijk van het plan. Effectief = planentitlements + toekenningen - intrekkingen.",
+    "text": "Ken rechten toe of trek ze in onafhankelijk van het plan. Effectief = planrechten + toekenningen - intrekkingen.",
     "source_hash": "4c38425b"
   },
   "web.admin.organizations.entitlements.inputLabel": {
-    "text": "Entitlement",
+    "text": "Recht",
     "source_hash": "0d8f0b2d"
   },
   "web.admin.organizations.entitlements.placeholder": {
@@ -196,11 +196,11 @@
     "source_hash": "87e6d00b"
   },
   "web.admin.organizations.entitlements.clear": {
-    "text": "Alle overrides wissen",
+    "text": "Alle overschrijvingen wissen",
     "source_hash": "f0e485c3"
   },
   "web.admin.organizations.entitlements.effective": {
-    "text": "Effectieve entitlements",
+    "text": "Effectieve rechten",
     "source_hash": "b840f8c8"
   },
   "web.admin.organizations.entitlements.grants": {
@@ -212,43 +212,43 @@
     "source_hash": "f0e69b17"
   },
   "web.admin.organizations.entitlements.noOverrides": {
-    "text": "Voer een actie uit om de huidige overridestatus van deze organisatie te bekijken.",
+    "text": "Voer een actie uit om de huidige overschrijvingsstatus van deze organisatie te bekijken.",
     "source_hash": "98d2e30d"
   },
   "web.admin.organizations.entitlements.confirm.grantTitle": {
-    "text": "Entitlement toekennen?",
+    "text": "Recht toekennen?",
     "source_hash": "a4b2c57b"
   },
   "web.admin.organizations.entitlements.confirm.grantDescription": {
-    "text": "Ken “{entitlement}” toe aan {org}. Dit wijzigt de facturatie-entitlements van de organisatie.",
+    "text": "Ken \"{entitlement}\" toe aan {org}. Dit wijzigt de factureringsrechten van de organisatie.",
     "source_hash": "542ce26a"
   },
   "web.admin.organizations.entitlements.confirm.revokeTitle": {
-    "text": "Entitlement intrekken?",
+    "text": "Recht intrekken?",
     "source_hash": "c93d520a"
   },
   "web.admin.organizations.entitlements.confirm.revokeDescription": {
-    "text": "Trek “{entitlement}” in bij {org}. Dit wijzigt de facturatie-entitlements van de organisatie.",
+    "text": "Trek \"{entitlement}\" in van {org}. Dit wijzigt de factureringsrechten van de organisatie.",
     "source_hash": "a5d2a8a6"
   },
   "web.admin.organizations.entitlements.confirm.clearTitle": {
-    "text": "Alle entitlement-overrides wissen?",
+    "text": "Alle rechtenoverschrijvingen wissen?",
     "source_hash": "e36eb218"
   },
   "web.admin.organizations.entitlements.confirm.clearDescription": {
-    "text": "Verwijder elke toekennings- en intrekkingsoverride voor {org} en zet deze terug naar de planentitlements.",
+    "text": "Verwijder elke toekennings- en intrekkingsoverschrijving voor {org}, en reset naar de planrechten.",
     "source_hash": "96bad079"
   },
   "web.admin.organizations.entitlements.success.granted": {
-    "text": "Entitlement “{entitlement}” toegekend.",
+    "text": "Recht \"{entitlement}\" toegekend.",
     "source_hash": "cf52fb0e"
   },
   "web.admin.organizations.entitlements.success.revoked": {
-    "text": "Entitlement “{entitlement}” ingetrokken.",
+    "text": "Recht \"{entitlement}\" ingetrokken.",
     "source_hash": "279d425d"
   },
   "web.admin.organizations.entitlements.success.cleared": {
-    "text": "Alle entitlement-overrides gewist.",
+    "text": "Alle rechtenoverschrijvingen gewist.",
     "source_hash": "a482743b"
   },
   "web.admin.organizations.fields.contactEmail": {
@@ -268,11 +268,11 @@
     "source_hash": "f0723c4e"
   },
   "web.admin.organizations.fields.periodEnd": {
-    "text": "Einde periode",
+    "text": "Periodeeinde",
     "source_hash": "eeae9fdd"
   },
   "web.admin.organizations.fields.billingEmail": {
-    "text": "Facturatie-e-mail",
+    "text": "Facturerings-e-mail",
     "source_hash": "8805b928"
   },
   "web.admin.organizations.fields.stripeCustomer": {
@@ -296,7 +296,7 @@
     "source_hash": "3a5ecca1"
   },
   "web.admin.organizations.investigate.description": {
-    "text": "Vergelijk de lokale facturatiestatus met het live Stripe-abonnement.",
+    "text": "Vergelijk de lokale factureringsstatus met het live Stripe-abonnement.",
     "source_hash": "d7bbe9ed"
   },
   "web.admin.organizations.investigate.rawPayload": {
@@ -304,11 +304,339 @@
     "source_hash": "29ca7df2"
   },
   "web.admin.organizations.investigate.parseError": {
-    "text": "De onderzoeksrespons kwam niet overeen met het verwachte formaat.",
+    "text": "Het onderzoeksantwoord kwam niet overeen met het verwachte formaat.",
     "source_hash": "db59cab1"
   },
   "web.admin.organizations.list.loadError": {
     "text": "Kon organisaties niet laden.",
     "source_hash": "130d5e70"
+  },
+  "web.admin.organizations.addMember.button": {
+    "text": "Bestaand account toevoegen",
+    "source_hash": "45a3b757"
+  },
+  "web.admin.organizations.addMember.title": {
+    "text": "Een bestaand account toevoegen",
+    "source_hash": "2f676a94"
+  },
+  "web.admin.organizations.addMember.description": {
+    "text": "Voeg iemand die al een account heeft toe aan {org}. Gebruik dit wanneer iemand zelf is aangemeld en niet kan worden uitgenodigd omdat het account al bestaat.",
+    "source_hash": "bb41faa6"
+  },
+  "web.admin.organizations.addMember.searchLabel": {
+    "text": "E-mailadres of account-id",
+    "source_hash": "82b3040b"
+  },
+  "web.admin.organizations.addMember.searchPlaceholder": {
+    "text": "Zoeken op e-mailadres",
+    "source_hash": "b75cc66c"
+  },
+  "web.admin.organizations.addMember.searchHint": {
+    "text": "Komt overeen met een deel van een e-mailadres of een exact account-id.",
+    "source_hash": "84547a60"
+  },
+  "web.admin.organizations.addMember.searchError": {
+    "text": "Kon accounts niet doorzoeken. Controleer de verbinding en probeer opnieuw.",
+    "source_hash": "4b6caa41"
+  },
+  "web.admin.organizations.addMember.searchParseError": {
+    "text": "Het zoeken naar accounts gaf een onverwacht antwoord. Resultaten kunnen onvolledig zijn.",
+    "source_hash": "0c814231"
+  },
+  "web.admin.organizations.addMember.idle": {
+    "text": "Voer een e-mailadres in om het account te vinden.",
+    "source_hash": "f6340d35"
+  },
+  "web.admin.organizations.addMember.noResults": {
+    "text": "Geen account komt overeen met \"{term}\".",
+    "source_hash": "199b662a"
+  },
+  "web.admin.organizations.addMember.noResultsHint": {
+    "text": "Alleen bestaande accounts kunnen hier worden toegevoegd. Als de persoon zich nog nooit heeft aangemeld, nodig deze dan uit.",
+    "source_hash": "ee90aeeb"
+  },
+  "web.admin.organizations.addMember.select": {
+    "text": "Selecteren",
+    "source_hash": "2a78025d"
+  },
+  "web.admin.organizations.addMember.selectedEyebrow": {
+    "text": "Geselecteerd account",
+    "source_hash": "8b63d947"
+  },
+  "web.admin.organizations.addMember.change": {
+    "text": "Kies een ander account",
+    "source_hash": "d4fe39ab"
+  },
+  "web.admin.organizations.addMember.createdOn": {
+    "text": "Aangemeld op {date}",
+    "source_hash": "cfc0e19f"
+  },
+  "web.admin.organizations.addMember.organizationsUnavailable": {
+    "text": "Kon de huidige organisaties van dit account niet laden.",
+    "source_hash": "a35b6bfc"
+  },
+  "web.admin.organizations.addMember.defaultOrg": {
+    "text": "standaard",
+    "source_hash": "37a8eec1"
+  },
+  "web.admin.organizations.addMember.roleLabel": {
+    "text": "Rol in deze organisatie",
+    "source_hash": "817475fa"
+  },
+  "web.admin.organizations.addMember.submit": {
+    "text": "Toevoegen aan organisatie",
+    "source_hash": "0e0cb636"
+  },
+  "web.admin.organizations.addMember.success": {
+    "text": "{account} toegevoegd als {role}.",
+    "source_hash": "533be0dc"
+  },
+  "web.admin.organizations.addMember.badges.verified": {
+    "text": "Geverifieerd",
+    "source_hash": "4f783840"
+  },
+  "web.admin.organizations.addMember.badges.unverified": {
+    "text": "Niet geverifieerd",
+    "source_hash": "15133907"
+  },
+  "web.admin.organizations.addMember.badges.suspended": {
+    "text": "Opgeschort",
+    "source_hash": "e392a389"
+  },
+  "web.admin.organizations.addMember.badges.alreadyMember": {
+    "text": "Al een lid",
+    "source_hash": "1739ed7c"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMember": {
+    "text": "Dit account is al lid van deze organisatie met de rol {role}. Toevoegen wijzigt geen bestaande rol — gebruik daarvoor de rol-wijzigen-actie.",
+    "source_hash": "cb6a4774"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMemberUnknownRole": {
+    "text": "Dit account is al lid van deze organisatie. Toevoegen wijzigt geen bestaande rol.",
+    "source_hash": "035641ec"
+  },
+  "web.admin.organizations.addMember.errors.notFound": {
+    "text": "Dat account of die organisatie bestaat niet meer. Zoek opnieuw om het account te bevestigen.",
+    "source_hash": "bd88db18"
+  },
+  "web.admin.organizations.addMember.errors.invalidRole": {
+    "text": "Die rol werd afgewezen. Kies een van de vermelde rollen en probeer opnieuw.",
+    "source_hash": "eb696a8f"
+  },
+  "web.admin.organizations.addMember.errors.noSelection": {
+    "text": "Geen account geselecteerd.",
+    "source_hash": "dd15bb5b"
+  },
+  "web.admin.organizations.addMember.fields.created": {
+    "text": "Aangemeld",
+    "source_hash": "486b3fe0"
+  },
+  "web.admin.organizations.addMember.fields.verified": {
+    "text": "Verificatie",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.organizations.addMember.fields.lastLogin": {
+    "text": "Laatste inloggen",
+    "source_hash": "0b70af7a"
+  },
+  "web.admin.organizations.addMember.fields.organizations": {
+    "text": "Huidige organisaties",
+    "source_hash": "cbb5b92f"
+  },
+  "web.admin.organizations.addMember.roleHints.member": {
+    "text": "Dagelijkse toegang tot de berichten en domeinen van de organisatie.",
+    "source_hash": "d0c7439e"
+  },
+  "web.admin.organizations.addMember.roleHints.admin": {
+    "text": "Kan leden, domeinen en organisatie-instellingen beheren.",
+    "source_hash": "beaa50d7"
+  },
+  "web.admin.organizations.addMember.roleHints.owner": {
+    "text": "Volledige controle, inclusief facturering. Ken dit alleen toe op verzoek.",
+    "source_hash": "614ace63"
+  },
+  "web.admin.organizations.addMember.roles.member": {
+    "text": "Lid",
+    "source_hash": "7c968fb7"
+  },
+  "web.admin.organizations.addMember.roles.admin": {
+    "text": "Beheerder",
+    "source_hash": "c1c224b0"
+  },
+  "web.admin.organizations.addMember.roles.owner": {
+    "text": "Eigenaar",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.detail.members.openCustomer": {
+    "text": "Klantrecord openen",
+    "source_hash": "c057ca13"
+  },
+  "web.admin.organizations.detail.reconcile.memberships": {
+    "text": "Lidmaatschappen opnieuw gematerialiseerd:",
+    "source_hash": "fe7db10c"
+  },
+  "web.admin.organizations.detail.reconcile.membershipsFailed": {
+    "text": "mislukt, verouderde rechten blijven:",
+    "source_hash": "cc4dae37"
+  },
+  "web.admin.organizations.entitlements.catalogWarning": {
+    "text": "\"{entitlement}\" staat niet in de factureringscatalogus — controleer op een typfout. Doorgaan: het toekennen van een recht dat in een latere catalogus komt, wordt ondersteund en niet geblokkeerd.",
+    "source_hash": "cbde548a"
+  },
+  "web.admin.organizations.entitlements.matrix.caption": {
+    "text": "Rechtenresolutiematrix: plan, overschrijvingstoekenningen en -intrekkingen, de opgeloste set en wat gematerialiseerd is.",
+    "source_hash": "9eac8999"
+  },
+  "web.admin.organizations.entitlements.matrix.yes": {
+    "text": "Ja",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.matrix.no": {
+    "text": "Nee",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.matrix.empty": {
+    "text": "Deze organisatie heeft geen rechten van het plan en geen overschrijvingen.",
+    "source_hash": "f6cf2169"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.entitlement": {
+    "text": "Recht",
+    "source_hash": "0d8f0b2d"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.inPlan": {
+    "text": "In plan",
+    "source_hash": "e2222361"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.granted": {
+    "text": "Toegekend",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.revoked": {
+    "text": "Ingetrokken",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.expected": {
+    "text": "Verwacht",
+    "source_hash": "ca99b7f1"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.materialized": {
+    "text": "Gematerialiseerd",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.state": {
+    "text": "Status",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.formula": {
+    "text": "Resolutie: verwacht = (plan ∪ toekenningen) − intrekkingen. Gematerialiseerd is wat daadwerkelijk is opgeslagen op de organisatie.",
+    "source_hash": "bc4bff2d"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.orphaned": {
+    "text": "Verweesd — gematerialiseerd maar niet verwacht, meestal achtergelaten door een intrekking die nooit opnieuw is gematerialiseerd. Verzoenen verwijdert het.",
+    "source_hash": "3a27a9af"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.missing": {
+    "text": "Ontbrekend — verwacht maar niet gematerialiseerd. Dit is de toestemming die leden nu daadwerkelijk missen.",
+    "source_hash": "485e44ad"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.revoked": {
+    "text": "Doorgestreepte rijen zijn ingetrokken door een beheerdersoverschrijving, die ze verwijdert uit de verwachte set.",
+    "source_hash": "89a2e9b6"
+  },
+  "web.admin.organizations.entitlements.matrix.state.plan": {
+    "text": "Van plan",
+    "source_hash": "1d346b26"
+  },
+  "web.admin.organizations.entitlements.matrix.state.granted": {
+    "text": "Toegekend",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.state.revoked": {
+    "text": "Ingetrokken",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.state.orphaned": {
+    "text": "Verweesd",
+    "source_hash": "8d827807"
+  },
+  "web.admin.organizations.entitlements.matrix.state.missing": {
+    "text": "Ontbrekend",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.organizations.entitlements.picker.selectPlaceholder": {
+    "text": "Selecteer een recht…",
+    "source_hash": "53af3be8"
+  },
+  "web.admin.organizations.entitlements.picker.other": {
+    "text": "Anders — niet in de catalogus…",
+    "source_hash": "f08bc3a3"
+  },
+  "web.admin.organizations.entitlements.picker.customLabel": {
+    "text": "Rechtnaam (niet in de catalogus)",
+    "source_hash": "52783229"
+  },
+  "web.admin.organizations.entitlements.picker.backToCatalog": {
+    "text": "Terug naar de catalogus",
+    "source_hash": "9b727f40"
+  },
+  "web.admin.organizations.entitlements.picker.uncategorized": {
+    "text": "Niet gecategoriseerd",
+    "source_hash": "8d40d123"
+  },
+  "web.admin.organizations.entitlements.picker.catalogUnavailable": {
+    "text": "De factureringscatalogus kon niet worden gelezen, dus rechtnamen worden hier niet gecontroleerd.",
+    "source_hash": "724869ec"
+  },
+  "web.admin.organizations.entitlements.picker.tags.inPlan": {
+    "text": "in plan",
+    "source_hash": "5f2251bb"
+  },
+  "web.admin.organizations.entitlements.picker.tags.granted": {
+    "text": "toegekend",
+    "source_hash": "dd515d19"
+  },
+  "web.admin.organizations.entitlements.picker.tags.revoked": {
+    "text": "ingetrokken",
+    "source_hash": "4bb47f18"
+  },
+  "web.admin.organizations.entitlements.summary.sync": {
+    "text": "Synchroniseren",
+    "source_hash": "8d261a37"
+  },
+  "web.admin.organizations.entitlements.summary.materialized": {
+    "text": "Gematerialiseerd",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.summary.materializedAt": {
+    "text": "Laatst gematerialiseerd",
+    "source_hash": "9325dce9"
+  },
+  "web.admin.organizations.entitlements.summary.planDefinition": {
+    "text": "Plandefinitie",
+    "source_hash": "6b531454"
+  },
+  "web.admin.organizations.entitlements.summary.yes": {
+    "text": "Ja",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.summary.no": {
+    "text": "Nee",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.summary.never": {
+    "text": "Nooit",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.organizations.entitlements.summary.planStale": {
+    "text": "Gewijzigd sinds materialisatie",
+    "source_hash": "e682d8a4"
+  },
+  "web.admin.organizations.entitlements.summary.planCurrent": {
+    "text": "Actueel",
+    "source_hash": "e0d1b682"
+  },
+  "web.admin.organizations.entitlements.summary.planUnknown": {
+    "text": "Onbekend — kon niet vergelijken",
+    "source_hash": "b607e540"
   }
 }

--- a/locales/content/nl/admin-overview.json
+++ b/locales/content/nl/admin-overview.json
@@ -8,7 +8,7 @@
     "source_hash": "cb7b24c6"
   },
   "web.admin.overview.feedback.total": {
-    "text": "{count} in de laatste 30 dagen",
+    "text": "{count} in de afgelopen 30 dagen",
     "source_hash": "b6b9147c"
   },
   "web.admin.overview.feedback.today": {
@@ -64,11 +64,11 @@
     "source_hash": "5f13cf7a"
   },
   "web.admin.overview.trends.title": {
-    "text": "Laatste 30 dagen",
+    "text": "Afgelopen 30 dagen",
     "source_hash": "f8f03fb4"
   },
   "web.admin.overview.trends.signups": {
-    "text": "Aanmeldingen per dag",
+    "text": "Registraties per dag",
     "source_hash": "8db399dc"
   },
   "web.admin.overview.trends.secretsCreated": {
@@ -80,11 +80,11 @@
     "source_hash": "e0f4f767"
   },
   "web.admin.overview.trends.collectingNote": {
-    "text": "Verzamelen sinds het eerste gegevenspunt — dagen daarvoor tonen nul.",
+    "text": "Verzamelen sinds eerste datapunt — dagen daarvoor tonen nul.",
     "source_hash": "269ee1eb"
   },
   "web.admin.overview.trends.sparklineAria": {
-    "text": "{label}: trend over 30 dagen, {count} vandaag",
+    "text": "{label}: 30-dagentrend, {count} vandaag",
     "source_hash": "eb57a7b2"
   },
   "web.admin.overview.trends.loadError": {

--- a/locales/content/nl/admin-secrets.json
+++ b/locales/content/nl/admin-secrets.json
@@ -1,11 +1,11 @@
 {
   "web.admin.secrets.title": {
-    "text": "Berichten",
-    "source_hash": "d8707d41"
+    "text": "Berichtontvangstbewijzen",
+    "source_hash": "a8a2d0e4"
   },
   "web.admin.secrets.description": {
-    "text": "Inspecteer het ontvangstbewijs van een bericht en verwijder het zonder SSH — zoek het op via de sleutel.",
-    "source_hash": "07775a11"
+    "text": "Zoek status, tijdstempels, ontvangstbewijs, etc. op.",
+    "source_hash": "91fba2a1"
   },
   "web.admin.secrets.never": {
     "text": "Nooit",
@@ -68,7 +68,7 @@
     "source_hash": "3a5ecca1"
   },
   "web.admin.secrets.fields.expiration": {
-    "text": "Vervaldatum",
+    "text": "Verloopt",
     "source_hash": "f38d6e0e"
   },
   "web.admin.secrets.fields.age": {
@@ -88,11 +88,11 @@
     "source_hash": "2c13d799"
   },
   "web.admin.secrets.fields.hasCiphertext": {
-    "text": "Heeft cijfertekst",
+    "text": "Heeft versleutelde tekst",
     "source_hash": "e9188bad"
   },
   "web.admin.secrets.fields.ciphertextLength": {
-    "text": "Lengte cijfertekst",
+    "text": "Lengte versleutelde tekst",
     "source_hash": "0f1744fd"
   },
   "web.admin.secrets.lookup.label": {
@@ -100,7 +100,7 @@
     "source_hash": "f47a99eb"
   },
   "web.admin.secrets.lookup.placeholder": {
-    "text": "Bericht-identificatie",
+    "text": "Berichtidentificatie",
     "source_hash": "cbcfd49f"
   },
   "web.admin.secrets.lookup.button": {
@@ -108,20 +108,20 @@
     "source_hash": "504101bc"
   },
   "web.admin.secrets.lookup.resultTitle": {
-    "text": "Bericht {shortid}",
-    "source_hash": "8b311d32"
+    "text": "Berichtrecord {shortid}",
+    "source_hash": "ee06d765"
   },
   "web.admin.secrets.lookup.notFound": {
-    "text": "Bericht niet gevonden",
-    "source_hash": "70a9532c"
+    "text": "Geen record gevonden",
+    "source_hash": "40f4d9e9"
   },
   "web.admin.secrets.lookup.notFoundDescription": {
-    "text": "Er bestaat geen bericht met deze sleutel. Het is mogelijk verlopen of verwijderd.",
+    "text": "Er bestaat geen bericht met deze sleutel. Het kan verlopen of verwijderd zijn.",
     "source_hash": "9f068a81"
   },
   "web.admin.secrets.lookup.loadError": {
-    "text": "Kon dit bericht niet laden.",
-    "source_hash": "c96672e4"
+    "text": "Kon dit record niet laden.",
+    "source_hash": "de77cc72"
   },
   "web.admin.secrets.lookup.retry": {
     "text": "Opnieuw proberen",
@@ -188,8 +188,8 @@
     "source_hash": "c127dab6"
   },
   "web.admin.secrets.sections.secret": {
-    "text": "Bericht",
-    "source_hash": "7e32a729"
+    "text": "Berichtrecord",
+    "source_hash": "263813c6"
   },
   "web.admin.secrets.sections.receipt": {
     "text": "Ontvangstbewijs",
@@ -200,7 +200,7 @@
     "source_hash": "4b1b8aa3"
   },
   "web.admin.secrets.sections.raw": {
-    "text": "Ruw",
+    "text": "Onbewerkt",
     "source_hash": "848123d1"
   },
   "web.admin.secrets.state.new": {
@@ -214,5 +214,25 @@
   "web.admin.secrets.state.viewed": {
     "text": "Bekeken",
     "source_hash": "1b28d178"
+  },
+  "web.admin.secrets.capability.title": {
+    "text": "Alleen metadata",
+    "source_hash": "df0453d1"
+  },
+  "web.admin.secrets.capability.canRead": {
+    "text": "Leest metadata van een bericht en het ontvangstbewijs: status, tijdstempels, eigenaar en de grootte van de opgeslagen versleutelde tekst.",
+    "source_hash": "d438ecc7"
+  },
+  "web.admin.secrets.capability.cannotRead": {
+    "text": "Kan berichtinhoud niet ontsleutelen of weergeven. Het eindpunt achter dit scherm retourneert dit nooit.",
+    "source_hash": "7f69f222"
+  },
+  "web.admin.secrets.capability.canDelete": {
+    "text": "Kan een bericht en het ontvangstbewijs permanent verwijderen, wat de inhoud vernietigt zonder deze ooit te onthullen.",
+    "source_hash": "77f2bc7e"
+  },
+  "web.admin.secrets.lookup.hint": {
+    "text": "De identificatie uit de berichtlink — niet de berichtinhoud.",
+    "source_hash": "acfbc352"
   }
 }

--- a/locales/content/nl/admin-sessions.json
+++ b/locales/content/nl/admin-sessions.json
@@ -4,7 +4,7 @@
     "source_hash": "6fa3cbf4"
   },
   "web.admin.sessions.description": {
-    "text": "Inspecteer, doorzoek en trek actieve sessies in voor incidentrespons.",
+    "text": "Inspecteer, zoek en herroep actieve sessies voor incidentrespons.",
     "source_hash": "784a3a44"
   },
   "web.admin.sessions.anonymous": {
@@ -68,7 +68,7 @@
     "source_hash": "424a2551"
   },
   "web.admin.sessions.detail.ttlSeconds": {
-    "text": "Nog {seconds}s",
+    "text": "{seconds}s resterend",
     "source_hash": "3c9d75ce"
   },
   "web.admin.sessions.drawer.title": {
@@ -80,7 +80,7 @@
     "source_hash": "0969eab8"
   },
   "web.admin.sessions.drawer.notFoundDescription": {
-    "text": "Deze sessie bestaat niet meer in Redis. Deze is mogelijk verlopen of al ingetrokken.",
+    "text": "Deze sessie bestaat niet meer in Redis. Deze kan verlopen of al herroepen zijn.",
     "source_hash": "11e3ef05"
   },
   "web.admin.sessions.drawer.loadError": {
@@ -124,7 +124,7 @@
     "source_hash": "14736a2e"
   },
   "web.admin.sessions.fields.locale": {
-    "text": "Landinstelling",
+    "text": "Taal",
     "source_hash": "ca3dc612"
   },
   "web.admin.sessions.fields.ipAddress": {
@@ -144,11 +144,11 @@
     "source_hash": "f32b1158"
   },
   "web.admin.sessions.fields.userAgent": {
-    "text": "User agent",
+    "text": "User Agent",
     "source_hash": "62e01345"
   },
   "web.admin.sessions.fields.orgContext": {
-    "text": "Org-context",
+    "text": "Organisatiecontext",
     "source_hash": "a596d9f2"
   },
   "web.admin.sessions.list.loadError": {
@@ -164,11 +164,11 @@
     "source_hash": "e35312d6"
   },
   "web.admin.sessions.revoke.button": {
-    "text": "Intrekken",
+    "text": "Herroepen",
     "source_hash": "87e6d00b"
   },
   "web.admin.sessions.revoke.confirmTitle": {
-    "text": "Deze sessie intrekken?",
+    "text": "Deze sessie herroepen?",
     "source_hash": "0c6605c1"
   },
   "web.admin.sessions.revoke.confirmDescription": {
@@ -176,15 +176,15 @@
     "source_hash": "9e08b1b8"
   },
   "web.admin.sessions.revoke.success": {
-    "text": "Sessie ingetrokken",
+    "text": "Sessie herroepen",
     "source_hash": "0af5e14d"
   },
   "web.admin.sessions.scan.summary": {
-    "text": "{shown} geauthenticeerd weergegeven · {anonymous} anoniem verborgen · {scanned} gescand",
+    "text": "Toont {shown} geauthenticeerd · {anonymous} anoniem verborgen · {scanned} gescand",
     "source_hash": "34cb67a4"
   },
   "web.admin.sessions.scan.capped": {
-    "text": "Scan afgekapt bij de eerste {scanned} sleutels — geauthenticeerde sessies buiten dit venster worden niet vermeld. Inspecteer een specifieke sessie op ID om deze te bereiken.",
+    "text": "Scan begrensd tot de eerste {scanned} sleutels — geauthenticeerde sessies buiten dit venster worden niet getoond. Inspecteer een specifieke sessie op ID om deze te bereiken.",
     "source_hash": "fa418b4e"
   },
   "web.admin.sessions.search.placeholder": {
@@ -200,7 +200,7 @@
     "source_hash": "c9f11eb4"
   },
   "web.admin.sessions.status.authenticated": {
-    "text": "Geverifieerd",
+    "text": "Geauthenticeerd",
     "source_hash": "6ab694cf"
   },
   "web.admin.sessions.status.anonymous": {

--- a/locales/content/nl/admin-system.json
+++ b/locales/content/nl/admin-system.json
@@ -4,7 +4,7 @@
     "source_hash": "6725e7bb"
   },
   "web.admin.system.description": {
-    "text": "Status van database, wachtrij en infrastructuur.",
+    "text": "Database-, wachtrij- en infrastructuurstatus.",
     "source_hash": "0115f495"
   },
   "web.admin.system.retry": {
@@ -16,7 +16,7 @@
     "source_hash": "1391230b"
   },
   "web.admin.system.database.loadError": {
-    "text": "Kan databasestatistieken niet laden.",
+    "text": "Kon databasestatistieken niet laden.",
     "source_hash": "905055c6"
   },
   "web.admin.system.database.server": {
@@ -56,7 +56,7 @@
     "source_hash": "6634251d"
   },
   "web.admin.system.database.fields.totalCommands": {
-    "text": "Totaal aantal opdrachten",
+    "text": "Totaal commando's",
     "source_hash": "c5ce5aaf"
   },
   "web.admin.system.database.fields.usedMemory": {
@@ -72,7 +72,7 @@
     "source_hash": "9d44afa6"
   },
   "web.admin.system.database.fields.fragmentation": {
-    "text": "Fragmentatieratio",
+    "text": "Fragmentatieverhouding",
     "source_hash": "721494dd"
   },
   "web.admin.system.database.stats.customers": {
@@ -88,7 +88,7 @@
     "source_hash": "60a627df"
   },
   "web.admin.system.database.stats.totalKeys": {
-    "text": "Totaal aantal sleutels",
+    "text": "Totaal sleutels",
     "source_hash": "4e0d27f5"
   },
   "web.admin.system.queue.title": {
@@ -96,7 +96,7 @@
     "source_hash": "3b2fe03e"
   },
   "web.admin.system.queue.loadError": {
-    "text": "Kan wachtrijstatistieken niet laden.",
+    "text": "Kon wachtrijstatistieken niet laden.",
     "source_hash": "715bdc88"
   },
   "web.admin.system.queue.empty": {
@@ -132,7 +132,7 @@
     "source_hash": "7f1e323b"
   },
   "web.admin.system.queue.health.degraded": {
-    "text": "Verminderd",
+    "text": "Verslechterd",
     "source_hash": "a8494c12"
   },
   "web.admin.system.queue.health.unhealthy": {
@@ -148,11 +148,139 @@
     "source_hash": "e762bd3c"
   },
   "web.admin.system.redis.loadError": {
-    "text": "Kan Redis-statistieken niet laden.",
+    "text": "Kon Redis-statistieken niet laden.",
     "source_hash": "ca5945d6"
   },
   "web.admin.system.redis.captured": {
     "text": "Vastgelegd {at}",
     "source_hash": "57b40c0f"
+  },
+  "web.admin.system.brand.title": {
+    "text": "Merkdiagnostiek",
+    "source_hash": "1cf9abd5"
+  },
+  "web.admin.system.brand.description": {
+    "text": "Welk merkpakket de draaiende instantie op schijf heeft opgelost — toont waarom een regio neutrale branding kan serveren.",
+    "source_hash": "be29e282"
+  },
+  "web.admin.system.brand.loadError": {
+    "text": "Kon merkdiagnostiek niet laden.",
+    "source_hash": "80607303"
+  },
+  "web.admin.system.brand.none": {
+    "text": "(geen)",
+    "source_hash": "552e4230"
+  },
+  "web.admin.system.brand.resolution": {
+    "text": "Resolutie",
+    "source_hash": "d4055faf"
+  },
+  "web.admin.system.brand.envVsConfig": {
+    "text": "Omgeving vs Configuratie",
+    "source_hash": "bee3debb"
+  },
+  "web.admin.system.brand.absorbed": {
+    "text": "Geabsorbeerde sleutels",
+    "source_hash": "9784e110"
+  },
+  "web.admin.system.brand.operatorKeys": {
+    "text": "Operatorsleutels",
+    "source_hash": "434e8248"
+  },
+  "web.admin.system.brand.overlayAssets": {
+    "text": "Overlay-assets",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.exists.yes": {
+    "text": "Aanwezig",
+    "source_hash": "43f9b89c"
+  },
+  "web.admin.system.brand.exists.no": {
+    "text": "Ontbreekt",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.system.brand.fields.resolvedDir": {
+    "text": "Opgeloste map",
+    "source_hash": "0623b983"
+  },
+  "web.admin.system.brand.fields.home": {
+    "text": "Home",
+    "source_hash": "3a786953"
+  },
+  "web.admin.system.brand.fields.envPack": {
+    "text": "ENV-merkpakket",
+    "source_hash": "940aeb5c"
+  },
+  "web.admin.system.brand.fields.configPack": {
+    "text": "Config-merkpakket",
+    "source_hash": "761b9550"
+  },
+  "web.admin.system.brand.fields.envAssetsDir": {
+    "text": "ENV-merkassetsmap",
+    "source_hash": "05854f1f"
+  },
+  "web.admin.system.brand.fields.configAssetsDir": {
+    "text": "Config-merkassetsmap",
+    "source_hash": "e91e5c46"
+  },
+  "web.admin.system.brand.flags.fellBack.danger": {
+    "text": "Teruggevallen op standaardpakket",
+    "source_hash": "7bf7ba2f"
+  },
+  "web.admin.system.brand.flags.fellBack.ok": {
+    "text": "Merkpakket opgelost",
+    "source_hash": "1ab3162f"
+  },
+  "web.admin.system.brand.flags.mismatch.danger": {
+    "text": "Boot / live mismatch",
+    "source_hash": "0a022192"
+  },
+  "web.admin.system.brand.flags.mismatch.ok": {
+    "text": "Boot komt overeen met live",
+    "source_hash": "d4792c09"
+  },
+  "web.admin.system.brand.manifest.title": {
+    "text": "Manifest",
+    "source_hash": "3c99f1f3"
+  },
+  "web.admin.system.brand.manifest.path": {
+    "text": "Pad",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.manifest.exists": {
+    "text": "Bestaat",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.manifest.keysOnDisk": {
+    "text": "Sleutels op schijf",
+    "source_hash": "52439c03"
+  },
+  "web.admin.system.brand.roots.title": {
+    "text": "Zoekwortels",
+    "source_hash": "d8696f2b"
+  },
+  "web.admin.system.brand.roots.empty": {
+    "text": "Geen zoekwortels",
+    "source_hash": "867a471c"
+  },
+  "web.admin.system.brand.roots.columns.path": {
+    "text": "Pad",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.roots.columns.exists": {
+    "text": "Bestaat",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.stats.brandPack": {
+    "text": "Merkpakket",
+    "source_hash": "884437d0"
+  },
+  "web.admin.system.brand.stats.overlayAssets": {
+    "text": "Overlay-assets",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.stats.manifestKeys": {
+    "text": "Manifestsleutels",
+    "source_hash": "c4267198"
   }
 }

--- a/locales/content/nl/admin-usage.json
+++ b/locales/content/nl/admin-usage.json
@@ -20,7 +20,7 @@
     "source_hash": "429532fe"
   },
   "web.admin.usage.loadError": {
-    "text": "Kan gebruiksgegevens niet laden.",
+    "text": "Kon gebruiksgegevens niet laden.",
     "source_hash": "ffb557d7"
   },
   "web.admin.usage.retry": {
@@ -60,7 +60,7 @@
     "source_hash": "37bac495"
   },
   "web.admin.usage.stats.totalSecrets": {
-    "text": "Totaal aantal berichten",
+    "text": "Totaal berichten",
     "source_hash": "e17a5459"
   },
   "web.admin.usage.stats.newUsers": {

--- a/locales/content/nl/api-domains-errors.json
+++ b/locales/content/nl/api-domains-errors.json
@@ -8,19 +8,19 @@
     "source_hash": "a0fd1025"
   },
   "api.domains.errors.organization_not_found": {
-    "text": "Geen organisatie gevonden voor domein: %{domain}",
+    "text": "Organisatie niet gevonden voor domein: %{domain}",
     "source_hash": "632afc93"
   },
   "api.domains.errors.incoming_secrets_disabled": {
-    "text": "Inkomende berichten zijn niet ingeschakeld op deze instance",
+    "text": "Inkomende berichten is niet ingeschakeld op deze instantie",
     "source_hash": "45c0b5c4"
   },
   "api.domains.errors.incoming_secrets_entitlement_required": {
-    "text": "Beheer van inkomende berichten vereist de incoming_secrets-entitlement. Upgrade je plan.",
+    "text": "Beheer van inkomende berichten vereist het incoming_secrets-recht. Upgrade je plan.",
     "source_hash": "1af54ec2"
   },
   "api.domains.errors.incoming_config_not_found": {
-    "text": "Geen inkomende-configuratie gevonden voor domein: %{extid}",
+    "text": "Inkomende configuratie niet gevonden voor domein: %{extid}",
     "source_hash": "491644a8"
   },
   "api.domains.errors.recipients_max_exceeded": {
@@ -32,7 +32,7 @@
     "source_hash": "e9c729c7"
   },
   "api.domains.errors.recipients_duplicate": {
-    "text": "Dubbele ontvanger-e-mailadressen zijn niet toegestaan",
+    "text": "Dubbele ontvangers-e-mails niet toegestaan",
     "source_hash": "6de22182"
   },
   "api.domains.errors.homepage_secrets_mode_invalid": {
@@ -40,11 +40,11 @@
     "source_hash": "cf093a04"
   },
   "api.domains.errors.homepage_incoming_entitlement_required": {
-    "text": "Modus voor inkomende berichten vereist de incoming_secrets-entitlement. Upgrade je plan.",
+    "text": "Inkomende berichtenmodus vereist het incoming_secrets-recht. Upgrade je plan.",
     "source_hash": "d68b13d8"
   },
   "api.domains.errors.homepage_incoming_not_ready": {
-    "text": "Inkomende berichten moeten zijn ingeschakeld met minstens één ontvanger voordat dit als homepage kan worden gebruikt.",
+    "text": "Inkomende berichten moet ingeschakeld zijn met minimaal één ontvanger voordat het als homepagina kan worden gebruikt.",
     "source_hash": "556da6e2"
   }
 }

--- a/locales/content/nl/api-entitlements-errors.json
+++ b/locales/content/nl/api-entitlements-errors.json
@@ -1,6 +1,6 @@
 {
   "api.entitlements.errors.context_unavailable": {
-    "text": "Kan entitlements niet verifiëren (organisatiecontext niet beschikbaar)",
+    "text": "Kan rechten niet verifiëren (organisatiecontext niet beschikbaar)",
     "source_hash": "704dc629"
   },
   "api.entitlements.errors.api_access_required": {
@@ -12,7 +12,7 @@
     "source_hash": "4e71274d"
   },
   "api.entitlements.errors.extended_default_expiration_required": {
-    "text": "Verlengde standaardvervaltijd vereist een planupgrade",
+    "text": "Verlengde standaard vervaldatum vereist een planupgrade",
     "source_hash": "efa702e7"
   },
   "api.entitlements.errors.custom_domains_required": {
@@ -24,7 +24,7 @@
     "source_hash": "a4c40a3a"
   },
   "api.entitlements.errors.homepage_secrets_required": {
-    "text": "Homepageberichten vereisen een planupgrade",
+    "text": "Homepagina-berichten vereisen een planupgrade",
     "source_hash": "650eeca8"
   },
   "api.entitlements.errors.incoming_secrets_required": {
@@ -32,11 +32,11 @@
     "source_hash": "ce1d47ef"
   },
   "api.entitlements.errors.custom_mail_sender_required": {
-    "text": "Aangepaste e-mailafzender vereist een planupgrade",
+    "text": "Aangepaste mailafzender vereist een planupgrade",
     "source_hash": "e058da13"
   },
   "api.entitlements.errors.flexible_from_domain_required": {
-    "text": "Flexibel from-domein vereist een planupgrade",
+    "text": "Flexibel van-domein vereist een planupgrade",
     "source_hash": "4931dc05"
   },
   "api.entitlements.errors.manage_org_required": {
@@ -56,19 +56,19 @@
     "source_hash": "4e5da22d"
   },
   "api.entitlements.errors.audit_logs_required": {
-    "text": "Auditlogboeken vereisen een planupgrade",
+    "text": "Auditlogs vereisen een planupgrade",
     "source_hash": "1ff748bc"
   },
   "api.entitlements.errors.custom_signup_validation_required": {
-    "text": "Aangepaste aanmeldvalidatie vereist een planupgrade",
+    "text": "Aangepaste registratievalidatie vereist een planupgrade",
     "source_hash": "93c9befa"
   },
   "api.entitlements.errors.create_secrets_required": {
-    "text": "Het aanmaken van berichten vereist een planupgrade",
+    "text": "Berichten aanmaken vereist een planupgrade",
     "source_hash": "01091fed"
   },
   "api.entitlements.errors.view_receipt_required": {
-    "text": "Het bekijken van ontvangstbewijzen vereist een planupgrade",
+    "text": "Ontvangstbewijzen bekijken vereist een planupgrade",
     "source_hash": "e6370d8c"
   },
   "api.entitlements.errors.notifications_required": {
@@ -76,7 +76,7 @@
     "source_hash": "82353ba6"
   },
   "api.entitlements.errors.workspace_branding_required": {
-    "text": "Workspace-branding vereist een planupgrade",
+    "text": "Werkruimtebranding vereist een planupgrade",
     "source_hash": "79ac8099"
   },
   "api.entitlements.errors.ip_access_rules_required": {
@@ -84,7 +84,7 @@
     "source_hash": "3e1d276e"
   },
   "api.entitlements.errors.manage_billing_required": {
-    "text": "Facturatiebeheer vereist een planupgrade",
+    "text": "Factureringsbeheer vereist een planupgrade",
     "source_hash": "dec5d6aa"
   },
   "api.entitlements.errors.custom_signin_config_required": {

--- a/locales/content/nl/api-incoming-errors.json
+++ b/locales/content/nl/api-incoming-errors.json
@@ -1,6 +1,6 @@
 {
   "api.incoming.errors.custom_domain_unresolved": {
-    "text": "Organisatie van aangepast domein kon niet worden bepaald",
+    "text": "Aangepaste domeinorganisatie kon niet worden opgelost",
     "source_hash": "b30d65d2"
   }
 }

--- a/locales/content/nl/api-organizations-errors.json
+++ b/locales/content/nl/api-organizations-errors.json
@@ -8,15 +8,15 @@
     "source_hash": "c8d058eb"
   },
   "api.organizations.errors.organization_owner_required": {
-    "text": "Alleen de eigenaar van de organisatie kan deze actie uitvoeren",
+    "text": "Alleen de organisatie-eigenaar kan deze actie uitvoeren",
     "source_hash": "5a729e94"
   },
   "api.organizations.errors.organization_member_required": {
-    "text": "Je moet lid van de organisatie zijn om deze actie uit te voeren",
+    "text": "Je moet lid zijn van de organisatie om deze actie uit te voeren",
     "source_hash": "f66f4a60"
   },
   "api.organizations.errors.organization_admin_required": {
-    "text": "Alleen eigenaren en beheerders van de organisatie kunnen deze actie uitvoeren",
+    "text": "Alleen organisatie-eigenaren en beheerders kunnen deze actie uitvoeren",
     "source_hash": "cd9e8c0e"
   },
   "api.organizations.errors.extid_required": {
@@ -28,11 +28,11 @@
     "source_hash": "c3f6e9af"
   },
   "api.organizations.errors.display_name_too_long": {
-    "text": "Organisatienaam moet minder dan %{max} tekens bevatten",
+    "text": "Organisatienaam moet minder dan %{max} tekens zijn",
     "source_hash": "5866973d"
   },
   "api.organizations.errors.description_too_long": {
-    "text": "Beschrijving moet minder dan %{max} tekens bevatten",
+    "text": "Beschrijving moet minder dan %{max} tekens zijn",
     "source_hash": "562b7250"
   },
   "api.organizations.errors.contact_email_exists": {
@@ -52,7 +52,7 @@
     "source_hash": "775ba9eb"
   },
   "api.organizations.invitations.errors.email_required": {
-    "text": "E-mailadres is vereist",
+    "text": "E-mail is vereist",
     "source_hash": "aae92911"
   },
   "api.organizations.invitations.errors.invalid_email_format": {
@@ -72,7 +72,7 @@
     "source_hash": "8eb45780"
   },
   "api.organizations.invitations.errors.invitation_already_pending": {
-    "text": "Er is al een uitnodiging in behandeling voor dit e-mailadres",
+    "text": "Uitnodiging al in behandeling voor dit e-mailadres",
     "source_hash": "7f5e3093"
   },
   "api.organizations.invitations.errors.member_limit_reached": {
@@ -80,15 +80,15 @@
     "source_hash": "b8f316e8"
   },
   "api.organizations.invitations.errors.resend_only_pending": {
-    "text": "Alleen uitnodigingen in behandeling kunnen opnieuw worden verzonden",
+    "text": "Kan alleen uitnodigingen in behandeling opnieuw verzenden",
     "source_hash": "b7578b3e"
   },
   "api.organizations.invitations.errors.resend_limit_reached": {
-    "text": "Maximale limiet voor opnieuw verzenden (%{max}) bereikt",
+    "text": "Maximale verzendlimiet (%{max}) bereikt",
     "source_hash": "8dc96729"
   },
   "api.organizations.invitations.errors.revoke_only_pending": {
-    "text": "Alleen uitnodigingen in behandeling kunnen worden ingetrokken",
+    "text": "Kan alleen uitnodigingen in behandeling intrekken",
     "source_hash": "732b78a6"
   },
   "api.organizations.members.errors.member_not_found": {
@@ -104,35 +104,35 @@
     "source_hash": "a51b8760"
   },
   "api.organizations.members.errors.invalid_role_value": {
-    "text": "Ongeldige rol. Moet een van de volgende zijn: %{roles}",
+    "text": "Ongeldige rol. Moet een van zijn: %{roles}",
     "source_hash": "c3331aa0"
   },
   "api.organizations.members.errors.cannot_change_owner_role": {
-    "text": "Kan de rol van eigenaar niet wijzigen. Gebruik in plaats daarvan eigendomsoverdracht.",
+    "text": "Kan eigenaarrol niet wijzigen. Gebruik in plaats daarvan eigendomsoverdracht.",
     "source_hash": "76015424"
   },
   "api.organizations.members.errors.member_already_has_role": {
-    "text": "Lid heeft de rol al: %{role}",
+    "text": "Lid heeft al de rol: %{role}",
     "source_hash": "6771166a"
   },
   "api.organizations.members.errors.cannot_promote_to_owner": {
-    "text": "Kan niet promoveren tot eigenaar. Gebruik in plaats daarvan eigendomsoverdracht.",
+    "text": "Kan niet promoveren naar eigenaar. Gebruik in plaats daarvan eigendomsoverdracht.",
     "source_hash": "cd574007"
   },
   "api.organizations.members.errors.must_be_member": {
-    "text": "Je moet lid van deze organisatie zijn",
+    "text": "Je moet lid zijn van deze organisatie",
     "source_hash": "de1c77b8"
   },
   "api.organizations.members.errors.cannot_remove_owner": {
-    "text": "Kan de eigenaar van de organisatie niet verwijderen. Draag eerst het eigendom over.",
+    "text": "Kan organisatie-eigenaar niet verwijderen. Draag eerst het eigendom over.",
     "source_hash": "d4f33003"
   },
   "api.organizations.members.errors.cannot_remove_self": {
-    "text": "Kan jezelf niet verwijderen. Verlaat in plaats daarvan de organisatie.",
+    "text": "Kan jezelf niet verwijderen. Gebruik in plaats daarvan organisatie verlaten.",
     "source_hash": "d64cec91"
   },
   "api.organizations.members.errors.admin_cannot_remove_admin": {
-    "text": "Beheerders kunnen geen andere beheerders verwijderen. Alleen eigenaren kunnen dat.",
+    "text": "Beheerders kunnen andere beheerders niet verwijderen. Alleen eigenaren kunnen dat.",
     "source_hash": "2b3e6e30"
   },
   "api.organizations.members.errors.no_permission_to_remove": {

--- a/locales/content/nl/api-secrets-errors.json
+++ b/locales/content/nl/api-secrets-errors.json
@@ -12,7 +12,7 @@
     "source_hash": "b41920ba"
   },
   "api.secrets.errors.secret_undecryptable": {
-    "text": "Dit bericht kan op dit moment niet worden ontsleuteld. De link is nog intact — de sitebeheerder moet de versleutelingssleutel herstellen voordat het kan worden onthuld.",
+    "text": "Dit bericht kan nu niet worden ontsleuteld. De link is nog intact — de site-operator moet de encryptiesleutel herstellen voordat het kan worden onthuld.",
     "source_hash": "56e283ee"
   }
 }

--- a/locales/content/nl/email.json
+++ b/locales/content/nl/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Secret Support",
+    "text": "Onetime Secret-supportteam",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/nl/email.json
+++ b/locales/content/nl/email.json
@@ -5,7 +5,7 @@
     "source_hash": "9e2074ae"
   },
   "email.incomingsupport.body1": {
-    "text": "Een klant heeft de volgende informatie verzonden",
+    "text": "Een klant heeft de volgende informatie gestuurd",
     "renderer": "erb",
     "source_hash": "9c965ab8"
   },
@@ -25,7 +25,7 @@
     "source_hash": "496d6960"
   },
   "email.secret_link.link_works_once": {
-    "text": "Deze link werkt maar één keer. Na het bekijken wordt het bericht permanent verwijderd.",
+    "text": "Deze link werkt slechts één keer. Na het bekijken wordt het bericht permanent verwijderd.",
     "renderer": "erb",
     "source_hash": "fecaf0a1"
   },
@@ -35,7 +35,7 @@
     "source_hash": "d01479b3"
   },
   "email.welcome.subject": {
-    "text": "Welkom bij %{product_name} - Verifieer alsjeblieft je e-mail",
+    "text": "Welkom bij %{product_name} - Verifieer je e-mail",
     "renderer": "erb",
     "source_hash": "96008c17"
   },
@@ -45,7 +45,7 @@
     "source_hash": "77e7dda4"
   },
   "email.welcome.verify_prompt": {
-    "text": "Verifieer je e-mailadres door op de onderstaande link te klikken:",
+    "text": "Verifieer je e-mailadres door op de link hieronder te klikken:",
     "renderer": "erb",
     "source_hash": "e373dcee"
   },
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Supportteam",
+    "text": "Ondersteuningsteam",
     "renderer": "erb",
     "source_hash": "dc75bf9f"
   },
@@ -80,7 +80,7 @@
     "source_hash": "0568c7b0"
   },
   "email.password_request.request_notice": {
-    "text": "We hebben een verzoek ontvangen om je wachtwoord te resetten voor %{product_name}.",
+    "text": "We hebben een verzoek ontvangen om je wachtwoord voor %{product_name} te resetten.",
     "renderer": "erb",
     "source_hash": "4ad3b5cd"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Supportteam",
+    "text": "Ondersteuningsteam",
     "renderer": "erb",
     "source_hash": "dc75bf9f"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Supportteam",
+    "text": "Ondersteuningsteam",
     "renderer": "erb",
     "source_hash": "dc75bf9f"
   },
@@ -175,7 +175,7 @@
     "source_hash": "12ac0a81"
   },
   "email.incoming_secret.view_instructions": {
-    "text": "Klik op de onderstaande link om dit bericht te bekijken:",
+    "text": "Klik op de link hieronder om dit bericht te bekijken:",
     "renderer": "erb",
     "source_hash": "1dcdc014"
   },
@@ -185,12 +185,12 @@
     "source_hash": "496d6960"
   },
   "email.incoming_secret.link_works_once": {
-    "text": "Deze link werkt maar één keer. Na het bekijken wordt het bericht permanent verwijderd.",
+    "text": "Deze link werkt slechts één keer. Na het bekijken wordt het bericht permanent verwijderd.",
     "renderer": "erb",
     "source_hash": "fecaf0a1"
   },
   "email.incoming_secret.passphrase_required": {
-    "text": "Dit bericht is beveiligd met een wachtwoordzin. De afzender moet deze apart aan je doorgeven.",
+    "text": "Dit bericht is beveiligd met een wachtwoordzin. De afzender moet deze apart aan je verstrekken.",
     "renderer": "erb",
     "source_hash": "1e49826b"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Supportteam",
+    "text": "Ondersteuningsteam",
     "renderer": "erb",
     "source_hash": "dc75bf9f"
   },
@@ -245,12 +245,12 @@
     "source_hash": "83cbd163"
   },
   "email.expiration_warning.subject": {
-    "text": "Je beveiligde link verloopt binnenkort",
+    "text": "Je berichtlink verloopt binnenkort",
     "renderer": "erb",
     "source_hash": "74813c5f"
   },
   "email.expiration_warning.expires_in": {
-    "text": "Je beveiligde link verloopt over %{time_remaining}",
+    "text": "Je berichtlink verloopt over %{time_remaining}",
     "renderer": "erb",
     "source_hash": "e7bb47f6"
   },
@@ -265,7 +265,7 @@
     "source_hash": "e945d640"
   },
   "email.expiration_warning.after_expiration": {
-    "text": "Na verlopen wordt het bericht permanent verwijderd en kan het niet worden hersteld.",
+    "text": "Na het verlopen wordt het bericht permanent verwijderd en kan het niet worden hersteld.",
     "renderer": "erb",
     "source_hash": "deb92a01"
   },
@@ -275,12 +275,12 @@
     "source_hash": "d01479b3"
   },
   "email.expiration_warning.view_before_gone": {
-    "text": "Bekijk het voordat het verdwijnt:",
+    "text": "Bekijk het voordat het weg is:",
     "renderer": "erb",
     "source_hash": "30342c04"
   },
   "email.expiration_warning.after_expiration_short": {
-    "text": "Na verlopen wordt het bericht permanent verwijderd.",
+    "text": "Na het verlopen wordt het bericht permanent verwijderd.",
     "renderer": "erb",
     "source_hash": "bd0a9bee"
   },
@@ -315,22 +315,22 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Onetime Secret-supportteam",
+    "text": "Secret Support",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },
   "email.organization_invitation.subject": {
-    "text": "Je bent uitgenodigd om deel te nemen aan %{organization_name}",
+    "text": "Je bent uitgenodigd om lid te worden van %{organization_name}",
     "renderer": "erb",
     "source_hash": "58591e00"
   },
   "email.organization_invitation.title": {
-    "text": "Je bent uitgenodigd om deel te nemen aan %{organization_name}!",
+    "text": "Je bent uitgenodigd om lid te worden van %{organization_name}!",
     "renderer": "erb",
     "source_hash": "19548dfd"
   },
   "email.organization_invitation.body": {
-    "text": "%{inviter_email} heeft je uitgenodigd om deel te nemen aan \"%{organization_name}\" als %{role_description}.",
+    "text": "%{inviter_email} heeft je uitgenodigd om lid te worden van \"%{organization_name}\" als %{role_description}.",
     "renderer": "erb",
     "source_hash": "e4d3fb65"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Supportteam",
+    "text": "Ondersteuningsteam",
     "renderer": "erb",
     "source_hash": "dc75bf9f"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Supportteam",
+    "text": "Ondersteuningsteam",
     "renderer": "erb",
     "source_hash": "dc75bf9f"
   },
@@ -410,7 +410,7 @@
     "source_hash": "db70f965"
   },
   "email.email_changed.security_notice": {
-    "text": "Als je deze wijziging niet hebt aangebracht, neem dan onmiddellijk contact op met de ondersteuning, omdat je account mogelijk is gehackt.",
+    "text": "Als je deze wijziging niet hebt aangebracht, neem dan onmiddellijk contact op met de ondersteuning omdat je account mogelijk is gecompromitteerd.",
     "renderer": "erb",
     "source_hash": "f505b562"
   },
@@ -430,7 +430,7 @@
     "source_hash": "f4a9cdda"
   },
   "email.email_changed.if_you_initiated": {
-    "text": "Als je deze wijziging hebt aangebracht, hoef je verder niets te doen.",
+    "text": "Als je deze wijziging hebt aangebracht, is er geen verdere actie nodig.",
     "renderer": "erb",
     "source_hash": "5cb54887"
   },
@@ -440,17 +440,17 @@
     "source_hash": "08f479fb"
   },
   "email.email_changed.contact_support": {
-    "text": "Contact opnemen met support",
+    "text": "Contact opnemen met ondersteuning",
     "renderer": "erb",
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Supportteam",
+    "text": "Ondersteuningsteam",
     "renderer": "erb",
     "source_hash": "dc75bf9f"
   },
   "email.email_changed.postscript": {
-    "text": "P.S. Deze e-mail is verzonden naar %{email_address} om je te informeren over een wijziging van je e-mailadres.",
+    "text": "P.S. Deze e-mail is verzonden naar %{email_address} om je te informeren over een e-mailadreswijziging.",
     "renderer": "erb",
     "source_hash": "475cae37"
   },
@@ -465,7 +465,7 @@
     "source_hash": "704cbdca"
   },
   "email.email_change_requested.change_notice": {
-    "text": "Er is een verzoek ingediend om het e-mailadres van je %{product_name}-account te wijzigen.",
+    "text": "Er is een verzoek gedaan om het e-mailadres van je %{product_name}-account te wijzigen.",
     "renderer": "erb",
     "source_hash": "d7e39154"
   },
@@ -480,7 +480,7 @@
     "source_hash": "ada23c51"
   },
   "email.email_change_requested.if_you_initiated": {
-    "text": "Als je dit verzoek hebt gedaan, controleer dan je nieuwe e-mailadres voor een bevestigingslink. Er zijn nog geen wijzigingen doorgevoerd.",
+    "text": "Als je dit verzoek hebt gedaan, controleer dan je nieuwe e-mail voor een bevestigingslink. Er zijn nog geen wijzigingen aangebracht.",
     "renderer": "erb",
     "source_hash": "aa1bf526"
   },
@@ -490,12 +490,12 @@
     "source_hash": "ff41a7b7"
   },
   "email.email_change_requested.contact_support": {
-    "text": "Neem contact op met support",
+    "text": "Contact opnemen met ondersteuning",
     "renderer": "erb",
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Supportteam",
+    "text": "Ondersteuningsteam",
     "renderer": "erb",
     "source_hash": "dc75bf9f"
   },
@@ -530,7 +530,7 @@
     "source_hash": "33277e1b"
   },
   "email.email_change_confirmation.confirm_button": {
-    "text": "E-mailadres wijzigen bevestigen",
+    "text": "E-mailwijziging bevestigen",
     "renderer": "erb",
     "source_hash": "c2736949"
   },
@@ -550,12 +550,12 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Supportteam",
+    "text": "Ondersteuningsteam",
     "renderer": "erb",
     "source_hash": "dc75bf9f"
   },
   "email.email_change_confirmation.postscript": {
-    "text": "P.S. Deze e-mail is verzonden naar %{email_address} om een wijziging van je e-mailadres te bevestigen.",
+    "text": "P.S. Deze e-mail is verzonden naar %{email_address} om een e-mailadreswijziging te bevestigen.",
     "renderer": "erb",
     "source_hash": "b72f557c"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Supportteam",
+    "text": "Ondersteuningsteam",
     "renderer": "erb",
     "source_hash": "dc75bf9f"
   },
@@ -605,22 +605,22 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Supportteam",
+    "text": "Ondersteuningsteam",
     "renderer": "erb",
     "source_hash": "dc75bf9f"
   },
   "email.new_login_alert.subject": {
-    "text": "Nieuwe aanmelding bij je account (%{display_domain})",
+    "text": "Nieuwe inlogpoging op je account (%{display_domain})",
     "renderer": "erb",
     "source_hash": "a704f0bb"
   },
   "email.new_login_alert.title": {
-    "text": "Nieuwe aanmelding gedetecteerd",
+    "text": "Nieuwe inlogpoging gedetecteerd",
     "renderer": "erb",
     "source_hash": "61172ee4"
   },
   "email.new_login_alert.body": {
-    "text": "Er is een nieuwe aanmelding bij je %{product_name}-account gedetecteerd op %{date} om %{time}.",
+    "text": "Een nieuwe inlogpoging op je %{product_name}-account is gedetecteerd op %{date} om %{time}.",
     "renderer": "erb",
     "source_hash": "040f8f48"
   },
@@ -640,7 +640,7 @@
     "source_hash": "a2cb73e4"
   },
   "email.new_login_alert.not_you_notice": {
-    "text": "Als jij dit niet was, is je account mogelijk gehackt.",
+    "text": "Als dit niet jij was, is je account mogelijk gecompromitteerd.",
     "renderer": "erb",
     "source_hash": "e2f819c9"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Supportteam",
+    "text": "Ondersteuningsteam",
     "renderer": "erb",
     "source_hash": "dc75bf9f"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Supportteam",
+    "text": "Ondersteuningsteam",
     "renderer": "erb",
     "source_hash": "dc75bf9f"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Supportteam",
+    "text": "Ondersteuningsteam",
     "renderer": "erb",
     "source_hash": "dc75bf9f"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Supportteam",
+    "text": "Ondersteuningsteam",
     "renderer": "erb",
     "source_hash": "dc75bf9f"
   },
@@ -720,12 +720,12 @@
     "source_hash": "82114f95"
   },
   "email.trial_expiring.title": {
-    "text": "Je proefperiode loopt bijna af",
+    "text": "Je proefperiode eindigt binnenkort",
     "renderer": "erb",
     "source_hash": "36200518"
   },
   "email.trial_expiring.body": {
-    "text": "Je gratis proefperiode van %{product_name} verloopt over %{days_remaining} dagen. Upgrade nu om toegang te behouden tot alle functies.",
+    "text": "Je gratis proefperiode van %{product_name} verloopt over %{days_remaining} dagen. Upgrade nu om toegang te houden tot alle functies.",
     "renderer": "erb",
     "source_hash": "17fc32dd"
   },
@@ -735,7 +735,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Supportteam",
+    "text": "Ondersteuningsteam",
     "renderer": "erb",
     "source_hash": "dc75bf9f"
   },
@@ -760,7 +760,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Supportteam",
+    "text": "Ondersteuningsteam",
     "renderer": "erb",
     "source_hash": "dc75bf9f"
   },
@@ -780,7 +780,7 @@
     "source_hash": "3e92efb7"
   },
   "email.common.view_in_browser": {
-    "text": "Bekijk in browser",
+    "text": "Bekijken in browser",
     "renderer": "erb",
     "source_hash": "be843876"
   },
@@ -790,23 +790,23 @@
     "source_hash": "1cd0194a"
   },
   "email.common.secret_link_label": {
-    "text": "Beveiligde link",
+    "text": "Berichtlink",
     "source_hash": "18ddf44f"
   },
   "email.common.automated_notice": {
-    "text": "Dit is een geautomatiseerd bericht van %{product_name}.",
+    "text": "Dit is een automatisch bericht van %{product_name}.",
     "source_hash": "8fbabfba"
   },
   "email.common.support_label": {
-    "text": "Support",
+    "text": "Ondersteuning",
     "source_hash": "be91940b"
   },
   "email.expiration_warning.signature": {
-    "text": "Supportteam",
+    "text": "Ondersteuningsteam",
     "source_hash": "dc75bf9f"
   },
   "email.expiration_warning.footer_note": {
-    "text": "Je hebt dit ontvangen omdat een bericht dat je op %{product_name} hebt aangemaakt binnenkort verloopt.",
+    "text": "Je hebt dit ontvangen omdat een bericht dat je hebt aangemaakt op %{product_name} binnenkort verloopt.",
     "source_hash": "920779e4"
   },
   "email.feedback_email.user_id_label": {
@@ -830,11 +830,47 @@
     "source_hash": "1ab9a20f"
   },
   "email.secret_link.passphrase_required": {
-    "text": "Dit bericht is beveiligd met een wachtwoordzin. De afzender hoort deze apart aan je te verstrekken.",
+    "text": "Dit bericht is beveiligd met een wachtwoordzin. De afzender moet deze apart aan je verstrekken.",
     "source_hash": "1e49826b"
   },
   "email.secret_link.footer_note": {
     "text": "Je hebt dit ontvangen omdat %{sender_email} %{product_name} heeft gebruikt om een bericht met je te delen. Als je dit niet verwachtte, kun je deze e-mail veilig negeren.",
     "source_hash": "2d544dad"
+  },
+  "email.sso_link_verification.subject": {
+    "text": "Bevestig het koppelen van %{provider} aan je %{product_name}-account",
+    "source_hash": "65e70296"
+  },
+  "email.sso_link_verification.title": {
+    "text": "Bevestig je SSO-inlogpoging",
+    "source_hash": "35bce6cc"
+  },
+  "email.sso_link_verification.request_notice": {
+    "text": "Iemand heeft ingelogd met %{provider} met het e-mailadres %{email_address}. Om het koppelen van %{provider} aan je %{product_name}-account te voltooien, bevestig hieronder.",
+    "source_hash": "baeb18c0"
+  },
+  "email.sso_link_verification.confirm_button": {
+    "text": "Bevestigen en %{provider} koppelen",
+    "source_hash": "9809e210"
+  },
+  "email.sso_link_verification.copy_link_prompt": {
+    "text": "Of kopieer en plak deze link:",
+    "source_hash": "88c72144"
+  },
+  "email.sso_link_verification.expiration_notice": {
+    "text": "Deze link verloopt over 15 minuten en kan slechts één keer worden gebruikt.",
+    "source_hash": "1a437f42"
+  },
+  "email.sso_link_verification.ignore_notice": {
+    "text": "Als je niet hebt geprobeerd in te loggen met %{provider}, kun je deze e-mail veilig negeren — er wordt niets aan je account gekoppeld.",
+    "source_hash": "d7317d30"
+  },
+  "email.sso_link_verification.signature": {
+    "text": "Ondersteuningsteam",
+    "source_hash": "dc75bf9f"
+  },
+  "email.sso_link_verification.postscript": {
+    "text": "P.S. Deze e-mail is verzonden naar %{email_address}.",
+    "source_hash": "8ab1dbea"
   }
 }

--- a/locales/content/nl/error-pages.json
+++ b/locales/content/nl/error-pages.json
@@ -4,7 +4,7 @@
     "source_hash": "bd545472"
   },
   "web.errors.secrets_are_designed_to_be_viewed_only_once": {
-    "text": "Geheimen zijn ontworpen om slechts één keer bekeken te worden. Deze link is mogelijk al geopend, verlopen of handmatig verwijderd door de afzender.",
+    "text": "Berichten zijn ontworpen om slechts één keer te worden bekeken. Deze link kan al zijn geopend, verlopen of handmatig door de afzender zijn verwijderd.",
     "source_hash": "44c54ed2"
   },
   "web.errors.what_should_i_do_now": {
@@ -12,7 +12,7 @@
     "source_hash": "fbf3e67f"
   },
   "web.errors.contact_the_person_who_sent_you_this_link": {
-    "text": "Neem contact op met de persoon die je deze link heeft gestuurd en vraag om een nieuw geheim aan te maken. Laat hen weten dat je geen toegang had tot de oorspronkelijke informatie.",
+    "text": "Neem contact op met de persoon die je deze link heeft gestuurd en vraag of ze een nieuw bericht willen aanmaken. Laat weten dat je de originele informatie niet kon openen.",
     "source_hash": "d9f4f41a"
   },
   "web.errors.warning_dismissed": {
@@ -20,7 +20,7 @@
     "source_hash": "e6d67409"
   },
   "web.errors.dismiss_truncation_warning": {
-    "text": "Afkappingswaarschuwing sluiten",
+    "text": "Afkapwaarschuwing sluiten",
     "source_hash": "79e02fe6"
   },
   "web.errors.oops_the_page_you_are_looking_for_doesnt_exist_o": {
@@ -48,11 +48,11 @@
     "source_hash": "0df00d3f"
   },
   "web.errors.information_shared_through_our_service_can_only_": {
-    "text": "Informatie die via onze service wordt gedeeld, kan slechts één keer worden bekeken. Na het bekijken wordt de inhoud permanent verwijderd van onze servers om vertrouwelijkheid te waarborgen. Deze aanpak helpt je gevoelige gegevens te beschermen door de blootstelling ervan te beperken en ongeautoriseerde toegang te voorkomen.",
+    "text": "Informatie die via onze dienst wordt gedeeld, kan slechts één keer worden geopend. Na het bekijken wordt de inhoud permanent van onze servers verwijderd om vertrouwelijkheid te garanderen. Deze aanpak helpt je gevoelige gegevens te beschermen door de blootstelling te beperken en ongeautoriseerde toegang te voorkomen.",
     "source_hash": "a3fd8283"
   },
   "web.errors.were_sorry_but_an_unexpected_error_occurred_whil": {
-    "text": "Het spijt ons, maar er is een onverwachte fout opgetreden tijdens het verwerken van je verzoek. Ons team is op de hoogte gebracht en we werken aan een oplossing.",
+    "text": "Het spijt ons, maar er is een onverwachte fout opgetreden bij het verwerken van je verzoek. Ons team is op de hoogte gesteld en we werken aan een oplossing.",
     "source_hash": "f3b50965"
   },
   "web.errors.t_web_common_oops_something_went_wrong": {
@@ -64,7 +64,7 @@
     "source_hash": "04c04b1a"
   },
   "web.errors.the_page_youre_looking_for_doesnt_exist_or_has_b": {
-    "text": "De pagina die je zoekt bestaat niet of is verplaatst. Maak je geen zorgen, dit gebeurt bij de besten!",
+    "text": "De pagina die je zoekt bestaat niet of is verplaatst. Geen zorgen, dat overkomt de besten!",
     "source_hash": "e26522de"
   },
   "web.errors.t_web_common_oops_404": {
@@ -72,7 +72,7 @@
     "source_hash": "ba5b5737"
   },
   "web.errors.unable_to_load_data_due_to_data_format_issues_pl": {
-    "text": "Kan gegevens niet laden vanwege problemen met gegevensformaat. Probeer het later opnieuw.",
+    "text": "Kan gegevens niet laden vanwege problemen met het gegevensformaat. Probeer het later opnieuw.",
     "source_hash": "a7b6f998"
   }
 }

--- a/locales/content/nl/feature-feedback.json
+++ b/locales/content/nl/feature-feedback.json
@@ -28,11 +28,11 @@
     "source_hash": "f58154f7"
   },
   "web.feedback.help_content_goes_here": {
-    "text": "Helpinhoud komt hier.",
+    "text": "Help-inhoud komt hier.",
     "source_hash": "796979ea"
   },
   "web.feedback.founder_note_line1": {
-    "text": "Ik lees elk stukje feedback dat hier binnenkomt. Zo bepaal ik waar ik mijn tijd aan besteed.",
+    "text": "Ik lees elk stuk feedback dat hier binnenkomt. Zo bepaal ik waar ik tijd aan besteed.",
     "source_hash": "8b430d93"
   },
   "web.feedback.founder_note_line2": {
@@ -56,15 +56,15 @@
     "source_hash": "286a3af7"
   },
   "web.feedback.reason_email_change_unauthorized": {
-    "text": "Het lijkt erop dat je een ongeautoriseerde wijziging van het e-mailadres op je account meldt. Beschrijf wat er is gebeurd en we onderzoeken het direct.",
+    "text": "Het lijkt erop dat je een ongeautoriseerde e-mailwijziging op je account meldt. Beschrijf wat er is gebeurd en we zullen dit meteen onderzoeken.",
     "source_hash": "00e56551"
   },
   "web.feedback.anonymous_no_reply": {
-    "text": "Let op: als je een reactie wilt, onderteken het bericht dan of vermeld een e-mailadres erin.",
+    "text": "Let op: als je een reactie wilt, onderteken dan of voeg een e-mailadres toe aan het bericht.",
     "source_hash": "c984f705"
   },
   "web.feedback.characters_remaining": {
-    "text": "Nog {count} tekens",
+    "text": "{count} tekens resterend",
     "source_hash": "8d796f40"
   },
   "web.feedback.character_limit_reached": {

--- a/locales/content/nl/feature-homepage-secrets.json
+++ b/locales/content/nl/feature-homepage-secrets.json
@@ -1,14 +1,14 @@
 {
   "homepage_secrets.disabled.members_only_eyebrow": {
-    "text": "Instance alleen voor leden",
+    "text": "Alleen voor leden",
     "source_hash": "979899b1"
   },
   "homepage_secrets.disabled.private_instance_eyebrow": {
-    "text": "Privé-instance",
+    "text": "Privé-instantie",
     "source_hash": "5ef5f093"
   },
   "homepage_secrets.disabled.team_link_headline": {
-    "text": "Deze link is voor het team van {workspace}.",
+    "text": "Deze link is voor het {workspace}-team.",
     "source_hash": "d17f49d1"
   },
   "homepage_secrets.disabled.signin_headline": {
@@ -16,15 +16,15 @@
     "source_hash": "08b665e2"
   },
   "homepage_secrets.disabled.signin_headline_action": {
-    "text": "beveiligde link",
+    "text": "berichtlink",
     "source_hash": "78c621b6"
   },
   "homepage_secrets.disabled.team_subtitle": {
-    "text": "Alleen geautoriseerde teamleden bij {domain} kunnen hier nieuwe eenmalige links aanmaken. Ontvangers kunnen nog steeds elke link openen die ze hebben ontvangen.",
+    "text": "Alleen geautoriseerde teamgenoten bij {domain} kunnen hier nieuwe eenmalige links aanmaken. Ontvangers kunnen nog steeds elke link openen die ze hebben ontvangen.",
     "source_hash": "62198a0e"
   },
   "homepage_secrets.disabled.public_subtitle": {
-    "text": "Alleen geautoriseerde leden van deze instance kunnen nieuwe eenmalige links aanmaken. Ontvangers kunnen nog steeds elke link openen die ze hebben ontvangen.",
+    "text": "Alleen geautoriseerde leden van deze instantie kunnen nieuwe eenmalige links aanmaken. Ontvangers kunnen nog steeds elke link openen die ze hebben ontvangen.",
     "source_hash": "0208d739"
   },
   "homepage_secrets.disabled.signin_cta": {
@@ -36,7 +36,7 @@
     "source_hash": "0b12ba39"
   },
   "homepage_secrets.disabled.trust_viewed_once": {
-    "text": "Eén keer bekeken, daarna weg",
+    "text": "Eenmaal bekeken, dan weg",
     "source_hash": "abb7a947"
   },
   "homepage_secrets.disabled.trust_zero_retained": {
@@ -48,11 +48,11 @@
     "source_hash": "00888d63"
   },
   "homepage_secrets.disabled.promo_subtitle": {
-    "text": "Wijs je domein toe aan Onetime Secret en verstuur berichten onder je eigen merk.",
+    "text": "Verwijs je domein naar Onetime Secret en verstuur berichten onder je eigen merk.",
     "source_hash": "27ecd53c"
   },
   "homepage_secrets.disabled.promo_learn_how": {
-    "text": "Ontdek hoe",
+    "text": "Leer hoe",
     "source_hash": "99c61c4c"
   },
   "homepage_secrets.disabled.logo_alt": {

--- a/locales/content/nl/feature-incoming.json
+++ b/locales/content/nl/feature-incoming.json
@@ -1,6 +1,6 @@
 {
   "incoming.page_title": {
-    "text": "Stuur een bericht",
+    "text": "Een bericht versturen",
     "source_hash": "f83b6303"
   },
   "incoming.page_description": {
@@ -28,7 +28,7 @@
     "source_hash": "64cecb8a"
   },
   "incoming.memo_placeholder": {
-    "text": "Korte beschrijving (bijv. Verzoek wachtwoordreset)",
+    "text": "Korte beschrijving (bijv. Wachtwoord-resetverzoek)",
     "source_hash": "16bf83fd"
   },
   "incoming.memo_hint": {
@@ -52,11 +52,11 @@
     "source_hash": "0dfafc45"
   },
   "incoming.no_recipients_available": {
-    "text": "Er zijn geen ontvangers beschikbaar",
+    "text": "Geen ontvangers beschikbaar",
     "source_hash": "62834334"
   },
   "incoming.secret_content_label": {
-    "text": "Beveiligde informatie",
+    "text": "Berichtinformatie",
     "source_hash": "b4f8c120"
   },
   "incoming.secret_content_placeholder": {
@@ -68,11 +68,11 @@
     "source_hash": "f9151d61"
   },
   "incoming.submit_button": {
-    "text": "Bericht verzenden",
+    "text": "Bericht versturen",
     "source_hash": "2a09f5e0"
   },
   "incoming.submit_secret": {
-    "text": "Bericht verzenden",
+    "text": "Bericht versturen",
     "source_hash": "2a09f5e0"
   },
   "incoming.submitting_button": {
@@ -120,11 +120,11 @@
     "source_hash": "099ff0c7"
   },
   "incoming.tagline2": {
-    "text": "Houd wachtwoorden en privégegevens uit e-mail en chatgeschiedenis",
+    "text": "Houd wachtwoorden en privégegevens uit e-mail- en chatlogs",
     "source_hash": "55566199"
   },
   "incoming.end_of_experience_suggestion": {
-    "text": "Bewaar je {receipt} voor je administratie.",
+    "text": "Sla je {receipt} op voor je administratie.",
     "source_hash": "db3d9c98"
   },
   "incoming.receipt_link_text": {
@@ -140,7 +140,7 @@
     "source_hash": "5df7f715"
   },
   "incoming.validation_memo_too_long": {
-    "text": "Memo mag maximaal {max} tekens bevatten",
+    "text": "Memo moet {max} tekens of minder zijn",
     "source_hash": "5727f2d3"
   },
   "incoming.validation_secret_required": {
@@ -152,7 +152,7 @@
     "source_hash": "67bb4666"
   },
   "incoming.validation_feature_disabled": {
-    "text": "Functie voor inkomende berichten is niet ingeschakeld",
+    "text": "Inkomende berichtenfunctie is niet ingeschakeld",
     "source_hash": "0616d3f4"
   },
   "incoming.validation_form_errors": {

--- a/locales/content/nl/feature-regions.json
+++ b/locales/content/nl/feature-regions.json
@@ -8,15 +8,15 @@
     "source_hash": "5e904993"
   },
   "web.regions.separate_environments_explanation": {
-    "text": "Elke regio functioneert als een volledig onafhankelijke omgeving met eigen infrastructuur, versleutelingssleutels en gegevensopslag",
+    "text": "Elke regio werkt als een volledig onafhankelijke omgeving met eigen infrastructuur, encryptiesleutels en gegevensopslag",
     "source_hash": "cd996732"
   },
   "web.regions.no_data_transfer_policy": {
-    "text": "We hanteren een strikt beleid: klantgegevens worden onder geen enkele omstandigheid tussen regio's overgedragen",
+    "text": "We hanteren een strikt beleid: klantgegevens worden nooit tussen regio's overgedragen onder welke omstandigheden dan ook",
     "source_hash": "33b74be3"
   },
   "web.regions.switching_creates_new_account": {
-    "text": "Belangrijk: Overschakelen naar een andere regio maakt een nieuw account aan. Je gegevens blijven in je oorspronkelijke regio.",
+    "text": "Belangrijk: Overschakelen naar een andere regio creëert een nieuw account. Je gegevens blijven in je oorspronkelijke regio.",
     "source_hash": "40e3ee34"
   },
   "web.regions.your_region": {
@@ -52,15 +52,15 @@
     "source_hash": "d13d2931"
   },
   "web.regions.privacy_description": {
-    "text": "Zorg ervoor dat je persoonlijke informatie wordt behandeld volgens de privacywetten en -regelgeving van je land, waardoor ongeautoriseerde toegang of misbruik wordt voorkomen.",
+    "text": "Zorg ervoor dat je persoonlijke informatie wordt behandeld volgens de privacywetten en -regelgeving van je land, en voorkom ongeautoriseerde toegang of misbruik.",
     "source_hash": "28d9d42e"
   },
   "web.regions.compliance_title": {
-    "text": "Regelgevingsnaleving",
+    "text": "Naleving van regelgeving",
     "source_hash": "8aa0df2a"
   },
   "web.regions.compliance_description": {
-    "text": "Voldoe aan AVG, HIPAA, CCPA en andere regionale gegevensbeschermingseisen",
+    "text": "Voldoe aan AVG, HIPAA, CCPA en andere regionale vereisten voor gegevensbescherming",
     "source_hash": "c3b2ee43"
   },
   "web.regions.performance_title": {
@@ -68,7 +68,7 @@
     "source_hash": "504b7b49"
   },
   "web.regions.performance_description": {
-    "text": "Gegevens die dichter bij je zijn opgeslagen betekenen lagere latentie en betere prestaties.",
+    "text": "Gegevens die dichter bij je worden opgeslagen betekent lagere latentie en betere prestaties.",
     "source_hash": "e133ef1d"
   },
   "web.regions.regions": {
@@ -76,7 +76,7 @@
     "source_hash": "610c65d8"
   },
   "web.regions.contact_our_compliance_team": {
-    "text": "neem contact op met ons complianceteam",
+    "text": "neem contact op met ons compliance-team",
     "source_hash": "87e6746e"
   },
   "web.regions.review_our_documentation": {
@@ -84,19 +84,19 @@
     "source_hash": "9cbd03df"
   },
   "web.regions.your_account_and_data_are_protected_under_the_la": {
-    "text": "Je account en gegevens worden beschermd onder de wetten en voorschriften van",
+    "text": "Je account en gegevens worden beschermd onder de wetten van",
     "source_hash": "5f5ef5b6"
   },
   "web.regions.this_regulatory_framework_is_determined_by_your_": {
-    "text": "Dit regelgevingskader wordt bepaald door je toegangsdomein:",
+    "text": "Je regelgevend kader wordt bepaald door je toegangsdomein:",
     "source_hash": "7fdbc59c"
   },
   "web.regions.each_jurisdiction_maintains_separate_legal_compl": {
-    "text": "Elke jurisdictie heeft afzonderlijke wettelijke naleving en gegevensbeheer. Hoewel je accounts in meerdere jurisdicties kunt aanmaken, blijven ze juridisch gescheiden zonder gegevensuitwisseling tussen regelgevingszones.",
+    "text": "Elke regio is volledig gescheiden met eigen infrastructuur, waar mogelijk met een eigen lokale hostingprovider. Je kunt accounts aanmaken in meerdere regio's, maar er worden geen gegevens tussen hen gedeeld.",
     "source_hash": "5c0b350e"
   },
   "web.regions.to_understand_the_specific_regulations_and_prote": {
-    "text": "Om de specifieke regelgeving en beschermingen te begrijpen die van toepassing zijn op je account,",
+    "text": "Voor details over regelgeving en beschermingen die van toepassing zijn op je account,",
     "source_hash": "e8acc835"
   },
   "web.regions.current": {
@@ -112,11 +112,11 @@
     "source_hash": "ee788590"
   },
   "web.regions.jurisdiction": {
-    "text": "Rechtsgebied",
+    "text": "Jurisdictie",
     "source_hash": "d69b9ac7"
   },
   "web.regions.data_center_location_currentjurisdiction_identif": {
-    "text": "Datacentrum locatie: {0}",
+    "text": "Datacenterlocatie: {0}",
     "source_hash": "f1699c90"
   },
   "web.regions.data_region": {
@@ -124,11 +124,11 @@
     "source_hash": "a1c6039f"
   },
   "web.regions.unknown_jurisdiction": {
-    "text": "Onbekend rechtsgebied",
+    "text": "Onbekende jurisdictie",
     "source_hash": "eae2e122"
   },
   "web.regions.serving_you_from_the": {
-    "text": "Je wordt bediend vanuit",
+    "text": "Serveren vanuit",
     "source_hash": "25db17aa"
   },
   "web.regions.continue_to_jurisdiction_domain": {
@@ -136,35 +136,35 @@
     "source_hash": "dd1a44e4"
   },
   "web.regions.current_jurisdiction": {
-    "text": "Huidig rechtsgebied:",
+    "text": "Huidige jurisdictie:",
     "source_hash": "d0f2192d"
   },
   "web.regions.changing_regions_title": {
-    "text": "Regio wijzigen",
+    "text": "Van regio wisselen",
     "source_hash": "189d6685"
   },
   "web.regions.changing_regions_description": {
-    "text": "Ons beleid is om nooit gegevens tussen regio's over te dragen. Elke regio functioneert als een volledig onafhankelijke omgeving.",
+    "text": "Ons beleid is om nooit gegevens tussen regio's over te dragen. Elke regio werkt als een volledig onafhankelijke omgeving.",
     "source_hash": "cf45b8be"
   },
   "web.regions.changing_regions_how_to": {
-    "text": "Om een andere regio te gebruiken, maak je daar een nieuw account aan met hetzelfde e-mailadres dat is gekoppeld aan je factuurcontact.",
+    "text": "Om een andere regio te gebruiken, maak daar een nieuw account aan met hetzelfde e-mailadres dat is gekoppeld aan je facturerings-e-mailadres.",
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "Als je e-mailadres voor facturatie afwijkt van het e-mailadres van je {product_name}-account, gebruik dan het e-mailadres voor facturatie voor het account in de nieuwe regio om de voordelen van je abonnement te behouden.",
+    "text": "Als je facturerings-e-mailadres verschilt van je {product_name}-account-e-mail, gebruik dan het facturerings-e-mailadres voor het nieuwe regio-account om je abonnementsvoordelen te behouden.",
     "source_hash": "d49662b0"
   },
   "web.regions.changing_regions_subscription_note": {
-    "text": "Je abonnementsvoordelen worden automatisch toegepast op elk account dat is aangemaakt met je factuur-e-mailadres.",
+    "text": "Je abonnementsvoordelen worden automatisch toegepast op elk account dat is aangemaakt met je facturerings-e-mailadres.",
     "source_hash": "5b2238b2"
   },
   "web.regions.jurisdictions.eu.name": {
-    "text": "European Union",
+    "text": "Europese Unie",
     "source_hash": "7fe24f2b"
   },
   "web.regions.jurisdictions.us.name": {
-    "text": "United States",
+    "text": "Verenigde Staten",
     "source_hash": "49dca65f"
   },
   "web.regions.jurisdictions.ca.name": {
@@ -172,19 +172,19 @@
     "source_hash": "be55ef3f"
   },
   "web.regions.jurisdictions.uk.name": {
-    "text": "United Kingdom",
+    "text": "Verenigd Koninkrijk",
     "source_hash": "8d23a6e3"
   },
   "web.regions.jurisdictions.nz.name": {
-    "text": "New Zealand",
+    "text": "Nieuw-Zeeland",
     "source_hash": "2898e16d"
   },
   "web.regions.jurisdictions.at.name": {
-    "text": "Austria",
+    "text": "Oostenrijk",
     "source_hash": "c9cab023"
   },
   "web.regions.jurisdictions.apac.name": {
-    "text": "Asia-Pacific",
+    "text": "Azië-Pacific",
     "source_hash": "7a757670"
   },
   "web.regions.no_region_configured": {

--- a/locales/content/nl/feature-testimonials.json
+++ b/locales/content/nl/feature-testimonials.json
@@ -44,7 +44,7 @@
     "source_hash": "4c8d20ba"
   },
   "web.testimonials.this_content_is_ai_generated_based_on_the_conten": {
-    "text": "Deze inhoud is door AI gegenereerd op basis van de inhoud van deze pagina en vertegenwoordigt geen echte persoon of bedrijf.",
+    "text": "Deze inhoud is AI-gegenereerd op basis van de inhoud van deze pagina en vertegenwoordigt geen echte persoon of bedrijf.",
     "source_hash": "03c16436"
   }
 }

--- a/locales/content/nl/feature-translations.json
+++ b/locales/content/nl/feature-translations.json
@@ -12,7 +12,7 @@
     "source_hash": "10056bff"
   },
   "web.translations.whove_helped_with_translations_as_we_continue_to": {
-    "text": "die geholpen hebben met vertalingen terwijl we nieuwe functies blijven ontwikkelen.",
+    "text": "die hebben geholpen met vertalingen terwijl we nieuwe functies blijven ontwikkelen.",
     "source_hash": "d629cc71"
   },
   "web.translations.25_contributors": {
@@ -20,15 +20,15 @@
     "source_hash": "080aa720"
   },
   "web.translations.were_grateful_to_the": {
-    "text": "We zijn dankbaar voor de",
+    "text": "We zijn dankbaar aan de",
     "source_hash": "cf446287"
   },
   "web.translations.as_we_add_new_features_our_translations_graduall": {
-    "text": "Naarmate we nieuwe functies toevoegen, hebben onze vertalingen geleidelijk updates nodig om actueel te blijven. Dit beïnvloedt zowel onetimesecret.com als duizenden zelf-gehoste installaties wereldwijd.",
+    "text": "Naarmate we nieuwe functies toevoegen, moeten onze vertalingen geleidelijk worden bijgewerkt om actueel te blijven. Dit betreft zowel onetimesecret.com als duizenden zelf-gehoste installaties wereldwijd.",
     "source_hash": "c6fb1cf5"
   },
   "web.translations.remember_to_include_your_email_if_youre_not_logg": {
-    "text": "- vergeet niet je e-mail toe te voegen als je niet bent ingelogd. Elke vertaling helpt meer mensen veilig te communiceren.",
+    "text": "- vergeet niet je e-mail op te nemen als je niet bent ingelogd. Elke vertaling helpt meer mensen veilig te communiceren.",
     "source_hash": "1a8ccc7d"
   },
   "web.translations.reach_out_to_us": {
@@ -44,15 +44,15 @@
     "source_hash": "f96a59a1"
   },
   "web.translations.english_template": {
-    "text": "Engelse sjabloon",
+    "text": "Engels sjabloon",
     "source_hash": "1a843644"
   },
   "web.translations.start_a_new_translation_from_our": {
-    "text": "Start een nieuwe vertaling vanuit onze",
+    "text": "Start een nieuwe vertaling vanuit ons",
     "source_hash": "b963b7e9"
   },
   "web.translations.update_a_language_directly_through_our_github_pr": {
-    "text": "Update een taal direct via ons GitHub-project",
+    "text": "Werk een taal rechtstreeks bij via ons GitHub-project",
     "source_hash": "449cde87"
   },
   "web.translations.review_existing_translations_using_the_language_": {
@@ -64,7 +64,7 @@
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "De volgende mensen hebben hun tijd gedoneerd om het bereik van {product_name} te vergroten:",
+    "text": "De volgende mensen hebben hun tijd gedoneerd om het bereik van {product_name} uit te breiden:",
     "source_hash": "6cc876ae"
   },
   "web.translations.translations": {
@@ -76,19 +76,19 @@
     "source_hash": "bb60a45d"
   },
   "web.translations.your_language_skills_can_help_expand_access_to_s": {
-    "text": "Je taalvaardigheden kunnen helpen bij het uitbreiden van toegang tot veilige communicatie.",
+    "text": "Je taalvaardigheden kunnen helpen om toegang tot veilige communicatie uit te breiden.",
     "source_hash": "ad22076b"
   },
   "web.translations.thanks_to_our_community_we_support_over_20_langu": {
-    "text": "Dankzij onze gemeenschap ondersteunen we vandaag meer dan 20 talen. Echter, met ons snelle ontwikkelingstempo hebben veel vertalingen updates nodig om actueel te blijven. Dit beïnvloedt zowel onetimesecret.com als de duizenden zelf-gehoste installaties wereldwijd.",
+    "text": "Dankzij onze gemeenschap ondersteunen we vandaag meer dan 20 talen. Echter, met ons snelle ontwikkeltempo hebben veel vertalingen updates nodig om actueel te blijven. Dit betreft zowel onetimesecret.com als de duizenden zelf-gehoste installaties wereldwijd.",
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "Sinds 2012 biedt {product_name} een beveiligde manier om wereldwijd gevoelige informatie te delen. Met gebruikers in regio's waar Engels niet de primaire taal is, zijn nauwkeurige vertalingen essentieel om beveiligde communicatie voor iedereen toegankelijk te maken.",
+    "text": "Sinds 2012 biedt {product_name} een veilige manier om gevoelige informatie wereldwijd te delen. Met gebruikers in regio's waar Engels niet de primaire taal is, zijn nauwkeurige vertalingen essentieel om veilige communicatie voor iedereen toegankelijk te maken.",
     "source_hash": "ded965d5"
   },
   "web.translations.help_secure_communication_go_global": {
-    "text": "Help beveiligde communicatie wereldwijd te verspreiden",
+    "text": "Help veilige communicatie wereldwijd te maken",
     "source_hash": "e94bdc8e"
   }
 }

--- a/locales/content/nl/secret-homepage.json
+++ b/locales/content/nl/secret-homepage.json
@@ -4,15 +4,15 @@
     "source_hash": "5785816e"
   },
   "web.homepage.tagline2": {
-    "text": "Houd gevoelige informatie uit je e-mail en chatgeschiedenis.",
+    "text": "Houd gevoelige informatie uit je e-mail- en chatlogs.",
     "source_hash": "69dd8d56"
   },
   "web.homepage.secret_hint": {
-    "text": "* Een beveiligde link werkt maar één keer en verdwijnt dan voor altijd.",
+    "text": "* Een berichtlink werkt slechts één keer en verdwijnt dan voor altijd.",
     "source_hash": "3c66e4e7"
   },
   "web.homepage.secret_form_more_text1": {
-    "text": "Meld je aan voor een",
+    "text": "Registreer je voor een",
     "source_hash": "bc6d69e8"
   },
   "web.homepage.secret_form_more_text2": {
@@ -20,15 +20,15 @@
     "source_hash": "cf05fe3b"
   },
   "web.homepage.secret_form_more_text3": {
-    "text": "en het bericht per e-mail kunnen versturen.",
+    "text": "en verstuur het bericht per e-mail.",
     "source_hash": "004dda26"
   },
   "web.homepage.cta_title": {
-    "text": "Vergroot vertrouwen en deel met zekerheid",
+    "text": "Verhoog vertrouwen en deel met zekerheid",
     "source_hash": "f0d63307"
   },
   "web.homepage.cta_subtitle": {
-    "text": "Verhef je merk en deel met vertrouwen",
+    "text": "Til je merk naar een hoger niveau en deel met vertrouwen",
     "source_hash": "0034dcc3"
   },
   "web.homepage.cta_feature1": {
@@ -40,7 +40,7 @@
     "source_hash": "e5bb7fc8"
   },
   "web.homepage.cta_feature3": {
-    "text": "Vergroot klantvertrouwen en betrokkenheid",
+    "text": "Verhoog klantvertrouwen en betrokkenheid",
     "source_hash": "d91e6ecc"
   },
   "web.homepage.explore_premium_plans": {
@@ -52,11 +52,11 @@
     "source_hash": "35d2ac76"
   },
   "web.homepage.sign_up_free": {
-    "text": "Gratis aanmelden",
+    "text": "Gratis registreren",
     "source_hash": "5e218489"
   },
   "web.homepage.visit_onetime_secret_home": {
-    "text": "Bezoek de homepage van {product_name}",
+    "text": "Bezoek de {product_name}-homepagina",
     "source_hash": "87802af5"
   },
   "web.homepage.password_generation_title": {
@@ -64,15 +64,15 @@
     "source_hash": "7bec027a"
   },
   "web.homepage.password_generation_description": {
-    "text": "Klik op \"Wachtwoord genereren\" om een veilig willekeurig wachtwoord aan te maken dat je kunt delen.",
+    "text": " Klik op \"Wachtwoord genereren\" om een veilig willekeurig wachtwoord te maken dat je kunt delen.",
     "source_hash": "82c42d54"
   },
   "web.homepage.protip1": {
-    "text": "Je bericht vernietigt zichzelf na bekijken. De link kan maar één keer geopend worden.",
+    "text": "Je bericht vernietigt zichzelf na het bekijken. De link kan slechts één keer worden geopend.",
     "source_hash": "085cd9bd"
   },
   "web.homepage.authonly.tagline2": {
-    "text": "De beveiligde berichtendienst is alleen voor intern gebruik.",
+    "text": "Beveiligde berichtendienst is alleen voor intern gebruik.",
     "source_hash": "d21ee2dd"
   },
   "web.homepage.authonly.tagline1": {
@@ -80,7 +80,7 @@
     "source_hash": "c6148896"
   },
   "web.homepage.disabled.tagline2": {
-    "text": "Deze dienst is alleen voor intern gebruik opgezet.",
+    "text": "Deze dienst is alleen ingesteld voor intern gebruik.",
     "source_hash": "8a727004"
   },
   "web.homepage.disabled.tagline1": {
@@ -92,15 +92,15 @@
     "source_hash": "140c4b1a"
   },
   "web.homepage.meets_and_exceeds_compliance_standards": {
-    "text": "Voldoet aan en overtreft nalevingsstandaarden",
+    "text": "Voldoet aan en overtreft nalevingsnormen",
     "source_hash": "4bd4c8a0"
   },
   "web.homepage.secure_your_brand_build_customer_trust_etc": {
-    "text": "Beveilig je merk, bouw klantenvertrouwen op met links vanaf je domein.",
+    "text": "Beveilig je merk, bouw klantvertrouwen met links van je eigen domein.",
     "source_hash": "101a3149"
   },
   "web.homepage.a_trusted_way_to_share_sensitive_information_etc": {
-    "text": "Een betrouwbare manier om gevoelige informatie te delen die zichzelf vernietigt na bekeken te zijn.",
+    "text": "Een betrouwbare manier om gevoelige informatie te delen die zichzelf vernietigt na het bekijken.",
     "source_hash": "a5429343"
   },
   "web.homepage.secure_links": {
@@ -112,7 +112,7 @@
     "source_hash": "b3046356"
   },
   "web.homepage.log_in_to_onetime_secret": {
-    "text": "Inloggen bij {product_name}",
+    "text": "Log in bij {product_name}",
     "source_hash": "b2e364a4"
   },
   "web.homepage.about_onetime_secret": {
@@ -120,7 +120,7 @@
     "source_hash": "b3046356"
   },
   "web.homepage.signup_individual_and_business_plans": {
-    "text": "Aanmelden - Individuele en Zakelijke abonnementen",
+    "text": "Registreren - Individuele en zakelijke plannen",
     "source_hash": "3fcd1682"
   },
   "web.homepage.tagline_signed": {
@@ -148,7 +148,7 @@
     "source_hash": "7bec5899"
   },
   "web.homepage.onetime_secret_homepage": {
-    "text": "{product_name} homepage",
+    "text": "{product_name}-homepagina",
     "source_hash": "0792b61e"
   },
   "web.homepage.send_sensitive_information_that_can_only_be_viewed_once": {
@@ -156,7 +156,7 @@
     "source_hash": "8c43aaaf"
   },
   "web.homepage.create_a_secure_link": {
-    "text": "Maak een beveiligde link",
+    "text": "Maak een beveiligde link aan",
     "source_hash": "550bb21e"
   },
   "web.homepage.now_with_custom_domains": {
@@ -164,7 +164,7 @@
     "source_hash": "94d5249b"
   },
   "web.homepage.this_is_a_private_instance_only_authorized_team_": {
-    "text": "Dit is een privé-instantie. Alleen geautoriseerde teamleden kunnen nieuwe veilige links genereren.",
+    "text": "Dit is een privé-instantie. Alleen geautoriseerde teamleden kunnen nieuwe beveiligde links genereren.",
     "source_hash": "e1073c60"
   },
   "web.homepage.welcome_to_onetime_secret": {
@@ -172,11 +172,11 @@
     "source_hash": "f4f49058"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "{product_name} helpt ons gevoelige informatie veilig te delen terwijl we onze professionele uitstraling behouden.",
+    "text": "{product_name} helpt ons om gevoelige informatie veilig te delen terwijl we onze professionele uitstraling behouden.",
     "source_hash": "7e9192bd"
   },
   "web.homepage.information_shared_through_this_service_can_only": {
-    "text": "Informatie die via deze service wordt gedeeld, kan slechts één keer worden bekeken. Eenmaal bekeken wordt de inhoud permanent verwijderd om vertrouwelijkheid te waarborgen.",
+    "text": "Informatie die via deze dienst wordt gedeeld, kan slechts één keer worden geopend. Na het bekijken wordt de inhoud permanent verwijderd om vertrouwelijkheid te garanderen.",
     "source_hash": "fc58212a"
   },
   "web.homepage.welcome_to_the_global_broadcast": {
@@ -184,11 +184,11 @@
     "source_hash": "210e1894"
   },
   "web.homepage.send_a_secret": {
-    "text": "Verstuur een bericht",
+    "text": "Stuur een bericht",
     "source_hash": "31fd9e03"
   },
   "web.homepage.deliver_sensitive_information_directly_and_securely": {
-    "text": "Lever gevoelige informatie rechtstreeks aan ons team. Het kan maar één keer worden bekeken.",
+    "text": "Lever gevoelige informatie direct en veilig aan ons team. Het kan slechts één keer worden bekeken.",
     "source_hash": "9976cf01"
   }
 }

--- a/locales/content/nl/secret-manage.json
+++ b/locales/content/nl/secret-manage.json
@@ -20,7 +20,7 @@
     "source_hash": "94997839"
   },
   "web.secrets.passphraseComplexityRequired": {
-    "text": "Moet hoofdletters, kleine letters, cijfers en symbolen bevatten",
+    "text": "Moet hoofdletter, kleine letter, cijfer en symbool bevatten",
     "source_hash": "1ddceea9"
   },
   "web.secrets.theyll_appear_here_once_youve_shared_them": {
@@ -28,7 +28,7 @@
     "source_hash": "f8e8fe7d"
   },
   "web.secrets.recipient_delivery_is_optional": {
-    "text": "Bezorging aan ontvanger is optioneel",
+    "text": "Levering aan ontvanger is optioneel",
     "source_hash": "4b6e1c1d"
   },
   "web.secrets.recent_secrets_count": {
@@ -36,19 +36,19 @@
     "source_hash": "db07174b"
   },
   "web.secrets.workspace_mode": {
-    "text": "Op pagina blijven",
+    "text": "Blijf op pagina",
     "source_hash": "afa3c09f"
   },
   "web.secrets.workspace_mode_description": {
-    "text": "Maak meerdere berichten zonder deze pagina te verlaten",
+    "text": "Maak meerdere berichten aan zonder deze pagina te verlaten",
     "source_hash": "7315b6eb"
   },
   "web.secrets.hide_secret_message": {
-    "text": "Beveiligd bericht verbergen",
+    "text": "Verberg bericht",
     "source_hash": "d6fe071f"
   },
   "web.secrets.view_secret_message": {
-    "text": "Beveiligd bericht bekijken",
+    "text": "Bekijk bericht",
     "source_hash": "5da08cab"
   },
   "web.secrets.content_hidden": {
@@ -64,7 +64,7 @@
     "source_hash": "88e4064e"
   },
   "web.secrets.create_a_secret": {
-    "text": "Maak een bericht",
+    "text": "Maak een bericht aan",
     "source_hash": "42c3da40"
   },
   "web.secrets.secret_access_form": {
@@ -72,7 +72,7 @@
     "source_hash": "d11c5b24"
   },
   "web.secrets.content_status": {
-    "text": "Inhoudstatus",
+    "text": "Inhoudsstatus",
     "source_hash": "5efa57d2"
   },
   "web.secrets.secret_content_copied_to_clipboard": {
@@ -100,7 +100,7 @@
     "source_hash": "d69e2157"
   },
   "web.secrets.enter_the_secret_content_to_share_here": {
-    "text": "Voer hier de berichtinhoud in die je wilt delen",
+    "text": "Voer hier de te delen berichtinhoud in",
     "source_hash": "d4d20dc3"
   },
   "web.secrets.formattedcharcount_formattedmaxlength_chars": {
@@ -112,7 +112,7 @@
     "source_hash": "8b450877"
   },
   "web.secrets.when_ready_click_the_view_secret_button_at_the_t": {
-    "text": "Wanneer je klaar bent, klik op de knop \"Bericht bekijken\" bovenaan de pagina om je eenmalige bericht te bekijken.",
+    "text": "Wanneer je klaar bent, klik op de knop bovenaan de pagina om je eenmalige bericht te onthullen.",
     "source_hash": "7a65b13e"
   },
   "web.secrets.what_happens_next": {
@@ -120,7 +120,7 @@
     "source_hash": "c72895ba"
   },
   "web.secrets.yes_after_viewing_the_secret_is_permanently_dele": {
-    "text": "Ja. Na het bekijken wordt het bericht permanent verwijderd van onze servers, wat je privacy waarborgt.",
+    "text": "Ja. Na het bekijken wordt het bericht permanent van onze servers verwijderd, wat je privacy garandeert.",
     "source_hash": "15e6ab70"
   },
   "web.secrets.is_it_secure": {
@@ -128,7 +128,7 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "{product_name} is een beveiligde manier om gevoelige informatie te delen die zichzelf vernietigt na één keer bekijken.",
+    "text": "{product_name} is een veilige manier om gevoelige informatie te delen die zichzelf vernietigt na één keer bekijken.",
     "source_hash": "bd0c6182"
   },
   "web.secrets.what_is_this": {
@@ -136,31 +136,31 @@
     "source_hash": "0b12ba39"
   },
   "web.secrets.before_you_open_it_heres_what_you_should_know": {
-    "text": "Voordat je het opent, hier is wat je moet weten:",
+    "text": "Voordat je het opent, dit moet je weten:",
     "source_hash": "f5c3bda4"
   },
   "web.secrets.a_secure_one_time_message_awaits_you": {
-    "text": "Een veilig, eenmalig bericht wacht op je.",
+    "text": "Een beveiligd, eenmalig bericht wacht op je.",
     "source_hash": "8e1ef474"
   },
   "web.secrets.youve_got_secret_mail": {
-    "text": "Je hebt (beveiligde) post",
+    "text": "Je hebt (geheime) post",
     "source_hash": "1cb809ea"
   },
   "web.secrets.auto_expire_after_viewing": {
-    "text": "Automatisch verlopen na bekijken",
+    "text": "Verloopt automatisch na bekijken",
     "source_hash": "08489543"
   },
   "web.secrets.secure_encrypted_storage": {
-    "text": "Veilige, versleutelde opslag",
+    "text": "Beveiligde, versleutelde opslag",
     "source_hash": "63f3282e"
   },
   "web.secrets.that_information_is_no_longer_available": {
-    "text": "Die informatie is niet langer beschikbaar.",
+    "text": "Dit bericht is bekeken of verlopen.",
     "source_hash": "4de19d63"
   },
   "web.secrets.information_no_longer_available": {
-    "text": "Informatie niet langer beschikbaar",
+    "text": "Informatie niet meer beschikbaar",
     "source_hash": "7e2f55cf"
   },
   "web.secrets.create_another_secret": {
@@ -184,7 +184,7 @@
     "source_hash": "ecada592"
   },
   "web.secrets.secret_link": {
-    "text": "Beveiligde link",
+    "text": "Berichtlink",
     "source_hash": "18ddf44f"
   },
   "web.secrets.you_have_a_message": {
@@ -192,7 +192,7 @@
     "source_hash": "5aef1455"
   },
   "web.secrets.hide_secret": {
-    "text": "Bericht verbergen",
+    "text": "Verberg bericht",
     "source_hash": "72884098"
   },
   "web.receipt.pretext": {
@@ -208,11 +208,11 @@
     "source_hash": "ede466b1"
   },
   "web.receipt.only_see_once": {
-    "text": "Let op: je ziet dit maar één keer.",
+    "text": "Let op: je ziet dit slechts één keer.",
     "source_hash": "a7c79715"
   },
   "web.receipt.created_success": {
-    "text": "Beveiligd bericht succesvol aangemaakt!",
+    "text": "Bericht succesvol aangemaakt!",
     "source_hash": "ce65f4ad"
   },
   "web.receipt.created_success_key": {
@@ -220,7 +220,7 @@
     "source_hash": "73708d50"
   },
   "web.receipt.created_securely": {
-    "text": "Je beveiligde bericht is veilig aangemaakt",
+    "text": "Je bericht is veilig aangemaakt",
     "source_hash": "8f3c17cc"
   },
   "web.receipt.burned_ago": {
@@ -228,7 +228,7 @@
     "source_hash": "855f10aa"
   },
   "web.receipt.viewed_ago": {
-    "text": "Dit beveiligde bericht is bekeken {time}",
+    "text": "Dit bericht is bekeken {time}",
     "source_hash": "bb4773d1"
   },
   "web.receipt.encrypted_message": {
@@ -248,7 +248,7 @@
     "source_hash": "1b28d178"
   },
   "web.receipt.view_receipt": {
-    "text": "Bevestigingen bekijken",
+    "text": "Bekijk ontvangstbewijzen",
     "source_hash": "6c664c31"
   },
   "web.receipt.destroyed": {
@@ -260,43 +260,43 @@
     "source_hash": "aadb8006"
   },
   "web.receipt.the_burn_feature_lets_you_permanently_delete_a_s": {
-    "text": "Met de vernietigingsfunctie kun je een bericht permanent vernietigen voordat iemand het bekijkt. Dit is handig als je de toegang moet intrekken of verkeerde informatie hebt gedeeld. Eenmaal vernietigd kan het bericht niet worden hersteld.",
+    "text": "De verbrandfunctie laat je een bericht permanent verwijderen voordat iemand het bekijkt. Dit is handig als je de toegang moet intrekken of de verkeerde informatie hebt gedeeld. Eenmaal verbrand kan het bericht niet worden hersteld.",
     "source_hash": "8f82008b"
   },
   "web.receipt.whats_the_burn_feature": {
-    "text": "Wat is de verbranden-functie?",
+    "text": "Wat is de verbrandfunctie?",
     "source_hash": "783da354"
   },
   "web.receipt.your_secret_will_remain_available_for_record_nat": {
-    "text": "Je bericht blijft beschikbaar voor {0} of totdat het bekeken wordt, afhankelijk van wat eerst komt. Nadat aan een van deze voorwaarden is voldaan, wordt het bericht permanent verwijderd.",
+    "text": "Je bericht blijft beschikbaar voor {0} of totdat het wordt bekeken, wat het eerst komt. Nadat aan een van beide voorwaarden is voldaan, wordt het bericht permanent verwijderd.",
     "source_hash": "d690ea63"
   },
   "web.receipt.how_does_secret_expiration_work": {
-    "text": "Hoe werkt de vervaldatum?",
+    "text": "Hoe werkt berichtvervaldatum?",
     "source_hash": "b69dacd2"
   },
   "web.receipt.for_security_reasons_we_cant_recover_lost_secret": {
-    "text": "Om veiligheidsredenen kunnen we verloren beveiligde links niet herstellen. Je moet een nieuw bericht aanmaken en een nieuwe link genereren. We raden aan de link direct na aanmaken te kopiëren.",
+    "text": "Om veiligheidsredenen kunnen we verloren berichtlinks niet herstellen. Je moet een nieuw bericht aanmaken en een nieuwe link genereren. We raden aan de link direct na het aanmaken te kopiëren.",
     "source_hash": "3b229db9"
   },
   "web.receipt.lost_your_secret_link": {
-    "text": "Je beveiligde link kwijt?",
+    "text": "Je berichtlink kwijtgeraakt?",
     "source_hash": "a968fd0b"
   },
   "web.receipt.expires_in_record_natural_expiration_0": {
-    "text": "Verloopt in {0}",
+    "text": "Verloopt over {0}",
     "source_hash": "1dceeb03"
   },
   "web.receipt.we_display_the_value_for_you_so_that_you_can_ver": {
-    "text": "We tonen de waarde eenmalig zodat je deze kunt verifiëren. Als iemand deze privépagina vindt (in je browsergeschiedenis of als je per ongeluk de privélink deelt in plaats van de beveiligde link), zullen ze het beveiligde bericht niet zien.",
+    "text": "We tonen de waarde zodat je deze kunt verifiëren, maar we doen dat slechts één keer, zodat als iemand deze privépagina krijgt (via je browsergeschiedenis of als je per ongeluk de privélink stuurt in plaats van de berichtlink), ze de berichtwaarde niet zien.",
     "source_hash": "cc1facdd"
   },
   "web.receipt.why_can_i_only_see_the_secret_value_once": {
-    "text": "Waarom kan ik het bericht maar één keer zien?",
+    "text": "Waarom kan ik de berichtwaarde maar één keer zien?",
     "source_hash": "b2e497d6"
   },
   "web.receipt.burning_a_secret_permanently_deletes_it_before_a": {
-    "text": "Het vernietigen van een bericht verwijdert het permanent voordat iemand het kan lezen. De ontvanger ziet een bericht dat het bericht niet bestaat. Dit is handig als je per ongeluk verkeerde informatie deelt of de toegang wilt voorkomen.",
+    "text": "Een bericht verbranden verwijdert het permanent voordat iemand het kan lezen. De ontvanger ziet een melding dat het bericht niet bestaat. Dit is handig als je per ongeluk de verkeerde informatie deelt of toegang moet voorkomen.",
     "source_hash": "f3fa5bbb"
   },
   "web.receipt.what_happens_when_i_burn_a_secret": {
@@ -304,15 +304,15 @@
     "source_hash": "cfc61708"
   },
   "web.receipt.and_never_stored_in_its_original_form_this_appro": {
-    "text": "en nooit opgeslagen in zijn originele vorm. Deze aanpak betekent dat wij je bericht niet kunnen openen of herstellen - alleen iemand met de juiste wachtwoordzin kan dat.",
+    "text": "en nooit in zijn oorspronkelijke vorm opgeslagen. Deze aanpak betekent dat we je bericht niet kunnen openen of herstellen - alleen iemand met de juiste wachtwoordzin kan dat.",
     "source_hash": "9b760dad"
   },
   "web.receipt.passphrase_protection": {
-    "text": "Bescherming met wachtwoordzin",
+    "text": "Wachtwoordzinbescherming",
     "source_hash": "0a6c3735"
   },
   "web.receipt.each_secret_can_only_be_viewed_once_after_viewin": {
-    "text": "Elk bericht kan slechts één keer worden bekeken. Na het bekijken wordt het permanent verwijderd van onze servers. Dit zorgt ervoor dat je gevoelige informatie niet per ongeluk wordt blootgesteld via browsergeschiedenis of per ongeluk gedeelde privélinks.",
+    "text": "Elk bericht kan slechts één keer worden bekeken. Na het bekijken wordt het permanent van onze servers verwijderd. Dit zorgt ervoor dat je gevoelige informatie niet per ongeluk wordt blootgesteld via browsergeschiedenis of per ongeluk gedeelde privélinks.",
     "source_hash": "581b5abf"
   },
   "web.receipt.one_time_access": {
@@ -320,11 +320,11 @@
     "source_hash": "76f1cd7e"
   },
   "web.receipt.core_security_features": {
-    "text": "Kernbeveiligingsfuncties",
+    "text": "Belangrijkste beveiligingsfuncties",
     "source_hash": "aa0fc6f9"
   },
   "web.receipt.expires_in_record_natural_expiration": {
-    "text": "Verloopt in {0}",
+    "text": "Verloopt over {0}",
     "source_hash": "1dceeb03"
   },
   "web.receipt.send_feedback": {
@@ -336,7 +336,7 @@
     "source_hash": "b38e604d"
   },
   "web.shared.viewed_own_secret": {
-    "text": "Je hebt je eigen bericht bekeken. Het is niet langer beschikbaar voor iemand anders.",
+    "text": "Je hebt je eigen bericht bekeken. Het is niet meer beschikbaar voor anderen.",
     "source_hash": "521e9a6f"
   },
   "web.shared.you_created_this_secret": {
@@ -344,7 +344,7 @@
     "source_hash": "1a4ac4ed"
   },
   "web.shared.your_secret_message": {
-    "text": "Je beveiligde bericht:",
+    "text": "Je berichtinhoud:",
     "source_hash": "eb762113"
   },
   "web.shared.this_message_for_you": {
@@ -356,7 +356,7 @@
     "source_hash": "94b7b921"
   },
   "web.shared.reply_with_secret": {
-    "text": "Antwoord met een ander bericht",
+    "text": "Beantwoord met een ander bericht",
     "source_hash": "dc7daf20"
   },
   "web.shared.pre_reveal_default": {
@@ -368,7 +368,7 @@
     "source_hash": "01dfb737"
   },
   "web.shared.secret_was_truncated": {
-    "text": "Bericht is ingekort",
+    "text": "Bericht is afgekapt",
     "source_hash": "edae5139"
   },
   "web.secrets.workspace_mode_disabled_for_generate": {
@@ -376,11 +376,11 @@
     "source_hash": "29969ba9"
   },
   "web.secrets.scope_org": {
-    "text": "Alle berichten tonen in {name}",
+    "text": "Toont alle berichten in {name}",
     "source_hash": "fcefa099"
   },
   "web.secrets.scope_domain": {
-    "text": "Berichten tonen op {name}",
+    "text": "Toont berichten op {name}",
     "source_hash": "f2a0be60"
   },
   "web.secrets.errors.domain_extid_required": {

--- a/locales/content/nl/session-auth-extended.json
+++ b/locales/content/nl/session-auth-extended.json
@@ -58,7 +58,7 @@
     "source_hash": "3cff3311"
   },
   "web.auth.complete_mfa_verification": {
-    "text": "MFA-verificatie voltooien",
+    "text": "Voltooi MFA-verificatie",
     "source_hash": "0e681134"
   },
   "web.auth.security._guidance": {
@@ -66,7 +66,7 @@
     "context": "⚠️ SECURITY-CRITICAL: Messages prevent information disclosure. See src/locales/SECURITY-TRANSLATION-GUIDE.md"
   },
   "web.auth.security.authentication_failed": {
-    "text": "Authenticatie mislukt. Controleer je inloggegevens en probeer het opnieuw.",
+    "text": "Authenticatie mislukt. Controleer je gegevens en probeer het opnieuw.",
     "source_hash": "b0eeece9"
   },
   "web.auth.security.rate_limited": {
@@ -82,7 +82,7 @@
     "source_hash": "f5f1bd09"
   },
   "web.auth.security.recovery_code_used": {
-    "text": "Deze herstelcode is al gebruikt. Elke code kan slechts één keer worden gebruikt.",
+    "text": "Deze herstelcode is al gebruikt. Elke code kan slechts eenmaal worden gebruikt.",
     "source_hash": "b51d6820"
   },
   "web.auth.security.network_error": {
@@ -103,7 +103,7 @@
     "source_hash": "1b6ffed2"
   },
   "web.auth.methods.webauthn": {
-    "text": "Biometrisch",
+    "text": "Biometrie",
     "source_hash": "ab2ba7db"
   },
   "web.auth.magicLink.title": {
@@ -115,11 +115,11 @@
     "source_hash": "5d75aeb0"
   },
   "web.auth.magicLink.emailPlaceholder": {
-    "text": "Voer je e-mail in",
+    "text": "Voer je e-mailadres in",
     "source_hash": "2837f6fa"
   },
   "web.auth.magicLink.sendLink": {
-    "text": "Inloglink verzenden",
+    "text": "Stuur inloglink",
     "source_hash": "f5f52392"
   },
   "web.auth.magicLink.checkEmail": {
@@ -127,7 +127,7 @@
     "source_hash": "77322879"
   },
   "web.auth.magicLink.sentTo": {
-    "text": "We hebben een inloglink verzonden naar {email}",
+    "text": "We hebben een inloglink gestuurd naar {email}",
     "source_hash": "d9193f59"
   },
   "web.auth.magicLink.linkExpiresIn": {
@@ -147,7 +147,7 @@
     "source_hash": "9ff8cfaf"
   },
   "web.auth.magicLink.requestFailed": {
-    "text": "Verzenden van inloglink mislukt. Probeer het opnieuw.",
+    "text": "Inloglink versturen mislukt. Probeer het opnieuw.",
     "source_hash": "4c685e97"
   },
   "web.auth.magicLink.invalidLink": {
@@ -155,7 +155,7 @@
     "source_hash": "d726c0da"
   },
   "web.auth.magicLink.sessionExpired": {
-    "text": "Je sessie is verlopen. Vernieuw de pagina en probeer het opnieuw.",
+    "text": "Je sessie is verlopen. Ververs de pagina en probeer het opnieuw.",
     "source_hash": "be9ed96d"
   },
   "web.auth.magicLink.loginFailed": {
@@ -237,7 +237,7 @@
     "source_hash": "a513ed5c"
   },
   "web.auth.passkeys.setup_description": {
-    "text": "Met passkeys log je veilig in zonder wachtwoord",
+    "text": "Met passkeys kun je veilig inloggen zonder wachtwoord",
     "context": "Setup page description",
     "source_hash": "85630bef"
   },
@@ -292,7 +292,7 @@
     "source_hash": "e5bc07f1"
   },
   "web.auth.passkeys.name": {
-    "text": "Passkey naam",
+    "text": "Passkey-naam",
     "context": "Label for passkey name field",
     "source_hash": "22eefa67"
   },
@@ -312,7 +312,7 @@
     "source_hash": "24d3236c"
   },
   "web.auth.passkeys.benefit_secure": {
-    "text": "Veiliger dan wachtwoorden - bestand tegen phishingaanvallen",
+    "text": "Veiliger dan wachtwoorden - bestand tegen phishing-aanvallen",
     "context": "Passkey benefit",
     "source_hash": "41afb6ec"
   },
@@ -322,7 +322,7 @@
     "source_hash": "5a0ce96c"
   },
   "web.auth.passkeys.benefit_synced": {
-    "text": "Gesynchroniseerd tussen je apparaten bij gebruik van platform-authenticators",
+    "text": "Gesynchroniseerd op al je apparaten bij gebruik van platform-authenticators",
     "context": "Passkey benefit",
     "source_hash": "7480c7ae"
   },
@@ -336,7 +336,7 @@
     "source_hash": "151dcb5e"
   },
   "web.auth.lockout.account_locked": {
-    "text": "Account vergrendeld vanwege te veel mislukte inlogpogingen",
+    "text": "Account vergrendeld door te veel mislukte inlogpogingen",
     "source_hash": "5247f389"
   },
   "web.auth.lockout.locked_until": {
@@ -344,11 +344,11 @@
     "source_hash": "1a8f382e"
   },
   "web.auth.lockout.contact_support": {
-    "text": "Neem contact op met de ondersteuning als je directe toegang nodig hebt",
+    "text": "Neem contact op met support als je direct toegang nodig hebt",
     "source_hash": "23d82e46"
   },
   "web.auth.lockout.try_password_reset": {
-    "text": "Je kunt in plaats daarvan je wachtwoord resetten",
+    "text": "Je kunt in plaats daarvan je wachtwoord opnieuw instellen",
     "source_hash": "a98a3f9d"
   },
   "web.auth.sessions._guidance": {
@@ -400,7 +400,7 @@
     "source_hash": "ef12c1ba"
   },
   "web.auth.sessions.confirm_remove_all": {
-    "text": "Dit logt je uit op alle andere apparaten. Weet je het zeker?",
+    "text": "Je wordt uitgelogd op alle andere apparaten. Weet je het zeker?",
     "source_hash": "4a1a73e9"
   },
   "web.auth.sessions.no_sessions": {
@@ -452,7 +452,7 @@
     "source_hash": "efd0134a"
   },
   "web.auth.mfa.step_verify": {
-    "text": "2. Verifieer installatie",
+    "text": "2. Verifieer instelling",
     "source_hash": "59bba5f7"
   },
   "web.auth.mfa.scan_qr": {
@@ -464,7 +464,7 @@
     "source_hash": "3ea15b3e"
   },
   "web.auth.mfa.verify_code": {
-    "text": "Voer de 6-cijferige code van je app in",
+    "text": "Voer de 6-cijferige code uit je app in",
     "source_hash": "38f61733"
   },
   "web.auth.mfa.enter_code": {
@@ -472,11 +472,11 @@
     "source_hash": "186a582a"
   },
   "web.auth.mfa.verify": {
-    "text": "Verifiëren en inschakelen",
+    "text": "Verifieer en schakel in",
     "source_hash": "7c08f68d"
   },
   "web.auth.mfa.verify_login": {
-    "text": "Verifiëren",
+    "text": "Verifieer",
     "source_hash": "eea2745e"
   },
   "web.auth.mfa.code_required": {
@@ -484,7 +484,7 @@
     "source_hash": "217de0fc"
   },
   "web.auth.mfa.invalid_code": {
-    "text": "Ongeldige code. Codes verlopen elke 30 seconden. Probeer de nieuwste code van je authenticator-app.",
+    "text": "Ongeldige code. Codes verlopen elke 30 seconden. Probeer de laatste code uit je authenticator-app.",
     "source_hash": "94b58889"
   },
   "web.auth.mfa.success_enabled": {
@@ -520,7 +520,7 @@
     "source_hash": "23d3441a"
   },
   "web.auth.mfa.use_recovery_code_short": {
-    "text": "Herstelcode gebruiken",
+    "text": "Gebruik herstelcode",
     "source_hash": "50d5790d"
   },
   "web.auth.mfa.back_to_code": {
@@ -528,7 +528,7 @@
     "source_hash": "6fa090b4"
   },
   "web.auth.mfa.cancel": {
-    "text": "Annuleren en terug naar inloggen",
+    "text": "Annuleer en ga terug naar inloggen",
     "source_hash": "83256742"
   },
   "web.auth.mfa.cancel_sign_in": {
@@ -540,15 +540,15 @@
     "source_hash": "01919f0e"
   },
   "web.auth.mfa.protected_description": {
-    "text": "Je account is beschermd met tweefactorauthenticatie",
+    "text": "Je account is beveiligd met tweefactorauthenticatie",
     "source_hash": "02b9d169"
   },
   "web.auth.mfa.enable_description": {
-    "text": "Bescherm je account met een extra beveiligingslaag",
+    "text": "Beveilig je account met een extra beveiligingslaag",
     "source_hash": "06d9123b"
   },
   "web.auth.mfa.benefit_unauthorized": {
-    "text": "Voorkom ongeautoriseerde toegang zelfs als je wachtwoord is gecompromitteerd",
+    "text": "Voorkom ongeautoriseerde toegang, zelfs als je wachtwoord is gecompromitteerd",
     "source_hash": "61d99c71"
   },
   "web.auth.mfa.benefit_apps": {
@@ -584,7 +584,7 @@
     "source_hash": "4da96e87"
   },
   "web.auth.mfa.enter_code_description": {
-    "text": "Voer de 6-cijferige code van je authenticator-app in",
+    "text": "Voer de 6-cijferige code uit je authenticator-app in",
     "source_hash": "a160dee6"
   },
   "web.auth.mfa.enable_and_continue": {
@@ -592,7 +592,7 @@
     "source_hash": "37c8090d"
   },
   "web.auth.mfa.complete_setup": {
-    "text": "Installatie voltooien",
+    "text": "Instelling voltooien",
     "source_hash": "30e87601"
   },
   "web.auth.mfa.enter_recovery_code": {
@@ -616,11 +616,11 @@
     "source_hash": "36a438ba"
   },
   "web.auth.mfa.recovery_code_mode_active": {
-    "text": "Herstelcodemodus actief",
+    "text": "Herstelcode-modus actief",
     "source_hash": "c895f08b"
   },
   "web.auth.mfa.otp_mode_active": {
-    "text": "Authenticatiecodemodus actief",
+    "text": "Authenticatiecode-modus actief",
     "source_hash": "8c44a306"
   },
   "web.auth.mfa.enter_all_digits": {
@@ -636,15 +636,15 @@
     "source_hash": "579c7f4e"
   },
   "web.auth.recovery_codes.description": {
-    "text": "Bewaar deze codes op een veilige plek. Elke code kan één keer worden gebruikt als je geen toegang meer hebt tot je authenticator.",
+    "text": "Bewaar deze codes op een veilige plaats. Elke code kan eenmaal worden gebruikt als je geen toegang meer hebt tot je authenticator.",
     "source_hash": "87aebdfb"
   },
   "web.auth.recovery_codes.warning": {
-    "text": "Deze codes worden slechts één keer getoond",
+    "text": "Deze codes worden slechts eenmaal getoond",
     "source_hash": "d13f2877"
   },
   "web.auth.recovery_codes.save_required": {
-    "text": "Je moet je herstelcodes downloaden of kopiëren voordat je de installatie voltooit.",
+    "text": "Je moet je herstelcodes downloaden of kopiëren voordat je de instelling voltooit.",
     "source_hash": "6b97bc6d"
   },
   "web.auth.recovery_codes.generate_new": {
@@ -680,7 +680,7 @@
     "source_hash": "06ebb466"
   },
   "web.auth.recovery_codes.copy_failed": {
-    "text": "Kopiëren van codes naar klembord mislukt",
+    "text": "Codes kopiëren naar klembord mislukt",
     "source_hash": "e8be6a51"
   },
   "web.auth.recovery_codes.code_used": {
@@ -692,11 +692,11 @@
     "source_hash": "231aedff"
   },
   "web.auth.recovery_codes.remaining": {
-    "text": "{count} van {limit} herstelcodes over",
+    "text": "{count} van {limit} herstelcodes resterend",
     "source_hash": "b5d484e7"
   },
   "web.auth.recovery_codes.usage_hint": {
-    "text": "Elke code kan slechts één keer worden gebruikt. Genereer nieuwe codes als je er weinig over hebt.",
+    "text": "Elke code kan slechts eenmaal worden gebruikt. Genereer nieuwe codes als je bijna door je codes heen bent.",
     "source_hash": "737a7702"
   },
   "web.auth.recovery_codes.none_remaining": {
@@ -730,5 +730,201 @@
   "web.auth.sessions.session_plural": {
     "text": "sessies",
     "source_hash": "1225ae6c"
+  },
+  "web.auth.connections.title": {
+    "text": "Gekoppelde identiteiten",
+    "source_hash": "e132c4d9"
+  },
+  "web.auth.connections.description": {
+    "text": "Beheer de single sign-on providers die aan je account zijn gekoppeld.",
+    "source_hash": "42c6d148"
+  },
+  "web.auth.connections.section_title": {
+    "text": "Single sign-on",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.section_subtitle": {
+    "text": "Identiteitsproviders waarmee je kunt inloggen bij dit account",
+    "source_hash": "507254cd"
+  },
+  "web.auth.connections.connect_title": {
+    "text": "Koppel een provider",
+    "source_hash": "a002b3f3"
+  },
+  "web.auth.connections.connect_description": {
+    "text": "Koppel nog een single sign-on provider waarmee je kunt inloggen bij dit account.",
+    "source_hash": "32895a5a"
+  },
+  "web.auth.connections.connect_action": {
+    "text": "Koppel {provider}",
+    "source_hash": "c77540af"
+  },
+  "web.auth.connections.issuer": {
+    "text": "Uitgever",
+    "source_hash": "39e02c46"
+  },
+  "web.auth.connections.identifier": {
+    "text": "Identificatie",
+    "source_hash": "9b10587f"
+  },
+  "web.auth.connections.remove": {
+    "text": "Verwijderen",
+    "source_hash": "c3812fc4"
+  },
+  "web.auth.connections.remove_confirm_title": {
+    "text": "Gekoppelde identiteit verwijderen",
+    "source_hash": "4e8ffe4c"
+  },
+  "web.auth.connections.remove_confirm_message": {
+    "text": "Weet je zeker dat je deze gekoppelde identiteit wilt verwijderen? Je kunt er dan niet meer mee inloggen.",
+    "source_hash": "64939c89"
+  },
+  "web.auth.connections.removed_success": {
+    "text": "Gekoppelde identiteit verwijderd",
+    "source_hash": "cf87daf3"
+  },
+  "web.auth.connections.no_identities": {
+    "text": "Geen gekoppelde identiteiten",
+    "source_hash": "5254048e"
+  },
+  "web.auth.connections.no_identities_description": {
+    "text": "Je hebt nog geen single sign-on providers aan dit account gekoppeld.",
+    "source_hash": "0f58d5d0"
+  },
+  "web.auth.connections.overview_status": {
+    "text": "Single sign-on",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.errors.last_credential": {
+    "text": "Dit is je enige manier om in te loggen. Koppel eerst een andere provider, of stel een wachtwoord in via Instellingen → Beveiliging, zodat je geen toegang verliest.",
+    "source_hash": "3de8084d"
+  },
+  "web.auth.connections.errors.last_credential_sso_enforced": {
+    "text": "Dit is je enige manier om in te loggen. Koppel eerst een andere provider zodat je geen toegang verliest.",
+    "source_hash": "eed7a50e"
+  },
+  "web.auth.connections.errors.not_found": {
+    "text": "Die gekoppelde identiteit kon niet worden gevonden. Mogelijk is deze al verwijderd.",
+    "source_hash": "cf2c7673"
+  },
+  "web.auth.connections.errors.unauthorized": {
+    "text": "Je sessie is verlopen. Log opnieuw in.",
+    "source_hash": "b529fce2"
+  },
+  "web.auth.connections.errors.generic": {
+    "text": "We konden die actie niet voltooien. Probeer het opnieuw.",
+    "source_hash": "a0d4edc0"
+  },
+  "web.link_sso.title": {
+    "text": "Koppel je inlogmethode",
+    "source_hash": "46339bac"
+  },
+  "web.link_sso.prompt": {
+    "text": "Je hebt ingelogd met {provider}, die overeenkomt met het bestaande account {email}. Voer het wachtwoord van dat account in om {provider} te koppelen en door te gaan.",
+    "source_hash": "59da1c08"
+  },
+  "web.link_sso.password_label": {
+    "text": "Wachtwoord",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.link_sso.password_placeholder": {
+    "text": "Je bestaande wachtwoord",
+    "source_hash": "ad4e56da"
+  },
+  "web.link_sso.submit": {
+    "text": "Koppelen en doorgaan",
+    "source_hash": "c969b759"
+  },
+  "web.link_sso.cancel": {
+    "text": "Annuleren",
+    "source_hash": "19766ed6"
+  },
+  "web.link_sso.unavailable_title": {
+    "text": "Dit koppelingsverzoek is verlopen",
+    "source_hash": "b53c7e55"
+  },
+  "web.link_sso.unavailable_message": {
+    "text": "Voor je veiligheid is het verzoek om deze inlogmethode te koppelen niet meer geldig. Log in met je bestaande wachtwoord en koppel deze provider via Beveiligingsinstellingen → Gekoppelde identiteiten.",
+    "source_hash": "f7e349d1"
+  },
+  "web.link_sso.unavailable_action": {
+    "text": "Doorgaan naar inloggen",
+    "source_hash": "d398cd0a"
+  },
+  "web.link_sso.errors.invalid_password": {
+    "text": "Dat wachtwoord komt niet overeen met dit account. Probeer het opnieuw.",
+    "source_hash": "3259b4f5"
+  },
+  "web.link_sso.errors.invalid_token": {
+    "text": "Dit koppelingsverzoek is verlopen of al gebruikt. Log in met je bestaande wachtwoord en koppel deze provider via je accountinstellingen.",
+    "source_hash": "541f9127"
+  },
+  "web.link_sso.errors.link_conflict": {
+    "text": "We konden deze inlogmethode niet koppelen. Je account is mogelijk gewijzigd, of deze provider is al gekoppeld aan een ander account. Log in met je bestaande wachtwoord en beheer koppelingen via Beveiligingsinstellingen → Gekoppelde identiteiten.",
+    "source_hash": "7b0e0d0e"
+  },
+  "web.link_sso.errors.link_rate_limited": {
+    "text": "Te veel wachtwoordpogingen. Wacht een paar minuten en probeer het opnieuw.",
+    "source_hash": "a95e78cd"
+  },
+  "web.link_sso.errors.invalid_request": {
+    "text": "We konden dit koppelingsverzoek niet verwerken. Log opnieuw in met je SSO-provider.",
+    "source_hash": "053b9fc6"
+  },
+  "web.link_sso.errors.generic": {
+    "text": "We konden je account niet koppelen. Probeer het opnieuw.",
+    "source_hash": "f727c174"
+  },
+  "web.sso_link_confirm.title": {
+    "text": "Bevestig het koppelen van je account",
+    "source_hash": "ad80bfe7"
+  },
+  "web.sso_link_confirm.prompt": {
+    "text": "Je hebt ingelogd met {provider}, die overeenkomt met je account {email}. Bevestig om {provider} aan dit account te koppelen en het inloggen af te ronden.",
+    "source_hash": "6ff0d6cc"
+  },
+  "web.sso_link_confirm.submit": {
+    "text": "Bevestigen en koppelen",
+    "source_hash": "5cf663e6"
+  },
+  "web.sso_link_confirm.cancel": {
+    "text": "Annuleren",
+    "source_hash": "19766ed6"
+  },
+  "web.sso_link_confirm.unavailable_title": {
+    "text": "Dit koppelingsverzoek kan niet worden voltooid",
+    "source_hash": "47abb784"
+  },
+  "web.sso_link_confirm.unavailable_message": {
+    "text": "Voor je veiligheid is dit verzoek om je inlogmethode te koppelen niet meer geldig. Log opnieuw in met je provider en we sturen je een nieuwe link per e-mail.",
+    "source_hash": "080e6f9f"
+  },
+  "web.sso_link_confirm.unavailable_action": {
+    "text": "Terug naar inloggen",
+    "source_hash": "8504054f"
+  },
+  "web.sso_link_confirm.errors.link_expired": {
+    "text": "Dit koppelingsverzoek is verlopen of al gebruikt. Log opnieuw in met je provider en we sturen je een nieuwe link per e-mail.",
+    "source_hash": "a50538df"
+  },
+  "web.sso_link_confirm.errors.link_conflict": {
+    "text": "We konden deze inlogmethode niet koppelen. Je account is mogelijk gewijzigd, of deze provider is al gekoppeld aan een ander account. Log opnieuw in met je provider om door te gaan.",
+    "source_hash": "c954854b"
+  },
+  "web.sso_link_confirm.errors.link_invalidated": {
+    "text": "Je accountgegevens zijn gewijzigd nadat deze link is verstuurd, dus deze is niet meer geldig. Log opnieuw in met je provider en we sturen je een nieuwe link per e-mail.",
+    "source_hash": "db88cb1d"
+  },
+  "web.sso_link_confirm.errors.link_error": {
+    "text": "Er ging iets mis aan onze kant en we konden deze link niet verifiëren. Log opnieuw in met je provider en we sturen je een nieuwe.",
+    "source_hash": "ec24e0a1"
+  },
+  "web.sso_link_confirm.errors.confirm_rate_limited": {
+    "text": "Te veel pogingen vanaf je apparaat. Wacht een paar minuten en open de ge-e-mailde link opnieuw of log in met je provider voor een nieuwe.",
+    "source_hash": "f29af782"
+  },
+  "web.sso_link_confirm.errors.generic": {
+    "text": "We konden deze koppeling niet bevestigen. Log opnieuw in met je provider.",
+    "source_hash": "076fa25a"
   }
 }

--- a/locales/content/nl/session-auth-extended.json
+++ b/locales/content/nl/session-auth-extended.json
@@ -757,6 +757,7 @@
   },
   "web.auth.connections.connect_action": {
     "text": "Koppel {provider}",
+    "context": "Button label to start linking a specific SSO provider; {provider} is the provider display name",
     "source_hash": "c77540af"
   },
   "web.auth.connections.issuer": {
@@ -821,6 +822,7 @@
   },
   "web.link_sso.prompt": {
     "text": "Je hebt ingelogd met {provider}, die overeenkomt met het bestaande account {email}. Voer het wachtwoord van dat account in om {provider} te koppelen en door te gaan.",
+    "context": "Instruction on the sign-in interstitial. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/link-sso/:token.",
     "source_hash": "59da1c08"
   },
   "web.link_sso.password_label": {
@@ -881,6 +883,7 @@
   },
   "web.sso_link_confirm.prompt": {
     "text": "Je hebt ingelogd met {provider}, die overeenkomt met je account {email}. Bevestig om {provider} aan dit account te koppelen en het inloggen af te ronden.",
+    "context": "Consent instruction on the #3840 Phase 4 mailbox-proof SSO linking page. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/sso-link-confirm/:token. No password is asked — clicking the emailed link is the proof.",
     "source_hash": "6ff0d6cc"
   },
   "web.sso_link_confirm.submit": {

--- a/locales/content/nl/session-auth.json
+++ b/locales/content/nl/session-auth.json
@@ -1,10 +1,10 @@
 {
   "web.login.alternate_prefix": {
-    "text": "Heb je een account nodig?",
+    "text": "Nog geen account?",
     "source_hash": "8b827e19"
   },
   "web.login.need_an_account": {
-    "text": "Aanmelden.",
+    "text": "Registreer je.",
     "source_hash": "10647723"
   },
   "web.login.forgot_your_password": {
@@ -16,7 +16,7 @@
     "source_hash": "bcc0bcc9"
   },
   "web.login.enter_your_credentials": {
-    "text": "Voer je inloggegevens in",
+    "text": "Voer je gegevens in",
     "source_hash": "07e1c44e"
   },
   "web.login.remember_me": {
@@ -24,11 +24,11 @@
     "source_hash": "f93267aa"
   },
   "web.login.send_sign_in_link": {
-    "text": "Inloglink verzenden",
+    "text": "Stuur inloglink",
     "source_hash": "b1402b67"
   },
   "web.login.secure_link_helper": {
-    "text": "Een beveiligde link wordt naar je e-mailinbox verzonden.",
+    "text": "Er wordt een beveiligde link naar je e-mail verstuurd.",
     "source_hash": "d31d20cf"
   },
   "web.login.or_divider": {
@@ -40,7 +40,7 @@
     "source_hash": "bedac809"
   },
   "web.login.use_passwordless": {
-    "text": "Wachtwoordloos inloggen",
+    "text": "Inloggen zonder wachtwoord",
     "source_hash": "dddc0097"
   },
   "web.login.create_account": {
@@ -56,7 +56,7 @@
     "source_hash": "e7cf3ef4"
   },
   "web.login.tab_magic_link": {
-    "text": "Magische link",
+    "text": "Inloglink",
     "source_hash": "7a9ba11a"
   },
   "web.login.tab_passkey": {
@@ -68,7 +68,7 @@
     "source_hash": "c225cdfb"
   },
   "web.login.or_continue_with": {
-    "text": "Of doorgaan met",
+    "text": "Of ga verder met",
     "source_hash": "eb4e8d3b"
   },
   "web.login.sign_in_with_sso": {
@@ -84,23 +84,23 @@
     "source_hash": "4d1213f9"
   },
   "web.auth.sso.error": {
-    "text": "SSO-aanmelding mislukt. Probeer het opnieuw.",
+    "text": "SSO-inloggen mislukt. Probeer het opnieuw.",
     "source_hash": "45a1e65d"
   },
   "web.login.errors.sso_failed": {
-    "text": "SSO-authenticatie mislukt. Probeer het opnieuw of gebruik wachtwoord-login.",
+    "text": "SSO-authenticatie mislukt. Probeer het opnieuw of log in met je wachtwoord.",
     "source_hash": "13a2210a"
   },
   "web.login.errors.token_missing": {
-    "text": "De authenticatielink is onvolledig. Vraag een nieuwe aanmeldlink aan.",
+    "text": "De authenticatielink is onvolledig. Vraag een nieuwe inloglink aan.",
     "source_hash": "f4a10652"
   },
   "web.login.errors.token_expired": {
-    "text": "Deze aanmeldlink is verlopen. Vraag een nieuwe aan.",
+    "text": "Deze inloglink is verlopen. Vraag een nieuwe aan.",
     "source_hash": "f0de42ec"
   },
   "web.login.errors.token_invalid": {
-    "text": "Deze aanmeldlink is ongeldig. Vraag een nieuwe aan.",
+    "text": "Deze inloglink is ongeldig. Vraag een nieuwe aan.",
     "source_hash": "270c6401"
   },
   "web.signup.create_your_account": {
@@ -112,11 +112,11 @@
     "source_hash": "f5dcb5d5"
   },
   "web.signup.have_an_account": {
-    "text": "Inloggen.",
+    "text": "Log in.",
     "source_hash": "6c52846f"
   },
   "web.signup.error_title": {
-    "text": "Fout bij account aanmaken",
+    "text": "Fout bij aanmaken account",
     "source_hash": "e380a0b6"
   },
   "web.signup.password_error": {
@@ -151,7 +151,7 @@
     "source_hash": "cec1312b"
   },
   "web.auth.verify.unable_to_verify": {
-    "text": "Kan account niet verifiëren. Probeer het opnieuw of neem contact op met de ondersteuning.",
+    "text": "Kan account niet verifiëren. Probeer het opnieuw of neem contact op met support.",
     "source_hash": "c0df463f"
   },
   "web.auth.verify.check_email": {
@@ -175,11 +175,11 @@
     "source_hash": "1c4a5748"
   },
   "web.auth.verify.check_spam": {
-    "text": "Controleer je spam/ongewenste e-mail map als je de e-mail niet kunt vinden",
+    "text": "Controleer je spam-/ongewenste-e-mailmap als je de e-mail niet kunt vinden",
     "source_hash": "ae481e5e"
   },
   "web.auth.verify.contact_support": {
-    "text": "Neem contact op met de ondersteuning als je problemen blijft ondervinden",
+    "text": "Neem contact op met support als je problemen blijft hebben",
     "source_hash": "c0067275"
   },
   "web.auth.verify.missing_key_title": {
@@ -187,7 +187,7 @@
     "source_hash": "e0b448ac"
   },
   "web.auth.verify.missing_key_message": {
-    "text": "Gebruik de verificatielink die naar je e-mailadres is verzonden om je account te verifiëren.",
+    "text": "Gebruik de verificatielink die naar je e-mailadres is gestuurd om je account te verifiëren.",
     "source_hash": "b1a8cfc6"
   },
   "web.auth.verify.create_new_account": {
@@ -207,7 +207,7 @@
     "source_hash": "7c451e0f"
   },
   "web.auth.change_password.confirm_password": {
-    "text": "Nieuw wachtwoord bevestigen",
+    "text": "Bevestig nieuw wachtwoord",
     "source_hash": "642776c0"
   },
   "web.auth.change_password.success": {
@@ -231,7 +231,7 @@
     "source_hash": "b44b1366"
   },
   "web.auth.close_account.password": {
-    "text": "Voer je wachtwoord in om te bevestigen",
+    "text": "Voer je wachtwoord in ter bevestiging",
     "source_hash": "0aec03a6"
   },
   "web.auth.close_account.button": {
@@ -243,15 +243,15 @@
     "source_hash": "19766ed6"
   },
   "web.auth.password_reset_request.title": {
-    "text": "Wachtwoordreset aanvragen",
+    "text": "Wachtwoord opnieuw instellen aanvragen",
     "source_hash": "456d421c"
   },
   "web.auth.password_reset_request.description": {
-    "text": "Voer hieronder je e-mailadres in en we sturen je een link om je wachtwoord te resetten",
+    "text": "Voer hieronder je e-mailadres in en we sturen je een link om je wachtwoord opnieuw in te stellen",
     "source_hash": "31c5f80f"
   },
   "web.auth.password_reset_request.button": {
-    "text": "Resetlink verzenden",
+    "text": "Stuur resetlink",
     "source_hash": "7d5f16d4"
   },
   "web.auth.password_reset.title": {
@@ -260,11 +260,11 @@
     "source_hash": "3dfdf7c4"
   },
   "web.auth.password_reset.description": {
-    "text": "Voer hieronder je nieuwe wachtwoord in. Zorg ervoor dat het sterk en uniek is om je account te beschermen.",
+    "text": "Voer hieronder je nieuwe wachtwoord in. Zorg dat het sterk en uniek is om je account te beschermen.",
     "source_hash": "5c789083"
   },
   "web.auth.passwordReset.emailSent": {
-    "text": "Er is een e-mail naar je verzonden met een link om het wachtwoord van je account te resetten",
+    "text": "Er is een e-mail naar je verzonden met een link om het wachtwoord van je account opnieuw in te stellen",
     "source_hash": "63a6af45"
   },
   "web.auth.terms.agree_prefix": {
@@ -341,19 +341,19 @@
     "source_hash": "e1513814"
   },
   "web.help.title": {
-    "text": "Help en ondersteuning",
+    "text": "Help & ondersteuning",
     "source_hash": "1f8ecc24"
   },
   "web.help.signin_troubleshooting": {
-    "text": "Probleemoplossing bij inloggen",
+    "text": "Problemen met inloggen",
     "source_hash": "a9a88a01"
   },
   "web.help.magic_link_not_arriving": {
-    "text": "Magische link komt niet aan?",
+    "text": "Ontvang je de inloglink niet?",
     "source_hash": "6919ce70"
   },
   "web.help.check_spam_folder": {
-    "text": "Controleer je spam- of ongewenste e-mailmap",
+    "text": "Controleer je spam- of ongewenste-e-mailmap",
     "source_hash": "813fe2d8"
   },
   "web.help.check_email_spelling": {
@@ -365,7 +365,7 @@
     "source_hash": "884fc272"
   },
   "web.help.try_again": {
-    "text": "Probeer een nieuwe link aan te vragen als het meer dan 10 minuten geleden is",
+    "text": "Probeer een nieuwe link aan te vragen als het langer dan 10 minuten duurt",
     "source_hash": "68109f96"
   },
   "web.help.forgot_password": {
@@ -373,7 +373,7 @@
     "source_hash": "afd25fdf"
   },
   "web.help.use_magic_link_instead": {
-    "text": "Je kunt een link voor het opnieuw instellen van je wachtwoord aanvragen om een nieuw wachtwoord aan te maken.",
+    "text": "Je kunt een wachtwoord-resetlink aanvragen om een nieuw wachtwoord aan te maken.",
     "source_hash": "3c3eabad"
   },
   "web.help.account_locked": {
@@ -381,7 +381,7 @@
     "source_hash": "ef1251c1"
   },
   "web.help.account_locked_explanation": {
-    "text": "Na meerdere mislukte inlogpogingen worden accounts tijdelijk vergrendeld voor de veiligheid. Wacht 15 minuten en probeer het opnieuw, of gebruik Magische link om in te loggen.",
+    "text": "Na meerdere mislukte inlogpogingen worden accounts tijdelijk vergrendeld voor de veiligheid. Wacht 15 minuten en probeer het opnieuw, of gebruik de inloglink om in te loggen.",
     "source_hash": "4b2cf891"
   },
   "web.help.still_need_help": {
@@ -389,11 +389,11 @@
     "source_hash": "5ff7d19e"
   },
   "web.help.contact_us_description": {
-    "text": "Als je nog steeds problemen ondervindt, staan we klaar om te helpen. Stuur ons een bericht en we nemen zo snel mogelijk contact met je op.",
+    "text": "Als je nog steeds problemen hebt, staan we voor je klaar. Stuur ons een bericht en we nemen zo snel mogelijk contact met je op.",
     "source_hash": "d97c90fe"
   },
   "web.help.contact_support": {
-    "text": "Contact ondersteuning",
+    "text": "Neem contact op met support",
     "source_hash": "f8d47b82"
   },
   "web.auth.account.sso_linked": {
@@ -409,7 +409,7 @@
     "source_hash": "af87d51e"
   },
   "web.login.custom_domain_sso_description": {
-    "text": "De beheerder van de organisatie kan SSO inschakelen zodat teamleden hier kunnen inloggen. Neem contact op met de beheerder voor toegang.",
+    "text": "De organisatiebeheerder kan SSO inschakelen zodat teamleden hier kunnen inloggen. Neem contact op met de beheerder voor toegang.",
     "source_hash": "f3726509"
   },
   "web.login.signin_disabled_heading": {
@@ -425,11 +425,11 @@
     "source_hash": "b39ef93e"
   },
   "web.login.errors.invalid_email": {
-    "text": "Het e-mailadres van je identity provider is ongeldig. Neem contact op met je beheerder.",
+    "text": "Het e-mailadres van je identiteitsprovider is ongeldig. Neem contact op met je beheerder.",
     "source_hash": "10c12029"
   },
   "web.login.errors.domain_not_allowed": {
-    "text": "Je e-maildomein is niet geautoriseerd voor SSO-aanmelding. Neem contact op met je beheerder.",
+    "text": "Je e-maildomein is niet geautoriseerd voor SSO-registratie. Neem contact op met je beheerder.",
     "source_hash": "87603782"
   },
   "web.auth.check_email.title": {
@@ -461,7 +461,7 @@
     "source_hash": "e7cf3ef4"
   },
   "web.auth.verify.resend_help_text": {
-    "text": "Geen verificatie-e-mail ontvangen? Voer je e-mailadres in om deze opnieuw te versturen.",
+    "text": "Verificatie-e-mail niet ontvangen? Voer je e-mailadres in om deze opnieuw te versturen.",
     "source_hash": "e0df48bb"
   },
   "web.auth.verify.resend_button": {
@@ -469,11 +469,11 @@
     "source_hash": "5173cc04"
   },
   "web.auth.verify.resend_sent": {
-    "text": "Als een account verificatie nodig heeft, is er een nieuwe e-mail verstuurd. Controleer je inbox en spammap.",
+    "text": "Als een account verificatie nodig heeft, is een nieuwe e-mail verstuurd. Controleer je inbox en spammap.",
     "source_hash": "6f838ffb"
   },
   "web.auth.verify.resend_error": {
-    "text": "Kan de verificatie-e-mail niet versturen. Controleer je verbinding en probeer het opnieuw.",
+    "text": "Kon de verificatie-e-mail niet versturen. Controleer je verbinding en probeer het opnieuw.",
     "source_hash": "15149f46"
   },
   "web.auth.verify.resend_short": {
@@ -483,5 +483,41 @@
   "web.login.verified_notice": {
     "text": "Je e-mail is geverifieerd — je kunt nu inloggen.",
     "source_hash": "c8d4b5a8"
+  },
+  "web.auth.password_setup_request.title": {
+    "text": "Stel een wachtwoord in",
+    "source_hash": "11b6978b"
+  },
+  "web.auth.password_setup_request.description": {
+    "text": "Je account heeft nog geen wachtwoord. We sturen je een beveiligde link per e-mail om er een in te stellen, zodat je ook direct kunt inloggen.",
+    "source_hash": "dc0b561f"
+  },
+  "web.auth.password_setup_request.button": {
+    "text": "Stuur instellink",
+    "source_hash": "22807292"
+  },
+  "web.auth.password_setup_request.emailSent": {
+    "text": "Er is een e-mail naar je verzonden met een link om een wachtwoord voor je account in te stellen",
+    "source_hash": "82b686c7"
+  },
+  "web.login.errors.account_exists_link_required": {
+    "text": "Er bestaat al een account met dit e-mailadres, maar dit is niet gekoppeld aan deze inlogmethode. Log in met je bestaande methode en koppel deze provider via Beveiligingsinstellingen → Gekoppelde identiteiten.",
+    "source_hash": "7fbbb7e7"
+  },
+  "web.login.errors.identity_connect_conflict": {
+    "text": "Deze identiteit kon niet worden gekoppeld. De koppeling is mogelijk gestart op het verkeerde domein, of je sessie is verlopen. Log opnieuw in en koppel deze via je accountinstellingen.",
+    "source_hash": "4238bbf2"
+  },
+  "web.login.errors.org_join_failed": {
+    "text": "We konden je niet aan je organisatie toevoegen. Neem contact op met je beheerder.",
+    "source_hash": "155e71bb"
+  },
+  "web.login.errors.link_sso_failed": {
+    "text": "We konden die inlogmethode niet koppelen. Log in met je bestaande wachtwoord en koppel deze provider via Beveiligingsinstellingen → Gekoppelde identiteiten.",
+    "source_hash": "49954127"
+  },
+  "web.login.notices.link_verification_sent": {
+    "text": "Controleer je inbox — we hebben je een link gemaild om het koppelen van je account te bevestigen. Open deze om het inloggen af te ronden.",
+    "source_hash": "b251c8f3"
   }
 }

--- a/locales/content/nl/workspace-account.json
+++ b/locales/content/nl/workspace-account.json
@@ -100,7 +100,7 @@
     "source_hash": "919bb4cb"
   },
   "web.account.created_windowprops_cust_secrets_created_secrets": {
-    "text": "Heeft {0} berichten aangemaakt sinds {1}.",
+    "text": "{0} berichten aangemaakt sinds {1}.",
     "source_hash": "8cb99810"
   },
   "web.account.delete_account": {
@@ -120,7 +120,7 @@
     "source_hash": "89e60bfb"
   },
   "web.account.support_details": {
-    "text": "Ondersteuningsgegevens",
+    "text": "Supportgegevens",
     "source_hash": "cbad8751"
   },
   "web.account.back_to_details": {
@@ -136,7 +136,7 @@
     "source_hash": "05986d95"
   },
   "web.account.keep_this_token_secure_it_provides_full_access_t": {
-    "text": "Houd dit token veilig. Het kan worden gebruikt om berichten aan te maken en te beheren via de API.",
+    "text": "Bewaar dit token veilig. Het kan worden gebruikt om berichten aan te maken en te beheren via de API.",
     "source_hash": "a63cc8ec"
   },
   "web.account.confirm_with_your_password": {
@@ -144,7 +144,7 @@
     "source_hash": "ff2147fd"
   },
   "web.account.are_you_sure_you_want_to_permanently_delete_your": {
-    "text": "Weet je zeker dat je jouw account permanent wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.",
+    "text": "Weet je zeker dat je je account permanent wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.",
     "source_hash": "4fa3e4b8"
   },
   "web.account.confirm_account_deletion": {
@@ -172,11 +172,11 @@
     "source_hash": "ec31577b"
   },
   "web.account.burn_them_before_continuing": {
-    "text": "verbrand ze voordat je doorgaat",
+    "text": "verbrand ze voordat je verdergaat",
     "source_hash": "f89a5794"
   },
   "web.account.any_secrets_you_wish_to_remove": {
-    "text": "Berichten die je wilt verwijderen,",
+    "text": "Alle berichten die je wilt verwijderen,",
     "source_hash": "b45e2dd5"
   },
   "web.account.secrets_will_remain_active_until_they_expire": {
@@ -196,7 +196,7 @@
     "source_hash": "fb1e6fa5"
   },
   "web.account.are_you_sure_you_want_to_deactivate_your_account": {
-    "text": "Weet je zeker dat je jouw account wilt deactiveren? Al je gegevens worden permanent van onze servers verwijderd. Deze actie kan niet ongedaan worden gemaakt.",
+    "text": "Weet je zeker dat je je account wilt deactiveren? Al je gegevens worden permanent van onze servers verwijderd. Deze actie kan niet ongedaan worden gemaakt.",
     "source_hash": "4940e20a"
   },
   "web.account.deactivate_account": {
@@ -272,7 +272,7 @@
     "source_hash": "945109d1"
   },
   "web.settings.profile_settings_description": {
-    "text": "Beheer je accountinformatie",
+    "text": "Beheer je accountgegevens",
     "source_hash": "4a23a29f"
   },
   "web.settings.profile.title": {
@@ -284,7 +284,7 @@
     "source_hash": "18c3f2d5"
   },
   "web.settings.profile.current_email": {
-    "text": "Huidig e-mailadres",
+    "text": "Huidige e-mail",
     "source_hash": "5f1cab64"
   },
   "web.settings.profile.current_password": {
@@ -292,7 +292,7 @@
     "source_hash": "8ac76099"
   },
   "web.settings.profile.new_email": {
-    "text": "Nieuw e-mailadres",
+    "text": "Nieuwe e-mail",
     "source_hash": "5bafb4be"
   },
   "web.settings.profile.enter_password_to_confirm": {
@@ -300,11 +300,11 @@
     "source_hash": "27814c03"
   },
   "web.settings.profile.password_required_for_security": {
-    "text": "Je wachtwoord is vereist om veiligheidsredenen",
+    "text": "Je wachtwoord is vereist voor beveiligingsdoeleinden",
     "source_hash": "d18f62f2"
   },
   "web.settings.profile.verification_email_notice": {
-    "text": "Er wordt een verificatie-e-mail verzonden naar het nieuwe adres",
+    "text": "Er wordt een verificatie-e-mail naar het nieuwe adres gestuurd",
     "source_hash": "575082a1"
   },
   "web.settings.profile.update_email": {
@@ -312,11 +312,11 @@
     "source_hash": "6ec61b2e"
   },
   "web.settings.profile.change_email_description": {
-    "text": "Werk het e-mailadres bij dat is gekoppeld aan je account",
+    "text": "Werk het e-mailadres bij dat aan je account is gekoppeld",
     "source_hash": "636abb16"
   },
   "web.settings.profile.all_fields_required": {
-    "text": "Alle velden zijn verplicht",
+    "text": "Alle velden zijn vereist",
     "source_hash": "04814271"
   },
   "web.settings.profile.invalid_email": {
@@ -324,11 +324,11 @@
     "source_hash": "b00f7e3a"
   },
   "web.settings.profile.email_same_as_current": {
-    "text": "Nieuw e-mailadres moet anders zijn dan huidig e-mailadres",
+    "text": "Nieuwe e-mail moet anders zijn dan de huidige e-mail",
     "source_hash": "f7cfed6e"
   },
   "web.settings.profile.email_change_success": {
-    "text": "Verificatie-e-mail verstuurd. Controleer je nieuwe inbox en klik op de bevestigingslink om de wijziging te voltooien.",
+    "text": "Verificatie-e-mail verzonden. Controleer je nieuwe inbox en klik op de bevestigingslink om de wijziging te voltooien.",
     "source_hash": "45f0a4b5"
   },
   "web.settings.profile.email_change_error": {
@@ -352,11 +352,11 @@
     "source_hash": "e7cf3ef4"
   },
   "web.settings.password.description": {
-    "text": "Je accountwachtwoord bijwerken",
+    "text": "Werk je accountwachtwoord bij",
     "source_hash": "cb3ae40b"
   },
   "web.settings.password.update_account_password": {
-    "text": "Je accountwachtwoord bijwerken",
+    "text": "Werk je accountwachtwoord bij",
     "source_hash": "cb3ae40b"
   },
   "web.settings.delete_account.title": {
@@ -364,11 +364,11 @@
     "source_hash": "c031bf99"
   },
   "web.settings.delete_account.description": {
-    "text": "Je account en alle gegevens permanent verwijderen",
+    "text": "Verwijder je account en alle gegevens permanent",
     "source_hash": "7a3a6da2"
   },
   "web.settings.delete_account.permanently_delete_your_account": {
-    "text": "Je account en alle gegevens permanent verwijderen",
+    "text": "Verwijder je account en alle gegevens permanent",
     "source_hash": "7a3a6da2"
   },
   "web.settings.security.security_score": {
@@ -376,7 +376,7 @@
     "source_hash": "02d2f374"
   },
   "web.settings.security.score_description": {
-    "text": "Je algehele accountbeveiligingsstatus",
+    "text": "De algehele beveiligingsstatus van je account",
     "source_hash": "cf20935e"
   },
   "web.settings.security.excellent": {
@@ -436,7 +436,7 @@
     "source_hash": "30737484"
   },
   "web.settings.security.best_practices": {
-    "text": "Beste beveiligingspraktijken",
+    "text": "Best practices voor beveiliging",
     "source_hash": "fd71b2da"
   },
   "web.settings.security.use_strong_unique_password": {
@@ -452,7 +452,7 @@
     "source_hash": "605513fc"
   },
   "web.settings.security.review_sessions_regularly": {
-    "text": "Bekijk en trek ongebruikte sessies regelmatig in",
+    "text": "Controleer en herroep ongebruikte sessies regelmatig",
     "source_hash": "efe59445"
   },
   "web.settings.security.view_details": {
@@ -460,15 +460,15 @@
     "source_hash": "d1bf045b"
   },
   "web.settings.api.title": {
-    "text": "API en integraties",
+    "text": "API & integraties",
     "source_hash": "21fc84f3"
   },
   "web.settings.api.description": {
-    "text": "API-sleutels en integraties beheren",
+    "text": "Beheer API-sleutels en integraties",
     "source_hash": "70976099"
   },
   "web.settings.api.manage_api_keys": {
-    "text": "API-sleutels en integraties beheren",
+    "text": "Beheer API-sleutels en integraties",
     "source_hash": "70976099"
   },
   "web.settings.api.documentation": {
@@ -476,7 +476,7 @@
     "source_hash": "1cc77e60"
   },
   "web.settings.api.documentation_description": {
-    "text": "Leer hoe je {product_name} integreert in je applicaties",
+    "text": "Leer hoe je {product_name} in je applicaties integreert",
     "source_hash": "9bba1ae8"
   },
   "web.settings.api.rest_api_reference": {
@@ -484,7 +484,7 @@
     "source_hash": "26a5af61"
   },
   "web.settings.api.complete_api_documentation": {
-    "text": "Volledige API-documentatie en eindpunten",
+    "text": "Volledige API-documentatie en endpoints",
     "source_hash": "c1c87ad8"
   },
   "web.settings.api.code_examples": {
@@ -496,7 +496,7 @@
     "source_hash": "61c5956f"
   },
   "web.settings.api.security_best_practices": {
-    "text": "Beste beveiligingspraktijken",
+    "text": "Best practices voor beveiliging",
     "source_hash": "fd71b2da"
   },
   "web.settings.api.never_commit_api_keys": {
@@ -508,19 +508,19 @@
     "source_hash": "c05e8802"
   },
   "web.settings.api.rotate_keys_regularly": {
-    "text": "Roteer API-sleutels regelmatig voor beveiliging",
+    "text": "Roteer API-sleutels regelmatig voor de veiligheid",
     "source_hash": "eda6a5db"
   },
   "web.settings.api.use_https_only": {
-    "text": "Gebruik altijd HTTPS bij API-verzoeken",
+    "text": "Gebruik altijd HTTPS bij het maken van API-verzoeken",
     "source_hash": "b3f405ef"
   },
   "web.settings.api.monitor_api_usage": {
-    "text": "Monitor je API-gebruik en stel waarschuwingen in",
+    "text": "Monitor je API-gebruik en stel meldingen in",
     "source_hash": "abb08beb"
   },
   "web.settings.api.important_notice": {
-    "text": "Belangrijke mededeling",
+    "text": "Belangrijke melding",
     "source_hash": "03d3ba93"
   },
   "web.settings.api.regenerating_key_warning": {
@@ -540,7 +540,7 @@
     "source_hash": "cad972db"
   },
   "web.settings.privacy.non_negotiable": {
-    "text": "Niet onderhandelbaar",
+    "text": "Niet-onderhandelbaar",
     "source_hash": "ad090a29"
   },
   "web.settings.privacy.not_a_setting": {
@@ -552,7 +552,7 @@
     "source_hash": "3e154b1c"
   },
   "web.settings.privacy.explanation": {
-    "text": "Dit is geen instelling omdat er niets aan of uit te zetten is. Je privacy is ingebouwd in hoe wij werken.",
+    "text": "Dit is geen instelling omdat er niets is om in of uit te schakelen. Je privacy is ingebouwd in hoe we werken.",
     "source_hash": "ed943792"
   },
   "web.settings.notifications.title": {
@@ -568,7 +568,7 @@
     "source_hash": "c08abc04"
   },
   "web.settings.notifications.reveal_notifications.title": {
-    "text": "Berichtonthullingsmeldingen",
+    "text": "Meldingen bij onthullen van berichten",
     "source_hash": "c0fb2e25"
   },
   "web.settings.notifications.reveal_notifications.description": {
@@ -580,11 +580,11 @@
     "source_hash": "ba93106d"
   },
   "web.settings.notifications.privacy_note": {
-    "text": "Meldingse-mails bevatten alleen het tijdstempel en bericht-ID. Kijkerinformatie wordt nooit opgenomen.",
+    "text": "Meldings-e-mails bevatten alleen de tijdstempel en het bericht-ID. Informatie over de ontvanger wordt nooit opgenomen.",
     "source_hash": "7aac282f"
   },
   "web.settings.caution.title": {
-    "text": "Zone voor zorgvuldige afweging",
+    "text": "Zone voor zorgvuldige overweging",
     "source_hash": "fe27a3a8"
   },
   "web.settings.caution.description": {
@@ -592,15 +592,15 @@
     "source_hash": "223ee55d"
   },
   "web.settings.caution.data_export": {
-    "text": "Gegevens exporteren",
+    "text": "Gegevensexport",
     "source_hash": "bdcea052"
   },
   "web.settings.caution.export_your_data": {
-    "text": "Je accountgegevens exporteren",
+    "text": "Exporteer je accountgegevens",
     "source_hash": "dc5ffcb0"
   },
   "web.settings.caution.export_description": {
-    "text": "Vraag een volledige kopie van je accountgegevens aan in machineleesbaar formaat",
+    "text": "Vraag een volledige kopie van je accountgegevens aan in een machineleesbaar formaat",
     "source_hash": "369c3391"
   },
   "web.settings.caution.request_data_export": {
@@ -608,11 +608,11 @@
     "source_hash": "902394be"
   },
   "web.settings.caution.export_info": {
-    "text": "Exportverwerkingstijd",
+    "text": "Verwerkingstijd export",
     "source_hash": "2ebb2d44"
   },
   "web.settings.caution.export_info_description": {
-    "text": "Exports worden binnen 24 uur verwerkt en naar je e-mailadres verzonden",
+    "text": "Exports worden binnen 24 uur verwerkt en naar je e-mailadres gestuurd",
     "source_hash": "a2f81e3b"
   },
   "web.settings.caution.deletion_warning_title": {
@@ -624,7 +624,7 @@
     "source_hash": "974ccdb9"
   },
   "web.settings.caution.deletion_warning_metadata": {
-    "text": "Alle berichtmetadata en geschiedenis verwijderen",
+    "text": "Alle metadata en geschiedenis van berichten verwijderen",
     "source_hash": "ec4ee372"
   },
   "web.settings.caution.deletion_warning_api_keys": {
@@ -640,7 +640,7 @@
     "source_hash": "cf02eb0c"
   },
   "web.settings.profile.email_confirmed_success": {
-    "text": "Je e-mailadres is succesvol bijgewerkt. Log in met je nieuwe e-mailadres.",
+    "text": "Je e-mail is succesvol bijgewerkt. Log in met je nieuwe e-mailadres.",
     "source_hash": "a84efcea"
   },
   "web.settings.profile.email_confirm_verifying": {
@@ -648,7 +648,7 @@
     "source_hash": "a6a4745f"
   },
   "web.settings.profile.email_confirm_error_title": {
-    "text": "E-mailadres wijzigen mislukt",
+    "text": "E-mailwijziging mislukt",
     "source_hash": "953f3936"
   },
   "web.settings.profile.email_confirm_invalid": {
@@ -664,11 +664,11 @@
     "source_hash": "c65f7dcc"
   },
   "web.settings.profile.resend_confirmation": {
-    "text": "Bevestigingsmail opnieuw verzenden",
+    "text": "Bevestigings-e-mail opnieuw versturen",
     "source_hash": "c617fff7"
   },
   "web.settings.profile.resend_confirmation_success": {
-    "text": "Bevestigingsmail succesvol opnieuw verzonden.",
+    "text": "Bevestigings-e-mail succesvol opnieuw verstuurd.",
     "source_hash": "2287783b"
   },
   "web.settings.profile.resend_confirmation_sending": {
@@ -684,7 +684,7 @@
     "source_hash": "fe3ac3ad"
   },
   "web.settings.api.api_disabled_notice": {
-    "text": "De API is uitgeschakeld voor deze instance.",
+    "text": "De API is uitgeschakeld voor deze instantie.",
     "source_hash": "66d12d6b"
   },
   "web.settings.security.sso_managed_title": {
@@ -692,7 +692,35 @@
     "source_hash": "1f6c9472"
   },
   "web.settings.security.sso_managed_description": {
-    "text": "Je account wordt geverifieerd via de single sign-on-provider van je organisatie. Wachtwoord, multifactorauthenticatie en herstelcodes worden beheerd door je identity provider.",
+    "text": "Je account wordt geauthenticeerd via de single sign-on provider van je organisatie. Wachtwoord, tweefactorauthenticatie en herstelcodes worden beheerd door je identiteitsprovider.",
     "source_hash": "cd0cf39f"
+  },
+  "web.settings.api.api_username": {
+    "text": "API-gebruikersnaam",
+    "source_hash": "0b3e483e"
+  },
+  "web.settings.api.api_username_description": {
+    "text": "Je gebruikersnaam voor HTTP Basic-authenticatie",
+    "source_hash": "f3e65de3"
+  },
+  "web.settings.api.basic_auth_hint": {
+    "text": "Voor HTTP Basic-authenticatie gebruik je je account-e-mail of dit ID als gebruikersnaam en je API-token als wachtwoord.",
+    "source_hash": "cfa3806d"
+  },
+  "web.settings.security.set": {
+    "text": "Instellen",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.settings.security.not_set": {
+    "text": "Niet ingesteld",
+    "source_hash": "4895f731"
+  },
+  "web.settings.security.set_password_title": {
+    "text": "Wachtwoord instellen",
+    "source_hash": "4e411687"
+  },
+  "web.settings.security.set_password_description": {
+    "text": "Voeg een wachtwoord toe aan je account zodat je ook kunt inloggen zonder je identiteitsprovider",
+    "source_hash": "a6970402"
   }
 }

--- a/locales/content/nl/workspace-billing.json
+++ b/locales/content/nl/workspace-billing.json
@@ -220,7 +220,7 @@
     "source_hash": "5428d7fe"
   },
   "web.billing.overview.entitlements.sso": {
-    "text": "Single Sign-On (SSO)",
+    "text": "Single sign-on (SSO)",
     "source_hash": "5db5c812"
   },
   "web.billing.overview.entitlements.priority_support": {
@@ -1030,7 +1030,7 @@
     "source_hash": "be0fe4c3"
   },
   "web.billing.overview.entitlements.manage_sso": {
-    "text": "Single Sign-On (SSO)",
+    "text": "Single sign-on (SSO)",
     "source_hash": "5db5c812"
   },
   "web.billing.overview.entitlements.manage_billing": {

--- a/locales/content/nl/workspace-billing.json
+++ b/locales/content/nl/workspace-billing.json
@@ -20,7 +20,7 @@
     "source_hash": "95bdda65"
   },
   "web.billing.upgrade.needCustomDomains": {
-    "text": "Aangepaste domeinen vereisen Identity Plus of hoger",
+    "text": "Aangepaste domeinen vereist Identity Plus of hoger",
     "source_hash": "e8af8484"
   },
   "web.billing.upgrade.needApiAccess": {
@@ -28,7 +28,7 @@
     "source_hash": "ab8be865"
   },
   "web.billing.upgrade.needAuditLogs": {
-    "text": "Auditlogs vereisen Multi-Team plan of hoger",
+    "text": "Auditlogs vereist Multi-Team plan of hoger",
     "source_hash": "91df96b0"
   },
   "web.billing.manage_subscription_and_billing": {
@@ -96,7 +96,7 @@
     "source_hash": "f37cd0d9"
   },
   "web.billing.plans.legacy_plan_warning": {
-    "text": "Van plan wisselen betekent dat je je huidige speciale tarief verliest. Dit kan niet ongedaan worden gemaakt.",
+    "text": "Van plan wisselen betekent dat je je bestaande tarief verliest. Dit kan niet ongedaan worden gemaakt.",
     "source_hash": "eda13d64"
   },
   "web.billing.overview.no_payment_method": {
@@ -136,7 +136,7 @@
     "source_hash": "6d3a16f5"
   },
   "web.billing.overview.manage_billing_description": {
-    "text": "Betalingsgegevens bijwerken",
+    "text": "Betalingsinfo bijwerken",
     "source_hash": "1f981aaf"
   },
   "web.billing.overview.no_organizations_title": {
@@ -144,11 +144,11 @@
     "source_hash": "c7f70723"
   },
   "web.billing.overview.no_organizations_description": {
-    "text": "Maak een werkruimte aan om je facturatie en abonnement te beheren",
+    "text": "Maak een werkruimte aan om je facturering en abonnement te beheren",
     "source_hash": "e0fd27a5"
   },
   "web.billing.overview.load_error": {
-    "text": "Factuurgegevens konden niet worden geladen",
+    "text": "Factureringsinformatie laden mislukt",
     "source_hash": "3bc44882"
   },
   "web.billing.overview.upgrade_success": {
@@ -180,11 +180,11 @@
     "source_hash": "6170ab94"
   },
   "web.billing.overview.entitlements.custom_privacy_defaults": {
-    "text": "Aangepaste privacystandaarden",
+    "text": "Aangepaste privacy-standaarden",
     "source_hash": "e677e27d"
   },
   "web.billing.overview.entitlements.extended_default_expiration": {
-    "text": "Uitgebreide standaardverlooptijd",
+    "text": "Verlengde standaard verlooptijd",
     "source_hash": "19b19637"
   },
   "web.billing.overview.entitlements.custom_mail_sender": {
@@ -196,7 +196,7 @@
     "source_hash": "237dabec"
   },
   "web.billing.overview.entitlements.homepage_secrets": {
-    "text": "Homepage-berichten",
+    "text": "Berichten op startpagina",
     "source_hash": "6360f7ec"
   },
   "web.billing.overview.entitlements.incoming_secrets": {
@@ -220,7 +220,7 @@
     "source_hash": "5428d7fe"
   },
   "web.billing.overview.entitlements.sso": {
-    "text": "Single sign-on (SSO)",
+    "text": "Single Sign-On (SSO)",
     "source_hash": "5db5c812"
   },
   "web.billing.overview.entitlements.priority_support": {
@@ -232,7 +232,7 @@
     "source_hash": "436f2550"
   },
   "web.billing.overview.entitlements_load_error": {
-    "text": "Kan functiedetails niet laden",
+    "text": "Kon functiedetails niet laden",
     "source_hash": "c350973c"
   },
   "web.billing.overview.no_entitlements": {
@@ -240,7 +240,7 @@
     "source_hash": "03d195e8"
   },
   "web.billing.features.create_secrets": {
-    "text": "Berichten maken en delen",
+    "text": "Berichten aanmaken & delen",
     "source_hash": "303f9386"
   },
   "web.billing.features.api_access": {
@@ -256,7 +256,7 @@
     "source_hash": "6a6be744"
   },
   "web.billing.features.unlimited_custom_domains": {
-    "text": "Onbeperkt aangepaste domeinen",
+    "text": "Onbeperkte aangepaste domeinen",
     "source_hash": "53eb7521"
   },
   "web.billing.features.custom_branding": {
@@ -264,7 +264,7 @@
     "source_hash": "237dabec"
   },
   "web.billing.features.homepage_secrets": {
-    "text": "Homepage-berichten",
+    "text": "Berichten op startpagina",
     "source_hash": "6360f7ec"
   },
   "web.billing.features.manage_teams": {
@@ -300,7 +300,7 @@
     "source_hash": "d52b4039"
   },
   "web.billing.features.activity_stream": {
-    "text": "Activiteitenstroom",
+    "text": "Activiteitenstream",
     "source_hash": "b9c6cba7"
   },
   "web.billing.features.handoff_workflows": {
@@ -336,7 +336,7 @@
     "source_hash": "d955b7e8"
   },
   "web.billing.plans.cancel_to_downgrade": {
-    "text": "Annuleren om te wisselen",
+    "text": "Annuleer om te wisselen",
     "source_hash": "1c4cda89"
   },
   "web.billing.plans.monthly": {
@@ -360,11 +360,11 @@
     "source_hash": "f411a1fb"
   },
   "web.billing.plans.single_team_plan": {
-    "text": "Single Team",
+    "text": "Enkel team",
     "source_hash": "267ad4cf"
   },
   "web.billing.plans.multi_team_plan": {
-    "text": "Multi Team",
+    "text": "Meerdere teams",
     "source_hash": "ffc73d2c"
   },
   "web.billing.plans.individual_account": {
@@ -376,7 +376,7 @@
     "source_hash": "44e90aad"
   },
   "web.billing.plans.multi_team_account": {
-    "text": "Organisatie-account",
+    "text": "Organisatieaccount",
     "source_hash": "86e3a165"
   },
   "web.billing.plans.features": {
@@ -384,7 +384,7 @@
     "source_hash": "5697d03d"
   },
   "web.billing.plans.unlimited_secrets": {
-    "text": "Onbeperkt berichten",
+    "text": "Onbeperkte berichten",
     "source_hash": "0f077568"
   },
   "web.billing.plans.api_access": {
@@ -404,7 +404,7 @@
     "source_hash": "484aa053"
   },
   "web.billing.plans.custom_needs_title": {
-    "text": "Heb je vragen of iets specifieks nodig?",
+    "text": "Heb je vragen of heb je iets op maat nodig?",
     "source_hash": "2f68484c"
   },
   "web.billing.plans.custom_needs_description": {
@@ -420,11 +420,11 @@
     "source_hash": "54fb2b4b"
   },
   "web.billing.plans.unlimited_teams": {
-    "text": "Onbeperkt teams",
+    "text": "Onbeperkte teams",
     "source_hash": "6d9fde65"
   },
   "web.billing.plans.unlimited_members": {
-    "text": "Onbeperkt leden per team",
+    "text": "Onbeperkte leden per team",
     "source_hash": "728ecef0"
   },
   "web.billing.plans.most_popular": {
@@ -444,7 +444,7 @@
     "source_hash": "d8454436"
   },
   "web.billing.plans.load_error": {
-    "text": "Plannen konden niet worden geladen",
+    "text": "Plannen laden mislukt",
     "source_hash": "a37d4d9a"
   },
   "web.billing.plans.change_immediate": {
@@ -464,7 +464,7 @@
     "source_hash": "001e4901"
   },
   "web.billing.plans.due_today": {
-    "text": "Vandaag verschuldigd:",
+    "text": "Vandaag te betalen:",
     "source_hash": "e370e3aa"
   },
   "web.billing.plans.next_billing": {
@@ -504,15 +504,15 @@
     "source_hash": "a0943c3b"
   },
   "web.billing.plans.next_bill_amount": {
-    "text": "Volgend factuurbedrag:",
+    "text": "Volgende factuurbedrag:",
     "source_hash": "526ad28f"
   },
   "web.billing.plans.credit_applied_to_bill": {
-    "text": "Tegoed toegepast:",
+    "text": "Toegepast tegoed:",
     "source_hash": "e5f2e81a"
   },
   "web.billing.plans.amount_due_next_billing": {
-    "text": "Verschuldigd bedrag bij volgende facturering:",
+    "text": "Te betalen bij volgende facturering:",
     "source_hash": "22ee868a"
   },
   "web.billing.plans.remaining_account_credit": {
@@ -548,7 +548,7 @@
     "source_hash": "d6eafe82"
   },
   "web.billing.invoices.invoice_number": {
-    "text": "Factuur #",
+    "text": "Factuurnr.",
     "source_hash": "48a67cac"
   },
   "web.billing.invoices.no_invoices": {
@@ -568,7 +568,7 @@
     "source_hash": "fb81b961"
   },
   "web.billing.invoices.pending": {
-    "text": "In afwachting",
+    "text": "In behandeling",
     "source_hash": "331551b0"
   },
   "web.billing.invoices.failed": {
@@ -652,23 +652,23 @@
     "source_hash": "9baaf69e"
   },
   "web.billing.portal.description": {
-    "text": "Beheer je abonnement, betaalmethoden en factureringsgeschiedenis",
+    "text": "Beheer je abonnement, betaalmethodes en factureringsgeschiedenis",
     "source_hash": "1a8f3c19"
   },
   "web.billing.portal.open_portal": {
-    "text": "Factureringsportaal openen",
+    "text": "Open factureringsportaal",
     "source_hash": "23fbfa2b"
   },
   "web.billing.portal.redirecting": {
-    "text": "Doorverwijzen naar factureringsportaal...",
+    "text": "Doorsturen naar factureringsportaal...",
     "source_hash": "b6f47df3"
   },
   "web.billing.start_today": {
-    "text": "Vandaag beginnen",
+    "text": "Begin vandaag",
     "source_hash": "80e73fc7"
   },
   "web.billing.start_today_with_identity_plus": {
-    "text": "Vandaag beginnen met Identity Plus",
+    "text": "Begin vandaag met Identity Plus",
     "source_hash": "cce4c7d7"
   },
   "web.billing.per_month": {
@@ -680,7 +680,7 @@
     "source_hash": "f5bedf1c"
   },
   "web.billing.privacy_first_design": {
-    "text": "Privacy-eerst ontwerp",
+    "text": "Privacy-first ontwerp",
     "source_hash": "587d738c"
   },
   "web.billing.identity_plus": {
@@ -704,7 +704,7 @@
     "source_hash": "272d3c80"
   },
   "web.billing.upgrade_for_teams": {
-    "text": "Upgrade voor teams",
+    "text": "Upgraden voor teams",
     "source_hash": "90dfb533"
   },
   "web.billing.benefits_of": {
@@ -724,11 +724,11 @@
     "source_hash": "8e4d766a"
   },
   "web.billing.includes_all_features_and_unlimited_sharing_capa": {
-    "text": "Inclusief alle functies en onbeperkte deelmogelijkheden",
+    "text": "Alle plannen bevatten privacyfuncties en onbeperkte deelcapaciteit",
     "source_hash": "e728e4e1"
   },
   "web.billing.includes_all_data_locality_options": {
-    "text": "Alle plannen omvatten keuze uit datalocatie: {0} regio's",
+    "text": "Alle plannen bevatten keuze uit datalokaliteit: {0} regio's",
     "source_hash": "22a60b49"
   },
   "web.billing.get_started": {
@@ -740,7 +740,7 @@
     "source_hash": "eaf5e2ef"
   },
   "web.billing.elevate_your_secure_sharing_with_custom_domains_": {
-    "text": "Verbeter je veilige delen met aangepaste domeinen, onbeperkte capaciteit en functies op bedrijfsniveau.",
+    "text": "Verbeter je beveiligde delen met aangepaste domeinen, onbeperkte capaciteit en enterprise-grade functies.",
     "source_hash": "db458d30"
   },
   "web.billing.payment_frequency": {
@@ -748,33 +748,33 @@
     "source_hash": "b2c87e39"
   },
   "web.billing.secure_your_brand_and_build_customer_trust_with_": {
-    "text": "Beveilig je merk en bouw klantenvertrouwen op met links vanaf je domein. Perfect voor bedrijven die privacy en professionaliteit waarderen.",
+    "text": "Beveilig je merk en bouw klantvertrouwen met links van je eigen domein. Perfect voor bedrijven die privacy en professionaliteit waarderen.",
     "source_hash": "c07cd25c"
   },
   "web.billing.secure_links_stronger_connections": {
-    "text": "Beveiligde links, sterkere verbindingen",
+    "text": "Beveiligde links, sterkere connecties",
     "source_hash": "dd8dae5d"
   },
   "web.billing.identity_tier_not_found_in_product_tiers": {
-    "text": "Identity-niveau niet gevonden in productniveaus",
+    "text": "Identity-tier niet gevonden in productlagen",
     "source_hash": "d0204fc4"
   },
   "web.billing.cancel.link_text": {
-    "text": "Abonnement annuleren",
+    "text": "Abonnement opzeggen",
     "context": "Link text shown below the plan selector for paid users",
     "source_hash": "3f85967f"
   },
   "web.billing.cancel.title": {
-    "text": "Abonnement annuleren",
+    "text": "Abonnement opzeggen",
     "context": "Modal dialog heading/title",
     "source_hash": "882e0c83"
   },
   "web.billing.cancel.confirmation": {
-    "text": "Weet je zeker dat je je {plan}-abonnement wilt annuleren?",
+    "text": "Weet je zeker dat je je {plan}-abonnement wilt opzeggen?",
     "source_hash": "f4d1b6ee"
   },
   "web.billing.cancel.what_happens": {
-    "text": "Wat er gebeurt wanneer je annuleert:",
+    "text": "Wat er gebeurt als je opzegt:",
     "source_hash": "4d8f5751"
   },
   "web.billing.cancel.access_until": {
@@ -786,11 +786,11 @@
     "source_hash": "1b07a54a"
   },
   "web.billing.cancel.no_future_charges": {
-    "text": "Je wordt niet meer in rekening gebracht",
+    "text": "Je wordt niet meer gefactureerd",
     "source_hash": "a01cdc16"
   },
   "web.billing.cancel.downgrade_to_free": {
-    "text": "Je account wordt teruggezet naar het gratis plan",
+    "text": "Je account keert terug naar het gratis plan",
     "source_hash": "e01b3fc3"
   },
   "web.billing.cancel.keep_subscription": {
@@ -799,30 +799,30 @@
     "source_hash": "31e80c41"
   },
   "web.billing.cancel.confirm_cancel": {
-    "text": "Abonnement annuleren",
+    "text": "Abonnement opzeggen",
     "context": "Primary action button in modal - confirms the cancellation",
     "source_hash": "882e0c83"
   },
   "web.billing.cancel.success": {
-    "text": "Je abonnement is geannuleerd. Je behoudt toegang tot het einde van je factureringsperiode.",
+    "text": "Je abonnement is opgezegd. Je behoudt toegang tot het einde van je factureringsperiode.",
     "source_hash": "e18fd9d5"
   },
   "web.billing.cancel.error": {
-    "text": "Abonnement annuleren mislukt. Probeer het opnieuw.",
+    "text": "Abonnement opzeggen mislukt. Probeer het opnieuw.",
     "source_hash": "68e8bdde"
   },
   "web.billing.cancel.scheduled_title": {
-    "text": "Abonnementsannulering gepland",
+    "text": "Opzegging abonnement gepland",
     "context": "Alert banner heading shown when cancellation is pending",
     "source_hash": "1427d139"
   },
   "web.billing.cancel.scheduled_description": {
-    "text": "Je abonnement blijft actief tot {date}. Je hebt tot dan volledige toegang tot alle functies.",
+    "text": "Je abonnement blijft actief tot {date}. Je behoudt tot dan volledige toegang tot alle functies.",
     "context": "Alert banner description explaining continued access",
     "source_hash": "aab4b1dc"
   },
   "web.billing.cancel.scheduled_note": {
-    "text": "Van gedachten veranderd? Je kunt je abonnement op elk moment vóór de annuleringsdatum opnieuw activeren.",
+    "text": "Van gedachten veranderd? Je kunt je abonnement op elk moment vóór de opzegdatum opnieuw activeren.",
     "context": "Alert banner note encouraging reactivation",
     "source_hash": "c94d5527"
   },
@@ -835,11 +835,11 @@
     "source_hash": "db966d47"
   },
   "web.billing.overview.entitlements.workspace_branding": {
-    "text": "Werkruimte-branding",
+    "text": "Werkruimtebranding",
     "source_hash": "e7acbf6f"
   },
   "web.billing.features.extended_retention": {
-    "text": "30 dagen berichtretentie",
+    "text": "30 dagen berichtbewaring",
     "source_hash": "21d6d514"
   },
   "web.billing.features.incoming_secrets": {
@@ -863,7 +863,7 @@
     "source_hash": "3c2d9a14"
   },
   "web.billing.features.unlimited_members": {
-    "text": "Onbeperkt teamleden",
+    "text": "Onbeperkte teamleden",
     "source_hash": "b7491ee9"
   },
   "web.billing.features.notifications": {
@@ -875,11 +875,11 @@
     "source_hash": "db966d47"
   },
   "web.billing.features.workspace_branding": {
-    "text": "Werkruimte-branding",
+    "text": "Werkruimtebranding",
     "source_hash": "e7acbf6f"
   },
   "web.billing.features.dedicated_infrastructure": {
-    "text": "Dedicated infrastructuur",
+    "text": "Toegewijde infrastructuur",
     "source_hash": "0c10aea7"
   },
   "web.billing.features.shared_workflows": {
@@ -892,7 +892,7 @@
     "source_hash": "2cd800c5"
   },
   "web.billing.currency_migration.description": {
-    "text": "Je huidige abonnement gebruikt {from}. Het geselecteerde plan wordt gefactureerd in {to}. Hiervoor moet je abonnement worden gemigreerd naar de nieuwe valuta.",
+    "text": "Je huidige abonnement gebruikt {from}. Het geselecteerde plan wordt gefactureerd in {to}. Dit vereist migratie van je abonnement naar de nieuwe valuta.",
     "source_hash": "f0cdf727"
   },
   "web.billing.currency_migration.current_plan": {
@@ -916,7 +916,7 @@
     "source_hash": "55cd980b"
   },
   "web.billing.currency_migration.graceful_description": {
-    "text": "Je huidige plan blijft actief tot {date}. Daarna voltooi je de afrekening voor je nieuwe plan.",
+    "text": "Je huidige plan blijft actief tot {date}. Daarna rond je de checkout af voor je nieuwe plan.",
     "source_hash": "b8661418"
   },
   "web.billing.currency_migration.immediate_title": {
@@ -924,7 +924,7 @@
     "source_hash": "e9d0ba59"
   },
   "web.billing.currency_migration.immediate_description": {
-    "text": "Je huidige plan wordt nu geannuleerd. Je ontvangt een terugbetaling voor ongebruikte tijd en voltooit de afrekening voor het nieuwe plan.",
+    "text": "Je huidige plan wordt nu geannuleerd. Je ontvangt een terugbetaling voor je ongebruikte tijd en rondt de checkout af voor het nieuwe plan.",
     "source_hash": "b08de0ca"
   },
   "web.billing.currency_migration.confirm": {
@@ -940,7 +940,7 @@
     "source_hash": "a8bf437e"
   },
   "web.billing.currency_migration.graceful_success": {
-    "text": "Je huidige plan blijft actief tot het einde van de factureringsperiode. Daarna word je gevraagd de afrekening voor je nieuwe plan te voltooien.",
+    "text": "Je huidige plan blijft actief tot het einde van de factureringsperiode. Je wordt daarna gevraagd om de checkout voor je nieuwe plan af te ronden.",
     "source_hash": "15d41483"
   },
   "web.billing.currency_migration.warning_credit_balance": {
@@ -948,11 +948,11 @@
     "source_hash": "aa15be91"
   },
   "web.billing.currency_migration.warning_pending_items": {
-    "text": "Je hebt openstaande factuuritems die moeten worden afgehandeld voor de migratie.",
+    "text": "Je hebt openstaande factuuritems die moeten worden opgelost vóór de migratie.",
     "source_hash": "7b4c5e10"
   },
   "web.billing.currency_migration.warning_coupons": {
-    "text": "Actieve kortingscodes op je account zijn mogelijk niet compatibel met de nieuwe valuta.",
+    "text": "Actieve kortingsbonnen op je account zijn mogelijk niet compatibel met de nieuwe valuta.",
     "source_hash": "f572ee81"
   },
   "web.billing.currency_migration.pending_title": {
@@ -961,7 +961,7 @@
     "source_hash": "018ae653"
   },
   "web.billing.currency_migration.pending_description": {
-    "text": "Je huidige plan eindigt op {date}. Voltooi je overschakeling naar {plan} ({currency}).",
+    "text": "Je huidige plan eindigt op {date}. Rond je overschakeling naar {plan} ({currency}) af.",
     "source_hash": "998ba4ab"
   },
   "web.billing.currency_migration.complete_migration": {
@@ -970,17 +970,17 @@
     "source_hash": "fa794e0c"
   },
   "web.billing.checkout_session_failed": {
-    "text": "Afrekensessie kon niet worden aangemaakt",
+    "text": "Aanmaken van checkout-sessie mislukt",
     "context": "Error when Stripe checkout session creation returns no URL",
     "source_hash": "a53f6fa3"
   },
   "web.billing.checkout_initiate_failed": {
-    "text": "Afrekenen kon niet worden gestart",
+    "text": "Initiëren van checkout mislukt",
     "context": "Fallback error for checkout failures",
     "source_hash": "3ff06e41"
   },
   "web.billing.plan_switch_success": {
-    "text": "Succesvol overgestapt naar {plan}",
+    "text": "Succesvol overgeschakeld naar {plan}",
     "context": "Success message after plan change",
     "source_hash": "ab7c715c"
   },
@@ -990,7 +990,7 @@
     "source_hash": "10de32e5"
   },
   "web.billing.already_subscribed": {
-    "text": "Je bent al geabonneerd op dit plan.",
+    "text": "Je hebt al een abonnement op dit plan.",
     "source_hash": "2b02438b"
   },
   "web.billing.cancel.reactivate_button": {
@@ -998,11 +998,11 @@
     "source_hash": "aa036442"
   },
   "web.billing.cancel.reactivate_success": {
-    "text": "Je abonnement is opnieuw geactiveerd. Je wordt op de normale manier verder gefactureerd.",
+    "text": "Je abonnement is opnieuw geactiveerd. Je wordt weer normaal gefactureerd.",
     "source_hash": "523bf7bf"
   },
   "web.billing.cancel.reactivate_error": {
-    "text": "Opnieuw activeren van het abonnement is mislukt. Probeer het opnieuw of neem contact op met support.",
+    "text": "Abonnement opnieuw activeren mislukt. Probeer het opnieuw of neem contact op met support.",
     "source_hash": "d0c79bd4"
   },
   "web.billing.features.manage_orgs": {
@@ -1010,11 +1010,11 @@
     "source_hash": "780ad17c"
   },
   "web.billing.features.flexible_from_domain": {
-    "text": "Flexibel e-mailafzenderdomein",
+    "text": "Flexibel e-mail afzenderdomein",
     "source_hash": "607572c3"
   },
   "web.billing.features.unlimited_admins": {
-    "text": "Onbeperkt aantal beheerders",
+    "text": "Onbeperkte beheerders",
     "source_hash": "5871a536"
   },
   "web.billing.features.manage_sso": {
@@ -1022,7 +1022,7 @@
     "source_hash": "5ba3ac9f"
   },
   "web.billing.overview.entitlements.flexible_from_domain": {
-    "text": "Flexibel e-mailafzenderdomein",
+    "text": "Flexibel e-mail afzenderdomein",
     "source_hash": "607572c3"
   },
   "web.billing.overview.entitlements.manage_orgs": {
@@ -1030,19 +1030,35 @@
     "source_hash": "be0fe4c3"
   },
   "web.billing.overview.entitlements.manage_sso": {
-    "text": "Single sign-on (SSO)",
+    "text": "Single Sign-On (SSO)",
     "source_hash": "5db5c812"
   },
   "web.billing.overview.entitlements.manage_billing": {
-    "text": "Facturatie beheren",
+    "text": "Facturering beheren",
     "source_hash": "6d3a16f5"
   },
   "web.billing.overview.entitlements.custom_signup_validation": {
-    "text": "Aangepaste aanmeldingsvalidatie",
+    "text": "Aangepaste registratievalidatie",
     "source_hash": "0ff55bfa"
   },
   "web.billing.plans.reactivate": {
     "text": "Opnieuw activeren",
     "source_hash": "2dc7478f"
+  },
+  "web.billing.currency_migration.refund_failed_warning": {
+    "text": "Je vorige plan is geannuleerd, maar we konden de terugbetaling voor je ongebruikte tijd niet automatisch uitvoeren. Neem contact op met support om je terugbetaling te ontvangen. Je moet nog steeds de checkout afronden om je nieuwe plan te activeren.",
+    "source_hash": "a390c498"
+  },
+  "web.billing.currency_migration.refund_failed_continue": {
+    "text": "Doorgaan naar checkout",
+    "source_hash": "eccdb8aa"
+  },
+  "web.billing.plans.per_year": {
+    "text": "/jaar",
+    "source_hash": "a2d5f1bc"
+  },
+  "web.billing.plans.billing_interval": {
+    "text": "Factureringsinterval",
+    "source_hash": "3ce28209"
   }
 }

--- a/locales/content/nl/workspace-branding.json
+++ b/locales/content/nl/workspace-branding.json
@@ -144,7 +144,7 @@
     "source_hash": "1e04ba2e"
   },
   "web.branding.powered_by_onetime_secret": {
-    "text": "Powered by {product_name}",
+    "text": "Mogelijk gemaakt door {product_name}",
     "source_hash": "1f393117"
   },
   "web.branding.low_contrast_warning": {
@@ -156,7 +156,7 @@
     "source_hash": "d521a5be"
   },
   "web.branding.heading_logo": {
-    "text": "{0} Logo",
+    "text": "{0}-logo",
     "source_hash": "3a3c98ed"
   },
   "web.branding.edge": {

--- a/locales/content/nl/workspace-branding.json
+++ b/locales/content/nl/workspace-branding.json
@@ -24,15 +24,15 @@
     "source_hash": "db3183e3"
   },
   "web.branding.preview_of_the_secret_link_page_for_recipients": {
-    "text": "Voorbeeld van de geheime linkpagina voor ontvangers",
+    "text": "Voorbeeld van de weergave voor ontvangers bij het openen van je beveiligde link",
     "source_hash": "199c165f"
   },
   "web.branding.preview_and_customize": {
-    "text": "Aanpassen en voorbeeld",
+    "text": "Aanpassen & voorvertonen",
     "source_hash": "fc68a28c"
   },
   "web.branding.switch_to_safari_browser_view": {
-    "text": "Overschakelen naar Safari-browserweergave",
+    "text": "Schakel naar Safari-browserweergave",
     "source_hash": "6e0fe791"
   },
   "web.branding.microsoft_edge": {
@@ -48,7 +48,7 @@
     "source_hash": "5cd54386"
   },
   "web.branding.switch_to_edge_browser_view": {
-    "text": "Overschakelen naar Edge-browserweergave",
+    "text": "Schakel naar Edge-browserweergave",
     "source_hash": "a8fcd82d"
   },
   "web.branding.charactercount_500_characters": {
@@ -56,19 +56,19 @@
     "source_hash": "e36598ef"
   },
   "web.branding.example_pre_reveal_instructions": {
-    "text": "Gebruik je telefoon om de QR-code te scannen",
-    "source_hash": "99ecf59f"
+    "text": "bijv. Gebruik je telefoon om de QR-code te scannen",
+    "source_hash": "9cf0caf8"
   },
   "web.branding.example_post_reveal_instructions": {
-    "text": "Neem contact op met onboarding{'@'}voorbeeld.com met eventuele vragen",
-    "source_hash": "bee120a7"
+    "text": "bijv. Neem contact op met onboarding{'@'}example.com met vragen",
+    "source_hash": "71749811"
   },
   "web.branding.these_instructions_will_be_shown_to_recipients_before": {
-    "text": "Deze instructies worden aan ontvangers getoond voordat ze de geheime inhoud bekijken",
+    "text": "Deze instructies worden aan ontvangers getoond voordat ze de inhoud van het bericht onthullen",
     "source_hash": "9d5a6334"
   },
   "web.branding.these_instructions_will_be_shown_to_recipients_after": {
-    "text": "Deze instructies worden aan ontvangers getoond nadat ze het geheim hebben onthuld",
+    "text": "Deze instructies worden aan ontvangers getoond nadat ze het bericht hebben onthuld",
     "source_hash": "9f82bd94"
   },
   "web.branding.pre_reveal_instructions": {
@@ -88,7 +88,7 @@
     "source_hash": "43e9a2d7"
   },
   "web.branding.click_to_upload_a_logo_with_recommendation": {
-    "text": "Klik om je logo te beheren. Aanbevolen formaat: 128x128 pixels. Maximale bestandsgrootte: 1 MB. Ondersteunde formaten: PNG, JPG, SVG",
+    "text": "Klik om je logo te beheren. Aanbevolen grootte: 128x128 pixels. Maximale bestandsgrootte: 1MB. Ondersteunde formaten: PNG, JPG, SVG",
     "source_hash": "7bb92395"
   },
   "web.branding.upload_logo": {
@@ -100,27 +100,27 @@
     "source_hash": "c02130fa"
   },
   "web.branding.preview_how_recipients_will_see_your_secrets": {
-    "text": "Bekijk hoe ontvangers je berichten zullen zien door de knop \"Bericht bekijken\" te testen",
+    "text": "Bekijk een voorbeeld van hoe ontvangers je berichten zien door de knop \"Bericht bekijken\" te testen",
     "source_hash": "3b58a297"
   },
   "web.branding.eye_icon": {
-    "text": "Oogpictogram",
+    "text": "Oogicoon",
     "source_hash": "7f605d3c"
   },
   "web.branding.click_the_preview_image_below_to_update_your_logo": {
-    "text": "Klik op de voorbeeldafbeelding hieronder om je logo bij te werken (minimaal 128x128 pixels aanbevolen, 1MB max)",
+    "text": "Klik op de voorbeeldafbeelding hieronder om je logo bij te werken (minimaal 128x128 pixels aanbevolen, max 1MB)",
     "source_hash": "77a19049"
   },
   "web.branding.image_icon": {
-    "text": "Afbeeldingspictogram",
+    "text": "Afbeeldingsicoon",
     "source_hash": "b0d64fcf"
   },
   "web.branding.use_the_controls_above_to_customize_brand_details": {
-    "text": "Gebruik de besturingselementen hierboven om merkkleur, stijlen en instructies voor ontvangers aan te passen",
+    "text": "Gebruik de bediening hierboven om merkkleur, stijlen en ontvangstinstructies aan te passen",
     "source_hash": "d6287134"
   },
   "web.branding.customization_icon": {
-    "text": "Aanpassingspictogram",
+    "text": "Aanpassingsicoon",
     "source_hash": "bde04d31"
   },
   "web.branding.you_have_unsaved_changes_are_you_sure": {
@@ -132,19 +132,19 @@
     "source_hash": "a7a1575e"
   },
   "web.branding.this_is_an_interactive_preview_o": {
-    "text": "Dit is een interactief voorbeeld van hoe ontvangers je beveiligde berichten zullen zien. Je kunt: - Kleuren en lettertypen aanpassen met de bedieningselementen hierboven - Een logo uploaden (minimaal 128x128 pixels aanbevolen, max 1MB) - Het voorbeeld testen met de \"Bericht bekijken\"-knop",
+    "text": "Dit is een interactief voorbeeld van hoe ontvangers je beveiligde berichten zien. Je kunt: - Kleuren en lettertypen aanpassen met de bediening hierboven - Een logo uploaden (minimaal 128x128 pixels aanbevolen, max 1MB) - Het voorbeeld testen met de knop \"Bericht bekijken\"",
     "source_hash": "3d8b2c0d"
   },
   "web.branding.this_is_an_interactive_preview_of_how_recipients": {
-    "text": "Dit is een interactief voorbeeld van hoe ontvangers je beveiligde berichten zullen zien. Je kunt: - Kleuren en lettertypen aanpassen met de besturingselementen hierboven - Een logo uploaden (minimaal 128x128 pixels aanbevolen, 1MB max) - Het voorbeeld testen met de knop \"Bericht bekijken\"",
+    "text": "Dit is een interactief voorbeeld van hoe ontvangers je beveiligde berichten zien. Je kunt: - Kleuren en lettertypen aanpassen met de bediening hierboven - Een logo uploaden (minimaal 128x128 pixels aanbevolen, max 1MB) - Het voorbeeld testen met de knop \"Bericht bekijken\"",
     "source_hash": "3d8b2c0d"
   },
   "web.branding.default_logo_icon": {
-    "text": "Japans kanji '秘' (himitsu) wat 'geheim' of 'vertrouwelijk' betekent",
+    "text": "Japans kanji '秘' (himitsu) betekent 'geheim' of 'vertrouwelijk'",
     "source_hash": "1e04ba2e"
   },
   "web.branding.powered_by_onetime_secret": {
-    "text": "Mogelijk gemaakt door {product_name}",
+    "text": "Powered by {product_name}",
     "source_hash": "1f393117"
   },
   "web.branding.low_contrast_warning": {
@@ -156,7 +156,7 @@
     "source_hash": "d521a5be"
   },
   "web.branding.heading_logo": {
-    "text": "{0}-logo",
+    "text": "{0} Logo",
     "source_hash": "3a3c98ed"
   },
   "web.branding.edge": {
@@ -164,7 +164,7 @@
     "source_hash": "0f82fe72"
   },
   "web.branding.switch_to_edge_preview": {
-    "text": "Overschakelen naar Edge-voorbeeld",
+    "text": "Schakel naar Edge-voorbeeld",
     "source_hash": "83883d84"
   },
   "web.branding.safari": {
@@ -172,19 +172,19 @@
     "source_hash": "5f033039"
   },
   "web.branding.switch_to_safari_preview": {
-    "text": "Overschakelen naar Safari-voorbeeld",
+    "text": "Schakel naar Safari-voorbeeld",
     "source_hash": "f24ac447"
   },
   "web.branding.upgrade_to_customize": {
-    "text": "Upgrade je plan om de branding voor dit domein aan te passen.",
+    "text": "Upgrade je plan om branding voor dit domein aan te passen.",
     "source_hash": "9077bf79"
   },
   "web.branding.saved_successfully": {
-    "text": "Brandinginstellingen succesvol opgeslagen",
+    "text": "Merkinstellingen succesvol opgeslagen",
     "source_hash": "9960c252"
   },
   "web.branding.keyhole_logo_icon": {
-    "text": "Sleutelgatpictogram dat beveiligd, privé delen voorstelt",
+    "text": "Sleutelgaticoon voor beveiligd, privé delen",
     "source_hash": "c868ac60"
   },
   "web.branding.secondary_color": {
@@ -228,7 +228,7 @@
     "source_hash": "5260dda5"
   },
   "web.branding.logo_modal_hint": {
-    "text": "PNG, JPG of SVG. Aanbevolen 128x128px, tot 1 MB.",
+    "text": "PNG, JPG of SVG. Aanbevolen 128x128px, tot 1MB.",
     "source_hash": "75d00802"
   },
   "web.branding.logo_modal_save": {
@@ -248,7 +248,7 @@
     "source_hash": "6613b73c"
   },
   "web.branding.image_invalid_type": {
-    "text": "Dat bestandstype wordt niet ondersteund. Kies een afbeelding.",
+    "text": "Dit bestandstype wordt niet ondersteund. Kies een afbeelding.",
     "source_hash": "50e18866"
   },
   "web.branding.image_too_large": {
@@ -260,7 +260,7 @@
     "source_hash": "d94fa99a"
   },
   "web.branding.image_upload_failed": {
-    "text": "Er is iets misgegaan. Probeer het opnieuw.",
+    "text": "Er ging iets mis. Probeer het opnieuw.",
     "source_hash": "3ccd9d65"
   },
   "web.branding.undo": {
@@ -268,7 +268,7 @@
     "source_hash": "a8283ade"
   },
   "web.branding.low_contrast_text_bg_warning": {
-    "text": "Laag contrast tussen tekst en achtergrond",
+    "text": "Laag tekst/achtergrond contrast",
     "source_hash": "1c676370"
   },
   "web.branding.path_simple": {
@@ -276,7 +276,7 @@
     "source_hash": "3fee95da"
   },
   "web.branding.path_match": {
-    "text": "Overeenkomen met mijn site",
+    "text": "Match mijn site",
     "source_hash": "776679cf"
   },
   "web.branding.path_advanced": {
@@ -284,7 +284,7 @@
     "source_hash": "9f088dbe"
   },
   "web.branding.path_simple_tag": {
-    "text": "De basis van je merk.",
+    "text": "Je merkessentials.",
     "source_hash": "7c9c0cca"
   },
   "web.branding.path_match_tag": {
@@ -292,7 +292,7 @@
     "source_hash": "e4b0d1cd"
   },
   "web.branding.path_advanced_tag": {
-    "text": "Schrijf je eigen Tailwind v4-CSS.",
+    "text": "Maak je eigen Tailwind v4 CSS.",
     "source_hash": "2405bb6d"
   },
   "web.branding.badge_default": {
@@ -320,15 +320,15 @@
     "source_hash": "bc79cdff"
   },
   "web.branding.paths_carryover_hint": {
-    "text": "Dit is een live voorbeeld — je wijzigingen zijn pas zichtbaar voor bezoekers nadat je hebt opgeslagen.",
-    "source_hash": "cb4b82de"
+    "text": "Dit is een live voorbeeld — je wijzigingen zijn pas zichtbaar voor bezoekers als je op Bijwerken klikt.",
+    "source_hash": "9a34df71"
   },
   "web.branding.coming_soon_match_blurb": {
-    "text": "Wijs ons naar je website en we lezen de kleuren en lettertypen, en dichten het gat met één klik.",
+    "text": "Verwijs ons naar je website en we lezen de kleuren en lettertypen, en passen alles in één klik aan.",
     "source_hash": "42c34cc1"
   },
   "web.branding.coming_soon_advanced_blurb": {
-    "text": "Bewerk de Tailwind v4 {'@'}theme-tokens rechtstreeks, of plak je eigen stylesheet.",
+    "text": "Bewerk de Tailwind v4 {'@'}theme tokens direct, of plak je eigen stylesheet.",
     "source_hash": "5a8473f5"
   },
   "web.branding.preview_recipient_page": {
@@ -340,11 +340,11 @@
     "source_hash": "324b134f"
   },
   "web.branding.preview_homepage_enabled": {
-    "text": "Homepage · ingeschakeld",
+    "text": "Startpagina · ingeschakeld",
     "source_hash": "2edd85f1"
   },
   "web.branding.preview_homepage_disabled": {
-    "text": "Homepage · uitgeschakeld",
+    "text": "Startpagina · uitgeschakeld",
     "source_hash": "15d87050"
   },
   "web.branding.preview_live": {
@@ -356,11 +356,11 @@
     "source_hash": "5384461b"
   },
   "web.branding.tile_create_link": {
-    "text": "Beveiligde link aanmaken",
+    "text": "Maak berichtlink aan",
     "source_hash": "610fd42e"
   },
   "web.branding.tile_delivery_only": {
-    "text": "Alleen bezorging van beveiligde berichten",
+    "text": "Alleen beveiligde berichtbezorging",
     "source_hash": "dc24dec2"
   },
   "web.branding.tile_no_create": {
@@ -368,11 +368,11 @@
     "source_hash": "17361d81"
   },
   "web.branding.recipient_page_content": {
-    "text": "Inhoud ontvangerspagina",
+    "text": "Ontvangerspagina-inhoud",
     "source_hash": "937733bd"
   },
   "web.branding.recipient_page_content_hint": {
-    "text": "Taal en onthulinstructies die aan ontvangers op dit domein worden getoond.",
+    "text": "Taal en onthullingsinstructies getoond aan ontvangers op dit domein.",
     "source_hash": "04162b70"
   },
   "web.branding.tab_brand": {
@@ -392,7 +392,7 @@
     "source_hash": "bfbc5599"
   },
   "web.branding.delivery_reveal_instructions": {
-    "text": "Onthulinstructies",
+    "text": "Onthullingsinstructies",
     "source_hash": "7e1331f7"
   },
   "web.branding.delivery_reveal_instructions_hint": {
@@ -400,11 +400,63 @@
     "source_hash": "51b9811d"
   },
   "web.branding.delivery_before_reveal": {
-    "text": "Vóór onthulling",
+    "text": "Vóór onthullen",
     "source_hash": "5ce82b01"
   },
   "web.branding.delivery_after_reveal": {
-    "text": "Na onthulling",
+    "text": "Na onthullen",
     "source_hash": "d5bfe7fd"
+  },
+  "web.branding.favicon": {
+    "text": "Favicon",
+    "source_hash": "42955289"
+  },
+  "web.branding.refresh_favicon": {
+    "text": "Favicon vernieuwen van domein",
+    "source_hash": "7cc3d5dc"
+  },
+  "web.branding.refresh_favicon_hint": {
+    "text": "Haal de favicon opnieuw op van je domein. Het nieuwe icoon verschijnt binnenkort.",
+    "source_hash": "ee007e44"
+  },
+  "web.branding.refresh_favicon_queued": {
+    "text": "Favicon vernieuwen — het nieuwe icoon verschijnt binnenkort.",
+    "source_hash": "6bf38e6e"
+  },
+  "web.branding.refresh_favicon_user_upload_hint": {
+    "text": "Je hebt een aangepaste favicon geüpload, dus een opgehaald icoon vervangt deze niet.",
+    "source_hash": "c22e1ed6"
+  },
+  "web.branding.upload_favicon": {
+    "text": "Favicon uploaden",
+    "source_hash": "ceda39cb"
+  },
+  "web.branding.replace_favicon": {
+    "text": "Vervangen",
+    "source_hash": "95e15439"
+  },
+  "web.branding.remove_favicon": {
+    "text": "Favicon verwijderen",
+    "source_hash": "03693698"
+  },
+  "web.branding.favicon_field_hint": {
+    "text": "ICO, PNG of SVG. Uploaden vervangt het opgehaalde icoon.",
+    "source_hash": "dfa0bfcb"
+  },
+  "web.branding.favicon_preview_alt": {
+    "text": "Domeinfavicon",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_title": {
+    "text": "Domeinfavicon",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_hint": {
+    "text": "ICO, PNG of SVG. Tot 256KB. Vervangt het automatisch opgehaalde icoon.",
+    "source_hash": "c9eafc83"
+  },
+  "web.branding.favicon_modal_save": {
+    "text": "Favicon opslaan",
+    "source_hash": "c8a1566c"
   }
 }

--- a/locales/content/nl/workspace-dashboard.json
+++ b/locales/content/nl/workspace-dashboard.json
@@ -12,7 +12,7 @@
     "source_hash": "02b7b86b"
   },
   "web.dashboard.get_started_by_creating_your_first_secret": {
-    "text": "Begin door je eerste bericht aan te maken.",
+    "text": "Begin met het aanmaken van je eerste bericht.",
     "source_hash": "e96db24d"
   },
   "web.dashboard.fetch_error_title": {
@@ -20,7 +20,7 @@
     "source_hash": "ba7df1be"
   },
   "web.dashboard.fetch_error_description": {
-    "text": "Er was een probleem bij het laden van je gegevens. Probeer het opnieuw.",
+    "text": "Er was een probleem met het laden van je gegevens. Probeer het opnieuw.",
     "source_hash": "ff0d904e"
   },
   "web.teams.create_first_team_title": {

--- a/locales/content/nl/workspace-domains.json
+++ b/locales/content/nl/workspace-domains.json
@@ -4,7 +4,7 @@
     "source_hash": "c592a5c6"
   },
   "web.domains.view_domain_verification_status": {
-    "text": "Domeinverificatiestatus bekijken",
+    "text": "Bekijk domeinverificatiestatus",
     "source_hash": "23635e2d"
   },
   "web.domains.domain_already_in_organization": {
@@ -12,7 +12,7 @@
     "source_hash": "6e0d628f"
   },
   "web.domains.domain_in_other_organization": {
-    "text": "Dit domein is al geregistreerd bij een andere organisatie. Neem contact op met de ondersteuning als je denkt dat dit een fout is.",
+    "text": "Dit domein is al geregistreerd bij een andere organisatie. Neem contact op met support als je denkt dat dit een fout is.",
     "source_hash": "7fae16a9"
   },
   "web.domains.domain_claimed_successfully": {
@@ -20,23 +20,23 @@
     "source_hash": "d53e1ac1"
   },
   "web.domains.privacy_defaults_title": {
-    "text": "Privacystandaarden",
+    "text": "Privacy-standaarden",
     "source_hash": "5bce069d"
   },
   "web.domains.privacy_defaults_description": {
-    "text": "Stel standaard privacyopties in voor berichten die onder dit domein worden aangemaakt. Deze instellingen worden vooraf ingevuld bij het aanmaken van nieuwe berichten.",
+    "text": "Stel standaard privacy-opties in voor berichten die onder dit domein worden aangemaakt. Deze instellingen worden vooraf ingevuld bij het aanmaken van nieuwe berichten.",
     "source_hash": "1d98959c"
   },
   "web.domains.privacy_defaults": {
-    "text": "Privacystandaarden",
+    "text": "Privacy-standaarden",
     "source_hash": "5bce069d"
   },
   "web.domains.privacy_defaults_icon": {
-    "text": "Privacystandaarden pictogram",
+    "text": "Privacy-standaarden icoon",
     "source_hash": "c6bef509"
   },
   "web.domains.default_ttl_label": {
-    "text": "Standaard levensduur",
+    "text": "Standaard geldigheid",
     "source_hash": "ce3c65fe"
   },
   "web.domains.default_ttl_hint": {
@@ -60,7 +60,7 @@
     "source_hash": "3e16dd5f"
   },
   "web.domains.use_global_default": {
-    "text": "Globale standaard gebruiken",
+    "text": "Gebruik globale standaard",
     "source_hash": "a83c91e4"
   },
   "web.domains.global_default": {
@@ -108,7 +108,7 @@
     "source_hash": "c776f846"
   },
   "web.domains.switcher_locked": {
-    "text": "Domeinwisseling niet beschikbaar op deze pagina",
+    "text": "Domein wisselen niet beschikbaar op deze pagina",
     "source_hash": "ccd202fe"
   },
   "web.domains.scope_list_label": {
@@ -140,15 +140,15 @@
     "source_hash": "421b1e61"
   },
   "web.domains.control_whether_users_can_create_secret_links": {
-    "text": "Bepaal of gebruikers geheime links kunnen maken vanaf de homepage van je domein",
+    "text": "Bepaal of gebruikers berichtlinks kunnen aanmaken vanaf de startpagina van je domein",
     "source_hash": "a25d6fca"
   },
   "web.domains.homepage_access": {
-    "text": "Homepage-toegang",
+    "text": "Startpagina-toegang",
     "source_hash": "00c89609"
   },
   "web.domains.and_status": {
-    "text": "en status",
+    "text": "& Status",
     "source_hash": "fe871d2c"
   },
   "web.domains.domain": {
@@ -172,7 +172,7 @@
     "source_hash": "bec72630"
   },
   "web.domains.ssl_renews": {
-    "text": "SSL vernieuwt",
+    "text": "SSL-vernieuwing",
     "source_hash": "c49a8cff"
   },
   "web.domains.dns_record": {
@@ -196,7 +196,7 @@
     "source_hash": "c1683eeb"
   },
   "web.domains.open_domain_in_new_tab": {
-    "text": "Domein openen in nieuw tabblad",
+    "text": "Open domein in nieuw tabblad",
     "source_hash": "01571f31"
   },
   "web.domains.back_to_domains": {
@@ -216,7 +216,7 @@
     "source_hash": "b6ec5cd4"
   },
   "web.domains.added_formatdistancetonow_domain_created_addsuffix_true": {
-    "text": "Toegevoegd {0}",
+    "text": "{0} geleden toegevoegd",
     "source_hash": "dc9ff9ec"
   },
   "web.domains.add_your_domain": {
@@ -224,7 +224,7 @@
     "source_hash": "6b95c91c"
   },
   "web.domains.get_started_by_adding_a_custom_domain": {
-    "text": "Begin door een aangepast domein toe te voegen.",
+    "text": "Begin met het toevoegen van een aangepast domein.",
     "source_hash": "abdbe9ab"
   },
   "web.domains.no_domains_found": {
@@ -236,15 +236,15 @@
     "source_hash": "b5549ff7"
   },
   "web.domains.in_order_to_connect_your_domain_youll_need_to_ha": {
-    "text": "Om je domein te verbinden, moet je een CNAME-record in je DNS hebben dat verwijst",
+    "text": "Om je domein te verbinden, moet je een CNAME-record in je DNS hebben dat verwijst naar",
     "source_hash": "c560710e"
   },
   "web.domains.if_you_already_have_a_cname_record_for_that_addr": {
-    "text": "Als je al een CNAME-record hebt voor dat adres, wijzig het dan om te verwijzen naar",
+    "text": "Als je al een CNAME-record voor dat adres hebt, wijzig het dan zodat het verwijst naar",
     "source_hash": "6f23e6db"
   },
   "web.domains.a_cname_record_is_not_allowed_instead_youll_need": {
-    "text": "), is een CNAME-record niet toegestaan. In plaats daarvan moet je een A-record maken. Details over hoe je dit kunt doen, worden verderop op de pagina gegeven.",
+    "text": "), is een CNAME-record niet toegestaan. In plaats daarvan moet je een A-record aanmaken. Details over hoe je dit doet staan verderop op de pagina.",
     "source_hash": "76d5ab5f"
   },
   "web.domains.and_remove_any_other_a_aaaa_or_cname_records_for": {
@@ -260,7 +260,7 @@
     "source_hash": "aae43a00"
   },
   "web.domains.please_note_that_for_apex_domains": {
-    "text": "Let op dat voor apex-domeinen (bijv.",
+    "text": "Let op: voor apex-domeinen (bijv.",
     "source_hash": "09a4b0ca"
   },
   "web.domains.verify_your_domain": {
@@ -268,23 +268,23 @@
     "source_hash": "afa10517"
   },
   "web.domains.secrets_example_dot_com": {
-    "text": "secrets.voorbeeld.com",
+    "text": "secrets.example.com",
     "source_hash": "9ea4d0d6"
   },
   "web.domains.customize_your_domain_branding": {
-    "text": "Pas je domeinbranding aan",
+    "text": "Pas de branding van je domein aan",
     "source_hash": "e3f97ac1"
   },
   "web.domains.it_may_take_a_few_minutes_for_your_ssl_certifica": {
-    "text": "Het kan enkele minuten duren voordat je SSL-certificaat van kracht wordt.",
+    "text": "Het kan enkele minuten duren voordat je SSL-certificaat actief wordt.",
     "source_hash": "2e4f3179"
   },
   "web.domains.dns_changes_can_take_as_little_as_60_seconds_or_": {
-    "text": "DNS-wijzigingen kunnen zo weinig als 60 seconden - of tot 24 uur - duren om van kracht te worden.",
+    "text": "DNS-wijzigingen kunnen al na 60 seconden actief worden -- of tot 24 uur duren.",
     "source_hash": "38774290"
   },
   "web.domains.3_wait_for_propagation": {
-    "text": "3. Wacht op doorgifte",
+    "text": "3. Wacht op propagatie",
     "source_hash": "3e6cf4e1"
   },
   "web.domains.value_2": {
@@ -336,7 +336,7 @@
     "source_hash": "62766ffd"
   },
   "web.domains.follow_these_steps_to_verify_domain_ownership_an": {
-    "text": "Volg deze stappen om domeineigendom te verifiëren en je online aanwezigheid te verbeteren:",
+    "text": "Volg deze stappen om domeineigendom te verifiëren en je online aanwezigheid te versterken:",
     "source_hash": "a33f94d3"
   },
   "web.domains.domain_verification_steps": {
@@ -380,7 +380,7 @@
     "source_hash": "4526107f"
   },
   "web.domains.edit_ttl": {
-    "text": "Levensduurinstelling bewerken",
+    "text": "Geldigheidsinstelling bewerken",
     "source_hash": "ea8afd62"
   },
   "web.domains.edit_passphrase": {
@@ -400,7 +400,7 @@
     "source_hash": "91c1af2e"
   },
   "web.domains.email.title": {
-    "text": "E-mailverzending",
+    "text": "E-mail verzenden",
     "source_hash": "6c428e5f"
   },
   "web.domains.email.config_title": {
@@ -420,7 +420,7 @@
     "source_hash": "63c8080c"
   },
   "web.domains.email.from_name_label": {
-    "text": "Afzendernaam",
+    "text": "Van naam",
     "source_hash": "2f13b589"
   },
   "web.domains.email.from_name_placeholder": {
@@ -428,7 +428,7 @@
     "source_hash": "03c0f138"
   },
   "web.domains.email.from_address_label": {
-    "text": "Afzenderadres",
+    "text": "Van adres",
     "source_hash": "60643eae"
   },
   "web.domains.email.from_address_placeholder": {
@@ -448,7 +448,7 @@
     "source_hash": "35322b5b"
   },
   "web.domains.email.discard_changes": {
-    "text": "Wijzigingen annuleren",
+    "text": "Wijzigingen verwerpen",
     "source_hash": "e07e053c"
   },
   "web.domains.email.provider_ses": {
@@ -464,7 +464,7 @@
     "source_hash": "ec994dad"
   },
   "web.domains.email.provider_inherit": {
-    "text": "Accountstandaarden gebruiken",
+    "text": "Gebruik accountstandaarden",
     "source_hash": "f6fa84e7"
   },
   "web.domains.email.provider_ses_description": {
@@ -472,7 +472,7 @@
     "source_hash": "4df5aa60"
   },
   "web.domains.email.provider_sendgrid_description": {
-    "text": "Vereist domeinauthenticatie-configuratie",
+    "text": "Vereist domeinauthenticatie-instelling",
     "source_hash": "71b53242"
   },
   "web.domains.email.provider_lettermint_description": {
@@ -480,7 +480,7 @@
     "source_hash": "87073c93"
   },
   "web.domains.email.provider_inherit_description": {
-    "text": "Gebruikt de standaard e-mailverzendconfiguratie van je account",
+    "text": "Gebruikt de standaard e-mailverzendingsconfiguratie van je account",
     "source_hash": "3f798263"
   },
   "web.domains.email.dns_records_title": {
@@ -504,11 +504,11 @@
     "source_hash": "8e37953d"
   },
   "web.domains.email.dns_optional_label": {
-    "text": "Recommended",
+    "text": "Aanbevolen",
     "source_hash": "d70604e8"
   },
   "web.domains.email.dns_optional_hint": {
-    "text": "This record is recommended but not required for verification. A DMARC policy at your organizational domain may already cover this subdomain.",
+    "text": "Dit record is aanbevolen maar niet vereist voor verificatie. Een DMARC-beleid op je organisatiedomein dekt mogelijk al dit subdomein.",
     "source_hash": "58e1a12b"
   },
   "web.domains.email.copy": {
@@ -588,7 +588,7 @@
     "source_hash": "dd1841d2"
   },
   "web.domains.email.badge_default_sender": {
-    "text": "Standaard afzender wordt gebruikt",
+    "text": "Gebruikt standaardafzender",
     "source_hash": "e1afb18f"
   },
   "web.domains.email.badge_verified": {
@@ -604,15 +604,15 @@
     "source_hash": "75081b59"
   },
   "web.domains.email.tooltip_not_configured": {
-    "text": "Geen e-mailafzender geconfigureerd — e-mails gebruiken de standaard platformafzender",
+    "text": "Geen e-mailafzender geconfigureerd — e-mails gebruiken de platformstandaardafzender",
     "source_hash": "360083bb"
   },
   "web.domains.email.tooltip_pending": {
-    "text": "E-mailafzenderconfiguratie wacht op verificatie — e-mails gebruiken de standaard platformafzender",
+    "text": "E-mailafzenderconfiguratie wacht op verificatie — e-mails gebruiken de platformstandaardafzender",
     "source_hash": "c8c2449c"
   },
   "web.domains.email.tooltip_disabled": {
-    "text": "E-mailafzender is uitgeschakeld — e-mails gebruiken de standaard platformafzender",
+    "text": "E-mailafzender is uitgeschakeld — e-mails gebruiken de platformstandaardafzender",
     "source_hash": "64e84955"
   },
   "web.domains.email.tooltip_verified": {
@@ -624,7 +624,7 @@
     "source_hash": "883dbca9"
   },
   "web.domains.incoming.config_title": {
-    "text": "Configuratie inkomende berichten",
+    "text": "Inkomende berichten configuratie",
     "source_hash": "b3fef15b"
   },
   "web.domains.incoming.config_description": {
@@ -648,11 +648,11 @@
     "source_hash": "eab52939"
   },
   "web.domains.incoming.not_configured_notice": {
-    "text": "Inkomende berichten is niet geconfigureerd voor dit domein. Voeg ontvangers toe om externe gebruikers berichten naar je team te laten sturen.",
+    "text": "Inkomende berichten is niet geconfigureerd voor dit domein. Voeg ontvangers toe om externe gebruikers toe te staan berichten naar je team te sturen.",
     "source_hash": "dbc443a6"
   },
   "web.domains.incoming.disabled_notice": {
-    "text": "Inkomende berichten zijn momenteel uitgeschakeld. Externe gebruikers kunnen geen berichten naar ontvangers op dit domein sturen. Schakel de functie hieronder in om inkomende berichten toe te staan.",
+    "text": "Inkomende berichten is momenteel uitgeschakeld. Externe gebruikers kunnen geen berichten sturen naar ontvangers op dit domein. Schakel de functie hieronder in om inkomende berichten toe te staan.",
     "source_hash": "d1f8dafb"
   },
   "web.domains.incoming.recipients_title": {
@@ -660,7 +660,7 @@
     "source_hash": "1e8568a8"
   },
   "web.domains.incoming.recipients_description": {
-    "text": "Bepaal wie inkomende berichten op dit domein kan ontvangen. Ontvangers ontvangen een e-mailmelding wanneer een bericht naar hen wordt gestuurd.",
+    "text": "Definieer wie inkomende berichten kan ontvangen op dit domein. Ontvangers krijgen e-mailmeldingen wanneer een bericht naar hen wordt gestuurd.",
     "source_hash": "026f9d9d"
   },
   "web.domains.incoming.add_recipient": {
@@ -692,7 +692,7 @@
     "source_hash": "bc8c2058"
   },
   "web.domains.incoming.empty_state_description": {
-    "text": "Voeg ontvangers toe om externe gebruikers berichten naar je team te laten sturen.",
+    "text": "Voeg ontvangers toe om externe gebruikers toe te staan berichten naar je team te sturen.",
     "source_hash": "2a647a40"
   },
   "web.domains.incoming.validation_invalid_email": {
@@ -720,15 +720,15 @@
     "source_hash": "35322b5b"
   },
   "web.domains.incoming.discard_changes": {
-    "text": "Wijzigingen annuleren",
+    "text": "Wijzigingen verwerpen",
     "source_hash": "e07e053c"
   },
   "web.domains.incoming.update_success": {
-    "text": "Configuratie inkomende berichten succesvol opgeslagen",
+    "text": "Inkomende berichten configuratie succesvol opgeslagen",
     "source_hash": "9317e02d"
   },
   "web.domains.incoming.delete_success": {
-    "text": "Configuratie inkomende berichten succesvol verwijderd",
+    "text": "Inkomende berichten configuratie succesvol verwijderd",
     "source_hash": "4c4a33ae"
   },
   "web.domains.incoming.recipient_count": {
@@ -756,7 +756,7 @@
     "source_hash": "c205cc54"
   },
   "web.domains.incoming.tooltip_disabled": {
-    "text": "Inkomende berichten-functie is uitgeschakeld voor dit domein",
+    "text": "Inkomende berichten functie is uitgeschakeld voor dit domein",
     "source_hash": "0413f96b"
   },
   "web.domains.incoming.enabled_label": {
@@ -768,11 +768,11 @@
     "source_hash": "24aadd31"
   },
   "web.domains.incoming.public_url_label": {
-    "text": "Publieke URL",
+    "text": "Openbare URL",
     "source_hash": "f7b60b04"
   },
   "web.domains.incoming.public_url_description": {
-    "text": "Deel deze URL met externe gebruikers om hen berichten te laten versturen",
+    "text": "Deel deze URL met externe gebruikers om hen toe te staan berichten te sturen",
     "source_hash": "df47a894"
   },
   "web.domains.incoming.copy_url": {
@@ -796,7 +796,7 @@
     "source_hash": "ca598f6d"
   },
   "web.domains.incoming.save_will_replace_confirmation": {
-    "text": "Opslaan vervangt alle bestaande ontvangers door je wijzigingen. Weet je het zeker?",
+    "text": "Opslaan vervangt alle bestaande ontvangers door je uitstaande wijzigingen. Weet je het zeker?",
     "source_hash": "f497862e"
   },
   "web.domains.incoming.delete_all_recipients": {
@@ -844,15 +844,15 @@
     "source_hash": "80d3a144"
   },
   "web.domains.sso.not_configured_notice": {
-    "text": "SSO is nog niet geconfigureerd voor dit domein. Schakel single sign-on in om teamleden te laten authenticeren via de identiteitsprovider van je organisatie.",
+    "text": "SSO is nog niet geconfigureerd voor dit domein. Schakel single sign-on in om teamleden toe te staan te authenticeren met de identiteitsprovider van je organisatie.",
     "source_hash": "c439214b"
   },
   "api.domains.errors.add_admin_required": {
-    "text": "Alleen eigenaren en beheerders van de organisatie kunnen aangepaste domeinen toevoegen",
+    "text": "Alleen organisatie-eigenaren en beheerders kunnen aangepaste domeinen toevoegen",
     "source_hash": "3324aabe"
   },
   "web.domains.public_homepage": {
-    "text": "Openbare homepage",
+    "text": "Openbare startpagina",
     "source_hash": "2ae3ccba"
   },
   "web.domains.status_tooltip_active": {
@@ -860,7 +860,7 @@
     "source_hash": "e4b6a6e1"
   },
   "web.domains.status_tooltip_dns_incorrect": {
-    "text": "DNS niet geconfigureerd — klik om te herstellen",
+    "text": "DNS niet geconfigureerd — klik om te repareren",
     "source_hash": "892cb2cb"
   },
   "web.domains.status_tooltip_not_verified": {
@@ -888,7 +888,7 @@
     "source_hash": "6eae7d9c"
   },
   "web.domains.remove_domain_description": {
-    "text": "Verwijder dit domein en alle bijbehorende configuratie permanent.",
+    "text": "Verwijder dit domein en al zijn configuratie permanent.",
     "source_hash": "73946b9e"
   },
   "web.domains.add_access_denied": {
@@ -896,11 +896,11 @@
     "source_hash": "d134ca02"
   },
   "web.domains.add_access_denied_description": {
-    "text": "Je hebt geen toestemming om domeinen aan deze organisatie toe te voegen. Neem contact op met de beheerder van je organisatie.",
+    "text": "Je hebt geen toestemming om domeinen aan deze organisatie toe te voegen. Neem contact op met je organisatiebeheerder.",
     "source_hash": "25e035c6"
   },
   "web.domains.dns_widget_load_failed": {
-    "text": "Laden van DNS-widget mislukt",
+    "text": "DNS-widget laden mislukt",
     "source_hash": "5a1d8ab5"
   },
   "web.domains.dns_widget_not_available": {
@@ -908,7 +908,7 @@
     "source_hash": "4eed448b"
   },
   "web.domains.dns_widget_init_failed": {
-    "text": "Initialiseren van DNS-widget mislukt",
+    "text": "DNS-widget initialiseren mislukt",
     "source_hash": "de477585"
   },
   "web.domains.verified": {
@@ -928,7 +928,7 @@
     "source_hash": "6de1f752"
   },
   "web.domains.entitlement_required_member": {
-    "text": "Deze functie is niet beschikbaar in je huidige plan. Neem contact op met de eigenaar van je organisatie.",
+    "text": "Deze functie is niet beschikbaar in je huidige plan. Neem contact op met de organisatie-eigenaar.",
     "source_hash": "8f1688b2"
   },
   "web.domains.detail.manage": {
@@ -940,11 +940,11 @@
     "source_hash": "5697d03d"
   },
   "web.domains.detail.homepage_title": {
-    "text": "Homepageberichten",
+    "text": "Berichten op startpagina",
     "source_hash": "6360f7ec"
   },
   "web.domains.detail.homepage_description": {
-    "text": "Sta openbare toegang toe om berichten aan te maken op de homepage van je domein",
+    "text": "Sta publieke toegang toe om berichten aan te maken op de startpagina van je domein",
     "source_hash": "209b3ded"
   },
   "web.domains.detail.brand_description": {
@@ -952,23 +952,23 @@
     "source_hash": "69f7a9e8"
   },
   "web.domains.detail.sso_description": {
-    "text": "Instellingen voor single sign-on-provider",
+    "text": "Single sign-on providerinstellingen",
     "source_hash": "234e6150"
   },
   "web.domains.detail.email_description": {
-    "text": "Configuratie voor aangepaste e-mailafzender",
+    "text": "Aangepaste e-mailafzenderconfiguratie",
     "source_hash": "7fcde01b"
   },
   "web.domains.detail.incoming_description": {
-    "text": "Instellingen voor ontvangers van inkomende berichten",
+    "text": "Instellingen voor inkomende berichten",
     "source_hash": "37c1fd6d"
   },
   "web.domains.detail.signup_description": {
-    "text": "Aanmeldingsvalidatiestrategie per domein",
+    "text": "Registratievalidatiestrategie per domein",
     "source_hash": "3c5a511f"
   },
   "web.domains.detail.signin_description": {
-    "text": "Configuratie van inlogmethode per domein",
+    "text": "Inlogmethodeconfiguratie per domein",
     "source_hash": "73e01e36"
   },
   "web.domains.email.dns_check_label": {
@@ -980,27 +980,27 @@
     "source_hash": "472590ae"
   },
   "web.domains.email.test_email_title": {
-    "text": "E-mailbezorging testen",
+    "text": "Test e-mailbezorging",
     "source_hash": "c1b3dee2"
   },
   "web.domains.email.test_email_hint": {
-    "text": "Stuur jezelf een test-e-mail met de opgeslagen configuratie. Werkt zelfs wanneer de functie nog niet is ingeschakeld.",
+    "text": "Stuur een test-e-mail naar jezelf met de opgeslagen configuratie. Werkt ook als de functie nog niet is ingeschakeld.",
     "source_hash": "33e876ad"
   },
   "web.domains.email.send_test": {
-    "text": "Test versturen",
+    "text": "Stuur test",
     "source_hash": "22d7b11d"
   },
   "web.domains.email.test_email_sent": {
-    "text": "Test-e-mail succesvol verstuurd",
+    "text": "Test-e-mail succesvol verzonden",
     "source_hash": "561617fd"
   },
   "web.domains.email.test_email_failed": {
-    "text": "Versturen van test-e-mail mislukt",
+    "text": "Test-e-mail verzenden mislukt",
     "source_hash": "95ce63bc"
   },
   "web.domains.email.test_email_sent_to": {
-    "text": "Verstuurd naar {email}",
+    "text": "Verzonden naar {email}",
     "source_hash": "8ceb9588"
   },
   "web.domains.email.delivered_via": {
@@ -1012,7 +1012,7 @@
     "source_hash": "0f96c5ec"
   },
   "web.domains.incoming.feature_disabled_description": {
-    "text": "Inkomende berichten is niet ingeschakeld op deze instance. Neem contact op met je beheerder.",
+    "text": "Inkomende berichten is niet ingeschakeld op deze instantie. Neem contact op met je beheerder.",
     "source_hash": "dce981e0"
   },
   "web.domains.signin.title": {
@@ -1024,7 +1024,7 @@
     "source_hash": "f72b58b5"
   },
   "web.domains.signin.config_description": {
-    "text": "Configureer authenticatiemethoden voor inloggen op dit domein",
+    "text": "Configureer inlogauthenticatiemethodes voor dit domein",
     "source_hash": "8efce428"
   },
   "web.domains.signin.access_denied": {
@@ -1032,11 +1032,11 @@
     "source_hash": "d134ca02"
   },
   "web.domains.signin.upgrade_to_configure": {
-    "text": "Upgrade je plan om inlogmethoden voor dit domein te configureren.",
+    "text": "Upgrade je plan om inlogmethodes voor dit domein te configureren.",
     "source_hash": "e242bb74"
   },
   "web.domains.signin.not_configured_notice": {
-    "text": "De inlogconfiguratie is nog niet ingesteld voor dit domein. Configureer overrides om te bepalen welke authenticatiemethoden beschikbaar zijn op de inlogpagina van dit domein.",
+    "text": "Inlogconfiguratie is nog niet ingesteld voor dit domein. Configureer overschrijvingen om te bepalen welke authenticatiemethodes beschikbaar zijn op de inlogpagina van dit domein.",
     "source_hash": "cb788a2d"
   },
   "web.domains.signin.signin_enabled_label": {
@@ -1056,15 +1056,15 @@
     "source_hash": "edbec83f"
   },
   "web.domains.signin.restrict_to_hint": {
-    "text": "Beperk dit domein tot één authenticatiemethode. Wanneer ingesteld, wordt alleen de gekozen methode op de inlogpagina getoond.",
+    "text": "Beperk dit domein tot één authenticatiemethode. Indien ingesteld, wordt alleen de gekozen methode getoond op de inlogpagina.",
     "source_hash": "682bc4c5"
   },
   "web.domains.signin.all_methods": {
-    "text": "Alle methoden",
+    "text": "Alle methodes",
     "source_hash": "e601c19e"
   },
   "web.domains.signin.all_methods_description": {
-    "text": "Toon alle ingeschakelde authenticatiemethoden op de inlogpagina",
+    "text": "Toon alle ingeschakelde authenticatiemethodes op de inlogpagina",
     "source_hash": "62723340"
   },
   "web.domains.signin.method_password": {
@@ -1080,15 +1080,15 @@
     "source_hash": "c40224ce"
   },
   "web.domains.signin.method_sso": {
-    "text": "Single sign-on",
+    "text": "Single Sign-On",
     "source_hash": "cf7cd744"
   },
   "web.domains.signin.method_overrides_label": {
-    "text": "Methode-overrides",
+    "text": "Methode-overschrijvingen",
     "source_hash": "5496cba6"
   },
   "web.domains.signin.method_overrides_hint": {
-    "text": "Schakel individuele authenticatiemethoden voor dit domein in of uit",
+    "text": "Schakel individuele authenticatiemethodes voor dit domein in of uit",
     "source_hash": "394e3878"
   },
   "web.domains.signin.mode_question": {
@@ -1100,7 +1100,7 @@
     "source_hash": "23665425"
   },
   "web.domains.signin.mode_any_hint": {
-    "text": "Toon elke methode die op dit domein beschikbaar is. Beperk individuele methoden hieronder.",
+    "text": "Toon elke methode beschikbaar op dit domein. Beperk individuele methodes hieronder.",
     "source_hash": "2f3dcba6"
   },
   "web.domains.signin.mode_one": {
@@ -1108,7 +1108,7 @@
     "source_hash": "601f5768"
   },
   "web.domains.signin.mode_one_hint": {
-    "text": "Beperk de inlogpagina tot één methode. Alleen methoden die op dit domein beschikbaar zijn, worden vermeld.",
+    "text": "Beperk de inlogpagina tot één methode. Alleen methodes beschikbaar op dit domein worden getoond.",
     "source_hash": "58bde6d5"
   },
   "web.domains.signin.mode_disabled": {
@@ -1120,15 +1120,15 @@
     "source_hash": "8938f098"
   },
   "web.domains.signin.mode_disabled_notice": {
-    "text": "Bezoekers van de inlogpagina van dit domein zien een melding dat inloggen niet beschikbaar is, met een link terug naar de homepage. Je vorige methode-instellingen worden bewaard en hersteld wanneer je inloggen opnieuw inschakelt.",
+    "text": "Bezoekers van de inlogpagina van dit domein zien een melding dat inloggen niet beschikbaar is, met een link terug naar de startpagina. Je vorige methode-instellingen worden bewaard en hersteld wanneer je inloggen weer inschakelt.",
     "source_hash": "1a04de18"
   },
   "web.domains.signin.methods_list_label": {
-    "text": "Methoden getoond op de inlogpagina",
+    "text": "Methodes getoond op de inlogpagina",
     "source_hash": "66fd133b"
   },
   "web.domains.signin.restrict_picker_hint": {
-    "text": "Alleen methoden die op dit domein beschikbaar zijn, worden vermeld.",
+    "text": "Alleen methodes beschikbaar op dit domein worden getoond.",
     "source_hash": "c7a56f44"
   },
   "web.domains.signin.availability_always": {
@@ -1144,7 +1144,7 @@
     "source_hash": "67a926f7"
   },
   "web.domains.signin.availability_unavailable": {
-    "text": "Niet beschikbaar voor de hele site",
+    "text": "Sitebreed niet beschikbaar",
     "source_hash": "da29c1be"
   },
   "web.domains.signin.allow_on_domain": {
@@ -1156,7 +1156,7 @@
     "source_hash": "ed1a02fd"
   },
   "web.domains.signin.method_email_auth_blurb": {
-    "text": "Wachtwoordloos inloggen met magic link",
+    "text": "Wachtwoordloos inloggen via e-maillink",
     "source_hash": "7f776a85"
   },
   "web.domains.signin.method_webauthn_blurb": {
@@ -1164,7 +1164,7 @@
     "source_hash": "7d6a7bd5"
   },
   "web.domains.signin.method_sso_blurb": {
-    "text": "Externe identity provider",
+    "text": "Externe identiteitsprovider",
     "source_hash": "a3442088"
   },
   "web.domains.signin.email_auth_label": {
@@ -1176,7 +1176,7 @@
     "source_hash": "6ad82127"
   },
   "web.domains.signin.sso_enabled_label": {
-    "text": "Single sign-on",
+    "text": "Single Sign-On",
     "source_hash": "cf7cd744"
   },
   "web.domains.signin.sso_enabled_hint": {
@@ -1188,7 +1188,7 @@
     "source_hash": "dbd8e11c"
   },
   "web.domains.signin.enabled_hint": {
-    "text": "Wanneer ingeschakeld, gebruikt dit domein de hierboven geconfigureerde inloginstellingen",
+    "text": "Indien ingeschakeld, gebruikt dit domein de hierboven geconfigureerde inloginstellingen",
     "source_hash": "6259f8a2"
   },
   "web.domains.signin.save_config": {
@@ -1200,11 +1200,11 @@
     "source_hash": "10ea50d8"
   },
   "web.domains.signin.reset_to_defaults": {
-    "text": "Terugzetten naar standaardwaarden",
+    "text": "Terugzetten naar standaard",
     "source_hash": "e240e635"
   },
   "web.domains.signin.reset_confirm": {
-    "text": "Inloggen terugzetten naar de globale standaardwaarden?",
+    "text": "Inloggen terugzetten naar de globale standaarden?",
     "source_hash": "2c6bbc32"
   },
   "web.domains.signin.reset_keeps_sso": {
@@ -1216,15 +1216,15 @@
     "source_hash": "4bb21d8b"
   },
   "web.domains.signin.reset_success": {
-    "text": "Inloginstellingen teruggezet naar de globale standaardwaarden",
+    "text": "Inloginstellingen teruggezet naar de globale standaarden",
     "source_hash": "0c364d89"
   },
   "web.domains.signup.title": {
-    "text": "Aanmeldingsvalidatie",
+    "text": "Registratievalidatie",
     "source_hash": "2c34ac0a"
   },
   "web.domains.signup.config_description": {
-    "text": "Configureer aanmeldingsvalidatie voor dit domein",
+    "text": "Configureer registratievalidatie voor dit domein",
     "source_hash": "e9c81e8a"
   },
   "web.domains.signup.access_denied": {
@@ -1232,19 +1232,19 @@
     "source_hash": "d134ca02"
   },
   "web.domains.signup.upgrade_to_configure": {
-    "text": "Upgrade je plan om aanmeldingsvalidatie per domein te configureren.",
+    "text": "Upgrade je plan om registratievalidatie per domein te configureren.",
     "source_hash": "d87d6614"
   },
   "web.domains.signup.configure_signup": {
-    "text": "Aanmelding configureren",
+    "text": "Registratie configureren",
     "source_hash": "e2697662"
   },
   "web.domains.signup.not_configured_notice": {
-    "text": "Aanmeldingsvalidatie is nog niet geconfigureerd voor dit domein. Configureer een strategie om te bepalen wie zich via dit domein kan aanmelden.",
+    "text": "Registratievalidatie is nog niet geconfigureerd voor dit domein. Configureer een strategie om te bepalen wie zich via dit domein kan registreren.",
     "source_hash": "fc6c6eb8"
   },
   "web.domains.signup.site_signups_disabled_warning": {
-    "text": "Aanmeldingen zijn momenteel uitgeschakeld op siteniveau. Dit beleid per domein is geconfigureerd, maar zal geen verkeer beperken totdat aanmeldingen op de site zijn ingeschakeld.",
+    "text": "Registraties zijn momenteel uitgeschakeld op siteniveau. Dit domeinbeleid is geconfigureerd maar wordt pas actief wanneer siteregistraties worden ingeschakeld.",
     "source_hash": "c0e59f86"
   },
   "web.domains.signup.strategy_label": {
@@ -1252,19 +1252,19 @@
     "source_hash": "a2e95531"
   },
   "web.domains.signup.strategy_description": {
-    "text": "Kies hoe e-mailadressen worden gevalideerd wanneer gebruikers zich op dit domein aanmelden.",
+    "text": "Kies hoe e-mailadressen worden gevalideerd wanneer gebruikers zich registreren op dit domein.",
     "source_hash": "8e232b03"
   },
   "web.domains.signup.network_validation_warning": {
-    "text": "Deze strategie voert netwerkaanroepen uit tijdens de aanmelding, wat extra latentie kan veroorzaken of door sommige providers kan worden geblokkeerd.",
+    "text": "Deze strategie voert netwerkoproepen uit tijdens registratie, wat latentie kan toevoegen of door sommige providers kan worden geblokkeerd.",
     "source_hash": "53d4c266"
   },
   "web.domains.signup.allowed_domains_label": {
-    "text": "Toegestane aanmeldingsdomeinen",
+    "text": "Toegestane registratiedomeinen",
     "source_hash": "9b5bb5b1"
   },
   "web.domains.signup.allowed_domains_hint": {
-    "text": "Alleen deze e-maildomeinen mogen zich aanmelden. Voeg één domein per item toe.",
+    "text": "Alleen deze e-maildomeinen mogen zich registreren. Voeg één domein per regel toe.",
     "source_hash": "c082414d"
   },
   "web.domains.signup.domain_placeholder": {
@@ -1288,7 +1288,7 @@
     "source_hash": "db103925"
   },
   "web.domains.signup.enabled_hint": {
-    "text": "Wanneer ingeschakeld, gebruiken aanmeldingen op dit domein de bovenstaande strategie in plaats van het globale beleid.",
+    "text": "Indien ingeschakeld, gebruiken registraties op dit domein de bovenstaande strategie in plaats van het globale beleid.",
     "source_hash": "99de2008"
   },
   "web.domains.signup.delete_config": {
@@ -1296,7 +1296,7 @@
     "source_hash": "a9a30c7f"
   },
   "web.domains.signup.delete_confirm": {
-    "text": "Configuratie voor aanmeldingsvalidatie verwijderen? Aanmeldingen vallen terug op het globale beleid.",
+    "text": "Registratievalidatieconfiguratie verwijderen? Registraties vallen terug naar het globale beleid.",
     "source_hash": "a8c9086e"
   },
   "web.domains.signup.save_config": {
@@ -1304,27 +1304,27 @@
     "source_hash": "b2b158f2"
   },
   "web.domains.signup.update_success": {
-    "text": "Aanmeldingsvalidatie succesvol bijgewerkt",
+    "text": "Registratievalidatie succesvol bijgewerkt",
     "source_hash": "57a529ac"
   },
   "web.domains.signup.delete_success": {
-    "text": "Configuratie voor aanmeldingsvalidatie succesvol verwijderd",
+    "text": "Registratievalidatieconfiguratie succesvol verwijderd",
     "source_hash": "eb6add4d"
   },
   "web.domains.signup.domain_overrides_label": {
-    "text": "Domein-overrides",
+    "text": "Domeinoverschrijvingen",
     "source_hash": "d25da3cd"
   },
   "web.domains.signup.domain_overrides_hint": {
-    "text": "Overschrijf globale aanmeldingsinstellingen voor dit domein",
+    "text": "Overschrijf globale registratie-instellingen voor dit domein",
     "source_hash": "53101057"
   },
   "web.domains.signup.signup_enabled_label": {
-    "text": "Aanmelding ingeschakeld",
+    "text": "Registratie ingeschakeld",
     "source_hash": "296ac66d"
   },
   "web.domains.signup.signup_enabled_hint": {
-    "text": "Overschrijf of aanmelding is ingeschakeld voor dit domein",
+    "text": "Overschrijf of registratie is ingeschakeld voor dit domein",
     "source_hash": "2ee146b6"
   },
   "web.domains.signup.autoverify_label": {
@@ -1344,7 +1344,7 @@
     "source_hash": "a45a37dd"
   },
   "web.domains.sso.enforce_moved_notice": {
-    "text": "Om SSO te vereisen voor alle inlogpogingen op dit domein, configureer je dit in de inloginstellingen van het domein. De SSO-only-modus beperkt de inlogpagina tot de hier geconfigureerde SSO-provider.",
+    "text": "Om SSO te vereisen voor alle inlogpogingen op dit domein, configureer het in de inloginstellingen van het domein. SSO-only modus beperkt de inlogpagina tot de hier geconfigureerde SSO-provider.",
     "source_hash": "d26627a5"
   },
   "web.domains.sso.edit_credentials": {
@@ -1368,15 +1368,15 @@
     "source_hash": "3ba71f78"
   },
   "web.domains.add.echo_label": {
-    "text": "Je beveiligde links komen op",
+    "text": "Je berichtlinks komen te staan op",
     "source_hash": "ad60b17d"
   },
   "web.domains.add.apex_question": {
-    "text": "Dat is je hele domein — waar moeten de beveiligde links komen?",
+    "text": "Dat is je hele domein — waar moeten berichtlinks komen?",
     "source_hash": "efacad1b"
   },
   "web.domains.add.apex_help": {
-    "text": "Een subdomein laat de rest van {domain} ongemoeid.",
+    "text": "Een subdomein laat de rest van {domain} onaangetast.",
     "source_hash": "0f7e6181"
   },
   "web.domains.add.recommended": {
@@ -1396,19 +1396,19 @@
     "source_hash": "5c23c007"
   },
   "web.domains.add.root_domain_label": {
-    "text": "Mijn hoofddomein gebruiken",
+    "text": "Gebruik mijn hoofddomein",
     "source_hash": "9fbbe253"
   },
   "web.domains.add.root_domain_description": {
-    "text": "Dit wijst heel {domain} naar ons — de site daar wordt niet meer geresolved — en vereist een A- / ALIAS-record.",
+    "text": "Dit verwijst het hele {domain} naar ons — de site daar stopt met werken — en vereist een A / ALIAS-record.",
     "source_hash": "fae93847"
   },
   "web.domains.add.error_unrecognized_suffix": {
-    "text": "“.{0}” is geen herkende domeinextensie — controleer op een typfout (bijv. {1}).",
+    "text": "\".{0}\" is geen herkende domeinuitgang — controleer op een typfout (bijv. {1}).",
     "source_hash": "4b90033d"
   },
   "web.domains.add.error_invalid_hostname": {
-    "text": "Voer een geldige hostnaam in — letters, cijfers, losse punten en streepjes (bijv. {0}).",
+    "text": "Voer een geldige hostnaam in — letters, cijfers, enkele punten en streepjes (bijv. {0}).",
     "source_hash": "c4ceabc1"
   },
   "web.domains.add.error_empty": {
@@ -1420,15 +1420,15 @@
     "source_hash": "73f8ab40"
   },
   "web.domains.auth_override.workspace_default_badge": {
-    "text": "Werkruimtestandaard",
+    "text": "Werkruimte-standaard",
     "source_hash": "da3706ee"
   },
   "web.domains.detail.dns_title": {
-    "text": "DNS-installatie",
+    "text": "DNS-configuratie",
     "source_hash": "6c63df31"
   },
   "web.domains.detail.dns_description": {
-    "text": "Wijs je domein naar deze server met een CNAME-record",
+    "text": "Verwijs je domein naar deze server met een CNAME-record",
     "source_hash": "080f84f0"
   },
   "web.domains.dns.title": {
@@ -1436,11 +1436,11 @@
     "source_hash": "da78c35d"
   },
   "web.domains.dns.point_domain_intro": {
-    "text": "Wijs",
+    "text": "Verwijs",
     "source_hash": "2fc0c524"
   },
   "web.domains.dns.point_domain_outro": {
-    "text": "naar deze server door het volgende DNS-record bij je provider toe te voegen.",
+    "text": "naar deze server door het volgende DNS-record toe te voegen bij je provider.",
     "source_hash": "8d260c05"
   },
   "web.domains.dns.cname_heading": {
@@ -1452,7 +1452,7 @@
     "source_hash": "41135375"
   },
   "web.domains.dns.apex_notice": {
-    "text": "Apex-domeinen (hoofddomeinen) kunnen geen CNAME-record gebruiken. Gebruik in plaats daarvan het ALIAS- of ANAME-record van je DNS-provider, of wijs een A-record naar het IP-adres van je server.",
+    "text": "Apex (hoofd)domeinen kunnen geen CNAME-record gebruiken. Gebruik in plaats daarvan het ALIAS- of ANAME-record van je DNS-provider, of verwijs een A-record naar het IP-adres van je server.",
     "source_hash": "2d1c3298"
   },
   "web.domains.email.from_address_local_placeholder": {
@@ -1460,31 +1460,31 @@
     "source_hash": "510d274d"
   },
   "web.domains.homepage.title": {
-    "text": "Homepage",
+    "text": "Startpagina",
     "source_hash": "9e3391e9"
   },
   "web.domains.homepage.description": {
-    "text": "Wat bezoekers kunnen doen op de homepage van je domein",
+    "text": "Wat bezoekers kunnen doen op de startpagina van je domein",
     "source_hash": "974d159e"
   },
   "web.domains.homepage.option_private_title": {
-    "text": "Privélandingspagina",
+    "text": "Privé-landingspagina",
     "source_hash": "dfd5bd1c"
   },
   "web.domains.homepage.option_private_description": {
-    "text": "Bezoekers zien een privélandingspagina zonder interactief formulier",
+    "text": "Bezoekers zien een privé-landingspagina zonder interactief formulier",
     "source_hash": "4d9aaf6f"
   },
   "web.domains.homepage.option_create_title": {
-    "text": "Formulier voor het aanmaken van berichten",
+    "text": "Bericht aanmaken formulier",
     "source_hash": "6539dfc1"
   },
   "web.domains.homepage.option_create_description": {
-    "text": "Bezoekers kunnen hun eigen beveiligde links aanmaken",
+    "text": "Bezoekers kunnen hun eigen berichtlinks aanmaken",
     "source_hash": "884310f4"
   },
   "web.domains.homepage.option_incoming_title": {
-    "text": "Formulier voor inkomende berichten",
+    "text": "Inkomende berichten formulier",
     "source_hash": "882997bf"
   },
   "web.domains.homepage.option_incoming_description": {
@@ -1492,7 +1492,7 @@
     "source_hash": "86bdaedb"
   },
   "web.domains.homepage.incoming_requires_recipients": {
-    "text": "Vereist dat inkomende berichten zijn ingeschakeld met minstens één ontvanger",
+    "text": "Vereist dat inkomende berichten is ingeschakeld met minimaal één ontvanger",
     "source_hash": "0462611d"
   },
   "web.domains.homepage.configure_recipients": {
@@ -1500,11 +1500,11 @@
     "source_hash": "1c3df8b4"
   },
   "web.domains.homepage.status_private": {
-    "text": "Privélandingspagina",
+    "text": "Privé-landingspagina",
     "source_hash": "dfd5bd1c"
   },
   "web.domains.homepage.status_create": {
-    "text": "Openbaar: bezoekers maken berichten aan",
+    "text": "Openbaar: bezoekers maken berichten",
     "source_hash": "251cfb95"
   },
   "web.domains.homepage.status_incoming": {
@@ -1512,7 +1512,7 @@
     "source_hash": "baa926b8"
   },
   "web.domains.homepage.status_incoming_unready": {
-    "text": "Inkomend niet gereed — privélandingspagina wordt getoond",
+    "text": "Inkomend niet gereed — toont privé-landingspagina",
     "source_hash": "a5cc237c"
   },
   "web.domains.homepage.badge_incoming": {
@@ -1520,11 +1520,11 @@
     "source_hash": "e301820a"
   },
   "web.domains.homepage.update_success": {
-    "text": "Homepage-instellingen opgeslagen",
+    "text": "Startpagina-instellingen opgeslagen",
     "source_hash": "4eac9f45"
   },
   "web.domains.homepage.homepage_uses_incoming_warning": {
-    "text": "De homepage van dit domein toont momenteel het formulier voor inkomende berichten. Als je inkomende berichten uitschakelt of alle ontvangers verwijdert, schakelt de homepage over naar een privélandingspagina totdat inkomend weer gereed is.",
+    "text": "De startpagina van dit domein toont momenteel het inkomende berichten formulier. Het uitschakelen van inkomende berichten of het verwijderen van alle ontvangers schakelt de startpagina over naar een privé-landingspagina totdat inkomend weer gereed is.",
     "source_hash": "cc0d4997"
   },
   "web.domains.signin.effective_status_label": {
@@ -1532,15 +1532,15 @@
     "source_hash": "d8b884c3"
   },
   "web.domains.signin.dormant_notice": {
-    "text": "Inloggen is werkruimtebreed uitgeschakeld, dus het is op elk domein niet beschikbaar. Je instellingen hier blijven bewaard en worden van kracht wanneer inloggen voor de werkruimte weer wordt ingeschakeld.",
+    "text": "Inloggen is werkruimtebreed uitgeschakeld, dus het is niet beschikbaar op elk domein. Je instellingen hier worden bewaard en worden van kracht wanneer werkruimte-inloggen weer wordt ingeschakeld.",
     "source_hash": "723d35dc"
   },
   "web.domains.signup.effective_status_label": {
-    "text": "Aanmeldingen op dit domein",
+    "text": "Registraties op dit domein",
     "source_hash": "115ab21b"
   },
   "web.domains.signup.dormant_notice": {
-    "text": "Aanmeldingen zijn werkruimtebreed uitgeschakeld, dus ze zijn op elk domein niet beschikbaar. Je instellingen hier blijven bewaard en worden van kracht wanneer aanmeldingen voor de werkruimte weer worden ingeschakeld.",
+    "text": "Registraties zijn werkruimtebreed uitgeschakeld, dus ze zijn niet beschikbaar op elk domein. Je instellingen hier worden bewaard en worden van kracht wanneer werkruimteregistraties weer worden ingeschakeld.",
     "source_hash": "49faefe4"
   }
 }

--- a/locales/content/nl/workspace-domains.json
+++ b/locales/content/nl/workspace-domains.json
@@ -148,7 +148,7 @@
     "source_hash": "00c89609"
   },
   "web.domains.and_status": {
-    "text": "& Status",
+    "text": "en status",
     "source_hash": "fe871d2c"
   },
   "web.domains.domain": {
@@ -268,7 +268,7 @@
     "source_hash": "afa10517"
   },
   "web.domains.secrets_example_dot_com": {
-    "text": "secrets.example.com",
+    "text": "secrets.voorbeeld.com",
     "source_hash": "9ea4d0d6"
   },
   "web.domains.customize_your_domain_branding": {
@@ -1080,7 +1080,7 @@
     "source_hash": "c40224ce"
   },
   "web.domains.signin.method_sso": {
-    "text": "Single Sign-On",
+    "text": "Single sign-on",
     "source_hash": "cf7cd744"
   },
   "web.domains.signin.method_overrides_label": {
@@ -1176,7 +1176,7 @@
     "source_hash": "6ad82127"
   },
   "web.domains.signin.sso_enabled_label": {
-    "text": "Single Sign-On",
+    "text": "Single sign-on",
     "source_hash": "cf7cd744"
   },
   "web.domains.signin.sso_enabled_hint": {

--- a/locales/content/nl/workspace-organizations.json
+++ b/locales/content/nl/workspace-organizations.json
@@ -32,7 +32,7 @@
     "source_hash": "97d0b117"
   },
   "web.organizations.no_organizations_description": {
-    "text": "Werkruimtes bieden geünificeerde facturatie en administratie. Begin met het aanmaken van je eerste werkruimte.",
+    "text": "Werkruimtes bieden gecentraliseerde facturering en administratie. Begin met het aanmaken van je eerste werkruimte.",
     "source_hash": "f09d4987"
   },
   "web.organizations.no_description": {
@@ -88,7 +88,7 @@
     "source_hash": "513332d3"
   },
   "web.organizations.contact_email_help": {
-    "text": "Primair contact voor facturering en administratieve meldingen",
+    "text": "Primair contact voor facturerings- en administratieve meldingen",
     "source_hash": "ee81c03d"
   },
   "web.organizations.select_organization": {
@@ -96,7 +96,7 @@
     "source_hash": "70a8ce66"
   },
   "web.organizations.switcher_locked": {
-    "text": "Werkruimtewisseling niet beschikbaar op deze pagina",
+    "text": "Werkruimte wisselen niet beschikbaar op deze pagina",
     "source_hash": "c34114ac"
   },
   "web.organizations.not_found": {
@@ -140,7 +140,7 @@
     "source_hash": "de322f87"
   },
   "web.organizations.billing_settings": {
-    "text": "Facturering en abonnement",
+    "text": "Facturering & abonnement",
     "source_hash": "896913f0"
   },
   "web.organizations.save_changes": {
@@ -160,7 +160,7 @@
     "source_hash": "080a7f11"
   },
   "web.organizations.billing_email_managed_on_billing": {
-    "text": "Facturerings-e-mail kan worden gewijzigd op de pagina Factureringsoverzicht",
+    "text": "Facturerings-e-mail kan worden gewijzigd op de factureringsoverzichtspagina",
     "source_hash": "8a131415"
   },
   "web.organizations.billing_coming_soon": {
@@ -168,7 +168,7 @@
     "source_hash": "d3e0ec75"
   },
   "web.organizations.billing_coming_soon_description": {
-    "text": "Geünificeerd facturering- en abonnementsbeheer wordt beschikbaar in een toekomstige release.",
+    "text": "Gecentraliseerde facturering en abonnementsbeheer komt beschikbaar in een toekomstige release.",
     "source_hash": "8836108f"
   },
   "web.organizations.about_title": {
@@ -176,7 +176,7 @@
     "source_hash": "2f3e2ad8"
   },
   "web.organizations.about_description": {
-    "text": "Organisaties bieden geünificeerde facturering en administratie voor gecentraliseerd beheer.",
+    "text": "Organisaties bieden gecentraliseerde facturering en administratie voor gecentraliseerd beheer.",
     "source_hash": "910f97a8"
   },
   "web.organizations.single_user_info_title": {
@@ -184,7 +184,7 @@
     "source_hash": "810a6c86"
   },
   "web.organizations.single_user_info_description": {
-    "text": "Werk hier je bedrijfsnaam en organisatiegegevens bij. Deze informatie helpt je account te personaliseren en kan worden gebruikt voor brandingfuncties in de toekomst.",
+    "text": "Werk hier je bedrijfsnaam en organisatiegegevens bij. Deze informatie helpt je account te personaliseren en kan in de toekomst worden gebruikt voor brandingfuncties.",
     "source_hash": "96b2e4b5"
   },
   "web.organizations.getting_started_title": {
@@ -300,11 +300,11 @@
     "source_hash": "61dd2085"
   },
   "web.organizations.members.role_updated": {
-    "text": "Lidrol succesvol bijgewerkt",
+    "text": "Rol van lid succesvol bijgewerkt",
     "source_hash": "d0d332c6"
   },
   "web.organizations.members.role_update_error": {
-    "text": "Lidrol bijwerken mislukt",
+    "text": "Rol van lid bijwerken mislukt",
     "source_hash": "17d5ca66"
   },
   "web.organizations.members.member_removed": {
@@ -376,11 +376,11 @@
     "source_hash": "0bfb50ed"
   },
   "web.organizations.invitations.pending_invitations": {
-    "text": "Openstaande uitnodigingen",
+    "text": "Uitnodigingen in behandeling",
     "source_hash": "b327e8a8"
   },
   "web.organizations.invitations.no_pending_invitations": {
-    "text": "Geen openstaande uitnodigingen",
+    "text": "Geen uitnodigingen in behandeling",
     "source_hash": "275814da"
   },
   "web.organizations.invitations.email_address": {
@@ -388,7 +388,7 @@
     "source_hash": "09bf25ef"
   },
   "web.organizations.invitations.email_placeholder": {
-    "text": "lid{'@'}voorbeeld.com",
+    "text": "lid{'@'}example.com",
     "source_hash": "7fd425f7"
   },
   "web.organizations.invitations.role": {
@@ -396,19 +396,19 @@
     "source_hash": "14736a2e"
   },
   "web.organizations.invitations.send_invite": {
-    "text": "Uitnodiging verzenden",
+    "text": "Uitnodiging versturen",
     "source_hash": "d076aa0f"
   },
   "web.organizations.invitations.invite_sent": {
-    "text": "Uitnodiging succesvol verzonden",
+    "text": "Uitnodiging succesvol verstuurd",
     "source_hash": "81facbe6"
   },
   "web.organizations.invitations.invite_error": {
-    "text": "Uitnodiging verzenden mislukt",
+    "text": "Uitnodiging versturen mislukt",
     "source_hash": "cedbf507"
   },
   "web.organizations.invitations.resend": {
-    "text": "Opnieuw verzenden",
+    "text": "Opnieuw versturen",
     "source_hash": "1f948437"
   },
   "web.organizations.invitations.revoke": {
@@ -416,11 +416,11 @@
     "source_hash": "87e6d00b"
   },
   "web.organizations.invitations.resend_success": {
-    "text": "Uitnodiging succesvol opnieuw verzonden",
+    "text": "Uitnodiging succesvol opnieuw verstuurd",
     "source_hash": "099eb255"
   },
   "web.organizations.invitations.resend_error": {
-    "text": "Uitnodiging opnieuw verzenden mislukt",
+    "text": "Uitnodiging opnieuw versturen mislukt",
     "source_hash": "82750487"
   },
   "web.organizations.invitations.revoke_success": {
@@ -444,15 +444,15 @@
     "source_hash": "f6725f3a"
   },
   "web.organizations.invitations.resent_count": {
-    "text": "{count} keer opnieuw verzonden",
+    "text": "{count} keer opnieuw verstuurd",
     "source_hash": "e71d1c6d"
   },
   "web.organizations.invitations.resent_count_plural": {
-    "text": "{count} keer opnieuw verzonden",
+    "text": "{count} keer opnieuw verstuurd",
     "source_hash": "e58d803d"
   },
   "web.organizations.invitations.status.pending": {
-    "text": "In afwachting",
+    "text": "In behandeling",
     "source_hash": "331551b0"
   },
   "web.organizations.invitations.status.accepted": {
@@ -492,7 +492,7 @@
     "source_hash": "59936259"
   },
   "web.organizations.invitations.you_are_invited": {
-    "text": "Je bent uitgenodigd om deel te nemen aan",
+    "text": "Je bent uitgenodigd om lid te worden van",
     "source_hash": "60e635c6"
   },
   "web.organizations.invitations.invited_as": {
@@ -536,7 +536,7 @@
     "source_hash": "5e3f8df8"
   },
   "web.organizations.invitations.upgrade_prompt": {
-    "text": "Leden uitnodigen vereist een betaald plan. Upgrade om medewerkers aan je organisatie toe te voegen.",
+    "text": "Ledenuitnodigingen vereisen een betaald plan. Upgrade om medewerkers aan je organisatie toe te voegen.",
     "source_hash": "47d0eeab"
   },
   "web.organizations.paid_badge": {
@@ -544,7 +544,7 @@
     "source_hash": "957b0b87"
   },
   "web.organizations.early_supporter_badge": {
-    "text": "Vroege supporter",
+    "text": "Early Supporter",
     "source_hash": "e67d2ef8"
   },
   "web.organizations.member_count": {
@@ -572,11 +572,11 @@
     "source_hash": "ccf9745d"
   },
   "web.organizations.invitations.expires_in_days": {
-    "text": "Nog {days}d",
+    "text": "nog {days}d",
     "source_hash": "50ff6f2b"
   },
   "web.organizations.invitations.expires_in_hours": {
-    "text": "Nog {hours}u",
+    "text": "nog {hours}u",
     "source_hash": "ff56d105"
   },
   "web.organizations.invitations.expires_soon": {
@@ -588,7 +588,7 @@
     "source_hash": "5db5c812"
   },
   "web.organizations.sso.description": {
-    "text": "Configureer SSO om leden te laten inloggen met de identiteitsprovider van je organisatie",
+    "text": "Configureer SSO om leden toe te staan in te loggen met de identiteitsprovider van je organisatie",
     "source_hash": "464f0a8b"
   },
   "web.organizations.sso.provider_type": {
@@ -604,7 +604,7 @@
     "source_hash": "18d67c99"
   },
   "web.organizations.sso.display_name_hint": {
-    "text": "Een vriendelijke naam die gebruikers zien bij het inloggen",
+    "text": "Een vriendelijke naam getoond aan gebruikers bij het inloggen",
     "source_hash": "a83f1fba"
   },
   "web.organizations.sso.display_name_placeholder": {
@@ -612,11 +612,11 @@
     "source_hash": "43c655c5"
   },
   "web.organizations.sso.client_id": {
-    "text": "Client-ID",
+    "text": "Client ID",
     "source_hash": "8726db01"
   },
   "web.organizations.sso.client_id_placeholder": {
-    "text": "Je OAuth client-ID",
+    "text": "Je OAuth client ID",
     "source_hash": "830723da"
   },
   "web.organizations.sso.client_secret": {
@@ -632,7 +632,7 @@
     "source_hash": "98bc3b40"
   },
   "web.organizations.sso.tenant_id": {
-    "text": "Tenant-ID",
+    "text": "Tenant ID",
     "source_hash": "de1f5fff"
   },
   "web.organizations.sso.tenant_id_hint": {
@@ -644,11 +644,11 @@
     "source_hash": "1a166316"
   },
   "web.organizations.sso.issuer": {
-    "text": "Issuer-URL",
+    "text": "Issuer URL",
     "source_hash": "4d03ba8a"
   },
   "web.organizations.sso.issuer_hint": {
-    "text": "De OIDC discovery-URL voor je identiteitsprovider",
+    "text": "De OIDC discovery URL voor je identiteitsprovider",
     "source_hash": "6102d81b"
   },
   "web.organizations.sso.issuer_placeholder": {
@@ -684,7 +684,7 @@
     "source_hash": "d10d0801"
   },
   "web.organizations.sso.enabled_hint": {
-    "text": "Wanneer ingeschakeld kunnen organisatieleden inloggen met deze SSO-provider",
+    "text": "Indien ingeschakeld, kunnen organisatieleden inloggen met deze SSO-provider",
     "source_hash": "d7da2fa2"
   },
   "web.organizations.sso.save_config": {
@@ -728,7 +728,7 @@
     "source_hash": "c02977b0"
   },
   "web.organizations.sso.test_connection_hint": {
-    "text": "Controleer of de identiteitsprovider bereikbaar is (valideert geen inloggegevens)",
+    "text": "Verifieer dat de identiteitsprovider bereikbaar is (valideert geen inloggegevens)",
     "source_hash": "22a23b68"
   },
   "web.organizations.sso.test_button": {
@@ -768,7 +768,7 @@
     "source_hash": "af5b799e"
   },
   "web.organizations.sso.provider_type_locked_hint": {
-    "text": "Verwijder eerst deze configuratie om van provider te wisselen",
+    "text": "Om van provider te wisselen, verwijder eerst deze configuratie",
     "source_hash": "0a1027ff"
   },
   "web.organizations.sso.status_not_configured": {
@@ -780,39 +780,39 @@
     "source_hash": "c8d058eb"
   },
   "api.organizations.errors.owner_required": {
-    "text": "Alleen de eigenaar van de organisatie kan deze actie uitvoeren",
+    "text": "Alleen de organisatie-eigenaar kan deze actie uitvoeren",
     "source_hash": "5a729e94"
   },
   "api.organizations.errors.admin_required": {
-    "text": "Alleen eigenaren en beheerders van de organisatie kunnen deze actie uitvoeren",
+    "text": "Alleen organisatie-eigenaren en beheerders kunnen deze actie uitvoeren",
     "source_hash": "cd9e8c0e"
   },
   "api.organizations.errors.member_required": {
-    "text": "Je moet lid zijn van de organisatie om deze actie uit te voeren",
+    "text": "Je moet een organisatielid zijn om deze actie uit te voeren",
     "source_hash": "f66f4a60"
   },
   "api.organizations.invitations.errors.create_admin_required": {
-    "text": "Alleen eigenaren en beheerders van de organisatie kunnen uitnodigingen aanmaken",
+    "text": "Alleen organisatie-eigenaren en beheerders kunnen uitnodigingen aanmaken",
     "source_hash": "777d150d"
   },
   "api.organizations.invitations.errors.resend_admin_required": {
-    "text": "Alleen eigenaren en beheerders van de organisatie kunnen uitnodigingen opnieuw versturen",
+    "text": "Alleen organisatie-eigenaren en beheerders kunnen uitnodigingen opnieuw versturen",
     "source_hash": "6a857d59"
   },
   "api.organizations.invitations.errors.view_admin_required": {
-    "text": "Alleen eigenaren en beheerders van de organisatie kunnen uitnodigingen bekijken",
+    "text": "Alleen organisatie-eigenaren en beheerders kunnen uitnodigingen bekijken",
     "source_hash": "42f5878b"
   },
   "api.organizations.invitations.errors.revoke_admin_required": {
-    "text": "Alleen eigenaren en beheerders van de organisatie kunnen uitnodigingen intrekken",
+    "text": "Alleen organisatie-eigenaren en beheerders kunnen uitnodigingen intrekken",
     "source_hash": "52f73c8a"
   },
   "api.organizations.invitations.errors.email_required": {
-    "text": "E-mail is verplicht",
+    "text": "E-mail is vereist",
     "source_hash": "aae92911"
   },
   "api.organizations.invitations.errors.email_invalid": {
-    "text": "Ongeldige e-mailindeling",
+    "text": "Ongeldig e-mailformaat",
     "source_hash": "0bcecf66"
   },
   "api.organizations.invitations.errors.role_invalid": {
@@ -828,7 +828,7 @@
     "source_hash": "8eb45780"
   },
   "api.organizations.invitations.errors.already_pending": {
-    "text": "Er is al een uitnodiging in behandeling voor dit e-mailadres",
+    "text": "Uitnodiging al in behandeling voor dit e-mailadres",
     "source_hash": "7f5e3093"
   },
   "api.organizations.invitations.errors.member_limit_reached": {
@@ -840,19 +840,19 @@
     "source_hash": "775ba9eb"
   },
   "api.organizations.invitations.errors.cannot_resend_non_pending": {
-    "text": "Alleen uitnodigingen in behandeling kunnen opnieuw worden verstuurd",
+    "text": "Kan alleen uitnodigingen in behandeling opnieuw versturen",
     "source_hash": "b7578b3e"
   },
   "api.organizations.invitations.errors.cannot_revoke_non_pending": {
-    "text": "Alleen uitnodigingen in behandeling kunnen worden ingetrokken",
+    "text": "Kan alleen uitnodigingen in behandeling intrekken",
     "source_hash": "732b78a6"
   },
   "api.organizations.invitations.errors.resend_limit_reached": {
-    "text": "Maximale limiet voor opnieuw versturen (%{max}) bereikt",
+    "text": "Maximale herzendingslimiet (%{max}) bereikt",
     "source_hash": "8dc96729"
   },
   "api.organizations.invitations.errors.accept_token_required": {
-    "text": "Token is verplicht",
+    "text": "Token is vereist",
     "source_hash": "6c718161"
   },
   "api.organizations.invitations.errors.accept_organization_gone": {
@@ -872,7 +872,7 @@
     "source_hash": "f56ad547"
   },
   "web.organizations.entitlements_title": {
-    "text": "Organisatie-entitlements",
+    "text": "Organisatierechten",
     "source_hash": "36054d4f"
   },
   "web.organizations.page_description_short": {
@@ -880,7 +880,7 @@
     "source_hash": "524fcb9a"
   },
   "web.organizations.delete_organization_remove_domains_first": {
-    "text": "Verwijder alle aangepaste domeinen voordat je deze organisatie verwijdert.",
+    "text": "Verwijder eerst alle aangepaste domeinen voordat je deze organisatie verwijdert.",
     "source_hash": "44678715"
   },
   "web.organizations.default_org_delete_notice_title": {
@@ -888,7 +888,7 @@
     "source_hash": "9191d915"
   },
   "web.organizations.default_org_delete_notice_before": {
-    "text": "Dit is je standaardorganisatie en kan niet vanuit het dashboard worden verwijderd. Neem voor het verwijderen contact op via het",
+    "text": "Dit is je standaardorganisatie en kan niet worden verwijderd vanuit het dashboard. Om deze te verwijderen, neem contact op via het",
     "source_hash": "e203607d"
   },
   "web.organizations.default_org_delete_notice_link": {
@@ -904,7 +904,7 @@
     "source_hash": "d534cff9"
   },
   "web.organizations.leave_organization_warning": {
-    "text": "Je verliest de toegang tot deze organisatie en haar resources.",
+    "text": "Je verliest toegang tot deze organisatie en de bronnen ervan.",
     "source_hash": "e9daab07"
   },
   "web.organizations.leave_organization_confirm_title": {
@@ -920,7 +920,7 @@
     "source_hash": "fc803eb3"
   },
   "web.organizations.leave_error": {
-    "text": "Organisatie verlaten is mislukt",
+    "text": "Organisatie verlaten mislukt",
     "source_hash": "6cb6af43"
   },
   "web.organizations.organizations": {
@@ -940,7 +940,7 @@
     "source_hash": "76c5505f"
   },
   "web.organizations.invitations.email_locked_hint": {
-    "text": "Deze uitnodiging is naar dit e-mailadres verzonden",
+    "text": "Deze uitnodiging is verstuurd naar dit e-mailadres",
     "source_hash": "2cff7075"
   },
   "web.organizations.invitations.signup_continue": {
@@ -956,7 +956,7 @@
     "source_hash": "2d14f9b0"
   },
   "web.organizations.invitations.go_to_organizations": {
-    "text": "Naar Organisaties",
+    "text": "Ga naar organisaties",
     "source_hash": "2afa38a3"
   },
   "web.organizations.invitations.already_member": {
@@ -964,7 +964,7 @@
     "source_hash": "f56ad547"
   },
   "web.organizations.invitations.join_organization": {
-    "text": "Lid worden van {orgName}",
+    "text": "Word lid van {orgName}",
     "source_hash": "1aea9194"
   },
   "web.organizations.invitations.sign_in_to_join": {
@@ -988,7 +988,7 @@
     "source_hash": "26cdb6b8"
   },
   "web.organizations.sso.view_discovery_document": {
-    "text": "Discovery-document bekijken",
+    "text": "Bekijk discovery document",
     "source_hash": "513bda60"
   },
   "web.organizations.sso.callback_url": {
@@ -996,7 +996,7 @@
     "source_hash": "dc297ae9"
   },
   "web.organizations.sso.callback_url_hint": {
-    "text": "Voeg deze URL toe aan de toegestane redirect-URI's van je identity provider",
+    "text": "Voeg deze URL toe aan de toegestane redirect URI's van je identiteitsprovider",
     "source_hash": "65d55683"
   },
   "web.organizations.sso.enforce_sso_only": {
@@ -1004,7 +1004,7 @@
     "source_hash": "b3a3f694"
   },
   "web.organizations.sso.enforce_sso_only_hint": {
-    "text": "Vereis SSO voor alle aanmeldingen op dit domein. Wanneer ingeschakeld, wordt authenticatie met wachtwoord uitgeschakeld.",
+    "text": "Vereist SSO voor alle inlogpogingen op dit domein. Indien ingeschakeld, wordt wachtwoordauthenticatie uitgeschakeld.",
     "source_hash": "19432210"
   },
   "web.organizations.sso.grant_org_scope": {
@@ -1012,7 +1012,7 @@
     "source_hash": "2070cef2"
   },
   "web.organizations.sso.grant_org_scope_hint": {
-    "text": "Nieuwe leden die via de SSO van dit domein lid worden, krijgen toegang tot alle domeinen van de organisatie. Bestaande leden worden niet beïnvloed. Wanneer uitgeschakeld (standaard), hebben nieuwe leden alleen toegang tot dit domein.",
+    "text": "Nieuwe leden die via de SSO van dit domein lid worden, krijgen toegang tot alle organisatiedomeinen. Bestaande leden worden niet beïnvloed. Indien uitgeschakeld (standaard), hebben nieuwe leden alleen toegang tot dit domein.",
     "source_hash": "2ac9f345"
   },
   "web.organizations.sso.no_domains": {
@@ -1020,7 +1020,7 @@
     "source_hash": "8a7fbb76"
   },
   "web.organizations.sso.no_domains_description": {
-    "text": "Voeg een domein toe en verifieer het voordat je er SSO voor configureert.",
+    "text": "Voeg een domein toe en verifieer het voordat je SSO ervoor configureert.",
     "source_hash": "e825d13a"
   },
   "web.organizations.tabs.team": {
@@ -1034,5 +1034,153 @@
   "web.organizations.create_workspace": {
     "text": "Werkruimte aanmaken",
     "source_hash": "c63c14cf"
+  },
+  "web.organizations.organization_id": {
+    "text": "Organisatie-ID",
+    "source_hash": "1f466322"
+  },
+  "web.organizations.organization_id_hint": {
+    "text": "Gebruik dit ID bij contact met support of voor het specificeren van API-verzoeken voor deze organisatie. Het is geen inloggegevens.",
+    "source_hash": "29549b3a"
+  },
+  "web.organizations.audit.title": {
+    "text": "Berichtactiviteit",
+    "source_hash": "6d6d41f3"
+  },
+  "web.organizations.audit.description": {
+    "text": "Audittrail van het aanmaken en openen van berichten geregistreerd voor deze organisatie.",
+    "source_hash": "553c564b"
+  },
+  "web.organizations.audit.country_unknown": {
+    "text": "Onbekend",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.empty_title": {
+    "text": "Nog geen activiteit",
+    "source_hash": "0a12b92c"
+  },
+  "web.organizations.audit.empty_description": {
+    "text": "Het aanmaken en openen van berichten verschijnt hier wanneer je team berichten deelt.",
+    "source_hash": "62fb14c2"
+  },
+  "web.organizations.audit.capped_notice": {
+    "text": "Alleen de nieuwste {max} gebeurtenissen worden bewaard; oudere activiteit is verwijderd.",
+    "source_hash": "da7901e2"
+  },
+  "web.organizations.audit.collection_paused_notice": {
+    "text": "Gebeurtenisverzameling is gepauzeerd; nieuwe berichtactiviteit wordt niet geregistreerd.",
+    "source_hash": "cb09d147"
+  },
+  "web.organizations.audit.load_error": {
+    "text": "Kan berichtactiviteit niet laden.",
+    "source_hash": "52fde814"
+  },
+  "web.organizations.audit.contract_mismatch": {
+    "text": "De activiteitsgegevens van de server konden niet worden gelezen. De trail is niet leeg — het kan alleen nu niet worden weergegeven.",
+    "source_hash": "db0d007a"
+  },
+  "web.organizations.audit.retry": {
+    "text": "Probeer opnieuw",
+    "source_hash": "d8b8392e"
+  },
+  "web.organizations.audit.showing_range": {
+    "text": "{from}–{to} van {total} weergeven",
+    "source_hash": "c329279d"
+  },
+  "web.organizations.audit.upgrade_prompt": {
+    "text": "Berichtactiviteit vereist een plan met auditlogs. Upgrade om te zien wie berichten heeft aangemaakt, bekeken en onthuld in deze organisatie.",
+    "source_hash": "453649ce"
+  },
+  "web.organizations.audit.role_required": {
+    "text": "Berichtactiviteit is beschikbaar voor organisatie-eigenaren en beheerders.",
+    "source_hash": "e066ec63"
+  },
+  "web.organizations.audit.actors.creator": {
+    "text": "Maker",
+    "source_hash": "88447b83"
+  },
+  "web.organizations.audit.actors.authenticated_other": {
+    "text": "Een andere ingelogde gebruiker",
+    "source_hash": "ee45aa5a"
+  },
+  "web.organizations.audit.actors.anonymous": {
+    "text": "Anoniem",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.organizations.audit.actors.system": {
+    "text": "Systeem",
+    "source_hash": "6725e7bb"
+  },
+  "web.organizations.audit.actors.unknown": {
+    "text": "Onbekend",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.columns.event": {
+    "text": "Gebeurtenis",
+    "source_hash": "4e1f49a9"
+  },
+  "web.organizations.audit.columns.secret": {
+    "text": "Bericht",
+    "source_hash": "7e32a729"
+  },
+  "web.organizations.audit.columns.actor": {
+    "text": "Actor",
+    "source_hash": "449995c4"
+  },
+  "web.organizations.audit.columns.country": {
+    "text": "Land",
+    "source_hash": "701d021d"
+  },
+  "web.organizations.audit.columns.when": {
+    "text": "Wanneer",
+    "source_hash": "cf9c7aa2"
+  },
+  "web.organizations.audit.kinds.created": {
+    "text": "Bericht aangemaakt",
+    "source_hash": "e4a1e1fd"
+  },
+  "web.organizations.audit.kinds.status_get": {
+    "text": "Linkstatus gecontroleerd",
+    "source_hash": "0753f60e"
+  },
+  "web.organizations.audit.kinds.secret_get": {
+    "text": "Berichtlink geopend",
+    "source_hash": "e271e060"
+  },
+  "web.organizations.audit.kinds.previewed": {
+    "text": "Voorbeeld bekeken door maker",
+    "source_hash": "639fc1e2"
+  },
+  "web.organizations.audit.kinds.creator_status_get": {
+    "text": "Status gecontroleerd door maker",
+    "source_hash": "7e4b5de5"
+  },
+  "web.organizations.audit.kinds.receipt_viewed": {
+    "text": "Ontvangstbewijs bekeken",
+    "source_hash": "a417ead4"
+  },
+  "web.organizations.audit.kinds.revealed": {
+    "text": "Bericht onthuld",
+    "source_hash": "aff2c84d"
+  },
+  "web.organizations.audit.kinds.burned": {
+    "text": "Bericht verbrand",
+    "source_hash": "5ac68dc6"
+  },
+  "web.organizations.audit.kinds.expired": {
+    "text": "Bericht verlopen",
+    "source_hash": "c127dab6"
+  },
+  "web.organizations.audit.kinds.orphaned": {
+    "text": "Bericht verweest",
+    "source_hash": "23fe1a47"
+  },
+  "web.organizations.audit.kinds.reveal_failed_undecryptable": {
+    "text": "Onthullen mislukt (niet te ontcijferen)",
+    "source_hash": "d5616abf"
+  },
+  "web.organizations.tabs.activity": {
+    "text": "Activiteit",
+    "source_hash": "38da1505"
   }
 }

--- a/locales/content/nl/workspace-organizations.json
+++ b/locales/content/nl/workspace-organizations.json
@@ -388,7 +388,7 @@
     "source_hash": "09bf25ef"
   },
   "web.organizations.invitations.email_placeholder": {
-    "text": "lid{'@'}example.com",
+    "text": "lid{'@'}voorbeeld.com",
     "source_hash": "7fd425f7"
   },
   "web.organizations.invitations.role": {
@@ -544,7 +544,7 @@
     "source_hash": "957b0b87"
   },
   "web.organizations.early_supporter_badge": {
-    "text": "Early Supporter",
+    "text": "Vroege supporter",
     "source_hash": "e67d2ef8"
   },
   "web.organizations.member_count": {


### PR DESCRIPTION
## `nl` translation update

Automated export of completed **nl** translations from the translation task DB.
Scope: `locales/content/nl/` only — 41 file(s), +3063/-1063.

⚠️ `i18n validate variables` reports **3** variable mismatch(es) for `nl` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ❌ Blockers — brand name altered, one string reverted to English.

**Summary:** Automated check found 3 empty/missing-variable `.context` metadata fields on new SSO-linking keys; manual review found a brand-name regression and an untranslated-English regression not caught by the variable checker.

**Critical (must fix):**
- `email.feedback_email.signature`: was "Onetime Secret-supportteam", now **"Secret Support"** — drops "Onetime" from the brand name and reverts to English, while every other `*.signature` key in the same file was correctly translated to "Ondersteuningsteam" in this same diff. Brand name must not be altered.
- `web.COMMON.end`: "Einde" → **"End"** — untranslated English left in a general/shared string (not admin-only jargon).
- Three new keys (`web.auth.connections.connect_action`, `web.link_sso.prompt`, `web.sso_link_confirm.prompt`) are missing their `.context` dev-notes field entirely (source has `{provider}`/`{email}` guidance text, nl has none). Doesn't affect the rendered UI, but leaves translator-guidance metadata incomplete for these new SSO-linking strings.

**Warnings:**
- Inconsistent EN/NL churn: several previously-correct Dutch terms reverted to English loanwords this pass (`Bronnen`→`Resources`, `Snelheidslimieten`→`Rate limits`, `Niveau`→`Tier`, `Consumenten`→`Consumers`), while `web.footer.support` goes Dutch→English opposite the direction email.json takes for the same word.
- `web.organizations.invitations.email_placeholder` reverted "lid@voorbeeld.com" back to English "lid@example.com" while sibling placeholders elsewhere in the diff were newly localized to `voorbeeld.com`.
- `web.admin.domaintoolbox.probe.*`: "Testen"→"Probe", inconsistent with `web.admin.domains.actions.probe.button` which keeps "Testen".

**Notes:**
- `web.COMMON.faq_title`: "Veelgestelde vragen"→"F.A.Q." — less localized but understandable.
- "uur | uren"→"uur | uur" for count-prefixed hour strings matches Dutch numeral+noun grammar; looks intentional, not a bug.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
