### PR TITLE
i18n: update vi translations

### DIFF
--- a/locales/content/vi/00-common.json
+++ b/locales/content/vi/00-common.json
@@ -1539,5 +1539,9 @@
   "web.TITLES.domain_dns": {
     "text": "Thiết lập DNS",
     "source_hash": "6c63df31"
+  },
+  "web.TITLES.connected_identities": {
+    "text": "Danh tính đã kết nối",
+    "source_hash": "e132c4d9"
   }
 }

--- a/locales/content/vi/admin-audit.json
+++ b/locales/content/vi/admin-audit.json
@@ -98,5 +98,41 @@
   "web.admin.audit.result.failure": {
     "text": "Thất bại",
     "source_hash": "7031edbc"
+  },
+  "web.admin.audit.categories.secret": {
+    "text": "Bí mật",
+    "source_hash": "d8707d41"
+  },
+  "web.admin.audit.categories.membership": {
+    "text": "Thành viên",
+    "source_hash": "b50f1a42"
+  },
+  "web.admin.audit.categories.entitlement_preview": {
+    "text": "Xem trước quyền",
+    "source_hash": "255c5797"
+  },
+  "web.admin.audit.categories.colonel": {
+    "text": "Đăng nhập Colonel",
+    "source_hash": "01eeeb38"
+  },
+  "web.admin.audit.filters.actorLabel": {
+    "text": "Người thực hiện",
+    "source_hash": "449995c4"
+  },
+  "web.admin.audit.filters.searchButton": {
+    "text": "Tìm kiếm",
+    "source_hash": "49c266ba"
+  },
+  "web.admin.audit.filters.searchHint": {
+    "text": "Nhập tên người thực hiện, sau đó nhấn Enter hoặc chọn Tìm kiếm để chạy. Danh sách không cập nhật khi bạn đang nhập.",
+    "source_hash": "45eceb12"
+  },
+  "web.admin.audit.filters.pendingSearch": {
+    "text": "Chưa tìm kiếm — nhấn Enter hoặc chọn Tìm kiếm để áp dụng người thực hiện này.",
+    "source_hash": "f76095c2"
+  },
+  "web.admin.audit.list.contractError": {
+    "text": "Máy chủ đã phản hồi, nhưng dữ liệu kiểm tra không khớp với định dạng mong đợi. Không thể hiển thị sự kiện nào — đây là lỗi báo cáo, không phải nhật ký trống.",
+    "source_hash": "7f48137e"
   }
 }

--- a/locales/content/vi/admin-billing.json
+++ b/locales/content/vi/admin-billing.json
@@ -122,5 +122,85 @@
   "web.admin.billing.status.changed": {
     "text": "Đã thay đổi",
     "source_hash": "2a6141e4"
+  },
+  "web.admin.billing.diff.backToCatalog": {
+    "text": "Quay lại danh mục thanh toán",
+    "source_hash": "8532b373"
+  },
+  "web.admin.billing.diff.driftedFields": {
+    "text": "Các trường khác nhau:",
+    "source_hash": "9890c95b"
+  },
+  "web.admin.billing.diff.notFound": {
+    "text": "Gói không có trong danh mục",
+    "source_hash": "0253898b"
+  },
+  "web.admin.billing.diff.notFoundDescription": {
+    "text": "Không tìm thấy gói nào với id {planid} trong danh mục đã cấu hình hoặc bộ nhớ đệm đồng bộ Stripe trực tiếp.",
+    "source_hash": "2e69551c"
+  },
+  "web.admin.billing.stripeOrgs.title": {
+    "text": "Khách hàng Stripe",
+    "source_hash": "0463ae27"
+  },
+  "web.admin.billing.stripeOrgs.description": {
+    "text": "Các tổ chức được liên kết với hồ sơ khách hàng Stripe.",
+    "source_hash": "2ab09aec"
+  },
+  "web.admin.billing.stripeOrgs.searchPlaceholder": {
+    "text": "Tìm kiếm theo ID khách hàng Stripe",
+    "source_hash": "d5acf08f"
+  },
+  "web.admin.billing.stripeOrgs.empty": {
+    "text": "Không có tổ chức nào có ID khách hàng Stripe.",
+    "source_hash": "2e373537"
+  },
+  "web.admin.billing.stripeOrgs.emptySearch": {
+    "text": "Không có ID khách hàng Stripe nào khớp với tìm kiếm đó.",
+    "source_hash": "75011174"
+  },
+  "web.admin.billing.stripeOrgs.loadError": {
+    "text": "Không thể tải danh sách khách hàng Stripe.",
+    "source_hash": "15e2d9a7"
+  },
+  "web.admin.billing.stripeOrgs.unavailable": {
+    "text": "Danh sách khách hàng Stripe chưa có sẵn trên máy chủ này.",
+    "source_hash": "aab6451a"
+  },
+  "web.admin.billing.stripeOrgs.none": {
+    "text": "Không có",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.billing.stripeOrgs.capped": {
+    "text": "Quét chỉ mục đã đạt giới hạn, vì vậy tổng số là giới hạn dưới — thu hẹp tìm kiếm để xem phần còn lại.",
+    "source_hash": "20bcaa38"
+  },
+  "web.admin.billing.stripeOrgs.stale": {
+    "text": "{count} mục chỉ mục trên trang này trỏ đến một tổ chức không còn tải được và đã bị bỏ qua.",
+    "source_hash": "51980f83"
+  },
+  "web.admin.billing.stripeOrgs.copyStripeId": {
+    "text": "Sao chép ID khách hàng Stripe",
+    "source_hash": "a77d18b1"
+  },
+  "web.admin.billing.stripeOrgs.columns.organization": {
+    "text": "Tổ chức",
+    "source_hash": "d764d425"
+  },
+  "web.admin.billing.stripeOrgs.columns.owner": {
+    "text": "Chủ sở hữu",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.billing.stripeOrgs.columns.plan": {
+    "text": "Gói",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.billing.stripeOrgs.columns.subscription": {
+    "text": "Đăng ký",
+    "source_hash": "4999c6c6"
+  },
+  "web.admin.billing.stripeOrgs.columns.stripeCustomer": {
+    "text": "ID khách hàng Stripe",
+    "source_hash": "7e1d8bbb"
   }
 }

--- a/locales/content/vi/admin-colonel.json
+++ b/locales/content/vi/admin-colonel.json
@@ -838,5 +838,37 @@
   "web.colonel.nav.groups.communications": {
     "text": "Liên lạc",
     "source_hash": "919a9253"
+  },
+  "web.colonel.organizations.sameAsContact": {
+    "text": "Giống như liên hệ",
+    "source_hash": "ed18ff43"
+  },
+  "web.colonel.organizations.refresh": {
+    "text": "Làm mới",
+    "source_hash": "0e916101"
+  },
+  "web.colonel.organizations.updatedAgo": {
+    "text": "Cập nhật {ago}",
+    "source_hash": "cda30b9c"
+  },
+  "web.colonel.organizations.columns.name": {
+    "text": "Tên",
+    "source_hash": "dcd1d522"
+  },
+  "web.colonel.organizations.columns.contactEmail": {
+    "text": "Email liên hệ",
+    "source_hash": "6d7fce11"
+  },
+  "web.colonel.organizations.columns.billingEmail": {
+    "text": "Email thanh toán",
+    "source_hash": "8805b928"
+  },
+  "web.colonel.organizations.columns.planSubscription": {
+    "text": "Gói và đăng ký",
+    "source_hash": "b396caac"
+  },
+  "web.colonel.organizations.filters.searchPlaceholder": {
+    "text": "Tìm kiếm theo ID, tên hoặc email",
+    "source_hash": "6fe16473"
   }
 }

--- a/locales/content/vi/admin-customers.json
+++ b/locales/content/vi/admin-customers.json
@@ -4,8 +4,8 @@
     "source_hash": "aabe76f1"
   },
   "web.admin.customers.description": {
-    "text": "Tìm khách hàng và giải quyết vấn đề hỗ trợ mà không cần SSH.",
-    "source_hash": "c8487e68"
+    "text": "Tìm khách hàng và giải quyết các vấn đề hỗ trợ.",
+    "source_hash": "00961ea3"
   },
   "web.admin.customers.actions.plan.label": {
     "text": "Gói",
@@ -482,5 +482,213 @@
   "web.admin.customers.suspended.badge": {
     "text": "Đã đình chỉ",
     "source_hash": "e392a389"
+  },
+  "web.admin.customers.actions.checkoutLink.button": {
+    "text": "Tạo liên kết thanh toán",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.modalTitle": {
+    "text": "Tạo liên kết thanh toán",
+    "source_hash": "9c5082cb"
+  },
+  "web.admin.customers.actions.checkoutLink.planLabel": {
+    "text": "Gói",
+    "source_hash": "fa8ed0bd"
+  },
+  "web.admin.customers.actions.checkoutLink.planPlaceholder": {
+    "text": "ID họ gói (ví dụ: identity_plus_v1)",
+    "source_hash": "12eba027"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleLabel": {
+    "text": "Chu kỳ thanh toán",
+    "source_hash": "d69f731e"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleMonthly": {
+    "text": "Hàng tháng",
+    "source_hash": "9b11f6b7"
+  },
+  "web.admin.customers.actions.checkoutLink.cycleYearly": {
+    "text": "Hàng năm",
+    "source_hash": "6e69b59e"
+  },
+  "web.admin.customers.actions.checkoutLink.allowPromo": {
+    "text": "Cho phép mã khuyến mãi",
+    "source_hash": "ebe7bc8b"
+  },
+  "web.admin.customers.actions.checkoutLink.submit": {
+    "text": "Tạo liên kết",
+    "source_hash": "e6b850cf"
+  },
+  "web.admin.customers.actions.checkoutLink.resultLead": {
+    "text": "Đã tạo liên kết thanh toán. Chia sẻ với khách hàng — liên kết chỉ dùng được một lần và sẽ hết hạn.",
+    "source_hash": "6ff1fb0e"
+  },
+  "web.admin.customers.actions.checkoutLink.copy": {
+    "text": "Sao chép liên kết thanh toán",
+    "source_hash": "f1e51ca7"
+  },
+  "web.admin.customers.actions.checkoutLink.expiry": {
+    "text": "Hết hạn sau khoảng {hours} giờ ({date}).",
+    "source_hash": "4c878a15"
+  },
+  "web.admin.customers.actions.checkoutLink.regionLabel": {
+    "text": "Khu vực",
+    "source_hash": "d3a008ef"
+  },
+  "web.admin.customers.actions.checkoutLink.parseError": {
+    "text": "Máy chủ đã chấp nhận yêu cầu nhưng trả về phản hồi không đọc được, vì vậy không thể hiển thị liên kết. Kiểm tra Stripe trước khi thử lại.",
+    "source_hash": "e7e08290"
+  },
+  "web.admin.customers.actions.checkoutLink.done": {
+    "text": "Xong",
+    "source_hash": "11a6767d"
+  },
+  "web.admin.customers.actions.purge.typePrompt": {
+    "text": "Để xác nhận, nhập địa chỉ email tài khoản {token} bên dưới",
+    "source_hash": "8b2a1819"
+  },
+  "web.admin.customers.actions.purge.unavailable": {
+    "text": "Không thể xóa vĩnh viễn: tài khoản này không có địa chỉ email để nhập lại làm xác nhận.",
+    "source_hash": "5f20f7e5"
+  },
+  "web.admin.customers.columns.actions": {
+    "text": "Hành động",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.customers.detail.diagnostics.title": {
+    "text": "Chẩn đoán tài khoản",
+    "source_hash": "5574ece8"
+  },
+  "web.admin.customers.detail.diagnostics.loading": {
+    "text": "Đang chạy chẩn đoán…",
+    "source_hash": "062c83d5"
+  },
+  "web.admin.customers.detail.diagnostics.loadError": {
+    "text": "Không thể tải chẩn đoán.",
+    "source_hash": "69e69f49"
+  },
+  "web.admin.customers.detail.diagnostics.healthy": {
+    "text": "Không tìm thấy điều kiện chặn. Trạng thái xác thực có vẻ bình thường — nghi ngờ các vấn đề phía máy khách (cookies, cấu hình đăng nhập tên miền tùy chỉnh) hoặc sai khu vực.",
+    "source_hash": "f6d5f8d1"
+  },
+  "web.admin.customers.detail.diagnostics.authUnavailable": {
+    "text": "Cơ sở dữ liệu xác thực không khả dụng (chế độ xác thực đơn giản) — các kiểm tra phía SQL đã bị bỏ qua.",
+    "source_hash": "d668907c"
+  },
+  "web.admin.customers.detail.diagnostics.authFailed": {
+    "text": "Cơ sở dữ liệu xác thực không phản hồi, vì vậy các kiểm tra phía SQL không thể chạy: {reason}",
+    "source_hash": "46d047c0"
+  },
+  "web.admin.customers.detail.diagnostics.unknown": {
+    "text": "Không xác định",
+    "source_hash": "b764cdc0"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.title": {
+    "text": "Nhật ký xác thực",
+    "source_hash": "48ad8ba8"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.empty": {
+    "text": "Không có sự kiện xác thực nào được ghi lại.",
+    "source_hash": "d2332558"
+  },
+  "web.admin.customers.detail.diagnostics.auditLog.unavailable": {
+    "text": "Không thể đọc nhật ký xác thực: {reason}",
+    "source_hash": "ab18af57"
+  },
+  "web.admin.customers.detail.diagnostics.facts.authStatus": {
+    "text": "Trạng thái xác thực",
+    "source_hash": "34def169"
+  },
+  "web.admin.customers.detail.diagnostics.facts.noAccount": {
+    "text": "Không có tài khoản xác thực",
+    "source_hash": "a9968e9e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.password": {
+    "text": "Mật khẩu",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordSet": {
+    "text": "Đã đặt",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.admin.customers.detail.diagnostics.facts.passwordNone": {
+    "text": "Không có",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfa": {
+    "text": "MFA",
+    "source_hash": "d39ce053"
+  },
+  "web.admin.customers.detail.diagnostics.facts.mfaNone": {
+    "text": "Không có",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.customers.detail.diagnostics.facts.loginFailures": {
+    "text": "Lần thử thất bại",
+    "source_hash": "63e7f0a8"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lockedBadge": {
+    "text": "Đã bị khóa",
+    "source_hash": "ace29f74"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiter": {
+    "text": "Giới hạn tốc độ",
+    "source_hash": "32892404"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterEngaged": {
+    "text": "Đang hoạt động",
+    "source_hash": "1b0d851e"
+  },
+  "web.admin.customers.detail.diagnostics.facts.rateLimiterClear": {
+    "text": "Rõ ràng",
+    "source_hash": "83b12c22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verification": {
+    "text": "Email xác minh",
+    "source_hash": "23fac8fb"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationPending": {
+    "text": "Đang chờ — gửi lần cuối {date}",
+    "source_hash": "9ab8d1b6"
+  },
+  "web.admin.customers.detail.diagnostics.facts.verificationNone": {
+    "text": "Không có gì đang chờ",
+    "source_hash": "a4d4cc22"
+  },
+  "web.admin.customers.detail.diagnostics.facts.sessions": {
+    "text": "Phiên đang hoạt động",
+    "source_hash": "61ad9909"
+  },
+  "web.admin.customers.detail.diagnostics.facts.lastLogin": {
+    "text": "Đăng nhập lần cuối (xác thực)",
+    "source_hash": "373e7fb1"
+  },
+  "web.admin.customers.detail.receipts.partial": {
+    "text": "Danh sách một phần — hiển thị {count} gần đây nhất. Khách hàng này có nhiều biên nhận hơn những gì được hiển thị ở đây.",
+    "source_hash": "127fd4db"
+  },
+  "web.admin.customers.detail.secrets.partial": {
+    "text": "Danh sách một phần — hiển thị {count} gần đây nhất. Khách hàng này sở hữu nhiều bí mật hơn những gì được hiển thị ở đây.",
+    "source_hash": "a537c8f3"
+  },
+  "web.admin.customers.detail.sessions.columns.country": {
+    "text": "Quốc gia",
+    "source_hash": "701d021d"
+  },
+  "web.admin.customers.detail.sessions.current.badge": {
+    "text": "Phiên này",
+    "source_hash": "6da6530a"
+  },
+  "web.admin.customers.detail.sessions.current.tooltip": {
+    "text": "Phiên quản trị hiện tại của bạn. Thu hồi ở đây không có tác dụng — nó được tạo lại cho phần còn lại của yêu cầu này.",
+    "source_hash": "ef097ab1"
+  },
+  "web.admin.customers.verification.verified": {
+    "text": "Đã xác minh",
+    "source_hash": "4f783840"
+  },
+  "web.admin.customers.verification.unverified": {
+    "text": "Chưa xác minh",
+    "source_hash": "15133907"
   }
 }

--- a/locales/content/vi/admin-domains.json
+++ b/locales/content/vi/admin-domains.json
@@ -190,5 +190,657 @@
   "web.admin.domains.verify.success.done": {
     "text": "Đã hoàn tất xác minh cho {domain}.",
     "source_hash": "ed67e22d"
+  },
+  "web.admin.domains.actions.preview": {
+    "text": "Xem trước",
+    "source_hash": "324b134f"
+  },
+  "web.admin.domains.actions.probe.button": {
+    "text": "Thăm dò",
+    "source_hash": "3bd51ab9"
+  },
+  "web.admin.domains.actions.remove.button": {
+    "text": "Xóa tên miền",
+    "source_hash": "5ce43507"
+  },
+  "web.admin.domains.actions.remove.previewButton": {
+    "text": "Xem trước việc xóa",
+    "source_hash": "6b81bd92"
+  },
+  "web.admin.domains.actions.remove.previewStatus": {
+    "text": "Trạng thái:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.remove.previewOrg": {
+    "text": "Tổ chức:",
+    "source_hash": "5300e286"
+  },
+  "web.admin.domains.actions.remove.reassertsSurvivor": {
+    "text": "Một bản ghi khác yêu cầu cùng tên miền và sẽ chiếm chỉ mục tra cứu.",
+    "source_hash": "902838f4"
+  },
+  "web.admin.domains.actions.remove.confirmTitle": {
+    "text": "Xóa tên miền?",
+    "source_hash": "716dfac9"
+  },
+  "web.admin.domains.actions.remove.confirmDescription": {
+    "text": "Thao tác này xóa vĩnh viễn {domain} cùng với thương hiệu, DNS và các bản ghi cấu hình của nó. Không thể hoàn tác. Nhập lại ID công khai của tên miền để tiếp tục.",
+    "source_hash": "d0b67b47"
+  },
+  "web.admin.domains.actions.remove.success": {
+    "text": "Đã xóa tên miền.",
+    "source_hash": "2ccaa6d3"
+  },
+  "web.admin.domains.actions.remove.notApplied": {
+    "text": "Máy chủ đã xem trước việc xóa thay vì áp dụng — tên miền KHÔNG bị xóa. Thử lại, và báo cáo nếu vấn đề vẫn tiếp tục.",
+    "source_hash": "dc6d70ae"
+  },
+  "web.admin.domains.actions.repair.title": {
+    "text": "Sửa liên kết tổ chức",
+    "source_hash": "82b40352"
+  },
+  "web.admin.domains.actions.repair.description": {
+    "text": "Tìm và sửa các liên kết bị hỏng giữa tên miền này và tổ chức của nó. Xem trước trước để xem những gì sẽ thay đổi.",
+    "source_hash": "531ed287"
+  },
+  "web.admin.domains.actions.repair.orgIdLabel": {
+    "text": "ID tổ chức (chỉ tên miền mồ côi)",
+    "source_hash": "0d3010eb"
+  },
+  "web.admin.domains.actions.repair.orgIdPlaceholder": {
+    "text": "Để trống trừ khi tên miền không có chủ sở hữu",
+    "source_hash": "118b7132"
+  },
+  "web.admin.domains.actions.repair.statusLabel": {
+    "text": "Trạng thái:",
+    "source_hash": "755c8b2a"
+  },
+  "web.admin.domains.actions.repair.noIssues": {
+    "text": "Không tìm thấy vấn đề — không có gì để sửa.",
+    "source_hash": "17735887"
+  },
+  "web.admin.domains.actions.repair.button": {
+    "text": "Áp dụng sửa chữa",
+    "source_hash": "4d0ab2d4"
+  },
+  "web.admin.domains.actions.repair.confirmTitle": {
+    "text": "Áp dụng sửa chữa?",
+    "source_hash": "ef0ffae5"
+  },
+  "web.admin.domains.actions.repair.confirmDescription": {
+    "text": "Thao tác này ghi lại liên kết tổ chức cho {domain}. Nhập lại ID công khai của tên miền để tiếp tục.",
+    "source_hash": "a9f2702f"
+  },
+  "web.admin.domains.actions.repair.success": {
+    "text": "Đã áp dụng sửa chữa.",
+    "source_hash": "850bd784"
+  },
+  "web.admin.domains.actions.transfer.title": {
+    "text": "Chuyển sang tổ chức khác",
+    "source_hash": "1b0b0655"
+  },
+  "web.admin.domains.actions.transfer.description": {
+    "text": "Di chuyển tên miền này sang một tổ chức khác. Xem trước trước để xác nhận cả hai bên của việc di chuyển.",
+    "source_hash": "457e852d"
+  },
+  "web.admin.domains.actions.transfer.toOrgLabel": {
+    "text": "ID tổ chức đích",
+    "source_hash": "1a3f05c4"
+  },
+  "web.admin.domains.actions.transfer.fromOrgLabel": {
+    "text": "ID tổ chức hiện tại dự kiến (tùy chọn)",
+    "source_hash": "f6e75729"
+  },
+  "web.admin.domains.actions.transfer.fromOrgPlaceholder": {
+    "text": "Xác nhận chủ sở hữu hiện tại trước khi di chuyển",
+    "source_hash": "1ac6c59b"
+  },
+  "web.admin.domains.actions.transfer.from": {
+    "text": "Từ",
+    "source_hash": "21819769"
+  },
+  "web.admin.domains.actions.transfer.to": {
+    "text": "Đến",
+    "source_hash": "f4b06ef6"
+  },
+  "web.admin.domains.actions.transfer.orphaned": {
+    "text": "Không có tổ chức (mồ côi)",
+    "source_hash": "6f4c745c"
+  },
+  "web.admin.domains.actions.transfer.button": {
+    "text": "Áp dụng chuyển",
+    "source_hash": "fb546c5c"
+  },
+  "web.admin.domains.actions.transfer.confirmTitle": {
+    "text": "Chuyển tên miền?",
+    "source_hash": "801eb986"
+  },
+  "web.admin.domains.actions.transfer.confirmDescription": {
+    "text": "Thao tác này di chuyển {domain} sang tổ chức {org}. Nhập lại ID công khai của tên miền để tiếp tục.",
+    "source_hash": "52c8808d"
+  },
+  "web.admin.domains.actions.transfer.success": {
+    "text": "Đã chuyển tên miền.",
+    "source_hash": "91e681ae"
+  },
+  "web.admin.domains.columns.domain": {
+    "text": "Tên miền",
+    "source_hash": "79fa3361"
+  },
+  "web.admin.domains.columns.organization": {
+    "text": "Tổ chức",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.columns.state": {
+    "text": "Xác minh",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.domains.columns.tls": {
+    "text": "TLS",
+    "source_hash": "d1c18ec0"
+  },
+  "web.admin.domains.columns.created": {
+    "text": "Đã tạo",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.columns.actions": {
+    "text": "Hành động",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.configs.title": {
+    "text": "Cấu hình tên miền",
+    "source_hash": "d46aa480"
+  },
+  "web.admin.domains.configs.description": {
+    "text": "Các bản ghi cấu hình cho từng tên miền kiểm soát đăng nhập, đăng ký, bí mật trang chủ, truy cập API, bí mật đến, SSO tenant và gửi thư. Bản ghi thiếu sẽ đóng mặc định cho năm mục đầu tiên.",
+    "source_hash": "1df99789"
+  },
+  "web.admin.domains.configs.loadError": {
+    "text": "Không thể tải các bản ghi cấu hình tên miền.",
+    "source_hash": "9417d718"
+  },
+  "web.admin.domains.configs.retry": {
+    "text": "Thử lại",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.configs.degraded": {
+    "text": "Phản hồi cấu hình không khớp với hợp đồng dự kiến. Làm mới, và báo cáo nếu vấn đề vẫn tiếp tục.",
+    "source_hash": "b5d890c0"
+  },
+  "web.admin.domains.configs.notFoundNote": {
+    "text": "Tên miền này không còn tồn tại, vì vậy các bản ghi cấu hình của nó không thể được tải.",
+    "source_hash": "2d88a392"
+  },
+  "web.admin.domains.configs.detailsToggle": {
+    "text": "Chi tiết",
+    "source_hash": "45989de4"
+  },
+  "web.admin.domains.configs.notEditable": {
+    "text": "Được quản lý trong cài đặt tên miền không gian làm việc.",
+    "source_hash": "54fe891f"
+  },
+  "web.admin.domains.configs.delete.button": {
+    "text": "Xóa",
+    "source_hash": "e2d0a549"
+  },
+  "web.admin.domains.configs.delete.confirmTitle": {
+    "text": "Xóa cấu hình {kind}?",
+    "source_hash": "98e672db"
+  },
+  "web.admin.domains.configs.delete.confirmDescription": {
+    "text": "Thao tác này xóa vĩnh viễn bản ghi cấu hình {kind} cho {domain}. Tên miền sẽ quay về hành vi thiếu bản ghi. Nhập lại loại để tiếp tục.",
+    "source_hash": "8272c40c"
+  },
+  "web.admin.domains.configs.delete.success": {
+    "text": "Đã xóa cấu hình.",
+    "source_hash": "a0184b66"
+  },
+  "web.admin.domains.configs.edit.button": {
+    "text": "Chỉnh sửa",
+    "source_hash": "464c4ffd"
+  },
+  "web.admin.domains.configs.edit.createButton": {
+    "text": "Tạo",
+    "source_hash": "4759498a"
+  },
+  "web.admin.domains.configs.edit.title": {
+    "text": "Cấu hình {kind}",
+    "source_hash": "8592148f"
+  },
+  "web.admin.domains.configs.edit.submit": {
+    "text": "Lưu",
+    "source_hash": "1509f561"
+  },
+  "web.admin.domains.configs.edit.success": {
+    "text": "Đã lưu cấu hình.",
+    "source_hash": "6b5b3c69"
+  },
+  "web.admin.domains.configs.edit.unsetOption": {
+    "text": "Chưa đặt",
+    "source_hash": "4895f731"
+  },
+  "web.admin.domains.configs.edit.domainsHint": {
+    "text": "Một tên miền mỗi dòng.",
+    "source_hash": "6c03f4f7"
+  },
+  "web.admin.domains.configs.ensure.button": {
+    "text": "Tạo cấu hình còn thiếu",
+    "source_hash": "77991b75"
+  },
+  "web.admin.domains.configs.ensure.confirmTitle": {
+    "text": "Tạo các bản ghi cấu hình còn thiếu?",
+    "source_hash": "3f41dec2"
+  },
+  "web.admin.domains.configs.ensure.confirmDescription": {
+    "text": "Tạo các bản ghi bị vô hiệu hóa trên {domain} cho: {kinds}. Mọi thứ bắt đầu bị vô hiệu hóa, vì vậy hành vi không thay đổi cho đến khi bản ghi được bật.",
+    "source_hash": "fed66221"
+  },
+  "web.admin.domains.configs.ensure.applyButton": {
+    "text": "Tạo bản ghi",
+    "source_hash": "4bcbef42"
+  },
+  "web.admin.domains.configs.ensure.success": {
+    "text": "Đã tạo các bản ghi cấu hình còn thiếu.",
+    "source_hash": "3b6ead80"
+  },
+  "web.admin.domains.configs.ensure.nothingMissing": {
+    "text": "Không có gì để tạo — mọi bản ghi cấu hình đã tồn tại. Danh sách đã được làm mới.",
+    "source_hash": "ad0df0ae"
+  },
+  "web.admin.domains.configs.ensure.notApplied": {
+    "text": "Máy chủ đã xem trước thay đổi thay vì áp dụng — không có bản ghi nào được tạo. Thử lại, và báo cáo nếu vấn đề vẫn tiếp tục.",
+    "source_hash": "09d26379"
+  },
+  "web.admin.domains.configs.fields.enabled": {
+    "text": "Đã bật",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.fields.signin_enabled": {
+    "text": "Đăng nhập đã bật",
+    "source_hash": "cabe4898"
+  },
+  "web.admin.domains.configs.fields.email_auth_enabled": {
+    "text": "Xác thực email đã bật",
+    "source_hash": "4a762960"
+  },
+  "web.admin.domains.configs.fields.sso_enabled": {
+    "text": "SSO đã bật",
+    "source_hash": "6e77e673"
+  },
+  "web.admin.domains.configs.fields.restrict_to": {
+    "text": "Giới hạn cho",
+    "source_hash": "a0bdf50a"
+  },
+  "web.admin.domains.configs.fields.signup_enabled": {
+    "text": "Đăng ký đã bật",
+    "source_hash": "2637d0b2"
+  },
+  "web.admin.domains.configs.fields.autoverify": {
+    "text": "Tự động xác minh",
+    "source_hash": "7e02211c"
+  },
+  "web.admin.domains.configs.fields.validation_strategy": {
+    "text": "Chiến lược xác thực",
+    "source_hash": "a2e95531"
+  },
+  "web.admin.domains.configs.fields.allowed_signup_domains": {
+    "text": "Tên miền đăng ký được phép",
+    "source_hash": "9b5bb5b1"
+  },
+  "web.admin.domains.configs.fields.secrets_mode": {
+    "text": "Chế độ bí mật",
+    "source_hash": "8d4349d6"
+  },
+  "web.admin.domains.configs.fields.disabled_homepage_variant": {
+    "text": "Biến thể trang chủ bị vô hiệu hóa",
+    "source_hash": "4695633b"
+  },
+  "web.admin.domains.configs.fields.ready": {
+    "text": "Sẵn sàng",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.configs.fields.recipients": {
+    "text": "Người nhận",
+    "source_hash": "1e8568a8"
+  },
+  "web.admin.domains.configs.fields.provider_type": {
+    "text": "Loại nhà cung cấp",
+    "source_hash": "8c0f6d3e"
+  },
+  "web.admin.domains.configs.fields.display_name": {
+    "text": "Tên hiển thị",
+    "source_hash": "2b7f6a84"
+  },
+  "web.admin.domains.configs.fields.issuer": {
+    "text": "Issuer",
+    "source_hash": "39e02c46"
+  },
+  "web.admin.domains.configs.fields.tenant_id": {
+    "text": "Tenant ID",
+    "source_hash": "de1f5fff"
+  },
+  "web.admin.domains.configs.fields.has_client_id": {
+    "text": "Client ID đã đặt",
+    "source_hash": "04a9fa3d"
+  },
+  "web.admin.domains.configs.fields.has_client_secret": {
+    "text": "Client secret đã đặt",
+    "source_hash": "6ee1c9e6"
+  },
+  "web.admin.domains.configs.fields.allowed_domains": {
+    "text": "Tên miền được phép",
+    "source_hash": "bcd60db0"
+  },
+  "web.admin.domains.configs.fields.enforce_sso_only": {
+    "text": "Chỉ bắt buộc SSO",
+    "source_hash": "b3a3f694"
+  },
+  "web.admin.domains.configs.fields.grant_org_scope": {
+    "text": "Cấp phạm vi tổ chức",
+    "source_hash": "698ea5de"
+  },
+  "web.admin.domains.configs.fields.provider": {
+    "text": "Nhà cung cấp",
+    "source_hash": "472590ae"
+  },
+  "web.admin.domains.configs.fields.from_name": {
+    "text": "Tên người gửi",
+    "source_hash": "b28f93ea"
+  },
+  "web.admin.domains.configs.fields.from_address": {
+    "text": "Địa chỉ người gửi",
+    "source_hash": "d465bcfa"
+  },
+  "web.admin.domains.configs.fields.reply_to": {
+    "text": "Trả lời đến",
+    "source_hash": "6b9c49b7"
+  },
+  "web.admin.domains.configs.fields.sending_mode": {
+    "text": "Chế độ gửi",
+    "source_hash": "e2d6bcf7"
+  },
+  "web.admin.domains.configs.fields.verification_status": {
+    "text": "Trạng thái xác minh",
+    "source_hash": "aedfff7e"
+  },
+  "web.admin.domains.configs.fields.dns_verified": {
+    "text": "DNS đã xác minh",
+    "source_hash": "8b2128c8"
+  },
+  "web.admin.domains.configs.fields.provider_verified": {
+    "text": "Nhà cung cấp đã xác minh",
+    "source_hash": "6f4d9cc4"
+  },
+  "web.admin.domains.configs.fields.has_api_key": {
+    "text": "API key đã đặt",
+    "source_hash": "d5115386"
+  },
+  "web.admin.domains.configs.fields.created": {
+    "text": "Đã tạo",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.configs.fields.updated": {
+    "text": "Đã cập nhật",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.configs.kinds.signin": {
+    "text": "Đăng nhập",
+    "source_hash": "5bbbe531"
+  },
+  "web.admin.domains.configs.kinds.signup": {
+    "text": "Đăng ký",
+    "source_hash": "3cc08ebe"
+  },
+  "web.admin.domains.configs.kinds.homepage": {
+    "text": "Trang chủ",
+    "source_hash": "9e3391e9"
+  },
+  "web.admin.domains.configs.kinds.api": {
+    "text": "API",
+    "source_hash": "c8e5998f"
+  },
+  "web.admin.domains.configs.kinds.incoming": {
+    "text": "Đến",
+    "source_hash": "e301820a"
+  },
+  "web.admin.domains.configs.kinds.sso": {
+    "text": "SSO",
+    "source_hash": "5ba3ac9f"
+  },
+  "web.admin.domains.configs.kinds.mailer": {
+    "text": "Mailer",
+    "source_hash": "6c07ba63"
+  },
+  "web.admin.domains.configs.missingNotes.signin": {
+    "text": "Không có bản ghi: đăng nhập bị vô hiệu hóa trên tên miền này trừ khi SSO tenant đang hoạt động.",
+    "source_hash": "17dd6099"
+  },
+  "web.admin.domains.configs.missingNotes.signup": {
+    "text": "Không có bản ghi: đăng ký bị vô hiệu hóa trên tên miền này.",
+    "source_hash": "c3c98956"
+  },
+  "web.admin.domains.configs.missingNotes.homepage": {
+    "text": "Không có bản ghi: bí mật trang chủ bị vô hiệu hóa (đóng mặc định và ghi lỗi).",
+    "source_hash": "9a258a88"
+  },
+  "web.admin.domains.configs.missingNotes.api": {
+    "text": "Không có bản ghi: API công khai bị vô hiệu hóa (đóng mặc định và ghi lỗi).",
+    "source_hash": "fed99f73"
+  },
+  "web.admin.domains.configs.missingNotes.incoming": {
+    "text": "Không có bản ghi: bí mật đến bị vô hiệu hóa.",
+    "source_hash": "b957fbe8"
+  },
+  "web.admin.domains.configs.missingNotes.sso": {
+    "text": "Không có bản ghi: SSO tenant không khả dụng; chính sách dự phòng SSO nền tảng được áp dụng.",
+    "source_hash": "7b05ade8"
+  },
+  "web.admin.domains.configs.missingNotes.mailer": {
+    "text": "Không có bản ghi: mailer nền tảng được sử dụng.",
+    "source_hash": "e027cc99"
+  },
+  "web.admin.domains.configs.status.missing": {
+    "text": "Thiếu",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.domains.configs.status.disabled": {
+    "text": "Bị vô hiệu hóa",
+    "source_hash": "75081b59"
+  },
+  "web.admin.domains.configs.status.enabled": {
+    "text": "Đã bật",
+    "source_hash": "92c1cdfd"
+  },
+  "web.admin.domains.configs.status.enabledNotReady": {
+    "text": "Đã bật, chưa sẵn sàng",
+    "source_hash": "cb806ba4"
+  },
+  "web.admin.domains.detail.openFullPage": {
+    "text": "Mở trang đầy đủ",
+    "source_hash": "a467911c"
+  },
+  "web.admin.domains.detail.backToList": {
+    "text": "Quay lại danh sách tên miền",
+    "source_hash": "22fd50fe"
+  },
+  "web.admin.domains.detail.notFound": {
+    "text": "Không tìm thấy tên miền",
+    "source_hash": "7b8fc0e6"
+  },
+  "web.admin.domains.detail.notFoundDescription": {
+    "text": "Tên miền này không tồn tại, hoặc đã bị xóa.",
+    "source_hash": "e0f0b987"
+  },
+  "web.admin.domains.detail.loadError": {
+    "text": "Không thể tải tên miền này.",
+    "source_hash": "39e9c657"
+  },
+  "web.admin.domains.detail.retry": {
+    "text": "Thử lại",
+    "source_hash": "942087cc"
+  },
+  "web.admin.domains.detail.never": {
+    "text": "Không bao giờ",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.domains.detail.none": {
+    "text": "Không có",
+    "source_hash": "dc937b59"
+  },
+  "web.admin.domains.detail.yes": {
+    "text": "Có",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.domains.detail.no": {
+    "text": "Không",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.domains.detail.organization.open": {
+    "text": "Mở tổ chức",
+    "source_hash": "54a43621"
+  },
+  "web.admin.domains.detail.organization.unknown": {
+    "text": "Tổ chức sở hữu không được bao gồm trong phản hồi này. Mở tên miền này từ danh sách tên miền để xem.",
+    "source_hash": "bb5bdc9c"
+  },
+  "web.admin.domains.detail.sections.overview": {
+    "text": "Tổng quan",
+    "source_hash": "d4b1ea57"
+  },
+  "web.admin.domains.detail.sections.actions": {
+    "text": "Hành động",
+    "source_hash": "ff8059dc"
+  },
+  "web.admin.domains.detail.sections.organization": {
+    "text": "Tổ chức sở hữu",
+    "source_hash": "39ad6d9c"
+  },
+  "web.admin.domains.detail.sections.dns": {
+    "text": "DNS",
+    "source_hash": "020965a2"
+  },
+  "web.admin.domains.detail.sections.diagnostics": {
+    "text": "Chẩn đoán",
+    "source_hash": "268f14bb"
+  },
+  "web.admin.domains.detail.sections.operations": {
+    "text": "Thao tác quyền sở hữu",
+    "source_hash": "eb9a8cbc"
+  },
+  "web.admin.domains.detail.sections.operationsHint": {
+    "text": "Mỗi thao tác xem trước trước. Không có gì được ghi cho đến khi bạn xác nhận bước áp dụng.",
+    "source_hash": "f09bf7bd"
+  },
+  "web.admin.domains.fields.publicId": {
+    "text": "ID công khai",
+    "source_hash": "3705b64f"
+  },
+  "web.admin.domains.fields.domainId": {
+    "text": "ID nội bộ",
+    "source_hash": "e468bb47"
+  },
+  "web.admin.domains.fields.organization": {
+    "text": "Tổ chức",
+    "source_hash": "d764d425"
+  },
+  "web.admin.domains.fields.baseDomain": {
+    "text": "Tên miền gốc",
+    "source_hash": "33295d5b"
+  },
+  "web.admin.domains.fields.subdomain": {
+    "text": "Tên miền phụ",
+    "source_hash": "ba4520ab"
+  },
+  "web.admin.domains.fields.apex": {
+    "text": "Tên miền apex",
+    "source_hash": "0a8a42fa"
+  },
+  "web.admin.domains.fields.status": {
+    "text": "Trạng thái",
+    "source_hash": "920e413c"
+  },
+  "web.admin.domains.fields.created": {
+    "text": "Đã tạo",
+    "source_hash": "d70b9e24"
+  },
+  "web.admin.domains.fields.updated": {
+    "text": "Đã cập nhật",
+    "source_hash": "3a5ecca1"
+  },
+  "web.admin.domains.fields.verified": {
+    "text": "Đã xác minh",
+    "source_hash": "4f783840"
+  },
+  "web.admin.domains.fields.resolving": {
+    "text": "Đang phân giải",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.fields.ready": {
+    "text": "Sẵn sàng",
+    "source_hash": "5fa7aac5"
+  },
+  "web.admin.domains.list.searchPlaceholder": {
+    "text": "Tìm kiếm theo tên miền hoặc ID",
+    "source_hash": "aecdd873"
+  },
+  "web.admin.domains.list.stateFilter": {
+    "text": "Trạng thái",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.domains.list.emptyFilter": {
+    "text": "Không có tên miền nào khớp với bộ lọc hiện tại.",
+    "source_hash": "be4d64ec"
+  },
+  "web.admin.domains.probe.healthLabel": {
+    "text": "Tình trạng",
+    "source_hash": "55898449"
+  },
+  "web.admin.domains.probe.certInvalid": {
+    "text": "Chứng chỉ không sử dụng được",
+    "source_hash": "5535f4d4"
+  },
+  "web.admin.domains.probe.noCertificate": {
+    "text": "Không có chứng chỉ nào được trả về — kết nối thất bại trước TLS.",
+    "source_hash": "8ffd63be"
+  },
+  "web.admin.domains.probe.fields.httpStatus": {
+    "text": "Trạng thái HTTP",
+    "source_hash": "0f7cf91f"
+  },
+  "web.admin.domains.probe.fields.httpError": {
+    "text": "Lỗi HTTP",
+    "source_hash": "5c6896d4"
+  },
+  "web.admin.domains.probe.fields.sslError": {
+    "text": "Lỗi TLS",
+    "source_hash": "7b827515"
+  },
+  "web.admin.domains.probe.fields.issuer": {
+    "text": "Nhà phát hành chứng chỉ",
+    "source_hash": "2912559a"
+  },
+  "web.admin.domains.probe.fields.subject": {
+    "text": "Chủ thể chứng chỉ",
+    "source_hash": "d7816b16"
+  },
+  "web.admin.domains.probe.fields.notAfter": {
+    "text": "Chứng chỉ hết hạn",
+    "source_hash": "1e73119d"
+  },
+  "web.admin.domains.probe.fields.expiresIn": {
+    "text": "{date} ({days} ngày)",
+    "source_hash": "a71a6e81"
+  },
+  "web.admin.domains.tls.serving": {
+    "text": "Đang phục vụ",
+    "source_hash": "f55e53f9"
+  },
+  "web.admin.domains.tls.resolving": {
+    "text": "Đang phân giải",
+    "source_hash": "3287a034"
+  },
+  "web.admin.domains.tls.none": {
+    "text": "Không phục vụ",
+    "source_hash": "da8a5ab9"
   }
 }

--- a/locales/content/vi/admin-organizations.json
+++ b/locales/content/vi/admin-organizations.json
@@ -310,5 +310,333 @@
   "web.admin.organizations.list.loadError": {
     "text": "Không thể tải tổ chức.",
     "source_hash": "130d5e70"
+  },
+  "web.admin.organizations.addMember.button": {
+    "text": "Thêm tài khoản hiện có",
+    "source_hash": "45a3b757"
+  },
+  "web.admin.organizations.addMember.title": {
+    "text": "Thêm một tài khoản hiện có",
+    "source_hash": "2f676a94"
+  },
+  "web.admin.organizations.addMember.description": {
+    "text": "Thêm người đã có tài khoản vào {org}. Sử dụng khi một người đã tự đăng ký và không thể được mời vì tài khoản đã tồn tại.",
+    "source_hash": "bb41faa6"
+  },
+  "web.admin.organizations.addMember.searchLabel": {
+    "text": "Địa chỉ email hoặc ID tài khoản",
+    "source_hash": "82b3040b"
+  },
+  "web.admin.organizations.addMember.searchPlaceholder": {
+    "text": "Tìm kiếm theo địa chỉ email",
+    "source_hash": "b75cc66c"
+  },
+  "web.admin.organizations.addMember.searchHint": {
+    "text": "Khớp một phần địa chỉ email, hoặc ID tài khoản chính xác.",
+    "source_hash": "84547a60"
+  },
+  "web.admin.organizations.addMember.searchError": {
+    "text": "Không thể tìm kiếm tài khoản. Kiểm tra kết nối và thử lại.",
+    "source_hash": "4b6caa41"
+  },
+  "web.admin.organizations.addMember.searchParseError": {
+    "text": "Tìm kiếm tài khoản trả về phản hồi không mong đợi. Kết quả có thể không đầy đủ.",
+    "source_hash": "0c814231"
+  },
+  "web.admin.organizations.addMember.idle": {
+    "text": "Nhập địa chỉ email để tìm tài khoản.",
+    "source_hash": "f6340d35"
+  },
+  "web.admin.organizations.addMember.noResults": {
+    "text": "Không có tài khoản nào khớp với \"{term}\".",
+    "source_hash": "199b662a"
+  },
+  "web.admin.organizations.addMember.noResultsHint": {
+    "text": "Chỉ có thể thêm tài khoản hiện có ở đây. Nếu người đó chưa bao giờ đăng ký, hãy mời họ thay thế.",
+    "source_hash": "ee90aeeb"
+  },
+  "web.admin.organizations.addMember.select": {
+    "text": "Chọn",
+    "source_hash": "2a78025d"
+  },
+  "web.admin.organizations.addMember.selectedEyebrow": {
+    "text": "Tài khoản đã chọn",
+    "source_hash": "8b63d947"
+  },
+  "web.admin.organizations.addMember.change": {
+    "text": "Chọn tài khoản khác",
+    "source_hash": "d4fe39ab"
+  },
+  "web.admin.organizations.addMember.createdOn": {
+    "text": "Đã đăng ký {date}",
+    "source_hash": "cfc0e19f"
+  },
+  "web.admin.organizations.addMember.organizationsUnavailable": {
+    "text": "Không thể tải các tổ chức hiện tại của tài khoản này.",
+    "source_hash": "a35b6bfc"
+  },
+  "web.admin.organizations.addMember.defaultOrg": {
+    "text": "mặc định",
+    "source_hash": "37a8eec1"
+  },
+  "web.admin.organizations.addMember.roleLabel": {
+    "text": "Vai trò trong tổ chức này",
+    "source_hash": "817475fa"
+  },
+  "web.admin.organizations.addMember.submit": {
+    "text": "Thêm vào tổ chức",
+    "source_hash": "0e0cb636"
+  },
+  "web.admin.organizations.addMember.success": {
+    "text": "Đã thêm {account} với vai trò {role}.",
+    "source_hash": "533be0dc"
+  },
+  "web.admin.organizations.addMember.badges.verified": {
+    "text": "Đã xác minh",
+    "source_hash": "4f783840"
+  },
+  "web.admin.organizations.addMember.badges.unverified": {
+    "text": "Chưa xác minh",
+    "source_hash": "15133907"
+  },
+  "web.admin.organizations.addMember.badges.suspended": {
+    "text": "Bị đình chỉ",
+    "source_hash": "e392a389"
+  },
+  "web.admin.organizations.addMember.badges.alreadyMember": {
+    "text": "Đã là thành viên",
+    "source_hash": "1739ed7c"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMember": {
+    "text": "Tài khoản này đã là thành viên của tổ chức này, với vai trò {role}. Thêm không thay đổi vai trò hiện có — sử dụng hành động đặt vai trò cho việc đó.",
+    "source_hash": "cb6a4774"
+  },
+  "web.admin.organizations.addMember.errors.alreadyMemberUnknownRole": {
+    "text": "Tài khoản này đã là thành viên của tổ chức này. Thêm không thay đổi vai trò hiện có.",
+    "source_hash": "035641ec"
+  },
+  "web.admin.organizations.addMember.errors.notFound": {
+    "text": "Tài khoản hoặc tổ chức đó không còn tồn tại. Tìm kiếm lại để xác nhận tài khoản.",
+    "source_hash": "bd88db18"
+  },
+  "web.admin.organizations.addMember.errors.invalidRole": {
+    "text": "Vai trò đó đã bị từ chối. Chọn một trong các vai trò được liệt kê và thử lại.",
+    "source_hash": "eb696a8f"
+  },
+  "web.admin.organizations.addMember.errors.noSelection": {
+    "text": "Không có tài khoản nào được chọn.",
+    "source_hash": "dd15bb5b"
+  },
+  "web.admin.organizations.addMember.fields.created": {
+    "text": "Đã đăng ký",
+    "source_hash": "486b3fe0"
+  },
+  "web.admin.organizations.addMember.fields.verified": {
+    "text": "Xác minh",
+    "source_hash": "7140f4f1"
+  },
+  "web.admin.organizations.addMember.fields.lastLogin": {
+    "text": "Đăng nhập lần cuối",
+    "source_hash": "0b70af7a"
+  },
+  "web.admin.organizations.addMember.fields.organizations": {
+    "text": "Các tổ chức hiện tại",
+    "source_hash": "cbb5b92f"
+  },
+  "web.admin.organizations.addMember.roleHints.member": {
+    "text": "Quyền truy cập hàng ngày vào bí mật và tên miền của tổ chức.",
+    "source_hash": "d0c7439e"
+  },
+  "web.admin.organizations.addMember.roleHints.admin": {
+    "text": "Có thể quản lý thành viên, tên miền và cài đặt tổ chức.",
+    "source_hash": "beaa50d7"
+  },
+  "web.admin.organizations.addMember.roleHints.owner": {
+    "text": "Toàn quyền kiểm soát, bao gồm thanh toán. Chỉ cấp khi được yêu cầu.",
+    "source_hash": "614ace63"
+  },
+  "web.admin.organizations.addMember.roles.member": {
+    "text": "Thành viên",
+    "source_hash": "7c968fb7"
+  },
+  "web.admin.organizations.addMember.roles.admin": {
+    "text": "Quản trị viên",
+    "source_hash": "c1c224b0"
+  },
+  "web.admin.organizations.addMember.roles.owner": {
+    "text": "Chủ sở hữu",
+    "source_hash": "4b1b8aa3"
+  },
+  "web.admin.organizations.detail.members.openCustomer": {
+    "text": "Mở hồ sơ khách hàng",
+    "source_hash": "c057ca13"
+  },
+  "web.admin.organizations.detail.reconcile.memberships": {
+    "text": "Thành viên đã được tái tạo:",
+    "source_hash": "fe7db10c"
+  },
+  "web.admin.organizations.detail.reconcile.membershipsFailed": {
+    "text": "thất bại, quyền cũ vẫn còn:",
+    "source_hash": "cc4dae37"
+  },
+  "web.admin.organizations.entitlements.catalogWarning": {
+    "text": "\"{entitlement}\" không có trong danh mục thanh toán — kiểm tra lỗi chính tả. Vẫn tiếp tục: việc cấp quyền được giao trong danh mục sau được hỗ trợ và cố ý không bị chặn.",
+    "source_hash": "cbde548a"
+  },
+  "web.admin.organizations.entitlements.matrix.caption": {
+    "text": "Ma trận phân giải quyền: gói, cấp và thu hồi ghi đè, tập hợp đã phân giải, và những gì được hiện thực hóa.",
+    "source_hash": "9eac8999"
+  },
+  "web.admin.organizations.entitlements.matrix.yes": {
+    "text": "Có",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.matrix.no": {
+    "text": "Không",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.matrix.empty": {
+    "text": "Tổ chức này không có quyền từ gói của nó và không có ghi đè.",
+    "source_hash": "f6cf2169"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.entitlement": {
+    "text": "Quyền",
+    "source_hash": "0d8f0b2d"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.inPlan": {
+    "text": "Trong gói",
+    "source_hash": "e2222361"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.granted": {
+    "text": "Đã cấp",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.revoked": {
+    "text": "Đã thu hồi",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.expected": {
+    "text": "Dự kiến",
+    "source_hash": "ca99b7f1"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.materialized": {
+    "text": "Đã hiện thực hóa",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.matrix.columns.state": {
+    "text": "Trạng thái",
+    "source_hash": "a3b50c47"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.formula": {
+    "text": "Phân giải: dự kiến = (gói ∪ cấp) − thu hồi. Đã hiện thực hóa là những gì thực sự được lưu trữ trên tổ chức.",
+    "source_hash": "bc4bff2d"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.orphaned": {
+    "text": "Mồ côi — đã hiện thực hóa nhưng không dự kiến, thường bị bỏ lại bởi thu hồi chưa bao giờ được tái hiện thực hóa. Đối chiếu sẽ xóa nó.",
+    "source_hash": "3a27a9af"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.missing": {
+    "text": "Thiếu — dự kiến nhưng không hiện thực hóa. Đây là quyền mà các thành viên thực sự đang thiếu ngay bây giờ.",
+    "source_hash": "485e44ad"
+  },
+  "web.admin.organizations.entitlements.matrix.legend.revoked": {
+    "text": "Các hàng bị gạch ngang là bị thu hồi bởi ghi đè quản trị, loại bỏ chúng khỏi tập hợp dự kiến.",
+    "source_hash": "89a2e9b6"
+  },
+  "web.admin.organizations.entitlements.matrix.state.plan": {
+    "text": "Từ gói",
+    "source_hash": "1d346b26"
+  },
+  "web.admin.organizations.entitlements.matrix.state.granted": {
+    "text": "Đã cấp",
+    "source_hash": "62026a42"
+  },
+  "web.admin.organizations.entitlements.matrix.state.revoked": {
+    "text": "Đã thu hồi",
+    "source_hash": "f6f738d0"
+  },
+  "web.admin.organizations.entitlements.matrix.state.orphaned": {
+    "text": "Mồ côi",
+    "source_hash": "8d827807"
+  },
+  "web.admin.organizations.entitlements.matrix.state.missing": {
+    "text": "Thiếu",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.organizations.entitlements.picker.selectPlaceholder": {
+    "text": "Chọn một quyền…",
+    "source_hash": "53af3be8"
+  },
+  "web.admin.organizations.entitlements.picker.other": {
+    "text": "Khác — không có trong danh mục…",
+    "source_hash": "f08bc3a3"
+  },
+  "web.admin.organizations.entitlements.picker.customLabel": {
+    "text": "Tên quyền (không có trong danh mục)",
+    "source_hash": "52783229"
+  },
+  "web.admin.organizations.entitlements.picker.backToCatalog": {
+    "text": "Quay lại danh mục",
+    "source_hash": "9b727f40"
+  },
+  "web.admin.organizations.entitlements.picker.uncategorized": {
+    "text": "Chưa phân loại",
+    "source_hash": "8d40d123"
+  },
+  "web.admin.organizations.entitlements.picker.catalogUnavailable": {
+    "text": "Không thể đọc danh mục thanh toán, vì vậy tên quyền không được kiểm tra ở đây.",
+    "source_hash": "724869ec"
+  },
+  "web.admin.organizations.entitlements.picker.tags.inPlan": {
+    "text": "trong gói",
+    "source_hash": "5f2251bb"
+  },
+  "web.admin.organizations.entitlements.picker.tags.granted": {
+    "text": "đã cấp",
+    "source_hash": "dd515d19"
+  },
+  "web.admin.organizations.entitlements.picker.tags.revoked": {
+    "text": "đã thu hồi",
+    "source_hash": "4bb47f18"
+  },
+  "web.admin.organizations.entitlements.summary.sync": {
+    "text": "Đồng bộ",
+    "source_hash": "8d261a37"
+  },
+  "web.admin.organizations.entitlements.summary.materialized": {
+    "text": "Đã hiện thực hóa",
+    "source_hash": "1298eb6e"
+  },
+  "web.admin.organizations.entitlements.summary.materializedAt": {
+    "text": "Hiện thực hóa lần cuối",
+    "source_hash": "9325dce9"
+  },
+  "web.admin.organizations.entitlements.summary.planDefinition": {
+    "text": "Định nghĩa gói",
+    "source_hash": "6b531454"
+  },
+  "web.admin.organizations.entitlements.summary.yes": {
+    "text": "Có",
+    "source_hash": "85a39ab3"
+  },
+  "web.admin.organizations.entitlements.summary.no": {
+    "text": "Không",
+    "source_hash": "1ea442a1"
+  },
+  "web.admin.organizations.entitlements.summary.never": {
+    "text": "Không bao giờ",
+    "source_hash": "6300ef80"
+  },
+  "web.admin.organizations.entitlements.summary.planStale": {
+    "text": "Đã thay đổi kể từ khi hiện thực hóa",
+    "source_hash": "e682d8a4"
+  },
+  "web.admin.organizations.entitlements.summary.planCurrent": {
+    "text": "Hiện tại",
+    "source_hash": "e0d1b682"
+  },
+  "web.admin.organizations.entitlements.summary.planUnknown": {
+    "text": "Không xác định — không thể so sánh",
+    "source_hash": "b607e540"
   }
 }

--- a/locales/content/vi/admin-secrets.json
+++ b/locales/content/vi/admin-secrets.json
@@ -1,11 +1,11 @@
 {
   "web.admin.secrets.title": {
-    "text": "Bí mật",
-    "source_hash": "d8707d41"
+    "text": "Biên nhận bí mật",
+    "source_hash": "a8a2d0e4"
   },
   "web.admin.secrets.description": {
-    "text": "Kiểm tra biên nhận của một bí mật và xóa nó mà không cần SSH — tra cứu theo khóa của nó.",
-    "source_hash": "07775a11"
+    "text": "Tra cứu trạng thái, dấu thời gian, biên nhận, v.v.",
+    "source_hash": "91fba2a1"
   },
   "web.admin.secrets.never": {
     "text": "Chưa bao giờ",
@@ -108,20 +108,20 @@
     "source_hash": "504101bc"
   },
   "web.admin.secrets.lookup.resultTitle": {
-    "text": "Bí mật {shortid}",
-    "source_hash": "8b311d32"
+    "text": "Bản ghi bí mật {shortid}",
+    "source_hash": "ee06d765"
   },
   "web.admin.secrets.lookup.notFound": {
-    "text": "Không tìm thấy bí mật",
-    "source_hash": "70a9532c"
+    "text": "Không tìm thấy bản ghi",
+    "source_hash": "40f4d9e9"
   },
   "web.admin.secrets.lookup.notFoundDescription": {
     "text": "Không có bí mật nào tồn tại với khóa này. Nó có thể đã hết hạn hoặc bị xóa.",
     "source_hash": "9f068a81"
   },
   "web.admin.secrets.lookup.loadError": {
-    "text": "Không thể tải bí mật này.",
-    "source_hash": "c96672e4"
+    "text": "Không thể tải bản ghi này.",
+    "source_hash": "de77cc72"
   },
   "web.admin.secrets.lookup.retry": {
     "text": "Thử lại",
@@ -188,8 +188,8 @@
     "source_hash": "c127dab6"
   },
   "web.admin.secrets.sections.secret": {
-    "text": "Bí mật",
-    "source_hash": "7e32a729"
+    "text": "Bản ghi bí mật",
+    "source_hash": "263813c6"
   },
   "web.admin.secrets.sections.receipt": {
     "text": "Biên nhận",
@@ -214,5 +214,25 @@
   "web.admin.secrets.state.viewed": {
     "text": "Đã xem",
     "source_hash": "1b28d178"
+  },
+  "web.admin.secrets.capability.title": {
+    "text": "Chỉ siêu dữ liệu",
+    "source_hash": "df0453d1"
+  },
+  "web.admin.secrets.capability.canRead": {
+    "text": "Đọc siêu dữ liệu của bí mật và biên nhận của nó: trạng thái, dấu thời gian, chủ sở hữu, và kích thước của văn bản mã hóa được lưu trữ.",
+    "source_hash": "d438ecc7"
+  },
+  "web.admin.secrets.capability.cannotRead": {
+    "text": "Không thể giải mã hoặc hiển thị nội dung bí mật. Điểm cuối đằng sau màn hình này không bao giờ trả về nó.",
+    "source_hash": "7f69f222"
+  },
+  "web.admin.secrets.capability.canDelete": {
+    "text": "Có thể xóa vĩnh viễn bí mật và biên nhận của nó, điều này hủy nội dung mà không bao giờ tiết lộ nó.",
+    "source_hash": "77f2bc7e"
+  },
+  "web.admin.secrets.lookup.hint": {
+    "text": "Định danh từ liên kết của bí mật — không phải nội dung bí mật.",
+    "source_hash": "acfbc352"
   }
 }

--- a/locales/content/vi/admin-system.json
+++ b/locales/content/vi/admin-system.json
@@ -154,5 +154,133 @@
   "web.admin.system.redis.captured": {
     "text": "Đã thu thập {at}",
     "source_hash": "57b40c0f"
+  },
+  "web.admin.system.brand.title": {
+    "text": "Chẩn đoán thương hiệu",
+    "source_hash": "1cf9abd5"
+  },
+  "web.admin.system.brand.description": {
+    "text": "Gói thương hiệu nào mà phiên bản đang chạy đã giải quyết trên đĩa — cho thấy tại sao một khu vực có thể phục vụ thương hiệu trung lập.",
+    "source_hash": "be29e282"
+  },
+  "web.admin.system.brand.loadError": {
+    "text": "Không thể tải chẩn đoán thương hiệu.",
+    "source_hash": "80607303"
+  },
+  "web.admin.system.brand.none": {
+    "text": "(không có)",
+    "source_hash": "552e4230"
+  },
+  "web.admin.system.brand.resolution": {
+    "text": "Giải quyết",
+    "source_hash": "d4055faf"
+  },
+  "web.admin.system.brand.envVsConfig": {
+    "text": "Môi trường so với Cấu hình",
+    "source_hash": "bee3debb"
+  },
+  "web.admin.system.brand.absorbed": {
+    "text": "Khóa đã hấp thụ",
+    "source_hash": "9784e110"
+  },
+  "web.admin.system.brand.operatorKeys": {
+    "text": "Khóa vận hành",
+    "source_hash": "434e8248"
+  },
+  "web.admin.system.brand.overlayAssets": {
+    "text": "Tài sản phủ",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.exists.yes": {
+    "text": "Có mặt",
+    "source_hash": "43f9b89c"
+  },
+  "web.admin.system.brand.exists.no": {
+    "text": "Thiếu",
+    "source_hash": "6be36ca4"
+  },
+  "web.admin.system.brand.fields.resolvedDir": {
+    "text": "Thư mục đã giải quyết",
+    "source_hash": "0623b983"
+  },
+  "web.admin.system.brand.fields.home": {
+    "text": "Trang chủ",
+    "source_hash": "3a786953"
+  },
+  "web.admin.system.brand.fields.envPack": {
+    "text": "ENV Brand Pack",
+    "source_hash": "940aeb5c"
+  },
+  "web.admin.system.brand.fields.configPack": {
+    "text": "Config Brand Pack",
+    "source_hash": "761b9550"
+  },
+  "web.admin.system.brand.fields.envAssetsDir": {
+    "text": "ENV Brand Assets Dir",
+    "source_hash": "05854f1f"
+  },
+  "web.admin.system.brand.fields.configAssetsDir": {
+    "text": "Config Brand Assets Dir",
+    "source_hash": "e91e5c46"
+  },
+  "web.admin.system.brand.flags.fellBack.danger": {
+    "text": "Đã quay về gói mặc định",
+    "source_hash": "7bf7ba2f"
+  },
+  "web.admin.system.brand.flags.fellBack.ok": {
+    "text": "Đã giải quyết gói thương hiệu",
+    "source_hash": "1ab3162f"
+  },
+  "web.admin.system.brand.flags.mismatch.danger": {
+    "text": "Không khớp Boot / live",
+    "source_hash": "0a022192"
+  },
+  "web.admin.system.brand.flags.mismatch.ok": {
+    "text": "Boot khớp với live",
+    "source_hash": "d4792c09"
+  },
+  "web.admin.system.brand.manifest.title": {
+    "text": "Manifest",
+    "source_hash": "3c99f1f3"
+  },
+  "web.admin.system.brand.manifest.path": {
+    "text": "Đường dẫn",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.manifest.exists": {
+    "text": "Tồn tại",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.manifest.keysOnDisk": {
+    "text": "Khóa trên đĩa",
+    "source_hash": "52439c03"
+  },
+  "web.admin.system.brand.roots.title": {
+    "text": "Gốc tìm kiếm",
+    "source_hash": "d8696f2b"
+  },
+  "web.admin.system.brand.roots.empty": {
+    "text": "Không có gốc tìm kiếm",
+    "source_hash": "867a471c"
+  },
+  "web.admin.system.brand.roots.columns.path": {
+    "text": "Đường dẫn",
+    "source_hash": "62fa5a5b"
+  },
+  "web.admin.system.brand.roots.columns.exists": {
+    "text": "Tồn tại",
+    "source_hash": "fefd8ba5"
+  },
+  "web.admin.system.brand.stats.brandPack": {
+    "text": "Brand Pack",
+    "source_hash": "884437d0"
+  },
+  "web.admin.system.brand.stats.overlayAssets": {
+    "text": "Tài sản phủ",
+    "source_hash": "c87de1f9"
+  },
+  "web.admin.system.brand.stats.manifestKeys": {
+    "text": "Khóa Manifest",
+    "source_hash": "c4267198"
   }
 }

--- a/locales/content/vi/email.json
+++ b/locales/content/vi/email.json
@@ -836,5 +836,41 @@
   "email.secret_link.footer_note": {
     "text": "Bạn nhận được email này vì %{sender_email} đã sử dụng %{product_name} để chia sẻ một bí mật với bạn. Nếu bạn không mong đợi điều này, bạn có thể yên tâm bỏ qua email này.",
     "source_hash": "2d544dad"
+  },
+  "email.sso_link_verification.subject": {
+    "text": "Xác nhận liên kết %{provider} với tài khoản %{product_name} của bạn",
+    "source_hash": "65e70296"
+  },
+  "email.sso_link_verification.title": {
+    "text": "Xác nhận đăng nhập SSO của bạn",
+    "source_hash": "35bce6cc"
+  },
+  "email.sso_link_verification.request_notice": {
+    "text": "Ai đó đã đăng nhập bằng %{provider} sử dụng email %{email_address}. Để hoàn tất kết nối %{provider} với tài khoản %{product_name} của bạn, xác nhận bên dưới.",
+    "source_hash": "baeb18c0"
+  },
+  "email.sso_link_verification.confirm_button": {
+    "text": "Xác nhận và liên kết %{provider}",
+    "source_hash": "9809e210"
+  },
+  "email.sso_link_verification.copy_link_prompt": {
+    "text": "Hoặc sao chép và dán liên kết này:",
+    "source_hash": "88c72144"
+  },
+  "email.sso_link_verification.expiration_notice": {
+    "text": "Liên kết này hết hạn sau 15 phút và chỉ có thể sử dụng một lần.",
+    "source_hash": "1a437f42"
+  },
+  "email.sso_link_verification.ignore_notice": {
+    "text": "Nếu bạn không cố gắng đăng nhập bằng %{provider}, bạn có thể bỏ qua email này một cách an toàn — không có gì sẽ được kết nối với tài khoản của bạn.",
+    "source_hash": "d7317d30"
+  },
+  "email.sso_link_verification.signature": {
+    "text": "Đội ngũ hỗ trợ",
+    "source_hash": "dc75bf9f"
+  },
+  "email.sso_link_verification.postscript": {
+    "text": "Tái bút: Email này được gửi đến %{email_address}.",
+    "source_hash": "8ab1dbea"
   }
 }

--- a/locales/content/vi/session-auth-extended.json
+++ b/locales/content/vi/session-auth-extended.json
@@ -730,5 +730,201 @@
   "web.auth.sessions.session_plural": {
     "text": "phiên",
     "source_hash": "1225ae6c"
+  },
+  "web.auth.connections.title": {
+    "text": "Danh tính đã kết nối",
+    "source_hash": "e132c4d9"
+  },
+  "web.auth.connections.description": {
+    "text": "Quản lý các nhà cung cấp đăng nhập một lần được liên kết với tài khoản của bạn.",
+    "source_hash": "42c6d148"
+  },
+  "web.auth.connections.section_title": {
+    "text": "Đăng nhập một lần",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.section_subtitle": {
+    "text": "Các nhà cung cấp danh tính bạn có thể sử dụng để đăng nhập vào tài khoản này",
+    "source_hash": "507254cd"
+  },
+  "web.auth.connections.connect_title": {
+    "text": "Kết nối một nhà cung cấp",
+    "source_hash": "a002b3f3"
+  },
+  "web.auth.connections.connect_description": {
+    "text": "Liên kết một nhà cung cấp đăng nhập một lần khác mà bạn có thể sử dụng để đăng nhập vào tài khoản này.",
+    "source_hash": "32895a5a"
+  },
+  "web.auth.connections.connect_action": {
+    "text": "Kết nối {provider}",
+    "source_hash": "c77540af"
+  },
+  "web.auth.connections.issuer": {
+    "text": "Issuer",
+    "source_hash": "39e02c46"
+  },
+  "web.auth.connections.identifier": {
+    "text": "Định danh",
+    "source_hash": "9b10587f"
+  },
+  "web.auth.connections.remove": {
+    "text": "Xóa",
+    "source_hash": "c3812fc4"
+  },
+  "web.auth.connections.remove_confirm_title": {
+    "text": "Xóa danh tính đã kết nối",
+    "source_hash": "4e8ffe4c"
+  },
+  "web.auth.connections.remove_confirm_message": {
+    "text": "Bạn có chắc chắn muốn xóa danh tính đã kết nối này? Bạn sẽ không thể đăng nhập bằng nó nữa.",
+    "source_hash": "64939c89"
+  },
+  "web.auth.connections.removed_success": {
+    "text": "Đã xóa danh tính đã kết nối",
+    "source_hash": "cf87daf3"
+  },
+  "web.auth.connections.no_identities": {
+    "text": "Không có danh tính đã kết nối",
+    "source_hash": "5254048e"
+  },
+  "web.auth.connections.no_identities_description": {
+    "text": "Bạn chưa liên kết bất kỳ nhà cung cấp đăng nhập một lần nào với tài khoản này.",
+    "source_hash": "0f58d5d0"
+  },
+  "web.auth.connections.overview_status": {
+    "text": "Đăng nhập một lần",
+    "source_hash": "3bc44ac2"
+  },
+  "web.auth.connections.errors.last_credential": {
+    "text": "Đây là cách duy nhất để bạn đăng nhập. Kết nối một nhà cung cấp khác trước, hoặc đặt mật khẩu từ Cài đặt → Bảo mật, để bạn không bị khóa.",
+    "source_hash": "3de8084d"
+  },
+  "web.auth.connections.errors.last_credential_sso_enforced": {
+    "text": "Đây là cách duy nhất để bạn đăng nhập. Kết nối một nhà cung cấp khác trước để bạn không bị khóa.",
+    "source_hash": "eed7a50e"
+  },
+  "web.auth.connections.errors.not_found": {
+    "text": "Không thể tìm thấy danh tính đã kết nối đó. Có thể nó đã bị xóa.",
+    "source_hash": "cf2c7673"
+  },
+  "web.auth.connections.errors.unauthorized": {
+    "text": "Phiên của bạn đã hết hạn. Vui lòng đăng nhập lại.",
+    "source_hash": "b529fce2"
+  },
+  "web.auth.connections.errors.generic": {
+    "text": "Chúng tôi không thể hoàn thành hành động đó. Vui lòng thử lại.",
+    "source_hash": "a0d4edc0"
+  },
+  "web.link_sso.title": {
+    "text": "Liên kết phương thức đăng nhập của bạn",
+    "source_hash": "46339bac"
+  },
+  "web.link_sso.prompt": {
+    "text": "Bạn đã đăng nhập bằng {provider}, khớp với tài khoản hiện có {email}. Nhập mật khẩu của tài khoản đó để liên kết {provider} và tiếp tục.",
+    "source_hash": "59da1c08"
+  },
+  "web.link_sso.password_label": {
+    "text": "Mật khẩu",
+    "source_hash": "e7cf3ef4"
+  },
+  "web.link_sso.password_placeholder": {
+    "text": "Mật khẩu hiện có của bạn",
+    "source_hash": "ad4e56da"
+  },
+  "web.link_sso.submit": {
+    "text": "Liên kết và tiếp tục",
+    "source_hash": "c969b759"
+  },
+  "web.link_sso.cancel": {
+    "text": "Hủy",
+    "source_hash": "19766ed6"
+  },
+  "web.link_sso.unavailable_title": {
+    "text": "Yêu cầu liên kết này đã hết hạn",
+    "source_hash": "b53c7e55"
+  },
+  "web.link_sso.unavailable_message": {
+    "text": "Vì sự an toàn của bạn, yêu cầu liên kết phương thức đăng nhập này không còn hợp lệ. Đăng nhập bằng mật khẩu hiện có của bạn, sau đó kết nối nhà cung cấp này trong Cài đặt bảo mật → Danh tính đã kết nối.",
+    "source_hash": "f7e349d1"
+  },
+  "web.link_sso.unavailable_action": {
+    "text": "Tiếp tục đăng nhập",
+    "source_hash": "d398cd0a"
+  },
+  "web.link_sso.errors.invalid_password": {
+    "text": "Mật khẩu đó không khớp với tài khoản này. Vui lòng thử lại.",
+    "source_hash": "3259b4f5"
+  },
+  "web.link_sso.errors.invalid_token": {
+    "text": "Yêu cầu liên kết này đã hết hạn hoặc đã được sử dụng. Đăng nhập bằng mật khẩu hiện có của bạn, sau đó kết nối nhà cung cấp này từ cài đặt tài khoản của bạn.",
+    "source_hash": "541f9127"
+  },
+  "web.link_sso.errors.link_conflict": {
+    "text": "Chúng tôi không thể liên kết phương thức đăng nhập này. Tài khoản của bạn có thể đã thay đổi, hoặc nhà cung cấp này đã được liên kết với tài khoản khác. Đăng nhập bằng mật khẩu hiện có của bạn, sau đó quản lý kết nối trong Cài đặt bảo mật → Danh tính đã kết nối.",
+    "source_hash": "7b0e0d0e"
+  },
+  "web.link_sso.errors.link_rate_limited": {
+    "text": "Quá nhiều lần thử mật khẩu. Vui lòng đợi vài phút, sau đó thử lại.",
+    "source_hash": "a95e78cd"
+  },
+  "web.link_sso.errors.invalid_request": {
+    "text": "Chúng tôi không thể xử lý yêu cầu liên kết này. Vui lòng đăng nhập lại bằng nhà cung cấp SSO của bạn.",
+    "source_hash": "053b9fc6"
+  },
+  "web.link_sso.errors.generic": {
+    "text": "Chúng tôi không thể liên kết tài khoản của bạn. Vui lòng thử lại.",
+    "source_hash": "f727c174"
+  },
+  "web.sso_link_confirm.title": {
+    "text": "Xác nhận kết nối tài khoản của bạn",
+    "source_hash": "ad80bfe7"
+  },
+  "web.sso_link_confirm.prompt": {
+    "text": "Bạn đã đăng nhập bằng {provider}, khớp với tài khoản {email} của bạn. Xác nhận để kết nối {provider} với tài khoản này và hoàn tất đăng nhập.",
+    "source_hash": "6ff0d6cc"
+  },
+  "web.sso_link_confirm.submit": {
+    "text": "Xác nhận và kết nối",
+    "source_hash": "5cf663e6"
+  },
+  "web.sso_link_confirm.cancel": {
+    "text": "Hủy",
+    "source_hash": "19766ed6"
+  },
+  "web.sso_link_confirm.unavailable_title": {
+    "text": "Yêu cầu liên kết này không thể hoàn thành",
+    "source_hash": "47abb784"
+  },
+  "web.sso_link_confirm.unavailable_message": {
+    "text": "Vì sự an toàn của bạn, yêu cầu kết nối phương thức đăng nhập này không còn hợp lệ. Đăng nhập lại bằng nhà cung cấp của bạn và chúng tôi sẽ gửi email cho bạn một liên kết mới.",
+    "source_hash": "080e6f9f"
+  },
+  "web.sso_link_confirm.unavailable_action": {
+    "text": "Quay lại đăng nhập",
+    "source_hash": "8504054f"
+  },
+  "web.sso_link_confirm.errors.link_expired": {
+    "text": "Yêu cầu liên kết này đã hết hạn hoặc đã được sử dụng. Đăng nhập lại bằng nhà cung cấp của bạn và chúng tôi sẽ gửi email cho bạn một liên kết mới.",
+    "source_hash": "a50538df"
+  },
+  "web.sso_link_confirm.errors.link_conflict": {
+    "text": "Chúng tôi không thể kết nối phương thức đăng nhập này. Tài khoản của bạn có thể đã thay đổi, hoặc nhà cung cấp này đã được liên kết với tài khoản khác. Đăng nhập lại bằng nhà cung cấp của bạn để tiếp tục.",
+    "source_hash": "c954854b"
+  },
+  "web.sso_link_confirm.errors.link_invalidated": {
+    "text": "Thông tin đăng nhập tài khoản của bạn đã thay đổi sau khi liên kết này được gửi, vì vậy nó không còn hợp lệ. Đăng nhập lại bằng nhà cung cấp của bạn và chúng tôi sẽ gửi email cho bạn một liên kết mới.",
+    "source_hash": "db88cb1d"
+  },
+  "web.sso_link_confirm.errors.link_error": {
+    "text": "Đã xảy ra sự cố ở phía chúng tôi và chúng tôi không thể xác minh liên kết này. Đăng nhập lại bằng nhà cung cấp của bạn và chúng tôi sẽ gửi email cho bạn một liên kết mới.",
+    "source_hash": "ec24e0a1"
+  },
+  "web.sso_link_confirm.errors.confirm_rate_limited": {
+    "text": "Quá nhiều lần thử từ thiết bị của bạn. Vui lòng đợi vài phút, sau đó mở lại liên kết đã gửi qua email hoặc đăng nhập bằng nhà cung cấp của bạn để nhận liên kết mới.",
+    "source_hash": "f29af782"
+  },
+  "web.sso_link_confirm.errors.generic": {
+    "text": "Chúng tôi không thể xác nhận kết nối này. Vui lòng đăng nhập lại bằng nhà cung cấp của bạn.",
+    "source_hash": "076fa25a"
   }
 }

--- a/locales/content/vi/session-auth-extended.json
+++ b/locales/content/vi/session-auth-extended.json
@@ -757,6 +757,7 @@
   },
   "web.auth.connections.connect_action": {
     "text": "Kết nối {provider}",
+    "context": "Button label to start linking a specific SSO provider; {provider} is the provider display name",
     "source_hash": "c77540af"
   },
   "web.auth.connections.issuer": {
@@ -821,6 +822,7 @@
   },
   "web.link_sso.prompt": {
     "text": "Bạn đã đăng nhập bằng {provider}, khớp với tài khoản hiện có {email}. Nhập mật khẩu của tài khoản đó để liên kết {provider} và tiếp tục.",
+    "context": "Instruction on the sign-in interstitial. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/link-sso/:token.",
     "source_hash": "59da1c08"
   },
   "web.link_sso.password_label": {
@@ -881,6 +883,7 @@
   },
   "web.sso_link_confirm.prompt": {
     "text": "Bạn đã đăng nhập bằng {provider}, khớp với tài khoản {email} của bạn. Xác nhận để kết nối {provider} với tài khoản này và hoàn tất đăng nhập.",
+    "context": "Consent instruction on the #3840 Phase 4 mailbox-proof SSO linking page. {provider} is a friendly provider name (e.g. Microsoft Entra); {email} is the claimed account email returned by GET /auth/sso-link-confirm/:token. No password is asked — clicking the emailed link is the proof.",
     "source_hash": "6ff0d6cc"
   },
   "web.sso_link_confirm.submit": {

--- a/locales/content/vi/session-auth.json
+++ b/locales/content/vi/session-auth.json
@@ -483,5 +483,41 @@
   "web.login.verified_notice": {
     "text": "Email của bạn đã được xác minh — bây giờ bạn có thể đăng nhập.",
     "source_hash": "c8d4b5a8"
+  },
+  "web.auth.password_setup_request.title": {
+    "text": "Đặt mật khẩu",
+    "source_hash": "11b6978b"
+  },
+  "web.auth.password_setup_request.description": {
+    "text": "Tài khoản của bạn chưa có mật khẩu. Chúng tôi sẽ gửi email cho bạn một liên kết an toàn để đặt mật khẩu để bạn cũng có thể đăng nhập trực tiếp.",
+    "source_hash": "dc0b561f"
+  },
+  "web.auth.password_setup_request.button": {
+    "text": "Gửi liên kết thiết lập",
+    "source_hash": "22807292"
+  },
+  "web.auth.password_setup_request.emailSent": {
+    "text": "Một email đã được gửi cho bạn với liên kết để đặt mật khẩu cho tài khoản của bạn",
+    "source_hash": "82b686c7"
+  },
+  "web.login.errors.account_exists_link_required": {
+    "text": "Một tài khoản với địa chỉ email này đã tồn tại nhưng chưa được liên kết với phương thức đăng nhập này. Đăng nhập bằng phương thức hiện có của bạn, sau đó liên kết nhà cung cấp này trong Cài đặt bảo mật → Danh tính đã kết nối.",
+    "source_hash": "7fbbb7e7"
+  },
+  "web.login.errors.identity_connect_conflict": {
+    "text": "Không thể kết nối danh tính này. Kết nối có thể đã được bắt đầu trên sai tên miền, hoặc phiên của bạn đã hết hạn. Vui lòng đăng nhập lại, sau đó kết nối nó từ cài đặt tài khoản của bạn.",
+    "source_hash": "4238bbf2"
+  },
+  "web.login.errors.org_join_failed": {
+    "text": "Chúng tôi không thể hoàn tất việc thêm bạn vào tổ chức của bạn. Vui lòng liên hệ quản trị viên của bạn.",
+    "source_hash": "155e71bb"
+  },
+  "web.login.errors.link_sso_failed": {
+    "text": "Chúng tôi không thể liên kết phương thức đăng nhập đó. Đăng nhập bằng mật khẩu hiện có của bạn, sau đó kết nối nhà cung cấp này trong Cài đặt bảo mật → Danh tính đã kết nối.",
+    "source_hash": "49954127"
+  },
+  "web.login.notices.link_verification_sent": {
+    "text": "Kiểm tra hộp thư đến — chúng tôi đã gửi email cho bạn một liên kết để xác nhận kết nối tài khoản của bạn. Mở nó để hoàn tất đăng nhập.",
+    "source_hash": "b251c8f3"
   }
 }

--- a/locales/content/vi/workspace-account.json
+++ b/locales/content/vi/workspace-account.json
@@ -694,5 +694,33 @@
   "web.settings.security.sso_managed_description": {
     "text": "Tài khoản của bạn được xác thực thông qua nhà cung cấp đăng nhập một lần (SSO) của tổ chức. Mật khẩu, xác thực đa yếu tố và mã khôi phục được quản lý bởi nhà cung cấp danh tính của bạn.",
     "source_hash": "cd0cf39f"
+  },
+  "web.settings.api.api_username": {
+    "text": "API Username",
+    "source_hash": "0b3e483e"
+  },
+  "web.settings.api.api_username_description": {
+    "text": "Tên người dùng của bạn cho xác thực HTTP Basic",
+    "source_hash": "f3e65de3"
+  },
+  "web.settings.api.basic_auth_hint": {
+    "text": "Để xác thực HTTP Basic, sử dụng email tài khoản của bạn hoặc ID này làm tên người dùng và API token của bạn làm mật khẩu.",
+    "source_hash": "cfa3806d"
+  },
+  "web.settings.security.set": {
+    "text": "Đã đặt",
+    "source_hash": "b6f6f3ad"
+  },
+  "web.settings.security.not_set": {
+    "text": "Chưa đặt",
+    "source_hash": "4895f731"
+  },
+  "web.settings.security.set_password_title": {
+    "text": "Đặt mật khẩu",
+    "source_hash": "4e411687"
+  },
+  "web.settings.security.set_password_description": {
+    "text": "Thêm mật khẩu vào tài khoản của bạn để bạn cũng có thể đăng nhập mà không cần nhà cung cấp danh tính",
+    "source_hash": "a6970402"
   }
 }

--- a/locales/content/vi/workspace-billing.json
+++ b/locales/content/vi/workspace-billing.json
@@ -1044,5 +1044,21 @@
   "web.billing.plans.reactivate": {
     "text": "Kích hoạt lại",
     "source_hash": "2dc7478f"
+  },
+  "web.billing.currency_migration.refund_failed_warning": {
+    "text": "Gói trước đó của bạn đã bị hủy, nhưng chúng tôi không thể tự động hoàn tiền cho thời gian chưa sử dụng của bạn. Vui lòng liên hệ hỗ trợ để nhận hoàn tiền. Bạn vẫn cần hoàn tất thanh toán để kích hoạt gói mới của bạn.",
+    "source_hash": "a390c498"
+  },
+  "web.billing.currency_migration.refund_failed_continue": {
+    "text": "Tiếp tục thanh toán",
+    "source_hash": "eccdb8aa"
+  },
+  "web.billing.plans.per_year": {
+    "text": "/năm",
+    "source_hash": "a2d5f1bc"
+  },
+  "web.billing.plans.billing_interval": {
+    "text": "Chu kỳ thanh toán",
+    "source_hash": "3ce28209"
   }
 }

--- a/locales/content/vi/workspace-branding.json
+++ b/locales/content/vi/workspace-branding.json
@@ -56,12 +56,12 @@
     "source_hash": "e36598ef"
   },
   "web.branding.example_pre_reveal_instructions": {
-    "text": "Sử dụng điện thoại để quét mã QR",
-    "source_hash": "99ecf59f"
+    "text": "ví dụ: Dùng điện thoại để quét mã QR",
+    "source_hash": "9cf0caf8"
   },
   "web.branding.example_post_reveal_instructions": {
-    "text": "Liên hệ onboarding{'@'}example.com nếu có câu hỏi",
-    "source_hash": "bee120a7"
+    "text": "ví dụ: Liên hệ onboarding{'@'}example.com nếu có câu hỏi",
+    "source_hash": "71749811"
   },
   "web.branding.these_instructions_will_be_shown_to_recipients_before": {
     "text": "Hướng dẫn này sẽ được hiển thị cho người nhận trước khi họ xem nội dung bí mật",
@@ -320,8 +320,8 @@
     "source_hash": "bc79cdff"
   },
   "web.branding.paths_carryover_hint": {
-    "text": "Đây là bản xem trước trực tiếp — thay đổi của bạn sẽ không hiển thị cho khách truy cập cho đến khi bạn lưu.",
-    "source_hash": "cb4b82de"
+    "text": "Đây là bản xem trước trực tiếp — các thay đổi của bạn sẽ không hiển thị cho khách truy cập cho đến khi bạn nhấp Cập nhật.",
+    "source_hash": "9a34df71"
   },
   "web.branding.coming_soon_match_blurb": {
     "text": "Chỉ cho chúng tôi trang web của bạn và chúng tôi sẽ đọc màu sắc cùng phông chữ của nó, rồi thu hẹp khoảng cách chỉ bằng một cú nhấp.",
@@ -406,5 +406,57 @@
   "web.branding.delivery_after_reveal": {
     "text": "Sau khi hiển thị",
     "source_hash": "d5bfe7fd"
+  },
+  "web.branding.favicon": {
+    "text": "Favicon",
+    "source_hash": "42955289"
+  },
+  "web.branding.refresh_favicon": {
+    "text": "Làm mới favicon từ tên miền",
+    "source_hash": "7cc3d5dc"
+  },
+  "web.branding.refresh_favicon_hint": {
+    "text": "Lấy lại favicon từ tên miền của bạn. Biểu tượng mới sẽ xuất hiện sau đó.",
+    "source_hash": "ee007e44"
+  },
+  "web.branding.refresh_favicon_queued": {
+    "text": "Đang làm mới favicon — biểu tượng mới sẽ xuất hiện sau đó.",
+    "source_hash": "6bf38e6e"
+  },
+  "web.branding.refresh_favicon_user_upload_hint": {
+    "text": "Bạn đã tải lên favicon tùy chỉnh, vì vậy biểu tượng được lấy sẽ không thay thế nó.",
+    "source_hash": "c22e1ed6"
+  },
+  "web.branding.upload_favicon": {
+    "text": "Tải lên favicon",
+    "source_hash": "ceda39cb"
+  },
+  "web.branding.replace_favicon": {
+    "text": "Thay thế",
+    "source_hash": "95e15439"
+  },
+  "web.branding.remove_favicon": {
+    "text": "Xóa favicon",
+    "source_hash": "03693698"
+  },
+  "web.branding.favicon_field_hint": {
+    "text": "ICO, PNG hoặc SVG. Tải lên thay thế biểu tượng đã lấy.",
+    "source_hash": "dfa0bfcb"
+  },
+  "web.branding.favicon_preview_alt": {
+    "text": "Favicon tên miền",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_title": {
+    "text": "Favicon tên miền",
+    "source_hash": "db7dca40"
+  },
+  "web.branding.favicon_modal_hint": {
+    "text": "ICO, PNG hoặc SVG. Tối đa 256KB. Thay thế biểu tượng tự động lấy.",
+    "source_hash": "c9eafc83"
+  },
+  "web.branding.favicon_modal_save": {
+    "text": "Lưu favicon",
+    "source_hash": "c8a1566c"
   }
 }

--- a/locales/content/vi/workspace-organizations.json
+++ b/locales/content/vi/workspace-organizations.json
@@ -1034,5 +1034,153 @@
   "web.organizations.create_workspace": {
     "text": "Tạo không gian làm việc",
     "source_hash": "c63c14cf"
+  },
+  "web.organizations.organization_id": {
+    "text": "ID tổ chức",
+    "source_hash": "1f466322"
+  },
+  "web.organizations.organization_id_hint": {
+    "text": "Sử dụng ID này khi liên hệ hỗ trợ hoặc xác định phạm vi yêu cầu API cho tổ chức này. Đây không phải là thông tin đăng nhập.",
+    "source_hash": "29549b3a"
+  },
+  "web.organizations.audit.title": {
+    "text": "Hoạt động bí mật",
+    "source_hash": "6d6d41f3"
+  },
+  "web.organizations.audit.description": {
+    "text": "Nhật ký kiểm tra các sự kiện tạo và truy cập bí mật được ghi lại cho tổ chức này.",
+    "source_hash": "553c564b"
+  },
+  "web.organizations.audit.country_unknown": {
+    "text": "Không xác định",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.empty_title": {
+    "text": "Chưa có hoạt động",
+    "source_hash": "0a12b92c"
+  },
+  "web.organizations.audit.empty_description": {
+    "text": "Các sự kiện tạo và truy cập bí mật sẽ xuất hiện ở đây khi nhóm của bạn chia sẻ bí mật.",
+    "source_hash": "62fb14c2"
+  },
+  "web.organizations.audit.capped_notice": {
+    "text": "Chỉ {max} sự kiện mới nhất được giữ lại; hoạt động cũ hơn đã bị cắt bỏ.",
+    "source_hash": "da7901e2"
+  },
+  "web.organizations.audit.collection_paused_notice": {
+    "text": "Thu thập sự kiện đang tạm dừng; hoạt động bí mật mới không được ghi lại.",
+    "source_hash": "cb09d147"
+  },
+  "web.organizations.audit.load_error": {
+    "text": "Không thể tải hoạt động bí mật.",
+    "source_hash": "52fde814"
+  },
+  "web.organizations.audit.contract_mismatch": {
+    "text": "Dữ liệu hoạt động được máy chủ trả về không thể đọc được. Nhật ký không trống — chỉ là không thể hiển thị ngay bây giờ.",
+    "source_hash": "db0d007a"
+  },
+  "web.organizations.audit.retry": {
+    "text": "Thử lại",
+    "source_hash": "d8b8392e"
+  },
+  "web.organizations.audit.showing_range": {
+    "text": "Hiển thị {from}–{to} của {total}",
+    "source_hash": "c329279d"
+  },
+  "web.organizations.audit.upgrade_prompt": {
+    "text": "Hoạt động bí mật yêu cầu gói có nhật ký kiểm tra. Nâng cấp để xem ai đã tạo, xem và tiết lộ bí mật trong tổ chức này.",
+    "source_hash": "453649ce"
+  },
+  "web.organizations.audit.role_required": {
+    "text": "Hoạt động bí mật có sẵn cho chủ sở hữu và quản trị viên tổ chức.",
+    "source_hash": "e066ec63"
+  },
+  "web.organizations.audit.actors.creator": {
+    "text": "Người tạo",
+    "source_hash": "88447b83"
+  },
+  "web.organizations.audit.actors.authenticated_other": {
+    "text": "Người dùng đã đăng nhập khác",
+    "source_hash": "ee45aa5a"
+  },
+  "web.organizations.audit.actors.anonymous": {
+    "text": "Ẩn danh",
+    "source_hash": "e7a8aa2d"
+  },
+  "web.organizations.audit.actors.system": {
+    "text": "Hệ thống",
+    "source_hash": "6725e7bb"
+  },
+  "web.organizations.audit.actors.unknown": {
+    "text": "Không xác định",
+    "source_hash": "b764cdc0"
+  },
+  "web.organizations.audit.columns.event": {
+    "text": "Sự kiện",
+    "source_hash": "4e1f49a9"
+  },
+  "web.organizations.audit.columns.secret": {
+    "text": "Bí mật",
+    "source_hash": "7e32a729"
+  },
+  "web.organizations.audit.columns.actor": {
+    "text": "Người thực hiện",
+    "source_hash": "449995c4"
+  },
+  "web.organizations.audit.columns.country": {
+    "text": "Quốc gia",
+    "source_hash": "701d021d"
+  },
+  "web.organizations.audit.columns.when": {
+    "text": "Khi nào",
+    "source_hash": "cf9c7aa2"
+  },
+  "web.organizations.audit.kinds.created": {
+    "text": "Đã tạo bí mật",
+    "source_hash": "e4a1e1fd"
+  },
+  "web.organizations.audit.kinds.status_get": {
+    "text": "Đã kiểm tra trạng thái liên kết",
+    "source_hash": "0753f60e"
+  },
+  "web.organizations.audit.kinds.secret_get": {
+    "text": "Đã mở liên kết bí mật",
+    "source_hash": "e271e060"
+  },
+  "web.organizations.audit.kinds.previewed": {
+    "text": "Người tạo đã xem trước",
+    "source_hash": "639fc1e2"
+  },
+  "web.organizations.audit.kinds.creator_status_get": {
+    "text": "Người tạo đã kiểm tra trạng thái",
+    "source_hash": "7e4b5de5"
+  },
+  "web.organizations.audit.kinds.receipt_viewed": {
+    "text": "Đã xem biên nhận",
+    "source_hash": "a417ead4"
+  },
+  "web.organizations.audit.kinds.revealed": {
+    "text": "Đã tiết lộ bí mật",
+    "source_hash": "aff2c84d"
+  },
+  "web.organizations.audit.kinds.burned": {
+    "text": "Đã xóa vĩnh viễn bí mật",
+    "source_hash": "5ac68dc6"
+  },
+  "web.organizations.audit.kinds.expired": {
+    "text": "Bí mật đã hết hạn",
+    "source_hash": "c127dab6"
+  },
+  "web.organizations.audit.kinds.orphaned": {
+    "text": "Bí mật bị mồ côi",
+    "source_hash": "23fe1a47"
+  },
+  "web.organizations.audit.kinds.reveal_failed_undecryptable": {
+    "text": "Tiết lộ thất bại (không thể giải mã)",
+    "source_hash": "d5616abf"
+  },
+  "web.organizations.tabs.activity": {
+    "text": "Hoạt động",
+    "source_hash": "38da1505"
   }
 }


### PR DESCRIPTION
## `vi` translation update

Automated export of completed **vi** translations from the translation task DB.
Scope: `locales/content/vi/` only — 16 file(s), +2020/-20.

⚠️ `i18n validate variables` reports **3** variable mismatch(es) for `vi` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

_Automated review did not complete (exit 1). See `locales/reviews/2026-08-09-2004/vi.stderr` for the error and `locales/reviews/2026-08-09-2004/vi.raw.txt` for any partial output._

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
