### PR TITLE
feat(admin): gate /colonel on a detected-host allowlist (#4062)

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -1259,13 +1259,19 @@ ASSUME_HTTPS=false
 # Comma-separated hostnames that serve /colonel and /api/colonel; any other host
 # gets the same 404. Unset/empty (default) = the canonical hosts (DEFAULT_DOMAIN
 # / HOST) plus their www. variants, so tenant custom domains and LINK_DOMAINS
-# stop serving the admin console. Explicit entries match literally. "*" (sole
-# entry) disables the host gate, logged at WARN, and is the one-variable
-# rollback. Punycode (xn--) form required for internationalized domains.
+# stop serving the admin console. Explicit entries match literally. "*"
+# ANYWHERE in the list disables the host gate, logged at WARN, and is the
+# one-variable rollback. Punycode (xn--) form required for internationalized
+# domains.
 # A value that can never match (an IP literal, localhost, *.example.com, a
-# non-ASCII name) FAILS THE BOOT, naming each rejected entry. Only the
+# non-ASCII name) leaves the gate ACTIVE and EMPTY: /colonel and /api/colonel
+# 404 on every hostname, with a boot WARN naming each rejected entry. The boot
+# itself is NOT aborted -- the rest of the app is unaffected. Only the
 # unset/fallback case self-disables, with a boot WARN, on installs with no
 # routable hostname (the stock HOST=localhost:3000, or a bare-IP install).
+# Behind a proxy that forwards the public hostname in a header instead of
+# rewriting Host, TRUSTED_PROXY_* must be configured or the admin gate refuses
+# the forwarded host and both surfaces 404.
 # Example: admin.example.com
 #ADMIN_ALLOWED_HOSTS=
 

--- a/.env.reference
+++ b/.env.reference
@@ -1255,6 +1255,20 @@ TRUSTED_PROXY_DEPTH=1
 # share/email/redirect links emit http:// while clients use https. Default: false.
 ASSUME_HTTPS=false
 
+# Admin (Colonel) host allowlist (config site.admin.allowed_hosts).
+# Comma-separated hostnames that serve /colonel and /api/colonel; any other host
+# gets the same 404. Unset/empty (default) = the canonical hosts (DEFAULT_DOMAIN
+# / HOST) plus their www. variants, so tenant custom domains and LINK_DOMAINS
+# stop serving the admin console. Explicit entries match literally. "*" (sole
+# entry) disables the host gate, logged at WARN, and is the one-variable
+# rollback. Punycode (xn--) form required for internationalized domains.
+# A value that can never match (an IP literal, localhost, *.example.com, a
+# non-ASCII name) FAILS THE BOOT, naming each rejected entry. Only the
+# unset/fallback case self-disables, with a boot WARN, on installs with no
+# routable hostname (the stock HOST=localhost:3000, or a bare-IP install).
+# Example: admin.example.com
+#ADMIN_ALLOWED_HOSTS=
+
 # Admin (Colonel) network isolation (config site.admin.allowed_cidrs).
 # Optional CIDR allowlist for the Colonel admin surfaces (/colonel shell and
 # /api/colonel API). Comma-separated. When set, a request whose

--- a/changelog.d/20260809_140000_claude_4062_admin_host_allowlist.rst
+++ b/changelog.d/20260809_140000_claude_4062_admin_host_allowlist.rst
@@ -30,15 +30,51 @@ Changed
   gate untouched. (#4062)
 
 - **Operators:** an ``ADMIN_ALLOWED_HOSTS`` that names nothing the gate could
-  ever match **fails the boot**, naming each rejected entry and why —
-  ``ADMIN_ALLOWED_HOSTS=127.0.0.1``, ``=localhost``, ``=*.example.com``, or a
-  non-ASCII name with no ``xn--`` form. Every one of those is an operator
-  writing an allowlist in order to restrict the admin surfaces, and the
-  alternative — disabling the gate — would serve ``/colonel`` on every hostname
-  the app answers on, the opposite of what was asked. Partial failures still
-  boot: as long as one entry is enforceable the rest are dropped with a WARN.
-  ``ADMIN_ALLOWED_HOSTS=*`` remains the way to ask for the gate to be off.
+  ever match — ``=127.0.0.1``, ``=localhost``, ``=*.example.com``, or a
+  non-ASCII name with no ``xn--`` form — leaves the host gate **active with an
+  empty allowlist**: ``/colonel`` and ``/api/colonel`` return 404 on every
+  hostname, and boot logs a WARN naming each rejected entry and why. Every one
+  of those values is an operator writing an allowlist in order to restrict the
+  admin surfaces, and the alternative — disabling the gate — would serve
+  ``/colonel`` on every hostname the app answers on, the opposite of what was
+  asked. The boot itself is not aborted: the admin surfaces are already
+  fail-closed for this config, so stopping the process would take the public
+  site, the API and the health endpoints down over an admin-console-only typo.
+  Partial failures are unaffected: as long as one entry is enforceable the rest
+  are dropped with a WARN. ``ADMIN_ALLOWED_HOSTS=*`` remains the way to ask for
+  the gate to be off, and a ``*`` **anywhere** in the list is honoured — a
+  sibling entry is ignored (and named in a WARN), never treated as ambiguous.
   (#4062)
+
+- **Operators:** the admin host gate accepts a forwarded host header
+  (``X-Forwarded-Host``, ``Apx-Incoming-Host``, ``X-Original-Host``,
+  ``Forwarded``) **only** from a peer ``site.network.trusted_proxy`` vouched
+  for. With no trusted proxy configured — the shipped default —
+  ``Rack::DetectHost`` falls back to a heuristic that lets any peer on a
+  private or loopback address name the host (#4024), which on a containerised
+  install would let a request to a tenant custom domain claim to be the
+  canonical admin host. When the gate refuses a forwarded host it returns the
+  same 404; it deliberately does not fall back to the ``Host`` header, because
+  in the ingress topology this defends ``Host`` carries the origin's own
+  (allowlisted) hostname. **If both admin surfaces start 404ing after this
+  upgrade** and your proxy forwards the public hostname in a header rather than
+  rewriting ``Host``, configure ``site.network.trusted_proxy`` (correct for the
+  CIDR gate, ban checks, sessions and audit attribution too) or set
+  ``ADMIN_ALLOWED_HOSTS=*``. (#4062)
+
+- **Operators:** an ``ADMIN_ALLOWED_CIDRS`` that is set but where **no** entry
+  parses as a CIDR now denies both admin surfaces (logged at ERROR) instead of
+  silently deactivating the network gate. Previously each malformed entry was
+  warned away individually and the empty result read as "no network gate", so
+  ``ADMIN_ALLOWED_CIDRS=100.64.0.0\10`` left the surfaces reachable from
+  anywhere while the operator believed a VPN restriction was in force. An
+  **empty or unset** list still means "no network gate" — that is the
+  self-hosted default and is unchanged. (#4062)
+
+- **Operators:** percent-encoded spellings of the admin paths (``/%63olonel``,
+  ``/colonel%2Fsettings``) are gated exactly like ``/colonel``. The router
+  decodes before dispatch, so matching the raw path would have let those
+  spellings skip both gates and reach the admin console. (#4062)
 
 - **Operators:** installs with no routable hostname are exempted rather than
   locked out. When ``ADMIN_ALLOWED_HOSTS`` is unset and neither canonical
@@ -48,7 +84,7 @@ Changed
   fallback only; a list the operator set is never silently disabled (above).
   (#4062)
 
-- **Operators:** boot logs one INFO line, ``Admin surface isolation posture``,
+- **Operators:** boot logs one INFO line per PROCESS, ``Admin surface isolation posture``,
   naming the effective hosts and CIDRs, whether each gate is active, and the
   ``site.network.trusted_proxy`` state (``disabled``, ``enabled
   (mode=filter)``, ``enabled (mode=depth)``). The trusted-proxy field is on
@@ -56,7 +92,9 @@ Changed
   — the shipped default — the detected host the gate judges may be chosen by
   any peer on a private or loopback address, and the client IP behind the CIDR
   gate comes from ``REMOTE_ADDR``. ``host_gate: active`` read next to
-  ``trusted_proxy: disabled`` is the combination to look for. (#4062)
+  ``trusted_proxy: disabled`` is the combination to look for. The line — and
+  every admin-isolation boot WARN beside it — is emitted once per process, not
+  once per mounted application. (#4062)
 
 - **Operators:** ``AdminNetworkIsolation`` now mounts after ``Rack::DetectHost``
   — where the host it judges is produced — instead of ahead of it. One visible
@@ -68,6 +106,6 @@ AI Assistance
 
 - Claude added the ``site.admin.allowed_hosts`` config key and its
   ``.env.reference`` entry, the shared ``Onetime::Utils::AdminHostAllowlist``
-  classifier behind both the boot validation and the gate, the host gate and
+  classifier behind both the boot diagnostic and the gate, the host gate and
   mount-order move in ``Onetime::Middleware::AdminNetworkIsolation``, and the
   two-factor rewrite of ``docs/operations/admin-network-isolation.md``. (#4062)

--- a/changelog.d/20260809_140000_claude_4062_admin_host_allowlist.rst
+++ b/changelog.d/20260809_140000_claude_4062_admin_host_allowlist.rst
@@ -25,9 +25,9 @@ Changed
   unchanged, while tenant custom domains and ``LINK_DOMAINS`` link-pool hosts
   stop serving the admin console. If you reach ``/colonel`` on any other
   hostname, set ``ADMIN_ALLOWED_HOSTS`` to that hostname before upgrading or it
-  will 404. Rollback is one variable: ``ADMIN_ALLOWED_HOSTS=*`` as the sole
-  entry disables the host gate (logged at WARN on boot) and leaves the CIDR
-  gate untouched. (#4062)
+  will 404. Rollback is one variable: ``ADMIN_ALLOWED_HOSTS=*`` disables the
+  host gate (logged at WARN on boot) and leaves the CIDR gate untouched — a
+  ``*`` anywhere in the list is honoured, not only as the sole entry. (#4062)
 
 - **Operators:** an ``ADMIN_ALLOWED_HOSTS`` that names nothing the gate could
   ever match — ``=127.0.0.1``, ``=localhost``, ``=*.example.com``, or a

--- a/changelog.d/20260809_140000_claude_4062_admin_host_allowlist.rst
+++ b/changelog.d/20260809_140000_claude_4062_admin_host_allowlist.rst
@@ -1,0 +1,73 @@
+.. A new scriv changelog fragment.
+
+Added
+-----
+
+- **Operators:** ``ADMIN_ALLOWED_HOSTS`` (``site.admin.allowed_hosts``) — a
+  comma-separated list of hostnames that serve the Colonel admin surfaces
+  (``/colonel`` and ``/api/colonel``). A request whose validated detected host
+  is not on the list receives the same 404 the existing CIDR allowlist returns:
+  indistinguishable from an absent route, never a 403. Host and network are
+  independent factors and a request must pass every gate that is active;
+  neither replaces the other, and both sit on top of the two app-layer auth
+  layers, which still enforce beneath them. Entries are matched literally
+  (no ``www.`` synthesis, no patterns) and must be ASCII A-labels, so an
+  internationalized domain has to be given in its ``xn--`` punycode form.
+  (#4062)
+
+Changed
+-------
+
+- **Operators:** the admin host gate is **active without configuration**.
+  Unset or empty, it falls back to the deployment's canonical anchor hosts —
+  ``features.domains.default`` (``DEFAULT_DOMAIN``) and ``site.host``
+  (``HOST``) — plus their ``www.`` siblings. A stock canonical install is
+  unchanged, while tenant custom domains and ``LINK_DOMAINS`` link-pool hosts
+  stop serving the admin console. If you reach ``/colonel`` on any other
+  hostname, set ``ADMIN_ALLOWED_HOSTS`` to that hostname before upgrading or it
+  will 404. Rollback is one variable: ``ADMIN_ALLOWED_HOSTS=*`` as the sole
+  entry disables the host gate (logged at WARN on boot) and leaves the CIDR
+  gate untouched. (#4062)
+
+- **Operators:** an ``ADMIN_ALLOWED_HOSTS`` that names nothing the gate could
+  ever match **fails the boot**, naming each rejected entry and why —
+  ``ADMIN_ALLOWED_HOSTS=127.0.0.1``, ``=localhost``, ``=*.example.com``, or a
+  non-ASCII name with no ``xn--`` form. Every one of those is an operator
+  writing an allowlist in order to restrict the admin surfaces, and the
+  alternative — disabling the gate — would serve ``/colonel`` on every hostname
+  the app answers on, the opposite of what was asked. Partial failures still
+  boot: as long as one entry is enforceable the rest are dropped with a WARN.
+  ``ADMIN_ALLOWED_HOSTS=*`` remains the way to ask for the gate to be off.
+  (#4062)
+
+- **Operators:** installs with no routable hostname are exempted rather than
+  locked out. When ``ADMIN_ALLOWED_HOSTS`` is unset and neither canonical
+  anchor is a hostname the app could ever detect — the shipped
+  ``HOST=localhost:3000``, or an install reached by bare IP — the host gate
+  self-disables and says so at WARN on boot. This exemption applies to the
+  fallback only; a list the operator set is never silently disabled (above).
+  (#4062)
+
+- **Operators:** boot logs one INFO line, ``Admin surface isolation posture``,
+  naming the effective hosts and CIDRs, whether each gate is active, and the
+  ``site.network.trusted_proxy`` state (``disabled``, ``enabled
+  (mode=filter)``, ``enabled (mode=depth)``). The trusted-proxy field is on
+  that line because it qualifies the two beside it: with trusted proxy disabled
+  — the shipped default — the detected host the gate judges may be chosen by
+  any peer on a private or loopback address, and the client IP behind the CIDR
+  gate comes from ``REMOTE_ADDR``. ``host_gate: active`` read next to
+  ``trusted_proxy: disabled`` is the combination to look for. (#4062)
+
+- **Operators:** ``AdminNetworkIsolation`` now mounts after ``Rack::DetectHost``
+  — where the host it judges is produced — instead of ahead of it. One visible
+  consequence: a request to ``/colonel`` while the app is still booting returns
+  503 (startup readiness) rather than 404. (#4062)
+
+AI Assistance
+-------------
+
+- Claude added the ``site.admin.allowed_hosts`` config key and its
+  ``.env.reference`` entry, the shared ``Onetime::Utils::AdminHostAllowlist``
+  classifier behind both the boot validation and the gate, the host gate and
+  mount-order move in ``Onetime::Middleware::AdminNetworkIsolation``, and the
+  two-factor rewrite of ``docs/operations/admin-network-isolation.md``. (#4062)

--- a/docs/operations/admin-network-isolation.md
+++ b/docs/operations/admin-network-isolation.md
@@ -1,8 +1,47 @@
-# Admin network isolation (`site.admin.allowed_cidrs`)
+# Admin surface isolation (`site.admin.allowed_hosts` + `allowed_cidrs`)
 
-Operator guide for restricting the Colonel admin surfaces to a trusted network
-as **defense-in-depth**, on top of the application's own authentication and
-authorization.
+Operator guide for restricting the Colonel admin surfaces to a trusted
+**hostname** and a trusted **network**, as **defense-in-depth** on top of the
+application's own authentication and authorization.
+
+The two factors are independent and neither replaces the other:
+
+| Factor | Config / env | Default |
+|---|---|---|
+| Host | `site.admin.allowed_hosts` / `ADMIN_ALLOWED_HOSTS` | **active** — canonical anchor hosts (+ `www.`) |
+| Network | `site.admin.allowed_cidrs` / `ADMIN_ALLOWED_CIDRS` | inactive (opt-in) |
+
+A request must pass every gate that is **active**. Failing either produces the
+same 404. When both are inactive the middleware is a strict no-op.
+
+## Upgrading
+
+The host gate is new in #4062 and is **active without configuration**. Before
+upgrading, confirm the hostname you use to reach `/colonel`:
+
+- `features.domains.default` (`DEFAULT_DOMAIN`) or `site.host` (`HOST`), or a
+  `www.` sibling of either → no change.
+- Anything else — a tenant custom domain, a `LINK_DOMAINS` entry, an internal
+  hostname → `/colonel` and `/api/colonel` return **404** on that hostname after
+  the upgrade. Set `ADMIN_ALLOWED_HOSTS` to the hostname admin should be served
+  on.
+- No routable hostname at all (stock `HOST=localhost:3000`, or an install
+  reached by bare IP) → no change; the gate self-disables. See [When the host
+  gate goes inert](#when-the-host-gate-goes-inert).
+
+If you do set `ADMIN_ALLOWED_HOSTS`, set it to something the gate can match: an
+explicit list with no usable entry in it (an IP address, a `*.` pattern, a
+non-ASCII name) **fails the boot** rather than quietly serving admin everywhere.
+See [When boot refuses to start](#when-boot-refuses-to-start).
+
+**Rollback is one variable:** `ADMIN_ALLOWED_HOSTS=*` restores the pre-#4062
+behavior — the host gate off, logged at WARN on boot. The CIDR gate is
+unaffected by it. It is also the only value that turns the gate off on purpose;
+nothing else does.
+
+The middleware also moved below `Rack::DetectHost` (which is below
+`StartupReadiness`), so a request to `/colonel` *while the app is still booting*
+now returns 503 rather than 404.
 
 ## What it does
 
@@ -18,28 +57,134 @@ Both are already protected by **two app-layer auth layers** that always enforce:
 2. `verify_one_of_roles!(colonel: true)` (plus `cust.verified?`) in each logic
    class.
 
-`site.admin.allowed_cidrs` adds an **optional network layer in front** of those.
-When configured, a request whose trusted-proxy-resolved client IP falls
-**outside** the allowlist receives a **404** — not a 403 — on both surfaces, so
-the admin console is *indistinguishable from absent* to an unauthorized network
-and does not advertise its existence. It is enforced by the
-`AdminNetworkIsolation` Rack middleware
-(`lib/onetime/middleware/admin_network_isolation.rb`), a sibling of the existing
-`IPBan` and `HealthAccessControl` middleware.
+`site.admin.allowed_hosts` and `site.admin.allowed_cidrs` add a **host layer**
+and a **network layer** in front of those. A request that fails either receives
+a **404** — not a 403 — on both surfaces, so the admin console is
+*indistinguishable from absent* to an unauthorized host or network and does not
+advertise its existence. Both are enforced by the `AdminNetworkIsolation` Rack
+middleware (`lib/onetime/middleware/admin_network_isolation.rb`), a sibling of
+the existing `IPBan` and `HealthAccessControl` middleware.
 
 Isolation is a **config posture, not a code fork**: the exact same app-layer
-enforcement runs in both postures. Flipping the allowlist on or off never
+enforcement runs in every posture. Flipping either allowlist on or off never
 changes the auth behavior beneath it.
 
-## Default: no-op (self-hosted single-container)
+## Host allowlist (`site.admin.allowed_hosts`)
 
-When `site.admin.allowed_cidrs` is **unset or empty**, the middleware is a strict
-**no-op** — both surfaces stay reachable and the two auth layers are the sole
-gate. This is the intended default for self-hosted single-container installs,
-which cannot require a VPN. **No new configuration is required** for an existing
-install to keep working.
+Without a host gate the admin surfaces answer on **every hostname the app
+serves**, including tenant custom domains and operator link-pool domains
+(`features.domains.link_domains`). Session cookies are host-only and
+custom-domain sign-in is off by default, so this is not by itself a takeover
+path — but on a custom domain with sign-in enabled, a colonel who signs in there
+gets the full admin console on a hostname the tenant controls in DNS. The gate
+removes the surface rather than relying on those defaults holding.
 
-## Cloud enablement (private CIDRs)
+**Unset or empty (the default) is active, not off.** The allowlist falls back to
+the deployment's canonical *anchor* hosts — `features.domains.default` and
+`site.host` — plus their `www.` siblings (an anchor configured as
+`www.example.com` also admits `example.com`). A stock canonical deployment sees
+no behavior change; custom domains and link-pool domains stop serving admin.
+
+```bash
+# Serve admin on its own hostname (recommended)
+ADMIN_ALLOWED_HOSTS=admin.example.com
+```
+
+Details that matter:
+
+- The host is taken from the **validated detected host** (`Rack::DetectHost`),
+  which only honors a forwarded host header when the peer is trusted — see
+  [Behind a reverse proxy or load balancer](#behind-a-reverse-proxy-or-load-balancer--required-for-both-gates).
+  It is never read from a raw `Host` header or from the `O-Domain-Context`
+  development header.
+- **Explicit entries match literally** — list the `www.` form too if you need
+  it. The `www.` tolerance applies only to the canonical fallback.
+- Matching is case-insensitive, port-stripped and trailing-dot-stripped. ASCII
+  A-labels only: give an internationalized domain in its `xn--` punycode form. A
+  non-ASCII entry can never match, so it is dropped and named in a boot WARN —
+  and if it was the *only* entry, the boot fails.
+- **Patterns are not supported.** `*.example.com` matches nothing: it is dropped
+  and named in a boot WARN, and a list of nothing but patterns fails the boot.
+  List each hostname explicitly.
+- **A nil or unresolvable detected host is a 404** while the gate is active.
+- `ADMIN_ALLOWED_HOSTS=*` (as the sole entry) disables the host gate, logged at
+  WARN on boot. The CIDR gate is unaffected. A list that mixes `*` with named
+  hosts is ambiguous: the `*` is dropped (with a WARN) and the named hosts are
+  enforced.
+- Both allowlists are resolved **once, at boot**. A config or env change needs a
+  restart.
+
+### When the host gate goes inert
+
+`Rack::DetectHost` never emits `localhost`, `localhost.localdomain`, an IP
+literal, or anything else it does not consider a routable hostname — so on stock
+local-dev (`HOST=localhost:3000`) and on bare-IP self-hosted installs there is
+no detected host at all.
+
+This applies to the **fallback only**. When `ADMIN_ALLOWED_HOSTS` is unset and
+neither anchor (`DEFAULT_DOMAIN`, `HOST`) is a hostname the app could ever
+detect, the host gate **self-disables** and logs at boot:
+
+```
+Admin host allowlist INACTIVE: no routable hostname configured
+  source: "canonical anchors"
+```
+
+That keeps single-container installs working out of the box instead of locking
+their operators out of `/colonel`. Set a routable hostname (via
+`ADMIN_ALLOWED_HOSTS`, `HOST`, or `DEFAULT_DOMAIN`) to turn the gate on.
+
+Nothing an operator writes into `ADMIN_ALLOWED_HOSTS` reaches this rule. A list
+that was set but cannot be enforced does not go inert — it fails the boot.
+
+### When boot refuses to start
+
+If `ADMIN_ALLOWED_HOSTS` is **set and non-empty** but no entry survives — every
+entry is an IP address, a `*.` pattern, a non-ASCII name, or not a hostname at
+all — the app raises a config error at boot naming each entry and why:
+
+```
+ADMIN_ALLOWED_HOSTS (site.admin.allowed_hosts) names no hostname the admin host
+gate could ever match, so /colonel and /api/colonel would be served on every
+hostname: "127.0.0.1": not a routable hostname — localhost forms and IP literals
+are never detected as a host. Set it to a routable hostname the deployment
+answers on (ADMIN_ALLOWED_HOSTS=admin.example.com), unset it entirely to allow
+the canonical host only, or set it to * to disable the host gate deliberately.
+```
+
+Refusing to boot is deliberate. Every one of these values is an operator writing
+an allowlist in order to **restrict** the admin surfaces; disabling the gate on
+a typo would do the opposite of what was asked and serve `/colonel` on every
+hostname the app answers on. The three ways out are the three in the message:
+name a routable hostname, unset it (canonical hosts only), or ask for the gate
+to be off with `ADMIN_ALLOWED_HOSTS=*`.
+
+Common triggers:
+
+| Value | Result |
+|---|---|
+| `ADMIN_ALLOWED_HOSTS=127.0.0.1` / `localhost` | boot error — never detected as a host |
+| `ADMIN_ALLOWED_HOSTS=*.example.com` | boot error — patterns are not supported |
+| `ADMIN_ALLOWED_HOSTS=ünïcode.example` | boot error — supply the `xn--` form |
+| `ADMIN_ALLOWED_HOSTS=*.example.com,admin.example.com` | boots; the pattern is dropped with a WARN, `admin.example.com` is enforced |
+| `ADMIN_ALLOWED_HOSTS=*` | boots; host gate off, WARN |
+| unset / empty | boots; canonical anchors, or inert (above) |
+
+Partial failures are not fatal: as long as **one** entry is enforceable, the
+rest are dropped with a WARN (`Ignoring unusable entries in
+site.admin.allowed_hosts`) and the survivors are enforced.
+
+## Network allowlist (`site.admin.allowed_cidrs`)
+
+### Default: no-op (self-hosted single-container)
+
+When `site.admin.allowed_cidrs` is **unset or empty**, the network gate is a
+strict **no-op** — the surfaces stay reachable from any IP and the auth layers
+(plus the host gate above) are the remaining gates. This is the intended default
+for self-hosted single-container installs, which cannot require a VPN. No new
+configuration is required to keep this factor as it was.
+
+### Cloud enablement (private CIDRs)
 
 On a cloud deployment where operators reach the admin console over a VPN or
 private network (e.g. Tailscale, WireGuard, an office range), set the allowlist
@@ -63,49 +208,84 @@ ADMIN_ALLOWED_CIDRS=100.64.0.0/10,10.0.0.0/8
 Now a request to `/colonel` or `/api/colonel` from any IP outside those ranges
 gets a 404; a request from inside passes through to the normal auth layers.
 
-### Behind a reverse proxy or load balancer — required
+Use **private ranges only**. Do not put a public CIDR in `allowed_cidrs`;
+network isolation is meant to limit the surface to a private/VPN network, and
+the app-layer auth layers remain the gate for anyone who is on that network.
 
-The allowlist is checked against the **trusted-proxy-resolved** client IP, the
-same value the rest of the stack uses (ban checks, sessions, audit attribution).
-It is resolved from `env['otto.client_ip']`, set once by the universal IP-privacy
-middleware from `site.network.trusted_proxy`. A **raw `X-Forwarded-For` header
-cannot bypass the allowlist** — that is the point.
+## Behind a reverse proxy or load balancer — required for both gates
+
+Each gate reads an input a proxy can rewrite, and each resolves that input the
+same way the rest of the stack does:
+
+- The **network** gate matches the **trusted-proxy-resolved** client IP — the
+  same value used for ban checks, sessions and audit attribution, read from
+  `env['otto.client_ip']`, which the universal IP-privacy middleware sets from
+  `site.network.trusted_proxy`. A **raw `X-Forwarded-For` header cannot bypass
+  the allowlist** — that is the point.
+- The **host** gate matches the host `Rack::DetectHost` validated. Forwarded
+  host headers (`X-Forwarded-Host`, `Apx-Incoming-Host`, `X-Original-Host`,
+  `Forwarded`) are honored only for requests that arrived through trusted
+  infrastructure.
 
 Consequently, if the app runs behind a reverse proxy, ingress, or load balancer,
-you **must** also configure `site.network.trusted_proxy` (see
-`.env.reference`, `TRUSTED_PROXY_*`). Otherwise every request resolves to the
-proxy's own hop IP, and either all requests are allowed (if that hop is inside
-the allowlist) or all are denied. Example:
+you **must** also configure `site.network.trusted_proxy` (see `.env.reference`,
+`TRUSTED_PROXY_*`). Otherwise every request resolves to the proxy's own hop IP,
+and either all requests are allowed (if that hop is inside the allowlist) or all
+are denied. Example:
 
 ```yaml
 site:
   network:
     trusted_proxy:
       enabled: true
-      mode: filter          # or depth, per your topology
+      mode: filter          # depth mode is broken, see #4024
   admin:
     allowed_cidrs:
       - 100.64.0.0/10
 ```
 
-Use **private ranges only**. Do not put a public CIDR in `allowed_cidrs`;
-network isolation is meant to limit the surface to a private/VPN network, and
-the app-layer auth layers remain the gate for anyone who is on that network.
+**With `trusted_proxy` disabled (the default), host detection falls back to a
+legacy heuristic**: any peer connecting from a private or loopback address is
+trusted to set a forwarded host header. That keeps single-container installs
+behind a local proxy working, but it also means anything able to open a
+connection from a private address — another container on the same network, an
+SSRF egress — can choose the host the gate sees. The client IP behind the CIDR
+gate has the same dependency: with no trusted proxy declared it is resolved from
+`REMOTE_ADDR`. Configure `trusted_proxy` on any deployment where a private-
+address peer is reachable.
 
-## Self-hosted alternative: reverse proxy (Caddy)
+Because that state qualifies both gates, it is reported on the same boot line
+they are — `trusted_proxy: disabled` sitting next to `host_gate: active` is the
+combination to look for. See [Verifying](#verifying).
 
-Self-hosted operators who want network isolation without turning on the app-level
-allowlist can instead **not expose the admin paths at the edge at all** and front
-them with a reverse proxy. This keeps the single-container default (`allowed_cidrs`
-empty, middleware no-op) while achieving the same network posture at the proxy.
+## Edge alternative: return 404 at the proxy (Caddy / nginx)
 
-Example Caddyfile that returns 404 for `/colonel*` and `/api/colonel*` unless the
-client is in a private range:
+An edge rule depends on no input the app has to trust, so it holds even if the
+app is misconfigured. Serve admin on its own hostname and 404 the admin paths on
+every other vhost:
+
+```caddy
+# Admin answers only on its own hostname.
+admin.example.com {
+    reverse_proxy localhost:3000
+}
+
+# Every other vhost 404s the admin paths, whatever the app is configured to do.
+example.com {
+    @admin path /colonel* /api/colonel*
+    respond @admin 404
+
+    reverse_proxy localhost:3000
+}
+```
+
+Self-hosted operators who want network isolation without turning on the
+app-level CIDR allowlist can front the admin paths the same way, keeping the
+single-container default (`allowed_cidrs` empty, network gate inactive) while
+achieving the same posture at the proxy:
 
 ```caddy
 example.com {
-    @admin path /colonel* /api/colonel*
-
     @admin_untrusted {
         path /colonel* /api/colonel*
         not remote_ip 100.64.0.0/10 10.0.0.0/8 192.168.0.0/16
@@ -128,18 +308,93 @@ Notes:
   `return 404;` for untrusted addresses, using `set_real_ip_from` /
   `real_ip_header` if fronted by another proxy.
 
-Either posture — app-level `allowed_cidrs` or an edge reverse-proxy rule — leaves
-the two app-layer auth layers fully in force underneath.
+Every posture — app-level allowlists, an edge rule, or both — leaves the two
+app-layer auth layers fully in force underneath.
+
+## Recommended posture
+
+- **Serve admin on its own hostname** (`admin.example.com`) and have the edge
+  return 404 for `/colonel` and `/api/colonel` on every *other* vhost. Set
+  `ADMIN_ALLOWED_HOSTS` to that hostname so the app enforces the same thing.
+- Do not terminate the admin hostname on a wildcard vhost that also serves
+  tenant custom domains.
+- **Keep `ADMIN_ALLOWED_CIDRS`** (VPN/Tailscale/office ranges). Host and network
+  are independent factors; neither replaces the other.
+- `site.network.trusted_proxy` must be configured correctly or **both** gates
+  read attacker-influenceable inputs. Depth mode is currently broken (#4024) —
+  prefer CIDR matchers until that lands.
 
 ## Verifying
 
+- On a host **not** on the allowlist (e.g. a tenant custom domain): `GET
+  /colonel` and `GET /api/colonel` both return `404`, for an authenticated
+  colonel and an anonymous request alike.
+- On an allowlisted host: the request reaches the auth layers, exactly as
+  before.
 - From an IP **outside** the allowlist: `GET /colonel` and `GET /api/colonel`
   both return `404`.
 - From an IP **inside** the allowlist: the request reaches the auth layers
   (e.g. `401/403` without a colonel session, `200` with one) — i.e. the
   middleware passes through.
-- With `allowed_cidrs` empty: both surfaces are reachable regardless of origin
-  (no-op).
+- With `allowed_cidrs` empty: the network factor imposes nothing; reachability
+  is decided by the host gate and the auth layers.
+- With `ADMIN_ALLOWED_HOSTS` set to something unenforceable (`127.0.0.1`,
+  `*.example.com`): the process **does not start** — it exits with a config
+  error naming the entries. Nothing is served, including the admin surfaces.
 - A spoofed `X-Forwarded-For: <allowed-ip>` from an untrusted origin does **not**
-  bypass the allowlist (resolution ignores raw headers unless a matching trusted
-  proxy is configured).
+  bypass the CIDR allowlist, and a spoofed `X-Forwarded-Host` /
+  `Apx-Incoming-Host` does **not** bypass the host allowlist — neither header is
+  honored unless the peer is trusted (see the heuristic caveat above for
+  private-address peers with `trusted_proxy` off).
+
+### The boot log
+
+One INFO line per process states the effective posture of both factors:
+
+```
+Admin surface isolation posture --
+  {host_gate: "active", allowed_hosts: ["admin.example.com"],
+   network_gate: "active", allowed_cidrs: ["100.64.0.0/10"],
+   trusted_proxy: "enabled (mode=filter)",
+   surfaces: ["/colonel", "/api/colonel"]}
+```
+
+Read it as three facts, not one:
+
+- `host_gate` / `network_gate` — `active` or `inactive`. An `inactive` gate is
+  distinguishable from a misconfigured one here without diffing config against
+  source.
+- `allowed_hosts` / `allowed_cidrs` — what is **effectively** enforced, after
+  dropped entries. Shorter than what you configured means something was
+  rejected; the WARN above it names it.
+- `trusted_proxy` — `disabled`, `enabled (mode=filter)`, or
+  `enabled (mode=depth)`, read from the same `site.network.trusted_proxy` state
+  that configures the IP-privacy mount.
+
+`host_gate: active` means the gate is comparing hosts. It does not mean the host
+it compares is trustworthy: with `trusted_proxy: disabled` the detected host may
+have been chosen by any peer on a private address, and the client IP behind
+`network_gate` comes from `REMOTE_ADDR`. Both gates are only as good as that
+line's third fact.
+
+Also emitted at boot, each at WARN, and each only in its own case:
+
+| Message | Means |
+|---|---|
+| ``Admin host allowlist DISABLED by `*` `` | `ADMIN_ALLOWED_HOSTS=*` — host gate off |
+| ``Dropped `*` from site.admin.allowed_hosts: it is only honored as the sole entry`` | `*` was mixed with named hosts |
+| `Ignoring unusable entries in site.admin.allowed_hosts` | some entries dropped; each named with its reason |
+| `Admin host allowlist INACTIVE: no routable hostname configured` | the unset/fallback case only — see [inert](#when-the-host-gate-goes-inert) |
+| `Invalid CIDR in site.admin.allowed_cidrs, skipping: …` | an unparseable CIDR entry |
+
+There is no boot WARN for an unenforceable `ADMIN_ALLOWED_HOSTS`; that is a
+[boot error](#when-boot-refuses-to-start) — the process stops before the
+middleware is built. One exception exists for embedders that build the Rack app
+without running config validation: the middleware then logs `Admin host
+allowlist has no enforceable entry; denying both admin surfaces` and 404s both
+surfaces. If you see that line, config validation did not run.
+
+Per-request denials log at WARN with the host or IP that was refused: `Admin
+surface access denied by host allowlist` and `Admin surface access denied by
+network isolation`. Two distinct messages for two distinct factors — the client
+cannot tell the denials apart, but the operator can.

--- a/docs/operations/admin-network-isolation.md
+++ b/docs/operations/admin-network-isolation.md
@@ -237,6 +237,20 @@ Use **private ranges only**. Do not put a public CIDR in `allowed_cidrs`;
 network isolation is meant to limit the surface to a private/VPN network, and
 the app-layer auth layers remain the gate for anyone who is on that network.
 
+### CIDR entries finer than `/24` never match
+
+The gate compares against `env['otto.client_ip']`, and that value is
+**privacy-masked before any middleware sees it** — IP masking is on for every
+deployment, including direct-connect ones. IPv4 clients arrive with the last
+octet zeroed (an effective `/24`), IPv6 clients at an effective `/48`.
+
+So a single-host entry — `10.0.0.5/32` for your VPN host, a Tailscale node's
+`/128` — is accepted at boot, reported as `active`, and then **matches nothing**:
+you get the same silent 404 as an outside address. The inverse also holds, an
+entry whose host bits are already zero (`10.0.0.0/32`) matches every client in
+`10.0.0.0/24`. Keep entries at `/24` or coarser for IPv4 and `/48` or coarser
+for IPv6 — the ranges in the example above already are. Tracked as #3912.
+
 ## Behind a reverse proxy or load balancer — required for both gates
 
 Each gate reads an input a proxy can rewrite, and each resolves that input the
@@ -246,7 +260,10 @@ same way the rest of the stack does:
   same value used for ban checks, sessions and audit attribution, read from
   `env['otto.client_ip']`, which the universal IP-privacy middleware sets from
   `site.network.trusted_proxy`. A **raw `X-Forwarded-For` header cannot bypass
-  the allowlist** — that is the point.
+  the allowlist** — that is the point. **That value is also privacy-masked**:
+  IPv4 arrives zeroed to its `/24` and IPv6 to its `/48`, so an entry finer than
+  that never matches — see [CIDR entries finer than `/24` never
+  match](#cidr-entries-finer-than-24-never-match).
 - The **host** gate matches the host `Rack::DetectHost` validated, and applies
   one extra check of its own: a forwarded host header (`X-Forwarded-Host`,
   `Apx-Incoming-Host`, `X-Original-Host`, `Forwarded`) is accepted **only** when

--- a/docs/operations/admin-network-isolation.md
+++ b/docs/operations/admin-network-isolation.md
@@ -498,8 +498,18 @@ Also emitted at boot, each only in its own case:
 [above](#when-the-allowlist-cannot-be-enforced)), so the reason arrives with the
 startup log rather than only on the first admin request.
 
-Per-request denials log at WARN with the host or IP that was refused: `Admin
-surface access denied by host allowlist`, `Admin surface access denied:
-forwarded host from an untrusted peer`, and `Admin surface access denied by
-network isolation`. Three distinct messages for three distinct refusals — the
-client cannot tell the denials apart, but the operator can.
+Per-request denials log at WARN with the host or IP that was refused. Four
+distinct messages for four distinct refusals — the client cannot tell the
+denials apart, but the operator can:
+
+| Message | Means |
+|---|---|
+| `Admin surface access denied by host allowlist` | a host was detected and is not on the list |
+| `Admin surface access denied: no host could be detected for this request` | `Rack::DetectHost` emitted nothing — a bare-IP or `localhost` `Host:` header, or a malformed name. The allowlist was never consulted, so no entry in it could have helped |
+| `Admin surface access denied: forwarded host from an untrusted peer` | see [Forwarded hosts and the admin gate](#forwarded-hosts-and-the-admin-gate) |
+| `Admin surface access denied by network isolation` | the client IP is outside `allowed_cidrs` |
+
+The second one is the line to look for if you set `ADMIN_ALLOWED_HOSTS` to an IP
+address: no hostname you write into the allowlist can match a request that has
+no detected host. Reach admin on a routable hostname, or set
+`ADMIN_ALLOWED_HOSTS=*` to turn the host gate off.

--- a/docs/operations/admin-network-isolation.md
+++ b/docs/operations/admin-network-isolation.md
@@ -31,8 +31,16 @@ upgrading, confirm the hostname you use to reach `/colonel`:
 
 If you do set `ADMIN_ALLOWED_HOSTS`, set it to something the gate can match: an
 explicit list with no usable entry in it (an IP address, a `*.` pattern, a
-non-ASCII name) **fails the boot** rather than quietly serving admin everywhere.
-See [When boot refuses to start](#when-boot-refuses-to-start).
+non-ASCII name) **404s both admin surfaces** rather than quietly serving admin
+everywhere, and says so at boot. See [When the allowlist cannot be
+enforced](#when-the-allowlist-cannot-be-enforced).
+
+If the app runs behind a reverse proxy that forwards the public hostname in a
+header (`X-Forwarded-Host`, `Apx-Incoming-Host`, `X-Original-Host`,
+`Forwarded`) rather than rewriting `Host`, you **must** configure
+`site.network.trusted_proxy` — otherwise the admin gate refuses the forwarded
+host and both surfaces 404. See [Behind a reverse proxy or load
+balancer](#behind-a-reverse-proxy-or-load-balancer--required-for-both-gates).
 
 **Rollback is one variable:** `ADMIN_ALLOWED_HOSTS=*` restores the pre-#4062
 behavior — the host gate off, logged at WARN on boot. The CIDR gate is
@@ -102,15 +110,21 @@ Details that matter:
 - Matching is case-insensitive, port-stripped and trailing-dot-stripped. ASCII
   A-labels only: give an internationalized domain in its `xn--` punycode form. A
   non-ASCII entry can never match, so it is dropped and named in a boot WARN —
-  and if it was the *only* entry, the boot fails.
+  and if it was the *only* entry, both admin surfaces 404.
 - **Patterns are not supported.** `*.example.com` matches nothing: it is dropped
-  and named in a boot WARN, and a list of nothing but patterns fails the boot.
-  List each hostname explicitly.
+  and named in a boot WARN, and a list of nothing but patterns 404s both admin
+  surfaces. List each hostname explicitly.
 - **A nil or unresolvable detected host is a 404** while the gate is active.
-- `ADMIN_ALLOWED_HOSTS=*` (as the sole entry) disables the host gate, logged at
-  WARN on boot. The CIDR gate is unaffected. A list that mixes `*` with named
-  hosts is ambiguous: the `*` is dropped (with a WARN) and the named hosts are
-  enforced.
+- **A forwarded host from an untrusted peer is a 404** while the gate is active
+  — see [Behind a reverse proxy or load
+  balancer](#behind-a-reverse-proxy-or-load-balancer--required-for-both-gates).
+- `ADMIN_ALLOWED_HOSTS=*` disables the host gate, logged at WARN on boot. The
+  CIDR gate is unaffected. **A `*` anywhere in the list turns the gate off** —
+  a `*` beside named hosts does not enforce those hosts, it ignores them (and
+  names them in a second WARN). Remove the `*` to enforce them.
+- **A percent-encoded spelling of an admin path is still an admin path.**
+  `/%63olonel` and `/colonel%2Fsettings` are gated exactly like `/colonel`,
+  because that is what the router serves them as.
 - Both allowlists are resolved **once, at boot**. A config or env change needs a
   restart.
 
@@ -135,42 +149,53 @@ their operators out of `/colonel`. Set a routable hostname (via
 `ADMIN_ALLOWED_HOSTS`, `HOST`, or `DEFAULT_DOMAIN`) to turn the gate on.
 
 Nothing an operator writes into `ADMIN_ALLOWED_HOSTS` reaches this rule. A list
-that was set but cannot be enforced does not go inert — it fails the boot.
+that was set but cannot be enforced does not go inert — it denies.
 
-### When boot refuses to start
+### When the allowlist cannot be enforced
 
 If `ADMIN_ALLOWED_HOSTS` is **set and non-empty** but no entry survives — every
 entry is an IP address, a `*.` pattern, a non-ASCII name, or not a hostname at
-all — the app raises a config error at boot naming each entry and why:
+all — the host gate stays **active with an empty allowlist**: `/colonel` and
+`/api/colonel` return 404 to every request, on every hostname. The rest of the
+app is untouched. Boot logs a WARN naming each entry and why:
 
 ```
 ADMIN_ALLOWED_HOSTS (site.admin.allowed_hosts) names no hostname the admin host
-gate could ever match, so /colonel and /api/colonel would be served on every
-hostname: "127.0.0.1": not a routable hostname — localhost forms and IP literals
-are never detected as a host. Set it to a routable hostname the deployment
-answers on (ADMIN_ALLOWED_HOSTS=admin.example.com), unset it entirely to allow
-the canonical host only, or set it to * to disable the host gate deliberately.
+gate could ever match, so /colonel and /api/colonel return 404 to EVERY request:
+"127.0.0.1": not a routable hostname — localhost forms and IP literals are never
+detected as a host. Set it to a routable hostname the deployment answers on
+(ADMIN_ALLOWED_HOSTS=admin.example.com), unset it entirely to allow the canonical
+host only, or set it to * to disable the host gate deliberately.
 ```
 
-Refusing to boot is deliberate. Every one of these values is an operator writing
-an allowlist in order to **restrict** the admin surfaces; disabling the gate on
-a typo would do the opposite of what was asked and serve `/colonel` on every
+Denying is deliberate. Every one of these values is an operator writing an
+allowlist in order to **restrict** the admin surfaces; disabling the gate on a
+typo would do the opposite of what was asked and serve `/colonel` on every
 hostname the app answers on. The three ways out are the three in the message:
 name a routable hostname, unset it (canonical hosts only), or ask for the gate
 to be off with `ADMIN_ALLOWED_HOSTS=*`.
+
+**This does not stop the boot** (it did until #4062 shipped). The admin surfaces
+are already fail-closed for this config, so aborting the process would take the
+public site, the API and the health endpoints down over an admin-console-only
+typo — an `ADMIN_ALLOWED_HOSTS=10.0.0.0/8` mixup with the adjacent
+`ADMIN_ALLOWED_CIDRS` key would be a full outage. Contrast `LINK_DOMAINS`
+(#4063), which *does* fail the boot: it has no fail-closed runtime backstop, so
+there the process has to stop.
 
 Common triggers:
 
 | Value | Result |
 |---|---|
-| `ADMIN_ALLOWED_HOSTS=127.0.0.1` / `localhost` | boot error — never detected as a host |
-| `ADMIN_ALLOWED_HOSTS=*.example.com` | boot error — patterns are not supported |
-| `ADMIN_ALLOWED_HOSTS=ünïcode.example` | boot error — supply the `xn--` form |
+| `ADMIN_ALLOWED_HOSTS=127.0.0.1` / `localhost` | boots with a WARN; both admin surfaces 404 — never detected as a host |
+| `ADMIN_ALLOWED_HOSTS=*.example.com` | boots with a WARN; both admin surfaces 404 — patterns are not supported |
+| `ADMIN_ALLOWED_HOSTS=ünïcode.example` | boots with a WARN; both admin surfaces 404 — supply the `xn--` form |
 | `ADMIN_ALLOWED_HOSTS=*.example.com,admin.example.com` | boots; the pattern is dropped with a WARN, `admin.example.com` is enforced |
 | `ADMIN_ALLOWED_HOSTS=*` | boots; host gate off, WARN |
+| `ADMIN_ALLOWED_HOSTS=*,admin.example.com` | boots; host gate **off** (the `*` wins), both entries named in a WARN |
 | unset / empty | boots; canonical anchors, or inert (above) |
 
-Partial failures are not fatal: as long as **one** entry is enforceable, the
+Partial failures change nothing: as long as **one** entry is enforceable, the
 rest are dropped with a WARN (`Ignoring unusable entries in
 site.admin.allowed_hosts`) and the survivors are enforced.
 
@@ -222,10 +247,13 @@ same way the rest of the stack does:
   `env['otto.client_ip']`, which the universal IP-privacy middleware sets from
   `site.network.trusted_proxy`. A **raw `X-Forwarded-For` header cannot bypass
   the allowlist** — that is the point.
-- The **host** gate matches the host `Rack::DetectHost` validated. Forwarded
-  host headers (`X-Forwarded-Host`, `Apx-Incoming-Host`, `X-Original-Host`,
-  `Forwarded`) are honored only for requests that arrived through trusted
-  infrastructure.
+- The **host** gate matches the host `Rack::DetectHost` validated, and applies
+  one extra check of its own: a forwarded host header (`X-Forwarded-Host`,
+  `Apx-Incoming-Host`, `X-Original-Host`, `Forwarded`) is accepted **only** when
+  `env['otto.via_trusted_proxy']` is true — i.e. `site.network.trusted_proxy` is
+  configured and this peer passed it. Otherwise the forwarded host must agree
+  with the `Host` header, or the request is refused. See [Forwarded hosts and
+  the admin gate](#forwarded-hosts-and-the-admin-gate).
 
 Consequently, if the app runs behind a reverse proxy, ingress, or load balancer,
 you **must** also configure `site.network.trusted_proxy` (see `.env.reference`,
@@ -249,14 +277,59 @@ legacy heuristic**: any peer connecting from a private or loopback address is
 trusted to set a forwarded host header. That keeps single-container installs
 behind a local proxy working, but it also means anything able to open a
 connection from a private address — another container on the same network, an
-SSRF egress — can choose the host the gate sees. The client IP behind the CIDR
-gate has the same dependency: with no trusted proxy declared it is resolved from
-`REMOTE_ADDR`. Configure `trusted_proxy` on any deployment where a private-
+SSRF egress — can choose the host the app sees (#4024). The client IP behind the
+CIDR gate has the same dependency: with no trusted proxy declared it is resolved
+from `REMOTE_ADDR`. Configure `trusted_proxy` on any deployment where a private-
 address peer is reachable.
 
 Because that state qualifies both gates, it is reported on the same boot line
 they are — `trusted_proxy: disabled` sitting next to `host_gate: active` is the
 combination to look for. See [Verifying](#verifying).
+
+### Forwarded hosts and the admin gate
+
+The admin host gate does not rely on that heuristic. It accepts a detected host
+only when one of these holds:
+
+1. `env['otto.via_trusted_proxy']` is **true** — `site.network.trusted_proxy` is
+   configured and this peer passed it; or
+2. the request carries **no** forwarded host header at all; or
+3. it carries one, but the detected host is **the same** as what the `Host`
+   header alone would have produced — the header changed nothing.
+
+Anything else is a 404 on both surfaces, logged as `Admin surface access denied:
+forwarded host from an untrusted peer`.
+
+Without this, on any install with `trusted_proxy` unset, a request to a tenant
+custom domain carrying `X-Forwarded-Host: <your canonical host>` would reach the
+admin console — the heuristic would trust it because the request arrived from
+the proxy's private address.
+
+The gate deliberately does **not** fall back to the `Host` header when it
+refuses a forwarded one. In the topology this defends (Approximated-style
+ingress with `trusted_proxy` unset) `Host` carries the *origin's* hostname —
+typically the canonical one, which is on the allowlist — while the tenant
+domain rides in `Apx-Incoming-Host`. Falling back would admit exactly the
+requests this exists to refuse.
+
+**If both admin surfaces started 404ing after this landed**, and your proxy
+forwards the public hostname in a header rather than rewriting `Host`, that is
+this rule. Two ways out:
+
+```yaml
+# Preferred — it is also what the CIDR gate, ban checks, sessions and audit
+# attribution all need to be correct.
+site:
+  network:
+    trusted_proxy:
+      enabled: true
+      mode: filter
+```
+
+```bash
+# Or turn the host gate off entirely.
+ADMIN_ALLOWED_HOSTS=*
+```
 
 ## Edge alternative: return 404 at the proxy (Caddy / nginx)
 
@@ -339,13 +412,20 @@ app-layer auth layers fully in force underneath.
 - With `allowed_cidrs` empty: the network factor imposes nothing; reachability
   is decided by the host gate and the auth layers.
 - With `ADMIN_ALLOWED_HOSTS` set to something unenforceable (`127.0.0.1`,
-  `*.example.com`): the process **does not start** — it exits with a config
-  error naming the entries. Nothing is served, including the admin surfaces.
+  `*.example.com`): the process starts and logs a WARN; `/colonel` and
+  `/api/colonel` return 404 on every hostname. Everything else is served
+  normally.
+- With `ADMIN_ALLOWED_CIDRS` set to something unparseable (every entry
+  malformed): same shape — the process starts, logs an error, and both admin
+  surfaces 404 from every IP. An **empty** `ADMIN_ALLOWED_CIDRS` still means "no
+  network gate"; that distinction is the point.
 - A spoofed `X-Forwarded-For: <allowed-ip>` from an untrusted origin does **not**
   bypass the CIDR allowlist, and a spoofed `X-Forwarded-Host` /
-  `Apx-Incoming-Host` does **not** bypass the host allowlist — neither header is
-  honored unless the peer is trusted (see the heuristic caveat above for
-  private-address peers with `trusted_proxy` off).
+  `Apx-Incoming-Host` does **not** bypass the host allowlist — for the host gate
+  a forwarded header counts only from a peer `site.network.trusted_proxy`
+  vouched for, never from the private-address heuristic.
+- A percent-encoded admin path (`/%63olonel`, `/colonel%2Fsettings`) returns the
+  same 404 as `/colonel` on a denied host or from a denied IP.
 
 ### The boot log
 
@@ -377,24 +457,32 @@ have been chosen by any peer on a private address, and the client IP behind
 `network_gate` comes from `REMOTE_ADDR`. Both gates are only as good as that
 line's third fact.
 
-Also emitted at boot, each at WARN, and each only in its own case:
+That line is emitted **once per process**, not once per mounted app. The
+middleware is constructed for each of the app's mounts, all from the same
+config; every message below is deduplicated the same way, so a repeated line
+means a genuinely different posture, not a second mount.
 
-| Message | Means |
-|---|---|
-| ``Admin host allowlist DISABLED by `*` `` | `ADMIN_ALLOWED_HOSTS=*` — host gate off |
-| ``Dropped `*` from site.admin.allowed_hosts: it is only honored as the sole entry`` | `*` was mixed with named hosts |
-| `Ignoring unusable entries in site.admin.allowed_hosts` | some entries dropped; each named with its reason |
-| `Admin host allowlist INACTIVE: no routable hostname configured` | the unset/fallback case only — see [inert](#when-the-host-gate-goes-inert) |
-| `Invalid CIDR in site.admin.allowed_cidrs, skipping: …` | an unparseable CIDR entry |
+Also emitted at boot, each only in its own case:
 
-There is no boot WARN for an unenforceable `ADMIN_ALLOWED_HOSTS`; that is a
-[boot error](#when-boot-refuses-to-start) — the process stops before the
-middleware is built. One exception exists for embedders that build the Rack app
-without running config validation: the middleware then logs `Admin host
-allowlist has no enforceable entry; denying both admin surfaces` and 404s both
-surfaces. If you see that line, config validation did not run.
+| Message | Level | Means |
+|---|---|---|
+| ``Admin host allowlist DISABLED by `*` `` | WARN | `ADMIN_ALLOWED_HOSTS` contains `*` — host gate off |
+| ``Ignoring every other entry in site.admin.allowed_hosts: `*` disables the host gate`` | WARN | `*` was listed beside other entries; those entries do nothing |
+| `Ignoring unusable entries in site.admin.allowed_hosts` | WARN | some entries dropped; each named with its reason |
+| `Admin host allowlist INACTIVE: no routable hostname configured` | WARN | the unset/fallback case only — see [inert](#when-the-host-gate-goes-inert) |
+| `Admin host allowlist has no enforceable entry; denying both admin surfaces` | WARN | an explicit list where nothing survived — see [above](#when-the-allowlist-cannot-be-enforced) |
+| `Invalid CIDR in site.admin.allowed_cidrs, skipping: …` | WARN | an unparseable CIDR entry, with others still usable |
+| `Admin CIDR allowlist has no usable range; denying both admin surfaces` | ERROR | a configured `ADMIN_ALLOWED_CIDRS` where **no** entry parsed |
+| `Cannot read site.admin.allowed_hosts; denying both admin surfaces` | ERROR | the config could not be read at all (not the same as unset) |
+| `Cannot read site.admin.allowed_cidrs; denying both admin surfaces` | ERROR | ditto, for the CIDR list |
+
+`Onetime::Config` emits the operator-facing diagnostic for an unenforceable
+`ADMIN_ALLOWED_HOSTS` at boot too (the message quoted
+[above](#when-the-allowlist-cannot-be-enforced)), so the reason arrives with the
+startup log rather than only on the first admin request.
 
 Per-request denials log at WARN with the host or IP that was refused: `Admin
-surface access denied by host allowlist` and `Admin surface access denied by
-network isolation`. Two distinct messages for two distinct factors — the client
-cannot tell the denials apart, but the operator can.
+surface access denied by host allowlist`, `Admin surface access denied:
+forwarded host from an untrusted peer`, and `Admin surface access denied by
+network isolation`. Three distinct messages for three distinct refusals — the
+client cannot tell the denials apart, but the operator can.

--- a/docs/operations/colonel-admin-guide.md
+++ b/docs/operations/colonel-admin-guide.md
@@ -98,9 +98,16 @@ a dedicated hostname (`admin.example.com`) if you have one. On an install where
 it is **unset** and there is no routable hostname to anchor on — the stock
 `HOST=localhost:3000`, or access by bare IP — the gate self-disables with a boot
 warning, so single-container installs are unaffected. A value that is set but
-can never match (an IP address, `*.example.com`, a non-ASCII name) **fails the
-boot** instead, naming what it rejected. `ADMIN_ALLOWED_HOSTS=*` is the one way
-to turn the gate off, and the one-variable rollback.
+can never match (an IP address, `*.example.com`, a non-ASCII name) **404s both
+admin surfaces** instead, with a boot warning naming what it rejected; the boot
+itself is not aborted, since the surfaces are already fail-closed and the rest
+of the app is unaffected. `ADMIN_ALLOWED_HOSTS=*` — anywhere in the list — is
+the one way to turn the gate off, and the one-variable rollback.
+
+Behind a proxy that forwards the public hostname in a header (`X-Forwarded-Host`,
+`Apx-Incoming-Host`, …) rather than rewriting `Host`, `site.network.trusted_proxy`
+must be configured: the host gate accepts a forwarded host only from a peer that
+trust vouched for, so otherwise both surfaces 404.
 
 **Network — `site.admin.allowed_cidrs` / `ADMIN_ALLOWED_CIDRS`, opt-in.** Which
 client IPs may reach the surfaces. Unset (the default) it is a no-op, the right

--- a/docs/operations/colonel-admin-guide.md
+++ b/docs/operations/colonel-admin-guide.md
@@ -8,7 +8,8 @@ It covers:
 
 1. [Promoting a colonel](#1-promoting-a-colonel-cli-only) (CLI only).
 2. [What the console can do](#2-what-the-console-can-do).
-3. [Enabling CIDR network isolation](#3-enabling-cidr-network-isolation).
+3. [Restricting the admin surfaces](#3-restricting-the-admin-surfaces) by
+   hostname and by network.
 
 The console lives at **`/colonel`** and is served to any signed-in account that
 holds the `colonel` role. Since the cutover it is the sole admin frontend (the
@@ -82,20 +83,32 @@ acting colonel, the verb, the target, and the result — whether it originated
 from the console or the CLI (both go through the same shared operations). This is
 the non-negotiable backstop for privileged actions.
 
-## 3. Enabling CIDR network isolation
+## 3. Restricting the admin surfaces
 
-By default the two auth layers above are the sole gate, which is the right
-posture for a self-hosted single-container install (no VPN required — no extra
-configuration needed).
+Two independent factors restrict which requests reach `/colonel*` and
+`/api/colonel*`, as **defense-in-depth** on top of the two auth layers above.
+A request failing either one receives a **404** (indistinguishable-from-absent),
+not a 403.
 
-As **defense-in-depth**, you can additionally restrict both admin surfaces
-(`/colonel*` and `/api/colonel*`) to a trusted network with
-`site.admin.allowed_cidrs`. When set, a request from outside the allowlist
-receives a **404** (indistinguishable-from-absent), not a 403.
+**Host — `site.admin.allowed_hosts` / `ADMIN_ALLOWED_HOSTS`, active by
+default.** Which hostnames serve the admin surfaces. Unset, it falls back to the
+canonical anchor hosts (`DEFAULT_DOMAIN` / `HOST`) plus their `www.` siblings, so
+tenant custom domains and link-pool domains stop serving the console. Set it to
+a dedicated hostname (`admin.example.com`) if you have one. On an install where
+it is **unset** and there is no routable hostname to anchor on — the stock
+`HOST=localhost:3000`, or access by bare IP — the gate self-disables with a boot
+warning, so single-container installs are unaffected. A value that is set but
+can never match (an IP address, `*.example.com`, a non-ASCII name) **fails the
+boot** instead, naming what it rejected. `ADMIN_ALLOWED_HOSTS=*` is the one way
+to turn the gate off, and the one-variable rollback.
 
-This is a config posture, not a code fork — the same app-layer enforcement runs
-underneath regardless. The full setup (private CIDRs, the required
-`site.network.trusted_proxy` behind a load balancer, and a reverse-proxy
+**Network — `site.admin.allowed_cidrs` / `ADMIN_ALLOWED_CIDRS`, opt-in.** Which
+client IPs may reach the surfaces. Unset (the default) it is a no-op, the right
+posture for a self-hosted single-container install that cannot require a VPN. Do
+not put public CIDRs in the allowlist — the app-layer auth remains the gate for
+anyone already on the trusted network.
+
+Both are a config posture, not a code fork — the same app-layer enforcement runs
+underneath regardless. The full setup (upgrade impact, private CIDRs, the
+required `site.network.trusted_proxy` behind a load balancer, and the edge
 alternative) is documented in **`docs/operations/admin-network-isolation.md`**.
-Do not put public CIDRs in the allowlist — the app-layer auth remains the gate
-for anyone already on the trusted network.

--- a/docs/operations/pentest-scope.md
+++ b/docs/operations/pentest-scope.md
@@ -124,8 +124,13 @@ Expected responses for the negative cases (asserted by the BFLA tryout):
   - *Host* (`site.admin.allowed_hosts`, active by default — the canonical
     anchor hosts when unset): a request whose detected host is not on the
     allowlist gets 404, including on a tenant custom domain. A spoofed
-    `X-Forwarded-Host` / `Apx-Incoming-Host` from an untrusted peer, or an
-    `O-Domain-Context` override, must not change the host the gate sees.
+    `X-Forwarded-Host` / `Apx-Incoming-Host`, or an `O-Domain-Context`
+    override, must not change the host the gate sees. Forwarded host headers
+    count only from a peer `site.network.trusted_proxy` vouched for
+    (`env['otto.via_trusted_proxy'] == true`) — **not** from the private/
+    loopback-address heuristic `Rack::DetectHost` falls back to (#4024).
+    Percent-encoded spellings (`/%63olonel`, `/colonel%2Fsettings`) are gated
+    identically; the router decodes before dispatch.
   - *Network* (`site.admin.allowed_cidrs`, opt-in): when set, a request from
     outside the allowlist gets 404; a spoofed `X-Forwarded-For` must not bypass
     it.

--- a/docs/operations/pentest-scope.md
+++ b/docs/operations/pentest-scope.md
@@ -7,8 +7,9 @@ missed.
 
 See also:
 
-- `docs/operations/admin-network-isolation.md` — optional network-layer
-  isolation (`site.admin.allowed_cidrs`, issue #51).
+- `docs/operations/admin-network-isolation.md` — host isolation
+  (`site.admin.allowed_hosts`, active by default) and optional network-layer
+  isolation (`site.admin.allowed_cidrs`).
 - `docs/operations/colonel-admin-guide.md` — operator guide (promotion, console
   capabilities, isolation).
 - `try/integration/api/colonel/bfla_colonel_authz_try.rb` — the automated BFLA
@@ -41,9 +42,10 @@ is a finding.
 
 Expected responses for the negative cases (asserted by the BFLA tryout):
 
-- Anonymous (no session) → **401** (or **404** when network isolation drops it).
+- Anonymous (no session) → **401** (or **404** when the host or network gate
+  drops it).
 - Authenticated non-colonel (any standard/verified user) → **403** (or **404**
-  under network isolation).
+  under host or network isolation).
 - Colonel promotion is **CLI-only** (`bin/ots customers role promote`); no admin
   route grants the colonel role to the caller.
 
@@ -116,7 +118,16 @@ Expected responses for the negative cases (asserted by the BFLA tryout):
 - **Bundle isolation** — the admin bundle (`src/admin.ts`) must not ship to the
   customer frontend and the customer bundle must not import `src/apps/admin/*`
   (enforced by `src/tests/apps/admin/admin-isolation.spec.ts`).
-- **Network isolation posture** — when `site.admin.allowed_cidrs` is set, both
-  surfaces return 404 (indistinguishable-from-absent) from outside the allowlist;
-  a spoofed `X-Forwarded-For` must not bypass it. See
-  `docs/operations/admin-network-isolation.md`.
+- **Isolation posture (two factors)** — both surfaces return 404
+  (indistinguishable-from-absent) when a request fails either gate, and a
+  spoofed header must not bypass either:
+  - *Host* (`site.admin.allowed_hosts`, active by default — the canonical
+    anchor hosts when unset): a request whose detected host is not on the
+    allowlist gets 404, including on a tenant custom domain. A spoofed
+    `X-Forwarded-Host` / `Apx-Incoming-Host` from an untrusted peer, or an
+    `O-Domain-Context` override, must not change the host the gate sees.
+  - *Network* (`site.admin.allowed_cidrs`, opt-in): when set, a request from
+    outside the allowlist gets 404; a spoofed `X-Forwarded-For` must not bypass
+    it.
+
+  See `docs/operations/admin-network-isolation.md`.

--- a/docs/specs/domain-ip-allowlist/domain-ip-allowlist.md
+++ b/docs/specs/domain-ip-allowlist/domain-ip-allowlist.md
@@ -268,9 +268,11 @@ Gemfile constraint `'~> 2.5'` already admits it.
 Sign-in/sign-up configs default **closed** for custom domains (ADR-024,
 `resolve_signin_enabled_for_custom_domain`). The IP allowlist defaults
 **open**: no config, master switch off, or empty entry list → no-op,
-matching `AdminNetworkIsolation`'s empty-allowlist behavior
-(`admin_network_isolation.rb:69`). An access-control feature that defaulted
-closed would brick every existing custom domain on deploy.
+matching `AdminNetworkIsolation`'s empty-`allowed_cidrs` behavior. (Its
+`allowed_hosts` gate, added by #4062, defaults the other way — an empty list
+falls back to the canonical anchor hosts rather than to a no-op.) An
+access-control feature that defaulted closed would brick every existing
+custom domain on deploy.
 
 ### Enforcement middleware
 
@@ -280,8 +282,10 @@ New `Onetime::Middleware::DomainAccessControl`, mounted in
 `otto.ip_match` (installed by `IPPrivacyMiddleware` at line 296) and
 `onetime.domain_strategy`/`onetime.display_domain` (set at line 379).
 The existing CIDR precedent
-`AdminNetworkIsolation` (line 322) runs *before* host detection and cannot
-be extended for this.
+`AdminNetworkIsolation` now runs *after* `Rack::DetectHost` (moved there by
+#4062, which added a host allowlist to it) but still *before*
+`DomainStrategy`, so it sees the detected host and not the domain strategy —
+it cannot be extended for this.
 
 Flow per request:
 

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -632,10 +632,10 @@ site:
     #
     #   ADMIN_ALLOWED_HOSTS=admin.example.com
     #
-    # "*" (as the sole entry) disables the host gate entirely and logs a WARN
-    # at boot. The CIDR gate is unaffected. This is the escape hatch for
-    # installs reached by bare IP or by a hostname that is not the canonical
-    # domain.
+    # "*" ANYWHERE in the list disables the host gate entirely and logs a WARN
+    # at boot; any other entry beside it is ignored (and named in a second
+    # WARN). The CIDR gate is unaffected. This is the escape hatch for installs
+    # reached by bare IP or by a hostname that is not the canonical domain.
     #
     # Matching is case-insensitive, port-stripped and trailing-dot-stripped.
     # ASCII/A-label only: there is no IDN library in this project, so an
@@ -644,10 +644,20 @@ site:
     # UNUSABLE ENTRIES — a wildcard pattern (*.example.com), a non-ASCII name,
     # a localhost form, or an IP literal — can never match a detected host.
     # Each is dropped and named in a boot WARN. If NOTHING in an explicitly set
-    # list survives, the boot FAILS (Onetime::Config
-    # .validate_admin_allowed_hosts!) rather than serving the admin console on
-    # every hostname: the operator asked to restrict it, and a typo must not
-    # produce the opposite. Set "*" to turn the gate off on purpose.
+    # list survives, the gate stays ACTIVE with an EMPTY allowlist: /colonel and
+    # /api/colonel 404 on every hostname, rather than the admin console being
+    # served on every hostname. The operator asked to restrict it, and a typo
+    # must not produce the opposite. Onetime::Config.check_admin_allowed_hosts
+    # says so at boot (WARN); it does NOT abort the boot, because the surfaces
+    # are already fail-closed and the rest of the app is innocent.
+    # Set "*" to turn the gate off on purpose.
+    #
+    # A forwarded host header (X-Forwarded-Host, Apx-Incoming-Host,
+    # X-Original-Host, Forwarded) only counts toward this gate when
+    # site.network.trusted_proxy is configured AND the peer passed it. Behind a
+    # proxy that forwards the public hostname instead of rewriting Host, set
+    # trusted_proxy or both admin surfaces 404 (see
+    # docs/operations/admin-network-isolation.md).
     #
     # INACTIVE only when this list is UNSET and neither canonical anchor is a
     # hostname the app could ever detect — the stock local-dev and bare-IP
@@ -672,7 +682,10 @@ site:
     #
     # Empty/unset (default): NO-OP. Both surfaces stay reachable and the auth
     # layers are the sole gate — the correct posture for self-hosted
-    # single-container installs, which cannot require a VPN. Set this on cloud
+    # single-container installs, which cannot require a VPN. A list that IS set
+    # but where no entry parses as a CIDR is the opposite case and denies both
+    # surfaces (with an ERROR at boot): a list an operator wrote is never
+    # silently disabled. Set this on cloud
     # deployments to private ranges only (e.g. a Tailscale/VPN CGNAT range like
     # 100.64.0.0/10, or an office RFC1918 range). Self-hosted operators who want
     # isolation without app config can instead front the surfaces with a reverse

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -612,8 +612,56 @@ site:
     assume_https: <%= ENV['ASSUME_HTTPS'] == 'true' %>
 
   # Admin (Colonel) Configuration
-  # Network-level posture for the Colonel admin surfaces.
+  # Host and network posture for the Colonel admin surfaces. The two factors
+  # below are INDEPENDENT: a request must pass every gate that is active, and
+  # neither replaces the other.
   admin:
+    # Which HOSTNAMES serve the Colonel admin surfaces (/colonel shell and
+    # /api/colonel API). A request whose validated detected host is not on this
+    # list receives the same 404 as the CIDR gate below.
+    #
+    # Empty/unset (default): ENFORCED, anchored on the canonical hosts —
+    # features.domains.default and site.host, each with its www. variant. A
+    # stock canonical deployment sees no change; tenant custom domains and
+    # operator link-pool domains (features.domains.link_domains) stop serving
+    # the admin console, which is the point.
+    #
+    # Set to serve admin on its own hostname (recommended; pair it with an edge
+    # rule that 404s /colonel and /api/colonel on every OTHER vhost). Explicit
+    # entries are matched LITERALLY — list the www. form too if you need it.
+    #
+    #   ADMIN_ALLOWED_HOSTS=admin.example.com
+    #
+    # "*" (as the sole entry) disables the host gate entirely and logs a WARN
+    # at boot. The CIDR gate is unaffected. This is the escape hatch for
+    # installs reached by bare IP or by a hostname that is not the canonical
+    # domain.
+    #
+    # Matching is case-insensitive, port-stripped and trailing-dot-stripped.
+    # ASCII/A-label only: there is no IDN library in this project, so an
+    # internationalized domain must be given in its punycode (xn--) form.
+    #
+    # UNUSABLE ENTRIES — a wildcard pattern (*.example.com), a non-ASCII name,
+    # a localhost form, or an IP literal — can never match a detected host.
+    # Each is dropped and named in a boot WARN. If NOTHING in an explicitly set
+    # list survives, the boot FAILS (Onetime::Config
+    # .validate_admin_allowed_hosts!) rather than serving the admin console on
+    # every hostname: the operator asked to restrict it, and a typo must not
+    # produce the opposite. Set "*" to turn the gate off on purpose.
+    #
+    # INACTIVE only when this list is UNSET and neither canonical anchor is a
+    # hostname the app could ever detect — the stock local-dev and bare-IP
+    # self-hosted posture (site.host defaults to localhost:3000). The gate
+    # self-disables and logs a WARN at boot rather than locking the admin
+    # surfaces out of installs that have no routable hostname to anchor on.
+    # This exemption never applies to a list an operator set (above).
+    #
+    # Boot logs the effective posture of both factors on one INFO line, "Admin
+    # surface isolation posture", including the site.network.trusted_proxy
+    # state — with no trusted proxy declared, both gates judge inputs any peer
+    # on a private address can influence.
+    allowed_hosts: <%= ENV['ADMIN_ALLOWED_HOSTS']&.split(',')&.map(&:strip) || [] %>
+
     # Optional network isolation for the Colonel admin surfaces (/colonel shell
     # and /api/colonel API). When set to a non-empty list of CIDR ranges, any
     # request whose trusted-proxy-resolved client IP falls OUTSIDE the allowlist

--- a/lib/onetime/application/middleware_stack.rb
+++ b/lib/onetime/application/middleware_stack.rb
@@ -401,19 +401,37 @@ module Onetime
           logger.debug 'Setting up Health Access Control middleware'
           builder.use Onetime::Middleware::HealthAccessControl
 
-          # Admin network isolation - optional CIDR allowlist for the Colonel
-          # surfaces (/colonel + /api/colonel). No-op unless
-          # site.admin.allowed_cidrs is configured; then a request from outside
-          # the allowlist gets a 404 (indistinguishable-from-absent). Runs after
-          # IP privacy so it can use the trusted-proxy-resolved client IP.
-          logger.debug 'Setting up Admin Network Isolation middleware'
-          builder.use Onetime::Middleware::AdminNetworkIsolation
-
           builder.use Rack::ContentLength
           builder.use Onetime::Middleware::StartupReadiness
 
           # Host detection and identity resolution (common to all apps)
           builder.use Rack::DetectHost, logger: Onetime.http_logger
+
+          # Admin surface isolation - host allowlist (site.admin.allowed_hosts,
+          # active by default, canonical anchors when unset) plus the optional
+          # CIDR allowlist (site.admin.allowed_cidrs) for the Colonel surfaces
+          # (/colonel + /api/colonel). Failing either ACTIVE gate returns a 404
+          # (indistinguishable-from-absent); a strict no-op when both are
+          # inactive.
+          #
+          # POSITION IS LOAD-BEARING — it sits between two upstream dependencies
+          # and one downstream cost:
+          #
+          #   - BELOW IPPrivacyMiddleware, which sets env['otto.client_ip']:
+          #     the CIDR gate must read the trusted-proxy-resolved client IP,
+          #     never a raw forwarding header.
+          #   - BELOW Rack::DetectHost, which sets
+          #     env[Rack::DetectHost.result_field_name]: the host gate reads the
+          #     already-validated detected host. Mounted above DetectHost (where
+          #     this was until #4062) the key is unset and the gate would deny
+          #     every request it is asked to judge.
+          #   - ABOVE Onetime::Session (and CSRF/Security below it), so a denied
+          #     admin request costs no session write or CSRF work.
+          #
+          # One consequence of running below StartupReadiness: during boot
+          # /colonel now returns 503 rather than 404.
+          logger.debug 'Setting up Admin Network Isolation middleware'
+          builder.use Onetime::Middleware::AdminNetworkIsolation
 
           # Adds env['HTTP_X_REQUEST_ID']
           require 'middleware/request_id'

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -5,7 +5,7 @@
 require 'date' # ensure Date/Time constants resolve for permitted_classes
 require 'json' # String#to_json for YAML-safe BRAND_* interpolation (see brand block)
 require 'public_suffix' # validate_link_domains! parses LINK_DOMAINS entries at boot
-require_relative 'utils/admin_host_allowlist' # validate_admin_allowed_hosts! classifies ADMIN_ALLOWED_HOSTS at boot
+require_relative 'utils/admin_host_allowlist' # check_admin_allowed_hosts classifies ADMIN_ALLOWED_HOSTS at boot
 require_relative 'utils/config_resolver'
 require_relative 'utils/domain_parser'
 require_relative 'utils/enumerables'
@@ -1004,9 +1004,10 @@ module Onetime
       validate_link_domains!(conf.dig('features', 'domains', 'link_domains'))
 
       # Fires regardless of whether the admin surfaces are otherwise reachable:
-      # an allowlist that names only unusable entries is a typo whose failure
-      # mode is silent over-exposure, so it must stop the boot.
-      validate_admin_allowed_hosts!(conf.dig('site', 'admin', 'allowed_hosts'))
+      # an allowlist that names only unusable entries is a typo the operator
+      # has to hear about at boot rather than on the first admin request.
+      # WARNs; it does not stop the boot — see the method.
+      check_admin_allowed_hosts(conf.dig('site', 'admin', 'allowed_hosts'))
     end
 
     # Rejects a LINK_DOMAINS that was set but yields no usable host.
@@ -1069,46 +1070,59 @@ module Onetime
         'links.example.com). Unset LINK_DOMAINS entirely to offer the canonical domain.'
     end
 
-    # Rejects a site.admin.allowed_hosts (ADMIN_ALLOWED_HOSTS, #4062) that was
-    # set but names nothing the host gate could ever match.
+    # WARNs about a site.admin.allowed_hosts (ADMIN_ALLOWED_HOSTS, #4062) that
+    # was set but names nothing the host gate could ever match.
     #
     # Takes the raw config value rather than reading OT.conf so it can be
     # driven directly by a spec without a booted config.
     #
-    #   nil / []           -> return (unset; the gate falls back to the
+    #   nil / []           -> silent (unset; the gate falls back to the
     #                         canonical anchors, and goes inert on a
     #                         localhost/bare-IP install)
-    #   ['*']              -> return (the documented escape hatch: host gate
+    #   ['*']              -> silent (the documented escape hatch: host gate
     #                         off, the middleware WARNs about it)
-    #   ['admin.ex.com']   -> return (enforceable)
-    #   ['*', 'admin.ex']  -> return (the `*` is dropped, 'admin.ex' enforced)
-    #   ['127.0.0.1']      -> RAISE
-    #   ['*.example.com']  -> RAISE
+    #   ['admin.ex.com']   -> silent (enforceable)
+    #   ['*', 'admin.ex']  -> silent (the `*` turns the gate off; the sibling
+    #                         is ignored and the middleware names it)
+    #   ['127.0.0.1']      -> WARN (and the middleware denies both surfaces)
+    #   ['*.example.com']  -> WARN (ditto)
     #
-    # NOTE: this is deliberately the OPPOSITE polarity from #4063's
-    # LINK_DOMAINS, where an empty list is the error. Here empty is the safe
-    # default (canonical-only) and NON-empty-but-unenforceable is the error.
-    # Both land on the same rule — an operator who typed something either gets
-    # what they meant or gets told — via opposite-looking checks. Do not
-    # "harmonize" one to match the other.
+    # WHY THIS WARNS AND validate_link_domains! RAISES — the asymmetry is
+    # deliberate, do not "harmonize" it:
     #
-    # Failing loud matters more here than it looks: every rejected-entry case
-    # is an operator writing an allowlist in order to RESTRICT the admin
-    # surfaces, and the pre-#4062 failure mode was to disable the gate and
-    # serve /colonel on every hostname. Silent over-exposure is the one outcome
-    # this must not have. `*` is how you ask for that on purpose.
-    def validate_admin_allowed_hosts!(raw)
+    #   LINK_DOMAINS has NO fail-closed runtime backstop. An empty or
+    #     unparseable pool silently becomes the canonical domain, i.e. the
+    #     picker offers the internal platform host LINK_DOMAINS exists to
+    #     hide. Nothing downstream can recover the operator's intent, so boot
+    #     has to stop.
+    #   ADMIN_ALLOWED_HOSTS HAS one. AdminNetworkIsolation#configured_host_gate
+    #     returns [[], true] for exactly this config — an ACTIVE gate with an
+    #     EMPTY allowlist, 404ing both admin surfaces — so the over-exposure
+    #     this check exists to prevent cannot happen whether or not the process
+    #     stops. Raising here would abort the PUBLIC site, the API and the
+    #     health endpoints over an admin-console-only typo (an
+    #     ADMIN_ALLOWED_HOSTS=10.0.0.0/8 mixup with the adjacent
+    #     ADMIN_ALLOWED_CIDRS key takes the whole deployment down). The blast
+    #     radius strictly exceeds the harm prevented.
+    #
+    # The diagnostic still fires at BOOT rather than only on the first admin
+    # request, which is the whole reason this check exists separately from the
+    # middleware: an operator who mistyped the allowlist learns it from the
+    # startup log, not from a 404 three days later.
+    #
+    # @param raw [Array<String>, nil] site.admin.allowed_hosts as loaded
+    # @return [void]
+    def check_admin_allowed_hosts(raw)
       classified = Onetime::Utils::AdminHostAllowlist.classify(raw)
       return unless classified.unenforceable?
 
       described = Onetime::Utils::AdminHostAllowlist.describe_rejections(classified.rejected).join('; ')
 
-      raise OT::ConfigError,
-        'ADMIN_ALLOWED_HOSTS (site.admin.allowed_hosts) names no hostname the admin host gate ' \
-        "could ever match, so /colonel and /api/colonel would be served on every hostname: #{described}. " \
-        'Set it to a routable hostname the deployment answers on (ADMIN_ALLOWED_HOSTS=admin.example.com), ' \
-        'unset it entirely to allow the canonical host only, or set it to * to disable the host gate ' \
-        'deliberately.'
+      OT.lw 'ADMIN_ALLOWED_HOSTS (site.admin.allowed_hosts) names no hostname the admin host gate ' \
+            "could ever match, so /colonel and /api/colonel return 404 to EVERY request: #{described}. " \
+            'Set it to a routable hostname the deployment answers on (ADMIN_ALLOWED_HOSTS=admin.example.com), ' \
+            'unset it entirely to allow the canonical host only, or set it to * to disable the host gate ' \
+            'deliberately.'
     end
 
     # Whether a configured link-pool host survives the same parse the

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -5,6 +5,7 @@
 require 'date' # ensure Date/Time constants resolve for permitted_classes
 require 'json' # String#to_json for YAML-safe BRAND_* interpolation (see brand block)
 require 'public_suffix' # validate_link_domains! parses LINK_DOMAINS entries at boot
+require_relative 'utils/admin_host_allowlist' # validate_admin_allowed_hosts! classifies ADMIN_ALLOWED_HOSTS at boot
 require_relative 'utils/config_resolver'
 require_relative 'utils/domain_parser'
 require_relative 'utils/enumerables'
@@ -116,13 +117,23 @@ module Onetime
             'autoverify' => false,
             'allowed_signup_domains' => [],
           },
-          # Colonel admin surfaces network posture. allowed_cidrs empty (default)
-          # = AdminNetworkIsolation middleware is a no-op; both /colonel and
-          # /api/colonel stay reachable, gated only by the two app-layer auth
-          # layers. Set to private CIDRs on cloud to require an in-network
-          # (VPN/private) origin as defense-in-depth. See
-          # lib/onetime/middleware/admin_network_isolation.rb.
+          # Colonel admin surfaces posture, two independent factors (#4062).
+          #
+          # allowed_hosts empty (default) = the host gate falls back to the
+          # canonical ANCHOR hosts (features.domains.default / site.host) and
+          # their www. variants, so the admin surfaces stop answering on tenant
+          # custom domains and link-pool domains. `*` disables it. The gate
+          # self-disables when no configured entry is a routable hostname (the
+          # stock localhost / bare-IP posture).
+          #
+          # allowed_cidrs empty (default) = the network gate is a no-op; both
+          # /colonel and /api/colonel stay reachable from any IP, gated only by
+          # the two app-layer auth layers. Set to private CIDRs on cloud to
+          # require an in-network (VPN/private) origin as defense-in-depth.
+          #
+          # See lib/onetime/middleware/admin_network_isolation.rb.
           'admin' => {
+            'allowed_hosts' => [],
             'allowed_cidrs' => [],
           },
         },
@@ -991,6 +1002,11 @@ module Onetime
       # wrote LINK_DOMAINS, so a blank value is a typo worth failing loud on,
       # and this is the only placement that runs before any feature gating.
       validate_link_domains!(conf.dig('features', 'domains', 'link_domains'))
+
+      # Fires regardless of whether the admin surfaces are otherwise reachable:
+      # an allowlist that names only unusable entries is a typo whose failure
+      # mode is silent over-exposure, so it must stop the boot.
+      validate_admin_allowed_hosts!(conf.dig('site', 'admin', 'allowed_hosts'))
     end
 
     # Rejects a LINK_DOMAINS that was set but yields no usable host.
@@ -1016,7 +1032,7 @@ module Onetime
     # entries, is the only honest option.
     #
     # NOTE: this is deliberately the OPPOSITE polarity from #4062's
-    # security.admin allowed_hosts, where an empty list means canonical-only.
+    # site.admin.allowed_hosts, where an empty list means canonical-only.
     # An empty admin-host allowlist failing closed to canonical is safe. An
     # empty link pool silently becoming the canonical domain hides the
     # operator's typo and produces exactly the outcome LINK_DOMAINS exists to
@@ -1051,6 +1067,48 @@ module Onetime
         'domain, so the link picker would have nothing to offer. Check for typos and ' \
         'private/internal hostnames (a host must have a public suffix, e.g. ' \
         'links.example.com). Unset LINK_DOMAINS entirely to offer the canonical domain.'
+    end
+
+    # Rejects a site.admin.allowed_hosts (ADMIN_ALLOWED_HOSTS, #4062) that was
+    # set but names nothing the host gate could ever match.
+    #
+    # Takes the raw config value rather than reading OT.conf so it can be
+    # driven directly by a spec without a booted config.
+    #
+    #   nil / []           -> return (unset; the gate falls back to the
+    #                         canonical anchors, and goes inert on a
+    #                         localhost/bare-IP install)
+    #   ['*']              -> return (the documented escape hatch: host gate
+    #                         off, the middleware WARNs about it)
+    #   ['admin.ex.com']   -> return (enforceable)
+    #   ['*', 'admin.ex']  -> return (the `*` is dropped, 'admin.ex' enforced)
+    #   ['127.0.0.1']      -> RAISE
+    #   ['*.example.com']  -> RAISE
+    #
+    # NOTE: this is deliberately the OPPOSITE polarity from #4063's
+    # LINK_DOMAINS, where an empty list is the error. Here empty is the safe
+    # default (canonical-only) and NON-empty-but-unenforceable is the error.
+    # Both land on the same rule — an operator who typed something either gets
+    # what they meant or gets told — via opposite-looking checks. Do not
+    # "harmonize" one to match the other.
+    #
+    # Failing loud matters more here than it looks: every rejected-entry case
+    # is an operator writing an allowlist in order to RESTRICT the admin
+    # surfaces, and the pre-#4062 failure mode was to disable the gate and
+    # serve /colonel on every hostname. Silent over-exposure is the one outcome
+    # this must not have. `*` is how you ask for that on purpose.
+    def validate_admin_allowed_hosts!(raw)
+      classified = Onetime::Utils::AdminHostAllowlist.classify(raw)
+      return unless classified.unenforceable?
+
+      described = Onetime::Utils::AdminHostAllowlist.describe_rejections(classified.rejected).join('; ')
+
+      raise OT::ConfigError,
+        'ADMIN_ALLOWED_HOSTS (site.admin.allowed_hosts) names no hostname the admin host gate ' \
+        "could ever match, so /colonel and /api/colonel would be served on every hostname: #{described}. " \
+        'Set it to a routable hostname the deployment answers on (ADMIN_ALLOWED_HOSTS=admin.example.com), ' \
+        'unset it entirely to allow the canonical host only, or set it to * to disable the host gate ' \
+        'deliberately.'
     end
 
     # Whether a configured link-pool host survives the same parse the

--- a/lib/onetime/middleware/admin_network_isolation.rb
+++ b/lib/onetime/middleware/admin_network_isolation.rb
@@ -2,29 +2,89 @@
 #
 # frozen_string_literal: true
 
+require_relative '../../middleware/detect_host'
+require_relative '../utils/admin_host_allowlist'
+require_relative '../utils/canonical_hosts'
+
 module Onetime
   module Middleware
-    # AdminNetworkIsolation - Optional network-level isolation for the Colonel
-    # admin surfaces (`/colonel` shell + `/api/colonel` API).
+    # AdminNetworkIsolation - host and network isolation for the Colonel admin
+    # surfaces (`/colonel` shell + `/api/colonel` API).
     #
     # A sibling of IPBan and HealthAccessControl in the universal middleware
     # stack (see Onetime::Application::MiddlewareStack.configure). It gives the
-    # deployment a config-selectable network posture WITHOUT forking the code:
+    # deployment a config-selectable posture WITHOUT forking the code, across
+    # TWO INDEPENDENT FACTORS. Neither replaces the other, and a request must
+    # pass every gate that is ACTIVE:
     #
-    #   - Self-hosted single-container default: `site.admin.allowed_cidrs` is
-    #     unset/empty, so this middleware is a strict NO-OP. Both admin surfaces
-    #     remain reachable and the two app-layer auth layers (role=colonel at the
-    #     Otto router + verify_one_of_roles!(colonel:true) in each logic class)
-    #     are the sole gate — exactly as before.
+    #   1. HOST — `site.admin.allowed_hosts` (#4062). WHICH HOSTNAME the admin
+    #      surfaces answer on. ACTIVE BY DEFAULT: an empty list falls back to
+    #      the deployment's canonical ANCHOR hosts plus their `www.` variants,
+    #      so a stock canonical deployment sees no behavior change while a
+    #      tenant custom domain (or any other vhost the app answers on) stops
+    #      serving the admin console. `*` is the explicit escape hatch. An
+    #      explicit list with nothing enforceable in it does not reach here —
+    #      Onetime::Config.validate_admin_allowed_hosts! refuses to boot.
     #
-    #   - Cloud / VPN posture: `site.admin.allowed_cidrs` is set to the private
-    #     ranges the admin surfaces should be reachable from (e.g. Tailscale
-    #     CGNAT 100.64.0.0/10, an office VPN CIDR, or RFC1918). A request whose
-    #     resolved client IP is OUTSIDE the allowlist gets a 404 on `/colonel`
-    #     and `/api/colonel` — indistinguishable-from-absent, NOT a 403, so the
-    #     admin surface does not even advertise its existence to an unauthorized
-    #     network. This is defense-in-depth ON TOP OF the two auth layers, which
-    #     still enforce beneath it for any request that does pass the CIDR gate.
+    #   2. NETWORK — `site.admin.allowed_cidrs`. WHICH CLIENT IPs may reach the
+    #      surfaces. OPT-IN: empty/unset (the self-hosted single-container
+    #      default) means this gate is not consulted at all. Set it on cloud to
+    #      the private ranges the surfaces should be reachable from (e.g.
+    #      Tailscale CGNAT 100.64.0.0/10, an office VPN CIDR, or RFC1918).
+    #
+    # A request that fails EITHER active gate gets a 404 on `/colonel` and
+    # `/api/colonel` — indistinguishable-from-absent, NOT a 403, so the admin
+    # surface does not even advertise its existence to an unauthorized host or
+    # network. Both gates are defense-in-depth ON TOP OF the two app-layer auth
+    # layers (role=colonel at the Otto router + verify_one_of_roles!(colonel:
+    # true) in each logic class), which still enforce beneath for any request
+    # that does pass.
+    #
+    # When BOTH gates are inactive the middleware is a strict NO-OP, exactly as
+    # before #4062.
+    #
+    # ## Host resolution
+    #
+    # The host is read from env[Rack::DetectHost.result_field_name] — the host
+    # Rack::DetectHost already validated, and which only honors a forwarded
+    # header when the peer was trusted. Three things it deliberately is NOT:
+    #
+    #   - NOT env['onetime.domain_strategy']. DomainStrategy honors an
+    #     `O-Domain-Context` REQUEST HEADER override when
+    #     development.domain_context_enabled is on. A header-settable input
+    #     must never decide admin reachability.
+    #   - NOT HTTP_HOST / HTTP_X_FORWARDED_HOST. Reading those raw would
+    #     bypass the trust decision DetectHost already made about the peer.
+    #   - NOT the literal string 'rack.detected_host'. The env key name is a
+    #     runtime-mutable accessor driven by the DETECTED_HOST env var, so a
+    #     hardcoded literal would read nil on a deployment that renames it —
+    #     a blanket 404 on both surfaces. Same access pattern DomainStrategy
+    #     uses.
+    #
+    # Both sides of the comparison are normalized identically (downcased, port
+    # stripped, trailing root dot stripped) by
+    # Onetime::Utils::AdminHostAllowlist, which also decides which configured
+    # entries can ever match. Matching is exact and ASCII/A-label only.
+    #
+    # ## Configured badly vs not configured — the asymmetry
+    #
+    # Rack::DetectHost never emits `localhost`, `localhost.localdomain`,
+    # `127.0.0.1`, `::1`, or ANY IP literal, so the detected host is nil on
+    # stock local-dev (shipped default site.host is `localhost:3000`) and on
+    # bare-IP self-hosted installs. The two cases that produces are NOT the
+    # same and must not be collapsed:
+    #
+    #   NOBODY CONFIGURED ANYTHING (allowed_hosts empty, anchors unroutable):
+    #     the gate goes INERT with a boot WARN. A literally fail-closed default
+    #     would 404 `/colonel` on every stock single-container install, which
+    #     the network gate was carefully designed never to do.
+    #
+    #   AN OPERATOR CONFIGURED SOMETHING UNENFORCEABLE (allowed_hosts set, no
+    #     entry survives): Onetime::Config.validate_admin_allowed_hosts! raises
+    #     at boot, and if that validation was somehow bypassed this middleware
+    #     DENIES both surfaces. Going inert here would serve the admin console
+    #     on every host from a config whose plain intent was to restrict it —
+    #     failing open on a typo. `*` remains the way to turn the gate off.
     #
     # ## Client IP resolution
     #
@@ -50,30 +110,88 @@ module Onetime
     # which app is handling the request.
     #
     class AdminNetworkIsolation
+      # The surfaces this middleware guards. Named in every boot log so an
+      # operator can grep for what is (and is not) gated.
+      SURFACES = %w[/colonel /api/colonel].freeze
+
+      # Sole-entry escape hatch that disables the HOST gate. The network gate
+      # is unaffected by it. Needed by self-hosted installs reached by bare IP
+      # or by a hostname that is not the configured canonical domain.
+      HOST_WILDCARD = Onetime::Utils::AdminHostAllowlist::WILDCARD
+
       def initialize(app)
         @app             = app
         @logger          = Onetime.get_logger('AdminNetworkIsolation')
-        @allowed_ranges  = parse_allowed_cidrs(configured_cidrs)
 
-        return if @allowed_ranges.empty?
+        # Both allowlists are resolved ONCE, here — the process has booted and
+        # nothing re-reads config per request. The host gate carries its own
+        # active flag rather than deriving one from emptiness: an ACTIVE gate
+        # with an EMPTY allowlist is the fail-closed backstop, and "inactive"
+        # must not be reachable by accident.
+        @allowed_ranges              = parse_allowed_cidrs(configured_cidrs)
+        @allowed_hosts, @host_gate   = resolve_host_gate
 
-        @logger.info 'Admin network isolation enabled',
-          {
-            allowed_cidrs: @allowed_ranges.map(&:to_s),
-            surfaces: %w[/colonel /api/colonel],
-          }
+        log_boot_posture
       end
 
       def call(env)
-        # NO-OP when no allowlist is configured — the self-hosted default.
-        return @app.call(env) if @allowed_ranges.empty?
-
+        # Cheapest discriminator first: any path that is not an admin surface
+        # leaves this middleware untouched, whatever the gates are set to.
         full_path = request_path(env)
         return @app.call(env) unless admin_surface?(full_path)
 
-        client_ip = resolve_client_ip(env)
+        # Both gates inactive — the pre-#4062 self-hosted default. Strict
+        # NO-OP: the two app-layer auth layers are the sole gate.
+        return @app.call(env) unless host_gate_active? || network_gate_active?
 
-        return @app.call(env) if allowed?(client_ip)
+        # Each gate is consulted INDEPENDENTLY and only while active; either
+        # denial produces the identical 404, so a host denial, a network
+        # denial, and an absent route are indistinguishable to the client.
+        return not_found_response(full_path) if host_denied?(env, full_path)
+        return not_found_response(full_path) if network_denied?(env, full_path)
+
+        @app.call(env)
+      end
+
+      private
+
+      # --- gates ---------------------------------------------------------
+
+      def host_gate_active?
+        @host_gate
+      end
+
+      def network_gate_active?
+        !@allowed_ranges.empty?
+      end
+
+      # Host gate. Fails closed: an active gate with an unresolvable (nil or
+      # empty) detected host denies, mirroring the nil-IP path in #allowed?.
+      # The denial WARN is distinct from the network one so operators can tell
+      # the two factors apart in logs; the allowlist is never echoed into the
+      # response, only into the log.
+      def host_denied?(env, full_path)
+        return false unless host_gate_active?
+
+        host = detected_host(env)
+        return false if host_allowed?(host)
+
+        @logger.warn 'Admin surface access denied by host allowlist',
+          {
+            host: host,
+            path: full_path,
+            method: env['REQUEST_METHOD'],
+          }
+
+        true
+      end
+
+      # Network (CIDR) gate. Unchanged semantics from before #4062.
+      def network_denied?(env, full_path)
+        return false unless network_gate_active?
+
+        client_ip = resolve_client_ip(env)
+        return false if allowed?(client_ip)
 
         @logger.warn 'Admin surface access denied by network isolation',
           {
@@ -82,10 +200,8 @@ module Onetime
             method: env['REQUEST_METHOD'],
           }
 
-        not_found_response(full_path)
+        true
       end
-
-      private
 
       # Full request path independent of where the app is mounted. Rack::URLMap
       # moves the mount prefix into SCRIPT_NAME, so PATH_INFO alone would be
@@ -115,6 +231,32 @@ module Onetime
         false
       end
 
+      # The validated detected host, normalized the same way the configured
+      # entries were. The env KEY is asked for at call time
+      # (Rack::DetectHost.result_field_name is a runtime-mutable accessor);
+      # never hardcode 'rack.detected_host'.
+      def detected_host(env)
+        normalize_host(env[Rack::DetectHost.result_field_name])
+      end
+
+      # ONE normalization for BOTH sides of the comparison. Delegated to the
+      # shared classifier rather than reimplemented: the configured entries were
+      # shaped by AdminHostAllowlist.normalize_host at construction, and a
+      # second local copy here is how an exact-match gate silently stops
+      # matching (a stripped port on one side, a kept trailing dot on the
+      # other).
+      def normalize_host(value)
+        Onetime::Utils::AdminHostAllowlist.normalize_host(value)
+      end
+
+      # Exact membership against the effective host allowlist. Nil/empty fails
+      # closed — an active host gate that cannot see a host denies.
+      def host_allowed?(host)
+        return false if host.nil? || host.empty?
+
+        @allowed_hosts.include?(host)
+      end
+
       # Resolve the client IP from the trusted-proxy-aware canonical value, with
       # the same fallback the auth strategies use. Never trusts a raw header.
       def resolve_client_ip(env)
@@ -128,7 +270,18 @@ module Onetime
       end
 
       def configured_cidrs
-        OT.conf.dig('site', 'admin', 'allowed_cidrs')
+        site_admin_list('allowed_cidrs')
+      end
+
+      def configured_hosts
+        site_admin_list('allowed_hosts')
+      end
+
+      # One reader for both site.admin.* lists. Config may be entirely absent
+      # (partial boot, specs); an unreadable config must never raise out of
+      # this middleware's constructor.
+      def site_admin_list(key)
+        OT.conf.dig('site', 'admin', key)
       rescue StandardError
         nil
       end
@@ -142,6 +295,216 @@ module Onetime
           @logger.warn "Invalid CIDR in site.admin.allowed_cidrs, skipping: #{cidr}"
           nil
         end
+      end
+
+      # Resolve the host gate ONCE at construction, from
+      # site.admin.allowed_hosts and — only when that is unset — the canonical
+      # anchors.
+      #
+      # @return [Array(Array<String>, Boolean)] the allowlist, and whether the
+      #   gate is active. ACTIVE with an EMPTY allowlist denies everything;
+      #   that is the backstop, not an accident.
+      def resolve_host_gate
+        configured = Onetime::Utils::AdminHostAllowlist.classify(configured_hosts)
+
+        return anchor_host_gate if configured.empty?
+        return wildcard_host_gate if configured.wildcard_only?
+
+        configured_host_gate(configured)
+      end
+
+      # An operator wrote a list. Enforce whatever survived classification.
+      def configured_host_gate(classified)
+        warn_dropped_wildcard if classified.wildcard
+        warn_rejected_entries(classified.rejected)
+
+        return [classified.hosts, true] if classified.hosts.any?
+
+        # BACKSTOP — normally unreachable: Onetime::Config
+        # .validate_admin_allowed_hosts! refuses this config at boot with a
+        # message naming every rejected entry. Reaching it means that
+        # validation did not run (an embedding that builds a Rack app without
+        # Config.raise_concerns). An explicit allowlist with nothing
+        # enforceable must DENY, never disable itself: the operator's plain
+        # intent was to restrict, and `*` is how you ask for the opposite.
+        # An operator reading this line is debugging an outage, not auditing an
+        # invariant: lead with what is happening to the surfaces, then the
+        # cause, then the remedy.
+        @logger.warn 'Admin host allowlist has no enforceable entry; denying both admin surfaces',
+          {
+            entries: classified.rejected.map(&:first),
+            surfaces: SURFACES,
+            note: '/colonel and /api/colonel are returning 404 to EVERY request because no entry in ' \
+                  'site.admin.allowed_hosts can match a detected host. This config is normally ' \
+                  'rejected at boot, so boot-time validation did not run here. Set ' \
+                  'ADMIN_ALLOWED_HOSTS to a routable hostname, unset it to allow the canonical ' \
+                  'host only, or set it to * to disable the host gate',
+          }
+
+        [[], true]
+      end
+
+      # `*` as the sole entry: the documented escape hatch.
+      def wildcard_host_gate
+        @logger.warn 'Admin host allowlist DISABLED by `*`',
+          {
+            surfaces: SURFACES,
+            note: 'both admin surfaces answer on every hostname the app serves; the CIDR gate is unaffected',
+          }
+
+        [[], false]
+      end
+
+      # Nobody configured anything: fall back to the canonical anchors, plus
+      # their `www.` variants.
+      #
+      # THE INERT RULE lives here and ONLY here. When the anchors yield nothing
+      # Rack::DetectHost could emit — stock local-dev (`site.host` defaults to
+      # `localhost:3000`) or a bare-IP self-hosted install — the gate goes
+      # inactive with a WARN rather than 404ing `/colonel` on an install nobody
+      # misconfigured. Contrast configured_host_gate, which denies: there the
+      # operator did write something.
+      #
+      # Judged BEFORE `www.` expansion: `localhost` is not emittable but a
+      # synthesized `www.localhost` would be, which would defeat the rule.
+      def anchor_host_gate
+        anchors = Onetime::Utils::AdminHostAllowlist.classify(canonical_anchor_hosts)
+        return [with_www_variants(anchors.hosts), true] if anchors.hosts.any?
+
+        @logger.warn 'Admin host allowlist INACTIVE: no routable hostname configured',
+          {
+            source: 'canonical anchors',
+            hosts: canonical_anchor_hosts,
+            surfaces: SURFACES,
+            note: 'localhost and bare-IP hosts are never detected as a host; set ADMIN_ALLOWED_HOSTS ' \
+                  '(or site.host / DEFAULT_DOMAIN) to a routable hostname to enable the host gate',
+          }
+
+        [[], false]
+      end
+
+      # States only what this check decided. Whether anything is left to
+      # enforce is the next check's business — and its answer may be "nothing",
+      # which is why this must not promise that named hosts are enforced.
+      def warn_dropped_wildcard
+        @logger.warn 'Dropped `*` from site.admin.allowed_hosts: it is only honored as the sole entry',
+          {
+            note: 'list `*` alone to disable the host gate',
+          }
+      end
+
+      # Entries that can never match are dropped, not fatal, as long as
+      # something enforceable remains. Named at boot so the operator can see
+      # WHY the effective allowlist is smaller than what they wrote.
+      def warn_rejected_entries(rejected)
+        return if rejected.empty?
+
+        @logger.warn 'Ignoring unusable entries in site.admin.allowed_hosts',
+          {
+            entries: Onetime::Utils::AdminHostAllowlist.describe_rejections(rejected),
+          }
+      end
+
+      # The fallback allowlist source: the deployment's ANCHOR hosts only —
+      # features.domains.default and site.host.
+      #
+      # NOT CanonicalHosts.hosts / normalized_hosts / canonical_host?: those
+      # include the features.domains.link_domains pool (#4063), so using them
+      # would serve the admin console on every operator short-link domain —
+      # the exact inverse of what the link pool exists to do. NOT
+      # DomainStrategy.canonical_host? either: its answer depends on
+      # features.domains.enabled and on lazily-initialized class state.
+      def canonical_anchor_hosts
+        Onetime::Utils::CanonicalHosts.normalized_anchor_hosts
+      end
+
+      # Admit the `www.` sibling of each anchor, matching the tolerance
+      # DomainStrategy::Chooserator.equal_to? applies to anchors (and only to
+      # anchors). Neither CanonicalHosts nor DomainParser synthesizes it.
+      def with_www_variants(hosts)
+        expanded = hosts.flat_map do |host|
+          if host.start_with?('www.')
+            [host, host.delete_prefix('www.')]
+          else
+            [host, "www.#{host}"]
+          end
+        end
+
+        expanded.uniq
+      end
+
+      # One INFO line per process describing the effective posture of BOTH
+      # factors, including when a gate is off — so "off" is distinguishable
+      # from "misconfigured" without diffing config against source.
+      #
+      # `trusted_proxy` is on this line, and deliberately not on one of its own:
+      # it qualifies the two gate states beside it. Both gates judge inputs that
+      # a proxy layer determines (the detected host; the resolved client IP), so
+      # `host_gate: active` correlated with `trusted_proxy: disabled` is the
+      # whole point — see #trusted_proxy_posture.
+      def log_boot_posture
+        @logger.info 'Admin surface isolation posture',
+          {
+            host_gate: host_gate_active? ? 'active' : 'inactive',
+            allowed_hosts: @allowed_hosts,
+            network_gate: network_gate_active? ? 'active' : 'inactive',
+            allowed_cidrs: effective_cidrs,
+            trusted_proxy: trusted_proxy_posture,
+            surfaces: SURFACES,
+          }
+      end
+
+      # The parsed ranges as an operator would have written them. IPAddr#to_s
+      # drops the mask, so a configured 100.64.0.0/10 would otherwise log as
+      # `100.64.0.0` — a /10 rendered as what looks like a single host, on the
+      # one line an operator reads to confirm the posture took effect.
+      def effective_cidrs
+        @allowed_ranges.map { |range| "#{range}/#{range.prefix}" }
+      end
+
+      # Whether the deployment declares a trusted reverse proxy, and in which
+      # mode. Read through the SAME predicate that decides how the universal
+      # IP-privacy mount is configured
+      # (Onetime::Application::MiddlewareStack.trusted_proxy_enabled?, consumed
+      # by .ip_privacy_security_config), so this line cannot report a posture
+      # the stack does not actually have.
+      #
+      # WHY IT IS LOGGED HERE: with trusted_proxy DISABLED — the shipped
+      # default — neither gate's input is authenticated. Rack::DetectHost falls
+      # back to a legacy heuristic that trusts any peer on a private or loopback
+      # address to set a forwarded host header, and otto resolves the client IP
+      # from REMOTE_ADDR. On a shared container network, or anywhere with SSRF
+      # egress, that is what these gates judge. `host_gate: active` alone reads
+      # stronger than it is.
+      #
+      # The mode is reported because it changes how the client IP is resolved —
+      # and because depth mode is currently broken (#4024).
+      #
+      # No require_relative for MiddlewareStack: it requires THIS file (the
+      # mount), so the dependency only runs the other way. The constant is
+      # resolved at call time, by which point anything that mounts this
+      # middleware has loaded it; the rescue covers an embedding that builds it
+      # standalone. A boot log line must never be the thing that fails a boot.
+      def trusted_proxy_posture
+        return 'disabled' unless Onetime::Application::MiddlewareStack.trusted_proxy_enabled?
+
+        # Reproduces MiddlewareStack.ip_privacy_security_config's own default
+        # for an enabled-but-modeless block. There is no shared reader for the
+        # MODE (only for `enabled`), so this expression is duplicated.
+        #
+        # TODO: consolidate the trusted-proxy config readers. `enabled` is
+        # already reimplemented verbatim in THREE places —
+        # Onetime::Application::MiddlewareStack.trusted_proxy_enabled?,
+        # Onetime::Security::ResetRequestRateLimiter, and
+        # Onetime::Security::CreateAccountRateLimiter — and this adds a fourth
+        # site reading `mode`. One accessor pair (enabled + mode) should serve
+        # all of them. Out of scope for #4062; tracked separately.
+        mode = OT.conf.dig('site', 'network', 'trusted_proxy', 'mode').to_s.strip
+        mode = 'filter' if mode.empty?
+
+        "enabled (mode=#{mode})"
+      rescue StandardError
+        'unknown'
       end
 
       # 404, not 403: the surface must be indistinguishable from absent to an

--- a/lib/onetime/middleware/admin_network_isolation.rb
+++ b/lib/onetime/middleware/admin_network_isolation.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require 'otto/utils'
+
 require_relative '../../middleware/detect_host'
 require_relative '../utils/admin_host_allowlist'
 require_relative '../utils/canonical_hosts'
@@ -23,14 +25,17 @@ module Onetime
     #      so a stock canonical deployment sees no behavior change while a
     #      tenant custom domain (or any other vhost the app answers on) stops
     #      serving the admin console. `*` is the explicit escape hatch. An
-    #      explicit list with nothing enforceable in it does not reach here —
-    #      Onetime::Config.validate_admin_allowed_hosts! refuses to boot.
+    #      explicit list with nothing enforceable in it DENIES both surfaces
+    #      here; Onetime::Config.check_admin_allowed_hosts says so at boot.
     #
     #   2. NETWORK — `site.admin.allowed_cidrs`. WHICH CLIENT IPs may reach the
     #      surfaces. OPT-IN: empty/unset (the self-hosted single-container
     #      default) means this gate is not consulted at all. Set it on cloud to
     #      the private ranges the surfaces should be reachable from (e.g.
     #      Tailscale CGNAT 100.64.0.0/10, an office VPN CIDR, or RFC1918).
+    #      A CONFIGURED list with no parseable range in it denies, by the same
+    #      rule as the host gate: a list an operator wrote is never silently
+    #      disabled.
     #
     # A request that fails EITHER active gate gets a 404 on `/colonel` and
     # `/api/colonel` — indistinguishable-from-absent, NOT a 403, so the admin
@@ -46,8 +51,7 @@ module Onetime
     # ## Host resolution
     #
     # The host is read from env[Rack::DetectHost.result_field_name] — the host
-    # Rack::DetectHost already validated, and which only honors a forwarded
-    # header when the peer was trusted. Three things it deliberately is NOT:
+    # Rack::DetectHost already validated. Three things it deliberately is NOT:
     #
     #   - NOT env['onetime.domain_strategy']. DomainStrategy honors an
     #     `O-Domain-Context` REQUEST HEADER override when
@@ -66,6 +70,50 @@ module Onetime
     # Onetime::Utils::AdminHostAllowlist, which also decides which configured
     # entries can ever match. Matching is exact and ASCII/A-label only.
     #
+    # ## Forwarded-host provenance (the extra trust check DetectHost does not
+    # ## make, and cannot make for us)
+    #
+    # DetectHost honors a forwarded host header (X-Forwarded-Host,
+    # Apx-Incoming-Host, X-Original-Host, Forwarded) when EITHER the operator
+    # configured proxy trust and this peer passed it (otto writes
+    # env['otto.via_trusted_proxy'] = true) OR — with no proxy trust configured
+    # at all, the SHIPPED DEFAULT — a legacy heuristic: any peer whose
+    # REMOTE_ADDR is private or loopback may name the host. That heuristic keeps
+    # single-container installs behind a local proxy working, and it is fine for
+    # DISPLAY decisions. It is not fine for deciding admin reachability: on every
+    # containerised install (and anywhere with SSRF egress) a client that can
+    # open a connection from a private address chooses the host this gate reads,
+    # so `X-Forwarded-Host: canonical.example.com` sent to a tenant custom domain
+    # would open the admin console. That weakness is project-wide (#4024) and is
+    # not fixable here; this gate declines to rely on it.
+    #
+    # THE RULE (#host_provenance_trusted?): a detected host is accepted only when
+    #
+    #   a. env['otto.via_trusted_proxy'] == true — the operator configured proxy
+    #      trust and this peer passed it. Forwarded headers are then a fact about
+    #      the operator's own proxy tier; OR
+    #   b. no forwarded host header is present at all, so nothing could have
+    #      overridden the Host header; OR
+    #   c. one is present but the detected host EQUALS the host the Host header
+    #      alone would have produced — the forwarded header did not change the
+    #      answer, so there is nothing to distrust.
+    #
+    # Otherwise the request is DENIED. It is not silently downgraded to the
+    # HTTP_HOST-derived host: in the topology this defends (Approximated-style
+    # ingress with trusted_proxy unset) `Host` is the ORIGIN's own hostname —
+    # the canonical one, which IS on the allowlist — while the tenant domain
+    # rides in Apx-Incoming-Host. Falling back to Host would therefore ADMIT
+    # every tenant-domain request, the exact inverse of this feature. Denying is
+    # the only reading that fails closed. The tryout at
+    # "HTTP_HOST naming a DENIED host does not evict an allowed detected host"
+    # pins the other half: HTTP_HOST is never an input, only a corroborator.
+    #
+    # Cost, stated plainly: a deployment behind a proxy that rewrites the Host
+    # header to an internal name AND forwards the public one in a header, with
+    # site.network.trusted_proxy unset, now 404s both admin surfaces. The two
+    # remedies are in the WARN — configure site.network.trusted_proxy (correct
+    # for every other gate in the stack too), or ADMIN_ALLOWED_HOSTS=*.
+    #
     # ## Configured badly vs not configured — the asymmetry
     #
     # Rack::DetectHost never emits `localhost`, `localhost.localdomain`,
@@ -80,11 +128,17 @@ module Onetime
     #     the network gate was carefully designed never to do.
     #
     #   AN OPERATOR CONFIGURED SOMETHING UNENFORCEABLE (allowed_hosts set, no
-    #     entry survives): Onetime::Config.validate_admin_allowed_hosts! raises
-    #     at boot, and if that validation was somehow bypassed this middleware
-    #     DENIES both surfaces. Going inert here would serve the admin console
-    #     on every host from a config whose plain intent was to restrict it —
-    #     failing open on a typo. `*` remains the way to turn the gate off.
+    #     entry survives): this middleware DENIES both surfaces, and
+    #     Onetime::Config.check_admin_allowed_hosts explains why at boot. Going
+    #     inert here would serve the admin console on every host from a config
+    #     whose plain intent was to restrict it — failing open on a typo. `*`
+    #     remains the way to turn the gate off.
+    #
+    #   THE CONFIG COULD NOT BE READ AT ALL (OT.conf raised): treated as the
+    #     second case, never the first. "Unset" and "unreadable" are different
+    #     facts and collapsing them would degrade a configured gate to the
+    #     anchor fallback and then to INACTIVE — admin on every hostname,
+    #     announced by a boot WARN blaming site.host.
     #
     # ## Client IP resolution
     #
@@ -107,42 +161,156 @@ module Onetime
     # `/api/colonel` (PATH_INFO becomes `/info`, `/stats`, …) and the core web
     # app at `/` (PATH_INFO stays `/colonel`). We reconstruct the full request
     # path from SCRIPT_NAME + PATH_INFO so both surfaces match regardless of
-    # which app is handling the request.
+    # which app is handling the request, and NORMALIZE it exactly the way the
+    # Otto router does before dispatch (Otto::Utils.normalize_path) — see
+    # #request_path.
     #
+    # The HTML denial body, kept OUTSIDE the class it belongs to only because a
+    # 37-line literal inside it eats a third of the Metrics/ClassLength budget
+    # that the gate's reasoning needs. Deliberately plain and generic: it must
+    # look like an ordinary not-found page, never like a guard announcing
+    # itself. Rendered once at load (the file is frozen_string_literal).
+    ADMIN_NOT_FOUND_HTML = <<~HTML
+      <!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <title>404 Not Found</title>
+          <style>
+            body {
+              font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+              background-color: #f9fafb;
+              color: #374151;
+              margin: 0;
+              padding: 40px 20px;
+              text-align: center;
+            }
+            .container {
+              max-width: 400px;
+              margin: 0 auto;
+            }
+            h1 {
+              font-size: 1.5rem;
+              margin-bottom: 0.5rem;
+            }
+            p {
+              color: #6b7280;
+            }
+          </style>
+        </head>
+        <body>
+          <div class="container">
+            <h1>404 Not Found</h1>
+            <p>The requested resource was not found.</p>
+          </div>
+        </body>
+      </html>
+    HTML
+
     class AdminNetworkIsolation
       # The surfaces this middleware guards. Named in every boot log so an
       # operator can grep for what is (and is not) gated.
       SURFACES = %w[/colonel /api/colonel].freeze
 
-      # Sole-entry escape hatch that disables the HOST gate. The network gate
-      # is unaffected by it. Needed by self-hosted installs reached by bare IP
-      # or by a hostname that is not the configured canonical domain.
+      # @see Onetime::Middleware::ADMIN_NOT_FOUND_HTML
+      NOT_FOUND_HTML = ADMIN_NOT_FOUND_HTML
+
+      # Escape hatch that disables the HOST gate. The network gate is
+      # unaffected by it. Needed by self-hosted installs reached by bare IP or
+      # by a hostname that is not the configured canonical domain.
       HOST_WILDCARD = Onetime::Utils::AdminHostAllowlist::WILDCARD
 
+      # Returned by #site_admin_list when the config could not be READ, as
+      # opposed to having been left unset. A Symbol, so it can never collide
+      # with a value that came out of YAML or ENV. See #site_admin_list.
+      CONFIG_UNREADABLE = :__admin_config_unreadable__
+
+      # Rack env keys for the host headers Rack::DetectHost will honor from a
+      # trusted peer. Derived from ITS list, never a local copy: a header added
+      # there is a header this gate must distrust from an untrusted peer.
+      FORWARDED_HOST_ENV_KEYS = Rack::DetectHost::FORWARDED_HEADERS.map do |header|
+        "HTTP_#{header.tr('-', '_').upcase}"
+      end.freeze
+
+      # Path used when the request path cannot be normalized at all. Fails
+      # CLOSED: an unparseable path is judged as an admin surface, so a
+      # normalization failure can never be a way past the gates.
+      UNPARSEABLE_PATH = '/colonel'
+
+      class << self
+        # Boot logging is per-DEPLOYMENT, but this middleware is constructed
+        # once per mounted application (13 of them). Without a ledger every
+        # boot prints 13 identical posture lines — and 13 copies of any WARN
+        # saying the admin surfaces are unprotected or dark, which reads like
+        # 13 separate misconfigurations.
+        #
+        # Keyed by [tag, payload] rather than tag alone: the 13 mounts share
+        # one config and collapse to one line, while a genuinely DIFFERENT
+        # posture (a second Rack app built from other config, which only
+        # happens in tests and embeddings) still gets its own line instead of
+        # being silently swallowed. Sibling of
+        # Onetime::Application::MiddlewareStack.warn_once, which cannot be
+        # reused here: it takes a String and these carry structured payloads
+        # the operator docs quote field by field.
+        #
+        # @param tag [Symbol] dedupe key
+        # @param payload [Hash] structured log payload, part of the key
+        # @return [void]
+        def log_once(tag, payload)
+          @announced ||= {}
+          key          = [tag, payload]
+          return if @announced.key?(key)
+
+          @announced[key] = true
+          yield
+        end
+
+        # Clear the ledger. Specs only — a process that has booted has no
+        # reason to re-announce its posture.
+        #
+        # @return [void]
+        def reset_boot_announcements!
+          @announced = {}
+        end
+
+        # How many distinct boot announcements this process has emitted.
+        # Specs only; the dedupe is otherwise invisible.
+        #
+        # @return [Integer]
+        def boot_announcement_count
+          (@announced || {}).size
+        end
+      end
+
       def initialize(app)
-        @app             = app
-        @logger          = Onetime.get_logger('AdminNetworkIsolation')
+        @app                = app
+        @logger             = Onetime.get_logger('AdminNetworkIsolation')
+        @config_read_errors = {}
 
         # Both allowlists are resolved ONCE, here — the process has booted and
-        # nothing re-reads config per request. The host gate carries its own
-        # active flag rather than deriving one from emptiness: an ACTIVE gate
-        # with an EMPTY allowlist is the fail-closed backstop, and "inactive"
-        # must not be reachable by accident.
-        @allowed_ranges              = parse_allowed_cidrs(configured_cidrs)
-        @allowed_hosts, @host_gate   = resolve_host_gate
+        # nothing re-reads config per request. EACH gate carries its own active
+        # flag rather than deriving one from emptiness: an ACTIVE gate with an
+        # EMPTY allowlist is the fail-closed backstop for a list that was
+        # configured but yielded nothing, and "inactive" must not be reachable
+        # by accident.
+        @allowed_ranges, @network_gate = resolve_network_gate
+        @allowed_hosts,  @host_gate    = resolve_host_gate
 
         log_boot_posture
       end
 
       def call(env)
-        # Cheapest discriminator first: any path that is not an admin surface
-        # leaves this middleware untouched, whatever the gates are set to.
+        # Cheapest discriminator first, and it is this one: with both gates
+        # inactive — the pre-#4062 self-hosted default — the middleware is a
+        # strict NO-OP that allocates nothing, and the two app-layer auth
+        # layers are the sole gate. Reconstructing the path first would put a
+        # String allocation on every request of every mounted app to answer a
+        # question two already-computed booleans settle.
+        return @app.call(env) unless host_gate_active? || network_gate_active?
+
         full_path = request_path(env)
         return @app.call(env) unless admin_surface?(full_path)
-
-        # Both gates inactive — the pre-#4062 self-hosted default. Strict
-        # NO-OP: the two app-layer auth layers are the sole gate.
-        return @app.call(env) unless host_gate_active? || network_gate_active?
 
         # Each gate is consulted INDEPENDENTLY and only while active; either
         # denial produces the identical 404, so a host denial, a network
@@ -162,18 +330,39 @@ module Onetime
       end
 
       def network_gate_active?
-        !@allowed_ranges.empty?
+        @network_gate
       end
 
-      # Host gate. Fails closed: an active gate with an unresolvable (nil or
-      # empty) detected host denies, mirroring the nil-IP path in #allowed?.
-      # The denial WARN is distinct from the network one so operators can tell
-      # the two factors apart in logs; the allowlist is never echoed into the
-      # response, only into the log.
+      # Host gate. Fails closed twice over: an active gate with an unresolvable
+      # (nil or empty) detected host denies, mirroring the nil-IP path in
+      # #allowed?, and so does one whose detected host cannot be attributed to
+      # a trusted peer (see #host_provenance_trusted?).
+      #
+      # The denial WARNs are distinct from the network one, and from each
+      # other, so operators can tell the three refusals apart in logs; the
+      # allowlist is never echoed into the response, only into the log.
       def host_denied?(env, full_path)
         return false unless host_gate_active?
 
         host = detected_host(env)
+
+        # Provenance BEFORE membership: a host we cannot attribute is denied
+        # even when it is on the allowlist — being on the allowlist is exactly
+        # what an attacker who can set a forwarded header would arrange.
+        unless host_provenance_trusted?(env, host)
+          @logger.warn 'Admin surface access denied: forwarded host from an untrusted peer',
+            {
+              host: host,
+              path: full_path,
+              method: env['REQUEST_METHOD'],
+              note: 'a forwarded host header changed the detected host, but the peer is not a ' \
+                    'configured trusted proxy (site.network.trusted_proxy). Configure it, or set ' \
+                    'ADMIN_ALLOWED_HOSTS=* to turn the host gate off',
+            }
+
+          return true
+        end
+
         return false if host_allowed?(host)
 
         @logger.warn 'Admin surface access denied by host allowlist',
@@ -186,7 +375,53 @@ module Onetime
         true
       end
 
-      # Network (CIDR) gate. Unchanged semantics from before #4062.
+      # Whether the detected host can be attributed to something better than a
+      # client-supplied forwarded header. See the class doc ("Forwarded-host
+      # provenance") for the threat this closes and why the answer is DENY
+      # rather than a fall back to HTTP_HOST.
+      #
+      # @param env [Hash] the Rack env
+      # @param host [String, nil] the normalized detected host
+      # @return [Boolean]
+      def host_provenance_trusted?(env, host)
+        # (a) Operator-configured proxy trust, and this peer passed it. The key
+        # is TRI-STATE (otto#228): written only when trust is configured, so
+        # `== true` — never `!= false` — is the grant-only read.
+        return true if env[Rack::DetectHost::VIA_TRUSTED_PROXY_KEY] == true
+
+        # There is no host to attribute. Not a provenance question:
+        # #host_allowed? denies nil anyway, with the ordinary allowlist WARN,
+        # which is the more accurate line for an operator to read.
+        return true if host.nil? || host.empty?
+
+        # (b) Nothing that could have overridden the Host header is present.
+        return true unless forwarded_host_header?(env)
+
+        # (c) A forwarded header is present but did not change the answer: the
+        # detected host is what the Host header alone would have produced.
+        # Both sides go through DetectHost's OWN extraction before ours, so
+        # this compares what DetectHost compared.
+        host == host_header_host(env)
+      end
+
+      # Whether the request carries any host header DetectHost would honor from
+      # a trusted peer. Presence only — the VALUE is never read here.
+      def forwarded_host_header?(env)
+        FORWARDED_HOST_ENV_KEYS.any? { |key| env.key?(key) }
+      end
+
+      # The host the `Host:` header alone would have produced, normalized
+      # identically to the detected host. A CORROBORATOR, never an input: it is
+      # only ever compared against the detected host, never matched against the
+      # allowlist. See the tryout "HTTP_HOST alone (no detected host at all)
+      # fails closed".
+      def host_header_host(env)
+        normalize_host(Rack::DetectHost.normalize_host(env['HTTP_HOST']))
+      end
+
+      # Network (CIDR) gate. Per-request semantics are unchanged from before
+      # #4062; what changed is when the gate counts as ACTIVE — see
+      # #resolve_network_gate.
       def network_denied?(env, full_path)
         return false unless network_gate_active?
 
@@ -203,11 +438,31 @@ module Onetime
         true
       end
 
-      # Full request path independent of where the app is mounted. Rack::URLMap
+      # Full request path independent of where the app is mounted, canonicalized
+      # the way the Otto router canonicalizes before dispatch. Rack::URLMap
       # moves the mount prefix into SCRIPT_NAME, so PATH_INFO alone would be
       # `/info` inside the colonel API app (mounted at /api/colonel).
+      #
+      # NORMALIZATION IS SECURITY-LOAD-BEARING, not tidiness. The router
+      # dispatches on Otto::Utils.normalize_path, which percent-decodes: it
+      # serves `GET /%63olonel` and `/colonel%2Fsettings` as the admin routes.
+      # Matching the RAW string here (as this did until the #4062 review) let
+      # both spellings miss #colonel_shell?, skip BOTH gates, and then be routed
+      # to the admin console anyway. Same idiom, and the same reasoning, as
+      # HealthAccessControl#health_endpoint? and SessionSkip#skip?.
+      #
+      # Otto::Utils.normalize_path documents that it does not raise (it catches
+      # ArgumentError from Rack::Utils.unescape and scrubs invalid bytes) and
+      # always returns a String. The rescue is for a future in which that stops
+      # being true: a path we cannot canonicalize is treated as an admin
+      # surface, so the failure mode is a denial, never a bypass.
       def request_path(env)
-        "#{env['SCRIPT_NAME']}#{env['PATH_INFO']}"
+        Otto::Utils.normalize_path("#{env['SCRIPT_NAME']}#{env['PATH_INFO']}")
+      rescue StandardError => ex
+        @logger.warn 'Admin surface path normalization failed; judging it as an admin surface',
+          { error: "#{ex.class}: #{ex.message}" }
+
+        UNPARSEABLE_PATH
       end
 
       def admin_surface?(path)
@@ -280,10 +535,83 @@ module Onetime
       # One reader for both site.admin.* lists. Config may be entirely absent
       # (partial boot, specs); an unreadable config must never raise out of
       # this middleware's constructor.
+      #
+      # RETURNS A SENTINEL, NOT nil, ON FAILURE. nil is indistinguishable from
+      # "the operator did not configure this", and that collision is a security
+      # bug: a raising or not-yet-populated OT.conf would silently degrade a
+      # CONFIGURED host gate to the canonical-anchor fallback, and from there to
+      # INACTIVE on any install whose anchors are unroutable — admin served on
+      # every hostname, announced by a boot WARN blaming site.host. The
+      # exception is kept so the eventual log names the real cause instead of
+      # the innocent bystander.
       def site_admin_list(key)
         OT.conf.dig('site', 'admin', key)
-      rescue StandardError
-        nil
+      rescue StandardError => ex
+        @config_read_errors[key] = "#{ex.class}: #{ex.message}"
+        CONFIG_UNREADABLE
+      end
+
+      def unreadable?(value)
+        value.equal?(CONFIG_UNREADABLE)
+      end
+
+      # Resolve the NETWORK gate once at construction.
+      #
+      # @return [Array(Array<IPAddr>, Boolean)] the ranges, and whether the gate
+      #   is active. Empty/unset config leaves it INACTIVE (the self-hosted
+      #   default, unchanged). A configured list that yields no usable range is
+      #   ACTIVE and denying — see #unusable_network_gate.
+      def resolve_network_gate
+        configured = configured_cidrs
+        return unreadable_network_gate if unreadable?(configured)
+
+        entries = Array(configured).map { |cidr| cidr.to_s.strip }.reject(&:empty?)
+        return [[], false] if entries.empty?
+
+        ranges = parse_allowed_cidrs(entries)
+        return [ranges, true] if ranges.any?
+
+        unusable_network_gate(entries)
+      end
+
+      # An operator wrote a CIDR list and not one entry parsed (`100.64.0.0\10`,
+      # a comma that survived splitting, a hostname). Before #4062's review this
+      # deactivated the gate: every WARNed-away entry left the range set empty,
+      # emptiness meant "inactive", and the admin surfaces silently became
+      # reachable from anywhere while the operator believed a VPN restriction
+      # was in force. Same rule as the host gate now — a list an operator wrote
+      # is never silently disabled — and the same deliberate asymmetry with an
+      # EMPTY list, which still means "no network gate".
+      def unusable_network_gate(entries)
+        log_once(:cidrs_unusable, { entries: entries }) do
+          @logger.error 'Admin CIDR allowlist has no usable range; denying both admin surfaces',
+            {
+              entries: entries,
+              surfaces: SURFACES,
+              note: '/colonel and /api/colonel are returning 404 to EVERY request because no entry in ' \
+                    'site.admin.allowed_cidrs parses as a CIDR range. Fix the entries ' \
+                    '(ADMIN_ALLOWED_CIDRS=100.64.0.0/10,10.0.0.0/8) or unset it entirely to leave the ' \
+                    'network gate off',
+            }
+        end
+
+        [[], true]
+      end
+
+      # OT.conf raised while reading site.admin.allowed_cidrs. ACTIVE and
+      # denying: see #site_admin_list for why this is not treated as "unset".
+      def unreadable_network_gate
+        log_once(:cidrs_unreadable, { error: @config_read_errors['allowed_cidrs'] }) do
+          @logger.error 'Cannot read site.admin.allowed_cidrs; denying both admin surfaces',
+            {
+              error: @config_read_errors['allowed_cidrs'],
+              surfaces: SURFACES,
+              note: 'the config could not be READ (this is not an unset value), so both admin gates ' \
+                    'fail closed and /colonel and /api/colonel return 404 to EVERY request',
+            }
+        end
+
+        [[], true]
       end
 
       def parse_allowed_cidrs(value)
@@ -292,7 +620,9 @@ module Onetime
 
           IPAddr.new(cidr.to_s.strip)
         rescue IPAddr::InvalidAddressError
-          @logger.warn "Invalid CIDR in site.admin.allowed_cidrs, skipping: #{cidr}"
+          log_once(:cidr_invalid, { cidr: cidr.to_s }) do
+            @logger.warn "Invalid CIDR in site.admin.allowed_cidrs, skipping: #{cidr}"
+          end
           nil
         end
       end
@@ -305,54 +635,101 @@ module Onetime
       #   gate is active. ACTIVE with an EMPTY allowlist denies everything;
       #   that is the backstop, not an accident.
       def resolve_host_gate
-        configured = Onetime::Utils::AdminHostAllowlist.classify(configured_hosts)
+        raw = configured_hosts
+        return unreadable_host_gate if unreadable?(raw)
+
+        configured = Onetime::Utils::AdminHostAllowlist.classify(raw)
 
         return anchor_host_gate if configured.empty?
-        return wildcard_host_gate if configured.wildcard_only?
+
+        # `*` ANYWHERE in the list turns the gate off, not just as the sole
+        # entry. It is the documented escape hatch and the remedy every
+        # diagnostic in this file recommends; a sibling entry does not make it
+        # ambiguous, it just makes the sibling inert (and named in a WARN).
+        return wildcard_host_gate(configured) if configured.wildcard
 
         configured_host_gate(configured)
       end
 
-      # An operator wrote a list. Enforce whatever survived classification.
-      def configured_host_gate(classified)
-        warn_dropped_wildcard if classified.wildcard
-        warn_rejected_entries(classified.rejected)
-
-        return [classified.hosts, true] if classified.hosts.any?
-
-        # BACKSTOP — normally unreachable: Onetime::Config
-        # .validate_admin_allowed_hosts! refuses this config at boot with a
-        # message naming every rejected entry. Reaching it means that
-        # validation did not run (an embedding that builds a Rack app without
-        # Config.raise_concerns). An explicit allowlist with nothing
-        # enforceable must DENY, never disable itself: the operator's plain
-        # intent was to restrict, and `*` is how you ask for the opposite.
-        # An operator reading this line is debugging an outage, not auditing an
-        # invariant: lead with what is happening to the surfaces, then the
-        # cause, then the remedy.
-        @logger.warn 'Admin host allowlist has no enforceable entry; denying both admin surfaces',
-          {
-            entries: classified.rejected.map(&:first),
-            surfaces: SURFACES,
-            note: '/colonel and /api/colonel are returning 404 to EVERY request because no entry in ' \
-                  'site.admin.allowed_hosts can match a detected host. This config is normally ' \
-                  'rejected at boot, so boot-time validation did not run here. Set ' \
-                  'ADMIN_ALLOWED_HOSTS to a routable hostname, unset it to allow the canonical ' \
-                  'host only, or set it to * to disable the host gate',
-          }
+      # OT.conf raised while reading site.admin.allowed_hosts. ACTIVE and
+      # denying: see #site_admin_list for why this is not treated as "unset".
+      def unreadable_host_gate
+        log_once(:hosts_unreadable, { error: @config_read_errors['allowed_hosts'] }) do
+          @logger.error 'Cannot read site.admin.allowed_hosts; denying both admin surfaces',
+            {
+              error: @config_read_errors['allowed_hosts'],
+              surfaces: SURFACES,
+              note: 'the config could not be READ (this is not an unset value), so the host gate fails ' \
+                    'closed and /colonel and /api/colonel return 404 to EVERY request',
+            }
+        end
 
         [[], true]
       end
 
-      # `*` as the sole entry: the documented escape hatch.
-      def wildcard_host_gate
-        @logger.warn 'Admin host allowlist DISABLED by `*`',
-          {
-            surfaces: SURFACES,
-            note: 'both admin surfaces answer on every hostname the app serves; the CIDR gate is unaffected',
-          }
+      # An operator wrote a list. Enforce whatever survived classification.
+      def configured_host_gate(classified)
+        warn_rejected_entries(classified.rejected)
+
+        return [classified.hosts, true] if classified.hosts.any?
+
+        # THE RUNTIME HALF of the same judgment Onetime::Config
+        # .check_admin_allowed_hosts warns about at boot. An explicit allowlist
+        # with nothing enforceable must DENY, never disable itself: the
+        # operator's plain intent was to restrict, and `*` is how you ask for
+        # the opposite. This is also why that boot check does not have to abort
+        # the process (see it) — the over-exposure it exists to prevent is
+        # already impossible by the time a request arrives.
+        #
+        # An operator reading this line is debugging an outage, not auditing an
+        # invariant: lead with what is happening to the surfaces, then the
+        # cause, then the remedy.
+        log_once(:hosts_unenforceable, { entries: classified.rejected.map(&:first) }) do
+          @logger.warn 'Admin host allowlist has no enforceable entry; denying both admin surfaces',
+            {
+              entries: classified.rejected.map(&:first),
+              surfaces: SURFACES,
+              note: '/colonel and /api/colonel are returning 404 to EVERY request because no entry in ' \
+                    'site.admin.allowed_hosts can match a detected host. Set ADMIN_ALLOWED_HOSTS to a ' \
+                    'routable hostname, unset it to allow the canonical host only, or set it to * to ' \
+                    'disable the host gate',
+            }
+        end
+
+        [[], true]
+      end
+
+      # `*` is listed: the documented escape hatch. Anything beside it is inert
+      # and gets named, so an operator who wrote `*,admin.example.com` learns
+      # the second entry did nothing — without the gate second-guessing the
+      # explicit `*`.
+      def wildcard_host_gate(classified)
+        log_once(:hosts_wildcard, { surfaces: SURFACES }) do
+          @logger.warn 'Admin host allowlist DISABLED by `*`',
+            {
+              surfaces: SURFACES,
+              note: 'both admin surfaces answer on every hostname the app serves; the CIDR gate is unaffected',
+            }
+        end
+
+        warn_ignored_wildcard_siblings(classified) unless classified.wildcard_only?
 
         [[], false]
+      end
+
+      # States only what `*` did to the OTHER entries. Whether those entries
+      # were themselves usable is beside the point: `*` turned the gate off, so
+      # nothing is enforced either way.
+      def warn_ignored_wildcard_siblings(classified)
+        ignored = classified.hosts + classified.rejected.map(&:first)
+
+        log_once(:hosts_wildcard_siblings, { entries: ignored }) do
+          @logger.warn 'Ignoring every other entry in site.admin.allowed_hosts: `*` disables the host gate',
+            {
+              entries: ignored,
+              note: 'remove the `*` to enforce the named hosts',
+            }
+        end
       end
 
       # Nobody configured anything: fall back to the canonical anchors, plus
@@ -371,26 +748,18 @@ module Onetime
         anchors = Onetime::Utils::AdminHostAllowlist.classify(canonical_anchor_hosts)
         return [with_www_variants(anchors.hosts), true] if anchors.hosts.any?
 
-        @logger.warn 'Admin host allowlist INACTIVE: no routable hostname configured',
-          {
-            source: 'canonical anchors',
-            hosts: canonical_anchor_hosts,
-            surfaces: SURFACES,
-            note: 'localhost and bare-IP hosts are never detected as a host; set ADMIN_ALLOWED_HOSTS ' \
-                  '(or site.host / DEFAULT_DOMAIN) to a routable hostname to enable the host gate',
-          }
+        log_once(:hosts_inactive, { hosts: canonical_anchor_hosts }) do
+          @logger.warn 'Admin host allowlist INACTIVE: no routable hostname configured',
+            {
+              source: 'canonical anchors',
+              hosts: canonical_anchor_hosts,
+              surfaces: SURFACES,
+              note: 'localhost and bare-IP hosts are never detected as a host; set ADMIN_ALLOWED_HOSTS ' \
+                    '(or site.host / DEFAULT_DOMAIN) to a routable hostname to enable the host gate',
+            }
+        end
 
         [[], false]
-      end
-
-      # States only what this check decided. Whether anything is left to
-      # enforce is the next check's business — and its answer may be "nothing",
-      # which is why this must not promise that named hosts are enforced.
-      def warn_dropped_wildcard
-        @logger.warn 'Dropped `*` from site.admin.allowed_hosts: it is only honored as the sole entry',
-          {
-            note: 'list `*` alone to disable the host gate',
-          }
       end
 
       # Entries that can never match are dropped, not fatal, as long as
@@ -399,10 +768,14 @@ module Onetime
       def warn_rejected_entries(rejected)
         return if rejected.empty?
 
-        @logger.warn 'Ignoring unusable entries in site.admin.allowed_hosts',
-          {
-            entries: Onetime::Utils::AdminHostAllowlist.describe_rejections(rejected),
-          }
+        described = Onetime::Utils::AdminHostAllowlist.describe_rejections(rejected)
+
+        log_once(:hosts_rejected, { entries: described }) do
+          @logger.warn 'Ignoring unusable entries in site.admin.allowed_hosts',
+            {
+              entries: described,
+            }
+        end
       end
 
       # The fallback allowlist source: the deployment's ANCHOR hosts only —
@@ -418,9 +791,21 @@ module Onetime
         Onetime::Utils::CanonicalHosts.normalized_anchor_hosts
       end
 
-      # Admit the `www.` sibling of each anchor, matching the tolerance
-      # DomainStrategy::Chooserator.equal_to? applies to anchors (and only to
-      # anchors). Neither CanonicalHosts nor DomainParser synthesizes it.
+      # Admit the `www.` SIBLING of each anchor, in both directions: a bare
+      # anchor also admits `www.<anchor>`, and a `www.` anchor also admits the
+      # name with the prefix removed. Neither CanonicalHosts nor DomainParser
+      # synthesizes either form, so it is done here.
+      #
+      # THIS IS NOT DomainStrategy::Chooserator.equal_to? AND MUST NOT BE
+      # "ALIGNED" WITH IT (an earlier version of this comment claimed it was).
+      # That predicate resolves the REGISTRABLE DOMAIN first, so for an anchor
+      # `app.example.com` it admits `www.example.com` — a different site — and
+      # never admits an apex when the anchor is a www host. This method is
+      # purely lexical: `app.example.com` yields `www.app.example.com`, and
+      # `www.example.com` yields `example.com`. Substituting one for the other
+      # silently changes WHICH HOSTS SERVE /colonel in both directions. The
+      # behavior here is pinned by tryouts on purpose; change the tryouts first
+      # if it should ever differ.
       def with_www_variants(hosts)
         expanded = hosts.flat_map do |host|
           if host.start_with?('www.')
@@ -433,9 +818,27 @@ module Onetime
         expanded.uniq
       end
 
+      # Emit a boot log line at most once per process for a given [tag,
+      # payload]. Delegates to the class-level ledger; see .log_once for why
+      # this middleware needs one at all (13 mounted apps, one deployment).
+      #
+      # Names the class EXPLICITLY rather than going through `self.class`: a
+      # subclass (try/unit/middleware's TestAdminNetworkIsolation, or any
+      # embedding that wraps this) would otherwise get a ledger of its own and
+      # the guarantee would silently become once-per-CLASS.
+      def log_once(tag, payload, &)
+        AdminNetworkIsolation.log_once(tag, payload, &)
+      end
+
       # One INFO line per process describing the effective posture of BOTH
       # factors, including when a gate is off — so "off" is distinguishable
       # from "misconfigured" without diffing config against source.
+      #
+      # ONCE PER PROCESS, NOT ONCE PER MOUNT. MiddlewareStack.configure runs for
+      # each of the 13 registered applications, all from the same config; before
+      # the #4062 review this line (and every WARN above it) appeared 13 times
+      # per boot, which reads like 13 separate deployments' worth of
+      # misconfiguration.
       #
       # `trusted_proxy` is on this line, and deliberately not on one of its own:
       # it qualifies the two gate states beside it. Both gates judge inputs that
@@ -443,15 +846,18 @@ module Onetime
       # `host_gate: active` correlated with `trusted_proxy: disabled` is the
       # whole point — see #trusted_proxy_posture.
       def log_boot_posture
-        @logger.info 'Admin surface isolation posture',
-          {
-            host_gate: host_gate_active? ? 'active' : 'inactive',
-            allowed_hosts: @allowed_hosts,
-            network_gate: network_gate_active? ? 'active' : 'inactive',
-            allowed_cidrs: effective_cidrs,
-            trusted_proxy: trusted_proxy_posture,
-            surfaces: SURFACES,
-          }
+        posture = {
+          host_gate: host_gate_active? ? 'active' : 'inactive',
+          allowed_hosts: @allowed_hosts,
+          network_gate: network_gate_active? ? 'active' : 'inactive',
+          allowed_cidrs: effective_cidrs,
+          trusted_proxy: trusted_proxy_posture,
+          surfaces: SURFACES,
+        }
+
+        log_once(:posture, posture) do
+          @logger.info 'Admin surface isolation posture', posture
+        end
       end
 
       # The parsed ranges as an operator would have written them. IPAddr#to_s
@@ -521,49 +927,9 @@ module Onetime
           [
             404,
             { 'Content-Type' => 'text/html; charset=utf-8' },
-            [html_body],
+            [NOT_FOUND_HTML],
           ]
         end
-      end
-
-      def html_body
-        <<~HTML
-          <!DOCTYPE html>
-          <html lang="en">
-            <head>
-              <meta charset="utf-8">
-              <meta name="viewport" content="width=device-width, initial-scale=1">
-              <title>404 Not Found</title>
-              <style>
-                body {
-                  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-                  background-color: #f9fafb;
-                  color: #374151;
-                  margin: 0;
-                  padding: 40px 20px;
-                  text-align: center;
-                }
-                .container {
-                  max-width: 400px;
-                  margin: 0 auto;
-                }
-                h1 {
-                  font-size: 1.5rem;
-                  margin-bottom: 0.5rem;
-                }
-                p {
-                  color: #6b7280;
-                }
-              </style>
-            </head>
-            <body>
-              <div class="container">
-                <h1>404 Not Found</h1>
-                <p>The requested resource was not found.</p>
-              </div>
-            </body>
-          </html>
-        HTML
       end
     end
   end

--- a/lib/onetime/middleware/admin_network_isolation.rb
+++ b/lib/onetime/middleware/admin_network_isolation.rb
@@ -363,6 +363,13 @@ module Onetime
           return true
         end
 
+        # THERE IS NO HOST TO JUDGE — same 404, its own line. Routing this into
+        # the membership WARN below (what it did until the #4098 review) told
+        # the operator their host was rejected BY THE ALLOWLIST, when the
+        # allowlist was never consulted and `host` logged as nil. See
+        # #warn_unresolvable_host.
+        return warn_unresolvable_host(env, full_path, host) if host.nil? || host.empty?
+
         return false if host_allowed?(host)
 
         @logger.warn 'Admin surface access denied by host allowlist',
@@ -370,6 +377,36 @@ module Onetime
             host: host,
             path: full_path,
             method: env['REQUEST_METHOD'],
+          }
+
+        true
+      end
+
+      # The third refusal: the gate is ACTIVE and Rack::DetectHost emitted
+      # nothing to compare against the allowlist.
+      #
+      # The behavior is identical to the other two (404, fail closed); only the
+      # diagnosis differs, and the diagnosis is the entire reason this exists.
+      # The shape that produces it in the field: a single-container install
+      # reached by bare IP whose operator set ADMIN_ALLOWED_HOSTS=10.0.0.5 — an
+      # IP literal, which DetectHost never emits and AdminHostAllowlist
+      # therefore never admits. That list is unenforceable, so the gate is
+      # active with an empty allowlist, the detected host is nil on EVERY
+      # request, and both surfaces 404 forever. Reported as an allowlist
+      # rejection it points the operator at site.admin.allowed_hosts, where
+      # nothing they can write will help.
+      #
+      # @return [true] always; the caller returns it as the denial.
+      def warn_unresolvable_host(env, full_path, host)
+        @logger.warn 'Admin surface access denied: no host could be detected for this request',
+          {
+            host: host,
+            path: full_path,
+            method: env['REQUEST_METHOD'],
+            note: 'Rack::DetectHost emits no host for a bare-IP `Host:` header, for localhost forms, ' \
+                  'or for a malformed name, so site.admin.allowed_hosts was never consulted — no entry ' \
+                  'in it could have matched. Reach the admin surface on a routable hostname the ' \
+                  'allowlist names, or set ADMIN_ALLOWED_HOSTS=* to turn the host gate off',
           }
 
         true
@@ -389,9 +426,12 @@ module Onetime
         # `== true` — never `!= false` — is the grant-only read.
         return true if env[Rack::DetectHost::VIA_TRUSTED_PROXY_KEY] == true
 
-        # There is no host to attribute. Not a provenance question:
-        # #host_allowed? denies nil anyway, with the ordinary allowlist WARN,
-        # which is the more accurate line for an operator to read.
+        # There is no host to attribute, so there is nothing to distrust: a
+        # forwarded header that produced NO host overrode nothing. Not a
+        # provenance question, and deliberately not answered as one — the
+        # caller denies it immediately afterwards through
+        # #warn_unresolvable_host, whose line names the real cause (no host was
+        # detected) instead of blaming a proxy the operator may not have.
         return true if host.nil? || host.empty?
 
         # (b) Nothing that could have overridden the Host header is present.

--- a/lib/onetime/middleware/admin_network_isolation.rb
+++ b/lib/onetime/middleware/admin_network_isolation.rb
@@ -338,9 +338,10 @@ module Onetime
       # #allowed?, and so does one whose detected host cannot be attributed to
       # a trusted peer (see #host_provenance_trusted?).
       #
-      # The denial WARNs are distinct from the network one, and from each
-      # other, so operators can tell the three refusals apart in logs; the
-      # allowlist is never echoed into the response, only into the log.
+      # The three host denials WARN distinctly — from each other and from the
+      # network one, four lines in total — so operators can tell the refusals
+      # apart in logs; the allowlist is never echoed into the response, only
+      # into the log.
       def host_denied?(env, full_path)
         return false unless host_gate_active?
 

--- a/lib/onetime/utils.rb
+++ b/lib/onetime/utils.rb
@@ -4,6 +4,7 @@
 
 require 'pathname'
 
+require_relative 'utils/admin_host_allowlist'
 require_relative 'utils/canonical_hosts'
 require_relative 'utils/domain_parser'
 require_relative 'utils/email_format'

--- a/lib/onetime/utils/admin_host_allowlist.rb
+++ b/lib/onetime/utils/admin_host_allowlist.rb
@@ -1,0 +1,159 @@
+# lib/onetime/utils/admin_host_allowlist.rb
+#
+# frozen_string_literal: true
+
+require_relative '../../middleware/detect_host'
+require_relative 'domain_parser'
+
+module Onetime
+  module Utils
+    # Shared judgment for `site.admin.allowed_hosts` (#4062): which configured
+    # entries can EVER match a request's detected host, and why the others
+    # cannot.
+    #
+    # Two call sites must agree exactly, so the judgment lives in neither:
+    #
+    #   Onetime::Config.validate_admin_allowed_hosts! — refuses to boot when an
+    #     explicitly configured allowlist has nothing enforceable left in it.
+    #     The LOUD path; it owns the operator-facing error text.
+    #   Onetime::Middleware::AdminNetworkIsolation — enforces the surviving
+    #     hosts, and DENIES both admin surfaces if it is ever constructed with
+    #     an explicit allowlist that has nothing enforceable. The backstop, for
+    #     an embedding that builds a Rack app without Config.raise_concerns.
+    #
+    # If those two ever disagreed, the app would either boot into a config the
+    # middleware then refuses to serve, or refuse to boot on a config the
+    # middleware would have served. One classifier, one answer.
+    #
+    # ## What makes an entry unenforceable
+    #
+    # Matching is exact, ASCII-only, against the host Rack::DetectHost
+    # validated. So an entry is rejected when it is a pattern (`*.example.com`
+    # matches nothing — there is no glob matching here), when it is non-ASCII
+    # (this project ships no IDN library; DomainParser.basically_valid? rejects
+    # U-labels, so DetectHost can never emit one), when it does not parse as a
+    # hostname at all, or when it is a host DetectHost would never emit —
+    # `localhost`, `localhost.localdomain`, and every IP literal.
+    #
+    # Routability is judged with DetectHost's OWN predicate (public via its
+    # `extend ClassMethods`) rather than a local copy, so the two cannot drift.
+    module AdminHostAllowlist
+      # Disables the host gate — honored only as the sole entry.
+      WILDCARD = '*'
+
+      # Why an entry was rejected, in the words shown to the operator. Used by
+      # both the boot WARN and the ConfigError: one judgment, one vocabulary.
+      REJECTION_REASONS = {
+        wildcard_pattern: 'wildcard patterns are not supported — list each hostname explicitly',
+        non_ascii: 'non-ASCII — supply the punycode (xn--) form',
+        unparseable: 'not a hostname',
+        not_routable: 'not a routable hostname — localhost forms and IP literals are never detected as a host',
+      }.freeze
+
+      # The outcome of classifying one configured list.
+      #
+      # @!attribute hosts
+      #   @return [Array<String>] normalized entries that can match
+      # @!attribute rejected
+      #   @return [Array<Array(String, Symbol)>] [entry, reason] pairs
+      # @!attribute wildcard
+      #   @return [Boolean] whether a bare `*` was listed
+      Classification = Data.define(:hosts, :rejected, :wildcard) do
+        # Nothing was configured at all (as opposed to configured badly).
+        def empty?
+          hosts.empty? && rejected.empty? && !wildcard
+        end
+
+        # `*` and nothing else: the documented escape hatch.
+        def wildcard_only?
+          wildcard && hosts.empty? && rejected.empty?
+        end
+
+        # Configured, but no entry survives — the fail-loud case.
+        def unenforceable?
+          !empty? && !wildcard_only? && hosts.empty?
+        end
+      end
+
+      class << self
+        # Classify a raw allowlist. Side-effect free: no logging, no raising —
+        # each caller decides what its posture does with the result.
+        #
+        # BLANK ENTRIES ARE SKIPPED, NOT REJECTED — a DELIBERATE asymmetry with
+        # #4063's LINK_DOMAINS, where `LINK_DOMAINS="  "` is a boot error.
+        # ADMIN_ALLOWED_HOSTS="   " classifies as empty?, which sends the gate
+        # to the canonical-anchor fallback: the RESTRICTIVE default. There is no
+        # over-exposure to fail loud about, so a benign typo does not earn a
+        # boot failure. The unenforceable cases are the opposite — an entry that
+        # survives stripping but can never match would leave the operator's
+        # intent to restrict silently unfulfilled — and those DO raise.
+        #
+        # @param raw [Array<String>, String, nil]
+        # @return [Classification]
+        def classify(raw)
+          wildcard = false
+          hosts    = []
+          rejected = []
+
+          Array(raw).each do |value|
+            entry = value.to_s.strip
+            next if entry.empty?
+
+            if entry == WILDCARD
+              wildcard = true
+              next
+            end
+
+            reason = rejection_reason(entry)
+            if reason
+              rejected << [entry, reason]
+            else
+              hosts << normalize_host(entry)
+            end
+          end
+
+          Classification.new(hosts: hosts.uniq, rejected: rejected.uniq, wildcard: wildcard)
+        end
+
+        # Why this entry cannot match, or nil when it can.
+        #
+        # @param entry [String] a stripped, non-empty configured entry
+        # @return [Symbol, nil] a key of REJECTION_REASONS
+        def rejection_reason(entry)
+          return :wildcard_pattern if entry.include?(WILDCARD)
+          return :non_ascii unless entry.ascii_only?
+
+          host = normalize_host(entry)
+          return :unparseable if host.nil?
+          return :not_routable unless Rack::DetectHost.valid_domain_name?(host)
+
+          nil
+        end
+
+        # The single normalization applied to BOTH sides of the comparison:
+        # downcase, strip a `:port` and any scheme (DomainParser), strip a
+        # trailing root dot (ours — `example.com.` is a legal client-supplied
+        # FQDN that DetectHost passes through untouched, and it must match a
+        # configured `example.com`).
+        #
+        # @param value [String, URI, nil]
+        # @return [String, nil]
+        def normalize_host(value)
+          host = DomainParser.extract_hostname(value)
+          return nil if host.nil?
+
+          host = host.sub(/\.+\z/, '')
+          host.empty? ? nil : host
+        end
+
+        # Human-readable "entry: reason" lines for an operator-facing message.
+        #
+        # @param rejected [Array<Array(String, Symbol)>]
+        # @return [Array<String>]
+        def describe_rejections(rejected)
+          rejected.map { |entry, reason| "#{entry.inspect}: #{REJECTION_REASONS.fetch(reason, reason)}" }
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/utils/admin_host_allowlist.rb
+++ b/lib/onetime/utils/admin_host_allowlist.rb
@@ -13,17 +13,17 @@ module Onetime
     #
     # Two call sites must agree exactly, so the judgment lives in neither:
     #
-    #   Onetime::Config.validate_admin_allowed_hosts! — refuses to boot when an
+    #   Onetime::Config.check_admin_allowed_hosts — WARNs at boot when an
     #     explicitly configured allowlist has nothing enforceable left in it.
-    #     The LOUD path; it owns the operator-facing error text.
+    #     The LOUD path; it owns the operator-facing diagnostic text.
     #   Onetime::Middleware::AdminNetworkIsolation — enforces the surviving
-    #     hosts, and DENIES both admin surfaces if it is ever constructed with
-    #     an explicit allowlist that has nothing enforceable. The backstop, for
-    #     an embedding that builds a Rack app without Config.raise_concerns.
+    #     hosts, and DENIES both admin surfaces when it is constructed with an
+    #     explicit allowlist that has nothing enforceable. The RUNTIME half of
+    #     the same judgment: the boot check explains, this denies.
     #
-    # If those two ever disagreed, the app would either boot into a config the
-    # middleware then refuses to serve, or refuse to boot on a config the
-    # middleware would have served. One classifier, one answer.
+    # If those two ever disagreed, the app would boot with a warning about a
+    # config the middleware then serves happily, or deny a config the boot
+    # check called fine. One classifier, one answer.
     #
     # ## What makes an entry unenforceable
     #
@@ -64,14 +64,25 @@ module Onetime
           hosts.empty? && rejected.empty? && !wildcard
         end
 
-        # `*` and nothing else: the documented escape hatch.
+        # `*` and nothing else: the documented escape hatch, written cleanly.
+        # Callers deciding whether the gate is OFF must ask #wildcard, not this
+        # — see #unenforceable?. This narrower predicate exists only to decide
+        # whether there are IGNORED SIBLINGS worth naming in a WARN.
         def wildcard_only?
           wildcard && hosts.empty? && rejected.empty?
         end
 
         # Configured, but no entry survives — the fail-loud case.
+        #
+        # AN EXPLICIT `*` ANYWHERE IN THE LIST MAKES THIS FALSE, whatever else
+        # is listed. `*` is the documented request for "host gate off"; it is
+        # not made ambiguous by a sibling entry, and the sibling is ignored
+        # either way. Reading `wildcard_only?` here instead (as this did before)
+        # classified `ADMIN_ALLOWED_HOSTS="*,10.0.0.5"` as unenforceable — total
+        # deny in the middleware, and formerly a boot abort — while the error
+        # text told the operator to do exactly what they had just done.
         def unenforceable?
-          !empty? && !wildcard_only? && hosts.empty?
+          !empty? && !wildcard && hosts.empty?
         end
       end
 
@@ -84,9 +95,10 @@ module Onetime
         # ADMIN_ALLOWED_HOSTS="   " classifies as empty?, which sends the gate
         # to the canonical-anchor fallback: the RESTRICTIVE default. There is no
         # over-exposure to fail loud about, so a benign typo does not earn a
-        # boot failure. The unenforceable cases are the opposite — an entry that
+        # diagnostic. The unenforceable cases are the opposite — an entry that
         # survives stripping but can never match would leave the operator's
-        # intent to restrict silently unfulfilled — and those DO raise.
+        # intent to restrict silently unfulfilled — and those DO warn loudly at
+        # boot and deny both surfaces at runtime.
         #
         # @param raw [Array<String>, String, nil]
         # @return [Classification]

--- a/lib/onetime/utils/admin_host_allowlist.rb
+++ b/lib/onetime/utils/admin_host_allowlist.rb
@@ -38,7 +38,9 @@ module Onetime
     # Routability is judged with DetectHost's OWN predicate (public via its
     # `extend ClassMethods`) rather than a local copy, so the two cannot drift.
     module AdminHostAllowlist
-      # Disables the host gate — honored only as the sole entry.
+      # Disables the host gate. Honored ANYWHERE in the list, not only as the
+      # sole entry — see Classification#unenforceable? for why a sibling entry
+      # does not make it ambiguous.
       WILDCARD = '*'
 
       # Why an entry was rejected, in the words shown to the operator. Used by

--- a/lib/onetime/utils/admin_host_allowlist.rb
+++ b/lib/onetime/utils/admin_host_allowlist.rb
@@ -131,14 +131,24 @@ module Onetime
 
         # Why this entry cannot match, or nil when it can.
         #
+        # THE WILDCARD TEST READS THE NORMALIZED HOST, NOT THE RAW ENTRY. A
+        # scheme, port, path and trailing slash are all accepted shapes here
+        # (see #normalize_host), so scanning the raw string for `*` rejected
+        # `https://admin.example.com/*` — an entry whose HOSTNAME is perfectly
+        # enforceable — and told the operator "wildcard patterns are not
+        # supported" about a hostname containing no wildcard. A pattern in the
+        # host itself (`*.example.com`) survives normalization unchanged and is
+        # still rejected here; a bare `*` never reaches this method at all,
+        # having been taken as the escape hatch in #classify.
+        #
         # @param entry [String] a stripped, non-empty configured entry
         # @return [Symbol, nil] a key of REJECTION_REASONS
         def rejection_reason(entry)
-          return :wildcard_pattern if entry.include?(WILDCARD)
           return :non_ascii unless entry.ascii_only?
 
           host = normalize_host(entry)
           return :unparseable if host.nil?
+          return :wildcard_pattern if host.include?(WILDCARD)
           return :not_routable unless Rack::DetectHost.valid_domain_name?(host)
 
           nil

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "test:rspec:apps:web:billing": "bundle exec rake spec:apps:web_billing",
     "test:rspec:apps:web:core": "bundle exec rake spec:apps:web_core",
     "test:rspec:apps:internal:acme": "bundle exec rake spec:apps:internal_acme",
-    "test:tryouts": "RACK_ENV=test bundle exec try",
+    "test:tryouts": "RACK_ENV=test RUBYOPT=\"-EUTF-8 ${RUBYOPT:-}\" bundle exec try",
     "test:tryouts:agent": "pnpm test:tryouts --agent",
     "test:tryouts:failures": "pnpm test:tryouts --stack --fails --debug",
     "test:tryouts:clean": "pnpm test:database:clean && pnpm test:tryouts",

--- a/spec/integration/all/colonel_host_allowlist_spec.rb
+++ b/spec/integration/all/colonel_host_allowlist_spec.rb
@@ -642,15 +642,50 @@ RSpec.describe 'Colonel admin surface host allowlist (#4062)', type: :integratio
 
       expect(last_response.status).to eq(403)
     end
+
+    # #4062 review, F5: `*` beside anything else is still `*`. The operator who
+    # follows the diagnostic ("set it to *") without deleting the entry that
+    # produced it gets the gate they asked for, not a blanket 404 — and the
+    # process still boots (Onetime::Config.check_admin_allowed_hosts stays
+    # silent for it, see spec/unit/onetime/config/admin_allowed_hosts_spec.rb).
+    context 'with `*` beside an unenforceable entry' do
+      before do
+        configure_admin!(
+          allowed_hosts: ['*', '10.0.0.5'],
+          default_domain: 'example.com',
+          site_host: 'example.com',
+        )
+      end
+
+      it 'serves a colonel on a non-canonical host' do
+        signed_in_as(colonel)
+        get_api('tenant.example.com')
+
+        expect(last_response.status).to eq(200)
+      end
+
+      it 'serves the shell too' do
+        signed_in_as(colonel)
+        get_shell('tenant.example.com')
+
+        expect(last_response.status).to eq(200)
+      end
+
+      it 'still refuses an anonymous caller at the role gate' do
+        anonymous!
+        get_api('tenant.example.com')
+
+        expect(last_response.status).to eq(401)
+      end
+    end
   end
 
   # ===========================================================================
-  # 8. The fail-closed backstop: an explicit list with nothing enforceable
+  # 8. The fail-closed enforcement: an explicit list with nothing enforceable
   # ===========================================================================
-  # Onetime::Config.validate_admin_allowed_hosts! normally refuses this config
-  # at boot (spec/unit/onetime/config/admin_allowed_hosts_spec.rb). Reaching
-  # the middleware with it means that validation did not run — an embedding
-  # that builds a Rack app without Config.raise_concerns. It must DENY, not
+  # Onetime::Config.check_admin_allowed_hosts WARNs about this config at boot
+  # (spec/unit/onetime/config/admin_allowed_hosts_spec.rb) but does not stop the
+  # process — the denial below is what makes that safe. It must DENY, not
   # disable itself: the operator's plain intent was to restrict.
   describe 'with an explicit allowed_hosts that names nothing enforceable' do
     before do
@@ -732,9 +767,74 @@ RSpec.describe 'Colonel admin surface host allowlist (#4062)', type: :integratio
       end
     end
 
+    # A PERCENT-ENCODED admin path is still an admin path. The Otto router
+    # dispatches on Otto::Utils.normalize_path, which decodes first, so a gate
+    # that matched the raw SCRIPT_NAME+PATH_INFO would skip both gates and then
+    # hand the request to the admin console anyway (#4062 review, F1).
+    describe 'percent-encoded spellings of the admin paths' do
+      before { configure_admin!(default_domain: 'example.com', site_host: 'example.com') }
+
+      it '404s /%63olonel on a denied host' do
+        signed_in_as(colonel)
+        header 'Host', 'tenant.example.com'
+        get '/%63olonel'
+
+        expect(last_response.status).to eq(404)
+      end
+
+      it '404s /colonel%2Fsettings on a denied host' do
+        signed_in_as(colonel)
+        header 'Host', 'tenant.example.com'
+        get '/colonel%2Fsettings'
+
+        expect(last_response.status).to eq(404)
+      end
+
+      it '404s an encoded admin API path on a denied host' do
+        signed_in_as(colonel)
+        header 'Host', 'tenant.example.com'
+        get '/api/colonel/%69nfo'
+
+        expect(last_response.status).to eq(404)
+      end
+
+      it '404s an encoded admin path from outside the CIDR allowlist' do
+        configure_admin!(
+          allowed_hosts: ['*'],
+          allowed_cidrs: ['10.0.0.0/8'],
+          default_domain: 'example.com',
+          site_host: 'example.com',
+        )
+        signed_in_as(colonel)
+        header 'Host', 'example.com'
+        get '/%63olonel', {}, 'REMOTE_ADDR' => '203.0.113.9'
+
+        expect(last_response.status).to eq(404)
+      end
+
+      # Control: the encoded spelling really does reach the admin console once
+      # the gate is off — otherwise the 404s above would only prove that the
+      # router does not serve it either.
+      it 'serves the encoded path on an allowlisted host (control)' do
+        signed_in_as(colonel)
+        header 'Host', 'example.com'
+        header 'Accept', 'application/json'
+        get '/api/colonel/%69nfo'
+
+        expect(last_response.status).to eq(200)
+        expect(json_body).to have_key('details')
+      end
+    end
+
     describe 'forwarded host headers from an untrusted peer' do
+      # Neither of these is a TRUSTED peer for the admin gate. Loopback is what
+      # Rack::DetectHost's legacy heuristic trusts when site.network.trusted_proxy
+      # is unset — which is every containerised install, and is exactly the
+      # weakness (#4024) the gate refuses to rely on. Genuine trust is otto's
+      # tri-state key, below.
       let(:untrusted_peer) { { 'REMOTE_ADDR' => '203.0.113.9' } }
-      let(:trusted_peer)   { { 'REMOTE_ADDR' => '127.0.0.1' } }
+      let(:heuristic_peer) { { 'REMOTE_ADDR' => '127.0.0.1' } }
+      let(:trusted_peer)   { { 'REMOTE_ADDR' => '127.0.0.1', 'otto.via_trusted_proxy' => true } }
 
       before { configure_admin!(default_domain: 'example.com', site_host: 'example.com') }
 
@@ -773,21 +873,70 @@ RSpec.describe 'Colonel admin surface host allowlist (#4062)', type: :integratio
         expect(gate_html_denial?).to be true
       end
 
-      # Control: the SAME header from a trusted (loopback) peer IS honoured by
-      # Rack::DetectHost. Without this the tests above could pass simply
-      # because forwarded host headers are inert in this stack.
-      it 'DOES honour X-Forwarded-Host from a trusted peer (control)' do
+      # THE #4062-review case (F2). Rack::DetectHost DOES honour this header
+      # from a loopback peer with no trusted_proxy configured — the control two
+      # examples down proves it — so before the fix this served the admin
+      # console to anything that could open a connection from a private address
+      # while claiming to be the canonical host.
+      it 'ignores X-Forwarded-Host from a loopback peer when no proxy trust is configured' do
+        signed_in_as(colonel)
+        get_api('tenant.example.com', heuristic_peer.merge('HTTP_X_FORWARDED_HOST' => 'example.com'))
+
+        expect(last_response.status).to eq(404)
+      end
+
+      it 'ignores Apx-Incoming-Host from a loopback peer when no proxy trust is configured' do
+        signed_in_as(colonel)
+        get_api('tenant.example.com', heuristic_peer.merge('HTTP_APX_INCOMING_HOST' => 'example.com'))
+
+        expect(last_response.status).to eq(404)
+      end
+
+      # Control: the header IS live in this stack — Rack::DetectHost really
+      # does read it from a loopback peer with no trusted_proxy configured, and
+      # DomainStrategy classifies the request by what it read. Without this the
+      # two examples above could pass simply because forwarded host headers do
+      # nothing here, which would be evidence about the stack, not the gate.
+      it 'is genuinely honoured by Rack::DetectHost from a loopback peer (control)' do
+        configure_admin!(default_domain: 'example.com', site_host: 'example.com', domains_enabled: true)
+        anonymous!
+        header 'Host', 'tenant.example.com'
+        get NON_ADMIN_PATH, {}, heuristic_peer.merge('HTTP_X_FORWARDED_HOST' => 'example.com')
+
+        expect(last_response.status).to eq(200)
+        # :canonical is only reachable here if the forwarded header replaced
+        # the tenant Host header.
+        expect(last_response.headers['O-Domain-Strategy']).to eq('canonical')
+      end
+
+      # Control: with otto's trust key set — the operator configured
+      # site.network.trusted_proxy and this peer passed it — the forwarded host
+      # IS accepted. Trust widens what may be read.
+      it 'DOES honour X-Forwarded-Host from a peer otto vouched for (control)' do
         signed_in_as(colonel)
         get_api('tenant.example.com', trusted_peer.merge('HTTP_X_FORWARDED_HOST' => 'example.com'))
 
         expect(last_response.status).to eq(200)
       end
 
-      it 'DOES honour Apx-Incoming-Host from a trusted peer (control)' do
+      it 'DOES honour Apx-Incoming-Host from a peer otto vouched for (control)' do
         signed_in_as(colonel)
         get_api('tenant.example.com', trusted_peer.merge('HTTP_APX_INCOMING_HOST' => 'example.com'))
 
         expect(last_response.status).to eq(200)
+      end
+
+      # otto.via_trusted_proxy is tri-state: present-and-false means trust IS
+      # configured and this peer FAILED it — strictly worse than absent.
+      it 'refuses a forwarded host when otto explicitly distrusted the peer' do
+        signed_in_as(colonel)
+        get_api(
+          'tenant.example.com',
+          { 'REMOTE_ADDR' => '127.0.0.1', 'otto.via_trusted_proxy' => false,
+            'HTTP_X_FORWARDED_HOST' => 'example.com' },
+        )
+
+        expect(last_response.status).to eq(404)
       end
 
       # The mirror image of the control: a trusted peer forwarding a
@@ -798,6 +947,16 @@ RSpec.describe 'Colonel admin surface host allowlist (#4062)', type: :integratio
         get_api('example.com', trusted_peer.merge('HTTP_X_FORWARDED_HOST' => 'tenant.example.com'))
 
         expect(last_response.status).to eq(404)
+      end
+
+      # A forwarded header that AGREES with the Host header changed nothing, so
+      # there is nothing to distrust — the ordinary `proxy_set_header Host $host`
+      # topology keeps working with no trusted_proxy configured.
+      it 'admits a loopback peer whose forwarded header agrees with the Host header' do
+        signed_in_as(colonel)
+        get_api('example.com', heuristic_peer.merge('HTTP_X_FORWARDED_HOST' => 'example.com'))
+
+        expect(last_response.status).to eq(200)
       end
 
       # And the inverse control: an untrusted peer on an ALLOWLISTED Host still

--- a/spec/integration/all/colonel_host_allowlist_spec.rb
+++ b/spec/integration/all/colonel_host_allowlist_spec.rb
@@ -1,0 +1,813 @@
+# spec/integration/all/colonel_host_allowlist_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration (Rack-level, real middleware stack, real Valkey)
+# =============================================================================
+#
+# #4062: the Colonel admin surfaces (/colonel shell + /api/colonel API) are
+# bound to an explicit HOST allowlist, enforced by
+# Onetime::Middleware::AdminNetworkIsolation. A request whose detected host is
+# not on the list gets a 404 — indistinguishable-from-absent, for authenticated
+# colonels and anonymous callers alike.
+#
+# These are FULL-STACK request specs: the app under test is the real
+# Rack::URLMap the server boots, so AdminNetworkIsolation is exercised in its
+# real position (below Rack::DetectHost, above Onetime::Session and
+# DomainStrategy) with a real detected host derived from the Host header.
+#
+# Mode-agnostic on purpose. The gate reads config and the detected host only —
+# nothing in it varies with AUTHENTICATION_MODE — and the assertions below are
+# written against behaviour that is identical in every mode. Running it in
+# every lane is the point: it is the same guard in all of them.
+#
+# WHY EVERY DENIAL CASE HAS A GATE-OFF CONTROL
+#
+# A 404 is a weak signal on its own — an unmatched route produces one too. Each
+# denial group is therefore paired with the SAME request against a stack built
+# with the `*` escape hatch, which must produce the ordinary served response.
+# If the gate were deleted the controls would stay green and the denials would
+# go red.
+#
+# TWO PIECES OF STATE ARE RESOLVED AT CONSTRUCTION, NOT PER REQUEST
+#
+#   1. AdminNetworkIsolation resolves both allowlists in #initialize, and
+#      DomainStrategy loads its class state there too. Writing OT.conf after
+#      the Rack app is built has no effect: `configure_admin!` drops the
+#      memoized app so the next request builds a stack that read the new config.
+#   2. The custom-domains FEATURE flag is not read from OT.conf at request time
+#      at all — DomainStrategy#call asks Onetime::Runtime.features.domains?,
+#      which the ConfigureDomains initializer sets once at boot. Flipping
+#      OT.conf['features']['domains']['enabled'] alone leaves the whole
+#      override/classification branch dead, which silently turns the
+#      O-Domain-Context spoofing tests below into assertions about nothing.
+#      configure_admin! therefore writes Runtime state too, and restores it.
+#
+# RUN (mode-agnostic — runs in every mode lane):
+#   tests/lanes/run simple
+#   tests/lanes/run full-sqlite
+#   tests/lanes/run disabled
+#
+# Requires Valkey on port 2163 (pnpm run test:database:start).
+#
+# =============================================================================
+
+require_relative '../../spec_helper'
+require_relative '../integration_spec_helper'
+
+RSpec.describe 'Colonel admin surface host allowlist (#4062)', type: :integration do
+  include Rack::Test::Methods
+
+  before(:all) do
+    require 'onetime'
+    Onetime.boot! :test
+    # Without this, Rack::URLMap has no /api/* entries and every API request
+    # 404s at the map level — which would look exactly like a host denial and
+    # pass vacuously.
+    Onetime::Application::Registry.prepare_application_registry
+  end
+
+  # Restore every piece of state these examples write. DomainStrategy caches its
+  # own class state from the same config at app-construction time, so the final
+  # restore also rebuilds one stack: that re-runs initialize_from_config
+  # against the pristine config and leaves no cross-file residue.
+  before do
+    @orig_admin      = OT.conf.dig('site', 'admin')&.dup
+    @orig_site_host  = OT.conf.dig('site', 'host')
+    @orig_domains    = OT.conf.dig('features', 'domains')&.dup
+    @orig_developmnt = OT.conf['development']&.dup
+    @orig_features   = Onetime::Runtime.features
+  end
+
+  after do
+    OT.conf['site']['admin']        = @orig_admin if @orig_admin
+    OT.conf['site']['host']         = @orig_site_host
+    OT.conf['features']['domains']  = @orig_domains if @orig_domains
+    OT.conf['development']          = @orig_developmnt if @orig_developmnt
+    Onetime::Runtime.features       = @orig_features
+    Onetime::Application::Registry.generate_rack_url_map
+  end
+
+  def app
+    @app ||= Onetime::Application::Registry.generate_rack_url_map
+  end
+
+  # Write every input the two gates and DomainStrategy read, then drop the
+  # memoized app. Defaults describe a stock canonical deployment with the
+  # allowlist unset, i.e. the anchor fallback.
+  def configure_admin!(allowed_hosts: [], allowed_cidrs: [], site_host: 'example.com',
+                       default_domain: 'example.com', link_domains: nil,
+                       domains_enabled: false, domain_context: false)
+    OT.conf['site']['admin'] = {
+      'allowed_hosts' => allowed_hosts,
+      'allowed_cidrs' => allowed_cidrs,
+    }
+    OT.conf['site']['host'] = site_host
+
+    domains                 = (OT.conf['features']['domains'] || {}).dup
+    domains['enabled']      = domains_enabled
+    domains['default']      = default_domain
+    domains['link_domains'] = link_domains
+    OT.conf['features']['domains'] = domains
+
+    development = (OT.conf['development'] || {}).dup
+    development['domain_context_enabled'] = domain_context
+    OT.conf['development'] = development
+
+    # The request path reads the FEATURE flag from Runtime, not OT.conf. See
+    # the header note; without this the domains branch never executes.
+    Onetime::Runtime.update_features(domains_enabled: domains_enabled)
+
+    @app = nil
+    reset_rack_test_session!
+  end
+
+  # Rack::Test::Methods memoizes a Session around the app the FIRST time a
+  # request is made in an example, so dropping @app alone is not enough to
+  # reconfigure MID-example: the session would keep serving the old stack and
+  # the new config would silently never apply. Drop the memo too.
+  def reset_rack_test_session!
+    @_rack_test_sessions        = nil
+    @_rack_test_current_session = nil
+  end
+
+  # A route on the SAME stack that the admin gate must never touch. Used as the
+  # "this vhost is reachable, it is the admin surface specifically that is
+  # absent" control; it is public, so it needs no session.
+  NON_ADMIN_PATH = '/api/v2/status'
+
+  # ---------------------------------------------------------------------------
+  # Principals. Real Customer records, so the role gates beneath the middleware
+  # are the real ones. Created inside the example (type: :integration flushes
+  # Valkey before each).
+  # ---------------------------------------------------------------------------
+  def create_customer(role:)
+    cust          = Onetime::Customer.create!(email: "#{role}-#{SecureRandom.hex(4)}@example.com")
+    cust.role     = role
+    cust.verified = 'true'
+    cust.save
+    cust
+  end
+
+  let(:colonel) { create_customer(role: 'colonel') }
+  let(:regular) { create_customer(role: 'customer') }
+
+  # Otto's session auth strategy reads env['rack.session']; injecting the hash
+  # is the established pattern here (spec/integration/full/admin_interface_spec.rb).
+  def signed_in_as(user)
+    env 'rack.session', {
+      'external_id' => user.extid,
+      'authenticated' => true,
+      'session_id' => SecureRandom.hex(16),
+    }
+  end
+
+  def anonymous!
+    env 'rack.session', nil
+    clear_cookies
+  end
+
+  # ---------------------------------------------------------------------------
+  # Requests. `Host:` is what Rack::DetectHost validates into
+  # env['rack.detected_host'], which is the only host input the gate reads.
+  # ---------------------------------------------------------------------------
+  def get_shell(host, rack_env = {})
+    header 'Host', host
+    header 'Accept', 'text/html'
+    get '/colonel', {}, rack_env
+  end
+
+  def get_api(host, rack_env = {})
+    header 'Host', host
+    header 'Accept', 'application/json'
+    get '/api/colonel/info', {}, rack_env
+  end
+
+  # The gate's HTML body, distinct from the SPA shell the real /colonel serves.
+  def gate_html_denial?
+    last_response.status == 404 &&
+      last_response.headers['content-type'] == 'text/html; charset=utf-8' &&
+      last_response.body.include?('404 Not Found')
+  end
+
+  def json_body
+    JSON.parse(last_response.body)
+  end
+
+  # A real verified tenant domain owned by `owner`. The host gate does not
+  # consult CustomDomain rows — it judges the detected host alone — but the AC
+  # names this case, and a real row is what makes the gate-off control an
+  # honest statement about a domain the deployment genuinely serves.
+  def create_verified_custom_domain(owner, fqdn)
+    org             = Onetime::Organization.create!("Tenant #{SecureRandom.hex(4)}", owner)
+    domain          = Onetime::CustomDomain.create!(fqdn, org.objid)
+    domain.verified = 'true'
+    domain.save
+    domain
+  end
+
+  # ===========================================================================
+  # 1. Default config (allowed_hosts unset) — canonical anchors only
+  # ===========================================================================
+  describe 'with allowed_hosts unset (canonical anchor fallback)' do
+    before { configure_admin!(default_domain: 'example.com', site_host: 'example.com') }
+
+    context 'on the canonical host' do
+      it 'serves the shell to a colonel, exactly as before #4062' do
+        signed_in_as(colonel)
+        get_shell('example.com')
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.headers['content-type']).to match(%r{text/html})
+        expect(last_response.body).to include('<!doctype html')
+      end
+
+      it 'serves the API to a colonel' do
+        signed_in_as(colonel)
+        get_api('example.com')
+
+        expect(last_response.status).to eq(200)
+        expect(json_body).to have_key('details')
+      end
+
+      # The role gates beneath the middleware are untouched: an unauthorized
+      # caller on an ALLOWLISTED host must still be refused BY THEM (a redirect
+      # or a 401/403), never by the host gate's 404. This is the "behaviour is
+      # exactly as today on an allowlisted host" half of the contract.
+      it 'still refuses an anonymous caller at the ROLE gate, not the host gate' do
+        anonymous!
+        get_shell('example.com')
+
+        expect(last_response.status).not_to eq(404)
+        expect(gate_html_denial?).to be false
+      end
+
+      it 'still 401s an anonymous API caller at the role gate' do
+        anonymous!
+        get_api('example.com')
+
+        expect(last_response.status).to eq(401)
+      end
+
+      it 'still 403s a non-colonel API caller at the role gate' do
+        signed_in_as(regular)
+        get_api('example.com')
+
+        expect(last_response.status).to eq(403)
+      end
+    end
+
+    context 'on the www. variant of the canonical host' do
+      it 'serves the shell to a colonel' do
+        signed_in_as(colonel)
+        get_shell('www.example.com')
+
+        expect(last_response.status).to eq(200)
+      end
+
+      it 'serves the API to a colonel' do
+        signed_in_as(colonel)
+        get_api('www.example.com')
+
+        expect(last_response.status).to eq(200)
+      end
+
+      it 'keeps the role gate in place there too' do
+        signed_in_as(regular)
+        get_api('www.example.com')
+
+        expect(last_response.status).to eq(403)
+      end
+    end
+
+    context 'on a subdomain of the canonical host' do
+      it '404s the shell for a colonel' do
+        signed_in_as(colonel)
+        get_shell('tenant.example.com')
+
+        expect(gate_html_denial?).to be true
+      end
+
+      it '404s the API for a colonel' do
+        signed_in_as(colonel)
+        get_api('tenant.example.com')
+
+        expect(last_response.status).to eq(404)
+        expect(last_response.headers['content-type']).to eq('application/json')
+        expect(json_body).to eq('error' => 'Not Found')
+      end
+
+      it '404s an anonymous caller too — no redirect, no 401' do
+        anonymous!
+        get_shell('tenant.example.com')
+        expect(last_response.status).to eq(404)
+
+        get_api('tenant.example.com')
+        expect(last_response.status).to eq(404)
+      end
+
+      it '404s a non-colonel — the host gate answers before the role gate' do
+        signed_in_as(regular)
+        get_api('tenant.example.com')
+
+        expect(last_response.status).to eq(404)
+      end
+    end
+
+    context 'on an unrelated host' do
+      it '404s both surfaces for a colonel' do
+        signed_in_as(colonel)
+
+        get_shell('unknown.example.org')
+        expect(last_response.status).to eq(404)
+
+        get_api('unknown.example.org')
+        expect(last_response.status).to eq(404)
+      end
+
+      it '404s both surfaces for an anonymous caller' do
+        anonymous!
+
+        get_shell('unknown.example.org')
+        expect(last_response.status).to eq(404)
+
+        get_api('unknown.example.org')
+        expect(last_response.status).to eq(404)
+      end
+
+      # Control: the SAME host with the gate off is served normally, so the
+      # 404s above are the gate's doing and not a routing accident.
+      it 'serves the same host once the gate is off (control)' do
+        configure_admin!(allowed_hosts: ['*'], default_domain: 'example.com', site_host: 'example.com')
+        signed_in_as(colonel)
+        get_api('unknown.example.org')
+
+        expect(last_response.status).to eq(200)
+      end
+    end
+
+    # A /colonel or /api/colonel SUBPATH is gated identically; nothing about
+    # the match depends on the exact endpoint.
+    context 'on subpaths' do
+      it 'gates /api/colonel/stats the same way' do
+        signed_in_as(colonel)
+        header 'Host', 'tenant.example.com'
+        get '/api/colonel/stats'
+
+        expect(last_response.status).to eq(404)
+      end
+
+      it 'leaves a NON-admin path untouched on a denied host' do
+        anonymous!
+        header 'Host', 'tenant.example.com'
+        get NON_ADMIN_PATH
+
+        expect(last_response.status).to eq(200)
+      end
+    end
+  end
+
+  # ===========================================================================
+  # 2. A verified tenant custom domain, with the domains feature ON
+  # ===========================================================================
+  # The AC names this case specifically: features.domains.enabled = true and a
+  # real verified CustomDomain row. DomainStrategy classifies that host
+  # :custom, and the admin surfaces must still be absent on it.
+  describe 'with features.domains.enabled and a verified custom domain' do
+    let(:tenant_host) { 'secrets.tenant-example.com' }
+
+    before do
+      configure_admin!(
+        default_domain: 'example.com',
+        site_host: 'example.com',
+        domains_enabled: true,
+      )
+      create_verified_custom_domain(colonel, tenant_host)
+    end
+
+    it '404s the shell on the tenant domain for a colonel' do
+      signed_in_as(colonel)
+      get_shell(tenant_host)
+
+      expect(gate_html_denial?).to be true
+    end
+
+    it '404s the API on the tenant domain for a colonel' do
+      signed_in_as(colonel)
+      get_api(tenant_host)
+
+      expect(last_response.status).to eq(404)
+      expect(json_body).to eq('error' => 'Not Found')
+    end
+
+    it '404s the tenant domain for an anonymous caller' do
+      anonymous!
+      get_api(tenant_host)
+
+      expect(last_response.status).to eq(404)
+    end
+
+    it 'still serves the canonical host, so the gate is active and not blanket-denying' do
+      signed_in_as(colonel)
+      get_api('example.com')
+
+      expect(last_response.status).to eq(200)
+    end
+
+    # Control: the tenant host IS a host this deployment serves and classifies
+    # :custom. Without this the 404s above could mean "that vhost reaches
+    # nothing at all", which would be evidence about routing, not the gate.
+    it 'serves the tenant domain — classified :custom — once the gate is off (control)' do
+      configure_admin!(
+        allowed_hosts: ['*'],
+        default_domain: 'example.com',
+        site_host: 'example.com',
+        domains_enabled: true,
+      )
+      signed_in_as(colonel)
+      get_api(tenant_host)
+
+      expect(last_response.status).to eq(200)
+      expect(last_response.headers['O-Domain-Strategy']).to eq('custom')
+    end
+  end
+
+  # ===========================================================================
+  # 3. A features.domains.link_domains pool member is NOT an admin host (#4063)
+  # ===========================================================================
+  describe 'with a link_domains pool configured' do
+    before do
+      configure_admin!(
+        default_domain: 'example.com',
+        site_host: 'example.com',
+        link_domains: ['links.example.net'],
+        domains_enabled: true,
+      )
+    end
+
+    it 'classifies the pool member as canonical (the config really took)' do
+      expect(Onetime::Utils::CanonicalHosts.normalized_hosts).to include('links.example.net')
+    end
+
+    it '404s the admin API on a link-pool domain' do
+      signed_in_as(colonel)
+      get_api('links.example.net')
+
+      expect(last_response.status).to eq(404)
+    end
+
+    it '404s the admin shell on a link-pool domain' do
+      signed_in_as(colonel)
+      get_shell('links.example.net')
+
+      expect(gate_html_denial?).to be true
+    end
+
+    it 'still serves the anchor host' do
+      signed_in_as(colonel)
+      get_api('example.com')
+
+      expect(last_response.status).to eq(200)
+    end
+
+    # Control: the pool member is a fully served, :canonical-classified host —
+    # it is the ADMIN surface specifically that is absent on it.
+    it 'serves a non-admin endpoint on the link-pool domain (control)' do
+      anonymous!
+      header 'Host', 'links.example.net'
+      get NON_ADMIN_PATH
+
+      expect(last_response.status).to eq(200)
+      expect(last_response.headers['O-Domain-Strategy']).to eq('canonical')
+    end
+  end
+
+  # ===========================================================================
+  # 4. An explicit allowed_hosts list is taken LITERALLY
+  # ===========================================================================
+  describe 'with an explicit site.admin.allowed_hosts' do
+    before do
+      configure_admin!(
+        allowed_hosts: ['admin.example.com'],
+        default_domain: 'example.com',
+        site_host: 'example.com',
+      )
+    end
+
+    it 'serves the named admin host' do
+      signed_in_as(colonel)
+      get_api('admin.example.com')
+
+      expect(last_response.status).to eq(200)
+    end
+
+    it 'keeps the role gate in place on the named admin host' do
+      signed_in_as(regular)
+      get_api('admin.example.com')
+
+      expect(last_response.status).to eq(403)
+    end
+
+    it 'does NOT synthesize a www. variant of an explicit entry' do
+      signed_in_as(colonel)
+      get_api('www.admin.example.com')
+
+      expect(last_response.status).to eq(404)
+    end
+
+    it 'replaces the anchor fallback — the canonical host is no longer admitted' do
+      signed_in_as(colonel)
+      get_api('example.com')
+
+      expect(last_response.status).to eq(404)
+    end
+  end
+
+  # ===========================================================================
+  # 5. Denial shape, and where in the stack the denial happens
+  # ===========================================================================
+  describe 'the denial response' do
+    before { configure_admin!(default_domain: 'example.com', site_host: 'example.com') }
+
+    it 'serves the gate 404 page, not the SPA shell, on /colonel' do
+      signed_in_as(colonel)
+      get_shell('tenant.example.com')
+
+      expect(last_response.body).to include('404 Not Found')
+      expect(last_response.body).not_to include('<!doctype html')
+    end
+
+    it 'carries no DomainStrategy headers — the gate short-circuits above it' do
+      signed_in_as(colonel)
+      get_api('tenant.example.com')
+
+      expect(last_response.headers).not_to have_key('O-Domain-Strategy')
+    end
+
+    it 'DOES carry DomainStrategy headers on an admitted host (control)' do
+      signed_in_as(colonel)
+      get_api('example.com')
+
+      expect(last_response.headers['O-Domain-Strategy']).to eq('canonical')
+    end
+
+    it 'sets no session cookie on a denial — the gate runs above Onetime::Session' do
+      anonymous!
+      get_api('tenant.example.com')
+
+      expect(last_response.headers['set-cookie']).to be_nil
+    end
+
+    # Host denials and CIDR denials must be byte-identical: operators tell them
+    # apart by the log line, clients cannot tell them apart at all.
+    it 'is byte-identical to a CIDR denial on the same surface' do
+      signed_in_as(colonel)
+      get_api('tenant.example.com')
+      host_denial = [last_response.status, last_response.headers.to_h, last_response.body]
+
+      configure_admin!(
+        allowed_hosts: ['*'],
+        allowed_cidrs: ['10.0.0.0/8'],
+        default_domain: 'example.com',
+        site_host: 'example.com',
+      )
+      signed_in_as(colonel)
+      get_api('example.com', 'REMOTE_ADDR' => '203.0.113.9')
+      cidr_denial = [last_response.status, last_response.headers.to_h, last_response.body]
+
+      expect(cidr_denial.first).to eq(404)
+      expect(host_denial).to eq(cidr_denial)
+    end
+  end
+
+  # ===========================================================================
+  # 6. Fail closed when no host can be resolved
+  # ===========================================================================
+  describe 'when the Host header yields no valid detected host' do
+    # DomainParser.basically_valid? rejects this (space + empty label), so
+    # Rack::DetectHost writes nil and the gate has nothing to match.
+    let(:unparseable_host) { 'ex ample..com' }
+
+    it '404s the API for a colonel' do
+      configure_admin!(default_domain: 'example.com', site_host: 'example.com')
+      signed_in_as(colonel)
+      get_api(unparseable_host)
+
+      expect(last_response.status).to eq(404)
+    end
+
+    it '404s the shell for a colonel' do
+      configure_admin!(default_domain: 'example.com', site_host: 'example.com')
+      signed_in_as(colonel)
+      get_shell(unparseable_host)
+
+      expect(last_response.status).to eq(404)
+    end
+
+    it 'reaches the app normally with the gate off (control)' do
+      configure_admin!(allowed_hosts: ['*'], default_domain: 'example.com', site_host: 'example.com')
+      signed_in_as(colonel)
+      get_api(unparseable_host)
+
+      expect(last_response.status).to eq(200)
+    end
+  end
+
+  # ===========================================================================
+  # 7. `*` disables the host gate — the documented rollback
+  # ===========================================================================
+  describe 'with ADMIN_ALLOWED_HOSTS=*' do
+    before do
+      configure_admin!(allowed_hosts: ['*'], default_domain: 'example.com', site_host: 'example.com')
+    end
+
+    it 'serves a colonel on a non-canonical host' do
+      signed_in_as(colonel)
+      get_api('tenant.example.com')
+
+      expect(last_response.status).to eq(200)
+    end
+
+    it 'leaves the role gate in place on a non-canonical host' do
+      anonymous!
+      get_api('tenant.example.com')
+
+      expect(last_response.status).to eq(401)
+    end
+
+    it 'leaves the role gate in place for a non-colonel' do
+      signed_in_as(regular)
+      get_api('tenant.example.com')
+
+      expect(last_response.status).to eq(403)
+    end
+  end
+
+  # ===========================================================================
+  # 8. The fail-closed backstop: an explicit list with nothing enforceable
+  # ===========================================================================
+  # Onetime::Config.validate_admin_allowed_hosts! normally refuses this config
+  # at boot (spec/unit/onetime/config/admin_allowed_hosts_spec.rb). Reaching
+  # the middleware with it means that validation did not run — an embedding
+  # that builds a Rack app without Config.raise_concerns. It must DENY, not
+  # disable itself: the operator's plain intent was to restrict.
+  describe 'with an explicit allowed_hosts that names nothing enforceable' do
+    before do
+      configure_admin!(allowed_hosts: ['127.0.0.1'], default_domain: 'example.com', site_host: 'example.com')
+    end
+
+    it '404s the admin API even on the canonical host' do
+      signed_in_as(colonel)
+      get_api('example.com')
+
+      expect(last_response.status).to eq(404)
+    end
+
+    it '404s the admin shell even on the canonical host' do
+      signed_in_as(colonel)
+      get_shell('example.com')
+
+      expect(gate_html_denial?).to be true
+    end
+
+    it 'leaves non-admin endpoints alone — it is not a blanket outage' do
+      anonymous!
+      header 'Host', 'example.com'
+      get NON_ADMIN_PATH
+
+      expect(last_response.status).to eq(200)
+    end
+  end
+
+  # ===========================================================================
+  # 9. SPOOFING — the security core
+  # ===========================================================================
+  # Each of these asserts an OUTCOME (still 404) rather than a mechanism, and
+  # each is paired with a control proving the spoofing vector is live in this
+  # stack. Without the control a green test could mean "the header did nothing
+  # anywhere", which would not be evidence about the gate at all.
+  describe 'spoofing' do
+    describe 'the O-Domain-Context request header' do
+      before do
+        configure_admin!(
+          default_domain: 'example.com',
+          site_host: 'example.com',
+          domains_enabled: true,
+          domain_context: true,
+        )
+      end
+
+      it 'cannot make a non-allowlisted host reach the admin API' do
+        signed_in_as(colonel)
+        get_api('tenant.example.com', 'HTTP_O_DOMAIN_CONTEXT' => 'example.com')
+
+        expect(last_response.status).to eq(404)
+      end
+
+      it 'cannot make a non-allowlisted host reach the admin shell' do
+        signed_in_as(colonel)
+        get_shell('tenant.example.com', 'HTTP_O_DOMAIN_CONTEXT' => 'example.com')
+
+        expect(last_response.status).to eq(404)
+      end
+
+      # Control: the header IS honoured by DomainStrategy in this exact
+      # configuration — it rewrites the display domain. So the 404s above are
+      # the admin gate refusing to read it, not the feature being inert.
+      it 'is genuinely honoured by DomainStrategy when the gate is off (control)' do
+        configure_admin!(
+          allowed_hosts: ['*'],
+          default_domain: 'example.com',
+          site_host: 'example.com',
+          domains_enabled: true,
+          domain_context: true,
+        )
+        anonymous!
+        header 'Host', 'example.com'
+        get NON_ADMIN_PATH, {}, 'HTTP_O_DOMAIN_CONTEXT' => 'other.example.net'
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.headers['O-Display-Domain']).to eq('other.example.net')
+      end
+    end
+
+    describe 'forwarded host headers from an untrusted peer' do
+      let(:untrusted_peer) { { 'REMOTE_ADDR' => '203.0.113.9' } }
+      let(:trusted_peer)   { { 'REMOTE_ADDR' => '127.0.0.1' } }
+
+      before { configure_admin!(default_domain: 'example.com', site_host: 'example.com') }
+
+      it 'ignores X-Forwarded-Host from an untrusted REMOTE_ADDR' do
+        signed_in_as(colonel)
+        get_api('tenant.example.com', untrusted_peer.merge('HTTP_X_FORWARDED_HOST' => 'example.com'))
+
+        expect(last_response.status).to eq(404)
+      end
+
+      it 'ignores Apx-Incoming-Host from an untrusted REMOTE_ADDR' do
+        signed_in_as(colonel)
+        get_api('tenant.example.com', untrusted_peer.merge('HTTP_APX_INCOMING_HOST' => 'example.com'))
+
+        expect(last_response.status).to eq(404)
+      end
+
+      it 'ignores X-Original-Host from an untrusted REMOTE_ADDR' do
+        signed_in_as(colonel)
+        get_api('tenant.example.com', untrusted_peer.merge('HTTP_X_ORIGINAL_HOST' => 'example.com'))
+
+        expect(last_response.status).to eq(404)
+      end
+
+      it 'ignores an RFC 7239 Forwarded host from an untrusted REMOTE_ADDR' do
+        signed_in_as(colonel)
+        get_api('tenant.example.com', untrusted_peer.merge('HTTP_FORWARDED' => 'host=example.com'))
+
+        expect(last_response.status).to eq(404)
+      end
+
+      it 'ignores a forwarded header even when it names an allowlisted host and the shell is asked for' do
+        signed_in_as(colonel)
+        get_shell('tenant.example.com', untrusted_peer.merge('HTTP_X_FORWARDED_HOST' => 'www.example.com'))
+
+        expect(gate_html_denial?).to be true
+      end
+
+      # Control: the SAME header from a trusted (loopback) peer IS honoured by
+      # Rack::DetectHost. Without this the tests above could pass simply
+      # because forwarded host headers are inert in this stack.
+      it 'DOES honour X-Forwarded-Host from a trusted peer (control)' do
+        signed_in_as(colonel)
+        get_api('tenant.example.com', trusted_peer.merge('HTTP_X_FORWARDED_HOST' => 'example.com'))
+
+        expect(last_response.status).to eq(200)
+      end
+
+      it 'DOES honour Apx-Incoming-Host from a trusted peer (control)' do
+        signed_in_as(colonel)
+        get_api('tenant.example.com', trusted_peer.merge('HTTP_APX_INCOMING_HOST' => 'example.com'))
+
+        expect(last_response.status).to eq(200)
+      end
+
+      # The mirror image of the control: a trusted peer forwarding a
+      # NON-allowlisted host is denied, so trust widens what is read, never
+      # what is admitted.
+      it 'denies a trusted-peer forwarded header that names a non-allowlisted host' do
+        signed_in_as(colonel)
+        get_api('example.com', trusted_peer.merge('HTTP_X_FORWARDED_HOST' => 'tenant.example.com'))
+
+        expect(last_response.status).to eq(404)
+      end
+
+      # And the inverse control: an untrusted peer on an ALLOWLISTED Host still
+      # gets through, so the 404s above are about the host, not the peer IP.
+      it 'admits an untrusted peer whose Host header is allowlisted' do
+        signed_in_as(colonel)
+        get_api('example.com', untrusted_peer)
+
+        expect(last_response.status).to eq(200)
+      end
+    end
+  end
+end

--- a/spec/unit/onetime/config/admin_allowed_hosts_spec.rb
+++ b/spec/unit/onetime/config/admin_allowed_hosts_spec.rb
@@ -3,9 +3,9 @@
 # frozen_string_literal: true
 
 # #4062: an explicitly set ADMIN_ALLOWED_HOSTS that names nothing the admin
-# host gate could ever match aborts boot.
+# host gate could ever match is announced at boot with a WARN.
 #
-# The validator is driven DIRECTLY with an explicit raw argument rather than
+# The check is driven DIRECTLY with an explicit raw argument rather than
 # through a booted OT.conf, the same way spec/unit/onetime/config/
 # link_domains_spec.rb drives validate_link_domains!. Reproducing these
 # postures through a real boot would mean setting ENV['ADMIN_ALLOWED_HOSTS']
@@ -13,22 +13,28 @@
 # what makes the criterion testable; the wiring into raise_concerns is pinned
 # separately below so deleting the call site is still caught.
 #
-# NOTE THE POLARITY, and do not "harmonize" it with #4063's LINK_DOMAINS:
+# WARN, NOT RAISE — and the asymmetry with #4063's LINK_DOMAINS is deliberate:
 #
-#   validate_link_domains!        — EMPTY is the error. An empty pool silently
-#                                   becomes the canonical domain, i.e. the
-#                                   picker offers the internal platform host
-#                                   LINK_DOMAINS exists to hide.
-#   validate_admin_allowed_hosts! — EMPTY is the SAFE DEFAULT (the host gate
-#                                   falls back to the canonical anchors).
-#                                   NON-EMPTY-but-unenforceable is the error,
-#                                   because before #4062 that config disabled
-#                                   the gate and served /colonel on every
-#                                   hostname — failing open on a typo.
+#   validate_link_domains!       — RAISES. An empty or unparseable pool has no
+#                                  fail-closed runtime backstop: it silently
+#                                  becomes the canonical domain, i.e. the
+#                                  picker offers the internal platform host
+#                                  LINK_DOMAINS exists to hide. Nothing
+#                                  downstream can recover the intent.
+#   check_admin_allowed_hosts    — WARNS. AdminNetworkIsolation already returns
+#                                  an ACTIVE gate with an EMPTY allowlist for
+#                                  exactly this config and 404s both admin
+#                                  surfaces, so the over-exposure this check
+#                                  exists to prevent cannot happen either way.
+#                                  Aborting the boot would take down the public
+#                                  site, the API and the health endpoints over
+#                                  an admin-console-only typo (e.g. an
+#                                  ADMIN_ALLOWED_HOSTS=10.0.0.0/8 mixup with the
+#                                  adjacent ADMIN_ALLOWED_CIDRS key).
 #
 # Both checks implement one rule: an operator who typed something either gets
-# what they meant or gets told. They look opposite because the safe fallback
-# is opposite. See the comments on both methods before changing either.
+# what they meant or gets told. See the comments on both methods before
+# changing either.
 #
 # Run with:
 #   bundle exec rspec spec/unit/onetime/config/admin_allowed_hosts_spec.rb
@@ -36,152 +42,202 @@
 require 'spec_helper'
 
 RSpec.describe Onetime::Config, 'ADMIN_ALLOWED_HOSTS validation (#4062)' do
-  describe '.validate_admin_allowed_hosts!' do
+  # Every example asserts on OT.lw, so nothing here writes to the real boot log.
+  # `allow` (not `expect`) by default: the silent postures assert absence.
+  before { allow(OT).to receive(:lw) }
+
+  describe '.check_admin_allowed_hosts' do
     # Posture 1: unset / empty. The gate falls back to the canonical anchors
-    # and self-disables on a localhost or bare-IP install. Nothing to refuse.
+    # and self-disables on a localhost or bare-IP install. Nothing to say.
     context 'when ADMIN_ALLOWED_HOSTS is unset or empty' do
-      it 'accepts nil — the canonical anchor fallback' do
-        expect { described_class.validate_admin_allowed_hosts!(nil) }.not_to raise_error
+      it 'says nothing for nil — the canonical anchor fallback' do
+        described_class.check_admin_allowed_hosts(nil)
+        expect(OT).not_to have_received(:lw)
       end
 
-      it 'accepts an empty list' do
-        expect { described_class.validate_admin_allowed_hosts!([]) }.not_to raise_error
+      it 'says nothing for an empty list' do
+        described_class.check_admin_allowed_hosts([])
+        expect(OT).not_to have_received(:lw)
       end
 
-      it 'accepts a list of only blanks (the shape ERB renders for a blank value)' do
-        expect { described_class.validate_admin_allowed_hosts!(['', '   ']) }.not_to raise_error
+      it 'says nothing for a list of only blanks (the shape ERB renders for a blank value)' do
+        described_class.check_admin_allowed_hosts(['', '   '])
+        expect(OT).not_to have_received(:lw)
       end
     end
 
-    # Posture 2: the documented escape hatch. The middleware WARNs; boot
-    # proceeds, because turning the gate off is a deliberate, supported choice.
+    # Posture 2: the documented escape hatch. The middleware WARNs about the
+    # gate being off; the boot check has nothing to add.
     context 'when ADMIN_ALLOWED_HOSTS is the `*` escape hatch' do
       it 'accepts a bare `*`' do
-        expect { described_class.validate_admin_allowed_hosts!(['*']) }.not_to raise_error
+        described_class.check_admin_allowed_hosts(['*'])
+        expect(OT).not_to have_received(:lw)
       end
 
       it 'accepts a padded `*`' do
-        expect { described_class.validate_admin_allowed_hosts!(['  *  ']) }.not_to raise_error
+        described_class.check_admin_allowed_hosts(['  *  '])
+        expect(OT).not_to have_received(:lw)
       end
 
       it 'accepts `*` beside blank entries' do
-        expect { described_class.validate_admin_allowed_hosts!(['', '*']) }.not_to raise_error
+        described_class.check_admin_allowed_hosts(['', '*'])
+        expect(OT).not_to have_received(:lw)
       end
     end
 
     # Posture 3: a routable hostname. The ordinary configured case.
     context 'when ADMIN_ALLOWED_HOSTS names a routable hostname' do
       it 'accepts a single host' do
-        expect { described_class.validate_admin_allowed_hosts!(['admin.example.com']) }.not_to raise_error
+        described_class.check_admin_allowed_hosts(['admin.example.com'])
+        expect(OT).not_to have_received(:lw)
       end
 
       it 'accepts several hosts' do
-        expect { described_class.validate_admin_allowed_hosts!(%w[admin.example.com ops.example.net]) }
-          .not_to raise_error
+        described_class.check_admin_allowed_hosts(%w[admin.example.com ops.example.net])
+        expect(OT).not_to have_received(:lw)
       end
 
       it 'accepts an entry carrying a port, scheme or trailing dot' do
-        expect { described_class.validate_admin_allowed_hosts!(['HTTPS://Admin.Example.COM:8443/']) }
-          .not_to raise_error
-        expect { described_class.validate_admin_allowed_hosts!(['admin.example.com.']) }.not_to raise_error
+        described_class.check_admin_allowed_hosts(['HTTPS://Admin.Example.COM:8443/'])
+        described_class.check_admin_allowed_hosts(['admin.example.com.'])
+        expect(OT).not_to have_received(:lw)
       end
 
       it 'accepts the punycode form of an internationalized domain' do
-        expect { described_class.validate_admin_allowed_hosts!(['xn--bcher-kva.example']) }.not_to raise_error
+        described_class.check_admin_allowed_hosts(['xn--bcher-kva.example'])
+        expect(OT).not_to have_received(:lw)
       end
 
-      # Partial failure is not a boot error: the middleware drops the bad entry
-      # with a WARN and the gate still has a host to enforce.
+      # Partial failure is not a boot concern: the middleware drops the bad
+      # entry with a WARN and the gate still has a host to enforce.
       it 'accepts a list that mixes an unusable entry with a routable one' do
-        expect { described_class.validate_admin_allowed_hosts!(['127.0.0.1', 'admin.example.com']) }
-          .not_to raise_error
+        described_class.check_admin_allowed_hosts(['127.0.0.1', 'admin.example.com'])
+        expect(OT).not_to have_received(:lw)
       end
     end
 
-    # Posture 4: `*` mixed with names. The `*` is dropped (it is only honored
-    # as the sole entry) and the names are enforced, so there is something to
-    # enforce and boot proceeds.
-    context 'when ADMIN_ALLOWED_HOSTS mixes `*` with a named host' do
-      it 'accepts the list' do
-        expect { described_class.validate_admin_allowed_hosts!(['*', 'admin.example.com']) }.not_to raise_error
+    # Posture 4: `*` mixed with anything. An explicit `*` turns the host gate
+    # off whatever else is listed — it is the remedy every diagnostic in this
+    # feature recommends, so it must never itself be the thing that trips one.
+    context 'when ADMIN_ALLOWED_HOSTS mixes `*` with other entries' do
+      it 'accepts `*` beside a named host' do
+        described_class.check_admin_allowed_hosts(['*', 'admin.example.com'])
+        expect(OT).not_to have_received(:lw)
+      end
+
+      # THE #4062-review case: the operator was told "set it to *" and did,
+      # without removing the entry that caused the message. Before the fix this
+      # classified as unenforceable — a boot abort, then a total deny.
+      it 'accepts `*` beside an entry that is itself unenforceable' do
+        described_class.check_admin_allowed_hosts(['*', '10.0.0.5'])
+        expect(OT).not_to have_received(:lw)
+      end
+
+      it 'accepts `*` beside a wildcard pattern' do
+        described_class.check_admin_allowed_hosts(['*.example.com', '*'])
+        expect(OT).not_to have_received(:lw)
       end
     end
 
     # Posture 5: set, but nothing survives classification. THE security case.
     # Pre-#4062 this disabled the gate — serving /colonel on every hostname
-    # from a config whose plain intent was to restrict it.
+    # from a config whose plain intent was to restrict it. It now denies both
+    # surfaces at runtime, and says so here.
     context 'when ADMIN_ALLOWED_HOSTS names nothing enforceable' do
-      it 'raises for a bare IPv4 literal (never a detected host)' do
-        expect { described_class.validate_admin_allowed_hosts!(['127.0.0.1']) }
-          .to raise_error(Onetime::ConfigError)
+      it 'warns for a bare IPv4 literal (never a detected host)' do
+        described_class.check_admin_allowed_hosts(['127.0.0.1'])
+        expect(OT).to have_received(:lw).with(/ADMIN_ALLOWED_HOSTS/)
       end
 
-      it 'raises for a public IPv4 literal too — no IP is ever a detected host' do
-        expect { described_class.validate_admin_allowed_hosts!(['203.0.113.9']) }
-          .to raise_error(Onetime::ConfigError)
+      it 'warns for a public IPv4 literal too — no IP is ever a detected host' do
+        described_class.check_admin_allowed_hosts(['203.0.113.9'])
+        expect(OT).to have_received(:lw).with(/ADMIN_ALLOWED_HOSTS/)
       end
 
-      it 'raises for localhost forms' do
-        expect { described_class.validate_admin_allowed_hosts!(%w[localhost localhost.localdomain]) }
-          .to raise_error(Onetime::ConfigError)
+      it 'warns for localhost forms' do
+        described_class.check_admin_allowed_hosts(%w[localhost localhost.localdomain])
+        expect(OT).to have_received(:lw).with(/ADMIN_ALLOWED_HOSTS/)
       end
 
-      it 'raises for a wildcard PATTERN — there is no glob matching, so it matches nothing' do
-        expect { described_class.validate_admin_allowed_hosts!(['*.example.com']) }
-          .to raise_error(Onetime::ConfigError)
+      it 'warns for a wildcard PATTERN — there is no glob matching, so it matches nothing' do
+        described_class.check_admin_allowed_hosts(['*.example.com'])
+        expect(OT).to have_received(:lw).with(/ADMIN_ALLOWED_HOSTS/)
       end
 
-      it 'raises for a non-ASCII (U-label) hostname — no IDN library ships here' do
-        expect { described_class.validate_admin_allowed_hosts!(['bücher.example']) }
-          .to raise_error(Onetime::ConfigError)
+      it 'warns for a non-ASCII (U-label) hostname — no IDN library ships here' do
+        described_class.check_admin_allowed_hosts(['bücher.example'])
+        expect(OT).to have_received(:lw).with(/ADMIN_ALLOWED_HOSTS/)
       end
 
-      it 'raises when no entry in a multi-entry list survives' do
-        expect { described_class.validate_admin_allowed_hosts!(['127.0.0.1', '*.example.com', 'localhost']) }
-          .to raise_error(Onetime::ConfigError)
+      it 'warns when no entry in a multi-entry list survives' do
+        described_class.check_admin_allowed_hosts(['127.0.0.1', '*.example.com', 'localhost'])
+        expect(OT).to have_received(:lw).with(/ADMIN_ALLOWED_HOSTS/)
+      end
+
+      # The point of the #4062 review's F6: this is an admin-console
+      # misconfiguration, and it must not take the public site down with it.
+      it 'does NOT raise — the public site, API and health endpoints still boot' do
+        expect { described_class.check_admin_allowed_hosts(['127.0.0.1']) }.not_to raise_error
+      end
+
+      # The mixup that motivated the downgrade: ADMIN_ALLOWED_HOSTS typed with
+      # the value that belongs in the adjacent ADMIN_ALLOWED_CIDRS key.
+      it 'does not raise on a CIDR typed into the hosts key' do
+        expect { described_class.check_admin_allowed_hosts(['10.0.0.0/8']) }.not_to raise_error
       end
     end
 
-    # The message is the whole point of failing loud: it has to name the
+    # The message is the whole point of warning loudly: it has to name the
     # setting, the offending entries, the reason, and every way out.
-    describe 'the error message' do
-      subject(:raise_it) { -> { described_class.validate_admin_allowed_hosts!(['127.0.0.1', '*.example.com']) } }
+    describe 'the warning message' do
+      let(:captured) do
+        message = nil
+        allow(OT).to receive(:lw) { |text| message = text }
+        described_class.check_admin_allowed_hosts(['127.0.0.1', '*.example.com'])
+        message
+      end
 
       it 'names the env var so the operator can find the setting' do
-        expect(&raise_it).to raise_error(Onetime::ConfigError, /ADMIN_ALLOWED_HOSTS/)
+        expect(captured).to match(/ADMIN_ALLOWED_HOSTS/)
       end
 
       it 'names the config path too' do
-        expect(&raise_it).to raise_error(Onetime::ConfigError, /site\.admin\.allowed_hosts/)
+        expect(captured).to match(/site\.admin\.allowed_hosts/)
       end
 
       it 'echoes every offending entry so the operator can spot the typo' do
-        expect(&raise_it).to raise_error(Onetime::ConfigError, /127\.0\.0\.1/)
-        expect(&raise_it).to raise_error(Onetime::ConfigError, /\*\.example\.com/)
+        expect(captured).to match(/127\.0\.0\.1/)
+        expect(captured).to match(/\*\.example\.com/)
       end
 
       it 'gives the reason per entry, in the operator vocabulary' do
-        expect(&raise_it).to raise_error(Onetime::ConfigError, /not a routable hostname/)
-        expect(&raise_it).to raise_error(Onetime::ConfigError, /wildcard patterns are not supported/)
+        expect(captured).to match(/not a routable hostname/)
+        expect(captured).to match(/wildcard patterns are not supported/)
       end
 
+      # The consequence changed with the downgrade: the surfaces 404, the
+      # process does not stop. The text has to say the true thing.
       it 'states the consequence of the config as written' do
-        expect(&raise_it).to raise_error(Onetime::ConfigError, %r{/colonel and /api/colonel})
+        expect(captured).to match(%r{/colonel and /api/colonel})
+        expect(captured).to match(/404/)
       end
 
       it 'offers the escape hatch by name' do
-        expect(&raise_it).to raise_error(Onetime::ConfigError, /\*/)
+        expect(captured).to match(/\*/)
       end
 
       it 'tells the non-ASCII operator to supply punycode' do
-        expect { described_class.validate_admin_allowed_hosts!(['bücher.example']) }
-          .to raise_error(Onetime::ConfigError, /punycode|xn--/)
+        message = nil
+        allow(OT).to receive(:lw) { |text| message = text }
+        described_class.check_admin_allowed_hosts(['bücher.example'])
+
+        expect(message).to match(/punycode|xn--/)
       end
     end
   end
 
   # The helper is only useful if boot actually calls it. A spec that drives
-  # validate_admin_allowed_hosts! alone stays green if the call site in
+  # check_admin_allowed_hosts alone stays green if the call site in
   # raise_concerns is deleted, so pin the wiring separately.
   describe '.raise_concerns wiring' do
     # The minimum conf that reaches the admin-hosts check: a global secret and
@@ -197,14 +253,19 @@ RSpec.describe Onetime::Config, 'ADMIN_ALLOWED_HOSTS validation (#4062)' do
       }
     end
 
-    it 'aborts boot when ADMIN_ALLOWED_HOSTS names nothing enforceable' do
-      expect { described_class.raise_concerns(conf_with(['127.0.0.1'])) }
-        .to raise_error(Onetime::ConfigError, /ADMIN_ALLOWED_HOSTS/)
+    it 'warns at boot when ADMIN_ALLOWED_HOSTS names nothing enforceable' do
+      described_class.raise_concerns(conf_with(['127.0.0.1']))
+      expect(OT).to have_received(:lw).with(/ADMIN_ALLOWED_HOSTS/)
     end
 
-    it 'aborts boot on a wildcard pattern' do
-      expect { described_class.raise_concerns(conf_with(['*.example.com'])) }
-        .to raise_error(Onetime::ConfigError, /ADMIN_ALLOWED_HOSTS/)
+    it 'warns at boot on a wildcard pattern' do
+      described_class.raise_concerns(conf_with(['*.example.com']))
+      expect(OT).to have_received(:lw).with(/ADMIN_ALLOWED_HOSTS/)
+    end
+
+    # The whole point of F6: an admin-console typo does not stop the process.
+    it 'still BOOTS with an unenforceable list — the warning is not fatal' do
+      expect { described_class.raise_concerns(conf_with(['127.0.0.1'])) }.not_to raise_error
     end
 
     it 'boots when the site.admin block is absent entirely' do
@@ -223,49 +284,57 @@ RSpec.describe Onetime::Config, 'ADMIN_ALLOWED_HOSTS validation (#4062)' do
       expect { described_class.raise_concerns(conf_with(['*'])) }.not_to raise_error
     end
 
+    it 'boots quietly on the `*` escape hatch beside junk' do
+      described_class.raise_concerns(conf_with(['*', '10.0.0.5']))
+      expect(OT).not_to have_received(:lw).with(/ADMIN_ALLOWED_HOSTS/)
+    end
+
     # The admin check must not depend on the domains feature being on: the
     # surfaces exist in every posture, and a self-hosted install with
     # features.domains.enabled=false is exactly where a typo goes unnoticed.
-    it 'aborts even when features.domains is absent from the config' do
+    it 'warns even when features.domains is absent from the config' do
       conf = conf_with(['127.0.0.1'])
       expect(conf).not_to have_key('features')
-      expect { described_class.raise_concerns(conf) }.to raise_error(Onetime::ConfigError, /ADMIN_ALLOWED_HOSTS/)
+
+      described_class.raise_concerns(conf)
+      expect(OT).to have_received(:lw).with(/ADMIN_ALLOWED_HOSTS/)
     end
   end
 
-  # One classifier, one answer. Onetime::Config refuses to boot exactly when
+  # One classifier, one answer. Onetime::Config warns at boot exactly when
   # Onetime::Middleware::AdminNetworkIsolation would construct itself with an
   # active gate and an EMPTY allowlist (deny both surfaces). If these two ever
-  # disagreed the app would either boot into a config the middleware then
-  # refuses to serve, or refuse to boot on a config it would have served.
+  # disagreed the app would boot quietly into a config the middleware then
+  # refuses to serve, or warn about one it serves happily.
   #
   # Asserted through the shared classifier rather than by booting a middleware
   # (that lives in try/unit/middleware/admin_network_isolation_try.rb), so this
   # stays a pure unit spec.
-  describe 'agreement with the middleware backstop' do
+  describe 'agreement with the middleware denial' do
     let(:classifier) { Onetime::Utils::AdminHostAllowlist }
 
-    def refuses_boot?(raw)
-      described_class.validate_admin_allowed_hosts!(raw)
-      false
-    rescue Onetime::ConfigError
-      true
+    def warns?(raw)
+      warned = false
+      allow(OT).to receive(:lw) { warned = true }
+      described_class.check_admin_allowed_hosts(raw)
+      warned
     end
 
     {
       nil => false,
-      []                                => false,
-      ['*']                             => false,
-      ['admin.example.com']             => false,
-      ['*', 'admin.example.com']        => false,
+      []                                 => false,
+      ['*']                              => false,
+      ['admin.example.com']              => false,
+      ['*', 'admin.example.com']         => false,
+      ['*', '10.0.0.5']                  => false,
       ['127.0.0.1', 'admin.example.com'] => false,
-      ['127.0.0.1']                     => true,
-      ['*.example.com']                 => true,
-      ['bücher.example']                => true,
-      %w[localhost ::1]                 => true,
+      ['127.0.0.1']                      => true,
+      ['*.example.com']                  => true,
+      ['bücher.example']                 => true,
+      %w[localhost ::1]                  => true,
     }.each do |raw, expected|
-      it "agrees on #{raw.inspect}: refuses_boot=#{expected}" do
-        expect(refuses_boot?(raw)).to eq(expected)
+      it "agrees on #{raw.inspect}: warns=#{expected}" do
+        expect(warns?(raw)).to eq(expected)
         expect(classifier.classify(raw).unenforceable?).to eq(expected)
       end
     end

--- a/spec/unit/onetime/config/admin_allowed_hosts_spec.rb
+++ b/spec/unit/onetime/config/admin_allowed_hosts_spec.rb
@@ -1,0 +1,273 @@
+# spec/unit/onetime/config/admin_allowed_hosts_spec.rb
+#
+# frozen_string_literal: true
+
+# #4062: an explicitly set ADMIN_ALLOWED_HOSTS that names nothing the admin
+# host gate could ever match aborts boot.
+#
+# The validator is driven DIRECTLY with an explicit raw argument rather than
+# through a booted OT.conf, the same way spec/unit/onetime/config/
+# link_domains_spec.rb drives validate_link_domains!. Reproducing these
+# postures through a real boot would mean setting ENV['ADMIN_ALLOWED_HOSTS']
+# and re-running the whole ERB+YAML load per case. Driving the pure helper is
+# what makes the criterion testable; the wiring into raise_concerns is pinned
+# separately below so deleting the call site is still caught.
+#
+# NOTE THE POLARITY, and do not "harmonize" it with #4063's LINK_DOMAINS:
+#
+#   validate_link_domains!        — EMPTY is the error. An empty pool silently
+#                                   becomes the canonical domain, i.e. the
+#                                   picker offers the internal platform host
+#                                   LINK_DOMAINS exists to hide.
+#   validate_admin_allowed_hosts! — EMPTY is the SAFE DEFAULT (the host gate
+#                                   falls back to the canonical anchors).
+#                                   NON-EMPTY-but-unenforceable is the error,
+#                                   because before #4062 that config disabled
+#                                   the gate and served /colonel on every
+#                                   hostname — failing open on a typo.
+#
+# Both checks implement one rule: an operator who typed something either gets
+# what they meant or gets told. They look opposite because the safe fallback
+# is opposite. See the comments on both methods before changing either.
+#
+# Run with:
+#   bundle exec rspec spec/unit/onetime/config/admin_allowed_hosts_spec.rb
+
+require 'spec_helper'
+
+RSpec.describe Onetime::Config, 'ADMIN_ALLOWED_HOSTS validation (#4062)' do
+  describe '.validate_admin_allowed_hosts!' do
+    # Posture 1: unset / empty. The gate falls back to the canonical anchors
+    # and self-disables on a localhost or bare-IP install. Nothing to refuse.
+    context 'when ADMIN_ALLOWED_HOSTS is unset or empty' do
+      it 'accepts nil — the canonical anchor fallback' do
+        expect { described_class.validate_admin_allowed_hosts!(nil) }.not_to raise_error
+      end
+
+      it 'accepts an empty list' do
+        expect { described_class.validate_admin_allowed_hosts!([]) }.not_to raise_error
+      end
+
+      it 'accepts a list of only blanks (the shape ERB renders for a blank value)' do
+        expect { described_class.validate_admin_allowed_hosts!(['', '   ']) }.not_to raise_error
+      end
+    end
+
+    # Posture 2: the documented escape hatch. The middleware WARNs; boot
+    # proceeds, because turning the gate off is a deliberate, supported choice.
+    context 'when ADMIN_ALLOWED_HOSTS is the `*` escape hatch' do
+      it 'accepts a bare `*`' do
+        expect { described_class.validate_admin_allowed_hosts!(['*']) }.not_to raise_error
+      end
+
+      it 'accepts a padded `*`' do
+        expect { described_class.validate_admin_allowed_hosts!(['  *  ']) }.not_to raise_error
+      end
+
+      it 'accepts `*` beside blank entries' do
+        expect { described_class.validate_admin_allowed_hosts!(['', '*']) }.not_to raise_error
+      end
+    end
+
+    # Posture 3: a routable hostname. The ordinary configured case.
+    context 'when ADMIN_ALLOWED_HOSTS names a routable hostname' do
+      it 'accepts a single host' do
+        expect { described_class.validate_admin_allowed_hosts!(['admin.example.com']) }.not_to raise_error
+      end
+
+      it 'accepts several hosts' do
+        expect { described_class.validate_admin_allowed_hosts!(%w[admin.example.com ops.example.net]) }
+          .not_to raise_error
+      end
+
+      it 'accepts an entry carrying a port, scheme or trailing dot' do
+        expect { described_class.validate_admin_allowed_hosts!(['HTTPS://Admin.Example.COM:8443/']) }
+          .not_to raise_error
+        expect { described_class.validate_admin_allowed_hosts!(['admin.example.com.']) }.not_to raise_error
+      end
+
+      it 'accepts the punycode form of an internationalized domain' do
+        expect { described_class.validate_admin_allowed_hosts!(['xn--bcher-kva.example']) }.not_to raise_error
+      end
+
+      # Partial failure is not a boot error: the middleware drops the bad entry
+      # with a WARN and the gate still has a host to enforce.
+      it 'accepts a list that mixes an unusable entry with a routable one' do
+        expect { described_class.validate_admin_allowed_hosts!(['127.0.0.1', 'admin.example.com']) }
+          .not_to raise_error
+      end
+    end
+
+    # Posture 4: `*` mixed with names. The `*` is dropped (it is only honored
+    # as the sole entry) and the names are enforced, so there is something to
+    # enforce and boot proceeds.
+    context 'when ADMIN_ALLOWED_HOSTS mixes `*` with a named host' do
+      it 'accepts the list' do
+        expect { described_class.validate_admin_allowed_hosts!(['*', 'admin.example.com']) }.not_to raise_error
+      end
+    end
+
+    # Posture 5: set, but nothing survives classification. THE security case.
+    # Pre-#4062 this disabled the gate — serving /colonel on every hostname
+    # from a config whose plain intent was to restrict it.
+    context 'when ADMIN_ALLOWED_HOSTS names nothing enforceable' do
+      it 'raises for a bare IPv4 literal (never a detected host)' do
+        expect { described_class.validate_admin_allowed_hosts!(['127.0.0.1']) }
+          .to raise_error(Onetime::ConfigError)
+      end
+
+      it 'raises for a public IPv4 literal too — no IP is ever a detected host' do
+        expect { described_class.validate_admin_allowed_hosts!(['203.0.113.9']) }
+          .to raise_error(Onetime::ConfigError)
+      end
+
+      it 'raises for localhost forms' do
+        expect { described_class.validate_admin_allowed_hosts!(%w[localhost localhost.localdomain]) }
+          .to raise_error(Onetime::ConfigError)
+      end
+
+      it 'raises for a wildcard PATTERN — there is no glob matching, so it matches nothing' do
+        expect { described_class.validate_admin_allowed_hosts!(['*.example.com']) }
+          .to raise_error(Onetime::ConfigError)
+      end
+
+      it 'raises for a non-ASCII (U-label) hostname — no IDN library ships here' do
+        expect { described_class.validate_admin_allowed_hosts!(['bücher.example']) }
+          .to raise_error(Onetime::ConfigError)
+      end
+
+      it 'raises when no entry in a multi-entry list survives' do
+        expect { described_class.validate_admin_allowed_hosts!(['127.0.0.1', '*.example.com', 'localhost']) }
+          .to raise_error(Onetime::ConfigError)
+      end
+    end
+
+    # The message is the whole point of failing loud: it has to name the
+    # setting, the offending entries, the reason, and every way out.
+    describe 'the error message' do
+      subject(:raise_it) { -> { described_class.validate_admin_allowed_hosts!(['127.0.0.1', '*.example.com']) } }
+
+      it 'names the env var so the operator can find the setting' do
+        expect(&raise_it).to raise_error(Onetime::ConfigError, /ADMIN_ALLOWED_HOSTS/)
+      end
+
+      it 'names the config path too' do
+        expect(&raise_it).to raise_error(Onetime::ConfigError, /site\.admin\.allowed_hosts/)
+      end
+
+      it 'echoes every offending entry so the operator can spot the typo' do
+        expect(&raise_it).to raise_error(Onetime::ConfigError, /127\.0\.0\.1/)
+        expect(&raise_it).to raise_error(Onetime::ConfigError, /\*\.example\.com/)
+      end
+
+      it 'gives the reason per entry, in the operator vocabulary' do
+        expect(&raise_it).to raise_error(Onetime::ConfigError, /not a routable hostname/)
+        expect(&raise_it).to raise_error(Onetime::ConfigError, /wildcard patterns are not supported/)
+      end
+
+      it 'states the consequence of the config as written' do
+        expect(&raise_it).to raise_error(Onetime::ConfigError, %r{/colonel and /api/colonel})
+      end
+
+      it 'offers the escape hatch by name' do
+        expect(&raise_it).to raise_error(Onetime::ConfigError, /\*/)
+      end
+
+      it 'tells the non-ASCII operator to supply punycode' do
+        expect { described_class.validate_admin_allowed_hosts!(['bücher.example']) }
+          .to raise_error(Onetime::ConfigError, /punycode|xn--/)
+      end
+    end
+  end
+
+  # The helper is only useful if boot actually calls it. A spec that drives
+  # validate_admin_allowed_hosts! alone stays green if the call site in
+  # raise_concerns is deleted, so pin the wiring separately.
+  describe '.raise_concerns wiring' do
+    # The minimum conf that reaches the admin-hosts check: a global secret and
+    # a truemail block. site.admin is omitted entirely when :unset, which is
+    # the shape of a config that predates the key.
+    def conf_with(allowed_hosts)
+      site = { 'secret' => 'a-test-secret' }
+      site['admin'] = { 'allowed_hosts' => allowed_hosts } unless allowed_hosts == :unset
+
+      {
+        'site' => site,
+        'mail' => { 'truemail' => {} },
+      }
+    end
+
+    it 'aborts boot when ADMIN_ALLOWED_HOSTS names nothing enforceable' do
+      expect { described_class.raise_concerns(conf_with(['127.0.0.1'])) }
+        .to raise_error(Onetime::ConfigError, /ADMIN_ALLOWED_HOSTS/)
+    end
+
+    it 'aborts boot on a wildcard pattern' do
+      expect { described_class.raise_concerns(conf_with(['*.example.com'])) }
+        .to raise_error(Onetime::ConfigError, /ADMIN_ALLOWED_HOSTS/)
+    end
+
+    it 'boots when the site.admin block is absent entirely' do
+      expect { described_class.raise_concerns(conf_with(:unset)) }.not_to raise_error
+    end
+
+    it 'boots when ADMIN_ALLOWED_HOSTS is empty (the canonical anchor fallback)' do
+      expect { described_class.raise_concerns(conf_with([])) }.not_to raise_error
+    end
+
+    it 'boots when ADMIN_ALLOWED_HOSTS names a routable hostname' do
+      expect { described_class.raise_concerns(conf_with(['admin.example.com'])) }.not_to raise_error
+    end
+
+    it 'boots on the `*` escape hatch' do
+      expect { described_class.raise_concerns(conf_with(['*'])) }.not_to raise_error
+    end
+
+    # The admin check must not depend on the domains feature being on: the
+    # surfaces exist in every posture, and a self-hosted install with
+    # features.domains.enabled=false is exactly where a typo goes unnoticed.
+    it 'aborts even when features.domains is absent from the config' do
+      conf = conf_with(['127.0.0.1'])
+      expect(conf).not_to have_key('features')
+      expect { described_class.raise_concerns(conf) }.to raise_error(Onetime::ConfigError, /ADMIN_ALLOWED_HOSTS/)
+    end
+  end
+
+  # One classifier, one answer. Onetime::Config refuses to boot exactly when
+  # Onetime::Middleware::AdminNetworkIsolation would construct itself with an
+  # active gate and an EMPTY allowlist (deny both surfaces). If these two ever
+  # disagreed the app would either boot into a config the middleware then
+  # refuses to serve, or refuse to boot on a config it would have served.
+  #
+  # Asserted through the shared classifier rather than by booting a middleware
+  # (that lives in try/unit/middleware/admin_network_isolation_try.rb), so this
+  # stays a pure unit spec.
+  describe 'agreement with the middleware backstop' do
+    let(:classifier) { Onetime::Utils::AdminHostAllowlist }
+
+    def refuses_boot?(raw)
+      described_class.validate_admin_allowed_hosts!(raw)
+      false
+    rescue Onetime::ConfigError
+      true
+    end
+
+    {
+      nil => false,
+      []                                => false,
+      ['*']                             => false,
+      ['admin.example.com']             => false,
+      ['*', 'admin.example.com']        => false,
+      ['127.0.0.1', 'admin.example.com'] => false,
+      ['127.0.0.1']                     => true,
+      ['*.example.com']                 => true,
+      ['bücher.example']                => true,
+      %w[localhost ::1]                 => true,
+    }.each do |raw, expected|
+      it "agrees on #{raw.inspect}: refuses_boot=#{expected}" do
+        expect(refuses_boot?(raw)).to eq(expected)
+        expect(classifier.classify(raw).unenforceable?).to eq(expected)
+      end
+    end
+  end
+end

--- a/try/README.md
+++ b/try/README.md
@@ -30,6 +30,17 @@ pnpm run test:tryouts:agent try/unit/models/v2/customer_try.rb
 pnpm run test:tryouts:failures try/unit/models/v2/customer_try.rb:42
 ```
 
+Run tryouts through these scripts (or `tests/lanes/run`, which pins the locale
+itself), not a bare `bundle exec try`. The parser reads each file with
+`File.read`, so under a non-UTF-8 locale — `LANG`/`LC_ALL` unset, as in a plain
+`env -i` shell or some CI images — every file containing a non-ASCII character
+(an em-dash in a comment is enough, and ~165 of these files have one) fails to
+parse with `invalid byte sequence in US-ASCII`. Tryouts reports that file under
+`Syntax Errors` but still **exits 0** when the others pass, so the run reads as
+green with the file silently dropped; only the `files_under_test` count gives it
+away. `test:tryouts` pins `RUBYOPT=-EUTF-8` so the encoding no longer depends on
+the caller's environment.
+
 ## Writing Tests
 
 ```ruby

--- a/try/README.md
+++ b/try/README.md
@@ -31,15 +31,20 @@ pnpm run test:tryouts:failures try/unit/models/v2/customer_try.rb:42
 ```
 
 Run tryouts through these scripts (or `tests/lanes/run`, which pins the locale
-itself), not a bare `bundle exec try`. The parser reads each file with
+itself), not a bare `bundle exec try`. The parser reads each file with plain
 `File.read`, so under a non-UTF-8 locale — `LANG`/`LC_ALL` unset, as in a plain
-`env -i` shell or some CI images — every file containing a non-ASCII character
-(an em-dash in a comment is enough, and ~165 of these files have one) fails to
-parse with `invalid byte sequence in US-ASCII`. Tryouts reports that file under
-`Syntax Errors` but still **exits 0** when the others pass, so the run reads as
-green with the file silently dropped; only the `files_under_test` count gives it
-away. `test:tryouts` pins `RUBYOPT=-EUTF-8` so the encoding no longer depends on
-the caller's environment.
+`env -i` shell or some CI images — the source is tagged US-ASCII and any
+non-ASCII byte the parser has to `strip` raises `invalid byte sequence in
+US-ASCII`, dropping the whole file. Indented comments and code lines are the
+ones that reach that path (a comment starting at column 0 does not); 22 of these
+files qualify.
+
+The run still exits non-zero, so CI cannot go green on it, but the report reads
+as if it had: `65 testcases passed, 0 failed in 3 files` with
+`files_under_test: 2` and a `Syntax Errors` block below the context, or `2 of 2
+files passed` in the default formatter. The dropped file's tests are counted
+nowhere. `test:tryouts` pins `RUBYOPT=-EUTF-8` so the encoding no longer depends
+on the caller's environment. Upstream: delano/tryouts#76.
 
 ## Writing Tests
 

--- a/try/unit/middleware/admin_network_isolation_try.rb
+++ b/try/unit/middleware/admin_network_isolation_try.rb
@@ -86,49 +86,71 @@ class TestAdminNetworkIsolation < Onetime::Middleware::AdminNetworkIsolation
     @allowed_hosts
   end
 
-  # Swap a recorder in for the duration of the block and return the WARN lines
-  # it saw, as [message, payload] pairs.
+  # Records the log lines one middleware instance emits.
+  #
+  # The three host refusals — unattributable forwarded host, unresolvable host,
+  # allowlist miss — are the IDENTICAL 404 by design; indistinguishable-from-absent
+  # is the whole point of the response side. That leaves the LOG LINE as the only
+  # thing that tells an operator which one fired, which is why it is worth
+  # asserting on and why these cases cannot go through status alone.
+  #
+  # EVERY level is recorded, not just #warn. The earlier version answered #warn
+  # and swallowed the rest through method_missing, which turned "this denial
+  # moved to ERROR" into "this request logged nothing at all" — the one outcome
+  # these cases must never confuse with an undiagnosed denial. A level not
+  # listed here raises NoMethodError rather than being absorbed, for the same
+  # reason. It is nested because the constant would otherwise be a bare
+  # top-level name in the single process `rake try:unit` runs all ~295 files in.
+  class LogRecorder
+    LEVELS = %i[debug info warn error fatal unknown].freeze
+
+    Entry = Struct.new(:level, :message, :payload)
+
+    attr_reader :entries
+
+    def initialize
+      @entries = []
+    end
+
+    LEVELS.each do |level|
+      define_method(level) do |message, payload = nil|
+        @entries << Entry.new(level, message, payload)
+        nil
+      end
+    end
+
+    def lines
+      @entries.map { |entry| [entry.message, entry.payload] }
+    end
+
+    def levels
+      @entries.map(&:level)
+    end
+  end
+
+  # Swap a recorder in for the duration of the block and return it.
   #
   # Installed AFTER construction on purpose: the boot lines already went to the
   # real logger (and have their own announcement-ledger cases at the bottom of
   # this file), so only PER-REQUEST denials land here.
-  def capture_warns
+  def with_log_recorder
     real     = @logger
-    recorder = WarnRecorder.new
+    recorder = LogRecorder.new
     @logger  = recorder
     yield
-    recorder.warns
+    recorder
   ensure
     @logger = real
   end
-end
 
-# Records the WARN lines one middleware instance emits.
-#
-# The three host refusals — unattributable forwarded host, unresolvable host,
-# allowlist miss — are the IDENTICAL 404 by design; indistinguishable-from-absent
-# is the whole point of the response side. That leaves the LOG LINE as the only
-# thing that tells an operator which one fired, which is why it is worth
-# asserting on and why these cases cannot go through status alone.
-class WarnRecorder
-  attr_reader :warns
-
-  def initialize
-    @warns = []
+  # The log lines one block produced, as [message, payload] pairs.
+  def capture_logs(&block)
+    with_log_recorder(&block).lines
   end
 
-  def warn(message, payload = nil)
-    @warns << [message, payload]
-    nil
-  end
-
-  # Every other level is swallowed: only the denial WARNs are under test.
-  def method_missing(_name, *_args)
-    nil
-  end
-
-  def respond_to_missing?(_name, _include_private = false)
-    true
+  # The levels those same lines came in at.
+  def capture_levels(&block)
+    with_log_recorder(&block).levels
   end
 end
 
@@ -222,7 +244,7 @@ end
 # the only way to tell the three identical-404 host refusals apart.
 def denial_warns(mw, detected_host, extra = {}, http_host: nil, path_info: '/colonel', script_name: '')
   status   = nil
-  recorded = mw.capture_warns do
+  recorded = mw.capture_logs do
     status = status_with(mw, detected_host, extra,
                          http_host: http_host, path_info: path_info, script_name: script_name)
   end
@@ -632,7 +654,7 @@ denial_warns(@hosts, nil)
 #=> [404, ['Admin surface access denied: no host could be detected for this request']]
 
 ## absent detected-host key - same line (DetectHost never ran, same diagnosis)
-@absent_warns = @hosts.capture_warns { status_for(@hosts, :unset) }
+@absent_warns = @hosts.capture_logs { status_for(@hosts, :unset) }
 @absent_warns.map(&:first)
 #=> ['Admin surface access denied: no host could be detected for this request']
 
@@ -657,17 +679,26 @@ denial_warns(@hosts, 'tenant.example.com')
 denial_warns(@hosts, 'admin.example.com')
 #=> [200, []]
 
+## the LEVEL each denial arrives at, not only its message. The level is what an
+## operator's log filter is tuned to, and a recorder that swallowed every level
+## but #warn reported a promotion to ERROR as silence instead of as a change.
+## Both host refusals log at WARN; an admitted request logs nothing
+[@hosts.capture_levels { status_for(@hosts, nil) },
+ @hosts.capture_levels { status_for(@hosts, 'tenant.example.com') },
+ @hosts.capture_levels { status_for(@hosts, 'admin.example.com') }]
+#=> [[:warn], [:warn], []]
+
 ## every host denial carries the same host/path/method triple, so an operator's
 ## existing log query does not have to special-case the new line. `note` rides
 ## alongside it on the two refusals that have a remedy to name
-@nil_warn = @hosts.capture_warns { status_for(@hosts, nil) }.first
+@nil_warn = @hosts.capture_logs { status_for(@hosts, nil) }.first
 [@nil_warn.last.keys.sort, @nil_warn.last[:host], @nil_warn.last[:path], @nil_warn.last[:method]]
 #=> [%i[host method note path], nil, '/colonel', 'GET']
 
 ## the allowlist miss for contrast: same triple, and no note - the host it
 ## names IS the diagnosis, and the remedy is the config key already in the
 ## message
-@miss_warn = @hosts.capture_warns { status_for(@hosts, 'tenant.example.com') }.first
+@miss_warn = @hosts.capture_logs { status_for(@hosts, 'tenant.example.com') }.first
 [@miss_warn.last.keys.sort, @miss_warn.last[:host], @miss_warn.last[:path], @miss_warn.last[:method]]
 #=> [%i[host method path], 'tenant.example.com', '/colonel', 'GET']
 

--- a/try/unit/middleware/admin_network_isolation_try.rb
+++ b/try/unit/middleware/admin_network_isolation_try.rb
@@ -4,21 +4,52 @@
 
 # Tests for Onetime::Middleware::AdminNetworkIsolation
 #
-# This middleware optionally restricts the Colonel admin surfaces
-# (/colonel shell + /api/colonel API) to a configured CIDR allowlist
-# (site.admin.allowed_cidrs). A request from OUTSIDE the allowlist receives a
-# 404 (indistinguishable-from-absent, NOT 403). When the allowlist is
-# unset/empty the middleware is a strict no-op (both surfaces reachable).
+# This middleware guards the Colonel admin surfaces (/colonel shell +
+# /api/colonel API) with TWO INDEPENDENT gates. A request must pass every gate
+# that is ACTIVE; failing either produces the SAME 404
+# (indistinguishable-from-absent, NOT 403). When both gates are inactive the
+# middleware is a strict no-op.
 #
-# Client IP is resolved from the trusted-proxy-aware env['otto.client_ip'], so a
-# raw X-Forwarded-For header cannot bypass the allowlist.
+#   HOST    (#4062, site.admin.allowed_hosts) — ACTIVE BY DEFAULT. An empty
+#           list falls back to the canonical ANCHOR hosts
+#           (features.domains.default + site.host, NOT the link_domains pool)
+#           plus their www. variants. `*` is the escape hatch. The ANCHOR
+#           fallback self-disables when no anchor is a hostname
+#           Rack::DetectHost could ever emit (localhost / bare IP), so stock
+#           local-dev is unaffected. An EXPLICIT list with nothing enforceable
+#           in it does the OPPOSITE: it denies (see below). The host comes from
+#           env[Rack::DetectHost.result_field_name] — never HTTP_HOST, never
+#           env['onetime.domain_strategy'].
+#
+#   NETWORK (site.admin.allowed_cidrs) — OPT-IN. Client IP is resolved from the
+#           trusted-proxy-aware env['otto.client_ip'], so a raw X-Forwarded-For
+#           header cannot bypass it.
+#
+# THE INERT/DENY ASYMMETRY, since it is the one thing most likely to be
+# "harmonized" by a later reader:
+#
+#   allowed_hosts UNSET + unroutable anchors  -> gate INERT (nobody configured
+#     anything; a fail-closed default would 404 /colonel on every stock
+#     single-container install).
+#   allowed_hosts SET to unenforceable values -> gate ACTIVE with an EMPTY
+#     allowlist, i.e. DENY BOTH SURFACES. Onetime::Config
+#     .validate_admin_allowed_hosts! normally refuses that config at boot; this
+#     is the middleware's backstop for an embedding that builds a Rack app
+#     without Config.raise_concerns. Going inert there would serve the admin
+#     console on every host from a config whose plain intent was to restrict
+#     it — failing open on a typo.
 #
 # Test categories:
 #   1. Path matching (colonel_shell? / colonel_api?), full-path reconstruction
-#   2. No-op when allowlist empty
-#   3. Outside allowlist -> 404 on both surfaces
-#   4. Inside allowlist -> pass-through to auth layers
+#   2. No-op when both allowlists are empty/unset
+#   3. Outside CIDR allowlist -> 404 on both surfaces
+#   4. Inside CIDR allowlist -> pass-through to auth layers
 #   5. Spoofed X-Forwarded-For cannot bypass
+#   6. Host gate: match/miss, normalization, nil host, `*`, literal entries
+#   7. Host gate: canonical anchor fallback, link_domains pool exclusion
+#   8. Host gate: the inert rule (anchors) vs the fail-closed backstop (explicit)
+#   9. Host input provenance: detected host only, not HTTP_HOST / domain_strategy
+#  10. Both gates together, and the identical shape of the two denials
 
 require_relative '../../support/test_helpers'
 
@@ -28,32 +59,126 @@ require 'rack/mock'
 require 'json'
 require_relative '../../../lib/onetime/middleware/admin_network_isolation'
 
-# Test subclass to expose private predicates
+# Test subclass to expose private predicates plus the resolved host allowlist
+# (the single most useful thing to assert directly — it is computed once in
+# #initialize and drives every host decision).
+#
+# `normalize_host` is a thin private DELEGATOR to
+# Onetime::Utils::AdminHostAllowlist (which is also what
+# Onetime::Config.validate_admin_allowed_hosts! uses, so the two cannot
+# drift). It is exposed here because #detected_host calls it on EVERY request
+# an active host gate judges: when it briefly went missing during the #4062
+# refactor, both admin surfaces raised NoMethodError instead of answering, and
+# nothing caught it because the default test config leaves the gate inert.
 class TestAdminNetworkIsolation < Onetime::Middleware::AdminNetworkIsolation
-  public :admin_surface?, :colonel_shell?, :colonel_api?, :request_path, :allowed?
+  public :admin_surface?, :colonel_shell?, :colonel_api?, :request_path, :allowed?,
+    :host_gate_active?, :network_gate_active?, :host_allowed?, :normalize_host, :detected_host
+
+  def allowed_hosts
+    @allowed_hosts
+  end
 end
+
+@allowlist = Onetime::Utils::AdminHostAllowlist
 
 # Mock app that returns 200 OK — stands in for the downstream auth layers.
 @mock_app = ->(_env) { [200, { 'Content-Type' => 'text/plain' }, ['OK']] }
 
-# Set the allowlist in config, then build a middleware instance that reads it.
+# Config this file mutates, captured BEFORE the first write. `rake try:unit`
+# runs every unit tryout in ONE process, so a leaked site.host or
+# features.domains.default would silently change what later files see.
+# Rack::DetectHost.result_field_name is process-global and mutable too.
+@orig_admin          = OT.conf.dig('site', 'admin')&.dup
+@orig_site_host      = OT.conf.dig('site', 'host')
+@orig_domains        = OT.conf.dig('features', 'domains')&.dup
+@orig_detected_field = Rack::DetectHost.result_field_name
+
+# Set the CIDR allowlist in config, then build a middleware instance that reads
+# it. site.host stays at the spec/config.test.yaml value (an IP literal), so
+# the host gate is inert and the network gate is the sole decider.
 def set_allowlist(cidrs)
   OT.conf['site'] ||= {}
   OT.conf['site']['admin'] ||= {}
+  OT.conf['site']['admin']['allowed_hosts'] = []
   OT.conf['site']['admin']['allowed_cidrs'] = cidrs
   TestAdminNetworkIsolation.new(@mock_app)
 end
 
-# Build a Rack env for a full path, injecting the resolved (otto) client IP.
+# Write EVERY input the host gate reads, then return a fresh instance.
+#
+# Both allowlists are resolved once in #initialize, so a config write without a
+# rebuild is invisible to an existing instance. The site_host default mirrors
+# spec/config.test.yaml (an IP literal -> the anchor fallback is unenforceable
+# -> the host gate is INERT), which is exactly why the ~22 existing colonel
+# suites stayed green when #4062 landed.
+def build_mw(hosts: [], cidrs: [], site_host: '127.0.0.1:3000', default_domain: nil, link_domains: nil)
+  OT.conf['site'] ||= {}
+  OT.conf['site']['admin'] ||= {}
+  OT.conf['site']['admin']['allowed_hosts'] = hosts
+  OT.conf['site']['admin']['allowed_cidrs'] = cidrs
+  OT.conf['site']['host'] = site_host
+  OT.conf['features'] ||= {}
+  OT.conf['features']['domains'] ||= {}
+  OT.conf['features']['domains']['default'] = default_domain
+  OT.conf['features']['domains']['link_domains'] = link_domains
+  TestAdminNetworkIsolation.new(@mock_app)
+end
+
+# Build a Rack env for a full path, injecting the resolved (otto) client IP and
+# the validated host Rack::DetectHost writes.
 # script_name simulates Rack::URLMap mounting (colonel API is mounted at
 # /api/colonel, so PATH_INFO is stripped to e.g. /info).
-def admin_env(script_name:, path_info:, client_ip:, xff: nil)
+#
+# detected_host: :unset leaves the env key ABSENT (a request that never passed
+# through Rack::DetectHost); nil writes an explicit nil (DetectHost ran and
+# found no valid host). Both must fail closed, and they are different envs.
+def admin_env(script_name:, path_info:, client_ip: nil, xff: nil, detected_host: :unset, http_host: nil,
+              domain_strategy: nil)
   env = Rack::MockRequest.env_for("http://example.com#{script_name}#{path_info}")
   env['SCRIPT_NAME'] = script_name
   env['PATH_INFO'] = path_info
   env['otto.client_ip'] = client_ip if client_ip
   env['HTTP_X_FORWARDED_FOR'] = xff if xff
+  env['HTTP_HOST'] = http_host if http_host
+  env['onetime.domain_strategy'] = domain_strategy if domain_strategy
+  env[Rack::DetectHost.result_field_name] = detected_host unless detected_host == :unset
   env
+end
+
+# Status of one admin-surface request. Defaults to the /colonel shell from a
+# public IP; pass script_name/path_info for the API surface.
+def status_for(mw, detected_host, script_name: '', path_info: '/colonel', client_ip: '203.0.113.9')
+  env = admin_env(
+    script_name: script_name,
+    path_info: path_info,
+    client_ip: client_ip,
+    detected_host: detected_host,
+  )
+  mw.call(env).first
+end
+
+# Both surfaces at once: [shell_status, api_status]. Most host-gate rules are
+# surface-independent and asserting one surface only would miss a path-matching
+# regression on the other.
+def both_surfaces(mw, detected_host, client_ip: '203.0.113.9')
+  [
+    status_for(mw, detected_host, client_ip: client_ip),
+    status_for(mw, detected_host, script_name: '/api/colonel', path_info: '/info', client_ip: client_ip),
+  ]
+end
+
+# The full response triple, with the body collapsed to a comparable String.
+# Used to prove a host denial and a network denial are byte-identical.
+def denial_triple(mw, detected_host, client_ip, script_name, path_info)
+  status, headers, body = mw.call(
+    admin_env(
+      script_name: script_name,
+      path_info: path_info,
+      client_ip: client_ip,
+      detected_host: detected_host,
+    ),
+  )
+  [status, headers, body.join]
 end
 
 # =================================================================
@@ -123,7 +248,7 @@ end
 #=> false
 
 # =================================================================
-# No-op when allowlist is empty/unset (self-hosted default)
+# No-op when both allowlists are empty/unset (self-hosted default)
 # =================================================================
 
 ## empty allowlist - /colonel from a public IP passes through (200)
@@ -240,5 +365,622 @@ end
 @status
 #=> 200
 
-# Restore config to a clean empty allowlist so later tryouts see a no-op posture.
-OT.conf['site']['admin']['allowed_cidrs'] = []
+# =================================================================
+# HOST GATE — explicit site.admin.allowed_hosts
+# =================================================================
+# The host is read from env[Rack::DetectHost.result_field_name] only. Every
+# case below uses a PUBLIC client IP and an empty CIDR list, so the network
+# gate is inactive and the host gate is the sole decider.
+
+## explicit allowlist - matching detected host passes through (200)
+@hosts = build_mw(hosts: ['admin.example.com'])
+status_for(@hosts, 'admin.example.com')
+#=> 200
+
+## explicit allowlist - the host gate reports itself active
+@hosts.host_gate_active?
+#=> true
+
+## explicit allowlist - the network gate stays inactive
+@hosts.network_gate_active?
+#=> false
+
+## explicit allowlist - effective list is the configured entry, verbatim
+@hosts.allowed_hosts
+#=> ['admin.example.com']
+
+## explicit allowlist - non-matching detected host is denied (404)
+status_for(@hosts, 'tenant.example.com')
+#=> 404
+
+## explicit allowlist - denial on /colonel is HTML, same as a CIDR denial
+@env = admin_env(script_name: '', path_info: '/colonel', client_ip: '203.0.113.9',
+                 detected_host: 'tenant.example.com')
+@status, @headers, @body = @hosts.call(@env)
+[@status, @headers['Content-Type']]
+#=> [404, 'text/html; charset=utf-8']
+
+## explicit allowlist - denial on /api/colonel is the JSON not-found body
+@env = admin_env(script_name: '/api/colonel', path_info: '/info', client_ip: '203.0.113.9',
+                 detected_host: 'tenant.example.com')
+@status, @headers, @body = @hosts.call(@env)
+[@status, @headers['Content-Type'], JSON.parse(@body.first)['error']]
+#=> [404, 'application/json', 'Not Found']
+
+## explicit allowlist - /api/colonel on an allowed host passes through
+status_for(@hosts, 'admin.example.com', script_name: '/api/colonel', path_info: '/info')
+#=> 200
+
+## explicit allowlist - a non-admin path is untouched on a denied host
+status_for(@hosts, 'tenant.example.com', path_info: '/dashboard')
+#=> 200
+
+## explicit allowlist - a /colonel SUBPATH is gated too, on both surfaces
+[status_for(@hosts, 'tenant.example.com', path_info: '/colonel/customers'),
+ status_for(@hosts, 'tenant.example.com', script_name: '/api/colonel', path_info: '/stats')]
+#=> [404, 404]
+
+# --- normalization: DETECTED side ---------------------------------------
+
+## detected host - uppercase matches a lowercase entry
+status_for(@hosts, 'ADMIN.Example.COM')
+#=> 200
+
+## detected host - a :port is stripped before matching
+status_for(@hosts, 'admin.example.com:8443')
+#=> 200
+
+## detected host - a trailing root dot is stripped before matching
+status_for(@hosts, 'admin.example.com.')
+#=> 200
+
+## detected host - multiple trailing dots are stripped
+status_for(@hosts, 'admin.example.com...')
+#=> 200
+
+## detected host - a scheme is stripped before matching
+status_for(@hosts, 'https://admin.example.com')
+#=> 200
+
+# --- normalization: CONFIGURED side -------------------------------------
+
+## configured entry - uppercase, scheme, port and trailing dot all normalize
+@messy = build_mw(hosts: ['  HTTPS://Admin.Example.COM:8443/  ', 'other.example.com.'])
+@messy.allowed_hosts
+#=> ['admin.example.com', 'other.example.com']
+
+## configured entry - a normalized entry matches the plain detected host
+status_for(@messy, 'admin.example.com')
+#=> 200
+
+## configured entry - the second normalized entry matches too
+status_for(@messy, 'other.example.com')
+#=> 200
+
+## configured entry - blank entries are dropped, not treated as a match-all
+@blanks = build_mw(hosts: ['', '   ', 'admin.example.com'])
+@blanks.allowed_hosts
+#=> ['admin.example.com']
+
+## configured entry - blanks beside a real host do not widen it
+status_for(@blanks, 'tenant.example.com')
+#=> 404
+
+## configured entry - duplicates collapse
+build_mw(hosts: ['admin.example.com', 'ADMIN.example.com:443']).allowed_hosts
+#=> ['admin.example.com']
+
+## normalize_host - ONE function for both sides, and it lives in the shared
+## classifier so the boot validator cannot drift from it
+@allowlist.normalize_host('HTTPS://Admin.Example.COM:8443/path')
+#=> 'admin.example.com'
+
+## normalize_host - the middleware DELEGATES to that one function rather than
+## keeping a second copy. #detected_host calls this on every request an active
+## gate judges, so a missing/renamed delegator is a NoMethodError on both admin
+## surfaces, not a mismatch.
+@hosts.normalize_host('HTTPS://Admin.Example.COM:8443/path')
+#=> 'admin.example.com'
+
+## detected_host - reads the env key and normalizes it, without raising
+@hosts.detected_host(Rack::DetectHost.result_field_name => 'ADMIN.Example.COM:8443')
+#=> 'admin.example.com'
+
+## detected_host - an absent key is nil, not an exception
+@hosts.detected_host({})
+#=> nil
+
+## REGRESSION (#4062 refactor): an ACTIVE gate judging a REAL detected host
+## must answer, not raise. Both surfaces, admitted and denied host — the four
+## request shapes that never occur under the inert default test config.
+[status_for(@hosts, 'admin.example.com'),
+ status_for(@hosts, 'tenant.example.com'),
+ status_for(@hosts, 'admin.example.com', script_name: '/api/colonel', path_info: '/info'),
+ status_for(@hosts, 'tenant.example.com', script_name: '/api/colonel', path_info: '/info')]
+#=> [200, 404, 200, 404]
+
+## normalize_host - trailing root dot is stripped (a legal client-supplied FQDN)
+@allowlist.normalize_host('Admin.Example.COM.')
+#=> 'admin.example.com'
+
+## normalize_host - nothing usable yields nil, never an empty match-all
+[@allowlist.normalize_host(nil), @allowlist.normalize_host(''), @allowlist.normalize_host('   ')]
+#=> [nil, nil, nil]
+
+# --- fail closed: no usable host ----------------------------------------
+
+## nil detected host - fails closed (404) even though the path is legitimate
+status_for(@hosts, nil)
+#=> 404
+
+## absent detected-host key - fails closed (404)
+status_for(@hosts, :unset)
+#=> 404
+
+## empty detected host - fails closed (404)
+status_for(@hosts, '')
+#=> 404
+
+## whitespace-only detected host - normalizes to nil and fails closed (404)
+status_for(@hosts, '   ')
+#=> 404
+
+## nil detected host - both surfaces, not just the shell
+both_surfaces(@hosts, nil)
+#=> [404, 404]
+
+## host_allowed? - nil and empty are rejected directly
+[@hosts.host_allowed?(nil), @hosts.host_allowed?('')]
+#=> [false, false]
+
+# --- exact match only: no subdomain or suffix tolerance -----------------
+
+## subdomain of an allowed host is NOT admitted
+status_for(@hosts, 'deeper.admin.example.com')
+#=> 404
+
+## parent of an allowed host is NOT admitted
+status_for(@hosts, 'example.com')
+#=> 404
+
+## suffix-lookalike host is NOT admitted
+status_for(@hosts, 'evil-admin.example.com')
+#=> 404
+
+## a host that merely ENDS with an allowed host is NOT admitted
+status_for(@hosts, 'admin.example.com.evil.test')
+#=> 404
+
+# --- explicit entries are LITERAL: no www. synthesis --------------------
+# The www. tolerance exists for the canonical anchor fallback only. An
+# operator who names admin.example.com is not asking for www.admin.example.com.
+
+## explicit entry does NOT admit its www. sibling
+status_for(@hosts, 'www.admin.example.com')
+#=> 404
+
+## explicit entry does NOT admit its www. sibling on the API surface either
+status_for(@hosts, 'www.admin.example.com', script_name: '/api/colonel', path_info: '/info')
+#=> 404
+
+## explicit www. entry does NOT admit the bare host
+@wwwonly = build_mw(hosts: ['www.admin.example.com'])
+[@wwwonly.allowed_hosts, status_for(@wwwonly, 'admin.example.com')]
+#=> [['www.admin.example.com'], 404]
+
+## explicit www. entry admits itself
+status_for(@wwwonly, 'www.admin.example.com')
+#=> 200
+
+## explicit list REPLACES the anchor fallback - the canonical host is not admitted
+@replaces = build_mw(hosts: ['admin.example.com'], default_domain: 'example.com', site_host: 'example.com')
+[@replaces.allowed_hosts, status_for(@replaces, 'example.com'), status_for(@replaces, 'admin.example.com')]
+#=> [['admin.example.com'], 404, 200]
+
+# =================================================================
+# HOST GATE — the `*` escape hatch
+# =================================================================
+
+## `*` as the sole entry disables the host gate
+@wild = build_mw(hosts: ['*'])
+[@wild.allowed_hosts, @wild.host_gate_active?]
+#=> [[], false]
+
+## `*` - any host reaches the app, on both surfaces
+both_surfaces(@wild, 'anything.example.test')
+#=> [200, 200]
+
+## `*` - even a nil detected host reaches the app (the gate is OFF, not open)
+status_for(@wild, nil)
+#=> 200
+
+## `*` surrounded by whitespace still normalizes to the escape hatch
+build_mw(hosts: ['  *  ']).host_gate_active?
+#=> false
+
+## `*` alongside blank entries is still the SOLE meaningful entry
+build_mw(hosts: ['', '*']).host_gate_active?
+#=> false
+
+## `*` does NOT disable the CIDR gate - the two factors are independent
+@wild_cidr = build_mw(hosts: ['*'], cidrs: ['10.0.0.0/8'])
+[@wild_cidr.host_gate_active?, @wild_cidr.network_gate_active?,
+ status_for(@wild_cidr, 'anything.example.test', client_ip: '10.0.0.5'),
+ status_for(@wild_cidr, 'anything.example.test', client_ip: '203.0.113.9')]
+#=> [false, true, 200, 404]
+
+## `*` mixed with named hosts - the wildcard is DROPPED, names are enforced
+@mixed = build_mw(hosts: ['*', 'admin.example.com'])
+[@mixed.allowed_hosts, @mixed.host_gate_active?]
+#=> [['admin.example.com'], true]
+
+## `*` mixed - the named host is admitted
+status_for(@mixed, 'admin.example.com')
+#=> 200
+
+## `*` mixed - everything else is still denied (fail closed on ambiguity)
+status_for(@mixed, 'tenant.example.com')
+#=> 404
+
+# =================================================================
+# HOST GATE — canonical ANCHOR fallback (allowed_hosts empty)
+# =================================================================
+# The fallback is CanonicalHosts.normalized_anchor_hosts —
+# features.domains.default + site.host — plus a www. variant of each. The
+# features.domains.link_domains pool is deliberately NOT a member (#4063).
+
+## anchor fallback - both anchors and their www. variants are admitted
+@anchors = build_mw(default_domain: 'example.com', site_host: 'app.example.net')
+@anchors.allowed_hosts
+#=> ['example.com', 'www.example.com', 'app.example.net', 'www.app.example.net']
+
+## anchor fallback - a nil allowed_hosts behaves exactly like an empty one
+build_mw(hosts: nil, default_domain: 'example.com', site_host: 'app.example.net').allowed_hosts
+#=> ['example.com', 'www.example.com', 'app.example.net', 'www.app.example.net']
+
+## anchor fallback - the primary anchor passes
+status_for(@anchors, 'example.com')
+#=> 200
+
+## anchor fallback - the www. variant of the primary anchor passes
+status_for(@anchors, 'www.example.com')
+#=> 200
+
+## anchor fallback - the secondary anchor (site.host) passes
+status_for(@anchors, 'app.example.net')
+#=> 200
+
+## anchor fallback - the www. variant of the secondary anchor passes
+status_for(@anchors, 'www.app.example.net')
+#=> 200
+
+## anchor fallback - a tenant custom domain is denied
+status_for(@anchors, 'secrets.tenant.test')
+#=> 404
+
+## anchor fallback - a subdomain of the anchor is denied
+status_for(@anchors, 'tenant.example.com')
+#=> 404
+
+## anchor fallback - an unknown host is denied
+status_for(@anchors, 'unknown.example.org')
+#=> 404
+
+## anchor fallback - /api/colonel is gated identically
+[status_for(@anchors, 'example.com', script_name: '/api/colonel', path_info: '/info'),
+ status_for(@anchors, 'secrets.tenant.test', script_name: '/api/colonel', path_info: '/info')]
+#=> [200, 404]
+
+## anchor fallback - a www. anchor also admits its bare form
+build_mw(default_domain: 'www.example.com', site_host: 'app.example.net').allowed_hosts
+#=> ['www.example.com', 'example.com', 'app.example.net', 'www.app.example.net']
+
+## anchor fallback - WITHOUT features.domains.default, site.host alone anchors
+@sitehost_only = build_mw(default_domain: nil, site_host: 'app.example.net')
+@sitehost_only.allowed_hosts
+#=> ['app.example.net', 'www.app.example.net']
+
+## anchor fallback - site.host alone: it passes, an unrelated host does not
+[status_for(@sitehost_only, 'app.example.net'), status_for(@sitehost_only, 'example.com')]
+#=> [200, 404]
+
+## anchor fallback - a configured :port on site.host is stripped
+build_mw(default_domain: nil, site_host: 'app.example.net:3000').allowed_hosts
+#=> ['app.example.net', 'www.app.example.net']
+
+# --- the #4063 boundary: link_domains are NOT admin hosts ---------------
+
+## link pool - a pool member is NOT in the effective admin allowlist
+@pool = build_mw(
+  default_domain: 'example.com',
+  site_host: 'example.com',
+  link_domains: ['links.example.net', 'short.example.org'],
+)
+@pool.allowed_hosts
+#=> ['example.com', 'www.example.com']
+
+## link pool - the pool member IS canonical for classification (config took)
+Onetime::Utils::CanonicalHosts.normalized_hosts
+#=> ['example.com', 'links.example.net', 'short.example.org']
+
+## link pool - a request on a link-pool domain is DENIED the admin surface
+status_for(@pool, 'links.example.net')
+#=> 404
+
+## link pool - second pool member is denied too
+status_for(@pool, 'short.example.org')
+#=> 404
+
+## link pool - a www. sibling of a pool member is denied as well
+status_for(@pool, 'www.links.example.net')
+#=> 404
+
+## link pool - the anchor still passes, so the gate is active (not vacuous)
+status_for(@pool, 'example.com')
+#=> 200
+
+## link pool - denial applies to /api/colonel as well
+status_for(@pool, 'links.example.net', script_name: '/api/colonel', path_info: '/info')
+#=> 404
+
+# =================================================================
+# HOST GATE — the INERT rule (anchor fallback only)
+# =================================================================
+# Rack::DetectHost never emits localhost or an IP literal, so an anchor set
+# made only of those would 404 both surfaces on every local-dev and bare-IP
+# install. When NOBODY configured allowed_hosts and no ANCHOR is a hostname
+# DetectHost could emit, the gate self-disables.
+
+## DetectHost never emits `localhost` — the premise of the rule
+Rack::DetectHost.valid_domain_name?('localhost')
+#=> false
+
+## ...but it WOULD emit `www.localhost`, so the rule must be judged BEFORE
+## www. expansion or a localhost anchor would wrongly activate the gate
+Rack::DetectHost.valid_domain_name?('www.localhost')
+#=> true
+
+## localhost anchor - the gate is inert, NOT deny-everything
+@localhost = build_mw(default_domain: nil, site_host: 'localhost:3000')
+[@localhost.allowed_hosts, @localhost.host_gate_active?]
+#=> [[], false]
+
+## localhost anchor - /colonel stays reachable on stock local-dev
+status_for(@localhost, 'anything.example.test')
+#=> 200
+
+## localhost anchor - a nil detected host is not denied either
+status_for(@localhost, nil)
+#=> 200
+
+## IP-literal anchor (the shipped spec/config.test.yaml posture) - inert
+@iplit = build_mw(default_domain: nil, site_host: '127.0.0.1:3000')
+[@iplit.allowed_hosts, @iplit.host_gate_active?]
+#=> [[], false]
+
+## IP-literal anchor - both surfaces stay reachable
+both_surfaces(@iplit, 'anything.example.test')
+#=> [200, 200]
+
+## a routable anchor makes the DEFAULT (unset allowed_hosts) posture enforcing
+build_mw(default_domain: 'example.com', site_host: '127.0.0.1:3000').host_gate_active?
+#=> true
+
+# =================================================================
+# HOST GATE — the fail-closed BACKSTOP (explicit list, nothing enforceable)
+# =================================================================
+# The opposite of the inert rule, and deliberately so. An operator who writes
+# ADMIN_ALLOWED_HOSTS=127.0.0.1 asked to RESTRICT the admin surfaces; going
+# inert would serve them on every hostname instead — failing open on a typo.
+# Onetime::Config.validate_admin_allowed_hosts! normally refuses this config at
+# boot (see spec/unit/onetime/config/admin_allowed_hosts_spec.rb); the
+# middleware still denies if it is ever constructed with one.
+
+## IP-literal list - ACTIVE gate with an EMPTY allowlist
+@ip_only = build_mw(hosts: ['127.0.0.1'])
+[@ip_only.allowed_hosts, @ip_only.host_gate_active?]
+#=> [[], true]
+
+## IP-literal list - both surfaces are DENIED, not served
+both_surfaces(@ip_only, 'anything.example.test')
+#=> [404, 404]
+
+## IP-literal list - the configured IP is denied too (it is never a detected host)
+status_for(@ip_only, '127.0.0.1')
+#=> 404
+
+## localhost list - same backstop
+@lh_only = build_mw(hosts: ['localhost', 'localhost.localdomain', '::1'])
+[@lh_only.allowed_hosts, @lh_only.host_gate_active?, status_for(@lh_only, 'anything.example.test')]
+#=> [[], true, 404]
+
+## wildcard PATTERN is not a match-all and not the escape hatch: it DENIES
+@pattern = build_mw(hosts: ['*.example.com'])
+[@pattern.allowed_hosts, @pattern.host_gate_active?]
+#=> [[], true]
+
+## wildcard pattern - the host it appears to name is still denied
+both_surfaces(@pattern, 'admin.example.com')
+#=> [404, 404]
+
+## non-ASCII entry (no IDN library ships here) - denies rather than widens
+@idn = build_mw(hosts: ['bücher.example'])
+[@idn.allowed_hosts, @idn.host_gate_active?, status_for(@idn, 'bücher.example')]
+#=> [[], true, 404]
+
+## the punycode form of that same host IS enforceable
+@puny = build_mw(hosts: ['xn--bcher-kva.example'])
+[@puny.allowed_hosts, status_for(@puny, 'xn--bcher-kva.example')]
+#=> [['xn--bcher-kva.example'], 200]
+
+## backstop denial is a 404, byte-identical to every other denial
+@ip_only.call(admin_env(script_name: '', path_info: '/colonel', client_ip: '203.0.113.9',
+                        detected_host: 'anything.example.test')).first
+#=> 404
+
+## backstop does NOT touch non-admin paths
+status_for(@ip_only, 'anything.example.test', path_info: '/dashboard')
+#=> 200
+
+## a wildcard pattern ALONGSIDE a routable host does not widen it
+@pattern_mixed = build_mw(hosts: ['*.example.com', 'admin.example.com'])
+[@pattern_mixed.allowed_hosts,
+ status_for(@pattern_mixed, 'admin.example.com'),
+ status_for(@pattern_mixed, 'other.example.com')]
+#=> [['admin.example.com'], 200, 404]
+
+## ONE routable entry among unenforceable ones activates the gate for that host
+@one_routable = build_mw(hosts: ['127.0.0.1', 'admin.example.com'])
+[@one_routable.host_gate_active?,
+ status_for(@one_routable, 'admin.example.com'),
+ status_for(@one_routable, 'other.example.com')]
+#=> [true, 200, 404]
+
+# =================================================================
+# HOST PROVENANCE — the detected host, and nothing else
+# =================================================================
+# Two inputs must never decide admin reachability: HTTP_HOST (raw, bypasses the
+# trust decision Rack::DetectHost already made about the peer) and
+# env['onetime.domain_strategy'] (DomainStrategy honors an O-Domain-Context
+# REQUEST HEADER override when development.domain_context_enabled is on).
+
+## HTTP_HOST naming an allowed host does NOT admit a denied detected host
+@provenance = build_mw(hosts: ['admin.example.com'])
+@env = admin_env(script_name: '', path_info: '/colonel', client_ip: '203.0.113.9',
+                 detected_host: 'tenant.example.com', http_host: 'admin.example.com')
+@provenance.call(@env).first
+#=> 404
+
+## HTTP_HOST naming a DENIED host does not evict an allowed detected host
+@env = admin_env(script_name: '', path_info: '/colonel', client_ip: '203.0.113.9',
+                 detected_host: 'admin.example.com', http_host: 'tenant.example.com')
+@provenance.call(@env).first
+#=> 200
+
+## a :canonical domain_strategy does not rescue a denied detected host
+@env = admin_env(script_name: '/api/colonel', path_info: '/info', client_ip: '203.0.113.9',
+                 detected_host: 'tenant.example.com', domain_strategy: :canonical)
+@provenance.call(@env).first
+#=> 404
+
+## a :custom domain_strategy does not deny an allowed detected host
+@env = admin_env(script_name: '/api/colonel', path_info: '/info', client_ip: '203.0.113.9',
+                 detected_host: 'admin.example.com', domain_strategy: :custom)
+@provenance.call(@env).first
+#=> 200
+
+## HTTP_HOST alone (no detected host at all) fails closed
+@env = admin_env(script_name: '', path_info: '/colonel', client_ip: '203.0.113.9',
+                 http_host: 'admin.example.com')
+@provenance.call(@env).first
+#=> 404
+
+# =================================================================
+# HOST GATE — the env key is an accessor, not a literal
+# =================================================================
+# Rack::DetectHost.result_field_name is driven by the DETECTED_HOST env var. A
+# hardcoded 'rack.detected_host' would read nil on a deployment that renames
+# it — a blanket 404 on both surfaces.
+
+## the middleware follows a renamed result field
+@renamed_status = begin
+  Rack::DetectHost.result_field_name = 'custom.detected_host'
+  mw  = build_mw(hosts: ['admin.example.com'])
+  env = Rack::MockRequest.env_for('http://example.com/colonel')
+  env['SCRIPT_NAME'] = ''
+  env['PATH_INFO'] = '/colonel'
+  env['otto.client_ip'] = '203.0.113.9'
+  env['custom.detected_host'] = 'admin.example.com'
+  mw.call(env).first
+ensure
+  Rack::DetectHost.result_field_name = @orig_detected_field
+end
+#=> 200
+
+## the field name was restored
+Rack::DetectHost.result_field_name == @orig_detected_field
+#=> true
+
+# =================================================================
+# BOTH GATES — independent, and either failure denies
+# =================================================================
+
+## both gates active - the middleware says so
+@both = build_mw(hosts: ['admin.example.com'], cidrs: ['10.0.0.0/8'])
+[@both.host_gate_active?, @both.network_gate_active?]
+#=> [true, true]
+
+## host pass + CIDR pass -> through to the auth layers (200)
+status_for(@both, 'admin.example.com', client_ip: '10.0.0.5')
+#=> 200
+
+## host pass + CIDR fail -> 404
+status_for(@both, 'admin.example.com', client_ip: '203.0.113.9')
+#=> 404
+
+## host fail + CIDR pass -> 404
+status_for(@both, 'tenant.example.com', client_ip: '10.0.0.5')
+#=> 404
+
+## host fail + CIDR fail -> 404
+status_for(@both, 'tenant.example.com', client_ip: '203.0.113.9')
+#=> 404
+
+## both gates active - the API surface behaves identically
+[status_for(@both, 'admin.example.com', script_name: '/api/colonel', path_info: '/info', client_ip: '10.0.0.5'),
+ status_for(@both, 'admin.example.com', script_name: '/api/colonel', path_info: '/info', client_ip: '203.0.113.9'),
+ status_for(@both, 'tenant.example.com', script_name: '/api/colonel', path_info: '/info', client_ip: '10.0.0.5')]
+#=> [200, 404, 404]
+
+## both gates active - a non-admin path is untouched even when both would fail
+status_for(@both, 'tenant.example.com', path_info: '/dashboard', client_ip: '203.0.113.9')
+#=> 200
+
+## both gates inactive - strict no-op on /colonel
+@none = build_mw(hosts: [], cidrs: [], site_host: '127.0.0.1:3000')
+[@none.host_gate_active?, @none.network_gate_active?, status_for(@none, 'anything.example.test')]
+#=> [false, false, 200]
+
+## both gates inactive - strict no-op on /api/colonel with no detected host
+status_for(@none, nil, script_name: '/api/colonel', path_info: '/info')
+#=> 200
+
+## both gates inactive - non-admin paths obviously unaffected
+status_for(@none, nil, path_info: '/dashboard')
+#=> 200
+
+# =================================================================
+# The two denials are indistinguishable to the client
+# =================================================================
+# Operators tell a host denial from a network denial by the log message, never
+# by the response. Same status, same headers, same bytes.
+
+## /colonel - host denial and CIDR denial are byte-identical
+@host_only = build_mw(hosts: ['admin.example.com'], cidrs: [])
+@cidr_only = build_mw(hosts: [], cidrs: ['10.0.0.0/8'], site_host: '127.0.0.1:3000')
+denial_triple(@host_only, 'tenant.example.com', '10.0.0.5', '', '/colonel') ==
+  denial_triple(@cidr_only, 'tenant.example.com', '203.0.113.9', '', '/colonel')
+#=> true
+
+## /api/colonel - host denial and CIDR denial are byte-identical
+denial_triple(@host_only, 'tenant.example.com', '10.0.0.5', '/api/colonel', '/info') ==
+  denial_triple(@cidr_only, 'tenant.example.com', '203.0.113.9', '/api/colonel', '/info')
+#=> true
+
+## sanity - the two setups really did deny for DIFFERENT reasons
+[@host_only.host_gate_active?, @host_only.network_gate_active?,
+ @cidr_only.host_gate_active?, @cidr_only.network_gate_active?]
+#=> [true, false, false, true]
+
+## the backstop denial is byte-identical to a host-allowlist denial too
+denial_triple(@ip_only, 'anything.example.test', '203.0.113.9', '', '/colonel') ==
+  denial_triple(@host_only, 'tenant.example.com', '203.0.113.9', '', '/colonel')
+#=> true
+
+# Restore every global this file mutated: both admin lists, site.host, the
+# features.domains block, and the DetectHost result field. `rake try:unit` runs
+# all unit tryouts in one process — a leak here changes what later files see.
+OT.conf['site']['admin'] = @orig_admin if @orig_admin
+OT.conf['site']['host'] = @orig_site_host
+OT.conf['features']['domains'] = @orig_domains if @orig_domains
+Rack::DetectHost.result_field_name = @orig_detected_field

--- a/try/unit/middleware/admin_network_isolation_try.rb
+++ b/try/unit/middleware/admin_network_isolation_try.rb
@@ -657,11 +657,19 @@ denial_warns(@hosts, 'tenant.example.com')
 denial_warns(@hosts, 'admin.example.com')
 #=> [200, []]
 
-## the unresolvable-host payload carries the SAME key set as the other two
-## denials, so an operator's existing log query does not have to special-case it
+## every host denial carries the same host/path/method triple, so an operator's
+## existing log query does not have to special-case the new line. `note` rides
+## alongside it on the two refusals that have a remedy to name
 @nil_warn = @hosts.capture_warns { status_for(@hosts, nil) }.first
 [@nil_warn.last.keys.sort, @nil_warn.last[:host], @nil_warn.last[:path], @nil_warn.last[:method]]
 #=> [%i[host method note path], nil, '/colonel', 'GET']
+
+## the allowlist miss for contrast: same triple, and no note - the host it
+## names IS the diagnosis, and the remedy is the config key already in the
+## message
+@miss_warn = @hosts.capture_warns { status_for(@hosts, 'tenant.example.com') }.first
+[@miss_warn.last.keys.sort, @miss_warn.last[:host], @miss_warn.last[:path], @miss_warn.last[:method]]
+#=> [%i[host method path], 'tenant.example.com', '/colonel', 'GET']
 
 ## the note names the real cause and the two remedies, and never blames the
 ## allowlist for a rejection it did not make

--- a/try/unit/middleware/admin_network_isolation_try.rb
+++ b/try/unit/middleware/admin_network_isolation_try.rb
@@ -33,11 +33,13 @@
 #     single-container install).
 #   allowed_hosts SET to unenforceable values -> gate ACTIVE with an EMPTY
 #     allowlist, i.e. DENY BOTH SURFACES. Onetime::Config
-#     .validate_admin_allowed_hosts! normally refuses that config at boot; this
-#     is the middleware's backstop for an embedding that builds a Rack app
-#     without Config.raise_concerns. Going inert there would serve the admin
+#     .check_admin_allowed_hosts says so at boot (WARN, not a boot abort — the
+#     denial here is the enforcement). Going inert instead would serve the admin
 #     console on every host from a config whose plain intent was to restrict
 #     it — failing open on a typo.
+#
+#   UNREADABLE config (OT.conf raised) -> same as the case above, never the
+#     unset one. "Unset" and "unreadable" are different facts.
 #
 # Test categories:
 #   1. Path matching (colonel_shell? / colonel_api?), full-path reconstruction
@@ -50,6 +52,12 @@
 #   8. Host gate: the inert rule (anchors) vs the fail-closed backstop (explicit)
 #   9. Host input provenance: detected host only, not HTTP_HOST / domain_strategy
 #  10. Both gates together, and the identical shape of the two denials
+#  11. Path NORMALIZATION: percent-encoded spellings reach the gates (the router
+#      decodes before dispatch, so raw matching was a two-character bypass)
+#  12. Forwarded-host provenance: a forwarded header only counts from a peer
+#      otto vouched for (env['otto.via_trusted_proxy'] == true)
+#  13. Unreadable config, and a CIDR list with nothing parseable: both DENY
+#  14. Boot logging is once per process, not once per mounted app
 
 require_relative '../../support/test_helpers'
 
@@ -65,7 +73,7 @@ require_relative '../../../lib/onetime/middleware/admin_network_isolation'
 #
 # `normalize_host` is a thin private DELEGATOR to
 # Onetime::Utils::AdminHostAllowlist (which is also what
-# Onetime::Config.validate_admin_allowed_hosts! uses, so the two cannot
+# Onetime::Config.check_admin_allowed_hosts uses, so the two cannot
 # drift). It is exposed here because #detected_host calls it on EVERY request
 # an active host gate judges: when it briefly went missing during the #4062
 # refactor, both admin surfaces raised NoMethodError instead of answering, and
@@ -132,8 +140,13 @@ end
 # detected_host: :unset leaves the env key ABSENT (a request that never passed
 # through Rack::DetectHost); nil writes an explicit nil (DetectHost ran and
 # found no valid host). Both must fail closed, and they are different envs.
+#
+# `extra` is merged LAST and is how the forwarded-host provenance cases below
+# write raw header keys (HTTP_X_FORWARDED_HOST, HTTP_APX_INCOMING_HOST) and
+# otto's tri-state trust key ('otto.via_trusted_proxy'). Those cases care about
+# the PRESENCE of a header, not its value: the middleware never reads it.
 def admin_env(script_name:, path_info:, client_ip: nil, xff: nil, detected_host: :unset, http_host: nil,
-              domain_strategy: nil)
+              domain_strategy: nil, extra: {})
   env = Rack::MockRequest.env_for("http://example.com#{script_name}#{path_info}")
   env['SCRIPT_NAME'] = script_name
   env['PATH_INFO'] = path_info
@@ -142,7 +155,22 @@ def admin_env(script_name:, path_info:, client_ip: nil, xff: nil, detected_host:
   env['HTTP_HOST'] = http_host if http_host
   env['onetime.domain_strategy'] = domain_strategy if domain_strategy
   env[Rack::DetectHost.result_field_name] = detected_host unless detected_host == :unset
+  env.merge!(extra)
   env
+end
+
+# Status of one /colonel request carrying raw header state. The host gate cases
+# above go through status_for; these need the env keys env_for does not model.
+def status_with(mw, detected_host, extra, http_host: nil, path_info: '/colonel', script_name: '')
+  env = admin_env(
+    script_name: script_name,
+    path_info: path_info,
+    client_ip: '203.0.113.9',
+    detected_host: detected_host,
+    http_host: http_host,
+    extra: extra,
+  )
+  mw.call(env).first
 end
 
 # Status of one admin-surface request. Defaults to the /colonel shell from a
@@ -609,18 +637,46 @@ build_mw(hosts: ['', '*']).host_gate_active?
  status_for(@wild_cidr, 'anything.example.test', client_ip: '203.0.113.9')]
 #=> [false, true, 200, 404]
 
-## `*` mixed with named hosts - the wildcard is DROPPED, names are enforced
+## `*` mixed with named hosts - the `*` WINS and the gate is off (#4062 review
+## F5). An explicit `*` is the documented request for "no host gate"; a sibling
+## entry does not make it ambiguous, it makes the sibling inert. Reading it the
+## other way made `ADMIN_ALLOWED_HOSTS="*,10.0.0.5"` a total deny — while the
+## diagnostic told the operator to set exactly `*`.
 @mixed = build_mw(hosts: ['*', 'admin.example.com'])
 [@mixed.allowed_hosts, @mixed.host_gate_active?]
-#=> [['admin.example.com'], true]
+#=> [[], false]
 
-## `*` mixed - the named host is admitted
+## `*` mixed - the named host is admitted (the gate is off, not open)
 status_for(@mixed, 'admin.example.com')
 #=> 200
 
-## `*` mixed - everything else is still denied (fail closed on ambiguity)
+## `*` mixed - so is everything else
 status_for(@mixed, 'tenant.example.com')
-#=> 404
+#=> 200
+
+## `*` beside an UNENFORCEABLE sibling boots to gate-off, not to total deny.
+## This is the exact config from the F5 finding: the operator followed the
+## remedy the error message named, and got a blanket 404 for it.
+@wild_junk = build_mw(hosts: ['*', '10.0.0.5'])
+[@wild_junk.allowed_hosts, @wild_junk.host_gate_active?, both_surfaces(@wild_junk, 'anything.example.test')]
+#=> [[], false, [200, 200]]
+
+## `*` beside junk is not classified unenforceable, so boot has nothing to warn
+## about (the classifier is what Onetime::Config reads too)
+@allowlist.classify(['*', '10.0.0.5']).unenforceable?
+#=> false
+
+## `*` beside a wildcard PATTERN is still gate-off
+build_mw(hosts: ['*.example.com', '*']).host_gate_active?
+#=> false
+
+## order does not matter: `*` last is the same as `*` first
+build_mw(hosts: ['admin.example.com', '*']).host_gate_active?
+#=> false
+
+## a wildcard PATTERN alone is NOT the escape hatch (only a bare `*` is)
+@allowlist.classify(['*.example.com']).wildcard
+#=> false
 
 # =================================================================
 # HOST GATE — canonical ANCHOR fallback (allowed_hosts empty)
@@ -772,9 +828,9 @@ build_mw(default_domain: 'example.com', site_host: '127.0.0.1:3000').host_gate_a
 # The opposite of the inert rule, and deliberately so. An operator who writes
 # ADMIN_ALLOWED_HOSTS=127.0.0.1 asked to RESTRICT the admin surfaces; going
 # inert would serve them on every hostname instead — failing open on a typo.
-# Onetime::Config.validate_admin_allowed_hosts! normally refuses this config at
-# boot (see spec/unit/onetime/config/admin_allowed_hosts_spec.rb); the
-# middleware still denies if it is ever constructed with one.
+# Onetime::Config.check_admin_allowed_hosts WARNs about this config at boot (see
+# spec/unit/onetime/config/admin_allowed_hosts_spec.rb) and the denial below is
+# what makes that warning safe to be only a warning.
 
 ## IP-literal list - ACTIVE gate with an EMPTY allowlist
 @ip_only = build_mw(hosts: ['127.0.0.1'])
@@ -977,6 +1033,296 @@ denial_triple(@ip_only, 'anything.example.test', '203.0.113.9', '', '/colonel') 
   denial_triple(@host_only, 'tenant.example.com', '203.0.113.9', '', '/colonel')
 #=> true
 
+# =================================================================
+# PATH NORMALIZATION — percent-encoded spellings reach the gates
+# =================================================================
+# The Otto router dispatches on Otto::Utils.normalize_path, which
+# percent-DECODES. Matching the raw SCRIPT_NAME+PATH_INFO here (as this did
+# until the #4062 review) meant `GET /%63olonel` missed colonel_shell?, skipped
+# BOTH gates, and was then routed to /colonel by the router — a complete
+# bypass of the feature with a two-character change to the URL.
+
+## request_path - a percent-encoded `c` normalizes to the admin surface
+@mw.request_path('SCRIPT_NAME' => '', 'PATH_INFO' => '/%63olonel')
+#=> '/colonel'
+
+## request_path - an encoded slash normalizes to a /colonel SUBPATH
+@mw.request_path('SCRIPT_NAME' => '', 'PATH_INFO' => '/colonel%2Fsettings')
+#=> '/colonel/settings'
+
+## request_path - a trailing slash is stripped, matching the router
+@mw.request_path('SCRIPT_NAME' => '', 'PATH_INFO' => '/colonel/')
+#=> '/colonel'
+
+## request_path - the API surface too, across the SCRIPT_NAME boundary
+@mw.request_path('SCRIPT_NAME' => '/api/colonel', 'PATH_INFO' => '/%73tats')
+#=> '/api/colonel/stats'
+
+## HOST gate - /%63olonel is denied on a non-allowlisted host
+@encoded = build_mw(hosts: ['admin.example.com'])
+status_for(@encoded, 'tenant.example.com', path_info: '/%63olonel')
+#=> 404
+
+## HOST gate - /colonel%2Fsettings is denied too
+status_for(@encoded, 'tenant.example.com', path_info: '/colonel%2Fsettings')
+#=> 404
+
+## HOST gate - a fully encoded /colonel is denied
+status_for(@encoded, 'tenant.example.com', path_info: '/%63%6f%6c%6f%6e%65%6c')
+#=> 404
+
+## HOST gate - the encoded API surface is denied
+status_for(@encoded, 'tenant.example.com', script_name: '/api/colonel', path_info: '/%69nfo')
+#=> 404
+
+## HOST gate - control: the same encoded paths are SERVED on an allowlisted
+## host, so the 404s above are the gate and not the encoding
+[status_for(@encoded, 'admin.example.com', path_info: '/%63olonel'),
+ status_for(@encoded, 'admin.example.com', path_info: '/colonel%2Fsettings')]
+#=> [200, 200]
+
+## CIDR gate - /%63olonel is denied from an outside IP
+@encoded_cidr = set_allowlist(['10.0.0.0/8'])
+@encoded_cidr.call(admin_env(script_name: '', path_info: '/%63olonel', client_ip: '203.0.113.9')).first
+#=> 404
+
+## CIDR gate - /colonel%2Fsettings is denied from an outside IP
+@encoded_cidr.call(admin_env(script_name: '', path_info: '/colonel%2Fsettings', client_ip: '203.0.113.9')).first
+#=> 404
+
+## CIDR gate - control: served from an inside IP
+@encoded_cidr.call(admin_env(script_name: '', path_info: '/%63olonel', client_ip: '10.0.0.5')).first
+#=> 200
+
+## a NON-admin path that merely decodes to something else is still untouched
+status_for(@encoded, 'tenant.example.com', path_info: '/%64ashboard')
+#=> 200
+
+## `/colonels` does not become an admin surface via encoding either
+status_for(@encoded, 'tenant.example.com', path_info: '/%63olonels')
+#=> 200
+
+# =================================================================
+# HOST PROVENANCE — a forwarded host from an untrusted peer (#4024)
+# =================================================================
+# With site.network.trusted_proxy unset (the shipped default) Rack::DetectHost
+# honors X-Forwarded-Host / Apx-Incoming-Host / X-Original-Host / Forwarded from
+# ANY peer on a private or loopback address — i.e. from every containerised
+# reverse-proxy install. The admin gate declines to rely on that: a detected
+# host that a forwarded header produced is accepted only when
+# env['otto.via_trusted_proxy'] is true, otherwise it must AGREE with the host
+# the `Host:` header alone would have given.
+#
+# HTTP_HOST is a corroborator here, never a source — see the HOST PROVENANCE
+# section above, which pins that HTTP_HOST cannot admit or evict anything.
+
+## forwarded header + untrusted peer + a host the Host header did NOT name:
+## DENIED, even though the detected host IS on the allowlist
+@fwd = build_mw(hosts: ['admin.example.com'])
+status_with(@fwd, 'admin.example.com', { 'HTTP_X_FORWARDED_HOST' => 'admin.example.com' },
+            http_host: 'tenant.example.com')
+#=> 404
+
+## the same request from a peer otto vouched for is SERVED (control: the header
+## is not inert, it is untrusted)
+status_with(@fwd, 'admin.example.com',
+            { 'HTTP_X_FORWARDED_HOST' => 'admin.example.com', 'otto.via_trusted_proxy' => true },
+            http_host: 'tenant.example.com')
+#=> 200
+
+## otto.via_trusted_proxy=false means trust IS configured and this peer FAILED
+## it — strictly worse than absent, so the forwarded host is still refused
+status_with(@fwd, 'admin.example.com',
+            { 'HTTP_X_FORWARDED_HOST' => 'admin.example.com', 'otto.via_trusted_proxy' => false },
+            http_host: 'tenant.example.com')
+#=> 404
+
+## a present-but-non-boolean trust key is treated as untrusted (presence implies
+## the tri-state contract; a future otto surprise must not widen the gate)
+status_with(@fwd, 'admin.example.com',
+            { 'HTTP_X_FORWARDED_HOST' => 'admin.example.com', 'otto.via_trusted_proxy' => 'true' },
+            http_host: 'tenant.example.com')
+#=> 404
+
+## Apx-Incoming-Host — the Approximated custom-domain ingress header — is
+## judged the same way. This is the live attack shape: a request to a tenant
+## custom domain claiming to be the canonical admin host.
+status_with(@fwd, 'admin.example.com', { 'HTTP_APX_INCOMING_HOST' => 'admin.example.com' },
+            http_host: 'secrets.tenant.test')
+#=> 404
+
+## X-Original-Host too
+status_with(@fwd, 'admin.example.com', { 'HTTP_X_ORIGINAL_HOST' => 'admin.example.com' },
+            http_host: 'secrets.tenant.test')
+#=> 404
+
+## and the RFC 7239 Forwarded header
+status_with(@fwd, 'admin.example.com', { 'HTTP_FORWARDED' => 'host=admin.example.com' },
+            http_host: 'secrets.tenant.test')
+#=> 404
+
+## the API surface is judged identically
+status_with(@fwd, 'admin.example.com', { 'HTTP_X_FORWARDED_HOST' => 'admin.example.com' },
+            http_host: 'tenant.example.com', script_name: '/api/colonel', path_info: '/info')
+#=> 404
+
+## a forwarded header that did NOT change the answer is fine: the detected host
+## equals what `Host:` alone would have produced. This is the ordinary
+## nginx/Caddy `proxy_set_header Host $host` topology.
+status_with(@fwd, 'admin.example.com', { 'HTTP_X_FORWARDED_HOST' => 'admin.example.com' },
+            http_host: 'admin.example.com')
+#=> 200
+
+## agreement is judged after normalization, not byte-for-byte
+status_with(@fwd, 'admin.example.com', { 'HTTP_X_FORWARDED_HOST' => 'admin.example.com' },
+            http_host: 'ADMIN.Example.COM:8443')
+#=> 200
+
+## no forwarded header at all: nothing could have overridden Host, so the
+## detected host stands on its own (this is every case elsewhere in this file)
+status_with(@fwd, 'admin.example.com', {}, http_host: 'tenant.example.com')
+#=> 200
+
+## an untrusted forwarded header cannot DENY an otherwise-good request either,
+## as long as it agrees — trust widens what is read, never what is admitted
+status_with(@fwd, 'tenant.example.com', { 'HTTP_X_FORWARDED_HOST' => 'admin.example.com' },
+            http_host: 'tenant.example.com')
+#=> 404
+
+## a nil detected host with a forwarded header present is denied, not rescued
+## by HTTP_HOST — HTTP_HOST is never a source
+status_with(@fwd, nil, { 'HTTP_X_FORWARDED_HOST' => 'admin.example.com' }, http_host: 'admin.example.com')
+#=> 404
+
+## provenance is a HOST-gate rule: with the host gate off, a forwarded header
+## from an untrusted peer changes nothing
+@fwd_off = build_mw(hosts: ['*'])
+status_with(@fwd_off, 'admin.example.com', { 'HTTP_X_FORWARDED_HOST' => 'admin.example.com' },
+            http_host: 'tenant.example.com')
+#=> 200
+
+## and it never touches a non-admin path
+status_with(@fwd, 'admin.example.com', { 'HTTP_X_FORWARDED_HOST' => 'admin.example.com' },
+            http_host: 'tenant.example.com', path_info: '/dashboard')
+#=> 200
+
+# =================================================================
+# UNREADABLE CONFIG — denies, never deactivates
+# =================================================================
+# OT.conf.dig raising is NOT the same fact as "the operator left it unset", and
+# returning nil for both let a raising config degrade a configured gate to the
+# anchor fallback and from there to INACTIVE — admin served on every hostname,
+# with a boot WARN blaming site.host.
+
+## an unreadable site.admin block leaves BOTH gates active and denying
+@unreadable = begin
+  OT.conf['site']['admin'] = Object.new # Hash#dig raises TypeError on this
+  TestAdminNetworkIsolation.new(@mock_app)
+end
+[@unreadable.host_gate_active?, @unreadable.network_gate_active?, @unreadable.allowed_hosts]
+#=> [true, true, []]
+
+## unreadable config - both surfaces 404, on every host
+both_surfaces(@unreadable, 'example.com')
+#=> [404, 404]
+
+## unreadable config - a routable canonical anchor does not rescue it
+status_for(@unreadable, 'anything.example.test')
+#=> 404
+
+## unreadable config - non-admin paths are untouched (not a blanket outage)
+status_for(@unreadable, 'example.com', path_info: '/dashboard')
+#=> 200
+
+## unreadable config - restored, and the next instance reads config normally
+@restored = begin
+  OT.conf['site']['admin'] = { 'allowed_hosts' => [], 'allowed_cidrs' => [] }
+  build_mw(hosts: ['admin.example.com'])
+end
+[@restored.allowed_hosts, @restored.network_gate_active?]
+#=> [['admin.example.com'], false]
+
+# =================================================================
+# CIDR GATE — a configured list with nothing parseable DENIES
+# =================================================================
+# Symmetric with the host gate: a list an operator wrote is never silently
+# disabled. Before the #4062 review every entry was WARNed away individually and
+# the empty result read as "no network gate" — the admin surfaces became
+# reachable from anywhere while the operator believed a VPN restriction held.
+
+## every entry malformed - the gate stays ACTIVE with no ranges
+@bad_cidrs = build_mw(cidrs: ['100.64.0.0\10', 'not-a-cidr'])
+[@bad_cidrs.network_gate_active?, @bad_cidrs.allowed?('100.64.7.7')]
+#=> [true, false]
+
+## every entry malformed - denied from inside the range the operator MEANT
+@bad_cidrs.call(admin_env(script_name: '', path_info: '/colonel', client_ip: '100.64.7.7')).first
+#=> 404
+
+## every entry malformed - denied from a public IP too, on both surfaces
+both_surfaces(@bad_cidrs, nil)
+#=> [404, 404]
+
+## every entry malformed - non-admin paths untouched
+status_for(@bad_cidrs, nil, path_info: '/dashboard')
+#=> 200
+
+## ONE parseable entry among malformed ones enforces normally (partial failure
+## is still a WARN, not a deny)
+@one_cidr = build_mw(cidrs: ['garbage', '10.0.0.0/8'])
+[@one_cidr.network_gate_active?,
+ status_for(@one_cidr, nil, client_ip: '10.0.0.5'),
+ status_for(@one_cidr, nil, client_ip: '203.0.113.9')]
+#=> [true, 200, 404]
+
+## an EMPTY list still means "no network gate" - unchanged, and the whole
+## reason the malformed case has to be told apart from it
+@no_cidrs = build_mw(cidrs: [])
+[@no_cidrs.network_gate_active?, status_for(@no_cidrs, nil, client_ip: '203.0.113.9')]
+#=> [false, 200]
+
+## a list of BLANK entries is "empty", not "unusable"
+build_mw(cidrs: ['', '   ']).network_gate_active?
+#=> false
+
+# =================================================================
+# BOOT LOGGING — once per process, not once per mounted app
+# =================================================================
+# MiddlewareStack.configure runs for each of the 13 registered applications, all
+# from one config. Without a ledger every boot prints 13 identical posture lines
+# and 13 copies of each WARN, which reads like 13 separate misconfigurations.
+
+## an identical posture built twice announces once
+@log_counts = begin
+  Onetime::Middleware::AdminNetworkIsolation.reset_boot_announcements!
+  build_mw(hosts: ['admin.example.com'])
+  first = Onetime::Middleware::AdminNetworkIsolation.boot_announcement_count
+  12.times { build_mw(hosts: ['admin.example.com']) }
+  [first, Onetime::Middleware::AdminNetworkIsolation.boot_announcement_count]
+end
+#=> [1, 1]
+
+## a DIFFERENT posture still announces - dedupe is per posture, not a mute
+build_mw(hosts: ['other.example.com'])
+Onetime::Middleware::AdminNetworkIsolation.boot_announcement_count
+#=> 2
+
+## the wildcard WARN and the posture line are separate announcements
+@wild_counts = begin
+  Onetime::Middleware::AdminNetworkIsolation.reset_boot_announcements!
+  build_mw(hosts: ['*'])
+  Onetime::Middleware::AdminNetworkIsolation.boot_announcement_count
+end
+#=> 2
+
+## the `*`-with-siblings case adds the ignored-siblings WARN
+@sibling_counts = begin
+  Onetime::Middleware::AdminNetworkIsolation.reset_boot_announcements!
+  build_mw(hosts: ['*', 'admin.example.com'])
+  Onetime::Middleware::AdminNetworkIsolation.boot_announcement_count
+end
+#=> 3
+
 # Restore every global this file mutated: both admin lists, site.host, the
 # features.domains block, and the DetectHost result field. `rake try:unit` runs
 # all unit tryouts in one process — a leak here changes what later files see.
@@ -984,3 +1330,4 @@ OT.conf['site']['admin'] = @orig_admin if @orig_admin
 OT.conf['site']['host'] = @orig_site_host
 OT.conf['features']['domains'] = @orig_domains if @orig_domains
 Rack::DetectHost.result_field_name = @orig_detected_field
+Onetime::Middleware::AdminNetworkIsolation.reset_boot_announcements!

--- a/try/unit/middleware/admin_network_isolation_try.rb
+++ b/try/unit/middleware/admin_network_isolation_try.rb
@@ -577,6 +577,33 @@ status_for(@blanks, 'tenant.example.com')
 build_mw(hosts: ['admin.example.com', 'ADMIN.example.com:443']).allowed_hosts
 #=> ['admin.example.com']
 
+## REGRESSION: the wildcard test reads the NORMALIZED host, not the raw entry.
+## A URL with a globbed path names one enforceable hostname; rejecting it made
+## a sole such entry an active-but-empty allowlist that 404s both surfaces,
+## under a WARN saying "wildcard patterns are not supported" about a hostname
+## that holds no wildcard.
+@globbed_path = build_mw(hosts: ['https://admin.example.com/*'])
+[@globbed_path.allowed_hosts, both_surfaces(@globbed_path, 'admin.example.com')]
+#=> [['admin.example.com'], [200, 200]]
+
+## a globbed QUERY on a scheme-bearing entry is the same story
+build_mw(hosts: ['https://admin.example.com/?q=*']).allowed_hosts
+#=> ['admin.example.com']
+
+## that entry is not merely tolerated - it is classified enforceable
+@allowlist.rejection_reason('https://admin.example.com/*')
+#=> nil
+
+## a pattern in the HOST survives normalization, so it is still rejected -
+## and still as :wildcard_pattern, not some downstream reason
+@allowlist.rejection_reason('*.example.com')
+#=> :wildcard_pattern
+
+## schemeless, the glob is not a path the parser can strip: it stays part of
+## the host and is rejected
+@allowlist.rejection_reason('admin.example.com/*')
+#=> :wildcard_pattern
+
 ## normalize_host - ONE function for both sides, and it lives in the shared
 ## classifier so the boot validator cannot drift from it
 @allowlist.normalize_host('HTTPS://Admin.Example.COM:8443/path')

--- a/try/unit/middleware/admin_network_isolation_try.rb
+++ b/try/unit/middleware/admin_network_isolation_try.rb
@@ -85,6 +85,51 @@ class TestAdminNetworkIsolation < Onetime::Middleware::AdminNetworkIsolation
   def allowed_hosts
     @allowed_hosts
   end
+
+  # Swap a recorder in for the duration of the block and return the WARN lines
+  # it saw, as [message, payload] pairs.
+  #
+  # Installed AFTER construction on purpose: the boot lines already went to the
+  # real logger (and have their own announcement-ledger cases at the bottom of
+  # this file), so only PER-REQUEST denials land here.
+  def capture_warns
+    real     = @logger
+    recorder = WarnRecorder.new
+    @logger  = recorder
+    yield
+    recorder.warns
+  ensure
+    @logger = real
+  end
+end
+
+# Records the WARN lines one middleware instance emits.
+#
+# The three host refusals — unattributable forwarded host, unresolvable host,
+# allowlist miss — are the IDENTICAL 404 by design; indistinguishable-from-absent
+# is the whole point of the response side. That leaves the LOG LINE as the only
+# thing that tells an operator which one fired, which is why it is worth
+# asserting on and why these cases cannot go through status alone.
+class WarnRecorder
+  attr_reader :warns
+
+  def initialize
+    @warns = []
+  end
+
+  def warn(message, payload = nil)
+    @warns << [message, payload]
+    nil
+  end
+
+  # Every other level is swallowed: only the denial WARNs are under test.
+  def method_missing(_name, *_args)
+    nil
+  end
+
+  def respond_to_missing?(_name, _include_private = false)
+    true
+  end
 end
 
 @allowlist = Onetime::Utils::AdminHostAllowlist
@@ -171,6 +216,18 @@ def status_with(mw, detected_host, extra, http_host: nil, path_info: '/colonel',
     extra: extra,
   )
   mw.call(env).first
+end
+
+# One request's [status, WARN messages]. Same call shape as status_with, and
+# the only way to tell the three identical-404 host refusals apart.
+def denial_warns(mw, detected_host, extra = {}, http_host: nil, path_info: '/colonel', script_name: '')
+  status   = nil
+  recorded = mw.capture_warns do
+    status = status_with(mw, detected_host, extra,
+                         http_host: http_host, path_info: path_info, script_name: script_name)
+  end
+
+  [status, recorded.map(&:first)]
 end
 
 # Status of one admin-surface request. Defaults to the /colonel shell from a
@@ -560,6 +617,64 @@ both_surfaces(@hosts, nil)
 ## host_allowed? - nil and empty are rejected directly
 [@hosts.host_allowed?(nil), @hosts.host_allowed?('')]
 #=> [false, false]
+
+# --- ...and the denial says WHICH refusal it was (#4098) -----------------
+# The behaviour above must never change: no host means 404, fail closed. What
+# the review found was a DIAGNOSABILITY defect one layer over. All three host
+# refusals are the same 404, so the WARN is the operator's only diagnosis — and
+# "denied by host allowlist" with `host: nil` names a config key that was never
+# consulted and cannot be edited into working. The live shape: a single
+# container reached by bare IP whose operator set ADMIN_ALLOWED_HOSTS=10.0.0.5,
+# an entry Rack::DetectHost can never produce a match for.
+
+## nil detected host - the WARN names the unresolvable host, NOT the allowlist
+denial_warns(@hosts, nil)
+#=> [404, ['Admin surface access denied: no host could be detected for this request']]
+
+## absent detected-host key - same line (DetectHost never ran, same diagnosis)
+@absent_warns = @hosts.capture_warns { status_for(@hosts, :unset) }
+@absent_warns.map(&:first)
+#=> ['Admin surface access denied: no host could be detected for this request']
+
+## empty detected host - same line
+denial_warns(@hosts, '')
+#=> [404, ['Admin surface access denied: no host could be detected for this request']]
+
+## whitespace-only detected host - normalizes to nil, so same line
+denial_warns(@hosts, '   ')
+#=> [404, ['Admin surface access denied: no host could be detected for this request']]
+
+## the API surface is diagnosed identically
+denial_warns(@hosts, nil, {}, script_name: '/api/colonel', path_info: '/info')
+#=> [404, ['Admin surface access denied: no host could be detected for this request']]
+
+## a host that WAS judged and missed still gets the allowlist line - the two
+## refusals did not collapse into one
+denial_warns(@hosts, 'tenant.example.com')
+#=> [404, ['Admin surface access denied by host allowlist']]
+
+## an admitted host warns about nothing
+denial_warns(@hosts, 'admin.example.com')
+#=> [200, []]
+
+## the unresolvable-host payload carries the SAME key set as the other two
+## denials, so an operator's existing log query does not have to special-case it
+@nil_warn = @hosts.capture_warns { status_for(@hosts, nil) }.first
+[@nil_warn.last.keys.sort, @nil_warn.last[:host], @nil_warn.last[:path], @nil_warn.last[:method]]
+#=> [%i[host method note path], nil, '/colonel', 'GET']
+
+## the note names the real cause and the two remedies, and never blames the
+## allowlist for a rejection it did not make
+@nil_note = @nil_warn.last[:note]
+[@nil_note.include?('Rack::DetectHost emits no host'),
+ @nil_note.include?('never consulted'),
+ @nil_note.include?('routable hostname'),
+ @nil_note.include?('ADMIN_ALLOWED_HOSTS=*')]
+#=> [true, true, true, true]
+
+## the allowlist is still never echoed into the RESPONSE, only the log
+denial_triple(@hosts, nil, '203.0.113.9', '', '/colonel').last.include?('admin.example.com')
+#=> false
 
 # --- exact match only: no subdomain or suffix tolerance -----------------
 
@@ -1193,6 +1308,29 @@ status_with(@fwd, 'tenant.example.com', { 'HTTP_X_FORWARDED_HOST' => 'admin.exam
 ## by HTTP_HOST — HTTP_HOST is never a source
 status_with(@fwd, nil, { 'HTTP_X_FORWARDED_HOST' => 'admin.example.com' }, http_host: 'admin.example.com')
 #=> 404
+
+## ...and the line it gets is the UNRESOLVABLE-HOST one, not the untrusted-peer
+## one. Nothing was overridden because nothing was produced: DetectHost declined
+## to emit a host at all, so there is no attribution question to answer. The
+## provenance line would send the operator to configure
+## site.network.trusted_proxy, which cannot conjure a host out of a request that
+## has none — the wrong remedy for the wrong cause.
+denial_warns(@fwd, nil, { 'HTTP_X_FORWARDED_HOST' => 'admin.example.com' }, http_host: 'admin.example.com')
+#=> [404, ['Admin surface access denied: no host could be detected for this request']]
+
+## control: a REAL detected host from an untrusted forwarded header still gets
+## the provenance line — the new line did not swallow it, and provenance is
+## still judged BEFORE membership
+denial_warns(@fwd, 'admin.example.com', { 'HTTP_X_FORWARDED_HOST' => 'admin.example.com' },
+             http_host: 'tenant.example.com')
+#=> [404, ['Admin surface access denied: forwarded host from an untrusted peer']]
+
+## control: an empty detected host with a trusted peer is STILL denied, with the
+## unresolvable line — trust widens what may be read, never what is admitted
+denial_warns(@fwd, nil,
+             { 'HTTP_X_FORWARDED_HOST' => 'admin.example.com', 'otto.via_trusted_proxy' => true },
+             http_host: 'admin.example.com')
+#=> [404, ['Admin surface access denied: no host could be detected for this request']]
 
 ## provenance is a HOST-gate rule: with the host gate off, a forwarded header
 ## from an untrusted peer changes nothing


### PR DESCRIPTION
Resolves #4062

The admin surfaces (`/colonel`, `/api/colonel`) answered on every hostname the app serves, including tenant custom domains. Nothing but incidental cookie scoping and custom-domain signin defaulting off kept the console off a tenant host.

This adds a host allowlist in front of the existing CIDR allowlist. The host comes from `Rack::DetectHost`'s validated result, deliberately not `onetime.domain_strategy` — a request header must never decide admin reachability. Either failure returns the same 404, so a denial stays indistinguishable from an absent route.

`site.admin.allowed_hosts` is new; an explicitly set allowlist that names nothing enforceable (IP literals, wildcards, non-ASCII) raises `ConfigError` at boot rather than silently disabling the gate. Unset falls back to the canonical ANCHOR hosts plus `www.` variants — not `CanonicalHosts.hosts`, which would include the #4063 link_domains pool. The fallback goes inert when the anchors yield nothing DetectHost could emit, so stock local-dev and bare-IP installs are unaffected.

Related to #4063.