### PR TITLE
Normalize IPv6 address handling in host checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,13 @@ and can reach dev data.
 $ tests/lanes/run --list     # all lanes and overlays
 $ tests/lanes/run unit       # try:unit + spec:fast (most changes)
 $ tests/lanes/run full-pg    # Postgres-backed auth integration
+$ tests/lanes/run simple --only path/to/one_spec.rb[:LINE]
 ```
+
+Use `--only <path>` (repeatable) while iterating: it runs just that file
+in the lane's environment — seconds instead of minutes — with the same
+env scrub. `*_try.rb` routes to tryouts, everything else to rspec. It
+skips the lane's other tasks, so run the whole lane before pushing.
 
 The runner needs bash 5+ (macOS ships 3.2: `brew install bash`) and
 starts the backing services itself if they aren't up

--- a/apps/api/domains/logic/sso_config/ssrf_protection.rb
+++ b/apps/api/domains/logic/sso_config/ssrf_protection.rb
@@ -130,10 +130,14 @@ module DomainsAPI
         # @param ip [IPAddr] The address to check
         # @return [Boolean] true if the address is internal/blocked
         def blocked_ip?(ip)
-          # Unwrap IPv4-mapped IPv6 (::ffff:a.b.c.d) to the embedded IPv4 so the
-          # native range predicates below actually see it. #native returns the
-          # address unchanged when it is not mapped, so this is safe for all IPs.
-          ip = ip.native if ip.ipv6? && ip.ipv4_mapped?
+          # Unwrap IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible (::a.b.c.d)
+          # IPv6 to the embedded IPv4 so the native range predicates below
+          # actually see it. Both formats otherwise slip past #loopback?,
+          # #private?, and #link_local?, which only match native ranges, so
+          # ::169.254.169.254 or ::127.0.0.1 would reach the metadata service or
+          # loopback. #native returns the address unchanged when it is neither,
+          # so this is safe for all IPs.
+          ip = ip.native if ip.ipv6? && (ip.ipv4_mapped? || ip.ipv4_compat?)
 
           return true if ip.loopback?
           return true if ip.private?

--- a/apps/api/domains/logic/sso_config/ssrf_protection.rb
+++ b/apps/api/domains/logic/sso_config/ssrf_protection.rb
@@ -18,8 +18,18 @@ module DomainsAPI
       #
       # Protection includes:
       # - Blocking literal internal IPs (loopback, private, link-local)
+      # - Unwrapping IPv4-mapped IPv6 literals and re-checking the embedded IPv4
+      # - Blocking IPv6 transition ranges (NAT64, 6to4, Teredo) wholesale
       # - Blocking internal hostnames (localhost, .local, .internal)
       # - DNS rebinding protection via hostname resolution check
+      #
+      # Note on IPv6 transition addresses: Ruby's IPAddr#loopback?, #private?,
+      # and #link_local? only match native IPv4/IPv6 ranges. They do NOT look at
+      # IPv4 addresses embedded in IPv6 transition formats, so an address like
+      # ::ffff:169.254.169.254 (IPv4-mapped) or 64:ff9b::a9fe:a9fe (NAT64) would
+      # otherwise slip past the guard. blocked_ip? closes that gap by unwrapping
+      # IPv4-mapped literals to their embedded IPv4 and by blocking the transition
+      # prefixes outright, since no legitimate SSO issuer resolves into them.
       #
       # Note on DNS rebinding: While we resolve hostnames at validation time,
       # a sophisticated attacker could still exploit DNS rebinding by returning
@@ -33,6 +43,17 @@ module DomainsAPI
       #   # Then call valid_issuer_host?(url) to validate
       #
       module SsrfProtection
+        # IPv6 transition prefixes that embed a routable IPv4 destination.
+        # These are blocked wholesale: an SSO issuer has no legitimate reason
+        # to resolve into any of them, and decoding-then-allowing would just
+        # reintroduce the bypass surface we are trying to close.
+        TRANSITION_RANGES = [
+          IPAddr.new('2001::/32'),      # Teredo (RFC 4380)
+          IPAddr.new('2002::/16'),      # 6to4 (RFC 3056)
+          IPAddr.new('64:ff9b::/96'),   # NAT64 well-known prefix (RFC 6052)
+          IPAddr.new('64:ff9b:1::/48'), # NAT64 local-use prefix (RFC 8215)
+        ].freeze
+
         # Validates that a URL host is safe for external requests.
         #
         # @param url [String] The URL to validate
@@ -64,14 +85,11 @@ module DomainsAPI
           return true if host.end_with?('.local')
           return true if host.end_with?('.internal')
 
-          # Block private IP ranges (when host is a literal IP)
+          # Block private IP ranges (when host is a literal IP). IPAddr accepts
+          # the bracketed IPv6 form that URI#host returns (e.g. "[::1]").
           begin
             ip = IPAddr.new(host)
-
-            # Check for loopback, private, or link-local addresses
-            return true if ip.loopback?
-            return true if ip.private?
-            return true if ip.link_local?
+            return true if blocked_ip?(ip)
           rescue IPAddr::InvalidAddressError
             # Not an IP address, continue to DNS resolution check
           end
@@ -86,7 +104,7 @@ module DomainsAPI
         # Resolves a hostname and checks if any resolved IP is internal.
         #
         # Returns true if the hostname resolves to a loopback, private,
-        # or link-local address.
+        # link-local, or IPv6-transition address.
         #
         # @param hostname [String] The hostname to resolve
         # @return [Boolean] true if any resolved IP is internal
@@ -95,8 +113,7 @@ module DomainsAPI
           addresses = Resolv.getaddresses(hostname)
 
           addresses.any? do |addr_str|
-            ip = IPAddr.new(addr_str)
-            ip.loopback? || ip.private? || ip.link_local?
+            blocked_ip?(IPAddr.new(addr_str))
           rescue IPAddr::InvalidAddressError
             # Skip malformed addresses
             false
@@ -105,6 +122,28 @@ module DomainsAPI
           # DNS resolution failed - block as a precaution
           # If we can't resolve the hostname, we shouldn't proceed
           true
+        end
+
+        # Determines whether an IP address points at an internal/private
+        # destination, accounting for IPv6 transition formats.
+        #
+        # @param ip [IPAddr] The address to check
+        # @return [Boolean] true if the address is internal/blocked
+        def blocked_ip?(ip)
+          # Unwrap IPv4-mapped IPv6 (::ffff:a.b.c.d) to the embedded IPv4 so the
+          # native range predicates below actually see it. #native returns the
+          # address unchanged when it is not mapped, so this is safe for all IPs.
+          ip = ip.native if ip.ipv6? && ip.ipv4_mapped?
+
+          return true if ip.loopback?
+          return true if ip.private?
+          return true if ip.link_local?
+
+          # NAT64 / 6to4 / Teredo carry an embedded IPv4 the native predicates
+          # ignore. Block the whole prefixes rather than decode-and-allow.
+          return true if ip.ipv6? && TRANSITION_RANGES.any? { |range| range.include?(ip) }
+
+          false
         end
       end
     end

--- a/apps/api/domains/logic/sso_config/ssrf_protection.rb
+++ b/apps/api/domains/logic/sso_config/ssrf_protection.rb
@@ -95,12 +95,23 @@ module DomainsAPI
         # prefixes, multicast, etc.). A resolver answer we cannot parse also
         # counts as internal: Guard.blocked_ip? fails closed on unparseable
         # input, so malformed addresses block rather than being skipped.
+        # Empty resolution (NXDOMAIN / no A/AAAA records) also counts as
+        # internal — an unresolvable host is not a valid egress target.
         #
         # @param hostname [String] The hostname to resolve
         # @return [Boolean] true if any resolved IP is internal
         def resolves_to_internal_ip?(hostname)
           # Resolve all A and AAAA records
           addresses = Resolv.getaddresses(hostname)
+
+          # Fail closed on empty resolution. Resolv.getaddresses returns []
+          # (rather than raising) for NXDOMAIN or a host with no A/AAAA
+          # records, so without this an unresolvable issuer host would slip
+          # through save-time validation as "not internal". A host that
+          # resolves to nothing is not a valid egress target; the request-time
+          # guard (Guard.resolve_and_validate!) already rejects empty
+          # resolution, and this keeps save-time consistent with it.
+          return true if addresses.empty?
 
           addresses.any? { |addr_str| blocked_ip?(addr_str) }
         rescue Resolv::ResolvError, Resolv::ResolvTimeout

--- a/apps/api/domains/logic/sso_config/ssrf_protection.rb
+++ b/apps/api/domains/logic/sso_config/ssrf_protection.rb
@@ -23,49 +23,24 @@ module DomainsAPI
       # - Blocking internal hostnames (localhost, .local, .internal)
       # - DNS rebinding protection via hostname resolution check
       #
-      # Note on IPv6 transition addresses: Ruby's IPAddr#loopback?, #private?,
-      # and #link_local? only match native IPv4/IPv6 ranges. They do NOT look at
-      # IPv4 addresses embedded in IPv6 transition formats, so an address like
-      # ::ffff:169.254.169.254 (IPv4-mapped) or 64:ff9b::a9fe:a9fe (NAT64) would
-      # otherwise slip past the guard. blocked_ip? closes that gap by unwrapping
-      # IPv4-mapped literals to their embedded IPv4 and by blocking the transition
-      # prefixes outright, since no legitimate SSO issuer resolves into them.
+      # IP range coverage (transition prefixes, special-use IPv4, multicast,
+      # documentation ranges, etc.) lives in Onetime::Http::Guard — the shared
+      # SSRF egress guard and single source of truth for "is this IP a
+      # forbidden egress target". blocked_ip? below delegates to it.
       #
       # Note on DNS rebinding: While we resolve hostnames at validation time,
       # a sophisticated attacker could still exploit DNS rebinding by returning
       # a safe IP during our check, then switching to an internal IP during
-      # the actual OmniAuth request (if sufficient time passes). Full mitigation
-      # would require DNS pinning at the HTTP client level, which is beyond
-      # the scope of this module.
+      # the actual OmniAuth request (if sufficient time passes). Request-time
+      # DNS pinning is now implemented at the HTTP-client callsites (SafeFetch,
+      # webhook dispatch, SSO test connection, and the OIDC Faraday hook), so
+      # the validation here is defense-in-depth, not the only line.
       #
       # Usage:
       #   include SsrfProtection
       #   # Then call valid_issuer_host?(url) to validate
       #
       module SsrfProtection
-        # IPv6 transition prefixes that embed a routable IPv4 destination.
-        # These are blocked wholesale: an SSO issuer has no legitimate reason
-        # to resolve into any of them, and decoding-then-allowing would just
-        # reintroduce the bypass surface we are trying to close.
-        TRANSITION_RANGES = [
-          IPAddr.new('2001::/32'),      # Teredo (RFC 4380)
-          IPAddr.new('2002::/16'),      # 6to4 (RFC 3056)
-          IPAddr.new('64:ff9b::/96'),   # NAT64 well-known prefix (RFC 6052)
-          IPAddr.new('64:ff9b:1::/48'), # NAT64 local-use prefix (RFC 8215)
-        ].freeze
-
-        # Special-use IPv4 ranges that IPAddr#loopback?/#private?/#link_local?
-        # do NOT match but which no legitimate SSO issuer resolves into. Most
-        # important is 0.0.0.0/8: 0.0.0.0 connects to localhost on Linux, so it
-        # is a loopback bypass the native predicates miss.
-        BLOCKED_IPV4_RANGES = [
-          IPAddr.new('0.0.0.0/8'),      # "this host on this network" (RFC 1122)
-          IPAddr.new('100.64.0.0/10'),  # CGNAT / shared address space (RFC 6598)
-          IPAddr.new('192.0.0.0/24'),   # IETF protocol assignments (RFC 6890)
-          IPAddr.new('198.18.0.0/15'),  # benchmarking (RFC 2544)
-          IPAddr.new('240.0.0.0/4'),    # reserved + 255.255.255.255 broadcast
-        ].freeze
-
         # Validates that a URL host is safe for external requests.
         #
         # @param url [String] The URL to validate
@@ -115,8 +90,11 @@ module DomainsAPI
 
         # Resolves a hostname and checks if any resolved IP is internal.
         #
-        # Returns true if the hostname resolves to a loopback, private,
-        # link-local, or IPv6-transition address.
+        # Returns true if the hostname resolves to any address the shared
+        # egress guard forbids (loopback, private, link-local, transition
+        # prefixes, multicast, etc.). A resolver answer we cannot parse also
+        # counts as internal: Guard.blocked_ip? fails closed on unparseable
+        # input, so malformed addresses block rather than being skipped.
         #
         # @param hostname [String] The hostname to resolve
         # @return [Boolean] true if any resolved IP is internal
@@ -124,12 +102,7 @@ module DomainsAPI
           # Resolve all A and AAAA records
           addresses = Resolv.getaddresses(hostname)
 
-          addresses.any? do |addr_str|
-            blocked_ip?(IPAddr.new(addr_str))
-          rescue IPAddr::InvalidAddressError
-            # Skip malformed addresses
-            false
-          end
+          addresses.any? { |addr_str| blocked_ip?(addr_str) }
         rescue Resolv::ResolvError, Resolv::ResolvTimeout
           # DNS resolution failed - block as a precaution
           # If we can't resolve the hostname, we shouldn't proceed
@@ -137,39 +110,14 @@ module DomainsAPI
         end
 
         # Determines whether an IP address points at an internal/private
-        # destination, accounting for IPv6 transition formats.
+        # destination. Thin delegation to the shared egress guard, which
+        # unwraps IPv4-embedded IPv6 forms, blocks transition prefixes, and
+        # fails closed (returns true) on anything IPAddr cannot parse.
         #
-        # @param ip [IPAddr] The address to check
+        # @param ip [IPAddr, String] The address to check
         # @return [Boolean] true if the address is internal/blocked
         def blocked_ip?(ip)
-          # Unwrap IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible (::a.b.c.d)
-          # IPv6 to the embedded IPv4 so the native range predicates below
-          # actually see it. Both formats otherwise slip past #loopback?,
-          # #private?, and #link_local?, which only match native ranges, so
-          # ::169.254.169.254 or ::127.0.0.1 would reach the metadata service or
-          # loopback. #native returns the address unchanged when it is neither,
-          # so this is safe for all IPs.
-          ip = ip.native if ip.ipv6? && (ip.ipv4_mapped? || ip.ipv4_compat?)
-
-          return true if ip.loopback?
-          return true if ip.private?
-          return true if ip.link_local?
-
-          # Unspecified address in either family (0.0.0.0, :: — including the
-          # ::0.0.0.0 spelling, which is not ipv4_compat? so the unwrap above
-          # leaves it as ::). Both route to localhost as a connect target.
-          return true if ip.to_i.zero?
-
-          # Special-use IPv4 the native predicates miss (0.0.0.0/8 → localhost,
-          # CGNAT, reserved, broadcast). Applies after the unwrap above, so it
-          # also catches ::0.0.0.0 / ::ffff:0.0.0.0 embed forms.
-          return true if ip.ipv4? && BLOCKED_IPV4_RANGES.any? { |range| range.include?(ip) }
-
-          # NAT64 / 6to4 / Teredo carry an embedded IPv4 the native predicates
-          # ignore. Block the whole prefixes rather than decode-and-allow.
-          return true if ip.ipv6? && TRANSITION_RANGES.any? { |range| range.include?(ip) }
-
-          false
+          Onetime::Http::Guard.blocked_ip?(ip)
         end
       end
     end

--- a/apps/api/domains/logic/sso_config/ssrf_protection.rb
+++ b/apps/api/domains/logic/sso_config/ssrf_protection.rb
@@ -54,6 +54,18 @@ module DomainsAPI
           IPAddr.new('64:ff9b:1::/48'), # NAT64 local-use prefix (RFC 8215)
         ].freeze
 
+        # Special-use IPv4 ranges that IPAddr#loopback?/#private?/#link_local?
+        # do NOT match but which no legitimate SSO issuer resolves into. Most
+        # important is 0.0.0.0/8: 0.0.0.0 connects to localhost on Linux, so it
+        # is a loopback bypass the native predicates miss.
+        BLOCKED_IPV4_RANGES = [
+          IPAddr.new('0.0.0.0/8'),      # "this host on this network" (RFC 1122)
+          IPAddr.new('100.64.0.0/10'),  # CGNAT / shared address space (RFC 6598)
+          IPAddr.new('192.0.0.0/24'),   # IETF protocol assignments (RFC 6890)
+          IPAddr.new('198.18.0.0/15'),  # benchmarking (RFC 2544)
+          IPAddr.new('240.0.0.0/4'),    # reserved + 255.255.255.255 broadcast
+        ].freeze
+
         # Validates that a URL host is safe for external requests.
         #
         # @param url [String] The URL to validate
@@ -142,6 +154,16 @@ module DomainsAPI
           return true if ip.loopback?
           return true if ip.private?
           return true if ip.link_local?
+
+          # Unspecified address in either family (0.0.0.0, :: — including the
+          # ::0.0.0.0 spelling, which is not ipv4_compat? so the unwrap above
+          # leaves it as ::). Both route to localhost as a connect target.
+          return true if ip.to_i.zero?
+
+          # Special-use IPv4 the native predicates miss (0.0.0.0/8 → localhost,
+          # CGNAT, reserved, broadcast). Applies after the unwrap above, so it
+          # also catches ::0.0.0.0 / ::ffff:0.0.0.0 embed forms.
+          return true if ip.ipv4? && BLOCKED_IPV4_RANGES.any? { |range| range.include?(ip) }
 
           # NAT64 / 6to4 / Teredo carry an embedded IPv4 the native predicates
           # ignore. Block the whole prefixes rather than decode-and-allow.

--- a/apps/api/domains/logic/sso_config/test_connection.rb
+++ b/apps/api/domains/logic/sso_config/test_connection.rb
@@ -284,6 +284,19 @@ module DomainsAPI
               description: sanitize_error_message(ex.message),
             },
           }
+        rescue Onetime::Http::Guard::Blocked
+          # Deliberately generic: Blocked#message carries the resolved IP,
+          # which must not be echoed back to the caller (information
+          # disclosure about internal address space).
+          {
+            success: false,
+            provider_type: @provider_type,
+            message: "#{provider_name} issuer resolves to a blocked address",
+            details: {
+              error_code: 'blocked_target',
+              description: 'The issuer host resolves to an address that is not allowed.',
+            },
+          }
         rescue StandardError => ex
           OT.le "[TestConnection] Unexpected error testing #{provider_name}: #{ex.class.name} - #{ex.message}"
           {
@@ -300,7 +313,21 @@ module DomainsAPI
         def fetch_url(url)
           uri = URI.parse(url)
 
-          http              = Net::HTTP.new(uri.host, uri.port)
+          # SSRF enforcement point: resolve + validate the host once, then pin
+          # the connection to that exact IP via Net::HTTP#ipaddr= while the
+          # Host header, SNI, and certificate verification keep using the
+          # hostname. Closes the validate-then-reresolve DNS-rebinding window,
+          # and covers every caller — including test_entra_id_connection,
+          # which never passes through valid_issuer_host? (that check remains
+          # upstream as a cheap early rejection with a friendly message).
+          # Raises Onetime::Http::Guard::Blocked for forbidden targets.
+          pinned_ip = Onetime::Http::Guard.pinned_address!(uri.host)
+
+          # The explicit nil p_addr disables environment-proxy pickup
+          # (http_proxy env var), which would otherwise route the request
+          # through a proxy and silently bypass the IP pinning below.
+          http              = Net::HTTP.new(uri.host, uri.port, nil)
+          http.ipaddr       = pinned_ip
           http.use_ssl      = (uri.scheme == 'https')
           http.open_timeout = CONNECTION_TIMEOUT
           http.read_timeout = READ_TIMEOUT

--- a/apps/api/domains/logic/sso_config/test_connection.rb
+++ b/apps/api/domains/logic/sso_config/test_connection.rb
@@ -313,31 +313,33 @@ module DomainsAPI
         def fetch_url(url)
           uri = URI.parse(url)
 
-          # SSRF enforcement point: resolve + validate the host once, then pin
-          # the connection to that exact IP via Net::HTTP#ipaddr= while the
-          # Host header, SNI, and certificate verification keep using the
-          # hostname. Closes the validate-then-reresolve DNS-rebinding window,
-          # and covers every caller — including test_entra_id_connection,
-          # which never passes through valid_issuer_host? (that check remains
-          # upstream as a cheap early rejection with a friendly message).
-          # Raises Onetime::Http::Guard::Blocked for forbidden targets.
-          pinned_ip = Onetime::Http::Guard.pinned_address!(uri.host)
-
-          # The explicit nil p_addr disables environment-proxy pickup
-          # (http_proxy env var), which would otherwise route the request
-          # through a proxy and silently bypass the IP pinning below.
-          http              = Net::HTTP.new(uri.host, uri.port, nil)
-          http.ipaddr       = pinned_ip
-          http.use_ssl      = (uri.scheme == 'https')
-          http.open_timeout = CONNECTION_TIMEOUT
-          http.read_timeout = READ_TIMEOUT
-          http.verify_mode  = OpenSSL::SSL::VERIFY_PEER
-
           request               = Net::HTTP::Get.new(uri.request_uri)
           request['Accept']     = 'application/json'
           request['User-Agent'] = 'OneTimeSecret-SSO-Test/1.0'
 
-          http.request(request)
+          # SSRF enforcement point: resolve + validate the host once, then
+          # dial each validated IP pinned via Net::HTTP#ipaddr= while the
+          # Host header, SNI, and certificate verification keep using the
+          # hostname. Closes the validate-then-reresolve DNS-rebinding
+          # window (the fallback walk only spans already-validated
+          # addresses), and covers every caller — including
+          # test_entra_id_connection, which never passes through
+          # valid_issuer_host? (that check remains upstream as a cheap early
+          # rejection with a friendly message). Raises
+          # Onetime::Http::Guard::Blocked for forbidden targets.
+          Onetime::Http::Guard.try_each_address!(uri.host) do |pinned_ip|
+            # The explicit nil p_addr disables environment-proxy pickup
+            # (http_proxy env var), which would otherwise route the request
+            # through a proxy and silently bypass the IP pinning below.
+            http              = Net::HTTP.new(uri.host, uri.port, nil)
+            http.ipaddr       = pinned_ip
+            http.use_ssl      = (uri.scheme == 'https')
+            http.open_timeout = CONNECTION_TIMEOUT
+            http.read_timeout = READ_TIMEOUT
+            http.verify_mode  = OpenSSL::SSL::VERIFY_PEER
+
+            http.request(request)
+          end
         end
 
         def validate_discovery_response(response, provider_name)

--- a/apps/api/domains/spec/integration/simple/domain_sso_config_spec.rb
+++ b/apps/api/domains/spec/integration/simple/domain_sso_config_spec.rb
@@ -69,6 +69,17 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
     end
   end
 
+  # Issuer save-time validation (SsrfProtection#valid_issuer_host?) resolves
+  # the issuer host and fails closed on empty resolution, so the fixture
+  # issuers below (auth.example.com, pkce-issuer.example.com — all NXDOMAIN)
+  # would be rejected with 422 on a machine with working DNS. Resolve them to
+  # a documentation-range public address instead: these tests are about the
+  # SSO config API's own semantics, and the SSRF rules themselves are covered
+  # in apps/api/domains/spec/logic/sso_config/ssrf_protection_spec.rb.
+  before do
+    allow(Resolv).to receive(:getaddresses).and_return(['203.0.113.10'])
+  end
+
   let(:test_run_id) { SecureRandom.hex(8) }
   let(:test_email) { "owner-#{test_run_id}@test.local" }
   let(:test_password) { 'Test123!@#' }

--- a/apps/api/domains/spec/logic/sso_config/ssrf_protection_spec.rb
+++ b/apps/api/domains/spec/logic/sso_config/ssrf_protection_spec.rb
@@ -25,9 +25,11 @@ RSpec.describe DomainsAPI::Logic::SsoConfig::SsrfProtection do
   end
 
   # Stub DNS resolution by default so tests are deterministic and fast.
-  # Individual examples override this when testing DNS behavior.
+  # Default to a public address: resolves_to_internal_ip? fails closed on
+  # empty resolution, so a host must resolve to something public to be
+  # accepted. Individual examples override this when testing DNS behavior.
   before do
-    allow(Resolv).to receive(:getaddresses).and_return([])
+    allow(Resolv).to receive(:getaddresses).and_return(['93.184.216.34'])
   end
 
   # ==========================================================================
@@ -303,6 +305,18 @@ RSpec.describe DomainsAPI::Logic::SsoConfig::SsrfProtection do
 
       it 'returns true (fail-closed)' do
         expect(validator.resolves_to_internal_ip?('nonexistent.example.com')).to be true
+      end
+    end
+
+    context 'when the host resolves to no addresses (NXDOMAIN returns [])' do
+      before do
+        allow(Resolv).to receive(:getaddresses)
+          .with('unresolvable.example.com')
+          .and_return([])
+      end
+
+      it 'returns true (fail-closed on empty resolution)' do
+        expect(validator.resolves_to_internal_ip?('unresolvable.example.com')).to be true
       end
     end
 

--- a/apps/api/domains/spec/logic/sso_config/test_connection_spec.rb
+++ b/apps/api/domains/spec/logic/sso_config/test_connection_spec.rb
@@ -129,6 +129,32 @@ RSpec.describe DomainsAPI::Logic::SsoConfig::TestConnection do
         expect(http_instance).to have_received(:ipaddr=).with('203.0.113.10')
       end
     end
+
+    context 'when the first validated address is unreachable' do
+      let(:discovery_body) do
+        {
+          issuer: issuer,
+          authorization_endpoint: "#{issuer}/authorize",
+          token_endpoint: "#{issuer}/token",
+          jwks_uri: "#{issuer}/jwks",
+        }.to_json
+      end
+
+      before do
+        stub_issuer_resolution(['203.0.113.10', '203.0.113.11'])
+        allow(http_instance).to receive(:request)
+          .and_invoke(->(_req) { raise Errno::ECONNREFUSED },
+                      ->(_req) { success_response(discovery_body) })
+      end
+
+      it 'falls back to the next validated address, each dial still pinned' do
+        result = logic.send(:test_oidc_connection)
+
+        expect(result[:success]).to be true
+        expect(http_instance).to have_received(:ipaddr=).with('203.0.113.10').ordered
+        expect(http_instance).to have_received(:ipaddr=).with('203.0.113.11').ordered
+      end
+    end
   end
 
   describe '#test_entra_id_connection' do

--- a/apps/api/domains/spec/logic/sso_config/test_connection_spec.rb
+++ b/apps/api/domains/spec/logic/sso_config/test_connection_spec.rb
@@ -1,0 +1,163 @@
+# apps/api/domains/spec/logic/sso_config/test_connection_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for TestConnection's SSRF-pinned discovery fetch.
+#
+# fetch_url resolves + validates the issuer host ONCE through the shared
+# egress guard (Onetime::Http::Guard) and pins the dial to that exact IP via
+# Net::HTTP#ipaddr=, closing the validate-then-reresolve DNS-rebinding
+# window. valid_issuer_host? remains upstream as a cheap early rejection,
+# but fetch_url is the enforcement point — it also covers
+# test_entra_id_connection, which never passes through valid_issuer_host?.
+#
+# Hermetic: the guard's DNS seam (Guard.resolve_addresses) and Net::HTTP.new
+# are stubbed; no live DNS or network.
+#
+# Run:
+#   pnpm run test:rspec apps/api/domains/spec/logic/sso_config/test_connection_spec.rb
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require_relative '../../../../../../apps/api/domains/application'
+
+RSpec.describe DomainsAPI::Logic::SsoConfig::TestConnection do
+  # The connection-test helpers under test are independent of the auth
+  # plumbing exercised in base_spec, so allocate an instance and set only
+  # the ivars the helpers read.
+  let(:logic) do
+    described_class.allocate.tap do |instance|
+      instance.instance_variable_set(:@provider_type, provider_type)
+      instance.instance_variable_set(:@issuer, issuer)
+      instance.instance_variable_set(:@tenant_id, tenant_id)
+    end
+  end
+
+  let(:provider_type) { 'oidc' }
+  let(:issuer) { 'https://idp.example.com' }
+  let(:tenant_id) { nil }
+
+  let(:http_instance) { instance_double(Net::HTTP) }
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:le)
+
+    allow(Net::HTTP).to receive(:new).and_return(http_instance)
+    allow(http_instance).to receive(:ipaddr=)
+    allow(http_instance).to receive(:use_ssl=)
+    allow(http_instance).to receive(:open_timeout=)
+    allow(http_instance).to receive(:read_timeout=)
+    allow(http_instance).to receive(:verify_mode=)
+    allow(http_instance).to receive(:request)
+  end
+
+  # Stub the guard's DNS seam; validation and pinning logic stay real.
+  def stub_issuer_resolution(addresses)
+    allow(Onetime::Http::Guard).to receive(:resolve_addresses).and_return(addresses)
+  end
+
+  def success_response(body)
+    Net::HTTPOK.new('1.1', '200', 'OK').tap do |response|
+      allow(response).to receive(:body).and_return(body)
+    end
+  end
+
+  describe '#test_oidc_connection' do
+    context 'when the issuer resolves to a blocked address' do
+      before { stub_issuer_resolution(['127.0.0.1']) }
+
+      it 'returns a structured blocked_target failure without connecting' do
+        result = logic.send(:test_oidc_connection)
+
+        expect(result[:success]).to be false
+        expect(result[:message]).to eq('OIDC issuer resolves to a blocked address')
+        expect(result[:details][:error_code]).to eq('blocked_target')
+        expect(Net::HTTP).not_to have_received(:new)
+        expect(http_instance).not_to have_received(:request)
+      end
+
+      it 'does not echo the resolved IP anywhere in the result' do
+        result = logic.send(:test_oidc_connection)
+
+        expect(result.inspect).not_to include('127.0.0.1')
+      end
+    end
+
+    context 'when the RRset mixes public and private answers' do
+      before { stub_issuer_resolution(['203.0.113.10', '10.0.0.5']) }
+
+      it 'blocks wholesale without connecting' do
+        result = logic.send(:test_oidc_connection)
+
+        expect(result[:details][:error_code]).to eq('blocked_target')
+        expect(result.inspect).not_to include('10.0.0.5')
+        expect(Net::HTTP).not_to have_received(:new)
+      end
+    end
+
+    context 'when the issuer resolves to a public address' do
+      let(:discovery_body) do
+        {
+          issuer: issuer,
+          authorization_endpoint: "#{issuer}/authorize",
+          token_endpoint: "#{issuer}/token",
+          jwks_uri: "#{issuer}/jwks",
+        }.to_json
+      end
+
+      before do
+        stub_issuer_resolution(['203.0.113.10'])
+        allow(http_instance).to receive(:request).and_return(success_response(discovery_body))
+      end
+
+      it 'pins the connection to the validated IP' do
+        result = logic.send(:test_oidc_connection)
+
+        expect(result[:success]).to be true
+        # Explicit nil p_addr disables environment-proxy pickup (http_proxy),
+        # which would otherwise silently bypass the IP pinning.
+        expect(Net::HTTP).to have_received(:new).with('idp.example.com', 443, nil)
+        expect(http_instance).to have_received(:ipaddr=).with('203.0.113.10')
+      end
+    end
+  end
+
+  describe '#test_entra_id_connection' do
+    # Entra's discovery URL is built from the tenant, not the issuer, and
+    # never passes through valid_issuer_host? — fetch_url's guard is the
+    # only enforcement on this path.
+    let(:provider_type) { 'entra_id' }
+    let(:issuer) { nil }
+    let(:tenant_id) { '11111111-2222-3333-4444-555555555555' }
+
+    it 'still enforces the egress guard at fetch time' do
+      stub_issuer_resolution(['192.168.1.10'])
+
+      result = logic.send(:test_entra_id_connection)
+
+      expect(result[:success]).to be false
+      expect(result[:message]).to eq('Entra ID issuer resolves to a blocked address')
+      expect(result[:details][:error_code]).to eq('blocked_target')
+      expect(result.inspect).not_to include('192.168.1.10')
+      expect(Net::HTTP).not_to have_received(:new)
+    end
+
+    it 'pins allowed resolutions to the validated IP' do
+      stub_issuer_resolution(['203.0.113.20'])
+      body = {
+        issuer: 'https://login.microsoftonline.com/x/v2.0',
+        authorization_endpoint: 'https://login.microsoftonline.com/x/authorize',
+        token_endpoint: 'https://login.microsoftonline.com/x/token',
+        jwks_uri: 'https://login.microsoftonline.com/x/jwks',
+      }.to_json
+      allow(http_instance).to receive(:request).and_return(success_response(body))
+
+      result = logic.send(:test_entra_id_connection)
+
+      expect(result[:success]).to be true
+      expect(Net::HTTP).to have_received(:new).with('login.microsoftonline.com', 443, nil)
+      expect(http_instance).to have_received(:ipaddr=).with('203.0.113.20')
+    end
+  end
+end

--- a/apps/api/domains/spec/logic/sso_config/test_connection_spec.rb
+++ b/apps/api/domains/spec/logic/sso_config/test_connection_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe DomainsAPI::Logic::SsoConfig::TestConnection do
     allow(OT).to receive(:ld)
     allow(OT).to receive(:le)
 
+    # Upstream valid_issuer_host? resolves the host via Resolv.getaddresses and
+    # now fails closed on empty resolution. Stub it to a public IP so the
+    # save-time check passes and these tests exercise fetch_url's pinned guard
+    # (the enforcement point). Guard.resolve_addresses is the separately-stubbed
+    # fetch-time seam, so a test can model DNS rebinding: public at check time,
+    # something else at fetch time.
+    allow(Resolv).to receive(:getaddresses).and_return(['203.0.113.10'])
+
     allow(Net::HTTP).to receive(:new).and_return(http_instance)
     allow(http_instance).to receive(:ipaddr=)
     allow(http_instance).to receive(:use_ssl=)

--- a/apps/web/auth/config/features/omniauth.rb
+++ b/apps/web/auth/config/features/omniauth.rb
@@ -21,9 +21,20 @@
 # required lazily, per definition, in configure_provider.
 require_relative '../../../../../lib/onetime/sso_provider/registry'
 
+# Runtime OIDC egress pinning (DNS-rebinding guard). Defines
+# Auth::OidcHttpPinning; installed below, first thing in configure.
+require_relative '../oidc_http_pinning'
+
 module Auth::Config::Features
   module OmniAuth
     def self.configure(auth)
+      # Pin OIDC egress (discovery/JWKS/token) to save-time-validated IPs
+      # BEFORE any provider registers: OpenIDConnect.http_config is
+      # set-once per process and skips already-configured sub-protocols,
+      # so this must be the first http_config caller. See
+      # ../oidc_http_pinning.rb for the full rationale.
+      Auth::OidcHttpPinning.install!
+
       auth.enable :omniauth
 
       # Route prefix for OmniAuth endpoints

--- a/apps/web/auth/config/oidc_http_pinning.rb
+++ b/apps/web/auth/config/oidc_http_pinning.rb
@@ -1,0 +1,104 @@
+# apps/web/auth/config/oidc_http_pinning.rb
+#
+# frozen_string_literal: true
+
+# DNS-rebinding guard for runtime OIDC egress (discovery, JWKS, token
+# exchange) — the request-time half of the tenant-issuer SSRF story.
+#
+# WHY THIS EXISTS
+#
+#   Tenant-configured issuer URLs are validated when the SSO config is
+#   SAVED (SsoConfig::SsrfProtection resolves the host and rejects
+#   forbidden ranges). But the OIDC gems re-resolve DNS at REQUEST time:
+#   omniauth_openid_connect -> openid_connect -> swd / webfinger /
+#   rack-oauth2 each build their own Faraday connection and dial whatever
+#   the hostname resolves to *now*. An attacker who controls the issuer's
+#   DNS can pass save-time validation with a public A record, then flip
+#   the record to 169.254.169.254 (or a loopback/internal address) before
+#   the first discovery fetch — classic validate-then-re-resolve rebinding.
+#
+# WHY THIS SEAM
+#
+#   The Faraday connections live inside the gems (OpenIDConnect.http_client,
+#   SWD.http_client, WebFinger, Rack::OAuth2.http_client); there is no app
+#   callsite to wrap. The one supported hook is OpenIDConnect.http_config,
+#   which yields each gem's Faraday builder. There we swap the adapter for
+#   :net_http with a config block that Net::HTTP invokes per request
+#   (faraday-net_http#configure_request), receiving the live Net::HTTP
+#   instance BEFORE it connects. Setting `http.ipaddr = <validated ip>`
+#   dials that exact IP while `http.address` (the hostname) still drives
+#   the Host header, SNI, and certificate verification — resolution and
+#   connection become one atomic, validated step.
+#
+#   This works because each gem's builder calls
+#   `faraday.adapter Faraday.default_adapter` BEFORE invoking http_config,
+#   and Faraday 2's RackBuilder#adapter REPLACES the adapter rather than
+#   appending — so the adapter registered here wins.
+#
+# ORDERING CONSTRAINT (set-once + propagation-skip)
+#
+#   OpenIDConnect.http_config stores its block with `@@http_config ||=`
+#   (SET-ONCE per process) and propagates it to SWD, WebFinger and
+#   Rack::OAuth2 — but SKIPS any sub-protocol that already has a config.
+#   Two consequences:
+#
+#     1. install! must run BEFORE any other http_config caller, or the
+#        pinning silently never applies to some (or all) of the gems.
+#        Today there is no other caller anywhere in the app; the spec
+#        (spec/unit/oidc_http_pinning_spec.rb) locks in that after
+#        install! all four modules share this exact block.
+#     2. Re-running install! is harmless (`||=` keeps the first block),
+#        so repeated config loads in tests are safe — but a re-run can
+#        never REPLACE an earlier, different block. If a sub-protocol
+#        ever reports a different http_config than OpenIDConnect, some
+#        other caller won the race; find it and remove it.
+#
+# PROXY FAIL-CLOSED
+#
+#   `http.ipaddr=` controls the TCP dial target. Through a forward proxy
+#   the PROXY makes the outbound connection and re-resolves the hostname
+#   itself, so pinning is void. faraday-net_http passes an explicit nil
+#   proxy unless a Faraday proxy is deliberately configured, so
+#   `http.proxy_address` is only non-nil on purpose — and in that case we
+#   refuse rather than silently un-pin.
+#
+# See: lib/onetime/http/guard.rb (blocklists + pinned_address!)
+# See: apps/api/domains/logic/sso_config/ssrf_protection.rb
+#      (the save-time half)
+
+module Auth
+  module OidcHttpPinning
+    # Per-request Net::HTTP configuration, invoked by faraday-net_http with
+    # the live connection object before it dials. Extracted as a constant so
+    # the unit spec can drive it with a double instead of network fakery.
+    ADAPTER_CONFIG = ->(http) do
+      if http.proxy_address
+        raise Onetime::Http::Guard::Blocked,
+          'OIDC egress pinning cannot operate through a forward proxy; ' \
+          'remove the proxy or disable SSO'
+      end
+
+      http.ipaddr = Onetime::Http::Guard.pinned_address!(http.address)
+    end
+
+    # The block handed to OpenIDConnect.http_config: replaces each gem's
+    # default adapter with :net_http carrying ADAPTER_CONFIG.
+    HTTP_CONFIG = ->(faraday) do
+      faraday.adapter :net_http, &ADAPTER_CONFIG
+    end
+
+    # Install the pinning hook process-wide. Idempotent (see the ordering
+    # note above). Called from Auth::Config::Features::OmniAuth.configure,
+    # i.e. at boot, before any provider is registered and before any OIDC
+    # traffic can occur — and only in processes that can serve SSO
+    # (AUTHENTICATION_MODE=full with omniauth or org SSO enabled).
+    def self.install!
+      # openid_connect is a hard transitive dependency (via
+      # omniauth_openid_connect in the Gemfile), required here rather than
+      # at file load so merely loading the config tree stays gem-lazy.
+      require 'openid_connect'
+
+      OpenIDConnect.http_config(&HTTP_CONFIG)
+    end
+  end
+end

--- a/apps/web/auth/config/oidc_http_pinning.rb
+++ b/apps/web/auth/config/oidc_http_pinning.rb
@@ -53,6 +53,18 @@
 #        ever reports a different http_config than OpenIDConnect, some
 #        other caller won the race; find it and remove it.
 #
+# SINGLE-PIN BY DESIGN AT THIS SEAM
+#
+#   Guard.try_each_address! gives callers that own their dial loop a
+#   reachability fallback across ALL validated addresses (webhook delivery
+#   and SSO test-connection use it). This hook cannot: faraday-net_http
+#   yields the live Net::HTTP instance exactly once, immediately before it
+#   dials — falling back to a different address would mean re-running the
+#   entire Faraday request, and this seam does not control the request
+#   cycle (it spans four gems: OpenIDConnect, SWD, WebFinger, Rack::OAuth2).
+#   pinned_address! prefers IPv4, which already sidesteps the common
+#   broken-dual-stack failure mode (unreachable AAAA ahead of a healthy A).
+#
 # PROXY FAIL-CLOSED
 #
 #   `http.ipaddr=` controls the TCP dial target. Through a forward proxy

--- a/apps/web/auth/spec/support/omniauth_test_helper.rb
+++ b/apps/web/auth/spec/support/omniauth_test_helper.rb
@@ -324,6 +324,17 @@ RSpec.configure do |config|
   # Ensures stubs are fresh after any WebMock.reset!
   config.before(:each, :omniauth_mock) do
     stub_oidc_discovery
+
+    # OIDC request-phase traffic now runs through the pinned Net::HTTP adapter
+    # installed by Auth::OidcHttpPinning (OpenIDConnect.http_config), which
+    # resolves the issuer host itself before dialing. That lookup is real DNS
+    # inside the adapter block, below the level WebMock intercepts, so the
+    # placeholder issuer (an unresolvable .invalid host) makes the guard raise
+    # and the request phase redirect to /signin?auth_error=sso_failed.
+    #
+    # Stub the resolver seam, not the guard: validation and pinning still run
+    # for real, and WebMock serves the stubbed discovery response as before.
+    allow(Onetime::Http::Guard).to receive(:resolve_addresses).and_return(['203.0.113.10'])
   end
 
   config.after(:each, :omniauth_mock) do

--- a/apps/web/auth/spec/unit/oidc_http_pinning_spec.rb
+++ b/apps/web/auth/spec/unit/oidc_http_pinning_spec.rb
@@ -1,0 +1,207 @@
+# apps/web/auth/spec/unit/oidc_http_pinning_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for Auth::OidcHttpPinning — the process-global
+# OpenIDConnect.http_config hook that pins runtime OIDC egress (discovery,
+# JWKS, token exchange) to IPs validated by Onetime::Http::Guard, closing
+# the save-time-validate / request-time-re-resolve DNS-rebinding window.
+#
+# Covers:
+# - install! propagates ONE shared block to OpenIDConnect, SWD, WebFinger
+#   and Rack::OAuth2 (the gems that carry tenant-issuer OIDC traffic)
+# - set-once semantics: a later http_config caller cannot displace the
+#   pinning block; install! itself is idempotent
+# - the propagation-skip hazard that makes install-first mandatory
+# - ADAPTER_CONFIG behavior against a Net::HTTP double: pins ipaddr,
+#   raises Guard::Blocked for blocked hosts, fails closed on a proxy
+# - end-to-end through a gem-shaped Faraday connection (adapter declared
+#   first, HTTP_CONFIG applied after — exactly what each gem's builder
+#   does), under WebMock
+#
+# These are unit tests — no Valkey and no full app boot. The gems'
+# http_config storage is process-global and set-once, so every example
+# snapshots and restores it (see around hook) to avoid leaking the hook
+# into sibling spec files that expect a pristine OpenIDConnect config.
+#
+# Run:
+#   pnpm run test:rspec apps/web/auth/spec/unit/oidc_http_pinning_spec.rb
+
+require_relative '../spec_helper'
+require 'openid_connect'
+require_relative '../../config/oidc_http_pinning'
+
+RSpec.describe Auth::OidcHttpPinning do
+  # Where each gem stores its http_config block. OpenIDConnect, SWD and
+  # Rack::OAuth2 use a class variable; WebFinger (module_function) uses a
+  # module-level instance variable. Kept here, not in the hook file: the
+  # hook only ever writes through the public OpenIDConnect.http_config API.
+  def http_config_stores
+    [
+      [OpenIDConnect, :cvar],
+      [SWD,           :cvar],
+      [Rack::OAuth2,  :cvar],
+      [WebFinger,     :ivar],
+    ]
+  end
+
+  def read_http_config(mod, kind)
+    case kind
+    when :cvar
+      mod.class_variable_defined?(:@@http_config) ? mod.class_variable_get(:@@http_config) : nil
+    when :ivar
+      mod.instance_variable_get(:@http_config)
+    end
+  end
+
+  def write_http_config(mod, kind, value)
+    case kind
+    when :cvar then mod.class_variable_set(:@@http_config, value)
+    when :ivar then mod.instance_variable_set(:@http_config, value)
+    end
+  end
+
+  def clear_http_configs
+    http_config_stores.each { |mod, kind| write_http_config(mod, kind, nil) }
+  end
+
+  # http_config is set-once per process across four gems. Snapshot before
+  # each example and restore after, so (a) examples are order-independent
+  # and (b) whatever state the surrounding suite had — unset in a pure
+  # unit run, installed when the full auth app booted first — is exactly
+  # what it gets back.
+  around do |example|
+    saved = http_config_stores.map { |mod, kind| [mod, kind, read_http_config(mod, kind)] }
+    begin
+      example.run
+    ensure
+      saved.each { |mod, kind, value| write_http_config(mod, kind, value) }
+    end
+  end
+
+  before { clear_http_configs }
+
+  describe '.install!' do
+    it 'propagates the same non-nil block to all four OIDC-traffic gems' do
+      described_class.install!
+
+      expect(OpenIDConnect.http_config).to eq(described_class::HTTP_CONFIG)
+      expect(SWD.http_config).to eq(described_class::HTTP_CONFIG)
+      expect(WebFinger.http_config).to eq(described_class::HTTP_CONFIG)
+      expect(Rack::OAuth2.http_config).to eq(described_class::HTTP_CONFIG)
+    end
+
+    it 'is idempotent' do
+      described_class.install!
+      described_class.install!
+
+      expect(OpenIDConnect.http_config).to eq(described_class::HTTP_CONFIG)
+      expect(SWD.http_config).to eq(described_class::HTTP_CONFIG)
+    end
+
+    it 'cannot be displaced by a later http_config caller (set-once)' do
+      described_class.install!
+
+      interloper = ->(faraday) {}
+      OpenIDConnect.http_config(&interloper)
+
+      expect(OpenIDConnect.http_config).to eq(described_class::HTTP_CONFIG)
+      expect(SWD.http_config).to eq(described_class::HTTP_CONFIG)
+      expect(WebFinger.http_config).to eq(described_class::HTTP_CONFIG)
+      expect(Rack::OAuth2.http_config).to eq(described_class::HTTP_CONFIG)
+    end
+
+    # OpenIDConnect.http_config propagates to sub-protocols with
+    # `unless klass.http_config` — an already-configured gem is SKIPPED,
+    # silently. This example documents WHY install! must be the first
+    # http_config caller in the process: were anything to configure (say)
+    # SWD before boot, discovery traffic through SWD would dial unpinned
+    # while the other gems pin.
+    it 'does not reach a sub-protocol that was configured first (install-first hazard)' do
+      interloper = ->(faraday) {}
+      SWD.http_config(&interloper)
+
+      described_class.install!
+
+      expect(SWD.http_config).to eq(interloper)
+      expect(OpenIDConnect.http_config).to eq(described_class::HTTP_CONFIG)
+      expect(WebFinger.http_config).to eq(described_class::HTTP_CONFIG)
+      expect(Rack::OAuth2.http_config).to eq(described_class::HTTP_CONFIG)
+    end
+  end
+
+  describe 'ADAPTER_CONFIG (per-request Net::HTTP hook)' do
+    it 'pins the connection to the Guard-validated address for the target host' do
+      http = instance_double(Net::HTTP, proxy_address: nil, address: 'idp.example.com')
+      allow(Onetime::Http::Guard).to receive(:pinned_address!)
+        .with('idp.example.com').and_return('203.0.113.7')
+
+      expect(http).to receive(:ipaddr=).with('203.0.113.7')
+
+      described_class::ADAPTER_CONFIG.call(http)
+    end
+
+    it 'raises Guard::Blocked for a blocked host before any connection is pinned' do
+      # instance_double with no ipaddr= stub: any pin attempt after the
+      # raise would itself fail the example.
+      http = instance_double(Net::HTTP, proxy_address: nil, address: 'internal.evil.example')
+      allow(Onetime::Http::Guard).to receive(:pinned_address!)
+        .and_raise(Onetime::Http::Guard::Blocked, 'blocked address 169.254.169.254')
+
+      expect {
+        described_class::ADAPTER_CONFIG.call(http)
+      }.to raise_error(Onetime::Http::Guard::Blocked, /blocked address/)
+    end
+
+    it 'fails closed when a forward proxy is configured, without resolving' do
+      http = instance_double(Net::HTTP, proxy_address: '10.9.8.7', address: 'idp.example.com')
+      allow(Onetime::Http::Guard).to receive(:pinned_address!)
+
+      expect {
+        described_class::ADAPTER_CONFIG.call(http)
+      }.to raise_error(Onetime::Http::Guard::Blocked, /forward proxy/)
+
+      expect(Onetime::Http::Guard).not_to have_received(:pinned_address!)
+    end
+  end
+
+  describe 'HTTP_CONFIG through a gem-shaped Faraday connection' do
+    # Build the connection the way OpenIDConnect/SWD/WebFinger/Rack::OAuth2
+    # builders do: default adapter declared FIRST, http_config applied
+    # after. Faraday 2's RackBuilder#adapter replaces rather than appends,
+    # which is what lets HTTP_CONFIG's :net_http adapter win.
+    def gem_shaped_connection(url)
+      Faraday.new(url: url) do |faraday|
+        faraday.adapter Faraday.default_adapter
+        described_class::HTTP_CONFIG.call(faraday)
+      end
+    end
+
+    it 'invokes the pinning hook with the target host on a real request path' do
+      allow(Onetime::Http::Guard).to receive(:pinned_address!)
+        .with('idp.example.com').and_return('203.0.113.7')
+      stub = WebMock.stub_request(:get, 'https://idp.example.com/.well-known/openid-configuration')
+        .to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
+
+      response = gem_shaped_connection('https://idp.example.com')
+        .get('/.well-known/openid-configuration')
+
+      expect(response.status).to eq(200)
+      expect(Onetime::Http::Guard).to have_received(:pinned_address!).with('idp.example.com')
+      expect(stub).to have_been_requested
+    end
+
+    it 'aborts a blocked host before the request is issued' do
+      allow(Onetime::Http::Guard).to receive(:pinned_address!)
+        .and_raise(Onetime::Http::Guard::Blocked, 'no A/AAAA records for rebound.example')
+      stub = WebMock.stub_request(:get, 'https://rebound.example/token')
+        .to_return(status: 200, body: '{}')
+
+      expect {
+        gem_shaped_connection('https://rebound.example').get('/token')
+      }.to raise_error(Onetime::Http::Guard::Blocked)
+
+      expect(stub).not_to have_been_requested
+    end
+  end
+end

--- a/lib/onetime.rb
+++ b/lib/onetime.rb
@@ -425,6 +425,7 @@ end
 require_relative 'onetime/alias'
 require_relative 'onetime/errors'
 require_relative 'onetime/error_handler'
+require_relative 'onetime/http/guard' # needs Onetime::Problem (errors) first
 require_relative 'onetime/version'
 require_relative 'onetime/config'
 require_relative 'onetime/config_generator'

--- a/lib/onetime/http/guard.rb
+++ b/lib/onetime/http/guard.rb
@@ -4,6 +4,7 @@
 
 require 'resolv'
 require 'ipaddr'
+require 'socket'
 
 module Onetime
   module Http
@@ -66,6 +67,16 @@ module Onetime
         64:ff9b::/96 64:ff9b:1::/48 2001::/32 2002::/16 2001:db8::/32
       ].map { |cidr| IPAddr.new(cidr) }.freeze
 
+      # IPv4-mapped (::ffff:0:0/96) and the deprecated IPv4-compatible (::/96)
+      # IPv6 forms carry a 32-bit IPv4 destination in their low bits. We detect
+      # them by prefix rather than IPAddr#ipv4_mapped?/#ipv4_compat? because the
+      # #ipv4_compat? predicate is obsolete in Ruby 3.4+ (it warns and is slated
+      # for removal); a prefix test is stable and warning-free. The embedded
+      # IPv4 is the low 32 bits (see #blocked_ip?).
+      IPV4_MAPPED_PREFIX = IPAddr.new('::ffff:0:0/96').freeze
+      IPV4_COMPAT_PREFIX = IPAddr.new('::/96').freeze
+      LOW32_MASK         = 0xffff_ffff
+
       # extend self (rather than module_function) keeps every method callable
       # both as Guard.blocked_ip?(...) and as an instance method for classes
       # that `include Guard`. The DNS seam stays stubbable in tests by
@@ -84,13 +95,16 @@ module Onetime
         ip = addr.is_a?(IPAddr) ? addr : IPAddr.new(addr.to_s)
         # Unwrap IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible (::a.b.c.d)
         # IPv6 to the embedded IPv4 so the v4 range list actually sees it.
-        # #native returns the address unchanged when it is neither, so this
-        # is safe for all IPs.
-        ip = ip.native if ip.ipv6? && (ip.ipv4_mapped? || ip.ipv4_compat?)
+        # Detected by prefix (not the obsolete #ipv4_compat? predicate); the
+        # embedded IPv4 is the low 32 bits. AF_INET keeps the result an IPv4
+        # IPAddr so the v4 branch below applies.
+        if ip.ipv6? && (IPV4_MAPPED_PREFIX.include?(ip) || IPV4_COMPAT_PREFIX.include?(ip))
+          ip = IPAddr.new(ip.to_i & LOW32_MASK, Socket::AF_INET)
+        end
 
-        # Unspecified address in either family (0.0.0.0, :: — including the
-        # ::0.0.0.0 spelling, which is not ipv4_compat? so the unwrap above
-        # leaves it as ::). Both route to localhost as a connect target.
+        # Unspecified address in either family (0.0.0.0, :: — the :: forms are
+        # unwrapped to 0.0.0.0 above, native 0.0.0.0 lands here directly). Both
+        # route to localhost as a connect target.
         return true if ip.to_i.zero?
 
         # 169.254.0.0/16 and fe80::/10 are already in BLOCKED_V4/BLOCKED_V6;

--- a/lib/onetime/http/guard.rb
+++ b/lib/onetime/http/guard.rb
@@ -26,11 +26,14 @@ module Onetime
     #     wholesale (defeats one-public-one-private split RRsets),
     #   - empty resolution is rejected (nothing resolvable, nothing fetchable).
     #
-    # Callers that dial the returned addresses should pin the connection to one
-    # exact validated IP (e.g. Net::HTTP#ipaddr=) so no second DNS resolution
-    # happens at connect time — closing the classic validate-then-reresolve
-    # (DNS-rebinding) window. See SafeFetch for the canonical pinned-dial
-    # implementation.
+    # Callers that dial the returned addresses should pin the connection to
+    # one exact validated IP (e.g. Net::HTTP#ipaddr=) so no second DNS
+    # resolution happens at connect time — closing the classic
+    # validate-then-reresolve (DNS-rebinding) window. Callers that own their
+    # dial loop should use #try_each_address!, which walks ALL validated
+    # addresses on connect-level reachability errors (each dial still pinned
+    # to one exact IP); SafeFetch implements the same fallback over its own
+    # per-instance resolver seam.
     module Guard
       # Raised when a host/address is a forbidden egress target (blocked
       # range, unparseable address, or empty resolution).
@@ -146,13 +149,54 @@ module Onetime
         v4 + v6
       end
 
-      # The single address a caller should pin its connection to.
+      # The single address a caller should pin its connection to. For callers
+      # that control their own dial loop, prefer #try_each_address!: it keeps
+      # the same per-dial pinning but falls back across the remaining
+      # validated addresses when one is unreachable. This single-address form
+      # exists for seams that get exactly one shot at configuring a
+      # connection (see Auth::OidcHttpPinning).
       #
       # @param host [String]
       # @return [String] the first validated address (IPv4 preferred)
       # @raise [Blocked]
       def pinned_address!(host)
         resolve_and_validate!(host).first
+      end
+
+      # Connect-time failures that justify dialing the next validated
+      # address. Deliberately excludes timeouts (falling through would spend
+      # a full extra open-timeout per address) and all post-connect errors.
+      # These errnos surface from connect(2) in microseconds, so walking the
+      # list adds no meaningful wall-clock. Shared with SafeFetch's dial loop.
+      CONNECT_FALLBACK_ERRNOS = [
+        Errno::EHOSTUNREACH,  # no route to host (e.g. AAAA on a v6-broken network)
+        Errno::ENETUNREACH,   # no route to network (v4-only or v6-only client)
+        Errno::EADDRNOTAVAIL, # no usable local address for this family
+        Errno::ECONNREFUSED,  # this endpoint is down; another may serve
+      ].freeze
+
+      # Resolve + validate host, then yield each validated address in order
+      # (IPv4-first) until the block completes without a connect-level
+      # reachability error, returning that block's value. The caller dials
+      # inside the block with the connection pinned to the yielded IP
+      # (Net::HTTP#ipaddr=), so walking the list is a reachability fallback
+      # across already-validated addresses — never a widening of the target
+      # set. Non-connect errors (timeouts, TLS, HTTP failures) propagate
+      # immediately from the first dial that raises them; when every address
+      # fails to connect, the last errno propagates unchanged.
+      #
+      # @param host [String]
+      # @yieldparam addr [String] one validated address to pin and dial
+      # @return the block's value for the first reachable address
+      # @raise [Blocked] if resolution or validation fails
+      def try_each_address!(host)
+        last_error = nil
+        resolve_and_validate!(host).each do |addr|
+          return yield(addr)
+        rescue *CONNECT_FALLBACK_ERRNOS => ex
+          last_error = ex
+        end
+        raise last_error # never nil: resolve_and_validate! raises on empty
       end
 
       # Isolated for testability (redefined in the unit tryout to avoid real

--- a/lib/onetime/http/guard.rb
+++ b/lib/onetime/http/guard.rb
@@ -1,0 +1,161 @@
+# lib/onetime/http/guard.rb
+#
+# frozen_string_literal: true
+
+require 'resolv'
+require 'ipaddr'
+
+module Onetime
+  module Http
+    # Shared SSRF egress guard: the single source of truth for "is this IP a
+    # forbidden egress target" and "resolve this host and give me addresses
+    # safe to pin".
+    #
+    # Unifies three previously divergent per-callsite blocklists
+    # (SafeFetch::BLOCKED_V4/V6, SsoConfig::SsrfProtection's
+    # TRANSITION_RANGES/BLOCKED_IPV4_RANGES, and DispatchNotification's
+    # loopback/private/link-local-only webhook check) into one deny-by-default,
+    # fail-closed range set. Each list below is the UNION of its predecessors —
+    # notably Teredo (2001::/32), which SafeFetch lacked.
+    #
+    # The guard is deny-by-default and fail-closed:
+    #   - anything IPAddr cannot parse is BLOCKED (encoded-loopback smuggling
+    #     like "2130706433" / "0x7f000001" fails closed),
+    #   - a host whose RRset contains even ONE blocked address is rejected
+    #     wholesale (defeats one-public-one-private split RRsets),
+    #   - empty resolution is rejected (nothing resolvable, nothing fetchable).
+    #
+    # Callers that dial the returned addresses should pin the connection to one
+    # exact validated IP (e.g. Net::HTTP#ipaddr=) so no second DNS resolution
+    # happens at connect time — closing the classic validate-then-reresolve
+    # (DNS-rebinding) window. See SafeFetch for the canonical pinned-dial
+    # implementation.
+    module Guard
+      # Raised when a host/address is a forbidden egress target (blocked
+      # range, unparseable address, or empty resolution).
+      class Blocked < Onetime::Problem; end
+
+      # Deny-by-default range lists. A resolved IP is blocked unless it
+      # belongs to NONE of these. v4-mapped and v4-compatible IPv6 are
+      # unwrapped to their v4 form first (see #blocked_ip?).
+      BLOCKED_V4 = %w[
+        0.0.0.0/8 10.0.0.0/8 100.64.0.0/10 127.0.0.0/8 169.254.0.0/16
+        172.16.0.0/12 192.0.0.0/24 192.168.0.0/16 198.18.0.0/15
+        224.0.0.0/4 240.0.0.0/4
+      ].map { |cidr| IPAddr.new(cidr) }.freeze
+      # 0.0.0.0/8      "this host on this network" (RFC 1122; 0.0.0.0
+      #                connects to localhost on Linux — a loopback bypass the
+      #                native IPAddr predicates miss)
+      # 100.64.0.0/10  CGNAT / shared address space (RFC 6598)
+      # 192.0.0.0/24   IETF protocol assignments (RFC 6890)
+      # 198.18.0.0/15  benchmarking (RFC 2544)
+      # 224.0.0.0/4    multicast
+      # 240.0.0.0/4    reserved + 255.255.255.255 broadcast
+
+      # ::/96 is the deprecated IPv4-compatible block (subsumes ::, ::1, and
+      # e.g. ::127.0.0.1). The IPv6 transition prefixes — 2002::/16 (6to4),
+      # the 64:ff9b* NAT64 ranges, and 2001::/32 (Teredo, RFC 4380) — all
+      # embed a routable IPv4 destination the native IPAddr predicates never
+      # look at; they are blocked wholesale because no legitimate egress
+      # target lives on a translation address, and decoding-then-allowing
+      # would just reintroduce the bypass surface we are trying to close.
+      # ::ffff:0:0/96 is the separate v4-MAPPED block (unwrapped to v4 in
+      # #blocked_ip?, listed here as a belt).
+      BLOCKED_V6 = %w[
+        ::/96 fc00::/7 fe80::/10 ff00::/8 ::ffff:0:0/96
+        64:ff9b::/96 64:ff9b:1::/48 2001::/32 2002::/16 2001:db8::/32
+      ].map { |cidr| IPAddr.new(cidr) }.freeze
+
+      # extend self (rather than module_function) keeps every method callable
+      # both as Guard.blocked_ip?(...) and as an instance method for classes
+      # that `include Guard`. The DNS seam stays stubbable in tests by
+      # redefining the singleton method (def Guard.resolve_addresses).
+      extend self
+
+      # Deny-by-default IP check. Accepts a String or IPAddr. Fails closed on
+      # anything IPAddr cannot parse — notably Ruby's IPAddr rejects
+      # decimal/octal/hex-encoded forms (e.g. "2130706433", "0x7f000001")
+      # with InvalidAddressError, so such loopback-smuggling attempts are
+      # treated as blocked rather than resolved.
+      #
+      # @param addr [String, IPAddr]
+      # @return [Boolean] true if the address is a forbidden egress target
+      def blocked_ip?(addr)
+        ip = addr.is_a?(IPAddr) ? addr : IPAddr.new(addr.to_s)
+        # Unwrap IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible (::a.b.c.d)
+        # IPv6 to the embedded IPv4 so the v4 range list actually sees it.
+        # #native returns the address unchanged when it is neither, so this
+        # is safe for all IPs.
+        ip = ip.native if ip.ipv6? && (ip.ipv4_mapped? || ip.ipv4_compat?)
+
+        # Unspecified address in either family (0.0.0.0, :: — including the
+        # ::0.0.0.0 spelling, which is not ipv4_compat? so the unwrap above
+        # leaves it as ::). Both route to localhost as a connect target.
+        return true if ip.to_i.zero?
+
+        # 169.254.0.0/16 and fe80::/10 are already in BLOCKED_V4/BLOCKED_V6;
+        # this is a redundant early-out on IPAddr's own predicate, not extra
+        # coverage.
+        return true if ip.link_local?
+
+        (ip.ipv4? ? BLOCKED_V4 : BLOCKED_V6).any? { |net| net.include?(ip) }
+      rescue IPAddr::InvalidAddressError
+        true # fail closed
+      end
+
+      # Resolve host A + AAAA, validate EVERY address, and fail closed: raise
+      # if ANY resolved address is blocked (defeats one-public-one-private
+      # RRsets). Returns ALL validated addresses uniq'd and ordered
+      # IPv4-first: resolvers commonly list AAAA ahead of A, and a machine
+      # with an IPv6 address but no IPv6 route (broken dual-stack) would
+      # otherwise dial an unreachable v6 and never try a perfectly good v4.
+      #
+      # IP-literal hosts: Resolv::DNS#getaddresses returns [] for a literal
+      # (it speaks only DNS; the generic Resolv.getaddresses handles literals
+      # via the hosts resolver, which we deliberately avoid), so a literal
+      # host is validated directly and returned as-is.
+      #
+      # @param host [String] hostname or IP literal
+      # @return [Array<String>] validated addresses, IPv4-first
+      # @raise [Blocked]
+      def resolve_and_validate!(host)
+        addrs = resolve_addresses(host)
+        addrs = [host] if addrs.empty? && ip_literal?(host)
+        raise Blocked, "no A/AAAA records for #{host}" if addrs.empty?
+
+        addrs.each do |addr|
+          raise Blocked, "blocked address #{addr} for #{host}" if blocked_ip?(addr)
+        end
+
+        # Safe to parse: anything unparseable already failed closed in blocked_ip?.
+        v4, v6 = addrs.uniq.partition { |addr| IPAddr.new(addr).ipv4? }
+        v4 + v6
+      end
+
+      # The single address a caller should pin its connection to.
+      #
+      # @param host [String]
+      # @return [String] the first validated address (IPv4 preferred)
+      # @raise [Blocked]
+      def pinned_address!(host)
+        resolve_and_validate!(host).first
+      end
+
+      # Isolated for testability (redefined in the unit tryout to avoid real
+      # DNS). Returns an array of IP strings (both families).
+      def resolve_addresses(host)
+        ::Resolv::DNS.open { |dns| dns.getaddresses(host).map(&:to_s) }
+      end
+
+      # @return [Boolean] true if host parses as an IP address literal
+      #   (IPAddr also accepts the bracketed IPv6 form URI#host returns,
+      #   e.g. "[::1]")
+      def ip_literal?(host)
+        IPAddr.new(host.to_s)
+        true
+      rescue IPAddr::InvalidAddressError
+        false
+      end
+    end
+  end
+end

--- a/lib/onetime/http/safe_fetch.rb
+++ b/lib/onetime/http/safe_fetch.rb
@@ -59,16 +59,11 @@ module Onetime
       SUCCESS_CODES   = (200..299)
 
       # Connect-time failures that justify dialing the next validated address.
-      # Deliberately excludes timeouts (mapped to retriable FetchTimeout — and
-      # falling through would spend a full extra @timeout per address) and all
-      # post-connect errors. These errnos surface from connect(2) in
-      # microseconds, so walking the list adds no meaningful wall-clock.
-      CONNECT_FALLBACK_ERRNOS = [
-        Errno::EHOSTUNREACH,  # no route to host (e.g. AAAA on a v6-broken network)
-        Errno::ENETUNREACH,   # no route to network (v4-only or v6-only client)
-        Errno::EADDRNOTAVAIL, # no usable local address for this family
-        Errno::ECONNREFUSED,  # this endpoint is down; another may serve
-      ].freeze
+      # The list lives on the shared Guard (which also documents the
+      # exclusions: timeouts — mapped here to retriable FetchTimeout — and all
+      # post-connect errors) so every pinned-dial callsite falls back on the
+      # same errno set.
+      CONNECT_FALLBACK_ERRNOS = Guard::CONNECT_FALLBACK_ERRNOS
 
       DEFAULT_HEADERS = { 'user-agent' => 'OnetimeSecret-SafeFetch/1.0' }.freeze
 

--- a/lib/onetime/http/safe_fetch.rb
+++ b/lib/onetime/http/safe_fetch.rb
@@ -2,13 +2,14 @@
 #
 # frozen_string_literal: true
 
-require 'resolv'
 require 'ipaddr'
 require 'net/http'
 require 'openssl'
 require 'uri'
 require 'stringio'
 require 'fastimage'
+
+require_relative 'guard'
 
 module Onetime
   module Http
@@ -18,7 +19,10 @@ module Onetime
     # The guard is deny-by-default and fail-closed. Every fetch:
     #   1. accepts only https:// on port 443 (no scheme/port downgrade surface),
     #   2. resolves the host's A + AAAA records and rejects the request if ANY
-    #      resolved address is private/link-local/loopback/metadata,
+    #      resolved address is private/link-local/loopback/metadata — the range
+    #      check itself is delegated to the shared Onetime::Http::Guard
+    #      blocklists (Guard::Blocked is translated to BlockedTarget at this
+    #      class's boundary, so callers keep rescuing SafeFetch errors only),
     #   3. pins each TCP connect to one exact validated IP (http.ipaddr=) so no
     #      second DNS resolution happens at connect time — closing the classic
     #      validate-then-reresolve (DNS-rebinding) window. Addresses are dialed
@@ -68,23 +72,10 @@ module Onetime
 
       DEFAULT_HEADERS = { 'user-agent' => 'OnetimeSecret-SafeFetch/1.0' }.freeze
 
-      # Deny-by-default range lists. A resolved IP is blocked unless it belongs
-      # to NONE of these. v4-mapped IPv6 is unwrapped to its v4 form first.
-      BLOCKED_V4 = %w[
-        0.0.0.0/8 10.0.0.0/8 100.64.0.0/10 127.0.0.0/8 169.254.0.0/16
-        172.16.0.0/12 192.0.0.0/24 192.168.0.0/16 198.18.0.0/15
-        224.0.0.0/4 240.0.0.0/4
-      ].map { |cidr| IPAddr.new(cidr) }.freeze
-
-      # ::/96 is the deprecated IPv4-compatible block (subsumes ::, ::1, and
-      # e.g. ::127.0.0.1). 2002::/16 (6to4) and the 64:ff9b* NAT64 ranges are
-      # blocked wholesale — no legitimate favicon host lives on a translation
-      # address, so we don't bother decoding the embedded IPv4. ::ffff:0:0/96 is
-      # the separate v4-MAPPED block (unwrapped to v4 in #blocked_ip?).
-      BLOCKED_V6 = %w[
-        ::/96 fc00::/7 fe80::/10 ff00::/8 ::ffff:0:0/96
-        64:ff9b::/96 64:ff9b:1::/48 2002::/16 2001:db8::/32
-      ].map { |cidr| IPAddr.new(cidr) }.freeze
+      # The deny-by-default IP range lists live in the shared SSRF guard
+      # (Onetime::Http::Guard::BLOCKED_V4/BLOCKED_V6) — the single source of
+      # truth for every egress callsite. Note Guard's V6 list also blocks
+      # Teredo (2001::/32), which SafeFetch's former local list lacked.
 
       # Magic-byte sniff family → the MIME we permit and canonicalize to. The
       # HTTP-declared Content-Type is never trusted for the accept decision.
@@ -210,39 +201,41 @@ module Onetime
       # list AAAA ahead of A, and a machine with an IPv6 address but no IPv6
       # route (broken dual-stack) would otherwise dial an unreachable v6 and
       # never try a perfectly good v4.
+      #
+      # Validation is delegated to Guard; resolution goes through this
+      # instance's #resolve_addresses seam (not Guard's own resolver) so the
+      # unit tryout can stub DNS per-instance. Guard::Blocked is translated to
+      # BlockedTarget here so SafeFetch's error contract stays self-contained.
+      # Unlike Guard.resolve_and_validate!, an IP-literal host is NOT accepted:
+      # it resolves to nothing and is rejected as before (a literal would fail
+      # TLS hostname verification anyway).
       def resolve_and_validate!(host)
         addrs = resolve_addresses(host)
-        raise BlockedTarget, "no A/AAAA records for #{host}" if addrs.empty?
+        raise Guard::Blocked, "no A/AAAA records for #{host}" if addrs.empty?
 
         addrs.each do |addr|
-          raise BlockedTarget, "blocked address #{addr} for #{host}" if blocked_ip?(addr)
+          raise Guard::Blocked, "blocked address #{addr} for #{host}" if Guard.blocked_ip?(addr)
         end
 
         # Safe to parse: anything unparseable already failed closed in blocked_ip?.
-        v4, v6 = addrs.partition { |addr| IPAddr.new(addr).ipv4? }
+        v4, v6 = addrs.uniq.partition { |addr| IPAddr.new(addr).ipv4? }
         v4 + v6
+      rescue Guard::Blocked => ex
+        raise BlockedTarget, ex.message
       end
 
-      # Isolated for testability (overridden in the unit tryout to avoid real
-      # DNS). Returns an array of IP strings (both families).
+      # DNS seam, isolated for testability (overridden in the unit tryout to
+      # avoid real DNS). Forwards to Guard's resolver on the real path.
+      # Returns an array of IP strings (both families).
       def resolve_addresses(host)
-        ::Resolv::DNS.open { |dns| dns.getaddresses(host).map(&:to_s) }
+        Guard.resolve_addresses(host)
       end
 
-      # Deny-by-default IP check. Fails closed on anything IPAddr cannot parse —
-      # notably Ruby's IPAddr rejects decimal/octal/hex-encoded forms
-      # (e.g. "2130706433", "0x7f000001") with InvalidAddressError, so such
-      # loopback-smuggling attempts are treated as blocked rather than resolved.
+      # Deny-by-default IP check, delegated to the shared Guard blocklists.
+      # Fails closed on anything IPAddr cannot parse (encoded-loopback
+      # smuggling like "2130706433" / "0x7f000001" is treated as blocked).
       def blocked_ip?(addr)
-        ip = IPAddr.new(addr.to_s)
-        ip = ip.native if ip.ipv6? && ip.ipv4_mapped? # unwrap ::ffff:a.b.c.d → v4
-        # 169.254.0.0/16 and fe80::/10 are already in BLOCKED_V4/BLOCKED_V6; this
-        # is a redundant early-out on IPAddr's own predicate, not extra coverage.
-        return true if ip.link_local?
-
-        (ip.ipv4? ? BLOCKED_V4 : BLOCKED_V6).any? { |net| net.include?(ip) }
-      rescue IPAddr::InvalidAddressError
-        true # fail closed
+        Guard.blocked_ip?(addr)
       end
 
       # Transport seam (overridden in the unit tryout). Opens a connection PINNED

--- a/lib/onetime/http/safe_fetch.rb
+++ b/lib/onetime/http/safe_fetch.rb
@@ -238,8 +238,12 @@ module Onetime
       # while keeping the Host header and TLS SNI set to the hostname so cert
       # verification still works. Does NOT rescue timeouts: #fetch owns that
       # mapping so the real path is exercised by tests.
+      #
+      # The explicit nil p_addr matters: Net::HTTP.new defaults it to :ENV, and a
+      # proxy from http_proxy would make #connect dial the proxy and CONNECT by
+      # hostname — the proxy re-resolves and the pin is silently inert.
       def with_pinned_response(uri, validated_ip)
-        http              = ::Net::HTTP.new(uri.host, uri.port)
+        http              = ::Net::HTTP.new(uri.host, uri.port, nil)
         http.ipaddr       = validated_ip
         http.use_ssl      = true
         http.verify_mode  = OpenSSL::SSL::VERIFY_PEER

--- a/lib/onetime/operations/dispatch_notification.rb
+++ b/lib/onetime/operations/dispatch_notification.rb
@@ -5,8 +5,6 @@
 require 'net/http'
 require 'uri'
 require 'securerandom'
-require 'ipaddr'
-require 'socket'
 
 module Onetime
   module Operations
@@ -228,22 +226,35 @@ module Onetime
       # @return [Net::HTTPResponse] HTTP response
       def send_webhook_request(url, payload)
         # ALPHA: Webhook delivery needs further security review before wide use.
-        # Current mitigations: SSRF protection, TLS verification, timeouts.
+        # Current mitigations: SSRF protection with DNS pinning (single pinned
+        # IP — no multi-address fallback if that one address is unreachable),
+        # TLS verification, timeouts.
         # Missing: request signing, URL allowlisting, rate limiting, payload size limits.
         logger.warn 'Webhook delivery is alpha functionality', url: url
 
         uri = URI.parse(url)
 
-        # SSRF Protection: Resolve hostname and check for private/loopback addresses
-        validate_webhook_target!(uri)
-
-        http = Net::HTTP.new(uri.host, uri.port)
-
-        # Validate scheme and configure SSL
+        # Validate scheme before doing any resolution work
         scheme = (uri.scheme || '').downcase
         unless %w[http https].include?(scheme)
           raise ArgumentError, "Unsupported webhook scheme: #{uri.scheme.inspect}"
         end
+
+        # SSRF Protection with DNS pinning: resolve + validate the hostname
+        # once, then dial that exact IP via Net::HTTP#ipaddr= while the Host
+        # header, SNI, and certificate verification keep using the hostname.
+        # This closes the validate-then-reresolve DNS-rebinding window the
+        # previous Addrinfo check left open. Raises Guard::Blocked (an
+        # Onetime::Problem) for forbidden targets; dispatch_to_channel's
+        # StandardError rescue classifies that as a permanent :error — the
+        # worker never retries per-channel failures.
+        pinned_ip = Onetime::Http::Guard.pinned_address!(uri.host)
+
+        # The explicit nil p_addr disables environment-proxy pickup
+        # (http_proxy env var), which would otherwise route the request
+        # through a proxy and silently bypass the IP pinning below.
+        http        = Net::HTTP.new(uri.host, uri.port, nil)
+        http.ipaddr = pinned_ip
 
         http.use_ssl = (scheme == 'https')
 
@@ -262,24 +273,6 @@ module Onetime
         request.body            = payload.to_json
 
         http.request(request)
-      end
-
-      # Validate webhook target to prevent SSRF attacks
-      # @param uri [URI] Parsed webhook URI
-      # @raise [ArgumentError] If URL resolves to private/loopback address
-      def validate_webhook_target!(uri)
-        # Resolve all IP addresses for the hostname
-        addresses = Addrinfo.getaddrinfo(uri.host, uri.port, nil, :STREAM)
-
-        addresses.each do |addr_info|
-          ip = IPAddr.new(addr_info.ip_address)
-
-          if ip.loopback? || ip.private? || ip.link_local?
-            raise ArgumentError, "Webhook URL resolves to restricted address: #{addr_info.ip_address}"
-          end
-        end
-      rescue SocketError => ex
-        raise ArgumentError, "Cannot resolve webhook hostname: #{ex.message}"
       end
 
       # @return [SemanticLogger::Logger] Logger instance

--- a/lib/onetime/operations/dispatch_notification.rb
+++ b/lib/onetime/operations/dispatch_notification.rb
@@ -226,9 +226,9 @@ module Onetime
       # @return [Net::HTTPResponse] HTTP response
       def send_webhook_request(url, payload)
         # ALPHA: Webhook delivery needs further security review before wide use.
-        # Current mitigations: SSRF protection with DNS pinning (single pinned
-        # IP — no multi-address fallback if that one address is unreachable),
-        # TLS verification, timeouts.
+        # Current mitigations: SSRF protection with DNS pinning (each dial
+        # pinned to one validated IP, with reachability fallback across the
+        # remaining validated addresses), TLS verification, timeouts.
         # Missing: request signing, URL allowlisting, rate limiting, payload size limits.
         logger.warn 'Webhook delivery is alpha functionality', url: url
 
@@ -240,39 +240,41 @@ module Onetime
           raise ArgumentError, "Unsupported webhook scheme: #{uri.scheme.inspect}"
         end
 
-        # SSRF Protection with DNS pinning: resolve + validate the hostname
-        # once, then dial that exact IP via Net::HTTP#ipaddr= while the Host
-        # header, SNI, and certificate verification keep using the hostname.
-        # This closes the validate-then-reresolve DNS-rebinding window the
-        # previous Addrinfo check left open. Raises Guard::Blocked (an
-        # Onetime::Problem) for forbidden targets; dispatch_to_channel's
-        # StandardError rescue classifies that as a permanent :error — the
-        # worker never retries per-channel failures.
-        pinned_ip = Onetime::Http::Guard.pinned_address!(uri.host)
-
-        # The explicit nil p_addr disables environment-proxy pickup
-        # (http_proxy env var), which would otherwise route the request
-        # through a proxy and silently bypass the IP pinning below.
-        http        = Net::HTTP.new(uri.host, uri.port, nil)
-        http.ipaddr = pinned_ip
-
-        http.use_ssl = (scheme == 'https')
-
-        # Explicit TLS verification settings
-        if http.use_ssl?
-          http.verify_mode     = OpenSSL::SSL::VERIFY_PEER
-          http.verify_hostname = true
-        end
-
-        http.open_timeout = WEBHOOK_OPEN_TIMEOUT
-        http.read_timeout = WEBHOOK_READ_TIMEOUT
-
         request                 = Net::HTTP::Post.new(uri.request_uri)
         request['Content-Type'] = 'application/json'
         request['User-Agent']   = Onetime::VERSION.user_agent
         request.body            = payload.to_json
 
-        http.request(request)
+        # SSRF Protection with DNS pinning: resolve + validate the hostname
+        # once, then dial each validated IP via Net::HTTP#ipaddr= while the
+        # Host header, SNI, and certificate verification keep using the
+        # hostname. This closes the validate-then-reresolve DNS-rebinding
+        # window the previous Addrinfo check left open; the fallback walk
+        # only spans already-validated addresses (reachability, not target
+        # widening). Raises Guard::Blocked (an Onetime::Problem) for
+        # forbidden targets; dispatch_to_channel's StandardError rescue
+        # classifies that as a permanent :error — the worker never retries
+        # per-channel failures.
+        Onetime::Http::Guard.try_each_address!(uri.host) do |pinned_ip|
+          # The explicit nil p_addr disables environment-proxy pickup
+          # (http_proxy env var), which would otherwise route the request
+          # through a proxy and silently bypass the IP pinning below.
+          http        = Net::HTTP.new(uri.host, uri.port, nil)
+          http.ipaddr = pinned_ip
+
+          http.use_ssl = (scheme == 'https')
+
+          # Explicit TLS verification settings
+          if http.use_ssl?
+            http.verify_mode     = OpenSSL::SSL::VERIFY_PEER
+            http.verify_hostname = true
+          end
+
+          http.open_timeout = WEBHOOK_OPEN_TIMEOUT
+          http.read_timeout = WEBHOOK_READ_TIMEOUT
+
+          http.request(request)
+        end
       end
 
       # @return [SemanticLogger::Logger] Logger instance

--- a/spec/integration/all/operations/dispatch_notification_spec.rb
+++ b/spec/integration/all/operations/dispatch_notification_spec.rb
@@ -42,20 +42,14 @@ require 'onetime/operations/dispatch_notification'
 RSpec.describe Onetime::Operations::DispatchNotification, type: :integration do
   let(:custid) { 'cust:test-user-456' }
 
-  # Helper to stub Addrinfo for SSRF validation in webhook tests.
-  # Must be called explicitly in webhook test contexts to avoid interfering with Redis client.
-  # Uses and_call_original as fallback so Redis connections still work.
+  # Helper to stub the shared SSRF guard's DNS seam for webhook tests.
+  # Guard.pinned_address! dispatches through Guard.resolve_addresses, so
+  # stubbing that single seam avoids live DNS while keeping the guard's
+  # validation and pinning logic real. Redis is unaffected (the Redis client
+  # does not resolve through Guard).
   def stub_public_ip_resolution
-    addr = instance_double(Addrinfo)
-    allow(addr).to receive(:ip_address).and_return('93.184.216.34') # example.com public IP
-
-    # Stub for webhook hostnames, let other calls (e.g., Redis) pass through
-    # Uses DomainParser.hostname_within_domain? for secure domain boundary checking
-    # to prevent matching attacker-controlled domains like 'attacker-example.com'
-    allow(Addrinfo).to receive(:getaddrinfo).and_call_original
-    allow(Addrinfo).to receive(:getaddrinfo)
-      .with(satisfy { |h| Onetime::Utils::DomainParser.hostname_within_domain?(h, 'example.com') }, anything, anything, anything)
-      .and_return([addr])
+    allow(Onetime::Http::Guard).to receive(:resolve_addresses)
+      .and_return(['93.184.216.34']) # example.com public IP
   end
 
   let(:base_data) do
@@ -196,6 +190,7 @@ RSpec.describe Onetime::Operations::DispatchNotification, type: :integration do
       before do
         stub_public_ip_resolution
         allow(Net::HTTP).to receive(:new).and_return(http_instance)
+        allow(http_instance).to receive(:ipaddr=)
         allow(http_instance).to receive(:use_ssl=)
         allow(http_instance).to receive(:use_ssl?).and_return(true)
         allow(http_instance).to receive(:verify_mode=)
@@ -272,6 +267,7 @@ RSpec.describe Onetime::Operations::DispatchNotification, type: :integration do
         allow(publisher_instance).to receive(:publish).and_return('msg-id')
 
         allow(Net::HTTP).to receive(:new).and_return(http_instance)
+        allow(http_instance).to receive(:ipaddr=)
         allow(http_instance).to receive(:use_ssl=)
         allow(http_instance).to receive(:use_ssl?).and_return(true)
         allow(http_instance).to receive(:verify_mode=)
@@ -434,6 +430,7 @@ RSpec.describe Onetime::Operations::DispatchNotification, type: :integration do
     before do
       stub_public_ip_resolution
       allow(Net::HTTP).to receive(:new).and_return(http_instance)
+      allow(http_instance).to receive(:ipaddr=)
       allow(http_instance).to receive(:use_ssl=)
       allow(http_instance).to receive(:use_ssl?).and_return(true)
       allow(http_instance).to receive(:verify_mode=)
@@ -482,6 +479,7 @@ RSpec.describe Onetime::Operations::DispatchNotification, type: :integration do
     before do
       stub_public_ip_resolution
       allow(Net::HTTP).to receive(:new).and_return(http_instance)
+      allow(http_instance).to receive(:ipaddr=)
       allow(http_instance).to receive(:use_ssl=)
       allow(http_instance).to receive(:verify_mode=)
       allow(http_instance).to receive(:verify_hostname=)
@@ -543,6 +541,7 @@ RSpec.describe Onetime::Operations::DispatchNotification, type: :integration do
 
     before do
       allow(Net::HTTP).to receive(:new).and_return(http_instance)
+      allow(http_instance).to receive(:ipaddr=)
       allow(http_instance).to receive(:use_ssl=)
       allow(http_instance).to receive(:use_ssl?).and_return(true)
       allow(http_instance).to receive(:verify_mode=)
@@ -551,22 +550,21 @@ RSpec.describe Onetime::Operations::DispatchNotification, type: :integration do
       allow(http_instance).to receive(:read_timeout=)
     end
 
-    # Helper to stub Addrinfo for specific IP while allowing Redis to work
+    # Helper to stub the guard's DNS seam for a specific resolved IP. The
+    # guard's validation logic stays real; only resolution is faked.
     def stub_webhook_ip(ip_address)
-      addr = instance_double(Addrinfo)
-      allow(addr).to receive(:ip_address).and_return(ip_address)
-      allow(Addrinfo).to receive(:getaddrinfo).and_call_original
-      allow(Addrinfo).to receive(:getaddrinfo)
-        .with(satisfy { |h| Onetime::Utils::DomainParser.hostname_within_domain?(h, 'example.com') }, anything, anything, anything)
-        .and_return([addr])
+      allow(Onetime::Http::Guard).to receive(:resolve_addresses).and_return([ip_address])
     end
 
-    it 'blocks loopback addresses' do
+    it 'blocks loopback addresses without attempting a connection' do
       stub_webhook_ip('127.0.0.1')
+      allow(http_instance).to receive(:request)
 
       results = described_class.new(data: data).call
 
       expect(results[:via_webhook]).to eq(:error)
+      expect(Net::HTTP).not_to have_received(:new)
+      expect(http_instance).not_to have_received(:request)
     end
 
     it 'blocks private network addresses' do
@@ -575,6 +573,7 @@ RSpec.describe Onetime::Operations::DispatchNotification, type: :integration do
       results = described_class.new(data: data).call
 
       expect(results[:via_webhook]).to eq(:error)
+      expect(Net::HTTP).not_to have_received(:new)
     end
 
     it 'blocks link-local addresses' do
@@ -583,9 +582,20 @@ RSpec.describe Onetime::Operations::DispatchNotification, type: :integration do
       results = described_class.new(data: data).call
 
       expect(results[:via_webhook]).to eq(:error)
+      expect(Net::HTTP).not_to have_received(:new)
     end
 
-    it 'allows public IP addresses' do
+    it 'blocks split RRsets with any restricted address' do
+      allow(Onetime::Http::Guard).to receive(:resolve_addresses)
+        .and_return(['93.184.216.34', '10.0.0.5'])
+
+      results = described_class.new(data: data).call
+
+      expect(results[:via_webhook]).to eq(:error)
+      expect(Net::HTTP).not_to have_received(:new)
+    end
+
+    it 'allows public IP addresses and pins the connection to the validated IP' do
       response = instance_double(Net::HTTPSuccess, code: '200', body: 'OK')
       allow(http_instance).to receive(:request).and_return(response)
       allow(response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
@@ -595,17 +605,21 @@ RSpec.describe Onetime::Operations::DispatchNotification, type: :integration do
       results = described_class.new(data: data).call
 
       expect(results[:via_webhook]).to eq(:success)
+      # Explicit nil p_addr disables environment-proxy pickup so pinning
+      # cannot be silently bypassed via http_proxy.
+      expect(Net::HTTP).to have_received(:new).with('example.com', 443, nil)
+      expect(http_instance).to have_received(:ipaddr=).with('93.184.216.34')
     end
 
     it 'handles DNS resolution failure' do
-      allow(Addrinfo).to receive(:getaddrinfo).and_call_original
-      allow(Addrinfo).to receive(:getaddrinfo)
-        .with(satisfy { |h| Onetime::Utils::DomainParser.hostname_within_domain?(h, 'example.com') }, anything, anything, anything)
-        .and_raise(SocketError, 'getaddrinfo: nodename nor servname provided')
+      # Resolv::DNS#getaddresses returns [] for unresolvable hosts; the guard
+      # fails closed on empty resolution.
+      allow(Onetime::Http::Guard).to receive(:resolve_addresses).and_return([])
 
       results = described_class.new(data: data).call
 
       expect(results[:via_webhook]).to eq(:error)
+      expect(Net::HTTP).not_to have_received(:new)
     end
   end
 

--- a/spec/integration/all/operations/dispatch_notification_spec.rb
+++ b/spec/integration/all/operations/dispatch_notification_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Onetime::Operations::DispatchNotification, type: :integration do
   let(:custid) { 'cust:test-user-456' }
 
   # Helper to stub the shared SSRF guard's DNS seam for webhook tests.
-  # Guard.pinned_address! dispatches through Guard.resolve_addresses, so
+  # Guard.try_each_address! dispatches through Guard.resolve_addresses, so
   # stubbing that single seam avoids live DNS while keeping the guard's
   # validation and pinning logic real. Redis is unaffected (the Redis client
   # does not resolve through Guard).
@@ -620,6 +620,34 @@ RSpec.describe Onetime::Operations::DispatchNotification, type: :integration do
 
       expect(results[:via_webhook]).to eq(:error)
       expect(Net::HTTP).not_to have_received(:new)
+    end
+
+    it 'falls back to the next validated address when the first is unreachable' do
+      response = instance_double(Net::HTTPSuccess, code: '200', body: 'OK')
+      allow(response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+      allow(Onetime::Http::Guard).to receive(:resolve_addresses)
+        .and_return(['93.184.216.34', '93.184.216.35'])
+      allow(http_instance).to receive(:request)
+        .and_invoke(->(_req) { raise Errno::ECONNREFUSED }, ->(_req) { response })
+
+      results = described_class.new(data: data).call
+
+      expect(results[:via_webhook]).to eq(:success)
+      # Each dial stays pinned to one exact validated IP; the fallback walk
+      # never widens beyond the guard-validated set.
+      expect(http_instance).to have_received(:ipaddr=).with('93.184.216.34').ordered
+      expect(http_instance).to have_received(:ipaddr=).with('93.184.216.35').ordered
+    end
+
+    it 'reports an error when every validated address is unreachable' do
+      allow(Onetime::Http::Guard).to receive(:resolve_addresses)
+        .and_return(['93.184.216.34', '93.184.216.35'])
+      allow(http_instance).to receive(:request).and_raise(Errno::ECONNREFUSED)
+
+      results = described_class.new(data: data).call
+
+      expect(results[:via_webhook]).to eq(:error)
+      expect(http_instance).to have_received(:request).twice
     end
   end
 

--- a/tests/lanes/README.md
+++ b/tests/lanes/README.md
@@ -20,6 +20,30 @@ $ tests/lanes/run full-pg --overlay billing
 $ docker compose -f compose.test.yml down
 ```
 
+### Iterating on one file: `--only`
+
+A whole lane is minutes; one file is seconds. `--only <path>` runs just
+that file (repeatable) in the lane's environment, skipping the lane's
+tasks file:
+
+```console
+$ tests/lanes/run simple --only apps/api/domains/spec/integration/simple/domain_sso_config_spec.rb
+$ tests/lanes/run full-sqlite --only apps/web/auth/spec/integration/full/omniauth_csrf_spec.rb:145
+$ tests/lanes/run unit --only try/logic/sso_config/ssrf_protection_transition_try.rb
+```
+
+- Pick the lane whose env the file expects — a `spec/integration/full/`
+  file under `simple` fails on missing auth-mode config, not on its own
+  logic. The lane table below maps lane to what it runs.
+- Runner is chosen by filename: `*_try.rb` goes to `try --agent`,
+  everything else to `rspec`. One kind per invocation.
+- `path:LINE` is forwarded to rspec, so a single example works.
+- The hermetic boundary is unchanged: same scrub, same lane env, same
+  exec. This is the sanctioned fast loop, not a bypass.
+- What it skips is the rest of the tasks file — including setup steps
+  like `pnpm run locales:sync` in the full lanes. Iterate with `--only`,
+  then run the whole lane before pushing. CI runs lanes, not files.
+
 Prerequisites: `bash` 5+ (the runner's env scrub needs it; stock macOS
 ships 3.2 — `brew install bash`), `bundle install`, `pnpm install`,
 `python3` (locale compilation). Lanes whose specs read built frontend

--- a/tests/lanes/run
+++ b/tests/lanes/run
@@ -296,7 +296,10 @@ list_lanes() {
 }
 
 if [[ $# -eq 0 || "${1:-}" == "--list" || "${1:-}" == "-l" ]]; then
-  echo "usage: tests/lanes/run <lane> [--overlay <name>]..."
+  echo "usage: tests/lanes/run <lane> [--overlay <name>]... [--only <path>]..."
+  echo
+  echo "  --only <path>  run just these test files in the lane's environment,"
+  echo "                 instead of the lane's tasks file. Repeatable."
   echo
   echo "Lanes:"
   list_lanes | sed 's/^/  /'
@@ -317,12 +320,28 @@ if [[ ! -f "${LANE_DIR}/env" || ! -f "${LANE_DIR}/tasks" ]]; then
 fi
 
 OVERLAYS=()
+ONLY=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --overlay)
       [[ $# -ge 2 ]] || { echo "error: --overlay requires a name" >&2; exit 64; }
       [[ "$2" =~ ^[A-Za-z0-9_-]+$ ]] || { echo "error: overlay name '$2' contains invalid characters" >&2; exit 64; }
       OVERLAYS+=("$2")
+      shift 2
+      ;;
+    --only)
+      # Iteration escape hatch: run one file (or a handful) inside the lane's
+      # environment instead of its whole tasks list. The hermetic boundary is
+      # unchanged — same scrub, same env, same exec — so this is the sanctioned
+      # way to loop on a single failing file. `path[:LINE]` is accepted and
+      # forwarded to rspec verbatim.
+      [[ $# -ge 2 ]] || { echo "error: --only requires a path" >&2; exit 64; }
+      # The command runs from the repo root, so a path is checked there (and
+      # as given, so an absolute path or one typed from the repo root while
+      # standing elsewhere both work). Catching a typo here beats a runner
+      # that boots the whole app and then reports "0 examples".
+      [[ -f "${REPO_ROOT}/${2%%:*}" || -f "${2%%:*}" ]] || { echo "error: --only path '${2%%:*}' not found (relative to the repo root)" >&2; exit 64; }
+      ONLY+=("$2")
       shift 2
       ;;
     *)
@@ -458,4 +477,38 @@ else
   echo "  whose names are not shell identifiers cannot be enumerated or stripped" >&2
 fi
 
-exec env ${_lanes_strip[@]+"${_lanes_strip[@]}"} bash -euo pipefail "${LANE_DIR}/tasks"
+if [[ ${#ONLY[@]} -eq 0 ]]; then
+  exec env ${_lanes_strip[@]+"${_lanes_strip[@]}"} bash -euo pipefail "${LANE_DIR}/tasks"
+fi
+
+# ── --only: single-file run inside the lane's environment ────────────────
+# The lane's tasks file is skipped wholesale, so anything it does *before*
+# the test command (e.g. `pnpm run locales:sync` in the full lanes) does not
+# run. That is fine for iterating on a spec and wrong for a final check —
+# the full lane is still the thing CI runs and the thing that must be green
+# before pushing.
+#
+# Runner is chosen by filename: tryouts own `*_try.rb`, rspec owns the rest.
+# Mixing the two in one invocation would need two commands and an ordering
+# rule nobody asked for; ask for two runs instead.
+_only_try=0
+_only_spec=0
+for _p in "${ONLY[@]}"; do
+  case "${_p%%:*}" in
+    *_try.rb) _only_try=1 ;;
+    *)        _only_spec=1 ;;
+  esac
+done
+if [[ ${_only_try} -eq 1 && ${_only_spec} -eq 1 ]]; then
+  echo "error: --only cannot mix tryouts (*_try.rb) and rspec files in one run" >&2
+  exit 64
+fi
+
+if [[ ${_only_try} -eq 1 ]]; then
+  _only_cmd=(bundle exec try --agent "${ONLY[@]}")
+else
+  _only_cmd=(bundle exec rspec "${ONLY[@]}")
+fi
+
+echo "[lane:${LANE}] --only: ${_only_cmd[*]}"
+exec env ${_lanes_strip[@]+"${_lanes_strip[@]}"} "${_only_cmd[@]}"

--- a/try/unit/http/guard_try.rb
+++ b/try/unit/http/guard_try.rb
@@ -17,7 +17,9 @@
 # lacked), v4-mapped AND v4-compatible unwrapping, zero-address guard,
 # fail-closed on unparseable/encoded addresses and mixed RRsets, empty
 # resolution rejected, IP-literal hosts validated directly (Resolv::DNS
-# returns [] for literals), IPv4-first uniq'd ordering, and pinned_address!.
+# returns [] for literals), IPv4-first uniq'd ordering, pinned_address!, and
+# try_each_address!'s reachability fallback (connect errnos fall through to
+# the next validated address; anything else propagates from the first dial).
 #
 # Run:
 #   bundle exec try --agent try/unit/http/guard_try.rb
@@ -140,4 +142,47 @@ G.pinned_address!('ds.test')
 
 ## pinned_address! propagates Blocked for a forbidden target
 classify { G.pinned_address!('meta.test') }
+#=> :blocked
+
+## try_each_address! yields the first validated address and returns the
+## block's value when the dial succeeds
+G.try_each_address!('ds.test') { |addr| "dialed #{addr}" }
+#=> 'dialed 8.8.8.8'
+
+## try_each_address! falls through connect-level errnos to the next
+## validated address, preserving the IPv4-first order
+attempts = []
+result = G.try_each_address!('ds.test') do |addr|
+  attempts << addr
+  raise Errno::ECONNREFUSED if attempts.size < 3
+  addr
+end
+[result, attempts]
+#=> ['2606:4700::6810:84e5', ['8.8.8.8', '93.184.216.34', '2606:4700::6810:84e5']]
+
+## try_each_address! re-raises the last connect error once every validated
+## address has been exhausted
+begin
+  G.try_each_address!('ok.test') { raise Errno::EHOSTUNREACH }
+rescue Errno::EHOSTUNREACH
+  :exhausted
+end
+#=> :exhausted
+
+## try_each_address! does NOT swallow non-connect errors: the first dial's
+## failure propagates without trying further addresses (timeouts and TLS
+## errors are not an excuse to widen the walk)
+dials = 0
+begin
+  G.try_each_address!('ds.test') do
+    dials += 1
+    raise 'tls verification failed'
+  end
+rescue RuntimeError
+  dials
+end
+#=> 1
+
+## try_each_address! propagates Blocked before any dial for forbidden targets
+classify { G.try_each_address!('meta.test') { :never } }
 #=> :blocked

--- a/try/unit/http/guard_try.rb
+++ b/try/unit/http/guard_try.rb
@@ -1,0 +1,143 @@
+# try/unit/http/guard_try.rb
+#
+# frozen_string_literal: true
+
+# Unit coverage for Onetime::Http::Guard, the shared SSRF egress guard that
+# unifies the SafeFetch, SsoConfig::SsrfProtection, and DispatchNotification
+# blocklists into one deny-by-default, fail-closed range set.
+#
+# Hermetic: DNS (Resolv) is stubbed by redefining the module_function seam
+# Guard.resolve_addresses (internal callers dispatch through the module
+# singleton, so the redefinition covers resolve_and_validate! too). NO real
+# network is touched and no OT.boot! / Redis / encryption is required
+# (requiring 'onetime' through the support helper is enough to define
+# Onetime::Problem, the error base).
+#
+# Proves: the UNION blocklist (incl. Teredo 2001::/32, which SafeFetch
+# lacked), v4-mapped AND v4-compatible unwrapping, zero-address guard,
+# fail-closed on unparseable/encoded addresses and mixed RRsets, empty
+# resolution rejected, IP-literal hosts validated directly (Resolv::DNS
+# returns [] for literals), IPv4-first uniq'd ordering, and pinned_address!.
+#
+# Run:
+#   bundle exec try --agent try/unit/http/guard_try.rb
+
+require_relative '../../support/test_helpers'
+require_relative '../../../lib/onetime/http/guard'
+
+G = Onetime::Http::Guard
+
+# Stub DNS: host => [ip strings]. Unknown hosts resolve to [] (which is also
+# what Resolv::DNS#getaddresses returns for IP-literal input, so the literal
+# fallback branch is exercised for free).
+GUARD_DNS = {
+  'ok.test'   => ['93.184.216.34'],
+  'mix.test'  => ['93.184.216.34', '127.0.0.1'], # split RRset: one public, one loopback
+  'ds.test'   => ['2606:4700::6810:84e5', '8.8.8.8', '93.184.216.34', '8.8.8.8'],
+  'nx.test'   => [],
+  'meta.test' => ['169.254.169.254'],
+}.freeze
+
+def G.resolve_addresses(host)
+  GUARD_DNS.fetch(host) { [] }
+end
+
+# Classify what resolve_and_validate!/pinned_address! raises.
+def classify
+  yield
+  :no_raise
+rescue G::Blocked
+  :blocked
+rescue StandardError => ex
+  "unexpected:#{ex.class}"
+end
+
+## Blocked subclasses Onetime::Problem (same pattern as SafeFetch::Error)
+G::Blocked < Onetime::Problem
+#=> true
+
+## Every forbidden v4/v6 target is blocked: loopback, RFC1918, metadata,
+## unspecified (both spellings), this-network, CGNAT, IETF, benchmarking,
+## reserved, broadcast, multicast, v6 loopback/unspecified, v4-compat,
+## v4-mapped IMDS, NAT64, 6to4, Teredo, doc range, link-local, ULA, v6 multicast
+%w[
+  127.0.0.1 10.0.0.1 169.254.169.254 0.0.0.0 0.1.2.3 100.64.0.1 192.0.0.1
+  198.18.0.1 240.0.0.1 255.255.255.255 224.0.0.1 172.16.0.1 192.168.1.1
+  ::1 :: ::127.0.0.1 ::ffff:169.254.169.254 64:ff9b::a9fe:a9fe
+  64:ff9b:1::a9fe:a9fe 2002:7f00:0001:: 2001:0:abcd::1 2001:db8::1
+  fe80::1 fc00::1 ff02::1
+].reject { |addr| G.blocked_ip?(addr) }
+#=> []
+
+## Teredo (2001::/32) is blocked — the range SafeFetch's own list lacked
+G.blocked_ip?('2001:0000:4136:e378:8000:63bf:3fff:fdd2')
+#=> true
+
+## ::0.0.0.0 spelling of the unspecified address is blocked (to_i.zero? guard)
+G.blocked_ip?('::0.0.0.0')
+#=> true
+
+## Encoded-loopback smuggling (decimal/hex) fails closed as blocked
+['2130706433', '0x7f000001', 'not-an-ip', ''].map { |addr| G.blocked_ip?(addr) }
+#=> [true, true, true, true]
+
+## Accepts IPAddr instances as well as Strings
+[G.blocked_ip?(IPAddr.new('127.0.0.1')), G.blocked_ip?(IPAddr.new('8.8.8.8'))]
+#=> [true, false]
+
+## Public addresses pass the guard (v4 and v6)
+%w[93.184.216.34 8.8.8.8 2606:4700::6810:84e5].select { |addr| G.blocked_ip?(addr) }
+#=> []
+
+## resolve_and_validate! returns the validated addresses for a clean host
+G.resolve_and_validate!('ok.test')
+#=> ['93.184.216.34']
+
+## Fail-closed: a mixed RRset (one public + one loopback) raises Blocked
+classify { G.resolve_and_validate!('mix.test') }
+#=> :blocked
+
+## A host resolving only to the metadata service raises Blocked
+classify { G.resolve_and_validate!('meta.test') }
+#=> :blocked
+
+## Empty resolution raises Blocked (nothing resolvable, nothing fetchable)
+classify { G.resolve_and_validate!('nx.test') }
+#=> :blocked
+
+## Addresses come back uniq'd and IPv4-first (AAAA listed first in the RRset)
+G.resolve_and_validate!('ds.test')
+#=> ['8.8.8.8', '93.184.216.34', '2606:4700::6810:84e5']
+
+## IP-literal host: Resolv::DNS resolves literals to [], so the literal is
+## validated directly and returned as-is
+G.resolve_and_validate!('93.184.216.34')
+#=> ['93.184.216.34']
+
+## IP-literal v6 host passes through the same branch
+G.resolve_and_validate!('2606:4700::6810:84e5')
+#=> ['2606:4700::6810:84e5']
+
+## A blocked IP literal raises Blocked, not "no A/AAAA records"
+begin
+  G.resolve_and_validate!('169.254.169.254')
+rescue G::Blocked => ex
+  ex.message
+end
+#=> 'blocked address 169.254.169.254 for 169.254.169.254'
+
+## An unresolvable non-IP host still reports empty resolution
+begin
+  G.resolve_and_validate!('unknown.test')
+rescue G::Blocked => ex
+  ex.message
+end
+#=> 'no A/AAAA records for unknown.test'
+
+## pinned_address! returns the first validated address (IPv4 preferred)
+G.pinned_address!('ds.test')
+#=> '8.8.8.8'
+
+## pinned_address! propagates Blocked for a forbidden target
+classify { G.pinned_address!('meta.test') }
+#=> :blocked

--- a/try/unit/http/guard_try.rb
+++ b/try/unit/http/guard_try.rb
@@ -8,7 +8,8 @@
 #
 # Hermetic: DNS (Resolv) is stubbed by redefining the module_function seam
 # Guard.resolve_addresses (internal callers dispatch through the module
-# singleton, so the redefinition covers resolve_and_validate! too). NO real
+# singleton, so the redefinition covers resolve_and_validate! too; it is
+# aliased away and restored in the teardown at the foot of this file). NO real
 # network is touched and no OT.boot! / Redis / encryption is required
 # (requiring 'onetime' through the support helper is enough to define
 # Onetime::Problem, the error base).
@@ -40,8 +41,11 @@ GUARD_DNS = {
   'meta.test' => ['169.254.169.254'],
 }.freeze
 
-def G.resolve_addresses(host)
-  GUARD_DNS.fetch(host) { [] }
+class << G
+  alias_method :__guard_try_orig_resolve_addresses, :resolve_addresses
+  def resolve_addresses(host)
+    GUARD_DNS.fetch(host) { [] }
+  end
 end
 
 # Classify what resolve_and_validate!/pinned_address! raises.
@@ -186,3 +190,12 @@ end
 ## try_each_address! propagates Blocked before any dial for forbidden targets
 classify { G.try_each_address!('meta.test') { :never } }
 #=> :blocked
+
+# Teardown: restore the singleton so sibling tryouts see the real resolver
+# (the lane runner shares one process across every file, and a module-level
+# redefinition outlives the per-test container).
+class << G
+  remove_method :resolve_addresses
+  alias_method :resolve_addresses, :__guard_try_orig_resolve_addresses
+  remove_method :__guard_try_orig_resolve_addresses
+end

--- a/try/unit/http/safe_fetch_try.rb
+++ b/try/unit/http/safe_fetch_try.rb
@@ -9,6 +9,12 @@
 # required (requiring 'onetime' through the support helper is enough to define
 # Onetime::Problem, the error base).
 #
+# The IP range checks are delegated to the shared Onetime::Http::Guard
+# (see try/unit/http/guard_try.rb for the blocklist's own coverage); SafeFetch
+# keeps thin resolve_addresses/blocked_ip? seams, so the stubs below are
+# unchanged and the assertions here prove the delegation preserves behavior —
+# plus one deliberate tightening: Teredo (2001::/32) is now blocked.
+#
 # Proves: metadata/loopback/link-local blocked (incl. v4-mapped and via
 # redirect), fail-closed on mixed RRsets and unparseable/encoded addresses,
 # https+443-only, redirect cap, timeout mapping, streamed + declared size caps,
@@ -317,6 +323,11 @@ f = StubFetch.new(dns: {}, responses: [])
 f = StubFetch.new(dns: {}, responses: [])
 [f.send(:blocked_ip?, '::127.0.0.1'), f.send(:blocked_ip?, '64:ff9b:1::7f00:1')]
 #=> [true, true]
+
+## Teredo (2001::/32) is blocked — a tightening from the shared Guard list
+## (SafeFetch's former local BLOCKED_V6 lacked this range)
+StubFetch.new(dns: {}, responses: []).send(:blocked_ip?, '2001:0:5ef5:79fd::1')
+#=> true
 
 ## A public IPv6 (Cloudflare 2606:4700:4700::1111) still passes the guard
 StubFetch.new(dns: {}, responses: []).send(:blocked_ip?, '2606:4700:4700::1111')

--- a/try/unit/logic/sso_config/ssrf_protection_transition_try.rb
+++ b/try/unit/logic/sso_config/ssrf_protection_transition_try.rb
@@ -12,23 +12,36 @@
 # point OmniAuth at loopback, the cloud metadata service (169.254.169.254),
 # or private networks.
 #
+# The range checks themselves now live in Onetime::Http::Guard (the shared
+# SSRF egress guard); SsrfProtection#blocked_ip? is a thin delegation. These
+# vectors stay as regression coverage that the delegation preserves the
+# original blocking behavior, plus the ranges Guard added on top (multicast,
+# v6 documentation) and Guard's fail-closed handling of unparseable input.
+#
 # These tests exercise the validation methods directly with literal IPs, so
-# they are hermetic: no HTTP and no DNS. DNS resolution is neutralized in
-# setup so resolves_to_internal_ip? cannot reach the network.
+# they are hermetic: no HTTP and no DNS. DNS resolution is stubbed in setup
+# so resolves_to_internal_ip? cannot reach the network.
 #
 # Run:
 #   try try/unit/logic/sso_config/ssrf_protection_transition_try.rb --agent
 
 require 'ipaddr'
 require 'resolv'
+require_relative '../../../../lib/onetime/errors'
+require_relative '../../../../lib/onetime/http/guard'
 require_relative '../../../../apps/api/domains/logic/sso_config/ssrf_protection'
 
-# Neutralize DNS: literal-IP hosts never resolve, and we assert on the
-# literal-IP path only. Returning [] means "no resolved addresses".
-class Resolv
-  def self.getaddresses(_hostname)
-    []
-  end
+# Stub DNS: known hosts resolve to fixed answers, everything else (including
+# literal-IP hosts) returns [] meaning "no resolved addresses". Defined on the
+# ::Resolv singleton (tryouts evaluates files inside a sandbox module, so a
+# bare `class Resolv` reopening would create a sandboxed twin, not stub the
+# real class SsrfProtection calls).
+ssrf_try_dns = {
+  'garbage-answer.test' => ['not-an-ip-address'],       # unparseable resolver answer
+  'mixed-garbage.test'  => ['93.184.216.34', 'bogus!'], # one good, one unparseable
+}.freeze
+::Resolv.define_singleton_method(:getaddresses) do |hostname|
+  ssrf_try_dns.fetch(hostname) { [] }
 end
 
 @validator = Object.new
@@ -148,6 +161,37 @@ end
 
 ## BYPASS: broadcast 255.255.255.255 is blocked
 @validator.blocked_ip?(IPAddr.new('255.255.255.255'))
+#=> true
+
+## NEWLY BLOCKED via Guard: IPv6 multicast ff00::/8 (ff02::1) is blocked
+@validator.blocked_ip?(IPAddr.new('ff02::1'))
+#=> true
+
+## NEWLY BLOCKED via Guard: IPv6 documentation 2001:db8::/32 is blocked
+@validator.blocked_ip?(IPAddr.new('2001:db8::1'))
+#=> true
+
+## NEWLY BLOCKED via Guard: IPv4 multicast 224.0.0.0/4 is blocked
+@validator.blocked_ip?(IPAddr.new('224.0.0.1'))
+#=> true
+
+## blocked_ip? accepts String input (delegation to Guard preserves both forms)
+@validator.blocked_ip?('127.0.0.1')
+#=> true
+
+## FAIL-CLOSED delta: blocked_ip? on unparseable input returns true (blocked);
+## the pre-delegation code was IPAddr-only and callers rescued the parse error
+## with false (skip). Guard treats unparseable as a forbidden target.
+@validator.blocked_ip?('not-an-ip-address')
+#=> true
+
+## FAIL-CLOSED delta: a resolver answer we cannot parse now BLOCKS the host
+## (previously resolves_to_internal_ip? skipped malformed addresses => false)
+@validator.resolves_to_internal_ip?('garbage-answer.test')
+#=> true
+
+## FAIL-CLOSED delta: one good address plus one unparseable answer still blocks
+@validator.resolves_to_internal_ip?('mixed-garbage.test')
 #=> true
 
 ## blocked_ip? leaves a normal public IPv6 address alone

--- a/try/unit/logic/sso_config/ssrf_protection_transition_try.rb
+++ b/try/unit/logic/sso_config/ssrf_protection_transition_try.rb
@@ -43,6 +43,9 @@ ssrf_try_dns = {
 }.freeze
 # Unknown hosts fall through to [] (NXDOMAIN / no A-AAAA records), which the
 # guard treats as a blocked host — see the empty-resolution case below.
+class << ::Resolv
+  alias_method :__ssrf_try_orig_getaddresses, :getaddresses
+end
 ::Resolv.define_singleton_method(:getaddresses) do |hostname|
   ssrf_try_dns.fetch(hostname) { [] }
 end
@@ -220,3 +223,12 @@ end
 ## predicate without over-blocking legitimate mapped public addresses.
 @validator.blocked_ip?(IPAddr.new('::ffff:8.8.8.8'))
 #=> false
+
+# Teardown: restore the real resolver. This stubs stdlib, not a project seam,
+# so leaving it in place would hand [] to every later tryout in the shared
+# `try` process that resolves through ::Resolv.getaddresses.
+class << ::Resolv
+  remove_method :getaddresses
+  alias_method :getaddresses, :__ssrf_try_orig_getaddresses
+  remove_method :__ssrf_try_orig_getaddresses
+end

--- a/try/unit/logic/sso_config/ssrf_protection_transition_try.rb
+++ b/try/unit/logic/sso_config/ssrf_protection_transition_try.rb
@@ -66,6 +66,22 @@ end
 @validator.valid_issuer_host?('https://[::ffff:a00:1]')
 #=> false
 
+## BYPASS: IPv4-compatible IPv6 cloud IMDS (::169.254.169.254) is blocked
+@validator.valid_issuer_host?('https://[::169.254.169.254]')
+#=> false
+
+## BYPASS: IPv4-compatible IPv6 loopback (::127.0.0.1) is blocked
+@validator.valid_issuer_host?('https://[::127.0.0.1]')
+#=> false
+
+## BYPASS: IPv4-compatible private 10.0.0.1 (::10.0.0.1) is blocked
+@validator.valid_issuer_host?('https://[::10.0.0.1]')
+#=> false
+
+## blocked_ip? unwraps IPv4-compatible and matches the embedded IPv4
+@validator.blocked_ip?(IPAddr.new('::169.254.169.254'))
+#=> true
+
 ## BYPASS: NAT64 well-known prefix to IMDS (64:ff9b::169.254.169.254) is blocked
 @validator.valid_issuer_host?('https://[64:ff9b::a9fe:a9fe]')
 #=> false

--- a/try/unit/logic/sso_config/ssrf_protection_transition_try.rb
+++ b/try/unit/logic/sso_config/ssrf_protection_transition_try.rb
@@ -122,10 +122,42 @@ end
 @validator.blocked_ip?(IPAddr.new('64:ff9b::a00:1'))
 #=> true
 
+## BYPASS: unspecified IPv4 0.0.0.0 (routes to localhost) is blocked
+@validator.valid_issuer_host?('https://0.0.0.0')
+#=> false
+
+## BYPASS: unspecified IPv6 [::] (routes to localhost) is blocked
+@validator.valid_issuer_host?('https://[::]')
+#=> false
+
+## BYPASS: ::0.0.0.0 spelling of the unspecified address is blocked
+@validator.blocked_ip?(IPAddr.new('::0.0.0.0'))
+#=> true
+
+## BYPASS: this-network 0.0.0.0/8 (0.0.0.5) is blocked
+@validator.blocked_ip?(IPAddr.new('0.0.0.5'))
+#=> true
+
+## BYPASS: CGNAT shared range 100.64.0.0/10 is blocked
+@validator.blocked_ip?(IPAddr.new('100.64.0.1'))
+#=> true
+
+## BYPASS: reserved 240.0.0.0/4 is blocked
+@validator.blocked_ip?(IPAddr.new('240.0.0.1'))
+#=> true
+
+## BYPASS: broadcast 255.255.255.255 is blocked
+@validator.blocked_ip?(IPAddr.new('255.255.255.255'))
+#=> true
+
 ## blocked_ip? leaves a normal public IPv6 address alone
 @validator.blocked_ip?(IPAddr.new('2606:4700:4700::1111'))
 #=> false
 
 ## blocked_ip? leaves a normal public IPv4 address alone
 @validator.blocked_ip?(IPAddr.new('93.184.216.34'))
+#=> false
+
+## blocked_ip? leaves another public IPv4 (8.8.8.8) alone
+@validator.blocked_ip?(IPAddr.new('8.8.8.8'))
 #=> false

--- a/try/unit/logic/sso_config/ssrf_protection_transition_try.rb
+++ b/try/unit/logic/sso_config/ssrf_protection_transition_try.rb
@@ -1,0 +1,115 @@
+# try/unit/logic/sso_config/ssrf_protection_transition_try.rb
+#
+# frozen_string_literal: true
+
+# Regression tests for the IPv6 transition-address SSRF bypass.
+#
+# Background: SsrfProtection guards SSO issuer URLs before OmniAuth OIDC
+# discovery fetches metadata from them. The original guard checked only
+# IPAddr#loopback?, #private?, and #link_local?, which match native IPv4/IPv6
+# ranges only. IPv4 addresses embedded in IPv6 transition formats
+# (IPv4-mapped, NAT64, 6to4, Teredo) therefore passed the guard and could
+# point OmniAuth at loopback, the cloud metadata service (169.254.169.254),
+# or private networks.
+#
+# These tests exercise the validation methods directly with literal IPs, so
+# they are hermetic: no HTTP and no DNS. DNS resolution is neutralized in
+# setup so resolves_to_internal_ip? cannot reach the network.
+#
+# Run:
+#   try try/unit/logic/sso_config/ssrf_protection_transition_try.rb --agent
+
+require 'ipaddr'
+require 'resolv'
+require_relative '../../../../apps/api/domains/logic/sso_config/ssrf_protection'
+
+# Neutralize DNS: literal-IP hosts never resolve, and we assert on the
+# literal-IP path only. Returning [] means "no resolved addresses".
+class Resolv
+  def self.getaddresses(_hostname)
+    []
+  end
+end
+
+@validator = Object.new
+@validator.extend(DomainsAPI::Logic::SsoConfig::SsrfProtection)
+
+## Sanity: a normal public HTTPS issuer is accepted
+@validator.valid_issuer_host?('https://idp.example.com')
+#=> true
+
+## Sanity: native IPv4 loopback is still blocked
+@validator.valid_issuer_host?('https://127.0.0.1')
+#=> false
+
+## Sanity: native IPv6 loopback is still blocked
+@validator.valid_issuer_host?('https://[::1]')
+#=> false
+
+## Sanity: native IPv6 ULA (private) is still blocked
+@validator.valid_issuer_host?('https://[fc00::1]')
+#=> false
+
+## BYPASS: IPv4-mapped IPv6 loopback (::ffff:127.0.0.1, hex form) is blocked
+@validator.valid_issuer_host?('https://[::ffff:7f00:1]')
+#=> false
+
+## BYPASS: IPv4-mapped IPv6 cloud IMDS (::ffff:169.254.169.254) is blocked
+@validator.valid_issuer_host?('https://[::ffff:a9fe:a9fe]')
+#=> false
+
+## BYPASS: IPv4-mapped dotted form (::ffff:169.254.169.254) is blocked
+@validator.valid_issuer_host?('https://[::ffff:169.254.169.254]')
+#=> false
+
+## BYPASS: IPv4-mapped private 10.0.0.1 (::ffff:10.0.0.1) is blocked
+@validator.valid_issuer_host?('https://[::ffff:a00:1]')
+#=> false
+
+## BYPASS: NAT64 well-known prefix to IMDS (64:ff9b::169.254.169.254) is blocked
+@validator.valid_issuer_host?('https://[64:ff9b::a9fe:a9fe]')
+#=> false
+
+## BYPASS: NAT64 well-known prefix to loopback (64:ff9b::127.0.0.1) is blocked
+@validator.valid_issuer_host?('https://[64:ff9b::7f00:1]')
+#=> false
+
+## BYPASS: NAT64 local-use prefix (64:ff9b:1::/48) is blocked
+@validator.valid_issuer_host?('https://[64:ff9b:1::a9fe:a9fe]')
+#=> false
+
+## BYPASS: 6to4 to loopback (2002:7f00:1::) is blocked
+@validator.valid_issuer_host?('https://[2002:7f00:1::]')
+#=> false
+
+## BYPASS: 6to4 to IMDS (2002:a9fe:a9fe::) is blocked
+@validator.valid_issuer_host?('https://[2002:a9fe:a9fe::]')
+#=> false
+
+## BYPASS: Teredo prefix (2001:0000::/32) is blocked
+@validator.valid_issuer_host?('https://[2001:0000:4136:e378:8000:63bf:3fff:fdd2]')
+#=> false
+
+## internal_host? blocks IPv4-mapped IMDS at the method level
+@validator.internal_host?('::ffff:a9fe:a9fe')
+#=> true
+
+## internal_host? blocks NAT64 IMDS at the method level
+@validator.internal_host?('64:ff9b::a9fe:a9fe')
+#=> true
+
+## blocked_ip? unwraps IPv4-mapped and matches the embedded IPv4
+@validator.blocked_ip?(IPAddr.new('::ffff:a9fe:a9fe'))
+#=> true
+
+## blocked_ip? matches a NAT64 address via the transition prefix list
+@validator.blocked_ip?(IPAddr.new('64:ff9b::a00:1'))
+#=> true
+
+## blocked_ip? leaves a normal public IPv6 address alone
+@validator.blocked_ip?(IPAddr.new('2606:4700:4700::1111'))
+#=> false
+
+## blocked_ip? leaves a normal public IPv4 address alone
+@validator.blocked_ip?(IPAddr.new('93.184.216.34'))
+#=> false

--- a/try/unit/logic/sso_config/ssrf_protection_transition_try.rb
+++ b/try/unit/logic/sso_config/ssrf_protection_transition_try.rb
@@ -37,9 +37,12 @@ require_relative '../../../../apps/api/domains/logic/sso_config/ssrf_protection'
 # bare `class Resolv` reopening would create a sandboxed twin, not stub the
 # real class SsrfProtection calls).
 ssrf_try_dns = {
+  'idp.example.com'     => ['93.184.216.34'],           # normal public issuer
   'garbage-answer.test' => ['not-an-ip-address'],       # unparseable resolver answer
   'mixed-garbage.test'  => ['93.184.216.34', 'bogus!'], # one good, one unparseable
 }.freeze
+# Unknown hosts fall through to [] (NXDOMAIN / no A-AAAA records), which the
+# guard treats as a blocked host — see the empty-resolution case below.
 ::Resolv.define_singleton_method(:getaddresses) do |hostname|
   ssrf_try_dns.fetch(hostname) { [] }
 end
@@ -204,4 +207,16 @@ end
 
 ## blocked_ip? leaves another public IPv4 (8.8.8.8) alone
 @validator.blocked_ip?(IPAddr.new('8.8.8.8'))
+#=> false
+
+## FAIL-CLOSED: a host that resolves to nothing (NXDOMAIN => []) is blocked.
+## Resolv.getaddresses returns [] rather than raising, so save-time validation
+## must reject empty resolution or an unresolvable host slips through.
+@validator.resolves_to_internal_ip?('no-such-host.test')
+#=> true
+
+## Public IPv4-mapped IPv6 (::ffff:8.8.8.8) unwraps to its public v4 and is
+## allowed — the prefix-based unwrap replaced the obsolete #ipv4_compat?
+## predicate without over-blocking legitimate mapped public addresses.
+@validator.blocked_ip?(IPAddr.new('::ffff:8.8.8.8'))
 #=> false

--- a/try/unit/operations/dispatch_notification_webhook_try.rb
+++ b/try/unit/operations/dispatch_notification_webhook_try.rb
@@ -1,0 +1,161 @@
+# try/unit/operations/dispatch_notification_webhook_try.rb
+#
+# frozen_string_literal: true
+
+# Unit coverage for the SSRF-pinned webhook path of
+# Onetime::Operations::DispatchNotification (via_webhook channel).
+#
+# Hermetic: the shared egress guard's DNS seam (Onetime::Http::Guard
+# .resolve_addresses) and Net::HTTP.new are both redefined on their
+# singletons and restored in the teardown at the bottom, so NO real DNS or
+# network is touched and no OT.boot! / Redis is required.
+#
+# Proves: a blocked resolution (loopback-only or split RRset) is classified
+# as a permanent :error by dispatch_to_channel's StandardError rescue —
+# Guard::Blocked propagates out of send_webhook_request untranslated — and
+# NO Net::HTTP connection object is ever built; an allowed resolution
+# constructs Net::HTTP with the explicit nil p_addr (environment-proxy
+# pickup disabled so http_proxy cannot bypass pinning) and pins the dial to
+# the validated IP via #ipaddr= while keeping the hostname for Host/SNI;
+# scheme validation happens BEFORE resolution (ftp:// raises ArgumentError
+# without a DNS lookup).
+#
+# Run:
+#   bundle exec try --agent try/unit/operations/dispatch_notification_webhook_try.rb
+
+require_relative '../../support/test_helpers'
+require_relative '../../../lib/onetime/operations/dispatch_notification'
+
+DNW_OP    = Onetime::Operations::DispatchNotification
+DNW_GUARD = Onetime::Http::Guard
+
+# Stubbed DNS: host => resolved addresses. Unknown hosts resolve to [].
+DNW_DNS = {
+  'hook.test'  => ['203.0.113.10'],
+  'inner.test' => ['127.0.0.1'],
+  'split.test' => ['203.0.113.10', '10.0.0.5'], # one public + one private
+}.freeze
+
+# Records how often resolution is attempted (proves scheme-first ordering).
+DNW_STATE = { resolves: 0, instances: [] }
+
+class << DNW_GUARD
+  alias_method :__dnw_orig_resolve_addresses, :resolve_addresses
+  def resolve_addresses(host)
+    DNW_STATE[:resolves] += 1
+    DNW_DNS.fetch(host) { [] }
+  end
+end
+
+# Recorder stand-in for a Net::HTTP connection; implements only what
+# send_webhook_request touches and never dials anything.
+class DnwFakeHttp
+  attr_reader :new_args, :calls
+
+  def initialize(*args)
+    @new_args = args
+    @calls    = {}
+  end
+
+  %i[ipaddr use_ssl verify_mode verify_hostname open_timeout read_timeout].each do |name|
+    define_method(:"#{name}=") { |value| @calls[name] = value }
+  end
+
+  def use_ssl?
+    @calls[:use_ssl]
+  end
+
+  def request(req)
+    @calls[:request] = req
+    Net::HTTPOK.new('1.1', '200', 'OK')
+  end
+end
+
+class << Net::HTTP
+  alias_method :__dnw_orig_new, :new
+  def new(*args)
+    fake = DnwFakeHttp.new(*args)
+    DNW_STATE[:instances] << fake
+    fake
+  end
+end
+
+def dnw_dispatch(webhook_url)
+  DNW_STATE[:instances].clear
+  op = DNW_OP.new(data: {
+    type: 'secret.viewed',
+    addressee: { webhook_url: webhook_url },
+    template: 'secret_viewed',
+    channels: ['via_webhook'],
+    data: {},
+  },)
+  op.call
+end
+
+## Allowed resolution delivers successfully
+dnw_dispatch('https://hook.test/notify')
+#=> { via_webhook: :success }
+
+## Allowed resolution dials through exactly one connection, constructed with
+## the hostname (Host/SNI/cert checks), the URI port, and the explicit nil
+## p_addr that disables environment-proxy pickup
+DNW_STATE[:instances].map(&:new_args)
+#=> [['hook.test', 443, nil]]
+
+## Allowed resolution pins the dial to the validated IP and enables TLS
+http = DNW_STATE[:instances].first
+[http.calls[:ipaddr], http.calls[:use_ssl], http.calls[:verify_mode] == OpenSSL::SSL::VERIFY_PEER, http.calls[:verify_hostname]]
+#=> ['203.0.113.10', true, true, true]
+
+## The request itself is a JSON POST
+req = DNW_STATE[:instances].first.calls[:request]
+[req.class, req['Content-Type']]
+#=> [Net::HTTP::Post, 'application/json']
+
+## Guard::Blocked propagates untranslated out of send_webhook_request; the
+## channel rescue classifies it as a permanent :error (never retried — the
+## worker's with_retry only sees exceptions, and per-channel failures are
+## swallowed into the results hash)
+dnw_dispatch('https://inner.test/notify')
+#=> { via_webhook: :error }
+
+## Blocked resolution never builds a connection object
+DNW_STATE[:instances]
+#=> []
+
+## Split RRset (one public + one private answer) is blocked wholesale
+dnw_dispatch('https://split.test/notify')
+#=> { via_webhook: :error }
+
+## ...and likewise attempts no connection
+DNW_STATE[:instances]
+#=> []
+
+## Unresolvable host fails closed as :error, no connection attempt
+[dnw_dispatch('https://unknown.test/notify'), DNW_STATE[:instances]]
+#=> [{ via_webhook: :error }, []]
+
+## Scheme validation runs BEFORE resolution: ftp:// raises ArgumentError
+## without a single DNS lookup
+before = DNW_STATE[:resolves]
+result = begin
+  DNW_OP.new(data: {}).send(:send_webhook_request, 'ftp://hook.test/x', {})
+rescue ArgumentError
+  :argument_error
+end
+[result, DNW_STATE[:resolves] - before]
+#=> [:argument_error, 0]
+
+# Teardown: restore the singletons so sibling tryouts in a directory run see
+# the real implementations (this dir shares one process across files).
+class << Net::HTTP
+  remove_method :new
+  alias_method :new, :__dnw_orig_new
+  remove_method :__dnw_orig_new
+end
+
+class << DNW_GUARD
+  remove_method :resolve_addresses
+  alias_method :resolve_addresses, :__dnw_orig_resolve_addresses
+  remove_method :__dnw_orig_resolve_addresses
+end


### PR DESCRIPTION
Closes the IPv6 transition-address SSRF bypass in the SSO issuer guard
(GHSA/advisory: IPv4-mapped, NAT64, 6to4, and Teredo addresses embed a
routable IPv4 destination that `IPAddr#loopback?/#private?/#link_local?`
never inspect, so they slipped past the guard and could reach loopback,
cloud IMDS at 169.254.169.254, or RFC 1918 hosts). Also hardens the
outbound HTTP paths that actually perform the fetch.

## Core fix
- `blocked_ip?` canonicalizes IPv4-mapped **and** IPv4-compatible IPv6 to
  the embedded IPv4 before range-checking, and blocks the transition
  prefixes wholesale (`64:ff9b::/96`, `64:ff9b:1::/48`, `2002::/16`,
  `2001::/32`) — no legitimate egress lives on a translation address, so
  blocking the whole prefix removes the decode surface entirely.
- Extends coverage the native predicates miss: unspecified `0.0.0.0`/`::`
  (route to localhost), special-use IPv4 (`0.0.0.0/8`, CGNAT
  `100.64.0.0/10`, benchmarking, multicast, reserved/broadcast), IPv6
  multicast/documentation, and fails closed on unparseable input
  (decimal/hex-encoded loopback smuggling).

## Shared guard + request-time pinning
- Unifies the three divergent per-callsite blocklists into one
  deny-by-default `Onetime::Http::Guard` (single source of truth).
- Pins each outbound connection to the one validated IP at the fetch
  callsites (SafeFetch, webhook dispatch, SSO test-connection, and the
  OmniAuth OIDC `http_config` hook), closing the validate-then-reresolve
  DNS-rebinding window that the save-time check alone cannot.

## Belt-and-suspenders hardening
- Drops the obsolete `IPAddr#ipv4_compat?` predicate (warns and is slated
  for removal in Ruby 3.4+) in favor of prefix detection + explicit
  low-32-bit unwrap. Warning-free under `-W2`; public mapped addresses
  still resolve to their v4 form rather than being over-blocked.
- `resolves_to_internal_ip?` fails closed on empty DNS resolution
  (`Resolv.getaddresses` returns `[]` for NXDOMAIN), so an unresolvable
  issuer host can no longer pass save-time validation — consistent with
  the request-time guard.

## Tests
Hermetic tryouts and specs cover every advisory vector (including Teredo),
the fail-closed deltas (unparseable answer, empty resolution), and the
pinned-dial behavior at each callsite. Unit lane green (355 examples,
0 failures + try:unit).