### PR TITLE
Update rodauth to 2.45.0 and rodauth-tools to 0.4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,7 +376,7 @@ GEM
       tilt (~> 2)
     roda (3.106.0)
       rack
-    rodauth (2.44.0)
+    rodauth (2.45.0)
       roda (>= 2.6.0)
       sequel (>= 4)
     rodauth-omniauth (0.6.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,7 +382,7 @@ GEM
     rodauth-omniauth (0.6.2)
       omniauth (~> 2.0)
       rodauth (~> 2.36)
-    rodauth-tools (0.4.0)
+    rodauth-tools (0.4.1)
       dry-inflector (~> 1.1)
       rodauth (~> 2.41)
       sequel (~> 5.0)

--- a/apps/web/auth/config/hooks/account.rb
+++ b/apps/web/auth/config/hooks/account.rb
@@ -541,7 +541,7 @@ module Auth::Config::Hooks
           # Durable follow-up (#3810): enqueue the async FULL sweep — including
           # the untracked keyspace scan the in-transaction revoke below skips —
           # once the reset actually COMMITS. First use of Sequel's after_commit in
-          # this codebase: Rodauth 2.44 runs this hook INSIDE its reset
+          # this codebase: Rodauth 2.45 runs this hook INSIDE its reset
           # transaction, and after_commit defers the block until commit (skipped
           # entirely on rollback; yields immediately when no transaction is open).
           # Registered BEFORE the inline revoke so the sweep is enqueued even when

--- a/apps/web/auth/config/hooks/create_account.rb
+++ b/apps/web/auth/config/hooks/create_account.rb
@@ -32,7 +32,7 @@ require 'onetime/security/create_account_rate_limiter'
 # before_create_account, which is a different hook AND fires too late for this
 # purpose — it runs inside the create-account POST body, after Rodauth has
 # begun processing the submission. before_create_account_route fires at the top
-# of the route (rodauth-2.44.0/lib/rodauth/features/create_account.rb:35),
+# of the route (rodauth-2.45.0/lib/rodauth/features/create_account.rb:35),
 # ahead of the db[:accounts] lookup at hooks/account.rb:67 and the
 # Onetime::Customer.email_exists? call at :92, which is the
 # "before any account lookup or write" ordering the limiter's header asserts.
@@ -60,7 +60,7 @@ require 'onetime/security/create_account_rate_limiter'
 # INTERNAL REQUESTS ARE EXCLUDED, EXPLICITLY. :internal_request is enabled
 # (config/base.rb), and handle_internal_request runs this same route block with
 # a SYNTHESIZED env whose REQUEST_METHOD is 'POST'
-# (rodauth-2.44.0/lib/rodauth/features/internal_request.rb:325) — so a bare
+# (rodauth-2.45.0/lib/rodauth/features/internal_request.rb:325) — so a bare
 # `request.post?` guard does NOT exclude it. The affected caller is the
 # invite-signup path (Auth::Config.create_account in
 # apps/api/invite/logic/invites/signup_and_accept.rb), which is already

--- a/apps/web/auth/config/overrides/reset_password_enumeration.rb
+++ b/apps/web/auth/config/overrides/reset_password_enumeration.rb
@@ -21,7 +21,7 @@
 # it shadows the enumeration-safe custom endpoint in apps/web/core (mounted at
 # `/`).
 #
-# Stock Rodauth 2.44.0 (lib/rodauth/features/reset_password.rb, the
+# Stock Rodauth 2.45.0 (lib/rodauth/features/reset_password.rb, the
 # reset_password_request route) distinguishes "account exists" from "no account"
 # on that request path in THREE ways, each an account-existence oracle (CWE-204):
 #
@@ -64,7 +64,7 @@
 # would fail OPEN (re-expose the oracle) rather than crash — so the enumeration
 # regression spec
 # (apps/web/auth/spec/integration/full/reset_password_request_enumeration_spec.rb)
-# is the guard that must catch such a change. Pinned against Rodauth 2.44.0.
+# is the guard that must catch such a change. Pinned against Rodauth 2.45.0.
 #
 # RESIDUAL: TIMING SIDE-CHANNEL (accepted, not closed)
 # ----------------------------------------------------
@@ -106,7 +106,7 @@ module Auth::Config::Overrides
     def self.configure(auth)
       auth_class = auth.instance_variable_get(:@auth)
       # Rodauth exposes the enabled feature symbols via the public `features`
-      # reader on the auth class (Rodauth 2.44.0). reset_password_email_sent_response
+      # reader on the auth class (Rodauth 2.45.0). reset_password_email_sent_response
       # and the two reset-request predicates only exist when :reset_password is
       # enabled, so there is nothing to harden otherwise; the safe-navigation guards
       # also make this a no-op if `features` is ever unavailable.

--- a/apps/web/auth/routes/link_sso.rb
+++ b/apps/web/auth/routes/link_sso.rb
@@ -284,7 +284,7 @@ module Auth
             # `.defer` and the login proceeds unlinked (fail-closed).
             #
             # VERSION-SENSITIVE: that block position is Rodauth internals (verified
-            # against rodauth 2.44.0, base.rb #login). If an upgrade moves the block
+            # against rodauth 2.45.0, login.rb #login). If an upgrade moves the block
             # relative to login_session/after_login, the stash is keyed to a
             # destroyed sid or written too late — caught by the end-to-end example
             # in spec/integration/full_mfa/ (the deferred bind would never land).

--- a/apps/web/auth/spec/integration/full/create_account_rate_limit_spec.rb
+++ b/apps/web/auth/spec/integration/full/create_account_rate_limit_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe 'Account-creation rate limiting — full mode (#3948 finding #4)'
     # Assert the source_location, not merely that the method is defined:
     # Rodauth's `before` definer class_evals a `def _before_create_account_route;
     # nil end` stub for every class carrying the :create_account feature
-    # (rodauth-2.44.0/lib/rodauth.rb:257), so `private_method_defined?` is true
+    # (rodauth-2.45.0/lib/rodauth.rb:278), so `private_method_defined?` is true
     # whether or not we registered anything. The file the method actually came
     # from is the part that discriminates.
     expect(Auth::Config.ancestors).to include(Onetime::Security::CreateAccountRateLimiter)


### PR DESCRIPTION
## Summary

Stacked on #4108 (`claude/omniauth-strategy-integration-vxi38r`) — merge that first; this PR's diff is only the dependency update on top of it.

Updates roda, rodauth, rodauth-omniauth and omniauth to their latest releases. Three of the four were already there, so `bundle lock --update roda rodauth rodauth-omniauth omniauth --conservative` moves exactly one line:

| Gem | Before | After |
| --- | --- | --- |
| roda | 3.106.0 | 3.106.0 (already latest) |
| **rodauth** | **2.44.0** | **2.45.0** |
| rodauth-omniauth | 0.6.2 | 0.6.2 (already latest) |
| omniauth | 2.1.4 | 2.1.4 (already latest) |
| **rodauth-tools** | **0.4.0** | **0.4.1** |

`--conservative` keeps rodauth's transitive dependencies pinned — without it the resolver also pulls sequel 5.106.0 → 5.107.0, which is out of scope for this PR.

Gemfile constraints are unchanged: `rodauth '~> 2.0'` already admits 2.45.0 and `rodauth-tools '~> 0.4.0'` already admits 0.4.1, so both bumps are lockfile-only. Nothing here depends on 2.45-only behavior, so tightening the floor would be noise.

### Re-verified pin annotations

This app carries several comments pinning against specific rodauth internals. Each was re-checked against 2.45.0 and the version it names updated to the version it was actually checked against:

- `lib/rodauth.rb`'s `before`/`after` definer still `class_eval`s the `def _before_; nil end` stub — now at `:278` (was `:257`; 2.45.0 inserted the feature-definition audit above it).
- `create_account.rb:35` (`before_create_account_route` at the top of the route) and `internal_request.rb:325` (the synthesized `'POST'` REQUEST_METHOD) are byte-identical in 2.45.0.
- `reset_password.rb`'s request route still distinguishes the three enumeration oracles the overrides in `config/overrides/reset_password_enumeration.rb` neutralise, and `reset_password_email_sent_response` still halts — the HALT CONTRACT those overrides depend on holds. The only 2.45.0 change to that file extracts `get_reset_password_key` out of `get_password_reset_key`, which this app does not configure.
- `after_reset_password` still runs inside the reset `transaction do` block, so the `db.after_commit` sweep in `hooks/account.rb` still defers to commit.
- The block `login` yields between `login_session` and `after_login` is unchanged. Also corrected the file reference in `routes/link_sso.rb` — `#login` lives in `login.rb`, never in `base.rb`.

Two further 2.45.0 changes, neither of which touches this app: `convert_token_id` moved from `auth_private_methods` to `auth_methods` (not configured here, and rodauth-tools' `account_id_obfuscation` deliberately leaves it alone), and `transaction` now merges a new `transaction_opts` that defaults to empty.

### Boot warnings resolved

rodauth 2.45.0 warned twice on boot that rodauth-tools' `table_guard` didn't define `_table_configuration` / `_column_requirements` privately. That's fixed in rodauth-tools 0.4.1 (delano/rodauth-tools#142), now published and picked up here, so the boot output is clean again.

Verified in both directions — requiring `rodauth/features/table_guard` emits both warnings under 0.4.0 and none under 0.4.1:

```
$ ruby -e 'gem "rodauth-tools", "0.4.0"; require "rodauth"; require "rodauth/features/table_guard"'
Bug in Rodauth table_guard feature definition, configuration method added for _table_configuration, but the feature doesn't define the method
Bug in Rodauth table_guard feature definition, configuration method added for _column_requirements, but the feature doesn't define the method

$ ruby -e 'gem "rodauth-tools", "0.4.1"; require "rodauth"; require "rodauth/features/table_guard"'
(no output)
```

Upstream marks that warning `RODAUTH3: raise instead of warn`, so this would have become a load-time error rather than stderr noise in the next major release.

## Related Issues

None — dependency maintenance.

## Test Plan

Run against ruby 3.4.10 with rodauth 2.45.0 installed:

| Suite | Result |
| --- | --- |
| `rake spec:apps:web_auth` | 1097 examples, 0 failures |
| `rspec apps/web/auth/spec/integration/full` | 397 examples, 0 failures, 4 pending (all expected) |
| `rake spec:integration:full:mfa` | 5 examples, 0 failures |
| `rake spec:integration:full` | 1595 examples, 3 failures |
| `rake spec:unit spec:apps:all` | 3516 examples, 1 failure |

The 4 failures are container artifacts, not regressions — all 4 reproduce identically with rodauth 2.44.0 installed:

- 3 in `spec/integration/all/config/after_load_spec.rb` — `raise_concerns` rejects `development.enabled` because no Vite frontend was built in this container.
- 1 in `spec/unit` (`Mailer.provider_credentials` SES) — the sandbox proxy injects `AWS_ACCESS_KEY_ID=proxy-injected`, which the spec's fixture values then don't match.

PostgreSQL lanes were not run (no PG service in this container).

### Re-run after the rodauth-tools 0.4.1 bump

| Suite | Result |
| --- | --- |
| `rake spec:apps:web_auth` | 1097 examples, 0 failures |
| `rspec apps/web/auth/spec/integration/full` | 397 examples, 0 failures, 84 pending |

The higher pending count in this run is environmental, not a change in behavior: the same suite on 0.4.0 in the same container reports an identical 397 / 0 / 84. All 80 additional skips are OmniAuth route-registration guards (`OmniAuth route not registered (OIDC discovery not available at boot)`) — no OIDC discovery endpoint is reachable from this container, so those routes never register.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjS25g5mca3H1Um7s7eW8f)_