### PR TITLE
i18n: update pt_BR translations

### DIFF
--- a/locales/content/pt_BR/00-common.json
+++ b/locales/content/pt_BR/00-common.json
@@ -1370,7 +1370,7 @@
     "source_hash": "6615bf1c"
   },
   "api.errors.service_unavailable": {
-    "text": "Serviço temporariamente indisponível. Por favor, tente novamente em breve.",
+    "text": "Serviço temporariamente indisponível. Tente novamente em breve.",
     "context": "Error message when database connection fails",
     "source_hash": "343ccdcb"
   },
@@ -1539,5 +1539,9 @@
   "web.TITLES.domain_dns": {
     "text": "Configuração de DNS",
     "source_hash": "6c63df31"
+  },
+  "web.TITLES.connected_identities": {
+    "text": "Identidades conectadas",
+    "source_hash": "e132c4d9"
   }
 }

--- a/locales/content/pt_BR/admin-audit.json
+++ b/locales/content/pt_BR/admin-audit.json
@@ -98,5 +98,41 @@
   "web.admin.audit.result.failure": {
     "text": "Falha",
     "source_hash": "7031edbc"
+  },
+  "web.admin.audit.categories.secret": {
+    "text": "Mensagens confidenciais",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.audit.categories.membership": {
+    "text": "Associações",
+    "source_hash": "b50f1a42"
+  },
+  "web.admin.audit.categories.entitlement_preview": {
+    "text": "Prévias de entitlements",
+    "source_hash": "255c5797"
+  },
+  "web.admin.audit.categories.colonel": {
+    "text": "Inícios de sessão no Colonel",
+    "source_hash": "01eeeb38"
+  },
+  "web.admin.audit.filters.actorLabel": {
+    "text": "Autor",
+    "source_hash": "449995c4"
+  },
+  "web.admin.audit.filters.searchButton": {
+    "text": "Buscar",
+    "source_hash": "49c266ba"
+  },
+  "web.admin.audit.filters.searchHint": {
+    "text": "Digite um autor e pressione Enter ou escolha Buscar para executar. A lista não é atualizada enquanto você digita.",
+    "source_hash": "45eceb12"
+  },
+  "web.admin.audit.filters.pendingSearch": {
+    "text": "Ainda não pesquisado — pressione Enter ou escolha Buscar para aplicar este autor.",
+    "source_hash": "f76095c2"
+  },
+  "web.admin.audit.list.contractError": {
+    "text": "O servidor respondeu, mas os dados de auditoria não corresponderam ao formato esperado. Nenhum evento pode ser exibido — esta é uma falha de relatório, não um registro vazio.",
+    "source_hash": "7f48137e"
   }
 }

--- a/locales/content/pt_BR/admin-billing.json
+++ b/locales/content/pt_BR/admin-billing.json
@@ -122,5 +122,85 @@
   "web.admin.billing.status.changed": {
     "text": "Alterado",
     "source_hash": "2a6141e4"
+  },
+  "web.admin.billing.diff.backToCatalog": {
+    "text": "Voltar ao catálogo de cobrança",
+    "source_hash": "8532b373"
+  },
+  "web.admin.billing.diff.driftedFields": {
+    "text": "Campos divergentes:",
+    "source_hash": "9890c95b"
+  },
+  "web.admin.billing.diff.notFound": {
+    "text": "Plano não encontrado no catálogo",
+    "source_hash": "0253898b"
+  },
+  "web.admin.billing.diff.notFoundDescription": {
+    "text": "Nenhum plano com o id {planid} foi encontrado no catálogo configurado nem no cache sincronizado com o Stripe.",
+    "source_hash": "2e69551c"
+  },
+  "web.admin.billing.stripeOrgs.title": {
+    "text": "Clientes do Stripe",
+    "source_hash": "0463ae27"
+  },
+  "web.admin.billing.stripeOrgs.description": {
+    "text": "Organizações vinculadas a um registro de cliente do Stripe.",
+    "source_hash": "2ab09aec"
+  },
+  "web.admin.billing.stripeOrgs.searchPlaceholder": {
+    "text": "Buscar por ID de cliente do Stripe",
+    "source_hash": "d5acf08f"
+  },
+  "web.admin.billing.stripeOrgs.empty": {
+    "text": "Nenhuma organização possui um ID de cliente do Stripe.",
+    "source_hash": "2e373537"
+  },
+  "web.admin.billing.stripeOrgs.emptySearch": {
+    "text": "Nenhum ID de cliente do Stripe corresponde a essa busca.",
+    "source_hash": "75011174"
+  },
+  "web.admin.billing.stripeOrgs.loadError": {
+    "text": "Não foi possível carregar a lista de clientes do Stripe.",
+    "source_hash": "15e2d9a7"
+  },
+  "web.admin.billing.stripeOrgs.unavailable": {
+    "text": "A lista de clientes do Stripe ainda não está disponível neste servidor.",
+    "source_hash": "aab6451a"
+  },
+  "web.admin.billing.stripeOrgs.none": {
+    "text": "Nenhum",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.billing.stripeOrgs.capped": {
+    "text": "A varredura do índice atingiu seu limite, portanto o total é um valor mínimo — refine a busca para ver o restante.",
+    "source_hash": "20bcaa38"
+  },
+  "web.admin.billing.stripeOrgs.stale": {
+    "text": "{count} entrada(s) de índice nesta página apontam para uma organização que não carrega mais e foram ignoradas.",
+    "source_hash": "51980f83"
+  },
+  "web.admin.billing.stripeOrgs.copyStripeId": {
+    "text": "Copiar ID de cliente do Stripe",
+    "source_hash": "a77d18b1"
+  },
+  "web.admin.billing.stripeOrgs.columns.organization": {
+    "text": "Organização",
+    "source_hash": "d764d425"
+  },
+  "web.admin.billing.stripeOrgs.columns.owner": {
+    "text": "Proprietário",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.billing.stripeOrgs.columns.plan": {
+    "text": "Plano",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.billing.stripeOrgs.columns.subscription": {
+    "text": "Assinatura",
+    "source_hash": "4999c6c6"
+  },
+  "web.admin.billing.stripeOrgs.columns.stripeCustomer": {
+    "text": "ID de cliente do Stripe",
+    "source_hash": "7e1d8bbb"
   }
 }

--- a/locales/content/pt_BR/admin-colonel.json
+++ b/locales/content/pt_BR/admin-colonel.json
@@ -838,5 +838,37 @@
   "web.colonel.nav.groups.communications": {
     "text": "Comunicações",
     "source_hash": "919a9253"
+  },
+  "web.colonel.organizations.sameAsContact": {
+    "text": "Igual ao contato",
+    "source_hash": "ed18ff43"
+  },
+  "web.colonel.organizations.refresh": {
+    "text": "Atualizar",
+    "source_hash": "0e916101"
+  },
+  "web.colonel.organizations.updatedAgo": {
+    "text": "Atualizado {ago}",
+    "source_hash": "cda30b9c"
+  },
+  "web.colonel.organizations.columns.name": {
+    "text": "Nome",
+    "source_hash": "dcd1d522"
+  },
+  "web.colonel.organizations.columns.contactEmail": {
+    "text": "E-mail de contato",
+    "source_hash": "6d7fce11"
+  },
+  "web.colonel.organizations.columns.billingEmail": {
+    "text": "E-mail de cobrança",
+    "source_hash": "8805b928"
+  },
+  "web.colonel.organizations.columns.planSubscription": {
+    "text": "Plano e assinatura",
+    "source_hash": "b396caac"
+  },
+  "web.colonel.organizations.filters.searchPlaceholder": {
+    "text": "Buscar por ID, nome ou e-mail",
+    "source_hash": "6fe16473"
   }
 }

--- a/locales/content/pt_BR/admin-customers.json
+++ b/locales/content/pt_BR/admin-customers.json
@@ -4,8 +4,8 @@
     "source_hash": "aabe76f1"
   },
   "web.admin.customers.description": {
-    "text": "Encontre um cliente e resolva problemas de suporte sem SSH.",
-    "source_hash": "c8487e68"
+    "text": "Encontre um cliente e resolva problemas de suporte.",
+    "source_hash": "00961ea3"
   },
   "web.admin.customers.actions.plan.label": {
     "text": "Plano",
@@ -482,5 +482,213 @@
   "web.admin.customers.suspended.badge": {
     "text": "Suspenso",
     "source_hash": "e392a389"
+  },
+  "web.admin.customers.actions.checkoutLink.button": {
+    "text": "Criar link de checkout",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.modalTitle": {
+    "text": "Criar link de checkout",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.planLabel": {
+    "text": "Plano",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.actions.checkoutLink.planPlaceholder": {
+    "text": "ID da família do plano (ex. identity_plus_v1)",
+    "source_hash": "12eba027"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleLabel": {
+    "text": "Ciclo de cobrança",
+    "source_hash": "d69f731e"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleMonthly": {
+    "text": "Mensal",
+    "source_hash": "9b11f6b7"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleYearly": {
+    "text": "Anual",
+    "source_hash": "6e69b59e"
+  },
+  "web.admin.customers.actions.checkoutLink.allowPromo": {
+    "text": "Permitir códigos promocionais",
+    "source_hash": "ebe7bc8b"
+  },
+  "web.admin.customers.actions.checkoutLink.submit": {
+    "text": "Criar link",
+    "source_hash": "e6b850cf"
+  },
+  "web.admin.customers.actions.checkoutLink.resultLead": {
+    "text": "Link de checkout criado. Compartilhe com o cliente — ele pode ser usado uma vez e expira.",
+    "source_hash": "6ff1fb0e"
+  },
+  "web.admin.customers.actions.checkoutLink.copy": {
+    "text": "Copiar link de checkout",
+    "source_hash": "f1e51ca7"
+  },
+  "web.admin.customers.actions.checkoutLink.expiry": {
+    "text": "Expira em ~{hours}h ({date}).",
+    "source_hash": "4c878a15"
+  },
+  "web.admin.customers.actions.checkoutLink.regionLabel": {
+    "text": "Região",
+    "source_hash": "d3a008ef"
+  },
+  "web.admin.customers.actions.checkoutLink.parseError": {
+    "text": "O servidor aceitou a solicitação, mas retornou uma resposta ilegível, então nenhum link pode ser exibido. Verifique o Stripe antes de tentar novamente.",
+    "source_hash": "e7e08290"
+  },
+  "web.admin.customers.actions.checkoutLink.done": {
+    "text": "Concluído",
+    "source_hash": "11a6767d"
+  },
+  "web.admin.customers.actions.purge.typePrompt": {
+    "text": "Para confirmar, digite o endereço de e-mail da conta {token} abaixo",
+    "source_hash": "8b2a1819"
+  },
+  "web.admin.customers.actions.purge.unavailable": {
+    "text": "Expurgo indisponível: esta conta não possui endereço de e-mail para redigitar como confirmação.",
+    "source_hash": "5f20f7e5"
+  },
+  "web.admin.customers.columns.actions": {
+    "text": "Ações",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.diagnostics.title": {
+    "text": "Diagnóstico da conta",
+    "source_hash": "5574ece8"
+  },
+  "web.admin.customers.detail.diagnostics.loading": {
+    "text": "Executando diagnóstico…",
+    "source_hash": "062c83d5"
+  },
+  "web.admin.customers.detail.diagnostics.loadError": {
+    "text": "Não foi possível carregar o diagnóstico.",
+    "source_hash": "69e69f49"
+  },
+  "web.admin.customers.detail.diagnostics.healthy": {
+    "text": "Nenhuma condição de bloqueio encontrada. O estado de autenticação parece saudável — suspeite de problemas no lado do cliente (cookies, configuração de início de sessão em domínio personalizado) ou da região incorreta.",
+    "source_hash": "f6d5f8d1"
+  },
+  "web.admin.customers.detail.diagnostics.authUnavailable": {
+    "text": "Banco de dados de autenticação indisponível (modo de autenticação simples) — as verificações via SQL foram ignoradas.",
+    "source_hash": "d668907c"
+  },
+  "web.admin.customers.detail.diagnostics.authFailed": {
+    "text": "O banco de dados de autenticação não respondeu, então as verificações via SQL não puderam ser executadas: {reason}",
+    "source_hash": "46d047c0"
+  },
+  "web.admin.customers.detail.diagnostics.unknown": {
+    "text": "Desconhecido",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.title": {
+    "text": "Registro de autenticação",
+    "source_hash": "48ad8ba8"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.empty": {
+    "text": "Nenhum evento de autenticação registrado.",
+    "source_hash": "d2332558"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.unavailable": {
+    "text": "Não foi possível ler o registro de autenticação: {reason}",
+    "source_hash": "ab18af57"
+  },
+  "web.admin.customers.detail.diagnostics.facts.authStatus": {
+    "text": "Status de autenticação",
+    "source_hash": "34def169"
+  },
+  "web.admin.customers.detail.diagnostics.facts.noAccount": {
+    "text": "Sem conta de autenticação",
+    "source_hash": "a9968e9e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.password": {
+    "text": "Senha",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordSet": {
+    "text": "Definida",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordNone": {
+    "text": "Nenhuma",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfa": {
+    "text": "MFA",
+    "source_hash": "d39ce053"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfaNone": {
+    "text": "Nenhum",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.loginFailures": {
+    "text": "Tentativas malsucedidas",
+    "source_hash": "63e7f0a8"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lockedBadge": {
+    "text": "Bloqueada",
+    "source_hash": "ace29f74"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiter": {
+    "text": "Limitador de taxa",
+    "source_hash": "32892404"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterEngaged": {
+    "text": "Acionado",
+    "source_hash": "1b0d851e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterClear": {
+    "text": "Livre",
+    "source_hash": "83b12c22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verification": {
+    "text": "E-mail de verificação",
+    "source_hash": "23fac8fb"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationPending": {
+    "text": "Pendente — último envio {date}",
+    "source_hash": "9ab8d1b6"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationNone": {
+    "text": "Nenhum pendente",
+    "source_hash": "a4d4cc22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.sessions": {
+    "text": "Sessões ativas",
+    "source_hash": "61ad9909"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lastLogin": {
+    "text": "Último início de sessão (autenticação)",
+    "source_hash": "373e7fb1"
+  },
+  "web.admin.customers.detail.receipts.partial": {
+    "text": "Lista parcial — exibindo os {count} mais recentes. Este cliente tem mais comprovantes do que os exibidos aqui.",
+    "source_hash": "127fd4db"
+  },
+  "web.admin.customers.detail.secrets.partial": {
+    "text": "Lista parcial — exibindo as {count} mais recentes. Este cliente possui mais mensagens confidenciais do que as exibidas aqui.",
+    "source_hash": "a537c8f3"
+  },
+  "web.admin.customers.detail.sessions.columns.country": {
+    "text": "País",
+    "source_hash": "701d021d"
+  },
+  "web.admin.customers.detail.sessions.current.badge": {
+    "text": "Esta sessão",
+    "source_hash": "6da6530a"
+  },
+  "web.admin.customers.detail.sessions.current.tooltip": {
+    "text": "Sua sessão de administrador atual. Revogá-la aqui não tem efeito — ela é recriada no restante desta solicitação.",
+    "source_hash": "ef097ab1"
+  },
+  "web.admin.customers.verification.verified": {
+    "text": "Verificado",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.verification.unverified": {
+    "text": "Não verificado",
+    "source_hash": "15133907"
   }
 }

--- a/locales/content/pt_BR/admin-domains.json
+++ b/locales/content/pt_BR/admin-domains.json
@@ -190,5 +190,657 @@
   "web.admin.domains.verify.success.done": {
     "text": "Verificação concluída para {domain}.",
     "source_hash": "ed67e22d"
+  },
+  "web.admin.domains.actions.preview": {
+    "text": "Pré-visualizar",
+    "source_hash": "324b134f"
+  },
+  "web.admin.domains.actions.probe.button": {
+    "text": "Sondar",
+    "source_hash": "3bd51ab9"
+  },
+  "web.admin.domains.actions.remove.button": {
+    "text": "Remover domínio",
+    "source_hash": "5ce43507"
+  },
+  "web.admin.domains.actions.remove.previewButton": {
+    "text": "Pré-visualizar remoção",
+    "source_hash": "6b81bd92"
+  },
+  "web.admin.domains.actions.remove.previewStatus": {
+    "text": "Status:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.remove.previewOrg": {
+    "text": "Organização:",
+    "source_hash": "5300e286"
+  },
+  "web.admin.domains.actions.remove.reassertsSurvivor": {
+    "text": "Outro registro reivindica o mesmo nome de domínio e assumirá o índice de consulta.",
+    "source_hash": "902838f4"
+  },
+  "web.admin.domains.actions.remove.confirmTitle": {
+    "text": "Remover domínio?",
+    "source_hash": "716dfac9"
+  },
+  "web.admin.domains.actions.remove.confirmDescription": {
+    "text": "Isso exclui permanentemente {domain} e seus registros de marca, DNS e configuração. Não pode ser desfeito. Redigite o ID público do domínio para continuar.",
+    "source_hash": "d0b67b47"
+  },
+  "web.admin.domains.actions.remove.success": {
+    "text": "Domínio removido.",
+    "source_hash": "2ccaa6d3"
+  },
+  "web.admin.domains.actions.remove.notApplied": {
+    "text": "O servidor pré-visualizou a remoção em vez de aplicá-la — o domínio NÃO foi removido. Tente novamente e relate isso se persistir.",
+    "source_hash": "dc6d70ae"
+  },
+  "web.admin.domains.actions.repair.title": {
+    "text": "Reparar vínculo com a organização",
+    "source_hash": "82b40352"
+  },
+  "web.admin.domains.actions.repair.description": {
+    "text": "Encontre e corrija vínculos quebrados entre este domínio e sua organização. Pré-visualize primeiro para ver o que mudaria.",
+    "source_hash": "531ed287"
+  },
+  "web.admin.domains.actions.repair.orgIdLabel": {
+    "text": "ID da organização (apenas domínios órfãos)",
+    "source_hash": "0d3010eb"
+  },
+  "web.admin.domains.actions.repair.orgIdPlaceholder": {
+    "text": "Deixe em branco a menos que o domínio não tenha proprietário",
+    "source_hash": "118b7132"
+  },
+  "web.admin.domains.actions.repair.statusLabel": {
+    "text": "Status:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.repair.noIssues": {
+    "text": "Nenhum problema encontrado — nada a reparar.",
+    "source_hash": "17735887"
+  },
+  "web.admin.domains.actions.repair.button": {
+    "text": "Aplicar reparo",
+    "source_hash": "4d0ab2d4"
+  },
+  "web.admin.domains.actions.repair.confirmTitle": {
+    "text": "Aplicar reparo?",
+    "source_hash": "ef0ffae5"
+  },
+  "web.admin.domains.actions.repair.confirmDescription": {
+    "text": "Isso reescreve o vínculo com a organização de {domain}. Redigite o ID público do domínio para continuar.",
+    "source_hash": "a9f2702f"
+  },
+  "web.admin.domains.actions.repair.success": {
+    "text": "Reparo aplicado.",
+    "source_hash": "850bd784"
+  },
+  "web.admin.domains.actions.transfer.title": {
+    "text": "Transferir para outra organização",
+    "source_hash": "1b0b0655"
+  },
+  "web.admin.domains.actions.transfer.description": {
+    "text": "Mova este domínio para outra organização. Pré-visualize primeiro para confirmar os dois lados da mudança.",
+    "source_hash": "457e852d"
+  },
+  "web.admin.domains.actions.transfer.toOrgLabel": {
+    "text": "ID da organização de destino",
+    "source_hash": "1a3f05c4"
+  },
+  "web.admin.domains.actions.transfer.fromOrgLabel": {
+    "text": "ID da organização atual esperada (opcional)",
+    "source_hash": "f6e75729"
+  },
+  "web.admin.domains.actions.transfer.fromOrgPlaceholder": {
+    "text": "Confirme o proprietário atual antes de mover",
+    "source_hash": "1ac6c59b"
+  },
+  "web.admin.domains.actions.transfer.from": {
+    "text": "De",
+    "source_hash": "21819769"
+  },
+  "web.admin.domains.actions.transfer.to": {
+    "text": "Para",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.domains.actions.transfer.orphaned": {
+    "text": "Sem organização (órfão)",
+    "source_hash": "6f4c745c"
+  },
+  "web.admin.domains.actions.transfer.button": {
+    "text": "Aplicar transferência",
+    "source_hash": "fb546c5c"
+  },
+  "web.admin.domains.actions.transfer.confirmTitle": {
+    "text": "Transferir domínio?",
+    "source_hash": "801eb986"
+  },
+  "web.admin.domains.actions.transfer.confirmDescription": {
+    "text": "Isso move {domain} para a organização {org}. Redigite o ID público do domínio para continuar.",
+    "source_hash": "52c8808d"
+  },
+  "web.admin.domains.actions.transfer.success": {
+    "text": "Domínio transferido.",
+    "source_hash": "91e681ae"
+  },
+  "web.admin.domains.columns.domain": {
+    "text": "Domínio",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domains.columns.organization": {
+    "text": "Organização",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.columns.state": {
+    "text": "Verificação",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.domains.columns.tls": {
+    "text": "TLS",
+    "source_hash": "d1c18ec0"
+  },
+  "web.admin.domains.columns.created": {
+    "text": "Criado em",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.columns.actions": {
+    "text": "Ações",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.configs.title": {
+    "text": "Configuração do domínio",
+    "source_hash": "d46aa480"
+  },
+  "web.admin.domains.configs.description": {
+    "text": "Registros de configuração por domínio que controlam início de sessão, cadastro, mensagens confidenciais na página inicial, acesso à API, mensagens confidenciais recebidas, SSO do locatário e envio de e-mails. Um registro ausente falha de forma fechada nos cinco primeiros.",
+    "source_hash": "1df99789"
+  },
+  "web.admin.domains.configs.loadError": {
+    "text": "Não foi possível carregar os registros de configuração do domínio.",
+    "source_hash": "9417d718"
+  },
+  "web.admin.domains.configs.retry": {
+    "text": "Tentar novamente",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.configs.degraded": {
+    "text": "A resposta de configuração não correspondeu ao contrato esperado. Atualize a página e relate isso se persistir.",
+    "source_hash": "b5d890c0"
+  },
+  "web.admin.domains.configs.notFoundNote": {
+    "text": "Este domínio não existe mais, então seus registros de configuração não podem ser carregados.",
+    "source_hash": "2d88a392"
+  },
+  "web.admin.domains.configs.detailsToggle": {
+    "text": "Detalhes",
+    "source_hash": "45989de4"
+  },
+  "web.admin.domains.configs.notEditable": {
+    "text": "Gerenciado nas configurações de domínio do Workspace.",
+    "source_hash": "54fe891f"
+  },
+  "web.admin.domains.configs.delete.button": {
+    "text": "Excluir",
+    "source_hash": "e2d0a549"
+  },
+  "web.admin.domains.configs.delete.confirmTitle": {
+    "text": "Excluir configuração de {kind}?",
+    "source_hash": "98e672db"
+  },
+  "web.admin.domains.configs.delete.confirmDescription": {
+    "text": "Isso exclui permanentemente o registro de configuração de {kind} para {domain}. O domínio volta ao comportamento de registro ausente. Redigite o tipo para continuar.",
+    "source_hash": "8272c40c"
+  },
+  "web.admin.domains.configs.delete.success": {
+    "text": "Configuração excluída.",
+    "source_hash": "a0184b66"
+  },
+  "web.admin.domains.configs.edit.button": {
+    "text": "Editar",
+    "source_hash": "464c4ffd"
+  },
+  "web.admin.domains.configs.edit.createButton": {
+    "text": "Criar",
+    "source_hash": "4759498a"
+  },
+  "web.admin.domains.configs.edit.title": {
+    "text": "Configurar {kind}",
+    "source_hash": "8592148f"
+  },
+  "web.admin.domains.configs.edit.submit": {
+    "text": "Salvar",
+    "source_hash": "1509f561"
+  },
+  "web.admin.domains.configs.edit.success": {
+    "text": "Configuração salva.",
+    "source_hash": "6b5b3c69"
+  },
+  "web.admin.domains.configs.edit.unsetOption": {
+    "text": "Não definido",
+    "source_hash": "4895f731"
+  },
+  "web.admin.domains.configs.edit.domainsHint": {
+    "text": "Um domínio por linha.",
+    "source_hash": "6c03f4f7"
+  },
+  "web.admin.domains.configs.ensure.button": {
+    "text": "Criar configurações ausentes",
+    "source_hash": "77991b75"
+  },
+  "web.admin.domains.configs.ensure.confirmTitle": {
+    "text": "Criar registros de configuração ausentes?",
+    "source_hash": "3f41dec2"
+  },
+  "web.admin.domains.configs.ensure.confirmDescription": {
+    "text": "Cria registros desativados em {domain} para: {kinds}. Tudo começa desativado, portanto o comportamento não muda até que um registro seja ativado.",
+    "source_hash": "fed66221"
+  },
+  "web.admin.domains.configs.ensure.applyButton": {
+    "text": "Criar registros",
+    "source_hash": "4bcbef42"
+  },
+  "web.admin.domains.configs.ensure.success": {
+    "text": "Registros de configuração ausentes criados.",
+    "source_hash": "3b6ead80"
+  },
+  "web.admin.domains.configs.ensure.nothingMissing": {
+    "text": "Nada a criar — todos os registros de configuração já existem. A lista foi atualizada.",
+    "source_hash": "ad0df0ae"
+  },
+  "web.admin.domains.configs.ensure.notApplied": {
+    "text": "O servidor pré-visualizou a alteração em vez de aplicá-la — nenhum registro foi criado. Tente novamente e relate isso se persistir.",
+    "source_hash": "09d26379"
+  },
+  "web.admin.domains.configs.fields.enabled": {
+    "text": "Ativado",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.fields.signin_enabled": {
+    "text": "Início de sessão ativado",
+    "source_hash": "cabe4898"
+  },
+  "web.admin.domains.configs.fields.email_auth_enabled": {
+    "text": "Autenticação por e-mail ativada",
+    "source_hash": "4a762960"
+  },
+  "web.admin.domains.configs.fields.sso_enabled": {
+    "text": "SSO ativado",
+    "source_hash": "6e77e673"
+  },
+  "web.admin.domains.configs.fields.restrict_to": {
+    "text": "Restringir a",
+    "source_hash": "a0bdf50a"
+  },
+  "web.admin.domains.configs.fields.signup_enabled": {
+    "text": "Cadastro ativado",
+    "source_hash": "2637d0b2"
+  },
+  "web.admin.domains.configs.fields.autoverify": {
+    "text": "Verificação automática",
+    "source_hash": "7e02211c"
+  },
+  "web.admin.domains.configs.fields.validation_strategy": {
+    "text": "Estratégia de validação",
+    "source_hash": "a2e95531"
+  },
+  "web.admin.domains.configs.fields.allowed_signup_domains": {
+    "text": "Domínios de cadastro permitidos",
+    "source_hash": "9b5bb5b1"
+  },
+  "web.admin.domains.configs.fields.secrets_mode": {
+    "text": "Modo de mensagens confidenciais",
+    "source_hash": "8d4349d6"
+  },
+  "web.admin.domains.configs.fields.disabled_homepage_variant": {
+    "text": "Variante da página inicial desativada",
+    "source_hash": "4695633b"
+  },
+  "web.admin.domains.configs.fields.ready": {
+    "text": "Pronto",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.configs.fields.recipients": {
+    "text": "Destinatários",
+    "source_hash": "1e8568a8"
+  },
+  "web.admin.domains.configs.fields.provider_type": {
+    "text": "Tipo de provedor",
+    "source_hash": "8c0f6d3e"
+  },
+  "web.admin.domains.configs.fields.display_name": {
+    "text": "Nome de exibição",
+    "source_hash": "2b7f6a84"
+  },
+  "web.admin.domains.configs.fields.issuer": {
+    "text": "Emissor",
+    "source_hash": "39e02c46"
+  },
+  "web.admin.domains.configs.fields.tenant_id": {
+    "text": "Tenant ID",
+    "source_hash": "de1f5fff"
+  },
+  "web.admin.domains.configs.fields.has_client_id": {
+    "text": "Client ID definido",
+    "source_hash": "04a9fa3d"
+  },
+  "web.admin.domains.configs.fields.has_client_secret": {
+    "text": "Client Secret definido",
+    "source_hash": "6ee1c9e6"
+  },
+  "web.admin.domains.configs.fields.allowed_domains": {
+    "text": "Domínios permitidos",
+    "source_hash": "bcd60db0"
+  },
+  "web.admin.domains.configs.fields.enforce_sso_only": {
+    "text": "Aplicar somente SSO",
+    "source_hash": "b3a3f694"
+  },
+  "web.admin.domains.configs.fields.grant_org_scope": {
+    "text": "Conceder escopo da organização",
+    "source_hash": "698ea5de"
+  },
+  "web.admin.domains.configs.fields.provider": {
+    "text": "Provedor",
+    "source_hash": "472590ae"
+  },
+  "web.admin.domains.configs.fields.from_name": {
+    "text": "Nome do remetente",
+    "source_hash": "b28f93ea"
+  },
+  "web.admin.domains.configs.fields.from_address": {
+    "text": "Endereço do remetente",
+    "source_hash": "d465bcfa"
+  },
+  "web.admin.domains.configs.fields.reply_to": {
+    "text": "Responder para",
+    "source_hash": "6b9c49b7"
+  },
+  "web.admin.domains.configs.fields.sending_mode": {
+    "text": "Modo de envio",
+    "source_hash": "e2d6bcf7"
+  },
+  "web.admin.domains.configs.fields.verification_status": {
+    "text": "Status da verificação",
+    "source_hash": "aedfff7e"
+  },
+  "web.admin.domains.configs.fields.dns_verified": {
+    "text": "DNS verificado",
+    "source_hash": "8b2128c8"
+  },
+  "web.admin.domains.configs.fields.provider_verified": {
+    "text": "Provedor verificado",
+    "source_hash": "6f4d9cc4"
+  },
+  "web.admin.domains.configs.fields.has_api_key": {
+    "text": "Chave de API definida",
+    "source_hash": "d5115386"
+  },
+  "web.admin.domains.configs.fields.created": {
+    "text": "Criado em",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.configs.fields.updated": {
+    "text": "Atualizado em",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.configs.kinds.signin": {
+    "text": "Início de sessão",
+    "source_hash": "5bbbe531"
+  },
+  "web.admin.domains.configs.kinds.signup": {
+    "text": "Cadastro",
+    "source_hash": "3cc08ebe"
+  },
+  "web.admin.domains.configs.kinds.homepage": {
+    "text": "Página inicial",
+    "source_hash": "9e3391e9"
+  },
+  "web.admin.domains.configs.kinds.api": {
+    "text": "API",
+    "source_hash": "c8e5998f"
+  },
+  "web.admin.domains.configs.kinds.incoming": {
+    "text": "Recebidas",
+    "source_hash": "e301820a"
+  },
+  "web.admin.domains.configs.kinds.sso": {
+    "text": "SSO",
+    "source_hash": "5ba3ac9f"
+  },
+  "web.admin.domains.configs.kinds.mailer": {
+    "text": "Mailer",
+    "source_hash": "6c07ba63"
+  },
+  "web.admin.domains.configs.missingNotes.signin": {
+    "text": "Sem registro: o início de sessão está desativado neste domínio, a menos que o SSO do locatário esteja ativo.",
+    "source_hash": "17dd6099"
+  },
+  "web.admin.domains.configs.missingNotes.signup": {
+    "text": "Sem registro: o cadastro está desativado neste domínio.",
+    "source_hash": "c3c98956"
+  },
+  "web.admin.domains.configs.missingNotes.homepage": {
+    "text": "Sem registro: as mensagens confidenciais na página inicial estão desativadas (falha de forma fechada e registra um erro).",
+    "source_hash": "9a258a88"
+  },
+  "web.admin.domains.configs.missingNotes.api": {
+    "text": "Sem registro: a API pública está desativada (falha de forma fechada e registra um erro).",
+    "source_hash": "fed99f73"
+  },
+  "web.admin.domains.configs.missingNotes.incoming": {
+    "text": "Sem registro: as mensagens confidenciais recebidas estão desativadas.",
+    "source_hash": "b957fbe8"
+  },
+  "web.admin.domains.configs.missingNotes.sso": {
+    "text": "Sem registro: o SSO do locatário está indisponível; aplica-se a política de fallback do SSO da plataforma.",
+    "source_hash": "7b05ade8"
+  },
+  "web.admin.domains.configs.missingNotes.mailer": {
+    "text": "Sem registro: o mailer da plataforma é utilizado.",
+    "source_hash": "e027cc99"
+  },
+  "web.admin.domains.configs.status.missing": {
+    "text": "Ausente",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.domains.configs.status.disabled": {
+    "text": "Desativado",
+    "source_hash": "75081b59"
+  },
+  "web.admin.domains.configs.status.enabled": {
+    "text": "Ativado",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.status.enabledNotReady": {
+    "text": "Ativado, não pronto",
+    "source_hash": "cb806ba4"
+  },
+  "web.admin.domains.detail.openFullPage": {
+    "text": "Abrir página completa",
+    "source_hash": "a467911c"
+  },
+  "web.admin.domains.detail.backToList": {
+    "text": "Voltar aos domínios",
+    "source_hash": "22fd50fe"
+  },
+  "web.admin.domains.detail.notFound": {
+    "text": "Domínio não encontrado",
+    "source_hash": "7b8fc0e6"
+  },
+  "web.admin.domains.detail.notFoundDescription": {
+    "text": "Este domínio não existe ou já foi removido.",
+    "source_hash": "e0f0b987"
+  },
+  "web.admin.domains.detail.loadError": {
+    "text": "Não foi possível carregar este domínio.",
+    "source_hash": "39e9c657"
+  },
+  "web.admin.domains.detail.retry": {
+    "text": "Tentar novamente",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.detail.never": {
+    "text": "Nunca",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.domains.detail.none": {
+    "text": "Nenhum",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.domains.detail.yes": {
+    "text": "Sim",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.domains.detail.no": {
+    "text": "Não",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.domains.detail.organization.open": {
+    "text": "Abrir organização",
+    "source_hash": "54a43621"
+  },
+  "web.admin.domains.detail.organization.unknown": {
+    "text": "A organização proprietária não está incluída nesta resposta. Abra este domínio pela lista de domínios para vê-la.",
+    "source_hash": "bb5bdc9c"
+  },
+  "web.admin.domains.detail.sections.overview": {
+    "text": "Visão geral",
+    "source_hash": "d4b1ea57"
+  },
+  "web.admin.domains.detail.sections.actions": {
+    "text": "Ações",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.detail.sections.organization": {
+    "text": "Organização proprietária",
+    "source_hash": "39ad6d9c"
+  },
+  "web.admin.domains.detail.sections.dns": {
+    "text": "DNS",
+    "source_hash": "020965a2"
+  },
+  "web.admin.domains.detail.sections.diagnostics": {
+    "text": "Diagnóstico",
+    "source_hash": "268f14bb"
+  },
+  "web.admin.domains.detail.sections.operations": {
+    "text": "Operações de propriedade",
+    "source_hash": "eb9a8cbc"
+  },
+  "web.admin.domains.detail.sections.operationsHint": {
+    "text": "Cada operação é pré-visualizada primeiro. Nada é gravado até você confirmar a etapa de aplicação.",
+    "source_hash": "f09bf7bd"
+  },
+  "web.admin.domains.fields.publicId": {
+    "text": "ID público",
+    "source_hash": "3705b64f"
+  },
+  "web.admin.domains.fields.domainId": {
+    "text": "ID interno",
+    "source_hash": "e468bb47"
+  },
+  "web.admin.domains.fields.organization": {
+    "text": "Organização",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.fields.baseDomain": {
+    "text": "Domínio base",
+    "source_hash": "33295d5b"
+  },
+  "web.admin.domains.fields.subdomain": {
+    "text": "Subdomínio",
+    "source_hash": "ba4520ab"
+  },
+  "web.admin.domains.fields.apex": {
+    "text": "Domínio apex",
+    "source_hash": "0a8a42fa"
+  },
+  "web.admin.domains.fields.status": {
+    "text": "Status",
+    "source_hash": "920e413c"
+  },
+  "web.admin.domains.fields.created": {
+    "text": "Criado em",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.fields.updated": {
+    "text": "Atualizado em",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.fields.verified": {
+    "text": "Verificado",
+    "source_hash": "4f783840"
+  },
+  "web.admin.domains.fields.resolving": {
+    "text": "Resolvendo",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.fields.ready": {
+    "text": "Pronto",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.list.searchPlaceholder": {
+    "text": "Buscar por nome ou ID do domínio",
+    "source_hash": "aecdd873"
+  },
+  "web.admin.domains.list.stateFilter": {
+    "text": "Estado",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.domains.list.emptyFilter": {
+    "text": "Nenhum domínio corresponde aos filtros atuais.",
+    "source_hash": "be4d64ec"
+  },
+  "web.admin.domains.probe.healthLabel": {
+    "text": "Saúde",
+    "source_hash": "55898449"
+  },
+  "web.admin.domains.probe.certInvalid": {
+    "text": "Certificado inutilizável",
+    "source_hash": "5535f4d4"
+  },
+  "web.admin.domains.probe.noCertificate": {
+    "text": "Nenhum certificado foi retornado — a conexão falhou antes do TLS.",
+    "source_hash": "8ffd63be"
+  },
+  "web.admin.domains.probe.fields.httpStatus": {
+    "text": "Status HTTP",
+    "source_hash": "0f7cf91f"
+  },
+  "web.admin.domains.probe.fields.httpError": {
+    "text": "Erro HTTP",
+    "source_hash": "5c6896d4"
+  },
+  "web.admin.domains.probe.fields.sslError": {
+    "text": "Erro de TLS",
+    "source_hash": "7b827515"
+  },
+  "web.admin.domains.probe.fields.issuer": {
+    "text": "Emissor do certificado",
+    "source_hash": "2912559a"
+  },
+  "web.admin.domains.probe.fields.subject": {
+    "text": "Titular do certificado",
+    "source_hash": "d7816b16"
+  },
+  "web.admin.domains.probe.fields.notAfter": {
+    "text": "Certificado expira em",
+    "source_hash": "1e73119d"
+  },
+  "web.admin.domains.probe.fields.expiresIn": {
+    "text": "{date} ({days} dias)",
+    "source_hash": "a71a6e81"
+  },
+  "web.admin.domains.tls.serving": {
+    "text": "Servindo",
+    "source_hash": "f55e53f9"
+  },
+  "web.admin.domains.tls.resolving": {
+    "text": "Resolvendo",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.tls.none": {
+    "text": "Não servindo",
+    "source_hash": "da8a5ab9"
   }
 }

--- a/locales/content/pt_BR/admin-organizations.json
+++ b/locales/content/pt_BR/admin-organizations.json
@@ -310,5 +310,333 @@
   "web.admin.organizations.list.loadError": {
     "text": "Não foi possível carregar as organizações.",
     "source_hash": "130d5e70"
+  },
+  "web.admin.organizations.addMember.button": {
+    "text": "Adicionar conta existente",
+    "source_hash": "45a3b757"
+  },
+  "web.admin.organizations.addMember.title": {
+    "text": "Adicionar uma conta existente",
+    "source_hash": "2f676a94"
+  },
+  "web.admin.organizations.addMember.description": {
+    "text": "Adicione a {org} alguém que já tem uma conta. Use isso quando a pessoa se cadastrou por conta própria e não pode ser convidada porque a conta já existe.",
+    "source_hash": "bb41faa6"
+  },
+  "web.admin.organizations.addMember.searchLabel": {
+    "text": "Endereço de e-mail ou ID da conta",
+    "source_hash": "82b3040b"
+  },
+  "web.admin.organizations.addMember.searchPlaceholder": {
+    "text": "Buscar por endereço de e-mail",
+    "source_hash": "b75cc66c"
+  },
+  "web.admin.organizations.addMember.searchHint": {
+    "text": "Corresponde a parte de um endereço de e-mail ou a um ID de conta exato.",
+    "source_hash": "84547a60"
+  },
+  "web.admin.organizations.addMember.searchError": {
+    "text": "Não foi possível buscar contas. Verifique a conexão e tente novamente.",
+    "source_hash": "4b6caa41"
+  },
+  "web.admin.organizations.addMember.searchParseError": {
+    "text": "A busca de contas retornou uma resposta inesperada. Os resultados podem estar incompletos.",
+    "source_hash": "0c814231"
+  },
+  "web.admin.organizations.addMember.idle": {
+    "text": "Digite um endereço de e-mail para encontrar a conta.",
+    "source_hash": "f6340d35"
+  },
+  "web.admin.organizations.addMember.noResults": {
+    "text": "Nenhuma conta corresponde a “{term}”.",
+    "source_hash": "199b662a"
+  },
+  "web.admin.organizations.addMember.noResultsHint": {
+    "text": "Apenas contas existentes podem ser adicionadas aqui. Se a pessoa nunca se cadastrou, envie um convite.",
+    "source_hash": "ee90aeeb"
+  },
+  "web.admin.organizations.addMember.select": {
+    "text": "Selecionar",
+    "source_hash": "2a78025d"
+  },
+  "web.admin.organizations.addMember.selectedEyebrow": {
+    "text": "Conta selecionada",
+    "source_hash": "8b63d947"
+  },
+  "web.admin.organizations.addMember.change": {
+    "text": "Escolher outra conta",
+    "source_hash": "d4fe39ab"
+  },
+  "web.admin.organizations.addMember.createdOn": {
+    "text": "Cadastrou-se em {date}",
+    "source_hash": "cfc0e19f"
+  },
+  "web.admin.organizations.addMember.organizationsUnavailable": {
+    "text": "Não foi possível carregar as organizações atuais desta conta.",
+    "source_hash": "a35b6bfc"
+  },
+  "web.admin.organizations.addMember.defaultOrg": {
+    "text": "padrão",
+    "source_hash": "37a8eec1"
+  },
+  "web.admin.organizations.addMember.roleLabel": {
+    "text": "Função nesta organização",
+    "source_hash": "817475fa"
+  },
+  "web.admin.organizations.addMember.submit": {
+    "text": "Adicionar à organização",
+    "source_hash": "0e0cb636"
+  },
+  "web.admin.organizations.addMember.success": {
+    "text": "{account} adicionado como {role}.",
+    "source_hash": "533be0dc"
+  },
+  "web.admin.organizations.addMember.badges.verified": {
+    "text": "Verificada",
+    "source_hash": "4f783840"
+  },
+  "web.admin.organizations.addMember.badges.unverified": {
+    "text": "Não verificada",
+    "source_hash": "15133907"
+  },
+  "web.admin.organizations.addMember.badges.suspended": {
+    "text": "Suspensa",
+    "source_hash": "e392a389"
+  },
+  "web.admin.organizations.addMember.badges.alreadyMember": {
+    "text": "Já é membro",
+    "source_hash": "1739ed7c"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMember": {
+    "text": "Esta conta já é membro desta organização, com a função {role}. Adicionar não altera uma função existente — use a ação de definir função para isso.",
+    "source_hash": "cb6a4774"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMemberUnknownRole": {
+    "text": "Esta conta já é membro desta organização. Adicionar não altera uma função existente.",
+    "source_hash": "035641ec"
+  },
+  "web.admin.organizations.addMember.errors.notFound": {
+    "text": "Essa conta ou organização não existe mais. Busque novamente para confirmar a conta.",
+    "source_hash": "bd88db18"
+  },
+  "web.admin.organizations.addMember.errors.invalidRole": {
+    "text": "Essa função foi rejeitada. Escolha uma das funções listadas e tente novamente.",
+    "source_hash": "eb696a8f"
+  },
+  "web.admin.organizations.addMember.errors.noSelection": {
+    "text": "Nenhuma conta selecionada.",
+    "source_hash": "dd15bb5b"
+  },
+  "web.admin.organizations.addMember.fields.created": {
+    "text": "Cadastro",
+    "source_hash": "486b3fe0"
+  },
+  "web.admin.organizations.addMember.fields.verified": {
+    "text": "Verificação",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.organizations.addMember.fields.lastLogin": {
+    "text": "Último início de sessão",
+    "source_hash": "0b70af7a"
+  },
+  "web.admin.organizations.addMember.fields.organizations": {
+    "text": "Organizações atuais",
+    "source_hash": "cbb5b92f"
+  },
+  "web.admin.organizations.addMember.roleHints.member": {
+    "text": "Acesso cotidiano às mensagens confidenciais e aos domínios da organização.",
+    "source_hash": "d0c7439e"
+  },
+  "web.admin.organizations.addMember.roleHints.admin": {
+    "text": "Pode gerenciar membros, domínios e configurações da organização.",
+    "source_hash": "beaa50d7"
+  },
+  "web.admin.organizations.addMember.roleHints.owner": {
+    "text": "Controle total, incluindo cobrança. Conceda apenas quando solicitado.",
+    "source_hash": "614ace63"
+  },
+  "web.admin.organizations.addMember.roles.member": {
+    "text": "Membro",
+    "source_hash": "7c968fb7"
+  },
+  "web.admin.organizations.addMember.roles.admin": {
+    "text": "Admin",
+    "source_hash": "c1c224b0"
+  },
+  "web.admin.organizations.addMember.roles.owner": {
+    "text": "Proprietário",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.detail.members.openCustomer": {
+    "text": "Abrir registro do cliente",
+    "source_hash": "c057ca13"
+  },
+  "web.admin.organizations.detail.reconcile.memberships": {
+    "text": "Associações rematerializadas:",
+    "source_hash": "fe7db10c"
+  },
+  "web.admin.organizations.detail.reconcile.membershipsFailed": {
+    "text": "falhou, entitlements desatualizados permanecem:",
+    "source_hash": "cc4dae37"
+  },
+  "web.admin.organizations.entitlements.catalogWarning": {
+    "text": "“{entitlement}” não está no catálogo de cobrança — verifique se há erro de digitação. Prosseguindo mesmo assim: conceder um entitlement que será lançado em um catálogo posterior é suportado e deliberadamente não bloqueado.",
+    "source_hash": "cbde548a"
+  },
+  "web.admin.organizations.entitlements.matrix.caption": {
+    "text": "Matriz de resolução de entitlements: plano, concessões e revogações de substituição, o conjunto resolvido e o que está materializado.",
+    "source_hash": "9eac8999"
+  },
+  "web.admin.organizations.entitlements.matrix.yes": {
+    "text": "Sim",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.matrix.no": {
+    "text": "Não",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.matrix.empty": {
+    "text": "Esta organização não possui entitlements do plano nem substituições.",
+    "source_hash": "f6cf2169"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.entitlement": {
+    "text": "Entitlement",
+    "source_hash": "0d8f0b2d"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.inPlan": {
+    "text": "No plano",
+    "source_hash": "e2222361"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.granted": {
+    "text": "Concedido",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.revoked": {
+    "text": "Revogado",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.expected": {
+    "text": "Esperado",
+    "source_hash": "ca99b7f1"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.materialized": {
+    "text": "Materializado",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.state": {
+    "text": "Estado",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.formula": {
+    "text": "Resolução: esperado = (plano ∪ concessões) − revogações. Materializado é o que está realmente armazenado na organização.",
+    "source_hash": "bc4bff2d"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.orphaned": {
+    "text": "Órfão — materializado, mas não esperado, normalmente deixado por uma revogação que nunca foi rematerializada. A reconciliação o remove.",
+    "source_hash": "3a27a9af"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.missing": {
+    "text": "Ausente — esperado, mas não materializado. Esta é a permissão que os membros realmente não têm no momento.",
+    "source_hash": "485e44ad"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.revoked": {
+    "text": "As linhas tachadas foram revogadas por uma substituição de administrador, que as remove do conjunto esperado.",
+    "source_hash": "89a2e9b6"
+  },
+  "web.admin.organizations.entitlements.matrix.state.plan": {
+    "text": "Do plano",
+    "source_hash": "1d346b26"
+  },
+  "web.admin.organizations.entitlements.matrix.state.granted": {
+    "text": "Concedido",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.state.revoked": {
+    "text": "Revogado",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.state.orphaned": {
+    "text": "Órfão",
+    "source_hash": "8d827807"
+  },
+  "web.admin.organizations.entitlements.matrix.state.missing": {
+    "text": "Ausente",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.organizations.entitlements.picker.selectPlaceholder": {
+    "text": "Selecione um entitlement…",
+    "source_hash": "53af3be8"
+  },
+  "web.admin.organizations.entitlements.picker.other": {
+    "text": "Outro — fora do catálogo…",
+    "source_hash": "f08bc3a3"
+  },
+  "web.admin.organizations.entitlements.picker.customLabel": {
+    "text": "Nome do entitlement (fora do catálogo)",
+    "source_hash": "52783229"
+  },
+  "web.admin.organizations.entitlements.picker.backToCatalog": {
+    "text": "Voltar ao catálogo",
+    "source_hash": "9b727f40"
+  },
+  "web.admin.organizations.entitlements.picker.uncategorized": {
+    "text": "Sem categoria",
+    "source_hash": "8d40d123"
+  },
+  "web.admin.organizations.entitlements.picker.catalogUnavailable": {
+    "text": "Não foi possível ler o catálogo de cobrança, então os nomes de entitlements não são verificados aqui.",
+    "source_hash": "724869ec"
+  },
+  "web.admin.organizations.entitlements.picker.tags.inPlan": {
+    "text": "no plano",
+    "source_hash": "5f2251bb"
+  },
+  "web.admin.organizations.entitlements.picker.tags.granted": {
+    "text": "concedido",
+    "source_hash": "dd515d19"
+  },
+  "web.admin.organizations.entitlements.picker.tags.revoked": {
+    "text": "revogado",
+    "source_hash": "4bb47f18"
+  },
+  "web.admin.organizations.entitlements.summary.sync": {
+    "text": "Sincronizar",
+    "source_hash": "8d261a37"
+  },
+  "web.admin.organizations.entitlements.summary.materialized": {
+    "text": "Materializado",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.summary.materializedAt": {
+    "text": "Última materialização",
+    "source_hash": "9325dce9"
+  },
+  "web.admin.organizations.entitlements.summary.planDefinition": {
+    "text": "Definição do plano",
+    "source_hash": "6b531454"
+  },
+  "web.admin.organizations.entitlements.summary.yes": {
+    "text": "Sim",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.summary.no": {
+    "text": "Não",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.summary.never": {
+    "text": "Nunca",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.organizations.entitlements.summary.planStale": {
+    "text": "Alterada desde a materialização",
+    "source_hash": "e682d8a4"
+  },
+  "web.admin.organizations.entitlements.summary.planCurrent": {
+    "text": "Atual",
+    "source_hash": "e0d1b682"
+  },
+  "web.admin.organizations.entitlements.summary.planUnknown": {
+    "text": "Desconhecido — não foi possível comparar",
+    "source_hash": "b607e540"
   }
 }

--- a/locales/content/pt_BR/admin-secrets.json
+++ b/locales/content/pt_BR/admin-secrets.json
@@ -1,11 +1,11 @@
 {
   "web.admin.secrets.title": {
-    "text": "Mensagens confidenciais",
-    "source_hash": "d8707d41"
+    "text": "Comprovantes de mensagens confidenciais",
+    "source_hash": "a8a2d0e4"
   },
   "web.admin.secrets.description": {
-    "text": "Inspecione o comprovante de uma mensagem confidencial e exclua-a sem SSH — consulte-a pela sua chave.",
-    "source_hash": "07775a11"
+    "text": "Consulte estado, data/hora, comprovante etc.",
+    "source_hash": "91fba2a1"
   },
   "web.admin.secrets.never": {
     "text": "Nunca",
@@ -108,20 +108,20 @@
     "source_hash": "504101bc"
   },
   "web.admin.secrets.lookup.resultTitle": {
-    "text": "Mensagem confidencial {shortid}",
-    "source_hash": "8b311d32"
+    "text": "Registro da mensagem confidencial {shortid}",
+    "source_hash": "ee06d765"
   },
   "web.admin.secrets.lookup.notFound": {
-    "text": "Mensagem confidencial não encontrada",
-    "source_hash": "70a9532c"
+    "text": "Nenhum registro encontrado",
+    "source_hash": "40f4d9e9"
   },
   "web.admin.secrets.lookup.notFoundDescription": {
     "text": "Nenhuma mensagem confidencial existe com esta chave. Ela pode ter expirado ou sido excluída.",
     "source_hash": "9f068a81"
   },
   "web.admin.secrets.lookup.loadError": {
-    "text": "Não foi possível carregar esta mensagem confidencial.",
-    "source_hash": "c96672e4"
+    "text": "Não foi possível carregar este registro.",
+    "source_hash": "de77cc72"
   },
   "web.admin.secrets.lookup.retry": {
     "text": "Tentar novamente",
@@ -188,8 +188,8 @@
     "source_hash": "c127dab6"
   },
   "web.admin.secrets.sections.secret": {
-    "text": "Mensagem confidencial",
-    "source_hash": "7e32a729"
+    "text": "Registro da mensagem confidencial",
+    "source_hash": "263813c6"
   },
   "web.admin.secrets.sections.receipt": {
     "text": "Comprovante",
@@ -214,5 +214,25 @@
   "web.admin.secrets.state.viewed": {
     "text": "Visualizado",
     "source_hash": "1b28d178"
+  },
+  "web.admin.secrets.capability.title": {
+    "text": "Somente metadados",
+    "source_hash": "df0453d1"
+  },
+  "web.admin.secrets.capability.canRead": {
+    "text": "Lê os metadados de uma mensagem confidencial e seu comprovante: estado, data/hora, proprietário e o tamanho do texto cifrado armazenado.",
+    "source_hash": "d438ecc7"
+  },
+  "web.admin.secrets.capability.cannotRead": {
+    "text": "Não é possível descriptografar ou exibir o conteúdo da mensagem confidencial. O endpoint por trás desta tela nunca o retorna.",
+    "source_hash": "7f69f222"
+  },
+  "web.admin.secrets.capability.canDelete": {
+    "text": "Pode excluir permanentemente uma mensagem confidencial e seu comprovante, o que destrói o conteúdo sem nunca revelá-lo.",
+    "source_hash": "77f2bc7e"
+  },
+  "web.admin.secrets.lookup.hint": {
+    "text": "O identificador do link da mensagem confidencial — não o conteúdo.",
+    "source_hash": "acfbc352"
   }
 }

--- a/locales/content/pt_BR/admin-system.json
+++ b/locales/content/pt_BR/admin-system.json
@@ -154,5 +154,133 @@
   "web.admin.system.redis.captured": {
     "text": "Capturado {at}",
     "source_hash": "57b40c0f"
+  },
+  "web.admin.system.brand.title": {
+    "text": "Diagnóstico de marca",
+    "source_hash": "1cf9abd5"
+  },
+  "web.admin.system.brand.description": {
+    "text": "Qual pacote de marca a instância em execução resolveu em disco — revela por que uma região pode servir marca neutra.",
+    "source_hash": "be29e282"
+  },
+  "web.admin.system.brand.loadError": {
+    "text": "Não foi possível carregar o diagnóstico de marca.",
+    "source_hash": "80607303"
+  },
+  "web.admin.system.brand.none": {
+    "text": "(nenhum)",
+    "source_hash": "552e4230"
+  },
+  "web.admin.system.brand.resolution": {
+    "text": "Resolução",
+    "source_hash": "d4055faf"
+  },
+  "web.admin.system.brand.envVsConfig": {
+    "text": "Ambiente vs. configuração",
+    "source_hash": "bee3debb"
+  },
+  "web.admin.system.brand.absorbed": {
+    "text": "Chaves absorvidas",
+    "source_hash": "9784e110"
+  },
+  "web.admin.system.brand.operatorKeys": {
+    "text": "Chaves do operador",
+    "source_hash": "434e8248"
+  },
+  "web.admin.system.brand.overlayAssets": {
+    "text": "Ativos de sobreposição",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.exists.yes": {
+    "text": "Presente",
+    "source_hash": "43f9b89c"
+  },
+  "web.admin.system.brand.exists.no": {
+    "text": "Ausente",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.system.brand.fields.resolvedDir": {
+    "text": "Diretório resolvido",
+    "source_hash": "0623b983"
+  },
+  "web.admin.system.brand.fields.home": {
+    "text": "Home",
+    "source_hash": "3a786953"
+  },
+  "web.admin.system.brand.fields.envPack": {
+    "text": "Pacote de marca via ENV",
+    "source_hash": "940aeb5c"
+  },
+  "web.admin.system.brand.fields.configPack": {
+    "text": "Pacote de marca via configuração",
+    "source_hash": "761b9550"
+  },
+  "web.admin.system.brand.fields.envAssetsDir": {
+    "text": "Diretório de ativos de marca via ENV",
+    "source_hash": "05854f1f"
+  },
+  "web.admin.system.brand.fields.configAssetsDir": {
+    "text": "Diretório de ativos de marca via configuração",
+    "source_hash": "e91e5c46"
+  },
+  "web.admin.system.brand.flags.fellBack.danger": {
+    "text": "Recorreu ao pacote padrão",
+    "source_hash": "7bf7ba2f"
+  },
+  "web.admin.system.brand.flags.fellBack.ok": {
+    "text": "Pacote de marca resolvido",
+    "source_hash": "1ab3162f"
+  },
+  "web.admin.system.brand.flags.mismatch.danger": {
+    "text": "Divergência entre inicialização e execução",
+    "source_hash": "0a022192"
+  },
+  "web.admin.system.brand.flags.mismatch.ok": {
+    "text": "Inicialização corresponde à execução",
+    "source_hash": "d4792c09"
+  },
+  "web.admin.system.brand.manifest.title": {
+    "text": "Manifesto",
+    "source_hash": "3c99f1f3"
+  },
+  "web.admin.system.brand.manifest.path": {
+    "text": "Caminho",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.manifest.exists": {
+    "text": "Existe",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.manifest.keysOnDisk": {
+    "text": "Chaves em disco",
+    "source_hash": "52439c03"
+  },
+  "web.admin.system.brand.roots.title": {
+    "text": "Raízes de busca",
+    "source_hash": "d8696f2b"
+  },
+  "web.admin.system.brand.roots.empty": {
+    "text": "Nenhuma raiz de busca",
+    "source_hash": "867a471c"
+  },
+  "web.admin.system.brand.roots.columns.path": {
+    "text": "Caminho",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.roots.columns.exists": {
+    "text": "Existe",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.stats.brandPack": {
+    "text": "Pacote de marca",
+    "source_hash": "884437d0"
+  },
+  "web.admin.system.brand.stats.overlayAssets": {
+    "text": "Ativos de sobreposição",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.stats.manifestKeys": {
+    "text": "Chaves do manifesto",
+    "source_hash": "c4267198"
   }
 }

--- a/locales/content/pt_BR/email.json
+++ b/locales/content/pt_BR/email.json
@@ -836,5 +836,41 @@
   "email.secret_link.footer_note": {
     "text": "Você recebeu este e-mail porque %{sender_email} usou o %{product_name} para compartilhar uma mensagem confidencial com você. Se você não estava esperando por isso, pode ignorar este e-mail com segurança.",
     "source_hash": "2d544dad"
+  },
+  "email.sso_link_verification.subject": {
+    "text": "Confirme a vinculação de %{provider} à sua conta %{product_name}",
+    "source_hash": "65e70296"
+  },
+  "email.sso_link_verification.title": {
+    "text": "Confirme seu início de sessão via SSO",
+    "source_hash": "35bce6cc"
+  },
+  "email.sso_link_verification.request_notice": {
+    "text": "Alguém entrou com %{provider} usando o e-mail %{email_address}. Para concluir a conexão de %{provider} à sua conta %{product_name}, confirme abaixo.",
+    "source_hash": "baeb18c0"
+  },
+  "email.sso_link_verification.confirm_button": {
+    "text": "Confirmar e vincular %{provider}",
+    "source_hash": "9809e210"
+  },
+  "email.sso_link_verification.copy_link_prompt": {
+    "text": "Ou copie e cole este link:",
+    "source_hash": "88c72144"
+  },
+  "email.sso_link_verification.expiration_notice": {
+    "text": "Este link expira em 15 minutos e pode ser usado apenas uma vez.",
+    "source_hash": "1a437f42"
+  },
+  "email.sso_link_verification.ignore_notice": {
+    "text": "Se você não tentou entrar com %{provider}, pode ignorar este e-mail com segurança — nada será conectado à sua conta.",
+    "source_hash": "d7317d30"
+  },
+  "email.sso_link_verification.signature": {
+    "text": "Equipe de Suporte",
+    "source_hash": "dc75bf9f"
+  },
+  "email.sso_link_verification.postscript": {
+    "text": "P.S. Este e-mail foi enviado para %{email_address}.",
+    "source_hash": "8ab1dbea"
   }
 }

--- a/locales/content/pt_BR/feature-regions.json
+++ b/locales/content/pt_BR/feature-regions.json
@@ -160,31 +160,31 @@
     "source_hash": "5b2238b2"
   },
   "web.regions.jurisdictions.eu.name": {
-    "text": "European Union",
+    "text": "União Europeia",
     "source_hash": "7fe24f2b"
   },
   "web.regions.jurisdictions.us.name": {
-    "text": "United States",
+    "text": "Estados Unidos",
     "source_hash": "49dca65f"
   },
   "web.regions.jurisdictions.ca.name": {
-    "text": "Canada",
+    "text": "Canadá",
     "source_hash": "be55ef3f"
   },
   "web.regions.jurisdictions.uk.name": {
-    "text": "United Kingdom",
+    "text": "Reino Unido",
     "source_hash": "8d23a6e3"
   },
   "web.regions.jurisdictions.nz.name": {
-    "text": "New Zealand",
+    "text": "Nova Zelândia",
     "source_hash": "2898e16d"
   },
   "web.regions.jurisdictions.at.name": {
-    "text": "Austria",
+    "text": "Áustria",
     "source_hash": "c9cab023"
   },
   "web.regions.jurisdictions.apac.name": {
-    "text": "Asia-Pacific",
+    "text": "Ásia-Pacífico",
     "source_hash": "7a757670"
   },
   "web.regions.no_region_configured": {

--- a/locales/content/pt_BR/session-auth-extended.json
+++ b/locales/content/pt_BR/session-auth-extended.json
@@ -730,5 +730,201 @@
   "web.auth.sessions.session_plural": {
     "text": "sessões",
     "source_hash": "1225ae6c"
+  },
+  "web.auth.connections.title": {
+    "text": "Identidades conectadas",
+    "source_hash": "e132c4d9"
+  },
+  "web.auth.connections.description": {
+    "text": "Gerencie os provedores de single sign-on vinculados à sua conta.",
+    "source_hash": "42c6d148"
+  },
+  "web.auth.connections.section_title": {
+    "text": "Início de sessão único",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.section_subtitle": {
+    "text": "Provedores de identidade que você pode usar para entrar nesta conta",
+    "source_hash": "507254cd"
+  },
+  "web.auth.connections.connect_title": {
+    "text": "Conectar um provedor",
+    "source_hash": "a002b3f3"
+  },
+  "web.auth.connections.connect_description": {
+    "text": "Vincule outro provedor de single sign-on que você pode usar para entrar nesta conta.",
+    "source_hash": "32895a5a"
+  },
+  "web.auth.connections.connect_action": {
+    "text": "Conectar {provider}",
+    "source_hash": "c77540af"
+  },
+  "web.auth.connections.issuer": {
+    "text": "Emissor",
+    "source_hash": "39e02c46"
+  },
+  "web.auth.connections.identifier": {
+    "text": "Identificador",
+    "source_hash": "9b10587f"
+  },
+  "web.auth.connections.remove": {
+    "text": "Remover",
+    "source_hash": "c3812fc4"
+  },
+  "web.auth.connections.remove_confirm_title": {
+    "text": "Remover identidade conectada",
+    "source_hash": "4e8ffe4c"
+  },
+  "web.auth.connections.remove_confirm_message": {
+    "text": "Tem certeza de que deseja remover esta identidade conectada? Você não poderá mais entrar com ela.",
+    "source_hash": "64939c89"
+  },
+  "web.auth.connections.removed_success": {
+    "text": "Identidade conectada removida",
+    "source_hash": "cf87daf3"
+  },
+  "web.auth.connections.no_identities": {
+    "text": "Nenhuma identidade conectada",
+    "source_hash": "5254048e"
+  },
+  "web.auth.connections.no_identities_description": {
+    "text": "Você ainda não vinculou nenhum provedor de single sign-on a esta conta.",
+    "source_hash": "0f58d5d0"
+  },
+  "web.auth.connections.overview_status": {
+    "text": "Início de sessão único",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.errors.last_credential": {
+    "text": "Esta é a sua única forma de entrar. Conecte outro provedor primeiro ou defina uma senha em Configurações → Segurança para não ficar sem acesso.",
+    "source_hash": "3de8084d"
+  },
+  "web.auth.connections.errors.last_credential_sso_enforced": {
+    "text": "Esta é a sua única forma de entrar. Conecte outro provedor primeiro para não ficar sem acesso.",
+    "source_hash": "eed7a50e"
+  },
+  "web.auth.connections.errors.not_found": {
+    "text": "Não foi possível encontrar essa identidade conectada. Ela pode já ter sido removida.",
+    "source_hash": "cf2c7673"
+  },
+  "web.auth.connections.errors.unauthorized": {
+    "text": "Sua sessão expirou. Entre novamente.",
+    "source_hash": "b529fce2"
+  },
+  "web.auth.connections.errors.generic": {
+    "text": "Não foi possível concluir essa ação. Tente novamente.",
+    "source_hash": "a0d4edc0"
+  },
+  "web.link_sso.title": {
+    "text": "Vincule seu método de início de sessão",
+    "source_hash": "46339bac"
+  },
+  "web.link_sso.prompt": {
+    "text": "Você entrou com {provider}, que corresponde à conta existente {email}. Digite a senha dessa conta para vincular {provider} e continuar.",
+    "source_hash": "59da1c08"
+  },
+  "web.link_sso.password_label": {
+    "text": "Senha",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.link_sso.password_placeholder": {
+    "text": "Sua senha existente",
+    "source_hash": "ad4e56da"
+  },
+  "web.link_sso.submit": {
+    "text": "Vincular e continuar",
+    "source_hash": "c969b759"
+  },
+  "web.link_sso.cancel": {
+    "text": "Cancelar",
+    "source_hash": "19766ed6"
+  },
+  "web.link_sso.unavailable_title": {
+    "text": "Esta solicitação de vinculação expirou",
+    "source_hash": "b53c7e55"
+  },
+  "web.link_sso.unavailable_message": {
+    "text": "Para sua segurança, a solicitação para vincular este método de início de sessão não é mais válida. Entre com sua senha existente e depois conecte este provedor em Configurações de segurança → Identidades conectadas.",
+    "source_hash": "f7e349d1"
+  },
+  "web.link_sso.unavailable_action": {
+    "text": "Continuar para entrar",
+    "source_hash": "d398cd0a"
+  },
+  "web.link_sso.errors.invalid_password": {
+    "text": "Essa senha não corresponde a esta conta. Tente novamente.",
+    "source_hash": "3259b4f5"
+  },
+  "web.link_sso.errors.invalid_token": {
+    "text": "Esta solicitação de vinculação expirou ou já foi usada. Entre com sua senha existente e depois conecte este provedor nas configurações da sua conta.",
+    "source_hash": "541f9127"
+  },
+  "web.link_sso.errors.link_conflict": {
+    "text": "Não foi possível vincular este método de início de sessão. Sua conta pode ter mudado ou este provedor já está vinculado a outra conta. Entre com sua senha existente e depois gerencie as conexões em Configurações de segurança → Identidades conectadas.",
+    "source_hash": "7b0e0d0e"
+  },
+  "web.link_sso.errors.link_rate_limited": {
+    "text": "Muitas tentativas de senha. Aguarde alguns minutos e tente novamente.",
+    "source_hash": "a95e78cd"
+  },
+  "web.link_sso.errors.invalid_request": {
+    "text": "Não foi possível processar esta solicitação de vinculação. Entre novamente com seu provedor de SSO.",
+    "source_hash": "053b9fc6"
+  },
+  "web.link_sso.errors.generic": {
+    "text": "Não foi possível vincular sua conta. Tente novamente.",
+    "source_hash": "f727c174"
+  },
+  "web.sso_link_confirm.title": {
+    "text": "Confirme a conexão da sua conta",
+    "source_hash": "ad80bfe7"
+  },
+  "web.sso_link_confirm.prompt": {
+    "text": "Você entrou com {provider}, que corresponde à sua conta {email}. Confirme para conectar {provider} a esta conta e concluir o início de sessão.",
+    "source_hash": "6ff0d6cc"
+  },
+  "web.sso_link_confirm.submit": {
+    "text": "Confirmar e conectar",
+    "source_hash": "5cf663e6"
+  },
+  "web.sso_link_confirm.cancel": {
+    "text": "Cancelar",
+    "source_hash": "19766ed6"
+  },
+  "web.sso_link_confirm.unavailable_title": {
+    "text": "Esta solicitação de vinculação não pode ser concluída",
+    "source_hash": "47abb784"
+  },
+  "web.sso_link_confirm.unavailable_message": {
+    "text": "Para sua segurança, esta solicitação para conectar seu método de início de sessão não é mais válida. Entre novamente com seu provedor e enviaremos um novo link por e-mail.",
+    "source_hash": "080e6f9f"
+  },
+  "web.sso_link_confirm.unavailable_action": {
+    "text": "Voltar para entrar",
+    "source_hash": "8504054f"
+  },
+  "web.sso_link_confirm.errors.link_expired": {
+    "text": "Esta solicitação de vinculação expirou ou já foi usada. Entre novamente com seu provedor e enviaremos um novo link por e-mail.",
+    "source_hash": "a50538df"
+  },
+  "web.sso_link_confirm.errors.link_conflict": {
+    "text": "Não foi possível conectar este método de início de sessão. Sua conta pode ter mudado ou este provedor já está vinculado a outra conta. Entre novamente com seu provedor para continuar.",
+    "source_hash": "c954854b"
+  },
+  "web.sso_link_confirm.errors.link_invalidated": {
+    "text": "As credenciais da sua conta mudaram depois que este link foi enviado, então ele não é mais válido. Entre novamente com seu provedor e enviaremos um novo link por e-mail.",
+    "source_hash": "db88cb1d"
+  },
+  "web.sso_link_confirm.errors.link_error": {
+    "text": "Algo deu errado do nosso lado e não foi possível verificar este link. Entre novamente com seu provedor e enviaremos um novo por e-mail.",
+    "source_hash": "ec24e0a1"
+  },
+  "web.sso_link_confirm.errors.confirm_rate_limited": {
+    "text": "Muitas tentativas a partir do seu dispositivo. Aguarde alguns minutos e abra novamente o link enviado por e-mail ou entre com seu provedor para obter um novo.",
+    "source_hash": "f29af782"
+  },
+  "web.sso_link_confirm.errors.generic": {
+    "text": "Não foi possível confirmar esta conexão. Entre novamente com seu provedor.",
+    "source_hash": "076fa25a"
   }
 }

--- a/locales/content/pt_BR/session-auth-extended.json
+++ b/locales/content/pt_BR/session-auth-extended.json
@@ -757,6 +757,7 @@
   },
   "web.auth.connections.connect_action": {
     "text": "Conectar {provider}",
+    "context": "Button label to start linking a specific SSO provider; {provider} is the provider display name",
     "source_hash": "c77540af"
   },
   "web.auth.connections.issuer": {
@@ -821,6 +822,7 @@
   },
   "web.link_sso.prompt": {
     "text": "Você entrou com {provider}, que corresponde à conta existente {email}. Digite a senha dessa conta para vincular {provider} e continuar.",
+    "context": "Instruction on the sign-in interstitial. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/link-sso/:token.",
     "source_hash": "59da1c08"
   },
   "web.link_sso.password_label": {
@@ -881,6 +883,7 @@
   },
   "web.sso_link_confirm.prompt": {
     "text": "Você entrou com {provider}, que corresponde à sua conta {email}. Confirme para conectar {provider} a esta conta e concluir o início de sessão.",
+    "context": "Consent instruction on the #3840 Phase 4 mailbox-proof SSO linking page. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/sso-link-confirm/:token. No password is asked — clicking the emailed link is the proof.",
     "source_hash": "6ff0d6cc"
   },
   "web.sso_link_confirm.submit": {

--- a/locales/content/pt_BR/session-auth.json
+++ b/locales/content/pt_BR/session-auth.json
@@ -483,5 +483,41 @@
   "web.login.verified_notice": {
     "text": "Seu e-mail foi verificado — agora você pode entrar.",
     "source_hash": "c8d4b5a8"
+  },
+  "web.auth.password_setup_request.title": {
+    "text": "Definir uma senha",
+    "source_hash": "11b6978b"
+  },
+  "web.auth.password_setup_request.description": {
+    "text": "Sua conta ainda não tem uma senha. Enviaremos um link seguro por e-mail para você definir uma e também poder entrar diretamente.",
+    "source_hash": "dc0b561f"
+  },
+  "web.auth.password_setup_request.button": {
+    "text": "Enviar link de configuração",
+    "source_hash": "22807292"
+  },
+  "web.auth.password_setup_request.emailSent": {
+    "text": "Um e-mail foi enviado a você com um link para definir uma senha para sua conta",
+    "source_hash": "82b686c7"
+  },
+  "web.login.errors.account_exists_link_required": {
+    "text": "Já existe uma conta com este endereço de e-mail, mas ela não está vinculada a este método de início de sessão. Entre com seu método existente e depois vincule este provedor em Configurações de segurança → Identidades conectadas.",
+    "source_hash": "7fbbb7e7"
+  },
+  "web.login.errors.identity_connect_conflict": {
+    "text": "Não foi possível conectar esta identidade. A conexão pode ter sido iniciada no domínio errado ou sua sessão expirou. Entre novamente e depois conecte-a nas configurações da sua conta.",
+    "source_hash": "4238bbf2"
+  },
+  "web.login.errors.org_join_failed": {
+    "text": "Não foi possível concluir sua adição à organização. Entre em contato com seu administrador.",
+    "source_hash": "155e71bb"
+  },
+  "web.login.errors.link_sso_failed": {
+    "text": "Não foi possível vincular esse método de início de sessão. Entre com sua senha existente e depois conecte este provedor em Configurações de segurança → Identidades conectadas.",
+    "source_hash": "49954127"
+  },
+  "web.login.notices.link_verification_sent": {
+    "text": "Verifique sua caixa de entrada — enviamos um link por e-mail para confirmar a conexão da sua conta. Abra-o para concluir o início de sessão.",
+    "source_hash": "b251c8f3"
   }
 }

--- a/locales/content/pt_BR/workspace-account.json
+++ b/locales/content/pt_BR/workspace-account.json
@@ -694,5 +694,33 @@
   "web.settings.security.sso_managed_description": {
     "text": "Sua conta é autenticada pelo provedor de single sign-on (SSO) da sua organização. A senha, a autenticação multifator e os códigos de recuperação são gerenciados pelo seu provedor de identidade.",
     "source_hash": "cd0cf39f"
+  },
+  "web.settings.api.api_username": {
+    "text": "Nome de usuário da API",
+    "source_hash": "0b3e483e"
+  },
+  "web.settings.api.api_username_description": {
+    "text": "Seu nome de usuário para autenticação HTTP Basic",
+    "source_hash": "f3e65de3"
+  },
+  "web.settings.api.basic_auth_hint": {
+    "text": "Para autenticação HTTP Basic, use o e-mail da sua conta ou este ID como nome de usuário e seu token de API como senha.",
+    "source_hash": "cfa3806d"
+  },
+  "web.settings.security.set": {
+    "text": "Definida",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.settings.security.not_set": {
+    "text": "Não definida",
+    "source_hash": "4895f731"
+  },
+  "web.settings.security.set_password_title": {
+    "text": "Definir senha",
+    "source_hash": "4e411687"
+  },
+  "web.settings.security.set_password_description": {
+    "text": "Adicione uma senha à sua conta para também poder entrar sem o seu provedor de identidade",
+    "source_hash": "a6970402"
   }
 }

--- a/locales/content/pt_BR/workspace-billing.json
+++ b/locales/content/pt_BR/workspace-billing.json
@@ -1044,5 +1044,21 @@
   "web.billing.plans.reactivate": {
     "text": "Reativar",
     "source_hash": "2dc7478f"
+  },
+  "web.billing.currency_migration.refund_failed_warning": {
+    "text": "Seu plano anterior foi cancelado, mas não conseguimos emitir automaticamente o reembolso do seu tempo não utilizado. Entre em contato com o suporte para receber seu reembolso. Você ainda precisa concluir o checkout para ativar seu novo plano.",
+    "source_hash": "a390c498"
+  },
+  "web.billing.currency_migration.refund_failed_continue": {
+    "text": "Continuar para o checkout",
+    "source_hash": "eccdb8aa"
+  },
+  "web.billing.plans.per_year": {
+    "text": "/ano",
+    "source_hash": "a2d5f1bc"
+  },
+  "web.billing.plans.billing_interval": {
+    "text": "Intervalo de cobrança",
+    "source_hash": "3ce28209"
   }
 }

--- a/locales/content/pt_BR/workspace-branding.json
+++ b/locales/content/pt_BR/workspace-branding.json
@@ -56,12 +56,12 @@
     "source_hash": "e36598ef"
   },
   "web.branding.example_pre_reveal_instructions": {
-    "text": "Use seu celular para escanear o código QR",
-    "source_hash": "99ecf59f"
+    "text": "ex. Use seu celular para escanear o QR code",
+    "source_hash": "9cf0caf8"
   },
   "web.branding.example_post_reveal_instructions": {
-    "text": "Entre em contato com onboarding{'@'}example.com para qualquer dúvida",
-    "source_hash": "bee120a7"
+    "text": "ex. Entre em contato com onboarding{'@'}example.com em caso de dúvidas",
+    "source_hash": "71749811"
   },
   "web.branding.these_instructions_will_be_shown_to_recipients_before": {
     "text": "Estas instruções serão mostradas aos destinatários antes de revelarem o conteúdo confidencial",
@@ -320,8 +320,8 @@
     "source_hash": "bc79cdff"
   },
   "web.branding.paths_carryover_hint": {
-    "text": "Esta é uma visualização ao vivo — suas alterações não ficarão visíveis para os visitantes até você salvar.",
-    "source_hash": "cb4b82de"
+    "text": "Esta é uma prévia ao vivo — suas alterações não ficarão visíveis para os visitantes até você clicar em Atualizar.",
+    "source_hash": "9a34df71"
   },
   "web.branding.coming_soon_match_blurb": {
     "text": "Indique seu site e leremos suas cores e fontes, depois preencheremos a diferença em um clique.",
@@ -406,5 +406,57 @@
   "web.branding.delivery_after_reveal": {
     "text": "Depois da revelação",
     "source_hash": "d5bfe7fd"
+  },
+  "web.branding.favicon": {
+    "text": "Favicon",
+    "source_hash": "42955289"
+  },
+  "web.branding.refresh_favicon": {
+    "text": "Atualizar favicon a partir do domínio",
+    "source_hash": "7cc3d5dc"
+  },
+  "web.branding.refresh_favicon_hint": {
+    "text": "Buscar novamente o favicon do seu domínio. O novo ícone aparece em instantes.",
+    "source_hash": "ee007e44"
+  },
+  "web.branding.refresh_favicon_queued": {
+    "text": "Atualizando o favicon — o novo ícone aparecerá em instantes.",
+    "source_hash": "6bf38e6e"
+  },
+  "web.branding.refresh_favicon_user_upload_hint": {
+    "text": "Você enviou um favicon personalizado, então um ícone buscado automaticamente não o substituirá.",
+    "source_hash": "c22e1ed6"
+  },
+  "web.branding.upload_favicon": {
+    "text": "Enviar favicon",
+    "source_hash": "ceda39cb"
+  },
+  "web.branding.replace_favicon": {
+    "text": "Substituir",
+    "source_hash": "95e15439"
+  },
+  "web.branding.remove_favicon": {
+    "text": "Remover favicon",
+    "source_hash": "03693698"
+  },
+  "web.branding.favicon_field_hint": {
+    "text": "ICO, PNG ou SVG. O envio substitui o ícone buscado automaticamente.",
+    "source_hash": "dfa0bfcb"
+  },
+  "web.branding.favicon_preview_alt": {
+    "text": "Favicon do domínio",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_title": {
+    "text": "Favicon do domínio",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_hint": {
+    "text": "ICO, PNG ou SVG. Até 256KB. Substitui o ícone buscado automaticamente.",
+    "source_hash": "c9eafc83"
+  },
+  "web.branding.favicon_modal_save": {
+    "text": "Salvar favicon",
+    "source_hash": "c8a1566c"
   }
 }

--- a/locales/content/pt_BR/workspace-domains.json
+++ b/locales/content/pt_BR/workspace-domains.json
@@ -504,11 +504,11 @@
     "source_hash": "8e37953d"
   },
   "web.domains.email.dns_optional_label": {
-    "text": "Recommended",
+    "text": "Recomendado",
     "source_hash": "d70604e8"
   },
   "web.domains.email.dns_optional_hint": {
-    "text": "This record is recommended but not required for verification. A DMARC policy at your organizational domain may already cover this subdomain.",
+    "text": "Este registro é recomendado, mas não é obrigatório para a verificação. Uma política DMARC no domínio da sua organização pode já cobrir este subdomínio.",
     "source_hash": "58e1a12b"
   },
   "web.domains.email.copy": {

--- a/locales/content/pt_BR/workspace-organizations.json
+++ b/locales/content/pt_BR/workspace-organizations.json
@@ -1034,5 +1034,153 @@
   "web.organizations.create_workspace": {
     "text": "Criar Workspace",
     "source_hash": "c63c14cf"
+  },
+  "web.organizations.organization_id": {
+    "text": "ID da organização",
+    "source_hash": "1f466322"
+  },
+  "web.organizations.organization_id_hint": {
+    "text": "Use este ID ao entrar em contato com o suporte ou ao limitar solicitações de API a esta organização. Não é uma credencial de início de sessão.",
+    "source_hash": "29549b3a"
+  },
+  "web.organizations.audit.title": {
+    "text": "Atividade de mensagens confidenciais",
+    "source_hash": "6d6d41f3"
+  },
+  "web.organizations.audit.description": {
+    "text": "Trilha de auditoria dos eventos de criação e acesso a mensagens confidenciais registrados para esta organização.",
+    "source_hash": "553c564b"
+  },
+  "web.organizations.audit.country_unknown": {
+    "text": "Desconhecido",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.empty_title": {
+    "text": "Nenhuma atividade ainda",
+    "source_hash": "0a12b92c"
+  },
+  "web.organizations.audit.empty_description": {
+    "text": "Os eventos de criação e acesso a mensagens confidenciais aparecerão aqui conforme sua equipe compartilhar mensagens.",
+    "source_hash": "62fb14c2"
+  },
+  "web.organizations.audit.capped_notice": {
+    "text": "Apenas os {max} eventos mais recentes são mantidos; a atividade mais antiga foi removida.",
+    "source_hash": "da7901e2"
+  },
+  "web.organizations.audit.collection_paused_notice": {
+    "text": "A coleta de eventos está pausada; novas atividades de mensagens confidenciais não estão sendo registradas.",
+    "source_hash": "cb09d147"
+  },
+  "web.organizations.audit.load_error": {
+    "text": "Não foi possível carregar a atividade de mensagens confidenciais.",
+    "source_hash": "52fde814"
+  },
+  "web.organizations.audit.contract_mismatch": {
+    "text": "Não foi possível ler os dados de atividade retornados pelo servidor. A trilha não está vazia — apenas não pode ser exibida no momento.",
+    "source_hash": "db0d007a"
+  },
+  "web.organizations.audit.retry": {
+    "text": "Tentar novamente",
+    "source_hash": "d8b8392e"
+  },
+  "web.organizations.audit.showing_range": {
+    "text": "Exibindo {from}–{to} de {total}",
+    "source_hash": "c329279d"
+  },
+  "web.organizations.audit.upgrade_prompt": {
+    "text": "A atividade de mensagens confidenciais requer um plano com logs de auditoria. Faça upgrade para ver quem criou, visualizou e revelou mensagens confidenciais nesta organização.",
+    "source_hash": "453649ce"
+  },
+  "web.organizations.audit.role_required": {
+    "text": "A atividade de mensagens confidenciais está disponível para proprietários e administradores da organização.",
+    "source_hash": "e066ec63"
+  },
+  "web.organizations.audit.actors.creator": {
+    "text": "Criador",
+    "source_hash": "88447b83"
+  },
+  "web.organizations.audit.actors.authenticated_other": {
+    "text": "Outro usuário autenticado",
+    "source_hash": "ee45aa5a"
+  },
+  "web.organizations.audit.actors.anonymous": {
+    "text": "Anônimo",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.organizations.audit.actors.system": {
+    "text": "Sistema",
+    "source_hash": "6725e7bb"
+  },
+  "web.organizations.audit.actors.unknown": {
+    "text": "Desconhecido",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.columns.event": {
+    "text": "Evento",
+    "source_hash": "4e1f49a9"
+  },
+  "web.organizations.audit.columns.secret": {
+    "text": "Mensagem confidencial",
+    "source_hash": "7e32a729"
+  },
+  "web.organizations.audit.columns.actor": {
+    "text": "Autor",
+    "source_hash": "449995c4"
+  },
+  "web.organizations.audit.columns.country": {
+    "text": "País",
+    "source_hash": "701d021d"
+  },
+  "web.organizations.audit.columns.when": {
+    "text": "Quando",
+    "source_hash": "cf9c7aa2"
+  },
+  "web.organizations.audit.kinds.created": {
+    "text": "Mensagem confidencial criada",
+    "source_hash": "e4a1e1fd"
+  },
+  "web.organizations.audit.kinds.status_get": {
+    "text": "Status do link consultado",
+    "source_hash": "0753f60e"
+  },
+  "web.organizations.audit.kinds.secret_get": {
+    "text": "Link da mensagem confidencial aberto",
+    "source_hash": "e271e060"
+  },
+  "web.organizations.audit.kinds.previewed": {
+    "text": "Pré-visualizada pelo criador",
+    "source_hash": "639fc1e2"
+  },
+  "web.organizations.audit.kinds.creator_status_get": {
+    "text": "Status consultado pelo criador",
+    "source_hash": "7e4b5de5"
+  },
+  "web.organizations.audit.kinds.receipt_viewed": {
+    "text": "Comprovante visualizado",
+    "source_hash": "a417ead4"
+  },
+  "web.organizations.audit.kinds.revealed": {
+    "text": "Mensagem confidencial revelada",
+    "source_hash": "aff2c84d"
+  },
+  "web.organizations.audit.kinds.burned": {
+    "text": "Mensagem confidencial queimada",
+    "source_hash": "5ac68dc6"
+  },
+  "web.organizations.audit.kinds.expired": {
+    "text": "Mensagem confidencial expirada",
+    "source_hash": "c127dab6"
+  },
+  "web.organizations.audit.kinds.orphaned": {
+    "text": "Mensagem confidencial órfã",
+    "source_hash": "23fe1a47"
+  },
+  "web.organizations.audit.kinds.reveal_failed_undecryptable": {
+    "text": "Falha ao revelar (não descriptografável)",
+    "source_hash": "d5616abf"
+  },
+  "web.organizations.tabs.activity": {
+    "text": "Atividade",
+    "source_hash": "38da1505"
   }
 }


### PR DESCRIPTION
## `pt_BR` translation update

Automated export of completed **pt_BR** translations from the translation task DB.
Scope: `locales/content/pt_BR/` only — 18 file(s), +2030/-30.

⚠️ `i18n validate variables` reports **3** variable mismatch(es) for `pt_BR` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ⚠️ Needs review — context-field vars missing, text fields fine

**Summary:** All actual user-facing `text` values in this diff correctly preserve every `{var}`/`%{var}` placeholder and read as natural, properly-accented Brazilian Portuguese; no mojibake, no untranslated leftovers, no brand-term tampering. The 3 flagged errors are all in the non-user-facing `context` (translator-note) field, not in `text`.

**Critical (must fix):**
- `session-auth-extended.json`: `web.auth.connections.connect_action`, `web.link_sso.prompt`, `web.sso_link_confirm.prompt` — English source has a `context` field containing `{provider}`/`{email}`, but pt_BR omits the `context` key entirely for these (and for all ~48 new keys in this SSO-linking batch), breaking from the established convention elsewhere in this same file where `context` is carried over verbatim (untranslated, English) alongside `text`. Doesn't affect what users see — the `text` values for these 3 keys are correctly translated with all placeholders intact — but it's a schema gap vs. existing entries and is what the automated checker is flagging. Worth confirming with the translator/pipeline whether `context` should be preserved for new keys before merge.

**Warnings:**
- None beyond the Critical item above (same root cause, no separate instances found).

**Notes:**
- `feature-regions.json`: jurisdiction names (EU, US, Canada, UK, NZ, Austria, APAC) were previously left in English and are now correctly translated — good fix, not new leakage.
- `workspace-domains.json`: two previously-untranslated English strings (`dns_optional_label`/`hint`) are now translated — good fix.
- Several `description`/`title` diffs (e.g. `admin-customers`, `admin-secrets`, `workspace-branding`) track legitimate upstream English source-text changes (hash bumps confirmed), not translation drift.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
