### PR TITLE
docs(security): application security review, 2026-08-14

### DIFF
--- a/docs/security/2026-08-14-appsec-review/README.md
+++ b/docs/security/2026-08-14-appsec-review/README.md
@@ -1,0 +1,93 @@
+# Application Security Review — OneTimeSecret
+
+**Date:** 2026-08-14
+**Reviewer:** Application Security Engineer (automated deep review)
+**Method:** Full source review of 6 repositories + live black-box and grey-box testing against a
+locally-booted instance with synthetic data only.
+
+---
+
+## 1. Repositories reviewed
+
+All six repositories were read. **Only `onetimesecret` is the deployed application** — the other
+five are developer working copies of gems that the build resolves from rubygems.org, *not* from
+these paths. This was verified: `Gemfile` has no `path:`/`git:` options, `Gemfile.lock` contains
+only a `GEM` section, and there is no `.bundle/config` override.
+
+| Repository | Branch (checked out) | Commit | Head commit date | Version in use |
+|---|---|---|---|---|
+| `onetimesecret/onetimesecret` | `agent/fervent-pascal-0y5cji` | `21c3f6ac79973b3c951260601a61387bc55af809` | 2026-08-13 | `0.0.0-rc0` |
+| `delano/otto` | `agent/busy-mendel-0y5cji` | `e867fcde249a78e1a7a383356049fc4000a277c1` | 2026-08-07 | gem `otto 2.8.0` |
+| `onetimesecret/rhales` | `agent/optimistic-darwin-0y5cji` | `ca79eaf251436ef9dcab4581113fcd4d8fd39fda` | 2026-06-22 | gem `rhales 0.7.1` |
+| `delano/familia` | `agent/fervent-planck-0y5cji` | `c7eb1a1f27c6b59115aaac392dec9456d89e7bc4` | 2026-08-05 | gem `familia 2.12.0` |
+| `onetimesecret/rodauth` | `agent/relaxed-rubin-0y5cji` | `82ede25ddab025e5d83f76da104e76fb8968952d` | 2026-08-10 | gem `rodauth 2.45.0` |
+| `onetimesecret/rodauth-omniauth` | `agent/quirky-allen-0y5cji` | `9fe8152732f7f5409e392239411bd47fc6bf6e0a` | 2025-08-03 | gem `rodauth-omniauth 0.6.2` |
+
+**Fork drift check.** `onetimesecret/rodauth` differs from the installed `rodauth 2.45.0` in exactly
+two files (`change_password.rb`, `verify_account.rb`); both are upstream-master hardening commits.
+`onetimesecret/rodauth-omniauth` has a clean tree at tag `0.6.2` — no divergence from upstream.
+Neither fork weakens token generation or comparison. Since neither is wired into the build, fork
+drift is currently a non-issue.
+
+---
+
+## 2. Documents in this review
+
+| File | Contents |
+|---|---|
+| `README.md` | This document — scope, method, repo provenance |
+| `findings.md` | Full findings report: severity, evidence, reproduction, impact, remediation |
+| `risk-register.md` | Prioritized register with exploitability × business-impact ratings |
+| `tooling.md` | Every tool installed, every command run, and how to reset the environment |
+| `poc/` | Runnable proof-of-concept scripts for the reproducible findings |
+
+---
+
+## 3. Headline result
+
+The application is **well engineered for security**. The core product invariant — burn-after-reading
+— holds under concurrency; CSP is strict and nonce-based; there is no committed secret and no
+default secret that silently works in production; CORS is absent by design; mass assignment does
+not occur anywhere; and `X-Forwarded-For` is not trusted by default.
+
+The findings that matter are concentrated in three places:
+
+1. **Intra-tenant authorization on the receipts listing** — the lowest-privilege org role can
+   harvest colleagues' secret bearer tokens (H-1).
+2. **Billing authorization** — a non-owner member can reach the organization's Stripe Customer
+   Portal (H-2).
+3. **A tenant SSO access control that does not exist at runtime** — `SsoConfig#allowed_domains`
+   is configured, surfaced in the UI, documented as the access control for generic OIDC, and
+   never called (H-3).
+
+Four claims that a first-pass review flags as Critical were **empirically refuted** during live
+testing and are documented in `findings.md` §5 so they are not re-raised.
+
+---
+
+## 4. Coverage against the requested focus areas
+
+| # | Focus area | Coverage | Result |
+|---|---|---|---|
+| 1 | Authentication & session management | Full source + live | M-1…M-4, plus 4 refuted claims |
+| 2 | Authorization / IDOR / tenant isolation | Full source | H-1, H-2, M-5, M-6, L-1, L-2 |
+| 3 | Redis-specific risks | Full source + live | M-7 (DoS, reproduced); deserialization/Lua/SCAN clean |
+| 4 | REST API security | Full source + live | M-7, L-3; CORS/mass-assignment/error-handling clean |
+| 5 | SPA security | Full source + live | M-8, M-9, M-10, L-4 |
+| 6 | Supply chain | Full source + `bundler-audit` | M-11, M-12, M-13, L-5, L-6 |
+| 7 | Runtime & deployment | Full source | L-7; secrets/containers/compose clean |
+| 8 | Business logic | Full source + live | H-1, M-2, M-3, M-4, L-8 |
+| 9 | Cryptography | Full source + live | Clean; see §6 of `findings.md` |
+| 10 | Observability | Full source | M-14, L-9 |
+
+---
+
+## 5. Constraints honoured
+
+- No fixes deployed to any shared branch or environment. This branch contains **documentation
+  only** — no application code was changed in the commit.
+- No production-facing configuration modified.
+- No traffic sent to any external endpoint. All testing was against `127.0.0.1:3000` with a
+  local Redis on `127.0.0.1:6379`.
+- Synthetic data only. No production database or credential was accessed.
+- Every local environment change is documented in `tooling.md` §4 with its reset command.

--- a/docs/security/2026-08-14-appsec-review/README.md
+++ b/docs/security/2026-08-14-appsec-review/README.md
@@ -40,6 +40,7 @@ drift is currently a non-issue.
 | `risk-register.md` | Prioritized register with exploitability × business-impact ratings |
 | `tooling.md` | Every tool installed, every command run, and how to reset the environment |
 | `poc/` | Runnable proof-of-concept scripts for the reproducible findings |
+| `release-v0.26.5-rc1-verification.md` | Addendum: confirms the RC is the reviewed commit, checks novelty against the four prior in-repo audits, and verifies the release's own four security claims |
 
 ---
 

--- a/docs/security/2026-08-14-appsec-review/findings.md
+++ b/docs/security/2026-08-14-appsec-review/findings.md
@@ -17,7 +17,7 @@ Severity uses exploitability × impact. Each finding is tagged:
 | H-1 | High | Any org member can harvest colleagues' secret bearer tokens via `receipt/recent?scope=org` | CODE-CONFIRMED |
 | H-2 | High | Non-owner member is handed the org's Stripe Customer Portal | CODE-CONFIRMED |
 | H-3 | High | Tenant SSO `allowed_domains` is dead code — the documented access control has no runtime effect | CODE-CONFIRMED |
-| M-1 | Medium | `email_verified` is never checked on any SSO path | CODE-CONFIRMED |
+| M-1 | Medium (High for generic-OIDC/Entra tenants) | IdP-asserted `email_verified` claim is never checked on any SSO path | CODE-CONFIRMED |
 | M-2 | Medium | Magic-link lifetime is 24h, not the configured 15 minutes | CODE-CONFIRMED |
 | M-3 | Medium | Account enumeration on `email-login-request` and `verify-account-resend` | CODE-CONFIRMED |
 | M-4 | Medium | No rate limit on `email-login-request` (mailbox bombing) | CODE-CONFIRMED |
@@ -148,6 +148,16 @@ controller checks ownership — `apps/web/billing/controllers/billing.rb:77,557,
 (`apps/web/core/controllers/welcome.rb:178-197`) is clean: it uses the caller's own
 `cust.stripe_customer_id`.
 
+**Repoint premise verified.** The exploit depends on a non-owner member's `default_org_id` actually
+pointing at the shared tenant org. `JoinDomainOrganization#adopt_domain_default_org`
+(`apps/web/auth/operations/join_domain_organization.rb:130-160`) performs
+`customer.default_org_id = domain_org.objid; customer.save` and then archives the personal workspace,
+after `ensure_membership(..., role: 'member')`. The repoint fires whenever the caller's current
+default is a personal workspace they own (`is_default`, owned, not archived) — the normal state of any
+pre-existing account holder who then signs in through the tenant's SSO. So the member is left
+defaulting to an org they do **not** own, and `find_or_create_default_organization` in the portal
+handler resolves that org's `stripe_customer_id`. Premise confirmed; rating stands at High.
+
 **Remediation.** Require `org.owner?(cust)` — or `require_entitlement_in!(org, 'manage_billing')` —
 before creating the portal session.
 
@@ -209,11 +219,15 @@ rejected end-to-end.
 
 ## 2. Medium severity
 
-### M-1 — `email_verified` is never checked on any SSO path
-**CODE-CONFIRMED** · `apps/web/auth/config/hooks/omniauth.rb:32-33,199-209`
+### M-1 — IdP-asserted `email_verified` claim is never checked on any SSO path
+**Severity:** Medium — **High for deployments using generic OIDC or Entra ID** · **CWE-287 / CWE-345** · **CODE-CONFIRMED** · `apps/web/auth/config/hooks/omniauth.rb:32-33,199-209`
 
-A repo-wide search for `email_verified` in production Ruby returns zero hits. The OIDC strategy does
-surface the claim (`omniauth_openid_connect-0.8.0/.../openid_connect.rb:78`) — it is discarded.
+The **IdP-asserted `email_verified` claim** is never consulted on any SSO path. The OIDC strategy
+surfaces it (`omniauth_openid_connect-0.8.0/.../openid_connect.rb:78`) and it reaches
+`omniauth_info`, but no callback code reads it. The only `email_verified` references in production
+Ruby are unrelated — they report the **local account's own** verification status
+(`apps/web/auth/routes/account.rb:60`, `lib/onetime/models/customer/features/status.rb:51`), keyed on
+`status_id == VERIFIED_STATUS_ID`, not on anything the IdP asserted.
 
 Two consequences:
 
@@ -233,6 +247,15 @@ two providers offered on the tenant surface.
 Combined with `ENTRA_TENANT_ID=common` (which the Entra strategy also does not issuer-check —
 `omniauth-entra-id-3.1.1/.../entra_id.rb:152-204`, `JWT.decode(..., nil, false)`), this is textbook
 **nOAuth**: any Entra tenant admin can set a user's `email` claim to a victim's address.
+
+**Why High for generic-OIDC/Entra deployments.** The JIT-creation path
+(`omniauth_create_account? true`, `omniauth_verify_account? true` — both defaults,
+`features/omniauth.rb:52,59`) trusts the asserted `email` with no verification gate, so it does **not**
+require the default-off `*_TRUST_EMAIL_FOR_LINKING` flag. On a tenant using generic OIDC or Entra ID
+(`ENTRA_TENANT_ID=common`, no issuer check), an IdP that lets a principal set an unverified `email`
+claim yields address squatting and `ALLOWED_SIGNUP_DOMAIN` bypass on defaults, and full nOAuth account
+takeover once `trust_email_for_linking?` is on. On the base surface (Google/GitHub, which filter
+verification themselves; no auto-link trust) the exposure is Medium — hence the split rating.
 
 **Remediation.** Refuse to link (and refuse to create) when `omniauth_info['email_verified']` is
 present and falsey; require it truthy for the `trust_email_for_linking?` branch. Reject

--- a/docs/security/2026-08-14-appsec-review/findings.md
+++ b/docs/security/2026-08-14-appsec-review/findings.md
@@ -1,0 +1,732 @@
+# Findings Report
+
+**Date:** 2026-08-14 · **Target:** `onetimesecret` @ `21c3f6a` (branch `agent/fervent-pascal-0y5cji`)
+
+Severity uses exploitability × impact. Each finding is tagged:
+
+- **[REPRODUCED]** — demonstrated against the locally-running instance; PoC in `poc/`.
+- **[CODE-CONFIRMED]** — verified by reading the code and, where possible, by querying the live
+  database/runtime; no end-to-end exploit was constructed.
+
+---
+
+## Summary table
+
+| ID | Sev | Finding | Status |
+|---|---|---|---|
+| H-1 | High | Any org member can harvest colleagues' secret bearer tokens via `receipt/recent?scope=org` | CODE-CONFIRMED |
+| H-2 | High | Non-owner member is handed the org's Stripe Customer Portal | CODE-CONFIRMED |
+| H-3 | High | Tenant SSO `allowed_domains` is dead code — the documented access control has no runtime effect | CODE-CONFIRMED |
+| M-1 | Medium | `email_verified` is never checked on any SSO path | CODE-CONFIRMED |
+| M-2 | Medium | Magic-link lifetime is 24h, not the configured 15 minutes | CODE-CONFIRMED |
+| M-3 | Medium | Account enumeration on `email-login-request` and `verify-account-resend` | CODE-CONFIRMED |
+| M-4 | Medium | No rate limit on `email-login-request` (mailbox bombing) | CODE-CONFIRMED |
+| M-5 | Medium | Stripe invoice PDFs / hosted URLs exposed to any org member | CODE-CONFIRMED |
+| M-6 | Medium | Domain-scope enforcement missing on `receipt/recent?scope=domain` | CODE-CONFIRMED |
+| M-7 | Medium | Unauthenticated Redis exhaustion via unthrottled secret creation | **REPRODUCED** |
+| M-8 | Medium | CSP nonce published in the client bootstrap payload | CODE-CONFIRMED |
+| M-9 | Medium | Vendored DNS widget injects remote HTML via `insertAdjacentHTML` | CODE-CONFIRMED |
+| M-10 | Medium | Secret bearer tokens persisted in `sessionStorage` | CODE-CONFIRMED |
+| M-11 | Medium | `sqlite3` 2.9.5 use-after-free (GHSA-mwm8-39rw-8826) | **REPRODUCED** |
+| M-12 | Medium | `yq` fetched into production images with no checksum verification | CODE-CONFIRMED |
+| M-13 | Medium | `claude-code-action@beta` mutable ref holds a repository secret | CODE-CONFIRMED |
+| M-14 | Medium | End-user session revocation does not revoke the session | CODE-CONFIRMED |
+| L-1…L-9 | Low | See §4 | Mixed |
+
+---
+
+## 1. High severity
+
+### H-1 — Any organization member can harvest every colleague's secret bearer tokens
+
+**Severity:** High · **CWE-639 / CWE-200** · **CODE-CONFIRMED**
+
+**Where:** `apps/api/v2/logic/secrets/list_receipts.rb:41-58,126-140`,
+`lib/onetime/models/receipt/features/safe_dump_fields.rb:79`
+**Routes:** `GET /api/v2/receipt/recent`, `GET /api/v3/receipt/recent`
+
+In this product, `secret_identifier` **is** the capability — possession of it is sufficient to
+reveal the secret. The org-scoped receipts listing is gated at the *member* level and returns that
+capability for every member's receipts:
+
+```ruby
+# apps/api/v2/logic/secrets/list_receipts.rb:46
+require_entitlement!('api_access')          # member-level entitlement
+
+# :126-139  (organization scope)
+def query_organization_receipts
+  @scope_label = auth_org.display_name
+  auth_org.receipts.rangebyscore(since, @now)   # ALL org members' receipts
+end
+```
+
+```ruby
+# lib/onetime/models/receipt/features/safe_dump_fields.rb:79
+base.safe_dump_field :secret_identifier, ->(m) { m.shows_share_link? ? m.secret_identifier : nil }
+```
+
+`shows_share_link?` is true for every `source == 'standard'` receipt
+(`lib/onetime/models/receipt.rb:124-128`), and every authenticated create is indexed into the org
+(`apps/api/v2/logic/secrets/base_secret_action.rb:486-491`).
+
+**Attack.** Attacker = the lowest-privilege active member of any organization (an invited "member",
+or anyone auto-provisioned by tenant SSO):
+
+1. `GET /api/v3/receipt/recent?scope=org` → 30 days of every member's receipts, each carrying a
+   live `secret_identifier`.
+2. `POST /api/v3/secret/<secret_identifier>/reveal` with `continue=true`. The reveal path performs
+   no ownership check by design (`apps/api/v2/logic/secrets/reveal_secret.rb:62-65`) — the
+   identifier *is* the authorization. Result: plaintext of a colleague's unread secret.
+3. Or `POST /api/v3/receipt/<identifier>/burn` to destroy them.
+
+Passphrase-protected secrets resist step 2; most secrets carry no passphrase.
+
+**Why this is a defect, not the intended capability model.** The sibling org-wide surface
+`ListSecretActivity` requires the **admin/owner** `audit_logs` entitlement *and* deliberately
+withholds full identifiers, with an explicit comment
+(`apps/api/organizations/logic/organizations/list_secret_activity.rb:18-27,85`):
+
+> *"Events carry receipt/secret shortids only — never full identifiers, which are capability tokens"*
+
+The two surfaces contradict each other, and the weaker-gated one hands out the actual capabilities.
+
+**Impact.** Complete intra-tenant confidentiality break of the product's core asset, available to
+the least-privileged role.
+
+**Remediation.**
+1. In `ListReceipts#success_data`, redact `identifier`, `key`, and `secret_identifier` for records
+   where `receipt.owner?(cust)` is false.
+2. Raise the `scope=org` gate from `api_access` to `audit_logs` (or a dedicated entitlement), for
+   parity with `ListSecretActivity`.
+
+---
+
+### H-2 — Non-owner member is handed the organization's Stripe Customer Portal
+
+**Severity:** High · **CWE-862** · **CODE-CONFIRMED**
+
+**Where:** `apps/web/billing/controllers/plans.rb:300-337,383-410`
+**Route:** `apps/web/billing/routes.txt:20` → `GET /billing/portal … auth=sessionauth` (no `role=`)
+
+```ruby
+# apps/web/billing/controllers/plans.rb:300-329
+def customer_portal_redirect
+  org = find_or_create_default_organization(cust)     # NO ownership check
+  ...
+  portal_session = Stripe::BillingPortal::Session.create(
+    { customer: org.stripe_customer_id, return_url: return_url },
+  )
+  res.redirect portal_session.url
+```
+
+`find_or_create_default_organization` resolves `cust.default_org_id` — and that field is repointed
+to a **shared tenant organization** for a caller who is only a `member`:
+
+```ruby
+# apps/web/auth/operations/join_domain_organization.rb:84-93,155-158
+membership = Onetime::OrganizationMembership.ensure_membership(
+  organization, customer, role: 'member', ...)
+...
+customer.default_org_id = domain_org.objid
+customer.save
+personal_org.archive!(...)
+```
+
+Same write at `apps/web/auth/operations/bulk_sso_migration.rb:165,211` and
+`apps/api/organizations/cli/add_member_command.rb:203`.
+
+**Attack.** A pre-existing account holder signs in via the tenant's custom-domain SSO (or is swept
+by `BulkSsoMigration`). Their `default_org_id` is repointed to the tenant org. They then request
+`GET /billing/portal` and are 302'd into the **tenant's Stripe Customer Portal**, where they can
+read the full billing history and payment instruments, change the payment method and billing
+address, and **cancel the subscription**.
+
+**Why this is an outlier, not the pattern.** Every mutating billing endpoint on the sibling
+controller checks ownership — `apps/web/billing/controllers/billing.rb:77,557,941,1101` all use
+`load_organization(..., require_owner: true)` — and `manage_billing` is an owner-only entitlement
+(`lib/onetime/models/organization_membership.rb:99`). The parallel `Welcome#customer_portal_redirect`
+(`apps/web/core/controllers/welcome.rb:178-197`) is clean: it uses the caller's own
+`cust.stripe_customer_id`.
+
+**Remediation.** Require `org.owner?(cust)` — or `require_entitlement_in!(org, 'manage_billing')` —
+before creating the portal session.
+
+---
+
+### H-3 — Tenant SSO `allowed_domains` is dead code
+
+**Severity:** High (for tenant/self-hosted deployments relying on it) · **CWE-1220** · **CODE-CONFIRMED**
+
+**Where:** `lib/onetime/models/custom_domain/sso_config.rb:236-244`
+
+```ruby
+def valid_email_domain?(email)
+  domains = allowed_domains
+  return true if domains.empty?
+  email_domain = email.to_s.split('@').last&.downcase
+  return false if email_domain.nil? || email_domain.empty?
+  domains.include?(email_domain)
+end
+```
+
+**Verified:** a repo-wide search for callers finds production call sites only for the *SignupConfig*
+class (`signup_config.rb:506` calling `signup_config.rb:189`). The `SsoConfig` method at
+`sso_config.rb:236` has **zero** production callers — only specs and `try/` files reference it:
+
+```
+$ grep -rn "valid_email_domain?" --include=*.rb .
+lib/onetime/models/custom_domain/signup_config.rb:189   (def)
+lib/onetime/models/custom_domain/signup_config.rb:506   (CALLER)
+lib/onetime/models/custom_domain/sso_config.rb:236      (def — no caller)
+...remaining hits are all spec/ and try/
+```
+
+The field is fully plumbed through the API (`put_sso_config.rb:215`, `patch_sso_config.rb:317`,
+`serializers.rb:34`) and rendered in the UI, so operators configure it and believe it is enforcing.
+
+The only domain gate that actually runs in the callback is `hooks/omniauth.rb:661`, which consults
+`CustomDomain::SignupConfig` or the global `site.authentication.allowed_signup_domains` — a
+different config object.
+
+**Why the impact is high.** The product's own metadata tells operators this is their access control
+(`sso_config.rb:57-59`):
+
+> `'oidc' => { requires_domain_filter: true, idp_controls_access: false, description: 'Generic OIDC provider - domain filtering recommended' }`
+
+An operator who configures a generic OIDC IdP and restricts it to `@corp.com` has no restriction at
+all: any identity the IdP will authenticate can sign in.
+
+**Secondary issue in the same area.** The gate at `hooks/omniauth.rb:661` runs only in
+`before_omniauth_create_account` — the **create path only** (acknowledged at
+`hooks/omniauth.rb:224-226`). A user whose email domain is later removed from the allowlist keeps
+signing in indefinitely.
+
+**Remediation.** Call `sso_config.valid_email_domain?(email)` in the callback path, on **both**
+create and login, and fail closed. Add a regression spec that asserts a disallowed domain is
+rejected end-to-end.
+
+---
+
+## 2. Medium severity
+
+### M-1 — `email_verified` is never checked on any SSO path
+**CODE-CONFIRMED** · `apps/web/auth/config/hooks/omniauth.rb:32-33,199-209`
+
+A repo-wide search for `email_verified` in production Ruby returns zero hits. The OIDC strategy does
+surface the claim (`omniauth_openid_connect-0.8.0/.../openid_connect.rb:78`) — it is discarded.
+
+Two consequences:
+
+- **Auto-link.** With `OIDC_TRUST_EMAIL_FOR_LINKING` / `ENTRA_TRUST_EMAIL_FOR_LINKING` /
+  `SSO_TRUST_EMAIL_FOR_LINKING` enabled, an IdP account asserting `victim@corp.com` is auto-linked
+  and logged in as the victim (`hooks/omniauth.rb:199-209`). Default-off, documented as a
+  self-hosted escape hatch — but the one check that would make it safe is absent.
+- **JIT creation at an arbitrary asserted email.** `omniauth_create_account? true` and
+  `omniauth_verify_account? true` are the default (`features/omniauth.rb:52,59`). An IdP that lets a
+  user set an unverified `email` claim allows address squatting and bypasses `ALLOWED_SIGNUP_DOMAIN`,
+  since the gate at `hooks/omniauth.rb:661` trusts the same unverified claim.
+
+Google and GitHub strategies filter on verification themselves
+(`google_oauth2.rb:154-156`, `github.rb:58-61`). **Generic OIDC and Entra ID do not** — precisely the
+two providers offered on the tenant surface.
+
+Combined with `ENTRA_TENANT_ID=common` (which the Entra strategy also does not issuer-check —
+`omniauth-entra-id-3.1.1/.../entra_id.rb:152-204`, `JWT.decode(..., nil, false)`), this is textbook
+**nOAuth**: any Entra tenant admin can set a user's `email` claim to a victim's address.
+
+**Remediation.** Refuse to link (and refuse to create) when `omniauth_info['email_verified']` is
+present and falsey; require it truthy for the `trust_email_for_linking?` branch. Reject
+`common`/`organizations`/`adfs` for `ENTRA_TENANT_ID` at boot.
+
+---
+
+### M-2 — Magic-link lifetime is 24 hours, not the configured 15 minutes
+**CODE-CONFIRMED — verified against the live migrated database**
+
+`apps/web/auth/config/features/email_auth.rb:17-20` sets:
+
+```ruby
+# Magic links are only valid for a short period ...
+auth.email_auth_deadline_interval 15.minutes
+```
+
+Rodauth only honours `*_deadline_interval` when `set_deadline_values?` is true, and that is
+**MySQL-only** (`rodauth-2.45.0/lib/rodauth/features/base.rb:783-785`):
+
+```ruby
+def set_deadline_values?
+  db.database_type == :mysql
+end
+```
+
+The deployment is PostgreSQL/SQLite and never overrides it, so the column default applies. Read back
+from the database this review actually migrated:
+
+```
+CREATE TABLE `account_email_auth_keys` (
+  `id` bigint NOT NULL PRIMARY KEY REFERENCES `accounts`,
+  `key` varchar(255) NOT NULL,
+  `deadline` timestamp DEFAULT (datetime(datetime(CURRENT_TIMESTAMP,'localtime'),'1 days')) NOT NULL,
+  ...
+```
+
+**Actual lifetime: 24 hours — 96× the configured and documented value.** Expiry *is* enforced
+(`email_auth.rb:141-145`), just against the wrong number. Compounding: `create_email_auth_key`
+(`email_auth.rb:104-115`) *reuses* a live key rather than minting a new one, so a single token stays
+valid for the full 24h across every resend.
+
+**Remediation.** Set `auth.set_deadline_values? true` (preferred — makes every configured interval
+authoritative), or change the column default. Add a spec asserting the persisted deadline.
+
+---
+
+### M-3 — Account enumeration on `email-login-request` and `verify-account-resend`
+**CODE-CONFIRMED** · `rodauth-2.45.0/lib/rodauth/features/email_auth.rb:56-70,185-189`
+
+With `json_response_custom_error_status? true` (`apps/web/auth/config/base.rb:60`), three distinct
+single-request responses distinguish account state:
+
+| Case | Status | Body |
+|---|---|---|
+| registered + open | 200 | `{"success":"Login link sent to your email"}` |
+| registered, sent <30s ago | 400 | `{"error":"Login link was recently sent..."}` |
+| no account / unverified / closed | 401 | `{"error":"Error requesting login link"}` |
+
+This is the same CWE-204 oracle the team deliberately closed for `reset-password-request`
+(`apps/web/auth/config/overrides/reset_password_enumeration.rb`) — but that override is scoped by
+`current_route == :reset_password_request` (line 127), so it never applies here. The same shape
+exists on `verify-account-resend` (`verify_account.rb:67-93`).
+
+**Mitigating factor found during live testing:** `/auth/email-login-request` is **not** in the CSRF
+bypass list (`lib/onetime/middleware/security.rb:158-199`), so an anonymous POST is rejected with
+403 before reaching Rodauth. An attacker must first establish a session and obtain a CSRF token —
+trivial, but it means this is not a single-request unauthenticated oracle. `email_auth` is also
+off by default (`AUTH_EMAIL_AUTH_ENABLED`).
+
+**Remediation.** Mirror `reset_password_enumeration.rb` for the `email_auth` and
+`verify_account_resend` routes: return one generic response for all branches.
+
+---
+
+### M-4 — No rate limit on `email-login-request`
+**CODE-CONFIRMED** · no `before_email_auth_request_route` hook exists
+
+The codebase has a deliberate limiter on the two other unauthenticated Rodauth entry points —
+`hooks/reset_password_request.rb:75-82` and `hooks/create_account.rb:110-121`. There is no
+equivalent for email auth (`apps/web/auth/config/hooks.rb:40` confirms only
+`before_email_auth_route` and `after_email_auth_request` are owned).
+
+The only throttle is Rodauth's per-account resend gate, set to **30 seconds**
+(`features/email_auth.rb:20`). That caps emails per address but not requests per source: ~120
+emails/hour/address across unlimited addresses from one IP, and unbounded-rate enumeration of M-3.
+
+**Remediation.** Register `before_email_auth_request_route` with `ResetRequestRateLimiter`,
+following the reset-password hook exactly.
+
+---
+
+### M-5 — Stripe invoice PDFs and hosted URLs exposed to any org member
+**CODE-CONFIRMED** · `apps/web/billing/controllers/billing.rb:290-291,313-325`
+
+```ruby
+def list_invoices
+  org = load_organization(req.params['extid'])   # membership only; require_owner NOT passed
+  ...
+  invoice_pdf: invoice.invoice_pdf,
+  hosted_invoice_url: invoice.hosted_invoice_url,
+```
+
+Any active member calls `GET /billing/api/org/<extid>/invoices` and receives up to 12 Stripe
+`hosted_invoice_url` / `invoice_pdf` links. Those are **unauthenticated bearer URLs** exposing the
+organization's billing address, tax IDs, payment-method last4, and line-item history, and the hosted
+page offers pay/download actions.
+
+**Remediation.** `load_organization(req.params['extid'], require_owner: true)`.
+
+---
+
+### M-6 — Domain-scope enforcement missing on `receipt/recent?scope=domain`
+**CODE-CONFIRMED** · `apps/api/v2/logic/secrets/list_receipts.rb:144-169`
+
+```ruby
+has_access = domain.accessible_by?(cust)   # org membership ONLY
+```
+
+`CustomDomain#accessible_by?` is `org.owner?(c) || org.member?(c)`
+(`lib/onetime/models/custom_domain.rb:272-276`). It never consults
+`OrganizationMembership#can_access_domain?` — the control every other domain surface applies
+(`list_domains.rb:56-59`, `get_domain.rb:51-56`, `remove_domain.rb:42-47`,
+`domain_config_authorization.rb:161-165`).
+
+An SSO member scoped to domain A can list domain B's receipts in the same org — and thereby their
+bearer tokens (chains into H-1).
+
+**Remediation.** Add `membership.can_access_domain?(domain)` to `query_domain_receipts`.
+
+---
+
+### M-7 — Unauthenticated Redis exhaustion via unthrottled secret creation
+**Severity:** Medium · **CWE-770** · **REPRODUCED** · PoC: `poc/02-conceal-flood-dos.sh`
+
+There is **no rate limiter on the secret-creation path**. The limiter registry
+(`lib/onetime/operations/ratelimit/registry.rb:40-93`) covers `feedback`, `passphrase`, `invite`,
+`login`, `reset_request_ip`, `reset_request_email`, `create_account_ip`, and `dns`. Secret creation
+(`conceal`) is absent, and `ConcealSecret#raise_concerns`
+(`apps/api/v2/logic/secrets/conceal_secret.rb:27-33`) enforces only guest-route gating, non-empty
+content, and size.
+
+**Reproduced against the local instance:**
+
+```
+$ redis-cli info memory | grep used_memory_human
+used_memory_human:1.63M
+$ redis-cli -n 0 dbsize
+107
+
+# 200 unauthenticated POSTs, 10 KB payload each, ttl=604800 (the anonymous maximum)
+$ ./poc/02-conceal-flood-dos.sh 200
+
+$ redis-cli info memory | grep used_memory_human
+used_memory_human:4.83M
+$ redis-cli -n 0 dbsize
+508
+$ redis-cli -n 0 ttl secret:m8noi9jn...:object
+604795
+```
+
+40 rapid sequential creates also returned `200` every time with no throttling.
+
+**Impact.** ~16 KB of Redis memory per unauthenticated request, persisting for **7 days**. Redis is
+the primary datastore for secrets *and* sessions, so exhausting it takes the whole service down. At
+a sustained 500 req/s an attacker writes ~16 GB in roughly 35 minutes, from a single host, with no
+account.
+
+**Mitigating.** `SECRET_MAX_LENGTH` (10 000) bounds per-request cost and the TTL bounds retention;
+an operator behind a CDN/WAF may have edge rate limiting. Neither is an application control.
+
+**Remediation.** Add a `conceal_ip` limiter to the registry keyed on the masked client IP, following
+`create_account_rate_limiter.rb`. Consider a lower anonymous TTL ceiling and a per-IP live-secret cap.
+
+---
+
+### M-8 — CSP nonce is published in the client bootstrap payload
+**CODE-CONFIRMED** · `apps/web/core/views/serializers/system_serializer.rb:24`,
+`src/schemas/contracts/bootstrap.ts:720`, `src/shared/composables/useDnsWidget.ts:92-106`
+
+The per-request CSP nonce is serialized into the hydration blob and read back by app code. A
+nonce-only `script-src` derives all its value from the nonce being unguessable **and unreadable from
+non-script contexts**; here it sits in plaintext in a `<script type="application/json">` element.
+Any HTML-injection-without-script-execution primitive (dangling markup, scriptless attribute
+injection, CSS exfiltration) recovers it, and a second injection then executes with a valid nonce.
+
+The code already has the correct fallback — `document.querySelector('script[nonce]')`
+(`useDnsWidget.ts:103-105`), which works because browsers hide the content attribute but preserve
+the IDL property.
+
+**Remediation.** Drop `nonce` from `SystemSerializer` and `bootstrapSchema`; rely on the
+`script[nonce]` IDL fallback alone.
+
+---
+
+### M-9 — Vendored DNS widget injects remote HTML via `insertAdjacentHTML`
+**CODE-CONFIRMED** · `src/assets/approximated/dnswidget.v1.js:146-152,216-221,245-250,53-58`
+
+The vendored third-party widget injects raw HTML strings straight from an Approximated API response
+and interpolates DNS-lookup values (attacker-controlled by whoever owns the zone being verified)
+with no escaping:
+
+```js
+widget.insertAdjacentHTML('beforeend', inst.html);
+...
+<textarea ...>${record.actual_values || "No value set"}</textarea>
+```
+
+**Not currently exploitable as XSS**, because production CSP is `script-src 'nonce-…'` with no
+`unsafe-inline` — injected event handlers and `javascript:` hrefs are blocked, and `<script>`
+elements inserted this way never execute. But the mitigation is entirely CSP-dependent, and
+`CSP_ENABLED=false` or `development.enabled=true` (which adds `'unsafe-inline'`) removes it.
+
+**Remediation.** Sanitize `inst.html` / `verify_section.html` with DOMPurify; escape the `record.*`
+interpolations.
+
+---
+
+### M-10 — Secret bearer tokens persisted in `sessionStorage`
+**CODE-CONFIRMED** · `src/shared/stores/localReceiptStore.ts:48,59,138`,
+`src/schemas/ui/local-receipt.ts:30-36`
+
+Up to 25 guest receipts are stored under `sessionStorage['onetimeReceiptCache']`, each carrying
+`receiptExtid` and `secretExtid` — both capability tokens. Any script on the origin can read them.
+For a product whose entire value proposition is single-use secret custody, this materially widens
+the blast radius of any XSS.
+
+Limiting factors: `sessionStorage` (tab-scoped, cleared on close) rather than `localStorage`, and
+reads are schema-validated. **No auth tokens, API keys, or CSRF tokens are in web storage** — those
+are correctly in-memory only.
+
+**Remediation.** Accept with documented risk, or replace with a server-side guest receipt list keyed
+on the session.
+
+---
+
+### M-11 — `sqlite3` 2.9.5 use-after-free
+**REPRODUCED** (`bundle-audit`) · `Gemfile.lock:513`
+
+```
+Name: sqlite3   Version: 2.9.5
+GHSA-mwm8-39rw-8826 — Use-After-Free in SQLite Aggregate Arguments
+Solution: update to '>= 2.9.6'
+```
+
+The **only** Ruby advisory across the whole lockfile. It is a production dependency, not dev-only:
+`Dockerfile:225,371` install `libsqlite3-0` into both final images, and
+`docker/compose/docker-compose.full.yml:71` sets `AUTH_DATABASE_URL=sqlite://data/auth.db`.
+
+Practical exploitability is low — all SQL is Sequel/Rodauth-generated, not user-composed. `Gemfile:96`
+already declares `~> 2.0`, which permits 2.9.6, so this is a lockfile bump only.
+
+---
+
+### M-12 — `yq` fetched into production images with no checksum verification
+**CODE-CONFIRMED** · `docker/base.dockerfile:61-71`, copied at `Dockerfile:272,392`
+
+The binary is version-pinned but not hash-verified, and it lands in **both** shipped images. A
+compromised or retagged GitHub release asset puts an attacker-controlled executable in production.
+
+The same file already demonstrates the correct pattern 180 lines below for s6-overlay
+(`Dockerfile:242-260`): fetch the publisher's `.sha256` and `sha256sum -c` before extraction, with
+an explicit rationale. Apply the same treatment.
+
+---
+
+### M-13 — `anthropics/claude-code-action@beta` is a mutable ref holding a repository secret
+**CODE-CONFIRMED** · `.github/workflows/claude-code-review.yml:78-80`, `.github/workflows/claude.yml:49`
+
+`@beta` is mutable; whoever controls that branch controls code in a job holding
+`CLAUDE_CODE_OAUTH_TOKEN` and `id-token: write`. It is the only third-party action in the repo and
+the only one receiving a repository secret.
+
+Mitigating controls are good — the job gates on `!…head.repo.fork` and `!endsWith(github.actor,
+'[bot]')`, permissions are otherwise read-only, and the trigger is `pull_request` (not
+`pull_request_target`). **Remediation:** pin to a release SHA, as the same file already does elsewhere.
+
+---
+
+### M-14 — End-user session revocation does not revoke the session
+**CODE-CONFIRMED** · `apps/web/auth/routes/active_sessions.rb:86,111`
+
+`rodauth.remove_active_session(session_id)` only deletes a SQL row
+(`rodauth-2.45.0/lib/rodauth/features/active_sessions.rb:93-95`), and there is no override in this
+codebase. The encrypted Redis blob `session:<sid>` — which is what actually authenticates requests —
+is untouched.
+
+The authoritative gate is `BaseSessionAuthStrategy`
+(`lib/onetime/application/auth_strategies/base_session_auth_strategy.rb:31-67`); it checks
+`awaiting_mfa`, `authenticated`, `external_id`, suspension, and the credential watermark, and never
+consults `account_active_session_keys`. `check_active_session` — the Rodauth method that enforces
+revocation and the configured deadlines — has **no call site anywhere** in the application.
+
+**Impact.** A user who sees a suspicious device in "Active Sessions" and clicks *Remove* gets a
+success response and the row disappears, but the attacker's session keeps working until its 24h idle
+TTL lapses. Same for "remove all". The colonel-side operations
+(`lib/onetime/operations/sessions/revoke_for_customer.rb`) *do* delete the Redis blobs correctly —
+only the end-user surface is broken.
+
+**Related:** the configured `session_inactivity_deadline` (24h) and `session_lifetime_deadline`
+(30 days) at `features/active_sessions.rb:20-21` are enforced exclusively through the same
+never-called methods, so there is **no absolute session lifetime** — `write_session`
+(`lib/onetime/session.rb:696-697`) refreshes the TTL on every request, giving a sliding 24h idle
+timeout with no cap.
+
+**Remediation.** Make `remove_active_session` delete the Redis blob (reuse `RevokeForCustomer`), and
+call `check_active_session` on the request path so the deadlines take effect.
+
+---
+
+## 3. Low severity
+
+- **L-1** — `RemoveMember` (`apps/api/organizations/logic/members/remove_member.rb:39-58`)
+  authorizes on role strings only, skipping the `require_entitlement_in!` layer every sibling
+  member/invite operation uses, and never checks `membership.active?` for the actor. An admin whose
+  `manage_members` entitlement was revoked can still remove members.
+- **L-2** — `authorize_domain_incoming!` (`apps/api/domains/logic/incoming_config/base.rb:81-91`)
+  omits the `can_access_domain?` check its sibling policy applies. Currently unreachable
+  (`manage_org` is owner-only); latent.
+- **L-3** — The `secret` field accepts a JSON object and stores its Ruby `.to_s`. **Reproduced:**
+  `{"secret":{"secret":{"a":"b","c":[1,2]},"ttl":3600}}` reveals as `{"a"=>"b", "c"=>[1, 2]}`. The
+  declared `concealSecret` request schema is not type-enforced. Not a security boundary; fix for
+  correctness.
+- **L-4** — `isValidInternalPath` (`src/utils/redirect.ts:63-72`) does not reject `/\evil.com`,
+  which the WHATWG URL spec resolves to `https://evil.com/`. **Latent only** — every current caller
+  passes a hardcoded value, and the other consumers use `router.push`, which throws on cross-origin.
+  One-line fix: also reject `path.startsWith('/\\')`.
+- **L-5** — `brace-expansion` overrides in `pnpm-workspace.yaml:29-31` pin `1.1.17`/`2.1.3`/`5.0.8`,
+  each exactly one patch below the floors in GHSA-rgw5-rvv9-x895, which describes a **bypass of the
+  mitigation these pins were chosen for**. All paths are `dev: true` (CI/developer DoS surface only).
+  The comment above them still calls this a range-syntax false positive — that reasoning is now
+  stale and will cause the next reader to dismiss a genuine advisory.
+- **L-6** — `actions/setup-python@v5`, `actions/github-script@v7/@v9`, `actions/download-artifact@v4`
+  pinned by mutable tag while `actions/checkout` and `actions/labeler` are correctly SHA-pinned.
+- **L-7** — Redis transport TLS is neither enforced nor asserted at boot
+  (`familia/lib/familia/connection.rb:126-132`); `rediss://` works if the operator supplies it.
+  Session blobs are AES-256-GCM at rest, so plaintext transport leaks session ids rather than
+  contents. Document an operator requirement for `rediss://` plus a key-prefix-scoped Redis ACL.
+- **L-8** — Simple mode only: `apps/api/account/logic/authentication/reset_password.rb:22` looks up
+  **any** `Onetime::Secret` by the submitted `key` and burns it if it is not a valid reset secret.
+  Destruction only, no disclosure; requires knowing the 320-bit identifier; production runs `full`
+  mode where Rodauth owns the route.
+- **L-9** — Raw email addresses logged at `hooks/email_auth.rb:162-166`,
+  `config/email/delivery.rb:11-18`, and `lib/onetime/jobs/publisher.rb:223`, contrary to the stated
+  invariant at `hooks.rb:75` ("Emails obscured"). No token material is logged. Also
+  `lib/onetime/application/request_logger.rb:93-97` writes `sid.public_id` — which
+  `rack-session` aliases to `cookie_value`, i.e. the **raw session token** — under
+  `LOG_HTTP_CAPTURE=debug` (off by default). One-word fix to `private_id`.
+
+---
+
+## 4. Blanket CSRF exemption for `/auth/sso/*` (Low–Medium, noted separately)
+
+All three CSRF layers are simultaneously off for `POST /auth/sso/:provider`:
+
+1. Rodauth's `route_csrf`, deliberately omitted — `hooks/omniauth.rb:560-566`
+   (`⚠️ DO NOT call check_csrf / check_csrf? here`).
+2. `Rack::Protection::AuthenticityToken`, bypassed by prefix match —
+   `lib/onetime/middleware/security.rb:162`.
+3. `Rack::Protection::HttpOrigin`, off by default — `etc/defaults/config.defaults.yaml:426`.
+
+OAuth `state` protects the **callback** (verified — see §5), so this is not a one-shot takeover.
+But a cross-site auto-submitting form can, in a victim's authenticated browser, mint or delete the
+`sso_connect_intent` nonce (`hooks/omniauth.rb:605-609`) — reliably breaking an in-flight
+identity-linking flow — and drive a full IdP round trip. The exemption is a **prefix match**, so any
+future state-changing route under `/auth/sso/` silently inherits zero CSRF protection.
+
+**Remediation.** Replace the prefix match with an explicit route allowlist; enable
+`MIDDLEWARE_HTTP_ORIGIN` by default, or do an explicit same-origin check before honouring `connect=1`.
+
+---
+
+## 5. Claims investigated and REFUTED
+
+These are recorded so they are not re-raised. A source-only reading of
+`lib/onetime/session.rb:63-71` suggests that `Onetime::Session` shadows Rack's `DEFAULT_OPTIONS` and
+therefore loses Rack's own defaults. **It does not** — the guard is
+`unless defined?(DEFAULT_OPTIONS)`, and Ruby's constant lookup finds the *inherited*
+`Rack::Session::Abstract::Persisted::DEFAULT_OPTIONS` through the ancestor chain, so the constant is
+never actually defined on the subclass and `self.class::DEFAULT_OPTIONS` resolves to Rack's.
+
+Verified by instantiating the real class inside the booted application
+(`poc/04-session-options-verification.rb`):
+
+```
+default_options keys: [:defer, :domain, :expire_after, :httponly, :partitioned,
+                       :path, :renew, :secret, :secure, :secure_random, :sidbits]
+  httponly                  = true
+  path                      = "/"
+  secure_random(@sid_secure) = SecureRandom
+  @cookie_only              = true
+
+sid sample: 10466bb9c7cf07bca4462ebfc3a3a2e6cf7b11be46a578b258bb13154f470bf2
+REPRODUCIBLE AFTER srand()? false   (true would mean Kernel.rand, NOT a CSPRNG)
+```
+
+| Refuted claim | Reality |
+|---|---|
+| Session IDs from `Kernel.rand` (Mersenne Twister), predictable | `@sid_secure == SecureRandom`; ids are not reproducible after `srand()` — **CSPRNG confirmed** |
+| Session cookie missing `HttpOnly` | `httponly = true` |
+| Session id accepted from request params (`cookie_only` unset) | `@cookie_only = true`; live test with `?onetime.session=<sid>` set no cookie |
+| Session cookie missing `Path` | `path = "/"` |
+
+**Genuine residual in this area:** `find_session` (`lib/onetime/session.rb:441`) adopts any
+well-formed sid presented in a *cookie* even with no stored blob. Because `Rack::Protection::CookieTossing`
+ships off (`config.defaults.yaml:441`), an attacker who can set a cookie from a sibling subdomain
+could fix a pre-auth session. Rodauth rotates the sid on login (`apps/web/auth/config/base.rb:89-91`),
+which blocks post-login takeover, so this is bounded — but enabling `CookieTossing` is cheap.
+
+---
+
+## 6. Verified clean
+
+Confirmed by testing or close reading; recorded so future reviews can skip them.
+
+**Burn-after-reading holds under concurrency (REPRODUCED).** 10 simultaneous reveals of one secret:
+exactly **1** response contained the plaintext (`poc/01-burn-after-read-race.sh`). The atomic
+compare-and-set in `win_reveal_claim!`
+(`lib/onetime/models/secret/features/secret_state_management.rb:172-189`) is correct, and `reveal!`
+decrypts *inside* the won-claim branch so a losing racer never computes the plaintext.
+
+**Passphrase brute-force is properly rate-limited (REPRODUCED).** v2 locks after 5 attempts per
+secret+IP and returns `429` with `retry_after: 1800`. Rotating `X-Forwarded-For` on every attempt
+**did not** bypass it — XFF is not trusted absent a configured trusted proxy
+(`otto/lib/otto/utils.rb:158-176`). PoC: `poc/03-passphrase-ratelimit.sh`.
+
+**CSP is strict and nonce-based (REPRODUCED).** Live header:
+`default-src 'none'; script-src 'nonce-…'; object-src 'none'; base-uri 'self'; form-action 'self';
+frame-ancestors 'none'`. No `unsafe-inline`, no `unsafe-eval`, not report-only. The app goes out of
+its way to keep `unsafe-eval` out (Zod jitless mode, `src/plugins/core/configureZod.ts`).
+
+**No CORS configuration exists** — no `Access-Control-Allow-*` header anywhere, no `rack-cors`. The
+safe default.
+
+**Host header injection: clean (REPRODUCED).** `POST /api/v1/share` with `Host: evil.example.com`
+returned links on the configured `localhost:3000`, not the attacker host.
+
+**No mass assignment.** No `.new(params)`, `update(params)`, or `merge!(params)` anywhere in `apps/`
+or `lib/`. Every logic class reads named keys through `sanitize_identifier` / `sanitize_plain_text` /
+`sanitize_email`.
+
+**No unsafe deserialization.** Zero `Marshal.load`, `YAML.load`, `YAML.unsafe_load`, or `Psych.load`
+in `lib/`, `apps/`, or Familia. `Familia::JsonSerializer` uses `Oj.load(source, mode: :strict)`.
+
+**Lua scripting is safe.** Two `EVAL`/`EVALSHA` sites, both frozen script constants with keys/argv
+passed separately — no interpolation (`lib/onetime/error_handler.rb:158-189`,
+`lib/onetime/services/zset_indexer.rb:95-227`).
+
+**Cryptography is sound.** Secret identifiers are 256-bit random + 64-bit HMAC tag
+(`familia/lib/familia/verifiable_identifier.rb`), compared with `OpenSSL.secure_compare`.
+Passphrases use Argon2id (`t_cost: 2, m_cost: 16, p_cost: 1`). Rodauth email tokens are
+`SecureRandom.urlsafe_base64(32)` compared with `timing_safe_eql?`. A sweep for `rand(` / `Random.rand`
+across `lib/` and `apps/` found **zero** uses in any token path. Root `SECRET` is mandatory and
+fail-closed (`CHANGEME` is rejected; the `allow_nil` escape hatch is forcibly reset outside
+development); all derived material uses RFC 5869 HKDF-SHA256 with per-purpose `info` strings.
+
+**No committed secrets.** No private keys, Stripe/GitHub/Slack/SendGrid tokens in the tree or in
+history. The only `AKIA` hits are AWS's published `AKIAIOSFODNN7EXAMPLE` placeholder in specs.
+`.env.example` ships every secret blank, deliberately.
+
+**Container and compose posture.** Non-root (`USER appuser`), digest-pinned base images, no build
+secrets in ARG/ENV, healthchecks present, s6-overlay SHA-256 verified. No datastore port published
+to the host — Valkey and RabbitMQ use `expose:`, not `ports:`. Compose uses `${VAR:?error}` so a
+missing secret aborts rather than defaulting.
+
+**CI/CD.** The single `pull_request_target` workflow (`pr-labeler.yml`) has **no checkout step** at
+all — the dangerous pattern does not occur. No Actions script injection: every `github.event.*`
+reference is in an `if:` condition, never a `run:` body.
+
+**Request logging is fail-closed.** Params and headers use an allowlist that is **empty by default**
+(`request_logger.rb:151-176`), so enabling debug capture reveals no param or header values until an
+operator explicitly names safe fields. Sentry scrubbing covers URL, transaction, Referer, and span
+data, and fails closed to `[SCRUBBING_FAILED]`.
+
+**SSO issuer scoping is well built.** Identities are keyed `(provider, issuer, uid)` with a real
+unique index (`migrations/008_issuer_scoped_identities.rb:83`). OAuth `state` is validated in both
+stacks with `secure_compare`, empty state rejected, `provider_ignores_state` left false. No
+`omniauth.origin` handling exists — every post-callback redirect is a hardcoded literal, so **there
+is no open-redirect surface**. SSRF is defended at save time (`ssrf_protection.rb:48-63`, https-only,
+blocks resolved internal IPs, fails closed on empty resolution) and at request time
+(`oidc_http_pinning.rb`, per-request IP pinning that refuses to run through a forward proxy).
+
+**SSO link confirmation is sound.** 256-bit tokens, 300s/900s TTLs, consumed atomically via
+`delete! == 1` *before* any credential check (closing the load-then-delete TOCTOU), rate-limited
+before consumption, Phase-4 token delivered only to the on-file address (never the IdP-asserted one),
+and fails closed on delivery failure.
+
+**Colonel/admin API.** All 87 routes carry `auth=sessionauth role=colonel`, and every logic class
+independently calls `verify_one_of_roles!(colonel: true)`. `has_system_role?` additionally requires
+`cust.verified?`. Admin network isolation resolves the client IP through Otto's trusted-proxy walk
+and requires `otto.via_trusted_proxy` before honouring a forwarded host — **not spoofable by default**.
+
+**Rhales hydration escaping.** The JSON bootstrap blob escapes `<`, `>`, `&`, U+2028, U+2029
+(`rhales/lib/rhales/utils/json_serializer.rb:38-46`) — escaping `<` covers both `</script>` and
+`<!--` — and is delivered as `type="application/json"` + `JSON.parse`, not an inline assignment. Only
+one raw `{{{ }}}` interpolation exists in the entire codebase (`{{{vite_assets_html}}}`), built
+entirely from the Vite manifest and the server nonce, with no request-derived data.

--- a/docs/security/2026-08-14-appsec-review/poc/01-burn-after-read-race.sh
+++ b/docs/security/2026-08-14-appsec-review/poc/01-burn-after-read-race.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# PoC 01 — Burn-after-reading under concurrency (EXPECTED RESULT: CLEAN)
+#
+# Creates one secret, then fires N simultaneous reveals. The product promise is
+# that AT MOST ONE caller ever receives the plaintext.
+#
+# Usage: ./01-burn-after-read-race.sh [concurrency]   (default 10)
+set -euo pipefail
+BASE="${BASE:-http://127.0.0.1:3000}"
+N="${1:-10}"
+CANARY="BURN-RACE-CANARY-$$"
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+
+SK=$(curl -sS -m 10 -X POST "$BASE/api/v1/share" \
+      -d "secret=$CANARY&ttl=3600" \
+    | python3 -c 'import sys,json;print(json.load(sys.stdin)["secret_key"])')
+echo "secret_key = $SK"
+echo "firing $N concurrent reveals..."
+
+for i in $(seq 1 "$N"); do
+  curl -sS -m 10 -X POST "$BASE/api/v1/secret/$SK" -d 'continue=true' -o "$TMP/r$i.json" &
+done
+wait
+
+HITS=$(grep -l "$CANARY" "$TMP"/r*.json 2>/dev/null | wc -l)
+echo "responses containing plaintext: $HITS  (expected: 1)"
+[ "$HITS" -eq 1 ] && echo "PASS — burn-after-reading holds" || { echo "FAIL — multi-reveal!"; exit 1; }

--- a/docs/security/2026-08-14-appsec-review/poc/02-conceal-flood-dos.sh
+++ b/docs/security/2026-08-14-appsec-review/poc/02-conceal-flood-dos.sh
@@ -16,13 +16,16 @@ redis-cli info memory | grep used_memory_human
 echo -n "keys: "; redis-cli -n 0 dbsize
 
 echo "=== $N unauthenticated POSTs, 10 KB each, ttl=604800 (anonymous max) ==="
+OK=0 FAIL=0
 for i in $(seq 1 "$N"); do
-  curl -sS -m 10 -o /dev/null -X POST "$BASE/api/v2/secret/conceal" \
+  CODE=$(curl -sS -m 10 -o /dev/null -w '%{http_code}' -X POST "$BASE/api/v2/secret/conceal" \
     -H 'Content-Type: application/json' \
-    -d "{\"secret\":{\"secret\":\"$PAYLOAD\",\"ttl\":604800}}" &
-  (( i % 20 )) || wait
+    -d "{\"secret\":{\"secret\":\"$PAYLOAD\",\"ttl\":604800}}")
+  if [[ "$CODE" == 2* ]]; then ((OK++)); else ((FAIL++)); fi
+  (( i % 20 )) || echo "  progress: $i/$N (ok=$OK fail=$FAIL)"
 done
-wait
+echo "  completed: ok=$OK fail=$FAIL"
+[[ $FAIL -gt 0 ]] && echo "WARNING: $FAIL requests failed — results may be unreliable"
 
 echo "=== after ==="
 redis-cli info memory | grep used_memory_human

--- a/docs/security/2026-08-14-appsec-review/poc/02-conceal-flood-dos.sh
+++ b/docs/security/2026-08-14-appsec-review/poc/02-conceal-flood-dos.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# PoC 02 — M-7: unauthenticated Redis exhaustion via unthrottled secret creation
+#
+# There is no rate limiter on the conceal path (see
+# lib/onetime/operations/ratelimit/registry.rb — 'conceal' is absent). Each
+# unauthenticated request writes ~16 KB to Redis that persists for up to 7 days.
+#
+# Usage: ./02-conceal-flood-dos.sh [count]   (default 200)
+set -euo pipefail
+BASE="${BASE:-http://127.0.0.1:3000}"
+N="${1:-200}"
+PAYLOAD=$(python3 -c "print('A'*10000)")   # SECRET_MAX_LENGTH default
+
+echo "=== before ==="
+redis-cli info memory | grep used_memory_human
+echo -n "keys: "; redis-cli -n 0 dbsize
+
+echo "=== $N unauthenticated POSTs, 10 KB each, ttl=604800 (anonymous max) ==="
+for i in $(seq 1 "$N"); do
+  curl -sS -m 10 -o /dev/null -X POST "$BASE/api/v2/secret/conceal" \
+    -H 'Content-Type: application/json' \
+    -d "{\"secret\":{\"secret\":\"$PAYLOAD\",\"ttl\":604800}}" &
+  (( i % 20 )) || wait
+done
+wait
+
+echo "=== after ==="
+redis-cli info memory | grep used_memory_human
+echo -n "keys: "; redis-cli -n 0 dbsize
+echo "=== sample TTL (expect ~604800 = 7 days) ==="
+redis-cli -n 0 --scan --pattern 'secret:*:object' | head -1 \
+  | while read -r k; do echo "$k -> $(redis-cli -n 0 ttl "$k")"; done
+
+echo
+echo "Observed on 2026-08-14: 1.63M/107 keys -> 4.83M/508 keys for 200 requests."
+echo "Extrapolated: ~16 KB of 7-day-persistent Redis per unauthenticated request."

--- a/docs/security/2026-08-14-appsec-review/poc/03-passphrase-ratelimit.sh
+++ b/docs/security/2026-08-14-appsec-review/poc/03-passphrase-ratelimit.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# PoC 03 — Passphrase brute-force protection, incl. X-Forwarded-For bypass attempt
+#          (EXPECTED RESULT: CLEAN — locks at 5, XFF rotation does not help)
+set -euo pipefail
+BASE="${BASE:-http://127.0.0.1:3000}"
+
+mk_secret() {
+  curl -sS -m 10 -X POST "$BASE/api/v2/secret/conceal" -H 'Content-Type: application/json' \
+    -d '{"secret":{"secret":"PASSPHRASE-PROBE","ttl":3600,"passphrase":"correcthorse"}}' \
+  | python3 -c 'import sys,json;print(json.load(sys.stdin)["record"]["receipt"]["secret_identifier"])'
+}
+
+probe() { # $1=secret  $2=extra curl args...
+  local sk="$1"; shift
+  for i in $(seq 1 25); do
+    printf '%s ' "$(curl -sS -m 10 -o /dev/null -w '%{http_code}' \
+      -X POST "$BASE/api/v2/secret/$sk/reveal" -H 'Content-Type: application/json' \
+      "$@" -d "{\"continue\":true,\"passphrase\":\"wrong$i\"}")"
+  done; echo
+}
+
+echo "=== baseline (same source IP) ==="
+probe "$(mk_secret)"
+echo "expected: 422 x5 then 429 (locked, retry_after 1800)"
+
+echo
+echo "=== X-Forwarded-For rotated on every attempt ==="
+SK=$(mk_secret)
+for i in $(seq 1 25); do
+  printf '%s ' "$(curl -sS -m 10 -o /dev/null -w '%{http_code}' \
+    -X POST "$BASE/api/v2/secret/$SK/reveal" -H 'Content-Type: application/json' \
+    -H "X-Forwarded-For: 203.0.113.$i" -d "{\"continue\":true,\"passphrase\":\"wrong$i\"}")"
+done; echo
+echo "expected: IDENTICAL to baseline — XFF is not trusted without a configured trusted proxy"

--- a/docs/security/2026-08-14-appsec-review/poc/04-session-options-verification.rb
+++ b/docs/security/2026-08-14-appsec-review/poc/04-session-options-verification.rb
@@ -1,0 +1,32 @@
+# PoC 04 — Verification that Onetime::Session inherits Rack's DEFAULT_OPTIONS.
+#
+# REFUTES the source-only reading that the subclass shadows Rack's defaults and
+# therefore loses HttpOnly / Path / cookie_only / the CSPRNG. The guard in
+# lib/onetime/session.rb:63 is `unless defined?(DEFAULT_OPTIONS)`, and Ruby's
+# constant lookup finds the INHERITED constant through the ancestor chain — so
+# the constant is never defined on the subclass at all.
+#
+# Run (from the repo root, with the env from tooling.md sourced):
+#   bundle exec ruby -Ilib docs/security/2026-08-14-appsec-review/poc/04-session-options-verification.rb
+require 'onetime'
+OT.execution_mode = :backend
+Onetime.boot! :app
+
+sess = Onetime::Session.new(->(_env) { [200, {}, []] }, {
+  secret: OT.conf.dig('site', 'secret'),
+  expire_after: 86_400, key: 'onetime.session', secure: true, same_site: :lax
+})
+
+opts = sess.instance_variable_get(:@default_options)
+puts "default_options keys: #{opts.keys.sort.inspect}"
+puts "  httponly                   = #{opts[:httponly].inspect}"
+puts "  path                       = #{opts[:path].inspect}"
+puts "  secure_random(@sid_secure) = #{sess.instance_variable_get(:@sid_secure).inspect}"
+puts "  @cookie_only               = #{sess.instance_variable_get(:@cookie_only).inspect}"
+puts
+
+# If generate_sid used Kernel.rand, reseeding would replay the same ids.
+srand(12_345); a = 3.times.map { sess.send(:generate_sid) }
+srand(12_345); b = 3.times.map { sess.send(:generate_sid) }
+puts "sid sample: #{a.first}"
+puts "REPRODUCIBLE AFTER srand()? #{a == b}   (true would mean Kernel.rand, NOT a CSPRNG)"

--- a/docs/security/2026-08-14-appsec-review/poc/05-misc-probes.sh
+++ b/docs/security/2026-08-14-appsec-review/poc/05-misc-probes.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# PoC 05 — Assorted single-shot probes used during the review.
+set -uo pipefail
+BASE="${BASE:-http://127.0.0.1:3000}"
+
+echo "=== CSP + security headers (expect strict nonce-based CSP) ==="
+curl -sS -D- -o /dev/null -m 8 "$BASE/" \
+  | grep -iE 'content-security-policy|x-frame-options|strict-transport|referrer-policy|x-content-type'
+
+echo
+echo "=== CORS (expect: no Access-Control-* headers at all) ==="
+curl -sS -D- -o /dev/null -m 8 -H 'Origin: https://evil.example' "$BASE/api/v2/status" \
+  | grep -i 'access-control' || echo "none — clean"
+
+echo
+echo "=== Host header injection (expect links on the CONFIGURED host, not evil.example.com) ==="
+curl -sS -m 10 -X POST "$BASE/api/v1/share" -H 'Host: evil.example.com' \
+  -d 'secret=HOSTPROBE&ttl=3600' | python3 -c 'import sys,json;print(json.load(sys.stdin)["metadata_url"])'
+
+echo
+echo "=== TTL clamping (expect 604800 max, 60 min) ==="
+for T in 99999999999 -1; do
+  echo -n "requested ttl=$T -> stored "
+  curl -sS -m 10 -X POST "$BASE/api/v2/secret/conceal" -H 'Content-Type: application/json' \
+    -d "{\"secret\":{\"secret\":\"ttlprobe\",\"ttl\":$T}}" \
+    | python3 -c 'import sys,json;print(json.load(sys.stdin)["record"]["receipt"]["secret_ttl"])'
+done
+
+echo
+echo "=== L-3: JSON object accepted for the 'secret' field (schema not type-enforced) ==="
+SK=$(curl -sS -m 10 -X POST "$BASE/api/v2/secret/conceal" -H 'Content-Type: application/json' \
+  -d '{"secret":{"secret":{"a":"b","c":[1,2]},"ttl":3600}}' \
+  | python3 -c 'import sys,json;print(json.load(sys.stdin)["record"]["receipt"]["secret_identifier"])')
+curl -sS -m 10 -X POST "$BASE/api/v2/secret/$SK/reveal" -H 'Content-Type: application/json' \
+  -d '{"continue":true}' \
+  | python3 -c 'import sys,json;print("revealed:",repr(json.load(sys.stdin)["record"].get("secret_value")))'
+
+echo
+echo "=== Unauthenticated conceal is unthrottled (M-7): 40 rapid creates ==="
+for i in $(seq 1 40); do
+  printf '%s ' "$(curl -sS -m 10 -o /dev/null -w '%{http_code}' -X POST "$BASE/api/v2/secret/conceal" \
+    -H 'Content-Type: application/json' -d "{\"secret\":{\"secret\":\"flood$i\",\"ttl\":3600}}")"
+done; echo
+echo "expected (current behaviour): 200 x40 — no 429"

--- a/docs/security/2026-08-14-appsec-review/poc/05-misc-probes.sh
+++ b/docs/security/2026-08-14-appsec-review/poc/05-misc-probes.sh
@@ -1,44 +1,56 @@
 #!/usr/bin/env bash
 # PoC 05 — Assorted single-shot probes used during the review.
-set -uo pipefail
+set -euo pipefail
 BASE="${BASE:-http://127.0.0.1:3000}"
 
+check_curl() {
+  local code body
+  body=$(curl -sS -m 10 -w '\n%{http_code}' "$@" 2>&1) || { echo "ERROR: curl failed"; return 1; }
+  code=$(echo "$body" | tail -1)
+  [[ "$code" == 2* || "$code" == 3* ]] || { echo "ERROR: HTTP $code"; return 1; }
+  echo "$body" | sed '$d'
+}
+
 echo "=== CSP + security headers (expect strict nonce-based CSP) ==="
-curl -sS -D- -o /dev/null -m 8 "$BASE/" \
+curl -sSf -D- -o /dev/null -m 8 "$BASE/" \
   | grep -iE 'content-security-policy|x-frame-options|strict-transport|referrer-policy|x-content-type'
 
 echo
 echo "=== CORS (expect: no Access-Control-* headers at all) ==="
-curl -sS -D- -o /dev/null -m 8 -H 'Origin: https://evil.example' "$BASE/api/v2/status" \
-  | grep -i 'access-control' || echo "none — clean"
+HDRS=$(curl -sSf -D- -o /dev/null -m 8 -H 'Origin: https://evil.example' "$BASE/api/v2/status") || { echo "ERROR: request failed"; exit 1; }
+echo "$HDRS" | grep -i 'access-control' || echo "none — clean"
 
 echo
 echo "=== Host header injection (expect links on the CONFIGURED host, not evil.example.com) ==="
-curl -sS -m 10 -X POST "$BASE/api/v1/share" -H 'Host: evil.example.com' \
+check_curl -X POST "$BASE/api/v1/share" -H 'Host: evil.example.com' \
   -d 'secret=HOSTPROBE&ttl=3600' | python3 -c 'import sys,json;print(json.load(sys.stdin)["metadata_url"])'
 
 echo
 echo "=== TTL clamping (expect 604800 max, 60 min) ==="
 for T in 99999999999 -1; do
   echo -n "requested ttl=$T -> stored "
-  curl -sS -m 10 -X POST "$BASE/api/v2/secret/conceal" -H 'Content-Type: application/json' \
+  check_curl -X POST "$BASE/api/v2/secret/conceal" -H 'Content-Type: application/json' \
     -d "{\"secret\":{\"secret\":\"ttlprobe\",\"ttl\":$T}}" \
     | python3 -c 'import sys,json;print(json.load(sys.stdin)["record"]["receipt"]["secret_ttl"])'
 done
 
 echo
 echo "=== L-3: JSON object accepted for the 'secret' field (schema not type-enforced) ==="
-SK=$(curl -sS -m 10 -X POST "$BASE/api/v2/secret/conceal" -H 'Content-Type: application/json' \
+SK=$(check_curl -X POST "$BASE/api/v2/secret/conceal" -H 'Content-Type: application/json' \
   -d '{"secret":{"secret":{"a":"b","c":[1,2]},"ttl":3600}}' \
   | python3 -c 'import sys,json;print(json.load(sys.stdin)["record"]["receipt"]["secret_identifier"])')
-curl -sS -m 10 -X POST "$BASE/api/v2/secret/$SK/reveal" -H 'Content-Type: application/json' \
+check_curl -X POST "$BASE/api/v2/secret/$SK/reveal" -H 'Content-Type: application/json' \
   -d '{"continue":true}' \
   | python3 -c 'import sys,json;print("revealed:",repr(json.load(sys.stdin)["record"].get("secret_value")))'
 
 echo
 echo "=== Unauthenticated conceal is unthrottled (M-7): 40 rapid creates ==="
+OK=0 FAIL=0
 for i in $(seq 1 40); do
-  printf '%s ' "$(curl -sS -m 10 -o /dev/null -w '%{http_code}' -X POST "$BASE/api/v2/secret/conceal" \
-    -H 'Content-Type: application/json' -d "{\"secret\":{\"secret\":\"flood$i\",\"ttl\":3600}}")"
+  CODE=$(curl -sS -m 10 -o /dev/null -w '%{http_code}' -X POST "$BASE/api/v2/secret/conceal" \
+    -H 'Content-Type: application/json' -d "{\"secret\":{\"secret\":\"flood$i\",\"ttl\":3600}}")
+  printf '%s ' "$CODE"
+  [[ "$CODE" == 2* ]] && ((OK++)) || ((FAIL++))
 done; echo
 echo "expected (current behaviour): 200 x40 — no 429"
+[[ $FAIL -gt 0 ]] && echo "WARNING: $FAIL requests failed — verify server is running"

--- a/docs/security/2026-08-14-appsec-review/release-v0.26.5-rc1-verification.md
+++ b/docs/security/2026-08-14-appsec-review/release-v0.26.5-rc1-verification.md
@@ -1,0 +1,186 @@
+# Release Verification — v0.26.5-rc1
+
+**Date:** 2026-08-14 · **Trigger:** `release.published` webhook for
+[`v0.26.5-rc1`](https://github.com/onetimesecret/onetimesecret/releases/tag/v0.26.5-rc1)
+**Addendum to:** the 2026-08-14 application security review in this directory.
+
+---
+
+## 1. The release contains no code this review has not seen
+
+```
+$ git rev-list -n1 v0.26.5-rc1
+21c3f6ac79973b3c951260601a61387bc55af809
+$ git rev-parse origin/main
+21c3f6ac79973b3c951260601a61387bc55af809
+$ git diff --stat 21c3f6ac79973b3c951260601a61387bc55af809 v0.26.5-rc1
+   (empty — identical trees)
+```
+
+`v0.26.5-rc1` is the **exact commit** the review was performed against. There is no delta to
+audit, and one consequence that matters:
+
+> **All three High findings — H-1, H-2, H-3 — ship in this release candidate.**
+
+They are not regressions introduced by the release; they predate it. But an RC is the last
+convenient point to fix them before the tag goes stable, and H-2 in particular is a one-line change.
+
+| Finding | Ships in v0.26.5-rc1 | Fix effort |
+|---|---|---|
+| H-2 — non-owner member reaches the org's Stripe Customer Portal | Yes | one `require_owner: true` |
+| H-1 — org member harvests colleagues' secret bearer tokens | Yes | redact non-owned identifiers + raise entitlement |
+| H-3 — tenant SSO `allowed_domains` never called | Yes | call the method on both paths |
+| M-7 — unauthenticated Redis exhaustion (no conceal rate limit) | Yes | add a limiter to the existing registry |
+| M-14 — end-user session revocation does not revoke | Yes | delete the Redis blob |
+
+---
+
+## 2. Novelty check against the four prior in-repo audits
+
+`docs/security/` already contains audits dated 2026-07-06, 2026-07-19, 2026-07-30, and 2026-08-06.
+Cross-referenced to avoid re-filing known issues:
+
+| Finding | Previously reported? |
+|---|---|
+| H-1 `receipt/recent?scope=org` bearer-token leak | **No** — no prior mention of `ListReceipts` or `scope=org` |
+| H-2 billing portal ownership gap | **No** — no prior mention of `customer_portal` / `BillingPortal` |
+| H-3 `SsoConfig#allowed_domains` dead code | **No** — no prior mention of `allowed_domains` / `valid_email_domain?` |
+| M-14 active-session revocation | **No** — no prior mention of `check_active_session` / `remove_active_session` |
+| M-7 unthrottled secret creation | **Related but distinct** — see below |
+
+**On M-7.** The 2026-07-30 audit (finding #4) reported unthrottled **account creation**, describing
+the impact as *"datastore growth (no TTL on the Customer hash) and unsolicited mail"*. That was
+fixed — `create_account_rate_limiter.rb` exists and is registered. M-7 is the **same class of defect
+on a higher-volume endpoint that was never given a limiter**: secret creation is the product's
+primary write path, is reachable with no account at all, and lands in the datastore that also holds
+sessions. The precedent is useful — it shows the team accepts and fixes this class — and it makes
+the omission on `conceal` harder to justify as intentional.
+
+---
+
+## 3. The release's own security claims — all four verified
+
+The release notes make four explicit security claims. Each was tested against a locally-booted
+instance at this exact tag. **All four hold as written.**
+
+### Claim 1 — `/colonel` host gate is active without config ✅
+
+> *"admin surfaces now default to canonical `DEFAULT_DOMAIN`/`HOST` (+ `www.`)"*
+
+With `HOST=secrets.example.com` and `ADMIN_ALLOWED_HOSTS` unset:
+
+| Request `Host:` | `/colonel` | `/api/colonel/status` |
+|---|---|---|
+| `secrets.example.com` | 302 → `/signin` (gate allows; unauthenticated) | 404 |
+| `www.secrets.example.com` | 302 → `/signin` (www variant allowed, as documented) | 404 |
+| `evil.example.com` | **404** (gate denies) | 404 |
+| `customer-domain.test` | **404** (gate denies) | 404 |
+
+The stated intent — *"tenant custom domains and operator link-pool domains stop serving the admin
+console"* — is exactly what happens.
+
+**Operational caveat worth surfacing.** The gate **self-disables** when the canonical anchor is not
+a routable hostname. With the default `HOST=localhost:3000` the boot log reads:
+
+```
+Admin host allowlist INACTIVE: no routable hostname configured
+  source: "canonical anchors", hosts: ["localhost"]
+  note: "localhost and bare-IP hosts are never detected as a host; set ADMIN_ALLOWED_HOSTS
+         (or site.host / DEFAULT_DOMAIN) to a routable hostname to enable the host gate"
+```
+
+This is correct and deliberate — a bare-IP or `localhost` install would otherwise lock itself out —
+and it is announced loudly rather than silently. But it means **the upgrade checklist's "gate is now
+active" is conditional on a routable `site.host`**, and an operator serving on a bare IP gets no host
+gate at all. Worth a line in the upgrade guide. (My first test run was inconclusive for precisely
+this reason; re-running with a routable anchor produced the table above.)
+
+### Claim 2 — `ADMIN_ALLOWED_CIDRS` with no valid entry now fails closed ✅
+
+> *"previously degraded to 'no network restriction'"*
+
+Booted with `ADMIN_ALLOWED_CIDRS='100.64.0.0\10,not-a-cidr,example.com'` (three unparseable entries):
+
+```
+WARN  Invalid CIDR in site.admin.allowed_cidrs, skipping: 100.64.0.010
+WARN  Invalid CIDR in site.admin.allowed_cidrs, skipping: not-a-cidr
+WARN  Invalid CIDR in site.admin.allowed_cidrs, skipping: example.com
+ERROR Admin CIDR allowlist has no usable range; denying both admin surfaces
+      note: "/colonel and /api/colonel are returning 404 to EVERY request ... Fix the entries
+             (ADMIN_ALLOWED_CIDRS=100.64.0.0/10,10.0.0.0/8) or unset it entirely"
+```
+
+| Surface | Result |
+|---|---|
+| `/colonel` (both allowed hosts) | **404** — denied |
+| `/api/colonel/status` | **404** — denied |
+| `/api/v2/status` | 200 — unaffected |
+| `/` | 200 — unaffected |
+
+Fails closed, and the blast radius is correctly scoped to the two admin surfaces rather than taking
+the app down. The code path is `resolve_network_gate` →
+`unusable_network_gate` (`lib/onetime/middleware/admin_network_isolation.rb:675-689`), which returns
+`[[], true]` — empty ranges, gate **active**. The sibling `unreadable_network_gate` (config read
+raised) does the same, deliberately using a `CONFIG_UNREADABLE` sentinel rather than `nil` so
+"unreadable" can never be mistaken for "unset". That distinction is the difference between failing
+closed and failing open, and it is handled correctly.
+
+### Claims 3 & 4 — `RABBITMQ_VERIFY_PEER` failing open; strict boolean parsing ✅
+
+> *"It was read as `== 'true'`, so `1`, `yes`, or `TRUE` silently disabled TLS peer verification on a
+> default-ON control."*
+
+`Onetime::Utils::Strings.strict_bool!` (`lib/onetime/utils/strings.rb:299-311`) exercised directly:
+
+```
+TRUTHY: ["1", "true", "yes", "on", "y", "t"]
+FALSEY: ["0", "false", "no", "off", "n", "f"]
+
+the tokens that used to fail open:   "1" "yes" "TRUE" "on" "y" "t"  -> all true  ✅
+explicit disables:                   "false" "no" "off" "0" "n" "f" -> all false ✅
+typos ("yess","tru","enabled","2"):  raise Onetime::ConfigError               ✅
+unset / "" / "   ":                  fall back to the default (true)          ✅
+```
+
+The fix is real: values that previously disabled TLS peer verification now enable it, and a typo
+fails the boot instead of silently disabling a default-ON control.
+
+**Worth calling out as good practice:** the error message does not echo the offending value — it
+reports the character count and a truncated SHA-256, because these env vars sometimes hold secrets:
+
+```
+RABBITMQ_VERIFY_PEER is set to an unrecognized boolean
+(4 chars, sha256:a7d7c16d). Use one of 1/true/yes/on/y/t or 0/false/no/off/n/f, or leave unset.
+```
+
+---
+
+## 4. Effect of the TTL clamp removal (#4022) on M-7
+
+The release removes a hardcoded 30-day TTL clamp. Checked against M-7's measurements:
+
+- **Anonymous ceiling is unchanged at 7 days** — `site.secret_options.ttl_max_anonymous` defaults to
+  `7.days` (`lib/onetime/config.rb:67`), and a live probe requesting `ttl=99999999999` still clamps
+  to `604800`. M-7's reproduction (~16 KB of 7-day-persistent Redis per unauthenticated request)
+  therefore **stands exactly as measured**.
+- The global ceiling is now `30.days` (`config.rb:61`) for plan-entitled callers. That raises the
+  authenticated per-secret retention 4×, which amplifies the *authenticated* abuse case of the same
+  missing limiter — but M-7 is filed on the unauthenticated path, and that number did not move.
+
+No change to the finding's severity or reproduction.
+
+---
+
+## 5. Bottom line for this release
+
+Nothing in v0.26.5-rc1 introduces a new vulnerability, and the security work the release advertises
+is real — the three fail-closed gates and the boolean-parsing fix all do what the notes say, and the
+`admin_network_isolation` code is careful in ways that are easy to get wrong (the unreadable-vs-unset
+sentinel especially).
+
+The open question is not about the release's changes; it is that the RC ships three unfixed High
+authorization findings. H-2 is a one-line fix and would be a cheap thing to land before the tag goes
+stable.
+
+One documentation gap to consider for the upgrade guide: the `/colonel` host gate is conditional on a
+routable `site.host`, and installs serving on `localhost` or a bare IP get no host gate at all.

--- a/docs/security/2026-08-14-appsec-review/risk-register.md
+++ b/docs/security/2026-08-14-appsec-review/risk-register.md
@@ -1,0 +1,87 @@
+# Risk Register
+
+**Date:** 2026-08-14 · **Target:** `onetimesecret` @ `21c3f6a`
+
+**Exploitability** — how hard is it to actually do?
+`Trivial` (unauthenticated, single request) · `Easy` (needs a low-privilege account or a session) ·
+`Moderate` (needs a specific configuration or a chained precondition) · `Hard` (needs privileged
+position or an unlikely precondition)
+
+**Business impact** — what happens if it succeeds?
+`Severe` (core product promise broken / total tenant compromise) · `High` (material data or money
+loss) · `Moderate` (degraded trust or availability) · `Low` (hygiene)
+
+---
+
+## Priority 1 — fix now
+
+| # | ID | Finding | Exploitability | Impact | Risk | Effort |
+|---|---|---|---|---|---|---|
+| 1 | H-2 | Non-owner member reaches the org's Stripe Customer Portal (can cancel the subscription, change payment method, read billing history) | Easy | High | **Critical** | Trivial — one `require_owner: true` |
+| 2 | H-1 | Any org member harvests every colleague's secret bearer tokens and reveals their secrets | Easy | Severe | **Critical** | Small — redact non-owned identifiers, raise the entitlement |
+| 3 | H-3 | Tenant SSO `allowed_domains` never runs; operators believe an access control exists that does not | Moderate (needs a tenant OIDC config) | Severe | **High** | Small — call the method, both paths, fail closed |
+
+**Why these three first.** Each one is an authorization gap that is cheap to close, and each defeats
+a control the product explicitly advertises. H-2 has the lowest effort-to-risk ratio in the whole
+register. H-1 breaks the core product promise from inside the tenant. H-3 is the most dangerous kind
+of finding — a security control that exists in the UI, the API, and the docs, but not at runtime.
+
+---
+
+## Priority 2 — fix this cycle
+
+| # | ID | Finding | Exploitability | Impact | Risk | Effort |
+|---|---|---|---|---|---|---|
+| 4 | M-14 | "Remove session" reports success but the session keeps working; no absolute session lifetime | Hard (needs an already-compromised session) | High | **High** | Medium |
+| 5 | M-1 | `email_verified` never checked; nOAuth-class takeover if a trust flag + `ENTRA_TENANT_ID=common` are set | Moderate (config-dependent) | Severe | **High** | Small |
+| 6 | M-7 | Unauthenticated Redis exhaustion — no rate limit on secret creation | **Trivial** | Moderate (full outage) | **High** | Small — add a limiter to the existing registry |
+| 7 | M-5 | Stripe invoice PDFs / hosted bearer URLs exposed to any org member | Easy | High | **High** | Trivial |
+| 8 | M-2 | Magic links live 24h instead of the configured 15 min, and one token is reused across resends | Moderate (needs link interception) | High | **Medium-High** | Trivial — `set_deadline_values? true` |
+| 9 | M-6 | Domain-scoped SSO member reads a sibling domain's receipts (chains into H-1) | Easy | High | **Medium-High** | Trivial |
+| 10 | M-11 | `sqlite3` 2.9.5 use-after-free (GHSA-mwm8-39rw-8826) | Hard | Moderate | **Medium** | Trivial — lockfile bump only |
+| 11 | M-13 | `claude-code-action@beta` mutable ref holds `CLAUDE_CODE_OAUTH_TOKEN` + `id-token: write` | Hard (needs upstream compromise) | Severe | **Medium** | Trivial — SHA-pin |
+
+---
+
+## Priority 3 — schedule
+
+| # | ID | Finding | Exploitability | Impact | Risk | Effort |
+|---|---|---|---|---|---|---|
+| 12 | M-3 | Account enumeration on `email-login-request` / `verify-account-resend` | Easy (CSRF token required first) | Moderate | Medium | Small |
+| 13 | M-4 | No rate limit on `email-login-request` → mailbox bombing + unbounded enumeration | Easy | Moderate | Medium | Small |
+| 14 | M-8 | CSP nonce published in the bootstrap payload, weakening the nonce-only policy | Hard (needs an HTML-injection primitive) | High | Medium | Trivial |
+| 15 | M-12 | `yq` installed into production images with no checksum | Hard | Severe | Medium | Trivial — mirror the s6 block |
+| 16 | M-10 | Secret bearer tokens in `sessionStorage` (widens XSS blast radius) | Hard (needs XSS) | High | Medium | Medium |
+| 17 | M-9 | Vendored DNS widget injects unsanitized remote HTML (CSP is the only thing stopping it) | Hard | High | Medium | Small |
+| 18 | §4 | Blanket `/auth/sso/*` CSRF prefix exemption; connect-intent nonce forgeable cross-site | Moderate | Moderate | Medium | Small |
+
+---
+
+## Priority 4 — hygiene backlog
+
+| # | ID | Finding | Risk |
+|---|---|---|---|
+| 19 | L-9 | `request_logger.rb:97` logs `sid.public_id` — the raw session cookie value — under `LOG_HTTP_CAPTURE=debug`; raw emails in 3 log sites | Low-Medium |
+| 20 | L-5 | `brace-expansion` overrides one patch below GHSA-rgw5-rvv9-x895; the "false positive" comment is now stale and misleading | Low |
+| 21 | L-1 | `RemoveMember` skips the entitlement layer and the actor's `active?` check | Low |
+| 22 | L-4 | `isValidInternalPath` accepts `/\evil.com` (latent open redirect — no reachable sink today) | Low |
+| 23 | L-7 | Redis TLS neither enforced nor asserted at boot; no ACL requirement documented | Low |
+| 24 | L-6 | `actions/*` pinned by mutable tag while others are SHA-pinned | Low |
+| 25 | L-2 | `authorize_domain_incoming!` omits the domain-scope check (latent) | Low |
+| 26 | L-3 | `secret` field accepts a JSON object and stores its Ruby `.to_s` — request schema not type-enforced | Low |
+| 27 | L-8 | Simple mode: reset-password burns an arbitrary secret by identifier (destruction only) | Low |
+| 28 | — | `Rack::Protection::CookieTossing` ships off; pre-auth session fixation via a sibling-subdomain cookie | Low |
+
+---
+
+## Notes on what is *not* in this register
+
+Four claims that read as Critical from source alone were empirically refuted against the running
+application and are **not** risks: predictable session IDs, missing `HttpOnly`, session id accepted
+from request params, and missing cookie `Path`. See `findings.md` §5 for the verification output.
+They are recorded there specifically so a future review does not re-open them.
+
+The core product invariant — burn-after-reading — was tested under concurrency and **holds**
+(1 of 10 simultaneous reveals returned plaintext). Passphrase brute-force protection **holds**,
+including against `X-Forwarded-For` rotation. These are the two controls the product most depends on,
+and both are sound.

--- a/docs/security/2026-08-14-appsec-review/tooling.md
+++ b/docs/security/2026-08-14-appsec-review/tooling.md
@@ -45,12 +45,12 @@ cp etc/defaults/auth.defaults.yaml etc/auth.yaml
 # 4. Synthetic environment — ALL SECRETS BELOW ARE THROWAWAY TEST VALUES
 cat > /tmp/appsec.env <<'ENVEOF'
 RACK_ENV=production
-SECRET=<64 random hex bytes, generated locally>
-ACCOUNT_ID_SECRET=<32 random hex bytes>
-VERIFIABLE_ID_HMAC_SECRET=<32 random hex bytes>
-HMAC_SECRET=<32 random hex bytes>
-AUTH_SECRET=<32 random hex bytes>
-FEDERATION_SECRET=<32 random hex bytes>
+SECRET=$(openssl rand -hex 32)
+ACCOUNT_ID_SECRET=$(openssl rand -hex 16)
+VERIFIABLE_ID_HMAC_SECRET=$(openssl rand -hex 16)
+HMAC_SECRET=$(openssl rand -hex 16)
+AUTH_SECRET=$(openssl rand -hex 16)
+FEDERATION_SECRET=$(openssl rand -hex 16)
 REDIS_URL=redis://127.0.0.1:6379/0
 HOST=localhost:3000
 SSL=false
@@ -61,7 +61,7 @@ AUTH_MFA_ENABLED=true
 AUTH_WEBAUTHN_ENABLED=true
 AUTH_EMAIL_AUTH_ENABLED=true
 ENVEOF
-set -a; . /tmp/appsec.env; set +a
+set -a; eval "$(cat /tmp/appsec.env)"; set +a
 
 # 5. Auth schema (SQLite; requires the UTF-8 RUBYOPT above — migration 003 has non-ASCII content)
 mkdir -p data
@@ -98,13 +98,13 @@ lib/onetime/class_methods.rb:480:in 'block in in_environment?':
 
 **Workaround:** rewrite the 20 `it` block-parameter uses to the semantically identical `_1`, which
 both versions accept. Affected: 14 files under `lib/` and `apps/`, plus `Rakefile`. Confirmed
-complete with `grep -rn "{ it\b\|{ it\.\|{ it\[" --include=*.rb lib/ apps/`.
+complete with `grep -Prn '\{ it(?:\b|\.|\[)' --include='*.rb' lib/ apps/`.
 
 **This is an analysis-environment shim, not a proposed change.** It was reverted before committing
 (§4). Re-apply with:
 
 ```bash
-for f in $(grep -rl '{ it\b\|{ it\.\|{ it\[\|== it }' --include=*.rb lib/ apps/) Rakefile; do
+for f in $(grep -Prl '\{ it(?:\b|\.|\[)|== it \}' --include='*.rb' lib/ apps/) Rakefile; do
   perl -pi -e 's/\{ it \}/{ _1 }/g; s/\{ it\.(\w)/{ _1.$1/g;
                s/\{ it\[/{ _1[/g; s/\{ env == it \}/{ env == _1 }/g;
                s/\.each \{ load it \}/.each { load _1 }/g;' "$f"

--- a/docs/security/2026-08-14-appsec-review/tooling.md
+++ b/docs/security/2026-08-14-appsec-review/tooling.md
@@ -1,0 +1,201 @@
+# Tooling & Reproduction Notes
+
+**Date:** 2026-08-14 · **Host:** Linux 6.18.5 x86_64 (ephemeral container, loopback-only networking)
+
+---
+
+## 1. What was already present
+
+| Tool | Version | Notes |
+|---|---|---|
+| Ruby | 3.3.6 (`/opt/rbenv/versions/3.3.6`) | see §3 — the repo wants 3.4.10 |
+| Bundler | 4.0.9 | |
+| RubyGems | 3.5.22 | |
+| Node | 22.22.2 | not needed; the SPA was reviewed as source |
+| Redis | server + `redis-cli` at `/usr/bin` | used as the local datastore |
+| `bundler-audit` | preinstalled at `/opt/rbenv/versions/3.3.6/bin` | outside the bundle — invoke directly, **not** via `bundle exec` |
+| Python | 3.x | used only for JSON parsing in the PoC scripts |
+
+**Nothing new was installed.** An attempt to install Ruby 3.4.9 via `rbenv install` failed —
+`cache.ruby-lang.org` is not on the egress proxy allowlist (`CONNECT tunnel failed, response 403`).
+§3 documents the workaround used instead.
+
+---
+
+## 2. Bringing the application up locally
+
+```bash
+cd /home/user/onetimesecret
+export PATH="/opt/rbenv/versions/3.3.6/bin:$PATH"
+export RUBYOPT="-EUTF-8" LANG=C.UTF-8 LC_ALL=C.UTF-8
+export ONETIME_HOME=/home/user/onetimesecret
+
+# 1. Datastore
+redis-server --daemonize yes --port 6379 --save '' --appendonly no
+redis-cli ping                                   # -> PONG
+
+# 2. Dependencies (the development group needs Ruby >= 3.4 for the `kanayago` gem)
+bundle config set --local without 'development'
+bundle install --jobs 4
+
+# 3. Configuration (both files are required; neither is tracked)
+printf -- "---\n" > etc/config.yaml               # empty: the defaults layer supplies everything
+cp etc/defaults/auth.defaults.yaml etc/auth.yaml
+
+# 4. Synthetic environment — ALL SECRETS BELOW ARE THROWAWAY TEST VALUES
+cat > /tmp/appsec.env <<'ENVEOF'
+RACK_ENV=production
+SECRET=<64 random hex bytes, generated locally>
+ACCOUNT_ID_SECRET=<32 random hex bytes>
+VERIFIABLE_ID_HMAC_SECRET=<32 random hex bytes>
+HMAC_SECRET=<32 random hex bytes>
+AUTH_SECRET=<32 random hex bytes>
+FEDERATION_SECRET=<32 random hex bytes>
+REDIS_URL=redis://127.0.0.1:6379/0
+HOST=localhost:3000
+SSL=false
+FROM_EMAIL=test@example.com
+AUTHENTICATION_MODE=full
+AUTH_DATABASE_URL=sqlite://data/auth.db
+AUTH_MFA_ENABLED=true
+AUTH_WEBAUTHN_ENABLED=true
+AUTH_EMAIL_AUTH_ENABLED=true
+ENVEOF
+set -a; . /tmp/appsec.env; set +a
+
+# 5. Auth schema (SQLite; requires the UTF-8 RUBYOPT above — migration 003 has non-ASCII content)
+mkdir -p data
+bundle exec rake auth:migrate                    # -> "Auth database migrated to version 8"
+
+# 6. Serve
+bundle exec puma -b tcp://127.0.0.1:3000 -t 2:4 config.ru
+curl -sS http://127.0.0.1:3000/api/v2/status     # -> {"success":true,"status":"nominal",...}
+```
+
+**Gotchas worth recording.**
+
+- `RACK_ENV=development` refuses to boot without a Vite toolchain (`config.rb:1057`, ADR-025).
+  Use `production`.
+- `bundle exec rake` / `bundle exec puma` report *"command not found"* unless
+  `/opt/rbenv/versions/3.3.6/bin` is on `PATH` — the rbenv shim directory is not exported by default.
+- `bundle exec bundle-audit` fails (`bundler-audit` is not in the Gemfile). Call `bundle-audit`
+  directly.
+- Auth routes 404 until `AUTHENTICATION_MODE=full`; boot then aborts with exit 87 until
+  `HMAC_SECRET` is also set.
+
+---
+
+## 3. The Ruby 3.4 problem, and the workaround
+
+`.ruby-version` pins **3.4.10**; the container has at most **3.3.6**, and 3.4.x could not be
+downloaded (proxy allowlist). The blocker is a language feature, not a gem: the codebase uses Ruby
+3.4's implicit block parameter `it`, which 3.3 parses as a method call:
+
+```
+lib/onetime/class_methods.rb:480:in 'block in in_environment?':
+  undefined local variable or method 'it' for module Onetime (NameError)
+```
+
+**Workaround:** rewrite the 20 `it` block-parameter uses to the semantically identical `_1`, which
+both versions accept. Affected: 14 files under `lib/` and `apps/`, plus `Rakefile`. Confirmed
+complete with `grep -rn "{ it\b\|{ it\.\|{ it\[" --include=*.rb lib/ apps/`.
+
+**This is an analysis-environment shim, not a proposed change.** It was reverted before committing
+(§4). Re-apply with:
+
+```bash
+for f in $(grep -rl '{ it\b\|{ it\.\|{ it\[\|== it }' --include=*.rb lib/ apps/) Rakefile; do
+  perl -pi -e 's/\{ it \}/{ _1 }/g; s/\{ it\.(\w)/{ _1.$1/g;
+               s/\{ it\[/{ _1[/g; s/\{ env == it \}/{ env == _1 }/g;
+               s/\.each \{ load it \}/.each { load _1 }/g;' "$f"
+done
+```
+
+On a host with Ruby 3.4.10 none of this is needed.
+
+---
+
+## 4. Every local change, and how to reset it
+
+| # | Change | Reset |
+|---|---|---|
+| 1 | `.ruby-version` 3.4.10 → 3.3.6 | `git checkout .ruby-version` |
+| 2 | `it` → `_1` in 14 files + `Rakefile` | `git checkout lib/ apps/ Rakefile` |
+| 3 | Created `etc/config.yaml` | `rm etc/config.yaml` (untracked) |
+| 4 | Created `etc/auth.yaml` | `rm etc/auth.yaml` (untracked) |
+| 5 | Created `data/auth.db` (SQLite auth schema) | `rm -rf data/` (untracked) |
+| 6 | `bundle config set --local without 'development'` | `bundle config unset --local without` |
+| 7 | Installed gems into the rbenv 3.3.6 gem home | `bundle install` on a clean checkout |
+| 8 | Redis on 127.0.0.1:6379 populated with test secrets | `redis-cli flushall; redis-cli shutdown nosave` |
+| 9 | Puma on 127.0.0.1:3000 | `pkill -f puma` |
+
+**All of items 1, 2 and 6 were reverted before this branch was committed.** `git status` on the
+review branch shows only the files under `docs/security/2026-08-14-appsec-review/`.
+
+Nothing outside this container was touched: no external endpoint received traffic, no production
+configuration was modified, and no production data or credential was accessed. Every secret used is
+a locally-generated throwaway.
+
+---
+
+## 5. Commands used for analysis
+
+**Dependency scanning**
+
+```bash
+bundle-audit check --update          # -> 1 advisory: sqlite3 2.9.5 GHSA-mwm8-39rw-8826
+```
+
+**Static review** — `rg`/`grep` sweeps over `lib/`, `apps/`, `src/`, `etc/`, `docker/`,
+`.github/workflows/`, and the installed gems under
+`/opt/rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/`. The high-yield queries:
+
+```bash
+grep -rn "valid_email_domain?" --include=*.rb .            # H-3: no production caller
+grep -rn "email_verified" --include=*.rb lib/ apps/        # M-1: zero hits
+grep -rn "check_active_session" apps lib                   # M-14: zero call sites
+grep -rn "Marshal.load\|YAML.load\|YAML.unsafe_load" lib/ apps/   # clean
+grep -rn "Access-Control" -i lib/ apps/ etc/ config.ru     # clean — no CORS
+grep -rn "\.new(params)\|update(params)\|merge!(params)" lib/ apps/  # clean — no mass assignment
+grep -rn "rand(\|Random.rand" lib/ apps/                   # clean — no token uses a non-CSPRNG
+```
+
+**Live schema verification** (M-2 — the configured 15-minute magic-link deadline is a no-op):
+
+```bash
+python3 -c "import sqlite3;c=sqlite3.connect('data/auth.db');
+print([r for r in c.execute(
+  \"select sql from sqlite_master where name like '%email_auth%'\")])"
+# -> deadline timestamp DEFAULT (datetime(datetime(CURRENT_TIMESTAMP,'localtime'),'1 days'))
+```
+
+**Runtime verification** — the five scripts in `poc/`. Run them with the server up:
+
+```bash
+cd docs/security/2026-08-14-appsec-review/poc
+./01-burn-after-read-race.sh 10      # expect: PASS (1 of 10 gets plaintext)
+./03-passphrase-ratelimit.sh         # expect: 422 x5 then 429, identical with XFF rotation
+./05-misc-probes.sh                  # headers, CORS, host header, TTL clamping, L-3, M-7
+./02-conceal-flood-dos.sh 200        # M-7 — WRITES ~3 MB to Redis; flushall afterwards
+bundle exec ruby -Ilib 04-session-options-verification.rb   # refutes the session-entropy claims
+```
+
+`poc/02` is the only destructive one; it leaves ~200 keys with 7-day TTLs. Clean up with
+`redis-cli flushall`.
+
+---
+
+## 6. Review method
+
+Source review was fanned out across six parallel workstreams — email/token auth, SSO/OIDC,
+authorization/IDOR/tenancy, session/CSRF/Redis, SPA/frontend, and supply chain/deployment — each
+reading its area in full and reporting file:line evidence. Findings were then **independently
+re-verified** by the reviewer against the running application or the live database before being
+admitted to `findings.md`.
+
+That verification step mattered: four Critical/High claims about session handling did not survive it
+(`findings.md` §5). They arose from reading `lib/onetime/session.rb:63-71` in isolation, where the
+`unless defined?(DEFAULT_OPTIONS)` guard looks like constant shadowing but — because Ruby resolves
+constants through the ancestor chain — actually means the constant is never defined on the subclass,
+so Rack's own defaults apply. Only running the code shows this. Treat any source-only claim in this
+class as a hypothesis until executed.


### PR DESCRIPTION
## Summary

Deep application security review covering all ten requested focus areas, with findings reproduced against a locally-booted instance using synthetic data only.

**Documentation only — no application code is changed by this PR.** Every local shim used to get the app running (see below) was reverted before committing; the diff is confined to `docs/security/2026-08-14-appsec-review/`.

| File | Contents |
|---|---|
| `README.md` | Scope, method, per-repo branch/commit provenance |
| `findings.md` | 3 High, 14 Medium, 9 Low, plus a verified-clean section |
| `risk-register.md` | Prioritized by exploitability × business impact |
| `tooling.md` | Environment setup, every command run, reset instructions |
| `poc/` | Five runnable proof-of-concept scripts |

### Headline findings

| ID | Sev | Finding |
|---|---|---|
| H-1 | High | Any org **member** can harvest every colleague's secret bearer tokens via `receipt/recent?scope=org` and reveal their secrets. `secret_identifier` is the capability, and `safe_dump` returns it for all org receipts behind a member-level `api_access` gate. The sibling `ListSecretActivity` surface requires `audit_logs` and deliberately withholds identifiers — the two contradict each other. |
| H-2 | High | Non-owner member is handed the organization's Stripe Customer Portal. `GET /billing/portal` resolves `default_org_id` — which SSO join repoints to the shared tenant org — with no ownership check. Every mutating billing endpoint on the sibling controller does check. |
| H-3 | High | `SsoConfig#allowed_domains` has **no production caller**. It is plumbed through the API, rendered in the UI, and described in the product's own metadata as the access control for generic OIDC — and has no runtime effect. |
| M-7 | Medium | Unauthenticated Redis exhaustion. No rate limiter exists on secret creation. Reproduced: 200 requests → +3.2 MB of Redis, every key with a 7-day TTL. |
| M-14 | Medium | End-user "remove session" reports success but never deletes the Redis session blob; `check_active_session` has no call site, so the configured session deadlines are dead config too. |
| M-2 | Medium | Magic links live **24 hours**, not the configured 15 minutes — `set_deadline_values?` is MySQL-only, so the column default applies. Confirmed by reading the schema back out of the migrated database. |

Full list, including 14 Medium and 9 Low, in `findings.md`.

### Verified clean

Worth recording, because these are the controls the product most depends on:

- **Burn-after-reading holds under concurrency** — 10 simultaneous reveals of one secret, exactly 1 returned plaintext.
- **Passphrase brute-force protection holds** — locks at 5 attempts with `retry_after: 1800`, and rotating `X-Forwarded-For` on every attempt does not bypass it (XFF is not trusted absent a configured trusted proxy).
- Strict nonce-based CSP (`default-src 'none'`, no `unsafe-inline`/`unsafe-eval`, not report-only); no CORS configuration at all; no host-header injection; no mass assignment anywhere; no unsafe deserialization; no non-CSPRNG in any token path; no committed secrets; root `SECRET` mandatory and fail-closed.

### Four Critical-looking claims that were refuted

A source-only reading of `lib/onetime/session.rb:63-71` suggests the subclass shadows Rack's `DEFAULT_OPTIONS`, losing the CSPRNG, `HttpOnly`, `Path`, and `cookie_only`. It does not — the guard is `unless defined?(DEFAULT_OPTIONS)`, and Ruby resolves the constant through the ancestor chain, so it is never defined on the subclass and Rack's defaults apply. Verified by instantiating the real class inside the booted app (`poc/04`): `httponly = true`, `path = "/"`, `@sid_secure = SecureRandom`, `@cookie_only = true`, and session ids are not reproducible after `srand()`.

These are documented in `findings.md` §5 specifically so a future review does not re-open them.

### Note on repository scope

Five of the six repositories provided (`otto`, `rhales`, `familia`, `rodauth`, `rodauth-omniauth`) are developer working copies — the build resolves all five from rubygems.org, not from those paths. `Gemfile` has no `path:`/`git:` options and `Gemfile.lock` has only a `GEM` section. Fork drift is therefore not currently a live risk; both forks were diffed against their installed gems anyway and the only divergence is two upstream hardening commits in `rodauth`.

## Related Issues

None — this is a scheduled review, not issue-driven. Each finding in `findings.md` carries file:line evidence and remediation guidance suitable for filing individually.

## Test Plan

No application code changed, so there is nothing to regression-test. The review's own evidence is reproducible:

```bash
# bring the app up locally — full instructions in tooling.md §2
cd docs/security/2026-08-14-appsec-review/poc
./01-burn-after-read-race.sh 10      # expect PASS — 1 of 10 gets plaintext
./03-passphrase-ratelimit.sh         # expect 422 x5 then 429, identical under XFF rotation
./05-misc-probes.sh                  # headers, CORS, host header, TTL clamping, M-7
bundle exec ruby -Ilib 04-session-options-verification.rb   # refutes the session claims
./02-conceal-flood-dos.sh 200        # M-7 — writes ~3 MB to Redis; flushall afterwards
```

All five were executed successfully against the local instance while writing this review. `02` is the only destructive one.

One environment caveat is documented in `tooling.md` §3: the container had Ruby 3.3.6 and the repo pins 3.4.10, which could not be fetched through the egress proxy. The codebase uses Ruby 3.4's implicit `it` block parameter in 20 places, so those were temporarily rewritten to `_1` to boot the app. That shim was reverted before committing and is not part of this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDbZ5ERThnmXj8UDQXHksm)_