### PR TITLE
i18n: update sv_SE translations

### DIFF
--- a/locales/content/sv_SE/00-common.json
+++ b/locales/content/sv_SE/00-common.json
@@ -1539,5 +1539,9 @@
   "web.TITLES.domain_dns": {
     "text": "DNS-konfiguration",
     "source_hash": "6c63df31"
+  },
+  "web.TITLES.connected_identities": {
+    "text": "Anslutna identiteter",
+    "source_hash": "e132c4d9"
   }
 }

--- a/locales/content/sv_SE/admin-audit.json
+++ b/locales/content/sv_SE/admin-audit.json
@@ -98,5 +98,41 @@
   "web.admin.audit.result.failure": {
     "text": "Misslyckades",
     "source_hash": "7031edbc"
+  },
+  "web.admin.audit.categories.secret": {
+    "text": "Hemligheter",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.audit.categories.membership": {
+    "text": "Medlemskap",
+    "source_hash": "b50f1a42"
+  },
+  "web.admin.audit.categories.entitlement_preview": {
+    "text": "Förhandsvisningar av rättigheter",
+    "source_hash": "255c5797"
+  },
+  "web.admin.audit.categories.colonel": {
+    "text": "Colonel-inloggningar",
+    "source_hash": "01eeeb38"
+  },
+  "web.admin.audit.filters.actorLabel": {
+    "text": "Aktör",
+    "source_hash": "449995c4"
+  },
+  "web.admin.audit.filters.searchButton": {
+    "text": "Sök",
+    "source_hash": "49c266ba"
+  },
+  "web.admin.audit.filters.searchHint": {
+    "text": "Skriv en aktör och tryck sedan Enter eller välj Sök för att köra den. Listan uppdateras inte medan du skriver.",
+    "source_hash": "45eceb12"
+  },
+  "web.admin.audit.filters.pendingSearch": {
+    "text": "Inte sökt ännu — tryck Enter eller välj Sök för att tillämpa denna aktör.",
+    "source_hash": "f76095c2"
+  },
+  "web.admin.audit.list.contractError": {
+    "text": "Servern svarade, men granskningsdata matchade inte det förväntade formatet. Inga händelser kan visas — detta är ett rapporteringsfel, inte en tom logg.",
+    "source_hash": "7f48137e"
   }
 }

--- a/locales/content/sv_SE/admin-billing.json
+++ b/locales/content/sv_SE/admin-billing.json
@@ -122,5 +122,85 @@
   "web.admin.billing.status.changed": {
     "text": "Ändrad",
     "source_hash": "2a6141e4"
+  },
+  "web.admin.billing.diff.backToCatalog": {
+    "text": "Tillbaka till faktureringskatalog",
+    "source_hash": "8532b373"
+  },
+  "web.admin.billing.diff.driftedFields": {
+    "text": "Fält som skiljer sig:",
+    "source_hash": "9890c95b"
+  },
+  "web.admin.billing.diff.notFound": {
+    "text": "Plan finns inte i katalogen",
+    "source_hash": "0253898b"
+  },
+  "web.admin.billing.diff.notFoundDescription": {
+    "text": "Ingen plan med id {planid} hittades i den konfigurerade katalogen eller den Stripe-synkroniserade cachen.",
+    "source_hash": "2e69551c"
+  },
+  "web.admin.billing.stripeOrgs.title": {
+    "text": "Stripe-kunder",
+    "source_hash": "0463ae27"
+  },
+  "web.admin.billing.stripeOrgs.description": {
+    "text": "Organisationer kopplade till en Stripe-kundpost.",
+    "source_hash": "2ab09aec"
+  },
+  "web.admin.billing.stripeOrgs.searchPlaceholder": {
+    "text": "Sök efter Stripe-kund-ID",
+    "source_hash": "d5acf08f"
+  },
+  "web.admin.billing.stripeOrgs.empty": {
+    "text": "Inga organisationer har ett Stripe-kund-ID.",
+    "source_hash": "2e373537"
+  },
+  "web.admin.billing.stripeOrgs.emptySearch": {
+    "text": "Inget Stripe-kund-ID matchar den sökningen.",
+    "source_hash": "75011174"
+  },
+  "web.admin.billing.stripeOrgs.loadError": {
+    "text": "Kunde inte ladda listan över Stripe-kunder.",
+    "source_hash": "15e2d9a7"
+  },
+  "web.admin.billing.stripeOrgs.unavailable": {
+    "text": "Listan över Stripe-kunder är inte tillgänglig på denna server ännu.",
+    "source_hash": "aab6451a"
+  },
+  "web.admin.billing.stripeOrgs.none": {
+    "text": "Ingen",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.billing.stripeOrgs.capped": {
+    "text": "Indexsökningen nådde sin gräns, så totalen är en undre gräns — begränsa sökningen för att se resten.",
+    "source_hash": "20bcaa38"
+  },
+  "web.admin.billing.stripeOrgs.stale": {
+    "text": "{count} indexpost/indexposter på denna sida pekar på en organisation som inte längre laddas och hoppades över.",
+    "source_hash": "51980f83"
+  },
+  "web.admin.billing.stripeOrgs.copyStripeId": {
+    "text": "Kopiera Stripe-kund-ID",
+    "source_hash": "a77d18b1"
+  },
+  "web.admin.billing.stripeOrgs.columns.organization": {
+    "text": "Organisation",
+    "source_hash": "d764d425"
+  },
+  "web.admin.billing.stripeOrgs.columns.owner": {
+    "text": "Ägare",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.billing.stripeOrgs.columns.plan": {
+    "text": "Plan",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.billing.stripeOrgs.columns.subscription": {
+    "text": "Prenumeration",
+    "source_hash": "4999c6c6"
+  },
+  "web.admin.billing.stripeOrgs.columns.stripeCustomer": {
+    "text": "Stripe-kund-ID",
+    "source_hash": "7e1d8bbb"
   }
 }

--- a/locales/content/sv_SE/admin-colonel.json
+++ b/locales/content/sv_SE/admin-colonel.json
@@ -838,5 +838,37 @@
   "web.colonel.nav.groups.communications": {
     "text": "Kommunikation",
     "source_hash": "919a9253"
+  },
+  "web.colonel.organizations.sameAsContact": {
+    "text": "Samma som kontakt",
+    "source_hash": "ed18ff43"
+  },
+  "web.colonel.organizations.refresh": {
+    "text": "Uppdatera",
+    "source_hash": "0e916101"
+  },
+  "web.colonel.organizations.updatedAgo": {
+    "text": "Uppdaterad {ago}",
+    "source_hash": "cda30b9c"
+  },
+  "web.colonel.organizations.columns.name": {
+    "text": "Namn",
+    "source_hash": "dcd1d522"
+  },
+  "web.colonel.organizations.columns.contactEmail": {
+    "text": "E-post för kontakt",
+    "source_hash": "6d7fce11"
+  },
+  "web.colonel.organizations.columns.billingEmail": {
+    "text": "E-post för fakturering",
+    "source_hash": "8805b928"
+  },
+  "web.colonel.organizations.columns.planSubscription": {
+    "text": "Plan och prenumeration",
+    "source_hash": "b396caac"
+  },
+  "web.colonel.organizations.filters.searchPlaceholder": {
+    "text": "Sök efter ID, namn eller e-post",
+    "source_hash": "6fe16473"
   }
 }

--- a/locales/content/sv_SE/admin-customers.json
+++ b/locales/content/sv_SE/admin-customers.json
@@ -4,8 +4,8 @@
     "source_hash": "aabe76f1"
   },
   "web.admin.customers.description": {
-    "text": "Hitta en kund och lös supportärenden utan SSH.",
-    "source_hash": "c8487e68"
+    "text": "Hitta en kund och lös supportärenden.",
+    "source_hash": "00961ea3"
   },
   "web.admin.customers.actions.plan.label": {
     "text": "Plan",
@@ -482,5 +482,213 @@
   "web.admin.customers.suspended.badge": {
     "text": "Avstängd",
     "source_hash": "e392a389"
+  },
+  "web.admin.customers.actions.checkoutLink.button": {
+    "text": "Skapa kassalänk",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.modalTitle": {
+    "text": "Skapa kassalänk",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.planLabel": {
+    "text": "Plan",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.actions.checkoutLink.planPlaceholder": {
+    "text": "Plan-familje-ID (t.ex. identity_plus_v1)",
+    "source_hash": "12eba027"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleLabel": {
+    "text": "Faktureringscykel",
+    "source_hash": "d69f731e"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleMonthly": {
+    "text": "Månadsvis",
+    "source_hash": "9b11f6b7"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleYearly": {
+    "text": "Årsvis",
+    "source_hash": "6e69b59e"
+  },
+  "web.admin.customers.actions.checkoutLink.allowPromo": {
+    "text": "Tillåt kampanjkoder",
+    "source_hash": "ebe7bc8b"
+  },
+  "web.admin.customers.actions.checkoutLink.submit": {
+    "text": "Skapa länk",
+    "source_hash": "e6b850cf"
+  },
+  "web.admin.customers.actions.checkoutLink.resultLead": {
+    "text": "Kassalänk skapad. Dela den med kunden — den kan användas en gång och går ut.",
+    "source_hash": "6ff1fb0e"
+  },
+  "web.admin.customers.actions.checkoutLink.copy": {
+    "text": "Kopiera kassalänk",
+    "source_hash": "f1e51ca7"
+  },
+  "web.admin.customers.actions.checkoutLink.expiry": {
+    "text": "Går ut om ~{hours}h ({date}).",
+    "source_hash": "4c878a15"
+  },
+  "web.admin.customers.actions.checkoutLink.regionLabel": {
+    "text": "Region",
+    "source_hash": "d3a008ef"
+  },
+  "web.admin.customers.actions.checkoutLink.parseError": {
+    "text": "Servern accepterade begäran men returnerade ett oläsligt svar, så ingen länk kan visas. Kontrollera Stripe innan du försöker igen.",
+    "source_hash": "e7e08290"
+  },
+  "web.admin.customers.actions.checkoutLink.done": {
+    "text": "Klar",
+    "source_hash": "11a6767d"
+  },
+  "web.admin.customers.actions.purge.typePrompt": {
+    "text": "För att bekräfta, skriv kontots e-postadress {token} nedan",
+    "source_hash": "8b2a1819"
+  },
+  "web.admin.customers.actions.purge.unavailable": {
+    "text": "Rensning är inte tillgänglig: detta konto har ingen e-postadress att skriva om som bekräftelse.",
+    "source_hash": "5f20f7e5"
+  },
+  "web.admin.customers.columns.actions": {
+    "text": "Åtgärder",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.diagnostics.title": {
+    "text": "Kontodiagnostik",
+    "source_hash": "5574ece8"
+  },
+  "web.admin.customers.detail.diagnostics.loading": {
+    "text": "Kör diagnos…",
+    "source_hash": "062c83d5"
+  },
+  "web.admin.customers.detail.diagnostics.loadError": {
+    "text": "Kunde inte ladda diagnostik.",
+    "source_hash": "69e69f49"
+  },
+  "web.admin.customers.detail.diagnostics.healthy": {
+    "text": "Inget blockerande tillstånd hittades. Autentiseringsstatus ser frisk ut — misstänk klientsideproblem (cookies, inloggningskonfiguration för anpassad domän) eller fel region.",
+    "source_hash": "f6d5f8d1"
+  },
+  "web.admin.customers.detail.diagnostics.authUnavailable": {
+    "text": "Autentiseringsdatabas inte tillgänglig (enkelt autentiseringsläge) — SQL-sidekontroller hoppades över.",
+    "source_hash": "d668907c"
+  },
+  "web.admin.customers.detail.diagnostics.authFailed": {
+    "text": "Autentiseringsdatabasen svarade inte, så SQL-sidekontroller kunde inte köras: {reason}",
+    "source_hash": "46d047c0"
+  },
+  "web.admin.customers.detail.diagnostics.unknown": {
+    "text": "Okänd",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.title": {
+    "text": "Autentiseringslogg",
+    "source_hash": "48ad8ba8"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.empty": {
+    "text": "Inga autentiseringshändelser registrerade.",
+    "source_hash": "d2332558"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.unavailable": {
+    "text": "Autentiseringsloggen kunde inte läsas: {reason}",
+    "source_hash": "ab18af57"
+  },
+  "web.admin.customers.detail.diagnostics.facts.authStatus": {
+    "text": "Autentiseringsstatus",
+    "source_hash": "34def169"
+  },
+  "web.admin.customers.detail.diagnostics.facts.noAccount": {
+    "text": "Inget autentiseringskonto",
+    "source_hash": "a9968e9e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.password": {
+    "text": "Lösenord",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordSet": {
+    "text": "Inställt",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordNone": {
+    "text": "Inget",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfa": {
+    "text": "MFA",
+    "source_hash": "d39ce053"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfaNone": {
+    "text": "Inget",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.loginFailures": {
+    "text": "Misslyckade försök",
+    "source_hash": "63e7f0a8"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lockedBadge": {
+    "text": "Utelåst",
+    "source_hash": "ace29f74"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiter": {
+    "text": "Hastighetsbegränsare",
+    "source_hash": "32892404"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterEngaged": {
+    "text": "Aktiverad",
+    "source_hash": "1b0d851e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterClear": {
+    "text": "Fri",
+    "source_hash": "83b12c22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verification": {
+    "text": "Verifieringsmail",
+    "source_hash": "23fac8fb"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationPending": {
+    "text": "Väntar — senast skickad {date}",
+    "source_hash": "9ab8d1b6"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationNone": {
+    "text": "Ingen väntar",
+    "source_hash": "a4d4cc22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.sessions": {
+    "text": "Aktiva sessioner",
+    "source_hash": "61ad9909"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lastLogin": {
+    "text": "Senaste inloggning (auth)",
+    "source_hash": "373e7fb1"
+  },
+  "web.admin.customers.detail.receipts.partial": {
+    "text": "Delvis lista — visar de {count} senaste. Denna kund har fler kvitton än vad som visas här.",
+    "source_hash": "127fd4db"
+  },
+  "web.admin.customers.detail.secrets.partial": {
+    "text": "Delvis lista — visar de {count} senaste. Denna kund äger fler hemligheter än vad som visas här.",
+    "source_hash": "a537c8f3"
+  },
+  "web.admin.customers.detail.sessions.columns.country": {
+    "text": "Land",
+    "source_hash": "701d021d"
+  },
+  "web.admin.customers.detail.sessions.current.badge": {
+    "text": "Denna session",
+    "source_hash": "6da6530a"
+  },
+  "web.admin.customers.detail.sessions.current.tooltip": {
+    "text": "Din nuvarande administratörssession. Att återkalla den här har ingen effekt — den återskapas för resten av denna begäran.",
+    "source_hash": "ef097ab1"
+  },
+  "web.admin.customers.verification.verified": {
+    "text": "Verifierad",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.verification.unverified": {
+    "text": "Inte verifierad",
+    "source_hash": "15133907"
   }
 }

--- a/locales/content/sv_SE/admin-domains.json
+++ b/locales/content/sv_SE/admin-domains.json
@@ -190,5 +190,657 @@
   "web.admin.domains.verify.success.done": {
     "text": "Verifieringen är klar för {domain}.",
     "source_hash": "ed67e22d"
+  },
+  "web.admin.domains.actions.preview": {
+    "text": "Förhandsgranska",
+    "source_hash": "324b134f"
+  },
+  "web.admin.domains.actions.probe.button": {
+    "text": "Sök",
+    "source_hash": "3bd51ab9"
+  },
+  "web.admin.domains.actions.remove.button": {
+    "text": "Ta bort domän",
+    "source_hash": "5ce43507"
+  },
+  "web.admin.domains.actions.remove.previewButton": {
+    "text": "Förhandsgranska borttagning",
+    "source_hash": "6b81bd92"
+  },
+  "web.admin.domains.actions.remove.previewStatus": {
+    "text": "Status:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.remove.previewOrg": {
+    "text": "Organisation:",
+    "source_hash": "5300e286"
+  },
+  "web.admin.domains.actions.remove.reassertsSurvivor": {
+    "text": "En annan post gör anspråk på samma domännamn och kommer att ta över uppslagsindexet.",
+    "source_hash": "902838f4"
+  },
+  "web.admin.domains.actions.remove.confirmTitle": {
+    "text": "Ta bort domän?",
+    "source_hash": "716dfac9"
+  },
+  "web.admin.domains.actions.remove.confirmDescription": {
+    "text": "Detta raderar permanent {domain} och dess varumärkes-, DNS- och konfigurationsposter. Det kan inte ångras. Skriv om domänens publika ID för att fortsätta.",
+    "source_hash": "d0b67b47"
+  },
+  "web.admin.domains.actions.remove.success": {
+    "text": "Domän borttagen.",
+    "source_hash": "2ccaa6d3"
+  },
+  "web.admin.domains.actions.remove.notApplied": {
+    "text": "Servern förhandsgranskade borttagningen istället för att tillämpa den — domänen togs INTE bort. Försök igen, och rapportera detta om det kvarstår.",
+    "source_hash": "dc6d70ae"
+  },
+  "web.admin.domains.actions.repair.title": {
+    "text": "Reparera organisationslänk",
+    "source_hash": "82b40352"
+  },
+  "web.admin.domains.actions.repair.description": {
+    "text": "Hitta och åtgärda trasiga länkar mellan denna domän och dess organisation. Förhandsgranska först för att se vad som skulle ändras.",
+    "source_hash": "531ed287"
+  },
+  "web.admin.domains.actions.repair.orgIdLabel": {
+    "text": "Organisations-ID (endast föräldralösa domäner)",
+    "source_hash": "0d3010eb"
+  },
+  "web.admin.domains.actions.repair.orgIdPlaceholder": {
+    "text": "Lämna tomt om inte domänen saknar ägare",
+    "source_hash": "118b7132"
+  },
+  "web.admin.domains.actions.repair.statusLabel": {
+    "text": "Status:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.repair.noIssues": {
+    "text": "Inga problem hittades — inget att reparera.",
+    "source_hash": "17735887"
+  },
+  "web.admin.domains.actions.repair.button": {
+    "text": "Tillämpa reparation",
+    "source_hash": "4d0ab2d4"
+  },
+  "web.admin.domains.actions.repair.confirmTitle": {
+    "text": "Tillämpa reparation?",
+    "source_hash": "ef0ffae5"
+  },
+  "web.admin.domains.actions.repair.confirmDescription": {
+    "text": "Detta skriver om organisationslänken för {domain}. Skriv om domänens publika ID för att fortsätta.",
+    "source_hash": "a9f2702f"
+  },
+  "web.admin.domains.actions.repair.success": {
+    "text": "Reparation tillämpad.",
+    "source_hash": "850bd784"
+  },
+  "web.admin.domains.actions.transfer.title": {
+    "text": "Överför till en annan organisation",
+    "source_hash": "1b0b0655"
+  },
+  "web.admin.domains.actions.transfer.description": {
+    "text": "Flytta denna domän till en annan organisation. Förhandsgranska först för att bekräfta båda sidor av flytten.",
+    "source_hash": "457e852d"
+  },
+  "web.admin.domains.actions.transfer.toOrgLabel": {
+    "text": "Destinations-organisations-ID",
+    "source_hash": "1a3f05c4"
+  },
+  "web.admin.domains.actions.transfer.fromOrgLabel": {
+    "text": "Förväntat nuvarande organisations-ID (valfritt)",
+    "source_hash": "f6e75729"
+  },
+  "web.admin.domains.actions.transfer.fromOrgPlaceholder": {
+    "text": "Bekräfta nuvarande ägare innan flytt",
+    "source_hash": "1ac6c59b"
+  },
+  "web.admin.domains.actions.transfer.from": {
+    "text": "Från",
+    "source_hash": "21819769"
+  },
+  "web.admin.domains.actions.transfer.to": {
+    "text": "Till",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.domains.actions.transfer.orphaned": {
+    "text": "Ingen organisation (föräldralös)",
+    "source_hash": "6f4c745c"
+  },
+  "web.admin.domains.actions.transfer.button": {
+    "text": "Tillämpa överföring",
+    "source_hash": "fb546c5c"
+  },
+  "web.admin.domains.actions.transfer.confirmTitle": {
+    "text": "Överför domän?",
+    "source_hash": "801eb986"
+  },
+  "web.admin.domains.actions.transfer.confirmDescription": {
+    "text": "Detta flyttar {domain} till organisation {org}. Skriv om domänens publika ID för att fortsätta.",
+    "source_hash": "52c8808d"
+  },
+  "web.admin.domains.actions.transfer.success": {
+    "text": "Domän överförd.",
+    "source_hash": "91e681ae"
+  },
+  "web.admin.domains.columns.domain": {
+    "text": "Domän",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domains.columns.organization": {
+    "text": "Organisation",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.columns.state": {
+    "text": "Verifiering",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.domains.columns.tls": {
+    "text": "TLS",
+    "source_hash": "d1c18ec0"
+  },
+  "web.admin.domains.columns.created": {
+    "text": "Skapad",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.columns.actions": {
+    "text": "Åtgärder",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.configs.title": {
+    "text": "Domänkonfiguration",
+    "source_hash": "d46aa480"
+  },
+  "web.admin.domains.configs.description": {
+    "text": "Domänspecifika konfigurationsposter som styr inloggning, registrering, hemligheter på startsidan, API-åtkomst, inkommande hemligheter, tenant-SSO och e-postutskick. En saknad post misslyckas stängt för de första fem.",
+    "source_hash": "1df99789"
+  },
+  "web.admin.domains.configs.loadError": {
+    "text": "Kunde inte ladda domänkonfigurationsposterna.",
+    "source_hash": "9417d718"
+  },
+  "web.admin.domains.configs.retry": {
+    "text": "Försök igen",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.configs.degraded": {
+    "text": "Konfigurationssvaret matchade inte det förväntade kontraktet. Uppdatera, och rapportera detta om det kvarstår.",
+    "source_hash": "b5d890c0"
+  },
+  "web.admin.domains.configs.notFoundNote": {
+    "text": "Denna domän finns inte längre, så dess konfigurationsposter kan inte laddas.",
+    "source_hash": "2d88a392"
+  },
+  "web.admin.domains.configs.detailsToggle": {
+    "text": "Detaljer",
+    "source_hash": "45989de4"
+  },
+  "web.admin.domains.configs.notEditable": {
+    "text": "Hanteras i arbetsytans domäninställningar.",
+    "source_hash": "54fe891f"
+  },
+  "web.admin.domains.configs.delete.button": {
+    "text": "Radera",
+    "source_hash": "e2d0a549"
+  },
+  "web.admin.domains.configs.delete.confirmTitle": {
+    "text": "Radera {kind}-konfiguration?",
+    "source_hash": "98e672db"
+  },
+  "web.admin.domains.configs.delete.confirmDescription": {
+    "text": "Detta raderar permanent {kind}-konfigurationsposten för {domain}. Domänen faller tillbaka till beteendet vid saknad post. Skriv om typen för att fortsätta.",
+    "source_hash": "8272c40c"
+  },
+  "web.admin.domains.configs.delete.success": {
+    "text": "Konfiguration raderad.",
+    "source_hash": "a0184b66"
+  },
+  "web.admin.domains.configs.edit.button": {
+    "text": "Redigera",
+    "source_hash": "464c4ffd"
+  },
+  "web.admin.domains.configs.edit.createButton": {
+    "text": "Skapa",
+    "source_hash": "4759498a"
+  },
+  "web.admin.domains.configs.edit.title": {
+    "text": "Konfigurera {kind}",
+    "source_hash": "8592148f"
+  },
+  "web.admin.domains.configs.edit.submit": {
+    "text": "Spara",
+    "source_hash": "1509f561"
+  },
+  "web.admin.domains.configs.edit.success": {
+    "text": "Konfiguration sparad.",
+    "source_hash": "6b5b3c69"
+  },
+  "web.admin.domains.configs.edit.unsetOption": {
+    "text": "Inte inställd",
+    "source_hash": "4895f731"
+  },
+  "web.admin.domains.configs.edit.domainsHint": {
+    "text": "En domän per rad.",
+    "source_hash": "6c03f4f7"
+  },
+  "web.admin.domains.configs.ensure.button": {
+    "text": "Skapa saknade konfigurationer",
+    "source_hash": "77991b75"
+  },
+  "web.admin.domains.configs.ensure.confirmTitle": {
+    "text": "Skapa saknade konfigurationsposter?",
+    "source_hash": "3f41dec2"
+  },
+  "web.admin.domains.configs.ensure.confirmDescription": {
+    "text": "Skapar inaktiverade poster på {domain} för: {kinds}. Allt startar inaktiverat, så beteendet ändras inte förrän en post aktiveras.",
+    "source_hash": "fed66221"
+  },
+  "web.admin.domains.configs.ensure.applyButton": {
+    "text": "Skapa poster",
+    "source_hash": "4bcbef42"
+  },
+  "web.admin.domains.configs.ensure.success": {
+    "text": "Saknade konfigurationsposter skapade.",
+    "source_hash": "3b6ead80"
+  },
+  "web.admin.domains.configs.ensure.nothingMissing": {
+    "text": "Inget att skapa — varje konfigurationspost finns redan. Listan har uppdaterats.",
+    "source_hash": "ad0df0ae"
+  },
+  "web.admin.domains.configs.ensure.notApplied": {
+    "text": "Servern förhandsgranskade ändringen istället för att tillämpa den — inga poster skapades. Försök igen, och rapportera detta om det kvarstår.",
+    "source_hash": "09d26379"
+  },
+  "web.admin.domains.configs.fields.enabled": {
+    "text": "Aktiverad",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.fields.signin_enabled": {
+    "text": "Inloggning aktiverad",
+    "source_hash": "cabe4898"
+  },
+  "web.admin.domains.configs.fields.email_auth_enabled": {
+    "text": "E-postautentisering aktiverad",
+    "source_hash": "4a762960"
+  },
+  "web.admin.domains.configs.fields.sso_enabled": {
+    "text": "SSO aktiverad",
+    "source_hash": "6e77e673"
+  },
+  "web.admin.domains.configs.fields.restrict_to": {
+    "text": "Begränsa till",
+    "source_hash": "a0bdf50a"
+  },
+  "web.admin.domains.configs.fields.signup_enabled": {
+    "text": "Registrering aktiverad",
+    "source_hash": "2637d0b2"
+  },
+  "web.admin.domains.configs.fields.autoverify": {
+    "text": "Autoverifiera",
+    "source_hash": "7e02211c"
+  },
+  "web.admin.domains.configs.fields.validation_strategy": {
+    "text": "Valideringsstrategi",
+    "source_hash": "a2e95531"
+  },
+  "web.admin.domains.configs.fields.allowed_signup_domains": {
+    "text": "Tillåtna registreringsdomäner",
+    "source_hash": "9b5bb5b1"
+  },
+  "web.admin.domains.configs.fields.secrets_mode": {
+    "text": "Hemlighetsläge",
+    "source_hash": "8d4349d6"
+  },
+  "web.admin.domains.configs.fields.disabled_homepage_variant": {
+    "text": "Inaktiverad startsidevariant",
+    "source_hash": "4695633b"
+  },
+  "web.admin.domains.configs.fields.ready": {
+    "text": "Redo",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.configs.fields.recipients": {
+    "text": "Mottagare",
+    "source_hash": "1e8568a8"
+  },
+  "web.admin.domains.configs.fields.provider_type": {
+    "text": "Leverantörstyp",
+    "source_hash": "8c0f6d3e"
+  },
+  "web.admin.domains.configs.fields.display_name": {
+    "text": "Visningsnamn",
+    "source_hash": "2b7f6a84"
+  },
+  "web.admin.domains.configs.fields.issuer": {
+    "text": "Utfärdare",
+    "source_hash": "39e02c46"
+  },
+  "web.admin.domains.configs.fields.tenant_id": {
+    "text": "Tenant-ID",
+    "source_hash": "de1f5fff"
+  },
+  "web.admin.domains.configs.fields.has_client_id": {
+    "text": "Klient-ID inställt",
+    "source_hash": "04a9fa3d"
+  },
+  "web.admin.domains.configs.fields.has_client_secret": {
+    "text": "Klienthemlighet inställd",
+    "source_hash": "6ee1c9e6"
+  },
+  "web.admin.domains.configs.fields.allowed_domains": {
+    "text": "Tillåtna domäner",
+    "source_hash": "bcd60db0"
+  },
+  "web.admin.domains.configs.fields.enforce_sso_only": {
+    "text": "Tvinga endast SSO",
+    "source_hash": "b3a3f694"
+  },
+  "web.admin.domains.configs.fields.grant_org_scope": {
+    "text": "Bevilja organisationsomfång",
+    "source_hash": "698ea5de"
+  },
+  "web.admin.domains.configs.fields.provider": {
+    "text": "Leverantör",
+    "source_hash": "472590ae"
+  },
+  "web.admin.domains.configs.fields.from_name": {
+    "text": "Från-namn",
+    "source_hash": "b28f93ea"
+  },
+  "web.admin.domains.configs.fields.from_address": {
+    "text": "Från-adress",
+    "source_hash": "d465bcfa"
+  },
+  "web.admin.domains.configs.fields.reply_to": {
+    "text": "Svara till",
+    "source_hash": "6b9c49b7"
+  },
+  "web.admin.domains.configs.fields.sending_mode": {
+    "text": "Sändningsläge",
+    "source_hash": "e2d6bcf7"
+  },
+  "web.admin.domains.configs.fields.verification_status": {
+    "text": "Verifieringsstatus",
+    "source_hash": "aedfff7e"
+  },
+  "web.admin.domains.configs.fields.dns_verified": {
+    "text": "DNS verifierad",
+    "source_hash": "8b2128c8"
+  },
+  "web.admin.domains.configs.fields.provider_verified": {
+    "text": "Leverantör verifierad",
+    "source_hash": "6f4d9cc4"
+  },
+  "web.admin.domains.configs.fields.has_api_key": {
+    "text": "API-nyckel inställd",
+    "source_hash": "d5115386"
+  },
+  "web.admin.domains.configs.fields.created": {
+    "text": "Skapad",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.configs.fields.updated": {
+    "text": "Uppdaterad",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.configs.kinds.signin": {
+    "text": "Inloggning",
+    "source_hash": "5bbbe531"
+  },
+  "web.admin.domains.configs.kinds.signup": {
+    "text": "Registrering",
+    "source_hash": "3cc08ebe"
+  },
+  "web.admin.domains.configs.kinds.homepage": {
+    "text": "Startsida",
+    "source_hash": "9e3391e9"
+  },
+  "web.admin.domains.configs.kinds.api": {
+    "text": "API",
+    "source_hash": "c8e5998f"
+  },
+  "web.admin.domains.configs.kinds.incoming": {
+    "text": "Inkommande",
+    "source_hash": "e301820a"
+  },
+  "web.admin.domains.configs.kinds.sso": {
+    "text": "SSO",
+    "source_hash": "5ba3ac9f"
+  },
+  "web.admin.domains.configs.kinds.mailer": {
+    "text": "E-postutskick",
+    "source_hash": "6c07ba63"
+  },
+  "web.admin.domains.configs.missingNotes.signin": {
+    "text": "Ingen post: inloggning är inaktiverad på denna domän om inte tenant-SSO är aktivt.",
+    "source_hash": "17dd6099"
+  },
+  "web.admin.domains.configs.missingNotes.signup": {
+    "text": "Ingen post: registrering är inaktiverad på denna domän.",
+    "source_hash": "c3c98956"
+  },
+  "web.admin.domains.configs.missingNotes.homepage": {
+    "text": "Ingen post: hemligheter på startsidan är inaktiverade (misslyckas stängt och loggar ett fel).",
+    "source_hash": "9a258a88"
+  },
+  "web.admin.domains.configs.missingNotes.api": {
+    "text": "Ingen post: det publika API:et är inaktiverat (misslyckas stängt och loggar ett fel).",
+    "source_hash": "fed99f73"
+  },
+  "web.admin.domains.configs.missingNotes.incoming": {
+    "text": "Ingen post: inkommande hemligheter är inaktiverade.",
+    "source_hash": "b957fbe8"
+  },
+  "web.admin.domains.configs.missingNotes.sso": {
+    "text": "Ingen post: tenant-SSO är inte tillgängligt; plattformens SSO-reservpolicy gäller.",
+    "source_hash": "7b05ade8"
+  },
+  "web.admin.domains.configs.missingNotes.mailer": {
+    "text": "Ingen post: plattformens e-posttjänst används.",
+    "source_hash": "e027cc99"
+  },
+  "web.admin.domains.configs.status.missing": {
+    "text": "Saknas",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.domains.configs.status.disabled": {
+    "text": "Inaktiverad",
+    "source_hash": "75081b59"
+  },
+  "web.admin.domains.configs.status.enabled": {
+    "text": "Aktiverad",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.status.enabledNotReady": {
+    "text": "Aktiverad, inte redo",
+    "source_hash": "cb806ba4"
+  },
+  "web.admin.domains.detail.openFullPage": {
+    "text": "Öppna helsida",
+    "source_hash": "a467911c"
+  },
+  "web.admin.domains.detail.backToList": {
+    "text": "Tillbaka till domäner",
+    "source_hash": "22fd50fe"
+  },
+  "web.admin.domains.detail.notFound": {
+    "text": "Domän hittades inte",
+    "source_hash": "7b8fc0e6"
+  },
+  "web.admin.domains.detail.notFoundDescription": {
+    "text": "Denna domän finns inte, eller så har den redan tagits bort.",
+    "source_hash": "e0f0b987"
+  },
+  "web.admin.domains.detail.loadError": {
+    "text": "Kunde inte ladda denna domän.",
+    "source_hash": "39e9c657"
+  },
+  "web.admin.domains.detail.retry": {
+    "text": "Försök igen",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.detail.never": {
+    "text": "Aldrig",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.domains.detail.none": {
+    "text": "Ingen",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.domains.detail.yes": {
+    "text": "Ja",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.domains.detail.no": {
+    "text": "Nej",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.domains.detail.organization.open": {
+    "text": "Öppna organisation",
+    "source_hash": "54a43621"
+  },
+  "web.admin.domains.detail.organization.unknown": {
+    "text": "Den ägande organisationen ingår inte i detta svar. Öppna denna domän från domänlistan för att se den.",
+    "source_hash": "bb5bdc9c"
+  },
+  "web.admin.domains.detail.sections.overview": {
+    "text": "Översikt",
+    "source_hash": "d4b1ea57"
+  },
+  "web.admin.domains.detail.sections.actions": {
+    "text": "Åtgärder",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.detail.sections.organization": {
+    "text": "Ägande organisation",
+    "source_hash": "39ad6d9c"
+  },
+  "web.admin.domains.detail.sections.dns": {
+    "text": "DNS",
+    "source_hash": "020965a2"
+  },
+  "web.admin.domains.detail.sections.diagnostics": {
+    "text": "Diagnostik",
+    "source_hash": "268f14bb"
+  },
+  "web.admin.domains.detail.sections.operations": {
+    "text": "Ägarskapsoperationer",
+    "source_hash": "eb9a8cbc"
+  },
+  "web.admin.domains.detail.sections.operationsHint": {
+    "text": "Varje operation förhandsgranskas först. Inget skrivs förrän du bekräftar tillämpningssteget.",
+    "source_hash": "f09bf7bd"
+  },
+  "web.admin.domains.fields.publicId": {
+    "text": "Publikt ID",
+    "source_hash": "3705b64f"
+  },
+  "web.admin.domains.fields.domainId": {
+    "text": "Internt ID",
+    "source_hash": "e468bb47"
+  },
+  "web.admin.domains.fields.organization": {
+    "text": "Organisation",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.fields.baseDomain": {
+    "text": "Basdomän",
+    "source_hash": "33295d5b"
+  },
+  "web.admin.domains.fields.subdomain": {
+    "text": "Underdomän",
+    "source_hash": "ba4520ab"
+  },
+  "web.admin.domains.fields.apex": {
+    "text": "Apex-domän",
+    "source_hash": "0a8a42fa"
+  },
+  "web.admin.domains.fields.status": {
+    "text": "Status",
+    "source_hash": "920e413c"
+  },
+  "web.admin.domains.fields.created": {
+    "text": "Skapad",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.fields.updated": {
+    "text": "Uppdaterad",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.fields.verified": {
+    "text": "Verifierad",
+    "source_hash": "4f783840"
+  },
+  "web.admin.domains.fields.resolving": {
+    "text": "Löser upp",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.fields.ready": {
+    "text": "Redo",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.list.searchPlaceholder": {
+    "text": "Sök efter domännamn eller ID",
+    "source_hash": "aecdd873"
+  },
+  "web.admin.domains.list.stateFilter": {
+    "text": "Status",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.domains.list.emptyFilter": {
+    "text": "Inga domäner matchar de aktuella filtren.",
+    "source_hash": "be4d64ec"
+  },
+  "web.admin.domains.probe.healthLabel": {
+    "text": "Hälsa",
+    "source_hash": "55898449"
+  },
+  "web.admin.domains.probe.certInvalid": {
+    "text": "Certifikat inte användbart",
+    "source_hash": "5535f4d4"
+  },
+  "web.admin.domains.probe.noCertificate": {
+    "text": "Inget certifikat returnerades — anslutningen misslyckades före TLS.",
+    "source_hash": "8ffd63be"
+  },
+  "web.admin.domains.probe.fields.httpStatus": {
+    "text": "HTTP-status",
+    "source_hash": "0f7cf91f"
+  },
+  "web.admin.domains.probe.fields.httpError": {
+    "text": "HTTP-fel",
+    "source_hash": "5c6896d4"
+  },
+  "web.admin.domains.probe.fields.sslError": {
+    "text": "TLS-fel",
+    "source_hash": "7b827515"
+  },
+  "web.admin.domains.probe.fields.issuer": {
+    "text": "Certifikatutfärdare",
+    "source_hash": "2912559a"
+  },
+  "web.admin.domains.probe.fields.subject": {
+    "text": "Certifikatsubjekt",
+    "source_hash": "d7816b16"
+  },
+  "web.admin.domains.probe.fields.notAfter": {
+    "text": "Certifikat går ut",
+    "source_hash": "1e73119d"
+  },
+  "web.admin.domains.probe.fields.expiresIn": {
+    "text": "{date} ({days} dagar)",
+    "source_hash": "a71a6e81"
+  },
+  "web.admin.domains.tls.serving": {
+    "text": "Serverar",
+    "source_hash": "f55e53f9"
+  },
+  "web.admin.domains.tls.resolving": {
+    "text": "Löser upp",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.tls.none": {
+    "text": "Serverar inte",
+    "source_hash": "da8a5ab9"
   }
 }

--- a/locales/content/sv_SE/admin-organizations.json
+++ b/locales/content/sv_SE/admin-organizations.json
@@ -310,5 +310,333 @@
   "web.admin.organizations.list.loadError": {
     "text": "Det gick inte att läsa in organisationer.",
     "source_hash": "130d5e70"
+  },
+  "web.admin.organizations.addMember.button": {
+    "text": "Lägg till befintligt konto",
+    "source_hash": "45a3b757"
+  },
+  "web.admin.organizations.addMember.title": {
+    "text": "Lägg till ett befintligt konto",
+    "source_hash": "2f676a94"
+  },
+  "web.admin.organizations.addMember.description": {
+    "text": "Lägg till någon som redan har ett konto till {org}. Använd detta när en person registrerade sig själv och inte kan bjudas in eftersom kontot redan finns.",
+    "source_hash": "bb41faa6"
+  },
+  "web.admin.organizations.addMember.searchLabel": {
+    "text": "E-postadress eller konto-ID",
+    "source_hash": "82b3040b"
+  },
+  "web.admin.organizations.addMember.searchPlaceholder": {
+    "text": "Sök efter e-postadress",
+    "source_hash": "b75cc66c"
+  },
+  "web.admin.organizations.addMember.searchHint": {
+    "text": "Matchar del av en e-postadress, eller ett exakt konto-ID.",
+    "source_hash": "84547a60"
+  },
+  "web.admin.organizations.addMember.searchError": {
+    "text": "Kunde inte söka konton. Kontrollera anslutningen och försök igen.",
+    "source_hash": "4b6caa41"
+  },
+  "web.admin.organizations.addMember.searchParseError": {
+    "text": "Kontosökningen returnerade ett oväntat svar. Resultaten kan vara ofullständiga.",
+    "source_hash": "0c814231"
+  },
+  "web.admin.organizations.addMember.idle": {
+    "text": "Ange en e-postadress för att hitta kontot.",
+    "source_hash": "f6340d35"
+  },
+  "web.admin.organizations.addMember.noResults": {
+    "text": "Inget konto matchar \"{term}\".",
+    "source_hash": "199b662a"
+  },
+  "web.admin.organizations.addMember.noResultsHint": {
+    "text": "Endast befintliga konton kan läggas till här. Om personen aldrig har registrerat sig, bjud in dem istället.",
+    "source_hash": "ee90aeeb"
+  },
+  "web.admin.organizations.addMember.select": {
+    "text": "Välj",
+    "source_hash": "2a78025d"
+  },
+  "web.admin.organizations.addMember.selectedEyebrow": {
+    "text": "Valt konto",
+    "source_hash": "8b63d947"
+  },
+  "web.admin.organizations.addMember.change": {
+    "text": "Välj ett annat konto",
+    "source_hash": "d4fe39ab"
+  },
+  "web.admin.organizations.addMember.createdOn": {
+    "text": "Registrerades {date}",
+    "source_hash": "cfc0e19f"
+  },
+  "web.admin.organizations.addMember.organizationsUnavailable": {
+    "text": "Kunde inte ladda detta kontos nuvarande organisationer.",
+    "source_hash": "a35b6bfc"
+  },
+  "web.admin.organizations.addMember.defaultOrg": {
+    "text": "standard",
+    "source_hash": "37a8eec1"
+  },
+  "web.admin.organizations.addMember.roleLabel": {
+    "text": "Roll i denna organisation",
+    "source_hash": "817475fa"
+  },
+  "web.admin.organizations.addMember.submit": {
+    "text": "Lägg till i organisation",
+    "source_hash": "0e0cb636"
+  },
+  "web.admin.organizations.addMember.success": {
+    "text": "Lade till {account} som {role}.",
+    "source_hash": "533be0dc"
+  },
+  "web.admin.organizations.addMember.badges.verified": {
+    "text": "Verifierad",
+    "source_hash": "4f783840"
+  },
+  "web.admin.organizations.addMember.badges.unverified": {
+    "text": "Inte verifierad",
+    "source_hash": "15133907"
+  },
+  "web.admin.organizations.addMember.badges.suspended": {
+    "text": "Avstängd",
+    "source_hash": "e392a389"
+  },
+  "web.admin.organizations.addMember.badges.alreadyMember": {
+    "text": "Redan medlem",
+    "source_hash": "1739ed7c"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMember": {
+    "text": "Detta konto är redan medlem i denna organisation, med rollen {role}. Att lägga till ändrar inte en befintlig roll — använd åtgärden för att sätta roll för det.",
+    "source_hash": "cb6a4774"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMemberUnknownRole": {
+    "text": "Detta konto är redan medlem i denna organisation. Att lägga till ändrar inte en befintlig roll.",
+    "source_hash": "035641ec"
+  },
+  "web.admin.organizations.addMember.errors.notFound": {
+    "text": "Det kontot eller organisationen finns inte längre. Sök igen för att bekräfta kontot.",
+    "source_hash": "bd88db18"
+  },
+  "web.admin.organizations.addMember.errors.invalidRole": {
+    "text": "Den rollen avvisades. Välj en av de listade rollerna och försök igen.",
+    "source_hash": "eb696a8f"
+  },
+  "web.admin.organizations.addMember.errors.noSelection": {
+    "text": "Inget konto valt.",
+    "source_hash": "dd15bb5b"
+  },
+  "web.admin.organizations.addMember.fields.created": {
+    "text": "Registrerades",
+    "source_hash": "486b3fe0"
+  },
+  "web.admin.organizations.addMember.fields.verified": {
+    "text": "Verifiering",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.organizations.addMember.fields.lastLogin": {
+    "text": "Senaste inloggning",
+    "source_hash": "0b70af7a"
+  },
+  "web.admin.organizations.addMember.fields.organizations": {
+    "text": "Nuvarande organisationer",
+    "source_hash": "cbb5b92f"
+  },
+  "web.admin.organizations.addMember.roleHints.member": {
+    "text": "Vardaglig åtkomst till organisationens hemligheter och domäner.",
+    "source_hash": "d0c7439e"
+  },
+  "web.admin.organizations.addMember.roleHints.admin": {
+    "text": "Kan hantera medlemmar, domäner och organisationsinställningar.",
+    "source_hash": "beaa50d7"
+  },
+  "web.admin.organizations.addMember.roleHints.owner": {
+    "text": "Full kontroll, inklusive fakturering. Ge detta endast när det efterfrågas.",
+    "source_hash": "614ace63"
+  },
+  "web.admin.organizations.addMember.roles.member": {
+    "text": "Medlem",
+    "source_hash": "7c968fb7"
+  },
+  "web.admin.organizations.addMember.roles.admin": {
+    "text": "Admin",
+    "source_hash": "c1c224b0"
+  },
+  "web.admin.organizations.addMember.roles.owner": {
+    "text": "Ägare",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.detail.members.openCustomer": {
+    "text": "Öppna kundpost",
+    "source_hash": "c057ca13"
+  },
+  "web.admin.organizations.detail.reconcile.memberships": {
+    "text": "Medlemskap återmaterialiserade:",
+    "source_hash": "fe7db10c"
+  },
+  "web.admin.organizations.detail.reconcile.membershipsFailed": {
+    "text": "misslyckades, inaktuella rättigheter kvarstår:",
+    "source_hash": "cc4dae37"
+  },
+  "web.admin.organizations.entitlements.catalogWarning": {
+    "text": "\"{entitlement}\" finns inte i faktureringskatalogen — kontrollera om det är ett stavfel. Fortsätter ändå: att bevilja en rättighet som levereras i en senare katalog stöds och blockeras avsiktligt inte.",
+    "source_hash": "cbde548a"
+  },
+  "web.admin.organizations.entitlements.matrix.caption": {
+    "text": "Rättighetsupplösningsmatris: plan, överskrivningsbeviljanden och återkallelser, den upplösta uppsättningen och vad som är materialiserat.",
+    "source_hash": "9eac8999"
+  },
+  "web.admin.organizations.entitlements.matrix.yes": {
+    "text": "Ja",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.matrix.no": {
+    "text": "Nej",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.matrix.empty": {
+    "text": "Denna organisation har inga rättigheter från sin plan och inga överskrivningar.",
+    "source_hash": "f6cf2169"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.entitlement": {
+    "text": "Rättighet",
+    "source_hash": "0d8f0b2d"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.inPlan": {
+    "text": "I plan",
+    "source_hash": "e2222361"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.granted": {
+    "text": "Beviljad",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.revoked": {
+    "text": "Återkallad",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.expected": {
+    "text": "Förväntad",
+    "source_hash": "ca99b7f1"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.materialized": {
+    "text": "Materialiserad",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.state": {
+    "text": "Status",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.formula": {
+    "text": "Upplösning: förväntad = (plan ∪ beviljanden) − återkallelser. Materialiserad är vad som faktiskt lagras på organisationen.",
+    "source_hash": "bc4bff2d"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.orphaned": {
+    "text": "Föräldralös — materialiserad men inte förväntad, vanligtvis kvarlämnad av en återkallelse som aldrig återmaterialiserades. Avstämning tar bort den.",
+    "source_hash": "3a27a9af"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.missing": {
+    "text": "Saknas — förväntad men inte materialiserad. Detta är den behörighet medlemmar faktiskt saknar just nu.",
+    "source_hash": "485e44ad"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.revoked": {
+    "text": "Genomstrukna rader är återkallade av en admin-överskrivning, vilket tar bort dem från den förväntade uppsättningen.",
+    "source_hash": "89a2e9b6"
+  },
+  "web.admin.organizations.entitlements.matrix.state.plan": {
+    "text": "Från plan",
+    "source_hash": "1d346b26"
+  },
+  "web.admin.organizations.entitlements.matrix.state.granted": {
+    "text": "Beviljad",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.state.revoked": {
+    "text": "Återkallad",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.state.orphaned": {
+    "text": "Föräldralös",
+    "source_hash": "8d827807"
+  },
+  "web.admin.organizations.entitlements.matrix.state.missing": {
+    "text": "Saknas",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.organizations.entitlements.picker.selectPlaceholder": {
+    "text": "Välj en rättighet…",
+    "source_hash": "53af3be8"
+  },
+  "web.admin.organizations.entitlements.picker.other": {
+    "text": "Annat — inte i katalogen…",
+    "source_hash": "f08bc3a3"
+  },
+  "web.admin.organizations.entitlements.picker.customLabel": {
+    "text": "Rättighetsnamn (inte i katalogen)",
+    "source_hash": "52783229"
+  },
+  "web.admin.organizations.entitlements.picker.backToCatalog": {
+    "text": "Tillbaka till katalogen",
+    "source_hash": "9b727f40"
+  },
+  "web.admin.organizations.entitlements.picker.uncategorized": {
+    "text": "Okategoriserad",
+    "source_hash": "8d40d123"
+  },
+  "web.admin.organizations.entitlements.picker.catalogUnavailable": {
+    "text": "Faktureringskatalogen kunde inte läsas, så rättighetsnamn kontrolleras inte här.",
+    "source_hash": "724869ec"
+  },
+  "web.admin.organizations.entitlements.picker.tags.inPlan": {
+    "text": "i plan",
+    "source_hash": "5f2251bb"
+  },
+  "web.admin.organizations.entitlements.picker.tags.granted": {
+    "text": "beviljad",
+    "source_hash": "dd515d19"
+  },
+  "web.admin.organizations.entitlements.picker.tags.revoked": {
+    "text": "återkallad",
+    "source_hash": "4bb47f18"
+  },
+  "web.admin.organizations.entitlements.summary.sync": {
+    "text": "Synkronisera",
+    "source_hash": "8d261a37"
+  },
+  "web.admin.organizations.entitlements.summary.materialized": {
+    "text": "Materialiserad",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.summary.materializedAt": {
+    "text": "Senast materialiserad",
+    "source_hash": "9325dce9"
+  },
+  "web.admin.organizations.entitlements.summary.planDefinition": {
+    "text": "Plandefinition",
+    "source_hash": "6b531454"
+  },
+  "web.admin.organizations.entitlements.summary.yes": {
+    "text": "Ja",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.summary.no": {
+    "text": "Nej",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.summary.never": {
+    "text": "Aldrig",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.organizations.entitlements.summary.planStale": {
+    "text": "Ändrad sedan materialisering",
+    "source_hash": "e682d8a4"
+  },
+  "web.admin.organizations.entitlements.summary.planCurrent": {
+    "text": "Aktuell",
+    "source_hash": "e0d1b682"
+  },
+  "web.admin.organizations.entitlements.summary.planUnknown": {
+    "text": "Okänd — kunde inte jämföra",
+    "source_hash": "b607e540"
   }
 }

--- a/locales/content/sv_SE/admin-secrets.json
+++ b/locales/content/sv_SE/admin-secrets.json
@@ -1,11 +1,11 @@
 {
   "web.admin.secrets.title": {
-    "text": "Hemligheter",
-    "source_hash": "d8707d41"
+    "text": "Hemlighetskvitton",
+    "source_hash": "a8a2d0e4"
   },
   "web.admin.secrets.description": {
-    "text": "Inspektera en hemlighets kvitto och radera den utan SSH – slå upp den med dess nyckel.",
-    "source_hash": "07775a11"
+    "text": "Slå upp status, tidsstämplar, kvitto, m.m.",
+    "source_hash": "91fba2a1"
   },
   "web.admin.secrets.never": {
     "text": "Aldrig",
@@ -108,20 +108,20 @@
     "source_hash": "504101bc"
   },
   "web.admin.secrets.lookup.resultTitle": {
-    "text": "Hemlighet {shortid}",
-    "source_hash": "8b311d32"
+    "text": "Hemlighetspost {shortid}",
+    "source_hash": "ee06d765"
   },
   "web.admin.secrets.lookup.notFound": {
-    "text": "Hemligheten hittades inte",
-    "source_hash": "70a9532c"
+    "text": "Ingen post hittades",
+    "source_hash": "40f4d9e9"
   },
   "web.admin.secrets.lookup.notFoundDescription": {
     "text": "Ingen hemlighet finns med den här nyckeln. Den kan ha gått ut eller raderats.",
     "source_hash": "9f068a81"
   },
   "web.admin.secrets.lookup.loadError": {
-    "text": "Det gick inte att läsa in den här hemligheten.",
-    "source_hash": "c96672e4"
+    "text": "Kunde inte ladda denna post.",
+    "source_hash": "de77cc72"
   },
   "web.admin.secrets.lookup.retry": {
     "text": "Försök igen",
@@ -188,8 +188,8 @@
     "source_hash": "c127dab6"
   },
   "web.admin.secrets.sections.secret": {
-    "text": "Hemlighet",
-    "source_hash": "7e32a729"
+    "text": "Hemlighetspost",
+    "source_hash": "263813c6"
   },
   "web.admin.secrets.sections.receipt": {
     "text": "Kvitto",
@@ -214,5 +214,25 @@
   "web.admin.secrets.state.viewed": {
     "text": "Visad",
     "source_hash": "1b28d178"
+  },
+  "web.admin.secrets.capability.title": {
+    "text": "Endast metadata",
+    "source_hash": "df0453d1"
+  },
+  "web.admin.secrets.capability.canRead": {
+    "text": "Läser en hemlighets metadata och dess kvitto: status, tidsstämplar, ägare och storleken på den lagrade krypterade texten.",
+    "source_hash": "d438ecc7"
+  },
+  "web.admin.secrets.capability.cannotRead": {
+    "text": "Kan inte dekryptera eller visa hemlighetsinnehåll. Slutpunkten bakom denna skärm returnerar det aldrig.",
+    "source_hash": "7f69f222"
+  },
+  "web.admin.secrets.capability.canDelete": {
+    "text": "Kan permanent radera en hemlighet och dess kvitto, vilket förstör innehållet utan att någonsin avslöja det.",
+    "source_hash": "77f2bc7e"
+  },
+  "web.admin.secrets.lookup.hint": {
+    "text": "Identifieraren från hemlighetens länk — inte hemlighetsinnehållet.",
+    "source_hash": "acfbc352"
   }
 }

--- a/locales/content/sv_SE/admin-system.json
+++ b/locales/content/sv_SE/admin-system.json
@@ -154,5 +154,133 @@
   "web.admin.system.redis.captured": {
     "text": "Fångad {at}",
     "source_hash": "57b40c0f"
+  },
+  "web.admin.system.brand.title": {
+    "text": "Varumärkesdiagnostik",
+    "source_hash": "1cf9abd5"
+  },
+  "web.admin.system.brand.description": {
+    "text": "Vilket varumärkespaket den körande instansen löste upp på disk — visar varför en region kan servera neutral varumärkesidentitet.",
+    "source_hash": "be29e282"
+  },
+  "web.admin.system.brand.loadError": {
+    "text": "Kunde inte ladda varumärkesdiagnostik.",
+    "source_hash": "80607303"
+  },
+  "web.admin.system.brand.none": {
+    "text": "(ingen)",
+    "source_hash": "552e4230"
+  },
+  "web.admin.system.brand.resolution": {
+    "text": "Upplösning",
+    "source_hash": "d4055faf"
+  },
+  "web.admin.system.brand.envVsConfig": {
+    "text": "Miljö kontra konfiguration",
+    "source_hash": "bee3debb"
+  },
+  "web.admin.system.brand.absorbed": {
+    "text": "Absorberade nycklar",
+    "source_hash": "9784e110"
+  },
+  "web.admin.system.brand.operatorKeys": {
+    "text": "Operatörsnycklar",
+    "source_hash": "434e8248"
+  },
+  "web.admin.system.brand.overlayAssets": {
+    "text": "Överlagringstillgångar",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.exists.yes": {
+    "text": "Finns",
+    "source_hash": "43f9b89c"
+  },
+  "web.admin.system.brand.exists.no": {
+    "text": "Saknas",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.system.brand.fields.resolvedDir": {
+    "text": "Upplöst katalog",
+    "source_hash": "0623b983"
+  },
+  "web.admin.system.brand.fields.home": {
+    "text": "Hem",
+    "source_hash": "3a786953"
+  },
+  "web.admin.system.brand.fields.envPack": {
+    "text": "ENV-varumärkespaket",
+    "source_hash": "940aeb5c"
+  },
+  "web.admin.system.brand.fields.configPack": {
+    "text": "Konfiguration-varumärkespaket",
+    "source_hash": "761b9550"
+  },
+  "web.admin.system.brand.fields.envAssetsDir": {
+    "text": "ENV-varumärkestillgångskatalog",
+    "source_hash": "05854f1f"
+  },
+  "web.admin.system.brand.fields.configAssetsDir": {
+    "text": "Konfiguration-varumärkestillgångskatalog",
+    "source_hash": "e91e5c46"
+  },
+  "web.admin.system.brand.flags.fellBack.danger": {
+    "text": "Föll tillbaka till standardpaket",
+    "source_hash": "7bf7ba2f"
+  },
+  "web.admin.system.brand.flags.fellBack.ok": {
+    "text": "Varumärkespaket upplöst",
+    "source_hash": "1ab3162f"
+  },
+  "web.admin.system.brand.flags.mismatch.danger": {
+    "text": "Uppstart-/livefel",
+    "source_hash": "0a022192"
+  },
+  "web.admin.system.brand.flags.mismatch.ok": {
+    "text": "Uppstart matchar live",
+    "source_hash": "d4792c09"
+  },
+  "web.admin.system.brand.manifest.title": {
+    "text": "Manifest",
+    "source_hash": "3c99f1f3"
+  },
+  "web.admin.system.brand.manifest.path": {
+    "text": "Sökväg",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.manifest.exists": {
+    "text": "Finns",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.manifest.keysOnDisk": {
+    "text": "Nycklar på disk",
+    "source_hash": "52439c03"
+  },
+  "web.admin.system.brand.roots.title": {
+    "text": "Sökrötter",
+    "source_hash": "d8696f2b"
+  },
+  "web.admin.system.brand.roots.empty": {
+    "text": "Inga sökrötter",
+    "source_hash": "867a471c"
+  },
+  "web.admin.system.brand.roots.columns.path": {
+    "text": "Sökväg",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.roots.columns.exists": {
+    "text": "Finns",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.stats.brandPack": {
+    "text": "Varumärkespaket",
+    "source_hash": "884437d0"
+  },
+  "web.admin.system.brand.stats.overlayAssets": {
+    "text": "Överlagringstillgångar",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.stats.manifestKeys": {
+    "text": "Manifestnycklar",
+    "source_hash": "c4267198"
   }
 }

--- a/locales/content/sv_SE/email.json
+++ b/locales/content/sv_SE/email.json
@@ -836,5 +836,41 @@
   "email.secret_link.footer_note": {
     "text": "Du fick det här eftersom %{sender_email} använde %{product_name} för att dela en hemlighet med dig. Om du inte väntade dig det kan du tryggt ignorera det här e-postmeddelandet.",
     "source_hash": "2d544dad"
+  },
+  "email.sso_link_verification.subject": {
+    "text": "Bekräfta länkning av %{provider} till ditt %{product_name}-konto",
+    "source_hash": "65e70296"
+  },
+  "email.sso_link_verification.title": {
+    "text": "Bekräfta din SSO-inloggning",
+    "source_hash": "35bce6cc"
+  },
+  "email.sso_link_verification.request_notice": {
+    "text": "Någon loggade in med %{provider} med e-postadressen %{email_address}. För att slutföra anslutningen av %{provider} till ditt %{product_name}-konto, bekräfta nedan.",
+    "source_hash": "baeb18c0"
+  },
+  "email.sso_link_verification.confirm_button": {
+    "text": "Bekräfta och länka %{provider}",
+    "source_hash": "9809e210"
+  },
+  "email.sso_link_verification.copy_link_prompt": {
+    "text": "Eller kopiera och klistra in denna länk:",
+    "source_hash": "88c72144"
+  },
+  "email.sso_link_verification.expiration_notice": {
+    "text": "Denna länk går ut om 15 minuter och kan endast användas en gång.",
+    "source_hash": "1a437f42"
+  },
+  "email.sso_link_verification.ignore_notice": {
+    "text": "Om du inte försökte logga in med %{provider} kan du ignorera detta e-postmeddelande — inget kommer att anslutas till ditt konto.",
+    "source_hash": "d7317d30"
+  },
+  "email.sso_link_verification.signature": {
+    "text": "Supportteamet",
+    "source_hash": "dc75bf9f"
+  },
+  "email.sso_link_verification.postscript": {
+    "text": "P.S. Detta e-postmeddelande skickades till %{email_address}.",
+    "source_hash": "8ab1dbea"
   }
 }

--- a/locales/content/sv_SE/session-auth-extended.json
+++ b/locales/content/sv_SE/session-auth-extended.json
@@ -730,5 +730,201 @@
   "web.auth.sessions.session_plural": {
     "text": "sessioner",
     "source_hash": "1225ae6c"
+  },
+  "web.auth.connections.title": {
+    "text": "Anslutna identiteter",
+    "source_hash": "e132c4d9"
+  },
+  "web.auth.connections.description": {
+    "text": "Hantera de enkel-inloggningsleverantörer som är länkade till ditt konto.",
+    "source_hash": "42c6d148"
+  },
+  "web.auth.connections.section_title": {
+    "text": "Enkel inloggning",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.section_subtitle": {
+    "text": "Identitetsleverantörer du kan använda för att logga in på detta konto",
+    "source_hash": "507254cd"
+  },
+  "web.auth.connections.connect_title": {
+    "text": "Anslut en leverantör",
+    "source_hash": "a002b3f3"
+  },
+  "web.auth.connections.connect_description": {
+    "text": "Länka en annan enkel-inloggningsleverantör du kan använda för att logga in på detta konto.",
+    "source_hash": "32895a5a"
+  },
+  "web.auth.connections.connect_action": {
+    "text": "Anslut {provider}",
+    "source_hash": "c77540af"
+  },
+  "web.auth.connections.issuer": {
+    "text": "Utfärdare",
+    "source_hash": "39e02c46"
+  },
+  "web.auth.connections.identifier": {
+    "text": "Identifierare",
+    "source_hash": "9b10587f"
+  },
+  "web.auth.connections.remove": {
+    "text": "Ta bort",
+    "source_hash": "c3812fc4"
+  },
+  "web.auth.connections.remove_confirm_title": {
+    "text": "Ta bort ansluten identitet",
+    "source_hash": "4e8ffe4c"
+  },
+  "web.auth.connections.remove_confirm_message": {
+    "text": "Är du säker på att du vill ta bort denna anslutna identitet? Du kommer inte längre att kunna logga in med den.",
+    "source_hash": "64939c89"
+  },
+  "web.auth.connections.removed_success": {
+    "text": "Ansluten identitet borttagen",
+    "source_hash": "cf87daf3"
+  },
+  "web.auth.connections.no_identities": {
+    "text": "Inga anslutna identiteter",
+    "source_hash": "5254048e"
+  },
+  "web.auth.connections.no_identities_description": {
+    "text": "Du har inte länkat några enkel-inloggningsleverantörer till detta konto ännu.",
+    "source_hash": "0f58d5d0"
+  },
+  "web.auth.connections.overview_status": {
+    "text": "Enkel inloggning",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.errors.last_credential": {
+    "text": "Detta är ditt enda sätt att logga in. Anslut en annan leverantör först, eller ställ in ett lösenord från Inställningar → Säkerhet, så att du inte blir utelåst.",
+    "source_hash": "3de8084d"
+  },
+  "web.auth.connections.errors.last_credential_sso_enforced": {
+    "text": "Detta är ditt enda sätt att logga in. Anslut en annan leverantör först så att du inte blir utelåst.",
+    "source_hash": "eed7a50e"
+  },
+  "web.auth.connections.errors.not_found": {
+    "text": "Den anslutna identiteten kunde inte hittas. Den kan redan ha tagits bort.",
+    "source_hash": "cf2c7673"
+  },
+  "web.auth.connections.errors.unauthorized": {
+    "text": "Din session har gått ut. Logga in igen.",
+    "source_hash": "b529fce2"
+  },
+  "web.auth.connections.errors.generic": {
+    "text": "Vi kunde inte slutföra den åtgärden. Försök igen.",
+    "source_hash": "a0d4edc0"
+  },
+  "web.link_sso.title": {
+    "text": "Länka din inloggningsmetod",
+    "source_hash": "46339bac"
+  },
+  "web.link_sso.prompt": {
+    "text": "Du loggade in med {provider}, som matchar det befintliga kontot {email}. Ange det kontots lösenord för att länka {provider} och fortsätta.",
+    "source_hash": "59da1c08"
+  },
+  "web.link_sso.password_label": {
+    "text": "Lösenord",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.link_sso.password_placeholder": {
+    "text": "Ditt befintliga lösenord",
+    "source_hash": "ad4e56da"
+  },
+  "web.link_sso.submit": {
+    "text": "Länka och fortsätt",
+    "source_hash": "c969b759"
+  },
+  "web.link_sso.cancel": {
+    "text": "Avbryt",
+    "source_hash": "19766ed6"
+  },
+  "web.link_sso.unavailable_title": {
+    "text": "Denna länkningsbegäran har gått ut",
+    "source_hash": "b53c7e55"
+  },
+  "web.link_sso.unavailable_message": {
+    "text": "För din säkerhet är begäran att länka denna inloggningsmetod inte längre giltig. Logga in med ditt befintliga lösenord och anslut sedan denna leverantör under Säkerhetsinställningar → Anslutna identiteter.",
+    "source_hash": "f7e349d1"
+  },
+  "web.link_sso.unavailable_action": {
+    "text": "Fortsätt till inloggning",
+    "source_hash": "d398cd0a"
+  },
+  "web.link_sso.errors.invalid_password": {
+    "text": "Det lösenordet matchar inte detta konto. Försök igen.",
+    "source_hash": "3259b4f5"
+  },
+  "web.link_sso.errors.invalid_token": {
+    "text": "Denna länkningsbegäran har gått ut eller har redan använts. Logga in med ditt befintliga lösenord och anslut sedan denna leverantör från dina kontoinställningar.",
+    "source_hash": "541f9127"
+  },
+  "web.link_sso.errors.link_conflict": {
+    "text": "Vi kunde inte länka denna inloggningsmetod. Ditt konto kan ha ändrats, eller så är denna leverantör redan länkad till ett annat konto. Logga in med ditt befintliga lösenord och hantera sedan anslutningar under Säkerhetsinställningar → Anslutna identiteter.",
+    "source_hash": "7b0e0d0e"
+  },
+  "web.link_sso.errors.link_rate_limited": {
+    "text": "För många lösenordsförsök. Vänta några minuter och försök sedan igen.",
+    "source_hash": "a95e78cd"
+  },
+  "web.link_sso.errors.invalid_request": {
+    "text": "Vi kunde inte behandla denna länkningsbegäran. Logga in med din SSO-leverantör igen.",
+    "source_hash": "053b9fc6"
+  },
+  "web.link_sso.errors.generic": {
+    "text": "Vi kunde inte länka ditt konto. Försök igen.",
+    "source_hash": "f727c174"
+  },
+  "web.sso_link_confirm.title": {
+    "text": "Bekräfta anslutning av ditt konto",
+    "source_hash": "ad80bfe7"
+  },
+  "web.sso_link_confirm.prompt": {
+    "text": "Du loggade in med {provider}, som matchar ditt konto {email}. Bekräfta för att ansluta {provider} till detta konto och slutföra inloggningen.",
+    "source_hash": "6ff0d6cc"
+  },
+  "web.sso_link_confirm.submit": {
+    "text": "Bekräfta och anslut",
+    "source_hash": "5cf663e6"
+  },
+  "web.sso_link_confirm.cancel": {
+    "text": "Avbryt",
+    "source_hash": "19766ed6"
+  },
+  "web.sso_link_confirm.unavailable_title": {
+    "text": "Denna länkningsbegäran kan inte slutföras",
+    "source_hash": "47abb784"
+  },
+  "web.sso_link_confirm.unavailable_message": {
+    "text": "För din säkerhet är denna begäran att ansluta din inloggningsmetod inte längre giltig. Logga in med din leverantör igen så skickar vi dig en ny länk via e-post.",
+    "source_hash": "080e6f9f"
+  },
+  "web.sso_link_confirm.unavailable_action": {
+    "text": "Tillbaka till inloggning",
+    "source_hash": "8504054f"
+  },
+  "web.sso_link_confirm.errors.link_expired": {
+    "text": "Denna länkningsbegäran har gått ut eller har redan använts. Logga in med din leverantör igen så skickar vi dig en ny länk via e-post.",
+    "source_hash": "a50538df"
+  },
+  "web.sso_link_confirm.errors.link_conflict": {
+    "text": "Vi kunde inte ansluta denna inloggningsmetod. Ditt konto kan ha ändrats, eller så är denna leverantör redan länkad till ett annat konto. Logga in med din leverantör igen för att fortsätta.",
+    "source_hash": "c954854b"
+  },
+  "web.sso_link_confirm.errors.link_invalidated": {
+    "text": "Dina kontouppgifter ändrades efter att denna länk skickades, så den är inte längre giltig. Logga in med din leverantör igen så skickar vi dig en ny länk via e-post.",
+    "source_hash": "db88cb1d"
+  },
+  "web.sso_link_confirm.errors.link_error": {
+    "text": "Något gick fel på vår sida och vi kunde inte verifiera denna länk. Logga in med din leverantör igen så skickar vi dig en ny.",
+    "source_hash": "ec24e0a1"
+  },
+  "web.sso_link_confirm.errors.confirm_rate_limited": {
+    "text": "För många försök från din enhet. Vänta några minuter och öppna sedan den e-postade länken igen eller logga in med din leverantör för en ny.",
+    "source_hash": "f29af782"
+  },
+  "web.sso_link_confirm.errors.generic": {
+    "text": "Vi kunde inte bekräfta denna anslutning. Logga in med din leverantör igen.",
+    "source_hash": "076fa25a"
   }
 }

--- a/locales/content/sv_SE/session-auth-extended.json
+++ b/locales/content/sv_SE/session-auth-extended.json
@@ -757,6 +757,7 @@
   },
   "web.auth.connections.connect_action": {
     "text": "Anslut {provider}",
+    "context": "Button label to start linking a specific SSO provider; {provider} is the provider display name",
     "source_hash": "c77540af"
   },
   "web.auth.connections.issuer": {
@@ -821,6 +822,7 @@
   },
   "web.link_sso.prompt": {
     "text": "Du loggade in med {provider}, som matchar det befintliga kontot {email}. Ange det kontots lösenord för att länka {provider} och fortsätta.",
+    "context": "Instruction on the sign-in interstitial. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/link-sso/:token.",
     "source_hash": "59da1c08"
   },
   "web.link_sso.password_label": {
@@ -881,6 +883,7 @@
   },
   "web.sso_link_confirm.prompt": {
     "text": "Du loggade in med {provider}, som matchar ditt konto {email}. Bekräfta för att ansluta {provider} till detta konto och slutföra inloggningen.",
+    "context": "Consent instruction on the #3840 Phase 4 mailbox-proof SSO linking page. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/sso-link-confirm/:token. No password is asked — clicking the emailed link is the proof.",
     "source_hash": "6ff0d6cc"
   },
   "web.sso_link_confirm.submit": {

--- a/locales/content/sv_SE/session-auth.json
+++ b/locales/content/sv_SE/session-auth.json
@@ -483,5 +483,41 @@
   "web.login.verified_notice": {
     "text": "Din e-post har verifierats – du kan nu logga in.",
     "source_hash": "c8d4b5a8"
+  },
+  "web.auth.password_setup_request.title": {
+    "text": "Ställ in ett lösenord",
+    "source_hash": "11b6978b"
+  },
+  "web.auth.password_setup_request.description": {
+    "text": "Ditt konto har inget lösenord ännu. Vi skickar dig en säker länk via e-post för att ställa in ett så att du också kan logga in direkt.",
+    "source_hash": "dc0b561f"
+  },
+  "web.auth.password_setup_request.button": {
+    "text": "Skicka inställningslänk",
+    "source_hash": "22807292"
+  },
+  "web.auth.password_setup_request.emailSent": {
+    "text": "Ett e-postmeddelande har skickats till dig med en länk för att ställa in ett lösenord för ditt konto",
+    "source_hash": "82b686c7"
+  },
+  "web.login.errors.account_exists_link_required": {
+    "text": "Ett konto med denna e-postadress finns redan men är inte länkat till denna inloggningsmetod. Logga in med din befintliga metod och länka sedan denna leverantör under Säkerhetsinställningar → Anslutna identiteter.",
+    "source_hash": "7fbbb7e7"
+  },
+  "web.login.errors.identity_connect_conflict": {
+    "text": "Denna identitet kunde inte anslutas. Anslutningen kan ha startats på fel domän, eller så har din session gått ut. Logga in igen och anslut den sedan från dina kontoinställningar.",
+    "source_hash": "4238bbf2"
+  },
+  "web.login.errors.org_join_failed": {
+    "text": "Vi kunde inte slutföra att lägga till dig i din organisation. Kontakta din administratör.",
+    "source_hash": "155e71bb"
+  },
+  "web.login.errors.link_sso_failed": {
+    "text": "Vi kunde inte länka den inloggningsmetoden. Logga in med ditt befintliga lösenord och anslut sedan denna leverantör under Säkerhetsinställningar → Anslutna identiteter.",
+    "source_hash": "49954127"
+  },
+  "web.login.notices.link_verification_sent": {
+    "text": "Kontrollera din inkorg — vi har skickat dig en länk via e-post för att bekräfta anslutningen av ditt konto. Öppna den för att slutföra inloggningen.",
+    "source_hash": "b251c8f3"
   }
 }

--- a/locales/content/sv_SE/workspace-account.json
+++ b/locales/content/sv_SE/workspace-account.json
@@ -694,5 +694,33 @@
   "web.settings.security.sso_managed_description": {
     "text": "Ditt konto autentiseras via din organisations single sign-on-leverantör. Lösenord, flerfaktorsautentisering och återställningskoder hanteras av din identitetsleverantör.",
     "source_hash": "cd0cf39f"
+  },
+  "web.settings.api.api_username": {
+    "text": "API-användarnamn",
+    "source_hash": "0b3e483e"
+  },
+  "web.settings.api.api_username_description": {
+    "text": "Ditt användarnamn för HTTP Basic-autentisering",
+    "source_hash": "f3e65de3"
+  },
+  "web.settings.api.basic_auth_hint": {
+    "text": "För HTTP Basic-autentisering, använd din kontos e-post eller detta ID som användarnamn och din API-token som lösenord.",
+    "source_hash": "cfa3806d"
+  },
+  "web.settings.security.set": {
+    "text": "Inställt",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.settings.security.not_set": {
+    "text": "Inte inställt",
+    "source_hash": "4895f731"
+  },
+  "web.settings.security.set_password_title": {
+    "text": "Ställ in lösenord",
+    "source_hash": "4e411687"
+  },
+  "web.settings.security.set_password_description": {
+    "text": "Lägg till ett lösenord till ditt konto så att du också kan logga in utan din identitetsleverantör",
+    "source_hash": "a6970402"
   }
 }

--- a/locales/content/sv_SE/workspace-billing.json
+++ b/locales/content/sv_SE/workspace-billing.json
@@ -1044,5 +1044,21 @@
   "web.billing.plans.reactivate": {
     "text": "Återaktivera",
     "source_hash": "2dc7478f"
+  },
+  "web.billing.currency_migration.refund_failed_warning": {
+    "text": "Din tidigare plan avbröts, men vi kunde inte automatiskt utfärda återbetalning för din oanvända tid. Kontakta support för att få din återbetalning. Du behöver fortfarande slutföra kassan för att aktivera din nya plan.",
+    "source_hash": "a390c498"
+  },
+  "web.billing.currency_migration.refund_failed_continue": {
+    "text": "Fortsätt till kassan",
+    "source_hash": "eccdb8aa"
+  },
+  "web.billing.plans.per_year": {
+    "text": "/år",
+    "source_hash": "a2d5f1bc"
+  },
+  "web.billing.plans.billing_interval": {
+    "text": "Faktureringsintervall",
+    "source_hash": "3ce28209"
   }
 }

--- a/locales/content/sv_SE/workspace-branding.json
+++ b/locales/content/sv_SE/workspace-branding.json
@@ -56,12 +56,12 @@
     "source_hash": "e36598ef"
   },
   "web.branding.example_pre_reveal_instructions": {
-    "text": "Använd din telefon för att skanna QR-koden",
-    "source_hash": "99ecf59f"
+    "text": "t.ex. Använd din telefon för att skanna QR-koden",
+    "source_hash": "9cf0caf8"
   },
   "web.branding.example_post_reveal_instructions": {
-    "text": "Kontakta onboarding{'@'}example.com vid frågor",
-    "source_hash": "bee120a7"
+    "text": "t.ex. Kontakta onboarding{'@'}example.com med eventuella frågor",
+    "source_hash": "71749811"
   },
   "web.branding.these_instructions_will_be_shown_to_recipients_before": {
     "text": "Dessa instruktioner visas för mottagare innan de avslöjar hemlighetens innehåll",
@@ -320,8 +320,8 @@
     "source_hash": "bc79cdff"
   },
   "web.branding.paths_carryover_hint": {
-    "text": "Detta är en live-förhandsgranskning – dina ändringar syns inte för besökare förrän du sparar.",
-    "source_hash": "cb4b82de"
+    "text": "Detta är en liveförhandsgranskning — dina ändringar blir inte synliga för besökare förrän du klickar på Uppdatera.",
+    "source_hash": "9a34df71"
   },
   "web.branding.coming_soon_match_blurb": {
     "text": "Peka oss mot din webbplats så läser vi in dess färger och typsnitt och sluter sedan gapet med ett klick.",
@@ -406,5 +406,57 @@
   "web.branding.delivery_after_reveal": {
     "text": "Efter visning",
     "source_hash": "d5bfe7fd"
+  },
+  "web.branding.favicon": {
+    "text": "Favicon",
+    "source_hash": "42955289"
+  },
+  "web.branding.refresh_favicon": {
+    "text": "Uppdatera favicon från domän",
+    "source_hash": "7cc3d5dc"
+  },
+  "web.branding.refresh_favicon_hint": {
+    "text": "Hämta favicon från din domän igen. Den nya ikonen visas snart.",
+    "source_hash": "ee007e44"
+  },
+  "web.branding.refresh_favicon_queued": {
+    "text": "Uppdaterar favicon — den nya ikonen visas snart.",
+    "source_hash": "6bf38e6e"
+  },
+  "web.branding.refresh_favicon_user_upload_hint": {
+    "text": "Du har laddat upp en anpassad favicon, så en hämtad ikon kommer inte att ersätta den.",
+    "source_hash": "c22e1ed6"
+  },
+  "web.branding.upload_favicon": {
+    "text": "Ladda upp favicon",
+    "source_hash": "ceda39cb"
+  },
+  "web.branding.replace_favicon": {
+    "text": "Ersätt",
+    "source_hash": "95e15439"
+  },
+  "web.branding.remove_favicon": {
+    "text": "Ta bort favicon",
+    "source_hash": "03693698"
+  },
+  "web.branding.favicon_field_hint": {
+    "text": "ICO, PNG eller SVG. Uppladdning ersätter den hämtade ikonen.",
+    "source_hash": "dfa0bfcb"
+  },
+  "web.branding.favicon_preview_alt": {
+    "text": "Domän-favicon",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_title": {
+    "text": "Domän-favicon",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_hint": {
+    "text": "ICO, PNG eller SVG. Upp till 256KB. Ersätter den automatiskt hämtade ikonen.",
+    "source_hash": "c9eafc83"
+  },
+  "web.branding.favicon_modal_save": {
+    "text": "Spara favicon",
+    "source_hash": "c8a1566c"
   }
 }

--- a/locales/content/sv_SE/workspace-organizations.json
+++ b/locales/content/sv_SE/workspace-organizations.json
@@ -1034,5 +1034,153 @@
   "web.organizations.create_workspace": {
     "text": "Skapa arbetsyta",
     "source_hash": "c63c14cf"
+  },
+  "web.organizations.organization_id": {
+    "text": "Organisations-ID",
+    "source_hash": "1f466322"
+  },
+  "web.organizations.organization_id_hint": {
+    "text": "Använd detta ID när du kontaktar support eller begränsar API-förfrågningar till denna organisation. Det är inte en inloggningsuppgift.",
+    "source_hash": "29549b3a"
+  },
+  "web.organizations.audit.title": {
+    "text": "Hemlighetsaktivitet",
+    "source_hash": "6d6d41f3"
+  },
+  "web.organizations.audit.description": {
+    "text": "Granskningsspår av hemlighetsskapande och åtkomsthändelser registrerade för denna organisation.",
+    "source_hash": "553c564b"
+  },
+  "web.organizations.audit.country_unknown": {
+    "text": "Okänt",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.empty_title": {
+    "text": "Ingen aktivitet ännu",
+    "source_hash": "0a12b92c"
+  },
+  "web.organizations.audit.empty_description": {
+    "text": "Hemlighetsskapande och åtkomsthändelser kommer att visas här när ditt team delar hemligheter.",
+    "source_hash": "62fb14c2"
+  },
+  "web.organizations.audit.capped_notice": {
+    "text": "Endast de {max} nyaste händelserna behålls; äldre aktivitet har trimmats.",
+    "source_hash": "da7901e2"
+  },
+  "web.organizations.audit.collection_paused_notice": {
+    "text": "Händelseinsamling är pausad; ny hemlighetsaktivitet registreras inte.",
+    "source_hash": "cb09d147"
+  },
+  "web.organizations.audit.load_error": {
+    "text": "Kunde inte ladda hemlighetsaktivitet.",
+    "source_hash": "52fde814"
+  },
+  "web.organizations.audit.contract_mismatch": {
+    "text": "Aktivitetsdata som returnerades av servern kunde inte läsas. Spåret är inte tomt — det kan bara inte visas just nu.",
+    "source_hash": "db0d007a"
+  },
+  "web.organizations.audit.retry": {
+    "text": "Försök igen",
+    "source_hash": "d8b8392e"
+  },
+  "web.organizations.audit.showing_range": {
+    "text": "Visar {from}–{to} av {total}",
+    "source_hash": "c329279d"
+  },
+  "web.organizations.audit.upgrade_prompt": {
+    "text": "Hemlighetsaktivitet kräver en plan med granskningsloggar. Uppgradera för att se vem som skapade, visade och avslöjade hemligheter i denna organisation.",
+    "source_hash": "453649ce"
+  },
+  "web.organizations.audit.role_required": {
+    "text": "Hemlighetsaktivitet är tillgänglig för organisationsägare och administratörer.",
+    "source_hash": "e066ec63"
+  },
+  "web.organizations.audit.actors.creator": {
+    "text": "Skapare",
+    "source_hash": "88447b83"
+  },
+  "web.organizations.audit.actors.authenticated_other": {
+    "text": "En annan inloggad användare",
+    "source_hash": "ee45aa5a"
+  },
+  "web.organizations.audit.actors.anonymous": {
+    "text": "Anonym",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.organizations.audit.actors.system": {
+    "text": "System",
+    "source_hash": "6725e7bb"
+  },
+  "web.organizations.audit.actors.unknown": {
+    "text": "Okänd",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.columns.event": {
+    "text": "Händelse",
+    "source_hash": "4e1f49a9"
+  },
+  "web.organizations.audit.columns.secret": {
+    "text": "Hemlighet",
+    "source_hash": "7e32a729"
+  },
+  "web.organizations.audit.columns.actor": {
+    "text": "Aktör",
+    "source_hash": "449995c4"
+  },
+  "web.organizations.audit.columns.country": {
+    "text": "Land",
+    "source_hash": "701d021d"
+  },
+  "web.organizations.audit.columns.when": {
+    "text": "När",
+    "source_hash": "cf9c7aa2"
+  },
+  "web.organizations.audit.kinds.created": {
+    "text": "Hemlighet skapad",
+    "source_hash": "e4a1e1fd"
+  },
+  "web.organizations.audit.kinds.status_get": {
+    "text": "Länkstatus kontrollerad",
+    "source_hash": "0753f60e"
+  },
+  "web.organizations.audit.kinds.secret_get": {
+    "text": "Hemlighetslänk öppnad",
+    "source_hash": "e271e060"
+  },
+  "web.organizations.audit.kinds.previewed": {
+    "text": "Förhandsgranskad av skapare",
+    "source_hash": "639fc1e2"
+  },
+  "web.organizations.audit.kinds.creator_status_get": {
+    "text": "Status kontrollerad av skapare",
+    "source_hash": "7e4b5de5"
+  },
+  "web.organizations.audit.kinds.receipt_viewed": {
+    "text": "Kvitto visat",
+    "source_hash": "a417ead4"
+  },
+  "web.organizations.audit.kinds.revealed": {
+    "text": "Hemlighet avslöjad",
+    "source_hash": "aff2c84d"
+  },
+  "web.organizations.audit.kinds.burned": {
+    "text": "Hemlighet raderad permanent",
+    "source_hash": "5ac68dc6"
+  },
+  "web.organizations.audit.kinds.expired": {
+    "text": "Hemlighet utgången",
+    "source_hash": "c127dab6"
+  },
+  "web.organizations.audit.kinds.orphaned": {
+    "text": "Hemlighet föräldralös",
+    "source_hash": "23fe1a47"
+  },
+  "web.organizations.audit.kinds.reveal_failed_undecryptable": {
+    "text": "Avslöjande misslyckades (okrypterbar)",
+    "source_hash": "d5616abf"
+  },
+  "web.organizations.tabs.activity": {
+    "text": "Aktivitet",
+    "source_hash": "38da1505"
   }
 }


### PR DESCRIPTION
## `sv_SE` translation update

Automated export of completed **sv_SE** translations from the translation task DB.
Scope: `locales/content/sv_SE/` only — 16 file(s), +2020/-20.

⚠️ `i18n validate variables` reports **3** variable mismatch(es) for `sv_SE` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ⚠️ Needs review — 3 flagged empty keys not in diff.

**Summary:** All sv_SE strings actually changed in this diff preserve placeholders/brand terms correctly and read as natural, professionally-registered Swedish with no encoding issues. However, the variable-consistency check reports 3 error-level findings for empty translations in `session-auth-extended.json` that don't appear anywhere in this diff.

**Critical (must fix):** None in the diff itself.

**Warnings:**
- The validator flags `web.auth.connections.connect_action.context`, `web.link_sso.prompt.context`, and `web.sso_link_confirm.prompt.context` as `[EMPTY]` with missing `{provider}`/`{email}`, but none of these `.context` keys appear in the diff (only the sibling non-`.context` keys, e.g. `web.auth.connections.connect_action`, `web.link_sso.prompt`, are present and correctly translated). These read like translator-note/context metadata rather than user-facing strings — confirm with the maintainer whether `.context` keys require a translated value at all before treating this as a real gap; if they do, it's pre-existing and out of scope for this branch but should be tracked separately.

**Notes:**
- `web.branding.example_pre_reveal_instructions` / `example_post_reveal_instructions` gained a "t.ex." prefix and a new `source_hash`, implying the English source text itself changed (not just the translation) — consistent with source, no action needed.
- Minor stylistic inconsistency across strings for "could not load" (`Kunde inte ladda…` vs. existing `Det gick inte att läsa in…`) — pre-existing variance, not introduced as an error here, purely cosmetic.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
