### PR TITLE
chore: upgrade tryouts to 4.0.0.pre1 and fix database/test issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,6 +80,9 @@ Lint/UnusedMethodArgument:
 
 Lint/UselessAssignment:
   Enabled: true
+  # See the Lint/Void note below — same hazard, same defence.
+  Exclude:
+    - '**/*_try.rb'
 
 Lint/DuplicateBranch:
   Enabled: true
@@ -276,6 +279,22 @@ Layout/FirstMethodArgumentLineBreak:
 
 Lint/Void:
   Enabled: true
+  # Tryouts files are excluded wholesale by AllCops (try/**/*, apps/**/try/**/*),
+  # but that exclusion is only honoured with --force-exclusion. The pre-commit
+  # hook passes it; an ad-hoc `bundle exec rubocop -A some_try.rb` does not, and
+  # then Lint/Void's autocorrect DELETES the trailing expression a testcase uses
+  # as its result value:
+  #
+  #     @domain.destroy!
+  #     true          # <- "literal in void context", silently removed
+  #     #=> true
+  #
+  # The case then asserts destroy!'s return value instead, which is a different
+  # (and sometimes still-passing) test. This bit us in bb9ca4cb9. A per-cop
+  # Exclude is honoured regardless of --force-exclusion, so it closes the hole
+  # for every invocation path.
+  Exclude:
+    - '**/*_try.rb'
 
 Lint/CopDirectiveSyntax:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -192,7 +192,7 @@ group :test do
   gem 'simplecov', require: false
   gem 'simplecov-cobertura', '~> 3.2', require: false # Cobertura XML output for GitHub Code Quality
   gem 'timecop', '~> 0.9'
-  gem 'tryouts', '~> 3.7.1', require: false
+  gem 'tryouts', '~> 4.0.0.pre1', require: false
   gem 'vcr', '~> 6.0'
   gem 'webmock', '~> 3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -540,7 +540,7 @@ GEM
       openssl-signature_algorithm (~> 1.0)
     truemail (3.3.1)
       simpleidn (~> 0.2.1)
-    tryouts (3.7.1)
+    tryouts (4.0.0.pre1)
       concurrent-ruby (~> 1.0, < 2)
       irb
       minitest (~> 5.0)
@@ -684,7 +684,7 @@ DEPENDENCIES
   tilt
   timecop (~> 0.9)
   truemail (~> 3.3)
-  tryouts (~> 3.7.1)
+  tryouts (~> 4.0.0.pre1)
   uri-valkey (~> 1.4.0)
   vcr (~> 6.0)
   webauthn (~> 3.0)

--- a/apps/web/auth/database.rb
+++ b/apps/web/auth/database.rb
@@ -123,6 +123,31 @@ module Auth
       end
     end
 
+    # Whether the auth database can actually be reached right now.
+    #
+    # `connection` returns a LazyConnection proxy, which is ALWAYS truthy in
+    # full mode — it defers the real connect to first use. So `if db` only
+    # answers "is this full mode?", never "is there a usable database?", and a
+    # caller that treats it as the latter blows up later at an arbitrary query.
+    # This forces the connection behind a rescue so callers that must degrade
+    # gracefully (CLI commands, tryouts without a provisioned DB) can ask
+    # directly.
+    #
+    # Not memoized: a database may come up (or go away) during a process's
+    # lifetime, and tests reset the connection between examples.
+    def self.available?
+      conn = connection
+      return false if conn.nil?
+
+      conn.__connect__!
+      true
+    rescue StandardError => ex
+      sequel_logger.warn '[Database] Auth database unavailable',
+        error: ex.message,
+        error_class: ex.class.name
+      false
+    end
+
     # Check if a connection has been established
     def self.connected?
       return false unless @connection

--- a/apps/web/auth/spec/spec_helper.rb
+++ b/apps/web/auth/spec/spec_helper.rb
@@ -55,14 +55,14 @@ WebMock.stub_request(:get, "#{PLACEHOLDER_OIDC_ISSUER}/.well-known/openid-config
       claims_supported: %w[sub email email_verified name],
       code_challenge_methods_supported: %w[S256],
     }.to_json,
-    headers: { 'Content-Type' => 'application/json' }
+    headers: { 'Content-Type' => 'application/json' },
   )
 
 WebMock.stub_request(:get, "#{PLACEHOLDER_OIDC_ISSUER}/.well-known/jwks.json")
   .to_return(
     status: 200,
     body: { keys: [] }.to_json,
-    headers: { 'Content-Type' => 'application/json' }
+    headers: { 'Content-Type' => 'application/json' },
   )
 
 require 'rspec'
@@ -110,7 +110,7 @@ module TenantVerifyingMockRegistration
     # Uses the strategy class from OmniAuth::Strategies namespace.
     auth.omniauth_provider(
       :tenant_verifying_mock,
-      name: :tenant_verify
+      name: :tenant_verify,
     )
   end
 end
@@ -118,6 +118,7 @@ end
 # Helper module for creating isolated Rodauth test environments
 module RodauthTestHelper
   include AuthTestConstants
+
   # Creates a fresh SQLite in-memory database with all Rodauth tables
   #
   # @return [Sequel::Database] configured database connection
@@ -136,7 +137,7 @@ module RodauthTestHelper
     # rather than the adapter's default datetime(CURRENT_TIMESTAMP,'localtime')
     # rewrite — otherwise DB-side comparisons (e.g. Rodauth's OTP replay guard
     # in otp_update_last_use) mix UTC-stored values with local wall clocks.
-    db.timezone = :utc
+    db.timezone              = :utc
     db.current_timestamp_utc = true
 
     create_core_tables(db)
@@ -159,7 +160,7 @@ module RodauthTestHelper
     end
     db[:account_statuses].import(
       [:id, :name],
-      [[STATUS_UNVERIFIED, 'Unverified'], [STATUS_VERIFIED, 'Verified'], [STATUS_CLOSED, 'Closed']]
+      [[STATUS_UNVERIFIED, 'Unverified'], [STATUS_VERIFIED, 'Verified'], [STATUS_CLOSED, 'Closed']],
     )
 
     db.create_table(:accounts) do
@@ -313,8 +314,8 @@ module RodauthTestHelper
   # @param config_block [Proc] additional Rodauth configuration
   # @return [Class] Roda application class
   def self.create_rodauth_app(db:, features: [:base, :login, :logout], &config_block)
-    app_db = db
-    app_features = features
+    app_db           = db
+    app_features     = features
     app_config_block = config_block
 
     Class.new(Roda) do
@@ -483,8 +484,8 @@ module ProductionConfigHelper
     return unless valkey_available?
 
     Familia.dbclient.flushdb
-  rescue StandardError => e
-    OT.le "[flush_test_database] Failed to flush test database: #{e.message}"
+  rescue StandardError => ex
+    OT.le "[flush_test_database] Failed to flush test database: #{ex.message}"
   end
 
   # Clean up SQL auth data between integration examples.
@@ -518,7 +519,7 @@ module ProductionConfigHelper
       # ENV, so a run outside the sanctioned :2154 PG lane must not wipe dev.
       dbname = db.opts[:database].to_s
       unless dbname =~ /test/i
-        raise "[auth spec_helper] Refusing to TRUNCATE non-test database: " \
+        raise '[auth spec_helper] Refusing to TRUNCATE non-test database: ' \
               "#{dbname.empty? ? '<unknown>' : dbname.inspect}. Check AUTH_DATABASE_URL."
       end
 
@@ -527,7 +528,7 @@ module ProductionConfigHelper
       if defined?(PostgresModeSuiteDatabase) && PostgresModeSuiteDatabase.migration_database
         PostgresModeSuiteDatabase.migration_database.run("TRUNCATE #{tables.join(', ')} RESTART IDENTITY CASCADE")
       else
-        migration_url = ENV['AUTH_DATABASE_URL_MIGRATIONS']
+        migration_url = ENV.fetch('AUTH_DATABASE_URL_MIGRATIONS', nil)
         if migration_url && !migration_url.to_s.empty? && migration_url != ENV['AUTH_DATABASE_URL']
           elevated_db = Sequel.connect(migration_url)
           begin
@@ -545,8 +546,8 @@ module ProductionConfigHelper
       db[:sqlite_sequence].delete if db.table_exists?(:sqlite_sequence)
       db.run('PRAGMA foreign_keys = ON')
     end
-  rescue StandardError => e
-    OT.le "[clear_auth_database] Failed to clear auth database: #{e.message}"
+  rescue StandardError => ex
+    OT.le "[clear_auth_database] Failed to clear auth database: #{ex.message}"
   end
 
   # Get the auth database connection for assertions
@@ -569,19 +570,21 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 
   # Helper methods available in all tests
-  config.include Module.new {
-    def create_test_database
-      RodauthTestHelper.create_test_database
-    end
+  config.include(
+    Module.new do
+        def create_test_database
+          RodauthTestHelper.create_test_database
+        end
 
-    def create_rodauth_app(db:, features: [:base, :login, :logout], &block)
-      RodauthTestHelper.create_rodauth_app(db: db, features: features, &block)
-    end
+        def create_rodauth_app(db:, features: [:base, :login, :logout], &)
+          RodauthTestHelper.create_rodauth_app(db: db, features: features, &)
+        end
 
-    def rodauth_responds_to?(app, method_name)
-      RodauthTestHelper.rodauth_responds_to?(app, method_name)
-    end
-  }
+        def rodauth_responds_to?(app, method_name)
+          RodauthTestHelper.rodauth_responds_to?(app, method_name)
+        end
+    end,
+  )
 
   # Integration test helpers (for tests requiring full app boot)
   config.include Rack::Test::Methods, type: :integration
@@ -644,10 +647,10 @@ RSpec.configure do |config|
   # never reset it, so :get leaks into subsequent strategy inits and triggers
   # the CVE-2015-9284 GET-request CSRF warning mid-suite. Unguarded (no
   # shared_db_state/billing opt-out) so it always runs.
-  config.after(:each) do
+  config.after do
     next unless defined?(OmniAuth)
 
     OmniAuth.config.allowed_request_methods = [:post]
-    OmniAuth.config.silence_get_warning = false
+    OmniAuth.config.silence_get_warning     = false
   end
 end

--- a/apps/web/auth/spec/spec_helper.rb
+++ b/apps/web/auth/spec/spec_helper.rb
@@ -502,6 +502,10 @@ module ProductionConfigHelper
   # privileges. Use AUTH_DATABASE_URL_MIGRATIONS (onetime_migrator) when available.
   def clear_auth_database
     db = Auth::Database.connection
+    # Simple mode has no SQL auth database (connection returns nil), but specs
+    # tagged type: :integration still run in that lane. Nothing to clear.
+    return if db.nil?
+
     # Preserve schema bookkeeping and seed-once reference tables (PRESERVED_TABLES).
     tables = db.tables - AuthTestConstants::PRESERVED_TABLES
     return if tables.empty?

--- a/apps/web/auth/try/operations/close_account_try.rb
+++ b/apps/web/auth/try/operations/close_account_try.rb
@@ -57,17 +57,18 @@ end
 # halts all remaining files in the batch. Test cases use skip_without_db
 # to return the expected value when @db is nil.
 unless @db
-  warn "[SKIP] close_account_try.rb: Auth database not reachable (full auth mode requires database)"
+  warn '[SKIP] close_account_try.rb: Auth database not reachable (full auth mode requires database)'
 end
 
-def skip_without_db(expected, &block)
+def skip_without_db(expected, &)
   return expected unless @db
-  block.call
+
+  yield
 end
 
 # Create a test account directly in the auth database
 if @db
-  @test_email = generate_unique_test_email("closeaccount")
+  @test_email = generate_unique_test_email('closeaccount')
   @test_extid = "test_extid_#{SecureRandom.hex(8)}"
 
   @db.transaction do
@@ -76,20 +77,20 @@ if @db
       status_id: 2,
       external_id: @test_extid,
       created_at: Time.now,
-      updated_at: Time.now
+      updated_at: Time.now,
     )
 
     # Insert related records to verify cascade deletion
     @db[:account_password_hashes].insert(
       id: @account_id,
       password_hash: '$argon2id$v=19$m=16384,t=2,p=1$fakehash',
-      created_at: Time.now
+      created_at: Time.now,
     )
 
     @db[:account_remember_keys].insert(
       id: @account_id,
       key: SecureRandom.hex(32),
-      deadline: Time.now + 86400
+      deadline: Time.now + 86_400,
     )
   end
 end
@@ -168,16 +169,16 @@ end
 # (session_config['secret'], the chain middleware_stack mounts the session
 # with) — the sweep's SessionCodec.from_config must resolve the SAME secret
 # for the encrypted blob to decode and match.
-@ca_secret = Onetime.session_config['secret']
-@ca_codec  = Onetime::SessionCodec.new(@ca_secret)
-@ca_db     = Familia.dbclient
-@ca_extid  = "extid_close_#{SecureRandom.hex(6)}"
-@ca_sid    = SecureRandom.hex(32) # 64 hex -- the shape the sidecar purge is gated on
-@ca_blob   = "session:#{@ca_sid}"
-@ca_mfa    = "sidecar:#{@ca_sid}:awaiting_mfa"
+@ca_secret     = Onetime.session_config['secret']
+@ca_codec      = Onetime::SessionCodec.new(@ca_secret)
+@ca_db         = Familia.dbclient
+@ca_extid      = "extid_close_#{SecureRandom.hex(6)}"
+@ca_sid        = SecureRandom.hex(32) # 64 hex -- the shape the sidecar purge is gated on
+@ca_blob       = "session:#{@ca_sid}"
+@ca_mfa        = "sidecar:#{@ca_sid}:awaiting_mfa"
 @ca_other_sid  = SecureRandom.hex(32)
 @ca_other_blob = "session:#{@ca_other_sid}"
-@ca_op = Auth::Operations::CloseAccount.new(extid: @ca_extid, db: :redis_only)
+@ca_op         = Auth::Operations::CloseAccount.new(extid: @ca_extid, db: :redis_only)
 @ca_db.set(@ca_blob, @ca_codec.encode({ 'external_id' => @ca_extid, 'authenticated' => true }), ex: 3600)
 Onetime::SessionSidecar.write(@ca_sid, 'awaiting_mfa', true, codec: @ca_codec)
 @ca_db.set(@ca_other_blob, @ca_codec.encode({ 'external_id' => 'someone_else', 'authenticated' => true }), ex: 3600)
@@ -190,7 +191,6 @@ Onetime::SessionSidecar.write(@ca_sid, 'awaiting_mfa', true, codec: @ca_codec)
 @ca_result = @ca_op.send(:delete_redis_sessions, @ca_extid)
 @ca_db.del(@ca_blob, @ca_other_blob)
 Onetime::SessionSidecar.purge(@ca_sid)
-@ca_result
 #=> 1
 
 # Teardown
@@ -200,7 +200,7 @@ if @db
     @db[:account_remember_keys].where(id: @account_id).delete
     @db[:account_password_hashes].where(id: @account_id).delete
     @db[:accounts].where(id: @account_id).delete
-  rescue StandardError => ex
+  rescue StandardError
     # Ignore cleanup errors - data should already be deleted
   end
 end

--- a/apps/web/auth/try/operations/close_account_try.rb
+++ b/apps/web/auth/try/operations/close_account_try.rb
@@ -7,9 +7,23 @@
 # Tests the deletion of auth accounts and all related data from the auth
 # database. This operation is used when a user deletes their account.
 
-# Setup - Load the real application with full auth mode
-ENV['RACK_ENV']            = 'test'
-ENV['AUTHENTICATION_MODE'] = 'full'
+# --- delete_redis_sessions: AES-GCM decode + sidecar purge (#3858) ---
+#
+# delete_redis_sessions SCANs session:* for blobs whose codec-DECODED
+# external_id matches the closing account, deletes each matching blob AND
+# purges its per-value sidecar keys, skipping sidecar-shaped keys. Sessions are
+# AES-256-GCM encrypted, so the sweep MUST decode through the codec -- the old
+# JSON.parse(base64) path raised on every authenticated blob and silently
+# skipped it, leaving live sessions behind on account closure. These cases
+# assert the real Redis effects (the method swallows all errors, so nothing
+# else could catch a regression). Redis-only: no auth DB required, so they run
+# even when the accounts DB is absent (db: passed non-nil to skip the connect).
+require 'onetime/session/codec'
+require 'onetime/session/sidecar'
+
+# Setup - Keep the lane's authentication mode. Database-backed cases are
+# skipped below when the lane does not provide an auth database.
+ENV['RACK_ENV'] = 'test'
 
 require_relative '../../../../../try/support/test_helpers'
 
@@ -21,12 +35,19 @@ OT.boot! :test, false
 require 'auth/database'
 require_relative '../../operations/close_account'
 
-@db = Auth::Database.connection
+# NOTE: Auth::Database.connection returns a LazyConnection proxy that is
+# truthy even when no database can be reached — it only answers "is this full
+# mode?". Ask #available?, which forces the connection behind a rescue, so a
+# lane without a provisioned database skips rather than exploding inside
+# Sequel::Migrator.run below.
+@db = Auth::Database.available? ? Auth::Database.connection : nil
 
 if @db
-  Sequel.extension :migration
-  migrations_path = File.join(Onetime::HOME, 'apps', 'web', 'auth', 'migrations')
-  Sequel::Migrator.run(@db, migrations_path)
+  # Use the app's migrator rather than a hand-rolled Sequel::Migrator.run on
+  # @db: on PostgreSQL, DDL requires the elevated database_url_migrations
+  # credentials, and only Auth::Migrator knows to switch connections for them.
+  require 'auth/migrator'
+  Auth::Migrator.run_if_needed
 end
 
 # Skip this test file gracefully if auth database is not available.
@@ -36,7 +57,7 @@ end
 # halts all remaining files in the batch. Test cases use skip_without_db
 # to return the expected value when @db is nil.
 unless @db
-  warn "[SKIP] close_account_try.rb: Auth database not configured (full auth mode requires database)"
+  warn "[SKIP] close_account_try.rb: Auth database not reachable (full auth mode requires database)"
 end
 
 def skip_without_db(expected, &block)
@@ -138,20 +159,6 @@ skip_without_db(false) do
   result[:success]
 end
 #=> false
-
-# --- delete_redis_sessions: AES-GCM decode + sidecar purge (#3858) ---
-#
-# delete_redis_sessions SCANs session:* for blobs whose codec-DECODED
-# external_id matches the closing account, deletes each matching blob AND
-# purges its per-value sidecar keys, skipping sidecar-shaped keys. Sessions are
-# AES-256-GCM encrypted, so the sweep MUST decode through the codec -- the old
-# JSON.parse(base64) path raised on every authenticated blob and silently
-# skipped it, leaving live sessions behind on account closure. These cases
-# assert the real Redis effects (the method swallows all errors, so nothing
-# else could catch a regression). Redis-only: no auth DB required, so they run
-# even when the accounts DB is absent (db: passed non-nil to skip the connect).
-require 'onetime/session/codec'
-require 'onetime/session/sidecar'
 
 ## an authenticated, AES-GCM-encrypted session blob for the closing account is
 ## deleted along with its sidecar keys, while a DIFFERENT account's blob

--- a/apps/web/auth/try/operations/close_account_try.rb
+++ b/apps/web/auth/try/operations/close_account_try.rb
@@ -191,6 +191,7 @@ Onetime::SessionSidecar.write(@ca_sid, 'awaiting_mfa', true, codec: @ca_codec)
 @ca_result = @ca_op.send(:delete_redis_sessions, @ca_extid)
 @ca_db.del(@ca_blob, @ca_other_blob)
 Onetime::SessionSidecar.purge(@ca_sid)
+@ca_result
 #=> 1
 
 # Teardown

--- a/etc/defaults/auth.defaults.yaml
+++ b/etc/defaults/auth.defaults.yaml
@@ -33,7 +33,11 @@ full:
   #     (e.g., /app/data or /data) or all data will be lost on container restart.
   #
   # NOTE: The double quotes prevent YAML issues when parsing `sqlite::memory:`
-  database_url: "<%= ENV['AUTH_DATABASE_URL'] || 'sqlite://data/auth.db' %>"
+  # NOTE: An exported-but-empty AUTH_DATABASE_URL is truthy in Ruby, so it is
+  #       normalized to unset here rather than rendering "" (which reaches
+  #       Sequel.connect as a schemeless URL). AuthConfig#database_url applies
+  #       the same rule for operator config files that do not.
+  database_url: "<%= ENV['AUTH_DATABASE_URL'].to_s.strip.empty? ? 'sqlite://data/auth.db' : ENV['AUTH_DATABASE_URL'] %>"
 
   # Migrations Connection (PostgreSQL, MySQL, MS SQL Server only)
   #
@@ -48,7 +52,7 @@ full:
   #
   # Not needed for SQLite or other databases that don't support this security model.
   #
-  database_url_migrations: <%= ENV['AUTH_DATABASE_URL_MIGRATIONS'] || nil %>
+  database_url_migrations: <%= ENV['AUTH_DATABASE_URL_MIGRATIONS'].to_s.strip.empty? ? nil : ENV['AUTH_DATABASE_URL_MIGRATIONS'] %>
 
   # Service URL (used for internal requests)
   #service_url: <%= ENV['AUTH_SERVICE_URL'] || 'http://127.0.0.1:3000/auth' %>

--- a/lib/onetime/auth_config.rb
+++ b/lib/onetime/auth_config.rb
@@ -59,14 +59,22 @@ module Onetime
     # Use Onetime.session_config instead of Onetime.auth_config.session
 
     # Full mode database URL (from config only, env vars captured in auth.yaml)
+    #
+    # A BLANK value is treated as unset. The config file renders this key from
+    # ENV (`ENV['AUTH_DATABASE_URL'] || <default>`), and an exported-but-empty
+    # AUTH_DATABASE_URL is truthy in Ruby — so without this normalization the
+    # empty string wins over the default and reaches Sequel.connect(''), where
+    # URI.parse('').scheme is nil and adapter_class raises a bare
+    # `NoMethodError: undefined method 'to_sym' for nil`.
     def database_url
-      full['database_url'] || 'sqlite://data/auth.db'
+      presence(full['database_url']) || 'sqlite://data/auth.db'
     end
 
     # Full mode database URL for migrations (with elevated privileges)
     # Returns nil if not explicitly configured - caller must handle fallback
+    # (blank is treated as unset, same as #database_url)
     def database_url_migrations
-      full['database_url_migrations']
+      presence(full['database_url_migrations'])
     end
 
     # Argon2 secret key (pepper) for password hashing defense-in-depth.
@@ -436,6 +444,16 @@ module Onetime
     end
 
     private
+
+    # Nil for a nil/blank/whitespace-only value, the value otherwise.
+    # Lets `presence(x) || default` behave the way `x || default` is
+    # usually intended when x originates from an environment variable.
+    def presence(value)
+      return nil if value.nil?
+
+      str = value.to_s.strip
+      str.empty? ? nil : value
+    end
 
     # Whether the legacy sso.sso_only flag is set in config.
     # Used as a fallback by #restrict_to for configs that predate

--- a/spec/auth.test.yaml
+++ b/spec/auth.test.yaml
@@ -16,8 +16,11 @@ simple:
 full:
   # Database connection for Full mode
   # Uses in-memory SQLite for tests to avoid file persistence issues
-  database_url: "<%= ENV['AUTH_DATABASE_URL'] || 'sqlite::memory:' %>"
-  database_url_migrations: <%= ENV['AUTH_DATABASE_URL_MIGRATIONS'] || nil %>
+  # An exported-but-empty AUTH_DATABASE_URL is truthy in Ruby; treat it as
+  # unset so a lane/direnv that blanks the var still gets in-memory SQLite
+  # instead of a schemeless URL reaching Sequel.connect.
+  database_url: "<%= ENV['AUTH_DATABASE_URL'].to_s.strip.empty? ? 'sqlite::memory:' : ENV['AUTH_DATABASE_URL'] %>"
+  database_url_migrations: <%= ENV['AUTH_DATABASE_URL_MIGRATIONS'].to_s.strip.empty? ? nil : ENV['AUTH_DATABASE_URL_MIGRATIONS'] %>
 
   # Explicitly nil to prevent defaults layer from injecting ARGON2_SECRET
   # pepper into test hashes. Direct Argon2 verification in tests (e.g.

--- a/spec/unit/onetime/models/organization/with_organization_billing_spec.rb
+++ b/spec/unit/onetime/models/organization/with_organization_billing_spec.rb
@@ -89,6 +89,10 @@ RSpec.describe 'WithOrganizationBilling', billing: true do
         def materialized_entitlements
           @materialized_entitlements ||= []
         end
+
+        def rematerialize_all_memberships!
+          { success: 0, failed: 0, total: 0, failed_ids: [] }
+        end
       end
     end
 

--- a/spec/unit/onetime/models/organization/with_organization_billing_spec.rb
+++ b/spec/unit/onetime/models/organization/with_organization_billing_spec.rb
@@ -14,26 +14,28 @@ require_relative '../../../../../apps/web/billing/models/plan'
 require_relative '../../../../../apps/web/billing/lib/plan_validator'
 require_relative '../../../../../apps/web/billing/operations/apply_subscription_to_org'
 
-RSpec.describe 'WithOrganizationBilling', billing: true do
+RSpec.describe 'WithOrganizationBilling', :billing do
   # Build a minimal Stripe::Subscription for testing
   def build_subscription(price_id: 'price_test', subscription_metadata: {}, price_metadata: {})
-    Stripe::Subscription.construct_from({
-      id: 'sub_test_123',
-      object: 'subscription',
-      customer: 'cus_test',
-      status: 'active',
-      metadata: subscription_metadata,
-      items: {
-        data: [{
-          price: {
-            id: price_id,
-            product: 'prod_test',
-            metadata: price_metadata,
-          },
-          current_period_end: (Time.now + 30 * 24 * 60 * 60).to_i,
-        }],
+    Stripe::Subscription.construct_from(
+      {
+        id: 'sub_test_123',
+        object: 'subscription',
+        customer: 'cus_test',
+        status: 'active',
+        metadata: subscription_metadata,
+        items: {
+          data: [{
+            price: {
+              id: price_id,
+              product: 'prod_test',
+              metadata: price_metadata,
+            },
+            current_period_end: (Time.now + (30 * 24 * 60 * 60)).to_i,
+          }],
+        },
       },
-    })
+    )
   end
 
   # Mock a plan in the catalog for a given price_id
@@ -41,7 +43,7 @@ RSpec.describe 'WithOrganizationBilling', billing: true do
     mock_plan = instance_double(
       Billing::Plan,
       plan_id: plan_id,
-      stripe_price_id: price_id
+      stripe_price_id: price_id,
     )
     allow(Billing::Plan).to receive(:find_by_stripe_price_id)
       .with(price_id)
@@ -58,9 +60,14 @@ RSpec.describe 'WithOrganizationBilling', billing: true do
       Class.new do
         include Onetime::Models::Features::WithOrganizationBilling::InstanceMethods
 
-        attr_accessor :objid, :extid, :stripe_subscription_id, :stripe_customer_id,
-                      :subscription_status, :subscription_period_end, :planid,
-                      :complimentary
+        attr_accessor :objid,
+          :extid,
+          :stripe_subscription_id,
+          :stripe_customer_id,
+          :subscription_status,
+          :subscription_period_end,
+          :planid,
+          :complimentary
 
         def initialize
           @objid = 'test-org-123'
@@ -97,26 +104,28 @@ RSpec.describe 'WithOrganizationBilling', billing: true do
     end
 
     let(:org) { saveable_test_class.new }
-    let(:period_end) { (Time.now + 30 * 24 * 60 * 60).to_i }
+    let(:period_end) { (Time.now + (30 * 24 * 60 * 60)).to_i }
 
     def build_valid_subscription(overrides = {})
-      Stripe::Subscription.construct_from({
-        id: 'sub_test_123',
-        object: 'subscription',
-        customer: 'cus_test_456',
-        status: 'active',
-        metadata: { Billing::Metadata::FIELD_PLAN_ID => 'identity_plus_v1' },
-        items: {
-          data: [{
-            price: {
-              id: 'price_test',
-              product: 'prod_test',
-              metadata: {},
-            },
-            current_period_end: period_end,
-          }],
-        },
-      }.merge(overrides))
+      Stripe::Subscription.construct_from(
+        {
+          id: 'sub_test_123',
+          object: 'subscription',
+          customer: 'cus_test_456',
+          status: 'active',
+          metadata: { Billing::Metadata::FIELD_PLAN_ID => 'identity_plus_v1' },
+          items: {
+            data: [{
+              price: {
+                id: 'price_test',
+                product: 'prod_test',
+                metadata: {},
+              },
+              current_period_end: period_end,
+            }],
+          },
+        }.merge(overrides),
+      )
     end
 
     before do
@@ -125,7 +134,7 @@ RSpec.describe 'WithOrganizationBilling', billing: true do
       # Mock catalog to return plan for price_test (catalog-first behavior)
       mock_plan = instance_double(
         Billing::Plan,
-        plan_id: 'identity_plus_v1'
+        plan_id: 'identity_plus_v1',
       )
       allow(Billing::Plan).to receive(:find_by_stripe_price_id)
         .with('price_test')
@@ -185,7 +194,7 @@ RSpec.describe 'WithOrganizationBilling', billing: true do
 
         expect(OT).to receive(:lw).with(
           '[Organization.update_from_stripe_subscription] Unknown subscription status',
-          hash_including(status: 'unknown_status')
+          hash_including(status: 'unknown_status'),
         )
         expect { org.update_from_stripe_subscription(subscription) }.not_to raise_error
       end
@@ -208,34 +217,40 @@ RSpec.describe 'WithOrganizationBilling', billing: true do
       end
 
       it 'raises ArgumentError when subscription id is missing' do
-        subscription = Stripe::Subscription.construct_from({
-          object: 'subscription',
-          customer: 'cus_test',
-          status: 'active',
-          items: { data: [{ price: { id: 'price_test' }, current_period_end: period_end }] },
-        })
+        subscription = Stripe::Subscription.construct_from(
+          {
+            object: 'subscription',
+            customer: 'cus_test',
+            status: 'active',
+            items: { data: [{ price: { id: 'price_test' }, current_period_end: period_end }] },
+          },
+        )
         expect { org.update_from_stripe_subscription(subscription) }
           .to raise_error(ArgumentError, /missing required fields/)
       end
 
       it 'raises ArgumentError when customer is missing' do
-        subscription = Stripe::Subscription.construct_from({
-          id: 'sub_test',
-          object: 'subscription',
-          status: 'active',
-          items: { data: [{ price: { id: 'price_test' }, current_period_end: period_end }] },
-        })
+        subscription = Stripe::Subscription.construct_from(
+          {
+            id: 'sub_test',
+            object: 'subscription',
+            status: 'active',
+            items: { data: [{ price: { id: 'price_test' }, current_period_end: period_end }] },
+          },
+        )
         expect { org.update_from_stripe_subscription(subscription) }
           .to raise_error(ArgumentError, /missing required fields/)
       end
 
       it 'raises ArgumentError when status is missing' do
-        subscription = Stripe::Subscription.construct_from({
-          id: 'sub_test',
-          object: 'subscription',
-          customer: 'cus_test',
-          items: { data: [{ price: { id: 'price_test' }, current_period_end: period_end }] },
-        })
+        subscription = Stripe::Subscription.construct_from(
+          {
+            id: 'sub_test',
+            object: 'subscription',
+            customer: 'cus_test',
+            items: { data: [{ price: { id: 'price_test' }, current_period_end: period_end }] },
+          },
+        )
         expect { org.update_from_stripe_subscription(subscription) }
           .to raise_error(ArgumentError, /missing required fields/)
       end
@@ -277,19 +292,21 @@ RSpec.describe 'WithOrganizationBilling', billing: true do
           .with('price_unknown')
           .and_return(nil)
 
-        subscription = Stripe::Subscription.construct_from({
-          id: 'sub_no_plan',
-          object: 'subscription',
-          customer: 'cus_test',
-          status: 'active',
-          metadata: {},
-          items: {
-            data: [{
-              price: { id: 'price_unknown', product: 'prod_test', metadata: {} },
-              current_period_end: period_end,
-            }],
+        subscription = Stripe::Subscription.construct_from(
+          {
+            id: 'sub_no_plan',
+            object: 'subscription',
+            customer: 'cus_test',
+            status: 'active',
+            metadata: {},
+            items: {
+              data: [{
+                price: { id: 'price_unknown', product: 'prod_test', metadata: {} },
+                current_period_end: period_end,
+              }],
+            },
           },
-        })
+        )
 
         expect { org.update_from_stripe_subscription(subscription) }
           .to raise_error(Billing::CatalogMissError)
@@ -305,26 +322,28 @@ RSpec.describe 'WithOrganizationBilling', billing: true do
 
     context 'complimentary metadata syncing' do
       it 'sets complimentary when subscription metadata has complimentary=true' do
-        subscription = Stripe::Subscription.construct_from({
-          id: 'sub_comp_123',
-          object: 'subscription',
-          customer: 'cus_test_456',
-          status: 'active',
-          metadata: {
-            Billing::Metadata::FIELD_PLAN_ID => 'identity_plus_v1',
-            Billing::Metadata::FIELD_COMPLIMENTARY => 'true',
+        subscription = Stripe::Subscription.construct_from(
+          {
+            id: 'sub_comp_123',
+            object: 'subscription',
+            customer: 'cus_test_456',
+            status: 'active',
+            metadata: {
+              Billing::Metadata::FIELD_PLAN_ID => 'identity_plus_v1',
+              Billing::Metadata::FIELD_COMPLIMENTARY => 'true',
+            },
+            items: {
+              data: [{
+                price: {
+                  id: 'price_test',
+                  product: 'prod_test',
+                  metadata: {},
+                },
+                current_period_end: period_end,
+              }],
+            },
           },
-          items: {
-            data: [{
-              price: {
-                id: 'price_test',
-                product: 'prod_test',
-                metadata: {},
-              },
-              current_period_end: period_end,
-            }],
-          },
-        })
+        )
 
         org.update_from_stripe_subscription(subscription)
         expect(org.complimentary).to eq('true')
@@ -332,7 +351,7 @@ RSpec.describe 'WithOrganizationBilling', billing: true do
 
       it 'clears complimentary when metadata does not have complimentary' do
         org.complimentary = 'true'
-        subscription = build_valid_subscription
+        subscription      = build_valid_subscription
         org.update_from_stripe_subscription(subscription)
         expect(org.complimentary).to be_nil
       end
@@ -351,8 +370,8 @@ RSpec.describe 'WithOrganizationBilling', billing: true do
 
         def initialize(status: nil, planid: nil, complimentary: nil)
           @subscription_status = status
-          @planid = planid
-          @complimentary = complimentary
+          @planid              = planid
+          @complimentary       = complimentary
         end
       end
     end
@@ -412,8 +431,8 @@ RSpec.describe 'WithOrganizationBilling', billing: true do
 
         def initialize(status: nil, planid: nil, complimentary: nil)
           @subscription_status = status
-          @planid = planid
-          @complimentary = complimentary
+          @planid              = planid
+          @complimentary       = complimentary
         end
       end
     end
@@ -422,7 +441,7 @@ RSpec.describe 'WithOrganizationBilling', billing: true do
       org = billing_test_class.new(
         status: 'active',
         planid: 'identity_plus_v1',
-        complimentary: 'true'
+        complimentary: 'true',
       )
       expect(org.complimentary?).to be true
     end
@@ -431,7 +450,7 @@ RSpec.describe 'WithOrganizationBilling', billing: true do
       org = billing_test_class.new(
         status: 'active',
         planid: 'identity_plus_v1',
-        complimentary: nil
+        complimentary: nil,
       )
       expect(org.complimentary?).to be false
     end
@@ -440,7 +459,7 @@ RSpec.describe 'WithOrganizationBilling', billing: true do
       org = billing_test_class.new(
         status: 'canceled',
         planid: 'identity_plus_v1',
-        complimentary: 'true'
+        complimentary: 'true',
       )
       expect(org.complimentary?).to be false
     end
@@ -449,7 +468,7 @@ RSpec.describe 'WithOrganizationBilling', billing: true do
       org = billing_test_class.new(
         status: 'active',
         planid: 'identity_plus_v1',
-        complimentary: ''
+        complimentary: '',
       )
       expect(org.complimentary?).to be false
     end
@@ -458,7 +477,7 @@ RSpec.describe 'WithOrganizationBilling', billing: true do
       org = billing_test_class.new(
         status: 'active',
         planid: 'identity_plus_v1',
-        complimentary: 'true'
+        complimentary: 'true',
       )
       expect(org.paid?).to be true
       expect(org.complimentary?).to be true

--- a/try/unit/auth/billing_hooks_try.rb
+++ b/try/unit/auth/billing_hooks_try.rb
@@ -80,6 +80,7 @@ def setup_test_plans
     region: 'global'
   )
   plan.active = 'true'
+  plan.save
   plan.prices[:month] = {
     stripe_price_id: 'price_test_identity_monthly',
     amount: '1500',
@@ -90,7 +91,6 @@ def setup_test_plans
     amount: '15000',
     interval: 'year'
   }
-  plan.save
 
   @plans_created = true
 end
@@ -105,6 +105,9 @@ end
 def billing_enabled_with_config?(config)
   config&.dig('enabled').to_s == 'true'
 end
+
+setup_test_plans
+BillingTestHelpers.restore_billing!(enabled: true)
 
 # ============================================================================
 # capture_plan_selection tests
@@ -153,9 +156,6 @@ instance.capture_plan_selection
 # ============================================================================
 # build_billing_redirect_info tests
 # ============================================================================
-
-setup_test_plans
-BillingTestHelpers.restore_billing!(enabled: true)
 
 ## build_billing_redirect_info returns valid structure for good params
 instance = MockRodauthInstance.new

--- a/try/unit/auth/billing_hooks_try.rb
+++ b/try/unit/auth/billing_hooks_try.rb
@@ -7,7 +7,6 @@
 #
 # Run: bundle exec try try/unit/auth/billing_hooks_try.rb
 #
-# frozen_string_literal: true
 
 require_relative '../../support/test_helpers'
 
@@ -23,8 +22,8 @@ class MockRodauthInstance
   attr_reader :session, :json_response, :params
 
   def initialize(params: {}, session: {}, json_response: {})
-    @params = params
-    @session = session
+    @params        = params
+    @session       = session
     @json_response = json_response
   end
 
@@ -37,9 +36,10 @@ class MockRodauthInstance
   # Capture plan selection from params into session
   # Mirrors the logic from Auth::Config::Hooks::Billing.define_capture_method
   def capture_plan_selection
-    product  = param_or_nil('product')
-    interval = param_or_nil('interval')
+    product                    = param_or_nil('product')
+    interval                   = param_or_nil('interval')
     return unless product || interval
+
     session[:billing_product]  = product  if product
     session[:billing_interval] = interval if interval
   end
@@ -53,6 +53,7 @@ class MockRodauthInstance
     unless product && interval
       return { product: product, interval: interval, valid: false, error: 'Missing product or interval' }
     end
+
     result = ::Billing::PlanResolver.resolve(product: product, interval: interval)
     if result.success?
       { product: product, interval: interval, valid: true }
@@ -71,32 +72,32 @@ def setup_test_plans
   BillingTestHelpers.ensure_familia_configured!
 
   # Create test plan with both monthly and yearly prices
-  plan = Billing::Plan.new(
+  plan                = Billing::Plan.new(
     plan_id: 'identity_plus_v1',
     stripe_product_id: 'prod_test_identity',
     name: 'Identity Plus',
     tier: 'identity',
     currency: 'cad',
-    region: 'global'
+    region: 'global',
   )
-  plan.active = 'true'
+  plan.active         = 'true'
   plan.save
   plan.prices[:month] = {
     stripe_price_id: 'price_test_identity_monthly',
     amount: '1500',
-    interval: 'month'
+    interval: 'month',
   }
-  plan.prices[:year] = {
+  plan.prices[:year]  = {
     stripe_price_id: 'price_test_identity_yearly',
     amount: '15000',
-    interval: 'year'
+    interval: 'year',
   }
 
   @plans_created = true
 end
 
 def teardown_test_plans
-  plan = Billing::Plan.load('identity_plus_v1')
+  plan           = Billing::Plan.load('identity_plus_v1')
   plan&.destroy! if plan&.exists?
   @plans_created = false
 end
@@ -115,7 +116,7 @@ BillingTestHelpers.restore_billing!(enabled: true)
 
 ## capture_plan_selection stores product in session
 instance = MockRodauthInstance.new(
-  params: { 'product' => 'identity_plus_v1', 'interval' => 'monthly' }
+  params: { 'product' => 'identity_plus_v1', 'interval' => 'monthly' },
 )
 instance.capture_plan_selection
 instance.session[:billing_product]
@@ -123,7 +124,7 @@ instance.session[:billing_product]
 
 ## capture_plan_selection stores interval in session
 instance = MockRodauthInstance.new(
-  params: { 'product' => 'identity_plus_v1', 'interval' => 'monthly' }
+  params: { 'product' => 'identity_plus_v1', 'interval' => 'monthly' },
 )
 instance.capture_plan_selection
 instance.session[:billing_interval]
@@ -131,7 +132,7 @@ instance.session[:billing_interval]
 
 ## capture_plan_selection handles nil params gracefully
 instance = MockRodauthInstance.new(
-  params: { 'product' => nil, 'interval' => nil }
+  params: { 'product' => nil, 'interval' => nil },
 )
 instance.capture_plan_selection
 [instance.session[:billing_product], instance.session[:billing_interval]]
@@ -139,7 +140,7 @@ instance.capture_plan_selection
 
 ## capture_plan_selection handles empty string params
 instance = MockRodauthInstance.new(
-  params: { 'product' => '', 'interval' => '   ' }
+  params: { 'product' => '', 'interval' => '   ' },
 )
 instance.capture_plan_selection
 [instance.session[:billing_product], instance.session[:billing_interval]]
@@ -147,7 +148,7 @@ instance.capture_plan_selection
 
 ## capture_plan_selection stores product only when interval missing
 instance = MockRodauthInstance.new(
-  params: { 'product' => 'identity_plus_v1' }
+  params: { 'product' => 'identity_plus_v1' },
 )
 instance.capture_plan_selection
 [instance.session[:billing_product], instance.session[:billing_interval]]
@@ -159,31 +160,31 @@ instance.capture_plan_selection
 
 ## build_billing_redirect_info returns valid structure for good params
 instance = MockRodauthInstance.new
-info = instance.build_billing_redirect_info('identity_plus_v1', 'monthly', billing_enabled: true)
+info     = instance.build_billing_redirect_info('identity_plus_v1', 'monthly', billing_enabled: true)
 [info[:product], info[:interval], info[:valid]]
 #=> ['identity_plus_v1', 'monthly', true]
 
 ## build_billing_redirect_info returns error for missing product
 instance = MockRodauthInstance.new
-info = instance.build_billing_redirect_info(nil, 'monthly', billing_enabled: true)
+info     = instance.build_billing_redirect_info(nil, 'monthly', billing_enabled: true)
 [info[:valid], info[:error]]
 #=> [false, 'Missing product or interval']
 
 ## build_billing_redirect_info returns error for missing interval
 instance = MockRodauthInstance.new
-info = instance.build_billing_redirect_info('identity_plus_v1', nil, billing_enabled: true)
+info     = instance.build_billing_redirect_info('identity_plus_v1', nil, billing_enabled: true)
 [info[:valid], info[:error]]
 #=> [false, 'Missing product or interval']
 
 ## build_billing_redirect_info validates plan exists via PlanResolver
 instance = MockRodauthInstance.new
-info = instance.build_billing_redirect_info('nonexistent_v1', 'monthly', billing_enabled: true)
+info     = instance.build_billing_redirect_info('nonexistent_v1', 'monthly', billing_enabled: true)
 [info[:valid], info[:error].include?('Plan not found')]
 #=> [false, true]
 
 ## build_billing_redirect_info returns error when billing disabled
 instance = MockRodauthInstance.new
-info = instance.build_billing_redirect_info('identity_plus_v1', 'monthly', billing_enabled: false)
+info     = instance.build_billing_redirect_info('identity_plus_v1', 'monthly', billing_enabled: false)
 [info[:valid], info[:error]]
 #=> [false, 'Billing not enabled']
 

--- a/try/unit/models/custom_domain_destroy_cascade_try.rb
+++ b/try/unit/models/custom_domain_destroy_cascade_try.rb
@@ -14,9 +14,9 @@ require_relative '../../support/test_helpers'
 
 OT.boot! :test
 
-@owner = Onetime::Customer.create!(email: generate_unique_test_email("cascade_owner"))
-@org = Onetime::Organization.create!("Cascade Test Org", @owner, generate_unique_test_email("cascade_contact"))
-@domain = Onetime::CustomDomain.create!("cascade-test.example.com", @org.objid)
+@owner     = Onetime::Customer.create!(email: generate_unique_test_email('cascade_owner'))
+@org       = Onetime::Organization.create!('Cascade Test Org', @owner, generate_unique_test_email('cascade_contact'))
+@domain    = Onetime::CustomDomain.create!('cascade-test.example.com', @org.objid)
 @domain_id = @domain.identifier
 
 # Stage sibling configs — HomepageConfig + ApiConfig exercise the cleanup path
@@ -26,25 +26,26 @@ Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @domain_id, enabled: tru
 Onetime::CustomDomain::ApiConfig.upsert(domain_id: @domain_id, enabled: true)
 
 # Create domain-scoped members
-@scoped_user_a = Onetime::Customer.create!(email: generate_unique_test_email("cascade_scoped_a"))
-@membership_a = Onetime::OrganizationMembership.ensure_membership(
-  @org, @scoped_user_a,
-  domain_scope_id: @domain.objid
+@scoped_user_a      = Onetime::Customer.create!(email: generate_unique_test_email('cascade_scoped_a'))
+@membership_a       = Onetime::OrganizationMembership.ensure_membership(
+  @org,
+  @scoped_user_a,
+  domain_scope_id: @domain.objid,
 )
 @membership_a_objid = @membership_a.objid
 
-@scoped_user_b = Onetime::Customer.create!(email: generate_unique_test_email("cascade_scoped_b"))
-@membership_b = Onetime::OrganizationMembership.ensure_membership(
-  @org, @scoped_user_b,
-  domain_scope_id: @domain.objid
+@scoped_user_b      = Onetime::Customer.create!(email: generate_unique_test_email('cascade_scoped_b'))
+@membership_b       = Onetime::OrganizationMembership.ensure_membership(
+  @org,
+  @scoped_user_b,
+  domain_scope_id: @domain.objid,
 )
 @membership_b_objid = @membership_b.objid
 
 # Create an org-scoped member who should NOT be removed
-@org_member = Onetime::Customer.create!(email: generate_unique_test_email("cascade_orgmember"))
-@org_membership = Onetime::OrganizationMembership.ensure_membership(@org, @org_member)
+@org_member           = Onetime::Customer.create!(email: generate_unique_test_email('cascade_orgmember'))
+@org_membership       = Onetime::OrganizationMembership.ensure_membership(@org, @org_member)
 @org_membership_objid = @org_membership.objid
-
 
 ## Pre-condition: domain-scoped memberships exist
 Onetime::OrganizationMembership.find_all_by_domain_scope(@domain.objid).size
@@ -68,7 +69,6 @@ Onetime::CustomDomain::ApiConfig.exists_for_domain?(@domain_id)
 
 ## Destroy the domain (triggers cascade)
 @domain.destroy!
-true
 #=> true
 
 ## After destroy: HomepageConfig was cleaned up
@@ -116,9 +116,9 @@ Onetime::OrganizationMembership.exists?(@org_membership_objid)
 # exercise destroy!'s no-op cleanup path.
 
 ## Setup: fresh domain, then delete the bootstrap configs so all siblings are absent
-@bare_owner = Onetime::Customer.create!(email: generate_unique_test_email("cascade_bare"))
-@bare_org = Onetime::Organization.create!("Cascade Bare Org", @bare_owner, generate_unique_test_email("cascade_bare_contact"))
-@bare_domain = Onetime::CustomDomain.create!("cascade-bare.example.com", @bare_org.objid)
+@bare_owner     = Onetime::Customer.create!(email: generate_unique_test_email('cascade_bare'))
+@bare_org       = Onetime::Organization.create!('Cascade Bare Org', @bare_owner, generate_unique_test_email('cascade_bare_contact'))
+@bare_domain    = Onetime::CustomDomain.create!('cascade-bare.example.com', @bare_org.objid)
 @bare_domain_id = @bare_domain.identifier
 Onetime::CustomDomain::HomepageConfig.delete_for_domain!(@bare_domain_id)
 Onetime::CustomDomain::ApiConfig.delete_for_domain!(@bare_domain_id)
@@ -131,7 +131,6 @@ Onetime::CustomDomain::ApiConfig.delete_for_domain!(@bare_domain_id)
 
 ## Destroy on bare domain does not raise
 @bare_domain.destroy!
-true
 #=> true
 
 ## Bare domain is gone
@@ -145,9 +144,9 @@ Onetime::CustomDomain.find_by_identifier(@bare_domain_id)
 # cleanup below runs normally.
 
 ## Setup: fail-path domain with both HomepageConfig and ApiConfig present
-@fail_owner = Onetime::Customer.create!(email: generate_unique_test_email("cascade_fail"))
-@fail_org = Onetime::Organization.create!("Cascade Fail Org", @fail_owner, generate_unique_test_email("cascade_fail_contact"))
-@fail_domain = Onetime::CustomDomain.create!("cascade-fail.example.com", @fail_org.objid)
+@fail_owner     = Onetime::Customer.create!(email: generate_unique_test_email('cascade_fail'))
+@fail_org       = Onetime::Organization.create!('Cascade Fail Org', @fail_owner, generate_unique_test_email('cascade_fail_contact'))
+@fail_domain    = Onetime::CustomDomain.create!('cascade-fail.example.com', @fail_org.objid)
 @fail_domain_id = @fail_domain.identifier
 Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @fail_domain_id, enabled: true)
 Onetime::CustomDomain::ApiConfig.upsert(domain_id: @fail_domain_id, enabled: true)
@@ -156,10 +155,10 @@ Onetime::CustomDomain::ApiConfig.upsert(domain_id: @fail_domain_id, enabled: tru
 #=> [true, true]
 
 ## Stubbed HomepageConfig raises during cleanup but destroy! still completes
-hp_class = Onetime::CustomDomain::HomepageConfig
+hp_class        = Onetime::CustomDomain::HomepageConfig
 original_delete = hp_class.method(:delete_for_domain!)
 hp_class.define_singleton_method(:delete_for_domain!) do |_domain_id|
-  raise Familia::HorreumError, "forced cleanup failure"
+  raise Familia::HorreumError, 'forced cleanup failure'
 end
 begin
   @fail_domain.destroy!
@@ -177,7 +176,6 @@ Onetime::CustomDomain::ApiConfig.exists_for_domain?(@fail_domain_id)
 Onetime::CustomDomain.find_by_identifier(@fail_domain_id)
 #=> nil
 
-
 # --- Sibling cleanups run before the primary record is destroyed ---
 #
 # Partial-failure recovery depends on this ordering: if super ran first, a
@@ -185,20 +183,20 @@ Onetime::CustomDomain.find_by_identifier(@fail_domain_id)
 # the primary record's existence at sibling-cleanup time to prove the order.
 
 ## Setup: ordering-path domain with HomepageConfig present (unique name avoids stale display_domain_index)
-@order_owner = Onetime::Customer.create!(email: generate_unique_test_email("cascade_order"))
-@order_org = Onetime::Organization.create!("Cascade Order Org", @order_owner, generate_unique_test_email("cascade_order_contact"))
-@order_domain_name = "cascade-order-#{SecureRandom.hex(4)}.example.com"
-@order_domain = Onetime::CustomDomain.create!(@order_domain_name, @order_org.objid)
-@order_domain_id = @order_domain.identifier
+@order_owner        = Onetime::Customer.create!(email: generate_unique_test_email('cascade_order'))
+@order_org          = Onetime::Organization.create!('Cascade Order Org', @order_owner, generate_unique_test_email('cascade_order_contact'))
+@order_domain_name  = "cascade-order-#{SecureRandom.hex(4)}.example.com"
+@order_domain       = Onetime::CustomDomain.create!(@order_domain_name, @order_org.objid)
+@order_domain_id    = @order_domain.identifier
 @order_domain_dbkey = @order_domain.dbkey
 Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @order_domain_id, enabled: true)
 Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@order_domain_id)
 #=> true
 
 ## Sibling cleanup fires while primary record still exists in Redis
-hp_class = Onetime::CustomDomain::HomepageConfig
-original_delete = hp_class.method(:delete_for_domain!)
-captured_dbkey = @order_domain_dbkey
+hp_class                = Onetime::CustomDomain::HomepageConfig
+original_delete         = hp_class.method(:delete_for_domain!)
+captured_dbkey          = @order_domain_dbkey
 captured_primary_exists = nil
 hp_class.define_singleton_method(:delete_for_domain!) do |domain_id|
   captured_primary_exists = Familia.dbclient.exists?(captured_dbkey)
@@ -209,19 +207,17 @@ begin
 ensure
   hp_class.define_singleton_method(:delete_for_domain!, original_delete)
 end
-captured_primary_exists
 #=> true
 
 ## After destroy: primary record is gone
 Onetime::CustomDomain.find_by_identifier(@order_domain_id)
 #=> nil
 
-
 # Cleanup
 [@org, @owner, @scoped_user_a, @scoped_user_b, @org_member,
  @bare_org, @bare_owner, @fail_org, @fail_owner,
  @order_org, @order_owner].each do |obj|
-  obj.destroy! if obj&.respond_to?(:destroy!) && obj.exists?
+  obj.destroy! if obj.respond_to?(:destroy!) && obj.exists?
 end
 # Remove the HomepageConfig we left behind on the fail_domain (the stub blocked its cleanup).
 Onetime::CustomDomain::HomepageConfig.delete_for_domain!(@fail_domain_id) if @fail_domain_id

--- a/try/unit/models/custom_domain_destroy_cascade_try.rb
+++ b/try/unit/models/custom_domain_destroy_cascade_try.rb
@@ -69,6 +69,7 @@ Onetime::CustomDomain::ApiConfig.exists_for_domain?(@domain_id)
 
 ## Destroy the domain (triggers cascade)
 @domain.destroy!
+true
 #=> true
 
 ## After destroy: HomepageConfig was cleaned up
@@ -131,6 +132,7 @@ Onetime::CustomDomain::ApiConfig.delete_for_domain!(@bare_domain_id)
 
 ## Destroy on bare domain does not raise
 @bare_domain.destroy!
+true
 #=> true
 
 ## Bare domain is gone
@@ -207,6 +209,7 @@ begin
 ensure
   hp_class.define_singleton_method(:delete_for_domain!, original_delete)
 end
+captured_primary_exists
 #=> true
 
 ## After destroy: primary record is gone

--- a/try/unit/models/custom_domain_destroy_cascade_try.rb
+++ b/try/unit/models/custom_domain_destroy_cascade_try.rb
@@ -165,9 +165,7 @@ begin
   @fail_domain.destroy!
   :completed
 ensure
-  hp_class.define_singleton_method(:delete_for_domain!) do |domain_id|
-    original_delete.call(domain_id)
-  end
+  hp_class.define_singleton_method(:delete_for_domain!, original_delete)
 end
 #=> :completed
 
@@ -209,9 +207,7 @@ end
 begin
   @order_domain.destroy!
 ensure
-  hp_class.define_singleton_method(:delete_for_domain!) do |domain_id|
-    original_delete.call(domain_id)
-  end
+  hp_class.define_singleton_method(:delete_for_domain!, original_delete)
 end
 captured_primary_exists
 #=> true


### PR DESCRIPTION
### Summary

- **Tryouts Upgrade**: Upgraded `tryouts` gem to version `4.0.0.pre1` and resolved resulting test harness failures across various suites (including custom domains, billing hooks, and close account operations).
- **Database Availability Guarding**: Added `Auth::Database.available?` to cleanly detect database presence, handled empty/blank `AUTH_DATABASE_URL` values, and guarded cleanup routines in simple mode to prevent nil pointer/database connection errors when running without a dedicated auth DB.
- **Linting & Code Style**: Cleaned up pre-existing rubocop violations in the modified files.
