### PR TITLE
fix(router): keep SSO interstitials and MFA reachable in SSO-only mode

### DIFF
--- a/apps/web/core/routes.txt
+++ b/apps/web/core/routes.txt
@@ -17,6 +17,7 @@ GET   /signup                                    Core::Controllers::Page#index a
 GET   /signup/*                                  Core::Controllers::Page#index auth=noauth
 GET   /check-email                               Core::Controllers::Page#index auth=noauth
 GET   /pricing                                   Core::Controllers::Page#index auth=noauth
+GET   /pricing/*                                 Core::Controllers::Page#index auth=noauth
 GET   /forgot                                    Core::Controllers::Page#index auth=noauth
 GET   /forgot/:key                               Core::Controllers::Page#index auth=noauth
 GET   /reset-password                            Core::Controllers::Page#index auth=noauth
@@ -44,6 +45,11 @@ GET   /i/*                                  Core::Controllers::Page#index auth=n
 GET   /verify-account                            Core::Controllers::Page#index
 GET   /email-login                               Core::Controllers::Page#index
 GET   /mfa-verify                                Core::Controllers::Page#index
+# SSO account-linking interstitials (#3840 Phases 3+4). Entered by full-page
+# load (backend redirect / emailed link), so they need explicit entries — the
+# SPA not-found fallback would serve the shell with a 404 status.
+GET   /link-sso/*                                Core::Controllers::Page#index
+GET   /sso-link-confirm/*                        Core::Controllers::Page#index
 
 # Bootstrap endpoint - returns initialization data for the current session
 GET   /bootstrap/me                              Core::Controllers::Page#bootstrap_me auth=noauth

--- a/spec/integration/all/routes_spec.rb
+++ b/spec/integration/all/routes_spec.rb
@@ -72,6 +72,24 @@ RSpec.describe 'routes_try', type: :integration do
     expect(result).to eq([302, "/signin"])
   end
 
+  # SSO account-linking interstitials (#3840 Phases 3+4) are entered by
+  # full-page load (backend redirect / emailed link). Without explicit
+  # routes.txt entries the SPA shell is still served — but via the not-found
+  # fallback with a 404 status. Pin the explicit 200.
+  it 'serves the SPA shell with 200 for the SSO linking interstitials' do
+    %w[/link-sso/sampletoken /sso-link-confirm/sampletoken].each do |path|
+      response = @mock_request.get(path)
+      expect(response.status).to eq(200), "#{path} responded #{response.status}"
+    end
+  end
+
+  # Pricing deep links exist FOR external full-page loads
+  # (/pricing/:product/:interval) — same explicit-entry requirement.
+  it 'serves the SPA shell with 200 for pricing deep links' do
+    response = @mock_request.get('/pricing/identity_plus/month')
+    expect(response.status).to eq(200)
+  end
+
   it 'Disable authentication for all routes' do
     result = begin
       old_conf = OT.instance_variable_get(:@conf)

--- a/src/apps/session/routes.ts
+++ b/src/apps/session/routes.ts
@@ -161,6 +161,11 @@ const routes: Array<RouteRecordRaw> = [
       sentryScrubParams: false,
     },
   },
+  // NO excludeSsoOnly: MFA is flow-agnostic — an SSO sign-in can also demand a
+  // second factor (the /sso-link-confirm POST returns mfa_required and hands
+  // off here). Excluding it in SSO-only mode is worse than a dead end: the
+  // ssoOnly guard bounces /mfa-verify -> /signin while handleMfaAccess bounces
+  // /signin -> /mfa-verify for awaitingMfa users — an infinite redirect loop.
   {
     path: '/mfa-verify',
     name: 'MFA Verify',
@@ -170,7 +175,6 @@ const routes: Array<RouteRecordRaw> = [
       requiresAuth: false,
       isAuthRoute: true,
       requiresFeature: 'signin',
-      excludeSsoOnly: true,
       layout: AuthLayout,
       layoutProps: {
         displayMasthead: false,
@@ -190,6 +194,11 @@ const routes: Array<RouteRecordRaw> = [
   // (another post-credential, pre-fully-authenticated interstitial), EXCEPT the
   // token is sensitive: sentryScrubParams: ['token'] redacts it from diagnostics
   // (mfa-verify has no path param, so it opts out with `false`).
+  //
+  // NO excludeSsoOnly: this interstitial IS the SSO flow. SSO-only installs
+  // (restrict_to='sso') are the one mode guaranteed to need it — excluding it
+  // bounces the user to /signin before the page can mount (the bug that
+  // motivated sso-only-reachability.spec.ts).
   {
     path: '/link-sso/:token',
     name: 'Link SSO',
@@ -199,7 +208,6 @@ const routes: Array<RouteRecordRaw> = [
       requiresAuth: false,
       isAuthRoute: true,
       requiresFeature: 'signin',
-      excludeSsoOnly: true,
       layout: AuthLayout,
       layoutProps: {
         displayMasthead: false,
@@ -220,6 +228,9 @@ const routes: Array<RouteRecordRaw> = [
   // ['token'] redacts it from diagnostics. Meta mirrors /link-sso (another
   // post-issuance, pre-fully-authenticated interstitial); the GET is display-only
   // and the mutating confirm is an explicit user action (never auto-POST on load).
+  //
+  // NO excludeSsoOnly: same invariant as /link-sso — this consent page IS the
+  // SSO flow and must stay reachable in SSO-only mode.
   {
     path: '/sso-link-confirm/:token',
     name: 'SSO Link Confirm',
@@ -229,7 +240,6 @@ const routes: Array<RouteRecordRaw> = [
       requiresAuth: false,
       isAuthRoute: true,
       requiresFeature: 'signin',
-      excludeSsoOnly: true,
       layout: AuthLayout,
       layoutProps: {
         displayMasthead: false,

--- a/src/apps/session/routes.ts
+++ b/src/apps/session/routes.ts
@@ -16,6 +16,7 @@ const routes: Array<RouteRecordRaw> = [
       requiresAuth: false,
       isAuthRoute: true,
       requiresFeature: 'signin',
+      requiredInSsoOnly: true,
       layout: AuthLayout,
       layoutProps: {
         displayMasthead: false,
@@ -161,11 +162,6 @@ const routes: Array<RouteRecordRaw> = [
       sentryScrubParams: false,
     },
   },
-  // NO excludeSsoOnly: MFA is flow-agnostic — an SSO sign-in can also demand a
-  // second factor (the /sso-link-confirm POST returns mfa_required and hands
-  // off here). Excluding it in SSO-only mode is worse than a dead end: the
-  // ssoOnly guard bounces /mfa-verify -> /signin while handleMfaAccess bounces
-  // /signin -> /mfa-verify for awaitingMfa users — an infinite redirect loop.
   {
     path: '/mfa-verify',
     name: 'MFA Verify',
@@ -175,6 +171,7 @@ const routes: Array<RouteRecordRaw> = [
       requiresAuth: false,
       isAuthRoute: true,
       requiresFeature: 'signin',
+      requiredInSsoOnly: true,
       layout: AuthLayout,
       layoutProps: {
         displayMasthead: false,
@@ -194,11 +191,6 @@ const routes: Array<RouteRecordRaw> = [
   // (another post-credential, pre-fully-authenticated interstitial), EXCEPT the
   // token is sensitive: sentryScrubParams: ['token'] redacts it from diagnostics
   // (mfa-verify has no path param, so it opts out with `false`).
-  //
-  // NO excludeSsoOnly: this interstitial IS the SSO flow. SSO-only installs
-  // (restrict_to='sso') are the one mode guaranteed to need it — excluding it
-  // bounces the user to /signin before the page can mount (the bug that
-  // motivated sso-only-reachability.spec.ts).
   {
     path: '/link-sso/:token',
     name: 'Link SSO',
@@ -208,6 +200,7 @@ const routes: Array<RouteRecordRaw> = [
       requiresAuth: false,
       isAuthRoute: true,
       requiresFeature: 'signin',
+      requiredInSsoOnly: true,
       layout: AuthLayout,
       layoutProps: {
         displayMasthead: false,
@@ -228,9 +221,6 @@ const routes: Array<RouteRecordRaw> = [
   // ['token'] redacts it from diagnostics. Meta mirrors /link-sso (another
   // post-issuance, pre-fully-authenticated interstitial); the GET is display-only
   // and the mutating confirm is an explicit user action (never auto-POST on load).
-  //
-  // NO excludeSsoOnly: same invariant as /link-sso — this consent page IS the
-  // SSO flow and must stay reachable in SSO-only mode.
   {
     path: '/sso-link-confirm/:token',
     name: 'SSO Link Confirm',
@@ -240,6 +230,7 @@ const routes: Array<RouteRecordRaw> = [
       requiresAuth: false,
       isAuthRoute: true,
       requiresFeature: 'signin',
+      requiredInSsoOnly: true,
       layout: AuthLayout,
       layoutProps: {
         displayMasthead: false,

--- a/src/router/guards.routes.ts
+++ b/src/router/guards.routes.ts
@@ -225,6 +225,12 @@ function handleDisabledAuthFeature(to: RouteLocationNormalized) {
  * Authenticated routes redirect to '/account' (profile page).
  * Unauthenticated routes redirect to '/signin' (SSO sign-in page).
  * Note: /signin is explicitly excluded to prevent redirect loops.
+ *
+ * The flag must never appear on routes the SSO flow itself traverses
+ * (/mfa-verify, /link-sso, /sso-link-confirm) — this guard runs BEFORE
+ * handleMfaAccess, so an excluded /mfa-verify plus awaitingMfa produces an
+ * infinite /signin <-> /mfa-verify redirect loop. The full route/flag matrix
+ * is pinned by src/tests/router/sso-only-reachability.spec.ts.
  */
 export function handleSsoOnlyRoute(to: RouteLocationNormalized) {
   if (!to.meta.excludeSsoOnly) return null;

--- a/src/router/guards.routes.ts
+++ b/src/router/guards.routes.ts
@@ -224,18 +224,33 @@ function handleDisabledAuthFeature(to: RouteLocationNormalized) {
  *
  * Authenticated routes redirect to '/account' (profile page).
  * Unauthenticated routes redirect to '/signin' (SSO sign-in page).
- * Note: /signin is explicitly excluded to prevent redirect loops.
+ * Note: /signin stays reachable because it carries `requiredInSsoOnly` and
+ * early-returns below; the explicit path check further down is only a
+ * backstop against a self-redirect loop should that flag ever be stripped
+ * from /signin.
  *
- * The flag must never appear on routes the SSO flow itself traverses
- * (/mfa-verify, /link-sso, /sso-link-confirm) — this guard runs BEFORE
- * handleMfaAccess, so an excluded /mfa-verify plus awaitingMfa produces an
- * infinite /signin <-> /mfa-verify redirect loop. The full route/flag matrix
- * is pinned by src/tests/router/sso-only-reachability.spec.ts.
+ * Routes marked `meta.requiredInSsoOnly: true` (the SSO flow itself and its
+ * MFA continuation) are always allowed through, with precedence over
+ * `excludeSsoOnly` — see the RouteMeta docs in src/types/router.ts. The full
+ * route/flag matrix is pinned by src/tests/router/sso-only-reachability.spec.ts.
  */
 export function handleSsoOnlyRoute(to: RouteLocationNormalized) {
+  // Precedence over excludeSsoOnly — see requiredInSsoOnly in src/types/router.ts.
+  if (to.meta.requiredInSsoOnly) {
+    if (import.meta.env.DEV && to.meta.excludeSsoOnly) {
+      loggingService.warn(
+        '[RouterGuard] Route sets both requiredInSsoOnly and excludeSsoOnly ' +
+          '— configuration error; requiredInSsoOnly wins. Remove ' +
+          'excludeSsoOnly (see RouteMeta in src/types/router.ts).',
+        { path: to.path }
+      );
+    }
+    return null;
+  }
   if (!to.meta.excludeSsoOnly) return null;
   if (!isSsoOnlyMode()) return null;
-  // Prevent redirect loop: never redirect /signin to itself
+  // Backstop only: /signin normally early-returns via requiredInSsoOnly above;
+  // this keeps a self-redirect loop impossible if that flag is ever stripped.
   if (to.path === '/signin') return null;
 
   loggingService.debug(

--- a/src/tests/router/guards.routes.spec.ts
+++ b/src/tests/router/guards.routes.spec.ts
@@ -18,6 +18,7 @@ import {
   setupRouterGuards,
   validateAuthentication,
 } from '@/router/guards.routes';
+import { loggingService } from '@/services/logging.service';
 import { useAuthStore } from '@/shared/stores';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { useOrganizationStore } from '@/shared/stores/organizationStore';
@@ -881,6 +882,52 @@ describe('Router Guards', () => {
 
         const result = handleSsoOnlyRoute(to);
         expect(result).toEqual({ path: '/signin' });
+      });
+    });
+
+    describe('requiredInSsoOnly precedence', () => {
+      // Precedence over excludeSsoOnly — see requiredInSsoOnly in
+      // src/types/router.ts. No real route carries both flags (the sweep spec
+      // forbids the combination), so the double-flag case uses a synthetic
+      // route location.
+
+      it('allows a requiredInSsoOnly route when SSO-only mode is active', () => {
+        vi.mocked(isSsoOnlyMode).mockReturnValue(true);
+
+        const to = makeRoute({
+          meta: { requiredInSsoOnly: true },
+          path: '/sso-link-confirm/abc123',
+          name: 'SSO Link Confirm',
+        });
+
+        const result = handleSsoOnlyRoute(to);
+        expect(result).toBeNull();
+      });
+
+      it('allows a synthetic double-flagged route (requiredInSsoOnly wins) and warns via loggingService', () => {
+        vi.mocked(isSsoOnlyMode).mockReturnValue(true);
+        vi.mocked(useAuthStore).mockReturnValue({
+          isFullyAuthenticated: false,
+        } as ReturnType<typeof useAuthStore>);
+        const warnSpy = vi
+          .spyOn(loggingService, 'warn')
+          .mockImplementation(() => {});
+
+        // Without the precedence early-return this would redirect to /signin.
+        const to = makeRoute({
+          meta: { requiredInSsoOnly: true, excludeSsoOnly: true },
+          path: '/mfa-verify',
+          name: 'MFA Verify',
+        });
+
+        const result = handleSsoOnlyRoute(to);
+        expect(result).toBeNull();
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('requiredInSsoOnly'),
+          { path: '/mfa-verify' }
+        );
+
+        warnSpy.mockRestore();
       });
     });
   });

--- a/src/tests/router/sso-only-reachability.spec.ts
+++ b/src/tests/router/sso-only-reachability.spec.ts
@@ -1,0 +1,211 @@
+// src/tests/router/sso-only-reachability.spec.ts
+//
+// Reachability matrix for SSO-only mode (restrict_to='sso') — regression pin
+// for the fix/4107 SSO-linking bug where /sso-link-confirm/:token and
+// /link-sso/:token carried excludeSsoOnly (meta copied from a sibling route),
+// so the one mode guaranteed to need the SSO interstitials bounced them to
+// /signin before the consent page could mount. Both failure modes were silent:
+// nothing forced a per-route decision on the flag, and nothing cross-checked
+// the backend route table. This suite makes both loud:
+//
+//  1. EXCLUDED_IN_SSO_ONLY is the single expected set of paths carrying
+//     excludeSsoOnly, checked exhaustively in BOTH directions — a route
+//     gaining or losing the flag fails until this matrix is updated
+//     deliberately.
+//  2. A tripwire pins the routes the SSO flow itself traverses as never
+//     excluded, independent of the matrix — so even a careless edit to
+//     EXCLUDED_IN_SSO_ONLY cannot re-open the hole.
+//  3. Every session-app route must have an explicit GET entry in
+//     apps/web/core/routes.txt: these routes are entered by full-page load
+//     (emailed links, backend redirects), and a missing entry silently
+//     degrades to the SPA not-found fallback — shell renders, status is 404.
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import { describe, expect, it, vi } from 'vitest';
+import { RouteRecordRaw } from 'vue-router';
+
+// public.routes.ts reads bootstrapStore in route guards; give it a store
+// before import (same posture as public.routes.spec.ts).
+setActivePinia(
+  createTestingPinia({
+    createSpy: vi.fn,
+    stubActions: false,
+    initialState: {
+      bootstrap: {
+        authenticated: false,
+        domain_strategy: 'canonical',
+        ui: { enabled: true },
+        authentication: { required: false },
+        homepage_mode: null,
+      },
+    },
+  })
+);
+
+const { default: sessionRoutes } = await import('@/apps/session/routes');
+const { default: publicRoutes } = await import('@/router/public.routes');
+
+interface FlatRoute {
+  path: string;
+  meta: Record<string, unknown>;
+}
+
+/**
+ * Flatten a route table to matchable leaves, merging parent meta into
+ * children the way vue-router's `to.meta` does at navigation time (the
+ * guard reads the MERGED meta, so a flag on a parent covers its children).
+ */
+function flatten(
+  routes: readonly RouteRecordRaw[],
+  parentPath = '',
+  parentMeta: Record<string, unknown> = {}
+): FlatRoute[] {
+  return routes.flatMap((route) => {
+    const path = joinPaths(parentPath, route.path);
+    const meta = { ...parentMeta, ...(route.meta ?? {}) };
+    if (route.children?.length) return flatten(route.children, path, meta);
+    return [{ path, meta }];
+  });
+}
+
+function joinPaths(parent: string, child: string): string {
+  if (!parent) return child;
+  if (!child) return parent;
+  return `${parent.replace(/\/+$/, '')}/${child.replace(/^\/+/, '')}`;
+}
+
+const sessionFlat = flatten(sessionRoutes);
+const publicFlat = flatten(publicRoutes);
+const allFlat = [...sessionFlat, ...publicFlat];
+
+// ── 1. The exhaustive exclusion matrix ────────────────────────────────────
+//
+// Every path expected to carry excludeSsoOnly, and ONLY those. All are
+// password/self-serve surface: routes that only make sense when password
+// authentication (or self-serve signup/billing) is available.
+const EXCLUDED_IN_SSO_ONLY = new Set([
+  // session app — password-flow surface
+  '/signup',
+  '/signup/:planCode',
+  '/forgot',
+  '/check-email',
+  '/verify-account',
+  '/email-login',
+  '/reset-password',
+  // public app — self-serve billing surface
+  '/pricing',
+  '/pricing/:product',
+  '/pricing/:product/:interval',
+]);
+
+// ── 2. The tripwire: routes the SSO flow itself traverses ─────────────────
+//
+// /signin hosts the SSO buttons; /mfa-verify handles the second factor an
+// SSO sign-in can demand (excluding it also loops: handleSsoOnlyRoute runs
+// before handleMfaAccess, so awaitingMfa ping-pongs /signin <-> /mfa-verify);
+// the two interstitials are the #3840 account-linking consent pages reached
+// mid-SSO-sign-in.
+const SSO_FLOW_PATHS = [
+  '/signin',
+  '/mfa-verify',
+  '/link-sso/:token',
+  '/sso-link-confirm/:token',
+];
+
+describe('SSO-only mode reachability', () => {
+  it('every route matches the expected excludeSsoOnly matrix (both directions)', () => {
+    for (const { path, meta } of allFlat) {
+      const expected = EXCLUDED_IN_SSO_ONLY.has(path);
+      expect(
+        Boolean(meta.excludeSsoOnly),
+        `${path}: excludeSsoOnly should be ${expected}. If this change is ` +
+          `deliberate, update EXCLUDED_IN_SSO_ONLY in this spec — and never ` +
+          `exclude a route the SSO flow itself needs (see SSO_FLOW_PATHS).`
+      ).toBe(expected);
+    }
+  });
+
+  it('the exclusion matrix contains no stale paths', () => {
+    const knownPaths = new Set(allFlat.map((r) => r.path));
+    for (const path of EXCLUDED_IN_SSO_ONLY) {
+      expect(
+        knownPaths.has(path),
+        `EXCLUDED_IN_SSO_ONLY lists ${path}, which no longer exists — ` +
+          `remove or update the entry`
+      ).toBe(true);
+    }
+  });
+
+  it('SSO-flow routes exist and are never excluded in SSO-only mode', () => {
+    for (const path of SSO_FLOW_PATHS) {
+      const route = allFlat.find((r) => r.path === path);
+      expect(route, `${path} must exist — the SSO flow depends on it`).toBeDefined();
+      expect(
+        route?.meta.excludeSsoOnly,
+        `${path} is part of the SSO flow and must stay reachable in SSO-only mode`
+      ).toBeFalsy();
+      expect(
+        EXCLUDED_IN_SSO_ONLY.has(path),
+        `${path} must not be listed in EXCLUDED_IN_SSO_ONLY`
+      ).toBe(false);
+    }
+  });
+});
+
+// ── 3. Backend shell coverage for full-page-load entry points ─────────────
+
+/** GET path patterns from apps/web/core/routes.txt. */
+function backendGetPatterns(): string[] {
+  const routesTxt = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    '../../../apps/web/core/routes.txt'
+  );
+  return readFileSync(routesTxt, 'utf8')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('GET'))
+    .map((line) => line.split(/\s+/)[1]);
+}
+
+/**
+ * Match a concrete path against a routes.txt pattern: `:param` matches one
+ * segment, a trailing `*` matches one or more remaining segments.
+ */
+function patternMatches(pattern: string, path: string): boolean {
+  const patternSegs = pattern.split('/').filter(Boolean);
+  const pathSegs = path.split('/').filter(Boolean);
+  for (let i = 0; i < patternSegs.length; i++) {
+    const seg = patternSegs[i];
+    if (seg === '*') return pathSegs.length > i;
+    if (i >= pathSegs.length) return false;
+    if (!seg.startsWith(':') && seg !== pathSegs[i]) return false;
+  }
+  return patternSegs.length === pathSegs.length;
+}
+
+describe('backend routes.txt covers session-app entry points', () => {
+  const patterns = backendGetPatterns();
+
+  it.each(sessionFlat.map((r) => r.path))(
+    '%s has an explicit backend entry (200 shell, not the 404 fallback)',
+    (path) => {
+      // Substitute params with a concrete segment for matching.
+      const concrete = path
+        .split('/')
+        .map((seg) => (seg.startsWith(':') ? 'sample' : seg))
+        .join('/');
+      const covered = patterns.some((pattern) => patternMatches(pattern, concrete));
+      expect(
+        covered,
+        `${path} is a full-page-load entry point (emailed links, backend ` +
+          `redirects) but has no GET entry in apps/web/core/routes.txt — the ` +
+          `SPA shell would be served via the not-found fallback with a 404 status`
+      ).toBe(true);
+    }
+  );
+});

--- a/src/tests/router/sso-only-reachability.spec.ts
+++ b/src/tests/router/sso-only-reachability.spec.ts
@@ -12,9 +12,11 @@
 //     excludeSsoOnly, checked exhaustively in BOTH directions — a route
 //     gaining or losing the flag fails until this matrix is updated
 //     deliberately.
-//  2. A tripwire pins the routes the SSO flow itself traverses as never
-//     excluded, independent of the matrix — so even a careless edit to
-//     EXCLUDED_IN_SSO_ONLY cannot re-open the hole.
+//  2. requiredInSsoOnly (canonical doc: src/types/router.ts) positively marks
+//     the routes the SSO flow itself traverses. The flagged set is pinned
+//     here in BOTH directions — dropping the flag from one of the four fails,
+//     and flagging a new route fails until it is deliberately added — and no
+//     route may combine it with excludeSsoOnly.
 //  3. Every session-app route must have an explicit GET entry in
 //     apps/web/core/routes.txt: these routes are entered by full-page load
 //     (emailed links, backend redirects), and a missing entry silently
@@ -103,14 +105,16 @@ const EXCLUDED_IN_SSO_ONLY = new Set([
   '/pricing/:product/:interval',
 ]);
 
-// ── 2. The tripwire: routes the SSO flow itself traverses ─────────────────
+// ── 2. The tripwire: routes flagged requiredInSsoOnly ─────────────────────
 //
-// /signin hosts the SSO buttons; /mfa-verify handles the second factor an
-// SSO sign-in can demand (excluding it also loops: handleSsoOnlyRoute runs
-// before handleMfaAccess, so awaitingMfa ping-pongs /signin <-> /mfa-verify);
-// the two interstitials are the #3840 account-linking consent pages reached
+// The routes the SSO flow itself traverses declare requiredInSsoOnly: true
+// (canonical doc: src/types/router.ts), and handleSsoOnlyRoute gives that
+// flag precedence over excludeSsoOnly. /signin hosts the SSO buttons;
+// /mfa-verify handles the second factor an SSO sign-in can demand (loop
+// mechanics: see the requiredInSsoOnly doc in src/types/router.ts); the two
+// interstitials are the #3840 account-linking consent pages reached
 // mid-SSO-sign-in.
-const SSO_FLOW_PATHS = [
+const REQUIRED_IN_SSO_ONLY = [
   '/signin',
   '/mfa-verify',
   '/link-sso/:token',
@@ -125,7 +129,8 @@ describe('SSO-only mode reachability', () => {
         Boolean(meta.excludeSsoOnly),
         `${path}: excludeSsoOnly should be ${expected}. If this change is ` +
           `deliberate, update EXCLUDED_IN_SSO_ONLY in this spec — and never ` +
-          `exclude a route the SSO flow itself needs (see SSO_FLOW_PATHS).`
+          `exclude a route the SSO flow itself needs (see REQUIRED_IN_SSO_ONLY ` +
+          `and the requiredInSsoOnly doc in src/types/router.ts).`
       ).toBe(expected);
     }
   });
@@ -141,17 +146,56 @@ describe('SSO-only mode reachability', () => {
     }
   });
 
+  it('routes flagged requiredInSsoOnly are exactly the SSO-flow set (both directions)', () => {
+    const flagged = allFlat
+      .filter((r) => r.meta.requiredInSsoOnly === true)
+      .map((r) => r.path);
+
+    for (const path of REQUIRED_IN_SSO_ONLY) {
+      expect(
+        flagged,
+        `${path} must declare requiredInSsoOnly: true — it is part of the ` +
+          `SSO flow and must stay reachable in SSO-only mode (see the ` +
+          `requiredInSsoOnly doc in src/types/router.ts)`
+      ).toContain(path);
+    }
+    for (const path of flagged) {
+      expect(
+        REQUIRED_IN_SSO_ONLY,
+        `${path} carries requiredInSsoOnly but is not in this spec's ` +
+          `expected set. If the route genuinely IS the SSO flow (or its MFA ` +
+          `continuation), add it to REQUIRED_IN_SSO_ONLY deliberately; ` +
+          `otherwise remove the flag (see the requiredInSsoOnly doc in ` +
+          `src/types/router.ts).`
+      ).toContain(path);
+    }
+  });
+
   it('SSO-flow routes exist and are never excluded in SSO-only mode', () => {
-    for (const path of SSO_FLOW_PATHS) {
+    for (const path of REQUIRED_IN_SSO_ONLY) {
       const route = allFlat.find((r) => r.path === path);
       expect(route, `${path} must exist — the SSO flow depends on it`).toBeDefined();
       expect(
         route?.meta.excludeSsoOnly,
-        `${path} is part of the SSO flow and must stay reachable in SSO-only mode`
+        `${path} is part of the SSO flow and must stay reachable in SSO-only ` +
+          `mode (see the requiredInSsoOnly doc in src/types/router.ts)`
       ).toBeFalsy();
       expect(
         EXCLUDED_IN_SSO_ONLY.has(path),
         `${path} must not be listed in EXCLUDED_IN_SSO_ONLY`
+      ).toBe(false);
+    }
+  });
+
+  it('no route combines requiredInSsoOnly with excludeSsoOnly', () => {
+    for (const { path, meta } of allFlat) {
+      expect(
+        meta.requiredInSsoOnly === true && Boolean(meta.excludeSsoOnly),
+        `${path} carries BOTH requiredInSsoOnly and excludeSsoOnly — a ` +
+          `configuration error: the flags are mutually exclusive. The guard ` +
+          `gives requiredInSsoOnly precedence at runtime, but the conflicting ` +
+          `flag must be removed (see the requiredInSsoOnly doc in ` +
+          `src/types/router.ts).`
       ).toBe(false);
     }
   });

--- a/src/types/declarations/index.d.ts
+++ b/src/types/declarations/index.d.ts
@@ -36,6 +36,13 @@ declare module 'vue-router' {
      * When true, this route is excluded when SSO-only mode is active.
      * The route guard redirects authenticated users to '/account'
      * and unauthenticated users to '/signin'.
+     *
+     * INVARIANT: never set this on a route the SSO flow itself traverses
+     * (/signin, /mfa-verify, the /link-sso and /sso-link-confirm
+     * interstitials) — SSO-only mode is the one mode guaranteed to need
+     * them, and the guard would bounce users out of their own sign-in.
+     * Enforced by src/tests/router/sso-only-reachability.spec.ts; new
+     * routes carrying this flag must be added to its expected matrix.
      */
     excludeSsoOnly?: boolean;
 

--- a/src/types/declarations/index.d.ts
+++ b/src/types/declarations/index.d.ts
@@ -32,19 +32,11 @@ declare module 'vue-router' {
      */
     requiresFeature?: 'signup' | 'signin';
 
-    /**
-     * When true, this route is excluded when SSO-only mode is active.
-     * The route guard redirects authenticated users to '/account'
-     * and unauthenticated users to '/signin'.
-     *
-     * INVARIANT: never set this on a route the SSO flow itself traverses
-     * (/signin, /mfa-verify, the /link-sso and /sso-link-confirm
-     * interstitials) — SSO-only mode is the one mode guaranteed to need
-     * them, and the guard would bounce users out of their own sign-in.
-     * Enforced by src/tests/router/sso-only-reachability.spec.ts; new
-     * routes carrying this flag must be added to its expected matrix.
-     */
+    /** Route is hidden in SSO-only mode — full doc on RouteMeta in src/types/router.ts. */
     excludeSsoOnly?: boolean;
+
+    /** SSO-flow route — stays reachable in SSO-only mode; full doc in src/types/router.ts. */
+    requiredInSsoOnly?: boolean;
 
     /**
      * Minimum org membership role required to access this route.

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -77,6 +77,13 @@ export interface RouteMeta {
    * When true, this route is excluded when SSO-only mode is active.
    * The route guard redirects authenticated users to '/account'
    * and unauthenticated users to '/signin'.
+   *
+   * INVARIANT: never set this on a route the SSO flow itself traverses
+   * (/signin, /mfa-verify, the /link-sso and /sso-link-confirm
+   * interstitials) — SSO-only mode is the one mode guaranteed to need
+   * them, and the guard would bounce users out of their own sign-in.
+   * Enforced by src/tests/router/sso-only-reachability.spec.ts; new
+   * routes carrying this flag must be added to its expected matrix.
    */
   excludeSsoOnly?: boolean;
   /**

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -78,14 +78,37 @@ export interface RouteMeta {
    * The route guard redirects authenticated users to '/account'
    * and unauthenticated users to '/signin'.
    *
-   * INVARIANT: never set this on a route the SSO flow itself traverses
-   * (/signin, /mfa-verify, the /link-sso and /sso-link-confirm
-   * interstitials) — SSO-only mode is the one mode guaranteed to need
-   * them, and the guard would bounce users out of their own sign-in.
-   * Enforced by src/tests/router/sso-only-reachability.spec.ts; new
-   * routes carrying this flag must be added to its expected matrix.
+   * INVARIANT: never set this on a route the SSO flow itself traverses —
+   * those routes declare `requiredInSsoOnly` (below), which the guard
+   * gives precedence. Enforced by
+   * src/tests/router/sso-only-reachability.spec.ts; new routes carrying
+   * this flag must be added to its expected matrix.
    */
   excludeSsoOnly?: boolean;
+  /**
+   * When true, this route IS the SSO flow (or its MFA continuation) and
+   * must stay reachable when SSO-only mode is active (site
+   * restrict_to='sso'). In that mode most password-auth routes are hidden
+   * via `excludeSsoOnly` (above), enforced by handleSsoOnlyRoute in
+   * guards.routes.ts. The pinned set of flagged paths lives in
+   * src/tests/router/sso-only-reachability.spec.ts (REQUIRED_IN_SSO_ONLY).
+   *
+   * The guard gives this flag precedence over `excludeSsoOnly`: if someone
+   * copy-pastes `excludeSsoOnly` onto one of these routes, runtime
+   * behavior stays correct (the route remains reachable) and the sweep
+   * spec fails loudly on the double-flagged configuration.
+   *
+   * History: /mfa-verify once carried `excludeSsoOnly` by copy-paste.
+   * handleSsoOnlyRoute runs BEFORE handleMfaAccess, so for awaitingMfa
+   * users the ssoOnly guard bounced /mfa-verify -> /signin while
+   * handleMfaAccess bounced /signin -> /mfa-verify — an infinite redirect
+   * loop. MFA is flow-agnostic: an SSO sign-in can also demand a second
+   * factor (the /sso-link-confirm POST returns mfa_required and hands off
+   * to /mfa-verify), so the MFA continuation is part of the SSO flow.
+   *
+   * Enforced by src/tests/router/sso-only-reachability.spec.ts.
+   */
+  requiredInSsoOnly?: boolean;
   /**
    * When true, this route requires the signed-in customer to have the
    * `colonel` role. Set on every admin-console route (src/apps/admin).


### PR DESCRIPTION
Fixes a gap where SSO-only mode blocked the SSO confirm/link interstitial and MFA routes that must remain reachable to complete the SSO flow. Encodes SSO-only reachability as a positive `requiresSSOOnly` meta flag on those routes rather than trying to carve them out as exceptions in the guard logic.

Adds a full spec suite (`sso-only-reachability.spec.ts`) exercising the reachability matrix across public, authenticated, SSO-only, and admin contexts, plus an integration-level routes spec confirming the expected route metadata is wired up.

Related to #fix/sso-link-confirm