### PR TITLE
Require positive operator classification before inheriting global auth defaults

### DIFF
--- a/apps/api/account/logic/account/create_account.rb
+++ b/apps/api/account/logic/account/create_account.rb
@@ -221,6 +221,16 @@ module AccountAPI::Logic
         display_domain
       end
 
+      # Classification hook for SignupConfigResolution's read-failure path
+      # (#4157). Same value the controller gate uses — Logic::Base lifts it
+      # from the strategy result's metadata, which DomainStrategy populated —
+      # so autoverify resolution and the gate carve out the same operator
+      # hosts. Without this the mixin's fail-closed default (nil) would 503
+      # canonical sign-ups on any Redis blip during process_params.
+      def signup_config_domain_strategy
+        domain_strategy
+      end
+
       def signup_config_auth_setting(key)
         site.dig('authentication', key)
       end

--- a/apps/web/auth/error_translator.rb
+++ b/apps/web/auth/error_translator.rb
@@ -38,9 +38,13 @@ module Auth
       Onetime::GuestRoutesDisabled => 403,
       Onetime::Forbidden => 403,
       Onetime::Unauthorized => 401,
-      # The restrict_to gate could not READ this host's policy (#4139). 503,
-      # not the gate's usual 404: see Onetime::SigninPolicyUnavailable.
-      Onetime::SigninPolicyUnavailable => 503,
+      # An auth gate could not READ this host's policy (#4139/#4157). 503, not
+      # the gate's usual 404: see Onetime::AuthPolicyUnavailable. Registered on
+      # the FAMILY, not on SigninPolicyUnavailable alone — this table's lookup
+      # walks ancestors, so the sign-up sibling gets the same status without a
+      # second copy to keep in sync (otto_hooks cannot do that: Otto dispatches
+      # on the exact class name and needs one handler per subclass).
+      Onetime::AuthPolicyUnavailable => 503,
     }.freeze
 
     # Per-class log severity for translated exceptions. Mirrors the
@@ -58,7 +62,7 @@ module Auth
       Onetime::GuestRoutesDisabled => :info,
       Onetime::Forbidden => :warn,
       Onetime::Unauthorized => :warn,
-      Onetime::SigninPolicyUnavailable => :error,
+      Onetime::AuthPolicyUnavailable => :error,
     }.freeze
 
     DEFAULT_STATUS     = 500

--- a/apps/web/auth/restrict_to.rb
+++ b/apps/web/auth/restrict_to.rb
@@ -364,11 +364,19 @@ module Auth
       end
 
       # CustomDomain identifier for the request host, or nil.
+      #
+      # from_display_domain, NOT load_by_display_domain (#4157): the latter
+      # rescues Redis::BaseError internally and returns nil, which would make
+      # resolution_for's rescue unreachable for the FIRST of the three reads its
+      # comment names — a blip would resolve as "host has no tenant config" and
+      # inherit the operator's global restrict_to instead of failing closed.
+      #
+      # @raise [Redis::BaseError] handled by resolution_for
       def domain_id_for(env)
         display_domain = env['onetime.display_domain']
         return nil if display_domain.to_s.empty?
 
-        Onetime::CustomDomain.load_by_display_domain(display_domain)&.identifier
+        Onetime::CustomDomain.from_display_domain(display_domain)&.identifier
       end
 
       # The router's shared 404 — a gated route must be indistinguishable from

--- a/apps/web/auth/spec/unit/restrict_to_gate_spec.rb
+++ b/apps/web/auth/spec/unit/restrict_to_gate_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Auth::RestrictTo do
     let(:custom_domain) { instance_double(Onetime::CustomDomain, identifier: domain_id) }
 
     before do
-      allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+      allow(Onetime::CustomDomain).to receive(:from_display_domain)
         .with('tenant.example.com').and_return(custom_domain)
       allow(Onetime::CustomDomain::SigninConfig).to receive(:find_by_domain_id)
         .with(domain_id).and_return(nil)
@@ -223,7 +223,7 @@ RSpec.describe Auth::RestrictTo do
     end
 
     it 'fails closed when the classified custom host cannot be resolved' do
-      allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+      allow(Onetime::CustomDomain).to receive(:from_display_domain)
         .with('tenant.example.com').and_raise(Redis::BaseError, 'lookup unavailable')
 
       expect { described_class.resolution_for(custom_env) }
@@ -232,7 +232,7 @@ RSpec.describe Auth::RestrictTo do
 
     it 'fails closed when the classified custom host signin config lookup fails' do
       domain = instance_double(Onetime::CustomDomain, identifier: 'domain-4139')
-      allow(Onetime::CustomDomain).to receive(:load_by_display_domain).and_return(domain)
+      allow(Onetime::CustomDomain).to receive(:from_display_domain).and_return(domain)
       allow(Onetime::CustomDomain::SigninConfig).to receive(:find_by_domain_id)
         .with('domain-4139').and_raise(Redis::BaseError, 'config unavailable')
 
@@ -242,7 +242,7 @@ RSpec.describe Auth::RestrictTo do
 
     it 'fails closed on the SSO probe too — that read is on the hot path of every request' do
       domain = instance_double(Onetime::CustomDomain, identifier: 'domain-4139')
-      allow(Onetime::CustomDomain).to receive(:load_by_display_domain).and_return(domain)
+      allow(Onetime::CustomDomain).to receive(:from_display_domain).and_return(domain)
       allow(Onetime::CustomDomain::SigninConfig).to receive(:find_by_domain_id)
         .with('domain-4139').and_return(nil)
       allow(Onetime::CustomDomain::SsoConfig).to receive(:sso_available_for_tenant_host?)
@@ -253,7 +253,7 @@ RSpec.describe Auth::RestrictTo do
     end
 
     it 'logs the failure — an auth surface is down and it must alert' do
-      allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+      allow(Onetime::CustomDomain).to receive(:from_display_domain)
         .with('tenant.example.com').and_raise(Redis::BaseError, 'lookup unavailable')
 
       expect { described_class.resolution_for(custom_env) }
@@ -264,7 +264,7 @@ RSpec.describe Auth::RestrictTo do
     end
 
     it 'carries a retry_after so the edge can hint a back-off' do
-      allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+      allow(Onetime::CustomDomain).to receive(:from_display_domain)
         .with('tenant.example.com').and_raise(Redis::BaseError, 'lookup unavailable')
 
       expect { described_class.resolution_for(custom_env) }
@@ -282,7 +282,7 @@ RSpec.describe Auth::RestrictTo do
       before { allow(Onetime.auth_config).to receive(:restrict_to).and_return(nil) }
 
       it 'still fails closed — a blank global says nothing about this host' do
-        allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+        allow(Onetime::CustomDomain).to receive(:from_display_domain)
           .with('tenant.example.com').and_raise(Redis::BaseError, 'lookup unavailable')
 
         expect { described_class.resolution_for(custom_env) }
@@ -299,7 +299,7 @@ RSpec.describe Auth::RestrictTo do
         'onetime.display_domain' => 'tenant.example.com',
         'onetime.domain_strategy' => :invalid,
       }
-      allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+      allow(Onetime::CustomDomain).to receive(:from_display_domain)
         .with('tenant.example.com').and_raise(Redis::BaseError, 'lookup unavailable')
 
       expect { described_class.resolution_for(unclassified_env) }
@@ -311,7 +311,7 @@ RSpec.describe Auth::RestrictTo do
         'onetime.display_domain' => 'example.com',
         'onetime.domain_strategy' => :canonical,
       }
-      allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+      allow(Onetime::CustomDomain).to receive(:from_display_domain)
         .with('example.com').and_raise(Redis::BaseError, 'lookup unavailable')
       allow(Onetime.auth_config).to receive(:restrict_to).and_return('password')
       allow(Onetime::CustomDomain::SigninConfig).to receive(:global_restriction_available?)

--- a/apps/web/core/controllers/base.rb
+++ b/apps/web/core/controllers/base.rb
@@ -336,12 +336,20 @@ module Core
       # inherited global restriction is narrowed by the host's own capabilities
       # either way, and `config&.domain_id` is nil in exactly that case (#4139).
       # Memoized — two gates ask per request.
+      #
+      # Uses from_display_domain, NOT load_by_display_domain (#4157): the
+      # latter rescues Redis::BaseError (and a blanket StandardError) internally
+      # and returns nil, which made the rescue below dead code and let a
+      # datastore blip on a tenant host read as "no SigninConfig" → operator
+      # global default. That is the widen ADR-024 closes. This is also the
+      # lookup the sign-up half already uses, so both policy reads now resolve
+      # tenant identity through one non-swallowing path.
       def custom_domain_id
         return @custom_domain_id if defined?(@custom_domain_id)
 
         display_domain    = req.env['onetime.display_domain']
         @custom_domain_id = display_domain &&
-                            Onetime::CustomDomain.load_by_display_domain(display_domain)&.identifier
+                            Onetime::CustomDomain.from_display_domain(display_domain)&.identifier
       rescue Redis::BaseError => ex
         signin_policy_read_failed!(ex)
       end

--- a/apps/web/core/controllers/base.rb
+++ b/apps/web/core/controllers/base.rb
@@ -167,7 +167,9 @@ module Core
       #
       # The branch is chosen by SigninConfig.resolve_signin_enabled_for_request,
       # NOT by custom_domain_request?, so operator defaults require a positive
-      # :canonical/:subdomain classification (ADR-024 A12). domain_id is omitted:
+      # :canonical/:subdomain classification
+      # (ADR-024#operator-defaults-require-positive-classification). domain_id
+      # is omitted:
       # this is the password/email POST gate, which never inherits the display
       # SSO carve-out.
       def signin_enabled?
@@ -255,7 +257,8 @@ module Core
       # creation unless an enabled SignupConfig opts in, while canonical /
       # subdomain requests follow the global default. The global kill switch
       # (AUTH_ENABLED / AUTH_SIGNUP) always wins. Branch chosen positively by
-      # the request resolver, same rule as signin_enabled? (ADR-024 A12).
+      # the request resolver, same rule as signin_enabled?.
+      # ADR-024#operator-defaults-require-positive-classification
       #
       # UNREADABLE POLICY IS NOT "FOLLOW THE GLOBAL" (#4157). domain_signup_config
       # is two datastore reads (CustomDomain identity, then SignupConfig), so
@@ -286,7 +289,8 @@ module Core
       # auth defaults; custom domains must opt in. Mirrors
       # ConfigSerializer#tenant_domain?.
       #
-      # NO LONGER DECIDES AUTH POLARITY (ADR-024 A12). It used to pick the
+      # NO LONGER DECIDES AUTH POLARITY
+      # (ADR-024#identity-predicates-are-not-auth-gates). It used to pick the
       # branch for signin_enabled? and signup_enabled?, and its false branch is
       # wider than "not a custom domain": :invalid and nil land there too, and
       # :invalid is also what DomainStrategy answers when its

--- a/apps/web/core/controllers/base.rb
+++ b/apps/web/core/controllers/base.rb
@@ -164,13 +164,19 @@ module Core
       # AUTH_SIGNIN) always wins: a per-domain config can only narrow. SSO login
       # is unaffected — it runs through the omniauth routes, gated separately by
       # SsoConfig. Keep in lockstep with ConfigSerializer#resolve_signin.
+      #
+      # The branch is chosen by SigninConfig.resolve_signin_enabled_for_request,
+      # NOT by custom_domain_request?, so operator defaults require a positive
+      # :canonical/:subdomain classification (ADR-024 A12). domain_id is omitted:
+      # this is the password/email POST gate, which never inherits the display
+      # SSO carve-out.
       def signin_enabled?
         global = Onetime::CustomDomain::SigninConfig.global_signin_enabled(auth_settings)
-        if custom_domain_request?
-          Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_custom_domain(global, domain_signin_config)
-        else
-          Onetime::CustomDomain::SigninConfig.resolve_signin_enabled(global, domain_signin_config)
-        end
+        Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_request(
+          global,
+          domain_signin_config,
+          domain_strategy: req.env['onetime.domain_strategy'],
+        )
       end
 
       # Runtime gate for `restrict_to` on the SIMPLE-MODE auth routes
@@ -248,14 +254,28 @@ module Core
       # polarity as signin_enabled?: a custom domain never accepts account
       # creation unless an enabled SignupConfig opts in, while canonical /
       # subdomain requests follow the global default. The global kill switch
-      # (AUTH_ENABLED / AUTH_SIGNUP) always wins.
+      # (AUTH_ENABLED / AUTH_SIGNUP) always wins. Branch chosen positively by
+      # the request resolver, same rule as signin_enabled? (ADR-024 A12).
+      #
+      # UNREADABLE POLICY IS NOT "FOLLOW THE GLOBAL" (#4157). domain_signup_config
+      # is two datastore reads (CustomDomain identity, then SignupConfig), so
+      # this gate can fail to learn whether the tenant opted in. Both reads are
+      # guarded inside Onetime::Logic::SignupConfigResolution, which fails
+      # closed via SignupConfig.resolve_lookup_failure — Onetime::SignupPolicyUnavailable
+      # → 503 on any host not positively an operator host, nil (the only answer
+      # such a host could have had) on canonical/subdomain. Before that, a blip
+      # produced an unhandled 500 here at best and, on the :invalid
+      # misclassification the same blip causes, the operator's global sign-up
+      # default at worst. Mirrors signin_policy_read_failed! exactly.
+      #
+      # @raise [Onetime::SignupPolicyUnavailable] on an unreadable custom-host policy
       def signup_enabled?
         global = Onetime::CustomDomain::SignupConfig.global_signup_enabled(auth_settings)
-        if custom_domain_request?
-          Onetime::CustomDomain::SignupConfig.resolve_signup_enabled_for_custom_domain(global, domain_signup_config)
-        else
-          Onetime::CustomDomain::SignupConfig.resolve_signup_enabled(global, domain_signup_config)
-        end
+        Onetime::CustomDomain::SignupConfig.resolve_signup_enabled_for_request(
+          global,
+          domain_signup_config,
+          domain_strategy: req.env['onetime.domain_strategy'],
+        )
       end
 
       private
@@ -266,21 +286,20 @@ module Core
       # auth defaults; custom domains must opt in. Mirrors
       # ConfigSerializer#tenant_domain?.
       #
-      # THIS ONE LINE DECIDES THE POLARITY OF signin_enabled? AND
-      # signup_enabled?, and its false branch is wider than "not a custom
-      # domain": :invalid and nil land there too. :invalid is not only a
-      # malformed host — DomainStrategy also answers it when its
-      # `known_custom_domain?` datastore read RAISES, so a blip classifies a
-      # real customer domain :invalid and this method reports false for it.
-      # The cost is an inverted default: custom domains are default-OFF for
-      # sign-in and sign-up, canonical follows the global default, so such a
-      # request follows the operator's default instead of the domain's own.
-      # Unlike SigninConfig.operator_host?, this is NOT a positive test and
-      # deliberately stays that way — flipping it would deny branding and
-      # tenant treatment to genuinely unplaceable hosts. The fix belongs in the
-      # resolvers, not here (unresolved — no ADR entry covers this asymmetry
-      # yet). See
-      # Onetime::Middleware::DomainStrategy's class doc for the full table.
+      # NO LONGER DECIDES AUTH POLARITY (ADR-024 A12). It used to pick the
+      # branch for signin_enabled? and signup_enabled?, and its false branch is
+      # wider than "not a custom domain": :invalid and nil land there too, and
+      # :invalid is also what DomainStrategy answers when its
+      # `known_custom_domain?` datastore read RAISES — so a blip handed a real
+      # customer domain the operator's global auth default. Those two gates now
+      # ask SigninConfig.operator_host? through the request resolvers, which
+      # require POSITIVE evidence of an operator host.
+      #
+      # This predicate stays a `== :custom` identity test and is NOT flipped:
+      # its remaining consumers govern branding, tenant treatment and the
+      # restrict_to custom-host narrowing, none of which a genuinely unplaceable
+      # host should receive. See Onetime::Middleware::DomainStrategy's class doc
+      # for the full consumer table.
       def custom_domain_request?
         req.env['onetime.domain_strategy'] == :custom
       end
@@ -291,6 +310,15 @@ module Core
 
       def signup_config_display_domain
         req.env['onetime.display_domain']
+      end
+
+      # Classification hook for Onetime::Logic::SignupConfigResolution's
+      # read-failure path (#4157), so an unreadable tenant sign-up policy fails
+      # closed on exactly the hosts the sign-in side fails closed on — the
+      # mixin's default is nil, which would 503 the canonical sign-up page
+      # during a blip that costs it nothing.
+      def signup_config_domain_strategy
+        req.env['onetime.domain_strategy']
       end
 
       def signup_config_auth_setting(key)

--- a/apps/web/core/spec/views/serializers/authentication_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/authentication_serializer_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Core::Views::AuthenticationSerializer do
 
       before do
         allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
-          .and_raise(StandardError, 'redis down')
+          .and_raise(Redis::ConnectionError, 'redis down')
       end
 
       it 'fails closed: an unresolvable domain policy does not advertise the affordance' do

--- a/apps/web/core/spec/views/serializers/config_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/config_serializer_spec.rb
@@ -1666,6 +1666,54 @@ RSpec.describe Core::Views::ConfigSerializer do
         expect(result).to be_nil
       end
     end
+
+    context 'when CustomDomain lookup fails (Redis error)' do
+      before do
+        allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+          .and_raise(Redis::ConnectionError.new('Connection refused'))
+      end
+
+      it 'returns DOMAIN_READ_FAILED sentinel (#4157)' do
+        vars = base_view_vars.merge(
+          'display_domain' => 'tenant.example.com'
+        )
+        result = described_class.resolve_domain_id(vars)
+        expect(result).to eq(described_class::DOMAIN_READ_FAILED)
+      end
+    end
+  end
+
+  describe 'tri-state domain resolution (#4157)' do
+    let(:custom_domain_view_vars) do
+      base_view_vars.merge(
+        'domain_strategy' => :custom,
+        'display_domain' => custom_display_domain,
+        'site' => { 'authentication' => { 'enabled' => true, 'signin' => true } },
+      )
+    end
+
+    before do
+      allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+        .and_raise(Redis::ConnectionError.new('Connection refused'))
+      allow(mock_auth_config).to receive(:email_auth_enabled?).and_return(true)
+      allow(mock_auth_config).to receive(:restrict_to).and_return(nil)
+    end
+
+    it 'resolve_signin returns false on read failure (narrowest surface)' do
+      result = described_class.resolve_signin(custom_domain_view_vars)
+      expect(result).to be(false)
+    end
+
+    it 'resolve_email_auth returns false on read failure' do
+      result = described_class.resolve_email_auth(custom_domain_view_vars)
+      expect(result).to be(false)
+    end
+
+    it 'restrict_to_resolution returns :unavailable on read failure' do
+      result = described_class.restrict_to_resolution(custom_domain_view_vars)
+      expect(result.unavailable?).to be(true)
+      expect(result.source).to eq(:domain_read_failed)
+    end
   end
 
   describe '.tenant_domain?' do

--- a/apps/web/core/spec/views/serializers/restrict_to_parity_spec.rb
+++ b/apps/web/core/spec/views/serializers/restrict_to_parity_spec.rb
@@ -105,7 +105,15 @@ RSpec.describe 'restrict_to display/gate parity' do
       { 'site' => { 'authentication' => { 'enabled' => true, 'signin' => true } } }
     )
 
+    # BOTH identity reads: the display half (ConfigSerializer) still uses the
+    # fail-open .load_by_display_domain, while the gate half (Auth::RestrictTo)
+    # reads through the non-swallowing .from_display_domain so a datastore blip
+    # can reach its 503 instead of resolving as "no tenant config" (#4157).
+    # Stubbing only one leaves the other reading a real (empty) datastore, which
+    # turns every assertion here into one about the unconfigured default.
     allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+      .with(display_domain).and_return(custom_domain)
+    allow(Onetime::CustomDomain).to receive(:from_display_domain)
       .with(display_domain).and_return(custom_domain)
     allow(Onetime::CustomDomain::SigninConfig).to receive(:find_by_domain_id)
       .with(domain_id).and_return(nil)
@@ -415,6 +423,8 @@ RSpec.describe 'restrict_to display/gate parity' do
 
     before do
       allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+        .with('example.com').and_return(nil)
+      allow(Onetime::CustomDomain).to receive(:from_display_domain)
         .with('example.com').and_return(nil)
       allow(mock_auth_config).to receive(:restrict_to).and_return('password')
     end

--- a/apps/web/core/spec/views/serializers/signin_signup_classification_parity_spec.rb
+++ b/apps/web/core/spec/views/serializers/signin_signup_classification_parity_spec.rb
@@ -1,0 +1,634 @@
+# apps/web/core/spec/views/serializers/signin_signup_classification_parity_spec.rb
+#
+# frozen_string_literal: true
+
+# DISPLAY <-> RUNTIME PARITY for the sign-in / sign-up DEFAULT, keyed by the
+# request's DomainStrategy classification (ADR-024 A12,
+# docs/specs/domain-resolution/domain-resolution.md).
+#
+# The defect this pins: choosing the auth resolver on `== :custom` picks the
+# OPERATOR branch for :invalid and nil, and :invalid is what DomainStrategy
+# answers when its own datastore read RAISES for a REAL customer domain. A blip
+# therefore handed that domain the operator's global sign-in/sign-up default —
+# an availability failure widening authentication access on a domain whose
+# owner never opted in. The fix is a POSITIVE test (SigninConfig.operator_host?)
+# at policy resolution, applied on BOTH surfaces:
+#
+#   runtime: Core::Controllers::Base#signin_enabled? / #signup_enabled?
+#   display: Core::Views::ConfigSerializer#resolve_signin
+#
+# Fixing only the runtime gate would leave /signin advertising availability
+# while the POST rejects it; fixing only the display would leave the widened
+# gate in place. So the matrix below asserts the VALUE per classification AND
+# that the two surfaces produce the same value.
+#
+# The identity predicates (custom_domain_request?, tenant_domain?) deliberately
+# stay `== :custom` and are pinned in
+# spec/unit/domain_strategy_classification_contract_spec.rb — flipping those
+# would hand tenant branding/routing to a genuinely unknown host, which the
+# spec text rejects.
+#
+# No datastore and no HTTP: the domain/config lookups are stubbed, because what
+# is under test is which BRANCH each surface takes and that the two agree.
+#
+# Run:
+#   bundle exec rspec apps/web/core/spec/views/serializers/signin_signup_classification_parity_spec.rb
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require_relative '../../../views/serializers'
+
+RSpec.describe 'sign-in/sign-up classification polarity (ADR-024 A12)' do
+  # Every value env['onetime.domain_strategy'] can carry at a consumer.
+  CLASSIFICATIONS_A12 = [:canonical, :subdomain, :custom, :invalid, nil].freeze
+
+  # The required test matrix from docs/specs/domain-resolution/domain-resolution.md,
+  # for global auth ENABLED and NO tenant configuration. Only the two
+  # classifications a datastore failure can never MANUFACTURE inherit the
+  # operator default.
+  EXPECTED_A12 = {
+    canonical: true,
+    subdomain: true,
+    custom: false,
+    invalid: false,
+    nil => false,
+  }.freeze
+
+  def expected_for(strategy)
+    EXPECTED_A12.fetch(strategy.nil? ? nil : strategy)
+  end
+
+  let(:display_domain) { 'secrets.tenant.example.com' }
+  let(:domain_id)      { 'domain_a12_1' }
+
+  let(:custom_domain) { instance_double(Onetime::CustomDomain, identifier: domain_id) }
+
+  # Global authentication: enabled for sign-in AND sign-up unless a context
+  # overrides it.
+  let(:auth_settings) { { 'enabled' => true, 'signin' => true, 'signup' => true } }
+
+  let(:signin_config) { nil }
+  let(:signup_config) { nil }
+  let(:sso_config)    { nil }
+
+  # SSO OFF by default so the display gate's SSO carve-out cannot mask the
+  # password/email default under test. The carve-out has its own section below.
+  let(:mock_auth_config) do
+    instance_double(
+      Onetime::AuthConfig,
+      sso_enabled?: false,
+      sso_providers: [],
+      allow_platform_fallback_for_tenants?: false,
+      email_auth_enabled?: false,
+      restrict_to: nil,
+      restrict_to_available?: true
+    )
+  end
+
+  before do
+    allow(Onetime).to receive(:auth_config).and_return(mock_auth_config)
+    allow(OT).to receive(:conf).and_return({ 'site' => { 'authentication' => auth_settings } })
+
+    allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+      .with(display_domain).and_return(custom_domain)
+    allow(Onetime::CustomDomain::SigninConfig).to receive(:find_by_domain_id)
+      .with(domain_id).and_return(signin_config)
+    allow(Onetime::CustomDomain::SignupConfig).to receive(:find_by_domain_id)
+      .with(domain_id).and_return(signup_config)
+    allow(Onetime::CustomDomain::SsoConfig).to receive(:find_by_domain_id)
+      .with(domain_id).and_return(sso_config)
+  end
+
+  # ---------------------------------------------------------------- surfaces
+
+  # The runtime gates, reached exactly as a request reaches them: through
+  # req.env['onetime.domain_strategy'].
+  let(:controller_class) do
+    Class.new do
+      include Core::Controllers::Base
+
+      def initialize(env)
+        @req = Struct.new(:env).new(env)
+      end
+    end
+  end
+
+  def controller_for(strategy)
+    controller_class.new(
+      'onetime.domain_strategy' => strategy,
+      'onetime.display_domain' => display_domain,
+    )
+  end
+
+  def runtime_signin(strategy)
+    controller_for(strategy).send(:signin_enabled?)
+  end
+
+  def runtime_signup(strategy)
+    controller_for(strategy).send(:signup_enabled?)
+  end
+
+  def view_vars_for(strategy)
+    {
+      'site' => { 'authentication' => auth_settings },
+      'domain_strategy' => strategy,
+      'display_domain' => display_domain,
+    }
+  end
+
+  # The display gate: features.signin in the bootstrap payload.
+  def display_signin(strategy)
+    Core::Views::ConfigSerializer.resolve_signin(view_vars_for(strategy))
+  end
+
+  # THE SIGN-UP DISPLAY SURFACE. There is no classification-keyed one:
+  # ConfigSerializer emits no features.signup, and the only serialized sign-up
+  # availability is DomainSerializer's branded-masthead link, which is keyed by
+  # domain_id and always resolves through the CUSTOM-DOMAIN (default-OFF)
+  # resolver. It is included here so the claim "display and runtime agree" is
+  # asserted rather than assumed: on every non-operator classification the
+  # masthead answer must equal the runtime gate's.
+  def display_signup_for_domain
+    Core::Views::DomainSerializer.effective_signup_enabled?(domain_id)
+  end
+
+  def display_signin_for_domain
+    Core::Views::DomainSerializer.effective_signin_enabled?(domain_id)
+  end
+
+  # ---------------------------------------------------- the required matrix
+
+  describe 'global auth ENABLED, no tenant configuration' do
+    CLASSIFICATIONS_A12.each do |strategy|
+      context "on #{strategy.inspect}" do
+        let(:expected) { EXPECTED_A12.fetch(strategy) }
+
+        it "resolves sign-in #{EXPECTED_A12.fetch(strategy) ? 'enabled' : 'disabled'} at the runtime gate" do
+          expect(runtime_signin(strategy)).to be(expected)
+        end
+
+        it "resolves sign-up #{EXPECTED_A12.fetch(strategy) ? 'enabled' : 'disabled'} at the runtime gate" do
+          expect(runtime_signup(strategy)).to be(expected)
+        end
+
+        it "resolves sign-in #{EXPECTED_A12.fetch(strategy) ? 'enabled' : 'disabled'} at the display gate" do
+          expect(display_signin(strategy)).to be(expected)
+        end
+
+        it 'agrees between display and runtime for sign-in' do
+          expect(display_signin(strategy)).to be(runtime_signin(strategy))
+        end
+      end
+    end
+
+    # The row the whole fix exists for, stated as the security property rather
+    # than as a table cell.
+    it ':invalid does NOT inherit the operator default — a blip cannot widen access' do
+      expect(runtime_signin(:invalid)).to be(false)
+      expect(runtime_signup(:invalid)).to be(false)
+      expect(display_signin(:invalid)).to be(false)
+
+      # ...while the operator's own host is untouched by the same rule.
+      expect(runtime_signin(:canonical)).to be(true)
+      expect(runtime_signup(:canonical)).to be(true)
+      expect(display_signin(:canonical)).to be(true)
+    end
+
+    it 'the branded sign-up display surface is default-OFF, matching every non-operator runtime answer' do
+      expect(display_signup_for_domain).to be(false)
+      expect(runtime_signup(:custom)).to be(false)
+      expect(runtime_signup(:invalid)).to be(false)
+      expect(runtime_signup(nil)).to be(false)
+    end
+  end
+
+  # --------------------------------------------------- global kill switch
+
+  describe 'global auth DISABLED' do
+    let(:auth_settings) { { 'enabled' => false, 'signin' => true, 'signup' => true } }
+
+    CLASSIFICATIONS_A12.each do |strategy|
+      it "stays disabled for #{strategy.inspect} on both surfaces" do
+        expect(runtime_signin(strategy)).to be(false)
+        expect(runtime_signup(strategy)).to be(false)
+        expect(display_signin(strategy)).to be(false)
+      end
+    end
+  end
+
+  describe 'AUTH_SIGNIN / AUTH_SIGNUP off with the master switch on' do
+    let(:auth_settings) { { 'enabled' => true, 'signin' => false, 'signup' => false } }
+
+    CLASSIFICATIONS_A12.each do |strategy|
+      it "stays disabled for #{strategy.inspect} on both surfaces" do
+        expect(runtime_signin(strategy)).to be(false)
+        expect(runtime_signup(strategy)).to be(false)
+        expect(display_signin(strategy)).to be(false)
+      end
+    end
+  end
+
+  # ------------------------------------------------ tenant config narrowing
+
+  describe 'an enabled tenant config can only NARROW' do
+    let(:signin_config) do
+      instance_double(
+        Onetime::CustomDomain::SigninConfig,
+        domain_id: domain_id,
+        enabled?: true,
+        signin_enabled?: signin_opt_in,
+        email_auth_enabled?: false,
+        sso_enabled?: false,
+        restrict_to: nil
+      )
+    end
+
+    let(:signup_config) do
+      instance_double(
+        Onetime::CustomDomain::SignupConfig,
+        domain_id: domain_id,
+        enabled?: true,
+        signup_enabled?: signup_opt_in
+      )
+    end
+
+    context 'when the tenant turns sign-in/sign-up OFF' do
+      let(:signin_opt_in) { false }
+      let(:signup_opt_in) { false }
+
+      CLASSIFICATIONS_A12.each do |strategy|
+        it "narrows #{strategy.inspect} to disabled, INCLUDING the operator's own host" do
+          expect(runtime_signin(strategy)).to be(false)
+          expect(runtime_signup(strategy)).to be(false)
+          expect(display_signin(strategy)).to be(false)
+        end
+      end
+    end
+
+    context 'when the tenant turns sign-in/sign-up ON but the install has it off' do
+      let(:signin_opt_in)  { true }
+      let(:signup_opt_in)  { true }
+      let(:auth_settings)  { { 'enabled' => true, 'signin' => false, 'signup' => false } }
+
+      CLASSIFICATIONS_A12.each do |strategy|
+        it "cannot widen #{strategy.inspect} back to enabled" do
+          expect(runtime_signin(strategy)).to be(false)
+          expect(runtime_signup(strategy)).to be(false)
+          expect(display_signin(strategy)).to be(false)
+        end
+      end
+    end
+
+    # THE COUNTERWEIGHT to the fail-closed rule: it must not make explicit
+    # enablement unreachable. A host misclassified :invalid whose tenant config
+    # WAS read successfully still follows that tenant's own policy.
+    context 'when the tenant explicitly ENABLES and the config read succeeded' do
+      let(:signin_opt_in) { true }
+      let(:signup_opt_in) { true }
+
+      it ':invalid follows the tenant policy — enabled, not default-OFF' do
+        expect(runtime_signin(:invalid)).to be(true)
+        expect(runtime_signup(:invalid)).to be(true)
+        expect(display_signin(:invalid)).to be(true)
+      end
+
+      it ':custom follows it identically — the two are not distinguished once a config is readable' do
+        expect(runtime_signin(:custom)).to be(true)
+        expect(runtime_signup(:custom)).to be(true)
+        expect(display_signin(:custom)).to be(true)
+      end
+
+      it 'nil follows it too' do
+        expect(runtime_signin(nil)).to be(true)
+        expect(runtime_signup(nil)).to be(true)
+      end
+
+      it 'the branded masthead surfaces agree' do
+        expect(display_signup_for_domain).to be(true)
+        expect(display_signin_for_domain).to be(true)
+      end
+    end
+  end
+
+  # --------------------------------------------------- String classifications
+
+  # StrategyResult metadata is not always a Symbol; operator_host? normalizes
+  # with to_sym, so the string forms must resolve identically.
+  describe 'String classifications' do
+    it "'canonical' behaves like :canonical" do
+      expect(runtime_signin('canonical')).to be(runtime_signin(:canonical))
+      expect(runtime_signup('canonical')).to be(runtime_signup(:canonical))
+      expect(runtime_signin('canonical')).to be(true)
+    end
+
+    it "'subdomain' behaves like :subdomain" do
+      expect(runtime_signin('subdomain')).to be(true)
+      expect(runtime_signup('subdomain')).to be(true)
+    end
+
+    it "'custom' behaves like :custom" do
+      expect(runtime_signin('custom')).to be(false)
+      expect(runtime_signup('custom')).to be(false)
+    end
+
+    it "'invalid' behaves like :invalid" do
+      expect(runtime_signin('invalid')).to be(false)
+      expect(runtime_signup('invalid')).to be(false)
+    end
+
+    it 'the display gate normalizes the same way' do
+      expect(display_signin('canonical')).to be(true)
+      expect(display_signin('custom')).to be(false)
+      expect(display_signin('invalid')).to be(false)
+    end
+  end
+
+  # ------------------------------------------------------- SSO distinction
+
+  # Spec refinement 3: resolve_signin_enabled_for_custom_domain has two modes,
+  # and the classification-aware change must not collapse them.
+  #
+  #   display gate  (domain_id passed): an SSO-only tenant reports AVAILABLE —
+  #     its /signin page works through the omniauth routes.
+  #   POST gate     (domain_id omitted): strictly disabled — SSO never flows
+  #     through POST /signin, so the password/email handler stays closed.
+  #
+  # The asymmetry must hold for :invalid exactly as for :custom: a
+  # misclassified SSO-only tenant must not lose its working sign-in link.
+  describe 'sign-in SSO carve-out' do
+    let(:global) { Onetime::CustomDomain::SigninConfig.global_signin_enabled(auth_settings) }
+
+    before do
+      allow(Onetime::CustomDomain::SsoConfig)
+        .to receive(:tenant_sso_available_for?).and_return(true)
+    end
+
+    def resolver_with_domain_id(strategy)
+      Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_request(
+        global, nil, domain_strategy: strategy, domain_id: domain_id
+      )
+    end
+
+    def resolver_without_domain_id(strategy)
+      Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_request(
+        global, nil, domain_strategy: strategy
+      )
+    end
+
+    [:custom, :invalid, nil].each do |strategy|
+      it "reports sign-in AVAILABLE for an SSO-only tenant on #{strategy.inspect} when domain_id is passed" do
+        expect(resolver_with_domain_id(strategy)).to be(true)
+      end
+
+      it "reports sign-in DISABLED for the same tenant on #{strategy.inspect} when domain_id is omitted" do
+        expect(resolver_without_domain_id(strategy)).to be(false)
+      end
+    end
+
+    it 'the POST gate omits domain_id, so an SSO-only tenant cannot POST credentials' do
+      expect(runtime_signin(:custom)).to be(false)
+      expect(runtime_signin(:invalid)).to be(false)
+    end
+
+    it 'the carve-out is irrelevant on an operator host — the global default already applies' do
+      expect(resolver_with_domain_id(:canonical)).to be(true)
+      expect(resolver_without_domain_id(:canonical)).to be(true)
+    end
+
+    # The serialized /signin page reaches the same conclusion by its own route
+    # (sso_available? / build_sso_config) rather than through the domain_id
+    # carve-out, so it is pinned separately.
+    context 'with an enabled tenant SsoConfig' do
+      let(:sso_config) do
+        instance_double(
+          Onetime::CustomDomain::SsoConfig,
+          domain_id: domain_id,
+          enabled?: true,
+          enforce_sso_only?: false,
+          platform_route_name: 'oidc',
+          display_name: 'Tenant SSO'
+        )
+      end
+
+      it 'keeps the /signin page available on :custom and :invalid alike' do
+        expect(display_signin(:custom)).to be(true)
+        expect(display_signin(:invalid)).to be(true)
+      end
+
+      it 'and the branded masthead link agrees with the page' do
+        expect(display_signin_for_domain).to be(true)
+      end
+    end
+  end
+
+  # ------------------------------------------- platform SSO fallback (closed)
+
+  # A12 ONE LAYER DOWN, CLOSED. Found while writing the matrix above and fixed
+  # in the same pass. resolve_signin moved to operator_domain?, but the SSO
+  # surface it delegates to still keyed on the IDENTITY predicate:
+  # build_sso_config's `tenant_domain?(view_vars) && !allow_platform_fallback?`
+  # guard. An operator who withheld platform fallback from tenants had that
+  # policy applied to :custom and SKIPPED for :invalid and nil — so a real
+  # customer domain misclassified by a datastore blip was offered the platform
+  # SSO providers (and features.signin true) its correct classification denies.
+  # Platform omniauth routes are host-independent, so that was a working
+  # sign-in method granted by an availability failure, not a rendering detail.
+  #
+  # The guard is a POLICY decision — "may this host borrow the platform's SSO
+  # providers" — so it takes the positive test like the sign-in gates. What is
+  # NOT flipped is the tenant-vs-platform SELECTION above it
+  # (resolve_tenant_sso_config, keyed on domain_id): that is genuine identity,
+  # and flipping tenant_domain? wholesale would have broken it. Splitting the
+  # two uses is what makes the fix safe, so both halves are pinned here.
+  #
+  # This block is deliberately kept rather than deleted, with its expectations
+  # inverted: a revert to the identity predicate reds here with the history
+  # attached.
+  describe 'platform SSO fallback takes the positive operator test' do
+    let(:mock_auth_config) do
+      instance_double(
+        Onetime::AuthConfig,
+        sso_enabled?: true,
+        sso_providers: [{ 'route_name' => 'oidc', 'display_name' => 'Platform SSO' }],
+        allow_platform_fallback_for_tenants?: fallback_allowed,
+        email_auth_enabled?: false,
+        restrict_to: nil,
+        restrict_to_available?: true
+      )
+    end
+
+    def sso_payload(strategy)
+      Core::Views::ConfigSerializer.build_sso_config(view_vars_for(strategy))
+    end
+
+    context 'when the operator WITHHOLDS platform fallback from tenants' do
+      let(:fallback_allowed) { false }
+
+      [:custom, :invalid, nil].each do |strategy|
+        it "withholds platform SSO on #{strategy.inspect} — a blip cannot grant a method the operator denied" do
+          expect(sso_payload(strategy)['enabled']).to be(false)
+          expect(sso_payload(strategy)['providers']).to eq([])
+          expect(display_signin(strategy)).to be(false)
+        end
+      end
+
+      [:canonical, :subdomain].each do |strategy|
+        it "still offers platform SSO on #{strategy.inspect} — the operator's own hosts were never the target" do
+          expect(sso_payload(strategy)['enabled']).to be(true)
+          expect(display_signin(strategy)).to be(true)
+        end
+      end
+
+      it 'agrees with the runtime password/email gate on every classification' do
+        CLASSIFICATIONS_A12.each do |strategy|
+          expect(display_signin(strategy)).to be(runtime_signin(strategy))
+        end
+      end
+    end
+
+    # THE COUNTERWEIGHT: the positive test must not manufacture a withholding
+    # the operator never configured. With fallback allowed, every
+    # classification keeps the platform providers it had before the fix.
+    context 'when the operator ALLOWS platform fallback' do
+      let(:fallback_allowed) { true }
+
+      CLASSIFICATIONS_A12.each do |strategy|
+        it "offers platform SSO on #{strategy.inspect}" do
+          expect(sso_payload(strategy)['enabled']).to be(true)
+        end
+      end
+
+      # The one surviving display/runtime asymmetry, and it is the documented
+      # SSO one: the page stays reachable because its omniauth providers work,
+      # while POST /signin (password/email only) stays closed.
+      it 'keeps the /signin page reachable on a tenant-safe host while the POST gate stays closed' do
+        expect(display_signin(:invalid)).to be(true)
+        expect(runtime_signin(:invalid)).to be(false)
+      end
+    end
+
+    # SELECTION IS UNTOUCHED: an enabled tenant SsoConfig is resolved by
+    # domain_id, before the policy guard runs, so it is returned on :custom and
+    # :invalid alike regardless of the fallback policy.
+    context 'with a tenant SsoConfig and fallback withheld' do
+      let(:fallback_allowed) { false }
+      let(:sso_config) do
+        instance_double(
+          Onetime::CustomDomain::SsoConfig,
+          domain_id: domain_id,
+          enabled?: true,
+          enforce_sso_only?: false,
+          platform_route_name: 'oidc',
+          display_name: 'Tenant SSO'
+        )
+      end
+
+      before do
+        allow(Onetime::CustomDomain::SsoConfig)
+          .to receive(:tenant_sso_available_for?).and_return(true)
+      end
+
+      [:custom, :invalid].each do |strategy|
+        it "returns the TENANT's own providers on #{strategy.inspect}, not the platform's" do
+          expect(sso_payload(strategy)['enabled']).to be(true)
+          expect(sso_payload(strategy)['providers'].first['display_name']).to eq('Tenant SSO')
+        end
+      end
+    end
+  end
+
+  # ------------------------------------------- unreadable policy fails closed
+
+  # Spec refinement 4. "Disabled unless explicitly enabled" requires actually
+  # READING the tenant policy. If that read fails, the application cannot
+  # establish explicit enablement and must not degrade into the operator
+  # default — that is the same widen A12 closes, arriving one layer later.
+  describe 'unreadable tenant policy' do
+    let(:redis_down) { Redis::BaseError.new('datastore unavailable') }
+
+    context 'when the CustomDomain identity read fails' do
+      before do
+        allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+          .with(display_domain).and_raise(redis_down)
+      end
+
+      [:custom, :invalid, nil].each do |strategy|
+        it "fails closed with SigninPolicyUnavailable on #{strategy.inspect}, never the operator default" do
+          expect { runtime_signin(strategy) }
+            .to raise_error(Onetime::SigninPolicyUnavailable)
+        end
+      end
+
+      [:canonical, :subdomain].each do |strategy|
+        it "keeps sign-in up on #{strategy.inspect} — no per-domain policy could have applied there" do
+          expect(runtime_signin(strategy)).to be(true)
+        end
+      end
+    end
+
+    context 'when the SigninConfig read fails' do
+      before do
+        allow(Onetime::CustomDomain::SigninConfig).to receive(:find_by_domain_id)
+          .with(domain_id).and_raise(redis_down)
+      end
+
+      [:custom, :invalid, nil].each do |strategy|
+        it "fails closed with SigninPolicyUnavailable on #{strategy.inspect}" do
+          expect { runtime_signin(strategy) }
+            .to raise_error(Onetime::SigninPolicyUnavailable)
+        end
+      end
+
+      # The operator hosts still reach the read (custom_domain_id resolves the
+      # display domain to a record here), so the carve-out has to be applied at
+      # the failure, not skipped by luck.
+      [:canonical, :subdomain].each do |strategy|
+        it "degrades to the still-known global policy on #{strategy.inspect}" do
+          expect(runtime_signin(strategy)).to be(true)
+        end
+      end
+    end
+
+    it 'the failure is a 503-shaped Problem, not the gate\'s ordinary 404 reject' do
+      allow(Onetime::CustomDomain::SigninConfig).to receive(:find_by_domain_id)
+        .with(domain_id).and_raise(redis_down)
+
+      expect { runtime_signin(:invalid) }.to raise_error(Onetime::SigninPolicyUnavailable) { |ex|
+        expect(ex.to_h[:error_type]).to eq('SigninPolicyUnavailable')
+      }
+    end
+
+    # SIGN-UP HALF. Owned by spec/unit/signup_policy_unavailable_spec.rb, which
+    # covers the decision owner (SignupConfig.resolve_lookup_failure), the
+    # error family, the mixin and the gate. NOT duplicated here. What this file
+    # adds is the one claim neither half can make alone: the two surfaces fail
+    # closed on the SAME hosts and survive on the same hosts, so a datastore
+    # blip cannot leave sign-up open where sign-in is closed or the reverse.
+    context 'sign-in and sign-up fail closed together' do
+      before do
+        allow(Onetime::CustomDomain::SigninConfig).to receive(:find_by_domain_id)
+          .with(domain_id).and_raise(redis_down)
+        allow(Onetime::CustomDomain::SignupConfig).to receive(:find_by_domain_id)
+          .with(domain_id).and_raise(redis_down)
+      end
+
+      [:custom, :invalid, nil].each do |strategy|
+        it "both raise an AuthPolicyUnavailable on #{strategy.inspect}, neither degrades to the operator default" do
+          expect { runtime_signin(strategy) }.to raise_error(Onetime::SigninPolicyUnavailable)
+          expect { runtime_signup(strategy) }.to raise_error(Onetime::SignupPolicyUnavailable)
+        end
+      end
+
+      [:canonical, :subdomain].each do |strategy|
+        it "both survive on #{strategy.inspect} — no per-domain policy could have applied there" do
+          expect(runtime_signin(strategy)).to be(true)
+          expect(runtime_signup(strategy)).to be(true)
+        end
+      end
+
+      it 'reports the surface that is actually down, not a shared class' do
+        expect(Onetime::SignupPolicyUnavailable).not_to be <= Onetime::SigninPolicyUnavailable
+        expect(Onetime::SignupPolicyUnavailable.new.to_h[:error_type]).to eq('SignupPolicyUnavailable')
+      end
+    end
+  end
+end

--- a/apps/web/core/spec/views/serializers/signin_signup_classification_parity_spec.rb
+++ b/apps/web/core/spec/views/serializers/signin_signup_classification_parity_spec.rb
@@ -89,7 +89,25 @@ RSpec.describe 'sign-in/sign-up default polarity by host classification' do
     allow(Onetime).to receive(:auth_config).and_return(mock_auth_config)
     allow(OT).to receive(:conf).and_return({ 'site' => { 'authentication' => auth_settings } })
 
+    # BOTH identity reads, because the surfaces in this parity spec do not
+    # share one. The runtime gates (Core::Controllers::Base#custom_domain_id
+    # and Onetime::Logic::SignupConfigResolution#domain_signup_config) resolve
+    # the host through the non-swallowing .from_display_domain (#4157); the
+    # display half (Core::Views::ConfigSerializer#resolve_domain_id) still
+    # resolves it through the fail-open .load_by_display_domain. They are
+    # distinct class methods with no alias between them, so stubbing only one
+    # leaves the other half reading a real (empty) datastore and answering "no
+    # tenant config" for every case — which silently turns its assertions
+    # below into assertions about the unconfigured default rather than the
+    # configured one. If a third lookup ever appears, it belongs here too: the
+    # whole claim of this file is that the two surfaces see an IDENTICAL world.
+    #
+    # `display_domain` is lowercase, so the single `.with` matcher is exact for
+    # both — since #4157 both finders downcase internally, and a lowercase let
+    # keeps these stubs matching what either would resolve in production.
     allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+      .with(display_domain).and_return(custom_domain)
+    allow(Onetime::CustomDomain).to receive(:from_display_domain)
       .with(display_domain).and_return(custom_domain)
     allow(Onetime::CustomDomain::SigninConfig).to receive(:find_by_domain_id)
       .with(domain_id).and_return(signin_config)
@@ -549,7 +567,11 @@ RSpec.describe 'sign-in/sign-up default polarity by host classification' do
 
     context 'when the CustomDomain identity read fails' do
       before do
+        # Both identity reads fail, for the reason given at the top-level
+        # `before`: one datastore is down, and it is down for both surfaces.
         allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+          .with(display_domain).and_raise(redis_down)
+        allow(Onetime::CustomDomain).to receive(:from_display_domain)
           .with(display_domain).and_raise(redis_down)
       end
 

--- a/apps/web/core/spec/views/serializers/signin_signup_classification_parity_spec.rb
+++ b/apps/web/core/spec/views/serializers/signin_signup_classification_parity_spec.rb
@@ -3,7 +3,8 @@
 # frozen_string_literal: true
 
 # DISPLAY <-> RUNTIME PARITY for the sign-in / sign-up DEFAULT, keyed by the
-# request's DomainStrategy classification (ADR-024 A12,
+# request's DomainStrategy classification (ADR-024#display-runtime-parity,
+# ADR-024#operator-defaults-require-positive-classification,
 # docs/specs/domain-resolution/domain-resolution.md).
 #
 # The defect this pins: choosing the auth resolver on `== :custom` picks the
@@ -37,15 +38,15 @@
 require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
 require_relative '../../../views/serializers'
 
-RSpec.describe 'sign-in/sign-up classification polarity (ADR-024 A12)' do
+RSpec.describe 'sign-in/sign-up default polarity by host classification' do
   # Every value env['onetime.domain_strategy'] can carry at a consumer.
-  CLASSIFICATIONS_A12 = [:canonical, :subdomain, :custom, :invalid, nil].freeze
+  PARITY_CLASSIFICATIONS = [:canonical, :subdomain, :custom, :invalid, nil].freeze
 
   # The required test matrix from docs/specs/domain-resolution/domain-resolution.md,
   # for global auth ENABLED and NO tenant configuration. Only the two
   # classifications a datastore failure can never MANUFACTURE inherit the
   # operator default.
-  EXPECTED_A12 = {
+  PARITY_EXPECTED_DEFAULT = {
     canonical: true,
     subdomain: true,
     custom: false,
@@ -54,7 +55,7 @@ RSpec.describe 'sign-in/sign-up classification polarity (ADR-024 A12)' do
   }.freeze
 
   def expected_for(strategy)
-    EXPECTED_A12.fetch(strategy.nil? ? nil : strategy)
+    PARITY_EXPECTED_DEFAULT.fetch(strategy.nil? ? nil : strategy)
   end
 
   let(:display_domain) { 'secrets.tenant.example.com' }
@@ -158,19 +159,19 @@ RSpec.describe 'sign-in/sign-up classification polarity (ADR-024 A12)' do
   # ---------------------------------------------------- the required matrix
 
   describe 'global auth ENABLED, no tenant configuration' do
-    CLASSIFICATIONS_A12.each do |strategy|
+    PARITY_CLASSIFICATIONS.each do |strategy|
       context "on #{strategy.inspect}" do
-        let(:expected) { EXPECTED_A12.fetch(strategy) }
+        let(:expected) { PARITY_EXPECTED_DEFAULT.fetch(strategy) }
 
-        it "resolves sign-in #{EXPECTED_A12.fetch(strategy) ? 'enabled' : 'disabled'} at the runtime gate" do
+        it "resolves sign-in #{PARITY_EXPECTED_DEFAULT.fetch(strategy) ? 'enabled' : 'disabled'} at the runtime gate" do
           expect(runtime_signin(strategy)).to be(expected)
         end
 
-        it "resolves sign-up #{EXPECTED_A12.fetch(strategy) ? 'enabled' : 'disabled'} at the runtime gate" do
+        it "resolves sign-up #{PARITY_EXPECTED_DEFAULT.fetch(strategy) ? 'enabled' : 'disabled'} at the runtime gate" do
           expect(runtime_signup(strategy)).to be(expected)
         end
 
-        it "resolves sign-in #{EXPECTED_A12.fetch(strategy) ? 'enabled' : 'disabled'} at the display gate" do
+        it "resolves sign-in #{PARITY_EXPECTED_DEFAULT.fetch(strategy) ? 'enabled' : 'disabled'} at the display gate" do
           expect(display_signin(strategy)).to be(expected)
         end
 
@@ -206,7 +207,7 @@ RSpec.describe 'sign-in/sign-up classification polarity (ADR-024 A12)' do
   describe 'global auth DISABLED' do
     let(:auth_settings) { { 'enabled' => false, 'signin' => true, 'signup' => true } }
 
-    CLASSIFICATIONS_A12.each do |strategy|
+    PARITY_CLASSIFICATIONS.each do |strategy|
       it "stays disabled for #{strategy.inspect} on both surfaces" do
         expect(runtime_signin(strategy)).to be(false)
         expect(runtime_signup(strategy)).to be(false)
@@ -218,7 +219,7 @@ RSpec.describe 'sign-in/sign-up classification polarity (ADR-024 A12)' do
   describe 'AUTH_SIGNIN / AUTH_SIGNUP off with the master switch on' do
     let(:auth_settings) { { 'enabled' => true, 'signin' => false, 'signup' => false } }
 
-    CLASSIFICATIONS_A12.each do |strategy|
+    PARITY_CLASSIFICATIONS.each do |strategy|
       it "stays disabled for #{strategy.inspect} on both surfaces" do
         expect(runtime_signin(strategy)).to be(false)
         expect(runtime_signup(strategy)).to be(false)
@@ -255,7 +256,7 @@ RSpec.describe 'sign-in/sign-up classification polarity (ADR-024 A12)' do
       let(:signin_opt_in) { false }
       let(:signup_opt_in) { false }
 
-      CLASSIFICATIONS_A12.each do |strategy|
+      PARITY_CLASSIFICATIONS.each do |strategy|
         it "narrows #{strategy.inspect} to disabled, INCLUDING the operator's own host" do
           expect(runtime_signin(strategy)).to be(false)
           expect(runtime_signup(strategy)).to be(false)
@@ -269,7 +270,7 @@ RSpec.describe 'sign-in/sign-up classification polarity (ADR-024 A12)' do
       let(:signup_opt_in)  { true }
       let(:auth_settings)  { { 'enabled' => true, 'signin' => false, 'signup' => false } }
 
-      CLASSIFICATIONS_A12.each do |strategy|
+      PARITY_CLASSIFICATIONS.each do |strategy|
         it "cannot widen #{strategy.inspect} back to enabled" do
           expect(runtime_signin(strategy)).to be(false)
           expect(runtime_signup(strategy)).to be(false)
@@ -422,7 +423,7 @@ RSpec.describe 'sign-in/sign-up classification polarity (ADR-024 A12)' do
 
   # ------------------------------------------- platform SSO fallback (closed)
 
-  # A12 ONE LAYER DOWN, CLOSED. Found while writing the matrix above and fixed
+  # THE SAME WIDEN ONE LAYER DOWN, CLOSED. Found while writing the matrix above and fixed
   # in the same pass. resolve_signin moved to operator_domain?, but the SSO
   # surface it delegates to still keyed on the IDENTITY predicate:
   # build_sso_config's `tenant_domain?(view_vars) && !allow_platform_fallback?`
@@ -479,7 +480,7 @@ RSpec.describe 'sign-in/sign-up classification polarity (ADR-024 A12)' do
       end
 
       it 'agrees with the runtime password/email gate on every classification' do
-        CLASSIFICATIONS_A12.each do |strategy|
+        PARITY_CLASSIFICATIONS.each do |strategy|
           expect(display_signin(strategy)).to be(runtime_signin(strategy))
         end
       end
@@ -491,7 +492,7 @@ RSpec.describe 'sign-in/sign-up classification polarity (ADR-024 A12)' do
     context 'when the operator ALLOWS platform fallback' do
       let(:fallback_allowed) { true }
 
-      CLASSIFICATIONS_A12.each do |strategy|
+      PARITY_CLASSIFICATIONS.each do |strategy|
         it "offers platform SSO on #{strategy.inspect}" do
           expect(sso_payload(strategy)['enabled']).to be(true)
         end
@@ -538,10 +539,11 @@ RSpec.describe 'sign-in/sign-up classification polarity (ADR-024 A12)' do
 
   # ------------------------------------------- unreadable policy fails closed
 
-  # Spec refinement 4. "Disabled unless explicitly enabled" requires actually
-  # READING the tenant policy. If that read fails, the application cannot
-  # establish explicit enablement and must not degrade into the operator
-  # default — that is the same widen A12 closes, arriving one layer later.
+  # "Disabled unless explicitly enabled" requires actually READING the tenant
+  # policy. If that read fails, the application cannot establish explicit
+  # enablement and must not degrade into the operator default — the same widen
+  # ADR-024#operator-defaults-require-positive-classification closes, arriving
+  # one layer later.
   describe 'unreadable tenant policy' do
     let(:redis_down) { Redis::BaseError.new('datastore unavailable') }
 

--- a/apps/web/core/views/serializers/authentication_serializer.rb
+++ b/apps/web/core/views/serializers/authentication_serializer.rb
@@ -173,7 +173,11 @@ module Core
           return false unless Onetime::CustomDomain::SsoConfig.tenant_sso_available_for?(domain_id, sso_config: config)
 
           config.enforce_sso_only?
-        rescue StandardError
+        rescue Redis::BaseError
+          # Tri-state handling (#4157): failed read → enforce SSO (narrowest
+          # surface for password_auth_permitted?). This hides the password
+          # form during a blip rather than showing it on a tenant that may
+          # have disabled local passwords.
           true
         end
 

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -436,9 +436,18 @@ module Core
           domain_id     = resolve_domain_id(view_vars)
           signin_config = Onetime::CustomDomain::SigninConfig.find_by_domain_id(domain_id) if domain_id
 
-          # Custom domain that has not opted into per-domain sign-in: password/
-          # email defaults OFF; keep the page only when SSO is available.
-          if tenant_domain?(view_vars) && !signin_config&.enabled?
+          # Anything but a positively-classified operator host, with no opted-in
+          # per-domain sign-in: password/email default OFF; keep the page only
+          # when SSO is available.
+          #
+          # The predicate is operator_domain?, NOT tenant_domain? (ADR-024 A12).
+          # The runtime gate now requires positive :canonical/:subdomain
+          # evidence before applying operator defaults, and this display gate
+          # must move with it: leaving `== :custom` here would advertise
+          # sign-in on a host classified :invalid by a datastore blip while
+          # Base#signin_enabled? rejects the POST — the display/runtime
+          # disagreement both gates' comments exist to forbid.
+          if !operator_domain?(view_vars) && !signin_config&.enabled?
             return sso_available?(view_vars)
           end
 
@@ -508,9 +517,25 @@ module Core
             return build_tenant_sso_response(tenant_config)
           end
 
-          # Check if we're on a custom domain that should have tenant config
-          # but doesn't - honor the fallback policy
-          if tenant_domain?(view_vars) && !allow_platform_fallback?
+          # No tenant config resolved. Honor the operator's fallback policy:
+          # when platform fallback is withheld from tenants, a host that is not
+          # positively one of the operator's OWN gets no providers.
+          #
+          # The predicate is operator_domain?, NOT tenant_domain? (ADR-024 A12).
+          # This is a POLICY decision — "may this host borrow the platform's
+          # SSO providers" — so it takes the same positive test as the sign-in
+          # gates. Keyed on `== :custom` it skipped the withholding for
+          # :invalid, and platform omniauth routes are host-independent, so a
+          # customer domain misclassified by a datastore blip was OFFERED the
+          # providers its correct classification denies — the A12 widen one
+          # layer down, in a working sign-in method rather than a rendering
+          # detail.
+          #
+          # Tenant-vs-platform SELECTION above is untouched and still keys on
+          # domain identity (resolve_tenant_sso_config, via domain_id): a
+          # genuinely unknown host has no tenant config to select, and this
+          # guard is what decides whether it may fall back.
+          if !operator_domain?(view_vars) && !allow_platform_fallback?
             return { 'enabled' => false, 'providers' => [] }
           end
 
@@ -587,6 +612,21 @@ module Core
         def tenant_domain?(view_vars)
           strategy = view_vars['domain_strategy']
           strategy == :custom
+        end
+
+        # Whether this request is positively classified as one of the operator's
+        # OWN hosts, and may therefore inherit operator auth defaults (ADR-024
+        # A12). The complement of tenant_domain? is NOT this: :invalid and nil
+        # are neither operator hosts nor tenant hosts, and must be treated as
+        # tenant-safe for auth while staying non-tenant for branding/routing.
+        #
+        # SigninConfig.operator_host? owns the classification list so this page
+        # and the runtime gates cannot disagree about it.
+        #
+        # @param view_vars [Hash] View variables
+        # @return [Boolean] true on :canonical / :subdomain
+        def operator_domain?(view_vars)
+          Onetime::CustomDomain::SigninConfig.operator_host?(view_vars['domain_strategy'])
         end
 
         # Check if platform fallback is allowed for tenant domains

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -23,6 +23,11 @@ module Core
     #   view_vars['display_domain'] -> CustomDomain.load_by_display_domain -> CustomDomain::SsoConfig
     #
     module ConfigSerializer
+      # Sentinel returned by resolve_domain_id when a datastore read fails.
+      # Callers must check for this and render the narrowest surface rather
+      # than treating it as "no tenant config" (#4157).
+      DOMAIN_READ_FAILED = :domain_read_failed
+
       # Serializes configuration data from view variables
       #
       # Transforms server configuration including site settings, feature flags,
@@ -323,7 +328,17 @@ module Core
         # @param view_vars [Hash] View variables with request context
         # @return [Onetime::CustomDomain::SigninConfig::RestrictToResolution]
         def restrict_to_resolution(view_vars)
-          domain_id     = resolve_domain_id(view_vars)
+          domain_id = resolve_domain_id(view_vars)
+
+          # Tri-state handling (#4157): failed read → unavailable (no auth methods).
+          if domain_id == DOMAIN_READ_FAILED
+            return Onetime::CustomDomain::SigninConfig::RestrictToResolution.new(
+              restrict_to: nil,
+              state: :unavailable,
+              source: :domain_read_failed,
+            )
+          end
+
           signin_config = Onetime::CustomDomain::SigninConfig.find_by_domain_id(domain_id) if domain_id
           global        = effective_global_restrict_to(view_vars, signin_config, domain_id)
 
@@ -390,12 +405,17 @@ module Core
         #
         # @param view_vars [Hash] View variables with request context
         # @param signin_config [Onetime::CustomDomain::SigninConfig, nil]
-        # @param domain_id [String, nil] already-resolved CustomDomain objid
+        # @param domain_id [String, nil, :domain_read_failed] already-resolved CustomDomain objid
         # @return [String, nil]
         def effective_global_restrict_to(view_vars, signin_config = nil, domain_id = nil)
-          if tenant_domain?(view_vars) && !signin_config&.enabled?
+          # Tri-state handling (#4157): if domain_id is DOMAIN_READ_FAILED, the
+          # caller should have already short-circuited. If we reach here anyway,
+          # don't attempt the SSO pin — fall through to global.
+          if tenant_domain?(view_vars) && !signin_config&.enabled? && domain_id != DOMAIN_READ_FAILED
             domain_id ||= resolve_domain_id(view_vars)
-            return 'sso' if Onetime::CustomDomain::SsoConfig.sso_available_for_tenant_host?(domain_id)
+            # Defensive: if the fallback read also failed, skip the SSO pin.
+            return 'sso' if domain_id != DOMAIN_READ_FAILED &&
+                            Onetime::CustomDomain::SsoConfig.sso_available_for_tenant_host?(domain_id)
           end
 
           Onetime.auth_config.restrict_to
@@ -433,7 +453,13 @@ module Core
           auth_settings = (view_vars['site'] || {})['authentication'] || {}
           global        = auth_settings['enabled'] && auth_settings['signin']
 
-          domain_id     = resolve_domain_id(view_vars)
+          domain_id = resolve_domain_id(view_vars)
+
+          # Tri-state handling (#4157): a failed read is not "no tenant config."
+          # Render the narrowest surface (no sign-in) rather than falling back
+          # to operator defaults during a datastore blip.
+          return false if domain_id == DOMAIN_READ_FAILED
+
           signin_config = Onetime::CustomDomain::SigninConfig.find_by_domain_id(domain_id) if domain_id
 
           # Anything but a positively-classified operator host, with no opted-in
@@ -474,8 +500,12 @@ module Core
         # @param view_vars [Hash] View variables with request context
         # @return [Boolean] true if email_auth is available
         def resolve_email_auth(view_vars)
-          global        = Onetime.auth_config.email_auth_enabled?
-          domain_id     = resolve_domain_id(view_vars)
+          global    = Onetime.auth_config.email_auth_enabled?
+          domain_id = resolve_domain_id(view_vars)
+
+          # Tri-state handling (#4157): failed read → narrow to off.
+          return false if domain_id == DOMAIN_READ_FAILED
+
           signin_config = Onetime::CustomDomain::SigninConfig.find_by_domain_id(domain_id) if domain_id
 
           Onetime::CustomDomain::SigninConfig.resolve_email_auth_enabled(global, signin_config)
@@ -565,7 +595,8 @@ module Core
         # @return [Onetime::CustomDomain::SsoConfig, nil] Config if found and enabled
         def resolve_tenant_sso_config(view_vars)
           domain_id = resolve_domain_id(view_vars)
-          return nil unless domain_id
+          # Tri-state handling (#4157): failed read → no SSO (narrowest surface).
+          return nil if domain_id.nil? || domain_id == DOMAIN_READ_FAILED
 
           config = Onetime::CustomDomain::SsoConfig.find_by_domain_id(domain_id)
           return nil unless config
@@ -576,8 +607,16 @@ module Core
 
         # Resolve domain identifier from view variables
         #
+        # Returns the CustomDomain identifier when the lookup succeeds,
+        # nil when the display_domain is blank or the domain doesn't exist,
+        # or DOMAIN_READ_FAILED when the datastore read fails.
+        #
+        # Callers MUST check for DOMAIN_READ_FAILED and render the narrowest
+        # surface (omit sign-in affordances) rather than treating a failed
+        # read as "no tenant config" (#4157).
+        #
         # @param view_vars [Hash] View variables
-        # @return [String, nil] CustomDomain identifier (objid) or nil
+        # @return [String, nil, :domain_read_failed]
         def resolve_domain_id(view_vars)
           display_domain = view_vars['display_domain']
           return nil if display_domain.to_s.empty?
@@ -586,17 +625,16 @@ module Core
           custom_domain&.identifier
         rescue Redis::BaseError => ex
           OT.le "[ConfigSerializer] Redis error resolving domain_id for domain=#{display_domain}: #{ex.class}"
-          nil
+          DOMAIN_READ_FAILED
         end
         # ASYMMETRIC WITH THE GATES ON PURPOSE (#4139). The runtime gates raise
         # Onetime::SigninPolicyUnavailable when this same read fails, because a
         # gate that cannot read the policy must not decide. This is the DISPLAY
-        # half: degrading to the global-only answer costs nothing an attacker
-        # can spend — every method it might over-advertise is still rejected by
-        # the gate the form posts to, so the safe ordering (gate at least as
-        # narrow as the page) holds in the one direction that matters. Raising
-        # here instead would take the whole bootstrap payload down, i.e. a blank
-        # app rather than a page whose submit answers 503.
+        # half: we return DOMAIN_READ_FAILED so callers can render the narrowest
+        # surface (no sign-in affordance) rather than falling back to operator
+        # defaults. The gate still catches any form submission with a 503, but
+        # now the display layer agrees: unknown tenant policy means no sign-in
+        # form, not the operator's default (#4157).
 
         # Check if request is from a tenant/custom domain
         #

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -440,13 +440,10 @@ module Core
           # per-domain sign-in: password/email default OFF; keep the page only
           # when SSO is available.
           #
-          # The predicate is operator_domain?, NOT tenant_domain? (ADR-024 A12).
-          # The runtime gate now requires positive :canonical/:subdomain
-          # evidence before applying operator defaults, and this display gate
-          # must move with it: leaving `== :custom` here would advertise
-          # sign-in on a host classified :invalid by a datastore blip while
-          # Base#signin_enabled? rejects the POST — the display/runtime
-          # disagreement both gates' comments exist to forbid.
+          # The predicate is operator_domain?, NOT tenant_domain? — this is the
+          # display half of the pair, and it must branch on whatever
+          # Base#signin_enabled? branches on.
+          # ADR-024#display-runtime-parity
           if !operator_domain?(view_vars) && !signin_config&.enabled?
             return sso_available?(view_vars)
           end
@@ -521,15 +518,11 @@ module Core
           # when platform fallback is withheld from tenants, a host that is not
           # positively one of the operator's OWN gets no providers.
           #
-          # The predicate is operator_domain?, NOT tenant_domain? (ADR-024 A12).
-          # This is a POLICY decision — "may this host borrow the platform's
-          # SSO providers" — so it takes the same positive test as the sign-in
-          # gates. Keyed on `== :custom` it skipped the withholding for
-          # :invalid, and platform omniauth routes are host-independent, so a
-          # customer domain misclassified by a datastore blip was OFFERED the
-          # providers its correct classification denies — the A12 widen one
-          # layer down, in a working sign-in method rather than a rendering
-          # detail.
+          # The predicate is operator_domain?, NOT tenant_domain? — "may this
+          # host borrow the platform's SSO providers" is an auth decision, and
+          # the platform omniauth routes are host-independent, so a widen here
+          # hands out a working sign-in method rather than a rendering detail.
+          # ADR-024#operator-defaults-require-positive-classification
           #
           # Tenant-vs-platform SELECTION above is untouched and still keys on
           # domain identity (resolve_tenant_sso_config, via domain_id): a
@@ -615,8 +608,10 @@ module Core
         end
 
         # Whether this request is positively classified as one of the operator's
-        # OWN hosts, and may therefore inherit operator auth defaults (ADR-024
-        # A12). The complement of tenant_domain? is NOT this: :invalid and nil
+        # OWN hosts, and may therefore inherit operator auth defaults.
+        # ADR-024#identity-predicates-are-not-auth-gates
+        #
+        # The complement of tenant_domain? is NOT this: :invalid and nil
         # are neither operator hosts nor tenant hosts, and must be treated as
         # tenant-safe for auth while staying non-tenant for branding/routing.
         #

--- a/changelog.d/20260813_120000_claude_4157_domain_resolution.rst
+++ b/changelog.d/20260813_120000_claude_4157_domain_resolution.rst
@@ -1,0 +1,62 @@
+.. A new scriv changelog fragment.
+
+Changed
+-------
+
+- (`#4157 <https://github.com/onetimesecret/onetimesecret/issues/4157>`_)
+  Sign-in and sign-up availability now requires a positively classified
+  operator host. The request's domain classification is passed to the
+  resolvers (``SigninConfig.resolve_signin_enabled_for_request`` /
+  ``SignupConfig.resolve_signup_enabled_for_request``), and the install's
+  global defaults are applied only on ``:canonical`` or ``:subdomain``.
+  Anything else — including a request whose classification could not be
+  established — takes the default-OFF custom-domain resolver, so a domain
+  the app cannot positively place as its own never inherits operator
+  defaults. Previously the branch was chosen by testing "is this exactly a
+  custom domain?", whose false side is wider than it reads. The display gate
+  (``ConfigSerializer#resolve_signin``) moves with the runtime gates, so the
+  ``/signin`` page and the POST handler continue to agree, and the tenant-SSO
+  display carve-out is unchanged.
+
+  Operator note: this is fail-closed. While the custom-domain datastore is
+  unreachable, a recognized operator **subdomain** can be held to the
+  stricter default, since its classification is established after that read.
+  The canonical host is unaffected — it classifies before any datastore
+  access. Nothing that was explicitly enabled on a domain is withdrawn.
+
+  Domain identity is unchanged: ``custom_domain_request?`` and
+  ``tenant_domain?`` remain exact custom-domain tests, so branding, favicon
+  and routing behavior for unknown hosts is the same as before.
+
+- (`#4157 <https://github.com/onetimesecret/onetimesecret/issues/4157>`_)
+  Platform SSO providers are withheld from any host that is not positively an
+  operator host when ``allow_platform_fallback_for_tenants`` is off. The
+  fallback policy previously applied only to hosts classified exactly as
+  custom domains, so a host the app could not place was offered providers the
+  operator had withheld from tenants. Installs that permit platform fallback
+  are unaffected.
+
+- (`#4157 <https://github.com/onetimesecret/onetimesecret/issues/4157>`_)
+  An unreadable per-domain sign-up policy now answers 503 instead of 500, on
+  the same terms as the existing sign-in behavior: operator hosts, whose
+  policy is entirely in-memory configuration, are unaffected and continue to
+  follow the global setting. Autoverify resolution takes the same rule, rather
+  than falling back to the install-wide setting for a tenant whose own
+  configuration could not be read.
+
+Documentation
+-------------
+
+- (`#4157 <https://github.com/onetimesecret/onetimesecret/issues/4157>`_)
+  ADR-024 gains amendment A12, recording the rule (operator defaults require
+  positive evidence), why the domain identity predicates were deliberately
+  not redefined, the fail-closed availability cost, and the display/runtime
+  parity requirement. The ``DomainStrategy`` consumer table now groups its
+  consumers by which test they use.
+
+AI Assistance
+-------------
+
+- Claude added the request-aware sign-in/sign-up resolvers and repointed the
+  runtime and display gates at them, wrote ADR-024 A12, and regrouped the
+  ``DomainStrategy`` consumer table. (#4157)

--- a/changelog.d/20260813_120000_claude_4157_domain_resolution.rst
+++ b/changelog.d/20260813_120000_claude_4157_domain_resolution.rst
@@ -48,8 +48,8 @@ Documentation
 -------------
 
 - (`#4157 <https://github.com/onetimesecret/onetimesecret/issues/4157>`_)
-  ADR-024 gains amendment A12, recording the rule (operator defaults require
-  positive evidence), why the domain identity predicates were deliberately
+  ADR-024 now states that operator auth defaults require positive evidence
+  of an operator host, why the domain identity predicates were deliberately
   not redefined, the fail-closed availability cost, and the display/runtime
   parity requirement. The ``DomainStrategy`` consumer table now groups its
   consumers by which test they use.
@@ -58,5 +58,5 @@ AI Assistance
 -------------
 
 - Claude added the request-aware sign-in/sign-up resolvers and repointed the
-  runtime and display gates at them, wrote ADR-024 A12, and regrouped the
+  runtime and display gates at them, updated ADR-024, and regrouped the
   ``DomainStrategy`` consumer table. (#4157)

--- a/docs/adr/adr-024-custom-domain-auth-override-resolution.md
+++ b/docs/adr/adr-024-custom-domain-auth-override-resolution.md
@@ -124,9 +124,7 @@ and the platform fallback, including the Rodauth `/auth` surface itself.
 `AUTH_SIGNIN` is narrower: it disables the password/email path only and
 does not touch either SSO carve-out.
 
-### A12. Operator auth defaults require a positive operator classification (#4157)
-
-Recorded as a known gap 2026-08-11; resolved 2026-08-13.
+### Operator auth defaults require a positive operator classification {#operator-defaults-require-positive-classification}
 
 Normative: **only a positively classified operator host may inherit the
 install's global sign-in/sign-up defaults.** The test is
@@ -156,7 +154,16 @@ semantics for administrative and non-request callers. Sign-up reuses
 so sign-in and sign-up cannot drift apart. The sign-in `domain_id:` carve-out
 is preserved verbatim.
 
-**The domain identity predicates are deliberately NOT flipped.**
+**Accepted cost: this is fail-closed, and it bites `:subdomain`.**
+`:canonical` classifies before the datastore read, but the subdomain sweeps
+run after it, so during an outage a recognized operator subdomain classifies
+`:invalid` and is held to the stricter default. That denies nothing ever
+explicitly granted, and it is the correct direction: `operator_host?` may be
+over-strict during an outage, never over-permissive.
+
+### Identity predicates are not auth gates {#identity-predicates-are-not-auth-gates}
+
+The domain identity predicates are deliberately NOT flipped.
 `Core::Controllers::Base#custom_domain_request?` and
 `ConfigSerializer#tenant_domain?` stay `== :custom` identity tests: redefining
 them as "not canonical and not subdomain" would hand tenant branding, routing
@@ -165,23 +172,17 @@ and presentation to genuinely malformed and unknown hosts. Splitting
 consumer) and 503-ing every `:invalid` request were both rejected as broader
 than the gap requires.
 
-**Accepted cost: this is fail-closed, and it bites `:subdomain`.**
-`:canonical` classifies before the datastore read, but the subdomain sweeps
-run after it, so during an outage a recognized operator subdomain classifies
-`:invalid` and is held to the stricter default. That denies nothing ever
-explicitly granted, and it is the correct direction: `operator_host?` may be
-over-strict during an outage, never over-permissive.
+An auth decision keyed to the request host asks `operator_host?`; a branding,
+routing or presentation decision asks the identity predicate. The two differ
+for `:invalid` by design.
 
-**Display/runtime parity is a requirement.** The runtime gates
-(`Base#signin_enabled?`, `Base#signup_enabled?`) and the display gate
-(`ConfigSerializer#resolve_signin`, via `operator_domain?`) branch on the same
-predicate, so `/signin` cannot advertise what the POST will reject.
+### Display and runtime gates branch on the same predicate {#display-runtime-parity}
+
+The runtime gates (`Base#signin_enabled?`, `Base#signup_enabled?`) and the
+display gate (`ConfigSerializer#resolve_signin`, via `operator_domain?`) branch
+on the same predicate, so `/signin` cannot advertise what the POST will reject.
 `DomainSerializer` needs no change — it already consumes the
 custom-domain-specific resolver.
-
-Follow-on rule: an auth decision keyed to the request host asks
-`operator_host?`; a branding, routing or presentation decision asks the
-identity predicate. The two differ for `:invalid` by design.
 
 ## References
 

--- a/docs/adr/adr-024-custom-domain-auth-override-resolution.md
+++ b/docs/adr/adr-024-custom-domain-auth-override-resolution.md
@@ -124,6 +124,65 @@ and the platform fallback, including the Rodauth `/auth` surface itself.
 `AUTH_SIGNIN` is narrower: it disables the password/email path only and
 does not touch either SSO carve-out.
 
+### A12. Operator auth defaults require a positive operator classification (#4157)
+
+Recorded as a known gap 2026-08-11; resolved 2026-08-13.
+
+Normative: **only a positively classified operator host may inherit the
+install's global sign-in/sign-up defaults.** The test is
+`SigninConfig.operator_host?` — true for `:canonical` and `:subdomain` only.
+`:custom`, `:invalid` and a missing classification all take the tenant-safe,
+default-OFF resolver. "Anything that is not `:custom`" is not evidence of an
+operator host and must never select the branch.
+
+`:invalid` is not purely a property of the hostname: `DomainStrategy` also
+answers it when its own custom-domain datastore read raises (that class's doc
+owns the full consumer table). Because the two context-free resolvers have
+**opposite** defaults — `resolve_signin_enabled` follows the operator's
+global setting, `resolve_signin_enabled_for_custom_domain` is default-OFF —
+choosing between them *is* the access-policy decision. Choosing on
+`== :custom` let a transient datastore failure hand a real customer domain
+the operator's global default on a domain whose owner never opted in: an
+availability failure widening an access policy.
+
+Resolution is request-aware and lives at the policy layer:
+`SigninConfig.resolve_signin_enabled_for_request(global, config,
+domain_strategy:, domain_id: nil)` and
+`SignupConfig.resolve_signup_enabled_for_request(global, config,
+domain_strategy:)`. Both are thin selectors over the existing resolvers, so
+invariant 4 holds unchanged and the context-free resolvers keep their
+semantics for administrative and non-request callers. Sign-up reuses
+`SigninConfig.operator_host?` rather than restating the classification list,
+so sign-in and sign-up cannot drift apart. The sign-in `domain_id:` carve-out
+is preserved verbatim.
+
+**The domain identity predicates are deliberately NOT flipped.**
+`Core::Controllers::Base#custom_domain_request?` and
+`ConfigSerializer#tenant_domain?` stay `== :custom` identity tests: redefining
+them as "not canonical and not subdomain" would hand tenant branding, routing
+and presentation to genuinely malformed and unknown hosts. Splitting
+`:invalid` into distinct classifications (accurate, but touches every
+consumer) and 503-ing every `:invalid` request were both rejected as broader
+than the gap requires.
+
+**Accepted cost: this is fail-closed, and it bites `:subdomain`.**
+`:canonical` classifies before the datastore read, but the subdomain sweeps
+run after it, so during an outage a recognized operator subdomain classifies
+`:invalid` and is held to the stricter default. That denies nothing ever
+explicitly granted, and it is the correct direction: `operator_host?` may be
+over-strict during an outage, never over-permissive.
+
+**Display/runtime parity is a requirement.** The runtime gates
+(`Base#signin_enabled?`, `Base#signup_enabled?`) and the display gate
+(`ConfigSerializer#resolve_signin`, via `operator_domain?`) branch on the same
+predicate, so `/signin` cannot advertise what the POST will reject.
+`DomainSerializer` needs no change — it already consumes the
+custom-domain-specific resolver.
+
+Follow-on rule: an auth decision keyed to the request host asks
+`operator_host?`; a branding, routing or presentation decision asks the
+identity predicate. The two differ for `:invalid` by design.
+
 ## References
 
 Source of truth is this ADR. Principal implementation: the model resolvers

--- a/docs/specs/domain-ip-allowlist/domain-ip-allowlist.md
+++ b/docs/specs/domain-ip-allowlist/domain-ip-allowlist.md
@@ -2,8 +2,9 @@
 
 Status: Draft (proposed) — 2026-07-25; classification handling revised 2026-08-13
 Depends on: Otto v2.6.0 trusted-proxy features; ADR-024 config-resolution
-semantics, in particular A12 (operator auth defaults require a positive
-operator classification, #4157)
+semantics, in particular
+ADR-024#operator-defaults-require-positive-classification (operator auth
+defaults require a positive operator classification, #4157)
 
 Tenant-configurable CIDR filtering that restricts which networks can reach a
 custom domain — an additional access-control layer alongside the existing
@@ -281,13 +282,15 @@ access-control feature that defaulted closed would brick every existing
 custom domain on deploy.
 
 That default-open polarity is exactly what makes this feature's handling of
-the host classification differ from every other auth gate, and why the A12
-rule cannot simply be copied. Read the next section before implementing.
+the host classification differ from every other auth gate, and why the
+positive-operator-classification rule cannot simply be copied. Read the next
+section before implementing.
 
 ### Classification: which hosts are in scope, and the `:invalid` ambiguity
 
 This supersedes the original "pass through unless `== :custom`" gate. It is
-the one place where this spec deviates from ADR-024 A12 in *mechanism*,
+the one place where this spec deviates from
+ADR-024#operator-defaults-require-positive-classification in *mechanism*,
 though not in intent.
 
 **The hazard.** `env['onetime.domain_strategy']` answers `:invalid` in two
@@ -297,10 +300,13 @@ read — *raised* and the blanket rescue in `choose_strategy` turned that into
 `:invalid` for what may be a perfectly real customer domain. A filter gated
 on `== :custom` therefore stops enforcing, entirely, for every protected
 domain for the duration of a datastore blip: a fail-open access-control
-bypass whose trigger is load. That is the shape A12, A3, A8 and A9 exist to
-refuse.
+bypass whose trigger is load. That is the shape the positive-classification
+and fail-closed-degradation rules exist to refuse
+(ADR-024#operator-defaults-require-positive-classification,
+ADR-034#degradation-is-fail-closed,
+ADR-034#resolution-intersects-never-widens).
 
-**Why A12's remedy does not transfer.** A12 works because sign-in and
+**Why the ADR-024 remedy does not transfer.** It works because sign-in and
 sign-up have *opposite* defaults on the two branches, so picking the branch
 is itself the policy decision. Here both branches default **open**, so a
 positive operator test alone changes nothing — an unreadable host passes
@@ -353,7 +359,8 @@ during a blip — that is the honest answer, the alternative is guessing at a
 policy, and it is bounded by the same outage already degrading the rest of
 the request path.
 
-**Consequence to accept, stated plainly.** Like A12, this is over-strict
+**Consequence to accept, stated plainly.** Like the sign-in/sign-up rule,
+this is over-strict
 during an outage and never over-permissive, and it bites `:subdomain` for
 the same reason: the subdomain sweeps run *after* the datastore read, so a
 recognized operator subdomain classifies `:invalid` during a blip and falls

--- a/docs/specs/domain-ip-allowlist/domain-ip-allowlist.md
+++ b/docs/specs/domain-ip-allowlist/domain-ip-allowlist.md
@@ -1,7 +1,9 @@
 # Per-Custom-Domain IP Allowlist (WAF-Style CIDR Filtering)
 
-Status: Draft (proposed) — 2026-07-25
-Depends on: Otto v2.6.0 trusted-proxy features; ADR-024 config-resolution semantics
+Status: Draft (proposed) — 2026-07-25; classification handling revised 2026-08-13
+Depends on: Otto v2.6.0 trusted-proxy features; ADR-024 config-resolution
+semantics, in particular A12 (operator auth defaults require a positive
+operator classification, #4157)
 
 Tenant-configurable CIDR filtering that restricts which networks can reach a
 custom domain — an additional access-control layer alongside the existing
@@ -235,7 +237,8 @@ Gemfile constraint `'~> 2.5'` already admits it.
 ### Threat model and scope contract
 
 - **Scope: host-scoped, every request.** Enforcement applies to any request
-  whose resolved `env['onetime.domain_strategy'] == :custom` and whose
+  whose host is not positively an operator host (see "Classification" below
+  — *not* an `== :custom` test) and whose
   domain has an enabled access config — HTML, all `/api/*` mounts, secret
   reveal links, and the Roda `/auth` mount (all sit behind the universal
   middleware stack; `/auth` bypasses only Otto's *router*, not the Rack
@@ -255,8 +258,11 @@ Gemfile constraint `'~> 2.5'` already admits it.
 - **Fail-closed** when a policy is enforcing and either the capability
   returns false with no resolvable IP, or `otto.ip_match` is absent
   entirely (stack misconfiguration — log loudly; matches
-  `AdminNetworkIsolation` and `LocalhostGuard` posture). Fail-open (no-op)
-  when no config exists, config is disabled, or the entry list is empty.
+  `AdminNetworkIsolation` and `LocalhostGuard` posture), **or the config
+  read itself raises** (see "Classification"). Fail-open (no-op) when no
+  config exists, config is disabled, or the entry list is empty — i.e. the
+  policy was read and says nothing, which is not the same as failing to
+  read it.
 - **Granularity: full precision** — /32 (IPv4) and /128 (IPv6) entries are
   supported via the capability; the former /24–/48 floor (an artifact of
   matching against the masked IP) is lifted. The homepage-mode
@@ -274,6 +280,95 @@ falls back to the canonical anchor hosts rather than to a no-op.) An
 access-control feature that defaulted closed would brick every existing
 custom domain on deploy.
 
+That default-open polarity is exactly what makes this feature's handling of
+the host classification differ from every other auth gate, and why the A12
+rule cannot simply be copied. Read the next section before implementing.
+
+### Classification: which hosts are in scope, and the `:invalid` ambiguity
+
+This supersedes the original "pass through unless `== :custom`" gate. It is
+the one place where this spec deviates from ADR-024 A12 in *mechanism*,
+though not in intent.
+
+**The hazard.** `env['onetime.domain_strategy']` answers `:invalid` in two
+distinct situations (`DomainStrategy`'s class doc owns the full account):
+the host is genuinely unplaceable, or `known_custom_domain?` — a datastore
+read — *raised* and the blanket rescue in `choose_strategy` turned that into
+`:invalid` for what may be a perfectly real customer domain. A filter gated
+on `== :custom` therefore stops enforcing, entirely, for every protected
+domain for the duration of a datastore blip: a fail-open access-control
+bypass whose trigger is load. That is the shape A12, A3, A8 and A9 exist to
+refuse.
+
+**Why A12's remedy does not transfer.** A12 works because sign-in and
+sign-up have *opposite* defaults on the two branches, so picking the branch
+is itself the policy decision. Here both branches default **open**, so a
+positive operator test alone changes nothing — an unreadable host passes
+through either way. And the naive fail-closed reading (503 anything not
+positively an operator host) would deny every malformed or unknown host on
+an install where most custom domains have no access config at all. The
+polarity is inverted, so the mechanism has to move.
+
+**The resolution.** Split the decision in two, and put the fail-closed
+behavior on the *config read* rather than on the classification:
+
+1. **Scope test is positive, not `== :custom`.** Pass through only when
+   `Onetime::CustomDomain::SigninConfig.operator_host?(strategy)` is true
+   (`:canonical`, `:subdomain`). Reuse that predicate — do not restate the
+   list — so this filter cannot drift from the sign-in and sign-up gates
+   about which hosts are the operator's. `:custom`, `:invalid` and a
+   missing classification all fall through to step 2.
+2. **The config read disambiguates the two `:invalid` cases.** Resolve the
+   domain and load its `AccessConfig` *without* rescuing to nil:
+   - **no record** → pass through (default-open preserved: a genuinely
+     unplaceable host has no tenant and no policy);
+   - **read raises** → fail closed (a real tenant whose policy cannot be
+     read right now).
+
+   This works because the middleware is mounted immediately after
+   `DomainStrategy` and performs the same class of read that
+   `DomainStrategy` swallowed. On the healthy path the read is free — it is
+   served from the `env['onetime.custom_domain']` stash described below — so
+   the disambiguation costs a round-trip only when something is already
+   wrong.
+
+**Fail-closed response is 503, not 403.** A 403 block page tells the user
+they are on the wrong network. During a policy-read failure that is a lie,
+and it sends the customer hunting through their CIDR list for a
+misconfiguration that does not exist. Return **503 with `Retry-After`**,
+matching the `AuthPolicyUnavailable` family's posture
+(`SigninPolicyUnavailable` / `SignupPolicyUnavailable`,
+`lib/onetime/errors.rb`) and carrying its own `error_type` for alert
+routing. Note the mechanical difference: those two are *raised* and rendered
+by Otto's error handlers, which dispatch on exact class name — this filter
+sits in the Rack stack outside Otto's router, so it must **return** the 503
+directly. A shared `AccessPolicyUnavailable` class, if added, is for the
+management API's benefit, not the middleware's.
+
+**Monitor mode does not soften this.** `mode: monitor` downgrades a *miss*
+to a log line; it says nothing about an unreadable policy. A domain whose
+config cannot be read has no known mode, so the read failure is handled
+before mode is consulted. In practice a monitor-mode domain will still 503
+during a blip — that is the honest answer, the alternative is guessing at a
+policy, and it is bounded by the same outage already degrading the rest of
+the request path.
+
+**Consequence to accept, stated plainly.** Like A12, this is over-strict
+during an outage and never over-permissive, and it bites `:subdomain` for
+the same reason: the subdomain sweeps run *after* the datastore read, so a
+recognized operator subdomain classifies `:invalid` during a blip and falls
+to step 2 — where it finds no `AccessConfig` and passes through, or 503s if
+the read raises. `:canonical` is read-free and classifies before the read,
+so canonical traffic and the break-glass management path stay up. That
+invariant — a datastore failure can never *manufacture* `:canonical` — is
+what this design rests on; a new read added ahead of the canonical arm in
+`choose_strategy` would break it silently.
+
+**Follow-on rule for this feature's own gates.** Any future access-control
+decision added here (per-path exemptions, step-up, deny-lists) asks
+`operator_host?` for scope and treats an unreadable policy as unavailable.
+Only branding, routing and presentation may test `== :custom`.
+
 ### Enforcement middleware
 
 New `Onetime::Middleware::DomainAccessControl`, mounted in
@@ -289,10 +384,19 @@ it cannot be extended for this.
 
 Flow per request:
 
-1. Pass through unless `env['onetime.domain_strategy'] == :custom`.
-2. Load the domain's `AccessConfig`; pass through unless present, enabled,
-   and non-empty. (Dev note: the domain-context override forces `:custom`
-   for any non-canonical host — the no-record path must pass through.)
+1. Pass through if
+   `SigninConfig.operator_host?(env['onetime.domain_strategy'])` — a
+   positive test for `:canonical`/`:subdomain`, **not** `== :custom`. See
+   "Classification" above; `:invalid` and nil continue to step 2.
+2. Resolve the domain and load its `AccessConfig`, with the read failure
+   handled explicitly rather than rescued to nil:
+   - no record → pass through;
+   - record present but disabled, or entry list empty → pass through;
+   - the read raises → **503** (see "Classification"); log at `error` with
+     the masked IP and the display domain.
+
+   (Dev note: the domain-context override forces `:custom` for any
+   non-canonical host — the no-record path must pass through.)
 3. `allowed = env['otto.ip_match']&.call(compiled_entries)` — pre-parsed
    `IPAddr` entries; the capability handles family awareness and
    `#native` folding. `false` covers both "outside every range" and "no
@@ -302,7 +406,8 @@ Flow per request:
    through.
    Miss + `mode: enforce` → block response.
 
-Blocked response: **403** with a branded human-readable explanation page for
+Blocked response (a **miss** — the policy was read and this client is
+outside it): **403** with a branded human-readable explanation page for
 HTML, JSON error body for `PATH_INFO` starting `/api` — same content
 negotiation as `IPBan` (`lib/onetime/middleware/ip_ban.rb:44-46`). 404-style
 hiding (the `AdminNetworkIsolation` choice) is rejected here: customers
@@ -310,12 +415,17 @@ configuring a corporate allowlist want employees on the wrong network to
 understand why access failed (Atlassian model), and the domain's existence
 is not a secret.
 
-Performance: enforcement adds Redis reads only on custom-domain requests.
-Free win while in there: `DomainStrategy#known_custom_domain?`
+Performance: enforcement adds Redis reads only on non-operator hosts. The
+`env['onetime.custom_domain']` stash is a **prerequisite**, not a
+nice-to-have: `DomainStrategy#known_custom_domain?`
 (`lib/onetime/middleware/domain_strategy.rb:281-286`) already loads the
-`CustomDomain` record and discards it — stash it as
-`env['onetime.custom_domain']` so the filter (and downstream controllers
-that re-resolve) reuse it.
+`CustomDomain` record and discards it, so stashing it lets step 2 resolve
+the domain for free on the healthy path — that is what keeps the `:invalid`
+disambiguation from costing a round-trip per request. Downstream controllers
+that re-resolve reuse it too. The stash must carry the *record*, and its
+absence must stay distinguishable from "no such domain": if the strategy
+read raised, no stash was written, and step 2's own read is what decides
+between pass-through and 503.
 
 ### Storage model
 
@@ -413,6 +523,11 @@ recoverable).
   DoS vector. Sampled audit events at most.
 - Monitor mode reuses the same log line with `mode: monitor` so customers
   can trial a list against real traffic before enforcing.
+- **Policy-read failures** (the 503 path) get their own `error`-level line
+  and their own counter, never folded into the blocked-request counter. A
+  spike in "we could not read the policy" is an outage signal; averaging it
+  into "clients on the wrong network" hides exactly the failure mode this
+  design exists to make visible. Alert on it.
 
 ### Explicit non-goals (v1)
 
@@ -428,12 +543,12 @@ login-only enforcement mode, Terraform provider.
 | # | Work | Anchors |
 |---|---|---|
 | 1 | `AccessConfig` model + validation + schema doc + delegators/cleanup | `signin_config.rb` template; `custom_domain.rb:334-362,453` |
-| 2 | `DomainAccessControl` middleware + mount + env stash of resolved domain | `middleware_stack.rb:379`; `domain_strategy.rb:283`; `ip_ban.rb` response shape |
+| 2 | `DomainAccessControl` middleware + mount + env stash of resolved domain; `operator_host?` scope test and explicit read-failure → 503 path | `middleware_stack.rb:379`; `domain_strategy.rb:283`; `signin_config.rb` `operator_host?`; `ip_ban.rb` response shape |
 | 3 | API quartet + logic + authorization + entitlement key | `apps/api/domains/routes.txt:56-59`; `logic/signin_config/` template |
 | 4 | TS contract + workspace view/form + route | `src/schemas/contracts/custom-domain/`; `dashboard.ts:183-184` |
 | 5 | Colonel read-only block + CLI info line | `AdminDomainDetail.vue`; `cli/info_command.rb:79` |
 | 6 | Audit events + blocked-request logging/counter | `audit_trail.rb:60` |
-| 7 | Tests: middleware spec (strategy gating, monitor/enforce, fail-closed incl. missing `otto.ip_match`, exemptions, dev override, /32 precision), model tryouts (validation matrix), logic specs, contract vitest | `spec/unit/onetime/application/middleware_stack_spec.rb` neighborhood |
+| 7 | Tests: middleware spec (`operator_host?` scope gating incl. both `:invalid` cases — no record passes through, raising read 503s — monitor/enforce, fail-closed incl. missing `otto.ip_match`, exemptions, dev override, /32 precision), model tryouts (validation matrix), logic specs, contract vitest | `spec/unit/onetime/application/middleware_stack_spec.rb` neighborhood |
 | 8 | Docs: scope contract + lockout guidance; locales (`locales:hashes` run) | this file |
 | 9 | Separate fix: `AdminNetworkIsolation` narrow-CIDR latent bug — migrate its matching to `env['otto.ip_match']` once the otto release lands, which makes `/32` admin CIDRs work instead of merely rejecting them | `admin_network_isolation.rb:110-145` |
 | 10 | ~~Upstream Otto~~ **done 2026-07-25** (`ip_in_cidrs?`, privacy profiles, `otto.ip_match`; geo gate pre-existing on main). Remaining: commit/release otto, then bump the gem here | §3; `~/Projects/dev/delano/otto` |

--- a/docs/specs/domain-resolution/domain-resolution.md
+++ b/docs/specs/domain-resolution/domain-resolution.md
@@ -1,0 +1,294 @@
+# docs/specs/domain-resolution/domain-resolution.md
+
+created: 2026-08-13
+---
+
+# Domain Resolution
+
+## Problem space
+
+The application serves two types of domains:
+
+1. **Operator domains** — the main application domain and its recognized subdomains.
+   These use the operator’s global settings for sign-in and sign-up.
+
+2. **Customer custom domains** — domains owned by tenants/customers.
+   These are intentionally more restrictive: sign-in and sign-up are off unless the tenant explicitly enables them.
+
+Before applying those rules, `DomainStrategy` classifies the request host as:
+
+- `:canonical` — main operator domain
+- `:subdomain` — recognized operator subdomain
+- `:custom` — known customer domain
+- `:invalid` — unknown or invalid domain
+
+### The ambiguity
+
+`:invalid` currently means two different things:
+
+- The hostname genuinely is not recognized or is malformed.
+- The hostname is a real customer domain, but the custom-domain datastore lookup temporarily failed.
+
+The code cannot distinguish those cases after classification.
+
+### Why it matters
+
+Many consumers use a check equivalent to:
+
+> “Is this exactly a custom domain?”
+
+If the answer is no, they take the operator-domain behavior.
+
+That is harmless for presentation details such as logos or favicons. It is unsafe for sign-in and sign-up:
+
+- A custom domain with no per-domain configuration defaults to **off**.
+- An operator domain follows the global setting, which may be **on**.
+
+So a transient Redis/datastore failure can cause a customer domain to be classified as `:invalid`, then treated like the operator site. If global signup is on, the customer’s domain can temporarily allow signup even though that customer never enabled it. Sign-in has the same inverted-default risk.
+
+This is an availability failure turning into an access-policy widening.
+
+## Constraints on a fix
+
+A fix should preserve two distinct behaviors:
+
+- A genuinely unknown/malformed host should retain its current generic, non-tenant presentation.
+- A host that might be a customer domain must not gain operator authentication defaults merely because the app could not confirm its identity.
+
+It must also respect an important classifier property:
+
+- A datastore failure cannot create a `:canonical` or `:subdomain` result.
+- It can turn a custom domain—and currently a subdomain—into `:invalid`.
+
+Therefore only a **positive** `:canonical` or `:subdomain` classification is sufficient evidence to apply operator defaults. “Anything other than `:custom`” is not sufficient evidence.
+
+## Potential solutions
+
+### 1. Resolver-side fail-closed behavior
+
+Pass the request’s domain classification into the sign-in and sign-up resolvers.
+
+The resolver would apply the operator/global default only when the classification is positively known to be operator-owned:
+
+```text
+canonical or subdomain → use global/operator default
+custom, invalid, missing → use tenant-safe default
+```
+
+For sign-in/sign-up, the tenant-safe default is disabled unless the tenant’s own configuration explicitly enables it.
+
+**Benefits**
+
+- Fixes the actual security issue.
+- Keeps generic/unknown-host rendering behavior unchanged.
+- Centralizes this security rule at the policy-resolution layer.
+- Matches the existing `SigninConfig.operator_host?` approach used for unreadable-policy failures.
+
+**Trade-off**
+
+- During an outage, a recognized operator subdomain can be treated more strictly than normal because it may become `:invalid`. That is a fail-closed availability cost, not an access widening.
+
+### 2. Preserve failure provenance in the classifier
+
+Instead of collapsing all failures into `:invalid`, return a more specific classification, such as:
+
+```text
+:invalid_host
+:custom_lookup_unavailable
+```
+
+Consumers could then explicitly handle the latter as a tenant-safe failure.
+
+**Benefits**
+
+- Accurately represents what happened.
+- Could help logging, metrics, response status choices, and future policies.
+
+**Trade-offs**
+
+- Requires updating every consumer of domain classification.
+- Easy to miss a consumer and recreate inconsistent behavior.
+- Broader change than the issue requires.
+
+This may be useful later, but it is not necessary to close the security gap.
+
+### 3. Change `custom_domain_request?` so anything non-operator is tenant-like
+
+One tempting fix is to redefine “custom domain request” as:
+
+```text
+not canonical and not subdomain
+```
+
+That would cause `:invalid` hosts to receive tenant behavior.
+
+**Why this is wrong**
+
+It also treats genuinely malformed and unknown hostnames as tenant domains. That can incorrectly apply tenant branding, tenant routing, or other tenant-specific behavior where no tenant exists. It fixes one policy decision by breaking the intended meaning of unrelated presentation and routing decisions.
+
+The issue explicitly rules this approach out.
+
+### 4. Fail all `:invalid` requests with a 503 — possible but too broad
+
+The application could reject every request classified as `:invalid`.
+
+**Benefits**
+
+- Prevents accidental fallback to operator policy.
+
+**Trade-offs**
+
+- Changes normal behavior for unknown/malformed hosts.
+- Makes a generic bad-host condition look like a service outage.
+- Affects cosmetic and public routes unnecessarily.
+- Does not distinguish a hostile/invalid host from a temporary infrastructure problem.
+
+This is generally too blunt unless the application wants a separate host-validation policy.
+
+### 5. Retry the custom-domain lookup — supplementary only
+
+The classifier could retry transient datastore reads before returning `:invalid`.
+
+**Benefits**
+
+- Might reduce the frequency of misclassification.
+
+**Why it is insufficient**
+
+- A retry can still fail.
+- It adds latency during degraded infrastructure.
+- It does not establish the safe behavior when the retry also fails.
+
+Retries can complement, but cannot replace, a fail-closed policy decision.
+
+---
+
+## Assessment
+
+The problem statement and core security analysis are correct.
+
+This is a fail-open authorization-policy bug:
+
+```text
+custom domain
+→ datastore lookup fails
+→ :invalid
+→ “not custom”
+→ operator/global default
+→ authentication may become enabled
+```
+
+A classification failure must not widen authentication access.
+
+## Recommended solution
+
+Resolver-side fail-closed behavior is the best targeted fix. Operator defaults should require positive evidence:
+
+```ruby
+SigninConfig.operator_host?(domain_strategy)
+```
+
+Only `:canonical` and `:subdomain` should inherit operator defaults. `:custom`, `:invalid`, and `nil` should use tenant-safe semantics.
+
+The other proposed solutions are correctly rejected or deferred:
+
+- Changing `custom_domain_request?` would contaminate branding and routing semantics.
+- Returning 503 for every `:invalid` host changes unrelated unknown-host behavior.
+- Retrying does not define safe terminal behavior.
+- Preserving failure provenance is useful observability work, but broader than necessary.
+
+## Implementation refinements
+
+### 1. Update every authentication decision surface
+
+The runtime controller is not the only relevant consumer.
+
+Current operator-fallback behavior exists in:
+
+- `apps/web/core/controllers/base.rb`
+  - `signin_enabled?`
+  - `signup_enabled?`
+- `apps/web/core/views/serializers/config_serializer.rb`
+  - `resolve_signin`
+
+If only the controller changes, the `/signin` page can advertise availability while the POST route rejects it. The existing comments explicitly require display/runtime parity.
+
+Signup presentation paths should also be checked, although `DomainSerializer` already uses the custom-domain-specific resolver.
+
+### 2. Avoid silently changing context-free resolver semantics
+
+The current generic methods have established operator-style behavior:
+
+```ruby
+resolve_signin_enabled(global, nil) # global
+resolve_signup_enabled(global, nil) # global
+```
+
+They are also used internally by the custom-domain resolvers and by non-request contexts. Making an omitted `domain_strategy` implicitly mean tenant-safe could alter administrative/API calculations unexpectedly.
+
+Prefer either:
+
+```ruby
+resolve_signin_enabled(global, config, domain_strategy:)
+resolve_signup_enabled(global, config, domain_strategy:)
+```
+
+with a required keyword for request-aware calls, or add explicitly named request resolvers:
+
+```ruby
+resolve_signin_enabled_for_request(...)
+resolve_signup_enabled_for_request(...)
+```
+
+The request-aware resolver can delegate to the existing operator/custom resolvers:
+
+```ruby
+if SigninConfig.operator_host?(domain_strategy)
+  resolve_signin_enabled(global, config)
+else
+  resolve_signin_enabled_for_custom_domain(global, config)
+end
+```
+
+This keeps existing context-free semantics explicit and minimizes accidental regressions.
+
+### 3. Preserve the sign-in SSO distinction
+
+`resolve_signin_enabled_for_custom_domain` has two intentional modes:
+
+- Runtime password/email POST gate: no `domain_id`, strictly disabled without enabled `SigninConfig`.
+- Display gate: receives `domain_id`, allowing the independently configured tenant-SSO carve-out.
+
+The classification-aware change must preserve that distinction. It should not accidentally hide valid tenant SSO or allow SSO configuration to enable password/email POST handling.
+
+### 4. Treat unreadable tenant configuration as unavailable
+
+“Disabled unless explicitly enabled” means the application must successfully read the tenant policy. If the follow-up `SigninConfig` or `SignupConfig` lookup also fails, the application cannot establish explicit enablement and must remain closed.
+
+The sign-in path already has `SigninPolicyUnavailable` handling. Verify signup has equivalent failure handling; classification-aware resolution alone does not protect against a later policy read raising.
+
+## Required test matrix
+
+For global authentication enabled and no tenant configuration:
+
+| Classification | Expected |
+| -------------- | -------: |
+| `:canonical`   |  enabled |
+| `:subdomain`   |  enabled |
+| `:custom`      | disabled |
+| `:invalid`     | disabled |
+| `nil`          | disabled |
+
+Also test:
+
+- Global disabled remains disabled for every classification.
+- Enabled tenant config can only narrow the global capability.
+- `:invalid` with successfully resolved, explicitly enabled tenant config follows the intended policy.
+- Unreadable tenant policy fails closed.
+- Runtime and serialized/display results agree.
+- Sign-in SSO-only display behavior remains available while password/email POST remains disabled.
+- String classifications, if accepted through `operator_host?`, behave consistently with symbols.
+
+## Conclusion
+
+Solution 1 is the correct immediate remediation, with one qualification: implement it as a request-aware policy resolver and propagate it to both runtime and display consumers. Do not redefine domain identity predicates. Preserve failure provenance later for diagnostics and metrics, but it is not required to close this access-policy widening.

--- a/docs/specs/domain-resolution/domain-resolution.md
+++ b/docs/specs/domain-resolution/domain-resolution.md
@@ -1,7 +1,6 @@
 # docs/specs/domain-resolution/domain-resolution.md
 
-created: 2026-08-13
----
+## created: 2026-08-13
 
 # Domain Resolution
 
@@ -292,3 +291,160 @@ Also test:
 ## Conclusion
 
 Solution 1 is the correct immediate remediation, with one qualification: implement it as a request-aware policy resolver and propagate it to both runtime and display consumers. Do not redefine domain identity predicates. Preserve failure provenance later for diagnostics and metrics, but it is not required to close this access-policy widening.
+
+## Long-term mitigation
+
+The durable solution is **typed classification with explicit trust and failure provenance**, combined with **centralized policy resolution**.
+
+Solution 1 should remain the security boundary. Solution 2 should eventually improve the information supplied to that boundary.
+
+### 1. Replace ambiguous symbols with a structured result
+
+`DomainStrategy` should return an object rather than a bare symbol:
+
+```ruby
+DomainResolution.new(
+  classification: :custom,
+  trust: :confirmed,
+  host: normalized_host,
+  tenant_id: domain_id,
+)
+```
+
+Failure example:
+
+```ruby
+DomainResolution.new(
+  classification: :unknown,
+  trust: :indeterminate,
+  reason: :custom_lookup_unavailable,
+  host: normalized_host,
+)
+```
+
+Useful states include:
+
+- Confirmed operator host
+- Confirmed customer host, ideally including `tenant_id`
+- Confirmed unknown or malformed host
+- Indeterminate because tenant lookup was unavailable
+
+The critical distinction is not merely `:invalid_host` versus `:custom_lookup_unavailable`. It is:
+
+```text
+confirmed operator
+confirmed tenant
+confirmed non-tenant
+indeterminate
+```
+
+### 2. Make authentication policy consume positive authority
+
+Centralize request policy resolution:
+
+```ruby
+AuthenticationPolicy.for(domain_resolution)
+```
+
+Its invariant should be:
+
+```text
+Operator defaults require a confirmed operator classification.
+Tenant permissions require confirmed tenant identity and readable tenant policy.
+Everything indeterminate fails closed.
+```
+
+This avoids negative tests such as:
+
+```ruby
+strategy != :custom
+```
+
+Individual controllers and serializers should consume the resolved policy rather than interpret domain classifications themselves.
+
+### 3. Separate identity, presentation, and security decisions
+
+A single predicate such as `custom_domain_request?` should not control unrelated concerns.
+
+Use distinct interfaces:
+
+```ruby
+resolution.presentation_context
+resolution.routing_context
+resolution.authentication_authority
+```
+
+That permits:
+
+- Unknown hosts to retain generic presentation.
+- Indeterminate hosts to avoid tenant branding.
+- Authentication to remain closed whenever operator ownership is not positively established.
+
+Generic presentation does not imply operator authorization.
+
+### 4. Resolve tenant identity once
+
+When custom-domain lookup succeeds, include the tenant/domain identifier in the resolution object. Downstream code should not independently repeat:
+
+```ruby
+CustomDomain.load_by_display_domain(host)
+```
+
+Repeated reads create inconsistent snapshots:
+
+1. Middleware lookup succeeds.
+2. A later lookup fails or returns different data.
+3. Routing, branding, and authentication disagree.
+
+One request should carry one authoritative domain-resolution result. Tenant policy reads can then use its confirmed `tenant_id`.
+
+### 5. Define explicit failure behavior
+
+For an indeterminate domain:
+
+- Authentication-enabling endpoints: reject, preferably with `503`.
+- Public/generic rendering: continue where safe.
+- Tenant-specific routing or sensitive operations: reject.
+- Branding: use generic presentation.
+- Logs and metrics: record lookup unavailability separately from invalid input.
+
+This preserves availability for harmless routes without widening access.
+
+### 6. Enforce the invariant structurally
+
+Use exhaustive handling instead of permissive `else` branches:
+
+```ruby
+case resolution.authentication_authority
+when :operator
+  operator_policy
+when :tenant
+  tenant_policy
+when :none, :indeterminate
+  disabled_policy
+else
+  raise "Unhandled authentication authority"
+end
+```
+
+Adding a new classification should cause tests—or preferably runtime construction validation/static exhaustiveness—to fail until its security behavior is chosen explicitly.
+
+Ban direct classification interpretation outside the domain-resolution/policy layer.
+
+### Migration path
+
+1. **Immediately:** implement classification-aware, fail-closed request resolvers.
+2. Introduce `DomainResolution` while retaining compatibility accessors for existing consumers.
+3. Carry confirmed `tenant_id` in the resolution.
+4. Move authentication decisions into one request-level policy object.
+5. Migrate consumers by concern: authentication first, then routing and presentation.
+6. Remove direct symbol comparisons after all consumers migrate.
+7. Add metrics for malformed, unknown, and lookup-unavailable outcomes.
+
+## Bottom line
+
+The long-term design is not classifier provenance alone. It is:
+
+> **Structured domain resolution, positive authority checks, one resolution per request, and centralized fail-closed security policy.**
+
+That makes an ambiguous or newly introduced classification unable to inherit operator permissions accidentally.

--- a/lib/onetime/application/otto_hooks.rb
+++ b/lib/onetime/application/otto_hooks.rb
@@ -188,6 +188,22 @@ module Onetime
           with_error_correlation(error.to_h, req, error)
         end
 
+        # The sign-up gate could not read this host's SignupConfig (#4157).
+        # Raised by Onetime::Logic::SignupConfigResolution — so from
+        # Core::Controllers::Base#signup_enabled? (POST /auth/create-account)
+        # and from CreateAccount's autoverify resolution.
+        #
+        # Registered separately from the sign-in handler above because Otto
+        # dispatches on the EXACT class name (Otto::Core::ErrorHandler looks up
+        # error.class.name), so the shared Onetime::AuthPolicyUnavailable
+        # parent buys the shape but not the routing. Identical status, level
+        # and body construction to its sibling: same failure, and the only
+        # thing that should differ between the two responses is the error_type
+        # and the sentence a user reads.
+        router.register_error_handler(Onetime::SignupPolicyUnavailable, status: 503, log_level: :error) do |error, req|
+          with_error_correlation(error.to_h, req, error)
+        end
+
         return unless Onetime.debug?
 
         router.on_request_complete do |req, res, duration|

--- a/lib/onetime/errors.rb
+++ b/lib/onetime/errors.rb
@@ -92,7 +92,8 @@ module Onetime
 
   # An authentication gate could not READ the policy for the request host
   # (ADR-034#restrict-to-is-an-access-control-not-a-display-preference /
-  # #degradation-is-fail-closed, ADR-024 A1/A3/A12, #4139/#4157): the
+  # #degradation-is-fail-closed,
+  # ADR-024#operator-defaults-require-positive-classification, #4139/#4157): the
   # per-domain half of that policy lives in the datastore, so a read failure
   # leaves the gate unable to say what this host permits. Sign-in and sign-up
   # each get a subclass; the SHAPE lives here exactly once, because the two
@@ -101,12 +102,13 @@ module Onetime
   # Maps to HTTP 503 at every edge — otto_hooks (Core, invite API) and
   # Auth::ErrorTranslator (the Roda auth router) — because that is the piece
   # that makes unconditional fail-closed survivable. A gate's normal reject
-  # shape is a 404 (A7) whose whole point is to be indistinguishable from an
+  # shape is a 404 (ADR-034#reject-as-not-found-not-forbidden) whose whole
+  # point is to be indistinguishable from an
   # undefined route, or a bare redirect home; answering an unreadable policy
   # the same way would put mystery not-founds on the auth routes of an install
   # that restricts nothing, indistinguishable from a routing regression. A 503
   # says what actually happened — a backend read failed, retry — and is
-  # alertable as itself. A7's 404 exists to hide policy-gated methods; when the
+  # alertable as itself. That 404 exists to hide policy-gated methods; when the
   # policy is unreadable there is no policy to hide.
   #
   # NOT a FormError/Forbidden: nothing about the request is wrong.

--- a/lib/onetime/errors.rb
+++ b/lib/onetime/errors.rb
@@ -90,43 +90,73 @@ module Onetime
     end
   end
 
-  # Raised when the `restrict_to` policy for the REQUEST HOST could not be
-  # read (ADR-034#restrict-to-is-an-access-control-not-a-display-preference /
-  # #degradation-is-fail-closed, #4139): the per-domain half of the policy lives in
-  # the datastore, and a read failure leaves the gate unable to say which
-  # sign-in methods this host permits.
+  # An authentication gate could not READ the policy for the request host
+  # (ADR-034#restrict-to-is-an-access-control-not-a-display-preference /
+  # #degradation-is-fail-closed, ADR-024 A1/A3/A12, #4139/#4157): the
+  # per-domain half of that policy lives in the datastore, so a read failure
+  # leaves the gate unable to say what this host permits. Sign-in and sign-up
+  # each get a subclass; the SHAPE lives here exactly once, because the two
+  # must not drift into differently-formed 503s for the identical failure.
   #
-  # Maps to HTTP 503 in BOTH edges — otto_hooks (Core, invite API) and
+  # Maps to HTTP 503 at every edge — otto_hooks (Core, invite API) and
   # Auth::ErrorTranslator (the Roda auth router) — because that is the piece
-  # that makes unconditional fail-closed survivable. The gate's normal reject
+  # that makes unconditional fail-closed survivable. A gate's normal reject
   # shape is a 404 (A7) whose whole point is to be indistinguishable from an
-  # undefined route; answering an unreadable policy the same way would put
-  # mystery 404s on the sign-in routes of an install that restricts nothing,
-  # indistinguishable from a routing regression. A 503 says what actually
-  # happened — a backend read failed, retry — and is alertable as itself.
-  # A7's 404 exists to hide policy-gated methods; when the policy is
-  # unreadable there is no policy to hide.
+  # undefined route, or a bare redirect home; answering an unreadable policy
+  # the same way would put mystery not-founds on the auth routes of an install
+  # that restricts nothing, indistinguishable from a routing regression. A 503
+  # says what actually happened — a backend read failed, retry — and is
+  # alertable as itself. A7's 404 exists to hide policy-gated methods; when the
+  # policy is unreadable there is no policy to hide.
   #
   # NOT a FormError/Forbidden: nothing about the request is wrong.
-  class SigninPolicyUnavailable < Problem
-    DEFAULT_MESSAGE = 'Sign-in is temporarily unavailable. Please try again shortly.'
-
+  #
+  # Otto resolves error handlers by EXACT class name (Otto::Core::ErrorHandler
+  # looks up `error.class.name`), so every subclass needs its own
+  # register_error_handler entry in lib/onetime/application/otto_hooks.rb —
+  # inheriting from this class is not enough to inherit the 503.
+  class AuthPolicyUnavailable < Problem
     # Seconds. Surfaced in the body (Otto error handlers cannot set response
     # headers) and lifted into a Retry-After header by
     # Onetime::Middleware::RetryAfterHeader.
     RETRY_AFTER = 5
 
-    def initialize(message = DEFAULT_MESSAGE)
+    def initialize(message = self.class::DEFAULT_MESSAGE)
       super
     end
 
+    # error_type is derived from the class name rather than restated per
+    # subclass: the two surfaces must be separable in alerting (a 503 on
+    # sign-up is a different page being down than a 503 on sign-in) without
+    # anyone having to keep a hand-written string in sync with the class.
     def to_h
       {
         error: message,
-        error_type: 'SigninPolicyUnavailable',
-        retry_after: RETRY_AFTER,
+        error_type: self.class.name.split('::').last,
+        retry_after: self.class::RETRY_AFTER,
       }
     end
+  end
+
+  # The `restrict_to` / sign-in policy for the REQUEST HOST could not be read.
+  # Raised by Core::Controllers::Base#signin_policy_read_failed! and by
+  # SigninConfig.resolve_lookup_failure.
+  class SigninPolicyUnavailable < AuthPolicyUnavailable
+    DEFAULT_MESSAGE = 'Sign-in is temporarily unavailable. Please try again shortly.'
+  end
+
+  # The sign-up policy for the REQUEST HOST could not be read (#4157). Same
+  # rule and same shape as the sign-in sibling above, deliberately NOT the same
+  # class: the user-visible copy would otherwise say "sign-in" on a failed
+  # POST /auth/create-account, and the error_type is what routes the alert.
+  #
+  # The decision to raise is not restated here or at the call sites — it is
+  # SignupConfig.resolve_lookup_failure, which carves out positively-classified
+  # operator hosts via the same SigninConfig.operator_host? predicate the
+  # sign-in path uses, so the two gates cannot disagree about which hosts
+  # survive a datastore blip.
+  class SignupPolicyUnavailable < AuthPolicyUnavailable
+    DEFAULT_MESSAGE = 'Sign-up is temporarily unavailable. Please try again shortly.'
   end
 
   class RecordNotFound < Problem

--- a/lib/onetime/logic/signup_config_resolution.rb
+++ b/lib/onetime/logic/signup_config_resolution.rb
@@ -50,7 +50,7 @@ module Onetime
         dd = signup_config_display_domain
         return unless dd
 
-        custom_domain = Onetime::CustomDomain.load_by_display_domain(dd)
+        custom_domain = Onetime::CustomDomain.from_display_domain(dd)
         return unless custom_domain
 
         Onetime::CustomDomain::SignupConfig.find_by_domain_id(custom_domain.identifier)

--- a/lib/onetime/logic/signup_config_resolution.rb
+++ b/lib/onetime/logic/signup_config_resolution.rb
@@ -8,10 +8,26 @@ module Onetime
     #
     # Includers must provide:
     #   - #signup_config_display_domain  → String or nil
+    #   - #signup_config_domain_strategy → env['onetime.domain_strategy'] for
+    #     this request (Symbol/String/nil). Only consulted on the read-failure
+    #     path; see #signup_config_domain_strategy below for what the default
+    #     costs you.
     #   - #signup_config_auth_setting(key) → the value of auth.{key} from site config
     module SignupConfigResolution
       private
 
+      # AUTOVERIFY IS A POLICY READ TOO (#4157). It reaches the same two
+      # datastore reads as the gate, so it inherits the same fail-closed rule
+      # rather than a softer one: falling back to the global autoverify setting
+      # on a host whose tenant config is unreadable auto-verifies accounts on a
+      # custom domain whose owner never opted into that — a widen, in the same
+      # direction and for the same reason as the gate's.
+      #
+      # This never fires ahead of the gate in practice: POST
+      # /auth/create-account (the only route reaching CreateAccount) runs
+      # Core::Controllers::Base#signup_enabled? first, and that raises on the
+      # same read. So the raise here is a backstop for any future caller that
+      # resolves autoverify without passing the gate, not the primary defense.
       def resolve_autoverify
         config = domain_signup_config
         return config.autoverify? if config&.enabled?
@@ -19,6 +35,17 @@ module Onetime
         signup_config_auth_setting('autoverify').to_s == 'true'
       end
 
+      # The tenant's SignupConfig for the request host, or nil when the host has
+      # none (including every operator host).
+      #
+      # Guarded at the READ, not at each gate, for the same reason the sign-in
+      # side is (Core::Controllers::Base#signin_policy_read_failed!): both
+      # reads here are policy reads, and #signup_enabled? plus
+      # #resolve_autoverify both go through them, so a rescue in one caller
+      # would leave the other crashing as an unhandled 500.
+      #
+      # @raise [Onetime::SignupPolicyUnavailable] on a non-operator host whose
+      #   policy could not be read
       def domain_signup_config
         dd = signup_config_display_domain
         return unless dd
@@ -27,6 +54,36 @@ module Onetime
         return unless custom_domain
 
         Onetime::CustomDomain::SignupConfig.find_by_domain_id(custom_domain.identifier)
+      rescue Redis::BaseError => ex
+        signup_policy_read_failed!(ex)
+      end
+
+      # The per-domain sign-up policy could not be read. Logged here, DECIDED
+      # by the model (SignupConfig.resolve_lookup_failure) so this mixin, the
+      # sign-in gate and any future consumer share one rule about which hosts
+      # survive an unreadable policy instead of each re-deriving it.
+      #
+      # @raise [Onetime::SignupPolicyUnavailable] on any non-operator host
+      # @return [nil] on an operator host
+      def signup_policy_read_failed!(exception)
+        OT.le "[signup] Sign-up policy lookup failed host=#{signup_config_display_domain} #{exception.class}"
+
+        Onetime::CustomDomain::SignupConfig.resolve_lookup_failure(
+          domain_strategy: signup_config_domain_strategy,
+        )
+      end
+
+      # Default classification for an includer that does not supply one: nil,
+      # which operator_host? rejects, so the read-failure path fails CLOSED for
+      # such a caller on every host — including the canonical one. That is the
+      # safe direction to be wrong in (a 503 during a datastore outage, never a
+      # widen), but it is over-strict, so a request-scoped includer should
+      # override this with the request's real classification. Both current
+      # includers do: Core::Controllers::Base reads env['onetime.domain_strategy']
+      # and AccountAPI::Logic::Account::CreateAccount reads the same value off
+      # Onetime::Logic::Base#domain_strategy.
+      def signup_config_domain_strategy
+        nil
       end
     end
   end

--- a/lib/onetime/middleware/domain_strategy.rb
+++ b/lib/onetime/middleware/domain_strategy.rb
@@ -69,18 +69,43 @@ module Onetime
     #
     # ## How downstream reads this
     #
-    # Every consumer below except the first tests `== :custom`, so :invalid,
-    # nil and :default all take the operator branch. This table is pinned by
+    # Consumers split into two groups, and the split IS the policy (ADR-024
+    # A12):
+    #
+    # - AUTH decisions ask a POSITIVE test — `SigninConfig.operator_host?`,
+    #   true for :canonical/:subdomain only. Everything else fails closed with
+    #   the custom domains, including nil.
+    # - IDENTITY / presentation decisions test `== :custom`, so :invalid and
+    #   nil take the operator/generic branch. That is correct for branding and
+    #   routing: a genuinely unplaceable host has no tenant.
+    #
+    # `call` always sets the env key, so nil reaches a consumer only outside a
+    # served request (internal callers, code invoked off the Rack path). Both
+    # groups already answer it correctly: fail-closed for auth, generic for
+    # presentation. One exception to know about — the view layer substitutes its
+    # own `:default` sentinel when the key is absent
+    # (InitializeViewVars: `req.env.fetch('onetime.domain_strategy', :default)`),
+    # which is not a classification this middleware can produce; it is neither
+    # :custom nor an operator host, so it lands on the same safe branches.
+    #
+    # This table is pinned by
     # spec/unit/domain_strategy_classification_contract_spec.rb — a new
     # consumer that disagrees with it fails there, not in review.
     #
     #   Consumer                                         :invalid resolves to
     #   ------------------------------------------------ --------------------
+    #   -- positive operator_host? test (auth) --
     #   SigninConfig.operator_host?                       FAIL CLOSED (503)
     #     (via resolve_lookup_failure; read-failure path only)
+    #   SigninConfig.resolve_signin_enabled_for_request   tenant-safe (OFF)
+    #   SignupConfig.resolve_signup_enabled_for_request   tenant-safe (OFF)
+    #   Base#signin_enabled? (via the request resolver)   tenant-safe (OFF)
+    #   Base#signup_enabled? (via the request resolver)   tenant-safe (OFF)
+    #   ConfigSerializer#operator_domain?                 false
+    #   ConfigSerializer#resolve_signin (via that helper) tenant-safe (OFF,
+    #                                                     SSO carve-out only)
+    #   -- `== :custom` identity test (branding, routing, narrowing) --
     #   Core::Controllers::Base#custom_domain_request?    false
-    #   Base#signin_enabled?                              operator polarity
-    #   Base#signup_enabled?                              operator polarity
     #   Auth::RestrictTo `custom_host:`                   false (no narrowing)
     #   Auth::RestrictTo host pin                         no 'sso' pin
     #   ConfigSerializer#tenant_domain?                   false
@@ -88,10 +113,13 @@ module Onetime
     #   InitializeViewVars / GetFavicon                   default favicon
     #   API v1 Logic::Base#custom_domain?                 false
     #
-    # "Operator polarity" is the load-bearing row: custom domains are
-    # default-OFF for sign-in and sign-up, canonical follows the global
-    # default, so a case-2 :invalid INVERTS the default (unresolved — no ADR
-    # entry covers this asymmetry yet).
+    # The auth rows used to read "operator polarity": they chose their branch
+    # on `== :custom`, so a case-2 :invalid INVERTED the default — custom
+    # domains are default-OFF for sign-in and sign-up while canonical follows
+    # the operator's global setting. They now require positive evidence, and
+    # the display gate (ConfigSerializer) moves with the runtime gates so the
+    # /signin page cannot advertise what the POST will reject. The identity
+    # predicates were deliberately left alone. See ADR-024 A12.
     class DomainStrategy
       include Onetime::LoggerMethods
 

--- a/lib/onetime/middleware/domain_strategy.rb
+++ b/lib/onetime/middleware/domain_strategy.rb
@@ -69,8 +69,8 @@ module Onetime
     #
     # ## How downstream reads this
     #
-    # Consumers split into two groups, and the split IS the policy (ADR-024
-    # A12):
+    # Consumers split into two groups, and the split IS the policy
+    # (ADR-024#identity-predicates-are-not-auth-gates):
     #
     # - AUTH decisions ask a POSITIVE test — `SigninConfig.operator_host?`,
     #   true for :canonical/:subdomain only. Everything else fails closed with
@@ -119,7 +119,8 @@ module Onetime
     # the operator's global setting. They now require positive evidence, and
     # the display gate (ConfigSerializer) moves with the runtime gates so the
     # /signin page cannot advertise what the POST will reject. The identity
-    # predicates were deliberately left alone. See ADR-024 A12.
+    # predicates were deliberately left alone.
+    # ADR-024#identity-predicates-are-not-auth-gates
     class DomainStrategy
       include Onetime::LoggerMethods
 

--- a/lib/onetime/models/custom_domain.rb
+++ b/lib/onetime/models/custom_domain.rb
@@ -1250,14 +1250,23 @@ module Onetime
         instances.rangebyscoreraw(spoint, epoint).collect { |identifier| load(identifier) }
       end
 
-      # Load a custom domain by display domain only. Used during requests
-      # after determining the domain strategy is :custom.
+      # Finds a custom domain by its display domain.
       #
-      # @param display_domain [String] The display domain to load
-      # @return [Onetime::CustomDomain, nil] The custom domain record or nil if not found
+      # The lookup normalizes `display_domain` to lowercase to match the index.
+      # Returns `nil` when the domain is blank, absent from the index, or its
+      # indexed record no longer exists. Datastore errors intentionally propagate:
+      # callers use this lookup to resolve tenant policy and must not treat a failed
+      # read as an absent tenant configuration.
+      #
+      # @param display_domain [String, #to_s] Display domain to look up
+      # @return [Onetime::CustomDomain, nil]
+      # @raise [Redis::BaseError] if reading the index or domain record fails
       def from_display_domain(display_domain)
+        normalized = display_domain.to_s.downcase
+        return nil if normalized.empty?
+
         # Get the domain ID from the display_domain_index hash
-        domain_id = display_domain_index.get(display_domain)
+        domain_id = display_domain_index.get(normalized)
         return nil unless domain_id
 
         # Load the record using the domain ID

--- a/lib/onetime/models/custom_domain/signin_config.rb
+++ b/lib/onetime/models/custom_domain/signin_config.rb
@@ -375,7 +375,8 @@ module Onetime
         end
 
         # Effective sign-in availability for a REQUEST, chosen by the request's
-        # DomainStrategy classification (ADR-024 A12).
+        # DomainStrategy classification.
+        # ADR-024#operator-defaults-require-positive-classification
         #
         # OPERATOR DEFAULTS REQUIRE POSITIVE EVIDENCE. The two context-free
         # resolvers above have OPPOSITE defaults — resolve_signin_enabled

--- a/lib/onetime/models/custom_domain/signin_config.rb
+++ b/lib/onetime/models/custom_domain/signin_config.rb
@@ -374,6 +374,47 @@ module Onetime
           resolve_signin_enabled(global, config)
         end
 
+        # Effective sign-in availability for a REQUEST, chosen by the request's
+        # DomainStrategy classification (ADR-024 A12).
+        #
+        # OPERATOR DEFAULTS REQUIRE POSITIVE EVIDENCE. The two context-free
+        # resolvers above have OPPOSITE defaults — resolve_signin_enabled
+        # follows the operator's global setting, resolve_signin_enabled_for_custom_domain
+        # is default-OFF — so choosing between them IS the access-policy
+        # decision. Choosing on `== :custom` picks the operator branch for
+        # :invalid and nil as well, and :invalid is what DomainStrategy answers
+        # when its own datastore read RAISES for a REAL customer domain. A blip
+        # would then hand that domain the operator's global default, i.e. an
+        # availability failure widening authentication access on a domain whose
+        # owner never opted in.
+        #
+        # So this asks operator_host?, a POSITIVE test: only :canonical and
+        # :subdomain — the two classifications a datastore failure can never
+        # manufacture — inherit operator defaults. :custom, :invalid and nil all
+        # take the tenant-safe branch. The cost is fail-closed, not fail-open: a
+        # recognized subdomain can be held to the stricter default during an
+        # outage (the subdomain sweep runs after the datastore read, so it is
+        # withdrawn too), which denies nothing that was ever explicitly granted.
+        #
+        # The domain identity predicates are deliberately NOT redefined to match
+        # (Core::Controllers::Base#custom_domain_request?,
+        # ConfigSerializer.tenant_domain?): those also decide branding, routing
+        # and tenant presentation, which a genuinely unknown host must not
+        # receive. The fix belongs here, at policy resolution, not there.
+        #
+        # @param global [Boolean] install-level availability (auth.enabled && auth.signin)
+        # @param config [SigninConfig, nil] the per-domain config, if any
+        # @param domain_strategy [Symbol, String, nil] env['onetime.domain_strategy']
+        # @param domain_id [String, nil] CustomDomain identifier; pass it on
+        #   DISPLAY surfaces to keep the tenant-SSO carve-out, omit it on the
+        #   password/email POST gate (see resolve_signin_enabled_for_custom_domain)
+        # @return [Boolean]
+        def resolve_signin_enabled_for_request(global, config, domain_strategy:, domain_id: nil)
+          return resolve_signin_enabled(global, config) if operator_host?(domain_strategy)
+
+          resolve_signin_enabled_for_custom_domain(global, config, domain_id: domain_id)
+        end
+
         # Resolve effective email-auth (magic-link) availability, combining the
         # install-level capability with an optional per-domain override.
         #

--- a/lib/onetime/models/custom_domain/signup_config.rb
+++ b/lib/onetime/models/custom_domain/signup_config.rb
@@ -334,6 +334,72 @@ module Onetime
           resolve_signup_enabled(global, config)
         end
 
+        # Effective sign-up availability for a REQUEST, chosen by the request's
+        # DomainStrategy classification (ADR-024 A12).
+        #
+        # Mirrors SigninConfig.resolve_signin_enabled_for_request, and shares
+        # its operator test rather than restating the classification list:
+        # SigninConfig.operator_host? is the ONE owner of "which hosts may
+        # inherit operator auth defaults", and sign-up must not be able to
+        # disagree with sign-in about that. Only :canonical and :subdomain take
+        # the global default; :custom, :invalid and nil are default-OFF, so a
+        # datastore blip that classifies a real customer domain :invalid can no
+        # longer hand it the operator's global sign-up setting.
+        #
+        # There is no display carve-out here — unlike sign-in, sign-up has no
+        # SSO path that works without an enabled config.
+        #
+        # @param global [Boolean] install-level availability (auth.enabled && auth.signup)
+        # @param config [SignupConfig, nil] the per-domain config, if any
+        # @param domain_strategy [Symbol, String, nil] env['onetime.domain_strategy']
+        # @return [Boolean]
+        def resolve_signup_enabled_for_request(global, config, domain_strategy:)
+          if Onetime::CustomDomain::SigninConfig.operator_host?(domain_strategy)
+            return resolve_signup_enabled(global, config)
+          end
+
+          resolve_signup_enabled_for_custom_domain(global, config)
+        end
+
+        # What the sign-up gate answers when the policy for this request host
+        # could NOT be read (#4157). Mirrors
+        # SigninConfig.resolve_lookup_failure exactly — same carve-out, same
+        # error family, different copy — because "disabled unless explicitly
+        # enabled" is only true if the application can actually READ the
+        # tenant's SignupConfig. Two datastore reads back that policy
+        # (CustomDomain.load_by_display_domain, then find_by_domain_id); when
+        # either raises, the gate cannot establish explicit enablement and must
+        # not guess.
+        #
+        # Guessing here is not hypothetical: before this, a Redis::BaseError on
+        # those reads propagated as an unhandled 500 in the controller — fail
+        # closed with the wrong shape — and, worse, the SAME blip that broke
+        # the read is what makes DomainStrategy answer :invalid for a real
+        # customer domain, which used to route that request to the operator's
+        # global sign-up default. Availability failure, access widening.
+        #
+        # OPERATOR HOSTS ARE CARVED OUT, and it costs nothing: a :canonical or
+        # :subdomain request has no per-domain SignupConfig to lose. The read
+        # could only ever have produced nil there, and nil is exactly what this
+        # returns, so the caller resolves against the operator's in-memory
+        # global setting as it always would. The test is POSITIVE
+        # (SigninConfig.operator_host?, the single owner of "which hosts may
+        # inherit operator auth defaults"), never `!= :custom`: :invalid and
+        # nil are precisely the classifications a datastore failure
+        # manufactures for a customer domain.
+        #
+        # @param domain_strategy [Symbol, String, nil] env['onetime.domain_strategy']
+        # @raise [Onetime::SignupPolicyUnavailable] on any host that is not positively an operator host
+        # @return [nil] on an operator host — "no per-domain config", the only
+        #   answer such a host could ever have had
+        def resolve_lookup_failure(domain_strategy:)
+          unless Onetime::CustomDomain::SigninConfig.operator_host?(domain_strategy)
+            raise Onetime::SignupPolicyUnavailable
+          end
+
+          nil
+        end
+
         # Install-level signup capability — the `global` input to
         # resolve_signup_enabled, defined once so the runtime gate
         # (Core::Controllers::Base#signup_enabled?) and the settings API

--- a/lib/onetime/models/custom_domain/signup_config.rb
+++ b/lib/onetime/models/custom_domain/signup_config.rb
@@ -335,7 +335,8 @@ module Onetime
         end
 
         # Effective sign-up availability for a REQUEST, chosen by the request's
-        # DomainStrategy classification (ADR-024 A12).
+        # DomainStrategy classification.
+        # ADR-024#operator-defaults-require-positive-classification
         #
         # Mirrors SigninConfig.resolve_signin_enabled_for_request, and shares
         # its operator test rather than restating the classification list:

--- a/lib/onetime/models/custom_domain/signup_config.rb
+++ b/lib/onetime/models/custom_domain/signup_config.rb
@@ -367,7 +367,7 @@ module Onetime
         # error family, different copy — because "disabled unless explicitly
         # enabled" is only true if the application can actually READ the
         # tenant's SignupConfig. Two datastore reads back that policy
-        # (CustomDomain.load_by_display_domain, then find_by_domain_id); when
+        # (CustomDomain.from_display_domain, then find_by_domain_id); when
         # either raises, the gate cannot establish explicit enablement and must
         # not guess.
         #

--- a/spec/integration/simple/restrict_to_enforcement_spec.rb
+++ b/spec/integration/simple/restrict_to_enforcement_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe 'restrict_to enforcement — simple mode (ADR-034#restrict-to-is-
       # has nothing per-domain to lose when a datastore read fails.
       features                  = Onetime::Runtime.features
       Onetime::Runtime.features = features.with(domains_enabled: false)
-      allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+      allow(Onetime::CustomDomain).to receive(:from_display_domain)
         .and_raise(Redis::BaseError, 'datastore unavailable')
 
       response = post_login(Onetime::Middleware::DomainStrategy.canonical_domain)

--- a/spec/unit/domain_strategy_classification_contract_spec.rb
+++ b/spec/unit/domain_strategy_classification_contract_spec.rb
@@ -106,7 +106,9 @@ RSpec.describe 'DomainStrategy classification contract' do
     # must opt in); resolve_*_enabled follows the operator's global default.
     #
     # The branch is chosen by SigninConfig.operator_host?, NOT by
-    # custom_domain_request? (ADR-024 A12): the operator branch requires a
+    # custom_domain_request?
+    # (ADR-024#operator-defaults-require-positive-classification): the
+    # operator branch requires a
     # POSITIVE :canonical/:subdomain classification, so :invalid and nil take
     # the tenant-safe branch along with :custom. That is the one row in this
     # file where the auth gates deliberately DISAGREE with the identity
@@ -142,7 +144,8 @@ RSpec.describe 'DomainStrategy classification contract' do
         end
       end
 
-      # ADR-024 A12, CLOSED. This is the row the table exists for: the defect
+      # ADR-024#operator-defaults-require-positive-classification, CLOSED.
+      # This is the row the table exists for: the defect
       # was invisible unless :invalid was evaluated against both branches side
       # by side. Before the fix, a domain that never opted into sign-up
       # followed the OPERATOR's default while misclassified — a datastore blip
@@ -150,7 +153,7 @@ RSpec.describe 'DomainStrategy classification contract' do
       # kept (not deleted) with its expectation inverted, so that a
       # re-introduction of the `== :custom` branch selection reds HERE with the
       # history attached rather than passing silently.
-      it 'A12 CLOSED: :invalid resolves the tenant-safe sign-up default, not the operator one' do
+      it ':invalid resolves the tenant-safe sign-up default, not the operator one' do
         controller = controller_for(:invalid)
         allow(controller).to receive(:domain_signup_config).and_return(nil)
         allow(Onetime::CustomDomain::SignupConfig).to receive(:global_signup_enabled).and_return(true)
@@ -165,7 +168,7 @@ RSpec.describe 'DomainStrategy classification contract' do
 
       # Sign-in has the same inverted-default risk and the same fix; pinned
       # explicitly so a partial revert (one gate only) cannot pass.
-      it 'A12 CLOSED: :invalid resolves the tenant-safe sign-in default, not the operator one' do
+      it ':invalid resolves the tenant-safe sign-in default, not the operator one' do
         controller = controller_for(:invalid)
         allow(controller).to receive(:domain_signin_config).and_return(nil)
         allow(Onetime::CustomDomain::SigninConfig).to receive(:global_signin_enabled).and_return(true)
@@ -178,7 +181,7 @@ RSpec.describe 'DomainStrategy classification contract' do
 
       # nil is the same failure with a different provenance: a request that
       # never passed through the middleware carries no classification at all.
-      it 'A12 CLOSED: nil is tenant-safe for both gates' do
+      it 'nil is tenant-safe for both gates' do
         controller = controller_for(nil)
         allow(controller).to receive_messages(domain_signin_config: nil, domain_signup_config: nil)
         allow(Onetime::CustomDomain::SigninConfig).to receive(:global_signin_enabled).and_return(true)
@@ -248,7 +251,8 @@ RSpec.describe 'DomainStrategy classification contract' do
 
   # ---------------------------------------------------------------- row 7b
   #
-  # The DISPLAY-side twin of SigninConfig.operator_host? (ADR-024 A12). It is
+  # The DISPLAY-side twin of SigninConfig.operator_host?
+  # (ADR-024#identity-predicates-are-not-auth-gates). It is
   # NOT the negation of tenant_domain? above: :invalid and nil are neither
   # operator hosts nor tenant hosts, and both predicates must answer false for
   # them — tenant-safe for auth, non-tenant for branding/routing.

--- a/spec/unit/domain_strategy_classification_contract_spec.rb
+++ b/spec/unit/domain_strategy_classification_contract_spec.rb
@@ -104,54 +104,88 @@ RSpec.describe 'DomainStrategy classification contract' do
     # WHICH RESOLVER IS CALLED is the whole point — the two have OPPOSITE
     # defaults. resolve_*_enabled_for_custom_domain is default-OFF (a domain
     # must opt in); resolve_*_enabled follows the operator's global default.
+    #
+    # The branch is chosen by SigninConfig.operator_host?, NOT by
+    # custom_domain_request? (ADR-024 A12): the operator branch requires a
+    # POSITIVE :canonical/:subdomain classification, so :invalid and nil take
+    # the tenant-safe branch along with :custom. That is the one row in this
+    # file where the auth gates deliberately DISAGREE with the identity
+    # predicates above — those stay `== :custom`.
     describe 'gate polarity' do
       before do
         allow(OT).to receive(:conf).and_return({ 'site' => { 'authentication' => {} } })
       end
 
       DomainStrategyContract::CLASSIFICATIONS.each do |strategy|
-        custom = strategy == :custom
+        operator = DomainStrategyContract::OPERATOR.include?(strategy)
 
-        it "signin_enabled? takes the #{custom ? 'custom-domain' : 'operator'} branch for #{strategy.inspect}" do
+        it "signin_enabled? takes the #{operator ? 'operator' : 'custom-domain'} branch for #{strategy.inspect}" do
           controller = controller_for(strategy)
           allow(controller).to receive(:domain_signin_config).and_return(nil)
           allow(Onetime::CustomDomain::SigninConfig).to receive(:global_signin_enabled).and_return(true)
 
-          expected_branch = custom ? :resolve_signin_enabled_for_custom_domain : :resolve_signin_enabled
+          expected_branch = operator ? :resolve_signin_enabled : :resolve_signin_enabled_for_custom_domain
           expect(Onetime::CustomDomain::SigninConfig).to receive(expected_branch).and_return(true)
 
           controller.send(:signin_enabled?)
         end
 
-        it "signup_enabled? takes the #{custom ? 'custom-domain' : 'operator'} branch for #{strategy.inspect}" do
+        it "signup_enabled? takes the #{operator ? 'operator' : 'custom-domain'} branch for #{strategy.inspect}" do
           controller = controller_for(strategy)
           allow(controller).to receive(:domain_signup_config).and_return(nil)
           allow(Onetime::CustomDomain::SignupConfig).to receive(:global_signup_enabled).and_return(true)
 
-          expected_branch = custom ? :resolve_signup_enabled_for_custom_domain : :resolve_signup_enabled
+          expected_branch = operator ? :resolve_signup_enabled : :resolve_signup_enabled_for_custom_domain
           expect(Onetime::CustomDomain::SignupConfig).to receive(expected_branch).and_return(true)
 
           controller.send(:signup_enabled?)
         end
       end
 
-      # STILL OPEN (unresolved — no ADR entry covers this asymmetry yet).
-      # This is the row the table exists for: it is
-      # invisible unless :invalid is evaluated against both branches side by
-      # side. A domain that never opted into sign-up follows the OPERATOR's
-      # default while misclassified. Change this expectation when A12's
-      # resolver-side fix lands — do not delete it.
-      it 'KNOWN GAP (A12): :invalid inverts the sign-up default for a real custom domain' do
+      # ADR-024 A12, CLOSED. This is the row the table exists for: the defect
+      # was invisible unless :invalid was evaluated against both branches side
+      # by side. Before the fix, a domain that never opted into sign-up
+      # followed the OPERATOR's default while misclassified — a datastore blip
+      # widening access on someone else's domain. This example is deliberately
+      # kept (not deleted) with its expectation inverted, so that a
+      # re-introduction of the `== :custom` branch selection reds HERE with the
+      # history attached rather than passing silently.
+      it 'A12 CLOSED: :invalid resolves the tenant-safe sign-up default, not the operator one' do
         controller = controller_for(:invalid)
         allow(controller).to receive(:domain_signup_config).and_return(nil)
         allow(Onetime::CustomDomain::SignupConfig).to receive(:global_signup_enabled).and_return(true)
 
-        # No config + operator polarity => follows the global default (true).
-        # The same request classified :custom would be false (default-OFF).
-        expect(controller.send(:signup_enabled?)).to be(true)
+        # No config + tenant-safe polarity => default-OFF, the same answer the
+        # request would get if it had been classified :custom correctly.
+        expect(controller.send(:signup_enabled?)).to be(false)
         expect(
           Onetime::CustomDomain::SignupConfig.resolve_signup_enabled_for_custom_domain(true, nil),
         ).to be(false)
+      end
+
+      # Sign-in has the same inverted-default risk and the same fix; pinned
+      # explicitly so a partial revert (one gate only) cannot pass.
+      it 'A12 CLOSED: :invalid resolves the tenant-safe sign-in default, not the operator one' do
+        controller = controller_for(:invalid)
+        allow(controller).to receive(:domain_signin_config).and_return(nil)
+        allow(Onetime::CustomDomain::SigninConfig).to receive(:global_signin_enabled).and_return(true)
+
+        expect(controller.send(:signin_enabled?)).to be(false)
+        expect(
+          Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_custom_domain(true, nil),
+        ).to be(false)
+      end
+
+      # nil is the same failure with a different provenance: a request that
+      # never passed through the middleware carries no classification at all.
+      it 'A12 CLOSED: nil is tenant-safe for both gates' do
+        controller = controller_for(nil)
+        allow(controller).to receive_messages(domain_signin_config: nil, domain_signup_config: nil)
+        allow(Onetime::CustomDomain::SigninConfig).to receive(:global_signin_enabled).and_return(true)
+        allow(Onetime::CustomDomain::SignupConfig).to receive(:global_signup_enabled).and_return(true)
+
+        expect(controller.send(:signin_enabled?)).to be(false)
+        expect(controller.send(:signup_enabled?)).to be(false)
       end
     end
   end
@@ -208,6 +242,41 @@ RSpec.describe 'DomainStrategy classification contract' do
       it "answers #{expected} for #{strategy.inspect}" do
         answer = Core::Views::ConfigSerializer.tenant_domain?('domain_strategy' => strategy)
         expect(answer).to be(expected)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------- row 7b
+  #
+  # The DISPLAY-side twin of SigninConfig.operator_host? (ADR-024 A12). It is
+  # NOT the negation of tenant_domain? above: :invalid and nil are neither
+  # operator hosts nor tenant hosts, and both predicates must answer false for
+  # them — tenant-safe for auth, non-tenant for branding/routing.
+  describe 'ConfigSerializer.operator_domain?' do
+    DomainStrategyContract::CLASSIFICATIONS.each do |strategy|
+      expected = DomainStrategyContract::OPERATOR.include?(strategy)
+
+      it "answers #{expected} for #{strategy.inspect}" do
+        answer = Core::Views::ConfigSerializer.operator_domain?('domain_strategy' => strategy)
+        expect(answer).to be(expected)
+      end
+    end
+
+    it 'delegates to SigninConfig.operator_host? — one owner of the classification list' do
+      expect(Onetime::CustomDomain::SigninConfig)
+        .to receive(:operator_host?).with(:canonical).and_return(true)
+
+      Core::Views::ConfigSerializer.operator_domain?('domain_strategy' => :canonical)
+    end
+
+    it 'is never simultaneously true with tenant_domain?, and both are false for :invalid/nil' do
+      DomainStrategyContract::CLASSIFICATIONS.each do |strategy|
+        vars   = { 'domain_strategy' => strategy }
+        tenant = Core::Views::ConfigSerializer.tenant_domain?(vars)
+        opera  = Core::Views::ConfigSerializer.operator_domain?(vars)
+
+        expect(tenant && opera).to be(false)
+        expect([tenant, opera]).to eq([false, false]) if [:invalid, nil].include?(strategy)
       end
     end
   end

--- a/spec/unit/domain_strategy_classification_contract_spec.rb
+++ b/spec/unit/domain_strategy_classification_contract_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe 'DomainStrategy classification contract' do
 
     describe 'custom_host: input to the availability half' do
       before do
-        allow(Onetime::CustomDomain).to receive(:load_by_display_domain).and_return(nil)
+        allow(Onetime::CustomDomain).to receive(:from_display_domain).and_return(nil)
         allow(Onetime.auth_config).to receive(:restrict_to).and_return(nil)
         allow(Onetime::CustomDomain::SigninConfig).to receive(:find_by_domain_id).and_return(nil)
       end
@@ -306,6 +306,130 @@ RSpec.describe 'DomainStrategy classification contract' do
       logic                 = V1::Logic::Base.allocate
       logic.domain_strategy = 'custom'
       expect(logic.send(:custom_domain?)).to be(true)
+    end
+  end
+
+  # ---------------------------------------------------------- identity read
+  #
+  # THE READ ITSELF, NOT A STUB OF IT (#4157). Every fail-closed example above
+  # and in the parity spec stubs the CustomDomain finder to raise — which is
+  # exactly what hid this: the sign-in gates called
+  # CustomDomain.load_by_display_domain, whose own body rescues
+  # Redis::BaseError AND a blanket StandardError and returns nil ("intentional
+  # fail-open behavior for the lookup layer", and correct for its ~15 CLI,
+  # operations and serializer callers). So in production a blip produced nil,
+  # not a raise: the gate read it as "this host has no SigninConfig" and fell
+  # through to the operator's global default on a tenant host. The rescue those
+  # gates carry was dead code, and every spec that stubbed the finder to raise
+  # jumped over the swallow.
+  #
+  # These examples therefore stub ONLY the datastore seam (display_domain_index)
+  # and let the real finder run, so the swallow-vs-propagate boundary is what is
+  # under test. If someone repoints an identity read back at the fail-open
+  # helper, these red and the stubbed examples do not.
+  describe 'the sign-in identity read propagates datastore failures' do
+    let(:blip) { Redis::BaseError.new('connection reset') }
+
+    let(:failing_index) do
+      instance_double(Familia::HashKey).tap do |index|
+        allow(index).to receive(:get).and_raise(blip)
+      end
+    end
+
+    let(:controller_class) do
+      Class.new do
+        include Core::Controllers::Base
+
+        def initialize(env)
+          @req = Struct.new(:env).new(env)
+        end
+      end
+    end
+
+    before do
+      allow(Onetime::CustomDomain).to receive(:display_domain_index).and_return(failing_index)
+      allow(OT).to receive(:le)
+      allow(Auth::Logging).to receive(:log_auth_event)
+    end
+
+    it 'raises out of CustomDomain.from_display_domain rather than answering nil' do
+      expect { Onetime::CustomDomain.from_display_domain('tenant.example.com') }
+        .to raise_error(Redis::BaseError)
+    end
+
+    it 'still swallows in load_by_display_domain — its other callers depend on that' do
+      expect(Onetime::CustomDomain.load_by_display_domain('tenant.example.com')).to be_nil
+    end
+
+    DomainStrategyContract::CLASSIFICATIONS.each do |strategy|
+      operator = DomainStrategyContract::OPERATOR.include?(strategy)
+
+      if operator
+        it "resolves custom_domain_id to nil on #{strategy.inspect} — no per-domain policy to lose" do
+          expect(controller_class.new(env_for(strategy)).send(:custom_domain_id)).to be_nil
+        end
+      else
+        it "raises SigninPolicyUnavailable from custom_domain_id on #{strategy.inspect}" do
+          expect { controller_class.new(env_for(strategy)).send(:custom_domain_id) }
+            .to raise_error(Onetime::SigninPolicyUnavailable)
+        end
+      end
+    end
+
+    # The row this exists for: the widen was silent BECAUSE the gate got a
+    # plausible nil. signin_enabled? must not answer at all here.
+    it 'does not let signin_enabled? answer from the operator global default on :invalid' do
+      controller = controller_class.new(env_for(:invalid))
+      allow(OT).to receive(:conf).and_return({ 'site' => { 'authentication' => {} } })
+      allow(Onetime::CustomDomain::SigninConfig).to receive(:global_signin_enabled).and_return(true)
+
+      expect { controller.send(:signin_enabled?) }
+        .to raise_error(Onetime::SigninPolicyUnavailable)
+    end
+
+    # Auth::RestrictTo reads the same identity through its own helper, so it
+    # had the same dead rescue: resolution_for's comment names the CustomDomain
+    # lookup as one of the three reads it guards, and it was the one that could
+    # not reach it.
+    it 'fails the restrict_to gate closed instead of inheriting the global restriction' do
+      allow(Onetime.auth_config).to receive(:restrict_to).and_return('password')
+      allow(Onetime::CustomDomain::SigninConfig)
+        .to receive(:global_restriction_available?).and_return(true)
+
+      expect { Auth::RestrictTo.resolution_for(env_for(:custom)) }
+        .to raise_error(Onetime::SigninPolicyUnavailable)
+    end
+  end
+
+  # ------------------------------------------------------- host normalization
+  #
+  # A mixed-case Host is the same widen by a different route: the index is
+  # keyed on the downcased display_domain, so an un-normalized lookup misses,
+  # reads as "no tenant config", and hands a tenant host the operator default.
+  # load_by_display_domain always downcased; from_display_domain did not, which
+  # left it latent on both the sign-in and sign-up policy paths once they share
+  # this finder.
+  describe 'CustomDomain.from_display_domain host normalization' do
+    let(:index) { instance_double(Familia::HashKey) }
+
+    before do
+      allow(Onetime::CustomDomain).to receive(:display_domain_index).and_return(index)
+      allow(index).to receive(:get).and_return(nil)
+      allow(index).to receive(:get).with('tenant.example.com').and_return('domain-1')
+      allow(Onetime::CustomDomain).to receive(:find_by_identifier)
+        .with('domain-1').and_return(:the_record)
+    end
+
+    ['tenant.example.com', 'Tenant.Example.com', 'TENANT.EXAMPLE.COM'].each do |host|
+      it "resolves #{host.inspect} to the indexed record" do
+        expect(Onetime::CustomDomain.from_display_domain(host)).to be(:the_record)
+      end
+    end
+
+    it 'returns nil for a blank host without touching the index' do
+      expect(Onetime::CustomDomain.from_display_domain(nil)).to be_nil
+      expect(Onetime::CustomDomain.from_display_domain('')).to be_nil
+      expect(index).not_to have_received(:get)
     end
   end
 

--- a/spec/unit/signup_policy_unavailable_spec.rb
+++ b/spec/unit/signup_policy_unavailable_spec.rb
@@ -1,0 +1,277 @@
+# spec/unit/signup_policy_unavailable_spec.rb
+#
+# frozen_string_literal: true
+
+# UNREADABLE TENANT SIGN-UP POLICY FAILS CLOSED (ADR-024 A12 refinement 4, #4157).
+#
+# The classification-aware resolvers only close the widening when the app can
+# actually READ the tenant's SignupConfig. Two datastore reads back that policy
+# (CustomDomain.load_by_display_domain, then SignupConfig.find_by_domain_id) and
+# both live in Onetime::Logic::SignupConfigResolution. Before this change a
+# Redis::BaseError there produced an unhandled 500 at best — and the same blip
+# is what makes DomainStrategy answer :invalid for a real customer domain, the
+# classification that used to inherit the operator's global sign-up default.
+#
+# The sign-in half of this rule is pinned in apps/web/auth/spec/unit/restrict_to_gate_spec.rb
+# and spec/unit/domain_strategy_classification_contract_spec.rb; this file is the
+# sign-up half, and it pins the two halves as the SAME rule (same carve-out
+# predicate, same 503 body shape) rather than two copies that can drift.
+
+require 'spec_helper'
+require 'onetime/logic/signup_config_resolution'
+require_relative '../../apps/web/auth/error_translator'
+
+module SignupPolicyContract
+  CLASSIFICATIONS = [:canonical, :subdomain, :custom, :invalid, nil].freeze
+  OPERATOR        = [:canonical, :subdomain].freeze
+
+  # Minimal includer of the mixin: the mixin's whole contract is the three
+  # hooks, so a fake that supplies them exercises the real read/rescue path
+  # without booting a controller or a logic class.
+  class FakeConsumer
+    include Onetime::Logic::SignupConfigResolution
+
+    def initialize(display_domain:, domain_strategy:, autoverify: 'false')
+      @display_domain  = display_domain
+      @domain_strategy = domain_strategy
+      @autoverify      = autoverify
+    end
+
+    # public wrappers — the mixin's methods are private by design
+    def config = domain_signup_config
+    def autoverify = resolve_autoverify
+
+    private
+
+    def signup_config_display_domain = @display_domain
+    def signup_config_domain_strategy = @domain_strategy
+    def signup_config_auth_setting(_key) = @autoverify
+  end
+
+  # An includer that forgot the classification hook, to pin the default.
+  class HooklessConsumer
+    include Onetime::Logic::SignupConfigResolution
+
+    def config = domain_signup_config
+
+    private
+
+    def signup_config_display_domain = 'tenant.example.com'
+    def signup_config_auth_setting(_key) = 'false'
+  end
+end
+
+RSpec.describe 'Sign-up policy read failure (#4157)' do
+  let(:blip) { Redis::BaseError.new('connection reset') }
+
+  describe 'SignupConfig.resolve_lookup_failure — the decision owner' do
+    SignupPolicyContract::CLASSIFICATIONS.each do |strategy|
+      operator = SignupPolicyContract::OPERATOR.include?(strategy)
+
+      if operator
+        it "returns nil (no per-domain config to lose) for #{strategy.inspect}" do
+          expect(
+            Onetime::CustomDomain::SignupConfig.resolve_lookup_failure(domain_strategy: strategy),
+          ).to be_nil
+        end
+      else
+        it "raises SignupPolicyUnavailable for #{strategy.inspect}" do
+          expect {
+            Onetime::CustomDomain::SignupConfig.resolve_lookup_failure(domain_strategy: strategy)
+          }.to raise_error(Onetime::SignupPolicyUnavailable)
+        end
+      end
+    end
+
+    # The carve-out must be the SAME predicate the sign-in path uses, not a
+    # second list: two gates disagreeing about which hosts survive an outage is
+    # exactly the drift ADR-024 A2 exists to kill.
+    it 'delegates the carve-out to SigninConfig.operator_host?' do
+      expect(Onetime::CustomDomain::SigninConfig).to receive(:operator_host?).with(:custom).and_return(true)
+
+      expect(
+        Onetime::CustomDomain::SignupConfig.resolve_lookup_failure(domain_strategy: :custom),
+      ).to be_nil
+    end
+
+    it 'accepts String classifications — StrategyResult metadata is not always a Symbol' do
+      expect(
+        Onetime::CustomDomain::SignupConfig.resolve_lookup_failure(domain_strategy: 'canonical'),
+      ).to be_nil
+      expect {
+        Onetime::CustomDomain::SignupConfig.resolve_lookup_failure(domain_strategy: 'custom')
+      }.to raise_error(Onetime::SignupPolicyUnavailable)
+    end
+  end
+
+  describe 'the error family' do
+    it 'is a sibling of the sign-in error, not a copy of its shape' do
+      signup = Onetime::SignupPolicyUnavailable.new
+      signin = Onetime::SigninPolicyUnavailable.new
+
+      expect(signup).to be_a(Onetime::AuthPolicyUnavailable)
+      expect(signin).to be_a(Onetime::AuthPolicyUnavailable)
+      expect(signup.to_h.keys).to eq(signin.to_h.keys)
+      expect(signup.to_h[:retry_after]).to eq(signin.to_h[:retry_after])
+    end
+
+    # The error_type is what routes an alert and what the frontend switches on;
+    # a shared parent must not have collapsed the two surfaces into one name,
+    # and the sign-in value is already pinned by existing specs.
+    it 'names the surface that is actually down' do
+      expect(Onetime::SignupPolicyUnavailable.new.to_h[:error_type]).to eq('SignupPolicyUnavailable')
+      expect(Onetime::SigninPolicyUnavailable.new.to_h[:error_type]).to eq('SigninPolicyUnavailable')
+      expect(Onetime::SignupPolicyUnavailable.new.message).to match(/Sign-up is temporarily unavailable/)
+    end
+
+    # Otto dispatches on the exact class name, so the sibling needs its own
+    # registration; the Roda edge walks ancestors, so the family entry covers
+    # both. This pins the Roda half (the Otto half is a boot-time registration).
+    it 'translates to 503 at the Roda auth edge via the family entry' do
+      status, body = Auth::ErrorTranslator.translate(Onetime::SignupPolicyUnavailable.new)
+
+      expect(status).to eq(503)
+      expect(body[:error_type]).to eq('SignupPolicyUnavailable')
+      expect(Auth::ErrorTranslator.level_for(Onetime::SignupPolicyUnavailable.new)).to eq(:error)
+      expect(Auth::ErrorTranslator.translate(Onetime::SigninPolicyUnavailable.new).first).to eq(503)
+    end
+  end
+
+  describe 'Onetime::Logic::SignupConfigResolution' do
+    # Both reads are guarded, because either one can be the one that fails.
+    {
+      'the CustomDomain identity read' => :identity,
+      'the SignupConfig read' => :config,
+    }.each do |label, failing_read|
+      context "when #{label} raises" do
+        before do
+          case failing_read
+          when :identity
+            allow(Onetime::CustomDomain).to receive(:load_by_display_domain).and_raise(blip)
+          when :config
+            allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+              .and_return(instance_double(Onetime::CustomDomain, identifier: 'domain-1'))
+            allow(Onetime::CustomDomain::SignupConfig).to receive(:find_by_domain_id).and_raise(blip)
+          end
+          allow(OT).to receive(:le)
+        end
+
+        SignupPolicyContract::CLASSIFICATIONS.each do |strategy|
+          operator = SignupPolicyContract::OPERATOR.include?(strategy)
+
+          if operator
+            it "resolves to nil on #{strategy.inspect} — the only answer that host could have had" do
+              consumer = SignupPolicyContract::FakeConsumer.new(
+                display_domain: 'www.example.com', domain_strategy: strategy,
+              )
+
+              expect(consumer.config).to be_nil
+            end
+          else
+            it "raises SignupPolicyUnavailable on #{strategy.inspect}" do
+              consumer = SignupPolicyContract::FakeConsumer.new(
+                display_domain: 'tenant.example.com', domain_strategy: strategy,
+              )
+
+              expect { consumer.config }.to raise_error(Onetime::SignupPolicyUnavailable)
+            end
+          end
+        end
+
+        # AUTOVERIFY IS A POLICY READ TOO. Falling back to the global setting
+        # on an unreadable tenant policy auto-verifies accounts on a domain
+        # whose owner never opted into that — the same widen as the gate's, so
+        # it takes the same rule.
+        it 'does not let autoverify fall back to the global setting on a tenant host' do
+          consumer = SignupPolicyContract::FakeConsumer.new(
+            display_domain: 'tenant.example.com', domain_strategy: :invalid, autoverify: 'true',
+          )
+
+          expect { consumer.autoverify }.to raise_error(Onetime::SignupPolicyUnavailable)
+        end
+
+        it 'still resolves autoverify from the global setting on an operator host' do
+          consumer = SignupPolicyContract::FakeConsumer.new(
+            display_domain: 'www.example.com', domain_strategy: :canonical, autoverify: 'true',
+          )
+
+          expect(consumer.autoverify).to be(true)
+        end
+
+        # An includer that supplies no classification gets nil, which
+        # operator_host? rejects: over-strict, never over-permissive.
+        it 'fails closed for an includer that omits the classification hook' do
+          expect { SignupPolicyContract::HooklessConsumer.new.config }
+            .to raise_error(Onetime::SignupPolicyUnavailable)
+        end
+      end
+    end
+
+    it 'is transparent when the reads succeed' do
+      config = instance_double(Onetime::CustomDomain::SignupConfig)
+      allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+        .and_return(instance_double(Onetime::CustomDomain, identifier: 'domain-1'))
+      allow(Onetime::CustomDomain::SignupConfig).to receive(:find_by_domain_id)
+        .with('domain-1').and_return(config)
+
+      consumer = SignupPolicyContract::FakeConsumer.new(
+        display_domain: 'tenant.example.com', domain_strategy: :custom,
+      )
+
+      expect(consumer.config).to be(config)
+    end
+  end
+
+  # The runtime gate is the surface that actually has to answer 503. Its hooks
+  # must feed the mixin the request's real classification, or a blip would take
+  # the CANONICAL sign-up page down for a read that costs it nothing.
+  describe 'Core::Controllers::Base#signup_enabled?' do
+    let(:controller_class) do
+      Class.new do
+        include Core::Controllers::Base
+
+        def initialize(env)
+          @req = Struct.new(:env).new(env)
+        end
+      end
+    end
+
+    def controller_for(strategy)
+      controller_class.new(
+        'onetime.domain_strategy' => strategy,
+        'onetime.display_domain' => 'tenant.example.com',
+      )
+    end
+
+    before do
+      allow(OT).to receive(:conf).and_return(
+        { 'site' => { 'authentication' => { 'enabled' => true, 'signup' => true } } },
+      )
+      allow(OT).to receive(:le)
+      allow(Onetime::CustomDomain).to receive(:load_by_display_domain).and_raise(blip)
+    end
+
+    it 'raises SignupPolicyUnavailable on :custom' do
+      expect { controller_for(:custom).send(:signup_enabled?) }
+        .to raise_error(Onetime::SignupPolicyUnavailable)
+    end
+
+    # The row this file exists for: a blip's :invalid must not become "follow
+    # the operator's global signup default".
+    it 'raises SignupPolicyUnavailable on :invalid rather than following the global default' do
+      expect { controller_for(:invalid).send(:signup_enabled?) }
+        .to raise_error(Onetime::SignupPolicyUnavailable)
+    end
+
+    it 'raises SignupPolicyUnavailable when the request never passed the middleware (nil)' do
+      expect { controller_for(nil).send(:signup_enabled?) }
+        .to raise_error(Onetime::SignupPolicyUnavailable)
+    end
+
+    SignupPolicyContract::OPERATOR.each do |strategy|
+      it "keeps following the global default on #{strategy.inspect}" do
+        expect(controller_for(strategy).send(:signup_enabled?)).to be(true)
+      end
+    end
+  end
+end

--- a/spec/unit/signup_policy_unavailable_spec.rb
+++ b/spec/unit/signup_policy_unavailable_spec.rb
@@ -2,7 +2,8 @@
 #
 # frozen_string_literal: true
 
-# UNREADABLE TENANT SIGN-UP POLICY FAILS CLOSED (ADR-024 A12 refinement 4, #4157).
+# UNREADABLE TENANT SIGN-UP POLICY FAILS CLOSED (#4157).
+# ADR-024#operator-defaults-require-positive-classification
 #
 # The classification-aware resolvers only close the widening when the app can
 # actually READ the tenant's SignupConfig. Two datastore reads back that policy
@@ -85,7 +86,7 @@ RSpec.describe 'Sign-up policy read failure (#4157)' do
 
     # The carve-out must be the SAME predicate the sign-in path uses, not a
     # second list: two gates disagreeing about which hosts survive an outage is
-    # exactly the drift ADR-024 A2 exists to kill.
+    # exactly the drift a single shared predicate exists to kill.
     it 'delegates the carve-out to SigninConfig.operator_host?' do
       expect(Onetime::CustomDomain::SigninConfig).to receive(:operator_host?).with(:custom).and_return(true)
 

--- a/spec/unit/signup_policy_unavailable_spec.rb
+++ b/spec/unit/signup_policy_unavailable_spec.rb
@@ -6,7 +6,7 @@
 #
 # The classification-aware resolvers only close the widening when the app can
 # actually READ the tenant's SignupConfig. Two datastore reads back that policy
-# (CustomDomain.load_by_display_domain, then SignupConfig.find_by_domain_id) and
+# (CustomDomain.from_display_domain, then SignupConfig.find_by_domain_id) and
 # both live in Onetime::Logic::SignupConfigResolution. Before this change a
 # Redis::BaseError there produced an unhandled 500 at best — and the same blip
 # is what makes DomainStrategy answer :invalid for a real customer domain, the
@@ -147,9 +147,14 @@ RSpec.describe 'Sign-up policy read failure (#4157)' do
         before do
           case failing_read
           when :identity
-            allow(Onetime::CustomDomain).to receive(:load_by_display_domain).and_raise(blip)
+            # Exercise from_display_domain's production behavior: unlike the
+            # fail-open load_by_display_domain helper, it lets primary-database
+            # failures escape so policy resolution can answer 503.
+            index = instance_double(Familia::HashKey)
+            allow(index).to receive(:get).and_raise(blip)
+            allow(Onetime::CustomDomain).to receive(:display_domain_index).and_return(index)
           when :config
-            allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+            allow(Onetime::CustomDomain).to receive(:from_display_domain)
               .and_return(instance_double(Onetime::CustomDomain, identifier: 'domain-1'))
             allow(Onetime::CustomDomain::SignupConfig).to receive(:find_by_domain_id).and_raise(blip)
           end
@@ -209,7 +214,7 @@ RSpec.describe 'Sign-up policy read failure (#4157)' do
 
     it 'is transparent when the reads succeed' do
       config = instance_double(Onetime::CustomDomain::SignupConfig)
-      allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+      allow(Onetime::CustomDomain).to receive(:from_display_domain)
         .and_return(instance_double(Onetime::CustomDomain, identifier: 'domain-1'))
       allow(Onetime::CustomDomain::SignupConfig).to receive(:find_by_domain_id)
         .with('domain-1').and_return(config)
@@ -248,7 +253,7 @@ RSpec.describe 'Sign-up policy read failure (#4157)' do
         { 'site' => { 'authentication' => { 'enabled' => true, 'signup' => true } } },
       )
       allow(OT).to receive(:le)
-      allow(Onetime::CustomDomain).to receive(:load_by_display_domain).and_raise(blip)
+      allow(Onetime::CustomDomain).to receive(:from_display_domain).and_raise(blip)
     end
 
     it 'raises SignupPolicyUnavailable on :custom' do

--- a/try/integration/domain_auth_enforcement_try.rb
+++ b/try/integration/domain_auth_enforcement_try.rb
@@ -611,13 +611,14 @@ Core::Views::ConfigSerializer.send(:resolve_tenant_sso_config, { 'display_domain
 #     carve-out so a domain that enabled SSO (SsoConfig) without a
 #     SigninConfig still renders its provider buttons.
 #   - ANYTHING ELSE (:invalid, or a missing classification): tenant-safe,
-#     i.e. default OFF (ADR-024 A12).
+#     i.e. default OFF.
+#     ADR-024#operator-defaults-require-positive-classification
 #
 # Global signin comes from site.authentication (AUTH_ENABLED + AUTH_SIGNIN)
 # via view_vars['site']. The BRANCH is chosen by operator_domain? — a
 # POSITIVE test on view_vars['domain_strategy'] — not by tenant_domain?, so
 # the "canonical" cases below must SAY :canonical. They used to omit the key
-# and rely on `!= :custom`, which is exactly the fail-open the A12 fix
+# and rely on `!= :custom`, which is exactly the fail-open the positive test
 # removed; served requests always carry a classification (the DomainStrategy
 # middleware is mounted unconditionally and falls back to :canonical), so the
 # omission was a fixture artifact, never a real request shape.
@@ -643,12 +644,12 @@ Core::Views::ConfigSerializer.send(
 )
 #=> false
 
-## A12: a MISSING classification is tenant-safe, not canonical — a request
+## A MISSING classification is tenant-safe, not canonical — a request
 ## that never passed the middleware must not inherit the operator default
 Core::Views::ConfigSerializer.send(:resolve_signin, { 'site' => SITE_SIGNIN_ON })
 #=> false
 
-## A12: :invalid is tenant-safe too — that is what a failing domain-index
+## :invalid is tenant-safe too — that is what a failing domain-index
 ## read answers for a REAL custom domain, so it must not widen sign-in
 Core::Views::ConfigSerializer.send(
   :resolve_signin,
@@ -761,7 +762,7 @@ Core::Views::ConfigSerializer.send(
 )
 #=> true
 
-## A12: the SAME host and the SAME master-off config, classified :invalid by a
+## The SAME host and the SAME master-off config, classified :invalid by a
 ## datastore blip, does NOT get that operator fallback — the whole point of the
 ## positive test
 Core::Views::ConfigSerializer.send(

--- a/try/integration/domain_auth_enforcement_try.rb
+++ b/try/integration/domain_auth_enforcement_try.rb
@@ -353,16 +353,48 @@ Core::Views::ConfigSerializer.send(:resolve_restrict_to, {})
 Core::Views::ConfigSerializer.send(:resolve_restrict_to, @view_vars_no_config)
 #=> Onetime.auth_config.restrict_to
 
-## resolve_restrict_to uses domain SigninConfig restrict_to when enabled
+## resolve_restrict_to uses domain SigninConfig restrict_to when the named
+## method can actually run here: enabled config restricting to 'sso', with the
+## tenant SSO credentials + activation that make 'sso' honorable
 @domain_rt2 = Onetime::CustomDomain.create!("dae-rt2-#{@ts}-#{SecureRandom.hex(2)}.example.com", @org.objid)
 @config_rt2 = Onetime::CustomDomain::SigninConfig.create!(
   domain_id: @domain_rt2.identifier,
   enabled: true,
   restrict_to: 'sso',
+  sso_enabled: true,
 )
-@view_vars_with_config = { 'display_domain' => @domain_rt2.display_domain }
+@sso_rt2 = Onetime::CustomDomain::SsoConfig.create!(
+  domain_id: @domain_rt2.identifier,
+  provider_type: 'oidc',
+  display_name: 'SSO RT2',
+  enabled: true,
+  issuer: 'https://idp-rt2.example.com',
+  client_id: 'client-rt2',
+)
+@view_vars_with_config = { 'display_domain' => @domain_rt2.display_domain, 'domain_strategy' => :custom }
 Core::Views::ConfigSerializer.send(:resolve_restrict_to, @view_vars_with_config)
 #=> 'sso'
+
+## FAIL CLOSED (#4139, ADR-024 A3): the same enabled restrict_to='sso' on a
+## domain with NO SSO credentials resolves :unavailable — the display value is
+## nil (nothing offered), NOT 'sso' and NOT a widening fallback to global. This
+## case used to expect 'sso'; the expectation predates the A3 availability
+## derivation, and the fixture above is what the case name actually meant.
+@domain_rt2b = Onetime::CustomDomain.create!("dae-rt2b-#{@ts}-#{SecureRandom.hex(2)}.example.com", @org.objid)
+@config_rt2b = Onetime::CustomDomain::SigninConfig.create!(
+  domain_id: @domain_rt2b.identifier,
+  enabled: true,
+  restrict_to: 'sso',
+)
+@resolution_rt2b = Core::Views::ConfigSerializer.send(
+  :restrict_to_resolution,
+  { 'display_domain' => @domain_rt2b.display_domain, 'domain_strategy' => :custom },
+)
+[@resolution_rt2b.state, @resolution_rt2b.restrict_to, Core::Views::ConfigSerializer.send(
+  :resolve_restrict_to,
+  { 'display_domain' => @domain_rt2b.display_domain, 'domain_strategy' => :custom },
+)]
+#=> [:unavailable, 'sso', nil]
 
 ## resolve_restrict_to falls back to global when SigninConfig master switch off
 @domain_rt3 = Onetime::CustomDomain.create!("dae-rt3-#{@ts}-#{SecureRandom.hex(2)}.example.com", @org.objid)
@@ -578,26 +610,57 @@ Core::Views::ConfigSerializer.send(:resolve_tenant_sso_config, { 'display_domain
 #   - Custom domain: default OFF (opt-in) for password/email, with an SSO
 #     carve-out so a domain that enabled SSO (SsoConfig) without a
 #     SigninConfig still renders its provider buttons.
+#   - ANYTHING ELSE (:invalid, or a missing classification): tenant-safe,
+#     i.e. default OFF (ADR-024 A12).
+#
 # Global signin comes from site.authentication (AUTH_ENABLED + AUTH_SIGNIN)
-# via view_vars['site']; tenant_domain? keys off view_vars['domain_strategy'].
-
-## Canonical: global on + no domain context => true
-Core::Views::ConfigSerializer.send(:resolve_signin, { 'site' => SITE_SIGNIN_ON })
+# via view_vars['site']. The BRANCH is chosen by operator_domain? — a
+# POSITIVE test on view_vars['domain_strategy'] — not by tenant_domain?, so
+# the "canonical" cases below must SAY :canonical. They used to omit the key
+# and rely on `!= :custom`, which is exactly the fail-open the A12 fix
+# removed; served requests always carry a classification (the DomainStrategy
+# middleware is mounted unconditionally and falls back to :canonical), so the
+# omission was a fixture artifact, never a real request shape.
+#
+## Canonical: global on, no per-domain context => true
+Core::Views::ConfigSerializer.send(
+  :resolve_signin,
+  { 'site' => SITE_SIGNIN_ON, 'domain_strategy' => :canonical },
+)
 #=> true
 
-## Canonical: global signin off + no domain context => false
-Core::Views::ConfigSerializer.send(:resolve_signin, { 'site' => SITE_SIGNIN_OFF })
+## Canonical: global signin off => false
+Core::Views::ConfigSerializer.send(
+  :resolve_signin,
+  { 'site' => SITE_SIGNIN_OFF, 'domain_strategy' => :canonical },
+)
 #=> false
 
-## Canonical: global auth master off + no domain context => false
-Core::Views::ConfigSerializer.send(:resolve_signin, { 'site' => SITE_AUTH_OFF })
+## Canonical: global auth master off => false
+Core::Views::ConfigSerializer.send(
+  :resolve_signin,
+  { 'site' => SITE_AUTH_OFF, 'domain_strategy' => :canonical },
+)
+#=> false
+
+## A12: a MISSING classification is tenant-safe, not canonical — a request
+## that never passed the middleware must not inherit the operator default
+Core::Views::ConfigSerializer.send(:resolve_signin, { 'site' => SITE_SIGNIN_ON })
+#=> false
+
+## A12: :invalid is tenant-safe too — that is what a failing domain-index
+## read answers for a REAL custom domain, so it must not widen sign-in
+Core::Views::ConfigSerializer.send(
+  :resolve_signin,
+  { 'site' => SITE_SIGNIN_ON, 'domain_strategy' => :invalid },
+)
 #=> false
 
 ## Canonical: domain with no SigninConfig follows global (true)
 @domain_si_a = Onetime::CustomDomain.create!("dae-si-a-#{@ts}-#{SecureRandom.hex(2)}.example.com", @org.objid)
 Core::Views::ConfigSerializer.send(
   :resolve_signin,
-  { 'site' => SITE_SIGNIN_ON, 'display_domain' => @domain_si_a.display_domain },
+  { 'site' => SITE_SIGNIN_ON, 'display_domain' => @domain_si_a.display_domain, 'domain_strategy' => :canonical },
 )
 #=> true
 
@@ -641,7 +704,7 @@ Core::Views::ConfigSerializer.send(
 ## resolve_restrict_to carve-out is custom-domain only: canonical request for the SSO-only domain follows global
 Core::Views::ConfigSerializer.send(
   :resolve_restrict_to,
-  { 'display_domain' => @domain_si_sso.display_domain },
+  { 'display_domain' => @domain_si_sso.display_domain, 'domain_strategy' => :canonical },
 )
 #=> Onetime.auth_config.restrict_to
 
@@ -694,9 +757,18 @@ Core::Views::ConfigSerializer.send(
 ## Canonical: same master-off config falls back to global (true) — operator surface unchanged
 Core::Views::ConfigSerializer.send(
   :resolve_signin,
-  { 'site' => SITE_SIGNIN_ON, 'display_domain' => @domain_si_d.display_domain },
+  { 'site' => SITE_SIGNIN_ON, 'display_domain' => @domain_si_d.display_domain, 'domain_strategy' => :canonical },
 )
 #=> true
+
+## A12: the SAME host and the SAME master-off config, classified :invalid by a
+## datastore blip, does NOT get that operator fallback — the whole point of the
+## positive test
+Core::Views::ConfigSerializer.send(
+  :resolve_signin,
+  { 'site' => SITE_SIGNIN_ON, 'display_domain' => @domain_si_d.display_domain, 'domain_strategy' => :invalid },
+)
+#=> false
 
 ## resolve_signin: missing site config => false (no global capability to narrow)
 Core::Views::ConfigSerializer.send(:resolve_signin, {})

--- a/try/unit/config/config_serializer_sso_try.rb
+++ b/try/unit/config/config_serializer_sso_try.rb
@@ -20,6 +20,16 @@ OT.boot! :test, false
 # Store original features for restoration
 @original_features = Onetime.auth_config.features.dup
 
+# View vars for a positively-classified operator host.
+#
+# ADR-024#operator-defaults-require-positive-classification makes the
+# platform-SSO fallback guard a POSITIVE operator-host test
+# (domain_strategy in :canonical/:subdomain) rather than a negative "not :custom"
+# test. An empty view_vars hash has no domain_strategy, so it now classifies as
+# tenant-safe and build_sso_config withholds platform providers. Cases exercising
+# platform SSO must therefore carry an operator strategy explicitly.
+@operator_view_vars = { 'domain_strategy' => :canonical }.freeze
+
 # Helper to modify features temporarily
 # Must also set mode to 'full' so sso_enabled? returns true (since it checks full_enabled?)
 # Sets OIDC env vars so sso_providers returns at least one provider entry.
@@ -106,77 +116,77 @@ end
 
 ## build_sso_config returns false when SSO is disabled
 result = with_sso_config(enabled: false) do
-  Core::Views::ConfigSerializer.send(:build_sso_config, {})
+  Core::Views::ConfigSerializer.send(:build_sso_config, @operator_view_vars)
 end
 result
 #=> false
 
 ## build_sso_config returns hash with enabled true when SSO is enabled
 result = with_sso_config(enabled: true) do
-  Core::Views::ConfigSerializer.send(:build_sso_config, {})
+  Core::Views::ConfigSerializer.send(:build_sso_config, @operator_view_vars)
 end
 result['enabled']
 #=> true
 
 ## build_sso_config omits display_name when not configured
 result = with_sso_config(enabled: true, display_name: '') do
-  Core::Views::ConfigSerializer.send(:build_sso_config, {})
+  Core::Views::ConfigSerializer.send(:build_sso_config, @operator_view_vars)
 end
 result.key?('display_name')
 #=> false
 
 ## build_sso_config omits display_name when whitespace-only
 result = with_sso_config(enabled: true, display_name: '   ') do
-  Core::Views::ConfigSerializer.send(:build_sso_config, {})
+  Core::Views::ConfigSerializer.send(:build_sso_config, @operator_view_vars)
 end
 result.key?('display_name')
 #=> false
 
 ## build_sso_config includes display_name in provider entry when configured
 result = with_sso_config(enabled: true, display_name: 'Zitadel') do
-  Core::Views::ConfigSerializer.send(:build_sso_config, {})
+  Core::Views::ConfigSerializer.send(:build_sso_config, @operator_view_vars)
 end
 result['providers'].first['display_name']
 #=> "Zitadel"
 
 ## build_sso_config returns correct structure with provider display_name
 result = with_sso_config(enabled: true, display_name: 'Okta') do
-  Core::Views::ConfigSerializer.send(:build_sso_config, {})
+  Core::Views::ConfigSerializer.send(:build_sso_config, @operator_view_vars)
 end
 [result['enabled'], result['providers'].first['display_name']]
 #=> [true, "Okta"]
 
 ## build_feature_flags includes sso as false when disabled
 result = with_sso_config(enabled: false) do
-  Core::Views::ConfigSerializer.send(:build_feature_flags, {})
+  Core::Views::ConfigSerializer.send(:build_feature_flags, @operator_view_vars)
 end
 result['sso']
 #=> false
 
 ## build_feature_flags includes sso hash when enabled
 result = with_sso_config(enabled: true, display_name: 'Azure AD') do
-  Core::Views::ConfigSerializer.send(:build_feature_flags, {})
+  Core::Views::ConfigSerializer.send(:build_feature_flags, @operator_view_vars)
 end
 [result['sso']['enabled'], result['sso']['providers'].first['display_name']]
 #=> [true, "Azure AD"]
 
 ## build_feature_flags includes restrict_to key
 result = with_sso_config(enabled: false) do
-  Core::Views::ConfigSerializer.send(:build_feature_flags, {})
+  Core::Views::ConfigSerializer.send(:build_feature_flags, @operator_view_vars)
 end
 result.key?('restrict_to')
 #=> true
 
 ## build_sso_config provider entry includes route_name
 result = with_sso_config(enabled: true, display_name: 'Okta') do
-  Core::Views::ConfigSerializer.send(:build_sso_config, {})
+  Core::Views::ConfigSerializer.send(:build_sso_config, @operator_view_vars)
 end
 result['providers'].first['route_name']
 #=> "oidc"
 
 ## build_sso_config provider entry has both route_name and display_name
 result = with_sso_config(enabled: true, display_name: 'Zitadel') do
-  Core::Views::ConfigSerializer.send(:build_sso_config, {})
+  Core::Views::ConfigSerializer.send(:build_sso_config, @operator_view_vars)
 end
 [result['providers'].first['route_name'], result['providers'].first['display_name']]
 #=> ["oidc", "Zitadel"]
@@ -190,14 +200,14 @@ end
 
 ## build_sso_config providers array has route_name and display_name strings
 result = with_sso_config(enabled: true) do
-  Core::Views::ConfigSerializer.send(:build_sso_config, {})
+  Core::Views::ConfigSerializer.send(:build_sso_config, @operator_view_vars)
 end
 result['providers'].is_a?(Array)
 #=> true
 
 ## build_sso_config provider entries use string keys
 result = with_sso_config(enabled: true) do
-  Core::Views::ConfigSerializer.send(:build_sso_config, {})
+  Core::Views::ConfigSerializer.send(:build_sso_config, @operator_view_vars)
 end
 result['providers'].empty? || result['providers'].all? { |p| p.key?('route_name') && p.key?('display_name') }
 #=> true

--- a/try/unit/models/custom_domain_auth_default_off_try.rb
+++ b/try/unit/models/custom_domain_auth_default_off_try.rb
@@ -298,6 +298,139 @@ Onetime::CustomDomain::SignupConfig.resolve_signup_enabled_for_custom_domain(fal
 Onetime::CustomDomain::SignupConfig.resolve_signup_enabled_for_custom_domain(true, signup_config(enabled: true, signup_enabled: false))
 #=> false
 
+# --- REQUEST resolvers: which default a classification gets (ADR-024 A12) ---
+#
+# The two resolvers above have OPPOSITE defaults, so CHOOSING between them is
+# the access-policy decision. Choosing on `== :custom` gave :invalid and nil
+# the operator branch — and :invalid is what DomainStrategy answers when its
+# own datastore read RAISES for a REAL customer domain, so a blip handed that
+# domain the operator's global default. resolve_*_enabled_for_request asks the
+# POSITIVE test (SigninConfig.operator_host?) instead: only :canonical and
+# :subdomain, the two classifications a datastore failure cannot manufacture,
+# inherit operator defaults.
+#
+# The required matrix (docs/specs/domain-resolution/domain-resolution.md) for
+# global ENABLED and no tenant config: canonical/subdomain enabled;
+# custom/invalid/nil disabled.
+
+## SIGN-IN matrix, global on, no config: only the operator's own hosts inherit
+[:canonical, :subdomain, :custom, :invalid, nil].map { |s|
+  Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_request(true, nil, domain_strategy: s)
+}
+#=> [true, true, false, false, false]
+
+## SIGN-UP matrix, same rule — sign-up must not disagree with sign-in about
+## which hosts are the operator's
+[:canonical, :subdomain, :custom, :invalid, nil].map { |s|
+  Onetime::CustomDomain::SignupConfig.resolve_signup_enabled_for_request(true, nil, domain_strategy: s)
+}
+#=> [true, true, false, false, false]
+
+## THE FIX, stated as the security property: a real customer domain
+## misclassified :invalid gets the SAME answer it would get correctly
+## classified :custom, not the operator's
+[
+  Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_request(true, nil, domain_strategy: :invalid),
+  Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_request(true, nil, domain_strategy: :custom),
+  Onetime::CustomDomain::SignupConfig.resolve_signup_enabled_for_request(true, nil, domain_strategy: :invalid),
+  Onetime::CustomDomain::SignupConfig.resolve_signup_enabled_for_request(true, nil, domain_strategy: :custom),
+]
+#=> [false, false, false, false]
+
+## KILL SWITCH: global off stays off for every classification, sign-in
+[:canonical, :subdomain, :custom, :invalid, nil].map { |s|
+  Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_request(false, nil, domain_strategy: s)
+}
+#=> [false, false, false, false, false]
+
+## KILL SWITCH: global off stays off for every classification, sign-up
+[:canonical, :subdomain, :custom, :invalid, nil].map { |s|
+  Onetime::CustomDomain::SignupConfig.resolve_signup_enabled_for_request(false, nil, domain_strategy: s)
+}
+#=> [false, false, false, false, false]
+
+## NARROW ONLY: an enabled config that turns sign-in off narrows every
+## classification, the operator's own hosts included
+[:canonical, :subdomain, :custom, :invalid, nil].map { |s|
+  Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_request(
+    true, signin_config(enabled: true, signin_enabled: false), domain_strategy: s
+  )
+}
+#=> [false, false, false, false, false]
+
+## NARROW ONLY: an enabled config cannot widen past a global kill, sign-up
+[:canonical, :subdomain, :custom, :invalid, nil].map { |s|
+  Onetime::CustomDomain::SignupConfig.resolve_signup_enabled_for_request(
+    false, signup_config(enabled: true, signup_enabled: true), domain_strategy: s
+  )
+}
+#=> [false, false, false, false, false]
+
+## EXPLICIT ENABLEMENT STAYS REACHABLE: the fail-closed default must not make
+## an opted-in tenant unreachable — an :invalid host whose config WAS read
+## successfully follows that tenant's own policy
+[
+  Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_request(
+    true, signin_config(enabled: true, signin_enabled: true), domain_strategy: :invalid
+  ),
+  Onetime::CustomDomain::SignupConfig.resolve_signup_enabled_for_request(
+    true, signup_config(enabled: true, signup_enabled: true), domain_strategy: :invalid
+  ),
+]
+#=> [true, true]
+
+## STRING classifications: StrategyResult metadata is not always a Symbol, and
+## operator_host? normalizes, so the string forms must resolve identically
+[
+  Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_request(true, nil, domain_strategy: 'canonical'),
+  Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_request(true, nil, domain_strategy: 'custom'),
+  Onetime::CustomDomain::SignupConfig.resolve_signup_enabled_for_request(true, nil, domain_strategy: 'subdomain'),
+  Onetime::CustomDomain::SignupConfig.resolve_signup_enabled_for_request(true, nil, domain_strategy: 'invalid'),
+]
+#=> [true, false, true, false]
+
+## SSO CARVE-OUT SURVIVES THE FIX (display surfaces pass domain_id:): an
+## SSO-only tenant reports sign-in available on :custom AND on :invalid —
+## fail-closed must not hide a working /signin page
+[
+  Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_request(
+    true, nil, domain_strategy: :custom, domain_id: @sso_only_domain
+  ),
+  Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_request(
+    true, nil, domain_strategy: :invalid, domain_id: @sso_only_domain
+  ),
+]
+#=> [true, true]
+
+## POST-GATE PARITY: the same SSO-only tenant WITHOUT domain_id stays strictly
+## off on both classifications — SSO never flows through POST /signin
+[
+  Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_request(true, nil, domain_strategy: :custom),
+  Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_request(true, nil, domain_strategy: :invalid),
+]
+#=> [false, false]
+
+## the carve-out never reaches an operator host: :canonical follows the global
+## default with or without domain_id, so a passed domain_id cannot smuggle SSO
+## availability into the operator's own answer
+[
+  Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_request(
+    false, nil, domain_strategy: :canonical, domain_id: @sso_only_domain
+  ),
+  Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_request(
+    true, nil, domain_strategy: :canonical, domain_id: @sso_only_domain
+  ),
+]
+#=> [false, true]
+
+## SHARED OWNER: sign-up reuses SigninConfig.operator_host? rather than
+## restating the list, so the two gates cannot drift about which hosts are the
+## operator's
+[:canonical, :subdomain, :custom, :invalid, nil].map { |s|
+  Onetime::CustomDomain::SigninConfig.operator_host?(s)
+}
+#=> [true, true, false, false, false]
+
 # --- Cleanup ---
 
 Familia.dbclient.flushdb

--- a/try/unit/models/custom_domain_auth_default_off_try.rb
+++ b/try/unit/models/custom_domain_auth_default_off_try.rb
@@ -298,7 +298,8 @@ Onetime::CustomDomain::SignupConfig.resolve_signup_enabled_for_custom_domain(fal
 Onetime::CustomDomain::SignupConfig.resolve_signup_enabled_for_custom_domain(true, signup_config(enabled: true, signup_enabled: false))
 #=> false
 
-# --- REQUEST resolvers: which default a classification gets (ADR-024 A12) ---
+# --- REQUEST resolvers: which default a classification gets ---
+# ADR-024#operator-defaults-require-positive-classification
 #
 # The two resolvers above have OPPOSITE defaults, so CHOOSING between them is
 # the access-policy decision. Choosing on `== :custom` gave :invalid and nil


### PR DESCRIPTION
Closes #4157. Implements ADR-024 A12.

## Problem

`DomainStrategy` answers `:invalid` for two unrelated situations: a genuinely
unplaceable host, and a `known_custom_domain?` datastore read that *raised*
and got swallowed by `choose_strategy`'s rescue. In the second case a real
customer domain wears the classification of an unrecognized one.

That distinction was invisible at the auth gates, which branched on
`custom_domain_request?` (`== :custom`). The two branches have **opposite
defaults** — custom domains are default-OFF and must opt in, operator hosts
follow the install's global setting — so choosing the branch *is* the
access-policy decision. During a datastore blip, a domain whose owner never
opted into sign-up followed the operator's global default instead. An
availability failure widening an access policy.

#4139's A3 rescue did not cover this: it closes the case where the gate's
*own* read also fails. A blip that clears in between leaves `:invalid` on the
request with a fully readable policy, no 503, and every `== :custom` consumer
still taking the operator branch.

## Approach

Only a **positively classified** operator host may inherit the global
defaults. The test is `SigninConfig.operator_host?` — true for `:canonical`
and `:subdomain` only; `:custom`, `:invalid` and a missing classification all
take the tenant-safe resolver. "Not `:custom`" is not evidence of an operator
host.

- Request-aware selectors at the policy layer:
  `resolve_signin_enabled_for_request` and `resolve_signup_enabled_for_request`.
  Both are thin wrappers over the existing resolvers, so ADR-024 invariant 4
  holds and the context-free resolvers keep their semantics for
  administrative and non-request callers — nothing acquires an implicit
  tenant-safe meaning from an omitted argument.
- Sign-up reuses `SigninConfig.operator_host?` rather than restating the
  classification list, so the two gates cannot drift apart. The sign-in
  `domain_id:` SSO carve-out is preserved verbatim.
- `SignupPolicyUnavailable` joins `SigninPolicyUnavailable` under a shared
  `AuthPolicyUnavailable`, with the 503 shape defined once. Otto resolves
  handlers by exact class name, so each subclass gets its own
  `register_error_handler` entry — inheritance is not enough.
- The display gate moves with the runtime gates (`ConfigSerializer` gains
  `operator_domain?`), so `/signin` cannot advertise what the POST rejects.

**The identity predicates are deliberately NOT flipped.**
`custom_domain_request?` and `tenant_domain?` stay `== :custom`. Redefining
them as "not canonical and not subdomain" would fix one policy decision by
handing tenant branding, routing and presentation to genuinely malformed
hosts, where no tenant exists.

## Accepted cost

This is fail-closed and it bites `:subdomain`. `:canonical` classifies before
the datastore read, but the subdomain sweeps run after it, so during an
outage a recognized operator subdomain classifies `:invalid` and is held to
the stricter default. That denies nothing ever explicitly granted, and it is
the correct direction: `operator_host?` may be over-strict during an outage,
never over-permissive. A read added ahead of the canonical arm would break
that invariant silently and take canonical sign-in dark too.

## Also here

- **`docs/specs/domain-ip-allowlist`** gated on `== :custom` and inherited
  the same ambiguity — a filter that would stop enforcing for every protected
  domain during a blip. A12's remedy does not transfer directly: that feature
  is default-**open** on both branches, so a positive test alone changes
  nothing, and the naive fail-closed reading would deny every unknown host.
  The mechanism splits instead — `operator_host?` for scope, and the
  `AccessConfig` read (not rescued to nil) disambiguates the two `:invalid`
  cases: no record passes through, a raising read returns 503 + `Retry-After`
  rather than the 403 block page, which would blame the customer's CIDR list
  for an outage. Spec-only; the feature is unimplemented.
- **`try/integration/domain_auth_enforcement_try.rb`** L365 was a stale #4139
  artifact, not A12: the case name promised tenant SSO credentials the
  fixture never created. Repaired by giving the fixture the credentials its
  name implies. Easy to lift out if you would rather it land with #4139.

## Coverage

`spec/unit/domain_strategy_classification_contract_spec.rb` drives every
classification through every gate. The A12 example is kept rather than
deleted, with its expectation inverted, so a re-introduction of `== :custom`
branch selection reds *there* with the history attached instead of passing
silently.

Local: 180 rspec examples green across the classification contract,
`SignupPolicyUnavailable` and the display/runtime parity spec; main's 39
`restrict_to` examples still pass; 122 tryout cases green across
`custom_domain_auth_default_off_try.rb` and `domain_auth_enforcement_try.rb`.
