### PR TITLE
Read trusted_proxy mode through a single accessor

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -1204,6 +1204,11 @@ TRUSTED_PROXY_ENABLED=false
 #   than the real hop count selects a client-supplied entry. Use for proxies
 #   with public IPs that filter mode would misread as the client, or when
 #   you need deterministic hop selection regardless of IP class.
+#
+#   Matched case-insensitively and canonicalized (as TRUSTED_PROXY_HEADER is).
+#   Anything outside the closed set falls back to filter — the safer mode — and
+#   WARNs at boot naming the value; the startup `trusted_proxy:` posture line
+#   always reports the mode actually in force, not the value configured here.
 TRUSTED_PROXY_MODE=filter
 
 # depth mode only: which header to read the forwarding chain from.

--- a/changelog.d/20260811_140000_claude_4087_trusted_proxy_mode_ssot.rst
+++ b/changelog.d/20260811_140000_claude_4087_trusted_proxy_mode_ssot.rst
@@ -1,0 +1,62 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- **Operators:** the startup ``trusted_proxy:`` posture line now reports the
+  mode actually in force instead of echoing the configured string back. The
+  admin-isolation boot diagnostics and the code that configures client-IP
+  resolution used to read ``TRUSTED_PROXY_MODE``
+  (``site.network.trusted_proxy.mode``) independently, with different
+  expressions, so a deployment configured ``TRUSTED_PROXY_MODE=Depth`` ran
+  filter — the resolution branch tests for the exact string ``depth`` — while
+  announcing ``trusted_proxy: enabled (mode=Depth)`` on the one line operators
+  are told to read to confirm the posture of the gates protecting the admin
+  surfaces. Both now read one accessor: the mode is matched
+  case-insensitively and canonicalized, and the posture line always names the
+  mode the request path will use. (#4087)
+
+- **Operators — action may be required on upgrade.** If your
+  ``TRUSTED_PROXY_MODE`` is not written in lower case, this release changes
+  how client IPs are resolved. ``Depth``, ``DEPTH`` and the like previously
+  failed the exact-string test and ran **filter**; they are now canonicalized
+  and genuinely select **depth**, which counts hops from the right of the
+  forwarded chain — a different address, and a wrong one if
+  ``TRUSTED_PROXY_DEPTH`` does not match the real proxy topology. Boot now
+  logs a warning naming both the configured and the canonicalized value when
+  this applies. Two things to check before upgrading: that
+  ``TRUSTED_PROXY_DEPTH`` matches your hop count, and that you are prepared
+  for depth mode's known limitation — depth does not record peer trust in
+  ``otto.via_trusted_proxy`` (pending delano/otto#226, the upstream half of
+  #4024), so forwarded host headers are discarded and every request
+  classifies as the canonical site; custom-domain branding, per-domain
+  homepage modes and domain-scoped sign-in behave as if the request arrived
+  on the canonical host. Setting ``TRUSTED_PROXY_MODE=filter`` explicitly
+  preserves the behaviour you were actually running. (#4087, #4024)
+
+Changed
+-------
+
+- **Operators:** an unrecognized ``TRUSTED_PROXY_MODE`` now WARNs at boot
+  naming the value and the mode actually running, instead of silently
+  falling through to filter. The accepted set is closed (``filter``,
+  ``depth``), matching how ``TRUSTED_PROXY_HEADER`` is already documented. A
+  typo such as ``dept`` still runs filter — the safer of the two, since it
+  authenticates each forwarded hop against the trusted-proxy CIDR set — and
+  still boots: a configuration whose misreading already fails closed should
+  not take a deployment offline. The warning is emitted once per process
+  rather than once per mounted application, and a second, distinct warning
+  covers the canonicalization case above. Behaviour for unset, empty and
+  exactly-lowercase values is unchanged, and those spellings log nothing.
+  (#4087)
+
+AI Assistance
+-------------
+
+- Claude consolidated the four independent readers of
+  ``site.network.trusted_proxy`` onto the single
+  ``MiddlewareStack.trusted_proxy_enabled?`` / ``.trusted_proxy_mode`` pair,
+  added the mode canonicalization, closed-set validation and the two boot
+  warnings (unrecognized value, and value reinterpreted by canonicalization),
+  and moved the ``filter`` default out of its three homes into the accessor.
+  (#4087)

--- a/changelog.d/20260811_140000_claude_4087_trusted_proxy_mode_ssot.rst
+++ b/changelog.d/20260811_140000_claude_4087_trusted_proxy_mode_ssot.rst
@@ -17,14 +17,17 @@ Fixed
   mode the request path will use. (#4087)
 
 - **Operators — action may be required on upgrade.** If your
-  ``TRUSTED_PROXY_MODE`` is not written in lower case, this release changes
-  how client IPs are resolved. ``Depth``, ``DEPTH`` and the like previously
+  ``TRUSTED_PROXY_MODE`` means depth but is not written as exactly ``depth``,
+  this release changes how client IPs are resolved. ``Depth``, ``DEPTH`` and
+  ``  depth  `` previously
   failed the exact-string test and ran **filter**; they are now canonicalized
   and genuinely select **depth**, which counts hops from the right of the
   forwarded chain — a different address, and a wrong one if
   ``TRUSTED_PROXY_DEPTH`` does not match the real proxy topology. Boot now
   logs a warning naming both the configured and the canonicalized value when
-  this applies. Check before upgrading that ``TRUSTED_PROXY_DEPTH`` matches
+  this applies. Other rewritten spellings — ``FILTER``, ``  filter  `` — ran
+  filter before and run filter now; they get a separate, milder boot line that
+  does not claim a behaviour change. Check before upgrading that ``TRUSTED_PROXY_DEPTH`` matches
   your actual hop count: a mismatch resolves a proxy or CDN address as the
   client, which affects admin CIDR enforcement and shares rate-limit buckets
   across unrelated clients. Setting ``TRUSTED_PROXY_MODE=filter`` explicitly
@@ -41,8 +44,11 @@ Changed
   authenticates each forwarded hop against the trusted-proxy CIDR set — and
   still boots: a configuration whose misreading already fails closed should
   not take a deployment offline. The warning is emitted once per process
-  rather than once per mounted application, and a second, distinct warning
-  covers the canonicalization case above. Behaviour for unset, empty and
+  rather than once per mounted application, and two further distinct warnings
+  cover the canonicalization cases above — one for a rewrite that selects depth
+  where filter used to run, one for a rewrite that changes nothing. Each is
+  tagged separately, so a cosmetic rewrite cannot silence the warning that
+  reports a real change. Behaviour for unset, empty and
   exactly-lowercase values is unchanged, and those spellings log nothing.
   (#4087)
 
@@ -52,7 +58,8 @@ AI Assistance
 - Claude consolidated the four independent readers of
   ``site.network.trusted_proxy`` onto the single
   ``MiddlewareStack.trusted_proxy_enabled?`` / ``.trusted_proxy_mode`` pair,
-  added the mode canonicalization, closed-set validation and the two boot
-  warnings (unrecognized value, and value reinterpreted by canonicalization),
+  added the mode canonicalization, closed-set validation and the three boot
+  warnings (unrecognized value, rewrite that changes the running mode, and
+  rewrite that does not),
   and moved the ``filter`` default out of its three homes into the accessor.
   (#4087)

--- a/changelog.d/20260811_140000_claude_4087_trusted_proxy_mode_ssot.rst
+++ b/changelog.d/20260811_140000_claude_4087_trusted_proxy_mode_ssot.rst
@@ -24,15 +24,11 @@ Fixed
   forwarded chain — a different address, and a wrong one if
   ``TRUSTED_PROXY_DEPTH`` does not match the real proxy topology. Boot now
   logs a warning naming both the configured and the canonicalized value when
-  this applies. Two things to check before upgrading: that
-  ``TRUSTED_PROXY_DEPTH`` matches your hop count, and that you are prepared
-  for depth mode's known limitation — depth does not record peer trust in
-  ``otto.via_trusted_proxy`` (pending delano/otto#226, the upstream half of
-  #4024), so forwarded host headers are discarded and every request
-  classifies as the canonical site; custom-domain branding, per-domain
-  homepage modes and domain-scoped sign-in behave as if the request arrived
-  on the canonical host. Setting ``TRUSTED_PROXY_MODE=filter`` explicitly
-  preserves the behaviour you were actually running. (#4087, #4024)
+  this applies. Check before upgrading that ``TRUSTED_PROXY_DEPTH`` matches
+  your actual hop count: a mismatch resolves a proxy or CDN address as the
+  client, which affects admin CIDR enforcement and shares rate-limit buckets
+  across unrelated clients. Setting ``TRUSTED_PROXY_MODE=filter`` explicitly
+  preserves the behaviour you were actually running. (#4087)
 
 Changed
 -------

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -531,6 +531,12 @@ site:
       #   - Forged leftmost entry: filter returns it (see SECURITY above); depth
       #     ignores it, since only the position N-from-the-right is read
       #
+      # Matched case-insensitively and canonicalized (like `header` below). The
+      # set is closed: any other value falls back to filter — the safer mode —
+      # and WARNs at boot naming the value, rather than failing the boot. The
+      # 'filter' default here is documentation; the app applies the same default
+      # itself, so an unset or programmatically assembled config behaves
+      # identically.
       mode: <%= ENV['TRUSTED_PROXY_MODE'] || 'filter' %>
 
       # Depth mode only: which header to read the forwarding chain from.

--- a/lib/onetime/application/middleware_stack.rb
+++ b/lib/onetime/application/middleware_stack.rb
@@ -458,8 +458,9 @@ module Onetime
               "(TRUSTED_PROXY_MODE) was canonicalized to #{raw.inspect}: running mode=#{raw}. " \
               'Earlier releases matched this setting literally and ran ' \
               "mode=#{default} for any other spelling, so upgrading with this value CHANGES " \
-              'how the client IP is resolved. Write it in lower case to silence this, or ' \
-              "set it to #{default} to keep the previous behaviour."
+              'how the client IP is resolved. Write it as ' \
+              "#{raw.inspect} exactly — lower case, no surrounding whitespace — to silence " \
+              "this, or set it to #{default} to keep the previous behaviour."
           end
 
           raw

--- a/lib/onetime/application/middleware_stack.rb
+++ b/lib/onetime/application/middleware_stack.rb
@@ -401,8 +401,8 @@ module Onetime
         # canonicalization (`dept`, `cidr`, garbage).
         #
         # BUT CANONICALIZING IS NOT SILENT. A second, distinct warning fires when
-        # canonicalization actually CHANGED the operator's value while still
-        # landing on a valid mode (`Depth`, `DEPTH`, ` depth `). Honouring those
+        # canonicalization CHANGED the operator's value while still landing on a
+        # valid mode (`Depth`, `DEPTH`, ` depth `). Honouring those
         # is a genuine RUNTIME CHANGE on upgrade: before this reader existed the
         # branch was an exact `== 'depth'` test, so a mixed-case value ran FILTER.
         # Such a deployment now switches client-IP resolution to depth, which
@@ -414,7 +414,9 @@ module Onetime
         # pinned in try/integration/middleware/detect_host_ip_privacy_stack_try.rb.)
         # The operator must be TOLD their value was reinterpreted, not merely
         # obeyed. Exact-lowercase valid values stay silent — nothing changed for
-        # them, and a warning on the correct spelling is noise.
+        # them, and a warning on the correct spelling is noise. A rewritten
+        # spelling that lands on the mode it already ran (`FILTER`, ` filter `)
+        # gets a THIRD, milder warning that does not claim a behaviour change.
         #
         # WARN, DO NOT RAISE. The fallback is the SAFER mode: filter authenticates
         # each hop against a CIDR set, where depth trusts a hop count. Refusing
@@ -452,10 +454,22 @@ module Onetime
           end
 
           # Valid, but not written the way the app stores it — say so. See the
-          # CANONICALIZING IS NOT SILENT note above: this is the upgrade case
-          # where a mixed-case value stops running filter and starts running
-          # what it says.
-          if raw != configured
+          # CANONICALIZING IS NOT SILENT note above.
+          #
+          # TWO DISTINCT CASES, TWO DISTINCT TAGS. The old branch was an exact
+          # `== 'depth'` test, so the ONLY spelling whose runtime behaviour moves
+          # on upgrade is one that canonicalizes TO depth without having been
+          # exactly `depth` already (`Depth`, `DEPTH`, `  depth  `). Every other
+          # rewritten spelling (`FILTER`, `  filter  `) ran filter before and
+          # runs filter now — telling that operator their client-IP resolution
+          # CHANGED is false, and sharing a warn_once tag with the real case
+          # would let a cosmetic rewrite in one Application subclass swallow the
+          # behaviour-change warning for the next one.
+          #
+          # Compare against `configured`, not `configured.strip`: whitespace was
+          # significant to the old exact match, so `  depth  ` ran filter then
+          # and runs depth now — a behaviour change like any other misspelling.
+          if raw == 'depth' && configured != 'depth'
             warn_once :trusted_proxy_mode_canonicalized,
               "[MiddlewareStack] site.network.trusted_proxy.mode #{configured.inspect} " \
               "(TRUSTED_PROXY_MODE) was canonicalized to #{raw.inspect}: running mode=#{raw}. " \
@@ -464,6 +478,13 @@ module Onetime
               'how the client IP is resolved. Write it as ' \
               "#{raw.inspect} exactly — lower case, no surrounding whitespace — to silence " \
               "this, or set it to #{default} to keep the previous behaviour."
+          elsif raw != configured
+            warn_once :trusted_proxy_mode_respelled,
+              "[MiddlewareStack] site.network.trusted_proxy.mode #{configured.inspect} " \
+              "(TRUSTED_PROXY_MODE) was canonicalized to #{raw.inspect}: running mode=#{raw}, " \
+              'the same mode earlier releases ran for this value — client IP resolution is ' \
+              "unchanged. Write it as #{raw.inspect} exactly — lower case, no surrounding " \
+              'whitespace — to silence this.'
           end
 
           raw

--- a/lib/onetime/application/middleware_stack.rb
+++ b/lib/onetime/application/middleware_stack.rb
@@ -87,6 +87,15 @@ module Onetime
         )
       /ix
 
+      # The closed set of client-IP resolution strategies accepted in
+      # site.network.trusted_proxy.mode. Anything else is an operator typo:
+      # .trusted_proxy_mode canonicalizes case, then falls back to 'filter' with
+      # a warning rather than defaulting through the unknown value silently
+      # (#4087). Module scope for the same two reasons as the regex above — it
+      # stays lexically visible to the singleton methods in `class << self`, and
+      # specs can assert against the set rather than restating it.
+      TRUSTED_PROXY_MODES = %w[filter depth].freeze
+
       class << self
         # Build locale map for Otto::Locale::Middleware
         #
@@ -191,6 +200,11 @@ module Onetime
         #     deleted walker's off-by-one). Mutually exclusive with
         #     add_trusted_proxy.
         #
+        # The mode itself is read through .trusted_proxy_mode, which owns the
+        # 'filter' default, canonicalizes case, and warns on an unrecognized
+        # value instead of letting it fall through the `else` branch below
+        # unannounced (#4087).
+        #
         # Header (site.network.trusted_proxy.header): in depth mode otto 2.3.1
         # counts hops from the configured forwarded header — 'X-Forwarded-For'
         # (default), RFC 7239 'Forwarded', or 'Both' — wired straight through to
@@ -244,8 +258,14 @@ module Onetime
           # still masks it per the flag above).
           return config unless trusted_proxy_enabled?
 
-          tp     = OT.conf.dig('site', 'network', 'trusted_proxy') || {}
-          mode   = tp['mode'] || 'filter'
+          tp = OT.conf.dig('site', 'network', 'trusted_proxy') || {}
+
+          # Mode comes from the shared reader, not from `tp` — it is the one
+          # key in this block that a second consumer (the admin-isolation
+          # posture line) also reads, and it is the one that gets defaulted and
+          # validated. See .trusted_proxy_mode.
+          mode = trusted_proxy_mode
+
           header = tp['header'].to_s.strip
           header = 'X-Forwarded-For' if header.empty?
 
@@ -356,6 +376,93 @@ module Onetime
         # @return [Boolean]
         def trusted_proxy_enabled?
           OT.conf.dig('site', 'network', 'trusted_proxy', 'enabled') == true
+        end
+
+        # How the client IP is resolved when a trusted proxy IS declared
+        # (site.network.trusted_proxy.mode). The SINGLE Ruby reader for this
+        # setting: ip_privacy_security_config branches on it to configure otto,
+        # and AdminNetworkIsolation#trusted_proxy_posture reports it on the boot
+        # line operators are told to read. Those two used to dig the config
+        # independently with different expressions, which is how a deployment
+        # could run filter while its boot log announced `mode=Depth` (#4087).
+        #
+        # The 'filter' default lives HERE and nowhere else in Ruby. The ERB
+        # default in etc/defaults/config.defaults.yaml stays as operator
+        # documentation, but nothing depends on it having been applied — OT.conf
+        # is also assembled programmatically (specs, embedders) and a modeless
+        # trusted_proxy block must still resolve to a defined mode.
+        #
+        # DOWNCASE FIRST, THEN VALIDATE. `Depth` is an operator writing the same
+        # setting in a different case, not a typo, and the sibling
+        # trusted_proxy.header setting is already documented as "matched
+        # case-insensitively and canonicalized" — canonicalizing case here keeps
+        # the two halves of the same config block consistent. The unknown-value
+        # WARN is reserved for values that are still unrecognized after
+        # canonicalization (`dept`, `cidr`, garbage).
+        #
+        # BUT CANONICALIZING IS NOT SILENT. A second, distinct warning fires when
+        # canonicalization actually CHANGED the operator's value while still
+        # landing on a valid mode (`Depth`, `DEPTH`, ` depth `). Honouring those
+        # is a genuine RUNTIME CHANGE on upgrade: before this reader existed the
+        # branch was an exact `== 'depth'` test, so a mixed-case value ran FILTER.
+        # Such a deployment now switches client-IP resolution to depth — which is
+        # still incomplete, since depth mode does not record peer trust in
+        # env['otto.via_trusted_proxy'] pending delano/otto#226, so forwarded host
+        # headers are discarded and custom domains classify as canonical (#4024).
+        # The operator must be TOLD their value was reinterpreted, not merely
+        # obeyed. Exact-lowercase valid values stay silent — nothing changed for
+        # them, and a warning on the correct spelling is noise.
+        #
+        # WARN, DO NOT RAISE. The fallback is the SAFER mode: filter authenticates
+        # each hop against a CIDR set, where depth trusts a hop count. Refusing
+        # the boot would take a deployment offline over a log-adjacent setting
+        # whose misreading already fails closed — the same reasoning #4062 applied
+        # to the admin host allowlist, where a boot log line must never be the
+        # thing that fails a boot. Silence is the only unacceptable option, since
+        # the operator asked for something the app is not doing.
+        #
+        # warn_once: every Application subclass builds its own Rack stack and
+        # reaches this reader, so an unguarded warning repeats once per app and
+        # reads like several distinct problems.
+        #
+        # The .strip is belt-and-braces: YAML plain-scalar parsing already strips
+        # whitespace out of the ERB interpolation, but OT.conf is also set
+        # directly in specs and by embedders.
+        #
+        # @return [String] 'filter' or 'depth' — never any other value
+        def trusted_proxy_mode
+          default    = 'filter'
+          configured = OT.conf.dig('site', 'network', 'trusted_proxy', 'mode').to_s
+          raw        = configured.strip.downcase
+
+          return default if raw.empty?
+
+          unless TRUSTED_PROXY_MODES.include?(raw)
+            warn_once :trusted_proxy_mode_unknown,
+              "[MiddlewareStack] site.network.trusted_proxy.mode #{raw.inspect} " \
+              '(TRUSTED_PROXY_MODE) is not a recognized mode — valid values are ' \
+              "#{TRUSTED_PROXY_MODES.join(', ')}. Running mode=#{default}: the client IP " \
+              'is resolved by walking the forwarded chain against the trusted-proxy ' \
+              'CIDRs. Fix the value or unset it to silence this.'
+
+            return default
+          end
+
+          # Valid, but not written the way the app stores it — say so. See the
+          # CANONICALIZING IS NOT SILENT note above: this is the upgrade case
+          # where a mixed-case value stops running filter and starts running
+          # what it says.
+          if raw != configured
+            warn_once :trusted_proxy_mode_canonicalized,
+              "[MiddlewareStack] site.network.trusted_proxy.mode #{configured.inspect} " \
+              "(TRUSTED_PROXY_MODE) was canonicalized to #{raw.inspect}: running mode=#{raw}. " \
+              'Earlier releases matched this setting literally and ran ' \
+              "mode=#{default} for any other spelling, so upgrading with this value CHANGES " \
+              'how the client IP is resolved. Write it in lower case to silence this, or ' \
+              "set it to #{default} to keep the previous behaviour."
+          end
+
+          raw
         end
 
         def configure(builder, application_context: nil)

--- a/lib/onetime/application/middleware_stack.rb
+++ b/lib/onetime/application/middleware_stack.rb
@@ -405,10 +405,13 @@ module Onetime
         # landing on a valid mode (`Depth`, `DEPTH`, ` depth `). Honouring those
         # is a genuine RUNTIME CHANGE on upgrade: before this reader existed the
         # branch was an exact `== 'depth'` test, so a mixed-case value ran FILTER.
-        # Such a deployment now switches client-IP resolution to depth — which is
-        # still incomplete, since depth mode does not record peer trust in
-        # env['otto.via_trusted_proxy'] pending delano/otto#226, so forwarded host
-        # headers are discarded and custom domains classify as canonical (#4024).
+        # Such a deployment now switches client-IP resolution to depth, which
+        # counts hops from the right of the forwarded chain instead of walking
+        # it against the trusted-proxy CIDRs — a different address, and a wrong
+        # one if TRUSTED_PROXY_DEPTH does not match the real proxy topology.
+        # (Forwarded-host trust is NOT a concern here: otto 2.8 records
+        # env['otto.via_trusted_proxy'] in depth mode too, delano/otto#226,
+        # pinned in try/integration/middleware/detect_host_ip_privacy_stack_try.rb.)
         # The operator must be TOLD their value was reinterpreted, not merely
         # obeyed. Exact-lowercase valid values stay silent — nothing changed for
         # them, and a warning on the correct spelling is noise.

--- a/lib/onetime/middleware/admin_network_isolation.rb
+++ b/lib/onetime/middleware/admin_network_isolation.rb
@@ -959,11 +959,16 @@ module Onetime
       end
 
       # Whether the deployment declares a trusted reverse proxy, and in which
-      # mode. Read through the SAME predicate that decides how the universal
-      # IP-privacy mount is configured
-      # (Onetime::Application::MiddlewareStack.trusted_proxy_enabled?, consumed
-      # by .ip_privacy_security_config), so this line cannot report a posture
-      # the stack does not actually have.
+      # mode. Both halves are read through the SAME accessors that decide how
+      # the universal IP-privacy mount is configured
+      # (Onetime::Application::MiddlewareStack.trusted_proxy_enabled? and
+      # .trusted_proxy_mode, consumed by .ip_privacy_security_config), so this
+      # line cannot report a posture the stack does not actually have. In
+      # particular the mode is the CANONICALIZED, VALIDATED one — a deployment
+      # configured `TRUSTED_PROXY_MODE=Depth` reports `mode=depth`, and one
+      # configured with a typo reports `mode=filter` (the mode it is really
+      # running) alongside the accessor's own boot warning, rather than echoing
+      # the operator's raw string back at them (#4087).
       #
       # WHY IT IS LOGGED HERE: with trusted_proxy DISABLED — the shipped
       # default — neither gate's input is authenticated. Rack::DetectHost falls
@@ -982,31 +987,10 @@ module Onetime
       # middleware has loaded it; the rescue covers an embedding that builds it
       # standalone. A boot log line must never be the thing that fails a boot.
       def trusted_proxy_posture
-        return 'disabled' unless Onetime::Application::MiddlewareStack.trusted_proxy_enabled?
+        stack = Onetime::Application::MiddlewareStack
+        return 'disabled' unless stack.trusted_proxy_enabled?
 
-        # Reproduces MiddlewareStack.ip_privacy_security_config's own default
-        # for an enabled-but-modeless block. There is no shared reader for the
-        # MODE (only for `enabled`), so this expression is duplicated.
-        #
-        # TODO: consolidate the trusted-proxy config readers. `enabled` is
-        # already reimplemented verbatim in THREE places —
-        # Onetime::Application::MiddlewareStack.trusted_proxy_enabled?,
-        # Onetime::Security::ResetRequestRateLimiter, and
-        # Onetime::Security::CreateAccountRateLimiter — and this adds a fourth
-        # site reading `mode`. One accessor pair (enabled + mode) should serve
-        # all of them. Out of scope for #4062; tracked in #4087.
-        #
-        # Note the two `mode` expressions are not identical today, and neither
-        # VALIDATES: MiddlewareStack takes `tp['mode'] || 'filter'` and then
-        # branches on `== 'depth'`, so any unrecognized value (`Depth`, a typo)
-        # silently runs the FILTER branch — while this line echoes the raw
-        # string, reporting `mode=Depth` for a deployment running filter. The
-        # consolidated reader should reject unknown modes, not just share the
-        # default.
-        mode = OT.conf.dig('site', 'network', 'trusted_proxy', 'mode').to_s.strip
-        mode = 'filter' if mode.empty?
-
-        "enabled (mode=#{mode})"
+        "enabled (mode=#{stack.trusted_proxy_mode})"
       rescue StandardError
         'unknown'
       end

--- a/lib/onetime/security/create_account_rate_limiter.rb
+++ b/lib/onetime/security/create_account_rate_limiter.rb
@@ -357,8 +357,14 @@ module Onetime
       # direct-connect deployment and boot has no evidence a proxy exists, so a
       # boot warning would fire on every default install. A lockout is the first
       # moment the condition is actually demonstrated.
+      #
+      # Read through the shared predicate rather than digging the config here:
+      # the hint's whole claim is about how the IP-privacy mount resolved the
+      # address, so it must ask the same question that mount asked (#4087). No
+      # require_relative — this file is reached via `require 'onetime'`, which
+      # loads the middleware stack, and the constant resolves at call time.
       def collapsed_create_account_ip_hint
-        return '' if OT.conf.dig('site', 'network', 'trusted_proxy', 'enabled') == true
+        return '' if Onetime::Application::MiddlewareStack.trusted_proxy_enabled?
 
         '. NOTE: site.network.trusted_proxy is not enabled, so the client IP is ' \
           'REMOTE_ADDR; if this deployment is behind a reverse proxy every visitor ' \

--- a/lib/onetime/security/reset_request_rate_limiter.rb
+++ b/lib/onetime/security/reset_request_rate_limiter.rb
@@ -480,9 +480,15 @@ module Onetime
       # the first moment the condition is actually demonstrated. Returns '' in
       # every other case, so a correctly configured deployment's log line is
       # byte-identical to before. Nothing here varies on account existence.
+      #
+      # Read through the shared predicate rather than digging the config here:
+      # the hint's whole claim is about how the IP-privacy mount resolved the
+      # address, so it must ask the same question that mount asked (#4087). No
+      # require_relative — this file is reached via `require 'onetime'`, which
+      # loads the middleware stack, and the constant resolves at call time.
       def collapsed_ip_tier_hint(tier_label)
         return '' unless tier_label == 'ip'
-        return '' if OT.conf.dig('site', 'network', 'trusted_proxy', 'enabled') == true
+        return '' if Onetime::Application::MiddlewareStack.trusted_proxy_enabled?
 
         '. NOTE: site.network.trusted_proxy is not enabled, so the client IP is ' \
           'REMOTE_ADDR; if this deployment is behind a reverse proxy every visitor ' \

--- a/spec/integration/all/colonel_host_allowlist_spec.rb
+++ b/spec/integration/all/colonel_host_allowlist_spec.rb
@@ -78,11 +78,18 @@ RSpec.describe 'Colonel admin surface host allowlist (#4062)', type: :integratio
     @orig_domains    = OT.conf.dig('features', 'domains')&.dup
     @orig_developmnt = OT.conf['development']&.dup
     @orig_features   = Onetime::Runtime.features
+    # The posture examples write site.network.trusted_proxy. Snapshotting it
+    # here rather than in those examples keeps the restore in ONE place: a
+    # leaked trusted_proxy block changes how every later example in the
+    # process resolves a client IP, which is exactly the cross-file residue
+    # the rest of this hook exists to prevent.
+    @orig_network    = OT.conf.dig('site', 'network')&.dup
   end
 
   after do
     OT.conf['site']['admin']        = @orig_admin if @orig_admin
     OT.conf['site']['host']         = @orig_site_host
+    OT.conf['site']['network']      = @orig_network if @orig_network
     OT.conf['features']['domains']  = @orig_domains if @orig_domains
     OT.conf['development']          = @orig_developmnt if @orig_developmnt
     Onetime::Runtime.features       = @orig_features
@@ -210,6 +217,22 @@ RSpec.describe 'Colonel admin surface host allowlist (#4062)', type: :integratio
       name == 'AdminNetworkIsolation' ? sink : original.call(name)
     end
     warns
+  end
+
+  # Same sink, one level up: the posture line is INFO, which
+  # capture_admin_gate_warns! deliberately swallows. Returns [message, payload]
+  # pairs for the info channel and must likewise be installed BEFORE the
+  # request that constructs the stack, since the middleware resolves its logger
+  # in #initialize and logs the posture there.
+  def capture_admin_gate_infos!
+    infos = []
+    sink  = Object.new
+    sink.define_singleton_method(:info) { |message, payload = {}| infos << [message, payload] }
+    %i[warn error debug].each { |level| sink.define_singleton_method(level) { |*, **| } }
+    allow(Onetime).to receive(:get_logger).and_wrap_original do |original, name|
+      name == 'AdminNetworkIsolation' ? sink : original.call(name)
+    end
+    infos
   end
 
   # A real verified tenant domain owned by `owner`. The host gate does not
@@ -1131,6 +1154,81 @@ RSpec.describe 'Colonel admin surface host allowlist (#4062)', type: :integratio
       get_api('example.com', 'REMOTE_ADDR' => '203.0.113.9')
 
       expect(last_response.status).to eq(404)
+    end
+  end
+
+  # ===========================================================================
+  # 11. The boot posture line reports the trusted-proxy mode ACTUALLY IN FORCE
+  # ===========================================================================
+  #
+  # #4087. `trusted_proxy` rides on the posture line because it qualifies the
+  # two gate states beside it — both gates judge inputs a proxy layer
+  # determines. That makes this field the artifact the #4062 changelog tells
+  # operators to read to confirm their configuration, so it must never report a
+  # posture the stack does not have.
+  #
+  # It used to echo the operator's raw string while
+  # MiddlewareStack.ip_privacy_security_config branched on `== 'depth'`, so
+  # TRUSTED_PROXY_MODE=Depth ran FILTER and announced `mode=Depth`, and a typo
+  # ran filter and announced the typo. Both halves now read
+  # MiddlewareStack.trusted_proxy_mode, which is also what configures otto —
+  # one reader, so the line and the behaviour cannot disagree.
+  #
+  # These assert the line, not the resolution: the resolution itself is pinned
+  # in spec/unit/onetime/application/middleware_stack_spec.rb, against the same
+  # accessor. The value here is that the OPERATOR-FACING string comes from it.
+  describe 'the trusted_proxy field on the boot posture line' do
+    # The posture is logged in AdminNetworkIsolation#initialize, so the first
+    # request after configure_admin! drops the memoized app is what emits it.
+    def posture_after_boot(trusted_proxy)
+      OT.conf['site']['network'] = (OT.conf['site']['network'] || {}).merge(
+        'trusted_proxy' => trusted_proxy,
+      )
+      configure_admin!(default_domain: 'example.com', site_host: 'example.com')
+
+      infos = capture_admin_gate_infos!
+      signed_in_as(colonel)
+      get_api('example.com')
+
+      _, payload = infos.find { |message, _| message.match?(/isolation posture/i) }
+      expect(payload).not_to be_nil, 'no posture line was logged'
+      payload[:trusted_proxy]
+    end
+
+    it 'reports disabled when no trusted proxy is declared (the shipped default)' do
+      # The control the other two are read against: `disabled` is a real
+      # posture, not an absence, and it is what says neither gate's input is
+      # authenticated.
+      expect(posture_after_boot('enabled' => false)).to eq('disabled')
+    end
+
+    it 'reports disabled when the trusted_proxy block is absent entirely' do
+      expect(posture_after_boot({})).to eq('disabled')
+    end
+
+    it 'reports the recognized mode verbatim' do
+      expect(posture_after_boot('enabled' => true, 'mode' => 'filter')).to eq('enabled (mode=filter)')
+    end
+
+    it 'reports mode=depth for a mixed-case Depth, which is what runs' do
+      # Honoured, not rejected — and reported in the canonical spelling the
+      # stack uses, so the line matches the otto configuration beside it.
+      expect(posture_after_boot('enabled' => true, 'mode' => 'Depth', 'depth' => 2))
+        .to eq('enabled (mode=depth)')
+    end
+
+    it 'reports mode=filter for a malformed mode, not the operator string' do
+      # The regression this issue ships. Echoing `dept` would tell the operator
+      # their typo took effect; the deployment is running filter.
+      posture = posture_after_boot('enabled' => true, 'mode' => 'dept')
+      aggregate_failures do
+        expect(posture).to eq('enabled (mode=filter)')
+        expect(posture).not_to include('dept')
+      end
+    end
+
+    it 'reports mode=filter for an enabled-but-modeless block' do
+      expect(posture_after_boot('enabled' => true)).to eq('enabled (mode=filter)')
     end
   end
 end

--- a/spec/unit/onetime/application/middleware_stack_spec.rb
+++ b/spec/unit/onetime/application/middleware_stack_spec.rb
@@ -171,6 +171,42 @@ RSpec.describe Onetime::Application::MiddlewareStack do
       end
     end
 
+    # The mode reaches this method through .trusted_proxy_mode, so the branch
+    # below must follow the CANONICALIZED, VALIDATED value — not the operator's
+    # raw string. Before #4087 `Depth` fell through the `== 'depth'` equality
+    # test into the filter branch while the boot log announced `mode=Depth`.
+    context 'when the mode needs canonicalizing or rejecting (#4087)' do
+      before do
+        allow(OT).to receive(:lw)
+        described_class.reset_warn_once!
+      end
+
+      after { described_class.reset_warn_once! }
+
+      it 'honours a mixed-case Depth as depth mode' do
+        stub_conf('enabled' => true, 'mode' => 'Depth', 'depth' => 3)
+        aggregate_failures do
+          expect(config.trusted_proxy_depth_mode?).to be(true)
+          expect(config.trusted_proxy_depth).to eq(3)
+          # depth and CIDRs are mutually exclusive in otto
+          expect(config.trusted_proxies).to be_empty
+        end
+      end
+
+      it 'runs the filter/CIDR branch for an unrecognized mode' do
+        # The fallback is the SAFER mode: each hop is authenticated against the
+        # trusted-proxy CIDRs rather than counted. Asserting the CIDRs are
+        # actually registered (not just "depth is off") is what distinguishes
+        # the filter branch from a stack that trusts nothing at all.
+        stub_conf('enabled' => true, 'mode' => 'dept', 'depth' => 3)
+        aggregate_failures do
+          expect(config.trusted_proxy_depth_mode?).to be(false)
+          expect(config.trusted_proxy?('10.0.0.1')).to be(true)
+          expect(config.trusted_proxies).not_to be_empty
+        end
+      end
+    end
+
     context 'when geo.header meets depth mode (#4068)' do
       # otto 2.8 raises on trusted_proxy_depth + geo_header, so the translator
       # skips the setting under depth. Skipping silently left the operator with
@@ -290,6 +326,215 @@ RSpec.describe Onetime::Application::MiddlewareStack do
       it 'is true only when explicitly enabled' do
         stub_conf('enabled' => true)
         expect(described_class.trusted_proxy_enabled?).to be(true)
+      end
+    end
+
+    # #4087: the SINGLE Ruby reader for site.network.trusted_proxy.mode. Two
+    # consumers depend on it agreeing with itself — .ip_privacy_security_config
+    # branches on it to configure otto, and
+    # AdminNetworkIsolation#trusted_proxy_posture prints it on the boot line
+    # operators are told to read. They used to dig the config independently
+    # with different expressions, which is how a deployment could run filter
+    # while announcing `mode=Depth`.
+    describe '.trusted_proxy_mode' do
+      subject(:mode) { described_class.trusted_proxy_mode }
+
+      def stub_mode(value)
+        allow(OT).to receive(:conf).and_return(
+          'site' => { 'network' => { 'trusted_proxy' => { 'enabled' => true, 'mode' => value } } },
+        )
+      end
+
+      before do
+        allow(OT).to receive(:lw)
+        # The ledger is process-wide and every example here is about whether a
+        # warning fired; without the reset the first example to warn is the
+        # only one that can observe it and the rest pass or fail by run order.
+        described_class.reset_warn_once!
+      end
+
+      after { described_class.reset_warn_once! }
+
+      it 'never returns a value outside the known set' do
+        # Pins the contract the two consumers rely on, against the constant
+        # rather than restating the set.
+        expect(described_class::TRUSTED_PROXY_MODES).to contain_exactly('filter', 'depth')
+      end
+
+      context 'with nothing configured' do
+        it 'defaults to filter when the trusted_proxy section is absent' do
+          allow(OT).to receive(:conf).and_return({})
+          aggregate_failures do
+            expect(mode).to eq('filter')
+            expect(OT).not_to have_received(:lw)
+          end
+        end
+
+        it 'defaults to filter when the key is absent from an enabled block' do
+          allow(OT).to receive(:conf).and_return(
+            'site' => { 'network' => { 'trusted_proxy' => { 'enabled' => true } } },
+          )
+          aggregate_failures do
+            expect(mode).to eq('filter')
+            expect(OT).not_to have_received(:lw)
+          end
+        end
+
+        it 'defaults to filter for an explicit nil' do
+          stub_mode(nil)
+          aggregate_failures do
+            expect(mode).to eq('filter')
+            expect(OT).not_to have_received(:lw)
+          end
+        end
+
+        it 'defaults to filter for an empty string, silently' do
+          # Unset and blank are the same operator statement — "I did not
+          # choose" — and must not produce a boot warning on a stock install.
+          stub_mode('')
+          aggregate_failures do
+            expect(mode).to eq('filter')
+            expect(OT).not_to have_received(:lw)
+          end
+        end
+
+        it 'defaults to filter for a whitespace-only value' do
+          stub_mode("  \t ")
+          aggregate_failures do
+            expect(mode).to eq('filter')
+            expect(OT).not_to have_received(:lw)
+          end
+        end
+      end
+
+      context 'with a recognized value' do
+        it 'returns filter' do
+          stub_mode('filter')
+          aggregate_failures do
+            expect(mode).to eq('filter')
+            expect(OT).not_to have_received(:lw)
+          end
+        end
+
+        it 'returns depth' do
+          stub_mode('depth')
+          aggregate_failures do
+            expect(mode).to eq('depth')
+            expect(OT).not_to have_received(:lw)
+          end
+        end
+
+        it 'strips surrounding whitespace' do
+          # OT.conf is also assembled programmatically (specs, embedders), so
+          # the strip is not covered by YAML plain-scalar parsing alone.
+          stub_mode('  depth  ')
+          expect(mode).to eq('depth')
+        end
+      end
+
+      # Downcase FIRST, then validate: `Depth` is the same setting written in a
+      # different case, not a typo, and the sibling trusted_proxy.header value
+      # is already canonicalized case-insensitively. The operator is still told
+      # their value was rewritten, so the boot log and their config file can be
+      # reconciled by eye.
+      context 'with a mixed-case value' do
+        it 'canonicalizes Depth to depth' do
+          stub_mode('Depth')
+          expect(mode).to eq('depth')
+        end
+
+        it 'canonicalizes DEPTH to depth' do
+          stub_mode('DEPTH')
+          expect(mode).to eq('depth')
+        end
+
+        it 'canonicalizes FILTER to filter' do
+          stub_mode('FILTER')
+          expect(mode).to eq('filter')
+        end
+
+        it 'warns that the value was canonicalized, naming both forms' do
+          stub_mode('Depth')
+          mode
+          expect(OT).to have_received(:lw).with(/Depth/)
+        end
+
+        it 'does not call the canonicalized value unrecognized' do
+          # A distinct warning from the unknown-value one: `Depth` IS honoured.
+          # Telling the operator it is "not a recognized mode" while running
+          # depth would be the same class of untrue boot line #4087 fixes.
+          stub_mode('Depth')
+          mode
+          expect(OT).not_to have_received(:lw).with(/not a recognized mode/)
+        end
+
+        it 'warns once across repeated calls' do
+          stub_mode('Depth')
+          3.times { described_class.trusted_proxy_mode }
+          expect(OT).to have_received(:lw).once
+        end
+      end
+
+      # WARN, do not raise: the fallback is the safer mode and a log-adjacent
+      # setting must never be the thing that fails a boot. Silence is the only
+      # unacceptable option, since the operator asked for something the app is
+      # not doing.
+      context 'with an unrecognized value' do
+        it 'falls back to filter for a near-miss typo' do
+          stub_mode('dept')
+          expect(mode).to eq('filter')
+        end
+
+        it 'falls back to filter for an unrelated word' do
+          stub_mode('cidr')
+          expect(mode).to eq('filter')
+        end
+
+        it 'falls back to filter for garbage' do
+          stub_mode('!!!')
+          expect(mode).to eq('filter')
+        end
+
+        it 'falls back to filter for a non-string value' do
+          stub_mode(2)
+          expect(mode).to eq('filter')
+        end
+
+        it 'does not raise' do
+          stub_mode('dept')
+          expect { mode }.not_to raise_error
+        end
+
+        it 'warns naming the rejected value and the mode actually in force' do
+          stub_mode('dept')
+          mode
+          aggregate_failures do
+            expect(OT).to have_received(:lw).with(/dept/)
+            expect(OT).to have_received(:lw).with(/filter/)
+          end
+        end
+
+        it 'names the valid values so the operator can fix it without the source' do
+          stub_mode('dept')
+          mode
+          expect(OT).to have_received(:lw).with(/depth/)
+        end
+
+        it 'warns once across repeated calls' do
+          # Seven Application subclasses each build a stack and reach this
+          # reader; the operator should read one finding, not seven.
+          stub_mode('dept')
+          3.times { described_class.trusted_proxy_mode }
+          expect(OT).to have_received(:lw).once
+        end
+
+        it 'still warns when the value is only unrecognized after downcasing' do
+          stub_mode('Dept')
+          aggregate_failures do
+            expect(mode).to eq('filter')
+            expect(OT).to have_received(:lw).with(/not a recognized mode/)
+          end
+        end
       end
     end
   end

--- a/spec/unit/onetime/application/middleware_stack_spec.rb
+++ b/spec/unit/onetime/application/middleware_stack_spec.rb
@@ -475,6 +475,62 @@ RSpec.describe Onetime::Application::MiddlewareStack do
         end
       end
 
+      # The behaviour-change claim is only true for values that canonicalize TO
+      # depth: the old branch was an exact `== 'depth'` test, so every other
+      # rewritten spelling ran filter before and runs filter now. Saying their
+      # client IP resolution CHANGED is the same class of untrue boot line #4087
+      # exists to fix, and sharing a warn_once tag with the real case would let a
+      # cosmetic rewrite swallow the warning that matters.
+      context 'when canonicalization does not change the effective mode' do
+        it 'does not claim a behaviour change for FILTER' do
+          stub_mode('FILTER')
+          mode
+          expect(OT).not_to have_received(:lw).with(/CHANGES how the client IP is resolved/)
+        end
+
+        it 'does not claim a behaviour change for padded filter' do
+          stub_mode('  filter  ')
+          mode
+          expect(OT).not_to have_received(:lw).with(/CHANGES how the client IP is resolved/)
+        end
+
+        it 'still tells the operator the value was rewritten, naming both forms' do
+          # Silence would leave the boot log and the config file irreconcilable
+          # by eye — the point of warning at all.
+          stub_mode('FILTER')
+          mode
+          expect(OT).to have_received(:lw).with(/FILTER.*"filter"/m)
+        end
+
+        it 'says client IP resolution is unchanged' do
+          stub_mode('FILTER')
+          mode
+          expect(OT).to have_received(:lw).with(/client IP resolution is unchanged/)
+        end
+
+        it 'does not consume the behaviour-change warning for a later value' do
+          # Each Application subclass builds its own stack and re-reads this;
+          # one tag for both cases means a cosmetic FILTER rewrite in the first
+          # stack silences the real Depth warning in the second.
+          stub_mode('FILTER')
+          mode
+          stub_mode('Depth')
+          described_class.trusted_proxy_mode
+          expect(OT).to have_received(:lw).with(/CHANGES how the client IP is resolved/)
+        end
+      end
+
+      # Whitespace was significant to the old exact `== 'depth'` match, so a
+      # padded depth ran filter then and runs depth now — a behaviour change like
+      # any other misspelling, not a cosmetic rewrite.
+      context 'with a padded depth value' do
+        it 'warns that the behaviour changed on upgrade' do
+          stub_mode('  depth  ')
+          mode
+          expect(OT).to have_received(:lw).with(/CHANGES how the client IP is resolved/)
+        end
+      end
+
       # WARN, do not raise: the fallback is the safer mode and a log-adjacent
       # setting must never be the thing that fails a boot. Silence is the only
       # unacceptable option, since the operator asked for something the app is

--- a/try/unit/security/create_account_rate_limiter_try.rb
+++ b/try/unit/security/create_account_rate_limiter_try.rb
@@ -274,6 +274,21 @@ set_trusted_proxy_enabled(true)
 @tester.send(:collapsed_create_account_ip_hint)
 #=> ""
 
+## #4087: the hint no longer digs the config itself - it asks
+## MiddlewareStack.trusted_proxy_enabled?, the SAME predicate that decides how
+## the IP-privacy mount resolves the address the hint is talking about. Two
+## things are pinned here. (1) The constant resolves at CALL TIME under a bare
+## tryout boot, with no require_relative in the limiter. (2) The predicate is
+## strict about `== true`, so a hand-edited string 'true' is NOT a declared
+## proxy and the hint still fires - the hint and the mount agree on the same
+## wrong-looking config rather than one of them guessing.
+set_trusted_proxy_enabled('true')
+[
+  Onetime::Application::MiddlewareStack.trusted_proxy_enabled?,
+  @tester.send(:collapsed_create_account_ip_hint).empty?,
+]
+#=> [false, false]
+
 ## The hint is WIRED IN: a REAL cap hit (trusted proxy not declared) emits
 ## exactly one OT.le line carrying both the cap text and the hint. The three
 ## cases above call the private helper directly, so they stay green even if the

--- a/try/unit/security/reset_request_rate_limiter_try.rb
+++ b/try/unit/security/reset_request_rate_limiter_try.rb
@@ -290,6 +290,21 @@ set_trusted_proxy_enabled(true)
 @tester.send(:collapsed_ip_tier_hint, 'ip')
 #=> ""
 
+## #4087: the hint no longer digs the config itself - it asks
+## MiddlewareStack.trusted_proxy_enabled?, the SAME predicate that decides how
+## the IP-privacy mount resolves the address the hint is talking about. Two
+## things are pinned here. (1) The constant resolves at CALL TIME under a bare
+## tryout boot, with no require_relative in the limiter. (2) The predicate is
+## strict about `== true`, so a hand-edited string 'true' is NOT a declared
+## proxy and the hint still fires - the hint and the mount agree on the same
+## wrong-looking config rather than one of them guessing.
+set_trusted_proxy_enabled('true')
+[
+  Onetime::Application::MiddlewareStack.trusted_proxy_enabled?,
+  @tester.send(:collapsed_ip_tier_hint, 'ip').empty?,
+]
+#=> [false, false]
+
 ## The email backstop never carries the hint - it does not key on IP, in either
 ## trusted-proxy state
 [false, true].map do |enabled|


### PR DESCRIPTION
Four call sites read `site.network.trusted_proxy` independently with different
expressions, so `TRUSTED_PROXY_MODE=Depth` failed the exact-string `depth` test
in the resolution branch and ran filter — while the boot posture line echoed the
configured string back and announced `mode=Depth`. Both now read
`MiddlewareStack.trusted_proxy_enabled?` / `.trusted_proxy_mode`, which
case-insensitively canonicalizes the value, closes the accepted set to
`filter`/`depth`, and moves the filter default out of its three homes.

Boot WARNs once per process on an unrecognized value (still runs filter, still
boots) and separately when canonicalization changes which mode is in force —
that second case is an upgrade behaviour change, documented in the changelog
fragment with the `TRUSTED_PROXY_DEPTH` check operators should make first.

Also drops a stale doc claim about depth mode and forwarded hosts, and pins the
new behaviour with specs for the accessor, the posture line, and the rate-limit
hint readers.

Stacked on #4142 (`fix/update-domain-config`) — merge that first.

Closes #4087