### PR TITLE
fix(jobs): write provider_dns_data before dirtying scalar fields

### DIFF
--- a/lib/onetime/jobs/workers/domain_validation_worker.rb
+++ b/lib/onetime/jobs/workers/domain_validation_worker.rb
@@ -203,6 +203,23 @@ module Onetime
                 end
               end
 
+              # Persist the provider's current domain status back into provider_dns_data
+              # so the UI can surface it (e.g. 'verified', 'pending_verification').
+              #
+              # provider_dns_data is a jsonkey (its own Redis key), so this writes
+              # immediately. It must happen BEFORE the scalar assignments below:
+              # Familia 2.12 warns when a related key is written while the parent
+              # holds unsaved scalar fields. Same ordering as DnsRecordCheckWorker.
+              if provider_result
+                current_provider_data                 = mailer_config.provider_dns_data.value || {}
+                provider_records                      = provider_result.dig(:details, :dns_records) || []
+                mailer_config.provider_dns_data.value = current_provider_data.merge(
+                  'status' => provider_result[:status],
+                  'dns_records' => provider_records,
+                  'raw_provider_response' => provider_result[:details],
+                )
+              end
+
               # Set provider_verified from provider API check when available.
               # Fall back to DNS result only when no provider credentials exist
               # (degraded mode - better than leaving nil).
@@ -214,18 +231,6 @@ module Onetime
 
               # Record provider status when verification fails so UI can explain why
               mailer_config.last_error = provider_api_verified == false && provider_result ? "Provider status: #{provider_result[:status]}" : nil
-
-              # Persist the provider's current domain status back into provider_dns_data
-              # so the UI can surface it (e.g. 'verified', 'pending_verification').
-              if provider_result
-                current_provider_data                 = mailer_config.provider_dns_data.value || {}
-                provider_records                      = provider_result.dig(:details, :dns_records) || []
-                mailer_config.provider_dns_data.value = current_provider_data.merge(
-                  'status' => provider_result[:status],
-                  'dns_records' => provider_records,
-                  'raw_provider_response' => provider_result[:details],
-                )
-              end
 
               mailer_config.provider_check_status       = JobLifecycle::COMPLETED
               mailer_config.provider_check_completed_at = Familia.now.to_i


### PR DESCRIPTION
`DomainValidationWorker` assigned `provider_verified` and `last_error` before writing the `provider_dns_data` jsonkey, so the related-key write landed while the parent `MailerConfig` still held unsaved scalar fields. Familia 2.12's `DataType#warn_if_dirty!` fires on exactly that pattern, so every provider check that returns a result emits a dirty-write warning (mode `:once`, deduped per dirty signature). Under `Familia.strict_write_order` it would raise instead and abort the provider block.

Moves the jsonkey write above the scalar assignments — the ordering `DnsRecordCheckWorker` already uses. The `ValidateSenderDomain` call in between runs with `persist: false` and gates every mutation behind that flag, so the parent is clean at the moved write.

Behavior is otherwise unchanged: same values written, same `save_fields` call, and `provider_result` is still assigned textually before its use.

Verified: `tests/lanes/run unit` green (7667 tryouts + 352 specs, 0 failures); rubocop clean.