### PR TITLE
i18n: update tr translations

### DIFF
--- a/locales/content/tr/00-common.json
+++ b/locales/content/tr/00-common.json
@@ -1539,5 +1539,9 @@
   "web.TITLES.domain_dns": {
     "text": "DNS Kurulumu",
     "source_hash": "6c63df31"
+  },
+  "web.TITLES.connected_identities": {
+    "text": "Bağlı Kimlikler",
+    "source_hash": "e132c4d9"
   }
 }

--- a/locales/content/tr/admin-audit.json
+++ b/locales/content/tr/admin-audit.json
@@ -98,5 +98,41 @@
   "web.admin.audit.result.failure": {
     "text": "Başarısız",
     "source_hash": "7031edbc"
+  },
+  "web.admin.audit.categories.secret": {
+    "text": "Gizli Mesajlar",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.audit.categories.membership": {
+    "text": "Üyelikler",
+    "source_hash": "b50f1a42"
+  },
+  "web.admin.audit.categories.entitlement_preview": {
+    "text": "Yetkilendirme önizlemeleri",
+    "source_hash": "255c5797"
+  },
+  "web.admin.audit.categories.colonel": {
+    "text": "Colonel oturum açmaları",
+    "source_hash": "01eeeb38"
+  },
+  "web.admin.audit.filters.actorLabel": {
+    "text": "Aktör",
+    "source_hash": "449995c4"
+  },
+  "web.admin.audit.filters.searchButton": {
+    "text": "Ara",
+    "source_hash": "49c266ba"
+  },
+  "web.admin.audit.filters.searchHint": {
+    "text": "Bir aktör yazın, ardından Enter tuşuna basın veya çalıştırmak için Ara seçeneğini seçin. Liste siz yazarken güncellenmez.",
+    "source_hash": "45eceb12"
+  },
+  "web.admin.audit.filters.pendingSearch": {
+    "text": "Henüz aranmadı — bu aktörü uygulamak için Enter tuşuna basın veya Ara seçeneğini seçin.",
+    "source_hash": "f76095c2"
+  },
+  "web.admin.audit.list.contractError": {
+    "text": "Sunucu yanıt verdi, ancak denetim verileri beklenen biçimle eşleşmedi. Hiçbir olay gösterilemiyor — bu bir raporlama hatası, boş bir günlük değil.",
+    "source_hash": "7f48137e"
   }
 }

--- a/locales/content/tr/admin-billing.json
+++ b/locales/content/tr/admin-billing.json
@@ -122,5 +122,85 @@
   "web.admin.billing.status.changed": {
     "text": "Değişti",
     "source_hash": "2a6141e4"
+  },
+  "web.admin.billing.diff.backToCatalog": {
+    "text": "Faturalandırma kataloğuna geri dön",
+    "source_hash": "8532b373"
+  },
+  "web.admin.billing.diff.driftedFields": {
+    "text": "Farklılık gösteren alanlar:",
+    "source_hash": "9890c95b"
+  },
+  "web.admin.billing.diff.notFound": {
+    "text": "Plan katalogda bulunamadı",
+    "source_hash": "0253898b"
+  },
+  "web.admin.billing.diff.notFoundDescription": {
+    "text": "{planid} kimlikli bir plan yapılandırılmış katalogda veya canlı Stripe senkronize önbelleğinde bulunamadı.",
+    "source_hash": "2e69551c"
+  },
+  "web.admin.billing.stripeOrgs.title": {
+    "text": "Stripe müşterileri",
+    "source_hash": "0463ae27"
+  },
+  "web.admin.billing.stripeOrgs.description": {
+    "text": "Bir Stripe müşteri kaydına bağlı organizasyonlar.",
+    "source_hash": "2ab09aec"
+  },
+  "web.admin.billing.stripeOrgs.searchPlaceholder": {
+    "text": "Stripe müşteri kimliğine göre ara",
+    "source_hash": "d5acf08f"
+  },
+  "web.admin.billing.stripeOrgs.empty": {
+    "text": "Hiçbir organizasyonun Stripe müşteri kimliği yok.",
+    "source_hash": "2e373537"
+  },
+  "web.admin.billing.stripeOrgs.emptySearch": {
+    "text": "Bu aramayla eşleşen Stripe müşteri kimliği bulunamadı.",
+    "source_hash": "75011174"
+  },
+  "web.admin.billing.stripeOrgs.loadError": {
+    "text": "Stripe müşterileri listesi yüklenemedi.",
+    "source_hash": "15e2d9a7"
+  },
+  "web.admin.billing.stripeOrgs.unavailable": {
+    "text": "Stripe müşterileri listesi henüz bu sunucuda mevcut değil.",
+    "source_hash": "aab6451a"
+  },
+  "web.admin.billing.stripeOrgs.none": {
+    "text": "Yok",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.billing.stripeOrgs.capped": {
+    "text": "Dizin taraması sınırına ulaştı, bu nedenle toplam bir alt sınırdır — geri kalanını görmek için aramayı daraltın.",
+    "source_hash": "20bcaa38"
+  },
+  "web.admin.billing.stripeOrgs.stale": {
+    "text": "Bu sayfadaki {count} dizin girdisi artık yüklenmeyen bir organizasyona işaret ediyor ve atlandı.",
+    "source_hash": "51980f83"
+  },
+  "web.admin.billing.stripeOrgs.copyStripeId": {
+    "text": "Stripe müşteri kimliğini kopyala",
+    "source_hash": "a77d18b1"
+  },
+  "web.admin.billing.stripeOrgs.columns.organization": {
+    "text": "Organizasyon",
+    "source_hash": "d764d425"
+  },
+  "web.admin.billing.stripeOrgs.columns.owner": {
+    "text": "Sahip",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.billing.stripeOrgs.columns.plan": {
+    "text": "Plan",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.billing.stripeOrgs.columns.subscription": {
+    "text": "Abonelik",
+    "source_hash": "4999c6c6"
+  },
+  "web.admin.billing.stripeOrgs.columns.stripeCustomer": {
+    "text": "Stripe müşteri kimliği",
+    "source_hash": "7e1d8bbb"
   }
 }

--- a/locales/content/tr/admin-colonel.json
+++ b/locales/content/tr/admin-colonel.json
@@ -838,5 +838,37 @@
   "web.colonel.nav.groups.communications": {
     "text": "İletişim",
     "source_hash": "919a9253"
+  },
+  "web.colonel.organizations.sameAsContact": {
+    "text": "İletişimle aynı",
+    "source_hash": "ed18ff43"
+  },
+  "web.colonel.organizations.refresh": {
+    "text": "Yenile",
+    "source_hash": "0e916101"
+  },
+  "web.colonel.organizations.updatedAgo": {
+    "text": "{ago} önce güncellendi",
+    "source_hash": "cda30b9c"
+  },
+  "web.colonel.organizations.columns.name": {
+    "text": "Ad",
+    "source_hash": "dcd1d522"
+  },
+  "web.colonel.organizations.columns.contactEmail": {
+    "text": "İletişim e-postası",
+    "source_hash": "6d7fce11"
+  },
+  "web.colonel.organizations.columns.billingEmail": {
+    "text": "Faturalandırma e-postası",
+    "source_hash": "8805b928"
+  },
+  "web.colonel.organizations.columns.planSubscription": {
+    "text": "Plan ve abonelik",
+    "source_hash": "b396caac"
+  },
+  "web.colonel.organizations.filters.searchPlaceholder": {
+    "text": "Kimlik, ad veya e-postaya göre ara",
+    "source_hash": "6fe16473"
   }
 }

--- a/locales/content/tr/admin-customers.json
+++ b/locales/content/tr/admin-customers.json
@@ -4,8 +4,8 @@
     "source_hash": "aabe76f1"
   },
   "web.admin.customers.description": {
-    "text": "SSH kullanmadan bir müşteri bulun ve destek sorunlarını çözün.",
-    "source_hash": "c8487e68"
+    "text": "Bir müşteri bulun ve destek sorunlarını çözün.",
+    "source_hash": "00961ea3"
   },
   "web.admin.customers.actions.plan.label": {
     "text": "Plan",
@@ -482,5 +482,213 @@
   "web.admin.customers.suspended.badge": {
     "text": "Askıya Alındı",
     "source_hash": "e392a389"
+  },
+  "web.admin.customers.actions.checkoutLink.button": {
+    "text": "Ödeme bağlantısı oluştur",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.modalTitle": {
+    "text": "Ödeme bağlantısı oluştur",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.planLabel": {
+    "text": "Plan",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.actions.checkoutLink.planPlaceholder": {
+    "text": "Plan aile kimliği (örn. identity_plus_v1)",
+    "source_hash": "12eba027"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleLabel": {
+    "text": "Faturalandırma döngüsü",
+    "source_hash": "d69f731e"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleMonthly": {
+    "text": "Aylık",
+    "source_hash": "9b11f6b7"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleYearly": {
+    "text": "Yıllık",
+    "source_hash": "6e69b59e"
+  },
+  "web.admin.customers.actions.checkoutLink.allowPromo": {
+    "text": "Promosyon kodlarına izin ver",
+    "source_hash": "ebe7bc8b"
+  },
+  "web.admin.customers.actions.checkoutLink.submit": {
+    "text": "Bağlantı oluştur",
+    "source_hash": "e6b850cf"
+  },
+  "web.admin.customers.actions.checkoutLink.resultLead": {
+    "text": "Ödeme bağlantısı oluşturuldu. Müşteriyle paylaşın — bir kez kullanılabilir ve süresi dolar.",
+    "source_hash": "6ff1fb0e"
+  },
+  "web.admin.customers.actions.checkoutLink.copy": {
+    "text": "Ödeme bağlantısını kopyala",
+    "source_hash": "f1e51ca7"
+  },
+  "web.admin.customers.actions.checkoutLink.expiry": {
+    "text": "~{hours} saat içinde ({date}) sona erer.",
+    "source_hash": "4c878a15"
+  },
+  "web.admin.customers.actions.checkoutLink.regionLabel": {
+    "text": "Bölge",
+    "source_hash": "d3a008ef"
+  },
+  "web.admin.customers.actions.checkoutLink.parseError": {
+    "text": "Sunucu isteği kabul etti ancak okunamayan bir yanıt döndürdü, bu nedenle bağlantı gösterilemiyor. Yeniden denemeden önce Stripe'ı kontrol edin.",
+    "source_hash": "e7e08290"
+  },
+  "web.admin.customers.actions.checkoutLink.done": {
+    "text": "Tamamlandı",
+    "source_hash": "11a6767d"
+  },
+  "web.admin.customers.actions.purge.typePrompt": {
+    "text": "Onaylamak için aşağıya hesap e-posta adresini {token} yazın",
+    "source_hash": "8b2a1819"
+  },
+  "web.admin.customers.actions.purge.unavailable": {
+    "text": "Temizleme kullanılamıyor: bu hesabın onay olarak yeniden yazılacak bir e-posta adresi yok.",
+    "source_hash": "5f20f7e5"
+  },
+  "web.admin.customers.columns.actions": {
+    "text": "İşlemler",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.diagnostics.title": {
+    "text": "Hesap Tanılama",
+    "source_hash": "5574ece8"
+  },
+  "web.admin.customers.detail.diagnostics.loading": {
+    "text": "Tanılama çalıştırılıyor…",
+    "source_hash": "062c83d5"
+  },
+  "web.admin.customers.detail.diagnostics.loadError": {
+    "text": "Tanılama yüklenemedi.",
+    "source_hash": "69e69f49"
+  },
+  "web.admin.customers.detail.diagnostics.healthy": {
+    "text": "Engelleyici bir durum bulunamadı. Kimlik doğrulama durumu sağlıklı görünüyor — istemci tarafı sorunlarından (çerezler, özel alan adı oturum açma yapılandırması) veya yanlış bölgeden şüphelenin.",
+    "source_hash": "f6d5f8d1"
+  },
+  "web.admin.customers.detail.diagnostics.authUnavailable": {
+    "text": "Kimlik doğrulama veritabanı mevcut değil (basit kimlik doğrulama modu) — SQL tarafı kontrolleri atlandı.",
+    "source_hash": "d668907c"
+  },
+  "web.admin.customers.detail.diagnostics.authFailed": {
+    "text": "Kimlik doğrulama veritabanı yanıt vermedi, bu nedenle SQL tarafı kontrolleri çalıştırılamadı: {reason}",
+    "source_hash": "46d047c0"
+  },
+  "web.admin.customers.detail.diagnostics.unknown": {
+    "text": "Bilinmiyor",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.title": {
+    "text": "Kimlik doğrulama günlüğü",
+    "source_hash": "48ad8ba8"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.empty": {
+    "text": "Kimlik doğrulama olayı kaydedilmedi.",
+    "source_hash": "d2332558"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.unavailable": {
+    "text": "Kimlik doğrulama günlüğü okunamadı: {reason}",
+    "source_hash": "ab18af57"
+  },
+  "web.admin.customers.detail.diagnostics.facts.authStatus": {
+    "text": "Kimlik doğrulama durumu",
+    "source_hash": "34def169"
+  },
+  "web.admin.customers.detail.diagnostics.facts.noAccount": {
+    "text": "Kimlik doğrulama hesabı yok",
+    "source_hash": "a9968e9e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.password": {
+    "text": "Parola",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordSet": {
+    "text": "Ayarlandı",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordNone": {
+    "text": "Yok",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfa": {
+    "text": "MFA",
+    "source_hash": "d39ce053"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfaNone": {
+    "text": "Yok",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.loginFailures": {
+    "text": "Başarısız denemeler",
+    "source_hash": "63e7f0a8"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lockedBadge": {
+    "text": "Kilitlendi",
+    "source_hash": "ace29f74"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiter": {
+    "text": "Hız sınırlayıcı",
+    "source_hash": "32892404"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterEngaged": {
+    "text": "Devrede",
+    "source_hash": "1b0d851e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterClear": {
+    "text": "Temiz",
+    "source_hash": "83b12c22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verification": {
+    "text": "Doğrulama e-postası",
+    "source_hash": "23fac8fb"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationPending": {
+    "text": "Bekliyor — son gönderim {date}",
+    "source_hash": "9ab8d1b6"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationNone": {
+    "text": "Bekleyen yok",
+    "source_hash": "a4d4cc22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.sessions": {
+    "text": "Aktif oturumlar",
+    "source_hash": "61ad9909"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lastLogin": {
+    "text": "Son oturum açma (auth)",
+    "source_hash": "373e7fb1"
+  },
+  "web.admin.customers.detail.receipts.partial": {
+    "text": "Kısmi liste — en son {count} tanesi gösteriliyor. Bu müşterinin burada gösterilenden daha fazla makbuzu var.",
+    "source_hash": "127fd4db"
+  },
+  "web.admin.customers.detail.secrets.partial": {
+    "text": "Kısmi liste — en son {count} tanesi gösteriliyor. Bu müşterinin burada gösterilenden daha fazla gizli mesajı var.",
+    "source_hash": "a537c8f3"
+  },
+  "web.admin.customers.detail.sessions.columns.country": {
+    "text": "Ülke",
+    "source_hash": "701d021d"
+  },
+  "web.admin.customers.detail.sessions.current.badge": {
+    "text": "Bu oturum",
+    "source_hash": "6da6530a"
+  },
+  "web.admin.customers.detail.sessions.current.tooltip": {
+    "text": "Mevcut yönetici oturumunuz. Burada iptal etmenin bir etkisi yoktur — bu isteğin geri kalanı için yeniden oluşturulur.",
+    "source_hash": "ef097ab1"
+  },
+  "web.admin.customers.verification.verified": {
+    "text": "Doğrulandı",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.verification.unverified": {
+    "text": "Doğrulanmadı",
+    "source_hash": "15133907"
   }
 }

--- a/locales/content/tr/admin-domains.json
+++ b/locales/content/tr/admin-domains.json
@@ -190,5 +190,657 @@
   "web.admin.domains.verify.success.done": {
     "text": "{domain} için doğrulama tamamlandı.",
     "source_hash": "ed67e22d"
+  },
+  "web.admin.domains.actions.preview": {
+    "text": "Önizleme",
+    "source_hash": "324b134f"
+  },
+  "web.admin.domains.actions.probe.button": {
+    "text": "Yokla",
+    "source_hash": "3bd51ab9"
+  },
+  "web.admin.domains.actions.remove.button": {
+    "text": "Alan adını kaldır",
+    "source_hash": "5ce43507"
+  },
+  "web.admin.domains.actions.remove.previewButton": {
+    "text": "Kaldırmayı önizle",
+    "source_hash": "6b81bd92"
+  },
+  "web.admin.domains.actions.remove.previewStatus": {
+    "text": "Durum:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.remove.previewOrg": {
+    "text": "Organizasyon:",
+    "source_hash": "5300e286"
+  },
+  "web.admin.domains.actions.remove.reassertsSurvivor": {
+    "text": "Başka bir kayıt aynı alan adını talep ediyor ve arama dizinini devralacak.",
+    "source_hash": "902838f4"
+  },
+  "web.admin.domains.actions.remove.confirmTitle": {
+    "text": "Alan adı kaldırılsın mı?",
+    "source_hash": "716dfac9"
+  },
+  "web.admin.domains.actions.remove.confirmDescription": {
+    "text": "Bu işlem {domain} alan adını ve markalaştırma, DNS ve yapılandırma kayıtlarını kalıcı olarak siler. Geri alınamaz. Devam etmek için alan adının genel kimliğini yeniden yazın.",
+    "source_hash": "d0b67b47"
+  },
+  "web.admin.domains.actions.remove.success": {
+    "text": "Alan adı kaldırıldı.",
+    "source_hash": "2ccaa6d3"
+  },
+  "web.admin.domains.actions.remove.notApplied": {
+    "text": "Sunucu kaldırmayı uygulamak yerine önizledi — alan adı kaldırılMADI. Yeniden deneyin ve devam ederse bildirin.",
+    "source_hash": "dc6d70ae"
+  },
+  "web.admin.domains.actions.repair.title": {
+    "text": "Organizasyon bağlantısını onar",
+    "source_hash": "82b40352"
+  },
+  "web.admin.domains.actions.repair.description": {
+    "text": "Bu alan adı ile organizasyonu arasındaki bozuk bağlantıları bulun ve düzeltin. Neyin değişeceğini görmek için önce önizleyin.",
+    "source_hash": "531ed287"
+  },
+  "web.admin.domains.actions.repair.orgIdLabel": {
+    "text": "Organizasyon kimliği (yalnızca sahipsiz alan adları)",
+    "source_hash": "0d3010eb"
+  },
+  "web.admin.domains.actions.repair.orgIdPlaceholder": {
+    "text": "Alan adının sahibi yoksa boş bırakın",
+    "source_hash": "118b7132"
+  },
+  "web.admin.domains.actions.repair.statusLabel": {
+    "text": "Durum:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.repair.noIssues": {
+    "text": "Sorun bulunamadı — onarılacak bir şey yok.",
+    "source_hash": "17735887"
+  },
+  "web.admin.domains.actions.repair.button": {
+    "text": "Onarımı uygula",
+    "source_hash": "4d0ab2d4"
+  },
+  "web.admin.domains.actions.repair.confirmTitle": {
+    "text": "Onarım uygulansın mı?",
+    "source_hash": "ef0ffae5"
+  },
+  "web.admin.domains.actions.repair.confirmDescription": {
+    "text": "Bu işlem {domain} için organizasyon bağlantısını yeniden yazar. Devam etmek için alan adının genel kimliğini yeniden yazın.",
+    "source_hash": "a9f2702f"
+  },
+  "web.admin.domains.actions.repair.success": {
+    "text": "Onarım uygulandı.",
+    "source_hash": "850bd784"
+  },
+  "web.admin.domains.actions.transfer.title": {
+    "text": "Başka bir organizasyona aktar",
+    "source_hash": "1b0b0655"
+  },
+  "web.admin.domains.actions.transfer.description": {
+    "text": "Bu alan adını farklı bir organizasyona taşıyın. Taşımanın her iki tarafını da onaylamak için önce önizleyin.",
+    "source_hash": "457e852d"
+  },
+  "web.admin.domains.actions.transfer.toOrgLabel": {
+    "text": "Hedef organizasyon kimliği",
+    "source_hash": "1a3f05c4"
+  },
+  "web.admin.domains.actions.transfer.fromOrgLabel": {
+    "text": "Beklenen mevcut organizasyon kimliği (isteğe bağlı)",
+    "source_hash": "f6e75729"
+  },
+  "web.admin.domains.actions.transfer.fromOrgPlaceholder": {
+    "text": "Taşımadan önce mevcut sahibi doğrulayın",
+    "source_hash": "1ac6c59b"
+  },
+  "web.admin.domains.actions.transfer.from": {
+    "text": "Kaynak",
+    "source_hash": "21819769"
+  },
+  "web.admin.domains.actions.transfer.to": {
+    "text": "Hedef",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.domains.actions.transfer.orphaned": {
+    "text": "Organizasyon yok (sahipsiz)",
+    "source_hash": "6f4c745c"
+  },
+  "web.admin.domains.actions.transfer.button": {
+    "text": "Aktarımı uygula",
+    "source_hash": "fb546c5c"
+  },
+  "web.admin.domains.actions.transfer.confirmTitle": {
+    "text": "Alan adı aktarılsın mı?",
+    "source_hash": "801eb986"
+  },
+  "web.admin.domains.actions.transfer.confirmDescription": {
+    "text": "Bu işlem {domain} alan adını {org} organizasyonuna taşır. Devam etmek için alan adının genel kimliğini yeniden yazın.",
+    "source_hash": "52c8808d"
+  },
+  "web.admin.domains.actions.transfer.success": {
+    "text": "Alan adı aktarıldı.",
+    "source_hash": "91e681ae"
+  },
+  "web.admin.domains.columns.domain": {
+    "text": "Alan adı",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domains.columns.organization": {
+    "text": "Organizasyon",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.columns.state": {
+    "text": "Doğrulama",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.domains.columns.tls": {
+    "text": "TLS",
+    "source_hash": "d1c18ec0"
+  },
+  "web.admin.domains.columns.created": {
+    "text": "Oluşturulma",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.columns.actions": {
+    "text": "İşlemler",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.configs.title": {
+    "text": "Alan adı yapılandırması",
+    "source_hash": "d46aa480"
+  },
+  "web.admin.domains.configs.description": {
+    "text": "Oturum açma, kayıt, ana sayfa gizli mesajları, API erişimi, gelen gizli mesajlar, kiracı SSO ve posta gönderimini kontrol eden alan adı bazlı yapılandırma kayıtları. Eksik kayıt ilk beşi için kapalı olarak başarısız olur.",
+    "source_hash": "1df99789"
+  },
+  "web.admin.domains.configs.loadError": {
+    "text": "Alan adı yapılandırma kayıtları yüklenemedi.",
+    "source_hash": "9417d718"
+  },
+  "web.admin.domains.configs.retry": {
+    "text": "Yeniden dene",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.configs.degraded": {
+    "text": "Yapılandırma yanıtı beklenen sözleşmeyle eşleşmedi. Yenileyin ve devam ederse bildirin.",
+    "source_hash": "b5d890c0"
+  },
+  "web.admin.domains.configs.notFoundNote": {
+    "text": "Bu alan adı artık mevcut değil, bu nedenle yapılandırma kayıtları yüklenemiyor.",
+    "source_hash": "2d88a392"
+  },
+  "web.admin.domains.configs.detailsToggle": {
+    "text": "Ayrıntılar",
+    "source_hash": "45989de4"
+  },
+  "web.admin.domains.configs.notEditable": {
+    "text": "Çalışma alanı alan adı ayarlarında yönetilir.",
+    "source_hash": "54fe891f"
+  },
+  "web.admin.domains.configs.delete.button": {
+    "text": "Sil",
+    "source_hash": "e2d0a549"
+  },
+  "web.admin.domains.configs.delete.confirmTitle": {
+    "text": "{kind} yapılandırması silinsin mi?",
+    "source_hash": "98e672db"
+  },
+  "web.admin.domains.configs.delete.confirmDescription": {
+    "text": "Bu işlem {domain} için {kind} yapılandırma kaydını kalıcı olarak siler. Alan adı eksik kayıt davranışına geri döner. Devam etmek için türü yeniden yazın.",
+    "source_hash": "8272c40c"
+  },
+  "web.admin.domains.configs.delete.success": {
+    "text": "Yapılandırma silindi.",
+    "source_hash": "a0184b66"
+  },
+  "web.admin.domains.configs.edit.button": {
+    "text": "Düzenle",
+    "source_hash": "464c4ffd"
+  },
+  "web.admin.domains.configs.edit.createButton": {
+    "text": "Oluştur",
+    "source_hash": "4759498a"
+  },
+  "web.admin.domains.configs.edit.title": {
+    "text": "{kind} yapılandır",
+    "source_hash": "8592148f"
+  },
+  "web.admin.domains.configs.edit.submit": {
+    "text": "Kaydet",
+    "source_hash": "1509f561"
+  },
+  "web.admin.domains.configs.edit.success": {
+    "text": "Yapılandırma kaydedildi.",
+    "source_hash": "6b5b3c69"
+  },
+  "web.admin.domains.configs.edit.unsetOption": {
+    "text": "Ayarlanmadı",
+    "source_hash": "4895f731"
+  },
+  "web.admin.domains.configs.edit.domainsHint": {
+    "text": "Her satıra bir alan adı.",
+    "source_hash": "6c03f4f7"
+  },
+  "web.admin.domains.configs.ensure.button": {
+    "text": "Eksik yapılandırmaları oluştur",
+    "source_hash": "77991b75"
+  },
+  "web.admin.domains.configs.ensure.confirmTitle": {
+    "text": "Eksik yapılandırma kayıtları oluşturulsun mu?",
+    "source_hash": "3f41dec2"
+  },
+  "web.admin.domains.configs.ensure.confirmDescription": {
+    "text": "{domain} üzerinde şunlar için devre dışı kayıtlar oluşturur: {kinds}. Her şey devre dışı başlar, bu nedenle bir kayıt etkinleştirilene kadar davranış değişmez.",
+    "source_hash": "fed66221"
+  },
+  "web.admin.domains.configs.ensure.applyButton": {
+    "text": "Kayıtları oluştur",
+    "source_hash": "4bcbef42"
+  },
+  "web.admin.domains.configs.ensure.success": {
+    "text": "Eksik yapılandırma kayıtları oluşturuldu.",
+    "source_hash": "3b6ead80"
+  },
+  "web.admin.domains.configs.ensure.nothingMissing": {
+    "text": "Oluşturulacak bir şey yok — her yapılandırma kaydı zaten mevcut. Liste yenilendi.",
+    "source_hash": "ad0df0ae"
+  },
+  "web.admin.domains.configs.ensure.notApplied": {
+    "text": "Sunucu değişikliği uygulamak yerine önizledi — hiçbir kayıt oluşturulmadı. Yeniden deneyin ve devam ederse bildirin.",
+    "source_hash": "09d26379"
+  },
+  "web.admin.domains.configs.fields.enabled": {
+    "text": "Etkin",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.fields.signin_enabled": {
+    "text": "Oturum açma etkin",
+    "source_hash": "cabe4898"
+  },
+  "web.admin.domains.configs.fields.email_auth_enabled": {
+    "text": "E-posta kimlik doğrulaması etkin",
+    "source_hash": "4a762960"
+  },
+  "web.admin.domains.configs.fields.sso_enabled": {
+    "text": "SSO etkin",
+    "source_hash": "6e77e673"
+  },
+  "web.admin.domains.configs.fields.restrict_to": {
+    "text": "Şuna kısıtla",
+    "source_hash": "a0bdf50a"
+  },
+  "web.admin.domains.configs.fields.signup_enabled": {
+    "text": "Kayıt etkin",
+    "source_hash": "2637d0b2"
+  },
+  "web.admin.domains.configs.fields.autoverify": {
+    "text": "Otomatik doğrula",
+    "source_hash": "7e02211c"
+  },
+  "web.admin.domains.configs.fields.validation_strategy": {
+    "text": "Doğrulama stratejisi",
+    "source_hash": "a2e95531"
+  },
+  "web.admin.domains.configs.fields.allowed_signup_domains": {
+    "text": "İzin verilen kayıt alan adları",
+    "source_hash": "9b5bb5b1"
+  },
+  "web.admin.domains.configs.fields.secrets_mode": {
+    "text": "Gizli mesaj modu",
+    "source_hash": "8d4349d6"
+  },
+  "web.admin.domains.configs.fields.disabled_homepage_variant": {
+    "text": "Devre dışı ana sayfa varyantı",
+    "source_hash": "4695633b"
+  },
+  "web.admin.domains.configs.fields.ready": {
+    "text": "Hazır",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.configs.fields.recipients": {
+    "text": "Alıcılar",
+    "source_hash": "1e8568a8"
+  },
+  "web.admin.domains.configs.fields.provider_type": {
+    "text": "Sağlayıcı türü",
+    "source_hash": "8c0f6d3e"
+  },
+  "web.admin.domains.configs.fields.display_name": {
+    "text": "Görünen ad",
+    "source_hash": "2b7f6a84"
+  },
+  "web.admin.domains.configs.fields.issuer": {
+    "text": "Veren",
+    "source_hash": "39e02c46"
+  },
+  "web.admin.domains.configs.fields.tenant_id": {
+    "text": "Kiracı kimliği",
+    "source_hash": "de1f5fff"
+  },
+  "web.admin.domains.configs.fields.has_client_id": {
+    "text": "İstemci kimliği ayarlandı",
+    "source_hash": "04a9fa3d"
+  },
+  "web.admin.domains.configs.fields.has_client_secret": {
+    "text": "İstemci sırrı ayarlandı",
+    "source_hash": "6ee1c9e6"
+  },
+  "web.admin.domains.configs.fields.allowed_domains": {
+    "text": "İzin verilen alan adları",
+    "source_hash": "bcd60db0"
+  },
+  "web.admin.domains.configs.fields.enforce_sso_only": {
+    "text": "Yalnızca SSO uygula",
+    "source_hash": "b3a3f694"
+  },
+  "web.admin.domains.configs.fields.grant_org_scope": {
+    "text": "Organizasyon kapsamı ver",
+    "source_hash": "698ea5de"
+  },
+  "web.admin.domains.configs.fields.provider": {
+    "text": "Sağlayıcı",
+    "source_hash": "472590ae"
+  },
+  "web.admin.domains.configs.fields.from_name": {
+    "text": "Gönderen adı",
+    "source_hash": "b28f93ea"
+  },
+  "web.admin.domains.configs.fields.from_address": {
+    "text": "Gönderen adresi",
+    "source_hash": "d465bcfa"
+  },
+  "web.admin.domains.configs.fields.reply_to": {
+    "text": "Yanıtla",
+    "source_hash": "6b9c49b7"
+  },
+  "web.admin.domains.configs.fields.sending_mode": {
+    "text": "Gönderim modu",
+    "source_hash": "e2d6bcf7"
+  },
+  "web.admin.domains.configs.fields.verification_status": {
+    "text": "Doğrulama durumu",
+    "source_hash": "aedfff7e"
+  },
+  "web.admin.domains.configs.fields.dns_verified": {
+    "text": "DNS doğrulandı",
+    "source_hash": "8b2128c8"
+  },
+  "web.admin.domains.configs.fields.provider_verified": {
+    "text": "Sağlayıcı doğrulandı",
+    "source_hash": "6f4d9cc4"
+  },
+  "web.admin.domains.configs.fields.has_api_key": {
+    "text": "API anahtarı ayarlandı",
+    "source_hash": "d5115386"
+  },
+  "web.admin.domains.configs.fields.created": {
+    "text": "Oluşturulma",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.configs.fields.updated": {
+    "text": "Güncelleme",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.configs.kinds.signin": {
+    "text": "Oturum açma",
+    "source_hash": "5bbbe531"
+  },
+  "web.admin.domains.configs.kinds.signup": {
+    "text": "Kayıt",
+    "source_hash": "3cc08ebe"
+  },
+  "web.admin.domains.configs.kinds.homepage": {
+    "text": "Ana sayfa",
+    "source_hash": "9e3391e9"
+  },
+  "web.admin.domains.configs.kinds.api": {
+    "text": "API",
+    "source_hash": "c8e5998f"
+  },
+  "web.admin.domains.configs.kinds.incoming": {
+    "text": "Gelen",
+    "source_hash": "e301820a"
+  },
+  "web.admin.domains.configs.kinds.sso": {
+    "text": "SSO",
+    "source_hash": "5ba3ac9f"
+  },
+  "web.admin.domains.configs.kinds.mailer": {
+    "text": "Posta gönderici",
+    "source_hash": "6c07ba63"
+  },
+  "web.admin.domains.configs.missingNotes.signin": {
+    "text": "Kayıt yok: kiracı SSO etkin olmadığı sürece bu alan adında oturum açma devre dışı.",
+    "source_hash": "17dd6099"
+  },
+  "web.admin.domains.configs.missingNotes.signup": {
+    "text": "Kayıt yok: bu alan adında kayıt devre dışı.",
+    "source_hash": "c3c98956"
+  },
+  "web.admin.domains.configs.missingNotes.homepage": {
+    "text": "Kayıt yok: ana sayfa gizli mesajları devre dışı (kapalı olarak başarısız olur ve hata kaydeder).",
+    "source_hash": "9a258a88"
+  },
+  "web.admin.domains.configs.missingNotes.api": {
+    "text": "Kayıt yok: genel API devre dışı (kapalı olarak başarısız olur ve hata kaydeder).",
+    "source_hash": "fed99f73"
+  },
+  "web.admin.domains.configs.missingNotes.incoming": {
+    "text": "Kayıt yok: gelen gizli mesajlar devre dışı.",
+    "source_hash": "b957fbe8"
+  },
+  "web.admin.domains.configs.missingNotes.sso": {
+    "text": "Kayıt yok: kiracı SSO kullanılamıyor; platform SSO geri dönüş politikası geçerli.",
+    "source_hash": "7b05ade8"
+  },
+  "web.admin.domains.configs.missingNotes.mailer": {
+    "text": "Kayıt yok: platform posta göndericisi kullanılır.",
+    "source_hash": "e027cc99"
+  },
+  "web.admin.domains.configs.status.missing": {
+    "text": "Eksik",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.domains.configs.status.disabled": {
+    "text": "Devre dışı",
+    "source_hash": "75081b59"
+  },
+  "web.admin.domains.configs.status.enabled": {
+    "text": "Etkin",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.status.enabledNotReady": {
+    "text": "Etkin, hazır değil",
+    "source_hash": "cb806ba4"
+  },
+  "web.admin.domains.detail.openFullPage": {
+    "text": "Tam sayfayı aç",
+    "source_hash": "a467911c"
+  },
+  "web.admin.domains.detail.backToList": {
+    "text": "Alan adlarına geri dön",
+    "source_hash": "22fd50fe"
+  },
+  "web.admin.domains.detail.notFound": {
+    "text": "Alan adı bulunamadı",
+    "source_hash": "7b8fc0e6"
+  },
+  "web.admin.domains.detail.notFoundDescription": {
+    "text": "Bu alan adı mevcut değil veya zaten kaldırılmış.",
+    "source_hash": "e0f0b987"
+  },
+  "web.admin.domains.detail.loadError": {
+    "text": "Bu alan adı yüklenemedi.",
+    "source_hash": "39e9c657"
+  },
+  "web.admin.domains.detail.retry": {
+    "text": "Yeniden dene",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.detail.never": {
+    "text": "Hiçbir zaman",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.domains.detail.none": {
+    "text": "Yok",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.domains.detail.yes": {
+    "text": "Evet",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.domains.detail.no": {
+    "text": "Hayır",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.domains.detail.organization.open": {
+    "text": "Organizasyonu aç",
+    "source_hash": "54a43621"
+  },
+  "web.admin.domains.detail.organization.unknown": {
+    "text": "Sahip organizasyon bu yanıta dahil değil. Görmek için bu alan adını alan adları listesinden açın.",
+    "source_hash": "bb5bdc9c"
+  },
+  "web.admin.domains.detail.sections.overview": {
+    "text": "Genel bakış",
+    "source_hash": "d4b1ea57"
+  },
+  "web.admin.domains.detail.sections.actions": {
+    "text": "İşlemler",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.detail.sections.organization": {
+    "text": "Sahip organizasyon",
+    "source_hash": "39ad6d9c"
+  },
+  "web.admin.domains.detail.sections.dns": {
+    "text": "DNS",
+    "source_hash": "020965a2"
+  },
+  "web.admin.domains.detail.sections.diagnostics": {
+    "text": "Tanılama",
+    "source_hash": "268f14bb"
+  },
+  "web.admin.domains.detail.sections.operations": {
+    "text": "Sahiplik işlemleri",
+    "source_hash": "eb9a8cbc"
+  },
+  "web.admin.domains.detail.sections.operationsHint": {
+    "text": "Her işlem önce önizlenir. Uygulama adımını onaylayana kadar hiçbir şey yazılmaz.",
+    "source_hash": "f09bf7bd"
+  },
+  "web.admin.domains.fields.publicId": {
+    "text": "Genel kimlik",
+    "source_hash": "3705b64f"
+  },
+  "web.admin.domains.fields.domainId": {
+    "text": "Dahili kimlik",
+    "source_hash": "e468bb47"
+  },
+  "web.admin.domains.fields.organization": {
+    "text": "Organizasyon",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.fields.baseDomain": {
+    "text": "Temel alan adı",
+    "source_hash": "33295d5b"
+  },
+  "web.admin.domains.fields.subdomain": {
+    "text": "Alt alan adı",
+    "source_hash": "ba4520ab"
+  },
+  "web.admin.domains.fields.apex": {
+    "text": "Apex alan adı",
+    "source_hash": "0a8a42fa"
+  },
+  "web.admin.domains.fields.status": {
+    "text": "Durum",
+    "source_hash": "920e413c"
+  },
+  "web.admin.domains.fields.created": {
+    "text": "Oluşturulma",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.fields.updated": {
+    "text": "Güncelleme",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.fields.verified": {
+    "text": "Doğrulandı",
+    "source_hash": "4f783840"
+  },
+  "web.admin.domains.fields.resolving": {
+    "text": "Çözümleniyor",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.fields.ready": {
+    "text": "Hazır",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.list.searchPlaceholder": {
+    "text": "Alan adı veya kimliğe göre ara",
+    "source_hash": "aecdd873"
+  },
+  "web.admin.domains.list.stateFilter": {
+    "text": "Durum",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.domains.list.emptyFilter": {
+    "text": "Mevcut filtrelerle eşleşen alan adı yok.",
+    "source_hash": "be4d64ec"
+  },
+  "web.admin.domains.probe.healthLabel": {
+    "text": "Sağlık",
+    "source_hash": "55898449"
+  },
+  "web.admin.domains.probe.certInvalid": {
+    "text": "Sertifika kullanılamıyor",
+    "source_hash": "5535f4d4"
+  },
+  "web.admin.domains.probe.noCertificate": {
+    "text": "Sertifika döndürülmedi — bağlantı TLS öncesinde başarısız oldu.",
+    "source_hash": "8ffd63be"
+  },
+  "web.admin.domains.probe.fields.httpStatus": {
+    "text": "HTTP durumu",
+    "source_hash": "0f7cf91f"
+  },
+  "web.admin.domains.probe.fields.httpError": {
+    "text": "HTTP hatası",
+    "source_hash": "5c6896d4"
+  },
+  "web.admin.domains.probe.fields.sslError": {
+    "text": "TLS hatası",
+    "source_hash": "7b827515"
+  },
+  "web.admin.domains.probe.fields.issuer": {
+    "text": "Sertifika veren",
+    "source_hash": "2912559a"
+  },
+  "web.admin.domains.probe.fields.subject": {
+    "text": "Sertifika konusu",
+    "source_hash": "d7816b16"
+  },
+  "web.admin.domains.probe.fields.notAfter": {
+    "text": "Sertifika sona erme",
+    "source_hash": "1e73119d"
+  },
+  "web.admin.domains.probe.fields.expiresIn": {
+    "text": "{date} ({days} gün)",
+    "source_hash": "a71a6e81"
+  },
+  "web.admin.domains.tls.serving": {
+    "text": "Hizmet veriyor",
+    "source_hash": "f55e53f9"
+  },
+  "web.admin.domains.tls.resolving": {
+    "text": "Çözümleniyor",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.tls.none": {
+    "text": "Hizmet vermiyor",
+    "source_hash": "da8a5ab9"
   }
 }

--- a/locales/content/tr/admin-organizations.json
+++ b/locales/content/tr/admin-organizations.json
@@ -310,5 +310,333 @@
   "web.admin.organizations.list.loadError": {
     "text": "Kuruluşlar yüklenemedi.",
     "source_hash": "130d5e70"
+  },
+  "web.admin.organizations.addMember.button": {
+    "text": "Mevcut hesap ekle",
+    "source_hash": "45a3b757"
+  },
+  "web.admin.organizations.addMember.title": {
+    "text": "Mevcut bir hesap ekle",
+    "source_hash": "2f676a94"
+  },
+  "web.admin.organizations.addMember.description": {
+    "text": "Zaten bir hesabi olan birini {org} organizasyonuna ekleyin. Bunu, bir kisi kendi basina kaydoldugunda ve hesap zaten var oldugu icin davet edilemediginde kullanin.",
+    "source_hash": "bb41faa6"
+  },
+  "web.admin.organizations.addMember.searchLabel": {
+    "text": "E-posta adresi veya hesap kimligi",
+    "source_hash": "82b3040b"
+  },
+  "web.admin.organizations.addMember.searchPlaceholder": {
+    "text": "E-posta adresine gore ara",
+    "source_hash": "b75cc66c"
+  },
+  "web.admin.organizations.addMember.searchHint": {
+    "text": "E-posta adresinin bir kismiyla veya tam hesap kimligiyle eslesir.",
+    "source_hash": "84547a60"
+  },
+  "web.admin.organizations.addMember.searchError": {
+    "text": "Hesaplar aranamadi. Baglantiyi kontrol edip yeniden deneyin.",
+    "source_hash": "4b6caa41"
+  },
+  "web.admin.organizations.addMember.searchParseError": {
+    "text": "Hesap aramasi beklenmedik bir yanit dondurdu. Sonuclar eksik olabilir.",
+    "source_hash": "0c814231"
+  },
+  "web.admin.organizations.addMember.idle": {
+    "text": "Hesabi bulmak icin bir e-posta adresi girin.",
+    "source_hash": "f6340d35"
+  },
+  "web.admin.organizations.addMember.noResults": {
+    "text": "\"{term}\" ile eslesen hesap yok.",
+    "source_hash": "199b662a"
+  },
+  "web.admin.organizations.addMember.noResultsHint": {
+    "text": "Buraya yalnizca mevcut hesaplar eklenebilir. Kisi hic kaydolmadiysa, bunun yerine davet edin.",
+    "source_hash": "ee90aeeb"
+  },
+  "web.admin.organizations.addMember.select": {
+    "text": "Sec",
+    "source_hash": "2a78025d"
+  },
+  "web.admin.organizations.addMember.selectedEyebrow": {
+    "text": "Secilen hesap",
+    "source_hash": "8b63d947"
+  },
+  "web.admin.organizations.addMember.change": {
+    "text": "Farkli bir hesap sec",
+    "source_hash": "d4fe39ab"
+  },
+  "web.admin.organizations.addMember.createdOn": {
+    "text": "{date} tarihinde kaydoldu",
+    "source_hash": "cfc0e19f"
+  },
+  "web.admin.organizations.addMember.organizationsUnavailable": {
+    "text": "Bu hesabin mevcut organizasyonlari yuklenemedi.",
+    "source_hash": "a35b6bfc"
+  },
+  "web.admin.organizations.addMember.defaultOrg": {
+    "text": "varsayilan",
+    "source_hash": "37a8eec1"
+  },
+  "web.admin.organizations.addMember.roleLabel": {
+    "text": "Bu organizasyondaki rol",
+    "source_hash": "817475fa"
+  },
+  "web.admin.organizations.addMember.submit": {
+    "text": "Organizasyona ekle",
+    "source_hash": "0e0cb636"
+  },
+  "web.admin.organizations.addMember.success": {
+    "text": "{account} {role} olarak eklendi.",
+    "source_hash": "533be0dc"
+  },
+  "web.admin.organizations.addMember.badges.verified": {
+    "text": "Dogrulanmis",
+    "source_hash": "4f783840"
+  },
+  "web.admin.organizations.addMember.badges.unverified": {
+    "text": "Dogrulanmamis",
+    "source_hash": "15133907"
+  },
+  "web.admin.organizations.addMember.badges.suspended": {
+    "text": "Askiya alinmis",
+    "source_hash": "e392a389"
+  },
+  "web.admin.organizations.addMember.badges.alreadyMember": {
+    "text": "Zaten uye",
+    "source_hash": "1739ed7c"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMember": {
+    "text": "Bu hesap zaten bu organizasyonun bir uyesi, rolu {role}. Ekleme mevcut rolu degistirmez - bunun icin rol ayarla islemini kullanin.",
+    "source_hash": "cb6a4774"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMemberUnknownRole": {
+    "text": "Bu hesap zaten bu organizasyonun bir uyesi. Ekleme mevcut rolu degistirmez.",
+    "source_hash": "035641ec"
+  },
+  "web.admin.organizations.addMember.errors.notFound": {
+    "text": "O hesap veya organizasyon artik mevcut degil. Hesabi onaylamak icin tekrar arayin.",
+    "source_hash": "bd88db18"
+  },
+  "web.admin.organizations.addMember.errors.invalidRole": {
+    "text": "O rol reddedildi. Listelenen rollerden birini secip tekrar deneyin.",
+    "source_hash": "eb696a8f"
+  },
+  "web.admin.organizations.addMember.errors.noSelection": {
+    "text": "Hesap secilmedi.",
+    "source_hash": "dd15bb5b"
+  },
+  "web.admin.organizations.addMember.fields.created": {
+    "text": "Kayit tarihi",
+    "source_hash": "486b3fe0"
+  },
+  "web.admin.organizations.addMember.fields.verified": {
+    "text": "Dogrulama",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.organizations.addMember.fields.lastLogin": {
+    "text": "Son oturum acma",
+    "source_hash": "0b70af7a"
+  },
+  "web.admin.organizations.addMember.fields.organizations": {
+    "text": "Mevcut organizasyonlar",
+    "source_hash": "cbb5b92f"
+  },
+  "web.admin.organizations.addMember.roleHints.member": {
+    "text": "Organizasyonun gizli mesajlarina ve alan adlarina gunluk erisim.",
+    "source_hash": "d0c7439e"
+  },
+  "web.admin.organizations.addMember.roleHints.admin": {
+    "text": "Uyeleri, alan adlarini ve organizasyon ayarlarini yonetebilir.",
+    "source_hash": "beaa50d7"
+  },
+  "web.admin.organizations.addMember.roleHints.owner": {
+    "text": "Faturalandirma dahil tam kontrol. Bunu yalnizca istendiginde verin.",
+    "source_hash": "614ace63"
+  },
+  "web.admin.organizations.addMember.roles.member": {
+    "text": "Uye",
+    "source_hash": "7c968fb7"
+  },
+  "web.admin.organizations.addMember.roles.admin": {
+    "text": "Yonetici",
+    "source_hash": "c1c224b0"
+  },
+  "web.admin.organizations.addMember.roles.owner": {
+    "text": "Sahip",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.detail.members.openCustomer": {
+    "text": "Musteri kaydini ac",
+    "source_hash": "c057ca13"
+  },
+  "web.admin.organizations.detail.reconcile.memberships": {
+    "text": "Uyelikler yeniden olusturuldu:",
+    "source_hash": "fe7db10c"
+  },
+  "web.admin.organizations.detail.reconcile.membershipsFailed": {
+    "text": "basarisiz, eski yetkilendirmeler kaliyor:",
+    "source_hash": "cc4dae37"
+  },
+  "web.admin.organizations.entitlements.catalogWarning": {
+    "text": "\"{entitlement}\" faturalandirma katalogunda yok - yazim hatasi olup olmadigini kontrol edin. Yine de devam ediliyor: sonraki bir katalogda yer alacak bir yetkilendirme vermek desteklenir ve kasitli olarak engellenmez.",
+    "source_hash": "cbde548a"
+  },
+  "web.admin.organizations.entitlements.matrix.caption": {
+    "text": "Yetkilendirme cozumleme matrisi: plan, gecersiz kilma vermeleri ve iptalleri, cozumlenmis kume ve somutlastirilan.",
+    "source_hash": "9eac8999"
+  },
+  "web.admin.organizations.entitlements.matrix.yes": {
+    "text": "Evet",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.matrix.no": {
+    "text": "Hayir",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.matrix.empty": {
+    "text": "Bu organizasyonun planindan yetkilendirmesi ve gecersiz kilmasi yok.",
+    "source_hash": "f6cf2169"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.entitlement": {
+    "text": "Yetkilendirme",
+    "source_hash": "0d8f0b2d"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.inPlan": {
+    "text": "Planda",
+    "source_hash": "e2222361"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.granted": {
+    "text": "Verildi",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.revoked": {
+    "text": "Iptal edildi",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.expected": {
+    "text": "Beklenen",
+    "source_hash": "ca99b7f1"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.materialized": {
+    "text": "Somutlastirilan",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.state": {
+    "text": "Durum",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.formula": {
+    "text": "Cozumleme: beklenen = (plan ∪ vermeler) − iptaller. Somutlastirilan, organizasyonda gercekte depolanan seydir.",
+    "source_hash": "bc4bff2d"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.orphaned": {
+    "text": "Yetim - somutlastirilmis ama beklenmemis, genellikle hic yeniden somutlastirilmamis bir iptal tarafindan birakilan. Uzlastirma bunu kaldirir.",
+    "source_hash": "3a27a9af"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.missing": {
+    "text": "Eksik - beklenen ama somutlastirilmamis. Bu, uyelerin su anda gercekten eksik oldugu izindir.",
+    "source_hash": "485e44ad"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.revoked": {
+    "text": "Ustu cizili satirlar bir yonetici gecersiz kilmasi tarafindan iptal edilmistir, bu da onlari beklenen kumeden kaldirir.",
+    "source_hash": "89a2e9b6"
+  },
+  "web.admin.organizations.entitlements.matrix.state.plan": {
+    "text": "Plandan",
+    "source_hash": "1d346b26"
+  },
+  "web.admin.organizations.entitlements.matrix.state.granted": {
+    "text": "Verildi",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.state.revoked": {
+    "text": "Iptal edildi",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.state.orphaned": {
+    "text": "Yetim",
+    "source_hash": "8d827807"
+  },
+  "web.admin.organizations.entitlements.matrix.state.missing": {
+    "text": "Eksik",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.organizations.entitlements.picker.selectPlaceholder": {
+    "text": "Bir yetkilendirme secin...",
+    "source_hash": "53af3be8"
+  },
+  "web.admin.organizations.entitlements.picker.other": {
+    "text": "Diger - katalogda yok...",
+    "source_hash": "f08bc3a3"
+  },
+  "web.admin.organizations.entitlements.picker.customLabel": {
+    "text": "Yetkilendirme adi (katalogda degil)",
+    "source_hash": "52783229"
+  },
+  "web.admin.organizations.entitlements.picker.backToCatalog": {
+    "text": "Kataloga geri don",
+    "source_hash": "9b727f40"
+  },
+  "web.admin.organizations.entitlements.picker.uncategorized": {
+    "text": "Kategorisiz",
+    "source_hash": "8d40d123"
+  },
+  "web.admin.organizations.entitlements.picker.catalogUnavailable": {
+    "text": "Faturalandirma katalogu okunamadi, bu nedenle yetkilendirme adlari burada kontrol edilmiyor.",
+    "source_hash": "724869ec"
+  },
+  "web.admin.organizations.entitlements.picker.tags.inPlan": {
+    "text": "planda",
+    "source_hash": "5f2251bb"
+  },
+  "web.admin.organizations.entitlements.picker.tags.granted": {
+    "text": "verildi",
+    "source_hash": "dd515d19"
+  },
+  "web.admin.organizations.entitlements.picker.tags.revoked": {
+    "text": "iptal edildi",
+    "source_hash": "4bb47f18"
+  },
+  "web.admin.organizations.entitlements.summary.sync": {
+    "text": "Senkronize et",
+    "source_hash": "8d261a37"
+  },
+  "web.admin.organizations.entitlements.summary.materialized": {
+    "text": "Somutlastirilmis",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.summary.materializedAt": {
+    "text": "Son somutlastirma",
+    "source_hash": "9325dce9"
+  },
+  "web.admin.organizations.entitlements.summary.planDefinition": {
+    "text": "Plan tanimi",
+    "source_hash": "6b531454"
+  },
+  "web.admin.organizations.entitlements.summary.yes": {
+    "text": "Evet",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.summary.no": {
+    "text": "Hayir",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.summary.never": {
+    "text": "Hicbir zaman",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.organizations.entitlements.summary.planStale": {
+    "text": "Somutlastirmadan beri degisti",
+    "source_hash": "e682d8a4"
+  },
+  "web.admin.organizations.entitlements.summary.planCurrent": {
+    "text": "Guncel",
+    "source_hash": "e0d1b682"
+  },
+  "web.admin.organizations.entitlements.summary.planUnknown": {
+    "text": "Bilinmiyor - karsilastirilamadi",
+    "source_hash": "b607e540"
   }
 }

--- a/locales/content/tr/admin-organizations.json
+++ b/locales/content/tr/admin-organizations.json
@@ -320,51 +320,51 @@
     "source_hash": "2f676a94"
   },
   "web.admin.organizations.addMember.description": {
-    "text": "Zaten bir hesabi olan birini {org} organizasyonuna ekleyin. Bunu, bir kisi kendi basina kaydoldugunda ve hesap zaten var oldugu icin davet edilemediginde kullanin.",
+    "text": "Zaten bir hesabı olan birini {org} organizasyonuna ekleyin. Bunu, bir kişi kendi başına kaydolduğunda ve hesap zaten var olduğu için davet edilemediğinde kullanın.",
     "source_hash": "bb41faa6"
   },
   "web.admin.organizations.addMember.searchLabel": {
-    "text": "E-posta adresi veya hesap kimligi",
+    "text": "E-posta adresi veya hesap kimliği",
     "source_hash": "82b3040b"
   },
   "web.admin.organizations.addMember.searchPlaceholder": {
-    "text": "E-posta adresine gore ara",
+    "text": "E-posta adresine göre ara",
     "source_hash": "b75cc66c"
   },
   "web.admin.organizations.addMember.searchHint": {
-    "text": "E-posta adresinin bir kismiyla veya tam hesap kimligiyle eslesir.",
+    "text": "E-posta adresinin bir kısmıyla veya tam hesap kimliğiyle eşleşir.",
     "source_hash": "84547a60"
   },
   "web.admin.organizations.addMember.searchError": {
-    "text": "Hesaplar aranamadi. Baglantiyi kontrol edip yeniden deneyin.",
+    "text": "Hesaplar aranamadı. Bağlantıyı kontrol edip yeniden deneyin.",
     "source_hash": "4b6caa41"
   },
   "web.admin.organizations.addMember.searchParseError": {
-    "text": "Hesap aramasi beklenmedik bir yanit dondurdu. Sonuclar eksik olabilir.",
+    "text": "Hesap araması beklenmedik bir yanıt döndürdü. Sonuçlar eksik olabilir.",
     "source_hash": "0c814231"
   },
   "web.admin.organizations.addMember.idle": {
-    "text": "Hesabi bulmak icin bir e-posta adresi girin.",
+    "text": "Hesabı bulmak için bir e-posta adresi girin.",
     "source_hash": "f6340d35"
   },
   "web.admin.organizations.addMember.noResults": {
-    "text": "\"{term}\" ile eslesen hesap yok.",
+    "text": "\"{term}\" ile eşleşen hesap yok.",
     "source_hash": "199b662a"
   },
   "web.admin.organizations.addMember.noResultsHint": {
-    "text": "Buraya yalnizca mevcut hesaplar eklenebilir. Kisi hic kaydolmadiysa, bunun yerine davet edin.",
+    "text": "Buraya yalnızca mevcut hesaplar eklenebilir. Kişi hiç kaydolmadıysa, bunun yerine davet edin.",
     "source_hash": "ee90aeeb"
   },
   "web.admin.organizations.addMember.select": {
-    "text": "Sec",
+    "text": "Seç",
     "source_hash": "2a78025d"
   },
   "web.admin.organizations.addMember.selectedEyebrow": {
-    "text": "Secilen hesap",
+    "text": "Seçilen hesap",
     "source_hash": "8b63d947"
   },
   "web.admin.organizations.addMember.change": {
-    "text": "Farkli bir hesap sec",
+    "text": "Farklı bir hesap seç",
     "source_hash": "d4fe39ab"
   },
   "web.admin.organizations.addMember.createdOn": {
@@ -372,11 +372,11 @@
     "source_hash": "cfc0e19f"
   },
   "web.admin.organizations.addMember.organizationsUnavailable": {
-    "text": "Bu hesabin mevcut organizasyonlari yuklenemedi.",
+    "text": "Bu hesabın mevcut organizasyonları yüklenemedi.",
     "source_hash": "a35b6bfc"
   },
   "web.admin.organizations.addMember.defaultOrg": {
-    "text": "varsayilan",
+    "text": "varsayılan",
     "source_hash": "37a8eec1"
   },
   "web.admin.organizations.addMember.roleLabel": {
@@ -392,51 +392,51 @@
     "source_hash": "533be0dc"
   },
   "web.admin.organizations.addMember.badges.verified": {
-    "text": "Dogrulanmis",
+    "text": "Doğrulanmış",
     "source_hash": "4f783840"
   },
   "web.admin.organizations.addMember.badges.unverified": {
-    "text": "Dogrulanmamis",
+    "text": "Doğrulanmamış",
     "source_hash": "15133907"
   },
   "web.admin.organizations.addMember.badges.suspended": {
-    "text": "Askiya alinmis",
+    "text": "Askıya alınmış",
     "source_hash": "e392a389"
   },
   "web.admin.organizations.addMember.badges.alreadyMember": {
-    "text": "Zaten uye",
+    "text": "Zaten üye",
     "source_hash": "1739ed7c"
   },
   "web.admin.organizations.addMember.errors.alreadyMember": {
-    "text": "Bu hesap zaten bu organizasyonun bir uyesi, rolu {role}. Ekleme mevcut rolu degistirmez - bunun icin rol ayarla islemini kullanin.",
+    "text": "Bu hesap zaten bu organizasyonun bir üyesi, rolü {role}. Ekleme mevcut rolü değiştirmez - bunun için rol ayarla işlemini kullanın.",
     "source_hash": "cb6a4774"
   },
   "web.admin.organizations.addMember.errors.alreadyMemberUnknownRole": {
-    "text": "Bu hesap zaten bu organizasyonun bir uyesi. Ekleme mevcut rolu degistirmez.",
+    "text": "Bu hesap zaten bu organizasyonun bir üyesi. Ekleme mevcut rolü değiştirmez.",
     "source_hash": "035641ec"
   },
   "web.admin.organizations.addMember.errors.notFound": {
-    "text": "O hesap veya organizasyon artik mevcut degil. Hesabi onaylamak icin tekrar arayin.",
+    "text": "O hesap veya organizasyon artık mevcut değil. Hesabı onaylamak için tekrar arayın.",
     "source_hash": "bd88db18"
   },
   "web.admin.organizations.addMember.errors.invalidRole": {
-    "text": "O rol reddedildi. Listelenen rollerden birini secip tekrar deneyin.",
+    "text": "O rol reddedildi. Listelenen rollerden birini seçip tekrar deneyin.",
     "source_hash": "eb696a8f"
   },
   "web.admin.organizations.addMember.errors.noSelection": {
-    "text": "Hesap secilmedi.",
+    "text": "Hesap seçilmedi.",
     "source_hash": "dd15bb5b"
   },
   "web.admin.organizations.addMember.fields.created": {
-    "text": "Kayit tarihi",
+    "text": "Kayıt tarihi",
     "source_hash": "486b3fe0"
   },
   "web.admin.organizations.addMember.fields.verified": {
-    "text": "Dogrulama",
+    "text": "Doğrulama",
     "source_hash": "7140f4f1"
   },
   "web.admin.organizations.addMember.fields.lastLogin": {
-    "text": "Son oturum acma",
+    "text": "Son oturum açma",
     "source_hash": "0b70af7a"
   },
   "web.admin.organizations.addMember.fields.organizations": {
@@ -444,23 +444,23 @@
     "source_hash": "cbb5b92f"
   },
   "web.admin.organizations.addMember.roleHints.member": {
-    "text": "Organizasyonun gizli mesajlarina ve alan adlarina gunluk erisim.",
+    "text": "Organizasyonun gizli mesajlarına ve alan adlarına günlük erişim.",
     "source_hash": "d0c7439e"
   },
   "web.admin.organizations.addMember.roleHints.admin": {
-    "text": "Uyeleri, alan adlarini ve organizasyon ayarlarini yonetebilir.",
+    "text": "Üyeleri, alan adlarını ve organizasyon ayarlarını yönetebilir.",
     "source_hash": "beaa50d7"
   },
   "web.admin.organizations.addMember.roleHints.owner": {
-    "text": "Faturalandirma dahil tam kontrol. Bunu yalnizca istendiginde verin.",
+    "text": "Faturalandırma dahil tam kontrol. Bunu yalnızca istendiğinde verin.",
     "source_hash": "614ace63"
   },
   "web.admin.organizations.addMember.roles.member": {
-    "text": "Uye",
+    "text": "Üye",
     "source_hash": "7c968fb7"
   },
   "web.admin.organizations.addMember.roles.admin": {
-    "text": "Yonetici",
+    "text": "Yönetici",
     "source_hash": "c1c224b0"
   },
   "web.admin.organizations.addMember.roles.owner": {
@@ -468,23 +468,23 @@
     "source_hash": "4b1b8aa3"
   },
   "web.admin.organizations.detail.members.openCustomer": {
-    "text": "Musteri kaydini ac",
+    "text": "Müşteri kaydını aç",
     "source_hash": "c057ca13"
   },
   "web.admin.organizations.detail.reconcile.memberships": {
-    "text": "Uyelikler yeniden olusturuldu:",
+    "text": "Üyelikler yeniden oluşturuldu:",
     "source_hash": "fe7db10c"
   },
   "web.admin.organizations.detail.reconcile.membershipsFailed": {
-    "text": "basarisiz, eski yetkilendirmeler kaliyor:",
+    "text": "başarısız, eski yetkilendirmeler kalıyor:",
     "source_hash": "cc4dae37"
   },
   "web.admin.organizations.entitlements.catalogWarning": {
-    "text": "\"{entitlement}\" faturalandirma katalogunda yok - yazim hatasi olup olmadigini kontrol edin. Yine de devam ediliyor: sonraki bir katalogda yer alacak bir yetkilendirme vermek desteklenir ve kasitli olarak engellenmez.",
+    "text": "\"{entitlement}\" faturalandırma katalogunda yok - yazım hatası olup olmadığını kontrol edin. Yine de devam ediliyor: sonraki bir katalogda yer alacak bir yetkilendirme vermek desteklenir ve kasıtlı olarak engellenmez.",
     "source_hash": "cbde548a"
   },
   "web.admin.organizations.entitlements.matrix.caption": {
-    "text": "Yetkilendirme cozumleme matrisi: plan, gecersiz kilma vermeleri ve iptalleri, cozumlenmis kume ve somutlastirilan.",
+    "text": "Yetkilendirme çözümleme matrisi: plan, geçersiz kılma vermeleri ve iptalleri, çözümlenmiş küme ve somutlaştırılan.",
     "source_hash": "9eac8999"
   },
   "web.admin.organizations.entitlements.matrix.yes": {
@@ -492,11 +492,11 @@
     "source_hash": "85a39ab3"
   },
   "web.admin.organizations.entitlements.matrix.no": {
-    "text": "Hayir",
+    "text": "Hayır",
     "source_hash": "1ea442a1"
   },
   "web.admin.organizations.entitlements.matrix.empty": {
-    "text": "Bu organizasyonun planindan yetkilendirmesi ve gecersiz kilmasi yok.",
+    "text": "Bu organizasyonun planından yetkilendirmesi ve geçersiz kılması yok.",
     "source_hash": "f6cf2169"
   },
   "web.admin.organizations.entitlements.matrix.columns.entitlement": {
@@ -512,7 +512,7 @@
     "source_hash": "62026a42"
   },
   "web.admin.organizations.entitlements.matrix.columns.revoked": {
-    "text": "Iptal edildi",
+    "text": "İptal edildi",
     "source_hash": "f6f738d0"
   },
   "web.admin.organizations.entitlements.matrix.columns.expected": {
@@ -520,7 +520,7 @@
     "source_hash": "ca99b7f1"
   },
   "web.admin.organizations.entitlements.matrix.columns.materialized": {
-    "text": "Somutlastirilan",
+    "text": "Somutlaştırılan",
     "source_hash": "1298eb6e"
   },
   "web.admin.organizations.entitlements.matrix.columns.state": {
@@ -528,19 +528,19 @@
     "source_hash": "a3b50c47"
   },
   "web.admin.organizations.entitlements.matrix.legend.formula": {
-    "text": "Cozumleme: beklenen = (plan ∪ vermeler) − iptaller. Somutlastirilan, organizasyonda gercekte depolanan seydir.",
+    "text": "Çözümleme: beklenen = (plan ∪ vermeler) − iptaller. Somutlaştırılan, organizasyonda gerçekte depolanan şeydir.",
     "source_hash": "bc4bff2d"
   },
   "web.admin.organizations.entitlements.matrix.legend.orphaned": {
-    "text": "Yetim - somutlastirilmis ama beklenmemis, genellikle hic yeniden somutlastirilmamis bir iptal tarafindan birakilan. Uzlastirma bunu kaldirir.",
+    "text": "Yetim - somutlaştırılmış ama beklenmemiş, genellikle hiç yeniden somutlaştırılmamış bir iptal tarafından bırakılan. Uzlaştırma bunu kaldırır.",
     "source_hash": "3a27a9af"
   },
   "web.admin.organizations.entitlements.matrix.legend.missing": {
-    "text": "Eksik - beklenen ama somutlastirilmamis. Bu, uyelerin su anda gercekten eksik oldugu izindir.",
+    "text": "Eksik - beklenen ama somutlaştırılmamış. Bu, üyelerin şu anda gerçekten eksik olduğu izindir.",
     "source_hash": "485e44ad"
   },
   "web.admin.organizations.entitlements.matrix.legend.revoked": {
-    "text": "Ustu cizili satirlar bir yonetici gecersiz kilmasi tarafindan iptal edilmistir, bu da onlari beklenen kumeden kaldirir.",
+    "text": "Üstü çizili satırlar bir yönetici geçersiz kılması tarafından iptal edilmiştir, bu da onları beklenen kümeden kaldırır.",
     "source_hash": "89a2e9b6"
   },
   "web.admin.organizations.entitlements.matrix.state.plan": {
@@ -552,7 +552,7 @@
     "source_hash": "62026a42"
   },
   "web.admin.organizations.entitlements.matrix.state.revoked": {
-    "text": "Iptal edildi",
+    "text": "İptal edildi",
     "source_hash": "f6f738d0"
   },
   "web.admin.organizations.entitlements.matrix.state.orphaned": {
@@ -564,19 +564,19 @@
     "source_hash": "6be36ca4"
   },
   "web.admin.organizations.entitlements.picker.selectPlaceholder": {
-    "text": "Bir yetkilendirme secin...",
+    "text": "Bir yetkilendirme seçin...",
     "source_hash": "53af3be8"
   },
   "web.admin.organizations.entitlements.picker.other": {
-    "text": "Diger - katalogda yok...",
+    "text": "Diğer - katalogda yok...",
     "source_hash": "f08bc3a3"
   },
   "web.admin.organizations.entitlements.picker.customLabel": {
-    "text": "Yetkilendirme adi (katalogda degil)",
+    "text": "Yetkilendirme adı (katalogda değil)",
     "source_hash": "52783229"
   },
   "web.admin.organizations.entitlements.picker.backToCatalog": {
-    "text": "Kataloga geri don",
+    "text": "Kataloga geri dön",
     "source_hash": "9b727f40"
   },
   "web.admin.organizations.entitlements.picker.uncategorized": {
@@ -584,7 +584,7 @@
     "source_hash": "8d40d123"
   },
   "web.admin.organizations.entitlements.picker.catalogUnavailable": {
-    "text": "Faturalandirma katalogu okunamadi, bu nedenle yetkilendirme adlari burada kontrol edilmiyor.",
+    "text": "Faturalandırma kataloğu okunamadı, bu nedenle yetkilendirme adları burada kontrol edilmiyor.",
     "source_hash": "724869ec"
   },
   "web.admin.organizations.entitlements.picker.tags.inPlan": {
@@ -604,15 +604,15 @@
     "source_hash": "8d261a37"
   },
   "web.admin.organizations.entitlements.summary.materialized": {
-    "text": "Somutlastirilmis",
+    "text": "Somutlaştırılmış",
     "source_hash": "1298eb6e"
   },
   "web.admin.organizations.entitlements.summary.materializedAt": {
-    "text": "Son somutlastirma",
+    "text": "Son somutlaştırma",
     "source_hash": "9325dce9"
   },
   "web.admin.organizations.entitlements.summary.planDefinition": {
-    "text": "Plan tanimi",
+    "text": "Plan tanımı",
     "source_hash": "6b531454"
   },
   "web.admin.organizations.entitlements.summary.yes": {
@@ -620,23 +620,23 @@
     "source_hash": "85a39ab3"
   },
   "web.admin.organizations.entitlements.summary.no": {
-    "text": "Hayir",
+    "text": "Hayır",
     "source_hash": "1ea442a1"
   },
   "web.admin.organizations.entitlements.summary.never": {
-    "text": "Hicbir zaman",
+    "text": "Hiçbir zaman",
     "source_hash": "6300ef80"
   },
   "web.admin.organizations.entitlements.summary.planStale": {
-    "text": "Somutlastirmadan beri degisti",
+    "text": "Somutlaştırmadan beri değişti",
     "source_hash": "e682d8a4"
   },
   "web.admin.organizations.entitlements.summary.planCurrent": {
-    "text": "Guncel",
+    "text": "Güncel",
     "source_hash": "e0d1b682"
   },
   "web.admin.organizations.entitlements.summary.planUnknown": {
-    "text": "Bilinmiyor - karsilastirilamadi",
+    "text": "Bilinmiyor - karşılaştırılamadı",
     "source_hash": "b607e540"
   }
 }

--- a/locales/content/tr/admin-secrets.json
+++ b/locales/content/tr/admin-secrets.json
@@ -1,11 +1,11 @@
 {
   "web.admin.secrets.title": {
-    "text": "Gizli Mesajlar",
-    "source_hash": "d8707d41"
+    "text": "Gizli Mesaj Makbuzlari",
+    "source_hash": "a8a2d0e4"
   },
   "web.admin.secrets.description": {
-    "text": "Bir gizli mesajın makbuzunu inceleyin ve SSH kullanmadan silin — anahtarıyla arayın.",
-    "source_hash": "07775a11"
+    "text": "Durum, zaman damgalari, makbuz vb. arayin.",
+    "source_hash": "91fba2a1"
   },
   "web.admin.secrets.never": {
     "text": "Hiçbir zaman",
@@ -108,20 +108,20 @@
     "source_hash": "504101bc"
   },
   "web.admin.secrets.lookup.resultTitle": {
-    "text": "{shortid} gizli mesajı",
-    "source_hash": "8b311d32"
+    "text": "Gizli mesaj kaydi {shortid}",
+    "source_hash": "ee06d765"
   },
   "web.admin.secrets.lookup.notFound": {
-    "text": "Gizli mesaj bulunamadı",
-    "source_hash": "70a9532c"
+    "text": "Kayit bulunamadi",
+    "source_hash": "40f4d9e9"
   },
   "web.admin.secrets.lookup.notFoundDescription": {
     "text": "Bu anahtarla bir gizli mesaj yok. Süresi dolmuş veya silinmiş olabilir.",
     "source_hash": "9f068a81"
   },
   "web.admin.secrets.lookup.loadError": {
-    "text": "Bu gizli mesaj yüklenemedi.",
-    "source_hash": "c96672e4"
+    "text": "Bu kayit yuklenemedi.",
+    "source_hash": "de77cc72"
   },
   "web.admin.secrets.lookup.retry": {
     "text": "Yeniden Dene",
@@ -188,8 +188,8 @@
     "source_hash": "c127dab6"
   },
   "web.admin.secrets.sections.secret": {
-    "text": "Gizli Mesaj",
-    "source_hash": "7e32a729"
+    "text": "Gizli mesaj kaydi",
+    "source_hash": "263813c6"
   },
   "web.admin.secrets.sections.receipt": {
     "text": "Makbuz",
@@ -214,5 +214,25 @@
   "web.admin.secrets.state.viewed": {
     "text": "Görüntülendi",
     "source_hash": "1b28d178"
+  },
+  "web.admin.secrets.capability.title": {
+    "text": "Yalnizca meta veri",
+    "source_hash": "df0453d1"
+  },
+  "web.admin.secrets.capability.canRead": {
+    "text": "Bir gizli mesajin meta verilerini ve makbuzunu okur: durum, zaman damgalari, sahip ve depolanan sifreli metnin boyutu.",
+    "source_hash": "d438ecc7"
+  },
+  "web.admin.secrets.capability.cannotRead": {
+    "text": "Gizli mesaj iceriginin sifresini cozemez veya goruntuleyemez. Bu ekranin arkasindaki ucnokta bunu asla dondurmuyor.",
+    "source_hash": "7f69f222"
+  },
+  "web.admin.secrets.capability.canDelete": {
+    "text": "Bir gizli mesaji ve makbuzunu kalici olarak silebilir, bu da icerigi hic ifsa etmeden yok eder.",
+    "source_hash": "77f2bc7e"
+  },
+  "web.admin.secrets.lookup.hint": {
+    "text": "Gizli mesajin baglantisindaki tanimlayici - gizli mesaj icerigi degil.",
+    "source_hash": "acfbc352"
   }
 }

--- a/locales/content/tr/admin-secrets.json
+++ b/locales/content/tr/admin-secrets.json
@@ -1,10 +1,10 @@
 {
   "web.admin.secrets.title": {
-    "text": "Gizli Mesaj Makbuzlari",
+    "text": "Gizli Mesaj Makbuzları",
     "source_hash": "a8a2d0e4"
   },
   "web.admin.secrets.description": {
-    "text": "Durum, zaman damgalari, makbuz vb. arayin.",
+    "text": "Durum, zaman damgaları, makbuz vb. arayın.",
     "source_hash": "91fba2a1"
   },
   "web.admin.secrets.never": {
@@ -108,11 +108,11 @@
     "source_hash": "504101bc"
   },
   "web.admin.secrets.lookup.resultTitle": {
-    "text": "Gizli mesaj kaydi {shortid}",
+    "text": "Gizli mesaj kaydı {shortid}",
     "source_hash": "ee06d765"
   },
   "web.admin.secrets.lookup.notFound": {
-    "text": "Kayit bulunamadi",
+    "text": "Kayıt bulunamadı",
     "source_hash": "40f4d9e9"
   },
   "web.admin.secrets.lookup.notFoundDescription": {
@@ -120,7 +120,7 @@
     "source_hash": "9f068a81"
   },
   "web.admin.secrets.lookup.loadError": {
-    "text": "Bu kayit yuklenemedi.",
+    "text": "Bu kayıt yüklenemedi.",
     "source_hash": "de77cc72"
   },
   "web.admin.secrets.lookup.retry": {
@@ -188,7 +188,7 @@
     "source_hash": "c127dab6"
   },
   "web.admin.secrets.sections.secret": {
-    "text": "Gizli mesaj kaydi",
+    "text": "Gizli mesaj kaydı",
     "source_hash": "263813c6"
   },
   "web.admin.secrets.sections.receipt": {
@@ -216,23 +216,23 @@
     "source_hash": "1b28d178"
   },
   "web.admin.secrets.capability.title": {
-    "text": "Yalnizca meta veri",
+    "text": "Yalnızca meta veri",
     "source_hash": "df0453d1"
   },
   "web.admin.secrets.capability.canRead": {
-    "text": "Bir gizli mesajin meta verilerini ve makbuzunu okur: durum, zaman damgalari, sahip ve depolanan sifreli metnin boyutu.",
+    "text": "Bir gizli mesajın meta verilerini ve makbuzunu okur: durum, zaman damgaları, sahip ve depolanan şifreli metnin boyutu.",
     "source_hash": "d438ecc7"
   },
   "web.admin.secrets.capability.cannotRead": {
-    "text": "Gizli mesaj iceriginin sifresini cozemez veya goruntuleyemez. Bu ekranin arkasindaki ucnokta bunu asla dondurmuyor.",
+    "text": "Gizli mesaj içeriğinin şifresini çözemez veya görüntüleyemez. Bu ekranın arkasındaki uçnokta bunu asla döndürmüyor.",
     "source_hash": "7f69f222"
   },
   "web.admin.secrets.capability.canDelete": {
-    "text": "Bir gizli mesaji ve makbuzunu kalici olarak silebilir, bu da icerigi hic ifsa etmeden yok eder.",
+    "text": "Bir gizli mesajı ve makbuzunu kalıcı olarak silebilir, bu da içeriği hiç ifşa etmeden yok eder.",
     "source_hash": "77f2bc7e"
   },
   "web.admin.secrets.lookup.hint": {
-    "text": "Gizli mesajin baglantisindaki tanimlayici - gizli mesaj icerigi degil.",
+    "text": "Gizli mesajın bağlantısındaki tanımlayıcı - gizli mesaj içeriği değil.",
     "source_hash": "acfbc352"
   }
 }

--- a/locales/content/tr/admin-system.json
+++ b/locales/content/tr/admin-system.json
@@ -154,5 +154,133 @@
   "web.admin.system.redis.captured": {
     "text": "{at} tarihinde yakalandı",
     "source_hash": "57b40c0f"
+  },
+  "web.admin.system.brand.title": {
+    "text": "Marka Tanilama",
+    "source_hash": "1cf9abd5"
+  },
+  "web.admin.system.brand.description": {
+    "text": "Calisan ornegin diskte hangi marka paketini cozumledigi - bir bolgenin neden notr markalama sunabilecegini ortaya koyar.",
+    "source_hash": "be29e282"
+  },
+  "web.admin.system.brand.loadError": {
+    "text": "Marka tanilama yuklenemedi.",
+    "source_hash": "80607303"
+  },
+  "web.admin.system.brand.none": {
+    "text": "(yok)",
+    "source_hash": "552e4230"
+  },
+  "web.admin.system.brand.resolution": {
+    "text": "Cozumleme",
+    "source_hash": "d4055faf"
+  },
+  "web.admin.system.brand.envVsConfig": {
+    "text": "Ortam ve Yapilandirma",
+    "source_hash": "bee3debb"
+  },
+  "web.admin.system.brand.absorbed": {
+    "text": "Emilen Anahtarlar",
+    "source_hash": "9784e110"
+  },
+  "web.admin.system.brand.operatorKeys": {
+    "text": "Operator Anahtarlari",
+    "source_hash": "434e8248"
+  },
+  "web.admin.system.brand.overlayAssets": {
+    "text": "Kaplama Varliklari",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.exists.yes": {
+    "text": "Mevcut",
+    "source_hash": "43f9b89c"
+  },
+  "web.admin.system.brand.exists.no": {
+    "text": "Eksik",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.system.brand.fields.resolvedDir": {
+    "text": "Cozumlenen Dizin",
+    "source_hash": "0623b983"
+  },
+  "web.admin.system.brand.fields.home": {
+    "text": "Ana Dizin",
+    "source_hash": "3a786953"
+  },
+  "web.admin.system.brand.fields.envPack": {
+    "text": "ENV Marka Paketi",
+    "source_hash": "940aeb5c"
+  },
+  "web.admin.system.brand.fields.configPack": {
+    "text": "Yapilandirma Marka Paketi",
+    "source_hash": "761b9550"
+  },
+  "web.admin.system.brand.fields.envAssetsDir": {
+    "text": "ENV Marka Varliklari Dizini",
+    "source_hash": "05854f1f"
+  },
+  "web.admin.system.brand.fields.configAssetsDir": {
+    "text": "Yapilandirma Marka Varliklari Dizini",
+    "source_hash": "e91e5c46"
+  },
+  "web.admin.system.brand.flags.fellBack.danger": {
+    "text": "Varsayilan pakete geri donuldu",
+    "source_hash": "7bf7ba2f"
+  },
+  "web.admin.system.brand.flags.fellBack.ok": {
+    "text": "Marka paketi cozumlendi",
+    "source_hash": "1ab3162f"
+  },
+  "web.admin.system.brand.flags.mismatch.danger": {
+    "text": "Baslangic / canli uyumsuzlugu",
+    "source_hash": "0a022192"
+  },
+  "web.admin.system.brand.flags.mismatch.ok": {
+    "text": "Baslangic canli ile eslesiyor",
+    "source_hash": "d4792c09"
+  },
+  "web.admin.system.brand.manifest.title": {
+    "text": "Manifest",
+    "source_hash": "3c99f1f3"
+  },
+  "web.admin.system.brand.manifest.path": {
+    "text": "Yol",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.manifest.exists": {
+    "text": "Var",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.manifest.keysOnDisk": {
+    "text": "Diskteki Anahtarlar",
+    "source_hash": "52439c03"
+  },
+  "web.admin.system.brand.roots.title": {
+    "text": "Arama Kokleri",
+    "source_hash": "d8696f2b"
+  },
+  "web.admin.system.brand.roots.empty": {
+    "text": "Arama koku yok",
+    "source_hash": "867a471c"
+  },
+  "web.admin.system.brand.roots.columns.path": {
+    "text": "Yol",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.roots.columns.exists": {
+    "text": "Var",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.stats.brandPack": {
+    "text": "Marka Paketi",
+    "source_hash": "884437d0"
+  },
+  "web.admin.system.brand.stats.overlayAssets": {
+    "text": "Kaplama Varliklari",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.stats.manifestKeys": {
+    "text": "Manifest Anahtarlari",
+    "source_hash": "c4267198"
   }
 }

--- a/locales/content/tr/admin-system.json
+++ b/locales/content/tr/admin-system.json
@@ -156,15 +156,15 @@
     "source_hash": "57b40c0f"
   },
   "web.admin.system.brand.title": {
-    "text": "Marka Tanilama",
+    "text": "Marka Tanılama",
     "source_hash": "1cf9abd5"
   },
   "web.admin.system.brand.description": {
-    "text": "Calisan ornegin diskte hangi marka paketini cozumledigi - bir bolgenin neden notr markalama sunabilecegini ortaya koyar.",
+    "text": "Çalışan örneğin diskte hangi marka paketini çözümlediği - bir bölgenin neden nötr markalama sunabileceğini ortaya koyar.",
     "source_hash": "be29e282"
   },
   "web.admin.system.brand.loadError": {
-    "text": "Marka tanilama yuklenemedi.",
+    "text": "Marka tanılama yüklenemedi.",
     "source_hash": "80607303"
   },
   "web.admin.system.brand.none": {
@@ -172,11 +172,11 @@
     "source_hash": "552e4230"
   },
   "web.admin.system.brand.resolution": {
-    "text": "Cozumleme",
+    "text": "Çözümleme",
     "source_hash": "d4055faf"
   },
   "web.admin.system.brand.envVsConfig": {
-    "text": "Ortam ve Yapilandirma",
+    "text": "Ortam ve Yapılandırma",
     "source_hash": "bee3debb"
   },
   "web.admin.system.brand.absorbed": {
@@ -184,11 +184,11 @@
     "source_hash": "9784e110"
   },
   "web.admin.system.brand.operatorKeys": {
-    "text": "Operator Anahtarlari",
+    "text": "Operatör Anahtarları",
     "source_hash": "434e8248"
   },
   "web.admin.system.brand.overlayAssets": {
-    "text": "Kaplama Varliklari",
+    "text": "Kaplama Varlıkları",
     "source_hash": "c87de1f9"
   },
   "web.admin.system.brand.exists.yes": {
@@ -200,7 +200,7 @@
     "source_hash": "6be36ca4"
   },
   "web.admin.system.brand.fields.resolvedDir": {
-    "text": "Cozumlenen Dizin",
+    "text": "Çözümlenen Dizin",
     "source_hash": "0623b983"
   },
   "web.admin.system.brand.fields.home": {
@@ -212,31 +212,31 @@
     "source_hash": "940aeb5c"
   },
   "web.admin.system.brand.fields.configPack": {
-    "text": "Yapilandirma Marka Paketi",
+    "text": "Yapılandırma Marka Paketi",
     "source_hash": "761b9550"
   },
   "web.admin.system.brand.fields.envAssetsDir": {
-    "text": "ENV Marka Varliklari Dizini",
+    "text": "ENV Marka Varlıkları Dizini",
     "source_hash": "05854f1f"
   },
   "web.admin.system.brand.fields.configAssetsDir": {
-    "text": "Yapilandirma Marka Varliklari Dizini",
+    "text": "Yapılandırma Marka Varlıkları Dizini",
     "source_hash": "e91e5c46"
   },
   "web.admin.system.brand.flags.fellBack.danger": {
-    "text": "Varsayilan pakete geri donuldu",
+    "text": "Varsayılan pakete geri dönüldü",
     "source_hash": "7bf7ba2f"
   },
   "web.admin.system.brand.flags.fellBack.ok": {
-    "text": "Marka paketi cozumlendi",
+    "text": "Marka paketi çözümlendi",
     "source_hash": "1ab3162f"
   },
   "web.admin.system.brand.flags.mismatch.danger": {
-    "text": "Baslangic / canli uyumsuzlugu",
+    "text": "Başlangıç / canlı uyumsuzluğu",
     "source_hash": "0a022192"
   },
   "web.admin.system.brand.flags.mismatch.ok": {
-    "text": "Baslangic canli ile eslesiyor",
+    "text": "Başlangıç canlı ile eşleşiyor",
     "source_hash": "d4792c09"
   },
   "web.admin.system.brand.manifest.title": {
@@ -256,11 +256,11 @@
     "source_hash": "52439c03"
   },
   "web.admin.system.brand.roots.title": {
-    "text": "Arama Kokleri",
+    "text": "Arama Kökleri",
     "source_hash": "d8696f2b"
   },
   "web.admin.system.brand.roots.empty": {
-    "text": "Arama koku yok",
+    "text": "Arama kökü yok",
     "source_hash": "867a471c"
   },
   "web.admin.system.brand.roots.columns.path": {
@@ -276,11 +276,11 @@
     "source_hash": "884437d0"
   },
   "web.admin.system.brand.stats.overlayAssets": {
-    "text": "Kaplama Varliklari",
+    "text": "Kaplama Varlıkları",
     "source_hash": "c87de1f9"
   },
   "web.admin.system.brand.stats.manifestKeys": {
-    "text": "Manifest Anahtarlari",
+    "text": "Manifest Anahtarları",
     "source_hash": "c4267198"
   }
 }

--- a/locales/content/tr/email.json
+++ b/locales/content/tr/email.json
@@ -838,31 +838,31 @@
     "source_hash": "2d544dad"
   },
   "email.sso_link_verification.subject": {
-    "text": "%{provider} hesabini %{product_name} hesabiniza baglamayi onaylayin",
+    "text": "%{provider} hesabını %{product_name} hesabınıza bağlamayı onaylayın",
     "source_hash": "65e70296"
   },
   "email.sso_link_verification.title": {
-    "text": "SSO oturum acmanizi onaylayin",
+    "text": "SSO oturum açmanızı onaylayın",
     "source_hash": "35bce6cc"
   },
   "email.sso_link_verification.request_notice": {
-    "text": "Birisi %{email_address} e-postasini kullanarak %{provider} ile oturum acti. %{provider} hesabini %{product_name} hesabiniza baglamayi tamamlamak icin asagidan onaylayin.",
+    "text": "Birisi %{email_address} e-postasını kullanarak %{provider} ile oturum açtı. %{provider} hesabını %{product_name} hesabınıza bağlamayı tamamlamak için aşağıdan onaylayın.",
     "source_hash": "baeb18c0"
   },
   "email.sso_link_verification.confirm_button": {
-    "text": "Onayla ve %{provider} hesabini bagla",
+    "text": "Onayla ve %{provider} hesabını bağla",
     "source_hash": "9809e210"
   },
   "email.sso_link_verification.copy_link_prompt": {
-    "text": "Veya bu baglantiya kopyalayip yapistirin:",
+    "text": "Veya bu bağlantıya kopyalayıp yapıştırın:",
     "source_hash": "88c72144"
   },
   "email.sso_link_verification.expiration_notice": {
-    "text": "Bu baglantinin suresi 15 dakika icinde dolar ve yalnizca bir kez kullanilabilir.",
+    "text": "Bu bağlantının süresi 15 dakika içinde dolar ve yalnızca bir kez kullanılabilir.",
     "source_hash": "1a437f42"
   },
   "email.sso_link_verification.ignore_notice": {
-    "text": "%{provider} ile oturum acmayi denemediyseniz, bu e-postayi guvenlice yoksayabilirsiniz - hesabiniza hicbir sey baglanmayacaktir.",
+    "text": "%{provider} ile oturum açmayı denemediyseniz, bu e-postayı güvenlice yoksayabilirsiniz - hesabınıza hiçbir şey bağlanmayacaktır.",
     "source_hash": "d7317d30"
   },
   "email.sso_link_verification.signature": {
@@ -870,7 +870,7 @@
     "source_hash": "dc75bf9f"
   },
   "email.sso_link_verification.postscript": {
-    "text": "N.B. Bu e-posta %{email_address} adresine gonderildi.",
+    "text": "N.B. Bu e-posta %{email_address} adresine gönderildi.",
     "source_hash": "8ab1dbea"
   }
 }

--- a/locales/content/tr/email.json
+++ b/locales/content/tr/email.json
@@ -836,5 +836,41 @@
   "email.secret_link.footer_note": {
     "text": "Bu mesajı, %{sender_email} sizinle bir gizli mesaj paylaşmak için %{product_name} kullandığı için aldınız. Beklemiyorsanız, bu e-postayı güvenle yok sayabilirsiniz.",
     "source_hash": "2d544dad"
+  },
+  "email.sso_link_verification.subject": {
+    "text": "%{provider} hesabini %{product_name} hesabiniza baglamayi onaylayin",
+    "source_hash": "65e70296"
+  },
+  "email.sso_link_verification.title": {
+    "text": "SSO oturum acmanizi onaylayin",
+    "source_hash": "35bce6cc"
+  },
+  "email.sso_link_verification.request_notice": {
+    "text": "Birisi %{email_address} e-postasini kullanarak %{provider} ile oturum acti. %{provider} hesabini %{product_name} hesabiniza baglamayi tamamlamak icin asagidan onaylayin.",
+    "source_hash": "baeb18c0"
+  },
+  "email.sso_link_verification.confirm_button": {
+    "text": "Onayla ve %{provider} hesabini bagla",
+    "source_hash": "9809e210"
+  },
+  "email.sso_link_verification.copy_link_prompt": {
+    "text": "Veya bu baglantiya kopyalayip yapistirin:",
+    "source_hash": "88c72144"
+  },
+  "email.sso_link_verification.expiration_notice": {
+    "text": "Bu baglantinin suresi 15 dakika icinde dolar ve yalnizca bir kez kullanilabilir.",
+    "source_hash": "1a437f42"
+  },
+  "email.sso_link_verification.ignore_notice": {
+    "text": "%{provider} ile oturum acmayi denemediyseniz, bu e-postayi guvenlice yoksayabilirsiniz - hesabiniza hicbir sey baglanmayacaktir.",
+    "source_hash": "d7317d30"
+  },
+  "email.sso_link_verification.signature": {
+    "text": "Destek Ekibi",
+    "source_hash": "dc75bf9f"
+  },
+  "email.sso_link_verification.postscript": {
+    "text": "N.B. Bu e-posta %{email_address} adresine gonderildi.",
+    "source_hash": "8ab1dbea"
   }
 }

--- a/locales/content/tr/session-auth-extended.json
+++ b/locales/content/tr/session-auth-extended.json
@@ -730,5 +730,201 @@
   "web.auth.sessions.session_plural": {
     "text": "oturum",
     "source_hash": "1225ae6c"
+  },
+  "web.auth.connections.title": {
+    "text": "Bagli Kimlikler",
+    "source_hash": "e132c4d9"
+  },
+  "web.auth.connections.description": {
+    "text": "Hesabiniza bagli tek oturum acma saglayicilarini yonetin.",
+    "source_hash": "42c6d148"
+  },
+  "web.auth.connections.section_title": {
+    "text": "Tek oturum acma",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.section_subtitle": {
+    "text": "Bu hesaba oturum acmak icin kullanabileceginiz kimlik saglayicilari",
+    "source_hash": "507254cd"
+  },
+  "web.auth.connections.connect_title": {
+    "text": "Bir saglayici bagla",
+    "source_hash": "a002b3f3"
+  },
+  "web.auth.connections.connect_description": {
+    "text": "Bu hesaba oturum acmak icin kullanabileceginiz baska bir tek oturum acma saglayicisi baglayin.",
+    "source_hash": "32895a5a"
+  },
+  "web.auth.connections.connect_action": {
+    "text": "{provider} bagla",
+    "source_hash": "c77540af"
+  },
+  "web.auth.connections.issuer": {
+    "text": "Veren",
+    "source_hash": "39e02c46"
+  },
+  "web.auth.connections.identifier": {
+    "text": "Tanimlayici",
+    "source_hash": "9b10587f"
+  },
+  "web.auth.connections.remove": {
+    "text": "Kaldir",
+    "source_hash": "c3812fc4"
+  },
+  "web.auth.connections.remove_confirm_title": {
+    "text": "Bagli kimligi kaldir",
+    "source_hash": "4e8ffe4c"
+  },
+  "web.auth.connections.remove_confirm_message": {
+    "text": "Bu bagli kimligi kaldirmak istediginizden emin misiniz? Artik onunla oturum acamayacaksiniz.",
+    "source_hash": "64939c89"
+  },
+  "web.auth.connections.removed_success": {
+    "text": "Bagli kimlik kaldirildi",
+    "source_hash": "cf87daf3"
+  },
+  "web.auth.connections.no_identities": {
+    "text": "Bagli kimlik yok",
+    "source_hash": "5254048e"
+  },
+  "web.auth.connections.no_identities_description": {
+    "text": "Henuz bu hesaba herhangi bir tek oturum acma saglayicisi baglamamisssiniz.",
+    "source_hash": "0f58d5d0"
+  },
+  "web.auth.connections.overview_status": {
+    "text": "Tek oturum acma",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.errors.last_credential": {
+    "text": "Bu oturum acmanin tek yoludur. Kilitleninmemek icin once baska bir saglayici baglayin veya Ayarlar -> Guvenlik bolumunden bir parola belirleyin.",
+    "source_hash": "3de8084d"
+  },
+  "web.auth.connections.errors.last_credential_sso_enforced": {
+    "text": "Bu oturum acmanin tek yoludur. Kilitleninmemek icin once baska bir saglayici baglayin.",
+    "source_hash": "eed7a50e"
+  },
+  "web.auth.connections.errors.not_found": {
+    "text": "Bu bagli kimlik bulunamadi. Zaten kaldirilmis olabilir.",
+    "source_hash": "cf2c7673"
+  },
+  "web.auth.connections.errors.unauthorized": {
+    "text": "Oturumunuzun suresi doldu. Lutfen tekrar oturum acin.",
+    "source_hash": "b529fce2"
+  },
+  "web.auth.connections.errors.generic": {
+    "text": "Bu islemi tamamlayamadik. Lutfen tekrar deneyin.",
+    "source_hash": "a0d4edc0"
+  },
+  "web.link_sso.title": {
+    "text": "Oturum acma yonteminizi baglayin",
+    "source_hash": "46339bac"
+  },
+  "web.link_sso.prompt": {
+    "text": "{provider} ile oturum actiniz, bu da mevcut {email} hesabiyla eslesiyor. {provider} hesabini baglamak ve devam etmek icin o hesabin parolasini girin.",
+    "source_hash": "59da1c08"
+  },
+  "web.link_sso.password_label": {
+    "text": "Parola",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.link_sso.password_placeholder": {
+    "text": "Mevcut parolaniz",
+    "source_hash": "ad4e56da"
+  },
+  "web.link_sso.submit": {
+    "text": "Bagla ve devam et",
+    "source_hash": "c969b759"
+  },
+  "web.link_sso.cancel": {
+    "text": "Iptal",
+    "source_hash": "19766ed6"
+  },
+  "web.link_sso.unavailable_title": {
+    "text": "Bu baglama isteginin suresi doldu",
+    "source_hash": "b53c7e55"
+  },
+  "web.link_sso.unavailable_message": {
+    "text": "Guvenliginiz icin, bu oturum acma yontemini baglama istegi artik gecerli degil. Mevcut parolanizla oturum acin, ardindan bu saglayiciyi Guvenlik ayarlari -> Bagli kimlikler altinda baglayin.",
+    "source_hash": "f7e349d1"
+  },
+  "web.link_sso.unavailable_action": {
+    "text": "Oturum acmaya devam et",
+    "source_hash": "d398cd0a"
+  },
+  "web.link_sso.errors.invalid_password": {
+    "text": "Bu parola bu hesapla eslesmiyor. Lutfen tekrar deneyin.",
+    "source_hash": "3259b4f5"
+  },
+  "web.link_sso.errors.invalid_token": {
+    "text": "Bu baglama isteginin suresi doldu veya zaten kullanildi. Mevcut parolanizla oturum acin, ardindan bu saglayiciyi hesap ayarlarinizdan baglayin.",
+    "source_hash": "541f9127"
+  },
+  "web.link_sso.errors.link_conflict": {
+    "text": "Bu oturum acma yontemini baglayamadik. Hesabiniz degismis olabilir veya bu saglayici zaten baska bir hesaba bagli. Mevcut parolanizla oturum acin, ardindan Guvenlik ayarlari -> Bagli kimlikler altinda baglantilari yonetin.",
+    "source_hash": "7b0e0d0e"
+  },
+  "web.link_sso.errors.link_rate_limited": {
+    "text": "Cok fazla parola denemesi. Lutfen birkac dakika bekleyin, ardindan tekrar deneyin.",
+    "source_hash": "a95e78cd"
+  },
+  "web.link_sso.errors.invalid_request": {
+    "text": "Bu baglama istegini isleyemedik. Lutfen SSO saglayicinizla tekrar oturum acin.",
+    "source_hash": "053b9fc6"
+  },
+  "web.link_sso.errors.generic": {
+    "text": "Hesabinizi baglayamadik. Lutfen tekrar deneyin.",
+    "source_hash": "f727c174"
+  },
+  "web.sso_link_confirm.title": {
+    "text": "Hesabinizi baglamayi onaylayin",
+    "source_hash": "ad80bfe7"
+  },
+  "web.sso_link_confirm.prompt": {
+    "text": "{provider} ile oturum actiniz, bu da {email} hesabinizla eslesiyor. {provider} hesabini bu hesaba baglamak ve oturum acmayi tamamlamak icin onaylayin.",
+    "source_hash": "6ff0d6cc"
+  },
+  "web.sso_link_confirm.submit": {
+    "text": "Onayla ve bagla",
+    "source_hash": "5cf663e6"
+  },
+  "web.sso_link_confirm.cancel": {
+    "text": "Iptal",
+    "source_hash": "19766ed6"
+  },
+  "web.sso_link_confirm.unavailable_title": {
+    "text": "Bu baglama istegi tamamlanamadi",
+    "source_hash": "47abb784"
+  },
+  "web.sso_link_confirm.unavailable_message": {
+    "text": "Guvenliginiz icin, oturum acma yonteminizi baglama istegi artik gecerli degil. Saglayicinizla tekrar oturum acin, size yeni bir baglanti e-postasi gonderecegiz.",
+    "source_hash": "080e6f9f"
+  },
+  "web.sso_link_confirm.unavailable_action": {
+    "text": "Oturum acmaya don",
+    "source_hash": "8504054f"
+  },
+  "web.sso_link_confirm.errors.link_expired": {
+    "text": "Bu baglama isteginin suresi doldu veya zaten kullanildi. Saglayicinizla tekrar oturum acin, size yeni bir baglanti e-postasi gonderecegiz.",
+    "source_hash": "a50538df"
+  },
+  "web.sso_link_confirm.errors.link_conflict": {
+    "text": "Bu oturum acma yontemini baglayamadik. Hesabiniz degismis olabilir veya bu saglayici zaten baska bir hesaba bagli. Devam etmek icin saglayicinizla tekrar oturum acin.",
+    "source_hash": "c954854b"
+  },
+  "web.sso_link_confirm.errors.link_invalidated": {
+    "text": "Bu baglanti gonderildikten sonra hesap kimlik bilgileriniz degisti, bu nedenle artik gecerli degil. Saglayicinizla tekrar oturum acin, size yeni bir baglanti e-postasi gonderecegiz.",
+    "source_hash": "db88cb1d"
+  },
+  "web.sso_link_confirm.errors.link_error": {
+    "text": "Bizim tarafimizda bir sorun olustu ve bu baglantivi dogrulayamadik. Saglayicinizla tekrar oturum acin, size yenisini e-postalariz.",
+    "source_hash": "ec24e0a1"
+  },
+  "web.sso_link_confirm.errors.confirm_rate_limited": {
+    "text": "Cihazinizdan cok fazla deneme yapildi. Lutfen birkac dakika bekleyin, ardindan e-postadaki baglantiyi tekrar acin veya saglayicinizla yenisini almak icin oturum acin.",
+    "source_hash": "f29af782"
+  },
+  "web.sso_link_confirm.errors.generic": {
+    "text": "Bu baglantiyi onaylayamadik. Lutfen saglayicinizla tekrar oturum acin.",
+    "source_hash": "076fa25a"
   }
 }

--- a/locales/content/tr/session-auth-extended.json
+++ b/locales/content/tr/session-auth-extended.json
@@ -732,31 +732,31 @@
     "source_hash": "1225ae6c"
   },
   "web.auth.connections.title": {
-    "text": "Bagli Kimlikler",
+    "text": "Bağlı Kimlikler",
     "source_hash": "e132c4d9"
   },
   "web.auth.connections.description": {
-    "text": "Hesabiniza bagli tek oturum acma saglayicilarini yonetin.",
+    "text": "Hesabınıza bağlı tek oturum açma sağlayıcılarını yönetin.",
     "source_hash": "42c6d148"
   },
   "web.auth.connections.section_title": {
-    "text": "Tek oturum acma",
+    "text": "Tek oturum açma",
     "source_hash": "3bc44ac2"
   },
   "web.auth.connections.section_subtitle": {
-    "text": "Bu hesaba oturum acmak icin kullanabileceginiz kimlik saglayicilari",
+    "text": "Bu hesaba oturum açmak için kullanabileceğiniz kimlik sağlayıcıları",
     "source_hash": "507254cd"
   },
   "web.auth.connections.connect_title": {
-    "text": "Bir saglayici bagla",
+    "text": "Bir sağlayıcı bağla",
     "source_hash": "a002b3f3"
   },
   "web.auth.connections.connect_description": {
-    "text": "Bu hesaba oturum acmak icin kullanabileceginiz baska bir tek oturum acma saglayicisi baglayin.",
+    "text": "Bu hesaba oturum açmak için kullanabileceğiniz başka bir tek oturum açma sağlayıcısı bağlayın.",
     "source_hash": "32895a5a"
   },
   "web.auth.connections.connect_action": {
-    "text": "{provider} bagla",
+    "text": "{provider} bağla",
     "source_hash": "c77540af"
   },
   "web.auth.connections.issuer": {
@@ -764,63 +764,63 @@
     "source_hash": "39e02c46"
   },
   "web.auth.connections.identifier": {
-    "text": "Tanimlayici",
+    "text": "Tanımlayıcı",
     "source_hash": "9b10587f"
   },
   "web.auth.connections.remove": {
-    "text": "Kaldir",
+    "text": "Kaldır",
     "source_hash": "c3812fc4"
   },
   "web.auth.connections.remove_confirm_title": {
-    "text": "Bagli kimligi kaldir",
+    "text": "Bağlı kimliği kaldır",
     "source_hash": "4e8ffe4c"
   },
   "web.auth.connections.remove_confirm_message": {
-    "text": "Bu bagli kimligi kaldirmak istediginizden emin misiniz? Artik onunla oturum acamayacaksiniz.",
+    "text": "Bu bağlı kimliği kaldırmak istediğinizden emin misiniz? Artık onunla oturum açamayacaksınız.",
     "source_hash": "64939c89"
   },
   "web.auth.connections.removed_success": {
-    "text": "Bagli kimlik kaldirildi",
+    "text": "Bağlı kimlik kaldırıldı",
     "source_hash": "cf87daf3"
   },
   "web.auth.connections.no_identities": {
-    "text": "Bagli kimlik yok",
+    "text": "Bağlı kimlik yok",
     "source_hash": "5254048e"
   },
   "web.auth.connections.no_identities_description": {
-    "text": "Henuz bu hesaba herhangi bir tek oturum acma saglayicisi baglamamisssiniz.",
+    "text": "Henüz bu hesaba herhangi bir tek oturum açma sağlayıcısı bağlamamışsınız.",
     "source_hash": "0f58d5d0"
   },
   "web.auth.connections.overview_status": {
-    "text": "Tek oturum acma",
+    "text": "Tek oturum açma",
     "source_hash": "3bc44ac2"
   },
   "web.auth.connections.errors.last_credential": {
-    "text": "Bu oturum acmanin tek yoludur. Kilitleninmemek icin once baska bir saglayici baglayin veya Ayarlar -> Guvenlik bolumunden bir parola belirleyin.",
+    "text": "Bu oturum açmanın tek yoludur. Kilitlenmemek için önce başka bir sağlayıcı bağlayın veya Ayarlar -> Güvenlik bölümünden bir parola belirleyin.",
     "source_hash": "3de8084d"
   },
   "web.auth.connections.errors.last_credential_sso_enforced": {
-    "text": "Bu oturum acmanin tek yoludur. Kilitleninmemek icin once baska bir saglayici baglayin.",
+    "text": "Bu oturum açmanın tek yoludur. Kilitlenmemek için önce başka bir sağlayıcı bağlayın.",
     "source_hash": "eed7a50e"
   },
   "web.auth.connections.errors.not_found": {
-    "text": "Bu bagli kimlik bulunamadi. Zaten kaldirilmis olabilir.",
+    "text": "Bu bağlı kimlik bulunamadı. Zaten kaldırılmış olabilir.",
     "source_hash": "cf2c7673"
   },
   "web.auth.connections.errors.unauthorized": {
-    "text": "Oturumunuzun suresi doldu. Lutfen tekrar oturum acin.",
+    "text": "Oturumunuzun süresi doldu. Lütfen tekrar oturum açın.",
     "source_hash": "b529fce2"
   },
   "web.auth.connections.errors.generic": {
-    "text": "Bu islemi tamamlayamadik. Lutfen tekrar deneyin.",
+    "text": "Bu işlemi tamamlayamadık. Lütfen tekrar deneyin.",
     "source_hash": "a0d4edc0"
   },
   "web.link_sso.title": {
-    "text": "Oturum acma yonteminizi baglayin",
+    "text": "Oturum açma yönteminizi bağlayın",
     "source_hash": "46339bac"
   },
   "web.link_sso.prompt": {
-    "text": "{provider} ile oturum actiniz, bu da mevcut {email} hesabiyla eslesiyor. {provider} hesabini baglamak ve devam etmek icin o hesabin parolasini girin.",
+    "text": "{provider} ile oturum açtınız, bu da mevcut {email} hesabıyla eşleşiyor. {provider} hesabını bağlamak ve devam etmek için o hesabın parolasını girin.",
     "source_hash": "59da1c08"
   },
   "web.link_sso.password_label": {
@@ -828,103 +828,103 @@
     "source_hash": "e7cf3ef4"
   },
   "web.link_sso.password_placeholder": {
-    "text": "Mevcut parolaniz",
+    "text": "Mevcut parolanız",
     "source_hash": "ad4e56da"
   },
   "web.link_sso.submit": {
-    "text": "Bagla ve devam et",
+    "text": "Bağla ve devam et",
     "source_hash": "c969b759"
   },
   "web.link_sso.cancel": {
-    "text": "Iptal",
+    "text": "İptal",
     "source_hash": "19766ed6"
   },
   "web.link_sso.unavailable_title": {
-    "text": "Bu baglama isteginin suresi doldu",
+    "text": "Bu bağlama isteğinin süresi doldu",
     "source_hash": "b53c7e55"
   },
   "web.link_sso.unavailable_message": {
-    "text": "Guvenliginiz icin, bu oturum acma yontemini baglama istegi artik gecerli degil. Mevcut parolanizla oturum acin, ardindan bu saglayiciyi Guvenlik ayarlari -> Bagli kimlikler altinda baglayin.",
+    "text": "Güvenliğiniz için, bu oturum açma yöntemini bağlama isteği artık geçerli değil. Mevcut parolanızla oturum açın, ardından bu sağlayıcıyı Güvenlik ayarları -> Bağlı kimlikler altında bağlayın.",
     "source_hash": "f7e349d1"
   },
   "web.link_sso.unavailable_action": {
-    "text": "Oturum acmaya devam et",
+    "text": "Oturum açmaya devam et",
     "source_hash": "d398cd0a"
   },
   "web.link_sso.errors.invalid_password": {
-    "text": "Bu parola bu hesapla eslesmiyor. Lutfen tekrar deneyin.",
+    "text": "Bu parola bu hesapla eşleşmiyor. Lütfen tekrar deneyin.",
     "source_hash": "3259b4f5"
   },
   "web.link_sso.errors.invalid_token": {
-    "text": "Bu baglama isteginin suresi doldu veya zaten kullanildi. Mevcut parolanizla oturum acin, ardindan bu saglayiciyi hesap ayarlarinizdan baglayin.",
+    "text": "Bu bağlama isteğinin süresi doldu veya zaten kullanıldı. Mevcut parolanızla oturum açın, ardından bu sağlayıcıyı hesap ayarlarınızdan bağlayın.",
     "source_hash": "541f9127"
   },
   "web.link_sso.errors.link_conflict": {
-    "text": "Bu oturum acma yontemini baglayamadik. Hesabiniz degismis olabilir veya bu saglayici zaten baska bir hesaba bagli. Mevcut parolanizla oturum acin, ardindan Guvenlik ayarlari -> Bagli kimlikler altinda baglantilari yonetin.",
+    "text": "Bu oturum açma yöntemini bağlayamadık. Hesabınız değişmiş olabilir veya bu sağlayıcı zaten başka bir hesaba bağlı. Mevcut parolanızla oturum açın, ardından Güvenlik ayarları -> Bağlı kimlikler altında bağlantıları yönetin.",
     "source_hash": "7b0e0d0e"
   },
   "web.link_sso.errors.link_rate_limited": {
-    "text": "Cok fazla parola denemesi. Lutfen birkac dakika bekleyin, ardindan tekrar deneyin.",
+    "text": "Çok fazla parola denemesi. Lütfen birkaç dakika bekleyin, ardından tekrar deneyin.",
     "source_hash": "a95e78cd"
   },
   "web.link_sso.errors.invalid_request": {
-    "text": "Bu baglama istegini isleyemedik. Lutfen SSO saglayicinizla tekrar oturum acin.",
+    "text": "Bu bağlama isteğini işleyemedik. Lütfen SSO sağlayıcınızla tekrar oturum açın.",
     "source_hash": "053b9fc6"
   },
   "web.link_sso.errors.generic": {
-    "text": "Hesabinizi baglayamadik. Lutfen tekrar deneyin.",
+    "text": "Hesabınızı bağlayamadık. Lütfen tekrar deneyin.",
     "source_hash": "f727c174"
   },
   "web.sso_link_confirm.title": {
-    "text": "Hesabinizi baglamayi onaylayin",
+    "text": "Hesabınızı bağlamayı onaylayın",
     "source_hash": "ad80bfe7"
   },
   "web.sso_link_confirm.prompt": {
-    "text": "{provider} ile oturum actiniz, bu da {email} hesabinizla eslesiyor. {provider} hesabini bu hesaba baglamak ve oturum acmayi tamamlamak icin onaylayin.",
+    "text": "{provider} ile oturum açtınız, bu da {email} hesabınızla eşleşiyor. {provider} hesabını bu hesaba bağlamak ve oturum açmayı tamamlamak için onaylayın.",
     "source_hash": "6ff0d6cc"
   },
   "web.sso_link_confirm.submit": {
-    "text": "Onayla ve bagla",
+    "text": "Onayla ve bağla",
     "source_hash": "5cf663e6"
   },
   "web.sso_link_confirm.cancel": {
-    "text": "Iptal",
+    "text": "İptal",
     "source_hash": "19766ed6"
   },
   "web.sso_link_confirm.unavailable_title": {
-    "text": "Bu baglama istegi tamamlanamadi",
+    "text": "Bu bağlama isteği tamamlanamadı",
     "source_hash": "47abb784"
   },
   "web.sso_link_confirm.unavailable_message": {
-    "text": "Guvenliginiz icin, oturum acma yonteminizi baglama istegi artik gecerli degil. Saglayicinizla tekrar oturum acin, size yeni bir baglanti e-postasi gonderecegiz.",
+    "text": "Güvenliğiniz için, oturum açma yönteminizi bağlama isteği artık geçerli değil. Sağlayıcınızla tekrar oturum açın, size yeni bir bağlantı e-postası göndereceğiz.",
     "source_hash": "080e6f9f"
   },
   "web.sso_link_confirm.unavailable_action": {
-    "text": "Oturum acmaya don",
+    "text": "Oturum açmaya dön",
     "source_hash": "8504054f"
   },
   "web.sso_link_confirm.errors.link_expired": {
-    "text": "Bu baglama isteginin suresi doldu veya zaten kullanildi. Saglayicinizla tekrar oturum acin, size yeni bir baglanti e-postasi gonderecegiz.",
+    "text": "Bu bağlama isteğinin süresi doldu veya zaten kullanıldı. Sağlayıcınızla tekrar oturum açın, size yeni bir bağlantı e-postası göndereceğiz.",
     "source_hash": "a50538df"
   },
   "web.sso_link_confirm.errors.link_conflict": {
-    "text": "Bu oturum acma yontemini baglayamadik. Hesabiniz degismis olabilir veya bu saglayici zaten baska bir hesaba bagli. Devam etmek icin saglayicinizla tekrar oturum acin.",
+    "text": "Bu oturum açma yöntemini bağlayamadık. Hesabınız değişmiş olabilir veya bu sağlayıcı zaten başka bir hesaba bağlı. Devam etmek için sağlayıcınızla tekrar oturum açın.",
     "source_hash": "c954854b"
   },
   "web.sso_link_confirm.errors.link_invalidated": {
-    "text": "Bu baglanti gonderildikten sonra hesap kimlik bilgileriniz degisti, bu nedenle artik gecerli degil. Saglayicinizla tekrar oturum acin, size yeni bir baglanti e-postasi gonderecegiz.",
+    "text": "Bu bağlantı gönderildikten sonra hesap kimlik bilgileriniz değişti, bu nedenle artık geçerli değil. Sağlayıcınızla tekrar oturum açın, size yeni bir bağlantı e-postası göndereceğiz.",
     "source_hash": "db88cb1d"
   },
   "web.sso_link_confirm.errors.link_error": {
-    "text": "Bizim tarafimizda bir sorun olustu ve bu baglantivi dogrulayamadik. Saglayicinizla tekrar oturum acin, size yenisini e-postalariz.",
+    "text": "Bizim tarafımızda bir sorun oluştu ve bu bağlantıyı doğrulayamadık. Sağlayıcınızla tekrar oturum açın, size yenisini e-postalarız.",
     "source_hash": "ec24e0a1"
   },
   "web.sso_link_confirm.errors.confirm_rate_limited": {
-    "text": "Cihazinizdan cok fazla deneme yapildi. Lutfen birkac dakika bekleyin, ardindan e-postadaki baglantiyi tekrar acin veya saglayicinizla yenisini almak icin oturum acin.",
+    "text": "Cihazınızdan çok fazla deneme yapıldı. Lütfen birkaç dakika bekleyin, ardından e-postadaki bağlantıyı tekrar açın veya sağlayıcınızla yenisini almak için oturum açın.",
     "source_hash": "f29af782"
   },
   "web.sso_link_confirm.errors.generic": {
-    "text": "Bu baglantiyi onaylayamadik. Lutfen saglayicinizla tekrar oturum acin.",
+    "text": "Bu bağlantıyı onaylayamadık. Lütfen sağlayıcınızla tekrar oturum açın.",
     "source_hash": "076fa25a"
   }
 }

--- a/locales/content/tr/session-auth.json
+++ b/locales/content/tr/session-auth.json
@@ -483,5 +483,41 @@
   "web.login.verified_notice": {
     "text": "E-postanız doğrulandı — artık oturum açabilirsiniz.",
     "source_hash": "c8d4b5a8"
+  },
+  "web.auth.password_setup_request.title": {
+    "text": "Parola Belirle",
+    "source_hash": "11b6978b"
+  },
+  "web.auth.password_setup_request.description": {
+    "text": "Hesabinizin henuz bir parolasi yok. Dogrudan da oturum acabilmeniz icin parola belirlemeniz icin size guvenli bir baglanti e-postasi gonderecegiz.",
+    "source_hash": "dc0b561f"
+  },
+  "web.auth.password_setup_request.button": {
+    "text": "Kurulum Baglantisi Gonder",
+    "source_hash": "22807292"
+  },
+  "web.auth.password_setup_request.emailSent": {
+    "text": "Hesabiniz icin parola belirleme baglantisi iceren bir e-posta gonderildi",
+    "source_hash": "82b686c7"
+  },
+  "web.login.errors.account_exists_link_required": {
+    "text": "Bu e-posta adresiyle bir hesap zaten mevcut ancak bu oturum acma yontemine bagli degil. Mevcut yonteminizle oturum acin, ardindan bu saglayiciyi Guvenlik ayarlari -> Bagli kimlikler altinda baglayin.",
+    "source_hash": "7fbbb7e7"
+  },
+  "web.login.errors.identity_connect_conflict": {
+    "text": "Bu kimlik baglanamadiI. Baglanti yanlis alan adinda baslatilmis olabilir veya oturumunuzun suresi dolmus olabilir. Lutfen tekrar oturum acin, ardindan hesap ayarlarinizdan baglayin.",
+    "source_hash": "4238bbf2"
+  },
+  "web.login.errors.org_join_failed": {
+    "text": "Sizi organizasyonunuza eklemeyi tamamlayamadik. Lutfen yoneticinizle iletisime gecin.",
+    "source_hash": "155e71bb"
+  },
+  "web.login.errors.link_sso_failed": {
+    "text": "Bu oturum acma yontemini baglayamadik. Mevcut parolanizla oturum acin, ardindan bu saglayiciyi Guvenlik ayarlari -> Bagli kimlikler altinda baglayin.",
+    "source_hash": "49954127"
+  },
+  "web.login.notices.link_verification_sent": {
+    "text": "Gelen kutunuzu kontrol edin - hesabinizi baglamayi onaylamak icin size bir baglanti e-postasi gonderdik. Oturum acmayi tamamlamak icin acin.",
+    "source_hash": "b251c8f3"
   }
 }

--- a/locales/content/tr/session-auth.json
+++ b/locales/content/tr/session-auth.json
@@ -489,35 +489,35 @@
     "source_hash": "11b6978b"
   },
   "web.auth.password_setup_request.description": {
-    "text": "Hesabinizin henuz bir parolasi yok. Dogrudan da oturum acabilmeniz icin parola belirlemeniz icin size guvenli bir baglanti e-postasi gonderecegiz.",
+    "text": "Hesabınızın henüz bir parolası yok. Doğrudan da oturum açabilmeniz için parola belirlemeniz için size güvenli bir bağlantı e-postası göndereceğiz.",
     "source_hash": "dc0b561f"
   },
   "web.auth.password_setup_request.button": {
-    "text": "Kurulum Baglantisi Gonder",
+    "text": "Kurulum Bağlantısı Gönder",
     "source_hash": "22807292"
   },
   "web.auth.password_setup_request.emailSent": {
-    "text": "Hesabiniz icin parola belirleme baglantisi iceren bir e-posta gonderildi",
+    "text": "Hesabınız için parola belirleme bağlantısı içeren bir e-posta gönderildi",
     "source_hash": "82b686c7"
   },
   "web.login.errors.account_exists_link_required": {
-    "text": "Bu e-posta adresiyle bir hesap zaten mevcut ancak bu oturum acma yontemine bagli degil. Mevcut yonteminizle oturum acin, ardindan bu saglayiciyi Guvenlik ayarlari -> Bagli kimlikler altinda baglayin.",
+    "text": "Bu e-posta adresiyle bir hesap zaten mevcut ancak bu oturum açma yöntemine bağlı değil. Mevcut yönteminizle oturum açın, ardından bu sağlayıcıyı Güvenlik ayarları -> Bağlı kimlikler altında bağlayın.",
     "source_hash": "7fbbb7e7"
   },
   "web.login.errors.identity_connect_conflict": {
-    "text": "Bu kimlik baglanamadiI. Baglanti yanlis alan adinda baslatilmis olabilir veya oturumunuzun suresi dolmus olabilir. Lutfen tekrar oturum acin, ardindan hesap ayarlarinizdan baglayin.",
+    "text": "Bu kimlik bağlanamadı. Bağlantı yanlış alan adında başlatılmış olabilir veya oturumunuzun süresi dolmuş olabilir. Lütfen tekrar oturum açın, ardından hesap ayarlarınızdan bağlayın.",
     "source_hash": "4238bbf2"
   },
   "web.login.errors.org_join_failed": {
-    "text": "Sizi organizasyonunuza eklemeyi tamamlayamadik. Lutfen yoneticinizle iletisime gecin.",
+    "text": "Sizi organizasyonunuza eklemeyi tamamlayamadık. Lütfen yöneticinizle iletişime geçin.",
     "source_hash": "155e71bb"
   },
   "web.login.errors.link_sso_failed": {
-    "text": "Bu oturum acma yontemini baglayamadik. Mevcut parolanizla oturum acin, ardindan bu saglayiciyi Guvenlik ayarlari -> Bagli kimlikler altinda baglayin.",
+    "text": "Bu oturum açma yöntemini bağlayamadık. Mevcut parolanızla oturum açın, ardından bu sağlayıcıyı Güvenlik ayarları -> Bağlı kimlikler altında bağlayın.",
     "source_hash": "49954127"
   },
   "web.login.notices.link_verification_sent": {
-    "text": "Gelen kutunuzu kontrol edin - hesabinizi baglamayi onaylamak icin size bir baglanti e-postasi gonderdik. Oturum acmayi tamamlamak icin acin.",
+    "text": "Gelen kutunuzu kontrol edin - hesabınızı bağlamayı onaylamak için size bir bağlantı e-postası gönderdik. Oturum açmayı tamamlamak için açın.",
     "source_hash": "b251c8f3"
   }
 }

--- a/locales/content/tr/workspace-account.json
+++ b/locales/content/tr/workspace-account.json
@@ -694,5 +694,33 @@
   "web.settings.security.sso_managed_description": {
     "text": "Hesabınız, kuruluşunuzun tek oturum açma (SSO) sağlayıcısı aracılığıyla doğrulanır. Parola, çok faktörlü kimlik doğrulama ve kurtarma kodları kimlik sağlayıcınız tarafından yönetilir.",
     "source_hash": "cd0cf39f"
+  },
+  "web.settings.api.api_username": {
+    "text": "API Kullanici Adi",
+    "source_hash": "0b3e483e"
+  },
+  "web.settings.api.api_username_description": {
+    "text": "HTTP Temel kimlik dogrulamasi icin kullanici adiniz",
+    "source_hash": "f3e65de3"
+  },
+  "web.settings.api.basic_auth_hint": {
+    "text": "HTTP Temel kimlik dogrulamasi icin, kullanici adi olarak hesap e-postanizi veya bu kimliği, parola olarak API anahtarinizi kullanin.",
+    "source_hash": "cfa3806d"
+  },
+  "web.settings.security.set": {
+    "text": "Ayarlandi",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.settings.security.not_set": {
+    "text": "Ayarlanmadi",
+    "source_hash": "4895f731"
+  },
+  "web.settings.security.set_password_title": {
+    "text": "Parola belirle",
+    "source_hash": "4e411687"
+  },
+  "web.settings.security.set_password_description": {
+    "text": "Kimlik saglayiciniz olmadan da oturum acabilmeniz icin hesabiniza bir parola ekleyin",
+    "source_hash": "a6970402"
   }
 }

--- a/locales/content/tr/workspace-account.json
+++ b/locales/content/tr/workspace-account.json
@@ -696,23 +696,23 @@
     "source_hash": "cd0cf39f"
   },
   "web.settings.api.api_username": {
-    "text": "API Kullanici Adi",
+    "text": "API Kullanıcı Adı",
     "source_hash": "0b3e483e"
   },
   "web.settings.api.api_username_description": {
-    "text": "HTTP Temel kimlik dogrulamasi icin kullanici adiniz",
+    "text": "HTTP Temel kimlik doğrulaması için kullanıcı adınız",
     "source_hash": "f3e65de3"
   },
   "web.settings.api.basic_auth_hint": {
-    "text": "HTTP Temel kimlik dogrulamasi icin, kullanici adi olarak hesap e-postanizi veya bu kimliği, parola olarak API anahtarinizi kullanin.",
+    "text": "HTTP Temel kimlik doğrulaması için, kullanıcı adı olarak hesap e-postanızı veya bu kimliği, parola olarak API anahtarınızı kullanın.",
     "source_hash": "cfa3806d"
   },
   "web.settings.security.set": {
-    "text": "Ayarlandi",
+    "text": "Ayarlandı",
     "source_hash": "b6f6f3ad"
   },
   "web.settings.security.not_set": {
-    "text": "Ayarlanmadi",
+    "text": "Ayarlanmadı",
     "source_hash": "4895f731"
   },
   "web.settings.security.set_password_title": {
@@ -720,7 +720,7 @@
     "source_hash": "4e411687"
   },
   "web.settings.security.set_password_description": {
-    "text": "Kimlik saglayiciniz olmadan da oturum acabilmeniz icin hesabiniza bir parola ekleyin",
+    "text": "Kimlik sağlayıcınız olmadan da oturum açabilmeniz için hesabınıza bir parola ekleyin",
     "source_hash": "a6970402"
   }
 }

--- a/locales/content/tr/workspace-billing.json
+++ b/locales/content/tr/workspace-billing.json
@@ -1046,19 +1046,19 @@
     "source_hash": "2dc7478f"
   },
   "web.billing.currency_migration.refund_failed_warning": {
-    "text": "Onceki planiniz iptal edildi, ancak kullanilmayan sureniniz icin otomatik olarak iade isleyemedik. Iadenizi almak icin lutfen destekle iletisime gecin. Yeni planinizi etkinlestirmek icin hala odemeyi tamamlamaniz gerekiyor.",
+    "text": "Önceki planınız iptal edildi, ancak kullanılmayan süreniz için otomatik olarak iade işleyemedik. İadenizi almak için lütfen destekle iletişime geçin. Yeni planınızı etkinleştirmek için hâlâ ödemeyi tamamlamanız gerekiyor.",
     "source_hash": "a390c498"
   },
   "web.billing.currency_migration.refund_failed_continue": {
-    "text": "Odemeye Devam Et",
+    "text": "Ödemeye Devam Et",
     "source_hash": "eccdb8aa"
   },
   "web.billing.plans.per_year": {
-    "text": "/yil",
+    "text": "/yıl",
     "source_hash": "a2d5f1bc"
   },
   "web.billing.plans.billing_interval": {
-    "text": "Faturalandirma araligi",
+    "text": "Faturalandırma aralığı",
     "source_hash": "3ce28209"
   }
 }

--- a/locales/content/tr/workspace-billing.json
+++ b/locales/content/tr/workspace-billing.json
@@ -1044,5 +1044,21 @@
   "web.billing.plans.reactivate": {
     "text": "Yeniden etkinleştir",
     "source_hash": "2dc7478f"
+  },
+  "web.billing.currency_migration.refund_failed_warning": {
+    "text": "Onceki planiniz iptal edildi, ancak kullanilmayan sureniniz icin otomatik olarak iade isleyemedik. Iadenizi almak icin lutfen destekle iletisime gecin. Yeni planinizi etkinlestirmek icin hala odemeyi tamamlamaniz gerekiyor.",
+    "source_hash": "a390c498"
+  },
+  "web.billing.currency_migration.refund_failed_continue": {
+    "text": "Odemeye Devam Et",
+    "source_hash": "eccdb8aa"
+  },
+  "web.billing.plans.per_year": {
+    "text": "/yil",
+    "source_hash": "a2d5f1bc"
+  },
+  "web.billing.plans.billing_interval": {
+    "text": "Faturalandirma araligi",
+    "source_hash": "3ce28209"
   }
 }

--- a/locales/content/tr/workspace-branding.json
+++ b/locales/content/tr/workspace-branding.json
@@ -56,11 +56,11 @@
     "source_hash": "e36598ef"
   },
   "web.branding.example_pre_reveal_instructions": {
-    "text": "orn. QR kodunu taramak icin telefonunuzu kullanin",
+    "text": "örn. QR kodunu taramak için telefonunuzu kullanın",
     "source_hash": "9cf0caf8"
   },
   "web.branding.example_post_reveal_instructions": {
-    "text": "orn. Sorulariniz icin onboarding{'@'}example.com adresine ulassin",
+    "text": "örn. Sorularınız için onboarding{'@'}example.com adresine ulaşın",
     "source_hash": "71749811"
   },
   "web.branding.these_instructions_will_be_shown_to_recipients_before": {
@@ -320,7 +320,7 @@
     "source_hash": "bc79cdff"
   },
   "web.branding.paths_carryover_hint": {
-    "text": "Bu canli bir onizleme - Guncelle'ye tiklayana kadar degisiklikleriniz ziyaretcilere gorunmez.",
+    "text": "Bu canlı bir önizleme - Güncelle'ye tıklayana kadar değişiklikleriniz ziyaretçilere görünmez.",
     "source_hash": "9a34df71"
   },
   "web.branding.coming_soon_match_blurb": {
@@ -412,47 +412,47 @@
     "source_hash": "42955289"
   },
   "web.branding.refresh_favicon": {
-    "text": "Favicon'u alan adindan yenile",
+    "text": "Favicon'u alan adından yenile",
     "source_hash": "7cc3d5dc"
   },
   "web.branding.refresh_favicon_hint": {
-    "text": "Favicon'u alan adinizdan tekrar cek. Yeni simge kisa surede gorunur.",
+    "text": "Favicon'u alan adınızdan tekrar çek. Yeni simge kısa sürede görünür.",
     "source_hash": "ee007e44"
   },
   "web.branding.refresh_favicon_queued": {
-    "text": "Favicon yenileniyor - yeni simge kisa surede gorunecek.",
+    "text": "Favicon yenileniyor - yeni simge kısa sürede görünecek.",
     "source_hash": "6bf38e6e"
   },
   "web.branding.refresh_favicon_user_upload_hint": {
-    "text": "Ozel bir favicon yuklediniz, bu nedenle cekilmis simge onu degistirmeyecek.",
+    "text": "Özel bir favicon yüklediniz, bu nedenle çekilmiş simge onu değiştirmeyecek.",
     "source_hash": "c22e1ed6"
   },
   "web.branding.upload_favicon": {
-    "text": "Favicon yukle",
+    "text": "Favicon yükle",
     "source_hash": "ceda39cb"
   },
   "web.branding.replace_favicon": {
-    "text": "Degistir",
+    "text": "Değiştir",
     "source_hash": "95e15439"
   },
   "web.branding.remove_favicon": {
-    "text": "Favicon'u kaldir",
+    "text": "Favicon'u kaldır",
     "source_hash": "03693698"
   },
   "web.branding.favicon_field_hint": {
-    "text": "ICO, PNG veya SVG. Yukleme, cekilmis simgenin yerini alir.",
+    "text": "ICO, PNG veya SVG. Yükleme, çekilmiş simgenin yerini alır.",
     "source_hash": "dfa0bfcb"
   },
   "web.branding.favicon_preview_alt": {
-    "text": "Alan adi favicon'u",
+    "text": "Alan adı favicon'u",
     "source_hash": "db7dca40"
   },
   "web.branding.favicon_modal_title": {
-    "text": "Alan adi favicon'u",
+    "text": "Alan adı favicon'u",
     "source_hash": "db7dca40"
   },
   "web.branding.favicon_modal_hint": {
-    "text": "ICO, PNG veya SVG. En fazla 256KB. Otomatik cekilmis simgenin yerini alir.",
+    "text": "ICO, PNG veya SVG. En fazla 256KB. Otomatik çekilmiş simgenin yerini alır.",
     "source_hash": "c9eafc83"
   },
   "web.branding.favicon_modal_save": {

--- a/locales/content/tr/workspace-branding.json
+++ b/locales/content/tr/workspace-branding.json
@@ -56,12 +56,12 @@
     "source_hash": "e36598ef"
   },
   "web.branding.example_pre_reveal_instructions": {
-    "text": "QR kodu taramak için telefonunuzu kullanın",
-    "source_hash": "99ecf59f"
+    "text": "orn. QR kodunu taramak icin telefonunuzu kullanin",
+    "source_hash": "9cf0caf8"
   },
   "web.branding.example_post_reveal_instructions": {
-    "text": "Sorularınız için destek{'@'}ornek.com ile iletişime geçin",
-    "source_hash": "bee120a7"
+    "text": "orn. Sorulariniz icin onboarding{'@'}example.com adresine ulassin",
+    "source_hash": "71749811"
   },
   "web.branding.these_instructions_will_be_shown_to_recipients_before": {
     "text": "Bu talimatlar, alıcılara mesaj içeriğini açmadan önce gösterilecektir",
@@ -320,8 +320,8 @@
     "source_hash": "bc79cdff"
   },
   "web.branding.paths_carryover_hint": {
-    "text": "Bu, canlı bir önizlemedir — değişiklikleriniz siz kaydedene kadar ziyaretçilere görünmez.",
-    "source_hash": "cb4b82de"
+    "text": "Bu canli bir onizleme - Guncelle'ye tiklayana kadar degisiklikleriniz ziyaretcilere gorunmez.",
+    "source_hash": "9a34df71"
   },
   "web.branding.coming_soon_match_blurb": {
     "text": "Bize web sitenizi gösterin, renklerini ve yazı tiplerini okuyalım, ardından tek tıkla aradaki farkı kapatalım.",
@@ -406,5 +406,57 @@
   "web.branding.delivery_after_reveal": {
     "text": "Açığa çıkardıktan sonra",
     "source_hash": "d5bfe7fd"
+  },
+  "web.branding.favicon": {
+    "text": "Favicon",
+    "source_hash": "42955289"
+  },
+  "web.branding.refresh_favicon": {
+    "text": "Favicon'u alan adindan yenile",
+    "source_hash": "7cc3d5dc"
+  },
+  "web.branding.refresh_favicon_hint": {
+    "text": "Favicon'u alan adinizdan tekrar cek. Yeni simge kisa surede gorunur.",
+    "source_hash": "ee007e44"
+  },
+  "web.branding.refresh_favicon_queued": {
+    "text": "Favicon yenileniyor - yeni simge kisa surede gorunecek.",
+    "source_hash": "6bf38e6e"
+  },
+  "web.branding.refresh_favicon_user_upload_hint": {
+    "text": "Ozel bir favicon yuklediniz, bu nedenle cekilmis simge onu degistirmeyecek.",
+    "source_hash": "c22e1ed6"
+  },
+  "web.branding.upload_favicon": {
+    "text": "Favicon yukle",
+    "source_hash": "ceda39cb"
+  },
+  "web.branding.replace_favicon": {
+    "text": "Degistir",
+    "source_hash": "95e15439"
+  },
+  "web.branding.remove_favicon": {
+    "text": "Favicon'u kaldir",
+    "source_hash": "03693698"
+  },
+  "web.branding.favicon_field_hint": {
+    "text": "ICO, PNG veya SVG. Yukleme, cekilmis simgenin yerini alir.",
+    "source_hash": "dfa0bfcb"
+  },
+  "web.branding.favicon_preview_alt": {
+    "text": "Alan adi favicon'u",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_title": {
+    "text": "Alan adi favicon'u",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_hint": {
+    "text": "ICO, PNG veya SVG. En fazla 256KB. Otomatik cekilmis simgenin yerini alir.",
+    "source_hash": "c9eafc83"
+  },
+  "web.branding.favicon_modal_save": {
+    "text": "Favicon'u kaydet",
+    "source_hash": "c8a1566c"
   }
 }

--- a/locales/content/tr/workspace-organizations.json
+++ b/locales/content/tr/workspace-organizations.json
@@ -1036,11 +1036,11 @@
     "source_hash": "c63c14cf"
   },
   "web.organizations.organization_id": {
-    "text": "Organizasyon Kimligi",
+    "text": "Organizasyon Kimliği",
     "source_hash": "1f466322"
   },
   "web.organizations.organization_id_hint": {
-    "text": "Destekle iletisime gecerken veya API isteklerini bu organizasyona yoneltirken bu kimligi kullanin. Oturum acma kimlik bilgisi degildir.",
+    "text": "Destekle iletişime geçerken veya API isteklerini bu organizasyona yöneltirken bu kimliği kullanın. Oturum açma kimlik bilgisi değildir.",
     "source_hash": "29549b3a"
   },
   "web.organizations.audit.title": {
@@ -1048,7 +1048,7 @@
     "source_hash": "6d6d41f3"
   },
   "web.organizations.audit.description": {
-    "text": "Bu organizasyon icin kaydedilen gizli mesaj olusturma ve erisim olaylarinin denetim izi.",
+    "text": "Bu organizasyon için kaydedilen gizli mesaj oluşturma ve erişim olaylarının denetim izi.",
     "source_hash": "553c564b"
   },
   "web.organizations.audit.country_unknown": {
@@ -1056,27 +1056,27 @@
     "source_hash": "b764cdc0"
   },
   "web.organizations.audit.empty_title": {
-    "text": "Henuz aktivite yok",
+    "text": "Henüz aktivite yok",
     "source_hash": "0a12b92c"
   },
   "web.organizations.audit.empty_description": {
-    "text": "Ekibiniz gizli mesajlari paylastikca gizli mesaj olusturma ve erisim olaylari burada gorunecek.",
+    "text": "Ekibiniz gizli mesajları paylaştıkça gizli mesaj oluşturma ve erişim olayları burada görünecek.",
     "source_hash": "62fb14c2"
   },
   "web.organizations.audit.capped_notice": {
-    "text": "Yalnizca en yeni {max} olay saklanir; eski aktivite kirpilmistir.",
+    "text": "Yalnızca en yeni {max} olay saklanır; eski aktivite kırpılmıştır.",
     "source_hash": "da7901e2"
   },
   "web.organizations.audit.collection_paused_notice": {
-    "text": "Olay toplama duraklatildi; yeni gizli mesaj aktivitesi kaydedilmiyor.",
+    "text": "Olay toplama duraklatıldı; yeni gizli mesaj aktivitesi kaydedilmiyor.",
     "source_hash": "cb09d147"
   },
   "web.organizations.audit.load_error": {
-    "text": "Gizli mesaj aktivitesi yuklenemedi.",
+    "text": "Gizli mesaj aktivitesi yüklenemedi.",
     "source_hash": "52fde814"
   },
   "web.organizations.audit.contract_mismatch": {
-    "text": "Sunucu tarafindan dondurrulen aktivite verileri okunamadi. Iz bos degil - sadece su anda goruntulenemiyor.",
+    "text": "Sunucu tarafından döndürülen aktivite verileri okunamadı. İz boş değil - sadece şu anda görüntülenemiyor.",
     "source_hash": "db0d007a"
   },
   "web.organizations.audit.retry": {
@@ -1084,23 +1084,23 @@
     "source_hash": "d8b8392e"
   },
   "web.organizations.audit.showing_range": {
-    "text": "{total} icerisinden {from}-{to} gosteriliyor",
+    "text": "{total} içerisinden {from}-{to} gösteriliyor",
     "source_hash": "c329279d"
   },
   "web.organizations.audit.upgrade_prompt": {
-    "text": "Gizli mesaj aktivitesi, denetim gunlukleri iceren bir plan gerektirir. Bu organizasyonda gizli mesajlari kimin olusturup goruntuledigini ve ifsa ettigini gormek icin yuksseltin.",
+    "text": "Gizli mesaj aktivitesi, denetim günlükleri içeren bir plan gerektirir. Bu organizasyonda gizli mesajları kimin oluşturup görüntülediğini ve ifşa ettiğini görmek için yükseltin.",
     "source_hash": "453649ce"
   },
   "web.organizations.audit.role_required": {
-    "text": "Gizli mesaj aktivitesi organizasyon sahipleri ve yoneticilerine aciktir.",
+    "text": "Gizli mesaj aktivitesi organizasyon sahipleri ve yöneticilerine açıktır.",
     "source_hash": "e066ec63"
   },
   "web.organizations.audit.actors.creator": {
-    "text": "Olusturan",
+    "text": "Oluşturan",
     "source_hash": "88447b83"
   },
   "web.organizations.audit.actors.authenticated_other": {
-    "text": "Baska bir oturum acmis kullanici",
+    "text": "Başka bir oturum açmış kullanıcı",
     "source_hash": "ee45aa5a"
   },
   "web.organizations.audit.actors.anonymous": {
@@ -1124,11 +1124,11 @@
     "source_hash": "7e32a729"
   },
   "web.organizations.audit.columns.actor": {
-    "text": "Aktor",
+    "text": "Aktör",
     "source_hash": "449995c4"
   },
   "web.organizations.audit.columns.country": {
-    "text": "Ulke",
+    "text": "Ülke",
     "source_hash": "701d021d"
   },
   "web.organizations.audit.columns.when": {
@@ -1136,47 +1136,47 @@
     "source_hash": "cf9c7aa2"
   },
   "web.organizations.audit.kinds.created": {
-    "text": "Gizli mesaj olusturuldu",
+    "text": "Gizli mesaj oluşturuldu",
     "source_hash": "e4a1e1fd"
   },
   "web.organizations.audit.kinds.status_get": {
-    "text": "Baglanti durumu kontrol edildi",
+    "text": "Bağlantı durumu kontrol edildi",
     "source_hash": "0753f60e"
   },
   "web.organizations.audit.kinds.secret_get": {
-    "text": "Gizli mesaj baglantisi acildi",
+    "text": "Gizli mesaj bağlantısı açıldı",
     "source_hash": "e271e060"
   },
   "web.organizations.audit.kinds.previewed": {
-    "text": "Olusturan tarafindan onizlendi",
+    "text": "Oluşturan tarafından önizlendi",
     "source_hash": "639fc1e2"
   },
   "web.organizations.audit.kinds.creator_status_get": {
-    "text": "Olusturan tarafindan durum kontrol edildi",
+    "text": "Oluşturan tarafından durum kontrol edildi",
     "source_hash": "7e4b5de5"
   },
   "web.organizations.audit.kinds.receipt_viewed": {
-    "text": "Makbuz goruntulendi",
+    "text": "Makbuz görüntülendi",
     "source_hash": "a417ead4"
   },
   "web.organizations.audit.kinds.revealed": {
-    "text": "Gizli mesaj ifsa edildi",
+    "text": "Gizli mesaj ifşa edildi",
     "source_hash": "aff2c84d"
   },
   "web.organizations.audit.kinds.burned": {
-    "text": "Gizli mesaj yakildi",
+    "text": "Gizli mesaj yakıldı",
     "source_hash": "5ac68dc6"
   },
   "web.organizations.audit.kinds.expired": {
-    "text": "Gizli mesajin suresi doldu",
+    "text": "Gizli mesajın süresi doldu",
     "source_hash": "c127dab6"
   },
   "web.organizations.audit.kinds.orphaned": {
-    "text": "Gizli mesaj yetim kaldi",
+    "text": "Gizli mesaj yetim kaldı",
     "source_hash": "23fe1a47"
   },
   "web.organizations.audit.kinds.reveal_failed_undecryptable": {
-    "text": "Ifsa basarisiz (sifre cozulemedi)",
+    "text": "İfşa başarısız (şifre çözülemedi)",
     "source_hash": "d5616abf"
   },
   "web.organizations.tabs.activity": {

--- a/locales/content/tr/workspace-organizations.json
+++ b/locales/content/tr/workspace-organizations.json
@@ -1034,5 +1034,153 @@
   "web.organizations.create_workspace": {
     "text": "Çalışma Alanı Oluştur",
     "source_hash": "c63c14cf"
+  },
+  "web.organizations.organization_id": {
+    "text": "Organizasyon Kimligi",
+    "source_hash": "1f466322"
+  },
+  "web.organizations.organization_id_hint": {
+    "text": "Destekle iletisime gecerken veya API isteklerini bu organizasyona yoneltirken bu kimligi kullanin. Oturum acma kimlik bilgisi degildir.",
+    "source_hash": "29549b3a"
+  },
+  "web.organizations.audit.title": {
+    "text": "Gizli Mesaj Aktivitesi",
+    "source_hash": "6d6d41f3"
+  },
+  "web.organizations.audit.description": {
+    "text": "Bu organizasyon icin kaydedilen gizli mesaj olusturma ve erisim olaylarinin denetim izi.",
+    "source_hash": "553c564b"
+  },
+  "web.organizations.audit.country_unknown": {
+    "text": "Bilinmiyor",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.empty_title": {
+    "text": "Henuz aktivite yok",
+    "source_hash": "0a12b92c"
+  },
+  "web.organizations.audit.empty_description": {
+    "text": "Ekibiniz gizli mesajlari paylastikca gizli mesaj olusturma ve erisim olaylari burada gorunecek.",
+    "source_hash": "62fb14c2"
+  },
+  "web.organizations.audit.capped_notice": {
+    "text": "Yalnizca en yeni {max} olay saklanir; eski aktivite kirpilmistir.",
+    "source_hash": "da7901e2"
+  },
+  "web.organizations.audit.collection_paused_notice": {
+    "text": "Olay toplama duraklatildi; yeni gizli mesaj aktivitesi kaydedilmiyor.",
+    "source_hash": "cb09d147"
+  },
+  "web.organizations.audit.load_error": {
+    "text": "Gizli mesaj aktivitesi yuklenemedi.",
+    "source_hash": "52fde814"
+  },
+  "web.organizations.audit.contract_mismatch": {
+    "text": "Sunucu tarafindan dondurrulen aktivite verileri okunamadi. Iz bos degil - sadece su anda goruntulenemiyor.",
+    "source_hash": "db0d007a"
+  },
+  "web.organizations.audit.retry": {
+    "text": "Tekrar dene",
+    "source_hash": "d8b8392e"
+  },
+  "web.organizations.audit.showing_range": {
+    "text": "{total} icerisinden {from}-{to} gosteriliyor",
+    "source_hash": "c329279d"
+  },
+  "web.organizations.audit.upgrade_prompt": {
+    "text": "Gizli mesaj aktivitesi, denetim gunlukleri iceren bir plan gerektirir. Bu organizasyonda gizli mesajlari kimin olusturup goruntuledigini ve ifsa ettigini gormek icin yuksseltin.",
+    "source_hash": "453649ce"
+  },
+  "web.organizations.audit.role_required": {
+    "text": "Gizli mesaj aktivitesi organizasyon sahipleri ve yoneticilerine aciktir.",
+    "source_hash": "e066ec63"
+  },
+  "web.organizations.audit.actors.creator": {
+    "text": "Olusturan",
+    "source_hash": "88447b83"
+  },
+  "web.organizations.audit.actors.authenticated_other": {
+    "text": "Baska bir oturum acmis kullanici",
+    "source_hash": "ee45aa5a"
+  },
+  "web.organizations.audit.actors.anonymous": {
+    "text": "Anonim",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.organizations.audit.actors.system": {
+    "text": "Sistem",
+    "source_hash": "6725e7bb"
+  },
+  "web.organizations.audit.actors.unknown": {
+    "text": "Bilinmiyor",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.columns.event": {
+    "text": "Olay",
+    "source_hash": "4e1f49a9"
+  },
+  "web.organizations.audit.columns.secret": {
+    "text": "Gizli Mesaj",
+    "source_hash": "7e32a729"
+  },
+  "web.organizations.audit.columns.actor": {
+    "text": "Aktor",
+    "source_hash": "449995c4"
+  },
+  "web.organizations.audit.columns.country": {
+    "text": "Ulke",
+    "source_hash": "701d021d"
+  },
+  "web.organizations.audit.columns.when": {
+    "text": "Zaman",
+    "source_hash": "cf9c7aa2"
+  },
+  "web.organizations.audit.kinds.created": {
+    "text": "Gizli mesaj olusturuldu",
+    "source_hash": "e4a1e1fd"
+  },
+  "web.organizations.audit.kinds.status_get": {
+    "text": "Baglanti durumu kontrol edildi",
+    "source_hash": "0753f60e"
+  },
+  "web.organizations.audit.kinds.secret_get": {
+    "text": "Gizli mesaj baglantisi acildi",
+    "source_hash": "e271e060"
+  },
+  "web.organizations.audit.kinds.previewed": {
+    "text": "Olusturan tarafindan onizlendi",
+    "source_hash": "639fc1e2"
+  },
+  "web.organizations.audit.kinds.creator_status_get": {
+    "text": "Olusturan tarafindan durum kontrol edildi",
+    "source_hash": "7e4b5de5"
+  },
+  "web.organizations.audit.kinds.receipt_viewed": {
+    "text": "Makbuz goruntulendi",
+    "source_hash": "a417ead4"
+  },
+  "web.organizations.audit.kinds.revealed": {
+    "text": "Gizli mesaj ifsa edildi",
+    "source_hash": "aff2c84d"
+  },
+  "web.organizations.audit.kinds.burned": {
+    "text": "Gizli mesaj yakildi",
+    "source_hash": "5ac68dc6"
+  },
+  "web.organizations.audit.kinds.expired": {
+    "text": "Gizli mesajin suresi doldu",
+    "source_hash": "c127dab6"
+  },
+  "web.organizations.audit.kinds.orphaned": {
+    "text": "Gizli mesaj yetim kaldi",
+    "source_hash": "23fe1a47"
+  },
+  "web.organizations.audit.kinds.reveal_failed_undecryptable": {
+    "text": "Ifsa basarisiz (sifre cozulemedi)",
+    "source_hash": "d5616abf"
+  },
+  "web.organizations.tabs.activity": {
+    "text": "Aktivite",
+    "source_hash": "38da1505"
   }
 }


### PR DESCRIPTION
## `tr` translation update

Automated export of completed **tr** translations from the translation task DB.
Scope: `locales/content/tr/` only — 16 file(s), +2020/-20.

⚠️ `i18n validate variables` reports **3** variable mismatch(es) for `tr` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ❌ Blockers — Turkish diacritics dropped in ~half the new strings

**Summary:** Placeholder/variable preservation is clean everywhere a `text` value actually exists. The real problem is a PR-wide split: roughly half the newly added translations render Turkish with diacritics stripped to ASCII (ı/İ, ş, ğ, ç, ö, ü), while the other half in the same diff uses correct Turkish orthography — reads like two different translation passes, one degraded.

**Critical (must fix):**
- ASCII-only Turkish (missing ı/İ, ş, ğ, ç, ö, ü) throughout: `admin-organizations.json` (`addMember.*`, `entitlements.*`), `admin-secrets.json` (every changed/new key — e.g. "Gizli Mesaj Makbuzlari" should be "Makbuzları"), `admin-system.json` (`brand.*`), `email.json` (`sso_link_verification.*`), `session-auth.json` (`password_setup_request.*`, `login.errors.*`, `login.notices.*`), `session-auth-extended.json` (`connections.*`, `link_sso.*`, `sso_link_confirm.*`), `workspace-account.json` (new keys), `workspace-billing.json` (new keys), `workspace-branding.json` (`favicon.*` plus 2 edited keys), `workspace-organizations.json` (`organization_id*`, `audit.*`).
- Contrast: `admin-audit.json`, `admin-billing.json`, `admin-colonel.json`, `admin-customers.json`, `admin-domains.json` in this same diff use fully correct diacritics (e.g. "Aktör", "Ödeme bağlantısı", "İletişimle aynı") — confirms the other half is a regression, not a locale-wide style choice.

**Warnings:**
- `web.branding.example_post_reveal_instructions`: "ulassin" is not a valid Turkish word (likely meant "ulaşın") — possible MT artifact worth a human pass.
- The 3 variable-validator hits all target the English-only `context` metadata field (translator notes), not `text`; every tr entry in this diff omits `context` by design like its untouched siblings — likely a validator false-positive, but worth confirming the checker is meant to skip `context`.

**Notes:**
- None beyond above.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
