### PR TITLE
i18n: update pl translations

### DIFF
--- a/locales/content/pl/00-common.json
+++ b/locales/content/pl/00-common.json
@@ -1539,5 +1539,9 @@
   "web.TITLES.domain_dns": {
     "text": "Konfiguracja DNS",
     "source_hash": "6c63df31"
+  },
+  "web.TITLES.connected_identities": {
+    "text": "Połączone tożsamości",
+    "source_hash": "e132c4d9"
   }
 }

--- a/locales/content/pl/admin-audit.json
+++ b/locales/content/pl/admin-audit.json
@@ -98,5 +98,41 @@
   "web.admin.audit.result.failure": {
     "text": "Niepowodzenie",
     "source_hash": "7031edbc"
+  },
+  "web.admin.audit.categories.secret": {
+    "text": "Sekrety",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.audit.categories.membership": {
+    "text": "Członkostwa",
+    "source_hash": "b50f1a42"
+  },
+  "web.admin.audit.categories.entitlement_preview": {
+    "text": "Podglądy uprawnień",
+    "source_hash": "255c5797"
+  },
+  "web.admin.audit.categories.colonel": {
+    "text": "Logowania Colonel",
+    "source_hash": "01eeeb38"
+  },
+  "web.admin.audit.filters.actorLabel": {
+    "text": "Wykonawca",
+    "source_hash": "449995c4"
+  },
+  "web.admin.audit.filters.searchButton": {
+    "text": "Szukaj",
+    "source_hash": "49c266ba"
+  },
+  "web.admin.audit.filters.searchHint": {
+    "text": "Wpisz wykonawcę, a następnie naciśnij Enter lub wybierz Szukaj, aby uruchomić wyszukiwanie. Lista nie aktualizuje się podczas pisania.",
+    "source_hash": "45eceb12"
+  },
+  "web.admin.audit.filters.pendingSearch": {
+    "text": "Jeszcze nie wyszukano — naciśnij Enter lub wybierz Szukaj, aby zastosować tego wykonawcę.",
+    "source_hash": "f76095c2"
+  },
+  "web.admin.audit.list.contractError": {
+    "text": "Serwer odpowiedział, ale dane audytu nie pasują do oczekiwanego formatu. Nie można wyświetlić żadnych zdarzeń — to błąd raportowania, a nie pusty dziennik.",
+    "source_hash": "7f48137e"
   }
 }

--- a/locales/content/pl/admin-billing.json
+++ b/locales/content/pl/admin-billing.json
@@ -122,5 +122,85 @@
   "web.admin.billing.status.changed": {
     "text": "Zmieniono",
     "source_hash": "2a6141e4"
+  },
+  "web.admin.billing.diff.backToCatalog": {
+    "text": "Powrót do katalogu płatności",
+    "source_hash": "8532b373"
+  },
+  "web.admin.billing.diff.driftedFields": {
+    "text": "Pola, które się różnią:",
+    "source_hash": "9890c95b"
+  },
+  "web.admin.billing.diff.notFound": {
+    "text": "Planu nie ma w katalogu",
+    "source_hash": "0253898b"
+  },
+  "web.admin.billing.diff.notFoundDescription": {
+    "text": "Nie znaleziono planu o identyfikatorze {planid} w skonfigurowanym katalogu ani w aktualnej pamięci podręcznej zsynchronizowanej ze Stripe.",
+    "source_hash": "2e69551c"
+  },
+  "web.admin.billing.stripeOrgs.title": {
+    "text": "Klienci Stripe",
+    "source_hash": "0463ae27"
+  },
+  "web.admin.billing.stripeOrgs.description": {
+    "text": "Organizacje powiązane z rekordem klienta Stripe.",
+    "source_hash": "2ab09aec"
+  },
+  "web.admin.billing.stripeOrgs.searchPlaceholder": {
+    "text": "Szukaj według identyfikatora klienta Stripe",
+    "source_hash": "d5acf08f"
+  },
+  "web.admin.billing.stripeOrgs.empty": {
+    "text": "Żadna organizacja nie ma identyfikatora klienta Stripe.",
+    "source_hash": "2e373537"
+  },
+  "web.admin.billing.stripeOrgs.emptySearch": {
+    "text": "Żaden identyfikator klienta Stripe nie pasuje do tego wyszukiwania.",
+    "source_hash": "75011174"
+  },
+  "web.admin.billing.stripeOrgs.loadError": {
+    "text": "Nie udało się załadować listy klientów Stripe.",
+    "source_hash": "15e2d9a7"
+  },
+  "web.admin.billing.stripeOrgs.unavailable": {
+    "text": "Lista klientów Stripe nie jest jeszcze dostępna na tym serwerze.",
+    "source_hash": "aab6451a"
+  },
+  "web.admin.billing.stripeOrgs.none": {
+    "text": "Brak",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.billing.stripeOrgs.capped": {
+    "text": "Skanowanie indeksu osiągnęło limit, więc łączna liczba jest wartością dolną — zawęź wyszukiwanie, aby zobaczyć resztę.",
+    "source_hash": "20bcaa38"
+  },
+  "web.admin.billing.stripeOrgs.stale": {
+    "text": "Pominięto wpisy indeksu na tej stronie, które wskazują organizację niedającą się już wczytać. Liczba: {count}.",
+    "source_hash": "51980f83"
+  },
+  "web.admin.billing.stripeOrgs.copyStripeId": {
+    "text": "Kopiuj identyfikator klienta Stripe",
+    "source_hash": "a77d18b1"
+  },
+  "web.admin.billing.stripeOrgs.columns.organization": {
+    "text": "Organizacja",
+    "source_hash": "d764d425"
+  },
+  "web.admin.billing.stripeOrgs.columns.owner": {
+    "text": "Właściciel",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.billing.stripeOrgs.columns.plan": {
+    "text": "Plan",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.billing.stripeOrgs.columns.subscription": {
+    "text": "Subskrypcja",
+    "source_hash": "4999c6c6"
+  },
+  "web.admin.billing.stripeOrgs.columns.stripeCustomer": {
+    "text": "Identyfikator klienta Stripe",
+    "source_hash": "7e1d8bbb"
   }
 }

--- a/locales/content/pl/admin-colonel.json
+++ b/locales/content/pl/admin-colonel.json
@@ -838,5 +838,37 @@
   "web.colonel.nav.groups.communications": {
     "text": "Komunikacja",
     "source_hash": "919a9253"
+  },
+  "web.colonel.organizations.sameAsContact": {
+    "text": "Taki sam jak kontaktowy",
+    "source_hash": "ed18ff43"
+  },
+  "web.colonel.organizations.refresh": {
+    "text": "Odśwież",
+    "source_hash": "0e916101"
+  },
+  "web.colonel.organizations.updatedAgo": {
+    "text": "Zaktualizowano {ago}",
+    "source_hash": "cda30b9c"
+  },
+  "web.colonel.organizations.columns.name": {
+    "text": "Nazwa",
+    "source_hash": "dcd1d522"
+  },
+  "web.colonel.organizations.columns.contactEmail": {
+    "text": "E-mail kontaktowy",
+    "source_hash": "6d7fce11"
+  },
+  "web.colonel.organizations.columns.billingEmail": {
+    "text": "E-mail do płatności",
+    "source_hash": "8805b928"
+  },
+  "web.colonel.organizations.columns.planSubscription": {
+    "text": "Plan i subskrypcja",
+    "source_hash": "b396caac"
+  },
+  "web.colonel.organizations.filters.searchPlaceholder": {
+    "text": "Szukaj według identyfikatora, nazwy lub adresu e-mail",
+    "source_hash": "6fe16473"
   }
 }

--- a/locales/content/pl/admin-customers.json
+++ b/locales/content/pl/admin-customers.json
@@ -4,8 +4,8 @@
     "source_hash": "aabe76f1"
   },
   "web.admin.customers.description": {
-    "text": "Znajdź klienta i rozwiązuj problemy pomocy technicznej bez SSH.",
-    "source_hash": "c8487e68"
+    "text": "Znajdź klienta i rozwiąż problemy zgłoszone do pomocy technicznej.",
+    "source_hash": "00961ea3"
   },
   "web.admin.customers.actions.plan.label": {
     "text": "Plan",
@@ -482,5 +482,213 @@
   "web.admin.customers.suspended.badge": {
     "text": "Zawieszony",
     "source_hash": "e392a389"
+  },
+  "web.admin.customers.actions.checkoutLink.button": {
+    "text": "Utwórz link do płatności",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.modalTitle": {
+    "text": "Utwórz link do płatności",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.planLabel": {
+    "text": "Plan",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.actions.checkoutLink.planPlaceholder": {
+    "text": "Identyfikator rodziny planu (np. identity_plus_v1)",
+    "source_hash": "12eba027"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleLabel": {
+    "text": "Cykl rozliczeniowy",
+    "source_hash": "d69f731e"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleMonthly": {
+    "text": "Miesięczny",
+    "source_hash": "9b11f6b7"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleYearly": {
+    "text": "Roczny",
+    "source_hash": "6e69b59e"
+  },
+  "web.admin.customers.actions.checkoutLink.allowPromo": {
+    "text": "Zezwalaj na kody promocyjne",
+    "source_hash": "ebe7bc8b"
+  },
+  "web.admin.customers.actions.checkoutLink.submit": {
+    "text": "Utwórz link",
+    "source_hash": "e6b850cf"
+  },
+  "web.admin.customers.actions.checkoutLink.resultLead": {
+    "text": "Link do płatności został utworzony. Udostępnij go klientowi — można go użyć tylko raz i wygasa.",
+    "source_hash": "6ff1fb0e"
+  },
+  "web.admin.customers.actions.checkoutLink.copy": {
+    "text": "Kopiuj link do płatności",
+    "source_hash": "f1e51ca7"
+  },
+  "web.admin.customers.actions.checkoutLink.expiry": {
+    "text": "Wygasa za ~{hours} godz. ({date}).",
+    "source_hash": "4c878a15"
+  },
+  "web.admin.customers.actions.checkoutLink.regionLabel": {
+    "text": "Region",
+    "source_hash": "d3a008ef"
+  },
+  "web.admin.customers.actions.checkoutLink.parseError": {
+    "text": "Serwer przyjął żądanie, ale zwrócił nieczytelną odpowiedź, więc nie można wyświetlić linku. Sprawdź Stripe przed ponowną próbą.",
+    "source_hash": "e7e08290"
+  },
+  "web.admin.customers.actions.checkoutLink.done": {
+    "text": "Gotowe",
+    "source_hash": "11a6767d"
+  },
+  "web.admin.customers.actions.purge.typePrompt": {
+    "text": "Aby potwierdzić, wpisz poniżej adres e-mail konta {token}",
+    "source_hash": "8b2a1819"
+  },
+  "web.admin.customers.actions.purge.unavailable": {
+    "text": "Trwałe usunięcie jest niedostępne: to konto nie ma adresu e-mail, który można przepisać w celu potwierdzenia.",
+    "source_hash": "5f20f7e5"
+  },
+  "web.admin.customers.columns.actions": {
+    "text": "Działania",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.diagnostics.title": {
+    "text": "Diagnostyka konta",
+    "source_hash": "5574ece8"
+  },
+  "web.admin.customers.detail.diagnostics.loading": {
+    "text": "Trwa diagnozowanie…",
+    "source_hash": "062c83d5"
+  },
+  "web.admin.customers.detail.diagnostics.loadError": {
+    "text": "Nie można załadować diagnostyki.",
+    "source_hash": "69e69f49"
+  },
+  "web.admin.customers.detail.diagnostics.healthy": {
+    "text": "Nie znaleziono żadnych blokujących warunków. Stan uwierzytelniania wygląda prawidłowo — podejrzewaj problemy po stronie klienta (pliki cookie, konfiguracja logowania w domenie niestandardowej) lub nieprawidłowy region.",
+    "source_hash": "f6d5f8d1"
+  },
+  "web.admin.customers.detail.diagnostics.authUnavailable": {
+    "text": "Baza danych uwierzytelniania jest niedostępna (tryb prostego uwierzytelniania) — pominięto kontrole po stronie SQL.",
+    "source_hash": "d668907c"
+  },
+  "web.admin.customers.detail.diagnostics.authFailed": {
+    "text": "Baza danych uwierzytelniania nie odpowiedziała, więc nie można było wykonać kontroli po stronie SQL: {reason}",
+    "source_hash": "46d047c0"
+  },
+  "web.admin.customers.detail.diagnostics.unknown": {
+    "text": "Nieznane",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.title": {
+    "text": "Dziennik uwierzytelniania",
+    "source_hash": "48ad8ba8"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.empty": {
+    "text": "Nie zarejestrowano żadnych zdarzeń uwierzytelniania.",
+    "source_hash": "d2332558"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.unavailable": {
+    "text": "Nie można odczytać dziennika uwierzytelniania: {reason}",
+    "source_hash": "ab18af57"
+  },
+  "web.admin.customers.detail.diagnostics.facts.authStatus": {
+    "text": "Stan uwierzytelniania",
+    "source_hash": "34def169"
+  },
+  "web.admin.customers.detail.diagnostics.facts.noAccount": {
+    "text": "Brak konta uwierzytelniania",
+    "source_hash": "a9968e9e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.password": {
+    "text": "Hasło",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordSet": {
+    "text": "Ustawione",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordNone": {
+    "text": "Brak",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfa": {
+    "text": "MFA",
+    "source_hash": "d39ce053"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfaNone": {
+    "text": "Brak",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.loginFailures": {
+    "text": "Nieudane próby",
+    "source_hash": "63e7f0a8"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lockedBadge": {
+    "text": "Zablokowane",
+    "source_hash": "ace29f74"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiter": {
+    "text": "Ogranicznik szybkości",
+    "source_hash": "32892404"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterEngaged": {
+    "text": "Aktywny",
+    "source_hash": "1b0d851e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterClear": {
+    "text": "Nieaktywny",
+    "source_hash": "83b12c22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verification": {
+    "text": "E-mail weryfikacyjny",
+    "source_hash": "23fac8fb"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationPending": {
+    "text": "Oczekuje — ostatnio wysłano {date}",
+    "source_hash": "9ab8d1b6"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationNone": {
+    "text": "Brak oczekujących",
+    "source_hash": "a4d4cc22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.sessions": {
+    "text": "Aktywne sesje",
+    "source_hash": "61ad9909"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lastLogin": {
+    "text": "Ostatnie logowanie (uwierzytelnianie)",
+    "source_hash": "373e7fb1"
+  },
+  "web.admin.customers.detail.receipts.partial": {
+    "text": "Lista częściowa — wyświetlane są tylko najnowsze pozycje. Liczba: {count}. Ten klient ma więcej potwierdzeń, niż tu pokazano.",
+    "source_hash": "127fd4db"
+  },
+  "web.admin.customers.detail.secrets.partial": {
+    "text": "Lista częściowa — wyświetlane są tylko najnowsze pozycje. Liczba: {count}. Ten klient ma więcej sekretów, niż tu pokazano.",
+    "source_hash": "a537c8f3"
+  },
+  "web.admin.customers.detail.sessions.columns.country": {
+    "text": "Kraj",
+    "source_hash": "701d021d"
+  },
+  "web.admin.customers.detail.sessions.current.badge": {
+    "text": "Ta sesja",
+    "source_hash": "6da6530a"
+  },
+  "web.admin.customers.detail.sessions.current.tooltip": {
+    "text": "Twoja bieżąca sesja administratora. Unieważnienie jej tutaj nie ma efektu — jest odtwarzana na czas trwania tego żądania.",
+    "source_hash": "ef097ab1"
+  },
+  "web.admin.customers.verification.verified": {
+    "text": "Zweryfikowany",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.verification.unverified": {
+    "text": "Niezweryfikowany",
+    "source_hash": "15133907"
   }
 }

--- a/locales/content/pl/admin-domains.json
+++ b/locales/content/pl/admin-domains.json
@@ -190,5 +190,657 @@
   "web.admin.domains.verify.success.done": {
     "text": "Weryfikacja zakończona dla {domain}.",
     "source_hash": "ed67e22d"
+  },
+  "web.admin.domains.actions.preview": {
+    "text": "Podgląd",
+    "source_hash": "324b134f"
+  },
+  "web.admin.domains.actions.probe.button": {
+    "text": "Sonduj",
+    "source_hash": "3bd51ab9"
+  },
+  "web.admin.domains.actions.remove.button": {
+    "text": "Usuń domenę",
+    "source_hash": "5ce43507"
+  },
+  "web.admin.domains.actions.remove.previewButton": {
+    "text": "Podgląd usunięcia",
+    "source_hash": "6b81bd92"
+  },
+  "web.admin.domains.actions.remove.previewStatus": {
+    "text": "Stan:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.remove.previewOrg": {
+    "text": "Organizacja:",
+    "source_hash": "5300e286"
+  },
+  "web.admin.domains.actions.remove.reassertsSurvivor": {
+    "text": "Inny rekord zgłasza tę samą nazwę domeny i przejmie indeks wyszukiwania.",
+    "source_hash": "902838f4"
+  },
+  "web.admin.domains.actions.remove.confirmTitle": {
+    "text": "Usunąć domenę?",
+    "source_hash": "716dfac9"
+  },
+  "web.admin.domains.actions.remove.confirmDescription": {
+    "text": "Spowoduje to trwałe usunięcie {domain} oraz jej rekordów brandingu, DNS i konfiguracji. Nie można tego cofnąć. Przepisz publiczny identyfikator domeny, aby kontynuować.",
+    "source_hash": "d0b67b47"
+  },
+  "web.admin.domains.actions.remove.success": {
+    "text": "Domena została usunięta.",
+    "source_hash": "2ccaa6d3"
+  },
+  "web.admin.domains.actions.remove.notApplied": {
+    "text": "Serwer wyświetlił podgląd usunięcia zamiast je zastosować — domena NIE została usunięta. Spróbuj ponownie i zgłoś to, jeśli problem będzie się powtarzał.",
+    "source_hash": "dc6d70ae"
+  },
+  "web.admin.domains.actions.repair.title": {
+    "text": "Napraw powiązanie z organizacją",
+    "source_hash": "82b40352"
+  },
+  "web.admin.domains.actions.repair.description": {
+    "text": "Znajdź i napraw uszkodzone powiązania między tą domeną a jej organizacją. Najpierw wyświetl podgląd, aby zobaczyć, co się zmieni.",
+    "source_hash": "531ed287"
+  },
+  "web.admin.domains.actions.repair.orgIdLabel": {
+    "text": "Identyfikator organizacji (tylko domeny osierocone)",
+    "source_hash": "0d3010eb"
+  },
+  "web.admin.domains.actions.repair.orgIdPlaceholder": {
+    "text": "Pozostaw puste, chyba że domena nie ma właściciela",
+    "source_hash": "118b7132"
+  },
+  "web.admin.domains.actions.repair.statusLabel": {
+    "text": "Stan:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.repair.noIssues": {
+    "text": "Nie znaleziono problemów — nie ma czego naprawiać.",
+    "source_hash": "17735887"
+  },
+  "web.admin.domains.actions.repair.button": {
+    "text": "Zastosuj naprawę",
+    "source_hash": "4d0ab2d4"
+  },
+  "web.admin.domains.actions.repair.confirmTitle": {
+    "text": "Zastosować naprawę?",
+    "source_hash": "ef0ffae5"
+  },
+  "web.admin.domains.actions.repair.confirmDescription": {
+    "text": "Spowoduje to nadpisanie powiązania z organizacją dla {domain}. Przepisz publiczny identyfikator domeny, aby kontynuować.",
+    "source_hash": "a9f2702f"
+  },
+  "web.admin.domains.actions.repair.success": {
+    "text": "Naprawa została zastosowana.",
+    "source_hash": "850bd784"
+  },
+  "web.admin.domains.actions.transfer.title": {
+    "text": "Przenieś do innej organizacji",
+    "source_hash": "1b0b0655"
+  },
+  "web.admin.domains.actions.transfer.description": {
+    "text": "Przenieś tę domenę do innej organizacji. Najpierw wyświetl podgląd, aby potwierdzić obie strony przeniesienia.",
+    "source_hash": "457e852d"
+  },
+  "web.admin.domains.actions.transfer.toOrgLabel": {
+    "text": "Identyfikator organizacji docelowej",
+    "source_hash": "1a3f05c4"
+  },
+  "web.admin.domains.actions.transfer.fromOrgLabel": {
+    "text": "Oczekiwany identyfikator bieżącej organizacji (opcjonalnie)",
+    "source_hash": "f6e75729"
+  },
+  "web.admin.domains.actions.transfer.fromOrgPlaceholder": {
+    "text": "Potwierdź bieżącego właściciela przed przeniesieniem",
+    "source_hash": "1ac6c59b"
+  },
+  "web.admin.domains.actions.transfer.from": {
+    "text": "Z",
+    "source_hash": "21819769"
+  },
+  "web.admin.domains.actions.transfer.to": {
+    "text": "Do",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.domains.actions.transfer.orphaned": {
+    "text": "Brak organizacji (osierocona)",
+    "source_hash": "6f4c745c"
+  },
+  "web.admin.domains.actions.transfer.button": {
+    "text": "Zastosuj przeniesienie",
+    "source_hash": "fb546c5c"
+  },
+  "web.admin.domains.actions.transfer.confirmTitle": {
+    "text": "Przenieść domenę?",
+    "source_hash": "801eb986"
+  },
+  "web.admin.domains.actions.transfer.confirmDescription": {
+    "text": "Spowoduje to przeniesienie {domain} do organizacji {org}. Przepisz publiczny identyfikator domeny, aby kontynuować.",
+    "source_hash": "52c8808d"
+  },
+  "web.admin.domains.actions.transfer.success": {
+    "text": "Domena została przeniesiona.",
+    "source_hash": "91e681ae"
+  },
+  "web.admin.domains.columns.domain": {
+    "text": "Domena",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domains.columns.organization": {
+    "text": "Organizacja",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.columns.state": {
+    "text": "Weryfikacja",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.domains.columns.tls": {
+    "text": "TLS",
+    "source_hash": "d1c18ec0"
+  },
+  "web.admin.domains.columns.created": {
+    "text": "Utworzono",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.columns.actions": {
+    "text": "Działania",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.configs.title": {
+    "text": "Konfiguracja domeny",
+    "source_hash": "d46aa480"
+  },
+  "web.admin.domains.configs.description": {
+    "text": "Rekordy konfiguracji poszczególnych domen kontrolujące logowanie, rejestrację, sekrety na stronie głównej, dostęp do API, przychodzące sekrety, SSO dzierżawy i wysyłanie poczty. Brak rekordu oznacza domyślne zablokowanie pierwszych pięciu.",
+    "source_hash": "1df99789"
+  },
+  "web.admin.domains.configs.loadError": {
+    "text": "Nie udało się załadować rekordów konfiguracji domeny.",
+    "source_hash": "9417d718"
+  },
+  "web.admin.domains.configs.retry": {
+    "text": "Spróbuj ponownie",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.configs.degraded": {
+    "text": "Odpowiedź konfiguracji nie pasowała do oczekiwanego kontraktu. Odśwież i zgłoś to, jeśli problem będzie się powtarzał.",
+    "source_hash": "b5d890c0"
+  },
+  "web.admin.domains.configs.notFoundNote": {
+    "text": "Ta domena już nie istnieje, więc nie można załadować jej rekordów konfiguracji.",
+    "source_hash": "2d88a392"
+  },
+  "web.admin.domains.configs.detailsToggle": {
+    "text": "Szczegóły",
+    "source_hash": "45989de4"
+  },
+  "web.admin.domains.configs.notEditable": {
+    "text": "Zarządzane w ustawieniach domen obszaru roboczego.",
+    "source_hash": "54fe891f"
+  },
+  "web.admin.domains.configs.delete.button": {
+    "text": "Usuń",
+    "source_hash": "e2d0a549"
+  },
+  "web.admin.domains.configs.delete.confirmTitle": {
+    "text": "Usunąć konfigurację {kind}?",
+    "source_hash": "98e672db"
+  },
+  "web.admin.domains.configs.delete.confirmDescription": {
+    "text": "Spowoduje to trwałe usunięcie rekordu konfiguracji {kind} dla {domain}. Domena przejdzie na zachowanie właściwe dla brakującego rekordu. Przepisz rodzaj, aby kontynuować.",
+    "source_hash": "8272c40c"
+  },
+  "web.admin.domains.configs.delete.success": {
+    "text": "Konfiguracja została usunięta.",
+    "source_hash": "a0184b66"
+  },
+  "web.admin.domains.configs.edit.button": {
+    "text": "Edytuj",
+    "source_hash": "464c4ffd"
+  },
+  "web.admin.domains.configs.edit.createButton": {
+    "text": "Utwórz",
+    "source_hash": "4759498a"
+  },
+  "web.admin.domains.configs.edit.title": {
+    "text": "Skonfiguruj {kind}",
+    "source_hash": "8592148f"
+  },
+  "web.admin.domains.configs.edit.submit": {
+    "text": "Zapisz",
+    "source_hash": "1509f561"
+  },
+  "web.admin.domains.configs.edit.success": {
+    "text": "Konfiguracja została zapisana.",
+    "source_hash": "6b5b3c69"
+  },
+  "web.admin.domains.configs.edit.unsetOption": {
+    "text": "Nie ustawiono",
+    "source_hash": "4895f731"
+  },
+  "web.admin.domains.configs.edit.domainsHint": {
+    "text": "Jedna domena w wierszu.",
+    "source_hash": "6c03f4f7"
+  },
+  "web.admin.domains.configs.ensure.button": {
+    "text": "Utwórz brakujące konfiguracje",
+    "source_hash": "77991b75"
+  },
+  "web.admin.domains.configs.ensure.confirmTitle": {
+    "text": "Utworzyć brakujące rekordy konfiguracji?",
+    "source_hash": "3f41dec2"
+  },
+  "web.admin.domains.configs.ensure.confirmDescription": {
+    "text": "Tworzy wyłączone rekordy w domenie {domain} dla: {kinds}. Wszystko zaczyna jako wyłączone, więc zachowanie nie zmienia się, dopóki rekord nie zostanie włączony.",
+    "source_hash": "fed66221"
+  },
+  "web.admin.domains.configs.ensure.applyButton": {
+    "text": "Utwórz rekordy",
+    "source_hash": "4bcbef42"
+  },
+  "web.admin.domains.configs.ensure.success": {
+    "text": "Brakujące rekordy konfiguracji zostały utworzone.",
+    "source_hash": "3b6ead80"
+  },
+  "web.admin.domains.configs.ensure.nothingMissing": {
+    "text": "Nie ma czego tworzyć — każdy rekord konfiguracji już istnieje. Lista została odświeżona.",
+    "source_hash": "ad0df0ae"
+  },
+  "web.admin.domains.configs.ensure.notApplied": {
+    "text": "Serwer wyświetlił podgląd zmiany zamiast ją zastosować — nie utworzono żadnych rekordów. Spróbuj ponownie i zgłoś to, jeśli problem będzie się powtarzał.",
+    "source_hash": "09d26379"
+  },
+  "web.admin.domains.configs.fields.enabled": {
+    "text": "Włączone",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.fields.signin_enabled": {
+    "text": "Logowanie włączone",
+    "source_hash": "cabe4898"
+  },
+  "web.admin.domains.configs.fields.email_auth_enabled": {
+    "text": "Uwierzytelnianie e-mail włączone",
+    "source_hash": "4a762960"
+  },
+  "web.admin.domains.configs.fields.sso_enabled": {
+    "text": "SSO włączone",
+    "source_hash": "6e77e673"
+  },
+  "web.admin.domains.configs.fields.restrict_to": {
+    "text": "Ogranicz do",
+    "source_hash": "a0bdf50a"
+  },
+  "web.admin.domains.configs.fields.signup_enabled": {
+    "text": "Rejestracja włączona",
+    "source_hash": "2637d0b2"
+  },
+  "web.admin.domains.configs.fields.autoverify": {
+    "text": "Automatyczna weryfikacja",
+    "source_hash": "7e02211c"
+  },
+  "web.admin.domains.configs.fields.validation_strategy": {
+    "text": "Strategia walidacji",
+    "source_hash": "a2e95531"
+  },
+  "web.admin.domains.configs.fields.allowed_signup_domains": {
+    "text": "Dozwolone domeny rejestracji",
+    "source_hash": "9b5bb5b1"
+  },
+  "web.admin.domains.configs.fields.secrets_mode": {
+    "text": "Tryb sekretów",
+    "source_hash": "8d4349d6"
+  },
+  "web.admin.domains.configs.fields.disabled_homepage_variant": {
+    "text": "Wariant wyłączonej strony głównej",
+    "source_hash": "4695633b"
+  },
+  "web.admin.domains.configs.fields.ready": {
+    "text": "Gotowe",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.configs.fields.recipients": {
+    "text": "Odbiorcy",
+    "source_hash": "1e8568a8"
+  },
+  "web.admin.domains.configs.fields.provider_type": {
+    "text": "Typ dostawcy",
+    "source_hash": "8c0f6d3e"
+  },
+  "web.admin.domains.configs.fields.display_name": {
+    "text": "Nazwa wyświetlana",
+    "source_hash": "2b7f6a84"
+  },
+  "web.admin.domains.configs.fields.issuer": {
+    "text": "Wystawca",
+    "source_hash": "39e02c46"
+  },
+  "web.admin.domains.configs.fields.tenant_id": {
+    "text": "Tenant ID",
+    "source_hash": "de1f5fff"
+  },
+  "web.admin.domains.configs.fields.has_client_id": {
+    "text": "Client ID ustawiony",
+    "source_hash": "04a9fa3d"
+  },
+  "web.admin.domains.configs.fields.has_client_secret": {
+    "text": "Client Secret ustawiony",
+    "source_hash": "6ee1c9e6"
+  },
+  "web.admin.domains.configs.fields.allowed_domains": {
+    "text": "Dozwolone domeny",
+    "source_hash": "bcd60db0"
+  },
+  "web.admin.domains.configs.fields.enforce_sso_only": {
+    "text": "Wymuś tryb wyłącznie SSO",
+    "source_hash": "b3a3f694"
+  },
+  "web.admin.domains.configs.fields.grant_org_scope": {
+    "text": "Przyznaj zakres organizacji",
+    "source_hash": "698ea5de"
+  },
+  "web.admin.domains.configs.fields.provider": {
+    "text": "Dostawca",
+    "source_hash": "472590ae"
+  },
+  "web.admin.domains.configs.fields.from_name": {
+    "text": "Nazwa nadawcy",
+    "source_hash": "b28f93ea"
+  },
+  "web.admin.domains.configs.fields.from_address": {
+    "text": "Adres nadawcy",
+    "source_hash": "d465bcfa"
+  },
+  "web.admin.domains.configs.fields.reply_to": {
+    "text": "Adres zwrotny (Reply-To)",
+    "source_hash": "6b9c49b7"
+  },
+  "web.admin.domains.configs.fields.sending_mode": {
+    "text": "Tryb wysyłania",
+    "source_hash": "e2d6bcf7"
+  },
+  "web.admin.domains.configs.fields.verification_status": {
+    "text": "Stan weryfikacji",
+    "source_hash": "aedfff7e"
+  },
+  "web.admin.domains.configs.fields.dns_verified": {
+    "text": "DNS zweryfikowany",
+    "source_hash": "8b2128c8"
+  },
+  "web.admin.domains.configs.fields.provider_verified": {
+    "text": "Dostawca zweryfikowany",
+    "source_hash": "6f4d9cc4"
+  },
+  "web.admin.domains.configs.fields.has_api_key": {
+    "text": "Klucz API ustawiony",
+    "source_hash": "d5115386"
+  },
+  "web.admin.domains.configs.fields.created": {
+    "text": "Utworzono",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.configs.fields.updated": {
+    "text": "Zaktualizowano",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.configs.kinds.signin": {
+    "text": "Logowanie",
+    "source_hash": "5bbbe531"
+  },
+  "web.admin.domains.configs.kinds.signup": {
+    "text": "Rejestracja",
+    "source_hash": "3cc08ebe"
+  },
+  "web.admin.domains.configs.kinds.homepage": {
+    "text": "Strona główna",
+    "source_hash": "9e3391e9"
+  },
+  "web.admin.domains.configs.kinds.api": {
+    "text": "API",
+    "source_hash": "c8e5998f"
+  },
+  "web.admin.domains.configs.kinds.incoming": {
+    "text": "Przychodzące",
+    "source_hash": "e301820a"
+  },
+  "web.admin.domains.configs.kinds.sso": {
+    "text": "SSO",
+    "source_hash": "5ba3ac9f"
+  },
+  "web.admin.domains.configs.kinds.mailer": {
+    "text": "Poczta",
+    "source_hash": "6c07ba63"
+  },
+  "web.admin.domains.configs.missingNotes.signin": {
+    "text": "Brak rekordu: logowanie jest wyłączone w tej domenie, chyba że aktywne jest SSO dzierżawy.",
+    "source_hash": "17dd6099"
+  },
+  "web.admin.domains.configs.missingNotes.signup": {
+    "text": "Brak rekordu: rejestracja jest wyłączona w tej domenie.",
+    "source_hash": "c3c98956"
+  },
+  "web.admin.domains.configs.missingNotes.homepage": {
+    "text": "Brak rekordu: sekrety na stronie głównej są wyłączone (domyślne zablokowanie i zapis błędu w dzienniku).",
+    "source_hash": "9a258a88"
+  },
+  "web.admin.domains.configs.missingNotes.api": {
+    "text": "Brak rekordu: publiczne API jest wyłączone (domyślne zablokowanie i zapis błędu w dzienniku).",
+    "source_hash": "fed99f73"
+  },
+  "web.admin.domains.configs.missingNotes.incoming": {
+    "text": "Brak rekordu: przychodzące sekrety są wyłączone.",
+    "source_hash": "b957fbe8"
+  },
+  "web.admin.domains.configs.missingNotes.sso": {
+    "text": "Brak rekordu: SSO dzierżawy jest niedostępne; obowiązuje zapasowa polityka SSO platformy.",
+    "source_hash": "7b05ade8"
+  },
+  "web.admin.domains.configs.missingNotes.mailer": {
+    "text": "Brak rekordu: używana jest poczta platformy.",
+    "source_hash": "e027cc99"
+  },
+  "web.admin.domains.configs.status.missing": {
+    "text": "Brak",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.domains.configs.status.disabled": {
+    "text": "Wyłączone",
+    "source_hash": "75081b59"
+  },
+  "web.admin.domains.configs.status.enabled": {
+    "text": "Włączone",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.status.enabledNotReady": {
+    "text": "Włączone, niegotowe",
+    "source_hash": "cb806ba4"
+  },
+  "web.admin.domains.detail.openFullPage": {
+    "text": "Otwórz pełną stronę",
+    "source_hash": "a467911c"
+  },
+  "web.admin.domains.detail.backToList": {
+    "text": "Powrót do domen",
+    "source_hash": "22fd50fe"
+  },
+  "web.admin.domains.detail.notFound": {
+    "text": "Nie znaleziono domeny",
+    "source_hash": "7b8fc0e6"
+  },
+  "web.admin.domains.detail.notFoundDescription": {
+    "text": "Ta domena nie istnieje lub została już usunięta.",
+    "source_hash": "e0f0b987"
+  },
+  "web.admin.domains.detail.loadError": {
+    "text": "Nie udało się załadować tej domeny.",
+    "source_hash": "39e9c657"
+  },
+  "web.admin.domains.detail.retry": {
+    "text": "Spróbuj ponownie",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.detail.never": {
+    "text": "Nigdy",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.domains.detail.none": {
+    "text": "Brak",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.domains.detail.yes": {
+    "text": "Tak",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.domains.detail.no": {
+    "text": "Nie",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.domains.detail.organization.open": {
+    "text": "Otwórz organizację",
+    "source_hash": "54a43621"
+  },
+  "web.admin.domains.detail.organization.unknown": {
+    "text": "Organizacja będąca właścicielem nie jest zawarta w tej odpowiedzi. Otwórz tę domenę z listy domen, aby ją zobaczyć.",
+    "source_hash": "bb5bdc9c"
+  },
+  "web.admin.domains.detail.sections.overview": {
+    "text": "Przegląd",
+    "source_hash": "d4b1ea57"
+  },
+  "web.admin.domains.detail.sections.actions": {
+    "text": "Działania",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.detail.sections.organization": {
+    "text": "Organizacja będąca właścicielem",
+    "source_hash": "39ad6d9c"
+  },
+  "web.admin.domains.detail.sections.dns": {
+    "text": "DNS",
+    "source_hash": "020965a2"
+  },
+  "web.admin.domains.detail.sections.diagnostics": {
+    "text": "Diagnostyka",
+    "source_hash": "268f14bb"
+  },
+  "web.admin.domains.detail.sections.operations": {
+    "text": "Operacje na własności",
+    "source_hash": "eb9a8cbc"
+  },
+  "web.admin.domains.detail.sections.operationsHint": {
+    "text": "Każda operacja jest najpierw wyświetlana w podglądzie. Nic nie zostaje zapisane, dopóki nie potwierdzisz kroku zastosowania.",
+    "source_hash": "f09bf7bd"
+  },
+  "web.admin.domains.fields.publicId": {
+    "text": "Publiczny identyfikator",
+    "source_hash": "3705b64f"
+  },
+  "web.admin.domains.fields.domainId": {
+    "text": "Identyfikator wewnętrzny",
+    "source_hash": "e468bb47"
+  },
+  "web.admin.domains.fields.organization": {
+    "text": "Organizacja",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.fields.baseDomain": {
+    "text": "Domena bazowa",
+    "source_hash": "33295d5b"
+  },
+  "web.admin.domains.fields.subdomain": {
+    "text": "Subdomena",
+    "source_hash": "ba4520ab"
+  },
+  "web.admin.domains.fields.apex": {
+    "text": "Domena główna",
+    "source_hash": "0a8a42fa"
+  },
+  "web.admin.domains.fields.status": {
+    "text": "Status",
+    "source_hash": "920e413c"
+  },
+  "web.admin.domains.fields.created": {
+    "text": "Utworzono",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.fields.updated": {
+    "text": "Zaktualizowano",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.fields.verified": {
+    "text": "Zweryfikowano",
+    "source_hash": "4f783840"
+  },
+  "web.admin.domains.fields.resolving": {
+    "text": "Rozwiązywanie",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.fields.ready": {
+    "text": "Gotowe",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.list.searchPlaceholder": {
+    "text": "Szukaj według nazwy domeny lub identyfikatora",
+    "source_hash": "aecdd873"
+  },
+  "web.admin.domains.list.stateFilter": {
+    "text": "Stan",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.domains.list.emptyFilter": {
+    "text": "Żadna domena nie pasuje do bieżących filtrów.",
+    "source_hash": "be4d64ec"
+  },
+  "web.admin.domains.probe.healthLabel": {
+    "text": "Kondycja",
+    "source_hash": "55898449"
+  },
+  "web.admin.domains.probe.certInvalid": {
+    "text": "Certyfikat nie nadaje się do użycia",
+    "source_hash": "5535f4d4"
+  },
+  "web.admin.domains.probe.noCertificate": {
+    "text": "Nie zwrócono certyfikatu — połączenie nie powiodło się przed TLS.",
+    "source_hash": "8ffd63be"
+  },
+  "web.admin.domains.probe.fields.httpStatus": {
+    "text": "Status HTTP",
+    "source_hash": "0f7cf91f"
+  },
+  "web.admin.domains.probe.fields.httpError": {
+    "text": "Błąd HTTP",
+    "source_hash": "5c6896d4"
+  },
+  "web.admin.domains.probe.fields.sslError": {
+    "text": "Błąd TLS",
+    "source_hash": "7b827515"
+  },
+  "web.admin.domains.probe.fields.issuer": {
+    "text": "Wystawca certyfikatu",
+    "source_hash": "2912559a"
+  },
+  "web.admin.domains.probe.fields.subject": {
+    "text": "Podmiot certyfikatu",
+    "source_hash": "d7816b16"
+  },
+  "web.admin.domains.probe.fields.notAfter": {
+    "text": "Certyfikat wygasa",
+    "source_hash": "1e73119d"
+  },
+  "web.admin.domains.probe.fields.expiresIn": {
+    "text": "{date} (dni: {days})",
+    "source_hash": "a71a6e81"
+  },
+  "web.admin.domains.tls.serving": {
+    "text": "Obsługuje",
+    "source_hash": "f55e53f9"
+  },
+  "web.admin.domains.tls.resolving": {
+    "text": "Rozwiązywanie",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.tls.none": {
+    "text": "Nie obsługuje",
+    "source_hash": "da8a5ab9"
   }
 }

--- a/locales/content/pl/admin-organizations.json
+++ b/locales/content/pl/admin-organizations.json
@@ -310,5 +310,333 @@
   "web.admin.organizations.list.loadError": {
     "text": "Nie można załadować organizacji.",
     "source_hash": "130d5e70"
+  },
+  "web.admin.organizations.addMember.button": {
+    "text": "Dodaj istniejące konto",
+    "source_hash": "45a3b757"
+  },
+  "web.admin.organizations.addMember.title": {
+    "text": "Dodaj istniejące konto",
+    "source_hash": "2f676a94"
+  },
+  "web.admin.organizations.addMember.description": {
+    "text": "Dodaj do {org} osobę, która ma już konto. Użyj tej opcji, gdy ktoś zarejestrował się samodzielnie i nie można go zaprosić, ponieważ konto już istnieje.",
+    "source_hash": "bb41faa6"
+  },
+  "web.admin.organizations.addMember.searchLabel": {
+    "text": "Adres e-mail lub identyfikator konta",
+    "source_hash": "82b3040b"
+  },
+  "web.admin.organizations.addMember.searchPlaceholder": {
+    "text": "Szukaj według adresu e-mail",
+    "source_hash": "b75cc66c"
+  },
+  "web.admin.organizations.addMember.searchHint": {
+    "text": "Dopasowuje część adresu e-mail lub dokładny identyfikator konta.",
+    "source_hash": "84547a60"
+  },
+  "web.admin.organizations.addMember.searchError": {
+    "text": "Nie udało się wyszukać kont. Sprawdź połączenie i spróbuj ponownie.",
+    "source_hash": "4b6caa41"
+  },
+  "web.admin.organizations.addMember.searchParseError": {
+    "text": "Wyszukiwanie kont zwróciło nieoczekiwaną odpowiedź. Wyniki mogą być niekompletne.",
+    "source_hash": "0c814231"
+  },
+  "web.admin.organizations.addMember.idle": {
+    "text": "Wprowadź adres e-mail, aby znaleźć konto.",
+    "source_hash": "f6340d35"
+  },
+  "web.admin.organizations.addMember.noResults": {
+    "text": "Żadne konto nie pasuje do „{term}”.",
+    "source_hash": "199b662a"
+  },
+  "web.admin.organizations.addMember.noResultsHint": {
+    "text": "Tutaj można dodać tylko istniejące konta. Jeśli dana osoba nigdy się nie rejestrowała, zamiast tego wyślij jej zaproszenie.",
+    "source_hash": "ee90aeeb"
+  },
+  "web.admin.organizations.addMember.select": {
+    "text": "Wybierz",
+    "source_hash": "2a78025d"
+  },
+  "web.admin.organizations.addMember.selectedEyebrow": {
+    "text": "Wybrane konto",
+    "source_hash": "8b63d947"
+  },
+  "web.admin.organizations.addMember.change": {
+    "text": "Wybierz inne konto",
+    "source_hash": "d4fe39ab"
+  },
+  "web.admin.organizations.addMember.createdOn": {
+    "text": "Zarejestrowano {date}",
+    "source_hash": "cfc0e19f"
+  },
+  "web.admin.organizations.addMember.organizationsUnavailable": {
+    "text": "Nie udało się załadować bieżących organizacji tego konta.",
+    "source_hash": "a35b6bfc"
+  },
+  "web.admin.organizations.addMember.defaultOrg": {
+    "text": "domyślna",
+    "source_hash": "37a8eec1"
+  },
+  "web.admin.organizations.addMember.roleLabel": {
+    "text": "Rola w tej organizacji",
+    "source_hash": "817475fa"
+  },
+  "web.admin.organizations.addMember.submit": {
+    "text": "Dodaj do organizacji",
+    "source_hash": "0e0cb636"
+  },
+  "web.admin.organizations.addMember.success": {
+    "text": "Dodano {account} jako {role}.",
+    "source_hash": "533be0dc"
+  },
+  "web.admin.organizations.addMember.badges.verified": {
+    "text": "Zweryfikowane",
+    "source_hash": "4f783840"
+  },
+  "web.admin.organizations.addMember.badges.unverified": {
+    "text": "Niezweryfikowane",
+    "source_hash": "15133907"
+  },
+  "web.admin.organizations.addMember.badges.suspended": {
+    "text": "Zawieszone",
+    "source_hash": "e392a389"
+  },
+  "web.admin.organizations.addMember.badges.alreadyMember": {
+    "text": "Już jest członkiem",
+    "source_hash": "1739ed7c"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMember": {
+    "text": "To konto jest już członkiem tej organizacji z rolą {role}. Dodanie nie zmienia istniejącej roli — użyj do tego działania ustawiania roli.",
+    "source_hash": "cb6a4774"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMemberUnknownRole": {
+    "text": "To konto jest już członkiem tej organizacji. Dodanie nie zmienia istniejącej roli.",
+    "source_hash": "035641ec"
+  },
+  "web.admin.organizations.addMember.errors.notFound": {
+    "text": "To konto lub ta organizacja już nie istnieje. Wyszukaj ponownie, aby potwierdzić konto.",
+    "source_hash": "bd88db18"
+  },
+  "web.admin.organizations.addMember.errors.invalidRole": {
+    "text": "Ta rola została odrzucona. Wybierz jedną z wymienionych ról i spróbuj ponownie.",
+    "source_hash": "eb696a8f"
+  },
+  "web.admin.organizations.addMember.errors.noSelection": {
+    "text": "Nie wybrano żadnego konta.",
+    "source_hash": "dd15bb5b"
+  },
+  "web.admin.organizations.addMember.fields.created": {
+    "text": "Zarejestrowano",
+    "source_hash": "486b3fe0"
+  },
+  "web.admin.organizations.addMember.fields.verified": {
+    "text": "Weryfikacja",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.organizations.addMember.fields.lastLogin": {
+    "text": "Ostatnie logowanie",
+    "source_hash": "0b70af7a"
+  },
+  "web.admin.organizations.addMember.fields.organizations": {
+    "text": "Bieżące organizacje",
+    "source_hash": "cbb5b92f"
+  },
+  "web.admin.organizations.addMember.roleHints.member": {
+    "text": "Codzienny dostęp do sekretów i domen organizacji.",
+    "source_hash": "d0c7439e"
+  },
+  "web.admin.organizations.addMember.roleHints.admin": {
+    "text": "Może zarządzać członkami, domenami i ustawieniami organizacji.",
+    "source_hash": "beaa50d7"
+  },
+  "web.admin.organizations.addMember.roleHints.owner": {
+    "text": "Pełna kontrola, w tym płatności. Przyznawaj tę rolę tylko na wyraźną prośbę.",
+    "source_hash": "614ace63"
+  },
+  "web.admin.organizations.addMember.roles.member": {
+    "text": "Członek",
+    "source_hash": "7c968fb7"
+  },
+  "web.admin.organizations.addMember.roles.admin": {
+    "text": "Administrator",
+    "source_hash": "c1c224b0"
+  },
+  "web.admin.organizations.addMember.roles.owner": {
+    "text": "Właściciel",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.detail.members.openCustomer": {
+    "text": "Otwórz rekord klienta",
+    "source_hash": "c057ca13"
+  },
+  "web.admin.organizations.detail.reconcile.memberships": {
+    "text": "Ponownie zmaterializowane członkostwa:",
+    "source_hash": "fe7db10c"
+  },
+  "web.admin.organizations.detail.reconcile.membershipsFailed": {
+    "text": "niepowodzenie, pozostają nieaktualne uprawnienia:",
+    "source_hash": "cc4dae37"
+  },
+  "web.admin.organizations.entitlements.catalogWarning": {
+    "text": "„{entitlement}” nie znajduje się w katalogu płatności — sprawdź, czy nie ma literówki. Mimo to kontynuujemy: przyznanie uprawnienia dostarczanego w późniejszym katalogu jest obsługiwane i celowo nieblokowane.",
+    "source_hash": "cbde548a"
+  },
+  "web.admin.organizations.entitlements.matrix.caption": {
+    "text": "Macierz rozstrzygania uprawnień: plan, przyznania i odebrania z nadpisań, zbiór wynikowy oraz to, co jest zmaterializowane.",
+    "source_hash": "9eac8999"
+  },
+  "web.admin.organizations.entitlements.matrix.yes": {
+    "text": "Tak",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.matrix.no": {
+    "text": "Nie",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.matrix.empty": {
+    "text": "Ta organizacja nie ma żadnych uprawnień z planu ani żadnych nadpisań.",
+    "source_hash": "f6cf2169"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.entitlement": {
+    "text": "Uprawnienie",
+    "source_hash": "0d8f0b2d"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.inPlan": {
+    "text": "W planie",
+    "source_hash": "e2222361"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.granted": {
+    "text": "Przyznane",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.revoked": {
+    "text": "Odebrane",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.expected": {
+    "text": "Oczekiwane",
+    "source_hash": "ca99b7f1"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.materialized": {
+    "text": "Zmaterializowane",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.state": {
+    "text": "Stan",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.formula": {
+    "text": "Rozstrzyganie: oczekiwane = (plan ∪ przyznania) − odebrania. Zmaterializowane to to, co jest faktycznie zapisane w organizacji.",
+    "source_hash": "bc4bff2d"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.orphaned": {
+    "text": "Osierocone — zmaterializowane, ale nieoczekiwane, zwykle pozostawione przez odebranie, które nigdy nie zostało ponownie zmaterializowane. Uzgodnienie je usuwa.",
+    "source_hash": "3a27a9af"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.missing": {
+    "text": "Brakujące — oczekiwane, ale niezmaterializowane. To jest uprawnienie, którego członkom faktycznie teraz brakuje.",
+    "source_hash": "485e44ad"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.revoked": {
+    "text": "Przekreślone wiersze są odebrane przez nadpisanie administratora, co usuwa je ze zbioru oczekiwanego.",
+    "source_hash": "89a2e9b6"
+  },
+  "web.admin.organizations.entitlements.matrix.state.plan": {
+    "text": "Z planu",
+    "source_hash": "1d346b26"
+  },
+  "web.admin.organizations.entitlements.matrix.state.granted": {
+    "text": "Przyznane",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.state.revoked": {
+    "text": "Odebrane",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.state.orphaned": {
+    "text": "Osierocone",
+    "source_hash": "8d827807"
+  },
+  "web.admin.organizations.entitlements.matrix.state.missing": {
+    "text": "Brakujące",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.organizations.entitlements.picker.selectPlaceholder": {
+    "text": "Wybierz uprawnienie…",
+    "source_hash": "53af3be8"
+  },
+  "web.admin.organizations.entitlements.picker.other": {
+    "text": "Inne — spoza katalogu…",
+    "source_hash": "f08bc3a3"
+  },
+  "web.admin.organizations.entitlements.picker.customLabel": {
+    "text": "Nazwa uprawnienia (spoza katalogu)",
+    "source_hash": "52783229"
+  },
+  "web.admin.organizations.entitlements.picker.backToCatalog": {
+    "text": "Powrót do katalogu",
+    "source_hash": "9b727f40"
+  },
+  "web.admin.organizations.entitlements.picker.uncategorized": {
+    "text": "Bez kategorii",
+    "source_hash": "8d40d123"
+  },
+  "web.admin.organizations.entitlements.picker.catalogUnavailable": {
+    "text": "Nie udało się odczytać katalogu płatności, więc nazwy uprawnień nie są tutaj sprawdzane.",
+    "source_hash": "724869ec"
+  },
+  "web.admin.organizations.entitlements.picker.tags.inPlan": {
+    "text": "w planie",
+    "source_hash": "5f2251bb"
+  },
+  "web.admin.organizations.entitlements.picker.tags.granted": {
+    "text": "przyznane",
+    "source_hash": "dd515d19"
+  },
+  "web.admin.organizations.entitlements.picker.tags.revoked": {
+    "text": "odebrane",
+    "source_hash": "4bb47f18"
+  },
+  "web.admin.organizations.entitlements.summary.sync": {
+    "text": "Synchronizacja",
+    "source_hash": "8d261a37"
+  },
+  "web.admin.organizations.entitlements.summary.materialized": {
+    "text": "Zmaterializowane",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.summary.materializedAt": {
+    "text": "Ostatnia materializacja",
+    "source_hash": "9325dce9"
+  },
+  "web.admin.organizations.entitlements.summary.planDefinition": {
+    "text": "Definicja planu",
+    "source_hash": "6b531454"
+  },
+  "web.admin.organizations.entitlements.summary.yes": {
+    "text": "Tak",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.summary.no": {
+    "text": "Nie",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.summary.never": {
+    "text": "Nigdy",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.organizations.entitlements.summary.planStale": {
+    "text": "Zmieniona od czasu materializacji",
+    "source_hash": "e682d8a4"
+  },
+  "web.admin.organizations.entitlements.summary.planCurrent": {
+    "text": "Aktualna",
+    "source_hash": "e0d1b682"
+  },
+  "web.admin.organizations.entitlements.summary.planUnknown": {
+    "text": "Nieznana — nie udało się porównać",
+    "source_hash": "b607e540"
   }
 }

--- a/locales/content/pl/admin-secrets.json
+++ b/locales/content/pl/admin-secrets.json
@@ -1,11 +1,11 @@
 {
   "web.admin.secrets.title": {
-    "text": "Sekrety",
-    "source_hash": "d8707d41"
+    "text": "Potwierdzenia sekretów",
+    "source_hash": "a8a2d0e4"
   },
   "web.admin.secrets.description": {
-    "text": "Sprawdź potwierdzenie sekretu i usuń go bez SSH — wyszukaj go według jego klucza.",
-    "source_hash": "07775a11"
+    "text": "Sprawdź stan, znaczniki czasu, potwierdzenie itp.",
+    "source_hash": "91fba2a1"
   },
   "web.admin.secrets.never": {
     "text": "Nigdy",
@@ -108,20 +108,20 @@
     "source_hash": "504101bc"
   },
   "web.admin.secrets.lookup.resultTitle": {
-    "text": "Sekret {shortid}",
-    "source_hash": "8b311d32"
+    "text": "Rekord sekretu {shortid}",
+    "source_hash": "ee06d765"
   },
   "web.admin.secrets.lookup.notFound": {
-    "text": "Nie znaleziono sekretu",
-    "source_hash": "70a9532c"
+    "text": "Nie znaleziono rekordu",
+    "source_hash": "40f4d9e9"
   },
   "web.admin.secrets.lookup.notFoundDescription": {
     "text": "Nie istnieje żaden sekret z tym kluczem. Mógł wygasnąć lub zostać usunięty.",
     "source_hash": "9f068a81"
   },
   "web.admin.secrets.lookup.loadError": {
-    "text": "Nie można załadować tego sekretu.",
-    "source_hash": "c96672e4"
+    "text": "Nie udało się załadować tego rekordu.",
+    "source_hash": "de77cc72"
   },
   "web.admin.secrets.lookup.retry": {
     "text": "Spróbuj ponownie",
@@ -188,8 +188,8 @@
     "source_hash": "c127dab6"
   },
   "web.admin.secrets.sections.secret": {
-    "text": "Sekret",
-    "source_hash": "7e32a729"
+    "text": "Rekord sekretu",
+    "source_hash": "263813c6"
   },
   "web.admin.secrets.sections.receipt": {
     "text": "Potwierdzenie",
@@ -214,5 +214,25 @@
   "web.admin.secrets.state.viewed": {
     "text": "Wyświetlony",
     "source_hash": "1b28d178"
+  },
+  "web.admin.secrets.capability.title": {
+    "text": "Tylko metadane",
+    "source_hash": "df0453d1"
+  },
+  "web.admin.secrets.capability.canRead": {
+    "text": "Odczytuje metadane sekretu i jego potwierdzenie: stan, znaczniki czasu, właściciela oraz rozmiar zapisanego szyfrogramu.",
+    "source_hash": "d438ecc7"
+  },
+  "web.admin.secrets.capability.cannotRead": {
+    "text": "Nie może odszyfrować ani wyświetlić treści sekretu. Punkt końcowy stojący za tym ekranem nigdy jej nie zwraca.",
+    "source_hash": "7f69f222"
+  },
+  "web.admin.secrets.capability.canDelete": {
+    "text": "Może trwale usunąć sekret i jego potwierdzenie, co niszczy treść bez jej ujawniania.",
+    "source_hash": "77f2bc7e"
+  },
+  "web.admin.secrets.lookup.hint": {
+    "text": "Identyfikator z linku do sekretu — nie treść sekretu.",
+    "source_hash": "acfbc352"
   }
 }

--- a/locales/content/pl/admin-system.json
+++ b/locales/content/pl/admin-system.json
@@ -154,5 +154,133 @@
   "web.admin.system.redis.captured": {
     "text": "Przechwycono {at}",
     "source_hash": "57b40c0f"
+  },
+  "web.admin.system.brand.title": {
+    "text": "Diagnostyka marki",
+    "source_hash": "1cf9abd5"
+  },
+  "web.admin.system.brand.description": {
+    "text": "Który pakiet marki działająca instancja odnalazła na dysku — pokazuje, dlaczego region może serwować neutralny branding.",
+    "source_hash": "be29e282"
+  },
+  "web.admin.system.brand.loadError": {
+    "text": "Nie udało się załadować diagnostyki marki.",
+    "source_hash": "80607303"
+  },
+  "web.admin.system.brand.none": {
+    "text": "(brak)",
+    "source_hash": "552e4230"
+  },
+  "web.admin.system.brand.resolution": {
+    "text": "Rozstrzyganie",
+    "source_hash": "d4055faf"
+  },
+  "web.admin.system.brand.envVsConfig": {
+    "text": "Środowisko a konfiguracja",
+    "source_hash": "bee3debb"
+  },
+  "web.admin.system.brand.absorbed": {
+    "text": "Wchłonięte klucze",
+    "source_hash": "9784e110"
+  },
+  "web.admin.system.brand.operatorKeys": {
+    "text": "Klucze operatora",
+    "source_hash": "434e8248"
+  },
+  "web.admin.system.brand.overlayAssets": {
+    "text": "Zasoby nakładki",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.exists.yes": {
+    "text": "Obecny",
+    "source_hash": "43f9b89c"
+  },
+  "web.admin.system.brand.exists.no": {
+    "text": "Brak",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.system.brand.fields.resolvedDir": {
+    "text": "Rozstrzygnięty katalog",
+    "source_hash": "0623b983"
+  },
+  "web.admin.system.brand.fields.home": {
+    "text": "Katalog domowy",
+    "source_hash": "3a786953"
+  },
+  "web.admin.system.brand.fields.envPack": {
+    "text": "Pakiet marki ze zmiennej ENV",
+    "source_hash": "940aeb5c"
+  },
+  "web.admin.system.brand.fields.configPack": {
+    "text": "Pakiet marki z konfiguracji",
+    "source_hash": "761b9550"
+  },
+  "web.admin.system.brand.fields.envAssetsDir": {
+    "text": "Katalog zasobów marki ze zmiennej ENV",
+    "source_hash": "05854f1f"
+  },
+  "web.admin.system.brand.fields.configAssetsDir": {
+    "text": "Katalog zasobów marki z konfiguracji",
+    "source_hash": "e91e5c46"
+  },
+  "web.admin.system.brand.flags.fellBack.danger": {
+    "text": "Powrót do domyślnego pakietu",
+    "source_hash": "7bf7ba2f"
+  },
+  "web.admin.system.brand.flags.fellBack.ok": {
+    "text": "Pakiet marki rozstrzygnięty",
+    "source_hash": "1ab3162f"
+  },
+  "web.admin.system.brand.flags.mismatch.danger": {
+    "text": "Niezgodność uruchomienia i stanu bieżącego",
+    "source_hash": "0a022192"
+  },
+  "web.admin.system.brand.flags.mismatch.ok": {
+    "text": "Stan uruchomienia zgodny z bieżącym",
+    "source_hash": "d4792c09"
+  },
+  "web.admin.system.brand.manifest.title": {
+    "text": "Manifest",
+    "source_hash": "3c99f1f3"
+  },
+  "web.admin.system.brand.manifest.path": {
+    "text": "Ścieżka",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.manifest.exists": {
+    "text": "Istnieje",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.manifest.keysOnDisk": {
+    "text": "Klucze na dysku",
+    "source_hash": "52439c03"
+  },
+  "web.admin.system.brand.roots.title": {
+    "text": "Katalogi wyszukiwania",
+    "source_hash": "d8696f2b"
+  },
+  "web.admin.system.brand.roots.empty": {
+    "text": "Brak katalogów wyszukiwania",
+    "source_hash": "867a471c"
+  },
+  "web.admin.system.brand.roots.columns.path": {
+    "text": "Ścieżka",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.roots.columns.exists": {
+    "text": "Istnieje",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.stats.brandPack": {
+    "text": "Pakiet marki",
+    "source_hash": "884437d0"
+  },
+  "web.admin.system.brand.stats.overlayAssets": {
+    "text": "Zasoby nakładki",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.stats.manifestKeys": {
+    "text": "Klucze manifestu",
+    "source_hash": "c4267198"
   }
 }

--- a/locales/content/pl/email.json
+++ b/locales/content/pl/email.json
@@ -836,5 +836,41 @@
   "email.secret_link.footer_note": {
     "text": "Otrzymujesz tę wiadomość, ponieważ %{sender_email} użył %{product_name}, aby udostępnić Ci sekret. Jeśli się tego nie spodziewałeś, możesz bezpiecznie zignorować tę wiadomość.",
     "source_hash": "2d544dad"
+  },
+  "email.sso_link_verification.subject": {
+    "text": "Potwierdź powiązanie %{provider} z Twoim kontem %{product_name}",
+    "source_hash": "65e70296"
+  },
+  "email.sso_link_verification.title": {
+    "text": "Potwierdź logowanie SSO",
+    "source_hash": "35bce6cc"
+  },
+  "email.sso_link_verification.request_notice": {
+    "text": "Ktoś zalogował się za pomocą %{provider}, używając adresu e-mail %{email_address}. Aby zakończyć łączenie %{provider} z Twoim kontem %{product_name}, potwierdź poniżej.",
+    "source_hash": "baeb18c0"
+  },
+  "email.sso_link_verification.confirm_button": {
+    "text": "Potwierdź i połącz %{provider}",
+    "source_hash": "9809e210"
+  },
+  "email.sso_link_verification.copy_link_prompt": {
+    "text": "Lub skopiuj i wklej ten link:",
+    "source_hash": "88c72144"
+  },
+  "email.sso_link_verification.expiration_notice": {
+    "text": "Ten link wygasa po 15 minutach i można go użyć tylko raz.",
+    "source_hash": "1a437f42"
+  },
+  "email.sso_link_verification.ignore_notice": {
+    "text": "Jeśli nie próbowałeś logować się za pomocą %{provider}, możesz bezpiecznie zignorować tę wiadomość — nic nie zostanie połączone z Twoim kontem.",
+    "source_hash": "d7317d30"
+  },
+  "email.sso_link_verification.signature": {
+    "text": "Zespół pomocy technicznej",
+    "source_hash": "dc75bf9f"
+  },
+  "email.sso_link_verification.postscript": {
+    "text": "PS. Ta wiadomość została wysłana na adres %{email_address}.",
+    "source_hash": "8ab1dbea"
   }
 }

--- a/locales/content/pl/session-auth-extended.json
+++ b/locales/content/pl/session-auth-extended.json
@@ -757,6 +757,7 @@
   },
   "web.auth.connections.connect_action": {
     "text": "Połącz {provider}",
+    "context": "Button label to start linking a specific SSO provider; {provider} is the provider display name",
     "source_hash": "c77540af"
   },
   "web.auth.connections.issuer": {
@@ -821,6 +822,7 @@
   },
   "web.link_sso.prompt": {
     "text": "Zalogowałeś się za pomocą {provider}, co odpowiada istniejącemu kontu {email}. Wprowadź hasło tego konta, aby powiązać {provider} i kontynuować.",
+    "context": "Instruction on the sign-in interstitial. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/link-sso/:token.",
     "source_hash": "59da1c08"
   },
   "web.link_sso.password_label": {
@@ -881,6 +883,7 @@
   },
   "web.sso_link_confirm.prompt": {
     "text": "Zalogowałeś się za pomocą {provider}, co odpowiada Twojemu kontu {email}. Potwierdź, aby połączyć {provider} z tym kontem i dokończyć logowanie.",
+    "context": "Consent instruction on the #3840 Phase 4 mailbox-proof SSO linking page. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/sso-link-confirm/:token. No password is asked — clicking the emailed link is the proof.",
     "source_hash": "6ff0d6cc"
   },
   "web.sso_link_confirm.submit": {

--- a/locales/content/pl/session-auth-extended.json
+++ b/locales/content/pl/session-auth-extended.json
@@ -730,5 +730,201 @@
   "web.auth.sessions.session_plural": {
     "text": "sesje",
     "source_hash": "1225ae6c"
+  },
+  "web.auth.connections.title": {
+    "text": "Połączone tożsamości",
+    "source_hash": "e132c4d9"
+  },
+  "web.auth.connections.description": {
+    "text": "Zarządzaj dostawcami jednokrotnego logowania połączonymi z Twoim kontem.",
+    "source_hash": "42c6d148"
+  },
+  "web.auth.connections.section_title": {
+    "text": "Jednokrotne logowanie",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.section_subtitle": {
+    "text": "Dostawcy tożsamości, których możesz użyć do zalogowania się na to konto",
+    "source_hash": "507254cd"
+  },
+  "web.auth.connections.connect_title": {
+    "text": "Połącz dostawcę",
+    "source_hash": "a002b3f3"
+  },
+  "web.auth.connections.connect_description": {
+    "text": "Połącz kolejnego dostawcę jednokrotnego logowania, którego możesz użyć do zalogowania się na to konto.",
+    "source_hash": "32895a5a"
+  },
+  "web.auth.connections.connect_action": {
+    "text": "Połącz {provider}",
+    "source_hash": "c77540af"
+  },
+  "web.auth.connections.issuer": {
+    "text": "Wystawca",
+    "source_hash": "39e02c46"
+  },
+  "web.auth.connections.identifier": {
+    "text": "Identyfikator",
+    "source_hash": "9b10587f"
+  },
+  "web.auth.connections.remove": {
+    "text": "Usuń",
+    "source_hash": "c3812fc4"
+  },
+  "web.auth.connections.remove_confirm_title": {
+    "text": "Usuń połączoną tożsamość",
+    "source_hash": "4e8ffe4c"
+  },
+  "web.auth.connections.remove_confirm_message": {
+    "text": "Czy na pewno chcesz usunąć tę połączoną tożsamość? Nie będziesz już mógł się za jej pomocą zalogować.",
+    "source_hash": "64939c89"
+  },
+  "web.auth.connections.removed_success": {
+    "text": "Połączona tożsamość została usunięta",
+    "source_hash": "cf87daf3"
+  },
+  "web.auth.connections.no_identities": {
+    "text": "Brak połączonych tożsamości",
+    "source_hash": "5254048e"
+  },
+  "web.auth.connections.no_identities_description": {
+    "text": "Nie połączyłeś jeszcze z tym kontem żadnego dostawcy jednokrotnego logowania.",
+    "source_hash": "0f58d5d0"
+  },
+  "web.auth.connections.overview_status": {
+    "text": "Jednokrotne logowanie",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.errors.last_credential": {
+    "text": "To jedyny sposób, w jaki możesz się zalogować. Najpierw połącz innego dostawcę lub ustaw hasło w Ustawienia → Zabezpieczenia, aby nie stracić dostępu.",
+    "source_hash": "3de8084d"
+  },
+  "web.auth.connections.errors.last_credential_sso_enforced": {
+    "text": "To jedyny sposób, w jaki możesz się zalogować. Najpierw połącz innego dostawcę, aby nie stracić dostępu.",
+    "source_hash": "eed7a50e"
+  },
+  "web.auth.connections.errors.not_found": {
+    "text": "Nie znaleziono tej połączonej tożsamości. Mogła zostać już usunięta.",
+    "source_hash": "cf2c7673"
+  },
+  "web.auth.connections.errors.unauthorized": {
+    "text": "Twoja sesja wygasła. Zaloguj się ponownie.",
+    "source_hash": "b529fce2"
+  },
+  "web.auth.connections.errors.generic": {
+    "text": "Nie udało się wykonać tego działania. Spróbuj ponownie.",
+    "source_hash": "a0d4edc0"
+  },
+  "web.link_sso.title": {
+    "text": "Powiąż swoją metodę logowania",
+    "source_hash": "46339bac"
+  },
+  "web.link_sso.prompt": {
+    "text": "Zalogowałeś się za pomocą {provider}, co odpowiada istniejącemu kontu {email}. Wprowadź hasło tego konta, aby powiązać {provider} i kontynuować.",
+    "source_hash": "59da1c08"
+  },
+  "web.link_sso.password_label": {
+    "text": "Hasło",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.link_sso.password_placeholder": {
+    "text": "Twoje dotychczasowe hasło",
+    "source_hash": "ad4e56da"
+  },
+  "web.link_sso.submit": {
+    "text": "Powiąż i kontynuuj",
+    "source_hash": "c969b759"
+  },
+  "web.link_sso.cancel": {
+    "text": "Anuluj",
+    "source_hash": "19766ed6"
+  },
+  "web.link_sso.unavailable_title": {
+    "text": "To żądanie powiązania wygasło",
+    "source_hash": "b53c7e55"
+  },
+  "web.link_sso.unavailable_message": {
+    "text": "Ze względów bezpieczeństwa żądanie powiązania tej metody logowania nie jest już ważne. Zaloguj się dotychczasowym hasłem, a następnie połącz tego dostawcę w Ustawieniach zabezpieczeń → Połączone tożsamości.",
+    "source_hash": "f7e349d1"
+  },
+  "web.link_sso.unavailable_action": {
+    "text": "Przejdź do logowania",
+    "source_hash": "d398cd0a"
+  },
+  "web.link_sso.errors.invalid_password": {
+    "text": "To hasło nie pasuje do tego konta. Spróbuj ponownie.",
+    "source_hash": "3259b4f5"
+  },
+  "web.link_sso.errors.invalid_token": {
+    "text": "To żądanie powiązania wygasło lub zostało już użyte. Zaloguj się dotychczasowym hasłem, a następnie połącz tego dostawcę w ustawieniach konta.",
+    "source_hash": "541f9127"
+  },
+  "web.link_sso.errors.link_conflict": {
+    "text": "Nie udało się powiązać tej metody logowania. Twoje konto mogło ulec zmianie lub ten dostawca jest już powiązany z innym kontem. Zaloguj się dotychczasowym hasłem, a następnie zarządzaj połączeniami w Ustawieniach zabezpieczeń → Połączone tożsamości.",
+    "source_hash": "7b0e0d0e"
+  },
+  "web.link_sso.errors.link_rate_limited": {
+    "text": "Zbyt wiele prób podania hasła. Odczekaj kilka minut i spróbuj ponownie.",
+    "source_hash": "a95e78cd"
+  },
+  "web.link_sso.errors.invalid_request": {
+    "text": "Nie udało się przetworzyć tego żądania powiązania. Zaloguj się ponownie u swojego dostawcy SSO.",
+    "source_hash": "053b9fc6"
+  },
+  "web.link_sso.errors.generic": {
+    "text": "Nie udało się powiązać Twojego konta. Spróbuj ponownie.",
+    "source_hash": "f727c174"
+  },
+  "web.sso_link_confirm.title": {
+    "text": "Potwierdź połączenie konta",
+    "source_hash": "ad80bfe7"
+  },
+  "web.sso_link_confirm.prompt": {
+    "text": "Zalogowałeś się za pomocą {provider}, co odpowiada Twojemu kontu {email}. Potwierdź, aby połączyć {provider} z tym kontem i dokończyć logowanie.",
+    "source_hash": "6ff0d6cc"
+  },
+  "web.sso_link_confirm.submit": {
+    "text": "Potwierdź i połącz",
+    "source_hash": "5cf663e6"
+  },
+  "web.sso_link_confirm.cancel": {
+    "text": "Anuluj",
+    "source_hash": "19766ed6"
+  },
+  "web.sso_link_confirm.unavailable_title": {
+    "text": "Nie można ukończyć tego żądania powiązania",
+    "source_hash": "47abb784"
+  },
+  "web.sso_link_confirm.unavailable_message": {
+    "text": "Ze względów bezpieczeństwa to żądanie połączenia metody logowania nie jest już ważne. Zaloguj się ponownie u swojego dostawcy, a wyślemy Ci e-mailem nowy link.",
+    "source_hash": "080e6f9f"
+  },
+  "web.sso_link_confirm.unavailable_action": {
+    "text": "Wróć do logowania",
+    "source_hash": "8504054f"
+  },
+  "web.sso_link_confirm.errors.link_expired": {
+    "text": "To żądanie powiązania wygasło lub zostało już użyte. Zaloguj się ponownie u swojego dostawcy, a wyślemy Ci e-mailem nowy link.",
+    "source_hash": "a50538df"
+  },
+  "web.sso_link_confirm.errors.link_conflict": {
+    "text": "Nie udało się połączyć tej metody logowania. Twoje konto mogło ulec zmianie lub ten dostawca jest już powiązany z innym kontem. Zaloguj się ponownie u swojego dostawcy, aby kontynuować.",
+    "source_hash": "c954854b"
+  },
+  "web.sso_link_confirm.errors.link_invalidated": {
+    "text": "Dane logowania do Twojego konta zmieniły się po wysłaniu tego linku, więc nie jest on już ważny. Zaloguj się ponownie u swojego dostawcy, a wyślemy Ci e-mailem nowy link.",
+    "source_hash": "db88cb1d"
+  },
+  "web.sso_link_confirm.errors.link_error": {
+    "text": "Coś poszło nie tak po naszej stronie i nie udało się zweryfikować tego linku. Zaloguj się ponownie u swojego dostawcy, a wyślemy Ci e-mailem nowy.",
+    "source_hash": "ec24e0a1"
+  },
+  "web.sso_link_confirm.errors.confirm_rate_limited": {
+    "text": "Zbyt wiele prób z Twojego urządzenia. Odczekaj kilka minut, a następnie otwórz ponownie link z wiadomości e-mail lub zaloguj się u swojego dostawcy, aby otrzymać nowy.",
+    "source_hash": "f29af782"
+  },
+  "web.sso_link_confirm.errors.generic": {
+    "text": "Nie udało się potwierdzić tego połączenia. Zaloguj się ponownie u swojego dostawcy.",
+    "source_hash": "076fa25a"
   }
 }

--- a/locales/content/pl/session-auth.json
+++ b/locales/content/pl/session-auth.json
@@ -483,5 +483,41 @@
   "web.login.verified_notice": {
     "text": "Twój adres e-mail został zweryfikowany — możesz się teraz zalogować.",
     "source_hash": "c8d4b5a8"
+  },
+  "web.auth.password_setup_request.title": {
+    "text": "Ustaw hasło",
+    "source_hash": "11b6978b"
+  },
+  "web.auth.password_setup_request.description": {
+    "text": "Twoje konto nie ma jeszcze hasła. Wyślemy Ci e-mailem bezpieczny link, aby je ustawić, dzięki czemu będziesz mógł logować się także bezpośrednio.",
+    "source_hash": "dc0b561f"
+  },
+  "web.auth.password_setup_request.button": {
+    "text": "Wyślij link konfiguracyjny",
+    "source_hash": "22807292"
+  },
+  "web.auth.password_setup_request.emailSent": {
+    "text": "Wysłaliśmy do Ciebie e-mail z linkiem do ustawienia hasła dla Twojego konta",
+    "source_hash": "82b686c7"
+  },
+  "web.login.errors.account_exists_link_required": {
+    "text": "Konto z tym adresem e-mail już istnieje, ale nie jest powiązane z tą metodą logowania. Zaloguj się dotychczasową metodą, a następnie powiąż tego dostawcę w Ustawieniach zabezpieczeń → Połączone tożsamości.",
+    "source_hash": "7fbbb7e7"
+  },
+  "web.login.errors.identity_connect_conflict": {
+    "text": "Nie udało się połączyć tej tożsamości. Połączenie mogło zostać rozpoczęte w niewłaściwej domenie lub Twoja sesja wygasła. Zaloguj się ponownie, a następnie połącz ją w ustawieniach konta.",
+    "source_hash": "4238bbf2"
+  },
+  "web.login.errors.org_join_failed": {
+    "text": "Nie udało się dokończyć dodawania Cię do Twojej organizacji. Skontaktuj się ze swoim administratorem.",
+    "source_hash": "155e71bb"
+  },
+  "web.login.errors.link_sso_failed": {
+    "text": "Nie udało się powiązać tej metody logowania. Zaloguj się dotychczasowym hasłem, a następnie połącz tego dostawcę w Ustawieniach zabezpieczeń → Połączone tożsamości.",
+    "source_hash": "49954127"
+  },
+  "web.login.notices.link_verification_sent": {
+    "text": "Sprawdź skrzynkę odbiorczą — wysłaliśmy Ci e-mailem link potwierdzający połączenie konta. Otwórz go, aby dokończyć logowanie.",
+    "source_hash": "b251c8f3"
   }
 }

--- a/locales/content/pl/workspace-account.json
+++ b/locales/content/pl/workspace-account.json
@@ -694,5 +694,33 @@
   "web.settings.security.sso_managed_description": {
     "text": "Twoje konto jest uwierzytelniane za pośrednictwem dostawcy jednokrotnego logowania Twojej organizacji. Hasło, uwierzytelnianie wieloskładnikowe oraz kody odzyskiwania są zarządzane przez Twojego dostawcę tożsamości.",
     "source_hash": "cd0cf39f"
+  },
+  "web.settings.api.api_username": {
+    "text": "Nazwa użytkownika API",
+    "source_hash": "0b3e483e"
+  },
+  "web.settings.api.api_username_description": {
+    "text": "Twoja nazwa użytkownika do uwierzytelniania HTTP Basic",
+    "source_hash": "f3e65de3"
+  },
+  "web.settings.api.basic_auth_hint": {
+    "text": "W przypadku uwierzytelniania HTTP Basic użyj adresu e-mail konta lub tego identyfikatora jako nazwy użytkownika, a tokenu API jako hasła.",
+    "source_hash": "cfa3806d"
+  },
+  "web.settings.security.set": {
+    "text": "Ustawione",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.settings.security.not_set": {
+    "text": "Nieustawione",
+    "source_hash": "4895f731"
+  },
+  "web.settings.security.set_password_title": {
+    "text": "Ustaw hasło",
+    "source_hash": "4e411687"
+  },
+  "web.settings.security.set_password_description": {
+    "text": "Dodaj hasło do swojego konta, aby móc logować się także bez dostawcy tożsamości",
+    "source_hash": "a6970402"
   }
 }

--- a/locales/content/pl/workspace-billing.json
+++ b/locales/content/pl/workspace-billing.json
@@ -1044,5 +1044,21 @@
   "web.billing.plans.reactivate": {
     "text": "Reaktywuj",
     "source_hash": "2dc7478f"
+  },
+  "web.billing.currency_migration.refund_failed_warning": {
+    "text": "Twój poprzedni plan został anulowany, ale nie udało się automatycznie zrealizować zwrotu za niewykorzystany czas. Skontaktuj się z pomocą techniczną, aby otrzymać zwrot. Aby aktywować nowy plan, nadal musisz dokończyć płatność.",
+    "source_hash": "a390c498"
+  },
+  "web.billing.currency_migration.refund_failed_continue": {
+    "text": "Przejdź do płatności",
+    "source_hash": "eccdb8aa"
+  },
+  "web.billing.plans.per_year": {
+    "text": "/rok",
+    "source_hash": "a2d5f1bc"
+  },
+  "web.billing.plans.billing_interval": {
+    "text": "Okres rozliczeniowy",
+    "source_hash": "3ce28209"
   }
 }

--- a/locales/content/pl/workspace-branding.json
+++ b/locales/content/pl/workspace-branding.json
@@ -56,12 +56,12 @@
     "source_hash": "e36598ef"
   },
   "web.branding.example_pre_reveal_instructions": {
-    "text": "Użyj telefonu, aby zeskanować kod QR",
-    "source_hash": "99ecf59f"
+    "text": "np. Zeskanuj kod QR telefonem",
+    "source_hash": "9cf0caf8"
   },
   "web.branding.example_post_reveal_instructions": {
-    "text": "Skontaktuj się z onboarding{'@'}example.com w razie pytań",
-    "source_hash": "bee120a7"
+    "text": "np. W razie pytań skontaktuj się z onboarding{'@'}example.com",
+    "source_hash": "71749811"
   },
   "web.branding.these_instructions_will_be_shown_to_recipients_before": {
     "text": "Te instrukcje zostaną pokazane odbiorcom, zanim ujawnią treść wiadomości",
@@ -320,8 +320,8 @@
     "source_hash": "bc79cdff"
   },
   "web.branding.paths_carryover_hint": {
-    "text": "To jest podgląd na żywo — Twoje zmiany nie będą widoczne dla odwiedzających, dopóki ich nie zapiszesz.",
-    "source_hash": "cb4b82de"
+    "text": "To jest podgląd na żywo — Twoje zmiany nie będą widoczne dla odwiedzających, dopóki nie klikniesz Aktualizuj.",
+    "source_hash": "9a34df71"
   },
   "web.branding.coming_soon_match_blurb": {
     "text": "Wskaż nam swoją witrynę, a odczytamy jej kolory i czcionki, a następnie wypełnimy różnicę jednym kliknięciem.",
@@ -406,5 +406,57 @@
   "web.branding.delivery_after_reveal": {
     "text": "Po ujawnieniu",
     "source_hash": "d5bfe7fd"
+  },
+  "web.branding.favicon": {
+    "text": "Favicon",
+    "source_hash": "42955289"
+  },
+  "web.branding.refresh_favicon": {
+    "text": "Odśwież favicon z domeny",
+    "source_hash": "7cc3d5dc"
+  },
+  "web.branding.refresh_favicon_hint": {
+    "text": "Pobierz ponownie favicon ze swojej domeny. Nowa ikona pojawi się wkrótce.",
+    "source_hash": "ee007e44"
+  },
+  "web.branding.refresh_favicon_queued": {
+    "text": "Trwa odświeżanie favicona — nowa ikona pojawi się wkrótce.",
+    "source_hash": "6bf38e6e"
+  },
+  "web.branding.refresh_favicon_user_upload_hint": {
+    "text": "Przesłano własny favicon, więc pobrana ikona go nie zastąpi.",
+    "source_hash": "c22e1ed6"
+  },
+  "web.branding.upload_favicon": {
+    "text": "Prześlij favicon",
+    "source_hash": "ceda39cb"
+  },
+  "web.branding.replace_favicon": {
+    "text": "Zastąp",
+    "source_hash": "95e15439"
+  },
+  "web.branding.remove_favicon": {
+    "text": "Usuń favicon",
+    "source_hash": "03693698"
+  },
+  "web.branding.favicon_field_hint": {
+    "text": "ICO, PNG lub SVG. Przesłanie zastępuje pobraną ikonę.",
+    "source_hash": "dfa0bfcb"
+  },
+  "web.branding.favicon_preview_alt": {
+    "text": "Favicon domeny",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_title": {
+    "text": "Favicon domeny",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_hint": {
+    "text": "ICO, PNG lub SVG. Do 256 KB. Zastępuje automatycznie pobraną ikonę.",
+    "source_hash": "c9eafc83"
+  },
+  "web.branding.favicon_modal_save": {
+    "text": "Zapisz favicon",
+    "source_hash": "c8a1566c"
   }
 }

--- a/locales/content/pl/workspace-organizations.json
+++ b/locales/content/pl/workspace-organizations.json
@@ -1034,5 +1034,153 @@
   "web.organizations.create_workspace": {
     "text": "Utwórz obszar roboczy",
     "source_hash": "c63c14cf"
+  },
+  "web.organizations.organization_id": {
+    "text": "Identyfikator organizacji",
+    "source_hash": "1f466322"
+  },
+  "web.organizations.organization_id_hint": {
+    "text": "Użyj tego identyfikatora, kontaktując się z pomocą techniczną lub ograniczając żądania API do tej organizacji. Nie są to dane logowania.",
+    "source_hash": "29549b3a"
+  },
+  "web.organizations.audit.title": {
+    "text": "Aktywność sekretów",
+    "source_hash": "6d6d41f3"
+  },
+  "web.organizations.audit.description": {
+    "text": "Ślad audytu zdarzeń tworzenia i dostępu do sekretów zarejestrowanych dla tej organizacji.",
+    "source_hash": "553c564b"
+  },
+  "web.organizations.audit.country_unknown": {
+    "text": "Nieznany",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.empty_title": {
+    "text": "Brak aktywności",
+    "source_hash": "0a12b92c"
+  },
+  "web.organizations.audit.empty_description": {
+    "text": "Zdarzenia tworzenia i dostępu do sekretów pojawią się tutaj, gdy Twój zespół zacznie udostępniać sekrety.",
+    "source_hash": "62fb14c2"
+  },
+  "web.organizations.audit.capped_notice": {
+    "text": "Przechowywane są tylko najnowsze zdarzenia (maksymalnie {max}); starsza aktywność została usunięta.",
+    "source_hash": "da7901e2"
+  },
+  "web.organizations.audit.collection_paused_notice": {
+    "text": "Zbieranie zdarzeń jest wstrzymane; nowa aktywność sekretów nie jest rejestrowana.",
+    "source_hash": "cb09d147"
+  },
+  "web.organizations.audit.load_error": {
+    "text": "Nie można załadować aktywności sekretów.",
+    "source_hash": "52fde814"
+  },
+  "web.organizations.audit.contract_mismatch": {
+    "text": "Nie udało się odczytać danych aktywności zwróconych przez serwer. Ślad nie jest pusty — po prostu nie można go teraz wyświetlić.",
+    "source_hash": "db0d007a"
+  },
+  "web.organizations.audit.retry": {
+    "text": "Spróbuj ponownie",
+    "source_hash": "d8b8392e"
+  },
+  "web.organizations.audit.showing_range": {
+    "text": "Wyświetlanie {from}–{to} z {total}",
+    "source_hash": "c329279d"
+  },
+  "web.organizations.audit.upgrade_prompt": {
+    "text": "Aktywność sekretów wymaga planu z logami audytu. Ulepsz plan, aby zobaczyć, kto tworzył, wyświetlał i ujawniał sekrety w tej organizacji.",
+    "source_hash": "453649ce"
+  },
+  "web.organizations.audit.role_required": {
+    "text": "Aktywność sekretów jest dostępna dla właścicieli i administratorów organizacji.",
+    "source_hash": "e066ec63"
+  },
+  "web.organizations.audit.actors.creator": {
+    "text": "Twórca",
+    "source_hash": "88447b83"
+  },
+  "web.organizations.audit.actors.authenticated_other": {
+    "text": "Inny zalogowany użytkownik",
+    "source_hash": "ee45aa5a"
+  },
+  "web.organizations.audit.actors.anonymous": {
+    "text": "Anonimowy",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.organizations.audit.actors.system": {
+    "text": "System",
+    "source_hash": "6725e7bb"
+  },
+  "web.organizations.audit.actors.unknown": {
+    "text": "Nieznany",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.columns.event": {
+    "text": "Zdarzenie",
+    "source_hash": "4e1f49a9"
+  },
+  "web.organizations.audit.columns.secret": {
+    "text": "Sekret",
+    "source_hash": "7e32a729"
+  },
+  "web.organizations.audit.columns.actor": {
+    "text": "Wykonawca",
+    "source_hash": "449995c4"
+  },
+  "web.organizations.audit.columns.country": {
+    "text": "Kraj",
+    "source_hash": "701d021d"
+  },
+  "web.organizations.audit.columns.when": {
+    "text": "Kiedy",
+    "source_hash": "cf9c7aa2"
+  },
+  "web.organizations.audit.kinds.created": {
+    "text": "Utworzono sekret",
+    "source_hash": "e4a1e1fd"
+  },
+  "web.organizations.audit.kinds.status_get": {
+    "text": "Sprawdzono status linku",
+    "source_hash": "0753f60e"
+  },
+  "web.organizations.audit.kinds.secret_get": {
+    "text": "Otwarto link do sekretu",
+    "source_hash": "e271e060"
+  },
+  "web.organizations.audit.kinds.previewed": {
+    "text": "Podgląd przez twórcę",
+    "source_hash": "639fc1e2"
+  },
+  "web.organizations.audit.kinds.creator_status_get": {
+    "text": "Status sprawdzony przez twórcę",
+    "source_hash": "7e4b5de5"
+  },
+  "web.organizations.audit.kinds.receipt_viewed": {
+    "text": "Wyświetlono potwierdzenie",
+    "source_hash": "a417ead4"
+  },
+  "web.organizations.audit.kinds.revealed": {
+    "text": "Ujawniono sekret",
+    "source_hash": "aff2c84d"
+  },
+  "web.organizations.audit.kinds.burned": {
+    "text": "Zniszczono sekret",
+    "source_hash": "5ac68dc6"
+  },
+  "web.organizations.audit.kinds.expired": {
+    "text": "Sekret wygasł",
+    "source_hash": "c127dab6"
+  },
+  "web.organizations.audit.kinds.orphaned": {
+    "text": "Sekret osierocony",
+    "source_hash": "23fe1a47"
+  },
+  "web.organizations.audit.kinds.reveal_failed_undecryptable": {
+    "text": "Ujawnienie nie powiodło się (nie można odszyfrować)",
+    "source_hash": "d5616abf"
+  },
+  "web.organizations.tabs.activity": {
+    "text": "Aktywność",
+    "source_hash": "38da1505"
   }
 }


### PR DESCRIPTION
## `pl` translation update

Automated export of completed **pl** translations from the translation task DB.
Scope: `locales/content/pl/` only — 16 file(s), +2020/-20.

⚠️ `i18n validate variables` reports **3** variable mismatch(es) for `pl` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ⚠️ Needs review — 3 dropped `context` fields trip the var gate.

**Summary:** All new/changed `text` values are accurate, natural Polish with placeholders, brand terms, and hash pins correctly preserved. The automated check's 3 errors are all in the `context` (translator-note) sub-field, not the rendered `text`, for the new SSO-linking keys in `session-auth-extended.json`.

**Critical (must fix):**
- `web.auth.connections.connect_action`, `web.link_sso.prompt`, `web.sso_link_confirm.prompt` in `session-auth-extended.json`: the diff adds only `text`+`source_hash`, omitting the `context` field entirely. Every other entry in this file (and its English source) carries a `context` note, left untranslated in English by convention. The omission makes `context` flatten to `""`, which the variable-consistency check flags as an empty-with-vars error against `{provider}`/`{email}` — this will fail `tasks audit --strict` and block export per the agent protocol. Fix: copy the English `context` string through verbatim for these 3 keys.

**Warnings:** None — the `text` values for these same 3 keys correctly translate and preserve `{provider}`/`{email}`.

**Notes:**
- `web.branding.paths_carryover_hint` now says "...dopóki nie klikniesz Aktualizuj" (until you click Aktualizuj) — verified "Aktualizuj" is the actual shared Update-button label in `00-common.json`, so the reference is accurate.
- Several existing keys (`admin-secrets.json`, `admin-customers.json`) were re-translated alongside English source-hash changes (Sekrety→Potwierdzenia sekretów, etc.) — reviewed as faithful re-translations, not regressions.
- Math/set notation (∪, −) in `entitlements.matrix.legend.formula` matches source exactly.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
