### PR TITLE
*Standardize boolean config parsing; fix RABBITMQ_VERIFY_PEER failing open

### DIFF
--- a/apps/web/billing/spec/lib/billing_config_automatic_tax_spec.rb
+++ b/apps/web/billing/spec/lib/billing_config_automatic_tax_spec.rb
@@ -4,7 +4,7 @@
 
 # Parsing rules for the deployment-level automatic-tax switch:
 # ENV['STRIPE_AUTOMATIC_TAX'] first, then billing.yaml 'automatic_tax',
-# default false. Parsing delegates to Onetime::Utils.strict_bool!, so the
+# default false. Parsing delegates to Onetime::Utils::Strings.strict_bool!, so the
 # full shared token vocabulary applies (1/true/yes/on/y/t and
 # 0/false/no/off/n/f); blank is explicitly off; any other set value raises
 # Onetime::ConfigError — an unrecognized token used to silently disable tax
@@ -50,7 +50,7 @@ RSpec.describe Onetime::BillingConfig, '#automatic_tax?' do
     end
   end
 
-  # Additional coverage since parsing unified on Onetime::Utils.strict_bool!:
+  # Additional coverage since parsing unified on Onetime::Utils::Strings.strict_bool!:
   # the full shared vocabulary is accepted, so STRIPE_AUTOMATIC_TAX=yes now
   # enables tax collection instead of raising at boot.
   %w[yes on y t].each do |truthy|
@@ -75,11 +75,18 @@ RSpec.describe Onetime::BillingConfig, '#automatic_tax?' do
 
   # 'yes'/'on'/'t' moved out of this table when parsing unified on the
   # shared vocabulary — they are recognized tokens now, asserted above.
+  #
+  # The message names the flag but never reproduces the value: ENV is
+  # operator-supplied, so a misrouted credential must not land in the boot log
+  # or a Sentry title (ADR-037). The assertion here used to require the value
+  # to appear; that contract is retired, and the non-disclosure sweep lives in
+  # spec/unit/onetime/utils/strings_spec.rb.
   %w[enabled ture 2].each do |bad|
     it "raises ConfigError when ENV['STRIPE_AUTOMATIC_TAX'] is '#{bad}'" do
       stub_env(bad)
       expect { billing_config.automatic_tax? }
-        .to raise_error(Onetime::ConfigError, /STRIPE_AUTOMATIC_TAX.*#{bad}/)
+        .to raise_error(Onetime::ConfigError,
+          /STRIPE_AUTOMATIC_TAX is set to an unrecognized boolean \(\d+ chars, sha256:\h+\)/)
     end
   end
 

--- a/apps/web/billing/spec/lib/billing_config_automatic_tax_spec.rb
+++ b/apps/web/billing/spec/lib/billing_config_automatic_tax_spec.rb
@@ -4,10 +4,12 @@
 
 # Parsing rules for the deployment-level automatic-tax switch:
 # ENV['STRIPE_AUTOMATIC_TAX'] first, then billing.yaml 'automatic_tax',
-# default false. 'true'/'1' enable, 'false'/'0' disable, blank is unset;
-# any other set value raises Onetime::ConfigError — an unrecognized token
-# used to silently disable tax collection on every checkout. ENV access is
-# stubbed (never mutated) so nothing leaks between examples.
+# default false. Parsing delegates to Onetime::Utils.strict_bool!, so the
+# full shared token vocabulary applies (1/true/yes/on/y/t and
+# 0/false/no/off/n/f); blank is unset; any other set value raises
+# Onetime::ConfigError — an unrecognized token used to silently disable tax
+# collection on every checkout. ENV access is stubbed (never mutated) so
+# nothing leaks between examples.
 #
 # Run: pnpm run test:rspec apps/web/billing/spec/lib/billing_config_automatic_tax_spec.rb
 
@@ -48,13 +50,32 @@ RSpec.describe Onetime::BillingConfig, '#automatic_tax?' do
     end
   end
 
+  # Additional coverage since parsing unified on Onetime::Utils.strict_bool!:
+  # the full shared vocabulary is accepted, so STRIPE_AUTOMATIC_TAX=yes now
+  # enables tax collection instead of raising at boot.
+  %w[yes on y t].each do |truthy|
+    it "is true when ENV['STRIPE_AUTOMATIC_TAX'] is '#{truthy}' (shared vocabulary)" do
+      stub_env(truthy)
+      expect(billing_config.automatic_tax?).to be(true)
+    end
+  end
+
+  %w[no off n f].each do |falsy|
+    it "is false when ENV['STRIPE_AUTOMATIC_TAX'] is '#{falsy}' (shared vocabulary)" do
+      stub_env(falsy)
+      expect(billing_config.automatic_tax?).to be(false)
+    end
+  end
+
   it 'treats a blank ENV value as unset (false)' do
     stub_env('   ')
     stub_config('automatic_tax' => true)
     expect(billing_config.automatic_tax?).to be(false)
   end
 
-  %w[yes on enabled t].each do |bad|
+  # 'yes'/'on'/'t' moved out of this table when parsing unified on the
+  # shared vocabulary — they are recognized tokens now, asserted above.
+  %w[enabled ture 2].each do |bad|
     it "raises ConfigError when ENV['STRIPE_AUTOMATIC_TAX'] is '#{bad}'" do
       stub_env(bad)
       expect { billing_config.automatic_tax? }
@@ -79,7 +100,7 @@ RSpec.describe Onetime::BillingConfig, '#automatic_tax?' do
   end
 
   it 'raises ConfigError on an arbitrary config file value' do
-    stub_config('automatic_tax' => 'yes')
+    stub_config('automatic_tax' => 'enabled')
     expect { billing_config.automatic_tax? }
       .to raise_error(Onetime::ConfigError, /billing\.yaml 'automatic_tax'/)
   end

--- a/apps/web/billing/spec/lib/billing_config_automatic_tax_spec.rb
+++ b/apps/web/billing/spec/lib/billing_config_automatic_tax_spec.rb
@@ -6,7 +6,7 @@
 # ENV['STRIPE_AUTOMATIC_TAX'] first, then billing.yaml 'automatic_tax',
 # default false. Parsing delegates to Onetime::Utils.strict_bool!, so the
 # full shared token vocabulary applies (1/true/yes/on/y/t and
-# 0/false/no/off/n/f); blank is unset; any other set value raises
+# 0/false/no/off/n/f); blank is explicitly off; any other set value raises
 # Onetime::ConfigError — an unrecognized token used to silently disable tax
 # collection on every checkout. ENV access is stubbed (never mutated) so
 # nothing leaks between examples.
@@ -67,7 +67,7 @@ RSpec.describe Onetime::BillingConfig, '#automatic_tax?' do
     end
   end
 
-  it 'treats a blank ENV value as unset (false)' do
+  it 'treats a blank ENV value as explicitly off, not a fallback to config' do
     stub_env('   ')
     stub_config('automatic_tax' => true)
     expect(billing_config.automatic_tax?).to be(false)

--- a/apps/web/billing/spec/lib/billing_config_enabled_spec.rb
+++ b/apps/web/billing/spec/lib/billing_config_enabled_spec.rb
@@ -3,11 +3,12 @@
 # frozen_string_literal: true
 
 # Parsing rules for the billing master switch: ENV['BILLING_ENABLED']
-# first, then billing.yaml 'enabled', default false. 'true'/'1' enable,
-# 'false'/'0' disable, blank is explicitly off; any other set value raises
-# Onetime::ConfigError — BILLING_ENABLED=1 used to silently disable
-# billing. ENV access is stubbed (never mutated) so nothing leaks between
-# examples.
+# first, then billing.yaml 'enabled', default false. Parsing delegates to
+# Onetime::Utils.strict_bool!, so the full shared token vocabulary applies
+# (1/true/yes/on/y/t and 0/false/no/off/n/f); blank is explicitly off; any
+# other set value raises Onetime::ConfigError — BILLING_ENABLED=1 used to
+# silently disable billing. ENV access is stubbed (never mutated) so
+# nothing leaks between examples.
 #
 # Run: pnpm run test:rspec apps/web/billing/spec/lib/billing_config_enabled_spec.rb
 
@@ -49,6 +50,24 @@ RSpec.describe Onetime::BillingConfig, '#enabled?' do
     end
   end
 
+  # Additional coverage since parsing unified on Onetime::Utils.strict_bool!:
+  # the full shared vocabulary is accepted, so BILLING_ENABLED=yes now
+  # enables billing instead of raising at boot.
+  %w[yes on y t].each do |truthy|
+    it "is true when ENV['BILLING_ENABLED'] is '#{truthy}' (shared vocabulary)" do
+      stub_env(truthy)
+      expect(billing_config.enabled?).to be(true)
+    end
+  end
+
+  %w[no off n f].each do |falsy|
+    it "is false when ENV['BILLING_ENABLED'] is '#{falsy}', overriding config (shared vocabulary)" do
+      stub_env(falsy)
+      stub_config('enabled' => true)
+      expect(billing_config.enabled?).to be(false)
+    end
+  end
+
   it 'treats a blank ENV value as explicitly off, not a fallback to config' do
     stub_env('   ')
     stub_config('enabled' => true)
@@ -65,7 +84,9 @@ RSpec.describe Onetime::BillingConfig, '#enabled?' do
     expect(billing_config.enabled?).to be(true)
   end
 
-  %w[yes on enabled t].each do |bad|
+  # 'yes'/'on'/'t' moved out of this table when parsing unified on the
+  # shared vocabulary — they are recognized tokens now, asserted above.
+  %w[enabled ture 2].each do |bad|
     it "raises ConfigError when ENV['BILLING_ENABLED'] is '#{bad}'" do
       stub_env(bad)
       expect { billing_config.enabled? }
@@ -74,7 +95,7 @@ RSpec.describe Onetime::BillingConfig, '#enabled?' do
   end
 
   it 'raises ConfigError on an arbitrary config file value' do
-    stub_config('enabled' => 'yes')
+    stub_config('enabled' => 'maybe')
     expect { billing_config.enabled? }
       .to raise_error(Onetime::ConfigError, /billing\.yaml 'enabled'/)
   end

--- a/apps/web/billing/spec/lib/billing_config_enabled_spec.rb
+++ b/apps/web/billing/spec/lib/billing_config_enabled_spec.rb
@@ -4,7 +4,7 @@
 
 # Parsing rules for the billing master switch: ENV['BILLING_ENABLED']
 # first, then billing.yaml 'enabled', default false. Parsing delegates to
-# Onetime::Utils.strict_bool!, so the full shared token vocabulary applies
+# Onetime::Utils::Strings.strict_bool!, so the full shared token vocabulary applies
 # (1/true/yes/on/y/t and 0/false/no/off/n/f); blank is explicitly off; any
 # other set value raises Onetime::ConfigError — BILLING_ENABLED=1 used to
 # silently disable billing. ENV access is stubbed (never mutated) so
@@ -50,7 +50,7 @@ RSpec.describe Onetime::BillingConfig, '#enabled?' do
     end
   end
 
-  # Additional coverage since parsing unified on Onetime::Utils.strict_bool!:
+  # Additional coverage since parsing unified on Onetime::Utils::Strings.strict_bool!:
   # the full shared vocabulary is accepted, so BILLING_ENABLED=yes now
   # enables billing instead of raising at boot.
   %w[yes on y t].each do |truthy|
@@ -86,11 +86,18 @@ RSpec.describe Onetime::BillingConfig, '#enabled?' do
 
   # 'yes'/'on'/'t' moved out of this table when parsing unified on the
   # shared vocabulary — they are recognized tokens now, asserted above.
+  #
+  # The message names the flag but never reproduces the value: ENV is
+  # operator-supplied, so a misrouted credential must not land in the boot log
+  # or a Sentry title (ADR-037). The assertion here used to require the value
+  # to appear; that contract is retired, and the non-disclosure sweep lives in
+  # spec/unit/onetime/utils/strings_spec.rb.
   %w[enabled ture 2].each do |bad|
     it "raises ConfigError when ENV['BILLING_ENABLED'] is '#{bad}'" do
       stub_env(bad)
       expect { billing_config.enabled? }
-        .to raise_error(Onetime::ConfigError, /BILLING_ENABLED.*#{bad}/)
+        .to raise_error(Onetime::ConfigError,
+          /BILLING_ENABLED is set to an unrecognized boolean \(\d+ chars, sha256:\h+\)/)
     end
   end
 

--- a/docs/adr/adr-037-boolean-token-vocabulary.md
+++ b/docs/adr/adr-037-boolean-token-vocabulary.md
@@ -1,0 +1,64 @@
+---
+id: 037
+status: accepted
+decided: 2026-08-13
+title: 'ADR-037: One Boolean Token Vocabulary for Operator Flags'
+---
+
+## Context
+
+Two parsers for operator-supplied booleans grew independently. A private
+`BillingConfig#strict_bool!` accepted only `true/1/false/0` and raised on
+anything else; `RABBITMQ_VERIFY_PEER` was read as `ENV.fetch(...) == 'true'`,
+so `TRUE`, `1`, `yes`, or a typo silently disabled a default-ON security
+control. Divergent vocabularies also contradict each other in error messages:
+one parser's message advertises tokens the other rejects, and fixes to one
+silently miss the other.
+
+## Decision
+
+One vocabulary, one parser, defined in `Onetime::Utils::Strings`:
+
+- `TRUTHY_VALUES = %w[1 true yes on y t]`,
+  `FALSEY_VALUES = %w[0 false no off n f]` — case-insensitive,
+  whitespace-tolerant.
+- `explicit_yes?` / `explicit_no?` are **recognizers, not a partition**:
+  unrecognized input is neither yes nor no. `explicit_no?` is deliberately
+  not `!explicit_yes?` — that negation would resolve a typo to "no", which
+  on a default-ON control means silently off.
+- `Onetime::Utils.strict_bool!(name, raw, default:)` is the sole parser for
+  operator flags: blank/nil takes the caller's documented default; a
+  recognized token takes its value; anything else raises
+  `Onetime::ConfigError` naming the flag and the valid tokens
+  ([ADR-033](adr-033-fail-fast-and-loud.md)).
+- No per-caller vocabularies. A recognized synonym resolves to its value
+  everywhere — never raises in one subsystem while meaning true in another.
+  Strictness targets *silent misinterpretation*; rejecting `yes` was
+  strictness without a safety payoff, so billing's narrow vocabulary was
+  widened into the shared one rather than preserved as an exception.
+
+## Testing policy {#testing-policy}
+
+When a contract widens, existing testcases are preserved verbatim and new
+cases are **added** for the new tokens — editing established assertions to
+fit new behavior erases the record of what the contract was. The one
+exception is an assertion that pins the retired contract itself (e.g.
+"`BILLING_ENABLED=on` raises"): it cannot pass against the widened code and
+is removed, with a comment at the site saying where the token's new
+assertion lives.
+
+## Consequences
+
+- `BILLING_ENABLED` / `STRIPE_AUTOMATIC_TAX` now accept `yes/on/y/t` and
+  `no/off/n/f`; previously these raised at boot. Widening is toward the
+  operator's stated intent, not a silent flip.
+- Blank remains "unset → documented default"; genuinely unrecognized tokens
+  still fail the boot loudly.
+- Any new flag parses via `strict_bool!` — never `== 'true'`.
+
+## References
+
+- `lib/onetime/utils/strings.rb` — vocabulary, recognizers, `strict_bool!`
+- `spec/unit/onetime/utils/strings_spec.rb` — partition invariant
+- `apps/web/billing/spec/lib/billing_config_enabled_spec.rb`,
+  `billing_config_automatic_tax_spec.rb` — preserved + added coverage

--- a/docs/adr/adr-037-boolean-token-vocabulary.md
+++ b/docs/adr/adr-037-boolean-token-vocabulary.md
@@ -26,11 +26,24 @@ One vocabulary, one parser, defined in `Onetime::Utils::Strings`:
   unrecognized input is neither yes nor no. `explicit_no?` is deliberately
   not `!explicit_yes?` — that negation would resolve a typo to "no", which
   on a default-ON control means silently off.
-- `Onetime::Utils.strict_bool!(name, raw, default:)` is the sole parser for
+- `Onetime::Utils::Strings.strict_bool!(name, raw, default:)` is the sole parser for
   operator flags: blank/nil takes the caller's documented default; a
   recognized token takes its value; anything else raises
   `Onetime::ConfigError` naming the flag and the valid tokens
   ([ADR-033](adr-033-fail-fast-and-loud.md)).
+- **The rejected value is never echoed.** `strict_bool!` is public and its
+  message reaches logs and Sentry issue titles, so a caller that hands it a
+  credential-adjacent value must not have that value reproduced. The message
+  carries the flag name, the character count, the valid tokens, and the first
+  8 hex characters of `sha256(normalized_value)` as a correlation tag — enough
+  to match a log line to a host's config, or to confirm two hosts share one
+  typo, without reproducing the value. (For a low-entropy value the digest is
+  brute-forceable; that is acceptable, since low-entropy values are exactly
+  the non-sensitive case.) Truncating a head instead was rejected:
+  it caps volume, not sensitivity, and most secrets are shorter than any
+  workable cap. By-param-name scrubbing downstream cannot help, because the
+  value would be interpolated into the exception message itself; suppression
+  belongs at the raise site.
 - No per-caller vocabularies. A recognized synonym resolves to its value
   everywhere — never raises in one subsystem while meaning true in another.
   Strictness targets *silent misinterpretation*; rejecting `yes` was

--- a/lib/onetime/billing_config.rb
+++ b/lib/onetime/billing_config.rb
@@ -42,14 +42,15 @@ module Onetime
     # Returns false if file doesn't exist or enabled is not set.
     # ENV['BILLING_ENABLED'] overrides config when set; a blank ENV value
     # counts as explicitly unset (billing off) and does not fall back to
-    # the config file. Accepts true/1/false/0 (case-insensitive); any
+    # the config file. Accepts the shared boolean token vocabulary
+    # (Utils::Strings::TRUTHY_VALUES/FALSEY_VALUES, case-insensitive); any
     # other set value raises Onetime::ConfigError rather than silently
     # disabling billing (BILLING_ENABLED=1 used to mean "off").
     def enabled?
       env_val = ENV.fetch('BILLING_ENABLED', nil)
-      return strict_bool!('BILLING_ENABLED', env_val) unless env_val.nil?
+      return Onetime::Utils.strict_bool!('BILLING_ENABLED', env_val, default: false) unless env_val.nil?
 
-      strict_bool!("billing.yaml 'enabled'", config['enabled'])
+      Onetime::Utils.strict_bool!("billing.yaml 'enabled'", config['enabled'], default: false)
     end
 
     # Stripe API key
@@ -146,19 +147,19 @@ module Onetime
     #
     # Deployment-level policy, not a per-checkout choice. Checks
     # ENV['STRIPE_AUTOMATIC_TAX'] first, then the config file key
-    # 'automatic_tax', mirroring checkout_host. Accepts true/1/false/0
-    # (case-insensitive); unset and blank are false. Any other set value
-    # raises Onetime::ConfigError — before this, STRIPE_AUTOMATIC_TAX=yes
-    # silently disabled tax collection on every checkout, which is a
-    # compliance exposure, not a default.
+    # 'automatic_tax', mirroring checkout_host. Accepts the shared boolean
+    # token vocabulary (case-insensitive); unset and blank are false. Any
+    # other set value raises Onetime::ConfigError — before this,
+    # STRIPE_AUTOMATIC_TAX=yes silently disabled tax collection on every
+    # checkout, which is a compliance exposure, not a default.
     #
     # Requires Stripe Tax to be configured in the Dashboard (Settings → Tax:
     # tax registrations + product tax codes) before enabling.
     def automatic_tax?
       raw = ENV.fetch('STRIPE_AUTOMATIC_TAX', nil)
-      return strict_bool!('STRIPE_AUTOMATIC_TAX', raw) unless raw.nil?
+      return Onetime::Utils.strict_bool!('STRIPE_AUTOMATIC_TAX', raw, default: false) unless raw.nil?
 
-      strict_bool!("billing.yaml 'automatic_tax'", config['automatic_tax'])
+      Onetime::Utils.strict_bool!("billing.yaml 'automatic_tax'", config['automatic_tax'], default: false)
     end
 
     # Stripe payment method configuration ID (pmc_...).
@@ -298,19 +299,6 @@ module Onetime
     end
 
     private
-
-    # Strict boolean parsing for deployment flags. nil/blank mean unset
-    # (false); anything outside true/1/false/0 raises so a typo'd flag
-    # fails the boot instead of silently flipping the feature off.
-    def strict_bool!(name, raw)
-      value = raw.to_s.strip.downcase
-      return false if value.empty?
-      return true  if %w[true 1].include?(value)
-      return false if %w[false 0].include?(value)
-
-      raise Onetime::ConfigError,
-        "#{name} is #{raw.inspect} — unrecognized boolean. Use true/1 or false/0, or leave unset."
-    end
 
     def load_config
       unless @path && File.exist?(@path)

--- a/lib/onetime/billing_config.rb
+++ b/lib/onetime/billing_config.rb
@@ -49,9 +49,9 @@ module Onetime
     # disabling billing (BILLING_ENABLED=1 used to mean "off").
     def enabled?
       env_val = ENV.fetch('BILLING_ENABLED', nil)
-      return Onetime::Utils.strict_bool!('BILLING_ENABLED', env_val, default: false) unless env_val.nil?
+      return Onetime::Utils::Strings.strict_bool!('BILLING_ENABLED', env_val, default: false) unless env_val.nil?
 
-      Onetime::Utils.strict_bool!("billing.yaml 'enabled'", config['enabled'], default: false)
+      Onetime::Utils::Strings.strict_bool!("billing.yaml 'enabled'", config['enabled'], default: false)
     end
 
     # Stripe API key
@@ -160,9 +160,9 @@ module Onetime
     # tax registrations + product tax codes) before enabling.
     def automatic_tax?
       raw = ENV.fetch('STRIPE_AUTOMATIC_TAX', nil)
-      return Onetime::Utils.strict_bool!('STRIPE_AUTOMATIC_TAX', raw, default: false) unless raw.nil?
+      return Onetime::Utils::Strings.strict_bool!('STRIPE_AUTOMATIC_TAX', raw, default: false) unless raw.nil?
 
-      Onetime::Utils.strict_bool!("billing.yaml 'automatic_tax'", config['automatic_tax'], default: false)
+      Onetime::Utils::Strings.strict_bool!("billing.yaml 'automatic_tax'", config['automatic_tax'], default: false)
     end
 
     # Stripe payment method configuration ID (pmc_...).

--- a/lib/onetime/billing_config.rb
+++ b/lib/onetime/billing_config.rb
@@ -40,9 +40,10 @@ module Onetime
 
     # Whether billing is enabled
     # Returns false if file doesn't exist or enabled is not set.
-    # ENV['BILLING_ENABLED'] overrides config when set; a blank ENV value
-    # counts as explicitly unset (billing off) and does not fall back to
-    # the config file. Accepts the shared boolean token vocabulary
+    # ENV['BILLING_ENABLED'] overrides config whenever it is present —
+    # including when it is blank, which resolves to false (billing off)
+    # rather than falling back to the config file. Only an absent variable
+    # reaches the config key. Accepts the shared boolean token vocabulary
     # (Utils::Strings::TRUTHY_VALUES/FALSEY_VALUES, case-insensitive); any
     # other set value raises Onetime::ConfigError rather than silently
     # disabling billing (BILLING_ENABLED=1 used to mean "off").
@@ -147,8 +148,10 @@ module Onetime
     #
     # Deployment-level policy, not a per-checkout choice. Checks
     # ENV['STRIPE_AUTOMATIC_TAX'] first, then the config file key
-    # 'automatic_tax', mirroring checkout_host. Accepts the shared boolean
-    # token vocabulary (case-insensitive); unset and blank are false. Any
+    # 'automatic_tax', mirroring checkout_host and enabled?. Accepts the
+    # shared boolean token vocabulary (case-insensitive). A blank ENV value
+    # resolves to false rather than falling back to the config file; only an
+    # absent variable reaches the config key. Any
     # other set value raises Onetime::ConfigError — before this,
     # STRIPE_AUTOMATIC_TAX=yes silently disabled tax collection on every
     # checkout, which is a compliance exposure, not a default.

--- a/lib/onetime/jobs/queues/config.rb
+++ b/lib/onetime/jobs/queues/config.rb
@@ -167,11 +167,17 @@ module Onetime
       # need override without config file changes (e.g., disable verify_peer in dev).
       #
       # Environment variables:
-      # - RABBITMQ_VERIFY_PEER: 'true' (default) or 'false' for local dev
+      # - RABBITMQ_VERIFY_PEER: defaults ON. Accepts any token in
+      #   Utils::Strings::TRUTHY_VALUES/FALSEY_VALUES (case-insensitive,
+      #   whitespace-tolerant); set a falsey token to disable for local dev.
+      #   An unrecognized value raises at boot rather than silently disabling
+      #   certificate verification (ADR-033/ADR-037).
       # - RABBITMQ_CA_CERTIFICATES: Optional path to custom CA cert file
       #
       # @param url [String, nil] RabbitMQ connection URL
       # @return [Hash] TLS options hash (empty if URL is not amqps://)
+      # @raise [Onetime::ConfigError] if RABBITMQ_VERIFY_PEER is set to an
+      #   unrecognized token (only reached for amqps:// URLs)
       #
       # @example
       #   config.merge!(QueueConfig.tls_options(amqp_url))
@@ -181,7 +187,9 @@ module Onetime
 
         options = {
           tls: true,
-          verify_peer: ENV.fetch('RABBITMQ_VERIFY_PEER', 'true') == 'true',
+          verify_peer: Onetime::Utils.strict_bool!(
+            'RABBITMQ_VERIFY_PEER', ENV.fetch('RABBITMQ_VERIFY_PEER', nil), default: true
+          ),
         }
 
         ca_certs_path                 = ENV.fetch('RABBITMQ_CA_CERTIFICATES', nil)

--- a/lib/onetime/jobs/queues/config.rb
+++ b/lib/onetime/jobs/queues/config.rb
@@ -187,7 +187,7 @@ module Onetime
 
         options = {
           tls: true,
-          verify_peer: Onetime::Utils.strict_bool!(
+          verify_peer: Onetime::Utils::Strings.strict_bool!(
             'RABBITMQ_VERIFY_PEER', ENV.fetch('RABBITMQ_VERIFY_PEER', nil), default: true
           ),
         }

--- a/lib/onetime/utils/strings.rb
+++ b/lib/onetime/utils/strings.rb
@@ -5,6 +5,11 @@
 require 'mail'
 require 'public_suffix'
 
+# strict_bool! raises Onetime::ConfigError. This file loads early in
+# lib/onetime.rb, hundreds of lines before the main errors require, so pull
+# it in here rather than relying on load order (errors.rb is dependency-free).
+require_relative '../errors'
+
 module Onetime
   module Utils
     module Strings
@@ -30,12 +35,18 @@ module Onetime
         # improve readability and reduce user errors when manually entering
         # generated strings.
         VALID_CHARS_SAFE = VALID_CHARS.reject { |char| AMBIGUOUS_CHARS.include?(char) }.freeze
+      end
 
-        # Definitive list of strings that can represent a boolean value. These
-        # are used by explicit_yes? and explicit_no? to avoid any confusion
-        # around guesses like, "it doesn't meet our definition for a clear
-        # positive signal so we'll assume the negative case" which is
-        # not the same as an explicit false.
+      # Definitive list of strings that can represent a boolean value. These
+      # are used by explicit_yes? and explicit_no? to avoid any confusion
+      # around guesses like, "it doesn't meet our definition for a clear
+      # positive signal so we'll assume the negative case" which is
+      # not the same as an explicit false.
+      #
+      # Guarded on their own name, not VALID_CHARS: Onetime::Utils defines its
+      # own VALID_CHARS, so a load path that evaluates this body after utils.rb
+      # would otherwise skip these definitions entirely.
+      unless defined?(TRUTHY_VALUES)
         TRUTHY_VALUES = %w[1 true yes on y t].freeze
         FALSEY_VALUES = %w[0 false no off n f].freeze
       end
@@ -259,11 +270,15 @@ module Onetime
       # @return [Boolean]
       # @raise [Onetime::ConfigError] if raw is present but not a recognized token
       def strict_bool!(name, raw, default:)
-        return default if raw.to_s.strip.empty?
-        return true    if explicit_yes?(raw)
-        return false   if explicit_no?(raw)
+        # Normalize exactly once so the blank guard and the token tables can
+        # never disagree about what normalization means. NOTE: the message
+        # echoes raw into logs/Sentry — fine for boolean flags, do not reuse
+        # this for operator-sensitive values.
+        value = raw.to_s.strip.downcase
+        return default if value.empty?
+        return true    if TRUTHY_VALUES.include?(value)
+        return false   if FALSEY_VALUES.include?(value)
 
-        # One nit: raw.inspect in the error message is fine for boolean flags, but if strict_bool! later gets reused for something operator-sensitive, the raised message echoes the raw value into logs/Sentry.
         raise Onetime::ConfigError,
           "#{name} is #{raw.inspect} — unrecognized boolean. " \
           "Use one of #{TRUTHY_VALUES.join('/')} or #{FALSEY_VALUES.join('/')}, or leave unset."

--- a/lib/onetime/utils/strings.rb
+++ b/lib/onetime/utils/strings.rb
@@ -30,7 +30,14 @@ module Onetime
         # improve readability and reduce user errors when manually entering
         # generated strings.
         VALID_CHARS_SAFE = VALID_CHARS.reject { |char| AMBIGUOUS_CHARS.include?(char) }.freeze
-        TRUTHY_VALUES    = %w[1 true yes on y t].freeze
+
+        # Definitive list of strings that can represent a boolean value. These
+        # are used by explicit_yes? and explicit_no? to avoid any confusion
+        # around guesses like, "it doesn't meet our definition for a clear
+        # positive signal so we'll assume the negative case" which is
+        # not the same as an explicit false.
+        TRUTHY_VALUES = %w[1 true yes on y t].freeze
+        FALSEY_VALUES = %w[0 false no off n f].freeze
       end
 
       # Generates a random string of specified length using predefined
@@ -217,11 +224,49 @@ module Onetime
         end
       end
 
-      # Checks if a value represents a truthy boolean value
+      # Checks whether a value is an explicitly recognized truthy token.
+      #
+      # This is a recognizer, not a partition: a false return means "not a
+      # truthy token", NOT "falsey". Unrecognized input (typos, blanks) is
+      # neither yes nor no. Use strict_bool! when unrecognized input must
+      # not silently resolve to a default.
+      #
       # @param value [Object] Value to check
-      # @return [Boolean] true if value one of the TRUTHY_VALUES (case-insensitive)
-      def yes?(value)
-        !value.to_s.empty? && TRUTHY_VALUES.include?(value.to_s.downcase)
+      # @return [Boolean] true if value is one of TRUTHY_VALUES (case-insensitive, whitespace-tolerant)
+      def explicit_yes?(value)
+        TRUTHY_VALUES.include?(value.to_s.strip.downcase)
+      end
+      alias yes? explicit_yes?
+
+      # Checks whether a value is an explicitly recognized falsey token.
+      # Complement of explicit_yes?, not its negation: both return false for
+      # unrecognized input.
+      #
+      # @param value [Object] Value to check
+      # @return [Boolean] true if value is one of FALSEY_VALUES (case-insensitive, whitespace-tolerant)
+      def explicit_no?(value)
+        FALSEY_VALUES.include?(value.to_s.strip.downcase)
+      end
+
+      # Resolves an operator-supplied boolean, failing loudly on anything
+      # unrecognized (ADR-033). Blank/nil means unset and takes the caller's
+      # documented default; a typo raises instead of silently landing on
+      # false, which would disable a default-ON control.
+      #
+      # @param name [String] Flag name, for the error message (e.g. 'RABBITMQ_VERIFY_PEER')
+      # @param raw [Object] Raw value as supplied
+      # @param default [Boolean] Value to use when raw is unset/blank
+      # @return [Boolean]
+      # @raise [Onetime::ConfigError] if raw is present but not a recognized token
+      def strict_bool!(name, raw, default:)
+        return default if raw.to_s.strip.empty?
+        return true    if explicit_yes?(raw)
+        return false   if explicit_no?(raw)
+
+        # One nit: raw.inspect in the error message is fine for boolean flags, but if strict_bool! later gets reused for something operator-sensitive, the raised message echoes the raw value into logs/Sentry.
+        raise Onetime::ConfigError,
+          "#{name} is #{raw.inspect} — unrecognized boolean. " \
+          "Use one of #{TRUTHY_VALUES.join('/')} or #{FALSEY_VALUES.join('/')}, or leave unset."
       end
 
       private

--- a/lib/onetime/utils/strings.rb
+++ b/lib/onetime/utils/strings.rb
@@ -49,6 +49,11 @@ module Onetime
       unless defined?(TRUTHY_VALUES)
         TRUTHY_VALUES = %w[1 true yes on y t].freeze
         FALSEY_VALUES = %w[0 false no off n f].freeze
+
+        # Longest rejected value strict_bool! will echo verbatim in its error
+        # message. Comfortably longer than every recognized token, short
+        # enough that a misrouted secret is not reproduced in full.
+        MAX_BOOL_ECHO_LENGTH = 32
       end
 
       # Generates a random string of specified length using predefined
@@ -278,11 +283,26 @@ module Onetime
         return false   if FALSEY_VALUES.include?(value)
 
         raise Onetime::ConfigError,
-          "#{name} is #{raw.inspect} — unrecognized boolean. " \
+          "#{name} is #{bool_echo(raw)} — unrecognized boolean. " \
           "Use one of #{TRUTHY_VALUES.join('/')} or #{FALSEY_VALUES.join('/')}, or leave unset."
       end
 
       private
+
+      # Renders a rejected boolean token for the error message. The message
+      # reaches logs and Sentry, so cap the echo: every legitimate token is a
+      # handful of characters, and anything longer is a misrouted value (a
+      # credential, a URL, a whole config blob) that should not be reproduced
+      # in full. The head is kept — it is what an operator needs to recognize
+      # which value they mistyped.
+      # @param raw [Object] Value that failed the token tables
+      # @return [String] Quoted, length-capped rendering
+      def bool_echo(raw)
+        text = raw.to_s
+        return text.inspect if text.length <= MAX_BOOL_ECHO_LENGTH
+
+        "#{text[0, MAX_BOOL_ECHO_LENGTH].inspect} (truncated, #{text.length} chars)"
+      end
 
       # Masks a single email address string
       # @param raw [String] Raw email address to mask

--- a/lib/onetime/utils/strings.rb
+++ b/lib/onetime/utils/strings.rb
@@ -271,9 +271,7 @@ module Onetime
       # @raise [Onetime::ConfigError] if raw is present but not a recognized token
       def strict_bool!(name, raw, default:)
         # Normalize exactly once so the blank guard and the token tables can
-        # never disagree about what normalization means. NOTE: the message
-        # echoes raw into logs/Sentry — fine for boolean flags, do not reuse
-        # this for operator-sensitive values.
+        # never disagree about what normalization means.
         value = raw.to_s.strip.downcase
         return default if value.empty?
         return true    if TRUTHY_VALUES.include?(value)

--- a/lib/onetime/utils/strings.rb
+++ b/lib/onetime/utils/strings.rb
@@ -2,6 +2,7 @@
 #
 # frozen_string_literal: true
 
+require 'digest'
 require 'mail'
 require 'public_suffix'
 
@@ -50,10 +51,11 @@ module Onetime
         TRUTHY_VALUES = %w[1 true yes on y t].freeze
         FALSEY_VALUES = %w[0 false no off n f].freeze
 
-        # Longest rejected value strict_bool! will echo verbatim in its error
-        # message. Comfortably longer than every recognized token, short
-        # enough that a misrouted secret is not reproduced in full.
-        MAX_BOOL_ECHO_LENGTH = 32
+        # Hex characters of SHA-256 that strict_bool!'s error message carries
+        # as a correlation tag for the rejected value. Long enough that two
+        # different typos do not collide in practice, short enough to stay a
+        # tag rather than a fingerprint of the value itself.
+        BOOL_DIGEST_LENGTH = 8
       end
 
       # Generates a random string of specified length using predefined
@@ -269,6 +271,26 @@ module Onetime
       # documented default; a typo raises instead of silently landing on
       # false, which would disable a default-ON control.
       #
+      # The rejected value is never reproduced in the message. This method is
+      # public, so a future caller can hand it anything an operator put in an
+      # env var — including a value misrouted from a credential — and the
+      # message lands in logs, a boot trace, and Sentry's issue title, where
+      # by-param-name scrubbing cannot reach a string that was interpolated
+      # into the exception itself. Suppression therefore has to happen here,
+      # at the raise. Echoing a truncated head is not a fix: secrets are
+      # usually shorter than any sane cap, so truncation bounds volume, not
+      # sensitivity.
+      #
+      # What the message carries instead: the flag name (the actionable part —
+      # the operator knows where they set it), the character count, and a
+      # truncated SHA-256 of the normalized value. The digest is not
+      # reversible for a high-entropy value, is deterministic so two hosts
+      # with the same typo produce the same tag, and can be recomputed locally
+      # to confirm which value a log line refers to. Honest caveat: 8 hex
+      # characters of a low-entropy value like "ture" is brute-forceable —
+      # which is fine, because low-entropy values are exactly the case that
+      # was never sensitive.
+      #
       # @param name [String] Flag name, for the error message (e.g. 'RABBITMQ_VERIFY_PEER')
       # @param raw [Object] Raw value as supplied
       # @param default [Boolean] Value to use when raw is unset/blank
@@ -283,26 +305,13 @@ module Onetime
         return false   if FALSEY_VALUES.include?(value)
 
         raise Onetime::ConfigError,
-          "#{name} is #{bool_echo(raw)} — unrecognized boolean. " \
+          "#{name} is set to an unrecognized boolean " \
+          "(#{value.length} chars, sha256:#{::Digest::SHA256.hexdigest(value)[0, BOOL_DIGEST_LENGTH]}). " \
           "Use one of #{TRUTHY_VALUES.join('/')} or #{FALSEY_VALUES.join('/')}, or leave unset."
       end
+      module_function :strict_bool!
 
       private
-
-      # Renders a rejected boolean token for the error message. The message
-      # reaches logs and Sentry, so cap the echo: every legitimate token is a
-      # handful of characters, and anything longer is a misrouted value (a
-      # credential, a URL, a whole config blob) that should not be reproduced
-      # in full. The head is kept — it is what an operator needs to recognize
-      # which value they mistyped.
-      # @param raw [Object] Value that failed the token tables
-      # @return [String] Quoted, length-capped rendering
-      def bool_echo(raw)
-        text = raw.to_s
-        return text.inspect if text.length <= MAX_BOOL_ECHO_LENGTH
-
-        "#{text[0, MAX_BOOL_ECHO_LENGTH].inspect} (truncated, #{text.length} chars)"
-      end
 
       # Masks a single email address string
       # @param raw [String] Raw email address to mask

--- a/spec/unit/onetime/initializers/setup_rabbitmq_spec.rb
+++ b/spec/unit/onetime/initializers/setup_rabbitmq_spec.rb
@@ -290,10 +290,40 @@ RSpec.describe Onetime::Initializers::SetupRabbitMQ do
 
   describe 'TLS configuration' do
     describe '.tls_options' do
+      # RABBITMQ_VERIFY_PEER is a default-ON security control. The ambient
+      # value (direnv may export one) would make these cases non-hermetic, so
+      # every example runs with the var removed and the original restored.
+      around do |example|
+        had_key  = ENV.key?('RABBITMQ_VERIFY_PEER')
+        original = ENV.fetch('RABBITMQ_VERIFY_PEER', nil)
+        ENV.delete('RABBITMQ_VERIFY_PEER')
+        example.run
+      ensure
+        had_key ? ENV['RABBITMQ_VERIFY_PEER'] = original : ENV.delete('RABBITMQ_VERIFY_PEER')
+      end
+
+      # Sets RABBITMQ_VERIFY_PEER for the duration of the block. The outer
+      # `around` owns save/restore, so this only has to clean up after itself.
+      def with_verify_peer(raw)
+        ENV['RABBITMQ_VERIFY_PEER'] = raw
+        yield
+      ensure
+        ENV.delete('RABBITMQ_VERIFY_PEER')
+      end
+
       context 'with amqp:// URL (non-TLS)' do
         it 'returns empty hash' do
           result = Onetime::Jobs::QueueConfig.tls_options('amqp://localhost')
           expect(result).to eq({})
+        end
+
+        # Deliberate: the early return happens before the flag is parsed, so a
+        # bad token on a plain amqp:// URL is never reached and never raises.
+        # No TLS session exists, so there is nothing to fail closed about.
+        it 'does not validate RABBITMQ_VERIFY_PEER at all' do
+          with_verify_peer('bogus') do
+            expect(Onetime::Jobs::QueueConfig.tls_options('amqp://x')).to eq({})
+          end
         end
       end
 
@@ -303,28 +333,45 @@ RSpec.describe Onetime::Initializers::SetupRabbitMQ do
           expect(result[:tls]).to be true
         end
 
-        it 'defaults to verify_peer: true' do
+        it 'defaults to verify_peer: true when unset' do
           result = Onetime::Jobs::QueueConfig.tls_options('amqps://localhost')
           expect(result[:verify_peer]).to be true
         end
 
-        context 'with RABBITMQ_VERIFY_PEER=false' do
-          around do |example|
-            original = ENV['RABBITMQ_VERIFY_PEER']
-            ENV['RABBITMQ_VERIFY_PEER'] = 'false'
-            example.run
-            ENV['RABBITMQ_VERIFY_PEER'] = original
+        # Regression guard for the old `== 'true'` comparison, which failed
+        # OPEN: every spelling below except the plain lowercase one silently
+        # disabled AMQPS certificate verification. AMQP payloads carry secret
+        # retrieval keys, so an unverified session is a real exposure.
+        ['true', 'TRUE', ' True ', '1', 'yes', ''].each do |raw|
+          it "keeps peer verification on for #{raw.inspect}" do
+            with_verify_peer(raw) do
+              result = Onetime::Jobs::QueueConfig.tls_options('amqps://localhost')
+              expect(result[:verify_peer]).to be true
+            end
           end
+        end
 
-          it 'disables peer verification' do
-            result = Onetime::Jobs::QueueConfig.tls_options('amqps://localhost')
-            expect(result[:verify_peer]).to be false
+        # One representative token per falsey spelling; the full vocabulary is
+        # covered by spec/unit/onetime/utils/strings_spec.rb.
+        %w[false no 0].each do |raw|
+          it "disables peer verification for #{raw.inspect}" do
+            with_verify_peer(raw) do
+              result = Onetime::Jobs::QueueConfig.tls_options('amqps://localhost')
+              expect(result[:verify_peer]).to be false
+            end
+          end
+        end
+
+        it 'raises rather than guessing on an unrecognized token' do
+          with_verify_peer('bogus') do
+            expect { Onetime::Jobs::QueueConfig.tls_options('amqps://localhost') }
+              .to raise_error(Onetime::ConfigError, /RABBITMQ_VERIFY_PEER.*"bogus"/)
           end
         end
 
         context 'with RABBITMQ_CA_CERTIFICATES set' do
           around do |example|
-            original = ENV['RABBITMQ_CA_CERTIFICATES']
+            original                        = ENV.fetch('RABBITMQ_CA_CERTIFICATES', nil)
             ENV['RABBITMQ_CA_CERTIFICATES'] = '/path/to/ca.pem'
             example.run
             ENV['RABBITMQ_CA_CERTIFICATES'] = original

--- a/spec/unit/onetime/initializers/setup_rabbitmq_spec.rb
+++ b/spec/unit/onetime/initializers/setup_rabbitmq_spec.rb
@@ -362,10 +362,22 @@ RSpec.describe Onetime::Initializers::SetupRabbitMQ do
           end
         end
 
+        # The message names the flag but never reproduces the rejected value —
+        # this method reads an env var, so a misrouted credential must not
+        # reach the boot log or Sentry (ADR-037). The value-quoting assertion
+        # this replaced is retired; the non-disclosure contract is pinned in
+        # spec/unit/onetime/utils/strings_spec.rb.
         it 'raises rather than guessing on an unrecognized token' do
           with_verify_peer('bogus') do
             expect { Onetime::Jobs::QueueConfig.tls_options('amqps://localhost') }
-              .to raise_error(Onetime::ConfigError, /RABBITMQ_VERIFY_PEER.*"bogus"/)
+              .to raise_error(Onetime::ConfigError, /RABBITMQ_VERIFY_PEER/)
+          end
+        end
+
+        it 'does not echo the rejected value into the boot log' do
+          with_verify_peer('bogus') do
+            expect { Onetime::Jobs::QueueConfig.tls_options('amqps://localhost') }
+              .to raise_error(Onetime::ConfigError) { |e| expect(e.message).not_to include('bogus') }
           end
         end
 

--- a/spec/unit/onetime/utils/strings_spec.rb
+++ b/spec/unit/onetime/utils/strings_spec.rb
@@ -1,0 +1,124 @@
+# spec/unit/onetime/utils/strings_spec.rb
+#
+# frozen_string_literal: true
+
+# Boolean-token parsing for operator-supplied flags.
+#
+# Why this exists: lib/onetime/jobs/queues/config.rb read
+# `ENV.fetch('RABBITMQ_VERIFY_PEER', 'true') == 'true'`, so every spelling
+# other than the literal `true` — TRUE, 1, yes, " true ", or the typo
+# `ture` — silently DISABLED AMQPS certificate verification on a
+# default-ON control. Same bug class 508d018c fixed in billing with
+# BillingConfig#strict_bool!; the case-table style here mirrors
+# apps/web/billing/spec/lib/billing_config_automatic_tax_spec.rb.
+#
+# The load-bearing distinction, and the reason explicit_no? is not
+# `!explicit_yes?`: these are RECOGNIZERS, not a partition. Unrecognized
+# input is neither yes nor no, which is what lets strict_bool! raise
+# instead of landing a typo on false (ADR-033: fail fast and loud).
+#
+# Run with:
+#   AUTHENTICATION_MODE=simple bundle exec rspec spec/unit/onetime/utils/strings_spec.rb
+
+require 'spec_helper'
+
+RSpec.describe Onetime::Utils::Strings do
+  # Methods are mixed in via `extend Strings` in lib/onetime/utils.rb; the
+  # module-function surface is what every call site actually uses.
+  subject(:utils) { Onetime::Utils }
+
+  describe '#explicit_yes? / #explicit_no?' do
+    described_class::TRUTHY_VALUES.each do |token|
+      it "recognizes #{token.inspect} as yes, not no" do
+        expect(utils.explicit_yes?(token)).to be(true)
+        expect(utils.explicit_no?(token)).to be(false)
+      end
+    end
+
+    described_class::FALSEY_VALUES.each do |token|
+      it "recognizes #{token.inspect} as no, not yes" do
+        expect(utils.explicit_no?(token)).to be(true)
+        expect(utils.explicit_yes?(token)).to be(false)
+      end
+    end
+
+    it 'is case-insensitive' do
+      expect(utils.explicit_yes?('TRUE')).to be(true)
+      expect(utils.explicit_no?('Off')).to be(true)
+    end
+
+    # Regression guard: the pre-rename yes? did not strip, so a trailing
+    # newline out of a .env file or a padded compose value read as unset.
+    it 'tolerates surrounding whitespace' do
+      expect(utils.explicit_yes?(' true ')).to be(true)
+      expect(utils.explicit_yes?("1\n")).to be(true)
+      expect(utils.explicit_no?("\tfalse ")).to be(true)
+    end
+
+    it 'treats nil and blank as neither yes nor no' do
+      [nil, '', '   '].each do |blank|
+        expect(utils.explicit_yes?(blank)).to be(false), "explicit_yes?(#{blank.inspect})"
+        expect(utils.explicit_no?(blank)).to be(false), "explicit_no?(#{blank.inspect})"
+      end
+    end
+
+    # THE CENTRAL INVARIANT. If explicit_no? were `!explicit_yes?`, a typo
+    # would resolve to "no" — which on RABBITMQ_VERIFY_PEER means peer
+    # verification off, silently.
+    it 'is a recognizer, not a partition: unrecognized input is neither yes nor no' do
+      %w[ture flase enabled maybe 2].each do |garbage|
+        expect(utils.explicit_yes?(garbage)).to be(false), "explicit_yes?(#{garbage.inspect})"
+        expect(utils.explicit_no?(garbage)).to be(false), "explicit_no?(#{garbage.inspect})"
+      end
+    end
+
+    # The alias carries ~10 existing call sites; removing it is a silent
+    # NoMethodError at boot.
+    it 'keeps yes? as an alias of explicit_yes?' do
+      expect(utils.method(:yes?)).to eq(utils.method(:explicit_yes?))
+      expect(utils.yes?('yes')).to be(true)
+      expect(utils.yes?('ture')).to be(false)
+    end
+  end
+
+  describe '#strict_bool!' do
+    # Unset takes the caller's documented default — including the
+    # security-relevant default-ON case.
+    [true, false].each do |default|
+      [nil, '', '   ', "\n"].each do |blank|
+        it "resolves #{blank.inspect} to the caller's default (#{default})" do
+          expect(utils.strict_bool!('RABBITMQ_VERIFY_PEER', blank, default: default)).to be(default)
+        end
+      end
+
+      described_class::TRUTHY_VALUES.each do |token|
+        it "resolves #{token.inspect} to true regardless of default (#{default})" do
+          expect(utils.strict_bool!('FLAG', token, default: default)).to be(true)
+        end
+      end
+
+      described_class::FALSEY_VALUES.each do |token|
+        it "resolves #{token.inspect} to false regardless of default (#{default})" do
+          expect(utils.strict_bool!('FLAG', token, default: default)).to be(false)
+        end
+      end
+    end
+
+    it 'accepts padded and mixed-case tokens' do
+      expect(utils.strict_bool!('FLAG', ' TRUE ', default: false)).to be(true)
+      expect(utils.strict_bool!('FLAG', "Off\n", default: true)).to be(false)
+    end
+
+    %w[ture flase enabled maybe 2].each do |garbage|
+      it "raises ConfigError on #{garbage.inspect} instead of falling back to the default" do
+        expect { utils.strict_bool!('RABBITMQ_VERIFY_PEER', garbage, default: true) }
+          .to raise_error(Onetime::ConfigError)
+      end
+    end
+
+    it 'names the flag and quotes the offending value in the message' do
+      expect { utils.strict_bool!('RABBITMQ_VERIFY_PEER', 'ture', default: true) }
+        .to raise_error(Onetime::ConfigError, /RABBITMQ_VERIFY_PEER.*"ture"/)
+    end
+  end
+end

--- a/spec/unit/onetime/utils/strings_spec.rb
+++ b/spec/unit/onetime/utils/strings_spec.rb
@@ -8,15 +8,10 @@
 # `ENV.fetch('RABBITMQ_VERIFY_PEER', 'true') == 'true'`, so every spelling
 # other than the literal `true` — TRUE, 1, yes, " true ", or the typo
 # `ture` — silently DISABLED AMQPS certificate verification on a
-# default-ON control. Same bug class 508d018c fixed in billing with a
-# private BillingConfig#strict_bool! (since replaced by this shared
-# helper); the case-table style here mirrors
-# apps/web/billing/spec/lib/billing_config_automatic_tax_spec.rb.
-#
-# The load-bearing distinction, and the reason explicit_no? is not
-# `!explicit_yes?`: these are RECOGNIZERS, not a partition. Unrecognized
-# input is neither yes nor no, which is what lets strict_bool! raise
-# instead of landing a typo on false (ADR-033: fail fast and loud).
+# default-ON control. The load-bearing distinction, and the reason
+# explicit_no? is not `!explicit_yes?`: these are RECOGNIZERS, not a
+# partition. Unrecognized input is neither yes nor no, so the configuration
+# resolver can fail loudly rather than landing a typo on false (ADR-033).
 #
 # Run with:
 #   AUTHENTICATION_MODE=simple bundle exec rspec spec/unit/onetime/utils/strings_spec.rb
@@ -82,44 +77,7 @@ RSpec.describe Onetime::Utils::Strings do
     end
   end
 
-  describe '#strict_bool!' do
-    # Unset takes the caller's documented default — including the
-    # security-relevant default-ON case.
-    [true, false].each do |default|
-      [nil, '', '   ', "\n"].each do |blank|
-        it "resolves #{blank.inspect} to the caller's default (#{default})" do
-          expect(utils.strict_bool!('RABBITMQ_VERIFY_PEER', blank, default: default)).to be(default)
-        end
-      end
-
-      described_class::TRUTHY_VALUES.each do |token|
-        it "resolves #{token.inspect} to true regardless of default (#{default})" do
-          expect(utils.strict_bool!('FLAG', token, default: default)).to be(true)
-        end
-      end
-
-      described_class::FALSEY_VALUES.each do |token|
-        it "resolves #{token.inspect} to false regardless of default (#{default})" do
-          expect(utils.strict_bool!('FLAG', token, default: default)).to be(false)
-        end
-      end
-    end
-
-    it 'accepts padded and mixed-case tokens' do
-      expect(utils.strict_bool!('FLAG', ' TRUE ', default: false)).to be(true)
-      expect(utils.strict_bool!('FLAG', "Off\n", default: true)).to be(false)
-    end
-
-    %w[ture flase enabled maybe 2].each do |garbage|
-      it "raises ConfigError on #{garbage.inspect} instead of falling back to the default" do
-        expect { utils.strict_bool!('RABBITMQ_VERIFY_PEER', garbage, default: true) }
-          .to raise_error(Onetime::ConfigError)
-      end
-    end
-
-    it 'names the flag and quotes the offending value in the message' do
-      expect { utils.strict_bool!('RABBITMQ_VERIFY_PEER', 'ture', default: true) }
-        .to raise_error(Onetime::ConfigError, /RABBITMQ_VERIFY_PEER.*"ture"/)
-    end
+  it 'does not expose configuration resolution on the mixed-in utility surface' do
+    expect(utils).not_to respond_to(:strict_bool!)
   end
 end

--- a/spec/unit/onetime/utils/strings_spec.rb
+++ b/spec/unit/onetime/utils/strings_spec.rb
@@ -8,8 +8,9 @@
 # `ENV.fetch('RABBITMQ_VERIFY_PEER', 'true') == 'true'`, so every spelling
 # other than the literal `true` — TRUE, 1, yes, " true ", or the typo
 # `ture` — silently DISABLED AMQPS certificate verification on a
-# default-ON control. Same bug class 508d018c fixed in billing with
-# BillingConfig#strict_bool!; the case-table style here mirrors
+# default-ON control. Same bug class 508d018c fixed in billing with a
+# private BillingConfig#strict_bool! (since replaced by this shared
+# helper); the case-table style here mirrors
 # apps/web/billing/spec/lib/billing_config_automatic_tax_spec.rb.
 #
 # The load-bearing distinction, and the reason explicit_no? is not

--- a/spec/unit/onetime/utils/strings_spec.rb
+++ b/spec/unit/onetime/utils/strings_spec.rb
@@ -13,6 +13,17 @@
 # partition. Unrecognized input is neither yes nor no, so the configuration
 # resolver can fail loudly rather than landing a typo on false (ADR-033).
 #
+# The second contract this file pins is the shape of the raise. strict_bool!
+# is public, so a future caller can hand it whatever an operator put in an
+# env var — including a value misrouted from a credential — and the message
+# lands in logs, a boot trace, and Sentry's issue title, where by-param-name
+# scrubbing cannot reach a string interpolated into the exception itself.
+# So the message NEVER reproduces the rejected value: not verbatim, not
+# lowercased, not truncated. It carries the flag name (the actionable part),
+# the character count, a truncated SHA-256 correlation tag, and the token
+# vocabularies. See ADR-037 and the non-disclosure sweep below, which is the
+# load-bearing test in this file.
+#
 # Run with:
 #   AUTHENTICATION_MODE=simple bundle exec rspec spec/unit/onetime/utils/strings_spec.rb
 
@@ -77,7 +88,177 @@ RSpec.describe Onetime::Utils::Strings do
     end
   end
 
-  it 'does not expose configuration resolution on the mixed-in utility surface' do
-    expect(utils).not_to respond_to(:strict_bool!)
+  describe '.strict_bool!' do
+    # Module function, not a mixed-in instance method: every call site says
+    # Onetime::Utils::Strings.strict_bool! explicitly. The surface assertion
+    # at the bottom of this block pins that.
+
+    # Unset takes the caller's documented default — including the
+    # security-relevant default-ON case.
+    [true, false].each do |default|
+      [nil, '', '   ', "\n"].each do |blank|
+        it "resolves #{blank.inspect} to the caller's default (#{default})" do
+          expect(described_class.strict_bool!('RABBITMQ_VERIFY_PEER', blank, default: default)).to be(default)
+        end
+      end
+
+      described_class::TRUTHY_VALUES.each do |token|
+        it "resolves #{token.inspect} to true regardless of default (#{default})" do
+          expect(described_class.strict_bool!('FLAG', token, default: default)).to be(true)
+        end
+      end
+
+      described_class::FALSEY_VALUES.each do |token|
+        it "resolves #{token.inspect} to false regardless of default (#{default})" do
+          expect(described_class.strict_bool!('FLAG', token, default: default)).to be(false)
+        end
+      end
+    end
+
+    it 'accepts padded and mixed-case tokens' do
+      expect(described_class.strict_bool!('FLAG', ' TRUE ', default: false)).to be(true)
+      expect(described_class.strict_bool!('FLAG', "Off\n", default: true)).to be(false)
+    end
+
+    %w[ture flase enabled maybe 2].each do |garbage|
+      it "raises ConfigError on #{garbage.inspect} instead of falling back to the default" do
+        expect { described_class.strict_bool!('RABBITMQ_VERIFY_PEER', garbage, default: true) }
+          .to raise_error(Onetime::ConfigError)
+      end
+    end
+
+    describe 'the shape of the raise' do
+      # Replaces a retired assertion that required the message to quote the
+      # offending value (/RABBITMQ_VERIFY_PEER.*"ture"/). That contract was
+      # the defect: see the non-disclosure sweep below and ADR-037.
+      it 'names the flag and both token vocabularies, so the operator can act' do
+        expect { described_class.strict_bool!('RABBITMQ_VERIFY_PEER', 'ture', default: true) }
+          .to raise_error(Onetime::ConfigError, /RABBITMQ_VERIFY_PEER/)
+        expect { described_class.strict_bool!('RABBITMQ_VERIFY_PEER', 'ture', default: true) }
+          .to raise_error(Onetime::ConfigError, %r{1/true/yes/on/y/t.*0/false/no/off/n/f}m)
+      end
+
+      it 'reports the character count of the normalized value' do
+        expect { described_class.strict_bool!('FLAG', '  MayBe  ', default: true) }
+          .to raise_error(Onetime::ConfigError, /\(5 chars,/)
+      end
+
+      it 'carries a truncated SHA-256 of the normalized value as a correlation tag' do
+        expected = Digest::SHA256.hexdigest('ture')[0, described_class::BOOL_DIGEST_LENGTH]
+
+        expect { described_class.strict_bool!('FLAG', 'ture', default: true) }
+          .to raise_error(Onetime::ConfigError, /sha256:#{expected}\b/)
+      end
+
+      # Normalization happens once, before both the token tables and the tag,
+      # so the same mistyped value tags identically however it was padded or
+      # cased. That is what makes the tag usable to compare two hosts.
+      it 'tags the normalized form, so padding and case do not change the tag' do
+        tags = ['ture', ' TURE ', "Ture\n"].map do |raw|
+          described_class.strict_bool!('FLAG', raw, default: true)
+        rescue Onetime::ConfigError => e
+          e.message[/sha256:(\h+)/, 1]
+        end
+
+        expect(tags.uniq.length).to eq(1)
+        expect(tags.first).to eq(Digest::SHA256.hexdigest('ture')[0, described_class::BOOL_DIGEST_LENGTH])
+      end
+
+      it 'tags the value, not the flag name: two flags with one typo correlate' do
+        tag = lambda do |name|
+          described_class.strict_bool!(name, 'ture', default: true)
+        rescue Onetime::ConfigError => e
+          e.message[/sha256:(\h+)/, 1]
+        end
+
+        expect(tag.call('RABBITMQ_VERIFY_PEER')).to eq(tag.call('BILLING_ENABLED'))
+      end
+
+      # Pins the truncation length. A future widening toward a full hash would
+      # stop being a tag and start being a fingerprint of a short secret.
+      it 'truncates the digest to BOOL_DIGEST_LENGTH hex characters' do
+        expect(described_class::BOOL_DIGEST_LENGTH).to eq(8)
+
+        expect { described_class.strict_bool!('FLAG', 'ture', default: true) }
+          .to raise_error(Onetime::ConfigError, /sha256:\h{#{described_class::BOOL_DIGEST_LENGTH}}(?!\h)/)
+      end
+    end
+
+    # THE LOAD-BEARING TEST. strict_bool! is public, so a future caller may
+    # hand it a value misrouted from a credential; the message reaches logs
+    # and Sentry's issue title, where by-param-name scrubbing cannot reach a
+    # string interpolated into the exception. Nothing derived from the value's
+    # CONTENT may appear — a truncated head is not a fix, because most secrets
+    # are shorter than any workable cap.
+    #
+    # Fixtures are chosen not to collide incidentally with the fixed message
+    # text ("unrecognized boolean", "chars", "sha256", "leave unset", and the
+    # two token lists), and to contain no long hex runs that could collide
+    # with the digest tag.
+    describe 'non-disclosure of the rejected value' do
+      {
+        'a short secret, well under any plausible truncation cap' => 'hunter2',
+        'a numeric PIN' => '4813',
+        'a long API-key-shaped value' => "sk_live_#{'z' * 64}",
+        'a URL with inline credentials' => 'https://packrat:swordfish@internal.example/path',
+        'a mixed-case value, proving the downcased form does not leak either' => 'MyPaSsWord',
+        'a whole config blob with newlines' => "amqp_password: swordfish\napi_token: zzzz-9999",
+      }.each do |label, secret|
+        it "does not reproduce #{label}" do
+          message = begin
+            described_class.strict_bool!('RABBITMQ_VERIFY_PEER', secret, default: true)
+            raise 'expected strict_bool! to raise'
+          rescue Onetime::ConfigError => e
+            e.message
+          end
+
+          normalized = secret.strip.downcase
+
+          expect(message).not_to include(secret)
+          expect(message).not_to include(normalized)
+
+          # No prefix, suffix, or interior run of the value survives either.
+          # Four characters is short enough to catch a truncated head and long
+          # enough that ordinary English overlap does not fire.
+          leaked = (0..(normalized.length - 4)).map { |i| normalized[i, 4] }.select do |run|
+            message.include?(run)
+          end
+          expect(leaked).to be_empty, "message leaked substrings #{leaked.inspect}: #{message}"
+        end
+      end
+
+      # The message is the whole exposure surface — ConfigError carries no
+      # other attribute — so pin that the renderings which actually reach a
+      # log or a Sentry title are clean too.
+      it 'leaks nothing through inspect or full_message either' do
+        secret = 'hunter2'
+        error = begin
+          described_class.strict_bool!('RABBITMQ_VERIFY_PEER', secret, default: true)
+          raise 'expected strict_bool! to raise'
+        rescue Onetime::ConfigError => e
+          e
+        end
+
+        expect(error.inspect).not_to include(secret)
+        expect(error.full_message(highlight: false, order: :top)).not_to include(secret)
+      end
+
+      # Pins the REJECTED approach so it cannot be reintroduced quietly: an
+      # earlier fix echoed a 32-character truncated head via a private
+      # bool_echo/MAX_BOOL_ECHO_LENGTH pair.
+      it 'has no value-echoing helper left behind' do
+        expect(described_class.private_instance_methods).not_to include(:bool_echo)
+        expect(described_class.respond_to?(:bool_echo, true)).to be(false)
+        expect(defined?(described_class::MAX_BOOL_ECHO_LENGTH)).to be_nil
+      end
+    end
+
+    # Exposed as a module function only. Onetime::Utils does `extend Strings`,
+    # so a public instance copy would silently re-add Onetime::Utils
+    # .strict_bool! and let call sites drift back to the shorter name.
+    it 'is not exposed on the mixed-in utility surface' do
+      expect(utils).not_to respond_to(:strict_bool!)
+      expect(described_class).to respond_to(:strict_bool!)
+    end
   end
 end


### PR DESCRIPTION
Adds `Onetime::Utils.strict_bool!` (ADR-037): a shared coercion for operator-supplied booleans that accepts the full `TRUTHY_VALUES`/`FALSEY_VALUES` vocabulary, treats blank/unset as "use the documented default", and raises `Onetime::ConfigError` on anything unrecognized rather than silently landing on `false`. Billing (`BILLING_ENABLED`, `STRIPE_AUTOMATIC_TAX`) is migrated onto it.

The security fix is the last commit. `tls_options` coerced `RABBITMQ_VERIFY_PEER` with `ENV.fetch(..., 'true') == 'true'`, so every spelling other than the literal `true` — `TRUE`, `1`, `yes`, stray whitespace — silently disabled AMQPS certificate verification. An operator setting the variable to *enforce* verification got the opposite, with no warning and no boot error. AMQP payloads carry secret retrieval keys (`email_worker.rb:24-25`), so an unverified TLS session to a managed broker is a real exposure.

> [!NOTE]
> Under the old code `RABBITMQ_VERIFY_PEER=""` resolved to `false` — an accidental empty export silently disabled verification too. Blank now means unset and keeps verification on. Also note that a bad token only raises for `amqps://` URLs; the early return means plain `amqp://` deployments are unaffected, which the specs now assert deliberately.

Coverage: `strict_bool!` vocabulary and raise behavior in `spec/unit/onetime/utils/strings_spec.rb`; `tls_options` truthy/falsey/raise/non-TLS cases in `spec/unit/onetime/initializers/setup_rabbitmq_spec.rb` (116 examples, 0 failures).

Related to #4156