### PR TITLE
fix(i18n): add __main__ guard so python3 -m i18n.cli actually runs

### DIFF
--- a/locales/scripts/i18n/cli.py
+++ b/locales/scripts/i18n/cli.py
@@ -33,3 +33,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     """CLI entry point. Returns a process exit code."""
     args = build_parser().parse_args(argv)
     return args.func(args) or 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

`python3 -m i18n.cli <args>` (run from `locales/scripts/`) imported `cli.py` cleanly, never called `main()`, and exited 0 with zero bytes of output regardless of arguments. Validations silently "passed" without running — an agent or script using this invocation reads success and moves on. Hit independently in two locale-PR review sessions (zh #4105, hu #4089).

## Fix

Add the missing `if __name__ == "__main__": raise SystemExit(main())` guard at the bottom of `locales/scripts/i18n/cli.py`, mirroring the existing package entry point `locales/scripts/i18n/__main__.py`.

## Verification

Before: `cd locales/scripts && python3 -m i18n.cli validate variables --locale hu` → exit 0, 0 bytes of output.

After:
- `python3 -m i18n.cli --help` → prints full usage (`content`/`tasks`/`db`/`validate` groups), exit 0
- `python3 -m i18n.cli validate variables --locale hu` → runs for real: `0 blocking, 0 untranslated`, exit 0
- Existing entry points unchanged: `python3 -m i18n --help` (from `locales/scripts/`) and `python3 scripts/i18n --help` (from `locales/`) both still work, exit 0
- Test suite: `python3 -m pytest tests/` from `locales/scripts/` → 88 passed

Closes #4113