### PR TITLE
fix(ui): give notification severities fixed semantic colors instead of brand tokens

### DIFF
--- a/src/apps/secret/components/branded/SecretDisplayCase.vue
+++ b/src/apps/secret/components/branded/SecretDisplayCase.vue
@@ -37,9 +37,9 @@
 
   const alertClasses = computed(() => ({
     'mb-4 p-4 rounded-md': true,
-    'bg-branddim-50 text-branddim-700 dark:bg-branddim-900 dark:text-branddim-100':
+    'bg-red-50 text-red-700 dark:bg-red-900 dark:text-red-100':
       props.submissionStatus?.status === 'error',
-    'bg-brand-50 text-brand-700 dark:bg-brand-900 dark:text-brand-100':
+    'bg-green-50 text-green-700 dark:bg-green-900 dark:text-green-100':
       props.submissionStatus?.status === 'success',
   }));
 

--- a/src/apps/secret/components/canonical/SecretDisplayCase.vue
+++ b/src/apps/secret/components/canonical/SecretDisplayCase.vue
@@ -36,9 +36,9 @@
 
   const alertClasses = computed(() => ({
     'mb-4 p-4 rounded-md': true,
-    'bg-branddim-50 text-branddim-700 dark:bg-branddim-900 dark:text-branddim-100':
+    'bg-red-50 text-red-700 dark:bg-red-900 dark:text-red-100':
       props.submissionStatus?.status === 'error',
-    'bg-brand-50 text-brand-700 dark:bg-brand-900 dark:text-brand-100':
+    'bg-green-50 text-green-700 dark:bg-green-900 dark:text-green-100':
       props.submissionStatus?.status === 'success',
   }));
 

--- a/src/apps/secret/reveal/canonical/ShowSecret.vue
+++ b/src/apps/secret/reveal/canonical/ShowSecret.vue
@@ -52,7 +52,9 @@
 
   const closeWarning = (event: Event) => {
     const element = event.target as HTMLElement;
-    const warning = element.closest('.bg-amber-50, .bg-brand-50, .bg-amber-900, .bg-brand-900');
+    // Match on role, not background classes: both dismissible creator alerts
+    // carry role="alert", so recoloring them can't silently break dismissal.
+    const warning = element.closest('[role="alert"]');
     if (warning) {
       warning.remove();
     }

--- a/src/shared/components/ui/notifications/global/NotificationBanner.vue
+++ b/src/shared/components/ui/notifications/global/NotificationBanner.vue
@@ -85,7 +85,9 @@ const showProgressBar = computed(() =>
         <button
           v-if="dismissible && !loading"
           type="button"
-          class="ml-4 text-gray-400 hover:text-gray-500 dark:hover:text-gray-300"
+          class="ml-4 shrink-0 rounded-full p-0.5 transition-colors
+            hover:bg-black/5 dark:hover:bg-white/10"
+          :class="colorConfig.textClasses"
           @click="emit('dismiss')">
           <span class="sr-only">{{ t('web.LABELS.dismiss') }}</span>
           <OIcon

--- a/src/shared/components/ui/notifications/severityConfig.ts
+++ b/src/shared/components/ui/notifications/severityConfig.ts
@@ -6,11 +6,21 @@
 // (dark bg in light mode) while Card/Banner use a standard scheme (light bg
 // in light mode). Both are exposed here so visuals don't duplicate the tables.
 //
-// `success` and `info` deliberately use fixed semantic hues (green, sky) rather
-// than the --color-brand* families: they read as "went fine" / "FYI" and must
-// not shift with per-domain branding. `info` in particular used to borrow the
-// orange brandcomp-* accent, which made neutral notices (e.g. Rodauth's "You
-// have been logged in" flash after SSO) look like warnings — see #4012.
+// The four STATUS severities use fixed semantic hues — success/green,
+// error/red, warning/amber, info/sky — rather than the --color-brand*
+// families. Status is a claim about what happened, so it has to be legible
+// independent of who is looking: a red toast means "this failed" on every
+// domain. Brand tokens can't carry that, because generateBrandPalette derives
+// brand, branddim, brandcomp and brandcompdim from a single per-domain hue
+// (see useBrandTheme) — so brand-tinted severities not only shift color per
+// customer, they collapse toward each other, error (brand) and warning
+// (branddim) differing only in lightness. Before #4012 that also put `info` on
+// the orange brandcomp-* accent, which made neutral notices (e.g. Rodauth's
+// "You have been logged in" flash after SSO) read as warnings.
+//
+// `loading` is the deliberate exception and stays on brand tokens: it reports
+// progress, not status, and its spinner already carries that meaning, so
+// tinting it per-domain is cohesion rather than mixed signals.
 
 export interface SeverityMeta {
   icon: string;
@@ -43,16 +53,16 @@ const INVERTED_COLORS: Record<string, SeverityColors> = {
     ringClasses: 'ring-green-700/50 dark:ring-green-300/50',
   },
   error: {
-    bgClasses: 'bg-brand-950/95 dark:bg-brand-50/95',
-    textClasses: 'text-brand-100 dark:text-brand-700',
-    iconClasses: 'text-brand-300 dark:text-brand-600',
-    ringClasses: 'ring-brand-700/50 dark:ring-brand-300/50',
+    bgClasses: 'bg-red-950/95 dark:bg-red-50/95',
+    textClasses: 'text-red-100 dark:text-red-700',
+    iconClasses: 'text-red-300 dark:text-red-600',
+    ringClasses: 'ring-red-700/50 dark:ring-red-300/50',
   },
   warning: {
-    bgClasses: 'bg-branddim-950/95 dark:bg-branddim-50/95',
-    textClasses: 'text-branddim-100 dark:text-branddim-700',
-    iconClasses: 'text-branddim-300 dark:text-branddim-600',
-    ringClasses: 'ring-branddim-700/50 dark:ring-branddim-300/50',
+    bgClasses: 'bg-amber-950/95 dark:bg-amber-50/95',
+    textClasses: 'text-amber-100 dark:text-amber-700',
+    iconClasses: 'text-amber-300 dark:text-amber-600',
+    ringClasses: 'ring-amber-700/50 dark:ring-amber-300/50',
   },
   info: {
     bgClasses: 'bg-sky-950/95 dark:bg-sky-50/95',
@@ -78,16 +88,16 @@ const STANDARD_COLORS: Record<string, SeverityColors> = {
     ringClasses: 'ring-green-200/50 dark:ring-green-800/50',
   },
   error: {
-    bgClasses: 'bg-brand-50/95 dark:bg-brand-950/95',
-    textClasses: 'text-brand-700 dark:text-brand-100',
-    iconClasses: 'text-brand-600 dark:text-brand-300',
-    ringClasses: 'ring-brand-200/50 dark:ring-brand-800/50',
+    bgClasses: 'bg-red-50/95 dark:bg-red-950/95',
+    textClasses: 'text-red-700 dark:text-red-100',
+    iconClasses: 'text-red-600 dark:text-red-300',
+    ringClasses: 'ring-red-200/50 dark:ring-red-800/50',
   },
   warning: {
-    bgClasses: 'bg-branddim-50/95 dark:bg-branddim-950/95',
-    textClasses: 'text-branddim-700 dark:text-branddim-100',
-    iconClasses: 'text-branddim-600 dark:text-branddim-300',
-    ringClasses: 'ring-branddim-200/50 dark:ring-branddim-800/50',
+    bgClasses: 'bg-amber-50/95 dark:bg-amber-950/95',
+    textClasses: 'text-amber-700 dark:text-amber-100',
+    iconClasses: 'text-amber-600 dark:text-amber-300',
+    ringClasses: 'ring-amber-200/50 dark:ring-amber-800/50',
   },
   info: {
     bgClasses: 'bg-sky-50/95 dark:bg-sky-950/95',
@@ -117,11 +127,11 @@ const BANNER_COLORS: Record<string, SeverityColors> = {
   },
   error: {
     ...STANDARD_COLORS.error,
-    bgClasses: 'bg-brand-50/90 dark:bg-brand-950/90',
+    bgClasses: 'bg-red-50/90 dark:bg-red-950/90',
   },
   warning: {
     ...STANDARD_COLORS.warning,
-    bgClasses: 'bg-branddim-50/90 dark:bg-branddim-950/90',
+    bgClasses: 'bg-amber-50/90 dark:bg-amber-950/90',
   },
   info: {
     ...STANDARD_COLORS.info,

--- a/src/shared/components/ui/notifications/severityConfig.ts
+++ b/src/shared/components/ui/notifications/severityConfig.ts
@@ -5,6 +5,12 @@
 // Two color palettes exist because NotificationPill uses an inverted scheme
 // (dark bg in light mode) while Card/Banner use a standard scheme (light bg
 // in light mode). Both are exposed here so visuals don't duplicate the tables.
+//
+// `success` and `info` deliberately use fixed semantic hues (green, sky) rather
+// than the --color-brand* families: they read as "went fine" / "FYI" and must
+// not shift with per-domain branding. `info` in particular used to borrow the
+// orange brandcomp-* accent, which made neutral notices (e.g. Rodauth's "You
+// have been logged in" flash after SSO) look like warnings — see #4012.
 
 export interface SeverityMeta {
   icon: string;
@@ -49,10 +55,10 @@ const INVERTED_COLORS: Record<string, SeverityColors> = {
     ringClasses: 'ring-branddim-700/50 dark:ring-branddim-300/50',
   },
   info: {
-    bgClasses: 'bg-brandcomp-950/95 dark:bg-brandcomp-50/95',
-    textClasses: 'text-brandcomp-100 dark:text-brandcomp-700',
-    iconClasses: 'text-brandcomp-300 dark:text-brandcomp-600',
-    ringClasses: 'ring-brandcomp-700/50 dark:ring-brandcomp-300/50',
+    bgClasses: 'bg-sky-950/95 dark:bg-sky-50/95',
+    textClasses: 'text-sky-100 dark:text-sky-700',
+    iconClasses: 'text-sky-300 dark:text-sky-600',
+    ringClasses: 'ring-sky-700/50 dark:ring-sky-300/50',
   },
   loading: {
     bgClasses: 'bg-brandcompdim-950/95 dark:bg-brandcompdim-50/95',
@@ -84,10 +90,10 @@ const STANDARD_COLORS: Record<string, SeverityColors> = {
     ringClasses: 'ring-branddim-200/50 dark:ring-branddim-800/50',
   },
   info: {
-    bgClasses: 'bg-brandcomp-50/95 dark:bg-brandcomp-950/95',
-    textClasses: 'text-brandcomp-700 dark:text-brandcomp-100',
-    iconClasses: 'text-brandcomp-600 dark:text-brandcomp-300',
-    ringClasses: 'ring-brandcomp-200/50 dark:ring-brandcomp-800/50',
+    bgClasses: 'bg-sky-50/95 dark:bg-sky-950/95',
+    textClasses: 'text-sky-700 dark:text-sky-100',
+    iconClasses: 'text-sky-600 dark:text-sky-300',
+    ringClasses: 'ring-sky-200/50 dark:ring-sky-800/50',
   },
   loading: {
     bgClasses: 'bg-brandcompdim-50/95 dark:bg-brandcompdim-950/95',
@@ -119,7 +125,7 @@ const BANNER_COLORS: Record<string, SeverityColors> = {
   },
   info: {
     ...STANDARD_COLORS.info,
-    bgClasses: 'bg-brandcomp-50/90 dark:bg-brandcomp-950/90',
+    bgClasses: 'bg-sky-50/90 dark:bg-sky-950/90',
   },
   loading: {
     ...STANDARD_COLORS.loading,

--- a/src/shared/components/ui/notifications/severityConfig.ts
+++ b/src/shared/components/ui/notifications/severityConfig.ts
@@ -12,15 +12,19 @@
 // independent of who is looking: a red toast means "this failed" on every
 // domain. Brand tokens can't carry that, because generateBrandPalette derives
 // brand, branddim, brandcomp and brandcompdim from a single per-domain hue
-// (see useBrandTheme) — so brand-tinted severities not only shift color per
-// customer, they collapse toward each other, error (brand) and warning
-// (branddim) differing only in lightness. Before #4012 that also put `info` on
-// the orange brandcomp-* accent, which made neutral notices (e.g. Rodauth's
-// "You have been logged in" flash after SSO) read as warnings.
+// (see useBrandTheme) — so brand-tinted severities shift color per customer
+// and collapse toward each other: branddim is brand at reduced chroma and
+// mid-range lightness, and every scale clamps to the same near-black floor at
+// shade 950, where the old error (brand) and warning (branddim) pill
+// backgrounds were literally identical. Before #4012 `info` sat on
+// brandcomp-* — the complement of the domain hue, orange on the default blue
+// palette — which made neutral notices (e.g. Rodauth's "You have been logged
+// in" flash after SSO) read as warnings.
 //
-// `loading` is the deliberate exception and stays on brand tokens: it reports
-// progress, not status, and its spinner already carries that meaning, so
-// tinting it per-domain is cohesion rather than mixed signals.
+// `loading` reports progress, not status, so it takes no semantic hue — but
+// it avoids brand tokens too: brandcompdim is the complement of the domain
+// hue, which on branded domains can land next to the amber/sky reserved for
+// warning/info. Neutral gray carries "in progress" on every domain.
 
 export interface SeverityMeta {
   icon: string;
@@ -71,10 +75,10 @@ const INVERTED_COLORS: Record<string, SeverityColors> = {
     ringClasses: 'ring-sky-700/50 dark:ring-sky-300/50',
   },
   loading: {
-    bgClasses: 'bg-brandcompdim-950/95 dark:bg-brandcompdim-50/95',
-    textClasses: 'text-brandcompdim-100 dark:text-brandcompdim-700',
-    iconClasses: 'text-brandcompdim-300 dark:text-brandcompdim-600',
-    ringClasses: 'ring-brandcompdim-700/50 dark:ring-brandcompdim-300/50',
+    bgClasses: 'bg-gray-950/95 dark:bg-gray-50/95',
+    textClasses: 'text-gray-100 dark:text-gray-700',
+    iconClasses: 'text-gray-300 dark:text-gray-600',
+    ringClasses: 'ring-gray-700/50 dark:ring-gray-300/50',
   },
 };
 
@@ -106,15 +110,15 @@ const STANDARD_COLORS: Record<string, SeverityColors> = {
     ringClasses: 'ring-sky-200/50 dark:ring-sky-800/50',
   },
   loading: {
-    bgClasses: 'bg-brandcompdim-50/95 dark:bg-brandcompdim-950/95',
-    textClasses: 'text-brandcompdim-700 dark:text-brandcompdim-100',
-    iconClasses: 'text-brandcompdim-600 dark:text-brandcompdim-300',
-    ringClasses: 'ring-brandcompdim-200/50 dark:ring-brandcompdim-800/50',
+    bgClasses: 'bg-gray-50/95 dark:bg-gray-950/95',
+    textClasses: 'text-gray-700 dark:text-gray-100',
+    iconClasses: 'text-gray-600 dark:text-gray-300',
+    ringClasses: 'ring-gray-200/50 dark:ring-gray-800/50',
   },
 };
 
-// Banner uses /90 opacity instead of /95 — override at the bg level only.
-// Everything else (text, icon, ring) matches standard.
+// Banner uses /90 opacity instead of /95, and unlike Card renders no ring —
+// entries carry only the fields NotificationBanner consumes.
 //
 // These bg classes are written as explicit literals (not a runtime transform
 // of STANDARD_COLORS) because Tailwind v4 scans source text for class names:
@@ -122,41 +126,44 @@ const STANDARD_COLORS: Record<string, SeverityColors> = {
 // is never generated.
 const BANNER_COLORS: Record<string, SeverityColors> = {
   success: {
-    ...STANDARD_COLORS.success,
     bgClasses: 'bg-green-50/90 dark:bg-green-950/90',
+    textClasses: STANDARD_COLORS.success.textClasses,
+    iconClasses: STANDARD_COLORS.success.iconClasses,
   },
   error: {
-    ...STANDARD_COLORS.error,
     bgClasses: 'bg-red-50/90 dark:bg-red-950/90',
+    textClasses: STANDARD_COLORS.error.textClasses,
+    iconClasses: STANDARD_COLORS.error.iconClasses,
   },
   warning: {
-    ...STANDARD_COLORS.warning,
     bgClasses: 'bg-amber-50/90 dark:bg-amber-950/90',
+    textClasses: STANDARD_COLORS.warning.textClasses,
+    iconClasses: STANDARD_COLORS.warning.iconClasses,
   },
   info: {
-    ...STANDARD_COLORS.info,
     bgClasses: 'bg-sky-50/90 dark:bg-sky-950/90',
+    textClasses: STANDARD_COLORS.info.textClasses,
+    iconClasses: STANDARD_COLORS.info.iconClasses,
   },
   loading: {
-    ...STANDARD_COLORS.loading,
-    bgClasses: 'bg-brandcompdim-50/90 dark:bg-brandcompdim-950/90',
+    bgClasses: 'bg-gray-50/90 dark:bg-gray-950/90',
+    textClasses: STANDARD_COLORS.loading.textClasses,
+    iconClasses: STANDARD_COLORS.loading.iconClasses,
   },
 };
-
-const DEFAULT_COLORS: SeverityColors = STANDARD_COLORS.info;
 
 export function getSeverityMeta(severity: string | null): SeverityMeta {
   return SEVERITY_META[severity || 'info'] ?? SEVERITY_META.info;
 }
 
 export function getInvertedColors(severity: string | null): SeverityColors {
-  return INVERTED_COLORS[severity || 'info'] ?? DEFAULT_COLORS;
+  return INVERTED_COLORS[severity || 'info'] ?? INVERTED_COLORS.info;
 }
 
 export function getStandardColors(severity: string | null): SeverityColors {
-  return STANDARD_COLORS[severity || 'info'] ?? DEFAULT_COLORS;
+  return STANDARD_COLORS[severity || 'info'] ?? STANDARD_COLORS.info;
 }
 
 export function getBannerColors(severity: string | null): SeverityColors {
-  return BANNER_COLORS[severity || 'info'] ?? DEFAULT_COLORS;
+  return BANNER_COLORS[severity || 'info'] ?? BANNER_COLORS.info;
 }


### PR DESCRIPTION
## Summary

[#4012](https://github.com/onetimesecret/onetimesecret/issues/4012)

The "You have been logged in" toast after an SSO sign-in rendered amber, while the equivalent password-login toast rendered green — the mismatch read as an unintended warning.

Confirmed the diagnosis in the issue:

- Password login sets `session['success_message']` explicitly (`apps/web/core/controllers/authentication.rb`), which bridges to `type: 'success'`.
- SSO goes through Rodauth's default `after_login` flash, which lands in Roda's generic `flash[:notice]` and is bridged to `type: 'info'` by `apps/web/core/views/helpers/initialize_view_vars.rb`. **That server-side classification is left alone** — the same `notice` flash carries other non-success Rodauth messages (password-reset-sent, etc.), so remapping it to `'success'` would misclassify those.
- The amber came from the frontend: severity `info` pointed at the `brandcomp-*` token family — the complement of the per-domain brand hue, which resolves to orange (`#f97316`) on the default blue palette — not an informational hue.

Fixing `info` surfaced that the same category error applied to `error` (`brand-*`) and `warning` (`branddim-*`), so this PR takes all status severities off brand tokens.

## Why brand tokens can't carry status

`generateBrandPalette` (`src/utils/brand-palette.ts`) derives **all four** families — `brand`, `branddim`, `brandcomp`, `brandcompdim` — from a single per-domain hue, and `useBrandTheme` injects them onto `<html>` per custom domain. Two consequences that aren't obvious from the default domain:

1. An error toast rendered in whatever color a customer configured — potentially green.
2. `branddim` is `brand` at reduced chroma and mid-range lightness, and every generated scale clamps to the same near-black floor at shade 950 — so the old `error` and `warning` pill backgrounds were *literally identical* there, and near-indistinguishable elsewhere, on every branded domain.

Status is a claim about what happened, so it has to be legible independent of who is looking. All severities now use fixed hues across the three palettes in `src/shared/components/ui/notifications/severityConfig.ts` — `INVERTED_COLORS` (pill), `STANDARD_COLORS` (card), `BANNER_COLORS`:

| severity | before | after |
|---|---|---|
| `success` | `green-*` | `green-*` (unchanged) |
| `error` | `brand-*` (per-domain hue) | `red-*` |
| `warning` | `branddim-*` (same hue, dimmed) | `amber-*` |
| `info` | `brandcomp-*` (complement hue, orange by default) | `sky-*` |
| `loading` | `brandcompdim-*` (dim complement hue) | `gray-*` |

`loading` reports progress rather than status, so it takes a neutral gray instead of a semantic hue — but it comes off brand tokens too: `brandcompdim` is the complement of the domain hue, which on branded domains can land right next to the amber/sky now reserved for `warning`/`info`.

Shades are written as verbatim literals per the existing note in that file: Tailwind v4 scans source text, so a runtime transform would never generate the utilities.

## Code-review follow-up (second/third commits)

An adversarially-verified review pass over the diff produced seven findings, all applied:

- **Inline submission alerts in both `SecretDisplayCase` variants** (branded + canonical) still mapped error → `branddim-*` / success → `brand-*` — the same per-domain-hue defect, on the surfaces guaranteed to run branding overrides. Now `red-*` / `green-*`.
- **Unknown-severity fallback**: the getters fell back to a shared `DEFAULT_COLORS = STANDARD_COLORS.info`, which handed `NotificationPill`'s inverted layout a standard-scheme (light-on-light-mode) object. Each getter now falls back to its own table's `info` entry.
- **Banner dismiss button** was fixed `text-gray-400` (≈2.8:1 against the light severity backgrounds, below the 3:1 non-text minimum); it now uses `colorConfig.textClasses`, matching `NotificationCard`.
- **`ShowSecret.closeWarning`** dismissed creator alerts via `closest('.bg-amber-50, .bg-brand-50, …')`, hard-coding background utilities as DOM selectors; it now matches `[role="alert"]`, so recoloring the alerts can't silently break the close button.
- **`BANNER_COLORS`** no longer carries `ringClasses` the banner never renders, and the header comment's description of the brand-palette mechanics was corrected (the scales differ by chroma and converge at the dark end, rather than "differing only in lightness").

## Test Plan

- `npx vitest run src/tests/shared/components/ui/notifications/ src/tests/components/ShowSecretCapabilities.spec.ts` — 10 passed.
- `npx eslint` on all five touched files — 0 errors; remaining warnings are pre-existing (this repo's `eslint-plugin-tailwindcss` is pointed at `src/assets/style.css`, so it validates the new class names against the real theme).
- `npx vite build`, then checked the emitted stylesheet programmatically rather than by eye: extracted all 90 class tokens referenced by `severityConfig.ts` and confirmed each has a matching selector in the built CSS, plus the new literals in the Vue components (`bg-red-50`, `dark:bg-green-900`, `hover:bg-black/5`, …). None missing — no silently-dropped utilities in either theme.
- Contrast, computed from Tailwind's own palette values since these carry body text. Every text/bg pair clears WCAG AA for normal text, each with at least as much headroom as the pre-existing `success` green:

  | pair | ratio | | pair | ratio |
  |---|---|---|---|---|
  | `green-700` on `green-50` | 4.72 | | `green-100` on `green-950` | 13.56 |
  | `red-700` on `red-50` | 5.88 | | `red-100` on `red-950` | 13.22 |
  | `amber-700` on `amber-50` | 4.87 | | `amber-100` on `amber-950` | 13.47 |
  | `sky-700` on `sky-50` | 5.49 | | `sky-100` on `sky-950` | 12.10 |
  | `gray-700` on `gray-50` | 9.87 | | `gray-100` on `gray-950` | 18.29 |

  Computed on solid colors; the real backgrounds are `/95` or `/90` over the page, which shifts the ratios only slightly.
- Not manually exercised in a browser: the SSO sign-in flow is unchanged by this diff — only the class strings the notifications resolve to — but a visual check of a toast in both light and dark mode is worth doing before merging.

## Related Issues

Fixes #4012

## Note for reviewers

This lands the practical half of a change `docs/planning/design-system-readiness.md` already anticipates: it earmarks a semantic `--color-{danger,warning,success}-*` ramp as Wave 1 design-system work. This PR uses Tailwind's stock `red`/`amber`/`sky`/`green`/`gray` directly rather than inventing tokens ahead of that effort — when the ramp lands, these tables are the natural first consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KfFVZJVmZS7mw4KJ4tJ9dY