### PR TITLE
Make the social card opt-in and suppress it on custom domains

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -1591,9 +1591,26 @@ HELP_ENABLED=true
 # Overrides the neutral /apple-touch-icon.png default. Full https:// URL.
 #BRAND_APPLE_TOUCH_ICON_URL=
 
-# Open Graph / Twitter social-card image URL (recommended 1200x630). Overrides
-# the neutral /social-preview.png default used for og:image and twitter:image.
-# Must be an absolute URL so social scrapers can fetch it.
+# Open Graph / Twitter social-card image URL (recommended 1200x630). Must be an
+# absolute URL so social scrapers can fetch it.
+#
+# Resolution:
+#   1. this variable, if set to a URL;
+#   2. else /social-preview.png, but ONLY if the resolved brand pack carries the
+#      file — the tracked `default` and example packs do, and a partial pack
+#      falls through to `default` for files it omits;
+#   3. else nothing — no og:image/twitter:image tags are emitted at all (never an
+#      empty tag, never one pointing at a 404), and twitter:card degrades from
+#      `summary_large_image` to `summary`, which renders correctly imageless.
+#
+# Set to `none` (or `off` / `false`) to suppress the card entirely. That is the
+# opt-out to use when you want NO social preview: deleting social-preview.png
+# from your own pack is not sufficient on its own, because a partial pack falls
+# through to the default pack's card. Blank means "unset", not "none".
+#
+# Custom domains NEVER inherit the install's card, regardless of this setting —
+# there is no per-domain social image, so emitting one would put your brand on a
+# customer's shared link.
 #BRAND_OG_IMAGE_URL=
 
 # Note: the remaining variety-pack assets (favicon.svg, safari-pinned-tab.svg,
@@ -1604,8 +1621,8 @@ HELP_ENABLED=true
 
 # Brand pack selection (#3739, v2 #3774). A brand pack is the single unit of
 # branding: a directory of root-served assets (favicon.ico, icon-192.png,
-# icon-512.png, favicon.svg, safari-pinned-tab.svg, site.webmanifest,
-# social-preview.png) PLUS an optional brand.yaml identity manifest (colours,
+# icon-512.png, favicon.svg, safari-pinned-tab.svg, site.webmanifest, plus the
+# OPTIONAL social-preview.png card) PLUS an optional brand.yaml identity manifest (colours,
 # product name — absorbed into OT.conf['brand'] at boot, below your BRAND_*
 # vars). Resolution always lands on a pack; unset = the tracked neutral `default`
 # pack. A partial selected pack falls through to `default` for files it omits.

--- a/apps/web/core/templates/partials/head.rue
+++ b/apps/web/core/templates/partials/head.rue
@@ -7,13 +7,21 @@
   <meta property="og:url" content="{{baseuri}}">
   <meta property="og:title" content="{{page_title}}">
   <meta property="og:description" content="{{description}}">
+  <!-- Social card is OPT-IN (#4150): emitted only when a brand pack carries
+       social-preview.png (or BRAND_OG_IMAGE_URL is set), and never on a custom
+       domain — the install's card is not the domain owner's brand. When absent,
+       twitter:card drops to `summary`, which renders correctly imageless. -->
+  {{#if brand_og_image_url}}
   <meta property="og:image" content="{{brand_og_image_url}}">
+  {{/if}}
 
   <!-- Twitter Card meta tags -->
-  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:card" content="{{twitter_card_type}}">
   <meta property="twitter:domain" content="{{site_host}}">
   <meta property="twitter:url" content="{{baseuri}}">
   <meta name="twitter:title" content="{{page_title}}">
   <meta name="twitter:description" content="{{description}}">
+  {{#if brand_og_image_url}}
   <meta name="twitter:image" content="{{brand_og_image_url}}">
+  {{/if}}
 </template>

--- a/apps/web/core/views/base.rb
+++ b/apps/web/core/views/base.rb
@@ -124,6 +124,7 @@ module Core
           'has_brand_color' => view_vars['has_brand_color'],
           'brand_apple_touch_icon_url' => view_vars['brand_apple_touch_icon_url'],
           'brand_og_image_url' => view_vars['brand_og_image_url'],
+          'twitter_card_type' => view_vars['twitter_card_type'],
           'show_default_svg_favicon' => view_vars['show_default_svg_favicon'],
           'vite_assets_html' => vite_assets(
             nonce: view_vars['nonce'],

--- a/apps/web/core/views/helpers/initialize_view_vars.rb
+++ b/apps/web/core/views/helpers/initialize_view_vars.rb
@@ -216,15 +216,35 @@ module Core
         brand_logo_dark_url         = brand_config['logo_dark_url']
         brand_logo_alt              = brand_config['logo_alt'] || brand_global_defaults[:logo_alt]
         brand_favicon_url           = brand_config['favicon_url'] || brand_global_defaults[:favicon_url]
-        # Mobile/social variety-pack URLs used by the HTML head. Unlike the
-        # fields above (which default to nil and fall through to the frontend
-        # neutral theme), these resolve to the bundled NEUTRAL asset files so
-        # the head always emits a valid, brand-agnostic pack. Operators set
-        # BRAND_APPLE_TOUCH_ICON_URL / BRAND_OG_IMAGE_URL (or drop replacement
-        # files into the brand directory) to override. og:image must be
-        # absolute for social scrapers, so the default is anchored to baseuri.
+        # Mobile/social variety-pack URLs used by the HTML head. apple-touch-icon
+        # resolves to the bundled NEUTRAL asset so the head always emits a valid,
+        # brand-agnostic pack; operators set BRAND_APPLE_TOUCH_ICON_URL (or drop a
+        # replacement file into the brand directory) to override.
         brand_apple_touch_icon_url  = brand_config['apple_touch_icon_url'] || '/apple-touch-icon.png'
-        brand_og_image_url          = brand_config['og_image_url'] || "#{baseuri}/social-preview.png"
+
+        # og:image / twitter:image are OPT-IN and may legitimately be absent
+        # (#4150) — see normalize_brand, which resolves brand.og_image_url from
+        # the pack asset and leaves it nil when no pack carries a social card.
+        # Two further gates apply here, both about the card travelling off-site:
+        #
+        #   - custom domains get NO card. brand_config is the INSTALL's brand
+        #     (OT.conf), not the domain's, and there is no per-domain social
+        #     image field, so anything we emitted here would put the install
+        #     operator's card on a customer's shared link. Same reasoning as
+        #     show_default_svg_favicon below, which suppresses the canonical SVG
+        #     for exactly this class of shadowing.
+        #   - a root-relative value is absolutized against baseuri, since social
+        #     scrapers require an absolute og:image.
+        #
+        # nil means "emit no image tags"; the head partial branches on it, and
+        # twitter:card degrades from summary_large_image to summary so the card
+        # still renders correctly without an image.
+        brand_og_image_url          = brand_config['og_image_url'].to_s.strip
+        brand_og_image_url          = nil if brand_og_image_url.empty? || domain_strategy == :custom
+        if brand_og_image_url&.start_with?('/') && !brand_og_image_url.start_with?('//')
+          brand_og_image_url = "#{baseuri}#{brand_og_image_url}"
+        end
+        twitter_card_type           = brand_og_image_url ? 'summary_large_image' : 'summary'
 
         # Whether to emit the static neutral SVG favicon link. Modern browsers
         # prefer an SVG <link rel="icon"> over the .ico, so we must NOT emit it
@@ -282,6 +302,7 @@ module Core
           'brand_favicon_url' => brand_favicon_url,
           'brand_apple_touch_icon_url' => brand_apple_touch_icon_url,
           'brand_og_image_url' => brand_og_image_url,
+          'twitter_card_type' => twitter_card_type,
           'show_default_svg_favicon' => show_default_svg_favicon,
           'support_email' => support_email,
           'docs_host' => docs_host,

--- a/apps/web/core/views/helpers/initialize_view_vars.rb
+++ b/apps/web/core/views/helpers/initialize_view_vars.rb
@@ -233,16 +233,20 @@ module Core
         #     operator's card on a customer's shared link. Same reasoning as
         #     show_default_svg_favicon below, which suppresses the canonical SVG
         #     for exactly this class of shadowing.
-        #   - a root-relative value is absolutized against baseuri, since social
-        #     scrapers require an absolute og:image.
+        #   - any value that is not already scheme-resolvable (no `scheme:`, no
+        #     protocol-relative `//`) is treated as a path and absolutized
+        #     against baseuri, since social scrapers require an absolute
+        #     og:image. That covers the pack-resolved `/social-preview.png` and
+        #     also an operator's bare `social-preview.png`, which serves from
+        #     the root like every other pack asset.
         #
         # nil means "emit no image tags"; the head partial branches on it, and
         # twitter:card degrades from summary_large_image to summary so the card
         # still renders correctly without an image.
         brand_og_image_url          = brand_config['og_image_url'].to_s.strip
         brand_og_image_url          = nil if brand_og_image_url.empty? || domain_strategy == :custom
-        if brand_og_image_url&.start_with?('/') && !brand_og_image_url.start_with?('//')
-          brand_og_image_url = "#{baseuri}#{brand_og_image_url}"
+        if brand_og_image_url && !brand_og_image_url.match?(%r{\A(?:[a-z][a-z0-9+.-]*:|//)}i)
+          brand_og_image_url = "#{baseuri}/#{brand_og_image_url.delete_prefix('/')}"
         end
         twitter_card_type           = brand_og_image_url ? 'summary_large_image' : 'summary'
 

--- a/bin/setup
+++ b/bin/setup
@@ -1119,7 +1119,11 @@ doctor_operator_assets() {
 # existing wins), else the tracked `default` pack. Then it lists the canonical
 # file set present in the winner and any uncommented brand.yaml keys.
 doctor_brand_pack() {
-  local canonical="favicon.ico favicon.svg apple-touch-icon.png icon-192.png icon-512.png safari-pinned-tab.svg social-preview.png site.webmanifest"
+  local canonical="favicon.ico favicon.svg apple-touch-icon.png icon-192.png icon-512.png safari-pinned-tab.svg site.webmanifest"
+  # Optional: a pack that omits social-preview.png emits no og:image/twitter:image
+  # at all (#4150) — that is a supported posture, not a partial pack, so it is
+  # reported separately rather than warned about.
+  local optional_social="social-preview.png"
   local roots="etc/branding public/branding"
   local resolved="" source=""
 
@@ -1164,7 +1168,13 @@ doctor_brand_pack() {
     doc_warn "Resolved pack missing canonical file(s):$missing" \
       "partial packs fall through to the default pack for these"
   else
-    doc_ok "Resolved pack carries the full canonical asset set (8 files)"
+    doc_ok "Resolved pack carries the full canonical asset set (7 files)"
+  fi
+
+  if [[ -f "$resolved/$optional_social" ]]; then
+    doc_ok "Social card present ($optional_social) — og:image/twitter:image emitted"
+  else
+    doc_info "No social card ($optional_social) — og:image/twitter:image omitted, twitter:card=summary"
   fi
 
   if [[ -f "$resolved/brand.yaml" ]]; then

--- a/changelog.d/20260812_233500_claude_4150_social_card_opt_in.rst
+++ b/changelog.d/20260812_233500_claude_4150_social_card_opt_in.rst
@@ -1,0 +1,37 @@
+.. A new scriv changelog fragment.
+
+Added
+-----
+
+- (`#4150 <https://github.com/onetimesecret/onetimesecret/issues/4150>`_) The
+  social card (``og:image`` / ``twitter:image``) can now be turned off entirely
+  with ``BRAND_OG_IMAGE_URL=none`` (``off`` / ``false`` also work). The head then
+  emits **no** image meta tags at all — never an empty tag, never one pointing at
+  a 404 — and ``twitter:card`` degrades from ``summary_large_image`` to
+  ``summary``, which renders correctly without an image. Previously there was no
+  way to suppress the card: the tag was emitted unconditionally, and a blank
+  ``BRAND_OG_IMAGE_URL`` was indistinguishable from an unset one.
+
+Changed
+-------
+
+- (`#4150 <https://github.com/onetimesecret/onetimesecret/issues/4150>`_) The
+  social card is now resolved from the brand-pack **asset** rather than a
+  hardcoded path, so serving and linking can no longer disagree: a pack that
+  carries ``social-preview.png`` has it served and linked, and one that carries
+  none (with nothing to fall through to) emits no tags instead of pointing at a
+  URL that 404s. ``social-preview.png`` moves from the mandatory pack asset set
+  to the existence-filtered optional set, alongside the pack-carried masthead
+  logo. The tracked ``default`` and example packs still ship a neutral card, so
+  a stock install is unchanged.
+
+Fixed
+-----
+
+- (`#4150 <https://github.com/onetimesecret/onetimesecret/issues/4150>`_) Custom
+  domains no longer inherit the install's social card. ``og:image`` resolves from
+  the install's brand config and there is no per-domain social image, so a secret
+  link shared from a customer's custom domain previewed with the install
+  operator's card. The card is now suppressed unconditionally on custom domains,
+  mirroring the existing suppression that keeps the canonical SVG favicon from
+  shadowing a domain's own icon.

--- a/docs/architecture/branding.md
+++ b/docs/architecture/branding.md
@@ -81,7 +81,7 @@ field. No defaults shipped.
 | `BRAND_LOGO_ALT`             | logo alt text (falls back to product-name i18n)    |
 | `BRAND_FAVICON_URL`          | `/favicon.ico` 302 redirect                        |
 | `BRAND_APPLE_TOUCH_ICON_URL` | head `apple-touch-icon`                            |
-| `BRAND_OG_IMAGE_URL`         | head `og:image` / `twitter:image` (absolute)       |
+| `BRAND_OG_IMAGE_URL`         | head `og:image` / `twitter:image` (absolute; `none` disables; never emitted on custom domains) |
 | `BRAND_TOTP_ISSUER`          | MFA issuer label (falls back to product name)      |
 | `BRAND_SIGNATURE_NAME`       | email sign-off (see Special cases)                 |
 | `BRAND_PACK`                 | pack NAME → `etc/branding/` then `public/branding/` (unset ⇒ `default`) |

--- a/docs/product/branding-favicon.md
+++ b/docs/product/branding-favicon.md
@@ -25,7 +25,36 @@ selects another. The neutral set:
 | PWA icons         | `icon-192.png`, `icon-512.png`  | `site.webmanifest`                       |
 | PWA manifest      | `site.webmanifest`              | `<link rel="manifest">`                  |
 | Safari pinned tab | `safari-pinned-tab.svg`         | `<link rel="mask-icon">`                 |
-| Social card       | `social-preview.png` (1200×630) | `og:image` / `twitter:image`             |
+| Social card       | `social-preview.png` (1200×630) — optional | `og:image` / `twitter:image` |
+
+### The social card can be turned off entirely
+
+Unlike the other assets, the card travels **off** the install — into someone
+else's chat window or timeline — so it needs both a real fall-back and a real
+off switch (#4150).
+
+It resolves in this order:
+
+1. `BRAND_OG_IMAGE_URL` (or `brand.og_image_url`), if set to a URL.
+2. `/social-preview.png`, if the resolved pack carries it. The `default` and
+   example packs do, and a partial pack falls through to `default`.
+3. Nothing — the head emits **no** `og:image` / `twitter:image` tags at all (not
+   an empty tag, not one pointing at a 404) and `twitter:card` drops from
+   `summary_large_image` to `summary`, which renders correctly without an image.
+
+Two things worth knowing:
+
+- **To ship no card, set `BRAND_OG_IMAGE_URL=none`** (`off` and `false` also
+  work). Deleting `social-preview.png` from your own pack is *not* sufficient by
+  itself: a partial pack falls through to the default pack's card, which is the
+  same fall-through every other asset relies on. Blank means "unset", not "none".
+  Serving and linking always agree — both key off the same file's existence,
+  resolved at boot, so adding or removing it needs a restart.
+- **Custom domains never get a card.** `og:image` resolves from the *install's*
+  brand config, and there is no per-domain social image, so emitting one would
+  put the operator's card on a customer's shared link. Suppression there is
+  unconditional, the same way the canonical SVG favicon is suppressed so it
+  cannot shadow a domain's own icon.
 
 ## Precedence
 
@@ -53,7 +82,7 @@ Replacing a **file** works for every asset and is the uniform override path. The
 | ---------------------------------------------------------- | -------------------------------------------- | ---- |
 | `favicon.ico`                                              | `BRAND_FAVICON_URL` (per-domain wins)        | ✅   |
 | `apple-touch-icon.png`                                     | `BRAND_APPLE_TOUCH_ICON_URL`                 | ✅   |
-| `social-preview.png`                                       | `BRAND_OG_IMAGE_URL` (absolute URL)          | ✅   |
+| `social-preview.png` (optional; `BRAND_OG_IMAGE_URL=none` for no card) | `BRAND_OG_IMAGE_URL` (absolute URL)  | ✅   |
 | `site.webmanifest` name/theme                              | `BRAND_PRODUCT_NAME` / `BRAND_PRIMARY_COLOR` | ✅   |
 | `favicon.svg`, `safari-pinned-tab.svg`, `icon-192/512.png` | —                                            | ✅   |
 | `brand-logo.svg` / `brand-logo.png` (masthead logo, optional) | `BRAND_LOGO_URL` (absolute CDN, or `/brand-logo.svg` for the pack file) | ✅   |

--- a/lib/onetime.rb
+++ b/lib/onetime.rb
@@ -297,7 +297,7 @@ module Onetime
     # from what StaticFiles actually serves — that overlay set is frozen at boot
     # — so a divergence here is itself a mount-race signal.
     overlay_urls   = Onetime::Middleware::StaticFiles::BRAND_PACK_URLS +
-                     Onetime::Middleware::StaticFiles::BRAND_PACK_LOGO_URLS
+                     Onetime::Middleware::StaticFiles::BRAND_PACK_OPTIONAL_URLS
     overlay_assets = overlay_urls.select { |u| resolved_dir && File.exist?(File.join(resolved_dir, u)) }
 
     {

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -669,6 +669,12 @@ module Onetime
       conf
     end
 
+    # Sentinel values for brand.og_image_url meaning "emit no social card at
+    # all" (#4150). A dedicated sentinel is needed because blank already means
+    # "unset" — see normalize_brand for why deleting the pack file is not on its
+    # own a sufficient opt-out. Compared case-insensitively after stripping.
+    OG_IMAGE_NONE = %w[none off false].freeze
+
     # Maps each brand config key to its backing env var. String fields are
     # trimmed (empty -> nil); button_text_light is coerced to a real boolean.
     BRAND_ENV = {
@@ -895,6 +901,34 @@ module Onetime
       end
       # rubocop:enable Style/CombinableLoops
 
+      # og:image resolves from the ASSET, not a hardcoded path (#4150). When the
+      # resolved pack (or the default pack it falls through to) carries
+      # social-preview.png, that file is the card; when nothing carries it, the
+      # key stays nil and the head emits no image meta tags AT ALL — never an
+      # empty tag, never one pointing at a 404. Serving and linking therefore key
+      # off the same file: StaticFiles existence-filters the URL and this resolves
+      # the tag, so a pack cannot advertise a card at a URL that serves nothing.
+      #
+      # Root-relative on purpose — the view absolutizes it against baseuri, since
+      # og:image must be absolute for social scrapers.
+      #
+      # OG_IMAGE_NONE is the explicit "no card at all" opt-out, and it is the one
+      # an install like onetimesecret.com needs. Deleting social-preview.png from
+      # your own pack is NOT sufficient by itself: a partial pack falls through to
+      # the default pack for the files it omits (that fall-through is the whole
+      # contract for every other asset), and the tracked default pack carries a
+      # card. Blank cannot serve as the opt-out either — the loop above collapses
+      # blanks to nil, which is indistinguishable from unset. So: set
+      # BRAND_OG_IMAGE_URL=none (or og_image_url: "none").
+      #
+      # Custom domains never inherit the install's card regardless of any of this
+      # — see initialize_view_vars. This switch is only the install-wide posture.
+      if OG_IMAGE_NONE.include?(brand['og_image_url'].to_s.strip.downcase)
+        brand['og_image_url'] = nil
+      elsif brand['og_image_url'].nil? && brand_pack_carries?(conf, 'social-preview.png')
+        brand['og_image_url'] = '/social-preview.png'
+      end
+
       # button_text_light: light text on brand-colored buttons. Default-on;
       # only an explicit 'false' (env or YAML) disables it. nil when unset.
       raw                        = ENV.fetch('BRAND_BUTTON_TEXT_LIGHT', nil)
@@ -909,6 +943,34 @@ module Onetime
       else
         raw.strip != 'false'
       end
+    end
+
+    # Whether a brand-pack asset file is actually on disk, resolved the SAME way
+    # StaticFiles serves it (#4150): the selected pack first, then the default
+    # pack it falls through to. Pure with respect to OT.conf — it reads the pack
+    # selection out of the conf hash being normalized, so it works at boot before
+    # OT.conf is installed (Onetime.brand_overlay_dir would not).
+    #
+    # Resolution happens ONCE at boot, matching the middleware, which also
+    # resolves overlay existence at boot: adding or removing a pack asset needs a
+    # restart either way, and the two must not disagree about which URLs serve.
+    #
+    # @param conf [Hash] the merged configuration
+    # @param name [String] pack-relative file name, e.g. 'social-preview.png'
+    # @return [Boolean]
+    def brand_pack_carries?(conf, name)
+      selected = Onetime.resolve_brand_pack_dir(
+        brand_assets_dir: conf.dig('site', 'brand_assets_dir'),
+        brand_pack: conf.dig('site', 'brand_pack'),
+      )
+      default  = Onetime.brand_pack_dir(Onetime::DEFAULT_BRAND_PACK)
+
+      [selected, default].compact.uniq.any? { |dir| File.exist?(File.join(dir, name)) }
+    rescue StandardError => ex
+      # Same posture as apply_brand_manifest: an unreadable pack must never abort
+      # boot. Absent means the tag is simply not emitted.
+      OT.le "[brand_pack_carries?] #{name}: #{ex.class}: #{ex.message}" if defined?(OT)
+      false
     end
 
     # Digs a key path out of a config hash, tolerating malformed intermediate

--- a/lib/onetime/middleware/static_files.rb
+++ b/lib/onetime/middleware/static_files.rb
@@ -29,8 +29,19 @@ module Onetime
       # serves them unconditionally.
       BRAND_PACK_URLS = %w[
         /favicon.svg /safari-pinned-tab.svg /apple-touch-icon.png
-        /icon-192.png /icon-512.png /social-preview.png
+        /icon-192.png /icon-512.png
       ].freeze
+
+      # Optional pack-carried social card (og:image / twitter:image). OPTIONAL —
+      # and deliberately so (#4150): a single canonical card is worse than no
+      # card on a custom domain, since the share preview would advertise someone
+      # else's brand. A pack opts IN by carrying social-preview.png; omitting the
+      # file means the head emits no image meta tags at all rather than pointing
+      # at a 404 or at the canonical card. Existence-filtered on BOTH layers for
+      # the same reason as BRAND_PACK_LOGO_URLS below: Rack::Static matches by
+      # URL prefix, not file existence, so listing a missing file would 404 the
+      # URL instead of letting it fall through.
+      BRAND_PACK_SOCIAL_URLS = %w[/social-preview.png].freeze
 
       # Optional pack-carried masthead/header logo, served overlay-first at a
       # stable URL so a pack can ship its OWN logo image instead of hosting it
@@ -47,6 +58,10 @@ module Onetime
       # web UI but is omitted from emails (which need an absolute URL) — the
       # same pre-existing caveat normalize_brand already warns about at boot.
       BRAND_PACK_LOGO_URLS = %w[/brand-logo.svg /brand-logo.png /brand-logo-dark.svg /brand-logo-dark.png].freeze
+
+      # Every existence-filtered (optional) brand-pack URL, in one list so both
+      # layers apply the same filter to the same set.
+      BRAND_PACK_OPTIONAL_URLS = (BRAND_PACK_LOGO_URLS + BRAND_PACK_SOCIAL_URLS).freeze
 
       # The wrapped Rack application
       # @return [#call] The Rack application instance passed to this middleware
@@ -112,7 +127,7 @@ module Onetime
             # omits a mandatory file simply isn't listed in this overlay layer, so it
             # falls through to the default base for that file.
             if overlay_dir && base_dir && overlay_dir != base_dir
-              overlay_urls = (BRAND_PACK_URLS + BRAND_PACK_LOGO_URLS).select { |u| File.exist?(File.join(overlay_dir, u)) }
+              overlay_urls = (BRAND_PACK_URLS + BRAND_PACK_OPTIONAL_URLS).select { |u| File.exist?(File.join(overlay_dir, u)) }
               unless overlay_urls.empty?
                 Onetime.ld "[StaticFiles] Brand overlay active: #{overlay_dir} (#{overlay_urls.size} file(s))"
                 use Rack::Static, urls: overlay_urls, root: overlay_dir
@@ -129,11 +144,11 @@ module Onetime
             # brand-aware manifest fields keep working.
             if base_dir
               # Mandatory assets serve unconditionally (drift-guarded present);
-              # the optional logo URLs are existence-filtered so an absent logo
-              # (the neutral default pack) falls through instead of 404-shadowing.
-              base_logo_urls = BRAND_PACK_LOGO_URLS.select { |u| File.exist?(File.join(base_dir, u)) }
+              # the optional URLs (logo, social card) are existence-filtered so an
+              # absent file falls through instead of 404-shadowing.
+              base_optional_urls = BRAND_PACK_OPTIONAL_URLS.select { |u| File.exist?(File.join(base_dir, u)) }
               Onetime.ld "[StaticFiles] Base brand layer: #{base_dir}"
-              use Rack::Static, urls: BRAND_PACK_URLS + base_logo_urls, root: base_dir
+              use Rack::Static, urls: BRAND_PACK_URLS + base_optional_urls, root: base_dir
             else
               Onetime.le '[StaticFiles] default brand pack not found; brand assets will 404'
             end

--- a/public/branding/README.md
+++ b/public/branding/README.md
@@ -2,7 +2,8 @@
 
 This directory holds **brand packs**: complete sets of root-served brand assets
 (`favicon.ico`, `favicon.svg`, `apple-touch-icon.png`, `icon-192/512.png`,
-`safari-pinned-tab.svg`, `social-preview.png`, `site.webmanifest`) plus an
+`safari-pinned-tab.svg`, `site.webmanifest`, plus the optional
+`social-preview.png` social card) plus an
 optional `brand.yaml` identity manifest. A pack is the single unit of branding:
 assets and the identity values that go with them, together. Introduced by the
 runtime brand-asset overlay ([#3739](https://github.com/onetimesecret/onetimesecret/issues/3739))

--- a/public/branding/default/brand.yaml
+++ b/public/branding/default/brand.yaml
@@ -48,8 +48,17 @@
 # logo_alt: "Example logo"                     # logo alt text
 # favicon_url: "https://cdn.example.com/favicon.ico" # /favicon.ico 302 redirect
 # apple_touch_icon_url: "https://cdn.example.com/touch.png" # head apple-touch-icon
-# og_image_url: "https://cdn.example.com/card.png"          # og:image / twitter:image (absolute)
+# og_image_url: "https://cdn.example.com/card.png"          # og:image / twitter:image (absolute; opt-in — see below)
 # totp_issuer: "Secure Links"                  # MFA issuer label (falls back to product_name)
+#
+# The social card (og:image / twitter:image) is resolved from the pack ASSET:
+# this pack ships a neutral social-preview.png, so it is served and linked by
+# default. To use your own, drop a social-preview.png into your pack or point
+# og_image_url / BRAND_OG_IMAGE_URL at an absolute CDN URL. To have NO card,
+# set og_image_url: "none" — deleting the file from your own pack is not enough
+# on its own, since a partial pack falls through to this one. With no card the
+# head emits no og:image/twitter:image at all (twitter:card degrades to
+# `summary`). Custom domains never inherit the install's card.
 #
 # Not a manifest key: button_text_light (light text on brand-colored CTA
 # buttons) is auto-derived from the primary_color luminance. A pack cannot set

--- a/public/branding/linkdepot/brand.yaml
+++ b/public/branding/linkdepot/brand.yaml
@@ -46,7 +46,8 @@ logo_url: "/favicon.svg"
 logo_alt: "LinkDepot logo"
 
 # Other asset URLs (optional) -------------------------------------------------
-# favicon.ico, apple-touch-icon.png, icon-*.png and social-preview.png are
+# favicon.ico, apple-touch-icon.png, icon-*.png and (when the pack carries one)
+# social-preview.png are
 # already served from THIS directory (root-overlaid when the pack is active),
 # so these keys stay unset. Set them only to point at an external CDN / absolute
 # URL.

--- a/public/branding/vshare/brand.yaml
+++ b/public/branding/vshare/brand.yaml
@@ -46,7 +46,8 @@ logo_url: "/favicon.svg"
 logo_alt: "VaultShare logo"
 
 # Other asset URLs (optional) -------------------------------------------------
-# favicon.ico, apple-touch-icon.png, icon-*.png and social-preview.png are
+# favicon.ico, apple-touch-icon.png, icon-*.png and (when the pack carries one)
+# social-preview.png are
 # already served from THIS directory (root-overlaid when the pack is active),
 # so these keys stay unset. Set them only to point at an external CDN / absolute
 # URL.

--- a/spec/integration/simple/rhales_migration_spec.rb
+++ b/spec/integration/simple/rhales_migration_spec.rb
@@ -60,7 +60,10 @@ RSpec.describe 'Rhales Migration Integration', type: :integration do
       # reads brand.product_name only (the legacy header.branding.site_name
       # tier was retired in #3612). Without this the rendered <title> would
       # be empty.
-      'brand' => { 'product_name' => 'One-Time Secret' },
+      # og_image_url mirrors what Config#normalize_brand resolves at boot for a
+      # pack carrying social-preview.png (the tracked default does) — this mock
+      # bypasses normalize_brand, so it has to state the resolved value (#4150).
+      'brand' => { 'product_name' => 'One-Time Secret', 'og_image_url' => '/social-preview.png' },
       'development' => { 'enabled' => false },
       'diagnostics' => {},
       'billing' => { 'enabled' => false }
@@ -265,9 +268,42 @@ RSpec.describe 'Rhales Migration Integration', type: :integration do
         expect(doc.css('link[rel="manifest"]')).not_to be_empty
       end
 
+      # A pack carrying social-preview.png emits both tags with an ABSOLUTE URL
+      # (social scrapers will not resolve a relative one) and the large-image
+      # card type. The imageless posture is asserted below (#4150).
       it 'emits og:image and twitter:image' do
         expect(doc.css('meta[property="og:image"]')).not_to be_empty
         expect(doc.css('meta[name="twitter:image"]')).not_to be_empty
+      end
+
+      it 'emits an absolute og:image URL' do
+        expect(doc.css('meta[property="og:image"]').first['content']).to match(%r{\Ahttps?://})
+      end
+
+      it 'emits twitter:card as summary_large_image when a card is present' do
+        expect(doc.css('meta[name="twitter:card"]').first&.[]('content')).to eq('summary_large_image')
+      end
+
+      # The opt-out posture (BRAND_OG_IMAGE_URL=none, or a pack carrying no card)
+      # reaches the view as a nil brand.og_image_url. Proven at the RENDER layer:
+      # the tags must be absent entirely, not emitted empty or pointing at a URL
+      # that 404s, and the card type must degrade so the preview still renders.
+      context 'with no social card' do
+        before do
+          @saved_brand   = OT.conf['brand']
+          OT.conf['brand'] = @saved_brand.merge('og_image_url' => nil)
+        end
+
+        after { OT.conf['brand'] = @saved_brand }
+
+        it 'omits og:image and twitter:image entirely' do
+          expect(doc.css('meta[property="og:image"]')).to be_empty
+          expect(doc.css('meta[name="twitter:image"]')).to be_empty
+        end
+
+        it 'degrades twitter:card to summary' do
+          expect(doc.css('meta[name="twitter:card"]').first&.[]('content')).to eq('summary')
+        end
       end
 
       it 'emits mobile web app metadata' do

--- a/try/unit/web/brand_asset_overlay_try.rb
+++ b/try/unit/web/brand_asset_overlay_try.rb
@@ -36,8 +36,9 @@ require 'onetime/middleware/static_files'
 require 'web/core/logic/page/get_favicon'
 require 'web/core/logic/page/get_webmanifest'
 
-BRAND_PACK_URLS      = Onetime::Middleware::StaticFiles::BRAND_PACK_URLS
-BRAND_PACK_LOGO_URLS = Onetime::Middleware::StaticFiles::BRAND_PACK_LOGO_URLS
+BRAND_PACK_URLS        = Onetime::Middleware::StaticFiles::BRAND_PACK_URLS
+BRAND_PACK_LOGO_URLS   = Onetime::Middleware::StaticFiles::BRAND_PACK_LOGO_URLS
+BRAND_PACK_SOCIAL_URLS = Onetime::Middleware::StaticFiles::BRAND_PACK_SOCIAL_URLS
 DEFAULT_PACK         = File.join(Onetime::HOME, 'public', 'branding', 'default')
 
 OT.conf['site'] ||= {}
@@ -76,6 +77,11 @@ File.write(File.join(@overlay_partial, 'favicon.svg'), '<svg/>')
 # to prove the optional logo URLs are existence-filtered like other assets.
 @overlay_logo = Dir.mktmpdir('ots-overlay-logo')
 File.write(File.join(@overlay_logo, 'brand-logo.svg'), '<svg/>')
+
+# Overlay carrying a pack-local social card (#4150): social-preview.png only,
+# to prove the optional social URL is existence-filtered like the logo URLs.
+@overlay_social = Dir.mktmpdir('ots-overlay-social')
+File.binwrite(File.join(@overlay_social, 'social-preview.png'), 'SOCIAL-OVERLAY-PNG')
 
 # Symmetric fixture: brand-logo.png ONLY, to prove the existence filter works
 # independently for the .png extension too.
@@ -336,7 +342,7 @@ overlay_dir = Onetime.brand_overlay_dir
 present = BRAND_PACK_URLS.select { |u| File.exist?(File.join(overlay_dir, u)) }
 absent  = (BRAND_PACK_URLS - present).sort
 [present, absent]
-#=> [['/favicon.svg'], ['/apple-touch-icon.png', '/icon-192.png', '/icon-512.png', '/safari-pinned-tab.svg', '/social-preview.png']]
+#=> [['/favicon.svg'], ['/apple-touch-icon.png', '/icon-192.png', '/icon-512.png', '/safari-pinned-tab.svg']]
 
 ## the default pack (base layer) carries the full BRAND_PACK_URLS set
 BRAND_PACK_URLS.all? { |u| File.exist?(File.join(DEFAULT_PACK, u)) }
@@ -372,6 +378,34 @@ overlay_dir = Onetime.brand_overlay_dir
 ## the neutral default pack ships NO logo — base layer existence-filters both out
 BRAND_PACK_LOGO_URLS.select { |u| File.exist?(File.join(DEFAULT_PACK, u)) }
 #=> []
+
+# ============================================================================
+# 7b. Optional pack-carried social card (#4150): same existence-filtered
+#     treatment as the logo, so a pack WITHOUT a card emits no og:image at all
+#     rather than serving/advertising the canonical one.
+# ============================================================================
+
+## the social card is NOT in the mandatory set (a pack may legitimately omit it)
+BRAND_PACK_URLS.include?('/social-preview.png')
+#=> false
+
+## the optional social URL set is the single og:image card
+BRAND_PACK_SOCIAL_URLS
+#=> ['/social-preview.png']
+
+## the optional URL set unions the logo and social URLs (one filter, both layers)
+Onetime::Middleware::StaticFiles::BRAND_PACK_OPTIONAL_URLS.sort
+#=> ['/brand-logo-dark.png', '/brand-logo-dark.svg', '/brand-logo.png', '/brand-logo.svg', '/social-preview.png']
+
+## an overlay carrying social-preview.png lists it among the optional URLs
+set_overlay(assets_dir: @overlay_social, pack: nil)
+overlay_dir = Onetime.brand_overlay_dir
+BRAND_PACK_SOCIAL_URLS.select { |u| File.exist?(File.join(overlay_dir, u)) }
+#=> ['/social-preview.png']
+
+## the tracked default pack ships a card, so the base layer serves it
+BRAND_PACK_SOCIAL_URLS.select { |u| File.exist?(File.join(DEFAULT_PACK, u)) }
+#=> ['/social-preview.png']
 
 clear_overlay
 
@@ -416,6 +450,6 @@ OT.conf['site']['brand_assets_dir'] = @orig_assets_dir
 OT.conf['site']['brand_pack']       = @orig_pack
 [@overlay_favicon, @overlay_manifest, @overlay_bad_manifest,
  @overlay_empty, @overlay_partial, @overlay_logo, @overlay_logo_png,
- @e2e_overlay].each { |d| FileUtils.remove_entry(d) rescue nil }
+ @overlay_social, @e2e_overlay].each { |d| FileUtils.remove_entry(d) rescue nil }
 [@etc_pack_dir, @public_pack_dir, @vendor_only_dir].each { |d| FileUtils.remove_entry(d) rescue nil }
 FileUtils.remove_entry(File.join(Onetime::HOME, 'etc', 'branding')) if Dir.exist?(File.join(Onetime::HOME, 'etc', 'branding')) && Dir.empty?(File.join(Onetime::HOME, 'etc', 'branding'))

--- a/try/unit/web/brand_pack_default_try.rb
+++ b/try/unit/web/brand_pack_default_try.rb
@@ -27,7 +27,22 @@ BRAND_YAML    = File.join(DEFAULT_PACK, 'brand.yaml')
 # site.webmanifest are served by routes; the rest by StaticFiles).
 CANONICAL_ASSETS = %w[
   favicon.ico favicon.svg apple-touch-icon.png icon-192.png icon-512.png
-  safari-pinned-tab.svg social-preview.png site.webmanifest
+  safari-pinned-tab.svg site.webmanifest
+].freeze
+
+# Assets a pack MAY carry. Optional because they are opt-in by nature, not
+# because they are unimportant:
+#   - brand-logo.*    — a pack-carried masthead logo (#3774), inert until
+#                       brand.logo_url points at it.
+#   - social-preview.png — the og:image/twitter:image card (#4150). The default
+#                       and example packs DO ship one; a pack may omit it, and
+#                       then no image meta tags are emitted at all (not a broken
+#                       tag pointing at a 404). Serving and linking both key off
+#                       this file's existence — see StaticFiles, head.rue and
+#                       Config#normalize_brand.
+OPTIONAL_ASSETS = %w[
+  social-preview.png brand-logo.svg brand-logo.png
+  brand-logo-dark.svg brand-logo-dark.png
 ].freeze
 
 # TRYOUTS
@@ -40,9 +55,18 @@ CANONICAL_ASSETS = %w[
 CANONICAL_ASSETS.all? { |f| File.file?(File.join(DEFAULT_PACK, f)) }
 #=> true
 
-## the default pack contains EXACTLY the canonical assets + brand.yaml (no cruft)
+## the default pack contains ONLY canonical + optional assets + brand.yaml (no cruft)
 entries = Dir.children(DEFAULT_PACK).reject { |e| e.start_with?('.') }.sort
-entries == (CANONICAL_ASSETS + ['brand.yaml']).sort
+(entries - (CANONICAL_ASSETS + OPTIONAL_ASSETS + ['brand.yaml'])).empty?
+#=> true
+
+## the default pack carries every canonical asset with nothing canonical missing
+entries = Dir.children(DEFAULT_PACK).reject { |e| e.start_with?('.') }.sort
+(CANONICAL_ASSETS - entries).empty?
+#=> true
+
+## the tracked default pack ships a social card (neutral, like the rest of the pack)
+File.file?(File.join(DEFAULT_PACK, 'social-preview.png'))
 #=> true
 
 ## the manifest file exists
@@ -78,3 +102,56 @@ documented.sort == Onetime::Config::BRAND_MANIFEST_KEYS.sort
 ## button_text_light is intentionally NOT manifest-settable (env/YAML-only)
 Onetime::Config::BRAND_MANIFEST_KEYS.include?('button_text_light')
 #=> false
+
+# ============================================================================
+# 4. Social card is resolved FROM THE PACK ASSET, not a hardcoded path (#4150)
+#
+#    normalize_brand is the single place the default is decided, so the served
+#    URL (StaticFiles existence filter) and the emitted tag (head.rue) can never
+#    disagree: both key off the same file being present in the resolved pack.
+# ============================================================================
+
+## a pack CARRYING social-preview.png resolves the card to the pack file
+conf = YAML.load(YAML.dump(OT.conf))
+conf['site']['brand_pack'] = 'vshare' # tracked sample pack; ships a card
+conf['brand']              = {}
+Onetime::Config.send(:normalize_brand, conf)
+conf.dig('brand', 'og_image_url')
+#=> '/social-preview.png'
+
+## the default pack carries one too, so an unconfigured install still gets a card
+conf = YAML.load(YAML.dump(OT.conf))
+conf['site']['brand_pack'] = 'default'
+conf['brand']              = {}
+Onetime::Config.send(:normalize_brand, conf)
+conf.dig('brand', 'og_image_url')
+#=> '/social-preview.png'
+
+## `none` is the explicit opt-out — the one an install whose pack DOES carry a
+## card (or that falls through to the default pack's card) has to use
+conf = YAML.load(YAML.dump(OT.conf))
+conf['site']['brand_pack'] = 'default'
+conf['brand']              = { 'og_image_url' => 'none' }
+Onetime::Config.send(:normalize_brand, conf)
+conf.dig('brand', 'og_image_url')
+#=> nil
+
+## the opt-out sentinel is case/whitespace tolerant (env vars arrive messy)
+conf = YAML.load(YAML.dump(OT.conf))
+conf['brand'] = { 'og_image_url' => '  NONE ' }
+Onetime::Config.send(:normalize_brand, conf)
+conf.dig('brand', 'og_image_url')
+#=> nil
+
+## the existence gate is a real file check, not an assumption about pack contents
+conf = YAML.load(YAML.dump(OT.conf))
+Onetime::Config.send(:brand_pack_carries?, conf, 'no-such-asset.png')
+#=> false
+
+## an explicit og_image_url always wins over pack resolution
+conf = YAML.load(YAML.dump(OT.conf))
+conf['site']['brand_pack'] = 'vshare'
+conf['brand']              = { 'og_image_url' => 'https://cdn.acme.test/card.png' }
+Onetime::Config.send(:normalize_brand, conf)
+conf.dig('brand', 'og_image_url')
+#=> 'https://cdn.acme.test/card.png'

--- a/try/unit/web/favicon_variety_pack_try.rb
+++ b/try/unit/web/favicon_variety_pack_try.rb
@@ -117,6 +117,15 @@ with_brand_conf({ 'og_image_url' => '/social-preview.png' }) do
 end
 #=> [true, true]
 
+## a bare-relative card is treated as a root path and absolutized too — pack
+## assets all serve from the root, and a relative og:image is ignored by scrapers
+with_brand_conf({ 'og_image_url' => 'social-preview.png' }) do
+  vars = @host.initialize_view_vars(Rack::Request.new(build_env))
+  u = vars['brand_og_image_url']
+  [u.start_with?('http://', 'https://'), u.end_with?('/social-preview.png')]
+end
+#=> [true, true]
+
 ## a protocol-relative card is left alone (already scheme-resolvable, not a path)
 with_brand_conf({ 'og_image_url' => '//cdn.acme.test/card.png' }) do
   vars = @host.initialize_view_vars(Rack::Request.new(build_env))

--- a/try/unit/web/favicon_variety_pack_try.rb
+++ b/try/unit/web/favicon_variety_pack_try.rb
@@ -79,13 +79,20 @@ with_brand_conf({ 'apple_touch_icon_url' => 'https://cdn.acme.test/touch.png' })
 end
 #=> 'https://cdn.acme.test/touch.png'
 
-## brand_og_image_url default is an absolute URL ending in the neutral social card
+## brand_og_image_url is nil when the brand block carries no card at all — the
+## head then emits NO image tags rather than a tag pointing at a 404 (#4150)
 with_brand_conf(nil) do
   vars = @host.initialize_view_vars(Rack::Request.new(build_env))
-  u = vars['brand_og_image_url']
-  [u.start_with?('http://', 'https://'), u.end_with?('/social-preview.png')]
+  vars['brand_og_image_url']
 end
-#=> [true, true]
+#=> nil
+
+## with no card, twitter:card degrades to `summary` (renders correctly imageless)
+with_brand_conf(nil) do
+  vars = @host.initialize_view_vars(Rack::Request.new(build_env))
+  vars['twitter_card_type']
+end
+#=> 'summary'
 
 ## brand_og_image_url reflects BRAND_OG_IMAGE_URL override when set
 with_brand_conf({ 'og_image_url' => 'https://cdn.acme.test/card.png' }) do
@@ -93,6 +100,53 @@ with_brand_conf({ 'og_image_url' => 'https://cdn.acme.test/card.png' }) do
   vars['brand_og_image_url']
 end
 #=> 'https://cdn.acme.test/card.png'
+
+## an explicit card restores summary_large_image
+with_brand_conf({ 'og_image_url' => 'https://cdn.acme.test/card.png' }) do
+  vars = @host.initialize_view_vars(Rack::Request.new(build_env))
+  vars['twitter_card_type']
+end
+#=> 'summary_large_image'
+
+## a root-relative card (the pack-resolved default) is absolutized against baseuri —
+## og:image must be absolute for social scrapers
+with_brand_conf({ 'og_image_url' => '/social-preview.png' }) do
+  vars = @host.initialize_view_vars(Rack::Request.new(build_env))
+  u = vars['brand_og_image_url']
+  [u.start_with?('http://', 'https://'), u.end_with?('/social-preview.png')]
+end
+#=> [true, true]
+
+## a protocol-relative card is left alone (already scheme-resolvable, not a path)
+with_brand_conf({ 'og_image_url' => '//cdn.acme.test/card.png' }) do
+  vars = @host.initialize_view_vars(Rack::Request.new(build_env))
+  vars['brand_og_image_url']
+end
+#=> '//cdn.acme.test/card.png'
+
+## a blank og_image_url yields no tag rather than an empty one. NOTE: reaching
+## the view blank means normalize_brand did not run (it collapses blanks to nil
+## and resolves `none` -> nil); the view is defensive here, and Config is where
+## the `none` opt-out is decided — see brand_pack_default_try.rb
+with_brand_conf({ 'og_image_url' => '  ' }) do
+  vars = @host.initialize_view_vars(Rack::Request.new(build_env))
+  [vars['brand_og_image_url'], vars['twitter_card_type']]
+end
+#=> [nil, 'summary']
+
+## [regression guard] a custom domain NEVER inherits the install's social card —
+## brand_config is the install's brand, so emitting it would put the operator's
+## card on a customer's shared link (#4150)
+def build_custom_env
+  env = build_env
+  env['onetime.domain_strategy'] = :custom
+  env
+end
+with_brand_conf({ 'og_image_url' => 'https://cdn.acme.test/card.png' }) do
+  vars = @host.initialize_view_vars(Rack::Request.new(build_custom_env))
+  [vars['brand_og_image_url'], vars['twitter_card_type']]
+end
+#=> [nil, 'summary']
 
 ## both variety-pack keys are exposed by initialize_view_vars
 vars = @host.initialize_view_vars(Rack::Request.new(build_env))
@@ -118,11 +172,6 @@ end
 #=> false
 
 ## [regression guard] a custom domain suppresses the static SVG so its uploaded /favicon.ico is not shadowed
-def build_custom_env
-  env = build_env
-  env['onetime.domain_strategy'] = :custom
-  env
-end
 with_brand_conf(nil) do
   vars = @host.initialize_view_vars(Rack::Request.new(build_custom_env))
   vars['show_default_svg_favicon']
@@ -136,8 +185,12 @@ end
 ## the full variety pack ships in the tracked default pack
 %w[
   favicon.ico favicon.svg apple-touch-icon.png icon-192.png icon-512.png
-  safari-pinned-tab.svg site.webmanifest social-preview.png
+  safari-pinned-tab.svg site.webmanifest
 ].all? { |f| File.exist?(File.join(PUBLIC_WEB, f)) }
+#=> true
+
+## the pack's social card ships too — neutral, like every other asset here
+File.file?(File.join(PUBLIC_WEB, 'social-preview.png'))
 #=> true
 
 ## favicon.svg uses the neutral blue, not the OTS orange (#DC4A22)


### PR DESCRIPTION
Closes #4150

Stacked on `fix/4087-trusted-proxy-ssot` (the branch this work was extracted from).

## Summary

- **Asset-derived resolution.** The card is resolved in `normalize_brand` from whether the brand pack actually carries `social-preview.png`, so the served URL and the emitted tag key off the same file and can no longer disagree.
- **Optional asset.** `/social-preview.png` moves out of the mandatory `BRAND_PACK_URLS` into `BRAND_PACK_SOCIAL_URLS`, unioned into the existence-filtered `BRAND_PACK_OPTIONAL_URLS` alongside the pack-carried logo URLs.
- **Explicit opt-out.** `Config::OG_IMAGE_NONE = %w[none off false]` — `BRAND_OG_IMAGE_URL=none` turns the card off per install. A sentinel rather than a blank, because `normalize_brand` already collapses blanks to nil meaning "unset". Deleting the pack file is *not* an opt-out: a partial pack falls through to the default pack.
- **Imageless degradation.** With no card, no `og:image` / `twitter:image` is emitted at all (never an empty tag, never a 404 target) and `twitter:card` drops from `summary_large_image` to `summary`, which renders correctly without an image.
- **Custom domains.** The card is suppressed unconditionally when `domain_strategy == :custom`, mirroring the existing suppression that keeps the canonical SVG favicon from shadowing a domain's own icon. Per-domain social images would be a follow-up.

The tracked `default` and example packs still ship a neutral card, so a stock install is unchanged.

Note: `spec/integration/simple/rhales_migration_spec.rb` builds a mock `OT.conf` directly and never runs `normalize_brand`, so it now states the resolved `og_image_url` itself.

## Test plan

- [ ] `try/unit/web/brand_pack_default_try.rb`
- [ ] `try/unit/web/brand_asset_overlay_try.rb`
- [ ] `try/unit/web/favicon_variety_pack_try.rb`
- [ ] `spec/integration/simple/rhales_migration_spec.rb`
- [ ] Stock install: head still emits `og:image` and `twitter:card: summary_large_image`
- [ ] `BRAND_OG_IMAGE_URL=none`: no image meta tags, `twitter:card: summary`
- [ ] Custom domain: no image meta tags regardless of install config