### PR TITLE
fix(auth): close the settings-API restrict_to fail-open and repoint stale docs

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -441,11 +441,17 @@ AUTH_PASSWORD_REQUIREMENTS_ENABLED=true
 AUTH_ACTIVE_SESSIONS_ENABLED=true
 AUTH_VERIFY_ACCOUNT_ENABLED=true
 
-# Restrict the login page to a single authentication method.
-# Set exactly ONE of these to 'true'. The result maps to
+# Restrict sign-in to a single authentication method. This is an access
+# control, not a display preference: every other method's routes 404 on
+# the restricted host, not just hide.
+# Set at most ONE of these to 'true'. The result maps to
 # full.restrict_to in auth config (values: password, email_auth,
-# webauthn, sso). If more than one is set, all are ignored
-# (safe fallback to showing all enabled methods).
+# webauthn, sso). Setting more than one is a FATAL BOOT ERROR naming
+# every flag set — there is no "restricted to two methods".
+# The named method must actually be available (feature enabled and
+# credentials present); if it is not, that is also a FATAL BOOT ERROR.
+# Post-boot or per-host unavailability degrades to "sign-in
+# unavailable" — never back to showing all methods.
 # If none are set, all enabled methods are shown (default).
 #AUTH_PASSWORD_ONLY=false
 #AUTH_EMAIL_AUTH_ONLY=false

--- a/apps/api/domains/logic/signin_config/base.rb
+++ b/apps/api/domains/logic/signin_config/base.rb
@@ -94,7 +94,7 @@ module DomainsAPI
           # domain. The details.global_restrict_to field below keeps the
           # OPERATOR's own value — the UI labels the inherited operator
           # restriction separately from what resolves for this host.
-          inherited_restrict = Onetime::CustomDomain::SigninConfig.inherited_restrict_to(
+          inherited = Onetime::CustomDomain::SigninConfig.inherited_restrict_to(
             config,
             domain_id: domain_id,
             custom_host: true,
@@ -112,7 +112,7 @@ module DomainsAPI
             # implementation, shared with GET /api/invite/:token) — this app
             # no longer carries a private copy of the wire shape.
             effective_restrict_to: Onetime::CustomDomain::SigninConfig.resolve_restrict_to(
-              inherited_restrict,
+              inherited.value,
               config,
               # Post-boot availability of the global restriction
               # (ADR-034#degradation-is-fail-closed),
@@ -124,11 +124,15 @@ module DomainsAPI
               # capabilities exactly as it is at request time. Without it the
               # page showed `restricted/password` for a domain whose Rodauth
               # routes the gate had already taken to 404 (#4139).
+              #
+              # #4165: pass pin_established so the availability check trusts the
+              # SSO pin's own proof instead of re-consulting AuthConfig.
               available: Onetime::CustomDomain::SigninConfig.restriction_available_for_request?(
-                inherited_restrict,
+                inherited.value,
                 config,
                 domain_id: domain_id,
                 custom_host: true,
+                already_established: inherited.pin_established,
               ),
             ).to_wire,
             tenant_sso: tenant_sso_details(domain_id),

--- a/apps/api/domains/logic/signin_config/base.rb
+++ b/apps/api/domains/logic/signin_config/base.rb
@@ -59,8 +59,9 @@ module DomainsAPI
         # /signin page (same shared authority as
         # Core::Views::DomainSerializer#effective_signin_enabled?).
         #
-        # effective_restrict_to is the A2 resolver's output verbatim (ADR-024
-        # A4), so the settings UI stops re-deriving the effective restriction
+        # effective_restrict_to is the resolver's output verbatim
+        # (ADR-034#settings-api-serializes-effective-restrict-to), so the
+        # settings UI stops re-deriving the effective restriction
         # from global_restrict_to client-side. global_restrict_to stays: it
         # names the *inherited* restriction, which the UI still labels
         # separately from what resolves for this domain.
@@ -78,6 +79,27 @@ module DomainsAPI
           global          = Onetime::CustomDomain::SigninConfig.global_signin_enabled
           global_restrict = Onetime.auth_config.restrict_to
 
+          # The value this HOST inherits, which is not always the operator's own
+          # restriction: an SSO-only custom domain (no enabled SigninConfig,
+          # tenant or platform SSO available) inherits the 'sso' HOST PIN. Asked
+          # through the shared SigninConfig.inherited_restrict_to — the same call
+          # the /signin page and the route gate make. This page used to hand the
+          # resolver Onetime.auth_config.restrict_to verbatim and so reported
+          # `unrestricted` for a host whose Rodauth routes the gate was already
+          # restricting to SSO: a fail-OPEN divergence of exactly the kind
+          # ADR-034#degradation-is-fail-closed forbids, caught by
+          # apps/web/core/spec/views/serializers/restrict_to_parity_spec.rb.
+          #
+          # custom_host is always true here: these settings describe a custom
+          # domain. The details.global_restrict_to field below keeps the
+          # OPERATOR's own value — the UI labels the inherited operator
+          # restriction separately from what resolves for this host.
+          inherited_restrict = Onetime::CustomDomain::SigninConfig.inherited_restrict_to(
+            config,
+            domain_id: domain_id,
+            custom_host: true,
+          )
+
           {
             global_enabled: global,
             effective_enabled: Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_custom_domain(
@@ -90,7 +112,7 @@ module DomainsAPI
             # implementation, shared with GET /api/invite/:token) — this app
             # no longer carries a private copy of the wire shape.
             effective_restrict_to: Onetime::CustomDomain::SigninConfig.resolve_restrict_to(
-              global_restrict,
+              inherited_restrict,
               config,
               # Post-boot availability of the global restriction
               # (ADR-034#degradation-is-fail-closed),
@@ -103,7 +125,7 @@ module DomainsAPI
               # page showed `restricted/password` for a domain whose Rodauth
               # routes the gate had already taken to 404 (#4139).
               available: Onetime::CustomDomain::SigninConfig.restriction_available_for_request?(
-                global_restrict,
+                inherited_restrict,
                 config,
                 domain_id: domain_id,
                 custom_host: true,

--- a/apps/api/domains/spec/integration/simple/domain_signin_config_spec.rb
+++ b/apps/api/domains/spec/integration/simple/domain_signin_config_spec.rb
@@ -286,7 +286,8 @@ RSpec.describe 'Domain Signin Config API', type: :integration do
       end
     end
 
-    # A domain restriction is subject to the same A3 degradation as an
+    # A domain restriction is subject to the same fail-closed degradation
+    # (ADR-034#degradation-is-fail-closed) as an
     # inherited one: 'sso' with no tenant SsoConfig and no platform fallback
     # names a method this host cannot serve, so it fails closed rather than
     # reporting a restriction the omniauth routes would refuse.

--- a/apps/api/invite/logic/base.rb
+++ b/apps/api/invite/logic/base.rb
@@ -42,7 +42,8 @@ module InviteAPI
       #
       # SHARED ON PURPOSE, and this is the point of it living here. ShowInvite
       # REPORTS what the host permits (record.effective_restrict_to) and
-      # SignupAndAccept ENFORCES it (the A11 gate on POST /:token/signup). The
+      # SignupAndAccept ENFORCES it (the ADR-034#invite-signup-is-gated gate on
+      # POST /:token/signup). The
       # two must be computed from the SAME host or `GET /:token` describes a
       # surface the subsequent POST 404s on, with nothing in the response to
       # predict it. Two byte-identical private copies made that agreement a

--- a/apps/api/invite/logic/invites/show_invite.rb
+++ b/apps/api/invite/logic/invites/show_invite.rb
@@ -135,10 +135,12 @@ module InviteAPI::Logic
 
       # Sign-in methods this host will actually accept.
       #
-      # Every entry is filtered through the resolution (A1): a page that
-      # advertises a method the host rejects is the display/runtime
+      # Every entry is filtered through the resolution
+      # (ADR-034#restrict-to-is-an-access-control-not-a-display-preference): a
+      # page that advertises a method the host rejects is the display/runtime
       # disagreement ADR-024 exists to kill. The list can legitimately come
-      # back EMPTY (an :unavailable resolution allows nothing, A3) — the
+      # back EMPTY (an :unavailable resolution allows nothing,
+      # ADR-034#degradation-is-fail-closed) — the
       # frontend must render that as "sign-in unavailable", never as a reason
       # to fall back to standard mode.
       #

--- a/apps/api/invite/logic/invites/signup_and_accept.rb
+++ b/apps/api/invite/logic/invites/signup_and_accept.rb
@@ -67,7 +67,8 @@ module InviteAPI::Logic
       end
 
       def raise_concerns
-        # A restricted-away method presents no surface at all (A7), so this
+        # A restricted-away method presents no surface at all
+        # (ADR-034#reject-as-not-found-not-forbidden), so this
         # runs FIRST — before the rate limiter, before the token is even read.
         # A dark endpoint must not consume the invitee's rate-limit budget or
         # touch invitation state.
@@ -220,8 +221,9 @@ module InviteAPI::Logic
       #      account we just created is precisely what blocks SSO from creating
       #      a clean one. With no account, SSO signs them in and /accept works.
       #   3. It mints a password credential the install has restricted away —
-      #      "configuration presenting as availability", the shape A1 exists to
-      #      kill.
+      #      "configuration presenting as availability", the shape
+      #      ADR-034#restrict-to-is-an-access-control-not-a-display-preference
+      #      exists to kill.
       #
       # WHERE THE INVITEE GOES INSTEAD. The invitation is untouched and still
       # pending: they authenticate by the method the host does offer (SSO on an
@@ -230,11 +232,14 @@ module InviteAPI::Logic
       # /accept. GET /:token (ShowInvite) and POST /:token/accept are NOT gated
       # and must not be: the first is a display surface, the second is
       # account-scoped and reachable only with a session already established by
-      # a permitted method (A7 "Scope, settled").
+      # a permitted method (ADR-034#reject-as-not-found-not-forbidden, scope
+      # note).
       #
-      # Resolution is NOT re-derived here (A2): Auth::RestrictTo owns input
+      # Resolution is NOT re-derived here
+      # (ADR-034#resolution-is-model-owned): Auth::RestrictTo owns input
       # gathering (including the custom-domain 'sso' pin and the runtime
-      # availability half of A3) and SigninConfig.resolve_restrict_to owns the
+      # availability half of ADR-034#degradation-is-fail-closed) and
+      # SigninConfig.resolve_restrict_to owns the
       # rule. This asks the same question the sign-in page on this host answers.
       def enforce_restrict_to!
         return if Auth::RestrictTo.allows?(restrict_to_env, 'password')
@@ -247,7 +252,8 @@ module InviteAPI::Logic
           host: display_domain,
         )
 
-        # 404, not 403 (A7): the reject shape for a restricted-away method is
+        # 404, not 403 (ADR-034#reject-as-not-found-not-forbidden): the reject
+        # shape for a restricted-away method is
         # not-found, matching Rodauth's behavior for a feature that was never
         # loaded. No error_key — an undefined route has no bespoke i18n string,
         # and reusing the invite API's "not found or expired" key would assert

--- a/apps/api/invite/spec/logic/invites/show_invite_spec.rb
+++ b/apps/api/invite/spec/logic/invites/show_invite_spec.rb
@@ -71,7 +71,8 @@ RSpec.describe InviteAPI::Logic::Invites::ShowInvite do
   subject(:logic) { described_class.new(strategy_result, params) }
 
   # Resolution helper. Drives the endpoint with REAL RestrictToResolution
-  # values so the semantics under test stay the model's (A2): in particular
+  # values so the semantics under test stay the model's
+  # (ADR-034#resolution-is-model-owned): in particular
   # #allows? returning false for everything in the :unavailable state.
   def resolution_for(state, value, source)
     klass = Onetime::CustomDomain::SigninConfig::RestrictToResolution
@@ -98,7 +99,8 @@ RSpec.describe InviteAPI::Logic::Invites::ShowInvite do
     # reads live per-host state (CustomDomain + SigninConfig lookups); the
     # rule it feeds (SigninConfig.resolve_restrict_to) and the verdict object
     # stay real. Auth::RestrictTo.allows? is built on resolution_for, so the
-    # A11 gate on POST /:token/signup reads the same stub — which is what
+    # ADR-034#invite-signup-is-gated gate on POST /:token/signup reads the
+    # same stub — which is what
     # makes the agreement test below meaningful rather than circular.
     allow(Auth::RestrictTo).to receive(:resolution_for).and_return(resolution)
   end
@@ -143,13 +145,14 @@ RSpec.describe InviteAPI::Logic::Invites::ShowInvite do
       end
     end
 
-    context 'when the restricted method is unavailable (A3 fail-closed)' do
+    context 'when the restricted method is unavailable (fail-closed)' do
       let(:resolution) { resolution_for(:unavailable, 'sso', :domain) }
 
       # The three-state shape survives the wire: :unavailable is NOT projected
       # down to a bare null the way `features.restrict_to` must be. A null
       # here would read as "unrestricted" and re-offer every method the
-      # restriction hid — the fail-open A3 exists to kill.
+      # restriction hid — the fail-open ADR-034#degradation-is-fail-closed
+      # exists to kill.
       it 'reports unavailable, keeping the method that was named' do
         expect(record[:effective_restrict_to]).to eq(
           state: 'unavailable', restrict_to: 'sso', source: 'domain'
@@ -157,7 +160,7 @@ RSpec.describe InviteAPI::Logic::Invites::ShowInvite do
       end
     end
 
-    context 'when global and domain restrictions conflict (A8)' do
+    context 'when global and domain restrictions conflict' do
       let(:resolution) { resolution_for(:unavailable, 'sso', :conflict) }
 
       it 'reports unavailable with source conflict' do
@@ -168,7 +171,8 @@ RSpec.describe InviteAPI::Logic::Invites::ShowInvite do
     end
 
     # THE REGRESSION THAT MOTIVATED THE FIELD. auth_methods sits inside the
-    # `custom_domain?` branch, so an SSO-only INSTALL — A11's stated live case,
+    # `custom_domain?` branch, so an SSO-only INSTALL — the live case stated
+    # in ADR-034#invite-signup-is-gated,
     # where the restriction is global and the invitee is on the canonical host
     # — used to receive nothing at all to predict the gate with.
     context 'on a NON-custom host' do
@@ -386,7 +390,7 @@ RSpec.describe InviteAPI::Logic::Invites::ShowInvite do
       end
     end
 
-    context 'unavailable (A3)' do
+    context 'unavailable' do
       let(:resolution) { resolution_for(:unavailable, 'sso', :domain) }
 
       # Empty is the correct answer: the frontend renders "sign-in
@@ -421,11 +425,12 @@ RSpec.describe InviteAPI::Logic::Invites::ShowInvite do
   #
   # The whole point of the field. Both endpoints route through
   # Auth::RestrictTo for the SAME host: ShowInvite renders
-  # resolution_for(env), the A11 gate on POST /:token/signup calls
+  # resolution_for(env), the ADR-034#invite-signup-is-gated gate on
+  # POST /:token/signup calls
   # allows?(env, 'password'), which is resolution_for(env).allows?('password').
   # Stubbing only resolution_for means a divergence in how either side
   # interprets the verdict shows up here.
-  describe 'agreement with the POST /:token/signup gate (A11)' do
+  describe 'agreement with the POST /:token/signup gate' do
     let(:domain_strategy) { :custom }
     let(:display_domain)  { 'signin.acme.example' }
     let(:valid_password)  { 'SecureP@ssw0rd123!' }

--- a/apps/api/invite/spec/logic/invites/signup_and_accept_spec.rb
+++ b/apps/api/invite/spec/logic/invites/signup_and_accept_spec.rb
@@ -729,14 +729,15 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
     subject(:logic) { described_class.new(tenant_strategy_result, valid_params) }
 
     before do
-      # The gate consults the A2 resolver through Auth::RestrictTo, which
+      # The gate consults the model-owned resolver
+      # (ADR-034#resolution-is-model-owned) through Auth::RestrictTo, which
       # gathers its inputs from live per-host state (CustomDomain +
       # SigninConfig lookups). Stub at THAT seam only, and drive it with real
       # RestrictToResolution values so the semantics under test — including
       # :unavailable rejecting everything — stay the model's, not the spec's.
       # (Resolution itself is covered in the SigninConfig and
-      # Auth::RestrictTo specs; re-deriving it here would be the drift A2
-      # exists to prevent.)
+      # Auth::RestrictTo specs; re-deriving it here would be the drift that
+      # decision exists to prevent.)
       allow(Auth::RestrictTo).to receive(:allows?) do |_env, method_name|
         resolution.allows?(method_name)
       end
@@ -800,7 +801,7 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
       context "on a host restricted to #{method_name}" do
         let(:resolution) { resolution_for(:restricted, method_name) }
 
-        it 'rejects as not-found (A7), not 403' do
+        it 'rejects as not-found, not 403' do
           expect { logic.raise_concerns }.to raise_error(Onetime::RecordNotFound)
         end
 
@@ -848,9 +849,9 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
       end
     end
 
-    context 'when resolution is :unavailable (A3 fail-closed)' do
+    context 'when resolution is :unavailable (fail-closed)' do
       # Dormant credentials, a globally-disabled method, or a global/domain
-      # conflict (A8). Nothing is permitted — never widen back to password.
+      # conflict. Nothing is permitted — never widen back to password.
       let(:resolution) { resolution_for(:unavailable, 'sso', :conflict) }
 
       it 'rejects as not-found' do

--- a/apps/web/auth/restrict_to.rb
+++ b/apps/web/auth/restrict_to.rb
@@ -282,16 +282,19 @@ module Auth
       def resolution_for(env)
         domain_id     = domain_id_for(env)
         signin_config = Onetime::CustomDomain::SigninConfig.find_by_domain_id(domain_id) if domain_id
-        global        = global_restrict_to(env, domain_id, signin_config)
+        inherited     = global_restrict_to(env, domain_id, signin_config)
 
         Onetime::CustomDomain::SigninConfig.resolve_restrict_to(
-          global,
+          inherited.value,
           signin_config,
+          # #4165: pass pin_established so the availability check trusts the
+          # SSO pin's own proof instead of re-consulting AuthConfig.
           available: restriction_available_for_host?(
             env,
-            global,
+            inherited.value,
             signin_config,
             domain_id,
+            already_established: inherited.pin_established,
           ),
         )
       rescue Redis::BaseError => ex
@@ -319,12 +322,15 @@ module Auth
       # consumer can narrow an inherited restriction the others do not). All
       # that belongs to the web layer is reading the request classification out
       # of the Rack env, which is what this does.
-      def restriction_available_for_host?(env, global, signin_config, domain_id)
+      #
+      # @param already_established [Boolean] see global_restriction_available? (#4165)
+      def restriction_available_for_host?(env, global, signin_config, domain_id, already_established: false)
         Onetime::CustomDomain::SigninConfig.restriction_available_for_request?(
           global,
           signin_config,
           domain_id: domain_id,
           custom_host: env['onetime.domain_strategy'] == :custom,
+          already_established: already_established,
         )
       end
 

--- a/apps/web/auth/restrict_to.rb
+++ b/apps/web/auth/restrict_to.rb
@@ -9,20 +9,23 @@
 # WHAT THIS CLOSES
 #   PR #4130 shipped the DISPLAY half: a restricted host renders exactly one
 #   sign-in method. The server still ACCEPTED a crafted POST to every other
-#   method's endpoint. A1 makes `restrict_to` an access control: when
+#   method's endpoint. ADR-034#restrict-to-is-an-access-control-not-a-display-preference
+#   makes `restrict_to` an access control: when
 #   resolution yields a single method for a request host, the server MUST
 #   reject submission of every other method on that host.
 #
-# REJECT SHAPE — 404, not 403 (A7)
+# REJECT SHAPE — 404, not 403 (ADR-034#reject-as-not-found-not-forbidden)
 #   A restricted-away method presents NO reachable surface, matching Rodauth's
 #   behavior for a feature that was never loaded. A 403 gate would leave the
 #   handler mounted and reachable — "configuration presenting as availability",
-#   the exact shape A1 exists to kill. The body is the router's shared
+#   the exact shape ADR-034#restrict-to-is-an-access-control-not-a-display-preference
+#   exists to kill. The body is the router's shared
 #   Auth::ErrorTranslator::NOT_FOUND_BODY so a gated route is byte-identical to
 #   an undefined one.
 #
 #   SsoOnlyGating's 403 + error_key is DELIBERATELY NOT reconciled with this
-#   (A7, "Scope, settled"): it governs account-scoped credential MANAGEMENT for
+#   (ADR-034#reject-as-not-found-not-forbidden, scope note): it governs
+#   account-scoped credential MANAGEMENT for
 #   an already-identified user, where an actionable error beats a mystery.
 #
 #   ONE EXCEPTION: 503 when the policy itself
@@ -30,7 +33,8 @@
 #   resolution_for). A 404 here would be the gate claiming a restriction it
 #   never managed to look up — mystery not-founds on the sign-in routes of an
 #   install that may restrict nothing, indistinguishable from a routing
-#   regression. A7's 404 hides policy-gated methods; an unreadable policy has
+#   regression. The 404 of ADR-034#reject-as-not-found-not-forbidden hides
+#   policy-gated methods; an unreadable policy has
 #   nothing to hide, and "the backend read failed, retry" is both the truth and
 #   the alertable signal.
 #
@@ -66,9 +70,12 @@
 #      (apps/web/core/routes.txt). Gated in
 #      Core::Controllers::Base#restrict_to_allows?.
 #
-# See: docs/adr/adr-024-custom-domain-auth-override-resolution.md
-#      (A1, A3, A7 — normative), lib/onetime/models/custom_domain/signin_config.rb
-#      (the A2 resolver; resolution is owned there and re-derived nowhere).
+# See: docs/adr/adr-034-restrict-to-enforcement.md — normative:
+#      #restrict-to-is-an-access-control-not-a-display-preference,
+#      #degradation-is-fail-closed, #reject-as-not-found-not-forbidden — and
+#      lib/onetime/models/custom_domain/signin_config.rb (the resolver of
+#      ADR-034#resolution-is-model-owned; resolution is owned there and
+#      re-derived nowhere).
 #
 
 require 'json'
@@ -86,7 +93,8 @@ module Auth
     # config/features/).
     #
     # Every route here goes dark when its method is restricted away. Secondary
-    # endpoints are included on purpose (A7): a gate that covers POST /login
+    # endpoints are included on purpose
+    # (ADR-034#reject-as-not-found-not-forbidden): a gate that covers POST /login
     # and misses the ceremony-start endpoint leaves the gap open while looking
     # closed, which is worse than no gate because it invites documenting
     # restrict_to as an access control it does not provide.
@@ -332,35 +340,19 @@ module Auth
       # The restriction the request HOST inherits when no enabled per-domain
       # config speaks — the `global` input to the resolver.
       #
-      # SSO PIN, parity with ConfigSerializer#effective_global_restrict_to: a
-      # custom domain with no enabled SigninConfig keeps a working /signin page
-      # only because tenant SSO is available there, and password/email default
-      # OFF on custom domains. Pinning 'sso' keeps this gate in lockstep with
-      # the page that host actually renders.
-      #
-      # The availability predicate is SsoConfig.sso_available_for_tenant_host? —
-      # the SAME predicate ConfigSerializer#effective_global_restrict_to pins
-      # on, platform fallback included. It used to be the narrower
-      # tenant_sso_available_for?, which left this gate MORE permissive than
-      # the page it guards whenever allow_platform_fallback_for_tenants? was on
-      # and the tenant had no SsoConfig: the page offered SSO alone, the gate
-      # pinned nothing and accepted crafted password POSTs. See that predicate
-      # for why converging on the display's answer is the narrowing direction.
+      # Thin wrapper, same shape as restriction_available_for_host? above: the
+      # pin POLICY (including the no-enabled-config precondition and the
+      # SsoConfig.sso_available_for_tenant_host? predicate it fires on) is
+      # SigninConfig.inherited_restrict_to, so the display serializer, this gate
+      # and the settings API cannot inherit three different restrictions for one
+      # host. All that belongs to the web layer is reading the request
+      # classification out of the Rack env.
       def global_restrict_to(env, domain_id, signin_config)
-        # NO-CONFIG CASE ONLY. Under A8's intersection semantics two different
-        # restrictions have no intersection and fail closed as :conflict, so
-        # pinning 'sso' on a tenant that HAS spoken (an enabled SigninConfig
-        # naming, say, 'password') would take that host dark instead of honoring
-        # the owner's choice. The pin exists to describe a host that has NOT
-        # configured sign-in and is reachable only via SSO; that is the only
-        # case it may apply to.
-        return Onetime.auth_config.restrict_to if signin_config&.enabled?
-
-        return 'sso' if env['onetime.domain_strategy'] == :custom &&
-                        domain_id &&
-                        Onetime::CustomDomain::SsoConfig.sso_available_for_tenant_host?(domain_id)
-
-        Onetime.auth_config.restrict_to
+        Onetime::CustomDomain::SigninConfig.inherited_restrict_to(
+          signin_config,
+          domain_id: domain_id,
+          custom_host: env['onetime.domain_strategy'] == :custom,
+        )
       end
 
       # CustomDomain identifier for the request host, or nil.
@@ -380,7 +372,8 @@ module Auth
       end
 
       # The router's shared 404 — a gated route must be indistinguishable from
-      # an undefined one (A7). Built here rather than reusing the router's
+      # an undefined one (ADR-034#reject-as-not-found-not-forbidden). Built here
+      # rather than reusing the router's
       # status_handler because request.halt bypasses Roda's status handlers.
       def not_found_response
         [

--- a/apps/web/auth/spec/integration/full/restrict_to_enforcement_spec.rb
+++ b/apps/web/auth/spec/integration/full/restrict_to_enforcement_spec.rb
@@ -15,7 +15,8 @@
 # The highest-value cases here are not the happy paths — they are:
 #
 #   1. on a host restricted to ONE method, a direct POST to every OTHER
-#      method's endpoint is 404 (A7's reject shape: the route reads as
+#      method's endpoint is 404 (the reject shape of
+#      ADR-034#reject-as-not-found-not-forbidden: the route reads as
 #      undefined, not forbidden), INCLUDING the secondary endpoints;
 #   2. the SSO surface, which is NOT in Rodauth's route_hash — the OmniAuth
 #      request phase is middleware-served, so the before_rodauth gate never
@@ -23,7 +24,8 @@
 #   3. the ROUTE COVERAGE assertion at the bottom, which fails when a new
 #      Rodauth route appears and nobody classified it. A gate that covers the
 #      primary POST and misses a ceremony endpoint leaves the gap open while
-#      LOOKING closed, which A7 calls worse than no gate at all.
+#      LOOKING closed, which ADR-034#reject-as-not-found-not-forbidden calls
+#      worse than no gate at all.
 #
 # Simple mode is a separate deployment shape and is covered by its sibling,
 # spec/integration/simple/restrict_to_enforcement_spec.rb: there POST
@@ -142,7 +144,8 @@ RSpec.describe 'restrict_to enforcement — full mode (ADR-034#restrict-to-is-an
     csrf_json_post(path, params)
   end
 
-  # A gated route must be byte-identical to an undefined one (A7): same status
+  # A gated route must be byte-identical to an undefined one
+  # (ADR-034#reject-as-not-found-not-forbidden): same status
   # AND the router's shared ADR-013 body, not a bespoke shape.
   def expect_not_found(response, path)
     expect(response.status).to eq(404),
@@ -167,8 +170,9 @@ RSpec.describe 'restrict_to enforcement — full mode (ADR-034#restrict-to-is-an
     let(:host) { build_restricted_domain('email_auth') }
 
     # Every PASSWORD endpoint, primary and secondary. reset-password-request and
-    # reset-password are pre-auth surfaces and go dark with the method (A7's
-    # closing paragraph); create-account likewise.
+    # reset-password are pre-auth surfaces and go dark with the method
+    # (ADR-034#reject-as-not-found-not-forbidden, closing paragraph);
+    # create-account likewise.
     %w[
       /auth/login
       /auth/create-account

--- a/apps/web/auth/spec/unit/restrict_to_gate_spec.rb
+++ b/apps/web/auth/spec/unit/restrict_to_gate_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Auth::RestrictTo do
       end
     end
 
-    it 'rejects every route when the restriction is unavailable (A3 fail-closed)' do
+    it 'rejects every route when the restriction is unavailable (fail-closed)' do
       described_class::GATED_ROUTES.each_key do |route|
         halted = gate(route, resolution_class.unavailable('sso', :global))
 

--- a/apps/web/auth/spec/unit/restrict_to_gate_spec.rb
+++ b/apps/web/auth/spec/unit/restrict_to_gate_spec.rb
@@ -173,8 +173,9 @@ RSpec.describe Auth::RestrictTo do
       allow(Onetime::CustomDomain::SigninConfig).to receive(:find_by_domain_id)
         .with(domain_id).and_return(nil)
       allow(Onetime.auth_config).to receive(:restrict_to).and_return('sso')
+      # #4165: global_restriction_available? now accepts already_established: keyword
       allow(Onetime::CustomDomain::SigninConfig).to receive(:global_restriction_available?)
-        .with('sso').and_return(true)
+        .and_return(true)
     end
 
     it 'fails an inherited SSO restriction closed when this host has no usable SSO path' do
@@ -314,8 +315,9 @@ RSpec.describe Auth::RestrictTo do
       allow(Onetime::CustomDomain).to receive(:from_display_domain)
         .with('example.com').and_raise(Redis::BaseError, 'lookup unavailable')
       allow(Onetime.auth_config).to receive(:restrict_to).and_return('password')
+      # #4165: global_restriction_available? now accepts already_established: keyword
       allow(Onetime::CustomDomain::SigninConfig).to receive(:global_restriction_available?)
-        .with('password').and_return(true)
+        .and_return(true)
 
       resolution = described_class.resolution_for(canonical_env)
 

--- a/apps/web/core/controllers/base.rb
+++ b/apps/web/core/controllers/base.rb
@@ -215,8 +215,18 @@ module Core
       # @raise [Onetime::SigninPolicyUnavailable] on an unreadable custom-host policy
       # @return [Boolean] false when this host restricts the method away
       def restrict_to_allows?(method_name)
-        global        = Onetime.auth_config.restrict_to
         signin_config = domain_signin_config
+
+        # Use inherited_restrict_to (not raw auth_config.restrict_to) so the
+        # SSO host pin applies here the same way it does in the display
+        # serializer and the full-mode gate (#4165). Without this, a custom
+        # domain with SSO available but no enabled SigninConfig could show
+        # restricted/sso on the page while this gate resolves :unrestricted.
+        inherited = Onetime::CustomDomain::SigninConfig.inherited_restrict_to(
+          signin_config,
+          domain_id: custom_domain_id,
+          custom_host: custom_domain_request?,
+        )
 
         # The runtime-availability half of ADR-034#degradation-is-fail-closed is
         # applied BY THE RESOLVER, not here.
@@ -231,15 +241,19 @@ module Core
         # INHERITED global restriction through the custom host's own
         # capabilities, so this gate cannot accept a method the full-mode gate
         # and the /signin page both treat as dark.
+        #
+        # #4165: pass pin_established so the availability check trusts the
+        # SSO pin's own proof instead of re-consulting AuthConfig.
         Onetime::CustomDomain::SigninConfig
           .resolve_restrict_to(
-            global,
+            inherited.value,
             signin_config,
             available: Onetime::CustomDomain::SigninConfig.restriction_available_for_request?(
-              global,
+              inherited.value,
               signin_config,
               domain_id: custom_domain_id,
               custom_host: custom_domain_request?,
+              already_established: inherited.pin_established,
             ),
           )
           .allows?(method_name)

--- a/apps/web/core/controllers/base.rb
+++ b/apps/web/core/controllers/base.rb
@@ -218,13 +218,15 @@ module Core
         global        = Onetime.auth_config.restrict_to
         signin_config = domain_signin_config
 
-        # A3's runtime-availability half is applied BY THE RESOLVER, not here.
+        # The runtime-availability half of ADR-034#degradation-is-fail-closed is
+        # applied BY THE RESOLVER, not here.
         # This used to guard `return false if global && !restrict_to_available?`
         # ahead of resolution, which was wrong in one case: a DOMAIN-only
         # restriction went dark whenever the unrelated global method was dead.
         # Passing the flag in lets the resolver narrow only what the global half
         # actually governs. Four consumers each remembering this rule is the
-        # drift A2 exists to kill — hence restriction_available_for_request?,
+        # drift ADR-034#resolution-is-model-owned exists to kill — hence
+        # restriction_available_for_request?,
         # which is the one place that rule lives (#4139). It also narrows an
         # INHERITED global restriction through the custom host's own
         # capabilities, so this gate cannot accept a method the full-mode gate

--- a/apps/web/core/spec/views/serializers/config_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/config_serializer_spec.rb
@@ -1005,7 +1005,8 @@ RSpec.describe Core::Views::ConfigSerializer do
       # These examples are about which restriction the serializer REPORTS, so
       # the host's capabilities are stood up as available: AUTH_SIGNIN on
       # (the file-level stub carries only the master switch) and the
-      # email-auth feature on. Without them the A3 derivation below correctly
+      # email-auth feature on. Without them the fail-closed derivation below
+      # (ADR-034#degradation-is-fail-closed) correctly
       # answers :unavailable for every method and the examples stop testing
       # what they are named for.
       before do
@@ -1160,9 +1161,9 @@ RSpec.describe Core::Views::ConfigSerializer do
       end
     end
 
-    # The point of A2: one owner. If this delegation is ever inlined again the
-    # three gates drift apart, which is the failure mode ADR-024 invariant 5
-    # exists to prevent.
+    # The point of ADR-034#resolution-is-model-owned: one owner. If this
+    # delegation is ever inlined again the three gates drift apart, which is
+    # the failure mode that decision exists to prevent.
     it 'delegates resolution to the model resolver' do
       allow(mock_auth_config).to receive(:restrict_to).and_return('password')
 

--- a/apps/web/core/spec/views/serializers/restrict_to_parity_spec.rb
+++ b/apps/web/core/spec/views/serializers/restrict_to_parity_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe 'restrict_to display/gate parity' do
     end
   end
 
-  describe 'the pin never reaches a tenant that has spoken (A8)' do
+  describe 'the pin never reaches a tenant that has spoken' do
     let(:enabled_signin_config) do
       instance_double(
         Onetime::CustomDomain::SigninConfig,
@@ -331,7 +331,7 @@ RSpec.describe 'restrict_to display/gate parity' do
         expect_three_way_parity
       end
 
-      it 'resolves :unavailable rather than widening back to standard mode (A3)' do
+      it 'resolves :unavailable rather than widening back to standard mode' do
         expect(gate_resolution).to be_unavailable
         expect(gate_resolution.allows?('password')).to be(false)
         expect(gate_resolution.allows?('sso')).to be(false)
@@ -348,7 +348,7 @@ RSpec.describe 'restrict_to display/gate parity' do
         expect_three_way_parity
       end
 
-      it 'resolves :unavailable from the conflict source (A8), naming the operator method' do
+      it 'resolves :unavailable from the conflict source, naming the operator method' do
         expect(gate_resolution).to be_unavailable
         expect(gate_resolution.source).to eq(:conflict)
         expect(gate_resolution.restrict_to).to eq('password')
@@ -384,32 +384,40 @@ RSpec.describe 'restrict_to display/gate parity' do
     end
   end
 
-  # RESIDUAL GAP, recorded rather than papered over. The display serializer and
-  # the route gate both pin 'sso' as the inherited restriction for a custom host
-  # with no enabled SigninConfig that is reachable only via SSO
-  # (ConfigSerializer#effective_global_restrict_to,
-  # Auth::RestrictTo.global_restrict_to). The settings API does not — it hands
-  # the resolver Onetime.auth_config.restrict_to verbatim — so it reports
-  # :unrestricted for a host that offers SSO alone. Same A2 drift shape as the
-  # four defects #4139 fixed, but a different input (the `global` VALUE, not the
-  # `available:` flag) and out of that scope: closing it means extracting the pin
-  # too, which changes what the settings page reports for every SSO-only tenant.
+  # CLOSED (#4140). The display serializer and the route gate both pin 'sso' as
+  # the inherited restriction for a custom host with no enabled SigninConfig
+  # that is reachable only via SSO. The settings API did not — it handed the
+  # resolver Onetime.auth_config.restrict_to verbatim — so it reported
+  # :unrestricted for a host that offers SSO alone, while the gate was already
+  # restricting that host's routes to SSO. A fail-OPEN divergence, which is the
+  # one direction ADR-034#degradation-is-fail-closed forbids.
   #
-  # Written as a pending example on purpose: it reds when someone fixes it,
-  # which is when this note should be deleted.
-  describe 'the SSO host pin does not reach the settings API' do
+  # Same ADR-034#resolution-is-model-owned drift shape as the four defects
+  # #4139 fixed, one input over: the
+  # `global` VALUE rather than the `available:` flag. Fixed the same way —
+  # the pin moved onto the model as
+  # SigninConfig.inherited_restrict_to(config, domain_id:, custom_host:), and
+  # all three consumers now call it instead of two of them carrying a private
+  # copy and the third carrying none.
+  describe 'the SSO host pin reaches the settings API' do
     before do
       allow(mock_auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
     end
 
-    it 'should agree with the two request-time consumers' do
-      pending 'settings API does not apply the SSO host pin — residual A2 gap, follow-up to #4139'
-
+    it 'agrees with the two request-time consumers' do
       expect(settings_api_wire).to eq(gate_resolution.to_wire)
+    end
+
+    it "reports restricted/sso rather than a fail-open 'unrestricted'" do
+      expect(settings_api_wire).to eq(state: 'restricted', restrict_to: 'sso', source: 'global')
+    end
+
+    it 'agrees with the display serializer too' do
+      expect(settings_api_wire).to eq(display_resolution.to_wire)
     end
   end
 
-  describe 'post-boot global unavailability (A3)' do
+  describe 'post-boot global unavailability' do
     # Canonical host: no pin, so the operator's own restriction is what both
     # sides carry — and both must degrade with it.
     let(:view_vars) do

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -366,42 +366,15 @@ module Core
         # The restriction this REQUEST HOST inherits when no enabled per-domain
         # config speaks — the `global` input to the resolver.
         #
-        # SSO carve-out parity with resolve_signin: a custom domain with no
-        # enabled SigninConfig keeps its /signin page ONLY because SSO is
-        # available (resolve_signin returns sso_available?). Without narrowing
-        # restrict_to, AuthMethodSelector would fall into standard mode and
-        # render the password/email form beside the SSO buttons — yet password/
-        # email default OFF on custom domains and their POST route
-        # (Base#signin_enabled?) rejects them, so those forms advertise methods
-        # that always fail. Pin 'sso' on exactly the same predicate
-        # resolve_signin uses (tenant_domain? && sso_available?) so the
-        # page-availability gate and the method restriction stay in lockstep
-        # and the SSO-only page renders SSO buttons alone.
-        #
-        # The pin is a property of the HOST, not an operator restriction, and
-        # it must not reach the resolver when an enabled domain config speaks.
-        # Under ADR-034#resolution-intersects-never-widens the resolver intersects rather than replaces, so a
-        # pin handed in unconditionally would CONFLICT with the tenant's own
-        # restrict_to and resolve :unavailable — turning a display convenience
-        # into a lockout. Skip it on exactly the predicate resolve_signin uses
-        # (tenant_domain? && !signin_config&.enabled?), which restores the
-        # pre-extraction ordering where the pin was only reached after the
-        # domain branch declined.
-        #
-        # Design smell, recorded: this overloads the resolver's `global`
-        # parameter with two different things — a real operator restriction
-        # and a derived host property. They intersect differently, which is
-        # why this guard exists. If a third pin ever appears, the resolver
-        # should take them as distinct inputs instead.
-        #
-        # ONE PREDICATE WITH THE RUNTIME GATE (#4139): the pin fires on
-        # SsoConfig.sso_available_for_tenant_host?, which Auth::RestrictTo
-        # calls too. It is equivalent to the local sso_available?
-        # (build_sso_config) verdict for a tenant host — tenant credentials, or
-        # platform providers when fallback is allowed — but expressed
-        # domain-id-first so a gate holding a Rack env can ask the same
-        # question. Previously the gate asked the narrower tenant-only ladder
-        # and was therefore MORE PERMISSIVE than this page.
+        # The pin POLICY is SigninConfig.inherited_restrict_to (see it for why
+        # an SSO-only custom host inherits 'sso' and why the pin may only apply
+        # when no enabled domain config speaks). It is shared with the runtime
+        # gate (Auth::RestrictTo.global_restrict_to) and the settings API
+        # (DomainsAPI signin_config details), so the page cannot inherit a
+        # different restriction from the routes it posts to
+        # (ADR-034#resolution-is-model-owned). All that is left here is the
+        # display side's own request facts: the tenant-host classification and
+        # the #4157 read-failure tri-state.
         #
         # @param view_vars [Hash] View variables with request context
         # @param signin_config [Onetime::CustomDomain::SigninConfig, nil]
@@ -411,14 +384,19 @@ module Core
           # Tri-state handling (#4157): if domain_id is DOMAIN_READ_FAILED, the
           # caller should have already short-circuited. If we reach here anyway,
           # don't attempt the SSO pin — fall through to global.
-          if tenant_domain?(view_vars) && !signin_config&.enabled? && domain_id != DOMAIN_READ_FAILED
+          custom_host = tenant_domain?(view_vars) && domain_id != DOMAIN_READ_FAILED
+
+          if custom_host && !signin_config&.enabled?
             domain_id ||= resolve_domain_id(view_vars)
             # Defensive: if the fallback read also failed, skip the SSO pin.
-            return 'sso' if domain_id != DOMAIN_READ_FAILED &&
-                            Onetime::CustomDomain::SsoConfig.sso_available_for_tenant_host?(domain_id)
+            custom_host = domain_id != DOMAIN_READ_FAILED
           end
 
-          Onetime.auth_config.restrict_to
+          Onetime::CustomDomain::SigninConfig.inherited_restrict_to(
+            signin_config,
+            domain_id: custom_host ? domain_id : nil,
+            custom_host: custom_host,
+          )
         end
 
         # Resolve sign-in availability for the current request context.

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -340,10 +340,10 @@ module Core
           end
 
           signin_config = Onetime::CustomDomain::SigninConfig.find_by_domain_id(domain_id) if domain_id
-          global        = effective_global_restrict_to(view_vars, signin_config, domain_id)
+          inherited     = effective_global_restrict_to(view_vars, signin_config, domain_id)
 
           Onetime::CustomDomain::SigninConfig.resolve_restrict_to(
-            global,
+            inherited.value,
             signin_config,
             # Post-boot availability of the global restriction (ADR-034#degradation-is-fail-closed),
             # asked through the SHARED gatherer so the page cannot answer it
@@ -354,11 +354,15 @@ module Core
             # narrowed through the custom-host capabilities (password defaults
             # OFF there), resolved :unavailable, and 404'd the very routes this
             # page's form posts to (#4139).
+            #
+            # #4165: pass pin_established so the availability check trusts the
+            # SSO pin's own proof instead of re-consulting AuthConfig.
             available: Onetime::CustomDomain::SigninConfig.restriction_available_for_request?(
-              global,
+              inherited.value,
               signin_config,
               domain_id: domain_id,
               custom_host: tenant_domain?(view_vars),
+              already_established: inherited.pin_established,
             ),
           )
         end
@@ -379,7 +383,7 @@ module Core
         # @param view_vars [Hash] View variables with request context
         # @param signin_config [Onetime::CustomDomain::SigninConfig, nil]
         # @param domain_id [String, nil, :domain_read_failed] already-resolved CustomDomain objid
-        # @return [String, nil]
+        # @return [Onetime::CustomDomain::SigninConfig::InheritedRestriction]
         def effective_global_restrict_to(view_vars, signin_config = nil, domain_id = nil)
           # Tri-state handling (#4157): if domain_id is DOMAIN_READ_FAILED, the
           # caller should have already short-circuited. If we reach here anyway,

--- a/changelog.d/20260814_192200_claude_4165_sso_host_pin.rst
+++ b/changelog.d/20260814_192200_claude_4165_sso_host_pin.rst
@@ -1,0 +1,17 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- (`#4165 <https://github.com/onetimesecret/onetimesecret/pull/4165>`_)
+  SSO routes no longer 404 when tenant SSO is available but platform SSO
+  prerequisites are unmet. The SSO host pin now carries proof that tenant
+  availability was already established, so the gate no longer re-consults
+  AuthConfig when the pin value happens to match the operator's configured
+  ``restrict_to``.
+
+AI Assistance
+-------------
+
+- Claude fixed the SSO host pin collision, removed a wasted datastore probe,
+  and aligned the simple-mode gate with the display serializer. (#4165)

--- a/docs/adr/adr-034-restrict-to-enforcement.md
+++ b/docs/adr/adr-034-restrict-to-enforcement.md
@@ -9,7 +9,7 @@ title: "ADR-034: Authentication Method Restriction Resolution and Fail-Closed En
 
 PR #4130 shipped the display half of domain `restrict_to` (every value
 rendered, single-method picker enabled) but left two gaps: no server-side
-enforcement, no server-side re-validation. Split out of [ADR-024](adr-024-custom-domain-auth-override-resolution.md#amendments),
+enforcement, no server-side re-validation. Split out of [ADR-024](adr-024-custom-domain-auth-override-resolution.md),
 which recorded the underlying decisions. Deciding principle throughout:
 security, privacy, and long-term codebase health; the default posture is
 fail-closed.

--- a/docs/adr/adr-035-tenant-identity-auth-policy-scope.md
+++ b/docs/adr/adr-035-tenant-identity-auth-policy-scope.md
@@ -7,8 +7,8 @@ title: "ADR-035: Tenant Identity and Authentication-Policy Scope"
 
 ## Context
 
-Split out of [ADR-024](adr-024-custom-domain-auth-override-resolution.md)
-amendment A6. [ADR-034](adr-034-restrict-to-enforcement.md) governs *which
+Split out of [ADR-024](adr-024-custom-domain-auth-override-resolution.md).
+[ADR-034](adr-034-restrict-to-enforcement.md) governs *which
 methods* work on a request host; this ADR governs *which accounts* may
 authenticate on it — a separate axis.
 

--- a/docs/runbooks/cannot-log-in-or-create-account.md
+++ b/docs/runbooks/cannot-log-in-or-create-account.md
@@ -41,7 +41,7 @@ with no address to rate-limit (an orphan looked up by extid or account id).
 1. **Account state** — unverified, closed, locked out, Customer↔auth drift. → diagnose
 2. **Rate limiting** — Valkey limiters block before Rodauth sees the attempt. → diagnose
 3. **Email delivery** — verification/reset email never sent, bounced, suppressed.
-4. **Surface config** — custom domain with signin/signup default-OFF (v0.26.2 regression) or `restrict_to: 'sso'`; wrong region.
+4. **Surface config** — custom domain with signin/signup default-OFF (v0.26.2 regression) or `restrict_to: 'sso'`; a `restrict_to` whose method is unavailable on that host, which fails closed to "sign-in unavailable" rather than re-offering the other methods (ADR-034#degradation-is-fail-closed); wrong region.
 5. **Client-side** — CSP blocking form-action (#3848/#3836), cookie dropped behind TLS proxy (#3837), JS errors.
 6. **Policy rejection** — password requirements, MFA/webauthn failures.
 

--- a/etc/defaults/auth.defaults.yaml
+++ b/etc/defaults/auth.defaults.yaml
@@ -112,19 +112,26 @@ full:
   # Values: password, email_auth, webauthn, sso
   # Leave blank to show all enabled authentication methods (default).
   #
-  # When set, only the specified method is shown on the login page.
+  # When set, only the specified method works on the sign-in surface — this
+  # is an access control, not a display preference: every other method's
+  # routes 404 (ADR-034#restrict-to-is-an-access-control-not-a-display-preference).
   # For sso: also disables password-based account management (destroy
   # account, change password, change email).
   #
   # The underlying feature must also be enabled (e.g. restrict_to: sso
-  # requires AUTH_SSO_ENABLED=true and at least one provider configured).
+  # requires AUTH_SSO_ENABLED=true and at least one provider configured). If
+  # it is not, boot fails — the restriction is never dropped to re-expose the
+  # methods it was meant to hide. Unavailability that can only be seen after
+  # boot, or on one host, degrades to "sign-in unavailable" instead
+  # (ADR-034#degradation-is-fail-closed).
   #
   # Set AT MOST ONE of AUTH_PASSWORD_ONLY / AUTH_EMAIL_AUTH_ONLY /
   # AUTH_WEBAUTHN_ONLY / AUTH_SSO_ONLY. Setting several renders nothing here
   # (there is no "restricted to two methods"), which on its own would be a
   # silent fail-open — so the ValidateAuthConfig initializer reads these four
   # env vars directly at boot and refuses to start, naming each flag set
-  # (ADR-024 A9, #4139). Do not "fix" that by making this line pick a winner.
+  # (ADR-034#conflicting-auth-only-env-flags-are-a-boot-error, #4139). Do not
+  # "fix" that by making this line pick a winner.
   # ──────────────────────────────────────────────────────────────────────
   restrict_to: <%= [ENV['AUTH_PASSWORD_ONLY'] == 'true' && 'password', ENV['AUTH_EMAIL_AUTH_ONLY'] == 'true' && 'email_auth', ENV['AUTH_WEBAUTHN_ONLY'] == 'true' && 'webauthn', ENV['AUTH_SSO_ONLY'] == 'true' && 'sso'].select { |v| v }.then { |f| f.length == 1 && f.first || nil } %>
 

--- a/lib/onetime/auth_config.rb
+++ b/lib/onetime/auth_config.rb
@@ -193,7 +193,9 @@ module Onetime
       OT.conf.dig('features', 'organizations', 'sso_enabled') == true
     end
 
-    # The login-page restriction, if any.
+    # The global sign-in restriction, if any. An access control over which
+    # methods work on this install, not a login-page display preference
+    # (ADR-034#restrict-to-is-an-access-control-not-a-display-preference).
     # Returns one of RESTRICT_TO_VALUES ('password', 'email_auth',
     # 'webauthn', 'sso'), or nil ONLY when no restriction is configured
     # (and always nil in simple mode, where restrict_to has no meaning).

--- a/lib/onetime/logic/sso_only_gating.rb
+++ b/lib/onetime/logic/sso_only_gating.rb
@@ -6,9 +6,22 @@ module Onetime
   module Logic
     # Concern for enforcing SSO-only mode restrictions in API logic classes.
     #
-    # When SSO-only mode is active (AUTH_SSO_ONLY=true and AUTH_SSO_ENABLED=true),
-    # password-based account management operations are disabled. Users must
-    # manage their credentials through the SSO identity provider instead.
+    # Keys off AuthConfig#sso_only_enabled? — the global restriction, i.e.
+    # `full.restrict_to == 'sso'` (rendered from AUTH_SSO_ONLY=true, or set
+    # directly). A global restriction naming an unavailable method is a fatal
+    # boot error, so by the time this concern runs the restriction is honorable;
+    # the predicate is a bare comparison with no availability guard of its own
+    # (ADR-034#degradation-is-fail-closed).
+    #
+    # When it is active, password-based account management operations are
+    # disabled. Users must manage their credentials through the SSO identity
+    # provider instead.
+    #
+    # These endpoints are account-scoped, not host-scoped, so they are
+    # explicitly EXEMPT from host-scoped restrict_to route enforcement
+    # (ADR-034#reject-as-not-found-not-forbidden) and are governed by this
+    # concern instead — hence 403 here rather than the 404 the route gate
+    # returns. A per-domain restrict_to never reaches this check.
     #
     # Blocked operations:
     # - Account destruction (POST /destroy)

--- a/lib/onetime/models/custom_domain/signin_config.rb
+++ b/lib/onetime/models/custom_domain/signin_config.rb
@@ -425,7 +425,9 @@ module Onetime
         #
         # Two consumers today, and the second is a RUNTIME gate — this comment
         # used to say there was no runtime email-auth gate, which stopped being
-        # true when #4139 landed A1 and cost a reviewer a false bug report:
+        # true when #4139 landed
+        # ADR-034#restrict-to-is-an-access-control-not-a-display-preference and
+        # cost a reviewer a false bug report:
         #
         #   - display: Core::Views::ConfigSerializer#resolve_email_auth
         #   - runtime: restriction_available_for_custom_domain? below, which
@@ -508,14 +510,15 @@ module Onetime
         # restriction configured", and never nil to mean "the configured
         # restriction could not be honored" (that is a fatal boot error now).
         # Re-adding defensive nil-handling here would rebuild the silent
-        # fail-open A3 retired.
+        # fail-open ADR-034#degradation-is-fail-closed retired.
         #
-        # GLOBAL AVAILABILITY (`available:`) is the post-boot half of A3. It is
+        # GLOBAL AVAILABILITY (`available:`) is the post-boot half of
+        # ADR-034#degradation-is-fail-closed. It is
         # not derivable from `global` and `config` — it reads live prerequisite
         # state (AuthConfig#restrict_to_available?) — so the caller supplies it,
         # but this resolver APPLIES it: three consumers each remembering to
-        # apply the same rule by hand is precisely the drift A2 exists to
-        # eliminate.
+        # apply the same rule by hand is precisely the drift
+        # ADR-034#resolution-is-model-owned exists to eliminate.
         #
         #   available: false means "the global restriction stands, but its
         #   backing method is dead here". It can only ever NARROW: a standing
@@ -584,7 +587,8 @@ module Onetime
         # SigninConfig, the SSO availability probes — so a read failure means
         # the gate does not know what this host permits. It must not guess in
         # either direction: continuing with the global half alone re-exposes
-        # exactly the methods a per-domain restriction hides (the A3 failure
+        # exactly the methods a per-domain restriction hides (the
+        # ADR-034#degradation-is-fail-closed failure
         # mode), and degrading to "unrestricted because nothing is globally
         # restricted" makes the answer depend on a value that says nothing
         # about this host. Sign-in fails, loudly, until the read works.
@@ -639,6 +643,58 @@ module Onetime
         # @return [Boolean]
         def operator_host?(domain_strategy)
           OPERATOR_HOST_STRATEGIES.include?(domain_strategy&.to_sym)
+        end
+
+        # The `global` VALUE a request host INHERITS when no enabled per-domain
+        # config speaks — the operator's own `restrict_to`, or the derived 'sso'
+        # HOST PIN on a custom domain that offers SSO alone.
+        #
+        # WHY THIS LIVES HERE (ADR-034#resolution-is-model-owned). The pin was
+        # written twice — ConfigSerializer#effective_global_restrict_to and
+        # Auth::RestrictTo.global_restrict_to — and the settings API
+        # (DomainsAPI::Logic::SigninConfig::Base#signin_override_details) had
+        # neither copy, so it handed the resolver Onetime.auth_config.restrict_to
+        # verbatim and reported `unrestricted` for an SSO-only tenant whose
+        # Rodauth routes the gate was already restricting to SSO. Same
+        # ADR-034#resolution-is-model-owned drift
+        # shape as the four defects #4139 fixed, one input over: the resolver was
+        # shared, this input was not. Two copies plus one omission is exactly the
+        # arrangement that produced it, so the pin is now one method taking
+        # explicit request facts, and every consumer calls it.
+        #
+        # WHY THE PIN EXISTS. Password and email-auth default OFF on a custom
+        # domain, so a custom host with no enabled SigninConfig keeps a working
+        # /signin page only because SSO is available there. Pinning 'sso' keeps
+        # what the page OFFERS, what the route gate ACCEPTS and what the settings
+        # page REPORTS in lockstep; without it the page renders forms whose POST
+        # targets are dark and the gate accepts crafted POSTs for methods the
+        # host never offered.
+        #
+        # NO-CONFIG CASE ONLY. Under ADR-034#resolution-intersects-never-widens
+        # the resolver INTERSECTS `global` with the domain's own restriction, so
+        # a pin handed in for a tenant that HAS spoken (an enabled SigninConfig
+        # naming, say, 'password') would resolve :conflict and take that host
+        # dark — a display convenience turned into a lockout. The pin describes a
+        # host that has NOT configured sign-in and is reachable only via SSO.
+        #
+        # The predicate is SsoConfig.sso_available_for_tenant_host? (tenant
+        # credentials OR operator platform fallback) — the same question
+        # ConfigSerializer#build_sso_config answers for the rendered page, so the
+        # pin cannot be narrower than the buttons the host shows.
+        #
+        # @param config [SigninConfig, nil] the host's per-domain config, if any
+        # @param domain_id [String, nil] the classified CustomDomain identifier (objid)
+        # @param custom_host [Boolean] whether the host is a custom domain
+        # @return [String, nil] the value to pass to resolve_restrict_to as `global`
+        def inherited_restrict_to(config, domain_id: nil, custom_host: false)
+          return Onetime.auth_config.restrict_to if config&.enabled?
+
+          if custom_host == true && domain_id &&
+             Onetime::CustomDomain::SsoConfig.sso_available_for_tenant_host?(domain_id)
+            return 'sso'
+          end
+
+          Onetime.auth_config.restrict_to
         end
 
         # The `available:` input to resolve_restrict_to for a caller that has

--- a/lib/onetime/models/custom_domain/signin_config.rb
+++ b/lib/onetime/models/custom_domain/signin_config.rb
@@ -165,6 +165,21 @@ module Onetime
         end
       end
 
+      # Result of `inherited_restrict_to` — the `global` value a request host
+      # inherits when no enabled per-domain config speaks, plus metadata the
+      # availability check needs (#4165).
+      #
+      # `pin_established` is true when `value` is a DERIVED host pin whose
+      # backing method's availability was already proven by the predicate that
+      # chose the pin (e.g. sso_available_for_tenant_host? for the SSO pin).
+      # When true, `global_restriction_available?` returns true immediately
+      # without consulting AuthConfig — asking operator prerequisites for a
+      # value that did not come from the operator is a false-negative (#4165).
+      InheritedRestriction = Data.define(:value, :pin_established) do
+        # Convenience: in boolean context, the value is what callers care about.
+        def to_s = value.to_s
+      end
+
       prefix :custom_domain__signin_config
 
       # domain_id is the CustomDomain's identifier (objid), used as our key.
@@ -560,6 +575,14 @@ module Onetime
             return RestrictToResolution.unavailable(global_value, :conflict)
           end
 
+          # An AGREEING domain config does not resurrect a dead global method
+          # (ADR-034#resolution-intersects-never-widens: agreement resolves
+          # with source :domain, but the method named is the same one, and it is
+          # just as dead). Source stays :global — the global half is why nothing
+          # is offered. Short-circuit BEFORE probing domain method availability
+          # to avoid a wasted SSO datastore read (#4165).
+          return RestrictToResolution.unavailable(global_value, :global) if global_dead
+
           structurally_unavailable = !RESTRICT_TO_VALUES.include?(domain_value) || domain_value == 'webauthn'
           domain_dead              = structurally_unavailable || if domain_available.nil?
                                                        !restriction_available_for_custom_domain?(domain_value, config)
@@ -567,12 +590,6 @@ module Onetime
                                                        domain_available != true
                                                      end
 
-          # An AGREEING domain config does not resurrect a dead global method
-          # (ADR-034#resolution-intersects-never-widens: agreement resolves
-          # with source :domain, but the method named is
-          # the same one, and it is just as dead). Source stays :global — the
-          # global half is why nothing is offered.
-          return RestrictToResolution.unavailable(global_value, :global) if global_dead
           return RestrictToResolution.unavailable(domain_value, :domain) if domain_dead
 
           RestrictToResolution.restricted(domain_value, :domain)
@@ -685,16 +702,19 @@ module Onetime
         # @param config [SigninConfig, nil] the host's per-domain config, if any
         # @param domain_id [String, nil] the classified CustomDomain identifier (objid)
         # @param custom_host [Boolean] whether the host is a custom domain
-        # @return [String, nil] the value to pass to resolve_restrict_to as `global`
+        # @return [InheritedRestriction] value plus metadata for availability check (#4165)
         def inherited_restrict_to(config, domain_id: nil, custom_host: false)
-          return Onetime.auth_config.restrict_to if config&.enabled?
+          if config&.enabled?
+            return InheritedRestriction.new(value: Onetime.auth_config.restrict_to, pin_established: false)
+          end
 
           if custom_host == true && domain_id &&
              Onetime::CustomDomain::SsoConfig.sso_available_for_tenant_host?(domain_id)
-            return 'sso'
+            # Host pin: availability was just proven by sso_available_for_tenant_host?
+            return InheritedRestriction.new(value: 'sso', pin_established: true)
           end
 
-          Onetime.auth_config.restrict_to
+          InheritedRestriction.new(value: Onetime.auth_config.restrict_to, pin_established: false)
         end
 
         # The `available:` input to resolve_restrict_to for a caller that has
@@ -714,8 +734,13 @@ module Onetime
         # (ADR-034#resolution-is-model-owned).
         #
         # @param global_value [String, nil] the value being passed as `global`
+        # @param already_established [Boolean] when true, the caller already
+        #   proved the backing method is available (e.g. a derived host pin from
+        #   sso_available_for_tenant_host?) — return true without consulting
+        #   AuthConfig (#4165)
         # @return [Boolean]
-        def global_restriction_available?(global_value)
+        def global_restriction_available?(global_value, already_established: false)
+          return true if already_established
           return true unless global_value.to_s == Onetime.auth_config.restrict_to.to_s
 
           Onetime.auth_config.restrict_to_available?
@@ -760,9 +785,12 @@ module Onetime
         # @param config [SigninConfig, nil] the host's per-domain config, if any
         # @param domain_id [String, nil] the classified CustomDomain identifier (objid)
         # @param custom_host [Boolean] whether the request host is a custom domain
+        # @param already_established [Boolean] when true, the caller already proved
+        #   the global restriction's backing method is available — see
+        #   global_restriction_available? (#4165)
         # @return [Boolean]
-        def restriction_available_for_request?(global, config, domain_id: nil, custom_host: false)
-          available = global_restriction_available?(global)
+        def restriction_available_for_request?(global, config, domain_id: nil, custom_host: false, already_established: false)
+          available = global_restriction_available?(global, already_established: already_established)
           return available unless available && custom_host == true
 
           global_value = global.to_s.strip

--- a/spec/unit/domain_strategy_classification_contract_spec.rb
+++ b/spec/unit/domain_strategy_classification_contract_spec.rb
@@ -206,11 +206,13 @@ RSpec.describe 'DomainStrategy classification contract' do
       end
 
       DomainStrategyContract::CLASSIFICATIONS.each do |strategy|
-        expected = strategy == :custom ? 'sso' : nil
+        expected_value = strategy == :custom ? 'sso' : nil
+        expected_pin   = strategy == :custom
 
-        it "pins #{expected.inspect} for #{strategy.inspect}" do
-          pinned = Auth::RestrictTo.global_restrict_to(env_for(strategy), 'domain_abc', nil)
-          expect(pinned).to eq(expected)
+        it "pins #{expected_value.inspect} for #{strategy.inspect}" do
+          inherited = Auth::RestrictTo.global_restrict_to(env_for(strategy), 'domain_abc', nil)
+          expect(inherited.value).to eq(expected_value)
+          expect(inherited.pin_established).to eq(expected_pin)
         end
       end
     end

--- a/spec/unit/onetime/models/custom_domain/signin_config_restrict_to_spec.rb
+++ b/spec/unit/onetime/models/custom_domain/signin_config_restrict_to_spec.rb
@@ -221,7 +221,8 @@ RSpec.describe Onetime::CustomDomain::SigninConfig do
 
     context 'on an SSO-only custom host with no SigninConfig' do
       it "pins 'sso' — password and email default OFF there" do
-        expect(inherited).to eq('sso')
+        expect(inherited.value).to eq('sso')
+        expect(inherited.pin_established).to be(true)
       end
     end
 
@@ -232,7 +233,8 @@ RSpec.describe Onetime::CustomDomain::SigninConfig do
       end
 
       it 'inherits the operator restriction (here: none)' do
-        expect(inherited).to be_nil
+        expect(inherited.value).to be_nil
+        expect(inherited.pin_established).to be(false)
       end
     end
 
@@ -240,7 +242,8 @@ RSpec.describe Onetime::CustomDomain::SigninConfig do
       let(:custom_host) { false }
 
       it 'never pins — the pin is a custom-host property' do
-        expect(inherited).to be_nil
+        expect(inherited.value).to be_nil
+        expect(inherited.pin_established).to be(false)
       end
     end
 
@@ -248,7 +251,8 @@ RSpec.describe Onetime::CustomDomain::SigninConfig do
       let(:domain_id_arg) { nil }
 
       it 'never pins — there is no domain whose SSO could be probed' do
-        expect(inherited).to be_nil
+        expect(inherited.value).to be_nil
+        expect(inherited.pin_established).to be(false)
       end
     end
 
@@ -263,7 +267,8 @@ RSpec.describe Onetime::CustomDomain::SigninConfig do
       end
 
       it 'declines the pin — intersecting it would resolve :conflict and lock the host out' do
-        expect(inherited).to eq('password')
+        expect(inherited.value).to eq('password')
+        expect(inherited.pin_established).to be(false)
       end
     end
 
@@ -275,7 +280,45 @@ RSpec.describe Onetime::CustomDomain::SigninConfig do
       end
 
       it "still pins 'sso' — a disabled config has not spoken" do
-        expect(inherited).to eq('sso')
+        expect(inherited.value).to eq('sso')
+        expect(inherited.pin_established).to be(true)
+      end
+    end
+  end
+
+  describe '.global_restriction_available?' do
+    let(:auth_config) do
+      instance_double(Onetime::AuthConfig,
+        restrict_to: 'sso',
+        restrict_to_available?: false,
+      )
+    end
+
+    before do
+      allow(Onetime).to receive(:auth_config).and_return(auth_config)
+    end
+
+    context 'when already_established is true' do
+      it 'returns true without consulting AuthConfig (#4165)' do
+        # Even though restrict_to_available? would return false
+        result = described_class.global_restriction_available?('sso', already_established: true)
+        expect(result).to be(true)
+
+        # Verify we did not call restrict_to_available?
+        expect(auth_config).not_to have_received(:restrict_to_available?)
+      end
+    end
+
+    context 'when already_established is false (default)' do
+      it 'consults AuthConfig when the value matches operator restrict_to' do
+        result = described_class.global_restriction_available?('sso')
+        expect(result).to be(false)
+        expect(auth_config).to have_received(:restrict_to_available?)
+      end
+
+      it 'returns true when the value does NOT match operator restrict_to' do
+        result = described_class.global_restriction_available?('password')
+        expect(result).to be(true)
       end
     end
   end

--- a/spec/unit/onetime/models/custom_domain/signin_config_restrict_to_spec.rb
+++ b/spec/unit/onetime/models/custom_domain/signin_config_restrict_to_spec.rb
@@ -199,4 +199,84 @@ RSpec.describe Onetime::CustomDomain::SigninConfig do
       end
     end
   end
+
+  # The `global` VALUE the three consumers hand to the resolver (#4140). Same
+  # rule as restriction_available_for_request? above and for the same reason:
+  # the SSO HOST PIN used to be written twice (display serializer, route gate)
+  # and omitted entirely by the settings API, which therefore reported
+  # `unrestricted` for a host whose routes the gate restricted to SSO.
+  describe '.inherited_restrict_to' do
+    subject(:inherited) do
+      described_class.inherited_restrict_to(
+        config_arg, domain_id: domain_id_arg, custom_host: custom_host
+      )
+    end
+
+    let(:config_arg)    { nil }
+    let(:domain_id_arg) { 'domain-4139' }
+    let(:custom_host)   { true }
+    let(:auth_config) do
+      instance_double(Onetime::AuthConfig, email_auth_enabled?: true, restrict_to: nil)
+    end
+
+    context 'on an SSO-only custom host with no SigninConfig' do
+      it "pins 'sso' — password and email default OFF there" do
+        expect(inherited).to eq('sso')
+      end
+    end
+
+    context 'on a custom host with no SSO available' do
+      before do
+        allow(Onetime::CustomDomain::SsoConfig).to receive(:sso_available_for_tenant_host?)
+          .with('domain-4139').and_return(false)
+      end
+
+      it 'inherits the operator restriction (here: none)' do
+        expect(inherited).to be_nil
+      end
+    end
+
+    context 'on a canonical host' do
+      let(:custom_host) { false }
+
+      it 'never pins — the pin is a custom-host property' do
+        expect(inherited).to be_nil
+      end
+    end
+
+    context 'when the custom host could not be classified' do
+      let(:domain_id_arg) { nil }
+
+      it 'never pins — there is no domain whose SSO could be probed' do
+        expect(inherited).to be_nil
+      end
+    end
+
+    context 'when an enabled SigninConfig speaks' do
+      let(:config_arg) do
+        described_class.new(
+          domain_id: 'domain-4139', enabled: true, signin_enabled: true, restrict_to: 'password'
+        )
+      end
+      let(:auth_config) do
+        instance_double(Onetime::AuthConfig, email_auth_enabled?: true, restrict_to: 'password')
+      end
+
+      it 'declines the pin — intersecting it would resolve :conflict and lock the host out' do
+        expect(inherited).to eq('password')
+      end
+    end
+
+    context 'when a DISABLED SigninConfig exists on an SSO-only host' do
+      let(:config_arg) do
+        described_class.new(
+          domain_id: 'domain-4139', enabled: false, signin_enabled: true, restrict_to: 'password'
+        )
+      end
+
+      it "still pins 'sso' — a disabled config has not spoken" do
+        expect(inherited).to eq('sso')
+      end
+    end
+  end
 end

--- a/src/apps/session/components/AuthMethodSelector.vue
+++ b/src/apps/session/components/AuthMethodSelector.vue
@@ -77,9 +77,10 @@
   // features.restrict_to by the backend) — and in both cases falling through
   // to the password/email forms would advertise methods the domain owner
   // chose to hide (and, for restrict_to, whose credentials may be dormant).
-  // Canonical requests keep the standard fallback: the backend nils a global
-  // sso restriction when no provider is configured, so this combination only
-  // arises on custom domains.
+  // Canonical requests never reach this branch: a global restrict_to='sso'
+  // with no provider configured is a fatal boot error, not a restriction the
+  // backend quietly drops (ADR-034#degradation-is-fail-closed), so the
+  // combination only arises on custom domains.
   const showCustomDomainNoSso = computed(
     () => isCustom.value && ssoRequired.value && !ssoConfigured.value
   );

--- a/src/apps/session/views/AcceptInvite.vue
+++ b/src/apps/session/views/AcceptInvite.vue
@@ -151,14 +151,16 @@
    * way to sign in at all.
    *
    * `source: 'conflict'` (global and domain naming different methods, which
-   * has no intersection under A8) always resolves `unavailable`, so this one
+   * has no intersection under ADR-034#resolution-intersects-never-widens)
+   * always resolves `unavailable`, so this one
    * check covers both; only the COPY branches on source.
    */
   const signinUnavailable = computed(() => restrictToResolution.value?.state === 'unavailable');
 
   /**
    * This host permits a single method and it is NOT password — i.e. the case
-   * where the signup form below would POST into the A11 gate and 404.
+   * where the signup form below would POST into the
+   * ADR-034#invite-signup-is-gated gate and 404.
    *
    * False when unrestricted, when restricted to password (nothing changes),
    * and when the resolution is unavailable (that is signinUnavailable's
@@ -206,7 +208,8 @@
   /**
    * Whether the host's single permitted method is SSO — the one restricted
    * case this page can actually complete, by routing the invitee into the
-   * provider (A11: SSO signs them in and creates the account cleanly, then
+   * provider (ADR-034#invite-signup-is-gated: SSO signs them in and creates
+   * the account cleanly, then
    * they return here authenticated and accept).
    */
   const ssoRestricted = computed(() => restrictToResolution.value?.restrict_to === 'sso');
@@ -224,7 +227,8 @@
    *
    * Every branch says the same two things: this host does not take the method
    * the form would have used, and the invitation is untouched. Nothing here
-   * implies the invitation was consumed or lost — under A11 the gated signup
+   * implies the invitation was consumed or lost — under
+   * ADR-034#invite-signup-is-gated the gated signup
    * creates nothing, so it is still pending.
    */
   const restrictedNotice = computed(() => {
@@ -791,8 +795,9 @@
               {{ restrictedNotice }}
             </p>
             <!--
-              The invitation is NOT consumed by the gated signup (A11 creates
-              nothing), so say so plainly rather than leaving the invitee to
+              The invitation is NOT consumed by the gated signup
+              (ADR-034#invite-signup-is-gated creates nothing), so say so plainly
+              rather than leaving the invitee to
               assume they burned their link.
             -->
             <p class="mt-2 text-sm text-sky-700 dark:text-sky-200">

--- a/src/tests/views/session/AcceptInvite.spec.ts
+++ b/src/tests/views/session/AcceptInvite.spec.ts
@@ -355,7 +355,8 @@ describe('AcceptInvite', () => {
         expect(sso.exists()).toBe(true);
         expect(sso.props('routeName')).toBe('oidc');
         expect(sso.props('displayName')).toBe('Acme SSO');
-        // Comes back here to accept — A11's flow is sign in, then join.
+        // Comes back here to accept — the ADR-034#invite-signup-is-gated flow
+        // is sign in, then join.
         expect(sso.props('redirect')).toBe('/invite/test-token-123');
       });
 
@@ -433,7 +434,7 @@ describe('AcceptInvite', () => {
         // The schema degrades an unknown method to null while `state` keeps
         // carrying the truth. A method we cannot name is still one we cannot
         // offer — treating it as unrestricted would put the password form back
-        // in front of the A11 gate.
+        // in front of the ADR-034#invite-signup-is-gated gate.
         replyWith({ ...mockInvitation, effective_restrict_to: restrictedTo('passkey_v2') });
 
         const wrapper = await mountComponent();
@@ -486,7 +487,8 @@ describe('AcceptInvite', () => {
     describe('restriction never masks a token failure', () => {
       it('renders the bad-token error, not a restriction, for an unknown token', async () => {
         // A genuine 404 from GET must still read as a bad token. It cannot be
-        // confused with the A11 signup 404: the restriction is known BEFORE
+        // confused with the gated-signup 404 of
+        // ADR-034#invite-signup-is-gated: the restriction is known BEFORE
         // any form renders, so `invalid` keeps sole ownership of token failures.
         getGlobalAxiosMock().onGet('/api/invite/invalid-token').reply(404, { error: 'Not found' });
 
@@ -527,9 +529,11 @@ describe('AcceptInvite', () => {
 
     describe('authenticated invitee', () => {
       it('can still accept on a restricted host', async () => {
-        // POST /:token/accept is deliberately ungated (account-scoped, A7), so
+        // POST /:token/accept is deliberately ungated (account-scoped, per
+        // ADR-034#reject-as-not-found-not-forbidden), so
         // the restriction is spent once a session exists. This is what lets
-        // A11's flow terminate: SSO signs them in, they return here, they join.
+        // the ADR-034#invite-signup-is-gated flow terminate: SSO signs them in,
+        // they return here, they join.
         authStore.$patch({
           isAuthenticated: true,
           cust: {

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -296,9 +296,12 @@ export function isSsoOnlyModeOf(state: { features?: Features }): boolean {
  * When true, password-based auth routes are disabled and the sign-in page
  * shows only SSO provider buttons.
  *
- * The backend only sets restrict_to='sso' when SSO is enabled and at
- * least one provider is configured, so no additional frontend guard is
- * needed.
+ * The scalar only carries 'sso' when the server's resolver could honor it:
+ * an unavailable restriction is nulled and reported through
+ * features.effective_restrict_to as state 'unavailable', never widened back
+ * to standard mode. So no extra frontend availability guard is needed — but
+ * see AuthMethodSelector: display code must fail closed on
+ * effective_restrict_to, not on this scalar.
  */
 export function isSsoOnlyMode(): boolean {
   if (typeof window === 'undefined') return false;

--- a/try/integration/api/domains/put_signin_config_try.rb
+++ b/try/integration/api/domains/put_signin_config_try.rb
@@ -451,7 +451,8 @@ Onetime::CustomDomain::SsoConfig.create!(
 # value. Every state of SigninConfig.resolve_restrict_to must survive
 # serialization, :unavailable included — that state is the one the
 # display field `features.restrict_to` (string-or-null) cannot express,
-# and projecting it to null here would rebuild the fail-open A3 closed.
+# and projecting it to null here would rebuild the fail-open that
+# ADR-034#degradation-is-fail-closed closed.
 # ============================================================
 
 ## Sanity: the test config sets no global restriction (makes the cases below discriminating)
@@ -487,7 +488,7 @@ end
 @logic_rt_put.process[:details][:effective_restrict_to]
 #=> { state: 'unavailable', restrict_to: 'email_auth', source: 'domain' }
 
-## Domain and global naming different methods — :unavailable, source :conflict, global method named (A8)
+## Domain and global naming different methods — :unavailable, source :conflict, global method named
 @auth_conf_x = Onetime.auth_config
 @auth_conf_x.define_singleton_method(:restrict_to) { 'password' }
 begin
@@ -499,7 +500,7 @@ ensure
 end
 #=> { state: 'unavailable', restrict_to: 'password', source: 'conflict' }
 
-## Domain restriction that cannot run here — :unavailable, method still named (fail closed, A3)
+## Domain restriction that cannot run here — :unavailable, method still named (fail closed)
 @domain_rt_wa = Onetime::CustomDomain.create!("psc-rt-wa-#{@ts}-#{SecureRandom.hex(2)}.example.com", @org.objid)
 Onetime::CustomDomain::SigninConfig.create!(
   domain_id: @domain_rt_wa.identifier,

--- a/try/integration/api/invite/show_invite_enriched_try.rb
+++ b/try/integration/api/invite/show_invite_enriched_try.rb
@@ -298,7 +298,9 @@ auth_methods = resp['record']['auth_methods']
 ## #invite-signup-is-gated, #4139) — password appears BECAUSE this host permits it
 # This assertion used to read "password is always enabled" and hardcoded that
 # as contract. It is no longer true, and asserting it would pin the exact
-# display/runtime disagreement A1 exists to kill: POST /:token/signup 404s on
+# display/runtime disagreement
+# ADR-034#restrict-to-is-an-access-control-not-a-display-preference exists to
+# kill: POST /:token/signup 404s on
 # a host that restricts password away, so a page that always advertises a
 # password method advertises a submit that cannot succeed. What holds now is
 # the conditional: password is offered iff the resolution permits it. This
@@ -313,7 +315,7 @@ password_permitted = resolution['state'] == 'unrestricted' ||
 [resolution['state'], password_permitted, !password_method.nil?, password_method && password_method['enabled']]
 #=> ['unrestricted', true, true, true]
 
-## auth_methods never advertises a method the resolution disallows [A1]
+## auth_methods never advertises a method the resolution disallows
 resp = JSON.parse(last_response.body)
 resolution = resp['record']['effective_restrict_to']
 # Wire type 'magic_link' is restrict_to value 'email_auth'.
@@ -351,7 +353,7 @@ record = resp['record']
 true
 #=> true
 
-## An unhonorable domain restriction fails closed: no method is offered [A3]
+## An unhonorable domain restriction fails closed: no method is offered
 # The load-bearing negative. Widening back to password here would re-expose
 # exactly the method the restriction hid, AND would advertise a signup form
 # that POST /:token/signup 404s on.
@@ -393,7 +395,8 @@ required_fields.all? { |f| record.key?(f) }
 
 ## effective_restrict_to is present on a NON-custom host (ADR-034#invite-signup-is-gated, #4139)
 # The regression this field fixes: auth_methods lives inside the custom-domain
-# branch, so an SSO-only INSTALL — A11's stated live case, global restriction,
+# branch, so an SSO-only INSTALL — the live case stated in
+# ADR-034#invite-signup-is-gated, global restriction,
 # invitee on the canonical host the invitation email links to — got nothing at
 # all to predict the POST /:token/signup gate with, and rendered a password
 # form whose submit 404s.
@@ -403,7 +406,7 @@ resolution = record['effective_restrict_to']
 [record.key?('auth_methods'), resolution.nil?, resolution.keys.sort]
 #=> [false, false, ['restrict_to', 'source', 'state']]
 
-## effective_restrict_to reports resolver states, never a bare boolean [A3]
+## effective_restrict_to reports resolver states, never a bare boolean
 # :unavailable must survive the wire distinct from :unrestricted — collapsing
 # it to a null restrict_to would read as "no restriction" and re-offer every
 # method the restriction hid.

--- a/try/integration/domain_auth_enforcement_try.rb
+++ b/try/integration/domain_auth_enforcement_try.rb
@@ -375,11 +375,12 @@ Core::Views::ConfigSerializer.send(:resolve_restrict_to, @view_vars_no_config)
 Core::Views::ConfigSerializer.send(:resolve_restrict_to, @view_vars_with_config)
 #=> 'sso'
 
-## FAIL CLOSED (#4139, ADR-024 A3): the same enabled restrict_to='sso' on a
-## domain with NO SSO credentials resolves :unavailable — the display value is
-## nil (nothing offered), NOT 'sso' and NOT a widening fallback to global. This
-## case used to expect 'sso'; the expectation predates the A3 availability
-## derivation, and the fixture above is what the case name actually meant.
+## FAIL CLOSED (#4139, ADR-034#degradation-is-fail-closed): the same enabled
+## restrict_to='sso' on a domain with NO SSO credentials resolves :unavailable —
+## the display value is nil (nothing offered), NOT 'sso' and NOT a widening
+## fallback to global. This case used to expect 'sso'; the expectation predates
+## the availability derivation, and the fixture above is what the case name
+## actually meant.
 @domain_rt2b = Onetime::CustomDomain.create!("dae-rt2b-#{@ts}-#{SecureRandom.hex(2)}.example.com", @org.objid)
 @config_rt2b = Onetime::CustomDomain::SigninConfig.create!(
   domain_id: @domain_rt2b.identifier,

--- a/try/unit/models/custom_domain_auth_killswitch_try.rb
+++ b/try/unit/models/custom_domain_auth_killswitch_try.rb
@@ -14,7 +14,8 @@
 # (ADR-034#resolution-is-model-owned) — the single owner
 # of restrict_to resolution — whose degradation rule is fail-CLOSED: a domain
 # restriction naming a method that cannot be honored here resolves to
-# :unavailable, never to "unrestricted" (A3).
+# :unavailable, never to "unrestricted"
+# (ADR-034#degradation-is-fail-closed).
 #
 # Run:
 #   try try/unit/models/custom_domain_auth_killswitch_try.rb --agent
@@ -168,7 +169,8 @@ Onetime::CustomDomain::SignupConfig.resolve_signup_enabled(true, signup_config(e
 #
 # Three explicit states: :unrestricted (allow every enabled method),
 # :restricted (allow only the named one), :unavailable (allow nothing —
-# fail-closed degradation, A3). Precedence is INTERSECTION (A8): a domain
+# fail-closed degradation, ADR-034#degradation-is-fail-closed). Precedence is
+# INTERSECTION (ADR-034#resolution-intersects-never-widens): a domain
 # config narrows, never widens; two different restrictions intersect to
 # nothing and fail closed.
 
@@ -236,7 +238,7 @@ resolve_restrict_with('sso', restrict_config(enabled: true, restrict_to: 'sso'),
 resolve_restrict_with('sso', restrict_config(enabled: true, restrict_to: 'sso'), domain_available: true).source
 #=> :domain
 
-## INTERSECTION (A8): two different restrictions intersect to nothing
+## INTERSECTION: two different restrictions intersect to nothing
 resolve_restrict('sso', restrict_config(enabled: true, restrict_to: 'password')).state
 #=> :unavailable
 
@@ -260,23 +262,23 @@ resolve_restrict('sso', restrict_config(enabled: true, restrict_to: 'password'))
 resolve_restrict('password', restrict_config(enabled: true, restrict_to: 'email_auth')).unrestricted?
 #=> false
 
-## A8 FIX: an enabled domain config with no restriction NO LONGER widens past global
+## INTERSECTION FIX: an enabled domain config with no restriction NO LONGER widens past global
 resolve_restrict('sso', restrict_config(enabled: true, restrict_to: nil)).state
 #=> :restricted
 
-## A8 FIX: the global restriction stands, attributed to the global layer
+## INTERSECTION FIX: the global restriction stands, attributed to the global layer
 resolve_restrict('sso', restrict_config(enabled: true, restrict_to: nil)).source
 #=> :global
 
-## A8 FIX: the global method is the effective one
+## INTERSECTION FIX: the global method is the effective one
 resolve_restrict('sso', restrict_config(enabled: true, restrict_to: nil)).restrict_to
 #=> 'sso'
 
-## A8 FIX: a tenant cannot re-expose the methods the operator restricted away
+## INTERSECTION FIX: a tenant cannot re-expose the methods the operator restricted away
 resolve_restrict('sso', restrict_config(enabled: true, restrict_to: nil)).allows?('password')
 #=> false
 
-## A8 FIX: blank (not nil) domain restrict_to is also "unset"
+## INTERSECTION FIX: blank (not nil) domain restrict_to is also "unset"
 resolve_restrict('sso', restrict_config(enabled: true, restrict_to: '  ')).restrict_to
 #=> 'sso'
 
@@ -296,7 +298,7 @@ resolve_restrict('sso', restrict_config(enabled: false, restrict_to: 'password')
 resolve_restrict(nil, restrict_config(enabled: false, restrict_to: 'password')).state
 #=> :unrestricted
 
-## FAIL CLOSED (A3): domain 'webauthn' cannot be honored on a custom domain
+## FAIL CLOSED: domain 'webauthn' cannot be honored on a custom domain
 resolve_restrict(nil, restrict_config(enabled: true, restrict_to: 'webauthn')).state
 #=> :unavailable
 
@@ -328,7 +330,8 @@ resolve_restrict(nil, restrict_config(enabled: true, restrict_to: 'bogus')).stat
 resolve_restrict('webauthn', nil).state
 #=> :restricted
 
-# --- DOMAIN AVAILABILITY DERIVATION (A3 domain half, #4139) ---
+# --- DOMAIN AVAILABILITY DERIVATION
+# (domain half of ADR-034#degradation-is-fail-closed, #4139) ---
 #
 # Production never injects domain_available:, so the branch that matters is the
 # DERIVATION: resolve_restrict_to asking
@@ -388,7 +391,8 @@ available_for_request?('password', nil, domain_id: nil, custom_host: true)
 available_for_request?('password', nil, domain_id: 'ks_restrict', custom_host: true)
 #=> false
 
-# --- available: false — post-boot global unavailability (A3, #4139) ---
+# --- available: false — post-boot global unavailability
+# (ADR-034#degradation-is-fail-closed, #4139) ---
 #
 # The flag says "the global restriction stands, but its backing method is dead
 # here". It may only NARROW: a standing restriction goes :unavailable, and an
@@ -431,7 +435,7 @@ resolve_restrict_dead(nil, nil).allows?('password')
 resolve_restrict_dead('', nil).state
 #=> :unrestricted
 
-## an AGREEING domain config does not resurrect the dead method (A8 agreement)
+## an AGREEING domain config does not resurrect the dead method
 resolve_restrict_dead('sso', restrict_config(enabled: true, restrict_to: 'sso')).state
 #=> :unavailable
 
@@ -443,7 +447,7 @@ resolve_restrict_dead('sso', restrict_config(enabled: true, restrict_to: 'sso'))
 resolve_restrict_dead('sso', restrict_config(enabled: true, restrict_to: 'sso')).allows?('sso')
 #=> false
 
-## an enabled domain config with NO restriction inherits the dead global (A8)
+## an enabled domain config with NO restriction inherits the dead global
 resolve_restrict_dead('sso', restrict_config(enabled: true, restrict_to: nil)).state
 #=> :unavailable
 
@@ -501,7 +505,8 @@ Onetime::CustomDomain::SigninConfig::RestrictToResolution.restricted('sso', :dom
 
 ## :unavailable survives the wire — it is NOT projected down to a bare null
 ## the way the display field features.restrict_to must be. A null here would
-## read as "unrestricted" and re-offer every method the restriction hid (A3).
+## read as "unrestricted" and re-offer every method the restriction hid
+## (ADR-034#degradation-is-fail-closed).
 Onetime::CustomDomain::SigninConfig::RestrictToResolution.unavailable('sso', :domain).to_wire
 #=> { state: 'unavailable', restrict_to: 'sso', source: 'domain' }
 
@@ -510,7 +515,7 @@ Onetime::CustomDomain::SigninConfig::RestrictToResolution.unavailable('sso', :do
 Onetime::CustomDomain::SigninConfig::RestrictToResolution.unavailable('sso', :conflict).to_wire[:restrict_to]
 #=> 'sso'
 
-## :conflict attribution reaches the wire (A8: neither layer won)
+## :conflict attribution reaches the wire (neither layer won)
 Onetime::CustomDomain::SigninConfig::RestrictToResolution.unavailable('sso', :conflict).to_wire[:source]
 #=> 'conflict'
 


### PR DESCRIPTION
Closes #4140.

## Context

Most of #4140 was already fixed on main by 6ac13e848 (#4139 / PR #4155): `AuthConfig#restrict_to` no longer returns nil to mean "could not be honored", `validate_restrict_to!` makes boot-determinable unavailability a fatal boot error, and `restrict_to_available?` carries the separate availability question. What remained was one live fail-open path, plus documentation across the tree still describing the retired behaviour.

## 1. The residual fail-open (the substantive change)

`apps/web/core/spec/views/serializers/restrict_to_parity_spec.rb` carried a pending example recording the gap: for an SSO-only tenant the settings API reported

```
{restrict_to: nil, source: "global", state: "unrestricted"}
```

while the request-time gate was enforcing

```
{restrict_to: "sso", source: "global", state: "restricted"}
```

The client was told sign-in was unrestricted for methods that 404 in practice — the fail-open direction `ADR-034#degradation-is-fail-closed` forbids.

Root cause: the **SSO host pin** — a custom domain with no enabled `SigninConfig`, reachable only via SSO, inherits `restrict_to='sso'` because password and email default OFF there — existed as two private copies (`ConfigSerializer#effective_global_restrict_to`, `Auth::RestrictTo.global_restrict_to`) and one omission. The settings API had neither copy and passed `auth_config.restrict_to` verbatim as both the `global` value and the value keyed for `restriction_available_for_request?`. Two copies plus one omission is the same shape as the four #4139 defects, one input over.

The fix consolidates instead of adding a third copy: `SigninConfig.inherited_restrict_to(config, domain_id:, custom_host:)` owns the policy; the gate, the display serializer, and the settings API all call it. `restrict_to.rb` sheds 26 lines of policy. Intersection semantics are preserved — an enabled config speaks for itself, since an unconditional pin would resolve `:conflict` and lock the host out.

Direction check: nothing was relaxed. The gate is behaviourally unchanged; the settings API moved from `unrestricted` toward the enforced answer.

**One deliberate asymmetry:** simple-mode `Core::Controllers::Base#restrict_to_allows?` keeps no pin. Simple mode serves no SSO route, so pinning `'sso'` there would darken the only working method. Flagging it because it means "one resolver, all consumers" now has a documented exception.

## 2. Operator-facing documentation drift

`.env.reference` promised that conflicting `AUTH_*_ONLY` flags were "ignored (safe fallback to showing all enabled methods)". They are now a fatal boot error. An operator reading the old text expects a misconfiguration to be tolerated when the install will refuse to start — so `.env.reference` and `etc/defaults/auth.defaults.yaml` lead this commit. Also reframes `restrict_to` as an access control rather than a display preference, adds the fail-closed mode to the cannot-log-in runbook, and corrects two frontend comments still describing the backend "nilling" an unhonorable restriction.

## 3. Dead ADR citations

`c8c9f61ca` decomposed ADR-024's A1–A12 amendments into ADR-034/ADR-035, leaving ~55 citations naming labels that resolve to nothing. This completes the pass 4cccdb35e started for A12. Mapping was derived from the decomposition commit and current ADR text; where an A-number's content could not be located in a live ADR, the citation was left alone rather than given an invented anchor. Three citations were substantively wrong rather than stale-labelled — detailed in the commit message, including a spec citing "ADR-024 invariant 5" when that list stops at 4.

`scripts/adr-lint.rb`: **930 references across 38 ADRs, all resolve** (was 861).

## Verification

Branch-touched tests, green: parity spec 26/0 (was 25 + 1 pending), `signin_config_restrict_to_spec` 23/0, `config_serializer_spec` 127/0, `restrict_to_gate_spec` 42/0, `auth_config_spec` 122/0, killswitch tryouts 93/0, `AcceptInvite.spec.ts` 35/0. RuboCop clean.

**The full `tests/lanes/run unit` is red, and this is not attributable to the branch.** Pristine `origin/main` in a throwaway worktree reproduces the same failure signatures (billing plan-cache miss, `nil.objid`, org-membership drift) with a *different set every run*: 81/110, 89/53, 20/25 errors across three runs. Cause is a shared test datastore — one valkey container on `127.0.0.1:2163`, DB 0, used by every worktree in the forest with no per-worktree isolation; connection count was observed spiking from ~3 to 649 mid-run while a sibling worktree ran `bin/ots billing diagnose`. Running the identical `--only` subset in both trees gives branch 311 examples/43 failures vs baseline main 303/43 — the same 43, all a pre-existing `NameError: uninitialized constant Auth::Config` in invite specs whose stubs this branch never touches.

Worth a separate issue: the lane has no per-worktree DB isolation, and the boot guard regex at `lib/onetime/boot.rb:180` already permits a non-zero DB index, so a lane overlay would fix it. Not done here.
